### PR TITLE
[Merged by Bors] - chore: deprime `induction` in `Computability` and `FieldTheory`

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
@@ -411,7 +411,7 @@ lemma exists_mem_support_mem_erase_mem_support_takeUntil_eq_empty (s : Finset V)
     (h : {x ∈ s | x ∈ p.support}.Nonempty) :
     ∃ x ∈ s, ∃ hx : x ∈ p.support, {t ∈ s.erase x | t ∈ (p.takeUntil x hx).support} = ∅ := by
   simp only [← Finset.subset_empty]
-  induction' hp : p.length + #s using Nat.strong_induction_on with n ih generalizing s v
+  induction hp : p.length + #s using Nat.strong_induction_on generalizing s v with | _ n ih
   simp only [Finset.Nonempty, mem_filter] at h
   obtain ⟨x, hxs, hx⟩ := h
   obtain h | h := Finset.eq_empty_or_nonempty {t ∈ s.erase x | t ∈ (p.takeUntil x hx).support}

--- a/Mathlib/Computability/Ackermann.lean
+++ b/Mathlib/Computability/Ackermann.lean
@@ -74,21 +74,22 @@ theorem ack_succ_succ (m n : ℕ) : ack (m + 1) (n + 1) = ack m (ack (m + 1) n) 
 
 @[simp]
 theorem ack_one (n : ℕ) : ack 1 n = n + 2 := by
-  induction' n with n IH
-  · simp
-  · simp [IH]
+  induction n with
+  | zero => simp
+  | succ n IH => simp [IH]
 
 @[simp]
 theorem ack_two (n : ℕ) : ack 2 n = 2 * n + 3 := by
-  induction' n with n IH
-  · simp
-  · simpa [mul_succ]
+  induction n with
+  | zero => simp
+  | succ n IH => simpa [mul_succ]
 
 @[simp]
 theorem ack_three (n : ℕ) : ack 3 n = 2 ^ (n + 3) - 3 := by
