### PR TITLE
[Merged by Bors] - refactor: redefine perfect pairings as a Prop-valued typeclass

### DIFF
--- a/Mathlib/Algebra/Lie/Weights/RootSystem.lean
+++ b/Mathlib/Algebra/Lie/Weights/RootSystem.lean
@@ -381,7 +381,7 @@ field of characteristic zero, relative to a splitting Cartan subalgebra. -/
 def rootSystem :
     RootSystem H.root K (Dual K H) H :=
   RootSystem.mk'
-    IsReflexive.toPerfectPairingDual
+    .id
     { toFun := (↑)
       inj' := by
         intro α β h; ext x; simpa using LinearMap.congr_fun h x  }
@@ -402,8 +402,7 @@ lemma corootForm_rootSystem_eq_killing :
   rw [restrict_killingForm_eq_sum, RootPairing.CorootForm, ← Finset.sum_coe_sort (s := H.root)]
   rfl
 
-@[simp] lemma rootSystem_toPerfectPairing_apply (f x) : (rootSystem H).toPerfectPairing f x = f x :=
-  rfl
+@[simp] lemma rootSystem_toLinearMap_apply (f x) : (rootSystem H).toLinearMap f x = f x := rfl
 @[simp] lemma rootSystem_pairing_apply (α β) : (rootSystem H).pairing β α = β.1 (coroot α.1) := rfl
 @[simp] lemma rootSystem_root_apply (α) : (rootSystem H).root α = α := rfl
 @[simp] lemma rootSystem_coroot_apply (α) : (rootSystem H).coroot α = coroot α := rfl

--- a/Mathlib/LinearAlgebra/PerfectPairing/Basic.lean
+++ b/Mathlib/LinearAlgebra/PerfectPairing/Basic.lean
@@ -1,12 +1,14 @@
 /-
 Copyright (c) 2023 Oliver Nash. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Oliver Nash
+Authors: Oliver Nash, Yaël Dillies
 -/
 import Mathlib.LinearAlgebra.Dual.Lemmas
 
 /-!
-# Perfect pairings of modules
+# Perfect pairings
+
+This file defines perfect pairings of modules.
 
 A perfect pairing of two (left) modules may be defined either as:
 1. A bilinear map `M × N → R` such that the induced maps `M → Dual R N` and `N → Dual R M` are both
@@ -14,29 +16,97 @@ A perfect pairing of two (left) modules may be defined either as:
 2. A linear equivalence `N ≃ Dual R M` for which `M` is reflexive. (It then follows that `N` is
   reflexive.)
 
-In this file we provide a `PerfectPairing` definition corresponding to 1 above, together with logic
+In this file we provide a definition `IsPerfPair` corresponding to 1 above, together with logic
 to connect 1 and 2.
-
-## Main definitions
-
-* `PerfectPairing`
-* `PerfectPairing.flip`
-* `PerfectPairing.dual`
-* `PerfectPairing.toDualLeft`
-* `PerfectPairing.toDualRight`
-* `LinearEquiv.flip`
-* `LinearEquiv.isReflexive_of_equiv_dual_of_isReflexive`
-* `LinearEquiv.toPerfectPairing`
-
 -/
 
 open Function Module
