### PR TITLE
[Merged by Bors] - chore(RingTheory): move lemmas to the right place

### DIFF
--- a/Mathlib/RingTheory/KrullDimension/Module.lean
+++ b/Mathlib/RingTheory/KrullDimension/Module.lean
@@ -79,7 +79,7 @@ end Module
 
 open Ideal IsLocalRing
 
-lemma support_of_supportDim_eq_zero [IsLocalRing R] [Module.Finite R N]
+lemma support_of_supportDim_eq_zero [IsLocalRing R]
     (dim : Module.supportDim R N = 0) :
     Module.support R N = PrimeSpectrum.zeroLocus (maximalIdeal R) := by
   let _ : Nontrivial N := by simp [← Module.supportDim_ne_bot_iff_nontrivial R, dim]

--- a/Mathlib/RingTheory/KrullDimension/Module.lean
+++ b/Mathlib/RingTheory/KrullDimension/Module.lean
@@ -4,8 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Nailin Guan
 -/
 import Mathlib.RingTheory.KrullDimension.NonZeroDivisors
-import Mathlib.RingTheory.Spectrum.Prime.Topology
-import Mathlib.RingTheory.Support
+import Mathlib.RingTheory.Spectrum.Prime.Module
 
 /-!
 
@@ -80,25 +79,11 @@ end Module
 
 open Ideal IsLocalRing
 
