### PR TITLE
[Merged by Bors] - style(NumberTheory): make sure items in docs have no odd indentation

### DIFF
--- a/Archive/Wiedijk100Theorems/AbelRuffini.lean
+++ b/Archive/Wiedijk100Theorems/AbelRuffini.lean
@@ -14,11 +14,11 @@ import Mathlib.RingTheory.RootsOfUnity.Minpoly
 # Construction of an algebraic number that is not solvable by radicals.
 
 The main ingredients are:
- * `solvableByRad.isSolvable'` in `Mathlib/FieldTheory/AbelRuffini.lean` :
+* `solvableByRad.isSolvable'` in `Mathlib/FieldTheory/AbelRuffini.lean` :
   an irreducible polynomial with an `IsSolvableByRad` root has solvable Galois group
- * `galActionHom_bijective_of_prime_degree'` in `Mathlib/FieldTheory/PolynomialGaloisGroup.lean` :
+* `galActionHom_bijective_of_prime_degree'` in `Mathlib/FieldTheory/PolynomialGaloisGroup.lean` :
   an irreducible polynomial of prime degree with 1-3 non-real roots has full Galois group
- * `Equiv.Perm.not_solvable` in `Mathlib/GroupTheory/Solvable.lean` : the symmetric group is not
+* `Equiv.Perm.not_solvable` in `Mathlib/GroupTheory/Solvable.lean` : the symmetric group is not
   solvable
 
 Then all that remains is the construction of a specific polynomial satisfying the conditions of

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Basic.lean
@@ -21,12 +21,12 @@ formulae for group operations in `Mathlib/AlgebraicGeometry/EllipticCurve/Affine
 
 ## Main definitions
 
- * `WeierstrassCurve.Affine.Equation`: the Weierstrass equation in affine coordinates.
- * `WeierstrassCurve.Affine.Nonsingular`: the nonsingular condition in affine coordinates.
+* `WeierstrassCurve.Affine.Equation`: the Weierstrass equation in affine coordinates.
+* `WeierstrassCurve.Affine.Nonsingular`: the nonsingular condition in affine coordinates.
 
 ## Main statements
 
- * `WeierstrassCurve.Affine.equation_iff_nonsingular`: an elliptic curve in affine coordinates is
+* `WeierstrassCurve.Affine.equation_iff_nonsingular`: an elliptic curve in affine coordinates is
     nonsingular at every point.
 
 ## Implementation notes

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Formula.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Formula.lean
@@ -10,10 +10,10 @@ import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Basic
 
 Let `W` be a Weierstrass curve over a field `F` with coefficients `aᵢ`. The nonsingular affine
 points on `W` can be given negation and addition operations defined by a secant-and-tangent process.
- * Given a nonsingular affine point `P`, its *negation* `-P` is defined to be the unique third
+* Given a nonsingular affine point `P`, its *negation* `-P` is defined to be the unique third
     nonsingular point of intersection between `W` and the vertical line through `P`.
     Explicitly, if `P` is `(x, y)`, then `-P` is `(x, -y - a₁x - a₃)`.
- * Given two nonsingular affine points `P` and `Q`, their *addition* `P + Q` is defined to be the
+* Given two nonsingular affine points `P` and `Q`, their *addition* `P + Q` is defined to be the
     negation of the unique third nonsingular point of intersection between `W` and the line `L`
     through `P` and `Q`. Explicitly, let `P` be `(x₁, y₁)` and let `Q` be `(x₂, y₂)`.
       * If `x₁ = x₂` and `y₁ = -y₂ - a₁x₂ - a₃`, then `L` is vertical.
@@ -34,17 +34,17 @@ coordinates will be defined in `Mathlib/AlgebraicGeometry/EllipticCurve/Affine/P
 
 ## Main definitions
 
- * `WeierstrassCurve.Affine.negY`: the `Y`-coordinate of `-P`.
- * `WeierstrassCurve.Affine.addX`: the `X`-coordinate of `P + Q`.
- * `WeierstrassCurve.Affine.negAddY`: the `Y`-coordinate of `-(P + Q)`.
- * `WeierstrassCurve.Affine.addY`: the `Y`-coordinate of `P + Q`.
+* `WeierstrassCurve.Affine.negY`: the `Y`-coordinate of `-P`.
+* `WeierstrassCurve.Affine.addX`: the `X`-coordinate of `P + Q`.
+* `WeierstrassCurve.Affine.negAddY`: the `Y`-coordinate of `-(P + Q)`.
+* `WeierstrassCurve.Affine.addY`: the `Y`-coordinate of `P + Q`.
 
 ## Main statements
 
- * `WeierstrassCurve.Affine.equation_neg`: negation preserves the Weierstrass equation.
- * `WeierstrassCurve.Affine.nonsingular_neg`: negation preserves the nonsingular condition.
- * `WeierstrassCurve.Affine.equation_add`: addition preserves the Weierstrass equation.
- * `WeierstrassCurve.Affine.nonsingular_add`: addition preserves the nonsingular condition.
+* `WeierstrassCurve.Affine.equation_neg`: negation preserves the Weierstrass equation.
+* `WeierstrassCurve.Affine.nonsingular_neg`: negation preserves the nonsingular condition.
+* `WeierstrassCurve.Affine.equation_add`: addition preserves the Weierstrass equation.
+* `WeierstrassCurve.Affine.nonsingular_add`: addition preserves the nonsingular condition.
 
 ## References
 

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
@@ -33,29 +33,29 @@ This file defines the group law on nonsingular points `W⟮F⟯` in affine coord
 
 ## Main definitions
 
- * `WeierstrassCurve.Affine.CoordinateRing`: the affine coordinate ring `F[W]`.
- * `WeierstrassCurve.Affine.CoordinateRing.basis`: the power basis of `F[W]` over `F[X]`.
- * `WeierstrassCurve.Affine.Point`: a nonsingular point in affine coordinates.
- * `WeierstrassCurve.Affine.Point.neg`: the negation of a nonsingular point in affine coordinates.
- * `WeierstrassCurve.Affine.Point.add`: the addition of a nonsingular point in affine coordinates.
+* `WeierstrassCurve.Affine.CoordinateRing`: the affine coordinate ring `F[W]`.
+* `WeierstrassCurve.Affine.CoordinateRing.basis`: the power basis of `F[W]` over `F[X]`.
+* `WeierstrassCurve.Affine.Point`: a nonsingular point in affine coordinates.
+* `WeierstrassCurve.Affine.Point.neg`: the negation of a nonsingular point in affine coordinates.
+* `WeierstrassCurve.Affine.Point.add`: the addition of a nonsingular point in affine coordinates.
 
 ## Main statements
 
- * `WeierstrassCurve.Affine.CoordinateRing.instIsDomainCoordinateRing`: the affine coordinate ring
+* `WeierstrassCurve.Affine.CoordinateRing.instIsDomainCoordinateRing`: the affine coordinate ring
     of a Weierstrass curve is an integral domain.
- * `WeierstrassCurve.Affine.CoordinateRing.degree_norm_smul_basis`: the degree of the norm of an
+* `WeierstrassCurve.Affine.CoordinateRing.degree_norm_smul_basis`: the degree of the norm of an
     element in the affine coordinate ring in terms of its power basis.
- * `WeierstrassCurve.Affine.Point.instAddCommGroup`: the type of nonsingular points `W⟮F⟯` in affine
+* `WeierstrassCurve.Affine.Point.instAddCommGroup`: the type of nonsingular points `W⟮F⟯` in affine
     coordinates forms an abelian group under addition.
 
 ## Notations
 
- * `W⟮K⟯`: the group of nonsingular points on `W` base changed to `K`.
+* `W⟮K⟯`: the group of nonsingular points on `W` base changed to `K`.
 
 ## References
 
- * [J Silverman, *The Arithmetic of Elliptic Curves*][silverman2009]
- * https://drops.dagstuhl.de/storage/00lipics/lipics-vol268-itp2023/LIPIcs.ITP.2023.6/LIPIcs.ITP.2023.6.pdf
+* [J Silverman, *The Arithmetic of Elliptic Curves*][silverman2009]
+* https://drops.dagstuhl.de/storage/00lipics/lipics-vol268-itp2023/LIPIcs.ITP.2023.6/LIPIcs.ITP.2023.6.pdf
 
 ## Tags
 

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Basic.lean
@@ -17,15 +17,15 @@ These are defined in terms of the auxiliary sequences for normalised elliptic di
 
 Let `W` be a Weierstrass curve over a commutative ring `R`. The sequence of `n`-division polynomials
 `ψₙ ∈ R[X, Y]` of `W` is the normalised EDS with initial values
- * `ψ₀ := 0`,
- * `ψ₁ := 1`,
- * `ψ₂ := 2Y + a₁X + a₃`,
- * `ψ₃ := 3X⁴ + b₂X³ + 3b₄X² + 3b₆X + b₈`, and
- * `ψ₄ := ψ₂ ⬝ (2X⁶ + b₂X⁵ + 5b₄X⁴ + 10b₆X³ + 10b₈X² + (b₂b₈ - b₄b₆)X + (b₄b₈ - b₆²))`.
+* `ψ₀ := 0`,
+* `ψ₁ := 1`,
+* `ψ₂ := 2Y + a₁X + a₃`,
+* `ψ₃ := 3X⁴ + b₂X³ + 3b₄X² + 3b₆X + b₈`, and
+* `ψ₄ := ψ₂ ⬝ (2X⁶ + b₂X⁵ + 5b₄X⁴ + 10b₆X³ + 10b₈X² + (b₂b₈ - b₄b₆)X + (b₄b₈ - b₆²))`.
 
 Furthermore, define the associated sequences `φₙ, ωₙ ∈ R[X, Y]` by
- * `φₙ := Xψₙ² - ψₙ₊₁ ⬝ ψₙ₋₁`, and
- * `ωₙ := (ψ₂ₙ / ψₙ - ψₙ ⬝ (a₁φₙ + a₃ψₙ²)) / 2`.
+* `φₙ := Xψₙ² - ψₙ₊₁ ⬝ ψₙ₋₁`, and
+* `ωₙ := (ψ₂ₙ / ψₙ - ψₙ ⬝ (a₁φₙ + a₃ψₙ²)) / 2`.
 
 Note that `ωₙ` is always well-defined as a polynomial in `R[X, Y]`. As a start, it can be shown by
 induction that `ψₙ` always divides `ψ₂ₙ` in `R[X, Y]`, so that `ψ₂ₙ / ψₙ` is always well-defined as
@@ -39,34 +39,34 @@ Now, in the coordinate ring `R[W]`, note that `ψ₂²` is congruent to the poly
 `Ψ₂Sq := 4X³ + b₂X² + 2b₄X + b₆ ∈ R[X]`. As such, the recurrences of a normalised EDS show that
 `ψₙ / ψ₂` are congruent to certain polynomials in `R[W]`. In particular, define `preΨₙ ∈ R[X]` as
 the auxiliary sequence for a normalised EDS with extra parameter `Ψ₂Sq²` and initial values
- * `preΨ₀ := 0`,
- * `preΨ₁ := 1`,
- * `preΨ₂ := 1`,
- * `preΨ₃ := ψ₃`, and
- * `preΨ₄ := ψ₄ / ψ₂`.
+* `preΨ₀ := 0`,
+* `preΨ₁ := 1`,
+* `preΨ₂ := 1`,
+* `preΨ₃ := ψ₃`, and
+* `preΨ₄ := ψ₄ / ψ₂`.
 
 The corresponding normalised EDS `Ψₙ ∈ R[X, Y]` is then given by
- * `Ψₙ := preΨₙ ⬝ ψ₂` if `n` is even, and
- * `Ψₙ := preΨₙ` if `n` is odd.
+* `Ψₙ := preΨₙ ⬝ ψ₂` if `n` is even, and
+* `Ψₙ := preΨₙ` if `n` is odd.
 
 Furthermore, define the associated sequences `ΨSqₙ, Φₙ ∈ R[X]` by
- * `ΨSqₙ := preΨₙ² ⬝ Ψ₂Sq` if `n` is even,
- * `ΨSqₙ := preΨₙ²` if `n` is odd,
- * `Φₙ := XΨSqₙ - preΨₙ₊₁ ⬝ preΨₙ₋₁` if `n` is even, and
- * `Φₙ := XΨSqₙ - preΨₙ₊₁ ⬝ preΨₙ₋₁ ⬝ Ψ₂Sq` if `n` is odd.
+* `ΨSqₙ := preΨₙ² ⬝ Ψ₂Sq` if `n` is even,
+* `ΨSqₙ := preΨₙ²` if `n` is odd,
+* `Φₙ := XΨSqₙ - preΨₙ₊₁ ⬝ preΨₙ₋₁` if `n` is even, and
+* `Φₙ := XΨSqₙ - preΨₙ₊₁ ⬝ preΨₙ₋₁ ⬝ Ψ₂Sq` if `n` is odd.
 
 With these definitions, `ψₙ ∈ R[X, Y]` and `φₙ ∈ R[X, Y]` are congruent in `R[W]` to `Ψₙ ∈ R[X, Y]`
 and `Φₙ ∈ R[X]` respectively, which are defined in terms of `Ψ₂Sq ∈ R[X]` and `preΨₙ ∈ R[X]`.
 
 ## Main definitions
 
- * `WeierstrassCurve.preΨ`: the univariate polynomials `preΨₙ`.
- * `WeierstrassCurve.ΨSq`: the univariate polynomials `ΨSqₙ`.
- * `WeierstrassCurve.Ψ`: the bivariate polynomials `Ψₙ`.
- * `WeierstrassCurve.Φ`: the univariate polynomials `Φₙ`.
- * `WeierstrassCurve.ψ`: the bivariate `n`-division polynomials `ψₙ`.
- * `WeierstrassCurve.φ`: the bivariate polynomials `φₙ`.
- * TODO: the bivariate polynomials `ωₙ`.
+* `WeierstrassCurve.preΨ`: the univariate polynomials `preΨₙ`.
+* `WeierstrassCurve.ΨSq`: the univariate polynomials `ΨSqₙ`.
+* `WeierstrassCurve.Ψ`: the bivariate polynomials `Ψₙ`.
+* `WeierstrassCurve.Φ`: the univariate polynomials `Φₙ`.
+* `WeierstrassCurve.ψ`: the bivariate `n`-division polynomials `ψₙ`.
+* `WeierstrassCurve.φ`: the bivariate polynomials `φₙ`.
+* TODO: the bivariate polynomials `ωₙ`.
 
 ## Implementation notes
 

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Degree.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Degree.lean
@@ -15,28 +15,28 @@ Weierstrass curves defined in `Mathlib.AlgebraicGeometry.EllipticCurve.DivisionP
 ## Mathematical background
 
 Let `W` be a Weierstrass curve over a commutative ring `R`. By strong induction,
- * `preΨₙ` has leading coefficient `n / 2` and degree `(n² - 4) / 2` if `n` is even,
- * `preΨₙ` has leading coefficient `n` and degree `(n² - 1) / 2` if `n` is odd,
- * `ΨSqₙ` has leading coefficient `n²` and degree `n² - 1`, and
- * `Φₙ` has leading coefficient `1` and degree `n²`.
+* `preΨₙ` has leading coefficient `n / 2` and degree `(n² - 4) / 2` if `n` is even,
+* `preΨₙ` has leading coefficient `n` and degree `(n² - 1) / 2` if `n` is odd,
+* `ΨSqₙ` has leading coefficient `n²` and degree `n² - 1`, and
+* `Φₙ` has leading coefficient `1` and degree `n²`.
 
 In particular, when `R` is an integral domain of characteristic different from `n`, the univariate
 polynomials `preΨₙ`, `ΨSqₙ`, and `Φₙ` all have their expected leading terms.
 
 ## Main statements
 
- * `WeierstrassCurve.natDegree_preΨ_le`: the degree bound `d` of `preΨₙ`.
- * `WeierstrassCurve.coeff_preΨ`: the `d`-th coefficient of `preΨₙ`.
- * `WeierstrassCurve.natDegree_preΨ`: the degree of `preΨₙ` when `n ≠ 0`.
- * `WeierstrassCurve.leadingCoeff_preΨ`: the leading coefficient of `preΨₙ` when `n ≠ 0`.
- * `WeierstrassCurve.natDegree_ΨSq_le`: the degree bound `d` of `ΨSqₙ`.
- * `WeierstrassCurve.coeff_ΨSq`: the `d`-th coefficient of `ΨSqₙ`.
- * `WeierstrassCurve.natDegree_ΨSq`: the degree of `ΨSqₙ` when `n ≠ 0`.
- * `WeierstrassCurve.leadingCoeff_ΨSq`: the leading coefficient of `ΨSqₙ` when `n ≠ 0`.
- * `WeierstrassCurve.natDegree_Φ_le`: the degree bound `d` of `Φₙ`.
- * `WeierstrassCurve.coeff_Φ`: the `d`-th coefficient of `Φₙ`.
- * `WeierstrassCurve.natDegree_Φ`: the degree of `Φₙ` when `n ≠ 0`.
- * `WeierstrassCurve.leadingCoeff_Φ`: the leading coefficient of `Φₙ` when `n ≠ 0`.
+* `WeierstrassCurve.natDegree_preΨ_le`: the degree bound `d` of `preΨₙ`.
+* `WeierstrassCurve.coeff_preΨ`: the `d`-th coefficient of `preΨₙ`.
+* `WeierstrassCurve.natDegree_preΨ`: the degree of `preΨₙ` when `n ≠ 0`.
+* `WeierstrassCurve.leadingCoeff_preΨ`: the leading coefficient of `preΨₙ` when `n ≠ 0`.
+* `WeierstrassCurve.natDegree_ΨSq_le`: the degree bound `d` of `ΨSqₙ`.
+* `WeierstrassCurve.coeff_ΨSq`: the `d`-th coefficient of `ΨSqₙ`.
+* `WeierstrassCurve.natDegree_ΨSq`: the degree of `ΨSqₙ` when `n ≠ 0`.
+* `WeierstrassCurve.leadingCoeff_ΨSq`: the leading coefficient of `ΨSqₙ` when `n ≠ 0`.
+* `WeierstrassCurve.natDegree_Φ_le`: the degree bound `d` of `Φₙ`.
+* `WeierstrassCurve.coeff_Φ`: the `d`-th coefficient of `Φₙ`.
+* `WeierstrassCurve.natDegree_Φ`: the degree of `Φₙ` when `n ≠ 0`.
+* `WeierstrassCurve.leadingCoeff_Φ`: the leading coefficient of `Φₙ` when `n ≠ 0`.
 
 ## References
 

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian/Basic.lean
@@ -28,13 +28,13 @@ group operations in `Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian/Formula.le
 
 ## Main definitions
 
- * `WeierstrassCurve.Jacobian.PointClass`: the equivalence class of a point representative.
- * `WeierstrassCurve.Jacobian.Nonsingular`: the nonsingular condition on a point representative.
- * `WeierstrassCurve.Jacobian.NonsingularLift`: the nonsingular condition on a point class.
+* `WeierstrassCurve.Jacobian.PointClass`: the equivalence class of a point representative.
+* `WeierstrassCurve.Jacobian.Nonsingular`: the nonsingular condition on a point representative.
+* `WeierstrassCurve.Jacobian.NonsingularLift`: the nonsingular condition on a point class.
 
 ## Main statements
 
- * `WeierstrassCurve.Jacobian.polynomial_relation`: Euler's homogeneous function theorem.
+* `WeierstrassCurve.Jacobian.polynomial_relation`: Euler's homogeneous function theorem.
 
 ## Implementation notes
 

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian/Formula.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian/Formula.lean
@@ -21,15 +21,15 @@ be defined in `Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian/Point.lean`.
 
 ## Main definitions
 
