### PR TITLE
[Merged by Bors] - feat(Data/Nat/Log) : when log and clog of successive integers are equal

### DIFF
--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -182,11 +182,10 @@ theorem log_lt_log_succ_iff {b n : ℕ} (hb : 1 < b) (hn : n ≠ 0) :
   · exact le_antisymm (lt_pow_of_log_lt hb H) (Nat.pow_log_le_self b (by simp))
   · exact Nat.log_lt_of_lt_pow hn (by simp [← H])
 
-theorem log_eq_log_succ_iff {b n : ℕ} (hb : 1 < b) (hn : 1 ≤ n) :
-    log b n = log b (n + 1) ↔ n + 1 ≠ b ^ (log b (n + 1)) := by
-  rw [ne_eq, ← log_lt_log_succ_iff hb hn, not_lt]
-  simp only [le_antisymm_iff, and_iff_right_iff_imp]
-  exact fun  _ ↦ log_monotone (le_add_right n 1)
+theorem log_eq_log_succ_iff {b n : ℕ} (hb : 1 < b) (hn : n ≠ 0) :
+    log b n = log b (n + 1) ↔ n + 1 ≠ b ^ log b (n + 1) := by
+  rw [ne_eq, ← log_lt_log_succ_iff hb hn, not_lt, le_antisymm_iff, and_iff_right]
+  exact log_monotone (le_add_right n 1)
 
 @[mono]
 theorem log_anti_left {b c n : ℕ} (hc : 1 < c) (hb : c ≤ b) : log b n ≤ log c n := by

--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -177,15 +177,15 @@ theorem log_mono_right {b n m : ℕ} (h : n ≤ m) : log b n ≤ log b m :=
   log_monotone h
 
 theorem log_lt_log_succ_iff {b n : ℕ} (hb : 1 < b) (hn : 1 ≤ n) :
-    log b n < Nat.log b (n + 1) ↔ n + 1 = b ^ (Nat.log b (n + 1)) := by
+    log b n < Nat.log b (n + 1) ↔ b ^ (Nat.log b (n + 1)) = n + 1:= by
   refine ⟨fun H ↦ ?_, fun H ↦ ?_⟩
-  · apply le_antisymm (Nat.lt_pow_of_log_lt hb H)
+  · apply le_antisymm _ (Nat.lt_pow_of_log_lt hb H)
     exact Nat.pow_log_le_self b (Ne.symm (Nat.zero_ne_add_one n))
   · apply Nat.log_lt_of_lt_pow (Nat.ne_zero_of_lt hn)
-    simp [← H]
+    simp [H]
 
 theorem log_eq_log_succ_iff {b n : ℕ} (hb : 1 < b) (hn : 1 ≤ n) :
-    log b n = log b (n + 1) ↔ n + 1 ≠ b ^ (log b (n + 1)) := by
+    log b n = log b (n + 1) ↔ b ^ (log b (n + 1)) ≠ n + 1 := by
   rw [ne_eq, ← log_lt_log_succ_iff hb hn, not_lt]
   simp only [le_antisymm_iff, and_iff_right_iff_imp]
   exact fun  _ ↦ log_monotone (le_add_right n 1)
@@ -337,16 +337,16 @@ theorem log_le_clog (b n : ℕ) : log b n ≤ clog b n := by
       ((pow_log_le_self b n.succ_ne_zero).trans <| le_pow_clog hb _)
 
 theorem clog_lt_clog_succ_iff {b n : ℕ} (hb : 1 < b) :
-    clog b n < clog b (n + 1) ↔ n  = b ^ (clog b n) := by
+    clog b n < clog b (n + 1) ↔ b ^ (clog b n) = n := by
   refine ⟨fun H ↦ ?_, fun H ↦ ?_⟩
-  · apply le_antisymm (le_pow_clog hb n)
+  · apply le_antisymm _ (le_pow_clog hb n)
     apply le_of_lt_succ
     exact (pow_lt_iff_lt_clog hb).mpr H
-  · rw [← pow_lt_iff_lt_clog hb, ← H]
+  · rw [← pow_lt_iff_lt_clog hb, H]
     exact n.lt_add_one
 
 theorem clog_eq_clog_succ_iff {b n : ℕ} (hb : 1 < b) :
