### PR TITLE
[Merged by Bors] - feat: `specialOrthogonalGroup` is a group

### DIFF
--- a/Mathlib/LinearAlgebra/UnitaryGroup.lean
+++ b/Mathlib/LinearAlgebra/UnitaryGroup.lean
@@ -52,9 +52,10 @@ variable (α : Type v) [CommRing α] [StarRing α]
 /-- `Matrix.unitaryGroup n` is the group of `n` by `n` matrices where the star-transpose is the
 inverse.
 -/
-abbrev unitaryGroup :=
+abbrev unitaryGroup : Submonoid (Matrix n n α) :=
   unitary (Matrix n n α)
 
+-- the group and star structure is already defined in another file
 example : Group (unitaryGroup n α) := inferInstance
 example : StarMul (unitaryGroup n α) := inferInstance
 
@@ -244,6 +245,7 @@ abbrev specialOrthogonalGroup : Submonoid (Matrix n n β) := specialUnitaryGroup
 
 variable {n} {β} {A : Matrix n n β}
 
+-- the group and star structure is automatic from `specialUnitaryGroup`
 example : Group (specialOrthogonalGroup n β) := inferInstance
 example : StarMul (specialOrthogonalGroup n β) := inferInstance
 

--- a/Mathlib/LinearAlgebra/UnitaryGroup.lean
+++ b/Mathlib/LinearAlgebra/UnitaryGroup.lean
@@ -180,9 +180,12 @@ variable (n) (α)
 
 /-- `Matrix.specialUnitaryGroup` is the group of unitary `n` by `n` matrices where the determinant
 is 1. (This definition is only correct if 2 is invertible.) -/
-abbrev specialUnitaryGroup := unitaryGroup n α ⊓ MonoidHom.mker detMonoidHom
+def specialUnitaryGroup : Submonoid (Matrix n n α) := unitaryGroup n α ⊓ MonoidHom.mker detMonoidHom
 
 variable {n} {α}
+
+theorem specialUnitaryGroup_le_unitaryGroup : specialUnitaryGroup n α ≤ unitaryGroup n α :=
+  inf_le_left
 
 theorem mem_specialUnitaryGroup_iff :
     A ∈ specialUnitaryGroup n α ↔ A ∈ unitaryGroup n α ∧ A.det = 1 :=
@@ -237,7 +240,7 @@ attribute [local instance] starRingOfComm
 
 /-- `Matrix.specialOrthogonalGroup n` is the group of orthogonal `n` by `n` where the determinant
 is one. (This definition is only correct if 2 is invertible.) -/
-abbrev specialOrthogonalGroup := specialUnitaryGroup n β
+abbrev specialOrthogonalGroup : Submonoid (Matrix n n β) := specialUnitaryGroup n β
 
 variable {n} {β} {A : Matrix n n β}
 

--- a/Mathlib/LinearAlgebra/UnitaryGroup.lean
+++ b/Mathlib/LinearAlgebra/UnitaryGroup.lean
@@ -55,6 +55,9 @@ inverse.
 abbrev unitaryGroup :=
   unitary (Matrix n n α)
 
+example : Group (unitaryGroup n α) := inferInstance
+example : StarMul (unitaryGroup n α) := inferInstance
+
 end
 
 variable {n : Type u} [DecidableEq n] [Fintype n]
@@ -185,6 +188,22 @@ theorem mem_specialUnitaryGroup_iff :
     A ∈ specialUnitaryGroup n α ↔ A ∈ unitaryGroup n α ∧ A.det = 1 :=
   Iff.rfl
 
+instance : StarMul (specialUnitaryGroup n α) where
+  star A := ⟨star A, by simpa using A.prop.1, by have := A.prop.2; simp_all [star_eq_conjTranspose]⟩
+  star_mul A B := Subtype.ext <| star_mul A.1 B.1
+  star_involutive A := Subtype.ext <| star_involutive A.1
+
+@[simp, norm_cast]
+theorem specialUnitaryGroup.coe_star (A : specialUnitaryGroup n α) : (star A).1 = star A.1 := rfl
+
+instance : Inv (specialUnitaryGroup n α) where inv := star
+
+theorem star_eq_inv (A : specialUnitaryGroup n α) : star A = A⁻¹ :=
+  rfl
+
+instance : Group (specialUnitaryGroup n α) where
+  inv_mul_cancel A := Subtype.ext A.prop.1.1
+
 end specialUnitaryGroup
 
 section OrthogonalGroup
@@ -201,14 +220,12 @@ inverse. -/
 abbrev orthogonalGroup := unitaryGroup n β
 
 theorem mem_orthogonalGroup_iff {A : Matrix n n β} :
-    A ∈ Matrix.orthogonalGroup n β ↔ A * star A = 1 := by
-  refine ⟨And.right, fun hA => ⟨?_, hA⟩⟩
-  simpa only [mul_eq_one_comm] using hA
+    A ∈ Matrix.orthogonalGroup n β ↔ A * Aᵀ = 1 :=
+  mem_unitaryGroup_iff
 
 theorem mem_orthogonalGroup_iff' {A : Matrix n n β} :
-    A ∈ Matrix.orthogonalGroup n β ↔ star A * A = 1 := by
-  refine ⟨And.left, fun hA => ⟨hA, ?_⟩⟩
-  rwa [mul_eq_one_comm] at hA
+    A ∈ Matrix.orthogonalGroup n β ↔ Aᵀ * A = 1 :=
+  mem_unitaryGroup_iff'
 
 end OrthogonalGroup
 
@@ -223,6 +240,9 @@ is one. (This definition is only correct if 2 is invertible.) -/
 abbrev specialOrthogonalGroup := specialUnitaryGroup n β
 
 variable {n} {β} {A : Matrix n n β}
+
+example : Group (specialOrthogonalGroup n β) := inferInstance
+example : StarMul (specialOrthogonalGroup n β) := inferInstance
 
 theorem mem_specialOrthogonalGroup_iff :
     A ∈ specialOrthogonalGroup n β ↔ A ∈ orthogonalGroup n β ∧ A.det = 1 :=


### PR DESCRIPTION
Also changes the statement of `mem_orthogonalGroup_iff`, since this should use transpose not star.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
