### PR TITLE
feat: the CFC commutes with set integrals

### DIFF
--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
@@ -17,12 +17,12 @@ that the integral commutes with the continuous functional calculus under appropr
 
 ## Main declarations
 
-+ `cfc_integral`: given a function `f : X → 𝕜 → 𝕜`, we have that
-  `cfc (fun r => ∫ x, f x r ∂μ) a = ∫ x, cfc (f x) a ∂μ`
-  under appropriate conditions
-+ `cfcₙ_integral`: given a function `f : X → 𝕜 → 𝕜`, we have that
-  `cfcₙ (fun r => ∫ x, f x r ∂μ) a = ∫ x, cfcₙ (f x) a ∂μ`
-  under appropriate conditions
++ `cfc_setIntegral` (resp. `cfc_integral`): given a function `f : X → 𝕜 → 𝕜`, we have that
+  `cfc (fun r => ∫ x in s, f x r ∂μ) a = ∫ x in s, cfc (f x) a ∂μ`
+  under appropriate conditions (resp. with `s = univ`)
++ `cfcₙ_integral`: the same for the non-unital continuous functional calculus
++ `integrable_cfc_set`, `integrable_cfcₙ_set`, `integrable_cfc`, `integrable_cfcₙ`:
+  functions of the form `fun x => cfc (f x) a` are integrable.
 
 ## TODO
 
@@ -37,53 +37,209 @@ section unital
 
 variable {X : Type*} {𝕜 : Type*} {A : Type*} {p : A → Prop} [RCLike 𝕜]
   [MeasurableSpace X] {μ : Measure X}
-  [NormedRing A] [StarRing A] [NormedAlgebra 𝕜 A] [NormedAlgebra ℝ A] [CompleteSpace A]
+  [NormedRing A] [StarRing A] [NormedAlgebra 𝕜 A] [CompleteSpace A]
   [ContinuousFunctionalCalculus 𝕜 A p]
 
-lemma cfcL_integral (a : A) (f : X → C(spectrum 𝕜 a, 𝕜)) (hf₁ : Integrable f μ)
+lemma cfcL_integral [NormedAlgebra ℝ A] (a : A) (f : X → C(spectrum 𝕜 a, 𝕜)) (hf₁ : Integrable f μ)
     (ha : p a := by cfc_tac) :
     ∫ x, cfcL (a := a) ha (f x) ∂μ = cfcL (a := a) ha (∫ x, f x ∂μ) := by
   rw [ContinuousLinearMap.integral_comp_comm _ hf₁]
 
-lemma cfcHom_integral (a : A) (f : X → C(spectrum 𝕜 a, 𝕜)) (hf₁ : Integrable f μ)
-    (ha : p a := by cfc_tac) :
+lemma cfcHom_integral [NormedAlgebra ℝ A] (a : A) (f : X → C(spectrum 𝕜 a, 𝕜))
+    (hf₁ : Integrable f μ) (ha : p a := by cfc_tac) :
     ∫ x, cfcHom (a := a) ha (f x) ∂μ = cfcHom (a := a) ha (∫ x, f x ∂μ) :=
   cfcL_integral a f hf₁ ha
 
