### PR TITLE
[Merged by Bors] - feat: add lemmas of the form `⟪_ -ᵥ _, _ -ᵥ _⟫ = dist _ _ ^ 2`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1537,6 +1537,7 @@ import Mathlib.Analysis.Fourier.ZMod
 import Mathlib.Analysis.FunctionalSpaces.SobolevInequality
 import Mathlib.Analysis.Hofer
 import Mathlib.Analysis.InnerProductSpace.Adjoint
+import Mathlib.Analysis.InnerProductSpace.Affine
 import Mathlib.Analysis.InnerProductSpace.Basic
 import Mathlib.Analysis.InnerProductSpace.Calculus
 import Mathlib.Analysis.InnerProductSpace.CanonicalTensor

--- a/Mathlib/Analysis/InnerProductSpace/Affine.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Affine.lean
@@ -1,0 +1,76 @@
+/-
+Copyright (c) 2025 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+-/
+import Mathlib.Analysis.InnerProductSpace.Basic
+import Mathlib.Analysis.Normed.Group.AddTorsor
+/-
+# Normed affine spaces over an inner product space
+-/
+
+variable {𝕜 V P : Type*}
+
+section RCLike
+variable [RCLike 𝕜] [NormedAddCommGroup V] [InnerProductSpace 𝕜 V] [MetricSpace P]
+variable [NormedAddTorsor V P]
+
+open scoped InnerProductSpace
+
+theorem inner_vsub_left_eq_zero_symm {a b : P} {v : V} :
+    ⟪a -ᵥ b, v⟫_𝕜 = 0 ↔ ⟪b -ᵥ a, v⟫_𝕜 = 0 := by
+  rw [← neg_vsub_eq_vsub_rev, inner_neg_left, neg_eq_zero]
+
+theorem inner_vsub_right_eq_zero_symm {v : V} {a b : P} :
+    ⟪v, a -ᵥ b⟫_𝕜 = 0 ↔ ⟪v, b -ᵥ a⟫_𝕜 = 0 := by
+  rw [← neg_vsub_eq_vsub_rev, inner_neg_right, neg_eq_zero]
+
+theorem inner_eq_ofReal_norm_sq_left_iff {v w : V} : ⟪v, w⟫_𝕜 = ‖v‖ ^ 2 ↔ ⟪v, v - w⟫_𝕜 = 0 := by
+  rw [inner_sub_right, sub_eq_zero, inner_self_eq_norm_sq_to_K, eq_comm]
+
+theorem inner_eq_ofReal_norm_sq_right_iff {v w : V} : ⟪v, w⟫_𝕜 = ‖w‖ ^ 2 ↔ ⟪v - w, w⟫_𝕜 = 0 := by
+  rw [inner_sub_left, sub_eq_zero, inner_self_eq_norm_sq_to_K, eq_comm]
+
+end RCLike
+
+section Real
+variable [NormedAddCommGroup V] [InnerProductSpace ℝ V] [MetricSpace P]
+variable [NormedAddTorsor V P]
+
+open scoped RealInnerProductSpace
+
+theorem inner_eq_norm_sq_left_iff {v w : V} : ⟪v, w⟫ = ‖v‖ ^ 2 ↔ ⟪v, v - w⟫ = 0 :=
+  inner_eq_ofReal_norm_sq_left_iff
+
+theorem inner_eq_norm_sq_right_iff {v w : V} : ⟪v, w⟫ = ‖w‖ ^ 2 ↔ ⟪v - w, w⟫ = 0 :=
+  inner_eq_ofReal_norm_sq_right_iff
+
+section vsub
+/-!
+In this section, the first `left`/`right` indicates where the common argument to `vsub` is,
+and the section refers to the argument of `inner` that ends up in the `dist`.
+
+The lemma shapes are such that the relevant argument of `inner` remains unchanged,
+and that the other `vsub` preserves the position of the unchanging argument. -/
+
+theorem inner_vsub_vsub_left_eq_dist_sq_left_iff (a b c : P) :
+    ⟪a -ᵥ b, a -ᵥ c⟫ = dist a b ^ 2 ↔ ⟪a -ᵥ b, b -ᵥ c⟫ = 0 := by
+  rw [dist_eq_norm_vsub V, inner_eq_norm_sq_left_iff, vsub_sub_vsub_cancel_left,
+    inner_vsub_right_eq_zero_symm]
+
+theorem inner_vsub_vsub_left_eq_dist_sq_right_iff (a b c : P) :
+    ⟪a -ᵥ b, a -ᵥ c⟫ = dist a c ^ 2 ↔ ⟪c -ᵥ b, a -ᵥ c⟫ = 0 := by
+  rw [real_inner_comm, inner_vsub_vsub_left_eq_dist_sq_left_iff, real_inner_comm]
+
+theorem inner_vsub_vsub_right_eq_dist_sq_left_iff (a b c : P) :
+    ⟪a -ᵥ c, b -ᵥ c⟫ = dist a c ^ 2 ↔ ⟪a -ᵥ c, b -ᵥ a⟫ = 0 := by
+  rw [dist_eq_norm_vsub V, inner_eq_norm_sq_left_iff, vsub_sub_vsub_cancel_right,
+    inner_vsub_right_eq_zero_symm]
+
+theorem inner_vsub_vsub_right_eq_dist_sq_right_iff (a b c : P) :
+    ⟪a -ᵥ c, b -ᵥ c⟫ = dist b c ^ 2 ↔ ⟪a -ᵥ b, b -ᵥ c⟫ = 0 := by
+  rw [real_inner_comm, inner_vsub_vsub_right_eq_dist_sq_left_iff, real_inner_comm]
+
+end vsub
+
+end Real

