### PR TITLE
[Merged by Bors] - fix: change token so Zulip reaction workflow is triggered

### DIFF
--- a/.github/workflows/maintainer_merge.yml
+++ b/.github/workflows/maintainer_merge.yml
@@ -113,7 +113,8 @@ jobs:
         if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          # labels added by GITHUB_TOKEN won't trigger the Zulip emoji workflow
+          github-token: ${{secrets.TRIAGE_TOKEN}}
           script: |
             const { owner, repo, number: issue_number } = context.issue;
             await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['maintainer-merge'] });


### PR DESCRIPTION
Currently the "maintainer merge" workflow adds labels using `GITHUB_TOKEN`, which means that the labeling event cannot trigger the Zulip emoji reaction workflow. Here we switch to using `TRIAGE_TOKEN`, which is what is used in the `maintainer_bors.yml` workflow for labeling / unlabeling.

cf. #25449.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