-open ContinuousMap in
-/-- The continuous functional calculus commutes with integration. -/
-lemma cfc_integral [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → 𝕜 → 𝕜)
+open ContinuousMap Classical in
+lemma integrable_cfc_set (s : Set X)
+    (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜)
+    (bound : X → ℝ) (a : A)
+    (hf₁ : ∀ x ∈ s, ContinuousOn (f x) (spectrum 𝕜 a))
+    (hf₂ : AEStronglyMeasurable (fun x : X =>
+      if h : x ∈ s then (⟨_, (hf₁ x h).restrict⟩ : C(spectrum 𝕜 a, 𝕜)) else 0) (μ.restrict s))
+    (hbound : ∀ x ∈ s, ∀ z ∈ spectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
+    (hbound_finite_integral : HasFiniteIntegral bound (μ.restrict s)) (ha : p a := by cfc_tac) :
+    IntegrableOn (fun x => cfc (f x) a) s μ := by
+  have ha : p a := ha
+  let fc : X → C(spectrum 𝕜 a, 𝕜) := fun x =>
+    if h : x ∈ s then ⟨_, (hf₁ x h).restrict⟩ else 0
+  have hfc : s.EqOn (fun x r => fc x r) (fun x => (spectrum 𝕜 a).restrict (f x)) := by
+    intro x hx
+    ext
+    simp [fc, hx]
+  have fc_integrable : IntegrableOn fc s μ := by
+    refine ⟨hf₂, ?_⟩
+    refine hbound_finite_integral.mono ?_
+    filter_upwards [ae_restrict_mem hs] with x hx
+    rw [norm_le _ (norm_nonneg (bound x))]
+    intro z
+    have := hfc hx
+    simp only at this
+    simp only [this, Set.restrict_apply]
+    exact hbound x hx z.1 z.2
+  have h₁ : s.EqOn (fun x : X => cfc (f x) a) (fun x : X => cfcL ha (fc x)) := by
+    intro x hx
+    dsimp
+    rw [cfc_apply ..]
+    unfold fc
+    simp [hx]
+  refine .congr_fun ?_ h₁.symm hs
+  exact ContinuousLinearMap.integrable_comp _ fc_integrable
+
+open ContinuousMap Classical in
+lemma integrable_cfc_set' [TopologicalSpace X] [OpensMeasurableSpace X] (s : Set X)
+    (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜)
+    (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(spectrum 𝕜 a, 𝕜)]
+    (hf : Continuous (fun x : s × spectrum 𝕜 a => f x.1 x.2))
+    (hbound : ∀ x ∈ s, ∀ z ∈ spectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
+    (hbound_finite_integral : HasFiniteIntegral bound (μ.restrict s)) (ha : p a := by cfc_tac) :
+    IntegrableOn (fun x => cfc (f x) a) s μ := by
+  let fc : C(s × (spectrum 𝕜 a), 𝕜) := ⟨fun x => f x.1 x.2, hf⟩
+  let fc₂ := fc.curry
+  refine integrable_cfc_set s hs f bound a ?_ ?_ hbound hbound_finite_integral
+  · intro x xs
+    rw [continuousOn_iff_continuous_restrict]
+    exact (fc₂ ⟨x, xs⟩).continuous
+  · refine ContinuousOn.aestronglyMeasurable ?_ hs
+    rw [continuousOn_iff_continuous_restrict]
+    refine fc₂.continuous.congr ?_
+    intro ⟨x, hx⟩
+    ext
+    simp [fc₂, fc, hx]
+
+open ContinuousMap Set in
+lemma integrable_cfc [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → 𝕜 → 𝕜)
     (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(spectrum 𝕜 a, 𝕜)]
     (hf₁ : ∀ x, ContinuousOn (f x) (spectrum 𝕜 a))
-    (hf₂ : Continuous (fun x ↦ (⟨_, hf₁ x |>.restrict⟩ : C(spectrum 𝕜 a, 𝕜))))
+    (hf₂ : AEStronglyMeasurable (fun x ↦ (⟨_, hf₁ x |>.restrict⟩ : C(spectrum 𝕜 a, 𝕜))) μ)
     (hbound : ∀ x, ∀ z ∈ spectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
     (hbound_finite_integral : HasFiniteIntegral bound μ) (ha : p a := by cfc_tac) :
-    cfc (fun r => ∫ x, f x r ∂μ) a = ∫ x, cfc (f x) a ∂μ := by
-  let fc : X → C(spectrum 𝕜 a, 𝕜) := fun x => ⟨_, (hf₁ x).restrict⟩
-  have fc_integrable : Integrable fc μ := by
-    refine ⟨hf₂.aestronglyMeasurable, ?_⟩
-    refine hbound_finite_integral.mono <| .of_forall fun x ↦ ?_
-    rw [norm_le _ (norm_nonneg (bound x))]
-    exact fun z ↦ hbound x z.1 z.2
-  have h_int_fc : (spectrum 𝕜 a).restrict (∫ x, f x · ∂μ) = ∫ x, fc x ∂μ := by
-    ext; simp [integral_apply fc_integrable, fc]
-  have hcont₂ : ContinuousOn (fun r => ∫ x, f x r ∂μ) (spectrum 𝕜 a) := by
+    Integrable (fun x => cfc (f x) a) μ := by
+  rw [← integrableOn_univ]
+  refine integrable_cfc_set univ MeasurableSet.univ f bound a ?_ ?_ ?_ ?_ ha
+  · exact fun x _ => hf₁ x
+  · simp [hf₂]
+  · exact fun x _ => hbound x
+  · simp [hbound_finite_integral]
+
+open ContinuousMap in
+lemma integrable_cfc' [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → 𝕜 → 𝕜)
+    (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(spectrum 𝕜 a, 𝕜)]
+    (hf : Continuous (fun x : X × spectrum 𝕜 a => f x.1 x.2))
+    (hbound : ∀ x, ∀ z ∈ spectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
+    (hbound_finite_integral : HasFiniteIntegral bound μ) (ha : p a := by cfc_tac) :
+    Integrable (fun x => cfc (f x) a) μ := by
+  let fc : C(X × (spectrum 𝕜 a), 𝕜) := ⟨fun x => f x.1 x.2, hf⟩
+  let fc₂ := fc.curry
+  refine integrable_cfc f bound a ?_ ?_ hbound hbound_finite_integral
+  · intro x
     rw [continuousOn_iff_continuous_restrict]
-    convert map_continuous (∫ x, fc x ∂μ)
-  rw [integral_congr_ae (.of_forall fun _ ↦ cfc_apply ..), cfc_apply ..,
-    cfcHom_integral _ _ fc_integrable]
+    exact (fc₂ x).continuous
+  · apply Continuous.aestronglyMeasurable
+    exact ContinuousMap.curry ⟨_, hf⟩ |>.continuous
+
+open ContinuousMap Classical in
+/-- The continuous functional calculus commutes with integration. -/
+lemma cfc_setIntegral [NormedAlgebra ℝ A] (s : Set X) (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜)
+    (bound : X → ℝ) (a : A)
+    (hf₁ : ∀ x ∈ s, ContinuousOn (f x) (spectrum 𝕜 a))
+    (hf₂ : AEStronglyMeasurable (fun x : X =>
+      if h : x ∈ s then (⟨_, (hf₁ x h).restrict⟩ : C(spectrum 𝕜 a, 𝕜)) else 0) (μ.restrict s))
+    (hbound : ∀ x ∈ s, ∀ z ∈ spectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
+    (hbound_finite_integral : HasFiniteIntegral bound (μ.restrict s)) (ha : p a := by cfc_tac) :
+    cfc (fun r => ∫ x in s, f x r ∂μ) a = ∫ x in s, cfc (f x) a ∂μ := by
+  let fc : X → C(spectrum 𝕜 a, 𝕜) := fun x =>
+    if h : x ∈ s then ⟨_, (hf₁ x h).restrict⟩ else 0
+  have hfc : s.EqOn (fun x r => fc x r) (fun x => (spectrum 𝕜 a).restrict (f x)) := by
+    intro x hx
+    ext
+    simp [fc, hx]
+  have fc_integrable : IntegrableOn fc s μ := by
+    refine ⟨hf₂, ?_⟩
+    refine hbound_finite_integral.mono ?_
+    filter_upwards [ae_restrict_mem hs] with x hx
+    rw [norm_le _ (norm_nonneg (bound x))]
+    intro z
+    have := hfc hx
+    simp only at this
+    simp only [this, Set.restrict_apply]
+    exact hbound x hx z.1 z.2
+  have ha : p a := ha
+  have h₁ : s.EqOn (fun x : X => cfc (f x) a) (fun x : X => cfcL ha (fc x)) := by
+    intro x hx
+    dsimp
+    rw [cfc_apply ..]
+    unfold fc
+    simp [hx]
+  have h₂ : ((spectrum 𝕜 a).restrict
+      fun r => ∫ (x : X) in s, f x r ∂μ) = (∫ (x : X) in s, fc x ∂μ).toFun := by
+    ext r
+    simp only [Set.restrict_apply, toFun_eq_coe, fc, ContinuousMap.integral_apply fc_integrable _]
+    refine integral_congr_ae ?_
+    filter_upwards [ae_restrict_mem hs] with x hx
+    simp [fc, hx]
+  have hcont₂ : ContinuousOn (fun r => ∫ x in s, f x r ∂μ) (spectrum 𝕜 a) := by
+    rw [continuousOn_iff_continuous_restrict]
+    convert map_continuous (∫ x in s, fc x ∂μ)
+  rw [setIntegral_congr_fun hs h₁, ContinuousLinearMap.integral_comp_comm _ fc_integrable,
+      cfcL_apply, cfc_apply ..]
   congr
 
+open ContinuousMap Classical in
 /-- The continuous functional calculus commutes with integration. -/
-lemma cfc_integral' [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → 𝕜 → 𝕜)
+lemma cfc_setIntegral' [NormedAlgebra ℝ A] [TopologicalSpace X] [OpensMeasurableSpace X] (s : Set X)
+    (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜)
     (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(spectrum 𝕜 a, 𝕜)]
-    (hf : Continuous (fun x => (spectrum 𝕜 a).restrict (f x)).uncurry)
+    (hf : Continuous (fun x : s × spectrum 𝕜 a => f x.1 x.2))
+    (hbound : ∀ x ∈ s, ∀ z ∈ spectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
+    (hbound_finite_integral : HasFiniteIntegral bound (μ.restrict s)) (ha : p a := by cfc_tac) :
+    cfc (fun r => ∫ x in s, f x r ∂μ) a = ∫ x in s, cfc (f x) a ∂μ := by
+  let fc : C(s × (spectrum 𝕜 a), 𝕜) := ⟨fun x => f x.1 x.2, hf⟩
+  let fc₂ := fc.curry
+  refine cfc_setIntegral s hs f bound a ?_ ?_ hbound hbound_finite_integral
+  · intro x xs
+    rw [continuousOn_iff_continuous_restrict]
+    exact (fc₂ ⟨x, xs⟩).continuous
+  · refine ContinuousOn.aestronglyMeasurable ?_ hs
+    rw [continuousOn_iff_continuous_restrict]
+    refine fc₂.continuous.congr ?_
+    intro ⟨x, hx⟩
+    ext
+    simp [fc₂, fc, hx]
+
+open ContinuousMap Set in
+/-- The continuous functional calculus commutes with integration. -/
+lemma cfc_integral [NormedAlgebra ℝ A] [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → 𝕜 → 𝕜)
+    (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(spectrum 𝕜 a, 𝕜)]
+    (hf₁ : ∀ x, ContinuousOn (f x) (spectrum 𝕜 a))
+    (hf₂ : AEStronglyMeasurable (fun x ↦ (⟨_, hf₁ x |>.restrict⟩ : C(spectrum 𝕜 a, 𝕜))) μ)
     (hbound : ∀ x, ∀ z ∈ spectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
     (hbound_finite_integral : HasFiniteIntegral bound μ) (ha : p a := by cfc_tac) :
     cfc (fun r => ∫ x, f x r ∂μ) a = ∫ x, cfc (f x) a ∂μ := by
+  have : cfc (fun r => ∫ x, f x r ∂μ) a = cfc (fun r => ∫ x in univ, f x r ∂μ) a := by
+    simp [← setIntegral_univ]
+  rw [← setIntegral_univ, this]
+  refine cfc_setIntegral univ MeasurableSet.univ f bound a ?_ ?_ ?_ ?_
+  · exact fun x _ => hf₁ x
+  · simp [hf₂]
+  · exact fun x _ => hbound x
+  · simp [hbound_finite_integral]
+
+/-- The continuous functional calculus commutes with integration. -/
+lemma cfc_integral' [NormedAlgebra ℝ A] [TopologicalSpace X] [OpensMeasurableSpace X]
+    (f : X → 𝕜 → 𝕜) (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(spectrum 𝕜 a, 𝕜)]
+    (hf : Continuous (fun x : X × spectrum 𝕜 a => f x.1 x.2))
+    (hbound : ∀ x, ∀ z ∈ spectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
+    (hbound_finite_integral : HasFiniteIntegral bound μ) (ha : p a := by cfc_tac) :
+    cfc (fun r => ∫ x, f x r ∂μ) a = ∫ x, cfc (f x) a ∂μ := by
+  let fc : C(X × (spectrum 𝕜 a), 𝕜) := ⟨fun x => f x.1 x.2, hf⟩
+  let fc₂ := fc.curry
   refine cfc_integral f bound a ?_ ?_ hbound hbound_finite_integral
-  · exact (continuousOn_iff_continuous_restrict.mpr <| hf.uncurry_left ·)
-  · exact ContinuousMap.curry ⟨_, hf⟩ |>.continuous
+  · intro x
+    rw [continuousOn_iff_continuous_restrict]
+    exact (fc₂ x).continuous
+  · apply Continuous.aestronglyMeasurable
+    exact ContinuousMap.curry ⟨_, hf⟩ |>.continuous
 
 end unital
 
@@ -91,22 +247,138 @@ section nonunital
 
 variable {X : Type*} {𝕜 : Type*} {A : Type*} {p : A → Prop} [RCLike 𝕜]
   [MeasurableSpace X] {μ : Measure X} [NonUnitalNormedRing A] [StarRing A] [CompleteSpace A]
-  [NormedSpace 𝕜 A] [NormedSpace ℝ A] [IsScalarTower 𝕜 A A] [SMulCommClass 𝕜 A A]
+  [NormedSpace 𝕜 A] [IsScalarTower 𝕜 A A] [SMulCommClass 𝕜 A A]
   [NonUnitalContinuousFunctionalCalculus 𝕜 A p]
 
-lemma cfcₙL_integral (a : A) (f : X → C(quasispectrum 𝕜 a, 𝕜)₀) (hf₁ : Integrable f μ)
-    (ha : p a := by cfc_tac) :
+lemma cfcₙL_integral [NormedSpace ℝ A] (a : A) (f : X → C(quasispectrum 𝕜 a, 𝕜)₀)
+    (hf₁ : Integrable f μ) (ha : p a := by cfc_tac) :
     ∫ x, cfcₙL (a := a) ha (f x) ∂μ = cfcₙL (a := a) ha (∫ x, f x ∂μ) := by
   rw [ContinuousLinearMap.integral_comp_comm _ hf₁]
 
-lemma cfcₙHom_integral (a : A) (f : X → C(quasispectrum 𝕜 a, 𝕜)₀) (hf₁ : Integrable f μ)
-    (ha : p a := by cfc_tac) :
+lemma cfcₙHom_integral [NormedSpace ℝ A] (a : A) (f : X → C(quasispectrum 𝕜 a, 𝕜)₀)
+    (hf₁ : Integrable f μ) (ha : p a := by cfc_tac) :
     ∫ x, cfcₙHom (a := a) ha (f x) ∂μ = cfcₙHom (a := a) ha (∫ x, f x ∂μ) :=
   cfcₙL_integral a f hf₁ ha
 
+open ContinuousMapZero Classical in
+lemma integrable_cfcₙ_set (s : Set X)
+    (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜)
+    (bound : X → ℝ) (a : A)
+    (hf₁ : ∀ x ∈ s, ContinuousOn (f x) (quasispectrum 𝕜 a))
+    (hf₂ : ∀ x ∈ s, f x 0 = 0)
+    (hf₃ : AEStronglyMeasurable (fun x : X =>
+      if h : x ∈ s then
+        (⟨⟨_, (hf₁ x h).restrict⟩, by simp [hf₂ x h]⟩ : C(quasispectrum 𝕜 a, 𝕜)₀)
+      else 0) (μ.restrict s))
+    (hbound : ∀ x ∈ s, ∀ z ∈ quasispectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
+    (hbound_finite_integral : HasFiniteIntegral bound (μ.restrict s)) (ha : p a := by cfc_tac) :
+    IntegrableOn (fun x => cfcₙ (f x) a) s μ := by
+  have ha : p a := ha
+  let fc : X → C(quasispectrum 𝕜 a, 𝕜)₀ := fun x =>
+    if h : x ∈ s then ⟨⟨_, (hf₁ x h).restrict⟩, by simp [hf₂ x h]⟩ else 0
+  have hfc : s.EqOn (fun x r => fc x r) (fun x => (quasispectrum 𝕜 a).restrict (f x)) := by
+    intro x hx
+    ext
+    simp [fc, hx]
+  have fc_integrable : IntegrableOn fc s μ := by
+    refine ⟨hf₃, ?_⟩
+    refine hbound_finite_integral.mono ?_
+    filter_upwards [ae_restrict_mem hs] with x hx
+    rw [norm_def, ContinuousMap.norm_le _ (norm_nonneg (bound x))]
+    intro z
+    have := hfc hx
+    simp only at this
+    simp only [ContinuousMap.coe_coe, this, Set.restrict_apply, Real.norm_eq_abs, ge_iff_le, fc]
+    exact hbound x hx z.1 z.2
+  have h₁ : s.EqOn (fun x : X => cfcₙ (f x) a) (fun x : X => cfcₙL ha (fc x)) := by
+    intro x hx
+    dsimp
+    rw [cfcₙ_apply ..]
+    unfold fc
+    simp [hx]
+  refine .congr_fun ?_ h₁.symm hs
+  exact ContinuousLinearMap.integrable_comp _ fc_integrable
+
+open ContinuousMap Classical in
+lemma integrable_cfcₙ_set' [TopologicalSpace X] [OpensMeasurableSpace X] (s : Set X)
+    (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜)
+    (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(quasispectrum 𝕜 a, 𝕜)₀]
+    (hf : Continuous (fun x : s × quasispectrum 𝕜 a => f x.1 x.2))
+    (hf₂ : ∀ x ∈ s, f x 0 = 0)
+    (hbound : ∀ x ∈ s, ∀ z ∈ quasispectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
+    (hbound_finite_integral : HasFiniteIntegral bound (μ.restrict s)) (ha : p a := by cfc_tac) :
+    IntegrableOn (fun x => cfcₙ (f x) a) s μ := by
+  let fc : C(s × (quasispectrum 𝕜 a), 𝕜) := ⟨fun x => f x.1 x.2, hf⟩
+  let fc₂ : C(s, C(quasispectrum 𝕜 a, 𝕜)₀) :=
+    { toFun := fun x => ⟨fc.curry x, by simp [fc, hf₂]⟩
+      continuous_toFun := by sorry }
+  refine integrable_cfcₙ_set s hs f bound a ?_ hf₂ ?_ hbound hbound_finite_integral
+  · intro x xs
+    rw [continuousOn_iff_continuous_restrict]
+    exact (fc₂ ⟨x, xs⟩).continuous
+  · refine ContinuousOn.aestronglyMeasurable ?_ hs
+    rw [continuousOn_iff_continuous_restrict]
+
+    refine fc₂.continuous.congr ?_
+    intro ⟨x, hx⟩
+    ext
+    simp [fc₂, fc, hx]
+
+open ContinuousMapZero Classical in
+/-- The continuous functional calculus commutes with integration. -/
+lemma cfcₙ_setIntegral [NormedSpace ℝ A] (s : Set X) (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜)
+    (bound : X → ℝ) (a : A)
+    (hf₁ : ∀ x ∈ s, ContinuousOn (f x) (quasispectrum 𝕜 a))
+    (hf₂ : ∀ x ∈ s, f x 0 = 0)
+    (hf₃ : AEStronglyMeasurable (fun x : X =>
+      if h : x ∈ s then
+        (⟨⟨_, (hf₁ x h).restrict⟩, by simp [hf₂ x h]⟩ : C(quasispectrum 𝕜 a, 𝕜)₀)
+      else 0) (μ.restrict s))
+    (hbound : ∀ x ∈ s, ∀ z ∈ quasispectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
+    (hbound_finite_integral : HasFiniteIntegral bound (μ.restrict s)) (ha : p a := by cfc_tac) :
+    cfcₙ (fun r => ∫ x in s, f x r ∂μ) a = ∫ x in s, cfcₙ (f x) a ∂μ := by
+  let fc : X → C(quasispectrum 𝕜 a, 𝕜)₀ := fun x =>
+    if h : x ∈ s then ⟨⟨_, (hf₁ x h).restrict⟩, by simp [hf₂ x h]⟩ else 0
+  have hfc : s.EqOn (fun x r => fc x r) (fun x => (quasispectrum 𝕜 a).restrict (f x)) := by
+    intro x hx
+    ext
+    simp [fc, hx]
+  have fc_integrable : IntegrableOn fc s μ := by
+    refine ⟨hf₃, ?_⟩
+    refine hbound_finite_integral.mono ?_
+    filter_upwards [ae_restrict_mem hs] with x hx
+    rw [norm_def, ContinuousMap.norm_le _ (norm_nonneg (bound x))]
+    intro z
+    have := hfc hx
+    simp only at this
+    simp only [ContinuousMap.coe_coe, this, Set.restrict_apply, Real.norm_eq_abs, ge_iff_le, fc]
+    exact hbound x hx z.1 z.2
+  have ha : p a := ha
+  have h₁ : s.EqOn (fun x : X => cfcₙ (f x) a) (fun x : X => cfcₙL ha (fc x)) := by
+    intro x hx
+    dsimp
+    rw [cfcₙ_apply ..]
+    unfold fc
+    simp [hx]
+  have h₂ : ((quasispectrum 𝕜 a).restrict fun r => ∫ (x : X) in s, f x r ∂μ)
+      = (∫ (x : X) in s, fc x ∂μ).toFun := by
+    ext r
+    simp [Set.restrict_apply, ContinuousMap.toFun_eq_coe, fc, ContinuousMapZero.integral_apply fc_integrable _]
+    sorry
+    --refine integral_congr_ae ?_
+    --filter_upwards [ae_restrict_mem hs] with x hx
+    --simp [fc, hx]
+  have hcont₂ : ContinuousOn (fun r => ∫ x in s, f x r ∂μ) (quasispectrum 𝕜 a) := by
+    rw [continuousOn_iff_continuous_restrict]
+    convert map_continuous (∫ x in s, fc x ∂μ)
+  sorry
+  --rw [setIntegral_congr_fun hs h₁, ContinuousLinearMap.integral_comp_comm _ fc_integrable,
+  --    cfcₙL_apply, cfcₙ_apply ..]
+  --congr
+
 open ContinuousMapZero in
 /-- The non-unital continuous functional calculus commutes with integration. -/
-lemma cfcₙ_integral [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → 𝕜 → 𝕜)
+lemma cfcₙ_integral [NormedSpace ℝ A] [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → 𝕜 → 𝕜)
     (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(quasispectrum 𝕜 a, 𝕜)₀]
     (hf₁ : ∀ x, ContinuousOn (f x) (quasispectrum 𝕜 a))
     (hf₂ : ∀ x, f x 0 = 0)
@@ -131,7 +403,7 @@ lemma cfcₙ_integral [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → �
   congr
 
 /-- The non-unital continuous functional calculus commutes with integration. -/
-lemma cfcₙ_integral' [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → 𝕜 → 𝕜)
+lemma cfcₙ_integral' [NormedSpace ℝ A] [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → 𝕜 → 𝕜)
     (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(quasispectrum 𝕜 a, 𝕜)₀]
     (hf : Continuous (fun x => (quasispectrum 𝕜 a).restrict (f x)).uncurry)
     (hf₂ : ∀ x, f x 0 = 0)

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
@@ -106,8 +106,7 @@ lemma integrable_cfc_set' [TopologicalSpace X] [OpensMeasurableSpace X] {s : Set
     simp [fc₂, fc, hx]
 
 open ContinuousMap Set in
-lemma integrable_cfc [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → 𝕜 → 𝕜)
-    (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(spectrum 𝕜 a, 𝕜)]
+lemma integrable_cfc (f : X → 𝕜 → 𝕜) (bound : X → ℝ) (a : A)
     (hf₁ : ∀ x, ContinuousOn (f x) (spectrum 𝕜 a))
     (hf₂ : AEStronglyMeasurable (fun x ↦ (⟨_, hf₁ x |>.restrict⟩ : C(spectrum 𝕜 a, 𝕜))) μ)
     (hbound : ∀ x, ∀ z ∈ spectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
@@ -206,8 +205,7 @@ lemma cfc_setIntegral' [NormedAlgebra ℝ A] [TopologicalSpace X] [OpensMeasurab
 
 open ContinuousMap Set in
 /-- The continuous functional calculus commutes with integration. -/
-lemma cfc_integral [NormedAlgebra ℝ A] [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → 𝕜 → 𝕜)
-    (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(spectrum 𝕜 a, 𝕜)]
+lemma cfc_integral [NormedAlgebra ℝ A] (f : X → 𝕜 → 𝕜) (bound : X → ℝ) (a : A)
     (hf₁ : ∀ x, ContinuousOn (f x) (spectrum 𝕜 a))
     (hf₂ : AEStronglyMeasurable (fun x ↦ (⟨_, hf₁ x |>.restrict⟩ : C(spectrum 𝕜 a, 𝕜))) μ)
     (hbound : ∀ x, ∀ z ∈ spectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
@@ -413,10 +411,8 @@ lemma cfcₙ_setIntegral' [NormedSpace ℝ A] [TopologicalSpace X] [OpensMeasura
 
 open ContinuousMapZero Set in
 /-- The non-unital continuous functional calculus commutes with integration. -/
-lemma cfcₙ_integral [NormedSpace ℝ A] [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → 𝕜 → 𝕜)
-    (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(quasispectrum 𝕜 a, 𝕜)₀]
-    (hf₁ : ∀ x, ContinuousOn (f x) (quasispectrum 𝕜 a))
-    (hf₂ : ∀ x, f x 0 = 0)
+lemma cfcₙ_integral [NormedSpace ℝ A] (f : X → 𝕜 → 𝕜) (bound : X → ℝ) (a : A)
+    (hf₁ : ∀ x, ContinuousOn (f x) (quasispectrum 𝕜 a)) (hf₂ : ∀ x, f x 0 = 0)
     (hf₃ : AEStronglyMeasurable
       (fun x ↦ (⟨⟨_, hf₁ x |>.restrict⟩, by simp [hf₂]⟩ : C(quasispectrum 𝕜 a, 𝕜)₀)) μ)
     (hbound : ∀ x, ∀ z ∈ quasispectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
@@ -311,14 +311,19 @@ lemma integrable_cfcₙ_set' [TopologicalSpace X] [OpensMeasurableSpace X] (s : 
   let fc : C(s × (quasispectrum 𝕜 a), 𝕜) := ⟨fun x => f x.1 x.2, hf⟩
   let fc₂ : C(s, C(quasispectrum 𝕜 a, 𝕜)₀) :=
     { toFun := fun x => ⟨fc.curry x, by simp [fc, hf₂]⟩
-      continuous_toFun := by sorry }
+      continuous_toFun := by
+        have : Continuous
+            (ContinuousMapZero.toContinuousMap ∘ (fun x => ⟨fc.curry x, by simp [fc, hf₂]⟩)) :=
+          ContinuousMap.continuous fc.curry
+        refine (Topology.IsEmbedding.continuous_iff ?_).mpr this
+        apply IsUniformEmbedding.isEmbedding
+        exact Isometry.isUniformEmbedding fun x1 ↦ congrFun rfl }
   refine integrable_cfcₙ_set s hs f bound a ?_ hf₂ ?_ hbound hbound_finite_integral
   · intro x xs
     rw [continuousOn_iff_continuous_restrict]
     exact (fc₂ ⟨x, xs⟩).continuous
   · refine ContinuousOn.aestronglyMeasurable ?_ hs
     rw [continuousOn_iff_continuous_restrict]
-
     refine fc₂.continuous.congr ?_
     intro ⟨x, hx⟩
     ext
@@ -363,18 +368,54 @@ lemma cfcₙ_setIntegral [NormedSpace ℝ A] (s : Set X) (hs : MeasurableSet s) 
   have h₂ : ((quasispectrum 𝕜 a).restrict fun r => ∫ (x : X) in s, f x r ∂μ)
       = (∫ (x : X) in s, fc x ∂μ).toFun := by
     ext r
-    simp [Set.restrict_apply, ContinuousMap.toFun_eq_coe, fc, ContinuousMapZero.integral_apply fc_integrable _]
-    sorry
-    --refine integral_congr_ae ?_
-    --filter_upwards [ae_restrict_mem hs] with x hx
-    --simp [fc, hx]
+    change (quasispectrum 𝕜 a).restrict (fun r ↦ ∫ (x : X) in s, f x r ∂μ) r
+      = (∫ (x : X) in s, fc x ∂μ) r
+    rw [ContinuousMapZero.integral_apply fc_integrable]
+    simp only [Set.restrict_apply, fc]
+    refine integral_congr_ae ?_
+    filter_upwards [ae_restrict_mem hs] with x hx
+    simp [fc, hx]
   have hcont₂ : ContinuousOn (fun r => ∫ x in s, f x r ∂μ) (quasispectrum 𝕜 a) := by
     rw [continuousOn_iff_continuous_restrict]
     convert map_continuous (∫ x in s, fc x ∂μ)
-  sorry
-  --rw [setIntegral_congr_fun hs h₁, ContinuousLinearMap.integral_comp_comm _ fc_integrable,
-  --    cfcₙL_apply, cfcₙ_apply ..]
-  --congr
+  have hf0 : (fun r => ∫ (x : X) in s, f x r ∂μ) 0 = 0 := by
+    simp only [fc]
+    calc ∫ x in s, f x 0 ∂μ = ∫ x in s, 0 ∂μ := setIntegral_congr_fun hs hf₂
+      _ = 0 := by simp
+  rw [setIntegral_congr_fun hs h₁, ContinuousLinearMap.integral_comp_comm _ fc_integrable,
+      cfcₙL_apply, cfcₙ_apply ..]
+  congr
+
+open ContinuousMap Classical in
+/-- The continuous functional calculus commutes with integration. -/
+lemma cfcₙ_setIntegral' [NormedSpace ℝ A] [TopologicalSpace X] [OpensMeasurableSpace X] (s : Set X)
+    (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜)
+    (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(quasispectrum 𝕜 a, 𝕜)₀]
+    (hf : Continuous (fun x : s × quasispectrum 𝕜 a => f x.1 x.2))
+    (hf₂ : ∀ x ∈ s, f x 0 = 0)
+    (hbound : ∀ x ∈ s, ∀ z ∈ quasispectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
+    (hbound_finite_integral : HasFiniteIntegral bound (μ.restrict s)) (ha : p a := by cfc_tac) :
+    cfcₙ (fun r => ∫ x in s, f x r ∂μ) a = ∫ x in s, cfcₙ (f x) a ∂μ := by
+  let fc : C(s × (quasispectrum 𝕜 a), 𝕜) := ⟨fun x => f x.1 x.2, hf⟩
+  let fc₂ : C(s, C(quasispectrum 𝕜 a, 𝕜)₀) :=
+    { toFun := fun x => ⟨fc.curry x, by simp [fc, hf₂]⟩
+      continuous_toFun := by
+        have : Continuous
+            (ContinuousMapZero.toContinuousMap ∘ (fun x => ⟨fc.curry x, by simp [fc, hf₂]⟩)) :=
+          ContinuousMap.continuous fc.curry
+        refine (Topology.IsEmbedding.continuous_iff ?_).mpr this
+        apply IsUniformEmbedding.isEmbedding
+        exact Isometry.isUniformEmbedding fun x1 ↦ congrFun rfl }
+  refine cfcₙ_setIntegral s hs f bound a ?_ hf₂ ?_ hbound hbound_finite_integral
+  · intro x xs
+    rw [continuousOn_iff_continuous_restrict]
+    exact (fc₂ ⟨x, xs⟩).continuous
+  · refine ContinuousOn.aestronglyMeasurable ?_ hs
+    rw [continuousOn_iff_continuous_restrict]
+    refine fc₂.continuous.congr ?_
+    intro ⟨x, hx⟩
+    ext
+    simp [fc₂, fc, hx]
 
 open ContinuousMapZero in
 /-- The non-unital continuous functional calculus commutes with integration. -/

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
@@ -51,10 +51,8 @@ lemma cfcHom_integral [NormedAlgebra ℝ A] (a : A) (f : X → C(spectrum 𝕜 a
   cfcL_integral a f hf₁ ha
 
 open ContinuousMap Classical in
-lemma integrable_cfc_set (s : Set X)
-    (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜)
-    (bound : X → ℝ) (a : A)
-    (hf₁ : ∀ x ∈ s, ContinuousOn (f x) (spectrum 𝕜 a))
+lemma integrable_cfc_set {s : Set X} (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜)
+    (bound : X → ℝ) (a : A) (hf₁ : ∀ x ∈ s, ContinuousOn (f x) (spectrum 𝕜 a))
     (hf₂ : AEStronglyMeasurable (fun x : X =>
       if h : x ∈ s then (⟨_, (hf₁ x h).restrict⟩ : C(spectrum 𝕜 a, 𝕜)) else 0) (μ.restrict s))
     (hbound : ∀ x ∈ s, ∀ z ∈ spectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
@@ -87,16 +85,16 @@ lemma integrable_cfc_set (s : Set X)
   exact ContinuousLinearMap.integrable_comp _ fc_integrable
 
 open ContinuousMap Classical in
-lemma integrable_cfc_set' [TopologicalSpace X] [OpensMeasurableSpace X] (s : Set X)
-    (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜)
-    (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(spectrum 𝕜 a, 𝕜)]
+lemma integrable_cfc_set' [TopologicalSpace X] [OpensMeasurableSpace X] {s : Set X}
+    (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜) (bound : X → ℝ) (a : A)
+    [SecondCountableTopologyEither X C(spectrum 𝕜 a, 𝕜)]
     (hf : Continuous (fun x : s × spectrum 𝕜 a => f x.1 x.2))
     (hbound : ∀ x ∈ s, ∀ z ∈ spectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
     (hbound_finite_integral : HasFiniteIntegral bound (μ.restrict s)) (ha : p a := by cfc_tac) :
     IntegrableOn (fun x => cfc (f x) a) s μ := by
   let fc : C(s × (spectrum 𝕜 a), 𝕜) := ⟨fun x => f x.1 x.2, hf⟩
   let fc₂ := fc.curry
-  refine integrable_cfc_set s hs f bound a ?_ ?_ hbound hbound_finite_integral
+  refine integrable_cfc_set hs f bound a ?_ ?_ hbound hbound_finite_integral
   · intro x xs
     rw [continuousOn_iff_continuous_restrict]
     exact (fc₂ ⟨x, xs⟩).continuous
@@ -116,7 +114,7 @@ lemma integrable_cfc [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → �
     (hbound_finite_integral : HasFiniteIntegral bound μ) (ha : p a := by cfc_tac) :
     Integrable (fun x => cfc (f x) a) μ := by
   rw [← integrableOn_univ]
-  refine integrable_cfc_set univ MeasurableSet.univ f bound a ?_ ?_ ?_ ?_ ha
+  refine integrable_cfc_set MeasurableSet.univ f bound a ?_ ?_ ?_ ?_ ha
   · exact fun x _ => hf₁ x
   · simp [hf₂]
   · exact fun x _ => hbound x
@@ -140,9 +138,8 @@ lemma integrable_cfc' [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → �
 
 open ContinuousMap Classical in
 /-- The continuous functional calculus commutes with integration. -/
-lemma cfc_setIntegral [NormedAlgebra ℝ A] (s : Set X) (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜)
-    (bound : X → ℝ) (a : A)
-    (hf₁ : ∀ x ∈ s, ContinuousOn (f x) (spectrum 𝕜 a))
+lemma cfc_setIntegral [NormedAlgebra ℝ A] {s : Set X} (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜)
+    (bound : X → ℝ) (a : A) (hf₁ : ∀ x ∈ s, ContinuousOn (f x) (spectrum 𝕜 a))
     (hf₂ : AEStronglyMeasurable (fun x : X =>
       if h : x ∈ s then (⟨_, (hf₁ x h).restrict⟩ : C(spectrum 𝕜 a, 𝕜)) else 0) (μ.restrict s))
     (hbound : ∀ x ∈ s, ∀ z ∈ spectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
@@ -187,16 +184,16 @@ lemma cfc_setIntegral [NormedAlgebra ℝ A] (s : Set X) (hs : MeasurableSet s) (
 
 open ContinuousMap Classical in
 /-- The continuous functional calculus commutes with integration. -/
-lemma cfc_setIntegral' [NormedAlgebra ℝ A] [TopologicalSpace X] [OpensMeasurableSpace X] (s : Set X)
-    (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜)
-    (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(spectrum 𝕜 a, 𝕜)]
+lemma cfc_setIntegral' [NormedAlgebra ℝ A] [TopologicalSpace X] [OpensMeasurableSpace X] {s : Set X}
+    (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜) (bound : X → ℝ) (a : A)
+    [SecondCountableTopologyEither X C(spectrum 𝕜 a, 𝕜)]
     (hf : Continuous (fun x : s × spectrum 𝕜 a => f x.1 x.2))
     (hbound : ∀ x ∈ s, ∀ z ∈ spectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
     (hbound_finite_integral : HasFiniteIntegral bound (μ.restrict s)) (ha : p a := by cfc_tac) :
     cfc (fun r => ∫ x in s, f x r ∂μ) a = ∫ x in s, cfc (f x) a ∂μ := by
   let fc : C(s × (spectrum 𝕜 a), 𝕜) := ⟨fun x => f x.1 x.2, hf⟩
   let fc₂ := fc.curry
-  refine cfc_setIntegral s hs f bound a ?_ ?_ hbound hbound_finite_integral
+  refine cfc_setIntegral hs f bound a ?_ ?_ hbound hbound_finite_integral
   · intro x xs
     rw [continuousOn_iff_continuous_restrict]
     exact (fc₂ ⟨x, xs⟩).continuous
@@ -219,7 +216,7 @@ lemma cfc_integral [NormedAlgebra ℝ A] [TopologicalSpace X] [OpensMeasurableSp
   have : cfc (fun r => ∫ x, f x r ∂μ) a = cfc (fun r => ∫ x in univ, f x r ∂μ) a := by
     simp [← setIntegral_univ]
   rw [← setIntegral_univ, this]
-  refine cfc_setIntegral univ MeasurableSet.univ f bound a ?_ ?_ ?_ ?_
+  refine cfc_setIntegral MeasurableSet.univ f bound a ?_ ?_ ?_ ?_
   · exact fun x _ => hf₁ x
   · simp [hf₂]
   · exact fun x _ => hbound x
@@ -261,9 +258,7 @@ lemma cfcₙHom_integral [NormedSpace ℝ A] (a : A) (f : X → C(quasispectrum 
   cfcₙL_integral a f hf₁ ha
 
 open ContinuousMapZero Classical in
-lemma integrable_cfcₙ_set (s : Set X)
-    (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜)
-    (bound : X → ℝ) (a : A)
+lemma integrable_cfcₙ_set {s : Set X} (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜) (bound : X → ℝ) (a : A)
     (hf₁ : ∀ x ∈ s, ContinuousOn (f x) (quasispectrum 𝕜 a))
     (hf₂ : ∀ x ∈ s, f x 0 = 0)
     (hf₃ : AEStronglyMeasurable (fun x : X =>
@@ -300,9 +295,9 @@ lemma integrable_cfcₙ_set (s : Set X)
   exact ContinuousLinearMap.integrable_comp _ fc_integrable
 
 open ContinuousMap Classical in
-lemma integrable_cfcₙ_set' [TopologicalSpace X] [OpensMeasurableSpace X] (s : Set X)
-    (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜)
-    (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(quasispectrum 𝕜 a, 𝕜)₀]
+lemma integrable_cfcₙ_set' [TopologicalSpace X] [OpensMeasurableSpace X] {s : Set X}
+    (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜) (bound : X → ℝ) (a : A)
+    [SecondCountableTopologyEither X C(quasispectrum 𝕜 a, 𝕜)₀]
     (hf : Continuous (fun x : s × quasispectrum 𝕜 a => f x.1 x.2))
     (hf₂ : ∀ x ∈ s, f x 0 = 0)
     (hbound : ∀ x ∈ s, ∀ z ∈ quasispectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
@@ -318,7 +313,7 @@ lemma integrable_cfcₙ_set' [TopologicalSpace X] [OpensMeasurableSpace X] (s : 
         refine (Topology.IsEmbedding.continuous_iff ?_).mpr this
         apply IsUniformEmbedding.isEmbedding
         exact Isometry.isUniformEmbedding fun x1 ↦ congrFun rfl }
-  refine integrable_cfcₙ_set s hs f bound a ?_ hf₂ ?_ hbound hbound_finite_integral
+  refine integrable_cfcₙ_set hs f bound a ?_ hf₂ ?_ hbound hbound_finite_integral
   · intro x xs
     rw [continuousOn_iff_continuous_restrict]
     exact (fc₂ ⟨x, xs⟩).continuous
@@ -330,10 +325,9 @@ lemma integrable_cfcₙ_set' [TopologicalSpace X] [OpensMeasurableSpace X] (s : 
     simp [fc₂, fc, hx]
 
 open ContinuousMapZero Classical in
-/-- The continuous functional calculus commutes with integration. -/
-lemma cfcₙ_setIntegral [NormedSpace ℝ A] (s : Set X) (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜)
-    (bound : X → ℝ) (a : A)
-    (hf₁ : ∀ x ∈ s, ContinuousOn (f x) (quasispectrum 𝕜 a))
+/-- The non-unital continuous functional calculus commutes with integration. -/
+lemma cfcₙ_setIntegral [NormedSpace ℝ A] {s : Set X} (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜)
+    (bound : X → ℝ) (a : A) (hf₁ : ∀ x ∈ s, ContinuousOn (f x) (quasispectrum 𝕜 a))
     (hf₂ : ∀ x ∈ s, f x 0 = 0)
     (hf₃ : AEStronglyMeasurable (fun x : X =>
       if h : x ∈ s then
@@ -387,10 +381,10 @@ lemma cfcₙ_setIntegral [NormedSpace ℝ A] (s : Set X) (hs : MeasurableSet s) 
   congr
 
 open ContinuousMap Classical in
-/-- The continuous functional calculus commutes with integration. -/
-lemma cfcₙ_setIntegral' [NormedSpace ℝ A] [TopologicalSpace X] [OpensMeasurableSpace X] (s : Set X)
-    (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜)
-    (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(quasispectrum 𝕜 a, 𝕜)₀]
+/-- The non-unital continuous functional calculus commutes with integration. -/
+lemma cfcₙ_setIntegral' [NormedSpace ℝ A] [TopologicalSpace X] [OpensMeasurableSpace X] {s : Set X}
+    (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜) (bound : X → ℝ) (a : A)
+    [SecondCountableTopologyEither X C(quasispectrum 𝕜 a, 𝕜)₀]
     (hf : Continuous (fun x : s × quasispectrum 𝕜 a => f x.1 x.2))
     (hf₂ : ∀ x ∈ s, f x 0 = 0)
     (hbound : ∀ x ∈ s, ∀ z ∈ quasispectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
@@ -406,7 +400,7 @@ lemma cfcₙ_setIntegral' [NormedSpace ℝ A] [TopologicalSpace X] [OpensMeasura
         refine (Topology.IsEmbedding.continuous_iff ?_).mpr this
         apply IsUniformEmbedding.isEmbedding
         exact Isometry.isUniformEmbedding fun x1 ↦ congrFun rfl }
-  refine cfcₙ_setIntegral s hs f bound a ?_ hf₂ ?_ hbound hbound_finite_integral
+  refine cfcₙ_setIntegral hs f bound a ?_ hf₂ ?_ hbound hbound_finite_integral
   · intro x xs
     rw [continuousOn_iff_continuous_restrict]
     exact (fc₂ ⟨x, xs⟩).continuous
@@ -417,44 +411,53 @@ lemma cfcₙ_setIntegral' [NormedSpace ℝ A] [TopologicalSpace X] [OpensMeasura
     ext
     simp [fc₂, fc, hx]
 
-open ContinuousMapZero in
+open ContinuousMapZero Set in
 /-- The non-unital continuous functional calculus commutes with integration. -/
 lemma cfcₙ_integral [NormedSpace ℝ A] [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → 𝕜 → 𝕜)
     (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(quasispectrum 𝕜 a, 𝕜)₀]
     (hf₁ : ∀ x, ContinuousOn (f x) (quasispectrum 𝕜 a))
     (hf₂ : ∀ x, f x 0 = 0)
-    (hf₃ : Continuous (fun x ↦ (⟨⟨_, hf₁ x |>.restrict⟩, hf₂ x⟩ : C(quasispectrum 𝕜 a, 𝕜)₀)))
+    (hf₃ : AEStronglyMeasurable
+      (fun x ↦ (⟨⟨_, hf₁ x |>.restrict⟩, by simp [hf₂]⟩ : C(quasispectrum 𝕜 a, 𝕜)₀)) μ)
     (hbound : ∀ x, ∀ z ∈ quasispectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
     (hbound_finite_integral : HasFiniteIntegral bound μ) (ha : p a := by cfc_tac) :
     cfcₙ (fun r => ∫ x, f x r ∂μ) a = ∫ x, cfcₙ (f x) a ∂μ := by
-  let fc : X → C(quasispectrum 𝕜 a, 𝕜)₀ := fun x => ⟨⟨_, (hf₁ x).restrict⟩, hf₂ x⟩
-  have fc_integrable : Integrable fc μ := by
-    refine ⟨hf₃.aestronglyMeasurable, ?_⟩
-    refine hbound_finite_integral.mono <| .of_forall fun x ↦ ?_
-    change ‖(fc x : C(quasispectrum  𝕜 a, 𝕜))‖ ≤ ‖bound x‖
-    rw [ContinuousMap.norm_le _ (norm_nonneg (bound x))]
-    exact fun z ↦ hbound x z.1 z.2
-  have h_int_fc : (quasispectrum 𝕜 a).restrict (∫ x, f x · ∂μ) = ∫ x, fc x ∂μ := by
-    ext; simp [integral_apply fc_integrable, fc]
-  have hcont₂ : ContinuousOn (fun r => ∫ x, f x r ∂μ) (quasispectrum 𝕜 a) := by
-    rw [continuousOn_iff_continuous_restrict]
-    convert map_continuous (∫ x, fc x ∂μ)
-  rw [integral_congr_ae (.of_forall fun _ ↦ cfcₙ_apply ..), cfcₙ_apply ..,
-    cfcₙHom_integral _ _ fc_integrable]
-  congr
+  have : cfcₙ (fun r => ∫ x, f x r ∂μ) a = cfcₙ (fun r => ∫ x in univ, f x r ∂μ) a := by
+    simp [← setIntegral_univ]
+  rw [← setIntegral_univ, this]
+  refine cfcₙ_setIntegral MeasurableSet.univ f bound a ?_ ?_ ?_ ?_ ?_
+  · exact fun x _ => hf₁ x
+  · simp [hf₂]
+  · simp [hf₃]
+  · exact fun x _ => hbound x
+  · simp [hbound_finite_integral]
 
 /-- The non-unital continuous functional calculus commutes with integration. -/
 lemma cfcₙ_integral' [NormedSpace ℝ A] [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → 𝕜 → 𝕜)
     (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(quasispectrum 𝕜 a, 𝕜)₀]
-    (hf : Continuous (fun x => (quasispectrum 𝕜 a).restrict (f x)).uncurry)
+    (hf : Continuous (fun x : X × quasispectrum 𝕜 a => f x.1 x.2))
     (hf₂ : ∀ x, f x 0 = 0)
     (hbound : ∀ x, ∀ z ∈ quasispectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
     (hbound_finite_integral : HasFiniteIntegral bound μ) (ha : p a := by cfc_tac) :
     cfcₙ (fun r => ∫ x, f x r ∂μ) a = ∫ x, cfcₙ (f x) a ∂μ := by
+  let fc : C(X × (quasispectrum 𝕜 a), 𝕜) := ⟨fun x => f x.1 x.2, hf⟩
+  let fc₂ : C(X, C(quasispectrum 𝕜 a, 𝕜)₀) :=
+    { toFun := fun x => ⟨fc.curry x, by simp [fc, hf₂]⟩
+      continuous_toFun := by
+        have : Continuous
+            (ContinuousMapZero.toContinuousMap ∘ (fun x => ⟨fc.curry x, by simp [fc, hf₂]⟩)) :=
+          ContinuousMap.continuous fc.curry
+        refine (Topology.IsEmbedding.continuous_iff ?_).mpr this
+        apply IsUniformEmbedding.isEmbedding
+        exact Isometry.isUniformEmbedding fun x1 ↦ congrFun rfl }
   refine cfcₙ_integral f bound a ?_ hf₂ ?_ hbound hbound_finite_integral
-  · exact (continuousOn_iff_continuous_restrict.mpr <| hf.uncurry_left ·)
-  · let g := ((↑) : C(quasispectrum 𝕜 a, 𝕜)₀ → C(quasispectrum 𝕜 a, 𝕜))
-    refine ((isInducing_iff g).mpr rfl).continuous_iff.mpr ?_
-    exact ContinuousMap.curry ⟨_, hf⟩ |>.continuous
+  · intro x
+    rw [continuousOn_iff_continuous_restrict]
+    exact (fc₂ x).continuous
+  · refine Continuous.aestronglyMeasurable ?_
+    refine fc₂.continuous.congr ?_
+    intro x
+    ext
+    simp [fc₂, fc]
 
 end nonunital

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Integral.lean
@@ -51,7 +51,7 @@ lemma cfcHom_integral [NormedAlgebra ℝ A] (a : A) (f : X → C(spectrum 𝕜 a
   cfcL_integral a f hf₁ ha
 
 open ContinuousMap Classical in
-lemma integrable_cfc_set {s : Set X} (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜)
+lemma integrableOn_cfc' {s : Set X} (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜)
     (bound : X → ℝ) (a : A) (hf₁ : ∀ x ∈ s, ContinuousOn (f x) (spectrum 𝕜 a))
     (hf₂ : AEStronglyMeasurable (fun x : X =>
       if h : x ∈ s then (⟨_, (hf₁ x h).restrict⟩ : C(spectrum 𝕜 a, 𝕜)) else 0) (μ.restrict s))
@@ -85,7 +85,7 @@ lemma integrable_cfc_set {s : Set X} (hs : MeasurableSet s) (f : X → 𝕜 → 
   exact ContinuousLinearMap.integrable_comp _ fc_integrable
 
 open ContinuousMap Classical in
-lemma integrable_cfc_set' [TopologicalSpace X] [OpensMeasurableSpace X] {s : Set X}
+lemma integrableOn_cfc [TopologicalSpace X] [OpensMeasurableSpace X] {s : Set X}
     (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜) (bound : X → ℝ) (a : A)
     [SecondCountableTopologyEither X C(spectrum 𝕜 a, 𝕜)]
     (hf : Continuous (fun x : s × spectrum 𝕜 a => f x.1 x.2))
@@ -94,7 +94,7 @@ lemma integrable_cfc_set' [TopologicalSpace X] [OpensMeasurableSpace X] {s : Set
     IntegrableOn (fun x => cfc (f x) a) s μ := by
   let fc : C(s × (spectrum 𝕜 a), 𝕜) := ⟨fun x => f x.1 x.2, hf⟩
   let fc₂ := fc.curry
-  refine integrable_cfc_set hs f bound a ?_ ?_ hbound hbound_finite_integral
+  refine integrableOn_cfc' hs f bound a ?_ ?_ hbound hbound_finite_integral
   · intro x xs
     rw [continuousOn_iff_continuous_restrict]
     exact (fc₂ ⟨x, xs⟩).continuous
@@ -106,21 +106,21 @@ lemma integrable_cfc_set' [TopologicalSpace X] [OpensMeasurableSpace X] {s : Set
     simp [fc₂, fc, hx]
 
 open ContinuousMap Set in
-lemma integrable_cfc (f : X → 𝕜 → 𝕜) (bound : X → ℝ) (a : A)
+lemma integrable_cfc' (f : X → 𝕜 → 𝕜) (bound : X → ℝ) (a : A)
     (hf₁ : ∀ x, ContinuousOn (f x) (spectrum 𝕜 a))
     (hf₂ : AEStronglyMeasurable (fun x ↦ (⟨_, hf₁ x |>.restrict⟩ : C(spectrum 𝕜 a, 𝕜))) μ)
     (hbound : ∀ x, ∀ z ∈ spectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
     (hbound_finite_integral : HasFiniteIntegral bound μ) (ha : p a := by cfc_tac) :
     Integrable (fun x => cfc (f x) a) μ := by
   rw [← integrableOn_univ]
-  refine integrable_cfc_set MeasurableSet.univ f bound a ?_ ?_ ?_ ?_ ha
+  refine integrableOn_cfc' MeasurableSet.univ f bound a ?_ ?_ ?_ ?_ ha
   · exact fun x _ => hf₁ x
   · simp [hf₂]
   · exact fun x _ => hbound x
   · simp [hbound_finite_integral]
 
 open ContinuousMap in
-lemma integrable_cfc' [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → 𝕜 → 𝕜)
+lemma integrable_cfc [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → 𝕜 → 𝕜)
     (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(spectrum 𝕜 a, 𝕜)]
     (hf : Continuous (fun x : X × spectrum 𝕜 a => f x.1 x.2))
     (hbound : ∀ x, ∀ z ∈ spectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
@@ -128,7 +128,7 @@ lemma integrable_cfc' [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → �
     Integrable (fun x => cfc (f x) a) μ := by
   let fc : C(X × (spectrum 𝕜 a), 𝕜) := ⟨fun x => f x.1 x.2, hf⟩
   let fc₂ := fc.curry
-  refine integrable_cfc f bound a ?_ ?_ hbound hbound_finite_integral
+  refine integrable_cfc' f bound a ?_ ?_ hbound hbound_finite_integral
   · intro x
     rw [continuousOn_iff_continuous_restrict]
     exact (fc₂ x).continuous
@@ -137,7 +137,7 @@ lemma integrable_cfc' [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → �
 
 open ContinuousMap Classical in
 /-- The continuous functional calculus commutes with integration. -/
-lemma cfc_setIntegral [NormedAlgebra ℝ A] {s : Set X} (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜)
+lemma cfc_setIntegral' [NormedAlgebra ℝ A] {s : Set X} (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜)
     (bound : X → ℝ) (a : A) (hf₁ : ∀ x ∈ s, ContinuousOn (f x) (spectrum 𝕜 a))
     (hf₂ : AEStronglyMeasurable (fun x : X =>
       if h : x ∈ s then (⟨_, (hf₁ x h).restrict⟩ : C(spectrum 𝕜 a, 𝕜)) else 0) (μ.restrict s))
@@ -183,7 +183,7 @@ lemma cfc_setIntegral [NormedAlgebra ℝ A] {s : Set X} (hs : MeasurableSet s) (
 
 open ContinuousMap Classical in
 /-- The continuous functional calculus commutes with integration. -/
-lemma cfc_setIntegral' [NormedAlgebra ℝ A] [TopologicalSpace X] [OpensMeasurableSpace X] {s : Set X}
+lemma cfc_setIntegral [NormedAlgebra ℝ A] [TopologicalSpace X] [OpensMeasurableSpace X] {s : Set X}
     (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜) (bound : X → ℝ) (a : A)
     [SecondCountableTopologyEither X C(spectrum 𝕜 a, 𝕜)]
     (hf : Continuous (fun x : s × spectrum 𝕜 a => f x.1 x.2))
@@ -192,7 +192,7 @@ lemma cfc_setIntegral' [NormedAlgebra ℝ A] [TopologicalSpace X] [OpensMeasurab
     cfc (fun r => ∫ x in s, f x r ∂μ) a = ∫ x in s, cfc (f x) a ∂μ := by
   let fc : C(s × (spectrum 𝕜 a), 𝕜) := ⟨fun x => f x.1 x.2, hf⟩
   let fc₂ := fc.curry
-  refine cfc_setIntegral hs f bound a ?_ ?_ hbound hbound_finite_integral
+  refine cfc_setIntegral' hs f bound a ?_ ?_ hbound hbound_finite_integral
   · intro x xs
     rw [continuousOn_iff_continuous_restrict]
     exact (fc₂ ⟨x, xs⟩).continuous
@@ -205,7 +205,7 @@ lemma cfc_setIntegral' [NormedAlgebra ℝ A] [TopologicalSpace X] [OpensMeasurab
 
 open ContinuousMap Set in
 /-- The continuous functional calculus commutes with integration. -/
-lemma cfc_integral [NormedAlgebra ℝ A] (f : X → 𝕜 → 𝕜) (bound : X → ℝ) (a : A)
+lemma cfc_integral' [NormedAlgebra ℝ A] (f : X → 𝕜 → 𝕜) (bound : X → ℝ) (a : A)
     (hf₁ : ∀ x, ContinuousOn (f x) (spectrum 𝕜 a))
     (hf₂ : AEStronglyMeasurable (fun x ↦ (⟨_, hf₁ x |>.restrict⟩ : C(spectrum 𝕜 a, 𝕜))) μ)
     (hbound : ∀ x, ∀ z ∈ spectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
@@ -214,14 +214,14 @@ lemma cfc_integral [NormedAlgebra ℝ A] (f : X → 𝕜 → 𝕜) (bound : X �
   have : cfc (fun r => ∫ x, f x r ∂μ) a = cfc (fun r => ∫ x in univ, f x r ∂μ) a := by
     simp [← setIntegral_univ]
   rw [← setIntegral_univ, this]
-  refine cfc_setIntegral MeasurableSet.univ f bound a ?_ ?_ ?_ ?_
+  refine cfc_setIntegral' MeasurableSet.univ f bound a ?_ ?_ ?_ ?_
   · exact fun x _ => hf₁ x
   · simp [hf₂]
   · exact fun x _ => hbound x
   · simp [hbound_finite_integral]
 
 /-- The continuous functional calculus commutes with integration. -/
-lemma cfc_integral' [NormedAlgebra ℝ A] [TopologicalSpace X] [OpensMeasurableSpace X]
+lemma cfc_integral [NormedAlgebra ℝ A] [TopologicalSpace X] [OpensMeasurableSpace X]
     (f : X → 𝕜 → 𝕜) (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(spectrum 𝕜 a, 𝕜)]
     (hf : Continuous (fun x : X × spectrum 𝕜 a => f x.1 x.2))
     (hbound : ∀ x, ∀ z ∈ spectrum 𝕜 a, ‖f x z‖ ≤ ‖bound x‖)
@@ -229,7 +229,7 @@ lemma cfc_integral' [NormedAlgebra ℝ A] [TopologicalSpace X] [OpensMeasurableS
     cfc (fun r => ∫ x, f x r ∂μ) a = ∫ x, cfc (f x) a ∂μ := by
   let fc : C(X × (spectrum 𝕜 a), 𝕜) := ⟨fun x => f x.1 x.2, hf⟩
   let fc₂ := fc.curry
-  refine cfc_integral f bound a ?_ ?_ hbound hbound_finite_integral
+  refine cfc_integral' f bound a ?_ ?_ hbound hbound_finite_integral
   · intro x
     rw [continuousOn_iff_continuous_restrict]
     exact (fc₂ x).continuous
@@ -256,7 +256,7 @@ lemma cfcₙHom_integral [NormedSpace ℝ A] (a : A) (f : X → C(quasispectrum 
   cfcₙL_integral a f hf₁ ha
 
 open ContinuousMapZero Classical in
-lemma integrable_cfcₙ_set {s : Set X} (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜) (bound : X → ℝ) (a : A)
+lemma integrableOn_cfcₙ' {s : Set X} (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜) (bound : X → ℝ) (a : A)
     (hf₁ : ∀ x ∈ s, ContinuousOn (f x) (quasispectrum 𝕜 a))
     (hf₂ : ∀ x ∈ s, f x 0 = 0)
     (hf₃ : AEStronglyMeasurable (fun x : X =>
@@ -293,7 +293,7 @@ lemma integrable_cfcₙ_set {s : Set X} (hs : MeasurableSet s) (f : X → 𝕜 �
   exact ContinuousLinearMap.integrable_comp _ fc_integrable
 
 open ContinuousMap Classical in
-lemma integrable_cfcₙ_set' [TopologicalSpace X] [OpensMeasurableSpace X] {s : Set X}
+lemma integrableOn_cfcₙ [TopologicalSpace X] [OpensMeasurableSpace X] {s : Set X}
     (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜) (bound : X → ℝ) (a : A)
     [SecondCountableTopologyEither X C(quasispectrum 𝕜 a, 𝕜)₀]
     (hf : Continuous (fun x : s × quasispectrum 𝕜 a => f x.1 x.2))
@@ -311,7 +311,7 @@ lemma integrable_cfcₙ_set' [TopologicalSpace X] [OpensMeasurableSpace X] {s : 
         refine (Topology.IsEmbedding.continuous_iff ?_).mpr this
         apply IsUniformEmbedding.isEmbedding
         exact Isometry.isUniformEmbedding fun x1 ↦ congrFun rfl }
-  refine integrable_cfcₙ_set hs f bound a ?_ hf₂ ?_ hbound hbound_finite_integral
+  refine integrableOn_cfcₙ' hs f bound a ?_ hf₂ ?_ hbound hbound_finite_integral
   · intro x xs
     rw [continuousOn_iff_continuous_restrict]
     exact (fc₂ ⟨x, xs⟩).continuous
@@ -324,7 +324,7 @@ lemma integrable_cfcₙ_set' [TopologicalSpace X] [OpensMeasurableSpace X] {s : 
 
 open ContinuousMapZero Classical in
 /-- The non-unital continuous functional calculus commutes with integration. -/
-lemma cfcₙ_setIntegral [NormedSpace ℝ A] {s : Set X} (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜)
+lemma cfcₙ_setIntegral' [NormedSpace ℝ A] {s : Set X} (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜)
     (bound : X → ℝ) (a : A) (hf₁ : ∀ x ∈ s, ContinuousOn (f x) (quasispectrum 𝕜 a))
     (hf₂ : ∀ x ∈ s, f x 0 = 0)
     (hf₃ : AEStronglyMeasurable (fun x : X =>
@@ -380,7 +380,7 @@ lemma cfcₙ_setIntegral [NormedSpace ℝ A] {s : Set X} (hs : MeasurableSet s) 
 
 open ContinuousMap Classical in
 /-- The non-unital continuous functional calculus commutes with integration. -/
-lemma cfcₙ_setIntegral' [NormedSpace ℝ A] [TopologicalSpace X] [OpensMeasurableSpace X] {s : Set X}
+lemma cfcₙ_setIntegral [NormedSpace ℝ A] [TopologicalSpace X] [OpensMeasurableSpace X] {s : Set X}
     (hs : MeasurableSet s) (f : X → 𝕜 → 𝕜) (bound : X → ℝ) (a : A)
     [SecondCountableTopologyEither X C(quasispectrum 𝕜 a, 𝕜)₀]
     (hf : Continuous (fun x : s × quasispectrum 𝕜 a => f x.1 x.2))
@@ -398,7 +398,7 @@ lemma cfcₙ_setIntegral' [NormedSpace ℝ A] [TopologicalSpace X] [OpensMeasura
         refine (Topology.IsEmbedding.continuous_iff ?_).mpr this
         apply IsUniformEmbedding.isEmbedding
         exact Isometry.isUniformEmbedding fun x1 ↦ congrFun rfl }
-  refine cfcₙ_setIntegral hs f bound a ?_ hf₂ ?_ hbound hbound_finite_integral
+  refine cfcₙ_setIntegral' hs f bound a ?_ hf₂ ?_ hbound hbound_finite_integral
   · intro x xs
     rw [continuousOn_iff_continuous_restrict]
     exact (fc₂ ⟨x, xs⟩).continuous
@@ -411,7 +411,7 @@ lemma cfcₙ_setIntegral' [NormedSpace ℝ A] [TopologicalSpace X] [OpensMeasura
 
 open ContinuousMapZero Set in
 /-- The non-unital continuous functional calculus commutes with integration. -/
-lemma cfcₙ_integral [NormedSpace ℝ A] (f : X → 𝕜 → 𝕜) (bound : X → ℝ) (a : A)
+lemma cfcₙ_integral' [NormedSpace ℝ A] (f : X → 𝕜 → 𝕜) (bound : X → ℝ) (a : A)
     (hf₁ : ∀ x, ContinuousOn (f x) (quasispectrum 𝕜 a)) (hf₂ : ∀ x, f x 0 = 0)
     (hf₃ : AEStronglyMeasurable
       (fun x ↦ (⟨⟨_, hf₁ x |>.restrict⟩, by simp [hf₂]⟩ : C(quasispectrum 𝕜 a, 𝕜)₀)) μ)
@@ -421,7 +421,7 @@ lemma cfcₙ_integral [NormedSpace ℝ A] (f : X → 𝕜 → 𝕜) (bound : X �
   have : cfcₙ (fun r => ∫ x, f x r ∂μ) a = cfcₙ (fun r => ∫ x in univ, f x r ∂μ) a := by
     simp [← setIntegral_univ]
   rw [← setIntegral_univ, this]
-  refine cfcₙ_setIntegral MeasurableSet.univ f bound a ?_ ?_ ?_ ?_ ?_
+  refine cfcₙ_setIntegral' MeasurableSet.univ f bound a ?_ ?_ ?_ ?_ ?_
   · exact fun x _ => hf₁ x
   · simp [hf₂]
   · simp [hf₃]
@@ -429,7 +429,7 @@ lemma cfcₙ_integral [NormedSpace ℝ A] (f : X → 𝕜 → 𝕜) (bound : X �
   · simp [hbound_finite_integral]
 
 /-- The non-unital continuous functional calculus commutes with integration. -/
-lemma cfcₙ_integral' [NormedSpace ℝ A] [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → 𝕜 → 𝕜)
+lemma cfcₙ_integral [NormedSpace ℝ A] [TopologicalSpace X] [OpensMeasurableSpace X] (f : X → 𝕜 → 𝕜)
     (bound : X → ℝ) (a : A) [SecondCountableTopologyEither X C(quasispectrum 𝕜 a, 𝕜)₀]
     (hf : Continuous (fun x : X × quasispectrum 𝕜 a => f x.1 x.2))
     (hf₂ : ∀ x, f x 0 = 0)
@@ -446,7 +446,7 @@ lemma cfcₙ_integral' [NormedSpace ℝ A] [TopologicalSpace X] [OpensMeasurable
         refine (Topology.IsEmbedding.continuous_iff ?_).mpr this
         apply IsUniformEmbedding.isEmbedding
         exact Isometry.isUniformEmbedding fun x1 ↦ congrFun rfl }
-  refine cfcₙ_integral f bound a ?_ hf₂ ?_ hbound hbound_finite_integral
+  refine cfcₙ_integral' f bound a ?_ hf₂ ?_ hbound hbound_finite_integral
   · intro x
     rw [continuousOn_iff_continuous_restrict]
     exact (fc₂ x).continuous


### PR DESCRIPTION
This PR shows various versions of `cfc (fun r => ∫ x in s, f x r ∂μ) a = ∫ x in s, cfc (f x) a ∂μ`. We previously had it for integrals over the whole space (i.e. without `s`), but the set version turns out to be very convenient. Lemmas showing the integrability of `fun x => cfc (f x) a` and friends are also added.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