- * `WeierstrassCurve.Jacobian.negY`: the `Y`-coordinate of `-P`.
- * `WeierstrassCurve.Jacobian.dblZ`: the `Z`-coordinate of `2 • P`.
- * `WeierstrassCurve.Jacobian.dblX`: the `X`-coordinate of `2 • P`.
- * `WeierstrassCurve.Jacobian.negDblY`: the `Y`-coordinate of `-(2 • P)`.
- * `WeierstrassCurve.Jacobian.dblY`: the `Y`-coordinate of `2 • P`.
- * `WeierstrassCurve.Jacobian.addZ`: the `Z`-coordinate of `P + Q`.
- * `WeierstrassCurve.Jacobian.addX`: the `X`-coordinate of `P + Q`.
- * `WeierstrassCurve.Jacobian.negAddY`: the `Y`-coordinate of `-(P + Q)`.
- * `WeierstrassCurve.Jacobian.addY`: the `Y`-coordinate of `P + Q`.
+* `WeierstrassCurve.Jacobian.negY`: the `Y`-coordinate of `-P`.
+* `WeierstrassCurve.Jacobian.dblZ`: the `Z`-coordinate of `2 • P`.
+* `WeierstrassCurve.Jacobian.dblX`: the `X`-coordinate of `2 • P`.
+* `WeierstrassCurve.Jacobian.negDblY`: the `Y`-coordinate of `-(2 • P)`.
+* `WeierstrassCurve.Jacobian.dblY`: the `Y`-coordinate of `2 • P`.
+* `WeierstrassCurve.Jacobian.addZ`: the `Z`-coordinate of `P + Q`.
+* `WeierstrassCurve.Jacobian.addX`: the `X`-coordinate of `P + Q`.
+* `WeierstrassCurve.Jacobian.negAddY`: the `Y`-coordinate of `-(P + Q)`.
+* `WeierstrassCurve.Jacobian.addY`: the `Y`-coordinate of `P + Q`.
 
 ## Implementation notes
 

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian/Point.lean
@@ -18,21 +18,21 @@ This file defines the group law on nonsingular Jacobian points.
 
 ## Main definitions
 
- * `WeierstrassCurve.Jacobian.neg`: the negation of a point representative.
- * `WeierstrassCurve.Jacobian.negMap`: the negation of a point class.
- * `WeierstrassCurve.Jacobian.add`: the addition of two point representatives.
- * `WeierstrassCurve.Jacobian.addMap`: the addition of two point classes.
- * `WeierstrassCurve.Jacobian.Point`: a nonsingular Jacobian point.
- * `WeierstrassCurve.Jacobian.Point.neg`: the negation of a nonsingular Jacobian point.
- * `WeierstrassCurve.Jacobian.Point.add`: the addition of two nonsingular Jacobian points.
- * `WeierstrassCurve.Jacobian.Point.toAffineAddEquiv`: the equivalence between the type of
+* `WeierstrassCurve.Jacobian.neg`: the negation of a point representative.
+* `WeierstrassCurve.Jacobian.negMap`: the negation of a point class.
+* `WeierstrassCurve.Jacobian.add`: the addition of two point representatives.
+* `WeierstrassCurve.Jacobian.addMap`: the addition of two point classes.
+* `WeierstrassCurve.Jacobian.Point`: a nonsingular Jacobian point.
+* `WeierstrassCurve.Jacobian.Point.neg`: the negation of a nonsingular Jacobian point.
+* `WeierstrassCurve.Jacobian.Point.add`: the addition of two nonsingular Jacobian points.
+* `WeierstrassCurve.Jacobian.Point.toAffineAddEquiv`: the equivalence between the type of
     nonsingular Jacobian points with the type of nonsingular points `W⟮F⟯` in affine coordinates.
 
 ## Main statements
 
- * `WeierstrassCurve.Jacobian.nonsingular_neg`: negation preserves the nonsingular condition.
- * `WeierstrassCurve.Jacobian.nonsingular_add`: addition preserves the nonsingular condition.
- * `WeierstrassCurve.Jacobian.Point.instAddCommGroup`: the type of nonsingular Jacobian points forms
+* `WeierstrassCurve.Jacobian.nonsingular_neg`: negation preserves the nonsingular condition.
+* `WeierstrassCurve.Jacobian.nonsingular_add`: addition preserves the nonsingular condition.
+* `WeierstrassCurve.Jacobian.Point.instAddCommGroup`: the type of nonsingular Jacobian points forms
     an abelian group under addition.
 
 ## Implementation notes

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/ModelsWithJ.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/ModelsWithJ.lean
@@ -14,18 +14,18 @@ It is a modification of [silverman2009], Chapter III, Proposition 1.4 (c).
 
 ## Main definitions
 
- * `WeierstrassCurve.ofJ0`: an elliptic curve whose j-invariant is 0.
- * `WeierstrassCurve.ofJ1728`: an elliptic curve whose j-invariant is 1728.
- * `WeierstrassCurve.ofJNe0Or1728`: an elliptic curve whose j-invariant is neither 0 nor 1728.
- * `WeierstrassCurve.ofJ`: an elliptic curve whose j-invariant equal to j.
+* `WeierstrassCurve.ofJ0`: an elliptic curve whose j-invariant is 0.
+* `WeierstrassCurve.ofJ1728`: an elliptic curve whose j-invariant is 1728.
+* `WeierstrassCurve.ofJNe0Or1728`: an elliptic curve whose j-invariant is neither 0 nor 1728.
+* `WeierstrassCurve.ofJ`: an elliptic curve whose j-invariant equal to j.
 
 ## Main statements
 
- * `WeierstrassCurve.ofJ_j`: the j-invariant of `WeierstrassCurve.ofJ` is equal to j.
+* `WeierstrassCurve.ofJ_j`: the j-invariant of `WeierstrassCurve.ofJ` is equal to j.
 
 ## References
 
- * [J Silverman, *The Arithmetic of Elliptic Curves*][silverman2009]
+* [J Silverman, *The Arithmetic of Elliptic Curves*][silverman2009]
 
 ## Tags
 

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Projective/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Projective/Basic.lean
@@ -28,13 +28,13 @@ for group operations in `Mathlib/AlgebraicGeometry/EllipticCurve/Projective/Form
 
 ## Main definitions
 
- * `WeierstrassCurve.Projective.PointClass`: the equivalence class of a point representative.
- * `WeierstrassCurve.Projective.Nonsingular`: the nonsingular condition on a point representative.
- * `WeierstrassCurve.Projective.NonsingularLift`: the nonsingular condition on a point class.
+* `WeierstrassCurve.Projective.PointClass`: the equivalence class of a point representative.
+* `WeierstrassCurve.Projective.Nonsingular`: the nonsingular condition on a point representative.
+* `WeierstrassCurve.Projective.NonsingularLift`: the nonsingular condition on a point class.
 
 ## Main statements
 
- * `WeierstrassCurve.Projective.polynomial_relation`: Euler's homogeneous function theorem.
+* `WeierstrassCurve.Projective.polynomial_relation`: Euler's homogeneous function theorem.
 
 ## Implementation notes
 

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Projective/Formula.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Projective/Formula.lean
@@ -21,15 +21,15 @@ be defined in `Mathlib/AlgebraicGeometry/EllipticCurve/Projective/Point.lean`.
 
 ## Main definitions
 
- * `WeierstrassCurve.Projective.negY`: the `Y`-coordinate of `-P`.
- * `WeierstrassCurve.Projective.dblZ`: the `Z`-coordinate of `2 • P`.
- * `WeierstrassCurve.Projective.dblX`: the `X`-coordinate of `2 • P`.
- * `WeierstrassCurve.Projective.negDblY`: the `Y`-coordinate of `-(2 • P)`.
- * `WeierstrassCurve.Projective.dblY`: the `Y`-coordinate of `2 • P`.
- * `WeierstrassCurve.Projective.addZ`: the `Z`-coordinate of `P + Q`.
- * `WeierstrassCurve.Projective.addX`: the `X`-coordinate of `P + Q`.
- * `WeierstrassCurve.Projective.negAddY`: the `Y`-coordinate of `-(P + Q)`.
- * `WeierstrassCurve.Projective.addY`: the `Y`-coordinate of `P + Q`.
+* `WeierstrassCurve.Projective.negY`: the `Y`-coordinate of `-P`.
+* `WeierstrassCurve.Projective.dblZ`: the `Z`-coordinate of `2 • P`.
+* `WeierstrassCurve.Projective.dblX`: the `X`-coordinate of `2 • P`.
+* `WeierstrassCurve.Projective.negDblY`: the `Y`-coordinate of `-(2 • P)`.
+* `WeierstrassCurve.Projective.dblY`: the `Y`-coordinate of `2 • P`.
+* `WeierstrassCurve.Projective.addZ`: the `Z`-coordinate of `P + Q`.
+* `WeierstrassCurve.Projective.addX`: the `X`-coordinate of `P + Q`.
+* `WeierstrassCurve.Projective.negAddY`: the `Y`-coordinate of `-(P + Q)`.
+* `WeierstrassCurve.Projective.addY`: the `Y`-coordinate of `P + Q`.
 
 ## Implementation notes
 

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Projective/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Projective/Point.lean
@@ -18,21 +18,21 @@ This file defines the group law on nonsingular projective points.
 
 ## Main definitions
 
- * `WeierstrassCurve.Projective.neg`: the negation of a point representative.
- * `WeierstrassCurve.Projective.negMap`: the negation of a point class.
- * `WeierstrassCurve.Projective.add`: the addition of two point representatives.
- * `WeierstrassCurve.Projective.addMap`: the addition of two point classes.
- * `WeierstrassCurve.Projective.Point`: a nonsingular projective point.
- * `WeierstrassCurve.Projective.Point.neg`: the negation of a nonsingular projective point.
- * `WeierstrassCurve.Projective.Point.add`: the addition of two nonsingular projective points.
- * `WeierstrassCurve.Projective.Point.toAffineAddEquiv`: the equivalence between the type of
+* `WeierstrassCurve.Projective.neg`: the negation of a point representative.
+* `WeierstrassCurve.Projective.negMap`: the negation of a point class.
+* `WeierstrassCurve.Projective.add`: the addition of two point representatives.
+* `WeierstrassCurve.Projective.addMap`: the addition of two point classes.
+* `WeierstrassCurve.Projective.Point`: a nonsingular projective point.
+* `WeierstrassCurve.Projective.Point.neg`: the negation of a nonsingular projective point.
+* `WeierstrassCurve.Projective.Point.add`: the addition of two nonsingular projective points.
+* `WeierstrassCurve.Projective.Point.toAffineAddEquiv`: the equivalence between the type of
     nonsingular projective points with the type of nonsingular points `W⟮F⟯` in affine coordinates.
 
 ## Main statements
 
- * `WeierstrassCurve.Projective.nonsingular_neg`: negation preserves the nonsingular condition.
- * `WeierstrassCurve.Projective.nonsingular_add`: addition preserves the nonsingular condition.
- * `WeierstrassCurve.Projective.Point.instAddCommGroup`: the type of nonsingular projective points
+* `WeierstrassCurve.Projective.nonsingular_neg`: negation preserves the nonsingular condition.
+* `WeierstrassCurve.Projective.nonsingular_add`: addition preserves the nonsingular condition.
+* `WeierstrassCurve.Projective.Point.instAddCommGroup`: the type of nonsingular projective points
     forms an abelian group under addition.
 
 ## Implementation notes

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/VariableChange.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/VariableChange.lean
@@ -12,19 +12,19 @@ This file defines admissible linear change of variables of Weierstrass curves.
 
 ## Main definitions
 
- * `WeierstrassCurve.VariableChange`: a change of variables of Weierstrass curves.
- * An instance which states that change of variables forms a group.
- * An instance which states that change of variables acts on Weierstrass curves.
+* `WeierstrassCurve.VariableChange`: a change of variables of Weierstrass curves.
+* An instance which states that change of variables forms a group.
+* An instance which states that change of variables acts on Weierstrass curves.
 
 ## Main statements
 
- * An instance which states that change of variables preserves elliptic curves.
- * `WeierstrassCurve.variableChange_j`: the j-invariant of an elliptic curve is invariant under an
+* An instance which states that change of variables preserves elliptic curves.
+* `WeierstrassCurve.variableChange_j`: the j-invariant of an elliptic curve is invariant under an
     admissible linear change of variables.
 
 ## References
 
- * [J Silverman, *The Arithmetic of Elliptic Curves*][silverman2009]
+* [J Silverman, *The Arithmetic of Elliptic Curves*][silverman2009]
 
 ## Tags
 

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Weierstrass.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Weierstrass.lean
@@ -30,16 +30,16 @@ field of `R` are precisely the `X`-coordinates of the non-zero 2-torsion points 
 
 ## Main definitions
 
- * `WeierstrassCurve`: a Weierstrass curve over a commutative ring.
- * `WeierstrassCurve.Δ`: the discriminant of a Weierstrass curve.
- * `WeierstrassCurve.map`: the Weierstrass curve mapped over a ring homomorphism.
- * `WeierstrassCurve.twoTorsionPolynomial`: the 2-torsion polynomial of a Weierstrass curve.
- * `WeierstrassCurve.IsElliptic`: typeclass asserting that a Weierstrass curve is an elliptic curve.
- * `WeierstrassCurve.j`: the j-invariant of an elliptic curve.
+* `WeierstrassCurve`: a Weierstrass curve over a commutative ring.
+* `WeierstrassCurve.Δ`: the discriminant of a Weierstrass curve.
+* `WeierstrassCurve.map`: the Weierstrass curve mapped over a ring homomorphism.
+* `WeierstrassCurve.twoTorsionPolynomial`: the 2-torsion polynomial of a Weierstrass curve.
+* `WeierstrassCurve.IsElliptic`: typeclass asserting that a Weierstrass curve is an elliptic curve.
+* `WeierstrassCurve.j`: the j-invariant of an elliptic curve.
 
 ## Main statements
 
- * `WeierstrassCurve.twoTorsionPolynomial_disc`: the discriminant of a Weierstrass curve is a
+* `WeierstrassCurve.twoTorsionPolynomial_disc`: the discriminant of a Weierstrass curve is a
     constant factor of the cubic discriminant of its 2-torsion polynomial.
 
 ## Implementation notes
@@ -53,9 +53,9 @@ which are not globally defined by a cubic equation valid over the entire base.
 
 ## References
 
- * [N Katz and B Mazur, *Arithmetic Moduli of Elliptic Curves*][katz_mazur]
- * [P Deligne, *Courbes Elliptiques: Formulaire (d'après J. Tate)*][deligne_formulaire]
- * [J Silverman, *The Arithmetic of Elliptic Curves*][silverman2009]
+* [N Katz and B Mazur, *Arithmetic Moduli of Elliptic Curves*][katz_mazur]
+* [P Deligne, *Courbes Elliptiques: Formulaire (d'après J. Tate)*][deligne_formulaire]
+* [J Silverman, *The Arithmetic of Elliptic Curves*][silverman2009]
 
 ## Tags
 

--- a/Mathlib/Analysis/Analytic/CPolynomialDef.lean
+++ b/Mathlib/Analysis/Analytic/CPolynomialDef.lean
@@ -22,7 +22,7 @@ for `n : ℕ`, and let `f` be a function from `E` to `F`.
 * `HasFiniteFPowerSeriesAt f p x n`: on some ball of center `x` with positive radius, holds
   `HasFiniteFPowerSeriesOnBall f p x n r`.
 * `CPolynomialAt 𝕜 f x`: there exists a power series `p` and a natural number `n` such that
-   holds `HasFPowerSeriesAt f p x n`.
+  holds `HasFPowerSeriesAt f p x n`.
 * `CPolynomialOn 𝕜 f s`: the function `f` is analytic at every point of `s`.
 
 In this file, we develop the basic properties of these notions, notably:

--- a/Mathlib/Analysis/Analytic/OfScalars.lean
+++ b/Mathlib/Analysis/Analytic/OfScalars.lean
@@ -11,13 +11,13 @@ import Mathlib.Analysis.Analytic.Basic
 This file contains API for analytic functions `∑ cᵢ • xⁱ` defined in terms of scalars
 `c₀, c₁, c₂, …`.
 ## Main definitions / results:
- * `FormalMultilinearSeries.ofScalars`: the formal power series `∑ cᵢ • xⁱ`.
- * `FormalMultilinearSeries.ofScalarsSum`: the sum of such a power series, if it exists, and zero
-   otherwise.
- * `FormalMultilinearSeries.ofScalars_radius_eq_(zero/inv/top)_of_tendsto`:
-   the ratio test for an analytic function defined in terms of a formal power series `∑ cᵢ • xⁱ`.
- * `FormalMultilinearSeries.ofScalars_radius_eq_inv_of_tendsto_ENNReal`:
-   the ratio test for an analytic function using `ENNReal` division for all values `ℝ≥0∞`.
+* `FormalMultilinearSeries.ofScalars`: the formal power series `∑ cᵢ • xⁱ`.
+* `FormalMultilinearSeries.ofScalarsSum`: the sum of such a power series, if it exists, and zero
+  otherwise.
+* `FormalMultilinearSeries.ofScalars_radius_eq_(zero/inv/top)_of_tendsto`:
+  the ratio test for an analytic function defined in terms of a formal power series `∑ cᵢ • xⁱ`.
+* `FormalMultilinearSeries.ofScalars_radius_eq_inv_of_tendsto_ENNReal`:
+  the ratio test for an analytic function using `ENNReal` division for all values `ℝ≥0∞`.
 -/
 
 namespace FormalMultilinearSeries

--- a/Mathlib/Analysis/BoxIntegral/Partition/Split.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/Split.lean
@@ -19,7 +19,7 @@ We introduce the following definitions.
 * `BoxIntegral.Box.splitLower I i a` and `BoxIntegral.Box.splitUpper I i a` are these boxes (as
   `WithBot (BoxIntegral.Box ι)`);
 * `BoxIntegral.Prepartition.split I i a` is the partition of `I` made of these two boxes (or of one
-   box `I` if one of these boxes is empty);
+  box `I` if one of these boxes is empty);
 * `BoxIntegral.Prepartition.splitMany I s`, where `s : Finset (ι × ℝ)` is a finite set of
   hyperplanes `{x : ι → ℝ | x i = a}` encoded as pairs `(i, a)`, is the partition of `I` made by
   cutting it along all the hyperplanes in `s`.

--- a/Mathlib/Analysis/Calculus/AddTorsor/AffineMap.lean
+++ b/Mathlib/Analysis/Calculus/AddTorsor/AffineMap.lean
@@ -13,7 +13,7 @@ This file contains results about smoothness of affine maps.
 
 ## Main definitions:
 
- * `ContinuousAffineMap.contDiff`: a continuous affine map is smooth
+* `ContinuousAffineMap.contDiff`: a continuous affine map is smooth
 
 -/
 

--- a/Mathlib/Analysis/Calculus/ParametricIntegral.lean
+++ b/Mathlib/Analysis/Calculus/ParametricIntegral.lean
@@ -39,8 +39,8 @@ variable.
   controlled by a positive number `ε`.
 
 * `hasFDerivAt_integral_of_dominated_of_fderiv_le`: this version assumes `fun x ↦ F x a` has
-   derivative `F' x a` for `x` near `x₀` and `F' x` is bounded by an integrable function independent
-   from `x` near `x₀`.
+  derivative `F' x a` for `x` near `x₀` and `F' x` is bounded by an integrable function independent
+  from `x` near `x₀`.
 
 `hasDerivAt_integral_of_dominated_loc_of_lip` and
 `hasDerivAt_integral_of_dominated_loc_of_deriv_le` are versions of the above two results that

--- a/Mathlib/Analysis/InnerProductSpace/JointEigenspace.lean
+++ b/Mathlib/Analysis/InnerProductSpace/JointEigenspace.lean
@@ -17,15 +17,15 @@ symmetric operators on a finite-dimensional inner product space.
 # Main Result
 
 * `LinearMap.IsSymmetric.directSum_isInternal_of_commute` establishes that in finite dimensions
-   if `{A B : E →ₗ[𝕜] E}`, then `IsSymmetric A`, `IsSymmetric B` and `Commute A B` imply that
-   `E` decomposes as an internal direct sum of the pairwise orthogonal spaces
-   `eigenspace B μ ⊓ eigenspace A ν`
+  if `{A B : E →ₗ[𝕜] E}`, then `IsSymmetric A`, `IsSymmetric B` and `Commute A B` imply that
+  `E` decomposes as an internal direct sum of the pairwise orthogonal spaces
+  `eigenspace B μ ⊓ eigenspace A ν`
 * `LinearMap.IsSymmetric.iSup_iInf_eigenspace_eq_top_of_commute` establishes that in finite
-   dimensions, the indexed supremum of the joint eigenspaces of a commuting tuple of symmetric
-   linear operators equals `⊤`
+  dimensions, the indexed supremum of the joint eigenspaces of a commuting tuple of symmetric
+  linear operators equals `⊤`
 * `LinearMap.IsSymmetric.directSum_isInternal_of_pairwise_commute` establishes the
-   analogous result to `LinearMap.IsSymmetric.directSum_isInternal_of_commute` for commuting
-   tuples of symmetric operators.
+  analogous result to `LinearMap.IsSymmetric.directSum_isInternal_of_commute` for commuting
+  tuples of symmetric operators.
 
 ## TODO
 

--- a/Mathlib/Analysis/Normed/Affine/AddTorsorBases.lean
+++ b/Mathlib/Analysis/Normed/Affine/AddTorsorBases.lean
@@ -13,11 +13,11 @@ This file contains results about bases in normed affine spaces.
 
 ## Main definitions:
 
- * `continuous_barycentric_coord`
- * `isOpenMap_barycentric_coord`
- * `AffineBasis.interior_convexHull`
- * `IsOpen.exists_subset_affineIndependent_span_eq_top`
- * `interior_convexHull_nonempty_iff_affineSpan_eq_top`
+* `continuous_barycentric_coord`
+* `isOpenMap_barycentric_coord`
+* `AffineBasis.interior_convexHull`
+* `IsOpen.exists_subset_affineIndependent_span_eq_top`
+* `interior_convexHull_nonempty_iff_affineSpan_eq_top`
 -/
 
 assert_not_exists HasFDerivAt

--- a/Mathlib/Analysis/Normed/Affine/ContinuousAffineMap.lean
+++ b/Mathlib/Analysis/Normed/Affine/ContinuousAffineMap.lean
@@ -31,10 +31,10 @@ submultiplicative: for a composition of maps, we have only `‖f.comp g‖ ≤ �
 
 ## Main definitions:
 
