### PR TITLE
feat(Analysis/Calculus/VectorField): Implement product rule for liebrackets

### DIFF
--- a/Mathlib/Analysis/Calculus/VectorField.lean
+++ b/Mathlib/Analysis/Calculus/VectorField.lean
@@ -107,6 +107,32 @@ lemma lieBracket_smul_right {c : 𝕜} (hW : DifferentiableAt 𝕜 W x) :
   simp only [← differentiableWithinAt_univ, ← lieBracketWithin_univ] at hW ⊢
   exact lieBracketWithin_smul_right hW uniqueDiffWithinAt_univ
 
+/--
+Product rule for Lie Brackets: given two vector fields `V W : E → E` and a function `f : E → 𝕜`,
+we have `[V, f • W] = (df V) • W + f • [V, W]`
+-/
+lemma lieBracketWithin_fmul_right {f : E → 𝕜}
+    (hf : DifferentiableWithinAt 𝕜 f s x)
+    (hW : DifferentiableWithinAt 𝕜 W s x)
+    (hs: UniqueDiffWithinAt 𝕜 s x) :
+    lieBracketWithin 𝕜 V (fun y => f y • W y) s x =
+      (fderivWithin 𝕜 f s x) (V x) • (W x)  + (f • lieBracketWithin 𝕜 V W s) x := by
+  simp [lieBracketWithin, fderivWithin_smul hs hf hW, smul_sub, add_comm, add_sub_assoc]
+
+/--
+Product rule for Lie Brackets: given two vector fields `V W : E → E` and a function `f : E → 𝕜`,
+we have `[V, f • W] = (df V) • W + f • [V, W]`
+-/
+lemma lieBracket_fmul_right {f : E → 𝕜}
+    (hf : DifferentiableAt 𝕜 f x)
+    (hW : DifferentiableAt 𝕜 W x) :
+    lieBracket 𝕜 V (fun y => f y • W y) x =
+      (fderiv 𝕜 f x) (V x) • (W x)  + (f • lieBracket 𝕜 V W) x := by
+  simp only [← differentiableWithinAt_univ, ← lieBracketWithin_univ] at hW ⊢
+  simp only [← differentiableWithinAt_univ, ← lieBracketWithin_univ] at hf ⊢
+  rw [fderiv]
+  exact lieBracketWithin_fmul_right hf hW uniqueDiffWithinAt_univ
+
 lemma lieBracketWithin_add_left (hV : DifferentiableWithinAt 𝕜 V s x)
     (hV₁ : DifferentiableWithinAt 𝕜 V₁ s x) (hs : UniqueDiffWithinAt 𝕜 s x) :
     lieBracketWithin 𝕜 (V + V₁) W s x =

--- a/Mathlib/Analysis/Calculus/VectorField.lean
+++ b/Mathlib/Analysis/Calculus/VectorField.lean
@@ -145,9 +145,9 @@ lemma lieBracketWithin_fmul_left {f : E → 𝕜}
     (hs: UniqueDiffWithinAt 𝕜 s x) :
     lieBracketWithin 𝕜 (fun y => f y • V y) W s x =
       - (fderivWithin 𝕜 f s x) (W x) • (V x)  + (f x) • lieBracketWithin 𝕜 V W s x := by
-  rw [lieBracketWithin_swap, Pi.neg_apply, lieBracketWithin_fmul_right hf hV hs, lieBracketWithin_swap]
-  rw [neg_add, Pi.neg_apply, smul_neg, neg_neg, neg_smul]
-
+  rw [lieBracketWithin, lieBracketWithin, fderivWithin_smul hs hf hV, ContinuousLinearMap.add_apply]
+  rw [map_smul, ContinuousLinearMap.smulRight_apply, sub_add_eq_sub_sub]
+  rw [ContinuousLinearMap.smul_apply, ← smul_sub, add_comm, neg_smul, sub_eq_add_neg]
 
 /--
 Product rule for Lie Brackets: given two vector fields `V W : E → E` and a function `f : E → 𝕜`,

