### PR TITLE
[Merged by Bors] - chore(Algebra/GroupWithZero): `assert_not_exists Ring`

### DIFF
--- a/Mathlib/Algebra/GroupWithZero/Action/Center.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Center.lean
@@ -10,6 +10,8 @@ import Mathlib.GroupTheory.Subgroup.Center
 # The center of a group with zero
 -/
 
+assert_not_exists Ring
+
 /-- For a group with zero, the center of the units is the same as the units of the center. -/
 @[simps! apply_val_coe symm_apply_coe_val]
 def Subgroup.centerUnitsEquivUnitsCenter (G₀ : Type*) [GroupWithZero G₀] :

--- a/Mathlib/Algebra/GroupWithZero/Action/Opposite.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Opposite.lean
@@ -27,6 +27,8 @@ With `open scoped RightActions`, this provides:
 * `p <+ᵥ v` as an alias for `AddOpposite.op v +ᵥ p`
 -/
 
+assert_not_exists Ring
+
 variable {M α : Type*}
 
 /-! ### Actions _on_ the opposite type

--- a/Mathlib/Algebra/GroupWithZero/Action/Pi.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Pi.lean
@@ -20,6 +20,7 @@ This file defines instances for `MulActionWithZero` and related structures on `P
 * `Algebra.GroupWithZero.Action.Units`
 -/
 
+assert_not_exists Ring
 
 universe u v
 

--- a/Mathlib/Algebra/GroupWithZero/Action/Pointwise/Finset.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Pointwise/Finset.lean
@@ -15,8 +15,7 @@ import Mathlib.Algebra.GroupWithZero.Pointwise.Finset
 This file proves properties of pointwise operations of finsets in a group with zero.
 -/
 
--- TODO
--- assert_not_exists Ring
+assert_not_exists Ring
 
 open scoped Pointwise
 

--- a/Mathlib/Algebra/GroupWithZero/Action/Units.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Units.lean
@@ -24,6 +24,8 @@ admits a `MulDistribMulAction G Mˣ` structure, again with the obvious definitio
 * `Algebra.GroupWithZero.Action.Prod`
 -/
 
+assert_not_exists Ring
+
 variable {G₀ G M α β : Type*}
 
 namespace Units

--- a/Mathlib/Algebra/GroupWithZero/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Basic.lean
@@ -34,7 +34,7 @@ and require `0⁻¹ = 0`.
 
 -/
 
-assert_not_exists DenselyOrdered
+assert_not_exists DenselyOrdered Ring
 
 open Function
 

--- a/Mathlib/Algebra/GroupWithZero/Commute.lean
+++ b/Mathlib/Algebra/GroupWithZero/Commute.lean
@@ -12,7 +12,7 @@ import Mathlib.Tactic.Nontriviality
 
 -/
 
-assert_not_exists DenselyOrdered
+assert_not_exists DenselyOrdered Ring
 
 variable {M₀ G₀ : Type*}
 variable [MonoidWithZero M₀]

--- a/Mathlib/Algebra/GroupWithZero/Conj.lean
+++ b/Mathlib/Algebra/GroupWithZero/Conj.lean
@@ -10,7 +10,7 @@ import Mathlib.Algebra.GroupWithZero.Units.Basic
 # Conjugacy in a group with zero
 -/
 
-assert_not_exists Multiset
+assert_not_exists Multiset Ring
 -- TODO
 -- assert_not_exists DenselyOrdered
 

--- a/Mathlib/Algebra/GroupWithZero/Defs.lean
+++ b/Mathlib/Algebra/GroupWithZero/Defs.lean
@@ -20,7 +20,7 @@ members.
 * `CommGroupWithZero`
 -/
 
-assert_not_exists DenselyOrdered
+assert_not_exists DenselyOrdered Ring
 
 universe u
 

--- a/Mathlib/Algebra/GroupWithZero/Divisibility.lean
+++ b/Mathlib/Algebra/GroupWithZero/Divisibility.lean
@@ -15,7 +15,7 @@ Lemmas about divisibility in groups and monoids with zero.
 
 -/
 
-assert_not_exists DenselyOrdered
+assert_not_exists DenselyOrdered Ring
 
 variable {α : Type*}
 

--- a/Mathlib/Algebra/GroupWithZero/Equiv.lean
+++ b/Mathlib/Algebra/GroupWithZero/Equiv.lean
@@ -8,6 +8,8 @@ import Mathlib.Algebra.GroupWithZero.Hom
 
 /-! # Isomorphisms of monoids with zero -/
 
+assert_not_exists Ring
+
 namespace MulEquivClass
 variable {F α β : Type*} [EquivLike F α β]
 

--- a/Mathlib/Algebra/GroupWithZero/Hom.lean
+++ b/Mathlib/Algebra/GroupWithZero/Hom.lean
@@ -31,7 +31,7 @@ can be inferred from the type it is faster to use this method than to use type c
 monoid homomorphism
 -/
 
-assert_not_exists DenselyOrdered
+assert_not_exists DenselyOrdered Ring
 
 open Function
 

--- a/Mathlib/Algebra/GroupWithZero/Indicator.lean
+++ b/Mathlib/Algebra/GroupWithZero/Indicator.lean
@@ -10,6 +10,8 @@ import Mathlib.Algebra.GroupWithZero.Basic
 # Indicator functions and support of a function in groups with zero
 -/
 
+assert_not_exists Ring
+
 open Set
 
 variable {ι κ G₀ M₀ R : Type*}

--- a/Mathlib/Algebra/GroupWithZero/InjSurj.lean
+++ b/Mathlib/Algebra/GroupWithZero/InjSurj.lean
@@ -11,7 +11,7 @@ import Mathlib.Algebra.GroupWithZero.NeZero
 
 -/
 
-assert_not_exists DenselyOrdered
+assert_not_exists DenselyOrdered Ring
 
 open Function
 

--- a/Mathlib/Algebra/GroupWithZero/Int.lean
+++ b/Mathlib/Algebra/GroupWithZero/Int.lean
@@ -10,6 +10,8 @@ import Mathlib.Algebra.GroupWithZero.WithZero
 # Lemmas about `ℤₘ₀`.
 -/
 
+assert_not_exists Ring
+
 local notation "ℤₘ₀" => WithZero (Multiplicative ℤ)
 
 namespace WithZero

--- a/Mathlib/Algebra/GroupWithZero/Invertible.lean
+++ b/Mathlib/Algebra/GroupWithZero/Invertible.lean
@@ -12,7 +12,7 @@ import Mathlib.Algebra.GroupWithZero.Units.Basic
 We intentionally keep imports minimal here as this file is used by `Mathlib.Tactic.NormNum`.
 -/
 
-assert_not_exists DenselyOrdered
+assert_not_exists DenselyOrdered Ring
 
 universe u
 

--- a/Mathlib/Algebra/GroupWithZero/NeZero.lean
+++ b/Mathlib/Algebra/GroupWithZero/NeZero.lean
@@ -13,7 +13,7 @@ This file exists to minimize the dependencies of `Mathlib.Algebra.GroupWithZero.
 which is a part of the algebraic hierarchy used by basic tactics.
 -/
 