- * `ContinuousAffineMap.contLinear`
- * `ContinuousAffineMap.hasNorm`
- * `ContinuousAffineMap.norm_comp_le`
- * `ContinuousAffineMap.toConstProdContinuousLinearMap`
+* `ContinuousAffineMap.contLinear`
+* `ContinuousAffineMap.hasNorm`
+* `ContinuousAffineMap.norm_comp_le`
+* `ContinuousAffineMap.toConstProdContinuousLinearMap`
 
 -/
 

--- a/Mathlib/Analysis/Normed/Group/AddCircle.lean
+++ b/Mathlib/Analysis/Normed/Group/AddCircle.lean
@@ -15,11 +15,11 @@ We define the normed group structure on `AddCircle p`, for `p : ℝ`. For exampl
 
 ## Main definitions:
 
- * `AddCircle.norm_eq`: a characterisation of the norm on `AddCircle p`
+* `AddCircle.norm_eq`: a characterisation of the norm on `AddCircle p`
 
 ## TODO
 
- * The fact `InnerProductGeometry.angle (Real.cos θ) (Real.sin θ) = ‖(θ : Real.Angle)‖`
+* The fact `InnerProductGeometry.angle (Real.cos θ) (Real.sin θ) = ‖(θ : Real.Angle)‖`
 
 -/
 

--- a/Mathlib/Analysis/Normed/Module/Dual.lean
+++ b/Mathlib/Analysis/Normed/Module/Dual.lean
@@ -59,7 +59,7 @@ variable (F : Type*) [NormedAddCommGroup F] [NormedSpace 𝕜 F]
 abbrev Dual : Type _ := E →L[𝕜] 𝕜
 
 /-- The inclusion of a normed space in its double (topological) dual, considered
-   as a bounded linear map. -/
+as a bounded linear map. -/
 def inclusionInDoubleDual : E →L[𝕜] Dual 𝕜 (Dual 𝕜 E) :=
   ContinuousLinearMap.apply 𝕜 𝕜
 

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Integral.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Integral.lean
@@ -18,7 +18,7 @@ A variant of the formula with measures of sets of the form `{ω | f(ω) > t}` in
 
 ## Main results
 
- * `MeasureTheory.lintegral_rpow_eq_lintegral_meas_le_mul` and
+* `MeasureTheory.lintegral_rpow_eq_lintegral_meas_le_mul` and
   `MeasureTheory.lintegral_rpow_eq_lintegral_meas_lt_mul`:
   other common special cases of the layer cake formulas, stating that for a nonnegative function `f`
   and `p > 0`, we have `∫ f(ω)ᵖ ∂μ(ω) = p * ∫ μ {ω | f(ω) ≥ t} * tᵖ⁻¹ dt` and

--- a/Mathlib/CategoryTheory/Bicategory/Coherence.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Coherence.lean
@@ -31,7 +31,7 @@ theorem follows immediately from this fact.
 ## References
 
 * [Ilya Beylin and Peter Dybjer, Extracting a proof of coherence for monoidal categories from a
-   proof of normalization for monoids][beylin1996]
+  proof of normalization for monoids][beylin1996]
 -/
 
 

--- a/Mathlib/CategoryTheory/CofilteredSystem.lean
+++ b/Mathlib/CategoryTheory/CofilteredSystem.lean
@@ -28,7 +28,7 @@ Given a functor `F : J ⥤ Type v`:
 * `nonempty_sections_of_finite_cofiltered_system` shows that if `J` is cofiltered and each
   `F.obj j` is nonempty and finite, `F.sections` is nonempty.
 * `nonempty_sections_of_finite_inverse_system` is a specialization of the above to `J` being a
-   directed set (and `F : Jᵒᵖ ⥤ Type v`).
+  directed set (and `F : Jᵒᵖ ⥤ Type v`).
 * `isMittagLeffler_of_exists_finite_range` shows that if `J` is cofiltered and for all `j`,
   there exists some `i` and `f : i ⟶ j` such that the range of `F.map f` is finite, then
   `F` is Mittag-Leffler.

--- a/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
@@ -29,7 +29,7 @@ is thin.
 ## References
 
 * [Ilya Beylin and Peter Dybjer, Extracting a proof of coherence for monoidal categories from a
-   proof of normalization for monoids][beylin1996]
+  proof of normalization for monoids][beylin1996]
 
 -/
 

--- a/Mathlib/CategoryTheory/Products/Basic.lean
+++ b/Mathlib/CategoryTheory/Products/Basic.lean
@@ -226,7 +226,7 @@ def prod (F : A ⥤ B) (G : C ⥤ D) : A × C ⥤ B × D where
   map f := (F.map f.1, G.map f.2)
 
 /- Because of limitations in Lean 3's handling of notations, we do not setup a notation `F × G`.
-   You can use `F.prod G` as a "poor man's infix", or just write `functor.prod F G`. -/
+You can use `F.prod G` as a "poor man's infix", or just write `functor.prod F G`. -/
 /-- Similar to `prod`, but both functors start from the same category `A` -/
 @[simps]
 def prod' (F : A ⥤ B) (G : A ⥤ C) : A ⥤ B × C where
@@ -264,7 +264,7 @@ def prod {F G : A ⥤ B} {H I : C ⥤ D} (α : F ⟶ G) (β : H ⟶ I) : F.prod 
   app X := (α.app X.1, β.app X.2)
 
 /- Again, it is inadvisable in Lean 3 to setup a notation `α × β`;
-   use instead `α.prod β` or `NatTrans.prod α β`. -/
+use instead `α.prod β` or `NatTrans.prod α β`. -/
 
 /-- The cartesian product of two natural transformations where both functors have the
 same source. -/

--- a/Mathlib/CategoryTheory/Sites/Closed.lean
+++ b/Mathlib/CategoryTheory/Sites/Closed.lean
@@ -26,7 +26,7 @@ that natural closure operators are in bijection with Grothendieck topologies.
 * `CategoryTheory.GrothendieckTopology.closureOperator`: The bundled `ClosureOperator` given
   by `CategoryTheory.GrothendieckTopology.close`.
 * `CategoryTheory.GrothendieckTopology.IsClosed`: A sieve `S` on `X` is closed for the topology `J`
-   if it contains every arrow it covers.
+  if it contains every arrow it covers.
 * `CategoryTheory.Functor.closedSieves`: The presheaf sending `X` to the collection of `J`-closed
   sieves on `X`. This is additionally shown to be a sheaf for `J`, and if this is a sheaf for a
   different topology `J'`, then `J' ≤ J`.

--- a/Mathlib/Combinatorics/Optimization/ValuedCSP.lean
+++ b/Mathlib/Combinatorics/Optimization/ValuedCSP.lean
@@ -25,11 +25,11 @@ General-Valued CSP subsumes Min-Cost-Hom (including 3-SAT for example) and Finit
 * `Function.HasMaxCutProperty`: Can given binary function express the Max-Cut problem?
 * `FractionalOperation`: Multiset of operations on given domain of the same arity.
 * `FractionalOperation.IsSymmetricFractionalPolymorphismFor`: Is given fractional operation a
-   symmetric fractional polymorphism for given VCSP template?
+  symmetric fractional polymorphism for given VCSP template?
 
 ## References
 * [D. A. Cohen, M. C. Cooper, P. Creed, P. G. Jeavons, S. Živný,
-   *An Algebraic Theory of Complexity for Discrete Optimisation*][cohen2012]
+  *An Algebraic Theory of Complexity for Discrete Optimisation*][cohen2012]
 
 -/
 

--- a/Mathlib/Combinatorics/SimpleGraph/StronglyRegular.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/StronglyRegular.lean
@@ -37,10 +37,10 @@ variable {V : Type u} [Fintype V]
 variable (G : SimpleGraph V) [DecidableRel G.Adj]
 
 /-- A graph is strongly regular with parameters `n k ℓ μ` if
- * its vertex set has cardinality `n`
- * it is regular with degree `k`
- * every pair of adjacent vertices has `ℓ` common neighbors
- * every pair of nonadjacent vertices has `μ` common neighbors
+* its vertex set has cardinality `n`
+* it is regular with degree `k`
+* every pair of adjacent vertices has `ℓ` common neighbors
+* every pair of nonadjacent vertices has `μ` common neighbors
 -/
 structure IsSRGWith (n k ℓ μ : ℕ) : Prop where
   card : Fintype.card V = n

--- a/Mathlib/Control/Bitraversable/Lemmas.lean
+++ b/Mathlib/Control/Bitraversable/Lemmas.lean
@@ -23,7 +23,7 @@ with the applicatives `id` and `comp`
 
 ## References
 
- * Hackage: <https://hackage.haskell.org/package/base-4.12.0.0/docs/Data-Bitraversable.html>
+* Hackage: <https://hackage.haskell.org/package/base-4.12.0.0/docs/Data-Bitraversable.html>
 
 ## Tags
 

--- a/Mathlib/Control/Fix.lean
+++ b/Mathlib/Control/Fix.lean
@@ -18,8 +18,8 @@ An instance is defined for `Part`.
 
 ## Main definition
 
- * class `Fix`
- * `Part.fix`
+* class `Fix`
+* `Part.fix`
 -/
 
 

--- a/Mathlib/Control/LawfulFix.lean
+++ b/Mathlib/Control/LawfulFix.lean
@@ -17,7 +17,7 @@ omega complete partial orders (ωCPO). Proofs of the lawfulness of all `Fix` ins
 
 ## Main definition
 
- * class `LawfulFix`
+* class `LawfulFix`
 -/
 
 universe u v

--- a/Mathlib/Control/Monad/Basic.lean
+++ b/Mathlib/Control/Monad/Basic.lean
@@ -10,9 +10,9 @@ import Mathlib.Logic.Equiv.Defs
 
 ## Attributes
 
- * ext
- * functor_norm
- * monad_norm
+* ext
+* functor_norm
+* monad_norm
 
 ## Implementation Details
 

--- a/Mathlib/Control/Traversable/Basic.lean
+++ b/Mathlib/Control/Traversable/Basic.lean
@@ -44,15 +44,15 @@ traversable iterator functor applicative
 
 ## References
 
- * "Applicative Programming with Effects", by Conor McBride and Ross Paterson,
-   Journal of Functional Programming 18:1 (2008) 1-13, online at
-   <http://www.soi.city.ac.uk/~ross/papers/Applicative.html>
- * "The Essence of the Iterator Pattern", by Jeremy Gibbons and Bruno Oliveira,
-   in Mathematically-Structured Functional Programming, 2006, online at
-   <http://web.comlab.ox.ac.uk/oucl/work/jeremy.gibbons/publications/#iterator>
- * "An Investigation of the Laws of Traversals", by Mauro Jaskelioff and Ondrej Rypacek,
-   in Mathematically-Structured Functional Programming, 2012,
-   online at <http://arxiv.org/pdf/1202.2919>
+* "Applicative Programming with Effects", by Conor McBride and Ross Paterson,
+  Journal of Functional Programming 18:1 (2008) 1-13, online at
+  <http://www.soi.city.ac.uk/~ross/papers/Applicative.html>
+* "The Essence of the Iterator Pattern", by Jeremy Gibbons and Bruno Oliveira,
+  in Mathematically-Structured Functional Programming, 2006, online at
+  <http://web.comlab.ox.ac.uk/oucl/work/jeremy.gibbons/publications/#iterator>
+* "An Investigation of the Laws of Traversals", by Mauro Jaskelioff and Ondrej Rypacek,
+  in Mathematically-Structured Functional Programming, 2012,
+  online at <http://arxiv.org/pdf/1202.2919>
 -/
 
 open Function hiding comp

--- a/Mathlib/Dynamics/Ergodic/AddCircle.lean
+++ b/Mathlib/Dynamics/Ergodic/AddCircle.lean
@@ -17,14 +17,14 @@ This file contains proofs of ergodicity for maps of the additive circle.
 
 ## Main definitions:
 
- * `AddCircle.ergodic_zsmul`: given `n : ℤ` such that `1 < |n|`, the self map `y ↦ n • y` on
-   the additive circle is ergodic (wrt the Haar measure).
- * `AddCircle.ergodic_nsmul`: given `n : ℕ` such that `1 < n`, the self map `y ↦ n • y` on
-   the additive circle is ergodic (wrt the Haar measure).
- * `AddCircle.ergodic_zsmul_add`: given `n : ℤ` such that `1 < |n|` and `x : AddCircle T`, the
-   self map `y ↦ n • y + x` on the additive circle is ergodic (wrt the Haar measure).
- * `AddCircle.ergodic_nsmul_add`: given `n : ℕ` such that `1 < n` and `x : AddCircle T`, the
-   self map `y ↦ n • y + x` on the additive circle is ergodic (wrt the Haar measure).
+* `AddCircle.ergodic_zsmul`: given `n : ℤ` such that `1 < |n|`, the self map `y ↦ n • y` on
+  the additive circle is ergodic (wrt the Haar measure).
+* `AddCircle.ergodic_nsmul`: given `n : ℕ` such that `1 < n`, the self map `y ↦ n • y` on
+  the additive circle is ergodic (wrt the Haar measure).
+* `AddCircle.ergodic_zsmul_add`: given `n : ℤ` such that `1 < |n|` and `x : AddCircle T`, the
+  self map `y ↦ n • y + x` on the additive circle is ergodic (wrt the Haar measure).
+* `AddCircle.ergodic_nsmul_add`: given `n : ℕ` such that `1 < n` and `x : AddCircle T`, the
+  self map `y ↦ n • y + x` on the additive circle is ergodic (wrt the Haar measure).
 
 -/
 

--- a/Mathlib/Dynamics/Ergodic/Ergodic.lean
+++ b/Mathlib/Dynamics/Ergodic/Ergodic.lean
@@ -19,13 +19,13 @@ preserving condition is relaxed to quasi measure preserving.
 
 # Main definitions:
 
- * `PreErgodic`: the ergodicity condition without the measure preserving condition. This exists
-   to share code between the `Ergodic` and `QuasiErgodic` definitions.
- * `Ergodic`: the definition of ergodic maps / measures.
- * `QuasiErgodic`: the definition of quasi ergodic maps / measures.
- * `Ergodic.quasiErgodic`: an ergodic map / measure is quasi ergodic.
- * `QuasiErgodic.ae_empty_or_univ'`: when the map is quasi measure preserving, one may relax the
-   strict invariance condition to almost invariance in the ergodicity condition.
+* `PreErgodic`: the ergodicity condition without the measure preserving condition. This exists
+  to share code between the `Ergodic` and `QuasiErgodic` definitions.
+* `Ergodic`: the definition of ergodic maps / measures.
+* `QuasiErgodic`: the definition of quasi ergodic maps / measures.
+* `Ergodic.quasiErgodic`: an ergodic map / measure is quasi ergodic.
+* `QuasiErgodic.ae_empty_or_univ'`: when the map is quasi measure preserving, one may relax the
+  strict invariance condition to almost invariance in the ergodicity condition.
 
 -/
 

--- a/Mathlib/Dynamics/Newton.lean
+++ b/Mathlib/Dynamics/Newton.lean
@@ -20,14 +20,14 @@ such as Hensel's lemma and Jordan-Chevalley decomposition.
 
 ## Main definitions / results:
 
- * `Polynomial.newtonMap`: the map `x ↦ x - P(x) / P'(x)`, where `P'` is the derivative of the
-   polynomial `P`.
- * `Polynomial.isFixedPt_newtonMap_of_isUnit_iff`: `x` is a fixed point for Newton iteration iff
-   it is a root of `P` (provided `P'(x)` is a unit).
- * `Polynomial.existsUnique_nilpotent_sub_and_aeval_eq_zero`: if `x` is almost a root of `P` in the
-   sense that `P(x)` is nilpotent (and `P'(x)` is a unit) then we may write `x` as a sum
-   `x = n + r` where `n` is nilpotent and `r` is a root of `P`. This can be used to prove the
-   Jordan-Chevalley decomposition of linear endomorphims.
+* `Polynomial.newtonMap`: the map `x ↦ x - P(x) / P'(x)`, where `P'` is the derivative of the
+  polynomial `P`.
+* `Polynomial.isFixedPt_newtonMap_of_isUnit_iff`: `x` is a fixed point for Newton iteration iff
+  it is a root of `P` (provided `P'(x)` is a unit).
+* `Polynomial.existsUnique_nilpotent_sub_and_aeval_eq_zero`: if `x` is almost a root of `P` in the
+  sense that `P(x)` is nilpotent (and `P'(x)` is a unit) then we may write `x` as a sum
+  `x = n + r` where `n` is nilpotent and `r` is a root of `P`. This can be used to prove the
+  Jordan-Chevalley decomposition of linear endomorphims.
 
 -/
 

--- a/Mathlib/FieldTheory/Finite/Basic.lean
+++ b/Mathlib/FieldTheory/Finite/Basic.lean
@@ -29,10 +29,10 @@ cyclic group, as well as the fact that every finite integral domain is a field
 
 1. `Fintype.card_units`: The unit group of a finite field has cardinality `q - 1`.
 2. `sum_pow_units`: The sum of `x^i`, where `x` ranges over the units of `K`, is
