### PR TITLE
feat(CategoryTheory/Monoidal/ExternalProduct): external product of left Kan extended functors

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2338,6 +2338,8 @@ import Mathlib.CategoryTheory.Monoidal.Comon_
 import Mathlib.CategoryTheory.Monoidal.Conv
 import Mathlib.CategoryTheory.Monoidal.Discrete
 import Mathlib.CategoryTheory.Monoidal.End
+import Mathlib.CategoryTheory.Monoidal.ExternalProduct.Basic
+import Mathlib.CategoryTheory.Monoidal.ExternalProduct.KanExtension
 import Mathlib.CategoryTheory.Monoidal.Free.Basic
 import Mathlib.CategoryTheory.Monoidal.Free.Coherence
 import Mathlib.CategoryTheory.Monoidal.Functor

--- a/Mathlib/CategoryTheory/Monoidal/ExternalProduct/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/ExternalProduct/Basic.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2025 Robin Carlier. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robin Carlier
+-/
+import Mathlib.CategoryTheory.Monoidal.FunctorCategory
+import Mathlib.CategoryTheory.Functor.Currying
+
+/-!
+# External product of diagrams in a monoidal category
+
+In a monoidal category `C`, given a pair of diagrams `K₁ : J₁ ⥤ C` and `K₂ : J₂ ⥤ C`, we
+introduce the external product `K₁ ⊠ K₂ : J₁ × J₂ ⥤ C` as the bifunctor `(j₁, j₂) ↦ K₁ j₁ ⊗ K₂ j₂`.
+The notation `- ⊠ -` is scoped to `MonoidalCategory.ExternalProduct`.
+-/
+
+universe v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
+
+namespace CategoryTheory.MonoidalCategory
+
+variable (J₁ : Type u₁) (J₂ : Type u₂) (C : Type u₃)
+    [Category.{v₁} J₁] [Category.{v₂} J₂] [Category.{v₃} C] [MonoidalCategory C]
+
+/-- The (uncurried version of the) external product bifunctor: Given diagrams
+`K₁ : J₁ ⥤ C` and `K₂ : J₂ ⥤ C`, this is the bifunctor `j₁ ↦ j₂ ↦ K₁ j₁ ⊗ K₂ j₂`. -/
+@[simps!]
+def externalProductBifunctorUncurried : (J₁ ⥤ C) ⥤ (J₂ ⥤ C) ⥤ J₁ ⥤ J₂ ⥤ C :=
+  (Functor.postcompose₂.obj <| (evaluation _ _).obj <| curriedTensor C).obj <| whiskeringLeft₂ C
+
+/-- The external product bifunctor: Given diagrams
+`K₁ : J₁ ⥤ C` and `K₂ : J₂ ⥤ C`, this is the bifunctor `(j₁, j₂) ↦ K₁ j₁ ⊗ K₂ j₂`. -/
+@[simps!]
+def externalProductBifunctor : ((J₁ ⥤ C) × (J₂ ⥤ C)) ⥤ J₁ × J₂ ⥤ C :=
+  uncurry.obj <| (Functor.postcompose₂.obj <| uncurry).obj <|
+    externalProductBifunctorUncurried J₁ J₂ C
+
+variable {J₁ J₂ C}
+/-- An abbreviation for the action of `externalProductBifunctor J₁ J₂ C` on objects. -/
+abbrev externalProduct (F₁ : J₁ ⥤ C) (F₂ : J₂ ⥤ C) :=
+  externalProductBifunctor J₁ J₂ C|>.obj (F₁, F₂)
+
+namespace ExternalProduct
+/-- Notation for `externalProduct`.
+```
+open scoped CategoryTheory.MonoidalCategory.ExternalProduct
+``` to bring this notation in scope. -/
+scoped infixr:80 " ⊠ " => externalProduct
+
+end ExternalProduct
+
+open scoped ExternalProduct
+
+variable (J₁ J₂ C)
+
+/-- When both diagrams have the same source category, composing the external product with
+the diagonal gives the pointwise functor tensor product.
+Note that `(externalProductCompDiagIso _ _).app (F₁, F₂) : Functor.diag J₁ ⋙ F₁ ⊠ F₂ ≅ F₁ ⊗ F₂`
+type checks. -/
+@[simps!]
+def externalProductCompDiagIso :
+    externalProductBifunctor J₁ J₁ C ⋙ (whiskeringLeft _ _ _|>.obj <| Functor.diag J₁) ≅
+    tensor (J₁ ⥤ C) :=
+  NatIso.ofComponents
+    (fun _ ↦ NatIso.ofComponents (fun _ ↦ Iso.refl _) (by simp [tensorHom_def]))
+    (fun _ ↦ by ext; simp [tensorHom_def])
+
+/-- When `C` is braided, there is an isomorphism `Prod.swap _ _ ⋙ F₁ ⊠ F₂ ≅ F₂ ⊠ F₁`, natural
+in both `F₁` and `F₂`.
+Note that `(externalProductSwap _ _ _).app (F₁, F₂) : Prod.swap _ _ ⋙ F₁ ⊠ F₂ ≅ F₂ ⊠ F₁`
+type checks. -/
+@[simps!]
+def externalProductSwap [BraidedCategory C] :
+    externalProductBifunctor J₁ J₂ C ⋙ (whiskeringLeft _ _ _|>.obj <| Prod.swap _ _)
+    ≅ Prod.swap _ _ ⋙ externalProductBifunctor J₂ J₁ C :=
+  NatIso.ofComponents
+    (fun _ ↦ NatIso.ofComponents (fun _ ↦ β_ _ _) (by simp [tensorHom_def, whisker_exchange]))
+    (fun _ ↦ by ext; simp [tensorHom_def, whisker_exchange])
+
+/-- A version of `externalProductSwap` phrased in terms of the uncurried functors. -/
+@[simps!]
+def externalProductFlip [BraidedCategory C] :
+    (Functor.postcompose₂.obj <| flipFunctor _ _ _).obj (externalProductBifunctorUncurried J₁ J₂ C)
+    ≅ (externalProductBifunctorUncurried J₂ J₁ C).flip :=
+  NatIso.ofComponents <| fun _ ↦ NatIso.ofComponents <|
+    fun _ ↦ NatIso.ofComponents <| fun _ ↦ NatIso.ofComponents (fun _ ↦ β_ _ _)
+
+section Composition
+
+variable {J₁ J₂ C} {I₁ : Type u₃} {I₂ : Type u₄} [Category.{v₃} I₁] [Category.{v₄} I₂]
+
+/-- Composing F₁ × F₂ with (G₁ ⊠ G₂) is isomorphic to (F₁ ⋙ G₁) ⊠ (F₂ ⋙ G₂) -/
+@[simps!]
+def prodCompExternalProduct (F₁ : I₁ ⥤ J₁) (G₁ : J₁ ⥤ C) (F₂ : I₂ ⥤ J₂) (G₂ : J₂ ⥤ C) :
+   F₁.prod F₂ ⋙ G₁ ⊠ G₂ ≅ (F₁ ⋙ G₁) ⊠ (F₂ ⋙ G₂) := NatIso.ofComponents (fun _ ↦ Iso.refl _)
+
+end Composition
+
+end CategoryTheory.MonoidalCategory

