### PR TITLE
[Merged by Bors] - fix(whitespace): better `≡ᵀ` pretty-print and remove a space

### DIFF
--- a/Mathlib/Analysis/Complex/ValueDistribution/ProximityFunction.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/ProximityFunction.lean
@@ -88,7 +88,7 @@ lemma proximity_coe_eq_proximity_sub_const_zero :
 For complex-valued `f`, establish a simple relation between the proximity functions of `f` and of
 `f⁻¹`.
 -/
-theorem proximity_inv  {f : ℂ → ℂ} : proximity f⁻¹ ⊤ = proximity f 0 := by
+theorem proximity_inv {f : ℂ → ℂ} : proximity f⁻¹ ⊤ = proximity f 0 := by
   simp [proximity_zero, proximity_top]
 
 end ValueDistribution

--- a/Mathlib/Computability/TuringDegree.lean
+++ b/Mathlib/Computability/TuringDegree.lean
@@ -86,7 +86,7 @@ abbrev TuringEquivalent (f g : ℕ →. ℕ) : Prop :=
   AntisymmRel TuringReducible f g
 
 @[inherit_doc] scoped[Computability] infix:50 " ≤ᵀ " => TuringReducible
-@[inherit_doc] scoped[Computability] infix:50 "≡ᵀ" => TuringEquivalent
+@[inherit_doc] scoped[Computability] infix:50 " ≡ᵀ " => TuringEquivalent
 
 open scoped Computability
 


### PR DESCRIPTION
Found by #24465.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
