### PR TITLE
feat: use ` binderNameHint` in sum_congr

### DIFF
--- a/Mathlib/Algebra/BigOperators/Expect.lean
+++ b/Mathlib/Algebra/BigOperators/Expect.lean
@@ -121,7 +121,7 @@ lemma expect_univ [Fintype ι] : 𝔼 i, f i = (∑ i, f i) /ℚ Fintype.card ι
 @[simp] lemma expect_const_zero (s : Finset ι) : 𝔼 _i ∈ s, (0 : M) = 0 := by simp [expect]
 
 @[congr]
-lemma expect_congr {t : Finset ι} (hst : s = t) (h : ∀ i ∈ t, f i = g i) :
+lemma expect_congr {t : Finset ι} (hst : s = t) (h : ∀ i ∈ t, binderNameHint i f (f i) = g i) :
     𝔼 i ∈ s, f i = 𝔼 i ∈ t, g i := by rw [expect, expect, sum_congr hst h, hst]
 
 lemma expectWith_congr (hst : s = t) (hpq : ∀ i ∈ t, p i ↔ q i) (h : ∀ i ∈ t, q i → f i = g i) :

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
@@ -74,7 +74,7 @@ lemma prod_attach (s : Finset ι) (f : ι → M) : ∏ x ∈ s.attach, f x = ∏
   classical rw [← prod_image Subtype.coe_injective.injOn, attach_image_val]
 
 @[to_additive (attr := congr)]
-theorem prod_congr (h : s₁ = s₂) : (∀ x ∈ s₂, f x = g x) → s₁.prod f = s₂.prod g := by
+theorem prod_congr (h : s₁ = s₂) : (∀ x ∈ s₂, binderNameHint x f (f x) = g x) → s₁.prod f = s₂.prod g := by
   rw [h]; exact fold_congr
 
 @[to_additive]

--- a/Mathlib/Analysis/BoxIntegral/Partition/Basic.lean
+++ b/Mathlib/Analysis/BoxIntegral/Partition/Basic.lean
@@ -287,7 +287,7 @@ theorem biUnion_top : (π.biUnion fun _ => ⊤) = π := by
   simp
 
 @[congr]
-theorem biUnion_congr (h : π₁ = π₂) (hi : ∀ J ∈ π₁, πi₁ J = πi₂ J) :
+theorem biUnion_congr (h : π₁ = π₂) (hi : ∀ J ∈ π₁, binderNameHint J πi₁ (πi₁ J) = πi₂ J) :
     π₁.biUnion πi₁ = π₂.biUnion πi₂ := by
   subst π₂
   ext J

--- a/Mathlib/Data/Finset/Fold.lean
+++ b/Mathlib/Data/Finset/Fold.lean
@@ -64,7 +64,8 @@ theorem fold_image [DecidableEq α] {g : γ → α} {s : Finset γ}
   simp only [fold, image_val_of_injOn H, Multiset.map_map]
 
 @[congr]
-theorem fold_congr {g : α → β} (H : ∀ x ∈ s, f x = g x) : s.fold op b f = s.fold op b g := by
+theorem fold_congr {g : α → β} (H : ∀ x ∈ s, binderNameHint x f (f x) = g x) :
+    s.fold op b f = s.fold op b g := by
   rw [fold, fold, map_congr rfl H]
 
 theorem fold_op_distrib {f g : α → β} {b₁ b₂ : β} :

--- a/Mathlib/Data/Finset/Lattice/Fold.lean
+++ b/Mathlib/Data/Finset/Lattice/Fold.lean
@@ -769,7 +769,8 @@ theorem sup'_mem (s : Set α) (w : ∀ᵉ (x ∈ s) (y ∈ s), x ⊔ y ∈ s) {�
   sup'_induction H p w h
 
 @[congr]
-theorem sup'_congr {t : Finset β} {f g : β → α} (h₁ : s = t) (h₂ : ∀ x ∈ s, f x = g x) :
+theorem sup'_congr {t : Finset β} {f g : β → α} (h₁ : s = t)
+    (h₂ : ∀ x ∈ s, binderNameHint x f (f x) = g x) :
     s.sup' H f = t.sup' (h₁ ▸ H) g := by
   subst s
   refine eq_of_forall_ge_iff fun c => ?_
