### PR TITLE
[Merged by Bors] - feat(Tactic/Finiteness): tag more lemmas

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
@@ -566,7 +566,7 @@ theorem rpow_eq_top_of_nonneg (x : ℝ≥0∞) {y : ℝ} (hy0 : 0 ≤ y) : x ^ y
 theorem rpow_ne_top_of_nonneg {x : ℝ≥0∞} {y : ℝ} (hy0 : 0 ≤ y) (h : x ≠ ⊤) : x ^ y ≠ ⊤ :=
   mt (ENNReal.rpow_eq_top_of_nonneg x hy0) h
 
--- This is an unsafe rule since we want to try `rpow_ne_top_of_nonneg'` if `x = 0`.
+-- This is an unsafe rule since we want to try `rpow_ne_top_of_nonneg` if `x = 0`.
 @[aesop (rule_sets := [finiteness]) unsafe apply]
 theorem rpow_ne_top_of_nonneg' {y : ℝ} {x : ℝ≥0∞} (hx : 0 < x) (hx' : x ≠ ⊤) : x ^ y ≠ ⊤ :=
   fun h ↦ by simp [rpow_eq_top_iff, hx.ne', hx'] at h

--- a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
@@ -561,34 +561,18 @@ theorem rpow_eq_top_of_nonneg (x : ℝ≥0∞) {y : ℝ} (hy0 : 0 ≤ y) : x ^ y
     exact h.right hy0
   · exact h.left
 
--- This is an unsafe rule since we want to try `rpow_ne_top_of_nonneg'` if `y < 0`.
+-- This is an unsafe rule since we want to try `rpow_ne_top_of_ne_zero` if `y < 0`.
 @[aesop (rule_sets := [finiteness]) unsafe apply]
 theorem rpow_ne_top_of_nonneg {x : ℝ≥0∞} {y : ℝ} (hy0 : 0 ≤ y) (h : x ≠ ⊤) : x ^ y ≠ ⊤ :=
   mt (ENNReal.rpow_eq_top_of_nonneg x hy0) h
 
--- This is an unsafe rule since we want to try `rpow_ne_top_of_nonneg` if `x = 0`.
-@[aesop (rule_sets := [finiteness]) unsafe apply]
-theorem rpow_ne_top_of_nonneg' {y : ℝ} {x : ℝ≥0∞} (hx : 0 < x) (hx' : x ≠ ⊤) : x ^ y ≠ ⊤ :=
-  fun h ↦ by simp [rpow_eq_top_iff, hx.ne', hx'] at h
-
 theorem rpow_lt_top_of_nonneg {x : ℝ≥0∞} {y : ℝ} (hy0 : 0 ≤ y) (h : x ≠ ⊤) : x ^ y < ⊤ :=
   lt_top_iff_ne_top.mpr (ENNReal.rpow_ne_top_of_nonneg hy0 h)
 
