### PR TITLE
[Merged by Bors] - feat(Algebra/ModEq): a lemma about `[PMOD (n • p)]`

### DIFF
--- a/Mathlib/Algebra/ModEq.lean
+++ b/Mathlib/Algebra/ModEq.lean
@@ -242,6 +242,26 @@ theorem not_modEq_iff_ne_mod_zmultiples :
     ¬a ≡ b [PMOD p] ↔ (b : α ⧸ AddSubgroup.zmultiples p) ≠ a :=
   modEq_iff_eq_mod_zmultiples.not
 
+/-- If `a ≡ b [PMOD p]`, then mod `n • p` there are `n` cases. -/
+theorem modEq_nsmul_cases (n : ℕ) (hn : n ≠ 0) :
+    a ≡ b [PMOD p] ↔ ∃ i < n, a ≡ b + i • p [PMOD (n • p)] := by
+  simp_rw [← sub_modEq_iff_modEq_add, modEq_comm (b := b)]
+  simp_rw [AddCommGroup.ModEq, sub_right_comm, sub_eq_iff_eq_add (b := _ • _), ← natCast_zsmul,
+    smul_smul, ← add_smul]
+  constructor
+  · rintro ⟨k, hk⟩
+    refine ⟨(k % n).toNat, ?_⟩
+    rw [← Int.ofNat_lt, Int.toNat_of_nonneg (Int.emod_nonneg _ (mod_cast hn))]
+    refine ⟨?_, k / n, ?_⟩
+    · refine Int.emod_lt_of_pos _ ?_
+      omega
+    · rw [hk, Int.ediv_add_emod']
+  · rintro ⟨k, _, j, hj⟩
+    rw [hj]
+    exact ⟨_, rfl⟩
+
+alias ⟨ModEq.nsmul_cases, _⟩ := AddCommGroup.modEq_nsmul_cases
+
 end AddCommGroup
 
 @[simp]


### PR DESCRIPTION
This ultimately didn't end up very useful to me, but I think it's still a nice result.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
