### PR TITLE
[Merged by Bors] - chore(RingTheory/HopfAlgebra): make tensor product heterobasic

### DIFF
--- a/Mathlib/Algebra/Category/BialgCat/Monoidal.lean
+++ b/Mathlib/Algebra/Category/BialgCat/Monoidal.lean
@@ -36,9 +36,9 @@ noncomputable instance instMonoidalCategoryStruct :
   whiskerRight f X := ofHom (f.1.rTensor X)
   tensorHom f g := ofHom (Bialgebra.TensorProduct.map f.1 g.1)
   tensorUnit := of R R
-  associator X Y Z := (Bialgebra.TensorProduct.assoc R X Y Z).toBialgIso
+  associator X Y Z := (Bialgebra.TensorProduct.assoc R R X Y Z).toBialgIso
   leftUnitor X := (Bialgebra.TensorProduct.lid R X).toBialgIso
-  rightUnitor X := (Bialgebra.TensorProduct.rid R X).toBialgIso
+  rightUnitor X := (Bialgebra.TensorProduct.rid R R X).toBialgIso
 
 /-- The data needed to induce a `MonoidalCategory` structure via
 `BialgCat.instMonoidalCategoryStruct` and the forgetful functor to algebras. -/

--- a/Mathlib/Algebra/Category/CoalgCat/Monoidal.lean
+++ b/Mathlib/Algebra/Category/CoalgCat/Monoidal.lean
@@ -39,9 +39,9 @@ noncomputable instance instMonoidalCategoryStruct :
   whiskerRight f X := ofHom (f.1.rTensor X)
   tensorHom f g := ofHom (Coalgebra.TensorProduct.map f.1 g.1)
   tensorUnit := CoalgCat.of R R
-  associator X Y Z := (Coalgebra.TensorProduct.assoc R X Y Z).toCoalgIso
+  associator X Y Z := (Coalgebra.TensorProduct.assoc R R X Y Z).toCoalgIso
   leftUnitor X := (Coalgebra.TensorProduct.lid R X).toCoalgIso
-  rightUnitor X := (Coalgebra.TensorProduct.rid R X).toCoalgIso
+  rightUnitor X := (Coalgebra.TensorProduct.rid R R X).toCoalgIso
 
 /-- The data needed to induce a `MonoidalCategory` structure via
 `CoalgCat.instMonoidalCategoryStruct` and the forgetful functor to modules. -/

--- a/Mathlib/Algebra/Category/HopfAlgCat/Monoidal.lean
+++ b/Mathlib/Algebra/Category/HopfAlgCat/Monoidal.lean
@@ -31,9 +31,9 @@ variable (R : Type u) [CommRing R]
   whiskerRight f X := ofHom (f.1.rTensor X)
   tensorHom f g := ofHom (Bialgebra.TensorProduct.map f.1 g.1)
   tensorUnit := of R R
-  associator X Y Z := (Bialgebra.TensorProduct.assoc R X Y Z).toHopfAlgIso
+  associator X Y Z := (Bialgebra.TensorProduct.assoc R R X Y Z).toHopfAlgIso
   leftUnitor X := (Bialgebra.TensorProduct.lid R X).toHopfAlgIso
-  rightUnitor X := (Bialgebra.TensorProduct.rid R X).toHopfAlgIso
+  rightUnitor X := (Bialgebra.TensorProduct.rid R R X).toHopfAlgIso
 
 /-- The data needed to induce a `MonoidalCategory` structure via
 `HopfAlgCat.instMonoidalCategoryStruct` and the forgetful functor to bialgebras. -/

--- a/Mathlib/RingTheory/Bialgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/Bialgebra/TensorProduct.lean
@@ -22,108 +22,109 @@ namespace Bialgebra.TensorProduct
 
 open Coalgebra.TensorProduct
 
-variable (R A B C D : Type*) [CommSemiring R] [Semiring A] [Semiring B]
-  [Bialgebra R A] [Bialgebra R B] [Semiring C] [Semiring D] [Bialgebra R C] [Bialgebra R D]
+variable (R S A B C D : Type*) [CommSemiring R] [CommSemiring S] [Semiring A] [Semiring B]
+  [Bialgebra S A] [Bialgebra R B] [Algebra R A] [Algebra R S] [IsScalarTower R S A]
 
 lemma counit_eq_algHom_toLinearMap :
-    Coalgebra.counit (R := R) (A := A ⊗[R] B) =
+    Coalgebra.counit (R := S) (A := A ⊗[R] B) =
       ((Algebra.TensorProduct.rid _ _ _).toAlgHom.comp (Algebra.TensorProduct.map
-      (Bialgebra.counitAlgHom R A) (Bialgebra.counitAlgHom R B))).toLinearMap :=
+      (Bialgebra.counitAlgHom S A) (Bialgebra.counitAlgHom R B))).toLinearMap :=
   rfl
 
 lemma comul_eq_algHom_toLinearMap :
