### PR TITLE
[Merged by Bors] - chore(CategoryTheory/IsConnected): register a `Trans` instance on Zigzags

### DIFF
--- a/Mathlib/CategoryTheory/IsConnected.lean
+++ b/Mathlib/CategoryTheory/IsConnected.lean
@@ -304,6 +304,9 @@ theorem zigzag_equivalence : _root_.Equivalence (@Zigzag J _) :=
     Zigzag j₁ j₃ :=
   zigzag_equivalence.trans h₁ h₂
 
+instance : Trans (α := J) (Zigzag · ·) (Zigzag · ·) (Zigzag · ·) where
+  trans := Zigzag.trans
+
 theorem Zigzag.of_zag {j₁ j₂ : J} (h : Zag j₁ j₂) : Zigzag j₁ j₂ :=
   Relation.ReflTransGen.single h
 

--- a/Mathlib/CategoryTheory/IsConnected.lean
+++ b/Mathlib/CategoryTheory/IsConnected.lean
@@ -319,6 +319,15 @@ theorem Zigzag.of_inv {j₁ j₂ : J} (f : j₂ ⟶ j₁) : Zigzag j₁ j₂ :=
 theorem Zigzag.of_zag_trans {j₁ j₂ j₃ : J} (h₁ : Zag j₁ j₂) (h₂ : Zag j₂ j₃) : Zigzag j₁ j₃ :=
   trans (of_zag h₁) (of_zag h₂)
 
+instance : Trans (α := J) (Zag · ·) (Zigzag · ·) (Zigzag · ·) where
+  trans h h' := Zigzag.trans (.of_zag h) h'
+
+instance : Trans (α := J) (Zigzag · ·) (Zag · ·) (Zigzag · ·) where
+  trans h h' := Zigzag.trans h (.of_zag h')
+
+instance : Trans (α := J) (Zag · ·) (Zag · ·) (Zigzag · ·) where
+  trans := Zigzag.of_zag_trans
+
 theorem Zigzag.of_hom_hom {j₁ j₂ j₃ : J} (f₁₂ : j₁ ⟶ j₂) (f₂₃ : j₂ ⟶ j₃) : Zigzag j₁ j₃ :=
   (of_hom f₁₂).trans (of_hom f₂₃)
 


### PR DESCRIPTION
Register a `Trans` instance on `CategoryTheory.Zigzag`, so that `calc` proofs for zigags are also an option. We also add 
related instances like `Trans (Zag · ·) (Zigzag · ·) (Zigzag · ·)`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I also considered adding a (scoped) notation `x ⇆ y` for `Zigzag x y`, but this might be a bit gratuitous.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
