### PR TITLE
[Merged by Bors] - chore(NumberTheory/EllipticDivisibilitySequence): simplify proofs and deprecate lemmas

### DIFF
--- a/Mathlib/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Basic.lean
@@ -95,12 +95,6 @@ open scoped Polynomial.Bivariate
 local macro "C_simp" : tactic =>
   `(tactic| simp only [map_ofNat, C_0, C_1, C_neg, C_add, C_sub, C_mul, C_pow])
 
-local macro "map_simp" : tactic =>
-  `(tactic| simp only [map_ofNat, map_neg, map_add, map_sub, map_mul, map_pow, map_div₀,
-    Polynomial.map_ofNat, Polynomial.map_one, map_C, map_X, Polynomial.map_neg, Polynomial.map_add,
-    Polynomial.map_sub, Polynomial.map_mul, Polynomial.map_pow, Polynomial.map_div, coe_mapRingHom,
-    apply_ite <| mapRingHom _, WeierstrassCurve.map])
-
 universe r s u v
 
 namespace WeierstrassCurve
@@ -125,10 +119,10 @@ lemma C_Ψ₂Sq : C W.Ψ₂Sq = W.ψ₂ ^ 2 - 4 * W.toAffine.polynomial := by
   ring1
 
 lemma ψ₂_sq : W.ψ₂ ^ 2 = C W.Ψ₂Sq + 4 * W.toAffine.polynomial := by
-  rw [C_Ψ₂Sq, sub_add_cancel]
+  simp [C_Ψ₂Sq]
 
 lemma Affine.CoordinateRing.mk_ψ₂_sq : mk W W.ψ₂ ^ 2 = mk W (C W.Ψ₂Sq) := by
-  rw [C_Ψ₂Sq, map_sub, map_mul, AdjoinRoot.mk_self, mul_zero, sub_zero, map_pow]
+  simp [C_Ψ₂Sq]
 
 -- TODO: remove `twoTorsionPolynomial` in favour of `Ψ₂Sq`
 lemma Ψ₂Sq_eq : W.Ψ₂Sq = W.twoTorsionPolynomial.toPoly :=
@@ -220,16 +214,6 @@ lemma preΨ_three : W.preΨ 3 = W.Ψ₃ :=
 lemma preΨ_four : W.preΨ 4 = W.preΨ₄ :=
   preNormEDS_four ..
 
-lemma preΨ_even_ofNat (m : ℕ) : W.preΨ (2 * (m + 3)) =
-    W.preΨ (m + 2) ^ 2 * W.preΨ (m + 3) * W.preΨ (m + 5) -
-      W.preΨ (m + 1) * W.preΨ (m + 3) * W.preΨ (m + 4) ^ 2 :=
-  preNormEDS_even_ofNat ..
-
-lemma preΨ_odd_ofNat (m : ℕ) : W.preΨ (2 * (m + 2) + 1) =
-    W.preΨ (m + 4) * W.preΨ (m + 2) ^ 3 * (if Even m then W.Ψ₂Sq ^ 2 else 1) -
-      W.preΨ (m + 1) * W.preΨ (m + 3) ^ 3 * (if Even m then 1 else W.Ψ₂Sq ^ 2) :=
-  preNormEDS_odd_ofNat ..
-
 @[simp]
 lemma preΨ_neg (n : ℤ) : W.preΨ (-n) = -W.preΨ n :=
   preNormEDS_neg ..
@@ -239,10 +223,14 @@ lemma preΨ_even (m : ℤ) : W.preΨ (2 * m) =
       W.preΨ (m - 2) * W.preΨ m * W.preΨ (m + 1) ^ 2 :=
   preNormEDS_even ..
 
+@[deprecated (since := "2025-05-15")] alias preΨ_even_ofNat := preΨ_even
+
 lemma preΨ_odd (m : ℤ) : W.preΨ (2 * m + 1) =
     W.preΨ (m + 2) * W.preΨ m ^ 3 * (if Even m then W.Ψ₂Sq ^ 2 else 1) -
       W.preΨ (m - 1) * W.preΨ (m + 1) ^ 3 * (if Even m then 1 else W.Ψ₂Sq ^ 2) :=
   preNormEDS_odd ..
+
+@[deprecated (since := "2025-05-15")] alias preΨ_odd_ofNat := preΨ_odd
 
 end preΨ
 
@@ -256,51 +244,45 @@ noncomputable def ΨSq (n : ℤ) : R[X] :=
 
 @[simp]
 lemma ΨSq_ofNat (n : ℕ) : W.ΨSq n = W.preΨ' n ^ 2 * if Even n then W.Ψ₂Sq else 1 := by
-  simp only [ΨSq, preΨ_ofNat, Int.even_coe_nat]
+  simp [ΨSq]
 
 @[simp]
 lemma ΨSq_zero : W.ΨSq 0 = 0 := by
