### PR TITLE
[Merged by Bors] - feat(Coalgebra): mixin for cocommutative coalgebras

### DIFF
--- a/Mathlib/RingTheory/Coalgebra/MonoidAlgebra.lean
+++ b/Mathlib/RingTheory/Coalgebra/MonoidAlgebra.lean
@@ -23,6 +23,8 @@ corresponding structure on its coefficients, defined in `Mathlib/RingTheory/Coal
 
 suppress_compilation
 
+open Coalgebra
+
 namespace MonoidAlgebra
 
 variable {R : Type*} [CommSemiring R] {A : Type*} [Semiring A]
@@ -30,6 +32,8 @@ variable {R : Type*} [CommSemiring R] {A : Type*} [Semiring A]
 
 variable (R A X) in
 instance instCoalgebra : Coalgebra R (MonoidAlgebra A X) := Finsupp.instCoalgebra R X A
+
+instance instIsCocomm [IsCocomm R A] : IsCocomm R (MonoidAlgebra A X) := Finsupp.instIsCocomm R X A
 
 @[simp]
 lemma counit_single (x : X) (a : A) :
@@ -52,6 +56,8 @@ variable {R : Type*} [CommSemiring R] {A : Type*} [Semiring A]
 variable (R A X) in
 instance instCoalgebra : Coalgebra R A[X] := Finsupp.instCoalgebra R X A
 
+instance instIsCocomm [IsCocomm R A] : IsCocomm R A[X] := Finsupp.instIsCocomm R X A
+
 @[simp]
 lemma counit_single (x : X) (a : A) :
     Coalgebra.counit (single x a) = Coalgebra.counit (R := R) a :=
@@ -71,9 +77,9 @@ open AddMonoidAlgebra
 
 variable (R A : Type*) [CommSemiring R] [Semiring A] [Module R A] [Coalgebra R A]
 
-instance instCoalgebra :
-    Coalgebra R A[T;T⁻¹] :=
-  inferInstanceAs (Coalgebra R <| A[ℤ])
+instance instCoalgebra : Coalgebra R A[T;T⁻¹] := inferInstanceAs <| Coalgebra R A[ℤ]
+
+instance instIsCocomm [IsCocomm R A] : IsCocomm R A[T;T⁻¹] := inferInstanceAs <| IsCocomm R A[ℤ]
 
 variable {R A}
 

--- a/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
@@ -140,12 +140,12 @@ instance instCoalgebra : Coalgebra S (A ⊗[R] B) where
     · dsimp
       simp only [one_smul]
 
-instance [IsCocomm R A] [IsCocomm R B] : IsCocomm R (A ⊗[R] B) where
+instance [IsCocomm S A] [IsCocomm R B] : IsCocomm S (A ⊗[R] B) where
   comm_comp_comul := by
     ext x y
     dsimp
     conv_rhs => rw [← comm_comul _ x, ← comm_comul _ y]
-    hopf_tensor_induction comul (R := R) x with x₁ x₂
+    hopf_tensor_induction comul (R := S) x with x₁ x₂
     hopf_tensor_induction comul (R := R) y with y₁ y₂
     simp
 

--- a/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
@@ -140,6 +140,15 @@ instance instCoalgebra : Coalgebra S (A ⊗[R] B) where
     · dsimp
       simp only [one_smul]
 
+instance [IsCocomm R A] [IsCocomm R B] : IsCocomm R (A ⊗[R] B) where
+  comm_comp_comul := by
+    ext x y
+    dsimp
+    conv_rhs => rw [← comm_comul _ x, ← comm_comul _ y]
+    hopf_tensor_induction comul (R := R) x with x₁ x₂
+    hopf_tensor_induction comul (R := R) y with y₁ y₂
+    simp
+
 end TensorProduct
 
 namespace Coalgebra


### PR DESCRIPTION
A coalgebra `A` is cocommutative if its comultiplication `δ : A → A ⊗ A` commutes with the swapping `β : A ⊗ A ≃ A ⊗ A` of the factors in the tensor product.

This is made a Prop-valued mixin because eg matrices are a non-cocommutative bialgebra.

From Toric

Co-authored-by: Michał Mrugała <kiolterino@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
