### PR TITLE
[Merged by Bors] - chore(*): use `gcongr` and `omega`

### DIFF
--- a/Mathlib/Algebra/Order/Group/Int/Sum.lean
+++ b/Mathlib/Algebra/Order/Group/Int/Sum.lean
@@ -26,7 +26,8 @@ lemma sum_le_sum_Ioc {s : Finset ℤ} {c : ℤ} (hs : ∀ x ∈ s, x ≤ c) :
   calc
     _ ≤ ∑ x ∈ s ∩ r, x + #(s \ r) • (c - #s) := by
       rw [← sum_inter_add_sum_diff s r _]
-      refine add_le_add_left (sum_le_card_nsmul _ _ _ fun x mx ↦ ?_) _
+      gcongr
+      refine sum_le_card_nsmul _ _ _ fun x mx ↦ ?_
       rw [mem_sdiff, mem_Ioc, not_and'] at mx
       have := mx.2 (hs _ mx.1); omega
     _ = ∑ x ∈ r ∩ s, x + #(r \ s) • (c - #s) := by
@@ -34,7 +35,8 @@ lemma sum_le_sum_Ioc {s : Finset ℤ} {c : ℤ} (hs : ∀ x ∈ s, x ≤ c) :
       rw [Int.card_Ioc, sub_sub_cancel, Int.toNat_natCast]
     _ ≤ _ := by
       rw [← sum_inter_add_sum_diff r s _]
-      refine add_le_add_left (card_nsmul_le_sum _ _ _ fun x mx ↦ ?_) _
+      gcongr
+      refine card_nsmul_le_sum _ _ _ fun x mx ↦ ?_
       rw [mem_sdiff, mem_Ioc] at mx; exact mx.1.1.le
 
 /-- Sharp upper bound for the sum of a finset of integers that is bounded above, `range` version. -/

--- a/Mathlib/Analysis/Convex/Piecewise.lean
+++ b/Mathlib/Analysis/Convex/Piecewise.lean
@@ -49,36 +49,36 @@ theorem convexOn_univ_piecewise_Iic_of_antitoneOn_Iic_monotoneOn_Ici
       Set.piecewise_eq_of_not_mem (Set.Iic e) f g (Set.not_mem_Iic.mpr hy)]
     by_cases hc : a • x + b • y ≤ e <;> push_neg at hc
     · rw [Set.piecewise_eq_of_mem (Set.Iic e) f g hc]
