### PR TITLE
[Merged by Bors] - chore: shake ignores the imports of `Mathlib.Init`

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -193,7 +193,7 @@
   "Mathlib.Util.WithWeakNamespace",
   "Qq"],
  "ignoreAll":
- ["Batteries.Tactic.Basic", "Mathlib.Mathport.Syntax", "Mathlib.Tactic.Linter"],
+ ["Batteries.Tactic.Basic", "Mathlib.Mathport.Syntax", "Mathlib.Tactic.Linter", "Mathlib.Init"],
  "ignore":
  {"Mathlib.Util.Notation3": ["Lean.Elab.BuiltinCommand"],
   "Mathlib.Topology.UniformSpace.Defs": ["Mathlib.Tactic.Monotonicity.Basic"],
@@ -396,20 +396,6 @@
   "Mathlib.Lean.Meta": ["Batteries.Logic"],
   "Mathlib.Lean.Expr.ExtraRecognizers": ["Mathlib.Data.Set.Operations"],
   "Mathlib.Lean.Expr.Basic": ["Batteries.Logic"],
-  "Mathlib.Init":
-  ["Mathlib.Tactic.Linter.DeprecatedSyntaxLinter",
-   "Mathlib.Tactic.Linter.DirectoryDependency",
-   "Mathlib.Tactic.Linter.DocPrime",
-   "Mathlib.Tactic.Linter.DocString",
-   "Mathlib.Tactic.Linter.FlexibleLinter",
-   "Mathlib.Tactic.Linter.GlobalAttributeIn",
-   "Mathlib.Tactic.Linter.HashCommandLinter",
-   "Mathlib.Tactic.Linter.Lint",
-   "Mathlib.Tactic.Linter.Multigoal",
-   "Mathlib.Tactic.Linter.OldObtain",
-   "Mathlib.Tactic.Linter.Style",
-   "Mathlib.Tactic.Linter.UnusedTactic",
-   "Mathlib.Tactic.Linter.UnusedTacticExtension"],
   "Mathlib.GroupTheory.MonoidLocalization.Basic": ["Mathlib.Init.Data.Prod"],
   "Mathlib.Geometry.Manifold.Sheaf.Smooth":
   ["Mathlib.CategoryTheory.Sites.Whiskering"],


### PR DESCRIPTION
This PR makes `shake` ignore the imports of `Mathlib.Init` in bulk.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
