### PR TITLE
[Merged by Bors] - feat: add some lemmas about `iteratedFDeriv` and `domDomCongr`

### DIFF
--- a/Mathlib/Analysis/Analytic/IteratedFDeriv.lean
+++ b/Mathlib/Analysis/Analytic/IteratedFDeriv.lean
@@ -247,7 +247,7 @@ theorem AnalyticOn.iteratedFDerivWithin_comp_perm
   conv_rhs => rw [← Equiv.sum_comp (Equiv.mulLeft σ)]
   simp only [coe_mulLeft, Perm.coe_mul, Function.comp_apply]
 
-theorem AnalyticOn.iteratedFDerivWithin_domDomCongr
+theorem AnalyticOn.domDomCongr_iteratedFDerivWithin
     (h : AnalyticOn 𝕜 f s) (hs : UniqueDiffOn 𝕜 s) (hx : x ∈ s) {n : ℕ} (σ : Perm (Fin n)) :
     (iteratedFDerivWithin 𝕜 n f s x).domDomCongr σ = iteratedFDerivWithin 𝕜 n f s x := by
   ext
@@ -265,7 +265,7 @@ theorem ContDiffWithinAt.iteratedFDerivWithin_comp_perm
   rw [← this]
   exact AnalyticOn.iteratedFDerivWithin_comp_perm hu.analyticOn (hs.inter u_open) ⟨hx, xu⟩ _ _
 
-theorem ContDiffWithinAt.iteratedFDerivWithin_domDomCongr
+theorem ContDiffWithinAt.domDomCongr_iteratedFDerivWithin
     (h : ContDiffWithinAt 𝕜 ω f s x) (hs : UniqueDiffOn 𝕜 s) (hx : x ∈ s) {n : ℕ}
     (σ : Perm (Fin n)) :
     (iteratedFDerivWithin 𝕜 n f s x).domDomCongr σ = iteratedFDerivWithin 𝕜 n f s x := by
@@ -279,10 +279,10 @@ theorem AnalyticOn.iteratedFDeriv_comp_perm
   rw [← iteratedFDerivWithin_univ]
   exact h.iteratedFDerivWithin_comp_perm uniqueDiffOn_univ (mem_univ x) _ _
 
-theorem AnalyticOn.iteratedFDeriv_domDomCongr (h : AnalyticOn 𝕜 f univ) {n : ℕ} (σ : Perm (Fin n)) :
+theorem AnalyticOn.domDomCongr_iteratedFDeriv (h : AnalyticOn 𝕜 f univ) {n : ℕ} (σ : Perm (Fin n)) :
     (iteratedFDeriv 𝕜 n f x).domDomCongr σ = iteratedFDeriv 𝕜 n f x := by
   rw [← iteratedFDerivWithin_univ]
-  exact h.iteratedFDerivWithin_domDomCongr uniqueDiffOn_univ (mem_univ x) _
+  exact h.domDomCongr_iteratedFDerivWithin uniqueDiffOn_univ (mem_univ x) _
 
 /-- The `n`-th iterated derivative of an analytic function is symmetric. -/
 theorem ContDiffAt.iteratedFDeriv_comp_perm
@@ -291,7 +291,7 @@ theorem ContDiffAt.iteratedFDeriv_comp_perm
   rw [← iteratedFDerivWithin_univ]
   exact h.iteratedFDerivWithin_comp_perm uniqueDiffOn_univ (mem_univ x) _ _
 
-theorem ContDiffAt.iteratedFDeriv_domDomCongr (h : ContDiffAt 𝕜 ω f x) {n : ℕ} (σ : Perm (Fin n)) :
+theorem ContDiffAt.domDomCongr_iteratedFDeriv (h : ContDiffAt 𝕜 ω f x) {n : ℕ} (σ : Perm (Fin n)) :
     (iteratedFDeriv 𝕜 n f x).domDomCongr σ = iteratedFDeriv 𝕜 n f x := by
   rw [← iteratedFDerivWithin_univ]
-  exact h.iteratedFDerivWithin_domDomCongr uniqueDiffOn_univ (mem_univ x) _
+  exact h.domDomCongr_iteratedFDerivWithin uniqueDiffOn_univ (mem_univ x) _

