### PR TITLE
feat: add `isPrincipalIdealRing_of_isPrincipal_of_lt_or_isPrincipal_of_mem_primesOver_of_mem_Icc`

### DIFF
--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -125,13 +125,15 @@ theorem isPrincipalIdealRing_of_isPrincipal_of_norm_le_of_isPrime
     absNorm_dvd_absNorm_of_le <| le_of_dvd <|
       UniqueFactorizationMonoid.dvd_of_mem_normalizedFactors hJ).trans hI
 
+set_option linter.style.longLine false in
 /-- Let `K` be a number field and let `M K` be the Minkowski bound of `K`.
 To show that `𝓞 K` is a PID it is enough to show that, for all (natural) primes
 `p ∈ Finset.Icc 1 ⌊(M K)⌋₊`, all ideals `P` above `p` such that
 `p ^ (span ({p}).inertiaDeg P) ≤ ⌊(M K)⌋₊` are principal. This is the standard technique to prove
 that `𝓞 K` is principal, see [marcus1977number], discussion after Theorem 37.
 If `K/ℚ` is Galois, one can use the more convenient
-`isPrincipalIdealRing_of_isPrincipal_of_lt_or_isPrincipal_of_mem_primesOver_of_mem_Icc`.
+`RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_lt_or_isPrincipal_of_mem_primesOver_of_mem_Icc`
+below.
 
 The way this theorem should be used is to first compute `⌊(M K)⌋₊` and then to use `fin_cases`
 to deal with the finite number of primes `p` in the interval. -/

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -34,7 +34,7 @@ be a number field such that `K/ℚ` is Galois and let `M K` be the Minkowski bou
 (by definition it is
 `(4 / π) ^ nrComplexPlaces K * ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|)`).
 To show that `𝓞 K` is a PID it is enough to show that, for all (natural) primes
-`p ∈ Finset.Icc 1 ⌊(M K)⌋₊`, there is an ideal `P` above `p` such that
+`p ∈ Finset.Icc 1 ⌊(M K)⌋₊`, there is an ideal `P` above `p` such that either
 `⌊(M K)⌋₊ < p ^ (span ({p}).inertiaDeg P)` or `P` is principal. This is the standard technique to
 prove that `𝓞 K` is principal, see [marcus1977number], discussion after Theorem 37.
 

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -17,27 +17,22 @@ the class group of its ring of integers. It also proves some elementary results
 on the class number.
 
 ## Main definitions
+We denote by `M K` the Minkowski bound of a number field `K`, defined as
+`(4 / π) ^ nrComplexPlaces K * ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|)`.
 - `NumberField.classNumber`: the class number of a number field is the (finite)
 cardinality of the class group of its ring of integers
 - `isPrincipalIdealRing_of_isPrincipal_of_pow_le_of_mem_primesOver_of_mem_Icc`: let `K`
-be a number field and let `M K` be the Minkowski bound of `K` (by definition it is
-`(4 / π) ^ nrComplexPlaces K * ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|)`).
-To show that `𝓞 K` is a PID it is enough to show that, for all (natural) primes
+be a number field. To show that `𝓞 K` is a PID it is enough to show that, for all (natural) primes
 `p ∈ Finset.Icc 1 ⌊(M K)⌋₊`, all ideals `P` above `p` such that
 `p ^ (span ({p}).inertiaDeg P) ≤ ⌊(M K)⌋₊` are principal. This is the standard technique to prove
 that `𝓞 K` is principal, see [marcus1977number], discussion after Theorem 37.
-
 The way this theorem should be used is to first compute `⌊(M K)⌋₊` and then to use `fin_cases`
 to deal with the finite number of primes `p` in the interval.
 - `isPrincipalIdealRing_of_isPrincipal_of_lt_or_isPrincipal_of_mem_primesOver_of_mem_Icc`: let `K`
