### PR TITLE
feat(GroupTheory/OrderOfElement): add `isOfFinOrder_of_isConj `

### DIFF
--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -69,6 +69,12 @@ theorem isOfFinOrder_ofAdd_iff {α : Type*} [AddMonoid α] {x : α} :
 theorem isOfFinOrder_iff_pow_eq_one : IsOfFinOrder x ↔ ∃ n, 0 < n ∧ x ^ n = 1 := by
   simp [IsOfFinOrder, mem_periodicPts, isPeriodicPt_mul_iff_pow_eq_one]
 
+theorem isOfFinOrder_of_isConj [Group α] {x y : α} :
+    IsConj x y → (IsOfFinOrder x → IsOfFinOrder y) := by
+  simp only [isConj_iff, isOfFinOrder_iff_pow_eq_one]
+  refine fun ⟨u, eq⟩ ⟨n, n_gt_0, eq'⟩ ↦ ⟨n, n_gt_0, ?_⟩
+  rw [← eq, conj_pow, eq', mul_one, mul_inv_cancel]
+
 @[to_additive] alias ⟨IsOfFinOrder.exists_pow_eq_one, _⟩ := isOfFinOrder_iff_pow_eq_one
 
 @[to_additive]


### PR DESCRIPTION
Upstreamed from the [EquationalTheories](https://github.com/teorth/equational_theories) project.

Co-authored-by: Bernhard Reinke

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