-    clog b n = clog b (n + 1) ↔ n ≠ b ^ (clog b n) := by
+    clog b n = clog b (n + 1) ↔ b ^ (clog b n) ≠ n := by
   rw [ne_eq, ← clog_lt_clog_succ_iff hb, not_lt]
   simp only [le_antisymm_iff, and_iff_right_iff_imp]
   exact fun _ ↦ clog_monotone b (le_add_right n 1)

--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -334,7 +334,7 @@ theorem log_le_clog (b n : ℕ) : log b n ≤ clog b n := by
       ((pow_log_le_self b n.succ_ne_zero).trans <| le_pow_clog hb _)
 
 theorem clog_lt_clog_succ_iff {b n : ℕ} (hb : 1 < b) :
-    clog b n < clog b (n + 1) ↔ n  = b ^ (clog b n) := by
+    clog b n < clog b (n + 1) ↔ n = b ^ clog b n := by
   refine ⟨fun H ↦ ?_, fun H ↦ ?_⟩
   · apply le_antisymm (le_pow_clog hb n)
     apply le_of_lt_succ

--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -176,15 +176,15 @@ theorem log_monotone {b : ℕ} : Monotone (log b) := by
 theorem log_mono_right {b n m : ℕ} (h : n ≤ m) : log b n ≤ log b m :=
   log_monotone h
 
-theorem log_lt_log_succ_iff {b n : ℕ} (hb : 1 < b) (hn : 1 ≤ n) :
+theorem log_lt_log_succ_iff {b n : ℕ} (hb : 1 < b) (hn : n ≠ 0) :
     log b n < Nat.log b (n + 1) ↔ b ^ (Nat.log b (n + 1)) = n + 1:= by
   refine ⟨fun H ↦ ?_, fun H ↦ ?_⟩
   · apply le_antisymm _ (Nat.lt_pow_of_log_lt hb H)
     exact Nat.pow_log_le_self b (Ne.symm (Nat.zero_ne_add_one n))
-  · apply Nat.log_lt_of_lt_pow (Nat.ne_zero_of_lt hn)
+  · apply Nat.log_lt_of_lt_pow hn
     simp [H]
 
-theorem log_eq_log_succ_iff {b n : ℕ} (hb : 1 < b) (hn : 1 ≤ n) :
+theorem log_eq_log_succ_iff {b n : ℕ} (hb : 1 < b) (hn : n ≠ 0) :
     log b n = log b (n + 1) ↔ b ^ (log b (n + 1)) ≠ n + 1 := by
   rw [ne_eq, ← log_lt_log_succ_iff hb hn, not_lt]
   simp only [le_antisymm_iff, and_iff_right_iff_imp]

--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -337,7 +337,7 @@ theorem log_le_clog (b n : ℕ) : log b n ≤ clog b n := by
       ((pow_log_le_self b n.succ_ne_zero).trans <| le_pow_clog hb _)
 
 theorem clog_lt_clog_succ_iff {b n : ℕ} (hb : 1 < b) :
-    clog b n < clog b (n + 1) ↔ b ^ (clog b n) = n := by
+    clog b n < clog b (n + 1) ↔ b ^ clog b n = n := by
   refine ⟨fun H ↦ ?_, fun H ↦ ?_⟩
   · apply le_antisymm _ (le_pow_clog hb n)
     apply le_of_lt_succ

--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -343,7 +343,7 @@ theorem clog_lt_clog_succ_iff {b n : ℕ} (hb : 1 < b) :
     exact n.lt_add_one
 
 theorem clog_eq_clog_succ_iff {b n : ℕ} (hb : 1 < b) :
-    clog b n = clog b (n + 1) ↔ n ≠ b ^ (clog b n) := by
+    clog b n = clog b (n + 1) ↔ n ≠ b ^ clog b n := by
   rw [ne_eq, ← clog_lt_clog_succ_iff hb, not_lt]
   simp only [le_antisymm_iff, and_iff_right_iff_imp]
   exact fun _ ↦ clog_monotone b (le_add_right n 1)

--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -177,7 +177,7 @@ theorem log_mono_right {b n m : ℕ} (h : n ≤ m) : log b n ≤ log b m :=
   log_monotone h
 
 theorem log_lt_log_succ_iff {b n : ℕ} (hb : 1 < b) (hn : n ≠ 0) :
