### PR TITLE
[Merged by Bors] - chore: rename `reflection_perm` to `reflectionPerm`

### DIFF
--- a/Mathlib/LinearAlgebra/RootSystem/BaseChange.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/BaseChange.lean
@@ -78,11 +78,11 @@ def restrictScalars' :
       have : algebraMap K L 2 = 2 := by
         rw [← Int.cast_two (R := K), ← Int.cast_two (R := L), map_intCast]
       exact FaithfulSMul.algebraMap_injective K L <| by simp [this]
-    reflection_perm := P.reflection_perm
-    reflection_perm_root i j := by
-      ext; simpa [algebra_compatible_smul L] using P.reflection_perm_root i j
-    reflection_perm_coroot i j := by
-      ext; simpa [algebra_compatible_smul L] using P.reflection_perm_coroot i j
+    reflectionPerm := P.reflectionPerm
+    reflectionPerm_root i j := by
+      ext; simpa [algebra_compatible_smul L] using P.reflectionPerm_root i j
+    reflectionPerm_coroot i j := by
+      ext; simpa [algebra_compatible_smul L] using P.reflectionPerm_coroot i j
     span_root_eq_top := by
       rw [← span_setOf_mem_eq_top]
       congr

--- a/Mathlib/LinearAlgebra/RootSystem/Basic.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Basic.lean
@@ -38,7 +38,7 @@ variable {ι R M N : Type*}
 
 namespace RootPairing
 