-    Coalgebra.comul (R := R) (A := A ⊗[R] B) =
-      ((Algebra.TensorProduct.tensorTensorTensorComm R R R R A A B B).toAlgHom.comp
-      (Algebra.TensorProduct.map (Bialgebra.comulAlgHom R A)
+    Coalgebra.comul (R := S) (A := A ⊗[R] B) =
+      ((Algebra.TensorProduct.tensorTensorTensorComm R S R S A A B B).toAlgHom.comp
+      (Algebra.TensorProduct.map (Bialgebra.comulAlgHom S A)
       (Bialgebra.comulAlgHom R B))).toLinearMap :=
   rfl
 
-noncomputable instance _root_.TensorProduct.instBialgebra : Bialgebra R (A ⊗[R] B) := by
-  have hcounit := congr(DFunLike.coe $(counit_eq_algHom_toLinearMap R A B))
-  have hcomul := congr(DFunLike.coe $(comul_eq_algHom_toLinearMap R A B))
-  refine Bialgebra.mk' R (A ⊗[R] B) ?_ (fun {x y} => ?_) ?_ (fun {x y} => ?_) <;>
+noncomputable instance _root_.TensorProduct.instBialgebra : Bialgebra S (A ⊗[R] B) := by
+  have hcounit := congr(DFunLike.coe $(counit_eq_algHom_toLinearMap R S A B))
+  have hcomul := congr(DFunLike.coe $(comul_eq_algHom_toLinearMap R S A B))
+  refine Bialgebra.mk' S (A ⊗[R] B) ?_ (fun {x y} => ?_) ?_ (fun {x y} => ?_) <;>
   simp_all only [AlgHom.toLinearMap_apply] <;>
   simp only [map_one, map_mul]
 
-variable {R A B C D}
+variable {R S A B C D}
+
+variable [Semiring C] [Semiring D] [Bialgebra S C]
+  [Bialgebra R D] [Algebra R C] [IsScalarTower R S C]
 
 /-- The tensor product of two bialgebra morphisms as a bialgebra morphism. -/
-noncomputable def map (f : A →ₐc[R] B) (g : C →ₐc[R] D) :
-    A ⊗[R] C →ₐc[R] B ⊗[R] D :=
-  { Coalgebra.TensorProduct.map (f : A →ₗc[R] B) (g : C →ₗc[R] D),
-    Algebra.TensorProduct.map (f : A →ₐ[R] B) (g : C →ₐ[R] D) with }
+noncomputable def map (f : A →ₐc[S] C) (g : B →ₐc[R] D) :
+    A ⊗[R] B →ₐc[S] C ⊗[R] D :=
+  { Coalgebra.TensorProduct.map (f : A →ₗc[S] C) (g : B →ₗc[R] D),
+    Algebra.TensorProduct.map (f : A →ₐ[S] C) (g : B →ₐ[R] D) with }
 
 @[simp]
-theorem map_tmul (f : A →ₐc[R] B) (g : C →ₐc[R] D) (x : A) (y : C) :
+theorem map_tmul (f : A →ₐc[S] C) (g : B →ₐc[R] D) (x : A) (y : B) :
     map f g (x ⊗ₜ y) = f x ⊗ₜ g y :=
   rfl
 
 @[simp]
-theorem map_toCoalgHom (f : A →ₐc[R] B) (g : C →ₐc[R] D) :
-    map f g = Coalgebra.TensorProduct.map (f : A →ₗc[R] B) (g : C →ₗc[R] D) := rfl
+theorem map_toCoalgHom (f : A →ₐc[S] C) (g : B →ₐc[R] D) :
+    map f g = Coalgebra.TensorProduct.map (f : A →ₗc[S] C) (g : B →ₗc[R] D) := rfl
 
 @[simp]
-theorem map_toAlgHom (f : A →ₐc[R] B) (g : C →ₐc[R] D) :
-    (map f g : A ⊗[R] C →ₐ[R] B ⊗[R] D) =
-      Algebra.TensorProduct.map (f : A →ₐ[R] B) (g : C →ₐ[R] D) :=
+theorem map_toAlgHom (f : A →ₐc[S] C) (g : B →ₐc[R] D) :
+    (map f g : A ⊗[R] B →ₐ[S] C ⊗[R] D) =
+      Algebra.TensorProduct.map (f : A →ₐ[S] C) (g : B →ₐ[R] D) :=
   rfl
 
-variable (R A B C) in
+variable (R S A C D) in
 /-- The associator for tensor products of R-bialgebras, as a bialgebra equivalence. -/
 protected noncomputable def assoc :
-    (A ⊗[R] B) ⊗[R] C ≃ₐc[R] A ⊗[R] (B ⊗[R] C) :=
-  { Coalgebra.TensorProduct.assoc R A B C, Algebra.TensorProduct.assoc R R A B C with }
+    (A ⊗[S] C) ⊗[R] D ≃ₐc[S] A ⊗[S] (C ⊗[R] D) :=
+  { Coalgebra.TensorProduct.assoc R S A C D, Algebra.TensorProduct.assoc R S A C D with }
 
 @[simp]
-theorem assoc_tmul (x : A) (y : B) (z : C) :
-    Bialgebra.TensorProduct.assoc R A B C ((x ⊗ₜ y) ⊗ₜ z) = x ⊗ₜ (y ⊗ₜ z) :=
+theorem assoc_tmul (x : A) (y : C) (z : D) :
+    Bialgebra.TensorProduct.assoc R S A C D ((x ⊗ₜ y) ⊗ₜ z) = x ⊗ₜ (y ⊗ₜ z) :=
   rfl
 
 @[simp]
-theorem assoc_symm_tmul (x : A) (y : B) (z : C) :
-    (Bialgebra.TensorProduct.assoc R A B C).symm (x ⊗ₜ (y ⊗ₜ z)) = (x ⊗ₜ y) ⊗ₜ z :=
+theorem assoc_symm_tmul (x : A) (y : C) (z : D) :
+    (Bialgebra.TensorProduct.assoc R S A C D).symm (x ⊗ₜ (y ⊗ₜ z)) = (x ⊗ₜ y) ⊗ₜ z :=
   rfl
 
 @[simp]
 theorem assoc_toCoalgEquiv :
-    (Bialgebra.TensorProduct.assoc R A B C : _ ≃ₗc[R] _) =
-    Coalgebra.TensorProduct.assoc R A B C := rfl
+    (Bialgebra.TensorProduct.assoc R S A C D : _ ≃ₗc[S] _) =
+    Coalgebra.TensorProduct.assoc R S A C D := rfl
 
 @[simp]
 theorem assoc_toAlgEquiv :
-    (Bialgebra.TensorProduct.assoc R A B C : _ ≃ₐ[R] _) =
-    Algebra.TensorProduct.assoc R R A B C := by ext; rfl
+    (Bialgebra.TensorProduct.assoc R S A C D : _ ≃ₐ[S] _) =
+    Algebra.TensorProduct.assoc R S A C D := rfl
 
-variable (R A) in
+variable (R B) in
 /-- The base ring is a left identity for the tensor product of bialgebras, up to
 bialgebra equivalence. -/
-protected noncomputable def lid : R ⊗[R] A ≃ₐc[R] A :=
-  { Coalgebra.TensorProduct.lid R A, Algebra.TensorProduct.lid R A with }
+protected noncomputable def lid : R ⊗[R] B ≃ₐc[R] B :=
+  { Coalgebra.TensorProduct.lid R B, Algebra.TensorProduct.lid R B with }
 
 @[simp]
 theorem lid_toCoalgEquiv :
-    (Bialgebra.TensorProduct.lid R A : R ⊗[R] A ≃ₗc[R] A) = Coalgebra.TensorProduct.lid R A := rfl
+    (Bialgebra.TensorProduct.lid R B : R ⊗[R] B ≃ₗc[R] B) = Coalgebra.TensorProduct.lid R B := rfl
 
 @[simp]
 theorem lid_toAlgEquiv :
-    (Bialgebra.TensorProduct.lid R A : R ⊗[R] A ≃ₐ[R] A) = Algebra.TensorProduct.lid R A := rfl
+    (Bialgebra.TensorProduct.lid R B : R ⊗[R] B ≃ₐ[R] B) = Algebra.TensorProduct.lid R B := rfl
 
 @[simp]
-theorem lid_tmul (r : R) (a : A) : Bialgebra.TensorProduct.lid R A (r ⊗ₜ a) = r • a := rfl
+theorem lid_tmul (r : R) (a : B) : Bialgebra.TensorProduct.lid R B (r ⊗ₜ a) = r • a := rfl
 
 @[simp]
-theorem lid_symm_apply (a : A) : (Bialgebra.TensorProduct.lid R A).symm a = 1 ⊗ₜ a := rfl
+theorem lid_symm_apply (a : B) : (Bialgebra.TensorProduct.lid R B).symm a = 1 ⊗ₜ a := rfl
 
-/- TODO: make this defeq, which would involve adding a heterobasic version of
-`Coalgebra.TensorProduct.rid`. -/
 theorem coalgebra_rid_eq_algebra_rid_apply (x : A ⊗[R] R) :
-    Coalgebra.TensorProduct.rid R A x = Algebra.TensorProduct.rid R R A x := rfl
+    Coalgebra.TensorProduct.rid R S A x = Algebra.TensorProduct.rid R R A x := rfl
 
-variable (R A) in
+variable (R S A) in
 /-- The base ring is a right identity for the tensor product of bialgebras, up to
 bialgebra equivalence. -/
-protected noncomputable def rid : A ⊗[R] R ≃ₐc[R] A where
-  toCoalgEquiv := Coalgebra.TensorProduct.rid R A
+protected noncomputable def rid : A ⊗[R] R ≃ₐc[S] A where
+  toCoalgEquiv := Coalgebra.TensorProduct.rid R S A
   map_mul' x y := by
     simp only [CoalgEquiv.toCoalgHom_eq_coe, CoalgHom.toLinearMap_eq_coe, AddHom.toFun_eq_coe,
       LinearMap.coe_toAddHom, CoalgHom.coe_toLinearMap, CoalgHom.coe_coe,
@@ -131,19 +132,19 @@ protected noncomputable def rid : A ⊗[R] R ≃ₐc[R] A where
 
 @[simp]
 theorem rid_toCoalgEquiv :
-    (TensorProduct.rid R A : A ⊗[R] R ≃ₗc[R] A) = Coalgebra.TensorProduct.rid R A := rfl
+    (TensorProduct.rid R S A : A ⊗[R] R ≃ₗc[S] A) = Coalgebra.TensorProduct.rid R S A := rfl
 
 @[simp]
 theorem rid_toAlgEquiv :
-    (Bialgebra.TensorProduct.rid R A : A ⊗[R] R ≃ₐ[R] A) = Algebra.TensorProduct.rid R R A := by
+    (Bialgebra.TensorProduct.rid R S A : A ⊗[R] R ≃ₐ[S] A) = Algebra.TensorProduct.rid R S A := by
   ext x
   exact coalgebra_rid_eq_algebra_rid_apply x
 
 @[simp]
-theorem rid_tmul (r : R) (a : A) : Bialgebra.TensorProduct.rid R A (a ⊗ₜ r) = r • a := rfl
+theorem rid_tmul (r : R) (a : A) : Bialgebra.TensorProduct.rid R S A (a ⊗ₜ r) = r • a := rfl
 
 @[simp]
-theorem rid_symm_apply (a : A) : (Bialgebra.TensorProduct.rid R A).symm a = a ⊗ₜ 1 := rfl
+theorem rid_symm_apply (a : A) : (Bialgebra.TensorProduct.rid R S A).symm a = a ⊗ₜ 1 := rfl
 
 end Bialgebra.TensorProduct
 namespace BialgHom

--- a/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
@@ -231,8 +231,7 @@ theorem lid_tmul (r : R) (a : P) : Coalgebra.TensorProduct.lid R P (r ⊗ₜ a) 
 @[simp]
 theorem lid_symm_apply (a : P) : (Coalgebra.TensorProduct.lid R P).symm a = 1 ⊗ₜ a := rfl
 
-variable (R S M)
-
+variable (R S M) in
 /-- The base ring is a right identity for the tensor product of coalgebras, up to
 coalgebra equivalence. -/
 protected noncomputable def rid : M ⊗[R] R ≃ₗc[S] M :=
@@ -244,8 +243,6 @@ protected noncomputable def rid : M ⊗[R] R ≃ₗc[S] M :=
       simp only [one_smul]
       hopf_tensor_induction comul (R := S) x with x₁ x₂
       simp }
-
-variable {R S M}
 
 @[simp]
 theorem rid_toLinearEquiv :

--- a/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
@@ -9,13 +9,16 @@ import Mathlib.RingTheory.Coalgebra.Equiv
 /-!
 # Tensor products of coalgebras
 
-Given two `R`-coalgebras `M, N`, we can define a natural comultiplication map
-`Δ : M ⊗[R] N → (M ⊗[R] N) ⊗[R] (M ⊗[R] N)` and counit map `ε : M ⊗[R] N → R` induced by
-the comultiplication and counit maps of `M` and `N`.
+Suppose `S` is an `A` algebra. Given an `S`-coalgebra `A` and `R`-coalgebra `B`, we can define
+a natural comultiplication map `Δ : A ⊗[R] B → (A ⊗[R] B) ⊗[S] (A ⊗[R] B)`
+and counit map `ε : A ⊗[R] B → S` induced by the comultiplication and counit maps of `A` and `B`.
 
 In this file we show that `Δ, ε` satisfy the axioms of a coalgebra, and also define other data
 in the monoidal structure on `R`-coalgebras, like the tensor product of two coalgebra morphisms
 as a coalgebra morphism.
+
+In particular, when `R = S` we get tensor products of coalgebras, and when `A = S` we get
+the base change `S ⊗[R] B` as an `R`-coalgebra.
 
 -/
 

--- a/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
@@ -21,31 +21,32 @@ as a coalgebra morphism.
 
 open TensorProduct
 
-variable {R A B : Type*} [CommSemiring R] [AddCommMonoid B] [AddCommMonoid A]
-    [Module R A] [Module R B] [Coalgebra R A] [Coalgebra R B]
+variable {R S A B : Type*} [CommSemiring R] [CommSemiring S] [AddCommMonoid A] [AddCommMonoid B]
+    [Algebra R S] [Module R A] [Module S A] [Module R B] [Coalgebra R B]
+    [Coalgebra S A] [IsScalarTower R S A]
 
 namespace TensorProduct
 
 open Coalgebra
 
 noncomputable
-instance instCoalgebraStruct : CoalgebraStruct R (A ⊗[R] B) where
+instance instCoalgebraStruct : CoalgebraStruct S (A ⊗[R] B) where
   comul :=
-    AlgebraTensorModule.tensorTensorTensorComm R R R R A A B B ∘ₗ
+    AlgebraTensorModule.tensorTensorTensorComm R S R S A A B B ∘ₗ
       AlgebraTensorModule.map comul comul
-  counit := AlgebraTensorModule.rid R R R ∘ₗ AlgebraTensorModule.map counit counit
+  counit := AlgebraTensorModule.rid R S S ∘ₗ AlgebraTensorModule.map counit counit
 
 lemma comul_def :
-    Coalgebra.comul (R := R) (A := A ⊗[R] B) =
-      AlgebraTensorModule.tensorTensorTensorComm R R R R A A B B ∘ₗ
+    Coalgebra.comul (R := S) (A := A ⊗[R] B) =
+      AlgebraTensorModule.tensorTensorTensorComm R S R S A A B B ∘ₗ
         AlgebraTensorModule.map Coalgebra.comul Coalgebra.comul :=
   rfl
 
 @[deprecated (since := "2025-04-09")] alias instCoalgebraStruct_comul := comul_def
 
 lemma counit_def :
-    Coalgebra.counit (R := R) (A := A ⊗[R] B) =
-      AlgebraTensorModule.rid R R R ∘ₗ AlgebraTensorModule.map counit counit :=
+    Coalgebra.counit (R := S) (A := A ⊗[R] B) =
+      AlgebraTensorModule.rid R S S ∘ₗ AlgebraTensorModule.map counit counit :=
   rfl
 
 @[deprecated (since := "2025-04-09")] alias instCoalgebraStruct_counit := counit_def
@@ -53,11 +54,11 @@ lemma counit_def :
 @[simp]
 lemma comul_tmul (x : A) (y : B) :
     comul (x ⊗ₜ y) =
-      AlgebraTensorModule.tensorTensorTensorComm R R R R A A B B (comul x ⊗ₜ comul y) := rfl
+      AlgebraTensorModule.tensorTensorTensorComm R S R S A A B B (comul x ⊗ₜ comul y) := rfl
 
 @[simp]
 lemma counit_tmul (x : A) (y : B) :
-    counit (R := R) (x ⊗ₜ[R] y) = counit (R := R) y • counit (R := R) x := rfl
+    counit (R := S) (x ⊗ₜ[R] y) = counit (R := R) y • counit (R := S) x := rfl
 
 open Lean.Parser.Tactic in
 /-- `hopf_tensor_induction x with x₁ x₂` attempts to replace `x` by
@@ -75,64 +76,64 @@ scoped macro "hopf_tensor_induction " var:elimTarget "with " var₁:ident var₂
       | tmul $var₁ $var₂ => ?_))
 
 private lemma coassoc :
