### PR TITLE
[Merged by Bors] - feat(Algebra/Order): add Archimedean class

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -752,6 +752,7 @@ import Mathlib.Algebra.Order.Antidiag.Nat
 import Mathlib.Algebra.Order.Antidiag.Pi
 import Mathlib.Algebra.Order.Antidiag.Prod
 import Mathlib.Algebra.Order.Archimedean.Basic
+import Mathlib.Algebra.Order.Archimedean.Class
 import Mathlib.Algebra.Order.Archimedean.Hom
 import Mathlib.Algebra.Order.Archimedean.IndicatorCard
 import Mathlib.Algebra.Order.Archimedean.Submonoid

--- a/Mathlib/Algebra/Order/Archimedean/Class.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Class.lean
@@ -16,36 +16,37 @@ This file defines archimedean classes of a given linearly ordered group.
 
 * `ArchimedeanClass` are classes of elements in a ordered additive commutative group
   that are archimedean equivelent. Two elements `a` and `b` are archimedean equivalent when there
-  exists two positive integers `m` and `n` such that `|a| ≤ m • |b|` and `|b| ≤ n • |a|`.
+  exists two natural numbers `m` and `n` such that `|a| ≤ m • |b|` and `|b| ≤ n • |a|`.
 * `MulArchimedeanClass` is the multiplicative version of `ArchimedeanClass`.
   Two elements `a` and `b` are mul-archimedean equivalent when there
-  exists two positive integers `m` and `n` such that `|a|ₘ ≤ |b|ₘ ^ m` and `|b|ₘ ≤ |a|ₘ ^ n`.
+  exists two natural numbers `m` and `n` such that `|a|ₘ ≤ |b|ₘ ^ m` and `|b|ₘ ≤ |a|ₘ ^ n`.
 * `ArchimedeanClass.orderHom` and `MulArchimedeanClass.orderHom` are `OrderHom` over
   archimedean classes lifted from ordered group homomorphisms.
 
 ## Main statements
-* `ArchimedeanClass.archimedean_of_mk_eq_mk` / `MulArchimedeanClass.mulArchimedean_of_mk_eq_mk`:
-  an ordered commutative group is (mul-)archimedean if
-  all non-identity elements belong to the same (`Mul`-)`ArchimedeanClass`.
+
+The following theorems state that an ordered commutative group is (mul-)archimedean if and only if
+all non-identity elements belong to the same (`Mul`-)`ArchimedeanClass`:
+* `ArchimedeanClass.archimedean_of_mk_eq_mk` / `MulArchimedeanClass.mulArchimedean_of_mk_eq_mk`
+* `ArchimedeanClass.mk_eq_mk_of_archimedean` / `MulArchimedeanClass.mk_eq_mk_of_mulArchimedean`
 
 -/
 
 variable {M: Type*}
-variable [CommGroup M] [LinearOrder M] [IsOrderedMonoid M]
+variable [CommGroup M] [LinearOrder M] [IsOrderedMonoid M] {a b : M}
 
 variable (M) in