-be a number field such that `K/ℚ` is Galois and let `M K` be the Minkowski bound of `K`
-(by definition it is
-`(4 / π) ^ nrComplexPlaces K * ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|)`).
-To show that `𝓞 K` is a PID it is enough to show that, for all (natural) primes
-`p ∈ Finset.Icc 1 ⌊(M K)⌋₊`, there is an ideal `P` above `p` such that either
-`⌊(M K)⌋₊ < p ^ (span ({p}).inertiaDeg P)` or `P` is principal. This is the standard technique to
-prove that `𝓞 K` is principal, see [marcus1977number], discussion after Theorem 37.
-
+be a number field such that `K/ℚ` is Galois. To show that `𝓞 K` is a PID it is enough to show that,
+for all (natural) primes `p ∈ Finset.Icc 1 ⌊(M K)⌋₊`, there is an ideal `P` above `p` such that
+either `⌊(M K)⌋₊ < p ^ (span ({p}).inertiaDeg P)` or `P` is principal. This is the standard
+technique to prove that `𝓞 K` is principal, see [marcus1977number], discussion after Theorem 37.
 The way this theorem should be used is to first compute `⌊(M K)⌋₊` and then to use `fin_cases`
 to deal with the finite number of primes `p` in the interval.
 -/
@@ -173,8 +168,9 @@ theorem isPrincipalIdealRing_of_isPrincipal_of_pow_le_of_mem_primesOver_of_mem_I
 `(4 / π) ^ nrComplexPlaces K * ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|)`).
 To show that `𝓞 K` is a PID it is enough to show that, for all (natural) primes
 `p ∈ Finset.Icc 1 ⌊(M K)⌋₊`, there is an ideal `P` above `p` such that
-`⌊(M K)⌋₊ < p ^ (span ({p}).inertiaDeg P)` or `P`is principal. This is the standard technique to
-prove that `𝓞 K` is principal in the Galois case, see [marcus1977number], discussion after Theorem 37.
+either `⌊(M K)⌋₊ < p ^ (span ({p}).inertiaDeg P)` or `P` is principal. This is the standard
+technique to prove that `𝓞 K` is principal in the Galois case, see [marcus1977number], discussion
+after Theorem 37.
 
 The way this theorem should be used is to first compute `⌊(M K)⌋₊` and then to use `fin_cases`
 to deal with the finite number of primes `p` in the interval. -/

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -35,7 +35,7 @@ be a number field such that `K/ℚ` is Galois and let `M K` be the Minkowski bou
 `(4 / π) ^ nrComplexPlaces K * ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|)`).
 To show that `𝓞 K` is a PID it is enough to show that, for all (natural) primes
 `p ∈ Finset.Icc 1 ⌊(M K)⌋₊`, there is an ideal `P` above `p` such that
-`⌊(M K)⌋₊ < p ^ (span ({p}).inertiaDeg P)` or `P`is principal. This is the standard technique to
+`⌊(M K)⌋₊ < p ^ (span ({p}).inertiaDeg P)` or `P` is principal. This is the standard technique to
 prove that `𝓞 K` is principal, see [marcus1977number], discussion after Theorem 37.
 
 The way this theorem should be used is to first compute `⌊(M K)⌋₊` and then to use `fin_cases`

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -174,7 +174,7 @@ theorem isPrincipalIdealRing_of_isPrincipal_of_pow_le_of_mem_primesOver_of_mem_I
 To show that `𝓞 K` is a PID it is enough to show that, for all (natural) primes
 `p ∈ Finset.Icc 1 ⌊(M K)⌋₊`, there is an ideal `P` above `p` such that
 `⌊(M K)⌋₊ < p ^ (span ({p}).inertiaDeg P)` or `P`is principal. This is the standard technique to
-prove that `𝓞 K` is principal, see [marcus1977number], discussion after Theorem 37.
+prove that `𝓞 K` is principal in the Galois case, see [marcus1977number], discussion after Theorem 37.
 
 The way this theorem should be used is to first compute `⌊(M K)⌋₊` and then to use `fin_cases`
 to deal with the finite number of primes `p` in the interval. -/

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -125,8 +125,7 @@ theorem isPrincipalIdealRing_of_isPrincipal_of_norm_le_of_isPrime
     absNorm_dvd_absNorm_of_le <| le_of_dvd <|
       UniqueFactorizationMonoid.dvd_of_mem_normalizedFactors hJ).trans hI
 
