### PR TITLE
[Merged by Bors] - fix: use exit instead of return

### DIFF
--- a/scripts/update_nolints_CI.sh
+++ b/scripts/update_nolints_CI.sh
@@ -26,7 +26,7 @@ pr_body='I am happy to remove some nolints for you!'
 
 git checkout -b "$branch_name"
 git add scripts/nolints.json
-git commit -m "$pr_title" || { echo "No changes to commit" && return 0; }
+git commit -m "$pr_title" || { echo "No changes to commit" && exit 0; }
 
 gh_api() {
   local url="$1"


### PR DESCRIPTION
Follow-up to #25387 
cf. https://github.com/leanprover-community/mathlib4/actions/runs/15419000071/job/43388752817#step:10:24

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
