### PR TITLE
[Merged by Bors] - feat: convolution product on linear maps from a coalgebra to an algebra

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5446,6 +5446,7 @@ import Mathlib.RingTheory.Binomial
 import Mathlib.RingTheory.ChainOfDivisors
 import Mathlib.RingTheory.ClassGroup
 import Mathlib.RingTheory.Coalgebra.Basic
+import Mathlib.RingTheory.Coalgebra.Convolution
 import Mathlib.RingTheory.Coalgebra.Equiv
 import Mathlib.RingTheory.Coalgebra.Hom
 import Mathlib.RingTheory.Coalgebra.MonoidAlgebra

--- a/Mathlib/Algebra/Algebra/Bilinear.lean
+++ b/Mathlib/Algebra/Algebra/Bilinear.lean
@@ -16,16 +16,17 @@ in order to avoid importing `LinearAlgebra.BilinearMap` and
 
 open TensorProduct Module
 
+variable {R A B : Type*}
+
 namespace LinearMap
 
 section NonUnitalNonAssoc
-variable (R A : Type*)
 
 section one_side
 variable [Semiring R] [NonUnitalNonAssocSemiring A] [Module R A]
 
 section left
-variable {A} [SMulCommClass R A A]
+variable (R) [SMulCommClass R A A]
 
 /-- The multiplication on the left in an algebra is a linear map.
 
@@ -50,7 +51,7 @@ theorem mulLeft_zero_eq_zero : mulLeft R (0 : A) = 0 := ext fun _ => zero_mul _
 end left
 
 section right
-variable {A} [IsScalarTower R A A]
+variable (R) [IsScalarTower R A A]
 
 /-- The multiplication on the right in an algebra is a linear map.
 
@@ -77,7 +78,7 @@ end right
 
 end one_side
 
-variable [CommSemiring R] [NonUnitalNonAssocSemiring A] [Module R A]
+variable (R A) [CommSemiring R] [NonUnitalNonAssocSemiring A] [Module R A]
 variable [SMulCommClass R A A] [IsScalarTower R A A]
 
 /-- The multiplication in a non-unital non-associative algebra is a bilinear map.
@@ -91,6 +92,9 @@ def mul : A →ₗ[R] A →ₗ[R] A :=
 -- TODO: upgrade to A-linear map if A is a semiring.
 def mul' : A ⊗[R] A →ₗ[R] A :=
   TensorProduct.lift (mul R A)
+
+@[inherit_doc] scoped[RingTheory.LinearMap] notation "μ" => LinearMap.mul' _ _
+@[inherit_doc] scoped[RingTheory.LinearMap] notation "μ[" R "]" => LinearMap.mul' R _
 
 variable {A}
 
@@ -123,10 +127,9 @@ theorem lift_lsmul_mul_eq_lsmul_lift_lsmul {r : R} :
 end NonUnitalNonAssoc
 
 section NonUnital
-variable (R A B : Type*)
 
 section one_side
-variable [Semiring R] [NonUnitalSemiring A] [NonUnitalSemiring B] [Module R B] [Module R A]
+variable (R A) [Semiring R] [NonUnitalSemiring A] [NonUnitalSemiring B] [Module R B] [Module R A]
 
 @[simp]
 theorem mulLeft_mul [SMulCommClass R A A] (a b : A) :
