### PR TITLE
[Merged by Bors] - chore: deprime `induction` in `Computability.TuringDegree`

### DIFF
--- a/Mathlib/Computability/TuringDegree.lean
+++ b/Mathlib/Computability/TuringDegree.lean
@@ -176,7 +176,7 @@ instance TuringDegree.instPartialOrder : PartialOrder TuringDegree :=
     induction fRecInNone with repeat {constructor}
     | oracle _ hg => simp at hg
     | pair | comp | prec | rfind =>
-    repeat {constructor; assumption; try assumption}
+      repeat {constructor; assumption; try assumption}
   mpr pF := by
     induction pF with repeat {constructor}
     | pair _ _ ih₁ ih₂ => exact RecursiveIn.pair ih₁ ih₂

--- a/Mathlib/Computability/TuringDegree.lean
+++ b/Mathlib/Computability/TuringDegree.lean
@@ -94,19 +94,20 @@ open scoped Computability
 If a function is partial recursive, then it is recursive in every partial function.
 -/
 lemma Nat.Partrec.turingReducible (pF : Nat.Partrec f) : f ≤ᵀ g := by
-  induction pF with repeat constructor
-  | pair ih₁ ih₂ => exact RecursiveIn.pair ih₁ ih₂
-  | comp ih₁ ih₂ => exact RecursiveIn.comp ih₁ ih₂
-  | prec ih₁ ih₂ => exact RecursiveIn.prec ih₁ ih₂
-  | rfind ih => exact RecursiveIn.rfind ih
+  induction pF with repeat {constructor}
+  | pair _ _ ih₁ ih₂ => exact RecursiveIn.pair ih₁ ih₂
+  | comp _ _ ih₁ ih₂ => exact RecursiveIn.comp ih₁ ih₂
+  | prec _ _ ih₁ ih₂ => exact RecursiveIn.prec ih₁ ih₂
+  | rfind _ ih => exact RecursiveIn.rfind ih
 
 /--
 If a function is recursive in the constant zero function,
 then it is partial recursive.
 -/
 lemma TuringReducible.partrec_of_zero (fRecInZero : f ≤ᵀ fun _ => Part.some 0) : Nat.Partrec f := by
-  induction fRecInZero with repeat constructor
-  | oracle hg => rw [Set.mem_singleton_iff] at hg; rw [hg]; exact Nat.Partrec.zero
+  induction fRecInZero with repeat {constructor}
+  | oracle _ hg => rw [Set.mem_singleton_iff] at hg; rw [hg]; exact Nat.Partrec.zero
+  | pair | comp | prec | rfind
   repeat {constructor; assumption; try assumption}
 
 /--
@@ -122,12 +123,12 @@ protected theorem TuringReducible.rfl : f ≤ᵀ f := .refl _
 instance : IsRefl (ℕ →. ℕ) TuringReducible where refl _ := .rfl
 
 theorem TuringReducible.trans (hg : f ≤ᵀ g) (hh : g ≤ᵀ h) : f ≤ᵀ h := by
-  induction hg with repeat constructor
-  | oracle hg => rw [Set.mem_singleton_iff] at hg; rw [hg]; exact hh
-  | pair ih₁ ih₂ => exact RecursiveIn.pair ih₁ ih₂
-  | comp ih₁ ih₂ => exact RecursiveIn.comp ih₁ ih₂
-  | prec ih₁ ih₂ => exact RecursiveIn.prec ih₁ ih₂
-  | rfind ih => exact RecursiveIn.rfind ih
+  induction hg with repeat {constructor}
+  | oracle _ hg => rw [Set.mem_singleton_iff] at hg; rw [hg]; exact hh
+  | pair _ _ ih₁ ih₂ => exact RecursiveIn.pair ih₁ ih₂
+  | comp _ _ ih₁ ih₂ => exact RecursiveIn.comp ih₁ ih₂
+  | prec _ _ ih₁ ih₂ => exact RecursiveIn.prec ih₁ ih₂
+  | rfind _ ih => exact RecursiveIn.rfind ih
 
 instance : IsTrans (ℕ →. ℕ) TuringReducible :=
   ⟨@TuringReducible.trans⟩
@@ -173,12 +174,12 @@ instance TuringDegree.instPartialOrder : PartialOrder TuringDegree :=
 
 @[simp] lemma recursiveIn_empty_iff_partrec : RecursiveIn {} f ↔ Nat.Partrec f where
   mp fRecInNone := by
