### PR TITLE
[Merged by Bors] - feat: add a recursor for WithLp

### DIFF
--- a/Mathlib/Analysis/Normed/Lp/WithLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/WithLp.lean
@@ -56,7 +56,7 @@ protected def equiv : WithLp p V ≃ V := Equiv.refl _
 
 /-- A recursor for `WithLp p V`, that reduces to the underlying space `V`.
 
-This unfortunately cannot be registed with `cases_eliminator`, but it can still be used as
+This unfortunately cannot be registered with `cases_eliminator`, but it can still be used as
 `cases v using WithLp.rec with | toLp v =>`. -/
 @[elab_as_elim]
 protected def rec {motive : WithLp p V → Sort*}

--- a/Mathlib/Analysis/Normed/Lp/WithLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/WithLp.lean
@@ -59,7 +59,8 @@ protected def equiv : WithLp p V ≃ V := Equiv.refl _
 This unfortunately cannot be registed with `cases_eliminator`, but it can still be used as
 `cases v using WithLp.rec with | toLp v =>`. -/
 @[elab_as_elim]
-protected def rec (motive : WithLp p V → Sort*) (toLp : ∀ v : V, motive ((WithLp.equiv p _).symm v)) :
+protected def rec {motive : WithLp p V → Sort*}
+    (toLp : ∀ v : V, motive ((WithLp.equiv p _).symm v)) :
     ∀ v, motive v :=
   fun v => toLp ((WithLp.equiv p _) v)
 

--- a/Mathlib/Analysis/Normed/Lp/WithLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/WithLp.lean
@@ -54,6 +54,15 @@ namespace WithLp
 back and forth between the representations. -/
 protected def equiv : WithLp p V ≃ V := Equiv.refl _
 
+/-- A recursor for `WithLp p V`, that reduces to the underlying space `V`.
+
+This unfortunately cannot be registed with `cases_eliminator`, but it can still be used as
+`cases v using WithLp.rec with | toLp v =>`. -/
+@[elab_as_elim]
+protected def rec (motive : WithLp p V → Sort*) (toLp : ∀ v : V, motive ((WithLp.equiv p _).symm v)) :
+    ∀ v, motive v :=
+  fun v => toLp ((WithLp.equiv p _) v)
+
 /-! `WithLp p V` inherits various module-adjacent structures from `V`. -/
 
 instance instNontrivial [Nontrivial V] : Nontrivial (WithLp p V) := ‹Nontrivial V›


### PR DESCRIPTION
Zulip thread: [#new members > Using crossProduct in EuclideanSpace (Fin 3) @ 💬](https://leanprover.zulipchat.com/#narrow/channel/113489-new-members/topic/Using.20crossProduct.20in.20EuclideanSpace.20.28Fin.203.29/near/520303699)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
