### PR TITLE
[Merged by Bors] - feat(Combinatorics/SimpleGraph/Clique): add results on cliqueFree graphs

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Clique.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Clique.lean
@@ -485,7 +485,7 @@ protected theorem CliqueFree.sup_edge (h : G.CliqueFree n) (v w : α) :
     (h.mono n.le_succ).mem_of_sup_edge_isNClique hs).not_cliqueFree h
 
 lemma IsNClique.exists_not_adj_of_cliqueFree_succ (hc : G.IsNClique n s)
-    (h : G.CliqueFree (n + 1)) (x : α) :  ∃ y, y ∈ s ∧ ¬ G.Adj x y := by
+    (h : G.CliqueFree (n + 1)) (x : α) : ∃ y, y ∈ s ∧ ¬ G.Adj x y := by
   classical
   by_contra! hf
   exact (hc.insert hf).not_cliqueFree h

--- a/Mathlib/Combinatorics/SimpleGraph/Clique.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Clique.lean
@@ -484,6 +484,26 @@ protected theorem CliqueFree.sup_edge (h : G.CliqueFree n) (v w : α) :
   fun _ hs ↦ (hs.erase_of_sup_edge_of_mem <|
     (h.mono n.le_succ).mem_of_sup_edge_isNClique hs).not_cliqueFree h
 
+lemma IsNClique.exists_not_adj_of_cliqueFree_succ (hc : G.IsNClique n s)
+    (h : G.CliqueFree (n + 1)) (x : α) :  ∃ y, y ∈ s ∧ ¬ G.Adj x y := by
+  classical
+  by_contra! hf
+  exact (hc.insert hf).not_cliqueFree h
+
+lemma exists_of_maximal_cliqueFree_not_adj [DecidableEq α] (h : Maximal (fun H ↦ H.CliqueFree n) G)
+    {x y : α} (hne : x ≠ y) (hn : ¬ G.Adj x y) :
+    ∃ s, x ∉ s ∧ y ∉ s ∧ G.IsNClique (n - 1) (insert x s) ∧ G.IsNClique (n - 1) (insert y s) := by
+  obtain ⟨t, hc⟩ := not_forall_not.1 <| h.not_prop_of_gt <| G.lt_sup_edge _ _ hne hn
+  use (t.erase x).erase y, erase_right_comm (a := x) ▸ (not_mem_erase _ _), not_mem_erase _ _
+  cases n with
+  | zero => exact (not_cliqueFree_zero h.1).elim
+  | succ r =>
+    have h1 := h.1.mem_of_sup_edge_isNClique hc
+    have h2 := h.1.mem_of_sup_edge_isNClique (edge_comm .. ▸ hc)
+    rw [insert_erase <| mem_erase_of_ne_of_mem hne.symm h2, erase_right_comm,
+        insert_erase <| mem_erase_of_ne_of_mem hne h1]
+    exact ⟨(edge_comm .. ▸ hc).erase_of_sup_edge_of_mem h2, hc.erase_of_sup_edge_of_mem h1⟩
+
 end CliqueFree
 
 section CliqueFreeOn

--- a/Mathlib/Combinatorics/SimpleGraph/Clique.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Clique.lean
@@ -490,19 +490,16 @@ lemma IsNClique.exists_not_adj_of_cliqueFree_succ (hc : G.IsNClique n s)
   by_contra! hf
   exact (hc.insert hf).not_cliqueFree h
 
-lemma exists_of_maximal_cliqueFree_not_adj [DecidableEq α] (h : Maximal (fun H ↦ H.CliqueFree n) G)
-    {x y : α} (hne : x ≠ y) (hn : ¬ G.Adj x y) :
-    ∃ s, x ∉ s ∧ y ∉ s ∧ G.IsNClique (n - 1) (insert x s) ∧ G.IsNClique (n - 1) (insert y s) := by
+lemma exists_of_maximal_cliqueFree_not_adj [DecidableEq α]
+    (h : Maximal (fun H ↦ H.CliqueFree (n + 1)) G) {x y : α} (hne : x ≠ y) (hn : ¬ G.Adj x y) :
+    ∃ s, x ∉ s ∧ y ∉ s ∧ G.IsNClique n (insert x s) ∧ G.IsNClique n (insert y s) := by
   obtain ⟨t, hc⟩ := not_forall_not.1 <| h.not_prop_of_gt <| G.lt_sup_edge _ _ hne hn
   use (t.erase x).erase y, erase_right_comm (a := x) ▸ (not_mem_erase _ _), not_mem_erase _ _
-  cases n with
-  | zero => exact (not_cliqueFree_zero h.1).elim
-  | succ r =>
-    have h1 := h.1.mem_of_sup_edge_isNClique hc
-    have h2 := h.1.mem_of_sup_edge_isNClique (edge_comm .. ▸ hc)
-    rw [insert_erase <| mem_erase_of_ne_of_mem hne.symm h2, erase_right_comm,
-        insert_erase <| mem_erase_of_ne_of_mem hne h1]
-    exact ⟨(edge_comm .. ▸ hc).erase_of_sup_edge_of_mem h2, hc.erase_of_sup_edge_of_mem h1⟩
+  have h1 := h.1.mem_of_sup_edge_isNClique hc
+  have h2 := h.1.mem_of_sup_edge_isNClique (edge_comm .. ▸ hc)
+  rw [insert_erase <| mem_erase_of_ne_of_mem hne.symm h2, erase_right_comm,
+      insert_erase <| mem_erase_of_ne_of_mem hne h1]
+  exact ⟨(edge_comm .. ▸ hc).erase_of_sup_edge_of_mem h2, hc.erase_of_sup_edge_of_mem h1⟩
 
 end CliqueFree
 


### PR DESCRIPTION
Add a lemmas about the existence of structures in clique-free and maximally-clique free graphs

Co-authored-by: John Talbot j.talbot@ucl.ac.uk

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
