### PR TITLE
feat(Analysis/PDE/Quasilinear/Defs): Add definitions about quasilinear first order PDEs

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1742,6 +1742,7 @@ import Mathlib.Analysis.NormedSpace.SphereNormEquiv
 import Mathlib.Analysis.ODE.Gronwall
 import Mathlib.Analysis.ODE.PicardLindelof
 import Mathlib.Analysis.Oscillation
+import Mathlib.Analysis.PDE.Quasilinear.Defs
 import Mathlib.Analysis.PSeries
 import Mathlib.Analysis.PSeriesComplex
 import Mathlib.Analysis.Polynomial.Basic

--- a/Mathlib/Analysis/PDE/Quasilinear/Defs.lean
+++ b/Mathlib/Analysis/PDE/Quasilinear/Defs.lean
@@ -76,23 +76,6 @@ class FirstOrderQuasiLinearPDE.RegularBy (E : FirstOrderQuasiLinearPDE 𝕜 V) (
 
 end
 
-namespace HasCanonicalBasis
-
-/-- A constructor to build a term of type `FirstOrderQuasiLinearPDE` from a coordinate representation.
-
-Given a `𝕜`-vector space `V` with a canonical basis indexed by `ι`, coefficient functions
-`coeffs i : V × 𝕜 → 𝕜` indexed by `i : ι`, and a constant term function `const : V × 𝕜 → V`,
-`ofCanonicalBasis coeffs const` is the first order quasilinear PDE corresponding to
-`E : ∑ i, coeff i ∂ᵢu = const`
--/
-noncomputable def FirstOrderQuasiLinearPDE.ofCanonicalBasis {ι 𝕜 : Type*} [Fintype ι] [Field 𝕜] [AddCommGroup V]
-    [Module 𝕜 V] {f : ι → V} [HasCanonicalBasis 𝕜 V ι f] (coeffs : ι → V × 𝕜 → 𝕜)
-    (const : V × 𝕜 → 𝕜) : FirstOrderQuasiLinearPDE 𝕜 V where
-  coeff := fun x ↦ Fintype.linearCombination 𝕜 𝕜 (HasCanonicalBasis.basis (𝕜:=𝕜)) (fun i ↦ coeffs i x)
-  const := const
-
-end HasCanonicalBasis
-
 namespace FirstOrderQuasiLinearPDE
 
 section Notation
@@ -104,8 +87,6 @@ scoped notation "a[" E "]" => FirstOrderQuasiLinearPDE.coeff E
 scoped notation "c[" E "]" => FirstOrderQuasiLinearPDE.const E
 
 end Notation
-
-open HasCanonicalBasis
 
 section Solutions
 
@@ -125,7 +106,6 @@ def HasSolutionAt (u : V → 𝕜) (x : V) : Prop :=
 
 end Solutions
 
-open HasCanonicalBasis
 
 section Characteristics
 

--- a/Mathlib/Analysis/PDE/Quasilinear/Defs.lean
+++ b/Mathlib/Analysis/PDE/Quasilinear/Defs.lean
@@ -1,0 +1,160 @@
+/-
+Copyright (c) 2025 Paul Lezeau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Lezeau
+-/
+import Mathlib.Analysis.Calculus.Deriv.Basic
+
+/-! # First Order Quasilinear PDEs
+
+This file develops some basic theory of first order quasilinear PDEs.
+
+## Main definitions
+
+- `FirstOrderQuasiLinearPDE 𝕜 V`: the type of quasilinear PDEs on a `𝕜` vector space `V`, i.e.
+  equations in a variable `u : V → 𝕜` of the form `E : (∂u) a = c` where `∂u` denotes the
+  _Frechet derivative_ of `u`, `a : V × 𝕜 → V` is the _vector of coefficients_ of `E` and
+  `c : V × 𝕜 → 𝕜` is the _constant term_ of `E`. When `V` is equipped with a set of standard
+  coordinates `x₁, ..., xₙ`, this simplifies to the more familiar form `E : a₁ ∂₁u + ... + aₙ ∂ₙu = c`
+  where `a(x, U) = (a₁(x, U),...,aₙ(x, U))` and `∂ᵢ` is the partial derivative with respect to
+  the `i`-th standard coordinate.
+
+- `E.regularBy P`: the predicate that the coefficients and constant term of the equation
+  `E` satisfy some regularity condition `P`. Typically, `P` will be `ContDiff 𝕜 n`
+  or something similar.
+
+- `E.hasSolutionAt u x`: the predicate that the function `u` is a solution to the equation at
+  point `x`.
+
+- `E.HasCharacteristicAt γ t₀`: the predicate that a curve `γ : 𝕜 → V × 𝕜` satisfies the relation
+  `γ'(t) = (a(γ(t)), c(γ(t)))` at time `t = t₀`, where `a` is the vector of coefficients of equation
+  `E`, and `c` is the constant term.
+
+-/
+
+open Set
+
+open scoped Topology
+
+variable {𝕜 V : Type*}
+
+noncomputable section
+
+open scoped Topology
+
+variable (𝕜 V) in
+/-- `FirstOrderQuasiLinearPDE 𝕜 V` is the type of quasilinear PDEs on a `𝕜` vector space `V`.
+
+Note: we need to consider functions defined on `V × ℝ` since in general the coefficients of a quasilinear
+PDE `a₁ ∂₁u + ... + aₙ ∂ₙu = c` might depend on the function `u : V → ℝ`.
+-/
+@[ext]
+structure FirstOrderQuasiLinearPDE where
+  /-- The vector of coefficients `a` of the equation.
+
+  When encoding equation `E : a₁ ∂₁u + ... + aₙ ∂ₙu = c` in an unknown function `u`,
+  with coefficients `aᵢ` and constant term `c` that depend on `x` and `u`,
+  `coeff (x, U)` corresponds to the vector `(a₁(x, U), ..., aₙ(x, U))`. Here, `U` is
+  a variable that encodes the dependence of the coefficients on the unknown function `u`,
+  and `x = (x₁, ..., xₙ)` is the variable on which `u` depends.
+  -/
+  coeff : V × 𝕜 → V
+  /-- The constant term `c` of the equation.
+
+  When encoding equation `E : a₁ ∂₁u + ... + aₙ ∂ₙu = c` in an unknown function `u`,
+  with coefficients `aᵢ` and constant term `c` that depend on `x` and `u`,
+  `const (x, U)` corresponds to the constant term `c(x, U)`. Here, `U` is
+  a variable that encodes the dependence of the constant term on the unknown function `u`,
+  and `x = (x₁, ..., xₙ)` is the variable on which `u` depends.
+  -/
+  const : V × 𝕜 → 𝕜
+
+/-- `E.RegularBy` is the predicate that the coefficients of `E` satisfy the regularity condition `P`.
+Typically, we would take `P = ContDiff` or so on. -/
+class FirstOrderQuasiLinearPDE.RegularBy (E : FirstOrderQuasiLinearPDE 𝕜 V) (P : (V × 𝕜 → V × 𝕜) → Prop) where
+  reg : P (fun x => (E.coeff x, E.const x)) := by fun_prop
+
+end
+
+namespace HasCanonicalBasis
+
+/-- A constructor to build a term of type `FirstOrderQuasiLinearPDE` from a coordinate representation.
+
+Given a `𝕜`-vector space `V` with a canonical basis indexed by `ι`, coefficient functions
+`coeffs i : V × 𝕜 → 𝕜` indexed by `i : ι`, and a constant term function `const : V × 𝕜 → V`,
+`ofCanonicalBasis coeffs const` is the first order quasilinear PDE corresponding to
+`E : ∑ i, coeff i ∂ᵢu = const`
+-/
+noncomputable def FirstOrderQuasiLinearPDE.ofCanonicalBasis {ι 𝕜 : Type*} [Fintype ι] [Field 𝕜] [AddCommGroup V]
+    [Module 𝕜 V] {f : ι → V} [HasCanonicalBasis 𝕜 V ι f] (coeffs : ι → V × 𝕜 → 𝕜)
+    (const : V × 𝕜 → 𝕜) : FirstOrderQuasiLinearPDE 𝕜 V where
+  coeff := fun x ↦ Fintype.linearCombination 𝕜 𝕜 (HasCanonicalBasis.basis (𝕜:=𝕜)) (fun i ↦ coeffs i x)
+  const := const
+
+end HasCanonicalBasis
+
+namespace FirstOrderQuasiLinearPDE
+
+section Notation
+
+@[inherit_doc FirstOrderQuasiLinearPDE.coeff]
+scoped notation "a[" E "]" => FirstOrderQuasiLinearPDE.coeff E
+
+@[inherit_doc FirstOrderQuasiLinearPDE.const]
+scoped notation "c[" E "]" => FirstOrderQuasiLinearPDE.const E
+
+end Notation
+
+open HasCanonicalBasis
+
+section Solutions
+
+variable (E : FirstOrderQuasiLinearPDE 𝕜 V)
+variable [AddCommGroup V] [TopologicalSpace V]
+variable [NontriviallyNormedField 𝕜] [Module 𝕜 V]
+
+
+/-- `E.hasSolutionAt u x` is the predicate that the function `u` is a solution to the PDE at point `E`.
+
+Note that we don't place any differentiability requirements. -/
+def HasSolutionAt (u : V → 𝕜) (x : V) : Prop :=
+  --In the future, I think we should include some weaker versions of this,
+  --e.g. `IsSolutionWithinAt` and so on. The main theorem about characteristics
+  --should be provable with weaker conditions.
+  ∃ u' : V →L[𝕜] 𝕜, HasFDerivAt u u' x ∧ u' (a[E] (x, u x)) = c[E] (x, u x)
+
+end Solutions
+
+open HasCanonicalBasis
+
+section Characteristics
+
+section
+
+variable (E : FirstOrderQuasiLinearPDE 𝕜 V)
+variable [NontriviallyNormedField 𝕜]
+variable [NormedAddCommGroup V] [Module 𝕜 V] [ContinuousSMul 𝕜 V]
+
+/-- The predicate that a curve `γ = (X, U) : ℝ → V × ℝ` is a characteristic curve for PDE `E`,
+at time `t₀` i.e. `d/dt X(t₀) = a(X(t), U(t))` and `d/dt U(t₀) = c(X(t), U(t))` -/
+def HasCharacteristicAt (γ : 𝕜 → V × 𝕜) (t₀ : 𝕜) : Prop :=
+  HasDerivAt γ (a[E] (γ t₀), c[E] (γ t₀)) t₀
+
+end
+
+section
+
+variable {E : FirstOrderQuasiLinearPDE 𝕜 V}
+variable [NontriviallyNormedField 𝕜] [NormedAddCommGroup V] [NormedSpace 𝕜 V]
+
+lemma differentiableAt_of_hasSolutionAt {u : V → 𝕜} {x : V}
+    (H : E.HasSolutionAt u x) : DifferentiableAt 𝕜 u x := by
+  obtain ⟨u', hu', _⟩ := H
+  exact hu'.differentiableAt
+
+lemma fderiv_apply_of_hasSolutionAt {u : V → 𝕜} {x : V}
+    (H : E.HasSolutionAt u x) : fderiv 𝕜 u x (a[E] (x, u x)) = c[E] (x, u x) := by
+  obtain ⟨u', hu', hu''⟩ := H
+  rwa [HasFDerivAt.fderiv hu']
+
+end


### PR DESCRIPTION
This PR introduces some basic definitions related to first order quasilinear PDEs. 
In a subsequent PR (I'm currently cleaning up the code), these will be used to state and prove some results about how solutions to quasilinear PDEs vary along characteristic curves.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