+
+namespace LinearMap
+variable {R K M N : Type*} [AddCommGroup M] [AddCommGroup N]
+
+section CommRing
+variable [CommRing R] [Module R M] [Module R N] {p : M →ₗ[R] N →ₗ[R] R} {x : M} {y : N}
+
+/-- For a ring `R` and two modules `M` and `N`, a perfect pairing is a bilinear map `M × N → R`
+that is bijective in both arguments. -/
+@[ext]
+class IsPerfPair (p : M →ₗ[R] N →ₗ[R] R) where
+  bijective_left (p) : Bijective p
+  bijective_right (p) : Bijective p.flip
+
+/-- Given a perfect pairing between `M`and `N`, we may interchange the roles of `M` and `N`. -/
+protected lemma IsPerfPair.flip (hp : p.IsPerfPair) : p.flip.IsPerfPair where
+  bijective_left := IsPerfPair.bijective_right p
+  bijective_right := IsPerfPair.bijective_left p
+
+variable [p.IsPerfPair]
+
+/-- Given a perfect pairing between `M`and `N`, we may interchange the roles of `M` and `N`. -/
+instance flip.instIsPerfPair : p.flip.IsPerfPair := .flip ‹_›
+
+variable (p)
+
+/-- Turn a perfect pairing between `M` and `N` into an isomorphism between `M` and the dual of `N`.
+-/
+noncomputable def toPerfPair : M ≃ₗ[R] Dual R N :=
+  .ofBijective { toFun := _, map_add' x y := by ext; simp, map_smul' r x := by ext; simp } <|
+    IsPerfPair.bijective_left p
+
+@[simp] lemma toLinearMap_toPerfPair (x : M) : p.toPerfPair x = p x := rfl
+@[simp] lemma toPerfPair_apply (x : M) (y : N) : p.toPerfPair x y = p x y := rfl
+
+@[simp] lemma apply_symm_toPerfPair_self (f : Dual R N) : p (p.toPerfPair.symm f) = f :=
+  p.toPerfPair.apply_symm_apply f
+
+@[simp] lemma apply_toPerfPair_flip (f : Dual R M) (x : M) : p x (p.flip.toPerfPair.symm f) = f x :=
+  congr($(p.flip.apply_symm_toPerfPair_self ..) x)
+
+include p in
+lemma _root_.Module.IsReflexive.of_isPerfPair : IsReflexive R M where
+  bijective_dual_eval' := by
+    convert (p.toPerfPair.trans p.flip.toPerfPair.dualMap.symm).bijective
+    ext x f
+    simp
+
+include p in
+lemma _root_.Module.finrank_of_isPerfPair [Module.Finite R M] [Module.Free R M] :
+    finrank R M = finrank R N :=
+  ((Module.Free.chooseBasis R M).toDualEquiv.trans p.flip.toPerfPair.symm).finrank_eq
+
+/-- A reflexive module has a perfect pairing with its dual. -/
+protected instance IsPerfPair.id [IsReflexive R M] : IsPerfPair (.id (R := R) (M := Dual R M)) where
+  bijective_left := bijective_id
+  bijective_right := bijective_dual_eval R M
+
+end CommRing
+
+section Field
+variable [Field K] [Module K M] [Module K N] {p : M →ₗ[K] N →ₗ[K] K} {x : M} {y : N}
+
+/-- If the coefficients are a field, and one of the spaces is finite-dimensional, it is sufficient
+to check only injectivity instead of bijectivity of the bilinear pairing. -/
+lemma IsPerfPair.of_injective [FiniteDimensional K M] (h : Injective p) (h' : Injective p.flip) :
+    p.IsPerfPair where
+  bijective_left := ⟨h, by rwa [← p.flip_injective_iff₁]⟩
+  bijective_right := ⟨h', by
+    have : FiniteDimensional K N := FiniteDimensional.of_injective p.flip h'
+    rwa [← p.flip.flip_injective_iff₁, LinearMap.flip_flip]⟩
+
+/-- If the coefficients are a field, and one of the spaces is finite-dimensional, it is sufficient
+to check only injectivity instead of bijectivity of the bilinear pairing. -/
+lemma IsPerfPair.of_injective' [FiniteDimensional K N] (h : Injective p) (h' : Injective p.flip) :
+    p.IsPerfPair := .flip <| .of_injective h' h
+
+end Field
+end LinearMap
 
 noncomputable section
 
 variable (R M N : Type*) [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
 
 /-- A perfect pairing of two (left) modules over a commutative ring. -/
+@[deprecated LinearMap.IsPerfPair (since := "2025-05-27")]
 structure PerfectPairing extends M →ₗ[R] N →ₗ[R] R where
   bijective_left : Bijective toLinearMap
   bijective_right : Bijective toLinearMap.flip
@@ -52,8 +122,10 @@ namespace PerfectPairing
 @[deprecated (since := "2025-04-20")] alias bijectiveLeft := bijective_left
 @[deprecated (since := "2025-04-20")] alias bijectiveRight := bijective_right
 
+set_option linter.deprecated false in
 /-- If the coefficients are a field, and one of the spaces is finite-dimensional, it is sufficient
 to check only injectivity instead of bijectivity of the bilinear form. -/
+@[deprecated LinearMap.IsPerfPair.of_injective (since := "2025-05-27")]
 def mkOfInjective {K V W : Type*}
     [Field K] [AddCommGroup V] [Module K V] [AddCommGroup W] [Module K W] [FiniteDimensional K V]
     (B : V →ₗ[K] W →ₗ[K] K)
@@ -66,8 +138,10 @@ def mkOfInjective {K V W : Type*}
     have : FiniteDimensional K W := FiniteDimensional.of_injective B.flip h'
     rwa [← B.flip.flip_injective_iff₁, LinearMap.flip_flip]⟩
 
+set_option linter.deprecated false in
 /-- If the coefficients are a field, and one of the spaces is finite-dimensional, it is sufficient
 to check only injectivity instead of bijectivity of the bilinear form. -/
+@[deprecated LinearMap.IsPerfPair.of_injective' (since := "2025-05-27")]
 def mkOfInjective' {K V W : Type*}
     [Field K] [AddCommGroup V] [Module K V] [AddCommGroup W] [Module K W] [FiniteDimensional K W]
     (B : V →ₗ[K] W →ₗ[K] K)
@@ -80,96 +154,112 @@ def mkOfInjective' {K V W : Type*}
     rwa [← B.flip_injective_iff₁]⟩
   bijective_right := ⟨h', by rwa [← B.flip.flip_injective_iff₁, LinearMap.flip_flip]⟩
 
+set_option linter.deprecated false in
+@[deprecated "No replacement" (since := "2025-05-27")]
 instance instFunLike : FunLike (PerfectPairing R M N) M (N →ₗ[R] R) where
   coe f := f.toLinearMap
   coe_injective' x y h := by cases x; cases y; simpa using h
 
-@[simp]
+set_option linter.deprecated false in
+@[deprecated "No replacement" (since := "2025-05-27")]
 lemma toLinearMap_apply (p : PerfectPairing R M N) (x : M) : p.toLinearMap x = p x := rfl
 
 @[deprecated (since := "2025-04-20")] alias toLin_apply := toLinearMap_apply
 
-@[simp]
+set_option linter.deprecated false in
+@[deprecated "No replacement" (since := "2025-05-27")]
 lemma mk_apply_apply {f : M →ₗ[R] N →ₗ[R] R} {hl} {hr} {x : M} :
     (⟨f, hl, hr⟩ : PerfectPairing R M N) x = f x :=
   rfl
 
+set_option linter.deprecated false
+
 variable (p : PerfectPairing R M N)
 
 /-- Given a perfect pairing between `M` and `N`, we may interchange the roles of `M` and `N`. -/
+@[deprecated LinearMap.IsPerfPair.flip (since := "2025-05-27")]
 protected def flip : PerfectPairing R N M where
   toLinearMap := p.toLinearMap.flip
   bijective_left := p.bijective_right
   bijective_right := p.bijective_left
 
-@[simp]
+@[deprecated "No replacement" (since := "2025-05-27")]
 lemma flip_apply_apply {x : M} {y : N} : p.flip y x = p x y :=
   rfl
 
-@[simp]
+@[deprecated "No replacement" (since := "2025-05-27")]
 lemma flip_flip : p.flip.flip = p :=
   rfl
 
 /-- The linear equivalence from `M` to `Dual R N` induced by a perfect pairing. -/
+@[deprecated LinearMap.toPerfPair (since := "2025-05-27")]
 def toDualLeft : M ≃ₗ[R] Dual R N :=
   LinearEquiv.ofBijective p.toLinearMap p.bijective_left
 
-@[simp]
+@[deprecated "No replacement" (since := "2025-05-27")]
 theorem toDualLeft_apply (a : M) : p.toDualLeft a = p a :=
   rfl
 
-@[simp]
+@[deprecated "No replacement" (since := "2025-05-27")]
 theorem apply_toDualLeft_symm_apply (f : Dual R N) (x : N) : p (p.toDualLeft.symm f) x = f x := by
   have h := LinearEquiv.apply_symm_apply p.toDualLeft f
   rw [toDualLeft_apply] at h
   exact congrFun (congrArg DFunLike.coe h) x
 
 /-- The linear equivalence from `N` to `Dual R M` induced by a perfect pairing. -/
+@[deprecated LinearMap.toPerfPair (since := "2025-05-27")]
 def toDualRight : N ≃ₗ[R] Dual R M :=
   toDualLeft p.flip
 
-@[simp]
+@[deprecated "No replacement" (since := "2025-05-27")]
 theorem toDualRight_apply (a : N) : p.toDualRight a = p.flip a :=
   rfl
 
-@[simp]
+@[deprecated "No replacement" (since := "2025-05-27")]
 theorem apply_apply_toDualRight_symm (x : M) (f : Dual R M) :
     (p x) (p.toDualRight.symm f) = f x := by
   have h := LinearEquiv.apply_symm_apply p.toDualRight f
   rw [toDualRight_apply] at h
   exact congrFun (congrArg DFunLike.coe h) x
 
+@[deprecated "No replacement" (since := "2025-05-27")]
 theorem toDualLeft_of_toDualRight_symm (x : M) (f : Dual R M) :
     (p.toDualLeft x) (p.toDualRight.symm f) = f x := by
   rw [@toDualLeft_apply]
   exact apply_apply_toDualRight_symm p x f
 
+@[deprecated "No replacement" (since := "2025-05-27")]
 theorem toDualRight_symm_toDualLeft (x : M) :
     p.toDualRight.symm.dualMap (p.toDualLeft x) = Dual.eval R M x := by
   ext f
   simp only [LinearEquiv.dualMap_apply, Dual.eval_apply]
   exact toDualLeft_of_toDualRight_symm p x f
 
+@[deprecated "No replacement" (since := "2025-05-27")]
 theorem toDualRight_symm_comp_toDualLeft :
     p.toDualRight.symm.dualMap ∘ₗ (p.toDualLeft : M →ₗ[R] Dual R N) = Dual.eval R M := by
   ext1 x
   exact p.toDualRight_symm_toDualLeft x
 
+@[deprecated "No replacement" (since := "2025-05-27")]
 theorem bijective_toDualRight_symm_toDualLeft :
     Bijective (fun x => p.toDualRight.symm.dualMap (p.toDualLeft x)) :=
   Bijective.comp (LinearEquiv.bijective p.toDualRight.symm.dualMap)
     (LinearEquiv.bijective p.toDualLeft)
 
 include p in
+@[deprecated Module.IsReflexive.of_isPerfPair (since := "2025-05-27")]
 theorem reflexive_left : IsReflexive R M where
   bijective_dual_eval' := by
     rw [← p.toDualRight_symm_comp_toDualLeft]
     exact p.bijective_toDualRight_symm_toDualLeft
 
 include p in
+@[deprecated Module.IsReflexive.of_isPerfPair (since := "2025-05-27")]
 theorem reflexive_right : IsReflexive R N :=
   p.flip.reflexive_left
 
+@[deprecated "No replacement" (since := "2025-05-27")]
 instance : EquivLike (PerfectPairing R M N) M (Dual R N) where
   coe p := p.toDualLeft
   inv p := p.toDualLeft.symm
@@ -183,25 +273,31 @@ instance : EquivLike (PerfectPairing R M N) M (Dual R N) where
     simp only [DFunLike.coe_fn_eq] at h
     exact LinearMap.congr_fun (LinearEquiv.congr_fun h m) n
 
+@[deprecated "No replacement" (since := "2025-05-27")]
 instance : LinearEquivClass (PerfectPairing R M N) R M (Dual R N) where
   map_add p m₁ m₂ := p.toLinearMap.map_add m₁ m₂
   map_smulₛₗ p t m := p.toLinearMap.map_smul t m
 
 include p in
+@[deprecated Module.finrank_of_isPerfPair (since := "2025-05-27")]
 theorem finrank_eq [Module.Finite R M] [Module.Free R M] :
     finrank R M = finrank R N :=
   ((Module.Free.chooseBasis R M).toDualEquiv.trans p.toDualRight.symm).finrank_eq
 
+end PerfectPairing
+
+namespace LinearMap
+variable {p : M →ₗ[R] N →ₗ[R] R} [p.IsPerfPair]
+
+variable (p) in
 /-- Given a perfect pairing `p` between `M` and `N`, we say a pair of submodules `U` in `M` and
 `V` in `N` are perfectly complementary wrt `p` if their dual annihilators are complementary, using
 `p` to identify `M` and `N` with dual spaces. -/
 structure IsPerfectCompl (U : Submodule R M) (V : Submodule R N) : Prop where
-  isCompl_left : IsCompl U (V.dualAnnihilator.map p.toDualLeft.symm)
-  isCompl_right : IsCompl V (U.dualAnnihilator.map p.toDualRight.symm)
+  isCompl_left : IsCompl U (V.dualAnnihilator.map p.toPerfPair.symm)
+  isCompl_right : IsCompl V (U.dualAnnihilator.map p.flip.toPerfPair.symm)
 
 namespace IsPerfectCompl
-
-variable {p}
 variable {U : Submodule R M} {V : Submodule R N}
 
 protected lemma flip (h : p.IsPerfectCompl U V) :
@@ -232,18 +328,20 @@ lemma right_top_iff :
 
 end IsPerfectCompl
 
-end PerfectPairing
+end LinearMap
 
 variable [IsReflexive R M]
 
+set_option linter.deprecated false in
 /-- A reflexive module has a perfect pairing with its dual. -/
-@[simps!]
+@[deprecated LinearMap.IsPerfPair.id (since := "2025-05-27")]
 def IsReflexive.toPerfectPairingDual : PerfectPairing R (Dual R M) M where
   toLinearMap := .id
   bijective_left := bijective_id
   bijective_right := bijective_dual_eval R M
 
-@[simp]
+set_option linter.deprecated false in
+@[deprecated "No replacement" (since := "2025-05-27")]
 lemma IsReflexive.toPerfectPairingDual_apply {f : Dual R M} {x : M} :
     IsReflexive.toPerfectPairingDual (R := R) f x = f x :=
   rfl
@@ -277,7 +375,13 @@ lemma isReflexive_of_equiv_dual_of_isReflexive : IsReflexive R N := by
     e.flip.flip = e := by
   ext; rfl
 
+instance : e.toLinearMap.IsPerfPair where
+  bijective_left := e.bijective
+  bijective_right := e.flip.bijective
+
+set_option linter.deprecated false in
 /-- If `M` is reflexive then a linear equivalence `N ≃ Dual R M` is a perfect pairing. -/
+@[deprecated "No replacement" (since := "2025-05-27")]
 def toPerfectPairing : PerfectPairing R N M where
   toLinearMap := e
   bijective_left := e.bijective
@@ -285,7 +389,9 @@ def toPerfectPairing : PerfectPairing R N M where
 
 end LinearEquiv
 
+set_option linter.deprecated false in
 /-- A perfect pairing induces a perfect pairing between dual spaces. -/
+@[deprecated "No replacement" (since := "2025-05-27")]
 def PerfectPairing.dual (p : PerfectPairing R M N) :
     PerfectPairing R (Dual R M) (Dual R N) :=
   let _i := p.reflexive_right

--- a/Mathlib/LinearAlgebra/PerfectPairing/Basic.lean
+++ b/Mathlib/LinearAlgebra/PerfectPairing/Basic.lean
@@ -79,6 +79,9 @@ protected instance IsPerfPair.id [IsReflexive R M] : IsPerfPair (.id (R := R) (M
   bijective_left := bijective_id
   bijective_right := bijective_dual_eval R M
 
+/-- A reflexive module has a perfect pairing with its dual. -/
+instance IsPerfPair.dualEval [IsReflexive R M] : IsPerfPair (Dual.eval R M) := .flip .id
+
 end CommRing
 
 section Field

--- a/Mathlib/LinearAlgebra/PerfectPairing/Matrix.lean
+++ b/Mathlib/LinearAlgebra/PerfectPairing/Matrix.lean
@@ -22,12 +22,16 @@ namespace Matrix
 variable {R n : Type*} [CommRing R] [Fintype n] [DecidableEq n]
   (A : Matrix n n R) (h : Invertible A)
 
+set_option linter.deprecated false in
 /-- We may regard an invertible matrix as a perfect pairing. -/
+@[deprecated "No replacement" (since := "2025-08-16")]
 def toPerfectPairing :
     PerfectPairing R (n → R) (n → R) :=
   ((A.toLinearEquiv' h).trans (dotProductEquiv R n)).toPerfectPairing
 
-@[simp] lemma toPerfectPairing_apply_apply (v w : n → R) :
+set_option linter.deprecated false in
+@[deprecated "No replacement" (since := "2025-08-16")]
+lemma toPerfectPairing_apply_apply (v w : n → R) :
     A.toPerfectPairing h v w = A *ᵥ v ⬝ᵥ w :=
   rfl
 

--- a/Mathlib/LinearAlgebra/PerfectPairing/Restrict.lean
+++ b/Mathlib/LinearAlgebra/PerfectPairing/Restrict.lean
@@ -127,7 +127,7 @@ private lemma restrictScalars_surjective_aux
   simpa using LinearMap.congr_fun hm n
 
 /-- Restricting a perfect pairing to a subring of the scalars results in a perfect pairing. -/
-instance restrictScalars.instIsPerfPair (hi : Injective i) (hj : Injective j)
+lemma IsPerfPair.restrictScalars (hi : Injective i) (hj : Injective j)
     (hM : span R (LinearMap.range i : Set M) = ⊤) (hN : span R (LinearMap.range j : Set N) = ⊤)
     (h₁ : ∀ g : Module.Dual S N', ∃ m,
       (p.toPerfPair (i m)).restrictScalars S ∘ₗ j = Algebra.linearMap S R ∘ₗ g)
@@ -143,7 +143,7 @@ instance restrictScalars.instIsPerfPair (hi : Injective i) (hj : Injective j)
 
 set_option linter.deprecated false in
 /-- Restriction of scalars for a perfect pairing taking values in a subring. -/
-@[deprecated restrictScalars.instIsPerfPair (since := "2025-05-28")]
+@[deprecated IsPerfPair.restrictScalars (since := "2025-05-28")]
 def _root_.PerfectPairing.restrictScalars
     (hi : Injective i) (hj : Injective j)
     (hM : span R (LinearMap.range i : Set M) = ⊤)
@@ -248,7 +248,7 @@ private lemma restrictScalars_field_aux
 include hi hj in
 /-- Simultaneously restrict both the domains and scalars of a perfect pairing with coefficients in a
 field. -/
-lemma restrictScalars.isPerfPair_of_field
+lemma IsPerfPair.restrictScalars_of_field
     (hij : p.IsPerfectCompl (span L <| LinearMap.range i) (span L <| LinearMap.range j))
     (hp : ∀ m n, p (i m) (j n) ∈ (algebraMap K L).range) :
     (LinearMap.restrictScalarsRange₂ i j (Algebra.linearMap K L)
@@ -281,3 +281,4 @@ omit [p.IsPerfPair] in
 end Field
 
 end LinearMap
+

--- a/Mathlib/LinearAlgebra/PerfectPairing/Restrict.lean
+++ b/Mathlib/LinearAlgebra/PerfectPairing/Restrict.lean
@@ -26,12 +26,12 @@ open Submodule (span subset_span)
 
 noncomputable section
 
-namespace PerfectPairing
+namespace LinearMap
 
 section CommRing
 
 variable {R M N : Type*} [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
-  (p : PerfectPairing R M N)
+  (p : M →ₗ[R] N →ₗ[R] R) [p.IsPerfPair]
 
 section Restrict
 
@@ -41,11 +41,11 @@ variable {M' N' : Type*} [AddCommGroup M'] [Module R M'] [AddCommGroup N'] [Modu
 
 include hi hj hij
 
-private lemma restrict_aux : Bijective (p.toLinearMap.compl₁₂ i j) := by
+private lemma restrict_aux : Bijective (p.compl₁₂ i j) := by
   refine ⟨LinearMap.ker_eq_bot.mp <| eq_bot_iff.mpr fun m hm ↦ ?_, fun f ↦ ?_⟩
-  · replace hm : i m ∈ (LinearMap.range j).dualAnnihilator.map p.toDualLeft.symm := by
+  · replace hm : i m ∈ (LinearMap.range j).dualAnnihilator.map p.toPerfPair.symm := by
       simp only [Submodule.mem_map, Submodule.mem_dualAnnihilator]
-      refine ⟨p.toDualLeft (i m), ?_, LinearEquiv.symm_apply_apply _ _⟩
+      refine ⟨p.toPerfPair (i m), ?_, LinearEquiv.symm_apply_apply _ _⟩
       rintro - ⟨n, rfl⟩
       simpa using LinearMap.congr_fun hm n
     suffices i m ∈ (⊥ : Submodule R M) by simpa [hi] using this
@@ -53,30 +53,30 @@ private lemma restrict_aux : Bijective (p.toLinearMap.compl₁₂ i j) := by
       using ⟨LinearMap.mem_range_self i m, hm⟩
   · set F : Module.Dual R N := f ∘ₗ j.linearProjOfIsCompl _ hj hij.isCompl_right with hF
     have hF (n : N') : F (j n) = f n := by simp [hF]
-    set m : M := p.toDualLeft.symm F with hm
+    set m : M := p.toPerfPair.symm F with hm
     obtain ⟨-, y, ⟨m₀, rfl⟩, hy, hm'⟩ :=
       Submodule.codisjoint_iff_exists_add_eq.mp hij.isCompl_left.codisjoint m
     refine ⟨m₀, LinearMap.ext fun n ↦ ?_⟩
     replace hy : (p y) (j n) = 0 := by
       simp only [Submodule.mem_map, Submodule.mem_dualAnnihilator] at hy
       obtain ⟨g, hg, rfl⟩ := hy
-      simpa only [apply_toDualLeft_symm_apply] using hg _ (LinearMap.mem_range_self j n)
-    rw [hm, ← LinearEquiv.symm_apply_eq, map_add, LinearEquiv.symm_symm,
-      toDualLeft_apply] at hm'
+      simpa using hg _ (LinearMap.mem_range_self j n)
+    rw [hm, ← LinearEquiv.symm_apply_eq, map_add, LinearEquiv.symm_symm] at hm'
     simpa [← hF, ← LinearMap.congr_fun hm' (j n)]
 
-/-- The restriction of a perfect pairing to submodules (expressed as injections to provide
-definitional control). -/
-@[simps!]
-def restrict : PerfectPairing R M' N' where
-  toLinearMap := p.toLinearMap.compl₁₂ i j
+/-- The restriction of a perfect pairing to submodules is a perfect pairing. -/
+lemma IsPerfPair.restrict : (p.compl₁₂ i j).IsPerfPair where
   bijective_left := p.restrict_aux i j hi hj hij
   bijective_right := p.flip.restrict_aux j i hj hi hij.flip
 
-@[simp]
-lemma restrict_apply_apply (x : M') (y : N') :
-    p.restrict i j hi hj hij x y = p (i x) (j y) :=
-  rfl
+set_option linter.deprecated false in
+/-- The restriction of a perfect pairing to submodules (expressed as injections to provide
+definitional control). -/
+@[deprecated IsPerfPair.restrict (since := "2025-05-28")]
+def _root_.PerfectPairing.restrict : PerfectPairing R M' N' where
+  toLinearMap := p.compl₁₂ i j
+  bijective_left := p.restrict_aux i j hi hj hij
+  bijective_right := p.flip.restrict_aux j i hj hi hij.flip
 
 end Restrict
 
@@ -88,20 +88,14 @@ variable {S M' N' : Type*}
   [AddCommGroup M'] [Module S M'] [AddCommGroup N'] [Module S N']
   (i : M' →ₗ[S] M) (j : N' →ₗ[S] N)
 
-/-- An auxiliary definition used to construct `PerfectPairing.restrictScalars`. -/
-private def restrictScalarsAux
-    (hp : ∀ m n, p (i m) (j n) ∈ (algebraMap S R).range) :
-    M' →ₗ[S] N' →ₗ[S] S :=
-  LinearMap.restrictScalarsRange₂ i j (Algebra.linearMap S R)
-    (FaithfulSMul.algebraMap_injective S R) p.toLinearMap hp
-
-private lemma restrictScalarsAux_injective
+private lemma restrictScalars_injective_aux
     (hi : Injective i)
     (hN : span R (LinearMap.range j : Set N) = ⊤)
     (hp : ∀ m n, p (i m) (j n) ∈ (algebraMap S R).range) :
-    Injective (p.restrictScalarsAux i j hp) := by
+    Injective ((LinearMap.restrictScalarsRange₂ i j (Algebra.linearMap S R)
+      (FaithfulSMul.algebraMap_injective S R) p hp)) := by
   let f := LinearMap.restrictScalarsRange₂ i j (Algebra.linearMap S R)
-      (FaithfulSMul.algebraMap_injective S R) p.toLinearMap hp
+      (FaithfulSMul.algebraMap_injective S R) p hp
   rw [← LinearMap.ker_eq_bot]
   refine (Submodule.eq_bot_iff _).mpr fun x (hx : f x = 0) ↦ ?_
   replace hx (n : N) : p (i x) n = 0 := by
@@ -111,17 +105,18 @@ private lemma restrictScalarsAux_injective
       obtain ⟨n', rfl⟩ := hz
       simpa [f] using LinearMap.congr_fun hx n'
     | zero => simp
-    | add => rw [← p.toLinearMap_apply, map_add]; aesop
-    | smul => rw [← p.toLinearMap_apply, map_smul]; aesop
-  rw [← i.map_eq_zero_iff hi, ← p.toLinearMap.map_eq_zero_iff p.bijective_left.injective]
+    | add => rw [map_add]; aesop
+    | smul => rw [map_smul]; aesop
+  rw [← i.map_eq_zero_iff hi, ← p.map_eq_zero_iff p.toPerfPair.injective]
   ext n
   simpa using hx n
 
-private lemma restrictScalarsAux_surjective
+private lemma restrictScalars_surjective_aux
     (h : ∀ g : Module.Dual S N', ∃ m,
-      (p.toDualLeft (i m)).restrictScalars S ∘ₗ j = Algebra.linearMap S R ∘ₗ g)
+      (p.toPerfPair (i m)).restrictScalars S ∘ₗ j = Algebra.linearMap S R ∘ₗ g)
     (hp : ∀ m n, p (i m) (j n) ∈ (algebraMap S R).range) :
-    Surjective (p.restrictScalarsAux i j hp) := by
+    Surjective ((LinearMap.restrictScalarsRange₂ i j (Algebra.linearMap S R)
+      (FaithfulSMul.algebraMap_injective S R) p hp)) := by
   rw [← LinearMap.range_eq_top]
   refine Submodule.eq_top_iff'.mpr fun g : Module.Dual S N' ↦ ?_
   obtain ⟨m, hm⟩ := h g
@@ -129,24 +124,42 @@ private lemma restrictScalarsAux_surjective
   ext n
   apply FaithfulSMul.algebraMap_injective S R
   change Algebra.linearMap S R _ = _
-  simpa [restrictScalarsAux] using LinearMap.congr_fun hm n
+  simpa using LinearMap.congr_fun hm n
 
+/-- Restricting a perfect pairing to a subring of the scalars results in a perfect pairing. -/
+instance restrictScalars.instIsPerfPair (hi : Injective i) (hj : Injective j)
+    (hM : span R (LinearMap.range i : Set M) = ⊤) (hN : span R (LinearMap.range j : Set N) = ⊤)
+    (h₁ : ∀ g : Module.Dual S N', ∃ m,
+      (p.toPerfPair (i m)).restrictScalars S ∘ₗ j = Algebra.linearMap S R ∘ₗ g)
+    (h₂ : ∀ g : Module.Dual S M', ∃ n,
+      (p.flip.toPerfPair (j n)).restrictScalars S ∘ₗ i = Algebra.linearMap S R ∘ₗ g)
+    (hp : ∀ m n, p (i m) (j n) ∈ (algebraMap S R).range) :
+    (LinearMap.restrictScalarsRange₂ i j (Algebra.linearMap S R)
+      (FaithfulSMul.algebraMap_injective S R) p hp).IsPerfPair where
+  bijective_left := ⟨p.restrictScalars_injective_aux i j hi hN hp,
+    p.restrictScalars_surjective_aux i j h₁ hp⟩
+  bijective_right := ⟨p.flip.restrictScalars_injective_aux j i hj hM fun m n ↦ hp n m,
+    p.flip.restrictScalars_surjective_aux j i h₂ fun m n ↦ hp n m⟩
+
+set_option linter.deprecated false in
 /-- Restriction of scalars for a perfect pairing taking values in a subring. -/
-def restrictScalars
+@[deprecated restrictScalars.instIsPerfPair (since := "2025-05-28")]
+def _root_.PerfectPairing.restrictScalars
     (hi : Injective i) (hj : Injective j)
     (hM : span R (LinearMap.range i : Set M) = ⊤)
     (hN : span R (LinearMap.range j : Set N) = ⊤)
     (h₁ : ∀ g : Module.Dual S N', ∃ m,
-      (p.toDualLeft (i m)).restrictScalars S ∘ₗ j = Algebra.linearMap S R ∘ₗ g)
+      (p.toPerfPair (i m)).restrictScalars S ∘ₗ j = Algebra.linearMap S R ∘ₗ g)
     (h₂ : ∀ g : Module.Dual S M', ∃ n,
-      (p.toDualRight (j n)).restrictScalars S ∘ₗ i = Algebra.linearMap S R ∘ₗ g)
+      (p.flip.toPerfPair (j n)).restrictScalars S ∘ₗ i = Algebra.linearMap S R ∘ₗ g)
     (hp : ∀ m n, p (i m) (j n) ∈ (algebraMap S R).range) :
     PerfectPairing S M' N' :=
-  { toLinearMap := p.restrictScalarsAux i j hp
-    bijective_left := ⟨p.restrictScalarsAux_injective i j hi hN hp,
-      p.restrictScalarsAux_surjective i j h₁ hp⟩
-    bijective_right := ⟨p.flip.restrictScalarsAux_injective j i hj hM (fun m n ↦ hp n m),
-      p.flip.restrictScalarsAux_surjective j i h₂ (fun m n ↦ hp n m)⟩}
+  { toLinearMap := LinearMap.restrictScalarsRange₂ i j (Algebra.linearMap S R)
+      (FaithfulSMul.algebraMap_injective S R) p hp
+    bijective_left := ⟨p.restrictScalars_injective_aux i j hi hN hp,
+      p.restrictScalars_surjective_aux i j h₁ hp⟩
+    bijective_right := ⟨p.flip.restrictScalars_injective_aux j i hj hM (fun m n ↦ hp n m),
+      p.flip.restrictScalars_surjective_aux j i h₂ (fun m n ↦ hp n m)⟩}
 
 end RestrictScalars
 
@@ -157,7 +170,7 @@ section Field
 variable {K L M N : Type*} [Field K] [Field L] [Algebra K L]
   [AddCommGroup M] [AddCommGroup N] [Module L M] [Module L N]
   [Module K M] [Module K N] [IsScalarTower K L M]
-  (p : PerfectPairing L M N)
+  (p : M →ₗ[L] N →ₗ[L] L) [p.IsPerfPair]
 
 /-- If a perfect pairing over a field `L` takes values in a subfield `K` along two `K`-subspaces
 whose `L` span is full, then these subspaces induce a `K`-structure in the sense of
@@ -169,8 +182,8 @@ lemma exists_basis_basis_of_span_eq_top_of_mem_algebraMap
     (hp : ∀ᵉ (x ∈ M') (y ∈ N'), p x y ∈ (algebraMap K L).range) :
     ∃ (n : ℕ) (b : Basis (Fin n) L M) (b' : Basis (Fin n) K M'), ∀ i, b i = b' i := by
   classical
-  have : IsReflexive L M := p.reflexive_left
-  have : IsReflexive L N := p.reflexive_right
+  have : IsReflexive L M := .of_isPerfPair p
+  have : IsReflexive L N := .of_isPerfPair p.flip
   obtain ⟨v, hv₁, hv₂, hv₃⟩ := exists_linearIndependent L (M' : Set M)
   rw [hM] at hv₂
   let b : Basis _ L M := Basis.mk hv₃ <| by rw [← hv₂, Subtype.range_coe_subtype, Set.setOf_mem_eq]
@@ -196,14 +209,14 @@ lemma exists_basis_basis_of_span_eq_top_of_mem_algebraMap
   let bN : Basis _ L N := Basis.mk hw₃ <| by rw [← hw₂, Subtype.range_coe_subtype, Set.setOf_mem_eq]
   have : Fintype w := Set.Finite.fintype <| Module.Finite.finite_basis bN
   have e : v ≃ w := Fintype.equivOfCardEq <| by rw [← Module.finrank_eq_card_basis b,
-    ← Module.finrank_eq_card_basis bN, p.finrank_eq]
-  let bM := bN.dualBasis.map p.toDualLeft.symm
+    ← Module.finrank_eq_card_basis bN, Module.finrank_of_isPerfPair p]
+  let bM := bN.dualBasis.map p.toPerfPair.symm
   have hbM (j : w) (x : M) (hx : x ∈ M') : bM.repr x j = p x (j : N) := by simp [bM, bN]
   have hj (j : w) : bM.repr m j ∈ (algebraMap K L).range := (hbM _ _ hm) ▸ hp m hm j (hw₁ j.2)
   replace hp (i : w) (j : v) :
-      (bN.dualBasis.map p.toDualLeft.symm).toMatrix b i j ∈ (algebraMap K L).fieldRange := by
+      (bN.dualBasis.map p.toPerfPair.symm).toMatrix b i j ∈ (algebraMap K L).fieldRange := by
     simp only [Basis.toMatrix, Basis.map_repr, LinearEquiv.symm_symm, LinearEquiv.trans_apply,
-      toDualLeft_apply, Basis.dualBasis_repr]
+      Basis.dualBasis_repr]
     exact hp (b j) (by simpa [b] using hv₁ j.2) (bN i) (by simpa [bN] using hw₁ i.2)
   have hA (i j) : b.toMatrix bM i j ∈ (algebraMap K L).range :=
     Matrix.mem_subfield_of_mul_eq_one_of_mem_subfield_left e _ (by simp [bM]) hp i j
@@ -215,30 +228,35 @@ variable {M' N' : Type*}
   [AddCommGroup M'] [AddCommGroup N'] [Module K M'] [Module K N'] [IsScalarTower K L N]
   (i : M' →ₗ[K] M) (j : N' →ₗ[K] N) (hi : Injective i) (hj : Injective j)
 
+include hi hj in
 /-- An auxiliary definition used only to simplify the construction of the more general definition
 `PerfectPairing.restrictScalarsField`. -/
-private def restrictScalarsFieldAux
+private lemma restrictScalars_field_aux
     (hM : span L (LinearMap.range i : Set M) = ⊤)
     (hN : span L (LinearMap.range j : Set N) = ⊤)
     (hp : ∀ m n, p (i m) (j n) ∈ (algebraMap K L).range) :
-    PerfectPairing K M' N' := by
-  suffices FiniteDimensional K M' from mkOfInjective _ (p.restrictScalarsAux_injective i j hi hN hp)
-    (p.flip.restrictScalarsAux_injective j i hj hM (fun m n ↦ hp n m))
+    (LinearMap.restrictScalarsRange₂ i j (Algebra.linearMap K L)
+      (FaithfulSMul.algebraMap_injective K L) p hp).IsPerfPair := by
+  suffices FiniteDimensional K M' from .of_injective (p.restrictScalars_injective_aux i j hi hN hp)
+    (p.flip.restrictScalars_injective_aux j i hj hM (fun m n ↦ hp n m))
   obtain ⟨n, -, b', -⟩ := p.exists_basis_basis_of_span_eq_top_of_mem_algebraMap _ _ hM hN <| by
     rintro - ⟨m, rfl⟩ - ⟨n, rfl⟩
     exact hp m n
   have : FiniteDimensional K (LinearMap.range i) := FiniteDimensional.of_fintype_basis b'
   exact Finite.equiv (LinearEquiv.ofInjective i hi).symm
 
+include hi hj in
 /-- Simultaneously restrict both the domains and scalars of a perfect pairing with coefficients in a
 field. -/
-def restrictScalarsField
+lemma restrictScalars.isPerfPair_of_field
     (hij : p.IsPerfectCompl (span L <| LinearMap.range i) (span L <| LinearMap.range j))
     (hp : ∀ m n, p (i m) (j n) ∈ (algebraMap K L).range) :
-    PerfectPairing K M' N' := by
-  letI P : PerfectPairing L (span L <| LinearMap.range i) (span L <| LinearMap.range j) :=
-    p.restrict (Submodule.subtype _) (Submodule.subtype _) (by simp) (by simp) (by simpa)
-  exact P.restrictScalarsFieldAux
+    (LinearMap.restrictScalarsRange₂ i j (Algebra.linearMap K L)
+      (FaithfulSMul.algebraMap_injective K L) p hp).IsPerfPair := by
+  have : (p.compl₁₂ (span L <| .range i).subtype (span L <| .range j).subtype).IsPerfPair :=
+    .restrict _ _ _ (by simp) (by simp) (by simpa)
+  exact restrictScalars_field_aux
+    (p.compl₁₂ (span L <| .range i).subtype (span L <| .range j).subtype)
     ((LinearMap.range i).inclusionSpan L ∘ₗ i.rangeRestrict)
     ((LinearMap.range j).inclusionSpan L ∘ₗ j.rangeRestrict)
     (((LinearMap.range i).injective_inclusionSpan L).comp (by simpa))
@@ -247,19 +265,19 @@ def restrictScalarsField
         exact (LinearMap.range i).span_range_inclusionSpan L)
     (by rw [LinearMap.range_comp_of_range_eq_top _ (LinearMap.range_rangeRestrict _)]
         exact (LinearMap.range j).span_range_inclusionSpan L)
-    (fun x y ↦ LinearMap.BilinMap.apply_apply_mem_of_mem_span
+    fun x y ↦ LinearMap.BilinMap.apply_apply_mem_of_mem_span
       (LinearMap.range <| Algebra.linearMap K L) (range i) (range j)
-      ((LinearMap.restrictScalarsₗ K L _ _ _).comp (p.toLinearMap.restrictScalars K))
-      (by simpa) (i x) (j y) (subset_span (mem_range_self x)) (subset_span (mem_range_self y)))
+      ((LinearMap.restrictScalarsₗ K L _ _ _).comp (p.restrictScalars K))
+      (by simpa) (i x) (j y) (subset_span <| by simp) (subset_span <| by simp)
 
-@[simp] lemma restrictScalarsField_apply_apply
-    (hij : p.IsPerfectCompl (span L <| LinearMap.range i) (span L <| LinearMap.range j))
-    (hp : ∀ m n, p (i m) (j n) ∈ (algebraMap K L).range)
+omit [p.IsPerfPair] in
+@[simp] lemma restrictScalarsField_apply_apply (hp : ∀ m n, p (i m) (j n) ∈ (algebraMap K L).range)
     (x : M') (y : N') :
-    algebraMap K L (p.restrictScalarsField i j hi hj hij hp x y) = p (i x) (j y) :=
+    algebraMap K L (LinearMap.restrictScalarsRange₂ i j (Algebra.linearMap K L)
+      (FaithfulSMul.algebraMap_injective K L) p hp x y) = p (i x) (j y) :=
   LinearMap.restrictScalarsRange₂_apply i j (Algebra.linearMap K L)
-    (FaithfulSMul.algebraMap_injective K L) p.toLinearMap hp x y
+    (FaithfulSMul.algebraMap_injective K L) p hp x y
 
 end Field
 
-end PerfectPairing
+end LinearMap

--- a/Mathlib/LinearAlgebra/RootSystem/BaseChange.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/BaseChange.lean
@@ -73,8 +73,7 @@ def restrictScalars' :
       (LinearMap.range (Algebra.linearMap K L)) (range P.root) (range P.coroot)
       (LinearMap.restrictScalarsₗ K L _ _ _ ∘ₗ P.toLinearMap.restrictScalars K)
       (by rintro - ⟨i, rfl⟩ - ⟨j, rfl⟩; exact hP i j) _ _ x.property y.property
-  isPerfPair_toLinearMap :=
-    LinearMap.restrictScalars.isPerfPair_of_field P.toLinearMap _ _
+  isPerfPair_toLinearMap := .restrictScalars_of_field P.toLinearMap _ _
     (injective_subtype _) (injective_subtype _) (by simpa using IsBalanced.isPerfectCompl) _
   root := ⟨fun i ↦ ⟨_, subset_span (mem_range_self i)⟩, fun i j h ↦ by simpa using h⟩
   coroot := ⟨fun i ↦ ⟨_, subset_span (mem_range_self i)⟩, fun i j h ↦ by simpa using h⟩

--- a/Mathlib/LinearAlgebra/RootSystem/BaseChange.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/BaseChange.lean
@@ -39,7 +39,7 @@ complementary.
 All root systems are balanced and all finite root pairings over a field are balanced. -/
 class IsBalanced {ι R M N : Type*} [AddCommGroup M] [AddCommGroup N]
     [CommRing R] [Module R M] [Module R N] (P : RootPairing ι R M N) : Prop where
-  isPerfectCompl : P.toPerfectPairing.IsPerfectCompl (P.rootSpan R) (P.corootSpan R)
+  isPerfectCompl : P.toLinearMap.IsPerfectCompl (P.rootSpan R) (P.corootSpan R)
 
 instance {ι R M N : Type*} [AddCommGroup M] [AddCommGroup N]
     [CommRing R] [Module R M] [Module R N] (P : RootSystem ι R M N) :
@@ -65,38 +65,42 @@ variable (hP : ∀ i j, P.pairing i j ∈ (algebraMap K L).range)
 Note that we obtain a root system (not just a root pairing). See also
 `RootPairing.restrictScalars`. -/
 def restrictScalars' :
-    RootSystem ι K (span K (range P.root)) (span K (range P.coroot)) :=
-  { toPerfectPairing := (P.toPerfectPairing.restrictScalarsField _ _
-      (injective_subtype _) (injective_subtype _) (by simpa using IsBalanced.isPerfectCompl)
-      (fun x y ↦ LinearMap.BilinMap.apply_apply_mem_of_mem_span
-        (LinearMap.range (Algebra.linearMap K L)) (range P.root) (range P.coroot)
-        (LinearMap.restrictScalarsₗ K L _ _ _ ∘ₗ P.toPerfectPairing.toLinearMap.restrictScalars K)
-        (by rintro - ⟨i, rfl⟩ - ⟨j, rfl⟩; exact hP i j) _ _ x.property y.property))
-    root := ⟨fun i ↦ ⟨_, subset_span (mem_range_self i)⟩, fun i j h ↦ by simpa using h⟩
-    coroot := ⟨fun i ↦ ⟨_, subset_span (mem_range_self i)⟩, fun i j h ↦ by simpa using h⟩
-    root_coroot_two i := by
-      have : algebraMap K L 2 = 2 := by
-        rw [← Int.cast_two (R := K), ← Int.cast_two (R := L), map_intCast]
-      exact FaithfulSMul.algebraMap_injective K L <| by simp [this]
-    reflectionPerm := P.reflectionPerm
-    reflectionPerm_root i j := by
-      ext; simpa [algebra_compatible_smul L] using P.reflectionPerm_root i j
-    reflectionPerm_coroot i j := by
-      ext; simpa [algebra_compatible_smul L] using P.reflectionPerm_coroot i j
-    span_root_eq_top := by
-      rw [← span_setOf_mem_eq_top]
-      congr
-      ext ⟨x, hx⟩
-      simp
-    span_coroot_eq_top := by
-      rw [← span_setOf_mem_eq_top]
-      congr
-      ext ⟨x, hx⟩
-      simp }
+    RootSystem ι K (span K (range P.root)) (span K (range P.coroot)) where
+  toLinearMap := .restrictScalarsRange₂ (R := L)
+    (span K (range P.root)).subtype (span K (range P.coroot)).subtype (Algebra.linearMap K L)
+    (FaithfulSMul.algebraMap_injective K L) P.toLinearMap fun x y ↦
+      LinearMap.BilinMap.apply_apply_mem_of_mem_span
+      (LinearMap.range (Algebra.linearMap K L)) (range P.root) (range P.coroot)
+      (LinearMap.restrictScalarsₗ K L _ _ _ ∘ₗ P.toLinearMap.restrictScalars K)
+      (by rintro - ⟨i, rfl⟩ - ⟨j, rfl⟩; exact hP i j) _ _ x.property y.property
+  isPerfPair_toLinearMap :=
+    LinearMap.restrictScalars.isPerfPair_of_field P.toLinearMap _ _
+    (injective_subtype _) (injective_subtype _) (by simpa using IsBalanced.isPerfectCompl) _
+  root := ⟨fun i ↦ ⟨_, subset_span (mem_range_self i)⟩, fun i j h ↦ by simpa using h⟩
+  coroot := ⟨fun i ↦ ⟨_, subset_span (mem_range_self i)⟩, fun i j h ↦ by simpa using h⟩
+  root_coroot_two i := by
+    have : algebraMap K L 2 = 2 := by
+      rw [← Int.cast_two (R := K), ← Int.cast_two (R := L), map_intCast]
+    exact FaithfulSMul.algebraMap_injective K L <| by simp [this]
+  reflectionPerm := P.reflectionPerm
+  reflectionPerm_root i j := by
+    ext; simpa [algebra_compatible_smul L] using P.reflectionPerm_root i j
+  reflectionPerm_coroot i j := by
+    ext; simpa [algebra_compatible_smul L] using P.reflectionPerm_coroot i j
+  span_root_eq_top := by
+    rw [← span_setOf_mem_eq_top]
+    congr
+    ext ⟨x, hx⟩
+    simp
+  span_coroot_eq_top := by
+    rw [← span_setOf_mem_eq_top]
+    congr
+    ext ⟨x, hx⟩
+    simp
 
-@[simp] lemma restrictScalars_toPerfectPairing_apply_apply
+@[simp] lemma restrictScalars_toLinearMap_apply_apply
     (x : span K (range P.root)) (y : span K (range P.coroot)) :
-    algebraMap K L ((P.restrictScalars' K hP).toPerfectPairing x y) = P.toPerfectPairing x y := by
+    algebraMap K L ((P.restrictScalars' K hP).toLinearMap x y) = P.toLinearMap x y := by
   simp [restrictScalars']
 
 @[simp] lemma restrictScalars_coe_root (i : ι) :
@@ -109,7 +113,7 @@ def restrictScalars' :
 
 @[simp] lemma restrictScalars_pairing (i j : ι) :
     algebraMap K L ((P.restrictScalars' K hP).pairing i j) = P.pairing i j := by
-  simp only [pairing, restrictScalars_toPerfectPairing_apply_apply, restrictScalars_coe_root,
+  simp only [pairing, restrictScalars_toLinearMap_apply_apply, restrictScalars_coe_root,
     restrictScalars_coe_coroot]
 
 end SubfieldValued

--- a/Mathlib/LinearAlgebra/RootSystem/Basic.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Basic.lean
@@ -40,8 +40,8 @@ namespace RootPairing
 
 section reflectionPerm
 
-variable (p : PerfectPairing R M N) (root : ι ↪ M) (coroot : ι ↪ N) (i j : ι)
-  (h : ∀ i, MapsTo (preReflection (root i) (p.toLinearMap.flip (coroot i)))
+variable (p : M →ₗ[R] N →ₗ[R] R) (root : ι ↪ M) (coroot : ι ↪ N) (i j : ι)
+  (h : ∀ i, MapsTo (preReflection (root i) (p.flip (coroot i)))
     (range root) (range root))
 include h
 
@@ -49,7 +49,7 @@ private theorem exist_eq_reflection_of_mapsTo :
     ∃ k, root k = (preReflection (root i) (p.flip (coroot i))) (root j) :=
   h i (mem_range_self j)
 
-variable (hp : ∀ i, p.toLinearMap (root i) (coroot i) = 2)
+variable (hp : ∀ i, p (root i) (coroot i) = 2)
 include hp
 
 private theorem choose_choose_eq_of_mapsTo :
@@ -82,7 +82,7 @@ lemma injOn_dualMap_subtype_span_root_coroot [NoZeroSMulDivisors ℤ M] :
   have := injOn_dualMap_subtype_span_range_range (finite_range P.root)
     (c := P.toLinearMap.flip ∘ P.coroot) P.root_coroot_two P.mapsTo_reflection_root
   rintro - ⟨i, rfl⟩ - ⟨j, rfl⟩ hij
-  exact P.bijective_right.injective <| this (mem_range_self i) (mem_range_self j) hij
+  exact P.flip.toPerfPair.injective <| this (mem_range_self i) (mem_range_self j) hij
 
 /-- In characteristic zero if there is no torsion, the correspondence between roots and coroots is
 unique.
@@ -91,7 +91,7 @@ Formally, the point is that the hypothesis `hc` depends only on the range of the
 @[ext]
 protected lemma ext [CharZero R] [NoZeroSMulDivisors R M]
     {P₁ P₂ : RootPairing ι R M N}
-    (he : P₁.toPerfectPairing = P₂.toPerfectPairing)
+    (he : P₁.toLinearMap = P₂.toLinearMap)
     (hr : P₁.root = P₂.root)
     (hc : range P₁.coroot = range P₂.coroot) :
     P₁ = P₂ := by
@@ -115,7 +115,7 @@ protected lemma ext [CharZero R] [NoZeroSMulDivisors R M]
   · exact hr ▸ he ▸ P₂.mapsTo_reflection_root i
 
 private lemma coroot_eq_coreflection_of_root_eq' [CharZero R] [NoZeroSMulDivisors R M]
-    (p : PerfectPairing R M N)
+    (p : M →ₗ[R] N →ₗ[R] R) [p.IsPerfPair]
     (root : ι ↪ M)
     (coroot : ι ↪ N)
     (hp : ∀ i, p (root i) (coroot i) = 2)
@@ -132,19 +132,19 @@ private lemma coroot_eq_coreflection_of_root_eq' [CharZero R] [NoZeroSMulDivisor
   let sα' := preReflection α' (p α)
   have hij : preReflection (sα β) (p.flip (sα' β')) = sα ∘ₗ sβ ∘ₗ sα := by
     ext
-    have hpi : (p.flip (coroot i)) (root i) = 2 := by rw [PerfectPairing.flip_apply_apply, hp i]
+    have hpi : (p.flip (coroot i)) (root i) = 2 := by simp [hp i]
     simp [α, β, α', β', sα, sβ, sα', ← preReflection_preReflection β (p.flip β') hpi,
       preReflection_apply]
-  have hk₀ : root k ≠ 0 := fun h ↦ by simpa [h, ← PerfectPairing.toLinearMap_apply] using hp k
+  have hk₀ : root k ≠ 0 := fun h ↦ by simpa [h] using hp k
   obtain ⟨l, hl⟩ := hc i (mem_range_self j)
   rw [← hl]
   have hkl : (p.flip (coroot l)) (root k) = 2 := by
-    simp only [hl, preReflection_apply, hk, PerfectPairing.flip_apply_apply, map_sub, hp j,
-      map_smul, smul_eq_mul, hp i, mul_sub, sα, α, α', β, mul_two, mul_add, LinearMap.sub_apply,
-      LinearMap.smul_apply]
+    simp only [hl, preReflection_apply, map_sub, map_smul, hk, LinearMap.flip_apply,
+      LinearMap.sub_apply, hp j, LinearMap.smul_apply, smul_eq_mul, hp i, mul_two,
+      sub_add_cancel_right, mul_neg, sub_neg_eq_add, sα, α, α', β]
     rw [mul_comm (p (root i) (coroot j))]
     abel
-  suffices p.flip (coroot k) = p.flip (coroot l) from p.bijective_right.injective this
+  suffices p.flip (coroot k) = p.flip (coroot l) from p.flip.toPerfPair.injective this
   have _i : NoZeroSMulDivisors ℤ M := NoZeroSMulDivisors.int_of_charZero R M
   have := injOn_dualMap_subtype_span_range_range (finite_range root)
     (c := p.flip ∘ coroot) hp hr
@@ -157,21 +157,20 @@ private lemma coroot_eq_coreflection_of_root_eq' [CharZero R] [NoZeroSMulDivisor
 /-- In characteristic zero if there is no torsion, to check that two finite families of roots and
 coroots form a root pairing, it is sufficient to check that they are stable under reflections. -/
 def mk' [CharZero R] [NoZeroSMulDivisors R M]
-    (p : PerfectPairing R M N)
+    (p : M →ₗ[R] N →ₗ[R] R) [p.IsPerfPair]
     (root : ι ↪ M)
     (coroot : ι ↪ N)
     (hp : ∀ i, p (root i) (coroot i) = 2)
     (hr : ∀ i, MapsTo (preReflection (root i) (p.flip (coroot i))) (range root) (range root))
     (hc : ∀ i, MapsTo (preReflection (coroot i) (p (root i))) (range coroot) (range coroot)) :
     RootPairing ι R M N where
-  toPerfectPairing := p
+  toLinearMap := p
   root := root
   coroot := coroot
   root_coroot_two := hp
   reflectionPerm i := RootPairing.equiv_of_mapsTo p root coroot i hr hp
   reflectionPerm_root i j := by
-    rw [equiv_of_mapsTo_apply, (exist_eq_reflection_of_mapsTo p root coroot i j hr).choose_spec,
-      preReflection_apply, PerfectPairing.flip_apply_apply]
+    simp [(exist_eq_reflection_of_mapsTo p root coroot i j hr).choose_spec, preReflection_apply]
   reflectionPerm_coroot i j := by
     refine (coroot_eq_coreflection_of_root_eq' p root coroot hp hr hc ?_).symm
     rw [equiv_of_mapsTo_apply, (exist_eq_reflection_of_mapsTo p root coroot i j hr).choose_spec]
@@ -189,10 +188,10 @@ its roots. -/
 @[ext]
 protected lemma ext [CharZero R] [NoZeroSMulDivisors R M]
     {P₁ P₂ : RootSystem ι R M N}
-    (he : P₁.toPerfectPairing = P₂.toPerfectPairing)
+    (he : P₁.toLinearMap = P₂.toLinearMap)
     (hr : P₁.root = P₂.root) :
     P₁ = P₂ := by
-  suffices ∀ P₁ P₂ : RootSystem ι R M N, P₁.toPerfectPairing = P₂.toPerfectPairing →
+  suffices ∀ P₁ P₂ : RootSystem ι R M N, P₁.toLinearMap = P₂.toLinearMap →
       P₁.root = P₂.root → range P₁.coroot ⊆ range P₂.coroot by
     have h₁ := this P₁ P₂ he hr
     have h₂ := this P₂ P₁ he.symm hr.symm
@@ -203,15 +202,17 @@ protected lemma ext [CharZero R] [NoZeroSMulDivisors R M]
   clear! P₁ P₂
   rintro P₁ P₂ he hr - ⟨i, rfl⟩
   use i
-  apply P₁.bijective_right.injective
+  apply P₁.flip.toPerfPair.injective
   apply Dual.eq_of_preReflection_mapsTo (finite_range P₁.root) P₁.span_root_eq_top
   · exact hr ▸ he ▸ P₂.coroot_root_two i
-  · exact hr ▸ he ▸ P₂.mapsTo_reflection_root i
+  · change MapsTo (preReflection _ (P₁.toLinearMap.flip.toPerfPair _)) _ _
+    simp_rw [hr, he]
+    exact P₂.mapsTo_reflection_root i
   · exact P₁.coroot_root_two i
   · exact P₁.mapsTo_reflection_root i
 
 private lemma coroot_eq_coreflection_of_root_eq_of_span_eq_top [CharZero R] [NoZeroSMulDivisors R M]
-    (p : PerfectPairing R M N)
+    (p : M →ₗ[R] N →ₗ[R] R) [p.IsPerfPair]
     (root : ι ↪ M)
     (coroot : ι ↪ N)
     (hp : ∀ i, p (root i) (coroot i) = 2)
@@ -226,18 +227,18 @@ private lemma coroot_eq_coreflection_of_root_eq_of_span_eq_top [CharZero R] [NoZ
   set sα := preReflection α (p.flip α')
   set sβ := preReflection β (p.flip β')
   let sα' := preReflection α' (p α)
-  have hij : preReflection (sα β) (p.toLinearMap.flip (sα' β')) = sα ∘ₗ sβ ∘ₗ sα := by
+  have hij : preReflection (sα β) (p.flip (sα' β')) = sα ∘ₗ sβ ∘ₗ sα := by
     ext
-    have hpi : (p.flip (coroot i)) (root i) = 2 := by rw [PerfectPairing.flip_apply_apply, hp i]
+    have hpi : (p.flip (coroot i)) (root i) = 2 := by simp [hp i]
     simp [α, β, α', β', sα, sβ, sα', ← preReflection_preReflection β (p.flip β') hpi,
       preReflection_apply] -- v4.7.0-rc1 issues
-  have hk₀ : root k ≠ 0 := fun h ↦ by simpa [h, ← PerfectPairing.toLinearMap_apply] using hp k
-  apply p.bijective_right.injective
+  have hk₀ : root k ≠ 0 := fun h ↦ by simpa [h] using hp k
+  apply p.flip.toPerfPair.injective
   apply Dual.eq_of_preReflection_mapsTo (finite_range root) hsp (hp k) (hs k)
   · simp [map_sub, α, β, α', β', sα, hk, preReflection_apply, hp i, hp j,
       mul_comm (p α β')]
     ring -- v4.7.0-rc1 issues
-  · rw [hk, hij]
+  · rw [hk, LinearMap.toLinearMap_toPerfPair, hij]
     exact (hs i).comp <| (hs j).comp (hs i)
 
 /-- Over a field of characteristic zero, to check that a finite family of roots form a
@@ -245,12 +246,11 @@ crystallographic root system, we do not need to check that the coroots are stabl
 since this follows from the corresponding property for the roots. Likewise, we do not need to
 check that the coroots span. -/
 def mk' {k : Type*} [Field k] [CharZero k] [Module k M] [Module k N]
-    (p : PerfectPairing k M N)
+    (p : M →ₗ[k] N →ₗ[k] k) [p.IsPerfPair]
     (root : ι ↪ M)
     (coroot : ι ↪ N)
-    (hp : ∀ i, p.toLinearMap (root i) (coroot i) = 2)
-    (hs : ∀ i, MapsTo (preReflection (root i) (p.toLinearMap.flip (coroot i)))
-      (range root) (range root))
+    (hp : ∀ i, p (root i) (coroot i) = 2)
+    (hs : ∀ i, MapsTo (preReflection (root i) (p.flip (coroot i))) (range root) (range root))
     (hsp : span k (range root) = ⊤)
     (h_int : ∀ i j, ∃ z : ℤ, z = p (root i) (coroot j)) :
     RootSystem ι k M N :=

--- a/Mathlib/LinearAlgebra/RootSystem/CartanMatrix.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/CartanMatrix.lean
@@ -108,7 +108,8 @@ variable [IsDomain R]
 
 lemma cartanMatrix_apply_eq_zero_iff_symm {i j : b.support} :
     b.cartanMatrix i j = 0 ↔ b.cartanMatrix j i = 0 := by
-  have _i := P.reflexive_left
+  have : Module.IsReflexive R M := .of_isPerfPair P.toLinearMap
+  have : Module.IsReflexive R N := .of_isPerfPair P.flip.toLinearMap
   simp only [cartanMatrix_apply_eq_zero_iff_pairing, P.pairing_eq_zero_iff]
 
 variable [Finite ι]
@@ -120,8 +121,8 @@ lemma cartanMatrix_le_zero_of_ne
 
 lemma cartanMatrix_mem_of_ne {i j : b.support} (hij : i ≠ j) :
     b.cartanMatrix i j ∈ ({-3, -2, -1, 0} : Set ℤ) := by
-  have := P.reflexive_left
-  have := P.reflexive_right
+  have : Module.IsReflexive R M := .of_isPerfPair P.toLinearMap
+  have : Module.IsReflexive R N := .of_isPerfPair P.flip.toLinearMap
   simp only [cartanMatrix, cartanMatrixIn_def]
   have h₁ := P.pairingIn_pairingIn_mem_set_of_isCrystallographic i j
   have h₂ : P.pairingIn ℤ i j ≤ 0 := b.cartanMatrix_le_zero_of_ne i j hij

--- a/Mathlib/LinearAlgebra/RootSystem/Chain.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Chain.lean
@@ -47,9 +47,10 @@ lemma setOf_root_add_zsmul_eq_Icc_of_linearIndependent
   have h_fin : S.Finite := by
     suffices Injective (fun z : S ↦ z.property.choose) from Finite.of_injective _ this
     intro ⟨z, hz⟩ ⟨z', hz'⟩ hzz
+    have : Module.IsReflexive R M := .of_isPerfPair P.toLinearMap
+    have : NoZeroSMulDivisors ℤ M := .int_of_charZero R M
     have : z • P.root i = z' • P.root i := by
       rwa [← add_right_inj (P.root j), ← hz.choose_spec, ← hz'.choose_spec, P.root.injective.eq_iff]
-    have _i : NoZeroSMulDivisors ℤ M := have := P.reflexive_left; .int_of_charZero R M
     exact Subtype.ext <| smul_left_injective ℤ (P.ne_zero i) this
   have h_ne : S.Nonempty := ⟨0, by simp [S_def]⟩
   refine ⟨sInf S, csInf_le h_fin.bddBelow hS₀, sSup S, le_csSup h_fin.bddAbove hS₀,

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -74,7 +74,8 @@ evaluates to `2`, and the permutation attached to each element of `ι` is compat
 reflections on the corresponding roots and coroots.
 
 It exists to allow for a convenient unification of the theories of root systems and root data. -/
-structure RootPairing extends PerfectPairing R M N where
+structure RootPairing extends M →ₗ[R] N →ₗ[R] R where
+  [isPerfPair_toLinearMap : toLinearMap.IsPerfPair]
   /-- A parametrized family of vectors, called roots. -/
   root : ι ↪ M
   /-- A parametrized family of dual vectors, called coroots. -/
@@ -87,9 +88,11 @@ structure RootPairing extends PerfectPairing R M N where
   permutation); and similarly for coroots. -/
   reflectionPerm : ι → (ι ≃ ι)
   reflectionPerm_root : ∀ i j,
-    root j - toPerfectPairing (root j) (coroot i) • root i = root (reflectionPerm i j)
+    root j - toLinearMap (root j) (coroot i) • root i = root (reflectionPerm i j)
   reflectionPerm_coroot : ∀ i j,
-    coroot j - toPerfectPairing (root i) (coroot j) • coroot i = coroot (reflectionPerm i j)
+    coroot j - toLinearMap (root i) (coroot j) • coroot i = coroot (reflectionPerm i j)
+
+attribute [instance] RootPairing.isPerfPair_toLinearMap
 
 /-- A root datum is a root pairing with coefficients in the integers and for which the root and
 coroot spaces are finitely-generated free Abelian groups.
@@ -116,22 +119,23 @@ namespace RootPairing
 variable {ι R M N}
 variable (P : RootPairing ι R M N) (i j : ι)
 
-@[simp]
+@[deprecated "Now a syntactic equality" (since := "2025-07-05")]
 lemma toLinearMap_eq_toPerfectPairing (x : M) (y : N) :
-    P.toLinearMap x y = P.toPerfectPairing x y := rfl
+    P.toLinearMap x y = P.toLinearMap x y := rfl
 
 @[deprecated (since := "2025-04-20")]
 alias toLin_toPerfectPairing := toLinearMap_eq_toPerfectPairing
 
 /-- If we interchange the roles of `M` and `N`, we still have a root pairing. -/
-protected def flip : RootPairing ι R N M :=
-  { P.toPerfectPairing.flip with
-    root := P.coroot
-    coroot := P.root
-    root_coroot_two := P.root_coroot_two
-    reflectionPerm := P.reflectionPerm
-    reflectionPerm_root := P.reflectionPerm_coroot
-    reflectionPerm_coroot := P.reflectionPerm_root }
+@[simps!, simps toLinearMap]
+protected def flip : RootPairing ι R N M where
+  toLinearMap := P.toLinearMap.flip
+  root := P.coroot
+  coroot := P.root
+  root_coroot_two := P.root_coroot_two
+  reflectionPerm := P.reflectionPerm
+  reflectionPerm_root := P.reflectionPerm_coroot
+  reflectionPerm_coroot := P.reflectionPerm_root
 
 @[simp]
 lemma flip_flip : P.flip.flip = P :=
@@ -193,16 +197,16 @@ protected lemma nontrivial' [Nonempty ι] [NeZero (2 : R)] : Nontrivial N :=
   P.flip.nontrivial
 
 /-- Roots written as functionals on the coweight space. -/
-abbrev root' (i : ι) : Dual R N := P.toPerfectPairing (P.root i)
+abbrev root' (i : ι) : Dual R N := P.toLinearMap (P.root i)
 
 /-- Coroots written as functionals on the weight space. -/
-abbrev coroot' (i : ι) : Dual R M := P.toPerfectPairing.flip (P.coroot i)
+abbrev coroot' (i : ι) : Dual R M := P.toLinearMap.flip (P.coroot i)
 
 /-- This is the pairing between roots and coroots. -/
 def pairing : R := P.root' i (P.coroot j)
 
 @[simp]
-lemma root_coroot_eq_pairing : P.toPerfectPairing (P.root i) (P.coroot j) = P.pairing i j :=
+lemma root_coroot_eq_pairing : P.toLinearMap (P.root i) (P.coroot j) = P.pairing i j :=
   rfl
 
 @[simp]
@@ -377,16 +381,12 @@ lemma coreflection_eq_flip_reflection :
 
 lemma reflection_reflectionPerm {i j : ι} :
     P.reflection (P.reflectionPerm j i) = P.reflection j * P.reflection i * P.reflection j := by
-  ext x
-  simp only [reflection_apply, coreflection_apply, PerfectPairing.flip_apply_apply,
-    coroot_reflectionPerm, root_coroot_eq_pairing, map_sub, map_smul, smul_eq_mul,
-    root_reflectionPerm, LinearEquiv.mul_apply, pairing_same]
-  module
+  ext x; simp [reflection_apply, coreflection_apply]; module
 
 lemma reflection_dualMap_eq_coreflection :
     (P.reflection i).dualMap ∘ₗ P.toLinearMap.flip = P.toLinearMap.flip ∘ₗ P.coreflection i := by
   ext n m
-  simp [map_sub, coreflection_apply, reflection_apply, mul_comm (P.toPerfectPairing m (P.coroot i))]
+  simp [map_sub, coreflection_apply, reflection_apply, mul_comm (P.toLinearMap m (P.coroot i))]
 
 lemma coroot_eq_coreflection_of_root_eq
     {i j k : ι} (hk : P.root k = P.reflection i (P.root j)) :
@@ -408,31 +408,26 @@ lemma coroot'_reflection {i j : ι} (y : M) :
 lemma pairing_reflectionPerm (i j k : ι) :
     P.pairing j (P.reflectionPerm i k) = P.pairing (P.reflectionPerm i j) k := by
   simp only [pairing, root', coroot_reflectionPerm, root_reflectionPerm]
-  simp only [coreflection_apply_coroot, map_sub, map_smul, smul_eq_mul,
-    reflection_apply_root]
-  simp [← toLinearMap_eq_toPerfectPairing, LinearMap.smul_apply,
-    LinearMap.sub_apply, smul_eq_mul]
-  simp [mul_comm]
+  simp [coreflection_apply_coroot, reflection_apply_root, mul_comm]
 
 @[deprecated (since := "2025-05-28")] alias pairing_reflection_perm := pairing_reflectionPerm
 
 @[simp]
-lemma toDualLeft_conj_reflection :
-    P.toDualLeft.conj (P.reflection i) = (P.coreflection i).toLinearMap.dualMap := by
+lemma toPerfPair_conj_reflection :
+    P.toPerfPair.conj (P.reflection i) = (P.coreflection i).toLinearMap.dualMap := by
   ext f n
   simp [LinearEquiv.conj_apply, reflection_apply, coreflection_apply, mul_comm (f <| P.coroot i)]
 
 @[simp]
-lemma toDualRight_conj_coreflection :
-    P.toDualRight.conj (P.coreflection i) = (P.reflection i).toLinearMap.dualMap :=
-  P.flip.toDualLeft_conj_reflection i
+lemma toPerfPair_flip_conj_coreflection :
+    P.flip.toPerfPair.conj (P.coreflection i) = (P.reflection i).toLinearMap.dualMap :=
+  P.flip.toPerfPair_conj_reflection i
 
 @[simp]
 lemma pairing_reflectionPerm_self_left (P : RootPairing ι R M N) (i j : ι) :
     P.pairing (P.reflectionPerm i i) j = - P.pairing i j := by
   rw [pairing, root', ← reflectionPerm_root, root'_coroot_eq_pairing, pairing_same, two_smul,
-    sub_add_cancel_left, ← toLinearMap_eq_toPerfectPairing, LinearMap.map_neg₂,
-    toLinearMap_eq_toPerfectPairing, root'_coroot_eq_pairing]
+    sub_add_cancel_left, LinearMap.map_neg₂, root'_coroot_eq_pairing]
 
 @[deprecated (since := "2025-05-28")]
 alias pairing_reflection_perm_self_left := pairing_reflectionPerm_self_left
@@ -441,8 +436,7 @@ alias pairing_reflection_perm_self_left := pairing_reflectionPerm_self_left
 lemma pairing_reflectionPerm_self_right (i j : ι) :
     P.pairing i (P.reflectionPerm j j) = - P.pairing i j := by
   rw [pairing, ← reflectionPerm_coroot, root_coroot_eq_pairing, pairing_same, two_smul,
-    sub_add_cancel_left, ← toLinearMap_eq_toPerfectPairing, map_neg,
-    toLinearMap_eq_toPerfectPairing, root_coroot_eq_pairing]
+    sub_add_cancel_left, map_neg, root_coroot_eq_pairing]
 
 @[deprecated (since := "2025-05-28")]
 alias pairing_reflection_perm_self_right := pairing_reflectionPerm_self_right
@@ -453,15 +447,15 @@ of a root / coroot. -/
   neg i := P.reflectionPerm i i
   neg_neg i := by
     apply P.root.injective
-    simp only [root_reflectionPerm, reflection_apply, PerfectPairing.flip_apply_apply,
-      root_coroot_eq_pairing, pairing_same, map_sub, map_smul, coroot_reflectionPerm,
-      coreflection_apply_self, map_neg]
+    simp only [root_reflectionPerm, reflection_apply, LinearMap.flip_apply, root_coroot_eq_pairing,
+      pairing_same, map_sub, coroot_reflectionPerm, coreflection_apply_self, map_neg, neg_smul,
+      sub_neg_eq_add, map_smul, smul_add]
     module
 
 lemma ne_neg [NeZero (2 : R)] [IsDomain R] :
     letI := P.indexNeg
     i ≠ -i := by
-  have := P.reflexive_left
+  have := Module.IsReflexive.of_isPerfPair P.toLinearMap
   intro contra
   replace contra : P.root i = -P.root i := by simpa using congr_arg P.root contra
   simp [eq_neg_iff_add_eq_zero, ← two_smul R, NeZero.out, P.ne_zero i] at contra
@@ -603,9 +597,9 @@ lemma _root_.RootSystem.reflectionPerm_eq_reflectionPerm_iff (P : RootSystem ι 
 alias _root_.RootSystem.reflection_perm_eq_reflection_perm_iff :=
   _root_.RootSystem.reflectionPerm_eq_reflectionPerm_iff
 
-@[simp] lemma toDualLeft_comp_root : P.toDualLeft ∘ P.root = P.root' := rfl
+@[simp] lemma toPerfPair_comp_root : P.toPerfPair ∘ P.root = P.root' := rfl
 
-@[simp] lemma toDualRight_comp_root : P.toDualRight ∘ P.coroot = P.coroot' := rfl
+@[simp] lemma toPerfPair_flip_comp_coroot : P.flip.toPerfPair ∘ P.coroot = P.coroot' := rfl
 
 /-- The Coxeter Weight of a pair gives the weight of an edge in a Coxeter diagram, when it is
 finite.  It is `4 cos² θ`, where `θ` describes the dihedral angle between hyperplanes. -/
@@ -625,8 +619,8 @@ lemma isOrthogonal_comm (h : IsOrthogonal P i j) : Commute (P.reflection i) (P.r
   ext v
   replace h : P.pairing i j = 0 ∧ P.pairing j i = 0 := by simpa [IsOrthogonal] using h
   erw [Module.End.mul_apply, Module.End.mul_apply]
-  simp only [LinearEquiv.coe_coe, reflection_apply, PerfectPairing.flip_apply_apply, map_sub,
-    map_smul, root_coroot_eq_pairing, h, zero_smul, sub_zero]
+  simp only [LinearEquiv.coe_coe, reflection_apply, LinearMap.flip_apply, map_sub, map_smul,
+    root_coroot_eq_pairing, h, zero_smul, sub_zero]
   abel
 
 variable {P i j}
@@ -701,12 +695,12 @@ lemma pairing_eq_zero_iff [NeZero (2 : R)] [NoZeroSMulDivisors R M] :
 
 lemma pairing_eq_zero_iff' [NeZero (2 : R)] [IsDomain R] :
     P.pairing i j = 0 ↔ P.pairing j i = 0 := by
-  have := P.reflexive_left
+  have : IsReflexive R M := .of_isPerfPair P.toLinearMap
   exact pairing_eq_zero_iff
 
 lemma coxeterWeight_zero_iff_isOrthogonal [NeZero (2 : R)] [IsDomain R] :
     P.coxeterWeight i j = 0 ↔ P.IsOrthogonal i j := by
-  have := P.reflexive_left
+  have : IsReflexive R M := .of_isPerfPair P.toLinearMap
   simp [coxeterWeight, IsOrthogonal, P.pairing_eq_zero_iff (i := i) (j := j)]
 
 lemma isOrthogonal_iff_pairing_eq_zero [NeZero (2 : R)] [NoZeroSMulDivisors R M] :

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -119,11 +119,11 @@ namespace RootPairing
 variable {ι R M N}
 variable (P : RootPairing ι R M N) (i j : ι)
 
-@[deprecated "Now a syntactic equality" (since := "2025-07-05")]
+@[deprecated "Now a syntactic equality" (since := "2025-07-05"), nolint synTaut]
 lemma toLinearMap_eq_toPerfectPairing (x : M) (y : N) :
     P.toLinearMap x y = P.toLinearMap x y := rfl
 
-@[deprecated (since := "2025-04-20")]
+@[deprecated (since := "2025-04-20"), nolint synTaut]
 alias toLin_toPerfectPairing := toLinearMap_eq_toPerfectPairing
 
 /-- If we interchange the roles of `M` and `N`, we still have a root pairing. -/
@@ -420,7 +420,7 @@ lemma toPerfPair_conj_reflection :
 
 @[simp]
 lemma toPerfPair_flip_conj_coreflection :
-    P.flip.toPerfPair.conj (P.coreflection i) = (P.reflection i).toLinearMap.dualMap :=
+    P.toLinearMap.flip.toPerfPair.conj (P.coreflection i) = (P.reflection i).toLinearMap.dualMap :=
   P.flip.toPerfPair_conj_reflection i
 
 @[simp]
@@ -599,7 +599,8 @@ alias _root_.RootSystem.reflection_perm_eq_reflection_perm_iff :=
 
 @[simp] lemma toPerfPair_comp_root : P.toPerfPair ∘ P.root = P.root' := rfl
 
-@[simp] lemma toPerfPair_flip_comp_coroot : P.flip.toPerfPair ∘ P.coroot = P.coroot' := rfl
+@[simp] lemma toPerfPair_flip_comp_coroot :
+    P.toLinearMap.flip.toPerfPair ∘ P.coroot = P.coroot' := rfl
 
 /-- The Coxeter Weight of a pair gives the weight of an edge in a Coxeter diagram, when it is
 finite.  It is `4 cos² θ`, where `θ` describes the dihedral angle between hyperplanes. -/

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
@@ -92,14 +92,14 @@ lemma corootForm_apply_apply (x y : N) : P.CorootForm x y =
     ∑ i, P.root' i x * P.root' i y :=
   P.flip.rootForm_apply_apply x y
 
-lemma toPerfectPairing_apply_apply_Polarization (x y : M) :
-    P.toPerfectPairing y (P.Polarization x) = P.RootForm x y := by
+lemma toLinearMap_apply_apply_Polarization (x y : M) :
+    P.toLinearMap y (P.Polarization x) = P.RootForm x y := by
   simp [RootForm]
 
-lemma toPerfectPairing_apply_CoPolarization (x : N) :
-    P.toPerfectPairing (P.CoPolarization x) = P.CorootForm x := by
+lemma toLinearMap_apply_CoPolarization (x : N) :
+    P.toLinearMap (P.CoPolarization x) = P.CorootForm x := by
   ext y
-  exact P.flip.toPerfectPairing_apply_apply_Polarization x y
+  exact P.flip.toLinearMap_apply_apply_Polarization x y
 
 lemma flip_comp_polarization_eq_rootForm :
     P.flip.toLinearMap ∘ₗ P.Polarization = P.RootForm := by
@@ -112,10 +112,9 @@ lemma self_comp_coPolarization_eq_corootForm :
 lemma polarization_apply_eq_zero_iff (m : M) :
     P.Polarization m = 0 ↔ P.RootForm m = 0 := by
   rw [← flip_comp_polarization_eq_rootForm]
-  refine ⟨fun h ↦ by simp [h], fun h ↦ ?_⟩
-  change P.toDualRight (P.Polarization m) = 0 at h
-  simp only [EmbeddingLike.map_eq_zero_iff] at h
-  exact h
+  refine ⟨fun h ↦ by simp [h], ?_⟩
+  rintro (h : P.flip.toPerfPair (P.Polarization m) = 0)
+  simpa only [EmbeddingLike.map_eq_zero_iff] using h
 
 lemma coPolarization_apply_eq_zero_iff (n : N) :
     P.CoPolarization n = 0 ↔ P.CorootForm n = 0 :=
@@ -155,19 +154,18 @@ theorem range_polarization_domRestrict_le_span_coroot :
   obtain ⟨x, hx⟩ := hy
   rw [← hx, LinearMap.domRestrict_apply, Polarization_apply]
   refine (Submodule.mem_span_range_iff_exists_fun R).mpr ?_
-  use fun i => (P.toPerfectPairing x) (P.coroot i)
+  use fun i => P.toLinearMap x (P.coroot i)
   simp
 
 theorem corootSpan_dualAnnihilator_le_ker_rootForm :
-    (P.corootSpan R).dualAnnihilator.map P.toDualLeft.symm ≤ LinearMap.ker P.RootForm := by
+    (P.corootSpan R).dualAnnihilator.map P.toPerfPair.symm ≤ LinearMap.ker P.RootForm := by
   rw [P.corootSpan_dualAnnihilator_map_eq_iInf_ker_coroot']
   intro x hx
   ext y
-  simp only [coroot', Submodule.mem_iInf, LinearMap.mem_ker, PerfectPairing.flip_apply_apply] at hx
-  simp [rootForm_apply_apply, hx]
+  simp_all [coroot', rootForm_apply_apply]
 
 theorem rootSpan_dualAnnihilator_le_ker_rootForm :
-    (P.rootSpan R).dualAnnihilator.map P.toDualRight.symm ≤ LinearMap.ker P.CorootForm :=
+    (P.rootSpan R).dualAnnihilator.map P.flip.toPerfPair.symm ≤ LinearMap.ker P.CorootForm :=
   P.flip.corootSpan_dualAnnihilator_le_ker_rootForm
 
 end Fintype
@@ -189,10 +187,9 @@ lemma PolarizationIn_apply (x : P.rootSpan S) :
 lemma PolarizationIn_eq (x : P.rootSpan S) :
     P.PolarizationIn S x = P.Polarization x := by
   simp only [PolarizationIn, LinearMap.coeFn_sum, LinearMap.coe_comp, Finset.sum_apply, comp_apply,
-    LinearMap.toSpanSingleton_apply, Polarization_apply, PerfectPairing.flip_apply_apply]
+    LinearMap.toSpanSingleton_apply, Polarization_apply]
   refine Finset.sum_congr rfl fun i hi ↦ ?_
-  rw [algebra_compatible_smul R (P.coroot'In S i x) (P.coroot i), algebraMap_coroot'In_apply,
-    PerfectPairing.flip_apply_apply]
+  rw [algebra_compatible_smul R (P.coroot'In S i x) (P.coroot i), algebraMap_coroot'In_apply]
 
 lemma range_polarizationIn :
     Submodule.map P.Polarization (P.rootSpan R) = LinearMap.range (P.PolarizationIn R) := by
@@ -223,11 +220,11 @@ lemma algebraMap_rootFormIn (x y : P.rootSpan S) :
     (algebraMap S R) (P.RootFormIn S x y) = P.RootForm x y := by
   simp [RootFormIn, rootForm_apply_apply]
 
-lemma toPerfectPairing_apply_PolarizationIn (x y : P.rootSpan S) :
-    P.toPerfectPairing y (P.PolarizationIn S x) =
+lemma toLinearMap_apply_PolarizationIn (x y : P.rootSpan S) :
+    P.toLinearMap y (P.PolarizationIn S x) =
       (algebraMap S R) (P.RootFormIn S x y) := by
   rw [PolarizationIn_eq, algebraMap_rootFormIn]
-  exact toPerfectPairing_apply_apply_Polarization P x y
+  exact toLinearMap_apply_apply_Polarization P x y
 
 omit [IsScalarTower S R N] in
 lemma range_polarizationIn_le_span_coroot :
@@ -301,13 +298,13 @@ lemma four_smul_rootForm_sq_eq_coxeterWeight_smul (i j : ι) :
     4 • (P.RootForm (P.root i) (P.root j)) ^ 2 = P.coxeterWeight i j •
       (P.RootForm (P.root i) (P.root i) * P.RootForm (P.root j) (P.root j)) := by
   have hij : 4 • (P.RootForm (P.root i)) (P.root j) =
-      2 • P.toPerfectPairing (P.root j) (2 • P.Polarization (P.root i)) := by
-    rw [← toPerfectPairing_apply_apply_Polarization, LinearMap.map_smul_of_tower, ← smul_assoc,
+      2 • P.toLinearMap (P.root j) (2 • P.Polarization (P.root i)) := by
+    rw [← toLinearMap_apply_apply_Polarization, LinearMap.map_smul_of_tower, ← smul_assoc,
       Nat.nsmul_eq_mul]
   have hji : 2 • (P.RootForm (P.root i)) (P.root j) =
-      P.toPerfectPairing (P.root i) (2 • P.Polarization (P.root j)) := by
+      P.toLinearMap (P.root i) (2 • P.Polarization (P.root j)) := by
     rw [show (P.RootForm (P.root i)) (P.root j) = (P.RootForm (P.root j)) (P.root i) by
-      apply (rootForm_symmetric P).eq, ← toPerfectPairing_apply_apply_Polarization,
+      apply (rootForm_symmetric P).eq, ← toLinearMap_apply_apply_Polarization,
       LinearMap.map_smul_of_tower]
   rw [sq, nsmul_eq_mul, ← mul_assoc, ← nsmul_eq_mul, hij, ← rootForm_self_smul_coroot,
     smul_mul_assoc 2, ← mul_smul_comm, hji, ← rootForm_self_smul_coroot, map_smul, ← pairing,

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/G2.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/G2.lean
@@ -174,7 +174,7 @@ To see that this lemma fails for `𝔤₂`, let `α` (short) and `β` (long) be 
 `α` and `α + β` provide a counterexample. -/
 lemma chainBotCoeff_if_one_zero [P.IsNotG2] (h : P.root i + P.root j ∈ range P.root) :
     P.chainBotCoeff i j = if P.pairingIn ℤ i j = 0 then 1 else 0 := by
-  have _i := P.reflexive_left
+  have : Module.IsReflexive R M := .of_isPerfPair P.toLinearMap
   have aux₁ := P.linearIndependent_of_add_mem_range_root' h
   have aux₂ := P.chainBotCoeff_add_chainTopCoeff_le_two i j
   have aux₃ : 1 ≤ P.chainTopCoeff i j := P.one_le_chainTopCoeff_of_root_add_mem h

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/G2.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/G2.lean
@@ -295,7 +295,7 @@ lemma threeShortAddTwoLongRoot_eq :
 
 lemma linearIndependent_short_long :
     LinearIndependent R ![shortRoot P, longRoot P] := by
-  have := P.reflexive_left
+  have : Module.IsReflexive R M := .of_isPerfPair P.toLinearMap
   simp [P.linearIndependent_iff_coxeterWeightIn_ne_four ℤ, coxeterWeightIn]
 
 /-- The coefficients of each root in the `𝔤₂` root pairing, relative to the base. -/
@@ -522,7 +522,7 @@ private lemma isOrthogonal_short_and_long_aux {a b c d e f a' b' c' d' e' f' : �
 lemma isOrthogonal_short_and_long {i : ι} (hi : P.root i ∉ allRoots P) :
     P.IsOrthogonal i (short P) ∧ P.IsOrthogonal i (long P) := by
   suffices P.pairingIn ℤ i (short P) = 0 ∧ P.pairingIn ℤ i (long P) = 0 by
-    have := P.reflexive_left
+    have : Module.IsReflexive R M := .of_isPerfPair P.toLinearMap
     simpa [isOrthogonal_iff_pairing_eq_zero, ← P.algebraMap_pairingIn ℤ]
   simp only [mem_cons, not_mem_nil, or_false, not_or] at hi
   obtain ⟨h₁, h₂, h₃, h₄, h₅, h₆, h₇, h₈, h₉, h₁₀, h₁₁, h₁₂⟩ := hi
@@ -566,7 +566,7 @@ lemma mem_allRoots (i : ι) :
   obtain ⟨h₁, h₂⟩ := isOrthogonal_short_and_long P hi
   have : Fintype ι := Fintype.ofFinite ι
   have B := (P.posRootForm ℤ).toInvariantForm
-  have := P.reflexive_left
+  have : Module.IsReflexive R M := .of_isPerfPair P.toLinearMap
   rw [isOrthogonal_iff_pairing_eq_zero, ← B.apply_root_root_zero_iff] at h₁ h₂
   have key : B.form (P.root i) = 0 := by
     ext x

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -103,7 +103,7 @@ lemma pairingIn_pairingIn_mem_set_of_isCrystal_of_isRed [P.IsReduced] :
     (P.pairingIn ℤ i j, P.pairingIn ℤ j i) ∈
       ({(0, 0), (1, 1), (-1, -1), (1, 2), (2, 1), (-1, -2), (-2, -1), (1, 3), (3, 1), (-1, -3),
         (-3, -1), (2, 2), (-2, -2)} : Set (ℤ × ℤ)) := by
-  have := P.reflexive_left
+  have : Module.IsReflexive R M := .of_isPerfPair P.toLinearMap
   rcases eq_or_ne i j with rfl | h₁; · simp
   rcases eq_or_ne (α i) (-α j) with h₂ | h₂; · aesop
   have aux₁ := P.pairingIn_pairingIn_mem_set_of_isCrystallographic i j
@@ -115,7 +115,7 @@ lemma pairingIn_pairingIn_mem_set_of_isCrystal_of_isRed' [P.IsReduced]
     (P.pairingIn ℤ i j, P.pairingIn ℤ j i) ∈
       ({(0, 0), (1, 1), (-1, -1), (1, 2), (2, 1), (-1, -2), (-2, -1), (1, 3), (3, 1), (-1, -3),
         (-3, -1)} : Set (ℤ × ℤ)) := by
-  have := P.reflexive_left
+  have : Module.IsReflexive R M := .of_isPerfPair P.toLinearMap
   have := P.pairingIn_pairingIn_mem_set_of_isCrystal_of_isRed i j
   aesop
 
@@ -144,7 +144,7 @@ lemma RootPositiveForm.rootLength_lt_of_pairingIn_notMem
     have := P.pairingIn_pairingIn_mem_set_of_isCrystallographic i j
     aesop -- #24551 (this should be faster)
   have aux₁ : P.pairingIn ℤ j i = -1 ∨ P.pairingIn ℤ j i = 1 := by
-    have _i := P.reflexive_left
+    have : Module.IsReflexive R M := .of_isPerfPair P.toLinearMap
     have := P.pairingIn_pairingIn_mem_set_of_isCrystallographic i j
     aesop -- #24551 (this should be faster)
   have aux₂ := B.pairingIn_mul_eq_pairingIn_mul_swap i j
@@ -172,7 +172,7 @@ lemma pairingIn_pairingIn_mem_set_of_length_eq_of_ne {B : P.InvariantForm}
     (len_eq : B.form (α i) (α i) = B.form (α j) (α j))
     (ne : i ≠ j) (ne' : α i ≠ -α j) :
     (P.pairingIn ℤ i j, P.pairingIn ℤ j i) ∈ ({(0, 0), (1, 1), (-1, -1)} : Set (ℤ × ℤ)) := by
-  have := P.reflexive_left
+  have : Module.IsReflexive R M := .of_isPerfPair P.toLinearMap
   have := P.pairingIn_pairingIn_mem_set_of_length_eq len_eq
   aesop
 
@@ -189,9 +189,9 @@ variable {i j}
 
 lemma root_sub_root_mem_of_pairingIn_pos (h : 0 < P.pairingIn ℤ i j) (h' : i ≠ j) :
     α i - α j ∈ Φ := by
-  have := P.reflexive_left
-  have := P.reflexive_right
-  have _i : NoZeroSMulDivisors ℤ M := NoZeroSMulDivisors.int_of_charZero R M
+  have : Module.IsReflexive R M := .of_isPerfPair P.toLinearMap
+  have : Module.IsReflexive R N := .of_isPerfPair P.flip.toLinearMap
+  have : NoZeroSMulDivisors ℤ M := NoZeroSMulDivisors.int_of_charZero R M
   by_cases hli : LinearIndependent R ![α i, α j]
   · -- The case where the two roots are linearly independent
     suffices P.pairingIn ℤ i j = 1 ∨ P.pairingIn ℤ j i = 1 by
@@ -269,7 +269,7 @@ lemma apply_eq_or_aux (i j : ι) (h : P.pairingIn ℤ i j ≠ 0) :
     B.form (α i) (α i) = 3 * B.form (α j) (α j) ∨
     B.form (α j) (α j) = 2 * B.form (α i) (α i) ∨
     B.form (α j) (α j) = 3 * B.form (α i) (α i) := by
-  have := P.reflexive_left
+  have : Module.IsReflexive R M := .of_isPerfPair P.toLinearMap
   have h₁ := P.pairingIn_pairingIn_mem_set_of_isCrystal_of_isRed i j
   have h₂ : algebraMap ℤ R (P.pairingIn ℤ j i) * B.form (α i) (α i) =
             algebraMap ℤ R (P.pairingIn ℤ i j) * B.form (α j) (α j) := by

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
@@ -99,7 +99,7 @@ variable (S : Type*) [CommRing S] [IsDomain R] [IsDomain S] [Algebra S R] [Faith
 lemma finrank_range_polarization_eq_finrank_span_coroot [P.IsAnisotropic] :
     finrank S (LinearMap.range (P.PolarizationIn S)) = finrank S (P.corootSpan S) := by
   apply (Submodule.finrank_mono (P.range_polarizationIn_le_span_coroot S)).antisymm
-  have : IsReflexive R N := PerfectPairing.reflexive_right P.toPerfectPairing
+  have : IsReflexive R N := .of_isPerfPair P.flip.toLinearMap
   have : NoZeroSMulDivisors S N := NoZeroSMulDivisors.trans_faithfulSMul S R N
   have h_ne : ∏ i, (P.RootFormIn S (P.rootSpanMem S i) (P.rootSpanMem S i)) ≠ 0 := by
     refine Finset.prod_ne_zero_iff.mpr fun i _ h ↦ ?_
@@ -128,7 +128,7 @@ lemma finrank_corootSpan_eq [P.IsAnisotropic] :
 
 lemma polarizationIn_Injective [P.IsAnisotropic] :
     Function.Injective (P.PolarizationIn S) := by
-  have : IsReflexive R M := PerfectPairing.reflexive_left P.toPerfectPairing
+  have : IsReflexive R M := .of_isPerfPair P.toLinearMap
   have : NoZeroSMulDivisors S M := NoZeroSMulDivisors.trans_faithfulSMul S R M
   rw [← LinearMap.ker_eq_bot, ← top_disjoint]
   refine Submodule.disjoint_ker_of_finrank_le (L := ⊤) (P.PolarizationIn S) ?_
@@ -203,7 +203,7 @@ lemma finrank_corootSpan_eq' :
 
 lemma disjoint_rootSpan_ker_rootForm :
     Disjoint (P.rootSpan R) (LinearMap.ker P.RootForm) := by
-  have : IsReflexive R M := PerfectPairing.reflexive_left P.toPerfectPairing
+  have : IsReflexive R M := .of_isPerfPair P.toLinearMap
   rw [← P.ker_polarization_eq_ker_rootForm]
   refine Submodule.disjoint_ker_of_finrank_le (L := P.rootSpan R) P.Polarization ?_
   rw [P.finrank_rootSpan_map_polarization_eq_finrank_corootSpan, P.finrank_corootSpan_eq']
@@ -225,13 +225,13 @@ variable [Field R] [Module R M] [Module R N] (P : RootPairing ι R M N) [P.IsAni
 
 lemma isCompl_rootSpan_ker_rootForm :
     IsCompl (P.rootSpan R) (LinearMap.ker P.RootForm) := by
-  have _iM : IsReflexive R M := PerfectPairing.reflexive_left P.toPerfectPairing
-  have _iN : IsReflexive R N := PerfectPairing.reflexive_right P.toPerfectPairing
+  have : IsReflexive R M := .of_isPerfPair P.toLinearMap
+  have : IsReflexive R N := .of_isPerfPair P.flip.toLinearMap
   refine (Submodule.isCompl_iff_disjoint _ _ ?_).mpr P.disjoint_rootSpan_ker_rootForm
   have aux : finrank R M =
       finrank R (P.rootSpan R) + finrank R (P.corootSpan R).dualAnnihilator := by
-    rw [P.toPerfectPairing.finrank_eq, ← P.finrank_corootSpan_eq',
-      Subspace.finrank_add_finrank_dualAnnihilator_eq (P.corootSpan R)]
+    rw [P.toPerfPair.finrank_eq, ← P.finrank_corootSpan_eq',
+      Subspace.finrank_add_finrank_dualAnnihilator_eq (P.corootSpan R), Subspace.dual_finrank_eq]
   rw [aux, add_le_add_iff_left]
   convert Submodule.finrank_mono P.corootSpan_dualAnnihilator_le_ker_rootForm
   exact (LinearEquiv.finrank_map_eq _ _).symm
@@ -241,20 +241,20 @@ lemma isCompl_corootSpan_ker_corootForm :
   P.flip.isCompl_rootSpan_ker_rootForm
 
 lemma ker_rootForm_eq_dualAnnihilator :
-    LinearMap.ker P.RootForm = (P.corootSpan R).dualAnnihilator.map P.toDualLeft.symm := by
-  have _iM : IsReflexive R M := PerfectPairing.reflexive_left P.toPerfectPairing
-  have _iN : IsReflexive R N := PerfectPairing.reflexive_right P.toPerfectPairing
+    LinearMap.ker P.RootForm = (P.corootSpan R).dualAnnihilator.map P.toPerfPair.symm := by
+  have : IsReflexive R M := .of_isPerfPair P.toLinearMap
+  have : IsReflexive R N := .of_isPerfPair P.flip.toLinearMap
   suffices finrank R (LinearMap.ker P.RootForm) = finrank R (P.corootSpan R).dualAnnihilator by
     refine (Submodule.eq_of_le_of_finrank_eq P.corootSpan_dualAnnihilator_le_ker_rootForm ?_).symm
     rw [this]
     apply LinearEquiv.finrank_map_eq
   have aux0 := Subspace.finrank_add_finrank_dualAnnihilator_eq (P.corootSpan R)
   have aux1 := Submodule.finrank_add_eq_of_isCompl P.isCompl_rootSpan_ker_rootForm
-  rw [← P.finrank_corootSpan_eq', P.toPerfectPairing.finrank_eq] at aux1
+  rw [← P.finrank_corootSpan_eq', P.toPerfPair.finrank_eq, Subspace.dual_finrank_eq] at aux1
   omega
 
 lemma ker_corootForm_eq_dualAnnihilator :
-    LinearMap.ker P.CorootForm = (P.rootSpan R).dualAnnihilator.map P.toDualRight.symm :=
+    LinearMap.ker P.CorootForm = (P.rootSpan R).dualAnnihilator.map P.flip.toPerfPair.symm :=
   P.flip.ker_rootForm_eq_dualAnnihilator
 
 instance : P.IsBalanced where
@@ -291,11 +291,12 @@ lemma orthogonal_corootSpan_eq :
 
 lemma rootSpan_eq_top_iff :
     P.rootSpan R = ⊤ ↔ P.corootSpan R = ⊤ := by
-  have := P.toPerfectPairing.reflexive_left
-  have := P.toPerfectPairing.reflexive_right
+  have : IsReflexive R M := .of_isPerfPair P.toLinearMap
+  have : IsReflexive R N := .of_isPerfPair P.flip.toLinearMap
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩ <;> apply Submodule.eq_top_of_finrank_eq
-  · rw [P.finrank_corootSpan_eq', h, finrank_top, P.toPerfectPairing.finrank_eq]
-  · rw [← P.finrank_corootSpan_eq', h, finrank_top, P.toPerfectPairing.finrank_eq]
+  · rw [P.finrank_corootSpan_eq', h, finrank_top, P.toPerfPair.finrank_eq, Subspace.dual_finrank_eq]
+  · rw [← P.finrank_corootSpan_eq', h, finrank_top, P.toPerfPair.finrank_eq,
+      Subspace.dual_finrank_eq]
 
 end Field
 

--- a/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Lemmas.lean
@@ -62,7 +62,7 @@ lemma root_sub_root_mem_of_mem_of_mem (hk : α k + α i - α j ∈ Φ)
       rw [contra] at hk'
       exact P.ne_zero _ hk'.choose_spec
     have aux (h : P.pairingIn ℤ i k = -2) : ¬P.pairingIn ℤ k i = -2 := by
-      have := P.reflexive_left
+      have : Module.IsReflexive R M := .of_isPerfPair P.toLinearMap
       contrapose! hk'; exact (P.pairingIn_neg_two_neg_two_iff ℤ i k).mp ⟨h, hk'⟩
     have := P.pairingIn_pairingIn_mem_set_of_isCrystallographic i k
     aesop -- #24551 (this should be faster)
@@ -71,8 +71,8 @@ lemma root_sub_root_mem_of_mem_of_mem (hk : α k + α i - α j ∈ Φ)
     apply algebraMap_injective ℤ R
     simp only [algebraMap_pairingIn, map_sub, map_one, algebraMap_pairingIn]
     convert (P.coroot' i : M →ₗ[R] R).congr_arg hl using 1
-    simp only [PerfectPairing.flip_apply_apply, map_sub, map_add,
-      root_coroot_eq_pairing, hki, pairing_same]
+    simp only [map_sub, map_add, LinearMap.flip_apply, root_coroot_eq_pairing, hki, pairing_same,
+      sub_left_inj]
     ring
   replace hij := pairingIn_le_zero_of_ne b hij.symm hj hi
   omega
@@ -109,7 +109,7 @@ variable {b : P.Base} {i j k l m : ι}
 private lemma chainBotCoeff_mul_chainTopCoeff.aux_0 [P.IsNotG2]
     (hik_mem : P.root k + P.root i ∈ range P.root) :
     P.pairingIn ℤ k i = 0 ∨ (P.pairingIn ℤ k i < 0 ∧ P.chainBotCoeff i k = 0) := by
-  have _i := P.reflexive_left
+  have : Module.IsReflexive R M := .of_isPerfPair P.toLinearMap
   have := pairingIn_le_zero_of_root_add_mem hik_mem
   rw [add_comm] at hik_mem
   rw [P.chainBotCoeff_if_one_zero hik_mem, ite_eq_right_iff, P.pairingIn_eq_zero_iff (i := i)]
@@ -196,7 +196,8 @@ lemma chainBotCoeff_mul_chainTopCoeff.isNotG2 : P.IsNotG2 := by
 /- An auxiliary result en route to `RootPairing.chainBotCoeff_mul_chainTopCoeff`. -/
 private lemma chainBotCoeff_mul_chainTopCoeff.aux_1
     (hki : P.pairingIn ℤ k i = 0) :
-    have _i := P.reflexive_left; letI := P.indexNeg
+    have : Module.IsReflexive R M := .of_isPerfPair P.toLinearMap
+    letI := P.indexNeg
     P.root i + P.root m ∈ range P.root → P.root j + P.root (-l) ∈ range P.root →
       P.root j + P.root (-k) ∈ range P.root →
       (P.chainBotCoeff i m + 1) * (P.chainBotCoeff j (-k) + 1) =
@@ -258,7 +259,8 @@ private lemma chainBotCoeff_mul_chainTopCoeff.aux_1
 open RootPositiveForm in
 private lemma chainBotCoeff_mul_chainTopCoeff.aux_2
     (hki' : P.pairingIn ℤ k i < 0) (hkj' : 0 < P.pairingIn ℤ k j) :
-    have _i := P.reflexive_left; letI := P.indexNeg
+    have : Module.IsReflexive R M := .of_isPerfPair P.toLinearMap
+    letI := P.indexNeg
     P.root i + P.root m ∈ range P.root → P.root j + P.root (-l) ∈ range P.root →
       P.root j + P.root (-k) ∈ range P.root →
       ¬ (P.chainBotCoeff i m = 1 ∧ P.chainBotCoeff j (-l) = 0) := by
@@ -329,7 +331,7 @@ lemma chainBotCoeff_mul_chainTopCoeff :
       (P.chainTopCoeff j l + 1) * (P.chainBotCoeff i k + 1) := by
   /- Setup some typeclasses. -/
   have := chainBotCoeff_mul_chainTopCoeff.isNotG2 hi hj hij h₁ h₂ h₃
-  have _i := P.reflexive_left
+  have : Module.IsReflexive R M := .of_isPerfPair P.toLinearMap
   letI := P.indexNeg
   suffices (P.chainBotCoeff i m + 1) * (P.chainBotCoeff j (-k) + 1) =
       (P.chainBotCoeff j (-l) + 1) * (P.chainBotCoeff i k + 1) by simpa

--- a/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Lemmas.lean
@@ -124,7 +124,8 @@ variable [P.IsReduced] [P.IsIrreducible]
 include hi hj hij h₁ h₂ h₃
 
 lemma chainBotCoeff_mul_chainTopCoeff.isNotG2 : P.IsNotG2 := by
-  have _i : NoZeroSMulDivisors ℤ M := have _i := P.reflexive_left; .int_of_charZero R M
+  have : Module.IsReflexive R M := .of_isPerfPair P.toLinearMap
+  have : NoZeroSMulDivisors ℤ M := .int_of_charZero R M
   rw [← P.not_isG2_iff_isNotG2]
   intro contra
   obtain ⟨n, h₃⟩ := h₃

--- a/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Relations.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Relations.lean
@@ -133,8 +133,9 @@ private lemma lie_e_f_same_aux (k : ι) (hki : k ≠ i) (hki' : k ≠ P.reflecti
 /-- Lemma 3.4 from [Geck](Geck2017). -/
 lemma lie_e_f_same :
     ⁅e i, f i⁆ = h i := by
-  letI _i := P.indexNeg
-  have _i : NoZeroSMulDivisors ℤ M := have := P.reflexive_left; .int_of_charZero R M
+  letI := P.indexNeg
+  have : Module.IsReflexive R M := .of_isPerfPair P.toLinearMap
+  have : NoZeroSMulDivisors ℤ M := .int_of_charZero R M
   classical
   ext (k | k) (l | l)
   · simp [e, f, h]

--- a/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Semisimple.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Semisimple.lean
@@ -41,8 +41,9 @@ private lemma isNilpotent_e_aux {j : ι} (n : ℕ) (h : letI _i := P.indexNeg; j
     (e i ^ n).col (.inr j) = 0 ∨
       ∃ (k : ι) (x : ℕ), P.root k = P.root j + n • P.root i ∧
         (e i ^ n).col (.inr j) = x • Pi.single (.inr k) 1 := by
-  have _i : NoZeroSMulDivisors ℤ M := by have := P.reflexive_left; exact .int_of_charZero R M
-  letI _i := P.indexNeg
+  have : Module.IsReflexive R M := .of_isPerfPair P.toLinearMap
+  have : NoZeroSMulDivisors ℤ M := .int_of_charZero R M
+  letI := P.indexNeg
   have aux (n : ℕ) : (e i ^ (n + 1)).col (.inr j) = (e i).mulVec ((e i ^ n).col (.inr j)) := by
     rw [pow_succ', ← Matrix.mulVec_single_one, ← Matrix.mulVec_mulVec]; simp
   induction n with
@@ -86,8 +87,9 @@ private lemma isNilpotent_e_aux {j : ι} (n : ℕ) (h : letI _i := P.indexNeg; j
 lemma isNilpotent_e :
     IsNilpotent (e i) := by
   classical
-  have _i : NoZeroSMulDivisors ℤ M := by have := P.reflexive_left; exact .int_of_charZero R M
-  letI _i := P.indexNeg
+  have : Module.IsReflexive R M := .of_isPerfPair P.toLinearMap
+  have : NoZeroSMulDivisors ℤ M := .int_of_charZero R M
+  letI := P.indexNeg
   rw [Matrix.isNilpotent_iff_forall_col]
   have case_inl (j : b.support) : (e i ^ 2).col (Sum.inl j) = 0 := by
     ext (k | k)

--- a/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
@@ -107,8 +107,8 @@ def toRootSystem [Nonempty ι] [NeZero (2 : R)] [P.IsIrreducible] : RootSystem �
 
 lemma invtSubmodule_reflection_of_invtSubmodule_coreflection (i : ι) (q : Submodule R N)
     (hq : q ∈ invtSubmodule (P.coreflection i)) :
-    q.dualAnnihilator.map P.toDualLeft.symm ∈ invtSubmodule (P.reflection i) := by
-  rw [LinearEquiv.map_mem_invtSubmodule_iff, LinearEquiv.symm_symm, toDualLeft_conj_reflection,
+    q.dualAnnihilator.map P.toPerfPair.symm ∈ invtSubmodule (P.reflection i) := by
+  rw [LinearEquiv.map_mem_invtSubmodule_iff, LinearEquiv.symm_symm, toPerfPair_conj_reflection,
     Module.End.mem_invtSubmodule, ← Submodule.map_le_iff_le_comap]
   exact (Submodule.dualAnnihilator_map_dualMap_le _ _).trans <| Submodule.dualAnnihilator_anti hq
 
@@ -119,10 +119,10 @@ lemma IsIrreducible.mk' {K : Type*} [Field K] [Module K M] [Module K N] [Nontriv
     (h : ∀ (q : Submodule K M), (∀ i, q ∈ invtSubmodule (P.reflection i)) → q ≠ ⊥ → q = ⊤) :
     P.IsIrreducible where
   nontrivial := inferInstance
-  nontrivial' := (Module.nontrivial_dual_iff K).mp P.toDualLeft.symm.nontrivial
+  nontrivial' := (Module.nontrivial_dual_iff K).mp P.toPerfPair.symm.nontrivial
   eq_top_of_invtSubmodule_reflection := h
   eq_top_of_invtSubmodule_coreflection q stab ne_bot := by
-    specialize h (q.dualAnnihilator.map P.toDualLeft.symm)
+    specialize h (q.dualAnnihilator.map P.toPerfPair.symm)
       fun i ↦ invtSubmodule_reflection_of_invtSubmodule_coreflection P i q (stab i)
     rw [Submodule.map_eq_top_iff, not_imp_comm] at h
     replace ne_bot : q.dualAnnihilator ≠ ⊤ := by simpa

--- a/Mathlib/LinearAlgebra/RootSystem/IsValuedIn.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/IsValuedIn.lean
@@ -278,8 +278,8 @@ lemma iInf_ker_coroot'_eq :
     (P.rootSpan R).map P.toPerfPair = span R (range P.root') := by
   rw [rootSpan, Submodule.map_span, ← image_univ, ← image_comp, image_univ, toPerfPair_comp_root]
 
-@[simp] lemma corootSpan_map_flip.toPerfPair :
-    (P.corootSpan R).map P.flip.toPerfPair = span R (range P.coroot') :=
+@[simp] lemma corootSpan_map_flip_toPerfPair :
+    (P.corootSpan R).map P.toLinearMap.flip.toPerfPair = span R (range P.coroot') :=
   P.flip.rootSpan_map_toPerfPair
 
 @[simp] lemma span_root'_eq_top (P : RootSystem ι R M N) :

--- a/Mathlib/LinearAlgebra/RootSystem/IsValuedIn.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/IsValuedIn.lean
@@ -249,25 +249,20 @@ lemma corootSpan_mem_invtSubmodule_coreflection (i : ι) :
   P.flip.rootSpan_mem_invtSubmodule_reflection i
 
 lemma rootSpan_dualAnnihilator_map_eq_iInf_ker_root' :
-    (P.rootSpan R).dualAnnihilator.map P.toDualRight.symm = ⨅ i, LinearMap.ker (P.root' i) := by
-  suffices (P.rootSpan R).dualAnnihilator.map P.toDualRight.symm = {x | ∀ i, P.root' i x = 0} from
-    SetLike.coe_injective <| by ext; simp [this]
-  ext x
-  rw [rootSpan, Submodule.map_coe, Submodule.coe_dualAnnihilator_span,
-    ← LinearEquiv.coe_symm_toEquiv, ← Equiv.setOf_apply_symm_eq_image_setOf, Equiv.symm_symm]
-  simp [Set.range_subset_iff]
+    (P.rootSpan R).dualAnnihilator.map P.flip.toPerfPair.symm = ⨅ i, LinearMap.ker (P.root' i) :=
+  SetLike.coe_injective <| by ext; simp [LinearEquiv.symm_apply_eq, subset_def]
 
 lemma corootSpan_dualAnnihilator_map_eq_iInf_ker_coroot' :
-    (P.corootSpan R).dualAnnihilator.map P.toDualLeft.symm = ⨅ i, LinearMap.ker (P.coroot' i) :=
+    (P.corootSpan R).dualAnnihilator.map P.toPerfPair.symm = ⨅ i, LinearMap.ker (P.coroot' i) :=
   P.flip.rootSpan_dualAnnihilator_map_eq_iInf_ker_root'
 
 lemma rootSpan_dualAnnihilator_map_eq :
-    (P.rootSpan R).dualAnnihilator.map P.toDualRight.symm =
+    (P.rootSpan R).dualAnnihilator.map P.flip.toPerfPair.symm =
       (span R (range P.root')).dualCoannihilator :=
-  SetLike.coe_injective <| by ext; simp [P.rootSpan_dualAnnihilator_map_eq_iInf_ker_root']
+  SetLike.coe_injective <| by ext; simp [LinearEquiv.symm_apply_eq, subset_def]
 
 lemma corootSpan_dualAnnihilator_map_eq :
-    (P.corootSpan R).dualAnnihilator.map P.toDualLeft.symm =
+    (P.corootSpan R).dualAnnihilator.map P.toPerfPair.symm =
       (span R (range P.coroot')).dualCoannihilator :=
   P.flip.rootSpan_dualAnnihilator_map_eq
 
@@ -279,17 +274,17 @@ lemma iInf_ker_coroot'_eq :
     ⨅ i, LinearMap.ker (P.coroot' i) = (span R (range P.coroot')).dualCoannihilator :=
   P.flip.iInf_ker_root'_eq
 
-@[simp] lemma rootSpan_map_toDualLeft :
-    (P.rootSpan R).map P.toDualLeft = span R (range P.root') := by
-  rw [rootSpan, Submodule.map_span, ← image_univ, ← image_comp, image_univ, toDualLeft_comp_root]
+@[simp] lemma rootSpan_map_toPerfPair :
+    (P.rootSpan R).map P.toPerfPair = span R (range P.root') := by
+  rw [rootSpan, Submodule.map_span, ← image_univ, ← image_comp, image_univ, toPerfPair_comp_root]
 
-@[simp] lemma corootSpan_map_toDualRight :
-    (P.corootSpan R).map P.toDualRight = span R (range P.coroot') :=
-  P.flip.rootSpan_map_toDualLeft
+@[simp] lemma corootSpan_map_flip.toPerfPair :
+    (P.corootSpan R).map P.flip.toPerfPair = span R (range P.coroot') :=
+  P.flip.rootSpan_map_toPerfPair
 
 @[simp] lemma span_root'_eq_top (P : RootSystem ι R M N) :
     span R (range P.root') = ⊤ := by
-  simp [← rootSpan_map_toDualLeft]
+  simp [← rootSpan_map_toPerfPair]
 
 @[simp] lemma span_coroot'_eq_top (P : RootSystem ι R M N) :
     span R (range P.coroot') = ⊤ :=

--- a/Mathlib/LinearAlgebra/RootSystem/OfBilinear.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/OfBilinear.lean
@@ -112,7 +112,7 @@ open LinearMap IsReflective
 def ofBilinear [IsReflexive R M] (B : M →ₗ[R] M →ₗ[R] R) (hNB : LinearMap.Nondegenerate B)
     (hSB : LinearMap.IsSymm B) (h2 : IsRegular (2 : R)) :
     RootPairing {x : M | IsReflective B x} R M (Dual R M) where
-  toLinearMap := LinearMap.id.flip
+  toLinearMap := Dual.eval R M
   root := Embedding.subtype fun x ↦ IsReflective B x
   coroot :=
     { toFun := fun x => IsReflective.coroot B x.2
@@ -158,8 +158,8 @@ def ofBilinear [IsReflexive R M] (B : M →ₗ[R] M →ₗ[R] R) (hNB : LinearMa
   reflectionPerm_root x y := by
     simp [Module.reflection_apply]
   reflectionPerm_coroot x y := by
-    simp only [coe_setOf, mem_setOf_eq, Embedding.coeFn_mk, Embedding.subtype_apply, flip_apply,
-      id_coe, id_eq, Equiv.coe_fn_mk]
+    simp only [coe_setOf, mem_setOf_eq, Embedding.coeFn_mk, Embedding.subtype_apply,
+      Dual.eval_apply, Equiv.coe_fn_mk]
     ext z
     simp only [sub_apply, smul_apply, smul_eq_mul]
     refine y.2.1.1 ?_

--- a/Mathlib/LinearAlgebra/RootSystem/OfBilinear.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/OfBilinear.lean
@@ -112,7 +112,7 @@ open LinearMap IsReflective
 def ofBilinear [IsReflexive R M] (B : M →ₗ[R] M →ₗ[R] R) (hNB : LinearMap.Nondegenerate B)
     (hSB : LinearMap.IsSymm B) (h2 : IsRegular (2 : R)) :
     RootPairing {x : M | IsReflective B x} R M (Dual R M) where
-  toPerfectPairing := (IsReflexive.toPerfectPairingDual (R := R) (M := M)).flip
+  toLinearMap := LinearMap.id.flip
   root := Embedding.subtype fun x ↦ IsReflective B x
   coroot :=
     { toFun := fun x => IsReflective.coroot B x.2
@@ -143,11 +143,7 @@ def ofBilinear [IsReflexive R M] (B : M →ₗ[R] M →ₗ[R] R) (hNB : LinearMa
         refine h2.1 ?_
         dsimp only
         rw [h2x z, ← h2y z, hxy, h2xy] }
-  root_coroot_two x := by
-    dsimp only [coe_setOf, Embedding.coe_subtype, PerfectPairing.toLinearMap_apply, mem_setOf_eq,
-      id_eq, eq_mp_eq_cast, RingHom.id_apply, eq_mpr_eq_cast, cast_eq, LinearMap.sub_apply,
-      Embedding.coeFn_mk, PerfectPairing.flip_apply_apply]
-    exact coroot_apply_self B x.2
+  root_coroot_two x := coroot_apply_self B x.2
   reflectionPerm x :=
     { toFun := fun y => ⟨(Module.reflection (coroot_apply_self B x.2) y),
         reflective_reflection B hSB x.2 y.2⟩
@@ -162,8 +158,8 @@ def ofBilinear [IsReflexive R M] (B : M →ₗ[R] M →ₗ[R] R) (hNB : LinearMa
   reflectionPerm_root x y := by
     simp [Module.reflection_apply]
   reflectionPerm_coroot x y := by
-    simp only [coe_setOf, mem_setOf_eq, Embedding.coeFn_mk, Embedding.subtype_apply,
-      PerfectPairing.flip_apply_apply, IsReflexive.toPerfectPairingDual_toFun, Equiv.coe_fn_mk]
+    simp only [coe_setOf, mem_setOf_eq, Embedding.coeFn_mk, Embedding.subtype_apply, flip_apply,
+      id_coe, id_eq, Equiv.coe_fn_mk]
     ext z
     simp only [sub_apply, smul_apply, smul_eq_mul]
     refine y.2.1.1 ?_

--- a/Mathlib/LinearAlgebra/RootSystem/Reduced.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Reduced.lean
@@ -110,14 +110,14 @@ lemma linearIndependent_of_sub_mem_range_root
 lemma linearIndependent_of_add_mem_range_root' [CharZero R] [IsDomain R] [P.IsReduced] {i j : ι}
     (h : P.root i + P.root j ∈ range P.root) :
     LinearIndependent R ![P.root i, P.root j] :=
-  have _i := P.reflexive_left
+  have : IsReflexive R M := .of_isPerfPair P.toLinearMap
   have _i : NoZeroSMulDivisors ℤ M := NoZeroSMulDivisors.int_of_charZero R M
   P.linearIndependent_of_add_mem_range_root h
 
 lemma linearIndependent_of_sub_mem_range_root' [CharZero R] [IsDomain R] [P.IsReduced] {i j : ι}
     (h : P.root i - P.root j ∈ range P.root) :
     LinearIndependent R ![P.root i, P.root j] :=
-  have _i := P.reflexive_left
+  have : IsReflexive R M := .of_isPerfPair P.toLinearMap
   have _i : NoZeroSMulDivisors ℤ M := NoZeroSMulDivisors.int_of_charZero R M
   P.linearIndependent_of_sub_mem_range_root h
 


### PR DESCRIPTION
Redefine perfect pairings using a Prop-valued typeclass `IsPerfPair` on a bilinear pairing `p : M →ₗ[R] N →ₗ[R] R`, and a function to turn `p : M →ₗ[R] N →ₗ[R] R` + `p.IsPerfPair` into `M ≃ₗ[R] Dual R N`.

The name `IsPerfPair` is kept short because it shows up in lemma and definition names.

From Toric

---


@ocfnash, do you like the direction this is going in?

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
