### PR TITLE
[Merged by Bors] - chore: remove `dsimp` when followed by `simp`

### DIFF
--- a/Archive/Imo/Imo1987Q1.lean
+++ b/Archive/Imo/Imo1987Q1.lean
@@ -40,7 +40,7 @@ def fixedPointsEquiv : { σx : α × Perm α // σx.2 σx.1 = σx.1 } ≃ Σ x :
     { σx : α × Perm α // σx.2 σx.1 = σx.1 } ≃ Σ x : α, { σ : Perm α // σ x = x } :=
       setProdEquivSigma _
     _ ≃ Σ x : α, { σ : Perm α // ∀ y : ({x} : Set α), σ y = Equiv.refl (↥({x} : Set α)) y } :=
-      (sigmaCongrRight fun x => Equiv.setCongr <| by simp only [SetCoe.forall]; dsimp; simp)
+      (sigmaCongrRight fun x => Equiv.setCongr <| by simp only [SetCoe.forall]; simp)
     _ ≃ Σ x : α, Perm ({x}ᶜ : Set α) := sigmaCongrRight fun x => by apply Equiv.Set.compl
 
 theorem card_fixed_points :

--- a/Mathlib/Algebra/Category/ModuleCat/Basic.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Basic.lean
@@ -237,7 +237,6 @@ theorem isZero_of_subsingleton (M : ModuleCat R) [Subsingleton M] : IsZero M whe
   unique_to X := ⟨⟨⟨ofHom (0 : M →ₗ[R] X)⟩, fun f => by
     ext x
     rw [Subsingleton.elim x (0 : M)]
-    dsimp
     simp⟩⟩
   unique_from X := ⟨⟨⟨ofHom (0 : X →ₗ[R] M)⟩, fun f => by
     ext x

--- a/Mathlib/Algebra/Group/Pi/Lemmas.lean
+++ b/Mathlib/Algebra/Group/Pi/Lemmas.lean
@@ -176,7 +176,7 @@ homomorphism `f` between `α` and `β`. -/
 protected def MonoidHom.compLeft {α β : Type*} [MulOneClass α] [MulOneClass β] (f : α →* β)
     (I : Type*) : (I → α) →* I → β where
   toFun h := f ∘ h
-  map_one' := by ext; dsimp; simp
+  map_one' := by ext; simp
   map_mul' _ _ := by ext; simp
 
 end MonoidHom

--- a/Mathlib/Algebra/Homology/Augment.lean
+++ b/Mathlib/Algebra/Homology/Augment.lean
@@ -92,17 +92,11 @@ def truncateAugment (C : ChainComplex V ℕ) {X : V} (f : C.X 0 ⟶ X) (w : C.d 
   inv :=
     { f := fun _ => 𝟙 _
       comm' := fun i j => by
-        cases j <;>
-          · dsimp
-            simp }
+        cases j <;> simp }
   hom_inv_id := by
-    ext (_ | i) <;>
-      · dsimp
-        simp
+    ext (_ | i) <;> simp
   inv_hom_id := by
-    ext (_ | i) <;>
-      · dsimp
-        simp
+    ext (_ | i) <;> simp
 
 @[simp]
 theorem truncateAugment_hom_f (C : ChainComplex V ℕ) {X : V} (f : C.X 0 ⟶ X) (w : C.d 1 0 ≫ f = 0)
@@ -142,14 +136,10 @@ def augmentTruncate (C : ChainComplex V ℕ) :
     }
   hom_inv_id := by
     ext i
-    cases i <;>
-      · dsimp
-        simp
+    cases i <;> simp
   inv_hom_id := by
     ext i
-    cases i <;>
-      · dsimp
-        simp
+    cases i <;> simp
 
 @[simp]
 theorem augmentTruncate_hom_f_zero (C : ChainComplex V ℕ) :
@@ -263,19 +253,13 @@ def truncateAugment (C : CochainComplex V ℕ) {X : V} (f : X ⟶ C.X 0) (w : f 
   inv :=
     { f := fun _ => 𝟙 _
       comm' := fun i j => by
-        cases j <;>
-          · dsimp
-            simp }
+        cases j <;> simp }
   hom_inv_id := by
     ext i
-    cases i <;>
-      · dsimp
-        simp
+    cases i <;> simp
   inv_hom_id := by
     ext i
-    cases i <;>
-      · dsimp
-        simp
+    cases i <;> simp
 
 @[simp]
 theorem truncateAugment_hom_f (C : CochainComplex V ℕ) {X : V} (f : X ⟶ C.X 0)
@@ -317,14 +301,10 @@ def augmentTruncate (C : CochainComplex V ℕ) :
             aesop }
   hom_inv_id := by
     ext i
-    cases i <;>
-      · dsimp
-        simp
+    cases i <;> simp
   inv_hom_id := by
     ext i
-    cases i <;>
-      · dsimp
-        simp
+    cases i <;> simp
 
 @[simp]
 theorem augmentTruncate_hom_f_zero (C : CochainComplex V ℕ) :

--- a/Mathlib/Algebra/Homology/DifferentialObject.lean
+++ b/Mathlib/Algebra/Homology/DifferentialObject.lean
@@ -43,7 +43,7 @@ theorem objEqToHom_refl (i : β) : X.objEqToHom (refl i) = 𝟙 _ :=
 
 @[reassoc (attr := simp)]
 theorem objEqToHom_d {x y : β} (h : x = y) :
-    X.objEqToHom h ≫ X.d y = X.d x ≫ X.objEqToHom (by cases h; rfl) := by cases h; dsimp; simp
+    X.objEqToHom h ≫ X.d y = X.d x ≫ X.objEqToHom (by cases h; rfl) := by cases h; simp
 
 @[reassoc (attr := simp)]
 theorem d_squared_apply {x : β} : X.d x ≫ X.d _ = 0 := congr_fun X.d_squared _

--- a/Mathlib/Algebra/Homology/ExactSequence.lean
+++ b/Mathlib/Algebra/Homology/ExactSequence.lean
@@ -159,8 +159,8 @@ def sc'MapIso {S₁ S₂ : ComposableArrows C n} (e : S₁ ≅ S₂)
     S₁.sc' h₁ i j k ≅ S₂.sc' h₂ i j k where
   hom := sc'Map e.hom h₁ h₂ i j k
   inv := sc'Map e.inv h₂ h₁ i j k
-  hom_inv_id := by ext <;> dsimp <;> simp
-  inv_hom_id := by ext <;> dsimp <;> simp
+  hom_inv_id := by ext <;> simp
+  inv_hom_id := by ext <;> simp
 
 /-- The isomorphism `S₁.sc _ i ≅ S₂.sc _ i` induced by an isomorphism `S₁ ≅ S₂`
 in `ComposableArrows C n`. -/
@@ -171,8 +171,8 @@ def scMapIso {S₁ S₂ : ComposableArrows C n} (e : S₁ ≅ S₂)
     S₁.sc h₁ i ≅ S₂.sc h₂ i where
   hom := scMap e.hom h₁ h₂ i
   inv := scMap e.inv h₂ h₁ i
-  hom_inv_id := by ext <;> dsimp <;> simp
-  inv_hom_id := by ext <;> dsimp <;> simp
+  hom_inv_id := by ext <;> simp
+  inv_hom_id := by ext <;> simp
 
 lemma exact_of_iso {S₁ S₂ : ComposableArrows C n} (e : S₁ ≅ S₂) (h₁ : S₁.Exact) :
     S₂.Exact where

--- a/Mathlib/Algebra/Homology/Homotopy.lean
+++ b/Mathlib/Algebra/Homology/Homotopy.lean
@@ -793,8 +793,7 @@ noncomputable def Homotopy.toShortComplex (ho : Homotopy f g) (i : ι) :
       rw [L.shape _ _ h, comp_zero]
   g_h₃ := by
     split_ifs with h
-    · dsimp
-      simp
+    · simp
     · dsimp
       rw [K.shape _ _ h, zero_comp]
   comm₁ := by

--- a/Mathlib/Algebra/Homology/HomotopyCategory/DegreewiseSplit.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/DegreewiseSplit.lean
@@ -204,7 +204,7 @@ noncomputable def triangleRotateIsoTriangleOfDegreewiseSplit :
     (triangle φ).rotate ≅
       triangleOfDegreewiseSplit _ (triangleRotateShortComplexSplitting φ) :=
   Triangle.isoMk _ _ (Iso.refl _) (Iso.refl _) (Iso.refl _)
-    (by simp) (by simp) (by ext; dsimp; simp)
+    (by simp) (by simp) (by ext; simp)
 
 /-- The triangle `(triangleh φ).rotate` is isomorphic to a triangle attached to a
 degreewise split short exact sequence of cochain complexes. -/

--- a/Mathlib/Algebra/Homology/HomotopyCategory/Pretriangulated.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/Pretriangulated.lean
@@ -72,7 +72,7 @@ lemma inr_f_triangle_mor₃_f (p : ℤ) : (inr φ).f p ≫ (triangle φ).mor₃.
     Preadditive.comp_neg, inr_f_fst_v, neg_zero]
 
 @[reassoc (attr := simp)]
-lemma inr_triangleδ : inr φ ≫ (triangle φ).mor₃ = 0 := by ext; dsimp; simp
+lemma inr_triangleδ : inr φ ≫ (triangle φ).mor₃ = 0 := by ext; simp
 
 /-- The (distinguished) triangle in the homotopy category that is associated to
 a morphism `φ : K ⟶ L` in the category `CochainComplex C ℤ`. -/
@@ -308,7 +308,7 @@ noncomputable def rotateTrianglehIso :
   Triangle.isoMk _ _ (Iso.refl _) (Iso.refl _)
     (((HomotopyCategory.quotient C (ComplexShape.up ℤ)).commShiftIso (1 : ℤ)).symm.app K ≪≫
       HomotopyCategory.isoOfHomotopyEquiv (rotateHomotopyEquiv φ))
-        (by dsimp; simp) (by dsimp; simp) (by
+        (by simp) (by simp) (by
         dsimp
         rw [CategoryTheory.Functor.map_id, comp_id, assoc, ← Functor.map_comp_assoc,
           rotateHomotopyEquiv_comm₃, Functor.map_neg, Preadditive.neg_comp,

--- a/Mathlib/Algebra/Homology/HomotopyCategory/Shift.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/Shift.lean
@@ -83,7 +83,7 @@ def shiftFunctorZero' (n : ℤ) (h : n = 0) :
     shiftFunctor C n ≅ 𝟭 _ :=
   NatIso.ofComponents (fun K => Hom.isoOfComponents
     (fun i => K.shiftFunctorObjXIso _ _ _ (by omega))
-    (fun _ _ _ => by dsimp; simp [h])) (fun _ ↦ by ext; dsimp; simp)
+    (fun _ _ _ => by simp [h])) (fun _ ↦ by ext; simp)
 
 /-- The compatibility of the shift functors on `CochainComplex C ℤ` with respect
 to the addition of integers. -/
@@ -97,7 +97,7 @@ def shiftFunctorAdd' (n₁ n₂ n₁₂ : ℤ) (h : n₁ + n₂ = n₁₂) :
       dsimp
       simp only [add_comm n₁ n₂, Int.negOnePow_add, Linear.units_smul_comp,
         Linear.comp_units_smul, d_comp_XIsoOfEq_hom, smul_smul, XIsoOfEq_hom_comp_d]))
-    (by intros; ext; dsimp; simp)
+    (by intros; ext; simp)
 
 attribute [local simp] XIsoOfEq
 
@@ -208,7 +208,7 @@ def shiftEval (n i i' : ℤ) (hi : n + i = i') :
       HomologicalComplex.eval C (ComplexShape.up ℤ) i ≅
       HomologicalComplex.eval C (ComplexShape.up ℤ) i' :=
   NatIso.ofComponents (fun K => K.XIsoOfEq (by dsimp; rw [← hi, add_comm i]))
-    (by intros; dsimp; simp)
+    (by intros; simp)
 
 end CochainComplex
 
@@ -230,7 +230,7 @@ def mapCochainComplexShiftIso (n : ℤ) :
     shiftFunctor _ n ⋙ F.mapHomologicalComplex (ComplexShape.up ℤ) ≅
       F.mapHomologicalComplex (ComplexShape.up ℤ) ⋙ shiftFunctor _ n :=
   NatIso.ofComponents (fun K => HomologicalComplex.Hom.isoOfComponents (fun _ => Iso.refl _)
-    (by dsimp; simp)) (fun _ => by ext; dsimp; rw [id_comp, comp_id])
+    (by simp)) (fun _ => by ext; dsimp; rw [id_comp, comp_id])
 
 instance commShiftMapCochainComplex :
     (F.mapHomologicalComplex (ComplexShape.up ℤ)).CommShift ℤ where

