### PR TITLE
[Merged by Bors] - fix(Order/Field/Pointwise): use `*` in the RHS

### DIFF
--- a/Mathlib/Algebra/Order/Field/Pointwise.lean
+++ b/Mathlib/Algebra/Order/Field/Pointwise.lean
@@ -24,13 +24,13 @@ namespace LinearOrderedField
 variable {K : Type*} [Field K] [LinearOrder K] [IsStrictOrderedRing K] {a b r : K} (hr : 0 < r)
 include hr
 
-theorem smul_Ioo : r • Ioo a b = Ioo (r • a) (r • b) := (OrderIso.mulLeft₀ r hr).image_Ioo a b
-theorem smul_Icc : r • Icc a b = Icc (r • a) (r • b) := (OrderIso.mulLeft₀ r hr).image_Icc a b
-theorem smul_Ico : r • Ico a b = Ico (r • a) (r • b) := (OrderIso.mulLeft₀ r hr).image_Ico a b
-theorem smul_Ioc : r • Ioc a b = Ioc (r • a) (r • b) := (OrderIso.mulLeft₀ r hr).image_Ioc a b
-theorem smul_Ioi : r • Ioi a = Ioi (r • a) := (OrderIso.mulLeft₀ r hr).image_Ioi a
-theorem smul_Iio : r • Iio a = Iio (r • a) := (OrderIso.mulLeft₀ r hr).image_Iio a
-theorem smul_Ici : r • Ici a = Ici (r • a) := (OrderIso.mulLeft₀ r hr).image_Ici a
-theorem smul_Iic : r • Iic a = Iic (r • a) := (OrderIso.mulLeft₀ r hr).image_Iic a
+theorem smul_Ioo : r • Ioo a b = Ioo (r * a) (r * b) := (OrderIso.mulLeft₀ r hr).image_Ioo a b
+theorem smul_Icc : r • Icc a b = Icc (r * a) (r * b) := (OrderIso.mulLeft₀ r hr).image_Icc a b
+theorem smul_Ico : r • Ico a b = Ico (r * a) (r * b) := (OrderIso.mulLeft₀ r hr).image_Ico a b
+theorem smul_Ioc : r • Ioc a b = Ioc (r * a) (r * b) := (OrderIso.mulLeft₀ r hr).image_Ioc a b
+theorem smul_Ioi : r • Ioi a = Ioi (r * a) := (OrderIso.mulLeft₀ r hr).image_Ioi a
+theorem smul_Iio : r • Iio a = Iio (r * a) := (OrderIso.mulLeft₀ r hr).image_Iio a
+theorem smul_Ici : r • Ici a = Ici (r * a) := (OrderIso.mulLeft₀ r hr).image_Ici a
+theorem smul_Iic : r • Iic a = Iic (r * a) := (OrderIso.mulLeft₀ r hr).image_Iic a
 
 end LinearOrderedField

--- a/Mathlib/MeasureTheory/Constructions/HaarToSphere.lean
+++ b/Mathlib/MeasureTheory/Constructions/HaarToSphere.lean
@@ -121,8 +121,7 @@ theorem measurePreserving_homeomorphUnitSphereProd :
     isPiSystem_measurableSet isPiSystem_Iio
     μ.toSphere.toFiniteSpanningSetsIn (finiteSpanningSetsIn_volumeIoiPow_range_Iio _)
     fun s hs ↦ forall_mem_range.2 fun r ↦ ?_
-  have : Ioo (0 : ℝ) r = r.1 • Ioo (0 : ℝ) 1 := by
-    rw [LinearOrderedField.smul_Ioo r.2.out, smul_zero, smul_eq_mul, mul_one]
+  have : Ioo (0 : ℝ) r = r.1 • Ioo (0 : ℝ) 1 := by simp [LinearOrderedField.smul_Ioo r.2.out]
   have hpos : 0 < dim E := Module.finrank_pos
   rw [(Homeomorph.measurableEmbedding _).map_apply, toSphere_apply' _ hs, volumeIoiPow_apply_Iio,
     comap_subtype_coe_apply (measurableSet_singleton _).compl, toSphere_apply_aux, this,


### PR DESCRIPTION
We may want to go back to `smul` in the future,
if we generalize these lemmas to `OrderedSMul`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)