### PR TITLE
[Merged by Bors] - chore: add missing deprecations

### DIFF
--- a/Mathlib/AlgebraicGeometry/IdealSheaf/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/IdealSheaf/Basic.lean
@@ -505,6 +505,9 @@ lemma le_support_iff_le_vanishingIdeal {I : X.IdealSheafData} {Z : Closeds X} :
     Set.image_preimage_eq_inter_range, IsAffineOpen.fromSpec_image_zeroLocus,
     IsAffineOpen.range_fromSpec]
 
+@[deprecated (since := "2025-05-16")]
+alias subset_support_iff_le_vanishingIdeal := le_support_iff_le_vanishingIdeal
+
 /-- `support` and `vanishingIdeal` forms a galois connection.
 This is the global version of `PrimeSpectrum.gc`. -/
 lemma gc : @GaloisConnection X.IdealSheafData (Closeds X)ᵒᵈ _ _ (support ·) (vanishingIdeal ·) :=

--- a/Mathlib/Analysis/SpecialFunctions/Complex/LogBounds.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/LogBounds.lean
@@ -372,6 +372,16 @@ lemma tendsto_mul_log_one_add_of_tendsto {g : ℝ → ℝ} {t : ℝ}
   filter_upwards [hg0.eventually_const_le (show (-1 : ℝ) < 0 by norm_num)] with x hg1
   rw [Complex.ofReal_log (by linarith), Complex.ofReal_add, Complex.ofReal_one]
 
+theorem tendsto_mul_log_one_add_div_atTop (t : ℝ) :
+    Tendsto (fun x => x * log (1 + t / x)) atTop (𝓝 t) :=
+  tendsto_mul_log_one_add_of_tendsto <|
+    tendsto_const_nhds.congr' <|
+      (EventuallyEq.div_mul_cancel_atTop tendsto_id).symm.trans <|
+        .of_eq <| funext fun _ => mul_comm _ _
+
+@[deprecated (since := "2025-05-22")]
+alias tendsto_mul_log_one_plus_div_atTop := tendsto_mul_log_one_add_div_atTop
+
 /-- The limit of `(1 + g x) ^ x` as `(x : ℝ) → ∞` is `exp t`,
 where `t : ℝ` is the limit of `x * g x`. -/
 lemma tendsto_one_add_rpow_exp_of_tendsto {g : ℝ → ℝ} {t : ℝ}
@@ -393,6 +403,9 @@ lemma tendsto_one_add_div_rpow_exp (t : ℝ) :
   filter_upwards [eventually_ne_atTop 0] with x hx0
   exact mul_div_cancel₀ t (mod_cast hx0)
 
+@[deprecated (since := "2025-05-22")]
+alias tendsto_one_plus_div_rpow_exp := tendsto_one_add_div_rpow_exp
+
 /-- The limit of `n * log (1 + g n)` as `(n : ℝ) → ∞` is `t`,
 where `t : ℝ` is the limit of `n * g n`. -/
 lemma tendsto_nat_mul_log_one_add_of_tendsto {g : ℕ → ℝ} {t : ℝ}
@@ -413,6 +426,9 @@ lemma tendsto_one_add_pow_exp_of_tendsto {g : ℕ → ℝ} {t : ℝ}
 lemma tendsto_one_add_div_pow_exp (t : ℝ) :
     Tendsto (fun n : ℕ ↦ (1 + t / n) ^ n) atTop (𝓝 (exp t)) :=
   tendsto_one_add_div_rpow_exp t |>.comp tendsto_natCast_atTop_atTop |>.congr (by simp)
+
+@[deprecated (since := "2025-05-22")]
+alias tendsto_one_plus_div_pow_exp := tendsto_one_add_div_pow_exp
 
 end Real
 

