### PR TITLE
feat(Geometry/Euclidean/Congurence): add triangle congruence

### DIFF
--- a/Mathlib/Geometry/Euclidean/Congruence.lean
+++ b/Mathlib/Geometry/Euclidean/Congruence.lean
@@ -43,10 +43,10 @@ variable {ι V₁ V₂ P₁ P₂ : Type*}
   {v₁ : ι → P₁} {v₂ : ι → P₂}
   {a b c : P₁} {a' b' c' :P₂}
 
-lemma triangle_congruent_iff_dist_eq {t₁ : Fin 3 → P₁} {t₂: Fin 3 → P₂} : t₁ ≅ t₂ ↔
-  ∀ (i j : Fin 3),dist (t₁ i) (t₁ j) = dist (t₂ i) (t₂ j) := by
+lemma triangle_congruent_iff_dist_eq {t₁ : Fin 3 → P₁} {t₂: Fin 3 → P₂} :
+    t₁ ≅ t₂ ↔ ∀ (i j : Fin 3),dist (t₁ i) (t₁ j) = dist (t₂ i) (t₂ j) := by
   constructor
-  · rw [←congruent_iff_dist_eq]
+  · rw [← congruent_iff_dist_eq]
     simp
   · rw [congruent_iff_dist_eq]
     intro h i j
@@ -54,7 +54,7 @@ lemma triangle_congruent_iff_dist_eq {t₁ : Fin 3 → P₁} {t₂: Fin 3 → P�
 
 /-- Side Side Side, possibly degenerate. -/
 theorem side_side_side (hd₁ : dist a b = dist a' b') (hd₂ : dist b c = dist b' c')
-  (hd₃ : dist c a = dist c' a') :
+    (hd₃ : dist c a = dist c' a') :
   ![a,b,c] ≅ ![a',b',c'] := by
   rw [triangle_congruent_iff_dist_eq]
   intro i j
@@ -62,43 +62,38 @@ theorem side_side_side (hd₁ : dist a b = dist a' b') (hd₂ : dist b c = dist 
 
 /-- Side Angle Side, possibly degenerate. -/
 theorem side_angle_side (h : ∠ a b c = ∠ a' b' c') (hd₁ : dist a b = dist a' b')
-  (hd₂ : dist b c = dist b' c') :
-  ![a,b,c] ≅ ![a',b',c'] := by
+    (hd₂ : dist b c = dist b' c') : ![a,b,c] ≅ ![a',b',c'] := by
   rw [triangle_congruent_iff_dist_eq]
   have h1:= EuclideanGeometry.law_cos a b c
   have h2:= EuclideanGeometry.law_cos a' b' c'
   have hdist: dist a c * dist a c = dist a' c' * dist a' c' := by
     rw [h1, h2]
     field_simp [h, hd₁, hd₂, dist_comm]
-  simp [←pow_two] at hdist
+  simp [← pow_two] at hdist
   rw [sq_eq_sq₀ (by positivity) (by positivity)] at hdist
   intro i j
   fin_cases i <;> fin_cases j <;> try simp_all [hd₁, hd₂, hdist, dist_comm]
 
 /-- Angle Side Angle, require not collinear. -/
-theorem angle_side_angle
-  (hindep: AffineIndependent ℝ ![a,b,c])
-  (hindep': AffineIndependent ℝ ![a',b',c'])
-  (ha₁ : ∠ a b c = ∠ a' b' c')
-  (hd : dist b c = dist b' c')
-  (ha₂ : ∠ b c a = ∠ b' c' a') :
-  ![a,b,c] ≅ ![a',b',c'] := by
+theorem angle_side_angle (hindep: AffineIndependent ℝ ![a,b,c])
+    (hindep': AffineIndependent ℝ ![a',b',c']) (ha₁ : ∠ a b c = ∠ a' b' c')
+    (hd : dist b c = dist b' c') (ha₂ : ∠ b c a = ∠ b' c' a') : ![a,b,c] ≅ ![a',b',c'] := by
   have h_ab1: b ≠ a := hindep.injective.ne (by decide : (1 : Fin 3) ≠ 0)
   have h_ac1: c ≠ a := hindep.injective.ne (by decide : (2 : Fin 3) ≠ 0)
   have ha₃:= angle_add_angle_add_angle_eq_pi h_ab1 h_ac1
   have h_ab2: b' ≠ a' := hindep'.injective.ne (by decide : (1 : Fin 3) ≠ 0)
   have h_ac2: c' ≠ a' := hindep'.injective.ne (by decide : (2 : Fin 3) ≠ 0)
   have ha₃':= angle_add_angle_add_angle_eq_pi h_ab2 h_ac2
-  rw [←ha₃'] at ha₃
+  rw [← ha₃'] at ha₃
   rw [ha₁,ha₂,angle_comm b' c' a',add_left_cancel_iff] at ha₃
   have h_indep_bac: AffineIndependent ℝ ![b,a,c] := by
-      rw [←affineIndependent_equiv (Equiv.swap (0 : Fin 3) 1)]
-      convert hindep using 1
-      ext x; fin_cases x <;> rfl
+    rw [← affineIndependent_equiv (Equiv.swap (0 : Fin 3) 1)]
+    convert hindep using 1
+    ext x; fin_cases x <;> rfl
   have h_indep_bac': AffineIndependent ℝ ![b',a',c'] := by
-      rw [←affineIndependent_equiv (Equiv.swap (0 : Fin 3) 1)]
-      convert hindep' using 1
-      ext x; fin_cases x <;> rfl
+    rw [← affineIndependent_equiv (Equiv.swap (0 : Fin 3) 1)]
+    convert hindep' using 1
+    ext x; fin_cases x <;> rfl
   have dist_ab_eq: dist a b = dist a' b' := by
     rw [dist_comm a b, dist_comm a' b']
     rw [dist_eq_dist_mul_sin_angle_div_sin_angle h_indep_bac]
@@ -108,29 +103,25 @@ theorem angle_side_angle
   exact side_angle_side ha₁ dist_ab_eq hd
 
 /-- Angle Angle Side, require not collinear. -/
-theorem angle_angle_side
-  (hindep: AffineIndependent ℝ ![a,b,c])
-  (hindep': AffineIndependent ℝ ![a',b',c'])
-  (ha₁ : ∠ a b c = ∠ a' b' c')
-  (ha₂ : ∠ b c a = ∠ b' c' a')
-  (hd : dist c a = dist c' a') :
-  ![a,b,c] ≅ ![a',b',c'] := by
+theorem angle_angle_side (hindep: AffineIndependent ℝ ![a,b,c])
+    (hindep': AffineIndependent ℝ ![a',b',c']) (ha₁ : ∠ a b c = ∠ a' b' c')
+    (ha₂ : ∠ b c a = ∠ b' c' a') (hd : dist c a = dist c' a') : ![a,b,c] ≅ ![a',b',c'] := by
   have h_ab1: b ≠ a := hindep.injective.ne (by decide : (1 : Fin 3) ≠ 0)
   have h_ac1: c ≠ a := hindep.injective.ne (by decide : (2 : Fin 3) ≠ 0)
   have ha₃:= angle_add_angle_add_angle_eq_pi h_ab1 h_ac1
   have h_ab2: b' ≠ a' := hindep'.injective.ne (by decide : (1 : Fin 3) ≠ 0)
   have h_ac2: c' ≠ a' := hindep'.injective.ne (by decide : (2 : Fin 3) ≠ 0)
   have ha₃':= angle_add_angle_add_angle_eq_pi h_ab2 h_ac2
-  rw [←ha₃'] at ha₃
+  rw [← ha₃'] at ha₃
   rw [ha₁,ha₂,angle_comm b' c' a',add_left_cancel_iff] at ha₃
   have h_indep_bca: AffineIndependent ℝ ![b,c,a] := by
-      rw [←affineIndependent_equiv (Equiv.swap (1 : Fin 3) 2)]
-      rw [←affineIndependent_equiv (Equiv.swap (0 : Fin 3) 1)]
-      convert hindep using 1
-      ext x; fin_cases x <;> rfl
+    rw [← affineIndependent_equiv (Equiv.swap (1 : Fin 3) 2)]
+    rw [← affineIndependent_equiv (Equiv.swap (0 : Fin 3) 1)]
+    convert hindep using 1
+    ext x; fin_cases x <;> rfl
   have h_indep_bca': AffineIndependent ℝ ![b',c',a'] := by
-    rw [←affineIndependent_equiv (Equiv.swap (1 : Fin 3) 2)]
-    rw [←affineIndependent_equiv (Equiv.swap (0 : Fin 3) 1)]
+    rw [← affineIndependent_equiv (Equiv.swap (1 : Fin 3) 2)]
+    rw [← affineIndependent_equiv (Equiv.swap (0 : Fin 3) 1)]
     convert hindep' using 1
     ext x; fin_cases x <;> rfl
   have h:= angle_side_angle h_indep_bca h_indep_bca' ha₂ hd ha₃
@@ -140,14 +131,14 @@ theorem angle_angle_side
 include V₁ V₂
 
 /-- Corresponding angles are equal for congruent triangles. -/
-theorem angle_eq (h: v₁ ≅ v₂) (i j k : ι) :
-  ∠ (v₁ i) (v₁ j) (v₁ k) = ∠ (v₂ i) (v₂ j) (v₂ k) := by
+theorem angle_eq_of_congruent (h: v₁ ≅ v₂) (i j k : ι) :
+    ∠ (v₁ i) (v₁ j) (v₁ k) = ∠ (v₂ i) (v₂ j) (v₂ k) := by
   unfold EuclideanGeometry.angle
   unfold InnerProductGeometry.angle
   have key := abs_le.1 (abs_real_inner_div_norm_mul_norm_le_one (v₁ i -ᵥ v₁ j) (v₁ k -ᵥ v₁ j))
   have key':= abs_le.1 (abs_real_inner_div_norm_mul_norm_le_one (v₂ i -ᵥ v₂ j) (v₂ k -ᵥ v₂ j))
   rw [Real.arccos_inj key.1 key.2 key'.1 key'.2]
-  simp_all [real_inner_eq_norm_mul_self_add_norm_mul_self_sub_norm_sub_mul_self_div_two,
-    ←dist_eq_norm_vsub,h.dist_eq]
+  simp [real_inner_eq_norm_mul_self_add_norm_mul_self_sub_norm_sub_mul_self_div_two]
+  simp [← dist_eq_norm_vsub,h.dist_eq]
 
 end EuclideanGeometry

--- a/Mathlib/Geometry/Euclidean/Congruence.lean
+++ b/Mathlib/Geometry/Euclidean/Congruence.lean
@@ -1,0 +1,153 @@
+/-
+Copyright (c) 2023 Jovan Gerbscheid. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jovan Gerbscheid, Chu Zheng
+-/
+
+import Mathlib.Topology.MetricSpace.Congruence
+import Mathlib.Analysis.InnerProductSpace.Basic
+import Mathlib.Analysis.Normed.Group.AddTorsor
+import Mathlib.Geometry.Euclidean.Angle.Unoriented.Affine
+import Mathlib.Geometry.Euclidean.Triangle
+
+/-!
+# Triangle congruence
+
+This file proves the classical triangle congruence criteria for (possibly degenerate) triangles
+in real inner product spaces and Euclidean affine spaces.
+We prove SSS, SAS ASA, and AAS congruence.
+
+## Implementation notes
+
+Side–Side–Side (SSS) congruence is proved using the definition of `Congruent`.
+Side–Angle–Side (SAS) congruence is proved via the law of cosines.
+Angle–Side–Angle (ASA) congruence is reduced to SAS using the law of sines.
+Angle–Angle–Side (AAS) congruence uses the fact that the sum of the angles in a triangle equals π,
+then reduces to ASA.
+
+## References
+
+* https://en.wikipedia.org/wiki/Congruence_(geometry)
+
+-/
+
+open scoped Congruent
+
+namespace EuclideanGeometry
+
+variable {ι V₁ V₂ P₁ P₂ : Type*}
+  [NormedAddCommGroup V₁] [NormedAddCommGroup V₂]
+  [InnerProductSpace ℝ V₁] [InnerProductSpace ℝ V₂]
+  [MetricSpace P₁] [MetricSpace P₂]
+  [NormedAddTorsor V₁ P₁]   [NormedAddTorsor V₂ P₂]
+  {v₁ : ι → P₁} {v₂ : ι → P₂}
+  {a b c : P₁} {a' b' c' :P₂}
+
+lemma triangle_congruent_iff_dist_eq {t₁ : Fin 3 → P₁} {t₂: Fin 3 → P₂} : t₁ ≅ t₂ ↔
+  ∀ (i j : Fin 3),dist (t₁ i) (t₁ j) = dist (t₂ i) (t₂ j) := by
+  constructor
+  · rw [←congruent_iff_dist_eq]
+    simp
+  · rw [congruent_iff_dist_eq]
+    intro h i j
+    rw [h i j]
+
+/-- Side Side Side, possibly degenerate. -/
+theorem side_side_side (hd₁ : dist a b = dist a' b') (hd₂ : dist b c = dist b' c')
+  (hd₃ : dist c a = dist c' a') :
+  ![a,b,c] ≅ ![a',b',c'] := by
+  rw [triangle_congruent_iff_dist_eq]
+  intro i j
+  fin_cases i <;> fin_cases j <;> try simp_all [hd₁, hd₂, hd₃, dist_comm]
+
+/-- Side Angle Side, possibly degenerate. -/
+theorem side_angle_side (h : ∠ a b c = ∠ a' b' c') (hd₁ : dist a b = dist a' b')
+  (hd₂ : dist b c = dist b' c') :
+  ![a,b,c] ≅ ![a',b',c'] := by
+  rw [triangle_congruent_iff_dist_eq]
+  have h1:= EuclideanGeometry.law_cos a b c
+  have h2:= EuclideanGeometry.law_cos a' b' c'
+  have hdist: dist a c * dist a c = dist a' c' * dist a' c' := by
+    rw [h1, h2]
+    field_simp [h, hd₁, hd₂, dist_comm]
+  simp [←pow_two] at hdist
+  rw [sq_eq_sq₀ (by positivity) (by positivity)] at hdist
+  intro i j
+  fin_cases i <;> fin_cases j <;> try simp_all [hd₁, hd₂, hdist, dist_comm]
+
+/-- Angle Side Angle, require not collinear. -/
+theorem angle_side_angle
+  (hindep: AffineIndependent ℝ ![a,b,c])
+  (hindep': AffineIndependent ℝ ![a',b',c'])
+  (ha₁ : ∠ a b c = ∠ a' b' c')
+  (hd : dist b c = dist b' c')
+  (ha₂ : ∠ b c a = ∠ b' c' a') :
+  ![a,b,c] ≅ ![a',b',c'] := by
+  have h_ab1: b ≠ a := hindep.injective.ne (by decide : (1 : Fin 3) ≠ 0)
+  have h_ac1: c ≠ a := hindep.injective.ne (by decide : (2 : Fin 3) ≠ 0)
+  have ha₃:= angle_add_angle_add_angle_eq_pi h_ab1 h_ac1
+  have h_ab2: b' ≠ a' := hindep'.injective.ne (by decide : (1 : Fin 3) ≠ 0)
+  have h_ac2: c' ≠ a' := hindep'.injective.ne (by decide : (2 : Fin 3) ≠ 0)
+  have ha₃':= angle_add_angle_add_angle_eq_pi h_ab2 h_ac2
+  rw [←ha₃'] at ha₃
+  rw [ha₁,ha₂,angle_comm b' c' a',add_left_cancel_iff] at ha₃
+  have h_indep_bac: AffineIndependent ℝ ![b,a,c] := by
+      rw [←affineIndependent_equiv (Equiv.swap (0 : Fin 3) 1)]
+      convert hindep using 1
+      ext x; fin_cases x <;> rfl
+  have h_indep_bac': AffineIndependent ℝ ![b',a',c'] := by
+      rw [←affineIndependent_equiv (Equiv.swap (0 : Fin 3) 1)]
+      convert hindep' using 1
+      ext x; fin_cases x <;> rfl
+  have dist_ab_eq: dist a b = dist a' b' := by
+    rw [dist_comm a b, dist_comm a' b']
+    rw [dist_eq_dist_mul_sin_angle_div_sin_angle h_indep_bac]
+    rw [dist_eq_dist_mul_sin_angle_div_sin_angle h_indep_bac']
+    rw [dist_comm c b, dist_comm c' b']
+    rw [hd,angle_comm,ha₂,angle_comm b' c' a',angle_comm b a c,ha₃,angle_comm b' a' c']
+  exact side_angle_side ha₁ dist_ab_eq hd
+
+/-- Angle Angle Side, require not collinear. -/
+theorem angle_angle_side
+  (hindep: AffineIndependent ℝ ![a,b,c])
+  (hindep': AffineIndependent ℝ ![a',b',c'])
+  (ha₁ : ∠ a b c = ∠ a' b' c')
+  (ha₂ : ∠ b c a = ∠ b' c' a')
+  (hd : dist c a = dist c' a') :
+  ![a,b,c] ≅ ![a',b',c'] := by
+  have h_ab1: b ≠ a := hindep.injective.ne (by decide : (1 : Fin 3) ≠ 0)
+  have h_ac1: c ≠ a := hindep.injective.ne (by decide : (2 : Fin 3) ≠ 0)
+  have ha₃:= angle_add_angle_add_angle_eq_pi h_ab1 h_ac1
+  have h_ab2: b' ≠ a' := hindep'.injective.ne (by decide : (1 : Fin 3) ≠ 0)
+  have h_ac2: c' ≠ a' := hindep'.injective.ne (by decide : (2 : Fin 3) ≠ 0)
+  have ha₃':= angle_add_angle_add_angle_eq_pi h_ab2 h_ac2
+  rw [←ha₃'] at ha₃
+  rw [ha₁,ha₂,angle_comm b' c' a',add_left_cancel_iff] at ha₃
+  have h_indep_bca: AffineIndependent ℝ ![b,c,a] := by
+      rw [←affineIndependent_equiv (Equiv.swap (1 : Fin 3) 2)]
+      rw [←affineIndependent_equiv (Equiv.swap (0 : Fin 3) 1)]
+      convert hindep using 1
+      ext x; fin_cases x <;> rfl
+  have h_indep_bca': AffineIndependent ℝ ![b',c',a'] := by
+    rw [←affineIndependent_equiv (Equiv.swap (1 : Fin 3) 2)]
+    rw [←affineIndependent_equiv (Equiv.swap (0 : Fin 3) 1)]
+    convert hindep' using 1
+    ext x; fin_cases x <;> rfl
+  have h:= angle_side_angle h_indep_bca h_indep_bca' ha₂ hd ha₃
+  have h_bc: dist b c = dist b' c':=by exact h.dist_eq 0 1
+  exact angle_side_angle hindep hindep' ha₁ h_bc ha₂
+
+include V₁ V₂
+
+/-- Corresponding angles are equal for congruent triangles. -/
+theorem angle_eq (h: v₁ ≅ v₂) (i j k : ι) :
+  ∠ (v₁ i) (v₁ j) (v₁ k) = ∠ (v₂ i) (v₂ j) (v₂ k) := by
+  unfold EuclideanGeometry.angle
+  unfold InnerProductGeometry.angle
+  have key := abs_le.1 (abs_real_inner_div_norm_mul_norm_le_one (v₁ i -ᵥ v₁ j) (v₁ k -ᵥ v₁ j))
+  have key':= abs_le.1 (abs_real_inner_div_norm_mul_norm_le_one (v₂ i -ᵥ v₂ j) (v₂ k -ᵥ v₂ j))
+  rw [Real.arccos_inj key.1 key.2 key'.1 key'.2]
+  simp_all [real_inner_eq_norm_mul_self_add_norm_mul_self_sub_norm_sub_mul_self_div_two,
+    ←dist_eq_norm_vsub,h.dist_eq]
+
+end EuclideanGeometry

--- a/Mathlib/Geometry/Euclidean/Congruence.lean
+++ b/Mathlib/Geometry/Euclidean/Congruence.lean
@@ -64,9 +64,9 @@ theorem side_side_side (hd₁ : dist a b = dist a' b') (hd₂ : dist b c = dist 
 theorem side_angle_side (h : ∠ a b c = ∠ a' b' c') (hd₁ : dist a b = dist a' b')
     (hd₂ : dist b c = dist b' c') : ![a,b,c] ≅ ![a',b',c'] := by
   rw [triangle_congruent_iff_dist_eq]
-  have h1:= EuclideanGeometry.law_cos a b c
-  have h2:= EuclideanGeometry.law_cos a' b' c'
-  have hdist: dist a c * dist a c = dist a' c' * dist a' c' := by
+  have h1 := EuclideanGeometry.law_cos a b c
+  have h2 := EuclideanGeometry.law_cos a' b' c'
+  have hdist : dist a c * dist a c = dist a' c' * dist a' c' := by
     rw [h1, h2]
     field_simp [h, hd₁, hd₂, dist_comm]
   simp [← pow_two] at hdist
@@ -76,16 +76,16 @@ theorem side_angle_side (h : ∠ a b c = ∠ a' b' c') (hd₁ : dist a b = dist 
 
 /-- Angle Side Angle, require not collinear. -/
 theorem angle_side_angle (hindep: AffineIndependent ℝ ![a,b,c])
-    (hindep': AffineIndependent ℝ ![a',b',c']) (ha₁ : ∠ a b c = ∠ a' b' c')
+    (hindep' : AffineIndependent ℝ ![a',b',c']) (ha₁ : ∠ a b c = ∠ a' b' c')
     (hd : dist b c = dist b' c') (ha₂ : ∠ b c a = ∠ b' c' a') : ![a,b,c] ≅ ![a',b',c'] := by
-  have h_ab1: b ≠ a := hindep.injective.ne (by decide : (1 : Fin 3) ≠ 0)
-  have h_ac1: c ≠ a := hindep.injective.ne (by decide : (2 : Fin 3) ≠ 0)
-  have ha₃:= angle_add_angle_add_angle_eq_pi h_ab1 h_ac1
-  have h_ab2: b' ≠ a' := hindep'.injective.ne (by decide : (1 : Fin 3) ≠ 0)
-  have h_ac2: c' ≠ a' := hindep'.injective.ne (by decide : (2 : Fin 3) ≠ 0)
-  have ha₃':= angle_add_angle_add_angle_eq_pi h_ab2 h_ac2
+  have h_ab1 : b ≠ a := hindep.injective.ne (by decide : (1 : Fin 3) ≠ 0)
+  have h_ac1 : c ≠ a := hindep.injective.ne (by decide : (2 : Fin 3) ≠ 0)
+  have ha₃ := angle_add_angle_add_angle_eq_pi h_ab1 h_ac1
+  have h_ab2 : b' ≠ a' := hindep'.injective.ne (by decide : (1 : Fin 3) ≠ 0)
+  have h_ac2 : c' ≠ a' := hindep'.injective.ne (by decide : (2 : Fin 3) ≠ 0)
+  have ha₃' := angle_add_angle_add_angle_eq_pi h_ab2 h_ac2
   rw [← ha₃'] at ha₃
-  rw [ha₁,ha₂,angle_comm b' c' a',add_left_cancel_iff] at ha₃
+  rw [ha₁, ha₂, angle_comm b' c' a', add_left_cancel_iff] at ha₃
   have h_indep_bac: AffineIndependent ℝ ![b,a,c] := by
     rw [← affineIndependent_equiv (Equiv.swap (0 : Fin 3) 1)]
     convert hindep using 1
@@ -99,33 +99,33 @@ theorem angle_side_angle (hindep: AffineIndependent ℝ ![a,b,c])
     rw [dist_eq_dist_mul_sin_angle_div_sin_angle h_indep_bac]
     rw [dist_eq_dist_mul_sin_angle_div_sin_angle h_indep_bac']
     rw [dist_comm c b, dist_comm c' b']
-    rw [hd,angle_comm,ha₂,angle_comm b' c' a',angle_comm b a c,ha₃,angle_comm b' a' c']
+    rw [hd, angle_comm, ha₂, angle_comm b' c' a', angle_comm b a c, ha₃, angle_comm b' a' c']
   exact side_angle_side ha₁ dist_ab_eq hd
 
 /-- Angle Angle Side, require not collinear. -/
-theorem angle_angle_side (hindep: AffineIndependent ℝ ![a,b,c])
-    (hindep': AffineIndependent ℝ ![a',b',c']) (ha₁ : ∠ a b c = ∠ a' b' c')
+theorem angle_angle_side (hindep : AffineIndependent ℝ ![a,b,c])
+    (hindep' : AffineIndependent ℝ ![a',b',c']) (ha₁ : ∠ a b c = ∠ a' b' c')
     (ha₂ : ∠ b c a = ∠ b' c' a') (hd : dist c a = dist c' a') : ![a,b,c] ≅ ![a',b',c'] := by
-  have h_ab1: b ≠ a := hindep.injective.ne (by decide : (1 : Fin 3) ≠ 0)
-  have h_ac1: c ≠ a := hindep.injective.ne (by decide : (2 : Fin 3) ≠ 0)
-  have ha₃:= angle_add_angle_add_angle_eq_pi h_ab1 h_ac1
-  have h_ab2: b' ≠ a' := hindep'.injective.ne (by decide : (1 : Fin 3) ≠ 0)
-  have h_ac2: c' ≠ a' := hindep'.injective.ne (by decide : (2 : Fin 3) ≠ 0)
-  have ha₃':= angle_add_angle_add_angle_eq_pi h_ab2 h_ac2
+  have h_ab1 : b ≠ a := hindep.injective.ne (by decide : (1 : Fin 3) ≠ 0)
+  have h_ac1 : c ≠ a := hindep.injective.ne (by decide : (2 : Fin 3) ≠ 0)
+  have ha₃ := angle_add_angle_add_angle_eq_pi h_ab1 h_ac1
+  have h_ab2 : b' ≠ a' := hindep'.injective.ne (by decide : (1 : Fin 3) ≠ 0)
+  have h_ac2 : c' ≠ a' := hindep'.injective.ne (by decide : (2 : Fin 3) ≠ 0)
+  have ha₃' := angle_add_angle_add_angle_eq_pi h_ab2 h_ac2
   rw [← ha₃'] at ha₃
-  rw [ha₁,ha₂,angle_comm b' c' a',add_left_cancel_iff] at ha₃
-  have h_indep_bca: AffineIndependent ℝ ![b,c,a] := by
+  rw [ha₁, ha₂, angle_comm b' c' a', add_left_cancel_iff] at ha₃
+  have h_indep_bca : AffineIndependent ℝ ![b,c,a] := by
     rw [← affineIndependent_equiv (Equiv.swap (1 : Fin 3) 2)]
     rw [← affineIndependent_equiv (Equiv.swap (0 : Fin 3) 1)]
     convert hindep using 1
     ext x; fin_cases x <;> rfl
-  have h_indep_bca': AffineIndependent ℝ ![b',c',a'] := by
+  have h_indep_bca' : AffineIndependent ℝ ![b',c',a'] := by
     rw [← affineIndependent_equiv (Equiv.swap (1 : Fin 3) 2)]
     rw [← affineIndependent_equiv (Equiv.swap (0 : Fin 3) 1)]
     convert hindep' using 1
     ext x; fin_cases x <;> rfl
-  have h:= angle_side_angle h_indep_bca h_indep_bca' ha₂ hd ha₃
-  have h_bc: dist b c = dist b' c':=by exact h.dist_eq 0 1
+  have h := angle_side_angle h_indep_bca h_indep_bca' ha₂ hd ha₃
+  have h_bc : dist b c = dist b' c' := by exact h.dist_eq 0 1
   exact angle_side_angle hindep hindep' ha₁ h_bc ha₂
 
 include V₁ V₂
@@ -136,9 +136,9 @@ theorem angle_eq_of_congruent (h: v₁ ≅ v₂) (i j k : ι) :
   unfold EuclideanGeometry.angle
   unfold InnerProductGeometry.angle
   have key := abs_le.1 (abs_real_inner_div_norm_mul_norm_le_one (v₁ i -ᵥ v₁ j) (v₁ k -ᵥ v₁ j))
-  have key':= abs_le.1 (abs_real_inner_div_norm_mul_norm_le_one (v₂ i -ᵥ v₂ j) (v₂ k -ᵥ v₂ j))
+  have key' := abs_le.1 (abs_real_inner_div_norm_mul_norm_le_one (v₂ i -ᵥ v₂ j) (v₂ k -ᵥ v₂ j))
   rw [Real.arccos_inj key.1 key.2 key'.1 key'.2]
   simp [real_inner_eq_norm_mul_self_add_norm_mul_self_sub_norm_sub_mul_self_div_two]
-  simp [← dist_eq_norm_vsub,h.dist_eq]
+  simp [← dist_eq_norm_vsub, h.dist_eq]
 
 end EuclideanGeometry

--- a/Mathlib/Geometry/Euclidean/Triangle.lean
+++ b/Mathlib/Geometry/Euclidean/Triangle.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2020 Joseph Myers. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Joseph Myers, Manuel Candales, Chu Zheng
+Authors: Joseph Myers, Manuel Candales
 -/
 import Mathlib.Geometry.Euclidean.Angle.Oriented.Affine
 import Mathlib.Geometry.Euclidean.Angle.Unoriented.Affine
@@ -67,13 +67,13 @@ theorem sin_angle_mul_norm_eq_sin_angle_mul_norm (x y : V) :
     simp [hxl]
     cases eq_or_ne y 0 with
     | inl hyl => right; exact hyl
-    | inr hyr => left; rw [angle_neg_right,angle_self hyr]; simp
+    | inr hyr => left; rw [angle_neg_right, angle_self hyr]; simp
   | inr hxr =>
     cases eq_or_ne y 0 with
     | inl hyl => simp [hyl]
     | inr hyr =>
       cases eq_or_ne x y with
-      | inl hxy => rw [hxy,sub_self, norm_zero,mul_zero, angle_self hyr, Real.sin_zero,zero_mul]
+      | inl hxy => rw [hxy, sub_self, norm_zero, mul_zero, angle_self hyr, Real.sin_zero, zero_mul]
       | inr hxy =>
         have hsub: x - y ≠ 0 := by exact sub_ne_zero_of_ne hxy
         have h_sin (x y: V) (hx: x ≠ 0) (hy: y ≠ 0) :
@@ -81,15 +81,15 @@ theorem sin_angle_mul_norm_eq_sin_angle_mul_norm (x y : V) :
           field_simp [sin_angle_mul_norm_mul_norm]
         rw [h_sin x y hxr hyr, h_sin y (x - y) hyr hsub]
         field_simp
-        rw [mul_assoc,mul_assoc]
+        rw [mul_assoc, mul_assoc]
         congr 1
         · congr 1
-          simp_rw [inner_sub_left,inner_sub_right]
+          simp_rw [inner_sub_left, inner_sub_right]
           rw [real_inner_comm x y]
           ring
         · ring
 
-/-- A variant of the law of sines, (two given sides are nonzero) ,vector angle form. -/
+/-- A variant of the law of sines, (two given sides are nonzero), vector angle form. -/
 theorem sin_angle_div_norm_eq_sin_angle_div_norm (x y : V) (hx : x ≠ 0) (hxy: x - y ≠ 0) :
     Real.sin (angle x y) / ‖x - y‖ = Real.sin (angle y (x - y)) / ‖x‖ := by
   field_simp; exact sin_angle_mul_norm_eq_sin_angle_mul_norm x y
@@ -297,35 +297,35 @@ theorem dist_sq_eq_dist_sq_add_dist_sq_sub_two_mul_dist_mul_dist_mul_cos_angle (
 
 alias law_cos := dist_sq_eq_dist_sq_add_dist_sq_sub_two_mul_dist_mul_dist_mul_cos_angle
 
-/-- **Law of sines** (sine rule),  angle-at-point form. -/
+/-- **Law of sines** (sine rule), angle-at-point form. -/
 theorem sin_angle_mul_dist_eq_sin_angle_mul_dist {p₁ p₂ p₃ : P} :
     Real.sin (∠ p₁ p₂ p₃) * dist p₂ p₃ = Real.sin (∠ p₃ p₁ p₂) * dist p₃ p₁ := by
-  simp only [dist_comm p₂ p₃,angle]
+  simp only [dist_comm p₂ p₃, angle]
   rw [dist_eq_norm_vsub V p₃ p₂, dist_eq_norm_vsub V p₃ p₁]
-  rw [InnerProductGeometry.angle_comm,sin_angle_mul_norm_eq_sin_angle_mul_norm]
-  rw [vsub_sub_vsub_cancel_right,mul_eq_mul_right_iff]
+  rw [InnerProductGeometry.angle_comm, sin_angle_mul_norm_eq_sin_angle_mul_norm]
+  rw [vsub_sub_vsub_cancel_right, mul_eq_mul_right_iff]
   left
-  rw [InnerProductGeometry.angle_comm,←neg_vsub_eq_vsub_rev p₁ p₂]
-  rw [InnerProductGeometry.angle_neg_right,Real.sin_pi_sub]
+  rw [InnerProductGeometry.angle_comm, ← neg_vsub_eq_vsub_rev p₁ p₂]
+  rw [angle_neg_right, Real.sin_pi_sub]
 
 alias law_sin := sin_angle_mul_dist_eq_sin_angle_mul_dist
 
 /-- A variant of the law of sines, angle-at-point form. -/
 theorem sin_angle_div_dist_eq_sin_angle_div_dist {p₁ p₂ p₃ : P} (h23: p₂ ≠ p₃) (h31: p₃ ≠ p₁):
     Real.sin (∠ p₁ p₂ p₃) / dist p₃ p₁ = Real.sin (∠ p₃ p₁ p₂) / dist p₂ p₃ := by
-  field_simp [dist_ne_zero.mpr h23,dist_ne_zero.mpr h31]
+  field_simp [dist_ne_zero.mpr h23, dist_ne_zero.mpr h31]
   exact law_sin
 
 /-- A variant of the law of sines, require not collinear. -/
 theorem dist_eq_dist_mul_sin_angle_div_sin_angle {p₁ p₂ p₃ : P}
     (h: AffineIndependent ℝ ![p₁,p₂,p₃]) :
     dist p₁ p₂ = dist p₃ p₁ * Real.sin (∠ p₂ p₃ p₁) / Real.sin (∠ p₁ p₂ p₃) :=by
-  have : Real.sin (∠ p₁ p₂ p₃) > 0 := by
-    apply EuclideanGeometry.sin_pos_of_not_collinear
+  have sin_gt_zero: Real.sin (∠ p₁ p₂ p₃) > 0 := by
+    apply sin_pos_of_not_collinear
     rw [← affineIndependent_iff_not_collinear_set]
     exact h
-  field_simp[this]
-  rw [mul_comm,mul_comm (dist p₃ p₁)]
+  field_simp [sin_gt_zero]
+  rw [mul_comm, mul_comm (dist p₃ p₁)]
   rw [law_sin]
 
 /-- **Isosceles Triangle Theorem**: Pons asinorum, angle-at-point form. -/

--- a/Mathlib/Geometry/Euclidean/Triangle.lean
+++ b/Mathlib/Geometry/Euclidean/Triangle.lean
@@ -59,6 +59,44 @@ theorem norm_sub_sq_eq_norm_sq_add_norm_sq_sub_two_mul_norm_mul_norm_mul_cos_ang
     real_inner_self_eq_norm_mul_norm, ← real_inner_self_eq_norm_mul_norm, real_inner_sub_sub_self,
     sub_add_eq_add_sub]
 
+/-- **Law of sines** (sine rule), vector form. -/
+theorem sin_mul_norm_eq_sin_mul_norm (x y : V) :
+  Real.sin (angle x y) * ‖x‖ = Real.sin (angle y (x - y)) * ‖x - y‖  := by
+  cases eq_or_ne x 0 with
+  | inl hxl =>
+    simp [hxl]
+    cases eq_or_ne y 0 with
+    | inl hyl => right; exact hyl
+    | inr hyr => left;rw [angle_neg_right,angle_self hyr];simp
+  | inr hxr =>
+    cases eq_or_ne y 0 with
+    | inl hyl => simp [hyl]
+    | inr hyr =>
+      cases eq_or_ne x y with
+      | inl hxy =>
+        rw [hxy]
+        simp;left
+        rw [angle_self hyr,Real.sin_zero]
+      | inr hxy =>
+        have hsub: x - y ≠ 0 :=by exact sub_ne_zero_of_ne hxy
+        have h_sin (x y: V) (hx: x ≠ 0) (hy: y ≠ 0):
+          Real.sin (angle x y) = √(⟪x, x⟫ * ⟪y, y⟫ - ⟪x, y⟫ * ⟪x, y⟫) / (‖x‖ * ‖y‖) :=by
+          field_simp [sin_angle_mul_norm_mul_norm]
+        rw [h_sin x y hxr hyr, h_sin y (x - y) hyr hsub]
+        field_simp
+        rw [mul_assoc,mul_assoc]
+        congr 1
+        · congr 1
+          simp_rw [inner_sub_left,inner_sub_right]
+          rw [real_inner_comm x y]
+          ring_nf
+        · ring_nf
+
+/-- A variant of the law of sines, (two given sides are nonzero) ,vector angle form. -/
+theorem sin_div_norm_eq_sin_div_norm (x y : V) (hx : x ≠ 0) (hxy: x - y ≠ 0) :
+  Real.sin (angle x y) / ‖x - y‖ = Real.sin (angle y (x - y)) / ‖x‖ := by
+  field_simp; exact sin_mul_norm_eq_sin_mul_norm x y
+
 /-- **Pons asinorum**, vector angle form. -/
 theorem angle_sub_eq_angle_sub_rev_of_norm_eq {x y : V} (h : ‖x‖ = ‖y‖) :
     angle x (x - y) = angle y (y - x) := by
@@ -261,6 +299,26 @@ theorem dist_sq_eq_dist_sq_add_dist_sq_sub_two_mul_dist_mul_dist_mul_cos_angle (
   · exact (vsub_sub_vsub_cancel_right p₁ p₃ p₂).symm
 
 alias law_cos := dist_sq_eq_dist_sq_add_dist_sq_sub_two_mul_dist_mul_dist_mul_cos_angle
+
+/-- **Law of sines** (sine rule),  angle-at-point form. -/
+theorem sin_angle_mul_norm_eq_sin_angle_mul_norm {p₁ p₂ p₃ : P} :
+  Real.sin (∠ p₁ p₂ p₃) * dist p₂ p₃ = Real.sin (∠ p₃ p₁ p₂) * dist p₃ p₁:=by
+  simp [dist_comm p₂ p₃,angle]
+  rw [dist_eq_norm_vsub V p₃ p₂, dist_eq_norm_vsub V p₃ p₁]
+  rw [InnerProductGeometry.angle_comm,sin_mul_norm_eq_sin_mul_norm]
+  simp
+  left
+  rw [InnerProductGeometry.angle_comm,←neg_vsub_eq_vsub_rev p₁ p₂]
+  rw [InnerProductGeometry.angle_neg_right,Real.sin_pi_sub]
+
+alias law_sin := sin_angle_mul_norm_eq_sin_angle_mul_norm
+
+/-- A variant of the law of sines, angle-at-point form. -/
+theorem sin_angle_div_norm_eq_sin_angle_div_norm {p₁ p₂ p₃ : P}
+  (h23: p₂ ≠ p₃) (h31: p₃ ≠ p₁):
+  Real.sin (∠ p₁ p₂ p₃) / dist p₃ p₁ = Real.sin (∠ p₃ p₁ p₂) / dist p₂ p₃ := by
+  field_simp [dist_ne_zero.mpr h23,dist_ne_zero.mpr h31]
+  exact law_sin
 
 /-- **Isosceles Triangle Theorem**: Pons asinorum, angle-at-point form. -/
 theorem angle_eq_angle_of_dist_eq {p₁ p₂ p₃ : P} (h : dist p₁ p₂ = dist p₁ p₃) :

--- a/Mathlib/Geometry/Euclidean/Triangle.lean
+++ b/Mathlib/Geometry/Euclidean/Triangle.lean
@@ -61,26 +61,23 @@ theorem norm_sub_sq_eq_norm_sq_add_norm_sq_sub_two_mul_norm_mul_norm_mul_cos_ang
 
 /-- **Law of sines** (sine rule), vector form. -/
 theorem sin_angle_mul_norm_eq_sin_angle_mul_norm (x y : V) :
-  Real.sin (angle x y) * ‖x‖ = Real.sin (angle y (x - y)) * ‖x - y‖  := by
+    Real.sin (angle x y) * ‖x‖ = Real.sin (angle y (x - y)) * ‖x - y‖ := by
   cases eq_or_ne x 0 with
   | inl hxl =>
     simp [hxl]
     cases eq_or_ne y 0 with
     | inl hyl => right; exact hyl
-    | inr hyr => left;rw [angle_neg_right,angle_self hyr];simp
+    | inr hyr => left; rw [angle_neg_right,angle_self hyr]; simp
   | inr hxr =>
     cases eq_or_ne y 0 with
     | inl hyl => simp [hyl]
     | inr hyr =>
       cases eq_or_ne x y with
-      | inl hxy =>
-        rw [hxy]
-        simp;left
-        rw [angle_self hyr,Real.sin_zero]
+      | inl hxy => rw [hxy,sub_self, norm_zero,mul_zero, angle_self hyr, Real.sin_zero,zero_mul]
       | inr hxy =>
-        have hsub: x - y ≠ 0 :=by exact sub_ne_zero_of_ne hxy
-        have h_sin (x y: V) (hx: x ≠ 0) (hy: y ≠ 0):
-          Real.sin (angle x y) = √(⟪x, x⟫ * ⟪y, y⟫ - ⟪x, y⟫ * ⟪x, y⟫) / (‖x‖ * ‖y‖) :=by
+        have hsub: x - y ≠ 0 := by exact sub_ne_zero_of_ne hxy
+        have h_sin (x y: V) (hx: x ≠ 0) (hy: y ≠ 0) :
+            Real.sin (angle x y) = √(⟪x, x⟫ * ⟪y, y⟫ - ⟪x, y⟫ * ⟪x, y⟫) / (‖x‖ * ‖y‖) := by
           field_simp [sin_angle_mul_norm_mul_norm]
         rw [h_sin x y hxr hyr, h_sin y (x - y) hyr hsub]
         field_simp
@@ -89,12 +86,12 @@ theorem sin_angle_mul_norm_eq_sin_angle_mul_norm (x y : V) :
         · congr 1
           simp_rw [inner_sub_left,inner_sub_right]
           rw [real_inner_comm x y]
-          ring_nf
-        · ring_nf
+          ring
+        · ring
 
 /-- A variant of the law of sines, (two given sides are nonzero) ,vector angle form. -/
 theorem sin_angle_div_norm_eq_sin_angle_div_norm (x y : V) (hx : x ≠ 0) (hxy: x - y ≠ 0) :
-  Real.sin (angle x y) / ‖x - y‖ = Real.sin (angle y (x - y)) / ‖x‖ := by
+    Real.sin (angle x y) / ‖x - y‖ = Real.sin (angle y (x - y)) / ‖x‖ := by
   field_simp; exact sin_angle_mul_norm_eq_sin_angle_mul_norm x y
 
 /-- **Pons asinorum**, vector angle form. -/
@@ -302,11 +299,11 @@ alias law_cos := dist_sq_eq_dist_sq_add_dist_sq_sub_two_mul_dist_mul_dist_mul_co
 
 /-- **Law of sines** (sine rule),  angle-at-point form. -/
 theorem sin_angle_mul_dist_eq_sin_angle_mul_dist {p₁ p₂ p₃ : P} :
-  Real.sin (∠ p₁ p₂ p₃) * dist p₂ p₃ = Real.sin (∠ p₃ p₁ p₂) * dist p₃ p₁:=by
-  simp [dist_comm p₂ p₃,angle]
+    Real.sin (∠ p₁ p₂ p₃) * dist p₂ p₃ = Real.sin (∠ p₃ p₁ p₂) * dist p₃ p₁ := by
+  simp only [dist_comm p₂ p₃,angle]
   rw [dist_eq_norm_vsub V p₃ p₂, dist_eq_norm_vsub V p₃ p₁]
   rw [InnerProductGeometry.angle_comm,sin_angle_mul_norm_eq_sin_angle_mul_norm]
-  simp
+  rw [vsub_sub_vsub_cancel_right,mul_eq_mul_right_iff]
   left
   rw [InnerProductGeometry.angle_comm,←neg_vsub_eq_vsub_rev p₁ p₂]
   rw [InnerProductGeometry.angle_neg_right,Real.sin_pi_sub]
@@ -314,19 +311,18 @@ theorem sin_angle_mul_dist_eq_sin_angle_mul_dist {p₁ p₂ p₃ : P} :
 alias law_sin := sin_angle_mul_dist_eq_sin_angle_mul_dist
 
 /-- A variant of the law of sines, angle-at-point form. -/
-theorem sin_angle_div_dist_eq_sin_angle_div_dist {p₁ p₂ p₃ : P}
-  (h23: p₂ ≠ p₃) (h31: p₃ ≠ p₁):
-  Real.sin (∠ p₁ p₂ p₃) / dist p₃ p₁ = Real.sin (∠ p₃ p₁ p₂) / dist p₂ p₃ := by
+theorem sin_angle_div_dist_eq_sin_angle_div_dist {p₁ p₂ p₃ : P} (h23: p₂ ≠ p₃) (h31: p₃ ≠ p₁):
+    Real.sin (∠ p₁ p₂ p₃) / dist p₃ p₁ = Real.sin (∠ p₃ p₁ p₂) / dist p₂ p₃ := by
   field_simp [dist_ne_zero.mpr h23,dist_ne_zero.mpr h31]
   exact law_sin
 
 /-- A variant of the law of sines, require not collinear. -/
 theorem dist_eq_dist_mul_sin_angle_div_sin_angle {p₁ p₂ p₃ : P}
-  (h: AffineIndependent ℝ ![p₁,p₂,p₃]):
-  dist p₁ p₂ = dist p₃ p₁ * Real.sin (∠ p₂ p₃ p₁) / Real.sin (∠ p₁ p₂ p₃) :=by
-  have : Real.sin (∠ p₁ p₂ p₃) > 0:=by
+    (h: AffineIndependent ℝ ![p₁,p₂,p₃]) :
+    dist p₁ p₂ = dist p₃ p₁ * Real.sin (∠ p₂ p₃ p₁) / Real.sin (∠ p₁ p₂ p₃) :=by
+  have : Real.sin (∠ p₁ p₂ p₃) > 0 := by
     apply EuclideanGeometry.sin_pos_of_not_collinear
-    rw [←affineIndependent_iff_not_collinear_set]
+    rw [← affineIndependent_iff_not_collinear_set]
     exact h
   field_simp[this]
   rw [mul_comm,mul_comm (dist p₃ p₁)]


### PR DESCRIPTION
Add triangle congruence theorems.

---

Some parts of the [original PR](https://github.com/leanprover-community/mathlib3/pull/18214) in Lean 3 have already been migrated to mathlib4:
`Mathlib.Topology.MetricSpace.Congruence` and `Mathlib.Topology.MetricSpace.Similarity`.
Therefore, I just rearranged the file and left the core triangle congruence proofs here.

I'm not sure whether we need a standalone `Congruence.lean` file or if we should merge these into `Triangle.lean`.

The law of sines was commited with another PR.

Discussion on [zulip](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/Law.20of.20Sines.20for.20Euclidean.20Geometry.20Triangles/near/520245156)

- [x] depends on: #25174


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