-    TensorProduct.assoc R (A ⊗[R] B) (A ⊗[R] B) (A ⊗[R] B) ∘ₗ
-      (comul (R := R) (A := (A ⊗[R] B))).rTensor (A ⊗[R] B) ∘ₗ
-        (comul (R := R) (A := (A ⊗[R] B))) =
-    (comul (R := R) (A := (A ⊗[R] B))).lTensor (A ⊗[R] B) ∘ₗ
-      (comul (R := R) (A := (A ⊗[R] B))) := by
+    TensorProduct.assoc S (A ⊗[R] B) (A ⊗[R] B) (A ⊗[R] B) ∘ₗ
+      (comul (R := S) (A := (A ⊗[R] B))).rTensor (A ⊗[R] B) ∘ₗ
+        (comul (R := S) (A := (A ⊗[R] B))) =
+    (comul (R := S) (A := (A ⊗[R] B))).lTensor (A ⊗[R] B) ∘ₗ
+      (comul (R := S) (A := (A ⊗[R] B))) := by
   ext x y
-  let F : (A ⊗[R] A ⊗[R] A) ⊗[R] (B ⊗[R] B ⊗[R] B) ≃ₗ[R]
-    (A ⊗[R] B) ⊗[R] (A ⊗[R] B) ⊗[R] A ⊗[R] B :=
+  let F : (A ⊗[S] A ⊗[S] A) ⊗[R] (B ⊗[R] B ⊗[R] B) ≃ₗ[S]
+    (A ⊗[R] B) ⊗[S] (A ⊗[R] B) ⊗[S] A ⊗[R] B :=
     AlgebraTensorModule.tensorTensorTensorComm _ _ _ _ _ _ _ _ ≪≫ₗ
       AlgebraTensorModule.congr (.refl _ _)
         (AlgebraTensorModule.tensorTensorTensorComm _ _ _ _ _ _ _ _)