@@ -146,6 +149,7 @@ variable [CommSemiring R] [NonUnitalSemiring A] [NonUnitalSemiring B] [Module R 
 variable [SMulCommClass R A A] [IsScalarTower R A A]
 variable [SMulCommClass R B B] [IsScalarTower R B B]
 
+variable (R A) in
 /-- The multiplication in a non-unital algebra is a bilinear map.
 
 A weaker version of this for non-unital non-associative algebras exists as `LinearMap.mul`. -/
@@ -153,8 +157,6 @@ def _root_.NonUnitalAlgHom.lmul : A →ₙₐ[R] End R A where
   __ := mul R A
   map_mul' := mulLeft_mul _ _
   map_zero' := mulLeft_zero_eq_zero _ _
-
-variable {R A B}
 
 @[simp]
 theorem _root_.NonUnitalAlgHom.coe_lmul_eq_mul : ⇑(NonUnitalAlgHom.lmul R A) = mul R A :=
@@ -191,7 +193,7 @@ end Injective
 
 section Semiring
 
-variable (R A : Type*)
+variable (R A)
 section one_side
 variable [Semiring R] [Semiring A]
 
@@ -263,4 +265,37 @@ theorem toSpanSingleton_eq_algebra_linearMap : toSpanSingleton R A 1 = Algebra.l
 
 end Semiring
 
+section CommSemiring
+-- TODO: Generalise to `NonUnitalNonAssocCommSemiring`. This can't currently be done
+-- because there is no instance **to** `NonUnitalNonAssocCommSemiring`.
+variable [CommSemiring R] [NonUnitalCommSemiring A]
+  [Module R A] [SMulCommClass R A A] [IsScalarTower R A A]
+
+lemma mul'_comp_comm : mul' R A ∘ₗ TensorProduct.comm R A A = mul' R A :=
+  TensorProduct.ext' <| by simp [mul_comm]
+
+lemma mul'_comm (x : A ⊗[R] A) : mul' R A (TensorProduct.comm R A A x) = mul' R A x :=
+  congr($mul'_comp_comm _)
+
+end CommSemiring
 end LinearMap
+
+open scoped RingTheory.LinearMap
+
+namespace NonUnitalAlgHom
+variable [CommSemiring R]
+  [NonUnitalSemiring A] [Module R A] [SMulCommClass R A A] [IsScalarTower R A A]
+  [NonUnitalNonAssocSemiring B] [Module R B] [SMulCommClass R B B] [IsScalarTower R B B]
+
+lemma comp_mul' (f : A →ₙₐ[R] B) : (f : A →ₗ[R] B) ∘ₗ μ = μ[R] ∘ₗ (f ⊗ₘ f) :=
+  TensorProduct.ext' <| by simp
+
+end NonUnitalAlgHom
+
+namespace AlgHom
+variable [CommSemiring R] [Semiring A] [Semiring B] [Algebra R A] [Algebra R B]
+
+lemma comp_mul' (f : A →ₐ B) : f.toLinearMap ∘ₗ μ = μ[R] ∘ₗ (f.toLinearMap ⊗ₘ f.toLinearMap) :=
+  TensorProduct.ext' <| by simp
+
+end AlgHom

--- a/Mathlib/Algebra/Algebra/Bilinear.lean
+++ b/Mathlib/Algebra/Algebra/Bilinear.lean
@@ -271,8 +271,10 @@ section CommSemiring
 variable [CommSemiring R] [NonUnitalCommSemiring A]
   [Module R A] [SMulCommClass R A A] [IsScalarTower R A A]
 
-lemma mul'_comp_comm : mul' R A ∘ₗ TensorProduct.comm R A A = mul' R A :=
-  TensorProduct.ext' <| by simp [mul_comm]
+@[simp] lemma flip_mul : (mul R A).flip = mul R A := by ext; simp [mul_comm]
+
+lemma mul'_comp_comm : mul' R A ∘ₗ TensorProduct.comm R A A = mul' R A := by
+  simp [mul', lift_comp_comm_eq]
 
 lemma mul'_comm (x : A ⊗[R] A) : mul' R A (TensorProduct.comm R A A x) = mul' R A x :=
   congr($mul'_comp_comm _)

--- a/Mathlib/Algebra/Algebra/Defs.lean
+++ b/Mathlib/Algebra/Algebra/Defs.lean
@@ -372,6 +372,9 @@ packaged as an `R`-linear map.
 protected def linearMap : R →ₗ[R] A :=
   { algebraMap R A with map_smul' := fun x y => by simp [Algebra.smul_def] }
 
+@[inherit_doc] scoped[RingTheory.LinearMap] notation "η" => Algebra.linearMap _ _
+@[inherit_doc] scoped[RingTheory.LinearMap] notation "η[" R "]" => Algebra.linearMap R _
+
 @[simp]
 theorem linearMap_apply (r : R) : Algebra.linearMap R A r = algebraMap R A r :=
   rfl

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -744,6 +744,8 @@ open LinearMap
 def map (f : M →ₛₗ[σ₁₂] M₂) (g : N →ₛₗ[σ₁₂] N₂) : M ⊗[R] N →ₛₗ[σ₁₂] M₂ ⊗[R₂] N₂ :=
   lift <| comp (compl₂ (mk _ _ _) g) f
 
+@[inherit_doc] scoped[RingTheory.LinearMap] infix:70 " ⊗ₘ " => TensorProduct.map
+
 @[simp]
 theorem map_tmul (f : M →ₛₗ[σ₁₂] M₂) (g : N →ₛₗ[σ₁₂] N₂) (m : M) (n : N) :
     map f g (m ⊗ₜ n) = f m ⊗ₜ g n :=

--- a/Mathlib/RingTheory/Coalgebra/Basic.lean
+++ b/Mathlib/RingTheory/Coalgebra/Basic.lean
@@ -34,6 +34,9 @@ class CoalgebraStruct (R : Type u) (A : Type v)
   /-- The counit of the coalgebra -/
   counit : A →ₗ[R] R
 
+@[inherit_doc] scoped[RingTheory.LinearMap] notation "ε" => CoalgebraStruct.counit
+@[inherit_doc] scoped[RingTheory.LinearMap] notation "δ" => CoalgebraStruct.comul
+
 /--
 A representation of an element `a` of a coalgebra `A` is a finite sum of pure tensors `∑ xᵢ ⊗ yᵢ`
 that is equal to `comul a`.

--- a/Mathlib/RingTheory/Coalgebra/Convolution.lean
+++ b/Mathlib/RingTheory/Coalgebra/Convolution.lean
@@ -108,9 +108,7 @@ non-unital algebra. -/
 abbrev convNonUnitalSemiring : NonUnitalSemiring (C →ₗ[R] A) where
   mul_assoc f g h := calc
         μ ∘ₗ (μ ∘ₗ (f ⊗ₘ g) ∘ₗ δ ⊗ₘ h) ∘ₗ δ
-    _ = (μ ∘ₗ .rTensor _ μ) ∘ₗ ((f ⊗ₘ g) ⊗ₘ h) ∘ₗ (.rTensor _ δ ∘ₗ δ) := by
-      rw [comp_assoc, ← comp_assoc _ _ (rTensor _ _), rTensor_comp_map,
-        ← comp_assoc _ (rTensor _ _), map_comp_rTensor, comp_assoc]
+    _ = (μ ∘ₗ .rTensor _ μ) ∘ₗ ((f ⊗ₘ g) ⊗ₘ h) ∘ₗ (.rTensor _ δ ∘ₗ δ) := by ext; simp
     _ = (μ ∘ₗ rTensor _ μ)
         ∘ₗ (((f ⊗ₘ g) ⊗ₘ h) ∘ₗ (TensorProduct.assoc R C C C).symm) ∘ₗ lTensor C δ ∘ₗ δ := by
       simp only [comp_assoc, coassoc_symm]
@@ -121,9 +119,7 @@ abbrev convNonUnitalSemiring : NonUnitalSemiring (C →ₗ[R] A) where
       congr 1
       ext
       simp [mul_assoc]
-    _ = μ ∘ₗ (f ⊗ₘ μ ∘ₗ (g ⊗ₘ h) ∘ₗ δ) ∘ₗ δ := by
-      rw [comp_assoc, ← comp_assoc _ _ (lTensor _ _), lTensor_comp_map,
-        ← comp_assoc _ (lTensor _ _), map_comp_lTensor, comp_assoc]
+    _ = μ ∘ₗ (f ⊗ₘ μ ∘ₗ (g ⊗ₘ h) ∘ₗ δ) ∘ₗ δ := by ext; simp
 
 scoped[ConvolutionProduct] attribute [instance] LinearMap.convNonUnitalSemiring
 

--- a/Mathlib/RingTheory/Coalgebra/Convolution.lean
+++ b/Mathlib/RingTheory/Coalgebra/Convolution.lean
@@ -1,0 +1,209 @@
+/-
+Copyright (c) 2025 Yaël Dillies, Michał Mrugała, Yunzhou Xie. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies, Michał Mrugała, Yunzhou Xie
+-/
+import Mathlib.Algebra.Algebra.Bilinear
+import Mathlib.LinearAlgebra.TensorProduct.Tower
+import Mathlib.RingTheory.Coalgebra.Hom
+
+/-!
+# Convolution product on linear maps from a coalgebra to an algebra
+
+This file constructs the ring structure on linear maps `C → A` where `C` is a coalgebra and `A` an
+algebra, where multiplication is given by `(f * g)(x) = ∑ f x₍₁₎ * g x₍₂₎` in Sweedler notation or
+```
+         |
+         μ
+|   |   / \
+f * g = f g
+|   |   \ /
+         δ
+         |
+```
+diagrammatically, where `μ` stands for multiplication and `δ` for comultiplication.
+
+## Implementation notes
+
+Note that in the case `C = A` this convolution product conflicts with the (unfortunately global!)
+group instance on `Module.End R A` with multiplication defined as composition.
+As a result, the convolution product is scoped to `ConvolutionProduct`.
+-/
+
+suppress_compilation
+
+open Coalgebra TensorProduct
+open scoped RingTheory.LinearMap
+
+variable {R A B C : Type*} [CommSemiring R]
+
+namespace LinearMap
+section NonUnitalNonAssocSemiring
+variable
+  [NonUnitalNonAssocSemiring A] [Module R A] [SMulCommClass R A A] [IsScalarTower R A A]
+  [AddCommMonoid C] [Module R C] [CoalgebraStruct R C]
+
+/-- Convolution product on linear maps from a coalgebra to an algebra. -/
+abbrev convMul : Mul (C →ₗ[R] A) where mul f g := mul' R A ∘ₗ TensorProduct.map f g ∘ₗ comul
+
+scoped[ConvolutionProduct] attribute [instance] LinearMap.convMul
+
+open scoped ConvolutionProduct
+
+lemma convMul_def (f g : C →ₗ[R] A) : f * g = mul' R A ∘ₗ TensorProduct.map f g ∘ₗ comul := rfl
+
+@[simp]
+lemma convMul_apply (f g : C →ₗ[R] A) (c : C) : (f * g) c = mul' R A (.map f g (comul c)) := rfl
+
+lemma _root_.Coalgebra.Repr.convMul_apply {a : C} (𝓡 : Coalgebra.Repr R a) (f g : C →ₗ[R] A) :
+    (f * g) a = ∑ i ∈ 𝓡.index, f (𝓡.left i) * g (𝓡.right i) := by
+  simp [convMul_def, ← 𝓡.eq]
+
+/-- Non-unital and non-associative convolution semiring structure on linear maps from a
+coalgebra to a non-unital non-associative algebra. -/
+abbrev convNonUnitalNonAssocSemiring : NonUnitalNonAssocSemiring (C →ₗ[R] A) where
+  left_distrib f g h := by ext; simp [map_add_right]
+  right_distrib f g h := by ext; simp [map_add_left]
+  zero_mul f := by ext; simp
+  mul_zero f := by ext; simp
+
+scoped[ConvolutionProduct] attribute [instance] LinearMap.convNonUnitalNonAssocSemiring
+
+@[simp] lemma toSpanSingleton_convMul_toSpanSingleton (x y : A) :
+    toSpanSingleton R A x * toSpanSingleton R A y = toSpanSingleton R A (x * y) := by ext; simp
+
+end NonUnitalNonAssocSemiring
+
+open scoped ConvolutionProduct
+
+section NonUnitalNonAssocRing
+variable [NonUnitalNonAssocRing A] [Module R A] [SMulCommClass R A A] [IsScalarTower R A A]
+  [AddCommMonoid C] [Module R C] [CoalgebraStruct R C]
+
+/-- Non-unital and non-associative convolution ring structure on linear maps from a
+coalgebra to a non-unital and non-associative algebra. -/
+abbrev convNonUnitalNonAssocRing : NonUnitalNonAssocRing (C →ₗ[R] A) where
+
+scoped[ConvolutionProduct] attribute [instance] LinearMap.convNonUnitalNonAssocRing
+
+end NonUnitalNonAssocRing
+
+section NonUnitalSemiring
+variable [NonUnitalSemiring A] [Module R A] [SMulCommClass R A A] [IsScalarTower R A A]
+  [AddCommMonoid C] [Module R C] [Coalgebra R C]
+
+lemma nonUnitalAlgHom_comp_convMul_distrib
+    [NonUnitalNonAssocSemiring B] [Module R B] [SMulCommClass R B B] [IsScalarTower R B B]
+    (h : A →ₙₐ[R] B) (f g : C →ₗ[R] A) :
+    (h : A →ₗ[R] B).comp (f * g) = .comp h f * .comp h g := by
+  simp [convMul_def, map_comp, ← comp_assoc, NonUnitalAlgHom.comp_mul']
+
+lemma convMul_comp_coalgHom_distrib [AddCommMonoid B] [Module R B] [CoalgebraStruct R B]
+    (f g : C →ₗ[R] A) (h : B →ₗc[R] C) :
+    (f * g).comp h.toLinearMap = f.comp h.toLinearMap * g.comp h.toLinearMap := by
+  simp [convMul_def, map_comp, comp_assoc]
+
+/-- Non-unital convolution semiring structure on linear maps from a coalgebra to a
+non-unital algebra. -/
+abbrev convNonUnitalSemiring : NonUnitalSemiring (C →ₗ[R] A) where
+  mul_assoc f g h := calc
+        μ ∘ₗ (μ ∘ₗ (f ⊗ₘ g) ∘ₗ δ ⊗ₘ h) ∘ₗ δ
+    _ = (μ ∘ₗ .rTensor _ μ) ∘ₗ ((f ⊗ₘ g) ⊗ₘ h) ∘ₗ (.rTensor _ δ ∘ₗ δ) := by
+      rw [comp_assoc, ← comp_assoc _ _ (rTensor _ _), rTensor_comp_map,
+        ← comp_assoc _ (rTensor _ _), map_comp_rTensor, comp_assoc]
+    _ = (μ ∘ₗ rTensor _ μ)
+        ∘ₗ (((f ⊗ₘ g) ⊗ₘ h) ∘ₗ (TensorProduct.assoc R C C C).symm) ∘ₗ lTensor C δ ∘ₗ δ := by
+      simp only [comp_assoc, coassoc_symm]
+    _ = (μ ∘ₗ rTensor A μ ∘ₗ ↑(TensorProduct.assoc R A A A).symm)
+        ∘ₗ (f ⊗ₘ (g ⊗ₘ h)) ∘ₗ lTensor C δ ∘ₗ δ := by
+      simp only [map_map_comp_assoc_symm_eq, comp_assoc]
+    _ = (μ ∘ₗ .lTensor _ μ) ∘ₗ (f ⊗ₘ (g ⊗ₘ h)) ∘ₗ (lTensor C δ ∘ₗ δ) := by
+      congr 1
+      ext
+      simp [mul_assoc]
+    _ = μ ∘ₗ (f ⊗ₘ μ ∘ₗ (g ⊗ₘ h) ∘ₗ δ) ∘ₗ δ := by
+      rw [comp_assoc, ← comp_assoc _ _ (lTensor _ _), lTensor_comp_map,
+        ← comp_assoc _ (lTensor _ _), map_comp_lTensor, comp_assoc]
+
+scoped[ConvolutionProduct] attribute [instance] LinearMap.convNonUnitalSemiring
+
+end NonUnitalSemiring
+
+section NonUnitalRing
+variable [NonUnitalRing A] [AddCommMonoid C] [Module R A] [SMulCommClass R A A]
+  [IsScalarTower R A A] [Module R C] [Coalgebra R C]
+
+/-- Non-unital convolution ring structure on linear maps from a coalgebra to a
+non-unital algebra. -/
+abbrev convNonUnitalRing : NonUnitalRing (C →ₗ[R] A) where
+
+scoped[ConvolutionProduct] attribute [instance] LinearMap.convNonUnitalRing
+
+end NonUnitalRing
+
+section Semiring
+variable [Semiring A] [Algebra R A] [Semiring B] [Algebra R B] [AddCommMonoid C] [Module R C]
+
+section CoalgebraStruct
+variable [CoalgebraStruct R C]
+
+lemma algHom_comp_convMul_distrib (h : A →ₐ B) (f g : C →ₗ[R] A) :
+    h.toLinearMap.comp (f * g) = h.toLinearMap.comp f * h.toLinearMap.comp g := by
+  simp [convMul_def, map_comp, ← comp_assoc, AlgHom.comp_mul']
+
+end CoalgebraStruct
+
+variable [Coalgebra R C]
+
+/-- Convolution unit on linear maps from a coalgebra to an algebra. -/
+abbrev convOne : One (C →ₗ[R] A) where one := Algebra.linearMap R A ∘ₗ counit
+
+scoped[ConvolutionProduct] attribute [instance] LinearMap.convOne LinearMap.convMul
+
+lemma convOne_def : (1 : C →ₗ[R] A) = Algebra.linearMap R A ∘ₗ counit := rfl
+
+@[simp] lemma convOne_apply (c : C) : (1 : C →ₗ[R] A) c = algebraMap R A (counit (R := R) c) := rfl
+
+/-- Convolution semiring structure on linear maps from a coalgebra to an algebra. -/
+abbrev convSemiring : Semiring (C →ₗ[R] A) where
+  one_mul f := by ext; simp [convOne_def, ← map_comp_rTensor]
+  mul_one f := by ext; simp [convOne_def, ← map_comp_lTensor]
+
+scoped[ConvolutionProduct] attribute [instance] LinearMap.convSemiring
+
+end Semiring
+
+section CommSemiring
+variable [CommSemiring A] [AddCommMonoid C] [Algebra R A] [Module R C] [Coalgebra R C]
+  [IsCocomm R C]
+
+/-- Commutative convolution semiring structure on linear maps from a cocommutative coalgebra to an
+algebra. -/
+abbrev convCommSemiring : CommSemiring (C →ₗ[R] A) where
+  mul_comm f g := by ext x; rw [convMul_apply, ← comm_comul R x, map_comm, mul'_comm, convMul_apply]
+
+scoped[ConvolutionProduct] attribute [instance] LinearMap.convCommSemiring
+
+end CommSemiring
+
+section Ring
+variable [Ring A] [AddCommMonoid C] [Algebra R A] [Module R C] [Coalgebra R C]
+
+/-- Convolution ring structure on linear maps from a coalgebra to an algebra. -/
+abbrev convRing : Ring (C →ₗ[R] A) where
+
+scoped[ConvolutionProduct] attribute [instance] LinearMap.convRing
+
+end Ring
+
+section CommRing
+variable [CommRing A] [AddCommMonoid C] [Algebra R A] [Module R C] [Coalgebra R C] [IsCocomm R C]
+
+/-- Commutative convolution ring structure on linear maps from a cocommutative coalgebra to an
+algebra. -/
+abbrev convCommRing : CommRing (C →ₗ[R] A) where
+
+scoped[ConvolutionProduct] attribute [instance] LinearMap.convCommRing
+
+end CommRing
+end LinearMap

--- a/Mathlib/RingTheory/Coalgebra/Convolution.lean
+++ b/Mathlib/RingTheory/Coalgebra/Convolution.lean
@@ -154,7 +154,7 @@ variable [Coalgebra R C]
 /-- Convolution unit on linear maps from a coalgebra to an algebra. -/
 abbrev convOne : One (C →ₗ[R] A) where one := Algebra.linearMap R A ∘ₗ counit
 
-scoped[ConvolutionProduct] attribute [instance] LinearMap.convOne LinearMap.convMul
+scoped[ConvolutionProduct] attribute [instance] LinearMap.convOne
 
 lemma convOne_def : (1 : C →ₗ[R] A) = Algebra.linearMap R A ∘ₗ counit := rfl
 

--- a/Mathlib/RingTheory/Regular/RegularSequence.lean
+++ b/Mathlib/RingTheory/Regular/RegularSequence.lean
@@ -573,7 +573,7 @@ lemma map_first_exact_on_four_term_right_exact_of_isSMulRegular_last
 
 section Perm
 
-open LinearMap in
+open _root_.LinearMap in
 private lemma IsWeaklyRegular.swap {a b : R} (h1 : IsWeaklyRegular M [a, b])
     (h2 : torsionBy R M b = a • torsionBy R M b → torsionBy R M b = ⊥) :
     IsWeaklyRegular M [b, a] := by


### PR DESCRIPTION
Construct the ring structure on linear maps `C → A` where `C` is a coalgebra and `A` an algebra, where multiplication is given by
`(f * g)(x) = ∑ f x₍₁₎ * g x₍₂₎` in Sweedler notation or
```
         |
         μ
|   |   / \
f * g = f g
|   |   \ /
         δ
         |
```
diagrammatically, where `μ` stands for multiplication and `δ` for comultiplication.

[Zulip](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/.60Mul.60.20instance.20on.20algebra.20homomorphisms.20from.20monoid.20algebra)

From Toric

Co-authored-by: Michał Mrugała <kiolterino@gmail.com>
Co-authored-by: Yunzhou Xie


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
