### PR TITLE
[Merged by Bors] - feat: more results about `Ideal.prod`

### DIFF
--- a/Mathlib/RingTheory/Ideal/Prod.lean
+++ b/Mathlib/RingTheory/Ideal/Prod.lean
@@ -45,6 +45,14 @@ theorem prod_mono {I₁ I₂ : Ideal R} {J₁ J₂ : Ideal S} (hI : I₁ ≤ I�
     prod I₁ J₁ ≤ prod I₂ J₂ :=
   Set.prod_mono hI hJ
 
+@[gcongr]
+theorem prod_mono_left {I₁ I₂ : Ideal R} {J : Ideal S} (hI : I₁ ≤ I₂) : prod I₁ J ≤ prod I₂ J :=
+  Set.prod_mono_left hI
+
+@[gcongr]
+theorem prod_mono_right {I : Ideal R} {J₁ J₂ : Ideal S} (hJ : J₁ ≤ J₂) : prod I J₁ ≤ prod I J₂ :=
+  Set.prod_mono_right hJ
+
 /-- Every ideal of the product ring is of the form `I × J`, where `I` and `J` can be explicitly
     given as the image under the projection maps. -/
 theorem ideal_prod_eq (I : Ideal (R × S)) :
@@ -125,6 +133,16 @@ theorem prod_inj {I I' : Ideal R} {J J' : Ideal S} :
 
 @[deprecated (since := "2025-05-22")] alias prod.ext_iff := prod_inj
 
+@[simp]
+theorem prod_eq_bot_iff {I : Ideal R} {J : Ideal S} :
+    prod I J = ⊥ ↔ I = ⊥ ∧ J = ⊥ := by
+  rw [← prod_inj, prod_bot_bot]
+
+@[simp]
+theorem prod_eq_top_iff {I : Ideal R} {J : Ideal S} :
+    prod I J = ⊤ ↔ I = ⊤ ∧ J = ⊤ := by
+  rw [← prod_inj, prod_top_top]
+
 theorem isPrime_of_isPrime_prod_top {I : Ideal R} (h : (Ideal.prod I (⊤ : Ideal S)).IsPrime) :
     I.IsPrime := by
   constructor
@@ -144,16 +162,9 @@ theorem isPrime_of_isPrime_prod_top' {I : Ideal S} (h : (Ideal.prod (⊤ : Ideal
   -- Note: couldn't synthesize the right instances without the `R` and `S` hints
   exact map_isPrime_of_equiv (RingEquiv.prodComm (R := R) (S := S))
 
-theorem isPrime_ideal_prod_top {I : Ideal R} [h : I.IsPrime] : (prod I (⊤ : Ideal S)).IsPrime := by
-  constructor
-  · rcases h with ⟨h, -⟩
-    contrapose! h
-    rw [← prod_top_top, prod.ext_iff] at h
-    exact h.1
-  rintro ⟨r₁, s₁⟩ ⟨r₂, s₂⟩ ⟨h₁, _⟩
-  rcases h.mem_or_mem h₁ with h | h
-  · exact Or.inl ⟨h, trivial⟩
-  · exact Or.inr ⟨h, trivial⟩
+theorem isPrime_ideal_prod_top {I : Ideal R} [h : I.IsPrime] : (prod I (⊤ : Ideal S)).IsPrime where
+  ne_top' := by simpa using h.ne_top
+  mem_or_mem' {x y} := by simpa using h.mem_or_mem
 
 theorem isPrime_ideal_prod_top' {I : Ideal S} [h : I.IsPrime] : (prod (⊤ : Ideal R) I).IsPrime := by
   letI : IsPrime (prod I (⊤ : Ideal R)) := isPrime_ideal_prod_top

--- a/Mathlib/RingTheory/Ideal/Prod.lean
+++ b/Mathlib/RingTheory/Ideal/Prod.lean
@@ -25,7 +25,7 @@ namespace Ideal
 def prod : Ideal (R × S) := I.comap (RingHom.fst R S) ⊓ J.comap (RingHom.snd R S)
 
 @[simp]
-theorem coe_prod (I : Ideal R) (J : Ideal S) : (I.prod J : Set (R × S)) = (I : Set _) ×ˢ J :=
+theorem coe_prod (I : Ideal R) (J : Ideal S) : ↑(prod I J) = (I ×ˢ J : Set (R × S)) :=
   rfl
 
 @[simp]

--- a/Mathlib/RingTheory/Ideal/Span.lean
+++ b/Mathlib/RingTheory/Ideal/Span.lean
@@ -73,6 +73,7 @@ theorem subset_span {s : Set α} : s ⊆ span s :=
 theorem span_le {s : Set α} {I} : span s ≤ I ↔ s ⊆ I :=
   Submodule.span_le
 
+@[gcongr]
 theorem span_mono {s t : Set α} : s ⊆ t → span s ≤ span t :=
   Submodule.span_mono
 

--- a/Mathlib/RingTheory/Spectrum/Prime/Basic.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Basic.lean
@@ -95,7 +95,7 @@ noncomputable def primeSpectrumProd :
     Equiv.ofBijective (primeSpectrumProdOfSum R S) (by
         constructor
         · rintro (⟨I, hI⟩ | ⟨J, hJ⟩) (⟨I', hI'⟩ | ⟨J', hJ'⟩) h <;>
-          simp only [mk.injEq, Ideal.prod.ext_iff, primeSpectrumProdOfSum] at h
+          simp only [mk.injEq, Ideal.prod_inj, primeSpectrumProdOfSum] at h
           · simp only [h]
           · exact False.elim (hI.ne_top h.left)
           · exact False.elim (hJ.ne_top h.right)


### PR DESCRIPTION
From [#Is there code for X? > &#96;Ideal.prod_span&#96; version for different rings @ 💬](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/.60Ideal.2Eprod_span.60.20version.20for.20different.20rings/near/519839282)

Co-authored-by: Yakov Pechersky <ffxen158@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