-/-- Let `K` be a number field and let `M K` be the Minkowski bound of `K` (by definition it is
-`(4 / π) ^ nrComplexPlaces K * ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|)`).
+/-- Let `K` be a number field and let `M K` be the Minkowski bound of `K`.
 To show that `𝓞 K` is a PID it is enough to show that, for all (natural) primes
 `p ∈ Finset.Icc 1 ⌊(M K)⌋₊`, all ideals `P` above `p` such that
 `p ^ (span ({p}).inertiaDeg P) ≤ ⌊(M K)⌋₊` are principal. This is the standard technique to prove
@@ -164,9 +163,7 @@ theorem isPrincipalIdealRing_of_isPrincipal_of_pow_le_of_mem_primesOver_of_mem_I
     exact hspan ▸ inertiaDeg_pos ..
   · exact hspan ▸ hlies
 
-/-- Let `K` be a number field such that `K/ℚ` is Galois and let `M K` be the Minkowski bound of `K`
-(by definition it is
-`(4 / π) ^ nrComplexPlaces K * ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|)`).
+/-- Let `K` be a number field such that `K/ℚ` is Galois and let `M K` be the Minkowski bound of `K`.
 To show that `𝓞 K` is a PID it is enough to show that, for all (natural) primes
 `p ∈ Finset.Icc 1 ⌊(M K)⌋₊`, there is an ideal `P` above `p` such that
 either `⌊(M K)⌋₊ < p ^ (span ({p}).inertiaDeg P)` or `P` is principal. This is the standard

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -180,7 +180,7 @@ theorem isPrincipalIdealRing_of_isPrincipal_of_lt_or_isPrincipal_of_mem_primesOv
         ⌊(M K)⌋₊ < p ^ ((span ({↑p} : Set ℤ)).inertiaDeg P) ∨
           Submodule.IsPrincipal P) :
       IsPrincipalIdealRing (𝓞 K) := by
-refine isPrincipalIdealRing_of_isPrincipal_of_pow_le_of_mem_primesOver_of_mem_Icc
+  refine isPrincipalIdealRing_of_isPrincipal_of_pow_le_of_mem_primesOver_of_mem_Icc
     (fun p hpmem hp P ⟨hP1, hP2⟩ hple ↦ ?_)
   obtain ⟨Q, ⟨hQ1, hQ2⟩, H⟩ := h p hpmem hp
   have := (isPrime_of_prime (prime_span_singleton_iff.mpr (prime_iff_prime_int.mp hp))).isMaximal

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -184,10 +184,9 @@ theorem isPrincipalIdealRing_of_isPrincipal_of_lt_or_isPrincipal_of_mem_primesOv
         ⌊(M K)⌋₊ < p ^ ((span ({↑p} : Set ℤ)).inertiaDeg P) ∨
           Submodule.IsPrincipal P) :
       IsPrincipalIdealRing (𝓞 K) := by
-  refine isPrincipalIdealRing_of_isPrincipal_of_pow_le_of_mem_primesOver_of_mem_Icc
-    (fun p hpmem hp P hP hple ↦ ?_)
-  obtain ⟨Q, hQ, H⟩ := h p hpmem hp
-  have := hP.1; have := hP.2; have := hQ.1; have := hQ.2
+refine isPrincipalIdealRing_of_isPrincipal_of_pow_le_of_mem_primesOver_of_mem_Icc
+    (fun p hpmem hp P ⟨hP1, hP2⟩ hple ↦ ?_)
+  obtain ⟨Q, ⟨hQ1, hQ2⟩, H⟩ := h p hpmem hp
   have := (isPrime_of_prime (prime_span_singleton_iff.mpr (prime_iff_prime_int.mp hp))).isMaximal
     (by simp [hp.ne_zero])
   by_cases h : ⌊(M K)⌋₊ < p ^ ((span ({↑p} : Set ℤ)).inertiaDeg P)

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -32,7 +32,8 @@ to deal with the finite number of primes `p` in the interval.
 be a number field such that `K/ℚ` is Galois. To show that `𝓞 K` is a PID it is enough to show that,
 for all (natural) primes `p ∈ Finset.Icc 1 ⌊(M K)⌋₊`, there is an ideal `P` above `p` such that
 either `⌊(M K)⌋₊ < p ^ (span ({p}).inertiaDeg P)` or `P` is principal. This is the standard
