### PR TITLE
[Merged by Bors] - doc(Order/Defs/Unbundled): improve docstring of `MaximalFor`

### DIFF
--- a/Mathlib/Order/Defs/Unbundled.lean
+++ b/Mathlib/Order/Defs/Unbundled.lean
@@ -245,10 +245,10 @@ end LE
 section LE
 variable {ι : Sort*} {α : Type*} [LE α] {P : ι → Prop} {f : ι → α} {i j : ι}
 
-/-- `Minimal P i` means that `i` is an element with minimal image along `f` satisfying `P`. -/
+/-- `MinimalFor P f i` means that `f i` is minimal over all `i` satisfying `P`. -/
 def MinimalFor (P : ι → Prop) (f : ι → α) (i : ι) : Prop := P i ∧ ∀ ⦃j⦄, P j → f j ≤ f i → f i ≤ f j
 
-/-- `Maximal P i` means that `i` is an element with maximal image along `f` satisfying `P`. -/
+/-- `MaximalFor P f i` means that `f i` is maximal over all `i` satisfying `P`. -/
 def MaximalFor (P : ι → Prop) (f : ι → α) (i : ι) : Prop := P i ∧ ∀ ⦃j⦄, P j → f i ≤ f j → f j ≤ f i
 
 lemma MinimalFor.prop (h : MinimalFor P f i) : P i := h.1


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
