### PR TITLE
[Merged by Bors] - feat: let `CharP` use `outParam`

### DIFF
--- a/Mathlib/Algebra/CharP/Defs.lean
+++ b/Mathlib/Algebra/CharP/Defs.lean
@@ -38,7 +38,7 @@ For instance, endowing `{0, 1}` with addition given by `max` (i.e. `1` is absorb
 This example is formalized in `Counterexamples/CharPZeroNeCharZero.lean`.
 -/
 @[mk_iff]
-class _root_.CharP (R : Type*) [AddMonoidWithOne R] (p : semiOutParam ℕ) : Prop where
+class _root_.CharP (R : Type*) [AddMonoidWithOne R] (p : outParam ℕ) : Prop where
   cast_eq_zero_iff (R p) : ∀ x : ℕ, (x : R) = 0 ↔ p ∣ x
 
 variable [CharP R p] {a b : ℕ}
@@ -64,9 +64,9 @@ lemma congr {q : ℕ} (h : p = q) : CharP R q := h ▸ ‹CharP R p›
 -- @[simp]
 lemma ofNat_eq_zero [p.AtLeastTwo] : (ofNat(p) : R) = 0 := cast_eq_zero R p
 
-lemma eq {p q : ℕ} (_hp : CharP R p) (_hq : CharP R q) : p = q :=
-  Nat.dvd_antisymm ((cast_eq_zero_iff R p q).1 (cast_eq_zero _ _))
-    ((cast_eq_zero_iff R q p).1 (cast_eq_zero _ _))
+lemma eq {p q : ℕ} (hp : CharP R p) (hq : CharP R q) : p = q :=
+  Nat.dvd_antisymm ((cast_eq_zero_iff (self := hp) R p q).1 (@cast_eq_zero _ _ _ hq))
+    ((cast_eq_zero_iff (self := hq) R q p).1 (@cast_eq_zero _ _ _ hp))
 
 instance ofCharZero [CharZero R] : CharP R 0 where
   cast_eq_zero_iff x := by rw [zero_dvd_iff, ← Nat.cast_zero, Nat.cast_inj]
@@ -144,7 +144,7 @@ lemma spec : ∀ x : ℕ, (x : R) = 0 ↔ ringChar R ∣ x := by
 lemma eq (p : ℕ) [C : CharP R p] : ringChar R = p :=
   ((Classical.choose_spec (CharP.existsUnique R)).2 p C).symm
 
-instance charP : CharP R (ringChar R) :=
+instance (priority := low) charP : CharP R (ringChar R) :=
   ⟨spec R⟩
 
 variable {R}
@@ -341,7 +341,7 @@ lemma expChar_one_of_char_zero (q : ℕ) [hp : CharP R 0] [hq : ExpChar R q] : q
 /-- The characteristic equals the exponential characteristic iff the former is prime. -/
 lemma char_eq_expChar_iff (p q : ℕ) [hp : CharP R p] [hq : ExpChar R q] : p = q ↔ p.Prime := by
   rcases hq with q | hq_prime
-  · rw [(CharP.eq R hp inferInstance : p = 0)]
+  · rw [(CharP.eq R hp (.ofCharZero R) : p = 0)]
     decide
   · exact ⟨fun hpq => hpq.symm ▸ hq_prime, fun _ => CharP.eq R hp ‹CharP R q›⟩
 
@@ -385,7 +385,7 @@ variable [Nontrivial R]
 /-- The exponential characteristic is one if the characteristic is zero. -/
 lemma char_zero_of_expChar_one (p : ℕ) [hp : CharP R p] [hq : ExpChar R 1] : p = 0 := by
   cases hq
-  · exact CharP.eq R hp inferInstance
+  · exact CharP.eq R hp (.ofCharZero R)
   · exact False.elim (CharP.char_ne_one R 1 rfl)
 
 -- This could be an instance, but there are no `ExpChar R 1` instances in mathlib.

--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -285,6 +285,7 @@ theorem cast_one (h : m ∣ n) : (cast (1 : ZMod n) : R) = 1 := by
   · exact Nat.cast_one
   exact Nat.lt_of_sub_eq_succ rfl
 
+@[simp]
 theorem cast_add (h : m ∣ n) (a b : ZMod n) : (cast (a + b : ZMod n) : R) = cast a + cast b := by
   cases n
   · apply Int.cast_add
@@ -294,6 +295,7 @@ theorem cast_add (h : m ∣ n) (a b : ZMod n) : (cast (a + b : ZMod n) : R) = ca
     @CharP.cast_eq_zero_iff R _ m]
   exact h.trans (Nat.dvd_sub_mod _)
 