--- a/Mathlib/Analysis/Calculus/VectorField.lean
+++ b/Mathlib/Analysis/Calculus/VectorField.lean
@@ -81,6 +81,18 @@ lemma lieBracket_eq_zero_of_eq_zero (hV : V x = 0) (hW : W x = 0) :
     lieBracket 𝕜 V W x = 0 := by
   simp [lieBracket, hV, hW]
 
+lemma lieBracketWithin_swap : lieBracketWithin 𝕜 V W s = - lieBracketWithin 𝕜 W V s := by
+  ext x; simp [lieBracketWithin]
+
+lemma lieBracket_swap : lieBracket 𝕜 V W x = - lieBracket 𝕜 W V x := by
+  simp [lieBracket]
+
+@[simp] lemma lieBracketWithin_self : lieBracketWithin 𝕜 V V s = 0 := by
+  ext x; simp [lieBracketWithin]
+
+@[simp] lemma lieBracket_self : lieBracket 𝕜 V V = 0 := by
+  ext x; simp [lieBracket]
+
 lemma lieBracketWithin_smul_left {c : 𝕜} (hV : DifferentiableWithinAt 𝕜 V s x)
     (hs : UniqueDiffWithinAt 𝕜 s x) :
     lieBracketWithin 𝕜 (c • V) W s x =
@@ -111,57 +123,45 @@ lemma lieBracket_smul_right {c : 𝕜} (hW : DifferentiableAt 𝕜 W x) :
 Product rule for Lie Brackets: given two vector fields `V W : E → E` and a function `f : E → 𝕜`,
 we have `[V, f • W] = (df V) • W + f • [V, W]`
 -/
-lemma lieBracketWithin_fmul_right {f : E → 𝕜}
-    (hf : DifferentiableWithinAt 𝕜 f s x)
-    (hW : DifferentiableWithinAt 𝕜 W s x)
-    (hs: UniqueDiffWithinAt 𝕜 s x) :
-    lieBracketWithin 𝕜 V (fun y => f y • W y) s x =
-      (fderivWithin 𝕜 f s x) (V x) • (W x)  + (f x) • lieBracketWithin 𝕜 V W s x := by
-  rw [lieBracketWithin, lieBracketWithin, fderivWithin_smul hs hf hW, ContinuousLinearMap.add_apply]
-  rw [map_smul, ContinuousLinearMap.smulRight_apply, add_comm, smul_sub]
-  rw [ContinuousLinearMap.smul_apply, add_sub_assoc]
+lemma lieBracketWithin_fmul_right {f : E → 𝕜} (hf : DifferentiableWithinAt 𝕜 f s x)
+    (hW : DifferentiableWithinAt 𝕜 W s x) (hs: UniqueDiffWithinAt 𝕜 s x) :
+    lieBracketWithin 𝕜 V (fun y ↦ f y • W y) s x =
+      (fderivWithin 𝕜 f s x) (V x) • (W x) + (f x) • lieBracketWithin 𝕜 V W s x := by
+  simp [lieBracketWithin, fderivWithin_smul hs hf hW, map_smul, add_comm, smul_sub, add_sub_assoc]
 
 /--
 Product rule for Lie Brackets: given two vector fields `V W : E → E` and a function `f : E → 𝕜`,
 we have `[V, f • W] = (df V) • W + f • [V, W]`
 -/
-lemma lieBracket_fmul_right {f : E → 𝕜}
-    (hf : DifferentiableAt 𝕜 f x)
+lemma lieBracket_fmul_right {f : E → 𝕜} (hf : DifferentiableAt 𝕜 f x)
     (hW : DifferentiableAt 𝕜 W x) :
