### PR TITLE
chore: import Mathlib.Tactic.Linter.DeprecatedModule in Mathlib.Init

### DIFF
--- a/Mathlib/Algebra/Order/Field/InjSurj.lean
+++ b/Mathlib/Algebra/Order/Field/InjSurj.lean
@@ -4,6 +4,5 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis, Leonardo de Moura, Mario Carneiro, Floris van Doorn
 -/
 import Mathlib.Algebra.Order.Ring.InjSurj
-import Mathlib.Tactic.Linter.DeprecatedModule
 
 deprecated_module (since := "2025-04-16")

--- a/Mathlib/Algebra/Order/Group/InjSurj.lean
+++ b/Mathlib/Algebra/Order/Group/InjSurj.lean
@@ -4,6 +4,5 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
 import Mathlib.Algebra.Order.Monoid.Basic
-import Mathlib.Tactic.Linter.DeprecatedModule
 
 deprecated_module (since := "2025-04-16")

--- a/Mathlib/Algebra/Order/Group/Instances.lean
+++ b/Mathlib/Algebra/Order/Group/Instances.lean
@@ -5,6 +5,5 @@ Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
 import Mathlib.Algebra.Order.Group.Defs
 import Mathlib.Algebra.Order.Monoid.OrderDual
-import Mathlib.Tactic.Linter.DeprecatedModule
 
 deprecated_module (since := "2025-04-16")

--- a/Mathlib/Algebra/Order/Group/Prod.lean
+++ b/Mathlib/Algebra/Order/Group/Prod.lean
@@ -5,6 +5,5 @@ Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
 import Mathlib.Algebra.Order.Group.Defs
 import Mathlib.Algebra.Order.Monoid.Prod
-import Mathlib.Tactic.Linter.DeprecatedModule
 
 deprecated_module (since := "2025-04-16")

--- a/Mathlib/Algebra/Order/Group/TypeTags.lean
+++ b/Mathlib/Algebra/Order/Group/TypeTags.lean
@@ -5,6 +5,5 @@ Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
 import Mathlib.Algebra.Order.Group.Defs
 import Mathlib.Algebra.Order.Monoid.TypeTags
-import Mathlib.Tactic.Linter.DeprecatedModule
 
 deprecated_module (since := "2025-04-16")

--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled.lean
@@ -5,6 +5,5 @@ Authors: Damiano Testa, Yuyang Zhao
 -/
 import Mathlib.Algebra.Order.GroupWithZero.Unbundled.Basic
 import Mathlib.Algebra.Order.GroupWithZero.Unbundled.Defs
-import Mathlib.Tactic.Linter.DeprecatedModule
 
 deprecated_module (since := "2025-04-13")

--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Lemmas.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Lemmas.lean
@@ -4,6 +4,5 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
 import Mathlib.Algebra.Order.GroupWithZero.Unbundled.OrderIso
-import Mathlib.Tactic.Linter.DeprecatedModule
 
 deprecated_module (since := "2025-04-13")

--- a/Mathlib/Init.lean
+++ b/Mathlib/Init.lean
@@ -18,6 +18,8 @@ import Mathlib.Tactic.Linter.UnusedTactic
 import Mathlib.Tactic.Linter.Style
 -- This import makes the `#min_imports` command available globally.
 import Mathlib.Tactic.MinImports
+-- This makes the `deprecated_module` command available globally.
+import Mathlib.Tactic.Linter.DeprecatedModule
 
 /-!
 This is the root file in Mathlib: it is imported by virtually *all* Mathlib files.

--- a/Mathlib/Order/Chain.lean
+++ b/Mathlib/Order/Chain.lean
@@ -4,6 +4,5 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
 import Mathlib.Order.Preorder.Chain
-import Mathlib.Tactic.Linter.DeprecatedModule
 
 deprecated_module (since := "2025-04-13")

--- a/Mathlib/RingTheory/Ideal/AssociatedPrime.lean
+++ b/Mathlib/RingTheory/Ideal/AssociatedPrime.lean
@@ -5,6 +5,5 @@ Authors: Andrew Yang
 -/
 
 import Mathlib.RingTheory.Ideal.AssociatedPrime.Basic
-import Mathlib.Tactic.Linter.DeprecatedModule
 
 deprecated_module (since := "2025-04-20")

--- a/Mathlib/Tactic/ExtractLets.lean
+++ b/Mathlib/Tactic/ExtractLets.lean
@@ -6,7 +6,6 @@ Authors: Kyle Miller
 import Mathlib.Lean.Expr.Basic
 import Mathlib.Tactic.Basic
 import Batteries.Tactic.Lint.Misc
-import Mathlib.Tactic.Linter.DeprecatedModule
 
 deprecated_module "The extract_let tactic was moved to Lean core; \
   you can probably just remove this import" (since := "2025-05-02")

--- a/Mathlib/Tactic/LiftLets.lean
+++ b/Mathlib/Tactic/LiftLets.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kyle Miller
 -/
 import Mathlib.Tactic.Basic
-import Mathlib.Tactic.Linter.DeprecatedModule
 
 deprecated_module "The lift_lets tactic was moved to Lean core; \
   you can probably just remove this import" (since := "2025-05-02")

--- a/Mathlib/Tactic/Linter.lean
+++ b/Mathlib/Tactic/Linter.lean
@@ -8,7 +8,6 @@ This file is ignored by `shake`:
 * it is in `ignoreImport`, meaning that where it is imported, it is considered necessary.
 -/
 
-import Mathlib.Tactic.Linter.DeprecatedModule
 import Mathlib.Tactic.Linter.HaveLetLinter
 import Mathlib.Tactic.Linter.MinImports
 import Mathlib.Tactic.Linter.PPRoundtrip

--- a/Mathlib/Tactic/Linter/DeprecatedModule.lean
+++ b/Mathlib/Tactic/Linter/DeprecatedModule.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa
 -/
 import Std.Time.Format
-import Mathlib.Init
+import Mathlib.Tactic.Linter.Header
 
 /-!
 #  The `deprecated.module` linter


### PR DESCRIPTION
Make the deprecated_module command available everywhere in mathlib. This way, creating a module deprecation does not require adding this as an additional import.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