-  rw [← Nat.cast_zero, ΨSq_ofNat, preΨ'_zero, zero_pow two_ne_zero, zero_mul]
+  simp [ΨSq]
 
 @[simp]
 lemma ΨSq_one : W.ΨSq 1 = 1 := by
-  rw [← Nat.cast_one, ΨSq_ofNat, preΨ'_one, one_pow, one_mul, if_neg Nat.not_even_one]
+  simp [ΨSq]
 
 @[simp]
 lemma ΨSq_two : W.ΨSq 2 = W.Ψ₂Sq := by
-  rw [← Nat.cast_two, ΨSq_ofNat, preΨ'_two, one_pow, one_mul, if_pos even_two]
+  simp [ΨSq]
 
 @[simp]
 lemma ΨSq_three : W.ΨSq 3 = W.Ψ₃ ^ 2 := by
-  rw [← Nat.cast_three, ΨSq_ofNat, preΨ'_three, if_neg <| by decide, mul_one]
+  simp [ΨSq, show ¬Even (3 : ℤ) by decide]
 
 @[simp]
 lemma ΨSq_four : W.ΨSq 4 = W.preΨ₄ ^ 2 * W.Ψ₂Sq := by
-  rw [← Nat.cast_four, ΨSq_ofNat, preΨ'_four, if_pos <| by decide]
-
-lemma ΨSq_even_ofNat (m : ℕ) : W.ΨSq (2 * (m + 3)) =
-    (W.preΨ' (m + 2) ^ 2 * W.preΨ' (m + 3) * W.preΨ' (m + 5) -
-      W.preΨ' (m + 1) * W.preΨ' (m + 3) * W.preΨ' (m + 4) ^ 2) ^ 2 * W.Ψ₂Sq := by
-  rw_mod_cast [ΨSq_ofNat, preΨ'_even, if_pos <| even_two_mul _]
-
-lemma ΨSq_odd_ofNat (m : ℕ) : W.ΨSq (2 * (m + 2) + 1) =
-    (W.preΨ' (m + 4) * W.preΨ' (m + 2) ^ 3 * (if Even m then W.Ψ₂Sq ^ 2 else 1) -
-      W.preΨ' (m + 1) * W.preΨ' (m + 3) ^ 3 * (if Even m then 1 else W.Ψ₂Sq ^ 2)) ^ 2 := by
-  rw_mod_cast [ΨSq_ofNat, preΨ'_odd, if_neg (m + 2).not_even_two_mul_add_one, mul_one]
+  simp [ΨSq, show ¬Odd (4 : ℤ) by decide]
 
 @[simp]
 lemma ΨSq_neg (n : ℤ) : W.ΨSq (-n) = W.ΨSq n := by
-  simp only [ΨSq, preΨ_neg, neg_sq, even_neg]
+  simp [ΨSq]
 
 lemma ΨSq_even (m : ℤ) : W.ΨSq (2 * m) =
     (W.preΨ (m - 1) ^ 2 * W.preΨ m * W.preΨ (m + 2) -
       W.preΨ (m - 2) * W.preΨ m * W.preΨ (m + 1) ^ 2) ^ 2 * W.Ψ₂Sq := by
-  rw [ΨSq, preΨ_even, if_pos <| even_two_mul _]
+  rw [ΨSq, preΨ_even, if_pos <| even_two_mul m]
+
+@[deprecated (since := "2025-05-15")] alias ΨSq_even_ofNat := ΨSq_even
 
 lemma ΨSq_odd (m : ℤ) : W.ΨSq (2 * m + 1) =
     (W.preΨ (m + 2) * W.preΨ m ^ 3 * (if Even m then W.Ψ₂Sq ^ 2 else 1) -
       W.preΨ (m - 1) * W.preΨ (m + 1) ^ 3 * (if Even m then 1 else W.Ψ₂Sq ^ 2)) ^ 2 := by
   rw [ΨSq, preΨ_odd, if_neg m.not_even_two_mul_add_one, mul_one]
+
+@[deprecated (since := "2025-05-15")] alias ΨSq_odd_ofNat := ΨSq_odd
 
 end ΨSq
 
@@ -316,67 +298,54 @@ open WeierstrassCurve (Ψ)
 
 @[simp]
 lemma Ψ_ofNat (n : ℕ) : W.Ψ n = C (W.preΨ' n) * if Even n then W.ψ₂ else 1 := by
-  simp only [Ψ, preΨ_ofNat, Int.even_coe_nat]
+  simp [Ψ]
 
 @[simp]
 lemma Ψ_zero : W.Ψ 0 = 0 := by
-  rw [← Nat.cast_zero, Ψ_ofNat, preΨ'_zero, C_0, zero_mul]
+  simp [Ψ]
 
 @[simp]
 lemma Ψ_one : W.Ψ 1 = 1 := by
-  rw [← Nat.cast_one, Ψ_ofNat, preΨ'_one, C_1, if_neg Nat.not_even_one, mul_one]
+  simp [Ψ]
 
 @[simp]
 lemma Ψ_two : W.Ψ 2 = W.ψ₂ := by
-  rw [← Nat.cast_two, Ψ_ofNat, preΨ'_two, C_1, one_mul, if_pos even_two]
+  simp [Ψ]
 
 @[simp]
 lemma Ψ_three : W.Ψ 3 = C W.Ψ₃ := by
-  rw [← Nat.cast_three, Ψ_ofNat, preΨ'_three, if_neg <| by decide, mul_one]
+  simp [Ψ, show ¬Even (3 : ℤ) by decide]
 
 @[simp]
 lemma Ψ_four : W.Ψ 4 = C W.preΨ₄ * W.ψ₂ := by
-  rw [← Nat.cast_four, Ψ_ofNat, preΨ'_four, if_pos <| by decide]
-
-lemma Ψ_even_ofNat (m : ℕ) : W.Ψ (2 * (m + 3)) * W.ψ₂ =
-    W.Ψ (m + 2) ^ 2 * W.Ψ (m + 3) * W.Ψ (m + 5) - W.Ψ (m + 1) * W.Ψ (m + 3) * W.Ψ (m + 4) ^ 2 := by
-  repeat rw_mod_cast [Ψ_ofNat]
-  simp_rw [preΨ'_even, if_pos <| even_two_mul _, Nat.even_add_one, ite_not]
-  split_ifs <;> C_simp <;> ring1
-
-lemma Ψ_odd_ofNat (m : ℕ) : W.Ψ (2 * (m + 2) + 1) =
-    W.Ψ (m + 4) * W.Ψ (m + 2) ^ 3 - W.Ψ (m + 1) * W.Ψ (m + 3) ^ 3 +
-      W.toAffine.polynomial * (16 * W.toAffine.polynomial - 8 * W.ψ₂ ^ 2) *
-        C (if Even m then W.preΨ' (m + 4) * W.preΨ' (m + 2) ^ 3
-            else -W.preΨ' (m + 1) * W.preΨ' (m + 3) ^ 3) := by
-  repeat rw_mod_cast [Ψ_ofNat]
-  simp_rw [preΨ'_odd, if_neg (m + 2).not_even_two_mul_add_one, Nat.even_add_one, ite_not]
-  split_ifs <;> C_simp <;> rw [C_Ψ₂Sq] <;> ring1
+  simp [Ψ, show ¬Odd (4 : ℤ) by decide]
 
 @[simp]
 lemma Ψ_neg (n : ℤ) : W.Ψ (-n) = -W.Ψ n := by
-  simp only [Ψ, preΨ_neg, C_neg, neg_mul (α := R[X][Y]), even_neg]
+  simp_rw [Ψ, preΨ_neg, C_neg, neg_mul, even_neg]
 
 lemma Ψ_even (m : ℤ) : W.Ψ (2 * m) * W.ψ₂ =
     W.Ψ (m - 1) ^ 2 * W.Ψ m * W.Ψ (m + 2) - W.Ψ (m - 2) * W.Ψ m * W.Ψ (m + 1) ^ 2 := by
-  repeat rw [Ψ]
-  simp_rw [preΨ_even, if_pos <| even_two_mul _, Int.even_add_one, show m + 2 = m + 1 + 1 by ring1,
-    Int.even_add_one, show m - 2 = m - 1 - 1 by ring1, Int.even_sub_one, ite_not]
+  simp_rw [Ψ, preΨ_even, if_pos <| even_two_mul m, Int.even_add, Int.even_sub, even_two, iff_true,
+    Int.not_even_one, iff_false]
   split_ifs <;> C_simp <;> ring1
+
+@[deprecated (since := "2025-05-15")] alias Ψ_even_ofNat := Ψ_even
 
 lemma Ψ_odd (m : ℤ) : W.Ψ (2 * m + 1) =
     W.Ψ (m + 2) * W.Ψ m ^ 3 - W.Ψ (m - 1) * W.Ψ (m + 1) ^ 3 +
       W.toAffine.polynomial * (16 * W.toAffine.polynomial - 8 * W.ψ₂ ^ 2) *
         C (if Even m then W.preΨ (m + 2) * W.preΨ m ^ 3
             else -W.preΨ (m - 1) * W.preΨ (m + 1) ^ 3) := by
-  repeat rw [Ψ]
-  simp_rw [preΨ_odd, if_neg m.not_even_two_mul_add_one, show m + 2 = m + 1 + 1 by ring1,
-    Int.even_add_one, Int.even_sub_one, ite_not]
+  simp_rw [Ψ, preΨ_odd, if_neg m.not_even_two_mul_add_one, Int.even_add, Int.even_sub, even_two,
+    iff_true, Int.not_even_one, iff_false]
   split_ifs <;> C_simp <;> rw [C_Ψ₂Sq] <;> ring1
 
+@[deprecated (since := "2025-05-15")] alias Ψ_odd_ofNat := Ψ_odd
+
 lemma Affine.CoordinateRing.mk_Ψ_sq (n : ℤ) : mk W (W.Ψ n) ^ 2 = mk W (C <| W.ΨSq n) := by
-  simp only [Ψ, ΨSq, map_one, map_mul, map_pow, one_pow, mul_pow, ite_pow, apply_ite C,
-    apply_ite <| mk W, mk_ψ₂_sq]
+  simp_rw [Ψ, ΨSq, map_mul, apply_ite C, apply_ite <| mk W, mul_pow, ite_pow, mk_ψ₂_sq, map_one,
+    one_pow, map_pow]
 
 end Ψ
 
@@ -394,19 +363,17 @@ open WeierstrassCurve (Φ)
 lemma Φ_ofNat (n : ℕ) : W.Φ (n + 1) =
     X * W.preΨ' (n + 1) ^ 2 * (if Even n then 1 else W.Ψ₂Sq) -
       W.preΨ' (n + 2) * W.preΨ' n * (if Even n then W.Ψ₂Sq else 1) := by
-  rw [Φ, ← Nat.cast_one, ← Nat.cast_add, ΨSq_ofNat, ← mul_assoc, ← Nat.cast_add, preΨ_ofNat,
-    Nat.cast_add, add_sub_cancel_right, preΨ_ofNat, ← Nat.cast_add]
-  simp only [Nat.even_add_one, Int.even_add_one, Int.even_coe_nat, ite_not]
+  rw [Φ, add_sub_cancel_right]
+  norm_cast
+  simp_rw [ΨSq_ofNat, Nat.even_add_one, ite_not, ← mul_assoc, preΨ_ofNat]
 
 @[simp]
 lemma Φ_zero : W.Φ 0 = 1 := by
-  rw [Φ, ΨSq_zero, mul_zero, zero_sub, zero_add, preΨ_one, one_mul, zero_sub, preΨ_neg, preΨ_one,
-    neg_one_mul, neg_neg, if_pos Even.zero]
+  simp [Φ]
 
 @[simp]
 lemma Φ_one : W.Φ 1 = X := by
-  rw [show 1 = ((0 : ℕ) + 1 : ℤ) by rfl, Φ_ofNat, preΨ'_one, one_pow, mul_one, if_pos Even.zero,
-    mul_one, preΨ'_zero, mul_zero, zero_mul, sub_zero]
+  simp [Φ]
 
 @[simp]
 lemma Φ_two : W.Φ 2 = X ^ 4 - C W.b₄ * X ^ 2 - C (2 * W.b₆) * X - C W.b₈ := by
@@ -429,8 +396,8 @@ lemma Φ_four : W.Φ 4 = X * W.preΨ₄ ^ 2 * W.Ψ₂Sq - W.Ψ₃ * (W.preΨ₄ 
 
 @[simp]
 lemma Φ_neg (n : ℤ) : W.Φ (-n) = W.Φ n := by
-  simp only [Φ, ΨSq_neg, neg_add_eq_sub, ← neg_sub n, preΨ_neg, ← neg_add', preΨ_neg, neg_mul_neg,
-    mul_comm <| W.preΨ <| n - 1, even_neg]
+  simp_rw [Φ, ΨSq_neg, ← sub_neg_eq_add, ← neg_sub', sub_neg_eq_add, ← neg_add', preΨ_neg,
+    neg_mul_neg, mul_comm <| W.preΨ <| n - 1, even_neg]
 
 end Φ
 
@@ -464,14 +431,6 @@ lemma ψ_three : W.ψ 3 = C W.Ψ₃ :=
 lemma ψ_four : W.ψ 4 = C W.preΨ₄ * W.ψ₂ :=
   normEDS_four ..
 
-lemma ψ_even_ofNat (m : ℕ) : W.ψ (2 * (m + 3)) * W.ψ₂ =
-    W.ψ (m + 2) ^ 2 * W.ψ (m + 3) * W.ψ (m + 5) - W.ψ (m + 1) * W.ψ (m + 3) * W.ψ (m + 4) ^ 2 :=
-  normEDS_even_ofNat ..
-
-lemma ψ_odd_ofNat (m : ℕ) : W.ψ (2 * (m + 2) + 1) =
-    W.ψ (m + 4) * W.ψ (m + 2) ^ 3 - W.ψ (m + 1) * W.ψ (m + 3) ^ 3 :=
-  normEDS_odd_ofNat ..
-
 @[simp]
 lemma ψ_neg (n : ℤ) : W.ψ (-n) = -W.ψ n :=
   normEDS_neg ..
@@ -480,12 +439,16 @@ lemma ψ_even (m : ℤ) : W.ψ (2 * m) * W.ψ₂ =
     W.ψ (m - 1) ^ 2 * W.ψ m * W.ψ (m + 2) - W.ψ (m - 2) * W.ψ m * W.ψ (m + 1) ^ 2 :=
   normEDS_even ..
 
+@[deprecated (since := "2025-05-15")] alias ψ_even_ofNat := ψ_even
+
 lemma ψ_odd (m : ℤ) : W.ψ (2 * m + 1) =
     W.ψ (m + 2) * W.ψ m ^ 3 - W.ψ (m - 1) * W.ψ (m + 1) ^ 3 :=
   normEDS_odd ..
 
+@[deprecated (since := "2025-05-15")] alias ψ_odd_ofNat := ψ_odd
+
 lemma Affine.CoordinateRing.mk_ψ (n : ℤ) : mk W (W.ψ n) = mk W (W.Ψ n) := by
-  simp only [ψ, normEDS, Ψ, preΨ, map_mul, map_pow, map_preNormEDS, ← mk_ψ₂_sq, ← pow_mul]
+  simp_rw [ψ, normEDS, Ψ, preΨ, map_mul, map_preNormEDS, map_pow, ← mk_ψ₂_sq, ← pow_mul]
 
 end ψ
 
@@ -501,21 +464,19 @@ open WeierstrassCurve (Ψ Φ φ)
 
 @[simp]
 lemma φ_zero : W.φ 0 = 1 := by
-  rw [φ, ψ_zero, zero_pow two_ne_zero, mul_zero, zero_sub, zero_add, ψ_one, one_mul, zero_sub,
-    ψ_neg, neg_neg, ψ_one]
+  simp [φ]
 
 @[simp]
 lemma φ_one : W.φ 1 = C X := by
-  rw [φ, ψ_one, one_pow, mul_one, sub_self, ψ_zero, mul_zero, sub_zero]
+  simp [φ]
 
 @[simp]
 lemma φ_two : W.φ 2 = C X * W.ψ₂ ^ 2 - C W.Ψ₃ := by
-  rw [φ, ψ_two, two_add_one_eq_three, ψ_three, show (2 - 1 : ℤ) = 1 by rfl, ψ_one, mul_one]
+  simp [φ]
 
 @[simp]
 lemma φ_three : W.φ 3 = C X * C W.Ψ₃ ^ 2 - C W.preΨ₄ * W.ψ₂ ^ 2 := by
-  rw [φ, ψ_three, three_add_one_eq_four, ψ_four, mul_assoc, show (3 - 1 : ℤ) = 2 by rfl, ψ_two,
-    ← sq]
+  simp [φ, mul_assoc, sq]
 
 @[simp]
 lemma φ_four :
@@ -527,12 +488,12 @@ lemma φ_four :
 
 @[simp]
 lemma φ_neg (n : ℤ) : W.φ (-n) = W.φ n := by
-  rw [φ, ψ_neg, neg_sq (R := R[X][Y]), neg_add_eq_sub, ← neg_sub n, ψ_neg, ← neg_add', ψ_neg,
-    neg_mul_neg (α := R[X][Y]), mul_comm <| W.ψ _, φ]
+  simp_rw [φ, ψ_neg, neg_sq, ← sub_neg_eq_add, ← neg_sub', sub_neg_eq_add, ← neg_add', ψ_neg,
+    neg_mul_neg, mul_comm <| W.ψ <| n - 1]
 
 lemma Affine.CoordinateRing.mk_φ (n : ℤ) : mk W (W.φ n) = mk W (C <| W.Φ n) := by
   simp_rw [φ, Φ, map_sub, map_mul, map_pow, mk_ψ, mk_Ψ_sq, Ψ, map_mul,
-    mul_mul_mul_comm _ <| mk W <| ite .., Int.even_add_one, Int.even_sub_one, ← sq, ite_not,
+    mul_mul_mul_comm _ <| mk W <| ite .., Int.even_add_one, Int.even_sub_one, ite_not, ← sq,
     apply_ite C, apply_ite <| mk W, ite_pow, map_one, one_pow, mk_ψ₂_sq]
 
 end φ
@@ -545,48 +506,52 @@ open WeierstrassCurve (Ψ Φ ψ φ)
 
 variable (f : R →+* S)
 
+@[simp]
 lemma map_ψ₂ : (W.map f).ψ₂ = W.ψ₂.map (mapRingHom f) := by
-  simp only [ψ₂, Affine.map_polynomialY]
+  simp_rw [ψ₂, Affine.map_polynomialY]
 
+@[simp]
 lemma map_Ψ₂Sq : (W.map f).Ψ₂Sq = W.Ψ₂Sq.map f := by
-  simp only [Ψ₂Sq, map_b₂, map_b₄, map_b₆]
-  map_simp
+  simp [Ψ₂Sq, map_ofNat]
 
+@[simp]
 lemma map_Ψ₃ : (W.map f).Ψ₃ = W.Ψ₃.map f := by
-  simp only [Ψ₃, map_b₂, map_b₄, map_b₆, map_b₈]
-  map_simp
+  simp [Ψ₃]
 
+@[simp]
 lemma map_preΨ₄ : (W.map f).preΨ₄ = W.preΨ₄.map f := by
-  simp only [preΨ₄, map_b₂, map_b₄, map_b₆, map_b₈]
-  map_simp
+  simp [preΨ₄]
 
+@[simp]
 lemma map_preΨ' (n : ℕ) : (W.map f).preΨ' n = (W.preΨ' n).map f := by
-  simp only [preΨ', map_Ψ₂Sq, map_Ψ₃, map_preΨ₄, ← coe_mapRingHom, map_preNormEDS']
-  map_simp
+  simp [preΨ', ← coe_mapRingHom]
 
+@[simp]
 lemma map_preΨ (n : ℤ) : (W.map f).preΨ n = (W.preΨ n).map f := by
-  simp only [preΨ, map_Ψ₂Sq, map_Ψ₃, map_preΨ₄, ← coe_mapRingHom, map_preNormEDS]
-  map_simp
+  simp [preΨ, ← coe_mapRingHom]
 
+@[simp]
 lemma map_ΨSq (n : ℤ) : (W.map f).ΨSq n = (W.ΨSq n).map f := by
-  simp only [ΨSq, map_preΨ, map_Ψ₂Sq, ← coe_mapRingHom]
-  map_simp
+  simp [ΨSq, ← coe_mapRingHom, apply_ite <| mapRingHom f]
 
+@[simp]
 lemma map_Ψ (n : ℤ) : (W.map f).Ψ n = (W.Ψ n).map (mapRingHom f) := by
-  simp only [Ψ, map_preΨ, map_ψ₂, ← coe_mapRingHom]
-  map_simp
+  rw [← coe_mapRingHom]
+  simp [Ψ, apply_ite <| mapRingHom _]
 
+@[simp]
 lemma map_Φ (n : ℤ) : (W.map f).Φ n = (W.Φ n).map f := by
-  simp only [Φ, map_ΨSq, map_preΨ, map_Ψ₂Sq, ← coe_mapRingHom]
-  map_simp
+  rw [← coe_mapRingHom]
+  simp [Φ, map_sub, apply_ite <| mapRingHom f]
 
+@[simp]
 lemma map_ψ (n : ℤ) : (W.map f).ψ n = (W.ψ n).map (mapRingHom f) := by
-  simp only [ψ, map_ψ₂, map_Ψ₃, map_preΨ₄, ← coe_mapRingHom, map_normEDS]
-  map_simp
+  rw [← coe_mapRingHom]
+  simp [ψ]
 
+@[simp]
 lemma map_φ (n : ℤ) : (W.map f).φ n = (W.φ n).map (mapRingHom f) := by
-  simp only [φ, map_ψ]
-  map_simp
+  simp [φ]
 
 end Map
 

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Degree.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Degree.lean
@@ -216,16 +216,14 @@ private lemma natDegree_coeff_preΨ' (n : ℕ) :
     rw [preΨ'_odd]
     constructor
     · nth_rw 1 [← max_self <| expDegree _, (expDegree_rec m).2.1, (expDegree_rec m).2.2]
-      refine natDegree_sub_le_of_le (dm (dm h₄.1 (dp h₂.1)) ?_) (dm (dm h₁.1 (dp h₃.1)) ?_)
-      all_goals split_ifs <;>
-        simp only [apply_ite natDegree, natDegree_one.le, dp W.natDegree_Ψ₂Sq_le]
+      refine natDegree_sub_le_of_le (dm (dm h₄.1 (dp h₂.1)) ?_) (dm (dm h₁.1 (dp h₃.1)) ?_) <;>
+        split_ifs <;> simp only [apply_ite, natDegree_one.le, dp W.natDegree_Ψ₂Sq_le]
     · nth_rw 1 [coeff_sub, (expDegree_rec m).2.1, cm (dm h₄.1 (dp h₂.1)), cm h₄.1 (dp h₂.1),
         h₄.2, cp h₂.1, h₂.2, apply_ite₂ coeff, cp W.natDegree_Ψ₂Sq_le, coeff_Ψ₂Sq, coeff_one_zero,
         (expDegree_rec m).2.2, cm (dm h₁.1 (dp h₃.1)), cm h₁.1 (dp h₃.1), h₁.2, cp h₃.1, h₃.2,
         apply_ite₂ coeff, cp W.natDegree_Ψ₂Sq_le, coeff_one_zero, coeff_Ψ₂Sq, (expCoeff_rec m).2]
       · norm_cast
-      all_goals split_ifs <;>
-        simp only [apply_ite natDegree, natDegree_one.le, dp W.natDegree_Ψ₂Sq_le]
+      all_goals split_ifs <;> simp only [apply_ite, natDegree_one.le, dp W.natDegree_Ψ₂Sq_le]
 
 lemma natDegree_preΨ'_le (n : ℕ) : (W.preΨ' n).natDegree ≤ (n ^ 2 - if Even n then 4 else 1) / 2 :=
   (W.natDegree_coeff_preΨ' n).left
@@ -249,9 +247,8 @@ lemma natDegree_preΨ' {n : ℕ} (h : (n : R) ≠ 0) :
   natDegree_eq_of_le_of_coeff_ne_zero (W.natDegree_preΨ'_le n) <| W.coeff_preΨ'_ne_zero h
 
 lemma natDegree_preΨ'_pos {n : ℕ} (hn : 2 < n) (h : (n : R) ≠ 0) : 0 < (W.preΨ' n).natDegree := by
-  simp only [W.natDegree_preΨ' h, Nat.div_pos_iff, zero_lt_two, true_and]
-  split_ifs <;>
-    exact Nat.AtLeastTwo.prop.trans <| Nat.sub_le_sub_right (Nat.pow_le_pow_left hn 2) _
+  simp_rw [W.natDegree_preΨ' h, Nat.div_pos_iff, zero_lt_two, true_and]
+  split_ifs <;> exact Nat.AtLeastTwo.prop.trans <| Nat.sub_le_sub_right (Nat.pow_le_pow_left hn 2) _
 
 @[simp]
 lemma leadingCoeff_preΨ' {n : ℕ} (h : (n : R) ≠ 0) :
@@ -271,7 +268,7 @@ lemma natDegree_preΨ_le (n : ℤ) : (W.preΨ n).natDegree ≤
     (n.natAbs ^ 2 - if Even n then 4 else 1) / 2 := by
   induction n using Int.negInduction with
   | nat n => exact_mod_cast W.preΨ_ofNat n ▸ W.natDegree_preΨ'_le n
-  | neg ih => simp only [preΨ_neg, natDegree_neg, Int.natAbs_neg, even_neg, ih]
+  | neg ih => simp_rw [preΨ_neg, natDegree_neg, Int.natAbs_neg, even_neg, ih]
 
 @[simp]
 lemma coeff_preΨ (n : ℤ) : (W.preΨ n).coeff ((n.natAbs ^ 2 - if Even n then 4 else 1) / 2) =
@@ -279,7 +276,7 @@ lemma coeff_preΨ (n : ℤ) : (W.preΨ n).coeff ((n.natAbs ^ 2 - if Even n then 
   induction n using Int.negInduction with
   | nat n => exact_mod_cast W.preΨ_ofNat n ▸ W.coeff_preΨ' n
   | neg ih n =>
-    simp only [preΨ_neg, coeff_neg, Int.natAbs_neg, even_neg]
+    simp_rw [preΨ_neg, coeff_neg, Int.natAbs_neg, even_neg]
     rcases ih n, n.even_or_odd' with ⟨ih, ⟨n, rfl | rfl⟩⟩ <;>
       push_cast [even_two_mul, Int.not_even_two_mul_add_one, Int.neg_ediv_of_dvd ⟨n, rfl⟩] at * <;>
       rw [ih]
@@ -326,7 +323,7 @@ private lemma natDegree_coeff_ΨSq_ofNat (n : ℕ) :
   rcases n with _ | n
   · simp
   have hd : (n + 1) ^ 2 - 1 = 2 * expDegree (n + 1) + if Even (n + 1) then 3 else 0 := by
-    push_cast [← @Nat.cast_inj ℤ, add_sq, expDegree_cast (by omega : n + 1 ≠ 0)]
+    push_cast [← @Nat.cast_inj ℤ, add_sq, expDegree_cast n.succ_ne_zero]
     split_ifs <;> ring1
   have hc : (n + 1 : ℕ) ^ 2 = expCoeff (n + 1) ^ 2 * if Even (n + 1) then 4 else 1 := by
     push_cast [← @Int.cast_inj ℚ, expCoeff_cast]
@@ -334,26 +331,26 @@ private lemma natDegree_coeff_ΨSq_ofNat (n : ℕ) :
   rw [ΨSq_ofNat, hd]
   constructor
   · refine natDegree_mul_le_of_le (dp h.1) ?_
-    split_ifs <;> simp only [apply_ite natDegree, natDegree_one.le, W.natDegree_Ψ₂Sq_le]
+    split_ifs <;> simp only [apply_ite, natDegree_one.le, W.natDegree_Ψ₂Sq_le]
   · rw [coeff_mul_of_natDegree_le (dp h.1), coeff_pow_of_natDegree_le h.1, h.2, apply_ite₂ coeff,
       coeff_Ψ₂Sq, coeff_one_zero, hc]
     · norm_cast
-    split_ifs <;> simp only [apply_ite natDegree, natDegree_one.le, W.natDegree_Ψ₂Sq_le]
+    split_ifs <;> simp only [apply_ite, natDegree_one.le, W.natDegree_Ψ₂Sq_le]
 
 lemma natDegree_ΨSq_le (n : ℤ) : (W.ΨSq n).natDegree ≤ n.natAbs ^ 2 - 1 := by
   induction n using Int.negInduction with
   | nat n => exact (W.natDegree_coeff_ΨSq_ofNat n).left
-  | neg ih => simp only [ΨSq_neg, Int.natAbs_neg, ih]
+  | neg ih => simp_rw [ΨSq_neg, Int.natAbs_neg, ih]
 
 @[simp]
 lemma coeff_ΨSq (n : ℤ) : (W.ΨSq n).coeff (n.natAbs ^ 2 - 1) = n ^ 2 := by
   induction n using Int.negInduction with
   | nat n => exact_mod_cast (W.natDegree_coeff_ΨSq_ofNat n).right
-  | neg ih => simp_rw [ΨSq_neg, Int.natAbs_neg, ← Int.cast_pow, neg_sq, Int.cast_pow, ih]
+  | neg ih => rw [ΨSq_neg, Int.natAbs_neg, ← Int.cast_pow, neg_sq, Int.cast_pow, ih]
 
 lemma coeff_ΨSq_ne_zero [NoZeroDivisors R] {n : ℤ} (h : (n : R) ≠ 0) :
     (W.ΨSq n).coeff (n.natAbs ^ 2 - 1) ≠ 0 := by
-  rwa [coeff_ΨSq, pow_ne_zero_iff two_ne_zero]
+  simpa
 
 @[simp]
 lemma natDegree_ΨSq [NoZeroDivisors R] {n : ℤ} (h : (n : R) ≠ 0) :
@@ -362,7 +359,7 @@ lemma natDegree_ΨSq [NoZeroDivisors R] {n : ℤ} (h : (n : R) ≠ 0) :
 
 lemma natDegree_ΨSq_pos [NoZeroDivisors R] {n : ℤ} (hn : 1 < n.natAbs) (h : (n : R) ≠ 0) :
     0 < (W.ΨSq n).natDegree := by
-  rwa [W.natDegree_ΨSq h, Nat.sub_pos_iff_lt, Nat.one_lt_pow_iff two_ne_zero]
+  simpa [W.natDegree_ΨSq h]
 
 @[simp]
 lemma leadingCoeff_ΨSq [NoZeroDivisors R] {n : ℤ} (h : (n : R) ≠ 0) :
@@ -390,16 +387,14 @@ private lemma natDegree_coeff_Φ_ofNat (n : ℕ) :
   let cm {m n p q} : _ → _ → (p * q : R[X]).coeff (m + n) = _ := coeff_mul_of_natDegree_le
   let h {n} := W.natDegree_coeff_preΨ' n
   rcases n with _ | _ | n
-  · simp
-  · simp [natDegree_X_le]
+  iterate 2 simp [natDegree_X_le]
   have hd : (n + 1 + 1) ^ 2 = 1 + 2 * expDegree (n + 2) + if Even (n + 1) then 0 else 3 := by
-    push_cast [← @Nat.cast_inj ℤ, expDegree_cast (by omega : n + 2 ≠ 0), Nat.even_add_one, ite_not]
+    push_cast [← @Nat.cast_inj ℤ, expDegree_cast (n + 1).succ_ne_zero, Nat.even_add_one, ite_not]
     split_ifs <;> ring1
   have hd' : (n + 1 + 1) ^ 2 =
       expDegree (n + 3) + expDegree (n + 1) + if Even (n + 1) then 3 else 0 := by
     push_cast [← @Nat.cast_inj ℤ, ← mul_left_cancel_iff_of_pos (b := (_ ^ 2 : ℤ)) two_pos, mul_add,
-      expDegree_cast (by omega : n + 3 ≠ 0), expDegree_cast (by omega : n + 1 ≠ 0),
-      Nat.even_add_one, ite_not]
+      expDegree_cast (n + 2).succ_ne_zero, expDegree_cast n.succ_ne_zero, Nat.even_add_one, ite_not]
     split_ifs <;> ring1
   have hc : (1 : ℤ) = 1 * expCoeff (n + 2) ^ 2 * (if Even (n + 1) then 1 else 4) -
       expCoeff (n + 3) * expCoeff (n + 1) * (if Even (n + 1) then 4 else 1) := by
@@ -408,25 +403,25 @@ private lemma natDegree_coeff_Φ_ofNat (n : ℕ) :
   rw [Nat.cast_add, Nat.cast_one, Φ_ofNat]
   constructor
   · nth_rw 1 [← max_self <| (_ + _) ^ 2, hd, hd']
-    refine natDegree_sub_le_of_le (dm (dm natDegree_X_le (dp h.1)) ?_) (dm (dm h.1 h.1) ?_)
-    all_goals split_ifs <;> simp only [apply_ite natDegree, natDegree_one.le, W.natDegree_Ψ₂Sq_le]
+    refine natDegree_sub_le_of_le (dm (dm natDegree_X_le (dp h.1)) ?_) (dm (dm h.1 h.1) ?_) <;>
+      split_ifs <;> simp only [apply_ite, natDegree_one.le, W.natDegree_Ψ₂Sq_le]
   · nth_rw 1 [coeff_sub, hd, hd', cm (dm natDegree_X_le (dp h.1)), cm natDegree_X_le (dp h.1),
       coeff_X_one, coeff_pow_of_natDegree_le h.1, h.2, apply_ite₂ coeff, coeff_one_zero, coeff_Ψ₂Sq,
       cm (dm h.1 h.1), cm h.1 h.1, h.2, h.2, apply_ite₂ coeff, coeff_one_zero, coeff_Ψ₂Sq]
     conv_rhs => rw [← Int.cast_one, hc]
     · norm_cast
-    all_goals split_ifs <;> simp only [apply_ite natDegree, natDegree_one.le, W.natDegree_Ψ₂Sq_le]
+    all_goals split_ifs <;> simp only [apply_ite, natDegree_one.le, W.natDegree_Ψ₂Sq_le]
 
 lemma natDegree_Φ_le (n : ℤ) : (W.Φ n).natDegree ≤ n.natAbs ^ 2 := by
   induction n using Int.negInduction with
   | nat n => exact (W.natDegree_coeff_Φ_ofNat n).left
-  | neg ih => simp only [Φ_neg, Int.natAbs_neg, ih]
+  | neg ih => simp_rw [Φ_neg, Int.natAbs_neg, ih]
 
 @[simp]
 lemma coeff_Φ (n : ℤ) : (W.Φ n).coeff (n.natAbs ^ 2) = 1 := by
   induction n using Int.negInduction with
   | nat n => exact (W.natDegree_coeff_Φ_ofNat n).right
-  | neg ih => simp only [Φ_neg, Int.natAbs_neg, ih]
+  | neg ih => rw [Φ_neg, Int.natAbs_neg, ih]
 
 lemma coeff_Φ_ne_zero [Nontrivial R] (n : ℤ) : (W.Φ n).coeff (n.natAbs ^ 2) ≠ 0 :=
   W.coeff_Φ n ▸ one_ne_zero
@@ -436,7 +431,7 @@ lemma natDegree_Φ [Nontrivial R] (n : ℤ) : (W.Φ n).natDegree = n.natAbs ^ 2 
   natDegree_eq_of_le_of_coeff_ne_zero (W.natDegree_Φ_le n) <| W.coeff_Φ_ne_zero n
 
 lemma natDegree_Φ_pos [Nontrivial R] {n : ℤ} (hn : n ≠ 0) : 0 < (W.Φ n).natDegree := by
-  rwa [natDegree_Φ, pow_pos_iff two_ne_zero, Int.natAbs_pos]
+  simpa [sq_pos_iff]
 
 @[simp]
 lemma leadingCoeff_Φ [Nontrivial R] (n : ℤ) : (W.Φ n).leadingCoeff = 1 := by

--- a/Mathlib/NumberTheory/EllipticDivisibilitySequence.lean
+++ b/Mathlib/NumberTheory/EllipticDivisibilitySequence.lean
@@ -84,7 +84,7 @@ def IsEllDivSequence : Prop :=
   IsEllSequence W ∧ IsDivSequence W
 
 lemma isEllSequence_id : IsEllSequence id :=
-  fun _ _ _ => by simp only [id_eq]; ring1
+  fun _ _ _ => by simp_rw [id_eq]; ring1
 
 lemma isDivSequence_id : IsDivSequence id :=
   fun _ _ => Int.ofNat_dvd.mpr
@@ -97,7 +97,7 @@ variable {W}
 
 lemma IsEllSequence.smul (h : IsEllSequence W) (x : R) : IsEllSequence (x • W) :=
   fun m n r => by
-    linear_combination (norm := (simp only [Pi.smul_apply, smul_eq_mul]; ring1)) x ^ 4 * h m n r
+    linear_combination (norm := (simp_rw [Pi.smul_apply, smul_eq_mul]; ring1)) x ^ 4 * h m n r
 
 lemma IsDivSequence.smul (h : IsDivSequence W) (x : R) : IsDivSequence (x • W) :=
   fun m n r => mul_dvd_mul_left x <| h m n r
@@ -107,61 +107,27 @@ lemma IsEllDivSequence.smul (h : IsEllDivSequence W) (x : R) : IsEllDivSequence 
 
 end IsEllDivSequence
 
-/-- Strong recursion principle for a normalised EDS: if we have
-* `P 0`, `P 1`, `P 2`, `P 3`, and `P 4`,
-* for all `m : ℕ` we can prove `P (2 * (m + 3))` from `P k` for all `k < 2 * (m + 3)`, and
-* for all `m : ℕ` we can prove `P (2 * (m + 2) + 1)` from `P k` for all `k < 2 * (m + 2) + 1`,
-then we have `P n` for all `n : ℕ`. -/
-@[elab_as_elim]
-noncomputable def normEDSRec' {P : ℕ → Sort u}
-    (zero : P 0) (one : P 1) (two : P 2) (three : P 3) (four : P 4)
-    (even : ∀ m : ℕ, (∀ k < 2 * (m + 3), P k) → P (2 * (m + 3)))
-    (odd : ∀ m : ℕ, (∀ k < 2 * (m + 2) + 1, P k) → P (2 * (m + 2) + 1)) (n : ℕ) : P n :=
-  n.evenOddStrongRec (by rintro (_ | _ | _ | _) h; exacts [zero, two, four, even _ h])
-    (by rintro (_ | _ | _) h; exacts [one, three, odd _ h])
-
-/-- Recursion principle for a normalised EDS: if we have
-* `P 0`, `P 1`, `P 2`, `P 3`, and `P 4`,
-* for all `m : ℕ` we can prove `P (2 * (m + 3))` from `P (m + 1)`, `P (m + 2)`, `P (m + 3)`,
-    `P (m + 4)`, and `P (m + 5)`, and
-* for all `m : ℕ` we can prove `P (2 * (m + 2) + 1)` from `P (m + 1)`, `P (m + 2)`, `P (m + 3)`,
-    and `P (m + 4)`,
-then we have `P n` for all `n : ℕ`. -/
-@[elab_as_elim]
-noncomputable def normEDSRec {P : ℕ → Sort u}
-    (zero : P 0) (one : P 1) (two : P 2) (three : P 3) (four : P 4)
-    (even : ∀ m : ℕ, P (m + 1) → P (m + 2) → P (m + 3) → P (m + 4) → P (m + 5) → P (2 * (m + 3)))
-    (odd : ∀ m : ℕ, P (m + 1) → P (m + 2) → P (m + 3) → P (m + 4) → P (2 * (m + 2) + 1)) (n : ℕ) :
-    P n :=
-  normEDSRec' zero one two three four
-    (fun _ ih => by apply even <;> exact ih _ <| by linarith only)
-    (fun _ ih => by apply odd <;> exact ih _ <| by linarith only) n
-
 variable (b c d : R)
 
 section PreNormEDS
 
 /-- The auxiliary sequence for a normalised EDS `W : ℕ → R`, with initial values
 `W(0) = 0`, `W(1) = 1`, `W(2) = 1`, `W(3) = c`, and `W(4) = d` and extra parameter `b`. -/
-def preNormEDS' (b c d : R) : ℕ → R
+def preNormEDS' : ℕ → R
   | 0 => 0
   | 1 => 1
   | 2 => 1
   | 3 => c
   | 4 => d
   | (n + 5) => let m := n / 2
-    have h4 : m + 4 < n + 5 := Nat.lt_succ.mpr <| add_le_add_right (n.div_le_self 2) 4
-    have h3 : m + 3 < n + 5 := (lt_add_one _).trans h4
-    have h2 : m + 2 < n + 5 := (lt_add_one _).trans h3
-    have _ : m + 1 < n + 5 := (lt_add_one _).trans h2
     if hn : Even n then
-      preNormEDS' b c d (m + 4) * preNormEDS' b c d (m + 2) ^ 3 * (if Even m then b else 1) -
-        preNormEDS' b c d (m + 1) * preNormEDS' b c d (m + 3) ^ 3 * (if Even m then 1 else b)
+      preNormEDS' (m + 4) * preNormEDS' (m + 2) ^ 3 * (if Even m then b else 1) -
+        preNormEDS' (m + 1) * preNormEDS' (m + 3) ^ 3 * (if Even m then 1 else b)
     else
-      have _ : m + 5 < n + 5 := add_lt_add_right
-        (Nat.div_lt_self (Nat.not_even_iff_odd.1 hn).pos <| Nat.lt_succ_self 1) 5
-      preNormEDS' b c d (m + 2) ^ 2 * preNormEDS' b c d (m + 3) * preNormEDS' b c d (m + 5) -
-        preNormEDS' b c d (m + 1) * preNormEDS' b c d (m + 3) * preNormEDS' b c d (m + 4) ^ 2
+      have : m + 5 < n + 5 :=
+        add_lt_add_right (Nat.div_lt_self (Nat.not_even_iff_odd.mp hn).pos one_lt_two) 5
+      preNormEDS' (m + 2) ^ 2 * preNormEDS' (m + 3) * preNormEDS' (m + 5) -
+        preNormEDS' (m + 1) * preNormEDS' (m + 3) * preNormEDS' (m + 4) ^ 2
 
 @[simp]
 lemma preNormEDS'_zero : preNormEDS' b c d 0 = 0 := by
@@ -183,18 +149,17 @@ lemma preNormEDS'_three : preNormEDS' b c d 3 = c := by
 lemma preNormEDS'_four : preNormEDS' b c d 4 = d := by
   rw [preNormEDS']
 
-lemma preNormEDS'_odd (m : ℕ) : preNormEDS' b c d (2 * (m + 2) + 1) =
-    preNormEDS' b c d (m + 4) * preNormEDS' b c d (m + 2) ^ 3 * (if Even m then b else 1) -
-      preNormEDS' b c d (m + 1) * preNormEDS' b c d (m + 3) ^ 3 * (if Even m then 1 else b) := by
-  rw [show 2 * (m + 2) + 1 = 2 * m + 5 by rfl, preNormEDS', dif_pos <| even_two_mul _]
-  simp only [m.mul_div_cancel_left two_pos]
-
 lemma preNormEDS'_even (m : ℕ) : preNormEDS' b c d (2 * (m + 3)) =
     preNormEDS' b c d (m + 2) ^ 2 * preNormEDS' b c d (m + 3) * preNormEDS' b c d (m + 5) -
       preNormEDS' b c d (m + 1) * preNormEDS' b c d (m + 3) * preNormEDS' b c d (m + 4) ^ 2 := by
   rw [show 2 * (m + 3) = 2 * m + 1 + 5 by rfl, preNormEDS', dif_neg m.not_even_two_mul_add_one]
-  simp only [Nat.mul_add_div two_pos]
-  rfl
+  simpa only [Nat.mul_add_div two_pos] using by rfl
+
+lemma preNormEDS'_odd (m : ℕ) : preNormEDS' b c d (2 * (m + 2) + 1) =
+    preNormEDS' b c d (m + 4) * preNormEDS' b c d (m + 2) ^ 3 * (if Even m then b else 1) -
+      preNormEDS' b c d (m + 1) * preNormEDS' b c d (m + 3) ^ 3 * (if Even m then 1 else b) := by
+  rw [show 2 * (m + 2) + 1 = 2 * m + 5 by rfl, preNormEDS', dif_pos <| even_two_mul m,
+    m.mul_div_cancel_left two_pos]
 
 /-- The auxiliary sequence for a normalised EDS `W : ℤ → R`, with initial values
 `W(0) = 0`, `W(1) = 1`, `W(2) = 1`, `W(3) = c`, and `W(4) = d` and extra parameter `b`.
@@ -206,46 +171,32 @@ def preNormEDS (n : ℤ) : R :=
 @[simp]
 lemma preNormEDS_ofNat (n : ℕ) : preNormEDS b c d n = preNormEDS' b c d n := by
   by_cases hn : n = 0
-  · rw [hn, preNormEDS, Nat.cast_zero, Int.sign_zero, Int.cast_zero, zero_mul, preNormEDS'_zero]
-  · rw [preNormEDS, Int.sign_natCast_of_ne_zero hn, Int.cast_one, one_mul, Int.natAbs_cast]
+  · simp [hn, preNormEDS]
+  · simp [preNormEDS, Int.sign_natCast_of_ne_zero hn]
 
 @[simp]
 lemma preNormEDS_zero : preNormEDS b c d 0 = 0 := by
-  rw [← Nat.cast_zero, preNormEDS_ofNat, preNormEDS'_zero]
+  simp [preNormEDS]
 
 @[simp]
 lemma preNormEDS_one : preNormEDS b c d 1 = 1 := by
-  rw [← Nat.cast_one, preNormEDS_ofNat, preNormEDS'_one]
+  simp [preNormEDS]
 
 @[simp]
 lemma preNormEDS_two : preNormEDS b c d 2 = 1 := by
-  rw [← Nat.cast_two, preNormEDS_ofNat, preNormEDS'_two]
+  simp [preNormEDS, Int.sign_eq_one_of_pos]
 
 @[simp]
 lemma preNormEDS_three : preNormEDS b c d 3 = c := by
-  rw [← Nat.cast_three, preNormEDS_ofNat, preNormEDS'_three]
+  simp [preNormEDS, Int.sign_eq_one_of_pos]
 
 @[simp]
 lemma preNormEDS_four : preNormEDS b c d 4 = d := by
-  rw [← Nat.cast_four, preNormEDS_ofNat, preNormEDS'_four]
-
-lemma preNormEDS_even_ofNat (m : ℕ) : preNormEDS b c d (2 * (m + 3)) =
-    preNormEDS b c d (m + 2) ^ 2 * preNormEDS b c d (m + 3) * preNormEDS b c d (m + 5) -
-      preNormEDS b c d (m + 1) * preNormEDS b c d (m + 3) * preNormEDS b c d (m + 4) ^ 2 := by
-  norm_cast
-  simp only [preNormEDS_ofNat]
-  exact preNormEDS'_even ..
-
-lemma preNormEDS_odd_ofNat (m : ℕ) : preNormEDS b c d (2 * (m + 2) + 1) =
-    preNormEDS b c d (m + 4) * preNormEDS b c d (m + 2) ^ 3 * (if Even m then b else 1) -
-      preNormEDS b c d (m + 1) * preNormEDS b c d (m + 3) ^ 3 * (if Even m then 1 else b) := by
-  norm_cast
-  simp only [preNormEDS_ofNat]
-  exact preNormEDS'_odd ..
+  simp [preNormEDS, Int.sign_eq_one_of_pos]
 
 @[simp]
 lemma preNormEDS_neg (n : ℤ) : preNormEDS b c d (-n) = -preNormEDS b c d n := by
-  rw [preNormEDS, Int.sign_neg, Int.cast_neg, neg_mul, Int.natAbs_neg, preNormEDS]
+  simp [preNormEDS]
 
 lemma preNormEDS_even (m : ℤ) : preNormEDS b c d (2 * m) =
     preNormEDS b c d (m - 1) ^ 2 * preNormEDS b c d m * preNormEDS b c d (m + 2) -
@@ -253,37 +204,36 @@ lemma preNormEDS_even (m : ℤ) : preNormEDS b c d (2 * m) =
   induction m using Int.negInduction with
   | nat m =>
     rcases m with _ | _ | _ | m
-    · simp
-    · simp
-    · simp
-    · simp only [Int.natCast_add, Nat.cast_one]
-      rw [Int.add_sub_cancel, show (m : ℤ) + 1 + 1 + 1 = m + 1 + 2 by rfl, Int.add_sub_cancel]
-      exact preNormEDS_even_ofNat ..
-  | neg h m =>
-    simp_rw [show 2 * -(m : ℤ) = -(2 * m) by omega, show -(m : ℤ) - 1 = -(m + 1) by omega,
-      show -(m : ℤ) + 2 = -(m - 2) by omega, show -(m : ℤ) - 2 = -(m + 2) by omega,
-      show -(m : ℤ) + 1 = -(m - 1) by omega, preNormEDS_neg, h m]
+    iterate 3 simp
+    simp_rw [Nat.cast_succ, Int.add_sub_cancel, show (m : ℤ) + 1 + 1 + 1 = m + 1 + 2 by rfl,
+      Int.add_sub_cancel]
+    norm_cast
+    simpa only [preNormEDS_ofNat] using preNormEDS'_even ..
+  | neg ih m =>
+    simp_rw [mul_neg, ← sub_neg_eq_add, ← neg_sub', ← neg_add', preNormEDS_neg, ih]
     ring1
+
+@[deprecated (since := "2025-05-15")] alias preNormEDS_even_ofNat := preNormEDS_even
 
 lemma preNormEDS_odd (m : ℤ) : preNormEDS b c d (2 * m + 1) =
     preNormEDS b c d (m + 2) * preNormEDS b c d m ^ 3 * (if Even m then b else 1) -
       preNormEDS b c d (m - 1) * preNormEDS b c d (m + 1) ^ 3 * (if Even m then 1 else b) := by
   induction m using Int.negInduction with
   | nat m =>
-    rcases m with _ | _ | m
-    · simp
-    · simp
-    · simp only [Int.natCast_add, Nat.cast_one, Int.even_add_one, not_not, Int.even_coe_nat]
-      rw [Int.add_sub_cancel]
-      exact preNormEDS_odd_ofNat ..
-  | neg h m =>
+    rcases m with _ | _ | _
+    iterate 2 simp
+    simp_rw [Nat.cast_succ, Int.add_sub_cancel, Int.even_add_one, not_not, Int.even_coe_nat]
+    norm_cast
+    simpa only [preNormEDS_ofNat] using preNormEDS'_odd ..
+  | neg ih m =>
     rcases m with _ | m
     · simp
-    · simp_rw [Int.natCast_add, Nat.cast_one, show 2 * -(m + 1 : ℤ) + 1 = -(2 * m + 1) by rfl,
-        show -(m + 1 : ℤ) + 2 = -(m - 1) by omega, show -(m + 1 : ℤ) - 1 = -(m + 2) by rfl,
-        show -(m + 1 : ℤ) + 1 = -m by omega, preNormEDS_neg, even_neg, Int.even_add_one, ite_not,
-        h m]
-      ring1
+    simp_rw [Nat.cast_succ, show 2 * -(m + 1 : ℤ) + 1 = -(2 * m + 1) by rfl,
+      show -(m + 1 : ℤ) + 2 = -(m - 1) by ring1, show -(m + 1 : ℤ) - 1 = -(m + 2) by rfl,
+      show -(m + 1 : ℤ) + 1 = -m by ring1, preNormEDS_neg, even_neg, Int.even_add_one, ite_not, ih]
+    ring1
+
+@[deprecated (since := "2025-05-15")] alias preNormEDS_odd_ofNat := preNormEDS_odd
 
 end PreNormEDS
 
@@ -299,66 +249,78 @@ def normEDS (n : ℤ) : R :=
 @[simp]
 lemma normEDS_ofNat (n : ℕ) :
     normEDS b c d n = preNormEDS' (b ^ 4) c d n * if Even n then b else 1 := by
-  simp only [normEDS, preNormEDS_ofNat, Int.even_coe_nat]
+  simp [normEDS]
 
 @[simp]
 lemma normEDS_zero : normEDS b c d 0 = 0 := by
-  rw [← Nat.cast_zero, normEDS_ofNat, preNormEDS'_zero, zero_mul]
+  simp [normEDS]
 
 @[simp]
 lemma normEDS_one : normEDS b c d 1 = 1 := by
-  rw [← Nat.cast_one, normEDS_ofNat, preNormEDS'_one, one_mul, if_neg Nat.not_even_one]
+  simp [normEDS]
 
 @[simp]
 lemma normEDS_two : normEDS b c d 2 = b := by
-  rw [← Nat.cast_two, normEDS_ofNat, preNormEDS'_two, one_mul, if_pos even_two]
+  simp [normEDS]
 
 @[simp]
 lemma normEDS_three : normEDS b c d 3 = c := by
-  rw [← Nat.cast_three, normEDS_ofNat, preNormEDS'_three, if_neg <| by decide, mul_one]
+  simp [normEDS, show ¬Even (3 : ℤ) by decide]
 
 @[simp]
 lemma normEDS_four : normEDS b c d 4 = d * b := by
-  rw [← Nat.cast_four, normEDS_ofNat, preNormEDS'_four, if_pos <| by decide]
-
-lemma normEDS_even_ofNat (m : ℕ) : normEDS b c d (2 * (m + 3)) * b =
-    normEDS b c d (m + 2) ^ 2 * normEDS b c d (m + 3) * normEDS b c d (m + 5) -
-      normEDS b c d (m + 1) * normEDS b c d (m + 3) * normEDS b c d (m + 4) ^ 2 := by
-  norm_cast
-  simp only [normEDS_ofNat]
-  simp only [preNormEDS'_even, if_pos <| even_two_mul _, Nat.even_add_one, ite_not]
-  split_ifs <;> ring1
-
-lemma normEDS_odd_ofNat (m : ℕ) : normEDS b c d (2 * (m + 2) + 1) =
-    normEDS b c d (m + 4) * normEDS b c d (m + 2) ^ 3 -
-      normEDS b c d (m + 1) * normEDS b c d (m + 3) ^ 3 := by
-  norm_cast
-  simp only [normEDS_ofNat]
-  simp_rw [preNormEDS'_odd, if_neg (m + 2).not_even_two_mul_add_one, Nat.even_add_one, ite_not]
-  split_ifs <;> ring1
+  simp [normEDS, show ¬Odd (4 : ℤ) by decide]
 
 @[simp]
 lemma normEDS_neg (n : ℤ) : normEDS b c d (-n) = -normEDS b c d n := by
-  simp only [normEDS, preNormEDS_neg, neg_mul, even_neg]
+  simp_rw [normEDS, preNormEDS_neg, even_neg, neg_mul]
 
 lemma normEDS_even (m : ℤ) : normEDS b c d (2 * m) * b =
     normEDS b c d (m - 1) ^ 2 * normEDS b c d m * normEDS b c d (m + 2) -
       normEDS b c d (m - 2) * normEDS b c d m * normEDS b c d (m + 1) ^ 2 := by
-  simp only [normEDS, preNormEDS_even, if_pos <| even_two_mul m, show m + 2 = m + 1 + 1 by ring1,
-    Int.even_add_one, show m - 2 = m - 1 - 1 by ring1, Int.even_sub_one, ite_not]
-  by_cases hm : Even m
-  · simp only [if_pos hm]
-    ring1
-  · simp only [if_neg hm]
-    ring1
+  simp_rw [normEDS, preNormEDS_even, if_pos <| even_two_mul m, Int.even_add, Int.even_sub, even_two,
+    iff_true, Int.not_even_one, iff_false]
+  split_ifs <;> ring1
+
+@[deprecated (since := "2025-05-15")] alias normEDS_even_ofNat := normEDS_even
 
 lemma normEDS_odd (m : ℤ) : normEDS b c d (2 * m + 1) =
     normEDS b c d (m + 2) * normEDS b c d m ^ 3 -
       normEDS b c d (m - 1) * normEDS b c d (m + 1) ^ 3 := by
-  simp only [normEDS, preNormEDS_odd, if_neg m.not_even_two_mul_add_one]
-  conv_lhs => rw [← @one_pow R _ 4, ← ite_pow, ← ite_pow]
-  simp only [show m + 2 = m + 1 + 1 by ring1, Int.even_add_one, Int.even_sub_one, ite_not]
-  ring1
+  simp_rw [normEDS, preNormEDS_odd, if_neg m.not_even_two_mul_add_one, Int.even_add, Int.even_sub,
+    even_two, iff_true, Int.not_even_one, iff_false]
+  split_ifs <;> ring1
+
+@[deprecated (since := "2025-05-15")] alias normEDS_odd_ofNat := normEDS_odd
+
+/-- Strong recursion principle for a normalised EDS: if we have
+* `P 0`, `P 1`, `P 2`, `P 3`, and `P 4`,
+* for all `m : ℕ` we can prove `P (2 * (m + 3))` from `P k` for all `k < 2 * (m + 3)`, and
+* for all `m : ℕ` we can prove `P (2 * (m + 2) + 1)` from `P k` for all `k < 2 * (m + 2) + 1`,
+then we have `P n` for all `n : ℕ`. -/
+@[elab_as_elim]
+noncomputable def normEDSRec' {P : ℕ → Sort u}
+    (zero : P 0) (one : P 1) (two : P 2) (three : P 3) (four : P 4)
+    (even : ∀ m : ℕ, (∀ k < 2 * (m + 3), P k) → P (2 * (m + 3)))
+    (odd : ∀ m : ℕ, (∀ k < 2 * (m + 2) + 1, P k) → P (2 * (m + 2) + 1)) (n : ℕ) : P n :=
+  n.evenOddStrongRec (by rintro (_ | _ | _ | _) h; exacts [zero, two, four, even _ h])
+    (by rintro (_ | _ | _) h; exacts [one, three, odd _ h])
+
+/-- Recursion principle for a normalised EDS: if we have
+* `P 0`, `P 1`, `P 2`, `P 3`, and `P 4`,
+* for all `m : ℕ` we can prove `P (2 * (m + 3))` from `P (m + 1)`, `P (m + 2)`, `P (m + 3)`,
+  `P (m + 4)`, and `P (m + 5)`, and
+* for all `m : ℕ` we can prove `P (2 * (m + 2) + 1)` from `P (m + 1)`, `P (m + 2)`, `P (m + 3)`,
+  and `P (m + 4)`,
+then we have `P n` for all `n : ℕ`. -/
+@[elab_as_elim]
+noncomputable def normEDSRec {P : ℕ → Sort u}
+    (zero : P 0) (one : P 1) (two : P 2) (three : P 3) (four : P 4)
+    (even : ∀ m : ℕ, P (m + 1) → P (m + 2) → P (m + 3) → P (m + 4) → P (m + 5) → P (2 * (m + 3)))
+    (odd : ∀ m : ℕ, P (m + 1) → P (m + 2) → P (m + 3) → P (m + 4) → P (2 * (m + 2) + 1)) (n : ℕ) :
+    P n :=
+  normEDSRec' zero one two three four (fun _ ih => by apply even <;> exact ih _ <| by linarith only)
+    (fun _ ih => by apply odd <;> exact ih _ <| by linarith only) n
 
 end NormEDS
 
@@ -366,21 +328,24 @@ section Map
 
 variable {S : Type v} [CommRing S] (f : R →+* S)
 
+@[simp]
 lemma map_preNormEDS' (n : ℕ) : f (preNormEDS' b c d n) = preNormEDS' (f b) (f c) (f d) n := by
   induction n using normEDSRec' with
-  | zero => rw [preNormEDS'_zero, map_zero, preNormEDS'_zero]
-  | one => rw [preNormEDS'_one, map_one, preNormEDS'_one]
-  | two => rw [preNormEDS'_two, map_one, preNormEDS'_two]
-  | three => rw [preNormEDS'_three, preNormEDS'_three]
-  | four => rw [preNormEDS'_four, preNormEDS'_four]
+  | zero => simp
+  | one => simp
+  | two => simp
+  | three => simp
+  | four => simp
   | _ _ ih =>
-    simp only [preNormEDS'_odd, preNormEDS'_even, map_one, map_sub, map_mul, map_pow, apply_ite f]
+    simp only [preNormEDS'_even, preNormEDS'_odd, apply_ite f, map_pow, map_mul, map_sub, map_one]
     repeat rw [ih _ <| by linarith only]
 
+@[simp]
 lemma map_preNormEDS (n : ℤ) : f (preNormEDS b c d n) = preNormEDS (f b) (f c) (f d) n := by
-  rw [preNormEDS, map_mul, map_intCast, map_preNormEDS', preNormEDS]
+  simp [preNormEDS]
 
+@[simp]
 lemma map_normEDS (n : ℤ) : f (normEDS b c d n) = normEDS (f b) (f c) (f d) n := by
-  rw [normEDS, map_mul, map_preNormEDS, map_pow, apply_ite f, map_one, normEDS]
+  simp [normEDS, apply_ite f]
 
 end Map


### PR DESCRIPTION
Simplify proofs with terminal `rw`s to terminal `simp`s and deprecate `even/odd_ofNat` lemmas.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
