### PR TITLE
[Merged by Bors] - feat(RingTheory/Ideal):  An ideal of `ℤ` is generated by its norm

### DIFF
--- a/Mathlib/Algebra/Ring/Associated.lean
+++ b/Mathlib/Algebra/Ring/Associated.lean
@@ -12,11 +12,18 @@ import Mathlib.Algebra.Ring.Units
 
 assert_not_exists OrderedCommMonoid Multiset Field
 
-namespace Associated
 variable {M : Type*} [Monoid M] [HasDistribNeg M] {a b : M}
+namespace Associated
+
 
 lemma neg_left (h : Associated a b) : Associated (-a) b := let ⟨u, hu⟩ := h; ⟨-u, by simp [hu]⟩
 lemma neg_right (h : Associated a b) : Associated a (-b) := h.symm.neg_left.symm
 lemma neg_neg (h : Associated a b) : Associated (-a) (-b) := h.neg_left.neg_right
 
 end Associated
+
+variable (a)
+
+lemma associated_neg_self_left : Associated (-a) a := Associated.rfl.neg_left
+
+lemma associated_neg_self_right : Associated a (-a) := Associated.rfl.neg_right

--- a/Mathlib/Algebra/Ring/Associated.lean
+++ b/Mathlib/Algebra/Ring/Associated.lean
@@ -23,4 +23,8 @@ lemma neg_neg (h : Associated a b) : Associated (-a) (-b) := h.neg_left.neg_righ
 lemma neg_left_iff : Associated (-a) b ↔ Associated a b :=
   ⟨fun h ↦ _root_.neg_neg a ▸ h.neg_left, fun h ↦ h.neg_left⟩
 
+@[simp]
+lemma neg_right_iff : Associated a (-b) ↔ Associated a b :=
+  ⟨fun h ↦ _root_.neg_neg b ▸ h.neg_right, fun h ↦ h.neg_right⟩
+
 end Associated

--- a/Mathlib/Algebra/Ring/Associated.lean
+++ b/Mathlib/Algebra/Ring/Associated.lean
@@ -19,4 +19,8 @@ lemma neg_left (h : Associated a b) : Associated (-a) b := let ⟨u, hu⟩ := h;
 lemma neg_right (h : Associated a b) : Associated a (-b) := h.symm.neg_left.symm
 lemma neg_neg (h : Associated a b) : Associated (-a) (-b) := h.neg_left.neg_right
 
+@[simp]
+lemma neg_left_iff : Associated (-a) b ↔ Associated a b :=
+  ⟨fun h ↦ _root_.neg_neg a ▸ h.neg_left, fun h ↦ h.neg_left⟩
+
 end Associated

--- a/Mathlib/Algebra/Ring/Associated.lean
+++ b/Mathlib/Algebra/Ring/Associated.lean
@@ -12,18 +12,11 @@ import Mathlib.Algebra.Ring.Units
 
 assert_not_exists OrderedCommMonoid Multiset Field
 
-variable {M : Type*} [Monoid M] [HasDistribNeg M] {a b : M}
 namespace Associated
-
+variable {M : Type*} [Monoid M] [HasDistribNeg M] {a b : M}
 
 lemma neg_left (h : Associated a b) : Associated (-a) b := let ⟨u, hu⟩ := h; ⟨-u, by simp [hu]⟩
 lemma neg_right (h : Associated a b) : Associated a (-b) := h.symm.neg_left.symm
 lemma neg_neg (h : Associated a b) : Associated (-a) (-b) := h.neg_left.neg_right
 
 end Associated
-
-variable (a)
-
-lemma associated_neg_self_left : Associated (-a) a := Associated.rfl.neg_left
-
-lemma associated_neg_self_right : Associated a (-a) := Associated.rfl.neg_right

--- a/Mathlib/Algebra/Ring/Divisibility/Lemmas.lean
+++ b/Mathlib/Algebra/Ring/Divisibility/Lemmas.lean
@@ -120,10 +120,20 @@ end CommRing
 
 section misc
 
-theorem associated_abs [Ring R] [LinearOrder R] (x : R) :
-    Associated x |x| := by
-  obtain h | h := abs_choice x
-  · rw [h]
-  · exact h ▸ associated_neg_self_right _
+variable [Ring R] [LinearOrder R] {x y : R}
+
+theorem Associated.abs_left (h : Associated x y) :
+    Associated |x| y := by
+  obtain ha | ha := abs_choice x
+  · simpa [ha]
+  · simpa [ha] using h.neg_left
+
+theorem Associated.abs_right (h : Associated x y) :
+    Associated x |y| :=
+  (h.symm.abs_left).symm
+
+theorem associated_abs (x : R) :
+    Associated x |x| :=
+  Associated.rfl.abs_right
 
 end misc

