### PR TITLE
[Merged by Bors] - feat: lemmas about `Orthonormal` and `Fin`

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Basic.lean
@@ -59,6 +59,9 @@ theorem inner_eq_zero_symm {x y : E} : ⟪x, y⟫ = 0 ↔ ⟪y, x⟫ = 0 := by
   rw [← inner_conj_symm]
   exact star_eq_zero
 
+instance {ι : Sort*} (v : ι → E) : IsSymm ι fun i j => ⟪v i, v j⟫ = 0 where
+  symm _ _ := inner_eq_zero_symm.1
+
 @[simp]
 theorem inner_self_im (x : E) : im ⟪x, x⟫ = 0 := by rw [← @ofReal_inj 𝕜, im_eq_conj_sub]; simp
 

--- a/Mathlib/Analysis/InnerProductSpace/Orthonormal.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Orthonormal.lean
@@ -50,6 +50,16 @@ def Orthonormal (v : ι → E) : Prop :=
 
 variable {𝕜}
 
+@[simp]
+lemma Orthonormal.of_isEmpty [IsEmpty ι] (v : ι → E) : Orthonormal 𝕜 v :=
+  ⟨IsEmpty.elim ‹_›, Subsingleton.pairwise⟩
+
+@[simp]
+lemma orthonormal_vecCons_iff {n : ℕ} {v : E} {vs : Fin n → E} :
+    Orthonormal 𝕜 (Matrix.vecCons v vs) ↔ ‖v‖ = 1 ∧ (∀ i, ⟪v, vs i⟫ = 0) ∧ Orthonormal 𝕜 vs := by
+  simp_rw [Orthonormal, pairwise_fin_succ_iff_of_isSymm, Fin.forall_fin_succ]
+  tauto
+
 lemma Orthonormal.norm_eq_one {v : ι → E} (h : Orthonormal 𝕜 v) (i : ι) :
     ‖v i‖ = 1 := h.1 i
 

--- a/Mathlib/Logic/Pairwise.lean
+++ b/Mathlib/Logic/Pairwise.lean
@@ -36,6 +36,7 @@ theorem Pairwise.mono (hr : Pairwise r) (h : ∀ ⦃i j⦄, r i j → p i j) : P
 protected theorem Pairwise.eq (h : Pairwise r) : ¬r a b → a = b :=
   not_imp_comm.1 <| @h _ _
 
+@[simp]
 protected lemma Subsingleton.pairwise [Subsingleton α] : Pairwise r :=
   fun _ _ h ↦ False.elim <| h.elim <| Subsingleton.elim _ _
 
@@ -54,6 +55,23 @@ lemma Pairwise.of_comp_of_surjective {f : β → α} (hr : Pairwise (r on f)) (h
 lemma Function.Bijective.pairwise_comp_iff {f : β → α} (hf : Bijective f) :
     Pairwise (r on f) ↔ Pairwise r :=
   ⟨fun hr ↦ hr.of_comp_of_surjective hf.surjective, fun hr ↦ hr.comp_of_injective hf.injective⟩
+
+theorem pairwise_fin_succ_iff {n : ℕ} {R : Fin n.succ → Fin n.succ → Prop} :
+    Pairwise R ↔
+      (∀ i, R (Fin.succ i) 0) ∧ (∀ j, R 0 (Fin.succ j)) ∧
+      Pairwise fun i j => R (Fin.succ i) (Fin.succ j) where
+  mp h := ⟨
+    fun _ => h (Fin.succ_ne_zero _), fun _ => h (Fin.succ_ne_zero _).symm,
+    fun _i _j hij => h <| Fin.succ_inj.not.2 hij⟩
+  mpr
+  | ⟨hi, hj, h⟩ =>
+    Fin.cases
+      (Fin.cases nofun fun j _ => hj j)
+      (fun i => Fin.cases (fun _ => hi i) fun _j hij => h (ne_of_apply_ne _ hij))
+
+theorem pairwise_fin_succ_iff_of_isSymm {n : ℕ} {R : Fin n.succ → Fin n.succ → Prop} [IsSymm _ R] :
+    Pairwise R ↔ (∀ j, R 0 (Fin.succ j)) ∧ Pairwise fun i j => R (Fin.succ i) (Fin.succ j) := by
+  simp only [pairwise_fin_succ_iff, comm (b := 0) (r := R), and_self_left]
 
 namespace Set
 


### PR DESCRIPTION
This makes it easier to work with `Orthonormal 𝕜 ![a, b, c]`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
