### PR TITLE
feat(Valued): Valuation.leAddSubgroup and ideal/submodule versions of ltAddSubgroup

### DIFF
--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -390,6 +390,9 @@ lemma mem_leAddSubgroup_iff {v : Valuation R Γ₀} {γ : Γ₀} {x : R} :
     x ∈ v.leAddSubgroup γ ↔ v x ≤ γ :=
   Iff.rfl
 
+lemma leAddSubgroup_mono (v : Valuation R Γ₀) : Monotone v.leAddSubgroup :=
+  fun _ _ h _ ↦ h.trans'
+
 /-- The subgroup of elements whose valuation is less than a certain unit. -/
 def ltAddSubgroup (v : Valuation R Γ₀) (γ : Γ₀ˣ) : AddSubgroup R where
   carrier := { x | v x < γ }
@@ -401,6 +404,9 @@ def ltAddSubgroup (v : Valuation R Γ₀) (γ : Γ₀ˣ) : AddSubgroup R where
 lemma mem_ltAddSubgroup_iff {v : Valuation R Γ₀} {γ : Γ₀ˣ} {x : R} :
     x ∈ v.ltAddSubgroup γ ↔ v x < γ :=
   Iff.rfl
+
+lemma ltAddSubgroup_mono (v : Valuation R Γ₀) : Monotone v.ltAddSubgroup :=
+  fun _ _ h _ ↦ (Units.val_le_val.mpr h).trans_lt'
 
 end Group
 

--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -412,6 +412,11 @@ lemma ltAddSubgroup_le_leAddSubgroup (v : Valuation R Γ₀) (γ : Γ₀ˣ) :
     v.ltAddSubgroup γ ≤ v.leAddSubgroup γ :=
   fun _ h ↦ h.le
 
+@[simp]
+lemma leAddSubgroup_zero {K : Type*} [Field K] (v : Valuation K Γ₀) :
+    v.leAddSubgroup 0 = ⊥ := by
+  ext; simp
+
 end Group
 
 end Basic

