### PR TITLE
[Merged by Bors] - feat: `selfAdjoint.continuous_expUnitary`

### DIFF
--- a/Mathlib/Analysis/CStarAlgebra/Exponential.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Exponential.lean
@@ -36,6 +36,16 @@ noncomputable def selfAdjoint.expUnitary (a : selfAdjoint A) : unitary A :=
 
 open selfAdjoint
 
+@[simp]
+lemma selfAdjoint.expUnitary_zero : expUnitary (0 : selfAdjoint A) = 1 := by
+  ext
+  simp
+
+@[fun_prop]
+lemma selfAdjoint.continuous_expUnitary : Continuous (expUnitary : selfAdjoint A → unitary A) := by
+  simp only [continuous_induced_rng, Function.comp_def, selfAdjoint.expUnitary_coe]
+  fun_prop
+
 theorem Commute.expUnitary_add {a b : selfAdjoint A} (h : Commute (a : A) (b : A)) :
     expUnitary (a + b) = expUnitary a * expUnitary b := by
   ext

--- a/Mathlib/Analysis/Normed/Algebra/Exponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Exponential.lean
@@ -428,7 +428,7 @@ theorem exp_hasFPowerSeriesOnBall : HasFPowerSeriesOnBall (exp 𝕂) (expSeries 
 theorem exp_hasFPowerSeriesAt_zero : HasFPowerSeriesAt (exp 𝕂) (expSeries 𝕂 𝔸) 0 :=
   exp_hasFPowerSeriesOnBall.hasFPowerSeriesAt
 
-@[continuity]
+@[continuity, fun_prop]
 theorem exp_continuous : Continuous (exp 𝕂 : 𝔸 → 𝔸) := by
   rw [continuous_iff_continuousOn_univ, ← Metric.eball_top_eq_univ (0 : 𝔸), ←
     expSeries_radius_eq_top 𝕂 𝔸]


### PR DESCRIPTION
The natural map (`selfAdjoint.expUnitary`)  from `selfAdjoint A` to `unitary A` is continuous and sends `0` to `1`.

We also mark `NormedSpace.exp_continuous` with `fun_prop`.


---

from [LeanOA](https://github.com/j-loreaux/LeanOA)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