-  induction' n with n IH
-  · simp
-  · rw [ack_succ_succ, IH, ack_two, Nat.succ_add, Nat.pow_succ 2 (n + 3), mul_comm _ 2,
+  induction n with
+  | zero => simp
+  | succ n IH =>
+    rw [ack_succ_succ, IH, ack_two, Nat.succ_add, Nat.pow_succ 2 (n + 3), mul_comm _ 2,
         Nat.mul_sub_left_distrib, ← Nat.sub_add_comm, two_mul 3, Nat.add_sub_add_right]
     have H : 2 * 3 ≤ 2 * 2 ^ 3 := by norm_num
     apply H.trans
@@ -225,9 +226,10 @@ theorem ack_succ_right_le_ack_succ_left (m n : ℕ) : ack m (n + 1) ≤ ack (m +
 
 -- All the inequalities from this point onwards are specific to the main proof.
 private theorem sq_le_two_pow_add_one_minus_three (n : ℕ) : n ^ 2 ≤ 2 ^ (n + 1) - 3 := by
-  induction' n with k hk
-  · norm_num
-  · rcases k with - | k
+  induction n with
+  | zero => norm_num
+  | succ k hk =>
+    rcases k with - | k
     · norm_num
     · rw [add_sq, Nat.pow_succ 2, mul_comm _ 2, two_mul (2 ^ _),
           add_tsub_assoc_of_le, add_comm (2 ^ _), add_assoc]
@@ -309,11 +311,11 @@ theorem exists_lt_ack_of_nat_primrec {f : ℕ → ℕ} (hf : Nat.Primrec f) :
         rec (f m) (fun y IH => g <| pair m <| pair y IH) n < ack (max a b + 9) (m + n) := by
       intro m n
       -- We induct on n.
-      induction' n with n IH
-      -- The base case is easy.
-      · apply (ha m).trans (ack_strictMono_left m <| (le_max_left a b).trans_lt _)
+      induction n with
+      | zero => -- The base case is easy.
+        apply (ha m).trans (ack_strictMono_left m <| (le_max_left a b).trans_lt _)
         omega
-      · -- We get rid of the first `pair`.
+      | succ n IH => -- We get rid of the first `pair`.
         simp only
         apply (hb _).trans ((ack_pair_lt _ _ _).trans_le _)
         -- If m is the maximum, we get a very weak inequality.

--- a/Mathlib/Computability/DFA.lean
+++ b/Mathlib/Computability/DFA.lean
@@ -154,9 +154,10 @@ theorem evalFrom_of_pow {x y : List α} {s : σ} (hx : M.evalFrom s x = s)
     (hy : y ∈ ({x} : Language α)∗) : M.evalFrom s y = s := by
   rw [Language.mem_kstar] at hy
   rcases hy with ⟨S, rfl, hS⟩
-  induction' S with a S ih
-  · rfl
-  · have ha := hS a List.mem_cons_self
+  induction S with
+  | nil => rfl
+  | cons a S ih =>
+    have ha := hS a List.mem_cons_self
     rw [Set.mem_singleton_iff] at ha
     rw [List.flatten, evalFrom_of_append, ha, hx]
     apply ih

--- a/Mathlib/Computability/Encoding.lean
+++ b/Mathlib/Computability/Encoding.lean
@@ -117,13 +117,13 @@ theorem encodePosNum_nonempty (n : PosNum) : encodePosNum n ≠ [] :=
   PosNum.casesOn n (List.cons_ne_nil _ _) (fun _m => List.cons_ne_nil _ _) fun _m =>
     List.cons_ne_nil _ _
 
-@[simp] theorem decode_encodePosNum : ∀ n, decodePosNum (encodePosNum n) = n := by
-  intro n
-  induction' n with m hm m hm <;> unfold encodePosNum decodePosNum
-  · rfl
-  · rw [hm]
+@[simp] theorem decode_encodePosNum : ∀ n, decodePosNum (encodePosNum n) = n := fun n ↦ by
+  induction n with unfold encodePosNum decodePosNum
+  | one => rfl
+  | bit1 m hm =>
+    rw [hm]
     exact if_neg (encodePosNum_nonempty m)
-  · exact congr_arg PosNum.bit0 hm
+  | bit0 m hm => exact congr_arg PosNum.bit0 hm
 
 @[simp] theorem decode_encodeNum : ∀ n, decodeNum (encodeNum n) = n := by
   intro n

--- a/Mathlib/Computability/EpsilonNFA.lean
+++ b/Mathlib/Computability/EpsilonNFA.lean
@@ -74,7 +74,7 @@ theorem mem_εClosure_iff_exists : s ∈ M.εClosure S ↔ ∃ t ∈ S, s ∈ M.
       solve_by_elim [εClosure.step]
   mpr := by
     intro ⟨t, _, h⟩
-    induction' h <;> subst_vars <;> solve_by_elim [εClosure.step]
+    induction h <;> subst_vars <;> solve_by_elim [εClosure.step]
 
 /-- `M.stepSet S a` is the union of the ε-closure of `M.step s a` for all `s ∈ S`. -/
 def stepSet (S : Set σ) (a : α) : Set σ :=
@@ -112,15 +112,16 @@ theorem evalFrom_append_singleton (S : Set σ) (x : List α) (a : α) :
 
 @[simp]
 theorem evalFrom_empty (x : List α) : M.evalFrom ∅ x = ∅ := by
-  induction' x using List.reverseRecOn with x a ih
-  · rw [evalFrom_nil, εClosure_empty]
-  · rw [evalFrom_append_singleton, ih, stepSet_empty]
+  induction x using List.reverseRecOn with
+  | nil => rw [evalFrom_nil, εClosure_empty]
+  | append_singleton x a ih => rw [evalFrom_append_singleton, ih, stepSet_empty]
 
 theorem mem_evalFrom_iff_exists {s : σ} {S : Set σ} {x : List α} :
     s ∈ M.evalFrom S x ↔ ∃ t ∈ S, s ∈ M.evalFrom {t} x := by
-  induction' x using List.reverseRecOn with _ _ ih generalizing s
-  · apply mem_εClosure_iff_exists
-  · simp_rw [evalFrom_append_singleton, mem_stepSet_iff, ih]
+  induction x using List.reverseRecOn generalizing s with
+  | nil => apply mem_εClosure_iff_exists
+  | append_singleton _ _ ih =>
+    simp_rw [evalFrom_append_singleton, mem_stepSet_iff, ih]
     tauto
 
 /-- `M.eval x` computes all possible paths through `M` with input `x` starting at an element of
@@ -171,10 +172,12 @@ alias ⟨_, IsPath.singleton⟩ := isPath_singleton
 theorem isPath_append {x y : List (Option α)} :
     M.IsPath s u (x ++ y) ↔ ∃ t, M.IsPath s t x ∧ M.IsPath t u y where
   mp := by
-    induction' x with x a ih generalizing s
-    · rw [List.nil_append]
+    induction x generalizing s with
+    | nil =>
+      rw [List.nil_append]
       tauto
-    · rintro (_ | ⟨t, _, _, _, _, _, h⟩)
+    | cons x a ih =>
+      rintro (_ | ⟨t, _, _, _, _, _, h⟩)
       apply ih at h
       tauto
   mpr := by
@@ -206,8 +209,9 @@ theorem mem_εClosure_iff_exists_path {s₁ s₂ : σ} :
 
 theorem mem_evalFrom_iff_exists_path {s₁ s₂ : σ} {x : List α} :
     s₂ ∈ M.evalFrom {s₁} x ↔ ∃ x', x'.reduceOption = x ∧ M.IsPath s₁ s₂ x' := by
-  induction' x using List.reverseRecOn with x a ih generalizing s₂
-  · rw [evalFrom_nil, mem_εClosure_iff_exists_path]
+  induction x using List.reverseRecOn generalizing s₂ with
+  | nil =>
+    rw [evalFrom_nil, mem_εClosure_iff_exists_path]
     constructor
     · intro ⟨n, _⟩
       use List.replicate n none
@@ -216,7 +220,8 @@ theorem mem_evalFrom_iff_exists_path {s₁ s₂ : σ} {x : List α} :
     · simp_rw [List.reduceOption_eq_nil_iff]
       intro ⟨_, ⟨n, rfl⟩, h⟩
       exact ⟨n, h⟩
-  · rw [evalFrom_append_singleton, mem_stepSet_iff]
+  | append_singleton x a ih =>
+    rw [evalFrom_append_singleton, mem_stepSet_iff]
     constructor
     · intro ⟨t, ht, h⟩
       obtain ⟨x', _, _⟩ := ih.mp ht

--- a/Mathlib/Computability/Language.lean
+++ b/Mathlib/Computability/Language.lean
@@ -225,14 +225,16 @@ theorem add_iSup {ι : Sort v} [Nonempty ι] (l : ι → Language α) (m : Langu
 
 theorem mem_pow {l : Language α} {x : List α} {n : ℕ} :
     x ∈ l ^ n ↔ ∃ S : List (List α), x = S.flatten ∧ S.length = n ∧ ∀ y ∈ S, y ∈ l := by
-  induction' n with n ihn generalizing x
-  · simp only [mem_one, pow_zero, length_eq_zero_iff]
+  induction n generalizing x with
+  | zero =>
+    simp only [mem_one, pow_zero, length_eq_zero_iff]
     constructor
     · rintro rfl
       exact ⟨[], rfl, rfl, fun _ h ↦ by contradiction⟩
     · rintro ⟨_, rfl, rfl, _⟩
       rfl
-  · simp only [pow_succ', mem_mul, ihn]
+  | succ n ihn =>
+    simp only [pow_succ', mem_mul, ihn]
     constructor
     · rintro ⟨a, ha, b, ⟨S, rfl, rfl, hS⟩, rfl⟩
       exact ⟨a :: S, rfl, rfl, forall_mem_cons.2 ⟨ha, hS⟩⟩
@@ -276,10 +278,11 @@ instance : KleeneAlgebra (Language α) :=
     kstar_mul_le_self := fun l m h ↦ by
       rw [kstar_eq_iSup_pow, iSup_mul]
       refine iSup_le (fun n ↦ ?_)
-      induction' n with n ih
-      · simp
-      rw [pow_succ, mul_assoc (l^n) l m]
-      exact le_trans (le_mul_congr le_rfl h) ih,
+      induction n with
+      | zero => simp
+      | succ n ih =>
+        rw [pow_succ, mul_assoc (l^n) l m]
+        exact le_trans (le_mul_congr le_rfl h) ih,
     mul_kstar_le_self := fun l m h ↦ by
       rw [kstar_eq_iSup_pow, mul_iSup]
       refine iSup_le (fun n ↦ ?_)
@@ -294,7 +297,7 @@ theorem self_eq_mul_add_iff {l m n : Language α} (hm : [] ∉ m) : l = m * l + 
   mp h := by
     apply le_antisymm
     · intro x hx
-      induction' hlen : x.length using Nat.strong_induction_on with _ ih generalizing x
+      induction hlen : x.length using Nat.strong_induction_on generalizing x with | _ _ ih
       subst hlen
       rw [h] at hx
       obtain hx | hx := hx
@@ -308,10 +311,12 @@ theorem self_eq_mul_add_iff {l m n : Language α} (hm : [] ∉ m) : l = m * l + 
       · exact ⟨[], nil_mem_kstar _, _, ⟨hx, nil_append _⟩⟩
     · rw [kstar_eq_iSup_pow, iSup_mul, iSup_le_iff]
       intro i
-      induction' i with _ ih <;> rw [h]
-      · rw [pow_zero, one_mul, add_comm]
+      induction i with rw [h]
+      | zero =>
+        rw [pow_zero, one_mul, add_comm]
         exact le_self_add
-      · rw [add_comm, pow_add, pow_one, mul_assoc]
+      | succ _ ih =>
+        rw [add_comm, pow_add, pow_one, mul_assoc]
         exact le_add_right (mul_le_mul_left' ih _)
   mpr h := by rw [h, add_comm, ← mul_assoc, ← one_add_mul, one_add_self_mul_kstar_eq_kstar]
 

--- a/Mathlib/Computability/NFA.lean
+++ b/Mathlib/Computability/NFA.lean
@@ -141,9 +141,10 @@ namespace DFA
 theorem toNFA_evalFrom_match (M : DFA α σ) (start : σ) (s : List α) :
     M.toNFA.evalFrom {start} s = {M.evalFrom start s} := by
   change List.foldl M.toNFA.stepSet {start} s = {List.foldl M.step start s}
-  induction' s with a s ih generalizing start
-  · tauto
-  · rw [List.foldl, List.foldl,
+  induction s generalizing start with
+  | nil => tauto
+  | cons a s ih =>
+    rw [List.foldl, List.foldl,
       show M.toNFA.stepSet {start} a = {M.step start a} by simp [NFA.stepSet] ]
     tauto
 

--- a/Mathlib/Computability/Partrec.lean
+++ b/Mathlib/Computability/Partrec.lean
@@ -46,9 +46,9 @@ private def wf_lbp (H : ∃ n, true ∈ p n ∧ ∀ k < n, (p k).Dom) : WellFoun
     let ⟨n, pn⟩ := H
     suffices ∀ m k, n ≤ k + m → Acc (lbp p) k by exact fun a => this _ _ (Nat.le_add_left _ _)
     intro m k kn
-    induction' m with m IH generalizing k <;> refine ⟨_, fun y r => ?_⟩ <;> rcases r with ⟨rfl, a⟩
-    · injection mem_unique pn.1 (a _ kn)
-    · exact IH _ (by rw [Nat.add_right_comm]; exact kn)⟩
+    induction m generalizing k with (refine ⟨_, fun y r => ?_⟩; rcases r with ⟨rfl, a⟩)
+    | zero => injection mem_unique pn.1 (a _ kn)
+    | succ m IH => exact IH _ (by rw [Nat.add_right_comm]; exact kn)⟩
 
 variable (H : ∃ n, true ∈ p n ∧ ∀ k < n, (p k).Dom)
 
@@ -414,7 +414,7 @@ theorem nat_rec {f : α → ℕ} {g : α →. σ} {h : α → ℕ × σ →. σ}
     (hh : Partrec₂ h) : Partrec fun a => (f a).rec (g a) fun y IH => IH.bind fun i => h a (y, i) :=
   (Nat.Partrec.prec' hf hg hh).of_eq fun n => by
     rcases e : decode (α := α) n with - | a <;> simp [e]
-    induction' f a with m IH <;> simp
+    induction f a with simp | succ m IH
     rw [IH, Part.bind_map]
     congr; funext s
     simp [encodek]
@@ -649,8 +649,9 @@ theorem nat_strong_rec (f : α → ℕ → σ) {g : α → List σ → Option σ
                 option_map (hg.comp (fst.comp <| fst.comp fst) snd)
                   (to₂ <| list_concat.comp (snd.comp fst) snd))).of_eq
       fun a => by
-      induction' a.2 with n IH; · rfl
-      simp [IH, H, List.range_succ]
+      induction a.2 with
+      | zero => rfl
+      | succ n IH => simp [IH, H, List.range_succ]
 
 theorem list_ofFn :
     ∀ {n} {f : Fin n → α → σ},
@@ -728,10 +729,11 @@ theorem fix_aux {α σ} (f : α →. σ ⊕ α) (a : α) (b : σ) :
   · rcases h with ⟨n, ⟨_x, h₁⟩, h₂⟩
     have : ∀ m a', Sum.inr a' ∈ F a m → b ∈ PFun.fix f a' → b ∈ PFun.fix f a := by
       intro m a' am ba
-      induction' m with m IH generalizing a' <;> simp [F] at am
-      · rwa [← am]
-      rcases am with ⟨a₂, am₂, fa₂⟩
-      exact IH _ am₂ (PFun.mem_fix_iff.2 (Or.inr ⟨_, fa₂, ba⟩))
+      induction m generalizing a' with simp [F] at am
+      | zero => rwa [← am]
+      | succ m IH =>
+        rcases am with ⟨a₂, am₂, fa₂⟩
+        exact IH _ am₂ (PFun.mem_fix_iff.2 (Or.inr ⟨_, fa₂, ba⟩))
     cases n <;> simp [F] at h₂
     rcases h₂ with (h₂ | ⟨a', am', fa'⟩)
     · obtain ⟨a', h⟩ := h₁ (Nat.lt_succ_self _)

--- a/Mathlib/Computability/PartrecCode.lean
+++ b/Mathlib/Computability/PartrecCode.lean
@@ -671,9 +671,10 @@ theorem evaln_sound : ∀ {k c n x}, x ∈ evaln k c n → x ∈ eval c n
       exact ⟨_, hg _ _ eg, hf _ _ ef⟩
     case prec cf cg hf hg _ =>
       revert h
-      induction' n.unpair.2 with m IH generalizing x <;> simp [Option.bind_eq_some_iff]
-      · apply hf
-      · refine fun y h₁ h₂ => ⟨y, IH _ ?_, ?_⟩
+      induction n.unpair.2 generalizing x with simp [Option.bind_eq_some_iff]
+      | zero => apply hf
+      | succ m IH =>
+        refine fun y h₁ h₂ => ⟨y, IH _ ?_, ?_⟩
         · have := evaln_mono k.le_succ h₁
           simp [evaln, Option.bind_eq_some_iff] at this
           exact this.2
@@ -719,11 +720,13 @@ theorem evaln_complete {c n x} : x ∈ eval c n ↔ ∃ k, x ∈ evaln k c n := 
   | prec cf cg hf hg =>
     revert h
     generalize n.unpair.1 = n₁; generalize n.unpair.2 = n₂
-    induction' n₂ with m IH generalizing x n <;> simp [Option.bind_eq_some_iff]
-    · intro h
+    induction n₂ generalizing x n with simp [Option.bind_eq_some_iff]
+    | zero =>
+      intro h
       rcases hf h with ⟨k, hk⟩
       exact ⟨_, le_max_left _ _, evaln_mono (Nat.succ_le_succ <| le_max_right _ _) hk⟩
-    · intro y hy hx
+    | succ m IH =>
+      intro y hy hx
       rcases IH hy with ⟨k₁, nk₁, hk₁⟩
       rcases hg hx with ⟨k₂, hk₂⟩
       refine
@@ -742,11 +745,13 @@ theorem evaln_complete {c n x} : x ∈ eval c n ↔ ∃ k, x ∈ evaln k c n := 
     revert hy₁ hy₂
     generalize n.unpair.2 = m
     intro hy₁ hy₂
-    induction' y with y IH generalizing m <;> simp [evaln, Option.bind_eq_some_iff]
-    · simp at hy₁
+    induction y generalizing m with simp [evaln, Option.bind_eq_some_iff]
+    | zero =>
+      simp at hy₁
       rcases hf hy₁ with ⟨k, hk⟩
       exact ⟨_, Nat.le_of_lt_succ <| evaln_bound hk, _, hk, by simp⟩
-    · rcases hy₂ (Nat.succ_pos _) with ⟨a, ha, a0⟩
+    | succ y IH =>
+      rcases hy₂ (Nat.succ_pos _) with ⟨a, ha, a0⟩
       rcases hf ha with ⟨k₁, hk₁⟩
       rcases IH m.succ (by simpa [Nat.succ_eq_add_one, add_comm, add_left_comm] using hy₁)
           fun {i} hi => by

--- a/Mathlib/Computability/PostTuringMachine.lean
+++ b/Mathlib/Computability/PostTuringMachine.lean
@@ -910,10 +910,13 @@ def trNormal : Stmt Γ Λ σ → Stmt Bool (Λ' Γ Λ σ) σ
 theorem stepAux_move (d : Dir) (q : Stmt Bool (Λ' Γ Λ σ) σ) (v : σ) (T : Tape Bool) :
     stepAux (move n d q) v T = stepAux q v ((Tape.move d)^[n] T) := by
   suffices ∀ i, stepAux ((Stmt.move d)^[i] q) v T = stepAux q v ((Tape.move d)^[i] T) from this n
-  intro i; induction' i with i IH generalizing T; · rfl
-  rw [iterate_succ', iterate_succ]
-  simp only [stepAux, Function.comp_apply]
-  rw [IH]
+  intro i
+  induction i generalizing T with
+  | zero => rfl
+  | succ i IH =>
+    rw [iterate_succ', iterate_succ]
+    simp only [stepAux, Function.comp_apply]
+    rw [IH]
 
 theorem supportsStmt_move {S : Finset (Λ' Γ Λ σ)} {d : Dir} {q : Stmt Bool (Λ' Γ Λ σ) σ} :
     SupportsStmt S (move n d q) = SupportsStmt S q := by
@@ -922,7 +925,7 @@ theorem supportsStmt_move {S : Finset (Λ' Γ Λ σ)} {d : Dir} {q : Stmt Bool (
 
 theorem supportsStmt_write {S : Finset (Λ' Γ Λ σ)} {l : List Bool} {q : Stmt Bool (Λ' Γ Λ σ) σ} :
     SupportsStmt S (write l q) = SupportsStmt S q := by
-  induction' l with _ l IH <;> simp only [write, SupportsStmt, *]
+  induction l <;> simp only [write, SupportsStmt, *]
 
 theorem supportsStmt_read {S : Finset (Λ' Γ Λ σ)} :
     ∀ {f : Γ → Stmt Bool (Λ' Γ Λ σ) σ}, (∀ a, SupportsStmt S (f a)) →
@@ -932,8 +935,9 @@ theorem supportsStmt_read {S : Finset (Λ' Γ Λ σ)} :
       (∀ v, SupportsStmt S (f v)) → SupportsStmt S (readAux i f)
     from fun hf ↦ this n _ (by intro; simp only [supportsStmt_move, hf])
   fun i f hf ↦ by
-  induction' i with i IH; · exact hf _
-  constructor <;> apply IH <;> intro <;> apply hf
+  induction i with
+  | zero => exact hf _
+  | succ i IH => constructor <;> apply IH <;> intro <;> apply hf
 
 variable (M : Λ → TM1.Stmt Γ Λ σ)
 
@@ -981,12 +985,12 @@ theorem trTape'_move_left (L R : ListBlank Γ) :
       Tape.mk' L' (ListBlank.append (Vector.toList (enc a)) R') by
     simpa only [List.length_reverse, Vector.toList_length] using this (List.reverse_reverse _).symm
   intro _ _ l₁ l₂ e
-  induction' l₁ with b l₁ IH generalizing l₂
-  · cases e
-    rfl
-  simp only [List.length, List.cons_append, iterate_succ_apply]
-  convert IH e
-  simp only [ListBlank.tail_cons, ListBlank.append, Tape.move_left_mk', ListBlank.head_cons]
+  induction l₁ generalizing l₂ with
+  | nil => cases e; rfl
+  | cons b l₁ IH =>
+    simp only [List.length, List.cons_append, iterate_succ_apply]
+    convert IH e
+    simp only [ListBlank.tail_cons, ListBlank.append, Tape.move_left_mk', ListBlank.head_cons]
 
 theorem trTape'_move_right (L R : ListBlank Γ) :
     (Tape.move Dir.right)^[n] (trTape' enc0 L R) = trTape' enc0 (L.cons R.head) R.tail := by
@@ -995,9 +999,9 @@ theorem trTape'_move_right (L R : ListBlank Γ) :
     simp only [trTape'_move_left, ListBlank.cons_head_tail, ListBlank.head_cons,
       ListBlank.tail_cons]
   intro i _
-  induction' i with i IH
-  · rfl
-  rw [iterate_succ_apply, iterate_succ_apply', Tape.move_left_right, IH]
+  induction i with
+  | zero => rfl
+  | succ i IH => rw [iterate_succ_apply, iterate_succ_apply', Tape.move_left_right, IH]
 
 theorem stepAux_write (q : Stmt Bool (Λ' Γ Λ σ) σ) (v : σ) (a b : Γ) (L R : ListBlank Γ) :
     stepAux (write (enc a).toList q) v (trTape' enc0 L (ListBlank.cons b R)) =
@@ -1009,13 +1013,13 @@ theorem stepAux_write (q : Stmt Bool (Λ' Γ Λ σ) σ) (v : σ) (a b : Γ) (L R
     exact this [] _ _ ((enc b).2.trans (enc a).2.symm)
   clear a b L R
   intro L' R' l₁ l₂ l₂' e
-  induction' l₂ with a l₂ IH generalizing l₁ l₂'
-  · cases List.length_eq_zero_iff.1 e
-    rfl
-  rcases l₂' with - | ⟨b, l₂'⟩ <;>
-    simp only [List.length_nil, List.length_cons, Nat.succ_inj, reduceCtorEq] at e
-  rw [List.reverseAux, ← IH (a :: l₁) l₂' e]
-  simp [stepAux, ListBlank.append, write]
+  induction l₂ generalizing l₁ l₂' with
+  | nil => cases List.length_eq_zero_iff.1 e; rfl
+  | cons a l₂ IH =>
+    rcases l₂' with - | ⟨b, l₂'⟩ <;>
+      simp only [List.length_nil, List.length_cons, Nat.succ_inj, reduceCtorEq] at e
+    rw [List.reverseAux, ← IH (a :: l₁) l₂' e]
+    simp [stepAux, ListBlank.append, write]
 
 variable (encdec : ∀ a, dec (enc a) = a)
 include encdec
@@ -1038,16 +1042,16 @@ theorem stepAux_read (f : Γ → Stmt Bool (Λ' Γ Λ σ) σ) (v : σ) (L R : Li
   clear f L a R
   intro i f L' R' l₁ l₂ _
   subst i
-  induction' l₂ with a l₂ IH generalizing l₁
-  · rfl
-  trans
-    stepAux (readAux l₂.length fun v ↦ f (a ::ᵥ v)) v
-      (Tape.mk' ((L'.append l₁).cons a) (R'.append l₂))
-  · dsimp [readAux, stepAux]
-    simp only [ListBlank.head_cons, Tape.move_right_mk', ListBlank.tail_cons]
-    cases a <;> rfl
-  rw [← ListBlank.append, IH]
-  rfl
+  induction l₂ generalizing l₁ with
+  | nil => rfl
+  | cons a l₂ IH =>
+    trans stepAux (readAux l₂.length fun v ↦ f (a ::ᵥ v)) v
+        (Tape.mk' ((L'.append l₁).cons a) (R'.append l₂))
+    · dsimp [readAux, stepAux]
+      simp only [ListBlank.head_cons, Tape.move_right_mk', ListBlank.tail_cons]
+      cases a <;> rfl
+    · rw [← ListBlank.append, IH]
+      rfl
 
 variable {enc0} in
 theorem tr_respects :

--- a/Mathlib/Computability/RegularExpressions.lean
+++ b/Mathlib/Computability/RegularExpressions.lean
@@ -198,15 +198,17 @@ theorem char_rmatch_iff (a : α) (x : List α) : rmatch (char a) x ↔ x = [a] :
 
 theorem add_rmatch_iff (P Q : RegularExpression α) (x : List α) :
     (P + Q).rmatch x ↔ P.rmatch x ∨ Q.rmatch x := by
-  induction' x with _ _ ih generalizing P Q
-  · simp only [rmatch, matchEpsilon, Bool.or_eq_true_iff]
-  · rw [rmatch, deriv_add]
+  induction x generalizing P Q with
+  | nil => simp only [rmatch, matchEpsilon, Bool.or_eq_true_iff]
+  | cons _ _ ih =>
+    rw [rmatch, deriv_add]
     exact ih _ _
 
 theorem mul_rmatch_iff (P Q : RegularExpression α) (x : List α) :
     (P * Q).rmatch x ↔ ∃ t u : List α, x = t ++ u ∧ P.rmatch t ∧ Q.rmatch u := by
-  induction' x with a x ih generalizing P Q
-  · rw [rmatch]; simp only [matchEpsilon]
+  induction x generalizing P Q with
+  | nil =>
+    rw [rmatch]; simp only [matchEpsilon]
     constructor
     · intro h
       refine ⟨[], [], rfl, ?_⟩
@@ -217,7 +219,8 @@ theorem mul_rmatch_iff (P Q : RegularExpression α) (x : List α) :
       subst ht hu
       repeat rw [rmatch] at h₂
       simp [h₂]
-  · rw [rmatch]; simp only [deriv]
+  | cons a x ih =>
+    rw [rmatch]; simp only [deriv]
     split_ifs with hepsilon
     · rw [add_rmatch_iff, ih]
       constructor

--- a/Mathlib/Computability/TMConfig.lean
+++ b/Mathlib/Computability/TMConfig.lean
@@ -247,9 +247,11 @@ theorem exists_code.comp {m n} {f : List.Vector ℕ n →. ℕ} {g : Fin n → L
       ⟨cf.comp cg, fun v => by
         simp [hg, hf, map_bind, seq_bind_eq, Function.comp_def]
         rfl⟩
-  clear hf f; induction' n with n IH
-  · exact ⟨nil, fun v => by simp [Vector.mOfFn, Bind.bind]; rfl⟩
-  · obtain ⟨cg, hg₁⟩ := hg 0
+  clear hf f
+  induction n with
+  | zero => exact ⟨nil, fun v => by simp [Vector.mOfFn, Bind.bind]; rfl⟩
+  | succ n IH =>
+    obtain ⟨cg, hg₁⟩ := hg 0
     obtain ⟨cl, hl⟩ := IH fun i => hg i.succ
     exact
       ⟨cons cg cl, fun v => by
@@ -282,9 +284,10 @@ theorem exists_code {n} {f : List.Vector ℕ n →. ℕ} (hf : Nat.Partrec' f) :
       simp only [Part.map_eq_map, Part.map_some, Vector.cons_val, Vector.tail_cons,
         Vector.head_cons, PFun.coe_val, Vector.tail_val]
       simp only [← Part.pure_eq_some] at hf hg ⊢
-      induction' v.head with n _ <;>
+      induction v.head with
         simp [prec, hf, Part.bind_assoc, ← Part.bind_some_eq_map, Part.bind_some,
           show ∀ x, pure x = [x] from fun _ => rfl, Bind.bind, Functor.map]
+      | succ n _ =>
       suffices ∀ a b, a + b = n →
         (n.succ :: 0 ::
           g (n ::ᵥ Nat.rec (f v.tail) (fun y IH => g (y ::ᵥ IH ::ᵥ v.tail)) n ::ᵥ v.tail) ::
@@ -300,11 +303,13 @@ theorem exists_code {n} {f : List.Vector ℕ n →. ℕ} (hf : Nat.Partrec' f) :
         erw [Part.eq_some_iff.2 (this 0 n (zero_add n))]
         simp only [List.headI, Part.bind_some, List.tail_cons]
       intro a b e
-      induction' b with b IH generalizing a
-      · refine PFun.mem_fix_iff.2 (Or.inl <| Part.eq_some_iff.1 ?_)
+      induction b generalizing a with
+      | zero =>
+        refine PFun.mem_fix_iff.2 (Or.inl <| Part.eq_some_iff.1 ?_)
         simp only [hg, ← e, Part.bind_some, List.tail_cons, pure]
         rfl
-      · refine PFun.mem_fix_iff.2 (Or.inr ⟨_, ?_, IH (a + 1) (by rwa [add_right_comm])⟩)
+      | succ b IH =>
+        refine PFun.mem_fix_iff.2 (Or.inr ⟨_, ?_, IH (a + 1) (by rwa [add_right_comm])⟩)
         simp only [hg, eval, Part.bind_some, Nat.rec_add_one, List.tail_nil, List.tail_cons, pure]
         exact Part.mem_some_iff.2 rfl
   | comp g _ _ IHf IHg => exact exists_code.comp IHf IHg

--- a/Mathlib/Computability/TMToPartrec.lean
+++ b/Mathlib/Computability/TMToPartrec.lean
@@ -557,8 +557,9 @@ theorem move_ok {p k₁ k₂ q s L₁ o L₂} {S : K' → List Γ'} (h₁ : k₁
     (e : splitAtPred p (S k₁) = (L₁, o, L₂)) :
     Reaches₁ (TM2.step tr) ⟨some (Λ'.move p k₁ k₂ q), s, S⟩
       ⟨some q, o, update (update S k₁ L₂) k₂ (L₁.reverseAux (S k₂))⟩ := by
-  induction' L₁ with a L₁ IH generalizing S s
-  · rw [(_ : [].reverseAux _ = _), Function.update_eq_self]
+  induction L₁ generalizing S s with
+  | nil =>
+    rw [(_ : [].reverseAux _ = _), Function.update_eq_self]
     swap
     · rw [Function.update_of_ne h₁.symm, List.reverseAux_nil]
     refine TransGen.head' rfl ?_
@@ -571,7 +572,8 @@ theorem move_ok {p k₁ k₂ q s L₁ o L₂} {S : K' → List Γ'} (h₁ : k₁
       simp only [cond_false, cond_true, Prod.mk.injEq, true_and, false_and, reduceCtorEq] at e ⊢
     simp only [e]
     rfl
-  · refine TransGen.head rfl ?_
+  | cons a L₁ IH =>
+    refine TransGen.head rfl ?_
     rw [tr]; simp only [pop', Option.elim, TM2.stepAux, push']
     rcases e₁ : S k₁ with - | ⟨a', Sk⟩ <;> rw [e₁, splitAtPred] at e
     · cases e
@@ -614,8 +616,9 @@ theorem move₂_ok {p k₁ k₂ q s L₁ o L₂} {S : K' → List Γ'} (h₁ : k
 
 theorem clear_ok {p k q s L₁ o L₂} {S : K' → List Γ'} (e : splitAtPred p (S k) = (L₁, o, L₂)) :
     Reaches₁ (TM2.step tr) ⟨some (Λ'.clear p k q), s, S⟩ ⟨some q, o, update S k L₂⟩ := by
-  induction' L₁ with a L₁ IH generalizing S s
-  · refine TransGen.head' rfl ?_
+  induction L₁ generalizing S s with
+  | nil =>
+    refine TransGen.head' rfl ?_
     rw [tr]; simp only [pop', TM2.step, Option.mem_def, TM2.stepAux, Option.elim]
     revert e; rcases S k with - | ⟨a, Sk⟩ <;> intro e
     · cases e
@@ -625,7 +628,8 @@ theorem clear_ok {p k q s L₁ o L₂} {S : K' → List Γ'} (e : splitAtPred p 
       simp only [cond_false, cond_true, Prod.mk.injEq, true_and, false_and, reduceCtorEq] at e ⊢
     rcases e with ⟨e₁, e₂⟩
     rw [e₁, e₂]
-  · refine TransGen.head rfl ?_
+  | cons a L₁ IH =>
+    refine TransGen.head rfl ?_
     rw [tr]; simp only [pop', TM2.step, Option.mem_def, TM2.stepAux, Option.elim]
     rcases e₁ : S k with - | ⟨a', Sk⟩ <;> rw [e₁, splitAtPred] at e
     · cases e
@@ -641,15 +645,17 @@ theorem clear_ok {p k q s L₁ o L₂} {S : K' → List Γ'} (e : splitAtPred p 
 theorem copy_ok (q s a b c d) :
     Reaches₁ (TM2.step tr) ⟨some (Λ'.copy q), s, K'.elim a b c d⟩
       ⟨some q, none, K'.elim (List.reverseAux b a) [] c (List.reverseAux b d)⟩ := by
-  induction' b with x b IH generalizing a d s
-  · refine TransGen.single ?_
+  induction b generalizing a d s with
+  | nil =>
+    refine TransGen.single ?_
     simp
-  refine TransGen.head rfl ?_
-  rw [tr]
-  simp only [TM2.step, Option.mem_def, TM2.stepAux, elim_rev, List.head?_cons, Option.isSome_some,
-    List.tail_cons, elim_update_rev, ne_eq, Function.update_of_ne, elim_main, elim_update_main,
-    elim_stack, elim_update_stack, cond_true, List.reverseAux_cons, pop', push']
-  exact IH _ _ _
+  | cons x b IH =>
+    refine TransGen.head rfl ?_
+    rw [tr]
+    simp only [TM2.step, Option.mem_def, TM2.stepAux, elim_rev, List.head?_cons, Option.isSome_some,
+      List.tail_cons, elim_update_rev, ne_eq, Function.update_of_ne, elim_main, elim_update_main,
+      elim_stack, elim_update_stack, cond_true, List.reverseAux_cons, pop', push']
+    exact IH _ _ _
 
 theorem trPosNum_natEnd : ∀ (n), ∀ x ∈ trPosNum n, natEnd x = false
   | PosNum.one, _, List.Mem.head _ => rfl
@@ -746,14 +752,17 @@ theorem succ_ok {q s n} {c d : List Γ'} :
     refine h.trans ?_
     convert unrev_ok using 2
     simp [e, List.reverseAux_eq]
-  induction' a with m IH m _ generalizing s <;> intro l₁
-  · refine ⟨Γ'.bit0 :: l₁, [Γ'.bit1], some Γ'.cons, rfl, TransGen.head rfl (TransGen.single ?_)⟩
+  induction a generalizing s with intro l₁
+  | one =>
+    refine ⟨Γ'.bit0 :: l₁, [Γ'.bit1], some Γ'.cons, rfl, TransGen.head rfl (TransGen.single ?_)⟩
     simp [trPosNum]
-  · obtain ⟨l₁', l₂', s', e, h⟩ := IH (Γ'.bit0 :: l₁)
+  | bit1 m IH =>
+    obtain ⟨l₁', l₂', s', e, h⟩ := IH (Γ'.bit0 :: l₁)
     refine ⟨l₁', l₂', s', e, TransGen.head ?_ h⟩
     simp [PosNum.succ, trPosNum]
     rfl
-  · refine ⟨l₁, _, some Γ'.bit0, rfl, TransGen.single ?_⟩
+  | bit0 m _ =>
+    refine ⟨l₁, _, some Γ'.bit0, rfl, TransGen.single ?_⟩
     simp only [TM2.step]; rw [tr]
     simp only [TM2.stepAux, pop', elim_main, elim_update_main, ne_eq, Function.update_of_ne,
       elim_rev, elim_update_rev, Function.update_self, Option.mem_def, Option.some.injEq]
@@ -788,14 +797,17 @@ theorem pred_ok (q₁ q₂ s v) (c d : List Γ') : ∃ s',
     refine h.trans ?_
     convert unrev_ok using 2
     simp [e, List.reverseAux_eq]
-  induction' a with m IH m IH generalizing s <;> intro l₁
-  · refine ⟨Γ'.bit1::l₁, [], some Γ'.cons, rfl, TransGen.head rfl (TransGen.single ?_)⟩
+  induction a generalizing s with intro l₁
+  | one =>
+    refine ⟨Γ'.bit1::l₁, [], some Γ'.cons, rfl, TransGen.head rfl (TransGen.single ?_)⟩
     simp [trPosNum, show PosNum.one.succ = PosNum.one.bit0 from rfl]
-  · obtain ⟨l₁', l₂', s', e, h⟩ := IH (some Γ'.bit0) (Γ'.bit1 :: l₁)
+  | bit1 m IH =>
+    obtain ⟨l₁', l₂', s', e, h⟩ := IH (some Γ'.bit0) (Γ'.bit1 :: l₁)
     refine ⟨l₁', l₂', s', e, TransGen.head ?_ h⟩
     simp
     rfl
-  · obtain ⟨a, l, e, h⟩ : ∃ a l, (trPosNum m = a::l) ∧ natEnd a = false := by
+  | bit0 m IH =>
+    obtain ⟨a, l, e, h⟩ : ∃ a l, (trPosNum m = a::l) ∧ natEnd a = false := by
       cases m <;> refine ⟨_, _, rfl, rfl⟩
     refine ⟨Γ'.bit0 :: l₁, _, some a, rfl, TransGen.single ?_⟩
     simp [trPosNum, PosNum.succ, e, h, show some Γ'.bit1 ≠ some Γ'.bit0 by decide,

--- a/Mathlib/Computability/Tape.lean
+++ b/Mathlib/Computability/Tape.lean
@@ -266,7 +266,7 @@ theorem ListBlank.nth_modifyNth {Γ} [Inhabited Γ] (f : Γ → Γ) (n i) (L : L
   | zero =>
     cases i <;> simp only [ListBlank.nth_zero, if_true, ListBlank.head_cons, ListBlank.modifyNth,
       ListBlank.nth_succ, if_false, ListBlank.tail_cons, reduceCtorEq]
-  | succ n IH  =>
+  | succ n IH =>
     cases i
     · rw [if_neg (Nat.succ_ne_zero _).symm]
       simp only [ListBlank.nth_zero, ListBlank.head_cons, ListBlank.modifyNth]

--- a/Mathlib/Computability/Tape.lean
+++ b/Mathlib/Computability/Tape.lean
@@ -262,10 +262,12 @@ def ListBlank.modifyNth {Γ} [Inhabited Γ] (f : Γ → Γ) : ℕ → ListBlank 
 
 theorem ListBlank.nth_modifyNth {Γ} [Inhabited Γ] (f : Γ → Γ) (n i) (L : ListBlank Γ) :
     (L.modifyNth f n).nth i = if i = n then f (L.nth i) else L.nth i := by
-  induction' n with n IH generalizing i L
-  · cases i <;> simp only [ListBlank.nth_zero, if_true, ListBlank.head_cons, ListBlank.modifyNth,
+  induction n generalizing i L with
+  | zero =>
+    cases i <;> simp only [ListBlank.nth_zero, if_true, ListBlank.head_cons, ListBlank.modifyNth,
       ListBlank.nth_succ, if_false, ListBlank.tail_cons, reduceCtorEq]
-  · cases i
+  | succ n IH  =>
+    cases i
     · rw [if_neg (Nat.succ_ne_zero _).symm]
       simp only [ListBlank.nth_zero, ListBlank.head_cons, ListBlank.modifyNth]
     · simp only [IH, ListBlank.modifyNth, ListBlank.nth_succ, ListBlank.tail_cons, Nat.succ.injEq]
@@ -351,7 +353,7 @@ theorem proj_map_nth {ι : Type*} {Γ : ι → Type*} [∀ i, Inhabited (Γ i)] 
 theorem ListBlank.map_modifyNth {Γ Γ'} [Inhabited Γ] [Inhabited Γ'] (F : PointedMap Γ Γ')
     (f : Γ → Γ) (f' : Γ' → Γ') (H : ∀ x, F (f x) = f' (F x)) (n) (L : ListBlank Γ) :
     (L.modifyNth f n).map F = (L.map F).modifyNth f' n := by
-  induction' n with n IH generalizing L <;>
+  induction n generalizing L <;>
     simp only [*, ListBlank.head_map, ListBlank.modifyNth, ListBlank.map_cons, ListBlank.tail_map]
 
 /-- Append a list on the left side of a `ListBlank`. -/
@@ -380,10 +382,11 @@ def ListBlank.flatMap {Γ Γ'} [Inhabited Γ] [Inhabited Γ'] (l : ListBlank Γ)
   apply l.liftOn (fun l ↦ ListBlank.mk (l.flatMap f))
   rintro l _ ⟨i, rfl⟩; obtain ⟨n, e⟩ := hf; refine Quotient.sound' (Or.inl ⟨i * n, ?_⟩)
   rw [List.flatMap_append, mul_comm]; congr
-  induction' i with i IH
-  · rfl
-  simp only [IH, e, List.replicate_add, Nat.mul_succ, add_comm, List.replicate_succ,
-    List.flatMap_cons]
+  induction i with
+  | zero => rfl
+  | succ i IH =>
+    simp only [IH, e, List.replicate_add, Nat.mul_succ, add_comm, List.replicate_succ,
+      List.flatMap_cons]
 
 @[simp]
 theorem ListBlank.flatMap_mk
@@ -582,11 +585,13 @@ theorem Tape.map_write {Γ Γ'} [Inhabited Γ] [Inhabited Γ'] (f : PointedMap �
 theorem Tape.write_move_right_n {Γ} [Inhabited Γ] (f : Γ → Γ) (L R : ListBlank Γ) (n : ℕ) :
     ((Tape.move Dir.right)^[n] (Tape.mk' L R)).write (f (R.nth n)) =
       (Tape.move Dir.right)^[n] (Tape.mk' L (R.modifyNth f n)) := by
-  induction' n with n IH generalizing L R
-  · simp only [ListBlank.nth_zero, ListBlank.modifyNth, iterate_zero_apply]
+  induction n generalizing L R with
+  | zero =>
+    simp only [ListBlank.nth_zero, ListBlank.modifyNth, iterate_zero_apply]
     rw [← Tape.write_mk', ListBlank.cons_head_tail]
-  simp only [ListBlank.head_cons, ListBlank.nth_succ, ListBlank.modifyNth, Tape.move_right_mk',
-    ListBlank.tail_cons, iterate_succ_apply, IH]
+  | succ n IH =>
+    simp only [ListBlank.head_cons, ListBlank.nth_succ, ListBlank.modifyNth, Tape.move_right_mk',
+      ListBlank.tail_cons, iterate_succ_apply, IH]
 
 theorem Tape.map_move {Γ Γ'} [Inhabited Γ] [Inhabited Γ'] (f : PointedMap Γ Γ') (T : Tape Γ) (d) :
     (T.move d).map f = (T.map f).move d := by

--- a/Mathlib/Computability/TuringMachine.lean
+++ b/Mathlib/Computability/TuringMachine.lean
@@ -630,24 +630,28 @@ theorem tr_respects_aux₁ {k} (o q v) {S : List (Γ k)} {L : ListBlank (∀ k, 
     (hL : L.map (proj k) = ListBlank.mk (S.map some).reverse) (n) (H : n ≤ S.length) :
     Reaches₀ (TM1.step (tr M)) ⟨some (go k o q), v, Tape.mk' ∅ (addBottom L)⟩
       ⟨some (go k o q), v, (Tape.move Dir.right)^[n] (Tape.mk' ∅ (addBottom L))⟩ := by
-  induction' n with n IH; · rfl
-  apply (IH (le_of_lt H)).tail
-  rw [iterate_succ_apply']
-  simp only [TM1.step, TM1.stepAux, tr, Tape.mk'_nth_nat, Tape.move_right_n_head,
-    addBottom_nth_snd, Option.mem_def]
-  rw [stk_nth_val _ hL, List.getElem?_eq_getElem]
-  · rfl
-  · rwa [List.length_reverse]
+  induction n with
+  | zero => rfl
+  | succ n IH =>
+    apply (IH (le_of_lt H)).tail
+    rw [iterate_succ_apply']
+    simp only [TM1.step, TM1.stepAux, tr, Tape.mk'_nth_nat, Tape.move_right_n_head,
+      addBottom_nth_snd, Option.mem_def]
+    rw [stk_nth_val _ hL, List.getElem?_eq_getElem]
+    · rfl
+    · rwa [List.length_reverse]
 
 theorem tr_respects_aux₃ {q v} {L : ListBlank (∀ k, Option (Γ k))} (n) : Reaches₀ (TM1.step (tr M))
     ⟨some (ret q), v, (Tape.move Dir.right)^[n] (Tape.mk' ∅ (addBottom L))⟩
     ⟨some (ret q), v, Tape.mk' ∅ (addBottom L)⟩ := by
-  induction' n with n IH; · rfl
-  refine Reaches₀.head ?_ IH
-  simp only [Option.mem_def, TM1.step]
-  rw [Option.some_inj, tr, TM1.stepAux, Tape.move_right_n_head, Tape.mk'_nth_nat,
-    addBottom_nth_succ_fst, TM1.stepAux, iterate_succ', Function.comp_apply, Tape.move_right_left]
-  rfl
+  induction n with
+  | zero => rfl
+  | succ n IH =>
+    refine Reaches₀.head ?_ IH
+    simp only [Option.mem_def, TM1.step]
+    rw [Option.some_inj, tr, TM1.stepAux, Tape.move_right_n_head, Tape.mk'_nth_nat,
+      addBottom_nth_succ_fst, TM1.stepAux, iterate_succ', Function.comp_apply, Tape.move_right_left]
+    rfl
 
 theorem tr_respects_aux {q v T k} {S : ∀ k, List (Γ k)}
     (hT : ∀ k, ListBlank.map (proj k) T = ListBlank.mk ((S k).map some).reverse)

--- a/Mathlib/Control/LawfulFix.lean
+++ b/Mathlib/Control/LawfulFix.lean
@@ -49,11 +49,11 @@ theorem approx_mono' {i : ℕ} : Fix.approx f i ≤ Fix.approx f (succ i) := by
   | succ _ i_ih => intro; apply f.monotone; apply i_ih
 
 theorem approx_mono ⦃i j : ℕ⦄ (hij : i ≤ j) : approx f i ≤ approx f j := by
-  induction' j with j ih
-  · cases hij
-    exact le_rfl
-  cases hij; · exact le_rfl
-  exact le_trans (ih ‹_›) (approx_mono' f)
+  induction j with
+  | zero => cases hij; exact le_rfl
+  | succ j ih =>
+    cases hij; · exact le_rfl
+    exact le_trans (ih ‹_›) (approx_mono' f)
 
 theorem mem_iff (a : α) (b : β a) : b ∈ Part.fix f a ↔ ∃ i, b ∈ approx f i a := by
   classical

--- a/Mathlib/FieldTheory/Finite/Basic.lean
+++ b/Mathlib/FieldTheory/Finite/Basic.lean
@@ -620,9 +620,10 @@ theorem Int.ModEq.pow_card_sub_one_eq_one {p : ℕ} (hp : Nat.Prime p) {n : ℤ}
   simpa [← ZMod.intCast_eq_intCast_iff] using ZMod.pow_card_sub_one_eq_one this
 
 theorem pow_pow_modEq_one (p m a : ℕ) : (1 + p * a) ^ (p ^ m) ≡ 1 [MOD p ^ m] := by
-  induction' m with m hm
-  · exact Nat.modEq_one
-  · rw [Nat.ModEq.comm, add_comm, Nat.modEq_iff_dvd' (Nat.one_le_pow' _ _)] at hm
+  induction m with
+  | zero => exact Nat.modEq_one
+  | succ m hm =>
+    rw [Nat.ModEq.comm, add_comm, Nat.modEq_iff_dvd' (Nat.one_le_pow' _ _)] at hm
     obtain ⟨d, hd⟩ := hm
     rw [tsub_eq_iff_eq_add_of_le (Nat.one_le_pow' _ _), add_comm] at hd
     rw [pow_succ, pow_mul, hd, add_pow, Finset.sum_range_succ', pow_zero, one_mul, one_pow,

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Basic.lean
@@ -498,19 +498,20 @@ variable {F} in
 theorem exists_lt_finrank_of_infinite_dimensional
     [Algebra.IsAlgebraic F E] (hnfd : ¬ FiniteDimensional F E) (n : ℕ) :
     ∃ L : IntermediateField F E, FiniteDimensional F L ∧ n < finrank F L := by
-  induction' n with n ih
-  · exact ⟨⊥, Subalgebra.finite_bot, finrank_pos⟩
-  obtain ⟨L, fin, hn⟩ := ih
-  obtain ⟨x, hx⟩ : ∃ x : E, x ∉ L := by
-    contrapose! hnfd
-    rw [show L = ⊤ from eq_top_iff.2 fun x _ ↦ hnfd x] at fin
-    exact topEquiv.toLinearEquiv.finiteDimensional
-  let L' := L ⊔ F⟮x⟯
-  haveI := adjoin.finiteDimensional (Algebra.IsIntegral.isIntegral (R := F) x)
-  refine ⟨L', inferInstance, by_contra fun h ↦ ?_⟩
-  have h1 : L = L' := eq_of_le_of_finrank_le le_sup_left ((not_lt.1 h).trans hn)
-  have h2 : F⟮x⟯ ≤ L' := le_sup_right
-  exact hx <| (h1.symm ▸ h2) <| mem_adjoin_simple_self F x
+  induction n with
+  | zero => exact ⟨⊥, Subalgebra.finite_bot, finrank_pos⟩
+  | succ n ih =>
+    obtain ⟨L, fin, hn⟩ := ih
+    obtain ⟨x, hx⟩ : ∃ x : E, x ∉ L := by
+      contrapose! hnfd
+      rw [show L = ⊤ from eq_top_iff.2 fun x _ ↦ hnfd x] at fin
+      exact topEquiv.toLinearEquiv.finiteDimensional
+    let L' := L ⊔ F⟮x⟯
+    haveI := adjoin.finiteDimensional (Algebra.IsIntegral.isIntegral (R := F) x)
+    refine ⟨L', inferInstance, by_contra fun h ↦ ?_⟩
+    have h1 : L = L' := eq_of_le_of_finrank_le le_sup_left ((not_lt.1 h).trans hn)
+    have h2 : F⟮x⟯ ≤ L' := le_sup_right
+    exact hx <| (h1.symm ▸ h2) <| mem_adjoin_simple_self F x
 
 theorem _root_.minpoly.natDegree_le (x : L) [FiniteDimensional K L] :
     (minpoly K x).natDegree ≤ finrank K L :=

--- a/Mathlib/FieldTheory/IntermediateField/Basic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Basic.lean
@@ -298,16 +298,16 @@ instance toField : Field S :=
 @[norm_cast]
 theorem coe_sum {ι : Type*} [Fintype ι] (f : ι → S) : (↑(∑ i, f i) : L) = ∑ i, (f i : L) := by
   classical
-    induction' (Finset.univ : Finset ι) using Finset.induction_on with i s hi H
-    · simp
-    · rw [Finset.sum_insert hi, AddMemClass.coe_add, H, Finset.sum_insert hi]
+    induction (Finset.univ : Finset ι) using Finset.induction_on with
+    | empty => simp
+    | insert i s hi H => rw [Finset.sum_insert hi, AddMemClass.coe_add, H, Finset.sum_insert hi]
 
 @[norm_cast]
 theorem coe_prod {ι : Type*} [Fintype ι] (f : ι → S) : (↑(∏ i, f i) : L) = ∏ i, (f i : L) := by
   classical
-    induction' (Finset.univ : Finset ι) using Finset.induction_on with i s hi H
-    · simp
-    · rw [Finset.prod_insert hi, MulMemClass.coe_mul, H, Finset.prod_insert hi]
+    induction (Finset.univ : Finset ι) using Finset.induction_on with
+    | empty => simp
+    | insert i s hi H => rw [Finset.prod_insert hi, MulMemClass.coe_mul, H, Finset.prod_insert hi]
 
 /-!
 `IntermediateField`s inherit structure from their `Subfield` coercions.

--- a/Mathlib/FieldTheory/PerfectClosure.lean
+++ b/Mathlib/FieldTheory/PerfectClosure.lean
@@ -232,22 +232,23 @@ theorem mk_zero : mk K p 0 = 0 :=
 
 @[simp]
 theorem mk_zero_right (n : ℕ) : mk K p (n, 0) = 0 := by
-  induction' n with n ih
-  · rfl
-  rw [← ih]
-  symm
-  apply Quot.sound
-  have := R.intro (p := p) n (0 : K)
-  rwa [frobenius_zero K p] at this
+  induction n with
+  | zero => rfl
+  | succ n ih =>
+    rw [← ih]
+    apply (Quot.sound _).symm
+    have := R.intro (p := p) n (0 : K)
+    rwa [frobenius_zero K p] at this
 
 theorem R.sound (m n : ℕ) (x y : K) (H : (frobenius K p)^[m] x = y) :
     mk K p (n, x) = mk K p (m + n, y) := by
   subst H
-  induction' m with m ih
-  · simp only [zero_add, iterate_zero_apply]
-  rw [ih, Nat.succ_add, iterate_succ']
-  apply Quot.sound
-  apply R.intro
+  induction m with
+  | zero => simp only [zero_add, iterate_zero_apply]
+  | succ m ih =>
+    rw [ih, Nat.succ_add, iterate_succ']
+    apply Quot.sound
+    apply R.intro
 
 instance instAddCommGroup : AddCommGroup (PerfectClosure K p) :=
   { (inferInstance : Add (PerfectClosure K p)),
@@ -345,15 +346,18 @@ theorem mk_pow (x : ℕ × K) (n : ℕ) : mk K p x ^ n = mk K p (x.1, x.2 ^ n) :
       ← pow_add, mul_assoc, ← pow_add]⟩
 
 theorem natCast (n x : ℕ) : (x : PerfectClosure K p) = mk K p (n, x) := by
-  induction' n with n ih
-  · induction' x with x ih
-    · simp
-    rw [Nat.cast_succ, Nat.cast_succ, ih]
-    rfl
-  rw [ih]; apply Quot.sound
-  suffices R K p (n, (x : K)) (Nat.succ n, frobenius K p (x : K)) by
-    rwa [frobenius_natCast K p x] at this
-  apply R.intro
+  induction n with
+  | zero =>
+    induction x with
+    | zero => simp
+    | succ x ih =>
+      rw [Nat.cast_succ, Nat.cast_succ, ih]
+      rfl
+  | succ n ih =>
+    rw [ih]; apply Quot.sound
+    suffices R K p (n, (x : K)) (Nat.succ n, frobenius K p (x : K)) by
+      rwa [frobenius_natCast K p x] at this
+    apply R.intro
 
 theorem intCast (x : ℤ) : (x : PerfectClosure K p) = mk K p (0, x) := by
   cases x <;> simp [natCast K p 0]
@@ -408,9 +412,9 @@ instance instPerfectRing : PerfectRing (PerfectClosure K p) p where
 @[simp]
 theorem iterate_frobenius_mk (n : ℕ) (x : K) :
     (frobenius (PerfectClosure K p) p)^[n] (mk K p ⟨n, x⟩) = of K p x := by
-  induction' n with n ih
-  · rfl
-  rw [iterate_succ_apply, ← ih, frobenius_mk, mk_succ_pow]
+  induction n with
+  | zero => rfl
+  | succ n ih => rw [iterate_succ_apply, ← ih, frobenius_mk, mk_succ_pow]
 
 /-- Given a ring `K` of characteristic `p` and a perfect ring `L` of the same characteristic,
 any homomorphism `K →+* L` can be lifted to `PerfectClosure K p`. -/

--- a/Mathlib/FieldTheory/RatFunc/Basic.lean
+++ b/Mathlib/FieldTheory/RatFunc/Basic.lean
@@ -342,8 +342,8 @@ def map [MonoidHomClass F R[X] S[X]] (φ : F) (hφ : R[X]⁰ ≤ S[X]⁰.comap �
       Localization.mk_one, Localization.mk_eq_monoidOf_mk', Submonoid.LocalizationMap.mk'_self]
   map_mul' x y := by
     obtain ⟨x⟩ := x; obtain ⟨y⟩ := y
-    induction' x using Localization.induction_on with pq
-    induction' y using Localization.induction_on with p'q'
+    cases x using Localization.induction_on with | _ pq
+    cases y using Localization.induction_on with | _ p'q'
     obtain ⟨p, q⟩ := pq
     obtain ⟨p', q'⟩ := p'q'
     have hq : φ q ∈ S[X]⁰ := hφ q.prop
@@ -411,8 +411,8 @@ def liftMonoidWithZeroHom (φ : R[X] →*₀ G₀) (hφ : R[X]⁰ ≤ G₀⁰.co
   map_mul' x y := by
     obtain ⟨x⟩ := x
     obtain ⟨y⟩ := y
-    induction' x using Localization.induction_on with p q
-    induction' y using Localization.induction_on with p' q'
+    cases x using Localization.induction_on
+    cases y using Localization.induction_on
     rw [← ofFractionRing_mul, Localization.mk_mul]
     simp only [liftOn_ofFractionRing_mk, div_mul_div_comm, map_mul, Submonoid.coe_mul]
   map_zero' := by
@@ -428,8 +428,8 @@ theorem liftMonoidWithZeroHom_injective [Nontrivial R] (φ : R[X] →*₀ G₀) 
     (hφ' : R[X]⁰ ≤ G₀⁰.comap φ := nonZeroDivisors_le_comap_nonZeroDivisors_of_injective _ hφ) :
     Function.Injective (liftMonoidWithZeroHom φ hφ') := by
   rintro ⟨x⟩ ⟨y⟩
-  induction' x using Localization.induction_on with a
-  induction' y using Localization.induction_on with a'
+  cases x using Localization.induction_on
+  cases y using Localization.induction_on with | _ a'
   simp_rw [liftMonoidWithZeroHom_apply_ofFractionRing_mk]
   intro h
   congr 1
@@ -448,8 +448,8 @@ def liftRingHom (φ : R[X] →+* L) (hφ : R[X]⁰ ≤ L⁰.comap φ) : RatFunc 
       · rw [Subsingleton.elim (x + y) y, Subsingleton.elim x 0, map_zero, zero_add]
       obtain ⟨x⟩ := x
       obtain ⟨y⟩ := y
-      induction' x using Localization.induction_on with pq
-      induction' y using Localization.induction_on with p'q'
+      cases x using Localization.induction_on with | _ pq
+      cases y using Localization.induction_on with | _ p'q'
       obtain ⟨p, q⟩ := pq
       obtain ⟨p', q'⟩ := p'q'
       rw [← ofFractionRing_add, Localization.add_mk]
@@ -504,7 +504,7 @@ instance (R : Type*) [CommSemiring R] [Algebra R K[X]] : Algebra R (RatFunc K) w
     map_zero' := by simp only [mk_one', RingHom.map_zero, ofFractionRing_zero] }
   smul := (· • ·)
   smul_def' c x := by
-    induction' x using RatFunc.induction_on' with p q hq
+    induction x using RatFunc.induction_on' with | _ p q hq
     rw [RingHom.coe_mk, MonoidHom.coe_mk, OneHom.coe_mk, mk_one', ← mk_smul,
       mk_def_of_ne (c • p) hq, mk_def_of_ne p hq, ← ofFractionRing_mul,
       IsLocalization.mul_mk'_eq_mk'_of_mul, Algebra.smul_def]
@@ -872,7 +872,7 @@ theorem denom_div_dvd (p q : K[X]) : denom (algebraMap _ _ p / algebraMap _ _ q)
 @[simp]
 theorem num_div_denom (x : RatFunc K) : algebraMap _ _ (num x) / algebraMap _ _ (denom x) = x := by
   classical
-  induction' x using RatFunc.induction_on with p q hq
+  induction x using RatFunc.induction_on with | _ p q hq
   have q_div_ne_zero : q / gcd p q ≠ 0 := right_div_gcd_ne_zero hq
   rw [num_div p q, denom_div p hq, RingHom.map_mul, RingHom.map_mul, mul_div_mul_left,
     div_eq_div_iff, ← RingHom.map_mul, ← RingHom.map_mul, mul_comm _ q, ←
@@ -886,7 +886,7 @@ theorem num_div_denom (x : RatFunc K) : algebraMap _ _ (num x) / algebraMap _ _ 
 
 theorem isCoprime_num_denom (x : RatFunc K) : IsCoprime x.num x.denom := by
   classical
-  induction' x using RatFunc.induction_on with p q hq
+  induction x using RatFunc.induction_on with | _ p q hq
   rw [num_div, denom_div _ hq]
   exact (isCoprime_mul_unit_left
     ((leadingCoeff_ne_zero.2 <| right_div_gcd_ne_zero hq).isUnit.inv.map C) _ _).2

--- a/Mathlib/FieldTheory/Separable.lean
+++ b/Mathlib/FieldTheory/Separable.lean
@@ -365,7 +365,7 @@ theorem separable_or {f : F[X]} (hf : Irreducible f) :
 theorem exists_separable_of_irreducible {f : F[X]} (hf : Irreducible f) (hp : p ≠ 0) :
     ∃ (n : ℕ) (g : F[X]), g.Separable ∧ expand F (p ^ n) g = f := by
   replace hp : p.Prime := (CharP.char_is_prime_or_zero F p).resolve_right hp
-  induction' hn : f.natDegree using Nat.strong_induction_on with N ih generalizing f
+  induction hn : f.natDegree using Nat.strong_induction_on generalizing f with | _ N ih
   rcases separable_or p hf with (h | ⟨h1, g, hg, hgf⟩)
   · refine ⟨0, f, h, ?_⟩
     rw [pow_zero, expand_one]


### PR DESCRIPTION
As well as the one instance in `Combinatorics` and the one instance in `Control`.