### PR TITLE
[Merged by Bors] - chore: put sections in Taylor.lean according to the ring

### DIFF
--- a/Mathlib/Algebra/Polynomial/Taylor.lean
+++ b/Mathlib/Algebra/Polynomial/Taylor.lean
@@ -26,6 +26,8 @@ noncomputable section
 
 namespace Polynomial
 
+section Semiring
+
 variable {R : Type*} [Semiring R] (r : R) (f : R[X])
 
 /-- The Taylor expansion of a polynomial `f` at `r`. -/
@@ -85,33 +87,52 @@ theorem natDegree_taylor (p : R[X]) (r : R) : natDegree (taylor r p) = natDegree
   intro n c c0
   simp [taylor_monomial, natDegree_C_mul_of_mul_ne_zero, natDegree_pow_X_add_C, c0]
 
+end Semiring
+
+section CommSemiring
+
+variable {R : Type*} [CommSemiring R] (r : R) (f : R[X])
+
 @[simp]
-theorem taylor_mul {R} [CommSemiring R] (r : R) (p q : R[X]) :
+theorem taylor_mul (p q : R[X]) :
     taylor r (p * q) = taylor r p * taylor r q := by simp only [taylor_apply, mul_comp]
 
 /-- `Polynomial.taylor` as an `AlgHom` for commutative semirings -/
 @[simps!]
-def taylorAlgHom {R} [CommSemiring R] (r : R) : R[X] →ₐ[R] R[X] :=
+def taylorAlgHom (r : R) : R[X] →ₐ[R] R[X] :=
   AlgHom.ofLinearMap (taylor r) (taylor_one r) (taylor_mul r)
 
-theorem taylor_taylor {R} [CommSemiring R] (f : R[X]) (r s : R) :
+theorem taylor_taylor (f : R[X]) (r s : R) :
     taylor r (taylor s f) = taylor (r + s) f := by
   simp only [taylor_apply, comp_assoc, map_add, add_comp, X_comp, C_comp, C_add, add_assoc]
 
-theorem taylor_eval {R} [CommSemiring R] (r : R) (f : R[X]) (s : R) :
+theorem taylor_eval (r : R) (f : R[X]) (s : R) :
     (taylor r f).eval s = f.eval (s + r) := by
   simp only [taylor_apply, eval_comp, eval_C, eval_X, eval_add]
 
-theorem taylor_eval_sub {R} [CommRing R] (r : R) (f : R[X]) (s : R) :
+theorem eval_add_of_sq_eq_zero (p : R[X]) (x y : R) (hy : y ^ 2 = 0) :
+    p.eval (x + y) = p.eval x + p.derivative.eval x * y := by
+  rw [add_comm, ← Polynomial.taylor_eval,
+    Polynomial.eval_eq_sum_range' ((Nat.lt_succ_self _).trans (Nat.lt_succ_self _)),
+    Finset.sum_range_succ', Finset.sum_range_succ']
+  simp [pow_succ, mul_assoc, ← pow_two, hy, add_comm (eval x p)]
+
+end CommSemiring
+
+section CommRing
+
+variable {R : Type*} [CommRing R] (r : R) (f : R[X])
+
+theorem taylor_eval_sub (s : R) :
     (taylor r f).eval (s - r) = f.eval s := by rw [taylor_eval, sub_add_cancel]
 
-theorem taylor_injective {R} [CommRing R] (r : R) : Function.Injective (taylor r) := by
+theorem taylor_injective (r : R) : Function.Injective (taylor r) := by
   intro f g h
   apply_fun taylor (-r) at h
   simpa only [taylor_apply, comp_assoc, add_comp, X_comp, C_comp, C_neg, neg_add_cancel_right,
     comp_X] using h
 
-theorem eq_zero_of_hasseDeriv_eq_zero {R} [CommRing R] (f : R[X]) (r : R)
+theorem eq_zero_of_hasseDeriv_eq_zero (f : R[X]) (r : R)
     (h : ∀ k, (hasseDeriv k f).eval r = 0) : f = 0 := by
   apply taylor_injective r
   rw [LinearMap.map_zero]
@@ -119,16 +140,11 @@ theorem eq_zero_of_hasseDeriv_eq_zero {R} [CommRing R] (f : R[X]) (r : R)
   simp only [taylor_coeff, h, coeff_zero]
 
 /-- Taylor's formula. -/
-theorem sum_taylor_eq {R} [CommRing R] (f : R[X]) (r : R) :
+theorem sum_taylor_eq (f : R[X]) (r : R) :
     ((taylor r f).sum fun i a => C a * (X - C r) ^ i) = f := by
   rw [← comp_eq_sum_left, sub_eq_add_neg, ← C_neg, ← taylor_apply, taylor_taylor, neg_add_cancel,
     taylor_zero]
 
-theorem eval_add_of_sq_eq_zero {A} [CommSemiring A] (p : Polynomial A) (x y : A) (hy : y ^ 2 = 0) :
-    p.eval (x + y) = p.eval x + p.derivative.eval x * y := by
-  rw [add_comm, ← Polynomial.taylor_eval,
-    Polynomial.eval_eq_sum_range' ((Nat.lt_succ_self _).trans (Nat.lt_succ_self _)),
-    Finset.sum_range_succ', Finset.sum_range_succ']
-  simp [pow_succ, mul_assoc, ← pow_two, hy, add_comm (eval x p)]
+end CommRing
 
 end Polynomial


### PR DESCRIPTION
I have sectioned `Mathlib.Algebra.Polynomial.Taylor` according to the type of ring (Semiring, CommSemiring, CommRing). I have also moved `eval_add_of_sq_eq_zero` from the CommRing section to the CommSemiring section because it uses the CommSemiring assumption. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
This is split off from #25139.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
