### PR TITLE
feat(CategoryTheory): generalize `Discrete` to arbitrary morphism levels

### DIFF
--- a/Mathlib/CategoryTheory/Bicategory/LocallyDiscrete.lean
+++ b/Mathlib/CategoryTheory/Bicategory/LocallyDiscrete.lean
@@ -21,7 +21,7 @@ namespace CategoryTheory
 
 open Bicategory Discrete
 
-universe w₂ w₁ v₂ v₁ v u₂ u₁ u
+universe w₂ w₁ w v₂ v₁ v u₂ u₁ u
 
 section
 
@@ -35,7 +35,7 @@ structure LocallyDiscrete (C : Type u) where
   /-- A wrapper for promoting any category to a bicategory,
   with the only 2-morphisms being equalities.
   -/
-  as : C
+  as : let _ := ULift.{w} C; C
 
 namespace LocallyDiscrete
 
@@ -56,8 +56,8 @@ instance [DecidableEq C] : DecidableEq (LocallyDiscrete C) :=
 instance [Inhabited C] : Inhabited (LocallyDiscrete C) :=
   ⟨⟨default⟩⟩
 
-instance categoryStruct [CategoryStruct.{v} C] : CategoryStruct (LocallyDiscrete C) where
-  Hom a b := Discrete (a.as ⟶ b.as)
+instance categoryStruct [CategoryStruct.{v} C] : CategoryStruct.{v} (LocallyDiscrete.{w} C) where
+  Hom a b := Discrete.{w} (a.as ⟶ b.as)
   id a := ⟨𝟙 a.as⟩
   comp f g := ⟨f.as ≫ g.as⟩
 

--- a/Mathlib/CategoryTheory/Discrete/Basic.lean
+++ b/Mathlib/CategoryTheory/Discrete/Basic.lean
@@ -11,15 +11,15 @@ import Mathlib.Data.ULift
 # Discrete categories
 
 We define `Discrete α` as a structure containing a term `a : α` for any type `α`,
-and use this type alias to provide a `SmallCategory` instance
+and use this type alias to provide a `Category` instance
 whose only morphisms are the identities.
 
 There is an annoying technical difficulty that it has turned out to be inconvenient
 to allow categories with morphisms living in `Prop`,
 so instead of defining `X ⟶ Y` in `Discrete α` as `X = Y`,
 one might define it as `PLift (X = Y)`.
-In fact, to allow `Discrete α` to be a `SmallCategory`
-(i.e. with morphisms in the same universe as the objects),
+In fact, to allow `Discrete α` to be a `Category.{v}`
+(i.e. with morphisms in some arbitrary universe level `v`),
 we actually define the hom type `X ⟶ Y` as `ULift (PLift (X = Y))`.
 
 `Discrete.functor` promotes a function `f : I → C` (for any category `C`) to a functor
@@ -47,7 +47,7 @@ with the only morphisms being equalities.
 structure Discrete (α : Type u₁) where
   /-- A wrapper for promoting any type to a category,
   with the only morphisms being equalities. -/
-  as : α
+  as : let _ := ULift.{v₁} α; α
 
 @[simp]
 theorem Discrete.mk_as {α : Type u₁} (X : Discrete α) : Discrete.mk X.as = X := by
@@ -69,7 +69,7 @@ instance {α : Type u₁} [DecidableEq α] : DecidableEq (Discrete α) :=
 Because we do not allow morphisms in `Prop` (only in `Type`),
 somewhat annoyingly we have to define `X ⟶ Y` as `ULift (PLift (X = Y))`. -/
 @[stacks 001A]
-instance discreteCategory (α : Type u₁) : SmallCategory (Discrete α) where
+instance discreteCategory (α : Type u₁) : Category.{v₁} (Discrete.{v₁} α) where
   Hom X Y := ULift (PLift (X.as = Y.as))
   id _ := ULift.up (PLift.up rfl)
   comp {X Y Z} g f := by

--- a/Mathlib/CategoryTheory/Discrete/Basic.lean
+++ b/Mathlib/CategoryTheory/Discrete/Basic.lean
@@ -35,7 +35,7 @@ discrete categories.
 namespace CategoryTheory
 
 -- morphism levels before object levels. See note [CategoryTheory universes].
