### PR TITLE
[Merged by Bors] - feat: `Finset.sort` commutes with `Finset.map`

### DIFF
--- a/Mathlib/Data/Finset/Sort.lean
+++ b/Mathlib/Data/Finset/Sort.lean
@@ -70,7 +70,7 @@ theorem sort_empty : sort r ∅ = [] :=
 theorem sort_singleton (a : α) : sort r {a} = [a] :=
   Multiset.sort_singleton r a
 
-theorem sort_map (f : α ↪ β) (s : Finset α)
+theorem map_sort (f : α ↪ β) (s : Finset α)
     (hs : ∀ a ∈ s, ∀ b ∈ s, r a b ↔ r' (f a) (f b)) :
     (s.sort r).map f = (s.map f).sort r' :=
   Multiset.map_sort _ _ _ _ hs
@@ -78,7 +78,7 @@ theorem sort_map (f : α ↪ β) (s : Finset α)
 theorem _root_.StrictMonoOn.map_finsetSort [LinearOrder α] [LinearOrder β]
     (f : α ↪ β) (s : Finset α) (hf : StrictMonoOn f s) :
     (s.sort (· ≤ ·)).map f = (s.map f).sort (· ≤ ·) :=
-  Finset.sort_map _ _ _ _ fun _a ha _b hb => (hf.le_iff_le ha hb).symm
+  Finset.map_sort _ _ _ _ fun _a ha _b hb => (hf.le_iff_le ha hb).symm
 
 theorem sort_cons {a : α} {s : Finset α} (h₁ : ∀ b ∈ s, r a b) (h₂ : a ∉ s) :
     sort r (cons a s h₂) = a :: sort r s := by

--- a/Mathlib/Data/Finset/Sort.lean
+++ b/Mathlib/Data/Finset/Sort.lean
@@ -24,6 +24,7 @@ variable {α β : Type*}
 section sort
 
 variable (r : α → α → Prop) [DecidableRel r] [IsTrans α r] [IsAntisymm α r] [IsTotal α r]
+variable (r' : β → β → Prop) [DecidableRel r'] [IsTrans β r'] [IsAntisymm β r'] [IsTotal β r']
 
 /-- `sort s` constructs a sorted list from the unordered set `s`.
   (Uses merge sort algorithm.) -/
@@ -68,6 +69,16 @@ theorem sort_empty : sort r ∅ = [] :=
 @[simp]
 theorem sort_singleton (a : α) : sort r {a} = [a] :=
   Multiset.sort_singleton r a
+
+theorem sort_map (f : α ↪ β) (s : Finset α)
+    (hs : ∀ a ∈ s, ∀ b ∈ s, r a b ↔ r' (f a) (f b)) :
+    (s.sort r).map f = (s.map f).sort r' :=
+  Multiset.map_sort _ _ _ _ hs
+
+theorem _root_.StrictMonoOn.map_finsetSort [LinearOrder α] [LinearOrder β]
+    (f : α ↪ β) (s : Finset α) (hf : StrictMonoOn f s) :
+    (s.sort (· ≤ ·)).map f = (s.map f).sort (· ≤ ·) :=
+  Finset.sort_map _ _ _ _ fun _a ha _b hb => (hf.le_iff_le ha hb).symm
 
 theorem sort_cons {a : α} {s : Finset α} (h₁ : ∀ b ∈ s, r a b) (h₂ : a ∉ s) :
     sort r (cons a s h₂) = a :: sort r s := by


### PR DESCRIPTION
We already had this lemma for `Multiset`.
For `Finset`, we can specialize to `StrictMonoOn`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
