### PR TITLE
[Merged by Bors] - fix: random (white)spaces

### DIFF
--- a/Mathlib/AlgebraicGeometry/Cover/MorphismProperty.lean
+++ b/Mathlib/AlgebraicGeometry/Cover/MorphismProperty.lean
@@ -76,7 +76,7 @@ theorem Cover.iUnion_range {X : Scheme.{u}} (𝒰 : X.Cover P) :
 lemma Cover.exists_eq (𝒰 : X.Cover P) (x : X) : ∃ i y, (𝒰.map i).base y = x :=
   ⟨_, 𝒰.covers x⟩
 
-instance Cover.nonempty_of_nonempty  [Nonempty X] (𝒰 : X.Cover P) : Nonempty 𝒰.J :=
+instance Cover.nonempty_of_nonempty [Nonempty X] (𝒰 : X.Cover P) : Nonempty 𝒰.J :=
   Nonempty.map 𝒰.f ‹_›
 
 /-- Given a family of schemes with morphisms to `X` satisfying `P` that jointly

--- a/Mathlib/Analysis/NormedSpace/Alternating/Basic.lean
+++ b/Mathlib/Analysis/NormedSpace/Alternating/Basic.lean
@@ -286,7 +286,7 @@ section
   NNReal.eq <| norm_ofSubsingleton i f
 
 /-- `ContinuousAlternatingMap.ofSubsingleton` as a linear isometry. -/
-@[simps (config := {simpRhs := true})]
+@[simps (config := { simpRhs := true })]
 def ofSubsingletonLIE [Subsingleton ι] (i : ι) : (E →L[𝕜] F) ≃ₗᵢ[𝕜] (E [⋀^ι]→L[𝕜] F) where
   __ := ofSubsingleton 𝕜 E F i
   map_add' _ _ := rfl
@@ -406,7 +406,7 @@ def compContinuousAlternatingMapCLM : (F →L[𝕜] G) →L[𝕜] (E [⋀^ι]→
     simpa using f.norm_compContinuousAlternatingMap_le g
 
 /-- `ContinuousLinearMap.compContinuousAlternatingMap` as a bundled continuous linear equiv. -/
-@[simps (config := {simpRhs := true}) apply]
+@[simps (config := { simpRhs := true }) apply]
 def _root_.ContinuousLinearEquiv.continuousAlternatingMapCongrRight (g : F ≃L[𝕜] G) :
     (E [⋀^ι]→L[𝕜] F) ≃L[𝕜] (E [⋀^ι]→L[𝕜] G) where
   __ := g.continuousAlternatingMapCongrRightEquiv

--- a/Mathlib/Data/Fin/Tuple/Embedding.lean
+++ b/Mathlib/Data/Fin/Tuple/Embedding.lean
@@ -116,7 +116,7 @@ def twoEmbeddingEquiv : (Fin 2 ↪ α) ≃ { (a, b) : α × α | a ≠ b } where
   right_inv := fun ⟨⟨a, b⟩, h⟩ ↦ by simp
 
 /-- Two distinct elements of `α` give an embedding `Fin 2 ↪ α`. -/
-def embFinTwo {a b: α} (h : a ≠ b) : Fin 2 ↪ α :=
+def embFinTwo {a b : α} (h : a ≠ b) : Fin 2 ↪ α :=
   twoEmbeddingEquiv.invFun ⟨(a, b), h⟩
 
 theorem embFinTwo_apply_zero {a b : α} (h : a ≠ b) :
@@ -126,4 +126,3 @@ theorem embFinTwo_apply_one {a b : α} (h : a ≠ b) :
     embFinTwo h 1 = b := rfl
 
 end Function.Embedding
-

--- a/Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean
+++ b/Mathlib/GroupTheory/GroupAction/MultipleTransitivity.lean
@@ -209,7 +209,7 @@ theorem isPretransitive_of_is_two_pretransitive
       exact ⟨g, h⟩
 
 /-- A `2`-transitive action is primitive. -/
-@[to_additive "A `2`-transitive additive action is primitive." ]
+@[to_additive "A `2`-transitive additive action is primitive."]
 theorem isPreprimitive_of_is_two_pretransitive
     (h2 : IsMultiplyPretransitive G α 2) : IsPreprimitive G α := by
   have : IsPretransitive G α := isPretransitive_of_is_two_pretransitive

--- a/Mathlib/NumberTheory/NumberField/InfinitePlace/TotallyRealComplex.lean
+++ b/Mathlib/NumberTheory/NumberField/InfinitePlace/TotallyRealComplex.lean
@@ -128,7 +128,7 @@ instance isTotallyReal_iSup {ι : Type*} {k : ι → Subfield K} [∀ i, IsTotal
     IsTotallyReal (⨆ i, k i : Subfield K) := by
   simp_all [isTotallyReal_iff_le_maximalRealSubfield]
 
- end maximalRealSubfield
+end maximalRealSubfield
 
 end TotallyRealField
 


### PR DESCRIPTION
Found by #24465.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