-universe v₁ v₂ v₃ u₁ u₁' u₂ u₃
+universe v₁ v₁' v₂ v₃ u₁ u₁' u₂ u₃
 
 -- This is intentionally a structure rather than a type synonym
 -- to enforce using `DiscreteEquiv` (or `Discrete.mk` and `Discrete.as`) to move between
@@ -153,7 +153,7 @@ attribute [local aesop safe tactic (rule_sets := [CategoryTheory])]
   CategoryTheory.Discrete.discreteCases
 
 /-- Any function `I → C` gives a functor `Discrete I ⥤ C`. -/
-def functor {I : Type u₁} (F : I → C) : Discrete I ⥤ C where
+def functor {I : Type u₁} (F : I → C) : Discrete.{v₁} I ⥤ C where
   obj := F ∘ Discrete.as
   map {X Y} f := by
     dsimp
@@ -162,22 +162,23 @@ def functor {I : Type u₁} (F : I → C) : Discrete I ⥤ C where
 
 @[simp]
 theorem functor_obj {I : Type u₁} (F : I → C) (i : I) :
-    (Discrete.functor F).obj (Discrete.mk i) = F i :=
+    (Discrete.functor.{v₁} F).obj (Discrete.mk i) = F i :=
   rfl
 
 theorem functor_map {I : Type u₁} (F : I → C) {i : Discrete I} (f : i ⟶ i) :
-    (Discrete.functor F).map f = 𝟙 (F i.as) := by aesop_cat
+    (Discrete.functor.{v₁} F).map f = 𝟙 (F i.as) := by aesop_cat
 
 @[simp]
 theorem functor_obj_eq_as {I : Type u₁} (F : I → C) (X : Discrete I) :
