### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/CrossProduct): vector triple product

### DIFF
--- a/Mathlib/LinearAlgebra/CrossProduct.lean
+++ b/Mathlib/LinearAlgebra/CrossProduct.lean
@@ -164,3 +164,23 @@ lemma crossProduct_ne_zero_iff_linearIndependent {F : Type*} [Field F] {v w : Fi
   simp only [smul_eq_mul, mul_comm (w 0), mul_comm (w 1), mul_comm (w 2), h1] at h20 h21 h22
   rw [hv', cons_eq_zero_iff, cons_eq_zero_iff, cons_eq_zero_iff, zero_empty] at hv
   exact hv ⟨(h20 trivial).2, (h21 trivial).2, (h22 trivial).2, rfl⟩
+
+/-- The triple product expansion of the vector triple product. -/
+theorem cross_cross_eq_smul_sub_smul (u v w : Fin 3 → R) :
+    u ×₃ v ×₃ w = (u ⬝ᵥ w) • v - (v ⬝ᵥ w) • u := by
+  simp_rw [cross_apply, vec3_dotProduct]
+  ext i
+  fin_cases i <;>
+  · simp only [Fin.isValue, Nat.succ_eq_add_one, Nat.reduceAdd, Fin.reduceFinMk, cons_val,
+    Pi.sub_apply, Pi.smul_apply, smul_eq_mul]
+    ring
+
+/-- Alternative form of the triple product expansion of the vector triple product. -/
+theorem cross_cross_eq_smul_sub_smul' (u v w : Fin 3 → R) :
+    u ×₃ (v ×₃ w) = (u ⬝ᵥ w) • v - (v ⬝ᵥ u) • w := by
+  simp_rw [cross_apply, vec3_dotProduct]
+  ext i
+  fin_cases i <;>
+  · simp only [Nat.succ_eq_add_one, Nat.reduceAdd, Fin.isValue, cons_val, cons_val_one,
+    cons_val_zero, Fin.reduceFinMk, Pi.sub_apply, Pi.smul_apply, smul_eq_mul]
+    ring

--- a/Mathlib/LinearAlgebra/CrossProduct.lean
+++ b/Mathlib/LinearAlgebra/CrossProduct.lean
@@ -165,22 +165,22 @@ lemma crossProduct_ne_zero_iff_linearIndependent {F : Type*} [Field F] {v w : Fi
   rw [hv', cons_eq_zero_iff, cons_eq_zero_iff, cons_eq_zero_iff, zero_empty] at hv
   exact hv ⟨(h20 trivial).2, (h21 trivial).2, (h22 trivial).2, rfl⟩
 
-/-- The triple product expansion of the vector triple product. -/
+/-- The scalar triple product expansion of the vector triple product. -/
 theorem cross_cross_eq_smul_sub_smul (u v w : Fin 3 → R) :
     u ×₃ v ×₃ w = (u ⬝ᵥ w) • v - (v ⬝ᵥ w) • u := by
   simp_rw [cross_apply, vec3_dotProduct]
   ext i
   fin_cases i <;>
   · simp only [Fin.isValue, Nat.succ_eq_add_one, Nat.reduceAdd, Fin.reduceFinMk, cons_val,
-    Pi.sub_apply, Pi.smul_apply, smul_eq_mul]
+      Pi.sub_apply, Pi.smul_apply, smul_eq_mul]
     ring
 
-/-- Alternative form of the triple product expansion of the vector triple product. -/
+/-- Alternative form of the scalar triple product expansion of the vector triple product. -/
 theorem cross_cross_eq_smul_sub_smul' (u v w : Fin 3 → R) :
     u ×₃ (v ×₃ w) = (u ⬝ᵥ w) • v - (v ⬝ᵥ u) • w := by
   simp_rw [cross_apply, vec3_dotProduct]
   ext i
   fin_cases i <;>
   · simp only [Nat.succ_eq_add_one, Nat.reduceAdd, Fin.isValue, cons_val, cons_val_one,
-    cons_val_zero, Fin.reduceFinMk, Pi.sub_apply, Pi.smul_apply, smul_eq_mul]
+      cons_val_zero, Fin.reduceFinMk, Pi.sub_apply, Pi.smul_apply, smul_eq_mul]
     ring


### PR DESCRIPTION
This PR adds two theorems about the vector triple product.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

First PR to Mathlib, please let me know if anything can be improved :)