-    log b n < Nat.log b (n + 1) ↔ b ^ (Nat.log b (n + 1)) = n + 1:= by
+    log b n < log b (n + 1) ↔ b ^ log b (n + 1) = n + 1 := by
   refine ⟨fun H ↦ ?_, fun H ↦ ?_⟩
   · apply le_antisymm _ (Nat.lt_pow_of_log_lt hb H)
     exact Nat.pow_log_le_self b (Ne.symm (Nat.zero_ne_add_one n))

--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -346,7 +346,7 @@ theorem clog_lt_clog_succ_iff {b n : ℕ} (hb : 1 < b) :
     exact n.lt_add_one
 
 theorem clog_eq_clog_succ_iff {b n : ℕ} (hb : 1 < b) :
-    clog b n = clog b (n + 1) ↔ b ^ (clog b n) ≠ n := by
+    clog b n = clog b (n + 1) ↔ b ^ clog b n ≠ n := by
   rw [ne_eq, ← clog_lt_clog_succ_iff hb, not_lt]
   simp only [le_antisymm_iff, and_iff_right_iff_imp]
   exact fun _ ↦ clog_monotone b (le_add_right n 1)

--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -176,6 +176,20 @@ theorem log_monotone {b : ℕ} : Monotone (log b) := by
 theorem log_mono_right {b n m : ℕ} (h : n ≤ m) : log b n ≤ log b m :=
   log_monotone h
 
+theorem log_lt_log_succ_iff {b n : ℕ} (hb : 1 < b) (hn : 1 ≤ n) :
+    log b n < Nat.log b (n + 1) ↔ n + 1 = b ^ (Nat.log b (n + 1)) := by
+  refine ⟨fun H ↦ ?_, fun H ↦ ?_⟩
+  · apply le_antisymm (Nat.lt_pow_of_log_lt hb H)
+    exact Nat.pow_log_le_self b (Ne.symm (Nat.zero_ne_add_one n))
+  · apply Nat.log_lt_of_lt_pow (Nat.ne_zero_of_lt hn)
+    simp [← H]
+
+theorem log_eq_log_succ_iff {b n : ℕ} (hb : 1 < b) (hn : 1 ≤ n) :
+    log b n = log b (n + 1) ↔ n + 1 ≠ b ^ (log b (n + 1)) := by
+  rw [ne_eq, ← log_lt_log_succ_iff hb hn, not_lt]
+  simp only [le_antisymm_iff, and_iff_right_iff_imp]
+  exact fun  _ ↦ log_monotone (le_add_right n 1)
+
 @[mono]
 theorem log_anti_left {b c n : ℕ} (hc : 1 < c) (hb : c ≤ b) : log b n ≤ log c n := by
   rcases eq_or_ne n 0 with (rfl | hn); · rw [log_zero_right, log_zero_right]
@@ -321,6 +335,21 @@ theorem log_le_clog (b n : ℕ) : log b n ≤ clog b n := by
   | succ n =>
     exact (Nat.pow_le_pow_iff_right hb).1
       ((pow_log_le_self b n.succ_ne_zero).trans <| le_pow_clog hb _)
+
+theorem clog_lt_clog_succ_iff {b n : ℕ} (hb : 1 < b) (hn : 1 ≤ n) :
+    clog b n < clog b (n + 1) ↔ n  = b ^ (clog b n) := by
+  refine ⟨fun H ↦ ?_, fun H ↦ ?_⟩
+  · apply le_antisymm (le_pow_clog hb n)
+    apply le_of_lt_succ
+    exact (pow_lt_iff_lt_clog hb).mpr H
+  · rw [← pow_lt_iff_lt_clog hb, ← H]
+    exact n.lt_add_one
+
+theorem clog_eq_clog_succ_iff {b n : ℕ} (hb : 1 < b) (hn : 1 ≤ n) :
+    clog b n = clog b (n + 1) ↔ n ≠ b ^ (clog b n) := by
+  rw [ne_eq, ← clog_lt_clog_succ_iff hb hn, not_lt]
+  simp only [le_antisymm_iff, and_iff_right_iff_imp]
+  exact fun _ ↦ clog_monotone b (le_add_right n 1)
 
 /-! ### Computating the logarithm efficiently -/
 section computation