-    (Discrete.functor F).obj X = F X.as :=
+    (Discrete.functor.{v₁} F).obj X = F X.as :=
   rfl
 /-- The discrete functor induced by a composition of maps can be written as a
 composition of two discrete functors.
 -/
 @[simps!]
 def functorComp {I : Type u₁} {J : Type u₁'} (f : J → C) (g : I → J) :
-    Discrete.functor (f ∘ g) ≅ Discrete.functor (Discrete.mk ∘ g) ⋙ Discrete.functor f :=
+    Discrete.functor.{v₁} (f ∘ g) ≅
+      Discrete.functor.{v₁} (Discrete.mk ∘ g) ⋙ Discrete.functor.{v₁'} f :=
   NatIso.ofComponents fun _ => Iso.refl _
 
 /-- For functors out of a discrete category,
@@ -185,7 +186,7 @@ a natural transformation is just a collection of maps,
 as the naturality squares are trivial.
 -/
 @[simps]
-def natTrans {I : Type u₁} {F G : Discrete I ⥤ C} (f : ∀ i : Discrete I, F.obj i ⟶ G.obj i) :
+def natTrans {I : Type u₁} {F G : Discrete.{v₁} I ⥤ C} (f : ∀ i : Discrete I, F.obj i ⟶ G.obj i) :
     F ⟶ G where
   app := f
   naturality := fun {X Y} ⟨⟨g⟩⟩ => by
@@ -199,7 +200,7 @@ a natural isomorphism is just a collection of isomorphisms,
 as the naturality squares are trivial.
 -/
 @[simps!]
-def natIso {I : Type u₁} {F G : Discrete I ⥤ C} (f : ∀ i : Discrete I, F.obj i ≅ G.obj i) :
+def natIso {I : Type u₁} {F G : Discrete.{v₁} I ⥤ C} (f : ∀ i : Discrete I, F.obj i ≅ G.obj i) :
     F ≅ G :=
   NatIso.ofComponents f fun ⟨⟨g⟩⟩ => by
     discrete_cases
@@ -207,32 +208,34 @@ def natIso {I : Type u₁} {F G : Discrete I ⥤ C} (f : ∀ i : Discrete I, F.o
     change F.map (𝟙 _) ≫ _ = _ ≫ G.map (𝟙 _)
     simp
 
-instance {I : Type*} {F G : Discrete I ⥤ C} (f : ∀ i, F.obj i ⟶ G.obj i) [∀ i, IsIso (f i)] :
+instance {I : Type*} {F G : Discrete.{v₁} I ⥤ C} (f : ∀ i, F.obj i ⟶ G.obj i) [∀ i, IsIso (f i)] :
     IsIso (Discrete.natTrans f) := by
   change IsIso (Discrete.natIso (fun i => asIso (f i))).hom
   infer_instance
 
 @[simp]
-theorem natIso_app {I : Type u₁} {F G : Discrete I ⥤ C} (f : ∀ i : Discrete I, F.obj i ≅ G.obj i)
-    (i : Discrete I) : (Discrete.natIso f).app i = f i := by aesop_cat
+theorem natIso_app {I : Type u₁} {F G : Discrete.{v₁} I ⥤ C}
+    (f : ∀ i : Discrete I, F.obj i ≅ G.obj i) (i : Discrete I) :
+    (Discrete.natIso f).app i = f i := by aesop_cat
 
 /-- Every functor `F` from a discrete category is naturally isomorphic (actually, equal) to
   `Discrete.functor (F.obj)`. -/
 @[simps!]
-def natIsoFunctor {I : Type u₁} {F : Discrete I ⥤ C} : F ≅ Discrete.functor (F.obj ∘ Discrete.mk) :=
+def natIsoFunctor {I : Type u₁} {F : Discrete.{v₁} I ⥤ C} :
+    F ≅ Discrete.functor (F.obj ∘ Discrete.mk) :=
   natIso fun _ => Iso.refl _
 
 /-- Composing `Discrete.functor F` with another functor `G` amounts to composing `F` with `G.obj` -/
 @[simps!]
 def compNatIsoDiscrete {I : Type u₁} {D : Type u₃} [Category.{v₃} D] (F : I → C) (G : C ⥤ D) :
-    Discrete.functor F ⋙ G ≅ Discrete.functor (G.obj ∘ F) :=
+    Discrete.functor.{v₁} F ⋙ G ≅ Discrete.functor (G.obj ∘ F) :=
   natIso fun _ => Iso.refl _
 
 /-- We can promote a type-level `Equiv` to
 an equivalence between the corresponding `discrete` categories.
 -/
 @[simps]
-def equivalence {I : Type u₁} {J : Type u₂} (e : I ≃ J) : Discrete I ≌ Discrete J where
+def equivalence {I : Type u₁} {J : Type u₂} (e : I ≃ J) : Discrete.{v₁} I ≌ Discrete.{v₂} J where
   functor := Discrete.functor (Discrete.mk ∘ (e : I → J))
   inverse := Discrete.functor (Discrete.mk ∘ (e.symm : J → I))
   unitIso :=
@@ -242,7 +245,8 @@ def equivalence {I : Type u₁} {J : Type u₂} (e : I ≃ J) : Discrete I ≌ D
 
 /-- We can convert an equivalence of `discrete` categories to a type-level `Equiv`. -/
 @[simps]
-def equivOfEquivalence {α : Type u₁} {β : Type u₂} (h : Discrete α ≌ Discrete β) : α ≃ β where
+def equivOfEquivalence {α : Type u₁} {β : Type u₂}
+    (h : Discrete.{v₁} α ≌ Discrete.{v₂} β) : α ≃ β where
   toFun := Discrete.as ∘ h.functor.obj ∘ Discrete.mk
   invFun := Discrete.as ∘ h.inverse.obj ∘ Discrete.mk
   left_inv a := by simpa using eq_of_hom (h.unitIso.app (Discrete.mk a)).2
@@ -258,7 +262,7 @@ open Opposite
 
 /-- A discrete category is equivalent to its opposite category. -/
 @[simps! functor_obj_as inverse_obj]
-protected def opposite (α : Type u₁) : (Discrete α)ᵒᵖ ≌ Discrete α :=
+protected def opposite (α : Type u₁) : (Discrete.{v₁} α)ᵒᵖ ≌ Discrete α :=
   let F : Discrete α ⥤ (Discrete α)ᵒᵖ := Discrete.functor fun x => op (Discrete.mk x)
   { functor := F.leftOp
     inverse := F
@@ -268,7 +272,7 @@ protected def opposite (α : Type u₁) : (Discrete α)ᵒᵖ ≌ Discrete α :=
 variable {C : Type u₂} [Category.{v₂} C]
 
 @[simp]
-theorem functor_map_id (F : Discrete J ⥤ C) {j : Discrete J} (f : j ⟶ j) :
+theorem functor_map_id (F : Discrete.{v₁} J ⥤ C) {j : Discrete J} (f : j ⟶ j) :
     F.map f = 𝟙 (F.obj j) := by
   have h : f = 𝟙 j := by aesop_cat
   rw [h]
@@ -279,7 +283,7 @@ end Discrete
 /-- The equivalence of categories `(J → C) ≌ (Discrete J ⥤ C)`. -/
 @[simps]
 def piEquivalenceFunctorDiscrete (J : Type u₂) (C : Type u₁) [Category.{v₁} C] :
-    (J → C) ≌ (Discrete J ⥤ C) where
+    (J → C) ≌ (Discrete.{v₁} J ⥤ C) where
   functor :=
     { obj := fun F => Discrete.functor F
       map := fun f => Discrete.natTrans (fun j => f j.as) }

--- a/Mathlib/CategoryTheory/IsConnected.lean
+++ b/Mathlib/CategoryTheory/IsConnected.lean
@@ -56,7 +56,8 @@ namespace CategoryTheory
 -/
 class IsPreconnected (J : Type u₁) [Category.{v₁} J] : Prop where
   iso_constant :
-    ∀ {α : Type u₁} (F : J ⥤ Discrete α) (j : J), Nonempty (F ≅ (Functor.const J).obj (F.obj j))
+    ∀ {α : Type u₁} (F : J ⥤ Discrete.{u₁} α) (j : J),
+      Nonempty (F ≅ (Functor.const J).obj (F.obj j))
 
 attribute [inherit_doc IsPreconnected] IsPreconnected.iso_constant
 
@@ -113,7 +114,7 @@ theorem any_functor_const_on_obj [IsPreconnected J] {α : Type u₂} (F : J ⥤ 
 The converse of `any_functor_const_on_obj`.
 -/
 theorem IsPreconnected.of_any_functor_const_on_obj
-    (h : ∀ {α : Type u₁} (F : J ⥤ Discrete α), ∀ j j' : J, F.obj j = F.obj j') :
+    (h : ∀ {α : Type u₁} (F : J ⥤ Discrete.{u₁} α), ∀ j j' : J, F.obj j = F.obj j') :
     IsPreconnected J where
   iso_constant := fun F j' => ⟨NatIso.ofComponents fun j => eqToIso (h F j j')⟩
 
@@ -128,7 +129,8 @@ instance IsConnected.prod [IsConnected J] [IsConnected K] : IsConnected (J × K)
 The converse of `any_functor_const_on_obj`.
 -/
 theorem IsConnected.of_any_functor_const_on_obj [Nonempty J]
-    (h : ∀ {α : Type u₁} (F : J ⥤ Discrete α), ∀ j j' : J, F.obj j = F.obj j') : IsConnected J :=
+    (h : ∀ {α : Type u₁} (F : J ⥤ Discrete.{u₁} α),
+      ∀ j j' : J, F.obj j = F.obj j') : IsConnected J :=
   { IsPreconnected.of_any_functor_const_on_obj h with }
 
 /-- If `J` is connected, then given any function `F` such that the presence of a
@@ -141,7 +143,7 @@ theorem constant_of_preserves_morphisms [IsPreconnected J] {α : Type u₂} (F :
     (h : ∀ (j₁ j₂ : J) (_ : j₁ ⟶ j₂), F j₁ = F j₂) (j j' : J) : F j = F j' := by
   simpa using
     any_functor_const_on_obj
-      { obj := Discrete.mk ∘ F
+      { obj := Discrete.mk.{u₂} ∘ F
         map := fun f => eqToHom (by ext; exact h _ _ f) }
       j j'
 
@@ -424,7 +426,7 @@ theorem isConnected_of_zigzag [Nonempty J] (h : ∀ j₁ j₂ : J, ∃ l,
 
 /-- If `Discrete α` is connected, then `α` is (type-)equivalent to `PUnit`. -/
 def discreteIsConnectedEquivPUnit {α : Type u₁} [IsConnected (Discrete α)] : α ≃ PUnit :=
-  Discrete.equivOfEquivalence.{u₁, u₁}
+  Discrete.equivOfEquivalence.{u₁, u₁, u₁, u₁}
     { functor := Functor.star (Discrete α)
       inverse := Discrete.functor fun _ => Classical.arbitrary _
       unitIso := isoConstant _ (Classical.arbitrary _)


### PR DESCRIPTION
Using an unused `let`, add an 'anchor' to the definition of `Discrete`, allowing it to carry a second universe level that is then used to permit discrete categories to live in any `Cat.{v, u}`.  (This trick was borrowed from the code of `ULiftHom`.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
