### PR TITLE
[Merged by Bors] - chore: generalize invertibility results to semifields

### DIFF
--- a/Mathlib/Algebra/CharP/Invertible.lean
+++ b/Mathlib/Algebra/CharP/Invertible.lean
@@ -67,9 +67,8 @@ theorem CharP.isUnit_intCast_iff {z : ℤ} (hp : p.Prime) : IsUnit (z : R) ↔ �
 
 end Ring
 
-section Field
-
-variable [Field K]
+section Semifield
+variable [Semifield K]
 
 /-- A natural number `t` is invertible in a field `K` if the characteristic of `K` does not divide
 `t`. -/
@@ -90,11 +89,10 @@ def invertibleOfCharPNotDvd {p : ℕ} [CharP K p] {t : ℕ} (not_dvd : ¬p ∣ t
 instance invertibleOfPos [CharZero K] (n : ℕ) [NeZero n] : Invertible (n : K) :=
   invertibleOfNonzero <| NeZero.out
 
-end Field
+end Semifield
 
-section DivisionRing
-
-variable [DivisionRing K] [CharZero K]
+section DivisionSemiring
+variable [DivisionSemiring K] [CharZero K]
 
 instance invertibleSucc (n : ℕ) : Invertible (n.succ : K) :=
   invertibleOfNonzero (Nat.cast_ne_zero.mpr (Nat.succ_ne_zero _))
@@ -111,4 +109,4 @@ instance invertibleTwo : Invertible (2 : K) :=
 instance invertibleThree : Invertible (3 : K) :=
   invertibleOfNonzero (mod_cast (by decide : 3 ≠ 0))
 
-end DivisionRing
+end DivisionSemiring


### PR DESCRIPTION
This fixes:
```lean
open scoped NNReal

#synth Invertible (2 : ℚ≥0)
#synth Invertible (2 : ℝ≥0)
```


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
