### PR TITLE
feat: invariant dual submodules define Lie ideals

### DIFF
--- a/Mathlib/Algebra/Lie/Weights/RootSystem.lean
+++ b/Mathlib/Algebra/Lie/Weights/RootSystem.lean
@@ -498,6 +498,7 @@ lemma lieSpan_rootSpace_q_eq_lieSpan_Phi
       exact ⟨h₂, hx'⟩
   rw[← key]
 
+/-- Any invariant submodule defines a Lie ideal via its nonzero root spaces. -/
 def invtSubmoduleToLieIdeal (q : Submodule K (Dual K H))
     (hq : ∀ i, q ∈ End.invtSubmodule ((rootSystem H).reflection i)) :
     LieIdeal K L where

--- a/Mathlib/Algebra/Lie/Weights/RootSystem.lean
+++ b/Mathlib/Algebra/Lie/Weights/RootSystem.lean
@@ -5,6 +5,7 @@ Authors: Andrew Yang
 -/
 import Mathlib.Algebra.Lie.Weights.Killing
 import Mathlib.LinearAlgebra.RootSystem.Basic
+import Mathlib.LinearAlgebra.RootSystem.Irreducible
 import Mathlib.LinearAlgebra.RootSystem.Reduced
 import Mathlib.LinearAlgebra.RootSystem.Finite.CanonicalBilinear
 import Mathlib.Algebra.Algebra.Rat

--- a/Mathlib/Algebra/Lie/Weights/RootSystem.lean
+++ b/Mathlib/Algebra/Lie/Weights/RootSystem.lean
@@ -448,7 +448,7 @@ lemma lieSpan_rootSpace_q_eq_lieSpan_Phi
     have h₂ : (S.coroot' i) (S.root i) = 0 := (hΦ₂ i hc.1) hc.2
     rw [h₁] at h₂
     field_simp at h₂
-  have hΦ₄ : ⋃ i ∈ Φ, (rootSpace H i : Set L) = ⋃ α ∈ {α ∈ q | α ≠ 0}, (rootSpace H α) := by
+  have key : ⋃ i ∈ Φ, (rootSpace H i : Set L) = ⋃ α ∈ {α ∈ q | α ≠ 0}, (rootSpace H α) := by
     apply Set.Subset.antisymm
     · intro x hx
       rw [Set.mem_iUnion] at hx
@@ -496,7 +496,7 @@ lemma lieSpan_rootSpace_q_eq_lieSpan_Phi
       use ⟨i_weight, mem⟩
       rw [Set.mem_iUnion]
       exact ⟨h₂, hx'⟩
-  rw[← hΦ₄]
+  rw[← key]
 
 def invtSubmoduleToLieIdeal (q : Submodule K (Dual K H))
     (hq : ∀ i, q ∈ End.invtSubmodule ((rootSystem H).reflection i)) :


### PR DESCRIPTION
Invariant dual submodules define Lie ideals
---
PR shows that Invariant dual submodules define Lie ideals.
This work is part of the framework: https://github.com/orgs/leanprover-community/projects/17
This is a preparatory PR for [#24849](https://github.com/leanprover-community/mathlib4/pull/24849)
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
