### PR TITLE
[Merged by Bors] - feat(Combinatorics/SimpleGraph/Bipartite): a graph is 2-colorable iff it's bipartite

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Bipartite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Bipartite.lean
@@ -29,6 +29,9 @@ This file proves results about bipartite simple graphs, including several double
 
 * `twocol_iff_bipartition` is the proof that a twocoloring implies a bipartition and vice versa.
 
+* `bipartite_iff_bipartition` proves that `G.IsBipartite` iff there exist sets
+  `s t : Set V` such that `G.IsBipartiteWith s t`.
+
 * `SimpleGraph.isBipartiteWith_sum_degrees_eq` is the proof that if `G.IsBipartiteWith s t`, then
   the sum of the degrees of the vertices in `s` is equal to the sum of the degrees of the vertices
   in `t`.
@@ -46,9 +49,6 @@ For the formulation of double-counting arguments where a bipartite graph is cons
 relation `r : α → β → Prop`, see `Mathlib.Combinatorics.Enumerative.DoubleCounting`.
 
 ## TODO
-
-* Define `G.IsBipartite := G.Colorable 2` and prove `G.IsBipartite` iff there exist sets
-  `s t : Set V` such that `G.IsBipartiteWith s t`.
 
 * Prove that `G.IsBipartite` iff `G` does not contain an odd cycle.
   I.e., `G.IsBipartite ↔ ∀ n, (cycleGraph (2*n+1)).Free G`.
@@ -306,5 +306,13 @@ theorem twocol_iff_bipartition :
   · exact twocol_imp_bipartition G
   · rintro ⟨s, t, h⟩
     exact bipartition_imp_twocol G h
+
+/--
+Using the previous statements to bride `IsBipartite` and `IsBipartiteWith`.
+-/
+theorem bipartite_iff_bipartition :
+  G.IsBipartite ↔ ∃ s t : Set V, G.IsBipartiteWith s t := by
+  dsimp [IsBipartite]
+  exact twocol_iff_bipartition G
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Bipartite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Bipartite.lean
@@ -246,11 +246,11 @@ theorem isBipartiteWith_sum_degrees_eq_card_edges' (h : G.IsBipartiteWith s t) :
 end IsBipartiteWith
 variable {V : Type*} (G : SimpleGraph V)
 
-/-- A graph is bipartite if it is `Colorable G 2`. -/
+/-- The predicate for a simple graph to be bipartite. -/
 abbrev IsBipartite (G : SimpleGraph V) : Prop := G.Colorable 2
 
-/-- If a graph is bipartite, then there exist disjoint sets `s` and `t`
-such that all edges connect a vertex in `s` to a vertex in `t`. -/
+/-- If a simple graph `G` is bipartite, then there exist disjoint sets `s` and `t`
+such that all edges in `G` connect a vertex in `s` to a vertex in `t`. -/
 lemma IsBipartite.exists_isBipartiteWith (h : G.IsBipartite) :
     ∃ s t, G.IsBipartiteWith s t := by
   rcases h with ⟨c, hc_adj⟩
@@ -270,7 +270,7 @@ lemma IsBipartite.exists_isBipartiteWith (h : G.IsBipartite) :
   exact ⟨s, t, h₁, h₂⟩
 
 
-/-- If a graph has a bipartition, then it is 2-colorable. -/
+/-- If a simple graph `G` has a bipartition, then it is bipartite. -/
 lemma IsBipartiteWith.isBipartite {s t : Set V} (h : G.IsBipartiteWith s t) :
     G.IsBipartite := by
   classical

--- a/Mathlib/Combinatorics/SimpleGraph/Bipartite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Bipartite.lean
@@ -276,7 +276,7 @@ lemma IsBipartite.exists_isBipartiteWith (h : G.IsBipartite) :
 
 /--
 Given a bipartition s, t of G, construct an explicit 2-coloring by sending vertices in s to 0
-and those in t to 1. Show adjacent vertices get different colors (through the pattern match).
+and vertices in t to 1. Show adjacent vertices get different colors (through the pattern match).
 -/
 lemma IsBipartiteWith.isBipartite {s t : Set V} (h : G.IsBipartiteWith s t) :
     G.IsBipartite := by
