### PR TITLE
[Merged by Bors] - feat: congruence in the domain and codomain of MultilinearMap

### DIFF
--- a/Mathlib/Analysis/NormedSpace/Alternating/Basic.lean
+++ b/Mathlib/Analysis/NormedSpace/Alternating/Basic.lean
@@ -452,7 +452,10 @@ def ContinuousAlternatingMap.compContinuousLinearMapCLM (f : E →L[𝕜] F) :
       (g.norm_compContinuousLinearMap_le f).trans_eq (mul_comm _ _)
 
 /-- Given a continuous linear isomorphism between the domains,
-generate a continuous linear isomorphism between the spaces of continuous alternating maps. -/
+generate a continuous linear isomorphism between the spaces of continuous alternating maps.
+
+This is `ContinuousAlternatingMap.compContinuousLinearMap` as an equivalence,
+and is the continuous version of `LinearEquiv.congrLeftAlternating`. -/
 @[simps apply]
 def ContinuousLinearEquiv.continuousAlternatingMapCongrLeft (f : E ≃L[𝕜] F) :
     E [⋀^ι]→L[𝕜] G ≃L[𝕜] (F [⋀^ι]→L[𝕜] G) where

--- a/Mathlib/Analysis/NormedSpace/Alternating/Basic.lean
+++ b/Mathlib/Analysis/NormedSpace/Alternating/Basic.lean
@@ -455,7 +455,7 @@ def ContinuousAlternatingMap.compContinuousLinearMapCLM (f : E →L[𝕜] F) :
 generate a continuous linear isomorphism between the spaces of continuous alternating maps.
 
 This is `ContinuousAlternatingMap.compContinuousLinearMap` as an equivalence,
-and is the continuous version of `LinearEquiv.congrLeftAlternating`. -/
+and is the continuous version of `AlternatingMap.domLCongr`. -/
 @[simps apply]
 def ContinuousLinearEquiv.continuousAlternatingMapCongrLeft (f : E ≃L[𝕜] F) :
     E [⋀^ι]→L[𝕜] G ≃L[𝕜] (F [⋀^ι]→L[𝕜] G) where

--- a/Mathlib/LinearAlgebra/Alternating/Basic.lean
+++ b/Mathlib/LinearAlgebra/Alternating/Basic.lean
@@ -567,7 +567,8 @@ variable (S : Type*) [Semiring S] [Module S N] [SMulCommClass R S N]
 
 /-- Construct a linear equivalence between maps from a linear equivalence between domains.
 
-This is the alternating version of `LinearEquiv.congrLeftMultilinear`. -/
+This is `AlternatingMap.compLinearMap` as an isomorphism,
+and the alternating version of `LinearEquiv.congrLeftMultilinear`. -/
 @[simps apply]
 def domLCongr (e : M ≃ₗ[R] M₂) : M [⋀^ι]→ₗ[R] N ≃ₗ[S] (M₂ [⋀^ι]→ₗ[R] N) where
   toFun f := f.compLinearMap e.symm
@@ -590,6 +591,7 @@ theorem domLCongr_trans (e : M ≃ₗ[R] M₂) (f : M₂ ≃ₗ[R] M₃) :
   rfl
 
 end DomLcongr
+
 
 /-- Composing an alternating map with the same linear equiv on each argument gives the zero map
 if and only if the alternating map is the zero map. -/
