### PR TITLE
[Merged by Bors] - feat(Order/SupClosed): `compl_image_latticeClosure` and `compl_image_latticeClosure_eq_of_compl_image_eq_self`

### DIFF
--- a/Mathlib/Order/SupClosed.lean
+++ b/Mathlib/Order/SupClosed.lean
@@ -467,7 +467,8 @@ lemma latticeClosure_idem (s : Set α) : latticeClosure (latticeClosure s) = lat
 @[simp] lemma latticeClosure_singleton (a : α) : latticeClosure {a} = {a} := by simp
 @[simp] lemma latticeClosure_univ : latticeClosure (Set.univ : Set α) = Set.univ := by simp
 
-variable (s) in
+variable (s)
+
 lemma image_latticeClosure [Lattice β] {f : α → β}
     (map_sup : ∀ a₁ a₂ : α, f (a₁ ⊔ a₂) = f a₁ ⊔ f a₂)
     (map_inf : ∀ a₁ a₂ : α, f (a₁ ⊓ a₂) = f a₁ ⊓ f a₂) :
@@ -489,27 +490,19 @@ lemma image_latticeClosure [Lattice β] {f : α → β}
           fun _ ⟨c, hcs, hfc⟩ _ ⟨d, hds, hfd⟩ =>
             ⟨c ⊓ d, hfc ▸ hfd ▸ ⟨isSublattice_latticeClosure.infClosed hcs hds, map_inf c d⟩⟩⟩
 
-variable (s) in
+lemma preimage_ofDual_latticeClosure :
+    ofDual ⁻¹' latticeClosure s = latticeClosure (ofDual ⁻¹' s) := by
+  change ClosureOperator.ofCompletePred _ _ _ = ClosureOperator.ofCompletePred _ _ _
+  congr
+  ext
+  exact ⟨fun h => ⟨h.2, h.1⟩, fun h => ⟨h.2, h.1⟩⟩
+
 lemma image_latticeClosure_of_sup_inf [Lattice β] {f : α → β}
     (hf1 : ∀ a₁ a₂ : α, f (a₁ ⊔ a₂) = f a₁ ⊓ f a₂)
     (hf2 : ∀ a₁ a₂ : α, f (a₁ ⊓ a₂) = f a₁ ⊔ f a₂) :
     f '' latticeClosure s = latticeClosure (f '' s) := by
-  refine Set.eq_of_subset_of_subset ?_ ?_
-  · intro _ ⟨_, h1, h2⟩
-    refine h2 ▸ latticeClosure_sup_inf_induction (fun a _ => f a ∈ _) ?_ ?_ ?_ h1
-    · intro _ h
-      exact subset_latticeClosure <| Set.mem_image_of_mem _ h
-    · intro a1 _ a2 _ h1 h2
-      exact hf1 a1 a2 ▸ isSublattice_latticeClosure.infClosed h1 h2
-    · intro a1 _ a2 _ h1 h2
-      exact hf2 a1 a2 ▸ isSublattice_latticeClosure.supClosed h1 h2
-  · refine latticeClosure_min ?_ ?_
-    · intro _ ⟨a, h1, h2⟩
-      exact ⟨a, subset_latticeClosure h1, h2⟩
-    · exact ⟨fun _ ⟨c, hcs, hfc⟩ _ ⟨d, hds, hfd⟩ =>
-        ⟨c ⊓ d, hfc ▸ hfd ▸ ⟨isSublattice_latticeClosure.infClosed hcs hds, hf2 ..⟩⟩,
-          fun _ ⟨c, hcs, hfc⟩ _ ⟨d, hds, hfd⟩ =>
-            ⟨c ⊔ d, hfc ▸ hfd ▸ ⟨isSublattice_latticeClosure.supClosed hcs hds, hf1 ..⟩⟩⟩
+  simpa only [Set.image_comp, ← Set.preimage_equiv_eq_image_symm, ← preimage_ofDual_latticeClosure]
+    using @image_latticeClosure _ _ _ s _ (ofDual.symm ∘ f) hf1 hf2
 
 end Lattice
 

