### PR TITLE
[Merged by Bors] - feat(Data/Nat/Sqrt): Added lemma `Nat.add_one_sqrt_le_of_ne_zero`

### DIFF
--- a/Mathlib/Data/Nat/Sqrt.lean
+++ b/Mathlib/Data/Nat/Sqrt.lean
@@ -178,7 +178,7 @@ lemma sqrt_succ_le_succ_sqrt (n : ℕ) : sqrt n.succ ≤ n.sqrt.succ :=
   succ_le_succ <| le_trans (sqrt_le_add n) <| Nat.add_le_add_right
     (by refine add_le_add (Nat.mul_le_mul_right _ ?_) ?_ <;> exact Nat.le_add_right _ 2) _
 
-lemma add_one_sqrt_le_of_pos {n : ℕ} (hn : 1 ≤ n) : (n + 1).sqrt ≤ n := by
+lemma add_one_sqrt_le_of_pos {n : ℕ} (hn : 0 < n) : (n + 1).sqrt ≤ n := by
   induction n, hn using le_induction
   case base => decide
   case succ n hn ih =>

--- a/Mathlib/Data/Nat/Sqrt.lean
+++ b/Mathlib/Data/Nat/Sqrt.lean
@@ -178,6 +178,13 @@ lemma sqrt_succ_le_succ_sqrt (n : ℕ) : sqrt n.succ ≤ n.sqrt.succ :=
   succ_le_succ <| le_trans (sqrt_le_add n) <| Nat.add_le_add_right
     (by refine add_le_add (Nat.mul_le_mul_right _ ?_) ?_ <;> exact Nat.le_add_right _ 2) _
 
+lemma succ_sqrt_le_of_pos {n : ℕ} (hn : 1 ≤ n) : n.succ.sqrt ≤ n := by
+  induction n, hn using le_induction
+  case base => decide
+  case succ n hn ih =>
+    apply le_trans n.succ.sqrt_succ_le_succ_sqrt
+    simp only [ih, succ_eq_add_one, Nat.add_le_add_iff_right]
+
 lemma exists_mul_self (x : ℕ) : (∃ n, n * n = x) ↔ sqrt x * sqrt x = x :=
   ⟨fun ⟨n, hn⟩ ↦ by rw [← hn, sqrt_eq], fun h ↦ ⟨sqrt x, h⟩⟩
 

--- a/Mathlib/Data/Nat/Sqrt.lean
+++ b/Mathlib/Data/Nat/Sqrt.lean
@@ -178,7 +178,7 @@ lemma sqrt_succ_le_succ_sqrt (n : ℕ) : sqrt n.succ ≤ n.sqrt.succ :=
   succ_le_succ <| le_trans (sqrt_le_add n) <| Nat.add_le_add_right
     (by refine add_le_add (Nat.mul_le_mul_right _ ?_) ?_ <;> exact Nat.le_add_right _ 2) _
 
-lemma succ_sqrt_le_of_pos {n : ℕ} (hn : 1 ≤ n) : n.succ.sqrt ≤ n := by
+lemma add_one_sqrt_le_of_pos {n : ℕ} (hn : 1 ≤ n) : (n + 1).sqrt ≤ n := by
   induction n, hn using le_induction
   case base => decide
   case succ n hn ih =>

--- a/Mathlib/Data/Nat/Sqrt.lean
+++ b/Mathlib/Data/Nat/Sqrt.lean
@@ -178,13 +178,9 @@ lemma sqrt_succ_le_succ_sqrt (n : ℕ) : sqrt n.succ ≤ n.sqrt.succ :=
   succ_le_succ <| le_trans (sqrt_le_add n) <| Nat.add_le_add_right
     (by refine add_le_add (Nat.mul_le_mul_right _ ?_) ?_ <;> exact Nat.le_add_right _ 2) _
 
-lemma add_one_sqrt_le_of_ne_zero {n : ℕ} (hn : n ≠ 0) : (n + 1).sqrt ≤ n := by
-  induction n, one_le_iff_ne_zero.mpr hn using le_induction
-  case base => decide
-  case succ n hn ih =>
-    apply le_trans n.succ.sqrt_succ_le_succ_sqrt
-    simp only [succ_eq_add_one, Nat.add_le_add_iff_right]
-    apply ih; omega
+lemma add_one_sqrt_le_of_ne_zero {n : ℕ} (hn : n ≠ 0) : (n + 1).sqrt ≤ n :=
+  le_induction le_rfl (fun n hn ih ↦ le_trans n.succ.sqrt_succ_le_succ_sqrt
+    <| by simp [Nat.add_le_add_iff_right, ih]) n (one_le_iff_ne_zero.mpr hn)
 
 lemma exists_mul_self (x : ℕ) : (∃ n, n * n = x) ↔ sqrt x * sqrt x = x :=
   ⟨fun ⟨n, hn⟩ ↦ by rw [← hn, sqrt_eq], fun h ↦ ⟨sqrt x, h⟩⟩

