### PR TITLE
[Merged by Bors] - feat: `(M →* N₁) ≃* (M →* N₂)` if `N₁ ≃* N₂`

### DIFF
--- a/Mathlib/Algebra/Category/Grp/ForgetCorepresentable.lean
+++ b/Mathlib/Algebra/Category/Grp/ForgetCorepresentable.lean
@@ -29,12 +29,12 @@ shouldn't be useful outside of category theory.
 /-- The equivalence `(ULift ℤ →+ G) ≃ G` for any additive group `G`. -/
 @[simps!]
 def uliftZMultiplesHom (G : Type u) [AddGroup G] : G ≃ (ULift.{u} ℤ →+ G) :=
-  (zmultiplesHom _).trans <| AddMonoidHom.precompEquiv .ulift _
+  (zmultiplesHom _).trans AddEquiv.ulift.symm.addMonoidHomCongrLeftEquiv
 
 /-- The equivalence `(ULift (Multiplicative ℤ) →* G) ≃ G` for any group `G`. -/
 @[simps!]
 def uliftZPowersHom (G : Type u) [Group G] : G ≃ (ULift.{u} (Multiplicative ℤ) →* G) :=
-  (zpowersHom _).trans <| MonoidHom.precompEquiv .ulift _
+  (zpowersHom _).trans MulEquiv.ulift.symm.monoidHomCongrLeftEquiv
 
 namespace MonoidHom
 

--- a/Mathlib/Algebra/Category/Grp/LargeColimits.lean
+++ b/Mathlib/Algebra/Category/Grp/LargeColimits.lean
@@ -36,12 +36,11 @@ lemma isColimit_iff_bijective_desc [DecidableEq J] :
   change Function.Bijective (Quot.desc F c).toIntLinearMap
   rw [← CharacterModule.dual_bijective_iff_bijective]
   refine ⟨fun χ ψ eq ↦ ?_, fun χ ↦ ?_⟩
-  · apply (AddMonoidHom.postcompEquiv (@AddEquiv.ulift (AddCircle (1 : ℚ)) _).symm _).injective
+  · apply AddEquiv.ulift.symm.addMonoidHomCongrRightEquiv.injective
     apply ofHom_injective
     refine hc.hom_ext (fun j ↦ ?_)
     ext x
     rw [ConcreteCategory.comp_apply, ConcreteCategory.comp_apply, ← Quot.ι_desc _ c j x]