--- a/Mathlib/Analysis/Analytic/IteratedFDeriv.lean
+++ b/Mathlib/Analysis/Analytic/IteratedFDeriv.lean
@@ -247,6 +247,12 @@ theorem AnalyticOn.iteratedFDerivWithin_comp_perm
   conv_rhs => rw [← Equiv.sum_comp (Equiv.mulLeft σ)]
   simp only [coe_mulLeft, Perm.coe_mul, Function.comp_apply]
 
+theorem AnalyticOn.iteratedFDerivWithin_domDomCongr
+    (h : AnalyticOn 𝕜 f s) (hs : UniqueDiffOn 𝕜 s) (hx : x ∈ s) {n : ℕ} (σ : Perm (Fin n)) :
+    (iteratedFDerivWithin 𝕜 n f s x).domDomCongr σ = iteratedFDerivWithin 𝕜 n f s x := by
+  ext
+  exact h.iteratedFDerivWithin_comp_perm hs hx _ _
+
 /-- The `n`-th iterated derivative of an analytic function on a set is symmetric. -/
 theorem ContDiffWithinAt.iteratedFDerivWithin_comp_perm
     (h : ContDiffWithinAt 𝕜 ω f s x) (hs : UniqueDiffOn 𝕜 s) (hx : x ∈ s) {n : ℕ} (v : Fin n → E)
@@ -259,6 +265,13 @@ theorem ContDiffWithinAt.iteratedFDerivWithin_comp_perm
   rw [← this]
   exact AnalyticOn.iteratedFDerivWithin_comp_perm hu.analyticOn (hs.inter u_open) ⟨hx, xu⟩ _ _
 
+theorem ContDiffWithinAt.iteratedFDerivWithin_domDomCongr
+    (h : ContDiffWithinAt 𝕜 ω f s x) (hs : UniqueDiffOn 𝕜 s) (hx : x ∈ s) {n : ℕ}
+    (σ : Perm (Fin n)) :
+    (iteratedFDerivWithin 𝕜 n f s x).domDomCongr σ = iteratedFDerivWithin 𝕜 n f s x := by
+  ext
+  exact h.iteratedFDerivWithin_comp_perm hs hx _ _
+
 /-- The `n`-th iterated derivative of an analytic function is symmetric. -/
 theorem AnalyticOn.iteratedFDeriv_comp_perm
     (h : AnalyticOn 𝕜 f univ) {n : ℕ} (v : Fin n → E) (σ : Perm (Fin n)) :
@@ -266,9 +279,19 @@ theorem AnalyticOn.iteratedFDeriv_comp_perm
   rw [← iteratedFDerivWithin_univ]
   exact h.iteratedFDerivWithin_comp_perm uniqueDiffOn_univ (mem_univ x) _ _
 
+theorem AnalyticOn.iteratedFDeriv_domDomCongr (h : AnalyticOn 𝕜 f univ) {n : ℕ} (σ : Perm (Fin n)) :
+    (iteratedFDeriv 𝕜 n f x).domDomCongr σ = iteratedFDeriv 𝕜 n f x := by
+  rw [← iteratedFDerivWithin_univ]
+  exact h.iteratedFDerivWithin_domDomCongr uniqueDiffOn_univ (mem_univ x) _
+
 /-- The `n`-th iterated derivative of an analytic function is symmetric. -/
 theorem ContDiffAt.iteratedFDeriv_comp_perm
     (h : ContDiffAt 𝕜 ω f x) {n : ℕ} (v : Fin n → E) (σ : Perm (Fin n)) :
     iteratedFDeriv 𝕜 n f x (v ∘ σ) = iteratedFDeriv 𝕜 n f x v := by
   rw [← iteratedFDerivWithin_univ]
   exact h.iteratedFDerivWithin_comp_perm uniqueDiffOn_univ (mem_univ x) _ _
+
+theorem ContDiffAt.iteratedFDeriv_domDomCongr (h : ContDiffAt 𝕜 ω f x) {n : ℕ} (σ : Perm (Fin n)) :
+    (iteratedFDeriv 𝕜 n f x).domDomCongr σ = iteratedFDeriv 𝕜 n f x := by
+  rw [← iteratedFDerivWithin_univ]
+  exact h.iteratedFDerivWithin_domDomCongr uniqueDiffOn_univ (mem_univ x) _


### PR DESCRIPTION
These are bundled versions of existing lemmas.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