--- a/Mathlib/Algebra/Ring/Divisibility/Lemmas.lean
+++ b/Mathlib/Algebra/Ring/Divisibility/Lemmas.lean
@@ -132,9 +132,15 @@ theorem Associated.abs_right (h : Associated x y) :
     Associated x |y| :=
   (h.symm.abs_left).symm
 
-theorem Associated.abs_left_iff :
+@[simp]
+theorem associated_abs_left_iff :
     Associated |x| y ↔ Associated x y := by
   obtain h | h := abs_choice x <;>
   simp [h]
+
+@[simp]
+theorem associated_abs_right_iff :
+    Associated x |y| ↔ Associated x y := by
+  rw [Associated.comm, associated_abs_left_iff, Associated.comm]
 
 end misc

--- a/Mathlib/Algebra/Ring/Divisibility/Lemmas.lean
+++ b/Mathlib/Algebra/Ring/Divisibility/Lemmas.lean
@@ -89,7 +89,6 @@ lemma add_pow_dvd_pow_of_pow_eq_zero_left (hp : n + m ≤ p + 1) (h_comm : Commu
     (hy : y ^ n = 0) : (x + y) ^ m ∣ x ^ p :=
   add_comm x y ▸ h_comm.symm.add_pow_dvd_pow_of_pow_eq_zero_right hp hy
 
-
 end Ring
 
 end Commute

--- a/Mathlib/Algebra/Ring/Divisibility/Lemmas.lean
+++ b/Mathlib/Algebra/Ring/Divisibility/Lemmas.lean
@@ -132,8 +132,9 @@ theorem Associated.abs_right (h : Associated x y) :
     Associated x |y| :=
   (h.symm.abs_left).symm
 
-theorem associated_abs (x : R) :
-    Associated x |x| :=
-  Associated.rfl.abs_right
+theorem Associated.abs_left_iff :
+    Associated |x| y ↔ Associated x y := by
+  obtain h | h := abs_choice x <;>
+  simp [h]
 
 end misc

--- a/Mathlib/Algebra/Ring/Divisibility/Lemmas.lean
+++ b/Mathlib/Algebra/Ring/Divisibility/Lemmas.lean
@@ -89,6 +89,7 @@ lemma add_pow_dvd_pow_of_pow_eq_zero_left (hp : n + m ≤ p + 1) (h_comm : Commu
     (hy : y ^ n = 0) : (x + y) ^ m ∣ x ^ p :=
   add_comm x y ▸ h_comm.symm.add_pow_dvd_pow_of_pow_eq_zero_right hp hy
 
+
 end Ring
 
 end Commute
@@ -117,3 +118,13 @@ lemma dvd_mul_sub_mul_mul_gcd_of_dvd {p a b c d x y : R} [IsDomain R] [GCDMonoid
     dvd_mul_sub_mul_mul_right_of_dvd h1 h2⟩
 
 end CommRing
+
+section misc
+
+theorem associated_abs [Ring R] [LinearOrder R] (x : R) :
+    Associated x |x| := by
+  obtain h | h := abs_choice x
+  · rw [h]
+  · exact h ▸ associated_neg_self_right _
+
+end misc

--- a/Mathlib/Algebra/Ring/Divisibility/Lemmas.lean
+++ b/Mathlib/Algebra/Ring/Divisibility/Lemmas.lean
@@ -122,16 +122,6 @@ section misc
 
 variable [Ring R] [LinearOrder R] {x y : R}
 
-theorem Associated.abs_left (h : Associated x y) :
-    Associated |x| y := by
-  obtain ha | ha := abs_choice x
-  · simpa [ha]
-  · simpa [ha] using h.neg_left
-
-theorem Associated.abs_right (h : Associated x y) :
-    Associated x |y| :=
-  (h.symm.abs_left).symm
-
 @[simp]
 theorem associated_abs_left_iff :
     Associated |x| y ↔ Associated x y := by
@@ -142,5 +132,9 @@ theorem associated_abs_left_iff :
 theorem associated_abs_right_iff :
     Associated x |y| ↔ Associated x y := by
   rw [Associated.comm, associated_abs_left_iff, Associated.comm]
+
+alias ⟨_, Associated.abs_left⟩ := associated_abs_left_iff
+
+alias ⟨_, Associated.abs_right⟩ := associated_abs_right_iff
 
 end misc

--- a/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
+++ b/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
@@ -410,11 +410,11 @@ section Int
 
 open Ideal
 
-theorem Int.ideal_eq_span_absNorm_self (J : Ideal ℤ) :
-    J = span {(absNorm J : ℤ)} := by
+@[simp]
+theorem Int.ideal_span_absNorm_eq_self (J : Ideal ℤ) :
+    span {(absNorm J : ℤ)} = J := by
   obtain ⟨g, rfl⟩ := IsPrincipalIdealRing.principal J
-  rw [submodule_span_eq, absNorm_span_singleton, Int.natCast_natAbs, Algebra.norm_self_apply]
-  exact (span_singleton_abs g).symm
+  simp
 
 end Int
 

--- a/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
+++ b/Mathlib/RingTheory/Ideal/Norm/AbsNorm.lean
@@ -406,4 +406,16 @@ end Ideal
 
 end RingOfIntegers
 
+section Int
+
+open Ideal
+
+theorem Int.ideal_eq_span_absNorm_self (J : Ideal ℤ) :
+    J = span {(absNorm J : ℤ)} := by
+  obtain ⟨g, rfl⟩ := IsPrincipalIdealRing.principal J
+  rw [submodule_span_eq, absNorm_span_singleton, Int.natCast_natAbs, Algebra.norm_self_apply]
+  exact (span_singleton_abs g).symm
+
+end Int
+
 end abs_norm

--- a/Mathlib/RingTheory/Ideal/Span.lean
+++ b/Mathlib/RingTheory/Ideal/Span.lean
@@ -235,6 +235,13 @@ theorem span_singleton_neg (x : α) : (span {-x} : Ideal α) = span {x} := by
   simp only [mem_span_singleton']
   exact ⟨fun ⟨y, h⟩ => ⟨-y, h ▸ neg_mul_comm y x⟩, fun ⟨y, h⟩ => ⟨-y, h ▸ neg_mul_neg y x⟩⟩
 
+@[simp]
+theorem span_singleton_abs [LinearOrder α] (x : α) :
+    span {|x|} = span {x} := by
+  obtain h | h := abs_choice x
+  · rw [h]
+  · exact  h ▸ span_singleton_neg _
+
 end Ideal
 
 end Ring

--- a/Mathlib/RingTheory/Ideal/Span.lean
+++ b/Mathlib/RingTheory/Ideal/Span.lean
@@ -238,9 +238,8 @@ theorem span_singleton_neg (x : α) : (span {-x} : Ideal α) = span {x} := by
 @[simp]
 theorem span_singleton_abs [LinearOrder α] (x : α) :
     span {|x|} = span {x} := by
-  obtain h | h := abs_choice x
-  · rw [h]
-  · exact  h ▸ span_singleton_neg _
+  obtain h | h := abs_choice x <;>
+  simp [h]
 
 end Ideal
 

--- a/Mathlib/RingTheory/Norm/Defs.lean
+++ b/Mathlib/RingTheory/Norm/Defs.lean
@@ -59,6 +59,11 @@ noncomputable def norm : S →* R :=
 
 theorem norm_apply (x : S) : norm R x = LinearMap.det (lmul R S x) := rfl
 
+@[simp]
+theorem norm_self_apply (x : R) :
+    Algebra.norm R x = x := by
+  simp [norm_apply]
+
 theorem norm_eq_one_of_not_exists_basis (h : ¬∃ s : Finset S, Nonempty (Basis s R S)) (x : S) :
     norm R x = 1 := by rw [norm_apply, LinearMap.det]; split_ifs <;> trivial
 

--- a/Mathlib/RingTheory/Norm/Defs.lean
+++ b/Mathlib/RingTheory/Norm/Defs.lean
@@ -60,8 +60,9 @@ noncomputable def norm : S →* R :=
 theorem norm_apply (x : S) : norm R x = LinearMap.det (lmul R S x) := rfl
 
 @[simp]
-theorem norm_self_apply (x : R) :
-    Algebra.norm R x = x := by
+theorem norm_self :
+    Algebra.norm R = MonoidHom.id R := by
+  ext
   simp [norm_apply]
 
 theorem norm_eq_one_of_not_exists_basis (h : ¬∃ s : Finset S, Nonempty (Basis s R S)) (x : S) :

--- a/Mathlib/RingTheory/Norm/Defs.lean
+++ b/Mathlib/RingTheory/Norm/Defs.lean
@@ -60,8 +60,7 @@ noncomputable def norm : S →* R :=
 theorem norm_apply (x : S) : norm R x = LinearMap.det (lmul R S x) := rfl
 
 @[simp]
-theorem norm_self :
-    Algebra.norm R = MonoidHom.id R := by
+theorem norm_self : Algebra.norm R = MonoidHom.id R := by
   ext
   simp [norm_apply]
 


### PR DESCRIPTION
We also prove that 
- `x` and `|x|` are associated
- `x` and `|x|` span the same ideal

Note however that the proof of the second result does not use the first result since that would require commutativity but the result is also true in the noncommutative case. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