-   - `q-1` if `q-1 ∣ i`
-   - `0`   otherwise
+  - `q-1` if `q-1 ∣ i`
+  - `0`   otherwise
 3. `FiniteField.card`: The cardinality `q` is a power of the characteristic of `K`.
-   See `FiniteField.card'` for a variant.
+  See `FiniteField.card'` for a variant.
 
 ## Notation
 

--- a/Mathlib/FieldTheory/Minpoly/IsIntegrallyClosed.lean
+++ b/Mathlib/FieldTheory/Minpoly/IsIntegrallyClosed.lean
@@ -14,13 +14,13 @@ This file specializes the theory of minpoly to the case of an algebra over a GCD
 
 ## Main results
 
- * `minpoly.isIntegrallyClosed_eq_field_fractions`: For integrally closed domains, the minimal
+* `minpoly.isIntegrallyClosed_eq_field_fractions`: For integrally closed domains, the minimal
     polynomial over the ring is the same as the minimal polynomial over the fraction field.
 
- * `minpoly.isIntegrallyClosed_dvd` : For integrally closed domains, the minimal polynomial divides
+* `minpoly.isIntegrallyClosed_dvd` : For integrally closed domains, the minimal polynomial divides
     any primitive polynomial that has the integral element as root.
 
- * `IsIntegrallyClosed.Minpoly.unique` : The minimal polynomial of an element `x` is
+* `IsIntegrallyClosed.Minpoly.unique` : The minimal polynomial of an element `x` is
     uniquely characterized by its defining property: if there is another monic polynomial of minimal
     degree that has `x` as a root, then this polynomial is equal to the minimal polynomial of `x`.
 