-/-- Two elements are mul-archimedean equivalent iff there exists two positive integers
+/-- Two elements are mul-archimedean equivalent iff there exists two natural numbers
 `m` and `n` such that `|a|ₘ ≤ |b|ₘ ^ m` and `|b|ₘ ≤ |a|ₘ ^ n`. -/
 @[to_additive archimedeanEquiv "Two elements are archimedean equivalent iff there exists
-two positive integers `m` and `n` such that `|a| ≤ m • |b|` and `|b| ≤ n • |a|`."]
+two natural numbers `m` and `n` such that `|a| ≤ m • |b|` and `|b| ≤ n • |a|`."]
 def mulArchimedeanEquiv : Setoid M where
-  r a b := (∃ m, m ≠ 0 ∧ |a|ₘ ≤ |b|ₘ ^ m) ∧ (∃ n, n ≠ 0 ∧ |b|ₘ ≤ |a|ₘ ^ n)
-  iseqv.refl _ := ⟨⟨1, by simp, by simp⟩, ⟨1, by simp, by simp⟩⟩
+  r a b := (∃ m, |a|ₘ ≤ |b|ₘ ^ m) ∧ (∃ n, |b|ₘ ≤ |a|ₘ ^ n)
+  iseqv.refl _ := ⟨⟨1, by simp⟩, ⟨1, by simp⟩⟩
   iseqv.symm := And.symm
   iseqv.trans {a b c} := by
-    intro ⟨⟨m, hm0, hm⟩, ⟨n, hn0, hn⟩⟩ ⟨⟨m', hm0', hm'⟩, ⟨n', hn0', hn'⟩⟩
-    refine ⟨⟨m' * m, mul_ne_zero hm0' hm0, hm.trans ?_⟩,
-      ⟨n * n', mul_ne_zero hn0 hn0', hn'.trans ?_⟩⟩
+    intro ⟨⟨m, hm⟩, ⟨n, hn⟩⟩ ⟨⟨m', hm'⟩, ⟨n', hn'⟩⟩
+    refine ⟨⟨m' * m, hm.trans ?_⟩, ⟨n * n', hn'.trans ?_⟩⟩
     · rw [pow_mul]
       exact pow_le_pow_left' hm' m
     · rw [pow_mul]
@@ -81,16 +82,16 @@ theorem out_eq (A : MulArchimedeanClass M) : mk A.out = A := Quotient.out_eq' A
 
 @[to_additive]
 theorem eq {a b : M} :
-    mk a = mk b ↔ (∃ m, m ≠ 0 ∧ |a|ₘ ≤ |b|ₘ ^ m) ∧ (∃ n, n ≠ 0 ∧ |b|ₘ ≤ |a|ₘ ^ n) := Quotient.eq''
+    mk a = mk b ↔ (∃ m, |a|ₘ ≤ |b|ₘ ^ m) ∧ (∃ n, |b|ₘ ≤ |a|ₘ ^ n) := Quotient.eq''
 
 @[to_additive]
 theorem mk_out (a : M) :
-    (∃ m, m ≠ 0 ∧ |(mk a).out|ₘ ≤ |a|ₘ ^ m) ∧ (∃ n, n ≠ 0 ∧ |a|ₘ ≤ |(mk a).out|ₘ ^ n) :=
+    (∃ m, |(mk a).out|ₘ ≤ |a|ₘ ^ m) ∧ (∃ n, |a|ₘ ≤ |(mk a).out|ₘ ^ n) :=
   eq.mp (by simp)
 
 @[to_additive (attr := simp)]
 theorem mk_inv (a : M) : mk a⁻¹ = mk a :=
-  eq.mpr ⟨⟨1, by simp, by simp⟩, ⟨1, by simp, by simp⟩⟩
+  eq.mpr ⟨⟨1, by simp⟩, ⟨1, by simp⟩⟩
 
 @[to_additive]
 theorem mk_div_comm (a b : M) : mk (a / b) = mk (b / a) := by
@@ -98,14 +99,13 @@ theorem mk_div_comm (a b : M) : mk (a / b) = mk (b / a) := by
 
 @[to_additive (attr := simp)]
 theorem mk_mabs (a : M) : mk |a|ₘ = mk a :=
-  eq.mpr ⟨⟨1, by simp, by simp⟩, ⟨1, by simp, by simp⟩⟩
+  eq.mpr ⟨⟨1, by simp⟩, ⟨1, by simp⟩⟩
 
 @[to_additive (attr := simp)]
 theorem mk_eq_mk_one_iff {a : M} : mk a = mk 1 ↔ a = 1 := by
   constructor
   · intro h
-    rw [eq] at h
-    obtain ⟨⟨_, _, hm⟩, _⟩ := h
+    obtain ⟨⟨_, hm⟩, _⟩ := eq.mp h
     simpa using hm
   · intro h
     rw [h]
@@ -119,7 +119,7 @@ variable (M) in
 /-- We equip archimedean classes with linear order using the absolute value of their
 representatives. By convention, elements with smaller absolute value are in *larger* classes.
 Ordering backwards this way simplifies formalization of theorems such as
-Hahn embedding theorem.
+the Hahn embedding theorem.
 
 While the order is defined using `MulArchimedean.out`, it is equivalently characterized by
 `MulArchimedean.mk_le_mk` and `MulArchimedean.mk_lt_mk`, which are recommended to use to
@@ -127,19 +127,17 @@ avoid using `MulArchimedean.out`. -/
 @[to_additive "We equip archimedean classes with linear order using the absolute value of their
 representatives. By convention, elements with smaller absolute value are in *larger* classes.
 Ordering backwards this way simplifies formalization of theorems such as
-Hahn embedding theorem.
+the Hahn embedding theorem.
 
 While the order is defined using `Archimedean.out`, it is equivalently characterized by
 `Archimedean.mk_le_mk` and `Archimedean.mk_lt_mk`, which are recommended to use to
 avoid using `Archimedean.out`."]
 noncomputable
 instance instLinearOrder : LinearOrder (MulArchimedeanClass M) :=
-  LinearOrder.lift' (OrderDual.toDual |·.out|ₘ) (by
-    intro A B
+  LinearOrder.lift' (OrderDual.toDual |·.out|ₘ) fun A B ↦ by
     simp only [EmbeddingLike.apply_eq_iff_eq]
     intro h
     simpa using congr_arg mk h
-  )
 
 @[to_additive]
 theorem le (A B : MulArchimedeanClass M) : A ≤ B ↔ |B.out|ₘ ≤ |A.out|ₘ := by rfl
@@ -153,36 +151,30 @@ theorem le_mk_one (A : MulArchimedeanClass M) : A ≤ mk 1 := by
   simp
 
 @[to_additive]
-theorem mk_lt_mk {a b : M} : mk a < mk b ↔ ∀ n, |b|ₘ ^ n < |a|ₘ := by
-  obtain ⟨⟨m, hm0, hm⟩, ⟨n, hn0, hn⟩⟩ := mk_out a
-  obtain ⟨⟨m', hm0', hm'⟩, ⟨n', hn0', hn'⟩⟩ := mk_out b
+theorem mk_lt_mk : mk a < mk b ↔ ∀ n, |b|ₘ ^ n < |a|ₘ := by
+  obtain ⟨⟨m, hm⟩, ⟨n, hn⟩⟩ := mk_out a
+  obtain ⟨⟨m', hm'⟩, ⟨n', hn'⟩⟩ := mk_out b
   constructor
   · intro h k
-    by_cases hk0 : k = 0
-    · rw [hk0]
-      simp only [pow_zero, one_lt_mabs]
-      contrapose! h
-      rw [h]
-      simpa using le_mk_one (mk b)
-    · have hne : ¬ mk a = mk b := ne_of_lt h
-      rw [eq] at hne
-      simp only [not_and, not_exists, not_le, forall_exists_index] at hne
-      by_contra!
-      obtain hne' := hne k ⟨hk0, this⟩ (m * n') (by simp [hn0', hm0])
-      rw [lt] at h
-      contrapose! hne'
-      refine le_of_lt (lt_of_le_of_lt hn' ?_)
-      rw [pow_mul, (pow_left_strictMono hn0').lt_iff_lt]
-      exact lt_of_lt_of_le h hm
+    have hne : ¬ mk a = mk b := ne_of_lt h
+    rw [eq] at hne
+    simp only [not_and, not_exists, not_le, forall_exists_index] at hne
+    by_contra!
+    obtain hne' := hne k this (m * n')
+    rw [lt] at h
+    contrapose! hne'
+    refine hn'.trans ?_
+    rw [pow_mul]
+    exact pow_le_pow_left' (lt_of_lt_of_le h hm).le n'
   · intro h
-    rw [lt, ← (pow_left_strictMono hn0).lt_iff_lt]
-    rw [← (pow_left_strictMono hn0).le_iff_le] at hm'
-    apply lt_of_le_of_lt hm'
+    rw [lt]
+    apply (pow_left_mono n).reflect_lt
+    apply lt_of_le_of_lt (pow_le_pow_left' hm' n)
     rw [← pow_mul]
     exact lt_of_lt_of_le (h (m' * n)) hn
 
 @[to_additive]
-theorem mk_le_mk {a b : M} : mk a ≤ mk b ↔ ∃ n, |b|ₘ ≤ |a|ₘ ^ n := by
+theorem mk_le_mk : mk a ≤ mk b ↔ ∃ n, |b|ₘ ≤ |a|ₘ ^ n := by
   simpa using mk_lt_mk.not
 
 variable (M) in
@@ -199,16 +191,10 @@ theorem top_eq : (⊤ : MulArchimedeanClass M) = mk 1 := rfl
 
 variable (M) in
 @[to_additive (attr := simp)]
-theorem top_out : (⊤ : MulArchimedeanClass M).out = 1 := by
-  exact mk_one_out M
+theorem top_out : (⊤ : MulArchimedeanClass M).out = 1 := mk_one_out M
 
 @[to_additive (attr := simp)]
-theorem mk_eq_top_iff {a : M} : mk a = ⊤ ↔ a = 1 := by
-  exact mk_eq_mk_one_iff
-
-@[to_additive]
-theorem ne_top_of_lt {A B : MulArchimedeanClass M} (h : A < B) : A ≠ ⊤ :=
-  lt_of_lt_of_le h le_top |>.ne
+theorem mk_eq_top_iff : mk a = ⊤ ↔ a = 1 := mk_eq_mk_one_iff
 
 variable (M) in
 @[to_additive]
@@ -238,32 +224,35 @@ theorem mk_monotoneOn : MonotoneOn mk (Set.Iic (1 : M)) := by
   simpa using h
 
 @[to_additive]
-theorem mk_le_mk_self_mul_of_mk_eq {a b : M} (hab : mk a = mk b) : mk a ≤ mk (a * b) := by
+theorem min_le_mk_mul (a b : M) : min (mk a) (mk b) ≤ mk (a * b) := by
   by_contra! h
-  obtain h1 := mk_lt_mk.mp h 2
-  obtain h2 := mk_lt_mk.mp (hab ▸ h) 2
-  rw [pow_two] at h1 h2
-  obtain h1 := lt_of_lt_of_le h1 (mabs_mul _ _)
-  obtain h2 := lt_of_lt_of_le h2 (mabs_mul _ _)
-  simp only [mul_lt_mul_iff_left, mul_lt_mul_iff_right] at h1 h2
-  have := h1.trans h2
-  simp at this
+  rw [lt_min_iff] at h
+  have h1 := (mk_lt_mk.mp h.1 2).trans_le (mabs_mul _ _)
+  have h2 := (mk_lt_mk.mp h.2 2).trans_le (mabs_mul _ _)
+  simp only [mul_lt_mul_iff_left, mul_lt_mul_iff_right, pow_two] at h1 h2
+  exact h1.not_lt h2
 
 @[to_additive]
-theorem mk_eq_mk_self_mul_of_mk_lt {a b : M} (h : mk a < mk b) : mk a = mk (a * b) := by
+theorem mk_left_le_mk_mul (hab : mk a ≤ mk b) : mk a ≤ mk (a * b) := by
+  simpa [hab] using min_le_mk_mul (a := a) (b := b)
+
+@[to_additive]
+theorem mk_right_le_mk_mul (hba : mk b ≤ mk a) : mk b ≤ mk (a * b) := by
+  simpa [hba] using min_le_mk_mul (a := a) (b := b)
+
+@[to_additive]
+theorem mk_left_eq_mk_mul (h : mk a < mk b) : mk a = mk (a * b) := by
+  refine le_antisymm (mk_left_le_mk_mul h.le) (mk_le_mk.mpr ⟨2, ?_⟩)
   rw [mk_lt_mk] at h
-  refine eq.mpr ⟨⟨2, by simp, ?_⟩, ⟨2, by simp, ?_⟩⟩
-  · apply (mabs_mul' _ b).trans
-    rw [mul_comm b a, pow_two, mul_le_mul_iff_right]
-    apply le_of_mul_le_mul_left' (a := |b|ₘ)
-    rw [mul_comm a b]
-    refine le_trans ?_ (mabs_mul' a b)
-    obtain h := (h 2).le
-    rw [pow_two] at h
-    exact h
-  · apply (mabs_mul _ _).trans
-    rw [pow_two, mul_le_mul_iff_left]
-    simpa using (h 1).le
+  apply (mabs_mul' _ b).trans
+  rw [mul_comm b a, pow_two, mul_le_mul_iff_right]
+  apply le_of_mul_le_mul_left' (a := |b|ₘ)
+  rw [mul_comm a b]
+  exact (pow_two |b|ₘ ▸ (h 2).le).trans (mabs_mul' a b)
+
+@[to_additive]
+theorem mk_right_eq_mk_mul (h : mk b < mk a) : mk b = mk (a * b) :=
+  mul_comm a b ▸ mk_left_eq_mk_mul h
 
 /-- The product over a set of an elements in distinct classes is in the lowest class. -/
 @[to_additive "The sum over a set of an elements in distinct classes is in the lowest class."]
@@ -285,7 +274,7 @@ theorem mk_prod {ι : Type*} [LinearOrder ι] {s : Finset ι} (hnonempty : s.Non
       exact hi (Finset.min'_mem _ hs)
     rw [← ih] at hne
     obtain hlt|hlt := lt_or_gt_of_ne hne
-    · rw [← mk_eq_mk_self_mul_of_mk_lt hlt]
+    · rw [← mk_left_eq_mk_mul hlt]
       congr
       apply le_antisymm (Finset.le_min' _ _ _ ?_) (Finset.min'_le _ _ (by simp))
       intro y hy
@@ -295,7 +284,7 @@ theorem mk_prod {ι : Type*} [LinearOrder ι] {s : Finset ι} (hnonempty : s.Non
         apply (hmono.lt_iff_lt (by simp) hminmem).mp
         rw [ih] at hlt
         exact hlt
-    · rw [mul_comm, ← mk_eq_mk_self_mul_of_mk_lt hlt, ih]
+    · rw [mul_comm, ← mk_left_eq_mk_mul hlt, ih]
       congr 2
       refine le_antisymm (Finset.le_min' _ _ _ ?_) (Finset.min'_le _ _ hminmem)
       intro y hy
@@ -306,31 +295,19 @@ theorem mk_prod {ι : Type*} [LinearOrder ι] {s : Finset ι} (hnonempty : s.Non
       · exact Finset.min'_le _ _ hmem
 
 @[to_additive]
-theorem min_le_mk_mul (a b : M) : min (mk a) (mk b) ≤ mk (a * b) := by
-  obtain hab|hab|hab := lt_trichotomy (mk a) (mk b)
-  · rw [inf_le_iff]
-    exact Or.inl (mk_eq_mk_self_mul_of_mk_lt hab).le
-  · rw [← hab]
-    simpa using mk_le_mk_self_mul_of_mk_eq hab
-  · rw [inf_le_iff]
-    right
-    rw [mul_comm]
-    exact (mk_eq_mk_self_mul_of_mk_lt hab).le
-
-@[to_additive]
-theorem lt_of_mk_lt_mk_of_one_le {a b : M} (h : mk a < mk b) (hpos : 1 ≤ a) : b < a := by
+theorem lt_of_mk_lt_mk_of_one_le (h : mk a < mk b) (hpos : 1 ≤ a) : b < a := by
   obtain h := (mk_lt_mk).mp h 1
   rw [pow_one, mabs_lt, mabs_eq_self.mpr hpos] at h
   exact h.2
 
 @[to_additive]
-theorem lt_of_mk_lt_mk_of_le_one {a b : M} (h : mk a < mk b) (hneg : a ≤ 1) : a < b := by
+theorem lt_of_mk_lt_mk_of_le_one (h : mk a < mk b) (hneg : a ≤ 1) : a < b := by
   obtain h := (mk_lt_mk).mp h 1
   rw [pow_one, mabs_lt, mabs_eq_inv_self.mpr hneg, inv_inv] at h
   exact h.1
 
 @[to_additive]
-theorem one_lt_of_one_lt_of_mk_lt {a b : M} (ha : 1 < a) (hab : mk a < mk (b / a)) :
+theorem one_lt_of_one_lt_of_mk_lt (ha : 1 < a) (hab : mk a < mk (b / a)) :
     1 < b := by
   suffices a⁻¹ < b / a by
     simpa using this
@@ -348,9 +325,16 @@ theorem mulArchimedean_of_mk_eq_mk (h : ∀ (a b : M), a ≠ 1 → b ≠ 1 → m
       simpa using hx
     · have hx : 1 < x := lt_of_not_ge hx
       have hxy : mk x = mk y := h x y hx.ne.symm hy.ne.symm
-      obtain ⟨⟨m, _, hm⟩, _⟩ := (MulArchimedeanClass.eq).mp hxy
+      obtain ⟨⟨m, hm⟩, _⟩ := (MulArchimedeanClass.eq).mp hxy
       rw [mabs_eq_self.mpr hx.le, mabs_eq_self.mpr hy.le] at hm
       exact ⟨m, hm⟩
+
+@[to_additive mk_eq_mk_of_archimedean]
+theorem mk_eq_mk_of_mulArchimedean [MulArchimedean M] (ha : a ≠ 1) (hb : b ≠ 1) :
+    mk a = mk b := by
+  obtain hm := MulArchimedean.arch |a|ₘ (show 1 < |b|ₘ by simpa using hb)
+  obtain hn := MulArchimedean.arch |b|ₘ (show 1 < |a|ₘ by simpa using ha)
+  exact eq.mpr ⟨hm, hn⟩
 
 section Hom
 
@@ -377,16 +361,16 @@ def orderHom (f : F) : MulArchimedeanClass M →o MulArchimedeanClass N where
     exact h
 
 @[to_additive]
-theorem orderHom_apply (f : F) (A : MulArchimedeanClass M) : (orderHom f) A = mk (f A.out) := rfl
+theorem orderHom_apply (f : F) (A : MulArchimedeanClass M) : orderHom f A = mk (f A.out) := rfl
 
 @[to_additive]
-theorem map_mk (f : F) (a : M) : mk (f a) = (orderHom f) (mk a) := by
+theorem map_mk (f : F) (a : M) : mk (f a) = orderHom f (mk a) := by
   rw [orderHom_apply]
   apply eq.mpr
   have heq : mk a = mk (mk a).out := by
     rw [out_eq]
-  obtain ⟨⟨m, hm0, hm⟩, ⟨n, hn0, hn⟩⟩ := eq.mp heq
-  refine ⟨⟨m, hm0, ?_⟩, ⟨n, hn0, ?_⟩⟩
+  obtain ⟨⟨m, hm⟩, ⟨n, hn⟩⟩ := eq.mp heq
+  refine ⟨⟨m, ?_⟩, ⟨n, ?_⟩⟩
   all_goals
     rw [← map_mabs, ← map_mabs, ← map_pow]
     apply OrderHomClass.monotone
@@ -394,11 +378,11 @@ theorem map_mk (f : F) (a : M) : mk (f a) = (orderHom f) (mk a) := by
     try exact hn
 
 @[to_additive]
-theorem map_mk_eq (f : F) {a b : M} (h : mk a = mk b) : mk (f a) = mk (f b) := by
+theorem map_mk_eq (f : F) (h : mk a = mk b) : mk (f a) = mk (f b) := by
   rw [map_mk, map_mk, h]
 
 @[to_additive]
-theorem map_mk_le (f : F) {a b : M} (h : mk a ≤ mk b) : mk (f a) ≤ mk (f b) := by
+theorem map_mk_le (f : F) (h : mk a ≤ mk b) : mk (f a) ≤ mk (f b) := by
   rw [map_mk, map_mk]
   apply OrderHomClass.monotone
   exact h
@@ -412,8 +396,8 @@ theorem orderHom_injective {f : F} (h : Function.Injective f) :
   rw [orderHom_apply, orderHom_apply, eq, eq]
   simp_rw [← map_mabs, ← map_pow]
   intro h
-  obtain ⟨⟨m, hm0, hm⟩, ⟨n, hn0, hn⟩⟩ := h
-  refine ⟨⟨m, hm0, ?_⟩, ⟨n, hn0, ?_⟩⟩
+  obtain ⟨⟨m, hm⟩, ⟨n, hn⟩⟩ := h
+  refine ⟨⟨m, ?_⟩, ⟨n, ?_⟩⟩
   · contrapose! hm
     apply lt_of_le_of_ne
     · apply OrderHomClass.monotone f hm.le
@@ -426,7 +410,7 @@ theorem orderHom_injective {f : F} (h : Function.Injective f) :
       exact (h hn).symm.le
 
 @[to_additive (attr := simp)]
-theorem orderHom_top (f : F) : (orderHom f) ⊤ = ⊤ := by
+theorem orderHom_top (f : F) : orderHom f ⊤ = ⊤ := by
   rw [top_eq, top_eq, ← map_mk]
   simp
 

--- a/Mathlib/Algebra/Order/Archimedean/Class.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Class.lean
@@ -1,0 +1,425 @@
+/-
+Copyright (c) 2025 Weiyi Wang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Weiyi Wang
+-/
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Algebra.Order.Archimedean.Basic
+import Mathlib.Data.Finset.Max
+
+/-!
+# Archimedean classes of linearly ordered group.
+
+This file defines archimedean classes of a given linearly ordered group.
+
+## Main definitions
+
+* `archimedeanClass` are classes of elements in a ordered additive commutative group
+  that are archimedean equivelent. Two elements `a` and `b` are archimedean equivalent when there
+  exists two positive integers `m` and `n` such that `|a| ≤ m • |b|` and `|b| ≤ n • |a|`.
+* `mulArchimedeanClass` is the multiplicative version of `archimedeanClass`.
+  Two elements `a` and `b` are mul-archimedean equivalent when there
+  exists two positive integers `m` and `n` such that `|a|ₘ ≤ |b|ₘ ^ m` and `|b|ₘ ≤ |a|ₘ ^ n`.
+* `archimedeanClass.orderHom` and `mulArchimedeanClass.orderHom` are `OrderHom` over
+  archimedean classes lifted from ordered group homomorphisms.
+
+## Main statements
+* `archimedeanClass.archimedean_of_mk_eq_mk` / `mulArchimedeanClass.mulArchimedean_of_mk_eq_mk`:
+  an ordered commutative group is (mul-)archimedean if
+  all non-identity elements belong to the same (mul-)archimedeanClass.
+
+-/
+
+variable {M: Type*}
+variable [CommGroup M] [LinearOrder M] [IsOrderedMonoid M]
+
+variable (M) in
+/-- Two elements are mul-archimedean equivalent iff there exists two positive integers
+`m` and `n` such that `|a|ₘ ≤ |b|ₘ ^ m` and `|b|ₘ ≤ |a|ₘ ^ n`. -/
+@[to_additive archimedeanEquiv "Two elements are archimedean equivalent iff there exists
+two positive integers `m` and `n` such that `|a| ≤ m • |b|` and `|b| ≤ n • |a|`."]
+def mulArchimedeanEquiv : Setoid M where
+  r (a b) := (∃ m, m ≠ 0 ∧ |a|ₘ ≤ |b|ₘ ^ m) ∧ (∃ n, n ≠ 0 ∧ |b|ₘ ≤ |a|ₘ ^ n)
+  iseqv := {
+    refl (a) := ⟨⟨1, by simp, by simp⟩, ⟨1, by simp, by simp⟩⟩
+    symm (h) := h.symm
+    trans := by
+      intro a b c ⟨⟨m, hm0, hm⟩, ⟨n, hn0, hn⟩⟩ ⟨⟨m', hm0', hm'⟩, ⟨n', hn0', hn'⟩⟩
+      refine ⟨⟨m' * m, by simp [hm0, hm0'], ?_⟩, ⟨n * n', by simp [hn0, hn0'], ?_⟩⟩
+      · refine le_trans hm ?_
+        rw [pow_mul]
+        exact pow_le_pow_left' hm' m
+      · refine le_trans hn' ?_
+        rw [pow_mul]
+        exact pow_le_pow_left' hn n'
+  }
+
+variable (M) in
+/-- `mulArchimedeanClass` is the quotient of `M` over `mulArchimedeanEquiv M`. -/
+@[to_additive archimedeanClass "`archimedeanClass` is the quotient of `M`
+over `archimedeanEquiv M`."]
+def mulArchimedeanClass := Quotient (mulArchimedeanEquiv M)
+
+namespace mulArchimedeanClass
+
+/-- The archimedean class of a given element. -/
+@[to_additive "The archimedean class of a given element."]
+def mk (a : M) : mulArchimedeanClass M := Quotient.mk'' a
+
+variable (M) in
+@[to_additive]
+theorem mk_surjective : Function.Surjective <| mk (M := M) := Quotient.mk''_surjective
+
+variable (M) in
+@[to_additive (attr := simp)]
+theorem range_mk : Set.range (mk (M := M)) = Set.univ := Set.range_eq_univ.mpr (mk_surjective M)
+
+/-- Choose a representative element from a given archimedean class. -/
+@[to_additive "Choose a representative element from a given archimedean class."]
+noncomputable
+def out (A : mulArchimedeanClass M) : M := Quotient.out A
+
+@[to_additive (attr := simp)]
+theorem out_eq (A : mulArchimedeanClass M) : mk A.out = A := Quotient.out_eq' A
+
+@[to_additive]
+theorem eq {a b : M} :
+    mk a = mk b ↔ (∃ m, m ≠ 0 ∧ |a|ₘ ≤ |b|ₘ ^ m) ∧ (∃ n, n ≠ 0 ∧ |b|ₘ ≤ |a|ₘ ^ n) := Quotient.eq''
+
+@[to_additive]
+theorem mk_out (a : M) :
+    (∃ m, m ≠ 0 ∧ |(mk a).out|ₘ ≤ |a|ₘ ^ m) ∧ (∃ n, n ≠ 0 ∧ |a|ₘ ≤ |(mk a).out|ₘ ^ n) :=
+  eq.mp (by simp)
+
+@[to_additive (attr := simp)]
+theorem mk_inv (a : M) : mk a⁻¹ = mk a :=
+  eq.mpr ⟨⟨1, by simp, by simp⟩, ⟨1, by simp, by simp⟩⟩
+
+@[to_additive]
+theorem mk_div_comm (a b : M) : mk (a / b) = mk (b / a) := by
+  rw [← mk_inv, inv_div]
+
+@[to_additive (attr := simp)]
+theorem mk_mabs (a : M) : mk |a|ₘ = mk a :=
+  eq.mpr ⟨⟨1, by simp, by simp⟩, ⟨1, by simp, by simp⟩⟩
+
+variable (M) in
+/-- Following the definition of archimedean classes, the identity element is always
+in its own class. We denote it as the zero class. -/
+@[to_additive "Following the definition of archimedean classes, the identity element is always
+in its own class. We denote it as the zero class."]
+instance instZero : Zero (mulArchimedeanClass M) := ⟨mk 1⟩
+
+variable (M) in
+@[to_additive (attr := simp)]
+theorem mk_one : mk (1 : M) = 0 := rfl
+
+@[to_additive (attr := simp)]
+theorem mk_eq_zero_iff {a : M} : mk a = 0 ↔ a = 1 := by
+  constructor
+  · intro h
+    rw [← mk_one, eq] at h
+    obtain ⟨⟨_, _, hm⟩, _⟩ := h
+    simpa using hm
+  · intro h
+    rw [h, mk_one]
+
+variable (M) in
+@[to_additive (attr := simp)]
+theorem zero_out : (0 : mulArchimedeanClass M).out = 1 := by
+  rw [← mk_eq_zero_iff, out_eq]
+
+variable (M) in
+@[to_additive]
+instance instNontrivial [Nontrivial M]: Nontrivial (mulArchimedeanClass M) where
+  exists_pair_ne := by
+    obtain ⟨x, hx⟩ := exists_ne (1 : M)
+    exact ⟨mk x, 0, mk_eq_zero_iff.ne.mpr hx⟩
+
+variable (M) in
+/-- We equip archimedean classes with linear order using the absolute value of their
+representatives. By convention, elements with smaller absolute value are in *larger* classes.
+Ordering backwards this way simplifies formalization of theorems such as
+Hahn embedding theorem. -/
+@[to_additive "We equip archimedean classes with linear order using the absolute value of their
+representatives. By convention, elements with smaller absolute value are in *larger* classes.
+Ordering backwards this way simplifies formalization of theorems such as
+Hahn embedding theorem."]
+noncomputable
+instance instLinearOrder : LinearOrder (mulArchimedeanClass M) :=
+  LinearOrder.lift' (OrderDual.toDual |·.out|ₘ) (by
+    intro A B
+    simp only [EmbeddingLike.apply_eq_iff_eq]
+    intro h
+    simpa using congr_arg mk h
+  )
+
+@[to_additive]
+theorem le (A B : mulArchimedeanClass M) : A ≤ B ↔ |B.out|ₘ ≤ |A.out|ₘ := by rfl
+
+@[to_additive]
+theorem lt (A B : mulArchimedeanClass M) : A < B ↔ |B.out|ₘ < |A.out|ₘ := by rfl
+
+/-- The zero class is the largest class -/
+@[to_additive le_zero "The zero class is the largest class"]
+theorem le_zero (A : mulArchimedeanClass M) : A ≤ 0 := by
+  rw [le]
+  simp
+
+@[to_additive]
+theorem ne_zero_of_lt {A B : mulArchimedeanClass M} (h : A < B) : A ≠ 0 :=
+  lt_of_lt_of_le h (le_zero _) |>.ne
+
+variable (M) in
+@[to_additive]
+noncomputable
+instance instOrderTop : OrderTop (mulArchimedeanClass M) where
+  top := 0
+  le_top := le_zero
+
+@[to_additive]
+theorem mk_lt_mk {a b : M} : mk a < mk b ↔ ∀ n, |b|ₘ ^ n < |a|ₘ := by
+  obtain ⟨⟨m, hm0, hm⟩, ⟨n, hn0, hn⟩⟩ := mk_out a
+  obtain ⟨⟨m', hm0', hm'⟩, ⟨n', hn0', hn'⟩⟩ := mk_out b
+  constructor
+  · intro h k
+    by_cases hk0 : k = 0
+    · rw [hk0]
+      simp only [pow_zero, one_lt_mabs]
+      contrapose! h
+      rw [h]
+      simpa using le_zero (mk b)
+    · have hne : ¬ mk a = mk b := ne_of_lt h
+      rw [eq] at hne
+      simp only [not_and, not_exists, not_le, forall_exists_index] at hne
+      by_contra!
+      obtain hne' := hne k ⟨hk0, this⟩ (m * n') (by simp [hn0', hm0])
+      rw [lt] at h
+      contrapose! hne'
+      refine le_of_lt (lt_of_le_of_lt hn' ?_)
+      rw [pow_mul, (pow_left_strictMono hn0').lt_iff_lt]
+      exact lt_of_lt_of_le h hm
+  · intro h
+    rw [lt, ← (pow_left_strictMono hn0).lt_iff_lt]
+    rw [← (pow_left_strictMono hn0).le_iff_le] at hm'
+    apply lt_of_le_of_lt hm'
+    rw [← pow_mul]
+    exact lt_of_lt_of_le (h (m' * n)) hn
+
+variable (M) in
+@[to_additive]
+theorem mk_antitoneOn : AntitoneOn mk (Set.Ici (1 : M)) := by
+  intro a ha b hb hab
+  contrapose! hab
+  rw [mk_lt_mk] at hab
+  obtain h := hab 1
+  rw [mabs_eq_self.mpr ha, mabs_eq_self.mpr hb] at h
+  simpa using h
+
+variable (M) in
+@[to_additive]
+theorem mk_monotoneOn : MonotoneOn mk (Set.Iic (1 : M)) := by
+  intro a ha b hb hab
+  contrapose! hab
+  rw [mk_lt_mk] at hab
+  obtain h := hab 1
+  rw [mabs_eq_inv_self.mpr ha, mabs_eq_inv_self.mpr hb] at h
+  simpa using h
+
+@[to_additive]
+theorem mk_le_mk_self_mul_of_mk_eq {a b : M} (hab : mk a = mk b) : mk a ≤ mk (a * b) := by
+  by_contra! h
+  obtain h1 := mk_lt_mk.mp h 2
+  obtain h2 := mk_lt_mk.mp (hab ▸ h) 2
+  rw [pow_two] at h1 h2
+  obtain h1 := lt_of_lt_of_le h1 (mabs_mul _ _)
+  obtain h2 := lt_of_lt_of_le h2 (mabs_mul _ _)
+  simp only [mul_lt_mul_iff_left, mul_lt_mul_iff_right] at h1 h2
+  have := h1.trans h2
+  simp at this
+
+@[to_additive]
+theorem mk_eq_mk_self_mul_of_mk_lt {a b : M} (h : mk a < mk b) : mk a = mk (a * b) := by
+  rw [mk_lt_mk] at h
+  refine eq.mpr ⟨⟨2, by simp, ?_⟩, ⟨2, by simp, ?_⟩⟩
+  · apply (mabs_mul' _ b).trans
+    rw [mul_comm b a, pow_two, mul_le_mul_iff_right]
+    apply le_of_mul_le_mul_left' (a := |b|ₘ)
+    rw [mul_comm a b]
+    refine le_trans ?_ (mabs_mul' a b)
+    obtain h := (h 2).le
+    rw [pow_two] at h
+    exact h
+  · apply (mabs_mul _ _).trans
+    rw [pow_two, mul_le_mul_iff_left]
+    simpa using (h 1).le
+
+/-- The product over a set of an elements in distinct classes is in the lowest class. -/
+@[to_additive "The sum over a set of an elements in distinct classes is in the lowest class."]
+theorem mk_prod {ι : Type*} [LinearOrder ι] {s : Finset ι} (hnonempty : s.Nonempty)
+    {a : ι → M}  :
+    StrictMonoOn (mk ∘ a) s → mk (∏ i ∈ s, (a i)) = mk (a (s.min' hnonempty)) := by
+  induction hnonempty using Finset.Nonempty.cons_induction with
+  | singleton i => simp
+  | cons i s hi hs ih =>
+    intro hmono
+    obtain ih := ih (hmono.mono (by simp))
+    rw [Finset.prod_cons]
+    have hminmem : s.min' hs ∈ (Finset.cons i s hi) :=
+      Finset.mem_cons_of_mem (by apply Finset.min'_mem)
+    have hne : mk (a i) ≠ mk (a (s.min' hs)) := by
+      by_contra!
+      obtain eq := hmono.injOn (by simp) hminmem this
+      rw [eq] at hi
+      exact hi (Finset.min'_mem _ hs)
+    rw [← ih] at hne
+    obtain hlt|hlt := lt_or_gt_of_ne hne
+    · rw [← mk_eq_mk_self_mul_of_mk_lt hlt]
+      congr
+      apply le_antisymm (Finset.le_min' _ _ _ ?_) (Finset.min'_le _ _ (by simp))
+      intro y hy
+      obtain rfl|hmem := Finset.mem_cons.mp hy
+      · rfl
+      · refine (lt_of_lt_of_le ?_ (Finset.min'_le _ _ hmem)).le
+        apply (hmono.lt_iff_lt (by simp) hminmem).mp
+        rw [ih] at hlt
+        exact hlt
+    · rw [mul_comm, ← mk_eq_mk_self_mul_of_mk_lt hlt, ih]
+      congr 2
+      refine le_antisymm (Finset.le_min' _ _ _ ?_) (Finset.min'_le _ _ hminmem)
+      intro y hy
+      obtain rfl|hmem := Finset.mem_cons.mp hy
+      · apply ((hmono.lt_iff_lt hminmem (by simp)).mp ?_).le
+        rw [ih] at hlt
+        exact hlt
+      · exact Finset.min'_le _ _ hmem
+
+@[to_additive]
+theorem min_le_mk_mul (a b : M) : min (mk a) (mk b) ≤ mk (a * b) := by
+  obtain hab|hab|hab := lt_trichotomy (mk a) (mk b)
+  · rw [inf_le_iff]
+    exact Or.inl (mk_eq_mk_self_mul_of_mk_lt hab).le
+  · rw [← hab]
+    simpa using mk_le_mk_self_mul_of_mk_eq hab
+  · rw [inf_le_iff]
+    right
+    rw [mul_comm]
+    exact (mk_eq_mk_self_mul_of_mk_lt hab).le
+
+@[to_additive]
+theorem lt_of_mk_lt_mk_of_one_le {a b : M} (h : mk a < mk b) (hpos : 1 ≤ a) : b < a := by
+  obtain h := (mk_lt_mk).mp h 1
+  rw [pow_one, mabs_lt, mabs_eq_self.mpr hpos] at h
+  exact h.2
+
+@[to_additive]
+theorem lt_of_mk_lt_mk_of_le_one {a b : M} (h : mk a < mk b) (hneg : a ≤ 1) : a < b := by
+  obtain h := (mk_lt_mk).mp h 1
+  rw [pow_one, mabs_lt, mabs_eq_inv_self.mpr hneg, inv_inv] at h
+  exact h.1
+
+@[to_additive]
+theorem one_lt_of_one_lt_of_mk_lt {a b : M} (ha : 1 < a) (hab : mk a < mk (b / a)) :
+    1 < b := by
+  suffices a⁻¹ < b / a by
+    simpa using this
+  apply lt_of_mk_lt_mk_of_le_one
+  · simpa using hab
+  · simpa using ha.le
+
+@[to_additive archimedean_of_mk_eq_mk]
+theorem mulArchimedean_of_mk_eq_mk (h : ∀ (a b : M), a ≠ 1 → b ≠ 1 → mk a = mk b) :
+    MulArchimedean M where
+  arch := by
+    intro x y hy
+    by_cases hx : x ≤ 1
+    · use 0
+      simpa using hx
+    · have hx : 1 < x := lt_of_not_ge hx
+      have hxy : mk x = mk y := h x y hx.ne.symm hy.ne.symm
+      obtain ⟨⟨m, _, hm⟩, _⟩ := (mulArchimedeanClass.eq).mp hxy
+      rw [mabs_eq_self.mpr hx.le, mabs_eq_self.mpr hy.le] at hm
+      exact ⟨m, hm⟩
+
+section Hom
+
+variable {N : Type*} [CommGroup N] [LinearOrder N] [IsOrderedMonoid N]
+variable {F : Type*} [FunLike F M N] [OrderHomClass F M N] [MonoidHomClass F M N]
+
+/-- An ordered group homomorphism can be lifted to an OrderHom
+over archimedean classes. -/
+@[to_additive "An ordered group homomorphism can be lifted to an OrderHom
+over archimedean classes."]
+noncomputable
+def orderHom (f : F) : mulArchimedeanClass M →o mulArchimedeanClass N where
+  toFun := fun a ↦ mk (f a.out)
+  monotone' := by
+    intro a b h
+    contrapose! h
+    rw [mk_lt_mk] at h
+    rw [← out_eq a, ← out_eq b, mk_lt_mk]
+    intro n
+    obtain h := h n
+    contrapose! h
+    obtain h := OrderHomClass.monotone f h
+    rw [map_pow, map_mabs, map_mabs] at h
+    exact h
+
+@[to_additive]
+theorem orderHom_apply (f : F) (A : mulArchimedeanClass M) : (orderHom f) A = mk (f A.out) := rfl
+
+@[to_additive]
+theorem map_mk (f : F) (a : M) : mk (f a) = (orderHom f) (mk a) := by
+  rw [orderHom_apply]
+  apply eq.mpr
+  have heq : mk a = mk (mk a).out := by
+    rw [out_eq]
+  obtain ⟨⟨m, hm0, hm⟩, ⟨n, hn0, hn⟩⟩ := eq.mp heq
+  refine ⟨⟨m, hm0, ?_⟩, ⟨n, hn0, ?_⟩⟩
+  all_goals
+    rw [← map_mabs, ← map_mabs, ← map_pow]
+    apply OrderHomClass.monotone
+    try exact hm
+    try exact hn
+
+@[to_additive]
+theorem map_mk_eq (f : F) {a b : M} (h : mk a = mk b) : mk (f a) = mk (f b) := by
+  rw [map_mk, map_mk, h]
+
+@[to_additive]
+theorem map_mk_le (f : F) {a b : M} (h : mk a ≤ mk b) : mk (f a) ≤ mk (f b) := by
+  rw [map_mk, map_mk]
+  apply OrderHomClass.monotone
+  exact h
+
+@[to_additive]
+theorem orderHom_injective {f : F} (h : Function.Injective f) :
+    Function.Injective (orderHom f) := by
+  intro a b
+  nth_rw 2 [← out_eq a]
+  nth_rw 2 [← out_eq b]
+  rw [orderHom_apply, orderHom_apply, eq, eq]
+  simp_rw [← map_mabs, ← map_pow]
+  intro h
+  obtain ⟨⟨m, hm0, hm⟩, ⟨n, hn0, hn⟩⟩ := h
+  refine ⟨⟨m, hm0, ?_⟩, ⟨n, hn0, ?_⟩⟩
+  · contrapose! hm
+    apply lt_of_le_of_ne
+    · apply OrderHomClass.monotone f hm.le
+    · contrapose! hm
+      exact (h hm).symm.le
+  · contrapose! hn
+    apply lt_of_le_of_ne
+    · apply OrderHomClass.monotone f hn.le
+    · contrapose! hn
+      exact (h hn).symm.le
+
+@[to_additive (attr := simp)]
+theorem orderHom_zero (f : F) :
+    (orderHom f) (0 : mulArchimedeanClass M) = (0 : mulArchimedeanClass N) := by
+  rw [← mk_one, ← mk_one, ← map_mk]
+  simp
+
+end Hom
+
+end mulArchimedeanClass

--- a/Mathlib/Algebra/Order/Archimedean/Class.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Class.lean
@@ -14,19 +14,19 @@ This file defines archimedean classes of a given linearly ordered group.
 
 ## Main definitions
 
-* `archimedeanClass` are classes of elements in a ordered additive commutative group
+* `ArchimedeanClass` are classes of elements in a ordered additive commutative group
   that are archimedean equivelent. Two elements `a` and `b` are archimedean equivalent when there
   exists two positive integers `m` and `n` such that `|a| ≤ m • |b|` and `|b| ≤ n • |a|`.
-* `mulArchimedeanClass` is the multiplicative version of `archimedeanClass`.
+* `MulArchimedeanClass` is the multiplicative version of `ArchimedeanClass`.
   Two elements `a` and `b` are mul-archimedean equivalent when there
   exists two positive integers `m` and `n` such that `|a|ₘ ≤ |b|ₘ ^ m` and `|b|ₘ ≤ |a|ₘ ^ n`.
-* `archimedeanClass.orderHom` and `mulArchimedeanClass.orderHom` are `OrderHom` over
+* `ArchimedeanClass.orderHom` and `MulArchimedeanClass.orderHom` are `OrderHom` over
   archimedean classes lifted from ordered group homomorphisms.
 
 ## Main statements
-* `archimedeanClass.archimedean_of_mk_eq_mk` / `mulArchimedeanClass.mulArchimedean_of_mk_eq_mk`:
+* `ArchimedeanClass.archimedean_of_mk_eq_mk` / `MulArchimedeanClass.mulArchimedean_of_mk_eq_mk`:
   an ordered commutative group is (mul-)archimedean if
-  all non-identity elements belong to the same (mul-)archimedeanClass.
+  all non-identity elements belong to the same (`Mul`-)`ArchimedeanClass`.
 
 -/
 
@@ -39,32 +39,29 @@ variable (M) in
 @[to_additive archimedeanEquiv "Two elements are archimedean equivalent iff there exists
 two positive integers `m` and `n` such that `|a| ≤ m • |b|` and `|b| ≤ n • |a|`."]
 def mulArchimedeanEquiv : Setoid M where
-  r (a b) := (∃ m, m ≠ 0 ∧ |a|ₘ ≤ |b|ₘ ^ m) ∧ (∃ n, n ≠ 0 ∧ |b|ₘ ≤ |a|ₘ ^ n)
-  iseqv := {
-    refl (a) := ⟨⟨1, by simp, by simp⟩, ⟨1, by simp, by simp⟩⟩
-    symm (h) := h.symm
-    trans := by
-      intro a b c ⟨⟨m, hm0, hm⟩, ⟨n, hn0, hn⟩⟩ ⟨⟨m', hm0', hm'⟩, ⟨n', hn0', hn'⟩⟩
-      refine ⟨⟨m' * m, by simp [hm0, hm0'], ?_⟩, ⟨n * n', by simp [hn0, hn0'], ?_⟩⟩
-      · refine le_trans hm ?_
-        rw [pow_mul]
-        exact pow_le_pow_left' hm' m
-      · refine le_trans hn' ?_
-        rw [pow_mul]
-        exact pow_le_pow_left' hn n'
-  }
+  r a b := (∃ m, m ≠ 0 ∧ |a|ₘ ≤ |b|ₘ ^ m) ∧ (∃ n, n ≠ 0 ∧ |b|ₘ ≤ |a|ₘ ^ n)
+  iseqv.refl _ := ⟨⟨1, by simp, by simp⟩, ⟨1, by simp, by simp⟩⟩
+  iseqv.symm := And.symm
+  iseqv.trans {a b c} := by
+    intro ⟨⟨m, hm0, hm⟩, ⟨n, hn0, hn⟩⟩ ⟨⟨m', hm0', hm'⟩, ⟨n', hn0', hn'⟩⟩
+    refine ⟨⟨m' * m, mul_ne_zero hm0' hm0, hm.trans ?_⟩,
+      ⟨n * n', mul_ne_zero hn0 hn0', hn'.trans ?_⟩⟩
+    · rw [pow_mul]
+      exact pow_le_pow_left' hm' m
+    · rw [pow_mul]
+      exact pow_le_pow_left' hn n'
 
 variable (M) in
-/-- `mulArchimedeanClass` is the quotient of `M` over `mulArchimedeanEquiv M`. -/
-@[to_additive archimedeanClass "`archimedeanClass` is the quotient of `M`
+/-- `MulArchimedeanClass` is the quotient of `M` over `mulArchimedeanEquiv M`. -/
+@[to_additive ArchimedeanClass "`ArchimedeanClass` is the quotient of `M`
 over `archimedeanEquiv M`."]
-def mulArchimedeanClass := Quotient (mulArchimedeanEquiv M)
+def MulArchimedeanClass := Quotient (mulArchimedeanEquiv M)
 
-namespace mulArchimedeanClass
+namespace MulArchimedeanClass
 
 /-- The archimedean class of a given element. -/
 @[to_additive "The archimedean class of a given element."]
-def mk (a : M) : mulArchimedeanClass M := Quotient.mk'' a
+def mk (a : M) : MulArchimedeanClass M := Quotient.mk'' a
 
 variable (M) in
 @[to_additive]
@@ -77,10 +74,10 @@ theorem range_mk : Set.range (mk (M := M)) = Set.univ := Set.range_eq_univ.mpr (
 /-- Choose a representative element from a given archimedean class. -/
 @[to_additive "Choose a representative element from a given archimedean class."]
 noncomputable
-def out (A : mulArchimedeanClass M) : M := Quotient.out A
+def out (A : MulArchimedeanClass M) : M := Quotient.out A
 
 @[to_additive (attr := simp)]
-theorem out_eq (A : mulArchimedeanClass M) : mk A.out = A := Quotient.out_eq' A
+theorem out_eq (A : MulArchimedeanClass M) : mk A.out = A := Quotient.out_eq' A
 
 @[to_additive]
 theorem eq {a b : M} :
@@ -103,50 +100,40 @@ theorem mk_div_comm (a b : M) : mk (a / b) = mk (b / a) := by
 theorem mk_mabs (a : M) : mk |a|ₘ = mk a :=
   eq.mpr ⟨⟨1, by simp, by simp⟩, ⟨1, by simp, by simp⟩⟩
 
-variable (M) in
-/-- Following the definition of archimedean classes, the identity element is always
-in its own class. We denote it as the zero class. -/
-@[to_additive "Following the definition of archimedean classes, the identity element is always
-in its own class. We denote it as the zero class."]
-instance instZero : Zero (mulArchimedeanClass M) := ⟨mk 1⟩
-
-variable (M) in
 @[to_additive (attr := simp)]
-theorem mk_one : mk (1 : M) = 0 := rfl
-
-@[to_additive (attr := simp)]
-theorem mk_eq_zero_iff {a : M} : mk a = 0 ↔ a = 1 := by
+theorem mk_eq_mk_one_iff {a : M} : mk a = mk 1 ↔ a = 1 := by
   constructor
   · intro h
-    rw [← mk_one, eq] at h
+    rw [eq] at h
     obtain ⟨⟨_, _, hm⟩, _⟩ := h
     simpa using hm
   · intro h
-    rw [h, mk_one]
+    rw [h]
 
 variable (M) in
 @[to_additive (attr := simp)]
-theorem zero_out : (0 : mulArchimedeanClass M).out = 1 := by
-  rw [← mk_eq_zero_iff, out_eq]
-
-variable (M) in
-@[to_additive]
-instance instNontrivial [Nontrivial M]: Nontrivial (mulArchimedeanClass M) where
-  exists_pair_ne := by
-    obtain ⟨x, hx⟩ := exists_ne (1 : M)
-    exact ⟨mk x, 0, mk_eq_zero_iff.ne.mpr hx⟩
+theorem mk_one_out : (mk 1 : MulArchimedeanClass M).out = 1 := by
+  rw [← mk_eq_mk_one_iff, out_eq]
 
 variable (M) in
 /-- We equip archimedean classes with linear order using the absolute value of their
 representatives. By convention, elements with smaller absolute value are in *larger* classes.
 Ordering backwards this way simplifies formalization of theorems such as
-Hahn embedding theorem. -/
+Hahn embedding theorem.
+
+While the order is defined using `MulArchimedean.out`, it is equivalently characterized by
+`MulArchimedean.mk_le_mk` and `MulArchimedean.mk_lt_mk`, which are recommended to use to
+avoid using `MulArchimedean.out`. -/
 @[to_additive "We equip archimedean classes with linear order using the absolute value of their
 representatives. By convention, elements with smaller absolute value are in *larger* classes.
 Ordering backwards this way simplifies formalization of theorems such as
-Hahn embedding theorem."]
+Hahn embedding theorem.
+
+While the order is defined using `Archimedean.out`, it is equivalently characterized by
+`Archimedean.mk_le_mk` and `Archimedean.mk_lt_mk`, which are recommended to use to
+avoid using `Archimedean.out`."]
 noncomputable
-instance instLinearOrder : LinearOrder (mulArchimedeanClass M) :=
+instance instLinearOrder : LinearOrder (MulArchimedeanClass M) :=
   LinearOrder.lift' (OrderDual.toDual |·.out|ₘ) (by
     intro A B
     simp only [EmbeddingLike.apply_eq_iff_eq]
@@ -155,27 +142,15 @@ instance instLinearOrder : LinearOrder (mulArchimedeanClass M) :=
   )
 
 @[to_additive]
-theorem le (A B : mulArchimedeanClass M) : A ≤ B ↔ |B.out|ₘ ≤ |A.out|ₘ := by rfl
+theorem le (A B : MulArchimedeanClass M) : A ≤ B ↔ |B.out|ₘ ≤ |A.out|ₘ := by rfl
 
 @[to_additive]
-theorem lt (A B : mulArchimedeanClass M) : A < B ↔ |B.out|ₘ < |A.out|ₘ := by rfl
+theorem lt (A B : MulArchimedeanClass M) : A < B ↔ |B.out|ₘ < |A.out|ₘ := by rfl
 
-/-- The zero class is the largest class -/
-@[to_additive le_zero "The zero class is the largest class"]
-theorem le_zero (A : mulArchimedeanClass M) : A ≤ 0 := by
+@[to_additive]
+theorem le_mk_one (A : MulArchimedeanClass M) : A ≤ mk 1 := by
   rw [le]
   simp
-
-@[to_additive]
-theorem ne_zero_of_lt {A B : mulArchimedeanClass M} (h : A < B) : A ≠ 0 :=
-  lt_of_lt_of_le h (le_zero _) |>.ne
-
-variable (M) in
-@[to_additive]
-noncomputable
-instance instOrderTop : OrderTop (mulArchimedeanClass M) where
-  top := 0
-  le_top := le_zero
 
 @[to_additive]
 theorem mk_lt_mk {a b : M} : mk a < mk b ↔ ∀ n, |b|ₘ ^ n < |a|ₘ := by
@@ -188,7 +163,7 @@ theorem mk_lt_mk {a b : M} : mk a < mk b ↔ ∀ n, |b|ₘ ^ n < |a|ₘ := by
       simp only [pow_zero, one_lt_mabs]
       contrapose! h
       rw [h]
-      simpa using le_zero (mk b)
+      simpa using le_mk_one (mk b)
     · have hne : ¬ mk a = mk b := ne_of_lt h
       rw [eq] at hne
       simp only [not_and, not_exists, not_le, forall_exists_index] at hne
@@ -205,6 +180,42 @@ theorem mk_lt_mk {a b : M} : mk a < mk b ↔ ∀ n, |b|ₘ ^ n < |a|ₘ := by
     apply lt_of_le_of_lt hm'
     rw [← pow_mul]
     exact lt_of_lt_of_le (h (m' * n)) hn
+
+@[to_additive]
+theorem mk_le_mk {a b : M} : mk a ≤ mk b ↔ ∃ n, |b|ₘ ≤ |a|ₘ ^ n := by
+  simpa using mk_lt_mk.not
+
+variable (M) in
+/-- 1 is in its own class, which is also the largest class. -/
+@[to_additive "0 is in its own class, which is also the largest class."]
+noncomputable
+instance instOrderTop : OrderTop (MulArchimedeanClass M) where
+  top := mk 1
+  le_top := le_mk_one
+
+variable (M) in
+@[to_additive]
+theorem top_eq : (⊤ : MulArchimedeanClass M) = mk 1 := rfl
+
+variable (M) in
+@[to_additive (attr := simp)]
+theorem top_out : (⊤ : MulArchimedeanClass M).out = 1 := by
+  exact mk_one_out M
+
+@[to_additive (attr := simp)]
+theorem mk_eq_top_iff {a : M} : mk a = ⊤ ↔ a = 1 := by
+  exact mk_eq_mk_one_iff
+
+@[to_additive]
+theorem ne_top_of_lt {A B : MulArchimedeanClass M} (h : A < B) : A ≠ ⊤ :=
+  lt_of_lt_of_le h le_top |>.ne
+
+variable (M) in
+@[to_additive]
+instance [Nontrivial M] : Nontrivial (MulArchimedeanClass M) where
+  exists_pair_ne := by
+    obtain ⟨x, hx⟩ := exists_ne (1 : M)
+    exact ⟨mk x, ⊤, mk_eq_top_iff.ne.mpr hx⟩
 
 variable (M) in
 @[to_additive]
@@ -337,7 +348,7 @@ theorem mulArchimedean_of_mk_eq_mk (h : ∀ (a b : M), a ≠ 1 → b ≠ 1 → m
       simpa using hx
     · have hx : 1 < x := lt_of_not_ge hx
       have hxy : mk x = mk y := h x y hx.ne.symm hy.ne.symm
-      obtain ⟨⟨m, _, hm⟩, _⟩ := (mulArchimedeanClass.eq).mp hxy
+      obtain ⟨⟨m, _, hm⟩, _⟩ := (MulArchimedeanClass.eq).mp hxy
       rw [mabs_eq_self.mpr hx.le, mabs_eq_self.mpr hy.le] at hm
       exact ⟨m, hm⟩
 
@@ -351,7 +362,7 @@ over archimedean classes. -/
 @[to_additive "An ordered group homomorphism can be lifted to an OrderHom
 over archimedean classes."]
 noncomputable
-def orderHom (f : F) : mulArchimedeanClass M →o mulArchimedeanClass N where
+def orderHom (f : F) : MulArchimedeanClass M →o MulArchimedeanClass N where
   toFun := fun a ↦ mk (f a.out)
   monotone' := by
     intro a b h
@@ -366,7 +377,7 @@ def orderHom (f : F) : mulArchimedeanClass M →o mulArchimedeanClass N where
     exact h
 
 @[to_additive]
-theorem orderHom_apply (f : F) (A : mulArchimedeanClass M) : (orderHom f) A = mk (f A.out) := rfl
+theorem orderHom_apply (f : F) (A : MulArchimedeanClass M) : (orderHom f) A = mk (f A.out) := rfl
 
 @[to_additive]
 theorem map_mk (f : F) (a : M) : mk (f a) = (orderHom f) (mk a) := by
@@ -415,11 +426,10 @@ theorem orderHom_injective {f : F} (h : Function.Injective f) :
       exact (h hn).symm.le
 
 @[to_additive (attr := simp)]
-theorem orderHom_zero (f : F) :
-    (orderHom f) (0 : mulArchimedeanClass M) = (0 : mulArchimedeanClass N) := by
-  rw [← mk_one, ← mk_one, ← map_mk]
+theorem orderHom_top (f : F) : (orderHom f) ⊤ = ⊤ := by
+  rw [top_eq, top_eq, ← map_mk]
   simp
 
 end Hom
 
-end mulArchimedeanClass
+end MulArchimedeanClass

--- a/Mathlib/Algebra/Order/Archimedean/Class.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Class.lean
@@ -82,7 +82,7 @@ theorem range_mk : Set.range (mk (M := M)) = Set.univ := Set.range_eq_univ.mpr (
 noncomputable
 def out (A : MulArchimedeanClass M) : M := Quotient.out A
 
-@[to_additive]
+@[to_additive (attr := simp)]
 theorem out_eq (A : MulArchimedeanClass M) : mk A.out = A := Quotient.out_eq' A
 
 @[to_additive]
@@ -92,7 +92,7 @@ theorem eq {a b : M} :
 @[to_additive]
 theorem mk_out (a : M) :
     (∃ m, |(mk a).out|ₘ ≤ |a|ₘ ^ m) ∧ (∃ n, |a|ₘ ≤ |(mk a).out|ₘ ^ n) :=
-  eq.mp (by simp [out_eq])
+  eq.mp (by simp)
 
 @[to_additive (attr := simp)]
 theorem mk_inv (a : M) : mk a⁻¹ = mk a :=
@@ -142,7 +142,7 @@ instance instLinearOrder : LinearOrder (MulArchimedeanClass M) :=
   LinearOrder.lift' (OrderDual.toDual |·.out|ₘ) fun A B ↦ by
     simp only [EmbeddingLike.apply_eq_iff_eq]
     intro h
-    simpa [out_eq] using congr_arg mk h
+    simpa using congr_arg mk h
 
 @[to_additive]
 theorem le (A B : MulArchimedeanClass M) : A ≤ B ↔ |B.out|ₘ ≤ |A.out|ₘ := by rfl

--- a/Mathlib/Algebra/Order/Archimedean/Class.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Class.lean
@@ -168,7 +168,7 @@ variable (M) in
 theorem range_mk : Set.range (mk (M := M)) = Set.univ := Set.range_eq_univ.mpr (mk_surjective M)
 
 @[to_additive]
-theorem eq {a b : M} : mk a = mk b ↔ (∃ m, |b|ₘ ≤ |a|ₘ ^ m) ∧ (∃ n, |a|ₘ ≤ |b|ₘ ^ n) := by
+theorem mk_eq_mk {a b : M} : mk a = mk b ↔ (∃ m, |b|ₘ ≤ |a|ₘ ^ m) ∧ (∃ n, |a|ₘ ≤ |b|ₘ ^ n) := by
   unfold mk toAntisymmetrization
   rw [Quotient.eq]
   rfl
@@ -179,11 +179,11 @@ noncomputable
 def out (A : MulArchimedeanClass M) : M := (Quotient.out A).val
 
 @[to_additive (attr := simp)]
-theorem out_eq (A : MulArchimedeanClass M) : mk A.out = A := Quotient.out_eq' A
+theorem mk_out (A : MulArchimedeanClass M) : mk A.out = A := Quotient.out_eq' A
 
 @[to_additive (attr := simp)]
 theorem mk_inv (a : M) : mk a⁻¹ = mk a :=
-  eq.mpr ⟨⟨1, by simp⟩, ⟨1, by simp⟩⟩
+  mk_eq_mk.mpr ⟨⟨1, by simp⟩, ⟨1, by simp⟩⟩
 
 @[to_additive]
 theorem mk_div_comm (a b : M) : mk (a / b) = mk (b / a) := by
@@ -191,21 +191,7 @@ theorem mk_div_comm (a b : M) : mk (a / b) = mk (b / a) := by
 
 @[to_additive (attr := simp)]
 theorem mk_mabs (a : M) : mk |a|ₘ = mk a :=
-  eq.mpr ⟨⟨1, by simp⟩, ⟨1, by simp⟩⟩
-
-@[to_additive]
-theorem mk_eq_mk_one_iff {a : M} : mk a = mk 1 ↔ a = 1 := by
-  constructor
-  · intro h
-    obtain ⟨_, ⟨_, hm⟩⟩ := eq.mp h
-    simpa using hm
-  · intro h
-    rw [h]
-
-variable (M) in
-@[to_additive]
-theorem out_mk_one : (mk 1 : MulArchimedeanClass M).out = 1 := by
-  rw [← mk_eq_mk_one_iff, out_eq]
+  mk_eq_mk.mpr ⟨⟨1, by simp⟩, ⟨1, by simp⟩⟩
 
 variable (M) in
 @[to_additive]
@@ -221,30 +207,35 @@ theorem mk_le_mk : mk a ≤ mk b ↔ ∃ n, |b|ₘ ≤ |a|ₘ ^ n := .rfl
 @[to_additive]
 theorem mk_lt_mk : mk a < mk b ↔ ∀ n, |b|ₘ ^ n < |a|ₘ := .rfl
 
-@[to_additive]
-theorem le_mk_one (A : MulArchimedeanClass M) : A ≤ mk 1 := by
-  induction A using ind with | mk a
-  rw [mk_le_mk]
-  exact ⟨1, by simp⟩
-
 variable (M) in
 /-- 1 is in its own class, which is also the largest class. -/
 @[to_additive "0 is in its own class, which is also the largest class."]
 noncomputable
 instance instOrderTop : OrderTop (MulArchimedeanClass M) where
   top := mk 1
-  le_top := le_mk_one
+  le_top A := by
+    induction A using ind with | mk a
+    rw [mk_le_mk]
+    exact ⟨1, by simp⟩
 
 variable (M) in
 @[to_additive (attr := simp)]
 theorem mk_one : mk 1 = (⊤ : MulArchimedeanClass M) := rfl
 
+@[to_additive (attr := simp)]
+theorem mk_eq_top_iff : mk a = ⊤ ↔ a = 1 := by
+  constructor
+  · intro h
+    obtain ⟨_, _, hm⟩ := mk_eq_mk.mp h
+    simpa using hm
+  · intro h
+    rw [h]
+    simp
+
 variable (M) in
 @[to_additive (attr := simp)]
-theorem out_top : (⊤ : MulArchimedeanClass M).out = 1 := out_mk_one M
-
-@[to_additive (attr := simp)]
-theorem mk_eq_top_iff : mk a = ⊤ ↔ a = 1 := mk_eq_mk_one_iff
+theorem out_top : (⊤ : MulArchimedeanClass M).out = 1 := by
+  rw [← mk_eq_top_iff, mk_out]
 
 variable (M) in
 @[to_additive]
@@ -374,7 +365,7 @@ theorem mulArchimedean_of_mk_eq_mk (h : ∀ a ≠ (1 : M), ∀ b ≠ 1, mk a = m
       simpa using hx
     · have hx : 1 < x := lt_of_not_ge hx
       have hxy : mk x = mk y := h x hx.ne.symm y hy.ne.symm
-      obtain ⟨_, ⟨m, hm⟩⟩ := (MulArchimedeanClass.eq).mp hxy
+      obtain ⟨_, ⟨m, hm⟩⟩ := (mk_eq_mk).mp hxy
       rw [mabs_eq_self.mpr hx.le, mabs_eq_self.mpr hy.le] at hm
       exact ⟨m, hm⟩
 
@@ -383,7 +374,7 @@ theorem mk_eq_mk_of_mulArchimedean [MulArchimedean M] (ha : a ≠ 1) (hb : b ≠
     mk a = mk b := by
   obtain hm := MulArchimedean.arch |b|ₘ (show 1 < |a|ₘ by simpa using ha)
   obtain hn := MulArchimedean.arch |a|ₘ (show 1 < |b|ₘ by simpa using hb)
-  exact eq.mpr ⟨hm, hn⟩
+  exact mk_eq_mk.mpr ⟨hm, hn⟩
 
 section Hom
 
@@ -413,7 +404,7 @@ theorem orderHom_injective {f : M →*o N} (h : Function.Injective f) :
   intro a b
   induction a using ind with | mk a
   induction b using ind with | mk b
-  simp_rw [orderHom_mk, eq, ← map_mabs, ← map_pow]
+  simp_rw [orderHom_mk, mk_eq_mk, ← map_mabs, ← map_pow]
   obtain hmono := (OrderHomClass.monotone f).strictMono_of_injective h
   intro ⟨⟨m, hm⟩, ⟨n, hn⟩⟩
   exact ⟨⟨m, hmono.le_iff_le.mp hm⟩, ⟨n, hmono.le_iff_le.mp hn⟩⟩

--- a/Mathlib/Algebra/Order/Archimedean/Class.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Class.lean
@@ -196,7 +196,7 @@ theorem mk_div_comm (a b : M) : mk (a / b) = mk (b / a) := by
 theorem mk_mabs (a : M) : mk |a|ₘ = mk a :=
   eq.mpr ⟨⟨1, by simp⟩, ⟨1, by simp⟩⟩
 
-@[to_additive (attr := simp)]
+@[to_additive]
 theorem mk_eq_mk_one_iff {a : M} : mk a = mk 1 ↔ a = 1 := by
   constructor
   · intro h
@@ -206,7 +206,7 @@ theorem mk_eq_mk_one_iff {a : M} : mk a = mk 1 ↔ a = 1 := by
     rw [h]
 
 variable (M) in
-@[to_additive (attr := simp)]
+@[to_additive]
 theorem mk_one_out : (mk 1 : MulArchimedeanClass M).out = 1 := by
   rw [← mk_eq_mk_one_iff, out_eq]
 

--- a/Mathlib/Algebra/Order/Archimedean/Class.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Class.lean
@@ -119,11 +119,10 @@ instance instPreorder : Preorder (MulArchimedeanOrder M) where
 variable (M) in
 @[to_additive]
 instance instIsTotal : IsTotal (MulArchimedeanOrder M) (· ≤ ·) where
-  total := by
-    simp_rw [le]
-    by_contra!
-    obtain ⟨a, b, hab, hba⟩ := this
-    exact (lt_self_iff_false _).mp <| (pow_one |a.val|ₘ ▸ hab 1).trans (pow_one |b.val|ₘ ▸ hba 1)
+  total a b := by
+    obtain hab | hab := le_total |a.val|ₘ |b.val|ₘ
+    · exact Or.inr ⟨1, by simpa using hab⟩
+    · exact Or.inl ⟨1, by simpa using hab⟩
 
 variable {N : Type*} [CommGroup N] [LinearOrder N] [IsOrderedMonoid N]
 variable {F : Type*} [FunLike F M N] [OrderHomClass F M N] [MonoidHomClass F M N]

--- a/Mathlib/Algebra/Order/Archimedean/Class.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Class.lean
@@ -13,7 +13,7 @@ import Mathlib.Order.Antisymmetrization
 # Archimedean classes of a linearly ordered group
 
 This file defines archimedean classes of a given linearly ordered group. Archimedean classes
-measure to what extent the group fails to be Archimedean. For additive group, elements `a` and `b`.
+measure to what extent the group fails to be Archimedean. For additive group, elements `a` and `b`
 in the same class are "equivalent" in the sense that there exist two natural numbers
 `m` and `n` such that `|a| ≤ m • |b|` and `|b| ≤ n • |a|`. An element `a` in a higher class than `b`
 is "infinitesimal" to `b` in the sense that `n • |a| < |b|` for all natural number `n`.
@@ -63,11 +63,17 @@ namespace MulArchimedeanOrder
 
 /-- Create a `MulArchimedeanOrder` element from the underlying type. -/
 @[to_additive "Create a `ArchimedeanOrder` element from the underlying type."]
-def of (a : M) : MulArchimedeanOrder M := a
+def of : M ≃ MulArchimedeanOrder M := Equiv.refl _
 
 /-- Retrieve the underlying value from a `MulArchimedeanOrder` element. -/
 @[to_additive "Retrieve the underlying value from a `ArchimedeanOrder` element."]
-def val (a : MulArchimedeanOrder M) : M := a
+def val : MulArchimedeanOrder M ≃ M := Equiv.refl _
+
+@[to_additive (attr := simp)]
+theorem of_symm_eq : (of (M := M)).symm = val := rfl
+
+@[to_additive (attr := simp)]
+theorem val_symm_eq : (val (M := M)).symm = of := rfl
 
 @[to_additive (attr := simp)]
 theorem of_val (a : MulArchimedeanOrder M) : of (val a) = a := rfl
@@ -201,8 +207,10 @@ theorem mk_le_mk : mk a ≤ mk b ↔ ∃ n, |b|ₘ ≤ |a|ₘ ^ n := .rfl
 @[to_additive]
 theorem mk_lt_mk : mk a < mk b ↔ ∀ n, |b|ₘ ^ n < |a|ₘ := .rfl
 
-/-- 1 is in its own class, which is also the largest class. -/
-@[to_additive "0 is in its own class, which is also the largest class."]
+/-- 1 is in its own class (see `MulArchimedeanClass.mk_eq_top_iff`),
+which is also the largest class. -/
+@[to_additive "0 is in its own class (see `ArchimedeanClass.mk_eq_top_iff`),
+which is also the largest class."]
 noncomputable
 instance : OrderTop (MulArchimedeanClass M) where
   top := mk 1

--- a/Mathlib/Algebra/Order/Archimedean/Class.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Class.lean
@@ -285,7 +285,7 @@ theorem min_le_mk_mul (a b : M) : min (mk a) (mk b) ≤ mk (a * b) := by
   have h1 := (mk_lt_mk.mp h.1 2).trans_le (mabs_mul _ _)
   have h2 := (mk_lt_mk.mp h.2 2).trans_le (mabs_mul _ _)
   simp only [mul_lt_mul_iff_left, mul_lt_mul_iff_right, pow_two] at h1 h2
-  exact h1.not_lt h2
+  exact h1.not_gt h2
 
 @[to_additive]
 theorem mk_left_le_mk_mul (hab : mk a ≤ mk b) : mk a ≤ mk (a * b) := by

--- a/Mathlib/Algebra/Order/Archimedean/Class.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Class.lean
@@ -108,7 +108,7 @@ instance instPreorder : Preorder (MulArchimedeanOrder M) where
     use m * n
     rw [pow_mul]
     exact hn.trans (pow_le_pow_left' hm n)
-  lt_iff_le_not_le a b := by
+  lt_iff_le_not_ge a b := by
     rw [lt, le, le]
     suffices (∀ (n : ℕ), |b.val|ₘ ^ n < |a.val|ₘ) → ∃ n, |b.val|ₘ ≤ |a.val|ₘ ^ n by
       simpa using this

--- a/Mathlib/Algebra/Order/Archimedean/Class.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Class.lean
@@ -44,8 +44,8 @@ the order.
 
 -/
 
-section Pre
-variable {M: Type*}
+section ArchimedeanOrder
+variable {M : Type*}
 
 variable (M) in
 /-- Type synonym to equip a ordered group with a new `Preorder` defined by the infinitesimal order
@@ -132,7 +132,7 @@ def orderHom (f : M →*o N) : MulArchimedeanOrder M →o MulArchimedeanOrder N 
 
 end MulArchimedeanOrder
 
-end Pre
+end ArchimedeanOrder
 
 variable {M : Type*}
 variable [CommGroup M] [LinearOrder M] [IsOrderedMonoid M] {a b : M}

--- a/Mathlib/Algebra/Order/Archimedean/Class.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Class.lean
@@ -5,6 +5,7 @@ Authors: Weiyi Wang
 -/
 import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 import Mathlib.Algebra.Order.Archimedean.Basic
+import Mathlib.Algebra.Order.Hom.Monoid
 import Mathlib.Data.Finset.Max
 import Mathlib.Order.Antisymmetrization
 
@@ -33,7 +34,7 @@ all non-identity elements belong to the same (`Mul`-)`ArchimedeanClass`:
 
 ## Implementation notes
 
-Archimedean classes are equiped with a linear order, where elements with smaller absolute value
+Archimedean classes are equipped with a linear order, where elements with smaller absolute value
 are placed in a *higher* classes by convention. Ordering backwards this way simplifies
 formalization of theorems such as the Hahn embedding theorem.
 
@@ -88,12 +89,10 @@ instance instLT : LT (MulArchimedeanOrder M) where
   lt a b := ∀ n, |b.val|ₘ ^ n < |a.val|ₘ
 
 @[to_additive]
-theorem le_def {a b : MulArchimedeanOrder M} :
-  a ≤ b ↔ ∃ n, |b.val|ₘ ≤ |a.val|ₘ ^ n := .rfl
+theorem le_def {a b : MulArchimedeanOrder M} : a ≤ b ↔ ∃ n, |b.val|ₘ ≤ |a.val|ₘ ^ n := .rfl
 
 @[to_additive]
-theorem lt_def {a b : MulArchimedeanOrder M} :
-  a < b ↔ ∀ n, |b.val|ₘ ^ n < |a.val|ₘ := .rfl
+theorem lt_def {a b : MulArchimedeanOrder M} : a < b ↔ ∀ n, |b.val|ₘ ^ n < |a.val|ₘ := .rfl
 
 variable {M: Type*}
 variable [CommGroup M] [LinearOrder M] [IsOrderedMonoid M] {a b : M}
@@ -124,14 +123,12 @@ instance instIsTotal : IsTotal (MulArchimedeanOrder M) (· ≤ ·) where
     · exact .inl ⟨1, by simpa using hab⟩
 
 variable {N : Type*} [CommGroup N] [LinearOrder N] [IsOrderedMonoid N]
-variable {F : Type*} [FunLike F M N] [OrderHomClass F M N] [MonoidHomClass F M N]
 
-/-- An ordered group homomorphism can be made to an
-`orderHom` between their `MulArchimedeanOrder`. -/
-@[to_additive "An ordered group homomorphism can be made to an
-`orderHom` between their `ArchimedeanOrder`."]
+/-- An `OrderMonoidHom` can be made to an `OrderHom` between their `MulArchimedeanOrder`. -/
+@[to_additive "An `OrderAddMonoidHom` can be made to an `OrderHom` between their
+`ArchimedeanOrder`."]
 noncomputable
-def orderHom (f : F) : MulArchimedeanOrder M →o MulArchimedeanOrder N where
+def orderHom (f : M →*o N) : MulArchimedeanOrder M →o MulArchimedeanOrder N where
   toFun a := of (f a.val)
   monotone' := by
     rintro a b ⟨n, hn⟩
@@ -142,7 +139,7 @@ end MulArchimedeanOrder
 
 end Pre
 
-variable {M: Type*}
+variable {M : Type*}
 variable [CommGroup M] [LinearOrder M] [IsOrderedMonoid M] {a b : M}
 
 variable (M) in
@@ -207,7 +204,7 @@ theorem mk_eq_mk_one_iff {a : M} : mk a = mk 1 ↔ a = 1 := by
 
 variable (M) in
 @[to_additive]
-theorem mk_one_out : (mk 1 : MulArchimedeanClass M).out = 1 := by
+theorem out_mk_one : (mk 1 : MulArchimedeanClass M).out = 1 := by
   rw [← mk_eq_mk_one_iff, out_eq]
 
 variable (M) in
@@ -215,7 +212,8 @@ variable (M) in
 noncomputable
 instance instLinearOrder : LinearOrder (MulArchimedeanClass M) := by
   classical
-  exact instLinearOrderAntisymmetrizationLeOfDecidableLEOfDecidableLTOfIsTotal
+  unfold MulArchimedeanClass
+  infer_instance
 
 @[to_additive]
 theorem mk_le_mk : mk a ≤ mk b ↔ ∃ n, |b|ₘ ≤ |a|ₘ ^ n := .rfl
@@ -243,7 +241,7 @@ theorem mk_one : mk 1 = (⊤ : MulArchimedeanClass M) := rfl
 
 variable (M) in
 @[to_additive (attr := simp)]
-theorem out_top : (⊤ : MulArchimedeanClass M).out = 1 := mk_one_out M
+theorem out_top : (⊤ : MulArchimedeanClass M).out = 1 := out_mk_one M
 
 @[to_additive (attr := simp)]
 theorem mk_eq_top_iff : mk a = ⊤ ↔ a = 1 := mk_eq_mk_one_iff
@@ -390,30 +388,27 @@ theorem mk_eq_mk_of_mulArchimedean [MulArchimedean M] (ha : a ≠ 1) (hb : b ≠
 section Hom
 
 variable {N : Type*} [CommGroup N] [LinearOrder N] [IsOrderedMonoid N]
-variable {F : Type*} [FunLike F M N] [OrderHomClass F M N] [MonoidHomClass F M N]
 
-/-- An ordered group homomorphism can be lifted to an `OrderHom`
-over archimedean classes. -/
-@[to_additive "An ordered group homomorphism can be lifted to an `OrderHom`
-over archimedean classes."]
+/-- An `OrderMonoidHom` can be lifted to an `OrderHom` over archimedean classes. -/
+@[to_additive "An `OrderAddMonoidHom` can be lifted to an `OrderHom` over archimedean classes."]
 noncomputable
-def orderHom (f : F) : MulArchimedeanClass M →o MulArchimedeanClass N :=
+def orderHom (f : M →*o N) : MulArchimedeanClass M →o MulArchimedeanClass N :=
   (MulArchimedeanOrder.orderHom f).antisymmetrization
 
 @[to_additive (attr := simp)]
-theorem orderHom_mk (f : F) (a : M) : orderHom f (mk a) = mk (f a) := rfl
+theorem orderHom_mk (f : M →*o N) (a : M) : orderHom f (mk a) = mk (f a) := rfl
 
 @[to_additive]
-theorem map_mk_eq (f : F) (h : mk a = mk b) : mk (f a) = mk (f b) := by
+theorem map_mk_eq (f : M →*o N) (h : mk a = mk b) : mk (f a) = mk (f b) := by
   rw [← orderHom_mk, ← orderHom_mk, h]
 
 @[to_additive]
-theorem map_mk_le (f : F) (h : mk a ≤ mk b) : mk (f a) ≤ mk (f b) := by
+theorem map_mk_le (f : M →*o N) (h : mk a ≤ mk b) : mk (f a) ≤ mk (f b) := by
   rw [← orderHom_mk, ← orderHom_mk]
   exact OrderHomClass.monotone _ h
 
 @[to_additive]
-theorem orderHom_injective {f : F} (h : Function.Injective f) :
+theorem orderHom_injective {f : M →*o N} (h : Function.Injective f) :
     Function.Injective (orderHom f) := by
   intro a b
   induction a using ind with | mk a
@@ -424,7 +419,7 @@ theorem orderHom_injective {f : F} (h : Function.Injective f) :
   exact ⟨⟨m, hmono.le_iff_le.mp hm⟩, ⟨n, hmono.le_iff_le.mp hn⟩⟩
 
 @[to_additive (attr := simp)]
-theorem orderHom_top (f : F) : orderHom f ⊤ = ⊤ := by
+theorem orderHom_top (f : M →*o N) : orderHom f ⊤ = ⊤ := by
   rw [← mk_one, ← mk_one, orderHom_mk, map_one]
 
 end Hom

--- a/Mathlib/Algebra/Order/Archimedean/Class.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Class.lean
@@ -9,18 +9,18 @@ import Mathlib.Data.Finset.Max
 import Mathlib.Order.Antisymmetrization
 
 /-!
-# Archimedean classes of linearly ordered group.
+# Archimedean classes of a linearly ordered group
 
-This file defines archimedean classes of a given linearly ordered group.
+This file defines archimedean classes of a given linearly ordered group. Archimedean classes
+measure to what extent the group fails to be Archimedean. For additive group, elements `a` and `b`.
+in the same class are "equivalent" in the sense that there exist two natural numbers
+`m` and `n` such that `|a| ≤ m • |b|` and `|b| ≤ n • |a|`. An element `a` in a higher class than `b`
+is "infinitesimal" to `b` in the sense that `n • |a| < |b|` for all natural number `n`.
 
 ## Main definitions
 
-* `ArchimedeanClass` are classes of elements in a ordered additive commutative group
-  that are archimedean equivelent. Two elements `a` and `b` are archimedean equivalent when there
-  exists two natural numbers `m` and `n` such that `|a| ≤ m • |b|` and `|b| ≤ n • |a|`.
-* `MulArchimedeanClass` is the multiplicative version of `ArchimedeanClass`.
-  Two elements `a` and `b` are mul-archimedean equivalent when there
-  exists two natural numbers `m` and `n` such that `|a|ₘ ≤ |b|ₘ ^ m` and `|b|ₘ ≤ |a|ₘ ^ n`.
+* `ArchimedeanClass` is the archimedean class for additive linearly ordered group.
+* `MulArchimedeanClass` is the archimedean class for multiplicative linearly ordered group.
 * `ArchimedeanClass.orderHom` and `MulArchimedeanClass.orderHom` are `OrderHom` over
   archimedean classes lifted from ordered group homomorphisms.
 
@@ -34,9 +34,8 @@ all non-identity elements belong to the same (`Mul`-)`ArchimedeanClass`:
 ## Implementation notes
 
 Archimedean classes are equiped with a linear order, where elements with smaller absolute value
-are placed in a *higher* classes by convention. In other words, if `b` is infinitesimal relative to
-`a`, `b` is in a higher class than `a`. Ordering backwards this way simplifies formalization of
-theorems such as the Hahn embedding theorem.
+are placed in a *higher* classes by convention. Ordering backwards this way simplifies
+formalization of theorems such as the Hahn embedding theorem.
 
 To naturally derive this order, we first define it on the underlying group via the type
 synonym (`Mul`-)`ArchimedeanOrder`, and define (`Mul`-)`ArchimedeanClass` as `Antisymmetrization` of
@@ -89,12 +88,12 @@ instance instLT : LT (MulArchimedeanOrder M) where
   lt a b := ∀ n, |b.val|ₘ ^ n < |a.val|ₘ
 
 @[to_additive]
-theorem le {a b : MulArchimedeanOrder M} :
-  a ≤ b ↔ ∃ n, |b.val|ₘ ≤ |a.val|ₘ ^ n := by rfl
+theorem le_def {a b : MulArchimedeanOrder M} :
+  a ≤ b ↔ ∃ n, |b.val|ₘ ≤ |a.val|ₘ ^ n := .rfl
 
 @[to_additive]
-theorem lt {a b : MulArchimedeanOrder M} :
-  a < b ↔ ∀ n, |b.val|ₘ ^ n < |a.val|ₘ := by rfl
+theorem lt_def {a b : MulArchimedeanOrder M} :
+  a < b ↔ ∀ n, |b.val|ₘ ^ n < |a.val|ₘ := .rfl
 
 variable {M: Type*}
 variable [CommGroup M] [LinearOrder M] [IsOrderedMonoid M] {a b : M}
@@ -109,7 +108,7 @@ instance instPreorder : Preorder (MulArchimedeanOrder M) where
     rw [pow_mul]
     exact hn.trans (pow_le_pow_left' hm n)
   lt_iff_le_not_ge a b := by
-    rw [lt, le, le]
+    rw [lt_def, le_def, le_def]
     suffices (∀ (n : ℕ), |b.val|ₘ ^ n < |a.val|ₘ) → ∃ n, |b.val|ₘ ≤ |a.val|ₘ ^ n by
       simpa using this
     intro h
@@ -121,8 +120,8 @@ variable (M) in
 instance instIsTotal : IsTotal (MulArchimedeanOrder M) (· ≤ ·) where
   total a b := by
     obtain hab | hab := le_total |a.val|ₘ |b.val|ₘ
-    · exact Or.inr ⟨1, by simpa using hab⟩
-    · exact Or.inl ⟨1, by simpa using hab⟩
+    · exact .inr ⟨1, by simpa using hab⟩
+    · exact .inl ⟨1, by simpa using hab⟩
 
 variable {N : Type*} [CommGroup N] [LinearOrder N] [IsOrderedMonoid N]
 variable {F : Type*} [FunLike F M N] [OrderHomClass F M N] [MonoidHomClass F M N]
@@ -134,10 +133,9 @@ variable {F : Type*} [FunLike F M N] [OrderHomClass F M N] [MonoidHomClass F M N
 noncomputable
 def orderHom (f : F) : MulArchimedeanOrder M →o MulArchimedeanOrder N where
   toFun a := of (f a.val)
-  monotone' a b h := by
-    rw [le] at h ⊢
-    obtain ⟨n, hn⟩ := h
-    simp_rw [val_of, ← map_mabs, ← map_pow]
+  monotone' := by
+    rintro a b ⟨n, hn⟩
+    simp_rw [le_def, val_of, ← map_mabs, ← map_pow]
     exact ⟨n, OrderHomClass.monotone f hn⟩
 
 end MulArchimedeanOrder
@@ -152,7 +150,6 @@ variable (M) in
 @[to_additive ArchimedeanClass
 "`ArchimedeanClass` is the antisymmetrization of `ArchimedeanOrder`."]
 def MulArchimedeanClass := Antisymmetrization (MulArchimedeanOrder M) (· ≤ ·)
-
 
 namespace MulArchimedeanClass
 
@@ -221,10 +218,10 @@ instance instLinearOrder : LinearOrder (MulArchimedeanClass M) := by
   exact instLinearOrderAntisymmetrizationLeOfDecidableLEOfDecidableLTOfIsTotal
 
 @[to_additive]
-theorem mk_le_mk : mk a ≤ mk b ↔ ∃ n, |b|ₘ ≤ |a|ₘ ^ n := by rfl
+theorem mk_le_mk : mk a ≤ mk b ↔ ∃ n, |b|ₘ ≤ |a|ₘ ^ n := .rfl
 
 @[to_additive]
-theorem mk_lt_mk : mk a < mk b ↔ ∀ n, |b|ₘ ^ n < |a|ₘ := by simpa using mk_le_mk.not
+theorem mk_lt_mk : mk a < mk b ↔ ∀ n, |b|ₘ ^ n < |a|ₘ := .rfl
 
 @[to_additive]
 theorem le_mk_one (A : MulArchimedeanClass M) : A ≤ mk 1 := by
@@ -241,12 +238,12 @@ instance instOrderTop : OrderTop (MulArchimedeanClass M) where
   le_top := le_mk_one
 
 variable (M) in
-@[to_additive]
-theorem top_eq : (⊤ : MulArchimedeanClass M) = mk 1 := rfl
+@[to_additive (attr := simp)]
+theorem mk_one : mk 1 = (⊤ : MulArchimedeanClass M) := rfl
 
 variable (M) in
 @[to_additive (attr := simp)]
-theorem top_out : (⊤ : MulArchimedeanClass M).out = 1 := mk_one_out M
+theorem out_top : (⊤ : MulArchimedeanClass M).out = 1 := mk_one_out M
 
 @[to_additive (attr := simp)]
 theorem mk_eq_top_iff : mk a = ⊤ ↔ a = 1 := mk_eq_mk_one_iff
@@ -371,14 +368,14 @@ theorem one_lt_of_one_lt_of_mk_lt (ha : 1 < a) (hab : mk a < mk (b / a)) :
   · simpa using ha.le
 
 @[to_additive archimedean_of_mk_eq_mk]
-theorem mulArchimedean_of_mk_eq_mk (h : ∀ (a b : M), a ≠ 1 → b ≠ 1 → mk a = mk b) :
+theorem mulArchimedean_of_mk_eq_mk (h : ∀ a ≠ (1 : M), ∀ b ≠ 1, mk a = mk b) :
     MulArchimedean M where
   arch x y hy := by
     by_cases hx : x ≤ 1
     · use 0
       simpa using hx
     · have hx : 1 < x := lt_of_not_ge hx
-      have hxy : mk x = mk y := h x y hx.ne.symm hy.ne.symm
+      have hxy : mk x = mk y := h x hx.ne.symm y hy.ne.symm
       obtain ⟨_, ⟨m, hm⟩⟩ := (MulArchimedeanClass.eq).mp hxy
       rw [mabs_eq_self.mpr hx.le, mabs_eq_self.mpr hy.le] at hm
       exact ⟨m, hm⟩
@@ -428,8 +425,7 @@ theorem orderHom_injective {f : F} (h : Function.Injective f) :
 
 @[to_additive (attr := simp)]
 theorem orderHom_top (f : F) : orderHom f ⊤ = ⊤ := by
-  rw [top_eq, top_eq]
-  simp
+  rw [← mk_one, ← mk_one, orderHom_mk, map_one]
 
 end Hom
 

--- a/Mathlib/Algebra/Order/Archimedean/Class.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Class.lean
@@ -282,8 +282,8 @@ theorem mk_right_le_mk_mul (hba : mk b ≤ mk a) : mk b ≤ mk (a * b) := by
   simpa [hba] using min_le_mk_mul (a := a) (b := b)
 
 @[to_additive]
-theorem mk_left_eq_mk_mul (h : mk a < mk b) : mk a = mk (a * b) := by
-  refine le_antisymm (mk_left_le_mk_mul h.le) (mk_le_mk.mpr ⟨2, ?_⟩)
+theorem mk_mul_eq_mk_left (h : mk a < mk b) : mk (a * b) = mk a := by
+  refine le_antisymm (mk_le_mk.mpr ⟨2, ?_⟩) (mk_left_le_mk_mul h.le)
   rw [mk_lt_mk] at h
   apply (mabs_mul' _ b).trans
   rw [mul_comm b a, pow_two, mul_le_mul_iff_right]
@@ -292,8 +292,8 @@ theorem mk_left_eq_mk_mul (h : mk a < mk b) : mk a = mk (a * b) := by
   exact (pow_two |b|ₘ ▸ (h 2).le).trans (mabs_mul' a b)
 
 @[to_additive]
-theorem mk_right_eq_mk_mul (h : mk b < mk a) : mk b = mk (a * b) :=
-  mul_comm a b ▸ mk_left_eq_mk_mul h
+theorem mk_mul_eq_mk_right (h : mk b < mk a) : mk (a * b) = mk b :=
+  mul_comm a b ▸ mk_mul_eq_mk_left h
 
 /-- The product over a set of an elements in distinct classes is in the lowest class. -/
 @[to_additive "The sum over a set of an elements in distinct classes is in the lowest class."]
@@ -315,7 +315,7 @@ theorem mk_prod {ι : Type*} [LinearOrder ι] {s : Finset ι} (hnonempty : s.Non
       exact hi (Finset.min'_mem _ hs)
     rw [← ih] at hne
     obtain hlt|hlt := lt_or_gt_of_ne hne
-    · rw [← mk_left_eq_mk_mul hlt]
+    · rw [mk_mul_eq_mk_left hlt]
       congr
       apply le_antisymm (Finset.le_min' _ _ _ ?_) (Finset.min'_le _ _ (by simp))
       intro y hy
@@ -325,7 +325,7 @@ theorem mk_prod {ι : Type*} [LinearOrder ι] {s : Finset ι} (hnonempty : s.Non
         apply (hmono.lt_iff_lt (by simp) hminmem).mp
         rw [ih] at hlt
         exact hlt
-    · rw [mul_comm, ← mk_left_eq_mk_mul hlt, ih]
+    · rw [mul_comm, mk_mul_eq_mk_left hlt, ih]
       congr 2
       refine le_antisymm (Finset.le_min' _ _ _ ?_) (Finset.min'_le _ _ hminmem)
       intro y hy

--- a/Mathlib/Algebra/Order/Archimedean/Class.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Class.lean
@@ -45,7 +45,6 @@ the order.
 -/
 
 section Pre
-
 variable {M: Type*}
 
 variable (M) in
@@ -78,14 +77,12 @@ theorem val_of (a : M) : val (of a) = a := rfl
 
 variable [Group M] [Lattice M]
 
-variable (M) in
 @[to_additive]
-instance instLE : LE (MulArchimedeanOrder M) where
+instance : LE (MulArchimedeanOrder M) where
   le a b := ∃ n, |b.val|ₘ ≤ |a.val|ₘ ^ n
 
-variable (M) in
 @[to_additive]
-instance instLT : LT (MulArchimedeanOrder M) where
+instance : LT (MulArchimedeanOrder M) where
   lt a b := ∀ n, |b.val|ₘ ^ n < |a.val|ₘ
 
 @[to_additive]
@@ -97,9 +94,8 @@ theorem lt_def {a b : MulArchimedeanOrder M} : a < b ↔ ∀ n, |b.val|ₘ ^ n <
 variable {M: Type*}
 variable [CommGroup M] [LinearOrder M] [IsOrderedMonoid M] {a b : M}
 
-variable (M) in
 @[to_additive]
-instance instPreorder : Preorder (MulArchimedeanOrder M) where
+instance : Preorder (MulArchimedeanOrder M) where
   le_refl a := ⟨1, by simp⟩
   le_trans a b c := by
     intro ⟨m, hm⟩ ⟨n, hn⟩
@@ -114,9 +110,8 @@ instance instPreorder : Preorder (MulArchimedeanOrder M) where
     obtain h := (h 1).le
     exact ⟨1, by simpa using h⟩
 
-variable (M) in
 @[to_additive]
-instance instIsTotal : IsTotal (MulArchimedeanOrder M) (· ≤ ·) where
+instance : IsTotal (MulArchimedeanOrder M) (· ≤ ·) where
   total a b := by
     obtain hab | hab := le_total |a.val|ₘ |b.val|ₘ
     · exact .inr ⟨1, by simpa using hab⟩
@@ -193,10 +188,9 @@ theorem mk_div_comm (a b : M) : mk (a / b) = mk (b / a) := by
 theorem mk_mabs (a : M) : mk |a|ₘ = mk a :=
   mk_eq_mk.mpr ⟨⟨1, by simp⟩, ⟨1, by simp⟩⟩
 
-variable (M) in
 @[to_additive]
 noncomputable
-instance instLinearOrder : LinearOrder (MulArchimedeanClass M) := by
+instance : LinearOrder (MulArchimedeanClass M) := by
   classical
   unfold MulArchimedeanClass
   infer_instance
@@ -207,11 +201,10 @@ theorem mk_le_mk : mk a ≤ mk b ↔ ∃ n, |b|ₘ ≤ |a|ₘ ^ n := .rfl
 @[to_additive]
 theorem mk_lt_mk : mk a < mk b ↔ ∀ n, |b|ₘ ^ n < |a|ₘ := .rfl
 
-variable (M) in
 /-- 1 is in its own class, which is also the largest class. -/
 @[to_additive "0 is in its own class, which is also the largest class."]
 noncomputable
-instance instOrderTop : OrderTop (MulArchimedeanClass M) where
+instance : OrderTop (MulArchimedeanClass M) where
   top := mk 1
   le_top A := by
     induction A using ind with | mk a
@@ -377,7 +370,6 @@ theorem mk_eq_mk_of_mulArchimedean [MulArchimedean M] (ha : a ≠ 1) (hb : b ≠
   exact mk_eq_mk.mpr ⟨hm, hn⟩
 
 section Hom
-
 variable {N : Type*} [CommGroup N] [LinearOrder N] [IsOrderedMonoid N]
 
 /-- An `OrderMonoidHom` can be lifted to an `OrderHom` over archimedean classes. -/

--- a/Mathlib/Algebra/Order/Group/Unbundled/Abs.lean
+++ b/Mathlib/Algebra/Order/Group/Unbundled/Abs.lean
@@ -213,6 +213,11 @@ variable [Group α] [LinearOrder α] {a b : α}
 
 @[to_additive] lemma lt_of_mabs_lt : |a|ₘ < b → a < b := (le_mabs_self _).trans_lt
 
+@[to_additive] lemma map_mabs {β F : Type*} [Group β] [LinearOrder β] [FunLike F α β]
+    [OrderHomClass F α β] [MonoidHomClass F α β] (f : F) (a : α) :
+    f |a|ₘ = |f a|ₘ := by
+  rw [mabs, mabs, Monotone.map_max (OrderHomClass.mono f), map_inv]
+
 variable [MulLeftMono α] {a b : α}
 
 @[to_additive (attr := simp) abs_pos] lemma one_lt_mabs : 1 < |a|ₘ ↔ a ≠ 1 := by

--- a/Mathlib/Algebra/Order/Group/Unbundled/Abs.lean
+++ b/Mathlib/Algebra/Order/Group/Unbundled/Abs.lean
@@ -213,7 +213,7 @@ variable [Group α] [LinearOrder α] {a b : α}
 
 @[to_additive] lemma lt_of_mabs_lt : |a|ₘ < b → a < b := (le_mabs_self _).trans_lt
 
-@[to_additive] lemma map_mabs {β F : Type*} [Group β] [LinearOrder β] [FunLike F α β]
+@[to_additive (attr := simp)] lemma map_mabs {β F : Type*} [Group β] [LinearOrder β] [FunLike F α β]
     [OrderHomClass F α β] [MonoidHomClass F α β] (f : F) (a : α) :
     f |a|ₘ = |f a|ₘ := by
   rw [mabs, mabs, (OrderHomClass.mono f).map_max, map_inv]

--- a/Mathlib/Algebra/Order/Group/Unbundled/Abs.lean
+++ b/Mathlib/Algebra/Order/Group/Unbundled/Abs.lean
@@ -216,7 +216,7 @@ variable [Group α] [LinearOrder α] {a b : α}
 @[to_additive] lemma map_mabs {β F : Type*} [Group β] [LinearOrder β] [FunLike F α β]
     [OrderHomClass F α β] [MonoidHomClass F α β] (f : F) (a : α) :
     f |a|ₘ = |f a|ₘ := by
-  rw [mabs, mabs, Monotone.map_max (OrderHomClass.mono f), map_inv]
+  rw [mabs, mabs, (OrderHomClass.mono f).map_max, map_inv]
 
 variable [MulLeftMono α] {a b : α}
 


### PR DESCRIPTION
This is the first of PRs for Hahn embedding theorem #25140

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
