### PR TITLE
chore: don't use MemoFix

### DIFF
--- a/Mathlib/Lean/Expr/ReplaceRec.lean
+++ b/Mathlib/Lean/Expr/ReplaceRec.lean
@@ -31,4 +31,10 @@ def replaceRec (f? : (Expr → Expr) → Expr → Option Expr) : Expr → Expr :
     | some x => x
     | none   => Id.run <| traverseChildren (pure <| r ·) e
 
+partial def replaceRec' (f? : (Expr → Expr) → Expr → Option Expr) : Expr → Expr :=
+  fun e => match f? (replaceRec' f?) e with
+  | some x => x
+  | none   => Id.run <| traverseChildren (pure <| replaceRec' f? ·) e
+
+
 end Lean.Expr

--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -576,7 +576,7 @@ where /-- Implementation of `applyReplacementFun`. -/
   aux (env : Environment) (trace : Bool) : Expr → Expr :=
   let reorderFn : Name → List (List ℕ) := fun nm ↦ (reorderAttr.find? env nm |>.getD [])
   let relevantArg : Name → ℕ := fun nm ↦ (relevantArgAttr.find? env nm).getD 0
-  Lean.Expr.replaceRec fun r e ↦ Id.run do
+  Lean.Expr.replaceRec' fun r e ↦ Id.run do
     if trace then
       dbg_trace s!"replacing at {e}"
     match e with


### PR DESCRIPTION
Experimental: checking the performance impact of not using `MemoFix` in `to_additive`.