-    induction fRecInNone with repeat constructor
-    | oracle hg => simp at hg
+    induction fRecInNone with repeat {constructor}
+    | oracle _ hg => simp at hg | pair | comp | prec | rfind
     repeat {constructor; assumption; try assumption}
   mpr pF := by
-    induction pF with repeat constructor
-    | pair ih₁ ih₂ => exact RecursiveIn.pair ih₁ ih₂
-    | comp ih₁ ih₂ => exact RecursiveIn.comp ih₁ ih₂
-    | prec ih₁ ih₂ => exact RecursiveIn.prec ih₁ ih₂
-    | rfind ih => exact RecursiveIn.rfind ih
+    induction pF with repeat {constructor}
+    | pair _ _ ih₁ ih₂ => exact RecursiveIn.pair ih₁ ih₂
+    | comp _ _ ih₁ ih₂ => exact RecursiveIn.comp ih₁ ih₂
+    | prec _ _ ih₁ ih₂ => exact RecursiveIn.prec ih₁ ih₂
+    | rfind _ ih => exact RecursiveIn.rfind ih

--- a/Mathlib/Computability/TuringDegree.lean
+++ b/Mathlib/Computability/TuringDegree.lean
@@ -174,7 +174,8 @@ instance TuringDegree.instPartialOrder : PartialOrder TuringDegree :=
 @[simp] lemma recursiveIn_empty_iff_partrec : RecursiveIn {} f ↔ Nat.Partrec f where
   mp fRecInNone := by
     induction fRecInNone with repeat {constructor}
-    | oracle _ hg => simp at hg | pair | comp | prec | rfind
+    | oracle _ hg => simp at hg
+    | pair | comp | prec | rfind =>
     repeat {constructor; assumption; try assumption}
   mpr pF := by
     induction pF with repeat {constructor}

--- a/Mathlib/Computability/TuringDegree.lean
+++ b/Mathlib/Computability/TuringDegree.lean
@@ -107,8 +107,7 @@ then it is partial recursive.
 lemma TuringReducible.partrec_of_zero (fRecInZero : f ≤ᵀ fun _ => Part.some 0) : Nat.Partrec f := by
   induction fRecInZero with repeat {constructor}
   | oracle _ hg => rw [Set.mem_singleton_iff] at hg; rw [hg]; exact Nat.Partrec.zero
-  | pair | comp | prec | rfind
-  repeat {constructor; assumption; try assumption}
+  | pair | comp | prec | rfind => repeat {constructor; assumption; try assumption}
 
 /--
 A partial function `f` is partial recursive if and only if it is recursive in

--- a/Mathlib/Computability/TuringDegree.lean
+++ b/Mathlib/Computability/TuringDegree.lean
@@ -94,26 +94,19 @@ open scoped Computability
 If a function is partial recursive, then it is recursive in every partial function.
 -/
 lemma Nat.Partrec.turingReducible (pF : Nat.Partrec f) : f ≤ᵀ g := by
-  induction' pF with f' g' _ _ ih₁ ih₂ f' g' _ _ ih₁ ih₂ f' g' _ _ ih₁ ih₂ f' _ ih
-  repeat {constructor}
-  · case pair =>
-    apply RecursiveIn.pair ih₁ ih₂
-  · case comp =>
-    apply RecursiveIn.comp ih₁ ih₂
-  · case prec =>
-    apply RecursiveIn.prec ih₁ ih₂
-  · case rfind =>
-    apply RecursiveIn.rfind ih
+  induction pF; repeat {constructor}
+  case pair ih₁ ih₂ => exact RecursiveIn.pair ih₁ ih₂
+  case comp ih₁ ih₂ => exact RecursiveIn.comp ih₁ ih₂
+  case prec ih₁ ih₂ => exact RecursiveIn.prec ih₁ ih₂
+  case rfind ih => exact RecursiveIn.rfind ih
 
 /--
 If a function is recursive in the constant zero function,
 then it is partial recursive.
 -/
 lemma TuringReducible.partrec_of_zero (fRecInZero : f ≤ᵀ fun _ => Part.some 0) : Nat.Partrec f := by