@@ -295,11 +295,9 @@ lemma IsBipartiteWith.isBipartite {s t : Set V} (h : G.IsBipartiteWith s t) :
 Putting the two previous lemmas together to show a biimplication between having a twocoloring
 and having a bipartition.
 -/
-theorem twocol_iff_bipartition :
-  G.Colorable 2 ↔ ∃ s t : Set V, G.IsBipartiteWith s t := by
-  constructor
-  · exact twocol_imp_bipartition G
-  · rintro ⟨s, t, h⟩
-    exact bipartition_imp_twocol G h
+theorem isBipartite_iff_exists_isBipartiteWith :
+  G.IsBipartite ↔ ∃ s t : Set V, G.IsBipartiteWith s t where
+  mp := IsBipartite.exists_isBipartiteWith G
+  mpr := by rintro ⟨s, t, h⟩; exact h.isBipartite
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Bipartite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Bipartite.lean
@@ -27,10 +27,8 @@ This file proves results about bipartite simple graphs, including several double
 * `SimpleGraph.IsBipartite`: Predicate for a simple graph to be bipartite.
   `G.IsBipartite` is defined as an abbreviation for `G.Colorable 2`.
 
-* `twocol_iff_bipartition` is the proof that a twocoloring implies a bipartition and vice versa.
-
-* `bipartite_iff_bipartition` proves that `G.IsBipartite` iff there exist sets
-  `s t : Set V` such that `G.IsBipartiteWith s t`.
+* `SimpleGraph.isBipartite_iff_exists_isBipartiteWith` is the proof that `G.IsBipartite` iff
+  `G.IsBipartiteWith s t`.
 
 * `SimpleGraph.isBipartiteWith_sum_degrees_eq` is the proof that if `G.IsBipartiteWith s t`, then
   the sum of the degrees of the vertices in `s` is equal to the sum of the degrees of the vertices
@@ -248,13 +246,11 @@ theorem isBipartiteWith_sum_degrees_eq_card_edges' (h : G.IsBipartiteWith s t) :
 end IsBipartiteWith
 variable {V : Type*} (G : SimpleGraph V)
 
-/-- A simple graph is bipartite if it admits a 2-coloring. -/
+/-- A graph is bipartite if it is `Colorable G 2`. -/
 abbrev IsBipartite (G : SimpleGraph V) : Prop := G.Colorable 2
 
-/--
-From a 2-coloring of G, produce two color classes s and t witnessing bipartiteness:
-Disjoint s t where every edge goes between s and t.
--/
+/-- If a graph is bipartite, then there exist disjoint sets `s` and `t`
+such that all edges connect a vertex in `s` to a vertex in `t`. -/
 lemma IsBipartite.exists_isBipartiteWith (h : G.IsBipartite) :
     ∃ s t, G.IsBipartiteWith s t := by
   rcases h with ⟨c, hc_adj⟩
@@ -274,10 +270,7 @@ lemma IsBipartite.exists_isBipartiteWith (h : G.IsBipartite) :
   exact ⟨s, t, h₁, h₂⟩
 
 
-/--
-Given a bipartition s, t of G, construct an explicit 2-coloring by sending vertices in s to 0
-and vertices in t to 1. Show adjacent vertices get different colors (through the pattern match).
--/
+/-- If a graph has a bipartition, then it is 2-colorable. -/
 lemma IsBipartiteWith.isBipartite {s t : Set V} (h : G.IsBipartiteWith s t) :
     G.IsBipartite := by
   classical
@@ -291,10 +284,7 @@ lemma IsBipartiteWith.isBipartite {s t : Set V} (h : G.IsBipartiteWith s t) :
   · have hv_not_s : v ∉ s := h_disj.subset_compl_left hv_t
     simp [hv_not_s, hw_s]
 
-/--
-Putting the two previous lemmas together to show a biimplication between having a twocoloring
-and having a bipartition.
--/
+/-- `G.IsBipartite` if and only if `G.IsBipartiteWith s t`. -/
 theorem isBipartite_iff_exists_isBipartiteWith :
   G.IsBipartite ↔ ∃ s t : Set V, G.IsBipartiteWith s t where
   mp := IsBipartite.exists_isBipartiteWith G

