### PR TITLE
[Merged by Bors] - docs(AlgebraicGeometry): remove redundant TODO

### DIFF
--- a/Mathlib/AlgebraicGeometry/Morphisms/Affine.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Affine.lean
@@ -26,9 +26,6 @@ It is equivalent to ask only that `Y` is covered by affine opens whose preimage 
 
 We also provide the instance `HasAffineProperty @IsAffineHom fun X _ _ _ ↦ IsAffine X`.
 
-## TODO
-- Affine morphisms are separated.
-
 -/
 
 universe v u


### PR DESCRIPTION
Remove the TODO message to prove that affine morphisms are separated, since this is already in `AlgebraicGeometry/Morphisms/Separated`, namely `of_isAffineHom`.
