### PR TITLE
[Merged by Bors] - feat: add supporting material for the counting function of value distribution theory

### DIFF
--- a/Mathlib/Analysis/Complex/ValueDistribution/CountingFunction.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/CountingFunction.lean
@@ -98,32 +98,21 @@ Alternate presentation of the finsum that appears in the definition of the count
 -/
 lemma countingFunction_finsum_eq_finsum_add {R : ℝ} {D : ℂ → ℤ} (hR : R ≠ 0)
     (hD : D.support.Finite) :
-    ∑ᶠ u, (D u) * (log R - log ‖u‖) = ∑ᶠ u, (D u) * log (R * ‖u‖⁻¹) + D 0 * log R := by
+    ∑ᶠ u, D u * (log R - log ‖u‖) = ∑ᶠ u, D u * log (R * ‖u‖⁻¹) + D 0 * log R := by
   by_cases h : 0 ∈ D.support
-  · have {g : ℂ → ℝ} : (fun u ↦ (D u) * (g u)).support ⊆ hD.toFinset := by
-      intro x
-      contrapose
-      simp_all
+  · have {g : ℂ → ℝ} : (fun u ↦ D u * g u).support ⊆ hD.toFinset := fun x ↦ by
+      simp +contextual
     simp only [finsum_eq_sum_of_support_subset _ this,
       Finset.sum_eq_sum_diff_singleton_add ((Set.Finite.mem_toFinset hD).mpr h), norm_zero,
       log_zero, sub_zero, inv_zero, mul_zero, add_zero, add_left_inj]
-    apply Finset.sum_congr rfl
-    intro x hx
-    simp only [Finset.mem_sdiff, Set.Finite.mem_toFinset, Function.mem_support, ne_eq,
-      Finset.mem_singleton] at hx
-    congr
-    rw [log_mul hR (inv_ne_zero (norm_ne_zero_iff.mpr hx.2)), log_inv]
-    ring
-  · simp_all only [ne_eq, Function.mem_support, Decidable.not_not, Int.cast_zero, zero_mul,
-      add_zero]
-    apply finsum_congr
-    intro x
+    refine Finset.sum_congr rfl fun x hx ↦ ?_
+    simp only [Finset.mem_sdiff, Finset.notMem_singleton] at hx
+    simp [log_mul hR (inv_ne_zero (norm_ne_zero_iff.mpr hx.2)), sub_eq_add_neg]
+  · simp_all only [mem_support, Decidable.not_not, Int.cast_zero, zero_mul, add_zero]
+    refine finsum_congr fun x ↦ ?_
     by_cases h₁ : x = 0
     · simp_all
-    · simp only [log_mul hR (inv_ne_zero (norm_ne_zero_iff.mpr h₁)), log_inv, mul_eq_mul_left_iff,
-        Int.cast_eq_zero]
-      left
-      ring
+    · simp [log_mul hR (inv_ne_zero (norm_ne_zero_iff.mpr h₁)), sub_eq_add_neg]
 
 /--
 Evaluation of the logarithmic counting function at zero yields zero.

--- a/Mathlib/Analysis/Complex/ValueDistribution/CountingFunction.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/CountingFunction.lean
@@ -60,14 +60,15 @@ noncomputable def toClosedBall {E : Type*} [NormedAddCommGroup E] (r : ℝ) :
 
 /--
 Definition of the logarithmic counting function, as a group morphism mapping functions `D` with
-locally finite support to maps `ℝ → ℝ`.  Given `D`, the result map `logCounting D` takes a real `r :
-ℝ` to a logarithmically weighted measure of values that `D` takes within the disk `∣z∣ ≤ r`.
+locally finite support to maps `ℝ → ℝ`.  Given `D`, the result map `logCounting D` takes `r : ℝ` to
+a logarithmically weighted measure of values that `D` takes within the disk `∣z∣ ≤ r`.
 
 Implementation Note: In case where `z = 0`, the term `log (r * ‖z‖⁻¹)` evaluates to zero, which is
 typically different from `log r - log ‖z‖ = log r`. The summand `(D 0) * log r` compensates this,
 producing cleaner formulas when the logarithmic counting function is used in the main theorms of
 Value Distribution Theory.  We refer the reader to page 164 of [Lang: Introduction to Complex
-Hyperbolic Spaces](https://link.springer.com/book/10.1007/978-1-4757-1945-1) for more details.
+Hyperbolic Spaces](https://link.springer.com/book/10.1007/978-1-4757-1945-1) for more details, and
+to the lemma `countingFunction_finsum_eq_finsum_add` for a formal statement.
 -/
 noncomputable def logCounting {E : Type*} [NormedAddCommGroup E] [ProperSpace E] :
     locallyFinsuppWithin (univ : Set E) ℤ →+ (ℝ → ℝ) where
@@ -91,6 +92,38 @@ noncomputable def logCounting {E : Type*} [NormedAddCommGroup E] [ProperSpace E]
         by_contra
         simp_all
     · ring
+
+/--
+Alternate presentation of the finsum that appears in the definition of the counting function.
+-/
+lemma countingFunction_finsum_eq_finsum_add {R : ℝ} {D : ℂ → ℤ} (hR : R ≠ 0)
+    (hD : D.support.Finite) :
+    ∑ᶠ u, (D u) * (log R - log ‖u‖) = ∑ᶠ u, (D u) * log (R * ‖u‖⁻¹) + D 0 * log R := by
+  by_cases h : 0 ∈ D.support
+  · have {g : ℂ → ℝ} : (fun u ↦ (D u) * (g u)).support ⊆ hD.toFinset := by
+      intro x
+      contrapose
+      simp_all
+    simp only [finsum_eq_sum_of_support_subset _ this,
+      Finset.sum_eq_sum_diff_singleton_add ((Set.Finite.mem_toFinset hD).mpr h), norm_zero,
+      log_zero, sub_zero, inv_zero, mul_zero, add_zero, add_left_inj]
+    apply Finset.sum_congr rfl
+    intro x hx
+    simp only [Finset.mem_sdiff, Set.Finite.mem_toFinset, Function.mem_support, ne_eq,
+      Finset.mem_singleton] at hx
+    congr
+    rw [log_mul hR (inv_ne_zero (norm_ne_zero_iff.mpr hx.2)), log_inv]
+    ring
+  · simp_all only [ne_eq, Function.mem_support, Decidable.not_not, Int.cast_zero, zero_mul,
+      add_zero]
+    apply finsum_congr
+    intro x
+    by_cases h₁ : x = 0
+    · simp_all
+    · simp only [log_mul hR (inv_ne_zero (norm_ne_zero_iff.mpr h₁)), log_inv, mul_eq_mul_left_iff,
+        Int.cast_eq_zero]
+      left
+      ring
 
 /--
 Evaluation of the logarithmic counting function at zero yields zero.


### PR DESCRIPTION
Establish an alternate formulation for finsum that appears in the definition of the counting function. This supports claims made in the docstring with a formal statement.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