-lemma IsLocalRing.maximalIdeal_mem_support [IsLocalRing R] [Module.Finite R M] [Nontrivial M] :
-    IsLocalRing.closedPoint R ∈ Module.support R M := by
-  simp only [Module.support_eq_zeroLocus, PrimeSpectrum.mem_zeroLocus, SetLike.coe_subset_coe]
-  apply IsLocalRing.le_maximalIdeal
-  simpa [Module.annihilator_eq_top_iff.not, not_subsingleton_iff_nontrivial]
-
-lemma zeroLocus_eq_singleton (m : Ideal R) [max : m.IsMaximal] :
-    PrimeSpectrum.zeroLocus m = {⟨m, IsMaximal.isPrime' m⟩} := by
-  ext I
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · simp only [PrimeSpectrum.mem_zeroLocus, SetLike.coe_subset_coe] at h
-    simpa using PrimeSpectrum.ext_iff.mpr (Ideal.IsMaximal.eq_of_le max I.2.ne_top h).symm
-  · simp [Set.mem_singleton_iff.mp h]
-
-lemma support_of_dimension_zero [IsLocalRing R] [Module.Finite R N]
+lemma support_of_supportDim_eq_zero [IsLocalRing R] [Module.Finite R N]
     (dim : Module.supportDim R N = 0) :
     Module.support R N = PrimeSpectrum.zeroLocus (maximalIdeal R) := by
   let _ : Nontrivial N := by simp [← Module.supportDim_ne_bot_iff_nontrivial R, dim]
-  rw [zeroLocus_eq_singleton]
+  rw [PrimeSpectrum.zeroLocus_eq_singleton]
   apply le_antisymm
   · intro p hp
     by_contra nmem
@@ -109,6 +94,6 @@ lemma support_of_dimension_zero [IsLocalRing R] [Module.Finite R N]
       simp only [Module.supportDim, gt_iff_lt, Order.krullDim_pos_iff, Subtype.exists,
         Subtype.mk_lt_mk, exists_prop]
       use p
-      simpa [hp] using ⟨_, IsLocalRing.maximalIdeal_mem_support R N, this⟩
+      simpa [hp] using ⟨_, IsLocalRing.closedPoint_mem_support R N, this⟩
     exact (ne_of_lt this) dim.symm
-  · simpa using IsLocalRing.maximalIdeal_mem_support R N
+  · simpa using IsLocalRing.closedPoint_mem_support R N

--- a/Mathlib/RingTheory/Spectrum/Prime/Basic.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Basic.lean
@@ -418,6 +418,14 @@ lemma isMax_iff {x : PrimeSpectrum R} :
   obtain ⟨m, hm, hm'⟩ := Ideal.exists_le_maximal I e
   exact hx.not_lt (show x < ⟨m, hm.isPrime⟩ from hI.trans_le hm')
 
+lemma zeroLocus_eq_singleton (m : Ideal R) [m.IsMaximal] :
+    zeroLocus m = {⟨m, inferInstance⟩} := by
+  ext I
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · simp only [mem_zeroLocus, SetLike.coe_subset_coe] at h
+    simpa using PrimeSpectrum.ext_iff.mpr (Ideal.IsMaximal.eq_of_le ‹_› I.2.ne_top h).symm
+  · simp [Set.mem_singleton_iff.mp h]
+
 lemma isMin_iff {x : PrimeSpectrum R} :
     IsMin x ↔ x.asIdeal ∈ minimalPrimes R := by
   show IsMin _ ↔ Minimal (fun q : Ideal R ↦ q.IsPrime ∧ ⊥ ≤ q) _

--- a/Mathlib/RingTheory/Spectrum/Prime/Module.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Module.lean
@@ -23,8 +23,11 @@ import Mathlib.RingTheory.Support
 variable {R A M : Type*} [CommRing R] [AddCommGroup M] [Module R M]
   [CommRing A] [Algebra R A] [Module A M]
 
-
-section support
+variable (R M) in
+lemma IsLocalRing.closedPoint_mem_support [IsLocalRing R] [Nontrivial M] :
+    IsLocalRing.closedPoint R ∈ Module.support R M := by
+  obtain ⟨p, hp⟩ := (Module.nonempty_support_iff (R := R)).mpr ‹_›
+  exact Module.mem_support_mono le_top hp
 
 /-- `M[1/f] = 0` if and only if `D(f) ∩ Supp M = 0`. -/
 lemma LocalizedModule.subsingleton_iff_disjoint {f : R} :
@@ -52,5 +55,3 @@ lemma Module.support_subset_preimage_comap [IsScalarTower R A M] :
     ne_eq, not_imp_not] at hx ⊢
   obtain ⟨m, hm⟩ := hx
   exact ⟨m, fun r e ↦ hm _ (by simpa)⟩
-
-end support

--- a/Mathlib/RingTheory/Support.lean
+++ b/Mathlib/RingTheory/Support.lean
@@ -71,6 +71,11 @@ lemma Module.mem_support_iff_exists_annihilator :
   rw [Module.mem_support_iff']
   simp_rw [not_imp_not, SetLike.le_def, Submodule.mem_annihilator_span_singleton]
 
+lemma Module.mem_support_mono {p q : PrimeSpectrum R} (H : p ≤ q) (hp : p ∈ Module.support R M) :
+    q ∈ Module.support R M := by
+  rw [Module.mem_support_iff_exists_annihilator] at hp ⊢
+  exact ⟨_, hp.choose_spec.trans H⟩
+
 lemma Module.mem_support_iff_of_span_eq_top {s : Set M} (hs : Submodule.span R s = ⊤) :
     p ∈ Module.support R M ↔ ∃ m ∈ s, (R ∙ m).annihilator ≤ p.asIdeal := by
   constructor
@@ -116,6 +121,11 @@ lemma Module.support_eq_empty_iff :
     ← LocalizedModule.subsingleton_iff_support_subset, LocalizedModule.subsingleton_iff,
     subsingleton_iff_forall_eq 0]
   simp only [Submonoid.powers_one, Submonoid.mem_bot, exists_eq_left, one_smul]
+
+lemma Module.nonempty_support_iff :
+    (Module.support R M).Nonempty ↔ Nontrivial M := by
+  rw [Set.nonempty_iff_ne_empty, ne_eq,
+    Module.support_eq_empty_iff, ← not_subsingleton_iff_nontrivial]
 
 lemma Module.support_eq_empty [Subsingleton M] :
     Module.support R M = ∅ :=


### PR DESCRIPTION
The lemmas were just added an hour ago in #24771 so I don't think deprecations are necessary.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