-  let F' : (A ⊗[R] A ⊗[R] A) ⊗[R] (B ⊗[R] B ⊗[R] B) →ₗ[R]
-      (A ⊗[R] B) ⊗[R] (A ⊗[R] B) ⊗[R] A ⊗[R] B :=
+  let F' : (A ⊗[S] A ⊗[S] A) ⊗[R] (B ⊗[R] B ⊗[R] B) →ₗ[S]
+      (A ⊗[R] B) ⊗[S] (A ⊗[R] B) ⊗[S] A ⊗[R] B :=
     TensorProduct.mapOfCompatibleSMul _ _ _ _ ∘ₗ
         TensorProduct.map .id (TensorProduct.mapOfCompatibleSMul _ _ _ _) ∘ₗ F.toLinearMap
   convert congr(F ($(Coalgebra.coassoc_apply x) ⊗ₜ[R] $(Coalgebra.coassoc_apply y))) using 1
   · dsimp
-    hopf_tensor_induction comul (R := R) x with x₁ x₂
+    hopf_tensor_induction comul (R := S) x with x₁ x₂
     hopf_tensor_induction comul (R := R) y with y₁ y₂
     dsimp
-    hopf_tensor_induction comul (R := R) x₁ with x₁₁ x₁₂
+    hopf_tensor_induction comul (R := S) x₁ with x₁₁ x₁₂
     hopf_tensor_induction comul (R := R) y₁ with y₁₁ y₁₂
     rfl
   · dsimp