--- a/Mathlib/FieldTheory/Perfect.lean
+++ b/Mathlib/FieldTheory/Perfect.lean
@@ -16,20 +16,20 @@ In this file we define perfect fields, together with a generalisation to (commut
 prime characteristic.
 
 ## Main definitions / statements:
- * `PerfectRing`: a ring of characteristic `p` (prime) is said to be perfect in the sense of Serre,
-   if its absolute Frobenius map `x ↦ xᵖ` is bijective.
- * `PerfectField`: a field `K` is said to be perfect if every irreducible polynomial over `K` is
-   separable.
- * `PerfectRing.toPerfectField`: a field that is perfect in the sense of Serre is a perfect field.
- * `PerfectField.toPerfectRing`: a perfect field of characteristic `p` (prime) is perfect in the
-   sense of Serre.
- * `PerfectField.ofCharZero`: all fields of characteristic zero are perfect.
- * `PerfectField.ofFinite`: all finite fields are perfect.
- * `PerfectField.separable_iff_squarefree`: a polynomial over a perfect field is separable iff
-   it is square-free.
- * `Algebra.IsAlgebraic.isSeparable_of_perfectField`, `Algebra.IsAlgebraic.perfectField`:
-   if `L / K` is an algebraic extension, `K` is a perfect field, then `L / K` is separable,
-   and `L` is also a perfect field.
+* `PerfectRing`: a ring of characteristic `p` (prime) is said to be perfect in the sense of Serre,
+  if its absolute Frobenius map `x ↦ xᵖ` is bijective.
+* `PerfectField`: a field `K` is said to be perfect if every irreducible polynomial over `K` is
+  separable.
+* `PerfectRing.toPerfectField`: a field that is perfect in the sense of Serre is a perfect field.
+* `PerfectField.toPerfectRing`: a perfect field of characteristic `p` (prime) is perfect in the
+  sense of Serre.
+* `PerfectField.ofCharZero`: all fields of characteristic zero are perfect.
+* `PerfectField.ofFinite`: all finite fields are perfect.
+* `PerfectField.separable_iff_squarefree`: a polynomial over a perfect field is separable iff
+  it is square-free.
+* `Algebra.IsAlgebraic.isSeparable_of_perfectField`, `Algebra.IsAlgebraic.perfectField`:
+  if `L / K` is an algebraic extension, `K` is a perfect field, then `L / K` is separable,
+  and `L` is also a perfect field.
 
 -/
 

--- a/Mathlib/FieldTheory/PurelyInseparable/Exponent.lean
+++ b/Mathlib/FieldTheory/PurelyInseparable/Exponent.lean
@@ -28,7 +28,7 @@ it gives cleaner API. To use the results in a context with `[ExpChar K p]`, cons
   for purely inseparable field extension `L / K` with exponent; for `n ≥ exponent K L`, it acts like
   `x ↦ x ^ p ^ n` but the codomain is the base field `K`.
 - `IsPurelyInseparable.iterateFrobeniusₛₗ`: version of `iterateFrobenius` as a semilinear map over
-   a subfield `F` of `K`, wrt the iterated Frobenius homomorphism on `F`.
+  a subfield `F` of `K`, wrt the iterated Frobenius homomorphism on `F`.
 
 ## Tags
 

--- a/Mathlib/FieldTheory/RatFunc/Basic.lean
+++ b/Mathlib/FieldTheory/RatFunc/Basic.lean
@@ -13,14 +13,15 @@ import Mathlib.RingTheory.Polynomial.Content
 
 ## Main definitions
 Working with rational functions as polynomials:
- - `RatFunc.instField` provides a field structure
+- `RatFunc.instField` provides a field structure
 You can use `IsFractionRing` API to treat `RatFunc` as the field of fractions of polynomials:
- * `algebraMap K[X] (RatFunc K)` maps polynomials to rational functions
- * `IsFractionRing.algEquiv` maps other fields of fractions of `K[X]` to `RatFunc K`,
-in particular:
- * `FractionRing.algEquiv K[X] (RatFunc K)` maps the generic field of
-    fraction construction to `RatFunc K`. Combine this with `AlgEquiv.restrictScalars` to change
-    the `FractionRing K[X] ≃ₐ[K[X]] RatFunc K` to `FractionRing K[X] ≃ₐ[K] RatFunc K`.
+* `algebraMap K[X] (RatFunc K)` maps polynomials to rational functions
+* `IsFractionRing.algEquiv` maps other fields of fractions of `K[X]` to `RatFunc K`.
+
+In particular:
+* `FractionRing.algEquiv K[X] (RatFunc K)` maps the generic field of
+  fraction construction to `RatFunc K`. Combine this with `AlgEquiv.restrictScalars` to change
+  the `FractionRing K[X] ≃ₐ[K[X]] RatFunc K` to `FractionRing K[X] ≃ₐ[K] RatFunc K`.
 
 Working with rational functions as fractions:
 - `RatFunc.num` and `RatFunc.denom` give the numerator and denominator.
@@ -29,11 +30,11 @@ Working with rational functions as fractions:
 Lifting homomorphisms of polynomials to other types, by mapping and dividing, as long
 as the homomorphism retains the non-zero-divisor property:
   - `RatFunc.liftMonoidWithZeroHom` lifts a `K[X] →*₀ G₀` to
-      a `RatFunc K →*₀ G₀`, where `[CommRing K] [CommGroupWithZero G₀]`
+    a `RatFunc K →*₀ G₀`, where `[CommRing K] [CommGroupWithZero G₀]`
   - `RatFunc.liftRingHom` lifts a `K[X] →+* L` to a `RatFunc K →+* L`,
-      where `[CommRing K] [Field L]`
+    where `[CommRing K] [Field L]`
   - `RatFunc.liftAlgHom` lifts a `K[X] →ₐ[S] L` to a `RatFunc K →ₐ[S] L`,
-      where `[CommRing K] [Field L] [CommSemiring S] [Algebra S K[X]] [Algebra S L]`
+    where `[CommRing K] [Field L] [CommSemiring S] [Algebra S K[X]] [Algebra S L]`
 This is satisfied by injective homs.
 
 We also have lifting homomorphisms of polynomials to other polynomials,

--- a/Mathlib/FieldTheory/RatFunc/Defs.lean
+++ b/Mathlib/FieldTheory/RatFunc/Defs.lean
@@ -19,11 +19,11 @@ For connections with Laurent Series, see `Mathlib.RingTheory.LaurentSeries`.
 ## Main definitions
 We provide a set of recursion and induction principles:
  - `RatFunc.liftOn`: define a function by mapping a fraction of polynomials `p/q` to `f p q`,
-   if `f` is well-defined in the sense that `p/q = p'/q' → f p q = f p' q'`.
+  if `f` is well-defined in the sense that `p/q = p'/q' → f p q = f p' q'`.
  - `RatFunc.liftOn'`: define a function by mapping a fraction of polynomials `p/q` to `f p q`,
-   if `f` is well-defined in the sense that `f (a * p) (a * q) = f p' q'`.
+  if `f` is well-defined in the sense that `f (a * p) (a * q) = f p' q'`.
  - `RatFunc.induction_on`: if `P` holds on `p / q` for all polynomials `p q`, then `P` holds on all
-   rational functions
+  rational functions
 
 ## Implementation notes
 

--- a/Mathlib/FieldTheory/RatFunc/Degree.lean
+++ b/Mathlib/FieldTheory/RatFunc/Degree.lean
@@ -13,9 +13,9 @@ import Mathlib.RingTheory.Polynomial.Content
 
 ## Main definitions
 We define the degree of a rational function, with values in `ℤ`:
- - `intDegree` is the degree of a rational function, defined as the difference between the
-   `natDegree` of its numerator and the `natDegree` of its denominator. In particular,
-   `intDegree 0 = 0`.
+- `intDegree` is the degree of a rational function, defined as the difference between the
+  `natDegree` of its numerator and the `natDegree` of its denominator. In particular,
+  `intDegree 0 = 0`.
 -/
 
 

--- a/Mathlib/Geometry/Manifold/LocalDiffeomorph.lean
+++ b/Mathlib/Geometry/Manifold/LocalDiffeomorph.lean
@@ -327,7 +327,7 @@ noncomputable def IsLocalDiffeomorph.diffeomorph_of_bijective
     (hf : IsLocalDiffeomorph I J n f) (hf' : Function.Bijective f) : Diffeomorph I J M N n := by
   -- Choose a right inverse `g` of `f`.
   choose g hgInverse using (Function.bijective_iff_has_inverse).mp hf'
-   -- Choose diffeomorphisms φ_x which coincide which `f` near `x`.
+  -- Choose diffeomorphisms φ_x which coincide which `f` near `x`.
   choose Φ hyp using (fun x ↦ hf x)
   -- Two such diffeomorphisms (and their inverses!) coincide on their sources:
   -- they're both inverses to g. In fact, the latter suffices for our proof.

--- a/Mathlib/Geometry/Manifold/PoincareConjecture.lean
+++ b/Mathlib/Geometry/Manifold/PoincareConjecture.lean
@@ -31,11 +31,11 @@ variable (M : Type*) [TopologicalSpace M]
 open ContinuousMap
 
 /-- The generalized topological Poincaré conjecture.
- - For n = 2 it follows from the classification of surfaces.
- - For n ≥ 5 it was proven by Stephen Smale in 1961 assuming M admits a smooth structure;
-   Newman (1966) and Connell (1967) proved it without the condition.
- - For n = 4 it was proven by Michael Freedman in 1982.
- - For n = 3 it was proven by Grigori Perelman in 2003. -/
+- For n = 2 it follows from the classification of surfaces.
+- For n ≥ 5 it was proven by Stephen Smale in 1961 assuming M admits a smooth structure;
+  Newman (1966) and Connell (1967) proved it without the condition.
+- For n = 4 it was proven by Michael Freedman in 1982.
+- For n = 3 it was proven by Grigori Perelman in 2003. -/
 proof_wanted ContinuousMap.HomotopyEquiv.nonempty_homeomorph_sphere [T2Space M]
     (n : ℕ) [ChartedSpace ℝⁿ M] : M ≃ₕ 𝕊ⁿ → Nonempty (M ≃ₜ 𝕊ⁿ)
 

--- a/Mathlib/GroupTheory/Congruence/Hom.lean
+++ b/Mathlib/GroupTheory/Congruence/Hom.lean
@@ -13,10 +13,10 @@ This file contains elementary definitions involving congruence relations and mor
 
 ## Main definitions
 
- * `Con.ker`: the kernel of a monoid homomorphism as a congruence relation
- * `Con.mk'`: the map from a monoid to its quotient by a congruence relation
- * `Con.lift`: the homomorphism on the quotient given that the congruence is in the kernel
- * `Con.map`: homomorphism from a smaller to a larger quotient
+* `Con.ker`: the kernel of a monoid homomorphism as a congruence relation
+* `Con.mk'`: the map from a monoid to its quotient by a congruence relation
+* `Con.lift`: the homomorphism on the quotient given that the congruence is in the kernel
+* `Con.map`: homomorphism from a smaller to a larger quotient
 
 ## Tags
 

--- a/Mathlib/GroupTheory/FreeGroup/NielsenSchreier.lean
+++ b/Mathlib/GroupTheory/FreeGroup/NielsenSchreier.lean
@@ -63,14 +63,15 @@ since `G` already has a quiver instance from being a groupoid. -/
 def IsFreeGroupoid.Generators (G) [Groupoid G] :=
   G
 
-/-- A groupoid `G` is free when we have the following data:
- - a quiver on `IsFreeGroupoid.Generators G` (a type synonym for `G`)
- - a function `of` taking a generating arrow to a morphism in `G`
- - such that a functor from `G` to any group `X` is uniquely determined
-   by assigning labels in `X` to the generating arrows.
+/--
+A groupoid `G` is free when we have the following data:
+- a quiver on `IsFreeGroupoid.Generators G` (a type synonym for `G`)
+- a function `of` taking a generating arrow to a morphism in `G`
+- such that a functor from `G` to any group `X` is uniquely determined
+  by assigning labels in `X` to the generating arrows.
 
-   This definition is nonstandard. Normally one would require that functors `G ⥤ X`
-   to any _groupoid_ `X` are given by graph homomorphisms from `generators`. -/
+This definition is nonstandard. Normally one would require that functors `G ⥤ X`
+to any _groupoid_ `X` are given by graph homomorphisms from `generators`. -/
 class IsFreeGroupoid (G) [Groupoid.{v} G] where
   quiverGenerators : Quiver.{v + 1} (IsFreeGroupoid.Generators G)
   of : ∀ {a b : IsFreeGroupoid.Generators G}, (a ⟶ b) → ((show G from a) ⟶ b)

--- a/Mathlib/GroupTheory/GroupAction/Blocks.lean
+++ b/Mathlib/GroupTheory/GroupAction/Blocks.lean
@@ -728,9 +728,9 @@ theorem subsingleton_of_card_lt [Finite X] (hB : IsBlock G B)
     exact fun hb ↦ hB' (Nat.mul_le_mul_right _ hb)
 
 /- The assumption `B.Finite` is necessary :
-   For G = ℤ acting on itself, a = 0 and B = ℕ, the translates `k • B` of the statement
-   are just `k + ℕ`, for `k ≤ 0`, and the corresponding intersection is `ℕ`, which is not a block.
-   (Remark by Thomas Browning) -/
+  For G = ℤ acting on itself, a = 0 and B = ℕ, the translates `k • B` of the statement
+  are just `k + ℕ`, for `k ≤ 0`, and the corresponding intersection is `ℕ`, which is not a block.
+  (Remark by Thomas Browning) -/
 /-- The intersection of the translates of a *finite* subset which contain a given point
 is a block (Wielandt, th. 7.3). -/
 @[to_additive

--- a/Mathlib/GroupTheory/NoncommPiCoprod.lean
+++ b/Mathlib/GroupTheory/NoncommPiCoprod.lean
@@ -20,7 +20,7 @@ images of different morphisms commute, we obtain a canonical morphism
 
 * `MonoidHom.noncommPiCoprod : (Π i, N i) →* M` is the main homomorphism
 * `Subgroup.noncommPiCoprod : (Π i, H i) →* G` is the specialization to `H i : Subgroup G`
-   and the subgroup embedding.
+  and the subgroup embedding.
 
 ## Main theorems
 
@@ -31,11 +31,11 @@ images of different morphisms commute, we obtain a canonical morphism
   `⨆ (i : ι), (ϕ i).range`
 * `Subgroup.noncommPiCoprod_range`: The range of `Subgroup.noncommPiCoprod` is `⨆ (i : ι), H i`.
 * `MonoidHom.injective_noncommPiCoprod_of_iSupIndep`: in the case of groups, `pi_hom.hom` is
-   injective if the `ϕ` are injective and the ranges of the `ϕ` are independent.
+  injective if the `ϕ` are injective and the ranges of the `ϕ` are independent.
 * `MonoidHom.independent_range_of_coprime_order`: If the `N i` have coprime orders, then the ranges
-   of the `ϕ` are independent.
+  of the `ϕ` are independent.
 * `Subgroup.independent_of_coprime_order`: If commuting normal subgroups `H i` have coprime orders,
-   they are independent.
+  they are independent.
 
 -/
 

--- a/Mathlib/GroupTheory/SchurZassenhaus.lean
+++ b/Mathlib/GroupTheory/SchurZassenhaus.lean
@@ -136,14 +136,14 @@ variable {G : Type u} [Group G] {N : Subgroup G} [Normal N]
 include h1 h3
 
 /-! We will arrive at a contradiction via the following steps:
- * step 0: `N` (the normal Hall subgroup) is nontrivial.
- * step 1: If `K` is a subgroup of `G` with `K ⊔ N = ⊤`, then `K = ⊤`.
- * step 2: `N` is a minimal normal subgroup, phrased in terms of subgroups of `G`.
- * step 3: `N` is a minimal normal subgroup, phrased in terms of subgroups of `N`.
- * step 4: `p` (`min_fact (Fintype.card N)`) is prime (follows from step0).
- * step 5: `P` (a Sylow `p`-subgroup of `N`) is nontrivial.
- * step 6: `N` is a `p`-group (applies step 1 to the normalizer of `P` in `G`).
- * step 7: `N` is abelian (applies step 3 to the center of `N`).
+* step 0: `N` (the normal Hall subgroup) is nontrivial.
+* step 1: If `K` is a subgroup of `G` with `K ⊔ N = ⊤`, then `K = ⊤`.
+* step 2: `N` is a minimal normal subgroup, phrased in terms of subgroups of `G`.
+* step 3: `N` is a minimal normal subgroup, phrased in terms of subgroups of `N`.
+* step 4: `p` (`min_fact (Fintype.card N)`) is prime (follows from step0).
+* step 5: `P` (a Sylow `p`-subgroup of `N`) is nontrivial.
+* step 6: `N` is a `p`-group (applies step 1 to the normalizer of `P` in `G`).
+* step 7: `N` is abelian (applies step 3 to the center of `N`).
 -/
 
 

--- a/Mathlib/Lean/Expr/Rat.lean
+++ b/Mathlib/Lean/Expr/Rat.lean
@@ -14,8 +14,8 @@ This file defines some operations involving `Expr` and rational numbers.
 
 ## Main definitions
 
- * `Lean.Expr.isExplicitNumber`: is an expression a number in normal form?
-   This includes natural numbers, integers and rationals.
+* `Lean.Expr.isExplicitNumber`: is an expression a number in normal form?
+  This includes natural numbers, integers and rationals.
 -/
 
 namespace Lean.Expr

--- a/Mathlib/Logic/Equiv/Fintype.lean
+++ b/Mathlib/Logic/Equiv/Fintype.lean
@@ -14,14 +14,14 @@ sides of the equivalence are `Fintype`s.
 # Main definitions
 
  - `Function.Embedding.toEquivRange`: computably turn an embedding of a
-   fintype into an `Equiv` of the domain to its range
+  fintype into an `Equiv` of the domain to its range
  - `Equiv.Perm.viaFintypeEmbedding : Perm α → (α ↪ β) → Perm β` extends the domain of
-   a permutation, fixing everything outside the range of the embedding
+  a permutation, fixing everything outside the range of the embedding
 
 # Implementation details
 
  - `Function.Embedding.toEquivRange` uses a computable inverse, but one that has poor
-   computational performance, since it operates by exhaustive search over the input `Fintype`s.
+  computational performance, since it operates by exhaustive search over the input `Fintype`s.
 -/
 
 assert_not_exists Equiv.Perm.sign

--- a/Mathlib/Logic/Relator.lean
+++ b/Mathlib/Logic/Relator.lean
@@ -14,11 +14,11 @@ namespace Relator
 universe u₁ u₂ v₁ v₂
 
 /- TODO(johoelzl):
- * should we introduce relators of datatypes as recursive function or as inductive
+* should we introduce relators of datatypes as recursive function or as inductive
 predicate? For now we stick to the recursor approach.
- * relation lift for datatypes, Π, Σ, set, and subtype types
- * proof composition and identity laws
- * implement method to derive relators from datatype
+* relation lift for datatypes, Π, Σ, set, and subtype types
+* proof composition and identity laws
+* implement method to derive relators from datatype
 -/
 
 section

--- a/Mathlib/MeasureTheory/Covering/LiminfLimsup.lean
+++ b/Mathlib/MeasureTheory/Covering/LiminfLimsup.lean
@@ -13,13 +13,13 @@ carrying a uniformly locally doubling measure.
 
 ## Main results:
 
- * `blimsup_cthickening_mul_ae_eq`: the limsup of the closed thickening of a sequence of subsets
-   of a metric space is unchanged almost everywhere for a uniformly locally doubling measure if the
-   sequence of distances is multiplied by a positive scale factor. This is a generalisation of a
-   result of Cassels, appearing as Lemma 9 on page 217 of
-   [J.W.S. Cassels, *Some metrical theorems in Diophantine approximation. I*](cassels1950).
- * `blimsup_thickening_mul_ae_eq`: a variant of `blimsup_cthickening_mul_ae_eq` for thickenings
-   rather than closed thickenings.
+* `blimsup_cthickening_mul_ae_eq`: the limsup of the closed thickening of a sequence of subsets
+  of a metric space is unchanged almost everywhere for a uniformly locally doubling measure if the
+  sequence of distances is multiplied by a positive scale factor. This is a generalisation of a
+  result of Cassels, appearing as Lemma 9 on page 217 of
+  [J.W.S. Cassels, *Some metrical theorems in Diophantine approximation. I*](cassels1950).
+* `blimsup_thickening_mul_ae_eq`: a variant of `blimsup_cthickening_mul_ae_eq` for thickenings
+  rather than closed thickenings.
 
 -/
 

--- a/Mathlib/MeasureTheory/Group/AddCircle.lean
+++ b/Mathlib/MeasureTheory/Group/AddCircle.lean
@@ -14,10 +14,10 @@ The file is a place to collect measure-theoretic results about the additive circ
 
 ## Main definitions:
 
- * `AddCircle.closedBall_ae_eq_ball`: open and closed balls in the additive circle are almost
-   equal
- * `AddCircle.isAddFundamentalDomain_of_ae_ball`: a ball is a fundamental domain for rational
-   angle rotation in the additive circle
+* `AddCircle.closedBall_ae_eq_ball`: open and closed balls in the additive circle are almost
+  equal
+* `AddCircle.isAddFundamentalDomain_of_ae_ball`: a ball is a fundamental domain for rational
+  angle rotation in the additive circle
 
 -/
 

--- a/Mathlib/MeasureTheory/Integral/Layercake.lean
+++ b/Mathlib/MeasureTheory/Integral/Layercake.lean
@@ -32,19 +32,19 @@ are also included.
 
 ## Main results
 
- * `MeasureTheory.lintegral_comp_eq_lintegral_meas_le_mul`
-   and `MeasureTheory.lintegral_comp_eq_lintegral_meas_lt_mul`:
-   The general layer cake formulas with Lebesgue integrals, written in terms of measures of
-   sets of the forms {ω | t ≤ f(ω)} and {ω | t < f(ω)}, respectively.
- * `MeasureTheory.lintegral_eq_lintegral_meas_le` and
-   `MeasureTheory.lintegral_eq_lintegral_meas_lt`:
-   The most common special cases of the layer cake formulas, stating that for a nonnegative
-   function f we have ∫ f(ω) ∂μ(ω) = ∫ μ {ω | f(ω) ≥ t} dt and
-   ∫ f(ω) ∂μ(ω) = ∫ μ {ω | f(ω) > t} dt, respectively.
- * `Integrable.integral_eq_integral_meas_lt`:
-   A Bochner integral version of the most common special case of the layer cake formulas, stating
-   that for an integrable and a.e.-nonnegative function f we have
-   ∫ f(ω) ∂μ(ω) = ∫ μ {ω | f(ω) > t} dt.
+* `MeasureTheory.lintegral_comp_eq_lintegral_meas_le_mul`
+  and `MeasureTheory.lintegral_comp_eq_lintegral_meas_lt_mul`:
+  The general layer cake formulas with Lebesgue integrals, written in terms of measures of
+  sets of the forms {ω | t ≤ f(ω)} and {ω | t < f(ω)}, respectively.
+* `MeasureTheory.lintegral_eq_lintegral_meas_le` and
+  `MeasureTheory.lintegral_eq_lintegral_meas_lt`:
+  The most common special cases of the layer cake formulas, stating that for a nonnegative
+  function f we have ∫ f(ω) ∂μ(ω) = ∫ μ {ω | f(ω) ≥ t} dt and
+  ∫ f(ω) ∂μ(ω) = ∫ μ {ω | f(ω) > t} dt, respectively.
+* `Integrable.integral_eq_integral_meas_lt`:
+  A Bochner integral version of the most common special case of the layer cake formulas, stating
+  that for an integrable and a.e.-nonnegative function f we have
+  ∫ f(ω) ∂μ(ω) = ∫ μ {ω | f(ω) > t} dt.
 
 ## See also
 

--- a/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/FiniteMeasure.lean
@@ -21,33 +21,33 @@ measure is continuous.
 ## Main definitions
 
 The main definitions are
- * `MeasureTheory.FiniteMeasure Ω`: The type of finite measures on `Ω` with the topology of weak
-   convergence of measures.
- * `MeasureTheory.FiniteMeasure.toWeakDualBCNN : FiniteMeasure Ω → (WeakDual ℝ≥0 (Ω →ᵇ ℝ≥0))`:
-   Interpret a finite measure as a continuous linear functional on the space of
-   bounded continuous nonnegative functions on `Ω`. This is used for the definition of the
-   topology of weak convergence.
- * `MeasureTheory.FiniteMeasure.map`: The push-forward `f* μ` of a finite measure `μ` on `Ω`
-   along a measurable function `f : Ω → Ω'`.
- * `MeasureTheory.FiniteMeasure.mapCLM`: The push-forward along a given continuous `f : Ω → Ω'`
-   as a continuous linear map `f* : FiniteMeasure Ω →L[ℝ≥0] FiniteMeasure Ω'`.
+* `MeasureTheory.FiniteMeasure Ω`: The type of finite measures on `Ω` with the topology of weak
+  convergence of measures.
+* `MeasureTheory.FiniteMeasure.toWeakDualBCNN : FiniteMeasure Ω → (WeakDual ℝ≥0 (Ω →ᵇ ℝ≥0))`:
+  Interpret a finite measure as a continuous linear functional on the space of
+  bounded continuous nonnegative functions on `Ω`. This is used for the definition of the
+  topology of weak convergence.
+* `MeasureTheory.FiniteMeasure.map`: The push-forward `f* μ` of a finite measure `μ` on `Ω`
+  along a measurable function `f : Ω → Ω'`.
+* `MeasureTheory.FiniteMeasure.mapCLM`: The push-forward along a given continuous `f : Ω → Ω'`
+  as a continuous linear map `f* : FiniteMeasure Ω →L[ℝ≥0] FiniteMeasure Ω'`.
 
 ## Main results
 
- * Finite measures `μ` on `Ω` give rise to continuous linear functionals on the space of
-   bounded continuous nonnegative functions on `Ω` via integration:
-   `MeasureTheory.FiniteMeasure.toWeakDualBCNN : FiniteMeasure Ω → (WeakDual ℝ≥0 (Ω →ᵇ ℝ≥0))`
- * `MeasureTheory.FiniteMeasure.tendsto_iff_forall_integral_tendsto`: Convergence of finite
-   measures is characterized by the convergence of integrals of all bounded continuous functions.
-   This shows that the chosen definition of topology coincides with the common textbook definition
-   of weak convergence of measures. A similar characterization by the convergence of integrals (in
-   the `MeasureTheory.lintegral` sense) of all bounded continuous nonnegative functions is
-   `MeasureTheory.FiniteMeasure.tendsto_iff_forall_lintegral_tendsto`.
- * `MeasureTheory.FiniteMeasure.continuous_map`: For a continuous function `f : Ω → Ω'`, the
-   push-forward of finite measures `f* : FiniteMeasure Ω → FiniteMeasure Ω'` is continuous.
- * `MeasureTheory.FiniteMeasure.t2Space`: The topology of weak convergence of finite Borel measures
-   is Hausdorff on spaces where indicators of closed sets have continuous decreasing approximating
-   sequences (in particular on any pseudo-metrizable spaces).
+* Finite measures `μ` on `Ω` give rise to continuous linear functionals on the space of
+  bounded continuous nonnegative functions on `Ω` via integration:
+  `MeasureTheory.FiniteMeasure.toWeakDualBCNN : FiniteMeasure Ω → (WeakDual ℝ≥0 (Ω →ᵇ ℝ≥0))`
+* `MeasureTheory.FiniteMeasure.tendsto_iff_forall_integral_tendsto`: Convergence of finite
+  measures is characterized by the convergence of integrals of all bounded continuous functions.
+  This shows that the chosen definition of topology coincides with the common textbook definition
+  of weak convergence of measures. A similar characterization by the convergence of integrals (in
+  the `MeasureTheory.lintegral` sense) of all bounded continuous nonnegative functions is
+  `MeasureTheory.FiniteMeasure.tendsto_iff_forall_lintegral_tendsto`.
+* `MeasureTheory.FiniteMeasure.continuous_map`: For a continuous function `f : Ω → Ω'`, the
+  push-forward of finite measures `f* : FiniteMeasure Ω → FiniteMeasure Ω'` is continuous.
+* `MeasureTheory.FiniteMeasure.t2Space`: The topology of weak convergence of finite Borel measures
+  is Hausdorff on spaces where indicators of closed sets have continuous decreasing approximating
+  sequences (in particular on any pseudo-metrizable spaces).
 
 ## Implementation notes
 
@@ -60,14 +60,14 @@ The implementation of `MeasureTheory.FiniteMeasure Ω` and is directly as a subt
 and the coercion to function of `MeasureTheory.Measure Ω`. Another alternative would have been to
 use a bijection with `MeasureTheory.VectorMeasure Ω ℝ≥0` as an intermediate step. Some
 considerations:
- * Potential advantages of using the `NNReal`-valued vector measure alternative:
-   * The coercion to function would avoid need to compose with `ENNReal.toNNReal`, the
-     `NNReal`-valued API could be more directly available.
- * Potential drawbacks of the vector measure alternative:
-   * The coercion to function would lose monotonicity, as non-measurable sets would be defined to
-     have measure 0.
-   * No integration theory directly. E.g., the topology definition requires
-     `MeasureTheory.lintegral` w.r.t. a coercion to `MeasureTheory.Measure Ω` in any case.
+* Potential advantages of using the `NNReal`-valued vector measure alternative:
+  * The coercion to function would avoid need to compose with `ENNReal.toNNReal`, the
+    `NNReal`-valued API could be more directly available.
+* Potential drawbacks of the vector measure alternative:
+  * The coercion to function would lose monotonicity, as non-measurable sets would be defined to
+    have measure 0.
+  * No integration theory directly. E.g., the topology definition requires
+    `MeasureTheory.lintegral` w.r.t. a coercion to `MeasureTheory.Measure Ω` in any case.
 
 ## References
 
@@ -594,11 +594,11 @@ theorem tendsto_lintegral_nn_of_le_const (μ : FiniteMeasure Ω) {fs : ℕ → �
 If bounded continuous non-negative functions are uniformly bounded by a constant and tend to a
 limit, then their integrals against the finite measure tend to the integral of the limit.
 This formulation assumes:
- * the functions tend to a limit along a countably generated filter;
- * the limit is in the almost everywhere sense;
- * boundedness holds almost everywhere;
- * integration is the pairing against non-negative continuous test functions
-   (`MeasureTheory.FiniteMeasure.testAgainstNN`).
+* the functions tend to a limit along a countably generated filter;
+* the limit is in the almost everywhere sense;
+* boundedness holds almost everywhere;
+* integration is the pairing against non-negative continuous test functions
+  (`MeasureTheory.FiniteMeasure.testAgainstNN`).
 
 A related result using `MeasureTheory.lintegral` for integration is
 `MeasureTheory.FiniteMeasure.tendsto_lintegral_nn_filter_of_le_const`.
@@ -617,10 +617,10 @@ tend pointwise to a limit, then their integrals (`MeasureTheory.FiniteMeasure.te
 against the finite measure tend to the integral of the limit.
 
 Related results:
- * `MeasureTheory.FiniteMeasure.tendsto_testAgainstNN_filter_of_le_const`:
-   more general assumptions
- * `MeasureTheory.FiniteMeasure.tendsto_lintegral_nn_of_le_const`:
-   using `MeasureTheory.lintegral` for integration.
+* `MeasureTheory.FiniteMeasure.tendsto_testAgainstNN_filter_of_le_const`:
+  more general assumptions
+* `MeasureTheory.FiniteMeasure.tendsto_lintegral_nn_of_le_const`:
+  using `MeasureTheory.lintegral` for integration.
 -/
 theorem tendsto_testAgainstNN_of_le_const {μ : FiniteMeasure Ω} {fs : ℕ → Ω →ᵇ ℝ≥0} {c : ℝ≥0}
     (fs_le_const : ∀ n ω, fs n ω ≤ c) {f : Ω →ᵇ ℝ≥0}

--- a/Mathlib/MeasureTheory/Measure/HasOuterApproxClosed.lean
+++ b/Mathlib/MeasureTheory/Measure/HasOuterApproxClosed.lean
@@ -19,18 +19,18 @@ convergence in distribution for random variables behave somewhat well in spaces 
 
 ## Main definitions
 
- * `HasOuterApproxClosed`: the typeclass for topological spaces in which indicator functions of
-   closed sets have sequences of bounded continuous functions approximating them.
- * `IsClosed.apprSeq`: a (non-constructive) choice of an approximating sequence to the indicator
-   function of a closed set.
+* `HasOuterApproxClosed`: the typeclass for topological spaces in which indicator functions of
+  closed sets have sequences of bounded continuous functions approximating them.
+* `IsClosed.apprSeq`: a (non-constructive) choice of an approximating sequence to the indicator
+  function of a closed set.
 
 ## Main results
 
- * `instHasOuterApproxClosed`: Any pseudo-emetrizable space has the property `HasOuterApproxClosed`.
- * `tendsto_lintegral_apprSeq`: The integrals of the approximating functions to the indicator of a
-   closed set tend to the measure of the set.
- * `ext_of_forall_lintegral_eq_of_IsFiniteMeasure`: Two finite measures are equal if the integrals
-   of all bounded continuous functions with respect to both agree.
+* `instHasOuterApproxClosed`: Any pseudo-emetrizable space has the property `HasOuterApproxClosed`.
+* `tendsto_lintegral_apprSeq`: The integrals of the approximating functions to the indicator of a
+  closed set tend to the measure of the set.
+* `ext_of_forall_lintegral_eq_of_IsFiniteMeasure`: Two finite measures are equal if the integrals
+  of all bounded continuous functions with respect to both agree.
 
 -/
 
@@ -47,11 +47,11 @@ variable {Ω : Type*} [TopologicalSpace Ω] [MeasurableSpace Ω] [OpensMeasurabl
 If bounded continuous non-negative functions are uniformly bounded by a constant and tend to a
 limit, then their integrals against the finite measure tend to the integral of the limit.
 This formulation assumes:
- * the functions tend to a limit along a countably generated filter;
- * the limit is in the almost everywhere sense;
- * boundedness holds almost everywhere;
- * integration is `MeasureTheory.lintegral`, i.e., the functions and their integrals are
-   `ℝ≥0∞`-valued.
+* the functions tend to a limit along a countably generated filter;
+* the limit is in the almost everywhere sense;
+* boundedness holds almost everywhere;
+* integration is `MeasureTheory.lintegral`, i.e., the functions and their integrals are
+  `ℝ≥0∞`-valued.
 -/
 theorem tendsto_lintegral_nn_filter_of_le_const {ι : Type*} {L : Filter ι} [L.IsCountablyGenerated]
     (μ : Measure Ω) [IsFiniteMeasure μ] {fs : ι → Ω →ᵇ ℝ≥0} {c : ℝ≥0}
@@ -67,9 +67,9 @@ theorem tendsto_lintegral_nn_filter_of_le_const {ι : Type*} {L : Filter ι} [L.
 /-- If bounded continuous functions tend to the indicator of a measurable set and are
 uniformly bounded, then their integrals against a finite measure tend to the measure of the set.
 This formulation assumes:
- * the functions tend to a limit along a countably generated filter;
- * the limit is in the almost everywhere sense;
- * boundedness holds almost everywhere.
+* the functions tend to a limit along a countably generated filter;
+* the limit is in the almost everywhere sense;
+* boundedness holds almost everywhere.
 -/
 theorem measure_of_cont_bdd_of_tendsto_filter_indicator {ι : Type*} {L : Filter ι}
     [L.IsCountablyGenerated] (μ : Measure Ω)

--- a/Mathlib/MeasureTheory/Measure/Portmanteau.lean
+++ b/Mathlib/MeasureTheory/Measure/Portmanteau.lean
@@ -35,11 +35,11 @@ general hypotheses) are:
       the measures of B under μs tend to the measure of B under μ, i.e., limᵢ μsᵢ(B) = μ(B).
 
 The separate implications are:
- * `MeasureTheory.FiniteMeasure.limsup_measure_closed_le_of_tendsto` is the implication (T) → (C).
- * `MeasureTheory.limsup_measure_closed_le_iff_liminf_measure_open_ge` is the equivalence (C) ↔ (O).
- * `MeasureTheory.tendsto_measure_of_null_frontier` is the implication (O) → (B).
- * `MeasureTheory.limsup_measure_closed_le_of_forall_tendsto_measure` is the implication (B) → (C).
- * `MeasureTheory.tendsto_of_forall_isOpen_le_liminf` gives the implication (O) → (T) for
+* `MeasureTheory.FiniteMeasure.limsup_measure_closed_le_of_tendsto` is the implication (T) → (C).
+* `MeasureTheory.limsup_measure_closed_le_iff_liminf_measure_open_ge` is the equivalence (C) ↔ (O).
+* `MeasureTheory.tendsto_measure_of_null_frontier` is the implication (O) → (B).
+* `MeasureTheory.limsup_measure_closed_le_of_forall_tendsto_measure` is the implication (B) → (C).
+* `MeasureTheory.tendsto_of_forall_isOpen_le_liminf` gives the implication (O) → (T) for
     any sequence of Borel probability measures.
 
 ## Implementation notes
@@ -51,15 +51,15 @@ theorem, however, is most convenient for probability measures on pseudo-emetriza
 their Borel sigma algebras.
 
 Some specific considerations on the assumptions in the different implications:
- * `MeasureTheory.FiniteMeasure.limsup_measure_closed_le_of_tendsto`, i.e., implication (T) → (C),
-   assumes that in the underlying topological space, indicator functions of closed sets have
-   decreasing bounded continuous pointwise approximating sequences. The assumption is in the form
-   of the type class `HasOuterApproxClosed`. Type class inference knows that for example the more
-   common assumptions of metrizability or pseudo-emetrizability suffice.
- * Where formulations are currently only provided for probability measures, one can obtain the
-   finite measure formulations using the characterization of convergence of finite measures by
-   their total masses and their probability-normalized versions, i.e., by
-   `MeasureTheory.FiniteMeasure.tendsto_normalize_iff_tendsto`.
+* `MeasureTheory.FiniteMeasure.limsup_measure_closed_le_of_tendsto`, i.e., implication (T) → (C),
+  assumes that in the underlying topological space, indicator functions of closed sets have
+  decreasing bounded continuous pointwise approximating sequences. The assumption is in the form
+  of the type class `HasOuterApproxClosed`. Type class inference knows that for example the more
+  common assumptions of metrizability or pseudo-emetrizability suffice.
+* Where formulations are currently only provided for probability measures, one can obtain the
+  finite measure formulations using the characterization of convergence of finite measures by
+  their total masses and their probability-normalized versions, i.e., by
+  `MeasureTheory.FiniteMeasure.tendsto_normalize_iff_tendsto`.
 
 ## References
 

--- a/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
+++ b/Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean
@@ -21,36 +21,36 @@ case of the topology of weak convergence of finite measures.
 ## Main definitions
 
 The main definitions are
- * the type `MeasureTheory.ProbabilityMeasure Ω` with the topology of convergence in
-   distribution (a.k.a. convergence in law, weak convergence of measures);
- * `MeasureTheory.ProbabilityMeasure.toFiniteMeasure`: Interpret a probability measure as
-   a finite measure;
- * `MeasureTheory.FiniteMeasure.normalize`: Normalize a finite measure to a probability measure
-   (returns junk for the zero measure).
- * `MeasureTheory.ProbabilityMeasure.map`: The push-forward `f* μ` of a probability measure
-   `μ` on `Ω` along a measurable function `f : Ω → Ω'`.
+* the type `MeasureTheory.ProbabilityMeasure Ω` with the topology of convergence in
+  distribution (a.k.a. convergence in law, weak convergence of measures);
+* `MeasureTheory.ProbabilityMeasure.toFiniteMeasure`: Interpret a probability measure as
+  a finite measure;
+* `MeasureTheory.FiniteMeasure.normalize`: Normalize a finite measure to a probability measure
+  (returns junk for the zero measure).
+* `MeasureTheory.ProbabilityMeasure.map`: The push-forward `f* μ` of a probability measure
+  `μ` on `Ω` along a measurable function `f : Ω → Ω'`.
 
 ## Main results
 
- * `MeasureTheory.ProbabilityMeasure.tendsto_iff_forall_integral_tendsto`: Convergence of
-   probability measures is characterized by the convergence of expected values of all bounded
-   continuous random variables. This shows that the chosen definition of topology coincides with
-   the common textbook definition of convergence in distribution, i.e., weak convergence of
-   measures. A similar characterization by the convergence of expected values (in the
-   `MeasureTheory.lintegral` sense) of all bounded continuous nonnegative random variables is
-   `MeasureTheory.ProbabilityMeasure.tendsto_iff_forall_lintegral_tendsto`.
- * `MeasureTheory.FiniteMeasure.tendsto_normalize_iff_tendsto`: The convergence of finite
-   measures to a nonzero limit is characterized by the convergence of the probability-normalized
-   versions and of the total masses.
- * `MeasureTheory.ProbabilityMeasure.continuous_map`: For a continuous function `f : Ω → Ω'`, the
-   push-forward of probability measures `f* : ProbabilityMeasure Ω → ProbabilityMeasure Ω'` is
-   continuous.
- * `MeasureTheory.ProbabilityMeasure.t2Space`: The topology of convergence in distribution is
-   Hausdorff on Borel spaces where indicators of closed sets have continuous decreasing
-   approximating sequences (in particular on any pseudo-metrizable spaces).
+* `MeasureTheory.ProbabilityMeasure.tendsto_iff_forall_integral_tendsto`: Convergence of
+  probability measures is characterized by the convergence of expected values of all bounded
+  continuous random variables. This shows that the chosen definition of topology coincides with
+  the common textbook definition of convergence in distribution, i.e., weak convergence of
+  measures. A similar characterization by the convergence of expected values (in the
+  `MeasureTheory.lintegral` sense) of all bounded continuous nonnegative random variables is
+  `MeasureTheory.ProbabilityMeasure.tendsto_iff_forall_lintegral_tendsto`.
+* `MeasureTheory.FiniteMeasure.tendsto_normalize_iff_tendsto`: The convergence of finite
+  measures to a nonzero limit is characterized by the convergence of the probability-normalized
+  versions and of the total masses.
+* `MeasureTheory.ProbabilityMeasure.continuous_map`: For a continuous function `f : Ω → Ω'`, the
+  push-forward of probability measures `f* : ProbabilityMeasure Ω → ProbabilityMeasure Ω'` is
+  continuous.
+* `MeasureTheory.ProbabilityMeasure.t2Space`: The topology of convergence in distribution is
+  Hausdorff on Borel spaces where indicators of closed sets have continuous decreasing
+  approximating sequences (in particular on any pseudo-metrizable spaces).
 
 TODO:
- * Probability measures form a convex space.
+* Probability measures form a convex space.
 
 ## Implementation notes
 

--- a/Mathlib/NumberTheory/ArithmeticFunction.lean
+++ b/Mathlib/NumberTheory/ArithmeticFunction.lean
@@ -21,31 +21,31 @@ to form the Dirichlet ring.
 
 ## Main Definitions
 
- * `ArithmeticFunction R` consists of functions `f : ℕ → R` such that `f 0 = 0`.
- * An arithmetic function `f` `IsMultiplicative` when `x.Coprime y → f (x * y) = f x * f y`.
- * The pointwise operations `pmul` and `ppow` differ from the multiplication
+* `ArithmeticFunction R` consists of functions `f : ℕ → R` such that `f 0 = 0`.
+* An arithmetic function `f` `IsMultiplicative` when `x.Coprime y → f (x * y) = f x * f y`.
+* The pointwise operations `pmul` and `ppow` differ from the multiplication
   and power instances on `ArithmeticFunction R`, which use Dirichlet multiplication.
- * `ζ` is the arithmetic function such that `ζ x = 1` for `0 < x`.
- * `σ k` is the arithmetic function such that `σ k x = ∑ y ∈ divisors x, y ^ k` for `0 < x`.
- * `pow k` is the arithmetic function such that `pow k x = x ^ k` for `0 < x`.
- * `id` is the identity arithmetic function on `ℕ`.
- * `ω n` is the number of distinct prime factors of `n`.
- * `Ω n` is the number of prime factors of `n` counted with multiplicity.
- * `μ` is the Möbius function (spelled `moebius` in code).
+* `ζ` is the arithmetic function such that `ζ x = 1` for `0 < x`.
+* `σ k` is the arithmetic function such that `σ k x = ∑ y ∈ divisors x, y ^ k` for `0 < x`.
+* `pow k` is the arithmetic function such that `pow k x = x ^ k` for `0 < x`.
+* `id` is the identity arithmetic function on `ℕ`.
+* `ω n` is the number of distinct prime factors of `n`.
+* `Ω n` is the number of prime factors of `n` counted with multiplicity.
+* `μ` is the Möbius function (spelled `moebius` in code).
 
 ## Main Results
 
- * Several forms of Möbius inversion:
- * `sum_eq_iff_sum_mul_moebius_eq` for functions to a `CommRing`
- * `sum_eq_iff_sum_smul_moebius_eq` for functions to an `AddCommGroup`
- * `prod_eq_iff_prod_pow_moebius_eq` for functions to a `CommGroup`
- * `prod_eq_iff_prod_pow_moebius_eq_of_nonzero` for functions to a `CommGroupWithZero`
- * And variants that apply when the equalities only hold on a set `S : Set ℕ` such that
+* Several forms of Möbius inversion:
+* `sum_eq_iff_sum_mul_moebius_eq` for functions to a `CommRing`
+* `sum_eq_iff_sum_smul_moebius_eq` for functions to an `AddCommGroup`
+* `prod_eq_iff_prod_pow_moebius_eq` for functions to a `CommGroup`
+* `prod_eq_iff_prod_pow_moebius_eq_of_nonzero` for functions to a `CommGroupWithZero`
+* And variants that apply when the equalities only hold on a set `S : Set ℕ` such that
   `m ∣ n → n ∈ S → m ∈ S`:
- * `sum_eq_iff_sum_mul_moebius_eq_on` for functions to a `CommRing`
- * `sum_eq_iff_sum_smul_moebius_eq_on` for functions to an `AddCommGroup`
- * `prod_eq_iff_prod_pow_moebius_eq_on` for functions to a `CommGroup`
- * `prod_eq_iff_prod_pow_moebius_eq_on_of_nonzero` for functions to a `CommGroupWithZero`
+* `sum_eq_iff_sum_mul_moebius_eq_on` for functions to a `CommRing`
+* `sum_eq_iff_sum_smul_moebius_eq_on` for functions to an `AddCommGroup`
+* `prod_eq_iff_prod_pow_moebius_eq_on` for functions to a `CommGroup`
+* `prod_eq_iff_prod_pow_moebius_eq_on_of_nonzero` for functions to a `CommGroupWithZero`
 
 ## Notation
 

--- a/Mathlib/NumberTheory/ClassNumber/AdmissibleAbs.lean
+++ b/Mathlib/NumberTheory/ClassNumber/AdmissibleAbs.lean
@@ -15,8 +15,8 @@ is finite.
 
 ## Main results
 
- * `AbsoluteValue.absIsAdmissible` shows the "standard" absolute value on `ℤ`,
-   mapping negative `x` to `-x`, is admissible.
+* `AbsoluteValue.absIsAdmissible` shows the "standard" absolute value on `ℤ`,
+  mapping negative `x` to `-x`, is admissible.
 -/
 
 

--- a/Mathlib/NumberTheory/ClassNumber/AdmissibleAbsoluteValue.lean
+++ b/Mathlib/NumberTheory/ClassNumber/AdmissibleAbsoluteValue.lean
@@ -14,17 +14,17 @@ of the ring of integers of a global field is finite.
 
 ## Main definitions
 
- * `AbsoluteValue.IsAdmissible abv` states the absolute value `abv : R → ℤ`
-   respects the Euclidean domain structure on `R`, and that a large enough set
-   of elements of `R^n` contains a pair of elements whose remainders are
-   pointwise close together.
+* `AbsoluteValue.IsAdmissible abv` states the absolute value `abv : R → ℤ`
+  respects the Euclidean domain structure on `R`, and that a large enough set
+  of elements of `R^n` contains a pair of elements whose remainders are
+  pointwise close together.
 
 ## Main results
 
- * `AbsoluteValue.absIsAdmissible` shows the "standard" absolute value on `ℤ`,
-   mapping negative `x` to `-x`, is admissible.
- * `Polynomial.cardPowDegreeIsAdmissible` shows `cardPowDegree`,
-   mapping `p : Polynomial 𝔽_q` to `q ^ degree p`, is admissible
+* `AbsoluteValue.absIsAdmissible` shows the "standard" absolute value on `ℤ`,
+  mapping negative `x` to `-x`, is admissible.
+* `Polynomial.cardPowDegreeIsAdmissible` shows `cardPowDegree`,
+  mapping `p : Polynomial 𝔽_q` to `q ^ degree p`, is admissible
 -/
 
 local infixl:50 " ≺ " => EuclideanDomain.r

--- a/Mathlib/NumberTheory/ClassNumber/Finite.lean
+++ b/Mathlib/NumberTheory/ClassNumber/Finite.lean
@@ -17,8 +17,8 @@ In this file, we use the notion of "admissible absolute value" to prove
 finiteness of the class group for number fields and function fields.
 
 ## Main definitions
- - `ClassGroup.fintypeOfAdmissibleOfAlgebraic`: if `R` has an admissible absolute value,
-   its integral closure has a finite class group
+- `ClassGroup.fintypeOfAdmissibleOfAlgebraic`: if `R` has an admissible absolute value,
+  its integral closure has a finite class group
 -/
 
 open scoped nonZeroDivisors

--- a/Mathlib/NumberTheory/Cyclotomic/CyclotomicCharacter.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/CyclotomicCharacter.lean
@@ -32,13 +32,13 @@ Let `L` be an integral domain, `g : L ≃+* L` and `n : ℕ+`. Let `d` be the nu
 of `1` in `L`.
 
 * `modularCyclotomicCharacter L n hn : (L ≃+* L) →* (ZMod n)ˣ` sends `g` to the unique `j` such
-   that `g(ζ)=ζ^j` for all `ζ : rootsOfUnity n L`. Here `hn` is a proof that there
-   are `n` `n`th roots of unity in `L`.
+  that `g(ζ)=ζ^j` for all `ζ : rootsOfUnity n L`. Here `hn` is a proof that there
+  are `n` `n`th roots of unity in `L`.
 
 * `cyclotomicCharacter L p : (L ≃+* L) →* ℤ_[p]ˣ` sends `g` to the unique `j` such
-   that `g(ζ) = ζ ^ (j mod pⁱ)` for all `pⁱ`'th roots of unity `ζ`.
+  that `g(ζ) = ζ ^ (j mod pⁱ)` for all `pⁱ`'th roots of unity `ζ`.
 
-   Note: This is defined to be the trivial character if `L` has no enough roots of unity.
+  Note: This is defined to be the trivial character if `L` has no enough roots of unity.
 
 ## Implementation note
 
@@ -84,8 +84,8 @@ theorem rootsOfUnity.integer_power_of_ringEquiv' (g : L ≃+* L) :
   simpa using rootsOfUnity.integer_power_of_ringEquiv n g
 
 /-- `modularCyclotomicCharacter_aux g n` is a non-canonical auxiliary integer `j`,
-   only well-defined modulo the number of `n`'th roots of unity in `L`, such that `g(ζ)=ζ^j`
-   for all `n`'th roots of unity `ζ` in `L`. -/
+  only well-defined modulo the number of `n`'th roots of unity in `L`, such that `g(ζ)=ζ^j`
+  for all `n`'th roots of unity `ζ` in `L`. -/
 noncomputable def modularCyclotomicCharacter.aux (g : L ≃+* L) (n : ℕ) [NeZero n] : ℤ :=
   (rootsOfUnity.integer_power_of_ringEquiv n g).choose
 

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -21,10 +21,10 @@ for defining Dirichlet convolution.
 
 ## Main Definitions
 Let `n : ℕ`. All of the following definitions are in the `Nat` namespace:
- * `divisors n` is the `Finset` of natural numbers that divide `n`.
- * `properDivisors n` is the `Finset` of natural numbers that divide `n`, other than `n`.
- * `divisorsAntidiagonal n` is the `Finset` of pairs `(x,y)` such that `x * y = n`.
- * `Perfect n` is true when `n` is positive and the sum of `properDivisors n` is `n`.
+* `divisors n` is the `Finset` of natural numbers that divide `n`.
+* `properDivisors n` is the `Finset` of natural numbers that divide `n`, other than `n`.
+* `divisorsAntidiagonal n` is the `Finset` of pairs `(x,y)` such that `x * y = n`.
+* `Perfect n` is true when `n` is positive and the sum of `properDivisors n` is `n`.
 
 ## Conventions
 

--- a/Mathlib/NumberTheory/EllipticDivisibilitySequence.lean
+++ b/Mathlib/NumberTheory/EllipticDivisibilitySequence.lean
@@ -20,23 +20,23 @@ A divisibility sequence is a sequence `W : ℤ → R` satisfying `W(m) ∣ W(n)`
 that `m ∣ n`. An elliptic divisibility sequence is simply a divisibility sequence that is elliptic.
 
 Some examples of EDSs include
- * the identity sequence,
- * certain terms of Lucas sequences, and
- * division polynomials of elliptic curves.
+* the identity sequence,
+* certain terms of Lucas sequences, and
+* division polynomials of elliptic curves.
 
 ## Main definitions
 
- * `IsEllSequence`: a sequence indexed by integers is an elliptic sequence.
- * `IsDivSequence`: a sequence indexed by integers is a divisibility sequence.
- * `IsEllDivSequence`: a sequence indexed by integers is an EDS.
- * `preNormEDS'`: the auxiliary sequence for a normalised EDS indexed by `ℕ`.
- * `preNormEDS`: the auxiliary sequence for a normalised EDS indexed by `ℤ`.
- * `normEDS`: the canonical example of a normalised EDS indexed by `ℤ`.
+* `IsEllSequence`: a sequence indexed by integers is an elliptic sequence.
+* `IsDivSequence`: a sequence indexed by integers is a divisibility sequence.
+* `IsEllDivSequence`: a sequence indexed by integers is an EDS.
+* `preNormEDS'`: the auxiliary sequence for a normalised EDS indexed by `ℕ`.
+* `preNormEDS`: the auxiliary sequence for a normalised EDS indexed by `ℤ`.
+* `normEDS`: the canonical example of a normalised EDS indexed by `ℤ`.
 
 ## Main statements
 
- * TODO: prove that `normEDS` satisfies `IsEllDivSequence`.
- * TODO: prove that a normalised sequence satisfying `IsEllDivSequence` can be given by `normEDS`.
+* TODO: prove that `normEDS` satisfies `IsEllDivSequence`.
+* TODO: prove that a normalised sequence satisfying `IsEllDivSequence` can be given by `normEDS`.
 
 ## Implementation notes
 
@@ -108,9 +108,9 @@ lemma IsEllDivSequence.smul (h : IsEllDivSequence W) (x : R) : IsEllDivSequence 
 end IsEllDivSequence
 
 /-- Strong recursion principle for a normalised EDS: if we have
- * `P 0`, `P 1`, `P 2`, `P 3`, and `P 4`,
- * for all `m : ℕ` we can prove `P (2 * (m + 3))` from `P k` for all `k < 2 * (m + 3)`, and
- * for all `m : ℕ` we can prove `P (2 * (m + 2) + 1)` from `P k` for all `k < 2 * (m + 2) + 1`,
+* `P 0`, `P 1`, `P 2`, `P 3`, and `P 4`,
+* for all `m : ℕ` we can prove `P (2 * (m + 3))` from `P k` for all `k < 2 * (m + 3)`, and
+* for all `m : ℕ` we can prove `P (2 * (m + 2) + 1)` from `P k` for all `k < 2 * (m + 2) + 1`,
 then we have `P n` for all `n : ℕ`. -/
 @[elab_as_elim]
 noncomputable def normEDSRec' {P : ℕ → Sort u}
@@ -121,10 +121,10 @@ noncomputable def normEDSRec' {P : ℕ → Sort u}
     (by rintro (_ | _ | _) h; exacts [one, three, odd _ h])
 
 /-- Recursion principle for a normalised EDS: if we have
- * `P 0`, `P 1`, `P 2`, `P 3`, and `P 4`,
- * for all `m : ℕ` we can prove `P (2 * (m + 3))` from `P (m + 1)`, `P (m + 2)`, `P (m + 3)`,
+* `P 0`, `P 1`, `P 2`, `P 3`, and `P 4`,
+* for all `m : ℕ` we can prove `P (2 * (m + 3))` from `P (m + 1)`, `P (m + 2)`, `P (m + 3)`,
     `P (m + 4)`, and `P (m + 5)`, and
- * for all `m : ℕ` we can prove `P (2 * (m + 2) + 1)` from `P (m + 1)`, `P (m + 2)`, `P (m + 3)`,
+* for all `m : ℕ` we can prove `P (2 * (m + 2) + 1)` from `P (m + 1)`, `P (m + 2)`, `P (m + 3)`,
     and `P (m + 4)`,
 then we have `P n` for all `n : ℕ`. -/
 @[elab_as_elim]

--- a/Mathlib/NumberTheory/FunctionField.lean
+++ b/Mathlib/NumberTheory/FunctionField.lean
@@ -14,14 +14,15 @@ import Mathlib.Topology.Algebra.Valued.ValuedField
 This file defines a function field and the ring of integers corresponding to it.
 
 ## Main definitions
- - `FunctionField Fq F` states that `F` is a function field over the (finite) field `Fq`,
-   i.e. it is a finite extension of the field of rational functions in one variable over `Fq`.
- - `FunctionField.ringOfIntegers` defines the ring of integers corresponding to a function field
-    as the integral closure of `Fq[X]` in the function field.
- - `FunctionField.inftyValuation` : The place at infinity on `Fq(t)` is the nonarchimedean
-    valuation on `Fq(t)` with uniformizer `1/t`.
- - `FunctionField.FqtInfty` : The completion `Fq((t⁻¹))` of `Fq(t)` with respect to the
-    valuation at infinity.
+
+- `FunctionField Fq F` states that `F` is a function field over the (finite) field `Fq`,
+  i.e. it is a finite extension of the field of rational functions in one variable over `Fq`.
+- `FunctionField.ringOfIntegers` defines the ring of integers corresponding to a function field
+  as the integral closure of `Fq[X]` in the function field.
+- `FunctionField.inftyValuation` : The place at infinity on `Fq(t)` is the nonarchimedean
+  valuation on `Fq(t)` with uniformizer `1/t`.
+- `FunctionField.FqtInfty` : The completion `Fq((t⁻¹))` of `Fq(t)` with respect to the
+  valuation at infinity.
 
 ## Implementation notes
 The definitions that involve a field of fractions choose a canonical field of fractions,

--- a/Mathlib/NumberTheory/JacobiSum/Basic.lean
+++ b/Mathlib/NumberTheory/JacobiSum/Basic.lean
@@ -21,7 +21,7 @@ commutative ring `R` with values in another commutative ring `R'`:
 
 We essentially follow
 * [K. Ireland, M. Rosen, *A classical introduction to modern number theory*
-   (Section 8.3)][IrelandRosen1990]
+  (Section 8.3)][IrelandRosen1990]
 
 but generalize where appropriate.
 

--- a/Mathlib/NumberTheory/KummerDedekind.lean
+++ b/Mathlib/NumberTheory/KummerDedekind.lean
@@ -19,15 +19,15 @@ with a formula).
 
 ## Main definitions
 
- * `normalizedFactorsMapEquivNormalizedFactorsMinPolyMk` : The bijection in the
+* `normalizedFactorsMapEquivNormalizedFactorsMinPolyMk` : The bijection in the
     Kummer-Dedekind theorem. This is the pairing between the prime factors of `I * S` and the prime
     factors of `f mod I`.
 
 ## Main results
 
- * `normalized_factors_ideal_map_eq_normalized_factors_min_poly_mk_map` : The Kummer-Dedekind
+* `normalized_factors_ideal_map_eq_normalized_factors_min_poly_mk_map` : The Kummer-Dedekind
     theorem.
- * `Ideal.irreducible_map_of_irreducible_minpoly` : `I.map (algebraMap R S)` is irreducible if
+* `Ideal.irreducible_map_of_irreducible_minpoly` : `I.map (algebraMap R S)` is irreducible if
     `(map (Ideal.Quotient.mk I) (minpoly R pb.gen))` is irreducible, where `pb` is a power basis
     of `S` over `R`.
   * `normalizedFactorsMapEquivNormalizedFactorsMinPolyMk_symm_apply_eq_span` : Let `Q` be a lift of
@@ -38,13 +38,13 @@ with a formula).
 
 ## TODO
 
- * Prove the Kummer-Dedekind theorem in full generality.
+* Prove the Kummer-Dedekind theorem in full generality.
 
- * Prove the converse of `Ideal.irreducible_map_of_irreducible_minpoly`.
+* Prove the converse of `Ideal.irreducible_map_of_irreducible_minpoly`.
 
 ## References
 
- * [J. Neukirch, *Algebraic Number Theory*][Neukirch1992]
+* [J. Neukirch, *Algebraic Number Theory*][Neukirch1992]
 
 ## Tags
 

--- a/Mathlib/NumberTheory/LSeries/Basic.lean
+++ b/Mathlib/NumberTheory/LSeries/Basic.lean
@@ -14,24 +14,24 @@ Given a sequence `f: ℕ → ℂ`, we define the corresponding L-series.
 
 ## Main Definitions
 
- * `LSeries.term f s n` is the `n`th term of the L-series of the sequence `f` at `s : ℂ`.
+* `LSeries.term f s n` is the `n`th term of the L-series of the sequence `f` at `s : ℂ`.
     We define it to be zero when `n = 0`.
 
- * `LSeries f` is the L-series with a given sequence `f` as its
+* `LSeries f` is the L-series with a given sequence `f` as its
     coefficients. This is not the analytic continuation (which does not necessarily exist),
     just the sum of the infinite series if it exists and zero otherwise.
 
- * `LSeriesSummable f s` indicates that the L-series of `f` converges at `s : ℂ`.
+* `LSeriesSummable f s` indicates that the L-series of `f` converges at `s : ℂ`.
 
- * `LSeriesHasSum f s a` expresses that the L-series of `f` converges (absolutely)
+* `LSeriesHasSum f s a` expresses that the L-series of `f` converges (absolutely)
     at `s : ℂ` to `a : ℂ`.
 
 ## Main Results
 
- * `LSeriesSummable_of_isBigO_rpow`: the `LSeries` of a sequence `f` such that
+* `LSeriesSummable_of_isBigO_rpow`: the `LSeries` of a sequence `f` such that
     `f = O(n^(x-1))` converges at `s` when `x < s.re`.
 
- * `LSeriesSummable.isBigO_rpow`: if the `LSeries` of `f` is summable at `s`,
+* `LSeriesSummable.isBigO_rpow`: if the `LSeries` of `f` is summable at `s`,
     then `f = O(n^(re s))`.
 
 ## Notation

--- a/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
+++ b/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
@@ -57,7 +57,7 @@ The main steps of the proof are as follows.
 
 We give two versions of **Dirichlet's Theorem**:
 * `Nat.setOf_prime_and_eq_mod_infinite` states that the set of primes `p`
-   such that `(p : ZMod q) = a` is infinite (when `a` is invertible in `ZMod q`).
+  such that `(p : ZMod q) = a` is infinite (when `a` is invertible in `ZMod q`).
 * `Nat.forall_exists_prime_gt_and_eq_mod` states that for any natural number `n`
   there is a prime `p > n` such that `(p : ZMod q) = a`.
 

--- a/Mathlib/NumberTheory/MulChar/Duality.lean
+++ b/Mathlib/NumberTheory/MulChar/Duality.lean
@@ -16,7 +16,7 @@ where `n` is the exponent of `M`. Then the main results of this file are as foll
   `M → R` separate elements of `Mˣ`.
 
 * `MulChar.mulEquiv_units`: the group of multiplicative characters `M → R` is
-   (noncanonically) isomorphic to `Mˣ`.
+  (noncanonically) isomorphic to `Mˣ`.
 -/
 
 namespace MulChar

--- a/Mathlib/NumberTheory/NumberField/AdeleRing.lean
+++ b/Mathlib/NumberTheory/NumberField/AdeleRing.lean
@@ -15,19 +15,20 @@ finite product of completions over its infinite places and the adele ring of a n
 direct product of the infinite adele ring and the finite adele ring.
 
 ## Main definitions
- - `NumberField.InfiniteAdeleRing` of a number field `K` is defined as the product of
-   the completions of `K` over its infinite places.
- - `NumberField.InfiniteAdeleRing.ringEquiv_mixedSpace` is the ring isomorphism between
-   the infinite adele ring of `K` and `ℝ ^ r₁ × ℂ ^ r₂`, where `(r₁, r₂)` is the signature of `K`.
- - `NumberField.AdeleRing K` is the adele ring of a number field `K`.
- - `NumberField.AdeleRing.principalSubgroup K` is the subgroup of principal adeles `(x)ᵥ`.
+
+- `NumberField.InfiniteAdeleRing` of a number field `K` is defined as the product of
+  the completions of `K` over its infinite places.
+- `NumberField.InfiniteAdeleRing.ringEquiv_mixedSpace` is the ring isomorphism between
+  the infinite adele ring of `K` and `ℝ ^ r₁ × ℂ ^ r₂`, where `(r₁, r₂)` is the signature of `K`.
+- `NumberField.AdeleRing K` is the adele ring of a number field `K`.
+- `NumberField.AdeleRing.principalSubgroup K` is the subgroup of principal adeles `(x)ᵥ`.
 
 ## Main results
- - `NumberField.InfiniteAdeleRing.locallyCompactSpace` : the infinite adele ring is a
-   locally compact space.
+- `NumberField.InfiniteAdeleRing.locallyCompactSpace` : the infinite adele ring is a
+  locally compact space.
 
 ## References
- * [J.W.S. Cassels, A. Fröhlich, *Algebraic Number Theory*][cassels1967algebraic]
+* [J.W.S. Cassels, A. Fröhlich, *Algebraic Number Theory*][cassels1967algebraic]
 
 ## Tags
 infinite adele ring, adele ring, number field

--- a/Mathlib/NumberTheory/PythagoreanTriples.lean
+++ b/Mathlib/NumberTheory/PythagoreanTriples.lean
@@ -80,8 +80,8 @@ theorem mul_iff (k : ℤ) (hk : k ≠ 0) :
 
 /-- A Pythagorean triple `x, y, z` is “classified” if there exist integers `k, m, n` such that
 either
- * `x = k * (m ^ 2 - n ^ 2)` and `y = k * (2 * m * n)`, or
- * `x = k * (2 * m * n)` and `y = k * (m ^ 2 - n ^ 2)`. -/
+* `x = k * (m ^ 2 - n ^ 2)` and `y = k * (2 * m * n)`, or
+* `x = k * (2 * m * n)` and `y = k * (m ^ 2 - n ^ 2)`. -/
 @[nolint unusedArguments]
 def IsClassified (_ : PythagoreanTriple x y z) :=
   ∃ k m n : ℤ,
@@ -91,8 +91,8 @@ def IsClassified (_ : PythagoreanTriple x y z) :=
 
 /-- A primitive Pythagorean triple `x, y, z` is a Pythagorean triple with `x` and `y` coprime.
  Such a triple is “primitively classified” if there exist coprime integers `m, n` such that either
- * `x = m ^ 2 - n ^ 2` and `y = 2 * m * n`, or
- * `x = 2 * m * n` and `y = m ^ 2 - n ^ 2`.
+* `x = m ^ 2 - n ^ 2` and `y = 2 * m * n`, or
+* `x = 2 * m * n` and `y = m ^ 2 - n ^ 2`.
 -/
 @[nolint unusedArguments]
 def IsPrimitiveClassified (_ : PythagoreanTriple x y z) :=

--- a/Mathlib/NumberTheory/RamificationInertia/Basic.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Basic.lean
@@ -25,11 +25,11 @@ The main theorem `Ideal.sum_ramification_inertia` states that for all coprime `P
 ## Implementation notes
 
 Often the above theory is set up in the case where:
- * `R` is the ring of integers of a number field `K`,
- * `L` is a finite separable extension of `K`,
- * `S` is the integral closure of `R` in `L`,
- * `p` and `P` are maximal ideals,
- * `P` is an ideal lying over `p`
+* `R` is the ring of integers of a number field `K`,
+* `L` is a finite separable extension of `K`,
+* `S` is the integral closure of `R` in `L`,
+* `p` and `P` are maximal ideals,
+* `P` is an ideal lying over `p`
 We will try to relax the above hypotheses as much as possible.
 
 ## Notation
@@ -257,10 +257,10 @@ variable {K} in
 /-- If `b` mod `p` spans `S/p` as `R/p`-space, then `b` itself spans `Frac(S)` as `K`-space.
 
 Here,
- * `p` is an ideal of `R` such that `R / p` is nontrivial
- * `K` is a field that has an embedding of `R` (in particular we can take `K = Frac(R)`)
- * `L` is a field extension of `K`
- * `S` is the integral closure of `R` in `L`
+* `p` is an ideal of `R` such that `R / p` is nontrivial
+* `K` is a field that has an embedding of `R` (in particular we can take `K = Frac(R)`)
+* `L` is a field extension of `K`
+* `S` is the integral closure of `R` in `L`
 
 More precisely, we avoid quotients in this statement and instead require that `b ∪ pS` spans `S`.
 -/
@@ -360,8 +360,8 @@ and `V'` a module over `S`. If `b`, in the intersection `V''` of `V` and `V'`,
 is linear independent over `S` in `V'`, then it is linear independent over `R` in `V`.
 
 The statement we prove is actually slightly more general:
- * it suffices that the inclusion `algebraMap R S : R → S` is nontrivial
- * the function `f' : V'' → V'` doesn't need to be injective
+* it suffices that the inclusion `algebraMap R S : R → S` is nontrivial
+* the function `f' : V'' → V'` doesn't need to be injective
 -/
 theorem FinrankQuotientMap.linearIndependent_of_nontrivial [IsDedekindDomain R]
     (hRS : RingHom.ker (algebraMap R S) ≠ ⊤) (f : V'' →ₗ[R] V) (hf : Function.Injective f)

--- a/Mathlib/NumberTheory/SelbergSieve.lean
+++ b/Mathlib/NumberTheory/SelbergSieve.lean
@@ -18,26 +18,26 @@ We mostly follow the treatment outlined by Heath-Brown in the notes to an old gr
 minor notational difference is that we write $\nu(n)$ in place of $\frac{\omega(n)}{n}$.
 
 ## Results
- * `siftedSum_le_mainSum_errSum_of_UpperBoundSieve` - Every upper bound sieve gives an upper bound
+* `siftedSum_le_mainSum_errSum_of_UpperBoundSieve` - Every upper bound sieve gives an upper bound
  on the size of the sifted set in terms of `mainSum` and `errSum`
 
 ## Notation
 The `SelbergSieve.Notation` namespace includes common shorthand for the variables included in the
 `SelbergSieve` structure.
- * `A` for `support`
- * `𝒜 d` for `multSum d` - the combined weight of the elements of `A` that are divisible by `d`
- * `P` for `prodPrimes`
- * `a` for `weights`
- * `X` for `totalMass`
- * `ν` for `nu`
- * `y` for `level`
- * `R d` for `rem d`
- * `g d` for `selbergTerms d`
+* `A` for `support`
+* `𝒜 d` for `multSum d` - the combined weight of the elements of `A` that are divisible by `d`
+* `P` for `prodPrimes`
+* `a` for `weights`
+* `X` for `totalMass`
+* `ν` for `nu`
+* `y` for `level`
+* `R d` for `rem d`
+* `g d` for `selbergTerms d`
 
 ## References
 
- * [Heath-Brown, *Lectures on sieves*][heathbrown2002lecturessieves]
- * [Koukoulopoulos, *The Distribution of Prime Numbers*][MR3971232]
+* [Heath-Brown, *Lectures on sieves*][heathbrown2002lecturessieves]
+* [Koukoulopoulos, *The Distribution of Prime Numbers*][MR3971232]
 
 -/
 

--- a/Mathlib/NumberTheory/WellApproximable.lean
+++ b/Mathlib/NumberTheory/WellApproximable.lean
@@ -35,16 +35,16 @@ We do *not* include a formalisation of the Koukoulopoulos-Maynard result here.
 
 ## Main definitions and results:
 
- * `approxOrderOf`: in a seminormed group `A`, given `n : ℕ` and `δ : ℝ`, `approxOrderOf A n δ`
-   is the set of elements within a distance `δ` of a point of order `n`.
- * `wellApproximable`: in a seminormed group `A`, given a sequence of distances `δ₁, δ₂, ...`,
-   `wellApproximable A δ` is the limsup as `n → ∞` of the sets `approxOrderOf A n δₙ`. Thus, it
-   is the set of points that lie in infinitely many of the sets `approxOrderOf A n δₙ`.
- * `AddCircle.addWellApproximable_ae_empty_or_univ`: *Gallagher's ergodic theorem* says that for
-   the (additive) circle `𝕊`, for any sequence of distances `δ`, the set
-   `addWellApproximable 𝕊 δ` is almost empty or almost full.
- * `NormedAddCommGroup.exists_norm_nsmul_le`: a general version of Dirichlet's approximation theorem
- * `AddCircle.exists_norm_nsmul_le`: Dirichlet's approximation theorem
+* `approxOrderOf`: in a seminormed group `A`, given `n : ℕ` and `δ : ℝ`, `approxOrderOf A n δ`
+  is the set of elements within a distance `δ` of a point of order `n`.
+* `wellApproximable`: in a seminormed group `A`, given a sequence of distances `δ₁, δ₂, ...`,
+  `wellApproximable A δ` is the limsup as `n → ∞` of the sets `approxOrderOf A n δₙ`. Thus, it
+  is the set of points that lie in infinitely many of the sets `approxOrderOf A n δₙ`.
+* `AddCircle.addWellApproximable_ae_empty_or_univ`: *Gallagher's ergodic theorem* says that for
+  the (additive) circle `𝕊`, for any sequence of distances `δ`, the set
+  `addWellApproximable 𝕊 δ` is almost empty or almost full.
+* `NormedAddCommGroup.exists_norm_nsmul_le`: a general version of Dirichlet's approximation theorem
+* `AddCircle.exists_norm_nsmul_le`: Dirichlet's approximation theorem
 
 ## TODO
 

--- a/Mathlib/Order/Atoms.lean
+++ b/Mathlib/Order/Atoms.lean
@@ -43,11 +43,11 @@ which are lattices with only two elements, and related ideas.
 
 ## Main results
   * `isAtom_dual_iff_isCoatom` and `isCoatom_dual_iff_isAtom` express the (definitional) duality
-   of `IsAtom` and `IsCoatom`.
+    of `IsAtom` and `IsCoatom`.
   * `isSimpleOrder_iff_isAtom_top` and `isSimpleOrder_iff_isCoatom_bot` express the
-  connection between atoms, coatoms, and simple lattices
+    connection between atoms, coatoms, and simple lattices
   * `IsCompl.isAtom_iff_isCoatom` and `IsCompl.isCoatom_if_isAtom`: In a modular
-  bounded lattice, a complement of an atom is a coatom and vice versa.
+    bounded lattice, a complement of an atom is a coatom and vice versa.
   * `isAtomic_iff_isCoatomic`: A modular complemented lattice is atomic iff it is coatomic.
 
 -/

--- a/Mathlib/Order/Category/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/Category/OmegaCompletePartialOrder.lean
@@ -18,8 +18,8 @@ an `OmegaCompletePartialOrder`.
 
 ## Main definitions
 
- * `ωCPO`
-   * an instance of `Category` and `ConcreteCategory`
+* `ωCPO`
+  * an instance of `Category` and `ConcreteCategory`
 
 -/
 

--- a/Mathlib/Order/CompactlyGenerated/Basic.lean
+++ b/Mathlib/Order/CompactlyGenerated/Basic.lean
@@ -22,23 +22,23 @@ is well-founded. In this file we define three especially-useful characterisation
 proofs that they are indeed equivalent to well-foundedness.
 
 ## Main definitions
- * `CompleteLattice.IsSupClosedCompact`
- * `CompleteLattice.IsSupFiniteCompact`
- * `CompleteLattice.IsCompactElement`
- * `IsCompactlyGenerated`
+* `CompleteLattice.IsSupClosedCompact`
+* `CompleteLattice.IsSupFiniteCompact`
+* `CompleteLattice.IsCompactElement`
+* `IsCompactlyGenerated`
 
 ## Main results
 The main result is that the following four conditions are equivalent for a complete lattice:
- * `well_founded (>)`
- * `CompleteLattice.IsSupClosedCompact`
- * `CompleteLattice.IsSupFiniteCompact`
- * `∀ k, CompleteLattice.IsCompactElement k`
+* `well_founded (>)`
+* `CompleteLattice.IsSupClosedCompact`
+* `CompleteLattice.IsSupFiniteCompact`
+* `∀ k, CompleteLattice.IsCompactElement k`
 
 This is demonstrated by means of the following four lemmas:
- * `CompleteLattice.WellFounded.isSupFiniteCompact`
- * `CompleteLattice.IsSupFiniteCompact.isSupClosedCompact`
- * `CompleteLattice.IsSupClosedCompact.wellFounded`
- * `CompleteLattice.isSupFiniteCompact_iff_all_elements_compact`
+* `CompleteLattice.WellFounded.isSupFiniteCompact`
+* `CompleteLattice.IsSupFiniteCompact.isSupClosedCompact`
+* `CompleteLattice.IsSupClosedCompact.wellFounded`
+* `CompleteLattice.isSupFiniteCompact_iff_all_elements_compact`
 
  We also show well-founded lattices are compactly generated
  (`CompleteLattice.isCompactlyGenerated_of_wellFounded`).

--- a/Mathlib/Order/Disjointed.lean
+++ b/Mathlib/Order/Disjointed.lean
@@ -118,7 +118,7 @@ theorem partialSups_disjointed (f : ι → α) :
   intro r i hi
   induction r generalizing i with
   | zero =>
-   -- Base case: `n` is minimal, so `partialSups f i = partialSups (disjointed f) n = f i`.
+    -- Base case: `n` is minimal, so `partialSups f i = partialSups (disjointed f) n = f i`.
     simp only [Nat.le_zero, card_eq_zero] at hi
     simp only [partialSups_apply, Iic_eq_cons_Iio, hi, disjointed_apply, sup'_eq_sup, sup_cons,
       sup_empty, sdiff_bot]

--- a/Mathlib/Order/Filter/Curry.lean
+++ b/Mathlib/Order/Filter/Curry.lean
@@ -37,7 +37,7 @@ describing the product of two sets, namely `s ×ˢ t = fst ⁻¹' s ∩ snd ⁻�
 
 * `Filter.eventually_curry_iff`: An alternative definition of a curried filter
 * `Filter.curry_le_prod`: Something that is eventually true on the a product filter is eventually
-   true on the curried filter
+  true on the curried filter
 
 ## Tags
 

--- a/Mathlib/Order/Hom/Basic.lean
+++ b/Mathlib/Order/Hom/Basic.lean
@@ -16,9 +16,9 @@ homomorphism `f : α →o β` is a function `α → β` along with a proof that 
 ## Main definitions
 
 In this file we define the following bundled monotone maps:
- * `OrderHom α β` a.k.a. `α →o β`: Preorder homomorphism.
+* `OrderHom α β` a.k.a. `α →o β`: Preorder homomorphism.
     An `OrderHom α β` is a function `f : α → β` such that `a₁ ≤ a₂ → f a₁ ≤ f a₂`
- * `OrderEmbedding α β` a.k.a. `α ↪o β`: Relation embedding.
+* `OrderEmbedding α β` a.k.a. `α ↪o β`: Relation embedding.
     An `OrderEmbedding α β` is an embedding `f : α ↪ β` such that `a ≤ b ↔ f a ≤ f b`.
     Defined as an abbreviation of `@RelEmbedding α β (≤) (≤)`.
 * `OrderIso`: Relation isomorphism.

--- a/Mathlib/Order/Hom/Order.lean
+++ b/Mathlib/Order/Hom/Order.lean
@@ -15,7 +15,7 @@ monotone functions.
 
 ## Main definitions
 
- * `OrderHom.CompleteLattice`: if `β` is a complete lattice, so is `α →o β`
+* `OrderHom.CompleteLattice`: if `β` is a complete lattice, so is `α →o β`
 
 ## Tags
 

--- a/Mathlib/Order/Interval/Set/OrdConnectedLinear.lean
+++ b/Mathlib/Order/Interval/Set/OrdConnectedLinear.lean
@@ -17,14 +17,14 @@ some convenience lemmas for characterising closed intervals in certain concrete 
 `ℕ`, and `Fin n`.
 
 ## Main results:
- * `Set.ordConnected_iff_disjoint_Ioo_empty`: a characterisation of `Set.OrdConnected` for
-   locally-finite linear orders.
- * `Set.Nonempty.ordConnected_iff_of_bdd`: a characterisation of closed intervals for locally-finite
-   conditionally complete linear orders.
- * `Set.Nonempty.ordConnected_iff_of_bdd'`: a characterisation of closed intervals for
-   locally-finite complete linear orders (convenient for `Fin n`).
- * `Set.Nonempty.eq_Icc_iff_nat`: characterisation of closed intervals for `ℕ`.
- * `Set.Nonempty.eq_Icc_iff_int`: characterisation of closed intervals for `ℤ`.
+* `Set.ordConnected_iff_disjoint_Ioo_empty`: a characterisation of `Set.OrdConnected` for
+  locally-finite linear orders.
+* `Set.Nonempty.ordConnected_iff_of_bdd`: a characterisation of closed intervals for locally-finite
+  conditionally complete linear orders.
+* `Set.Nonempty.ordConnected_iff_of_bdd'`: a characterisation of closed intervals for
+  locally-finite complete linear orders (convenient for `Fin n`).
+* `Set.Nonempty.eq_Icc_iff_nat`: characterisation of closed intervals for `ℕ`.
+* `Set.Nonempty.eq_Icc_iff_int`: characterisation of closed intervals for `ℤ`.
 -/
 
 variable {α : Type*} {I : Set α}

--- a/Mathlib/Order/Interval/Set/ProjIcc.lean
+++ b/Mathlib/Order/Interval/Set/ProjIcc.lean
@@ -12,9 +12,9 @@ import Mathlib.Order.Interval.Set.OrdConnected
 Given a linearly ordered type `α`, in this file we define
 
 * `Set.projIci (a : α)` to be the map `α → [a, ∞)` sending `(-∞, a]` to `a`, and each point
-   `x ∈ [a, ∞)` to itself;
+  `x ∈ [a, ∞)` to itself;
 * `Set.projIic (b : α)` to be the map `α → (-∞, b[` sending `[b, ∞)` to `b`, and each point
-   `x ∈ (-∞, b]` to itself;
+  `x ∈ (-∞, b]` to itself;
 * `Set.projIcc (a b : α) (h : a ≤ b)` to be the map `α → [a, b]` sending `(-∞, a]` to `a`, `[b, ∞)`
   to `b`, and each point `x ∈ [a, b]` to itself;
 * `Set.IccExtend {a b : α} (h : a ≤ b) (f : Icc a b → β)` to be the extension of `f` to `α` defined

--- a/Mathlib/Order/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/OmegaCompletePartialOrder.lean
@@ -25,33 +25,33 @@ supremum helps define the meaning of recursive procedures.
 
 ## Main definitions
 
- * class `OmegaCompletePartialOrder`
- * `ite`, `map`, `bind`, `seq` as continuous morphisms
+* class `OmegaCompletePartialOrder`
+* `ite`, `map`, `bind`, `seq` as continuous morphisms
 
 ## Instances of `OmegaCompletePartialOrder`
 
- * `Part`
- * every `CompleteLattice`
- * pi-types
- * product types
- * `OrderHom`
- * `ContinuousHom` (with notation →𝒄)
-   * an instance of `OmegaCompletePartialOrder (α →𝒄 β)`
- * `ContinuousHom.ofFun`
- * `ContinuousHom.ofMono`
- * continuous functions:
-   * `id`
-   * `ite`
-   * `const`
-   * `Part.bind`
-   * `Part.map`
-   * `Part.seq`
+* `Part`
+* every `CompleteLattice`
+* pi-types
+* product types
+* `OrderHom`
+* `ContinuousHom` (with notation →𝒄)
+  * an instance of `OmegaCompletePartialOrder (α →𝒄 β)`
+* `ContinuousHom.ofFun`
+* `ContinuousHom.ofMono`
+* continuous functions:
+  * `id`
+  * `ite`
+  * `const`
+  * `Part.bind`
+  * `Part.map`
+  * `Part.seq`
 
 ## References
 
- * [Chain-complete posets and directed sets with applications][markowsky1976]
- * [Recursive definitions of partial functions and their computations][cadiou1972]
- * [Semantics of Programming Languages: Structures and Techniques][gunter1992]
+* [Chain-complete posets and directed sets with applications][markowsky1976]
+* [Recursive definitions of partial functions and their computations][cadiou1972]
+* [Semantics of Programming Languages: Structures and Techniques][gunter1992]
 -/
 
 assert_not_exists OrderedCommMonoid

--- a/Mathlib/Order/OrderIsoNat.lean
+++ b/Mathlib/Order/OrderIsoNat.lean
@@ -19,7 +19,7 @@ defines the limit value of an eventually-constant sequence.
 ## Main declarations
 
 * `natLT`/`natGT`: Make an order embedding `Nat ↪ α` from
-   an increasing/decreasing function `Nat → α`.
+  an increasing/decreasing function `Nat → α`.
 * `monotonicSequenceLimit`: The limit of an eventually-constant monotone sequence `Nat →o α`.
 * `monotonicSequenceLimitIndex`: The index of the first occurrence of `monotonicSequenceLimit`
   in the sequence.

--- a/Mathlib/Order/WellFoundedSet.lean
+++ b/Mathlib/Order/WellFoundedSet.lean
@@ -16,25 +16,25 @@ This file introduces versions of `WellFounded` and `WellQuasiOrdered` for sets.
 
 ## Main Definitions
 
- * `Set.WellFoundedOn s r` indicates that the relation `r` is
+* `Set.WellFoundedOn s r` indicates that the relation `r` is
   well-founded when restricted to the set `s`.
- * `Set.IsWF s` indicates that `<` is well-founded when restricted to `s`.
- * `Set.PartiallyWellOrderedOn s r` indicates that the relation `r` is
+* `Set.IsWF s` indicates that `<` is well-founded when restricted to `s`.
+* `Set.PartiallyWellOrderedOn s r` indicates that the relation `r` is
   partially well-ordered (also known as well quasi-ordered) when restricted to the set `s`.
- * `Set.IsPWO s` indicates that any infinite sequence of elements in `s` contains an infinite
+* `Set.IsPWO s` indicates that any infinite sequence of elements in `s` contains an infinite
   monotone subsequence. Note that this is equivalent to containing only two comparable elements.
 
 ## Main Results
 
- * Higman's Lemma, `Set.PartiallyWellOrderedOn.partiallyWellOrderedOn_sublistForall₂`,
+* Higman's Lemma, `Set.PartiallyWellOrderedOn.partiallyWellOrderedOn_sublistForall₂`,
   shows that if `r` is partially well-ordered on `s`, then `List.SublistForall₂` is partially
   well-ordered on the set of lists of elements of `s`. The result was originally published by
   Higman, but this proof more closely follows Nash-Williams.
- * `Set.wellFoundedOn_iff` relates `well_founded_on` to the well-foundedness of a relation on the
+* `Set.wellFoundedOn_iff` relates `well_founded_on` to the well-foundedness of a relation on the
  original type, to avoid dealing with subtypes.
- * `Set.IsWF.mono` shows that a subset of a well-founded subset is well-founded.
- * `Set.IsWF.union` shows that the union of two well-founded subsets is well-founded.
- * `Finset.isWF` shows that all `Finset`s are well-founded.
+* `Set.IsWF.mono` shows that a subset of a well-founded subset is well-founded.
+* `Set.IsWF.union` shows that the union of two well-founded subsets is well-founded.
+* `Finset.isWF` shows that all `Finset`s are well-founded.
 
 ## TODO
 
@@ -42,8 +42,8 @@ This file introduces versions of `WellFounded` and `WellQuasiOrdered` for sets.
 * Rename `Set.PartiallyWellOrderedOn` to `Set.WellQuasiOrderedOn` and `Set.IsPWO` to `Set.IsWQO`.
 
 ## References
- * [Higman, *Ordering by Divisibility in Abstract Algebras*][Higman52]
- * [Nash-Williams, *On Well-Quasi-Ordering Finite Trees*][Nash-Williams63]
+* [Higman, *Ordering by Divisibility in Abstract Algebras*][Higman52]
+* [Nash-Williams, *On Well-Quasi-Ordering Finite Trees*][Nash-Williams63]
 -/
 
 assert_not_exists OrderedSemiring

--- a/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
@@ -39,12 +39,12 @@ standard projective resolution of `k` as a trivial `k`-linear `G`-representation
 
 ## Main definitions
 
- * `groupCohomology.resolution.actionDiagonalSucc`
- * `groupCohomology.resolution.diagonalSucc`
- * `groupCohomology.resolution.ofMulActionBasis`
- * `classifyingSpaceUniversalCover`
- * `groupCohomology.resolution.forget₂ToModuleCatHomotopyEquiv`
- * `groupCohomology.projectiveResolution`
+* `groupCohomology.resolution.actionDiagonalSucc`
+* `groupCohomology.resolution.diagonalSucc`
+* `groupCohomology.resolution.ofMulActionBasis`
+* `classifyingSpaceUniversalCover`
+* `groupCohomology.resolution.forget₂ToModuleCatHomotopyEquiv`
+* `groupCohomology.projectiveResolution`
 
 ## Implementation notes
 

--- a/Mathlib/Tactic/CC/MkProof.lean
+++ b/Mathlib/Tactic/CC/MkProof.lean
@@ -318,8 +318,8 @@ partial def mkCongrProofCore (lhs rhs : Expr) (heqProofs : Bool) : CCM Expr := d
 /-- If `e₁ : R lhs₁ rhs₁`, `e₂ : R lhs₂ rhs₂` and `lhs₁ = rhs₂`, where `R` is a symmetric relation,
 prove `R lhs₁ rhs₁` is equivalent to `R lhs₂ rhs₂`.
 
- * if `lhs₁` is known to equal `lhs₂`, return `none`
- * if `lhs₁` is not known to equal `rhs₂`, fail. -/
+* if `lhs₁` is known to equal `lhs₂`, return `none`
+* if `lhs₁` is not known to equal `rhs₂`, fail. -/
 partial def mkSymmCongrProof (e₁ e₂ : Expr) (heqProofs : Bool) : CCM (Option Expr) := do
   let some (R₁, lhs₁, rhs₁) ← e₁.relSidesIfSymm? | return none
   let some (R₂, lhs₂, rhs₂) ← e₂.relSidesIfSymm? | return none
@@ -379,10 +379,10 @@ partial def mkDelayedProof (H : DelayedExpr) : CCM Expr := do
   | .heqSymm h => mkHEqSymm (← mkDelayedProof h)
 
 /-- Use the format of `H` to try and construct a proof or `lhs = rhs`:
- * If `H = .congr`, then use congruence.
- * If `H = .eqTrue`, try to prove `lhs = True` or `rhs = True`,
-   if they have the format `R a b`, by proving `a = b`.
- * Otherwise, return the (delayed) proof encoded by `H` itself. -/
+* If `H = .congr`, then use congruence.
+* If `H = .eqTrue`, try to prove `lhs = True` or `rhs = True`,
+  if they have the format `R a b`, by proving `a = b`.
+* Otherwise, return the (delayed) proof encoded by `H` itself. -/
 partial def mkProof (lhs rhs : Expr) (H : EntryExpr) (heqProofs : Bool) : CCM Expr := do
   match H with
   | .congr => mkCongrProof lhs rhs heqProofs

--- a/Mathlib/Tactic/ComputeDegree.lean
+++ b/Mathlib/Tactic/ComputeDegree.lean
@@ -392,18 +392,18 @@ def splitApply (mvs static : List MVarId) : MetaM ((List MVarId) × (List MVarId
 
 /-- `miscomputedDegree? deg false_goals` takes as input
 *  an `Expr`ession `deg`, representing the degree of a polynomial
-   (i.e. an `Expr`ession of inferred type either `ℕ` or `WithBot ℕ`);
+  (i.e. an `Expr`ession of inferred type either `ℕ` or `WithBot ℕ`);
 *  a list of `MVarId`s `false_goals`.
 
 Although inconsequential for this function, the list of goals `false_goals` reduces to `False`
 if `norm_num`med.
 `miscomputedDegree?` extracts error information from goals of the form
 *  `a ≠ b`, assuming it comes from `⊢ coeff_of_given_degree ≠ 0`
-   -- reducing to `False` means that the coefficient that was supposed to vanish, does not;
+  --- reducing to `False` means that the coefficient that was supposed to vanish, does not;
 *  `a ≤ b`, assuming it comes from `⊢ degree_of_subterm ≤ degree_of_polynomial`
-   -- reducing to `False` means that there is a term of degree that is apparently too large;
+  --- reducing to `False` means that there is a term of degree that is apparently too large;
 *  `a = b`, assuming it comes from `⊢ computed_degree ≤ given_degree`
-   -- reducing to `False` means that there is a term of degree that is apparently too large.
+  --- reducing to `False` means that there is a term of degree that is apparently too large.
 
 The cases `a ≠ b` and `a = b` are not a perfect match with the top coefficient:
 reducing to `False` is not exactly correlated with a coefficient being non-zero.

--- a/Mathlib/Tactic/Linter/FlexibleLinter.lean
+++ b/Mathlib/Tactic/Linter/FlexibleLinter.lean
@@ -145,10 +145,10 @@ variable (take? : Syntax → Bool) in
 an `InfoTree` and returns the array of pairs `(stx, mvars)`,
 where `stx` is a syntax node such that `take? stx` is `true` and
 `mvars` indicates the goal state:
- * the context before `stx`
- * the context after `stx`
- * a list of metavariables closed by `stx`
- * a list of metavariables created by `stx`
+* the context before `stx`
+* the context after `stx`
+* a list of metavariables closed by `stx`
+* a list of metavariables created by `stx`
 
 A typical usage is to find the goals following a `simp` application.
 -/

--- a/Mathlib/Tactic/NormNum/BigOperators.lean
+++ b/Mathlib/Tactic/NormNum/BigOperators.lean
@@ -19,7 +19,7 @@ on that subset until the set is completely exhausted.
 
 ## See also
 
- * The `fin_cases` tactic has similar scope: splitting out a finite collection into its elements.
+* The `fin_cases` tactic has similar scope: splitting out a finite collection into its elements.
 
 ## Porting notes
 
@@ -30,10 +30,10 @@ In particular, we can't use the plugin on sums containing variables.
 
 ## TODO
 
- * Support intervals: `Finset.Ico`, `Finset.Icc`, ...
- * To support variables, like in Mathlib 3, turn this into a standalone tactic that unfolds
-   the sum/prod, without computing its numeric value (using the `ring` tactic to do some
-   normalization?)
+* Support intervals: `Finset.Ico`, `Finset.Icc`, ...
+* To support variables, like in Mathlib 3, turn this into a standalone tactic that unfolds
+  the sum/prod, without computing its numeric value (using the `ring` tactic to do some
+  normalization?)
 -/
 
 namespace Mathlib.Meta

--- a/docs/Conv/Guide.lean
+++ b/docs/Conv/Guide.lean
@@ -157,7 +157,7 @@ in Lean 4 core.
 * `change t` changes the expression to `t` if the expression and `t` are definitionally equal.
 
 * `equals t => tacticSeq` changes the current expression, say `e`, to `t`, and asks you to prove
-   the equality `e = t`. (Batteries)
+  the equality `e = t`. (Batteries)
 
 * `rw [thms...]` rewrites the expression using the given theorems. The syntax is similar to `rw`.
 


### PR DESCRIPTION
In all lines starting with " *" or " -", remove the leading space. That space is not required and does not match mathlib style.
Then, manually make indentation of subsequent lines match (often, decreasing by one, and sometimes two, space(s).)

Like #24886, but for everything inside `NumberTheory`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
