### PR TITLE
[Merged by Bors] - chore: move pointed cones, proper cones

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1482,11 +1482,10 @@ import Mathlib.Analysis.Convex.Birkhoff
 import Mathlib.Analysis.Convex.Body
 import Mathlib.Analysis.Convex.Caratheodory
 import Mathlib.Analysis.Convex.Combination
+import Mathlib.Analysis.Convex.Cone.Basic
 import Mathlib.Analysis.Convex.Cone.Closure
 import Mathlib.Analysis.Convex.Cone.Extension
 import Mathlib.Analysis.Convex.Cone.InnerDual
-import Mathlib.Analysis.Convex.Cone.Pointed
-import Mathlib.Analysis.Convex.Cone.Proper
 import Mathlib.Analysis.Convex.Continuous
 import Mathlib.Analysis.Convex.Contractible
 import Mathlib.Analysis.Convex.Deriv
@@ -3562,6 +3561,7 @@ import Mathlib.FieldTheory.SplittingField.Construction
 import Mathlib.FieldTheory.SplittingField.IsSplittingField
 import Mathlib.FieldTheory.Tower
 import Mathlib.Geometry.Convex.Cone.Basic
+import Mathlib.Geometry.Convex.Cone.Pointed
 import Mathlib.Geometry.Euclidean.Altitude
 import Mathlib.Geometry.Euclidean.Angle.Oriented.Affine
 import Mathlib.Geometry.Euclidean.Angle.Oriented.Basic

--- a/Mathlib/Analysis/Convex/Cone/Closure.lean
+++ b/Mathlib/Analysis/Convex/Cone/Closure.lean
@@ -3,7 +3,9 @@ Copyright (c) 2023 Apurva Nakade. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Apurva Nakade
 -/
-import Mathlib.Analysis.Convex.Cone.Pointed
+import Mathlib.Geometry.Convex.Cone.Pointed
+import Mathlib.Topology.Algebra.ConstMulAction
+import Mathlib.Topology.Algebra.Monoid.Defs
 
 /-!
 # Closure of cones

--- a/Mathlib/Analysis/Convex/Cone/InnerDual.lean
+++ b/Mathlib/Analysis/Convex/Cone/InnerDual.lean
@@ -3,8 +3,9 @@ Copyright (c) 2021 Alexander Bentkamp. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alexander Bentkamp
 -/
+import Mathlib.Analysis.Convex.Cone.Basic
+import Mathlib.Analysis.InnerProductSpace.Adjoint
 import Mathlib.Analysis.InnerProductSpace.Projection
-import Mathlib.Geometry.Convex.Cone.Basic
 
 /-!
 # Convex cones in inner product spaces