--- a/Mathlib/CategoryTheory/Monoidal/ExternalProduct/KanExtension.lean
+++ b/Mathlib/CategoryTheory/Monoidal/ExternalProduct/KanExtension.lean
@@ -1,0 +1,144 @@
+/-
+Copyright (c) 2025 Robin Carlier. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robin Carlier
+-/
+import Mathlib.CategoryTheory.Monoidal.ExternalProduct.Basic
+import Mathlib.CategoryTheory.Functor.KanExtension.Pointwise
+import Mathlib.CategoryTheory.Limits.Final
+
+/-!
+# Preservation of pointwise left Kan extensions by external products
+
+We prove that if a functor `H' : D' ⥤ V` is pointwise left Kan extended from
+`H : D ⥤ V` along `L : D ⥤ D'`, and if `K : E ⥤ V` is any functor such that
+for any `e : E`, the functor `tensorRight (K.obj e)` commutes with colimits of
+shape `CostructuredArrow L d`, then the functor `H' ⊠ K` is pointwise left kan extended
+from `H ⊠ K` along `L.prod (𝟭 E)`.
+
+We also prove a similar criterion to establish that `K ⊠ H'` is pointwise left Kan
+extended from `K ⊠ H` along `(𝟭 E).prod L`.
+-/
+universe v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
+
+namespace CategoryTheory.MonoidalCategory.ExternalProduct
+
+noncomputable section
+
+variable {V : Type u₁} [Category.{v₁} V] [MonoidalCategory V]
+  {D : Type u₂} {D' : Type u₃} {E : Type u₄}
+  [Category.{v₂} D] [Category.{v₃} D'] [Category.{v₄} E]
+  {H : D ⥤ V} {L : D ⥤ D'} (H' : D' ⥤ V) (α : H ⟶ L ⋙ H') (K : E ⥤ V)
+
+/-- Given an extension `α : H ⟶ L ⋙ H'`, this is the canonical extension
+`H ⊠ K ⟶ L.prod (𝟭 E) ⋙ H' ⊠ K` it induces through bifunctoriality of the external product. -/
+abbrev extensionUnitLeft : H ⊠ K ⟶ L.prod (𝟭 E) ⋙ H' ⊠ K :=
+    (externalProductBifunctor D E V).map ((α, K.leftUnitor.inv) : (H, K) ⟶ (L ⋙ H', 𝟭 E ⋙ K))
+
+/-- Given an extension `α : H ⟶ L ⋙ H'`, this is the canonical extension
+`K ⊠ H ⟶ (𝟭 E).prod L ⋙ K ⊠ H'` it induces through bifunctoriality of the external product. -/
+abbrev extensionUnitRight : K ⊠ H ⟶ (𝟭 E).prod L ⋙ K ⊠ H' :=
+    (externalProductBifunctor E D V).map ((K.leftUnitor.inv, α) : (K, H) ⟶ (𝟭 E ⋙ K, L ⋙ H'))
+
+/-- If `H' : D' ⥤ V` is pointwise left Kan extended along `L : D ⥤ D'` at `(d : D')`,
+and if tensoring right with an object preserves colimis in `V`
+then `H' ⊠ K : D' × E ⥤ V` is pointwise left Kan extended along `L × (𝟭 E)` at `(d, e)`
+for every `e : E`. -/
+def pointwiseLeftKanExtensionAtLeft
+    (d : D') (P : (Functor.LeftExtension.mk H' α).IsPointwiseLeftKanExtensionAt d) (e : E)
+    [Limits.PreservesColimitsOfShape (CostructuredArrow L d) (tensorRight <| K.obj e)] :
+    Functor.LeftExtension.mk (H' ⊠ K) (extensionUnitLeft H' α K)|>.IsPointwiseLeftKanExtensionAt
+      (d, e) := by
+  dsimp [Functor.LeftExtension.IsPointwiseLeftKanExtensionAt]
+  set cone := Functor.LeftExtension.mk (H' ⊠ K) (extensionUnitLeft H' α K)|>.coconeAt (d, e)
+  let equiv := CostructuredArrow.prodEquivalence L (𝟭 E) d e|>.symm
+  apply Limits.IsColimit.ofWhiskerEquivalence equiv
+  let I : CostructuredArrow L d ⥤ (CostructuredArrow L d) × CostructuredArrow (𝟭 E) e :=
+    -- this definition makes it easier to prove finality of I
+    (prod.rightUnitorEquivalence (CostructuredArrow L d)).inverse ⋙
+      (𝟭 _).prod (Functor.fromPUnit.{0} <| .mk <| 𝟙 _)
+  letI : I.Final := by
+    letI : Functor.fromPUnit.{0} (.mk (𝟙 e) : CostructuredArrow (𝟭 E) e)|>.Final :=
+      Functor.final_fromPUnit_of_isTerminal <| CostructuredArrow.mkIdTerminal (S := 𝟭 E) (Y := e)
+    haveI := Functor.final_iff_final_comp
+      (F := (prod.rightUnitorEquivalence <| CostructuredArrow L d).inverse)
+      (G := (𝟭 _).prod <| Functor.fromPUnit.{0} (.mk (𝟙 e) : CostructuredArrow (𝟭 E) e))
+    dsimp [I] at this ⊢
+    rw [← this]
+    infer_instance
+  apply Functor.Final.isColimitWhiskerEquiv I (Limits.Cocone.whisker equiv.functor cone)|>.toFun
+  -- through all the equivalences above, the new cocone we consider is in fact
+  -- `(tensorRight (H.obj y)).mapCocone (dayConvolutionExtension G H).coconeAt y`
+  let diag_iso :
+      (CostructuredArrow.proj L d ⋙ H) ⋙ tensorRight (K.obj e) ≅
+      I ⋙ equiv.functor ⋙ CostructuredArrow.proj (L.prod <| 𝟭 E) (d, e) ⋙ H ⊠ K :=
+    NatIso.ofComponents (fun _ ↦ Iso.refl _)
+  apply Limits.IsColimit.equivOfNatIsoOfIso diag_iso
+    (d := Limits.Cocone.whisker I (Limits.Cocone.whisker equiv.functor cone))
+    (c := tensorRight (K.obj e)|>.mapCocone <| (Functor.LeftExtension.mk H' α).coconeAt d)
+    (Limits.Cocones.ext <| .refl _)|>.toFun
+  exact Limits.PreservesColimit.preserves (F := tensorRight <| K.obj e) P|>.some
+
+/-- If `H' : D' ⥤ V` is pointwise left Kan extended along `L : D ⥤ D'`,
+and if tensoring right with an object preserves colimis in `V`
+then `H' ⊠ K : D' × E ⥤ V` is pointwise left Kan extended along `L × (𝟭 E)`. -/
+def pointwiseLeftKanExtensionLeft
+    [∀ d : D', ∀ e : E,
+      Limits.PreservesColimitsOfShape (CostructuredArrow L d) (tensorRight <| K.obj e)]
+    (P : (Functor.LeftExtension.mk H' α).IsPointwiseLeftKanExtension) :
+    Functor.LeftExtension.mk (H' ⊠ K) (extensionUnitLeft H' α K)|>.IsPointwiseLeftKanExtension :=
+  fun ⟨d, e⟩ ↦ pointwiseLeftKanExtensionAtLeft H' α K d (P d) e
+
+/-- If `H' : D' ⥤ V` is pointwise left Kan extended along `L : D ⥤ D'` at `d : D'` and
+if tensoring left with an object preserves colimis in `V`,
+then `K ⊠ H' : D' × E ⥤ V` is pointwise left Kan extended along `(𝟭 E) × L` at `(e, d)` for
+every `e`. -/
+def pointwiseLeftKanExtensionAtRight
+    (d : D') (P : (Functor.LeftExtension.mk H' α).IsPointwiseLeftKanExtensionAt d) (e : E)
+    [Limits.PreservesColimitsOfShape (CostructuredArrow L d) (tensorLeft <| K.obj e)] :
+    (Functor.LeftExtension.mk (K ⊠ H')
+      (extensionUnitRight H' α K)).IsPointwiseLeftKanExtensionAt (e, d) := by
+  dsimp [Functor.LeftExtension.IsPointwiseLeftKanExtensionAt]
+  set cone := Functor.LeftExtension.mk (K ⊠ H')
+    (extensionUnitRight H' α K)|>.coconeAt (e, d)
+  let equiv := CostructuredArrow.prodEquivalence (𝟭 E) L e d|>.symm
+  apply Limits.IsColimit.ofWhiskerEquivalence equiv
+  let I : CostructuredArrow L d ⥤ CostructuredArrow (𝟭 E) e × CostructuredArrow L d :=
+    -- this definition makes it easier to prove finality of I
+    (prod.leftUnitorEquivalence <| CostructuredArrow L d).inverse ⋙
+      (Functor.fromPUnit.{0} <| .mk <| 𝟙 _).prod (𝟭 _)
+  letI : I.Final := by
+    letI : Functor.fromPUnit.{0} (.mk (𝟙 e) : (CostructuredArrow (𝟭 E) e))|>.Final :=
+      Functor.final_fromPUnit_of_isTerminal <| CostructuredArrow.mkIdTerminal (S := 𝟭 E) (Y := e)
+    haveI := Functor.final_iff_final_comp
+      (F := (prod.leftUnitorEquivalence <| CostructuredArrow L d).inverse)
+      (G := Functor.fromPUnit.{0} (.mk (𝟙 e) : CostructuredArrow (𝟭 E) e)|>.prod <| 𝟭 _)
+    dsimp [I] at this ⊢
+    rw [← this]
+    infer_instance
+  apply Functor.Final.isColimitWhiskerEquiv I (Limits.Cocone.whisker equiv.functor cone)|>.toFun
+  -- through all the equivalences above, the new cocone we consider is in fact
+  -- `(tensorRight (H.obj y)).mapCocone (dayConvolutionExtension G H).coconeAt y`
+  let diag_iso :
+      (CostructuredArrow.proj L d ⋙ H) ⋙ tensorLeft (K.obj e) ≅
+      I ⋙ equiv.functor ⋙ CostructuredArrow.proj (𝟭 E|>.prod L) (e, d) ⋙ K ⊠ H :=
+    NatIso.ofComponents (fun _ ↦ Iso.refl _)
+  apply Limits.IsColimit.equivOfNatIsoOfIso diag_iso
+    (d := Limits.Cocone.whisker I <| Limits.Cocone.whisker equiv.functor cone)
+    (c := (tensorLeft <| K.obj e).mapCocone <| (Functor.LeftExtension.mk H' α).coconeAt d)
+    (Limits.Cocones.ext <| .refl _)|>.toFun
+  exact Limits.PreservesColimit.preserves (F := tensorLeft <| K.obj e) P|>.some
+
+/-- If `H' : D' ⥤ V` is pointwise left Kan extended along `L : D ⥤ D'` and
+if tensoring left with an object preserves colimis in `V`,
+then `K ⊠ H' : D' × E ⥤ V` is pointwise left Kan extended along `(𝟭 E) × L`. -/
+def pointwiseLeftKanExtensionRight
+    [∀ d : D', ∀ e : E,
+      Limits.PreservesColimitsOfShape (CostructuredArrow L d) (tensorLeft <| K.obj e)]
+    (P : Functor.LeftExtension.mk H' α|>.IsPointwiseLeftKanExtension) :
+    Functor.LeftExtension.mk (K ⊠ H') (extensionUnitRight H' α K)|>.IsPointwiseLeftKanExtension :=
+  fun ⟨e, d⟩ ↦ pointwiseLeftKanExtensionAtRight H' α K d (P d) e
+
+end
+
+end CategoryTheory.MonoidalCategory.ExternalProduct


### PR DESCRIPTION
Given a functor `H' : D' ⥤ V` to a monoidal category that is pointwise left Kan extended along `L : D ⥤ D'`, we show that for a functor `K : E ⥤ V` and under suitable preservations of colimits by the tensor product of `V`, the functor `H' ⊠ K : D' × E ⥤ V` is pointwise left Kan extended along `L.prod (𝟭 E)`. We show a similar statement for the functor `K ⊠ H'`.

This property is crucial for proving properties of Day convolutions of functors from a monoidal category to `V`. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [ ] depends on: #25731

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
