### PR TITLE
[Merged by Bors] - feat: Measure.comap_smul

### DIFF
--- a/Mathlib/MeasureTheory/Measure/Comap.lean
+++ b/Mathlib/MeasureTheory/Measure/Comap.lean
@@ -151,7 +151,7 @@ lemma comap_comap (hf' : ∀ s, MeasurableSet s → MeasurableSet (f '' s)) (hg 
   · rw [comap, dif_neg <| mt And.left hf, comap, dif_neg fun h ↦ hf h.1.of_comp]
 
 lemma comap_smul {μ : Measure β} (c : ℝ≥0∞) : comap f (c • μ) = c • comap f μ := by
-  obtain rfl | hc := eq_zero_or_pos c
+  obtain rfl | hc := eq_or_ne c 0
   · simp
   by_cases h : Function.Injective f ∧ ∀ s : Set α, MeasurableSet s → NullMeasurableSet (f '' s) μ
   · ext s hs

--- a/Mathlib/MeasureTheory/Measure/Comap.lean
+++ b/Mathlib/MeasureTheory/Measure/Comap.lean
@@ -73,8 +73,7 @@ theorem comap_apply₀ (f : α → β) (μ : Measure β) (hfi : Injective f)
 
 lemma comap_undef {μ : Measure β}
     (h : ¬ (Injective f ∧ ∀ s, MeasurableSet s → NullMeasurableSet (f '' s) μ)) :
-    comap f μ = 0 := by
-  rw [comap, dif_neg h]
+    comap f μ = 0 := dif_neg h
 
 theorem le_comap_apply (f : α → β) (μ : Measure β) (hfi : Injective f)
     (hf : ∀ s, MeasurableSet s → NullMeasurableSet (f '' s) μ) (s : Set α) :

--- a/Mathlib/MeasureTheory/Measure/Comap.lean
+++ b/Mathlib/MeasureTheory/Measure/Comap.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov, Rémy Degenne
 -/
-import Mathlib.MeasureTheory.Measure.Map
+import Mathlib.MeasureTheory.Measure.QuasiMeasurePreserving
 
 /-!
 # Pullback of a measure
@@ -70,6 +70,11 @@ theorem comap_apply₀ (f : α → β) (μ : Measure β) (hfi : Injective f)
     (hs : NullMeasurableSet s (comap f μ)) : comap f μ s = μ (f '' s) := by
   rw [comap, dif_pos (And.intro hfi hf)] at hs ⊢
   rw [toMeasure_apply₀ _ _ hs, OuterMeasure.comap_apply, coe_toOuterMeasure]
+
+lemma comap_undef {μ : Measure β}
+    (h : ¬ (Injective f ∧ ∀ s, MeasurableSet s → NullMeasurableSet (f '' s) μ)) :
+    comap f μ = 0 := by
+  rw [comap, dif_neg h]
 
 theorem le_comap_apply (f : α → β) (μ : Measure β) (hfi : Injective f)
     (hf : ∀ s, MeasurableSet s → NullMeasurableSet (f '' s) μ) (s : Set α) :
@@ -146,6 +151,18 @@ lemma comap_comap (hf' : ∀ s, MeasurableSet s → MeasurableSet (f '' s)) (hg 
       comap_apply _ (hg.comp hf) (fun t ht ↦ image_comp g f _ ▸ hg' _ <| hf' _ ht) _ hs, image_comp]
   · rw [comap, dif_neg <| mt And.left hf, comap, dif_neg fun h ↦ hf h.1.of_comp]
 
+lemma comap_smul {μ : Measure β} (c : ℝ≥0∞) : comap f (c • μ) = c • comap f μ := by
+  obtain rfl | hc := eq_zero_or_pos c
+  · simp
+  by_cases h : Function.Injective f ∧ ∀ s : Set α, MeasurableSet s → NullMeasurableSet (f '' s) μ
+  · ext s hs
+    rw [comap_apply₀ f _ h.1 _ hs.nullMeasurableSet, smul_apply, smul_apply,
+      comap_apply₀ f μ h.1 h.2 hs.nullMeasurableSet]
+    simpa [nullMeasurableSet_smul_measure_iff hc] using h.2
+  · have h' : ¬ (Function.Injective f ∧
+        ∀ (s : Set α), MeasurableSet s → NullMeasurableSet (f '' s) (c • μ)) := by
+      simpa [nullMeasurableSet_smul_measure_iff hc] using h
+    simp [comap_undef, h, h']
 
 end Measure
 

--- a/Mathlib/MeasureTheory/Measure/QuasiMeasurePreserving.lean
+++ b/Mathlib/MeasureTheory/Measure/QuasiMeasurePreserving.lean
@@ -223,9 +223,9 @@ lemma NullMeasurableSet.smul_measure (h : NullMeasurableSet s μ) (c : ℝ≥0�
     NullMeasurableSet s (c • μ) :=
   NullMeasurableSet.mono_ac h (Measure.AbsolutelyContinuous.rfl.smul_left c)
 
-lemma nullMeasurableSet_smul_measure_iff {c : ℝ≥0∞} (hc : 0 < c) :
+lemma nullMeasurableSet_smul_measure_iff {c : ℝ≥0∞} (hc : c ≠ 0) :
     NullMeasurableSet s (c • μ) ↔ NullMeasurableSet s μ :=
-  ⟨fun h ↦ h.mono_ac (Measure.absolutelyContinuous_smul hc.ne'), fun h ↦ h.smul_measure c⟩
+  ⟨fun h ↦ h.mono_ac (Measure.absolutelyContinuous_smul hc), fun h ↦ h.smul_measure c⟩
 
 theorem AEDisjoint.preimage {ν : Measure β} {f : α → β} {s t : Set β} (ht : AEDisjoint ν s t)
     (hf : QuasiMeasurePreserving f μ ν) : AEDisjoint μ (f ⁻¹' s) (f ⁻¹' t) :=

--- a/Mathlib/MeasureTheory/Measure/QuasiMeasurePreserving.lean
+++ b/Mathlib/MeasureTheory/Measure/QuasiMeasurePreserving.lean
@@ -219,6 +219,14 @@ theorem NullMeasurableSet.mono_ac (h : NullMeasurableSet s μ) (hle : ν ≪ μ)
 theorem NullMeasurableSet.mono (h : NullMeasurableSet s μ) (hle : ν ≤ μ) : NullMeasurableSet s ν :=
   h.mono_ac hle.absolutelyContinuous
 
+lemma NullMeasurableSet.smul_measure (h : NullMeasurableSet s μ) (c : ℝ≥0∞) :
+    NullMeasurableSet s (c • μ) :=
+  NullMeasurableSet.mono_ac h (Measure.AbsolutelyContinuous.rfl.smul_left c)
+
+lemma nullMeasurableSet_smul_measure_iff {c : ℝ≥0∞} (hc : 0 < c) :
+    NullMeasurableSet s (c • μ) ↔ NullMeasurableSet s μ :=
+  ⟨fun h ↦ h.mono_ac (Measure.absolutelyContinuous_smul hc.ne'), fun h ↦ h.smul_measure c⟩
+
 theorem AEDisjoint.preimage {ν : Measure β} {f : α → β} {s t : Set β} (ht : AEDisjoint ν s t)
     (hf : QuasiMeasurePreserving f μ ν) : AEDisjoint μ (f ⁻¹' s) (f ⁻¹' t) :=
   hf.preimage_null ht

--- a/Mathlib/MeasureTheory/Measure/QuasiMeasurePreserving.lean
+++ b/Mathlib/MeasureTheory/Measure/QuasiMeasurePreserving.lean
@@ -221,7 +221,7 @@ theorem NullMeasurableSet.mono (h : NullMeasurableSet s μ) (hle : ν ≤ μ) : 
 
 lemma NullMeasurableSet.smul_measure (h : NullMeasurableSet s μ) (c : ℝ≥0∞) :
     NullMeasurableSet s (c • μ) :=
-  NullMeasurableSet.mono_ac h (Measure.AbsolutelyContinuous.rfl.smul_left c)
+  h.mono_ac (Measure.AbsolutelyContinuous.rfl.smul_left c)
 
 lemma nullMeasurableSet_smul_measure_iff {c : ℝ≥0∞} (hc : 0 < c) :
     NullMeasurableSet s (c • μ) ↔ NullMeasurableSet s μ :=


### PR DESCRIPTION
`comap f (c • μ) = c • comap f μ`

Co-authored-by: Kevin Buzzard

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