@@ -140,6 +141,37 @@ theorem ConvexCone.pointed_of_nonempty_of_isClosed (K : ConvexCone ℝ H) (ne : 
   have f₀ : f 0 = 0 := zero_smul ℝ x
   simpa only [f₀, ConvexCone.Pointed, ← SetLike.mem_coe] using mem_of_subset_of_mem clf mem₀
 
+namespace PointedCone
+
+/-- The inner dual cone of a pointed cone is a pointed cone. -/
+def dual (C : PointedCone ℝ H) : PointedCone ℝ H :=
+  ((C : Set H).innerDualCone).toPointedCone <| pointed_innerDualCone (C : Set H)
+
+@[simp, norm_cast]
+lemma toConvexCone_dual (C : PointedCone ℝ H) : ↑(dual C) = (C : Set H).innerDualCone := rfl
+
+open InnerProductSpace in
+@[simp]
+lemma mem_dual {C : PointedCone ℝ H} {y : H} : y ∈ dual C ↔ ∀ ⦃x⦄, x ∈ C → 0 ≤ ⟪x, y⟫_ℝ := .rfl
+
+end PointedCone
+
+namespace ProperCone
+
+/-- The inner dual cone of a proper cone is a proper cone. -/
+def dual (C : ProperCone ℝ H) : ProperCone ℝ H where
+  toSubmodule := PointedCone.dual (C : PointedCone ℝ H)
+  isClosed' := isClosed_innerDualCone _
+
+@[simp, norm_cast]
+lemma coe_dual (C : ProperCone ℝ H) : C.dual = (C : Set H).innerDualCone := rfl
+
+open scoped InnerProductSpace in
+@[simp]
+lemma mem_dual {C : ProperCone ℝ H} {y : H} : y ∈ dual C ↔ ∀ ⦃x⦄, x ∈ C → 0 ≤ ⟪x, y⟫_ℝ := .rfl
+
+end ProperCone
+
 section CompleteSpace
 
 variable [CompleteSpace H]
@@ -195,6 +227,63 @@ theorem ConvexCone.innerDualCone_of_innerDualCone_eq_self (K : ConvexCone ℝ H)
   · rintro hxK y h
     specialize h x hxK
     rwa [real_inner_comm]
+
+namespace ProperCone
+variable {F : Type*} [NormedAddCommGroup F] [InnerProductSpace ℝ F]
+
+/-- The dual of the dual of a proper cone is itself. -/
+@[simp]
+theorem dual_dual (K : ProperCone ℝ H) : K.dual.dual = K :=
+  ProperCone.toPointedCone_injective <| PointedCone.toConvexCone_injective <|
+    (K : ConvexCone ℝ H).innerDualCone_of_innerDualCone_eq_self K.nonempty K.isClosed
+
+/-- This is a relative version of
+`ConvexCone.hyperplane_separation_of_nonempty_of_isClosed_of_notMem`, which we recover by setting
+`f` to be the identity map. This is also a geometric interpretation of the Farkas' lemma
+stated using proper cones. -/
+theorem hyperplane_separation (K : ProperCone ℝ H) {f : H →L[ℝ] F} {b : F} :
+    b ∈ K.map f ↔ ∀ y : F, f.adjoint y ∈ K.dual → 0 ≤ ⟪y, b⟫_ℝ where
+  mp := by
+    -- suppose `b ∈ K.map f`
+    simp_rw [mem_map, PointedCone.mem_closure, PointedCone.coe_map, coe_coe,
+      mem_closure_iff_seq_limit, mem_image, SetLike.mem_coe, mem_coe, mem_dual,
+      adjoint_inner_right, forall_exists_index, and_imp]
+    -- there is a sequence `seq : ℕ → F` in the image of `f` that converges to `b`
+    rintro seq hmem htends y hinner
+    suffices h : ∀ n, 0 ≤ ⟪y, seq n⟫_ℝ from
+      ge_of_tendsto' (Continuous.seqContinuous (Continuous.inner (@continuous_const _ _ _ _ y)
+        continuous_id) htends) h
+    intro n
+    obtain ⟨_, h, hseq⟩ := hmem n
+    simpa only [← hseq, real_inner_comm] using hinner h
+  mpr := by
+    -- proof by contradiction
+    -- suppose `b ∉ K.map f`
+    intro h
+    contrapose! h
+    -- as `b ∉ K.map f`, there is a hyperplane `y` separating `b` from `K.map f`
+    let C := PointedCone.toConvexCone (𝕜 := ℝ) (E := F) (K.map f)
+    obtain ⟨y, hxy, hyb⟩ :=
+      @ConvexCone.hyperplane_separation_of_nonempty_of_isClosed_of_notMem
+      _ _ _ _ C (K.map f).nonempty (K.map f).isClosed b h
+    -- the rest of the proof is a straightforward algebraic manipulation
+    refine ⟨y, ?_, hyb⟩
+    simp_rw [ProperCone.mem_dual, adjoint_inner_right]
+    intro x hxK
+    apply hxy (f x)
+    simp_rw [C, coe_map]
+    apply subset_closure
+    simp_rw [PointedCone.toConvexCone_map, ConvexCone.coe_map, coe_coe, mem_image, SetLike.mem_coe]
+    exact ⟨x, hxK, rfl⟩
+
+theorem hyperplane_separation_of_notMem (K : ProperCone ℝ E) {f : E →L[ℝ] F} {b : F}
+    (disj : b ∉ K.map f) : ∃ y : F, adjoint f y ∈ K.dual ∧ ⟪y, b⟫_ℝ < 0 := by
+  contrapose! disj; rwa [K.hyperplane_separation]
+
+@[deprecated (since := "2025-05-24")]
+alias hyperplane_separation_of_nmem := hyperplane_separation_of_notMem
+
+end ProperCone
 
 end CompleteSpace
 

