### PR TITLE
[Merged by Bors] - feat(Mathlib/Algebra/Polynomial/Degree/Domain.lean): generalize `natDegree_smul` from `SMulWithZero` to `SMulZeroClass`

### DIFF
--- a/Mathlib/Algebra/Polynomial/Degree/Domain.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Domain.lean
@@ -42,14 +42,15 @@ lemma natDegree_mul (hp : p ≠ 0) (hq : q ≠ 0) : (p*q).natDegree = p.natDegre
 
 omit [NoZeroDivisors R] in
 variable (p) in
-lemma natDegree_smul {R' : Type*} [Zero R'] [SMulWithZero R' R] [NoZeroSMulDivisors R' R] {a : R'}
+lemma natDegree_smul {S : Type*} [Zero S] [SMulZeroClass S R] [NoZeroSMulDivisors S R] {a : S}
     (ha : a ≠ 0) : (a • p).natDegree = p.natDegree := by
   by_cases hp : p = 0
   · simp only [hp, smul_zero]
   · apply natDegree_eq_of_le_of_coeff_ne_zero
     · exact (natDegree_smul_le _ _).trans (le_refl _)
-    · simpa only [coeff_smul, coeff_natDegree, ne_eq, smul_eq_zero,
-        leadingCoeff_eq_zero, not_or] using ⟨ha, hp⟩
+    · simp
+      apply not_imp_not.mpr eq_zero_or_eq_zero_of_smul_eq_zero
+      simp [ha, hp]
 
 @[simp]
 lemma natDegree_pow (p : R[X]) (n : ℕ) : natDegree (p ^ n) = n * natDegree p := by

--- a/Mathlib/Algebra/Polynomial/Degree/Domain.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Domain.lean
@@ -48,9 +48,9 @@ lemma natDegree_smul {S : Type*} [Zero S] [SMulZeroClass S R] [NoZeroSMulDivisor
   · simp only [hp, smul_zero]
   · apply natDegree_eq_of_le_of_coeff_ne_zero
     · exact (natDegree_smul_le _ _).trans (le_refl _)
-    · simp
-      apply not_imp_not.mpr eq_zero_or_eq_zero_of_smul_eq_zero
-      simp [ha, hp]
+    · simp only [coeff_smul]
+      apply smul_ne_zero ha
+      simp [hp]
 
 @[simp]
 lemma natDegree_pow (p : R[X]) (n : ℕ) : natDegree (p ^ n) = n * natDegree p := by


### PR DESCRIPTION
as suggested by @eric-wieser in https://github.com/leanprover-community/mathlib4/pull/25237#discussion_r2111599865


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
