### PR TITLE
[Merged by Bors] - docs(Topology/Algebra/IsUniformGroup): remove reference to deprecated lemma

### DIFF
--- a/Mathlib/Topology/Algebra/IsUniformGroup/Defs.lean
+++ b/Mathlib/Topology/Algebra/IsUniformGroup/Defs.lean
@@ -408,15 +408,15 @@ variable (G : Type*) [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
 
 Warning: in general the right and left uniformities do not coincide and so one does not obtain a
 `IsUniformGroup` structure. Two important special cases where they _do_ coincide are for
-commutative groups (see `comm_topologicalGroup_is_uniform`) and for compact groups (see
-`isUniformGroup_of_commGroup`). -/
+commutative groups (see `isUniformGroup_of_commGroup`) and for compact groups (see
+`topologicalGroup_is_uniform_of_compactSpace`). -/
 @[to_additive "The right uniformity on a topological additive group (as opposed to the left
 uniformity).
 
 Warning: in general the right and left uniformities do not coincide and so one does not obtain a
 `IsUniformAddGroup` structure. Two important special cases where they _do_ coincide are for
-commutative additive groups (see `comm_topologicalAddGroup_is_uniform`) and for compact
-additive groups (see `isUniformAddGroup_of_addCommGroup`)."]
+commutative additive groups (see `isUniformAddGroup_of_addCommGroup`) and for compact
+additive groups (see `topologicalAddGroup_is_uniform_of_compactSpace`)."]
 def IsTopologicalGroup.toUniformSpace : UniformSpace G where
   uniformity := comap (fun p : G × G => p.2 / p.1) (𝓝 1)
   symm :=

--- a/Mathlib/Topology/Algebra/IsUniformGroup/Defs.lean
+++ b/Mathlib/Topology/Algebra/IsUniformGroup/Defs.lean
@@ -409,14 +409,14 @@ variable (G : Type*) [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
 Warning: in general the right and left uniformities do not coincide and so one does not obtain a
 `IsUniformGroup` structure. Two important special cases where they _do_ coincide are for
 commutative groups (see `comm_topologicalGroup_is_uniform`) and for compact groups (see
-`topologicalGroup_is_uniform_of_compactSpace`). -/
+`isUniformGroup_of_commGroup`). -/
 @[to_additive "The right uniformity on a topological additive group (as opposed to the left
 uniformity).
 
 Warning: in general the right and left uniformities do not coincide and so one does not obtain a
 `IsUniformAddGroup` structure. Two important special cases where they _do_ coincide are for
 commutative additive groups (see `comm_topologicalAddGroup_is_uniform`) and for compact
-additive groups (see `topologicalAddGroup_is_uniform_of_compactSpace`)."]
+additive groups (see `isUniformAddGroup_of_addCommGroup`)."]
 def IsTopologicalGroup.toUniformSpace : UniformSpace G where
   uniformity := comap (fun p : G × G => p.2 / p.1) (𝓝 1)
   symm :=


### PR DESCRIPTION
Update the docstrings of `IsTopologicalGroup.toUniformSpace` and `IsTopologicalAddGroup.toUniformSpace` to not mention a deprecated lemma.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