-technique to prove that `𝓞 K` is principal, see [marcus1977number], discussion after Theorem 37.
+technique to prove that `𝓞 K` is principal in the Galois case, see [marcus1977number], discussion
+after Theorem 37.
 The way this theorem should be used is to first compute `⌊(M K)⌋₊` and then to use `fin_cases`
 to deal with the finite number of primes `p` in the interval.
 -/

--- a/Mathlib/NumberTheory/NumberField/ClassNumber.lean
+++ b/Mathlib/NumberTheory/NumberField/ClassNumber.lean
@@ -7,7 +7,7 @@ import Mathlib.NumberTheory.ClassNumber.AdmissibleAbs
 import Mathlib.NumberTheory.ClassNumber.Finite
 import Mathlib.NumberTheory.NumberField.Discriminant.Basic
 import Mathlib.RingTheory.Ideal.IsPrincipal
-import Mathlib.NumberTheory.RamificationInertia.Basic
+import Mathlib.NumberTheory.RamificationInertia.Galois
 
 /-!
 # Class numbers of number fields
@@ -19,13 +19,24 @@ on the class number.
 ## Main definitions
 - `NumberField.classNumber`: the class number of a number field is the (finite)
 cardinality of the class group of its ring of integers
-- `isPrincipalIdealRing_of_isPrincipal_of_pow_inertiaDeg_le_of_mem_primesOver_of_mem_Icc`: let `K`
+- `isPrincipalIdealRing_of_isPrincipal_of_pow_le_of_mem_primesOver_of_mem_Icc`: let `K`
 be a number field and let `M K` be the Minkowski bound of `K` (by definition it is
 `(4 / π) ^ nrComplexPlaces K * ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|)`).
 To show that `𝓞 K` is a PID it is enough to show that, for all (natural) primes
 `p ∈ Finset.Icc 1 ⌊(M K)⌋₊`, all ideals `P` above `p` such that
 `p ^ (span ({p}).inertiaDeg P) ≤ ⌊(M K)⌋₊` are principal. This is the standard technique to prove
 that `𝓞 K` is principal, see [marcus1977number], discussion after Theorem 37.
+
+The way this theorem should be used is to first compute `⌊(M K)⌋₊` and then to use `fin_cases`
+to deal with the finite number of primes `p` in the interval.
+- `isPrincipalIdealRing_of_isPrincipal_of_lt_or_isPrincipal_of_mem_primesOver_of_mem_Icc`: let `K`
+be a number field such that `K/ℚ` is Galois and let `M K` be the Minkowski bound of `K`
+(by definition it is
+`(4 / π) ^ nrComplexPlaces K * ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|)`).
+To show that `𝓞 K` is a PID it is enough to show that, for all (natural) primes
+`p ∈ Finset.Icc 1 ⌊(M K)⌋₊`, there is an ideal `P` above `p` such that
+`⌊(M K)⌋₊ < p ^ (span ({p}).inertiaDeg P)` or `P`is principal. This is the standard technique to
+prove that `𝓞 K` is principal, see [marcus1977number], discussion after Theorem 37.
 
 The way this theorem should be used is to first compute `⌊(M K)⌋₊` and then to use `fin_cases`
 to deal with the finite number of primes `p` in the interval.
@@ -124,10 +135,12 @@ To show that `𝓞 K` is a PID it is enough to show that, for all (natural) prim
 `p ∈ Finset.Icc 1 ⌊(M K)⌋₊`, all ideals `P` above `p` such that
 `p ^ (span ({p}).inertiaDeg P) ≤ ⌊(M K)⌋₊` are principal. This is the standard technique to prove
 that `𝓞 K` is principal, see [marcus1977number], discussion after Theorem 37.