@@ -903,7 +904,8 @@ theorem inf'_mem (s : Set α) (w : ∀ᵉ (x ∈ s) (y ∈ s), x ⊓ y ∈ s) {�
   inf'_induction H p w h
 
 @[congr]
-theorem inf'_congr {t : Finset β} {f g : β → α} (h₁ : s = t) (h₂ : ∀ x ∈ s, f x = g x) :
+theorem inf'_congr {t : Finset β} {f g : β → α} (h₁ : s = t)
+    (h₂ : ∀ x ∈ s, binderNameHint x f (f x) = g x) :
     s.inf' H f = t.inf' (h₁ ▸ H) g :=
   sup'_congr (α := αᵒᵈ) H h₁ h₂
 

--- a/Mathlib/Data/List/OfFn.lean
+++ b/Mathlib/Data/List/OfFn.lean
@@ -44,7 +44,7 @@ theorem map_ofFn {β : Type*} {n : ℕ} (f : Fin n → α) (g : α → β) :
 theorem ofFn_congr {m n : ℕ} (h : m = n) (f : Fin m → α) :
     ofFn f = ofFn fun i : Fin n => binderNameHint i f (f (Fin.cast h.symm i)) := by
   subst h
-  simp_rw [Fin.cast_refl, id]
+  simp_rw [binderNameHint, Fin.cast_refl, id]
 
 theorem ofFn_succ' {n} (f : Fin (succ n) → α) :
     ofFn f = (ofFn fun i => f (Fin.castSucc i)).concat (f (Fin.last _)) := by
@@ -88,7 +88,8 @@ theorem ofFn_mul' {m n} (f : Fin (m * n) → α) :
     calc
       m * i + j < m * (i + 1) :=
         (Nat.add_lt_add_left j.prop _).trans_eq (by rw [Nat.mul_add, Nat.mul_one])
-      _ ≤ _ := Nat.mul_le_mul_left _ i.prop⟩) := by simp_rw [m.mul_comm, ofFn_mul, Fin.cast_mk]
+      _ ≤ _ := Nat.mul_le_mul_left _ i.prop⟩) := by
+        simp_rw [m.mul_comm, ofFn_mul, Fin.cast_mk, binderNameHint]
 
 @[simp]
 theorem ofFn_get : ∀ l : List α, (ofFn (get l)) = l

--- a/Mathlib/Data/List/OfFn.lean
+++ b/Mathlib/Data/List/OfFn.lean
@@ -42,7 +42,7 @@ theorem map_ofFn {β : Type*} {n : ℕ} (f : Fin n → α) (g : α → β) :
 
 @[congr]
 theorem ofFn_congr {m n : ℕ} (h : m = n) (f : Fin m → α) :
-    ofFn f = ofFn fun i : Fin n => f (Fin.cast h.symm i) := by
+    ofFn f = ofFn fun i : Fin n => binderNameHint i f (f (Fin.cast h.symm i)) := by
   subst h
   simp_rw [Fin.cast_refl, id]
 

--- a/Mathlib/Data/Multiset/Count.lean
+++ b/Mathlib/Data/Multiset/Count.lean
@@ -98,7 +98,7 @@ theorem countP_pos_of_mem {s a} (h : a ∈ s) (pa : p a) : 0 < countP p s :=
 @[congr]
 theorem countP_congr {s s' : Multiset α} (hs : s = s')
     {p p' : α → Prop} [DecidablePred p] [DecidablePred p']
