### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/TensorProduct): make `AlgebraTensorModule.*` defeq to the regular version

### DIFF
--- a/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
@@ -81,10 +81,12 @@ theorem rid_tmul (m : M) (r : R) : (TensorProduct.rid R M) (m ⊗ₜ r) = r • 
 theorem rid_symm_apply (m : M) : (TensorProduct.rid R M).symm m = m ⊗ₜ 1 :=
   rfl
 
+@[simp]
 theorem comm_trans_lid :
     TensorProduct.comm R M R ≪≫ₗ TensorProduct.lid R M = TensorProduct.rid R M :=
   LinearEquiv.toLinearMap_injective (ext (by ext; rfl))
 
+@[simp]
 theorem comm_trans_rid :
     TensorProduct.comm R R M ≪≫ₗ TensorProduct.rid R M = TensorProduct.lid R M :=
   LinearEquiv.toLinearMap_injective (ext (by ext; rfl))

--- a/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
@@ -65,7 +65,11 @@ variable (R M)
 /-- The base ring is a right identity for the tensor product of modules, up to linear equivalence.
 -/
 protected def rid : M ⊗[R] R ≃ₗ[R] M :=
-  LinearEquiv.trans (TensorProduct.comm R M R) (TensorProduct.lid R M)
+  LinearEquiv.ofLinear
+    (lift <| .flip (LinearMap.lsmul R M))
+    (mk R M R |>.flip 1)
+    (LinearMap.ext <| one_smul _)
+    (ext <| by ext; simp)
 
 end
 
@@ -102,17 +106,14 @@ section
 
 variable (R M N P)
 
+attribute [local ext high] ext in
 /-- The associator for tensor product of R-modules, as a linear equivalence. -/
