### PR TITLE
[Merged by Bors] - feat (MeasureTheory/Measure/Dirac): a point being in a measurable set is equivalent with dirac measure evaluation

### DIFF
--- a/Mathlib/MeasureTheory/Measure/Dirac.lean
+++ b/Mathlib/MeasureTheory/Measure/Dirac.lean
@@ -179,6 +179,16 @@ instance Measure.dirac.isProbabilityMeasure {x : α} : IsProbabilityMeasure (dir
 instance Measure.dirac.instIsFiniteMeasure {a : α} : IsFiniteMeasure (dirac a) := inferInstance
 instance Measure.dirac.instSigmaFinite {a : α} : SigmaFinite (dirac a) := inferInstance
 
+theorem mem_dirac_eq_one_iff {a : α} (hs : MeasurableSet s)
+    : dirac a s = 1 ↔ a ∈ s := by
+  rw [Iff.symm (prob_compl_eq_zero_iff hs), ← mem_ae_iff]
+  apply mem_ae_dirac_iff hs
+
+theorem mem_dirac_eq_zero_iff {a : α} (hs : MeasurableSet s)
+    : dirac a s = 0 ↔ a ∉ s := by
+  rw [Eq.symm (compl_compl s), ← mem_ae_iff, notMem_compl_iff]
+  apply mem_ae_dirac_iff (MeasurableSet.compl_iff.mpr hs)
+
 theorem restrict_dirac' (hs : MeasurableSet s) [Decidable (a ∈ s)] :
     (Measure.dirac a).restrict s = if a ∈ s then Measure.dirac a else 0 := by
   split_ifs with has

--- a/Mathlib/MeasureTheory/Measure/Dirac.lean
+++ b/Mathlib/MeasureTheory/Measure/Dirac.lean
@@ -179,11 +179,11 @@ instance Measure.dirac.isProbabilityMeasure {x : α} : IsProbabilityMeasure (dir
 instance Measure.dirac.instIsFiniteMeasure {a : α} : IsFiniteMeasure (dirac a) := inferInstance
 instance Measure.dirac.instSigmaFinite {a : α} : SigmaFinite (dirac a) := inferInstance
 
-theorem mem_dirac_eq_one_iff (hs : MeasurableSet s) : dirac a s = 1 ↔ a ∈ s := by
+theorem dirac_eq_one_iff_mem (hs : MeasurableSet s) : dirac a s = 1 ↔ a ∈ s := by
   rw [Iff.symm (prob_compl_eq_zero_iff hs), ← mem_ae_iff]
   apply mem_ae_dirac_iff hs
 
-theorem mem_dirac_eq_zero_iff (hs : MeasurableSet s) : dirac a s = 0 ↔ a ∉ s := by
+theorem dirac_eq_zero_iff_not_mem (hs : MeasurableSet s) : dirac a s = 0 ↔ a ∉ s := by
   rw [Eq.symm (compl_compl s), ← mem_ae_iff, notMem_compl_iff]
   apply mem_ae_dirac_iff (MeasurableSet.compl_iff.mpr hs)
 

--- a/Mathlib/MeasureTheory/Measure/Dirac.lean
+++ b/Mathlib/MeasureTheory/Measure/Dirac.lean
@@ -179,13 +179,11 @@ instance Measure.dirac.isProbabilityMeasure {x : α} : IsProbabilityMeasure (dir
 instance Measure.dirac.instIsFiniteMeasure {a : α} : IsFiniteMeasure (dirac a) := inferInstance
 instance Measure.dirac.instSigmaFinite {a : α} : SigmaFinite (dirac a) := inferInstance
 
-theorem mem_dirac_eq_one_iff {a : α} (hs : MeasurableSet s)
-    : dirac a s = 1 ↔ a ∈ s := by
+theorem mem_dirac_eq_one_iff (hs : MeasurableSet s) : dirac a s = 1 ↔ a ∈ s := by
   rw [Iff.symm (prob_compl_eq_zero_iff hs), ← mem_ae_iff]
   apply mem_ae_dirac_iff hs
 
-theorem mem_dirac_eq_zero_iff {a : α} (hs : MeasurableSet s)
-    : dirac a s = 0 ↔ a ∉ s := by
+theorem mem_dirac_eq_zero_iff (hs : MeasurableSet s) : dirac a s = 0 ↔ a ∉ s := by
   rw [Eq.symm (compl_compl s), ← mem_ae_iff, notMem_compl_iff]
   apply mem_ae_dirac_iff (MeasurableSet.compl_iff.mpr hs)
 

--- a/Mathlib/MeasureTheory/Measure/Dirac.lean
+++ b/Mathlib/MeasureTheory/Measure/Dirac.lean
@@ -180,11 +180,11 @@ instance Measure.dirac.instIsFiniteMeasure {a : α} : IsFiniteMeasure (dirac a) 
 instance Measure.dirac.instSigmaFinite {a : α} : SigmaFinite (dirac a) := inferInstance
 
 theorem dirac_eq_one_iff_mem (hs : MeasurableSet s) : dirac a s = 1 ↔ a ∈ s := by
-  rw [Iff.symm (prob_compl_eq_zero_iff hs), ← mem_ae_iff]
+  rw [← prob_compl_eq_zero_iff hs, ← mem_ae_iff]
   apply mem_ae_dirac_iff hs
 
 theorem dirac_eq_zero_iff_not_mem (hs : MeasurableSet s) : dirac a s = 0 ↔ a ∉ s := by
-  rw [Eq.symm (compl_compl s), ← mem_ae_iff, notMem_compl_iff]
+  rw [← compl_compl s, ← mem_ae_iff, notMem_compl_iff]
   apply mem_ae_dirac_iff (MeasurableSet.compl_iff.mpr hs)
 
 theorem restrict_dirac' (hs : MeasurableSet s) [Decidable (a ∈ s)] :


### PR DESCRIPTION
Mathlib has `mem_ae_dirac_iff` that provides `s ∈ ae (dirac a) ↔ a ∈ s`, which expands to `(dirac a) sᶜ = 0 ↔ a ∈ s`. A more natural statement (arguably) is `(dirac a) s = 1 ↔ a ∈ s`.

This feature adds `(dirac a) s = 1 ↔ a ∈ s` and a companion theorem `(dirac a) s = 0 ↔ a ∉ s`.

As an example, suppose we have
```
hs : MeasurableSet s
this : f i ∈ s
⊢ (dirac (f i)) s = 1
```
This goal can be closed with `rwa [mem_dirac_eq_one_iff hs]` if this feature is merged.

(Note, the proofs depend on `dirac` being a `ProbabilityMeasure`, hence why the theorems are where they are in Dirac.lean.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
