### PR TITLE
chore(LocallyIntegrable): reorder hypotheses to enable dot notation

### DIFF
--- a/Mathlib/Analysis/SumIntegralComparisons.lean
+++ b/Mathlib/Analysis/SumIntegralComparisons.lean
@@ -232,7 +232,7 @@ lemma sum_mul_Ico_le_integral_of_monotone_antitone
   · apply Integrable.mono_measure _ (Measure.restrict_mono_set _ Ico_subset_Icc_self)
     apply Integrable.mul_of_top_left
     · exact hf.integrableOn_isCompact isCompact_Icc
-    · apply AntitoneOn.memLp_isCompact isCompact_Icc
+    · apply AntitoneOn.memLp_isCompact ?_ isCompact_Icc
       intro x hx y hy hxy
       apply hg
       · simpa using hx
@@ -277,7 +277,7 @@ lemma integral_le_sum_mul_Ico_of_antitone_monotone
   · apply Integrable.mono_measure _ (Measure.restrict_mono_set _ Ico_subset_Icc_self)
     apply Integrable.mul_of_top_left
     · exact hf.integrableOn_isCompact isCompact_Icc
-    · apply MonotoneOn.memLp_isCompact isCompact_Icc
+    · apply MonotoneOn.memLp_isCompact ?_ isCompact_Icc
       intro x hx y hy hxy
       apply hg
       · simpa using hx

--- a/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
@@ -517,8 +517,8 @@ theorem MonotoneOn.memLp_of_measure_ne_top (hmono : MonotoneOn f s) {a b : X}
 @[deprecated (since := "2025-02-21")]
 alias MonotoneOn.memℒp_of_measure_ne_top := MonotoneOn.memLp_of_measure_ne_top
 
-theorem MonotoneOn.memLp_isCompact [IsFiniteMeasureOnCompacts μ] (hs : IsCompact s)
-    (hmono : MonotoneOn f s) : MemLp f p (μ.restrict s) := by
+theorem MonotoneOn.memLp_isCompact [IsFiniteMeasureOnCompacts μ] (hmono : MonotoneOn f s)
+    (hs : IsCompact s) : MemLp f p (μ.restrict s) := by
   obtain rfl | h := s.eq_empty_or_nonempty
   · simp
   · exact hmono.memLp_of_measure_ne_top (hs.isLeast_sInf h) (hs.isGreatest_sSup h)
@@ -543,9 +543,9 @@ theorem AntitoneOn.memLp_of_measure_ne_top (hanti : AntitoneOn f s) {a b : X}
 @[deprecated (since := "2025-02-21")]
 alias AntitoneOn.memℒp_of_measure_ne_top := AntitoneOn.memLp_of_measure_ne_top
 
-theorem AntitoneOn.memLp_isCompact [IsFiniteMeasureOnCompacts μ] (hs : IsCompact s)
-    (hanti : AntitoneOn f s) : MemLp f p (μ.restrict s) :=
-  MonotoneOn.memLp_isCompact (E := Eᵒᵈ) hs hanti
+theorem AntitoneOn.memLp_isCompact [IsFiniteMeasureOnCompacts μ] (hanti : AntitoneOn f s)
+    (hs : IsCompact s) : MemLp f p (μ.restrict s) :=
+  MonotoneOn.memLp_isCompact (E := Eᵒᵈ) hanti hs
 
 @[deprecated (since := "2025-02-21")]
 alias AntitoneOn.memℒp_isCompact := AntitoneOn.memLp_isCompact
@@ -555,8 +555,8 @@ theorem MonotoneOn.integrableOn_of_measure_ne_top (hmono : MonotoneOn f s) {a b 
     IntegrableOn f s μ :=
   memLp_one_iff_integrable.1 (hmono.memLp_of_measure_ne_top ha hb hs h's)
 
-theorem MonotoneOn.integrableOn_isCompact [IsFiniteMeasureOnCompacts μ] (hs : IsCompact s)
-    (hmono : MonotoneOn f s) : IntegrableOn f s μ :=
+theorem MonotoneOn.integrableOn_isCompact [IsFiniteMeasureOnCompacts μ] (hmono : MonotoneOn f s)
+    (hs : IsCompact s) : IntegrableOn f s μ :=
   memLp_one_iff_integrable.1 (hmono.memLp_isCompact hs)
 
 theorem AntitoneOn.integrableOn_of_measure_ne_top (hanti : AntitoneOn f s) {a b : X}
@@ -564,8 +564,8 @@ theorem AntitoneOn.integrableOn_of_measure_ne_top (hanti : AntitoneOn f s) {a b 
     IntegrableOn f s μ :=
   memLp_one_iff_integrable.1 (hanti.memLp_of_measure_ne_top ha hb hs h's)
 
-theorem AntitoneOn.integrableOn_isCompact [IsFiniteMeasureOnCompacts μ] (hs : IsCompact s)
-    (hanti : AntitoneOn f s) : IntegrableOn f s μ :=
+theorem AntitoneOn.integrableOn_isCompact [IsFiniteMeasureOnCompacts μ] (hanti : AntitoneOn f s)
+    (hs : IsCompact s) : IntegrableOn f s μ :=
   memLp_one_iff_integrable.1 (hanti.memLp_isCompact hs)
 
 theorem Monotone.locallyIntegrable [IsLocallyFiniteMeasure μ] (hmono : Monotone f) :


### PR DESCRIPTION
In general, an explicit argument `MonotoneOn` to a lemma in the `MonotoneOn` namespace should come first, similarly for AntitoneOn. If there's a reason to deviate here, I'd love to be enlightened (and a comment to be added).

---

Split out of #24862.
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
