### PR TITLE
[Merged by Bors] - docs(Topology/Perfect): Mention dense-in-itself

### DIFF
--- a/Mathlib/Topology/Perfect.lean
+++ b/Mathlib/Topology/Perfect.lean
@@ -14,12 +14,16 @@ including a version of the Cantor-Bendixson Theorem.
 
 ## Main Definitions
 
+* `Preperfect C`: A set `C` is preperfect if every point of it is an accumulation point
+  of itself. Equivalently, if it has no isolated points in the induced topology.
+  This property is also called dense-in-itself.
 * `Perfect C`: A set `C` is perfect, meaning it is closed and every point of it
   is an accumulation point of itself.
 * `PerfectSpace X`: A topological space `X` is perfect if its universe is a perfect set.
 
 ## Main Statements
 
+* `preperfect_iff_perfect_closure`: In a T1 space, a set is preperfect iff its closure is perfect.
 * `Perfect.splitting`: A perfect nonempty set contains two disjoint perfect nonempty subsets.
   The main inductive step in the construction of an embedding from the Cantor space to a
   perfect nonempty complete metric space.
@@ -30,10 +34,6 @@ including a version of the Cantor-Bendixson Theorem.
 ## Implementation Notes
 
 We do not require perfect sets to be nonempty.
-
-We define a nonstandard predicate, `Preperfect`, which drops the closed-ness requirement
-from the definition of perfect. In T1 spaces, this is equivalent to having a perfect closure,
-see `preperfect_iff_perfect_closure`.
 
 ## See also
 
@@ -46,7 +46,7 @@ namely Polish spaces.
 
 ## Tags
 
-accumulation point, perfect set, cantor-bendixson.
+accumulation point, perfect set, dense-in-itself, cantor-bendixson.
 
 -/
 
@@ -68,8 +68,8 @@ theorem AccPt.nhds_inter {x : α} {U : Set α} (h_acc : AccPt x (𝓟 C)) (hU : 
   exact h_acc
 
 /-- A set `C` is preperfect if all of its points are accumulation points of itself.
-If `C` is nonempty and `α` is a T1 space, this is equivalent to the closure of `C` being perfect.
-See `preperfect_iff_perfect_closure`. -/
+If `α` is a T1 space, this is equivalent to the closure of `C` being perfect,
+see `preperfect_iff_perfect_closure`. This property is also called dense-in-itself. -/
 def Preperfect (C : Set α) : Prop :=
   ∀ x ∈ C, AccPt x (𝓟 C)
 

--- a/Mathlib/Topology/Perfect.lean
+++ b/Mathlib/Topology/Perfect.lean
@@ -14,8 +14,8 @@ including a version of the Cantor-Bendixson Theorem.
 
 ## Main Definitions
 
-* `Preperfect C`: A set `C` is preperfect if every point of it is an accumulation point
-  of itself. Equivalently, if it has no isolated points in the induced topology.
+* `Preperfect C`: A set `C` is preperfect if every point of `C` is an accumulation point
+  of `C`. Equivalently, if it has no isolated points in the induced topology.
   This property is also called dense-in-itself.
 * `Perfect C`: A set `C` is perfect, meaning it is closed and every point of it
   is an accumulation point of itself.


### PR DESCRIPTION
The file `Mathlib/Topology/Perfect` defines a "nonstandard" predicate `Preperfect C` to mean that every point of `C` is an accumulation point of `C`. This property already has a name, it is called [dense-in-itself](https://en.wikipedia.org/wiki/Dense-in-itself). This PR adds this name to the docs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
