### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Monad): review of erws in the `CategoryTheory/Monad` directory

### DIFF
--- a/Mathlib/CategoryTheory/Monad/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Monad/Adjunction.lean
@@ -316,8 +316,8 @@ instance [Reflective R] (X : (reflectorAdjunction R).toMonad.Algebra) :
         rw [← (reflectorAdjunction R).unit_naturality]
         dsimp only [Functor.comp_obj, Adjunction.toMonad_coe]
         rw [unit_obj_eq_map_unit, ← Functor.map_comp, ← Functor.map_comp]
-        erw [X.unit]
-        simp⟩⟩⟩
+        dsimp [X.unit]
+        simpa using congrArg (fun t ↦ R.map ((reflector R).map t)) X.unit ⟩⟩⟩
 
 instance comparison_essSurj [Reflective R] :
     (Monad.comparison (reflectorAdjunction R)).EssSurj := by
@@ -349,8 +349,7 @@ instance [Coreflective R] (X : (coreflectorAdjunction R).toComonad.Coalgebra) :
         rw [← (coreflectorAdjunction R).counit_naturality]
         dsimp only [Functor.comp_obj, Adjunction.toMonad_coe]
         rw [counit_obj_eq_map_counit, ← Functor.map_comp, ← Functor.map_comp]
-        erw [X.counit]
-        simp, X.counit⟩⟩⟩
+        simpa using congrArg (fun t ↦ R.map ((coreflector R).map t)) X.counit, X.counit⟩⟩⟩
 
 instance comparison_essSurj [Coreflective R] :
     (Comonad.comparison (coreflectorAdjunction R)).EssSurj := by
@@ -360,8 +359,7 @@ instance comparison_essSurj [Coreflective R] :
   rw [← cancel_mono ((coreflectorAdjunction R).counit.app X.A)]
   simp only [Adjunction.counit_naturality, Functor.comp_obj, Functor.id_obj,
     Adjunction.left_triangle_components_assoc, assoc]
-  erw [X.counit]
-  simp
+  simpa using (coreflectorAdjunction R).counit.app X.A ≫= X.counit.symm
 
 lemma comparison_full [R.Full] {L : C ⥤ D} (adj : R ⊣ L) :
     (Comonad.comparison adj).Full where

--- a/Mathlib/CategoryTheory/Monad/Basic.lean
+++ b/Mathlib/CategoryTheory/Monad/Basic.lean
@@ -45,6 +45,16 @@ structure Monad extends C ⥤ C where
   left_unit : ∀ X : C, η.app (toFunctor.obj X) ≫ μ.app _ = 𝟙 _ := by aesop_cat
   right_unit : ∀ X : C, toFunctor.map (η.app X) ≫ μ.app _ = 𝟙 _ := by aesop_cat
 
+@[reassoc]
+lemma Monad.unit_naturality (T : Monad C) ⦃X Y : C⦄ (f : X ⟶ Y) :
+    f ≫ T.η.app Y = T.η.app X ≫ T.map f :=
+  T.η.naturality _
+
+@[reassoc]
+lemma Monad.mu_naturality (T : Monad C) ⦃X Y : C⦄ (f : X ⟶ Y) :
+    T.map (T.map f) ≫ T.μ.app Y = T.μ.app X ≫ T.map f :=
+  T.μ.naturality _
+
 /-- The data of a comonad on C consists of an endofunctor G together with natural transformations
 ε : G ⟶ 𝟭 C and δ : G ⟶ G ⋙ G satisfying three equations:
 - δ_X ≫ G δ_X = δ_X ≫ δ_(GX) (coassociativity)
@@ -60,6 +70,16 @@ structure Comonad extends C ⥤ C where
     aesop_cat
   left_counit : ∀ X : C, δ.app X ≫ ε.app (toFunctor.obj X) = 𝟙 _ := by aesop_cat
   right_counit : ∀ X : C, δ.app X ≫ toFunctor.map (ε.app X) = 𝟙 _ := by aesop_cat
+
+@[reassoc]
+lemma Comonad.counit_naturality (T : Comonad C) ⦃X Y : C⦄ (f : X ⟶ Y) :
+    T.map f ≫ T.ε.app Y = T.ε.app X ≫ f :=
+  T.ε.naturality _
+
+@[reassoc]
+lemma Comonad.delta_naturality (T : Comonad C) ⦃X Y : C⦄ (f : X ⟶ Y) :
+    T.map f ≫ T.δ.app Y = T.δ.app X ≫ T.map (T.map f) :=
+  T.δ.naturality _
 
 variable {C}
 variable (T : Monad C) (G : Comonad C)
