### PR TITLE
[Merged by Bors] - feat(SimpleGraph): add surjectivity result for colorings of graphs with cliques

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
@@ -461,7 +461,7 @@ lemma Coloring.surjOn_of_card_le_isClique {γ : Type*} [Fintype γ] {s : Finset 
   obtain ⟨_, hx⟩ := card_le_chromaticNumber_iff_forall_surjective.mp
                     (by simp_all [isClique_iff_induce_eq]) (C.comp (Embedding.induce s).toHom) _
   exact ⟨_, Subtype.coe_prop _, hx⟩
-  
+
 namespace completeMultipartiteGraph
 
 variable {ι : Type*} (V : ι → Type*)

--- a/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
@@ -454,6 +454,14 @@ theorem cliqueFree_of_chromaticNumber_lt {n : ℕ} (hc : G.chromaticNumber < n) 
   rw [← hne] at hc
   simpa using hc
 
+lemma Coloring.surjOn_of_card_le_isClique {γ : Type*} [Fintype γ] {s : Finset V}
+    (h : G.IsClique s) (hc : Fintype.card γ ≤ s.card) (C : G.Coloring γ) :
+    Set.SurjOn C s Set.univ := by
+  intro _ _
+  obtain ⟨_, hx⟩ := card_le_chromaticNumber_iff_forall_surjective.mp
+                    (by simp_all [isClique_iff_induce_eq]) (C.comp (Embedding.induce s).toHom) _
+  exact ⟨_, Subtype.coe_prop _, hx⟩
+  
 namespace completeMultipartiteGraph
 
 variable {ι : Type*} (V : ι → Type*)

--- a/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Coloring.lean
@@ -454,9 +454,12 @@ theorem cliqueFree_of_chromaticNumber_lt {n : ℕ} (hc : G.chromaticNumber < n) 
   rw [← hne] at hc
   simpa using hc
 
-lemma Coloring.surjOn_of_card_le_isClique {γ : Type*} [Fintype γ] {s : Finset V}
-    (h : G.IsClique s) (hc : Fintype.card γ ≤ s.card) (C : G.Coloring γ) :
-    Set.SurjOn C s Set.univ := by
+/--
+Given a colouring `α` of `G`, and a clique of size at least the number of colours, the clique
+contains a vertex of each colour.
+-/
+lemma Coloring.surjOn_of_card_le_isClique [Fintype α] {s : Finset V} (h : G.IsClique s)
+    (hc : Fintype.card α ≤ s.card) (C : G.Coloring α) : Set.SurjOn C s Set.univ := by
   intro _ _
   obtain ⟨_, hx⟩ := card_le_chromaticNumber_iff_forall_surjective.mp
                     (by simp_all [isClique_iff_induce_eq]) (C.comp (Embedding.induce s).toHom) _


### PR DESCRIPTION
Any `γ`-coloring of a graph `G` containing a clique of cardinality at least `Fintype.card γ` must be surjective on the clique.

This result will be used to prove that any maximally `(r + 1)` - CliqueFree graph is  `r` - colorable iff it is complete-multipartite.

Co-authored-by: Lian Bremner Tattersall <lian.tattersall.20@alumni.ucl.ac.uk>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