--- a/Mathlib/Analysis/Convex/Cone/InnerDual.lean
+++ b/Mathlib/Analysis/Convex/Cone/InnerDual.lean
@@ -237,6 +237,10 @@ theorem dual_dual (K : ProperCone ℝ H) : K.dual.dual = K :=
   ProperCone.toPointedCone_injective <| PointedCone.toConvexCone_injective <|
     (K : ConvexCone ℝ H).innerDualCone_of_innerDualCone_eq_self K.nonempty K.isClosed
 
+variable [CompleteSpace F]
+
+open scoped InnerProductSpace
+
 /-- This is a relative version of
 `ConvexCone.hyperplane_separation_of_nonempty_of_isClosed_of_notMem`, which we recover by setting
 `f` to be the identity map. This is also a geometric interpretation of the Farkas' lemma
@@ -245,9 +249,9 @@ theorem hyperplane_separation (K : ProperCone ℝ H) {f : H →L[ℝ] F} {b : F}
     b ∈ K.map f ↔ ∀ y : F, f.adjoint y ∈ K.dual → 0 ≤ ⟪y, b⟫_ℝ where
   mp := by
     -- suppose `b ∈ K.map f`
-    simp_rw [mem_map, PointedCone.mem_closure, PointedCone.coe_map, coe_coe,
+    simp only [mem_map, PointedCone.mem_closure, PointedCone.coe_map, ContinuousLinearMap.coe_coe,
       mem_closure_iff_seq_limit, mem_image, SetLike.mem_coe, mem_coe, mem_dual,
-      adjoint_inner_right, forall_exists_index, and_imp]
+      ContinuousLinearMap.adjoint_inner_right, forall_exists_index, and_imp]
     -- there is a sequence `seq : ℕ → F` in the image of `f` that converges to `b`
     rintro seq hmem htends y hinner
     suffices h : ∀ n, 0 ≤ ⟪y, seq n⟫_ℝ from
@@ -268,16 +272,12 @@ theorem hyperplane_separation (K : ProperCone ℝ H) {f : H →L[ℝ] F} {b : F}
       _ _ _ _ C (K.map f).nonempty (K.map f).isClosed b h
     -- the rest of the proof is a straightforward algebraic manipulation
     refine ⟨y, ?_, hyb⟩
-    simp_rw [ProperCone.mem_dual, adjoint_inner_right]
+    simp only [mem_dual, ContinuousLinearMap.adjoint_inner_right]
     intro x hxK
-    apply hxy (f x)
-    simp_rw [C, coe_map]
-    apply subset_closure
-    simp_rw [PointedCone.toConvexCone_map, ConvexCone.coe_map, coe_coe, mem_image, SetLike.mem_coe]
-    exact ⟨x, hxK, rfl⟩
+    exact hxy (f x) <| subset_closure <| Set.mem_image_of_mem _ hxK
 
-theorem hyperplane_separation_of_notMem (K : ProperCone ℝ E) {f : E →L[ℝ] F} {b : F}
-    (disj : b ∉ K.map f) : ∃ y : F, adjoint f y ∈ K.dual ∧ ⟪y, b⟫_ℝ < 0 := by
+theorem hyperplane_separation_of_notMem (K : ProperCone ℝ H) {f : H →L[ℝ] F} {b : F}
+    (disj : b ∉ K.map f) : ∃ y : F, ContinuousLinearMap.adjoint f y ∈ K.dual ∧ ⟪y, b⟫_ℝ < 0 := by
   contrapose! disj; rwa [K.hyperplane_separation]
 
 @[deprecated (since := "2025-05-24")]

--- a/Mathlib/Analysis/Convex/Cone/README.md
+++ b/Mathlib/Analysis/Convex/Cone/README.md
@@ -1,12 +1,15 @@
-# Theory of convex cones in normed spaces
+# Topological and analytic theory of convex cones
 
-This subfolder is destined to contain results about convex cones that require a norm or an inner product.
+This subfolder is destined to contain results about convex cones that require a topology, a norm or
+an inner product.
 