-assert_not_exists DenselyOrdered
+assert_not_exists DenselyOrdered Ring
 
 universe u
 

--- a/Mathlib/Algebra/GroupWithZero/Pi.lean
+++ b/Mathlib/Algebra/GroupWithZero/Pi.lean
@@ -13,7 +13,7 @@ import Mathlib.Algebra.Group.Pi.Basic
 This file defines monoid with zero, group with zero, and related structure instances for pi types.
 -/
 
-assert_not_exists DenselyOrdered
+assert_not_exists DenselyOrdered Ring
 
 open Function Pi
 

--- a/Mathlib/Algebra/GroupWithZero/Pointwise/Finset.lean
+++ b/Mathlib/Algebra/GroupWithZero/Pointwise/Finset.lean
@@ -12,9 +12,7 @@ import Mathlib.Algebra.Group.Pointwise.Finset.Basic
 This file proves properties of pointwise operations of finsets in a group with zero.
 -/
 
--- TODO
--- assert_not_exists Ring
-assert_not_exists MulAction
+assert_not_exists MulAction Ring
 
 open scoped Pointwise
 

--- a/Mathlib/Algebra/GroupWithZero/Prod.lean
+++ b/Mathlib/Algebra/GroupWithZero/Prod.lean
@@ -18,7 +18,7 @@ In this file we define `MonoidWithZero`, `GroupWithZero`, etc... instances for `
 * `divMonoidWithZeroHom`: Division bundled as a monoid with zero homomorphism.
 -/
 
-assert_not_exists DenselyOrdered
+assert_not_exists DenselyOrdered Ring
 
 variable {M₀ N₀ : Type*}
 

--- a/Mathlib/Algebra/GroupWithZero/Semiconj.lean
+++ b/Mathlib/Algebra/GroupWithZero/Semiconj.lean
@@ -11,7 +11,7 @@ import Mathlib.Algebra.Group.Semiconj.Units
 
 -/
 
-assert_not_exists DenselyOrdered
+assert_not_exists DenselyOrdered Ring
 
 variable {G₀ : Type*}
 

--- a/Mathlib/Algebra/GroupWithZero/Submonoid/Primal.lean
+++ b/Mathlib/Algebra/GroupWithZero/Submonoid/Primal.lean
@@ -10,7 +10,7 @@ import Mathlib.Algebra.GroupWithZero.Divisibility
 # Submonoid of primal elements
 -/
 
-assert_not_exists RelIso
+assert_not_exists RelIso Ring
 
 /-- The submonoid of primal elements in a cancellative commutative monoid with zero. -/
 def Submonoid.isPrimal (M₀ : Type*) [CancelCommMonoidWithZero M₀] : Submonoid M₀ where

--- a/Mathlib/Algebra/GroupWithZero/ULift.lean
+++ b/Mathlib/Algebra/GroupWithZero/ULift.lean
@@ -14,6 +14,7 @@ This file defines instances for group and monoid with zero and related structure
 (Recall `ULift α` is just a "copy" of a type `α` in a higher universe.)
 -/
 
+assert_not_exists Ring
 
 universe u
 

--- a/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
@@ -19,9 +19,7 @@ We also define `Ring.inverse`, a globally defined function on any ring
 (in fact any `MonoidWithZero`), which inverts units and sends non-units to zero.
 -/
 
--- Guard against import creep
-assert_not_exists DenselyOrdered Equiv Subtype.restrict Multiplicative
-
+assert_not_exists DenselyOrdered Equiv Subtype.restrict Multiplicative Ring
 
 variable {α M₀ G₀ : Type*}
 variable [MonoidWithZero M₀]

--- a/Mathlib/Algebra/GroupWithZero/Units/Equiv.lean
+++ b/Mathlib/Algebra/GroupWithZero/Units/Equiv.lean
@@ -10,7 +10,7 @@ import Mathlib.Algebra.GroupWithZero.Units.Basic
 # Multiplication by a nonzero element in a `GroupWithZero` is a permutation.
 -/
 
-assert_not_exists DenselyOrdered
+assert_not_exists DenselyOrdered Ring
 
 variable {G₀ : Type*}
 

--- a/Mathlib/Algebra/GroupWithZero/Units/Lemmas.lean
+++ b/Mathlib/Algebra/GroupWithZero/Units/Lemmas.lean
@@ -12,7 +12,7 @@ import Mathlib.Algebra.GroupWithZero.Hom
 
 -/
 
-assert_not_exists DenselyOrdered MulAction
+assert_not_exists DenselyOrdered MulAction Ring
 
 variable {M M₀ G₀ M₀' G₀' F F' : Type*}
 variable [MonoidWithZero M₀]

--- a/Mathlib/Algebra/GroupWithZero/WithZero.lean
+++ b/Mathlib/Algebra/GroupWithZero/WithZero.lean
@@ -22,7 +22,7 @@ This file proves that one can adjoin a new zero element to a group and get a gro
   a monoid homomorphism `f : α →* β`.
 -/
 
-assert_not_exists DenselyOrdered
+assert_not_exists DenselyOrdered Ring
 
 namespace WithZero
 variable {α β γ : Type*}


### PR DESCRIPTION
Only a few files importing `Ring` remain under `Algebra.GroupWithZero`, such as `Algebra.GroupWithZero.Conj`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