--- a/Mathlib/Combinatorics/SimpleGraph/Bipartite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Bipartite.lean
@@ -55,7 +55,7 @@ relation `r : α → β → Prop`, see `Mathlib.Combinatorics.Enumerative.Double
 -/
 
 
-open BigOperators Finset Fintype Classical
+open BigOperators Finset Fintype
 
 namespace SimpleGraph
 
@@ -254,8 +254,8 @@ variable {V : Type*} (G : SimpleGraph V)
 def IsBipartite (G : SimpleGraph V) : Prop := G.Colorable 2
 
 /--
-From a 2-coloring of `G`, produce two color classes `s` and `t` witnessing bipartiteness:
-`Disjoint s t` where every edge goes between `s` and `t`.
+From a 2-coloring of G, produce two color classes s and t witnessing bipartiteness:
+Disjoint s t where every edge goes between s and t.
 -/
 lemma twocol_imp_bipartition (h : G.Colorable 2) : ∃ s t, G.IsBipartiteWith s t := by
   rcases h with ⟨c, hc_adj⟩
@@ -273,16 +273,17 @@ lemma twocol_imp_bipartition (h : G.Colorable 2) : ∃ s t, G.IsBipartiteWith s 
     intro v w h_adj
     have h_color := hc_adj h_adj
     simp [s, t, Set.mem_setOf_eq, Fin.forall_fin_two] at h_color ⊢
-    ; omega
+    omega
   exact ⟨s, t, ⟨h₁, h₂⟩⟩
 
 
 /--
-Given a bipartition `s, t` of `G`, construct an explicit 2-coloring by sending vertices in `s` to 0
-and those in `t` to 1. Show adjacent vertices get different colors (through the pattern match).
+Given a bipartition s, t of G, construct an explicit 2-coloring by sending vertices in s to 0
+and those in t to 1. Show adjacent vertices get different colors (through the pattern match).
 -/
 lemma bipartition_imp_twocol {s t : Set V}
   (h : G.IsBipartiteWith s t) : G.Colorable 2 := by
+  classical
   have h_disj  : Disjoint s t := h.1
   have h_edges : ∀ v w, G.Adj v w → v ∈ s ∧ w ∈ t ∨ v ∈ t ∧ w ∈ s := h.2
   use fun v => if v ∈ s then 0 else 1
@@ -308,11 +309,10 @@ theorem twocol_iff_bipartition :
     exact bipartition_imp_twocol G h
 
 /--
-Using the previous statements to bride `IsBipartite` and `IsBipartiteWith`.
+Using the previous statements to bride IsBipartite and IsBipartiteWith.
 -/
 theorem bipartite_iff_bipartition :
   G.IsBipartite ↔ ∃ s t : Set V, G.IsBipartiteWith s t := by
   dsimp [IsBipartite]
   exact twocol_iff_bipartition G
-
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Bipartite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Bipartite.lean
@@ -263,7 +263,6 @@ lemma IsBipartite.exists_isBipartiteWith (h : G.IsBipartite) : ∃ s t, G.IsBipa
 
 /-- If a simple graph `G` has a bipartition, then it is bipartite. -/
 lemma IsBipartiteWith.isBipartite {s t : Set V} (h : G.IsBipartiteWith s t) : G.IsBipartite := by
-  classical
   refine ⟨s.indicator 1, fun {v w} hw ↦ ?_⟩
   obtain (⟨hs, ht⟩ | ⟨ht, hs⟩) := h.2 hw <;>
     { replace ht : _ ∉ s := h.1.subset_compl_left ht; simp [hs, ht] }


### PR DESCRIPTION
Define a predicate for a simple graph to be bipartite (`def IsBipartite (G : SimpleGraph V) : Prop := G.Colorable 2`) and prove ` G.IsBipartite ↔ ∃ s t : Set V, G.IsBipartiteWith s t`.

---

This is my first attempt at contributing to mathlib and therefore I have a couple of points of uncertainty related to:
- Naming conventions for theorems - Seeing a lot of isBipartite vs IsBipartite in the original work. What do we want to go with when?
- Definition placement - Where should I put the IsBipartite definition.
- Structure of biimplication theorems - Should I combine the different lemmas into 1 bgi theorem? 

Feedback is greatly appreciated :)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
