### PR TITLE
[Merged by Bors] - chore: fix docstrings of IsAddTorsionFree and IsMulTorsionFree

### DIFF
--- a/Mathlib/Algebra/Group/Torsion.lean
+++ b/Mathlib/Algebra/Group/Torsion.lean
@@ -24,7 +24,7 @@ open Function
 variable {M G : Type*}
 
 variable (M) in
-/-- A monoid is `R`-torsion-free if scalar multiplication by every non-zero element `a : R` is
+/-- A monoid is torsion-free if scalar multiplication by every non-zero element `a : ℕ` is
 injective. -/
 @[mk_iff]
 class IsAddTorsionFree [AddMonoid M] where
@@ -34,7 +34,7 @@ section Monoid
 variable [Monoid M]
 
 variable (M) in
-/-- A monoid is `R`-torsion-free if power by every non-zero element `a : R` is injective. -/
+/-- A monoid is torsion-free if power by every non-zero element `a : ℕ` is injective. -/
 @[to_additive, mk_iff]
 class IsMulTorsionFree where
   protected pow_left_injective ⦃n : ℕ⦄ (hn : n ≠ 0) : Injective fun a : M ↦ a ^ n

--- a/Mathlib/Algebra/Group/Torsion.lean
+++ b/Mathlib/Algebra/Group/Torsion.lean
@@ -24,7 +24,7 @@ open Function
 variable {M G : Type*}
 
 variable (M) in
-/-- A monoid is torsion-free if scalar multiplication by every non-zero element `a : ℕ` is
+/-- An additive monoid is torsion-free if scalar multiplication by every non-zero element `a : ℕ` is
 injective. -/
 @[mk_iff]
 class IsAddTorsionFree [AddMonoid M] where


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

(current docstrings are nonsense)