+If `K/ℚ` is Galois, one can use the more convenient
+`isPrincipalIdealRing_of_isPrincipal_of_lt_or_isPrincipal_of_mem_primesOver_of_mem_Icc`.
 
 The way this theorem should be used is to first compute `⌊(M K)⌋₊` and then to use `fin_cases`
 to deal with the finite number of primes `p` in the interval. -/
-theorem isPrincipalIdealRing_of_isPrincipal_of_pow_inertiaDeg_le_of_mem_primesOver_of_mem_Icc
+theorem isPrincipalIdealRing_of_isPrincipal_of_pow_le_of_mem_primesOver_of_mem_Icc
     (h : ∀ p ∈ Finset.Icc 1 ⌊(M K)⌋₊, p.Prime → ∀ (P : Ideal (𝓞 K)),
       P ∈ primesOver (span {(p : ℤ)}) (𝓞 K) → p ^ ((span ({↑p} : Set ℤ)).inertiaDeg P) ≤ ⌊(M K)⌋₊ →
       Submodule.IsPrincipal P) : IsPrincipalIdealRing (𝓞 K) := by
@@ -154,6 +167,34 @@ theorem isPrincipalIdealRing_of_isPrincipal_of_pow_inertiaDeg_le_of_mem_primesOv
       hpprime (hP.under _))).isMaximal <| by simp [((hpprime (hP.under _))).ne_zero]
     exact hspan ▸ inertiaDeg_pos ..
   · exact hspan ▸ hlies
+
+/-- Let `K` be a number field such that `K/ℚ` is Galois and let `M K` be the Minkowski bound of `K`
+(by definition it is
+`(4 / π) ^ nrComplexPlaces K * ((finrank ℚ K)! / (finrank ℚ K) ^ (finrank ℚ K) * √|discr K|)`).
+To show that `𝓞 K` is a PID it is enough to show that, for all (natural) primes
+`p ∈ Finset.Icc 1 ⌊(M K)⌋₊`, there is an ideal `P` above `p` such that
+`⌊(M K)⌋₊ < p ^ (span ({p}).inertiaDeg P)` or `P`is principal. This is the standard technique to
+prove that `𝓞 K` is principal, see [marcus1977number], discussion after Theorem 37.
+
+The way this theorem should be used is to first compute `⌊(M K)⌋₊` and then to use `fin_cases`
+to deal with the finite number of primes `p` in the interval. -/
+theorem isPrincipalIdealRing_of_isPrincipal_of_lt_or_isPrincipal_of_mem_primesOver_of_mem_Icc
+    [IsGalois ℚ K] (h : ∀ p ∈ Finset.Icc 1 ⌊(M K)⌋₊, p.Prime →
+      ∃ P ∈ primesOver (span {(p : ℤ)}) (𝓞 K),
+        ⌊(M K)⌋₊ < p ^ ((span ({↑p} : Set ℤ)).inertiaDeg P) ∨
+          Submodule.IsPrincipal P) :
+      IsPrincipalIdealRing (𝓞 K) := by
+  refine isPrincipalIdealRing_of_isPrincipal_of_pow_le_of_mem_primesOver_of_mem_Icc
+    (fun p hpmem hp P hP hple ↦ ?_)
+  obtain ⟨Q, hQ, H⟩ := h p hpmem hp
+  have := hP.1; have := hP.2; have := hQ.1; have := hQ.2
+  have := (isPrime_of_prime (prime_span_singleton_iff.mpr (prime_iff_prime_int.mp hp))).isMaximal
+    (by simp [hp.ne_zero])
+  by_cases h : ⌊(M K)⌋₊ < p ^ ((span ({↑p} : Set ℤ)).inertiaDeg P)
+  · linarith
+  rw [inertiaDeg_eq_of_isGalois _ Q P ℚ K] at H
+  obtain ⟨σ, rfl⟩ := exists_map_eq_of_isGalois (span ({↑p} : Set ℤ)) Q P ℚ K
+  exact (H.resolve_left h).map_ringHom σ
 
 theorem isPrincipalIdealRing_of_abs_discr_lt
     (h : |discr K| < (2 * (π / 4) ^ nrComplexPlaces K *


### PR DESCRIPTION
The standard technique to prove that `𝓞 K` is principal in the Galois case.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
