### PR TITLE
[Merged by Bors] - chore(LocallyConvexSpace): drop an unused argument

### DIFF
--- a/Mathlib/Analysis/LocallyConvex/StrongTopology.lean
+++ b/Mathlib/Analysis/LocallyConvex/StrongTopology.lean
@@ -38,7 +38,7 @@ section General
 namespace UniformConvergenceCLM
 
 variable (R)
-variable [Semiring R] [PartialOrder R] [IsOrderedRing R]
+variable [Semiring R] [PartialOrder R]
 variable [NormedField 𝕜₁] [NormedField 𝕜₂] [Module 𝕜₁ E] [Module 𝕜₂ F] {σ : 𝕜₁ →+* 𝕜₂}
 variable [Module R F] [ContinuousConstSMul R F] [LocallyConvexSpace R F] [SMulCommClass 𝕜₂ R F]
 
@@ -59,7 +59,7 @@ section BoundedSets
 
 namespace ContinuousLinearMap
 
-variable [Semiring R] [PartialOrder R] [IsOrderedRing R]
+variable [Semiring R] [PartialOrder R]
 variable [NormedField 𝕜₁] [NormedField 𝕜₂] [Module 𝕜₁ E] [Module 𝕜₂ F] {σ : 𝕜₁ →+* 𝕜₂}
 variable [Module R F] [ContinuousConstSMul R F] [LocallyConvexSpace R F] [SMulCommClass 𝕜₂ R F]
 

--- a/Mathlib/Topology/Algebra/Module/LocallyConvex.lean
+++ b/Mathlib/Topology/Algebra/Module/LocallyConvex.lean
@@ -42,16 +42,16 @@ section Semimodule
 
 /-- A `LocallyConvexSpace` is a topological semimodule over an ordered semiring in which convex
 neighborhoods of a point form a neighborhood basis at that point. -/
-class LocallyConvexSpace (𝕜 E : Type*) [Semiring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜]
+class LocallyConvexSpace (𝕜 E : Type*) [Semiring 𝕜] [PartialOrder 𝕜]
     [AddCommMonoid E] [Module 𝕜 E] [TopologicalSpace E] : Prop where
   convex_basis : ∀ x : E, (𝓝 x).HasBasis (fun s : Set E => s ∈ 𝓝 x ∧ Convex 𝕜 s) id
 
-variable (𝕜 E : Type*) [Semiring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜]
+variable (𝕜 E : Type*) [Semiring 𝕜] [PartialOrder 𝕜]
   [AddCommMonoid E] [Module 𝕜 E] [TopologicalSpace E]
 
 theorem locallyConvexSpace_iff :
     LocallyConvexSpace 𝕜 E ↔ ∀ x : E, (𝓝 x).HasBasis (fun s : Set E => s ∈ 𝓝 x ∧ Convex 𝕜 s) id :=
-  ⟨@LocallyConvexSpace.convex_basis _ _ _ _ _ _ _ _, LocallyConvexSpace.mk⟩
+  ⟨fun _ ↦ LocallyConvexSpace.convex_basis, LocallyConvexSpace.mk⟩
 
 theorem LocallyConvexSpace.ofBases {ι : Type*} (b : E → ι → Set E) (p : E → ι → Prop)
     (hbasis : ∀ x : E, (𝓝 x).HasBasis (p x) (b x)) (hconvex : ∀ x i, p x i → Convex 𝕜 (b x i)) :
@@ -74,7 +74,7 @@ end Semimodule
 
 section Module
 
-variable (𝕜 E : Type*) [Semiring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜]
+variable (𝕜 E : Type*) [Semiring 𝕜] [PartialOrder 𝕜]
   [AddCommGroup E] [Module 𝕜 E] [TopologicalSpace E]
   [IsTopologicalAddGroup E]
 
@@ -157,35 +157,35 @@ end LinearOrderedField
 
 section LatticeOps
 
-variable {ι : Sort*} {𝕜 E F : Type*} [Semiring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜]
+variable {ι : Sort*} {𝕜 E F : Type*} [Semiring 𝕜] [PartialOrder 𝕜]
   [AddCommMonoid E] [Module 𝕜 E]
   [AddCommMonoid F] [Module 𝕜 F]
 
 protected theorem LocallyConvexSpace.sInf {ts : Set (TopologicalSpace E)}