@@ -363,8 +383,8 @@ lemma map_unit_app (T : Monad C) (X : C) [IsIso T.μ] :
 lemma isSplitMono_iff_isIso_unit (T : Monad C) (X : C) [IsIso T.μ] :
     IsSplitMono (T.η.app X) ↔ IsIso (T.η.app X) := by
   refine ⟨fun _ ↦ ⟨retraction (T.η.app X), by simp, ?_⟩, fun _ ↦ inferInstance⟩
-  erw [← map_id, ← IsSplitMono.id (T.η.app X), map_comp, T.map_unit_app X, T.η.naturality]
-  rfl
+  rw [← map_id, ← show T.η.app X ≫ retraction (T.η.app X) = 𝟙 X from IsSplitMono.id _,
+    map_comp, T.map_unit_app X, ← T.unit_naturality]
 
 end Monad
 
@@ -377,8 +397,8 @@ lemma map_counit_app (T : Comonad C) (X : C) [IsIso T.δ] :
 lemma isSplitEpi_iff_isIso_counit (T : Comonad C) (X : C) [IsIso T.δ] :
     IsSplitEpi (T.ε.app X) ↔ IsIso (T.ε.app X) := by
   refine ⟨fun _ ↦ ⟨section_ (T.ε.app X), ?_, by simp⟩, fun _ ↦ inferInstance⟩
-  erw [← map_id, ← IsSplitEpi.id (T.ε.app X), map_comp, T.map_counit_app X, T.ε.naturality]
-  rfl
+  rw [← map_id, ← show section_ (T.ε.app X) ≫ T.ε.app X = 𝟙 X from IsSplitEpi.id (T.ε.app X),
+    map_comp, T.map_counit_app X, T.counit_naturality]
 
 end Comonad
 

--- a/Mathlib/CategoryTheory/Monad/Equalizer.lean
+++ b/Mathlib/CategoryTheory/Monad/Equalizer.lean
@@ -91,7 +91,7 @@ def beckCoalgebraEqualizer : IsLimit (beckCoalgebraFork X) :=
     · dsimp
       rw [Functor.map_comp, reassoc_of% h₂, Comonad.right_counit]
       dsimp
-      rw [Category.comp_id, Category.assoc, ← T.counit_naturality, 
+      rw [Category.comp_id, Category.assoc, ← T.counit_naturality,
         reassoc_of% h₁, Comonad.left_counit]
       simp
     · ext

--- a/Mathlib/CategoryTheory/Monad/Equalizer.lean
+++ b/Mathlib/CategoryTheory/Monad/Equalizer.lean
@@ -91,8 +91,8 @@ def beckCoalgebraEqualizer : IsLimit (beckCoalgebraFork X) :=
     · dsimp
       rw [Functor.map_comp, reassoc_of% h₂, Comonad.right_counit]
       dsimp
-      rw [Category.comp_id, Category.assoc]
-      erw [← T.ε.naturality, reassoc_of% h₁, Comonad.left_counit] -- TODO: missing simp lemmas
+      rw [Category.comp_id, Category.assoc, ← T.counit_naturality, 
+        reassoc_of% h₁, Comonad.left_counit]
       simp
     · ext
       simpa [← T.ε.naturality_assoc, T.left_counit_assoc] using h₁ =≫ T.ε.app ((T : C ⥤ C).obj X.A)

--- a/Mathlib/CategoryTheory/Monad/EquivMon.lean
+++ b/Mathlib/CategoryTheory/Monad/EquivMon.lean
@@ -57,18 +57,11 @@ def ofMon (M : Mon_ (C ⥤ C)) : Monad C where
   η := M.one
   μ := M.mul
   left_unit := fun X => by
-    -- Porting note: now using `erw`
-    erw [← whiskerLeft_app, ← NatTrans.comp_app, M.mul_one]
-    rfl
+    simpa [-Mon_.mul_one] using congrArg (fun t ↦ t.app X) M.mul_one
   right_unit := fun X => by
-    -- Porting note: now using `erw`
-    erw [← whiskerRight_app, ← NatTrans.comp_app, M.one_mul]
-    rfl
+    simpa [-Mon_.one_mul] using congrArg (fun t ↦ t.app X) M.one_mul
   assoc := fun X => by
-    rw [← whiskerLeft_app, ← whiskerRight_app, ← NatTrans.comp_app]
-    -- Porting note: had to add this step:
-    erw [M.mul_assoc]
-    simp
+    simpa [-Mon_.mul_assoc] using congrArg (fun t ↦ t.app X) M.mul_assoc
 
 -- Porting note: `@[simps]` fails to generate `ofMon_obj`:
 @[simp] lemma ofMon_obj (M : Mon_ (C ⥤ C)) (X : C) : (ofMon M).obj X = M.X.obj X := rfl
@@ -81,15 +74,10 @@ def monToMonad : Mon_ (C ⥤ C) ⥤ Monad C where
   obj := ofMon
   map {X Y} f :=
     { f.hom with
-      app_η := by
-        intro X
-        erw [← NatTrans.comp_app, f.one_hom]
-        simp only [Functor.id_obj, ofMon_obj, ofMon_η]
-      app_μ := by
-        intro Z
-        erw [← NatTrans.comp_app, f.mul_hom]
-        dsimp
-        simp only [Category.assoc, NatTrans.naturality, ofMon_obj, ofMon] }
+      app_η X := by
+        simpa [-Mon_.Hom.one_hom] using congrArg (fun t ↦ t.app X) f.one_hom
+      app_μ Z := by
+        simpa [-Mon_.Hom.mul_hom] using congrArg (fun t ↦ t.app Z) f.mul_hom }
 
 /-- Oh, monads are just monoids in the category of endofunctors (equivalence of categories). -/
 @[simps]

