### PR TITLE
[Merged by Bors] - feat(UniqueFactorizationMonoid): a `MulEquiv` that commutes with `normalize` preserves `normalizedFactors`

### DIFF
--- a/Mathlib/Algebra/GCDMonoid/Basic.lean
+++ b/Mathlib/Algebra/GCDMonoid/Basic.lean
@@ -157,6 +157,10 @@ theorem normalize_eq_normalize_iff {x y : α} : normalize x = normalize y ↔ x 
   ⟨fun h => ⟨Units.dvd_mul_right.1 ⟨_, h.symm⟩, Units.dvd_mul_right.1 ⟨_, h⟩⟩, fun ⟨hxy, hyx⟩ =>
     normalize_eq_normalize hxy hyx⟩
 
+theorem normalize_eq_normalize_iff_associated {x y : α} :
+    normalize x = normalize y ↔ Associated x y := by
+  rw [normalize_eq_normalize_iff, dvd_dvd_iff_associated]
+
 theorem dvd_antisymm_of_normalize_eq {a b : α} (ha : normalize a = a) (hb : normalize b = b)
     (hab : a ∣ b) (hba : b ∣ a) : a = b :=
   ha ▸ hb ▸ normalize_eq_normalize hab hba

--- a/Mathlib/Algebra/Ring/Divisibility/Basic.lean
+++ b/Mathlib/Algebra/Ring/Divisibility/Basic.lean
@@ -27,6 +27,11 @@ theorem map_dvd_iff (f : F) {a b} : f a ∣ f b ↔ a ∣ b :=
   let f := MulEquivClass.toMulEquiv f
   ⟨fun h ↦ by rw [← f.left_inv a, ← f.left_inv b]; exact map_dvd f.symm h, map_dvd f⟩
 
+theorem map_dvd_iff_dvd_symm (f : F) {a : α} {b : β} :
+    f a ∣ b ↔ a ∣ (MulEquivClass.toMulEquiv f).symm b := by
+  obtain ⟨c, rfl⟩ : ∃ c, f c = b := EquivLike.surjective f b
+  simp [map_dvd_iff]
+
 theorem MulEquiv.decompositionMonoid (f : F) [DecompositionMonoid β] : DecompositionMonoid α where
   primal a b c h := by
     rw [← map_dvd_iff f, map_mul] at h

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/NormalizedFactors.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/NormalizedFactors.lean
@@ -239,7 +239,7 @@ theorem mem_normalizedFactors_iff [Subsingleton αˣ] {p x : α} (hx : x ≠ 0) 
 theorem mem_normalizedFactors_iff' {p x : α} (h : x ≠ 0) :
     p ∈ normalizedFactors x ↔ Irreducible p ∧ normalize p = p ∧ p ∣ x := by
   refine ⟨fun h ↦ ⟨irreducible_of_normalized_factor p h, normalize_normalized_factor p h,
-    dvd_of_normalized_factor p h⟩, fun ⟨h₁, h₂, h₃⟩ ↦ ?_⟩
+    dvd_of_normalized_factor h⟩, fun ⟨h₁, h₂, h₃⟩ ↦ ?_⟩
   obtain ⟨y, hy₁, hy₂⟩ := exists_mem_factors_of_dvd h h₁ h₃
   exact Multiset.mem_map.mpr ⟨y, hy₁, by
     rwa [← h₂, normalize_eq_normalize_iff_associated, Associated.comm]⟩

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/NormalizedFactors.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/NormalizedFactors.lean
@@ -79,9 +79,9 @@ theorem normalize_normalized_factor {a : α} :
   obtain ⟨y, _, rfl⟩ := Multiset.mem_map.1 hx
   apply normalize_idem
 
-theorem dvd_of_normalized_factor {a : α} :
-    ∀ x : α, x ∈ normalizedFactors a → x ∣ a := fun x h ↦ by
-  obtain ⟨y, hy, rfl⟩ := Multiset.mem_map.mp h
+theorem dvd_of_normalized_factor {a x : α} (hx : x ∈ normalizedFactors a ) :
+    x ∣ a := by
+  obtain ⟨y, hy, rfl⟩ := Multiset.mem_map.mp hx
   exact normalize_dvd_iff.mpr <| dvd_of_mem_factors hy
 
 theorem normalizedFactors_irreducible {a : α} (ha : Irreducible a) :
@@ -325,9 +325,16 @@ def normalizedFactorsEquiv [DecidableEq α] (he : ∀ x, normalize (f x) = f (no
         mem_normalizedFactors_iff' (EmbeddingLike.map_ne_zero_iff.mpr ha), map_dvd_iff_dvd_symm,
         MulEquiv.irreducible_iff, he]
 
+@[simp, nolint simpNF]
 theorem normalizedFactorsEquiv_apply [DecidableEq α] (he : ∀ x, normalize (f x) = f (normalize x))
     {a p : α} (hp : p ∈ normalizedFactors a) :
     ↑(normalizedFactorsEquiv he a ⟨p, hp⟩) = f p := rfl
+
+@[simp, nolint simpNF]
+theorem normalizedFactorsEquiv_symm_apply [DecidableEq α]
+    (he : ∀ x, normalize (f x) = f (normalize x))
+    {a : α} {q : β} (hq : q ∈ normalizedFactors (f a)) :
+    ((normalizedFactorsEquiv he a).symm ⟨q, hq⟩) = (MulEquivClass.toMulEquiv f).symm q := rfl
 
 end UniqueFactorizationMonoid
 

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/NormalizedFactors.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/NormalizedFactors.lean
@@ -318,23 +318,23 @@ If the monoid equiv `f : α ≃* β` commutes with `normalize` then, for `a : α
 bijection between the `normalizedFactors` of `a` and of `f a`.
 -/
 def normalizedFactorsEquiv [DecidableEq α] (he : ∀ x, normalize (f x) = f (normalize x)) (a : α) :
-    {x | x ∈ normalizedFactors a} ≃ {y | y ∈ normalizedFactors (f a)} :=
+    {x // x ∈ normalizedFactors a} ≃ {y // y ∈ normalizedFactors (f a)} :=
   Equiv.subtypeEquiv f fun x ↦
     if ha : a = 0 then by simp [ha] else by
       simp [mem_normalizedFactors_iff' ha,
         mem_normalizedFactors_iff' (EmbeddingLike.map_ne_zero_iff.mpr ha), map_dvd_iff_dvd_symm,
         MulEquiv.irreducible_iff, he]
 
-@[simp, nolint simpNF]
+@[simp]
 theorem normalizedFactorsEquiv_apply [DecidableEq α] (he : ∀ x, normalize (f x) = f (normalize x))
     {a p : α} (hp : p ∈ normalizedFactors a) :
-    ↑(normalizedFactorsEquiv he a ⟨p, hp⟩) = f p := rfl
+    normalizedFactorsEquiv he a ⟨p, hp⟩ = f p := rfl
 
-@[simp, nolint simpNF]
+@[simp]
 theorem normalizedFactorsEquiv_symm_apply [DecidableEq α]
     (he : ∀ x, normalize (f x) = f (normalize x))
     {a : α} {q : β} (hq : q ∈ normalizedFactors (f a)) :
-    ((normalizedFactorsEquiv he a).symm ⟨q, hq⟩) = (MulEquivClass.toMulEquiv f).symm q := rfl
+    (normalizedFactorsEquiv he a).symm ⟨q, hq⟩ = (MulEquivClass.toMulEquiv f).symm q := rfl
 
 end UniqueFactorizationMonoid
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
