### PR TITLE
[Merged by Bors] - feat(RingHom): define `RingHom.Smooth`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5369,6 +5369,7 @@ import Mathlib.RingTheory.RingHom.Flat
 import Mathlib.RingTheory.RingHom.Injective
 import Mathlib.RingTheory.RingHom.Integral
 import Mathlib.RingTheory.RingHom.Locally
+import Mathlib.RingTheory.RingHom.Smooth
 import Mathlib.RingTheory.RingHom.StandardSmooth
 import Mathlib.RingTheory.RingHom.Surjective
 import Mathlib.RingTheory.RingHom.Unramified

--- a/Mathlib/RingTheory/RingHom/Smooth.lean
+++ b/Mathlib/RingTheory/RingHom/Smooth.lean
@@ -1,0 +1,136 @@
+/-
+Copyright (c) 2025 Andrew Yang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrew Yang
+-/
+import Mathlib.RingTheory.RingHom.FinitePresentation
+import Mathlib.RingTheory.Smooth.Locus
+
+/-!
+# Smooth ring homomorphisms
+
+In this file we define smooth ring homomorphisms and show their meta properties.
+
+-/
+
+universe u
+
+variable {R S : Type u} [CommRing R] [CommRing S]
+
+open TensorProduct
+
+namespace RingHom
+
+/-- A ring homomorphism `f : R →+* S` is smooth if `S` is formally smooth as an `R` algebra. -/
+@[algebraize RingHom.FormallySmooth.toAlgebra]
+def FormallySmooth (f : R →+* S) : Prop :=
+  letI := f.toAlgebra
+  Algebra.FormallySmooth R S
+
+/-- Helper lemma for the `algebraize` tactic -/
+lemma FormallySmooth.toAlgebra {f : R →+* S} (hf : FormallySmooth f) :
+    @Algebra.FormallySmooth R _ S _ f.toAlgebra := hf
+
+lemma formallySmooth_algebraMap [Algebra R S] :
+    (algebraMap R S).FormallySmooth ↔ Algebra.FormallySmooth R S := by
+  delta FormallySmooth
+  congr!
+  exact Algebra.algebra_ext _ _ fun _ ↦ rfl
+
+lemma FormallySmooth.localizationPreserves : LocalizationPreserves @FormallySmooth := by
+  intros R S T _ f M R' S' _ _ _ _ _ _ hf
+  algebraize [f, (algebraMap S S').comp f, (IsLocalization.map (S := R') S' f M.le_comap_map)]
+  have : IsScalarTower R S S' := .of_algebraMap_eq' rfl
+  have : IsScalarTower R R' S' := .of_algebraMap_eq'
+    (IsLocalization.map_comp (S := R') M.le_comap_map).symm
+  have : IsLocalization (Submonoid.map (algebraMap R S) M) S' := ‹_›
+  exact .localization_map (S := S) M
+
+lemma FormallySmooth.stableUnderComposition : StableUnderComposition @FormallySmooth := by
+  intros R S T _ _ _ f g hf hg
+  algebraize [f, g, g.comp f]
+  exact .comp R S T
+
+lemma FormallySmooth.respectsIso : RespectsIso @FormallySmooth :=
+  localizationPreserves.away.respectsIso
+
+lemma FormallySmooth.isStableUnderBaseChange : IsStableUnderBaseChange @FormallySmooth := by
+  refine .mk respectsIso ?_
+  intros R S T _ _ _ _ _ H
+  show (algebraMap _ _).FormallySmooth
+  rw [formallySmooth_algebraMap] at H ⊢
+  infer_instance
+
+/-- A ring homomorphism `f : R →+* S` is smooth if `S` is smooth as an `R` algebra. -/
+@[algebraize RingHom.Smooth.toAlgebra]
+def Smooth (f : R →+* S) : Prop :=
+  letI : Algebra R S := f.toAlgebra
+  Algebra.Smooth R S
+
+/-- Helper lemma for the `algebraize` tactic -/
+lemma Smooth.toAlgebra {f : R →+* S} (hf : Smooth f) :
+    @Algebra.Smooth R _ S _ f.toAlgebra := hf
+
+lemma smooth_algebraMap [Algebra R S] :
+    (algebraMap R S).Smooth ↔ Algebra.Smooth R S := by
+  simp only [RingHom.Smooth]
+  congr!
+  exact Algebra.algebra_ext _ _ fun _ ↦ rfl
+
+lemma smooth_def {f : R →+* S} : f.Smooth ↔ f.FormallySmooth ∧ f.FinitePresentation :=
+  letI := f.toAlgebra
+  Algebra.smooth_iff _ _
+
+namespace Smooth
+
+variable {R S T : Type u} [CommRing R] [CommRing S] [CommRing T]
+
+lemma stableUnderComposition : StableUnderComposition Smooth := by
+  convert RingHom.FormallySmooth.stableUnderComposition.and
+    RingHom.finitePresentation_stableUnderComposition
+  rw [smooth_def]
+
+lemma isStableUnderBaseChange : IsStableUnderBaseChange Smooth := by
+  convert RingHom.FormallySmooth.isStableUnderBaseChange.and
+    RingHom.finitePresentation_isStableUnderBaseChange
+  rw [smooth_def]
+
+lemma holdsForLocalizationAway : HoldsForLocalizationAway Smooth := by
+  introv R h
+  rw [smooth_algebraMap]
+  exact ⟨Algebra.FormallySmooth.of_isLocalization (.powers r),
+    IsLocalization.Away.finitePresentation r⟩
+
+variable (R) in
+/-- The identity of a ring is smooth. -/
+lemma id : RingHom.Smooth (RingHom.id R) :=
+  holdsForLocalizationAway.containsIdentities R
+
+/-- Composition of smooth ring homomorphisms is smooth. -/
+lemma comp {f : R →+* S} {g : S →+* T} (hf : f.Smooth) (hg : g.Smooth) : (g.comp f).Smooth :=
+  stableUnderComposition f g hf hg
+
+lemma ofLocalizationSpanTarget : OfLocalizationSpanTarget Smooth := by
+  introv R hs hf
+  have : f.FinitePresentation :=
+    finitePresentation_ofLocalizationSpanTarget _ s hs fun r ↦ (hf r).finitePresentation
+  algebraize [f]
+  refine ⟨?_, ‹_›⟩
+  rw [← Algebra.smoothLocus_eq_univ_iff, ← Set.univ_subset_iff, ← TopologicalSpace.Opens.coe_top,
+    ← PrimeSpectrum.iSup_basicOpen_eq_top_iff'.mpr hs]
+  simp only [TopologicalSpace.Opens.coe_iSup, Set.iUnion_subset_iff,
+    Algebra.basicOpen_subset_smoothLocus_iff, ← formallySmooth_algebraMap]
+  exact fun r hr ↦ (hf ⟨r, hr⟩).1
+
+/-- smoothness is a local property of ring homomorphisms. -/
+lemma propertyIsLocal : PropertyIsLocal Smooth where
+  localizationAwayPreserves := isStableUnderBaseChange.localizationPreserves.away
+  ofLocalizationSpanTarget := ofLocalizationSpanTarget
+  ofLocalizationSpan := ofLocalizationSpanTarget.ofLocalizationSpan
+    (stableUnderComposition.stableUnderCompositionWithLocalizationAway
+      holdsForLocalizationAway).left
+  StableUnderCompositionWithLocalizationAwayTarget :=
+    (stableUnderComposition.stableUnderCompositionWithLocalizationAway
+      holdsForLocalizationAway).right
+
+end RingHom.Smooth

--- a/Mathlib/RingTheory/RingHom/Smooth.lean
+++ b/Mathlib/RingTheory/RingHom/Smooth.lean
@@ -21,7 +21,8 @@ open TensorProduct
 
 namespace RingHom
 
-/-- A ring homomorphism `f : R →+* S` is smooth if `S` is formally smooth as an `R` algebra. -/
+/-- A ring homomorphism `f : R →+* S` is formally smooth
+if `S` is formally smooth as an `R` algebra. -/
 @[algebraize RingHom.FormallySmooth.toAlgebra]
 def FormallySmooth (f : R →+* S) : Prop :=
   letI := f.toAlgebra
@@ -37,14 +38,8 @@ lemma formallySmooth_algebraMap [Algebra R S] :
   congr!
   exact Algebra.algebra_ext _ _ fun _ ↦ rfl
 
-lemma FormallySmooth.localizationPreserves : LocalizationPreserves @FormallySmooth := by
-  intros R S T _ f M R' S' _ _ _ _ _ _ hf
-  algebraize [f, (algebraMap S S').comp f, (IsLocalization.map (S := R') S' f M.le_comap_map)]
-  have : IsScalarTower R S S' := .of_algebraMap_eq' rfl
-  have : IsScalarTower R R' S' := .of_algebraMap_eq'
-    (IsLocalization.map_comp (S := R') M.le_comap_map).symm
-  have : IsLocalization (Submonoid.map (algebraMap R S) M) S' := ‹_›
-  exact .localization_map (S := S) M
+lemma FormallySmooth.holdsForLocalizationAway : HoldsForLocalizationAway @FormallySmooth :=
+  fun _ _ _ _ _ r _ ↦ formallySmooth_algebraMap.mpr <| .of_isLocalization (.powers r)
 
 lemma FormallySmooth.stableUnderComposition : StableUnderComposition @FormallySmooth := by
   intros R S T _ _ _ f g hf hg
@@ -52,7 +47,7 @@ lemma FormallySmooth.stableUnderComposition : StableUnderComposition @FormallySm
   exact .comp R S T
 
 lemma FormallySmooth.respectsIso : RespectsIso @FormallySmooth :=
-  localizationPreserves.away.respectsIso
+  stableUnderComposition.respectsIso fun e ↦ holdsForLocalizationAway.of_bijective _ _ e.bijective
 
 lemma FormallySmooth.isStableUnderBaseChange : IsStableUnderBaseChange @FormallySmooth := by
   refine .mk respectsIso ?_
@@ -60,6 +55,9 @@ lemma FormallySmooth.isStableUnderBaseChange : IsStableUnderBaseChange @Formally
   show (algebraMap _ _).FormallySmooth
   rw [formallySmooth_algebraMap] at H ⊢
   infer_instance
+
+lemma FormallySmooth.localizationPreserves : LocalizationPreserves @FormallySmooth :=
+  isStableUnderBaseChange.localizationPreserves
 
 /-- A ring homomorphism `f : R →+* S` is smooth if `S` is smooth as an `R` algebra. -/
 @[algebraize RingHom.Smooth.toAlgebra]
@@ -122,7 +120,7 @@ lemma ofLocalizationSpanTarget : OfLocalizationSpanTarget Smooth := by
     Algebra.basicOpen_subset_smoothLocus_iff, ← formallySmooth_algebraMap]
   exact fun r hr ↦ (hf ⟨r, hr⟩).1
 
-/-- smoothness is a local property of ring homomorphisms. -/
+/-- Smoothness is a local property of ring homomorphisms. -/
 lemma propertyIsLocal : PropertyIsLocal Smooth where
   localizationAwayPreserves := isStableUnderBaseChange.localizationPreserves.away
   ofLocalizationSpanTarget := ofLocalizationSpanTarget

--- a/Mathlib/RingTheory/Smooth/Basic.lean
+++ b/Mathlib/RingTheory/Smooth/Basic.lean
@@ -331,7 +331,8 @@ variable (A : Type u) [Semiring A] [Algebra R A]
 
 /-- An `R` algebra `A` is smooth if it is formally smooth and of finite presentation. -/
 @[stacks 00T2 "In the stacks project, the definition of smooth is completely different, and tag
-<https://stacks.math.columbia.edu/tag/00TN> proves that their definition is equivalent to this."]
+<https://stacks.math.columbia.edu/tag/00TN> proves that their definition is equivalent to this.",
+mk_iff]
 class Smooth [CommSemiring R] (A : Type u) [Semiring A] [Algebra R A] : Prop where
   formallySmooth : FormallySmooth R A := by infer_instance
   finitePresentation : FinitePresentation R A := by infer_instance


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
