### PR TITLE
feat(GroupTheory/Divisible): Add rational SMul and Module

### DIFF
--- a/Mathlib/Data/Rat/Lemmas.lean
+++ b/Mathlib/Data/Rat/Lemmas.lean
@@ -91,6 +91,18 @@ theorem mul_den (q₁ q₂ : ℚ) :
       q₁.den * q₂.den / Nat.gcd (q₁.num * q₂.num).natAbs (q₁.den * q₂.den) := by
   rw [mul_def, normalize_eq]
 
+theorem den_mul_den_eq_den_mul_gcd (q₁ q₂ : ℚ) :
+    q₁.den * q₂.den = (q₁ * q₂).den * ((q₁.num * q₂.num).natAbs.gcd (q₁.den * q₂.den)) := by
+  rw [Rat.mul_den]
+  exact ((Nat.dvd_iff_div_mul_eq _ _).mp (Nat.gcd_dvd_right _ _)).symm
+
+theorem num_mul_num_eq_num_mul_gcd (q₁ q₂ : ℚ) :
+    q₁.num * q₂.num = (q₁ * q₂).num * ((q₁.num * q₂.num).natAbs.gcd (q₁.den * q₂.den)) := by
+  rw [Rat.mul_num]
+  refine Eq.symm (Int.ediv_mul_cancel ?_)
+  rw [← Int.dvd_natAbs]
+  exact Int.ofNat_dvd.mpr (Nat.gcd_dvd_left _ _)
+
 theorem mul_self_num (q : ℚ) : (q * q).num = q.num * q.num := by
   rw [mul_num, Int.natAbs_mul, Nat.Coprime.gcd_eq_one, Int.ofNat_one, Int.ediv_one]
   exact (q.reduced.mul_right q.reduced).mul (q.reduced.mul_right q.reduced)


### PR DESCRIPTION
This is part of #25140. A torsion-free ℕ-divisible commutative group is a ℚ-module.

This new instance could collide with existing instances such as ℚ-module on ℝ that comes from `Algebra`. I don't know how much an issue this is. I set the new instance with low priority so hopefully it won't interfere existing instances.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