-    (hp : ∀ x ∈ s, p x = p' x) : s.countP p = s'.countP p' := by
+    (hp : ∀ x ∈ s, binderNameHint x p (p x) = p' x) : s.countP p = s'.countP p' := by
   revert hs hp
   exact Quot.induction_on₂ s s'
     (fun l l' hs hp => by

--- a/Mathlib/Data/Multiset/Filter.lean
+++ b/Mathlib/Data/Multiset/Filter.lean
@@ -47,7 +47,7 @@ theorem filter_zero : filter p 0 = 0 :=
 
 @[congr]
 theorem filter_congr {p q : α → Prop} [DecidablePred p] [DecidablePred q] {s : Multiset α} :
-    (∀ x ∈ s, p x ↔ q x) → filter p s = filter q s :=
+    (∀ x ∈ s, binderNameHint x p (p x) ↔ q x) → filter p s = filter q s :=
   Quot.inductionOn s fun _l h => congr_arg ofList <| List.filter_congr <| by simpa using h
 
 @[simp]

--- a/Mathlib/Data/Multiset/MapFold.lean
+++ b/Mathlib/Data/Multiset/MapFold.lean
@@ -45,7 +45,7 @@ def map (f : α → β) (s : Multiset α) : Multiset β :=
 
 @[congr]
 theorem map_congr {f g : α → β} {s t : Multiset α} :
-    s = t → (∀ x ∈ t, f x = g x) → map f s = map g t := by
+    s = t → (∀ x ∈ t, binderNameHint x f (f x) = g x) → map f s = map g t := by
   rintro rfl h
   induction s using Quot.inductionOn
   exact congr_arg _ (List.map_congr_left h)

--- a/Mathlib/Data/Option/Basic.lean
+++ b/Mathlib/Data/Option/Basic.lean
@@ -89,7 +89,7 @@ theorem bind_eq_some' {x : Option α} {f : α → Option β} {b : β} :
 
 @[congr]
 theorem bind_congr' {f g : α → Option β} {x y : Option α} (hx : x = y)
-    (hf : ∀ a ∈ y, f a = g a) : x.bind f = y.bind g :=
+    (hf : ∀ a ∈ y, binderNameHint a f (f a) = g a) : x.bind f = y.bind g :=
   hx.symm ▸ bind_congr hf
 
 @[deprecated bind_congr (since := "2025-03-20")]

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -204,7 +204,8 @@ theorem exists_mem_image {f : α → β} {s : Set α} {p : β → Prop} :
     (∃ y ∈ f '' s, p y) ↔ ∃ x ∈ s, p (f x) := by simp
 
 @[congr]
-theorem image_congr {f g : α → β} {s : Set α} (h : ∀ a ∈ s, f a = g a) : f '' s = g '' s := by
+theorem image_congr {f g : α → β} {s : Set α}
+    (h : ∀ a ∈ s, binderNameHint a f (f a) = g a) : f '' s = g '' s := by
   aesop
 
 /-- A common special case of `image_congr` -/

--- a/Mathlib/Data/Sym/Basic.lean
+++ b/Mathlib/Data/Sym/Basic.lean
@@ -367,7 +367,8 @@ theorem map_cons {n : ℕ} (f : α → β) (a : α) (s : Sym α n) : (a ::ₛ s)
   ext <| Multiset.map_cons _ _ _
 
 @[congr]
-theorem map_congr {f g : α → β} {s : Sym α n} (h : ∀ x ∈ s, f x = g x) : map f s = map g s :=
+theorem map_congr {f g : α → β} {s : Sym α n} (h : ∀ x ∈ s, binderNameHint x f (f x) = g x) :
+    map f s = map g s :=
   Subtype.ext <| Multiset.map_congr rfl h
 
 @[simp]

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -382,7 +382,8 @@ theorem mem_map {f : α → β} {b : β} {z : Sym2 α} : b ∈ Sym2.map f z ↔ 
   aesop
 
 @[congr]
-theorem map_congr {f g : α → β} {s : Sym2 α} (h : ∀ x ∈ s, f x = g x) : map f s = map g s := by
+theorem map_congr {f g : α → β} {s : Sym2 α} (h : ∀ x ∈ s, binderNameHint x f (f x) = g x) :
+    map f s = map g s := by
   ext y
   simp only [mem_map]
   constructor <;>


### PR DESCRIPTION
Zulip thread: [#new members > Choosing dummy variable inside summation @ 💬](https://leanprover.zulipchat.com/#narrow/channel/113489-new-members/topic/Choosing.20dummy.20variable.20inside.20summation/near/518492888)

Co-authored-by: Joachim Breitner <mail@joachim-breitner.de>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
