### PR TITLE
[Merged by Bors] - chore: add `Fin.range_snoc`

### DIFF
--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -545,6 +545,11 @@ theorem update_snoc_last : update (snoc p x) (last n) z = snoc p z := by
   ext j
   cases j using lastCases <;> simp
 
+@[simp]
+lemma range_snoc {α : Type*} (f : Fin n → α) (x : α) :
+    Set.range (Fin.snoc f x) = insert x (Set.range f) := by
+  ext; simp [Fin.exists_fin_succ', or_comm, eq_comm]
+
 /-- As a binary function, `Fin.snoc` is injective. -/
 theorem snoc_injective2 : Function.Injective2 (@snoc n α) := fun x y xₙ yₙ h ↦
   ⟨funext fun i ↦ by simpa using congr_fun h (castSucc i), by simpa using congr_fun h (last n)⟩

--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -547,7 +547,7 @@ theorem update_snoc_last : update (snoc p x) (last n) z = snoc p z := by
 
 @[simp]
 lemma range_snoc {α : Type*} (f : Fin n → α) (x : α) :
-    Set.range (Fin.snoc f x) = insert x (Set.range f) := by
+    Set.range (snoc f x) = insert x (Set.range f) := by
   ext; simp [Fin.exists_fin_succ', or_comm, eq_comm]
 
 /-- As a binary function, `Fin.snoc` is injective. -/


### PR DESCRIPTION
This matches the existing `Fin.range_cons`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
