### PR TITLE
feat(CategoryTheory/Monoidal): Day convolution of functors

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2336,8 +2336,10 @@ import Mathlib.CategoryTheory.Monoidal.CommGrp_
 import Mathlib.CategoryTheory.Monoidal.CommMon_
 import Mathlib.CategoryTheory.Monoidal.Comon_
 import Mathlib.CategoryTheory.Monoidal.Conv
+import Mathlib.CategoryTheory.Monoidal.DayConvolution
 import Mathlib.CategoryTheory.Monoidal.Discrete
 import Mathlib.CategoryTheory.Monoidal.End
+import Mathlib.CategoryTheory.Monoidal.ExternalProduct
 import Mathlib.CategoryTheory.Monoidal.Free.Basic
 import Mathlib.CategoryTheory.Monoidal.Free.Coherence
 import Mathlib.CategoryTheory.Monoidal.Functor

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -189,6 +189,7 @@ lemma hom_ext_of_isLeftKanExtension {G : D ⥤ H} (γ₁ γ₂ : F' ⟶ G)
 
 /-- If `(F', α)` is a left Kan extension of `F` along `L`, then this
 is the induced bijection `(F' ⟶ G) ≃ (F ⟶ L ⋙ G)` for all `G`. -/
+@[simps!]
 noncomputable def homEquivOfIsLeftKanExtension (G : D ⥤ H) :
     (F' ⟶ G) ≃ (F ⟶ L ⋙ G) where
   toFun β := α ≫ whiskerLeft _ β

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution.lean
@@ -1,0 +1,185 @@
+/-
+Copyright (c) 2025 Robin Carlier. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robin Carlier
+-/
+import Mathlib.CategoryTheory.Monoidal.ExternalProduct
+import Mathlib.CategoryTheory.Functor.KanExtension.Pointwise
+
+/-!
+# Day convolution monoidal structure
+
+-/
+
+universe v₁ v₂ v₃ v₄ v₅ u₁ u₂ u₃ u₄ u₅
+
+namespace CategoryTheory.MonoidalCategory
+open scoped ExternalProduct
+
+noncomputable section
+
+variable {C : Type u₁} [Category.{v₁} C] {V : Type u₂} [Category.{v₂} V]
+  [MonoidalCategory C] [MonoidalCategory V]
+
+/-- A `DayConvolution` structure on functors `F G : C ⥤ V` is the data of
+a functor `F ⊛ G : C ⥤ V`, along with a unit `F ⊠ G to tensor C ⋙ F ⊛ G`
+that exhibits this functor as a pointwise left Kan extension of `F ⊠ G` along
+`tensor C`. This is a `class` used to prove various property of such extensions,
+but registering global instances of this class is probably a bad idea. -/
+class DayConvolution (F G : C ⥤ V) where
+  /-- The chosen convolution between the functors. Denoted `F ⊛ G`. -/
+  convolution : C ⥤ V
+  /-- The chosen convolution between the functors. -/
+  unit (F) (G) : F ⊠ G ⟶ tensor C ⋙ convolution
+  /-- The transformation `unit` exhibits `F ⊛ G` as a pointwise left Kan extension
+  of `F ⊠ G` along `tensor C`. -/
+  unitPointwiseKan (F G) :
+    (Functor.LeftExtension.mk (convolution) unit).IsPointwiseLeftKanExtension
+
+namespace DayConvolution
+
+section
+
+/-- A notation for the Day convolution of two functors. -/
+scoped infixr:80 " ⊛ " => convolution
+
+variable (F G : C ⥤ V)
+
+instance leftKanExtension [DayConvolution F G] :
+    (F ⊛ G).IsLeftKanExtension (unit F G) :=
+  unitPointwiseKan F G|>.isLeftKanExtension
+
+variable {F G}
+
+/-- Two day convolution structures on the same functors gives an isomorphic functor. -/
+def uniqueUpToIso (h : DayConvolution F G) (h' : DayConvolution F G) :
+    h.convolution ≅ h'.convolution :=
+  Functor.leftKanExtensionUnique h.convolution h.unit h'.convolution h'.unit
+
+@[simp]
+lemma uniqueUpToIso_hom_unit (h : DayConvolution F G) (h' : DayConvolution F G) :
+    h.unit ≫ CategoryTheory.whiskerLeft (tensor C) (h.uniqueUpToIso h').hom = h'.unit := by
+  simp [uniqueUpToIso]
+
+@[simp]
+lemma uniqueUpToIso_inv_unit (h : DayConvolution F G) (h' : DayConvolution F G) :
+    h'.unit ≫ CategoryTheory.whiskerLeft (tensor C) (h.uniqueUpToIso h').inv = h.unit := by
+  simp [uniqueUpToIso]
+
+variable (F G) [DayConvolution F G]
+
+section unit
+
+variable {x x' y y' : C}
+
+@[reassoc (attr := simp)]
+lemma unit_naturality (f : x ⟶ x') (g : y ⟶ y') :
+    (F.map f ⊗ G.map g) ≫ (unit F G).app (x', y') =
+    (unit F G).app (x, y) ≫ (F ⊛ G).map (f ⊗ g) := by
+  simpa [tensorHom_def] using (unit F G).naturality ((f, g) : (x, y) ⟶ (x', y'))
+
+variable (y) in
+@[reassoc (attr := simp)]
+lemma unit_naturality_id_right (f : x ⟶ x') :
+    F.map f ▷ G.obj y ≫ (unit F G).app (x', y) =
+    (unit F G).app (x, y) ≫ (F ⊛ G).map (f ▷ y) := by
+  simpa [tensorHom_def] using (unit F G).naturality ((f, 𝟙 _) : (x, y) ⟶ (x', y))
+
+variable (x) in
+@[reassoc (attr := simp)]
+lemma unit_naturality_id_left (g : y ⟶ y') :
+    F.obj x ◁ G.map g ≫ (unit F G).app (x, y') =
+    (unit F G).app (x, y) ≫ (F ⊛ G).map (x ◁ g) := by
+  simpa [tensorHom_def] using (unit F G).naturality ((𝟙 _, g) : (x, y) ⟶ (x, y'))
+
+end unit
+
+variable {F G}
+
+section map
+
+variable {F' G' : C ⥤ V} [DayConvolution F' G']
+
+/-- The morphism between day convolutions (provided they exist) induced by a pair of morphisms. -/
+def map (f : F ⟶ F') (g : G ⟶ G') : F ⊛ G ⟶ F' ⊛ G' :=
+  Functor.descOfIsLeftKanExtension (F ⊛ G) (unit F G) (F' ⊛ G') <|
+    (externalProductBifunctor C C V).map ((f, g) : (F, G) ⟶ (F', G')) ≫ unit F' G'
+
+variable (f : F ⟶ F') (g : G ⟶ G') (x y : C)
+
+@[reassoc (attr := simp)]
+lemma map_unit_app :
+  (unit F G).app (x, y) ≫ (map f g).app (x ⊗ y : C) =
+    (f.app x ⊗ g.app y) ≫ (unit F' G').app (x, y) := by
+  simpa [tensorHom_def] using
+    (Functor.descOfIsLeftKanExtension_fac_app (F ⊛ G) (unit F G) (F' ⊛ G') <|
+      (externalProductBifunctor C C V).map ((f, g) : (F, G) ⟶ (F', G')) ≫ unit F' G') (x, y)
+
+end map
+
+variable (F G)
+/-- The universal property of left Kan extensions characterizes the functor
+corepresented by `F ⊛ G`. -/
+@[simps!]
+def corepresentableIso : coyoneda.obj (.op <| F ⊛ G) ≅
+    (whiskeringLeft _ _ _).obj (tensor C) ⋙ coyoneda.obj (.op <| F ⊠ G) :=
+  NatIso.ofComponents
+    (fun H ↦ Equiv.toIso <| Functor.homEquivOfIsLeftKanExtension _ (unit F G) _)
+
+/-- The universal property of left Kan extensions characterizes the functor
+corepresented by `F ⊛ G`. -/
+def corepresentable :
+    (whiskeringLeft _ _ _).obj (tensor C) ⋙ coyoneda.obj (.op <| F ⊠ G)|>.CorepresentableBy
+      (F ⊛ G) :=
+  Functor.corepresentableByEquiv.symm <| corepresentableIso F G
+
+/-- Use the fact that `(F ⊛ G).obj c` is a colimit to characterize morphisms out of it at a
+point. -/
+theorem convolution_hom_ext_at (c : C) {v : V} {f g : (F ⊛ G).obj c ⟶ v}
+    (h : ∀ {x y : C} (u : x ⊗ y ⟶ c),
+      (unit F G).app (x, y) ≫ (F ⊛ G).map u ≫ f = (unit F G).app (x, y) ≫ (F ⊛ G).map u ≫ g) :
+    f = g :=
+  ((unitPointwiseKan F G) c).hom_ext (fun j ↦ by simpa using h j.hom)
+
+end
+
+end DayConvolution
+
+/-- A dayConvolutionUnit structure on a functor `C ⥤ V` is the data of a pointwise
+left Kan extension of `fromPUnit (𝟙_ V)` along `fromPUnit (𝟙_ C)`. Again, this is
+made a class to ease proofs when constructing `DayConvolutionMonoidalCategory` structures, but one
+should avoid registering it globally. -/
+class DayConvolutionUnit (F : C ⥤ V) where
+  /-- A "canonical" structure map `𝟙_ V ⟶ F.obj (𝟙_ C)` that defines a natural transformation
+  `fromPUnit (𝟙_ V) ⟶ fromPUnit (𝟙_ C) ⋙ F`. -/
+  can : 𝟙_ V ⟶ F.obj (𝟙_ C)
+  /-- The canonical map `𝟙_ V ⟶ F.obj (𝟙_ C)` exhibits `F` as a pointwise left kan extension
+  of `fromPUnit.{0} 𝟙_ V` along `fromPUnit.{0} 𝟙_ C`. -/
+  canPointwiseLeftKanExtension : Functor.LeftExtension.mk F
+    ({app _ := can} : Functor.fromPUnit.{0} (𝟙_ V) ⟶
+      Functor.fromPUnit.{0} (𝟙_ C) ⋙ F)|>.IsPointwiseLeftKanExtension
+
+namespace DayConvolutionUnit
+
+variable (U : C ⥤ V) [DayConvolutionUnit U]
+open scoped DayConvolution
+
+/-- A shorthand for the natural transformation of functors out of PUnit defined by
+the canonical morphism `𝟙_ V ⟶ U.obj (𝟙_ C)` when `U` is a unit for Day convolution. -/
+abbrev φ : Functor.fromPUnit.{0} (𝟙_ V) ⟶ Functor.fromPUnit.{0} (𝟙_ C) ⋙ U where
+  app _ := can
+
+/-- Since a convolution unit is a pointwise left Kan extension, maps out of it at
+any object are uniquely characterized. -/
+lemma hom_ext {c : C} {v : V} {g h : U.obj c ⟶ v}
+    (e : ∀ f : 𝟙_ C ⟶ c, can ≫ U.map f ≫ g = can ≫ U.map f ≫ h) :
+    g = h := by
+  apply (canPointwiseLeftKanExtension c).hom_ext
+  intro j
+  simpa using e j.hom
+
+end DayConvolutionUnit
+
+end
+
+end CategoryTheory.MonoidalCategory

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution.lean
@@ -9,6 +9,29 @@ import Mathlib.CategoryTheory.Functor.KanExtension.Pointwise
 /-!
 # Day convolution monoidal structure
 
+Given functors `F G : C ⥤ V` between two monoidal categories,
+this file defines a typeclass `DayConvolution` on functors `F` `G` that contains
+a functor `F ⊛ G`, as well as the required data to exhibit `F ⊛ G` as a pointwise
+left Kan extension of `F ⊠ G` (see `CategoryTheory/Monoidal/ExternalProduct` for the definition)
+along the tensor product of `C`. Such a functor is called a Day convolution of `F` and `G`, and
+although we do not show it yet, this operation defines a monoidal structure on `C ⥤ V`.
+
+We also define a typeclass `DayConvolutionUnit` on a functor `U : C ⥤ V` that bundle the data
+required to make it a unit for the Day convolution monoidal structure: said data is that of
+a map `𝟙_ V ⟶ U.obj (𝟙_ C)` that exhibits `U` as a pointwise left Kan extension of
+`fromPUnit (𝟙_ V)` along `fromPUnit (𝟙_ C)`.
+
+## References
+- [nLab page: Day convolution](https://ncatlab.org/nlab/show/Day+convolution)
+
+## TODOs (@robin-carlier)
+- Define associators and unitors, prove the pentagon and triangle identities.
+- Braided/symmetric case.
+- Case where `V` is closed.
+- Define a typeclass `DayConvolutionMonoidalCategory` extending `MonoidalCategory`
+- Characterization of lax monoidal functors out of a day convolution monoidal category.
+- Case `V = Type u` and its universal property.
+
 -/
 
 universe v₁ v₂ v₃ v₄ v₅ u₁ u₂ u₃ u₄ u₅

--- a/Mathlib/CategoryTheory/Monoidal/ExternalProduct.lean
+++ b/Mathlib/CategoryTheory/Monoidal/ExternalProduct.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2025 Robin Carlier. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robin Carlier
+-/
+import Mathlib.CategoryTheory.Monoidal.FunctorCategory
+import Mathlib.CategoryTheory.Functor.Currying
+
+/-!
+# External product of diagrams in a monoidal category
+
+In a monoidal category `C`, given a pair of diagrams `K₁ : J₁ ⥤ C` and `K₂ : J₂ ⥤ C`, we
+introduce the external product `K₁ ⊠ K₂ : J₁ × J₂ ⥤ C` as the bifunctor `(j₁, j₂) ↦ K₁ j₁ ⊗ K₂ j₂`.
+The notation `- ⊠ -` is scoped to `MonoidalCategory.ExternalProduct`.
+-/
+
+universe v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
+
+namespace CategoryTheory.MonoidalCategory
+
+variable (J₁ : Type u₁) (J₂ : Type u₂) (C : Type u₃)
+    [Category.{v₁} J₁] [Category.{v₂} J₂] [Category.{v₃} C] [MonoidalCategory C]
+
+/-- The (uncurried version of the) external product bifunctor: Given diagrams
+`K₁ : J₁ ⥤ C` and `K₂ : J₂ ⥤ C`, this is the bifunctor `j₁ ↦ j₂ ↦ K₁ j₁ ⊗ K₂ j₂`. -/
+@[simps!]
+def externalProductBifunctorUncurried : (J₁ ⥤ C) ⥤ (J₂ ⥤ C) ⥤ J₁ ⥤ J₂ ⥤ C :=
+  (Functor.postcompose₂.obj <| (evaluation _ _).obj <| curriedTensor C).obj <| whiskeringLeft₂ C
+
+/-- The external product bifunctor: Given diagrams
+`K₁ : J₁ ⥤ C` and `K₂ : J₂ ⥤ C`, this is the bifunctor `(j₁, j₂) ↦ K₁ j₁ ⊗ K₂ j₂`. -/
+@[simps!]
+def externalProductBifunctor : ((J₁ ⥤ C) × (J₂ ⥤ C)) ⥤ J₁ × J₂ ⥤ C :=
+  uncurry.obj <| (Functor.postcompose₂.obj <| uncurry).obj <|
+    externalProductBifunctorUncurried J₁ J₂ C
+
+variable {J₁ J₂ C}
+/-- An abbreviation for the action of `externalProductBifunctor J₁ J₂ C` on objects. -/
+abbrev externalProduct (F₁ : J₁ ⥤ C) (F₂ : J₂ ⥤ C) :=
+  externalProductBifunctor J₁ J₂ C|>.obj (F₁, F₂)
+
+namespace ExternalProduct
+/-- Notation for `externalProduct`.
+```
+open scoped CategoryTheory.MonoidalCategory.ExternalProduct
+``` to bring this notation in scope. -/
+scoped infixr:80 " ⊠ " => externalProduct
+
+end ExternalProduct
+
+open scoped ExternalProduct
+
+variable (J₁ J₂ C)
+
+/-- When both diagrams have the same source category, composing the external product with
+the diagonal gives the pointwise functor tensor product.
+Note that `(externalProductCompDiagIso _ _).app (F₁, F₂) : Functor.diag J₁ ⋙ F₁ ⊠ F₂ ≅ F₁ ⊗ F₂`
+type checks. -/
+@[simps!]
+def externalProductCompDiagIso :
+    externalProductBifunctor J₁ J₁ C ⋙ (whiskeringLeft _ _ _|>.obj <| Functor.diag J₁) ≅
+    tensor (J₁ ⥤ C) :=
+  NatIso.ofComponents
+    (fun _ ↦ NatIso.ofComponents (fun _ ↦ Iso.refl _) (by simp [tensorHom_def]))
+    (fun _ ↦ by ext; simp [tensorHom_def])
+
+/-- When `C` is braided, there is an isomorphism `Prod.swap _ _ ⋙ F₁ ⊠ F₂ ≅ F₂ ⊠ F₁`, natural
+in both `F₁` and `F₂`.
+Note that `(externalProductSwap _ _ _).app (F₁, F₂) : Prod.swap _ _ ⋙ F₁ ⊠ F₂ ≅ F₂ ⊠ F₁`
+type checks. -/
+@[simps!]
+def externalProductSwap [BraidedCategory C] :
+    externalProductBifunctor J₁ J₂ C ⋙ (whiskeringLeft _ _ _|>.obj <| Prod.swap _ _)
+    ≅ Prod.swap _ _ ⋙ externalProductBifunctor J₂ J₁ C :=
+  NatIso.ofComponents
+    (fun _ ↦ NatIso.ofComponents (fun _ ↦ β_ _ _) (by simp [tensorHom_def, whisker_exchange]))
+    (fun _ ↦ by ext; simp [tensorHom_def, whisker_exchange])
+
+/-- A version of `externalProductSwap` phrased in terms of the uncurried functors. -/
+@[simps!]
+def externalProductFlip [BraidedCategory C] :
+    (Functor.postcompose₂.obj <| flipFunctor _ _ _).obj (externalProductBifunctorUncurried J₁ J₂ C)
+    ≅ (externalProductBifunctorUncurried J₂ J₁ C).flip :=
+  NatIso.ofComponents <| fun _ ↦ NatIso.ofComponents <|
+    fun _ ↦ NatIso.ofComponents <| fun _ ↦ NatIso.ofComponents (fun _ ↦ β_ _ _)
+
+section Composition
+
+variable {J₁ J₂ C} {I₁ : Type u₃} {I₂ : Type u₄} [Category.{v₃} I₁] [Category.{v₄} I₂]
+
+/-- Composing F₁ × F₂ with (G₁ ⊠ G₂) is isomorphic to (F₁ ⋙ G₁) ⊠ (F₂ ⋙ G₂) -/
+@[simps!]
+def prodCompExternalProduct (F₁ : I₁ ⥤ J₁) (G₁ : J₁ ⥤ C) (F₂ : I₂ ⥤ J₂) (G₂ : J₂ ⥤ C) :
+   F₁.prod F₂ ⋙ G₁ ⊠ G₂ ≅ (F₁ ⋙ G₁) ⊠ (F₂ ⋙ G₂) := NatIso.ofComponents (fun _ ↦ Iso.refl _)
+
+end Composition
+
+end CategoryTheory.MonoidalCategory


### PR DESCRIPTION
Given monoidal categories `C`,`V` and functors `F G : C ⥤ V`, we introduce a typeclass `[DayConvolution F G]` that bundles the data of a functor `F ⊛ G`, as well as the data required to exhibit `F ⊛ G` as a pointwise left Kan extension of `F ⊠ G` (the external product of `F` and `G`) along the tensor product of `C`.

We give basic API  around this class.

We also define a class `DayConvolutionUnit U` which contains the data that `U` is pointwise left Kan extended from `fromPUnit (𝟙_ V)` along `fromPUnit (𝟙_ C)`. Again, we give basic API around this class.

Properties like construction of associators and unitors isomorphisms (and the pentagon/triangle identities) will be the subject of subsequent PRs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [ ] depends on: #25731

I opted to make `DayConvolution` a class to make assumptions on `C` and `V` minimal.
Also, I realized that `C ⥤ V` already has a monoidal structure (given by pointwise tensor product), so trying to turn it into a monoidal category through Day convolution is probably pointless.
What I intend to do instead is to define a typeclass `DayConvolutionMonoidalCategory A` that will extend `MonoidalCategory A`. This class will contain the data of a fully faithful functor `A ⥤ (C ⥤ V)`, and the data required to make it a "monoidal full subcategory" of `C ⥤ V`. This should allow us to register instances on type aliases for `C ⥤ V`, of course, there should be a constructor for this class that takes as input the embedding and existence of suitable pointwise extensions, and then turn it into a `DayConvolutionMonoidalCategory`. This is upcoming work 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
