### PR TITLE
[Merged by Bors] - feat(Topology): DiscreteTopology and IsLocalHomeomorph

### DIFF
--- a/Mathlib/Topology/Homeomorph/Defs.lean
+++ b/Mathlib/Topology/Homeomorph/Defs.lean
@@ -230,6 +230,9 @@ alias embedding := isEmbedding
 protected theorem discreteTopology [DiscreteTopology X] (h : X ≃ₜ Y) :
   DiscreteTopology Y := h.symm.isEmbedding.discreteTopology
 
+theorem discreteTopology_iff (h : X ≃ₜ Y) : DiscreteTopology X ↔ DiscreteTopology Y :=
+  ⟨fun _ ↦ h.discreteTopology, fun _ ↦ h.symm.discreteTopology⟩
+
 @[simp]
 theorem isOpen_preimage (h : X ≃ₜ Y) {s : Set Y} : IsOpen (h ⁻¹' s) ↔ IsOpen s :=
   h.isQuotientMap.isOpen_preimage

--- a/Mathlib/Topology/IsLocalHomeomorph.lean
+++ b/Mathlib/Topology/IsLocalHomeomorph.lean
@@ -57,6 +57,30 @@ theorem isLocalHomeomorphOn_iff_isOpenEmbedding_restrict {f : X → Y} :
 
 namespace IsLocalHomeomorphOn
 
+variable {f s}
+
+theorem discreteTopology_of_image (h : IsLocalHomeomorphOn f s)
+    [DiscreteTopology (f '' s)] : DiscreteTopology s :=
+  singletons_open_iff_discrete.mp fun x ↦ by
+    obtain ⟨e, hx, rfl⟩ := h x x.2
+    have ⟨U, hU, eq⟩ := isOpen_discrete {(⟨_, _, x.2, rfl⟩ : e '' s)}
+    refine ⟨e.source ∩ e ⁻¹' U, e.continuousOn_toFun.isOpen_inter_preimage e.open_source hU,
+      subset_antisymm (fun x' mem ↦ Subtype.ext <| e.injOn mem.1 hx ?_) ?_⟩
+    · exact Subtype.ext_iff.mp (eq.subset (a := ⟨_, x', x'.2, rfl⟩) mem.2)
+    · rintro x rfl; exact ⟨hx, eq.superset rfl⟩
+
+theorem discreteTopology_image_iff (h : IsLocalHomeomorphOn f s) (hs : IsOpen s) :
+    DiscreteTopology (f '' s) ↔ DiscreteTopology s := by
+  refine ⟨fun _ ↦ h.discreteTopology_of_image, ?_⟩
+  simp_rw [← singletons_open_iff_discrete]
+  rintro hX ⟨_, x, hx, rfl⟩
+  obtain ⟨e, hxe, rfl⟩ := h x hx
+  refine ⟨e '' {x}, e.isOpen_image_of_subset_source ?_ (Set.singleton_subset_iff.mpr hxe), ?_⟩
+  · simpa using hs.isOpenMap_subtype_val _ (hX ⟨x, hx⟩)
+  · ext; simp [Subtype.ext_iff]
+
+variable (f s)
+
 /-- Proves that `f` satisfies `IsLocalHomeomorphOn f s`. The condition `h` is weaker than the
 definition of `IsLocalHomeomorphOn f s`, since it only requires `e : PartialHomeomorph X Y` to
 agree with `f` on its source `e.source`, as opposed to on the whole space `X`. -/
@@ -150,9 +174,22 @@ theorem Topology.IsOpenEmbedding.isLocalHomeomorph (hf : IsOpenEmbedding f) : Is
   isLocalHomeomorph_iff_isOpenEmbedding_restrict.mpr fun _ ↦
     ⟨_, Filter.univ_mem, hf.comp (Homeomorph.Set.univ X).isOpenEmbedding⟩
 
-variable (f)
-
 namespace IsLocalHomeomorph
+
+theorem comap_discreteTopology (h : IsLocalHomeomorph f)
+    [DiscreteTopology Y] : DiscreteTopology X :=
+  (Homeomorph.Set.univ X).discreteTopology_iff.mp h.isLocalHomeomorphOn.discreteTopology_of_image
+
+theorem discreteTopology_range_iff (h : IsLocalHomeomorph f) :
+    DiscreteTopology (Set.range f) ↔ DiscreteTopology X := by
+  rw [← Set.image_univ, ← (Homeomorph.Set.univ X).discreteTopology_iff]
+  exact h.isLocalHomeomorphOn.discreteTopology_image_iff isOpen_univ
+
+theorem discreteTopology_iff_of_surjective (h : IsLocalHomeomorph f) (hs : Function.Surjective f) :
+    DiscreteTopology X ↔ DiscreteTopology Y := by
+  rw [← (Homeomorph.Set.univ Y).discreteTopology_iff, ← hs.range_eq, h.discreteTopology_range_iff]
+
+variable (f)
 
 /-- Proves that `f` satisfies `IsLocalHomeomorph f`. The condition `h` is weaker than the
 definition of `IsLocalHomeomorph f`, since it only requires `e : PartialHomeomorph X Y` to

--- a/Mathlib/Topology/IsLocalHomeomorph.lean
+++ b/Mathlib/Topology/IsLocalHomeomorph.lean
@@ -79,8 +79,7 @@ theorem discreteTopology_image_iff (h : IsLocalHomeomorphOn f s) (hs : IsOpen s)
   · simpa using hs.isOpenMap_subtype_val _ (hX ⟨x, hx⟩)
   · ext; simp [Subtype.ext_iff]
 
-variable (f s)
-
+variable (f s) in
 /-- Proves that `f` satisfies `IsLocalHomeomorphOn f s`. The condition `h` is weaker than the
 definition of `IsLocalHomeomorphOn f s`, since it only requires `e : PartialHomeomorph X Y` to
 agree with `f` on its source `e.source`, as opposed to on the whole space `X`. -/
@@ -102,7 +101,7 @@ lemma PartialHomeomorph.isLocalHomeomorphOn (e : PartialHomeomorph X Y) :
     IsLocalHomeomorphOn e e.source :=
   fun _ hx ↦ ⟨e, hx, rfl⟩
 
-variable {g f s t}
+variable {g t}
 
 theorem mono {t : Set X} (hf : IsLocalHomeomorphOn f t) (hst : s ⊆ t) : IsLocalHomeomorphOn f s :=
   fun x hx ↦ hf x (hst hx)
@@ -176,6 +175,7 @@ theorem Topology.IsOpenEmbedding.isLocalHomeomorph (hf : IsOpenEmbedding f) : Is
 
 namespace IsLocalHomeomorph
 
+/-- A space that admits a local homeomorphism to a discrete space is itself discrete. -/
 theorem comap_discreteTopology (h : IsLocalHomeomorph f)
     [DiscreteTopology Y] : DiscreteTopology X :=
   (Homeomorph.Set.univ X).discreteTopology_iff.mp h.isLocalHomeomorphOn.discreteTopology_of_image
@@ -185,6 +185,8 @@ theorem discreteTopology_range_iff (h : IsLocalHomeomorph f) :
   rw [← Set.image_univ, ← (Homeomorph.Set.univ X).discreteTopology_iff]
   exact h.isLocalHomeomorphOn.discreteTopology_image_iff isOpen_univ
 
+/-- If there is a surjective local homeomorphism between two spaces and one of them is discrete,
+then both spaces are discrete. -/
 theorem discreteTopology_iff_of_surjective (h : IsLocalHomeomorph f) (hs : Function.Surjective f) :
     DiscreteTopology X ↔ DiscreteTopology Y := by
   rw [← (Homeomorph.Set.univ Y).discreteTopology_iff, ← hs.range_eq, h.discreteTopology_range_iff]


### PR DESCRIPTION
A space with a local homeomorphism to a discrete space is itself discrete.

A space with a surjective local homeomorphism from a discrete space onto it is itself discrete.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
