### PR TITLE
feat(CategoryTheory/Bicategory): (2,1)-categories and `Pith`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1913,6 +1913,7 @@ import Mathlib.CategoryTheory.Bicategory.Kan.Adjunction
 import Mathlib.CategoryTheory.Bicategory.Kan.HasKan
 import Mathlib.CategoryTheory.Bicategory.Kan.IsKan
 import Mathlib.CategoryTheory.Bicategory.LocallyDiscrete
+import Mathlib.CategoryTheory.Bicategory.LocallyGroupoid
 import Mathlib.CategoryTheory.Bicategory.Modification.Oplax
 import Mathlib.CategoryTheory.Bicategory.NaturalTransformation.Oplax
 import Mathlib.CategoryTheory.Bicategory.NaturalTransformation.Pseudo

--- a/Mathlib/CategoryTheory/Bicategory/LocallyGroupoid.lean
+++ b/Mathlib/CategoryTheory/Bicategory/LocallyGroupoid.lean
@@ -1,0 +1,168 @@
+/-
+Copyright (c) 2025 Robin Carlier. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robin Carlier
+-/
+import Mathlib.CategoryTheory.Core
+import Mathlib.CategoryTheory.Bicategory.Functor.Prelax
+import Mathlib.CategoryTheory.Bicategory.Functor.Pseudofunctor
+
+/-!
+# (2,1)-categories
+
+A bicategory `B` is said to be locally groupoidal (or a (2,1)-category) if for every pair
+of objects `x, y`, the Hom-category `x ⟶ y` is a groupoid (which is expressed using the
+`CategoryTheory.IsGroupoid` typeclass).
+
+Given a bicategory `B`, we construct a bicategory `Pith B` which is obtained from `B`
+by discarding non-invertible 2-morphisms. This is realized in practice by applying
+`Core` to each hom-category of `C`. By construction, `Pith B` is a (2,1)-category,
+and for every (2,1)-category B', every pseudofunctor `B' ⥤ B` factors uniquely
+through the inclusion from `Pith B` to `B`.
+
+## References
+- [Kerodon, section 1.2.2](https://kerodon.net/tag/02GD).
+
+-/
+
+namespace CategoryTheory
+
+open Bicategory
+
+universe w₁ w₂ v₁ v₂ u₁ u₂
+
+/-- A bicategory is locally groupoidal if the categories of 1-morphisms are groupoids. -/
+@[kerodon 009Q]
+abbrev IsLocallyGroupoid (B : Type*) [Bicategory B] := ∀ (b c : B), IsGroupoid (b ⟶ c)
+
+/-- Given a bicategory `B`, `Pith B` is the bicategory obtain by discarding the non-invertible
+2-cells from `B`. We implement this as a wrapper type for `B`, and use `CategoryTheory.Core`
+to discard the non-invertible morphisms. -/
+@[kerodon 00AL]
+structure Pith (B : Type*) where
+  as : B
+
+namespace Pith
+
+variable (B : Type u₁)
+
+theorem mk_as (b : Pith B) : mk b.as = b := rfl
+
+instance [Inhabited B] : Inhabited (Pith B) := ⟨⟨default⟩⟩
+
+instance categoryStruct [Bicategory.{w₁, v₁} B] : CategoryStruct (Pith B) where
+  Hom a b := Core (a.as ⟶ b.as)
+  id a := ⟨𝟙 a.as⟩
+  comp f g := ⟨f.of ≫ g.of⟩
+
+variable [Bicategory.{w₁, v₁} B]
+
+-- @[simps!] in categoryStruct puts `Core (a.as ⟶ b.as)` in the hyps for the next two
+-- lemmas, so we record them manually instead.
+@[simp]
+lemma id_of (a : Pith B) : (𝟙 a : a ⟶ a).of = 𝟙 a.as := rfl
+
+@[simp]
+lemma comp_of {a b c : Pith B} (f : a ⟶ b) (g : b ⟶ c) : (f ≫ g).of = f.of ≫ g.of := rfl
+
+instance homGroupoid  (a b : Pith B) :
+    Groupoid.{w₁} (a ⟶ b) := inferInstanceAs <| Groupoid <| Core _
+
+@[ext]
+lemma hom₂_ext {a b : Pith B} {x y : a ⟶ b} {f g : x ⟶ y} {h : f.iso.hom = g.iso.hom} :
+    f = g := CoreHom.ext <| Iso.ext h
+
+@[simp, reassoc]
+lemma comp₂_iso_hom {a b : Pith B} {x y z : a ⟶ b} {f : x ⟶ y} {g : y ⟶ z} :
+    (f ≫ g).iso.hom = f.iso.hom ≫ g.iso.hom := rfl
+
+@[simp, reassoc]
+lemma comp₂_iso_inv {a b : Pith B} {x y z : a ⟶ b} {f : x ⟶ y} {g : y ⟶ z} :
+    (f ≫ g).iso.inv = g.iso.inv ≫ f.iso.inv := rfl
+
+@[simp]
+lemma id₂_iso_hom {a b : Pith B} {x : a ⟶ b} : (𝟙 x : x ⟶ x).iso.hom = 𝟙 _ := rfl
+
+@[simp]
+lemma id₂_iso_inv {a b : Pith B} {x : a ⟶ b} : (𝟙 x : x ⟶ x).iso.inv = 𝟙 _ := rfl
+
+@[simps! whiskerLeft_iso_hom whiskerLeft_iso_inv whiskerRight_iso_hom whiskerRight_iso_inv
+associator_hom_iso associator_inv_iso_hom associator_inv_iso_inv leftUnitor_hom_iso
+leftUnitor_inv_iso_hom rightUnitor_hom_iso rightUnitor_inv_iso_hom rightUnitor_inv_iso_inv]
+instance : Bicategory.{w₁, v₁} (Pith B) where
+  whiskerLeft x _ _ f := CoreHom.mk <| whiskerLeftIso x.of (CoreHom.iso f)
+  whiskerRight f y := CoreHom.mk <| whiskerRightIso (CoreHom.iso f) y.of
+  leftUnitor x :=
+    { hom := CoreHom.mk <| leftUnitor x.of
+      inv := CoreHom.mk (leftUnitor x.of|>.symm) }
+  rightUnitor x :=
+    { hom := CoreHom.mk <| rightUnitor x.of
+      inv := CoreHom.mk (rightUnitor x.of|>.symm) }
+  associator x y z :=
+    { hom := CoreHom.mk <| associator x.of y.of z.of
+      inv := CoreHom.mk (associator x.of y.of z.of|>.symm) }
+  whisker_exchange η θ := by
+    ext
+    simp [whisker_exchange]
+
+/-- The pith is a (2,1)-category. -/
+example : IsLocallyGroupoid (Pith B) := by infer_instance
+
+/-- The canonical inclusion from the pith of `B` to `B`, as a Pseudofunctor. -/
+def inclusion : Pseudofunctor (Pith B) B where
+  obj x := x.as
+  map f := f.of
+  map₂ η := η.iso.hom
+  mapId _ := .refl _
+  mapComp _ _ := .refl _
+
+variable {B} in
+/-- Any pseudofunctor from a (2,1)-category to a bicategory factors through
+the pith of the target bicateogry. -/
+@[simps!]
+noncomputable def pseudofunctorToPith {B' : Type*} [Bicategory B']
+    [IsLocallyGroupoid B'] (F : Pseudofunctor B' B) :
+    Pseudofunctor B' (Pith B) where
+  obj x := .mk <| F.obj x
+  map f := .mk <| F.map f
+  map₂ f := .mk <| asIso <| F.map₂ f
+  mapId x :=
+    { hom := .mk <| F.mapId x
+      inv := .mk (F.mapId x|>.symm) }
+  mapComp f g :=
+    { hom := .mk <| F.mapComp f g
+      inv := .mk <| (F.mapComp f g).symm }
+
+end Pith
+
+variable {B : Type u₁} [Bicategory.{w₁, v₁} B]
+
+/-- If `B` is a (2,1)-category, then every lax functor `F` from a bicategory to `B` defines a
+`CategoryTheory.LaxFunctor.PseudoCore` structure on `F` that can be used to promote `F` to a
+pseudofunctor using `CategoryTheory.Pseudofunctor.mkOfLax`. -/
+@[simps!]
+noncomputable def Pseudofunctor.ofLaxFunctorToLocallyGroupoid
+    {B' : Type u₂} [Bicategory.{w₂, v₂} B'] [IsLocallyGroupoid B] (F : LaxFunctor B' B) :
+    F.PseudoCore where
+  mapIdIso x :=
+    { hom := inv <| F.mapId x
+      inv := F.mapId x}
+  mapCompIso f g :=
+    { hom := inv <| F.mapComp f g
+      inv := F.mapComp f g}
+
+/-- If `B` is a (2,1)-category, then every oplax functor `F` from a bicategory to `B` defines
+a `CategoryTheory.OplaxFunctor.PseudoCore` structure on `F` that can be used to promote `F`
+to a pseudofunctor using `CategoryTheory.Pseudofunctor.mkOfOplax`. -/
+@[simps!]
+noncomputable def Pseudofunctor.ofOplaxFunctorToLocallyGroupoid
+    {B' : Type u₂} [Bicategory.{w₂, v₂} B'] [IsLocallyGroupoid B] (F : OplaxFunctor B' B) :
+    F.PseudoCore where
+  mapIdIso x :=
+    { hom := F.mapId x
+      inv := inv <| F.mapId x}
+  mapCompIso f g :=
+    { hom := F.mapComp f g
+      inv := inv <| F.mapComp f g}
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Bicategory/LocallyGroupoid.lean
+++ b/Mathlib/CategoryTheory/Bicategory/LocallyGroupoid.lean
@@ -4,8 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robin Carlier
 -/
 import Mathlib.CategoryTheory.Core
-import Mathlib.CategoryTheory.Bicategory.Functor.Prelax
-import Mathlib.CategoryTheory.Bicategory.Functor.Pseudofunctor
+import Mathlib.CategoryTheory.Bicategory.NaturalTransformation.Pseudo
 
 /-!
 # (2,1)-categories
@@ -18,14 +17,15 @@ Given a bicategory `B`, we construct a bicategory `Pith B` which is obtained fro
 by discarding non-invertible 2-morphisms. This is realized in practice by applying
 `Core` to each hom-category of `C`. By construction, `Pith B` is a (2,1)-category,
 and for every (2,1)-category B', every pseudofunctor `B' ⥤ B` factors uniquely