--- a/Mathlib/Analysis/InnerProductSpace/Affine.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Affine.lean
@@ -5,7 +5,7 @@ Authors: Eric Wieser
 -/
 import Mathlib.Analysis.InnerProductSpace.Basic
 import Mathlib.Analysis.Normed.Group.AddTorsor
-/-
+/-!
 # Normed affine spaces over an inner product space
 -/
 
@@ -25,12 +25,6 @@ theorem inner_vsub_right_eq_zero_symm {v : V} {a b : P} :
     ⟪v, a -ᵥ b⟫_𝕜 = 0 ↔ ⟪v, b -ᵥ a⟫_𝕜 = 0 := by
   rw [← neg_vsub_eq_vsub_rev, inner_neg_right, neg_eq_zero]
 
-theorem inner_eq_ofReal_norm_sq_left_iff {v w : V} : ⟪v, w⟫_𝕜 = ‖v‖ ^ 2 ↔ ⟪v, v - w⟫_𝕜 = 0 := by
-  rw [inner_sub_right, sub_eq_zero, inner_self_eq_norm_sq_to_K, eq_comm]
-
-theorem inner_eq_ofReal_norm_sq_right_iff {v w : V} : ⟪v, w⟫_𝕜 = ‖w‖ ^ 2 ↔ ⟪v - w, w⟫_𝕜 = 0 := by
-  rw [inner_sub_left, sub_eq_zero, inner_self_eq_norm_sq_to_K, eq_comm]
-
 end RCLike
 
 section Real
@@ -39,13 +33,6 @@ variable [NormedAddTorsor V P]
 
 open scoped RealInnerProductSpace
 
-theorem inner_eq_norm_sq_left_iff {v w : V} : ⟪v, w⟫ = ‖v‖ ^ 2 ↔ ⟪v, v - w⟫ = 0 :=
-  inner_eq_ofReal_norm_sq_left_iff
-
-theorem inner_eq_norm_sq_right_iff {v w : V} : ⟪v, w⟫ = ‖w‖ ^ 2 ↔ ⟪v - w, w⟫ = 0 :=
-  inner_eq_ofReal_norm_sq_right_iff
-
-section vsub
 /-!
 In this section, the first `left`/`right` indicates where the common argument to `vsub` is,
 and the section refers to the argument of `inner` that ends up in the `dist`.
@@ -53,24 +40,22 @@ and the section refers to the argument of `inner` that ends up in the `dist`.
 The lemma shapes are such that the relevant argument of `inner` remains unchanged,
 and that the other `vsub` preserves the position of the unchanging argument. -/
 
