### PR TITLE
feat: update build commands to run quietly during CI

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -107,6 +107,15 @@ jobs:
           run: |
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
 
+      # `lake build` again with --quiet and --no-build flags to make error messages easier to find
+      - name: build mathlib quietly
+        id: quiet build
+        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
+        with:
+          linters: lean
+          run: |
+            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --quiet --no-build --wfail -KCI"
+
       - name: print the sizes of the oleans
         run: |
           du .lake/build/lib/lean/Mathlib ||

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -105,7 +105,7 @@ jobs:
         with:
           linters: lean
           run: |
-            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --quiet --wfail -KCI"
+            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
 
       - name: print the sizes of the oleans
         run: |

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -109,7 +109,7 @@ jobs:
 
       # `lake build` again with --quiet and --no-build flags to make error messages easier to find
       - name: build mathlib quietly
-        id: quiet build
+        id: quiet-build
         uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
         with:
           linters: lean

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -105,7 +105,7 @@ jobs:
         with:
           linters: lean
           run: |
-            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
+            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --quiet --wfail -KCI"
 
       - name: print the sizes of the oleans
         run: |

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -115,7 +115,7 @@ jobs:
         with:
           linters: lean
           run: |
-            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
+            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --quiet --wfail -KCI"
 
       - name: print the sizes of the oleans
         run: |

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -115,7 +115,7 @@ jobs:
         with:
           linters: lean
           run: |
-            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --quiet --wfail -KCI"
+            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
 
       - name: print the sizes of the oleans
         run: |

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -119,7 +119,7 @@ jobs:
 
       # `lake build` again with --quiet and --no-build flags to make error messages easier to find
       - name: build mathlib quietly
-        id: quiet build
+        id: quiet-build
         uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
         with:
           linters: lean

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -117,6 +117,15 @@ jobs:
           run: |
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
 
+      # `lake build` again with --quiet and --no-build flags to make error messages easier to find
+      - name: build mathlib quietly
+        id: quiet build
+        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
+        with:
+          linters: lean
+          run: |
+            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --quiet --no-build --wfail -KCI"
+
       - name: print the sizes of the oleans
         run: |
           du .lake/build/lib/lean/Mathlib ||

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,6 +124,15 @@ jobs:
           run: |
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
 
+      # `lake build` again with --quiet and --no-build flags to make error messages easier to find
+      - name: build mathlib quietly
+        id: quiet build
+        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
+        with:
+          linters: lean
+          run: |
+            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --quiet --no-build --wfail -KCI"
+
       - name: print the sizes of the oleans
         run: |
           du .lake/build/lib/lean/Mathlib ||

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
         with:
           linters: lean
           run: |
-            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
+            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --quiet --wfail -KCI"
 
       - name: print the sizes of the oleans
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
         with:
           linters: lean
           run: |
-            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --quiet --wfail -KCI"
+            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
 
       - name: print the sizes of the oleans
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
 
       # `lake build` again with --quiet and --no-build flags to make error messages easier to find
       - name: build mathlib quietly
-        id: quiet build
+        id: quiet-build
         uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
         with:
           linters: lean

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -119,7 +119,7 @@ jobs:
         with:
           linters: lean
           run: |
-            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
+            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --quiet --wfail -KCI"
 
       - name: print the sizes of the oleans
         run: |

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -119,7 +119,7 @@ jobs:
         with:
           linters: lean
           run: |
-            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --quiet --wfail -KCI"
+            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
 
       - name: print the sizes of the oleans
         run: |

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -121,6 +121,15 @@ jobs:
           run: |
             bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
 
+      # `lake build` again with --quiet and --no-build flags to make error messages easier to find
+      - name: build mathlib quietly
+        id: quiet build
+        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
+        with:
+          linters: lean
+          run: |
+            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --quiet --no-build --wfail -KCI"
+
       - name: print the sizes of the oleans
         run: |
           du .lake/build/lib/lean/Mathlib ||

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -123,7 +123,7 @@ jobs:
 
       # `lake build` again with --quiet and --no-build flags to make error messages easier to find
       - name: build mathlib quietly
-        id: quiet build
+        id: quiet-build
         uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
         with:
           linters: lean

--- a/Mathlib/Algebra/BigOperators/Associated.lean
+++ b/Mathlib/Algebra/BigOperators/Associated.lean
@@ -10,7 +10,7 @@ import Mathlib.Algebra.GroupWithZero.Associated
 /-!
 # Products of associated, prime, and irreducible elements.
 
-This file contains some theorems relating definitions in `Algebra.Associated`. This line is to intentionally violate the linter to see what happens.
+This file contains some theorems relating definitions in `Algebra.Associated`. Let's make a long line again.
 and products of multisets, finsets, and finsupps.
 
 -/
@@ -111,8 +111,7 @@ theorem divisor_closure_eq_closure [CancelCommMonoidWithZero α]
         · right; exact ha₂
         rw [← mul_left_cancel₀ ha₂.ne_zero hprod]
         exact multiset_prod_mem _ _ (fun t ht => subset_closure (hs t ht))
-      rw [hc, mul_comm x _, mul_assoc, mul_comm c _] at hprod
-      refine hind x c ?_ hs (mul_left_cancel₀ ha₂.ne_zero hprod)
+      rw [hc, mul_comm x _, mul_assoc, mul_comm c _] at hprod ; refine hind x c ?_ hs (mul_left_cancel₀ ha₂.ne_zero hprod)
       rw [← mul_left_cancel₀ ha₂.ne_zero hprod]
       exact multiset_prod_mem _ _ (fun t ht => subset_closure (hs t ht))
 

--- a/Mathlib/Algebra/BigOperators/Associated.lean
+++ b/Mathlib/Algebra/BigOperators/Associated.lean
@@ -10,7 +10,7 @@ import Mathlib.Algebra.GroupWithZero.Associated
 /-!
 # Products of associated, prime, and irreducible elements.
 
-This file contains some theorems relating definitions in `Algebra.Associated`
+This file contains some theorems relating definitions in `Algebra.Associated`. This line is to intentionally violate the linter to see what happens.
 and products of multisets, finsets, and finsupps.
 
 -/


### PR DESCRIPTION
Adds the `--quiet` flag to the CI build command.

This was done by changing `.github/build.in.yml`, and then running the script mentioned in that file to regenerate the others.

See Zulip Thread [here](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Quieter.20CI.20logging/near/520239070).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