-    lieBracket 𝕜 V (fun y => f y • W y) x =
-      (fderiv 𝕜 f x) (V x) • (W x)  + (f x) • lieBracket 𝕜 V W x := by
-  simp only [← differentiableWithinAt_univ, ← lieBracketWithin_univ] at hW ⊢
-  simp only [← differentiableWithinAt_univ, ← lieBracketWithin_univ] at hf ⊢
-  rw [fderiv]
+    lieBracket 𝕜 V (fun y ↦ f y • W y) x =
+      (fderiv 𝕜 f x) (V x) • (W x) + (f x) • lieBracket 𝕜 V W x := by
+  simp_rw [← differentiableWithinAt_univ, ← lieBracketWithin_univ, fderiv] at hW hf ⊢
   exact lieBracketWithin_fmul_right hf hW uniqueDiffWithinAt_univ
 
 /--
 Product rule for Lie Brackets: given two vector fields `V W : E → E` and a function `f : E → 𝕜`,
 we have `[f • V, W] = - (df W) • V + f • [V, W]`
 -/
-lemma lieBracketWithin_fmul_left {f : E → 𝕜}
-    (hf : DifferentiableWithinAt 𝕜 f s x)
-    (hV : DifferentiableWithinAt 𝕜 V s x)
-    (hs: UniqueDiffWithinAt 𝕜 s x) :
-    lieBracketWithin 𝕜 (fun y => f y • V y) W s x =
+lemma lieBracketWithin_fmul_left {f : E → 𝕜} (hf : DifferentiableWithinAt 𝕜 f s x)
+    (hV : DifferentiableWithinAt 𝕜 V s x) (hs: UniqueDiffWithinAt 𝕜 s x) :
+    lieBracketWithin 𝕜 (fun y ↦ f y • V y) W s x =
       - (fderivWithin 𝕜 f s x) (W x) • (V x)  + (f x) • lieBracketWithin 𝕜 V W s x := by
-  rw [lieBracketWithin, lieBracketWithin, fderivWithin_smul hs hf hV, ContinuousLinearMap.add_apply]
-  rw [map_smul, ContinuousLinearMap.smulRight_apply, sub_add_eq_sub_sub]
-  rw [ContinuousLinearMap.smul_apply, ← smul_sub, add_comm, neg_smul, sub_eq_add_neg]
+  rw [lieBracketWithin_swap, Pi.neg_apply, lieBracketWithin_fmul_right hf hV hs,
+    lieBracketWithin_swap, add_comm]
+  simp
 
 /--
 Product rule for Lie Brackets: given two vector fields `V W : E → E` and a function `f : E → 𝕜`,
 we have `[f • V, W] = - (df W) • V + f • [V, W]`
 -/
-lemma lieBracket_fmul_left {f : E → 𝕜}
-    (hf : DifferentiableAt 𝕜 f x)
+lemma lieBracket_fmul_left {f : E → 𝕜} (hf : DifferentiableAt 𝕜 f x)
     (hV : DifferentiableAt 𝕜 V x) :
-    lieBracket 𝕜 (fun y => f y • V y) W x =
+    lieBracket 𝕜 (fun y ↦ f y • V y) W x =
       - (fderiv 𝕜 f x) (W x) • (V x)  + (f x) • lieBracket 𝕜 V W x := by
-  simp only [← differentiableWithinAt_univ, ← lieBracketWithin_univ] at hV ⊢
-  simp only [← differentiableWithinAt_univ, ← lieBracketWithin_univ] at hf ⊢
-  rw [fderiv]
-  exact lieBracketWithin_fmul_left hf hV uniqueDiffWithinAt_univ
+  rw [lieBracket_swap, lieBracket_fmul_right hf hV, lieBracket_swap, add_comm]
+  simp
 
 lemma lieBracketWithin_add_left (hV : DifferentiableWithinAt 𝕜 V s x)
     (hV₁ : DifferentiableWithinAt 𝕜 V₁ s x) (hs : UniqueDiffWithinAt 𝕜 s x) :
