### PR TITLE
feat(Analysis/Calculus/PartialDerivatives): Propose notation for partial derivatives.

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1430,6 +1430,7 @@ import Mathlib.Analysis.Calculus.MeanValue
 import Mathlib.Analysis.Calculus.Monotone
 import Mathlib.Analysis.Calculus.ParametricIntegral
 import Mathlib.Analysis.Calculus.ParametricIntervalIntegral
+import Mathlib.Analysis.Calculus.PartialDerivatives.Notation
 import Mathlib.Analysis.Calculus.Rademacher
 import Mathlib.Analysis.Calculus.SmoothSeries
 import Mathlib.Analysis.Calculus.TangentCone

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3861,6 +3861,7 @@ import Mathlib.LinearAlgebra.Basis.Defs
 import Mathlib.LinearAlgebra.Basis.Exact
 import Mathlib.LinearAlgebra.Basis.Fin
 import Mathlib.LinearAlgebra.Basis.Flag
+import Mathlib.LinearAlgebra.Basis.HasCanonicalBasis
 import Mathlib.LinearAlgebra.Basis.Prod
 import Mathlib.LinearAlgebra.Basis.SMul
 import Mathlib.LinearAlgebra.Basis.Submodule

--- a/Mathlib/Analysis/Calculus/PartialDerivatives/Notation.lean
+++ b/Mathlib/Analysis/Calculus/PartialDerivatives/Notation.lean
@@ -30,11 +30,10 @@ This can be written using the following notations:
 - `(∂ᵢ[ℝ] f) tx` if the index `i` is subscriptable,
 - `(∂[i;ℝ] f) tx` in general.
 -/
-@[simp]
+@[simp, nolint unusedArguments] -- we need `HasCanonicalBasis 𝕜 V ι f` to make the notation work
 noncomputable def partialDeriv (𝕜 : Type u) {V : Type v} {ι : Type w} {E : Type*}
     {f : ι → V} [NontriviallyNormedField 𝕜] [AddCommGroup V]