--- a/Mathlib/Order/SupClosed.lean
+++ b/Mathlib/Order/SupClosed.lean
@@ -438,9 +438,9 @@ lemma latticeClosure_min : s ⊆ t → IsSublattice t → latticeClosure s ⊆ t
 lemma latticeClosure_sup_inf_induction (p : (a : α) → a ∈ latticeClosure s → Prop)
     (mem : ∀ (a : α) (has : a ∈ s), p a (subset_latticeClosure has))
     (sup : ∀ (a : α) (has : a ∈ latticeClosure s) (b : α) (hbs : b ∈ latticeClosure s),
-      p a has → p b hbs → p (a ⊔ b) (IsSublattice.supClosed isSublattice_latticeClosure has hbs))
+      p a has → p b hbs → p (a ⊔ b) (isSublattice_latticeClosure.supClosed has hbs))
     (inf : ∀ (a : α) (has : a ∈ latticeClosure s) (b : α) (hbs : b ∈ latticeClosure s),
-      p a has → p b hbs → p (a ⊓ b) (IsSublattice.infClosed isSublattice_latticeClosure has hbs))
+      p a has → p b hbs → p (a ⊓ b) (isSublattice_latticeClosure.infClosed has hbs))
     {a : α} (has : a ∈ latticeClosure s) :
     p a has := by
   have h1 : s ⊆ { a : α | ∃ has : a ∈ latticeClosure s, p a has } := by
@@ -448,9 +448,9 @@ lemma latticeClosure_sup_inf_induction (p : (a : α) → a ∈ latticeClosure s 
     exact ⟨subset_latticeClosure ha, mem a ha⟩
   have h2 : IsSublattice { a : α | ∃ has : a ∈ latticeClosure s, p a has } := {
     supClosed := fun a ⟨has, hpa⟩ b ⟨hbs, hpb⟩ =>
-      ⟨IsSublattice.supClosed isSublattice_latticeClosure has hbs, sup a has b hbs hpa hpb⟩
+      ⟨isSublattice_latticeClosure.supClosed has hbs, sup a has b hbs hpa hpb⟩
     infClosed := fun a ⟨has, hpa⟩ b ⟨hbs, hpb⟩ =>
-      ⟨IsSublattice.infClosed isSublattice_latticeClosure has hbs, inf a has b hbs hpa hpb⟩ }
+      ⟨isSublattice_latticeClosure.infClosed has hbs, inf a has b hbs hpa hpb⟩ }
   exact (latticeClosure_min h1 h2 has).choose_spec
 
 lemma latticeClosure_mono : Monotone (latticeClosure : Set α → Set α) := latticeClosure.monotone
@@ -466,6 +466,50 @@ lemma latticeClosure_idem (s : Set α) : latticeClosure (latticeClosure s) = lat
 @[simp] lemma latticeClosure_empty : latticeClosure (∅ : Set α) = ∅ := by simp
 @[simp] lemma latticeClosure_singleton (a : α) : latticeClosure {a} = {a} := by simp
 @[simp] lemma latticeClosure_univ : latticeClosure (Set.univ : Set α) = Set.univ := by simp
+
+variable (s) in
+lemma image_latticeClosure [Lattice β] {f : α → β}
+    (map_sup : ∀ a₁ a₂ : α, f (a₁ ⊔ a₂) = f a₁ ⊔ f a₂)
+    (map_inf : ∀ a₁ a₂ : α, f (a₁ ⊓ a₂) = f a₁ ⊓ f a₂) :
+    f '' latticeClosure s = latticeClosure (f '' s) := by
+  refine Set.eq_of_subset_of_subset ?_ ?_
+  · intro _ ⟨_, h1, h2⟩
+    refine h2 ▸ latticeClosure_sup_inf_induction (fun a _ => f a ∈ _) ?_ ?_ ?_ h1
+    · intro _ h
+      exact subset_latticeClosure <| Set.mem_image_of_mem _ h
+    · intro _ _ _ _ h1 h2
+      exact  map_sup .. ▸ isSublattice_latticeClosure.supClosed h1 h2
+    · intro _ _ _ _ h1 h2
+      exact map_inf .. ▸ isSublattice_latticeClosure.infClosed h1 h2
+  · refine latticeClosure_min ?_ ?_
+    · intro _ ⟨a, h1, h2⟩
+      exact ⟨a, subset_latticeClosure h1, h2⟩
+    · exact ⟨fun _ ⟨c, hcs, hfc⟩ _ ⟨d, hds, hfd⟩ =>
+        ⟨c ⊔ d, hfc ▸ hfd ▸ ⟨isSublattice_latticeClosure.supClosed hcs hds, map_sup c d⟩⟩,
+          fun _ ⟨c, hcs, hfc⟩ _ ⟨d, hds, hfd⟩ =>
+            ⟨c ⊓ d, hfc ▸ hfd ▸ ⟨isSublattice_latticeClosure.infClosed hcs hds, map_inf c d⟩⟩⟩
+
+variable (s) in
+lemma image_latticeClosure_of_sup_inf [Lattice β] {f : α → β}
+    (hf1 : ∀ a₁ a₂ : α, f (a₁ ⊔ a₂) = f a₁ ⊓ f a₂)
+    (hf2 : ∀ a₁ a₂ : α, f (a₁ ⊓ a₂) = f a₁ ⊔ f a₂) :
+    f '' latticeClosure s = latticeClosure (f '' s) := by
+  refine Set.eq_of_subset_of_subset ?_ ?_
+  · intro _ ⟨_, h1, h2⟩
+    refine h2 ▸ latticeClosure_sup_inf_induction (fun a _ => f a ∈ _) ?_ ?_ ?_ h1
+    · intro _ h
+      exact subset_latticeClosure <| Set.mem_image_of_mem _ h
+    · intro a1 _ a2 _ h1 h2
+      exact hf1 a1 a2 ▸ isSublattice_latticeClosure.infClosed h1 h2
+    · intro a1 _ a2 _ h1 h2
+      exact hf2 a1 a2 ▸ isSublattice_latticeClosure.supClosed h1 h2
+  · refine latticeClosure_min ?_ ?_
+    · intro _ ⟨a, h1, h2⟩
+      exact ⟨a, subset_latticeClosure h1, h2⟩
+    · exact ⟨fun _ ⟨c, hcs, hfc⟩ _ ⟨d, hds, hfd⟩ =>
+        ⟨c ⊓ d, hfc ▸ hfd ▸ ⟨isSublattice_latticeClosure.infClosed hcs hds, hf2 ..⟩⟩,
+          fun _ ⟨c, hcs, hfc⟩ _ ⟨d, hds, hfd⟩ =>
+            ⟨c ⊔ d, hfc ▸ hfd ▸ ⟨isSublattice_latticeClosure.supClosed hcs hds, hf1 ..⟩⟩⟩
 
 end Lattice
 