-  induction' fRecInZero with g hg g h _ _ ih₁ ih₂ g h _ _ ih₁ ih₂ g h _ _ ih₁ ih₂ g _ ih
-  repeat {constructor}
-  · rw [Set.mem_singleton_iff] at hg; rw [hg];
-    exact Nat.Partrec.zero
+  induction fRecInZero; repeat {constructor}
+  case oracle hg => rw [Set.mem_singleton_iff] at hg; rw [hg]; exact Nat.Partrec.zero
   repeat {constructor; assumption; try assumption}
 
 /--
@@ -129,17 +122,12 @@ protected theorem TuringReducible.rfl : f ≤ᵀ f := .refl _
 instance : IsRefl (ℕ →. ℕ) TuringReducible where refl _ := .rfl
 
 theorem TuringReducible.trans (hg : f ≤ᵀ g) (hh : g ≤ᵀ h) : f ≤ᵀ h := by
-  induction' hg with g' hg g' h' _ _ ih₁ ih₂ g' h' _ _ ih₁ ih₂ g' h' _ _ ih₁ ih₂ g' _ ih
-  repeat {constructor}
-  · rw [Set.mem_singleton_iff] at hg; rw [hg]; exact hh
-  · case pair =>
-    apply RecursiveIn.pair ih₁ ih₂
-  · case comp =>
-    apply RecursiveIn.comp ih₁ ih₂
-  · case prec =>
-    apply RecursiveIn.prec ih₁ ih₂
-  · case rfind =>
-    apply RecursiveIn.rfind ih
+  induction hg; repeat {constructor}
+  case oracle hg => rw [Set.mem_singleton_iff] at hg; rw [hg]; exact hh
+  case pair ih₁ ih₂ => exact RecursiveIn.pair ih₁ ih₂
+  case comp ih₁ ih₂ => exact RecursiveIn.comp ih₁ ih₂
+  case prec ih₁ ih₂ => exact RecursiveIn.prec ih₁ ih₂
+  case rfind ih => exact RecursiveIn.rfind ih
 
 instance : IsTrans (ℕ →. ℕ) TuringReducible :=
   ⟨@TuringReducible.trans⟩
@@ -183,20 +171,14 @@ private instance : Preorder (ℕ →. ℕ) where
 instance TuringDegree.instPartialOrder : PartialOrder TuringDegree :=
   instPartialOrderAntisymmetrization
 
-@[simp] lemma recursiveIn_empty_iff_partrec : RecursiveIn {} f ↔ Nat.Partrec f  where
+@[simp] lemma recursiveIn_empty_iff_partrec : RecursiveIn {} f ↔ Nat.Partrec f where
   mp fRecInNone := by
-    induction' fRecInNone with g hg g h _ _ ih₁ ih₂ g h _ _ ih₁ ih₂ g h _ _ ih₁ ih₂ g _ ih
-    repeat {constructor}
-    · simp at hg
+    induction fRecInNone; repeat {constructor}
+    case oracle hg => simp at hg
     repeat {constructor; assumption; try assumption}
   mpr pF := by
-    induction' pF with f' g' _ _ ih₁ ih₂ f' g' _ _ ih₁ ih₂ f' g' _ _ ih₁ ih₂ f' _ ih
-    repeat {constructor}
-    · case pair =>
-      apply RecursiveIn.pair ih₁ ih₂
-    · case comp =>
-      apply RecursiveIn.comp ih₁ ih₂
-    · case prec =>
-      apply RecursiveIn.prec ih₁ ih₂
-    · case rfind =>
-      apply RecursiveIn.rfind ih
+    induction pF; repeat {constructor}
+    case pair ih₁ ih₂ => exact RecursiveIn.pair ih₁ ih₂
+    case comp ih₁ ih₂ => exact RecursiveIn.comp ih₁ ih₂
+    case prec ih₁ ih₂ => exact RecursiveIn.prec ih₁ ih₂
+    case rfind ih => exact RecursiveIn.rfind ih

--- a/Mathlib/Computability/TuringDegree.lean
+++ b/Mathlib/Computability/TuringDegree.lean
@@ -94,19 +94,19 @@ open scoped Computability
 If a function is partial recursive, then it is recursive in every partial function.
 -/
 lemma Nat.Partrec.turingReducible (pF : Nat.Partrec f) : f ≤ᵀ g := by
