### PR TITLE
[Merged by Bors] - refactor: Use medium rather than low priority for hom lemmas

### DIFF
--- a/Mathlib/Algebra/Group/Hom/Defs.lean
+++ b/Mathlib/Algebra/Group/Hom/Defs.lean
@@ -209,9 +209,18 @@ the entirety of the `FunLike` hierarchy in order to determine this because so ma
 a significant performance hit when `map_one` fails to apply.
 
 To avoid this problem, we mark these widely applicable simp lemmas with key discimination tree keys
-with `mid` priority in order to ensure that they are not tried first. We do not use `low`, to allow
-bundled morphisms to unfold themselves with `low` priority, such that the generic morphism lemmas
-are applied first.
+with `mid` priority in order to ensure that they are not tried first.
+
+We do not use `low`, to allow bundled morphisms to unfold themselves with `low` priority such that
+the generic morphism lemmas are applied first. For instance, we might have
+```lean
+def fooMonoidHom : M →* N where
+  toFun := foo; map_one' := sorry; map_mul' := sorry
+
+@[simp low] lemma fooMonoidHom_apply (x : M) : fooMonoidHom x = foo x := rfl
+```
+As `map_mul` is tagged `simp mid`, this means that it still fires before `fooMonoidHom_apply`, which
+is the behavior we desire.
 -/
 
 variable [FunLike F M N]

--- a/Mathlib/Algebra/Group/Hom/Defs.lean
+++ b/Mathlib/Algebra/Group/Hom/Defs.lean
@@ -193,7 +193,7 @@ instance OneHom.funLike : FunLike (OneHom M N) M N where
 instance OneHom.oneHomClass : OneHomClass (OneHom M N) M N where
   map_one := OneHom.map_one'
 
-library_note "low priority simp lemmas"
+library_note "hom simp lemma priority"
 /--
 The hom class hierarchy allows for a single lemma, such as `map_one`, to apply to a large variety
 of morphism types, so long as they have an instance of `OneHomClass`. For example, this applies to
@@ -209,13 +209,15 @@ the entirety of the `FunLike` hierarchy in order to determine this because so ma
 a significant performance hit when `map_one` fails to apply.
 
 To avoid this problem, we mark these widely applicable simp lemmas with key discimination tree keys
-with `low` priority in order to ensure that they are not tried first.
+with `mid` priority in order to ensure that they are not tried first. We do not use `low`, to allow
+bundled morphisms to unfold themselves with `low` priority, such that the generic morphism lemmas
+are applied first.
 -/
 
 variable [FunLike F M N]
 
-/-- See note [low priority simp lemmas] -/
-@[to_additive (attr := simp low)]
+/-- See note [hom simp lemma priority] -/
+@[to_additive (attr := simp mid)]
 theorem map_one [OneHomClass F M N] (f : F) : f 1 = 1 :=
   OneHomClass.map_one f
 
@@ -306,8 +308,8 @@ instance MulHom.mulHomClass : MulHomClass (M →ₙ* N) M N where
 
 variable [FunLike F M N]
 
-/-- See note [low priority simp lemmas] -/
-@[to_additive (attr := simp low)]
+/-- See note [hom simp lemma priority] -/
+@[to_additive (attr := simp mid)]
 theorem map_mul [MulHomClass F M N] (f : F) (x y : M) : f (x * y) = f x * f y :=
   MulHomClass.map_mul f x y
 
@@ -420,8 +422,8 @@ lemma map_comp_div' [DivInvMonoid G] [DivInvMonoid H] [MulHomClass F G H] (f : F
 
 /-- Group homomorphisms preserve inverse.
 
-See note [low priority simp lemmas] -/
-@[to_additive (attr := simp low) "Additive group homomorphisms preserve negation."]
+See note [hom simp lemma priority] -/
+@[to_additive (attr := simp mid) "Additive group homomorphisms preserve negation."]
 theorem map_inv [Group G] [DivisionMonoid H] [MonoidHomClass F G H]
     (f : F) (a : G) : f a⁻¹ = (f a)⁻¹ :=
   eq_inv_of_mul_eq_one_left <| map_mul_eq_one f <| inv_mul_cancel _
@@ -441,8 +443,8 @@ lemma map_comp_mul_inv [Group G] [DivisionMonoid H] [MonoidHomClass F G H] (f : 
 
 /-- Group homomorphisms preserve division.
 
-See note [low priority simp lemmas] -/
-@[to_additive (attr := simp low) "Additive group homomorphisms preserve subtraction."]
+See note [hom simp lemma priority] -/
+@[to_additive (attr := simp mid) "Additive group homomorphisms preserve subtraction."]
 theorem map_div [Group G] [DivisionMonoid H] [MonoidHomClass F G H] (f : F) :
     ∀ a b, f (a / b) = f a / f b := map_div' _ <| map_inv f
 
@@ -450,8 +452,8 @@ theorem map_div [Group G] [DivisionMonoid H] [MonoidHomClass F G H] (f : F) :
 lemma map_comp_div [Group G] [DivisionMonoid H] [MonoidHomClass F G H] (f : F) (g h : ι → G) :
     f ∘ (g / h) = f ∘ g / f ∘ h := by ext; simp
 
-/-- See note [low priority simp lemmas] -/
-@[to_additive (attr := simp low) (reorder := 9 10)]
+/-- See note [hom simp lemma priority] -/
+@[to_additive (attr := simp mid) (reorder := 9 10)]
 theorem map_pow [Monoid G] [Monoid H] [MonoidHomClass F G H] (f : F) (a : G) :
     ∀ n : ℕ, f (a ^ n) = f a ^ n
   | 0 => by rw [pow_zero, pow_zero, map_one]
@@ -474,8 +476,8 @@ lemma map_comp_zpow' [DivInvMonoid G] [DivInvMonoid H] [MonoidHomClass F G H] (f
 
 /-- Group homomorphisms preserve integer power.
 
-See note [low priority simp lemmas] -/
-@[to_additive (attr := simp low) (reorder := 9 10)
+See note [hom simp lemma priority] -/
+@[to_additive (attr := simp mid) (reorder := 9 10)
 "Additive group homomorphisms preserve integer scaling."]
 theorem map_zpow [Group G] [DivisionMonoid H] [MonoidHomClass F G H]
     (f : F) (g : G) (n : ℤ) : f (g ^ n) = f g ^ n := map_zpow' f (map_inv f) g n


### PR DESCRIPTION
The alternative would be to have such callers use `low - 1` or similar, but this seems cleaner.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
