### PR TITLE
[Merged by Bors] - chore: remove global `NatCast (Fin n)` and `CommRing (Fin n)` instances.

### DIFF
--- a/Archive/Imo/Imo2024Q5.lean
+++ b/Archive/Imo/Imo2024Q5.lean
@@ -66,13 +66,14 @@ def MonsterData.monsterCells (m : MonsterData N) :
 def Adjacent (x y : Cell N) : Prop :=
   Nat.dist x.1 y.1 + Nat.dist x.2 y.2 = 1
 
+open Fin.NatCast in -- TODO: can this be refactor to avoid using a cast from `Nat` to `Fin (N + 1)`?
 /-- A valid path from the first to the last row. -/
 structure Path (N : ℕ) where
   /-- The cells on the path. -/
   cells : List (Cell N)
   nonempty : cells ≠ []
   head_first_row : (cells.head nonempty).1 = 0
-  last_last_row : (cells.getLast nonempty).1 = N + 1
+  last_last_row : (cells.getLast nonempty).1 = (N : Fin (N + 1)) + 1
   valid_move_seq : cells.Chain' Adjacent
 
 /-- The first monster on a path, or `none`. -/

--- a/Archive/Imo/Imo2024Q5.lean
+++ b/Archive/Imo/Imo2024Q5.lean
@@ -66,14 +66,13 @@ def MonsterData.monsterCells (m : MonsterData N) :
 def Adjacent (x y : Cell N) : Prop :=
   Nat.dist x.1 y.1 + Nat.dist x.2 y.2 = 1
 
-open Fin.NatCast in -- TODO: can this be refactor to avoid using a cast from `Nat` to `Fin (N + 1)`?
 /-- A valid path from the first to the last row. -/
 structure Path (N : ℕ) where
   /-- The cells on the path. -/
   cells : List (Cell N)
   nonempty : cells ≠ []
   head_first_row : (cells.head nonempty).1 = 0
-  last_last_row : (cells.getLast nonempty).1 = (N : Fin (N + 1)) + 1
+  last_last_row : (cells.getLast nonempty).1 = Fin.last (N + 1)
   valid_move_seq : cells.Chain' Adjacent
 
 /-- The first monster on a path, or `none`. -/
@@ -184,12 +183,11 @@ lemma Path.exists_mem_fst_eq (p : Path N) (r : Fin (N + 2)) : ∃ c ∈ p.cells,
   let i : ℕ := p.cells.findIdx fun c ↦ r ≤ c.1
   have hi : i < p.cells.length := by
     refine List.findIdx_lt_length_of_exists ⟨p.cells.getLast p.nonempty, ?_⟩
-    simp only [List.getLast_mem, p.last_last_row, decide_eq_true_eq, true_and]
-    rw [Fin.le_def, Fin.add_def]
+    simp only [List.getLast_mem, p.last_last_row, decide_eq_true_eq, true_and, Fin.last]
+    rw [Fin.le_def]
     have h := r.isLt
     rw [Nat.lt_succ_iff] at h
     convert h
-    simp
   have hig : r ≤ (p.cells[i]).1 := of_decide_eq_true (List.findIdx_getElem (w := hi))
   refine ⟨p.cells[i], List.getElem_mem _, ?_⟩
   refine (hig.lt_or_eq.resolve_left fun h => ?_).symm
@@ -422,7 +420,7 @@ def Path.ofFn {m : ℕ} (f : Fin m → Cell N) (hm : m ≠ 0)
   head_first_row := by
     rw [List.head_ofFn, hf]
   last_last_row := by