-  induction pF; repeat {constructor}
-  case pair ih₁ ih₂ => exact RecursiveIn.pair ih₁ ih₂
-  case comp ih₁ ih₂ => exact RecursiveIn.comp ih₁ ih₂
-  case prec ih₁ ih₂ => exact RecursiveIn.prec ih₁ ih₂
-  case rfind ih => exact RecursiveIn.rfind ih
+  induction pF with repeat constructor
+  | pair ih₁ ih₂ => exact RecursiveIn.pair ih₁ ih₂
+  | comp ih₁ ih₂ => exact RecursiveIn.comp ih₁ ih₂
+  | prec ih₁ ih₂ => exact RecursiveIn.prec ih₁ ih₂
+  | rfind ih => exact RecursiveIn.rfind ih
 
 /--
 If a function is recursive in the constant zero function,
 then it is partial recursive.
 -/
 lemma TuringReducible.partrec_of_zero (fRecInZero : f ≤ᵀ fun _ => Part.some 0) : Nat.Partrec f := by
-  induction fRecInZero; repeat {constructor}
-  case oracle hg => rw [Set.mem_singleton_iff] at hg; rw [hg]; exact Nat.Partrec.zero
+  induction fRecInZero with repeat constructor
+  | oracle hg => rw [Set.mem_singleton_iff] at hg; rw [hg]; exact Nat.Partrec.zero
   repeat {constructor; assumption; try assumption}
 
 /--
@@ -122,12 +122,12 @@ protected theorem TuringReducible.rfl : f ≤ᵀ f := .refl _
 instance : IsRefl (ℕ →. ℕ) TuringReducible where refl _ := .rfl
 
 theorem TuringReducible.trans (hg : f ≤ᵀ g) (hh : g ≤ᵀ h) : f ≤ᵀ h := by
-  induction hg; repeat {constructor}
-  case oracle hg => rw [Set.mem_singleton_iff] at hg; rw [hg]; exact hh
-  case pair ih₁ ih₂ => exact RecursiveIn.pair ih₁ ih₂
-  case comp ih₁ ih₂ => exact RecursiveIn.comp ih₁ ih₂
-  case prec ih₁ ih₂ => exact RecursiveIn.prec ih₁ ih₂
-  case rfind ih => exact RecursiveIn.rfind ih
+  induction hg with repeat constructor
+  | oracle hg => rw [Set.mem_singleton_iff] at hg; rw [hg]; exact hh
+  | pair ih₁ ih₂ => exact RecursiveIn.pair ih₁ ih₂
+  | comp ih₁ ih₂ => exact RecursiveIn.comp ih₁ ih₂
+  | prec ih₁ ih₂ => exact RecursiveIn.prec ih₁ ih₂
+  | rfind ih => exact RecursiveIn.rfind ih
 
 instance : IsTrans (ℕ →. ℕ) TuringReducible :=
   ⟨@TuringReducible.trans⟩
@@ -173,12 +173,12 @@ instance TuringDegree.instPartialOrder : PartialOrder TuringDegree :=
 
 @[simp] lemma recursiveIn_empty_iff_partrec : RecursiveIn {} f ↔ Nat.Partrec f where
   mp fRecInNone := by
-    induction fRecInNone; repeat {constructor}
-    case oracle hg => simp at hg
+    induction fRecInNone with repeat constructor
+    | oracle hg => simp at hg
     repeat {constructor; assumption; try assumption}
   mpr pF := by
-    induction pF; repeat {constructor}
-    case pair ih₁ ih₂ => exact RecursiveIn.pair ih₁ ih₂
-    case comp ih₁ ih₂ => exact RecursiveIn.comp ih₁ ih₂
-    case prec ih₁ ih₂ => exact RecursiveIn.prec ih₁ ih₂
-    case rfind ih => exact RecursiveIn.rfind ih
+    induction pF with repeat constructor
+    | pair ih₁ ih₂ => exact RecursiveIn.pair ih₁ ih₂
+    | comp ih₁ ih₂ => exact RecursiveIn.comp ih₁ ih₂
+    | prec ih₁ ih₂ => exact RecursiveIn.prec ih₁ ih₂
+    | rfind ih => exact RecursiveIn.rfind ih


### PR DESCRIPTION
[Found](https://github.com/leanprover-community/mathlib4/actions/runs/15200666975/job/42754098883) as the only new cases of `induction'` with four or more named arguments after #23324.