### PR TITLE
[Merged by Bors] - feat(RepresentationTheory/Character): the scalar product of characters is the dimension of the space of equivariant maps

### DIFF
--- a/Mathlib/RepresentationTheory/Character.lean
+++ b/Mathlib/RepresentationTheory/Character.lean
@@ -102,9 +102,13 @@ theorem scalar_product_char_eq_finrank_equivariant (V W : FDRep k G) :
     ⅟ (Fintype.card G : k) • ∑ g : G, W.character g * V.character g⁻¹ =
     Module.finrank k (V ⟶ W) := by
   conv_lhs => congr; rfl; congr; rfl; intro _; rw [mul_comm, ← FDRep.char_linHom]
+-- The scalar product is the character of `Hom(V, W).`
   rw [FDRep.average_char_eq_finrank_invariants, ← LinearEquiv.finrank_eq
     (Representation.linHom.invariantsEquivFDRepHom V W), of_ρ']
   rfl
+-- The average over the group of the character of a representation equals the dimension of the
+-- space of invariants, and the space of invariants of `Hom(W, V)` is the subspace of
+--`G`-equivariant linear maps, `Hom_G(W, V)`.
 
 end Group
 

--- a/Mathlib/RepresentationTheory/Character.lean
+++ b/Mathlib/RepresentationTheory/Character.lean
@@ -93,7 +93,7 @@ theorem average_char_eq_finrank_invariants (V : FDRep k G) :
   rw [← (isProj_averageMap V.ρ).trace]
   simp [character, GroupAlgebra.average, _root_.map_sum]
 
-/-!
+/--
 If `V` are `W` are finite-dimensional representations of a finite group, then the
 scalar product of their characters is equal to the dimension of the space of
 equivariant maps from `V` to `W`.

--- a/Mathlib/RepresentationTheory/Character.lean
+++ b/Mathlib/RepresentationTheory/Character.lean
@@ -93,6 +93,19 @@ theorem average_char_eq_finrank_invariants (V : FDRep k G) :
   rw [← (isProj_averageMap V.ρ).trace]
   simp [character, GroupAlgebra.average, _root_.map_sum]
 
+/-!
+If `V` are `W` are finite-dimensional representations of a finite group, then the
+scalar product of their characters is equal to the dimension of the space of
+equivariant maps from `V` to `W`.
+-/
+theorem scalar_product_char_eq_finrank_equivariant (V W : FDRep k G) :
+    ⅟ (Fintype.card G : k) • ∑ g : G, W.character g * V.character g⁻¹ =
+    Module.finrank k (V ⟶ W) := by
+  conv_lhs => congr; rfl; congr; rfl; intro _; rw [mul_comm, ← FDRep.char_linHom]
+  rw [FDRep.average_char_eq_finrank_invariants, ← LinearEquiv.finrank_eq
+    (Representation.linHom.invariantsEquivFDRepHom V W), of_ρ']
+  rfl
+
 end Group
 
 section Orthogonality
@@ -107,22 +120,11 @@ algebraically closed field whose characteristic doesn't divide the order of the 
 theorem char_orthonormal (V W : FDRep k G) [Simple V] [Simple W] :
     ⅟ (Fintype.card G : k) • ∑ g : G, V.character g * W.character g⁻¹ =
       if Nonempty (V ≅ W) then ↑1 else ↑0 := by
-  -- First, we can rewrite the summand `V.character g * W.character g⁻¹` as the character
-  -- of the representation `V ⊗ W* ≅ Hom(W, V)` applied to `g`.
-  -- Porting note: Originally `conv in V.character _ * W.character _ =>`
-  conv_lhs =>
-    enter [2, 2, g]
-    rw [mul_comm, ← char_dual, ← Pi.mul_apply, ← char_tensor]
-    rw [char_iso (FDRep.dualTensorIsoLinHom W.ρ V)]
-  -- The average over the group of the character of a representation equals the dimension of the
-  -- space of invariants.
-  rw [average_char_eq_finrank_invariants, ← FDRep.endRingEquiv_comp_ρ (of _),
-      FDRep.of_ρ (linHom W.ρ V.ρ)]
-  -- The space of invariants of `Hom(W, V)` is the subspace of `G`-equivariant linear maps,
-  -- `Hom_G(W, V)`.
-  erw [(linHom.invariantsEquivFDRepHom W V).finrank_eq] -- Porting note: Changed `rw` to `erw`
-  -- By Schur's Lemma, the dimension of `Hom_G(W, V)` is `1` is `V ≅ W` and `0` otherwise.
+  rw [scalar_product_char_eq_finrank_equivariant]
+-- The scalar products of the characters is equal to the dimension of the space of
+-- equivariant maps `W ⟶ V`.
   rw_mod_cast [finrank_hom_simple_simple W V, Iso.nonempty_iso_symm]
+  -- By Schur's Lemma, the dimension of `Hom_G(W, V)` is `1` is `V ≅ W` and `0` otherwise.
 
 end Orthogonality
 


### PR DESCRIPTION
If `V` are `W` are finite-dimensional representations of a finite group, then the scalar product of their characters is equal to the dimension of the space of equivariant maps from `V` to `W`.

The current version of mathlib has all the necessary ingredients to prove this, but doesn't for some reason; it only has the case where `V` and `W` are irreducible (i.e. Schur orthogonality). This PR proves the general case and deduces Schur orthogonality from it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