+@[simp]
 theorem cast_mul (h : m ∣ n) (a b : ZMod n) : (cast (a * b : ZMod n) : R) = cast a * cast b := by
   cases n
   · apply Int.cast_mul
@@ -347,33 +349,21 @@ section CharEq
 
 variable [CharP R n]
 
-@[simp]
-theorem cast_one' : (cast (1 : ZMod n) : R) = 1 :=
-  cast_one dvd_rfl
+theorem cast_one' : (cast (1 : ZMod n) : R) = 1 := by simp
 
-@[simp]
-theorem cast_add' (a b : ZMod n) : (cast (a + b : ZMod n) : R) = cast a + cast b :=
-  cast_add dvd_rfl a b
+theorem cast_add' (a b : ZMod n) : (cast (a + b : ZMod n) : R) = cast a + cast b := by simp
 
-@[simp]
-theorem cast_mul' (a b : ZMod n) : (cast (a * b : ZMod n) : R) = cast a * cast b :=
-  cast_mul dvd_rfl a b
+theorem cast_mul' (a b : ZMod n) : (cast (a * b : ZMod n) : R) = cast a * cast b := by simp
 
-@[simp]
-theorem cast_sub' (a b : ZMod n) : (cast (a - b : ZMod n) : R) = cast a - cast b :=
-  cast_sub dvd_rfl a b
+theorem cast_sub' (a b : ZMod n) : (cast (a - b : ZMod n) : R) = cast a - cast b := by simp
 
-@[simp]
-theorem cast_pow' (a : ZMod n) (k : ℕ) : (cast (a ^ k : ZMod n) : R) = (cast a : R) ^ k :=
-  cast_pow dvd_rfl a k
+theorem cast_pow' (a : ZMod n) (k : ℕ) : (cast (a ^ k : ZMod n) : R) = (cast a : R) ^ k := by simp
 
-@[simp, norm_cast]
-theorem cast_natCast' (k : ℕ) : (cast (k : ZMod n) : R) = k :=
-  cast_natCast dvd_rfl k
+@[norm_cast]
+theorem cast_natCast' (k : ℕ) : (cast (k : ZMod n) : R) = k := by simp
 
-@[simp, norm_cast]
-theorem cast_intCast' (k : ℤ) : (cast (k : ZMod n) : R) = k :=
-  cast_intCast dvd_rfl k
+@[norm_cast]
+theorem cast_intCast' (k : ℤ) : (cast (k : ZMod n) : R) = k := by simp
 
 variable (R)
 

--- a/Mathlib/ModelTheory/Algebra/Field/IsAlgClosed.lean
+++ b/Mathlib/ModelTheory/Algebra/Field/IsAlgClosed.lean
@@ -210,7 +210,7 @@ theorem finite_ACF_prime_not_realize_of_ACF_zero_realize
         Term.realize_relabel, Sum.elim_comp_inl, realize_termOfFreeCommRing, map_natCast,
         realize_zero, ← CharP.charP_iff_prime_eq_zero hp]
       intro _
-      exact hqp <| CharP.eq K inferInstance inferInstance
+      exact hqp <| CharP.eq K this inferInstance
   let s : Finset Nat.Primes := T0.attach.biUnion (fun φ => f φ.1 (hT0 φ.2))
   have hs : ∀ (p : Nat.Primes) ψ, ψ ∈ T0 → p ∉ s → Theory.ACF p ⊨ᵇ ψ := by
     intro p ψ hψ hpψ


### PR DESCRIPTION
This PR changes the `p` in `CharP R p` to be an `outParam` instead of a `semiOutParam`. This means that `simp` can now infer the characteristic of a ring.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
