### PR TITLE
[Merged by Bors] - chore(Tactic/Positivity): generalise positivity extension for addition

### DIFF
--- a/Mathlib/Tactic/Positivity/Basic.lean
+++ b/Mathlib/Tactic/Positivity/Basic.lean
@@ -162,11 +162,11 @@ such that `positivity` successfully recognises both `a` and `b`. -/
     let _a ← synthInstanceQ q(AddLeftStrictMono $α)
     pure (.positive q(add_pos $pa $pb))
   | .positive pa, .nonnegative pb =>
-    let _a ← synthInstanceQ q(AddRightStrictMono $α)
-    pure (.positive q(lt_add_of_pos_of_le $pa $pb))
+    let _a ← synthInstanceQ q(AddLeftMono $α)
+    pure (.positive q(add_pos_of_pos_of_nonneg $pa $pb))
   | .nonnegative pa, .positive pb =>
-    let _a ← synthInstanceQ q(AddLeftStrictMono $α)
-    pure (.positive q(lt_add_of_le_of_pos $pa $pb))
+    let _a ← synthInstanceQ q(AddRightMono $α)
+    pure (.positive q(Right.add_pos_of_nonneg_of_pos $pa $pb))
   | .nonnegative pa, .nonnegative pb =>
     let _a ← synthInstanceQ q(AddLeftMono $α)
     pure (.nonnegative q(add_nonneg $pa $pb))

--- a/MathlibTest/positivity.lean
+++ b/MathlibTest/positivity.lean
@@ -1,6 +1,7 @@
 import Mathlib.Tactic.Positivity
 import Mathlib.Data.Complex.Trigonometric
 import Mathlib.Data.Real.Sqrt
+import Mathlib.Data.ENNReal.Basic
 import Mathlib.Analysis.Normed.Group.Basic
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
@@ -205,6 +206,20 @@ end
 example (a : ℤ) : 0 ≤ a⁺ := by positivity
 example (a : ℤ) (ha : 0 < a) : 0 < a⁺ := by positivity
 example (a : ℤ) : 0 ≤ a⁻ := by positivity
+
+section
+
+open scoped ENNReal
+variable {a b : ℝ≥0∞}
+
+example : 0 ≤ a := by positivity
+example : 0 ≤ a + b := by positivity
+example (ha : a ≠ 0) : 0 < a + b := by positivity
+example : 0 < a + 5 := by positivity
+example : 0 < 2 * a + 3 := by positivity
+example (ha : 0 < a) : 0 < a + b := by positivity
+
+end
 
 /-! ### Exponentiation -/
 

--- a/MathlibTest/positivity.lean
+++ b/MathlibTest/positivity.lean
@@ -213,13 +213,33 @@ open scoped ENNReal
 variable {a b : ℝ≥0∞}
 
 example : 0 ≤ a := by positivity
+example (ha : a ≠ 0) : 0 < a := by positivity
 example : 0 ≤ a + b := by positivity
 example (ha : a ≠ 0) : 0 < a + b := by positivity
 example : 0 < a + 5 := by positivity
 example : 0 < 2 * a + 3 := by positivity
 example (ha : 0 < a) : 0 < a + b := by positivity
 
+variable {a b : EReal}
+
+private axiom test_sorry : ∀ {α}, α
+
+example (ha : 0 ≤ a) (hb : 0 ≤ b) : 0 ≤ a + b := by positivity
+example (ha : 0 ≤ a) (hb : 0 < b) : 0 < a + b := by positivity
+example (ha : 0 < a) (hb : 0 ≤ b) : 0 < a + b := by positivity
+-- Missing positivity extension: literals in EReal
+example : 0 < (5 : EReal) := by
+  fail_if_success positivity
+  exact test_sorry
+example (_ha : 0 ≤ a) : 0 < a + 5 := by
+  fail_if_success positivity
+  exact test_sorry
+example (_ha : 0 ≤ a) : 0 < 2 * a + 3 := by
+  fail_if_success positivity
+  exact test_sorry
+
 end
+
 
 /-! ### Exponentiation -/
 

--- a/MathlibTest/positivity.lean
+++ b/MathlibTest/positivity.lean
@@ -239,8 +239,6 @@ example (_ha : 0 ≤ a) : 0 < 2 * a + 3 := by
   exact test_sorry
 
 end
-
-
 /-! ### Exponentiation -/
 
 example [Semiring α] [PartialOrder α] [IsOrderedRing α] [Nontrivial α]

--- a/MathlibTest/positivity.lean
+++ b/MathlibTest/positivity.lean
@@ -239,6 +239,7 @@ example (_ha : 0 ≤ a) : 0 < 2 * a + 3 := by
   exact test_sorry
 
 end
+
 /-! ### Exponentiation -/
 
 example [Semiring α] [PartialOrder α] [IsOrderedRing α] [Nontrivial α]


### PR DESCRIPTION
to also handle positivity (or non-negativity) in semirings with monotone, but not strictly monotone addition. In particular, ENNReal (and EReal) are supported now. This was [discussed on zulip](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/.22Missing.20Tactics.22.20list/near/519643888).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
