### PR TITLE
[Merged by Bors] - style: rename `t2Quotient` to `T2Quotient`

### DIFF
--- a/Mathlib/Topology/Separation/Hausdorff.lean
+++ b/Mathlib/Topology/Separation/Hausdorff.lean
@@ -470,24 +470,6 @@ lemma unique_lift {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] [T2Spa
   simp [← hfg]
 
 end T2Quotient
-
-namespace t2Quotient
-
-@[deprecated (since := "2025-05-15")] alias instTopologicalSpace := T2Quotient.instTopologicalSpace
-@[deprecated (since := "2025-05-15")] alias mk := T2Quotient.mk
-@[deprecated (since := "2025-05-15")] alias mk_eq := T2Quotient.mk_eq
-@[deprecated (since := "2025-05-15")] alias surjective_mk := T2Quotient.surjective_mk
-@[deprecated (since := "2025-05-15")] alias continuous_mk := T2Quotient.continuous_mk
-@[deprecated (since := "2025-05-15")] protected alias inductionOn := T2Quotient.inductionOn
-@[deprecated (since := "2025-05-15")] protected alias inductionOn₂ := T2Quotient.inductionOn₂
-@[deprecated (since := "2025-05-15")] alias instT2Space := T2Quotient.instT2Space
-@[deprecated (since := "2025-05-15")] alias compatible := T2Quotient.compatible
-@[deprecated (since := "2025-05-15")] alias lift := T2Quotient.lift
-@[deprecated (since := "2025-05-15")] alias continuous_lift := T2Quotient.continuous_lift
-@[deprecated (since := "2025-05-15")] alias lift_mk := T2Quotient.lift_mk
-@[deprecated (since := "2025-05-15")] alias unique_lift := T2Quotient.unique_lift
-
-end t2Quotient
 end
 
 variable {Z : Type*} [TopologicalSpace Y] [TopologicalSpace Z]

--- a/Mathlib/Topology/Separation/Hausdorff.lean
+++ b/Mathlib/Topology/Separation/Hausdorff.lean
@@ -46,7 +46,7 @@ occasionally the literature swaps definitions for e.g. T₃ and regular.
   it is a `TotallySeparatedSpace`.
 * `loc_compact_t2_tot_disc_iff_tot_sep`: A locally compact T₂ space is totally disconnected iff
   it is totally separated.
-* `t2Quotient`: the largest T2 quotient of a given topological space.
+* `T2Quotient`: the largest T2 quotient of a given topological space.
 
 If the space is also compact:
 
@@ -397,44 +397,46 @@ def t2Setoid : Setoid X := sInf {s | T2Space (Quotient s)}
 
 /-- The largest T2 quotient of a topological space. This construction is left-adjoint to the
 inclusion of T2 spaces into all topological spaces. -/
-def t2Quotient := Quotient (t2Setoid X)
+def T2Quotient := Quotient (t2Setoid X)
 
-namespace t2Quotient
+@[deprecated (since := "2025-05-15")] alias t2Quotient := T2Quotient
+
+namespace T2Quotient
 variable {X}
 
-instance : TopologicalSpace (t2Quotient X) :=
+instance : TopologicalSpace (T2Quotient X) :=
   inferInstanceAs <| TopologicalSpace (Quotient _)
 
 /-- The map from a topological space to its largest T2 quotient. -/
-def mk : X → t2Quotient X := Quotient.mk (t2Setoid X)
+def mk : X → T2Quotient X := Quotient.mk (t2Setoid X)
 
 lemma mk_eq {x y : X} : mk x = mk y ↔ ∀ s : Setoid X, T2Space (Quotient s) → s x y :=
   Setoid.quotient_mk_sInf_eq
 
 variable (X)
 
-lemma surjective_mk : Surjective (mk : X → t2Quotient X) := Quotient.mk_surjective
+lemma surjective_mk : Surjective (mk : X → T2Quotient X) := Quotient.mk_surjective
 
-lemma continuous_mk : Continuous (mk : X → t2Quotient X) :=
+lemma continuous_mk : Continuous (mk : X → T2Quotient X) :=
   continuous_quotient_mk'
 
 variable {X}
 
 @[elab_as_elim]
-protected lemma inductionOn {motive : t2Quotient X → Prop} (q : t2Quotient X)
-    (h : ∀ x, motive (t2Quotient.mk x)) : motive q := Quotient.inductionOn q h
+protected lemma inductionOn {motive : T2Quotient X → Prop} (q : T2Quotient X)
+    (h : ∀ x, motive (T2Quotient.mk x)) : motive q := Quotient.inductionOn q h
 
 @[elab_as_elim]
-protected lemma inductionOn₂ [TopologicalSpace Y] {motive : t2Quotient X → t2Quotient Y → Prop}
-    (q : t2Quotient X) (q' : t2Quotient Y) (h : ∀ x y, motive (mk x) (mk y)) : motive q q' :=
+protected lemma inductionOn₂ [TopologicalSpace Y] {motive : T2Quotient X → T2Quotient Y → Prop}
+    (q : T2Quotient X) (q' : T2Quotient Y) (h : ∀ x y, motive (mk x) (mk y)) : motive q q' :=
   Quotient.inductionOn₂ q q' h
 
 /-- The largest T2 quotient of a topological space is indeed T2. -/
-instance : T2Space (t2Quotient X) := by
+instance : T2Space (T2Quotient X) := by
   rw [t2Space_iff]
-  rintro ⟨x⟩ ⟨y⟩ (h : ¬ t2Quotient.mk x = t2Quotient.mk y)
+  rintro ⟨x⟩ ⟨y⟩ (h : ¬ T2Quotient.mk x = T2Quotient.mk y)
   obtain ⟨s, hs, hsxy⟩ : ∃ s, T2Space (Quotient s) ∧ Quotient.mk s x ≠ Quotient.mk s y := by
-    simpa [t2Quotient.mk_eq] using h
+    simpa [T2Quotient.mk_eq] using h
   exact separated_by_continuous (continuous_map_sInf (by exact hs)) hsxy
 
 lemma compatible {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] [T2Space Y]
@@ -445,27 +447,45 @@ lemma compatible {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] [T2Spac
     (Setoid.ker_lift_injective _) (hf.quotient_lift fun _ _ ↦ id)
 
 /-- The universal property of the largest T2 quotient of a topological space `X`: any continuous
-map from `X` to a T2 space `Y` uniquely factors through `t2Quotient X`. This declaration builds the
-factored map. Its continuity is `t2Quotient.continuous_lift`, the fact that it indeed factors the
-original map is `t2Quotient.lift_mk` and uniqueness is `t2Quotient.unique_lift`. -/
+map from `X` to a T2 space `Y` uniquely factors through `T2Quotient X`. This declaration builds the
+factored map. Its continuity is `T2Quotient.continuous_lift`, the fact that it indeed factors the
+original map is `T2Quotient.lift_mk` and uniqueness is `T2Quotient.unique_lift`. -/
 def lift {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] [T2Space Y]
-    {f : X → Y} (hf : Continuous f) : t2Quotient X → Y :=
-  Quotient.lift f (t2Quotient.compatible hf)
+    {f : X → Y} (hf : Continuous f) : T2Quotient X → Y :=
+  Quotient.lift f (T2Quotient.compatible hf)
 
 lemma continuous_lift {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] [T2Space Y]
-    {f : X → Y} (hf : Continuous f) : Continuous (t2Quotient.lift hf) :=
+    {f : X → Y} (hf : Continuous f) : Continuous (T2Quotient.lift hf) :=
   continuous_coinduced_dom.mpr hf
 
 @[simp]
 lemma lift_mk {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] [T2Space Y]
     {f : X → Y} (hf : Continuous f) (x : X) : lift hf (mk x) = f x :=
-  Quotient.lift_mk (s := t2Setoid X) f (t2Quotient.compatible hf) x
+  Quotient.lift_mk (s := t2Setoid X) f (T2Quotient.compatible hf) x
 
 lemma unique_lift {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] [T2Space Y]
-    {f : X → Y} (hf : Continuous f) {g : t2Quotient X → Y} (hfg : g ∘ mk = f) :
+    {f : X → Y} (hf : Continuous f) {g : T2Quotient X → Y} (hfg : g ∘ mk = f) :
     g = lift hf := by
   apply surjective_mk X |>.right_cancellable |>.mp <| funext _
   simp [← hfg]
+
+end T2Quotient
+
+namespace t2Quotient
+
+@[deprecated (since := "2025-05-15")] alias instTopologicalSpace := T2Quotient.instTopologicalSpace
+@[deprecated (since := "2025-05-15")] alias mk := T2Quotient.mk
+@[deprecated (since := "2025-05-15")] alias mk_eq := T2Quotient.mk_eq
+@[deprecated (since := "2025-05-15")] alias surjective_mk := T2Quotient.surjective_mk
+@[deprecated (since := "2025-05-15")] alias continuous_mk := T2Quotient.continuous_mk
+@[deprecated (since := "2025-05-15")] protected alias inductionOn := T2Quotient.inductionOn
+@[deprecated (since := "2025-05-15")] protected alias inductionOn₂ := T2Quotient.inductionOn₂
+@[deprecated (since := "2025-05-15")] alias instT2Space := T2Quotient.instT2Space
+@[deprecated (since := "2025-05-15")] alias compatible := T2Quotient.compatible
+@[deprecated (since := "2025-05-15")] alias lift := T2Quotient.lift
+@[deprecated (since := "2025-05-15")] alias continuous_lift := T2Quotient.continuous_lift
+@[deprecated (since := "2025-05-15")] alias lift_mk := T2Quotient.lift_mk
+@[deprecated (since := "2025-05-15")] alias unique_lift := T2Quotient.unique_lift
 
 end t2Quotient
 end

--- a/Mathlib/Topology/StoneCech.lean
+++ b/Mathlib/Topology/StoneCech.lean
@@ -30,7 +30,7 @@ case is different because the equivalence relation on spaces of ultrafilters des
 by Stekelenburg causes issues with universes since it involves a condition
 on all compact Hausdorff spaces. We replace it by a two steps construction.
 The first step called `PreStoneCech` guarantees the expected universal property but
-not the Hausdorff condition. We then define `StoneCech α` as `t2Quotient (PreStoneCech α)`.
+not the Hausdorff condition. We then define `StoneCech α` as `T2Quotient (PreStoneCech α)`.
 -/
 
 
@@ -310,15 +310,15 @@ variable (α : Type u) [TopologicalSpace α]
 
 /-- The Stone-Čech compactification of a topological space. -/
 def StoneCech : Type u :=
-  t2Quotient (PreStoneCech α)
+  T2Quotient (PreStoneCech α)
 
 variable {α}
 
 instance : TopologicalSpace (StoneCech α) :=
-  inferInstanceAs <| TopologicalSpace <| t2Quotient _
+  inferInstanceAs <| TopologicalSpace <| T2Quotient _
 
 instance : T2Space (StoneCech α) :=
-  inferInstanceAs <| T2Space <| t2Quotient _
+  inferInstanceAs <| T2Space <| T2Quotient _
 
 instance : CompactSpace (StoneCech α) :=
   Quot.compactSpace
@@ -328,16 +328,16 @@ instance [Inhabited α] : Inhabited (StoneCech α) :=
 
 /-- The natural map from α to its Stone-Čech compactification. -/
 def stoneCechUnit (x : α) : StoneCech α :=
-  t2Quotient.mk (preStoneCechUnit x)
+  T2Quotient.mk (preStoneCechUnit x)
 
 theorem continuous_stoneCechUnit : Continuous (stoneCechUnit : α → StoneCech α) :=
-  (t2Quotient.continuous_mk _).comp continuous_preStoneCechUnit
+  (T2Quotient.continuous_mk _).comp continuous_preStoneCechUnit
 
 /-- The image of `stoneCechUnit` is dense. (But `stoneCechUnit` need
   not be an embedding, for example if the original space is not Hausdorff.) -/
 theorem denseRange_stoneCechUnit : DenseRange (stoneCechUnit : α → StoneCech α) := by
-  unfold stoneCechUnit t2Quotient.mk
-  have : Function.Surjective (t2Quotient.mk : PreStoneCech α → StoneCech α) := by
+  unfold stoneCechUnit T2Quotient.mk
+  have : Function.Surjective (T2Quotient.mk : PreStoneCech α → StoneCech α) := by
     exact Quot.mk_surjective
   exact this.denseRange.comp denseRange_preStoneCechUnit continuous_coinduced_rng
 
@@ -358,11 +358,11 @@ variable [CompactSpace β]
   Hausdorff space `β` to the Stone-Čech compactification of `α`.
   This extension implements the universal property of this compactification. -/
 def stoneCechExtend : StoneCech α → β :=
-  t2Quotient.lift (continuous_preStoneCechExtend hg)
+  T2Quotient.lift (continuous_preStoneCechExtend hg)
 
 theorem stoneCechExtend_extends : stoneCechExtend hg ∘ stoneCechUnit = g := by
   ext x
-  rw [stoneCechExtend, Function.comp_apply, stoneCechUnit, t2Quotient.lift_mk]
+  rw [stoneCechExtend, Function.comp_apply, stoneCechUnit, T2Quotient.lift_mk]
   apply congrFun (preStoneCechExtend_extends hg)
 
 theorem continuous_stoneCechExtend : Continuous (stoneCechExtend hg) :=


### PR DESCRIPTION
`t2Quotient X` is a type so should be capitalized.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
