### PR TITLE
fix(CI): maintainer merge emoji reaction

### DIFF
--- a/.github/workflows/zulip_emoji_labelling.yaml
+++ b/.github/workflows/zulip_emoji_labelling.yaml
@@ -5,7 +5,7 @@ jobs:
   # When a PR is (un)labelled with awaiting-author or maintainer-merge,
   # add resp. remove the matching emoji reaction from zulip messages.
   set_pr_emoji:
-    if: github.event.label.name == 'awaiting-author' || github.event.label.name == 'maintainer-merge'
+    if: ${{ github.event.label.name == 'awaiting-author' || github.event.label.name == 'maintainer-merge' }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout mathlib repository


### PR DESCRIPTION
The `maintainer-merge` emoji reaction does not seem to work and I think that this PR will fix it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
