### PR TITLE
[Merged by Bors] - feat: `counit (antipode a) = counit a`

### DIFF
--- a/Mathlib/RingTheory/Coalgebra/Basic.lean
+++ b/Mathlib/RingTheory/Coalgebra/Basic.lean
@@ -80,7 +80,7 @@ class Coalgebra (R : Type u) (A : Type v)
 
 namespace Coalgebra
 variable {R : Type u} {A : Type v}
-variable [CommSemiring R] [AddCommMonoid A] [Module R A] [Coalgebra R A]
+variable [CommSemiring R] [AddCommMonoid A] [Module R A] [Coalgebra R A] {a : A}
 
 @[simp]
 theorem coassoc_apply (a : A) :
@@ -154,6 +154,23 @@ theorem sum_map_tmul_tmul_eq {B : Type*} [AddCommMonoid B] [Module R B]
   apply_fun TensorProduct.map (f : A →ₗ[R] B)
     (TensorProduct.map (g : A →ₗ[R] B) (h : A →ₗ[R] B)) at this
   simp_all only [map_sum, TensorProduct.map_tmul, LinearMap.coe_coe]
+
+lemma sum_counit_smul (𝓡 : Coalgebra.Repr R a) :
+    ∑ x ∈ 𝓡.index, counit (R := R) (𝓡.left x) • 𝓡.right x = a := by
+  have := sum_counit_tmul_eq (R := R) 𝓡
+  apply_fun TensorProduct.lift (LinearMap.lsmul R A) at this
+  simp_rw [map_sum] at this
+  convert this
+  simp
+
+lemma lift_lsmul_comp_counit_comp_comul :
+    TensorProduct.lift (.lsmul R A ∘ₗ counit) ∘ₗ comul = .id := by
+  have := Coalgebra.rTensor_counit_comp_comul (R := R) (A := A)
+  apply_fun (TensorProduct.lift (LinearMap.lsmul R A) ∘ₗ ·) at this
+  rw [LinearMap.rTensor, ← LinearMap.comp_assoc, TensorProduct.lift_comp_map, LinearMap.compl₂_id]
+    at this
+  ext
+  simp [this]
 
 variable (R A) in
 /-- A coalgebra `A` is cocommutative if its comultiplication `δ : A → A ⊗ A` commutes with the

--- a/Mathlib/RingTheory/Coalgebra/Basic.lean
+++ b/Mathlib/RingTheory/Coalgebra/Basic.lean
@@ -155,17 +155,14 @@ theorem sum_map_tmul_tmul_eq {B : Type*} [AddCommMonoid B] [Module R B]
     (TensorProduct.map (g : A →ₗ[R] B) (h : A →ₗ[R] B)) at this
   simp_all only [map_sum, TensorProduct.map_tmul, LinearMap.coe_coe]
 
-lemma sum_counit_smul (𝓡 : Coalgebra.Repr R a) :
+lemma sum_counit_smul (𝓡 : Repr R a) :
     ∑ x ∈ 𝓡.index, counit (R := R) (𝓡.left x) • 𝓡.right x = a := by
-  have := sum_counit_tmul_eq (R := R) 𝓡
-  apply_fun TensorProduct.lift (LinearMap.lsmul R A) at this
-  simp_rw [map_sum] at this
-  convert this
-  simp
+  simpa only [map_sum, TensorProduct.lift.tmul, LinearMap.lsmul_apply, one_smul]
+    using congr(TensorProduct.lift (LinearMap.lsmul R A) $(sum_counit_tmul_eq (R := R) 𝓡))
 
 lemma lift_lsmul_comp_counit_comp_comul :
     TensorProduct.lift (.lsmul R A ∘ₗ counit) ∘ₗ comul = .id := by
-  have := Coalgebra.rTensor_counit_comp_comul (R := R) (A := A)
+  have := rTensor_counit_comp_comul (R := R) (A := A)
   apply_fun (TensorProduct.lift (LinearMap.lsmul R A) ∘ₗ ·) at this
   rw [LinearMap.rTensor, ← LinearMap.comp_assoc, TensorProduct.lift_comp_map, LinearMap.compl₂_id]
     at this