--- a/Mathlib/Data/Nat/Sqrt.lean
+++ b/Mathlib/Data/Nat/Sqrt.lean
@@ -179,8 +179,8 @@ lemma sqrt_succ_le_succ_sqrt (n : ℕ) : sqrt n.succ ≤ n.sqrt.succ :=
     (by refine add_le_add (Nat.mul_le_mul_right _ ?_) ?_ <;> exact Nat.le_add_right _ 2) _
 
 lemma add_one_sqrt_le_of_ne_zero {n : ℕ} (hn : n ≠ 0) : (n + 1).sqrt ≤ n :=
-  le_induction le_rfl (fun n hn ih ↦ le_trans n.succ.sqrt_succ_le_succ_sqrt
-    <| by simp [Nat.add_le_add_iff_right, ih]) n (one_le_iff_ne_zero.mpr hn)
+  le_induction le_rfl (fun n _ ih ↦ le_trans n.succ.sqrt_succ_le_succ_sqrt (succ_le_succ ih)) n
+    (Nat.pos_of_ne_zero hn)
 
 lemma exists_mul_self (x : ℕ) : (∃ n, n * n = x) ↔ sqrt x * sqrt x = x :=
   ⟨fun ⟨n, hn⟩ ↦ by rw [← hn, sqrt_eq], fun h ↦ ⟨sqrt x, h⟩⟩

--- a/Mathlib/Data/Nat/Sqrt.lean
+++ b/Mathlib/Data/Nat/Sqrt.lean
@@ -178,12 +178,13 @@ lemma sqrt_succ_le_succ_sqrt (n : ℕ) : sqrt n.succ ≤ n.sqrt.succ :=
   succ_le_succ <| le_trans (sqrt_le_add n) <| Nat.add_le_add_right
     (by refine add_le_add (Nat.mul_le_mul_right _ ?_) ?_ <;> exact Nat.le_add_right _ 2) _
 
-lemma add_one_sqrt_le_of_pos {n : ℕ} (hn : 0 < n) : (n + 1).sqrt ≤ n := by
-  induction n, hn using le_induction
+lemma add_one_sqrt_le_of_pos {n : ℕ} (hn : n ≠ 0) : (n + 1).sqrt ≤ n := by
+  induction n, (by omega : 1 ≤ n) using le_induction
   case base => decide
   case succ n hn ih =>
     apply le_trans n.succ.sqrt_succ_le_succ_sqrt
-    simp only [ih, succ_eq_add_one, Nat.add_le_add_iff_right]
+    simp only [succ_eq_add_one, Nat.add_le_add_iff_right]
+    apply ih; omega
 
 lemma exists_mul_self (x : ℕ) : (∃ n, n * n = x) ↔ sqrt x * sqrt x = x :=
   ⟨fun ⟨n, hn⟩ ↦ by rw [← hn, sqrt_eq], fun h ↦ ⟨sqrt x, h⟩⟩

--- a/Mathlib/Data/Nat/Sqrt.lean
+++ b/Mathlib/Data/Nat/Sqrt.lean
@@ -178,8 +178,8 @@ lemma sqrt_succ_le_succ_sqrt (n : ℕ) : sqrt n.succ ≤ n.sqrt.succ :=
   succ_le_succ <| le_trans (sqrt_le_add n) <| Nat.add_le_add_right
     (by refine add_le_add (Nat.mul_le_mul_right _ ?_) ?_ <;> exact Nat.le_add_right _ 2) _
 
-lemma add_one_sqrt_le_of_pos {n : ℕ} (hn : n ≠ 0) : (n + 1).sqrt ≤ n := by
-  induction n, (by omega : 1 ≤ n) using le_induction
+lemma add_one_sqrt_le_of_ne_zero {n : ℕ} (hn : n ≠ 0) : (n + 1).sqrt ≤ n := by
+  induction n, one_le_iff_ne_zero.mpr hn using le_induction
   case base => decide
   case succ n hn ih =>
     apply le_trans n.succ.sqrt_succ_le_succ_sqrt


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

This commit proves a single lemma `Nat.add_one_sqrt_le_of_ne_zero`.
```lean
lemma add_one_sqrt_le_of_ne_zero {n : ℕ} (hn : n ≠ 0) : (n + 1).sqrt ≤ n
```

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
