### PR TITLE
[Merged by Bors] - feat: restricting `Affine.Simplex` to an affine subspace that contains it

### DIFF
--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Basic.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Basic.lean
@@ -575,7 +575,7 @@ theorem map_span (s : Set P₁) : (affineSpan k s).map f = affineSpan k (f '' s)
           subset_affineSpan k _ (mem_image_of_mem f hp)⟩
 
 section inclusion
-variable {S₁ S₂ : AffineSubspace k P₁} [Nonempty S₁] [Nonempty S₂]
+variable {S₁ S₂ : AffineSubspace k P₁} [Nonempty S₁]
 
 attribute [local instance] AffineSubspace.toAddTorsor
 
@@ -583,10 +583,13 @@ attribute [local instance] AffineSubspace.toAddTorsor
 
 This is the affine version of `Submodule.inclusion`. -/
 @[simps linear]
-def inclusion (h : S₁ ≤ S₂) : S₁ →ᵃ[k] S₂ where
-  toFun := Set.inclusion h
-  linear := Submodule.inclusion <| AffineSubspace.direction_le h
-  map_vadd' := fun ⟨_,_⟩ ⟨_,_⟩ => rfl
+def inclusion (h : S₁ ≤ S₂) :
+    letI := Nonempty.map (Set.inclusion h) ‹_›
+    S₁ →ᵃ[k] S₂ :=
+  letI := Nonempty.map (Set.inclusion h) ‹_›
+  { toFun := Set.inclusion h
+    linear := Submodule.inclusion <| AffineSubspace.direction_le h
+    map_vadd' := fun ⟨_,_⟩ ⟨_,_⟩ => rfl }
 
 @[simp]
 theorem coe_inclusion_apply (h : S₁ ≤ S₂) (x : S₁) : (inclusion h x : P₁) = x :=

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Basic.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Basic.lean
@@ -574,6 +574,10 @@ theorem map_span (s : Set P₁) : (affineSpan k s).map f = affineSpan k (f '' s)
   · exact ⟨f p, mem_image_of_mem f (subset_affineSpan k _ hp),
           subset_affineSpan k _ (mem_image_of_mem f hp)⟩
 
+@[gcongr]
+theorem map_mono {s₁ s₂ : AffineSubspace k P₁} (h : s₁ ≤ s₂) : s₁.map f ≤ s₂.map f :=
+  Set.image_mono h
+
 section inclusion
 variable {S₁ S₂ : AffineSubspace k P₁} [Nonempty S₁]
 

--- a/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
@@ -965,6 +965,13 @@ theorem restrict_map_inclusion {n : ℕ} (s : Affine.Simplex k P n)
       s.restrict S₂ (hS₁.trans hS₂) :=
   rfl
 
+@[simp]
+theorem map_subtype_restrict
+    {n : ℕ} (S : AffineSubspace k P) [Nonempty S] (s : Affine.Simplex k S n) :
+    (s.map (AffineSubspace.subtype _) Subtype.coe_injective).restrict
+      S (affineSpan_le.2 <| by rintro x ⟨y, rfl⟩; exact Subtype.prop _) = s := by
+  rfl
+
 /-- Restricting to `S₁` then mapping through the restriction of `f` to `S₁ →ᵃ[k] S₂` is the same
 as mapping through unrestricted `f`, then restricting to `S₂`. -/
 theorem restrict_map_restrict

--- a/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
@@ -8,6 +8,7 @@ import Mathlib.Data.Fin.VecNotation
 import Mathlib.Data.Sign
 import Mathlib.LinearAlgebra.AffineSpace.Combination
 import Mathlib.LinearAlgebra.AffineSpace.AffineEquiv
+import Mathlib.LinearAlgebra.AffineSpace.Restrict
 import Mathlib.LinearAlgebra.Basis.VectorSpace
 
 /-!
@@ -962,16 +963,30 @@ theorem restrict_map_inclusion {n : ℕ} (s : Affine.Simplex k P n)
     letI := Nonempty.map (Set.inclusion hS₂) ‹_›
     (s.restrict S₁ hS₁).map (AffineSubspace.inclusion hS₂) (Set.inclusion_injective hS₂) =
       s.restrict S₂ (hS₁.trans hS₂) :=
-  letI := Nonempty.map (AffineSubspace.inclusion hS₁) inferInstance
-  letI := Nonempty.map (Set.inclusion hS₂) ‹_›
-  Affine.Simplex.ext fun _i => rfl
+  rfl
+
+/-- Restricting to `S₁` then mapping through the restriction of `f` to `S₁ →ᵃ[k] S₂` is the same
+as mapping through unrestricted `f`, then restricting to `S₂`. -/
+theorem restrict_map_restrict
+    {n : ℕ} (s : Affine.Simplex k P n) (f : P →ᵃ[k] P₂) (hf : Function.Injective f)
+    (S₁ : AffineSubspace k P) (S₂ : AffineSubspace k P₂)
+    (hS₁ : affineSpan k (Set.range s.points) ≤ S₁) (hfS : AffineSubspace.map f S₁ ≤ S₂) :
+    letI := Nonempty.map (AffineSubspace.inclusion hS₁) inferInstance
+    letI : Nonempty (S₁.map f) := AffineSubspace.nonempty_map
+    letI := Nonempty.map (AffineSubspace.inclusion hfS) inferInstance
+    (s.restrict S₁ hS₁).map (f.restrict hfS) (AffineMap.restrict.injective hf _) =
+      (s.map f hf).restrict S₂ (
+        Eq.trans_le
+          (by simp [AffineSubspace.map_span, Set.range_comp])
+          (AffineSubspace.map_mono f hS₁) |>.trans hfS) := by
+  rfl
 
 /-- Restricting to `affineSpan k (Set.range s.points)` can be reversed by mapping through
 `AffineSubspace.subtype`. -/
 @[simp]
 theorem restrict_map_subtype {n : ℕ} (s : Affine.Simplex k P n) :
     (s.restrict _ le_rfl).map (AffineSubspace.subtype _) Subtype.coe_injective = s :=
-  Affine.Simplex.ext fun _i => rfl
+  rfl
 
 end restrict
 

--- a/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
@@ -941,6 +941,40 @@ theorem reindex_map {m n : ℕ} (s : Simplex k P m) (e : Fin (m + 1) ≃ Fin (n 
     (s.map f hf).reindex e = (s.reindex e).map f hf :=
   rfl
 
+section restrict
+attribute [local instance] AffineSubspace.toAddTorsor
+
+/-- Restrict an affine simplex to an affine subspace that contains it. -/
+@[simps]
+def restrict {n : ℕ} (s : Affine.Simplex k P n) (S : AffineSubspace k P)
+    (hS : affineSpan k (Set.range s.points) ≤ S) :
+    letI := Nonempty.map (AffineSubspace.inclusion hS) inferInstance
+    Affine.Simplex (V := S.direction) k S n :=
+  letI := Nonempty.map (AffineSubspace.inclusion hS) inferInstance
+  { points i := ⟨s.points i, hS <| mem_affineSpan _ <| Set.mem_range_self _⟩
+    independent := AffineIndependent.of_comp S.subtype s.independent }
+
+/-- Restricting to `S₁` then mapping to a larger `S₂` is the same as restricting to `S₂`. -/
+@[simp]
+theorem restrict_map_inclusion {n : ℕ} (s : Affine.Simplex k P n)
+    (S₁ S₂ : AffineSubspace k P) (hS₁) (hS₂ : S₁ ≤ S₂) :
+    letI := Nonempty.map (AffineSubspace.inclusion hS₁) inferInstance
+    letI := Nonempty.map (Set.inclusion hS₂) ‹_›
+    (s.restrict S₁ hS₁).map (AffineSubspace.inclusion hS₂) (Set.inclusion_injective hS₂) =
+      s.restrict S₂ (hS₁.trans hS₂) :=
+  letI := Nonempty.map (AffineSubspace.inclusion hS₁) inferInstance
+  letI := Nonempty.map (Set.inclusion hS₂) ‹_›
+  Affine.Simplex.ext fun _i => rfl
+
+/-- Restricting to `affineSpan k (Set.range s.points)` can be reversed by mapping through
+`AffineSubspace.subtype`. -/
+@[simp]
+theorem restrict_map_subtype {n : ℕ} (s : Affine.Simplex k P n) :
+    (s.restrict _ le_rfl).map (AffineSubspace.subtype _) Subtype.coe_injective = s :=
+  Affine.Simplex.ext fun _i => rfl
+
+end restrict
+
 end Simplex
 
 end Affine


### PR DESCRIPTION
Also removes a redundant `Nonempty` argument.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