-    simp [List.getLast_ofFn, hl, Fin.add_def]
+    simp [Fin.last, List.getLast_ofFn, hl]
   valid_move_seq := by
     rwa [List.chain'_ofFn]
 

--- a/Mathlib/Algebra/CharP/Basic.lean
+++ b/Mathlib/Algebra/CharP/Basic.lean
@@ -185,6 +185,8 @@ end CharZero
 
 namespace Fin
 
+open Fin.NatCast
+
 /-- The characteristic of `F_p` is `p`. -/
 @[stacks 09FS "First part. We don't require `p` to be a prime in mathlib."]
 instance charP (n : ℕ) [NeZero n] : CharP (Fin n) n where cast_eq_zero_iff _ := natCast_eq_zero

--- a/Mathlib/Algebra/Group/Fin/Basic.lean
+++ b/Mathlib/Algebra/Group/Fin/Basic.lean
@@ -41,7 +41,7 @@ instance addCommMonoid (n : ℕ) [NeZero n] : AddCommMonoid (Fin n) where
 
 namespace NatCast
 
-/---
+/--
 This is not a global instance, but can introduced locally using `open Fin.NatCast in ...`.
 
 This is not an instance because the `binop%` elaborator assumes that

--- a/Mathlib/Algebra/Group/Fin/Basic.lean
+++ b/Mathlib/Algebra/Group/Fin/Basic.lean
@@ -39,11 +39,18 @@ instance addCommMonoid (n : ℕ) [NeZero n] : AddCommMonoid (Fin n) where
   nsmul := nsmulRec
   __ := Fin.addCommSemigroup n
 
-instance instAddMonoidWithOne (n) [NeZero n] : AddMonoidWithOne (Fin n) where
+namespace NatCast
+
+/-- This isn't a global instance ... -/
+def instAddMonoidWithOne (n) [NeZero n] : AddMonoidWithOne (Fin n) where
   __ := inferInstanceAs (AddCommMonoid (Fin n))
   natCast i := Fin.ofNat n i
   natCast_zero := rfl
   natCast_succ _ := Fin.ext (add_mod _ _ _)
+
+attribute [scoped instance] instAddMonoidWithOne
+
+end NatCast
 
 instance addCommGroup (n : ℕ) [NeZero n] : AddCommGroup (Fin n) where
   __ := addCommMonoid n
@@ -131,6 +138,7 @@ lemma sub_one_lt_iff {k : Fin (n + 1)} : k - 1 < k ↔ 0 < k :=
 
 @[simp] lemma neg_last (n : ℕ) : -Fin.last n = 1 := by simp [neg_eq_iff_add_eq_zero]
 
+open Fin.NatCast in
 lemma neg_natCast_eq_one (n : ℕ) : -(n : Fin (n + 1)) = 1 := by
   simp only [natCast_eq_last, neg_last]
 

--- a/Mathlib/Algebra/Group/Fin/Basic.lean
+++ b/Mathlib/Algebra/Group/Fin/Basic.lean
@@ -39,8 +39,6 @@ instance addCommMonoid (n : ℕ) [NeZero n] : AddCommMonoid (Fin n) where
   nsmul := nsmulRec
   __ := Fin.addCommSemigroup n
 
-namespace NatCast
-
 /--
 This is not a global instance, but can introduced locally using `open Fin.NatCast in ...`.
 
@@ -59,7 +57,9 @@ def instAddMonoidWithOne (n) [NeZero n] : AddMonoidWithOne (Fin n) where
   natCast_zero := rfl
   natCast_succ _ := Fin.ext (add_mod _ _ _)
 
-attribute [scoped instance] instAddMonoidWithOne
+namespace NatCast
+
+attribute [scoped instance] Fin.instAddMonoidWithOne
 
 end NatCast
 

--- a/Mathlib/Algebra/Group/Fin/Basic.lean
+++ b/Mathlib/Algebra/Group/Fin/Basic.lean
@@ -45,7 +45,7 @@ namespace NatCast
 This is not a global instance, but can introduced locally using `open Fin.NatCast in ...`.
 
 This is not an instance because the `binop%` elaborator assumes that
-here are no non-trivial coercion loops,
+there are no non-trivial coercion loops,
 but this instance  would introduce a coercion from `Nat` to `Fin n` and back.
 Non-trivial loops lead to undesirable and counterintuitive elaboration behavior.
 

--- a/Mathlib/Algebra/Group/Fin/Basic.lean
+++ b/Mathlib/Algebra/Group/Fin/Basic.lean
@@ -41,7 +41,18 @@ instance addCommMonoid (n : ℕ) [NeZero n] : AddCommMonoid (Fin n) where
 
 namespace NatCast
 
-/-- This isn't a global instance ... -/
+/---
+This is not a global instance, but can introduced locally using `open Fin.NatCast in ...`.
+
+This is not an instance because the `binop%` elaborator assumes that
+here are no non-trivial coercion loops,
+but this instance  would introduce a coercion from `Nat` to `Fin n` and back.
+Non-trivial loops lead to undesirable and counterintuitive elaboration behavior.
+
+For example, for `x : Fin k` and `n : Nat`,
+it causes `x < n` to be elaborated as `x < ↑n` rather than `↑x < n`,
+silently introducing wraparound arithmetic.
+-/
 def instAddMonoidWithOne (n) [NeZero n] : AddMonoidWithOne (Fin n) where
   __ := inferInstanceAs (AddCommMonoid (Fin n))
   natCast i := Fin.ofNat n i

--- a/Mathlib/Algebra/Ring/Parity.lean
+++ b/Mathlib/Algebra/Ring/Parity.lean
@@ -56,9 +56,6 @@ end DivisionMonoid
 
 @[simp] lemma IsSquare.zero [MulZeroClass α] : IsSquare (0 : α) := ⟨0, (mul_zero _).symm⟩
 
-/-- An element `a` of a semiring is odd if there exists `k` such `a = 2*k + 1`. -/
-def Odd {α : Type*} [OfNat α 1] [OfNat α 2] [Add α] [Mul α] (a : α) : Prop := ∃ k, a = 2 * k + 1
-
 section Semiring
 variable [Semiring α] [Semiring β] {a b : α} {m n : ℕ}
 
@@ -88,6 +85,9 @@ lemma even_two_mul (a : α) : Even (2 * a) := ⟨a, two_mul _⟩
 
 lemma Even.pow_of_ne_zero (ha : Even a) : ∀ {n : ℕ}, n ≠ 0 → Even (a ^ n)
   | n + 1, _ => by rw [pow_succ]; exact ha.mul_left _
+
+/-- An element `a` of a semiring is odd if there exists `k` such `a = 2*k + 1`. -/
+def Odd (a : α) : Prop := ∃ k, a = 2 * k + 1
 
 lemma odd_iff_exists_bit1 : Odd a ↔ ∃ b, a = 2 * b + 1 := exists_congr fun b ↦ by rw [two_mul]
 

--- a/Mathlib/Algebra/Ring/Parity.lean
+++ b/Mathlib/Algebra/Ring/Parity.lean
@@ -56,6 +56,9 @@ end DivisionMonoid
 
 @[simp] lemma IsSquare.zero [MulZeroClass α] : IsSquare (0 : α) := ⟨0, (mul_zero _).symm⟩
 
+/-- An element `a` of a semiring is odd if there exists `k` such `a = 2*k + 1`. -/
+def Odd {α : Type*} [OfNat α 1] [OfNat α 2] [Add α] [Mul α] (a : α) : Prop := ∃ k, a = 2 * k + 1
+
 section Semiring
 variable [Semiring α] [Semiring β] {a b : α} {m n : ℕ}
 
@@ -85,9 +88,6 @@ lemma even_two_mul (a : α) : Even (2 * a) := ⟨a, two_mul _⟩
 
 lemma Even.pow_of_ne_zero (ha : Even a) : ∀ {n : ℕ}, n ≠ 0 → Even (a ^ n)
   | n + 1, _ => by rw [pow_succ]; exact ha.mul_left _
-
-/-- An element `a` of a semiring is odd if there exists `k` such `a = 2*k + 1`. -/
-def Odd (a : α) : Prop := ∃ k, a = 2 * k + 1
 
 lemma odd_iff_exists_bit1 : Odd a ↔ ∃ b, a = 2 * b + 1 := exists_congr fun b ↦ by rw [two_mul]
 

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
@@ -398,7 +398,7 @@ lemma mk_XYIdeal'_mul_mk_XYIdeal' {x₁ x₂ y₁ y₂ : F} (h₁ : W.Nonsingula
 
 /-! ## Norms on the affine coordinate ring -/
 
-open Fin.CommRing in
+open Fin.CommRing in -- TODO: should this be refactored to avoid needing the coercion?
 lemma norm_smul_basis (p q : R[X]) : Algebra.norm R[X] (p • (1 : W'.CoordinateRing) + q • mk W' Y) =
     p ^ 2 - p * q * (C W'.a₁ * X + C W'.a₃) -
       q ^ 2 * (X ^ 3 + C W'.a₂ * X ^ 2 + C W'.a₄ * X + C W'.a₆) := by

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean
@@ -398,6 +398,7 @@ lemma mk_XYIdeal'_mul_mk_XYIdeal' {x₁ x₂ y₁ y₂ : F} (h₁ : W.Nonsingula
 
 /-! ## Norms on the affine coordinate ring -/
 
+open Fin.CommRing in
 lemma norm_smul_basis (p q : R[X]) : Algebra.norm R[X] (p • (1 : W'.CoordinateRing) + q • mk W' Y) =
     p ^ 2 - p * q * (C W'.a₁ * X + C W'.a₃) -
       q ^ 2 * (X ^ 3 + C W'.a₂ * X ^ 2 + C W'.a₄ * X + C W'.a₆) := by

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Jacobian/Basic.lean
@@ -296,6 +296,7 @@ associated to a Weierstrass curve `W` in Jacobian coordinates. -/
 noncomputable def polynomialX : MvPolynomial (Fin 3) R :=
   pderiv x W'.polynomial
 
+open Fin.CommRing in
 lemma polynomialX_eq : W'.polynomialX =
     C W'.a₁ * X 1 * X 2 - (C 3 * X 0 ^ 2 + C (2 * W'.a₂) * X 0 * X 2 ^ 2 + C W'.a₄ * X 2 ^ 4) := by
   rw [polynomialX, polynomial]
@@ -320,6 +321,7 @@ associated to a Weierstrass curve `W` in Jacobian coordinates. -/
 noncomputable def polynomialY : MvPolynomial (Fin 3) R :=
   pderiv y W'.polynomial
 
+open Fin.CommRing in
 lemma polynomialY_eq : W'.polynomialY = C 2 * X 1 + C W'.a₁ * X 0 * X 2 + C W'.a₃ * X 2 ^ 3 := by
   rw [polynomialY, polynomial]
   pderiv_simp

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/Projective/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/Projective/Basic.lean
@@ -287,6 +287,7 @@ associated to a Weierstrass curve `W` in projective coordinates. -/
 noncomputable def polynomialX : MvPolynomial (Fin 3) R :=
   pderiv x W'.polynomial
 
+open Fin.CommRing in
 lemma polynomialX_eq : W'.polynomialX =
     C W'.a₁ * X 1 * X 2 - (C 3 * X 0 ^ 2 + C (2 * W'.a₂) * X 0 * X 2 + C W'.a₄ * X 2 ^ 2) := by
   rw [polynomialX, polynomial]
@@ -310,6 +311,7 @@ associated to a Weierstrass curve `W` in projective coordinates. -/
 noncomputable def polynomialY : MvPolynomial (Fin 3) R :=
   pderiv y W'.polynomial
 
+open Fin.CommRing in
 lemma polynomialY_eq : W'.polynomialY =
     C 2 * X 1 * X 2 + C W'.a₁ * X 0 * X 2 + C W'.a₃ * X 2 ^ 2 := by
   rw [polynomialY, polynomial]

--- a/Mathlib/Combinatorics/Additive/AP/Three/Defs.lean
+++ b/Mathlib/Combinatorics/Additive/AP/Three/Defs.lean
@@ -439,12 +439,12 @@ theorem addRothNumber_Ico (a b : ℕ) : addRothNumber (Ico a b) = rothNumberNat 
   convert (image_add_left_Ico 0 (b - a) _).symm
   exact (add_tsub_cancel_of_le h).symm
 
-open Fin.NatCast in -- TODO: refactor to avoid needing the coercion
+open Fin.NatCast in -- TODO: should this be refactored to avoid needing the coercion?
 lemma Fin.addRothNumber_eq_rothNumberNat (hkn : 2 * k ≤ n) :
     addRothNumber (Iio k : Finset (Fin n.succ)) = rothNumberNat k :=
   IsAddFreimanIso.addRothNumber_congr <| mod_cast isAddFreimanIso_Iio two_ne_zero hkn
 
-open Fin.CommRing in
+open Fin.CommRing in -- TODO: should this be refactored to avoid needing the coercion?
 lemma Fin.addRothNumber_le_rothNumberNat (k n : ℕ) (hkn : k ≤ n) :
     addRothNumber (Iio k : Finset (Fin n.succ)) ≤ rothNumberNat k := by
   suffices h : Set.BijOn (Nat.cast : ℕ → Fin n.succ) (range k) (Iio k : Finset (Fin n.succ)) by

--- a/Mathlib/Combinatorics/Additive/AP/Three/Defs.lean
+++ b/Mathlib/Combinatorics/Additive/AP/Three/Defs.lean
@@ -443,6 +443,7 @@ lemma Fin.addRothNumber_eq_rothNumberNat (hkn : 2 * k ≤ n) :
     addRothNumber (Iio k : Finset (Fin n.succ)) = rothNumberNat k :=
   IsAddFreimanIso.addRothNumber_congr <| mod_cast isAddFreimanIso_Iio two_ne_zero hkn
 
+open Fin.CommRing in
 lemma Fin.addRothNumber_le_rothNumberNat (k n : ℕ) (hkn : k ≤ n) :
     addRothNumber (Iio k : Finset (Fin n.succ)) ≤ rothNumberNat k := by
   suffices h : Set.BijOn (Nat.cast : ℕ → Fin n.succ) (range k) (Iio k : Finset (Fin n.succ)) by

--- a/Mathlib/Combinatorics/Additive/AP/Three/Defs.lean
+++ b/Mathlib/Combinatorics/Additive/AP/Three/Defs.lean
@@ -439,6 +439,7 @@ theorem addRothNumber_Ico (a b : ℕ) : addRothNumber (Ico a b) = rothNumberNat 
   convert (image_add_left_Ico 0 (b - a) _).symm
   exact (add_tsub_cancel_of_le h).symm
 
+open Fin.NatCast in -- TODO: refactor to avoid needing the coercion
 lemma Fin.addRothNumber_eq_rothNumberNat (hkn : 2 * k ≤ n) :
     addRothNumber (Iio k : Finset (Fin n.succ)) = rothNumberNat k :=
   IsAddFreimanIso.addRothNumber_congr <| mod_cast isAddFreimanIso_Iio two_ne_zero hkn

--- a/Mathlib/Combinatorics/Additive/Corner/Roth.lean
+++ b/Mathlib/Combinatorics/Additive/Corner/Roth.lean
@@ -97,6 +97,7 @@ theorem corners_theorem (ε : ℝ) (hε : 0 < ε) (hG : cornersTheoremBound ε �
   rw [card_triangles, card_triangleIndices] at h₁
   convert h₁.trans (Nat.cast_le.2 <| card_le_univ _) using 1 <;> simp <;> ring
 
+open Fin.NatCast in -- TODO: refactor to avoid needing the coercion
 /-- The **corners theorem** for `ℕ`.
 
 The maximum density of a corner-free set in `{1, ..., n} × {1, ..., n}` goes to zero as `n` tends to
@@ -159,6 +160,7 @@ theorem roth_3ap_theorem (ε : ℝ) (hε : 0 < ε) (hG : cornersTheoremBound ε 
       sub_eq_sub_iff_add_eq_add, add_comm, hxy, add_comm]
   exact hx₁x₂ <| by simpa using this.symm
 
+open Fin.NatCast in -- TODO: refactor to avoid needing the coercion
 /-- **Roth's theorem** for `ℕ`.
 
 The maximum density of a 3AP-free set in `{1, ..., n}` goes to zero as `n` tends to infinity. -/

--- a/Mathlib/Combinatorics/Additive/FreimanHom.lean
+++ b/Mathlib/Combinatorics/Additive/FreimanHom.lean
@@ -389,6 +389,8 @@ end Prod
 namespace Fin
 variable {k m n : ℕ}
 
+open Fin.CommRing
+
 private lemma aux (hm : m ≠ 0) (hkmn : m * k ≤ n) : k < (n + 1) :=
   Nat.lt_succ_iff.2 <| le_trans (Nat.le_mul_of_pos_left _ hm.bot_lt) hkmn
 

--- a/Mathlib/Combinatorics/Extremal/RuzsaSzemeredi.lean
+++ b/Mathlib/Combinatorics/Extremal/RuzsaSzemeredi.lean
@@ -173,7 +173,7 @@ lemma addRothNumber_le_ruzsaSzemerediNumber :
   rw [← hscard, ← card_triangleIndices, ← card_triangles]
   exact (locallyLinear hs).le_ruzsaSzemerediNumber
 
-open Fin.CommRing in
+open Fin.CommRing in -- TODO: can this be refactored to avoid using the ring structure in the proof?
 lemma rothNumberNat_le_ruzsaSzemerediNumberNat (n : ℕ) :
     (2 * n + 1) * rothNumberNat n ≤ ruzsaSzemerediNumberNat (6 * n + 3) := by
   let α := Fin (2 * n + 1)

--- a/Mathlib/Combinatorics/Extremal/RuzsaSzemeredi.lean
+++ b/Mathlib/Combinatorics/Extremal/RuzsaSzemeredi.lean
@@ -173,6 +173,7 @@ lemma addRothNumber_le_ruzsaSzemerediNumber :
   rw [← hscard, ← card_triangleIndices, ← card_triangles]
   exact (locallyLinear hs).le_ruzsaSzemerediNumber
 
+open Fin.CommRing in
 lemma rothNumberNat_le_ruzsaSzemerediNumberNat (n : ℕ) :
     (2 * n + 1) * rothNumberNat n ≤ ruzsaSzemerediNumberNat (6 * n + 3) := by
   let α := Fin (2 * n + 1)

--- a/Mathlib/Computability/AkraBazzi/AkraBazzi.lean
+++ b/Mathlib/Computability/AkraBazzi/AkraBazzi.lean
@@ -1310,6 +1310,7 @@ lemma T_isBigO_smoothingFn_mul_asympBound :
                                               · exact le_of_lt <| h_smoothing_gt_half n hn
         _ = C * ((1 - ε n) * asympBound g a b n) := by ring
 
+
 /-- The main proof of the lower bound part of the Akra-Bazzi theorem. The factor
 `1 + ε n` does not change the asymptotic order, but is needed for the induction step to go
 through. -/

--- a/Mathlib/Computability/AkraBazzi/AkraBazzi.lean
+++ b/Mathlib/Computability/AkraBazzi/AkraBazzi.lean
@@ -1310,7 +1310,6 @@ lemma T_isBigO_smoothingFn_mul_asympBound :
                                               · exact le_of_lt <| h_smoothing_gt_half n hn
         _ = C * ((1 - ε n) * asympBound g a b n) := by ring
 
-
 /-- The main proof of the lower bound part of the Akra-Bazzi theorem. The factor
 `1 + ε n` does not change the asymptotic order, but is needed for the induction step to go
 through. -/

--- a/Mathlib/Data/BitVec.lean
+++ b/Mathlib/Data/BitVec.lean
@@ -69,11 +69,12 @@ instance : CommSemiring (BitVec w) :=
 -- The statement in the new API would be: `n#(k.succ) = ((n / 2)#k).concat (n % 2 != 0)`
 
 -- Variant of `Fin.intCast_def'` for when we are using the `Fin.CommRing` instance.
+open Fin.CommRing in
 theorem _root_.Fin.intCast_def' {n : Nat} [NeZero n] (x : Int) :
     (x : Fin n) = if 0 ≤ x then Fin.ofNat n x.natAbs else -Fin.ofNat n x.natAbs := by
   unfold instCommRing
   dsimp [Int.cast, IntCast.intCast, Int.castDef]
-  split <;> simp
+  split <;> (simp [Fin.intCast]; omega)
 
 @[simp] theorem _root_.Fin.val_intCast {n : Nat} [NeZero n] (x : Int) :
     (x : Fin n).val = (x % n).toNat := by

--- a/Mathlib/Data/BitVec.lean
+++ b/Mathlib/Data/BitVec.lean
@@ -49,7 +49,7 @@ lemma toFin_pow (x : BitVec w) (n : ℕ)    : toFin (x ^ n) = x.toFin ^ n := by
 ## Ring
 -/
 
-attribute [local instance] Fin.instCommRing
+open Fin.CommRing
 
 -- Verify that the `HPow` instance from Lean agrees definitionally with the instance via `Monoid`.
 example : @instHPow (Fin (2 ^ w)) ℕ Monoid.toNatPow = Lean.Grind.Fin.instHPowFinNatOfNeZero := rfl

--- a/Mathlib/Data/BitVec.lean
+++ b/Mathlib/Data/BitVec.lean
@@ -49,6 +49,8 @@ lemma toFin_pow (x : BitVec w) (n : ℕ)    : toFin (x ^ n) = x.toFin ^ n := by
 ## Ring
 -/
 
+attribute [local instance] Fin.instCommRing
+
 -- Verify that the `HPow` instance from Lean agrees definitionally with the instance via `Monoid`.
 example : @instHPow (Fin (2 ^ w)) ℕ Monoid.toNatPow = Lean.Grind.Fin.instHPowFinNatOfNeZero := rfl
 

--- a/Mathlib/Data/BitVec.lean
+++ b/Mathlib/Data/BitVec.lean
@@ -36,6 +36,8 @@ theorem toFin_injective {n : Nat} : Function.Injective (toFin : BitVec n → _)
 Having instance of `SMul ℕ`, `SMul ℤ` and `Pow` are prerequisites for a `CommRing` instance
 -/
 
+open Fin.NatCast
+
 instance : SMul ℕ (BitVec w) := ⟨fun x y => ofFin <| x • y.toFin⟩
 instance : SMul ℤ (BitVec w) := ⟨fun x y => ofFin <| x • y.toFin⟩
 lemma toFin_nsmul (n : ℕ) (x : BitVec w)  : toFin (n • x) = n • x.toFin := rfl
@@ -54,6 +56,7 @@ open Fin.CommRing
 -- Verify that the `HPow` instance from Lean agrees definitionally with the instance via `Monoid`.
 example : @instHPow (Fin (2 ^ w)) ℕ Monoid.toNatPow = Lean.Grind.Fin.instHPowFinNatOfNeZero := rfl
 
+open Fin.CommRing in
 instance : CommSemiring (BitVec w) :=
   toFin_injective.commSemiring _
     rfl /- toFin_zero -/
@@ -65,12 +68,16 @@ instance : CommSemiring (BitVec w) :=
     (fun _ => rfl) /- toFin_natCast -/
 -- The statement in the new API would be: `n#(k.succ) = ((n / 2)#k).concat (n % 2 != 0)`
 
-open Fin.IntCast
+-- Variant of `Fin.intCast_def'` for when we are using the `Fin.CommRing` instance.
+theorem _root_.Fin.intCast_def' {n : Nat} [NeZero n] (x : Int) :
+    (x : Fin n) = if 0 ≤ x then Fin.ofNat n x.natAbs else -Fin.ofNat n x.natAbs := by
+  unfold instCommRing
+  dsimp [Int.cast, IntCast.intCast, Int.castDef]
+  split <;> simp
 
--- TODO: move to the Lean4 repository.
 @[simp] theorem _root_.Fin.val_intCast {n : Nat} [NeZero n] (x : Int) :
     (x : Fin n).val = (x % n).toNat := by
-  rw [Fin.intCast_def]
+  rw [Fin.intCast_def']
   split <;> rename_i h
   · simp [Int.emod_natAbs_of_nonneg h]
   · simp only [Fin.ofNat_eq_cast, Fin.val_neg, Fin.natCast_eq_zero, Fin.val_natCast]
@@ -96,9 +103,11 @@ theorem ofFin_intCast (z : ℤ) : ofFin (z : Fin (2^w)) = ↑z := by
     · refine Int.emod_nonneg z ?_
       exact pow_ne_zero (w + 1) (by decide)
 
+open Fin.CommRing in
 theorem toFin_intCast (z : ℤ) : toFin (z : BitVec w) = z := by
   apply toFin_inj.mpr <| (ofFin_intCast z).symm
 
+open Fin.CommRing in
 instance : CommRing (BitVec w) :=
   toFin_injective.commRing _
     toFin_zero toFin_one toFin_add toFin_mul toFin_neg toFin_sub

--- a/Mathlib/Data/BitVec.lean
+++ b/Mathlib/Data/BitVec.lean
@@ -72,7 +72,7 @@ instance : CommSemiring (BitVec w) :=
 open Fin.CommRing in
 theorem _root_.Fin.intCast_def' {n : Nat} [NeZero n] (x : Int) :
     (x : Fin n) = if 0 ≤ x then Fin.ofNat n x.natAbs else -Fin.ofNat n x.natAbs := by
-  unfold instCommRing
+  unfold Fin.instCommRing
   dsimp [Int.cast, IntCast.intCast, Int.castDef]
   split <;> (simp [Fin.intCast]; omega)
 

--- a/Mathlib/Data/BitVec.lean
+++ b/Mathlib/Data/BitVec.lean
@@ -68,7 +68,7 @@ instance : CommSemiring (BitVec w) :=
     (fun _ => rfl) /- toFin_natCast -/
 -- The statement in the new API would be: `n#(k.succ) = ((n / 2)#k).concat (n % 2 != 0)`
 
--- Variant of `Fin.intCast_def'` for when we are using the `Fin.CommRing` instance.
+-- Variant of `Fin.intCast_def` for when we are using the `Fin.CommRing` instance.
 open Fin.CommRing in
 theorem _root_.Fin.intCast_def' {n : Nat} [NeZero n] (x : Int) :
     (x : Fin n) = if 0 ≤ x then Fin.ofNat n x.natAbs else -Fin.ofNat n x.natAbs := by

--- a/Mathlib/Data/Complex/Module.lean
+++ b/Mathlib/Data/Complex/Module.lean
@@ -8,7 +8,6 @@ import Mathlib.Algebra.CharP.Invertible
 import Mathlib.Data.Complex.Basic
 import Mathlib.LinearAlgebra.Matrix.ToLin
 import Mathlib.Data.Real.Star
-import Mathlib.Data.ZMod.Defs
 
 /-!
 # Complex number as a vector space over `ℝ`

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -313,10 +313,28 @@ instance inhabitedFinOneAdd (n : ℕ) : Inhabited (Fin (1 + n)) :=
 theorem default_eq_zero (n : ℕ) [NeZero n] : (default : Fin n) = 0 :=
   rfl
 
-instance instNatCast [NeZero n] : NatCast (Fin n) where
+namespace NatCast
+
+/--
+This is not a global instance, but can introduced locally using `open Fin.NatCast in ...`.
+
+This is not an instance because the `binop%` elaborator assumes that
+here are no non-trivial coercion loops,
+but this instance  would introduce a coercion from `Nat` to `Fin n` and back.
+Non-trivial loops lead to undesirable and counterintuitive elaboration behavior.
+For example, for `x : Fin k` and `n : Nat`,
+it causes `x < n` to be elaborated as `x < ↑n` rather than `↑x < n`,
+silently introducing wraparound arithmetic.
+-/
+-- Note: this instance duplicates one in Lean, and should be removed later.
+def instNatCast [NeZero n] : NatCast (Fin n) where
   natCast i := Fin.ofNat n i
 
+attribute [scoped instance] instNatCast
+
 lemma natCast_def [NeZero n] (a : ℕ) : (a : Fin n) = ⟨a % n, mod_lt _ n.pos_of_neZero⟩ := rfl
+
+end NatCast
 
 end Monoid
 

--- a/Mathlib/Data/Fin/Parity.lean
+++ b/Mathlib/Data/Fin/Parity.lean
@@ -38,6 +38,7 @@ lemma neg_one_pow_succAbove_add_predAbove {R : Type*} [Monoid R] [HasDistribNeg 
   rw [← neg_one_mul (_ ^ _), ← pow_succ', neg_one_pow_congr]
   rw [even_succAbove_add_predAbove, Nat.even_add_one, Nat.not_even_iff_odd]
 
+open Fin.NatCast in
 lemma even_of_val (h : Even k.val) : Even k := by
   have : NeZero n := ⟨k.pos.ne'⟩
   rw [← Fin.cast_val_eq_self k]
@@ -48,6 +49,7 @@ lemma odd_of_val [NeZero n] (h : Odd k.val) : Odd k := by
   rw [← Fin.cast_val_eq_self k]
   exact h.natCast
 
+open Fin.NatCast in
 lemma even_of_odd (hn : Odd n) (k : Fin n) : Even k := by
   have : NeZero n := ⟨k.pos.ne'⟩
   rcases k.val.even_or_odd with hk | hk

--- a/Mathlib/Data/Fin/Parity.lean
+++ b/Mathlib/Data/Fin/Parity.lean
@@ -21,6 +21,8 @@ open Fin
 
 namespace Fin
 
+open Fin.CommRing
+
 variable {n : ℕ} {k : Fin n}
 
 theorem even_succAbove_add_predAbove (i : Fin (n + 1)) (j : Fin n) :
@@ -38,25 +40,21 @@ lemma neg_one_pow_succAbove_add_predAbove {R : Type*} [Monoid R] [HasDistribNeg 
   rw [← neg_one_mul (_ ^ _), ← pow_succ', neg_one_pow_congr]
   rw [even_succAbove_add_predAbove, Nat.even_add_one, Nat.not_even_iff_odd]
 
-open Fin.NatCast in
 lemma even_of_val (h : Even k.val) : Even k := by
   have : NeZero n := ⟨k.pos.ne'⟩
   rw [← Fin.cast_val_eq_self k]
   exact h.natCast
 
-open Fin.CommRing in
 lemma odd_of_val [NeZero n] (h : Odd k.val) : Odd k := by
   rw [← Fin.cast_val_eq_self k]
   exact h.natCast
 
-open Fin.NatCast in
 lemma even_of_odd (hn : Odd n) (k : Fin n) : Even k := by
   have : NeZero n := ⟨k.pos.ne'⟩
   rcases k.val.even_or_odd with hk | hk
   · exact even_of_val hk
   · simpa using (hk.add_odd hn).natCast (α := Fin n)
 
-open Fin.CommRing in
 lemma odd_of_odd [NeZero n] (hn : Odd n) (k : Fin n) : Odd k := by
   rcases k.val.even_or_odd with hk | hk
   · simpa using (Even.add_odd hk hn).natCast (R := Fin n)
@@ -117,11 +115,9 @@ lemma not_even_iff_odd_of_even [NeZero n] (hn : Even n) : ¬Even k ↔ Odd k := 
   rw [even_iff_of_even hn, odd_iff_of_even hn]
   exact Nat.not_even_iff_odd
 
-open Fin.CommRing in
 lemma odd_add_one_iff_even [NeZero n] : Odd (k + 1) ↔ Even k :=
   ⟨fun ⟨k, hk⟩ ↦ add_right_cancel hk ▸ even_two_mul k, Even.add_one⟩
 
-open Fin.CommRing in
 lemma even_add_one_iff_odd [NeZero n] : Even (k + 1) ↔ Odd k :=
   ⟨fun ⟨k, hk⟩ ↦ eq_sub_iff_add_eq.mpr hk ▸ (Even.add_self k).sub_odd odd_one, Odd.add_one⟩
 

--- a/Mathlib/Data/Fin/Parity.lean
+++ b/Mathlib/Data/Fin/Parity.lean
@@ -43,6 +43,7 @@ lemma even_of_val (h : Even k.val) : Even k := by
   rw [← Fin.cast_val_eq_self k]
   exact h.natCast
 
+open Fin.CommRing in
 lemma odd_of_val [NeZero n] (h : Odd k.val) : Odd k := by
   rw [← Fin.cast_val_eq_self k]
   exact h.natCast
@@ -53,7 +54,7 @@ lemma even_of_odd (hn : Odd n) (k : Fin n) : Even k := by
   · exact even_of_val hk
   · simpa using (hk.add_odd hn).natCast (α := Fin n)
 
-
+open Fin.CommRing in
 lemma odd_of_odd [NeZero n] (hn : Odd n) (k : Fin n) : Odd k := by
   rcases k.val.even_or_odd with hk | hk
   · simpa using (Even.add_odd hk hn).natCast (R := Fin n)
@@ -114,9 +115,11 @@ lemma not_even_iff_odd_of_even [NeZero n] (hn : Even n) : ¬Even k ↔ Odd k := 
   rw [even_iff_of_even hn, odd_iff_of_even hn]
   exact Nat.not_even_iff_odd
 
+open Fin.CommRing in
 lemma odd_add_one_iff_even [NeZero n] : Odd (k + 1) ↔ Even k :=
   ⟨fun ⟨k, hk⟩ ↦ add_right_cancel hk ▸ even_two_mul k, Even.add_one⟩
 
+open Fin.CommRing in
 lemma even_add_one_iff_odd [NeZero n] : Even (k + 1) ↔ Odd k :=
   ⟨fun ⟨k, hk⟩ ↦ eq_sub_iff_add_eq.mpr hk ▸ (Even.add_self k).sub_odd odd_one, Odd.add_one⟩
 

--- a/Mathlib/Data/FinEnum/Option.lean
+++ b/Mathlib/Data/FinEnum/Option.lean
@@ -29,6 +29,7 @@ It keeps the mapping of the existing `α`-inhabitants intact, modulo `Fin.castSu
 instance instFinEnumOptionLast (α : Type u) [FinEnum α] : FinEnum (Option α) :=
   insertNone α (Fin.last _)
 
+open Fin.NatCast in -- TODO: refactor the proof to avoid needing this.
 /-- A recursor principle for finite-and-enumerable types, analogous to `Nat.rec`.
 It effectively says that every `FinEnum` is either `Empty` or `Option α`, up to an `Equiv` mediated
 by `Fin`s of equal cardinality.
@@ -74,6 +75,7 @@ theorem recEmptyOption_of_card_eq_zero {P : Type u → Sort v}
   · congr 1; exact Subsingleton.allEq _ _
   · exact Nat.noConfusion <| h.symm.trans ‹_›
 
+open Fin.NatCast in -- TODO: refactor the proof to avoid needing this.
 /--
 For a type with positive `card`, the recursion principle evaluates to whatever
 `congr` makes of the step result, where `Option.none` has been inserted into the

--- a/Mathlib/Data/ZMod/Defs.lean
+++ b/Mathlib/Data/ZMod/Defs.lean
@@ -63,14 +63,14 @@ private theorem left_distrib_aux (n : ℕ) : ∀ a b c : Fin n, a * (b + c) = a 
       _ ≡ a * b % n + a * c % n [MOD n] := (Nat.mod_modEq _ _).symm.add (Nat.mod_modEq _ _).symm
 
 /-- Commutative ring structure on `Fin n`. -/
-instance instDistrib (n : ℕ) : Distrib (Fin n) :=
+def instDistrib (n : ℕ) : Distrib (Fin n) :=
   { Fin.addCommSemigroup n, Fin.instCommSemigroup n with
     left_distrib := left_distrib_aux n
     right_distrib := fun a b c => by
       rw [mul_comm, left_distrib_aux, mul_comm _ b, mul_comm] }
 
 /-- Commutative ring structure on `Fin n`. -/
-instance instCommRing (n : ℕ) [NeZero n] : CommRing (Fin n) :=
+def instCommRing (n : ℕ) [NeZero n] : CommRing (Fin n) :=
   { Fin.instAddMonoidWithOne n, Fin.addCommGroup n, Fin.instCommSemigroup n, Fin.instDistrib n with
     intCast n := Fin.intCast n
     one_mul := Fin.one_mul'
@@ -78,8 +78,9 @@ instance instCommRing (n : ℕ) [NeZero n] : CommRing (Fin n) :=
     zero_mul := Fin.zero_mul'
     mul_zero := Fin.mul_zero' }
 
+attribute [local instance] Fin.instCommRing in
 /-- Note this is more general than `Fin.instCommRing` as it applies (vacuously) to `Fin 0` too. -/
-instance instHasDistribNeg (n : ℕ) : HasDistribNeg (Fin n) :=
+def instHasDistribNeg (n : ℕ) : HasDistribNeg (Fin n) :=
   { toInvolutiveNeg := Fin.instInvolutiveNeg n
     mul_neg := Nat.casesOn n finZeroElim fun _i => mul_neg
     neg_mul := Nat.casesOn n finZeroElim fun _i => neg_mul }
@@ -116,6 +117,7 @@ theorem card (n : ℕ) [Fintype (ZMod n)] : Fintype.card (ZMod n) = n := by
   | zero => exact (not_finite (ZMod 0)).elim
   | succ n => convert Fintype.card_fin (n + 1) using 2
 
+attribute [local instance] Fin.instCommRing in
 /- We define each field by cases, to ensure that the eta-expanded `ZMod.commRing` is defeq to the
 original, this helps avoid diamonds with instances coming from classes extending `CommRing` such as
 field. -/

--- a/Mathlib/Data/ZMod/Defs.lean
+++ b/Mathlib/Data/ZMod/Defs.lean
@@ -77,9 +77,10 @@ Commutative ring structure on `Fin n`.
 This is not a global instance, but can introduced locally using `open Fin.CommRing in ...`.
 
 This is not an instance because the `binop%` elaborator assumes that
-here are no non-trivial coercion loops,
+htere are no non-trivial coercion loops,
 but this instance  would introduce a coercion from `Nat` to `Fin n` and back.
 Non-trivial loops lead to undesirable and counterintuitive elaboration behavior.
+
 For example, for `x : Fin k` and `n : Nat`,
 it causes `x < n` to be elaborated as `x < ↑n` rather than `↑x < n`,
 silently introducing wraparound arithmetic.

--- a/Mathlib/Data/ZMod/Defs.lean
+++ b/Mathlib/Data/ZMod/Defs.lean
@@ -84,7 +84,7 @@ it causes `x < n` to be elaborated as `x < ↑n` rather than `↑x < n`,
 silently introducing wraparound arithmetic.
 -/
 def instCommRing (n : ℕ) [NeZero n] : CommRing (Fin n) :=
-  { Fin.NatCast.instAddMonoidWithOne n, Fin.addCommGroup n, Fin.instCommSemigroup n,
+  { Fin.instAddMonoidWithOne n, Fin.addCommGroup n, Fin.instCommSemigroup n,
       Fin.instDistrib n with
     intCast n := Fin.intCast n
     one_mul := Fin.one_mul'

--- a/Mathlib/Data/ZMod/Defs.lean
+++ b/Mathlib/Data/ZMod/Defs.lean
@@ -62,14 +62,28 @@ private theorem left_distrib_aux (n : ℕ) : ∀ a b c : Fin n, a * (b + c) = a 
       _ ≡ a * b + a * c [MOD n] := by rw [mul_add]
       _ ≡ a * b % n + a * c % n [MOD n] := (Nat.mod_modEq _ _).symm.add (Nat.mod_modEq _ _).symm
 
-/-- Commutative ring structure on `Fin n`. -/
-def instDistrib (n : ℕ) : Distrib (Fin n) :=
+/-- Distributive structure on `Fin n`. -/
+instance instDistrib (n : ℕ) : Distrib (Fin n) :=
   { Fin.addCommSemigroup n, Fin.instCommSemigroup n with
     left_distrib := left_distrib_aux n
     right_distrib := fun a b c => by
       rw [mul_comm, left_distrib_aux, mul_comm _ b, mul_comm] }
 
-/-- Commutative ring structure on `Fin n`. -/
+namespace CommRing
+
+/--
+Commutative ring structure on `Fin n`.
+
+This is not a global instance, but can introduced locally using `open Fin.CommRing in ...`.
+
+This is not an instance because the `binop%` elaborator assumes that
+here are no non-trivial coercion loops,
+but this instance  would introduce a coercion from `Nat` to `Fin n` and back.
+Non-trivial loops lead to undesirable and counterintuitive elaboration behavior.
+For example, for `x : Fin k` and `n : Nat`,
+it causes `x < n` to be elaborated as `x < ↑n` rather than `↑x < n`,
+silently introducing wraparound arithmetic.
+-/
 def instCommRing (n : ℕ) [NeZero n] : CommRing (Fin n) :=
   { Fin.instAddMonoidWithOne n, Fin.addCommGroup n, Fin.instCommSemigroup n, Fin.instDistrib n with
     intCast n := Fin.intCast n
@@ -78,7 +92,11 @@ def instCommRing (n : ℕ) [NeZero n] : CommRing (Fin n) :=
     zero_mul := Fin.zero_mul'
     mul_zero := Fin.mul_zero' }
 
-attribute [local instance] Fin.instCommRing in
+attribute [scoped instance] Fin.CommRing.instCommRing
+
+end CommRing
+
+open Fin.CommRing in
 /-- Note this is more general than `Fin.instCommRing` as it applies (vacuously) to `Fin 0` too. -/
 def instHasDistribNeg (n : ℕ) : HasDistribNeg (Fin n) :=
   { toInvolutiveNeg := Fin.instInvolutiveNeg n
@@ -117,7 +135,7 @@ theorem card (n : ℕ) [Fintype (ZMod n)] : Fintype.card (ZMod n) = n := by
   | zero => exact (not_finite (ZMod 0)).elim
   | succ n => convert Fintype.card_fin (n + 1) using 2
 
-attribute [local instance] Fin.instCommRing in
+open Fin.CommRing in
 /- We define each field by cases, to ensure that the eta-expanded `ZMod.commRing` is defeq to the
 original, this helps avoid diamonds with instances coming from classes extending `CommRing` such as
 field. -/

--- a/Mathlib/Data/ZMod/Defs.lean
+++ b/Mathlib/Data/ZMod/Defs.lean
@@ -85,7 +85,8 @@ it causes `x < n` to be elaborated as `x < ↑n` rather than `↑x < n`,
 silently introducing wraparound arithmetic.
 -/
 def instCommRing (n : ℕ) [NeZero n] : CommRing (Fin n) :=
-  { Fin.instAddMonoidWithOne n, Fin.addCommGroup n, Fin.instCommSemigroup n, Fin.instDistrib n with
+  { Fin.NatCast.instAddMonoidWithOne n, Fin.addCommGroup n, Fin.instCommSemigroup n,
+      Fin.instDistrib n with
     intCast n := Fin.intCast n
     one_mul := Fin.one_mul'
     mul_one := Fin.mul_one',

--- a/Mathlib/Data/ZMod/Defs.lean
+++ b/Mathlib/Data/ZMod/Defs.lean
@@ -69,8 +69,6 @@ instance instDistrib (n : ℕ) : Distrib (Fin n) :=
     right_distrib := fun a b c => by
       rw [mul_comm, left_distrib_aux, mul_comm _ b, mul_comm] }
 
-namespace CommRing
-
 /--
 Commutative ring structure on `Fin n`.
 
@@ -94,7 +92,9 @@ def instCommRing (n : ℕ) [NeZero n] : CommRing (Fin n) :=
     zero_mul := Fin.zero_mul'
     mul_zero := Fin.mul_zero' }
 
-attribute [scoped instance] Fin.CommRing.instCommRing
+namespace CommRing
+
+attribute [scoped instance] Fin.instCommRing
 
 end CommRing
 

--- a/Mathlib/FieldTheory/AxGrothendieck.lean
+++ b/Mathlib/FieldTheory/AxGrothendieck.lean
@@ -140,7 +140,7 @@ noncomputable def genericPolyMapSurjOnOfInjOn [Finite ι]
             (fun i => (Equiv.sumAssoc _ _ _).symm (Sum.inr i)))))
   Formula.iAlls (α ⊕ Σ i : ι, mons i) ((mapsTo.imp <| injOn.imp <| surjOn).relabel Sum.inr)
 
-open Fin.CommRing in
+open Fin.CommRing in -- TODO: can this be refactored to avoid using the ring structure in the proof?
 theorem realize_genericPolyMapSurjOnOfInjOn
     [Finite ι] (φ : ring.Formula (α ⊕ ι)) (mons : ι → Finset (ι →₀ ℕ)) :
     (K ⊨ genericPolyMapSurjOnOfInjOn φ mons) ↔

--- a/Mathlib/FieldTheory/AxGrothendieck.lean
+++ b/Mathlib/FieldTheory/AxGrothendieck.lean
@@ -140,6 +140,7 @@ noncomputable def genericPolyMapSurjOnOfInjOn [Finite ι]
             (fun i => (Equiv.sumAssoc _ _ _).symm (Sum.inr i)))))
   Formula.iAlls (α ⊕ Σ i : ι, mons i) ((mapsTo.imp <| injOn.imp <| surjOn).relabel Sum.inr)
 
+open Fin.CommRing in
 theorem realize_genericPolyMapSurjOnOfInjOn
     [Finite ι] (φ : ring.Formula (α ⊕ ι)) (mons : ι → Finset (ι →₀ ℕ)) :
     (K ⊨ genericPolyMapSurjOnOfInjOn φ mons) ↔

--- a/Mathlib/GroupTheory/Perm/Fin.lean
+++ b/Mathlib/GroupTheory/Perm/Fin.lean
@@ -130,6 +130,7 @@ theorem cycleType_finRotate_of_le {n : ℕ} (h : 2 ≤ n) : cycleType (finRotate
 
 namespace Fin
 
+open Fin.NatCast in -- TODO: refactor to avoid needing this
 /-- `Fin.cycleRange i` is the cycle `(0 1 2 ... i)` leaving `(i+1 ... (n-1))` unchanged. -/
 def cycleRange {n : ℕ} (i : Fin n) : Perm (Fin n) :=
   (finRotate (i + 1)).extendDomain

--- a/Mathlib/LinearAlgebra/LinearDisjoint.lean
+++ b/Mathlib/LinearAlgebra/LinearDisjoint.lean
@@ -483,7 +483,7 @@ section
 
 variable [Nontrivial R]
 
-open Fin.CommRing in
+open Fin.CommRing in -- TODO: can this be refactored to avoid using the ring structure in the proof?
 /-- If `M` and `N` are linearly disjoint, if `M` is flat, then any two commutative
 elements of `↥(M ⊓ N)` are not `R`-linearly independent (namely, their span is not `R ^ 2`). -/
 theorem not_linearIndependent_pair_of_commute_of_flat_left [Module.Flat R M]

--- a/Mathlib/LinearAlgebra/LinearDisjoint.lean
+++ b/Mathlib/LinearAlgebra/LinearDisjoint.lean
@@ -483,6 +483,7 @@ section
 
 variable [Nontrivial R]
 
+open Fin.CommRing in
 /-- If `M` and `N` are linearly disjoint, if `M` is flat, then any two commutative
 elements of `↥(M ⊓ N)` are not `R`-linearly independent (namely, their span is not `R ^ 2`). -/
 theorem not_linearIndependent_pair_of_commute_of_flat_left [Module.Flat R M]
@@ -499,6 +500,7 @@ theorem not_linearIndependent_pair_of_commute_of_flat_left [Module.Flat R M]
   repeat rw [AddSubmonoid.mk_eq_zero, ZeroMemClass.coe_eq_zero] at hm
   exact h.ne_zero 0 hm.2
 
+open Fin.CommRing in
 /-- If `M` and `N` are linearly disjoint, if `N` is flat, then any two commutative
 elements of `↥(M ⊓ N)` are not `R`-linearly independent (namely, their span is not `R ^ 2`). -/
 theorem not_linearIndependent_pair_of_commute_of_flat_right [Module.Flat R N]

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Card.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Card.lean
@@ -31,6 +31,7 @@ local notation "n" => Module.finrank K V
 
 attribute [local instance] Fintype.ofFinite in
 open Fintype in
+open Fin.NatCast in
 /-- The cardinal of the set of linearly independent vectors over a finite dimensional vector space
 over a finite field. -/
 theorem card_linearIndependent {k : ℕ} (hk : k ≤ n) :

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Card.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Card.lean
@@ -31,7 +31,7 @@ local notation "n" => Module.finrank K V
 
 attribute [local instance] Fintype.ofFinite in
 open Fintype in
-open Fin.NatCast in
+open Fin.NatCast in -- TODO: should this be refactored to avoid needing the coercion?
 /-- The cardinal of the set of linearly independent vectors over a finite dimensional vector space
 over a finite field. -/
 theorem card_linearIndependent {k : ℕ} (hk : k ≤ n) :

--- a/Mathlib/MeasureTheory/Function/UnifTight.lean
+++ b/Mathlib/MeasureTheory/Function/UnifTight.lean
@@ -158,6 +158,7 @@ theorem unifTight_of_subsingleton [Subsingleton ι] (hp_top : p ≠ ∞)
   refine ⟨s, ne_of_lt hμs, fun j => ?_⟩
   convert hfε.le
 
+open Fin.NatCast in
 /-- This lemma is less general than `MeasureTheory.unifTight_finite` which applies to
 all sequences indexed by a finite type. -/
 private theorem unifTight_fin (hp_top : p ≠ ∞) {n : ℕ} {f : Fin n → α → β}

--- a/Mathlib/MeasureTheory/Function/UnifTight.lean
+++ b/Mathlib/MeasureTheory/Function/UnifTight.lean
@@ -158,7 +158,7 @@ theorem unifTight_of_subsingleton [Subsingleton ι] (hp_top : p ≠ ∞)
   refine ⟨s, ne_of_lt hμs, fun j => ?_⟩
   convert hfε.le
 
-open Fin.NatCast in
+open Fin.NatCast in -- TODO: should this be refactored to avoid needing the coercion?
 /-- This lemma is less general than `MeasureTheory.unifTight_finite` which applies to
 all sequences indexed by a finite type. -/
 private theorem unifTight_fin (hp_top : p ≠ ∞) {n : ℕ} {f : Fin n → α → β}

--- a/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/UniformIntegrable.lean
@@ -422,6 +422,7 @@ theorem unifIntegrable_subsingleton [Subsingleton ι] (hp_one : 1 ≤ p) (hp_top
     convert hδ s hs hμs
   · exact ⟨1, zero_lt_one, fun i => False.elim <| hι <| Nonempty.intro i⟩
 
+open Fin.NatCast -- TODO: refactor the proof to avoid needing this
 /-- This lemma is less general than `MeasureTheory.unifIntegrable_finite` which applies to
 all sequences indexed by a finite type. -/
 theorem unifIntegrable_fin (hp_one : 1 ≤ p) (hp_top : p ≠ ∞) {n : ℕ} {f : Fin n → α → β}

--- a/Mathlib/MeasureTheory/Integral/RieszMarkovKakutani/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/RieszMarkovKakutani/Basic.lean
@@ -154,7 +154,7 @@ section PartitionOfUnity
 
 variable [T2Space X] [LocallyCompactSpace X]
 
-open Fin.CommRing in
+open Fin.CommRing in -- TODO: can this be refactored to avoid using the ring structure in the proof?
 lemma exists_continuous_add_one_of_isCompact_nnreal
     {s₀ s₁ : Set X} {t : Set X} (s₀_compact : IsCompact s₀) (s₁_compact : IsCompact s₁)
     (t_compact : IsCompact t) (disj : Disjoint s₀ s₁) (hst : s₀ ∪ s₁ ⊆ t) :

--- a/Mathlib/MeasureTheory/Integral/RieszMarkovKakutani/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/RieszMarkovKakutani/Basic.lean
@@ -154,6 +154,7 @@ section PartitionOfUnity
 
 variable [T2Space X] [LocallyCompactSpace X]
 
+open Fin.CommRing in
 lemma exists_continuous_add_one_of_isCompact_nnreal
     {s₀ s₁ : Set X} {t : Set X} (s₀_compact : IsCompact s₀) (s₁_compact : IsCompact s₁)
     (t_compact : IsCompact t) (disj : Disjoint s₀ s₁) (hst : s₀ ∪ s₁ ⊆ t) :

--- a/Mathlib/Order/JordanHolder.lean
+++ b/Mathlib/Order/JordanHolder.lean
@@ -196,7 +196,7 @@ theorem head_le_of_mem {s : CompositionSeries X} {x : X} (hx : x ∈ s) : s.head
 theorem last_eraseLast_le (s : CompositionSeries X) : s.eraseLast.last ≤ s.last := by
   simp [eraseLast, last, s.strictMono.le_iff_le, Fin.le_iff_val_le_val]
 
-open Fin.NatCast in
+open Fin.NatCast in -- TODO: should this be refactored to avoid needing the coercion?
 theorem mem_eraseLast_of_ne_of_mem {s : CompositionSeries X} {x : X}
     (hx : x ≠ s.last) (hxs : x ∈ s) : x ∈ s.eraseLast := by
   rcases hxs with ⟨i, rfl⟩
@@ -204,7 +204,7 @@ theorem mem_eraseLast_of_ne_of_mem {s : CompositionSeries X} {x : X}
     conv_rhs => rw [← Nat.succ_sub (length_pos_of_nontrivial ⟨_, ⟨i, rfl⟩, _, s.last_mem, hx⟩),
       Nat.add_one_sub_one]
     exact lt_of_le_of_ne (Nat.le_of_lt_succ i.2) (by simpa [last, s.inj, Fin.ext_iff] using hx)
-  -- TODO: This is surely wrong: there is a double coercion hidden here:
+  -- TODO: This can surely be improved: there is a double coercion hidden here:
   refine ⟨Fin.castSucc (n := s.length + 1) i, ?_⟩
   simp [Fin.ext_iff, Nat.mod_eq_of_lt hi]
 

--- a/Mathlib/Order/JordanHolder.lean
+++ b/Mathlib/Order/JordanHolder.lean
@@ -196,6 +196,7 @@ theorem head_le_of_mem {s : CompositionSeries X} {x : X} (hx : x ∈ s) : s.head
 theorem last_eraseLast_le (s : CompositionSeries X) : s.eraseLast.last ≤ s.last := by
   simp [eraseLast, last, s.strictMono.le_iff_le, Fin.le_iff_val_le_val]
 
+open Fin.NatCast in
 theorem mem_eraseLast_of_ne_of_mem {s : CompositionSeries X} {x : X}
     (hx : x ≠ s.last) (hxs : x ∈ s) : x ∈ s.eraseLast := by
   rcases hxs with ⟨i, rfl⟩
@@ -203,6 +204,7 @@ theorem mem_eraseLast_of_ne_of_mem {s : CompositionSeries X} {x : X}
     conv_rhs => rw [← Nat.succ_sub (length_pos_of_nontrivial ⟨_, ⟨i, rfl⟩, _, s.last_mem, hx⟩),
       Nat.add_one_sub_one]
     exact lt_of_le_of_ne (Nat.le_of_lt_succ i.2) (by simpa [last, s.inj, Fin.ext_iff] using hx)
+  -- TODO: This is surely wrong: there is a double coercion hidden here:
   refine ⟨Fin.castSucc (n := s.length + 1) i, ?_⟩
   simp [Fin.ext_iff, Nat.mod_eq_of_lt hi]
 

--- a/Mathlib/Order/RelSeries.lean
+++ b/Mathlib/Order/RelSeries.lean
@@ -314,6 +314,7 @@ lemma append_apply_left (p q : RelSeries r) (connect : r p.last q.head)
   simp only [Function.comp_apply]
   convert Fin.append_left _ _ _
 
+open Fin.NatCast in -- TODO: can this be removed?
 lemma append_apply_right (p q : RelSeries r) (connect : r p.last q.head)
     (i : Fin (q.length + 1)) :
     p.append q connect (i.natAdd p.length + 1) = q i := by

--- a/Mathlib/RingTheory/ChainOfDivisors.lean
+++ b/Mathlib/RingTheory/ChainOfDivisors.lean
@@ -176,7 +176,7 @@ theorem element_of_chain_eq_pow_second_of_chain {q r : Associates M} {n : ℕ} (
     · exact H
     · exact Nat.succ_le_succ_iff.mp a.2
 
-open Fin.NatCast in
+open Fin.NatCast in -- TODO: should this be refactored to avoid needing the coercion?
 theorem eq_pow_second_of_chain_of_has_chain {q : Associates M} {n : ℕ} (hn : n ≠ 0)
     {c : Fin (n + 1) → Associates M} (h₁ : StrictMono c)
     (h₂ : ∀ {r : Associates M}, r ≤ q ↔ ∃ i, r = c i) (hq : q ≠ 0) : q = c 1 ^ n := by

--- a/Mathlib/RingTheory/ChainOfDivisors.lean
+++ b/Mathlib/RingTheory/ChainOfDivisors.lean
@@ -6,7 +6,6 @@ Authors: Anne Baanen, Paul Lezeau
 import Mathlib.Algebra.GCDMonoid.Basic
 import Mathlib.Algebra.IsPrimePow
 import Mathlib.RingTheory.UniqueFactorizationDomain.Multiplicity
-import Mathlib.Data.ZMod.Defs
 import Mathlib.Order.Atoms
 import Mathlib.Order.Hom.Bounded
 /-!

--- a/Mathlib/RingTheory/ChainOfDivisors.lean
+++ b/Mathlib/RingTheory/ChainOfDivisors.lean
@@ -176,6 +176,7 @@ theorem element_of_chain_eq_pow_second_of_chain {q r : Associates M} {n : ℕ} (
     · exact H
     · exact Nat.succ_le_succ_iff.mp a.2
 
+open Fin.NatCast in
 theorem eq_pow_second_of_chain_of_has_chain {q : Associates M} {n : ℕ} (hn : n ≠ 0)
     {c : Fin (n + 1) → Associates M} (h₁ : StrictMono c)
     (h₂ : ∀ {r : Associates M}, r ≤ q ↔ ∃ i, r = c i) (hq : q ≠ 0) : q = c 1 ^ n := by

--- a/Mathlib/SetTheory/Cardinal/Free.lean
+++ b/Mathlib/SetTheory/Cardinal/Free.lean
@@ -105,6 +105,7 @@ end Cardinal
 
 section Nonempty
 
+open Fin.CommRing in
 /-- A commutative ring can be constructed on any non-empty type.
 
 See also `Infinite.nonempty_field`. -/

--- a/Mathlib/Topology/Category/Stonean/Basic.lean
+++ b/Mathlib/Topology/Category/Stonean/Basic.lean
@@ -112,6 +112,7 @@ def mkFinite (X : Type*) [Finite X] [TopologicalSpace X] [DiscreteTopology X] : 
     intro U _
     apply isOpen_discrete (closure U)
 
+open Fin.CommRing in
 /--
 A morphism in `Stonean` is an epi iff it is surjective.
 -/

--- a/Mathlib/Topology/Category/Stonean/Basic.lean
+++ b/Mathlib/Topology/Category/Stonean/Basic.lean
@@ -112,7 +112,7 @@ def mkFinite (X : Type*) [Finite X] [TopologicalSpace X] [DiscreteTopology X] : 
     intro U _
     apply isOpen_discrete (closure U)
 
-open Fin.CommRing in
+open Fin.CommRing in -- TODO: can this be refactored to avoid using the ring structure in the proof?
 /--
 A morphism in `Stonean` is an epi iff it is surjective.
 -/

--- a/Mathlib/Topology/Connected/PathConnected.lean
+++ b/Mathlib/Topology/Connected/PathConnected.lean
@@ -376,6 +376,7 @@ theorem IsPathConnected.preimage_coe {U W : Set X} (hW : IsPathConnected W) (hWU
     IsPathConnected (((↑) : U → X) ⁻¹' W) := by
   rwa [IsInducing.subtypeVal.isPathConnected_iff, Subtype.image_preimage_val, inter_eq_right.2 hWU]
 
+open Fin.NatCast in -- TODO: refactor to avoid needing this.
 theorem IsPathConnected.exists_path_through_family {n : ℕ}
     {s : Set X} (h : IsPathConnected s) (p : Fin (n + 1) → X) (hp : ∀ i, p i ∈ s) :
     ∃ γ : Path (p 0) (p n), range γ ⊆ s ∧ ∀ i, p i ∈ range γ := by
@@ -433,6 +434,7 @@ theorem IsPathConnected.exists_path_through_family {n : ℕ}
   suffices i = i % n.succ by congr
   rw [Nat.mod_eq_of_lt hi]
 
+open Fin.NatCast in -- TODO: refactor to avoid needing this.
 theorem IsPathConnected.exists_path_through_family' {n : ℕ}
     {s : Set X} (h : IsPathConnected s) (p : Fin (n + 1) → X) (hp : ∀ i, p i ∈ s) :
     ∃ (γ : Path (p 0) (p n)) (t : Fin (n + 1) → I), (∀ t, γ t ∈ s) ∧ ∀ i, γ (t i) = p i := by
@@ -528,12 +530,14 @@ namespace PathConnectedSpace
 
 variable [PathConnectedSpace X]
 
+open Fin.NatCast in -- TODO: refactor to avoid needing this.
 theorem exists_path_through_family {n : ℕ} (p : Fin (n + 1) → X) :
     ∃ γ : Path (p 0) (p n), ∀ i, p i ∈ range γ := by
   have : IsPathConnected (univ : Set X) := pathConnectedSpace_iff_univ.mp (by infer_instance)
   rcases this.exists_path_through_family p fun _i => True.intro with ⟨γ, -, h⟩
   exact ⟨γ, h⟩
 
+open Fin.NatCast in -- TODO: refactor to avoid needing this.
 theorem exists_path_through_family' {n : ℕ} (p : Fin (n + 1) → X) :
     ∃ (γ : Path (p 0) (p n)) (t : Fin (n + 1) → I), ∀ i, γ (t i) = p i := by
   have : IsPathConnected (univ : Set X) := pathConnectedSpace_iff_univ.mp (by infer_instance)

--- a/MathlibTest/FinCoercions.lean
+++ b/MathlibTest/FinCoercions.lean
@@ -10,7 +10,6 @@ set_option pp.mvars false
 -- We first verify that there is no global coercion from `Nat` to `Fin n`.
 -- Such a coercion would frequently introduce unexpected modular arithmetic.
 
-#check Fin.instNatCast
 #synth NatCast (Fin 3)
 
 /-- info: fun n => ↑n : ℕ → Fin 3 -/

--- a/MathlibTest/FinCoercions.lean
+++ b/MathlibTest/FinCoercions.lean
@@ -10,10 +10,16 @@ set_option pp.mvars false
 -- We first verify that there is no global coercion from `Nat` to `Fin n`.
 -- Such a coercion would frequently introduce unexpected modular arithmetic.
 
-#check Fin.instAddMonoidWithOne
-#synth NatCast (Fin 3)
-
-/-- info: fun n => ↑n : ℕ → Fin 3 -/
+/--
+error: type mismatch
+  n
+has type
+  ℕ : Type
+but is expected to have type
+  Fin 3 : Type
+---
+info: fun n => sorry : (n : ℕ) → ?_ n
+-/
 #guard_msgs in #check fun (n : Nat) => (n : Fin 3)
 
 -- This coercion is available via `open Fin.CommRing in ...`

--- a/MathlibTest/FinCoercions.lean
+++ b/MathlibTest/FinCoercions.lean
@@ -1,0 +1,31 @@
+-- We verify that after importing Mathlib,
+-- we have not introduced a global coercion from `Nat` to `Fin n`.
+-- Such coercions introduce unexpected invisible wrap-around arithmetic.
+-- `open Fin.CommRing ...` *does* introduce such a coercion.
+
+import Mathlib
+
+set_option pp.mvars false
+
+-- We first verify that there is no global coercion from `Nat` to `Fin n`.
+-- Such a coercion would frequently introduce unexpected modular arithmetic.
+
+#check Fin.instNatCast
+#synth NatCast (Fin 3)
+
+/-- info: fun n => ↑n : ℕ → Fin 3 -/
+#guard_msgs in #check fun (n : Nat) => (n : Fin 3)
+
+-- This coercion is available via `open Fin.CommRing in ...`
+
+section
+
+open Fin.CommRing
+
+variable (m : Nat) (n : Fin 3)
+/-- info: n < ↑m : Prop -/
+#guard_msgs in #check n < m
+
+end
+
+example (x : Fin (n + 1)) (h : x < n) : Fin (n + 1) := x.succ.castLT (by simp [h])

--- a/MathlibTest/FinCoercions.lean
+++ b/MathlibTest/FinCoercions.lean
@@ -10,6 +10,7 @@ set_option pp.mvars false
 -- We first verify that there is no global coercion from `Nat` to `Fin n`.
 -- Such a coercion would frequently introduce unexpected modular arithmetic.
 
+#check Fin.instAddMonoidWithOne
 #synth NatCast (Fin 3)
 
 /-- info: fun n => ↑n : ℕ → Fin 3 -/

--- a/MathlibTest/instance_diamonds.lean
+++ b/MathlibTest/instance_diamonds.lean
@@ -229,10 +229,10 @@ example :
       ZMod.commRing p := by
   with_reducible_and_instances rfl
 
--- We need `open Fin.CommRing`, as otherwise `Fin.CommRing.instCommRing` is not an instance,
+-- We need `open Fin.CommRing`, as otherwise `Fin.instCommRing` is not an instance,
 -- so `with_reducible_and_instances` doesn't have the desired effect.
 open Fin.CommRing in
-example (n : ℕ) : ZMod.commRing (n + 1) = Fin.CommRing.instCommRing (n + 1) := by
+example (n : ℕ) : ZMod.commRing (n + 1) = Fin.instCommRing (n + 1) := by
   with_reducible_and_instances rfl
 
 example : ZMod.commRing 0 = Int.instCommRing := by

--- a/MathlibTest/instance_diamonds.lean
+++ b/MathlibTest/instance_diamonds.lean
@@ -229,7 +229,10 @@ example :
       ZMod.commRing p := by
   with_reducible_and_instances rfl
 
-example (n : ℕ) : ZMod.commRing (n + 1) = Fin.instCommRing (n + 1) := by
+-- We need `open Fin.CommRing`, as otherwise `Fin.CommRing.instCommRing` is not an instance,
+-- so `with_reducible_and_instances` doesn't have the desired effect.
+open Fin.CommRing in
+example (n : ℕ) : ZMod.commRing (n + 1) = Fin.CommRing.instCommRing (n + 1) := by
   with_reducible_and_instances rfl
 
 example : ZMod.commRing 0 = Int.instCommRing := by


### PR DESCRIPTION
This PR ensures there are no global `NatCast (Fin n)` instances --- and necessary to achieve this, also removes the global `CommRing (Fin n)` instance. I can appreciate some may not like this, but I think this change is important.

It should not be an instance because the `binop%` elaborator assumes that
there are no non-trivial coercion loops,
but this instance  would introduce a coercion from `Nat` to `Fin n` and back.
Non-trivial loops lead to undesirable and counterintuitive elaboration behavior.

For example, for `x : Fin k` and `n : Nat`,
it causes `x < n` to be elaborated as `x < ↑n` rather than `↑x < n`,
silently introducing wraparound arithmetic.

There are ~25 places where we need to use `open Fin.CommRing` or `open Fin.NatCast` to make these instances available locally. Many of these could be refactored to avoid needing the instances, but I have not done so here. I hope others will contribute to cleaning these up later.