### PR TITLE
[Merged by Bors] - chore(Algebra/Notation/Pi): improve variable names

### DIFF
--- a/Mathlib/Algebra/FreeMonoid/Count.lean
+++ b/Mathlib/Algebra/FreeMonoid/Count.lean
@@ -54,7 +54,7 @@ theorem count_apply [DecidableEq α] (x : α) (l : FreeAddMonoid α) :
     count x l = Multiplicative.ofAdd (l.toList.count x) := rfl
 
 theorem count_of [DecidableEq α] (x y : α) :
-    count x (of y) = Pi.mulSingle (f := fun _ => Multiplicative ℕ) x (Multiplicative.ofAdd 1) y :=
+    count x (of y) = Pi.mulSingle (M := fun _ => Multiplicative ℕ) x (Multiplicative.ofAdd 1) y :=
   by simp only [count, eq_comm, countP_of, ofAdd_zero, Pi.mulSingle_apply]
 
 end FreeMonoid

--- a/Mathlib/Algebra/Group/Pi/Basic.lean
+++ b/Mathlib/Algebra/Group/Pi/Basic.lean
@@ -140,67 +140,50 @@ instance cancelCommMonoid [∀ i, CancelCommMonoid (f i)] : CancelCommMonoid (�
   { leftCancelMonoid, commMonoid with }
 
 section
-
-variable [DecidableEq I]
-variable [∀ i, One (f i)] [∀ i, One (g i)] [∀ i, One (h i)]
+variable {ι : Type*} {M N O : ι → Type*}
+variable [DecidableEq ι]
+variable [∀ i, One (M i)] [∀ i, One (N i)] [∀ i, One (O i)]
 
 /-- The function supported at `i`, with value `x` there, and `1` elsewhere. -/
 @[to_additive "The function supported at `i`, with value `x` there, and `0` elsewhere."]
-def mulSingle (i : I) (x : f i) : ∀ (j : I), f j :=
+def mulSingle (i : ι) (x : M i) : ∀ j, M j :=
   Function.update 1 i x
 
 @[to_additive (attr := simp)]
-theorem mulSingle_eq_same (i : I) (x : f i) : mulSingle i x i = x :=
+theorem mulSingle_eq_same (i : ι) (x : M i) : mulSingle i x i = x :=
   Function.update_self i x _
 
 @[to_additive (attr := simp)]
-theorem mulSingle_eq_of_ne {i i' : I} (h : i' ≠ i) (x : f i) : mulSingle i x i' = 1 :=
+theorem mulSingle_eq_of_ne {i i' : ι} (h : i' ≠ i) (x : M i) : mulSingle i x i' = 1 :=
   Function.update_of_ne h x _
 
 /-- Abbreviation for `mulSingle_eq_of_ne h.symm`, for ease of use by `simp`. -/
 @[to_additive (attr := simp)
   "Abbreviation for `single_eq_of_ne h.symm`, for ease of use by `simp`."]
-theorem mulSingle_eq_of_ne' {i i' : I} (h : i ≠ i') (x : f i) : mulSingle i x i' = 1 :=
+theorem mulSingle_eq_of_ne' {i i' : ι} (h : i ≠ i') (x : M i) : mulSingle i x i' = 1 :=
   mulSingle_eq_of_ne h.symm x
 
 @[to_additive (attr := simp)]
-theorem mulSingle_one (i : I) : mulSingle i (1 : f i) = 1 :=
+theorem mulSingle_one (i : ι) : mulSingle i (1 : M i) = 1 :=
   Function.update_eq_self _ _
 
 @[to_additive (attr := simp)]
-theorem mulSingle_eq_one_iff {i : I} {x : f i} : mulSingle i x = 1 ↔ x = 1 := by
+theorem mulSingle_eq_one_iff {i : ι} {x : M i} : mulSingle i x = 1 ↔ x = 1 := by
   refine ⟨fun h => ?_, fun h => h.symm ▸ mulSingle_one i⟩
   rw [← mulSingle_eq_same i x, h, one_apply]
 
 @[to_additive]
-theorem mulSingle_ne_one_iff {i : I} {x : f i} : mulSingle i x ≠ 1 ↔ x ≠ 1 :=
+theorem mulSingle_ne_one_iff {i : ι} {x : M i} : mulSingle i x ≠ 1 ↔ x ≠ 1 :=
   mulSingle_eq_one_iff.ne
 
--- Porting note:
--- 1) Why do I have to specify the type of `mulSingle i x` explicitly?
--- 2) Why do I have to specify the type of `(1 : I → β)`?
--- 3) Removed `{β : Sort*}` as `[One β]` converts it to a type anyways.
-/-- On non-dependent functions, `Pi.mulSingle` can be expressed as an `ite` -/
-@[to_additive "On non-dependent functions, `Pi.single` can be expressed as an `ite`"]
-theorem mulSingle_apply [One β] (i : I) (x : β) (i' : I) :
-    (mulSingle i x : I → β) i' = if i' = i then x else 1 :=
-  Function.update_apply (1 : I → β) i x i'
-
--- Porting note: Same as above.
-/-- On non-dependent functions, `Pi.mulSingle` is symmetric in the two indices. -/
-@[to_additive "On non-dependent functions, `Pi.single` is symmetric in the two indices."]
-theorem mulSingle_comm [One β] (i : I) (x : β) (i' : I) :
-    (mulSingle i x : I → β) i' = (mulSingle i' x : I → β) i := by
-  simp [mulSingle_apply, eq_comm]
-
 @[to_additive]
-theorem apply_mulSingle (f' : ∀ i, f i → g i) (hf' : ∀ i, f' i 1 = 1) (i : I) (x : f i) (j : I) :
+theorem apply_mulSingle (f' : ∀ i, M i → N i) (hf' : ∀ i, f' i 1 = 1) (i : ι) (x : M i) (j : ι) :
     f' j (mulSingle i x j) = mulSingle i (f' i x) j := by
   simpa only [Pi.one_apply, hf', mulSingle] using Function.apply_update f' 1 i x j
 
 @[to_additive apply_single₂]
-theorem apply_mulSingle₂ (f' : ∀ i, f i → g i → h i) (hf' : ∀ i, f' i 1 1 = 1) (i : I)
-    (x : f i) (y : g i) (j : I) :
+theorem apply_mulSingle₂ (f' : ∀ i, M i → N i → O i) (hf' : ∀ i, f' i 1 1 = 1) (i : ι)
+    (x : M i) (y : N i) (j : ι) :
     f' j (mulSingle i x j) (mulSingle i y j) = mulSingle i (f' i x y) j := by
   by_cases h : j = i
   · subst h
@@ -208,26 +191,41 @@ theorem apply_mulSingle₂ (f' : ∀ i, f i → g i → h i) (hf' : ∀ i, f' i 
   · simp only [mulSingle_eq_of_ne h, hf']
 
 @[to_additive]
-theorem mulSingle_op {g : I → Type*} [∀ i, One (g i)] (op : ∀ i, f i → g i)
-    (h : ∀ i, op i 1 = 1) (i : I) (x : f i) :
+theorem mulSingle_op (op : ∀ i, M i → N i) (h : ∀ i, op i 1 = 1) (i : ι) (x : M i) :
     mulSingle i (op i x) = fun j => op j (mulSingle i x j) :=
   Eq.symm <| funext <| apply_mulSingle op h i x
 
 @[to_additive]
-theorem mulSingle_op₂ {g₁ g₂ : I → Type*} [∀ i, One (g₁ i)] [∀ i, One (g₂ i)]
-    (op : ∀ i, g₁ i → g₂ i → f i) (h : ∀ i, op i 1 1 = 1) (i : I) (x₁ : g₁ i) (x₂ : g₂ i) :
+theorem mulSingle_op₂ (op : ∀ i, M i → N i → O i) (h : ∀ i, op i 1 1 = 1) (i : ι) (x₁ : M i)
+    (x₂ : N i) :
     mulSingle i (op i x₁ x₂) = fun j => op j (mulSingle i x₁ j) (mulSingle i x₂ j) :=
   Eq.symm <| funext <| apply_mulSingle₂ op h i x₁ x₂
 
 variable (f)
 
 @[to_additive]
-theorem mulSingle_injective (i : I) : Function.Injective (mulSingle i : f i → ∀ i, f i) :=
+theorem mulSingle_injective (i : ι) : Function.Injective (mulSingle i : M i → ∀ i, M i) :=
   Function.update_injective _ i
 
 @[to_additive (attr := simp)]
-theorem mulSingle_inj (i : I) {x y : f i} : mulSingle i x = mulSingle i y ↔ x = y :=
-  (Pi.mulSingle_injective _ _).eq_iff
+theorem mulSingle_inj (i : ι) {x y : M i} : mulSingle i x = mulSingle i y ↔ x = y :=
+  (Pi.mulSingle_injective _).eq_iff
+
+variable {M : Type*} [One M]
+
+-- Porting note: added `(_ : ι → M)`
+/-- On non-dependent functions, `Pi.mulSingle` can be expressed as an `ite` -/
+@[to_additive "On non-dependent functions, `Pi.single` can be expressed as an `ite`"]
+lemma mulSingle_apply (i : ι) (x : M) (i' : ι) :
+    (mulSingle i x : ι → M) i' = if i' = i then x else 1 :=
+  Function.update_apply _ i x i'
+
+-- Porting note: added `(_ : ι → M)`
+/-- On non-dependent functions, `Pi.mulSingle` is symmetric in the two indices. -/
+@[to_additive "On non-dependent functions, `Pi.single` is symmetric in the two indices."]
+lemma mulSingle_comm (i : ι) (x : M) (i' : ι) :
+    (mulSingle i x : ι → M) i' = (mulSingle i' x : ι → M) i := by
+  simp [mulSingle_apply, eq_comm]
 
 end
 

--- a/Mathlib/Algebra/Group/TypeTags/Basic.lean
+++ b/Mathlib/Algebra/Group/TypeTags/Basic.lean
@@ -458,8 +458,7 @@ instance Multiplicative.coeToFun {α : Type*} {β : α → Sort*} [CoeFun α β]
 
 lemma Pi.mulSingle_multiplicativeOfAdd_eq {ι : Type*} [DecidableEq ι] {M : ι → Type*}
     [(i : ι) → AddMonoid (M i)] (i : ι) (a : M i) (j : ι) :
-    Pi.mulSingle (f := fun i ↦ Multiplicative (M i)) i (Multiplicative.ofAdd a) j =
-      Multiplicative.ofAdd ((Pi.single i a) j) := by
+    Pi.mulSingle (M := fun i ↦ Multiplicative (M i)) i (.ofAdd a) j = .ofAdd (Pi.single i a j) := by
   rcases eq_or_ne j i with rfl | h
   · simp only [mulSingle_eq_same, single_eq_same]
   · simp only [mulSingle, ne_eq, h, not_false_eq_true, Function.update_of_ne, one_apply, single,
@@ -467,8 +466,7 @@ lemma Pi.mulSingle_multiplicativeOfAdd_eq {ι : Type*} [DecidableEq ι] {M : ι 
 
 lemma Pi.single_additiveOfMul_eq {ι : Type*} [DecidableEq ι] {M : ι → Type*}
     [(i : ι) → Monoid (M i)] (i : ι) (a : M i) (j : ι) :
-    Pi.single (f := fun i ↦ Additive (M i)) i (Additive.ofMul a) j =
-      Additive.ofMul ((Pi.mulSingle i a) j) := by
+    Pi.single (M := fun i ↦ Additive (M i)) i (.ofMul a) j = .ofMul (Pi.mulSingle i a j) := by
   rcases eq_or_ne j i with rfl | h
   · simp only [mulSingle_eq_same, single_eq_same]
   · simp only [single, ne_eq, h, not_false_eq_true, Function.update_of_ne, zero_apply, mulSingle,

--- a/Mathlib/Algebra/GroupWithZero/Action/Pi.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Pi.lean
@@ -67,7 +67,7 @@ theorem single_smul {α} [Monoid α] [∀ i, AddMonoid <| f i] [∀ i, DistribMu
 /-- A version of `Pi.single_smul` for non-dependent functions. It is useful in cases where Lean
 fails to apply `Pi.single_smul`. -/
 theorem single_smul' {α β} [Monoid α] [AddMonoid β] [DistribMulAction α β] [DecidableEq I] (i : I)
-    (r : α) (x : β) : single (f := fun _ => β) i (r • x) = r • single (f := fun _ => β) i x :=
+    (r : α) (x : β) : single (M := fun _ => β) i (r • x) = r • single (M := fun _ => β) i x :=
   single_smul (f := fun _ => β) i r x
 
 theorem single_smul₀ {g : I → Type*} [∀ i, MonoidWithZero (f i)] [∀ i, AddMonoid (g i)]

--- a/Mathlib/Algebra/MvPolynomial/PDeriv.lean
+++ b/Mathlib/Algebra/MvPolynomial/PDeriv.lean
@@ -86,7 +86,7 @@ theorem pderiv_one {i : σ} : pderiv i (1 : MvPolynomial σ R) = 0 := pderiv_C
 
 @[simp]
 theorem pderiv_X [DecidableEq σ] (i j : σ) :
-    pderiv i (X j : MvPolynomial σ R) = Pi.single (f := fun _ => _) i 1 j := by
+    pderiv i (X j : MvPolynomial σ R) = Pi.single (M := fun _ => _) i 1 j := by
   rw [pderiv_def, mkDerivation_X]
 
 @[simp]

--- a/Mathlib/Algebra/Notation/Pi.lean
+++ b/Mathlib/Algebra/Notation/Pi.lean
@@ -17,120 +17,121 @@ assert_not_exists Set.range Monoid DenselyOrdered
 
 open Function
 
-universe u v₁ v₂ v₃
-
-variable {I : Type u}
-
--- The indexing type
-variable {α β γ : Type*}
-
--- The families of types already equipped with instances
-variable {f : I → Type v₁} (x y : ∀ i, f i) (i : I)
+variable {ι α β : Type*} {G M : ι → Type*}
 
 namespace Pi
 
 /-! `1`, `0`, `+`, `*`, `+ᵥ`, `•`, `^`, `-`, `⁻¹`, and `/` are defined pointwise. -/
 
+section One
+variable [∀ i, One (M i)]
+
 @[to_additive]
-instance instOne [∀ i, One <| f i] : One (∀ i : I, f i) :=
-  ⟨fun _ => 1⟩
+instance instOne : One (∀ i, M i) where one _ := 1
 
 @[to_additive (attr := simp high)]
-theorem one_apply [∀ i, One <| f i] : (1 : ∀ i, f i) i = 1 :=
-  rfl
+lemma one_apply (i : ι) : (1 : ∀ i, M i) i = 1 := rfl
 
 @[to_additive]
-theorem one_def [∀ i, One <| f i] : (1 : ∀ i, f i) = fun _ => 1 :=
-  rfl
+lemma one_def : (1 : ∀ i, M i) = fun _ ↦ 1 := rfl
 
-@[to_additive (attr := simp)] lemma _root_.Function.const_one [One β] : const α (1 : β) = 1 := rfl
+variable {M : Type*} [One M]
+
+@[to_additive (attr := simp)] lemma _root_.Function.const_one : const α (1 : M) = 1 := rfl
+
+@[to_additive (attr := simp)] lemma one_comp (f : α → β) : (1 : β → M) ∘ f = 1 := rfl
+@[to_additive (attr := simp)] lemma comp_one (f : M → β) : f ∘ (1 : α → M) = const α (f 1) := rfl
+
+end One
+
+section Mul
+variable [∀ i, Mul (M i)]
+
+@[to_additive]
+instance instMul : Mul (∀ i, M i) where mul f g i := f i * g i
 
 @[to_additive (attr := simp)]
-theorem one_comp [One γ] (x : α → β) : (1 : β → γ) ∘ x = 1 :=
-  rfl
+lemma mul_apply (f g : ∀ i, M i) (i : ι) : (f * g) i = f i * g i := rfl
+
+@[to_additive]
+lemma mul_def (f g : ∀ i, M i) : f * g = fun i ↦ f i * g i := rfl
+
+variable {M : Type*} [Mul M]
 
 @[to_additive (attr := simp)]
-theorem comp_one [One β] (x : β → γ) : x ∘ (1 : α → β) = const α (x 1) :=
-  rfl
+lemma _root_.Function.const_mul (a b : M) : const ι a * const ι b = const ι (a * b) := rfl
 
 @[to_additive]
-instance instMul [∀ i, Mul <| f i] : Mul (∀ i : I, f i) :=
-  ⟨fun f g i => f i * g i⟩
+lemma mul_comp (f g : β → M) (z : α → β) : (f * g) ∘ z = f ∘ z * g ∘ z := rfl
+
+end Mul
+
+section Inv
+variable [∀ i, Inv (G i)]
+
+@[to_additive]
+instance instInv : Inv (∀ i, G i) where inv f i := (f i)⁻¹
 
 @[to_additive (attr := simp)]
-theorem mul_apply [∀ i, Mul <| f i] : (x * y) i = x i * y i :=
-  rfl
+lemma inv_apply (f : ∀ i, G i) (i : ι) : f⁻¹ i = (f i)⁻¹ := rfl
 
 @[to_additive]
-theorem mul_def [∀ i, Mul <| f i] : x * y = fun i => x i * y i :=
-  rfl
+lemma inv_def (f : ∀ i, G i) : f⁻¹ = fun i ↦ (f i)⁻¹ := rfl
+
+variable {G : Type*} [Inv G]
+
+@[to_additive]
+lemma _root_.Function.const_inv (a : G) : (const ι a)⁻¹ = const ι a⁻¹ := rfl
+
+@[to_additive]
+lemma inv_comp (f : β → G) (g : α → β) : f⁻¹ ∘ g = (f ∘ g)⁻¹ := rfl
+end Inv
+
+section Div
+variable [∀ i, Div (G i)]
+
+@[to_additive]
+instance instDiv : Div (∀ i, G i) where div f g i := f i / g i
 
 @[to_additive (attr := simp)]
-lemma _root_.Function.const_mul [Mul β] (a b : β) : const α a * const α b = const α (a * b) := rfl
+lemma div_apply (f g : ∀ i, G i) (i : ι) : (f / g) i = f i / g i :=rfl
 
 @[to_additive]
-theorem mul_comp [Mul γ] (x y : β → γ) (z : α → β) : (x * y) ∘ z = x ∘ z * y ∘ z :=
-  rfl
+lemma div_def (f g : ∀ i, G i) : f / g = fun i ↦ f i / g i := rfl
+
+variable {G : Type*} [Div G]
 
 @[to_additive]
-instance instSMul [∀ i, SMul α <| f i] : SMul α (∀ i : I, f i) :=
-  ⟨fun s x => fun i => s • x i⟩
+lemma div_comp (f g : β → G) (z : α → β) : (f / g) ∘ z = f ∘ z / g ∘ z := rfl
+
+@[to_additive (attr := simp)]
+lemma _root_.Function.const_div (a b : G) : const ι a / const ι b = const ι (a / b) := rfl
+
+end Div
+
+section Pow
+
+@[to_additive]
+instance instSMul [∀ i, SMul α (M i)] : SMul α (∀ i, M i) where smul a f i := a • f i
+
+variable [∀ i, Pow (M i) α]
 
 @[to_additive existing instSMul]
-instance instPow [∀ i, Pow (f i) β] : Pow (∀ i, f i) β :=
-  ⟨fun x b i => x i ^ b⟩
+instance instPow : Pow (∀ i, M i) α where pow f a i := f i ^ a
 
 @[to_additive (attr := simp, to_additive) (reorder := 5 6) smul_apply]
-theorem pow_apply [∀ i, Pow (f i) β] (x : ∀ i, f i) (b : β) (i : I) : (x ^ b) i = x i ^ b :=
-  rfl
+lemma pow_apply (f : ∀ i, M i) (a : α) (i : ι) : (f ^ a) i = f i ^ a := rfl
 
 @[to_additive (attr := to_additive) (reorder := 5 6) smul_def]
-theorem pow_def [∀ i, Pow (f i) β] (x : ∀ i, f i) (b : β) : x ^ b = fun i => x i ^ b :=
-  rfl
+lemma pow_def (f : ∀ i, M i) (a : α) : f ^ a = fun i ↦ f i ^ a := rfl
+
+variable {M : Type*} [Pow M α]
 
 @[to_additive (attr := simp, to_additive) (reorder := 2 3, 5 6) smul_const]
-lemma _root_.Function.const_pow [Pow α β] (a : α) (b : β) : const I a ^ b = const I (a ^ b) := rfl
+lemma _root_.Function.const_pow (a : M) (b : α) : const ι a ^ b = const ι (a ^ b) := rfl
 
 @[to_additive (attr := to_additive) (reorder := 6 7) smul_comp]
-theorem pow_comp [Pow γ α] (x : β → γ) (a : α) (y : I → β) : (x ^ a) ∘ y = x ∘ y ^ a :=
-  rfl
+lemma pow_comp (f : β → M) (a : α) (g : ι → β) : (f ^ a) ∘ g = f ∘ g ^ a := rfl
 
-@[to_additive]
-instance instInv [∀ i, Inv <| f i] : Inv (∀ i : I, f i) :=
-  ⟨fun f i => (f i)⁻¹⟩
-
-@[to_additive (attr := simp)]
-theorem inv_apply [∀ i, Inv <| f i] : x⁻¹ i = (x i)⁻¹ :=
-  rfl
-
-@[to_additive]
-theorem inv_def [∀ i, Inv <| f i] : x⁻¹ = fun i => (x i)⁻¹ :=
-  rfl
-
-@[to_additive]
-lemma _root_.Function.const_inv [Inv β] (a : β) : (const α a)⁻¹ = const α a⁻¹ := rfl
-
-@[to_additive]
-theorem inv_comp [Inv γ] (x : β → γ) (y : α → β) : x⁻¹ ∘ y = (x ∘ y)⁻¹ :=
-  rfl
-
-@[to_additive]
-instance instDiv [∀ i, Div <| f i] : Div (∀ i : I, f i) :=
-  ⟨fun f g i => f i / g i⟩
-
-@[to_additive (attr := simp)]
-theorem div_apply [∀ i, Div <| f i] : (x / y) i = x i / y i :=
-  rfl
-
-@[to_additive]
-theorem div_def [∀ i, Div <| f i] : x / y = fun i => x i / y i :=
-  rfl
-
-@[to_additive]
-theorem div_comp [Div γ] (x y : β → γ) (z : α → β) : (x / y) ∘ z = x ∘ z / y ∘ z :=
-  rfl
-
-@[to_additive (attr := simp)]
-lemma _root_.Function.const_div [Div β] (a b : β) : const α a / const α b = const α (a / b) := rfl
-
+end Pow
 end Pi

--- a/Mathlib/AlgebraicTopology/SingularSet.lean
+++ b/Mathlib/AlgebraicTopology/SingularSet.lean
@@ -71,7 +71,7 @@ def TopCat.toSSetIsoConst (X : TopCat) [TotallyDisconnectedSpace X] :
     TopCat.toSSet.obj X ≅ (Functor.const _).obj X :=
   .symm <|
   NatIso.ofComponents (fun i ↦
-    { inv v := v.1 ⟨Pi.single (I := Fin _) 0 1, (show ∑ _, _ = _ by simp)⟩
+    { inv v := v.1 ⟨Pi.single 0 1, show ∑ _, _ = _ by simp⟩
       hom x := TopCat.ofHom ⟨fun _ ↦ x, continuous_const⟩
       inv_hom_id := types_ext _ _ fun f ↦ TopCat.hom_ext (ContinuousMap.ext
         fun j ↦ TotallyDisconnectedSpace.eq_of_continuous (α := i.unop.toTopObj) _ f.1.2 _ _)

--- a/Mathlib/AlgebraicTopology/TopologicalSimplex.lean
+++ b/Mathlib/AlgebraicTopology/TopologicalSimplex.lean
@@ -46,7 +46,7 @@ lemma toTopObj_one_coe_add_coe_eq_one (f : ⦋1⦌.toTopObj) : (f 0 : ℝ) + f 1
   rw [toTopObj_one_add_eq_one]
 
 instance (x : SimplexCategory) : Nonempty x.toTopObj :=
-  ⟨⟨Pi.single (I := Fin _) 0 1, (show ∑ _, _ = _ by simp)⟩⟩
+  ⟨⟨Pi.single 0 1, (show ∑ _, _ = _ by simp)⟩⟩
 
 instance : Unique ⦋0⦌.toTopObj :=
   ⟨⟨1, show ∑ _, _ = _ by simp [toType_apply]⟩, fun f ↦ by ext i; fin_cases i; simp⟩

--- a/Mathlib/Analysis/Analytic/OfScalars.lean
+++ b/Mathlib/Analysis/Analytic/OfScalars.lean
@@ -78,7 +78,7 @@ theorem ofScalars_series_eq_iff [Nontrivial E] (c' : ℕ → 𝕜) :
   ⟨fun e => ofScalars_series_injective 𝕜 E e, _root_.congrArg _⟩
 
 theorem ofScalars_apply_zero (n : ℕ) :
-    (ofScalars E c n fun _ => 0) = Pi.single (f := fun _ => E) 0 (c 0 • 1) n := by
+    (ofScalars E c n fun _ => 0) = Pi.single (M := fun _ => E) 0 (c 0 • 1) n := by
   rw [ofScalars]
   cases n <;> simp
 

--- a/Mathlib/Analysis/Analytic/OfScalars.lean
+++ b/Mathlib/Analysis/Analytic/OfScalars.lean
@@ -78,7 +78,7 @@ theorem ofScalars_series_eq_iff [Nontrivial E] (c' : ℕ → 𝕜) :
   ⟨fun e => ofScalars_series_injective 𝕜 E e, _root_.congrArg _⟩
 
 theorem ofScalars_apply_zero (n : ℕ) :
-    (ofScalars E c n fun _ => 0) = Pi.single (M := fun _ => E) 0 (c 0 • 1) n := by
+    ofScalars E c n (fun _ => 0) = Pi.single (M := fun _ => E) 0 (c 0 • 1) n := by
   rw [ofScalars]
   cases n <;> simp
 

--- a/Mathlib/Analysis/Calculus/Deriv/Pi.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Pi.lean
@@ -22,7 +22,7 @@ theorem hasDerivAt_update (x : ι → 𝕜) (i : ι) (y : 𝕜) :
   · simp [Pi.single_eq_of_ne h]
 
 theorem hasDerivAt_single (i : ι) (y : 𝕜) :
-    HasDerivAt (Pi.single (f := fun _ ↦ 𝕜) i) (Pi.single i (1 : 𝕜)) y :=
+    HasDerivAt (Pi.single (M := fun _ ↦ 𝕜) i) (Pi.single i (1 : 𝕜)) y :=
   hasDerivAt_update 0 i y
 
 theorem deriv_update (x : ι → 𝕜) (i : ι) (y : 𝕜) :
@@ -30,5 +30,5 @@ theorem deriv_update (x : ι → 𝕜) (i : ι) (y : 𝕜) :
   (hasDerivAt_update x i y).deriv
 
 theorem deriv_single (i : ι) (y : 𝕜) :
-    deriv (Pi.single (f := fun _ ↦ 𝕜) i) y = Pi.single i (1 : 𝕜) :=
+    deriv (Pi.single (M := fun _ ↦ 𝕜) i) y = Pi.single i (1 : 𝕜) :=
   deriv_update 0 i y

--- a/Mathlib/Analysis/Normed/Algebra/Exponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/Exponential.lean
@@ -137,7 +137,7 @@ theorem exp_eq_ofScalarsSum : exp 𝕂 = ofScalarsSum (E := 𝔸) fun n ↦ (n !
   rw [exp_eq_tsum, ofScalarsSum_eq_tsum]
 
 theorem expSeries_apply_zero (n : ℕ) :
-    (expSeries 𝕂 𝔸 n fun _ => (0 : 𝔸)) = Pi.single (f := fun _ => 𝔸) 0 1 n := by
+    expSeries 𝕂 𝔸 n (fun _ => (0 : 𝔸)) = Pi.single (M := fun _ => 𝔸) 0 1 n := by
   rw [expSeries_apply_eq]
   rcases n with - | n
   · rw [pow_zero, Nat.factorial_zero, Nat.cast_one, inv_one, one_smul, Pi.single_eq_same]

--- a/Mathlib/Analysis/Normed/Group/Constructions.lean
+++ b/Mathlib/Analysis/Normed/Group/Constructions.lean
@@ -397,7 +397,7 @@ instance Pi.normedCommGroup [∀ i, NormedCommGroup (G i)] : NormedCommGroup (�
 
 theorem Pi.nnnorm_single [DecidableEq ι] [∀ i, NormedAddCommGroup (G i)] {i : ι} (y : G i) :
     ‖Pi.single i y‖₊ = ‖y‖₊ := by
-  have H : ∀ b, ‖single i y b‖₊ = single (f := fun _ ↦ ℝ≥0) i ‖y‖₊ b := by
+  have H : ∀ b, ‖single i y b‖₊ = single (M := fun _ ↦ ℝ≥0) i ‖y‖₊ b := by
     intro b
     refine Pi.apply_single (fun i (x : G i) ↦ ‖x‖₊) ?_ i y b
     simp

--- a/Mathlib/Analysis/SpecialFunctions/OrdinaryHypergeometric.lean
+++ b/Mathlib/Analysis/SpecialFunctions/OrdinaryHypergeometric.lean
@@ -102,7 +102,7 @@ theorem ordinaryHypergeometric_eq_tsum : ₂F₁ a b c =
   funext (ordinaryHypergeometric_sum_eq a b c)
 
 theorem ordinaryHypergeometricSeries_apply_zero (n : ℕ) :
-    (ordinaryHypergeometricSeries 𝔸 a b c n fun _ => 0) = Pi.single (f := fun _ => 𝔸) 0 1 n := by
+    ordinaryHypergeometricSeries 𝔸 a b c n (fun _ => 0) = Pi.single (M := fun _ => 𝔸) 0 1 n := by
   rw [ordinaryHypergeometricSeries, ofScalars_apply_eq, ordinaryHypergeometricCoefficient]
   cases n <;> simp
 

--- a/Mathlib/Data/DFinsupp/Defs.lean
+++ b/Mathlib/Data/DFinsupp/Defs.lean
@@ -474,7 +474,7 @@ theorem single_eq_of_ne {i i' b} (h : i ≠ i') : (single i b : Π₀ i, β i) i
   simp only [single_apply, dif_neg h]
 
 theorem single_injective {i} : Function.Injective (single i : β i → Π₀ i, β i) := fun _ _ H =>
-  Pi.single_injective β i <| DFunLike.coe_injective.eq_iff.mpr H
+  Pi.single_injective i <| DFunLike.coe_injective.eq_iff.mpr H
 
 /-- Like `Finsupp.single_eq_single_iff`, but with a `HEq` due to dependent types -/
 theorem single_eq_single_iff (i j : ι) (xi : β i) (xj : β j) :

--- a/Mathlib/Data/Finsupp/Single.lean
+++ b/Mathlib/Data/Finsupp/Single.lean
@@ -70,7 +70,7 @@ theorem single_eq_set_indicator : ⇑(single a b) = Set.indicator {a} fun _ => b
 
 @[simp]
 theorem single_eq_same : (single a b : α →₀ M) a = b := by
-  classical exact Pi.single_eq_same (f := fun _ ↦ M) a b
+  classical exact Pi.single_eq_same (M := fun _ ↦ M) a b
 
 @[simp]
 theorem single_eq_of_ne (h : a ≠ a') : (single a b : α →₀ M) a' = 0 := by

--- a/Mathlib/Data/Matrix/Diagonal.lean
+++ b/Mathlib/Data/Matrix/Diagonal.lean
@@ -200,7 +200,7 @@ protected theorem map_one [Zero β] [One β] (f : α → β) (h₀ : f 0 = 0) (h
   simp only [one_apply, map_apply]
   split_ifs <;> simp [h₀, h₁]
 
-theorem one_eq_pi_single {i j} : (1 : Matrix n n α) i j = Pi.single (f := fun _ => α) i 1 j := by
+theorem one_eq_pi_single {i j} : (1 : Matrix n n α) i j = Pi.single (M := fun _ => α) i 1 j := by
   simp only [one_apply, Pi.single_apply, eq_comm]
 
 end One

--- a/Mathlib/Data/Matrix/Mul.lean
+++ b/Mathlib/Data/Matrix/Mul.lean
@@ -208,8 +208,8 @@ protected alias Matrix.dotProduct_diagonal' := dotProduct_diagonal'
 
 @[simp]
 theorem single_dotProduct (x : α) (i : m) : Pi.single i x ⬝ᵥ v = x * v i := by
-  -- Porting note: (implicit arg) added `(f := fun _ => α)`
-  have : ∀ j ≠ i, Pi.single (f := fun _ => α) i x j * v j = 0 := fun j hij => by
+-- Porting note: added `(_ : m → α)`
+  have : ∀ j ≠ i, (Pi.single i x : m → α) j * v j = 0 := fun j hij => by
     simp [Pi.single_eq_of_ne hij]
   convert Finset.sum_eq_single i (fun j _ => this j) _ using 1 <;> simp
 
@@ -217,8 +217,8 @@ theorem single_dotProduct (x : α) (i : m) : Pi.single i x ⬝ᵥ v = x * v i :=
 
 @[simp]
 theorem dotProduct_single (x : α) (i : m) : v ⬝ᵥ Pi.single i x = v i * x := by
-  -- Porting note: (implicit arg) added `(f := fun _ => α)`
-  have : ∀ j ≠ i, v j * Pi.single (f := fun _ => α) i x j = 0 := fun j hij => by
+-- Porting note: added `(_ : m → α)`
+  have : ∀ j ≠ i, v j * (Pi.single i x : m → α) j = 0 := fun j hij => by
     simp [Pi.single_eq_of_ne hij]
   convert Finset.sum_eq_single i (fun j _ => this j) _ using 1 <;> simp
 

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -1204,6 +1204,6 @@ section single
 lemma orderOf_piMulSingle {ι : Type*} [DecidableEq ι] {M : ι → Type*} [(i : ι) → Monoid (M i)]
     (i : ι) (g : M i) :
     orderOf (Pi.mulSingle i g) = orderOf g :=
-  orderOf_injective (MonoidHom.mulSingle M i) (Pi.mulSingle_injective M i) g
+  orderOf_injective (MonoidHom.mulSingle M i) (Pi.mulSingle_injective i) g
 
 end single

--- a/Mathlib/LinearAlgebra/Matrix/HermitianFunctionalCalculus.lean
+++ b/Mathlib/LinearAlgebra/Matrix/HermitianFunctionalCalculus.lean
@@ -64,7 +64,8 @@ noncomputable def cfcAux : C(spectrum ℝ A, ℝ) →⋆ₐ[ℝ] (Matrix n n �
   toFun := fun g => (eigenvectorUnitary hA : Matrix n n 𝕜) *
     diagonal (RCLike.ofReal ∘ g ∘ (fun i ↦ ⟨hA.eigenvalues i, hA.eigenvalues_mem_spectrum_real i⟩))
     * star (eigenvectorUnitary hA : Matrix n n 𝕜)
-  map_one' := by simp [Pi.one_def (f := fun _ : n ↦ 𝕜)]
+  map_zero' := by simp [Pi.zero_def, Function.comp_def]
+  map_one' := by simp [Pi.one_def, Function.comp_def]
   map_mul' f g := by
     have {a b c d e f : Matrix n n 𝕜} : (a * b * c) * (d * e * f) = a * (b * (c * d) * e) * f := by
       simp only [mul_assoc]
@@ -72,7 +73,6 @@ noncomputable def cfcAux : C(spectrum ℝ A, ℝ) →⋆ₐ[ℝ] (Matrix n n �
       diagonal_mul_diagonal, Function.comp_apply]
     congr! with i
     simp
-  map_zero' := by simp [Pi.zero_def (f := fun _ : n ↦ 𝕜)]
   map_add' f g := by
     simp only [ContinuousMap.coe_add, ← add_mul, ← mul_add, diagonal_add, Function.comp_apply]
     congr! with i

--- a/Mathlib/LinearAlgebra/Pi.lean
+++ b/Mathlib/LinearAlgebra/Pi.lean
@@ -320,7 +320,7 @@ theorem single_eq_pi_diag (i : ι) : single R φ i = pi (diag i) := by
   rfl
 
 theorem ker_single (i : ι) : ker (single R φ i) = ⊥ :=
-  ker_eq_bot_of_injective <| Pi.single_injective _ _
+  ker_eq_bot_of_injective <| Pi.single_injective _
 
 theorem proj_comp_single (i j : ι) : (proj i).comp (single R φ j) = diag j i := by
   rw [single_eq_pi_diag, proj_pi]

--- a/Mathlib/RingTheory/HahnSeries/Basic.lean
+++ b/Mathlib/RingTheory/HahnSeries/Basic.lean
@@ -176,13 +176,13 @@ variable {a b : Γ} {r : R}
 
 @[simp]
 theorem coeff_single_same (a : Γ) (r : R) : (single a r).coeff a = r := by
-  classical exact Pi.single_eq_same (f := fun _ => R) a r
+  classical exact Pi.single_eq_same (M := fun _ => R) a r
 
 @[deprecated (since := "2025-01-31")] alias single_coeff_same := coeff_single_same
 
 @[simp]
 theorem coeff_single_of_ne (h : b ≠ a) : (single a r).coeff b = 0 := by
-  classical exact Pi.single_eq_of_ne (f := fun _ => R) h r
+  classical exact Pi.single_eq_of_ne (M := fun _ => R) h r
 
 @[deprecated (since := "2025-01-31")] alias single_coeff_of_ne := coeff_single_of_ne
 

--- a/Mathlib/RingTheory/Idempotents.lean
+++ b/Mathlib/RingTheory/Idempotents.lean
@@ -151,7 +151,7 @@ lemma CompleteOrthogonalIdempotents.unique_iff [Unique I] :
 
 lemma CompleteOrthogonalIdempotents.single {I : Type*} [Fintype I] [DecidableEq I]
     (R : I → Type*) [∀ i, Semiring (R i)] :
-    CompleteOrthogonalIdempotents (Pi.single (f := R) · 1) := by
+    CompleteOrthogonalIdempotents (Pi.single (M := R) · 1) := by
   refine ⟨⟨by simp [IsIdempotentElem, ← Pi.single_mul], ?_⟩, Finset.univ_sum_single 1⟩
   intros i j hij
   ext k

--- a/Mathlib/RingTheory/IsAdjoinRoot.lean
+++ b/Mathlib/RingTheory/IsAdjoinRoot.lean
@@ -480,12 +480,12 @@ theorem coeff_root_pow (h : IsAdjoinRootMonic S f) {n} (hn : n < natDegree f) :
   · calc
       h.basis.repr (h.root ^ n) ⟨i, _⟩ = h.basis.repr (h.basis ⟨n, hn⟩) ⟨i, hi⟩ := by
         rw [h.basis_apply, Fin.val_mk]
-      _ = Pi.single (f := fun _ => R) ((⟨n, hn⟩ : Fin _) : ℕ) (1 : (fun _ => R) n)
+      _ = Pi.single (M := fun _ => R) ((⟨n, hn⟩ : Fin _) : ℕ) (1 : (fun _ => R) n)
         ↑(⟨i, _⟩ : Fin _) := by
         rw [h.basis.repr_self, ← Finsupp.single_eq_pi_single,
           Finsupp.single_apply_left Fin.val_injective]
-      _ = Pi.single (f := fun _ => R) n 1 i := by rw [Fin.val_mk, Fin.val_mk]
-  · refine (Pi.single_eq_of_ne (f := fun _ => R) ?_ (1 : (fun _ => R) n)).symm
+      _ = Pi.single (M := fun _ => R) n 1 i := by rw [Fin.val_mk, Fin.val_mk]
+  · rw [Pi.single_eq_of_ne]
     rintro rfl
     simp [hi] at hn
 


### PR DESCRIPTION
Stick to using `ι` for the domain of the functions, `M`, `G` for the codomains equipped with a monoid-like or group-like structure, `f`, `g` for the functions themselves, `α`, `β` for the auxiliary types with no particular structure.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
