### PR TITLE
chore(Algebra/Ring/Subring): simp tag `Subring.smul_def`

### DIFF
--- a/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Basic.lean
@@ -759,6 +759,7 @@ variable {α β : Type*}
 instance [SMul A α] (S : Subalgebra R A) : SMul S α :=
   inferInstanceAs (SMul S.toSubsemiring α)
 
+@[simp]
 theorem smul_def [SMul A α] {S : Subalgebra R A} (g : S) (m : α) : g • m = (g : A) • m := rfl
 
 instance smulCommClass_left [SMul A β] [SMul α β] [SMulCommClass A α β] (S : Subalgebra R A) :

--- a/Mathlib/Algebra/Field/Subfield/Basic.lean
+++ b/Mathlib/Algebra/Field/Subfield/Basic.lean
@@ -600,6 +600,7 @@ variable {X Y}
 instance [SMul K X] (F : Subfield K) : SMul F X :=
   inferInstanceAs (SMul F.toSubsemiring X)
 
+@[simp]
 theorem smul_def [SMul K X] {F : Subfield K} (g : F) (m : X) : g • m = (g : K) • m :=
   rfl
 

--- a/Mathlib/Algebra/Group/Subgroup/Actions.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Actions.lean
@@ -27,7 +27,7 @@ variable [MulAction G α] {S : Subgroup G}
 @[to_additive "The additive action by an add_subgroup is the action by the underlying `AddGroup`. "]
 instance instMulAction : MulAction S α := inferInstanceAs (MulAction S.toSubmonoid α)
 
-@[to_additive] lemma smul_def (g : S) (m : α) : g • m = (g : G) • m := rfl
+@[to_additive (attr := simp)] lemma smul_def (g : S) (m : α) : g • m = (g : G) • m := rfl
 
 @[to_additive (attr := simp)]
 lemma mk_smul (g : G) (hg : g ∈ S) (a : α) : (⟨g, hg⟩ : S) • a = g • a := rfl