-through the inclusion from `Pith B` to `B`.
+through the inclusion from `Pith B` to `B` (see
+`CategoryTheory.Bicategory.Pith.pseudofunctorToPith`).
 
 ## References
 - [Kerodon, section 1.2.2](https://kerodon.net/tag/02GD).
 
 -/
 
-namespace CategoryTheory
+namespace CategoryTheory.Bicategory
 
 open Bicategory
 
@@ -109,6 +109,7 @@ instance : Bicategory.{w₁, v₁} (Pith B) where
 example : IsLocallyGroupoid (Pith B) := by infer_instance
 
 /-- The canonical inclusion from the pith of `B` to `B`, as a Pseudofunctor. -/
+@[simps]
 def inclusion : Pseudofunctor (Pith B) B where
   obj x := x.as
   map f := f.of
@@ -132,6 +133,26 @@ noncomputable def pseudofunctorToPith {B' : Type*} [Bicategory B']
   mapComp f g :=
     { hom := .mk <| F.mapComp f g
       inv := .mk <| (F.mapComp f g).symm }
+
+section
+
+variable {B} {B' : Type*} [Bicategory B'] [IsLocallyGroupoid B'] (F : Pseudofunctor B' B)
+
+/-- The hom direction of the (strong) natural isomorphism of pseudofunctors
+between `(pseudofunctorToPith F).comp (inclusion B)` and `F`. -/
+noncomputable def pseudofunctorToPithCompInclusionStrongIsoHom :
+    Pseudofunctor.StrongTrans ((pseudofunctorToPith F).comp (inclusion B)) F where
+  app b' := 𝟙 _
+  naturality f := (ρ_ _) ≪≫ (λ_ _).symm
+
+/-- The inv direction of the (strong) natural isomorphism of pseudofunctors
+between `(pseudofunctorToPith F).comp (inclusion B)` and `F`. -/
+noncomputable def pseudofunctorToPithCompInclusionStrongIsoInv :
+    Pseudofunctor.StrongTrans F ((pseudofunctorToPith F).comp (inclusion B)) where
+  app b' := 𝟙 _
+  naturality f := (ρ_ _) ≪≫ (λ_ _).symm
+
+end
 
 end Pith
 
@@ -165,4 +186,4 @@ noncomputable def Pseudofunctor.ofOplaxFunctorToLocallyGroupoid
     { hom := F.mapComp f g
       inv := inv <| F.mapComp f g}
 
-end CategoryTheory
+end CategoryTheory.Bicategory

--- a/Mathlib/CategoryTheory/Bicategory/LocallyGroupoid.lean
+++ b/Mathlib/CategoryTheory/Bicategory/LocallyGroupoid.lean
@@ -142,14 +142,14 @@ variable {B} {B' : Type*} [Bicategory B'] [IsLocallyGroupoid B'] (F : Pseudofunc
 /-- The hom direction of the (strong) natural isomorphism of pseudofunctors
 between `(pseudofunctorToPith F).comp (inclusion B)` and `F`. -/
 noncomputable def pseudofunctorToPithCompInclusionStrongIsoHom :
-    Pseudofunctor.StrongTrans ((pseudofunctorToPith F).comp (inclusion B)) F where
+    ((pseudofunctorToPith F).comp (inclusion B)).StrongTrans F where
   app b' := 𝟙 _
   naturality f := (ρ_ _) ≪≫ (λ_ _).symm
 
 /-- The inv direction of the (strong) natural isomorphism of pseudofunctors
 between `(pseudofunctorToPith F).comp (inclusion B)` and `F`. -/
 noncomputable def pseudofunctorToPithCompInclusionStrongIsoInv :
-    Pseudofunctor.StrongTrans F ((pseudofunctorToPith F).comp (inclusion B)) where
+    F.StrongTrans ((pseudofunctorToPith F).comp (inclusion B)) where
   app b' := 𝟙 _
   naturality f := (ρ_ _) ≪≫ (λ_ _).symm
 

--- a/Mathlib/CategoryTheory/Bicategory/LocallyGroupoid.lean
+++ b/Mathlib/CategoryTheory/Bicategory/LocallyGroupoid.lean
@@ -40,6 +40,7 @@ abbrev IsLocallyGroupoid (B : Type*) [Bicategory B] := ∀ (b c : B), IsGroupoid
 to discard the non-invertible morphisms. -/
 @[kerodon 00AL]
 structure Pith (B : Type*) where
+  /-- The underlying object of the bicategory. -/
   as : B
 
 namespace Pith

--- a/Mathlib/CategoryTheory/Bicategory/LocallyGroupoid.lean
+++ b/Mathlib/CategoryTheory/Bicategory/LocallyGroupoid.lean
@@ -16,7 +16,7 @@ of objects `x, y`, the Hom-category `x ⟶ y` is a groupoid (which is expressed 
 Given a bicategory `B`, we construct a bicategory `Pith B` which is obtained from `B`
 by discarding non-invertible 2-morphisms. This is realized in practice by applying
 `Core` to each hom-category of `C`. By construction, `Pith B` is a (2,1)-category,
-and for every (2,1)-category B', every pseudofunctor `B' ⥤ B` factors uniquely
+and for every (2,1)-category B', every pseudofunctor `B' ⥤ B` factors (essentially) uniquely
 through the inclusion from `Pith B` to `B` (see
 `CategoryTheory.Bicategory.Pith.pseudofunctorToPith`).
 


### PR DESCRIPTION
This PR introduces a class `IsLocallyGroupoid` on bicategories, asserting that every hom-category has an `IsGroupoid` instance.
With this definition, `IsLocallyGroupoid (LocallyDiscrete C)` is correctly inferred.

Given a bicategory `B`, we introduce a type alias `Pith B` for `B` (realized as a one-field structure), and we equip it with a `Bicategory` instance where the hom-categories are the cores of the hom-categories of `B`. We show that this bicategory is a (2,1)-category, construct an inclusion pseudo-functor from `Pith B` to `B`, and show that every pseudofunctor from a (2,1)-category to `B` factors through this inclusion. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

We can’t fully state the fact that `(pseudofunctorToPith F).comp (inclusion F)` "is" `F` because #18254 is still not merged.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
