### PR TITLE
feat(Data/Real): add embedding of archimedean groups into Real

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3357,6 +3357,7 @@ import Mathlib.Data.Real.CompleteField
 import Mathlib.Data.Real.ConjExponents
 import Mathlib.Data.Real.ENatENNReal
 import Mathlib.Data.Real.EReal
+import Mathlib.Data.Real.Embedding
 import Mathlib.Data.Real.GoldenRatio
 import Mathlib.Data.Real.Hyperreal
 import Mathlib.Data.Real.Irrational

--- a/Mathlib/Data/Rat/Lemmas.lean
+++ b/Mathlib/Data/Rat/Lemmas.lean
@@ -129,6 +129,10 @@ theorem isSquare_ofNat_iff {n : ℕ} :
     IsSquare (ofNat(n) : ℚ) ↔ IsSquare (OfNat.ofNat n : ℕ) :=
   isSquare_natCast_iff
 
+theorem mkRat_add_mkRat_of_den (n₁ n₂ : Int) {d : Nat} (h : d ≠ 0)  :
+    mkRat n₁ d + mkRat n₂ d = mkRat (n₁ + n₂) d := by
+  rw [mkRat_add_mkRat _ _ h h, ← add_mul, mkRat_mul_right h]
+
 section Casts
 
 theorem exists_eq_mul_div_num_and_eq_mul_div_den (n : ℤ) {d : ℤ} (d_ne_zero : d ≠ 0) :

--- a/Mathlib/Data/Real/Embedding.lean
+++ b/Mathlib/Data/Real/Embedding.lean
@@ -4,8 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Weiyi Wang
 -/
 
+import Mathlib.Data.Real.Archimedean
 import Mathlib.Data.Real.Basic
 import Mathlib.Algebra.Order.Archimedean.Basic
+import Mathlib.Algebra.Order.Group.Pointwise.CompleteLattice
 import Mathlib.Algebra.Order.Hom.Monoid
 import Mathlib.Algebra.Order.Module.OrderedSMul
 import Mathlib.Tactic.Qify
@@ -26,253 +28,173 @@ This file provides embedding of any archimedean groups into reals.
 namespace Archimedean
 
 variable {M : Type*}
-variable [AddCommGroup M] [LinearOrder M] [IsOrderedAddMonoid M] [Archimedean M]
+variable [AddCommGroup M] [LinearOrder M] [IsOrderedAddMonoid M]
 
-/-- An auxiliary function that takes floor after multiplying by a power of two. -/
+abbrev ratLt (one x : M) : Set ℚ := {r | r.num • one < r.den • x}
+
+abbrev ratLt' (one x : M) : Set ℝ := (Rat.castHom ℝ) '' (ratLt one x)
+
 noncomputable
-def kfloor {one : M} (hpos: 0 < one) (k : ℕ) (a : M) :=
-  (existsUnique_zsmul_near_of_pos hpos ((2 ^ k) • a)).choose
+abbrev embed_real (one : M) (x : M) := sSup (ratLt' one x)
 
-theorem kfloor_smul_le {one : M} (hpos: 0 < one) (k : ℕ) (a : M):
-    (kfloor hpos k a) • one ≤ ((2 ^ k) • a) :=
-  (existsUnique_zsmul_near_of_pos hpos ((2 ^ k) • a)).choose_spec.1.1
+variable [Archimedean M]
 
-theorem lt_kfloor_smul {one : M} (hpos: 0 < one) (k : ℕ) (a : M):
-    ((2 ^ k) • a) < (kfloor hpos k a + 1) • one :=
-  (existsUnique_zsmul_near_of_pos hpos ((2 ^ k) • a)).choose_spec.1.2
+theorem ratLt_bddAbove {one : M} (hpos : 0 < one) (x : M) : BddAbove (ratLt one x) := by
+  obtain ⟨n, hn⟩ := Archimedean.arch x hpos
+  use Rat.ofInt n
+  rw [ratLt, mem_upperBounds]
+  intro ⟨num, den, _, _⟩
+  rw [Rat.le_iff]
+  suffices num • one < den • x → num ≤ n * den by simpa using this
+  intro h
+  refine le_of_smul_le_smul_right (h.le.trans ?_) hpos
+  rw [mul_comm, ← smul_smul]
+  simpa using nsmul_le_nsmul_right hn den
 
-theorem kfloor_add_one_mem_Ico {one : M} (hpos: 0 < one) (k : ℕ) (a : M):
-    kfloor hpos (k + 1) a ∈ Set.Ico (2 * (kfloor hpos k a)) (2 * (kfloor hpos k a + 1)) := by
+theorem ratLt_nonempty {one : M} (hpos : 0 < one) (x : M) : (ratLt one x).Nonempty := by
+  obtain hneg | rfl | hxpos := lt_trichotomy x 0
+  · obtain ⟨n, hn⟩ := Archimedean.arch (-x - x) hpos
+    use Rat.ofInt (-n)
+    suffices -(n • one) < x by simpa using this
+    refine neg_lt.mpr (lt_of_lt_of_le ?_ hn)
+    simpa using hneg
+  · exact ⟨Rat.ofInt (-1), by simpa using hpos⟩
+  · obtain ⟨n, hn⟩ := Archimedean.arch one hxpos
+    use Rat.mk' 1 (n + 1) (by simp) (by simp)
+    simpa using hn.trans_lt <| (nsmul_lt_nsmul_iff_left hxpos).mpr (by simp)
 
-  obtain hleft := (smul_le_smul_iff_of_pos_left (show (0 : ℤ) < 2 by simp)).mpr <|
-    kfloor_smul_le hpos k a
-  obtain hright := (smul_lt_smul_iff_of_pos_left (show (0 : ℤ) < 2 by simp)).mpr <|
-    lt_kfloor_smul hpos k a
-  rw [smul_smul, ← natCast_zsmul, smul_smul] at hleft hright
-  norm_cast at hleft hright
-  have : (2 * 2 ^ k : ℕ) = 2 ^ (k + 1) := by omega
-  rw [this] at hleft hright
-
-  obtain hleft' := kfloor_smul_le hpos (k + 1) a
-  obtain hright' := lt_kfloor_smul hpos (k + 1) a
-
+open Pointwise in
+theorem ratLt_add {one : M} (hpos : 0 < one) (x y : M) :
+    ratLt one (x + y) = ratLt one x + ratLt one y := by
+  unfold ratLt
+  ext a
+  rw [Set.mem_add]
   constructor
-  · obtain h := hleft.trans_lt hright'
-    rw [smul_lt_smul_iff_of_pos_right hpos] at h
-    exact Int.lt_add_one_iff.mp h
-  · obtain h := hleft'.trans_lt hright
-    rw [smul_lt_smul_iff_of_pos_right hpos] at h
-    exact h
+  · sorry
+  · intro ⟨u, hu, v, hv, huv⟩
+    rw [← huv]
+    rw [Set.mem_setOf_eq] at hu hv ⊢
+    have hu' : (u.num * v.den) • one < (u.den * v.den: ℤ) • x := by
+      rw [mul_comm u.num, mul_comm (u.den : ℤ)]
+      rw [← smul_smul, ← smul_smul]
+      exact zsmul_lt_zsmul_right (by simpa using v.den_pos) (by simpa using hu)
+    have hv' : (v.num * u.den) • one < (u.den * v.den: ℤ) • y := by
+      rw [mul_comm]
+      rw [← smul_smul, ← smul_smul]
+      apply zsmul_lt_zsmul_right (by simpa using u.den_pos) (by simpa using hv)
+    suffices ((u + v).num * u.den * v.den) • one <
+        ((u + v).den : ℤ) • (u.den * v.den : ℤ) • (x + y) by
+      rw [mul_assoc, mul_comm, zsmul_comm, ← smul_smul] at this
+      rw [smul_lt_smul_iff_of_pos_left
+        (mul_pos (by simpa using u.den_pos) (by simpa using v.den_pos))] at this
+      simpa using this
+    rw [Rat.add_num_den']
+    rw [mul_comm, ←smul_smul]
+    rw [smul_lt_smul_iff_of_pos_left (by simpa using (u + v).den_pos)]
+    rw [add_smul, smul_add]
+    apply add_lt_add hu' hv'
 
-private theorem kfloor_add_mem_Ico {one : M} (hpos: 0 < one) (k : ℕ) (n : ℕ) (a : M):
-    kfloor hpos (k + n) a ∈ Set.Ico (2 ^ n * (kfloor hpos k a)) (2 ^ n * (kfloor hpos k a + 1)) :=
-    by
-  induction n with
-  | zero => simp
-  | succ n ih =>
-    obtain ⟨ihleft, ihright⟩ := ih
-    obtain ihleft := (mul_le_mul_iff_of_pos_left (show (0 : ℤ) < 2 by simp)).mpr ihleft
-    obtain ihright := (mul_le_mul_iff_of_pos_left (show (0 : ℤ) < 2 by simp)).mpr
-      (Int.add_one_le_iff.mpr ihright)
-    rw [← mul_assoc] at ihleft ihright
-    have : (2 * 2 ^ n : ℤ) = 2 ^ (n + 1) := by omega
-    rw [this] at ihleft ihright
-    rw [mul_add] at ihright
-    rw [show (2 * 1 : ℤ) = 1 + 1 by simp] at ihright
-    rw [← add_assoc] at ihright
-    obtain ihright' := Int.add_one_le_iff.mp ihright
+theorem ratLt'_bddAbove {one : M} (hpos : 0 < one) (x : M) : BddAbove (ratLt' one x) := by
+  refine Monotone.map_bddAbove ?_ ?_
+  · exact Rat.cast_mono
+  · exact ratLt_bddAbove hpos x
 
-    rw [← add_assoc]
-    obtain ⟨hleft, hright⟩ := kfloor_add_one_mem_Ico hpos (k + n) a
-    refine ⟨ihleft.trans hleft, ?_⟩
-    have hright' : kfloor hpos (k + n + 1) a ≤ 2 * (kfloor hpos (k + n) a) + 1 := by
-      rw [mul_add, mul_one] at hright
-      apply Int.lt_add_one_iff.mp
-      rw [add_assoc _ 1 1]
-      simpa using hright
-    apply hright'.trans_lt ihright
+theorem ratLt'_nonempty {one : M} (hpos : 0 < one) (x : M): (ratLt' one x).Nonempty := by
+  apply Set.image_nonempty.mpr (ratLt_nonempty hpos x)
 
