### PR TITLE
[Merged by Bors] - chore(RingTheory/HopfAlgebra): redo tensor product

### DIFF
--- a/Mathlib/Algebra/Category/CoalgCat/ComonEquivalence.lean
+++ b/Mathlib/Algebra/Category/CoalgCat/ComonEquivalence.lean
@@ -7,6 +7,8 @@ import Mathlib.CategoryTheory.Monoidal.Braided.Opposite
 import Mathlib.Algebra.Category.ModuleCat.Monoidal.Symmetric
 import Mathlib.CategoryTheory.Monoidal.Comon_
 import Mathlib.Algebra.Category.CoalgCat.Basic
+import Mathlib.RingTheory.Coalgebra.TensorProduct
+import Mathlib.LinearAlgebra.TensorProduct.Tower
 
 /-!
 # The category equivalence between `R`-coalgebras and comonoid objects in `R-Mod`
@@ -147,10 +149,8 @@ theorem comul_tensorObj :
     Coalgebra.comul (R := R) (A := (CoalgCat.of R M ⊗ CoalgCat.of R N : CoalgCat R))
       = Coalgebra.comul (A := M ⊗[R] N) := by
   rw [ofComonObjCoalgebraStruct_comul]
-  dsimp only [Equivalence.symm_inverse, comonEquivalence_functor, toComon_obj,
-    comul_def]
-  simp only [Comon_.monoidal_tensorObj_comul, toComonObj_X,
-    toComonObj_comul, tensorμ_eq_tensorTensorTensorComm]
+  simp [tensorμ_eq_tensorTensorTensorComm, TensorProduct.comul_def,
+    AlgebraTensorModule.tensorTensorTensorComm_eq]
   rfl
 
 theorem comul_tensorObj_tensorObj_right :
@@ -158,14 +158,11 @@ theorem comul_tensorObj_tensorObj_right :
       (CoalgCat.of R N ⊗ CoalgCat.of R P) : CoalgCat R))
       = Coalgebra.comul (A := M ⊗[R] N ⊗[R] P) := by
   rw [ofComonObjCoalgebraStruct_comul]
-  dsimp only [Equivalence.symm_inverse, comonEquivalence_functor, toComon_obj,
-    comul_def]
-  simp only [Comon_.monoidal_tensorObj_comul, toComonObj_X, ModuleCat.of_coe, toComonObj_comul]
+  dsimp
+  simp only [Comon_.monoidal_tensorObj_comul, toComonObj_comul]
   rw [ofComonObjCoalgebraStruct_comul]
-  dsimp only [Equivalence.symm_inverse, comonEquivalence_functor, toComon_obj]
-  simp only [instMonoidalCategoryStruct_tensorObj, ModuleCat.MonoidalCategory.tensorObj,
-    ModuleCat.coe_of, Comon_.monoidal_tensorObj_comul, toComonObj_X, toComonObj_comul,
-    tensorμ_eq_tensorTensorTensorComm]
+  simp [tensorμ_eq_tensorTensorTensorComm, TensorProduct.comul_def,
+    AlgebraTensorModule.tensorTensorTensorComm_eq]
   rfl
 
 theorem comul_tensorObj_tensorObj_left :
@@ -173,31 +170,34 @@ theorem comul_tensorObj_tensorObj_left :
       (A := ((CoalgCat.of R M ⊗ CoalgCat.of R N) ⊗ CoalgCat.of R P : CoalgCat R))
       = Coalgebra.comul (A := (M ⊗[R] N) ⊗[R] P) := by
   rw [ofComonObjCoalgebraStruct_comul]
-  dsimp only [Equivalence.symm_inverse, comonEquivalence_functor, toComon_obj,
-    comul_def]
-  simp only [Comon_.monoidal_tensorObj_comul, toComonObj_X, ModuleCat.of_coe, toComonObj_comul]
+  dsimp
+  simp only [Comon_.monoidal_tensorObj_comul, toComonObj_comul]
   rw [ofComonObjCoalgebraStruct_comul]
-  dsimp only [Equivalence.symm_inverse, comonEquivalence_functor, toComon_obj]
-  simp only [instMonoidalCategoryStruct_tensorObj, ModuleCat.MonoidalCategory.tensorObj,
-    ModuleCat.coe_of, Comon_.monoidal_tensorObj_comul, toComonObj_X, toComonObj_comul,
-    tensorμ_eq_tensorTensorTensorComm]
+  simp [tensorμ_eq_tensorTensorTensorComm, TensorProduct.comul_def,
+    AlgebraTensorModule.tensorTensorTensorComm_eq]
   rfl
 
 theorem counit_tensorObj :
     Coalgebra.counit (R := R) (A := (CoalgCat.of R M ⊗ CoalgCat.of R N : CoalgCat R))
       = Coalgebra.counit (A := M ⊗[R] N) := by
+  rw [ofComonObjCoalgebraStruct_counit]
+  simp [TensorProduct.counit_def, TensorProduct.AlgebraTensorModule.rid_eq_rid, ← lid_eq_rid]
   rfl
 
 theorem counit_tensorObj_tensorObj_right :
     Coalgebra.counit (R := R)
       (A := (CoalgCat.of R M ⊗ (CoalgCat.of R N ⊗ CoalgCat.of R P) : CoalgCat R))
       = Coalgebra.counit (A := M ⊗[R] (N ⊗[R] P)) := by
-  ext; rfl
+  rw [ofComonObjCoalgebraStruct_counit]
+  simp [TensorProduct.counit_def, TensorProduct.AlgebraTensorModule.rid_eq_rid, ← lid_eq_rid]
+  rfl
 
 theorem counit_tensorObj_tensorObj_left :
     Coalgebra.counit (R := R)
       (A := ((CoalgCat.of R M ⊗ CoalgCat.of R N) ⊗ CoalgCat.of R P : CoalgCat R))
       = Coalgebra.counit (A := (M ⊗[R] N) ⊗[R] P) := by
-  ext; rfl
+  rw [ofComonObjCoalgebraStruct_counit]
+  simp [TensorProduct.counit_def, TensorProduct.AlgebraTensorModule.rid_eq_rid, ← lid_eq_rid]
+  rfl
 
 end CoalgCat.MonoidalCategoryAux

--- a/Mathlib/Algebra/Category/CoalgCat/ComonEquivalence.lean
+++ b/Mathlib/Algebra/Category/CoalgCat/ComonEquivalence.lean
@@ -3,12 +3,12 @@ Copyright (c) 2024 Amelia Livingston. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Amelia Livingston
 -/
-import Mathlib.CategoryTheory.Monoidal.Braided.Opposite
-import Mathlib.Algebra.Category.ModuleCat.Monoidal.Symmetric
-import Mathlib.CategoryTheory.Monoidal.Comon_
 import Mathlib.Algebra.Category.CoalgCat.Basic
-import Mathlib.RingTheory.Coalgebra.TensorProduct
+import Mathlib.Algebra.Category.ModuleCat.Monoidal.Symmetric
+import Mathlib.CategoryTheory.Monoidal.Braided.Opposite
+import Mathlib.CategoryTheory.Monoidal.Comon_
 import Mathlib.LinearAlgebra.TensorProduct.Tower
+import Mathlib.RingTheory.Coalgebra.TensorProduct
 
 /-!
 # The category equivalence between `R`-coalgebras and comonoid objects in `R-Mod`

--- a/Mathlib/Algebra/Category/CoalgCat/Monoidal.lean
+++ b/Mathlib/Algebra/Category/CoalgCat/Monoidal.lean
@@ -4,6 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Amelia Livingston
 -/
 
+import Mathlib.Algebra.Category.CoalgCat.Basic
+import Mathlib.Algebra.Category.ModuleCat.Monoidal.Basic
+import Mathlib.CategoryTheory.Monoidal.Transport
 import Mathlib.RingTheory.Coalgebra.TensorProduct
 
 /-!

--- a/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
@@ -520,6 +520,12 @@ theorem tensorTensorTensorComm_symm_tmul (m : M) (n : N) (p : P) (q : Q) :
     (tensorTensorTensorComm R A M N P Q).symm ((m ⊗ₜ p) ⊗ₜ (n ⊗ₜ q)) = (m ⊗ₜ n) ⊗ₜ (p ⊗ₜ q) :=
   rfl
 
+theorem tensorTensorTensorComm_eq :
+    tensorTensorTensorComm R R M N P Q = TensorProduct.tensorTensorTensorComm R M N P Q := by
+  apply LinearEquiv.toLinearMap_injective
+  ext
+  simp
+
 end tensorTensorTensorComm
 
 end CommSemiring

--- a/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
@@ -520,6 +520,7 @@ theorem tensorTensorTensorComm_symm_tmul (m : M) (n : N) (p : P) (q : Q) :
     (tensorTensorTensorComm R A M N P Q).symm ((m ⊗ₜ p) ⊗ₜ (n ⊗ₜ q)) = (m ⊗ₜ n) ⊗ₜ (p ⊗ₜ q) :=
   rfl
 
