### PR TITLE
[Merged by Bors] - feat: range of `lift`s

### DIFF
--- a/Mathlib/Algebra/DualNumber.lean
+++ b/Mathlib/Algebra/DualNumber.lean
@@ -160,6 +160,13 @@ set_option linter.unusedVariables false in
 #adaptation_note /-- https://github.com/leanprover/lean4/pull/5338
 The new unused variable linter flags `{fe : (A →ₐ[R] B) × B // _}`. -/
 set_option linter.unusedVariables false in
+@[simp] theorem lift_comp_inlHom (fe : {fe : (A →ₐ[R] B) × B // _}) :
+    (lift fe).comp (inlAlgHom R A A) = fe.val.1 :=
+  AlgHom.ext <| lift_apply_inl fe
+
+#adaptation_note /-- https://github.com/leanprover/lean4/pull/5338
+The new unused variable linter flags `{fe : (A →ₐ[R] B) × B // _}`. -/
+set_option linter.unusedVariables false in
 /-- Scaling on the left is sent by `DualNumber.lift` to multiplication on the left -/
 @[simp] theorem lift_smul (fe : {fe : (A →ₐ[R] B) × B // _}) (a : A) (ad : A[ε]) :
     lift fe (a • ad) = fe.val.1 a * lift fe ad := by
@@ -184,6 +191,24 @@ set_option linter.unusedVariables false in
 theorem lift_inlAlgHom_eps :
     lift ⟨(inlAlgHom _ _ _, ε), eps_mul_eps, fun _ => commute_eps_left _⟩ = AlgHom.id R A[ε] :=
   lift.apply_symm_apply <| AlgHom.id R A[ε]
+
+@[simp]
+theorem range_inlAlgHom_sup_adjoin_eps :
+    (inlAlgHom R A A).range ⊔ Algebra.adjoin R {ε} = ⊤ := by
+  refine top_unique fun x hx => ?_; clear hx
+  rw [← x.inl_fst_add_inr_snd_eq, inr_eq_smul_eps, ← inl_mul_eq_smul]
+  refine add_mem ?_ (mul_mem ?_ ?_)
+  · exact le_sup_left (α := Subalgebra R _) <| Set.mem_range_self x.fst
+  · exact le_sup_left (α := Subalgebra R _) <| Set.mem_range_self x.snd
+  · refine le_sup_right (α := Subalgebra R _) <| Algebra.subset_adjoin <| Set.mem_singleton ε
+
+@[simp]
+theorem range_lift
+    (fe : {fe : (A →ₐ[R] B) × B // fe.2 * fe.2 = 0 ∧ ∀ a, Commute fe.2 (fe.1 a)}) :
+    (lift fe).range = fe.1.1.range ⊔ Algebra.adjoin R {fe.1.2} := by
+  simp_rw [← Algebra.map_top, ← range_inlAlgHom_sup_adjoin_eps, Algebra.map_sup,
+    AlgHom.map_adjoin, ← AlgHom.range_comp, Set.image_singleton, lift_apply_eps, lift_comp_inlHom,
+    Algebra.map_top]
 
 /-- Show DualNumber with values x and y as an "x + y*ε" string -/
 instance instRepr [Repr R] : Repr (DualNumber R) where

--- a/Mathlib/Algebra/QuaternionBasis.lean
+++ b/Mathlib/Algebra/QuaternionBasis.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
+import Mathlib.Algebra.Algebra.Subalgebra.Lattice
 import Mathlib.Algebra.Quaternion
 import Mathlib.Tactic.Ring
 
@@ -141,6 +142,20 @@ def liftHom : ℍ[R,c₁,c₂,c₃] →ₐ[R] A :=
       map_one' := q.lift_one
       map_add' := q.lift_add
       map_mul' := q.lift_mul } q.lift_smul
+
+@[simp]
+theorem range_liftHom (B : Basis A c₁ c₂ c₃) :
+    (liftHom B).range = Algebra.adjoin R {B.i, B.j, B.k} := by
+  apply le_antisymm
+  · rintro x ⟨y, rfl⟩
+    refine add_mem (add_mem (add_mem ?_ ?_) ?_) ?_
+    · exact algebraMap_mem _ _
+    all_goals
+      exact Subalgebra.smul_mem _ (Algebra.subset_adjoin <| by simp) _
+  · rw [Algebra.adjoin_le_iff]
+    rintro x (rfl | rfl | rfl)
+      <;> [use (Basis.self R).i; use (Basis.self R).j; use (Basis.self R).k]
+    all_goals simp [lift]
 
 /-- Transform a `QuaternionAlgebra.Basis` through an `AlgHom`. -/
 @[simps i j k]

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -6,6 +6,7 @@ Authors: Kenny Lau, Eric Wieser
 import Mathlib.Algebra.BigOperators.GroupWithZero.Action
 import Mathlib.Algebra.GroupWithZero.Invertible
 import Mathlib.LinearAlgebra.Prod
+import Mathlib.Algebra.Algebra.Subalgebra.Lattice
 
 /-!
 # Trivial Square-Zero Extension
@@ -998,6 +999,26 @@ theorem lift_inlAlgHom_inrHom :
       (inr_mul_inr R) (fun _ _ => (inl_mul_inr _ _).symm) (fun _ _ => (inr_mul_inl _ _).symm) =
     AlgHom.id S (tsze R M) :=
   algHom_ext' (lift_comp_inlHom _ _ _ _ _) (lift_comp_inrHom _ _ _ _ _)
+
+
+@[simp]
+theorem range_inlAlgHom_sup_adjoin_range_inr :
+    (inlAlgHom S R M).range ⊔ Algebra.adjoin S (Set.range inr : Set (tsze R M)) = ⊤ := by
+  refine top_unique fun x hx => ?_; clear hx
+  rw [← x.inl_fst_add_inr_snd_eq]
+  refine add_mem ?_ ?_
+  · exact le_sup_left (α := Subalgebra S _) <| Set.mem_range_self x.fst
+  · exact le_sup_right (α := Subalgebra S _) <| Algebra.subset_adjoin <| Set.mem_range_self x.snd
+
+@[simp]
+theorem range_liftAux (f : R →ₐ[S] A) (g : M →ₗ[S] A)
+    (hg : ∀ x y, g x * g y = 0)
+    (hfg : ∀ r x, g (r •> x) = f r * g x)
+    (hgf : ∀ r x, g (x <• r) = g x * f r) :
+    (lift f g hg hfg hgf).range = f.range ⊔ Algebra.adjoin S (Set.range g) := by
+  simp_rw [← Algebra.map_top, ← range_inlAlgHom_sup_adjoin_range_inr, Algebra.map_sup,
+    AlgHom.map_adjoin, ← AlgHom.range_comp, lift_comp_inlHom, ← Set.range_comp, Function.comp_def,
+    lift_apply_inr, Algebra.map_top]
 
 /-- A universal property of the trivial square-zero extension, providing a unique
 `TrivSqZeroExt R M →ₐ[R] A` for every pair of maps `f : R →ₐ[S] A` and `g : M →ₗ[S] A`,

--- a/Mathlib/Algebra/TrivSqZeroExt.lean
+++ b/Mathlib/Algebra/TrivSqZeroExt.lean
@@ -1003,7 +1003,7 @@ theorem lift_inlAlgHom_inrHom :
 
 @[simp]
 theorem range_inlAlgHom_sup_adjoin_range_inr :
-    (inlAlgHom S R M).range ⊔ Algebra.adjoin S (Set.range inr : Set (tsze R M)) = ⊤ := by
+    (inlAlgHom S R M).range ⊔ Algebra.adjoin S (Set.range inr) = (⊤ : Subalgebra S (tsze R M)) := by
   refine top_unique fun x hx => ?_; clear hx
   rw [← x.inl_fst_add_inr_snd_eq]
   refine add_mem ?_ ?_

--- a/Mathlib/Data/Complex/Module.lean
+++ b/Mathlib/Data/Complex/Module.lean
@@ -295,6 +295,16 @@ theorem liftAux_apply (I' : A) (hI') (z : ℂ) : liftAux I' hI' z = algebraMap �
 
 theorem liftAux_apply_I (I' : A) (hI') : liftAux I' hI' I = I' := by simp
 
+@[simp]
+theorem range_liftAux (I' : A) (hI') : (liftAux I' hI').range = Algebra.adjoin ℝ {I'} := by
+  apply le_antisymm
+  · rintro x ⟨y, rfl⟩
+    refine add_mem (algebraMap_mem _ _) (Subalgebra.smul_mem _ (Algebra.subset_adjoin ?_) _)
+    simp
+  · rw [Algebra.adjoin_le_iff]
+    rintro x rfl
+    exact ⟨I, liftAux_apply_I _ _⟩
+
 /-- A universal property of the complex numbers, providing a unique `ℂ →ₐ[ℝ] A` for every element
 of `A` which squares to `-1`.
 

--- a/Mathlib/Data/Complex/Module.lean
+++ b/Mathlib/Data/Complex/Module.lean
@@ -296,14 +296,14 @@ theorem liftAux_apply (I' : A) (hI') (z : ℂ) : liftAux I' hI' z = algebraMap �
 theorem liftAux_apply_I (I' : A) (hI') : liftAux I' hI' I = I' := by simp
 
 @[simp]
+theorem adjoin_I : Algebra.adjoin ℝ {I} = ⊤ := by
+  refine top_unique fun x hx => ?_; clear hx
+  rw [← x.re_add_im, ← smul_eq_mul, ← Complex.coe_algebraMap]
+  exact add_mem (algebraMap_mem _ _) (Subalgebra.smul_mem _ (Algebra.subset_adjoin <| by simp) _)
+
+@[simp]
 theorem range_liftAux (I' : A) (hI') : (liftAux I' hI').range = Algebra.adjoin ℝ {I'} := by
-  apply le_antisymm
-  · rintro x ⟨y, rfl⟩
-    refine add_mem (algebraMap_mem _ _) (Subalgebra.smul_mem _ (Algebra.subset_adjoin ?_) _)
-    simp
-  · rw [Algebra.adjoin_le_iff]
-    rintro x rfl
-    exact ⟨I, liftAux_apply_I _ _⟩
+  simp_rw [← Algebra.map_top, ← adjoin_I, AlgHom.map_adjoin, Set.image_singleton, liftAux_apply_I]
 
 /-- A universal property of the complex numbers, providing a unique `ℂ →ₐ[ℝ] A` for every element
 of `A` which squares to `-1`.

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Basic.lean
@@ -207,6 +207,21 @@ theorem induction {C : CliffordAlgebra Q → Prop}
   rw [← AlgHom.id_apply (R := R) a, ← of_id]
   exact (lift Q of a).prop
 
+@[simp]
+theorem adjoin_range_ι : Algebra.adjoin R (Set.range (ι Q)) = ⊤ := by
+  refine top_unique fun x hx => ?_; clear hx
+  induction x using induction with
+  | algebraMap => exact algebraMap_mem _ _
+  | add x y hx hy => exact add_mem hx hy
+  | mul x y hx hy => exact mul_mem hx hy
+  | ι x => exact Algebra.subset_adjoin (Set.mem_range_self _)
+
+@[simp]
+theorem range_lift (f : M →ₗ[R] A) (cond : ∀ m, f m * f m = algebraMap _ _ (Q m)) :
+    (lift Q ⟨f, cond⟩).range = Algebra.adjoin R (Set.range f) := by
+  simp_rw [← Algebra.map_top, ← adjoin_range_ι, AlgHom.map_adjoin, ← Set.range_comp,
+    Function.comp_def, lift_ι_apply]
+
 theorem mul_add_swap_eq_polar_of_forall_mul_self_eq {A : Type*} [Ring A] [Algebra R A]
     (f : M →ₗ[R] A) (hf : ∀ x, f x * f x = algebraMap _ _ (Q x)) (a b : M) :
     f a * f b + f b * f a = algebraMap R _ (QuadraticMap.polar Q a b) :=

--- a/Mathlib/LinearAlgebra/TensorAlgebra/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorAlgebra/Basic.lean
@@ -202,6 +202,21 @@ theorem induction {C : TensorAlgebra R M → Prop}
   rw [← AlgHom.id_apply (R := R) a, of_id]
   exact Subtype.prop (lift R of a)
 
+@[simp]
+theorem adjoin_range_ι : Algebra.adjoin R (Set.range (ι R (M := M))) = ⊤ := by
+  refine top_unique fun x hx => ?_; clear hx
+  induction x using induction with
+  | algebraMap => exact algebraMap_mem _ _
+  | add x y hx hy => exact add_mem hx hy
+  | mul x y hx hy => exact mul_mem hx hy
+  | ι x => exact Algebra.subset_adjoin (Set.mem_range_self _)
+
+@[simp]
+theorem range_lift {A : Type*} [Semiring A] [Algebra R A] (f : M →ₗ[R] A) :
+    (lift R f).range = Algebra.adjoin R (Set.range f) := by
+  simp_rw [← Algebra.map_top, ← adjoin_range_ι, AlgHom.map_adjoin, ← Set.range_comp,
+    Function.comp_def, lift_ι_apply]
+
 /-- The left-inverse of `algebraMap`. -/
 def algebraMapInv : TensorAlgebra R M →ₐ[R] R :=
   lift R (0 : M →ₗ[R] R)


### PR DESCRIPTION
It turns out that the `range` of most universal properties can be expressed via `adjoin`.

This adds this result for:
* `CliffordAlgebra`
* `TensorAlgebra`
* `QuaternionBasis`
* `Complex`
* `TrivSqZeroExt`
* `DualNumber`

It already exists for `FreeAlgebra`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
