### PR TITLE
[Merged by Bors] - feat(scripts/lint-style): select linters with Lakefile options

### DIFF
--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -32,7 +32,7 @@ or for downstream projects to allow a gradual adoption of this linter.
 An executable running all these linters is defined in `scripts/lint-style.lean`.
 -/
 
-open System
+open Lean.Linter System
 
 namespace Mathlib.Linter.TextBased
 
@@ -195,13 +195,19 @@ return an array of all style errors with line numbers. If possible,
 also return the collection of all lines, changed as needed to fix the linter errors.
 (Such automatic fixes are only possible for some kinds of `StyleError`s.)
 -/
-abbrev TextbasedLinter := Array String → Array (StyleError × ℕ) × (Option (Array String))
+abbrev TextbasedLinter := Lean.Options → Array String →
+  Array (StyleError × ℕ) × (Option (Array String))
 
 /-! Definitions of the actual text-based linters. -/
 section
 
 /-- Lint on any occurrences of the string "Adaptation note:" or variants thereof. -/
-def adaptationNoteLinter : TextbasedLinter := fun lines ↦ Id.run do
+register_option linter.adaptationNote : Bool := { defValue := true }
+
+/-- Lint on any occurrences of the string "Adaptation note:" or variants thereof. -/
+def adaptationNoteLinter : TextbasedLinter := fun opts lines ↦ Id.run do
+  unless getLinterValue linter.adaptationNote opts do return (#[], none)
+
   let mut errors := Array.mkEmpty 0
   for h : idx in [:lines.size] do
     -- We make this shorter to catch "Adaptation note", "adaptation note" and a missing colon.
@@ -209,9 +215,13 @@ def adaptationNoteLinter : TextbasedLinter := fun lines ↦ Id.run do
       errors := errors.push (StyleError.adaptationNote, idx + 1)
   return (errors, none)
 
+/-- Place a lint on trailing whitespace. -/
+register_option linter.trailingWhitespace : Bool := { defValue := true }
 
 /-- Lint a collection of input strings if one of them contains trailing whitespace. -/
-def trailingWhitespaceLinter : TextbasedLinter := fun lines ↦ Id.run do
+def trailingWhitespaceLinter : TextbasedLinter := fun opts lines ↦ Id.run do
+  unless getLinterValue linter.trailingWhitespace opts do return (#[], none)
+
   let mut errors := Array.mkEmpty 0
   let mut fixedLines : Vector String lines.size := lines.toVector
   for h : idx in [:lines.size] do
@@ -221,9 +231,13 @@ def trailingWhitespaceLinter : TextbasedLinter := fun lines ↦ Id.run do
       fixedLines := fixedLines.set idx line.trimRight
   return (errors, if errors.size > 0 then some fixedLines.toArray else none)
 
+/-- Place a lint on a semicolon preceded by a space. -/
+register_option linter.whitespaceBeforeSemicolon : Bool := { defValue := true }
 
 /-- Lint a collection of input strings for a semicolon preceded by a space. -/
-def semicolonLinter : TextbasedLinter := fun lines ↦ Id.run do
+def semicolonLinter : TextbasedLinter := fun opts lines ↦ Id.run do
+  unless getLinterValue linter.whitespaceBeforeSemicolon opts do return (#[], none)
+
   let mut errors := Array.mkEmpty 0
   let mut fixedLines := lines
   for h : idx in [:lines.size] do
@@ -256,7 +270,7 @@ def allLinters : Array TextbasedLinter := #[
 Return a list of all unexpected errors, and, if some errors could be fixed automatically,
 the collection of all lines with every automatic fix applied.
 `exceptions` are any pre-existing style exceptions for this file. -/
-def lintFile (path : FilePath) (exceptions : Array ErrorContext) :
+def lintFile (opts : Lean.Options) (path : FilePath) (exceptions : Array ErrorContext) :
     IO (Array ErrorContext × Option (Array String)) := do
   let mut errors := #[]
   -- Whether any changes were made by auto-fixes.
@@ -280,7 +294,7 @@ def lintFile (path : FilePath) (exceptions : Array ErrorContext) :
   let mut changed := lines
 
   for lint in allLinters do
-    let (err, changes) := lint changed
+    let (err, changes) := lint opts changed
     allOutput := allOutput.append (Array.map (fun (e, n) ↦ #[(ErrorContext.mk e n path)]) err)
     -- TODO: auto-fixes do not take style exceptions into account
     if let some c := changes then
@@ -291,16 +305,20 @@ def lintFile (path : FilePath) (exceptions : Array ErrorContext) :
     (allOutput.flatten.filter (fun e ↦ (e.find?_comparable exceptions).isNone))
   return (errors, if changes_made then some changed else none)
 
+/-- Enables the old Python-based style linters. -/
+register_option linter.pythonStyle : Bool := { defValue := true }
+
 /-- Lint a collection of modules for style violations.
 Print formatted errors for all unexpected style violations to standard output;
 correct automatically fixable style errors if configured so.
 Return the number of files which had new style errors.
+`opts` contains the options defined in the Lakefile, determining which linters to enable.
 `nolints` is a list of style exceptions to take into account.
 `moduleNames` are the names of all the modules to lint,
 `mode` specifies what kind of output this script should produce,
 `fix` configures whether fixable errors should be corrected in-place. -/
-def lintModules (nolints : Array String) (moduleNames : Array Lean.Name) (style : ErrorFormat)
-    (fix : Bool) : IO UInt32 := do
+def lintModules (opts : Lean.Options) (nolints : Array String) (moduleNames : Array Lean.Name)
+    (style : ErrorFormat) (fix : Bool) : IO UInt32 := do
   let styleExceptions := parseStyleExceptions nolints
   let mut numberErrorFiles : UInt32 := 0
   let mut allUnexpectedErrors := #[]
@@ -308,7 +326,7 @@ def lintModules (nolints : Array String) (moduleNames : Array Lean.Name) (style 
     -- Convert the module name to a file name, then lint that file.
     let path := mkFilePath (module.components.map toString)|>.addExtension "lean"
 
-    let (errors, changed) := ← lintFile path styleExceptions
+    let (errors, changed) := ← lintFile opts path styleExceptions
     if let some c := changed then
       if fix then
         let _ := ← IO.FS.writeFile path ("\n".intercalate c.toList)
@@ -316,27 +334,36 @@ def lintModules (nolints : Array String) (moduleNames : Array Lean.Name) (style 
       allUnexpectedErrors := allUnexpectedErrors.append errors
       numberErrorFiles := numberErrorFiles + 1
 
-  -- Run the remaining python linters. It is easier to just run on all files.
-  -- If this poses an issue, I can either filter the output
-  -- or wait until lint-style.py is fully rewritten in Lean.
-  let args := if fix then #["--fix"] else #[]
-  let output ← IO.Process.output { cmd := "./scripts/print-style-errors.sh", args := args }
-  if output.exitCode != 0 then
-    numberErrorFiles := numberErrorFiles + 1
-    IO.eprintln s!"error: `print-style-error.sh` exited with code {output.exitCode}"
-    IO.eprint output.stderr
-  else if output.stdout != "" then
-    numberErrorFiles := numberErrorFiles + 1
-    IO.eprint output.stdout
+  -- Passing Lean options to Python files seems like a lot of work for something we want to
+  -- run entirely inside of Lean in the end anyway.
+  -- So for now, we enable/disable all of them with a single switch.
+  if getLinterValue linter.pythonStyle opts then
+    -- Run the remaining python linters. It is easier to just run on all files.
+    -- If this poses an issue, I can either filter the output
+    -- or wait until lint-style.py is fully rewritten in Lean.
+    let args := if fix then #["--fix"] else #[]
+    let output ← IO.Process.output { cmd := "./scripts/print-style-errors.sh", args := args }
+    if output.exitCode != 0 then
+      numberErrorFiles := numberErrorFiles + 1
+      IO.eprintln s!"error: `print-style-error.sh` exited with code {output.exitCode}"
+      IO.eprint output.stderr
+    else if output.stdout != "" then
+      numberErrorFiles := numberErrorFiles + 1
+      IO.eprint output.stdout
   formatErrors allUnexpectedErrors style
   if allUnexpectedErrors.size > 0 then
     IO.eprintln s!"error: found {allUnexpectedErrors.size} new style error(s)"
   return numberErrorFiles
 
+/-- Verify that all modules are named in `UpperCamelCase` -/
+register_option linter.modulesUpperCamelCase : Bool := { defValue := true }
+
 /-- Verifies that all modules in `modules` are named in `UpperCamelCase`
 (except for explicitly discussed exceptions, which are hard-coded here).
 Return the number of modules violating this. -/
-def modulesNotUpperCamelCase (modules : Array Lean.Name) : IO Nat := do
+def modulesNotUpperCamelCase (opts : Lean.Options) (modules : Array Lean.Name) : IO Nat := do
+  unless getLinterValue linter.modulesUpperCamelCase opts do return 0
+
   -- Exceptions to this list should be discussed on zulip!
   let exceptions := [
     `Mathlib.Analysis.CStarAlgebra.lpSpace,

--- a/Mathlib/Tactic/Linter/TextBased.lean
+++ b/Mathlib/Tactic/Linter/TextBased.lean
@@ -204,7 +204,7 @@ section
 /-- Lint on any occurrences of the string "Adaptation note:" or variants thereof. -/
 register_option linter.adaptationNote : Bool := { defValue := true }
 
-/-- Lint on any occurrences of the string "Adaptation note:" or variants thereof. -/
+@[inherit_doc linter.adaptationNote]
 def adaptationNoteLinter : TextbasedLinter := fun opts lines ↦ Id.run do
   unless getLinterValue linter.adaptationNote opts do return (#[], none)
 
@@ -215,10 +215,10 @@ def adaptationNoteLinter : TextbasedLinter := fun opts lines ↦ Id.run do
       errors := errors.push (StyleError.adaptationNote, idx + 1)
   return (errors, none)
 
-/-- Place a lint on trailing whitespace. -/
+/-- Lint a collection of input strings if one of them contains trailing whitespace. -/
 register_option linter.trailingWhitespace : Bool := { defValue := true }
 
-/-- Lint a collection of input strings if one of them contains trailing whitespace. -/
+@[inherit_doc linter.trailingWhitespace]
 def trailingWhitespaceLinter : TextbasedLinter := fun opts lines ↦ Id.run do
   unless getLinterValue linter.trailingWhitespace opts do return (#[], none)
 
@@ -231,10 +231,10 @@ def trailingWhitespaceLinter : TextbasedLinter := fun opts lines ↦ Id.run do
       fixedLines := fixedLines.set idx line.trimRight
   return (errors, if errors.size > 0 then some fixedLines.toArray else none)
 
-/-- Place a lint on a semicolon preceded by a space. -/
+/-- Lint a collection of input strings for a semicolon preceded by a space. -/
 register_option linter.whitespaceBeforeSemicolon : Bool := { defValue := true }
 
-/-- Lint a collection of input strings for a semicolon preceded by a space. -/
+@[inherit_doc linter.whitespaceBeforeSemicolon]
 def semicolonLinter : TextbasedLinter := fun opts lines ↦ Id.run do
   unless getLinterValue linter.whitespaceBeforeSemicolon opts do return (#[], none)
 

--- a/MathlibTest/ModuleCasing.lean
+++ b/MathlibTest/ModuleCasing.lean
@@ -8,16 +8,19 @@ open Mathlib.Linter.TextBased
 
 /-- Some unit tests for `modulesNotUpperCamelCase` -/
 def testModulesNotUpperCamelCase : IO Unit := do
-  assert!((← modulesNotUpperCamelCase #[]) == 0)
-  assert!((← modulesNotUpperCamelCase #[`Mathlib.Fine]) == 0)
-  assert!((← modulesNotUpperCamelCase #[`Mathlib.AlsoFine_]) == 0)
-  assert!((← modulesNotUpperCamelCase #[`Mathlib.NotFine_.Foo]) == 1)
+  -- Explicitly enable the linter, although it is enabled by default.
+  let opts : Lean.Options := linter.modulesUpperCamelCase.set {} true
 
-  assert!((← modulesNotUpperCamelCase #[`bad_module]) == 1)
-  assert!((← modulesNotUpperCamelCase #[`GoodName, `bad_module, `bad_module]) == 2)
-  assert!((← modulesNotUpperCamelCase #[`Mathlib.BadModule__]) == 1)
-  assert!((← modulesNotUpperCamelCase #[`Mathlib.lowerCase]) == 1)
-  assert!((← modulesNotUpperCamelCase #[`Mathlib.snake_case]) == 1)
+  assert!((← modulesNotUpperCamelCase opts #[]) == 0)
+  assert!((← modulesNotUpperCamelCase opts #[`Mathlib.Fine]) == 0)
+  assert!((← modulesNotUpperCamelCase opts #[`Mathlib.AlsoFine_]) == 0)
+  assert!((← modulesNotUpperCamelCase opts #[`Mathlib.NotFine_.Foo]) == 1)
+
+  assert!((← modulesNotUpperCamelCase opts #[`bad_module]) == 1)
+  assert!((← modulesNotUpperCamelCase opts #[`GoodName, `bad_module, `bad_module]) == 2)
+  assert!((← modulesNotUpperCamelCase opts #[`Mathlib.BadModule__]) == 1)
+  assert!((← modulesNotUpperCamelCase opts #[`Mathlib.lowerCase]) == 1)
+  assert!((← modulesNotUpperCamelCase opts #[`Mathlib.snake_case]) == 1)
 
 /--
 info: error: module name 'Mathlib.NotFine_.Foo' is not in 'UpperCamelCase': it should be 'Mathlib.NotFine.Foo' instead

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -131,6 +131,9 @@ lean_exe shake where
 /-- `lake exe lint-style` runs text-based style linters. -/
 lean_exe «lint-style» where
   srcDir := "scripts"
+  supportInterpreter := true
+  -- Executables which import `Lake` must set `-lLake`.
+  weakLinkArgs := #["-lLake"]
 
 /--
 `lake exe pole` queries the Mathlib speedcenter for build times for the current commit,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -26,6 +26,8 @@ require "leanprover-community" / "plausible" @ git "main"
 /-- These options are used as `leanOptions`, prefixed by `` `weak``, so that
 `lake build` uses them, as well as `Archive` and `Counterexamples`. -/
 abbrev mathlibOnlyLinters : Array LeanOption := #[
+  ⟨`linter.allScriptsDocumented, true⟩,
+  ⟨`linter.checkInitImports, true⟩,
   -- The `docPrime` linter is disabled: https://github.com/leanprover-community/mathlib4/issues/20560
   ⟨`linter.docPrime, false⟩,
   ⟨`linter.hashCommand, true⟩,
@@ -44,7 +46,7 @@ abbrev mathlibOnlyLinters : Array LeanOption := #[
   ⟨`linter.style.multiGoal, true⟩,
   ⟨`linter.style.openClassical, true⟩,
   ⟨`linter.style.refine, true⟩,
-  ⟨`linter.style.setOption, true⟩
+  ⟨`linter.style.setOption, true⟩,
 ]
 
 /-- These options are passed as `leanOptions` to building mathlib, as well as the

--- a/scripts/lint-style.lean
+++ b/scripts/lint-style.lean
@@ -68,7 +68,7 @@ def getLakefileLeanOptions : IO Lean.Options := do
   let rootOpts := root.leanOptions
   -- Other projects, like Mathlib, declare options in the targets.
   -- Here we use the default targets, since that probably contains the modules we'll be linting.
-  let defaultOpts := root.defaultTargets.flatMap fun target =>
+  let defaultOpts := root.defaultTargets.flatMap fun target ↦
     if let some lib := root.findLeanLib? target then
       lib.config.leanOptions
     else if let some exe := root.findLeanExe? target then


### PR DESCRIPTION
This PR modifies the lint-style script to enable or disable specific linters by specifying them with Lean options, just like the other style linters.

Linters can be selected by setting the corresponding option in the lakefile of the project. (Since we don't actually run any of the code in the project to be linted, `set_option` calls will be ignored.)

More precisely, we use Lake to parse the Lean options from the root project and any default libs and executables. This should correspond to the most common way linter options are set, project-wide. This PR uses a single option to enable/disable all of the Python-based linters. Passing options to the Python program could also work, but sounds like a lot of work for something we want to get rid of in the longer term.

Testing routine for this PR:
```bash
touch scripts/undocumented.lean
lake exe lint-style -- Receive style linter error
$EDITOR lakefile.lean -- Remove the line ⟨`linter.allScriptsDocumented, true⟩,
lake exe lint-style -- See that the style linter error is gone.
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
