### PR TITLE
feat(Tactic/ComputeDegree): add support for scalar multiplication with different types

### DIFF
--- a/Mathlib/Tactic/ComputeDegree.lean
+++ b/Mathlib/Tactic/ComputeDegree.lean
@@ -122,15 +122,16 @@ theorem coeff_pow_of_natDegree_le_of_eq_ite' {m n o : ℕ} {a : R} {p : R[X]}
     · exact natDegree_pow_le_of_le m ‹_›
     · exact Iff.mp ne_comm h
 
-theorem natDegree_smul_le_of_le {n : ℕ} {a : R} {f : R[X]} (hf : natDegree f ≤ n) :
-    natDegree (a • f) ≤ n :=
+theorem natDegree_smul_le_of_le {n : ℕ} {S : Type*} [SMulZeroClass S R] {a : S} {f : R[X]}
+    (hf : natDegree f ≤ n) : natDegree (a • f) ≤ n :=
   (natDegree_smul_le a f).trans hf
 
-theorem degree_smul_le_of_le {n : ℕ} {a : R} {f : R[X]} (hf : degree f ≤ n) :
-    degree (a • f) ≤ n :=
+theorem degree_smul_le_of_le {n : ℕ} {S : Type*} [SMulZeroClass S R] {a : S} {f : R[X]}
+    (hf : degree f ≤ n) : degree (a • f) ≤ n :=
   (degree_smul_le a f).trans hf
 
-theorem coeff_smul {n : ℕ} {a : R} {f : R[X]} : (a • f).coeff n = a * f.coeff n := rfl
+theorem coeff_smul {n : ℕ} {S : Type*} [SMulZeroClass S R] {a : S} {f : R[X]} :
+    (a • f).coeff n = a • f.coeff n := rfl
 
 section congr_lemmas
 

--- a/MathlibTest/ComputeDegree.lean
+++ b/MathlibTest/ComputeDegree.lean
@@ -64,6 +64,9 @@ example [Ring R] : coeff (1 : R[X]) n = if n = 0 then 1 else 0 := by compute_deg
 
 example [Ring R] (h : (0 : R) = 6) : coeff (1 : R[X]) 1 = 6 := by compute_degree!
 
+example [Ring R] {S : Type*} [SMulZeroClass S R] {a : S} : coeff (a • X) 1 = a • (1 : R) := by
+  compute_degree!
+
 /-! Test error messages -/
 
 /--
@@ -226,10 +229,18 @@ example : natDegree (7 * X : R[X]) ≤ 1 := by compute_degree
 example {a : R} : natDegree (a • X ^ 5 : R[X]) ≤ 5 := by
   compute_degree
 
+example {S : Type*} [SMulZeroClass S R] {a : S} : natDegree (a • X ^ 5 : R[X]) ≤ 5 := by
+  compute_degree
+
+example {S : Type*} [SMulZeroClass S R] {a : S} : degree (a • X ^ 5 : R[X]) ≤ 5 := by
+  compute_degree!
+
 example {a : R} (a0 : a ≠ 0) : natDegree (a • X ^ 5 + X : R[X]) = 5 := by
   compute_degree!
 
 example {a : R} (a0 : a ≠ 0) : degree (a • X ^ 5 + X ^ 2 : R[X]) = 5 := by
   compute_degree!; rfl
+
+example : (3 • X ^ 2 : ℚ[X]).natDegree = 2 := by compute_degree!
 
 end tests_from_mathlib3


### PR DESCRIPTION
It would be able to deal with `a • (X : R[X])` where `a : S` is in a different type `S` with `[SMulZeroClass S R]`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #25237

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
