### PR TITLE
[Merged by Bors] - feat: positivity extension for `Simplex.height`

### DIFF
--- a/Mathlib/Geometry/Euclidean/Altitude.lean
+++ b/Mathlib/Geometry/Euclidean/Altitude.lean
@@ -171,6 +171,16 @@ def height {n : ℕ} [NeZero n] (s : Simplex ℝ P n) (i : Fin (n + 1)) : ℝ :=
 lemma height_pos {n : ℕ} [NeZero n] (s : Simplex ℝ P n) (i : Fin (n + 1)) : 0 < s.height i := by
   simp [height]
 
+open Qq Mathlib.Meta.Positivity in
+/-- Extension for the `positivity` tactic: the height of a simplex is always positive. -/
+@[positivity height _]
+def evalNonemptyIntervalLength : PositivityExt where eval {u α} _ _ e := do
+  match u, α, e with
+  | 0, ~q(ℝ), ~q(@height $V $P $i1 $i2 $i3 $i4 $n $hn $s $i) =>
+    assertInstancesCommute
+    return .positive q(height_pos $s $i)
+  | _, _, _ => throwError "not Simplex.height"
+
 end Simplex
 
 end Affine

--- a/Mathlib/Geometry/Euclidean/Altitude.lean
+++ b/Mathlib/Geometry/Euclidean/Altitude.lean
@@ -173,8 +173,8 @@ lemma height_pos {n : ℕ} [NeZero n] (s : Simplex ℝ P n) (i : Fin (n + 1)) : 
 
 open Qq Mathlib.Meta.Positivity in
 /-- Extension for the `positivity` tactic: the height of a simplex is always positive. -/
-@[positivity height _]
-def evalNonemptyIntervalLength : PositivityExt where eval {u α} _ _ e := do
+@[positivity height _ _]
+def evalHeight : PositivityExt where eval {u α} _ _ e := do
   match u, α, e with
   | 0, ~q(ℝ), ~q(@height $V $P $i1 $i2 $i3 $i4 $n $hn $s $i) =>
     assertInstancesCommute

--- a/Mathlib/Geometry/Euclidean/Altitude.lean
+++ b/Mathlib/Geometry/Euclidean/Altitude.lean
@@ -181,6 +181,9 @@ def evalHeight : PositivityExt where eval {u α} _ _ e := do
     return .positive q(height_pos $s $i)
   | _, _, _ => throwError "not Simplex.height"
 
+example {n : ℕ} [NeZero n] (s : Simplex ℝ P n) (i : Fin (n + 1)) : 0 < s.height i := by
+  positivity
+
 end Simplex
 
 end Affine


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