@@ -192,18 +192,6 @@ lemma lieBracket_add_right (hW : DifferentiableAt 𝕜 W x) (hW₁ : Differentia
   simp only [lieBracket, Pi.add_apply, map_add]
   rw [fderiv_add' hW hW₁, ContinuousLinearMap.add_apply]
   abel
-
-lemma lieBracketWithin_swap : lieBracketWithin 𝕜 V W s = - lieBracketWithin 𝕜 W V s := by
-  ext x; simp [lieBracketWithin]
-
-lemma lieBracket_swap : lieBracket 𝕜 V W x = - lieBracket 𝕜 W V x := by
-  simp [lieBracket]
-
-@[simp] lemma lieBracketWithin_self : lieBracketWithin 𝕜 V V s = 0 := by
-  ext x; simp [lieBracketWithin]
-
-@[simp] lemma lieBracket_self : lieBracket 𝕜 V V = 0 := by
-  ext x; simp [lieBracket]
 
 lemma _root_.ContDiffWithinAt.lieBracketWithin_vectorField
     {m n : WithTop ℕ∞} (hV : ContDiffWithinAt 𝕜 n V s x)

--- a/Mathlib/Analysis/Calculus/VectorField.lean
+++ b/Mathlib/Analysis/Calculus/VectorField.lean
@@ -93,7 +93,7 @@ lemma lieBracket_swap : lieBracket 𝕜 V W x = - lieBracket 𝕜 W V x := by
 @[simp] lemma lieBracket_self : lieBracket 𝕜 V V = 0 := by
   ext x; simp [lieBracket]
 
-lemma lieBracketWithin_smul_left {c : 𝕜} (hV : DifferentiableWithinAt 𝕜 V s x)
+lemma lieBracketWithin_const_smul_left {c : 𝕜} (hV : DifferentiableWithinAt 𝕜 V s x)
     (hs : UniqueDiffWithinAt 𝕜 s x) :
     lieBracketWithin 𝕜 (c • V) W s x =
       c • lieBracketWithin 𝕜 V W s x := by
@@ -101,12 +101,12 @@ lemma lieBracketWithin_smul_left {c : 𝕜} (hV : DifferentiableWithinAt 𝕜 V 
   rw [fderivWithin_const_smul' hs hV]
   rfl
 
-lemma lieBracket_smul_left {c : 𝕜} (hV : DifferentiableAt 𝕜 V x) :
+lemma lieBracket_const_smul_left {c : 𝕜} (hV : DifferentiableAt 𝕜 V x) :
     lieBracket 𝕜 (c • V) W x = c • lieBracket 𝕜 V W x := by
   simp only [← differentiableWithinAt_univ, ← lieBracketWithin_univ] at hV ⊢
-  exact lieBracketWithin_smul_left hV uniqueDiffWithinAt_univ
+  exact lieBracketWithin_const_smul_left hV uniqueDiffWithinAt_univ
 
-lemma lieBracketWithin_smul_right {c : 𝕜} (hW : DifferentiableWithinAt 𝕜 W s x)
+lemma lieBracketWithin_const_smul_right {c : 𝕜} (hW : DifferentiableWithinAt 𝕜 W s x)
     (hs : UniqueDiffWithinAt 𝕜 s x) :
     lieBracketWithin 𝕜 V (c • W) s x =
       c • lieBracketWithin 𝕜 V W s x := by
@@ -114,16 +114,16 @@ lemma lieBracketWithin_smul_right {c : 𝕜} (hW : DifferentiableWithinAt 𝕜 W
   rw [fderivWithin_const_smul' hs hW]
   rfl
 
-lemma lieBracket_smul_right {c : 𝕜} (hW : DifferentiableAt 𝕜 W x) :
+lemma lieBracket_const_smul_right {c : 𝕜} (hW : DifferentiableAt 𝕜 W x) :
     lieBracket 𝕜 V (c • W) x = c • lieBracket 𝕜 V W x := by
   simp only [← differentiableWithinAt_univ, ← lieBracketWithin_univ] at hW ⊢
-  exact lieBracketWithin_smul_right hW uniqueDiffWithinAt_univ
+  exact lieBracketWithin_const_smul_right hW uniqueDiffWithinAt_univ
 
 /--
 Product rule for Lie Brackets: given two vector fields `V W : E → E` and a function `f : E → 𝕜`,
 we have `[V, f • W] = (df V) • W + f • [V, W]`
 -/
-lemma lieBracketWithin_fmul_right {f : E → 𝕜} (hf : DifferentiableWithinAt 𝕜 f s x)
+lemma lieBracketWithin_smul_right {f : E → 𝕜} (hf : DifferentiableWithinAt 𝕜 f s x)
     (hW : DifferentiableWithinAt 𝕜 W s x) (hs: UniqueDiffWithinAt 𝕜 s x) :
     lieBracketWithin 𝕜 V (fun y ↦ f y • W y) s x =
       (fderivWithin 𝕜 f s x) (V x) • (W x) + (f x) • lieBracketWithin 𝕜 V W s x := by
@@ -133,22 +133,22 @@ lemma lieBracketWithin_fmul_right {f : E → 𝕜} (hf : DifferentiableWithinAt 
 Product rule for Lie Brackets: given two vector fields `V W : E → E` and a function `f : E → 𝕜`,
 we have `[V, f • W] = (df V) • W + f • [V, W]`
 -/
-lemma lieBracket_fmul_right {f : E → 𝕜} (hf : DifferentiableAt 𝕜 f x)
+lemma lieBracket_smul_right {f : E → 𝕜} (hf : DifferentiableAt 𝕜 f x)
     (hW : DifferentiableAt 𝕜 W x) :
     lieBracket 𝕜 V (fun y ↦ f y • W y) x =
       (fderiv 𝕜 f x) (V x) • (W x) + (f x) • lieBracket 𝕜 V W x := by
   simp_rw [← differentiableWithinAt_univ, ← lieBracketWithin_univ, fderiv] at hW hf ⊢
-  exact lieBracketWithin_fmul_right hf hW uniqueDiffWithinAt_univ
+  exact lieBracketWithin_smul_right hf hW uniqueDiffWithinAt_univ
 
 /--
 Product rule for Lie Brackets: given two vector fields `V W : E → E` and a function `f : E → 𝕜`,
 we have `[f • V, W] = - (df W) • V + f • [V, W]`
 -/
-lemma lieBracketWithin_fmul_left {f : E → 𝕜} (hf : DifferentiableWithinAt 𝕜 f s x)
+lemma lieBracketWithin_smul_left {f : E → 𝕜} (hf : DifferentiableWithinAt 𝕜 f s x)
     (hV : DifferentiableWithinAt 𝕜 V s x) (hs: UniqueDiffWithinAt 𝕜 s x) :
     lieBracketWithin 𝕜 (fun y ↦ f y • V y) W s x =
       - (fderivWithin 𝕜 f s x) (W x) • (V x)  + (f x) • lieBracketWithin 𝕜 V W s x := by
-  rw [lieBracketWithin_swap, Pi.neg_apply, lieBracketWithin_fmul_right hf hV hs,
+  rw [lieBracketWithin_swap, Pi.neg_apply, lieBracketWithin_smul_right hf hV hs,
     lieBracketWithin_swap, add_comm]
   simp
 
@@ -160,7 +160,7 @@ lemma lieBracket_fmul_left {f : E → 𝕜} (hf : DifferentiableAt 𝕜 f x)
     (hV : DifferentiableAt 𝕜 V x) :
     lieBracket 𝕜 (fun y ↦ f y • V y) W x =
       - (fderiv 𝕜 f x) (W x) • (V x)  + (f x) • lieBracket 𝕜 V W x := by
-  rw [lieBracket_swap, lieBracket_fmul_right hf hV, lieBracket_swap, add_comm]
+  rw [lieBracket_swap, lieBracket_smul_right hf hV, lieBracket_swap, add_comm]
   simp
 
 lemma lieBracketWithin_add_left (hV : DifferentiableWithinAt 𝕜 V s x)

--- a/Mathlib/Analysis/Calculus/VectorField.lean
+++ b/Mathlib/Analysis/Calculus/VectorField.lean
@@ -118,8 +118,8 @@ lemma lieBracketWithin_fmul_right {f : E → 𝕜}
     lieBracketWithin 𝕜 V (fun y => f y • W y) s x =
       (fderivWithin 𝕜 f s x) (V x) • (W x)  + (f x) • lieBracketWithin 𝕜 V W s x := by
   rw [lieBracketWithin, lieBracketWithin, fderivWithin_smul hs hf hW, ContinuousLinearMap.add_apply]
-  rw [map_smul, ContinuousLinearMap.smulRight_apply, add_comm, ContinuousLinearMap.coe_smul']
-  simp only [Pi.smul_apply, smul_sub, add_sub_assoc]
+  rw [map_smul, ContinuousLinearMap.smulRight_apply, add_comm, smul_sub]
+  rw [ContinuousLinearMap.smul_apply, add_sub_assoc]
 
 /--
 Product rule for Lie Brackets: given two vector fields `V W : E → E` and a function `f : E → 𝕜`,

--- a/Mathlib/Analysis/Calculus/VectorField.lean
+++ b/Mathlib/Analysis/Calculus/VectorField.lean
@@ -119,6 +119,12 @@ lemma lieBracket_const_smul_right {c : 𝕜} (hW : DifferentiableAt 𝕜 W x) :
   simp only [← differentiableWithinAt_univ, ← lieBracketWithin_univ] at hW ⊢
   exact lieBracketWithin_const_smul_right hW uniqueDiffWithinAt_univ
 
+@[deprecated (since := "2025-05-17")]
+alias lieBracketWithin_smul_right := lieBracketWithin_const_smul_right
+
+@[deprecated (since := "2025-05-17")]
+alias lieBracket_smul_right := lieBracket_const_smul_right
+
 /--
 Product rule for Lie Brackets: given two vector fields `V W : E → E` and a function `f : E → 𝕜`,
 we have `[V, f • W] = (df V) • W + f • [V, W]`

--- a/Mathlib/Analysis/Calculus/VectorField.lean
+++ b/Mathlib/Analysis/Calculus/VectorField.lean
@@ -116,8 +116,10 @@ lemma lieBracketWithin_fmul_right {f : E → 𝕜}
     (hW : DifferentiableWithinAt 𝕜 W s x)
     (hs: UniqueDiffWithinAt 𝕜 s x) :
     lieBracketWithin 𝕜 V (fun y => f y • W y) s x =
-      (fderivWithin 𝕜 f s x) (V x) • (W x)  + (f • lieBracketWithin 𝕜 V W s) x := by
-  simp [lieBracketWithin, fderivWithin_smul hs hf hW, smul_sub, add_comm, add_sub_assoc]
+      (fderivWithin 𝕜 f s x) (V x) • (W x)  + (f x) • lieBracketWithin 𝕜 V W s x := by
+  rw [lieBracketWithin, lieBracketWithin, fderivWithin_smul hs hf hW, ContinuousLinearMap.add_apply]
+  rw [map_smul, ContinuousLinearMap.smulRight_apply, add_comm, ContinuousLinearMap.coe_smul']
+  simp only [Pi.smul_apply, smul_sub, add_sub_assoc]
 
 /--
 Product rule for Lie Brackets: given two vector fields `V W : E → E` and a function `f : E → 𝕜`,
@@ -127,11 +129,39 @@ lemma lieBracket_fmul_right {f : E → 𝕜}
     (hf : DifferentiableAt 𝕜 f x)
     (hW : DifferentiableAt 𝕜 W x) :
     lieBracket 𝕜 V (fun y => f y • W y) x =
-      (fderiv 𝕜 f x) (V x) • (W x)  + (f • lieBracket 𝕜 V W) x := by
+      (fderiv 𝕜 f x) (V x) • (W x)  + (f x) • lieBracket 𝕜 V W x := by
   simp only [← differentiableWithinAt_univ, ← lieBracketWithin_univ] at hW ⊢
   simp only [← differentiableWithinAt_univ, ← lieBracketWithin_univ] at hf ⊢
   rw [fderiv]
   exact lieBracketWithin_fmul_right hf hW uniqueDiffWithinAt_univ
+
+/--
+Product rule for Lie Brackets: given two vector fields `V W : E → E` and a function `f : E → 𝕜`,
+we have `[f • V, W] = - (df W) • V + f • [V, W]`
+-/
+lemma lieBracketWithin_fmul_left {f : E → 𝕜}
+    (hf : DifferentiableWithinAt 𝕜 f s x)
+    (hV : DifferentiableWithinAt 𝕜 V s x)
+    (hs: UniqueDiffWithinAt 𝕜 s x) :
+    lieBracketWithin 𝕜 (fun y => f y • V y) W s x =
+      - (fderivWithin 𝕜 f s x) (W x) • (V x)  + (f x) • lieBracketWithin 𝕜 V W s x := by
+  rw [lieBracketWithin_swap, Pi.neg_apply, lieBracketWithin_fmul_right hf hV hs, lieBracketWithin_swap]
+  rw [neg_add, Pi.neg_apply, smul_neg, neg_neg, neg_smul]
+
+
+/--
+Product rule for Lie Brackets: given two vector fields `V W : E → E` and a function `f : E → 𝕜`,
+we have `[f • V, W] = - (df W) • V + f • [V, W]`
+-/
+lemma lieBracket_fmul_left {f : E → 𝕜}
+    (hf : DifferentiableAt 𝕜 f x)
+    (hV : DifferentiableAt 𝕜 V x) :
+    lieBracket 𝕜 (fun y => f y • V y) W x =
+      - (fderiv 𝕜 f x) (W x) • (V x)  + (f x) • lieBracket 𝕜 V W x := by
+  simp only [← differentiableWithinAt_univ, ← lieBracketWithin_univ] at hV ⊢
+  simp only [← differentiableWithinAt_univ, ← lieBracketWithin_univ] at hf ⊢
+  rw [fderiv]
+  exact lieBracketWithin_fmul_left hf hV uniqueDiffWithinAt_univ
 
 lemma lieBracketWithin_add_left (hV : DifferentiableWithinAt 𝕜 V s x)
     (hV₁ : DifferentiableWithinAt 𝕜 V₁ s x) (hs : UniqueDiffWithinAt 𝕜 s x) :

--- a/Mathlib/Geometry/Manifold/GroupLieAlgebra.lean
+++ b/Mathlib/Geometry/Manifold/GroupLieAlgebra.lean
@@ -248,7 +248,7 @@ noncomputable instance instLieAlgebraAddGroupLieAlgebra
     [LieAddGroup I (minSmoothness 𝕜 3) G] : LieAlgebra 𝕜 (AddGroupLieAlgebra I G) where
   lie_smul c v w := by
     simp only [AddGroupLieAlgebra.bracket_def, addInvariantVectorField_smul]
-    rw [mlieBracket_smul_right]
+    rw [mlieBracket_const_smul_right]
     exact mdifferentiableAt_addInvariantVectorField _
 
 /-- The tangent space at the identity of a Lie group is a Lie algebra, for the bracket
@@ -257,7 +257,7 @@ given by the Lie bracket of invariant vector fields. -/
 noncomputable instance instLieAlgebraGroupLieAlgebra : LieAlgebra 𝕜 (GroupLieAlgebra I G) where
   lie_smul c v w := by
     simp only [GroupLieAlgebra.bracket_def, mulInvariantVectorField_smul]
-    rw [mlieBracket_smul_right]
+    rw [mlieBracket_sonst_smul_right]
     exact mdifferentiableAt_mulInvariantVectorField _
 
 end LieGroup

--- a/Mathlib/Geometry/Manifold/GroupLieAlgebra.lean
+++ b/Mathlib/Geometry/Manifold/GroupLieAlgebra.lean
@@ -257,7 +257,7 @@ given by the Lie bracket of invariant vector fields. -/
 noncomputable instance instLieAlgebraGroupLieAlgebra : LieAlgebra 𝕜 (GroupLieAlgebra I G) where
   lie_smul c v w := by
     simp only [GroupLieAlgebra.bracket_def, mulInvariantVectorField_smul]
-    rw [mlieBracket_sonst_smul_right]
+    rw [mlieBracket_const_smul_right]
     exact mdifferentiableAt_mulInvariantVectorField _
 
 end LieGroup

--- a/Mathlib/Geometry/Manifold/VectorField/LieBracket.lean
+++ b/Mathlib/Geometry/Manifold/VectorField/LieBracket.lean
@@ -300,35 +300,35 @@ lemma _root_.MDifferentiableWithinAt.differentiableWithinAt_mpullbackWithin_vect
   exact ((contMDiff_snd_tangentBundle_modelSpace E 𝓘(𝕜, E)).contMDiffAt.mdifferentiableAt
     le_rfl).comp_mdifferentiableWithinAt _ this
 
-lemma mlieBracketWithin_smul_left
+lemma mlieBracketWithin_const_smul_left
     (hV : MDifferentiableWithinAt I I.tangent (fun x ↦ (V x : TangentBundle I M)) s x)
     (hs : UniqueMDiffWithinAt I s x) :
     mlieBracketWithin I (c • V) W s x = c • mlieBracketWithin I V W s x := by
   simp only [mlieBracketWithin_apply]
-  rw [← ContinuousLinearMap.map_smul, mpullbackWithin_smul, lieBracketWithin_smul_left]
+  rw [← ContinuousLinearMap.map_smul, mpullbackWithin_smul, lieBracketWithin_const_smul_left]
   · exact hV.differentiableWithinAt_mpullbackWithin_vectorField
   · exact uniqueMDiffWithinAt_iff_inter_range.1 hs
 
-lemma mlieBracket_smul_left
+lemma mlieBracket_const_smul_left
     (hV : MDifferentiableAt I I.tangent (fun x ↦ (V x : TangentBundle I M)) x) :
     mlieBracket I (c • V) W x = c • mlieBracket I V W x := by
   simp only [← mlieBracketWithin_univ, ← contMDiffWithinAt_univ] at hV ⊢
-  exact mlieBracketWithin_smul_left hV (uniqueMDiffWithinAt_univ _)
+  exact mlieBracketWithin_const_smul_left hV (uniqueMDiffWithinAt_univ _)
 
-lemma mlieBracketWithin_smul_right
+lemma mlieBracketWithin_const_smul_right
     (hW : MDifferentiableWithinAt I I.tangent (fun x ↦ (W x : TangentBundle I M)) s x)
     (hs : UniqueMDiffWithinAt I s x) :
     mlieBracketWithin I V (c • W) s x = c • mlieBracketWithin I V W s x := by
   simp only [mlieBracketWithin_apply]
-  rw [← ContinuousLinearMap.map_smul, mpullbackWithin_smul, lieBracketWithin_smul_right]
+  rw [← ContinuousLinearMap.map_smul, mpullbackWithin_smul, lieBracketWithin_const_smul_right]
   · exact hW.differentiableWithinAt_mpullbackWithin_vectorField
   · exact uniqueMDiffWithinAt_iff_inter_range.1 hs
 
-lemma mlieBracket_smul_right
+lemma mlieBracket_const_smul_right
     (hW : MDifferentiableAt I I.tangent (fun x ↦ (W x : TangentBundle I M)) x) :
     mlieBracket I V (c • W) x = c • mlieBracket I V W x := by
   simp only [← mlieBracketWithin_univ, ← contMDiffWithinAt_univ] at hW ⊢
-  exact mlieBracketWithin_smul_right hW (uniqueMDiffWithinAt_univ _)
+  exact mlieBracketWithin_const_smul_right hW (uniqueMDiffWithinAt_univ _)
 
 lemma mlieBracketWithin_add_left
     (hV : MDifferentiableWithinAt I I.tangent (fun x ↦ (V x : TangentBundle I M)) s x)


### PR DESCRIPTION
This adds lemmas for the product rule (or Leibniz rule) for Lie brackets on vector fields.
These new lemmas are called `lieBracket_smul_left` and similar.
To accomodate this, rename the existing lemmas `{m}lieBracket{Within}_smul_{left,right}` to `{m}lieBracket{Within}_const_smul_{left,right}`.

An additional PR for the same functionality on manifolds is in preparation and would depend on this PR. This will become useful when introducing Lie derivatives or covariant derivatives in differential geometry.