-See the `Mathlib.Geometry.Convex.Cone` folder for the results that do not need a norm nor an inner product.
+See the `Mathlib.Geometry.Convex.Cone` folder for the purely algebraic theory of convex cones.
 
 ## Topics
 
 The convex cone topics currently covered are:
+* Proper cone
+* Dual cone along a continuous bilinear pairing
 * Inner dual cone
 * Farkas' lemma, Hahn-Banach separation, hyperplane separation, double dual of a proper cone
 * M. Riesz extension theorem

--- a/Mathlib/Geometry/Convex/Cone/Basic.lean
+++ b/Mathlib/Geometry/Convex/Cone/Basic.lean
@@ -36,8 +36,7 @@ While `Convex 𝕜` is a predicate on sets, `ConvexCone 𝕜 E` is a bundled con
 * [Emo Welzl and Bernd Gärtner, *Cone Programming*][welzl_garter]
 -/
 
-
-assert_not_exists NormedSpace Real Cardinal
+assert_not_exists TopologicalSpace Real Cardinal
 
 open Set LinearMap Pointwise
 

--- a/Mathlib/Geometry/Convex/Cone/Pointed.lean
+++ b/Mathlib/Geometry/Convex/Cone/Pointed.lean
@@ -3,9 +3,8 @@ Copyright (c) 2023 Apurva Nakade. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Apurva Nakade
 -/
-import Mathlib.Analysis.Convex.Cone.InnerDual
 import Mathlib.Algebra.Order.Nonneg.Module
-import Mathlib.Algebra.Module.Submodule.Basic
+import Mathlib.Geometry.Convex.Cone.Basic
 
 /-!
 # Pointed cones
@@ -16,6 +15,8 @@ contains `0`. This is a bundled version of `ConvexCone.Pointed`. We choose the s
 as it allows us to use the `Module` API to work with convex cones.
 
 -/
+
+assert_not_exists TopologicalSpace
 
 variable {𝕜 E F G : Type*}
 
@@ -175,23 +176,4 @@ theorem toConvexCone_positive : ↑(positive 𝕜 E) = ConvexCone.positive 𝕜 
   rfl
 
 end PositiveCone
-section Dual
-
-variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
-
-/-- The inner dual cone of a pointed cone is a pointed cone. -/
-def dual (S : PointedCone ℝ E) : PointedCone ℝ E :=
-  ((S : Set E).innerDualCone).toPointedCone <| pointed_innerDualCone (S : Set E)
-
-@[simp, norm_cast]
-theorem toConvexCone_dual (S : PointedCone ℝ E) : ↑(dual S) = (S : Set E).innerDualCone :=
-  rfl
-
-open scoped InnerProductSpace in
-@[simp]
-theorem mem_dual {S : PointedCone ℝ E} {y : E} : y ∈ dual S ↔ ∀ ⦃x⦄, x ∈ S → 0 ≤ ⟪x, y⟫_ℝ := by
-  rfl
-
-end Dual
-
 end PointedCone

--- a/Mathlib/Geometry/Convex/Cone/README.md
+++ b/Mathlib/Geometry/Convex/Cone/README.md
@@ -1,10 +1,12 @@
-# Theory of convex cones in topological modules
+# Algebraic theory of convex cones
 
-This subfolder is destined to contain results about convex cones that do not require a norm nor an inner product.
+This subfolder is destined to contain results about convex cones that do not require a topology,
+a norm nor an inner product.
 
-See the `Mathlib.Analysis.Convex.Cone` folder for the results that need a norm or an inner product.
+See the `Mathlib.Analysis.Convex.Cone` folder for the topological results.
 
 ## Topics
 
 The convex cone topics currently covered are:
 * Convex cones
+* Pointed cones


### PR DESCRIPTION
Pointed cones too are a kind of algebraic cone. They therefore move to the new `Geometry.Convex.Cone` folder.

In turn, this makes proper cones the primitive kind of topological/analytic cones, and therefore `Analysis.Convex.Cone.Proper` gets renamed to `Analysis.Convex.Cone.Basic`.

The two sections about dual pointed cones and dual proper cones move to the existing `Analysis.Convex.Cone.InnerDual`.

The READMEs about `Geometry.Convex.Cone` and `Analysis.Convex.Cone` get updated to reflect that the separation is non-topology vs topology, rather topology vs analysis.

From Toric

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