--- a/Mathlib/CategoryTheory/Monad/Kleisli.lean
+++ b/Mathlib/CategoryTheory/Monad/Kleisli.lean
@@ -49,8 +49,7 @@ instance category : Category (Kleisli T) where
     rw [← T.η.naturality_assoc f, T.left_unit]
     apply Category.comp_id
   assoc f g h := by
-    simp only [Functor.map_comp, Category.assoc, Monad.assoc]
-    erw [T.μ.naturality_assoc]
+    simp [Monad.assoc, T.mu_naturality_assoc]
 
 namespace Adjunction
 

--- a/Mathlib/CategoryTheory/Monad/Limits.lean
+++ b/Mathlib/CategoryTheory/Monad/Limits.lean
@@ -79,9 +79,7 @@ def liftedCone : Cone D where
     { app := fun j => { f := c.π.app j }
       naturality := fun X Y f => by
         ext1
-        dsimp
-        erw [c.w f]
-        simp }
+        simpa using (c.w f).symm }
 
 /-- (Impl) Prove that the lifted cone is limiting. -/
 @[simps]
@@ -237,8 +235,7 @@ noncomputable instance forgetCreatesColimit (D : J ⥤ Algebra T)
                   h := commuting _ _ _ }
               naturality := fun A B f => by
                 ext1
-                dsimp
-                erw [comp_id, c.w] } }
+                simpa using (c.w f) } }
       validLift := Cocones.ext (Iso.refl _)
       makesColimit := liftedCoconeIsColimit _ _ }
 
@@ -418,9 +415,7 @@ def liftedCocone : Cocone D where
     { app := fun j => { f := c.ι.app j }
       naturality := fun X Y f => by
         ext1
-        dsimp
-        erw [c.w f]
-        simp }
+        simpa using (c.w f) }
 
 /-- (Impl) Prove that the lifted cocone is colimiting. -/
 @[simps]
@@ -565,8 +560,7 @@ noncomputable instance forgetCreatesLimit (D : J ⥤ Coalgebra T)
                   h := commuting _ _ _ }
               naturality := fun A B f => by
                 ext1
-                dsimp
-                erw [id_comp, c.w] } }
+                simpa using (c.w f).symm } }
       validLift := Cones.ext (Iso.refl _)
       makesLimit := liftedConeIsLimit _ _ }
 


### PR DESCRIPTION
Introduce some missing lemmas, and use them (along the usual tricks) to remove all erws in the `CategoryTheory/Monad` directory.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

SimpNF complained about making the new lemmas `simp`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