--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -378,12 +378,29 @@ theorem val_le_one_or_val_inv_le_one (v : Valuation K Γ₀) (x : K) : v x ≤ 1
   · simp only [h, map_zero, zero_le', inv_zero, or_self]
   · simp only [← one_le_val_iff v h, le_total]
 
+/-- The subgroup of elements whose valuation is less than or equal to a certain value. -/
+def leAddSubgroup (v : Valuation R Γ₀) (γ : Γ₀) : AddSubgroup R where
+  carrier := { x | v x ≤ γ }
+  zero_mem' := by simp
+  add_mem' {x y} x_in y_in := (v.map_add x y).trans (max_le x_in y_in)
+  neg_mem' x_in := by rwa [Set.mem_setOf, map_neg]
+
+@[simp]
+lemma mem_leAddSubgroup_iff {v : Valuation R Γ₀} {γ : Γ₀} {x : R} :
+    x ∈ v.leAddSubgroup γ ↔ v x ≤ γ :=
+  Iff.rfl
+
 /-- The subgroup of elements whose valuation is less than a certain unit. -/
 def ltAddSubgroup (v : Valuation R Γ₀) (γ : Γ₀ˣ) : AddSubgroup R where
   carrier := { x | v x < γ }
   zero_mem' := by simp
   add_mem' {x y} x_in y_in := lt_of_le_of_lt (v.map_add x y) (max_lt x_in y_in)
   neg_mem' x_in := by rwa [Set.mem_setOf, map_neg]
+
+@[simp]
+lemma mem_ltAddSubgroup_iff {v : Valuation R Γ₀} {γ : Γ₀ˣ} {x : R} :
+    x ∈ v.ltAddSubgroup γ ↔ v x < γ :=
+  Iff.rfl
 
 end Group
 

--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -408,6 +408,10 @@ lemma mem_ltAddSubgroup_iff {v : Valuation R Γ₀} {γ : Γ₀ˣ} {x : R} :
 lemma ltAddSubgroup_mono (v : Valuation R Γ₀) : Monotone v.ltAddSubgroup :=
   fun _ _ h _ ↦ (Units.val_le_val.mpr h).trans_lt'
 
+lemma ltAddSubgroup_le_leAddSubgroup (v : Valuation R Γ₀) (γ : Γ₀ˣ) :
+    v.ltAddSubgroup γ ≤ v.leAddSubgroup γ :=
+  fun _ h ↦ h.le
+
 end Group
 
 end Basic

--- a/Mathlib/RingTheory/Valuation/Integers.lean
+++ b/Mathlib/RingTheory/Valuation/Integers.lean
@@ -250,4 +250,150 @@ theorem Integer.not_isUnit_iff_valuation_lt_one {x : v.integer} : ¬IsUnit x ↔
 
 end Field
 
+section Ideal
+
+variable {R : Type u} {Γ₀ : Type v} [Ring R] [LinearOrderedCommGroupWithZero Γ₀]
+variable (v : Valuation R Γ₀)
+local notation "𝓞" => v.integer
+
+/-- The submodule of over the valuation subring whose valuation is less than or equal to a
+certain value. -/
+def leSubmodule (γ : Γ₀) : Submodule 𝓞 R where
+  __ := leAddSubgroup v γ
+  smul_mem' r x h := by
+    simpa [Subring.smul_def] using mul_le_of_le_one_of_le r.prop h
+
+/-- The submodule of over the valuation subring whose valuation is less than a certain unit. -/
+def ltSubmodule (γ : Γ₀ˣ) : Submodule 𝓞 R where
+  __ := ltAddSubgroup v γ
+  smul_mem' r x h := by
+    simpa [Subring.smul_def] using mul_lt_of_le_one_of_lt r.prop h
+
+lemma leSubmodule_mono : Monotone (leSubmodule v) :=
+  leAddSubgroup_mono v
+
+lemma ltSubmodule_mono : Monotone (ltSubmodule v) :=
+  ltAddSubgroup_mono v
+
+lemma ltSubmodule_le_leSubmodule (γ : Γ₀ˣ) :
+    ltSubmodule v γ ≤ leSubmodule v (γ : Γ₀) :=
+  ltAddSubgroup_le_leAddSubgroup v γ
+
+variable {v} in
+@[simp]
+lemma mem_leSubmodule_iff {γ : Γ₀} {x : R} :
+    x ∈ leSubmodule v γ ↔ v x ≤ γ :=
+  Iff.rfl
+
+variable {v} in
+@[simp]
+lemma mem_ltSubmodule_iff {γ : Γ₀ˣ} {x : R} :
+    x ∈ ltSubmodule v γ ↔ v x < γ :=
+  Iff.rfl
+
+@[simp]
+lemma leSubmodule_zero (K : Type*) [Field K] (v : Valuation K Γ₀) :
+    leSubmodule v (0 : Γ₀) = ⊥ := by
+  ext; simp
+
+lemma leSubmodule_v_le_of_mem {K : Type*} [Field K] (v : Valuation K Γ₀)
+    {S : Submodule v.integer K} {x : K} (hx : x ∈ S) :
+    leSubmodule v (v x) ≤ S := by
+  rcases eq_or_ne x 0 with rfl | hx0
+  · simp
+  intro y hy
+  have : v ((y : K) / x) ≤ 1 := by simp [div_le_one_of_le₀ hy]
+  simpa [Subring.smul_def, div_mul_cancel₀ _ hx0] using S.smul_mem ⟨_, this⟩ hx
+
+lemma ltSubmodule_v_le_of_mem {K : Type*} [Field K] {v : Valuation K Γ₀}
+    {S : Submodule v.integer K} {x : K} (hx : x ∈ S) (hxv : v x ≠ 0) :
+    ltSubmodule v (Units.mk0 _ hxv) ≤ S :=
+  (leSubmodule_v_le_of_mem v hx).trans' (ltSubmodule_le_leSubmodule _ _)
+
+-- the ideals do not use the submodules due to `Submodule.comap _ (Algebra.linearMap _ _)`
+-- requiring commutativity
+
+/-- The ideal of elements of the valuation subring whose valuation is less than or equal to a
+certain value. -/
+def leIdeal (γ : Γ₀) : Ideal 𝓞 where
+  __ := AddSubgroup.addSubgroupOf (leAddSubgroup v γ) v.integer.toAddSubgroup
+  smul_mem' r x h := by
+    change v ((r : R) * x) ≤ γ -- not sure why simp can't get us to here
+    simpa [Subring.smul_def] using mul_le_of_le_one_of_le r.prop h
+
+/-- The ideal of elements of the valuation subring whose valuation is less than a certain unit. -/
+def ltIdeal (γ : Γ₀ˣ) : Ideal 𝓞 where
+  __ := AddSubgroup.addSubgroupOf (ltAddSubgroup v γ) v.integer.toAddSubgroup
+  smul_mem' r x h := by
+    change v ((r : R) * x) < γ -- not sure why simp can't get us to here
+    simpa [Subring.smul_def] using mul_lt_of_le_one_of_lt r.prop h
+
+-- Can't use `leAddSubgroup` because `addSubgroupOf` is a dependent function
+lemma leIdeal_mono : Monotone (leIdeal v) :=
+  fun _ _ h _ ↦ h.trans'
+
+lemma ltIdeal_mono : Monotone (ltIdeal v) :=
+  fun _ _ h _ ↦ (Units.val_le_val.mpr h).trans_lt'
+
+lemma ltIdeal_le_leIdeal (γ : Γ₀ˣ) :
+    ltIdeal v γ ≤ leIdeal v (γ : Γ₀) :=
+  fun _ h ↦ h.le
+
+variable {v} in
+@[simp]
+lemma mem_leIdeal_iff {γ : Γ₀} {x : 𝓞} :
+    x ∈ leIdeal v γ ↔ v (x : R) ≤ γ :=
+  Iff.rfl
+
+variable {v} in
+@[simp]
+lemma mem_ltIdeal_iff {γ : Γ₀ˣ} {x : 𝓞} :
+    x ∈ ltIdeal v γ ↔ v (x : R) < γ :=
+  Iff.rfl
+
+@[simp]
+lemma leIdeal_zero (K : Type*) [Field K] (v : Valuation K Γ₀) :
+    leIdeal v (0 : Γ₀) = ⊥ := by
+  ext; simp
+
+lemma leSubmodule_comap_algebraMap_eq_leIdeal {K : Type*} [Field K] (v : Valuation K Γ₀) (γ : Γ₀) :
+    (leSubmodule v γ).comap (Algebra.linearMap _ _) = leIdeal v γ :=
+  Submodule.ext fun _ ↦ Iff.rfl
+
+lemma leIdeal_map_algebraMap_eq_leSubmodule_min {K : Type*} [Field K] (v : Valuation K Γ₀)
+    (γ : Γ₀) :
+    Submodule.map (Algebra.linearMap _ _) (leIdeal v γ) = leSubmodule v (min 1 γ) := by
+  ext x
+  simp only [Submodule.mem_map, mem_leIdeal_iff, Algebra.linearMap_apply,
+    exists_and_left, mem_leSubmodule_iff]
+  constructor
+  · rintro ⟨y, hy, rfl⟩
+    rcases min_cases 1 γ with ⟨h, _⟩ | ⟨h, _⟩
+    · rw [h]
+      exact y.prop
+    · rw [h]
+      exact hy
+  · intro hx
+    rcases min_cases 1 γ with ⟨h, h'⟩ | ⟨h, h'⟩ <;> rw [h] at hx
+    · exact ⟨⟨x, hx⟩, hx.trans h', rfl⟩
+    · exact ⟨⟨x, hx.trans h'.le⟩, hx, rfl⟩
+
+-- Ideally, this would follow from `leSubmodule_v_le_of_mem`
+lemma leIdeal_v_le_of_mem {K : Type*} [Field K] (v : Valuation K Γ₀)
+    {I : Ideal v.integer} {x : v.integer} (hx : x ∈ I) :
+    leIdeal v (v (x : K)) ≤ I := by
+  rcases eq_or_ne x 0 with rfl | hx0
+  · simp
+  intro y hy
+  have : v ((y : K) / x) ≤ 1 := by simpa using div_le_one_of_le₀ hy zero_le'
+  convert I.smul_mem ⟨_, this⟩ hx using 1
+  simp [Subtype.ext_iff, div_mul_cancel₀ _ (ZeroMemClass.coe_eq_zero.not.mpr hx0)]
+
+lemma ltIdeal_v_le_of_mem {K : Type*} [Field K] {v : Valuation K Γ₀}
+    {I : Ideal v.integer} {x : v.integer} (hx : x ∈ I) (hxv : v (x : K) ≠ 0) :
+    ltIdeal v (Units.mk0 _ hxv) ≤ I :=
+  (leIdeal_v_le_of_mem v hx).trans' (ltIdeal_le_leIdeal _ _)
+
+end Ideal
+
 end Valuation

--- a/Mathlib/Topology/Algebra/Valued/LocallyCompact.lean
+++ b/Mathlib/Topology/Algebra/Valued/LocallyCompact.lean
@@ -206,7 +206,7 @@ lemma isPrincipalIdealRing_of_compactSpace {F Γ₀} [Field F]
     intro y
     simp only [U]
     split_ifs with hy
-    · refine IsOpen.mem_nhds ((Valued.isOpen_closedball _ hx.ne').preimage ?_) ?_
+    · refine IsOpen.mem_nhds ((Valued.isOpen_closedBall _ hx.ne').preimage ?_) ?_
       · exact continuous_subtype_val
       · simp [hy.le]
     · refine IsOpen.mem_nhds ((Valued.isOpen_sphere _ ?_).preimage ?_) ?_

--- a/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
+++ b/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
@@ -328,7 +328,8 @@ lemma leSubmodule_zero (K : Type u) [Field K] [hv : Valued K Γ₀] :
     leSubmodule K (0 : Γ₀) = ⊥ := by
   ext; simp
 
---- the ideals do not use the submodules due to `Ideal.comap` requiring commutativity
+-- the ideals do not use the submodules due to `Submodule.comap _ (Algebra.linearMap _ _)`
+-- requiring commutativity
 
 /-- The ideal of elements of the valuation subring whose valuation is less than or equal to a
 certain value. -/

--- a/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
+++ b/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
@@ -324,9 +324,28 @@ lemma mem_ltSubmodule_iff {γ : Γ₀ˣ} {x : R} :
   Iff.rfl
 
 @[simp]
-lemma leSubmodule_zero (K : Type u) [Field K] [hv : Valued K Γ₀] :
+lemma leSubmodule_zero (K : Type*) [Field K] [Valued K Γ₀] :
     leSubmodule K (0 : Γ₀) = ⊥ := by
   ext; simp
+
+lemma leSubmodule_v_le_of_mem {K : Type*} [Field K] [Valued K Γ₀]
+    {S : Submodule v.integer K} {x : K} (hx : x ∈ S) :
+    leSubmodule K (v x) ≤ S := by
+  rcases eq_or_ne x 0 with rfl | hx0
+  · simp
+  intro y hy
+  simp only [mem_leSubmodule_iff] at hy
+  have hyx : v ((y : K) / x) ≤ 1 := by
+    simp [map_div₀,div_le_one_of_le₀ hy]
+  have : y = (⟨_, hyx⟩ : v.integer) • x := by
+    rw [Subring.smul_def, smul_eq_mul, mul_comm, mul_div_cancel₀ _ (by simpa using hx0)]
+  rw [this]
+  exact Submodule.smul_mem _ _ hx
+
+lemma ltSubmodule_v_le_of_mem {K : Type*} [Field K] [Valued K Γ₀]
+    {S : Submodule v.integer K} {x : K} (hx : x ∈ S) (hxv : Valued.v x ≠ 0) :
+    ltSubmodule K (Units.mk0 _ hxv) ≤ S :=
+  (leSubmodule_v_le_of_mem hx).trans' (ltSubmodule_le_leSubmodule _ _)
 
 -- the ideals do not use the submodules due to `Submodule.comap _ (Algebra.linearMap _ _)`
 -- requiring commutativity
@@ -370,9 +389,34 @@ lemma mem_ltIdeal_iff {γ : Γ₀ˣ} {x : 𝓞} :
   Iff.rfl
 
 @[simp]
-lemma leIdeal_zero (K : Type u) [Field K] [hv : Valued K Γ₀] :
+lemma leIdeal_zero (K : Type*) [Field K] [hv : Valued K Γ₀] :
     leIdeal K (0 : Γ₀) = ⊥ := by
   ext; simp
+
+lemma leSubmodule_comap_algebraMap_eq_leIdeal {K : Type*} [Field K] [Valued K Γ₀] (γ : Γ₀) :
+    (leSubmodule K γ).comap (Algebra.linearMap _ _) = leIdeal K γ :=
+  Submodule.ext fun _ ↦ Iff.rfl
+
+-- Ideally, this would follow from `leSubmodule_v_le_of_mem`
+lemma leIdeal_v_le_of_mem {K : Type*} [Field K] [Valued K Γ₀]
+    {I : Ideal v.integer} {x : v.integer} (hx : x ∈ I) :
+    leIdeal K (v (x : K)) ≤ I := by
+  rcases eq_or_ne x 0 with rfl | hx0
+  · simp
+  intro y hy
+  simp only [mem_leIdeal_iff] at hy
+  have hyx : v ((y : K) / x) ≤ 1 := by
+    simp [map_div₀,div_le_one_of_le₀ hy]
+  have : y = (⟨_, hyx⟩ : v.integer) * x := by
+    ext
+    rw [Subring.coe_mul, mul_comm, mul_div_cancel₀ _ (by simpa using hx0)]
+  rw [this]
+  exact I.mul_mem_left _ hx
+
+lemma ltIdeal_v_le_of_mem {K : Type*} [Field K] [Valued K Γ₀]
+    {I : Ideal v.integer} {x : v.integer} (hx : x ∈ I) (hxv : Valued.v (x : K) ≠ 0) :
+    ltIdeal K (Units.mk0 _ hxv) ≤ I :=
+  (leIdeal_v_le_of_mem hx).trans' (ltIdeal_le_leIdeal _ _)
 
 lemma isOpen_ltIdeal (γ : Γ₀ˣ) :
     IsOpen (ltIdeal R γ : Set 𝓞) :=

--- a/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
+++ b/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
@@ -334,13 +334,8 @@ lemma leSubmodule_v_le_of_mem {K : Type*} [Field K] [Valued K Γ₀]
   rcases eq_or_ne x 0 with rfl | hx0
   · simp
   intro y hy
-  simp only [mem_leSubmodule_iff] at hy
-  have hyx : v ((y : K) / x) ≤ 1 := by
-    simp [map_div₀,div_le_one_of_le₀ hy]
-  have : y = (⟨_, hyx⟩ : v.integer) • x := by
-    rw [Subring.smul_def, smul_eq_mul, mul_comm, mul_div_cancel₀ _ (by simpa using hx0)]
-  rw [this]
-  exact Submodule.smul_mem _ _ hx
+  have : v ((y : K) / x) ≤ 1 := by simp [div_le_one_of_le₀ hy]
+  simpa [Subring.smul_def, div_mul_cancel₀ _ hx0] using S.smul_mem ⟨_, this⟩ hx
 
 lemma ltSubmodule_v_le_of_mem {K : Type*} [Field K] [Valued K Γ₀]
     {S : Submodule v.integer K} {x : K} (hx : x ∈ S) (hxv : Valued.v x ≠ 0) :
@@ -404,14 +399,9 @@ lemma leIdeal_v_le_of_mem {K : Type*} [Field K] [Valued K Γ₀]
   rcases eq_or_ne x 0 with rfl | hx0
   · simp
   intro y hy
-  simp only [mem_leIdeal_iff] at hy
-  have hyx : v ((y : K) / x) ≤ 1 := by
-    simp [map_div₀,div_le_one_of_le₀ hy]
-  have : y = (⟨_, hyx⟩ : v.integer) * x := by
-    ext
-    rw [Subring.coe_mul, mul_comm, mul_div_cancel₀ _ (by simpa using hx0)]
-  rw [this]
-  exact I.mul_mem_left _ hx
+  have : v ((y : K) / x) ≤ 1 := by simpa using div_le_one_of_le₀ hy zero_le'
+  convert I.smul_mem ⟨_, this⟩ hx using 1
+  simp [Subtype.ext_iff, div_mul_cancel₀ _ (ZeroMemClass.coe_eq_zero.not.mpr hx0)]
 
 lemma ltIdeal_v_le_of_mem {K : Type*} [Field K] [Valued K Γ₀]
     {I : Ideal v.integer} {x : v.integer} (hx : x ∈ I) (hxv : Valued.v (x : K) ≠ 0) :

--- a/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
+++ b/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
@@ -161,13 +161,16 @@ theorem isClopen_ball (r : Γ₀) : IsClopen (X := R) {x | v x < r} :=
   ⟨isClosed_ball _ _, isOpen_ball _ _⟩
 
 /-- A closed ball centred at the origin in a valued ring is open. -/
-theorem isOpen_closedball {r : Γ₀} (hr : r ≠ 0) : IsOpen (X := R) {x | v x ≤ r} := by
+theorem isOpen_closedBall {r : Γ₀} (hr : r ≠ 0) : IsOpen (X := R) {x | v x ≤ r} := by
   rw [isOpen_iff_mem_nhds]
   intro x hx
   rw [mem_nhds]
   simp only [setOf_subset_setOf]
   exact ⟨Units.mk0 _ hr,
     fun y hy => (sub_add_cancel y x).symm ▸ le_trans (v.map_add _ _) (max_le (le_of_lt hy) hx)⟩
+
+@[deprecated (since := "2025-06-04")]
+alias isOpen_closedball := isOpen_closedBall
 
 /-- A closed ball centred at the origin in a valued ring is closed. -/
 theorem isClosed_closedBall (r : Γ₀) : IsClosed (X := R) {x | v x ≤ r} := by
@@ -202,7 +205,7 @@ theorem isClosed_sphere (r : Γ₀) : IsClosed (X := R) {x | v x = r} := by
 
 /-- The closed unit ball in a valued ring is open. -/
 theorem isOpen_integer : IsOpen (_i.v.integer : Set R) :=
-  isOpen_closedball _ one_ne_zero
+  isOpen_closedBall _ one_ne_zero
 
 @[deprecated (since := "2025-04-25")]
 alias integer_isOpen := isOpen_integer

--- a/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
+++ b/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
@@ -323,7 +323,12 @@ lemma mem_ltSubmodule_iff {γ : Γ₀ˣ} {x : R} :
     x ∈ ltSubmodule R γ ↔ v x < γ :=
   Iff.rfl
 
--- the ideals do not use the submodules due to `Ideal.comap` requiring commutativity
+@[simp]
+lemma leSubmodule_zero (K : Type u) [Field K] [hv : Valued K Γ₀] :
+    leSubmodule K (0 : Γ₀) = ⊥ := by
+  ext; simp
+
+--- the ideals do not use the submodules due to `Ideal.comap` requiring commutativity
 
 /-- The ideal of elements of the valuation subring whose valuation is less than or equal to a
 certain value. -/
@@ -362,6 +367,11 @@ variable {R} in
 lemma mem_ltIdeal_iff {γ : Γ₀ˣ} {x : 𝓞} :
     x ∈ ltIdeal R γ ↔ v (x : R) < γ :=
   Iff.rfl
+
+@[simp]
+lemma leIdeal_zero (K : Type u) [Field K] [hv : Valued K Γ₀] :
+    leIdeal K (0 : Γ₀) = ⊥ := by
+  ext; simp
 
 lemma isOpen_ltIdeal (γ : Γ₀ˣ) :
     IsOpen (ltIdeal R γ : Set 𝓞) :=

--- a/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
+++ b/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
@@ -31,10 +31,9 @@ variable (v : Valuation R Γ₀)
 
 /-- The basis of open subgroups for the topology on a ring determined by a valuation. -/
 theorem subgroups_basis : RingSubgroupsBasis fun γ : Γ₀ˣ => (v.ltAddSubgroup γ : AddSubgroup R) :=
-  { inter := by
-      rintro γ₀ γ₁
-      use min γ₀ γ₁
-      simp [SetLike.le_def]
+  { inter _ _ :=
+      ⟨_, le_inf
+        (ltAddSubgroup_mono _ (min_le_left _ _)) (ltAddSubgroup_mono _ (min_le_right _ _))⟩
     mul := by
       rintro γ
       obtain ⟨γ₀, h⟩ := exists_square_le γ

--- a/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
+++ b/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
@@ -34,16 +34,13 @@ theorem subgroups_basis : RingSubgroupsBasis fun γ : Γ₀ˣ => (v.ltAddSubgrou
   { inter := by
       rintro γ₀ γ₁
       use min γ₀ γ₁
-      simp only [ltAddSubgroup, Units.min_val, Units.val_le_val, lt_min_iff,
-        AddSubgroup.mk_le_mk, setOf_subset_setOf, le_inf_iff, and_imp, imp_self, implies_true,
-        forall_const, and_true]
-      tauto
+      simp [SetLike.le_def]
     mul := by
       rintro γ
       obtain ⟨γ₀, h⟩ := exists_square_le γ
       use γ₀
       rintro - ⟨r, r_in, s, s_in, rfl⟩
-      simp only [ltAddSubgroup, AddSubgroup.coe_set_mk, mem_setOf_eq] at r_in s_in
+      simp only [SetLike.mem_coe, mem_ltAddSubgroup_iff] at r_in s_in
       calc
         (v (r * s) : Γ₀) = v r * v s := Valuation.map_mul _ _ _
         _ < γ₀ * γ₀ := by gcongr <;> exact zero_le'
@@ -52,30 +49,17 @@ theorem subgroups_basis : RingSubgroupsBasis fun γ : Γ₀ˣ => (v.ltAddSubgrou
       rintro x γ
       rcases GroupWithZero.eq_zero_or_unit (v x) with (Hx | ⟨γx, Hx⟩)
       · use (1 : Γ₀ˣ)
-        rintro y _
-        change v (x * y) < _
-        rw [Valuation.map_mul, Hx, zero_mul]
-        exact Units.zero_lt γ
+        rintro y
+        simp [Hx]
       · use γx⁻¹ * γ
-        rintro y (vy_lt : v y < ↑(γx⁻¹ * γ))
-        change (v (x * y) : Γ₀) < γ
-        rw [Valuation.map_mul, Hx, mul_comm]
-        rw [Units.val_mul, mul_comm] at vy_lt
-        simpa using mul_inv_lt_of_lt_mul₀ vy_lt
+        simp [subset_def, lt_inv_mul_iff₀, Hx]
     rightMul := by
       rintro x γ
       rcases GroupWithZero.eq_zero_or_unit (v x) with (Hx | ⟨γx, Hx⟩)
       · use 1
-        rintro y _
-        change v (y * x) < _
-        rw [Valuation.map_mul, Hx, mul_zero]
-        exact Units.zero_lt γ
+        simp [subset_def, Hx]
       · use γx⁻¹ * γ
-        rintro y (vy_lt : v y < ↑(γx⁻¹ * γ))
-        change (v (y * x) : Γ₀) < γ
-        rw [Valuation.map_mul, Hx]
-        rw [Units.val_mul, mul_comm] at vy_lt
-        simpa using mul_inv_lt_of_lt_mul₀ vy_lt }
+        simp [subset_def, lt_mul_inv_iff₀, Hx, mul_comm] }
 
 end Valuation
 

--- a/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
+++ b/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
@@ -233,4 +233,85 @@ theorem isClopen_valuationSubring (K : Type u) [Field K] [hv : Valued K Γ₀] :
     IsClopen (hv.v.valuationSubring : Set K) :=
   isClopen_integer K
 
+section Ideal
+
+local notation "𝓞" => _i.v.integer
+
+/-- The submodule of over the valuation subring whose valuation is less than or equal to a
+certain value. -/
+def leSubmodule (γ : Γ₀) : Submodule 𝓞 R where
+  __ := leAddSubgroup v γ
+  smul_mem' r x h := by
+    simpa [Subring.smul_def] using mul_le_of_le_one_of_le r.prop h
+
+/-- The submodule of over the valuation subring whose valuation is less than a certain unit. -/
+def ltSubmodule (γ : Γ₀ˣ) : Submodule 𝓞 R where
+  __ := ltAddSubgroup v γ
+  smul_mem' r x h := by
+    simpa [Subring.smul_def] using mul_lt_of_le_one_of_lt r.prop h
+
+lemma leSubmodule_mono : Monotone (leSubmodule R) :=
+  leAddSubgroup_mono v
+
+lemma ltSubmodule_mono : Monotone (ltSubmodule R) :=
+  ltAddSubgroup_mono v
+
+lemma ltSubmodule_le_leSubmodule (γ : Γ₀ˣ) :
+    ltSubmodule R γ ≤ leSubmodule R (γ : Γ₀) :=
+  ltAddSubgroup_le_leAddSubgroup v γ
+
+variable {R} in
+@[simp]
+lemma mem_leSubmodule_iff {γ : Γ₀} {x : R} :
+    x ∈ leSubmodule R γ ↔ v x ≤ γ :=
+  Iff.rfl
+
+variable {R} in
+@[simp]
+lemma mem_ltSubmodule_iff {γ : Γ₀ˣ} {x : R} :
+    x ∈ ltSubmodule R γ ↔ v x < γ :=
+  Iff.rfl
+
+-- the ideals do not use the submodules due to `Ideal.comap` requiring commutativity
+
+/-- The ideal of elements of the valuation subring whose valuation is less than or equal to a
+certain value. -/
+def leIdeal (γ : Γ₀) : Ideal 𝓞 where
+  __ := AddSubgroup.addSubgroupOf (leAddSubgroup v γ) _i.v.integer.toAddSubgroup
+  smul_mem' r x h := by
+    change v ((r : R) * x) ≤ γ -- not sure why simp can't get us to here
+    simpa [Subring.smul_def] using mul_le_of_le_one_of_le r.prop h
+
+/-- The ideal of elements of the valuation subring whose valuation is less than a certain unit. -/
+def ltIdeal (γ : Γ₀ˣ) : Ideal 𝓞 where
+  __ := AddSubgroup.addSubgroupOf (ltAddSubgroup v γ) _i.v.integer.toAddSubgroup
+  smul_mem' r x h := by
+    change v ((r : R) * x) < γ -- not sure why simp can't get us to here
+    simpa [Subring.smul_def] using mul_lt_of_le_one_of_lt r.prop h
+
+-- Can't use `leAddSubgroup` because `addSubgroupOf` is a dependent function
+lemma leIdeal_mono : Monotone (leIdeal R) :=
+  fun _ _ h _ ↦ h.trans'
+
+lemma ltIdeal_mono : Monotone (ltIdeal R) :=
+  fun _ _ h _ ↦ (Units.val_le_val.mpr h).trans_lt'
+
+lemma ltIdeal_le_leIdeal (γ : Γ₀ˣ) :
+    ltIdeal R γ ≤ leIdeal R (γ : Γ₀) :=
+  fun _ h ↦ h.le
+
+variable {R} in
+@[simp]
+lemma mem_leIdeal_iff {γ : Γ₀} {x : 𝓞} :
+    x ∈ leIdeal R γ ↔ v (x : R) ≤ γ :=
+  Iff.rfl
+
+variable {R} in
+@[simp]
+lemma mem_ltIdeal_iff {γ : Γ₀ˣ} {x : 𝓞} :
+    x ∈ ltIdeal R γ ↔ v (x : R) < γ :=
+  Iff.rfl
+
+end Ideal
+
 end Valued

--- a/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
+++ b/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
@@ -160,6 +160,18 @@ theorem isClosed_ball (r : Γ₀) : IsClosed (X := R) {x | v x < r} := by
 theorem isClopen_ball (r : Γ₀) : IsClopen (X := R) {x | v x < r} :=
   ⟨isClosed_ball _ _, isOpen_ball _ _⟩
 
+lemma isOpen_ltAddSubgroup (γ : Γ₀ˣ) :
+    IsOpen ((v.ltAddSubgroup γ : AddSubgroup R) : Set R) :=
+  isOpen_ball _ _
+
+lemma isClosed_ltAddSubgroup (γ : Γ₀ˣ) :
+    IsClosed ((v.ltAddSubgroup γ : AddSubgroup R) : Set R) :=
+  isClosed_ball _ _
+
+lemma isClopen_ltAddSubgroup (γ : Γ₀ˣ) :
+    IsClopen ((v.ltAddSubgroup γ : AddSubgroup R) : Set R) :=
+  isClopen_ball _ _
+
 /-- A closed ball centred at the origin in a valued ring is open. -/
 theorem isOpen_closedBall {r : Γ₀} (hr : r ≠ 0) : IsOpen (X := R) {x | v x ≤ r} := by
   rw [isOpen_iff_mem_nhds]
@@ -183,7 +195,19 @@ theorem isClosed_closedBall (r : Γ₀) : IsClosed (X := R) {x | v x ≤ r} := b
 
 /-- A closed ball centred at the origin in a valued ring is clopen. -/
 theorem isClopen_closedBall {r : Γ₀} (hr : r ≠ 0) : IsClopen (X := R) {x | v x ≤ r} :=
-  ⟨isClosed_closedBall _ _, isOpen_closedball _ hr⟩
+  ⟨isClosed_closedBall _ _, isOpen_closedBall _ hr⟩
+
+lemma isOpen_leAddSubgroup {γ : Γ₀} (hγ : γ ≠ 0) :
+    IsOpen ((v.leAddSubgroup γ : AddSubgroup R) : Set R) :=
+  isOpen_closedBall _ hγ
+
+lemma isClosed_leAddSubgroup (γ : Γ₀) :
+    IsClosed ((v.leAddSubgroup γ : AddSubgroup R) : Set R) :=
+  isClosed_closedBall _ _
+
+lemma isClopen_leAddSubgroup {γ : Γ₀} (hγ : γ ≠ 0) :
+    IsClopen ((v.leAddSubgroup γ : AddSubgroup R) : Set R) :=
+  isClopen_closedBall _ hγ
 
 /-- A sphere centred at the origin in a valued ring is clopen. -/
 theorem isClopen_sphere {r : Γ₀} (hr : r ≠ 0) : IsClopen (X := R) {x | v x = r} := by
@@ -263,6 +287,30 @@ lemma ltSubmodule_le_leSubmodule (γ : Γ₀ˣ) :
     ltSubmodule R γ ≤ leSubmodule R (γ : Γ₀) :=
   ltAddSubgroup_le_leAddSubgroup v γ
 
+lemma isOpen_ltSubmodule (γ : Γ₀ˣ) :
+    IsOpen (ltSubmodule R γ : Set R) :=
+  isOpen_ball _ _
+
+lemma isClosed_ltSubmodule (γ : Γ₀ˣ) :
+    IsClosed (ltSubmodule R γ : Set R) :=
+  isClosed_ball _ _
+
+lemma isClopen_ltSubmodule (γ : Γ₀ˣ) :
+    IsClopen (ltSubmodule R γ : Set R) :=
+  isClopen_ball _ _
+
+lemma isOpen_leSubmodule {γ : Γ₀} (hγ : γ ≠ 0) :
+    IsOpen (leSubmodule R γ : Set R) :=
+  isOpen_closedBall _ hγ
+
+lemma isClosed_leSubmodule (γ : Γ₀) :
+    IsClosed (leSubmodule R γ : Set R) :=
+  isClosed_closedBall _ _
+
+lemma isClopen_leSubmodule {γ : Γ₀} (hγ : γ ≠ 0) :
+    IsClopen (leSubmodule R γ : Set R) :=
+  isClopen_closedBall _ hγ
+
 variable {R} in
 @[simp]
 lemma mem_leSubmodule_iff {γ : Γ₀} {x : R} :
@@ -314,6 +362,30 @@ variable {R} in
 lemma mem_ltIdeal_iff {γ : Γ₀ˣ} {x : 𝓞} :
     x ∈ ltIdeal R γ ↔ v (x : R) < γ :=
   Iff.rfl
+
+lemma isOpen_ltIdeal (γ : Γ₀ˣ) :
+    IsOpen (ltIdeal R γ : Set 𝓞) :=
+  isOpen_ball _ _ |>.preimage continuous_subtype_val
+
+lemma isClosed_ltIdeal (γ : Γ₀ˣ) :
+    IsClosed (ltIdeal R γ : Set 𝓞) :=
+  isClosed_ball _ _ |>.preimage continuous_subtype_val
+
+lemma isClopen_ltIdeal (γ : Γ₀ˣ) :
+    IsClopen (ltIdeal R γ : Set 𝓞) :=
+  isClopen_ball _ _ |>.preimage continuous_subtype_val
+
+lemma isOpen_leIdeal {γ : Γ₀} (hγ : γ ≠ 0) :
+    IsOpen (leIdeal R γ : Set 𝓞) :=
+  isOpen_closedBall _ hγ |>.preimage continuous_subtype_val
+
+lemma isClosed_leIdeal (γ : Γ₀) :
+    IsClosed (leIdeal R γ : Set 𝓞) :=
+  isClosed_closedBall _ _ |>.preimage continuous_subtype_val
+
+lemma isClopen_leIdeal {γ : Γ₀} (hγ : γ ≠ 0) :
+    IsClopen (leIdeal R γ : Set 𝓞) :=
+  isClopen_closedBall _ hγ |>.preimage continuous_subtype_val
 
 end Ideal
 

--- a/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
+++ b/Mathlib/Topology/Algebra/Valued/ValuationTopology.lean
@@ -264,172 +264,52 @@ section Ideal
 
 local notation "𝓞" => _i.v.integer
 
-/-- The submodule of over the valuation subring whose valuation is less than or equal to a
-certain value. -/
-def leSubmodule (γ : Γ₀) : Submodule 𝓞 R where
-  __ := leAddSubgroup v γ
-  smul_mem' r x h := by
-    simpa [Subring.smul_def] using mul_le_of_le_one_of_le r.prop h
-
-/-- The submodule of over the valuation subring whose valuation is less than a certain unit. -/
-def ltSubmodule (γ : Γ₀ˣ) : Submodule 𝓞 R where
-  __ := ltAddSubgroup v γ
-  smul_mem' r x h := by
-    simpa [Subring.smul_def] using mul_lt_of_le_one_of_lt r.prop h
-
-lemma leSubmodule_mono : Monotone (leSubmodule R) :=
-  leAddSubgroup_mono v
-
-lemma ltSubmodule_mono : Monotone (ltSubmodule R) :=
-  ltAddSubgroup_mono v
-
-lemma ltSubmodule_le_leSubmodule (γ : Γ₀ˣ) :
-    ltSubmodule R γ ≤ leSubmodule R (γ : Γ₀) :=
-  ltAddSubgroup_le_leAddSubgroup v γ
-
 lemma isOpen_ltSubmodule (γ : Γ₀ˣ) :
-    IsOpen (ltSubmodule R γ : Set R) :=
+    IsOpen ((ltSubmodule v γ : Submodule 𝓞 R) : Set R) :=
   isOpen_ball _ _
 
 lemma isClosed_ltSubmodule (γ : Γ₀ˣ) :
-    IsClosed (ltSubmodule R γ : Set R) :=
+    IsClosed ((ltSubmodule v γ : Submodule 𝓞 R) : Set R) :=
   isClosed_ball _ _
 
 lemma isClopen_ltSubmodule (γ : Γ₀ˣ) :
-    IsClopen (ltSubmodule R γ : Set R) :=
+    IsClopen ((ltSubmodule v γ : Submodule 𝓞 R) : Set R) :=
   isClopen_ball _ _
 
 lemma isOpen_leSubmodule {γ : Γ₀} (hγ : γ ≠ 0) :
-    IsOpen (leSubmodule R γ : Set R) :=
+    IsOpen ((leSubmodule v γ : Submodule 𝓞 R) : Set R) :=
   isOpen_closedBall _ hγ
 
 lemma isClosed_leSubmodule (γ : Γ₀) :
-    IsClosed (leSubmodule R γ : Set R) :=
+    IsClosed ((leSubmodule v γ : Submodule 𝓞 R) : Set R) :=
   isClosed_closedBall _ _
 
 lemma isClopen_leSubmodule {γ : Γ₀} (hγ : γ ≠ 0) :
-    IsClopen (leSubmodule R γ : Set R) :=
+    IsClopen ((leSubmodule v γ : Submodule 𝓞 R) : Set R) :=
   isClopen_closedBall _ hγ
 
-variable {R} in
-@[simp]
-lemma mem_leSubmodule_iff {γ : Γ₀} {x : R} :
-    x ∈ leSubmodule R γ ↔ v x ≤ γ :=
-  Iff.rfl
-
-variable {R} in
-@[simp]
-lemma mem_ltSubmodule_iff {γ : Γ₀ˣ} {x : R} :
-    x ∈ ltSubmodule R γ ↔ v x < γ :=
-  Iff.rfl
-
-@[simp]
-lemma leSubmodule_zero (K : Type*) [Field K] [Valued K Γ₀] :
-    leSubmodule K (0 : Γ₀) = ⊥ := by
-  ext; simp
-
-lemma leSubmodule_v_le_of_mem {K : Type*} [Field K] [Valued K Γ₀]
-    {S : Submodule v.integer K} {x : K} (hx : x ∈ S) :
-    leSubmodule K (v x) ≤ S := by
-  rcases eq_or_ne x 0 with rfl | hx0
-  · simp
-  intro y hy
-  have : v ((y : K) / x) ≤ 1 := by simp [div_le_one_of_le₀ hy]
-  simpa [Subring.smul_def, div_mul_cancel₀ _ hx0] using S.smul_mem ⟨_, this⟩ hx
-
-lemma ltSubmodule_v_le_of_mem {K : Type*} [Field K] [Valued K Γ₀]
-    {S : Submodule v.integer K} {x : K} (hx : x ∈ S) (hxv : Valued.v x ≠ 0) :
-    ltSubmodule K (Units.mk0 _ hxv) ≤ S :=
-  (leSubmodule_v_le_of_mem hx).trans' (ltSubmodule_le_leSubmodule _ _)
-
--- the ideals do not use the submodules due to `Submodule.comap _ (Algebra.linearMap _ _)`
--- requiring commutativity
-
-/-- The ideal of elements of the valuation subring whose valuation is less than or equal to a
-certain value. -/
-def leIdeal (γ : Γ₀) : Ideal 𝓞 where
-  __ := AddSubgroup.addSubgroupOf (leAddSubgroup v γ) _i.v.integer.toAddSubgroup
-  smul_mem' r x h := by
-    change v ((r : R) * x) ≤ γ -- not sure why simp can't get us to here
-    simpa [Subring.smul_def] using mul_le_of_le_one_of_le r.prop h
-
-/-- The ideal of elements of the valuation subring whose valuation is less than a certain unit. -/
-def ltIdeal (γ : Γ₀ˣ) : Ideal 𝓞 where
-  __ := AddSubgroup.addSubgroupOf (ltAddSubgroup v γ) _i.v.integer.toAddSubgroup
-  smul_mem' r x h := by
-    change v ((r : R) * x) < γ -- not sure why simp can't get us to here
-    simpa [Subring.smul_def] using mul_lt_of_le_one_of_lt r.prop h
-
--- Can't use `leAddSubgroup` because `addSubgroupOf` is a dependent function
-lemma leIdeal_mono : Monotone (leIdeal R) :=
-  fun _ _ h _ ↦ h.trans'
-
-lemma ltIdeal_mono : Monotone (ltIdeal R) :=
-  fun _ _ h _ ↦ (Units.val_le_val.mpr h).trans_lt'
-
-lemma ltIdeal_le_leIdeal (γ : Γ₀ˣ) :
-    ltIdeal R γ ≤ leIdeal R (γ : Γ₀) :=
-  fun _ h ↦ h.le
-
-variable {R} in
-@[simp]
-lemma mem_leIdeal_iff {γ : Γ₀} {x : 𝓞} :
-    x ∈ leIdeal R γ ↔ v (x : R) ≤ γ :=
-  Iff.rfl
-
-variable {R} in
-@[simp]
-lemma mem_ltIdeal_iff {γ : Γ₀ˣ} {x : 𝓞} :
-    x ∈ ltIdeal R γ ↔ v (x : R) < γ :=
-  Iff.rfl
-
-@[simp]
-lemma leIdeal_zero (K : Type*) [Field K] [hv : Valued K Γ₀] :
-    leIdeal K (0 : Γ₀) = ⊥ := by
-  ext; simp
-
-lemma leSubmodule_comap_algebraMap_eq_leIdeal {K : Type*} [Field K] [Valued K Γ₀] (γ : Γ₀) :
-    (leSubmodule K γ).comap (Algebra.linearMap _ _) = leIdeal K γ :=
-  Submodule.ext fun _ ↦ Iff.rfl
-
--- Ideally, this would follow from `leSubmodule_v_le_of_mem`
-lemma leIdeal_v_le_of_mem {K : Type*} [Field K] [Valued K Γ₀]
-    {I : Ideal v.integer} {x : v.integer} (hx : x ∈ I) :
-    leIdeal K (v (x : K)) ≤ I := by
-  rcases eq_or_ne x 0 with rfl | hx0
-  · simp
-  intro y hy
-  have : v ((y : K) / x) ≤ 1 := by simpa using div_le_one_of_le₀ hy zero_le'
-  convert I.smul_mem ⟨_, this⟩ hx using 1
-  simp [Subtype.ext_iff, div_mul_cancel₀ _ (ZeroMemClass.coe_eq_zero.not.mpr hx0)]
-
-lemma ltIdeal_v_le_of_mem {K : Type*} [Field K] [Valued K Γ₀]
-    {I : Ideal v.integer} {x : v.integer} (hx : x ∈ I) (hxv : Valued.v (x : K) ≠ 0) :
-    ltIdeal K (Units.mk0 _ hxv) ≤ I :=
-  (leIdeal_v_le_of_mem hx).trans' (ltIdeal_le_leIdeal _ _)
-
 lemma isOpen_ltIdeal (γ : Γ₀ˣ) :
-    IsOpen (ltIdeal R γ : Set 𝓞) :=
+    IsOpen ((ltIdeal v γ : Ideal 𝓞) : Set 𝓞) :=
   isOpen_ball _ _ |>.preimage continuous_subtype_val
 
 lemma isClosed_ltIdeal (γ : Γ₀ˣ) :
-    IsClosed (ltIdeal R γ : Set 𝓞) :=
+    IsClosed ((ltIdeal v γ : Ideal 𝓞) : Set 𝓞) :=
   isClosed_ball _ _ |>.preimage continuous_subtype_val
 
 lemma isClopen_ltIdeal (γ : Γ₀ˣ) :
-    IsClopen (ltIdeal R γ : Set 𝓞) :=
+    IsClopen ((ltIdeal v γ : Ideal 𝓞) : Set 𝓞) :=
   isClopen_ball _ _ |>.preimage continuous_subtype_val
 
 lemma isOpen_leIdeal {γ : Γ₀} (hγ : γ ≠ 0) :
-    IsOpen (leIdeal R γ : Set 𝓞) :=
+    IsOpen ((leIdeal v γ : Ideal 𝓞) : Set 𝓞) :=
   isOpen_closedBall _ hγ |>.preimage continuous_subtype_val
 
 lemma isClosed_leIdeal (γ : Γ₀) :
-    IsClosed (leIdeal R γ : Set 𝓞) :=
+    IsClosed ((leIdeal v γ : Ideal 𝓞) : Set 𝓞) :=
   isClosed_closedBall _ _ |>.preimage continuous_subtype_val
 
 lemma isClopen_leIdeal {γ : Γ₀} (hγ : γ ≠ 0) :
-    IsClopen (leIdeal R γ : Set 𝓞) :=
+    IsClopen ((leIdeal v γ : Ideal 𝓞) : Set 𝓞) :=
   isClopen_closedBall _ hγ |>.preimage continuous_subtype_val
 
 end Ideal


### PR DESCRIPTION
Also prove that these are clopen.

Factored out of #24627

Fix capitalization spelling mistake on `closedball` in a lemma

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
