### PR TITLE
[Merged by Bors] - feat: a `grind` test case

### DIFF
--- a/MathlibTest/grind/trig.lean
+++ b/MathlibTest/grind/trig.lean
@@ -8,16 +8,6 @@ grind_pattern cos_sq_add_sin_sq => cos x
 grind_pattern cos_sq_add_sin_sq => sin x
 
 -- Whenever `grind` sees `cos` or `sin`, it adds `(cos x)^2 + (sin x)^2 = 1` to the blackboard.
--- That's a polynomial,import Mathlib
-
-set_option grind.warning false
-
-open Real
-
-grind_pattern cos_sq_add_sin_sq => cos x
-grind_pattern cos_sq_add_sin_sq => sin x
-
--- Whenever `grind` sees `cos` or `sin`, it adds `(cos x)^2 + (sin x)^2 = 1` to the blackboard.
 -- That's a polynomial, so it is sent to the Grobner basis module.
 -- And we can prove equalities modulo that relation!
 example : (cos x + sin x)^2 = 2 * cos x * sin x + 1 := by

--- a/MathlibTest/grind/trig.lean
+++ b/MathlibTest/grind/trig.lean
@@ -1,0 +1,40 @@
+import Mathlib
+
+set_option grind.warning false
+
+open Real
+
+grind_pattern cos_sq_add_sin_sq => cos x
+grind_pattern cos_sq_add_sin_sq => sin x
+
+-- Whenever `grind` sees `cos` or `sin`, it adds `(cos x)^2 + (sin x)^2 = 1` to the blackboard.
+-- That's a polynomial,import Mathlib
+
+set_option grind.warning false
+
+open Real
+
+grind_pattern cos_sq_add_sin_sq => cos x
+grind_pattern cos_sq_add_sin_sq => sin x
+
+-- Whenever `grind` sees `cos` or `sin`, it adds `(cos x)^2 + (sin x)^2 = 1` to the blackboard.
+-- That's a polynomial, so it is sent to the Grobner basis module.
+-- And we can prove equalities modulo that relation!
+example : (cos x + sin x)^2 = 2 * cos x * sin x + 1 := by
+  grind +ring
+
+-- `grind` notices that the two arguments of `f` are equal,
+-- and hence the function applications are too.
+example (f : ℝ → ℕ) : f ((cos x + sin x)^2) = f (2 * cos x * sin x + 1) := by
+  grind +ring
+
+-- After that, we can use basic modularity conditions:
+-- this reduces to `4 * x ≠ 2 + x` for some `x : ℕ`
+example (f : ℝ → ℕ) : 4 * f ((cos x + sin x)^2) ≠ 2 + f (2 * cos x * sin x + 1) := by
+  grind +ring
+
+-- A bit of case splitting is also fine.
+-- If `max = 3`, then `f _ = 0`, and we're done.
+-- Otherwise, the previous argument applies.
+example (f : ℝ → ℕ) : max 3 (4 * f ((cos x + sin x)^2)) ≠ 2 + f (2 * cos x * sin x + 1) := by
+  grind +ring


### PR DESCRIPTION
Adds a test case for `grind` that was previously failing in the presence of Mathlib's typeclass shortcuts. Let's just keep it in Mathlib as a regression test.

Note that this is a PR to `bump/v4.21.0`, as it requires a recent nightly toolchain. (It can still be reviewed and bors'd as any other PR.)