-private theorem aux_εbound {ε : ℚ} (h : 0 < ε) : 1 < ε * 2 ^ ⌊ε⁻¹⌋₊ := by
-  suffices ε⁻¹ < 2 ^ (⌊ε⁻¹⌋₊) by
-    apply (inv_mul_lt_iff₀ h).mp
-    simpa using this
-  apply lt_of_lt_of_le (Nat.lt_floor_add_one ε⁻¹)
-  generalize ⌊ε⁻¹⌋₊ = n
-  norm_cast
-  induction n with
-  | zero => simp
-  | succ n ih =>
-    rw [Nat.pow_add_one, mul_two]
-    apply add_le_add ih
-    exact Nat.one_le_two_pow
+open Pointwise in
+theorem ratLt'_add {one : M} (hpos : 0 < one) (x y : M) :
+    ratLt' one (x + y) = ratLt' one x + ratLt' one y := by
+  unfold ratLt'
+  rw [ratLt_add hpos, Set.image_add]
 
-/-- An unbundled function that embeds archimedean`M` into `ℝ`.
-The given element `one` is mapped to the real number 1. -/
-noncomputable
-abbrev embed_real {one : M} (hpos: 0 < one) (a : M) : ℝ :=
-  Real.mk ⟨fun k ↦ (kfloor hpos k a / (2 ^ k) : ℚ), by
-    intro ε hε
-    use ⌊ε⁻¹⌋₊
-    intro k hk
-    simp only
-    have : ((kfloor hpos ⌊ε⁻¹⌋₊ a) / 2 ^ ⌊ε⁻¹⌋₊ : ℚ) =
-      2 ^ (k - ⌊ε⁻¹⌋₊) * (kfloor hpos ⌊ε⁻¹⌋₊ a) / 2 ^ k := by
-      rw [div_eq_div_iff (by simp) (by simp)]
-      rw [mul_comm (2 ^ (k - ⌊ε⁻¹⌋₊)), mul_assoc, ← pow_add, Nat.sub_add_cancel hk]
-    rw [this, ← sub_div, abs_div, div_lt_iff₀ (by simp)]
-    apply lt_of_le_of_lt (b := 2 ^ (k - ⌊ε⁻¹⌋₊))
-    · have : k = k - ⌊ε⁻¹⌋₊ + ⌊ε⁻¹⌋₊ := (Nat.sub_eq_iff_eq_add hk).mp rfl
-      nth_rw 1 [this]
-      obtain ⟨hleft, hright⟩ := kfloor_add_mem_Ico hpos ⌊ε⁻¹⌋₊ (k - ⌊ε⁻¹⌋₊) a
-      rw [abs_le]
-      constructor
-      · simp only [neg_le_sub_iff_le_add]
-        qify at hleft
-        apply le_trans hleft
-        rw [add_comm]
-        simp
-      · apply sub_left_le_of_le_add
-        rw [add_comm]
-        qify at hright
-        rw [← mul_add_one]
-        exact le_of_lt hright
-    · rw [abs_eq_self.mpr (by simp), ← one_lt_div (by simp), mul_div_assoc, div_eq_mul_inv]
-      rw [← pow_sub₀ _ (by simp) (by simp), Nat.sub_sub_self (hk)]
-      exact aux_εbound hε
-  ⟩
+theorem embed_real_zero {one : M} (hpos: 0 < one) : embed_real one 0 = 0 := by
+  apply le_antisymm
+  · apply csSup_le (ratLt'_nonempty hpos 0)
+    intro x
+    unfold ratLt' ratLt
+    suffices ∀ (y : ℚ), y.num • one < 0 → y = x → x ≤ 0 by simpa using this
+    intro y hy hyx
+    have hynum : y.num < 0 := by
+      contrapose! hy
+      exact smul_nonneg hy hpos.le
+    rw [← hyx]
+    simpa using (Rat.num_neg.mp hynum).le
+  · rw [le_csSup_iff (ratLt'_bddAbove hpos 0) (ratLt'_nonempty hpos 0)]
+    intro x
+    rw [mem_upperBounds]
+    suffices (∀ (y : ℚ), y.num • one < 0 → y ≤ x) → 0 ≤ x by simpa using this
+    intro h
+    have h' (y : ℚ) (hy: y < 0) : y ≤ x := by
+      exact h _ <| (smul_neg_iff_of_neg_left (by simpa using hy)).mpr hpos
+    contrapose! h'
+    obtain ⟨y, hxy, hy⟩ := exists_rat_btwn h'
+    exact ⟨y, by simpa using hy, hxy⟩
 
-theorem embed_real_map_zero {one : M} (hpos: 0 < one) : embed_real hpos 0 = 0 := by
-  convert Real.mk_zero
-  rw [Subtype.eq_iff, CauSeq.coe_zero]
-  ext k
-  obtain hleft := kfloor_smul_le hpos k 0
-  obtain hright := lt_kfloor_smul hpos k 0
-  rw [smul_zero] at hleft hright
-  rw [smul_nonpos_iff, or_iff_right (by simp [hpos])] at hleft
-  rw [smul_pos_iff_of_pos_right hpos] at hright
-  obtain hle := hleft.1
-  obtain hge := Int.add_one_le_iff.mpr (Int.sub_lt_iff.mpr hright)
-  simp only [zero_sub, Int.reduceNeg, neg_add_cancel] at hge
-  simpa using le_antisymm hle hge
 
-theorem embed_real_map_add {one : M} (hpos: 0 < one) (a b : M) :
-    embed_real hpos (a + b) = embed_real hpos a + embed_real hpos b := by
-  rw [← Real.mk_add, Real.mk_eq]
-  intro ε hε
-  use ⌊ε⁻¹⌋₊
-  intro k hk
-  simp only [CauSeq.sub_apply, CauSeq.add_apply]
-  rw [← add_div, ← sub_div, abs_div, div_lt_iff₀ (by simp)]
-  apply lt_of_le_of_lt (b := 1)
-  · obtain hal := kfloor_smul_le hpos k a
-    obtain har := lt_kfloor_smul hpos k a
-    obtain hbl := kfloor_smul_le hpos k b
-    obtain hbr := lt_kfloor_smul hpos k b
-    obtain habl := kfloor_smul_le hpos k (a + b)
-    obtain habr := lt_kfloor_smul hpos k (a + b)
-    obtain habl' := add_le_add hal hbl
-    obtain habr' := add_lt_add har hbr
-    rw [← smul_add, ← add_smul] at habl' habr'
+open Pointwise in
+theorem embed_real_add {one : M} (hpos: 0 < one) (x y : M) :
+    embed_real one (x + y) = embed_real one x + embed_real one y := by
+  unfold embed_real
+  rw [ratLt'_add hpos]
+  rw [csSup_add (ratLt'_nonempty hpos x) (ratLt'_bddAbove hpos x)
+    (ratLt'_nonempty hpos y) (ratLt'_bddAbove hpos y)]
 
-    obtain hab1 := (smul_lt_smul_iff_of_pos_right hpos).mp <| lt_of_le_of_lt habl' habr
-    obtain hab2 := (smul_lt_smul_iff_of_pos_right hpos).mp <| lt_of_le_of_lt habl habr'
-    rw [add_right_comm, Int.lt_add_one_iff, ← add_assoc] at hab2
-    qify at hab1 hab2
+theorem embed_real_strictMono {one : M} (hpos: 0 < one) : StrictMono (embed_real one) := by
+  intro x y h
+  let z := y - x
+  have hz : 0 < z := sub_pos.mpr h
+  have hy : y = z + x := Eq.symm (sub_add_cancel y x)
+  apply lt_of_sub_pos
+  rw [hy, embed_real_add hpos, add_sub_cancel_right]
 
-    rw [abs_le]
-    exact ⟨by simpa using hab1.le, sub_left_le_of_le_add hab2⟩
-  · rw [abs_eq_self.mpr (by simp)]
-    apply lt_of_lt_of_le (aux_εbound hε)
-    rw [mul_le_mul_left hε]
-    exact pow_le_pow_right₀ (by simp) hk
+  obtain ⟨n, hn⟩ := Archimedean.arch one hz
 
-theorem embed_real_strictMono {one : M} (hpos: 0 < one) : StrictMono (embed_real hpos) := by
-  intro a b hab
-  have : b = a + (b - a) := by abel
-  rw [this, embed_real_map_add, lt_add_iff_pos_right]
-  set x := b - a
-  have hx : 0 < x := sub_pos.mpr hab
-  obtain ⟨s, hs⟩ := arch one hx
+  have : (Rat.mk' 1 (n + 1) (by simp) (by simp) : ℝ) ∈ ratLt' one z := by
+    simpa using hn.trans_lt <| nsmul_lt_nsmul_left hz (show n < n + 1 by simp)
 
-  rw [Real.mk_pos]
-
-  have hpos : ∃ k, 0 < kfloor hpos k x := by
-    by_contra! hkfloor
-    have (k) : (kfloor hpos k x + 1) • one ≤ one := by
-      nth_rw 3 [show one = (1: ℤ) • one by simp]
-      rw [smul_le_smul_iff_of_pos_right hpos]
-      simpa using hkfloor k
-    have (k) : ((2 ^ k) • x) < one := lt_of_lt_of_le (lt_kfloor_smul _ _ _ ) (this k)
-    obtain hxx : 2 ^ s < s := (nsmul_left_monotone hx.le).reflect_lt (lt_of_lt_of_le (this s) hs)
-    contrapose! hxx
-    generalize s = a
-    induction a with
-    | zero => simp
-    | succ a ih =>
-      rw [Nat.pow_add_one, mul_two]
-      exact add_le_add ih Nat.one_le_two_pow
-
-  obtain ⟨k, hk⟩ := hpos
-  refine ⟨1 / 2 ^ k, ⟨by simp, ⟨k, ?_⟩⟩⟩
-  intro j hj
-  obtain hleft := (kfloor_add_mem_Ico hpos k (j - k) x).1
-  have : k + (j - k) = j := Nat.add_sub_of_le hj
-  rw [this] at hleft
-  qify at hleft
-
-  simp only
-  rw [le_div_iff₀ (by simp), one_div_mul_eq_div, div_eq_mul_inv, ← pow_sub₀ _ (by simp) hj]
-  refine le_trans ?_ hleft
-  simpa using Int.cast_one_le_of_pos hk
+  apply lt_csSup_of_lt (ratLt'_bddAbove hpos z) this
+  rw [Rat.cast_pos, ← Rat.num_pos]
+  simp only [zero_lt_one]
 
 /-- The bundled `M →+o ℝ` for archimedean `M`.
 The given element `one` is mapped to the real number 1. -/
 noncomputable
 def orderAddMonoidHom_real_of_pos {one : M} (hpos: 0 < one) : M →+o ℝ where
-  toFun := embed_real hpos
-  map_zero' := embed_real_map_zero hpos
-  map_add' := embed_real_map_add hpos
+  toFun := embed_real one
+  map_zero' := embed_real_zero hpos
+  map_add' := embed_real_add hpos
   monotone' := (embed_real_strictMono hpos).monotone
 
 theorem orderAddMonoidHom_real_apply {one : M} (hpos: 0 < one) (a : M):
-    (orderAddMonoidHom_real_of_pos hpos) a = embed_real hpos a := by rfl
+    (orderAddMonoidHom_real_of_pos hpos) a = embed_real one a := by rfl
 
 theorem orderAddMonoidHom_real_injective_of_pos {one : M} (hpos: 0 < one) :
     Function.Injective (orderAddMonoidHom_real_of_pos hpos) :=
   (embed_real_strictMono hpos).injective
 
-theorem orderAddMonoidHom_real_map_one {one : M} (hpos: 0 < one) :
+theorem orderAddMonoidHom_real_one {one : M} (hpos: 0 < one) :
     (orderAddMonoidHom_real_of_pos hpos) one = 1 := by
-  rw [← Real.mk_one, orderAddMonoidHom_real_apply, Real.mk_eq]
-  intro ε hε
-  use ⌊ε⁻¹⌋₊
-  intro k hk
-  simp only [CauSeq.sub_apply, CauSeq.one_apply]
-  rw [div_sub_one (by simp), abs_div, div_lt_iff₀ (by simp)]
-
-  have hnonpos : kfloor hpos k one - (2 : ℚ) ^ k ≤ 0 := by
-    apply sub_nonpos_of_le
-    norm_cast
-    apply (zsmul_left_strictMono hpos).le_iff_le.mp
-    rw [natCast_zsmul]
-    apply kfloor_smul_le
-
-  rw [abs_eq_neg_self.mpr hnonpos, neg_sub]
-  rw [abs_eq_self.mpr (by simp)]
-  rw [sub_lt_comm]
-  rw [← add_lt_add_iff_right 1]
-  have : (2 : ℚ) ^ k < kfloor hpos k one + 1 := by
-    norm_cast
-    apply (zsmul_left_strictMono hpos).lt_iff_lt.mp
-    rw [natCast_zsmul]
-    apply lt_kfloor_smul
-
-  refine lt_trans ?_ this
-  rw [sub_add]
-  suffices 1 < ε * 2 ^ k by simpa using this
-  apply lt_of_lt_of_le (aux_εbound hε)
-  rw [mul_le_mul_left hε]
-  exact pow_le_pow_right₀ (by simp) hk
+  rw [orderAddMonoidHom_real_apply]
+  apply le_antisymm
+  · apply csSup_le (ratLt'_nonempty hpos one)
+    suffices ∀ (x : ℚ), x.num • one < (x.den : ℤ) • one → (x : ℝ) ≤ 1 by simpa using this
+    intro x hx
+    suffices x ≤ 1 by norm_cast
+    rw [Rat.le_iff]
+    simpa using ((smul_lt_smul_iff_of_pos_right hpos).mp hx).le
+  · rw [le_csSup_iff (ratLt'_bddAbove hpos one) (ratLt'_nonempty hpos one)]
+    simp_rw [mem_upperBounds]
+    suffices ∀ (x : ℝ), (∀ (y : ℚ), y.num • one < (y.den : ℤ) • one → y ≤ x) → 1 ≤ x by
+      simpa using this
+    intro x h
+    have h' (y : ℚ) (hy : y < 1) : y ≤ x := by
+      refine h _ ((smul_lt_smul_iff_of_pos_right hpos).mpr ?_)
+      simpa using (Rat.lt_iff _ _).mp hy
+    contrapose! h'
+    obtain ⟨y, hxy, hy⟩ := exists_rat_btwn h'
+    norm_cast at hy
+    refine ⟨y, hy, hxy⟩
 
 variable (M) in
 theorem exists_orderAddMonoidHom_real_injective :

--- a/Mathlib/Data/Real/Embedding.lean
+++ b/Mathlib/Data/Real/Embedding.lean
@@ -278,15 +278,7 @@ variable (M) in
 theorem exists_orderAddMonoidHom_real_injective :
     ∃ f : M →+o ℝ, Function.Injective f := by
   by_cases h : Subsingleton M
-  · let f : M →+o ℝ := {
-      toFun := fun _ ↦ 0
-      map_zero' := by simp
-      map_add' := by simp
-      monotone' := by
-        intro a b h
-        simp
-    }
-    exact ⟨f, Function.injective_of_subsingleton _⟩
+  · exact ⟨0, Function.injective_of_subsingleton _⟩
   · have : Nontrivial M := not_subsingleton_iff_nontrivial.mp h
     obtain ⟨a, ha⟩ := exists_ne (0 : M)
     have ha : 0 < |a| := by simpa using ha

--- a/Mathlib/Data/Real/Embedding.lean
+++ b/Mathlib/Data/Real/Embedding.lean
@@ -1,0 +1,295 @@
+/-
+Copyright (c) 2025 Weiyi Wang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Weiyi Wang
+-/
+
+import Mathlib.Data.Real.Basic
+import Mathlib.Algebra.Order.Archimedean.Basic
+import Mathlib.Algebra.Order.Hom.Monoid
+import Mathlib.Algebra.Order.Module.OrderedSMul
+import Mathlib.Tactic.Qify
+
+/-!
+# Embedding of archimedean groups into reals
+
+This file provides embedding of any archimedean groups into reals.
+
+## Main declarations
+* `orderAddMonoidHom_real_of_pos` defines a `M →+o ℝ` for archimedean group `M`
+  that maps a given positive element to the real number 1.
+* `exists_orderAddMonoidHom_real_injective` states there exists an injective `M →+o ℝ`
+  for any archimedean group `M`.
+-/
+
+
+namespace Archimedean
+
+variable {M : Type*}
+variable [AddCommGroup M] [LinearOrder M] [IsOrderedAddMonoid M] [Archimedean M]
+
+/-- An auxiliary function that takes floor after multiplying by a power of two. -/
+noncomputable
+def kfloor {one : M} (hpos: 0 < one) (k : ℕ) (a : M) :=
+  (existsUnique_zsmul_near_of_pos hpos ((2 ^ k) • a)).choose
+
+theorem kfloor_smul_le {one : M} (hpos: 0 < one) (k : ℕ) (a : M):
+    (kfloor hpos k a) • one ≤ ((2 ^ k) • a) :=
+  (existsUnique_zsmul_near_of_pos hpos ((2 ^ k) • a)).choose_spec.1.1
+
+theorem lt_kfloor_smul {one : M} (hpos: 0 < one) (k : ℕ) (a : M):
+    ((2 ^ k) • a) < (kfloor hpos k a + 1) • one :=
+  (existsUnique_zsmul_near_of_pos hpos ((2 ^ k) • a)).choose_spec.1.2
+
+theorem kfloor_add_one_mem_Ico {one : M} (hpos: 0 < one) (k : ℕ) (a : M):
+    kfloor hpos (k + 1) a ∈ Set.Ico (2 * (kfloor hpos k a)) (2 * (kfloor hpos k a + 1)) := by
+
+  obtain hleft := (smul_le_smul_iff_of_pos_left (show (0 : ℤ) < 2 by simp)).mpr <|
+    kfloor_smul_le hpos k a
+  obtain hright := (smul_lt_smul_iff_of_pos_left (show (0 : ℤ) < 2 by simp)).mpr <|
+    lt_kfloor_smul hpos k a
+  rw [smul_smul, ← natCast_zsmul, smul_smul] at hleft hright
+  norm_cast at hleft hright
+  have : (2 * 2 ^ k : ℕ) = 2 ^ (k + 1) := by omega
+  rw [this] at hleft hright
+
+  obtain hleft' := kfloor_smul_le hpos (k + 1) a
+  obtain hright' := lt_kfloor_smul hpos (k + 1) a
+
+  constructor
+  · obtain h := hleft.trans_lt hright'
+    rw [smul_lt_smul_iff_of_pos_right hpos] at h
+    exact Int.lt_add_one_iff.mp h
+  · obtain h := hleft'.trans_lt hright
+    rw [smul_lt_smul_iff_of_pos_right hpos] at h
+    exact h
+
+private theorem kfloor_add_mem_Ico {one : M} (hpos: 0 < one) (k : ℕ) (n : ℕ) (a : M):
+    kfloor hpos (k + n) a ∈ Set.Ico (2 ^ n * (kfloor hpos k a)) (2 ^ n * (kfloor hpos k a + 1)) :=
+    by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    obtain ⟨ihleft, ihright⟩ := ih
+    obtain ihleft := (mul_le_mul_iff_of_pos_left (show (0 : ℤ) < 2 by simp)).mpr ihleft
+    obtain ihright := (mul_le_mul_iff_of_pos_left (show (0 : ℤ) < 2 by simp)).mpr
+      (Int.add_one_le_iff.mpr ihright)
+    rw [← mul_assoc] at ihleft ihright
+    have : (2 * 2 ^ n : ℤ) = 2 ^ (n + 1) := by omega
+    rw [this] at ihleft ihright
+    rw [mul_add] at ihright
+    rw [show (2 * 1 : ℤ) = 1 + 1 by simp] at ihright
+    rw [← add_assoc] at ihright
+    obtain ihright' := Int.add_one_le_iff.mp ihright
+
+    rw [← add_assoc]
+    obtain ⟨hleft, hright⟩ := kfloor_add_one_mem_Ico hpos (k + n) a
+    refine ⟨ihleft.trans hleft, ?_⟩
+    have hright' : kfloor hpos (k + n + 1) a ≤ 2 * (kfloor hpos (k + n) a) + 1 := by
+      rw [mul_add, mul_one] at hright
+      apply Int.lt_add_one_iff.mp
+      rw [add_assoc _ 1 1]
+      simpa using hright
+    apply hright'.trans_lt ihright
+
+private theorem aux_εbound {ε : ℚ} (h : 0 < ε) : 1 < ε * 2 ^ ⌊ε⁻¹⌋₊ := by
+  suffices ε⁻¹ < 2 ^ (⌊ε⁻¹⌋₊) by
+    apply (inv_mul_lt_iff₀ h).mp
+    simpa using this
+  apply lt_of_lt_of_le (Nat.lt_floor_add_one ε⁻¹)
+  generalize ⌊ε⁻¹⌋₊ = n
+  norm_cast
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [Nat.pow_add_one, mul_two]
+    apply add_le_add ih
+    exact Nat.one_le_two_pow
+
+/-- An unbundled function that embeds archimedean`M` into `ℝ`.
+The given element `one` is mapped to the real number 1. -/
+noncomputable
+abbrev embed_real {one : M} (hpos: 0 < one) (a : M) : ℝ :=
+  Real.mk ⟨fun k ↦ (kfloor hpos k a / (2 ^ k) : ℚ), by
+    intro ε hε
+    use ⌊ε⁻¹⌋₊
+    intro k hk
+    simp only
+    have : ((kfloor hpos ⌊ε⁻¹⌋₊ a) / 2 ^ ⌊ε⁻¹⌋₊ : ℚ) =
+      2 ^ (k - ⌊ε⁻¹⌋₊) * (kfloor hpos ⌊ε⁻¹⌋₊ a) / 2 ^ k := by
+      rw [div_eq_div_iff (by simp) (by simp)]
+      rw [mul_comm (2 ^ (k - ⌊ε⁻¹⌋₊)), mul_assoc, ← pow_add, Nat.sub_add_cancel hk]
+    rw [this, ← sub_div, abs_div, div_lt_iff₀ (by simp)]
+    apply lt_of_le_of_lt (b := 2 ^ (k - ⌊ε⁻¹⌋₊))
+    · have : k = k - ⌊ε⁻¹⌋₊ + ⌊ε⁻¹⌋₊ := (Nat.sub_eq_iff_eq_add hk).mp rfl
+      nth_rw 1 [this]
+      obtain ⟨hleft, hright⟩ := kfloor_add_mem_Ico hpos ⌊ε⁻¹⌋₊ (k - ⌊ε⁻¹⌋₊) a
+      rw [abs_le]
+      constructor
+      · simp only [neg_le_sub_iff_le_add]
+        qify at hleft
+        apply le_trans hleft
+        rw [add_comm]
+        simp
+      · apply sub_left_le_of_le_add
+        rw [add_comm]
+        qify at hright
+        rw [← mul_add_one]
+        exact le_of_lt hright
+    · rw [abs_eq_self.mpr (by simp), ← one_lt_div (by simp), mul_div_assoc, div_eq_mul_inv]
+      rw [← pow_sub₀ _ (by simp) (by simp), Nat.sub_sub_self (hk)]
+      exact aux_εbound hε
+  ⟩
+
+theorem embed_real_map_zero {one : M} (hpos: 0 < one) : embed_real hpos 0 = 0 := by
+  convert Real.mk_zero
+  rw [Subtype.eq_iff, CauSeq.coe_zero]
+  ext k
+  obtain hleft := kfloor_smul_le hpos k 0
+  obtain hright := lt_kfloor_smul hpos k 0
+  rw [smul_zero] at hleft hright
+  rw [smul_nonpos_iff, or_iff_right (by simp [hpos])] at hleft
+  rw [smul_pos_iff_of_pos_right hpos] at hright
+  obtain hle := hleft.1
+  obtain hge := Int.add_one_le_iff.mpr (Int.sub_lt_iff.mpr hright)
+  simp only [zero_sub, Int.reduceNeg, neg_add_cancel] at hge
+  simpa using le_antisymm hle hge
+
+theorem embed_real_map_add {one : M} (hpos: 0 < one) (a b : M) :
+    embed_real hpos (a + b) = embed_real hpos a + embed_real hpos b := by
+  rw [← Real.mk_add, Real.mk_eq]
+  intro ε hε
+  use ⌊ε⁻¹⌋₊
+  intro k hk
+  simp only [CauSeq.sub_apply, CauSeq.add_apply]
+  rw [← add_div, ← sub_div, abs_div, div_lt_iff₀ (by simp)]
+  apply lt_of_le_of_lt (b := 1)
+  · obtain hal := kfloor_smul_le hpos k a
+    obtain har := lt_kfloor_smul hpos k a
+    obtain hbl := kfloor_smul_le hpos k b
+    obtain hbr := lt_kfloor_smul hpos k b
+    obtain habl := kfloor_smul_le hpos k (a + b)
+    obtain habr := lt_kfloor_smul hpos k (a + b)
+    obtain habl' := add_le_add hal hbl
+    obtain habr' := add_lt_add har hbr
+    rw [← smul_add, ← add_smul] at habl' habr'
+
+    obtain hab1 := (smul_lt_smul_iff_of_pos_right hpos).mp <| lt_of_le_of_lt habl' habr
+    obtain hab2 := (smul_lt_smul_iff_of_pos_right hpos).mp <| lt_of_le_of_lt habl habr'
+    rw [add_right_comm, Int.lt_add_one_iff, ← add_assoc] at hab2
+    qify at hab1 hab2
+
+    rw [abs_le]
+    exact ⟨by simpa using hab1.le, sub_left_le_of_le_add hab2⟩
+  · rw [abs_eq_self.mpr (by simp)]
+    apply lt_of_lt_of_le (aux_εbound hε)
+    rw [mul_le_mul_left hε]
+    exact pow_le_pow_right₀ (by simp) hk
+
+theorem embed_real_strictMono {one : M} (hpos: 0 < one) : StrictMono (embed_real hpos) := by
+  intro a b hab
+  have : b = a + (b - a) := by abel
+  rw [this, embed_real_map_add, lt_add_iff_pos_right]
+  set x := b - a
+  have hx : 0 < x := sub_pos.mpr hab
+  obtain ⟨s, hs⟩ := arch one hx
+
+  rw [Real.mk_pos]
+
+  have hpos : ∃ k, 0 < kfloor hpos k x := by
+    by_contra! hkfloor
+    have (k) : (kfloor hpos k x + 1) • one ≤ one := by
+      nth_rw 3 [show one = (1: ℤ) • one by simp]
+      rw [smul_le_smul_iff_of_pos_right hpos]
+      simpa using hkfloor k
+    have (k) : ((2 ^ k) • x) < one := lt_of_lt_of_le (lt_kfloor_smul _ _ _ ) (this k)
+    obtain hxx : 2 ^ s < s := (nsmul_left_monotone hx.le).reflect_lt (lt_of_lt_of_le (this s) hs)
+    contrapose! hxx
+    generalize s = a
+    induction a with
+    | zero => simp
+    | succ a ih =>
+      rw [Nat.pow_add_one, mul_two]
+      exact add_le_add ih Nat.one_le_two_pow
+
+  obtain ⟨k, hk⟩ := hpos
+  refine ⟨1 / 2 ^ k, ⟨by simp, ⟨k, ?_⟩⟩⟩
+  intro j hj
+  obtain hleft := (kfloor_add_mem_Ico hpos k (j - k) x).1
+  have : k + (j - k) = j := Nat.add_sub_of_le hj
+  rw [this] at hleft
+  qify at hleft
+
+  simp only
+  rw [le_div_iff₀ (by simp), one_div_mul_eq_div, div_eq_mul_inv, ← pow_sub₀ _ (by simp) hj]
+  refine le_trans ?_ hleft
+  simpa using Int.cast_one_le_of_pos hk
+
+/-- The bundled `M →+o ℝ` for archimedean `M`.
+The given element `one` is mapped to the real number 1. -/
+noncomputable
+def orderAddMonoidHom_real_of_pos {one : M} (hpos: 0 < one) : M →+o ℝ where
+  toFun := embed_real hpos
+  map_zero' := embed_real_map_zero hpos
+  map_add' := embed_real_map_add hpos
+  monotone' := (embed_real_strictMono hpos).monotone
+
+theorem orderAddMonoidHom_real_apply {one : M} (hpos: 0 < one) (a : M):
+    (orderAddMonoidHom_real_of_pos hpos) a = embed_real hpos a := by rfl
+
+theorem orderAddMonoidHom_real_of_pos_injective {one : M} (hpos: 0 < one) :
+    Function.Injective (orderAddMonoidHom_real_of_pos hpos) :=
+  (embed_real_strictMono hpos).injective
+
+theorem orderAddMonoidHom_real_map_one {one : M} (hpos: 0 < one) :
+    (orderAddMonoidHom_real_of_pos hpos) one = 1 := by
+  rw [← Real.mk_one, orderAddMonoidHom_real_apply, Real.mk_eq]
+  intro ε hε
+  use ⌊ε⁻¹⌋₊
+  intro k hk
+  simp only [CauSeq.sub_apply, CauSeq.one_apply]
+  rw [div_sub_one (by simp), abs_div, div_lt_iff₀ (by simp)]
+
+  have hnonpos : kfloor hpos k one - (2 : ℚ) ^ k ≤ 0 := by
+    apply sub_nonpos_of_le
+    norm_cast
+    apply (zsmul_left_strictMono hpos).le_iff_le.mp
+    rw [natCast_zsmul]
+    apply kfloor_smul_le
+
+  rw [abs_eq_neg_self.mpr hnonpos, neg_sub]
+  rw [abs_eq_self.mpr (by simp)]
+  rw [sub_lt_comm]
+  rw [← add_lt_add_iff_right 1]
+  have : (2 : ℚ) ^ k < kfloor hpos k one + 1 := by
+    norm_cast
+    apply (zsmul_left_strictMono hpos).lt_iff_lt.mp
+    rw [natCast_zsmul]
+    apply lt_kfloor_smul
+
+  refine lt_trans ?_ this
+  rw [sub_add]
+  suffices 1 < ε * 2 ^ k by simpa using this
+  apply lt_of_lt_of_le (aux_εbound hε)
+  rw [mul_le_mul_left hε]
+  exact pow_le_pow_right₀ (by simp) hk
+
+variable (M) in
+theorem exists_orderAddMonoidHom_real_injective :
+    ∃ f : M →+o ℝ, Function.Injective f := by
+  by_cases h : Subsingleton M
+  · let f : M →+o ℝ := {
+      toFun := fun _ ↦ 0
+      map_zero' := by simp
+      map_add' := by simp
+      monotone' := by
+        intro a b h
+        simp
+    }
+    exact ⟨f, Function.injective_of_subsingleton _⟩
+  · have : Nontrivial M := not_subsingleton_iff_nontrivial.mp h
+    obtain ⟨a, ha⟩ := exists_ne (0 : M)
+    have ha : 0 < |a| := by simpa using ha
+    exact ⟨orderAddMonoidHom_real_of_pos ha, orderAddMonoidHom_real_of_pos_injective ha⟩
+
+end Archimedean

--- a/Mathlib/Data/Real/Embedding.lean
+++ b/Mathlib/Data/Real/Embedding.lean
@@ -237,7 +237,7 @@ def orderAddMonoidHom_real_of_pos {one : M} (hpos: 0 < one) : M →+o ℝ where
 theorem orderAddMonoidHom_real_apply {one : M} (hpos: 0 < one) (a : M):
     (orderAddMonoidHom_real_of_pos hpos) a = embed_real hpos a := by rfl
 
-theorem orderAddMonoidHom_real_of_pos_injective {one : M} (hpos: 0 < one) :
+theorem orderAddMonoidHom_real_injective_of_pos {one : M} (hpos: 0 < one) :
     Function.Injective (orderAddMonoidHom_real_of_pos hpos) :=
   (embed_real_strictMono hpos).injective
 
@@ -282,6 +282,6 @@ theorem exists_orderAddMonoidHom_real_injective :
   · have : Nontrivial M := not_subsingleton_iff_nontrivial.mp h
     obtain ⟨a, ha⟩ := exists_ne (0 : M)
     have ha : 0 < |a| := by simpa using ha
-    exact ⟨orderAddMonoidHom_real_of_pos ha, orderAddMonoidHom_real_of_pos_injective ha⟩
+    exact ⟨orderAddMonoidHom_real_of_pos ha, orderAddMonoidHom_real_injective_of_pos ha⟩
 
 end Archimedean

--- a/Mathlib/Data/Real/Embedding.lean
+++ b/Mathlib/Data/Real/Embedding.lean
@@ -18,24 +18,19 @@ import Mathlib.Tactic.Qify
 This file provides embedding of any archimedean groups into reals.
 
 ## Main declarations
-* `orderAddMonoidHom_real_of_pos` defines a `M →+o ℝ` for archimedean group `M`
+* `orderAddMonoidHom_real` defines a `M →+o ℝ` for archimedean group `M`
   that maps a given positive element to the real number 1.
 * `exists_orderAddMonoidHom_real_injective` states there exists an injective `M →+o ℝ`
   for any archimedean group `M`.
 -/
-
-
-theorem Rat.mkRat_add_mkRat_of_den (n₁ n₂ : Int) {d : Nat} (z : d ≠ 0)  :
-    mkRat n₁ d + mkRat n₂ d = mkRat (n₁ + n₂) d := by
-  rw [Rat.mkRat_add_mkRat _ _ z z, ← add_mul, Rat.mkRat_mul_right z]
 
 namespace Archimedean
 
 variable {M : Type*}
 variable [AddCommGroup M] [LinearOrder M] [IsOrderedAddMonoid M]
 
-/-- Set of rational numbers that are less than the "number" `x / one`. Formally,
- these are numbers `p / q` such that `p • one < q • x`. -/
+/-- Set of rational numbers that are less than the "number" `x / one`.
+ Formally, these are numbers `p / q` such that `p • one < q • x`. -/
 abbrev ratLt (one x : M) : Set ℚ := {r | r.num • one < r.den • x}
 
 theorem mkRat_mem_ratLt {num : ℤ} {den : ℕ} (hden: den ≠ 0) {one x : M} :
@@ -74,8 +69,7 @@ theorem ratLt_nonempty {one : M} (hpos : 0 < one) (x : M) : (ratLt one x).Nonemp
   · obtain ⟨n, hn⟩ := Archimedean.arch (-x - x) hpos
     use Rat.ofInt (-n)
     suffices -(n • one) < x by simpa using this
-    refine neg_lt.mpr (lt_of_lt_of_le ?_ hn)
-    simpa using hneg
+    exact neg_lt.mpr (lt_of_lt_of_le (by simpa using hneg) hn)
   · exact ⟨Rat.ofInt (-1), by simpa using hpos⟩
   · obtain ⟨n, hn⟩ := Archimedean.arch one hxpos
     use Rat.mk' 1 (n + 1) (by simp) (by simp)
@@ -88,12 +82,12 @@ theorem ratLt_add {one : M} (hpos : 0 < one) (x y : M) :
   rw [Set.mem_add]
   constructor
   · /- Given `a ∈ ratLt one (x + y)`, find `u ∈ ratLt one x`, `v ∈ ratLt one y`
-       such that `u + v = a`.
-       In a naive attempt, one can take the denominator `d` of `a`,
-       and find the largest `u = p / d < x / one`
-       However, `d` could be too "coarse", and `v = a - u` could be 1/d too large than `y / one`
-       To ensure a large enough denominator, we take `d * k`, where
-       `one + one ≤ k • (d • (x + y) - a.num • one)` -/
+      such that `u + v = a`.
+      In a naive attempt, one can take the denominator `d` of `a`,
+      and find the largest `u = p / d < x / one`
+      However, `d` could be too "coarse", and `v = a - u` could be 1/d too large than `y / one`
+      To ensure a large enough denominator, we take `d * k`, where
+      `one + one ≤ k • (d • (x + y) - a.num • one)` -/
     intro h
     rw [Set.mem_setOf_eq] at h
     have : 0 < a.den • (x + y) - a.num • one := sub_pos.mpr h
@@ -108,49 +102,44 @@ theorem ratLt_add {one : M} (hpos : 0 < one) (x y : M) :
     · rw [mkRat_mem_ratLt hka0, ← smul_smul]
       simpa using hm2
     · have hk' : one + (k • a.num • one - k • a.den • y) ≤ k • a.den • x - one := by
-        rw [smul_add, smul_sub, smul_add] at hk
-        rw [le_sub_iff_add_le, ← sub_le_iff_le_add] at hk
+        rw [smul_add, smul_sub, smul_add, le_sub_iff_add_le, ← sub_le_iff_le_add] at hk
         rw [le_sub_iff_add_le]
         convert hk using 1
         abel
       have h : one + (k • a.num • one - k • a.den • y) ≤ m • one := by
         simpa using hk'.trans hm1
-      have : k • a.num • one - k • a.den • y < m • one := by
-        exact lt_of_lt_of_le (lt_add_of_pos_left _ hpos) h
+      have : k • a.num • one - k • a.den • y < m • one :=
+        lt_of_lt_of_le (lt_add_of_pos_left _ hpos) h
       rw [mkRat_mem_ratLt hka0, sub_smul, sub_lt_comm, ← smul_smul, ← smul_smul, natCast_zsmul]
       exact this
     · rw [Rat.mkRat_add_mkRat_of_den _ _ hka0]
       rw [add_sub_cancel, Rat.mkRat_mul_left hk0, Rat.mkRat_num_den']
-  · intro ⟨u, hu, v, hv, huv⟩
+  · -- `u ∈ ratLt one x`, `v ∈ ratLt one y` → `u + v ∈ ratLt one (x + y)`
+    intro ⟨u, hu, v, hv, huv⟩
     rw [← huv]
     rw [Set.mem_setOf_eq] at hu hv ⊢
-    have hu' : (u.num * v.den) • one < (u.den * v.den: ℤ) • x := by
-      rw [mul_comm u.num, mul_comm (u.den : ℤ)]
-      rw [← smul_smul, ← smul_smul]
+    have hu' : (u.num * v.den) • one < (u.den * v.den : ℤ) • x := by
+      rw [mul_comm u.num, mul_comm (u.den : ℤ), ← smul_smul, ← smul_smul]
       exact zsmul_lt_zsmul_right (by simpa using v.den_pos) (by simpa using hu)
-    have hv' : (v.num * u.den) • one < (u.den * v.den: ℤ) • y := by
-      rw [mul_comm]
-      rw [← smul_smul, ← smul_smul]
-      apply zsmul_lt_zsmul_right (by simpa using u.den_pos) (by simpa using hv)
+    have hv' : (v.num * u.den) • one < (u.den * v.den : ℤ) • y := by
+      rw [mul_comm, ← smul_smul, ← smul_smul]
+      exact zsmul_lt_zsmul_right (by simpa using u.den_pos) (by simpa using hv)
     suffices ((u + v).num * u.den * v.den) • one <
         ((u + v).den : ℤ) • (u.den * v.den : ℤ) • (x + y) by
       rw [mul_assoc, mul_comm, zsmul_comm, ← smul_smul] at this
       rw [smul_lt_smul_iff_of_pos_left
         (mul_pos (by simpa using u.den_pos) (by simpa using v.den_pos))] at this
       simpa using this
-    rw [Rat.add_num_den']
-    rw [mul_comm, ←smul_smul]
+    rw [Rat.add_num_den', mul_comm, ← smul_smul]
     rw [smul_lt_smul_iff_of_pos_left (by simpa using (u + v).den_pos)]
     rw [add_smul, smul_add]
-    apply add_lt_add hu' hv'
+    exact add_lt_add hu' hv'
 
-theorem ratLt'_bddAbove {one : M} (hpos : 0 < one) (x : M) : BddAbove (ratLt' one x) := by
-  refine Monotone.map_bddAbove ?_ ?_
-  · exact Rat.cast_mono
-  · exact ratLt_bddAbove hpos x
+theorem ratLt'_bddAbove {one : M} (hpos : 0 < one) (x : M) : BddAbove (ratLt' one x) :=
+   Monotone.map_bddAbove Rat.cast_mono <| ratLt_bddAbove hpos x
 
-theorem ratLt'_nonempty {one : M} (hpos : 0 < one) (x : M): (ratLt' one x).Nonempty := by
-  apply Set.image_nonempty.mpr (ratLt_nonempty hpos x)
+theorem ratLt'_nonempty {one : M} (hpos : 0 < one) (x : M): (ratLt' one x).Nonempty :=
+   Set.image_nonempty.mpr (ratLt_nonempty hpos x)
 
 open Pointwise in
 theorem ratLt'_add {one : M} (hpos : 0 < one) (x y : M) :
@@ -204,21 +193,21 @@ theorem embed_real_strictMono {one : M} (hpos: 0 < one) : StrictMono (embed_real
 /-- The bundled `M →+o ℝ` for archimedean `M`.
 The given element `one` is mapped to the real number 1. -/
 noncomputable
-def orderAddMonoidHom_real_of_pos {one : M} (hpos: 0 < one) : M →+o ℝ where
+def orderAddMonoidHom_real {one : M} (hpos: 0 < one) : M →+o ℝ where
   toFun := embed_real one
   map_zero' := embed_real_zero hpos
   map_add' := embed_real_add hpos
   monotone' := (embed_real_strictMono hpos).monotone
 
 theorem orderAddMonoidHom_real_apply {one : M} (hpos: 0 < one) (a : M):
-    (orderAddMonoidHom_real_of_pos hpos) a = embed_real one a := by rfl
+    (orderAddMonoidHom_real hpos) a = embed_real one a := by rfl
 
-theorem orderAddMonoidHom_real_injective_of_pos {one : M} (hpos: 0 < one) :
-    Function.Injective (orderAddMonoidHom_real_of_pos hpos) :=
+theorem orderAddMonoidHom_real_injective {one : M} (hpos: 0 < one) :
+    Function.Injective (orderAddMonoidHom_real hpos) :=
   (embed_real_strictMono hpos).injective
 
 theorem orderAddMonoidHom_real_one {one : M} (hpos: 0 < one) :
-    (orderAddMonoidHom_real_of_pos hpos) one = 1 := by
+    (orderAddMonoidHom_real hpos) one = 1 := by
   rw [orderAddMonoidHom_real_apply]
   apply le_antisymm
   · apply csSup_le (ratLt'_nonempty hpos one)
@@ -238,7 +227,7 @@ theorem orderAddMonoidHom_real_one {one : M} (hpos: 0 < one) :
     contrapose! h'
     obtain ⟨y, hxy, hy⟩ := exists_rat_btwn h'
     norm_cast at hy
-    refine ⟨y, hy, hxy⟩
+    exact ⟨y, hy, hxy⟩
 
 variable (M) in
 theorem exists_orderAddMonoidHom_real_injective :
@@ -248,6 +237,6 @@ theorem exists_orderAddMonoidHom_real_injective :
   · have : Nontrivial M := not_subsingleton_iff_nontrivial.mp h
     obtain ⟨a, ha⟩ := exists_ne (0 : M)
     have ha : 0 < |a| := by simpa using ha
-    exact ⟨orderAddMonoidHom_real_of_pos ha, orderAddMonoidHom_real_injective_of_pos ha⟩
+    exact ⟨orderAddMonoidHom_real ha, orderAddMonoidHom_real_injective ha⟩
 
 end Archimedean


### PR DESCRIPTION
This is part of #25140, and is the special case of Hahn embedding theorem applied to archimedean group. ~~The construction is rather unpleasant as it uses explicit Cauchy sequence with essentially the binary representation of numbers, but I haven't found a better way to do this.~~ Rewritten with Dedekind cut

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