-theorem inner_vsub_vsub_left_eq_dist_sq_left_iff (a b c : P) :
+theorem inner_vsub_vsub_left_eq_dist_sq_left_iff {a b c : P} :
     ⟪a -ᵥ b, a -ᵥ c⟫ = dist a b ^ 2 ↔ ⟪a -ᵥ b, b -ᵥ c⟫ = 0 := by
   rw [dist_eq_norm_vsub V, inner_eq_norm_sq_left_iff, vsub_sub_vsub_cancel_left,
     inner_vsub_right_eq_zero_symm]
 
-theorem inner_vsub_vsub_left_eq_dist_sq_right_iff (a b c : P) :
+theorem inner_vsub_vsub_left_eq_dist_sq_right_iff {a b c : P} :
     ⟪a -ᵥ b, a -ᵥ c⟫ = dist a c ^ 2 ↔ ⟪c -ᵥ b, a -ᵥ c⟫ = 0 := by
   rw [real_inner_comm, inner_vsub_vsub_left_eq_dist_sq_left_iff, real_inner_comm]
 
-theorem inner_vsub_vsub_right_eq_dist_sq_left_iff (a b c : P) :
+theorem inner_vsub_vsub_right_eq_dist_sq_left_iff {a b c : P} :
     ⟪a -ᵥ c, b -ᵥ c⟫ = dist a c ^ 2 ↔ ⟪a -ᵥ c, b -ᵥ a⟫ = 0 := by
   rw [dist_eq_norm_vsub V, inner_eq_norm_sq_left_iff, vsub_sub_vsub_cancel_right,
     inner_vsub_right_eq_zero_symm]
 
-theorem inner_vsub_vsub_right_eq_dist_sq_right_iff (a b c : P) :
+theorem inner_vsub_vsub_right_eq_dist_sq_right_iff {a b c : P} :
     ⟪a -ᵥ c, b -ᵥ c⟫ = dist b c ^ 2 ↔ ⟪a -ᵥ b, b -ᵥ c⟫ = 0 := by
   rw [real_inner_comm, inner_vsub_vsub_right_eq_dist_sq_left_iff, real_inner_comm]
-
-end vsub
 
 end Real

--- a/Mathlib/Analysis/InnerProductSpace/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Basic.lean
@@ -265,6 +265,18 @@ theorem real_inner_mul_inner_self_le (x y : F) : ⟪x, y⟫_ℝ * ⟪x, y⟫_ℝ
       exact le_abs_self _
     _ ≤ ⟪x, x⟫_ℝ * ⟪y, y⟫_ℝ := @inner_mul_inner_self_le ℝ _ _ _ _ x y
 
+theorem inner_eq_ofReal_norm_sq_left_iff {v w : E} : ⟪v, w⟫_𝕜 = ‖v‖ ^ 2 ↔ ⟪v, v - w⟫_𝕜 = 0 := by
+  rw [inner_sub_right, sub_eq_zero, inner_self_eq_norm_sq_to_K, eq_comm]
+
+theorem inner_eq_norm_sq_left_iff {v w : F} : ⟪v, w⟫_ℝ = ‖v‖ ^ 2 ↔ ⟪v, v - w⟫_ℝ = 0 :=
+  inner_eq_ofReal_norm_sq_left_iff
+
+theorem inner_eq_ofReal_norm_sq_right_iff {v w : E} : ⟪v, w⟫_𝕜 = ‖w‖ ^ 2 ↔ ⟪v - w, w⟫_𝕜 = 0 := by
+  rw [inner_sub_left, sub_eq_zero, inner_self_eq_norm_sq_to_K, eq_comm]
+
+theorem inner_eq_norm_sq_right_iff {v w : F} : ⟪v, w⟫_ℝ = ‖w‖ ^ 2 ↔ ⟪v - w, w⟫_ℝ = 0 :=
+  inner_eq_ofReal_norm_sq_right_iff
+
 end BasicProperties_Seminormed
 
 section BasicProperties


### PR DESCRIPTION
Zulip: [#Is there code for X? > inner product lemmas for perpendicular vectors @ 💬](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/inner.20product.20lemmas.20for.20perpendicular.20vectors/near/518762687)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I'm not really sure which file these belong in.