-    [Module 𝕜 V] [HasCanonicalBasis 𝕜 V ι f] [TopologicalSpace V]
-    [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+    [Module 𝕜 V] [HasCanonicalBasis 𝕜 V ι f] [NormedAddCommGroup E] [NormedSpace 𝕜 E]
     (F : V → E) (i : ι) (tx : V) : E :=
   lineDeriv 𝕜 F tx (f i)
 

--- a/Mathlib/Analysis/Calculus/PartialDerivatives/Notation.lean
+++ b/Mathlib/Analysis/Calculus/PartialDerivatives/Notation.lean
@@ -1,0 +1,85 @@
+import Mathlib.Analysis.Calculus.LineDeriv.Basic
+import Mathlib.LinearAlgebra.Basis.HasCanonicalBasis
+
+
+/-! # Notation for partial derivatives
+
+This file introduces some custom notation for partial derivatives. In order to make this
+as flexible as possible (e.g. we would like to have consistent notation that works for
+`ℝ × ℝ`, `Fin 2 → ℝ` and `EuclideanSpace ℝ (Fin 2)`), we work on abstract vector spaces
+equiped with a `HasCanonicalBasis` instance.
+
+We introduce two different notations
+- Whenever the index `i` is subscriptable, we can use `∂ᵢ[ℝ] f` to denote the `i-th` partial
+  derivative. This works for e.g `i : Fin n`.
+- In general, if the basis is indexed by a type `ι`, then we can use `∂[i; ℝ] f` for the
+  `i`-th partial derivative.
+
+-/
+
+universe u v w u' v' w'
+
+namespace HasCanonicalBasis
+/--
+The partial derivative of a function `F : V → 𝕜`.
+
+`partialDeriv 𝕜 F i tx` return the partial derivative of function `F : V → 𝕜`
+with respect to the `i`-th component of the canonical basis of `V` at point `tx : V`.
+
+This can be written using the following notations:
+- `(∂ᵢ[ℝ] f) tx` if the index `i` is subscriptable,
+- `(∂[i;ℝ] f) tx` in general.
+-/
+@[simp]
+noncomputable def partialDeriv (𝕜 : Type u) {V : Type v} {ι : Type w} {E : Type*}
+    {f : ι → V} [NontriviallyNormedField 𝕜] [AddCommGroup V]
+    [Module 𝕜 V] [HasCanonicalBasis 𝕜 V ι f] [TopologicalSpace V]
+    [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+    (F : V → E) (i : ι) (tx : V) : E :=
+  lineDeriv 𝕜 F tx (f i)
+
+section Notation
+
+open Mathlib Lean Meta Tactic Elab
+
+/-
+Define the partial derivative notations. Note that we need to use a macro
+rather than the `notation` command since we need to use the subscript parser
+`subscriptTerm`.
+-/
+
+@[inherit_doc partialDeriv]
+scoped syntax:100 "∂" noWs subscriptTerm noWs "[" term "]" term:max : term
+
+@[inherit_doc partialDeriv]
+scoped syntax:100 "∂[" term ";" term "]" term:max : term
+
+macro_rules
+  | `(∂$i:subscript[$𝕜] $f) => `(partialDeriv $𝕜 $f $i)
+  | `(∂[$i:term; $𝕜:term] $f) => `(partialDeriv $𝕜 $f $i)
+
+end Notation
+
+end HasCanonicalBasis
+
+open scoped HasCanonicalBasis
+
+
+section demos
+--Here we demo some examples of this notation.
+
+example (f : ℝ → ℝ) (hf : f = 0) : (∂₀[ℝ] f) 0 = 0 := by
+  simp [hf, Pi.zero_def, lineDeriv, deriv_const]
+
+example : (∂₀[ℝ] fun (x : ℝ × ℝ) => x.1) 0 = 1 := by
+  simp [Pi.zero_def, lineDeriv]
+
+
+example : (∂[0; ℝ] (fun (x : ℝ × ℝ) => x.1)) 0 = 1 := by
+  simp [Pi.zero_def, lineDeriv]
+
+example (n : ℕ) (f : (Fin n → ℝ) → ℝ) (x : Fin n → ℝ) :
+    ∑ (i : Fin n), (∂ᵢ[ℝ] f) x = ∑ (i : Fin n), (∂[i; ℝ] f) x := by
+  rfl
+
+end demos

--- a/Mathlib/Analysis/Calculus/PartialDerivatives/Notation.lean
+++ b/Mathlib/Analysis/Calculus/PartialDerivatives/Notation.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2025 Paul Lezeau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Lezeau, Eric Wieser
+-/
 import Mathlib.Analysis.Calculus.LineDeriv.Basic
 import Mathlib.LinearAlgebra.Basis.HasCanonicalBasis
 

--- a/Mathlib/LinearAlgebra/Basis/HasCanonicalBasis.lean
+++ b/Mathlib/LinearAlgebra/Basis/HasCanonicalBasis.lean
@@ -1,0 +1,100 @@
+import Mathlib.Analysis.InnerProductSpace.PiL2
+
+/-! # Canonical Bases for vector spaces
+
+This file introduces the notion of canonical bases for modules,
+which allows us to work with an implicit notion of the canonical basis for familiar spaces.
+
+-/
+
+universe u v w u' v' w'
+
+/-- `HasCanonicalBasis 𝕜 V ι f` means that the `𝕜`-module `V` is canonically
+represented by an `ι`-indexed basis with elements `f`.
+
+`f` is an outParam so that theorems about a particular basis can use the simp-normal `Pi.single`
+rather than `Pi.basisFun`. -/
+class HasCanonicalBasis (𝕜 : Type u) (V : Type v) (ι : outParam <| Type w)
+    --TODO: can some of these be `semiOutParam`/regular params?
+    (f : outParam <| ι → V) [Semiring 𝕜] [AddCommGroup V]
+    [Module 𝕜 V] where
+  basis : Basis ι 𝕜 V
+  coe_basis_eq : basis = f
+
+namespace HasCanonicalBasis
+
+@[simp]
+lemma basis_apply (𝕜 : Type u) (V : Type v) (ι : outParam <| Type w)
+    (f : outParam <| ι → V) [Semiring 𝕜] [AddCommGroup V]
+    [Module 𝕜 V] [hc : HasCanonicalBasis 𝕜 V ι f] (i : ι) :
+    hc.basis i = f i := by
+  simp [coe_basis_eq]
+
+end HasCanonicalBasis
+
+variable {𝕜 : Type u} {ι : Type w} [DecidableEq ι] [Fintype ι]
+
+noncomputable instance EuclideanSpace.hasCanonicalBasis [RCLike 𝕜] :
+    HasCanonicalBasis 𝕜 (EuclideanSpace 𝕜 ι) ι (EuclideanSpace.single · 1) where
+  basis := PiLp.basisFun 2 𝕜 ι
+  coe_basis_eq := by ext : 1; simp
+
+variable [Ring 𝕜]
+
+noncomputable instance Pi.hasCanonicalBasis : HasCanonicalBasis 𝕜 (ι → 𝕜) ι (Pi.single · 1) where
+  basis := Pi.basisFun 𝕜 ι
+  coe_basis_eq := by ext ; simp
+
+/-
+Note: this could be generalised to a product of vector spaces that each have a
+`HasCanonicalBasis` instance, but for now this isn't necessary, and the index
+type would be a very ugly type, which is undesirable.
+-/
+noncomputable instance [Ring 𝕜] (p : ENNReal) :
+  HasCanonicalBasis 𝕜 (PiLp p (fun (_ : ι) ↦ 𝕜)) ι (Pi.single · 1) where
+  basis := (PiLp.basisFun p 𝕜 ι)
+  coe_basis_eq := by ext; simp
+
+noncomputable instance : HasCanonicalBasis 𝕜 𝕜 (Fin 1) (fun _ ↦ 1) where
+  basis := Basis.singleton _ 𝕜
+  coe_basis_eq := by ext i; aesop
+
+/-- This abbrev provides us with a way of reindexing canonical bases, which is useful
+in the context of defining canonical bases for products. -/
+noncomputable abbrev reindex {V : Type v} {κ : Type w'}
+    {f : ι → V} {g : κ → V} [Semiring 𝕜] [AddCommGroup V] [Module 𝕜 V]
+    (hc : HasCanonicalBasis 𝕜 V ι f) (e : ι ≃ κ) (he : ∀ (i : κ), g i = hc.basis (e.symm i)) :
+    HasCanonicalBasis 𝕜 V κ g where
+  basis := Basis.reindex (HasCanonicalBasis.basis) e
+  coe_basis_eq := by ext ; simp [Basis.reindex_apply, he]
+
+/-
+The following isn't an instance since have a sum as the index type for our
+bases is in general undesirable (e.g. this would force `𝕜 × 𝕜`  to have basis
+`Fin 1 ⊕ Fin 1` rather than `Fin 2`)
+-/
+variable (𝕜) in
+noncomputable abbrev prod {V : Type v} {W : Type v'} {κ : Type w'}
+    [AddCommGroup V] [AddCommGroup W] [Module 𝕜 V] [Module 𝕜 W]
+    (f : ι → V) (g : κ → W) [HasCanonicalBasis 𝕜 V ι f] [HasCanonicalBasis 𝕜 W κ g] :
+    HasCanonicalBasis 𝕜 (V × W) (ι ⊕ κ) (Sum.elim (LinearMap.inl 𝕜 _ _ ∘ f)
+      (LinearMap.inr 𝕜 _ _ ∘ g)) where
+  basis := Basis.prod HasCanonicalBasis.basis HasCanonicalBasis.basis
+  coe_basis_eq := by ext <;> simp [Basis.prod_apply, Sum.elim]
+
+/--
+The canonical basis for `𝕜 × 𝕜`
+-/
+noncomputable instance : HasCanonicalBasis 𝕜 (𝕜 × 𝕜) (Fin 2) (![(1, 0), (0, 1)]) :=
+  reindex (prod 𝕜 _ _) finSumFinEquiv
+    (fun i ↦  by fin_cases i <;> simp [finSumFinEquiv, prod, Sum.elim, Fin.addCases])
+
+/--
+The canonical basis for `𝕜 × 𝕜 × 𝕜`.
+-/
+noncomputable instance : HasCanonicalBasis 𝕜 (𝕜 × 𝕜 × 𝕜) (Fin 3)
+    (![(1, 0, 0), (0, 1, 0), (0, 0, 1)]) :=
+  reindex (prod 𝕜 _ _) finSumFinEquiv
+    (fun i ↦  by fin_cases i <;> simp [finSumFinEquiv, prod, Sum.elim, Fin.addCases])
+
+-- TODO: maybe we also want to manually construct an instance on `𝕜 × 𝕜 × 𝕜 × 𝕜`

--- a/Mathlib/LinearAlgebra/Basis/HasCanonicalBasis.lean
+++ b/Mathlib/LinearAlgebra/Basis/HasCanonicalBasis.lean
@@ -18,6 +18,7 @@ class HasCanonicalBasis (𝕜 : Type u) (V : Type v) (ι : outParam <| Type w)
     --TODO: can some of these be `semiOutParam`/regular params?
     (f : outParam <| ι → V) [Semiring 𝕜] [AddCommGroup V]
     [Module 𝕜 V] where
+  /-- The underlying basis -/
   basis : Basis ι 𝕜 V
   coe_basis_eq : basis = f
 
@@ -43,7 +44,7 @@ variable [Ring 𝕜]
 
 noncomputable instance Pi.hasCanonicalBasis : HasCanonicalBasis 𝕜 (ι → 𝕜) ι (Pi.single · 1) where
   basis := Pi.basisFun 𝕜 ι
-  coe_basis_eq := by ext ; simp
+  coe_basis_eq := by ext; simp
 
 /-
 Note: this could be generalised to a product of vector spaces that each have a
@@ -66,14 +67,12 @@ noncomputable abbrev reindex {V : Type v} {κ : Type w'}
     (hc : HasCanonicalBasis 𝕜 V ι f) (e : ι ≃ κ) (he : ∀ (i : κ), g i = hc.basis (e.symm i)) :
     HasCanonicalBasis 𝕜 V κ g where
   basis := Basis.reindex (HasCanonicalBasis.basis) e
-  coe_basis_eq := by ext ; simp [Basis.reindex_apply, he]
+  coe_basis_eq := by ext; simp [Basis.reindex_apply, he]
 
-/-
-The following isn't an instance since have a sum as the index type for our
-bases is in general undesirable (e.g. this would force `𝕜 × 𝕜`  to have basis
-`Fin 1 ⊕ Fin 1` rather than `Fin 2`)
--/
 variable (𝕜) in
+/-- Constructs a "canonical basis" on a product of two modules equipped with a canonical basis.
+This isn't an instance since have a sum as the index type for our bases is in general undesirable
+(e.g. this would force `𝕜 × 𝕜`  to have basis `Fin 1 ⊕ Fin 1` rather than `Fin 2`) -/
 noncomputable abbrev prod {V : Type v} {W : Type v'} {κ : Type w'}
     [AddCommGroup V] [AddCommGroup W] [Module 𝕜 V] [Module 𝕜 W]
     (f : ι → V) (g : κ → W) [HasCanonicalBasis 𝕜 V ι f] [HasCanonicalBasis 𝕜 W κ g] :

--- a/Mathlib/LinearAlgebra/Basis/HasCanonicalBasis.lean
+++ b/Mathlib/LinearAlgebra/Basis/HasCanonicalBasis.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2025 Paul Lezeau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Lezeau, Eric Wieser
+-/
 import Mathlib.Analysis.InnerProductSpace.PiL2
 
 /-! # Canonical Bases for vector spaces


### PR DESCRIPTION
This PR introduces a notation for partial derivatives, taken with respect to a canonical basis. The idea here is that this might be useful for e.g. writing down PDEs. The notation allows use to write things like
```lean 
-- The canonical basis for `ℝ × ℝ` is indexed by `Fin 0` so `∂₀[ℝ]` corresponds to taking 
-- the first partial derivative
example : (∂₀[ℝ] fun (x : ℝ × ℝ) => x.1) 0 = 1 := by
  simp [Pi.zero_def, lineDeriv]
```

This has already been discussed on Zulip [here](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Partial.20derivatives).

I've opened this PR as a draft in order to get preliminary feedback on the contents (e.g. is this appropriate for Mathlib?); the file contains some demos of the notation in action.

Co-authored-by: Eric Wieser <efw@google.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [ ] depends on: #25425

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
