### PR TITLE
[Merged by Bors] - feat(CI): add a weekly "long files" report

### DIFF
--- a/.github/workflows/long_file_report.yml
+++ b/.github/workflows/long_file_report.yml
@@ -1,0 +1,30 @@
+name: Weekly Technical Debt Counters
+
+on:
+  schedule:
+    - cron: '0 4 * * 1'  # Run at 04:00 UTC every Monday
+  workflow_dispatch:
+
+jobs:
+  run-script:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+    - name: Run script
+      id: long_files
+      run: |
+        printf $'summary<<EOF\n%s\nEOF' "$(./scripts/long_file_report.sh)" | tee "$GITHUB_OUTPUT"
+
+    - name: Post output to Zulip
+      uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
+      with:
+        api-key: ${{ secrets.ZULIP_API_KEY }}
+        email: 'github-mathlib4-bot@leanprover.zulipchat.com'
+        organization-url: 'https://leanprover.zulipchat.com'
+        to: 'mathlib4'
+        type: 'stream'
+        topic: long files
+        content: ${{ steps.long_files.outputs.summary }}

--- a/.github/workflows/long_file_report.yml
+++ b/.github/workflows/long_file_report.yml
@@ -1,4 +1,4 @@
-name: Weekly Technical Debt Counters
+name: Weekly Long File Report
 
 on:
   schedule:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -81,6 +81,9 @@ to learn about it as well!
 - `technical-debt-metrics.sh`
   Prints information on certain kind of technical debt in Mathlib.
   This output is automatically posted to zulip once a week.
+- `long_file_report.sh`
+  Prints the list of the 10 longest Lean files in `Mathlib`.
+  This output is automatically posted to zulip once a week.
 
 **Mathlib tactics**
 - `polyrith_sage.py`, `polyrith_sage_helper.py` are required for `polyrith`

--- a/scripts/long_file_report.sh
+++ b/scripts/long_file_report.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# takes a comma-separated list of headers and a file/stdin input and returns
+# a md-style table. The file/stdin is expected to be space-separated entries.
+mkMDtable () {
+  awk -v heads="${1}" 'BEGIN{
+    n=split(heads, headers, ",")
+    printf("|")
+    for(i=1; i<=n; i++) {printf(" %s |", headers[i])}
+    print ""
+
+    printf("|")
+    for(i=1; i<=n; i++) {printf("-|")}
+    print ""
+  } {
+    printf("|")
+    for(i=1; i<=n; i++) {printf(" %s |", $i)}
+    print ""
+  }' "${2}"
+}
+
+git ls-files 'Mathlib/*.lean' | # list the git-managed `Mathlib/` lean files
+  tr -d "'" |                   # remove `'`, otherwise `xargs`` complains
+  xargs wc -l --total=never |   # count lines, do not report totals
+  sort -nr -k1 |                # numerical reverse sort of the first entry
+  head -10 |                    # keep the first 10 lines
+  sed 's=\(Mathlib[^ ]*\)\.lean=file#\1=' | # linkify the filenames
+  mkMDtable "Lines,File"        # format into an md-table

--- a/scripts/long_file_report.sh
+++ b/scripts/long_file_report.sh
@@ -3,22 +3,31 @@
 # takes a comma-separated list of headers and a file/stdin input and returns
 # a md-style table. The file/stdin is expected to be space-separated entries.
 mkMDtable () {
-  awk -v limit=1500 -v heads="${1}" 'BEGIN{
+  awk -v limit=1500 -v heads="${1}" '
+    function mkRow(m,str)
+    { printf("|")
+      for(i=1; i<=m; i++) {printf("%s|", str)}
+      print "" }
+    BEGIN{
     longTotal=0
+    foundShort=0
     n=split(heads, headers, ",")
+    # mkRow, with the header entries
     printf("|")
     for(i=1; i<=n; i++) {printf(" %s |", headers[i])}
     print ""
-
-    printf("|")
-    for(i=1; i<=n; i++) {printf("-|")}
-    print ""
-  } ((longTotal == "0") && ($1+0 <= limit)) {longTotal=1; print "here"}
-    {
-    printf("|")
-    for(i=1; i<=n; i++) {printf(" %s |", $i)}
-    print ""
-  } END{if(longTotal == "0") {printf("All files are within the length limit!\n")}{printf("There are long files.\n")}}' "${2}"
+    mkRow(n, "-")
+  } (limit < $1+0) {longTotal++}
+    ((foundShort == "0") && (0 < longTotal) && ($1+0 <= limit) && ($1+0 == $1)) {mkRow(n, " "); foundShort=1}
+    # mkRow, with the entries of each line
+    { printf("|")
+      for(i=1; i<=n; i++) {printf(" %s |", $i)}
+      print "" } END{
+      if(longTotal == "0")
+      { printf("\nAll files are within the length limit!\n") }
+      else
+      { printf("\n%s file%s exceed the length limit (%s).\n", longTotal, (longTotal == 1) ? "" : "s", limit) }
+    }' "${2}"
 }
 
 git ls-files 'Mathlib/*.lean' | # list the git-managed `Mathlib/` lean files