-    (h : ∀ t ∈ ts, @LocallyConvexSpace 𝕜 E _ _ _ _ _ t) :
-    @LocallyConvexSpace 𝕜 E _ _ _ _ _ (sInf ts) := by
+    (h : ∀ t ∈ ts, @LocallyConvexSpace 𝕜 E _ _ _ _ t) :
+    @LocallyConvexSpace 𝕜 E _ _ _ _ (sInf ts) := by
   letI : TopologicalSpace E := sInf ts
   refine .ofBases 𝕜 E (fun _ => fun If : Set ts × (ts → Set E) => ⋂ i ∈ If.1, If.2 i)
       (fun x => fun If : Set ts × (ts → Set E) =>
         If.1.Finite ∧ ∀ i ∈ If.1, If.2 i ∈ @nhds _ (↑i) x ∧ Convex 𝕜 (If.2 i))
       (fun x => ?_) fun x If hif => convex_iInter fun i => convex_iInter fun hi => (hif.2 i hi).2
   rw [nhds_sInf, ← iInf_subtype'']
-  exact .iInf' fun i : ts => (@locallyConvexSpace_iff 𝕜 E _ _ _ _ _ ↑i).mp (h (↑i) i.2) x
+  exact .iInf' fun i : ts => (@locallyConvexSpace_iff 𝕜 E _ _ _ _ ↑i).mp (h (↑i) i.2) x
 
 @[deprecated (since := "2025-05-05")]
 alias locallyConvexSpace_sInf := LocallyConvexSpace.sInf
 
 protected theorem LocallyConvexSpace.iInf {ts' : ι → TopologicalSpace E}
-    (h' : ∀ i, @LocallyConvexSpace 𝕜 E _ _ _ _ _ (ts' i)) :
-    @LocallyConvexSpace 𝕜 E _ _ _ _ _ (⨅ i, ts' i) :=
+    (h' : ∀ i, @LocallyConvexSpace 𝕜 E _ _ _ _ (ts' i)) :
+    @LocallyConvexSpace 𝕜 E _ _ _ _ (⨅ i, ts' i) :=
   .sInf <| by rwa [forall_mem_range]
 
 @[deprecated (since := "2025-05-05")]
 alias locallyConvexSpace_iInf := LocallyConvexSpace.iInf
 
 protected theorem LocallyConvexSpace.inf {t₁ t₂ : TopologicalSpace E}
-    (h₁ : @LocallyConvexSpace 𝕜 E _ _ _ _ _ t₁)
-    (h₂ : @LocallyConvexSpace 𝕜 E _ _ _ _ _ t₂) : @LocallyConvexSpace 𝕜 E _ _ _ _ _ (t₁ ⊓ t₂) := by
+    (h₁ : @LocallyConvexSpace 𝕜 E _ _ _ _ t₁)
+    (h₂ : @LocallyConvexSpace 𝕜 E _ _ _ _ t₂) : @LocallyConvexSpace 𝕜 E _ _ _ _ (t₁ ⊓ t₂) := by
   rw [inf_eq_iInf]
   refine .iInf fun b => ?_
   cases b <;> assumption
@@ -194,7 +194,7 @@ protected theorem LocallyConvexSpace.inf {t₁ t₂ : TopologicalSpace E}
 alias locallyConvexSpace_inf := LocallyConvexSpace.inf
 
 protected theorem LocallyConvexSpace.induced {t : TopologicalSpace F} [LocallyConvexSpace 𝕜 F]
-    (f : E →ₗ[𝕜] F) : @LocallyConvexSpace 𝕜 E _ _ _ _ _ (t.induced f) := by
+    (f : E →ₗ[𝕜] F) : @LocallyConvexSpace 𝕜 E _ _ _ _ (t.induced f) := by
   letI : TopologicalSpace E := t.induced f
   refine LocallyConvexSpace.ofBases 𝕜 E (fun _ => preimage f)
     (fun x => fun s : Set F => s ∈ 𝓝 (f x) ∧ Convex 𝕜 s) (fun x => ?_) fun x s ⟨_, hs⟩ =>
@@ -249,7 +249,7 @@ instance LinearOrderedSemiring.toLocallyConvexSpace {R : Type*} [TopologicalSpac
 end LinearOrderedSemiring
 
 lemma Convex.eventually_nhdsWithin_segment {E 𝕜 : Type*}
-    [Semiring 𝕜] [PartialOrder 𝕜] [IsOrderedRing 𝕜]
+    [Semiring 𝕜] [PartialOrder 𝕜]
     [AddCommMonoid E] [Module 𝕜 E] [TopologicalSpace E] [LocallyConvexSpace 𝕜 E]
     {s : Set E} (hs : Convex 𝕜 s) {x₀ : E} (hx₀s : x₀ ∈ s)
     {p : E → Prop} (h : ∀ᶠ x in 𝓝[s] x₀, p x) :


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
