### PR TITLE
feat(Combinatorics/SimpleGraph): define `between` subgraphs

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Bipartite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Bipartite.lean
@@ -254,6 +254,8 @@ def between (s t : Set V) (G : SimpleGraph V) : SimpleGraph V where
 
 lemma between_adj : (G.between s t).Adj v w ↔ G.Adj v w ∧ (v ∈ s ∧ w ∈ t ∨ v ∈ t ∧ w ∈ s) := by rfl
 
+lemma between_le : G.between s t ≤ G := fun _ _ h ↦ h.1
+
 lemma between_comm : G.between s t = G.between t s := by
   ext v w; simp [between_adj, or_comm]
 


### PR DESCRIPTION
The simple graph `G.between s t` is the subgraph of `G` containing edges that connect a vertex in the set `s` to a vertex in the set `t`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
