### PR TITLE
[Merged by Bors] - docs: add `Dirichlet class number formula` to the overview

### DIFF
--- a/Mathlib/NumberTheory/NumberField/DedekindZeta.lean
+++ b/Mathlib/NumberTheory/NumberField/DedekindZeta.lean
@@ -65,7 +65,7 @@ theorem dedekindZeta_residue_pos : 0 < dedekindZeta_residue K := by
 theorem dedekindZeta_residue_ne_zero : dedekindZeta_residue K ≠ 0 :=
   (dedekindZeta_residue_pos K).ne'
 
-/-
+/--
 **Dirichlet class number formula**
 -/
 theorem tendsto_sub_one_mul_dedekindZeta_nhdsGT :

--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -145,6 +145,7 @@ General algebra:
   Algebraic Number Theory:
     Finiteness of the class number: 'NumberField.RingOfIntegers.instFintypeClassGroup'
     Dirichlet unit theorem: 'NumberField.Units.exist_unique_eq_mul_prod'
+    Dirichlet class number formula: 'NumberField.tendsto_sub_one_mul_dedekindZeta_nhdsGT'
 
   Representation theory:
     representation : 'Representation'


### PR DESCRIPTION
Also add a `-` missing in the docstring of `tendsto_sub_one_mul_dedekindZeta_nhdsGT`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
