### PR TITLE
[Merged by Bors] - feat: left-tensoring a linear map by a tensor product

### DIFF
--- a/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
@@ -283,10 +283,9 @@ variable {N}
 
 variable (g : P →ₗ[R] Q) (f : N →ₗ[R] P)
 
-local notation "α" => TensorProduct.assoc
-
 lemma lTensor_tensor (f : P →ₗ[R] Q) :
-    lTensor (M ⊗[R] N) f = (α R M N Q).symm ∘ₗ (f.lTensor N).lTensor M ∘ₗ α R M N P :=
+    lTensor (M ⊗[R] N) f = (TensorProduct.assoc R M N Q).symm ∘ₗ
+      (f.lTensor N).lTensor M ∘ₗ TensorProduct.assoc R M N P :=
   TensorProduct.ext <| TensorProduct.ext rfl
 
 theorem rTensor_tensor : rTensor (M ⊗[R] N) g =

--- a/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
@@ -283,13 +283,14 @@ variable {N}
 
 variable (g : P →ₗ[R] Q) (f : N →ₗ[R] P)
 
+open TensorProduct (assoc) in
 lemma lTensor_tensor (f : P →ₗ[R] Q) :
-    lTensor (M ⊗[R] N) f = (TensorProduct.assoc R M N Q).symm ∘ₗ
-      (f.lTensor N).lTensor M ∘ₗ TensorProduct.assoc R M N P :=
+    lTensor (M ⊗[R] N) f = (assoc R M N Q).symm ∘ₗ (f.lTensor N).lTensor M ∘ₗ assoc R M N P :=
   TensorProduct.ext <| TensorProduct.ext rfl
 
+open TensorProduct (assoc) in
 theorem rTensor_tensor : rTensor (M ⊗[R] N) g =
-    TensorProduct.assoc R Q M N ∘ₗ rTensor N (rTensor M g) ∘ₗ (TensorProduct.assoc R P M N).symm :=
+    assoc R Q M N ∘ₗ rTensor N (rTensor M g) ∘ₗ (assoc R P M N).symm :=
   TensorProduct.ext <| LinearMap.ext fun _ ↦ TensorProduct.ext rfl
 
 open TensorProduct

--- a/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
@@ -283,12 +283,12 @@ variable {N}
 
 variable (g : P →ₗ[R] Q) (f : N →ₗ[R] P)
 
-open TensorProduct (assoc) in
+open TensorProduct (assoc lid rid)
+
 lemma lTensor_tensor (f : P →ₗ[R] Q) :
     lTensor (M ⊗[R] N) f = (assoc R M N Q).symm ∘ₗ (f.lTensor N).lTensor M ∘ₗ assoc R M N P :=
   TensorProduct.ext <| TensorProduct.ext rfl
 
-open TensorProduct (assoc) in
 theorem rTensor_tensor : rTensor (M ⊗[R] N) g =
     assoc R Q M N ∘ₗ rTensor N (rTensor M g) ∘ₗ (assoc R P M N).symm :=
   TensorProduct.ext <| LinearMap.ext fun _ ↦ TensorProduct.ext rfl
@@ -296,6 +296,9 @@ theorem rTensor_tensor : rTensor (M ⊗[R] N) g =
 open TensorProduct
 
 theorem lid_comp_rTensor (f : N →ₗ[R] R) :
-    (TensorProduct.lid R M).comp (rTensor M f) = lift ((lsmul R M).comp f) := ext' fun _ _ ↦ rfl
+    (lid R M).comp (rTensor M f) = lift ((lsmul R M).comp f) := ext' fun _ _ ↦ rfl
+
+lemma rid_comp_lTensor (f : M →ₗ[R] R) :
+    (rid R N).comp (lTensor N f) = lift ((lsmul R N).flip.compl₂ f) := ext' fun _ _ ↦ rfl
 
 end LinearMap

--- a/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
@@ -283,6 +283,12 @@ variable {N}
 
 variable (g : P →ₗ[R] Q) (f : N →ₗ[R] P)
 
+local notation "α" => TensorProduct.assoc
+
+lemma lTensor_tensor (f : P →ₗ[R] Q) :
+    lTensor (M ⊗[R] N) f = (α R M N Q).symm ∘ₗ (f.lTensor N).lTensor M ∘ₗ α R M N P :=
+  TensorProduct.ext <| TensorProduct.ext rfl
+
 theorem rTensor_tensor : rTensor (M ⊗[R] N) g =
     TensorProduct.assoc R Q M N ∘ₗ rTensor N (rTensor M g) ∘ₗ (TensorProduct.assoc R P M N).symm :=
   TensorProduct.ext <| LinearMap.ext fun _ ↦ TensorProduct.ext rfl


### PR DESCRIPTION
From Toric

Co-authored-by: Michał Mrugała <kiolterino@gmail.com>


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
