### PR TITLE
[Merged by Bors] - feat: if `p = a * b` is irreducible, then `a = 1` or `b = 1`

### DIFF
--- a/Mathlib/Algebra/Group/Irreducible/Defs.lean
+++ b/Mathlib/Algebra/Group/Irreducible/Defs.lean
@@ -70,8 +70,7 @@ lemma irreducible_or_factor (hp : ¬IsUnit p) :
   simpa [irreducible_iff, hp, and_rotate] using em (∀ a b, p = a * b → IsUnit a ∨ IsUnit b)
 
 @[to_additive]
-lemma Irreducible.eq_one_or_eq_one [Subsingleton Mˣ] (hp : Irreducible p) (hab : p = a * b) :
-    a = 1 ∨ b = 1 := by
-  simpa using hp.isUnit_or_isUnit hab
+lemma Irreducible.eq_one_or_eq_one [Subsingleton Mˣ] (hab : Irreducible (a * b)) :
+    a = 1 ∨ b = 1 := by simpa using hab.isUnit_or_isUnit rfl
 
 end Monoid

--- a/Mathlib/Algebra/Group/Irreducible/Defs.lean
+++ b/Mathlib/Algebra/Group/Irreducible/Defs.lean
@@ -30,7 +30,7 @@ structure AddIrreducible [AddMonoid M] (p : M) : Prop where
   isAddUnit_or_isAddUnit ⦃a b⦄ : p = a + b → IsAddUnit a ∨ IsAddUnit b
 
 section Monoid
-variable [Monoid M] {p q x y : M}
+variable [Monoid M] {p q a b : M}
 
 /-- `Irreducible p` states that `p` is non-unit and only factors into units.
 
@@ -41,7 +41,7 @@ structure Irreducible (p : M) : Prop where
   /-- An irreducible element is not a unit. -/
   not_isUnit : ¬IsUnit p
   /-- If an irreducible element factors, then one factor is a unit. -/
-  isUnit_or_isUnit ⦃a b⦄ : p = a * b → IsUnit a ∨ IsUnit b
+  isUnit_or_isUnit ⦃a b : M⦄ : p = a * b → IsUnit a ∨ IsUnit b
 
 namespace Irreducible
 
@@ -62,11 +62,16 @@ lemma not_irreducible_one : ¬Irreducible (1 : M) := by simp [irreducible_iff]
 lemma Irreducible.ne_one (hp : Irreducible p) : p ≠ 1 := by rintro rfl; exact not_irreducible_one hp
 
 @[to_additive]
-lemma of_irreducible_mul : Irreducible (x * y) → IsUnit x ∨ IsUnit y | ⟨_, h⟩ => h rfl
+lemma of_irreducible_mul : Irreducible (a * b) → IsUnit a ∨ IsUnit b | ⟨_, h⟩ => h rfl
 
 @[to_additive]
 lemma irreducible_or_factor (hp : ¬IsUnit p) :
     Irreducible p ∨ ∃ a b, ¬IsUnit a ∧ ¬IsUnit b ∧ p = a * b := by
   simpa [irreducible_iff, hp, and_rotate] using em (∀ a b, p = a * b → IsUnit a ∨ IsUnit b)
+
+@[to_additive]
+lemma Irreducible.eq_one_or_eq_one [Subsingleton Mˣ] (hp : Irreducible p) (hab : p = a * b) :
+    a = 1 ∨ b = 1 := by
+  simpa using hp.isUnit_or_isUnit hab
 
 end Monoid


### PR DESCRIPTION
From Toric


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