-lemma rpow_ne_top {x : ℝ≥0∞} {y : ℝ} (h : x ≠ 0 ∨ 0 ≤ y) (h' : x ≠ ∞ ∨ y ≤ 0) : x ^ y ≠ ⊤ := by
-  by_contra h
-  rw [rpow_eq_top_iff (x := x) (y := y)] at h
-  obtain (h1 | h1) := h
-  · obtain (h | h) := h
-    · exact h h1.1
-    · linarith
-  · obtain (h' | h') := h'
-    · exact h' h1.1
-    · linarith
-
+-- This is an unsafe rule since we want to try `rpow_ne_top_of_nonneg` if `x = 0`.
 @[aesop (rule_sets := [finiteness]) unsafe apply]
-lemma rpow_ne_top_of_ne_zero {x : ℝ≥0∞} {y : ℝ} (hx : x ≠ 0) (hx' : x ≠ ⊤) : x ^ y ≠ ⊤ := by
-  apply rpow_ne_top
-  all_goals simp [hx, hx']
+theorem rpow_ne_top_of_ne_zero {x : ℝ≥0∞} {y : ℝ} (hx : x ≠ 0) (hx' : x ≠ ⊤) : x ^ y ≠ ⊤ := by
+  simp [rpow_eq_top_iff, hx, hx']
 
 theorem rpow_add {x : ℝ≥0∞} (y z : ℝ) (hx : x ≠ 0) (h'x : x ≠ ⊤) : x ^ (y + z) = x ^ y * x ^ z := by
   cases x with

--- a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
@@ -561,11 +561,23 @@ theorem rpow_eq_top_of_nonneg (x : ℝ≥0∞) {y : ℝ} (hy0 : 0 ≤ y) : x ^ y
     exact h.right hy0
   · exact h.left
 
+-- This is an unsafe rule since we want to try `rpow_pos` if x = 0.
+@[aesop (rule_sets := [finiteness]) unsafe apply]
 theorem rpow_ne_top_of_nonneg {x : ℝ≥0∞} {y : ℝ} (hy0 : 0 ≤ y) (h : x ≠ ⊤) : x ^ y ≠ ⊤ :=
   mt (ENNReal.rpow_eq_top_of_nonneg x hy0) h
 
 theorem rpow_lt_top_of_nonneg {x : ℝ≥0∞} {y : ℝ} (hy0 : 0 ≤ y) (h : x ≠ ⊤) : x ^ y < ⊤ :=
   lt_top_iff_ne_top.mpr (ENNReal.rpow_ne_top_of_nonneg hy0 h)
+
+lemma rpow_ne_top {x : ℝ≥0∞} {y : ℝ} : ¬(x = 0 ∧ y < 0 ∨ x = ⊤ ∧ 0 < y) → x ^ y ≠ ⊤ := by
+  contrapose
+  rw [← rpow_eq_top_iff (x := x) (y := y)]
+  simp
+
+@[aesop (rule_sets := [finiteness]) unsafe apply]
+lemma rpow_ne_top_of_pos {x : ℝ≥0∞} {y : ℝ} (hx : x ≠ 0) (hx' : x ≠ ⊤) : x ^ y ≠ ⊤ := by
+  apply ENNReal.rpow_ne_top
+  simp [hx, hx']
 
 theorem rpow_add {x : ℝ≥0∞} (y z : ℝ) (hx : x ≠ 0) (h'x : x ≠ ⊤) : x ^ (y + z) = x ^ y * x ^ z := by
   cases x with
@@ -812,6 +824,8 @@ theorem rpow_pos_of_nonneg {p : ℝ} {x : ℝ≥0∞} (hx_pos : 0 < x) (hp_nonne
     rw [← zero_rpow_of_pos hp_pos]
     exact rpow_lt_rpow hx_pos hp_pos
 
+-- This is an unsafe rule since we want to try `rpow_ne_top_of_nonneg` if x = 0.
+@[aesop (rule_sets := [finiteness]) unsafe apply]
 theorem rpow_pos {p : ℝ} {x : ℝ≥0∞} (hx_pos : 0 < x) (hx_ne_top : x ≠ ⊤) : 0 < x ^ p := by
   rcases lt_or_le 0 p with hp_pos | hp_nonpos
   · exact rpow_pos_of_nonneg hx_pos (le_of_lt hp_pos)

--- a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
@@ -561,23 +561,34 @@ theorem rpow_eq_top_of_nonneg (x : ℝ≥0∞) {y : ℝ} (hy0 : 0 ≤ y) : x ^ y
     exact h.right hy0
   · exact h.left
 
--- This is an unsafe rule since we want to try `rpow_pos` if x = 0.
+-- This is an unsafe rule since we want to try `rpow_ne_top_of_nonneg'` if `y < 0`.
 @[aesop (rule_sets := [finiteness]) unsafe apply]
 theorem rpow_ne_top_of_nonneg {x : ℝ≥0∞} {y : ℝ} (hy0 : 0 ≤ y) (h : x ≠ ⊤) : x ^ y ≠ ⊤ :=
   mt (ENNReal.rpow_eq_top_of_nonneg x hy0) h
 
+-- This is an unsafe rule since we want to try `rpow_ne_top_of_nonneg'` if `x = 0`.
+@[aesop (rule_sets := [finiteness]) unsafe apply]
+theorem rpow_ne_top_of_nonneg' {y : ℝ} {x : ℝ≥0∞} (hx : 0 < x) (hx' : x ≠ ⊤) : x ^ y ≠ ⊤ :=
+  fun h ↦ by simp [rpow_eq_top_iff, hx.ne', hx'] at h
+
 theorem rpow_lt_top_of_nonneg {x : ℝ≥0∞} {y : ℝ} (hy0 : 0 ≤ y) (h : x ≠ ⊤) : x ^ y < ⊤ :=
   lt_top_iff_ne_top.mpr (ENNReal.rpow_ne_top_of_nonneg hy0 h)
 
-lemma rpow_ne_top {x : ℝ≥0∞} {y : ℝ} : ¬(x = 0 ∧ y < 0 ∨ x = ⊤ ∧ 0 < y) → x ^ y ≠ ⊤ := by
-  contrapose
-  rw [← rpow_eq_top_iff (x := x) (y := y)]
-  simp
+lemma rpow_ne_top {x : ℝ≥0∞} {y : ℝ} (h : x ≠ 0 ∨ 0 ≤ y) (h' : x ≠ ∞ ∨ y ≤ 0) : x ^ y ≠ ⊤ := by
+  by_contra h
+  rw [rpow_eq_top_iff (x := x) (y := y)] at h
+  obtain (h1 | h1) := h
+  · obtain (h | h) := h
+    · exact h h1.1
+    · linarith
+  · obtain (h' | h') := h'
+    · exact h' h1.1
+    · linarith
 
 @[aesop (rule_sets := [finiteness]) unsafe apply]
-lemma rpow_ne_top_of_pos {x : ℝ≥0∞} {y : ℝ} (hx : x ≠ 0) (hx' : x ≠ ⊤) : x ^ y ≠ ⊤ := by
-  apply ENNReal.rpow_ne_top
-  simp [hx, hx']
+lemma rpow_ne_top_of_ne_zero {x : ℝ≥0∞} {y : ℝ} (hx : x ≠ 0) (hx' : x ≠ ⊤) : x ^ y ≠ ⊤ := by
+  apply rpow_ne_top
+  all_goals simp [hx, hx']
 
 theorem rpow_add {x : ℝ≥0∞} (y z : ℝ) (hx : x ≠ 0) (h'x : x ≠ ⊤) : x ^ (y + z) = x ^ y * x ^ z := by
   cases x with
@@ -824,8 +835,6 @@ theorem rpow_pos_of_nonneg {p : ℝ} {x : ℝ≥0∞} (hx_pos : 0 < x) (hp_nonne
     rw [← zero_rpow_of_pos hp_pos]
     exact rpow_lt_rpow hx_pos hp_pos
 
--- This is an unsafe rule since we want to try `rpow_ne_top_of_nonneg` if x = 0.
-@[aesop (rule_sets := [finiteness]) unsafe apply]
 theorem rpow_pos {p : ℝ} {x : ℝ≥0∞} (hx_pos : 0 < x) (hx_ne_top : x ≠ ⊤) : 0 < x ^ p := by
   rcases lt_or_le 0 p with hp_pos | hp_nonpos
   · exact rpow_pos_of_nonneg hx_pos (le_of_lt hp_pos)

--- a/Mathlib/Data/ENNReal/Inv.lean
+++ b/Mathlib/Data/ENNReal/Inv.lean
@@ -196,6 +196,9 @@ theorem inv_lt_top {x : ℝ≥0∞} : x⁻¹ < ∞ ↔ 0 < x := by
 theorem div_lt_top {x y : ℝ≥0∞} (h1 : x ≠ ∞) (h2 : y ≠ 0) : x / y < ∞ :=
   mul_lt_top h1.lt_top (inv_ne_top.mpr h2).lt_top
 
+@[aesop (rule_sets := [finiteness]) safe apply]
+theorem div_ne_top {x y : ℝ≥0∞} (h1 : x ≠ ∞) (h2 : y ≠ 0) : x / y ≠ ∞ := (div_lt_top h1 h2).ne
+
 @[simp]
 protected theorem inv_eq_zero : a⁻¹ = 0 ↔ a = ∞ :=
   inv_top ▸ inv_inj

--- a/Mathlib/Data/ENNReal/Inv.lean
+++ b/Mathlib/Data/ENNReal/Inv.lean
@@ -639,7 +639,7 @@ theorem zpow_lt_top (ha : a ≠ 0) (h'a : a ≠ ∞) (n : ℤ) : a ^ n < ∞ := 
   · simpa using ENNReal.pow_lt_top h'a.lt_top
   · simp only [ENNReal.pow_pos ha.bot_lt, zpow_negSucc, inv_lt_top]
 
-@[aesop (rule_sets := [finiteness]) safe apply]
+@[aesop (rule_sets := [finiteness]) unsafe apply]
 lemma zpow_ne_top {a : ℝ≥0∞} (ha : a ≠ 0) (h'a : a ≠ ∞) (n : ℤ) : a ^ n ≠ ∞ :=
   (ENNReal.zpow_lt_top ha h'a n).ne
 

--- a/Mathlib/Data/ENNReal/Inv.lean
+++ b/Mathlib/Data/ENNReal/Inv.lean
@@ -373,10 +373,12 @@ theorem div_le_of_le_mul' (h : a ≤ b * c) : a / b ≤ c :=
 @[simp] protected lemma mul_inv_le_one (a : ℝ≥0∞) : a * a⁻¹ ≤ 1 := ENNReal.div_self_le_one
 @[simp] protected lemma inv_mul_le_one (a : ℝ≥0∞) : a⁻¹ * a ≤ 1 := by simp [mul_comm]
 
-@[simp] lemma mul_inv_ne_top (a : ℝ≥0∞) : a * a⁻¹ ≠ ⊤ :=
+@[aesop (rule_sets := [finiteness]) safe apply, simp]
+lemma mul_inv_ne_top (a : ℝ≥0∞) : a * a⁻¹ ≠ ⊤ :=
   ne_top_of_le_ne_top one_ne_top a.mul_inv_le_one
 
-@[simp] lemma inv_mul_ne_top (a : ℝ≥0∞) : a⁻¹ * a ≠ ⊤ := by simp [mul_comm]
+@[aesop (rule_sets := [finiteness]) safe apply, simp]
+lemma inv_mul_ne_top (a : ℝ≥0∞) : a⁻¹ * a ≠ ⊤ := by simp [mul_comm]
 
 theorem mul_le_of_le_div (h : a ≤ b / c) : a * c ≤ b := by
   rw [← inv_inv c]
@@ -636,6 +638,10 @@ theorem zpow_lt_top (ha : a ≠ 0) (h'a : a ≠ ∞) (n : ℤ) : a ^ n < ∞ := 
   cases n
   · simpa using ENNReal.pow_lt_top h'a.lt_top
   · simp only [ENNReal.pow_pos ha.bot_lt, zpow_negSucc, inv_lt_top]
+
+@[aesop (rule_sets := [finiteness]) safe apply]
+lemma zpow_ne_top {a : ℝ≥0∞} (ha : a ≠ 0) (h'a : a ≠ ∞) (n : ℤ) : a ^ n ≠ ∞ :=
+  (ENNReal.zpow_lt_top ha h'a n).ne
 
 theorem exists_mem_Ico_zpow {x y : ℝ≥0∞} (hx : x ≠ 0) (h'x : x ≠ ∞) (hy : 1 < y) (h'y : y ≠ ⊤) :
     ∃ n : ℤ, x ∈ Ico (y ^ n) (y ^ (n + 1)) := by

--- a/Mathlib/Data/ENNReal/Operations.lean
+++ b/Mathlib/Data/ENNReal/Operations.lean
@@ -232,6 +232,7 @@ lemma eq_top_of_pow (n : ℕ) (ha : a ^ n = ∞) : a = ∞ := WithTop.eq_top_of_
 
 @[deprecated (since := "2025-04-24")] alias pow_eq_top := eq_top_of_pow
 
+@[aesop (rule_sets := [finiteness]) safe apply]
 lemma pow_ne_top (ha : a ≠ ∞) : a ^ n ≠ ∞ := WithTop.pow_ne_top ha
 lemma pow_lt_top (ha : a < ∞) : a ^ n < ∞ := WithTop.pow_lt_top ha
 

--- a/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
@@ -337,6 +337,11 @@ theorem measure_ball_lt_top [PseudoMetricSpace α] [ProperSpace α] {μ : Measur
     [IsFiniteMeasureOnCompacts μ] {x : α} {r : ℝ} : μ (Metric.ball x r) < ∞ :=
   Metric.isBounded_ball.measure_lt_top
 
+@[aesop (rule_sets := [finiteness]) safe apply]
+theorem measure_ball_ne_top [PseudoMetricSpace α] [ProperSpace α] {μ : Measure α}
+    [IsFiniteMeasureOnCompacts μ] {x : α} {r : ℝ} : μ (Metric.ball x r) ≠ ∞ :=
+  measure_ball_lt_top.ne
+
 protected theorem IsFiniteMeasureOnCompacts.smul [TopologicalSpace α] (μ : Measure α)
     [IsFiniteMeasureOnCompacts μ] {c : ℝ≥0∞} (hc : c ≠ ∞) : IsFiniteMeasureOnCompacts (c • μ) :=
   ⟨fun _K hK => ENNReal.mul_lt_top hc.lt_top hK.measure_lt_top⟩

--- a/Mathlib/Order/BoundedOrder/Lattice.lean
+++ b/Mathlib/Order/BoundedOrder/Lattice.lean
@@ -154,6 +154,12 @@ theorem min_eq_bot [OrderBot α] {a b : α} : min a b = ⊥ ↔ a = ⊥ ∨ b = 
 theorem max_eq_top [OrderTop α] {a b : α} : max a b = ⊤ ↔ a = ⊤ ∨ b = ⊤ :=
   @min_eq_bot αᵒᵈ _ _ a b
 
+@[aesop (rule_sets := [finiteness]) safe apply]
+lemma max_ne_top [OrderTop α] {a b : α} (ha : a ≠ ⊤) (hb : b ≠ ⊤) : max a b ≠ ⊤ := by
+  by_contra h
+  obtain (h | h) := max_eq_top.mp h
+  all_goals simp_all
+
 end LinearOrder
 
 /-! ### Induction on `WellFoundedGT` and `WellFoundedLT` -/

--- a/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
@@ -290,7 +290,7 @@ theorem edist_lt_top {α : Type*} [PseudoMetricSpace α] (x y : α) : edist x y 
   (edist_dist x y).symm ▸ ENNReal.ofReal_lt_top
 
 /-- In a pseudometric space, the extended distance is always finite -/
-@[aesop (rule_sets := [finiteness]) unsafe apply]
+@[aesop (rule_sets := [finiteness]) safe apply]
 theorem edist_ne_top (x y : α) : edist x y ≠ ⊤ :=
   (edist_lt_top x y).ne
 

--- a/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
@@ -290,6 +290,7 @@ theorem edist_lt_top {α : Type*} [PseudoMetricSpace α] (x y : α) : edist x y 
   (edist_dist x y).symm ▸ ENNReal.ofReal_lt_top
 
 /-- In a pseudometric space, the extended distance is always finite -/
+@[aesop (rule_sets := [finiteness]) unsafe apply]
 theorem edist_ne_top (x y : α) : edist x y ≠ ⊤ :=
   (edist_lt_top x y).ne
 

--- a/MathlibTest/finiteness.lean
+++ b/MathlibTest/finiteness.lean
@@ -1,9 +1,10 @@
-import Mathlib.Data.ENNReal.Real
+import Mathlib.Analysis.SpecialFunctions.Pow.NNReal
+import Mathlib.Data.ENNReal.Inv
 import Mathlib.MeasureTheory.Measure.Typeclasses.Finite
 import Mathlib.Tactic.Finiteness
 
-open MeasureTheory
-open scoped ENNReal
+open MeasureTheory Set
+open scoped ENNReal NNReal
 
 example : (1 : ℝ≥0∞) < ∞ := by finiteness
 example : (3 : ℝ≥0∞) ≠ ∞ := by finiteness
@@ -12,6 +13,34 @@ example (a : ℝ) (b : ℕ) : ENNReal.ofReal a + b < ∞ := by finiteness
 
 example {a : ℝ≥0∞} (ha : a ≠ ∞) : a + 3 < ∞ := by finiteness
 example {a : ℝ≥0∞} (ha : a < ∞) : a + 3 < ∞ := by finiteness
+
+example {a : ℝ≥0∞} (ha : a ≠ ∞) : a ^ 10 ≠ ∞ := by finiteness
+example {a : ℝ≥0∞} (ha : a ≠ ∞) : a / 10 + 5 ≠ ∞ := by finiteness
+example {a b : ℝ≥0∞} (ha : a ≠ ∞) (hb : b ≠ 0) : a / b ≠ ∞ := by finiteness
+example {a : ℝ≥0∞} {b : ℝ≥0} (ha : a ≠ ∞) (hb : b ≠ 0) : a / b ≠ ∞ := by finiteness
+example {a b : ℝ≥0∞} (ha : a ≠ ∞) : a / (b + 5) ≠ ∞ := by
+  -- finiteness cannot infer this on its own (yet?)
+  have : b + 5 ≠ 0 :=
+    -- XXX: after #25092, this can become `by positivity`
+    (Right.add_pos_of_nonneg_of_pos (by positivity) (by norm_num)).ne'
+  finiteness
+
+example {a b : ℝ≥0∞} (ha : a ≠ ∞) (hb : b ≠ ∞) : a * b ≠ ∞ := by finiteness
+example {a : ℝ≥0∞} (ha : 0 < a) : a⁻¹ ≠ ∞ := by finiteness
+-- not supported yet
+-- example {t a : ℝ≥0∞} (ht : t ∈ Ioo 0 1) (this : a ≠ 0) : t * a ≠ ∞ := by finiteness
+-- example {t a : ℝ≥0∞} (ht : t ∈ Ioo 0 1) (this : a ≠ 0) : a * t ≠ ∞ := by finiteness
+
+example {a : ℝ≥0∞} (ha : a ≠ ∞) : a ^ 10 ≠ ∞ := by finiteness
+-- no extension for integer powers
+-- example {a : ℝ≥0∞} (ha : a ≠ ∞) (ha' : a ≠ 0): a ^ (10 : ℤ) ≠ ∞ := by finiteness
+example {a : ℝ≥0∞} (ha : a ≠ ∞) : a ^ (10 : ℝ) ≠ ∞ := by finiteness
+example {a : ℝ} : (10 : ℝ≥0∞) ^ a ≠ ∞ := by finiteness
+example {a : ℝ≥0∞} {t : ℝ} (ha : a ≠ 0) (ha : a ≠ ∞) : a ^ t ≠ ∞ := by finiteness
+
+example {a : ℝ≥0∞} (ha : a ≠ ∞) : max a 37 ≠ ∞ := by finiteness
+example {a b : ℝ≥0∞} (ha : a ≠ ∞) (hb : b ≠ ∞) : max a b < ∞ := by finiteness
+
 /--
 Test that `finiteness_nonterminal` makes progress but does not fail on not
 closing the goal.

--- a/MathlibTest/finiteness.lean
+++ b/MathlibTest/finiteness.lean
@@ -18,12 +18,7 @@ example {a : ℝ≥0∞} (ha : a ≠ ∞) : a ^ 10 ≠ ∞ := by finiteness
 example {a : ℝ≥0∞} (ha : a ≠ ∞) : a / 10 + 5 ≠ ∞ := by finiteness
 example {a b : ℝ≥0∞} (ha : a ≠ ∞) (hb : b ≠ 0) : a / b ≠ ∞ := by finiteness
 example {a : ℝ≥0∞} {b : ℝ≥0} (ha : a ≠ ∞) (hb : b ≠ 0) : a / b ≠ ∞ := by finiteness
-example {a b : ℝ≥0∞} (ha : a ≠ ∞) : a / (b + 5) ≠ ∞ := by
-  -- finiteness cannot infer this on its own (yet?)
-  have : b + 5 ≠ 0 :=
-    -- XXX: after #25092, this can become `by positivity`
-    (Right.add_pos_of_nonneg_of_pos (by positivity) (by norm_num)).ne'
-  finiteness
+example {a b : ℝ≥0∞} (ha : a ≠ ∞) : a / (b + 5) ≠ ∞ := by finiteness
 
 example {a b : ℝ≥0∞} (ha : a ≠ ∞) (hb : b ≠ ∞) : a * b ≠ ∞ := by finiteness
 example {a : ℝ≥0∞} (ha : 0 < a) : a⁻¹ ≠ ∞ := by finiteness

--- a/MathlibTest/finiteness.lean
+++ b/MathlibTest/finiteness.lean
@@ -32,11 +32,13 @@ example {a : ℝ≥0∞} (ha : 0 < a) : a⁻¹ ≠ ∞ := by finiteness
 -- example {t a : ℝ≥0∞} (ht : t ∈ Ioo 0 1) (this : a ≠ 0) : a * t ≠ ∞ := by finiteness
 
 example {a : ℝ≥0∞} (ha : a ≠ ∞) : a ^ 10 ≠ ∞ := by finiteness
--- no extension for integer powers
--- example {a : ℝ≥0∞} (ha : a ≠ ∞) (ha' : a ≠ 0): a ^ (10 : ℤ) ≠ ∞ := by finiteness
+example {a : ℝ≥0∞} (ha : a ≠ ∞) : a ^ (10 : ℤ) ≠ ∞ := by finiteness
 example {a : ℝ≥0∞} (ha : a ≠ ∞) : a ^ (10 : ℝ) ≠ ∞ := by finiteness
 example {a : ℝ} : (10 : ℝ≥0∞) ^ a ≠ ∞ := by finiteness
 example {a : ℝ≥0∞} {t : ℝ} (ha : a ≠ 0) (ha : a ≠ ∞) : a ^ t ≠ ∞ := by finiteness
+
+example {a : ℝ≥0∞} : a * a⁻¹ ≠ ∞ := by finiteness
+example {a : ℝ≥0∞} : 2 * a⁻¹ * a ≠ ∞ := by finiteness
 
 example {a : ℝ≥0∞} (ha : a ≠ ∞) : max a 37 ≠ ∞ := by finiteness
 example {a b : ℝ≥0∞} (ha : a ≠ ∞) (hb : b ≠ ∞) : max a b < ∞ := by finiteness

--- a/MathlibTest/finiteness.lean
+++ b/MathlibTest/finiteness.lean
@@ -32,13 +32,15 @@ example {a : ℝ≥0∞} (ha : 0 < a) : a⁻¹ ≠ ∞ := by finiteness
 -- example {t a : ℝ≥0∞} (ht : t ∈ Ioo 0 1) (this : a ≠ 0) : a * t ≠ ∞ := by finiteness
 
 example {a : ℝ≥0∞} (ha : a ≠ ∞) : a ^ 10 ≠ ∞ := by finiteness
-example {a : ℝ≥0∞} (ha : a ≠ ∞) : a ^ (10 : ℤ) ≠ ∞ := by finiteness
+example {a : ℝ≥0∞} (ha : a ≠ ∞) (ha' : a ≠ 0) : a ^ (10 : ℤ) ≠ ∞ := by finiteness
 example {a : ℝ≥0∞} (ha : a ≠ ∞) : a ^ (10 : ℝ) ≠ ∞ := by finiteness
 example {a : ℝ} : (10 : ℝ≥0∞) ^ a ≠ ∞ := by finiteness
 example {a : ℝ≥0∞} {t : ℝ} (ha : a ≠ 0) (ha : a ≠ ∞) : a ^ t ≠ ∞ := by finiteness
 
 example {a : ℝ≥0∞} : a * a⁻¹ ≠ ∞ := by finiteness
-example {a : ℝ≥0∞} : 2 * a⁻¹ * a ≠ ∞ := by finiteness
+example {a : ℝ≥0∞} : a⁻¹ * a ≠ ∞ := by finiteness
+example {a : ℝ≥0∞} : 2 * (a⁻¹ * a) ≠ ∞ := by finiteness
+-- fails: example {a : ℝ≥0∞} : 2 * a⁻¹ * a ≠ ∞ := by finiteness
 
 example {a : ℝ≥0∞} (ha : a ≠ ∞) : max a 37 ≠ ∞ := by finiteness
 example {a b : ℝ≥0∞} (ha : a ≠ ∞) (hb : b ≠ ∞) : max a b < ∞ := by finiteness
@@ -53,5 +55,5 @@ example (a : ℝ) : (ENNReal.ofReal (1 + a ^ 2))⁻¹ < ∞ := by finiteness
 
 example {α : Type*} (f : α → ℕ) : ∀ i, (f i : ℝ≥0∞) ≠ ∞ := by finiteness
 
-example {_ : MeasurableSpace α} (μ : Measure α) [IsFiniteMeasure μ] (s : Set α) : μ s ≠ ∞ := by
+example {α} {_ : MeasurableSpace α} (μ : Measure α) [IsFiniteMeasure μ] (s : Set α) : μ s ≠ ∞ := by
   finiteness

--- a/MathlibTest/finiteness.lean
+++ b/MathlibTest/finiteness.lean
@@ -34,13 +34,15 @@ example {a : ℝ≥0∞} (ha : 0 < a) : a⁻¹ ≠ ∞ := by finiteness
 example {a : ℝ≥0∞} (ha : a ≠ ∞) : a ^ 10 ≠ ∞ := by finiteness
 example {a : ℝ≥0∞} (ha : a ≠ ∞) (ha' : a ≠ 0) : a ^ (10 : ℤ) ≠ ∞ := by finiteness
 example {a : ℝ≥0∞} (ha : a ≠ ∞) : a ^ (10 : ℝ) ≠ ∞ := by finiteness
+example : (0 : ℝ≥0∞) ^ (10 : ℝ) ≠ ∞ := by finiteness
+example {a : ℝ≥0∞} (ha : a ≠ 0) (ha' : a ≠ ∞) : a ^ (-10 : ℝ) ≠ ∞ := by finiteness
 example {a : ℝ} : (10 : ℝ≥0∞) ^ a ≠ ∞ := by finiteness
 example {a : ℝ≥0∞} {t : ℝ} (ha : a ≠ 0) (ha : a ≠ ∞) : a ^ t ≠ ∞ := by finiteness
 
 example {a : ℝ≥0∞} : a * a⁻¹ ≠ ∞ := by finiteness
 example {a : ℝ≥0∞} : a⁻¹ * a ≠ ∞ := by finiteness
 example {a : ℝ≥0∞} : 2 * (a⁻¹ * a) ≠ ∞ := by finiteness
--- fails: example {a : ℝ≥0∞} : 2 * a⁻¹ * a ≠ ∞ := by finiteness
+example {a : ℝ≥0∞} : 2 * a⁻¹ * a ≠ ∞ := by rw [mul_assoc]; finiteness
 
 example {a : ℝ≥0∞} (ha : a ≠ ∞) : max a 37 ≠ ∞ := by finiteness
 example {a b : ℝ≥0∞} (ha : a ≠ ∞) (hb : b ≠ ∞) : max a b < ∞ := by finiteness


### PR DESCRIPTION
Tag a few more lemmas with finiteness, and add a few more lemmas for it.
Now, `finiteness` should handle (basic cases of) ENNReal division, powers and maximum.
Also tag `edist_ne_top` and `measure_ball_ne_top`, to enable further use of finiteness.

From the Carleson project.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