--- a/Mathlib/Algebra/Homology/HomotopyCategory/ShiftSequence.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/ShiftSequence.lean
@@ -41,8 +41,8 @@ def shiftShortComplexFunctor' (n i j k i' j' k' : ℤ)
   NatIso.ofComponents (fun K => ShortComplex.isoMk
       (n.negOnePow • ((shiftEval C n i i' hi).app K))
       ((shiftEval C n j j' hj).app K) (n.negOnePow • ((shiftEval C n k k' hk).app K))
-      (by dsimp; simp) (by dsimp; simp))
-      (fun f ↦ by ext <;> dsimp <;> simp)
+      (by simp) (by simp))
+      (fun f ↦ by ext <;> simp)
 
 /-- The natural isomorphism `(K⟦n⟧).sc i ≅ K.sc i'` when `n + i = i'`. -/
 @[simps!]
@@ -57,7 +57,7 @@ lemma shiftShortComplexFunctorIso_zero_add_hom_app (a : ℤ) (K : CochainComplex
     (shiftShortComplexFunctorIso C 0 a a (zero_add a)).hom.app K =
       (shortComplexFunctor C (ComplexShape.up ℤ) a).map
         ((shiftFunctorZero (CochainComplex C ℤ) ℤ).hom.app K) := by
-  ext <;> dsimp <;> simp [one_smul, shiftFunctorZero_hom_app_f]
+  ext <;> simp [one_smul, shiftFunctorZero_hom_app_f]
 
 lemma shiftShortComplexFunctorIso_add'_hom_app
     (n m mn : ℤ) (hmn : m + n = mn) (a a' a'' : ℤ) (ha' : n + a = a') (ha'' : m + a' = a'')

--- a/Mathlib/Algebra/Homology/HomotopyCategory/Triangulated.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/Triangulated.lean
@@ -66,7 +66,7 @@ is the canonical morphism (which is an homotopy equivalence) from `mappingCone g
 the mapping cone of the morphism `mappingCone f ⟶ mappingCone (f ≫ g)`. -/
 noncomputable def hom :
     mappingCone g ⟶ mappingCone (mappingConeCompTriangle f g).mor₁ :=
-  lift _ (descCocycle g (Cochain.ofHom (inr f)) 0 (zero_add 1) (by dsimp; simp))
+  lift _ (descCocycle g (Cochain.ofHom (inr f)) 0 (zero_add 1) (by simp))
     (descCochain _ 0 (Cochain.ofHom (inr (f ≫ g))) (neg_add_cancel 1)) (by
       ext p _ rfl
       dsimp [mappingConeCompTriangle, map]

--- a/Mathlib/Algebra/Homology/HomotopyCofiber.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCofiber.lean
@@ -186,8 +186,7 @@ lemma d_sndX (i j : ι) (hij : c.Rel i j) :
 lemma inlX_d (i j k : ι) (hij : c.Rel i j) (hjk : c.Rel j k) :
     inlX φ j i hij ≫ d φ i j = -F.d j k ≫ inlX φ k j hjk + φ.f j ≫ inrX φ j := by
   apply ext_to_X φ j k hjk
-  · dsimp
-    simp [d_fstX φ  _ _ _ hij hjk]
+  · simp [d_fstX φ  _ _ _ hij hjk]
   · simp [d_sndX φ _ _ hij]
 
 @[reassoc]
@@ -280,7 +279,6 @@ noncomputable def desc :
     else sndX φ j ≫ α.f j
   comm' j k hjk := by
     obtain rfl := c.next_eq' hjk
-    dsimp
     simp [dif_pos hjk]
     have H := hα.comm (c.next j)
     simp only [comp_f, zero_f, add_zero, prevD_eq _ hjk] at H

--- a/Mathlib/AlgebraicGeometry/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/Scheme.lean
@@ -332,7 +332,7 @@ theorem comp_appLE {X Y Z : Scheme} (f : X ⟶ Y) (g : Y ⟶ Z) (U V e) :
 
 theorem congr_app {X Y : Scheme} {f g : X ⟶ Y} (e : f = g) (U) :
     f.app U = g.app U ≫ X.presheaf.map (eqToHom (by subst e; rfl)).op := by
-  subst e; dsimp; simp
+  subst e; simp
 
 theorem app_eq {X Y : Scheme} (f : X ⟶ Y) {U V : Y.Opens} (e : U = V) :
     f.app U =
@@ -755,7 +755,7 @@ theorem basicOpen_eq_of_affine' {R : CommRingCat} (f : Γ(Spec R, ⊤)) :
   exact (Iso.hom_inv_id_apply (Scheme.ΓSpecIso R) f).symm
 
 theorem Scheme.Spec_map_presheaf_map_eqToHom {X : Scheme} {U V : X.Opens} (h : U = V) (W) :
-    (Spec.map (X.presheaf.map (eqToHom h).op)).app W = eqToHom (by cases h; dsimp; simp) := by
+    (Spec.map (X.presheaf.map (eqToHom h).op)).app W = eqToHom (by cases h; simp) := by
   have : Scheme.Spec.map (X.presheaf.map (𝟙 (op U))).op = 𝟙 _ := by
     rw [X.presheaf.map_id, op_id, Scheme.Spec.map_id]
   cases h

--- a/Mathlib/AlgebraicTopology/CechNerve.lean
+++ b/Mathlib/AlgebraicTopology/CechNerve.lean
@@ -122,11 +122,9 @@ def equivalenceLeftToRight (X : SimplicialObject.Augmented C) (F : Arrow C)
         intro x y f
         dsimp
         ext
-        · dsimp
-          simp only [WidePullback.lift_π, Category.assoc, ← X.left.map_comp_assoc]
+        · simp only [WidePullback.lift_π, Category.assoc, ← X.left.map_comp_assoc]
           rfl
-        · dsimp
-          simp }
+        · simp }
   right := G.right
 
 /-- A helper function used in defining the Čech adjunction. -/
@@ -152,8 +150,7 @@ def cechNerveEquiv (X : SimplicialObject.Augmented C) (F : Arrow C) :
     intro A
     ext x : 2
     · refine WidePullback.hom_ext _ _ _ (fun j => ?_) ?_
-      · dsimp
-        simp
+      · simp
         rfl
       · simpa using congr_app A.w.symm x
     · rfl
@@ -274,8 +271,7 @@ def equivalenceRightToLeft (F : Arrow C) (X : CosimplicialObject.Augmented C)
           simp only [WidePushout.ι_desc_assoc, WidePushout.ι_desc]
           rw [Category.assoc, ← X.right.map_comp]
           rfl
-        · dsimp
-          simp [← NatTrans.naturality] }
+        · simp [← NatTrans.naturality] }
 
 /-- A helper function used in defining the Čech conerve adjunction. -/
 @[simps]
@@ -343,7 +339,7 @@ def wideCospan.limitCone [Finite ι] (X : C) : LimitCone (wideCospan ι X) where
           naturality := fun i j f => by
             cases f
             · cases i
-              all_goals dsimp; simp
+              all_goals simp
             · simp only [Functor.const_obj_obj, Functor.const_obj_map, terminal.comp_from]
               subsingleton } }
   isLimit :=

--- a/Mathlib/AlgebraicTopology/SimplicialObject/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialObject/Basic.lean
@@ -829,7 +829,7 @@ def whiskering (D : Type u') [Category.{v'} D] : (C ⥤ D) ⥤ Augmented C ⥤ A
             ext n
             dsimp
             rw [Category.id_comp, Category.id_comp, η.naturality] }
-      naturality := fun _ _ f => by ext <;> dsimp <;> simp }
+      naturality := fun _ _ f => by ext <;> simp }
 
 variable {C}
 

--- a/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
@@ -453,7 +453,6 @@ instance nerveFunctor₂.full : nerveFunctor₂.{u, u}.Full where
         simp only [Nat.reduceAdd, id_eq, Int.reduceNeg, Int.cast_ofNat_Int, Int.reduceSub,
           Int.reduceAdd, Nat.cast_ofNat, Fin.zero_eta, Fin.isValue, Fin.mk_one,
           ComposableArrows.map', homOfLE_leOfHom, Fk, uF, Fh, uF']
-        dsimp
         simp [uF', nerveFunctor₂, SSet.truncation, forget₂, HasForget₂.forget₂,
           ReflQuiv.comp_eq_comp, OneTruncation₂.nerveHomEquiv, Fk, uF, ComposableArrows.hom, Fhk']
       rw [Fhk.map'_comp 0 1 2] at lem1

--- a/Mathlib/Analysis/Analytic/Inverse.lean
+++ b/Mathlib/Analysis/Analytic/Inverse.lean
@@ -90,7 +90,6 @@ theorem leftInv_removeZero (p : FormalMultilinearSeries 𝕜 E F) (i : E ≃L[�
     refine Finset.sum_congr rfl fun c cuniv => ?_
     rcases c with ⟨c, hc⟩
     ext v
-    dsimp
     simp [IH _ hc]
 
 /-- The left inverse to a formal multilinear series is indeed a left inverse, provided its linear

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm/Prod.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm/Prod.lean
@@ -97,7 +97,6 @@ noncomputable def prodMapL : (M₁ →L[𝕜] M₂) × (M₃ →L[𝕜] M₄) �
       apply funext
       rintro ⟨φ, ψ⟩
       refine ContinuousLinearMap.ext fun ⟨x₁, x₂⟩ => ?_
-      dsimp
       simp)
 
 variable {M₁ M₂ M₃ M₄}

--- a/Mathlib/CategoryTheory/Adjunction/Evaluation.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Evaluation.lean
@@ -65,10 +65,9 @@ def evaluationAdjunctionRight (c : C) : evaluationLeftAdjoint D c ⊣ (evaluatio
               evaluationLeftAdjoint_obj_map, colimit.ι_desc_assoc,
               Discrete.functor_obj, Cofan.mk_pt, Discrete.natTrans_app, Category.id_comp]
           right_inv := fun f => by
-            dsimp
             simp }
       -- This used to be automatic before https://github.com/leanprover/lean4/pull/2644
-      homEquiv_naturality_right := by intros; dsimp; simp }
+      homEquiv_naturality_right := by intros; simp }
 
 instance evaluationIsRightAdjoint (c : C) : ((evaluation _ D).obj c).IsRightAdjoint  :=
   ⟨_, ⟨evaluationAdjunctionRight _ _⟩⟩
@@ -115,9 +114,7 @@ def evaluationAdjunctionLeft (c : C) : (evaluation _ _).obj c ⊣ evaluationRigh
                 ext
                 simp }
           invFun := fun f => f.app _ ≫ Pi.π _ (𝟙 _)
-          left_inv := fun f => by
-            dsimp
-            simp
+          left_inv := fun f => by simp
           right_inv := by
             intro f
             ext x

--- a/Mathlib/CategoryTheory/Adjunction/Limits.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Limits.lean
@@ -298,7 +298,7 @@ def coconesIsoComponentInv {J : Type u} [Category.{v} J] {K : J ⥤ C} (Y : D)
   app j := (adj.homEquiv (K.obj j) Y).symm (t.app j)
   naturality j j' f := by
     erw [← adj.homEquiv_naturality_left_symm, ← adj.homEquiv_naturality_right_symm, t.naturality]
-    dsimp; simp
+    simp
 
 /-- auxiliary construction for `conesIso` -/
 @[simp]

--- a/Mathlib/CategoryTheory/Adjunction/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Whiskering.lean
@@ -29,11 +29,11 @@ protected def whiskerRight (adj : F ⊣ G) :
   unit :=
     { app := fun X =>
         (Functor.rightUnitor _).inv ≫ whiskerLeft X adj.unit ≫ (Functor.associator _ _ _).inv
-      naturality := by intros; ext; dsimp; simp }
+      naturality := by intros; ext; simp }
   counit :=
     { app := fun X =>
         (Functor.associator _ _ _).hom ≫ whiskerLeft X adj.counit ≫ (Functor.rightUnitor _).hom
-      naturality := by intros; ext; dsimp; simp }
+      naturality := by intros; ext; simp }
 
 /-- Given an adjunction `F ⊣ G`, this provides the natural adjunction
   `(whiskeringLeft _ _ C).obj G ⊣ (whiskeringLeft _ _ C).obj F`. -/

--- a/Mathlib/CategoryTheory/Bicategory/Functor/Pseudofunctor.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/Pseudofunctor.lean
@@ -146,11 +146,11 @@ def comp (F : Pseudofunctor B C) (G : Pseudofunctor C D) : Pseudofunctor B D whe
   mapId := fun a => G.map₂Iso (F.mapId a) ≪≫ G.mapId (F.obj a)
   mapComp := fun f g => (G.map₂Iso (F.mapComp f g)) ≪≫ G.mapComp (F.map f) (F.map g)
   -- Note: whilst these are all provable by `aesop_cat`, the proof is very slow
-  map₂_whisker_left f η := by dsimp; simp
-  map₂_whisker_right η h := by dsimp; simp
-  map₂_associator f g h := by dsimp; simp
-  map₂_left_unitor f := by dsimp; simp
-  map₂_right_unitor f := by dsimp; simp
+  map₂_whisker_left f η := by simp
+  map₂_whisker_right η h := by simp
+  map₂_associator f g h := by simp
+  map₂_left_unitor f := by simp
+  map₂_right_unitor f := by simp
 
 section
 

--- a/Mathlib/CategoryTheory/Category/Cat/Limit.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/Limit.lean
@@ -133,7 +133,6 @@ def limitConeIsLimit (F : J ⥤ Cat.{v, v}) : IsLimit (limitCone F) where
       intro j
       simp [Types.Limit.lift_π_apply', ← w j]
     · intro X Y f
-      dsimp
       simp [fun j => Functor.congr_hom (w j).symm f]
 
 end HasLimits

--- a/Mathlib/CategoryTheory/Closed/Functor.lean
+++ b/Mathlib/CategoryTheory/Closed/Functor.lean
@@ -88,7 +88,6 @@ theorem coev_expComparison (A B : C) :
       (exp.coev _).app (F.obj B) ≫ (exp (F.obj A)).map (inv (prodComparison F A B)) := by
   convert unit_mateEquiv _ _ (prodComparisonNatIso F A).inv B using 3
   apply IsIso.inv_eq_of_hom_inv_id -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): was `ext`
-  dsimp
   simp
 
 theorem uncurry_expComparison (A B : C) :

--- a/Mathlib/CategoryTheory/Functor/Currying.lean
+++ b/Mathlib/CategoryTheory/Functor/Currying.lean
@@ -56,7 +56,7 @@ def curryObj (F : C × D ⥤ E) : C ⥤ D ⥤ E where
     { app := fun Y => F.map (f, 𝟙 Y)
       naturality := fun {Y} {Y'} g => by simp [← F.map_comp] }
   map_id := fun X => by ext Y; exact F.map_id _
-  map_comp := fun f g => by ext Y; dsimp; simp [← F.map_comp]
+  map_comp := fun f g => by ext Y; simp [← F.map_comp]
 
 /-- The currying functor, taking a functor `(C × D) ⥤ E` and producing a functor `C ⥤ (D ⥤ E)`.
 -/

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -151,7 +151,6 @@ theorem comp_fiber {X Y Z : Grothendieck F} (f : X ⟶ Y) (g : Y ⟶ Z) :
 theorem congr {X Y : Grothendieck F} {f g : X ⟶ Y} (h : f = g) :
     f.fiber = eqToHom (by subst h; rfl) ≫ g.fiber := by
   subst h
-  dsimp
   simp
 
 @[simp]
@@ -408,7 +407,6 @@ def grothendieckTypeToCat : Grothendieck (G ⋙ typeToCat) ≌ G.Elements where
         rfl)
   functor_unitIso_comp := by
     rintro ⟨_, ⟨⟩⟩
-    dsimp
     simp
     rfl
 

--- a/Mathlib/CategoryTheory/GuitartExact/VerticalComposition.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/VerticalComposition.lean
@@ -129,7 +129,7 @@ lemma vComp_iff_of_equivalences (eL : C₂ ≌ C₃) (eR : D₂ ≌ D₃)
     have : w = (w ≫ᵥ w'.hom).vComp' w''.hom α β := by
       ext X₁
       simp? [w'', α, β] says
-        simp only [vComp'_app, Functor.comp_obj, Iso.trans_inv, isoWhiskerLeft_inv, Iso.symm_inv,
+        simp only [Functor.comp_obj, vComp'_app, Iso.trans_inv, isoWhiskerLeft_inv, Iso.symm_inv,
           assoc, NatTrans.comp_app, Functor.id_obj, Functor.rightUnitor_inv_app,
           CategoryTheory.whiskerLeft_app, Functor.associator_inv_app, comp_id, id_comp, vComp_app,
           Functor.map_comp, Equivalence.inv_fun_map, CatCommSq.vInv_iso'_hom_app, Iso.trans_hom,

--- a/Mathlib/CategoryTheory/GuitartExact/VerticalComposition.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/VerticalComposition.lean
@@ -128,7 +128,6 @@ lemma vComp_iff_of_equivalences (eL : C₂ ≌ C₃) (eR : D₂ ≌ D₃)
       Functor.associator _ _ _ ≪≫ isoWhiskerLeft R₁ eR.unitIso.symm ≪≫ R₁.rightUnitor
     have : w = (w ≫ᵥ w'.hom).vComp' w''.hom α β := by
       ext X₁
-      dsimp
       simp? [w'', α, β] says
         simp only [vComp'_app, Functor.comp_obj, Iso.trans_inv, isoWhiskerLeft_inv, Iso.symm_inv,
           assoc, NatTrans.comp_app, Functor.id_obj, Functor.rightUnitor_inv_app,

--- a/Mathlib/CategoryTheory/Limits/ConeCategory.lean
+++ b/Mathlib/CategoryTheory/Limits/ConeCategory.lean
@@ -136,7 +136,6 @@ def Cone.fromCostructuredArrow (F : J ⥤ C) : CostructuredArrow (const J) F ⥤
     { hom := f.left
       w := fun j => by
         convert congr_fun (congr_arg NatTrans.app f.w) j
-        dsimp
         simp }
 
 /-- The category of cones on `F` is just the comma category `(Δ ↓ F)`, where `Δ` is the constant
@@ -296,7 +295,6 @@ def Cocone.fromStructuredArrow (F : J ⥤ C) : StructuredArrow F (const J) ⥤ C
     { hom := f.right
       w := fun j => by
         convert (congr_fun (congr_arg NatTrans.app f.w) j).symm
-        dsimp
         simp }
 
 /-- The category of cocones on `F` is just the comma category `(F ↓ Δ)`, where `Δ` is the constant

--- a/Mathlib/CategoryTheory/Limits/Constructions/Over/Products.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/Over/Products.lean
@@ -62,11 +62,11 @@ def pullbackConeEquivBinaryFan : PullbackCone f g ≌ BinaryFan (Over.mk f) (.mk
     hom := a.hom.left
     w := by rintro (_|_|_) <;> simp [← Over.comp_left_assoc, ← Over.comp_left]
   }
-  unitIso := NatIso.ofComponents (fun c ↦ c.eta) (by intros; ext; dsimp; simp)
+  unitIso := NatIso.ofComponents (fun c ↦ c.eta) (by intros; ext; simp)
   counitIso := NatIso.ofComponents (fun X ↦ BinaryFan.ext (Over.isoMk (Iso.refl _)
-    (by simpa using X.fst.w.symm)) (by ext; dsimp; simp) (by ext; dsimp; simp))
-    (by intros; ext; dsimp; simp [BinaryFan.ext])
-  functor_unitIso_comp c := by ext; dsimp; simp [BinaryFan.ext]
+    (by simpa using X.fst.w.symm)) (by ext; simp) (by ext; simp))
+    (by intros; ext; simp [BinaryFan.ext])
+  functor_unitIso_comp c := by ext; simp [BinaryFan.ext]
 
 /-- A binary fan in `Over X` is a limit if its corresponding pullback cone to `X` is a limit. -/
 -- `IsLimit.ofConeEquiv` isn't used here because the lift it defines is `𝟙 _ ≫ pullback.lift`.
@@ -121,13 +121,13 @@ def pushoutCoconeEquivBinaryCofan : PushoutCocone f g ≌ BinaryCofan (Under.mk 
   inverse.obj c := .mk c.inl.right c.inr.right (c.inl.w.symm.trans c.inr.w)
   inverse.map {c₁ c₂} a := {
     hom := a.hom.right
-    w := by rintro (_|_|_) <;> dsimp <;> simp [← Under.comp_right]
+    w := by rintro (_|_|_) <;> simp [← Under.comp_right]
   }
-  unitIso := NatIso.ofComponents (fun c ↦ c.eta) (fun f ↦ by ext; dsimp; simp)
+  unitIso := NatIso.ofComponents (fun c ↦ c.eta) (fun f ↦ by ext; simp)
   counitIso := NatIso.ofComponents (fun X ↦ BinaryCofan.ext (Under.isoMk (.refl _)
-    (by dsimp; simpa using X.inl.w.symm)) (by ext; dsimp; simp) (by ext; dsimp; simp))
-    (by intros; ext; dsimp; simp)
-  functor_unitIso_comp c := by ext; dsimp; simp
+    (by dsimp; simpa using X.inl.w.symm)) (by ext; simp) (by ext; simp))
+    (by intros; ext; simp)
+  functor_unitIso_comp c := by ext; simp
 
 /-- A binary cofan in `Under X` is a colimit if its corresponding pushout cocone from `X` is a
 colimit. -/

--- a/Mathlib/CategoryTheory/Limits/Creates.lean
+++ b/Mathlib/CategoryTheory/Limits/Creates.lean
@@ -309,7 +309,6 @@ def createsLimitOfFullyFaithfulOfIso' {K : J ⥤ C} {F : C ⥤ D} [F.Full] [F.Fa
         { app := fun j => F.preimage (i.hom ≫ l.π.app j)
           naturality := fun Y Z f =>
             F.map_injective <| by
-              dsimp
               simpa using (l.w f).symm } }
     (Cones.ext i fun j => by simp only [Functor.map_preimage, Functor.mapCone_π_app])
 
@@ -446,7 +445,6 @@ def createsColimitOfFullyFaithfulOfIso' {K : J ⥤ C} {F : C ⥤ D} [F.Full] [F.
         { app := fun j => F.preimage (l.ι.app j ≫ i.inv)
           naturality := fun Y Z f =>
             F.map_injective <| by
-              dsimp
               simpa [← cancel_mono i.hom] using l.w f } }
     (Cocones.ext i fun j => by simp)
 

--- a/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean
@@ -396,7 +396,6 @@ theorem ι_colimitLimitIso_limit_π (F : J ⥤ K ⥤ C) (a) (b) :
   simp only [← Category.assoc, Iso.comp_inv_eq,
     Limits.colimitObjIsoColimitCompEvaluation_ι_app_hom,
     Limits.HasColimit.isoOfNatIso_ι_hom, NatIso.ofComponents_hom_app]
-  dsimp
   simp
 
 end

--- a/Mathlib/CategoryTheory/Limits/Final.lean
+++ b/Mathlib/CategoryTheory/Limits/Final.lean
@@ -211,12 +211,10 @@ def induction {d : D} (Z : ∀ (X : C) (_ : d ⟶ F.obj X), Sort*)
   · intro j₁ j₂ f a
     fapply h₁ _ _ _ _ f.right _ a
     convert f.w.symm
-    dsimp
     simp
   · intro j₁ j₂ f a
     fapply h₂ _ _ _ _ f.right _ a
     convert f.w.symm
-    dsimp
     simp
 
 variable {F G}
@@ -555,12 +553,10 @@ def induction {d : D} (Z : ∀ (X : C) (_ : F.obj X ⟶ d), Sort*)
   · intro j₁ j₂ f a
     fapply h₁ _ _ _ _ f.left _ a
     convert f.w
-    dsimp
     simp
   · intro j₁ j₂ f a
     fapply h₂ _ _ _ _ f.left _ a
     convert f.w
-    dsimp
     simp
 
 variable {F G}

--- a/Mathlib/CategoryTheory/Limits/Fubini.lean
+++ b/Mathlib/CategoryTheory/Limits/Fubini.lean
@@ -457,7 +457,6 @@ noncomputable def coconeOfHasColimitCurryCompColim : Cocone G :=
         have := (Q.obj y.1).w f₂
         dsimp [Q] at this ⊢
         rw [← colimit.w (F := curry.obj G ⋙ colim) (f := f₁)]
-        dsimp
         simp [Category.assoc, Category.comp_id, Prod.fac' (f₁, f₂),
           G.map_comp, ι_colimMap_assoc, curry_obj_map_app, reassoc_of% this] } }
 

--- a/Mathlib/CategoryTheory/Limits/FunctorCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/FunctorCategory/Basic.lean
@@ -72,9 +72,7 @@ def combineCones (F : J ⥤ K ⥤ C) (c : ∀ k : K, LimitCone (F.flip.obj k)) :
     { obj := fun k => (c k).cone.pt
       map := fun {k₁} {k₂} f => (c k₂).isLimit.lift ⟨_, (c k₁).cone.π ≫ F.flip.map f⟩
       map_id := fun k =>
-        (c k).isLimit.hom_ext fun j => by
-          dsimp
-          simp
+        (c k).isLimit.hom_ext fun j => by simp
       map_comp := fun {k₁} {k₂} {k₃} f₁ f₂ => (c k₃).isLimit.hom_ext fun j => by simp }
   π :=
     { app := fun j => { app := fun k => (c k).cone.π.app j }
@@ -104,7 +102,6 @@ def evaluationJointlyReflectsColimits {F : J ⥤ K ⥤ C} (c : Cocone F)
           rw [(t X).fac_assoc _ j]
           erw [← (c.ι.app j).naturality_assoc f]
           erw [(t Y).fac ⟨s.pt.obj _, whiskerRight s.ι _⟩ j]
-          dsimp
           simp }
   fac s j := by ext k; exact (t k).fac _ j
   uniq s m w := by
@@ -125,9 +122,7 @@ def combineCocones (F : J ⥤ K ⥤ C) (c : ∀ k : K, ColimitCocone (F.flip.obj
     { obj := fun k => (c k).cocone.pt
       map := fun {k₁} {k₂} f => (c k₁).isColimit.desc ⟨_, F.flip.map f ≫ (c k₂).cocone.ι⟩
       map_id := fun k =>
-        (c k).isColimit.hom_ext fun j => by
-          dsimp
-          simp
+        (c k).isColimit.hom_ext fun j => by simp
       map_comp := fun {k₁} {k₂} {k₃} f₁ f₂ => (c k₁).isColimit.hom_ext fun j => by simp }
   ι :=
     { app := fun j => { app := fun k => (c k).cocone.ι.app j }
@@ -241,7 +236,6 @@ theorem limit_map_limitObjIsoLimitCompEvaluation_hom [HasLimitsOfShape J C] {i j
     (F : J ⥤ K ⥤ C) (f : i ⟶ j) : (limit F).map f ≫ (limitObjIsoLimitCompEvaluation _ _).hom =
     (limitObjIsoLimitCompEvaluation _ _).hom ≫ limMap (whiskerLeft _ ((evaluation _ _).map f)) := by
   ext
-  dsimp
   simp
 
 @[reassoc (attr := simp)]
@@ -328,7 +322,6 @@ theorem colimitObjIsoColimitCompEvaluation_inv_colimit_map [HasColimitsOfShape J
       colimMap (whiskerLeft _ ((evaluation _ _).map f)) ≫
         (colimitObjIsoColimitCompEvaluation _ _).inv := by
   ext
-  dsimp
   simp
 
 @[reassoc (attr := simp)]

--- a/Mathlib/CategoryTheory/Limits/HasLimits.lean
+++ b/Mathlib/CategoryTheory/Limits/HasLimits.lean
@@ -337,7 +337,6 @@ theorem HasLimit.isoOfEquivalence_hom_π {F : J ⥤ C} [HasLimit F] {G : K ⥤ C
     (HasLimit.isoOfEquivalence e w).hom ≫ limit.π G k =
       limit.π F (e.inverse.obj k) ≫ w.inv.app (e.inverse.obj k) ≫ G.map (e.counit.app k) := by
   simp only [HasLimit.isoOfEquivalence, IsLimit.conePointsIsoOfEquivalence_hom]
-  dsimp
   simp
 
 @[simp]
@@ -346,7 +345,6 @@ theorem HasLimit.isoOfEquivalence_inv_π {F : J ⥤ C} [HasLimit F] {G : K ⥤ C
     (HasLimit.isoOfEquivalence e w).inv ≫ limit.π F j =
     limit.π G (e.functor.obj j) ≫ w.hom.app j := by
   simp only [HasLimit.isoOfEquivalence, IsLimit.conePointsIsoOfEquivalence_hom]
-  dsimp
   simp
 
 section Pre

--- a/Mathlib/CategoryTheory/Limits/IsLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/IsLimit.lean
@@ -806,7 +806,6 @@ def coconePointsIsoOfEquivalence {F : J ⥤ C} {s : Cocone F} {G : K ⥤ C} {t :
       simp only [Limits.Cocone.whisker_ι, fac, invFunIdAssoc_inv_app, whiskerLeft_app, assoc,
         comp_id, Limits.Cocones.precompose_obj_ι, fac_assoc, NatTrans.comp_app]
       rw [counitInv_app_functor, ← Functor.comp_map, ← w.inv.naturality_assoc]
-      dsimp
       simp
     inv_hom_id := by
       apply hom_ext Q

--- a/Mathlib/CategoryTheory/Limits/Preserves/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Basic.lean
@@ -294,7 +294,6 @@ lemma preservesLimitsOfShape_of_equiv {J' : Type w₂} [Category.{w₂'} J'] (e 
         have := (isLimitOfPreserves F (t.whiskerEquivalence e)).whiskerEquivalence e.symm
         apply ((IsLimit.postcomposeHomEquiv equ _).symm this).ofIsoLimit
         refine Cones.ext (Iso.refl _) fun j => ?_
-        dsimp
         simp [equ, ← Functor.map_comp]⟩ }
 
 @[deprecated "use preservesLimitsOfShape_of_equiv" (since := "2024-11-19")]
@@ -313,7 +312,6 @@ lemma preservesLimitsOfSizeOfUnivLE (F : C ⥤ D) [UnivLE.{w, w'}] [UnivLE.{w₂
     [PreservesLimitsOfSize.{w', w₂'} F] : PreservesLimitsOfSize.{w, w₂} F :=
   preservesLimitsOfSize_of_univLE.{w', w₂'} F
 
--- See library note [dsimp, simp].
 /-- `PreservesLimitsOfSize_shrink.{w w'} F` tries to obtain `PreservesLimitsOfSize.{w w'} F`
 from some other `PreservesLimitsOfSize F`.
 -/
@@ -401,7 +399,6 @@ lemma preservesColimitsOfShape_of_equiv {J' : Type w₂} [Category.{w₂'} J'] (
         have := (isColimitOfPreserves F (t.whiskerEquivalence e)).whiskerEquivalence e.symm
         apply ((IsColimit.precomposeInvEquiv equ _).symm this).ofIsoColimit
         refine Cocones.ext (Iso.refl _) fun j => ?_
-        dsimp
         simp [equ, ← Functor.map_comp]⟩ }
 
 @[deprecated "use preservesColimitsOfShape_of_equiv" (since := "2024-11-19")]
@@ -420,7 +417,6 @@ lemma preservesColimitsOfSizeOfUnivLE (F : C ⥤ D) [UnivLE.{w, w'}] [UnivLE.{w�
     [PreservesColimitsOfSize.{w', w₂'} F] : PreservesColimitsOfSize.{w, w₂} F :=
   preservesColimitsOfSize_of_univLE.{w', w₂'} F
 
--- See library note [dsimp, simp].
 /--
 `PreservesColimitsOfSize_shrink.{w w'} F` tries to obtain `PreservesColimitsOfSize.{w w'} F`
 from some other `PreservesColimitsOfSize F`.

--- a/Mathlib/CategoryTheory/Limits/Shapes/BinaryBiproducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/BinaryBiproducts.lean
@@ -559,7 +559,7 @@ theorem biprod.map_eq_map' {W X Y Z : C} [HasBinaryBiproduct W X] [HasBinaryBipr
   · simp only [mapPair_left, IsColimit.ι_map, IsLimit.map_π, biprod.inl_fst_assoc,
       Category.assoc, ← BinaryBicone.toCone_π_app_left, ← BinaryBiproduct.bicone_fst, ←
       BinaryBicone.toCocone_ι_app_left, ← BinaryBiproduct.bicone_inl]
-    dsimp; simp
+    simp
   · simp only [mapPair_left, IsColimit.ι_map, IsLimit.map_π, zero_comp, biprod.inl_snd_assoc,
       Category.assoc, ← BinaryBicone.toCone_π_app_right, ← BinaryBiproduct.bicone_snd, ←
       BinaryBicone.toCocone_ι_app_left, ← BinaryBiproduct.bicone_inl]

--- a/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
@@ -1229,13 +1229,13 @@ noncomputable def Over.coprod [HasBinaryCoproducts C] {A : C} : Over A ⥤ Over 
         dsimp; rw [coprod.map_desc, Category.id_comp, Over.w k])
       naturality := fun f g k => by
         ext
-        dsimp; simp }
+        simp }
   map_id X := by
     ext
-    dsimp; simp
+    simp
   map_comp f g := by
     ext
-    dsimp; simp
+    simp
 
 end CategoryTheory
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Diagonal.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Diagonal.lean
@@ -361,7 +361,7 @@ theorem diagonal_pullback_fst {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) :
         ((Over.pullback f).map
               (Over.homMk (diagonal g) : Over.mk g ⟶ Over.mk (pullback.snd _ _ ≫ g))).left ≫
           (diagonalObjPullbackFstIso f g).inv := by
-  ext <;> dsimp <;> simp
+  ext <;> simp
 
 /-- Informally, this is a special case of `pullback_map_diagonal_isPullback` for `T = X`. -/
 lemma pullback_lift_diagonal_isPullback (g : Y ⟶ X) (f : X ⟶ S) :

--- a/Mathlib/CategoryTheory/Limits/Shapes/Equalizers.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Equalizers.lean
@@ -190,7 +190,7 @@ def parallelPair (f g : X ⟶ Y) : WalkingParallelPair ⥤ C where
     | right => g
   -- `sorry` can cope with this, but it's too slow:
   map_comp := by
-    rintro _ _ _ ⟨⟩ g <;> cases g <;> {dsimp; simp}
+    rintro _ _ _ ⟨⟩ g <;> cases g <;> simp
 
 @[simp]
 theorem parallelPair_obj_zero (f g : X ⟶ Y) : (parallelPair f g).obj zero = X := rfl
@@ -223,7 +223,7 @@ def parallelPairHom {X' Y' : C} (f g : X ⟶ Y) (f' g' : X' ⟶ Y') (p : X ⟶ X
     | zero => p
     | one => q
   naturality := by
-    rintro _ _ ⟨⟩ <;> {dsimp; simp [wf,wg]}
+    rintro _ _ ⟨⟩ <;> simp [wf,wg]
 
 @[simp]
 theorem parallelPairHom_app_zero {X' Y' : C} (f g : X ⟶ Y) (f' g' : X' ⟶ Y') (p : X ⟶ X')
@@ -314,7 +314,7 @@ def Fork.ofι {P : C} (ι : P ⟶ X) (w : ι ≫ f = ι ≫ g) : Fork f g where
         · exact ι
         · exact ι ≫ f
       naturality := fun {X} {Y} f =>
-        by cases X <;> cases Y <;> cases f <;> dsimp <;> simp; assumption }
+        by cases X <;> cases Y <;> cases f <;> simp; assumption }
 
 /-- A cofork on `f g : X ⟶ Y` is determined by the morphism `π : Y ⟶ P` satisfying
     `f ≫ π = g ≫ π`. -/
@@ -323,9 +323,8 @@ def Cofork.ofπ {P : C} (π : Y ⟶ P) (w : f ≫ π = g ≫ π) : Cofork f g wh
   pt := P
   ι :=
     { app := fun X => WalkingParallelPair.casesOn X (f ≫ π) π
-      naturality := fun i j f => by cases f <;> dsimp <;> simp [w] }
+      naturality := fun i j f => by cases f <;> simp [w] }
 
--- See note [dsimp, simp]
 @[simp]
 theorem Fork.ι_ofι {P : C} (ι : P ⟶ X) (w : ι ≫ f = ι ≫ g) : (Fork.ofι ι w).ι = ι :=
   rfl
@@ -523,7 +522,7 @@ def Cone.ofFork {F : WalkingParallelPair ⥤ C} (t : Fork (F.map left) (F.map ri
   pt := t.pt
   π :=
     { app := fun X => t.π.app X ≫ eqToHom (by simp)
-      naturality := by rintro _ _ (_|_|_) <;> {dsimp; simp [t.condition]}}
+      naturality := by rintro _ _ (_|_|_) <;> simp [t.condition]}
 
 /-- This is a helper construction that can be useful when verifying that a category has all
     coequalizers. Given `F : WalkingParallelPair ⥤ C`, which is really the same as
@@ -538,7 +537,7 @@ def Cocone.ofCofork {F : WalkingParallelPair ⥤ C} (t : Cofork (F.map left) (F.
   pt := t.pt
   ι :=
     { app := fun X => eqToHom (by simp) ≫ t.ι.app X
-      naturality := by rintro _ _ (_|_|_) <;> {dsimp; simp [t.condition]}}
+      naturality := by rintro _ _ (_|_|_) <;> simp [t.condition]}
 
 @[simp]
 theorem Cone.ofFork_π {F : WalkingParallelPair ⥤ C} (t : Fork (F.map left) (F.map right)) (j) :
@@ -554,7 +553,7 @@ theorem Cocone.ofCofork_ι {F : WalkingParallelPair ⥤ C} (t : Cofork (F.map le
 def Fork.ofCone {F : WalkingParallelPair ⥤ C} (t : Cone F) : Fork (F.map left) (F.map right) where
   pt := t.pt
   π := { app := fun X => t.π.app X ≫ eqToHom (by simp)
-         naturality := by rintro _ _ (_|_|_) <;> {dsimp; simp}}
+         naturality := by rintro _ _ (_|_|_) <;> simp}
 
 /-- Given `F : WalkingParallelPair ⥤ C`, which is really the same as
     `parallelPair (F.map left) (F.map right)` and a cocone on `F`, we get a cofork on
@@ -563,7 +562,7 @@ def Cofork.ofCocone {F : WalkingParallelPair ⥤ C} (t : Cocone F) :
     Cofork (F.map left) (F.map right) where
   pt := t.pt
   ι := { app := fun X => eqToHom (by simp) ≫ t.ι.app X
-         naturality := by rintro _ _ (_|_|_) <;> {dsimp; simp}}
+         naturality := by rintro _ _ (_|_|_) <;> simp}
 
 @[simp]
 theorem Fork.ofCone_π {F : WalkingParallelPair ⥤ C} (t : Cone F) (j) :
@@ -656,7 +655,7 @@ def Cofork.ext {s t : Cofork f g} (i : s.pt ≅ t.pt) (w : s.π ≫ i.hom = t.π
 
 /-- Every cofork is isomorphic to one of the form `Cofork.ofπ _ _`. -/
 def Cofork.isoCoforkOfπ (c : Cofork f g) : c ≅ Cofork.ofπ c.π c.condition :=
-  Cofork.ext (by simp only [Cofork.ofπ_pt, Functor.const_obj_obj]; rfl) (by dsimp; simp)
+  Cofork.ext (by simp only [Cofork.ofπ_pt, Functor.const_obj_obj]; rfl) (by simp)
 
 variable (f g)
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/CommSq.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/CommSq.lean
@@ -254,9 +254,7 @@ theorem of_is_product {c : BinaryFan X Y} (h : Limits.IsLimit c) (t : IsTerminal
       (IsLimit.ofIsoLimit h
         (Limits.Cones.ext (Iso.refl c.pt)
           (by
-            rintro ⟨⟨⟩⟩ <;>
-              · dsimp
-                simp))))
+            rintro ⟨⟨⟩⟩ <;> simp))))
 
 /-- A variant of `of_is_product` that is more useful with `apply`. -/
 theorem of_is_product' (h : Limits.IsLimit (BinaryFan.mk fst snd)) (t : IsTerminal Z) :
@@ -478,9 +476,7 @@ theorem of_is_coproduct {c : BinaryCofan X Y} (h : Limits.IsColimit c) (t : IsIn
       (IsColimit.ofIsoColimit h
         (Limits.Cocones.ext (Iso.refl c.pt)
           (by
-            rintro ⟨⟨⟩⟩ <;>
-              · dsimp
-                simp))))
+            rintro ⟨⟨⟩⟩ <;> simp))))
 
 /-- A variant of `of_is_coproduct` that is more useful with `apply`. -/
 theorem of_is_coproduct' (h : Limits.IsColimit (BinaryCofan.mk inl inr)) (t : IsInitial Z) :

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Cospan.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Cospan.lean
@@ -223,7 +223,7 @@ theorem span_map_id {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z) (w : WalkingSpan) :
 def diagramIsoCospan (F : WalkingCospan ⥤ C) : F ≅ cospan (F.map inl) (F.map inr) :=
   NatIso.ofComponents
   (fun j => eqToIso (by rcases j with (⟨⟩ | ⟨⟨⟩⟩) <;> rfl))
-  (by rintro (⟨⟩ | ⟨⟨⟩⟩) (⟨⟩ | ⟨⟨⟩⟩) f <;> cases f <;> dsimp <;> simp)
+  (by rintro (⟨⟩ | ⟨⟨⟩⟩) (⟨⟩ | ⟨⟨⟩⟩) f <;> cases f <;> simp)
 
 /-- Every diagram indexing a pushout is naturally isomorphic (actually, equal) to a `span` -/
 -- @[simps (config := { rhsMd := semireducible })]  Porting note: no semireducible
@@ -231,7 +231,7 @@ def diagramIsoCospan (F : WalkingCospan ⥤ C) : F ≅ cospan (F.map inl) (F.map
 def diagramIsoSpan (F : WalkingSpan ⥤ C) : F ≅ span (F.map fst) (F.map snd) :=
   NatIso.ofComponents
   (fun j => eqToIso (by rcases j with (⟨⟩ | ⟨⟨⟩⟩) <;> rfl))
-  (by rintro (⟨⟩ | ⟨⟨⟩⟩) (⟨⟩ | ⟨⟨⟩⟩) f <;> cases f <;> dsimp <;> simp)
+  (by rintro (⟨⟩ | ⟨⟨⟩⟩) (⟨⟩ | ⟨⟨⟩⟩) f <;> cases f <;> simp)
 
 variable {D : Type u₂} [Category.{v₂} D]
 
@@ -239,7 +239,7 @@ variable {D : Type u₂} [Category.{v₂} D]
 def cospanCompIso (F : C ⥤ D) {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) :
     cospan f g ⋙ F ≅ cospan (F.map f) (F.map g) :=
   NatIso.ofComponents (by rintro (⟨⟩ | ⟨⟨⟩⟩) <;> exact Iso.refl _)
-    (by rintro (⟨⟩ | ⟨⟨⟩⟩) (⟨⟩ | ⟨⟨⟩⟩) f <;> cases f <;> dsimp <;> simp)
+    (by rintro (⟨⟩ | ⟨⟨⟩⟩) (⟨⟩ | ⟨⟨⟩⟩) f <;> cases f <;> simp)
 
 section
 
@@ -283,7 +283,7 @@ end
 def spanCompIso (F : C ⥤ D) {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z) :
     span f g ⋙ F ≅ span (F.map f) (F.map g) :=
   NatIso.ofComponents (by rintro (⟨⟩ | ⟨⟨⟩⟩) <;> exact Iso.refl _)
-    (by rintro (⟨⟩ | ⟨⟨⟩⟩) (⟨⟩ | ⟨⟨⟩⟩) f <;> cases f <;> dsimp <;> simp)
+    (by rintro (⟨⟩ | ⟨⟨⟩⟩) (⟨⟩ | ⟨⟨⟩⟩) f <;> cases f <;> simp)
 
 section
 
@@ -331,7 +331,7 @@ def cospanExt (wf : iX.hom ≫ f' = f ≫ iZ.hom) (wg : iY.hom ≫ g' = g ≫ iZ
     cospan f g ≅ cospan f' g' :=
   NatIso.ofComponents
     (by rintro (⟨⟩ | ⟨⟨⟩⟩); exacts [iZ, iX, iY])
-    (by rintro (⟨⟩ | ⟨⟨⟩⟩) (⟨⟩ | ⟨⟨⟩⟩) f <;> cases f <;> dsimp <;> simp [wf, wg])
+    (by rintro (⟨⟩ | ⟨⟨⟩⟩) (⟨⟩ | ⟨⟨⟩⟩) f <;> cases f <;> simp [wf, wg])
 
 variable (wf : iX.hom ≫ f' = f ≫ iZ.hom) (wg : iY.hom ≫ g' = g ≫ iZ.hom)
 
@@ -381,7 +381,7 @@ variable {f : X ⟶ Y} {g : X ⟶ Z} {f' : X' ⟶ Y'} {g' : X' ⟶ Z'}
 def spanExt (wf : iX.hom ≫ f' = f ≫ iY.hom) (wg : iX.hom ≫ g' = g ≫ iZ.hom) :
     span f g ≅ span f' g' :=
   NatIso.ofComponents (by rintro (⟨⟩ | ⟨⟨⟩⟩); exacts [iX, iY, iZ])
-    (by rintro (⟨⟩ | ⟨⟨⟩⟩) (⟨⟩ | ⟨⟨⟩⟩) f <;> cases f <;> dsimp <;> simp [wf, wg])
+    (by rintro (⟨⟩ | ⟨⟨⟩⟩) (⟨⟩ | ⟨⟨⟩⟩) f <;> cases f <;> simp [wf, wg])
 
 variable (wf : iX.hom ≫ f' = f ≫ iY.hom) (wg : iX.hom ≫ g' = g ≫ iZ.hom)
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/PullbackCone.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/PullbackCone.lean
@@ -109,7 +109,7 @@ theorem condition_one (t : PullbackCone f g) : t.π.app WalkingCospan.one = t.fs
 def mk {W : C} (fst : W ⟶ X) (snd : W ⟶ Y) (eq : fst ≫ f = snd ≫ g) : PullbackCone f g where
   pt := W
   π := { app := fun j => Option.casesOn j (fst ≫ f) fun j' => WalkingPair.casesOn j' fst snd
-         naturality := by rintro (⟨⟩ | ⟨⟨⟩⟩) (⟨⟩ | ⟨⟨⟩⟩) j <;> cases j <;> dsimp <;> simp [eq] }
+         naturality := by rintro (⟨⟩ | ⟨⟨⟩⟩) (⟨⟩ | ⟨⟨⟩⟩) j <;> cases j <;> simp [eq] }
 
 @[simp]
 theorem mk_π_app_left {W : C} (fst : W ⟶ X) (snd : W ⟶ Y) (eq : fst ≫ f = snd ≫ g) :
@@ -288,9 +288,7 @@ def PullbackCone.isoMk {F : WalkingCospan ⥤ C} (t : Cone F) :
       PullbackCone.mk (t.π.app WalkingCospan.left) (t.π.app WalkingCospan.right)
         ((t.π.naturality inl).symm.trans (t.π.naturality inr :)) :=
   Cones.ext (Iso.refl _) <| by
-    rintro (_ | (_ | _)) <;>
-      · dsimp
-        simp
+    rintro (_ | (_ | _)) <;> simp
 
 /-- A pushout cocone is just a cocone on the span formed by two morphisms `f : X ⟶ Y` and
     `g : X ⟶ Z`. -/
@@ -508,8 +506,6 @@ def PushoutCocone.isoMk {F : WalkingSpan ⥤ C} (t : Cocone F) :
       PushoutCocone.mk (t.ι.app WalkingSpan.left) (t.ι.app WalkingSpan.right)
         ((t.ι.naturality fst).trans (t.ι.naturality snd).symm) :=
   Cocones.ext (Iso.refl _) <| by
-    rintro (_ | (_ | _)) <;>
-      · dsimp
-        simp
+    rintro (_ | (_ | _)) <;> simp
 
 end CategoryTheory.Limits

--- a/Mathlib/CategoryTheory/Limits/Shapes/Terminal.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Terminal.lean
@@ -263,7 +263,6 @@ variable {J : Type u} [Category.{v} J]
 instance hasLimit_of_domain_hasInitial [HasInitial J] {F : J ⥤ C} : HasLimit F :=
   HasLimit.mk { cone := _, isLimit := limitOfDiagramInitial (initialIsInitial) F }
 
--- See note [dsimp, simp]
 -- This is reducible to allow usage of lemmas about `cone_point_unique_up_to_iso`.
 /-- For a functor `F : J ⥤ C`, if `J` has an initial object then the image of it is isomorphic
 to the limit of `F`. -/

--- a/Mathlib/CategoryTheory/Limits/Shapes/WideEqualizers.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/WideEqualizers.lean
@@ -217,7 +217,6 @@ def Trident.ofι [Nonempty J] {P : C} (ι : P ⟶ X) (w : ∀ j₁ j₂, ι ≫ 
   π :=
     { app := fun X => WalkingParallelFamily.casesOn X ι (ι ≫ f (Classical.arbitrary J))
       naturality := fun i j f => by
-        dsimp
         obtain - | k := f
         · simp
         · simp [w (Classical.arbitrary J) k] }
@@ -232,12 +231,10 @@ def Cotrident.ofπ [Nonempty J] {P : C} (π : Y ⟶ P) (w : ∀ j₁ j₂, f j�
   ι :=
     { app := fun X => WalkingParallelFamily.casesOn X (f (Classical.arbitrary J) ≫ π) π
       naturality := fun i j f => by
-        dsimp
         obtain - | k := f
         · simp
         · simp [w (Classical.arbitrary J) k] }
 
--- See note [dsimp, simp]
 theorem Trident.ι_ofι [Nonempty J] {P : C} (ι : P ⟶ X) (w : ∀ j₁ j₂, ι ≫ f j₁ = ι ≫ f j₂) :
     (Trident.ofι ι w).ι = ι :=
   rfl
@@ -405,7 +402,7 @@ def Cocone.ofCotrident {F : WalkingParallelFamily J ⥤ C} (t : Cotrident fun j 
   pt := t.pt
   ι :=
     { app := fun X => eqToHom (by cases X <;> aesop_cat) ≫ t.ι.app X
-      naturality := fun j j' g => by cases g <;> dsimp <;> simp [Cotrident.app_one t] }
+      naturality := fun j j' g => by cases g <;> simp [Cotrident.app_one t] }
 
 @[simp]
 theorem Cone.ofTrident_π {F : WalkingParallelFamily J ⥤ C} (t : Trident fun j => F.map (line j))

--- a/Mathlib/CategoryTheory/Limits/Shapes/WidePullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/WidePullbacks.lean
@@ -128,7 +128,7 @@ def mkCone {F : WidePullbackShape J ⥤ C} {X : C} (f : X ⟶ F.obj none) (π : 
           | none => f
           | some j => π j
         naturality := fun j j' f => by
-          cases j <;> cases j' <;> cases f <;> dsimp <;> simp [w] } }
+          cases j <;> cases j' <;> cases f <;> simp [w] } }
 
 /-- Wide pullback diagrams of equivalent index types are equivalent. -/
 def equivalenceOfEquiv (J' : Type w') (h : J ≃ J') :
@@ -231,7 +231,7 @@ def mkCocone {F : WidePushoutShape J ⥤ C} {X : C} (f : F.obj none ⟶ X) (ι :
           | none => f
           | some j => ι j
         naturality := fun j j' f => by
-          cases j <;> cases j' <;> cases f <;> dsimp <;> simp [w] } }
+          cases j <;> cases j' <;> cases f <;> simp [w] } }
 
 /-- Wide pushout diagrams of equivalent index types are equivalent. -/
 def equivalenceOfEquiv (J' : Type w') (h : J ≃ J') : WidePushoutShape J ≌ WidePushoutShape J' where

--- a/Mathlib/CategoryTheory/Limits/Types/Shapes.lean
+++ b/Mathlib/CategoryTheory/Limits/Types/Shapes.lean
@@ -307,7 +307,6 @@ theorem binaryCofan_isColimit_iff {X Y : Type u} (c : BinaryCofan X Y) :
           else g ((Equiv.ofInjective _ h₂).symm ⟨x, (this x).resolve_left h⟩)
       · intro T f g
         funext x
-        dsimp
         simp [h₁.eq_iff]
       · intro T f g
         funext x

--- a/Mathlib/CategoryTheory/Limits/VanKampen.lean
+++ b/Mathlib/CategoryTheory/Limits/VanKampen.lean
@@ -461,7 +461,7 @@ theorem hasStrictInitial_of_isUniversal [HasInitial C]
         obtain ⟨l, h₁, h₂⟩ := Limits.BinaryCofan.IsColimit.desc' this (f ≫ initial.to A) (𝟙 A)
         rcases(Category.id_comp _).symm.trans h₂ with rfl
         exact ⟨⟨_, ((Category.id_comp _).symm.trans h₁).symm, initialIsInitial.hom_ext _ _⟩⟩
-      refine (H (BinaryCofan.mk (𝟙 _) (𝟙 _)) (mapPair f f) f (by ext ⟨⟨⟩⟩ <;> dsimp <;> simp)
+      refine (H (BinaryCofan.mk (𝟙 _) (𝟙 _)) (mapPair f f) f (by ext ⟨⟨⟩⟩ <;> simp)
         (mapPair_equifibered _) ?_).some
       rintro ⟨⟨⟩⟩ <;> dsimp <;>
         exact IsPullback.of_horiz_isIso ⟨(Category.id_comp _).trans (Category.comp_id _).symm⟩)
@@ -560,7 +560,7 @@ theorem BinaryCofan.mono_inr_of_isVanKampen [HasInitial C] {X Y : C} {c : Binary
   refine PullbackCone.mono_of_isLimitMkIdId _ (IsPullback.isLimit ?_)
   refine (h (BinaryCofan.mk (initial.to Y) (𝟙 Y)) (mapPair (initial.to X) (𝟙 Y)) c.inr ?_
       (mapPair_equifibered _)).mp ⟨?_⟩ ⟨WalkingPair.right⟩
-  · ext ⟨⟨⟩⟩ <;> dsimp; simp
+  · ext ⟨⟨⟩⟩ <;> simp
   · exact ((BinaryCofan.isColimit_iff_isIso_inr initialIsInitial _).mpr (by
       dsimp
       infer_instance)).some
@@ -569,7 +569,7 @@ theorem BinaryCofan.isPullback_initial_to_of_isVanKampen [HasInitial C] {c : Bin
     (h : IsVanKampenColimit c) : IsPullback (initial.to _) (initial.to _) c.inl c.inr := by
   refine ((h (BinaryCofan.mk (initial.to Y) (𝟙 Y)) (mapPair (initial.to X) (𝟙 Y)) c.inr ?_
       (mapPair_equifibered _)).mp ⟨?_⟩ ⟨WalkingPair.left⟩).flip
-  · ext ⟨⟨⟩⟩ <;> dsimp; simp
+  · ext ⟨⟨⟩⟩ <;> simp
   · exact ((BinaryCofan.isColimit_iff_isIso_inr initialIsInitial _).mpr (by
       dsimp
       infer_instance)).some

--- a/Mathlib/CategoryTheory/Monad/Algebra.lean
+++ b/Mathlib/CategoryTheory/Monad/Algebra.lean
@@ -156,12 +156,9 @@ def adj : T.free ⊣ T.forget :=
         { toFun := fun f => T.η.app X ≫ f.f
           invFun := fun f =>
             { f := T.map f ≫ Y.a
-              h := by
-                dsimp
-                simp [← Y.assoc, ← T.μ.naturality_assoc] }
+              h := by simp [← Y.assoc, ← T.μ.naturality_assoc] }
           left_inv := fun f => by
             ext
-            dsimp
             simp
           right_inv := fun f => by
             dsimp only [forget_obj]
@@ -205,12 +202,8 @@ def algebraFunctorOfMonadHom {T₁ T₂ : Monad C} (h : T₂ ⟶ T₁) : Algebra
   obj A :=
     { A := A.A
       a := h.app A.A ≫ A.a
-      unit := by
-        dsimp
-        simp [A.unit]
-      assoc := by
-        dsimp
-        simp [A.assoc] }
+      unit := by simp [A.unit]
+      assoc := by simp [A.assoc] }
   map f := { f := f.f }
 
 /--
@@ -386,9 +379,7 @@ def adj : G.forget ⊣ G.cofree :=
     { homEquiv := fun X Y =>
         { toFun := fun f =>
             { f := X.a ≫ G.map f
-              h := by
-                dsimp
-                simp [← Coalgebra.coassoc_assoc] }
+              h := by simp [← Coalgebra.coassoc_assoc] }
           invFun := fun g => g.f ≫ G.ε.app Y
           left_inv := fun f => by
             dsimp

--- a/Mathlib/CategoryTheory/Monad/Kleisli.lean
+++ b/Mathlib/CategoryTheory/Monad/Kleisli.lean
@@ -85,7 +85,6 @@ def adj : toKleisli T ⊣ fromKleisli T :=
         -- Porting note: used to be unfold_projs; dsimp
         change f ≫ g = (f ≫ T.η.app Y) ≫ T.map g ≫ T.μ.app Z
         rw [Category.assoc, ← T.η.naturality_assoc g, Functor.id_map]
-        dsimp
         simp [Monad.left_unit] }
 
 /-- The composition of the adjunction gives the original functor. -/

--- a/Mathlib/CategoryTheory/Monad/Limits.lean
+++ b/Mathlib/CategoryTheory/Monad/Limits.lean
@@ -62,8 +62,7 @@ def conePoint : Algebra T where
     t.hom_ext fun j => by
       rw [Category.assoc, t.fac, newCone_π_app, ← T.η.naturality_assoc, Functor.id_map,
         (D.obj j).unit]
-      dsimp; simp
-  -- See library note [dsimp, simp]
+      simp
   assoc :=
     t.hom_ext fun j => by
       rw [Category.assoc, Category.assoc, t.fac (newCone D c), newCone_π_app, ←
@@ -176,8 +175,7 @@ noncomputable def coconePoint : Algebra T where
     rw [show c.ι.app j ≫ T.η.app c.pt ≫ _ = T.η.app (D.obj j).A ≫ _ ≫ _ from
         T.η.naturality_assoc _ _,
       commuting, Algebra.unit_assoc (D.obj j)]
-    dsimp; simp
-  -- See library note [dsimp, simp]
+    simp
   assoc := by
     refine (isColimitOfPreserves _ (isColimitOfPreserves _ t)).hom_ext fun j => ?_
     rw [Functor.mapCocone_ι_app, Functor.mapCocone_ι_app,

--- a/Mathlib/CategoryTheory/Monad/Products.lean
+++ b/Mathlib/CategoryTheory/Monad/Products.lean
@@ -54,7 +54,6 @@ def coalgebraToOver : Coalgebra (prodComonad X) ⥤ Over X where
     Over.homMk f.f
       (by
         rw [Over.mk_hom, ← f.h_assoc]
-        dsimp
         simp)
 
 /-- The backward direction of the equivalence from coalgebras for the product comonad to the over
@@ -101,7 +100,6 @@ def algebraToUnder : Monad.Algebra (coprodMonad X) ⥤ Under X where
     Under.homMk f.f
       (by
         rw [Under.mk_hom, Category.assoc, ← f.h]
-        dsimp
         simp)
 
 /-- The backward direction of the equivalence from algebras for the coproduct monad to the under

--- a/Mathlib/CategoryTheory/Monoidal/Bimon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Bimon_.lean
@@ -115,7 +115,7 @@ def toMon_Comon_obj (M : Bimon_ C) : Mon_ (Comon_ C) where
   one := { hom := M.X.one }
   mul :=
   { hom := M.X.mul,
-    hom_comul := by dsimp; simp [tensor_μ] }
+    hom_comul := by simp [tensor_μ] }
 
 attribute [simps] toMon_Comon_obj -- We add this after the fact to avoid a timeout.
 
@@ -133,7 +133,7 @@ def ofMon_Comon_obj (M : Mon_ (Comon_ C)) : Bimon_ C where
   counit := { hom := M.X.counit }
   comul :=
   { hom := M.X.comul,
-    mul_hom := by dsimp; simp [tensor_μ] }
+    mul_hom := by simp [tensor_μ] }
 
 /-- The backward direction of `Comon_ (Mon_ C) ≌ Mon_ (Comon_ C)` -/
 @[simps]

--- a/Mathlib/CategoryTheory/Monoidal/CommMon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CommMon_.lean
@@ -263,7 +263,7 @@ def unitIso :
         laxBraidedToCommMon C ⋙ commMonToLaxBraided C :=
   NatIso.ofComponents
     (fun F ↦ LaxBraidedFunctor.isoOfComponents (fun _ ↦ F.mapIso (eqToIso (by ext))))
-    (fun f ↦ by ext ⟨⟨⟩⟩; simp)
+    (fun f ↦ by ext ⟨⟨⟩⟩; dsimp; simp)
 
 /-- Implementation of `CommMon_.equivLaxBraidedFunctorPUnit`. -/
 @[simps!]

--- a/Mathlib/CategoryTheory/Monoidal/CommMon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CommMon_.lean
@@ -263,7 +263,7 @@ def unitIso :
         laxBraidedToCommMon C ⋙ commMonToLaxBraided C :=
   NatIso.ofComponents
     (fun F ↦ LaxBraidedFunctor.isoOfComponents (fun _ ↦ F.mapIso (eqToIso (by ext))))
-    (fun f ↦ by ext ⟨⟨⟩⟩; dsimp; simp)
+    (fun f ↦ by ext ⟨⟨⟩⟩; simp)
 
 /-- Implementation of `CommMon_.equivLaxBraidedFunctorPUnit`. -/
 @[simps!]

--- a/Mathlib/CategoryTheory/Monoidal/Internal/Types/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Internal/Types/Basic.lean
@@ -47,8 +47,8 @@ noncomputable def inverse : MonCat.{u} ⥤ Mon_ (Type u) where
     { X := A
       one := fun _ => 1
       mul := fun p => p.1 * p.2
-      one_mul := by ext ⟨_, _⟩; dsimp; simp
-      mul_one := by ext ⟨_, _⟩; dsimp; simp
+      one_mul := by ext ⟨_, _⟩; simp
+      mul_one := by ext ⟨_, _⟩; simp
       mul_assoc := by ext ⟨⟨x, y⟩, z⟩; simp [mul_assoc] }
   map f := { hom := f }
 

--- a/Mathlib/CategoryTheory/Monoidal/OfHasFiniteProducts.lean
+++ b/Mathlib/CategoryTheory/Monoidal/OfHasFiniteProducts.lean
@@ -154,7 +154,7 @@ def symmetricOfHasFiniteProducts [HasTerminal C] [HasBinaryProducts C] : Symmetr
   braiding_naturality_right X _ _ f := by simp
   hexagon_forward X Y Z := by dsimp [monoidalOfHasFiniteProducts.associator_hom]; simp
   hexagon_reverse X Y Z := by dsimp [monoidalOfHasFiniteProducts.associator_inv]; simp
-  symmetry X Y := by dsimp; simp
+  symmetry X Y := by simp
 
 end
 
@@ -250,7 +250,7 @@ def symmetricOfHasFiniteCoproducts [HasInitial C] [HasBinaryCoproducts C] :
   braiding_naturality_right f g := by simp
   hexagon_forward X Y Z := by dsimp [monoidalOfHasFiniteCoproducts.associator_hom]; simp
   hexagon_reverse X Y Z := by dsimp [monoidalOfHasFiniteCoproducts.associator_inv]; simp
-  symmetry X Y := by dsimp; simp
+  symmetry X Y := by simp
 
 end
 

--- a/Mathlib/CategoryTheory/Monoidal/Rigid/FunctorCategory.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Rigid/FunctorCategory.lean
@@ -57,12 +57,10 @@ instance functorHasLeftDual [LeftRigidCategory D] (F : C ⥤ D) : HasLeftDual F 
     { evaluation' :=
         { app := fun _ => ε_ _ _
           naturality := fun X Y f => by
-            dsimp
             simp [tensorHom_def, leftAdjointMate_comp_evaluation] }
       coevaluation' :=
         { app := fun _ => η_ _ _
           naturality := fun X Y f => by
-            dsimp
             simp [tensorHom_def, coevaluation_comp_leftAdjointMate_assoc] } }
 
 instance leftRigidFunctorCategory [LeftRigidCategory D] : LeftRigidCategory (C ⥤ D) where

--- a/Mathlib/CategoryTheory/Monoidal/Types/Coyoneda.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Types/Coyoneda.lean
@@ -33,11 +33,9 @@ instance (C : Type u) [Category.{v} C] [MonoidalCategory C] :
     (left_unitality' := by
       intros
       ext ⟨⟨⟩, f⟩; dsimp at f
-      dsimp
       simp)
     (right_unitality' := fun X => by
       ext ⟨f, ⟨⟩⟩; dsimp at f
-      dsimp
       simp [unitors_inv_equal])
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
@@ -227,7 +227,7 @@ theorem pullback_map [HasPullbacks C]
           ((Over.pullback _).map (Over.homMk _ e₂.symm : Over.mk g ⟶ Over.mk g')).left) ≫
         (pullbackSymmetry _ _).hom ≫
           ((Over.pullback g').map (Over.homMk _ e₁.symm : Over.mk f ⟶ Over.mk f')).left := by
-    ext <;> dsimp <;> simp
+    ext <;> simp
   rw [this]
   apply P.comp_mem <;> rw [P.cancel_left_of_respectsIso]
   exacts [baseChange_map _ (Over.homMk _ e₂.symm : Over.mk g ⟶ Over.mk g') h₂,

--- a/Mathlib/CategoryTheory/Opposites.lean
+++ b/Mathlib/CategoryTheory/Opposites.lean
@@ -496,7 +496,6 @@ def op (e : C ≌ D) : Cᵒᵖ ≌ Dᵒᵖ where
   counitIso := (NatIso.op e.counitIso).symm
   functor_unitIso_comp X := by
     apply Quiver.Hom.unop_inj
-    dsimp
     simp
 
 /-- An equivalence between opposite categories gives an equivalence between the original categories.
@@ -509,7 +508,6 @@ def unop (e : Cᵒᵖ ≌ Dᵒᵖ) : C ≌ D where
   counitIso := (NatIso.unop e.counitIso).symm
   functor_unitIso_comp X := by
     apply Quiver.Hom.op_inj
-    dsimp
     simp
 
 /-- An equivalence between `C` and `Dᵒᵖ` gives an equivalence between `Cᵒᵖ` and `D`. -/

--- a/Mathlib/CategoryTheory/Preadditive/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Biproducts.lean
@@ -99,8 +99,6 @@ def isBilimitOfTotal {f : J → C} (b : Bicone f) (total : ∑ j : J, b.π j ≫
         classical
         cases j
         simp only [sum_comp, Category.assoc, Bicone.toCone_π_app, b.ι_π, comp_dite]
-        -- See note [dsimp, simp].
-        dsimp
         simp }
   isColimit :=
     { desc := fun s => ∑ j : J, b.π j ≫ s.ι.app ⟨j⟩
@@ -115,7 +113,7 @@ def isBilimitOfTotal {f : J → C} (b : Bicone f) (total : ∑ j : J, b.π j ≫
         classical
         cases j
         simp only [comp_sum, ← Category.assoc, Bicone.toCocone_ι_app, b.ι_π, dite_comp]
-        dsimp; simp }
+        simp }
 
 theorem IsBilimit.total {f : J → C} {b : Bicone f} (i : b.IsBilimit) :
     ∑ j : J, b.π j ≫ b.ι j = 𝟙 b.pt :=
@@ -347,11 +345,11 @@ def BinaryBicone.ofLimitCone {X Y : C} {t : Cone (pair X Y)} (ht : IsLimit t) :
 
 theorem inl_of_isLimit {X Y : C} {t : BinaryBicone X Y} (ht : IsLimit t.toCone) :
     t.inl = ht.lift (BinaryFan.mk (𝟙 X) 0) := by
-  apply ht.uniq (BinaryFan.mk (𝟙 X) 0); rintro ⟨⟨⟩⟩ <;> dsimp <;> simp
+  apply ht.uniq (BinaryFan.mk (𝟙 X) 0); rintro ⟨⟨⟩⟩ <;> simp
 
 theorem inr_of_isLimit {X Y : C} {t : BinaryBicone X Y} (ht : IsLimit t.toCone) :
     t.inr = ht.lift (BinaryFan.mk 0 (𝟙 Y)) := by
-  apply ht.uniq (BinaryFan.mk 0 (𝟙 Y)); rintro ⟨⟨⟩⟩ <;> dsimp <;> simp
+  apply ht.uniq (BinaryFan.mk 0 (𝟙 Y)); rintro ⟨⟨⟩⟩ <;> simp
 
 /-- In a preadditive category, any binary bicone which is a limit cone is in fact a bilimit
     bicone. -/
@@ -389,12 +387,12 @@ def BinaryBicone.ofColimitCocone {X Y : C} {t : Cocone (pair X Y)} (ht : IsColim
 theorem fst_of_isColimit {X Y : C} {t : BinaryBicone X Y} (ht : IsColimit t.toCocone) :
     t.fst = ht.desc (BinaryCofan.mk (𝟙 X) 0) := by
   apply ht.uniq (BinaryCofan.mk (𝟙 X) 0)
-  rintro ⟨⟨⟩⟩ <;> dsimp <;> simp
+  rintro ⟨⟨⟩⟩ <;> simp
 
 theorem snd_of_isColimit {X Y : C} {t : BinaryBicone X Y} (ht : IsColimit t.toCocone) :
     t.snd = ht.desc (BinaryCofan.mk 0 (𝟙 Y)) := by
   apply ht.uniq (BinaryCofan.mk 0 (𝟙 Y))
-  rintro ⟨⟨⟩⟩ <;> dsimp <;> simp
+  rintro ⟨⟨⟩⟩ <;> simp
 
 /-- In a preadditive category, any binary bicone which is a colimit cocone is in fact a
     bilimit bicone. -/

--- a/Mathlib/CategoryTheory/Shift/Basic.lean
+++ b/Mathlib/CategoryTheory/Shift/Basic.lean
@@ -124,12 +124,10 @@ instance (h : ShiftMkCore C A) : (Discrete.functor h.F).Monoidal :=
       μIso_hom_natural_left := by
         rintro ⟨X⟩ ⟨Y⟩ ⟨⟨⟨rfl⟩⟩⟩ ⟨X'⟩
         ext
-        dsimp
         simp
       μIso_hom_natural_right := by
         rintro ⟨X⟩ ⟨Y⟩ ⟨X'⟩ ⟨⟨⟨rfl⟩⟩⟩
         ext
-        dsimp
         simp
       associativity := by
         rintro ⟨m₁⟩ ⟨m₂⟩ ⟨m₃⟩
@@ -739,7 +737,6 @@ def hasShift :
           shiftFunctorAdd_zero_add_hom_app, eqToHom_map]
         congr 1
         erw [(i n).hom.naturality]
-        dsimp
         simp)
       add_zero_hom_app := fun n X => hF.map_injective (by
         have := dcongr_arg (fun a => (i a).hom.app X) (add_zero n)

--- a/Mathlib/CategoryTheory/Shift/ShiftSequence.lean
+++ b/Mathlib/CategoryTheory/Shift/ShiftSequence.lean
@@ -235,7 +235,6 @@ lemma shiftIso_hom_app_comp_shiftMap_of_add_eq_zero [F.ShiftSequence G]
       (by rw [← add_left_inj m, add_assoc, hnm, zero_add, add_zero])).hom.app Y) := by
   have hnm' : m + n = 0 := by
     rw [← add_left_inj m, add_assoc, hnm, zero_add, add_zero]
-  dsimp
   simp [F.shiftIso_hom_app_comp_shiftMap f n 0 hnm' a' a, shiftIso_zero_hom_app,
     shiftFunctorCompIsoId]
 

--- a/Mathlib/CategoryTheory/Shift/SingleFunctors.lean
+++ b/Mathlib/CategoryTheory/Shift/SingleFunctors.lean
@@ -248,7 +248,6 @@ def postcompIsoOfIso {G G' : D ⥤ E} (e : G ≅ G') [G.CommShift A] [G'.CommShi
     F.postcomp G ≅ F.postcomp G' :=
   isoMk (fun a => isoWhiskerLeft (F.functor a) e) (fun n a a' ha' => by
     ext X
-    dsimp
     simp [NatTrans.shift_app e.hom n])
 
 end SingleFunctors

--- a/Mathlib/CategoryTheory/Sites/CompatiblePlus.lean
+++ b/Mathlib/CategoryTheory/Sites/CompatiblePlus.lean
@@ -52,7 +52,6 @@ theorem diagramCompIso_hom_ι (X : C) (W : (J.Cover X)ᵒᵖ) (i : W.unop.Arrow)
     (J.diagramCompIso F P X).hom.app W ≫ Multiequalizer.ι ((unop W).index (P ⋙ F)) i =
   F.map (Multiequalizer.ι _ _) := by
   delta diagramCompIso
-  dsimp
   simp
 
 variable [∀ X : C, HasColimitsOfShape (J.Cover X)ᵒᵖ D]

--- a/Mathlib/CategoryTheory/Sites/DenseSubsite/Basic.lean
+++ b/Mathlib/CategoryTheory/Sites/DenseSubsite/Basic.lean
@@ -417,7 +417,6 @@ theorem sheafHom_eq (α : ℱ ⟶ ℱ'.val) : sheafHom (whiskerLeft G.op α) = �
   · exact (pushforwardFamily_compatible _ _)
   intro Y f hf
   conv_lhs => rw [← hf.some.fac]
-  dsimp
   simp
 
 /--

--- a/Mathlib/CategoryTheory/Sites/DenseSubsite/Basic.lean
+++ b/Mathlib/CategoryTheory/Sites/DenseSubsite/Basic.lean
@@ -417,7 +417,7 @@ theorem sheafHom_eq (α : ℱ ⟶ ℱ'.val) : sheafHom (whiskerLeft G.op α) = �
   · exact (pushforwardFamily_compatible _ _)
   intro Y f hf
   conv_lhs => rw [← hf.some.fac]
-  simp
+  dsimp; simp
 
 /--
 A locally-full and cover-dense functor `G` induces an equivalence between morphisms into a sheaf and

--- a/Mathlib/CategoryTheory/Sites/IsSheafFor.lean
+++ b/Mathlib/CategoryTheory/Sites/IsSheafFor.lean
@@ -460,15 +460,12 @@ theorem extension_iff_amalgamation {P : Cᵒᵖ ⥤ Type v₁} (x : S.functor �
   constructor
   · rintro rfl Y f hf
     rw [yonedaEquiv_naturality]
-    dsimp
     simp [yonedaEquiv_apply]
-  -- See note [dsimp, simp].
   · intro h
     ext Y ⟨f, hf⟩
     convert h f hf
     rw [yonedaEquiv_naturality]
-    dsimp [yonedaEquiv]
-    simp
+    simp [yonedaEquiv]
 
 /-- The yoneda version of the sheaf condition is equivalent to the sheaf condition.
 

--- a/Mathlib/CategoryTheory/Sites/Limits.lean
+++ b/Mathlib/CategoryTheory/Sites/Limits.lean
@@ -139,9 +139,7 @@ instance (F : K ⥤ Sheaf J D) : CreatesLimit F (sheafToPresheaf J D) :=
   createsLimitOfReflectsIso fun E hE =>
     { liftedCone := ⟨⟨E.pt, isSheaf_of_isLimit _ _ hE⟩,
         ⟨fun _ => ⟨E.π.app _⟩, fun _ _ _ => Sheaf.Hom.ext <| E.π.naturality _⟩⟩
-      validLift := Cones.ext (eqToIso rfl) fun j => by
-        dsimp
-        simp
+      validLift := Cones.ext (eqToIso rfl) fun j => by simp
       makesLimit :=
         { lift := fun S => ⟨hE.lift ((sheafToPresheaf J D).mapCone S)⟩
           fac := fun S j => by

--- a/Mathlib/CategoryTheory/Sites/Plus.lean
+++ b/Mathlib/CategoryTheory/Sites/Plus.lean
@@ -49,7 +49,7 @@ def diagramPullback {X Y : C} (f : X ⟶ Y) : J.diagram P Y ⟶ (J.pullback f).o
   app S :=
     Multiequalizer.lift _ _ (fun I => Multiequalizer.ι (S.unop.index P) I.base) fun I =>
       Multiequalizer.condition (S.unop.index P) (Cover.Relation.mk' I.r.base)
-  naturality S T f := Multiequalizer.hom_ext _ _ _ (fun I => by dsimp; simp; rfl)
+  naturality S T f := Multiequalizer.hom_ext _ _ _ (fun I => by simp; rfl)
 
 /-- A natural transformation `P ⟶ Q` induces a natural transformation
 between diagrams whose colimits define the values of `plus`. -/
@@ -142,7 +142,7 @@ def plusMap {P Q : Cᵒᵖ ⥤ D} (η : P ⟶ Q) : J.plusObj P ⟶ J.plusObj Q w
       ι_colimMap_assoc, Category.assoc]
     simp_rw [← Category.assoc]
     congr 1
-    exact Multiequalizer.hom_ext _ _ _ (fun I => by dsimp; simp)
+    exact Multiequalizer.hom_ext _ _ _ (fun I => by simp)
 
 @[simp]
 theorem plusMap_id (P : Cᵒᵖ ⥤ D) : J.plusMap (𝟙 P) = 𝟙 _ := by
@@ -150,7 +150,6 @@ theorem plusMap_id (P : Cᵒᵖ ⥤ D) : J.plusMap (𝟙 P) = 𝟙 _ := by
   dsimp only [plusMap, plusObj]
   rw [J.diagramNatTrans_id, NatTrans.id_app]
   ext
-  dsimp
   simp
 
 @[simp]
@@ -200,7 +199,7 @@ theorem toPlus_naturality {P Q : Cᵒᵖ ⥤ D} (η : P ⟶ Q) :
   simp only [ι_colimMap, Category.assoc]
   simp_rw [← Category.assoc]
   congr 1
-  exact Multiequalizer.hom_ext _ _ _ (fun I => by dsimp; simp)
+  exact Multiequalizer.hom_ext _ _ _ (fun I => by simp)
 
 variable (D) in
 /-- The natural transformation from the identity functor to `plus`. -/
@@ -228,7 +227,7 @@ theorem plusMap_toPlus : J.plusMap (J.toPlus P) = J.toPlus (J.plusObj P) := by
   refine Multiequalizer.hom_ext _ _ _ (fun II => ?_)
   convert Multiequalizer.condition (S.unop.index P)
     { fst := I, snd := II.base, r.Z := II.Y, r.g₁ := II.f, r.g₂ := 𝟙 II.Y } using 1
-  all_goals dsimp; simp
+  all_goals simp
 
 theorem isIso_toPlus_of_isSheaf (hP : Presheaf.IsSheaf J P) : IsIso (J.toPlus P) := by
   rw [Presheaf.isSheaf_iff_multiequalizer] at hP
@@ -239,7 +238,7 @@ theorem isIso_toPlus_of_isSheaf (hP : Presheaf.IsSheaf J P) : IsIso (J.toPlus P)
     isIso_ι_of_isInitial (initialOpOfTerminal isTerminalTop) _
   intro S T e
   have : S.unop.toMultiequalizer P ≫ (J.diagram P X.unop).map e = T.unop.toMultiequalizer P :=
-    Multiequalizer.hom_ext _ _ _ (fun II => by dsimp; simp)
+    Multiequalizer.hom_ext _ _ _ (fun II => by simp)
   have :
     (J.diagram P X.unop).map e = inv (S.unop.toMultiequalizer P) ≫ T.unop.toMultiequalizer P := by
     simp [← this]

--- a/Mathlib/CategoryTheory/Subobject/Comma.lean
+++ b/Mathlib/CategoryTheory/Subobject/Comma.lean
@@ -63,9 +63,7 @@ theorem projectSubobject_factors [HasFiniteLimits C] [PreservesFiniteLimits T]
     {A : StructuredArrow S T} :
     ∀ P : Subobject A, ∃ q, q ≫ T.map (projectSubobject P).arrow = A.hom :=
   Subobject.ind _ fun P f hf =>
-    ⟨P.hom ≫ T.map (Subobject.underlyingIso _).inv, by
-      dsimp
-      simp [← T.map_comp]⟩
+    ⟨P.hom ≫ T.map (Subobject.underlyingIso _).inv, by simp [← T.map_comp]⟩
 
 /-- A subobject of the underlying object of a structured arrow can be lifted to a subobject of
     the structured arrow, provided that there is a morphism making the subobject into a structured
@@ -88,7 +86,7 @@ theorem lift_projectSubobject [HasFiniteLimits C] [PreservesFiniteLimits T]
       · fapply isoMk
         · exact Subobject.underlyingIso _
         · exact (cancel_mono (T.map f.right)).1 (by dsimp; simpa [← T.map_comp] using hq)
-      · exact ext _ _ (by dsimp; simp))
+      · exact ext _ _ (by simp))
 
 /-- If `A : S → T.obj B` is a structured arrow for `S : D` and `T : C ⥤ D`, then we can explicitly
     describe the subobjects of `A` as the subobjects `P` of `B` in `C` for which `A.hom` factors

--- a/Mathlib/CategoryTheory/Subobject/Lattice.lean
+++ b/Mathlib/CategoryTheory/Subobject/Lattice.lean
@@ -694,9 +694,7 @@ def subobjectOrderIso {X : C} (Y : Subobject X) : Subobject (Y : C) ≃o Set.Iic
       Set.mem_Iic.mpr (le_of_comm ((underlyingIso _).hom ≫ Z.arrow) (by simp))⟩
   invFun Z := Subobject.mk (ofLE _ _ Z.2)
   left_inv Z := mk_eq_of_comm _ (underlyingIso _) (by aesop_cat)
-  right_inv Z := Subtype.ext (mk_eq_of_comm _ (underlyingIso _) (by
-          dsimp
-          simp [← Iso.eq_inv_comp]))
+  right_inv Z := Subtype.ext (mk_eq_of_comm _ (underlyingIso _) (by simp [← Iso.eq_inv_comp]))
   map_rel_iff' {W Z} := by
     dsimp
     constructor

--- a/Mathlib/CategoryTheory/Triangulated/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Adjunction.lean
@@ -113,8 +113,7 @@ lemma isTriangulated_rightAdjoint [F.IsTriangulated] : G.IsTriangulated where
         simpa [homEquiv_unit, h₁'] using congr_arg (adj.homEquiv _ _).toFun hβ.symm)
     refine isomorphic_distinguished _ mem _ (Iso.symm ?_)
     refine Triangle.isoMk _ _ (Iso.refl _) (Iso.refl _) (asIso (adj.homEquiv Z T.obj₃ h)) ?_ ?_ ?_
-    · dsimp
-      simp
+    · simp
     · apply (adj.homEquiv _ _).symm.injective
       dsimp
       simp only [homEquiv_unit, homEquiv_counit, Functor.map_comp, assoc,

--- a/Mathlib/CategoryTheory/Triangulated/HomologicalFunctor.lean
+++ b/Mathlib/CategoryTheory/Triangulated/HomologicalFunctor.lean
@@ -209,7 +209,7 @@ lemma homologySequence_exact₂ :
     (Triangle.shift_distinguished _ hT n₀))
   exact ShortComplex.isoMk ((F.isoShift n₀).app _)
     (n₀.negOnePow • ((F.isoShift n₀).app _)) ((F.isoShift n₀).app _)
-    (by dsimp; simp) (by dsimp; simp)
+    (by simp) (by simp)
 
 lemma homologySequence_exact₃ :
     (ShortComplex.mk _ _ (F.comp_homologySequenceδ T hT _ _ h)).Exact := by

--- a/Mathlib/CategoryTheory/Triangulated/Opposite/Functor.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Opposite/Functor.lean
@@ -170,7 +170,7 @@ noncomputable def mapTriangleOpCompTriangleOpEquivalenceFunctorApp (T : Triangle
     (triangleOpEquivalence D).functor.obj (op (F.mapTriangle.obj T)) ≅
       F.op.mapTriangle.obj ((triangleOpEquivalence C).functor.obj (op T)) :=
   Triangle.isoMk _ _ (Iso.refl _) (Iso.refl _) (Iso.refl _)
-    (by dsimp; simp) (by dsimp; simp) (by
+    (by simp) (by simp) (by
       dsimp
       simp only [map_comp, shift_map_op, map_id, comp_id, op_comp, op_unop,
         map_opShiftFunctorEquivalence_counitIso_inv_app_unop,

--- a/Mathlib/CategoryTheory/Triangulated/TStructure/Basic.lean
+++ b/Mathlib/CategoryTheory/Triangulated/TStructure/Basic.lean
@@ -83,7 +83,7 @@ lemma exists_triangle (A : C) (n₀ n₁ : ℤ) (h : n₀ + 1 = n₁) :
   have hT' : Triangle.mk (T.mor₁ ≫ e.hom) (e.inv ≫ T.mor₂) T.mor₃ ∈ distTriang C := by
     refine isomorphic_distinguished _ (Triangle.shift_distinguished _ mem (-n₀)) _ ?_
     refine Triangle.isoMk _ _ (Iso.refl _) e.symm (Iso.refl _) ?_ ?_ ?_
-    all_goals dsimp; simp [T]
+    all_goals simp [T]
   exact ⟨_, _, t.le_shift _ _ _ (neg_add_cancel n₀) _ hX,
     t.ge_shift _ _ _ (by omega) _ hY, _, _, _, hT'⟩
 

--- a/Mathlib/CategoryTheory/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Yoneda.lean
@@ -52,7 +52,6 @@ namespace Yoneda
 
 theorem obj_map_id {X Y : C} (f : op X ⟶ op Y) :
     (yoneda.obj X).map f (𝟙 X) = (yoneda.map f.unop).app (op Y) (𝟙 Y) := by
-  dsimp
   simp
 
 @[simp]
@@ -469,7 +468,6 @@ lemma yonedaEquiv_naturality {X Y : C} {F : Cᵒᵖ ⥤ Type v₁} (f : yoneda.o
     (g : Y ⟶ X) : F.map g.op (yonedaEquiv f) = yonedaEquiv (yoneda.map g ≫ f) := by
   change (f.app (op X) ≫ F.map g.op) (𝟙 X) = f.app (op Y) (𝟙 Y ≫ g)
   rw [← f.naturality]
-  dsimp
   simp
 
 /-- Variant of `yonedaEquiv_naturality` with general `g`. This is technically strictly more general
@@ -681,7 +679,6 @@ lemma coyonedaEquiv_naturality {X Y : C} {F : C ⥤ Type v₁} (f : coyoneda.obj
     (g : X ⟶ Y) : F.map g (coyonedaEquiv f) = coyonedaEquiv (coyoneda.map g.op ≫ f) := by
   change (f.app X ≫ F.map g) (𝟙 X) = f.app Y (g ≫ 𝟙 Y)
   rw [← f.naturality]
-  dsimp
   simp
 
 lemma coyonedaEquiv_comp {X : C} {F G : C ⥤ Type v₁} (α : coyoneda.obj (op X) ⟶ F) (β : F ⟶ G) :

--- a/Mathlib/Data/DFinsupp/Defs.lean
+++ b/Mathlib/Data/DFinsupp/Defs.lean
@@ -1018,7 +1018,7 @@ theorem support_filter (f : Π₀ i, β i) : (f.filter p).support = {x ∈ f.sup
 
 theorem subtypeDomain_def (f : Π₀ i, β i) :
     f.subtypeDomain p = mk (f.support.subtype p) fun i => f i := by
-  ext i; by_cases h2 : f i ≠ 0 <;> try simp at h2; dsimp; simp [h2]
+  ext i; by_cases h2 : f i ≠ 0 <;> try simp at h2; simp [h2]
 
 @[simp]
 theorem support_subtypeDomain {f : Π₀ i, β i} :

--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -398,7 +398,7 @@ theorem append_injective_iff {xs : Fin m → α} {ys : Fin n → α} :
   let finSumFinEquiv : Fin m ⊕ Fin n ≃ Fin (m + n) :=
   { toFun := Sum.elim (Fin.castAdd n) (Fin.natAdd m)
     invFun i := @Fin.addCases m n (fun _ => Fin m ⊕ Fin n) Sum.inl Sum.inr i
-    left_inv x := by rcases x with y | y <;> dsimp <;> simp
+    left_inv x := by rcases x with y | y <;> simp
     right_inv x := by refine Fin.addCases (fun i => ?_) (fun i => ?_) x <;> simp }
   rw [← Sum.elim_injective, ← append_comp_sumElim, ← finSumFinEquiv.injective_comp,
     Equiv.coe_fn_mk]

--- a/Mathlib/Data/Int/Bitwise.lean
+++ b/Mathlib/Data/Int/Bitwise.lean
@@ -385,7 +385,7 @@ theorem shiftLeft_add : ∀ (m : ℤ) (n : ℕ) (k : ℤ), m <<< (n + k) = (m <<
   | (m : ℕ), n, -[k+1] =>
     subNatNat_elim n k.succ (fun n k i => (↑m) <<< i = (Nat.shiftLeft' false m n) >>> k)
       (fun (i n : ℕ) =>
-        by dsimp; simp [← Nat.shiftLeft_sub _ , Nat.add_sub_cancel_left])
+        by simp [← Nat.shiftLeft_sub _ , Nat.add_sub_cancel_left])
       fun i n => by
         dsimp
         simp_rw [negSucc_eq, shiftLeft_neg, Nat.shiftLeft'_false, Nat.shiftRight_add,

--- a/Mathlib/Data/Num/ZNum.lean
+++ b/Mathlib/Data/Num/ZNum.lean
@@ -320,10 +320,10 @@ theorem cmp_to_int : ∀ m n, (Ordering.casesOn (cmp m n) ((m : ℤ) < n) (m = n
   | 0, 0 => rfl
   | pos a, pos b => by
     have := PosNum.cmp_to_nat a b; revert this; dsimp [cmp]
-    cases PosNum.cmp a b <;> dsimp <;> [simp; exact congr_arg pos; simp [GT.gt]]
+    cases PosNum.cmp a b <;> [simp; exact congr_arg pos; simp [GT.gt]]
   | neg a, neg b => by
     have := PosNum.cmp_to_nat b a; revert this; dsimp [cmp]
-    cases PosNum.cmp b a <;> dsimp <;> [simp; simp +contextual; simp [GT.gt]]
+    cases PosNum.cmp b a <;> [simp; simp +contextual; simp [GT.gt]]
   | pos _, 0 => PosNum.cast_pos _
   | pos _, neg _ => lt_trans (neg_lt_zero.2 <| PosNum.cast_pos _) (PosNum.cast_pos _)
   | 0, neg _ => neg_lt_zero.2 <| PosNum.cast_pos _

--- a/Mathlib/Data/Rat/Defs.lean
+++ b/Mathlib/Data/Rat/Defs.lean
@@ -177,7 +177,7 @@ lemma mk'_mul_mk' (n₁ n₂ : ℤ) (d₁ d₂ : ℕ) (hd₁ hd₂ hnd₁ hnd₂
     (h₂₁ : n₂.natAbs.Coprime d₁) :
     mk' n₁ d₁ hd₁ hnd₁ * mk' n₂ d₂ hd₂ hnd₂ = mk' (n₁ * n₂) (d₁ * d₂) (Nat.mul_ne_zero hd₁ hd₂) (by
       rw [Int.natAbs_mul]; exact (hnd₁.mul h₂₁).mul_right (h₁₂.mul hnd₂)) := by
-  rw [mul_def]; dsimp; simp [mk_eq_normalize]
+  rw [mul_def]; simp [mk_eq_normalize]
 
 lemma mul_eq_mkRat (q r : ℚ) : q * r = mkRat (q.num * r.num) (q.den * r.den) := by
   rw [mul_def, normalize_eq_mkRat]

--- a/Mathlib/Data/Vector/Mem.lean
+++ b/Mathlib/Data/Vector/Mem.lean
@@ -32,7 +32,6 @@ theorem mem_iff_get (v : Vector α n) : a ∈ v.toList ↔ ∃ i, v.get i = a :=
 
 theorem notMem_nil : a ∉ (Vector.nil : Vector α 0).toList := by
   unfold Vector.nil
-  dsimp
   simp
 
 @[deprecated (since := "2025-05-23")] alias not_mem_nil := notMem_nil

--- a/Mathlib/Geometry/RingedSpace/PresheafedSpace/HasColimits.lean
+++ b/Mathlib/Geometry/RingedSpace/PresheafedSpace/HasColimits.lean
@@ -69,7 +69,6 @@ theorem map_comp_c_app (F : J ⥤ PresheafedSpace.{_, _, v} C) {j₁ j₂ j₃}
           (pushforwardEq (congr_arg Hom.base (F.map_comp f g).symm) _).hom.app U := by
   simp [PresheafedSpace.congr_app (F.map_comp f g)]
 
--- See note [dsimp, simp]
 /-- Given a diagram of `PresheafedSpace C`s, its colimit is computed by pushing the sheaves onto
 the colimit of the underlying spaces, and taking componentwise limit.
 This is the componentwise diagram for an open set `U` of the colimit of the underlying spaces.
@@ -81,9 +80,7 @@ def componentwiseDiagram (F : J ⥤ PresheafedSpace.{_, _, v} C) [HasColimit F]
   map {j k} f := (F.map f.unop).c.app _ ≫
     (F.obj (unop k)).presheaf.map (eqToHom (by rw [← colimit.w F f.unop, comp_base]; rfl))
   map_comp {i j k} f g := by
-    dsimp
-    simp only [assoc, CategoryTheory.NatTrans.naturality_assoc]
-    simp
+    simp [assoc, CategoryTheory.NatTrans.naturality_assoc]
 
 variable [HasColimitsOfShape J TopCat.{v}]
 

--- a/Mathlib/Geometry/RingedSpace/PresheafedSpace/HasColimits.lean
+++ b/Mathlib/Geometry/RingedSpace/PresheafedSpace/HasColimits.lean
@@ -80,7 +80,8 @@ def componentwiseDiagram (F : J ⥤ PresheafedSpace.{_, _, v} C) [HasColimit F]
   map {j k} f := (F.map f.unop).c.app _ ≫
     (F.obj (unop k)).presheaf.map (eqToHom (by rw [← colimit.w F f.unop, comp_base]; rfl))
   map_comp {i j k} f g := by
-    simp [assoc, CategoryTheory.NatTrans.naturality_assoc]
+    simp only [assoc, CategoryTheory.NatTrans.naturality_assoc]
+    simp
 
 variable [HasColimitsOfShape J TopCat.{v}]
 

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Prod.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Prod.lean
@@ -157,7 +157,7 @@ lemma toProd_comp_ofProd : (toProd Q₁ Q₂).comp (ofProd Q₁ Q₂) = AlgHom.i
       LinearMap.map_zero, zero_add]
 
 lemma ofProd_comp_toProd : (ofProd Q₁ Q₂).comp (toProd Q₁ Q₂) = AlgHom.id _ _ := by
-  ext <;> (dsimp; simp)
+  ext <;> simp
 
 /-- The Clifford algebra over an orthogonal direct sum of quadratic vector spaces is isomorphic
 as an algebra to the graded tensor product of the Clifford algebras of each space.

--- a/Mathlib/LinearAlgebra/TensorProduct/Graded/External.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Graded/External.lean
@@ -84,7 +84,6 @@ theorem gradedCommAux_lof_tmul (i j : ι) (a : 𝒜 i) (b : ℬ j) :
     gradedCommAux R 𝒜 ℬ (lof R _ 𝒜ℬ (i, j) (a ⊗ₜ b)) =
       (-1 : ℤˣ)^(j * i) • lof R _ ℬ𝒜 (j, i) (b ⊗ₜ a) := by
   rw [gradedCommAux]
-  dsimp
   simp [mul_comm i j]
 
 @[simp]

--- a/Mathlib/Logic/Encodable/Basic.lean
+++ b/Mathlib/Logic/Encodable/Basic.lean
@@ -136,7 +136,7 @@ theorem decode_unit_succ (n) : decode (succ n) = (none : Option PUnit) :=
 instance _root_.Option.encodable {α : Type*} [h : Encodable α] : Encodable (Option α) :=
   ⟨fun o => Option.casesOn o Nat.zero fun a => succ (encode a), fun n =>
     Nat.casesOn n (some none) fun m => (decode m).map some, fun o => by
-    cases o <;> dsimp; simp [encodek, Nat.succ_ne_zero]⟩
+    cases o <;> simp [encodek, Nat.succ_ne_zero]⟩
 
 @[simp]
 theorem encode_none [Encodable α] : encode (@none α) = 0 :=

--- a/Mathlib/Logic/Equiv/Fin/Basic.lean
+++ b/Mathlib/Logic/Equiv/Fin/Basic.lean
@@ -54,7 +54,7 @@ def finSuccEquiv' (i : Fin (n + 1)) : Fin (n + 1) ≃ Option (Fin n) where
   toFun := i.insertNth none some
   invFun x := x.casesOn' i (Fin.succAbove i)
   left_inv x := Fin.succAboveCases i (by simp) (fun j => by simp) x
-  right_inv x := by cases x <;> dsimp <;> simp
+  right_inv x := by cases x <;> simp
 
 @[simp]
 theorem finSuccEquiv'_at (i : Fin (n + 1)) : (finSuccEquiv' i) i = none := by
@@ -220,7 +220,7 @@ def Equiv.embeddingFinSucc (n : ℕ) (ι : Type*) :
 def finSumFinEquiv : Fin m ⊕ Fin n ≃ Fin (m + n) where
   toFun := Sum.elim (Fin.castAdd n) (Fin.natAdd m)
   invFun i := @Fin.addCases m n (fun _ => Fin m ⊕ Fin n) Sum.inl Sum.inr i
-  left_inv x := by rcases x with y | y <;> dsimp <;> simp
+  left_inv x := by rcases x with y | y <;> simp
   right_inv x := by refine Fin.addCases (fun i => ?_) (fun i => ?_) x <;> simp
 
 @[simp]

--- a/Mathlib/MeasureTheory/Covering/Besicovitch.lean
+++ b/Mathlib/MeasureTheory/Covering/Besicovitch.lean
@@ -431,13 +431,13 @@ theorem color_lt {i : Ordinal.{u}} (hi : i < p.lastStep) {N : ℕ}
       hlast := by
         intro a ha
         have I : (a : ℕ) < N := ha
-        have : G a < G (Fin.last N) := by dsimp; simp [G, I.ne, (hg a I).1]
+        have : G a < G (Fin.last N) := by simp [G, I.ne, (hg a I).1]
         exact Gab _ _ this
       inter := by
         intro a ha
         have I : (a : ℕ) < N := ha
         have J : G (Fin.last N) = i := by dsimp; simp only [G, if_true, eq_self_iff_true]
-        have K : G a = g a := by dsimp [G]; simp [I.ne, (hg a I).1]
+        have K : G a = g a := by simp [G, I.ne, (hg a I).1]
         convert dist_le_add_of_nonempty_closedBall_inter_closedBall (hg _ I).2.1 }
   -- this is a contradiction
   exact hN.false sc

--- a/Mathlib/RepresentationTheory/Basic.lean
+++ b/Mathlib/RepresentationTheory/Basic.lean
@@ -354,7 +354,6 @@ noncomputable def ofMulAction : Representation k G (H →₀ k) where
   toFun g := Finsupp.lmapDomain k k (g • ·)
   map_one' := by
     ext x y
-    dsimp
     simp
   map_mul' x y := by
     ext z w

--- a/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
@@ -597,7 +597,6 @@ theorem εToSingle₀_comp_eq :
       (forget₂ToModuleCatHomotopyEquiv k G).hom := by
   dsimp
   ext1
-  dsimp
   simpa using (forget₂ToModuleCatHomotopyEquiv_f_0_eq k G).symm
 
 theorem quasiIso_forget₂_εToSingle₀ :

--- a/Mathlib/RingTheory/Kaehler/Basic.lean
+++ b/Mathlib/RingTheory/Kaehler/Basic.lean
@@ -550,7 +550,7 @@ noncomputable def KaehlerDifferential.derivationQuotKerTotal :
   map_one_eq_zero' := KaehlerDifferential.kerTotal_mkQ_single_algebraMap_one _ _ _
   leibniz' a b :=
     (KaehlerDifferential.kerTotal_mkQ_single_mul _ _ _ _ _).trans
-      (by simp_rw [← Finsupp.smul_single_one _ (1 * _ : S)]; simp)
+      (by simp_rw [← Finsupp.smul_single_one _ (1 * _ : S)]; dsimp; simp)
 
 theorem KaehlerDifferential.derivationQuotKerTotal_apply (x) :
     KaehlerDifferential.derivationQuotKerTotal R S x = 1𝖣x :=

--- a/Mathlib/RingTheory/Kaehler/Basic.lean
+++ b/Mathlib/RingTheory/Kaehler/Basic.lean
@@ -550,7 +550,7 @@ noncomputable def KaehlerDifferential.derivationQuotKerTotal :
   map_one_eq_zero' := KaehlerDifferential.kerTotal_mkQ_single_algebraMap_one _ _ _
   leibniz' a b :=
     (KaehlerDifferential.kerTotal_mkQ_single_mul _ _ _ _ _).trans
-      (by simp_rw [← Finsupp.smul_single_one _ (1 * _ : S)]; dsimp; simp)
+      (by simp_rw [← Finsupp.smul_single_one _ (1 * _ : S)]; simp)
 
 theorem KaehlerDifferential.derivationQuotKerTotal_apply (x) :
     KaehlerDifferential.derivationQuotKerTotal R S x = 1𝖣x :=
@@ -573,7 +573,7 @@ theorem KaehlerDifferential.kerTotal_eq :
     rw [← KaehlerDifferential.derivationQuotKerTotal_lift_comp_linearCombination]
     exact LinearMap.ker_le_ker_comp _ _
   · rw [KaehlerDifferential.kerTotal, Submodule.span_le]
-    rintro _ ((⟨⟨x, y⟩, rfl⟩ | ⟨⟨x, y⟩, rfl⟩) | ⟨x, rfl⟩) <;> dsimp <;> simp [LinearMap.mem_ker]
+    rintro _ ((⟨⟨x, y⟩, rfl⟩ | ⟨⟨x, y⟩, rfl⟩) | ⟨x, rfl⟩) <;> simp [LinearMap.mem_ker]
 
 theorem KaehlerDifferential.linearCombination_surjective :
     Function.Surjective (Finsupp.linearCombination S (KaehlerDifferential.D R S)) := by


### PR DESCRIPTION
Now that my `simp` optimizations have landed, I'm testing the hypothesis that `dsimp` followed by `simp` is slower than just `simp`.

By the way, I can't find the [dsimp, simp] library note anywhere. Has it disappeared?

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
