### PR TITLE
[Merged by Bors] - feat: add `DFinsupp` version of `Finsupp` constructions

### DIFF
--- a/Mathlib/Algebra/DirectSum/Module.lean
+++ b/Mathlib/Algebra/DirectSum/Module.lean
@@ -142,16 +142,9 @@ variable (ι M)
 
 /-- Given `Fintype α`, `linearEquivFunOnFintype R` is the natural `R`-linear equivalence
 between `⨁ i, M i` and `∀ i, M i`. -/
-@[simps apply]
+@[simps! apply]
 def linearEquivFunOnFintype [Fintype ι] : (⨁ i, M i) ≃ₗ[R] ∀ i, M i :=
-  { DFinsupp.equivFunOnFintype with
-    toFun := (↑)
-    map_add' := fun f g ↦ by
-      ext
-      rw [add_apply, Pi.add_apply]
-    map_smul' := fun c f ↦ by
-      simp_rw [RingHom.id_apply]
-      rw [DFinsupp.coe_smul] }
+  DFinsupp.linearEquivFunOnFintype
 
 variable {ι M}
 
@@ -164,17 +157,15 @@ theorem linearEquivFunOnFintype_lof [Fintype ι] (i : ι) (m : M i) :
 
 @[simp]
 theorem linearEquivFunOnFintype_symm_single [Fintype ι] (i : ι) (m : M i) :
-    (linearEquivFunOnFintype R ι M).symm (Pi.single i m) = lof R ι M i m := by
-  change (DFinsupp.equivFunOnFintype.symm (Pi.single i m)) = _
-  rw [DFinsupp.equivFunOnFintype_symm_single i m]
-  rfl
+    (linearEquivFunOnFintype R ι M).symm (Pi.single i m) = lof R ι M i m :=
+  DFinsupp.equivFunOnFintype_symm_single i m
 
 end DecidableEq
 
 @[simp]
 theorem linearEquivFunOnFintype_symm_coe [Fintype ι] (f : ⨁ i, M i) :
-    (linearEquivFunOnFintype R ι M).symm f = f := by
-  simp [linearEquivFunOnFintype]
+    (linearEquivFunOnFintype R ι M).symm f = f :=
+  (linearEquivFunOnFintype R ι M).symm_apply_apply _
 
 /-- The natural linear equivalence between `⨁ _ : ι, M` and `M` when `Unique ι`. -/
 protected def lid (M : Type v) (ι : Type* := PUnit) [AddCommMonoid M] [Module R M] [Unique ι] :
@@ -310,7 +301,7 @@ variable {κ : Type*}
 
 /-- Reindexing terms of a direct sum is linear. -/
 def lequivCongrLeft (h : ι ≃ κ) : (⨁ i, M i) ≃ₗ[R] ⨁ k, M (h.symm k) :=
-  { equivCongrLeft h with map_smul' := DFinsupp.comapDomain'_smul h.invFun h.right_inv }
+  DFinsupp.domLCongr h
 
 @[simp]
 theorem lequivCongrLeft_apply (h : ι ≃ κ) (f : ⨁ i, M i) (k : κ) :
@@ -344,7 +335,7 @@ theorem sigmaLuncurry_apply (f : ⨁ (i) (j), δ i j) (i : ι) (j : α i) :
 
 /-- `curryEquiv` as a linear equiv. -/
 def sigmaLcurryEquiv : (⨁ i : Σ_, _, δ i.1 i.2) ≃ₗ[R] ⨁ (i) (j), δ i j :=
-  { sigmaCurryEquiv, sigmaLcurry R with }
+  DFinsupp.sigmaCurryLEquiv
 
 end Sigma
 

--- a/Mathlib/LinearAlgebra/DFinsupp.lean
+++ b/Mathlib/LinearAlgebra/DFinsupp.lean
@@ -136,7 +136,7 @@ def sigmaCurryLEquiv {α : ι → Type*} {M : (i : ι) → α i → Type*}
 
 This is the `DFinsupp` version of `Finsupp.linearEquivFunOnFintype`. -/
 @[simps! apply symm_apply]
-def linearEquivFunOnFintype [Fintype ι]: (Π₀ i, M i) ≃ₗ[R] (Π i, M i) where
+def linearEquivFunOnFintype [Fintype ι] : (Π₀ i, M i) ≃ₗ[R] (Π i, M i) where
   __ := equivFunOnFintype
   map_add' _ _ := by ext; rfl
   map_smul' _ _ := by ext; rfl

--- a/Mathlib/LinearAlgebra/DFinsupp.lean
+++ b/Mathlib/LinearAlgebra/DFinsupp.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Kenny Lau
 -/
 import Mathlib.Data.DFinsupp.Submonoid
+import Mathlib.Data.DFinsupp.Sigma
 import Mathlib.Data.Finsupp.ToDFinsupp
 import Mathlib.LinearAlgebra.Finsupp.SumProd
 import Mathlib.LinearAlgebra.LinearIndependent.Lemmas
@@ -34,7 +35,7 @@ much more developed, but many lemmas in that file should be eligible to copy ove
 function with finite support, module, linear algebra
 -/
 
-variable {ι : Type*} {R : Type*} {S : Type*} {M : ι → Type*} {N : Type*}
+variable {ι ι' : Type*} {R : Type*} {S : Type*} {M : ι → Type*} {N : Type*}
 
 namespace DFinsupp
 
@@ -110,6 +111,35 @@ instance {R : Type*} {S : Type*} [Semiring R] [Semiring S] (σ : R →+* S)
     [AddCommMonoid M] [AddCommMonoid M₂] [Module R M] [Module S M₂] :
     EquivLike (LinearEquiv σ M M₂) M M₂ :=
   inferInstance
+
+/-- `DFinsupp.equivCongrLeft` as a linear equivalence.
+
+This is the `DFinsupp` version of `Finsupp.domLCongr`. -/
+@[simps! apply]
+def domLCongr (e : ι ≃ ι') : (Π₀ i, M i) ≃ₗ[R] (Π₀ i, M (e.symm i)) where
+  __ := DFinsupp.equivCongrLeft e
+  map_add' _ _ := by ext; rfl
+  map_smul' _ _ := by ext; rfl
+
+/-- `DFinsupp.sigmaCurryEquiv` as a linear equivalence.
+
+This is the `DFinsupp` version of `Finsupp.finsuppProdLEquiv`. -/
+@[simps! apply symm_apply]
+def sigmaCurryLEquiv {α : ι → Type*} {M : (i : ι) → α i → Type*}
+    [Π i j, AddCommMonoid (M i j)] [Π i j, Module R (M i j)] [DecidableEq ι] :
+    (Π₀ (i : (x : ι) × α x), M i.fst i.snd) ≃ₗ[R] Π₀ (i : ι) (j : α i), M i j where
+  __ := DFinsupp.sigmaCurryEquiv
+  map_add' _ _ := by ext; rfl
+  map_smul' _ _ := by ext; rfl
+
+/-- `DFinsupp.equivFunOnFintype` as a linear equivalence.
+
+This is the `DFinsupp` version of `Finsupp.linearEquivFunOnFintype`. -/
+@[simps! apply symm_apply]
+def linearEquivFunOnFintype [Fintype ι]: (Π₀ i, M i) ≃ₗ[R] (Π i, M i) where
+  __ := equivFunOnFintype
+  map_add' _ _ := by ext; rfl
+  map_smul' _ _ := by ext; rfl
 
 /-- The `DFinsupp` version of `Finsupp.lsum`.
 


### PR DESCRIPTION
For ease of discovery, I copy the `Finsupp` names rather than the `DirectSum` names.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