-section reflection_perm
+section reflectionPerm
 
 variable (p : PerfectPairing R M N) (root : ι ↪ M) (coroot : ι ↪ N) (i j : ι)
   (h : ∀ i, MapsTo (preReflection (root i) (p.toLinearMap.flip (coroot i)))
@@ -69,7 +69,7 @@ protected def equiv_of_mapsTo :
   left_inv j := choose_choose_eq_of_mapsTo p root coroot i j h hp
   right_inv j := choose_choose_eq_of_mapsTo p root coroot i j h hp
 
-end reflection_perm
+end reflectionPerm
 
 variable (P : RootPairing ι R M N) [Finite ι]
 
@@ -95,11 +95,11 @@ protected lemma ext [CharZero R] [NoZeroSMulDivisors R M]
     (hr : P₁.root = P₂.root)
     (hc : range P₁.coroot = range P₂.coroot) :
     P₁ = P₂ := by
-  have hp (hc' : P₁.coroot = P₂.coroot) : P₁.reflection_perm = P₂.reflection_perm := by
+  have hp (hc' : P₁.coroot = P₂.coroot) : P₁.reflectionPerm = P₂.reflectionPerm := by
     ext i j
     refine P₁.root.injective ?_
     conv_rhs => rw [hr]
-    simp only [root_reflection_perm, reflection_apply, coroot']
+    simp only [root_reflectionPerm, reflection_apply, coroot']
     simp only [hr, he, hc']
   suffices P₁.coroot = P₂.coroot by
     obtain ⟨p₁⟩ := P₁; obtain ⟨p₂⟩ := P₂; cases p₁; cases p₂; congr; exact hp this
@@ -168,11 +168,11 @@ def mk' [CharZero R] [NoZeroSMulDivisors R M]
   root := root
   coroot := coroot
   root_coroot_two := hp
-  reflection_perm i := RootPairing.equiv_of_mapsTo p root coroot i hr hp
-  reflection_perm_root i j := by
+  reflectionPerm i := RootPairing.equiv_of_mapsTo p root coroot i hr hp
+  reflectionPerm_root i j := by
     rw [equiv_of_mapsTo_apply, (exist_eq_reflection_of_mapsTo p root coroot i j hr).choose_spec,
       preReflection_apply, PerfectPairing.flip_apply_apply]
-  reflection_perm_coroot i j := by
+  reflectionPerm_coroot i j := by
     refine (coroot_eq_coreflection_of_root_eq' p root coroot hp hr hc ?_).symm
     rw [equiv_of_mapsTo_apply, (exist_eq_reflection_of_mapsTo p root coroot i j hr).choose_spec]
 

--- a/Mathlib/LinearAlgebra/RootSystem/Chain.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Chain.lean
@@ -182,7 +182,7 @@ lemma root_sub_zsmul_mem_range_iff {z : ℤ} :
 
 omit h
 
-private lemma chainCoeff_reflection_perm_left_aux :
+private lemma chainCoeff_reflectionPerm_left_aux :
     letI := P.indexNeg
     Icc (-P.chainTopCoeff i j : ℤ) (P.chainBotCoeff i j) =
       Icc (-P.chainBotCoeff (-i) j : ℤ) (P.chainTopCoeff (-i) j) := by
@@ -190,14 +190,14 @@ private lemma chainCoeff_reflection_perm_left_aux :
   by_cases h : LinearIndependent R ![P.root i, P.root j]
   · have h' : LinearIndependent R ![P.root (-i), P.root j] := by simpa
     ext z
-    rw [← P.root_add_zsmul_mem_range_iff h', indexNeg_neg, root_reflection_perm, mem_Icc,
+    rw [← P.root_add_zsmul_mem_range_iff h', indexNeg_neg, root_reflectionPerm, mem_Icc,
       reflection_apply_self, smul_neg, ← neg_smul, P.root_add_zsmul_mem_range_iff h, mem_Icc]
     omega
   · have h' : ¬ LinearIndependent R ![P.root (-i), P.root j] := by simpa
     simp only [chainTopCoeff_of_not_linearIndependent h, chainTopCoeff_of_not_linearIndependent h',
       chainBotCoeff_of_not_linearIndependent h, chainBotCoeff_of_not_linearIndependent h']
 
-private lemma chainCoeff_reflection_perm_right_aux :
+private lemma chainCoeff_reflectionPerm_right_aux :
     letI := P.indexNeg
     Icc (-P.chainTopCoeff i j : ℤ) (P.chainBotCoeff i j) =
       Icc (-P.chainBotCoeff i (-j) : ℤ) (P.chainTopCoeff i (-j)) := by
@@ -205,7 +205,7 @@ private lemma chainCoeff_reflection_perm_right_aux :
   by_cases h : LinearIndependent R ![P.root i, P.root j]
   · have h' : LinearIndependent R ![P.root i, P.root (-j)] := by simpa
     ext z
-    rw [← P.root_add_zsmul_mem_range_iff h', indexNeg_neg, root_reflection_perm, mem_Icc,
+    rw [← P.root_add_zsmul_mem_range_iff h', indexNeg_neg, root_reflectionPerm, mem_Icc,
       reflection_apply_self, ← sub_neg_eq_add, ← neg_sub', neg_mem_range_root_iff,
       P.root_sub_zsmul_mem_range_iff h, mem_Icc]
   · have h' : ¬ LinearIndependent R ![P.root i, P.root (-j)] := by simpa
@@ -213,45 +213,45 @@ private lemma chainCoeff_reflection_perm_right_aux :
       chainBotCoeff_of_not_linearIndependent h, chainBotCoeff_of_not_linearIndependent h']
 
 @[simp]
-lemma chainTopCoeff_reflection_perm_left :
-    P.chainTopCoeff (P.reflection_perm i i) j = P.chainBotCoeff i j := by
+lemma chainTopCoeff_reflectionPerm_left :
+    P.chainTopCoeff (P.reflectionPerm i i) j = P.chainBotCoeff i j := by
   letI := P.indexNeg
   have (z : ℤ) : z ∈ Icc (-P.chainTopCoeff i j : ℤ) (P.chainBotCoeff i j) ↔
       z ∈ Icc (-P.chainBotCoeff (-i) j : ℤ) (P.chainTopCoeff (-i) j) := by
-    rw [P.chainCoeff_reflection_perm_left_aux]
+    rw [P.chainCoeff_reflectionPerm_left_aux]
   refine le_antisymm ?_ ?_
   · simpa using this (P.chainTopCoeff (-i) j)
   · simpa using this (P.chainBotCoeff i j)
 
 @[simp]
-lemma chainBotCoeff_reflection_perm_left :
-    P.chainBotCoeff (P.reflection_perm i i) j = P.chainTopCoeff i j := by
+lemma chainBotCoeff_reflectionPerm_left :
+    P.chainBotCoeff (P.reflectionPerm i i) j = P.chainTopCoeff i j := by
   letI := P.indexNeg
   have (z : ℤ) : z ∈ Icc (-P.chainTopCoeff i j : ℤ) (P.chainBotCoeff i j) ↔
       z ∈ Icc (-P.chainBotCoeff (-i) j : ℤ) (P.chainTopCoeff (-i) j) := by
-    rw [P.chainCoeff_reflection_perm_left_aux]
+    rw [P.chainCoeff_reflectionPerm_left_aux]
   refine le_antisymm ?_ ?_
   · simpa using this (-P.chainBotCoeff (-i) j)
   · simpa using this (-P.chainTopCoeff i j)
 
 @[simp]
-lemma chainTopCoeff_reflection_perm_right :
-    P.chainTopCoeff i (P.reflection_perm j j) = P.chainBotCoeff i j := by
+lemma chainTopCoeff_reflectionPerm_right :
+    P.chainTopCoeff i (P.reflectionPerm j j) = P.chainBotCoeff i j := by
   letI := P.indexNeg
   have (z : ℤ) : z ∈ Icc (-P.chainTopCoeff i j : ℤ) (P.chainBotCoeff i j) ↔
       z ∈ Icc (-P.chainBotCoeff i (-j) : ℤ) (P.chainTopCoeff i (-j)) := by
-    rw [P.chainCoeff_reflection_perm_right_aux]
+    rw [P.chainCoeff_reflectionPerm_right_aux]
   refine le_antisymm ?_ ?_
   · simpa using this (P.chainTopCoeff i (-j))
   · simpa using this (P.chainBotCoeff i j)
 
 @[simp]
-lemma chainBotCoeff_reflection_perm_right :
-    P.chainBotCoeff i (P.reflection_perm j j) = P.chainTopCoeff i j := by
+lemma chainBotCoeff_reflectionPerm_right :
+    P.chainBotCoeff i (P.reflectionPerm j j) = P.chainTopCoeff i j := by
   letI := P.indexNeg
   have (z : ℤ) : z ∈ Icc (-P.chainTopCoeff i j : ℤ) (P.chainBotCoeff i j) ↔
       z ∈ Icc (-P.chainBotCoeff i (-j) : ℤ) (P.chainTopCoeff i (-j)) := by
-    rw [P.chainCoeff_reflection_perm_right_aux]
+    rw [P.chainCoeff_reflectionPerm_right_aux]
   refine le_antisymm ?_ ?_
   · simpa using this (-P.chainBotCoeff i (-j))
   · simpa using this (-P.chainTopCoeff i j)
@@ -307,9 +307,9 @@ lemma chainBotCoeff_sub_chainTopCoeff :
   suffices ∀ i j, LinearIndependent R ![P.root i, P.root j] →
       P.chainBotCoeff i j - P.chainTopCoeff i j ≤ P.pairingIn ℤ j i by
     refine le_antisymm (this i j h) ?_
-    specialize this (P.reflection_perm i i) j (by simpa)
-    simp only [chainBotCoeff_reflection_perm_left, chainTopCoeff_reflection_perm_left,
-      pairingIn_reflection_perm_self_right] at this
+    specialize this (P.reflectionPerm i i) j (by simpa)
+    simp only [chainBotCoeff_reflectionPerm_left, chainTopCoeff_reflectionPerm_left,
+      pairingIn_reflectionPerm_self_right] at this
     omega
   intro i j h
   have h₁ : P.reflection i (P.root <| P.chainBotIdx i j) =
@@ -317,7 +317,7 @@ lemma chainBotCoeff_sub_chainTopCoeff :
     simp [reflection_apply_root, ← P.algebraMap_pairingIn ℤ]
     module
   have h₂ : P.reflection i (P.root <| P.chainBotIdx i j) ∈ range P.root := by
-    rw [← root_reflection_perm]
+    rw [← root_reflectionPerm]
     exact mem_range_self _
   rw [h₁, root_add_zsmul_mem_range_iff h, mem_Icc] at h₂
   omega
@@ -413,7 +413,7 @@ lemma pairingIn_le_zero_of_root_add_mem [P.IsNotG2] (h : P.root i + P.root j ∈
 
 lemma zero_le_pairingIn_of_root_sub_mem [P.IsNotG2] (h : P.root i - P.root j ∈ range P.root) :
     0 ≤ P.pairingIn ℤ i j := by
-  replace h : P.root i + P.root (P.reflection_perm j j) ∈ range P.root := by
+  replace h : P.root i + P.root (P.reflectionPerm j j) ∈ range P.root := by
     simpa [-mem_range, ← sub_eq_add_neg]
   simpa using P.pairingIn_le_zero_of_root_add_mem h
 
@@ -608,11 +608,11 @@ lemma chainBotCoeff_mul_chainTopCoeff :
   have hjl_mem : P.root j + P.root (-l) ∈ range P.root := by
     rw [h₁, ← neg_mem_range_root_iff] at h₃; convert h₃ using 1; simp [sub_eq_add_neg]
   have h₁' : P.root (-k) - P.root i = P.root (-l) := by
-    simp only [root_reflection_perm, reflection_apply_self, indexNeg_neg]; rw [← h₁]; abel
+    simp only [root_reflectionPerm, reflection_apply_self, indexNeg_neg]; rw [← h₁]; abel
   have h₂' : P.root (-k) + P.root j = P.root (-m) := by
-    simp only [root_reflection_perm, reflection_apply_self, indexNeg_neg]; rw [← h₂]; abel
+    simp only [root_reflectionPerm, reflection_apply_self, indexNeg_neg]; rw [← h₂]; abel
   have h₃' : P.root (-k) + P.root j - P.root i ∈ range P.root := by
-    simp only [root_reflection_perm, reflection_apply_self, indexNeg_neg]
+    simp only [root_reflectionPerm, reflection_apply_self, indexNeg_neg]
     rw [← neg_mem_range_root_iff]; convert h₃ using 1; abel
   /- Proceed to the main argument, following Geck's case splits. It's all just bookkeeping. -/
   rcases aux_0 hik_mem with hki | ⟨hki, hik⟩

--- a/Mathlib/LinearAlgebra/RootSystem/Chain.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Chain.lean
@@ -197,6 +197,9 @@ private lemma chainCoeff_reflectionPerm_left_aux :
     simp only [chainTopCoeff_of_not_linearIndependent h, chainTopCoeff_of_not_linearIndependent h',
       chainBotCoeff_of_not_linearIndependent h, chainBotCoeff_of_not_linearIndependent h']
 
+@[deprecated (since := "2025-05-28")]
+alias chainCoeff_reflection_perm_left_aux := chainCoeff_reflectionPerm_left_aux
+
 private lemma chainCoeff_reflectionPerm_right_aux :
     letI := P.indexNeg
     Icc (-P.chainTopCoeff i j : ℤ) (P.chainBotCoeff i j) =
@@ -212,6 +215,9 @@ private lemma chainCoeff_reflectionPerm_right_aux :
     simp only [chainTopCoeff_of_not_linearIndependent h, chainTopCoeff_of_not_linearIndependent h',
       chainBotCoeff_of_not_linearIndependent h, chainBotCoeff_of_not_linearIndependent h']
 
+@[deprecated (since := "2025-05-28")]
+alias chainCoeff_reflection_perm_right_aux := chainCoeff_reflectionPerm_right_aux
+
 @[simp]
 lemma chainTopCoeff_reflectionPerm_left :
     P.chainTopCoeff (P.reflectionPerm i i) j = P.chainBotCoeff i j := by
@@ -222,6 +228,9 @@ lemma chainTopCoeff_reflectionPerm_left :
   refine le_antisymm ?_ ?_
   · simpa using this (P.chainTopCoeff (-i) j)
   · simpa using this (P.chainBotCoeff i j)
+
+@[deprecated (since := "2025-05-28")]
+alias chainTopCoeff_reflection_perm_left := chainTopCoeff_reflectionPerm_left
 
 @[simp]
 lemma chainBotCoeff_reflectionPerm_left :
@@ -234,6 +243,9 @@ lemma chainBotCoeff_reflectionPerm_left :
   · simpa using this (-P.chainBotCoeff (-i) j)
   · simpa using this (-P.chainTopCoeff i j)
 
+@[deprecated (since := "2025-05-28")]
+alias chainBotCoeff_reflection_perm_left := chainBotCoeff_reflectionPerm_left
+
 @[simp]
 lemma chainTopCoeff_reflectionPerm_right :
     P.chainTopCoeff i (P.reflectionPerm j j) = P.chainBotCoeff i j := by
@@ -245,6 +257,9 @@ lemma chainTopCoeff_reflectionPerm_right :
   · simpa using this (P.chainTopCoeff i (-j))
   · simpa using this (P.chainBotCoeff i j)
 
+@[deprecated (since := "2025-05-28")]
+alias chainTopCoeff_reflection_perm_right := chainTopCoeff_reflectionPerm_right
+
 @[simp]
 lemma chainBotCoeff_reflectionPerm_right :
     P.chainBotCoeff i (P.reflectionPerm j j) = P.chainTopCoeff i j := by
@@ -255,6 +270,9 @@ lemma chainBotCoeff_reflectionPerm_right :
   refine le_antisymm ?_ ?_
   · simpa using this (-P.chainBotCoeff i (-j))
   · simpa using this (-P.chainTopCoeff i j)
+
+@[deprecated (since := "2025-05-28")]
+alias chainBotCoeff_reflection_perm_right := chainBotCoeff_reflectionPerm_right
 
 variable (i j)
 

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -236,6 +236,8 @@ lemma root_reflectionPerm (j : ι) :
     P.root (P.reflectionPerm i j) = (P.reflection i) (P.root j) :=
   (P.reflectionPerm_root i j).symm
 
+@[deprecated (since := "2025-05-28")] alias root_reflection_perm := root_reflectionPerm
+
 theorem mapsTo_reflection_root :
     MapsTo (P.reflection i) (range P.root) (range P.root) := by
   rintro - ⟨j, rfl⟩
@@ -274,21 +276,31 @@ lemma reflectionPerm_sq : P.reflectionPerm i ^ 2 = 1 := by
   apply P.root.injective
   simp only [sq, Equiv.Perm.mul_apply, root_reflectionPerm, reflection_same, Equiv.Perm.one_apply]
 
+@[deprecated (since := "2025-05-28")] alias reflection_perm_sq := reflectionPerm_sq
+
 @[simp]
 lemma reflectionPerm_inv : (P.reflectionPerm i)⁻¹ = P.reflectionPerm i :=
   (mul_eq_one_iff_eq_inv.mp <| P.reflectionPerm_sq i).symm
+
+@[deprecated (since := "2025-05-28")] alias reflection_perm_inv := reflectionPerm_inv
 
 @[simp]
 lemma reflectionPerm_self : P.reflectionPerm i (P.reflectionPerm i j) = j := by
   apply P.root.injective
   simp only [root_reflectionPerm, reflection_same]
 
+@[deprecated (since := "2025-05-28")] alias reflection_perm_self := reflectionPerm_self
+
 lemma reflectionPerm_involutive : Involutive (P.reflectionPerm i) :=
   involutive_iff_iter_2_eq_id.mpr (by ext; simp)
+
+@[deprecated (since := "2025-05-28")] alias reflection_perm_involutive := reflectionPerm_involutive
 
 @[simp]
 lemma reflectionPerm_symm : (P.reflectionPerm i).symm = P.reflectionPerm i :=
   Involutive.symm_eq_self_of_involutive (P.reflectionPerm i) <| P.reflectionPerm_involutive i
+
+@[deprecated (since := "2025-05-28")] alias reflection_perm_symm := reflectionPerm_symm
 
 lemma bijOn_reflection_root :
     BijOn (P.reflection i) (range P.root) (range P.root) :=
@@ -307,6 +319,8 @@ def coreflection : N ≃ₗ[R] N :=
 lemma coroot_reflectionPerm (j : ι) :
     P.coroot (P.reflectionPerm i j) = (P.coreflection i) (P.coroot j) :=
   (P.reflectionPerm_coroot i j).symm
+
+@[deprecated (since := "2025-05-28")] alias coroot_reflection_perm := coroot_reflectionPerm
 
 theorem mapsTo_coreflection_coroot :
     MapsTo (P.coreflection i) (range P.coroot) (range P.coroot) := by
@@ -369,6 +383,8 @@ lemma coroot'_reflectionPerm {i j : ι} :
   ext y
   simp [coreflection_apply_coroot, reflection_apply, map_sub, mul_comm]
 
+@[deprecated (since := "2025-05-28")] alias coroot'_reflection_perm := coroot'_reflectionPerm
+
 lemma coroot'_reflection {i j : ι} (y : M) :
     P.coroot' j (P.reflection i y) = P.coroot' (P.reflectionPerm i j) y :=
   (LinearMap.congr_fun P.coroot'_reflectionPerm y).symm
@@ -381,6 +397,8 @@ lemma pairing_reflectionPerm (i j k : ι) :
   simp [← toLinearMap_eq_toPerfectPairing, map_smul, LinearMap.smul_apply, map_sub, map_smul,
     LinearMap.sub_apply, smul_eq_mul]
   simp [mul_comm]
+
+@[deprecated (since := "2025-05-28")] alias pairing_reflection_perm := pairing_reflectionPerm
 
 @[simp]
 lemma toDualLeft_conj_reflection :
@@ -400,12 +418,18 @@ lemma pairing_reflectionPerm_self_left (P : RootPairing ι R M N) (i j : ι) :
     sub_add_cancel_left, ← toLinearMap_eq_toPerfectPairing, LinearMap.map_neg₂,
     toLinearMap_eq_toPerfectPairing, root'_coroot_eq_pairing]
 
+@[deprecated (since := "2025-05-28")]
+alias pairing_reflection_perm_self_left := pairing_reflectionPerm_self_left
+
 @[simp]
 lemma pairing_reflectionPerm_self_right (i j : ι) :
     P.pairing i (P.reflectionPerm j j) = - P.pairing i j := by
   rw [pairing, ← reflectionPerm_coroot, root_coroot_eq_pairing, pairing_same, two_smul,
     sub_add_cancel_left, ← toLinearMap_eq_toPerfectPairing, map_neg,
     toLinearMap_eq_toPerfectPairing, root_coroot_eq_pairing]
+
+@[deprecated (since := "2025-05-28")]
+alias pairing_reflection_perm_self_right := pairing_reflectionPerm_self_right
 
 /-- The indexing set of a root pairing carries an involutive negation, corresponding to the negation
 of a root / coroot. -/
@@ -524,6 +548,10 @@ lemma reflectionPerm_eq_reflectionPerm_iff_of_isSMulRegular (h2 : IsSMulRegular 
   replace h2 : IsSMulRegular (M → M) 2 := IsSMulRegular.pi fun _ ↦ h2
   exact h2 <| P.two_nsmul_reflection_eq_of_perm_eq i j h
 
+@[deprecated (since := "2025-05-28")]
+alias reflection_perm_eq_reflection_perm_iff_of_isSMulRegular :=
+  reflectionPerm_eq_reflectionPerm_iff_of_isSMulRegular
+
 lemma reflectionPerm_eq_reflectionPerm_iff_of_span :
     P.reflectionPerm i = P.reflectionPerm j ↔
     ∀ x ∈ span R (range P.root), P.reflection i x = P.reflection j x := by
@@ -539,11 +567,18 @@ lemma reflectionPerm_eq_reflectionPerm_iff_of_span :
     apply P.root.injective
     simp [h (P.root k) (Submodule.subset_span <| mem_range_self k)]
 
+@[deprecated (since := "2025-05-28")]
+alias reflection_perm_eq_reflection_perm_iff_of_span := reflectionPerm_eq_reflectionPerm_iff_of_span
+
 lemma _root_.RootSystem.reflectionPerm_eq_reflectionPerm_iff (P : RootSystem ι R M N) (i j : ι) :
     P.reflectionPerm i = P.reflectionPerm j ↔ P.reflection i = P.reflection j := by
   refine ⟨fun h ↦ ?_, fun h ↦ Equiv.ext fun k ↦ P.root.injective <| by simp [h]⟩
   ext x
   exact (P.reflectionPerm_eq_reflectionPerm_iff_of_span i j).mp h x <| by simp
+
+@[deprecated (since := "2025-05-28")]
+alias _root_.RootSystem.reflection_perm_eq_reflection_perm_iff :=
+  _root_.RootSystem.reflectionPerm_eq_reflectionPerm_iff
 
 @[simp] lemma toDualLeft_comp_root : P.toDualLeft ∘ P.root = P.root' := rfl
 
@@ -609,18 +644,30 @@ lemma reflectionPerm_eq_of_pairing_eq_zero (h : P.pairing j i = 0) :
     P.reflectionPerm i j = j :=
   P.root.injective <| by simp [reflection_apply, h]
 
+@[deprecated (since := "2025-05-28")]
+alias reflection_perm_eq_of_pairing_eq_zero := reflectionPerm_eq_of_pairing_eq_zero
+
 lemma reflectionPerm_eq_of_pairing_eq_zero' (h : P.pairing i j = 0) :
     P.reflectionPerm i j = j :=
   P.flip.reflectionPerm_eq_of_pairing_eq_zero h
+
+@[deprecated (since := "2025-05-28")]
+alias reflection_perm_eq_of_pairing_eq_zero' := reflectionPerm_eq_of_pairing_eq_zero'
 
 lemma reflectionPerm_eq_iff_smul_root :
     P.reflectionPerm i j = j ↔ P.pairing j i • P.root i = 0 :=
   ⟨fun h ↦ by simpa [h] using P.reflectionPerm_root i j,
     fun h ↦ P.root.injective <| by simp [reflection_apply, h]⟩
 
+@[deprecated (since := "2025-05-28")]
+alias reflection_perm_eq_iff_smul_root := reflectionPerm_eq_iff_smul_root
+
 lemma reflectionPerm_eq_iff_smul_coroot :
     P.reflectionPerm i j = j ↔ P.pairing i j • P.coroot i = 0 :=
   P.flip.reflectionPerm_eq_iff_smul_root
+
+@[deprecated (since := "2025-05-28")]
+alias reflection_perm_eq_iff_smul_coroot := reflectionPerm_eq_iff_smul_coroot
 
 lemma pairing_eq_zero_iff [NeZero (2 : R)] [NoZeroSMulDivisors R M] :
     P.pairing i j = 0 ↔ P.pairing j i = 0 := by
@@ -647,5 +694,8 @@ lemma isFixedPt_reflectionPerm_iff [NeZero (2 : R)] [NoZeroSMulDivisors R M] :
     IsFixedPt (P.reflectionPerm i) j ↔ P.pairing i j = 0 := by
   refine ⟨fun h ↦ ?_, P.reflectionPerm_eq_of_pairing_eq_zero'⟩
   simpa [P.ne_zero i, pairing_eq_zero_iff, IsFixedPt, reflectionPerm_eq_iff_smul_root] using h
+
+@[deprecated (since := "2025-05-28")]
+alias isFixedPt_reflection_perm_iff := isFixedPt_reflectionPerm_iff
 
 end RootPairing

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -85,11 +85,11 @@ structure RootPairing extends PerfectPairing R M N where
       `RootPairing.reflection`) leave the whole set of roots stable: as explained above, we
       formalize this stability by fixing the image of the roots through each reflection (whence the
       permutation); and similarly for coroots. -/
-  reflection_perm : ι → (ι ≃ ι)
-  reflection_perm_root : ∀ i j,
-    root j - toPerfectPairing (root j) (coroot i) • root i = root (reflection_perm i j)
-  reflection_perm_coroot : ∀ i j,
-    coroot j - toPerfectPairing (root i) (coroot j) • coroot i = coroot (reflection_perm i j)
+  reflectionPerm : ι → (ι ≃ ι)
+  reflectionPerm_root : ∀ i j,
+    root j - toPerfectPairing (root j) (coroot i) • root i = root (reflectionPerm i j)
+  reflectionPerm_coroot : ∀ i j,
+    coroot j - toPerfectPairing (root i) (coroot j) • coroot i = coroot (reflectionPerm i j)
 
 /-- A root datum is a root pairing with coefficients in the integers and for which the root and
 coroot spaces are finitely-generated free Abelian groups.
@@ -129,9 +129,9 @@ protected def flip : RootPairing ι R N M :=
     root := P.coroot
     coroot := P.root
     root_coroot_two := P.root_coroot_two
-    reflection_perm := P.reflection_perm
-    reflection_perm_root := P.reflection_perm_coroot
-    reflection_perm_coroot := P.reflection_perm_root }
+    reflectionPerm := P.reflectionPerm
+    reflectionPerm_root := P.reflectionPerm_coroot
+    reflectionPerm_coroot := P.reflectionPerm_root }
 
 @[simp]
 lemma flip_flip : P.flip.flip = P :=
@@ -232,14 +232,14 @@ def reflection : M ≃ₗ[R] M :=
   Module.reflection (P.flip.root_coroot_two i)
 
 @[simp]
-lemma root_reflection_perm (j : ι) :
-    P.root (P.reflection_perm i j) = (P.reflection i) (P.root j) :=
-  (P.reflection_perm_root i j).symm
+lemma root_reflectionPerm (j : ι) :
+    P.root (P.reflectionPerm i j) = (P.reflection i) (P.root j) :=
+  (P.reflectionPerm_root i j).symm
 
 theorem mapsTo_reflection_root :
     MapsTo (P.reflection i) (range P.root) (range P.root) := by
   rintro - ⟨j, rfl⟩
-  exact P.root_reflection_perm i j ▸ mem_range_self (P.reflection_perm i j)
+  exact P.root_reflectionPerm i j ▸ mem_range_self (P.reflectionPerm i j)
 
 lemma reflection_apply (x : M) :
     P.reflection i x = x - (P.coroot' i x) • P.root i :=
@@ -265,33 +265,30 @@ lemma reflection_inv :
   rfl
 
 @[simp]
-lemma reflection_sq :
-    P.reflection i ^ 2 = 1 :=
+lemma reflection_sq : P.reflection i ^ 2 = 1 :=
   mul_eq_one_iff_eq_inv.mpr rfl
 
 @[simp]
-lemma reflection_perm_sq :
-    P.reflection_perm i ^ 2 = 1 := by
+lemma reflectionPerm_sq : P.reflectionPerm i ^ 2 = 1 := by
   ext j
   apply P.root.injective
-  simp only [sq, Equiv.Perm.mul_apply, root_reflection_perm, reflection_same, Equiv.Perm.one_apply]
+  simp only [sq, Equiv.Perm.mul_apply, root_reflectionPerm, reflection_same, Equiv.Perm.one_apply]
 
 @[simp]
-lemma reflection_perm_inv :
-    (P.reflection_perm i)⁻¹ = P.reflection_perm i :=
-  (mul_eq_one_iff_eq_inv.mp <| P.reflection_perm_sq i).symm
+lemma reflectionPerm_inv : (P.reflectionPerm i)⁻¹ = P.reflectionPerm i :=
+  (mul_eq_one_iff_eq_inv.mp <| P.reflectionPerm_sq i).symm
 
 @[simp]
-lemma reflection_perm_self : P.reflection_perm i (P.reflection_perm i j) = j := by
+lemma reflectionPerm_self : P.reflectionPerm i (P.reflectionPerm i j) = j := by
   apply P.root.injective
-  simp only [root_reflection_perm, reflection_same]
+  simp only [root_reflectionPerm, reflection_same]
 
-lemma reflection_perm_involutive : Involutive (P.reflection_perm i) :=
+lemma reflectionPerm_involutive : Involutive (P.reflectionPerm i) :=
   involutive_iff_iter_2_eq_id.mpr (by ext; simp)
 
 @[simp]
-lemma reflection_perm_symm : (P.reflection_perm i).symm = P.reflection_perm i :=
-  Involutive.symm_eq_self_of_involutive (P.reflection_perm i) <| P.reflection_perm_involutive i
+lemma reflectionPerm_symm : (P.reflectionPerm i).symm = P.reflectionPerm i :=
+  Involutive.symm_eq_self_of_involutive (P.reflectionPerm i) <| P.reflectionPerm_involutive i
 
 lemma bijOn_reflection_root :
     BijOn (P.reflection i) (range P.root) (range P.root) :=
@@ -307,14 +304,14 @@ def coreflection : N ≃ₗ[R] N :=
   Module.reflection (P.root_coroot_two i)
 
 @[simp]
-lemma coroot_reflection_perm (j : ι) :
-    P.coroot (P.reflection_perm i j) = (P.coreflection i) (P.coroot j) :=
-  (P.reflection_perm_coroot i j).symm
+lemma coroot_reflectionPerm (j : ι) :
+    P.coroot (P.reflectionPerm i j) = (P.coreflection i) (P.coroot j) :=
+  (P.reflectionPerm_coroot i j).symm
 
 theorem mapsTo_coreflection_coroot :
     MapsTo (P.coreflection i) (range P.coroot) (range P.coroot) := by
   rintro - ⟨j, rfl⟩
-  exact P.coroot_reflection_perm i j ▸ mem_range_self (P.reflection_perm i j)
+  exact P.coroot_reflectionPerm i j ▸ mem_range_self (P.reflectionPerm i j)
 
 lemma coreflection_apply (f : N) :
     P.coreflection i f = f - (P.root' i) f • P.coroot i :=
@@ -364,21 +361,21 @@ lemma reflection_dualMap_eq_coreflection :
 lemma coroot_eq_coreflection_of_root_eq
     {i j k : ι} (hk : P.root k = P.reflection i (P.root j)) :
     P.coroot k = P.coreflection i (P.coroot j) := by
-  rw [← P.root_reflection_perm, EmbeddingLike.apply_eq_iff_eq] at hk
-  rw [← P.coroot_reflection_perm, hk]
+  rw [← P.root_reflectionPerm, EmbeddingLike.apply_eq_iff_eq] at hk
+  rw [← P.coroot_reflectionPerm, hk]
 
-lemma coroot'_reflection_perm {i j : ι} :
-    P.coroot' (P.reflection_perm i j) = P.coroot' j ∘ₗ P.reflection i := by
+lemma coroot'_reflectionPerm {i j : ι} :
+    P.coroot' (P.reflectionPerm i j) = P.coroot' j ∘ₗ P.reflection i := by
   ext y
   simp [coreflection_apply_coroot, reflection_apply, map_sub, mul_comm]
 
 lemma coroot'_reflection {i j : ι} (y : M) :
-    P.coroot' j (P.reflection i y) = P.coroot' (P.reflection_perm i j) y :=
-  (LinearMap.congr_fun P.coroot'_reflection_perm y).symm
+    P.coroot' j (P.reflection i y) = P.coroot' (P.reflectionPerm i j) y :=
+  (LinearMap.congr_fun P.coroot'_reflectionPerm y).symm
 
-lemma pairing_reflection_perm (i j k : ι) :
-    P.pairing j (P.reflection_perm i k) = P.pairing (P.reflection_perm i j) k := by
-  simp only [pairing, root', coroot_reflection_perm, root_reflection_perm]
+lemma pairing_reflectionPerm (i j k : ι) :
+    P.pairing j (P.reflectionPerm i k) = P.pairing (P.reflectionPerm i j) k := by
+  simp only [pairing, root', coroot_reflectionPerm, root_reflectionPerm]
   simp only [coreflection_apply_coroot, map_sub, map_smul, smul_eq_mul,
     reflection_apply_root]
   simp [← toLinearMap_eq_toPerfectPairing, map_smul, LinearMap.smul_apply, map_sub, map_smul,
@@ -397,27 +394,27 @@ lemma toDualRight_conj_coreflection :
   P.flip.toDualLeft_conj_reflection i
 
 @[simp]
-lemma pairing_reflection_perm_self_left (P : RootPairing ι R M N) (i j : ι) :
-    P.pairing (P.reflection_perm i i) j = - P.pairing i j := by
-  rw [pairing, root', ← reflection_perm_root, root'_coroot_eq_pairing, pairing_same, two_smul,
+lemma pairing_reflectionPerm_self_left (P : RootPairing ι R M N) (i j : ι) :
+    P.pairing (P.reflectionPerm i i) j = - P.pairing i j := by
+  rw [pairing, root', ← reflectionPerm_root, root'_coroot_eq_pairing, pairing_same, two_smul,
     sub_add_cancel_left, ← toLinearMap_eq_toPerfectPairing, LinearMap.map_neg₂,
     toLinearMap_eq_toPerfectPairing, root'_coroot_eq_pairing]
 
 @[simp]
-lemma pairing_reflection_perm_self_right (i j : ι) :
-    P.pairing i (P.reflection_perm j j) = - P.pairing i j := by
-  rw [pairing, ← reflection_perm_coroot, root_coroot_eq_pairing, pairing_same, two_smul,
+lemma pairing_reflectionPerm_self_right (i j : ι) :
+    P.pairing i (P.reflectionPerm j j) = - P.pairing i j := by
+  rw [pairing, ← reflectionPerm_coroot, root_coroot_eq_pairing, pairing_same, two_smul,
     sub_add_cancel_left, ← toLinearMap_eq_toPerfectPairing, map_neg,
     toLinearMap_eq_toPerfectPairing, root_coroot_eq_pairing]
 
 /-- The indexing set of a root pairing carries an involutive negation, corresponding to the negation
 of a root / coroot. -/
 @[simps] def indexNeg : InvolutiveNeg ι where
-  neg i := P.reflection_perm i i
+  neg i := P.reflectionPerm i i
   neg_neg i := by
     apply P.root.injective
-    simp only [root_reflection_perm, reflection_apply, PerfectPairing.flip_apply_apply,
-      root_coroot_eq_pairing, pairing_same, map_sub, map_smul, coroot_reflection_perm,
+    simp only [root_reflectionPerm, reflection_apply, PerfectPairing.flip_apply_apply,
+      root_coroot_eq_pairing, pairing_same, map_sub, map_smul, coroot_reflectionPerm,
       coreflection_apply_self, LinearMap.sub_apply, map_neg, LinearMap.smul_apply, smul_eq_mul,
       mul_neg, sub_neg_eq_add]
     module
@@ -425,14 +422,14 @@ of a root / coroot. -/
 variable {i j} in
 @[simp]
 lemma root_eq_neg_iff :
-    P.root i = - P.root j ↔ i = P.reflection_perm j j := by
+    P.root i = - P.root j ↔ i = P.reflectionPerm j j := by
   refine ⟨fun h ↦ P.root.injective ?_, fun h ↦ by simp [h]⟩
-  rw [root_reflection_perm, reflection_apply_self, h]
+  rw [root_reflectionPerm, reflection_apply_self, h]
 
 variable {i j} in
 @[simp]
 lemma coroot_eq_neg_iff :
-    P.coroot i = - P.coroot j ↔ i = P.reflection_perm j j :=
+    P.coroot i = - P.coroot j ↔ i = P.reflectionPerm j j :=
   P.flip.root_eq_neg_iff
 
 lemma neg_mem_range_root_iff {x : M} :
@@ -442,7 +439,7 @@ lemma neg_mem_range_root_iff {x : M} :
     rw [← neg_neg x] at h
     exact this (-x) h
   intro y ⟨i, hi⟩
-  exact ⟨P.reflection_perm i i, by simp [neg_eq_iff_eq_neg.mpr hi]⟩
+  exact ⟨P.reflectionPerm i i, by simp [neg_eq_iff_eq_neg.mpr hi]⟩
 
 lemma neg_mem_range_coroot_iff {x : N} :
     -x ∈ range P.coroot ↔ x ∈ range P.coroot :=
@@ -450,7 +447,7 @@ lemma neg_mem_range_coroot_iff {x : N} :
 
 lemma neg_root_mem :
     - P.root i ∈ range P.root :=
-  ⟨P.reflection_perm i i, by simp⟩
+  ⟨P.reflectionPerm i i, by simp⟩
 
 lemma neg_coroot_mem :
     - P.coroot i ∈ range P.coroot :=
@@ -481,28 +478,28 @@ lemma mem_range_root_of_mem_range_reflection_of_mem_range_root
     r • α ∈ range P.root := by
   obtain ⟨i, rfl⟩ := hr
   obtain ⟨j, rfl⟩ := hα
-  exact ⟨P.reflection_perm i j, P.root_reflection_perm i j⟩
+  exact ⟨P.reflectionPerm i j, P.root_reflectionPerm i j⟩
 
 lemma mem_range_coroot_of_mem_range_coreflection_of_mem_range_coroot
     {r : N ≃ₗ[R] N} {α : N} (hr : r ∈ range P.coreflection) (hα : α ∈ range P.coroot) :
     r • α ∈ range P.coroot := by
   obtain ⟨i, rfl⟩ := hr
   obtain ⟨j, rfl⟩ := hα
-  exact ⟨P.reflection_perm i j, P.coroot_reflection_perm i j⟩
+  exact ⟨P.reflectionPerm i j, P.coroot_reflectionPerm i j⟩
 
-lemma pairing_smul_root_eq (k : ι) (hij : P.reflection_perm i = P.reflection_perm j) :
+lemma pairing_smul_root_eq (k : ι) (hij : P.reflectionPerm i = P.reflectionPerm j) :
     P.pairing k i • P.root i = P.pairing k j • P.root j := by
   have h : P.reflection i (P.root k) = P.reflection j (P.root k) := by
-    simp only [← root_reflection_perm, hij]
+    simp only [← root_reflectionPerm, hij]
   simpa only [reflection_apply_root, sub_right_inj] using h
 
-lemma pairing_smul_coroot_eq (k : ι) (hij : P.reflection_perm i = P.reflection_perm j) :
+lemma pairing_smul_coroot_eq (k : ι) (hij : P.reflectionPerm i = P.reflectionPerm j) :
     P.pairing i k • P.coroot i = P.pairing j k • P.coroot j := by
   have h : P.coreflection i (P.coroot k) = P.coreflection j (P.coroot k) := by
-    simp only [← coroot_reflection_perm, hij]
+    simp only [← coroot_reflectionPerm, hij]
   simpa only [coreflection_apply_coroot, sub_right_inj] using h
 
-lemma two_nsmul_reflection_eq_of_perm_eq (hij : P.reflection_perm i = P.reflection_perm j) :
+lemma two_nsmul_reflection_eq_of_perm_eq (hij : P.reflectionPerm i = P.reflectionPerm j) :
     2 • ⇑(P.reflection i) = 2 • P.reflection j := by
   ext x
   suffices
@@ -520,21 +517,21 @@ lemma two_nsmul_reflection_eq_of_perm_eq (hij : P.reflection_perm i = P.reflecti
   · rw [← P.pairing_smul_coroot_eq j i j hij.symm, pairing_same]
   · rw [map_smul, smul_assoc, ← Nat.cast_smul_eq_nsmul R, Nat.cast_ofNat]
 
-lemma reflection_perm_eq_reflection_perm_iff_of_isSMulRegular (h2 : IsSMulRegular M 2) :
-    P.reflection_perm i = P.reflection_perm j ↔ P.reflection i = P.reflection j := by
+lemma reflectionPerm_eq_reflectionPerm_iff_of_isSMulRegular (h2 : IsSMulRegular M 2) :
+    P.reflectionPerm i = P.reflectionPerm j ↔ P.reflection i = P.reflection j := by
   refine ⟨fun h ↦ ?_, fun h ↦ Equiv.ext fun k ↦ P.root.injective <| by simp [h]⟩
   suffices ⇑(P.reflection i) = ⇑(P.reflection j) from DFunLike.coe_injective this
   replace h2 : IsSMulRegular (M → M) 2 := IsSMulRegular.pi fun _ ↦ h2
   exact h2 <| P.two_nsmul_reflection_eq_of_perm_eq i j h
 
-lemma reflection_perm_eq_reflection_perm_iff_of_span :
-    P.reflection_perm i = P.reflection_perm j ↔
+lemma reflectionPerm_eq_reflectionPerm_iff_of_span :
+    P.reflectionPerm i = P.reflectionPerm j ↔
     ∀ x ∈ span R (range P.root), P.reflection i x = P.reflection j x := by
   refine ⟨fun h x hx ↦ ?_, fun h ↦ ?_⟩
   · induction hx using Submodule.span_induction with
     | mem x hx =>
       obtain ⟨k, rfl⟩ := hx
-      simp only [← root_reflection_perm, h]
+      simp only [← root_reflectionPerm, h]
     | zero => simp
     | add x y _ _ hx hy => simp [hx, hy]
     | smul t x _ hx => simp [hx]
@@ -542,11 +539,11 @@ lemma reflection_perm_eq_reflection_perm_iff_of_span :
     apply P.root.injective
     simp [h (P.root k) (Submodule.subset_span <| mem_range_self k)]
 
-lemma _root_.RootSystem.reflection_perm_eq_reflection_perm_iff (P : RootSystem ι R M N) (i j : ι) :
-    P.reflection_perm i = P.reflection_perm j ↔ P.reflection i = P.reflection j := by
+lemma _root_.RootSystem.reflectionPerm_eq_reflectionPerm_iff (P : RootSystem ι R M N) (i j : ι) :
+    P.reflectionPerm i = P.reflectionPerm j ↔ P.reflection i = P.reflection j := by
   refine ⟨fun h ↦ ?_, fun h ↦ Equiv.ext fun k ↦ P.root.injective <| by simp [h]⟩
   ext x
-  exact (P.reflection_perm_eq_reflection_perm_iff_of_span i j).mp h x <| by simp
+  exact (P.reflectionPerm_eq_reflectionPerm_iff_of_span i j).mp h x <| by simp
 
 @[simp] lemma toDualLeft_comp_root : P.toDualLeft ∘ P.root = P.root' := rfl
 
@@ -608,29 +605,29 @@ lemma isFixedPt_reflection_of_isOrthogonal {s : Set ι} (hj : ∀ i ∈ s, P.IsO
       obtain ⟨i, his, rfl⟩ := hu
       exact IsOrthogonal.reflection_apply_right <| hj i his
 
-lemma reflection_perm_eq_of_pairing_eq_zero (h : P.pairing j i = 0) :
-    P.reflection_perm i j = j :=
+lemma reflectionPerm_eq_of_pairing_eq_zero (h : P.pairing j i = 0) :
+    P.reflectionPerm i j = j :=
   P.root.injective <| by simp [reflection_apply, h]
 
-lemma reflection_perm_eq_of_pairing_eq_zero' (h : P.pairing i j = 0) :
-    P.reflection_perm i j = j :=
-  P.flip.reflection_perm_eq_of_pairing_eq_zero h
+lemma reflectionPerm_eq_of_pairing_eq_zero' (h : P.pairing i j = 0) :
+    P.reflectionPerm i j = j :=
+  P.flip.reflectionPerm_eq_of_pairing_eq_zero h
 
-lemma reflection_perm_eq_iff_smul_root :
-    P.reflection_perm i j = j ↔ P.pairing j i • P.root i = 0 :=
-  ⟨fun h ↦ by simpa [h] using P.reflection_perm_root i j,
+lemma reflectionPerm_eq_iff_smul_root :
+    P.reflectionPerm i j = j ↔ P.pairing j i • P.root i = 0 :=
+  ⟨fun h ↦ by simpa [h] using P.reflectionPerm_root i j,
     fun h ↦ P.root.injective <| by simp [reflection_apply, h]⟩
 
-lemma reflection_perm_eq_iff_smul_coroot :
-    P.reflection_perm i j = j ↔ P.pairing i j • P.coroot i = 0 :=
-  P.flip.reflection_perm_eq_iff_smul_root
+lemma reflectionPerm_eq_iff_smul_coroot :
+    P.reflectionPerm i j = j ↔ P.pairing i j • P.coroot i = 0 :=
+  P.flip.reflectionPerm_eq_iff_smul_root
 
 lemma pairing_eq_zero_iff [NeZero (2 : R)] [NoZeroSMulDivisors R M] :
     P.pairing i j = 0 ↔ P.pairing j i = 0 := by
   suffices ∀ {i j : ι}, P.pairing i j = 0 → P.pairing j i = 0 from ⟨this, this⟩
   intro i j h
-  simpa [P.ne_zero i, reflection_perm_eq_iff_smul_root] using
-    P.reflection_perm_eq_of_pairing_eq_zero' h
+  simpa [P.ne_zero i, reflectionPerm_eq_iff_smul_root] using
+    P.reflectionPerm_eq_of_pairing_eq_zero' h
 
 lemma pairing_eq_zero_iff' [NeZero (2 : R)] [IsDomain R] :
     P.pairing i j = 0 ↔ P.pairing j i = 0 := by
@@ -646,9 +643,9 @@ lemma isOrthogonal_iff_pairing_eq_zero [NeZero (2 : R)] [NoZeroSMulDivisors R M]
     P.IsOrthogonal i j ↔ P.pairing i j = 0 :=
   ⟨fun h ↦ h.1, fun h ↦ ⟨h, pairing_eq_zero_iff.mp h⟩⟩
 
-lemma isFixedPt_reflection_perm_iff [NeZero (2 : R)] [NoZeroSMulDivisors R M] :
-    IsFixedPt (P.reflection_perm i) j ↔ P.pairing i j = 0 := by
-  refine ⟨fun h ↦ ?_, P.reflection_perm_eq_of_pairing_eq_zero'⟩
-  simpa [P.ne_zero i, pairing_eq_zero_iff, IsFixedPt, reflection_perm_eq_iff_smul_root] using h
+lemma isFixedPt_reflectionPerm_iff [NeZero (2 : R)] [NoZeroSMulDivisors R M] :
+    IsFixedPt (P.reflectionPerm i) j ↔ P.pairing i j = 0 := by
+  refine ⟨fun h ↦ ?_, P.reflectionPerm_eq_of_pairing_eq_zero'⟩
+  simpa [P.ne_zero i, pairing_eq_zero_iff, IsFixedPt, reflectionPerm_eq_iff_smul_root] using h
 
 end RootPairing

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
@@ -137,8 +137,8 @@ lemma rootForm_symmetric :
 lemma rootForm_reflection_reflection_apply (i : ι) (x y : M) :
     P.RootForm (P.reflection i x) (P.reflection i y) = P.RootForm x y := by
   simp only [rootForm_apply_apply, coroot'_reflection]
-  exact Fintype.sum_equiv (P.reflection_perm i)
-    (fun j ↦ (P.coroot' (P.reflection_perm i j) x) * (P.coroot' (P.reflection_perm i j) y))
+  exact Fintype.sum_equiv (P.reflectionPerm i)
+    (fun j ↦ (P.coroot' (P.reflectionPerm i j) x) * (P.coroot' (P.reflectionPerm i j) y))
     (fun j ↦ P.coroot' j x * P.coroot' j y) (congrFun rfl)
 
 lemma rootForm_self_sum_of_squares (x : M) :
@@ -243,16 +243,16 @@ lemma rootFormIn_self_smul_coroot (i : ι) :
     P.RootFormIn S (P.rootSpanMem S i) (P.rootSpanMem S i) • P.coroot i =
       2 • P.PolarizationIn S (P.rootSpanMem S i) := by
   have hP : P.PolarizationIn S (P.rootSpanMem S i) =
-      ∑ j : ι, P.pairingIn S i (P.reflection_perm i j) • P.coroot (P.reflection_perm i j) := by
+      ∑ j : ι, P.pairingIn S i (P.reflectionPerm i j) • P.coroot (P.reflectionPerm i j) := by
     simp_rw [PolarizationIn_apply, coroot'In_rootSpanMem_eq_pairingIn]
-    exact (Fintype.sum_equiv (P.reflection_perm i)
-          (fun j ↦ P.pairingIn S i (P.reflection_perm i j) • P.coroot (P.reflection_perm i j))
+    exact (Fintype.sum_equiv (P.reflectionPerm i)
+          (fun j ↦ P.pairingIn S i (P.reflectionPerm i j) • P.coroot (P.reflectionPerm i j))
           (fun j ↦ P.pairingIn S i j • P.coroot j) (congrFun rfl)).symm
   rw [two_nsmul]
   nth_rw 2 [hP]
   rw [PolarizationIn_apply]
-  simp only [coroot'In_rootSpanMem_eq_pairingIn, pairingIn_reflection_perm,
-    pairingIn_reflection_perm_self_left, ← reflection_perm_coroot, neg_smul, Finset.sum_neg_distrib,
+  simp only [coroot'In_rootSpanMem_eq_pairingIn, pairingIn_reflectionPerm,
+    pairingIn_reflectionPerm_self_left, ← reflectionPerm_coroot, neg_smul, Finset.sum_neg_distrib,
     smul_sub, sub_neg_eq_add]
   rw [Finset.sum_add_distrib, ← add_assoc, ← sub_eq_iff_eq_add, RootFormIn]
   simp only [LinearMap.coeFn_sum, LinearMap.coe_smulRight, Finset.sum_apply,
@@ -387,7 +387,7 @@ lemma zero_lt_pairingIn_iff' :
 
 lemma pairingIn_lt_zero_iff :
     P.pairingIn S i j < 0 ↔ P.pairingIn S j i < 0 := by
-  simpa using P.zero_lt_pairingIn_iff' S (i := i) (j := P.reflection_perm j j)
+  simpa using P.zero_lt_pairingIn_iff' S (i := i) (j := P.reflectionPerm j j)
 
 lemma pairingIn_le_zero_iff [NeZero (2 : R)] [NoZeroSMulDivisors R M] :
     P.pairingIn S i j ≤ 0 ↔ P.pairingIn S j i ≤ 0 := by

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/G2.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/G2.lean
@@ -87,7 +87,7 @@ lemma not_isG2_iff_isNotG2 :
     ¬ P.IsG2 ↔ P.IsNotG2 := by
   simp only [isG2_iff, isNotG2_iff, not_exists, Set.mem_insert_iff, mem_singleton_iff]
   refine ⟨fun h i j ↦ ?_, fun h i j ↦ ?_⟩
-  · have hij := h (P.reflection_perm i i) j
+  · have hij := h (P.reflectionPerm i i) j
     have := P.pairingIn_pairingIn_mem_set_of_isCrystal_of_isRed i j
     aesop
   · specialize h i j
@@ -119,7 +119,7 @@ namespace EmbeddedG2
 /-- A pair of roots which pair to `+3` are also sufficient to distinguish an embedded `𝔤₂`. -/
 @[simps] def ofPairingInThree [CharZero R] [P.IsCrystallographic] [P.IsReduced] (long short : ι)
     (h : P.pairingIn ℤ long short = 3) : P.EmbeddedG2 where
-  long := P.reflection_perm long long
+  long := P.reflectionPerm long long
   short := short
   pairingIn_long_short := by simp [h]
 
@@ -136,16 +136,16 @@ lemma pairing_long_short : P.pairing (long P) (short P) = - 3 := by
   simp
 
 /-- The index of the root `α + β` where `α` is the short root and `β` is the long root. -/
-def shortAddLong : ι := P.reflection_perm (long P) (short P)
+def shortAddLong : ι := P.reflectionPerm (long P) (short P)
 
 /-- The index of the root `2α + β` where `α` is the short root and `β` is the long root. -/
-def twoShortAddLong : ι := P.reflection_perm (short P) <| P.reflection_perm (long P) (short P)
+def twoShortAddLong : ι := P.reflectionPerm (short P) <| P.reflectionPerm (long P) (short P)
 
 /-- The index of the root `3α + β` where `α` is the short root and `β` is the long root. -/
-def threeShortAddLong : ι := P.reflection_perm (short P) (long P)
+def threeShortAddLong : ι := P.reflectionPerm (short P) (long P)
 
 /-- The index of the root `3α + 2β` where `α` is the short root and `β` is the long root. -/
-def threeShortAddTwoLong : ι := P.reflection_perm (long P) <| P.reflection_perm (short P) (long P)
+def threeShortAddTwoLong : ι := P.reflectionPerm (long P) <| P.reflectionPerm (short P) (long P)
 
 /-- The short root `α`. -/
 abbrev shortRoot := P.root (short P)

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -197,10 +197,10 @@ lemma root_sub_root_mem_of_pairingIn_pos (h : 0 < P.pairingIn ℤ i j) (h' : i �
     suffices P.pairingIn ℤ i j = 1 ∨ P.pairingIn ℤ j i = 1 by
       rcases this with h₁ | h₁
       · replace h₁ : P.pairing i j = 1 := by simpa [← P.algebraMap_pairingIn ℤ]
-        exact ⟨P.reflection_perm j i, by simpa [h₁] using P.reflection_apply_root j i⟩
+        exact ⟨P.reflectionPerm j i, by simpa [h₁] using P.reflection_apply_root j i⟩
       · replace h₁ : P.pairing j i = 1 := by simpa [← P.algebraMap_pairingIn ℤ]
         rw [← neg_mem_range_root_iff, neg_sub]
-        exact ⟨P.reflection_perm i j, by simpa [h₁] using P.reflection_apply_root i j⟩
+        exact ⟨P.reflectionPerm i j, by simpa [h₁] using P.reflection_apply_root i j⟩
     have : P.coxeterWeightIn ℤ i j ∈ ({1, 2, 3} : Set _) := by
       have aux₁ := P.coxeterWeightIn_mem_set_of_isCrystallographic i j
       have aux₂ := (linearIndependent_iff_coxeterWeightIn_ne_four P ℤ).mp hli
@@ -455,12 +455,12 @@ lemma root_add_root_mem_of_mem_of_mem (hk : α k + α i - α j ∈ Φ)
   replace hk : α (-k) + α j - α i ∈ Φ := by
     rw [← neg_mem_range_root_iff]
     convert hk using 1
-    simp only [indexNeg_neg, root_reflection_perm, reflection_apply_self]
+    simp only [indexNeg_neg, root_reflectionPerm, reflection_apply_self]
     module
   rw [← neg_mem_range_root_iff]
   convert b.root_sub_root_mem_of_mem_of_mem j i (-k) hij.symm hj hi hk (by contrapose! hkj; aesop)
     (by convert P.neg_mem_range_root_iff.mpr hk' using 1; simp [neg_add_eq_sub]) using 1
-  simp only [indexNeg_neg, root_reflection_perm, reflection_apply_self]
+  simp only [indexNeg_neg, root_reflectionPerm, reflection_apply_self]
   module
 
 end Base

--- a/Mathlib/LinearAlgebra/RootSystem/Hom.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Hom.lean
@@ -602,7 +602,7 @@ lemma indexEquiv_inv {P : RootPairing ι R M N} (g : Aut P) :
 def reflection (P : RootPairing ι R M N) (i : ι) : Aut P where
   weightMap := P.reflection i
   coweightMap := P.coreflection i
-  indexEquiv := P.reflection_perm i
+  indexEquiv := P.reflectionPerm i
   weight_coweight_transpose := by
     ext f x
     simp only [LinearMap.coe_comp, LinearEquiv.coe_coe, comp_apply,
@@ -633,7 +633,7 @@ lemma reflection_coweightEquiv (P : RootPairing ι R M N) (i : ι) :
 
 @[simp]
 lemma reflection_indexEquiv (P : RootPairing ι R M N) (i : ι) :
-    (reflection P i).indexEquiv = P.reflection_perm i :=
+    (reflection P i).indexEquiv = P.reflectionPerm i :=
   rfl
 
 @[simp]

--- a/Mathlib/LinearAlgebra/RootSystem/IsValuedIn.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/IsValuedIn.lean
@@ -82,19 +82,19 @@ lemma pairingIn_same [FaithfulSMul S R] [P.IsValuedIn S] (i : ι) :
     P.pairingIn S i i = 2 :=
   FaithfulSMul.algebraMap_injective S R <| by simp [map_ofNat]
 
-lemma pairingIn_reflection_perm [FaithfulSMul S R] [P.IsValuedIn S] (i j k : ι) :
-    P.pairingIn S j (P.reflection_perm i k) = P.pairingIn S (P.reflection_perm i j) k := by
+lemma pairingIn_reflectionPerm [FaithfulSMul S R] [P.IsValuedIn S] (i j k : ι) :
+    P.pairingIn S j (P.reflectionPerm i k) = P.pairingIn S (P.reflectionPerm i j) k := by
   simp only [← (FaithfulSMul.algebraMap_injective S R).eq_iff, algebraMap_pairingIn]
-  exact pairing_reflection_perm P i j k
+  exact pairing_reflectionPerm P i j k
 
 @[simp]
-lemma pairingIn_reflection_perm_self_left [FaithfulSMul S R] [P.IsValuedIn S] (i j : ι) :
-    P.pairingIn S (P.reflection_perm i i) j = - P.pairingIn S i j := by
+lemma pairingIn_reflectionPerm_self_left [FaithfulSMul S R] [P.IsValuedIn S] (i j : ι) :
+    P.pairingIn S (P.reflectionPerm i i) j = - P.pairingIn S i j := by
   simp [← (FaithfulSMul.algebraMap_injective S R).eq_iff]
 
 @[simp]
-lemma pairingIn_reflection_perm_self_right [FaithfulSMul S R] [P.IsValuedIn S] (i j : ι) :
-    P.pairingIn S i (P.reflection_perm j j) = - P.pairingIn S i j := by
+lemma pairingIn_reflectionPerm_self_right [FaithfulSMul S R] [P.IsValuedIn S] (i j : ι) :
+    P.pairingIn S i (P.reflectionPerm j j) = - P.pairingIn S i j := by
   simp [← (FaithfulSMul.algebraMap_injective S R).eq_iff]
 
 lemma IsValuedIn.trans (T : Type*) [CommRing T] [Algebra T S] [Algebra T R] [IsScalarTower T S R]
@@ -144,13 +144,13 @@ abbrev corootSpanMem [Module S N] (i : ι) : P.corootSpan S :=
   ⟨P.coroot i, Submodule.subset_span (mem_range_self i)⟩
 
 omit [Algebra S R] in
-lemma rootSpanMem_reflection_perm_self [Module S M] (i : ι) :
-    P.rootSpanMem S (P.reflection_perm i i) = - P.rootSpanMem S i := by
+lemma rootSpanMem_reflectionPerm_self [Module S M] (i : ι) :
+    P.rootSpanMem S (P.reflectionPerm i i) = - P.rootSpanMem S i := by
   ext; simp
 
 omit [Algebra S R] in
-lemma corootSpanMem_reflection_perm_self [Module S N] (i : ι) :
-    P.corootSpanMem S (P.reflection_perm i i) = - P.corootSpanMem S i := by
+lemma corootSpanMem_reflectionPerm_self [Module S N] (i : ι) :
+    P.corootSpanMem S (P.reflectionPerm i i) = - P.corootSpanMem S i := by
   ext; simp
 
 /-- The `S`-linear map on the span of coroots given by evaluating at a root. -/

--- a/Mathlib/LinearAlgebra/RootSystem/IsValuedIn.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/IsValuedIn.lean
@@ -87,15 +87,23 @@ lemma pairingIn_reflectionPerm [FaithfulSMul S R] [P.IsValuedIn S] (i j k : ι) 
   simp only [← (FaithfulSMul.algebraMap_injective S R).eq_iff, algebraMap_pairingIn]
   exact pairing_reflectionPerm P i j k
 
+@[deprecated (since := "2025-05-28")] alias pairingIn_reflection_perm := pairingIn_reflectionPerm
+
 @[simp]
 lemma pairingIn_reflectionPerm_self_left [FaithfulSMul S R] [P.IsValuedIn S] (i j : ι) :
     P.pairingIn S (P.reflectionPerm i i) j = - P.pairingIn S i j := by
   simp [← (FaithfulSMul.algebraMap_injective S R).eq_iff]
 
+@[deprecated (since := "2025-05-28")]
+alias pairingIn_reflection_perm_self_left := pairingIn_reflectionPerm_self_left
+
 @[simp]
 lemma pairingIn_reflectionPerm_self_right [FaithfulSMul S R] [P.IsValuedIn S] (i j : ι) :
     P.pairingIn S i (P.reflectionPerm j j) = - P.pairingIn S i j := by
   simp [← (FaithfulSMul.algebraMap_injective S R).eq_iff]
+
+@[deprecated (since := "2025-05-28")]
+alias pairingIn_reflection_perm_self_right := pairingIn_reflectionPerm_self_right
 
 lemma IsValuedIn.trans (T : Type*) [CommRing T] [Algebra T S] [Algebra T R] [IsScalarTower T S R]
     [P.IsValuedIn T] :
@@ -148,10 +156,16 @@ lemma rootSpanMem_reflectionPerm_self [Module S M] (i : ι) :
     P.rootSpanMem S (P.reflectionPerm i i) = - P.rootSpanMem S i := by
   ext; simp
 
+@[deprecated (since := "2025-05-28")]
+alias rootSpanMem_reflection_perm_self := rootSpanMem_reflectionPerm_self
+
 omit [Algebra S R] in
 lemma corootSpanMem_reflectionPerm_self [Module S N] (i : ι) :
     P.corootSpanMem S (P.reflectionPerm i i) = - P.corootSpanMem S i := by
   ext; simp
+
+@[deprecated (since := "2025-05-28")]
+alias corootSpanMem_reflection_perm_self := corootSpanMem_reflectionPerm_self
 
 /-- The `S`-linear map on the span of coroots given by evaluating at a root. -/
 def root'In [Module S N] [IsScalarTower S R N] [FaithfulSMul S R] [P.IsValuedIn S] (i : ι) :

--- a/Mathlib/LinearAlgebra/RootSystem/OfBilinear.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/OfBilinear.lean
@@ -148,7 +148,7 @@ def ofBilinear [IsReflexive R M] (B : M →ₗ[R] M →ₗ[R] R) (hNB : LinearMa
       id_eq, eq_mp_eq_cast, RingHom.id_apply, eq_mpr_eq_cast, cast_eq, LinearMap.sub_apply,
       Embedding.coeFn_mk, PerfectPairing.flip_apply_apply]
     exact coroot_apply_self B x.2
-  reflection_perm x :=
+  reflectionPerm x :=
     { toFun := fun y => ⟨(Module.reflection (coroot_apply_self B x.2) y),
         reflective_reflection B hSB x.2 y.2⟩
       invFun := fun y => ⟨(Module.reflection (coroot_apply_self B x.2) y),
@@ -159,9 +159,9 @@ def ofBilinear [IsReflexive R M] (B : M →ₗ[R] M →ₗ[R] R) (hNB : LinearMa
       right_inv := by
         intro y
         simp [involutive_reflection (coroot_apply_self B x.2) y] }
-  reflection_perm_root x y := by
+  reflectionPerm_root x y := by
     simp [Module.reflection_apply]
-  reflection_perm_coroot x y := by
+  reflectionPerm_coroot x y := by
     simp only [coe_setOf, mem_setOf_eq, Embedding.coeFn_mk, Embedding.coe_subtype,
       PerfectPairing.flip_apply_apply, IsReflexive.toPerfectPairingDual_apply, Equiv.coe_fn_mk]
     ext z

--- a/Mathlib/LinearAlgebra/RootSystem/Reduced.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Reduced.lean
@@ -98,7 +98,7 @@ lemma linearIndependent_of_sub_mem_range_root
     [NeZero (2 : R)] [NoZeroSMulDivisors ℤ M] [P.IsReduced] {i j : ι}
     (h : P.root i - P.root j ∈ range P.root) :
     LinearIndependent R ![P.root i, P.root j] := by
-  suffices LinearIndependent R ![P.root i, P.root (P.reflection_perm j j)] by simpa using this
+  suffices LinearIndependent R ![P.root i, P.root (P.reflectionPerm j j)] by simpa using this
   apply P.linearIndependent_of_add_mem_range_root
   simpa [sub_eq_add_neg] using h
 
@@ -207,7 +207,7 @@ lemma pairing_neg_two_neg_two_iff :
     P.pairing i j = -2 ∧ P.pairing j i = -2 ↔ P.root i = -P.root j := by
   simp only [← neg_eq_iff_eq_neg]
   simpa [eq_comm (a := -P.root i), eq_comm (b := j)] using
-    P.pairing_two_two_iff (P.reflection_perm i i) j
+    P.pairing_two_two_iff (P.reflectionPerm i i) j
 
 variable [NoZeroSMulDivisors R N]
 
@@ -230,7 +230,7 @@ lemma pairing_one_four_iff' (h2 : IsSMulRegular R (2 : R)) :
 
 lemma pairing_neg_one_neg_four_iff' (h2 : IsSMulRegular R (2 : R)) :
     P.pairing i j = -1 ∧ P.pairing j i = -4 ↔ P.root j = (-2 : R) • P.root i := by
-  simpa [neg_smul, ← neg_eq_iff_eq_neg] using P.pairing_one_four_iff' i (P.reflection_perm j j) h2
+  simpa [neg_smul, ← neg_eq_iff_eq_neg] using P.pairing_one_four_iff' i (P.reflectionPerm j j) h2
 
 /-- See also `RootPairing.pairingIn_one_four_iff`. -/
 @[simp]

--- a/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
@@ -186,6 +186,9 @@ lemma rootLength_reflectionPerm_self (i : ι) :
     B.rootLength (P.reflectionPerm i i) = B.rootLength i := by
   simp [rootLength, rootSpanMem_reflectionPerm_self]
 
+@[deprecated (since := "2025-05-28")]
+alias rootLength_reflection_perm_self := rootLength_reflectionPerm_self
+
 @[simp] lemma algebraMap_rootLength (i : ι) :
     algebraMap S R (B.rootLength i) = B.form (P.root i) (P.root i) := by
   simp [rootLength]

--- a/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
@@ -182,9 +182,9 @@ lemma rootLength_pos (i : ι) : 0 < B.rootLength i := by
   simpa using B.zero_lt_posForm_apply_root i
 
 @[simp]
-lemma rootLength_reflection_perm_self (i : ι) :
-    B.rootLength (P.reflection_perm i i) = B.rootLength i := by
-  simp [rootLength, rootSpanMem_reflection_perm_self]
+lemma rootLength_reflectionPerm_self (i : ι) :
+    B.rootLength (P.reflectionPerm i i) = B.rootLength i := by
+  simp [rootLength, rootSpanMem_reflectionPerm_self]
 
 @[simp] lemma algebraMap_rootLength (i : ι) :
     algebraMap S R (B.rootLength i) = B.form (P.root i) (P.root i) := by

--- a/Mathlib/LinearAlgebra/RootSystem/WeylGroup.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/WeylGroup.lean
@@ -146,11 +146,11 @@ lemma range_weylGroup_coweightHom :
     | mul w₁ w₂ hw₁ hw₂ h₁ h₂ =>
       simpa only [← Submonoid.mk_mul_mk _ w₁ w₂ hw₁ hw₂, map_mul] using Subgroup.mul_mem _ h₁ h₂
 
-/-- The permutation representation of the Weyl group induced by `reflection_perm`. -/
+/-- The permutation representation of the Weyl group induced by `reflectionPerm`. -/
 abbrev weylGroupToPerm := (Equiv.indexHom P).restrict P.weylGroup
 
 lemma range_weylGroupToPerm :
-    P.weylGroupToPerm.range = Subgroup.closure (range P.reflection_perm) := by
+    P.weylGroupToPerm.range = Subgroup.closure (range P.reflectionPerm) := by
   refine (Subgroup.closure_eq_of_le _ ?_ ?_).symm
   · rintro - ⟨i, rfl⟩
     simp only [MonoidHom.restrict_range, Subgroup.coe_map, Equiv.weightHom_apply, mem_image,


### PR DESCRIPTION
This matches the naming convention.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
