### PR TITLE
[Merged by Bors] - feat(Cache): repository-scoped caches

### DIFF
--- a/Cache/Main.lean
+++ b/Cache/Main.lean
@@ -97,7 +97,7 @@ def main (args : List String) : IO Unit := do
   let pack (overwrite verbose unpackedOnly := false) := do
     packCache hashMap overwrite verbose unpackedOnly (← getGitCommitHash)
   let put (overwrite unpackedOnly := false) := do
-    let repo ← repo?.getDM getRemoteRepo
+    let repo := repo?.getD MATHLIBREPO
     putFiles repo (← pack overwrite (verbose := true) unpackedOnly) overwrite (← getToken)
   match args with
   | "get"  :: args => get args

--- a/Cache/Main.lean
+++ b/Cache/Main.lean
@@ -56,6 +56,16 @@ def curlArgs : List String :=
 def leanTarArgs : List String :=
   ["get", "get!", "pack", "pack!", "unpack", "lookup"]
 
+/-- Parses an optional `--repo` option. -/
+def parseRepo (args : List String) : IO (Option String × List String) := do
+  if let arg :: args := args then
+    if arg.startsWith "--" then
+      if let some repo := arg.dropPrefix? "--repo=" then
+        return (some repo.toString, args)
+      else
+        throw <| IO.userError s!"unknown option: {arg}"
+  return (none, args)
+
 open Cache IO Hashing Requests System in
 def main (args : List String) : IO Unit := do
   if Lean.versionString == "4.8.0-rc1" && Lean.githash == "b470eb522bfd68ca96938c23f6a1bce79da8a99f" then do
@@ -67,6 +77,7 @@ def main (args : List String) : IO Unit := do
     Process.exit 0
   CacheM.run do
 
+  let (repo?, args) ← parseRepo args
   let mut roots : Std.HashMap Lean.Name FilePath ← parseArgs args
   if roots.isEmpty then do
     -- No arguments means to start from `Mathlib.lean`
@@ -82,11 +93,12 @@ def main (args : List String) : IO Unit := do
   if leanTarArgs.contains (args.headD "") then validateLeanTar
   let get (args : List String) (force := false) (decompress := true) := do
     let hashMap ← if args.isEmpty then pure hashMap else hashMemo.filterByRootModules roots.keys
-    getFiles hashMap force force goodCurl decompress
+    getFiles repo? hashMap force force goodCurl decompress
   let pack (overwrite verbose unpackedOnly := false) := do
     packCache hashMap overwrite verbose unpackedOnly (← getGitCommitHash)
   let put (overwrite unpackedOnly := false) := do
-    putFiles (← pack overwrite (verbose := true) unpackedOnly) overwrite (← getToken)
+    let repo ← repo?.getDM getRemoteRepo
+    putFiles repo (← pack overwrite (verbose := true) unpackedOnly) overwrite (← getToken)
   match args with
   | "get"  :: args => get args
   | "get!" :: args => get args (force := true)

--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -16,6 +16,8 @@ def getRemoteRepo : IO String := do
       Failed to run Git to determine project repository (exit code: {out.exitCode}).\n\
       Ensure Git is installed and the `origin` remote points to the project's GitHub repository.\n\
       Stdout:\n{out.stdout.trim}\nStderr:{out.stderr.trim}\n"
+  -- No strong validation is done here because this is simply used as a smart default
+  -- for `lake exe cache get`, which is freely modifiable by any user.
   let url := out.stdout.trim.stripSuffix ".git"
   let repo? : Option String := do
     let pos ← url.revFind (· == '/')


### PR DESCRIPTION
Cache can now scope files by repository.  By default, it will use the `origin` Git remote to determine the project repository. This can be overridden with the `--repo=` option (e.g., `lake exe cache --repo=foo/bar get`). 

On a `get`, it will first fetch the cache for detected repository and then the cache for the main Mathlib repository (i.e., this one). If `--repo` is specified, it will only fetch the cache for it.

On a `put`, it will upload **ALL** build files to the (detected  or specified) repository's cache. To avoid uploading files already present on the main Mathlib cache, use `put-unpacked` after fetching from the main cache. This will upload only the newly built (and thus not yet packed) artifacts.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
