### PR TITLE
[Merged by Bors] - feat: generalize the Integral.Pi file from `volume` to other measures

### DIFF
--- a/Mathlib/Analysis/Fourier/AddCircleMulti.lean
+++ b/Mathlib/Analysis/Fourier/AddCircleMulti.lean
@@ -168,7 +168,7 @@ theorem orthonormal_mFourier : Orthonormal ℂ (mFourierLp (d := d) 2) := by
   split_ifs with h
   · simpa only [h, add_neg_cancel, mFourier_zero, measureReal_univ_eq_one, one_smul] using
       integral_const (α := UnitAddTorus d) (μ := volume) (1 : ℂ)
-  rw [mFourier, ContinuousMap.coe_mk, MeasureTheory.integral_fintype_prod_eq_prod]
+  rw [mFourier, ContinuousMap.coe_mk, MeasureTheory.integral_fintype_prod_volume_eq_prod]
   obtain ⟨i, hi⟩ := Function.ne_iff.mp h
   apply Finset.prod_eq_zero (Finset.mem_univ i)
   simpa only [eq_false_intro hi, if_false, ContinuousMap.inner_toLp, ← fourier_neg,

--- a/Mathlib/Analysis/SpecialFunctions/Gaussian/FourierTransform.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gaussian/FourierTransform.lean
@@ -286,7 +286,7 @@ theorem integral_cexp_neg_sum_mul_add {ι : Type*} [Fintype ι] {b : ι → ℂ}
     ∫ v : ι → ℝ, cexp (- ∑ i, b i * (v i : ℂ) ^ 2 + ∑ i, c i * v i)
       = ∏ i, (π / b i) ^ (1 / 2 : ℂ) * cexp (c i ^ 2 / (4 * b i)) := by
   simp_rw [← Finset.sum_neg_distrib, ← Finset.sum_add_distrib, Complex.exp_sum, ← neg_mul]
-  rw [integral_fintype_prod_eq_prod (f := fun i (v : ℝ) ↦ cexp (-b i * v ^ 2 + c i * v))]
+  rw [integral_fintype_prod_volume_eq_prod (f := fun i (v : ℝ) ↦ cexp (-b i * v ^ 2 + c i * v))]
   congr with i
   have : (-b i).re < 0 := by simpa using hb i
   convert integral_cexp_quadratic this (c i) 0 using 1 <;> simp [div_neg]

--- a/Mathlib/MeasureTheory/Integral/Pi.lean
+++ b/Mathlib/MeasureTheory/Integral/Pi.lean
@@ -21,35 +21,37 @@ namespace MeasureTheory
 
 namespace Integrable
 
-variable {𝕜 : Type*} [NormedCommRing 𝕜]
+variable {𝕜 : Type*} [NormedCommRing 𝕜] {ι : Type*} [Fintype ι]
 
 /-- On a finite product space in `n` variables, for a natural number `n`, a product of integrable
 functions depending on each coordinate is integrable. -/
 theorem fin_nat_prod {n : ℕ} {E : Fin n → Type*}
-    [∀ i, MeasureSpace (E i)] [∀ i, SigmaFinite (volume : Measure (E i))]
-    {f : (i : Fin n) → E i → 𝕜} (hf : ∀ i, Integrable (f i)) :
-    Integrable (fun (x : (i : Fin n) → E i) ↦ ∏ i, f i (x i)) := by
+    [∀ i, MeasurableSpace (E i)] {μ : (i : Fin n) → Measure (E i)} [∀ i, SigmaFinite (μ i)]
+    {f : (i : Fin n) → E i → 𝕜} (hf : ∀ i, Integrable (f i) (μ i)) :
+    Integrable (fun (x : (i : Fin n) → E i) ↦ ∏ i, f i (x i)) (Measure.pi μ) := by
   induction n with
   | zero => simp only [Finset.univ_eq_empty, Finset.prod_empty, volume_pi, isFiniteMeasure_iff,
       integrable_const_iff, one_ne_zero, pi_empty_univ, ENNReal.one_lt_top, or_true]
   | succ n n_ih =>
-      have := ((measurePreserving_piFinSuccAbove (fun i => (volume : Measure (E i))) 0).symm)
-      rw [volume_pi, ← this.integrable_comp_emb (MeasurableEquiv.measurableEmbedding _)]
+      have := ((measurePreserving_piFinSuccAbove μ 0).symm)
+      rw [← this.integrable_comp_emb (MeasurableEquiv.measurableEmbedding _)]
       simp_rw [MeasurableEquiv.piFinSuccAbove_symm_apply, Fin.insertNthEquiv,
         Fin.prod_univ_succ, Fin.insertNth_zero]
       simp only [Fin.zero_succAbove, cast_eq, Function.comp_def, Fin.cons_zero, Fin.cons_succ]
-      have : Integrable (fun (x : (j : Fin n) → E (Fin.succ j)) ↦ ∏ j, f (Fin.succ j) (x j)) :=
+      have : Integrable (fun (x : (j : Fin n) → E (Fin.succ j)) ↦ ∏ j, f (Fin.succ j) (x j))
+          (Measure.pi (fun i ↦ μ i.succ)) :=
         n_ih (fun i ↦ hf _)
       exact Integrable.mul_prod (hf 0) this
 
 /-- On a finite product space, a product of integrable functions depending on each coordinate is
 integrable. Version with dependent target. -/
-theorem fintype_prod_dep {ι : Type*} [Fintype ι] {E : ι → Type*}
-    {f : (i : ι) → E i → 𝕜} [∀ i, MeasureSpace (E i)] [∀ i, SigmaFinite (volume : Measure (E i))]
-    (hf : ∀ i, Integrable (f i)) :
-    Integrable (fun (x : (i : ι) → E i) ↦ ∏ i, f i (x i)) := by
+theorem fintype_prod_dep {E : ι → Type*}
+    {f : (i : ι) → E i → 𝕜} [∀ i, MeasurableSpace (E i)] {μ : (i : ι) → Measure (E i)}
+    [∀ i, SigmaFinite (μ i)]
+    (hf : ∀ i, Integrable (f i) (μ i)) :
+    Integrable (fun (x : (i : ι) → E i) ↦ ∏ i, f i (x i)) (Measure.pi μ) := by
   let e := (equivFin ι).symm
-  simp_rw [← (volume_measurePreserving_piCongrLeft _ e).integrable_comp_emb
+  simp_rw [← (measurePreserving_piCongrLeft _ e).integrable_comp_emb
     (MeasurableEquiv.measurableEmbedding _),
     ← e.prod_comp, MeasurableEquiv.coe_piCongrLeft, Function.comp_def,
     Equiv.piCongrLeft_apply_apply]
@@ -57,10 +59,10 @@ theorem fintype_prod_dep {ι : Type*} [Fintype ι] {E : ι → Type*}
 
 /-- On a finite product space, a product of integrable functions depending on each coordinate is
 integrable. -/
-theorem fintype_prod {ι : Type*} [Fintype ι] {E : Type*}
-    {f : ι → E → 𝕜} [MeasureSpace E] [SigmaFinite (volume : Measure E)]
-    (hf : ∀ i, Integrable (f i)) :
-    Integrable (fun (x : ι → E) ↦ ∏ i, f i (x i)) :=
+theorem fintype_prod {E : Type*}
+    {f : ι → E → 𝕜} [MeasurableSpace E] {μ : ι → Measure E} [∀ i, SigmaFinite (μ i)]
+    (hf : ∀ i, Integrable (f i) (μ i)) :
+    Integrable (fun (x : ι → E) ↦ ∏ i, f i (x i)) (Measure.pi μ) :=
   Integrable.fintype_prod_dep hf
 
 end Integrable
@@ -69,37 +71,54 @@ variable {𝕜 : Type*} [RCLike 𝕜]
 
 /-- A version of **Fubini's theorem** in `n` variables, for a natural number `n`. -/
 theorem integral_fin_nat_prod_eq_prod {n : ℕ} {E : Fin n → Type*}
-    [∀ i, MeasureSpace (E i)] [∀ i, SigmaFinite (volume : Measure (E i))]
+    [∀ i, MeasurableSpace (E i)] {μ : (i : Fin n) → Measure (E i)} [∀ i, SigmaFinite (μ i)]
     (f : (i : Fin n) → E i → 𝕜) :
-    ∫ x : (i : Fin n) → E i, ∏ i, f i (x i) = ∏ i, ∫ x, f i x := by
+    ∫ x : (i : Fin n) → E i, ∏ i, f i (x i) ∂(Measure.pi μ) = ∏ i, ∫ x, f i x ∂(μ i) := by
   induction n with
-  | zero =>
-      simp [volume_pi, measureReal_def]
+  | zero => simp [measureReal_def]
   | succ n n_ih =>
       calc
         _ = ∫ x : E 0 × ((i : Fin n) → E (Fin.succ i)),
-            f 0 x.1 * ∏ i : Fin n, f (Fin.succ i) (x.2 i) := by
-          rw [volume_pi, ← ((measurePreserving_piFinSuccAbove
-            (fun i => (volume : Measure (E i))) 0).symm).integral_comp']
+            f 0 x.1 * ∏ i : Fin n, f (Fin.succ i) (x.2 i)
+            ∂((μ 0).prod (Measure.pi (fun i ↦ μ i.succ))) := by
+          rw [← ((measurePreserving_piFinSuccAbove μ 0).symm).integral_comp']
           simp_rw [MeasurableEquiv.piFinSuccAbove_symm_apply, Fin.insertNthEquiv,
-            Fin.prod_univ_succ, Fin.insertNth_zero, Equiv.coe_fn_mk, Fin.cons_succ, volume_eq_prod,
-            volume_pi, Fin.zero_succAbove, cast_eq, Fin.cons_zero]
-        _ = (∫ x, f 0 x) * ∏ i : Fin n, ∫ (x : E (Fin.succ i)), f (Fin.succ i) x := by
-          rw [← n_ih, ← integral_prod_mul, volume_eq_prod]
-        _ = ∏ i, ∫ x, f i x := by rw [Fin.prod_univ_succ]
+            Fin.prod_univ_succ, Fin.insertNth_zero, Equiv.coe_fn_mk, Fin.cons_succ,
+            Fin.zero_succAbove, cast_eq, Fin.cons_zero]
+        _ = (∫ x, f 0 x ∂μ 0)
+            * ∏ i : Fin n, ∫ (x : E (Fin.succ i)), f (Fin.succ i) x ∂(μ i.succ) := by
+          rw [← n_ih, ← integral_prod_mul]
+        _ = ∏ i, ∫ x, f i x ∂(μ i) := by rw [Fin.prod_univ_succ]
+
+/-- A version of **Fubini's theorem** in `n` variables, for a natural number `n`. -/
+theorem integral_fin_nat_prod_volume_eq_prod {n : ℕ} {E : Fin n → Type*}
+    [∀ i, MeasureSpace (E i)] [∀ i, SigmaFinite (volume : Measure (E i))]
+    (f : (i : Fin n) → E i → 𝕜) :
+    ∫ x : (i : Fin n) → E i, ∏ i, f i (x i) = ∏ i, ∫ x, f i x := integral_fin_nat_prod_eq_prod _
 
 /-- A version of **Fubini's theorem** with the variables indexed by a general finite type. -/
 theorem integral_fintype_prod_eq_prod (ι : Type*) [Fintype ι] {E : ι → Type*}
-    (f : (i : ι) → E i → 𝕜) [∀ i, MeasureSpace (E i)] [∀ i, SigmaFinite (volume : Measure (E i))] :
-    ∫ x : (i : ι) → E i, ∏ i, f i (x i) = ∏ i, ∫ x, f i x := by
+    (f : (i : ι) → E i → 𝕜) [∀ i, MeasurableSpace (E i)] {μ : (i : ι) → Measure (E i)}
+    [∀ i, SigmaFinite (μ i)] :
+    ∫ x : (i : ι) → E i, ∏ i, f i (x i) ∂(Measure.pi μ) = ∏ i, ∫ x, f i x ∂(μ i) := by
   let e := (equivFin ι).symm
-  rw [← (volume_measurePreserving_piCongrLeft _ e).integral_comp']
+  rw [← (measurePreserving_piCongrLeft _ e).integral_comp']
   simp_rw [← e.prod_comp, MeasurableEquiv.coe_piCongrLeft, Equiv.piCongrLeft_apply_apply,
     MeasureTheory.integral_fin_nat_prod_eq_prod]
 
+/-- A version of **Fubini's theorem** with the variables indexed by a general finite type. -/
+theorem integral_fintype_prod_volume_eq_prod (ι : Type*) [Fintype ι] {E : ι → Type*}
+    (f : (i : ι) → E i → 𝕜) [∀ i, MeasureSpace (E i)]
+    [∀ i, SigmaFinite (volume : Measure (E i))] :
+    ∫ x : (i : ι) → E i, ∏ i, f i (x i) = ∏ i, ∫ x, f i x := integral_fintype_prod_eq_prod _ _
+
 theorem integral_fintype_prod_eq_pow {E : Type*} (ι : Type*) [Fintype ι] (f : E → 𝕜)
-    [MeasureSpace E] [SigmaFinite (volume : Measure E)] :
-    ∫ x : ι → E, ∏ i, f (x i) = (∫ x, f x) ^ (card ι) := by
+    [MeasurableSpace E] {μ : Measure E} [SigmaFinite μ] :
+    ∫ x : ι → E, ∏ i, f (x i) ∂(Measure.pi (fun _ ↦ μ)) = (∫ x, f x ∂μ) ^ (card ι) := by
   rw [integral_fintype_prod_eq_prod, Finset.prod_const, card]
+
+theorem integral_fintype_prod_volume_eq_pow {E : Type*} (ι : Type*) [Fintype ι] (f : E → 𝕜)
+    [MeasureSpace E] [SigmaFinite (volume : Measure E)] :
+    ∫ x : ι → E, ∏ i, f (x i) = (∫ x, f x) ^ (card ι) := integral_fintype_prod_eq_pow _ _
 
 end MeasureTheory

--- a/Mathlib/MeasureTheory/Integral/Pi.lean
+++ b/Mathlib/MeasureTheory/Integral/Pi.lean
@@ -21,7 +21,7 @@ namespace MeasureTheory
 
 namespace Integrable
 
-variable {𝕜 : Type*} [NormedCommRing 𝕜] {ι : Type*} [Fintype ι]
+variable {𝕜 ι : Type*} [NormedCommRing 𝕜] [Fintype ι]
 
 /-- On a finite product space in `n` variables, for a natural number `n`, a product of integrable
 functions depending on each coordinate is integrable. -/

--- a/Mathlib/MeasureTheory/Integral/Pi.lean
+++ b/Mathlib/MeasureTheory/Integral/Pi.lean
@@ -26,7 +26,7 @@ variable {𝕜 ι : Type*} [NormedCommRing 𝕜] [Fintype ι]
 /-- On a finite product space in `n` variables, for a natural number `n`, a product of integrable
 functions depending on each coordinate is integrable. -/
 theorem fin_nat_prod {n : ℕ} {E : Fin n → Type*}
-    [∀ i, MeasurableSpace (E i)] {μ : (i : Fin n) → Measure (E i)} [∀ i, SigmaFinite (μ i)]
+    {mE : ∀ i, MeasurableSpace (E i)} {μ : (i : Fin n) → Measure (E i)} [∀ i, SigmaFinite (μ i)]
     {f : (i : Fin n) → E i → 𝕜} (hf : ∀ i, Integrable (f i) (μ i)) :
     Integrable (fun (x : (i : Fin n) → E i) ↦ ∏ i, f i (x i)) (Measure.pi μ) := by
   induction n with
@@ -46,7 +46,7 @@ theorem fin_nat_prod {n : ℕ} {E : Fin n → Type*}
 /-- On a finite product space, a product of integrable functions depending on each coordinate is
 integrable. Version with dependent target. -/
 theorem fintype_prod_dep {E : ι → Type*}
-    {f : (i : ι) → E i → 𝕜} [∀ i, MeasurableSpace (E i)] {μ : (i : ι) → Measure (E i)}
+    {f : (i : ι) → E i → 𝕜} {mE : ∀ i, MeasurableSpace (E i)} {μ : (i : ι) → Measure (E i)}
     [∀ i, SigmaFinite (μ i)]
     (hf : ∀ i, Integrable (f i) (μ i)) :
     Integrable (fun (x : (i : ι) → E i) ↦ ∏ i, f i (x i)) (Measure.pi μ) := by
@@ -60,7 +60,7 @@ theorem fintype_prod_dep {E : ι → Type*}
 /-- On a finite product space, a product of integrable functions depending on each coordinate is
 integrable. -/
 theorem fintype_prod {E : Type*}
-    {f : ι → E → 𝕜} [MeasurableSpace E] {μ : ι → Measure E} [∀ i, SigmaFinite (μ i)]
+    {f : ι → E → 𝕜} {mE : MeasurableSpace E} {μ : ι → Measure E} [∀ i, SigmaFinite (μ i)]
     (hf : ∀ i, Integrable (f i) (μ i)) :
     Integrable (fun (x : ι → E) ↦ ∏ i, f i (x i)) (Measure.pi μ) :=
   Integrable.fintype_prod_dep hf
@@ -71,7 +71,7 @@ variable {𝕜 : Type*} [RCLike 𝕜]
 
 /-- A version of **Fubini's theorem** in `n` variables, for a natural number `n`. -/
 theorem integral_fin_nat_prod_eq_prod {n : ℕ} {E : Fin n → Type*}
-    [∀ i, MeasurableSpace (E i)] {μ : (i : Fin n) → Measure (E i)} [∀ i, SigmaFinite (μ i)]
+    {mE : ∀ i, MeasurableSpace (E i)} {μ : (i : Fin n) → Measure (E i)} [∀ i, SigmaFinite (μ i)]
     (f : (i : Fin n) → E i → 𝕜) :
     ∫ x : (i : Fin n) → E i, ∏ i, f i (x i) ∂(Measure.pi μ) = ∏ i, ∫ x, f i x ∂(μ i) := by
   induction n with
@@ -98,7 +98,7 @@ theorem integral_fin_nat_prod_volume_eq_prod {n : ℕ} {E : Fin n → Type*}
 
 /-- A version of **Fubini's theorem** with the variables indexed by a general finite type. -/
 theorem integral_fintype_prod_eq_prod (ι : Type*) [Fintype ι] {E : ι → Type*}
-    (f : (i : ι) → E i → 𝕜) [∀ i, MeasurableSpace (E i)] {μ : (i : ι) → Measure (E i)}
+    (f : (i : ι) → E i → 𝕜) {mE : ∀ i, MeasurableSpace (E i)} {μ : (i : ι) → Measure (E i)}
     [∀ i, SigmaFinite (μ i)] :
     ∫ x : (i : ι) → E i, ∏ i, f i (x i) ∂(Measure.pi μ) = ∏ i, ∫ x, f i x ∂(μ i) := by
   let e := (equivFin ι).symm
@@ -113,7 +113,7 @@ theorem integral_fintype_prod_volume_eq_prod (ι : Type*) [Fintype ι] {E : ι �
     ∫ x : (i : ι) → E i, ∏ i, f i (x i) = ∏ i, ∫ x, f i x := integral_fintype_prod_eq_prod _ _
 
 theorem integral_fintype_prod_eq_pow {E : Type*} (ι : Type*) [Fintype ι] (f : E → 𝕜)
-    [MeasurableSpace E] {μ : Measure E} [SigmaFinite μ] :
+    {mE : MeasurableSpace E} {μ : Measure E} [SigmaFinite μ] :
     ∫ x : ι → E, ∏ i, f (x i) ∂(Measure.pi (fun _ ↦ μ)) = (∫ x, f x ∂μ) ^ (card ι) := by
   rw [integral_fintype_prod_eq_prod, Finset.prod_const, card]
 

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
@@ -193,7 +193,7 @@ theorem MeasureTheory.volume_sum_rpow_lt_one (hp : 1 ≤ p) :
     exact Finset.sum_nonneg' (fun _ => rpow_nonneg (abs_nonneg _) _)
   · simp_rw [← rpow_mul (h₂ _), div_mul_cancel₀ _ (ne_of_gt h₁), Real.rpow_one,
       ← Finset.sum_neg_distrib, exp_sum]
-    rw [integral_fintype_prod_eq_pow ι fun x : ℝ => exp (- |x| ^ p), integral_comp_abs
+    rw [integral_fintype_prod_volume_eq_pow ι fun x : ℝ => exp (- |x| ^ p), integral_comp_abs
       (f := fun x => exp (- x ^ p)), integral_exp_neg_rpow h₁]
   · rw [finrank_fintype_fun_eq_card]
 
@@ -265,7 +265,7 @@ theorem Complex.volume_sum_rpow_lt_one {p : ℝ} (hp : 1 ≤ p) :
     exact Finset.sum_nonneg' (fun _ => rpow_nonneg (norm_nonneg _) _)
   · simp_rw [← rpow_mul (h₂ _), div_mul_cancel₀ _ (ne_of_gt h₁), Real.rpow_one,
       ← Finset.sum_neg_distrib, Real.exp_sum]
-    rw [integral_fintype_prod_eq_pow ι fun x : ℂ => Real.exp (- ‖x‖ ^ p),
+    rw [integral_fintype_prod_volume_eq_pow ι fun x : ℂ => Real.exp (- ‖x‖ ^ p),
       Complex.integral_exp_neg_rpow hp]
   · rw [finrank_pi_fintype, Complex.finrank_real_complex, Finset.sum_const, smul_eq_mul,
       Nat.cast_mul, Nat.cast_ofNat, Fintype.card, mul_comm]

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
@@ -411,8 +411,8 @@ theorem convexBodySum_volume :
           ← Finset.sum_neg_distrib, exp_add, exp_sum, ← integral_prod_mul, volume_eq_prod]
       _ = (∫ x : ℝ, exp (-|x|)) ^ nrRealPlaces K *
               (∫ x : ℂ, Real.exp (-2 * ‖x‖)) ^ nrComplexPlaces K := by
-        rw [integral_fintype_prod_eq_pow _ (fun x => exp (- ‖x‖)), integral_fintype_prod_eq_pow _
-          (fun x => exp (- 2 * ‖x‖))]
+        rw [integral_fintype_prod_volume_eq_pow _ (fun x => exp (- ‖x‖)),
+          integral_fintype_prod_volume_eq_pow _ (fun x => exp (- 2 * ‖x‖))]
         simp_rw [norm_eq_abs]
       _ =  (2 * Gamma (1 / 1 + 1)) ^ nrRealPlaces K *
               (π * (2 : ℝ) ^ (-(2 : ℝ) / 1) * Gamma (2 / 1 + 1)) ^ nrComplexPlaces K := by


### PR DESCRIPTION


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