@@ -896,6 +898,20 @@ variable {R' : Type*} {M'' M₂'' N'' N₂'' : Type*} [CommSemiring R'] [AddComm
   [AddCommMonoid M₂''] [AddCommMonoid N''] [AddCommMonoid N₂''] [Module R' M''] [Module R' M₂'']
   [Module R' N''] [Module R' N₂'']
 
+/-- An isomorphism of multilinear maps given an isomorphism between their codomains.
+
+This is `Linear.compAlternatingMap` as an isomorphism,
+and the alternating version of `LinearEquiv.congrRightMultilinear`. -/
+@[simps!]
+def LinearEquiv.congrRightAlternating (e : N'' ≃ₗ[R'] N₂'') :
+    M''[⋀^ι]→ₗ[R'] N'' ≃ₗ[R'] (M'' [⋀^ι]→ₗ[R'] N₂'') where
+  toFun f := e.compAlternatingMap f
+  invFun f := e.symm.compAlternatingMap f
+  map_add' _ _ := by ext; simp
+  map_smul' _ _ := by ext; simp
+  left_inv _ := by ext; simp
+  right_inv _ := by ext; simp
+
 /-- The space of constant maps is equivalent to the space of maps that are alternating with respect
 to an empty family. -/
 @[simps]
@@ -906,4 +922,3 @@ def AlternatingMap.constLinearEquivOfIsEmpty [IsEmpty ι] : N'' ≃ₗ[R'] (M'' 
   invFun f := f 0
   left_inv _ := rfl
   right_inv f := ext fun _ => AlternatingMap.congr_arg f <| Subsingleton.elim _ _
-

--- a/Mathlib/LinearAlgebra/Alternating/Basic.lean
+++ b/Mathlib/LinearAlgebra/Alternating/Basic.lean
@@ -592,7 +592,6 @@ theorem domLCongr_trans (e : M ≃ₗ[R] M₂) (f : M₂ ≃ₗ[R] M₃) :
 
 end DomLcongr
 
-
 /-- Composing an alternating map with the same linear equiv on each argument gives the zero map
 if and only if the alternating map is the zero map. -/
 @[simp]

--- a/Mathlib/LinearAlgebra/Alternating/Basic.lean
+++ b/Mathlib/LinearAlgebra/Alternating/Basic.lean
@@ -568,7 +568,8 @@ variable (S : Type*) [Semiring S] [Module S N] [SMulCommClass R S N]
 /-- Construct a linear equivalence between maps from a linear equivalence between domains.
 
 This is `AlternatingMap.compLinearMap` as an isomorphism,
-and the alternating version of `LinearEquiv.congrLeftMultilinear`. -/
+and the alternating version of `LinearEquiv.multilinearMapCongrLeft`.
+It could also have been called `LinearEquiv.alternatingMapCongrLeft`. -/
 @[simps apply]
 def domLCongr (e : M ≃ₗ[R] M₂) : M [⋀^ι]→ₗ[R] N ≃ₗ[S] (M₂ [⋀^ι]→ₗ[R] N) where
   toFun f := f.compLinearMap e.symm
@@ -900,9 +901,9 @@ variable {R' : Type*} {M'' M₂'' N'' N₂'' : Type*} [CommSemiring R'] [AddComm
 /-- An isomorphism of multilinear maps given an isomorphism between their codomains.
 
 This is `Linear.compAlternatingMap` as an isomorphism,
-and the alternating version of `LinearEquiv.congrRightMultilinear`. -/
+and the alternating version of `LinearEquiv.multilinearMapCongrRight`. -/
 @[simps!]
-def LinearEquiv.congrRightAlternating (e : N'' ≃ₗ[R'] N₂'') :
+def LinearEquiv.alternatingMapCongrRight (e : N'' ≃ₗ[R'] N₂'') :
     M''[⋀^ι]→ₗ[R'] N'' ≃ₗ[R'] (M'' [⋀^ι]→ₗ[R'] N₂'') where
   toFun f := e.compAlternatingMap f
   invFun f := e.symm.compAlternatingMap f

--- a/Mathlib/LinearAlgebra/Alternating/Basic.lean
+++ b/Mathlib/LinearAlgebra/Alternating/Basic.lean
@@ -565,7 +565,9 @@ section DomLcongr
 variable (ι R N)
 variable (S : Type*) [Semiring S] [Module S N] [SMulCommClass R S N]
 
-/-- Construct a linear equivalence between maps from a linear equivalence between domains. -/
+/-- Construct a linear equivalence between maps from a linear equivalence between domains.
+
+This is the alternating version of `LinearEquiv.congrLeftMultilinear`. -/
 @[simps apply]
 def domLCongr (e : M ≃ₗ[R] M₂) : M [⋀^ι]→ₗ[R] N ≃ₗ[S] (M₂ [⋀^ι]→ₗ[R] N) where
   toFun f := f.compLinearMap e.symm

--- a/Mathlib/LinearAlgebra/Multilinear/Basic.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Basic.lean
@@ -882,9 +882,7 @@ variable [AddCommMonoid M₃] [Module S M₃] [Module R M₃] [SMulCommClass R S
 variable (S) in
 /-- `LinearMap.compMultilinearMap` as an `S`-linear map. -/
 @[simps]
-def _root_.LinearMap.compMultilinearMapₗ [Semiring S] [Module S M₂] [Module S M₃]
-    [SMulCommClass R S M₂] [SMulCommClass R S M₃] [LinearMap.CompatibleSMul M₂ M₃ S R]
-    (g : M₂ →ₗ[R] M₃) :
+def _root_.LinearMap.compMultilinearMapₗ [LinearMap.CompatibleSMul M₂ M₃ S R] (g : M₂ →ₗ[R] M₃) :
     MultilinearMap R M₁ M₂ →ₗ[S] MultilinearMap R M₁ M₃ where
   toFun := g.compMultilinearMap
   map_add' := g.compMultilinearMap_add
@@ -895,13 +893,11 @@ variable (S) in
 
 This is `LinearMap.compMultilinearMap` as an `S`-linear equivalence. -/
 @[simps! apply symm_apply]
-def _root_.LinearEquiv.congrRightMultilinear [Semiring S] [Module S M₂] [Module S M₃]
-    [SMulCommClass R S M₂] [SMulCommClass R S M₃]
-    [LinearMap.CompatibleSMul M₂ M₃ S R] [LinearMap.CompatibleSMul M₃ M₂ S R]
-    (g : M₂ ≃ₗ[R] M₃) :
+def _root_.LinearEquiv.congrRightMultilinear
+    [LinearMap.CompatibleSMul M₂ M₃ S R] [LinearMap.CompatibleSMul M₃ M₂ S R] (g : M₂ ≃ₗ[R] M₃) :
     MultilinearMap R M₁ M₂ ≃ₗ[S] MultilinearMap R M₁ M₃ where
-  __ := LinearMap.compMultilinearMapₗ S g.toLinearMap
-  invFun := LinearMap.compMultilinearMapₗ S g.symm.toLinearMap
+  __ := g.toLinearMap.compMultilinearMapₗ S
+  invFun := g.symm.toLinearMap.compMultilinearMapₗ S
   left_inv _ := by ext; simp
   right_inv _ := by ext; simp
 

--- a/Mathlib/LinearAlgebra/Multilinear/Basic.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Basic.lean
@@ -891,7 +891,9 @@ def _root_.LinearMap.compMultilinearMapₗ [Semiring S] [Module S M₂] [Module 
   map_smul' := g.compMultilinearMap_smul
 
 variable (S) in
-/-- `LinearMap.compMultilinearMap` as an `S`-linear equivalence. -/
+/-- An isomorphism of multilinear maps given an isomorphism between their codomains.
+
+This is `LinearMap.compMultilinearMap` as an `S`-linear equivalence. -/
 @[simps! apply symm_apply]
 def _root_.LinearEquiv.congrRightMultilinear [Semiring S] [Module S M₂] [Module S M₃]
     [SMulCommClass R S M₂] [SMulCommClass R S M₃]

--- a/Mathlib/LinearAlgebra/Multilinear/Basic.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Basic.lean
@@ -894,7 +894,7 @@ variable (S) in
 This is `LinearMap.compMultilinearMap` as an `S`-linear equivalence,
 and the multilinear version of `LinearEquiv.congrRight`. -/
 @[simps! apply symm_apply]
-def _root_.LinearEquiv.congrRightMultilinear
+def _root_.LinearEquiv.multilinearMapCongrRight
     [LinearMap.CompatibleSMul M₂ M₃ S R] [LinearMap.CompatibleSMul M₃ M₂ S R] (g : M₂ ≃ₗ[R] M₃) :
     MultilinearMap R M₁ M₂ ≃ₗ[S] MultilinearMap R M₁ M₃ where
   __ := g.toLinearMap.compMultilinearMapₗ S
@@ -1065,7 +1065,7 @@ sending a multilinear map `g` to `g (f₁ ⬝ , ..., fₙ ⬝ )` is linear in `g
 This is `MultilinearMap.compLinearMap` as a linear equivalence,
 and the multilinear version of `LinearEquiv.congrLeft`. -/
 @[simps! apply symm_apply]
-def _root_.LinearEquiv.congrLeftMultilinear (e : Π (i : ι), M₁ i ≃ₗ[R] M₁' i) :
+def _root_.LinearEquiv.multilinearMapCongrLeft (e : Π (i : ι), M₁ i ≃ₗ[R] M₁' i) :
     (MultilinearMap R M₁' M₂) ≃ₗ[R] MultilinearMap R M₁ M₂ where
   __ := compLinearMapₗ (e · |>.toLinearMap)
   invFun := compLinearMapₗ (e · |>.symm.toLinearMap)

--- a/Mathlib/LinearAlgebra/Multilinear/Basic.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Basic.lean
@@ -891,7 +891,8 @@ def _root_.LinearMap.compMultilinearMapₗ [LinearMap.CompatibleSMul M₂ M₃ S
 variable (S) in
 /-- An isomorphism of multilinear maps given an isomorphism between their codomains.
 
-This is `LinearMap.compMultilinearMap` as an `S`-linear equivalence. -/
+This is `LinearMap.compMultilinearMap` as an `S`-linear equivalence,
+and the multilinear version of `LinearEquiv.congrRight`. -/
 @[simps! apply symm_apply]
 def _root_.LinearEquiv.congrRightMultilinear
     [LinearMap.CompatibleSMul M₂ M₃ S R] [LinearMap.CompatibleSMul M₃ M₂ S R] (g : M₂ ≃ₗ[R] M₃) :
@@ -1061,7 +1062,8 @@ sending a multilinear map `g` to `g (f₁ ⬝ , ..., fₙ ⬝ )` is linear in `g
 
 /-- An isomorphism of multilinear maps given an isomorphism between their domains.
 
-This is `MultilinearMap.compLinearMap` as a linear equivalence. -/
+This is `MultilinearMap.compLinearMap` as a linear equivalence,
+and the multilinear version of `LinearEquiv.congrLeft`. -/
 @[simps! apply symm_apply]
 def _root_.LinearEquiv.congrLeftMultilinear (e : Π (i : ι), M₁ i ≃ₗ[R] M₁' i) :
     (MultilinearMap R M₁' M₂) ≃ₗ[R] MultilinearMap R M₁ M₂ where

--- a/Mathlib/LinearAlgebra/Multilinear/Basic.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Basic.lean
@@ -890,6 +890,19 @@ def _root_.LinearMap.compMultilinearMapₗ [Semiring S] [Module S M₂] [Module 
   map_add' := g.compMultilinearMap_add
   map_smul' := g.compMultilinearMap_smul
 
+variable (S) in
+/-- `LinearMap.compMultilinearMap` as an `S`-linear equivalence. -/
+@[simps! apply symm_apply]
+def _root_.LinearEquiv.congrRightMultilinear [Semiring S] [Module S M₂] [Module S M₃]
+    [SMulCommClass R S M₂] [SMulCommClass R S M₃]
+    [LinearMap.CompatibleSMul M₂ M₃ S R] [LinearMap.CompatibleSMul M₃ M₂ S R]
+    (g : M₂ ≃ₗ[R] M₃) :
+    MultilinearMap R M₁ M₂ ≃ₗ[S] MultilinearMap R M₁ M₃ where
+  __ := LinearMap.compMultilinearMapₗ S g.toLinearMap
+  invFun := LinearMap.compMultilinearMapₗ S g.symm.toLinearMap
+  left_inv _ := by ext; simp
+  right_inv _ := by ext; simp
+
 variable (R S M₁ M₂ M₃)
 
 section OfSubsingleton
@@ -1047,6 +1060,17 @@ sending a multilinear map `g` to `g (f₁ ⬝ , ..., fₙ ⬝ )` is linear in `g
   toFun := fun g ↦ g.compLinearMap f
   map_add' := fun _ _ ↦ rfl
   map_smul' := fun _ _ ↦ rfl
+
+/-- An isomorphism of multilinear maps given an isomorphism between their domains.
+
+This is `MultilinearMap.compLinearMap` as a linear equivalence. -/
+@[simps! apply symm_apply]
+def _root_.LinearEquiv.congrLeftMultilinear (e : Π (i : ι), M₁ i ≃ₗ[R] M₁' i) :
+    (MultilinearMap R M₁' M₂) ≃ₗ[R] MultilinearMap R M₁ M₂ where
+  __ := compLinearMapₗ (e · |>.toLinearMap)
+  invFun := compLinearMapₗ (e · |>.symm.toLinearMap)
+  left_inv _ := by ext; simp
+  right_inv _ := by ext; simp
 
 /-- If `f` is a collection of linear maps, then the construction `MultilinearMap.compLinearMap`
 sending a multilinear map `g` to `g (f₁ ⬝ , ..., fₙ ⬝ )` is linear in `g` and multilinear in

--- a/Mathlib/Topology/Algebra/Module/Alternating/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Alternating/Basic.lean
@@ -333,7 +333,12 @@ theorem _root_.ContinuousLinearMap.compContinuousAlternatingMap_coe (g : N →L[
   rfl
 
 /-- A continuous linear equivalence of domains
-defines an equivalence between continuous alternating maps. -/
+defines an equivalence between continuous alternating maps.
+
+This is available as a continuos linear isomorphism at
+`ContinuousLinearEquiv.continuousAlternatingMapCongrLeft`.
+
+This is `ContinuousAlternatingMap.compContinuousLinearMap` as an equivalence. -/
 @[simps -fullyApplied apply]
 def _root_.ContinuousLinearEquiv.continuousAlternatingMapCongrLeftEquiv (e : M ≃L[R] M') :
     M [⋀^ι]→L[R] N ≃ M' [⋀^ι]→L[R] N where

--- a/Mathlib/Topology/Algebra/Module/Alternating/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Alternating/Basic.lean
@@ -335,7 +335,7 @@ theorem _root_.ContinuousLinearMap.compContinuousAlternatingMap_coe (g : N →L[
 /-- A continuous linear equivalence of domains
 defines an equivalence between continuous alternating maps.
 
-This is available as a continuos linear isomorphism at
+This is available as a continuous linear isomorphism at
 `ContinuousLinearEquiv.continuousAlternatingMapCongrLeft`.
 
 This is `ContinuousAlternatingMap.compContinuousLinearMap` as an equivalence. -/


### PR DESCRIPTION
I found myself wanting these in #25141

We already have some of these results with inconsistent names elsewhere; for now this just adds crosslinks, we can unify the names later.

The names are a little inconsistent here; for the domain we have:

* `LinearEquiv.multilinearMapCongrLeft` (new in this PR)
* `AlternatingMap.domLCongr`
* `ContinuousLinearEquiv.continuousMultilinearMapCongrRight`
* `ContinuousLinearEquiv.continuousAlternatingMapCongrLeft`
  * `ContinuousLinearEquiv.continuousAlternatingMapCongrLeftEquiv` (not a linear equiv)

and for the range:

* `LinearEquiv.multilinearMapCongrRight` (new in this PR)
* `LinearEquiv.alternatingMapCongrRight` (new in this PR)
* `ContinuousLinearEquiv.continuousMultilinearMapCongrRight`
* `ContinuousLinearEquiv.continuousAlternatingMapCongrRight`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