+/-- The heterobasic version of `tensorTensorTensorComm` coincides with the regular version. -/
 theorem tensorTensorTensorComm_eq :
     tensorTensorTensorComm R R M N P Q = TensorProduct.tensorTensorTensorComm R M N P Q := by
   apply LinearEquiv.toLinearMap_injective

--- a/Mathlib/RingTheory/Bialgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/Bialgebra/TensorProduct.lean
@@ -45,77 +45,78 @@ noncomputable instance _root_.TensorProduct.instBialgebra : Bialgebra R (A ⊗[R
   simp_all only [AlgHom.toLinearMap_apply] <;>
   simp only [map_one, map_mul]
 
-variable {R A B C D}
-
-variable [Semiring C] [Semiring D] [Bialgebra R C] [Bialgebra R D]
+variable {R A B C D : Type*} [CommRing R] [Ring A] [Ring B] [Ring C] [Ring D]
+    [Bialgebra R A] [Bialgebra R B] [Bialgebra R C] [Bialgebra R D]
 
 /-- The tensor product of two bialgebra morphisms as a bialgebra morphism. -/
-noncomputable def map (f : A →ₐc[R] C) (g : B →ₐc[R] D) :
-    A ⊗[R] B →ₐc[R] C ⊗[R] D :=
-  { Coalgebra.TensorProduct.map (f : A →ₗc[R] C) (g : B →ₗc[R] D),
-    Algebra.TensorProduct.map (f : A →ₐ[R] C) (g : B →ₐ[R] D) with }
+noncomputable def map (f : A →ₐc[R] B) (g : C →ₐc[R] D) :
+    A ⊗[R] C →ₐc[R] B ⊗[R] D :=
+  { Coalgebra.TensorProduct.map (f : A →ₗc[R] B) (g : C →ₗc[R] D),
+    Algebra.TensorProduct.map (f : A →ₐ[R] B) (g : C →ₐ[R] D) with }
 
 @[simp]
-theorem map_tmul (f : A →ₐc[R] C) (g : B →ₐc[R] D) (x : A) (y : B) :
+theorem map_tmul (f : A →ₐc[R] B) (g : C →ₐc[R] D) (x : A) (y : C) :
     map f g (x ⊗ₜ y) = f x ⊗ₜ g y :=
   rfl
 
 @[simp]
-theorem map_toCoalgHom (f : A →ₐc[R] C) (g : B →ₐc[R] D) :
-    map f g = Coalgebra.TensorProduct.map (f : A →ₗc[R] C) (g : B →ₗc[R] D) := rfl
+theorem map_toCoalgHom (f : A →ₐc[R] B) (g : C →ₐc[R] D) :
+    map f g = Coalgebra.TensorProduct.map (f : A →ₗc[R] B) (g : C →ₗc[R] D) := rfl
 
 @[simp]
-theorem map_toAlgHom (f : A →ₐc[R] C) (g : B →ₐc[R] D) :
-    (map f g : A ⊗[R] B →ₐ[R] C ⊗[R] D) =
-      Algebra.TensorProduct.map (f : A →ₐ[R] C) (g : B →ₐ[R] D) :=
+theorem map_toAlgHom (f : A →ₐc[R] B) (g : C →ₐc[R] D) :
+    (map f g : A ⊗[R] C →ₐ[R] B ⊗[R] D) =
+      Algebra.TensorProduct.map (f : A →ₐ[R] B) (g : C →ₐ[R] D) :=
   rfl
 
-variable (R A C D) in
+variable (R A B C) in
 /-- The associator for tensor products of R-bialgebras, as a bialgebra equivalence. -/
 protected noncomputable def assoc :
-    (A ⊗[R] C) ⊗[R] D ≃ₐc[R] A ⊗[R] (C ⊗[R] D) :=
-  { Coalgebra.TensorProduct.assoc R A C D, Algebra.TensorProduct.assoc R A C D with }
+    (A ⊗[R] B) ⊗[R] C ≃ₐc[R] A ⊗[R] (B ⊗[R] C) :=
+  { Coalgebra.TensorProduct.assoc R A B C, Algebra.TensorProduct.assoc R A B C with }
 
 @[simp]
-theorem assoc_tmul (x : A) (y : C) (z : D) :
-    Bialgebra.TensorProduct.assoc R A C D ((x ⊗ₜ y) ⊗ₜ z) = x ⊗ₜ (y ⊗ₜ z) :=
+theorem assoc_tmul (x : A) (y : B) (z : C) :
+    Bialgebra.TensorProduct.assoc R A B C ((x ⊗ₜ y) ⊗ₜ z) = x ⊗ₜ (y ⊗ₜ z) :=
   rfl
 
 @[simp]
-theorem assoc_symm_tmul (x : A) (y : C) (z : D) :
-    (Bialgebra.TensorProduct.assoc R A C D).symm (x ⊗ₜ (y ⊗ₜ z)) = (x ⊗ₜ y) ⊗ₜ z :=
+theorem assoc_symm_tmul (x : A) (y : B) (z : C) :
+    (Bialgebra.TensorProduct.assoc R A B C).symm (x ⊗ₜ (y ⊗ₜ z)) = (x ⊗ₜ y) ⊗ₜ z :=
   rfl
 
 @[simp]
 theorem assoc_toCoalgEquiv :
-    (Bialgebra.TensorProduct.assoc R A C D : _ ≃ₗc[R] _) =
-    Coalgebra.TensorProduct.assoc R A C D := rfl
+    (Bialgebra.TensorProduct.assoc R A B C : _ ≃ₗc[R] _) =
+    Coalgebra.TensorProduct.assoc R A B C := rfl
 
 @[simp]
 theorem assoc_toAlgEquiv :
-    (Bialgebra.TensorProduct.assoc R A C D : _ ≃ₐ[R] _) =
-    Algebra.TensorProduct.assoc R A C D := by ext; rfl
+    (Bialgebra.TensorProduct.assoc R A B C : _ ≃ₐ[R] _) =
+    Algebra.TensorProduct.assoc R A B C := by ext; rfl
 
-variable (R B) in
+variable (R A) in
 /-- The base ring is a left identity for the tensor product of bialgebras, up to
 bialgebra equivalence. -/
-protected noncomputable def lid : R ⊗[R] B ≃ₐc[R] B :=
-  { Coalgebra.TensorProduct.lid R B, Algebra.TensorProduct.lid R B with }
+protected noncomputable def lid : R ⊗[R] A ≃ₐc[R] A :=
+  { Coalgebra.TensorProduct.lid R A, Algebra.TensorProduct.lid R A with }
 
 @[simp]
 theorem lid_toCoalgEquiv :
-    (Bialgebra.TensorProduct.lid R B : R ⊗[R] B ≃ₗc[R] B) = Coalgebra.TensorProduct.lid R B := rfl
+    (Bialgebra.TensorProduct.lid R A : R ⊗[R] A ≃ₗc[R] A) = Coalgebra.TensorProduct.lid R A := rfl
 
 @[simp]
 theorem lid_toAlgEquiv :
-    (Bialgebra.TensorProduct.lid R B : R ⊗[R] B ≃ₐ[R] B) = Algebra.TensorProduct.lid R B := rfl
+    (Bialgebra.TensorProduct.lid R A : R ⊗[R] A ≃ₐ[R] A) = Algebra.TensorProduct.lid R A := rfl
 
 @[simp]
-theorem lid_tmul (r : R) (a : B) : Bialgebra.TensorProduct.lid R B (r ⊗ₜ a) = r • a := rfl
+theorem lid_tmul (r : R) (a : A) : Bialgebra.TensorProduct.lid R A (r ⊗ₜ a) = r • a := rfl
 
 @[simp]
-theorem lid_symm_apply (a : B) : (Bialgebra.TensorProduct.lid R B).symm a = 1 ⊗ₜ a := rfl
+theorem lid_symm_apply (a : A) : (Bialgebra.TensorProduct.lid R A).symm a = 1 ⊗ₜ a := rfl
 
+/- TODO: make this defeq, which would involve adding a heterobasic version of
+`Coalgebra.TensorProduct.rid`. -/
 theorem coalgebra_rid_eq_algebra_rid_apply (x : A ⊗[R] R) :
     Coalgebra.TensorProduct.rid R A x = Algebra.TensorProduct.rid R R A x := rfl
 

--- a/Mathlib/RingTheory/Bialgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/Bialgebra/TensorProduct.lean
@@ -23,7 +23,7 @@ namespace Bialgebra.TensorProduct
 open Coalgebra.TensorProduct
 
 variable (R A B C D : Type*) [CommSemiring R] [Semiring A] [Semiring B]
-  [Bialgebra R A] [Bialgebra R B]
+  [Bialgebra R A] [Bialgebra R B] [Semiring C] [Semiring D] [Bialgebra R C] [Bialgebra R D]
 
 lemma counit_eq_algHom_toLinearMap :
     Coalgebra.counit (R := R) (A := A ⊗[R] B) =
@@ -45,8 +45,7 @@ noncomputable instance _root_.TensorProduct.instBialgebra : Bialgebra R (A ⊗[R
   simp_all only [AlgHom.toLinearMap_apply] <;>
   simp only [map_one, map_mul]
 
-variable {R A B C D : Type*} [CommRing R] [Ring A] [Ring B] [Ring C] [Ring D]
-    [Bialgebra R A] [Bialgebra R B] [Bialgebra R C] [Bialgebra R D]
+variable {R A B C D}
 
 /-- The tensor product of two bialgebra morphisms as a bialgebra morphism. -/
 noncomputable def map (f : A →ₐc[R] B) (g : C →ₐc[R] D) :

--- a/Mathlib/RingTheory/Bialgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/Bialgebra/TensorProduct.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024 Amelia Livingston. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Amelia Livingston
+Authors: Amelia Livingston, Andrew Yang
 -/
 import Mathlib.RingTheory.Bialgebra.Equiv
 import Mathlib.RingTheory.Coalgebra.TensorProduct
@@ -14,126 +14,110 @@ We define the data in the monoidal structure on the category of bialgebras - e.g
 instance on a tensor product of bialgebras, and the tensor product of two `BialgHom`s as a
 `BialgHom`. This is done by combining the corresponding API for coalgebras and algebras.
 
-## Implementation notes
-
-Since the coalgebra instance on a tensor product of coalgebras is defined using a universe
-monomorphic monoidal category structure on `ModuleCat R`, we require our bialgebras to be in the
-same universe as the base ring `R` here too. Any contribution that achieves universe polymorphism
-would be welcome. For instance, the tensor product of bialgebras in the
-[FLT repo](https://github.com/ImperialCollegeLondon/FLT/blob/eef74b4538c8852363936dfaad23e6ffba72eca5/FLT/mathlibExperiments/Coalgebra/TensorProduct.lean)
-is already universe polymorphic since it does not go via category theory.
-
 -/
-
-universe v u
 
 open scoped TensorProduct
 
 namespace Bialgebra.TensorProduct
 
-variable (R A B : Type*) [CommRing R] [Ring A] [Ring B] [Bialgebra R A] [Bialgebra R B]
+open Coalgebra.TensorProduct
+
+variable (R A B C D : Type*) [CommSemiring R] [Semiring A] [Semiring B]
+  [Bialgebra R A] [Bialgebra R B]
 
 lemma counit_eq_algHom_toLinearMap :
     Coalgebra.counit (R := R) (A := A ⊗[R] B) =
-      ((Algebra.TensorProduct.lmul' R).comp (Algebra.TensorProduct.map
-      (Bialgebra.counitAlgHom R A) (Bialgebra.counitAlgHom R B))).toLinearMap := by
+      ((Algebra.TensorProduct.rid _ _ _).toAlgHom.comp (Algebra.TensorProduct.map
+      (Bialgebra.counitAlgHom R A) (Bialgebra.counitAlgHom R B))).toLinearMap :=
   rfl
 
 lemma comul_eq_algHom_toLinearMap :
     Coalgebra.comul (R := R) (A := A ⊗[R] B) =
       ((Algebra.TensorProduct.tensorTensorTensorComm R R A A B B).toAlgHom.comp
       (Algebra.TensorProduct.map (Bialgebra.comulAlgHom R A)
-      (Bialgebra.comulAlgHom R B))).toLinearMap := by
-  ext; simp [← Algebra.TensorProduct.toLinearEquiv_tensorTensorTensorComm]
+      (Bialgebra.comulAlgHom R B))).toLinearMap :=
+  rfl
 
-end Bialgebra.TensorProduct
-
-noncomputable instance TensorProduct.instBialgebra
-    {R A B : Type u} [CommRing R] [Ring A] [Ring B]
-    [Bialgebra R A] [Bialgebra R B] : Bialgebra R (A ⊗[R] B) := by
-  have hcounit := congr(DFunLike.coe $(Bialgebra.TensorProduct.counit_eq_algHom_toLinearMap R A B))
-  have hcomul := congr(DFunLike.coe $(Bialgebra.TensorProduct.comul_eq_algHom_toLinearMap R A B))
+noncomputable instance _root_.TensorProduct.instBialgebra : Bialgebra R (A ⊗[R] B) := by
+  have hcounit := congr(DFunLike.coe $(counit_eq_algHom_toLinearMap R A B))
+  have hcomul := congr(DFunLike.coe $(comul_eq_algHom_toLinearMap R A B))
   refine Bialgebra.mk' R (A ⊗[R] B) ?_ (fun {x y} => ?_) ?_ (fun {x y} => ?_) <;>
   simp_all only [AlgHom.toLinearMap_apply] <;>
   simp only [map_one, map_mul]
 
-namespace Bialgebra.TensorProduct
+variable {R A B C D}
 
-variable {R A B C D : Type u} [CommRing R] [Ring A] [Ring B] [Ring C] [Ring D]
-    [Bialgebra R A] [Bialgebra R B] [Bialgebra R C] [Bialgebra R D]
+variable [Semiring C] [Semiring D] [Bialgebra R C] [Bialgebra R D]
 
 /-- The tensor product of two bialgebra morphisms as a bialgebra morphism. -/
-noncomputable def map (f : A →ₐc[R] B) (g : C →ₐc[R] D) :
-    A ⊗[R] C →ₐc[R] B ⊗[R] D :=
-  { Coalgebra.TensorProduct.map (f : A →ₗc[R] B) (g : C →ₗc[R] D),
-    Algebra.TensorProduct.map (f : A →ₐ[R] B) (g : C →ₐ[R] D) with }
+noncomputable def map (f : A →ₐc[R] C) (g : B →ₐc[R] D) :
+    A ⊗[R] B →ₐc[R] C ⊗[R] D :=
+  { Coalgebra.TensorProduct.map (f : A →ₗc[R] C) (g : B →ₗc[R] D),
+    Algebra.TensorProduct.map (f : A →ₐ[R] C) (g : B →ₐ[R] D) with }
 
 @[simp]
-theorem map_tmul (f : A →ₐc[R] B) (g : C →ₐc[R] D) (x : A) (y : C) :
+theorem map_tmul (f : A →ₐc[R] C) (g : B →ₐc[R] D) (x : A) (y : B) :
     map f g (x ⊗ₜ y) = f x ⊗ₜ g y :=
   rfl
 
 @[simp]
-theorem map_toCoalgHom (f : A →ₐc[R] B) (g : C →ₐc[R] D) :
-    map f g = Coalgebra.TensorProduct.map (f : A →ₗc[R] B) (g : C →ₗc[R] D) := rfl
+theorem map_toCoalgHom (f : A →ₐc[R] C) (g : B →ₐc[R] D) :
+    map f g = Coalgebra.TensorProduct.map (f : A →ₗc[R] C) (g : B →ₗc[R] D) := rfl
 
 @[simp]
-theorem map_toAlgHom (f : A →ₐc[R] B) (g : C →ₐc[R] D) :
-    (map f g : A ⊗[R] C →ₐ[R] B ⊗[R] D) =
-      Algebra.TensorProduct.map (f : A →ₐ[R] B) (g : C →ₐ[R] D) :=
+theorem map_toAlgHom (f : A →ₐc[R] C) (g : B →ₐc[R] D) :
+    (map f g : A ⊗[R] B →ₐ[R] C ⊗[R] D) =
+      Algebra.TensorProduct.map (f : A →ₐ[R] C) (g : B →ₐ[R] D) :=
   rfl
 
-variable (R A B C) in
+variable (R A C D) in
 /-- The associator for tensor products of R-bialgebras, as a bialgebra equivalence. -/
 protected noncomputable def assoc :
-    (A ⊗[R] B) ⊗[R] C ≃ₐc[R] A ⊗[R] (B ⊗[R] C) :=
-  { Coalgebra.TensorProduct.assoc R A B C, Algebra.TensorProduct.assoc R A B C with }
+    (A ⊗[R] C) ⊗[R] D ≃ₐc[R] A ⊗[R] (C ⊗[R] D) :=
+  { Coalgebra.TensorProduct.assoc R A C D, Algebra.TensorProduct.assoc R A C D with }
 
 @[simp]
-theorem assoc_tmul (x : A) (y : B) (z : C) :
-    Bialgebra.TensorProduct.assoc R A B C ((x ⊗ₜ y) ⊗ₜ z) = x ⊗ₜ (y ⊗ₜ z) :=
+theorem assoc_tmul (x : A) (y : C) (z : D) :
+    Bialgebra.TensorProduct.assoc R A C D ((x ⊗ₜ y) ⊗ₜ z) = x ⊗ₜ (y ⊗ₜ z) :=
   rfl
 
 @[simp]
-theorem assoc_symm_tmul (x : A) (y : B) (z : C) :
-    (Bialgebra.TensorProduct.assoc R A B C).symm (x ⊗ₜ (y ⊗ₜ z)) = (x ⊗ₜ y) ⊗ₜ z :=
+theorem assoc_symm_tmul (x : A) (y : C) (z : D) :
+    (Bialgebra.TensorProduct.assoc R A C D).symm (x ⊗ₜ (y ⊗ₜ z)) = (x ⊗ₜ y) ⊗ₜ z :=
   rfl
 
 @[simp]
 theorem assoc_toCoalgEquiv :
-    (Bialgebra.TensorProduct.assoc R A B C : _ ≃ₗc[R] _) =
-    Coalgebra.TensorProduct.assoc R A B C := rfl
+    (Bialgebra.TensorProduct.assoc R A C D : _ ≃ₗc[R] _) =
+    Coalgebra.TensorProduct.assoc R A C D := rfl
 
 @[simp]
 theorem assoc_toAlgEquiv :
-    (Bialgebra.TensorProduct.assoc R A B C : _ ≃ₐ[R] _) =
-    Algebra.TensorProduct.assoc R A B C := rfl
+    (Bialgebra.TensorProduct.assoc R A C D : _ ≃ₐ[R] _) =
+    Algebra.TensorProduct.assoc R A C D := by ext; rfl
 
-variable (R A) in
+variable (R B) in
 /-- The base ring is a left identity for the tensor product of bialgebras, up to
 bialgebra equivalence. -/
-protected noncomputable def lid : R ⊗[R] A ≃ₐc[R] A :=
-  { Coalgebra.TensorProduct.lid R A, Algebra.TensorProduct.lid R A with }
+protected noncomputable def lid : R ⊗[R] B ≃ₐc[R] B :=
+  { Coalgebra.TensorProduct.lid R B, Algebra.TensorProduct.lid R B with }
 
 @[simp]
 theorem lid_toCoalgEquiv :
-    (Bialgebra.TensorProduct.lid R A : R ⊗[R] A ≃ₗc[R] A) = Coalgebra.TensorProduct.lid R A := rfl
+    (Bialgebra.TensorProduct.lid R B : R ⊗[R] B ≃ₗc[R] B) = Coalgebra.TensorProduct.lid R B := rfl
 
 @[simp]
 theorem lid_toAlgEquiv :
-    (Bialgebra.TensorProduct.lid R A : R ⊗[R] A ≃ₐ[R] A) = Algebra.TensorProduct.lid R A := rfl
+    (Bialgebra.TensorProduct.lid R B : R ⊗[R] B ≃ₐ[R] B) = Algebra.TensorProduct.lid R B := rfl
 
 @[simp]
-theorem lid_tmul (r : R) (a : A) : Bialgebra.TensorProduct.lid R A (r ⊗ₜ a) = r • a := rfl
+theorem lid_tmul (r : R) (a : B) : Bialgebra.TensorProduct.lid R B (r ⊗ₜ a) = r • a := rfl
 
 @[simp]
-theorem lid_symm_apply (a : A) : (Bialgebra.TensorProduct.lid R A).symm a = 1 ⊗ₜ a := rfl
+theorem lid_symm_apply (a : B) : (Bialgebra.TensorProduct.lid R B).symm a = 1 ⊗ₜ a := rfl
 
-/- TODO: make this defeq, which would involve adding a heterobasic version of
-`Coalgebra.TensorProduct.rid`. -/
 theorem coalgebra_rid_eq_algebra_rid_apply (x : A ⊗[R] R) :
-    Coalgebra.TensorProduct.rid R A x = Algebra.TensorProduct.rid R R A x :=
-  congr($((TensorProduct.AlgebraTensorModule.rid_eq_rid R A).symm) x)
+    Coalgebra.TensorProduct.rid R A x = Algebra.TensorProduct.rid R R A x := rfl
 
 variable (R A) in
 /-- The base ring is a right identity for the tensor product of bialgebras, up to
@@ -147,7 +131,7 @@ protected noncomputable def rid : A ⊗[R] R ≃ₐc[R] A where
 
 @[simp]
 theorem rid_toCoalgEquiv :
-    (Bialgebra.TensorProduct.rid R A : A ⊗[R] R ≃ₗc[R] A) = Coalgebra.TensorProduct.rid R A := rfl
+    (TensorProduct.rid R A : A ⊗[R] R ≃ₗc[R] A) = Coalgebra.TensorProduct.rid R A := rfl
 
 @[simp]
 theorem rid_toAlgEquiv :
@@ -164,7 +148,7 @@ theorem rid_symm_apply (a : A) : (Bialgebra.TensorProduct.rid R A).symm a = a �
 end Bialgebra.TensorProduct
 namespace BialgHom
 
-variable {R A B C : Type u} [CommRing R] [Ring A] [Ring B] [Ring C]
+variable {R A B C : Type*} [CommRing R] [Ring A] [Ring B] [Ring C]
     [Bialgebra R A] [Bialgebra R B] [Bialgebra R C]
 
 variable (A)

--- a/Mathlib/RingTheory/Coalgebra/Basic.lean
+++ b/Mathlib/RingTheory/Coalgebra/Basic.lean
@@ -3,9 +3,6 @@ Copyright (c) 2023 Ali Ramsey. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Ali Ramsey, Eric Wieser
 -/
-import Mathlib.Algebra.Algebra.Bilinear
-import Mathlib.LinearAlgebra.DFinsupp
-import Mathlib.LinearAlgebra.Prod
 import Mathlib.LinearAlgebra.TensorProduct.Finiteness
 import Mathlib.LinearAlgebra.TensorProduct.Associator
 

--- a/Mathlib/RingTheory/Coalgebra/Basic.lean
+++ b/Mathlib/RingTheory/Coalgebra/Basic.lean
@@ -380,36 +380,3 @@ instance instCoalgebra : Coalgebra R (ι →₀ A) where
         TensorProduct.map_map_comp_assoc_eq]
 
 end Finsupp
-
-namespace TensorProduct
-open Coalgebra
-
-variable {R A B : Type*} [CommSemiring R] [AddCommMonoid A] [AddCommMonoid B]
-  [Module R A] [Module R B] [CoalgebraStruct R A] [CoalgebraStruct R B]
-
-/-- See `Mathlib/RingTheory/Coalgebra/TensorProduct.lean` for the `Coalgebra` instance. -/
-instance instCoalgebraStruct : CoalgebraStruct R (A ⊗[R] B) where
-  comul := TensorProduct.tensorTensorTensorComm R A A B B ∘ₗ TensorProduct.map comul comul
-  counit := LinearMap.mul' R R ∘ₗ TensorProduct.map counit counit
-
-lemma comul_def :
-    Coalgebra.comul (R := R) (A := A ⊗[R] B) =
-    tensorTensorTensorComm R A A B B ∘ₗ map comul comul :=
-  rfl
-
-@[deprecated (since := "2025-04-09")] alias instCoalgebraStruct_comul := comul_def
-
-@[simp] lemma comul_tmul (a : A) (b : B) :
-    comul (R := R) (a ⊗ₜ[R] b) =
-      tensorTensorTensorComm _ _ _ _ _ (comul (R := R) a ⊗ₜ[R] comul (R := R) b) := rfl
-
-lemma counit_def :
-    Coalgebra.counit (R := R) (A := A ⊗[R] B) = LinearMap.mul' R R ∘ₗ map counit counit :=
-  rfl
-
-@[deprecated (since := "2025-04-09")] alias instCoalgebraStruct_counit := counit_def
-
-@[simp] lemma counit_tmul (a : A) (b : B) :
-    counit (R := R) (a ⊗ₜ[R] b) = counit a * counit b := rfl
-
-end TensorProduct

--- a/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
@@ -61,8 +61,8 @@ lemma counit_tmul (x : A) (y : B) :
 
 open Lean.Parser.Tactic in
 /-- `hopf_tensor_induction x with x₁ x₂` attempts to replace `x` by
-`x₁ ⊗ₜ x₂` via linearity. This is an implementation detail that is used to set up
-tensor products of coalgebras, bialgebras, and hopf algebras, and shouldn't be relied on downstream. -/
+`x₁ ⊗ₜ x₂` via linearity. This is an implementation detail that is used to set up tensor products
+of coalgebras, bialgebras, and hopf algebras, and shouldn't be relied on downstream. -/
 scoped macro "hopf_tensor_induction " var:elimTarget "with " var₁:ident var₂:ident : tactic =>
   `(tactic|
     (induction $var with

--- a/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
@@ -1,90 +1,160 @@
 /-
 Copyright (c) 2024 Amelia Livingston. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Amelia Livingston
+Authors: Amelia Livingston, Andrew Yang
 -/
-import Mathlib.Algebra.Category.CoalgCat.ComonEquivalence
+import Mathlib.LinearAlgebra.TensorProduct.Tower
+import Mathlib.RingTheory.Coalgebra.Equiv
 
 /-!
 # Tensor products of coalgebras
 
 Given two `R`-coalgebras `M, N`, we can define a natural comultiplication map
 `Δ : M ⊗[R] N → (M ⊗[R] N) ⊗[R] (M ⊗[R] N)` and counit map `ε : M ⊗[R] N → R` induced by
-the comultiplication and counit maps of `M` and `N`. These `Δ, ε` are declared as linear maps
-in `TensorProduct.instCoalgebraStruct` in `Mathlib/RingTheory/Coalgebra/Basic.lean`.
+the comultiplication and counit maps of `M` and `N`.
 
 In this file we show that `Δ, ε` satisfy the axioms of a coalgebra, and also define other data
 in the monoidal structure on `R`-coalgebras, like the tensor product of two coalgebra morphisms
 as a coalgebra morphism.
 
-## Implementation notes
-
-We keep the linear maps underlying `Δ, ε` and other definitions in this file syntactically equal
-to the corresponding definitions for tensor products of modules in the hope that this makes
-life easier. However, to fill in prop fields, we use the API in
-`Mathlib/Algebra/Category/CoalgCat/ComonEquivalence.lean`. That file defines the monoidal category
-structure on coalgebras induced by an equivalence with comonoid objects in the category of modules,
-`CoalgCat.instMonoidalCategoryAux`, but we do not declare this as an instance - we just use it
-to prove things. Then, we use the definitions in this file to make a monoidal category instance on
-`CoalgCat R` in `Mathlib/Algebra/Category/CoalgCat/Monoidal.lean` that has simpler data.
-
-However, this approach forces our coalgebras to be in the same universe as the base ring `R`,
-since it relies on the monoidal category structure on `ModuleCat R`, which is currently
-universe monomorphic. Any contribution that achieves universe polymorphism would be welcome. For
-instance, the tensor product of coalgebras in the
-[FLT repo](https://github.com/ImperialCollegeLondon/FLT/blob/eef74b4538c8852363936dfaad23e6ffba72eca5/FLT/mathlibExperiments/Coalgebra/TensorProduct.lean)
-is already universe polymorphic since it does not go via category theory.
-
 -/
 
-universe v u
+open TensorProduct
 
-open CategoryTheory
-open scoped TensorProduct
+variable {R A B : Type*} [CommSemiring R] [AddCommMonoid B] [AddCommMonoid A]
+    [Module R A] [Module R B] [Coalgebra R A] [Coalgebra R B]
 
-section
+namespace TensorProduct
 
-variable {R M N P Q : Type u} [CommRing R]
-  [AddCommGroup M] [AddCommGroup N] [Module R M] [Module R N] [Coalgebra R M] [Coalgebra R N]
+open Coalgebra
 
-open MonoidalCategory in
-noncomputable instance TensorProduct.instCoalgebra : Coalgebra R (M ⊗[R] N) :=
-  let I := Monoidal.transport ((CoalgCat.comonEquivalence R).symm)
-  CoalgEquiv.toCoalgebra
-    (A := (CoalgCat.of R M ⊗ CoalgCat.of R N : CoalgCat R))
-    { LinearEquiv.refl R _ with
-      counit_comp := rfl
-      map_comp_comul := by
-        rw [CoalgCat.ofComonObjCoalgebraStruct_comul]
-        simp [-Mon_.monMonoidalStruct_tensorObj_X,
-          ModuleCat.MonoidalCategory.instMonoidalCategoryStruct_tensorHom,
-          ModuleCat.hom_comp, ModuleCat.of, ModuleCat.ofHom, comul_def,
-          ModuleCat.MonoidalCategory.tensorμ_eq_tensorTensorTensorComm] }
+noncomputable
+instance instCoalgebraStruct : CoalgebraStruct R (A ⊗[R] B) where
+  comul :=
+    AlgebraTensorModule.tensorTensorTensorComm R R A A B B ∘ₗ
+      AlgebraTensorModule.map comul comul
+  counit := AlgebraTensorModule.rid R R R ∘ₗ AlgebraTensorModule.map counit counit
 
-end
+lemma comul_def :
+    Coalgebra.comul (R := R) (A := A ⊗[R] B) =
+      AlgebraTensorModule.tensorTensorTensorComm R R A A B B ∘ₗ
+        AlgebraTensorModule.map Coalgebra.comul Coalgebra.comul :=
+  rfl
+
+@[deprecated (since := "2025-04-09")] alias instCoalgebraStruct_comul := comul_def
+
+lemma counit_def :
+    Coalgebra.counit (R := R) (A := A ⊗[R] B) =
+      AlgebraTensorModule.rid R R R ∘ₗ AlgebraTensorModule.map counit counit :=
+  rfl
+
+@[deprecated (since := "2025-04-09")] alias instCoalgebraStruct_counit := counit_def
+
+@[simp]
+lemma comul_tmul (x : A) (y : B) : comul (x ⊗ₜ y) =
+  AlgebraTensorModule.tensorTensorTensorComm R R A A B B (comul x ⊗ₜ comul y) := rfl
+
+@[simp]
+lemma counit_tmul (x : A) (y : B) :
+  counit (R := R) (x ⊗ₜ[R] y) = counit (R := R) y • counit (R := R) x := rfl
+
+/-- `expand_comul R x with x₁ x₂` attempts to replace `comul (R := R) x` by
+`x₁ ⊗ₜ x₂` via linearity. -/
+scoped macro "expand_comul" ring:ident var:ident "with" var₁:ident var₂:ident : tactic =>
+  `(tactic|
+    (induction comul (R := $ring) $var with
+      | zero => simp only [tmul_zero, LinearEquiv.map_zero, LinearMap.map_zero,
+          zero_tmul, zero_mul, mul_zero]
+      | add _ _ h₁ h₂ => simp only [LinearEquiv.map_add, LinearMap.map_add,
+          tmul_add, add_tmul, add_mul, mul_add, h₁, h₂]
+      | tmul $var₁ $var₂ => ?_))
+
+private lemma coassoc :
+    TensorProduct.assoc R (A ⊗[R] B) (A ⊗[R] B) (A ⊗[R] B) ∘ₗ
+      (comul (R := R) (A := (A ⊗[R] B))).rTensor (A ⊗[R] B) ∘ₗ
+        (comul (R := R) (A := (A ⊗[R] B))) =
+    (comul (R := R) (A := (A ⊗[R] B))).lTensor (A ⊗[R] B) ∘ₗ
+      (comul (R := R) (A := (A ⊗[R] B))) := by
+  ext x y
+  let F : (A ⊗[R] A ⊗[R] A) ⊗[R] (B ⊗[R] B ⊗[R] B) ≃ₗ[R]
+    (A ⊗[R] B) ⊗[R] (A ⊗[R] B) ⊗[R] A ⊗[R] B :=
+    AlgebraTensorModule.tensorTensorTensorComm _ _ _ _ _ _ ≪≫ₗ
+      AlgebraTensorModule.congr (.refl _ _)
+        (AlgebraTensorModule.tensorTensorTensorComm _ _ _ _ _ _)
+  let F' : (A ⊗[R] A ⊗[R] A) ⊗[R] (B ⊗[R] B ⊗[R] B) →ₗ[R]
+      (A ⊗[R] B) ⊗[R] (A ⊗[R] B) ⊗[R] A ⊗[R] B :=
+    TensorProduct.mapOfCompatibleSMul _ _ _ _ ∘ₗ
+        TensorProduct.map .id (TensorProduct.mapOfCompatibleSMul _ _ _ _) ∘ₗ F.toLinearMap
+  convert congr(F ($(Coalgebra.coassoc_apply x) ⊗ₜ[R] $(Coalgebra.coassoc_apply y))) using 1
+  · dsimp
+    expand_comul R x with x₁ x₂
+    expand_comul R y with y₁ y₂
+    dsimp
+    expand_comul R x₁ with x₁₁ x₁₂
+    expand_comul R y₁ with y₁₁ y₁₂
+    rfl
+  · dsimp
+    expand_comul R x with x₁ x₂
+    expand_comul R y with y₁ y₂
+    dsimp
+    expand_comul R x₂ with x₂₁ x₂₂
+    expand_comul R y₂ with y₂₁ y₂₂
+    rfl
+
+noncomputable
+instance instCoalgebra : Coalgebra R (A ⊗[R] B) where
+  coassoc := coassoc (R := R)
+  rTensor_counit_comp_comul := by
+    ext x y
+    convert congr((TensorProduct.lid R _).symm
+      (TensorProduct.lid _ _ $(rTensor_counit_comul (R := R) x) ⊗ₜ[R]
+        TensorProduct.lid _ _ $(rTensor_counit_comul (R := R) y)))
+    · dsimp
+      expand_comul R x with x₁ x₂
+      expand_comul R y with y₁ y₂
+      apply (TensorProduct.lid R _).injective
+      dsimp
+      rw [tmul_smul, mul_smul, one_smul, smul_tmul']
+    · dsimp
+      simp only [one_smul]
+  lTensor_counit_comp_comul := by
+    ext x y
+    convert congr((TensorProduct.rid R _).symm
+      (TensorProduct.rid _ _ $(lTensor_counit_comul (R := R) x) ⊗ₜ[R]
+        TensorProduct.rid _ _ $(lTensor_counit_comul (R := R) y)))
+    · dsimp
+      expand_comul R x with x₁ x₂
+      expand_comul R y with y₁ y₂
+      apply (TensorProduct.rid R _).injective
+      dsimp
+      rw [tmul_smul, mul_smul, one_smul, smul_tmul']
+    · dsimp
+      simp only [one_smul]
+
+end TensorProduct
 
 namespace Coalgebra
 namespace TensorProduct
 
-open CoalgCat.MonoidalCategoryAux MonoidalCategory
+variable {R M N P Q : Type*} [CommSemiring R]
+  [AddCommMonoid M] [AddCommMonoid N] [AddCommMonoid P] [AddCommMonoid Q] [Module R M] [Module R N]
+  [Module R P] [Module R Q] [Coalgebra R M]
+  [Coalgebra R N] [Coalgebra R P] [Coalgebra R Q]
 
-variable {R M N P Q : Type u} [CommRing R]
-  [AddCommGroup M] [AddCommGroup N] [AddCommGroup P] [AddCommGroup Q] [Module R M] [Module R N]
-  [Module R P] [Module R Q] [Coalgebra R M] [Coalgebra R N] [Coalgebra R P] [Coalgebra R Q]
-
-attribute [local instance] CoalgCat.instMonoidalCategoryAux in
 section
 
 /-- The tensor product of two coalgebra morphisms as a coalgebra morphism. -/
 noncomputable def map (f : M →ₗc[R] N) (g : P →ₗc[R] Q) :
     M ⊗[R] P →ₗc[R] N ⊗[R] Q where
-  toLinearMap := _root_.TensorProduct.map f.toLinearMap g.toLinearMap
-  counit_comp := by
-    simp_rw [← tensorHom_toLinearMap]
-    apply (CoalgCat.ofHom f ⊗ CoalgCat.ofHom g).1.counit_comp
+  toLinearMap := AlgebraTensorModule.map f.toLinearMap g.toLinearMap
+  counit_comp := by ext; simp
   map_comp_comul := by
-    simp_rw [← tensorHom_toLinearMap, ← comul_tensorObj]
-    apply (CoalgCat.ofHom f ⊗ CoalgCat.ofHom g).1.map_comp_comul
+    ext x y
+    dsimp
+    simp only [← CoalgHomClass.map_comp_comul_apply]
+    expand_comul R x with x₁ x₂
+    expand_comul R y with y₁ y₂
+    simp
 
 @[simp]
 theorem map_tmul (f : M →ₗc[R] N) (g : P →ₗc[R] Q) (x : M) (y : P) :
@@ -93,24 +163,22 @@ theorem map_tmul (f : M →ₗc[R] N) (g : P →ₗc[R] Q) (x : M) (y : P) :
 
 @[simp]
 theorem map_toLinearMap (f : M →ₗc[R] N) (g : P →ₗc[R] Q) :
-    map f g = _root_.TensorProduct.map (f : M →ₗ[R] N) (g : P →ₗ[R] Q) := rfl
+    map f g = AlgebraTensorModule.map (f : M →ₗ[R] N) (g : P →ₗ[R] Q) := rfl
 
 variable (R M N P)
 
 /-- The associator for tensor products of R-coalgebras, as a coalgebra equivalence. -/
 protected noncomputable def assoc :
     (M ⊗[R] N) ⊗[R] P ≃ₗc[R] M ⊗[R] (N ⊗[R] P) :=
-  { _root_.TensorProduct.assoc R M N P with
-    counit_comp := by
-      simp_rw [← associator_hom_toLinearMap, ← counit_tensorObj_tensorObj_right,
-        ← counit_tensorObj_tensorObj_left]
-      apply CoalgHom.counit_comp (α_ (CoalgCat.of R M) (CoalgCat.of R N)
-        (CoalgCat.of R P)).hom.1
+  { AlgebraTensorModule.assoc R R R M N P with
+    counit_comp := by ext; simp [mul_assoc]
     map_comp_comul := by
-      simp_rw [← associator_hom_toLinearMap, ← comul_tensorObj_tensorObj_left,
-        ← comul_tensorObj_tensorObj_right]
-      exact CoalgHom.map_comp_comul (α_ (CoalgCat.of R M)
-        (CoalgCat.of R N) (CoalgCat.of R P)).hom.1 }
+      ext x y z
+      dsimp
+      expand_comul R x with x₁ x₂
+      expand_comul R y with y₁ y₂
+      expand_comul R z with z₁ z₂
+      simp }
 
 variable {R M N P}
 
@@ -126,51 +194,53 @@ theorem assoc_symm_tmul (x : M) (y : N) (z : P) :
 
 @[simp]
 theorem assoc_toLinearEquiv :
-    Coalgebra.TensorProduct.assoc R M N P = _root_.TensorProduct.assoc R M N P := rfl
+    Coalgebra.TensorProduct.assoc R M N P = AlgebraTensorModule.assoc R R R M N P := rfl
 
-variable (R M)
+variable (R P)
 
 /-- The base ring is a left identity for the tensor product of coalgebras, up to
 coalgebra equivalence. -/
-protected noncomputable def lid : R ⊗[R] M ≃ₗc[R] M :=
-  { _root_.TensorProduct.lid R M with
-    counit_comp := by
-      simp only [← leftUnitor_hom_toLinearMap]
-      apply CoalgHom.counit_comp (λ_ (CoalgCat.of R M)).hom.1
+protected noncomputable def lid : R ⊗[R] P ≃ₗc[R] P :=
+  { _root_.TensorProduct.lid R P with
+    counit_comp := by ext; simp
     map_comp_comul := by
-      simp_rw [← leftUnitor_hom_toLinearMap, ← comul_tensorObj]
-      apply CoalgHom.map_comp_comul (λ_ (CoalgCat.of R M)).hom.1 }
+      ext x
+      dsimp
+      simp only [one_smul]
+      expand_comul R x with x₁ x₂
+      simp }
 
-variable {R M}
+variable {R P}
 
 @[simp]
 theorem lid_toLinearEquiv :
-    (Coalgebra.TensorProduct.lid R M) = _root_.TensorProduct.lid R M := rfl
+    (Coalgebra.TensorProduct.lid R P) = _root_.TensorProduct.lid R P := rfl
 
 @[simp]
-theorem lid_tmul (r : R) (a : M) : Coalgebra.TensorProduct.lid R M (r ⊗ₜ a) = r • a := rfl
+theorem lid_tmul (r : R) (a : P) : Coalgebra.TensorProduct.lid R P (r ⊗ₜ a) = r • a := rfl
 
 @[simp]
-theorem lid_symm_apply (a : M) : (Coalgebra.TensorProduct.lid R M).symm a = 1 ⊗ₜ a := rfl
+theorem lid_symm_apply (a : P) : (Coalgebra.TensorProduct.lid R P).symm a = 1 ⊗ₜ a := rfl
 
 variable (R M)
 
 /-- The base ring is a right identity for the tensor product of coalgebras, up to
 coalgebra equivalence. -/
 protected noncomputable def rid : M ⊗[R] R ≃ₗc[R] M :=
-  { _root_.TensorProduct.rid R M with
-    counit_comp := by
-      simp only [← rightUnitor_hom_toLinearMap]
-      apply CoalgHom.counit_comp (ρ_ (CoalgCat.of R M)).hom.1
+  { AlgebraTensorModule.rid R R M with
+    counit_comp := by ext; simp
     map_comp_comul := by
-      simp_rw [← rightUnitor_hom_toLinearMap, ← comul_tensorObj]
-      apply CoalgHom.map_comp_comul (ρ_ (CoalgCat.of R M)).hom.1 }
+      ext x
+      dsimp
+      simp only [one_smul]
+      expand_comul R x with x₁ x₂
+      simp }
 
 variable {R M}
 
 @[simp]
 theorem rid_toLinearEquiv :
-    (Coalgebra.TensorProduct.rid R M) = _root_.TensorProduct.rid R M := rfl
+    (Coalgebra.TensorProduct.rid R M) = AlgebraTensorModule.rid R R M := rfl
 
 @[simp]
 theorem rid_tmul (r : R) (a : M) : Coalgebra.TensorProduct.rid R M (a ⊗ₜ r) = r • a := rfl
@@ -184,7 +254,7 @@ end TensorProduct
 end Coalgebra
 namespace CoalgHom
 
-variable {R M N P : Type u} [CommRing R]
+variable {R M N P : Type*} [CommRing R]
   [AddCommGroup M] [AddCommGroup N] [AddCommGroup P] [Module R M] [Module R N]
   [Module R P] [Coalgebra R M] [Coalgebra R N] [Coalgebra R P]
 

--- a/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
@@ -68,7 +68,9 @@ scoped macro "hopf_tensor_induction " var:elimTarget "with " var₁:ident var₂
     (induction $var with
       | zero => simp only [tmul_zero, LinearEquiv.map_zero, LinearMap.map_zero,
           zero_tmul, zero_mul, mul_zero]
-      | add _ _ h₁ h₂ => simp only [LinearEquiv.map_add, LinearMap.map_add,
+      | add _ _ h₁ h₂ =>
+        -- avoid the more general `map_add` for performance reasons
+        simp only [LinearEquiv.map_add, LinearMap.map_add,
           tmul_add, add_tmul, add_mul, mul_add, h₁, h₂]
       | tmul $var₁ $var₂ => ?_))
 

--- a/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
@@ -62,7 +62,7 @@ lemma counit_tmul (x : A) (y : B) :
 open Lean.Parser.Tactic in
 /-- `hopf_tensor_induction x with x₁ x₂` attempts to replace `x` by
 `x₁ ⊗ₜ x₂` via linearity. This is an implementation detail that is used to set up
-tensor products of coalgebras and shouldn't be relied on downstream. -/
+tensor products of coalgebras, bialgebras, and hopf algebras, and shouldn't be relied on downstream. -/
 scoped macro "hopf_tensor_induction " var:elimTarget "with " var₁:ident var₂:ident : tactic =>
   `(tactic|
     (induction $var with

--- a/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
@@ -61,7 +61,7 @@ lemma counit_tmul (x : A) (y : B) :
 
 /-- `expand_comul R x with x₁ x₂` attempts to replace `comul (R := R) x` by
 `x₁ ⊗ₜ x₂` via linearity. -/
-scoped macro "expand_comul" ring:ident var:ident "with" var₁:ident var₂:ident : tactic =>
+scoped macro "expand_comul" ring:term ", " var:term "with " var₁:ident var₂:ident : tactic =>
   `(tactic|
     (induction comul (R := $ring) $var with
       | zero => simp only [tmul_zero, LinearEquiv.map_zero, LinearMap.map_zero,

--- a/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
@@ -59,7 +59,7 @@ lemma comul_tmul (x : A) (y : B) :
 lemma counit_tmul (x : A) (y : B) :
     counit (R := R) (x ⊗ₜ[R] y) = counit (R := R) y • counit (R := R) x := rfl
 
-/-- `expand_comul R x with x₁ x₂` attempts to replace `comul (R := R) x` by
+/-- `expand_comul R, x with x₁ x₂` attempts to replace `comul (R := R) x` by
 `x₁ ⊗ₜ x₂` via linearity. -/
 scoped macro "expand_comul" ring:term ", " var:term "with " var₁:ident var₂:ident : tactic =>
   `(tactic|
@@ -88,18 +88,18 @@ private lemma coassoc :
         TensorProduct.map .id (TensorProduct.mapOfCompatibleSMul _ _ _ _) ∘ₗ F.toLinearMap
   convert congr(F ($(Coalgebra.coassoc_apply x) ⊗ₜ[R] $(Coalgebra.coassoc_apply y))) using 1
   · dsimp
-    expand_comul R x with x₁ x₂
-    expand_comul R y with y₁ y₂
+    expand_comul R, x with x₁ x₂
+    expand_comul R, y with y₁ y₂
     dsimp
-    expand_comul R x₁ with x₁₁ x₁₂
-    expand_comul R y₁ with y₁₁ y₁₂
+    expand_comul R, x₁ with x₁₁ x₁₂
+    expand_comul R, y₁ with y₁₁ y₁₂
     rfl
   · dsimp
-    expand_comul R x with x₁ x₂
-    expand_comul R y with y₁ y₂
+    expand_comul R, x with x₁ x₂
+    expand_comul R, y with y₁ y₂
     dsimp
-    expand_comul R x₂ with x₂₁ x₂₂
-    expand_comul R y₂ with y₂₁ y₂₂
+    expand_comul R, x₂ with x₂₁ x₂₂
+    expand_comul R, y₂ with y₂₁ y₂₂
     rfl
 
 noncomputable
@@ -111,8 +111,8 @@ instance instCoalgebra : Coalgebra R (A ⊗[R] B) where
       (TensorProduct.lid _ _ $(rTensor_counit_comul (R := R) x) ⊗ₜ[R]
         TensorProduct.lid _ _ $(rTensor_counit_comul (R := R) y)))
     · dsimp
-      expand_comul R x with x₁ x₂
-      expand_comul R y with y₁ y₂
+      expand_comul R, x with x₁ x₂
+      expand_comul R, y with y₁ y₂
       apply (TensorProduct.lid R _).injective
       dsimp
       rw [tmul_smul, mul_smul, one_smul, smul_tmul']
@@ -124,8 +124,8 @@ instance instCoalgebra : Coalgebra R (A ⊗[R] B) where
       (TensorProduct.rid _ _ $(lTensor_counit_comul (R := R) x) ⊗ₜ[R]
         TensorProduct.rid _ _ $(lTensor_counit_comul (R := R) y)))
     · dsimp
-      expand_comul R x with x₁ x₂
-      expand_comul R y with y₁ y₂
+      expand_comul R, x with x₁ x₂
+      expand_comul R, y with y₁ y₂
       apply (TensorProduct.rid R _).injective
       dsimp
       rw [tmul_smul, mul_smul, one_smul, smul_tmul']
@@ -153,8 +153,8 @@ noncomputable def map (f : M →ₗc[R] N) (g : P →ₗc[R] Q) :
     ext x y
     dsimp
     simp only [← CoalgHomClass.map_comp_comul_apply]
-    expand_comul R x with x₁ x₂
-    expand_comul R y with y₁ y₂
+    expand_comul R, x with x₁ x₂
+    expand_comul R, y with y₁ y₂
     simp
 
 @[simp]
@@ -176,9 +176,9 @@ protected noncomputable def assoc :
     map_comp_comul := by
       ext x y z
       dsimp
-      expand_comul R x with x₁ x₂
-      expand_comul R y with y₁ y₂
-      expand_comul R z with z₁ z₂
+      expand_comul R, x with x₁ x₂
+      expand_comul R, y with y₁ y₂
+      expand_comul R, z with z₁ z₂
       simp }
 
 variable {R M N P}
@@ -208,7 +208,7 @@ protected noncomputable def lid : R ⊗[R] P ≃ₗc[R] P :=
       ext x
       dsimp
       simp only [one_smul]
-      expand_comul R x with x₁ x₂
+      expand_comul R, x with x₁ x₂
       simp }
 
 variable {R P}
@@ -234,7 +234,7 @@ protected noncomputable def rid : M ⊗[R] R ≃ₗc[R] M :=
       ext x
       dsimp
       simp only [one_smul]
-      expand_comul R x with x₁ x₂
+      expand_comul R, x with x₁ x₂
       simp }
 
 variable {R M}

--- a/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/Coalgebra/TensorProduct.lean
@@ -51,12 +51,13 @@ lemma counit_def :
 @[deprecated (since := "2025-04-09")] alias instCoalgebraStruct_counit := counit_def
 
 @[simp]
-lemma comul_tmul (x : A) (y : B) : comul (x ⊗ₜ y) =
-  AlgebraTensorModule.tensorTensorTensorComm R R A A B B (comul x ⊗ₜ comul y) := rfl
+lemma comul_tmul (x : A) (y : B) :
+    comul (x ⊗ₜ y) =
+      AlgebraTensorModule.tensorTensorTensorComm R R A A B B (comul x ⊗ₜ comul y) := rfl
 
 @[simp]
 lemma counit_tmul (x : A) (y : B) :
-  counit (R := R) (x ⊗ₜ[R] y) = counit (R := R) y • counit (R := R) x := rfl
+    counit (R := R) (x ⊗ₜ[R] y) = counit (R := R) y • counit (R := R) x := rfl
 
 /-- `expand_comul R x with x₁ x₂` attempts to replace `comul (R := R) x` by
 `x₁ ⊗ₜ x₂` via linearity. -/

--- a/Mathlib/RingTheory/HopfAlgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/HopfAlgebra/TensorProduct.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024 Amelia Livingston. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Amelia Livingston
+Authors: Amelia Livingston, Andrew Yang
 -/
 import Mathlib.RingTheory.HopfAlgebra.Basic
 import Mathlib.RingTheory.Bialgebra.TensorProduct
@@ -13,29 +13,39 @@ We define the Hopf algebra instance on the tensor product of two Hopf algebras.
 
 -/
 
-universe u
-namespace TensorProduct
-variable {R A B : Type u} [CommRing R] [Ring A] [Ring B] [HopfAlgebra R A] [HopfAlgebra R B]
+open TensorProduct Coalgebra.TensorProduct
 
-open HopfAlgebra
+namespace HopfAlgebra.TensorProduct
 
-noncomputable instance instHopfAlgebra : HopfAlgebra R (A ⊗[R] B) :=
-  { antipode := map antipode antipode
-    mul_antipode_rTensor_comul := by
-      simp only [comul_def, counit_def, LinearMap.rTensor_def,
-        ← map_id, ← LinearMap.comp_assoc (map _ _), ← tensorTensorTensorComm_comp_map,
-        Algebra.mul'_comp_tensorTensorTensorComm, ← map_comp]
-      simp only [← LinearMap.rTensor_def, LinearMap.comp_assoc, mul_antipode_rTensor_comul,
-        map_comp, Algebra.linearMap_comp_mul']
-    mul_antipode_lTensor_comul := by
-      simp only [comul_def, counit_def, LinearMap.lTensor_def,
-        ← map_id, ← LinearMap.comp_assoc (map _ _), ← tensorTensorTensorComm_comp_map,
-        Algebra.mul'_comp_tensorTensorTensorComm, ← map_comp]
-      simp only [← LinearMap.lTensor_def, LinearMap.comp_assoc, mul_antipode_lTensor_comul,
-        map_comp, Algebra.linearMap_comp_mul'] }
+variable {R A B : Type*} [CommSemiring R] [Semiring A] [Semiring B] [HopfAlgebra R A]
+    [HopfAlgebra R B]
+
+noncomputable
+instance : HopfAlgebra R (B ⊗[R] A) where
+  antipode := AlgebraTensorModule.map HopfAlgebra.antipode HopfAlgebra.antipode
+  mul_antipode_rTensor_comul := by
+    ext x y
+    convert congr($(HopfAlgebra.mul_antipode_rTensor_comul_apply (R := R) x) ⊗ₜ[R]
+      $(HopfAlgebra.mul_antipode_rTensor_comul_apply (R := R) y)) using 1
+    · dsimp
+      expand_comul R x with x₁ x₂
+      expand_comul R y with y₁ y₂
+      simp
+    · dsimp [Algebra.TensorProduct.one_def]
+      simp [Algebra.algebraMap_eq_smul_one, smul_tmul', mul_smul]
+  mul_antipode_lTensor_comul := by
+    ext x y
+    convert congr($(HopfAlgebra.mul_antipode_lTensor_comul_apply (R := R) x) ⊗ₜ[R]
+      $(HopfAlgebra.mul_antipode_lTensor_comul_apply (R := R) y)) using 1
+    · dsimp [Algebra.TensorProduct.one_def]
+      expand_comul R x with x₁ x₂
+      expand_comul R y with y₁ y₂
+      simp
+    · dsimp [Algebra.TensorProduct.one_def]
+      simp [Algebra.algebraMap_eq_smul_one, smul_tmul', mul_smul]
 
 @[simp]
 theorem antipode_def :
-    HopfAlgebra.antipode (R := R) (A := A ⊗[R] B) = map antipode antipode := rfl
+    HopfAlgebra.antipode (R := R) (A := B ⊗[R] A) = AlgebraTensorModule.map antipode antipode := rfl
 
-end TensorProduct
+end HopfAlgebra.TensorProduct

--- a/Mathlib/RingTheory/HopfAlgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/HopfAlgebra/TensorProduct.lean
@@ -13,7 +13,7 @@ We define the Hopf algebra instance on the tensor product of two Hopf algebras.
 
 -/
 
-open TensorProduct Coalgebra.TensorProduct
+open TensorProduct Coalgebra.TensorProduct HopfAlgebra
 
 namespace TensorProduct
 
@@ -25,8 +25,8 @@ instance : HopfAlgebra R (B ⊗[R] A) where
   antipode := AlgebraTensorModule.map HopfAlgebra.antipode HopfAlgebra.antipode
   mul_antipode_rTensor_comul := by
     ext x y
-    convert congr($(HopfAlgebra.mul_antipode_rTensor_comul_apply (R := R) x) ⊗ₜ[R]
-      $(HopfAlgebra.mul_antipode_rTensor_comul_apply (R := R) y)) using 1
+    convert congr($(mul_antipode_rTensor_comul_apply (R := R) x) ⊗ₜ[R]
+      $(mul_antipode_rTensor_comul_apply (R := R) y)) using 1
     · dsimp
       expand_comul R, x with x₁ x₂
       expand_comul R, y with y₁ y₂
@@ -35,8 +35,8 @@ instance : HopfAlgebra R (B ⊗[R] A) where
       simp [Algebra.algebraMap_eq_smul_one, smul_tmul', mul_smul]
   mul_antipode_lTensor_comul := by
     ext x y
-    convert congr($(HopfAlgebra.mul_antipode_lTensor_comul_apply (R := R) x) ⊗ₜ[R]
-      $(HopfAlgebra.mul_antipode_lTensor_comul_apply (R := R) y)) using 1
+    convert congr($(mul_antipode_lTensor_comul_apply (R := R) x) ⊗ₜ[R]
+      $(mul_antipode_lTensor_comul_apply (R := R) y)) using 1
     · dsimp [Algebra.TensorProduct.one_def]
       expand_comul R, x with x₁ x₂
       expand_comul R, y with y₁ y₂
@@ -46,6 +46,6 @@ instance : HopfAlgebra R (B ⊗[R] A) where
 
 @[simp]
 theorem antipode_def :
-    HopfAlgebra.antipode (R := R) (A := B ⊗[R] A) = AlgebraTensorModule.map antipode antipode := rfl
+    antipode (R := R) (A := B ⊗[R] A) = AlgebraTensorModule.map antipode antipode := rfl
 
 end TensorProduct

--- a/Mathlib/RingTheory/HopfAlgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/HopfAlgebra/TensorProduct.lean
@@ -13,7 +13,7 @@ We define the Hopf algebra instance on the tensor product of two Hopf algebras.
 
 -/
 
-open TensorProduct Coalgebra.TensorProduct HopfAlgebra
+open Coalgebra TensorProduct HopfAlgebra
 
 namespace TensorProduct
 

--- a/Mathlib/RingTheory/HopfAlgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/HopfAlgebra/TensorProduct.lean
@@ -15,7 +15,7 @@ We define the Hopf algebra instance on the tensor product of two Hopf algebras.
 
 open TensorProduct Coalgebra.TensorProduct
 
-namespace HopfAlgebra.TensorProduct
+namespace TensorProduct
 
 variable {R A B : Type*} [CommSemiring R] [Semiring A] [Semiring B] [HopfAlgebra R A]
     [HopfAlgebra R B]
@@ -48,4 +48,4 @@ instance : HopfAlgebra R (B ⊗[R] A) where
 theorem antipode_def :
     HopfAlgebra.antipode (R := R) (A := B ⊗[R] A) = AlgebraTensorModule.map antipode antipode := rfl
 
-end HopfAlgebra.TensorProduct
+end TensorProduct

--- a/Mathlib/RingTheory/HopfAlgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/HopfAlgebra/TensorProduct.lean
@@ -28,8 +28,8 @@ instance : HopfAlgebra R (B ⊗[R] A) where
     convert congr($(mul_antipode_rTensor_comul_apply (R := R) x) ⊗ₜ[R]
       $(mul_antipode_rTensor_comul_apply (R := R) y)) using 1
     · dsimp
-      expand_comul R, x with x₁ x₂
-      expand_comul R, y with y₁ y₂
+      hopf_tensor_induction comul (R := R) x with x₁ x₂
+      hopf_tensor_induction comul (R := R) y with y₁ y₂
       simp
     · dsimp [Algebra.TensorProduct.one_def]
       simp [Algebra.algebraMap_eq_smul_one, smul_tmul', mul_smul]
@@ -38,8 +38,8 @@ instance : HopfAlgebra R (B ⊗[R] A) where
     convert congr($(mul_antipode_lTensor_comul_apply (R := R) x) ⊗ₜ[R]
       $(mul_antipode_lTensor_comul_apply (R := R) y)) using 1
     · dsimp [Algebra.TensorProduct.one_def]
-      expand_comul R, x with x₁ x₂
-      expand_comul R, y with y₁ y₂
+      hopf_tensor_induction comul (R := R) x with x₁ x₂
+      hopf_tensor_induction comul (R := R) y with y₁ y₂
       simp
     · dsimp [Algebra.TensorProduct.one_def]
       simp [Algebra.algebraMap_eq_smul_one, smul_tmul', mul_smul]

--- a/Mathlib/RingTheory/HopfAlgebra/TensorProduct.lean
+++ b/Mathlib/RingTheory/HopfAlgebra/TensorProduct.lean
@@ -28,8 +28,8 @@ instance : HopfAlgebra R (B ⊗[R] A) where
     convert congr($(HopfAlgebra.mul_antipode_rTensor_comul_apply (R := R) x) ⊗ₜ[R]
       $(HopfAlgebra.mul_antipode_rTensor_comul_apply (R := R) y)) using 1
     · dsimp
-      expand_comul R x with x₁ x₂
-      expand_comul R y with y₁ y₂
+      expand_comul R, x with x₁ x₂
+      expand_comul R, y with y₁ y₂
       simp
     · dsimp [Algebra.TensorProduct.one_def]
       simp [Algebra.algebraMap_eq_smul_one, smul_tmul', mul_smul]
@@ -38,8 +38,8 @@ instance : HopfAlgebra R (B ⊗[R] A) where
     convert congr($(HopfAlgebra.mul_antipode_lTensor_comul_apply (R := R) x) ⊗ₜ[R]
       $(HopfAlgebra.mul_antipode_lTensor_comul_apply (R := R) y)) using 1
     · dsimp [Algebra.TensorProduct.one_def]
-      expand_comul R x with x₁ x₂
-      expand_comul R y with y₁ y₂
+      expand_comul R, x with x₁ x₂
+      expand_comul R, y with y₁ y₂
       simp
     · dsimp [Algebra.TensorProduct.one_def]
       simp [Algebra.algebraMap_eq_smul_one, smul_tmul', mul_smul]


### PR DESCRIPTION
...without category theory, so that we can easily generalize to the base change of hopf algebras later.

This also makes things universe-polymorphic.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