--- a/Mathlib/Algebra/Group/Submonoid/MulAction.lean
+++ b/Mathlib/Algebra/Group/Submonoid/MulAction.lean
@@ -86,7 +86,7 @@ instance isScalarTower [SMul α β] [SMul M' α] [SMul M' β] [IsScalarTower M' 
 section SMul
 variable [SMul M' α] {S : Submonoid M'}
 
-@[to_additive] lemma smul_def (g : S) (a : α) : g • a = (g : M') • a := rfl
+@[to_additive (attr := simp)] lemma smul_def (g : S) (a : α) : g • a = (g : M') • a := rfl
 
 @[to_additive (attr := simp)]
 lemma mk_smul (g : M') (hg : g ∈ S) (a : α) : (⟨g, hg⟩ : S) • a = g • a := rfl

--- a/Mathlib/Algebra/Module/LocalizedModule/Basic.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule/Basic.lean
@@ -638,8 +638,7 @@ theorem lift'_add (g : M →ₗ[R] M'') (h : ∀ x : S, IsUnit ((algebraMap R (M
         simp only [Submonoid.coe_mul, LinearMap.map_smul_of_tower]
         rw [mul_smul, Submonoid.smul_def]
       · dsimp
-        rw [Module.End.algebraMap_isUnit_inv_apply_eq_iff, mul_comm, mul_smul, ← map_smul]
-        rfl)
+        rw [Module.End.algebraMap_isUnit_inv_apply_eq_iff, mul_comm, mul_smul, ← map_smul])
     x y
 
 theorem lift'_smul (g : M →ₗ[R] M'') (h : ∀ x : S, IsUnit ((algebraMap R (Module.End R M'')) x))
@@ -1148,7 +1147,7 @@ lemma injective_of_map_eq {N : Type*} [AddCommMonoid N] [Module R N]
     apply H at h
     rw [map_smul, map_smul] at h
     rwa [← IsLocalizedModule.smul_inj f (n * m), mul_smul, mul_comm, mul_smul, hxm, hym]
-  simp [← hxm, ← hym, hab, ← S.smul_def, ← mul_smul, mul_comm, ← mul_smul]
+  simp [← hxm, ← hym, smul_comm (m : R), hab]
 
 lemma injective_of_map_zero {M M' N : Type*} [AddCommGroup M] [AddCommGroup M']
     [Module R M] [Module R M'] (f : M →ₗ[R] M') [IsLocalizedModule S f]

--- a/Mathlib/Algebra/Module/LocalizedModule/Basic.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule/Basic.lean
@@ -379,18 +379,15 @@ noncomputable instance isModule : Module T (LocalizedModule S M) where
   add_smul := add_smul_aux
   zero_smul := zero_smul_aux
 
-@[simp]
 theorem mk_cancel_common_left (s' s : S) (m : M) : mk (s' • m) (s' * s) = mk m s :=
   mk_eq.mpr
     ⟨1, by
       simp only [mul_smul, one_smul]
       rw [smul_comm]⟩
 
-@[simp]
 theorem mk_cancel (s : S) (m : M) : mk (s • m) s = mk m 1 :=
   mk_eq.mpr ⟨1, by simp⟩
 
-@[simp]
 theorem mk_cancel_common_right (s s' : S) (m : M) : mk (s' • m) (s * s') = mk m s :=
   mk_eq.mpr ⟨1, by simp [mul_smul]⟩
 
@@ -994,22 +991,18 @@ theorem mk'_one (m : M) : mk' f m (1 : S) = f m := by
   rw [fromLocalizedModule_mk, Module.End.algebraMap_isUnit_inv_apply_eq_iff, Submonoid.coe_one,
     one_smul]
 
-@[simp]
 theorem mk'_cancel (m : M) (s : S) : mk' f (s • m) s = f m := by
   delta mk'
   rw [LocalizedModule.mk_cancel, ← mk'_one S f, fromLocalizedModule_mk,
     Module.End.algebraMap_isUnit_inv_apply_eq_iff, OneMemClass.coe_one, mk'_one, one_smul]
 
-@[simp]
 theorem mk'_cancel' (m : M) (s : S) : s • mk' f m s = f m := by
   rw [Submonoid.smul_def, ← mk'_smul, ← Submonoid.smul_def, mk'_cancel]
 
-@[simp]
 theorem mk'_cancel_left (m : M) (s₁ s₂ : S) : mk' f (s₁ • m) (s₁ * s₂) = mk' f m s₂ := by
   delta mk'
   rw [LocalizedModule.mk_cancel_common_left]
 
-@[simp]
 theorem mk'_cancel_right (m : M) (s₁ s₂ : S) : mk' f (s₂ • m) (s₁ * s₂) = mk' f m s₁ := by
   delta mk'
   rw [LocalizedModule.mk_cancel_common_right]

--- a/Mathlib/Algebra/Module/LocalizedModule/Submodule.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule/Submodule.lean
@@ -171,7 +171,7 @@ instance : IsLocalizedModule p (M'.toLocalized₀ p f) where
         ← IsLocalizedModule.mk'_smul, ← Submonoid.smul_def, IsLocalizedModule.mk'_cancel_right]
   surj' := by
     rintro ⟨y, x, hx, s, rfl⟩
-    exact ⟨⟨⟨x, hx⟩, s⟩, by ext; simp⟩
+    exact ⟨⟨⟨x, hx⟩, s⟩, by ext; exact IsLocalizedModule.mk'_cancel' ..⟩
   exists_of_eq e := by simpa [Subtype.ext_iff] using
       IsLocalizedModule.exists_of_eq (S := p) (f := f) (congr_arg Subtype.val e)
 
@@ -190,8 +190,7 @@ open Pointwise
 lemma localized₀_le_localized₀_of_smul_le {P Q : Submodule R M} (x : p) (h : x • P ≤ Q) :
     P.localized₀ p f ≤ Q.localized₀ p f := by
   rintro - ⟨a, ha, r, rfl⟩
-  refine ⟨x • a, h ⟨a, ha, rfl⟩, x * r, ?_⟩
-  simp
+  exact ⟨x • a, h ⟨a, ha, rfl⟩, x * r, IsLocalizedModule.mk'_cancel_left ..⟩
 
 lemma localized'_le_localized'_of_smul_le {P Q : Submodule R M} (x : p) (h : x • P ≤ Q) :
     P.localized' S p f ≤ Q.localized' S p f :=
@@ -238,7 +237,8 @@ instance IsLocalizedModule.toLocalizedQuotient' (M' : Submodule R M) :
   exists_of_eq {m n} e := by
     obtain ⟨⟨m, rfl⟩, n, rfl⟩ := PProd.mk (mk_surjective _ m) (mk_surjective _ n)
     obtain ⟨x, hx, s, hs⟩ : f (m - n) ∈ _ := by simpa [Submodule.Quotient.eq] using e
-    obtain ⟨c, hc⟩ := exists_of_eq (S := p) (show f (s • (m - n)) = f x by simp [-map_sub, ← hs])
+    obtain ⟨c, hc⟩ := exists_of_eq (S := p)
+      (show f (s • (m - n)) = f x by simpa [← hs] using IsLocalizedModule.mk'_cancel' ..)
     exact ⟨c * s, by simpa only [← Quotient.mk_smul, Submodule.Quotient.eq,
       ← smul_sub, mul_smul, hc] using M'.smul_mem c hx⟩
 
@@ -271,7 +271,7 @@ lemma ker_localizedMap_eq_localized₀_ker (g : M →ₗ[R] P) :
   · obtain ⟨⟨a, b⟩, rfl⟩ := IsLocalizedModule.mk'_surjective p f x
     simp only [Function.uncurry_apply_pair, map_mk', mk'_eq_zero, eq_zero_iff p f'] at h
     obtain ⟨c, hc⟩ := h
-    refine ⟨c • a, by simpa, c * b, by simp⟩
+    refine ⟨c • a, by simpa, c * b, by simpa using IsLocalizedModule.mk'_cancel_left ..⟩
   · rintro ⟨m, hm, a, ha, rfl⟩
     simp [IsLocalizedModule.map_mk', hm]
 

--- a/Mathlib/Algebra/Module/Submodule/Pointwise.lean
+++ b/Mathlib/Algebra/Module/Submodule/Pointwise.lean
@@ -233,7 +233,6 @@ theorem smul_sup' (a : α) (S T : Submodule R M) : a • (S ⊔ T) = a • S ⊔
 theorem smul_span (a : α) (s : Set M) : a • span R s = span R (a • s) :=
   map_span _ _
 
-@[simp]
 lemma smul_def (a : α) (S : Submodule R M) : a • S = span R (a • S : Set M) := by simp [← smul_span]
 
 theorem span_smul (a : α) (s : Set M) : span R (a • s) = a • span R s :=

--- a/Mathlib/Algebra/Module/Submodule/Pointwise.lean
+++ b/Mathlib/Algebra/Module/Submodule/Pointwise.lean
@@ -233,6 +233,7 @@ theorem smul_sup' (a : α) (S T : Submodule R M) : a • (S ⊔ T) = a • S ⊔
 theorem smul_span (a : α) (s : Set M) : a • span R s = span R (a • s) :=
   map_span _ _
 
+@[simp]
 lemma smul_def (a : α) (S : Submodule R M) : a • S = span R (a • S : Set M) := by simp [← smul_span]
 
 theorem span_smul (a : α) (s : Set M) : span R (a • s) = a • span R s :=

--- a/Mathlib/Algebra/Ring/Subring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Subring/Basic.lean
@@ -992,6 +992,7 @@ variable {α β : Type*}
 instance [SMul R α] (S : Subring R) : SMul S α :=
   inferInstanceAs (SMul S.toSubsemiring α)
 
+@[simp]
 theorem smul_def [SMul R α] {S : Subring R} (g : S) (m : α) : g • m = (g : R) • m :=
   rfl
 

--- a/Mathlib/Algebra/Ring/Subsemiring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/Basic.lean
@@ -871,6 +871,7 @@ variable [NonAssocSemiring R']
 instance smul [SMul R' α] (S : Subsemiring R') : SMul S α :=
   inferInstance
 
+@[simp]
 theorem smul_def [SMul R' α] {S : Subsemiring R'} (g : S) (m : α) : g • m = (g : R') • m :=
   rfl
 

--- a/Mathlib/Analysis/CStarAlgebra/Basic.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Basic.lean
@@ -216,7 +216,6 @@ theorem norm_coe_unitary_mul (U : unitary E) (A : E) : ‖(U : E) * A‖ = ‖A�
         exact norm_mul_le _ _
       _ = ‖(U : E) * A‖ := by rw [norm_star, norm_coe_unitary, one_mul]
 
-@[simp]
 theorem norm_unitary_smul (U : unitary E) (A : E) : ‖U • A‖ = ‖A‖ :=
   norm_coe_unitary_mul U A
 

--- a/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
@@ -170,7 +170,7 @@ lemma exists_form_eq_form_and_form_ne_zero (B : P.InvariantForm) (i j : ι) :
   obtain ⟨g, rfl⟩ := mem_orbit_iff.mp hv
   simp only [P.weylGroup_apply_root, SetLike.mem_coe, LinearMap.mem_ker]
   apply contra
-  simp [← Subgroup.smul_def g]
+  simp
 
 lemma span_root_image_eq_top_of_forall_orthogonal (s : Set ι)
     (hne : s.Nonempty) (h : ∀ j, P.root j ∉ span R (P.root '' s) → ∀ i ∈ s, P.IsOrthogonal j i) :

--- a/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/RootPositive.lean
@@ -76,7 +76,6 @@ lemma apply_reflection_reflection (x y : M) :
     B.form (P.reflection i x) (P.reflection i y) = B.form x y :=
   B.isOrthogonal_reflection i x y
 
-@[simp]
 lemma apply_weylGroup_smul (g : P.weylGroup) (x y : M) :
     B.form (g • x) (g • y) = B.form x y := by
   revert x y
@@ -87,6 +86,11 @@ lemma apply_weylGroup_smul (g : P.weylGroup) (x y : M) :
   | mul g₁ g₂ hg₁ hg₂ hg₁' hg₂' =>
     intro x y
     rw [← Submonoid.mk_mul_mk _ _ _ hg₁ hg₂, mul_smul, mul_smul, hg₁', hg₂']
+
+@[simp]
+lemma apply_weylGroup_coe_mul (g : P.weylGroup) (x y : M) :
+    B.form ((g : P.Aut) • x) ((g : P.Aut) • y) = B.form x y :=
+  apply_weylGroup_smul _ g x y
 
 @[simp]
 lemma apply_root_root_zero_iff [IsDomain R] [NeZero (2 : R)]:

--- a/Mathlib/LinearAlgebra/RootSystem/WeylGroup.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/WeylGroup.lean
@@ -52,7 +52,7 @@ lemma reflection_mem_weylGroup : Equiv.reflection P i ∈ P.weylGroup :=
 /-- The `ith` reflection as a term of the Weyl group. -/
 def weylGroup.ofIdx (i : ι) : P.weylGroup := ⟨_, P.reflection_mem_weylGroup i⟩
 
-@[simp] lemma weylGroup.ofIdx_smul (i : ι) (m : M) :
+lemma weylGroup.ofIdx_smul (i : ι) (m : M) :
     weylGroup.ofIdx P i • m = Equiv.reflection P i • m :=
   rfl
 

--- a/Mathlib/RingTheory/Localization/InvSubmonoid.lean
+++ b/Mathlib/RingTheory/Localization/InvSubmonoid.lean
@@ -64,7 +64,6 @@ theorem toInvSubmonoid_mul (m : M) : (toInvSubmonoid M S m : S) * algebraMap R S
 theorem mul_toInvSubmonoid (m : M) : algebraMap R S m * (toInvSubmonoid M S m : S) = 1 :=
   Submonoid.mul_leftInvEquiv_symm _ (submonoid_map_le_is_unit _ _) ⟨_, _⟩
 
-@[simp]
 theorem smul_toInvSubmonoid (m : M) : m • (toInvSubmonoid M S m : S) = 1 := by
   convert mul_toInvSubmonoid M S m
   ext

--- a/Mathlib/RingTheory/OreLocalization/Basic.lean
+++ b/Mathlib/RingTheory/OreLocalization/Basic.lean
@@ -106,7 +106,7 @@ private def add' (r₂ : X) (s₂ : S) : X[S⁻¹] → X[S⁻¹] :=
     have : sd * sb * s₁ = rd * rc * s₂ := by
       rw [mul_assoc, hb', ← mul_assoc, hd, mul_assoc, hc, ← mul_assoc]
     rw [add''_char _ _ _ _ (rd * rc : R) (sd * sb) this (sd * sb * s₁).2]
-    rw [mul_smul, ← Submonoid.smul_def sb, hb, smul_smul, hd, oreDiv_eq_iff]
+    rw [mul_smul, hb, smul_smul, hd, oreDiv_eq_iff]
     use 1
     use rd
     simp only [mul_smul, smul_add, one_smul, OneMemClass.coe_one, one_mul, true_and]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I found this being not-simp frustrating when talking about submodules over a valuation subring.