### PR TITLE
[Merged by Bors] - feat: add a congruence lemma for `orthogonalProjection`

### DIFF
--- a/Mathlib/Geometry/Euclidean/Projection.lean
+++ b/Mathlib/Geometry/Euclidean/Projection.lean
@@ -143,7 +143,7 @@ alongside the `s` argument.
 
 Note that without the coercion to `P`, the LHS and RHS would have different types. -/
 @[congr]
-theorem orthogonalProjection_congr (s₁ s₂ : AffineSubspace ℝ P) {p₁ p₂ : P}
+theorem orthogonalProjection_congr {s₁ s₂ : AffineSubspace ℝ P} {p₁ p₂ : P}
     [Nonempty s₁] [s₁.direction.HasOrthogonalProjection]
     (h : s₁ = s₂) (hp : p₁ = p₂) :
     letI : Nonempty s₂ := h ▸ ‹_›

--- a/Mathlib/Geometry/Euclidean/Projection.lean
+++ b/Mathlib/Geometry/Euclidean/Projection.lean
@@ -138,6 +138,20 @@ theorem orthogonalProjectionFn_eq {s : AffineSubspace ℝ P} [Nonempty s]
     orthogonalProjectionFn s p = orthogonalProjection s p :=
   rfl
 
+/-- Since both instance arguments are propositions, allow `simp` to rewrite them
+alongside the `s` argument.
+
+Note that without the coercion to `P`, the LHS and RHS would have different types. -/
+@[congr]
+theorem orthogonalProjection_congr (s₁ s₂ : AffineSubspace ℝ P) {p₁ p₂ : P}
+    [Nonempty s₁] [s₁.direction.HasOrthogonalProjection]
+    (h : s₁ = s₂) (hp : p₁ = p₂) :
+    letI : Nonempty s₂ := h ▸ ‹_›
+    letI : s₂.direction.HasOrthogonalProjection := h ▸ ‹_›
+    (orthogonalProjection s₁ p₁ : P) = (orthogonalProjection s₂ p₂ : P) := by
+  subst h hp
+  rfl
+
 /-- The linear map corresponding to `orthogonalProjection`. -/
 @[simp]
 theorem orthogonalProjection_linear {s : AffineSubspace ℝ P} [Nonempty s]


### PR DESCRIPTION
While it is still tricky to rewrite with `rw`, this makes it work with `simp`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