--- a/Mathlib/Analysis/SpecialFunctions/MulExpNegMulSqIntegral.lean
+++ b/Mathlib/Analysis/SpecialFunctions/MulExpNegMulSqIntegral.lean
@@ -112,6 +112,9 @@ theorem tendsto_integral_mul_one_add_inv_smul_sq_pow (g : E →ᵇ ℝ) (hε : 0
     simp [mul_assoc, inv_mul_eq_div, ← neg_div]
     exact tendsto_one_add_div_pow_exp (-(ε * (g x * g x)))
 
+@[deprecated (since := "2025-05-22")]
+alias tendsto_integral_mul_one_plus_inv_smul_sq_pow := tendsto_integral_mul_one_add_inv_smul_sq_pow
+
 theorem integral_mulExpNegMulSq_comp_eq {P' : Measure E} [IsFiniteMeasure P']
     {A : Subalgebra ℝ (E →ᵇ ℝ)} (hε : 0 < ε)
     (heq : ∀ g ∈ A, ∫ x, (g : E → ℝ) x ∂P = ∫ x, (g : E → ℝ) x ∂P') {g : E →ᵇ ℝ} (hgA : g ∈ A) :

--- a/Mathlib/GroupTheory/Perm/Finite.lean
+++ b/Mathlib/GroupTheory/Perm/Finite.lean
@@ -221,6 +221,10 @@ theorem apply_mem_fixedPoints_iff_mem_of_mem_centralizer {g p : Perm α}
   simp only [Function.mem_fixedPoints_iff]
   rw [← mul_apply, ← hp, mul_apply, EmbeddingLike.apply_eq_iff_eq]
 
+@[deprecated (since := "2025-05-19")]
+alias mem_fixedPoints_iff_apply_mem_of_mem_centralizer :=
+  apply_mem_fixedPoints_iff_mem_of_mem_centralizer
+
 
 
 variable [DecidableEq α]

--- a/Mathlib/GroupTheory/Perm/Support.lean
+++ b/Mathlib/GroupTheory/Perm/Support.lean
@@ -658,6 +658,8 @@ theorem support_subtypePerm [DecidableEq α] {s : Finset α} (f : Perm α) (h) :
     (f.subtypePerm h : Perm s).support = ({x | f x ≠ x} : Finset s) := by
   ext; simp [Subtype.ext_iff]
 
+@[deprecated (since := "2025-05-19")] alias support_subtype_perm := support_subtypePerm
+
 end Equiv.Perm
 
 section FixedPoints

--- a/Mathlib/NumberTheory/NumberField/InfinitePlace/TotallyRealComplex.lean
+++ b/Mathlib/NumberTheory/NumberField/InfinitePlace/TotallyRealComplex.lean
@@ -58,6 +58,8 @@ theorem IsTotallyReal.of_algebra [IsTotallyReal K] [Algebra F K] : IsTotallyReal
     obtain ⟨W, rfl⟩ : ∃ W : InfinitePlace K, W.comap (algebraMap F K) = w := comap_surjective w
     exact IsReal.comap _ (IsTotallyReal.isReal W)
 
+@[deprecated (since := "2025-05-19")] alias IsTotally.of_algebra := IsTotallyReal.of_algebra
+
 instance [IsTotallyReal K] (F : IntermediateField ℚ K) : IsTotallyReal F :=
   IsTotallyReal.of_algebra F K
 

--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -1308,3 +1308,7 @@ lemma Ideal.exists_subset_radical_span_sup_of_subset_radical_sup {R : Type*} [Co
   choose m a b ha hb heq using hs
   refine ⟨a, by rwa [Set.range_subset_iff], fun z hz ↦ ⟨m ⟨z, hz⟩, heq ⟨z, hz⟩ ▸ ?_⟩⟩
   exact Ideal.add_mem _ (mem_sup_left (subset_span ⟨⟨z, hz⟩, rfl⟩)) (mem_sup_right <| hb _)
+
+@[deprecated (since := "2025-05-13")]
+alias Ideal.exists_subset_radical_span_sup_span_of_subset_radical_sup :=
+  Ideal.exists_subset_radical_span_sup_of_subset_radical_sup

--- a/Mathlib/RingTheory/MvPowerSeries/PiTopology.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/PiTopology.lean
@@ -150,6 +150,8 @@ theorem denseRange_toMvPowerSeries [CommSemiring R] :
   classical
   exact mem_closure_of_tendsto (tendsto_trunc'_atTop f) <| .of_forall fun _ ↦ Set.mem_range_self _
 
+@[deprecated (since := "2025-05-21")] alias toMvPowerSeries_denseRange := denseRange_toMvPowerSeries
+
 variable (σ R)
 
 /-- The semiring topology on `MvPowerSeries` of a topological semiring -/


### PR DESCRIPTION
From #23643, #23804, #24762, #24827, #24833, and #25016.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Maybe for some of those there could be reasons to argue that a deprecation is not terribly useful, but adding them is so cheap that I don't think it's worth spending much time arguing about it.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
