### PR TITLE
[Merged by Bors] - feat(AlgebraicGeometry): inverse limit of nonempty quasicompact closeds is nonempty

### DIFF
--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -3,8 +3,8 @@ Copyright (c) 2025 Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
-import Mathlib.AlgebraicGeometry.Morphisms.Affine
-import Mathlib.AlgebraicGeometry.Properties
+import Mathlib.AlgebraicGeometry.IdealSheaf.Functorial
+import Mathlib.AlgebraicGeometry.Morphisms.Separated
 import Mathlib.CategoryTheory.Filtered.Final
 
 /-!
@@ -85,3 +85,73 @@ lemma Scheme.nonempty_of_isLimit [IsCofilteredOrEmpty I]
       (whiskerLeft (Over.post D) (Over.mapPullbackAdj (𝒰.map j)).counit) (Over.forget _)
     exact this.map (((Functor.Initial.isLimitWhiskerEquiv (Over.forget i) c).symm hc).lift
         ((Cones.postcompose α).obj c'.1)).base
+
+include hc in
+open Scheme.IdealSheafData in
+/--
+Suppose we have a cofiltered diagram of schemes whose transition maps are affine. The limit of
+a family of compatible nonempty quasicompact closed sets in the diagram is also nonempty.
+-/
+lemma exists_mem_of_isClosed_of_nonempty
+    [IsCofilteredOrEmpty I]
+    [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
+    (Z : ∀ (i : I), Set (D.obj i))
+    (hZc : ∀ (i : I), IsClosed (Z i))
+    (hZne : ∀ i, (Z i).Nonempty)
+    (hZcpt : ∀ i, IsCompact (Z i))
+    (hmapsTo : ∀ {i i' : I} (f : i ⟶ i'), Set.MapsTo (D.map f).base (Z i) (Z i')) :
+    ∃ (s : c.pt), ∀ i, (c.π.app i).base s ∈ Z i := by
+  let D' : I ⥤ Scheme :=
+  { obj i := (vanishingIdeal ⟨Z i, hZc i⟩).subscheme
+    map {X Y} f := subschemeMap _ _ (D.map f) (by
+      rw [map_vanishingIdeal, ← le_support_iff_le_vanishingIdeal]
+      simpa [(hZc _).closure_subset_iff] using (hmapsTo f).subset_preimage)
+    map_id _ := by simp [← cancel_mono (subschemeι _)]
+    map_comp _ _ := by simp [← cancel_mono (subschemeι _)] }
+  let ι : D' ⟶ D := { app i := subschemeι _, naturality _ _ _ := by simp [D'] }
+  haveI {i j} (f : i ⟶ j) : IsAffineHom (D'.map f) := by
+    suffices IsAffineHom (D'.map f ≫ ι.app j) from .of_comp _ (ι.app j)
+    simp only [TopologicalSpace.Closeds.coe_mk, id_eq, TopologicalSpace.Closeds.coe_closure,
+      coe_support_vanishingIdeal, eq_mpr_eq_cast, subschemeMap_subschemeι, D', ι]
+    infer_instance
+  haveI (i) : Nonempty (D'.obj i) := Set.nonempty_coe_sort.mpr (hZne i)
+  haveI (i) : CompactSpace (D'.obj i) := isCompact_iff_compactSpace.mp (hZcpt i)
+  let c' : Cone D' :=
+  { pt := (⨆ i, (vanishingIdeal ⟨Z i, hZc i⟩).comap (c.π.app i)).subscheme
+    π :=
+    { app i := subschemeMap _ _ (c.π.app i) (by simp [le_map_iff_comap_le, le_iSup_of_le i])
+      naturality {i j} f := by simp [D', ← cancel_mono (subschemeι _)] } }
+  let hc' : IsLimit c' :=
+  { lift s := IsClosedImmersion.lift (subschemeι _) (hc.lift ((Cones.postcompose ι).obj s)) (by
+      suffices ∀ i, vanishingIdeal ⟨Z i, hZc i⟩ ≤ (s.π.app i ≫ ι.app i).ker by
+        simpa [← le_map_iff_comap_le, ← Scheme.Hom.ker_comp]
+      refine fun i ↦ .trans ?_ (Scheme.Hom.le_ker_comp _ _)
+      simp [ι])
+    fac s i := by simp [← cancel_mono (subschemeι _), c', ι]
+    uniq s m hm := by
+      rw [← cancel_mono (subschemeι _)]
+      refine hc.hom_ext fun i ↦ ?_
+      simp [← cancel_mono (subschemeι _), ι, c', ← hm] }
+  have : Nonempty (⨆ i, (vanishingIdeal ⟨Z i, hZc i⟩).comap (c.π.app i)).support :=
+    Scheme.nonempty_of_isLimit D' c' hc'
+  simpa using this
+
+include hc in
+@[stacks 01Z3]
+lemma exists_mem_of_isClosed_of_nonempty'
+    [IsCofilteredOrEmpty I]
+    [∀ {i j} (f : i ⟶ j), IsAffineHom (D.map f)]
+    {j : I}
+    (Z : ∀ (i : I), (i ⟶ j) → Set (D.obj i))
+    (hZc : ∀ i hij, IsClosed (Z i hij))
+    (hZne : ∀ i hij, (Z i hij).Nonempty)
+    (hZcpt : ∀ i hij, IsCompact (Z i hij))
+    (hstab : ∀ (i i' : I) (hi'i : i' ⟶ i) (hij : i ⟶ j) ,
+      Set.MapsTo (D.map hi'i).base (Z i' (hi'i ≫ hij)) (Z i hij)) :
+    ∃ (s : c.pt), ∀ i hij, (c.π.app i).base s ∈ Z i hij := by
+  have {i₁ i₂ : Over j} (f : i₁ ⟶ i₂) : IsAffineHom ((Over.forget j ⋙ D).map f) := by
+    dsimp; infer_instance
+  simpa [Over.forall_iff] using exists_mem_of_isClosed_of_nonempty (Over.forget j ⋙ D) _
+    ((Functor.Initial.isLimitWhiskerEquiv (Over.forget j) c).symm hc)
+    (fun i ↦ Z i.left i.hom) (fun _ ↦ hZc _ _)  (fun _ ↦ hZne _ _)  (fun _ ↦ hZcpt _ _)
+    (fun {i₁ i₂} f ↦ by dsimp; rw [← Over.w f]; exact hstab ..)

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -137,6 +137,10 @@ lemma exists_mem_of_isClosed_of_nonempty
   simpa using this
 
 include hc in
+/--
+A variant of `exists_mem_of_isClosed_of_nonempty` where the closed sets are only defined 
+for the objects over a given `j : I`.
+-/
 @[stacks 01Z3]
 lemma exists_mem_of_isClosed_of_nonempty'
     [IsCofilteredOrEmpty I]

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -138,7 +138,7 @@ lemma exists_mem_of_isClosed_of_nonempty
 
 include hc in
 /--
-A variant of `exists_mem_of_isClosed_of_nonempty` where the closed sets are only defined 
+A variant of `exists_mem_of_isClosed_of_nonempty` where the closed sets are only defined
 for the objects over a given `j : I`.
 -/
 @[stacks 01Z3]

--- a/Mathlib/AlgebraicGeometry/Morphisms/Separated.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Separated.lean
@@ -209,7 +209,19 @@ lemma IsSeparated.of_comp [IsSeparated (f ≫ g)] : IsSeparated f := by
   rw [pullback.diagonal_comp] at this
   exact ⟨@IsClosedImmersion.of_comp _ _ _ _ _ this inferInstance⟩
 
+variable {f g} in
 lemma IsSeparated.comp_iff [IsSeparated g] : IsSeparated (f ≫ g) ↔ IsSeparated f :=
+  ⟨fun _ ↦ .of_comp f g, fun _ ↦ inferInstance⟩
+
+lemma IsAffineHom.of_comp [IsAffineHom (f ≫ g)] [IsSeparated g] :
+    IsAffineHom f := by
+  rw [← pullback.lift_snd (𝟙 _) f (Category.id_comp (f ≫ g))]
+  have := MorphismProperty.pullback_snd (P := @IsAffineHom) (f ≫ g) g inferInstance
+  infer_instance
+
+variable {f g} in
+lemma IsAffineHom.comp_iff [IsAffineHom g] :
+    IsAffineHom (f ≫ g) ↔ IsAffineHom f :=
   ⟨fun _ ↦ .of_comp f g, fun _ ↦ inferInstance⟩
 
 @[stacks 01KM]

--- a/Mathlib/CategoryTheory/Comma/Over/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Basic.lean
@@ -123,6 +123,10 @@ lemma inv_left_hom_left {f g : Over X} (e : f ≅ g) :
     e.inv.left ≫ e.hom.left = 𝟙 g.left := by
   simp [← Over.comp_left]
 
+lemma forall_iff (P : Over X → Prop) :
+    (∀ Y, P Y) ↔ (∀ (Y) (f : Y ⟶ X), P (.mk f)) := by
+  aesop
+
 section
 
 variable (X)
@@ -534,6 +538,10 @@ lemma hom_right_inv_right {f g : Under X} (e : f ≅ g) :
 lemma inv_right_hom_right {f g : Under X} (e : f ≅ g) :
     e.inv.right ≫ e.hom.right = 𝟙 g.right := by
   simp [← Under.comp_right]
+
+lemma forall_iff (P : Under X → Prop) :
+    (∀ Y, P Y) ↔ (∀ (Y) (f : X ⟶ Y), P (.mk f)) := by
+  aesop
 
 section
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