-      have hc' : a • x + b • e ≤ a • x + b • y :=
-        add_le_add_left (smul_le_smul_of_nonneg_left hy.le hb) (a • x)
+      have hc' : a • x + b • e ≤ a • x + b • y := by gcongr
       trans a • f x + b • f e
       · exact (h_anti (hc'.trans hc) hc hc').trans (hf.2 hx Set.right_mem_Iic ha hb hab)
-      · rw [add_le_add_iff_left, h_eq]
-        exact smul_le_smul_of_nonneg_left (h_mono Set.left_mem_Ici hy.le hy.le) hb
+      · rw [h_eq]
+        gcongr
+        exact h_mono Set.left_mem_Ici hy.le hy.le
     · rw [Set.piecewise_eq_of_not_mem (Set.Iic e) f g (Set.not_mem_Iic.mpr hc)]
-      have hc' : a • x + b • y ≤ a • e + b • y :=
-        add_le_add_right (smul_le_smul_of_nonneg_left hx ha) (b • y)
+      have hc' : a • x + b • y ≤ a • e + b • y := by gcongr
       trans a • g e + b • g y
       · exact (h_mono hc.le (hc.le.trans hc') hc').trans (hg.2 Set.left_mem_Ici hy.le ha hb hab)
-      · rw [add_le_add_iff_right, ← h_eq]
-        exact smul_le_smul_of_nonneg_left (h_anti hx Set.right_mem_Iic hx) ha
+      · rw [← h_eq]
+        gcongr
+        exact h_anti hx Set.right_mem_Iic hx
   · rw [Set.piecewise_eq_of_not_mem (Set.Iic e) f g (Set.not_mem_Iic.mpr hx),
       Set.piecewise_eq_of_mem (Set.Iic e) f g hy]
     by_cases hc : a • x + b • y ≤ e <;> push_neg at hc
     · rw [Set.piecewise_eq_of_mem (Set.Iic e) f g hc]
-      have hc' : a • e + b • y ≤ a • x + b • y :=
-        add_le_add_right (smul_le_smul_of_nonneg_left hx.le ha) (b • y)
+      have hc' : a • e + b • y ≤ a • x + b • y := by gcongr
       trans a • f e + b • f y
       · exact (h_anti (hc'.trans hc) hc hc').trans (hf.2 Set.right_mem_Iic hy ha hb hab)
-      · rw [add_le_add_iff_right, h_eq]
-        exact smul_le_smul_of_nonneg_left (h_mono Set.left_mem_Ici hx.le hx.le) ha
+      · rw [h_eq]
+        gcongr
+        exact h_mono Set.left_mem_Ici hx.le hx.le
     · rw [Set.piecewise_eq_of_not_mem (Set.Iic e) f g (Set.not_mem_Iic.mpr hc)]
-      have hc' : a • x + b • y ≤ a • x + b • e :=
-        add_le_add_left (smul_le_smul_of_nonneg_left hy hb) (a • x)
+      have hc' : a • x + b • y ≤ a • x + b • e := by gcongr
       trans a • g x + b • g e
       · exact (h_mono hc.le (hc.le.trans hc') hc').trans (hg.2 hx.le Set.left_mem_Ici ha hb hab)
-      · rw [add_le_add_iff_left, ← h_eq]
-        exact smul_le_smul_of_nonneg_left (h_anti hy Set.right_mem_Iic hy) hb
+      · rw [← h_eq]
+        gcongr
+        exact h_anti hy Set.right_mem_Iic hy
   · have hc : e < a • x + b • y :=
         (lt_min hx hy).trans_le (Convex.min_le_combo x y ha hb hab)
     rw [(Set.Iic e).piecewise_eq_of_not_mem f g (Set.not_mem_Iic.mpr hx),

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Uniform.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Uniform.lean
@@ -289,7 +289,7 @@ lemma IsEquipartition.card_interedges_sparsePairs_le' (hP : P.IsEquipartition)
     (_ : ℕ) ≤ _ := sum_le_card_nsmul P.parts.offDiag (fun i ↦ #i.1 * #i.2)
             ((#A / #P.parts + 1)^2 : ℕ) ?_
     _ ≤ (#P.parts * (#A / #P.parts) + #P.parts) ^ 2 := ?_
-    _ ≤ _ := Nat.pow_le_pow_left (add_le_add_right (Nat.mul_div_le _ _) _) _
+    _ ≤ _ := by gcongr; apply Nat.mul_div_le
   · simp only [Prod.forall, Finpartition.mk_mem_nonUniforms, and_imp, mem_offDiag, sq]
     rintro U V hU hV -
     exact_mod_cast Nat.mul_le_mul (hP.card_part_le_average_add_one hU)

--- a/Mathlib/Data/Bool/Count.lean
+++ b/Mathlib/Data/Bool/Count.lean
@@ -66,9 +66,9 @@ theorem count_not_le_count_add_one (hl : Chain' (· ≠ ·) l) (b : Bool) :
   · exact zero_le _
   obtain rfl | rfl : b = x ∨ b = !x := by simp only [Bool.eq_not_iff, em]
   · rw [count_cons_of_ne b.not_ne_self.symm, count_cons_self, hl.count_not, add_assoc]
-    exact add_le_add_left (Nat.mod_lt _ two_pos).le _
+    omega
   · rw [Bool.not_not, count_cons_self, count_cons_of_ne x.not_ne_self.symm, hl.count_not]
-    exact add_le_add_right (le_add_right le_rfl) _
+    omega
 
 theorem count_false_le_count_true_add_one (hl : Chain' (· ≠ ·) l) :
     count false l ≤ count true l + 1 :=


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)