### PR TITLE
[Merged by Bors] - chore(Behrend): golf using `calc` and `gcongr`

### DIFF
--- a/Mathlib/Combinatorics/Additive/AP/Three/Behrend.lean
+++ b/Mathlib/Combinatorics/Additive/AP/Three/Behrend.lean
@@ -274,14 +274,11 @@ open Real
 section NumericalBounds
 
 theorem log_two_mul_two_le_sqrt_log_eight : log 2 * 2 ≤ √(log 8) := by
-  have : (8 : ℝ) = 2 ^ ((3 : ℕ) : ℝ) := by rw [rpow_natCast]; norm_num
-  rw [this, log_rpow zero_lt_two (3 : ℕ)]
+  rw [show (8 : ℝ) = 2 ^ 3 by norm_num1, Real.log_pow, Nat.cast_ofNat]
   apply le_sqrt_of_sq_le
   rw [mul_pow, sq (log 2), mul_assoc, mul_comm]
-  refine mul_le_mul_of_nonneg_right ?_ (log_nonneg one_le_two)
-  rw [← le_div_iff₀]
-  on_goal 1 => apply log_two_lt_d9.le.trans
-  all_goals norm_num1
+  gcongr
+  linarith only [log_two_lt_d9.le]
 
 theorem two_div_one_sub_two_div_e_le_eight : 2 / (1 - 2 / exp 1) ≤ 8 := by
   rw [div_le_iff₀, mul_sub, mul_one, mul_div_assoc', le_sub_comm, div_le_iff₀ (exp_pos _)]
@@ -289,24 +286,19 @@ theorem two_div_one_sub_two_div_e_le_eight : 2 / (1 - 2 / exp 1) ≤ 8 := by
   rw [sub_pos, div_lt_one] <;> exact exp_one_gt_d9.trans' (by norm_num)
 
 theorem le_sqrt_log (hN : 4096 ≤ N) : log (2 / (1 - 2 / exp 1)) * (69 / 50) ≤ √(log ↑N) := by
-  have : (12 : ℕ) * log 2 ≤ log N := by
-    rw [← log_rpow zero_lt_two, rpow_natCast]
-    exact log_le_log (by positivity) (mod_cast hN)
-  refine (mul_le_mul_of_nonneg_right (log_le_log ?_ two_div_one_sub_two_div_e_le_eight) <| by
-    norm_num1).trans ?_
-  · refine div_pos zero_lt_two ?_
-    rw [sub_pos, div_lt_one (exp_pos _)]
-    exact exp_one_gt_d9.trans_le' (by norm_num1)
-  have l8 : log 8 = (3 : ℕ) * log 2 := by
-    rw [← log_rpow zero_lt_two, rpow_natCast]
-    norm_num
-  rw [l8]
-  apply le_sqrt_of_sq_le (le_trans _ this)
-  rw [mul_right_comm, mul_pow, sq (log 2), ← mul_assoc]
-  apply mul_le_mul_of_nonneg_right _ (log_nonneg one_le_two)
-  rw [← le_div_iff₀']
-  · exact log_two_lt_d9.le.trans (by norm_num1)
-  exact sq_pos_of_ne_zero (by norm_num1)
+  calc
+    _ ≤ log (2 ^ 3) * (69 / 50) := by
+      gcongr
+      · field_simp [show 2 < Real.exp 1 from lt_trans (by norm_num1) exp_one_gt_d9]
+      · norm_num1
+        exact two_div_one_sub_two_div_e_le_eight
+    _ ≤ √(log (2 ^ 12)) := by
+      simp only [Real.log_pow, Nat.cast_ofNat]
+      apply le_sqrt_of_sq_le
+      nlinarith [log_two_lt_d9, log_two_gt_d9]
+    _ ≤ √(log ↑N) := by
+      gcongr
+      exact mod_cast hN
 
 theorem exp_neg_two_mul_le {x : ℝ} (hx : 0 < x) : exp (-2 * x) < exp (2 - ⌈x⌉₊) / ⌈x⌉₊ := by
   have h₁ := ceil_lt_add_one hx.le
@@ -440,21 +432,22 @@ theorem roth_lower_bound_explicit (hN : 4096 ≤ N) :
   rw [← rpow_natCast, div_rpow (rpow_nonneg hN₀.le _) (exp_pos _).le, ← rpow_mul hN₀.le,
     inv_mul_eq_div, cast_sub hn₂.le, cast_two, same_sub_div hn.ne', exp_one_rpow,
     div_div, rpow_sub hN₀, rpow_one, div_div, div_eq_mul_inv]
-  refine mul_le_mul_of_nonneg_left ?_ (cast_nonneg _)
+  gcongr _ * ?_
   rw [mul_inv, mul_inv, ← exp_neg, ← rpow_neg (cast_nonneg _), neg_sub, ← div_eq_mul_inv]
   have : exp (-4 * √(log N)) = exp (-2 * √(log N)) * exp (-2 * √(log N)) := by
     rw [← exp_add, ← add_mul]
     norm_num
   rw [this]
-  refine mul_le_mul ?_ (exp_neg_two_mul_le <| Real.sqrt_pos.2 <| log_pos ?_).le (exp_pos _).le <|
-      rpow_nonneg (cast_nonneg _) _
+  gcongr
   · rw [← le_log_iff_exp_le (rpow_pos_of_pos hN₀ _), log_rpow hN₀, ← le_div_iff₀, mul_div_assoc,
       div_sqrt, neg_mul, neg_le_neg_iff, div_mul_eq_mul_div, div_le_iff₀ hn]
-    · exact mul_le_mul_of_nonneg_left (le_ceil _) zero_le_two
+    · gcongr
+      apply le_ceil
     refine Real.sqrt_pos.2 (log_pos ?_)
     rw [one_lt_cast]
     exact hN.trans_lt' (by norm_num1)
-  · rw [one_lt_cast]
+  · refine (exp_neg_two_mul_le <| Real.sqrt_pos.2 <| log_pos ?_).le
+    rw [one_lt_cast]
     exact hN.trans_lt' (by norm_num1)
 
 theorem exp_four_lt : exp 4 < 64 := by


### PR DESCRIPTION
IMHO, `calc` proofs are more readable, though these estimates should be done by a tactic.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