--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -176,13 +176,11 @@ theorem log_monotone {b : ℕ} : Monotone (log b) := by
 theorem log_mono_right {b n m : ℕ} (h : n ≤ m) : log b n ≤ log b m :=
   log_monotone h
 
-theorem log_lt_log_succ_iff {b n : ℕ} (hb : 1 < b) (hn : 1 ≤ n) :
-    log b n < Nat.log b (n + 1) ↔ n + 1 = b ^ (Nat.log b (n + 1)) := by
+theorem log_lt_log_succ_iff {b n : ℕ} (hb : 1 < b) (hn : n ≠ 0) :
+    log b n < log b (n + 1) ↔ n + 1 = b ^ log b (n + 1) := by
   refine ⟨fun H ↦ ?_, fun H ↦ ?_⟩
-  · apply le_antisymm (Nat.lt_pow_of_log_lt hb H)
-    exact Nat.pow_log_le_self b (Ne.symm (Nat.zero_ne_add_one n))
-  · apply Nat.log_lt_of_lt_pow (Nat.ne_zero_of_lt hn)
-    simp [← H]
+  · exact le_antisymm (lt_pow_of_log_lt hb H) (Nat.pow_log_le_self b (by simp))
+  · exact Nat.log_lt_of_lt_pow hn (by simp [← H])
 
 theorem log_eq_log_succ_iff {b n : ℕ} (hb : 1 < b) (hn : 1 ≤ n) :
     log b n = log b (n + 1) ↔ n + 1 ≠ b ^ (log b (n + 1)) := by

--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -185,7 +185,7 @@ theorem log_lt_log_succ_iff {b n : ℕ} (hb : 1 < b) (hn : n ≠ 0) :
     simp [H]
 
 theorem log_eq_log_succ_iff {b n : ℕ} (hb : 1 < b) (hn : n ≠ 0) :
-    log b n = log b (n + 1) ↔ b ^ (log b (n + 1)) ≠ n + 1 := by
+    log b n = log b (n + 1) ↔ b ^ log b (n + 1) ≠ n + 1 := by
   rw [ne_eq, ← log_lt_log_succ_iff hb hn, not_lt]
   simp only [le_antisymm_iff, and_iff_right_iff_imp]
   exact fun  _ ↦ log_monotone (le_add_right n 1)

--- a/Mathlib/Data/Nat/Log.lean
+++ b/Mathlib/Data/Nat/Log.lean
@@ -336,7 +336,7 @@ theorem log_le_clog (b n : ℕ) : log b n ≤ clog b n := by
     exact (Nat.pow_le_pow_iff_right hb).1
       ((pow_log_le_self b n.succ_ne_zero).trans <| le_pow_clog hb _)
 
-theorem clog_lt_clog_succ_iff {b n : ℕ} (hb : 1 < b) (hn : 1 ≤ n) :
+theorem clog_lt_clog_succ_iff {b n : ℕ} (hb : 1 < b) :
     clog b n < clog b (n + 1) ↔ n  = b ^ (clog b n) := by
   refine ⟨fun H ↦ ?_, fun H ↦ ?_⟩
   · apply le_antisymm (le_pow_clog hb n)
@@ -345,9 +345,9 @@ theorem clog_lt_clog_succ_iff {b n : ℕ} (hb : 1 < b) (hn : 1 ≤ n) :
   · rw [← pow_lt_iff_lt_clog hb, ← H]
     exact n.lt_add_one
 
-theorem clog_eq_clog_succ_iff {b n : ℕ} (hb : 1 < b) (hn : 1 ≤ n) :
+theorem clog_eq_clog_succ_iff {b n : ℕ} (hb : 1 < b) :
     clog b n = clog b (n + 1) ↔ n ≠ b ^ (clog b n) := by
-  rw [ne_eq, ← clog_lt_clog_succ_iff hb hn, not_lt]
+  rw [ne_eq, ← clog_lt_clog_succ_iff hb, not_lt]
   simp only [le_antisymm_iff, and_iff_right_iff_imp]
   exact fun _ ↦ clog_monotone b (le_add_right n 1)
 


### PR DESCRIPTION
Prove 4 lemmas that describe when `Nat.log b n = Nat.log b (n + 1)`
and `Nat.clog b n = Nat.clog b (n + 1)`.

`Nat.log_eq_log_succ_iff`, `Nat.log_lt_log_succ_iff`, and the two variants for `Nat.clog`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
