### PR TITLE
[Merged by Bors] - chore: fix some defeq abuse in theorem statements around the `Id` monad

### DIFF
--- a/Mathlib/Algebra/Free.lean
+++ b/Mathlib/Algebra/Free.lean
@@ -669,7 +669,7 @@ instance : LawfulTraversable FreeSemigroup.{u} :=
           (fun x y ih1 ih2 ↦ by simp only [traverse_mul, functor_norm, ih1, ih2])
     traverse_eq_map_id := fun f x ↦
       FreeSemigroup.recOnMul x (fun _ ↦ rfl) fun x y ih1 ih2 ↦ by
-        rw [traverse_mul, ih1, ih2, map_mul', map_pure]; rfl }
+        rw [traverse_mul, ih1, ih2, map_mul', map_pure, seq_pure, map_pure] }
 
 end Category
 

--- a/Mathlib/Algebra/Free.lean
+++ b/Mathlib/Algebra/Free.lean
@@ -173,7 +173,7 @@ protected def recOnPure {C : FreeMagma α → Sort l} (x) (ih1 : ∀ x, C (pure 
   FreeMagma.recOnMul x ih1 ih2
 
 @[to_additive (attr := simp)]
-theorem map_pure (f : α → β) (x) : (f <$> pure x : FreeMagma β) = pure (f x) := rfl
+protected theorem map_pure (f : α → β) (x) : (f <$> pure x : FreeMagma β) = pure (f x) := rfl
 
 @[to_additive (attr := simp)]
 theorem map_mul' (f : α → β) (x y : FreeMagma α) : f <$> (x * y) = f <$> x * f <$> y := rfl
@@ -249,8 +249,7 @@ theorem traverse_mul' :
 @[to_additive (attr := simp)]
 theorem traverse_eq (x) : FreeMagma.traverse F x = traverse F x := rfl
 
--- This is not a simp lemma because the left-hand side is not in simp normal form.
-@[to_additive]
+@[to_additive (attr := deprecated "Use map_pure and seq_pure" (since := "2025-05-21"))]
 theorem mul_map_seq (x y : FreeMagma α) :
     ((· * ·) <$> x <*> y : Id (FreeMagma α)) = (x * y : FreeMagma α) := rfl
 
@@ -259,7 +258,7 @@ instance : LawfulTraversable FreeMagma.{u} :=
   { instLawfulMonad with
     id_traverse := fun x ↦
       FreeMagma.recOnPure x (fun _ ↦ rfl) fun x y ih1 ih2 ↦ by
-        rw [traverse_mul, ih1, ih2, mul_map_seq]
+        rw [traverse_mul, ih1, ih2, seq_pure, map_pure, map_pure]
     comp_traverse := fun f g x ↦
       FreeMagma.recOnPure x
         (fun x ↦ by simp only [Function.comp_def, traverse_pure, traverse_pure', functor_norm])
@@ -273,7 +272,7 @@ instance : LawfulTraversable FreeMagma.{u} :=
         (fun x y ih1 ih2 ↦ by simp only [traverse_mul, functor_norm, ih1, ih2])
     traverse_eq_map_id := fun f x ↦
       FreeMagma.recOnPure x (fun _ ↦ rfl) fun x y ih1 ih2 ↦ by
-        rw [traverse_mul, ih1, ih2, map_mul', mul_map_seq]; rfl }
+        rw [traverse_mul, ih1, ih2, map_mul', map_pure, seq_pure, map_pure] }
 
 end Category
 
@@ -579,7 +578,7 @@ def recOnPure {C : FreeSemigroup α → Sort l} (x) (ih1 : ∀ x, C (pure x))
   FreeSemigroup.recOnMul x ih1 ih2
 
 @[to_additive (attr := simp)]
-theorem map_pure (f : α → β) (x) : (f <$> pure x : FreeSemigroup β) = pure (f x) := rfl
+protected theorem map_pure (f : α → β) (x) : (f <$> pure x : FreeSemigroup β) = pure (f x) := rfl
 
 @[to_additive (attr := simp)]
 theorem map_mul' (f : α → β) (x y : FreeSemigroup α) : f <$> (x * y) = f <$> x * f <$> y :=
@@ -650,8 +649,7 @@ end
 @[to_additive (attr := simp)]
 theorem traverse_eq (x) : FreeSemigroup.traverse F x = traverse F x := rfl
 
--- This is not a simp lemma because the left-hand side is not in simp normal form.
-@[to_additive]
+@[to_additive (attr := deprecated "Use map_pure and seq_pure" (since := "2025-05-21"))]
 theorem mul_map_seq (x y : FreeSemigroup α) :
     ((· * ·) <$> x <*> y : Id (FreeSemigroup α)) = (x * y : FreeSemigroup α) := rfl
 
@@ -660,7 +658,7 @@ instance : LawfulTraversable FreeSemigroup.{u} :=
   { instLawfulMonad with
     id_traverse := fun x ↦
       FreeSemigroup.recOnMul x (fun _ ↦ rfl) fun x y ih1 ih2 ↦ by
-        rw [traverse_mul, ih1, ih2, mul_map_seq]
+        rw [traverse_mul, ih1, ih2, seq_pure, map_pure, map_pure]
     comp_traverse := fun f g x ↦
       recOnPure x (fun x ↦ by simp only [traverse_pure, functor_norm, Function.comp_def])
         fun x y ih1 ih2 ↦ by
@@ -671,7 +669,7 @@ instance : LawfulTraversable FreeSemigroup.{u} :=
           (fun x y ih1 ih2 ↦ by simp only [traverse_mul, functor_norm, ih1, ih2])
     traverse_eq_map_id := fun f x ↦
       FreeSemigroup.recOnMul x (fun _ ↦ rfl) fun x y ih1 ih2 ↦ by
-        rw [traverse_mul, ih1, ih2, map_mul', mul_map_seq]; rfl }
+        rw [traverse_mul, ih1, ih2, map_mul', map_pure]; rfl }
 
 end Category
 

--- a/Mathlib/Control/Bitraversable/Basic.lean
+++ b/Mathlib/Control/Bitraversable/Basic.lean
@@ -57,8 +57,7 @@ open Functor
 /-- Bifunctor. This typeclass asserts that a lawless bitraversable bifunctor is lawful. -/
 class LawfulBitraversable (t : Type u → Type u → Type u) [Bitraversable t] : Prop
   extends LawfulBifunctor t where
-  -- Porting note: need to specify `m := Id` because `id` no longer has a `Monad` instance
-  id_bitraverse : ∀ {α β} (x : t α β), bitraverse (m := Id) pure pure x = pure x
+  id_bitraverse : ∀ {α β} (x : t α β), (bitraverse pure pure x : Id _) = pure x
   comp_bitraverse :
     ∀ {F G} [Applicative F] [Applicative G] [LawfulApplicative F] [LawfulApplicative G]
       {α α' β β' γ γ'} (f : β → F γ) (f' : β' → F γ') (g : α → G β) (g' : α' → G β') (x : t α α'),

--- a/Mathlib/Control/Bitraversable/Instances.lean
+++ b/Mathlib/Control/Bitraversable/Instances.lean
@@ -92,7 +92,7 @@ instance (priority := 10) Bitraversable.isLawfulTraversable [LawfulBitraversable
     LawfulTraversable (t α) := by
   constructor <;> intros <;>
     simp [traverse, comp_tsnd, functor_norm]
-  · simp [tsnd_eq_snd_id, (· <$> ·), id.mk]
+  · simp [tsnd_eq_snd_id, (· <$> ·)]
   · simp [tsnd, binaturality, Function.comp_def, functor_norm]
 
 end

--- a/Mathlib/Control/Functor.lean
+++ b/Mathlib/Control/Functor.lean
@@ -57,6 +57,7 @@ end Functor
 
 /-- Introduce `id` as a quasi-functor. (Note that where a lawful `Monad` or
 `Applicative` or `Functor` is needed, `Id` is the correct definition). -/
+@[deprecated "Use `pure : α → Id α` instead." (since := "2025-05-21")]
 def id.mk {α : Sort u} : α → id α :=
   id
 

--- a/Mathlib/Control/Traversable/Basic.lean
+++ b/Mathlib/Control/Traversable/Basic.lean
@@ -221,7 +221,7 @@ satisfy a naturality condition with respect to applicative
 transformations. -/
 class LawfulTraversable (t : Type u → Type u) [Traversable t] : Prop extends LawfulFunctor t where
   /-- `traverse` plays well with `pure` of the identity monad -/
-  id_traverse : ∀ {α} (x : t α), traverse (pure : α → Id α) x = x
+  id_traverse : ∀ {α} (x : t α), traverse (pure : α → Id α) x = pure x
   /-- `traverse` plays well with composition of applicative functors. -/
   comp_traverse :
     ∀ {F G} [Applicative F] [Applicative G] [LawfulApplicative F] [LawfulApplicative G] {α β γ}
@@ -229,7 +229,7 @@ class LawfulTraversable (t : Type u → Type u) [Traversable t] : Prop extends L
       traverse (Functor.Comp.mk ∘ map f ∘ g) x = Comp.mk (map (traverse f) (traverse g x))
   /-- An axiom for `traverse` involving `pure : β → Id β`. -/
   traverse_eq_map_id : ∀ {α β} (f : α → β) (x : t α),
-    traverse ((pure : β → Id β) ∘ f) x = id.mk (f <$> x)
+    traverse ((pure : β → Id β) ∘ f) x = pure (f <$> x)
   /-- The naturality axiom explaining how lawful traversable functors should play with
   lawful applicative functors. -/
   naturality :

--- a/Mathlib/Control/Traversable/Equiv.lean
+++ b/Mathlib/Control/Traversable/Equiv.lean
@@ -113,8 +113,8 @@ variable {α β γ : Type u}
 
 open LawfulTraversable Functor
 
-protected theorem id_traverse (x : t' α) : Equiv.traverse eqv (pure : α → Id α) x = x := by
-  rw [Equiv.traverse, id_traverse, Id.map_eq, apply_symm_apply]
+protected theorem id_traverse (x : t' α) : Equiv.traverse eqv (pure : α → Id α) x = pure x := by
+  rw [Equiv.traverse, id_traverse, map_pure, apply_symm_apply]
 
 protected theorem traverse_eq_map_id (f : α → β) (x : t' α) :
     Equiv.traverse eqv ((pure : β → Id β) ∘ f) x = pure (Equiv.map eqv f x) := by
@@ -158,7 +158,7 @@ protected theorem isLawfulTraversable' [Traversable t']
   toLawfulFunctor := Equiv.lawfulFunctor' eqv @h₀ @h₁
   id_traverse _ := by rw [h₂, Equiv.id_traverse]
   comp_traverse _ _ _ := by rw [h₂, Equiv.comp_traverse, h₂]; congr; rw [h₂]
-  traverse_eq_map_id _ _ := by rw [h₂, Equiv.traverse_eq_map_id, h₀]; rfl
+  traverse_eq_map_id _ _ := by rw [h₂, Equiv.traverse_eq_map_id, h₀]
   naturality _ _ _ _ _ := by rw [h₂, Equiv.naturality, h₂]
 
 end Equiv

--- a/Mathlib/Control/Traversable/Instances.lean
+++ b/Mathlib/Control/Traversable/Instances.lean
@@ -26,7 +26,7 @@ variable {F G : Type u → Type u}
 variable [Applicative F] [Applicative G]
 variable [LawfulApplicative G]
 
-theorem Option.id_traverse {α} (x : Option α) : Option.traverse (pure : α → Id α) x = x := by
+theorem Option.id_traverse {α} (x : Option α) : Option.traverse (pure : α → Id α) x = pure x := by
   cases x <;> rfl
 
 theorem Option.comp_traverse {α β γ} (f : β → F γ) (g : α → G β) (x : Option α) :
@@ -66,7 +66,7 @@ variable [LawfulApplicative G]
 
 open Applicative Functor List
 
-protected theorem id_traverse {α} (xs : List α) : List.traverse (pure : α → Id α) xs = xs := by
+protected theorem id_traverse {α} (xs : List α) : (List.traverse pure xs : Id _) = pure xs := by
   induction xs <;> simp! [*, List.traverse, functor_norm]; rfl
 
 protected theorem comp_traverse {α β γ} (f : β → F γ) (g : α → G β) (x : List α) :

--- a/Mathlib/Control/Traversable/Lemmas.lean
+++ b/Mathlib/Control/Traversable/Lemmas.lean
@@ -57,7 +57,6 @@ theorem pureTransformation_apply {α} (x : id α) : PureTransformation F x = pur
 
 variable {F G}
 
--- Porting note: need to specify `m/F/G := Id` because `id` no longer has a `Monad` instance
 theorem map_eq_traverse_id : map (f := t) f = Id.run ∘ traverse (pure ∘ f) :=
   funext fun y => (traverse_eq_map_id f y).symm
 

--- a/Mathlib/Control/Traversable/Lemmas.lean
+++ b/Mathlib/Control/Traversable/Lemmas.lean
@@ -58,7 +58,7 @@ theorem pureTransformation_apply {α} (x : id α) : PureTransformation F x = pur
 variable {F G}
 
 -- Porting note: need to specify `m/F/G := Id` because `id` no longer has a `Monad` instance
-theorem map_eq_traverse_id : map (f := t) f = traverse (m := Id) (pure ∘ f) :=
+theorem map_eq_traverse_id : map (f := t) f = Id.run ∘ traverse (pure ∘ f) :=
   funext fun y => (traverse_eq_map_id f y).symm
 
 theorem map_traverse (x : t α) : map f <$> traverse g x = traverse (map f ∘ g) x := by

--- a/Mathlib/Data/Finset/Functor.lean
+++ b/Mathlib/Data/Finset/Functor.lean
@@ -187,7 +187,7 @@ def traverse [DecidableEq β] (f : α → F β) (s : Finset α) : F (Finset β) 
   Multiset.toFinset <$> Multiset.traverse f s.1
 
 @[simp]
-theorem id_traverse [DecidableEq α] (s : Finset α) : traverse (pure : α → Id α) s = s := by
+theorem id_traverse [DecidableEq α] (s : Finset α) : traverse (pure : α → Id α) s = pure s := by
   rw [traverse, Multiset.id_traverse]
   exact s.val_toFinset
 

--- a/Mathlib/Data/Multiset/Functor.lean
+++ b/Mathlib/Data/Multiset/Functor.lean
@@ -87,7 +87,7 @@ theorem map_comp_coe {α β} (h : α → β) :
     Functor.map h ∘ ofList = (ofList ∘ Functor.map h : List α → Multiset β) := by
   funext; simp only [Function.comp_apply, fmap_def, map_coe, List.map_eq_map]
 
-theorem id_traverse {α : Type*} (x : Multiset α) : traverse (pure : α → Id α) x = x := by
+theorem id_traverse {α : Type*} (x : Multiset α) : traverse (pure : α → Id α) x = pure x := by
   refine Quotient.inductionOn x ?_
   intro
   simp [traverse]

--- a/Mathlib/Data/Tree/Traversable.lean
+++ b/Mathlib/Data/Tree/Traversable.lean
@@ -38,8 +38,7 @@ lemma comp_traverse
     rfl
 
 lemma traverse_eq_map_id (f : α → β) (t : Tree α) :
-    t.traverse ((pure : β → Id β) ∘ f) = t.map f := by
-  rw [← Id.pure_eq (t.map f)]
+    t.traverse ((pure : β → Id β) ∘ f) = pure (t.map f) := by
   induction t with
   | nil => rw [traverse, map]
   | node v l r hl hr =>

--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -646,7 +646,7 @@ protected theorem traverse_def (f : α → F β) (x : α) :
     ∀ xs : Vector α n, (x ::ᵥ xs).traverse f = cons <$> f x <*> xs.traverse f := by
   rintro ⟨xs, rfl⟩; rfl
 
-protected theorem id_traverse : ∀ x : Vector α n, x.traverse (pure : _ → Id _) = x := by
+protected theorem id_traverse : ∀ x : Vector α n, x.traverse (pure : _ → Id _) = pure x := by
   rintro ⟨x, rfl⟩; dsimp [Vector.traverse, cast]
   induction' x with x xs IH; · rfl
   simp! [IH]; rfl
@@ -671,7 +671,7 @@ protected theorem comp_traverse (f : β → F γ) (g : α → G β) (x : Vector 
     simp [functor_norm, Function.comp_def]
 
 protected theorem traverse_eq_map_id {α β} (f : α → β) :
-    ∀ x : Vector α n, x.traverse ((pure : _ → Id _) ∘ f) = (pure : _ → Id _) (map f x) := by
+    ∀ x : Vector α n, x.traverse ((pure : _ → Id _) ∘ f) = pure (map f x) := by
   rintro ⟨x, rfl⟩; simp!; induction x <;> simp! [*, functor_norm] <;> rfl
 
 variable [LawfulApplicative F] (η : ApplicativeTransformation F G)

--- a/Mathlib/Lean/Expr/ReplaceRec.lean
+++ b/Mathlib/Lean/Expr/ReplaceRec.lean
@@ -29,6 +29,6 @@ def replaceRec (f? : (Expr → Expr) → Expr → Option Expr) : Expr → Expr :
   memoFix fun r e ↦
     match f? r e with
     | some x => x
-    | none   => traverseChildren (M := Id) r e
+    | none   => Id.run <| traverseChildren (pure <| r ·) e
 
 end Lean.Expr


### PR DESCRIPTION
Follows on from https://github.com/leanprover/lean4/pull/7352.

This also deprecates:
* `id.mk`, which looks like a porting error
* `Free(Add)(Magma|Semigroup).mul_map_seq`, which is a garbage lemma that both is not meaningfully about the free objects and has defeq abuse everywhere.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
