### PR TITLE
feat(Analysis/Normed/Lp/PiLp): add uniqueness instances for `PiLp`

### DIFF
--- a/Mathlib/Analysis/Normed/Lp/PiLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/PiLp.lean
@@ -80,6 +80,14 @@ instance (p : ℝ≥0∞) {ι : Type*} (α : ι → Type*) : CoeFun (PiLp p α) 
 instance (p : ℝ≥0∞) {ι : Type*} (α : ι → Type*) [∀ i, Inhabited (α i)] : Inhabited (PiLp p α) :=
   ⟨fun _ => default⟩
 
+instance PiLp.unique (p : ℝ≥0∞) {ι : Type*} (α : ι → Type*) [∀ i, Unique (α i)] :
+    Unique (PiLp p α) :=
+  Pi.unique
+
+instance PiLp.uniqueOfIsEmpty (p : ℝ≥0∞) {ι : Type*} [Fintype ι] [IsEmpty ι] (α : ι → Type*) :
+    Unique (PiLp p α) :=
+  Pi.uniqueOfIsEmpty _
+
 @[ext]
 protected theorem PiLp.ext {p : ℝ≥0∞} {ι : Type*} {α : ι → Type*} {x y : PiLp p α}
     (h : ∀ i, x i = y i) : x = y := funext h

--- a/Mathlib/Analysis/Normed/Lp/PiLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/PiLp.lean
@@ -84,7 +84,7 @@ instance PiLp.unique (p : ℝ≥0∞) {ι : Type*} (α : ι → Type*) [∀ i, U
     Unique (PiLp p α) :=
   Pi.unique
 
-instance PiLp.uniqueOfIsEmpty (p : ℝ≥0∞) {ι : Type*} [Fintype ι] [IsEmpty ι] (α : ι → Type*) :
+instance PiLp.uniqueOfIsEmpty (p : ℝ≥0∞) {ι : Type*} [IsEmpty ι] (α : ι → Type*) :
     Unique (PiLp p α) :=
   Pi.uniqueOfIsEmpty _
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

This commit introduces two instances for uniqueness of `PiLp`.
The name for both instances are adopted from those of `Pi`.

```lean
instance PiLp.unique (p : ℝ≥0∞) {ι : Type*} (α : ι → Type*) [∀ i, Unique (α i)] :
    Unique (PiLp p α)

instance PiLp.uniqueOfIsEmpty (p : ℝ≥0∞) {ι : Type*} [IsEmpty ι] (α : ι → Type*) :
    Unique (PiLp p α)
```

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
