### PR TITLE
[Merged by Bors] - refactor(CategoryTheory/Core): make `Core` and its Hom one-field structures

### DIFF
--- a/Mathlib/CategoryTheory/Core.lean
+++ b/Mathlib/CategoryTheory/Core.lean
@@ -59,11 +59,6 @@ def inclusion : Core C ⥤ C where
   obj := of
   map f := f.iso.hom
 
-@[simps!]
-def invclusion : Core C ⥤ Cᵒᵖ where
-  obj X := .op (of X)
-  map f := f.iso.inv.op
-
 @[ext]
 theorem hom_ext {X Y : Core C} {f g : X ⟶ Y} (h : f.iso.hom = g.iso.hom) :
     f = g := by

--- a/Mathlib/CategoryTheory/Core.lean
+++ b/Mathlib/CategoryTheory/Core.lean
@@ -67,11 +67,7 @@ theorem hom_ext {X Y : Core C} {f g : X ⟶ Y} (h : f.iso.hom = g.iso.hom) :
 
 variable (C)
 
--- Porting note: This worked without proof before.
 instance : (inclusion C).Faithful where
-  map_injective := by
-    intro _ _
-    apply hom_ext
 
 variable {C} {G : Type u₂} [Groupoid.{v₂} G]
 

--- a/Mathlib/CategoryTheory/Core.lean
+++ b/Mathlib/CategoryTheory/Core.lean
@@ -189,7 +189,7 @@ def ofEquivFunctor (m : Type u₁ → Type u₂) [EquivFunctor m] : Core (Type u
   map f := .mk <| (EquivFunctor.mapEquiv m f.iso.toEquiv).toIso
   map_id α := by ext x; exact congr_fun (EquivFunctor.map_refl' _) x
   map_comp f g := by
-    ext x; dsimp
-    rw [EquivFunctor.map_trans', Function.comp]
+    ext
+    simp [EquivFunctor.map_trans', Function.comp]
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Core.lean
+++ b/Mathlib/CategoryTheory/Core.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2019 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Kim Morrison
+Authors: Kim Morrison, Robin Carlier
 -/
 import Mathlib.Control.EquivFunctor
 import Mathlib.CategoryTheory.Groupoid
@@ -28,56 +28,70 @@ universe v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
 -- morphism levels before object levels. See note [CategoryTheory universes].
 /-- The core of a category C is the groupoid whose morphisms are all the
 isomorphisms of C. -/
-def Core (C : Type u₁) := C
+structure Core (C : Type u₁) where
+  of : C
 
 variable {C : Type u₁} [Category.{v₁} C]
 
+/-- The hom-type between two objects of `Core C`.
+It is defined as a one-field structure to prevent defeq abuses. -/
+@[ext]
+structure CoreHom (X Y : Core C) where
+  iso : X.of ≅ Y.of
+
+@[simps!]
 instance coreCategory : Groupoid.{v₁} (Core C) where
-  Hom (X Y : C) := X ≅ Y
-  id (X : C) := Iso.refl X
-  comp f g := Iso.trans f g
-  inv {_ _} f := Iso.symm f
+  Hom (X Y : Core C) := CoreHom X Y
+  id (X : Core C) := .mk <| Iso.refl X.of
+  comp f g := .mk <| Iso.trans f.iso g.iso
+  inv {_ _} f := .mk <| Iso.symm f.iso
+
+@[simp]
+lemma coreCategory_comp_iso {x y z : Core C} (f : x ⟶ y) (g : y ⟶ z) :
+    (f ≫ g).iso = f.iso ≪≫ g.iso := rfl
 
 namespace Core
 
-/- Porting note: abomination -/
-@[simp]
-theorem id_hom (X : C) : Iso.hom (coreCategory.id X) = @CategoryStruct.id C _ X := by
-  rfl
-
-@[simp]
-theorem comp_hom {X Y Z : Core C} (f : X ⟶ Y) (g : Y ⟶ Z) : (f ≫ g).hom = f.hom ≫ g.hom :=
-  rfl
-
-@[ext]
-theorem hom_ext {X Y : Core C} {f g : X ⟶ Y} (h : f.hom = g.hom) : f = g := Iso.ext h
-
-variable (C)
-
+variable (C) in
 /-- The core of a category is naturally included in the category. -/
 @[simps!]
 def inclusion : Core C ⥤ C where
-  obj := id
-  map f := f.hom
+  obj := of
+  map f := f.iso.hom
+
+@[simps!]
+def invclusion : Core C ⥤ Cᵒᵖ where
+  obj X := .op (of X)
+  map f := f.iso.inv.op
+
+@[ext]
+theorem hom_ext {X Y : Core C} {f g : X ⟶ Y} (h : f.iso.hom = g.iso.hom) :
+    f = g := by
+  apply CoreHom.ext
+  exact Iso.ext h
+
+variable (C)
 
 -- Porting note: This worked without proof before.
 instance : (inclusion C).Faithful where
   map_injective := by
     intro _ _
-    apply Iso.ext
+    apply hom_ext
 
 variable {C} {G : Type u₂} [Groupoid.{v₂} G]
 
 -- Note that this function is not functorial
 -- (consider the two functors from [0] to [1], and the natural transformation between them).
 /-- A functor from a groupoid to a category C factors through the core of C. -/
+@[simps!]
 def functorToCore (F : G ⥤ C) : G ⥤ Core C where
-  obj X := F.obj X
-  map f := { hom := F.map f, inv := F.map (Groupoid.inv f) }
+  obj X := .mk <| F.obj X
+  map f := .mk <| { hom := F.map f, inv := F.map (Groupoid.inv f) }
 
 /-- We can functorially associate to any functor from a groupoid to the core of a category `C`,
 a functor from the groupoid to `C`, simply by composing with the embedding `Core C ⥤ C`.
 -/
+@[simps!]
 def forgetFunctorToCore : (G ⥤ Core C) ⥤ G ⥤ C :=
   (whiskeringRight _ _ _).obj (inclusion C)
 
@@ -95,11 +109,11 @@ def core (F : C ⥤ D) : Core C ⥤ Core D := Core.functorToCore (Core.inclusion
 
 variable (C) in
 /-- The core of the identity functor is the identity functor on the cores. -/
-@[simps! hom_app inv_app]
+@[simps!]
 def coreId : (𝟭 C).core ≅ 𝟭 (Core C) := Iso.refl _
 
 /-- The core of the composition of F and G is the composition of the cores. -/
-@[simps! hom_app inv_app]
+@[simps!]
 def coreComp {E : Type u₃} [Category.{v₃} E] (F : C ⥤ D) (G : D ⥤ E) :
   (F ⋙ G).core ≅ F.core ⋙ G.core := Iso.refl _
 
@@ -110,11 +124,10 @@ namespace Iso
 variable {D : Type u₂} [Category.{v₂} D]
 
 /-- A natural isomorphism of functors induces a natural isomorphism between their cores. -/
-@[simps! hom_app inv_app]
+@[simps!]
 def core {F G : C ⥤ D} (α : F ≅ G) : F.core ≅ G.core :=
   NatIso.ofComponents
-    (fun x ↦ Groupoid.isoEquivHom _ _|>.symm <| α.app x)
-    (fun {_ _} f ↦ by aesop_cat)
+    (fun x ↦ Groupoid.isoEquivHom _ _|>.symm <| .mk <| α.app x.of)
 
 @[simp]
 lemma coreComp {F G H : C ⥤ D} (α : F ≅ G) (β : G ≅ H) : (α ≪≫ β).core = α.core ≪≫ β.core := rfl
@@ -172,8 +185,8 @@ variable (C) in
 transformations. -/
 @[simps!]
 def coreFunctor : Core (C ⥤ D) ⥤ Core C ⥤ Core D where
-  obj F := F.core
-  map η := η.core.hom
+  obj F := F.of.core
+  map η := η.iso.core.hom
 
 end
 
@@ -181,12 +194,11 @@ end
 to a categorical functor `Core (Type u₁) ⥤ Core (Type u₂)`.
 -/
 def ofEquivFunctor (m : Type u₁ → Type u₂) [EquivFunctor m] : Core (Type u₁) ⥤ Core (Type u₂) where
-  obj := m
-  map f := (EquivFunctor.mapEquiv m f.toEquiv).toIso
-  map_id α := by apply Iso.ext; funext x; exact congr_fun (EquivFunctor.map_refl' _) x
+  obj x := .mk <| m x.of
+  map f := .mk <| (EquivFunctor.mapEquiv m f.iso.toEquiv).toIso
+  map_id α := by ext x; exact congr_fun (EquivFunctor.map_refl' _) x
   map_comp f g := by
-    apply Iso.ext; funext x; dsimp
-    erw [Iso.toEquiv_comp]
+    ext x; dsimp
     rw [EquivFunctor.map_trans', Function.comp]
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Core.lean
+++ b/Mathlib/CategoryTheory/Core.lean
@@ -29,6 +29,7 @@ universe v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
 /-- The core of a category C is the groupoid whose morphisms are all the
 isomorphisms of C. -/
 structure Core (C : Type u₁) where
+  /-- The object of the base category underlying an object in `Core C`. -/
   of : C
 
 variable {C : Type u₁} [Category.{v₁} C]
@@ -37,6 +38,7 @@ variable {C : Type u₁} [Category.{v₁} C]
 It is defined as a one-field structure to prevent defeq abuses. -/
 @[ext]
 structure CoreHom (X Y : Core C) where
+  /-- The isomorphism of objects of `C` underlying a morphism in `Core C`. -/
   iso : X.of ≅ Y.of
 
 @[simps!]


### PR DESCRIPTION
This PR refactors the groupoid core of a category to prevents abuses on its `Hom` field. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