--- a/Mathlib/RingTheory/HopfAlgebra/Basic.lean
+++ b/Mathlib/RingTheory/HopfAlgebra/Basic.lean
@@ -40,6 +40,8 @@ so we could deduce the facts here from an equivalence `HopfAlgCat R ≌ Hopf_ (M
 
 -/
 
+open Bialgebra
+
 universe u v w
 
 /-- Isolates the antipode of a Hopf algebra, to allow API to be constructed before proving the
@@ -64,7 +66,7 @@ namespace HopfAlgebra
 
 export HopfAlgebraStruct (antipode)
 
-variable {R : Type u} {A : Type v} [CommSemiring R] [Semiring A] [HopfAlgebra R A]
+variable {R : Type u} {A : Type v} [CommSemiring R] [Semiring A] [HopfAlgebra R A] {a : A}
 
 @[simp]
 theorem mul_antipode_rTensor_comul_apply (a : A) :
@@ -85,27 +87,35 @@ theorem antipode_one :
 
 open Coalgebra
 
-@[simp]
-lemma sum_antipode_mul_eq {a : A} (repr : Repr R a) :
+lemma sum_antipode_mul_eq_algebraMap_counit (repr : Repr R a) :
     ∑ i ∈ repr.index, antipode R (repr.left i) * repr.right i =
       algebraMap R A (counit a) := by
   simpa [← repr.eq, map_sum] using congr($(mul_antipode_rTensor_comul (R := R)) a)
 
-@[simp]
-lemma sum_mul_antipode_eq {a : A} (repr : Repr R a) :
+lemma sum_mul_antipode_eq_algebraMap_counit (repr : Repr R a) :
     ∑ i ∈ repr.index, repr.left i * antipode R (repr.right i) =
       algebraMap R A (counit a) := by
   simpa [← repr.eq, map_sum] using congr($(mul_antipode_lTensor_comul (R := R)) a)
 
-lemma sum_antipode_mul_eq_smul {a : A} (repr : Repr R a) :
+lemma sum_antipode_mul_eq_smul (repr : Repr R a) :
     ∑ i ∈ repr.index, antipode R (repr.left i) * repr.right i =
       counit (R := R) a • 1 := by
-  rw [sum_antipode_mul_eq, Algebra.smul_def, mul_one]
+  rw [sum_antipode_mul_eq_algebraMap_counit, Algebra.smul_def, mul_one]
 
-lemma sum_mul_antipode_eq_smul {a : A} (repr : Repr R a) :
+lemma sum_mul_antipode_eq_smul (repr : Repr R a) :
     ∑ i ∈ repr.index, repr.left i * antipode R (repr.right i) =
       counit (R := R) a • 1 := by
-  rw [sum_mul_antipode_eq, Algebra.smul_def, mul_one]
+  rw [sum_mul_antipode_eq_algebraMap_counit, Algebra.smul_def, mul_one]
+
+@[simp] lemma counit_antipode (a : A) : counit (R := R) (antipode R a) = counit a := by
+  calc
+        counit (antipode R a)
+    _ = counit (∑ i ∈ (ℛ R a).index, (ℛ R a).left i * antipode R ((ℛ R a).right i)) := by
+      simp_rw [map_sum, counit_mul, ← smul_eq_mul, ← map_smul, ← map_sum, sum_counit_smul]
+    _ = counit a := by simpa using congr(counit (R := R) $(sum_mul_antipode_eq_smul (ℛ R a)))
+
+@[simp] lemma counit_comp_antipode : counit ∘ₗ antipode R = counit (A := A) := by
+  ext; exact counit_antipode _
 
 end HopfAlgebra
 

--- a/Mathlib/RingTheory/HopfAlgebra/Basic.lean
+++ b/Mathlib/RingTheory/HopfAlgebra/Basic.lean
@@ -92,10 +92,16 @@ lemma sum_antipode_mul_eq_algebraMap_counit (repr : Repr R a) :
       algebraMap R A (counit a) := by
   simpa [← repr.eq, map_sum] using congr($(mul_antipode_rTensor_comul (R := R)) a)
 
+@[deprecated (since := "2025-05-29")]
+alias sum_antipode_mul_eq := sum_antipode_mul_eq_algebraMap_counit
+
 lemma sum_mul_antipode_eq_algebraMap_counit (repr : Repr R a) :
     ∑ i ∈ repr.index, repr.left i * antipode R (repr.right i) =
       algebraMap R A (counit a) := by
   simpa [← repr.eq, map_sum] using congr($(mul_antipode_lTensor_comul (R := R)) a)
+
+@[deprecated (since := "2025-05-29")]
+alias sum_mul_antipode_eq := sum_mul_antipode_eq_algebraMap_counit
 
 lemma sum_antipode_mul_eq_smul (repr : Repr R a) :
     ∑ i ∈ repr.index, antipode R (repr.left i) * repr.right i =

--- a/Mathlib/RingTheory/HopfAlgebra/MonoidAlgebra.lean
+++ b/Mathlib/RingTheory/HopfAlgebra/MonoidAlgebra.lean
@@ -44,12 +44,12 @@ open Coalgebra in
 instance instHopfAlgebra : HopfAlgebra R (MonoidAlgebra A G) where
   mul_antipode_rTensor_comul := by
     ext a b : 2
-    simpa [← (ℛ R b).eq, -sum_antipode_mul_eq] using congr(lsingle (R := R) (1 : G)
-      $(sum_antipode_mul_eq (Coalgebra.Repr.arbitrary R b)))
+    simpa [← (ℛ R b).eq] using congr(lsingle (R := R) (1 : G)
+      $(sum_antipode_mul_eq_algebraMap_counit (ℛ R b)))
   mul_antipode_lTensor_comul := by
     ext a b : 2
-    simpa [← (ℛ R b).eq, -sum_mul_antipode_eq] using congr(lsingle (R := R) (1 : G)
-      $(sum_mul_antipode_eq (Coalgebra.Repr.arbitrary R b)))
+    simpa [← (ℛ R b).eq] using congr(lsingle (R := R) (1 : G)
+      $(sum_mul_antipode_eq_algebraMap_counit (ℛ R b)))
 
 end MonoidAlgebra
 
@@ -71,12 +71,12 @@ open Coalgebra in
 instance instHopfAlgebra : HopfAlgebra R A[G] where
   mul_antipode_rTensor_comul := by
     ext a b : 2
-    simpa [← (ℛ R b).eq, single_mul_single, -sum_antipode_mul_eq] using
-      congr(lsingle (R := R) (0 : G) $(sum_antipode_mul_eq (Coalgebra.Repr.arbitrary R b)))
+    simpa [← (ℛ R b).eq, single_mul_single] using congr(lsingle (R := R) (0 : G)
+      $(sum_antipode_mul_eq_algebraMap_counit (ℛ R b)))
   mul_antipode_lTensor_comul := by
     ext a b : 2
-    simpa [← (ℛ R b).eq, single_mul_single, -sum_mul_antipode_eq] using
-      congr(lsingle (R := R) (0 : G) $(sum_mul_antipode_eq (Coalgebra.Repr.arbitrary R b)))
+    simpa [← (ℛ R b).eq, single_mul_single] using congr(lsingle (R := R) (0 : G)
+      $(sum_mul_antipode_eq_algebraMap_counit (ℛ R b)))
 
 end AddMonoidAlgebra
 


### PR DESCRIPTION
and unsimp `sum_antipode_mul_eq_algebraMap_counit`/`sum_mul_antipode_eq_algebraMap_counit` since they are annoying lemmas to fight against.

From Toric

Co-authored-by: Patrick Massot


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
