### PR TITLE
[Merged by Bors] - chore: use TreeMap in linarith Fourier-Motzkin oracle

### DIFF
--- a/Mathlib/Tactic/Linarith/Oracle/FourierMotzkin.lean
+++ b/Mathlib/Tactic/Linarith/Oracle/FourierMotzkin.lean
@@ -5,7 +5,6 @@ Authors: Robert Y. Lewis
 -/
 import Mathlib.Std.Data.HashMap
 import Batteries.Lean.HashMap
-import Batteries.Data.RBMap.Basic
 import Mathlib.Tactic.Linarith.Datatypes
 
 /-!
@@ -225,7 +224,7 @@ instance : ToString PComp :=
   ⟨fun p => toString p.c.coeffs ++ toString p.c.str ++ "0"⟩
 
 /-- A collection of comparisons. -/
-abbrev PCompSet := RBSet PComp PComp.cmp
+abbrev PCompSet := TreeSet PComp PComp.cmp
 
 /-! ### Elimination procedure -/
 
@@ -261,7 +260,7 @@ def elimWithSet (a : ℕ) (p : PComp) (comps : PCompSet) : PCompSet :=
   comps.foldl (fun s pc =>
   match pelimVar p pc a with
   | some pc => if pc.maybeMinimal a then s.insert pc else s
-  | none => s) RBSet.empty
+  | none => s) TreeSet.empty
 
 /--
 The state for the elimination monad.
@@ -320,7 +319,7 @@ def splitSetByVarSign (a : ℕ) (comps : PCompSet) : PCompSet × PCompSet × PCo
     if n > 0 then ⟨pos.insert pc, neg, notPresent⟩
     else if n < 0 then ⟨pos, neg.insert pc, notPresent⟩
     else ⟨pos, neg, notPresent.insert pc⟩)
-    ⟨RBSet.empty, RBSet.empty, RBSet.empty⟩
+    ⟨TreeSet.empty, TreeSet.empty, TreeSet.empty⟩
 
 /--
 `elimVarM a` performs one round of Fourier-Motzkin elimination, eliminating the variable `a`

--- a/MathlibTest/linarith.lean
+++ b/MathlibTest/linarith.lean
@@ -687,20 +687,6 @@ example {x1 x2 x3 x4 x5 x6 x7 x8 : ℚ} :
     False := by
   intros; linarith
 
--- TODO: still broken with Fourier-Motzkin
-/--
-error: linarith failed to find a contradiction
-case h1.h
-a b c d e : ℚ
-ha : 2 * a + b + c + d + e = 4
-hb : a + 2 * b + c + d + e = 5
-hc : a + b + 2 * c + d + e = 6
-hd : a + b + c + 2 * d + e = 7
-he : a + b + c + d + 2 * e = 8
-a✝ : e < 3
-⊢ False
-failed
--/
 #guard_msgs in
 /-- https://github.com/leanprover-community/mathlib4/issues/8875 -/
 example (a b c d e : ℚ)
@@ -712,24 +698,6 @@ example (a b c d e : ℚ)
     e = 3 := by
   linarith (config := { oracle := .fourierMotzkin })
 
-set_option linter.unusedTactic false in
--- TODO: still broken with Fourier-Motzkin
-/--
-error: linarith failed to find a contradiction
-x1 x2 x3 x4 x5 x6 x7 x8 : ℚ
-a✝⁹ : 3 * x4 - x3 - x2 - x1 < 0
-a✝⁸ : x5 - x4 < 0
-a✝⁷ : 2 * (x5 - x4) < 0
-a✝⁶ : -x6 + x3 < 0
-a✝⁵ : -x6 + x2 < 0
-a✝⁴ : 2 * (x6 - x5) < 0
-a✝³ : x8 - x7 < 0
-a✝² : -x8 + x2 < 0
-a✝¹ : -x8 + x7 - x5 + x1 < 0
-a✝ : x7 - x5 < 0
-⊢ False
-failed
--/
 #guard_msgs in
 /-- https://github.com/leanprover-community/mathlib4/issues/2717 -/
 example {x1 x2 x3 x4 x5 x6 x7 x8 : ℚ} :
@@ -745,7 +713,6 @@ example {x1 x2 x3 x4 x5 x6 x7 x8 : ℚ} :
     x7 - x5 < 0 → False := by
   intros
   linarith (config := { oracle := .fourierMotzkin })
-
 section findSquares
 
 private abbrev wrapped (z : ℤ) : ℤ := z


### PR DESCRIPTION
Mysteriously, this *fixes* two previously failing tests, where I expected this change was not going to have any observable effect!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