@@ -550,33 +594,13 @@ section BooleanAlgebra
 variable [BooleanAlgebra α] (s : Set α)
 
 lemma compl_image_latticeClosure :
-    compl '' (latticeClosure s) = latticeClosure (compl '' s) := by
-  refine Set.eq_of_subset_of_subset ?_ ?_
-  · intro a ⟨_, hs, ha⟩
-    refine ha ▸ latticeClosure_sup_inf_induction (fun c _ => cᶜ ∈ _) ?_ ?_ ?_ hs
-    · intro _ h
-      exact subset_latticeClosure <| Set.mem_image_of_mem compl h
-    · intro _ _ _ _ h1 h2
-      exact @compl_sup α .. ▸ IsSublattice.infClosed isSublattice_latticeClosure h1 h2
-    · intro _ _ _ _ h1 h2
-      exact @compl_inf α .. ▸ IsSublattice.supClosed isSublattice_latticeClosure h1 h2
-  · refine latticeClosure_min ?_ ?_
-    · intro a ⟨c, hcs, hca⟩
-      exact ⟨c, subset_latticeClosure hcs, hca⟩
-    · exact {
-      supClosed := fun a ⟨c, hcs, hca⟩ b ⟨d, hds, hdb⟩ =>
-        ⟨aᶜ ⊓ bᶜ, hca ▸ hdb ▸ IsSublattice.infClosed isSublattice_latticeClosure
-          ((compl_compl c).symm ▸ hcs) ((compl_compl d).symm ▸ hds),
-            @compl_inf α .. ▸ (compl_compl a).symm ▸ (compl_compl b).symm ▸ rfl⟩
-      infClosed := fun a ⟨c, hcs, hca⟩ b ⟨d, hds, hdb⟩ =>
-        ⟨aᶜ ⊔ bᶜ, hca ▸ hdb ▸ IsSublattice.supClosed isSublattice_latticeClosure
-          ((compl_compl c).symm ▸ hcs) ((compl_compl d).symm ▸ hds),
-            @compl_sup α .. ▸ (compl_compl a).symm ▸ (compl_compl b).symm ▸ rfl⟩ }
+    compl '' latticeClosure s = latticeClosure (compl '' s) :=
+  image_latticeClosure_of_sup_inf s compl_sup_distrib (fun _ _ => compl_inf)
 
 variable {s}
 
 lemma compl_image_latticeClosure_eq_of_compl_image_eq_self (hs : compl '' s = s) :
-    compl '' (latticeClosure s) = latticeClosure s :=
+    compl '' latticeClosure s = latticeClosure s :=
   compl_image_latticeClosure s ▸ hs.symm ▸ rfl
 
 end BooleanAlgebra


### PR DESCRIPTION
The main results in this pull request are:
1. `compl_image_latticeClosure`: given any Boolean algebra `α` and `s : Set α`, `compl '' latticeClosure s` is the same as `latticeClosure (compl '' s)`;
2. `compl_image_latticeClosure_eq_of_compl_image_eq_self`: given any Boolean algebra `α` and `s : Set α` such that `compl '' s = s`, we have `compl '' latticeClosure s = latticeClosure s`.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)