### PR TITLE
[Merged by Bors] - chore: avoid lattice phrasing for sets for blocks

### DIFF
--- a/Mathlib/GroupTheory/GroupAction/Blocks.lean
+++ b/Mathlib/GroupTheory/GroupAction/Blocks.lean
@@ -124,7 +124,7 @@ theorem IsTrivialBlock.image {φ : M → N} {f : α →ₑ[φ] β}
   obtain hB | hB := hB
   · apply Or.intro_left; apply Set.Subsingleton.image hB
   · apply Or.intro_right; rw [hB]
-    simp only [Set.top_eq_univ, Set.image_univ, Set.range_eq_univ, hf]
+    simp only [Set.image_univ, Set.range_eq_univ, hf]
 
 @[to_additive]
 theorem IsTrivialBlock.preimage {φ : M → N} {f : α →ₑ[φ] β}
@@ -132,7 +132,7 @@ theorem IsTrivialBlock.preimage {φ : M → N} {f : α →ₑ[φ] β}
     IsTrivialBlock (f ⁻¹' B) := by
   obtain hB | hB := hB
   · apply Or.intro_left; exact Set.Subsingleton.preimage hB hf
-  · apply Or.intro_right; simp only [hB, Set.top_eq_univ]; apply Set.preimage_univ
+  · apply Or.intro_right; simp only [hB]; apply Set.preimage_univ
 
 end monoid
 
@@ -626,10 +626,10 @@ namespace BlockMem
 @[to_additive
 "The type of blocks for an additive group action containing a given element is a bounded order"]
 instance (a : X) : BoundedOrder (BlockMem G a) where
-  top := ⟨⊤, Set.mem_univ a, .univ⟩
+  top := ⟨Set.univ, Set.mem_univ a, .univ⟩
   le_top := by
     rintro ⟨B, ha, hB⟩
-    simp only [Set.top_eq_univ, Subtype.mk_le_mk, Set.le_eq_subset, Set.subset_univ]
+    simp only [Subtype.mk_le_mk, le_eq_subset, subset_univ]
   bot := ⟨{a}, Set.mem_singleton a, IsBlock.singleton⟩
   bot_le := by
     rintro ⟨B, ha, hB⟩
@@ -638,7 +638,7 @@ instance (a : X) : BoundedOrder (BlockMem G a) where
 
 @[to_additive (attr := simp, norm_cast)]
 theorem coe_top (a : X) :
-    ((⊤ : BlockMem G a) : Set X) = ⊤ :=
+    ((⊤ : BlockMem G a) : Set X) = Set.univ :=
   rfl
 
 @[to_additive (attr := simp, norm_cast)]
@@ -655,7 +655,7 @@ instance [Nontrivial X] (a : X) : Nontrivial (BlockMem G a) := by
   simp only [coe_top, coe_bot] at h
   obtain ⟨b, hb⟩ := exists_ne a
   apply hb
-  rw [← Set.mem_singleton_iff, h, Set.top_eq_univ]
+  rw [← Set.mem_singleton_iff, h]
   apply Set.mem_univ
 
 end BlockMem

--- a/Mathlib/GroupTheory/GroupAction/Primitive.lean
+++ b/Mathlib/GroupTheory/GroupAction/Primitive.lean
@@ -381,14 +381,14 @@ theorem exists_mem_smul_and_notMem_smul [IsPreprimitive G X]
   · -- B.subsingleton
     apply Set.Subsingleton.eq_singleton_of_mem hyp
     rw [Set.mem_iInter]; intro g; simp only [Set.mem_iInter, imp_self]
-  · -- B = ⊤ : contradiction
-    change B = ⊤ at hyp
+  · -- B = Set.univ: contradiction
+    change B = Set.univ at hyp
     exfalso; apply hA'
     suffices ∃ g : G, a ∈ g • A by
       obtain ⟨g, hg⟩ := this
-      have : B ≤ g • A := Set.biInter_subset_of_mem hg
-      rw [hyp, top_le_iff, ← eq_inv_smul_iff] at this
-      rw [this, Set.top_eq_univ, Set.smul_set_univ]
+      have : B ⊆ g • A := Set.biInter_subset_of_mem hg
+      rw [hyp, Set.univ_subset_iff, ← eq_inv_smul_iff] at this
+      rw [this, Set.smul_set_univ]
     -- ∃ (g : M), a ∈ g • A
     obtain ⟨x, hx⟩ := hA
     obtain ⟨g, hg⟩ := MulAction.exists_smul_eq G x a


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