-    simp only [hom_ofHom, AddMonoidHom.postcompEquiv_apply, AddMonoidHom.comp_apply]
     exact DFunLike.congr_fun eq (Quot.ι F j x)
   · set c' : Cocone F :=
       { pt := AddCommGrp.of (ULift (AddCircle (1 : ℚ)))

--- a/Mathlib/Algebra/Category/MonCat/ForgetCorepresentable.lean
+++ b/Mathlib/Algebra/Category/MonCat/ForgetCorepresentable.lean
@@ -33,13 +33,13 @@ shouldn't be useful outside of category theory.
 /-- Monoid homomorphisms from `ULift ℕ` are defined by the image of `1`. -/
 @[simps!]
 def uliftMultiplesHom (M : Type u) [AddMonoid M] : M ≃ (ULift.{u} ℕ →+ M) :=
-  (multiplesHom _).trans <| AddMonoidHom.precompEquiv .ulift _
+  (multiplesHom _).trans AddEquiv.ulift.symm.addMonoidHomCongrLeftEquiv
 
 /-- Monoid homomorphisms from `ULift (Multiplicative ℕ)` are defined by the image
 of `Multiplicative.ofAdd 1`. -/
 @[simps!]
 def uliftPowersHom (M : Type u) [Monoid M] : M ≃ (ULift.{u} (Multiplicative ℕ) →* M) :=
-  (powersHom _).trans <| MonoidHom.precompEquiv .ulift _
+  (powersHom _).trans MulEquiv.ulift.symm.monoidHomCongrLeftEquiv
 
 namespace MonoidHom
 

--- a/Mathlib/Algebra/Group/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Group/Equiv/Basic.lean
@@ -6,6 +6,7 @@ Authors: Johannes Hölzl, Callum Sutton, Yury Kudryashov
 import Mathlib.Algebra.Group.Equiv.Defs
 import Mathlib.Algebra.Group.Hom.Basic
 import Mathlib.Logic.Equiv.Basic
+import Mathlib.Tactic.Spread
 
 /-!
 # Multiplicative and additive equivs
@@ -21,7 +22,7 @@ assert_not_exists Fintype
 
 open Function
 
-variable {F α β M N P G H : Type*}
+variable {F α β M M₁ M₂ M₃ N N₁ N₂ N₃ P Q G H : Type*}
 
 namespace EmbeddingLike
 variable [One M] [One N] [FunLike F M N] [EmbeddingLike F M N] [OneHomClass F M N]
@@ -74,19 +75,115 @@ def arrowCongr {M N P Q : Type*} [Mul P] [Mul Q] (f : M ≃ N) (g : P ≃* Q) :
   right_inv k := by ext; simp
   map_mul' h k := by ext; simp
 
+section monoidHomCongrEquiv
+variable [MulOneClass M] [MulOneClass M₁] [MulOneClass M₂] [MulOneClass M₃]
+  [Monoid N] [Monoid N₁] [Monoid N₂] [Monoid N₃]
+
+/-- The equivalence `(M₁ →* N) ≃ (M₂ →* N)` obtained by postcomposition with
+a multiplicative equivalence `e : M₁ ≃* M₂`. -/
+@[to_additive (attr := simps)
+"The equivalence `(M₁ →+ N) ≃ (M₂ →+ N)` obtained by postcomposition with
+an additive equivalence `e : M₁ ≃+ M₂`."]
+def monoidHomCongrLeftEquiv (e : M₁ ≃* M₂) : (M₁ →* N) ≃ (M₂ →* N) where
+  toFun f := f.comp e.symm.toMonoidHom
+  invFun f := f.comp e.toMonoidHom
+  left_inv f := by ext; simp
+  right_inv f := by ext; simp
+
+/-- The equivalence `(M →* N₁) ≃ (M →* N₂)` obtained by postcomposition with
+a multiplicative equivalence `e : N₁ ≃* N₂`. -/
+@[to_additive (attr := simps)
+"The equivalence `(M →+ N₁) ≃ (M →+ N₂)` obtained by postcomposition with
+an additive equivalence `e : N₁ ≃+ N₂`."]
+def monoidHomCongrRightEquiv (e : N₁ ≃* N₂) : (M →* N₁) ≃ (M →* N₂) where
+  toFun := e.toMonoidHom.comp
+  invFun := e.symm.toMonoidHom.comp
+  left_inv f := by ext; simp
+  right_inv f := by ext; simp
+
+@[to_additive (attr := simp)]
+lemma monoidHomCongrLeftEquiv_refl : monoidHomCongrLeftEquiv (.refl M) = .refl (M →* N) := rfl
+
+@[to_additive (attr := simp)]
+lemma monoidHomCongrRightEquiv_refl : monoidHomCongrRightEquiv (.refl N) = .refl (M →* N) := rfl
+
+@[to_additive (attr := simp)]
+lemma symm_monoidHomCongrLeftEquiv (e : M₁ ≃* M₂) :
+    (monoidHomCongrLeftEquiv e).symm = monoidHomCongrLeftEquiv (N := N) e.symm := rfl
+
+@[to_additive (attr := simp)]
+lemma symm_monoidHomCongrRightEquiv (e : N₁ ≃* N₂) :
+    (monoidHomCongrRightEquiv e).symm = monoidHomCongrRightEquiv (M := M) e.symm := rfl
+
+@[to_additive (attr := simp)]
+lemma monoidHomCongrLeftEquiv_trans (e₁₂ : M₁ ≃* M₂) (e₂₃ : M₂ ≃* M₃) :
+    monoidHomCongrLeftEquiv (N := N) (e₁₂.trans e₂₃) =
+      (monoidHomCongrLeftEquiv e₁₂).trans (monoidHomCongrLeftEquiv e₂₃) := rfl
+
+@[to_additive (attr := simp)]
+lemma monoidHomCongrRightEquiv_trans (e₁₂ : N₁ ≃* N₂) (e₂₃ : N₂ ≃* N₃) :
+    monoidHomCongrRightEquiv (M := M) (e₁₂.trans e₂₃) =
+      (monoidHomCongrRightEquiv e₁₂).trans (monoidHomCongrRightEquiv e₂₃) := rfl
+
+end monoidHomCongrEquiv
+
+section monoidHomCongr
+variable [MulOneClass M] [MulOneClass M₁] [MulOneClass M₂] [MulOneClass M₃]
+  [CommMonoid N] [CommMonoid N₁] [CommMonoid N₂] [CommMonoid N₃]
+
+/-- The isomorphism `(M₁ →* N) ≃* (M₂ →* N)` obtained by postcomposition with
+a multiplicative equivalence `e : M₁ ≃* M₂`. -/
+@[to_additive (attr := simps! apply)
+"The isomorphism `(M₁ →+ N) ≃+ (M₂ →+ N)` obtained by postcomposition with
+an additive equivalence `e : M₁ ≃+ M₂`."]
+def monoidHomCongrLeft (e : M₁ ≃* M₂) : (M₁ →* N) ≃* (M₂ →* N) where
+  __ := e.monoidHomCongrLeftEquiv
+  map_mul' f g := by ext; simp
+
+/-- The isomorphism `(M →* N₁) ≃* (M →* N₂)` obtained by postcomposition with
+a multiplicative equivalence `e : N₁ ≃* N₂`. -/
+@[to_additive (attr := simps! apply)
+"The isomorphism `(M →+ N₁) ≃+ (M →+ N₂)` obtained by postcomposition with
+an additive equivalence `e : N₁ ≃+ N₂`."]
+def monoidHomCongrRight (e : N₁ ≃* N₂) : (M →* N₁) ≃* (M →* N₂) where
+  __ := e.monoidHomCongrRightEquiv
+  map_mul' f g := by ext; simp
+
+@[to_additive (attr := simp)]
+lemma monoidHomCongrLeft_refl : monoidHomCongrLeft (.refl M) = .refl (M →* N) := rfl
+
+@[to_additive (attr := simp)]
+lemma monoidHomCongrRight_refl : monoidHomCongrRight (.refl N) = .refl (M →* N) := rfl
+
+@[to_additive (attr := simp)]
+lemma symm_monoidHomCongrLeft (e : M₁ ≃* M₂) :
+    (monoidHomCongrLeft e).symm = monoidHomCongrLeft (N := N) e.symm := rfl
+
+@[to_additive (attr := simp)]
+lemma symm_monoidHomCongrRight (e : N₁ ≃* N₂) :
+    (monoidHomCongrRight e).symm = monoidHomCongrRight (M := M) e.symm := rfl
+
+@[to_additive (attr := simp)]
+lemma monoidHomCongrLeft_trans (e₁₂ : M₁ ≃* M₂) (e₂₃ : M₂ ≃* M₃) :
+    monoidHomCongrLeft (N := N) (e₁₂.trans e₂₃) =
+      (monoidHomCongrLeft e₁₂).trans (monoidHomCongrLeft e₂₃) := rfl
+
+@[to_additive (attr := simp)]
+lemma monoidHomCongrRight_trans (e₁₂ : N₁ ≃* N₂) (e₂₃ : N₂ ≃* N₃) :
+    monoidHomCongrRight (M := M) (e₁₂.trans e₂₃) =
+      (monoidHomCongrRight e₁₂).trans (monoidHomCongrRight e₂₃) := rfl
+
+end monoidHomCongr
+
 /-- A multiplicative analogue of `Equiv.arrowCongr`,
 for multiplicative maps from a monoid to a commutative monoid.
 -/
-@[to_additive (attr := simps apply)
+@[to_additive (attr := deprecated MulEquiv.monoidHomCongrLeft (since := "2025-08-12"))
   /-- An additive analogue of `Equiv.arrowCongr`,
   for additive maps from an additive monoid to a commutative additive monoid. -/]
 def monoidHomCongr {M N P Q} [MulOneClass M] [MulOneClass N] [CommMonoid P] [CommMonoid Q]
-    (f : M ≃* N) (g : P ≃* Q) : (M →* P) ≃* (N →* Q) where
-  toFun h := g.toMonoidHom.comp (h.comp f.symm.toMonoidHom)
-  invFun k := g.symm.toMonoidHom.comp (k.comp f.toMonoidHom)
-  left_inv h := by ext; simp
-  right_inv k := by ext; simp
-  map_mul' h k := by ext; simp
+    (f : M ≃* N) (g : P ≃* Q) : (M →* P) ≃* (N →* Q) :=
+  f.monoidHomCongrLeft.trans g.monoidHomCongrRight
 
 /-- A family of multiplicative equivalences `Π j, (Ms j ≃* Ns j)` generates a
 multiplicative equivalence between `Π j, Ms j` and `Π j, Ns j`.
@@ -132,10 +229,12 @@ def piUnique {ι : Type*} (M : ι → Type*) [∀ j, Mul (M j)] [Unique ι] :
 end MulEquiv
 
 namespace MonoidHom
+variable {M N₁ N₂ : Type*} [Monoid M] [CommMonoid N₁] [CommMonoid N₂]
 
 /-- The equivalence `(β →* γ) ≃ (α →* γ)` obtained by precomposition with
 a multiplicative equivalence `e : α ≃* β`. -/
-@[to_additive (attr := simps)
+@[to_additive (attr := simps -isSimp,
+deprecated MulEquiv.monoidHomCongrLeftEquiv (since := "2025-08-12"))
 /-- The equivalence `(β →+ γ) ≃ (α →+ γ)` obtained by precomposition with
 an additive equivalence `e : α ≃+ β`. -/]
 def precompEquiv {α β : Type*} [Monoid α] [Monoid β] (e : α ≃* β) (γ : Type*) [Monoid γ] :
@@ -147,7 +246,8 @@ def precompEquiv {α β : Type*} [Monoid α] [Monoid β] (e : α ≃* β) (γ : 
 
 /-- The equivalence `(γ →* α) ≃ (γ →* β)` obtained by postcomposition with
 a multiplicative equivalence `e : α ≃* β`. -/
-@[to_additive (attr := simps)
+@[to_additive (attr := simps -isSimp,
+deprecated MulEquiv.monoidHomCongrRightEquiv (since := "2025-08-12"))
 /-- The equivalence `(γ →+ α) ≃ (γ →+ β)` obtained by postcomposition with
 an additive equivalence `e : α ≃+ β`. -/]
 def postcompEquiv {α β : Type*} [Monoid α] [Monoid β] (e : α ≃* β) (γ : Type*) [Monoid γ] :

--- a/Mathlib/GroupTheory/FiniteAbelian/Duality.lean
+++ b/Mathlib/GroupTheory/FiniteAbelian/Duality.lean
@@ -69,7 +69,6 @@ theorem monoidHom_mulEquiv_of_hasEnoughRootsOfUnity : Nonempty ((G →* Mˣ) ≃
   obtain ⟨ι, _, n, ⟨h₁, h₂⟩⟩ := equiv_prod_multiplicative_zmod_of_finite G
   let e := h₂.some
   let e' := Pi.monoidHomMulEquiv (fun i ↦ Multiplicative (ZMod (n i))) Mˣ
-  let e'' := MulEquiv.monoidHomCongr e (.refl Mˣ)
   have : ∀ i, NeZero (n i) := fun i ↦ NeZero.of_gt (h₁ i)
   have inst i : HasEnoughRootsOfUnity M <| Nat.card <| Multiplicative <| ZMod (n i) := by
     have hdvd : Nat.card (Multiplicative (ZMod (n i))) ∣ Monoid.exponent G := by
@@ -77,6 +76,6 @@ theorem monoidHom_mulEquiv_of_hasEnoughRootsOfUnity : Nonempty ((G →* Mˣ) ≃
         using dvd_exponent e i
     exact HasEnoughRootsOfUnity.of_dvd M hdvd
   let E i := (IsCyclic.monoidHom_equiv_self (Multiplicative (ZMod (n i))) M).some
-  exact ⟨e''.trans <| e'.trans <| (MulEquiv.piCongrRight E).trans e.symm⟩
+  exact ⟨e.monoidHomCongrLeft.trans <| e'.trans <| .trans (.piCongrRight E) e.symm⟩
 
 end CommGroup


### PR DESCRIPTION
The names were discussed on [Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Naming.20congruence.20of.20maps) but no consensus was reached due to lack of engagement.

The names I choose here are consistent with [`ContinuousLinearEquiv.continuousAlternatingMapCongrLeft`](https://leanprover-community.github.io/mathlib4_docs/find/?pattern=ContinuousLinearEquiv.continuousAlternatingMapCongrLeft#doc) and around.

From Toric

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