--- a/scripts/long_file_report.sh
+++ b/scripts/long_file_report.sh
@@ -27,7 +27,7 @@ mkMDtable () {
       ((foundShort == "0") && (0 < longTotal) && ($1+0 <= limit) && ($1+0 == $1)) {mkRow(n, " "); foundShort=1}
       # mkRow, with the entries of each line
       { printf("|")
-        for(i=1; i<=n; i++) {printf(" %s |", $i)}
+        for(i=1; i<=n; i++) { printf(" %s |", $i) }
         print "" } END{
         if(longTotal == "0")
         { printf("\nAll files are within the length limit!\n") }

--- a/scripts/long_file_report.sh
+++ b/scripts/long_file_report.sh
@@ -15,24 +15,24 @@ mkMDtable () {
       for(i=1; i<=m; i++) {printf("%s|", str)}
       print "" }
     BEGIN{
-    longTotal=0
-    foundShort=0
-    n=split(heads, headers, ",")
-    # mkRow, with the header entries
-    printf("|")
-    for(i=1; i<=n; i++) {printf(" %s |", headers[i])}
-    print ""
-    mkRow(n, "-")
-  } (limit < $1+0) {longTotal++}
-    ((foundShort == "0") && (0 < longTotal) && ($1+0 <= limit) && ($1+0 == $1)) {mkRow(n, " "); foundShort=1}
-    # mkRow, with the entries of each line
-    { printf("|")
-      for(i=1; i<=n; i++) {printf(" %s |", $i)}
-      print "" } END{
-      if(longTotal == "0")
-      { printf("\nAll files are within the length limit!\n") }
-      else
-      { printf("\n%s file%s exceed the length limit (%s).\n", longTotal, (longTotal == 1) ? "" : "s", limit) }
+      longTotal=0
+      foundShort=0
+      n=split(heads, headers, ",")
+      # mkRow, with the header entries
+      printf("|")
+      for(i=1; i<=n; i++) {printf(" %s |", headers[i])}
+      print ""
+      mkRow(n, "-")
+    } (limit < $1+0) {longTotal++}
+      ((foundShort == "0") && (0 < longTotal) && ($1+0 <= limit) && ($1+0 == $1)) {mkRow(n, " "); foundShort=1}
+      # mkRow, with the entries of each line
+      { printf("|")
+        for(i=1; i<=n; i++) {printf(" %s |", $i)}
+        print "" } END{
+        if(longTotal == "0")
+        { printf("\nAll files are within the length limit!\n") }
+        else
+        { printf("\n%s file%s exceed the length limit (%s).\n", longTotal, (longTotal == 1) ? "" : "s", limit) }
     }' "${2}"
 }
 

--- a/scripts/long_file_report.sh
+++ b/scripts/long_file_report.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 
-# takes a comma-separated list of headers and a file/stdin input and returns
-# a md-style table. The file/stdin is expected to be space-separated entries.
+# The line length limit of each file
+limit=1500
+
+# takes as input
+# * a comma-separated list of headers, i.e. `"Lines,File"` and
+# * a file/stdin input;
+# returns an md-style table, introducing an empty line to separate long files from short ones.
+# The file/stdin is expected to consist of space-separated entries.
 mkMDtable () {
-  awk -v limit=1500 -v heads="${1}" '
+  awk -v limit="${limit}" -v heads="${1}" '
     function mkRow(m,str)
     { printf("|")
       for(i=1; i<=m; i++) {printf("%s|", str)}


### PR DESCRIPTION
Add a CI workflow that weekly reports the list of the 10 longest files in `Mathlib`.  This helps maintain the number of files exceeding the 1500 line limit in control.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
