### PR TITLE
[Merged by Bors] - chore: two more deprecations

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1048,6 +1048,7 @@ import Mathlib.Algebra.Ring.Regular
 import Mathlib.Algebra.Ring.Semiconj
 import Mathlib.Algebra.Ring.Semireal.Defs
 import Mathlib.Algebra.Ring.Subgroup
+import Mathlib.Algebra.Ring.Submonoid
 import Mathlib.Algebra.Ring.Submonoid.Basic
 import Mathlib.Algebra.Ring.Submonoid.Pointwise
 import Mathlib.Algebra.Ring.Subring.Basic

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2577,6 +2577,7 @@ import Mathlib.CategoryTheory.Types
 import Mathlib.CategoryTheory.UnivLE
 import Mathlib.CategoryTheory.Whiskering
 import Mathlib.CategoryTheory.Widesubcategory
+import Mathlib.CategoryTheory.WithTerminal
 import Mathlib.CategoryTheory.WithTerminal.Basic
 import Mathlib.CategoryTheory.WithTerminal.Cone
 import Mathlib.CategoryTheory.WithTerminal.FinCategory

--- a/Mathlib/Algebra/Ring/Submonoid.lean
+++ b/Mathlib/Algebra/Ring/Submonoid.lean
@@ -1,0 +1,11 @@
+/-
+Copyright (c) 2018 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Kenny Lau, Johan Commelin, Mario Carneiro, Kevin Buzzard,
+Amelia Livingston, Yury Kudryashov
+-/
+import Mathlib.Algebra.Group.Submonoid.Basic
+import Mathlib.Algebra.Ring.Defs
+import Mathlib.Tactic.MinImports
+
+deprecated_module (since := "2025-04-09")

--- a/Mathlib/Algebra/Ring/Submonoid.lean
+++ b/Mathlib/Algebra/Ring/Submonoid.lean
@@ -7,5 +7,6 @@ Amelia Livingston, Yury Kudryashov
 import Mathlib.Algebra.Group.Submonoid.Basic
 import Mathlib.Algebra.Ring.Defs
 import Mathlib.Tactic.MinImports
+import Mathlib.Tactic.Linter.DeprecatedModule
 
 deprecated_module (since := "2025-04-09")

--- a/Mathlib/CategoryTheory/WithTerminal.lean
+++ b/Mathlib/CategoryTheory/WithTerminal.lean
@@ -1,0 +1,10 @@
+/-
+Copyright (c) 2021 Adam Topaz. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Tooby-Smith, Adam Topaz
+-/
+import Mathlib.CategoryTheory.Limits.Shapes.IsTerminal
+import Mathlib.CategoryTheory.Limits.Shapes.Terminal
+import Mathlib.CategoryTheory.Bicategory.Functor.Pseudofunctor
+
+deprecated_module (since := "2025-04-10")


### PR DESCRIPTION
The deprecated_module declarations were fully auto-generated by #24917. See the individual commits for details.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
