### PR TITLE
[Merged by Bors] - chore: generalize DistribMulAction instance for DomMulAct on Measure to general group actions

### DIFF
--- a/Mathlib/MeasureTheory/Group/MeasurableEquiv.lean
+++ b/Mathlib/MeasureTheory/Group/MeasurableEquiv.lean
@@ -217,7 +217,7 @@ lemma _root_.measurableEmbedding_divLeft [MeasurableMul G] [MeasurableInv G] (g 
 end MeasurableEquiv
 
 namespace MeasureTheory.Measure
-variable {G A : Type*} [Group G] [AddCommGroup A] [DistribMulAction G A] [MeasurableSpace A]
+variable {G A : Type*} [Group G] [MulAction G A] [MeasurableSpace A]
   [MeasurableConstSMul G A] {μ ν : Measure A} {g : G}
 
 noncomputable instance : DistribMulAction Gᵈᵐᵃ (Measure A) where


### PR DESCRIPTION
`noncomputable instance : DistribMulAction Gᵈᵐᵃ (Measure A)` currently requires `[AddCommGroup A] [DistribMulAction G A]`. This can be weakened to only require `[MulAction G A]` without changing anything else.

As an example, the following code works with the patch but not without it:
```lean
import Mathlib

open MeasureTheory

variable {G A : Type*} [Group G] [MulAction G A] [MeasurableSpace A] [MeasurableConstSMul G A]

variable {Ω : Type*} [MeasurableSpace Ω]
variable {P : Measure Ω} [IsProbabilityMeasure P]
variable {κ : ProbabilityTheory.Kernel Ω A}

def IsStationary : Prop := ∀ g : G, P.map ((DomMulAct.mk g) • (⇑κ)) = P.map κ
```