### PR TITLE
[Merged by Bors] - chore(RingTheory/KrullDimension/Module): change some variables to be implicit

### DIFF
--- a/Mathlib/RingTheory/KrullDimension/Module.lean
+++ b/Mathlib/RingTheory/KrullDimension/Module.lean
@@ -50,12 +50,14 @@ lemma supportDim_self_eq_ringKrullDim : supportDim R R = ringKrullDim R := by
   rw [supportDim_eq_ringKrullDim_quotient_annihilator, this]
   exact (RingEquiv.ringKrullDim (RingEquiv.quotientBot R))
 
+lemma supportDim_le_ringKrullDim : supportDim R M ≤ ringKrullDim R :=
+  krullDim_le_of_strictMono (fun a ↦ a) fun {_ _} lt ↦ lt
+
+variable {R M N}
+
 lemma supportDim_quotient_eq_ringKrullDim (I : Ideal R) :
     supportDim R (R ⧸ I) = ringKrullDim (R ⧸ I) := by
   rw [supportDim_eq_ringKrullDim_quotient_annihilator, Ideal.annihilator_quotient]
-
-lemma supportDim_le_ringKrullDim : supportDim R M ≤ ringKrullDim R :=
-  krullDim_le_of_strictMono (fun a ↦ a) fun {_ _} lt ↦ lt
 
 lemma supportDim_le_of_injective (f : M →ₗ[R] N) (h : Function.Injective f) :
     supportDim R M ≤ supportDim R N :=
@@ -69,7 +71,7 @@ lemma supportDim_le_of_surjective (f : M →ₗ[R] N) (h : Function.Surjective f
 
 lemma supportDim_eq_of_equiv (e : M ≃ₗ[R] N) :
     supportDim R M = supportDim R N :=
-  le_antisymm (supportDim_le_of_injective R M N e e.injective)
-    (supportDim_le_of_surjective R M N e e.surjective)
+  le_antisymm (supportDim_le_of_injective e e.injective)
+    (supportDim_le_of_surjective e e.surjective)
 
 end Module


### PR DESCRIPTION
Change some variables to be implicit, since they can be inferred from other variables.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