-protected def assoc : (M ⊗[R] N) ⊗[R] P ≃ₗ[R] M ⊗[R] N ⊗[R] P := by
-  refine
-      LinearEquiv.ofLinear (lift <| lift <| comp (lcurry R _ _ _) <| mk _ _ _)
-        (lift <| comp (uncurry R _ _ _) <| curry <| mk _ _ _)
-        (ext <| LinearMap.ext fun m => ext' fun n p => ?_)
-        (ext <| flip_inj <| LinearMap.ext fun p => ext' fun m n => ?_) <;>
-    repeat'
-      first
-        |rw [lift.tmul]|rw [compr₂_apply]|rw [comp_apply]|rw [mk_apply]|rw [flip_apply]
-        |rw [lcurry_apply]|rw [uncurry_apply]|rw [curry_apply]|rw [id_apply]
+protected def assoc : (M ⊗[R] N) ⊗[R] P ≃ₗ[R] M ⊗[R] N ⊗[R] P :=
+  LinearEquiv.ofLinear
+    (lift <| lift <| lcurry _ _ _ _ ∘ₗ mk _ _ _)
+    (lift <| uncurry _ _ _ _ ∘ₗ curry (mk R _ _))
+    (by ext; rfl)
+    (by ext; rfl)
 
 end
 
@@ -179,6 +180,23 @@ theorem leftComm_symm_tmul (m : M) (n : N) (p : P) :
     (leftComm R M N P).symm (n ⊗ₜ (m ⊗ₜ p)) = m ⊗ₜ (n ⊗ₜ p) :=
   rfl
 
+variable (M N P) in
+attribute [local ext high] ext in
+/-- A tensor product analogue of `mul_right_comm`. -/
+def rightComm : (M ⊗[R] N) ⊗[R] P ≃ₗ[R] (M ⊗[R] P) ⊗[R] N :=
+  LinearEquiv.ofLinear
+    (lift (lift (LinearMap.lflip ∘ₗ (mk _ _ _).compr₂ (mk _ _ _))))
+    (lift (lift (LinearMap.lflip ∘ₗ (mk _ _ _).compr₂ (mk _ _ _))))
+  (by ext; rfl) (by ext; rfl)
+
+@[simp]
+theorem rightComm_tmul (m : M) (n : N) (p : P) :
+    rightComm R M N P ((m ⊗ₜ n) ⊗ₜ p) = (m ⊗ₜ p) ⊗ₜ n :=
+  rfl
+
+@[simp]
+theorem rightComm_symm : (rightComm R M N P).symm = rightComm R M P N := rfl
+
 variable (M N P Q)
 
 /-- This special case is worth defining explicitly since it is useful for defining multiplication
@@ -192,10 +210,9 @@ the `TensorProduct.semiring` instance (currently defined "by hand" using `Tensor
 
 See also `mul_mul_mul_comm`. -/
 def tensorTensorTensorComm : (M ⊗[R] N) ⊗[R] P ⊗[R] Q ≃ₗ[R] (M ⊗[R] P) ⊗[R] N ⊗[R] Q :=
-  let e₁ := TensorProduct.assoc R M N (P ⊗[R] Q)
-  let e₂ := congr (1 : M ≃ₗ[R] M) (leftComm R N P Q)
-  let e₃ := (TensorProduct.assoc R M P (N ⊗[R] Q)).symm
-  e₁ ≪≫ₗ (e₂ ≪≫ₗ e₃)
+  (TensorProduct.assoc R (M ⊗[R] N) P Q).symm
+    ≪≫ₗ congr (TensorProduct.rightComm R M N P) (.refl R Q)
+    ≪≫ₗ TensorProduct.assoc R (M ⊗[R] P) N Q
 
 variable {M N P Q}
 

--- a/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
@@ -81,6 +81,9 @@ theorem rid_tmul (m : M) (r : R) : (TensorProduct.rid R M) (m ⊗ₜ r) = r • 
 theorem rid_symm_apply (m : M) : (TensorProduct.rid R M).symm m = m ⊗ₜ 1 :=
   rfl
 
+theorem rid_def : TensorProduct.rid R M = TensorProduct.comm R M R ≪≫ₗ TensorProduct.lid R M :=
+  LinearEquiv.toLinearMap_injective (ext (by ext; rfl))
+
 variable (R) in
 theorem lid_eq_rid : TensorProduct.lid R R = TensorProduct.rid R R :=
   LinearEquiv.toLinearMap_injective <| ext' mul_comm

--- a/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
@@ -81,7 +81,12 @@ theorem rid_tmul (m : M) (r : R) : (TensorProduct.rid R M) (m ⊗ₜ r) = r • 
 theorem rid_symm_apply (m : M) : (TensorProduct.rid R M).symm m = m ⊗ₜ 1 :=
   rfl
 
-theorem rid_def : TensorProduct.rid R M = TensorProduct.comm R M R ≪≫ₗ TensorProduct.lid R M :=
+theorem comm_trans_lid :
+    TensorProduct.comm R M R ≪≫ₗ TensorProduct.lid R M = TensorProduct.rid R M :=
+  LinearEquiv.toLinearMap_injective (ext (by ext; rfl))
+
+theorem comm_trans_rid :
+    TensorProduct.comm R R M ≪≫ₗ TensorProduct.rid R M = TensorProduct.lid R M :=
   LinearEquiv.toLinearMap_injective (ext (by ext; rfl))
 
 variable (R) in

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -550,12 +550,14 @@ variable (R M N P) in
 /-- Linearly constructing a linear map `M ⊗ N → P` given a bilinear map `M → N → P`
 with the property that its composition with the canonical bilinear map `M → N → M ⊗ N` is
 the given bilinear map `M → N → P`. -/
-def uncurry : (M →ₗ[R] N →ₗ[R] P) →ₗ[R] M ⊗[R] N →ₗ[R] P :=
-  LinearMap.flip <| lift <| LinearMap.lflip.comp (LinearMap.flip LinearMap.id)
+def uncurry : (M →ₗ[R] N →ₗ[R] P) →ₗ[R] M ⊗[R] N →ₗ[R] P where
+  toFun := lift
+  map_add' f g := by ext; rfl
+  map_smul' _ _ := by ext; rfl
 
 @[simp]
 theorem uncurry_apply (f : M →ₗ[R] N →ₗ[R] P) (m : M) (n : N) :
-    uncurry R M N P f (m ⊗ₜ n) = f m n := by rw [uncurry, LinearMap.flip_apply, lift.tmul]; rfl
+    uncurry R M N P f (m ⊗ₜ n) = f m n := rfl
 
 variable (R M N P)
 

--- a/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
@@ -220,6 +220,9 @@ theorem map_smul_left (b : B) (f : M →ₗ[A] P) (g : N →ₗ[R] Q) : map (b �
   simp_rw [curry_apply, TensorProduct.curry_apply, restrictScalars_apply, smul_apply, map_tmul,
     smul_apply, smul_tmul']
 
+/-- The heterobasic version of `map` coincides with the regular version. -/
+theorem map_eq (f : M →ₗ[R] P) (g : N →ₗ[R] Q) : map f g = TensorProduct.map f g := rfl
+
 variable (A M) in
 /-- Heterobasic version of `LinearMap.lTensor` -/
 def lTensor : (N →ₗ[R] Q) →ₗ[R] M ⊗[R] N →ₗ[A] M ⊗[R] Q where
@@ -349,8 +352,8 @@ protected def rid : M ⊗[R] R ≃ₗ[A] M :=
     (LinearMap.ext <| one_smul _)
     (ext fun _ _ => smul_tmul _ _ _ |>.trans <| congr_arg _ <| mul_one _)
 
-theorem rid_eq_rid : AlgebraTensorModule.rid R R M = TensorProduct.rid R M :=
-  LinearEquiv.toLinearMap_injective <| TensorProduct.ext' fun _ _ => rfl
+/-- The heterobasic version of `rid` coincides with the regular version. -/
+theorem rid_eq_rid : AlgebraTensorModule.rid R R M = TensorProduct.rid R M := rfl
 
 variable {R M} in
 @[simp]
@@ -405,6 +408,9 @@ theorem assoc_tmul (m : M) (p : P) (q : Q) :
 theorem assoc_symm_tmul (m : M) (p : P) (q : Q) :
     (assoc R A B M P Q).symm (m ⊗ₜ (p ⊗ₜ q)) = (m ⊗ₜ p) ⊗ₜ q :=
   rfl
+
+/-- The heterobasic version of `assoc` coincides with the regular version. -/
+theorem assoc_eq : assoc R R R M P Q = TensorProduct.assoc R M P Q := rfl
 
 theorem rTensor_tensor [Module R P'] [IsScalarTower R A P'] (g : P →ₗ[A] P') :
     g.rTensor (M ⊗[R] N) =
@@ -467,6 +473,9 @@ theorem leftComm_symm_tmul (m : M) (p : P) (q : Q) :
     (leftComm R A M P Q).symm (p ⊗ₜ (m ⊗ₜ q)) = m ⊗ₜ (p ⊗ₜ q) :=
   rfl
 
+/-- The heterobasic version of `leftComm` coincides with the regular version. -/
+theorem leftComm_eq : leftComm R R M P Q = TensorProduct.leftComm R M P Q := rfl
+
 end leftComm
 
 section rightComm
@@ -509,6 +518,9 @@ theorem rightComm_symm_tmul (m : M) (p : P) (q : Q) :
     (rightComm R S B M P Q).symm ((m ⊗ₜ q) ⊗ₜ p) = (m ⊗ₜ p) ⊗ₜ q :=
   rfl
 
+/-- The heterobasic version of `leftComm` coincides with the regular version. -/
+theorem rightComm_eq [Module R P] : rightComm R R R M P Q = TensorProduct.rightComm R M P Q := rfl
+
 end rightComm
 
 section tensorTensorTensorComm
@@ -533,9 +545,9 @@ a `B`-module `M`, `S`-module `N`, `A`-module `P`, `R`-module `Q`, then
 -/
 def tensorTensorTensorComm :
     (M ⊗[S] N) ⊗[A] (P ⊗[R] Q) ≃ₗ[B] (M ⊗[A] P) ⊗[S] (N ⊗[R] Q) :=
-(assoc R A B (M ⊗[S] N) P Q).symm
-  ≪≫ₗ congr (rightComm A S B M N P) (.refl R Q)
-  ≪≫ₗ assoc R _ _ (M ⊗[A] P) N Q
+  (assoc R A B (M ⊗[S] N) P Q).symm
+    ≪≫ₗ congr (rightComm A S B M N P) (.refl R Q)
+    ≪≫ₗ assoc R _ _ (M ⊗[A] P) N Q
 
 variable {M N P Q}
 
@@ -554,10 +566,7 @@ theorem tensorTensorTensorComm_symm_tmul (m : M) (n : N) (p : P) (q : Q) :
 
 /-- The heterobasic version of `tensorTensorTensorComm` coincides with the regular version. -/
 theorem tensorTensorTensorComm_eq :
-    tensorTensorTensorComm R R R R M N P Q = TensorProduct.tensorTensorTensorComm R M N P Q := by
-  apply LinearEquiv.toLinearMap_injective
-  ext
-  simp
+    tensorTensorTensorComm R R R R M N P Q = TensorProduct.tensorTensorTensorComm R M N P Q := rfl
 
 end tensorTensorTensorComm
 


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