-    hopf_tensor_induction comul (R := R) x with x₁ x₂
+    hopf_tensor_induction comul (R := S) x with x₁ x₂
     hopf_tensor_induction comul (R := R) y with y₁ y₂
     dsimp
-    hopf_tensor_induction comul (R := R) x₂ with x₂₁ x₂₂
+    hopf_tensor_induction comul (R := S) x₂ with x₂₁ x₂₂
     hopf_tensor_induction comul (R := R) y₂ with y₂₁ y₂₂
     rfl
 
 noncomputable
-instance instCoalgebra : Coalgebra R (A ⊗[R] B) where
+instance instCoalgebra : Coalgebra S (A ⊗[R] B) where
   coassoc := coassoc (R := R)
   rTensor_counit_comp_comul := by
     ext x y
-    convert congr((TensorProduct.lid R _).symm
-      (TensorProduct.lid _ _ $(rTensor_counit_comul (R := R) x) ⊗ₜ[R]
+    convert congr((TensorProduct.lid S _).symm
+      (TensorProduct.lid _ _ $(rTensor_counit_comul (R := S) x) ⊗ₜ[R]
         TensorProduct.lid _ _ $(rTensor_counit_comul (R := R) y)))
     · dsimp
-      hopf_tensor_induction comul (R := R) x with x₁ x₂
+      hopf_tensor_induction comul (R := S) x with x₁ x₂
       hopf_tensor_induction comul (R := R) y with y₁ y₂
-      apply (TensorProduct.lid R _).injective
+      apply (TensorProduct.lid S _).injective
       dsimp
-      rw [tmul_smul, mul_smul, one_smul, smul_tmul']
+      rw [tmul_smul, smul_assoc, one_smul, smul_tmul']
     · dsimp
       simp only [one_smul]
   lTensor_counit_comp_comul := by
     ext x y
-    convert congr((TensorProduct.rid R _).symm
-      (TensorProduct.rid _ _ $(lTensor_counit_comul (R := R) x) ⊗ₜ[R]
+    convert congr((TensorProduct.rid S _).symm
+      (TensorProduct.rid _ _ $(lTensor_counit_comul (R := S) x) ⊗ₜ[R]
         TensorProduct.rid _ _ $(lTensor_counit_comul (R := R) y)))
     · dsimp
-      hopf_tensor_induction comul (R := R) x with x₁ x₂
+      hopf_tensor_induction comul (R := S) x with x₁ x₂
       hopf_tensor_induction comul (R := R) y with y₁ y₂
-      apply (TensorProduct.rid R _).injective
+      apply (TensorProduct.rid S _).injective
       dsimp
-      rw [tmul_smul, mul_smul, one_smul, smul_tmul']
+      rw [tmul_smul, smul_assoc, one_smul, smul_tmul']
     · dsimp
       simp only [one_smul]
 
@@ -141,65 +142,65 @@ end TensorProduct
 namespace Coalgebra
 namespace TensorProduct
 
-variable {R M N P Q : Type*} [CommSemiring R]
+variable {R S M N P Q : Type*} [CommSemiring R] [CommSemiring S] [Algebra R S]
   [AddCommMonoid M] [AddCommMonoid N] [AddCommMonoid P] [AddCommMonoid Q] [Module R M] [Module R N]
-  [Module R P] [Module R Q] [Coalgebra R M]
-  [Coalgebra R N] [Coalgebra R P] [Coalgebra R Q]
+  [Module R P] [Module R Q] [Module S M] [IsScalarTower R S M] [Coalgebra S M] [Module S N]
+  [IsScalarTower R S N] [Coalgebra S N] [Coalgebra R P] [Coalgebra R Q]
 
 section
 
 /-- The tensor product of two coalgebra morphisms as a coalgebra morphism. -/
-noncomputable def map (f : M →ₗc[R] N) (g : P →ₗc[R] Q) :
-    M ⊗[R] P →ₗc[R] N ⊗[R] Q where
+noncomputable def map (f : M →ₗc[S] N) (g : P →ₗc[R] Q) :
+    M ⊗[R] P →ₗc[S] N ⊗[R] Q where
   toLinearMap := AlgebraTensorModule.map f.toLinearMap g.toLinearMap
   counit_comp := by ext; simp
   map_comp_comul := by
     ext x y
     dsimp
     simp only [← CoalgHomClass.map_comp_comul_apply]
-    hopf_tensor_induction comul (R := R) x with x₁ x₂
+    hopf_tensor_induction comul (R := S) x with x₁ x₂
     hopf_tensor_induction comul (R := R) y with y₁ y₂
     simp
 
 @[simp]
-theorem map_tmul (f : M →ₗc[R] N) (g : P →ₗc[R] Q) (x : M) (y : P) :
+theorem map_tmul (f : M →ₗc[S] N) (g : P →ₗc[R] Q) (x : M) (y : P) :
     map f g (x ⊗ₜ y) = f x ⊗ₜ g y :=
   rfl
 
 @[simp]
-theorem map_toLinearMap (f : M →ₗc[R] N) (g : P →ₗc[R] Q) :
-    map f g = AlgebraTensorModule.map (f : M →ₗ[R] N) (g : P →ₗ[R] Q) := rfl
+theorem map_toLinearMap (f : M →ₗc[S] N) (g : P →ₗc[R] Q) :
+    map f g = AlgebraTensorModule.map (f : M →ₗ[S] N) (g : P →ₗ[R] Q) := rfl
 
-variable (R M N P)
+variable (R S M N P)
 
 /-- The associator for tensor products of R-coalgebras, as a coalgebra equivalence. -/
 protected noncomputable def assoc :
-    (M ⊗[R] N) ⊗[R] P ≃ₗc[R] M ⊗[R] (N ⊗[R] P) :=
-  { AlgebraTensorModule.assoc R R R M N P with
-    counit_comp := by ext; simp [mul_assoc]
+    (M ⊗[S] N) ⊗[R] P ≃ₗc[S] M ⊗[S] (N ⊗[R] P) :=
+  { AlgebraTensorModule.assoc R S S M N P with
+    counit_comp := by ext; simp
     map_comp_comul := by
       ext x y z
       dsimp
-      hopf_tensor_induction comul (R := R) x with x₁ x₂
-      hopf_tensor_induction comul (R := R) y with y₁ y₂
+      hopf_tensor_induction comul (R := S) x with x₁ x₂
+      hopf_tensor_induction comul (R := S) y with y₁ y₂
       hopf_tensor_induction comul (R := R) z with z₁ z₂
       simp }
 
-variable {R M N P}
+variable {R S M N P}
 
 @[simp]
 theorem assoc_tmul (x : M) (y : N) (z : P) :
-    Coalgebra.TensorProduct.assoc R M N P ((x ⊗ₜ y) ⊗ₜ z) = x ⊗ₜ (y ⊗ₜ z) :=
+    Coalgebra.TensorProduct.assoc R S M N P ((x ⊗ₜ y) ⊗ₜ z) = x ⊗ₜ (y ⊗ₜ z) :=
   rfl
 
 @[simp]
 theorem assoc_symm_tmul (x : M) (y : N) (z : P) :
-    (Coalgebra.TensorProduct.assoc R M N P).symm (x ⊗ₜ (y ⊗ₜ z)) = (x ⊗ₜ y) ⊗ₜ z :=
+    (Coalgebra.TensorProduct.assoc R S M N P).symm (x ⊗ₜ (y ⊗ₜ z)) = (x ⊗ₜ y) ⊗ₜ z :=
   rfl
 
 @[simp]
 theorem assoc_toLinearEquiv :
-    Coalgebra.TensorProduct.assoc R M N P = AlgebraTensorModule.assoc R R R M N P := rfl
+    Coalgebra.TensorProduct.assoc R S M N P = AlgebraTensorModule.assoc R S S M N P := rfl
 
 variable (R P)
 
@@ -227,31 +228,31 @@ theorem lid_tmul (r : R) (a : P) : Coalgebra.TensorProduct.lid R P (r ⊗ₜ a) 
 @[simp]
 theorem lid_symm_apply (a : P) : (Coalgebra.TensorProduct.lid R P).symm a = 1 ⊗ₜ a := rfl
 
-variable (R M)
+variable (R S M)
 
 /-- The base ring is a right identity for the tensor product of coalgebras, up to
 coalgebra equivalence. -/
-protected noncomputable def rid : M ⊗[R] R ≃ₗc[R] M :=
-  { AlgebraTensorModule.rid R R M with
+protected noncomputable def rid : M ⊗[R] R ≃ₗc[S] M :=
+  { AlgebraTensorModule.rid R S M with
     counit_comp := by ext; simp
     map_comp_comul := by
       ext x
       dsimp
       simp only [one_smul]
-      hopf_tensor_induction comul (R := R) x with x₁ x₂
+      hopf_tensor_induction comul (R := S) x with x₁ x₂
       simp }
 
-variable {R M}
+variable {R S M}
 
 @[simp]
 theorem rid_toLinearEquiv :
-    (Coalgebra.TensorProduct.rid R M) = AlgebraTensorModule.rid R R M := rfl
+    (Coalgebra.TensorProduct.rid R S M) = AlgebraTensorModule.rid R S M := rfl
 
 @[simp]
-theorem rid_tmul (r : R) (a : M) : Coalgebra.TensorProduct.rid R M (a ⊗ₜ r) = r • a := rfl
+theorem rid_tmul (r : R) (a : M) : Coalgebra.TensorProduct.rid R S M (a ⊗ₜ r) = r • a := rfl
 
 @[simp]
-theorem rid_symm_apply (a : M) : (Coalgebra.TensorProduct.rid R M).symm a = a ⊗ₜ 1 := rfl
+theorem rid_symm_apply (a : M) : (Coalgebra.TensorProduct.rid R S M).symm a = a ⊗ₜ 1 := rfl
 
 end
 

--- a/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
@@ -18,7 +18,7 @@ in the monoidal structure on `R`-coalgebras, like the tensor product of two coal
 as a coalgebra morphism.
 
 In particular, when `R = S` we get tensor products of coalgebras, and when `A = S` we get
-the base change `S ⊗[R] B` as an `R`-coalgebra.
+the base change `S ⊗[R] B` as an `S`-coalgebra.
 
 -/
 

--- a/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
@@ -9,7 +9,7 @@ import Mathlib.RingTheory.Coalgebra.Equiv
 /-!
 # Tensor products of coalgebras
 
-Suppose `S` is an `A` algebra. Given an `S`-coalgebra `A` and `R`-coalgebra `B`, we can define
+Suppose `S` is an `R`-algebra. Given an `S`-coalgebra `A` and `R`-coalgebra `B`, we can define
 a natural comultiplication map `Δ : A ⊗[R] B → (A ⊗[R] B) ⊗[S] (A ⊗[R] B)`
 and counit map `ε : A ⊗[R] B → S` induced by the comultiplication and counit maps of `A` and `B`.
 

--- a/Mathlib/RingTheory/HopfAlgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/HopfAlgebra/TensorProduct.lean
@@ -17,35 +17,36 @@ open Coalgebra TensorProduct HopfAlgebra
 
 namespace TensorProduct
 
-variable {R A B : Type*} [CommSemiring R] [Semiring A] [Semiring B] [HopfAlgebra R A]
-    [HopfAlgebra R B]
+variable {R S A B : Type*} [CommSemiring R] [CommSemiring S] [Semiring A] [Semiring B]
+    [Algebra R S] [HopfAlgebra R A] [HopfAlgebra S B] [Algebra R B]
+    [IsScalarTower R S B]
 
 noncomputable
-instance : HopfAlgebra R (B ⊗[R] A) where
-  antipode := AlgebraTensorModule.map HopfAlgebra.antipode HopfAlgebra.antipode
+instance : HopfAlgebra S (B ⊗[R] A) where
+  antipode := AlgebraTensorModule.map antipode antipode
   mul_antipode_rTensor_comul := by
     ext x y
-    convert congr($(mul_antipode_rTensor_comul_apply (R := R) x) ⊗ₜ[R]
+    convert congr($(mul_antipode_rTensor_comul_apply (R := S) x) ⊗ₜ[R]
       $(mul_antipode_rTensor_comul_apply (R := R) y)) using 1
     · dsimp
-      hopf_tensor_induction comul (R := R) x with x₁ x₂
+      hopf_tensor_induction comul (R := S) x with x₁ x₂
       hopf_tensor_induction comul (R := R) y with y₁ y₂
       simp
     · dsimp [Algebra.TensorProduct.one_def]
-      simp [Algebra.algebraMap_eq_smul_one, smul_tmul', mul_smul]
+      simp [Algebra.algebraMap_eq_smul_one, smul_tmul']
   mul_antipode_lTensor_comul := by
     ext x y
-    convert congr($(mul_antipode_lTensor_comul_apply (R := R) x) ⊗ₜ[R]
+    convert congr($(mul_antipode_lTensor_comul_apply (R := S) x) ⊗ₜ[R]
       $(mul_antipode_lTensor_comul_apply (R := R) y)) using 1
     · dsimp [Algebra.TensorProduct.one_def]
-      hopf_tensor_induction comul (R := R) x with x₁ x₂
+      hopf_tensor_induction comul (R := S) x with x₁ x₂
       hopf_tensor_induction comul (R := R) y with y₁ y₂
       simp
     · dsimp [Algebra.TensorProduct.one_def]
-      simp [Algebra.algebraMap_eq_smul_one, smul_tmul', mul_smul]
+      simp [Algebra.algebraMap_eq_smul_one, smul_tmul']
 
 @[simp]
 theorem antipode_def :
-    antipode (R := R) (A := B ⊗[R] A) = AlgebraTensorModule.map antipode antipode := rfl
+    antipode (R := S) (A := B ⊗[R] A) = AlgebraTensorModule.map antipode antipode := rfl
 
 end TensorProduct


### PR DESCRIPTION
Suppose `S` is an `R`-algebra. Given an `S`-coalgebra `A` and `R`-coalgebra `B`, we generalize the existing construction to give `A ⊗[R] B` an `S`-coalgebra structure. Similar generalizations are done for bialgebras and Hopf algebras.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [x] depends on: #25196
- [x] depends on: #25216

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
