### PR TITLE
[Merged by Bors] - feat(RingTheory/Radical): generalise and fill in TODOs

### DIFF
--- a/Mathlib/Algebra/Divisibility/Units.lean
+++ b/Mathlib/Algebra/Divisibility/Units.lean
@@ -142,6 +142,7 @@ def IsRelPrime [Monoid α] (x y : α) : Prop := ∀ ⦃d⦄, d ∣ x → d ∣ y
 variable [CommMonoid α] {x y z : α}
 
 @[symm] theorem IsRelPrime.symm (H : IsRelPrime x y) : IsRelPrime y x := fun _ hx hy ↦ H hy hx
+theorem symmetric_isRelPrime : Symmetric (IsRelPrime : α → α → Prop) := fun _ _ ↦ .symm
 
 theorem isRelPrime_comm : IsRelPrime x y ↔ IsRelPrime y x :=
   ⟨IsRelPrime.symm, IsRelPrime.symm⟩

--- a/Mathlib/NumberTheory/FLT/MasonStothers.lean
+++ b/Mathlib/NumberTheory/FLT/MasonStothers.lean
@@ -41,9 +41,9 @@ private theorem abc_subcall {a b c w : k[X]} {hw : w ≠ 0} (wab : w = wronskian
     a.natDegree + b.natDegree + c.natDegree = (a * b * c).natDegree := by
       rw [Polynomial.natDegree_mul ab_nz hc, Polynomial.natDegree_mul ha hb]
     _ = ((divRadical (a * b * c)) * (radical (a * b * c))).natDegree := by
-      rw [mul_comm _ (radical _), radical_mul_divRadical (a * b * c)]
+      rw [mul_comm _ (radical _), radical_mul_divRadical]
     _ = abc_dr.natDegree + abc_r.natDegree := by
-      rw [← Polynomial.natDegree_mul (divRadical_ne_zero abc_nz) (radical_ne_zero (a * b * c))]
+      rw [← Polynomial.natDegree_mul (divRadical_ne_zero abc_nz) radical_ne_zero]
     _ < a.natDegree + b.natDegree + abc_r.natDegree := by
       exact Nat.add_lt_add_right abc_dr_ndeg_lt _
 

--- a/Mathlib/NumberTheory/FLT/Polynomial.lean
+++ b/Mathlib/NumberTheory/FLT/Polynomial.lean
@@ -38,21 +38,21 @@ private lemma Ne.isUnit_C {u : k} (hu : u ≠ 0) : IsUnit (C u) :=
 -- auxiliary lemma that 'rotates' coprimality
 private lemma rot_coprime
     {p q r : ℕ} {a b c : k[X]} {u v w : k}
-    {hp : 0 < p} {hq : 0 < q} {hr : 0 < r}
+    {hp : p ≠ 0} {hq : q ≠ 0} {hr : r ≠ 0}
     {hu : u ≠ 0} {hv : v ≠ 0} {hw : w ≠ 0}
     (heq : C u * a ^ p + C v * b ^ q + C w * c ^ r = 0) (hab : IsCoprime a b) : IsCoprime b c := by
   have hCu : IsUnit (C u) := hu.isUnit_C
   have hCv : IsUnit (C v) := hv.isUnit_C
   have hCw : IsUnit (C w) := hw.isUnit_C
-  rw [← IsCoprime.pow_iff hp hq, ← isCoprime_mul_units_left hCu hCv] at hab
+  rw [← IsCoprime.pow_iff hp.bot_lt hq.bot_lt, ← isCoprime_mul_units_left hCu hCv] at hab
   rw [add_eq_zero_iff_neg_eq] at heq
-  rw [← IsCoprime.pow_iff hq hr, ← isCoprime_mul_units_left hCv hCw,
+  rw [← IsCoprime.pow_iff hq.bot_lt hr.bot_lt, ← isCoprime_mul_units_left hCv hCw,
     ← heq, IsCoprime.neg_right_iff]
   convert IsCoprime.add_mul_left_right hab.symm 1 using 2
   rw [mul_one]
 
 private lemma ineq_pqr_contradiction {p q r a b c : ℕ}
-    (hp : 0 < p) (hq : 0 < q) (hr : 0 < r)
+    (hp : p ≠ 0) (hq : q ≠ 0) (hr : r ≠ 0)
     (hineq : q * r + r * p + p * q ≤ p * q * r)
     (hpa : p * a < a + b + c)
     (hqb : q * b < a + b + c)
@@ -67,7 +67,7 @@ private lemma ineq_pqr_contradiction {p q r a b c : ℕ}
     _ ≤ _ := by gcongr
 
 private theorem Polynomial.flt_catalan_deriv
-    {p q r : ℕ} (hp : 0 < p) (hq : 0 < q) (hr : 0 < r)
+    {p q r : ℕ} (hp : p ≠ 0) (hq : q ≠ 0) (hr : r ≠ 0)
     (hineq : q * r + r * p + p * q ≤ p * q * r)
     (chp : (p : k) ≠ 0) (chq : (q : k) ≠ 0) (chr : (r : k) ≠ 0)
     {a b c : k[X]} (ha : a ≠ 0) (hb : b ≠ 0) (hc : c ≠ 0)
@@ -95,7 +95,7 @@ private theorem Polynomial.flt_catalan_deriv
   rcases Polynomial.abc
       (mul_ne_zero hCu hap) (mul_ne_zero hCv hbq) (mul_ne_zero hCw hcr)
       habp heq with nd_lt | dr0
-  · simp_rw [radical_mul habcp, radical_mul habp,
+  · simp_rw [radical_mul habcp.isRelPrime, radical_mul habp.isRelPrime,
       radical_mul_of_isUnit_left hu.isUnit_C,
       radical_mul_of_isUnit_left hv.isUnit_C,
       radical_mul_of_isUnit_left hw.isUnit_C,
@@ -104,8 +104,8 @@ private theorem Polynomial.flt_catalan_deriv
       natDegree_mul hCv hbq,
       natDegree_mul hCw hcr,
       natDegree_C, natDegree_pow, zero_add,
-      ← radical_mul hab,
-      ← radical_mul (hca.symm.mul_left hbc)] at nd_lt
+      ← radical_mul hab.isRelPrime,
+      ← radical_mul (hca.symm.mul_left hbc).isRelPrime] at nd_lt
     obtain ⟨hpa', hqb', hrc'⟩ := nd_lt
     have hpa := hpa'.trans natDegree_radical_le
     have hqb := hqb'.trans natDegree_radical_le
@@ -140,7 +140,7 @@ private lemma find_contract {a : k[X]}
 private theorem Polynomial.flt_catalan_aux
     {p q r : ℕ} {a b c : k[X]} {u v w : k}
     (heq : C u * a ^ p + C v * b ^ q + C w * c ^ r = 0)
-    (hp : 0 < p) (hq : 0 < q) (hr : 0 < r)
+    (hp : p ≠ 0) (hq : q ≠ 0) (hr : r ≠ 0)
     (hineq : q * r + r * p + p * q ≤ p * q * r)
     (chp : (p : k) ≠ 0) (chq : (q : k) ≠ 0) (chr : (r : k) ≠ 0)
     (ha : a ≠ 0) (hb : b ≠ 0) (hc : c ≠ 0) (hab : IsCoprime a b)
@@ -190,7 +190,7 @@ private theorem Polynomial.flt_catalan_aux
 
 /-- Nonsolvability of the Fermat-Catalan equation. -/
 theorem Polynomial.flt_catalan
-    {p q r : ℕ} (hp : 0 < p) (hq : 0 < q) (hr : 0 < r)
+    {p q r : ℕ} (hp : p ≠ 0) (hq : q ≠ 0) (hr : r ≠ 0)
     (hineq : q * r + r * p + p * q ≤ p * q * r)
     (chp : (p : k) ≠ 0) (chq : (q : k) ≠ 0) (chr : (r : k) ≠ 0)
     {a b c : k[X]} (ha : a ≠ 0) (hb : b ≠ 0) (hc : c ≠ 0) (hab : IsCoprime a b)
@@ -224,7 +224,7 @@ theorem Polynomial.flt
   have hone : (1 : k[X]) = C 1 := by rfl
   have hneg_one : (-1 : k[X]) = C (-1) := by simp only [map_neg, map_one]
   simp_rw [hneg_one, hone] at heq
-  apply flt_catalan hn' hn' hn' _
+  apply flt_catalan hn'.ne' hn'.ne' hn'.ne' _
     chn chn chn ha hb hc hab one_ne_zero one_ne_zero (neg_ne_zero.mpr one_ne_zero) heq
   have eq_lhs : n * n + n * n + n * n = 3 * n * n := by ring
   rw [eq_lhs, mul_assoc, mul_assoc]

--- a/Mathlib/NumberTheory/FLT/Polynomial.lean
+++ b/Mathlib/NumberTheory/FLT/Polynomial.lean
@@ -27,7 +27,7 @@ The proof uses the Mason-Stothers theorem (Polynomial ABC theorem) and infinite 
 (in the characteristic p case).
 -/
 
-open Polynomial UniqueFactorizationMonoid UniqueFactorizationDomain
+open Polynomial UniqueFactorizationMonoid
 
 variable {k R : Type*} [Field k] [CommRing R] [IsDomain R] [NormalizationMonoid R]
   [UniqueFactorizationMonoid R]

--- a/Mathlib/RingTheory/Polynomial/Radical.lean
+++ b/Mathlib/RingTheory/Polynomial/Radical.lean
@@ -20,13 +20,13 @@ open Polynomial UniqueFactorizationMonoid UniqueFactorizationDomain EuclideanDom
 variable {k : Type*} [Field k] [DecidableEq k]
 
 theorem degree_radical_le {a : k[X]} (h : a ≠ 0) :
-  (radical a).degree ≤ a.degree := degree_le_of_dvd (radical_dvd_self a) h
+  (radical a).degree ≤ a.degree := degree_le_of_dvd radical_dvd_self h
 
 theorem natDegree_radical_le {a : k[X]} :
     (radical a).natDegree ≤ a.natDegree := by
   by_cases ha : a = 0
   · simp [ha]
-  · exact natDegree_le_of_dvd (radical_dvd_self a) ha
+  · exact natDegree_le_of_dvd radical_dvd_self ha
 
 theorem divRadical_dvd_derivative (a : k[X]) : divRadical a ∣ derivative a := by
   induction a using induction_on_coprime
@@ -40,8 +40,8 @@ theorem divRadical_dvd_derivative (a : k[X]) : divRadical a ∣ derivative a := 
     · rw [pow_zero, derivative_one]
       apply dvd_zero
     · case succ i =>
-      rw [← mul_dvd_mul_iff_left (radical_ne_zero (p ^ i.succ)), radical_mul_divRadical,
-        radical_pow_of_prime hp i.succ_pos, derivative_pow_succ, ← mul_assoc]
+      rw [← mul_dvd_mul_iff_left radical_ne_zero, radical_mul_divRadical,
+        radical_pow_of_prime hp i.succ_ne_zero, derivative_pow_succ, ← mul_assoc]
       apply dvd_mul_of_dvd_left
       rw [mul_comm, mul_assoc]
       apply dvd_mul_of_dvd_right

--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -102,9 +102,21 @@ lemma normalizedFactors_nodup (ha : IsRadical a) : (normalizedFactors a).Nodup :
   · simp
   rwa [← squarefree_iff_nodup_normalizedFactors ha₀, ← isRadical_iff_squarefree_of_ne_zero ha₀]
 
+/--
+If `x` is a unit, then the finset of prime factors of `x` is empty.
+The converse is true with a nonzero assumption, see `normalizedFactors_eq_zero_iff`.
+-/
 lemma primeFactors_of_isUnit (h : IsUnit a) : primeFactors a = ∅ := by
   classical
   rw [primeFactors, normalizedFactors_of_isUnit h, Multiset.toFinset_zero]
+
+/--
+The finset of prime factors of `x` is empty if and only if `x` is a unit.
+The converse is true without the nonzero assumption, see `primeFactors_of_isUnit`.
+-/
+theorem primeFactors_eq_empty_iff (ha : a ≠ 0) : primeFactors a = ∅ ↔ IsUnit a := by
+  classical
+  rw [primeFactors, Multiset.toFinset_eq_empty, normalizedFactors_eq_zero_iff ha]
 
 lemma primeFactors_val_eq_normalizedFactors (ha : IsRadical a) :
     (primeFactors a).val = normalizedFactors a := by
@@ -241,8 +253,16 @@ lemma squarefree_radical : Squarefree (radical a) := by
   · simp [primeFactors]
   have : Nontrivial M := ⟨a, 0, ha₀⟩
   ext p
-  simp +contextual [mem_primeFactors, mem_normalizedFactors_iff' ha₀, mem_normalizedFactors_iff',
-    and_congr_right_iff, and_imp, dvd_radical_iff_of_irreducible, ha₀]
+  simp +contextual [mem_primeFactors, mem_normalizedFactors_iff',
+    dvd_radical_iff_of_irreducible, ha₀]
+
+theorem radical_eq_one_iff : radical a = 1 ↔ a = 0 ∨ IsUnit a := by
+  refine ⟨?_, (Or.elim · (by simp +contextual) radical_of_isUnit)⟩
+  intro h
+  rw [or_iff_not_imp_left]
+  intro ha
+  have : primeFactors a = ∅ := by rw [← primeFactors_radical, h, primeFactors_one]
+  rwa [primeFactors_eq_empty_iff ha] at this
 
 @[simp]
 lemma radical_radical : radical (radical a) = radical a :=

--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -206,7 +206,7 @@ theorem radical_pow_of_prime (ha : Prime a) {n : ℕ} (hn : n ≠ 0) :
 
 /--
 An irreducible `a` divides the radical of `b` if and only if it divides `b` itself.
-Note this generalises to radical elements `a`, see `dvd_radical_iff`.
+Note this generalises to radical elements `a`, see `UniqueFactorizationMonoid.dvd_radical_iff`.
 -/
 lemma dvd_radical_iff_of_irreducible (ha : Irreducible a) (hb : b ≠ 0) :
     a ∣ radical b ↔ a ∣ b := by
@@ -236,7 +236,7 @@ lemma squarefree_radical : Squarefree (radical a) := by
   nontriviality M
   exact isRadical_radical.squarefree (by simp [radical_ne_zero])
 
-lemma primeFactors_radical : primeFactors (radical a) = primeFactors a := by
+@[simp] lemma primeFactors_radical : primeFactors (radical a) = primeFactors a := by
   obtain rfl | ha₀ := eq_or_ne a 0
   · simp [primeFactors]
   have : Nontrivial M := ⟨a, 0, ha₀⟩
@@ -425,38 +425,26 @@ lemma UniqueFactorizationMonoid.primeFactors_eq_natPrimeFactors :
 
 namespace Nat
 
-theorem radical_le_self {n : ℕ} (hn : n ≠ 0) : radical n ≤ n :=
-  Nat.le_of_dvd (by omega) radical_dvd_self
+@[simp] theorem radical_le_self_iff {n : ℕ} : radical n ≤ n ↔ n ≠ 0 :=
+  ⟨by aesop, fun h ↦ Nat.le_of_dvd (by omega) radical_dvd_self⟩
 
-theorem two_le_radical {n : ℕ} (hn : 2 ≤ n) : 2 ≤ radical n := by
-  obtain ⟨p, hp, hpn⟩ := Nat.exists_prime_and_dvd (show n ≠ 1 by omega)
-  trans p
-  · apply hp.two_le
-  · apply Nat.le_of_dvd (Nat.pos_of_ne_zero radical_ne_zero)
-    rwa [dvd_radical_iff_of_irreducible hp.prime.irreducible (by omega)]
+@[simp] theorem two_le_radical_iff {n : ℕ} : 2 ≤ radical n ↔ 2 ≤ n := by
+  refine ⟨?_, ?_⟩
+  · match n with | 0 | 1 | _ + 2 => simp
+  · intro hn
+    obtain ⟨p, hp, hpn⟩ := Nat.exists_prime_and_dvd (show n ≠ 1 by omega)
+    trans p
+    · apply hp.two_le
+    · apply Nat.le_of_dvd (Nat.pos_of_ne_zero radical_ne_zero)
+      rwa [dvd_radical_iff_of_irreducible hp.prime.irreducible (by omega)]
+
+@[simp] theorem one_lt_radical_iff {n : ℕ} : 1 < radical n ↔ 1 < n := two_le_radical_iff
+
+@[simp] theorem radical_le_one_iff {n : ℕ} : radical n ≤ 1 ↔ n ≤ 1 := by
+  simpa only [not_lt] using one_lt_radical_iff.not
 
 theorem radical_pos (n : ℕ) : 0 < radical n := pos_of_ne_zero radical_ne_zero
 
 end Nat
-
-open Qq Lean Mathlib.Meta Finset
-
-namespace Mathlib.Meta.Positivity
-open Positivity
-
-attribute [local instance] monadLiftOptionMetaM in
-/-- Positivity extension for radical. Proves radicals are nonzero. -/
-@[positivity UniqueFactorizationMonoid.radical _]
-def evalRadical : PositivityExt where eval {u α} _ _ e := do
-  match e with
-  | ~q(@radical _ $inst $inst' $inst'' $n) =>
-    have _ := ← synthInstanceQ q(Nontrivial $α)
-    assertInstancesCommute
-    return .nonzero q(radical_ne_zero)
-  | _ => throwError "not radical"
-
-example : 0 < radical 100 := by positivity
-
-end Mathlib.Meta.Positivity
 
 end Nat

--- a/Mathlib/RingTheory/Radical.lean
+++ b/Mathlib/RingTheory/Radical.lean
@@ -1,14 +1,16 @@
 /-
 Copyright (c) 2024 Jineon Baek, Seewoo Lee. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jineon Baek, Seewoo Lee
+Authors: Jineon Baek, Seewoo Lee, Bhavik Mehta, Arend Mellendijk
 -/
 import Mathlib.Algebra.EuclideanDomain.Basic
 import Mathlib.Algebra.Order.Group.Finset
-import Mathlib.RingTheory.Coprime.Basic
+import Mathlib.RingTheory.Coprime.Lemmas
 import Mathlib.RingTheory.UniqueFactorizationDomain.NormalizedFactors
 import Mathlib.RingTheory.UniqueFactorizationDomain.Nat
+import Mathlib.RingTheory.Nilpotent.Basic
 import Mathlib.Data.Nat.PrimeFin
+import Mathlib.Algebra.Squarefree.Basic
 
 /-!
 # Radical of an element of a unique factorization normalization monoid
@@ -28,10 +30,10 @@ This is different from the radical of an ideal.
 - `radical_pow`: `radical (a ^ n) = radical a` for any `n ≥ 1`
 - `radical_of_prime`: Radical of a prime element is equal to its normalization
 - `radical_pow_of_prime`: Radical of a power of prime element is equal to its normalization
+- `radical_mul`: Radical is multiplicative for two relatively prime elements.
+- `radical_prod`: Radical is multiplicative for finitely many relatively prime elements.
 
 ### For unique factorization domains
-
-- `radical_mul`: Radical is multiplicative for coprime elements.
 
 ### For Euclidean domains
 
@@ -39,12 +41,17 @@ This is different from the radical of an ideal.
 - `EuclideanDomain.divRadical_mul`: `divRadical` of a product is the product of `divRadical`s.
 - `IsCoprime.divRadical`: `divRadical` of coprime elements are coprime.
 
+## For natural numbers
+
+- `UniqueFactorizationMonoid.primeFactors_eq_natPrimeFactors`: The prime factors of a natural number
+  are the same as the prime factors defined in `Nat.primeFactors`.
+- `Nat.radical_le_self`: The radical of a natural number is less than or equal to the number itself.
+- `Nat.two_le_radical`: If a natural number is at least 2, then its radical is at least 2.
+
 ## TODO
 
 - Make a comparison with `Ideal.radical`. Especially, for principal ideal,
   `Ideal.radical (Ideal.span {a}) = Ideal.span {radical a}`.
-- Prove `radical (radical a) = radical a`.
-- Prove a comparison between `primeFactors` and `Nat.primeFactors`.
 -/
 
 noncomputable section
@@ -53,14 +60,14 @@ namespace UniqueFactorizationMonoid
 
 -- `CancelCommMonoidWithZero` is required by `UniqueFactorizationMonoid`
 variable {M : Type*} [CancelCommMonoidWithZero M] [NormalizationMonoid M]
-  [UniqueFactorizationMonoid M]
+  [UniqueFactorizationMonoid M] {a b u : M}
 
 open scoped Classical in
 /-- The finite set of prime factors of an element in a unique factorization monoid. -/
 def primeFactors (a : M) : Finset M :=
   (normalizedFactors a).toFinset
 
-@[simp] lemma mem_primeFactors {a b : M} : a ∈ primeFactors b ↔ a ∈ normalizedFactors b := by
+@[simp] lemma mem_primeFactors : a ∈ primeFactors b ↔ a ∈ normalizedFactors b := by
   simp only [primeFactors, Multiset.mem_toFinset]
 
 theorem _root_.Associated.primeFactors_eq {a b : M} (h : Associated a b) :
@@ -72,8 +79,8 @@ theorem _root_.Associated.primeFactors_eq {a b : M} (h : Associated a b) :
 
 @[simp] lemma primeFactors_one : primeFactors (1 : M) = ∅ := by simp [primeFactors]
 
-lemma primeFactors_pairwise_isRelPrime {a : M} :
-    (primeFactors a).toSet.Pairwise IsRelPrime := by
+lemma pairwise_primeFactors_isRelPrime :
+    Set.Pairwise (primeFactors a : Set M) IsRelPrime := by
   obtain rfl | ha₀ := eq_or_ne a 0
   · simp
   intro x hx y hy hxy
@@ -83,6 +90,38 @@ lemma primeFactors_pairwise_isRelPrime {a : M} :
   have : Associated x y := hx.1.associated_of_dvd hy.1 hxy
   exact this.eq_of_normalized hx.2.1 hy.2.1
 
+theorem primeFactors_pow (a : M) {n : ℕ} (hn : n ≠ 0) : primeFactors (a ^ n) = primeFactors a := by
+  simp_rw [primeFactors, normalizedFactors_pow, Multiset.toFinset_nsmul _ _ hn]
+
+lemma normalizedFactors_nodup (ha : IsRadical a) : (normalizedFactors a).Nodup := by
+  obtain rfl | ha₀ := eq_or_ne a 0
+  · simp
+  rwa [← squarefree_iff_nodup_normalizedFactors ha₀, ← isRadical_iff_squarefree_of_ne_zero ha₀]
+
+lemma primeFactors_val_eq_normalizedFactors (ha : IsRadical a) :
+    (primeFactors a).val = normalizedFactors a := by
+  classical
+  rw [primeFactors, Multiset.toFinset_val, Multiset.dedup_eq_self]
+  exact normalizedFactors_nodup ha
+
+theorem primeFactors_mul_eq_union [DecidableEq M] (ha : a ≠ 0) (hb : b ≠ 0)  :
+    primeFactors (a * b) = primeFactors a ∪ primeFactors b := by
+  ext p
+  simp [mem_normalizedFactors_iff', ha, hb]
+
+/-- Relatively prime elements have disjoint prime factors (as finsets). -/
+theorem disjoint_primeFactors (hc : IsRelPrime a b) :
+    Disjoint (primeFactors a) (primeFactors b) := by
+  classical
+  exact Multiset.disjoint_toFinset.mpr (disjoint_normalizedFactors hc)
+
+theorem primeFactors_mul_eq_disjUnion (ha : a ≠ 0) (hb : b ≠ 0)
+    (hc : IsRelPrime a b) :
+    primeFactors (a * b) =
+      (primeFactors a).disjUnion (primeFactors b) (disjoint_primeFactors hc) := by
+  classical
+  rw [Finset.disjUnion_eq_union, primeFactors_mul_eq_union ha hb]
+
 /--
 Radical of an element `a` in a unique factorization monoid is the product of
 the prime factors of `a`.
@@ -90,29 +129,41 @@ the prime factors of `a`.
 def radical (a : M) : M :=
   (primeFactors a).prod id
 
-@[simp] theorem radical_zero_eq : radical (0 : M) = 1 := by simp [radical]
+@[simp] theorem radical_zero : radical (0 : M) = 1 := by simp [radical]
+@[deprecated (since := "2025-05-31")] alias radical_zero_eq := radical_zero
 
-@[simp] theorem radical_one_eq : radical (1 : M) = 1 := by simp [radical]
+@[simp] theorem radical_one : radical (1 : M) = 1 := by simp [radical]
+@[deprecated (since := "2025-05-31")] alias radical_one_eq := radical_one
 
-theorem radical_eq_of_associated {a b : M} (h : Associated a b) : radical a = radical b := by
-  rw [radical, radical, h.primeFactors_eq]
+lemma radical_eq_of_primeFactors_eq (h : primeFactors a = primeFactors b) :
+    radical a = radical b := by
+  simp only [radical, h]
 
-theorem radical_of_isUnit {a : M} (h : IsUnit a) : radical a = 1 :=
-  (radical_eq_of_associated (associated_one_iff_isUnit.mpr h)).trans radical_one_eq
+theorem radical_eq_of_associated (h : Associated a b) : radical a = radical b :=
+  radical_eq_of_primeFactors_eq h.primeFactors_eq
 
-theorem radical_mul_of_isUnit_left {a u : M} (h : IsUnit u) : radical (u * a) = radical a :=
+lemma radical_associated (ha : IsRadical a) (ha' : a ≠ 0) :
+    Associated (radical a) a := by
+  rw [radical, ← Finset.prod_val, primeFactors_val_eq_normalizedFactors ha]
+  exact prod_normalizedFactors ha'
+
+/-- If `a` is a radical element, then it divides its radical. -/
+lemma _root_.IsRadical.dvd_radical (ha : IsRadical a) (ha' : a ≠ 0) : a ∣ radical a :=
+  (radical_associated ha ha').dvd'
+
+theorem radical_of_isUnit (h : IsUnit a) : radical a = 1 :=
+  (radical_eq_of_associated (associated_one_iff_isUnit.mpr h)).trans radical_one
+
+theorem radical_mul_of_isUnit_left (h : IsUnit u) : radical (u * a) = radical a :=
   radical_eq_of_associated (associated_unit_mul_left _ _ h)
 
-theorem radical_mul_of_isUnit_right {a u : M} (h : IsUnit u) : radical (a * u) = radical a :=
+theorem radical_mul_of_isUnit_right (h : IsUnit u) : radical (a * u) = radical a :=
   radical_eq_of_associated (associated_mul_unit_left _ _ h)
 
-theorem primeFactors_pow (a : M) {n : ℕ} (hn : 0 < n) : primeFactors (a ^ n) = primeFactors a := by
-  simp_rw [primeFactors, normalizedFactors_pow, Multiset.toFinset_nsmul _ _ hn.ne']
-
-theorem radical_pow (a : M) {n : Nat} (hn : 0 < n) : radical (a ^ n) = radical a := by
+theorem radical_pow (a : M) {n : ℕ} (hn : n ≠ 0) : radical (a ^ n) = radical a := by
   simp_rw [radical, primeFactors_pow a hn]
 
-theorem radical_dvd_self (a : M) : radical a ∣ a := by
+theorem radical_dvd_self : radical a ∣ a := by
   classical
   by_cases ha : a = 0
   · rw [ha]
@@ -122,17 +173,17 @@ theorem radical_dvd_self (a : M) : radical a ∣ a := by
     rw [primeFactors, Multiset.toFinset_val]
     apply Multiset.dedup_le
 
-theorem radical_of_prime {a : M} (ha : Prime a) : radical a = normalize a := by
+theorem radical_of_prime (ha : Prime a) : radical a = normalize a := by
   rw [radical, primeFactors]
   rw [normalizedFactors_irreducible ha.irreducible]
   simp only [Multiset.toFinset_singleton, id, Finset.prod_singleton]
 
-theorem radical_pow_of_prime {a : M} (ha : Prime a) {n : ℕ} (hn : 0 < n) :
+theorem radical_pow_of_prime (ha : Prime a) {n : ℕ} (hn : n ≠ 0) :
     radical (a ^ n) = normalize a := by
   rw [radical_pow a hn]
   exact radical_of_prime ha
 
-theorem radical_ne_zero (a : M) [Nontrivial M] : radical a ≠ 0 := by
+@[simp] theorem radical_ne_zero [Nontrivial M] : radical a ≠ 0 := by
   rw [radical, ← Finset.prod_val]
   apply Multiset.prod_ne_zero
   rw [primeFactors]
@@ -143,69 +194,170 @@ theorem radical_ne_zero (a : M) [Nontrivial M] : radical a ≠ 0 := by
 An irreducible `a` divides the radical of `b` if and only if it divides `b` itself.
 Note this generalises to radical elements `a`, see `dvd_radical_iff`.
 -/
-lemma dvd_radical_iff_of_irreducible {a b : M} (ha : Irreducible a) (hb : b ≠ 0) :
+lemma dvd_radical_iff_of_irreducible (ha : Irreducible a) (hb : b ≠ 0) :
     a ∣ radical b ↔ a ∣ b := by
   constructor
   · intro ha
-    exact ha.trans (radical_dvd_self b)
+    exact ha.trans radical_dvd_self
   · intro ha'
     obtain ⟨c, hc, hc'⟩ := exists_mem_normalizedFactors_of_dvd hb ha ha'
     exact hc'.dvd.trans (Finset.dvd_prod_of_mem _ (by simpa))
+
+lemma isRadical_radical : IsRadical (radical a) := by
+  intro n p ha
+  rw [radical]
+  apply Finset.prod_dvd_of_isRelPrime
+  · exact pairwise_primeFactors_isRelPrime
+  intro i hi
+  simp only [mem_primeFactors] at hi
+  have : i ∣ radical a := by
+    rw [dvd_radical_iff_of_irreducible]
+    · exact dvd_of_mem_normalizedFactors hi
+    · exact irreducible_of_normalized_factor i hi
+    · rintro rfl
+      simp only [normalizedFactors_zero, Multiset.notMem_zero] at hi
+  exact (prime_of_normalized_factor i hi).isRadical n p (this.trans ha)
+
+lemma squarefree_radical : Squarefree (radical a) := by
+  nontriviality M
+  exact isRadical_radical.squarefree (by simp [radical_ne_zero])
+
+lemma primeFactors_radical : primeFactors (radical a) = primeFactors a := by
+  obtain rfl | ha₀ := eq_or_ne a 0
+  · simp [primeFactors]
+  have : Nontrivial M := ⟨a, 0, ha₀⟩
+  ext p
+  simp +contextual [mem_primeFactors, mem_normalizedFactors_iff' ha₀, mem_normalizedFactors_iff',
+    and_congr_right_iff, and_imp, dvd_radical_iff_of_irreducible, ha₀]
+
+@[simp]
+lemma radical_radical : radical (radical a) = radical a :=
+  radical_eq_of_primeFactors_eq primeFactors_radical
+
+lemma radical_dvd_radical_iff_normalizedFactors_subset_normalizedFactors :
+    radical a ∣ radical b ↔ normalizedFactors a ⊆ normalizedFactors b := by
+  obtain rfl | ha₀ := eq_or_ne a 0
+  · simp
+  have : Nontrivial M := ⟨a, 0, ha₀⟩
+  rw [dvd_iff_normalizedFactors_le_normalizedFactors radical_ne_zero radical_ne_zero,
+    Multiset.le_iff_subset (normalizedFactors_nodup isRadical_radical)]
+  simp only [Multiset.subset_iff, ← mem_primeFactors, primeFactors_radical]
+
+lemma radical_dvd_radical_iff_primeFactors_subset_primeFactors :
+    radical a ∣ radical b ↔ primeFactors a ⊆ primeFactors b := by
+  classical
+  rw [radical_dvd_radical_iff_normalizedFactors_subset_normalizedFactors, primeFactors,
+    primeFactors, Multiset.toFinset_subset]
+
+/-- If `a` divides `b`, then the radical of `a` divides the radical of `b`. The theorem requires
+that `b ≠ 0`, since `radical 0 = 1` but `a ∣ 0` holds for every `a`. -/
+lemma radical_dvd_radical (h : a ∣ b) (hb₀ : b ≠ 0) : radical a ∣ radical b := by
+  obtain rfl | ha₀ := eq_or_ne a 0
+  · simp
+  rw [dvd_iff_normalizedFactors_le_normalizedFactors ha₀ hb₀] at h
+  rw [radical_dvd_radical_iff_normalizedFactors_subset_normalizedFactors]
+  exact Multiset.subset_of_le h
+
+/--
+If `a` is a radical element, then `a` divides the radical of `b` if and only if it divides `b`.
+Note the forward implication holds without the `b ≠ 0` assumption via `radical_dvd_self`.
+-/
+lemma dvd_radical_iff (ha : IsRadical a) (hb₀ : b ≠ 0) : a ∣ radical b ↔ a ∣ b := by
+  refine ⟨fun ha' ↦ ha'.trans radical_dvd_self, fun hab ↦ ?_⟩
+  obtain rfl | ha₀ := eq_or_ne a 0
+  · simp_all
+  · exact (ha.dvd_radical ha₀).trans (radical_dvd_radical hab hb₀)
+
+theorem radical_dvd_iff_primeFactors_subset (hb : b ≠ 0) :
+    radical a ∣ b ↔ primeFactors a ⊆ primeFactors b := by
+  rw [← dvd_radical_iff isRadical_radical hb,
+    radical_dvd_radical_iff_primeFactors_subset_primeFactors]
+
+/-- Radical is multiplicative for relatively prime elements. -/
+theorem radical_mul (hc : IsRelPrime a b) :
+    radical (a * b) = radical a * radical b := by
+  obtain rfl | ha := eq_or_ne a 0
+  · rw [isRelPrime_zero_left] at hc
+    simp [radical_of_isUnit hc]
+  obtain rfl | hb := eq_or_ne b 0
+  · rw [isRelPrime_zero_right] at hc
+    simp [radical_of_isUnit hc]
+  simp_rw [radical]
+  rw [primeFactors_mul_eq_disjUnion ha hb hc, Finset.prod_disjUnion (disjoint_primeFactors hc)]
+
+theorem radical_prod {ι : Type*} {f : ι → M} (s : Finset ι)
+    (h : Set.Pairwise (s : Set ι) (Function.onFun IsRelPrime f)) :
+    radical (∏ i ∈ s, f i) = ∏ i ∈ s, radical (f i) := by
+  induction s using Finset.cons_induction with
+  | empty => simp
+  | cons i s his ih =>
+    simp only [Finset.prod_cons]
+    rw [Finset.coe_cons,
+      Set.pairwise_insert_of_symmetric_of_notMem (symmetric_isRelPrime.comap _) (by simpa)] at h
+    rw [radical_mul, ih h.1]
+    exact IsRelPrime.prod_right h.2
+
+theorem radical_mul_dvd : radical (a * b) ∣ radical a * radical b := by
+  classical
+  by_cases ha : a = 0
+  · subst ha; simp
+  by_cases hb : b = 0
+  · subst hb; simp
+  nontriviality M
+  simp [radical_dvd_iff_primeFactors_subset, primeFactors_mul_eq_union,
+    primeFactors_mul_eq_union ha hb, primeFactors_radical]
+
+theorem radical_prod_dvd {ι : Type*} {s : Finset ι} {f : ι → M} :
+    radical (∏ i ∈ s, f i) ∣ ∏ i ∈ s, radical (f i) := by
+  induction s using Finset.cons_induction with
+  | empty => simp
+  | cons i s h ih =>
+    simp only [Finset.prod_cons]
+    exact radical_mul_dvd.trans (mul_dvd_mul_left _ ih)
 
 end UniqueFactorizationMonoid
 
 open UniqueFactorizationMonoid
 
+/-! Theorems for UFDs -/
 namespace UniqueFactorizationDomain
--- Theorems for UFDs
 
 variable {R : Type*} [CommRing R] [IsDomain R] [NormalizationMonoid R]
-  [UniqueFactorizationMonoid R]
+  [UniqueFactorizationMonoid R] {a b : R}
 
 /-- Coprime elements have disjoint prime factors (as multisets). -/
-theorem disjoint_normalizedFactors {a b : R} (hc : IsCoprime a b) :
-    Disjoint (normalizedFactors a) (normalizedFactors b) := by
-  rw [Multiset.disjoint_left]
-  intro x hxa hxb
-  have x_dvd_a := dvd_of_mem_normalizedFactors hxa
-  have x_dvd_b := dvd_of_mem_normalizedFactors hxb
-  have xp := prime_of_normalized_factor x hxa
-  exact xp.not_unit (hc.isUnit_of_dvd' x_dvd_a x_dvd_b)
+@[deprecated "UniqueFactorizationMonoid.disjoint_normalizedFactors, IsCoprime.isRelPrime"
+  (since := "2025-05-31")]
+theorem disjoint_normalizedFactors (hc : IsCoprime a b) :
+    Disjoint (normalizedFactors a) (normalizedFactors b) :=
+  UniqueFactorizationMonoid.disjoint_normalizedFactors hc.isRelPrime
 
 /-- Coprime elements have disjoint prime factors (as finsets). -/
-theorem disjoint_primeFactors {a b : R} (hc : IsCoprime a b) :
-    Disjoint (primeFactors a) (primeFactors b) := by
-  classical
-  exact Multiset.disjoint_toFinset.mpr (disjoint_normalizedFactors hc)
+@[deprecated "UniqueFactorizationMonoid.disjoint_primeFactors, IsCoprime.isRelPrime"
+  (since := "2025-05-31")]
+theorem disjoint_primeFactors (hc : IsCoprime a b) :
+    Disjoint (primeFactors a) (primeFactors b) :=
+  UniqueFactorizationMonoid.disjoint_primeFactors hc.isRelPrime
 
-theorem mul_primeFactors_disjUnion {a b : R} (ha : a ≠ 0) (hb : b ≠ 0)
-    (hc : IsCoprime a b) :
-    primeFactors (a * b) =
-    (primeFactors a).disjUnion (primeFactors b) (disjoint_primeFactors hc) := by
-  classical
-  rw [Finset.disjUnion_eq_union]
-  simp_rw [primeFactors]
-  rw [normalizedFactors_mul ha hb, Multiset.toFinset_add]
-
-@[simp]
-theorem radical_neg_one : radical (-1 : R) = 1 :=
-  radical_of_isUnit isUnit_one.neg
+set_option linter.deprecated false in
+@[deprecated "UniqueFactorizationMonoid.primeFactors_mul_eq_disjUnion, IsCoprime.isRelPrime"
+  (since := "2025-05-31")]
+theorem mul_primeFactors_disjUnion (ha : a ≠ 0) (hb : b ≠ 0)
+    (hc : IsCoprime a b) : primeFactors (a * b) =
+    (primeFactors a).disjUnion (primeFactors b) (disjoint_primeFactors hc) :=
+  UniqueFactorizationMonoid.primeFactors_mul_eq_disjUnion ha hb hc.isRelPrime
 
 /-- Radical is multiplicative for coprime elements. -/
-theorem radical_mul {a b : R} (hc : IsCoprime a b) :
-    radical (a * b) = radical a * radical b := by
-  by_cases ha : a = 0
-  · subst ha; rw [isCoprime_zero_left] at hc
-    simp only [zero_mul, radical_zero_eq, one_mul, radical_of_isUnit hc]
-  by_cases hb : b = 0
-  · subst hb; rw [isCoprime_zero_right] at hc
-    simp only [mul_zero, radical_zero_eq, mul_one, radical_of_isUnit hc]
-  simp_rw [radical]
-  rw [mul_primeFactors_disjUnion ha hb hc]
-  rw [Finset.prod_disjUnion (disjoint_primeFactors hc)]
+@[deprecated "UniqueFactorizationMonoid.radical_mul, IsCoprime.isRelPrime" (since := "2025-05-31")]
+theorem radical_mul (hc : IsCoprime a b) :
+    radical (a * b) = radical a * radical b :=
+  UniqueFactorizationMonoid.radical_mul hc.isRelPrime
 
-theorem radical_neg {a : R} : radical (-a) = radical a :=
+@[simp]
+theorem radical_neg : radical (-a) = radical a :=
   radical_eq_of_associated Associated.rfl.neg_left
+
+theorem radical_neg_one : radical (-1 : R) = 1 := by simp
 
 end UniqueFactorizationDomain
 
@@ -213,53 +365,90 @@ open UniqueFactorizationDomain
 namespace EuclideanDomain
 
 variable {E : Type*} [EuclideanDomain E] [NormalizationMonoid E] [UniqueFactorizationMonoid E]
+  {a b u x : E}
 
 /-- Division of an element by its radical in an Euclidean domain. -/
 def divRadical (a : E) : E := a / radical a
 
-theorem radical_mul_divRadical (a : E) : radical a * divRadical a = a := by
-  rw [divRadical, ← EuclideanDomain.mul_div_assoc _ (radical_dvd_self a),
-    mul_div_cancel_left₀ _ (radical_ne_zero a)]
+theorem radical_mul_divRadical : radical a * divRadical a = a := by
+  rw [divRadical, ← EuclideanDomain.mul_div_assoc _ radical_dvd_self,
+    mul_div_cancel_left₀ _ radical_ne_zero]
 
-theorem divRadical_mul_radical (a : E) : divRadical a * radical a = a := by
+theorem divRadical_mul_radical : divRadical a * radical a = a := by
   rw [mul_comm]
-  exact radical_mul_divRadical a
+  exact radical_mul_divRadical
 
-theorem divRadical_ne_zero {a : E} (ha : a ≠ 0) : divRadical a ≠ 0 := by
-  rw [← radical_mul_divRadical a] at ha
+theorem divRadical_ne_zero (ha : a ≠ 0) : divRadical a ≠ 0 := by
+  rw [← radical_mul_divRadical (a := a)] at ha
   exact right_ne_zero_of_mul ha
 
-theorem divRadical_isUnit {u : E} (hu : IsUnit u) : IsUnit (divRadical u) := by
+theorem divRadical_isUnit (hu : IsUnit u) : IsUnit (divRadical u) := by
   rwa [divRadical, radical_of_isUnit hu, EuclideanDomain.div_one]
 
-theorem eq_divRadical {a x : E} (h : radical a * x = a) : x = divRadical a := by
-  apply EuclideanDomain.eq_div_of_mul_eq_left (radical_ne_zero a)
+theorem eq_divRadical (h : radical a * x = a) : x = divRadical a := by
+  apply EuclideanDomain.eq_div_of_mul_eq_left radical_ne_zero
   rwa [mul_comm]
 
-theorem divRadical_mul {a b : E} (hab : IsCoprime a b) :
+theorem divRadical_mul (hab : IsCoprime a b) :
     divRadical (a * b) = divRadical a * divRadical b := by
   symm; apply eq_divRadical
-  rw [radical_mul hab]
+  rw [UniqueFactorizationMonoid.radical_mul hab.isRelPrime]
   rw [mul_mul_mul_comm, radical_mul_divRadical, radical_mul_divRadical]
 
-theorem divRadical_dvd_self (a : E) : divRadical a ∣ a := by
-  exact Dvd.intro (radical a) (divRadical_mul_radical a)
+theorem divRadical_dvd_self (a : E) : divRadical a ∣ a :=
+  ⟨radical a, divRadical_mul_radical.symm⟩
 
 theorem _root_.IsCoprime.divRadical {a b : E} (h : IsCoprime a b) :
     IsCoprime (divRadical a) (divRadical b) := by
-  rw [← radical_mul_divRadical a] at h
-  rw [← radical_mul_divRadical b] at h
+  rw [← radical_mul_divRadical (a := a)] at h
+  rw [← radical_mul_divRadical (a := b)] at h
   exact h.of_mul_left_right.of_mul_right_right
 
 end EuclideanDomain
 
 section Nat
 
-lemma primeFactors_eq_natPrimeFactors :
+lemma UniqueFactorizationMonoid.primeFactors_eq_natPrimeFactors :
     primeFactors = Nat.primeFactors := by
   ext n : 1
   rw [primeFactors, Nat.factors_eq, Nat.primeFactors]
   -- this convert is necessary because of the different DecidableEq instances
   convert List.toFinset_coe _
+
+namespace Nat
+
+theorem radical_le_self {n : ℕ} (hn : n ≠ 0) : radical n ≤ n :=
+  Nat.le_of_dvd (by omega) radical_dvd_self
+
+theorem two_le_radical {n : ℕ} (hn : 2 ≤ n) : 2 ≤ radical n := by
+  obtain ⟨p, hp, hpn⟩ := Nat.exists_prime_and_dvd (show n ≠ 1 by omega)
+  trans p
+  · apply hp.two_le
+  · apply Nat.le_of_dvd (Nat.pos_of_ne_zero radical_ne_zero)
+    rwa [dvd_radical_iff_of_irreducible hp.prime.irreducible (by omega)]
+
+theorem radical_pos (n : ℕ) : 0 < radical n := pos_of_ne_zero radical_ne_zero
+
+end Nat
+
+open Qq Lean Mathlib.Meta Finset
+
+namespace Mathlib.Meta.Positivity
+open Positivity
+
+attribute [local instance] monadLiftOptionMetaM in
+/-- Positivity extension for radical. Proves radicals are nonzero. -/
+@[positivity UniqueFactorizationMonoid.radical _]
+def evalRadical : PositivityExt where eval {u α} _ _ e := do
+  match e with
+  | ~q(@radical _ $inst $inst' $inst'' $n) =>
+    have _ := ← synthInstanceQ q(Nontrivial $α)
+    assertInstancesCommute
+    return .nonzero q(radical_ne_zero)
+  | _ => throwError "not radical"
+
+example : 0 < radical 100 := by positivity
+
+end Mathlib.Meta.Positivity
 
 end Nat

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/NormalizedFactors.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/NormalizedFactors.lean
@@ -247,6 +247,15 @@ theorem mem_normalizedFactors_iff' {p x : α} (h : x ≠ 0) :
   exact Multiset.mem_map.mpr ⟨y, hy₁, by
     rwa [← h₂, normalize_eq_normalize_iff_associated, Associated.comm]⟩
 
+/-- Relatively prime elements have disjoint prime factors (as multisets). -/
+theorem disjoint_normalizedFactors {a b : α} (hc : IsRelPrime a b) :
+    Disjoint (normalizedFactors a) (normalizedFactors b) := by
+  rw [Multiset.disjoint_left]
+  intro x hxa hxb
+  have x_dvd_a := dvd_of_mem_normalizedFactors hxa
+  have x_dvd_b := dvd_of_mem_normalizedFactors hxb
+  exact (prime_of_normalized_factor x hxa).not_unit (hc x_dvd_a x_dvd_b)
+
 theorem exists_associated_prime_pow_of_unique_normalized_factor {p r : α}
     (h : ∀ {m}, m ∈ normalizedFactors r → m = p) (hr : r ≠ 0) : ∃ i : ℕ, Associated (p ^ i) r := by
   use (normalizedFactors r).card

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/NormalizedFactors.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/NormalizedFactors.lean
@@ -293,6 +293,24 @@ theorem normalizedFactors_pos (x : α) (hx : x ≠ 0) : 0 < normalizedFactors x 
       bot_lt_iff_ne_bot.mpr
         (mt Multiset.eq_zero_iff_forall_notMem.mp (not_forall.mpr ⟨p, not_not.mpr hp⟩))
 
+/--
+The multiset of normalized factors of `x` is nil if and only if `x` is a unit.
+The converse is true without the nonzero assumption, see `normalizedFactors_of_isUnit`.
+-/
+theorem normalizedFactors_eq_zero_iff {x : α} (hx : x ≠ 0) :
+    normalizedFactors x = 0 ↔ IsUnit x := by
+  rw [← not_iff_not, ← normalizedFactors_pos _ hx, pos_iff_ne_zero]
+
+/--
+If `x` is a unit, then the multiset of normalized factors of `x` is nil.
+The converse is true with a nonzero assumption, see `normalizedFactors_eq_zero_iff`.
+-/
+theorem normalizedFactors_of_isUnit {x : α} (hx : IsUnit x) :
+    normalizedFactors x = 0 := by
+  obtain rfl | hx₀ := eq_or_ne x 0
+  · simp
+  rwa [normalizedFactors_eq_zero_iff hx₀]
+
 theorem dvdNotUnit_iff_normalizedFactors_lt_normalizedFactors {x y : α} (hx : x ≠ 0) (hy : y ≠ 0) :
     DvdNotUnit x y ↔ normalizedFactors x < normalizedFactors y := by
   constructor


### PR DESCRIPTION
- Generalise some lemmas from unique factorisation domains to unique factorisation monoids, with the additional consequence that they no longer require addition to be defined.
- Fill in TODOs for `radical (radical a) = radical a` and connecting `UFM.primeFactors` to `Nat.primeFactors`
- Style changes

The large-import is due to importing `IsRadical` for the definition of `radical`, and importing primality facts for natural numbers. The former is an obviously useful change to make, and the latter isn't necessary but the alternative is to have a separate file for radical on nat (which would be very short and a bit silly) or import RingTheory in Data/Nat, which would be undesirable.

Upstreamed from the [ABC-Exceptions project](https://github.com/b-mehta/abc-exceptions)

Co-authored-by: Arend Mellendijk <arend.mellendijk@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
