### PR TITLE
[Merged by Bors] - feat: an invertible matrix as a perfect pairing

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4034,6 +4034,7 @@ import Mathlib.LinearAlgebra.Multilinear.TensorProduct
 import Mathlib.LinearAlgebra.Orientation
 import Mathlib.LinearAlgebra.PID
 import Mathlib.LinearAlgebra.PerfectPairing.Basic
+import Mathlib.LinearAlgebra.PerfectPairing.Matrix
 import Mathlib.LinearAlgebra.PerfectPairing.Restrict
 import Mathlib.LinearAlgebra.Pi
 import Mathlib.LinearAlgebra.PiTensorProduct

--- a/Mathlib/Data/Matrix/Mul.lean
+++ b/Mathlib/Data/Matrix/Mul.lean
@@ -59,7 +59,9 @@ section DotProduct
 
 variable [Fintype m] [Fintype n]
 
-/-- `dotProduct v w` is the sum of the entrywise products `v i * w i` -/
+/-- `dotProduct v w` is the sum of the entrywise products `v i * w i`.
+
+See also `dotProductEquiv`. -/
 def dotProduct [Mul α] [AddCommMonoid α] (v w : m → α) : α :=
   ∑ i, v i * w i
 

--- a/Mathlib/LinearAlgebra/Matrix/Dual.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Dual.lean
@@ -43,7 +43,7 @@ theorem Matrix.toLin_transpose (M : Matrix ι₁ ι₂ K) : Matrix.toLin B₁.du
 end Transpose
 
 /-- The dot product as a linear equivalence to the dual. -/
-@[simps] def dotProductEquiv (R n : Type*) [CommRing R] [Fintype n] [DecidableEq n] :
+@[simps] def dotProductEquiv (R n : Type*) [CommSemiring R] [Fintype n] [DecidableEq n] :
     (n → R) ≃ₗ[R] Module.Dual R (n → R) where
   toFun v := ⟨⟨dotProduct v, dotProduct_add v⟩, fun t ↦ dotProduct_smul t v⟩
   map_add' v w := by ext; simp

--- a/Mathlib/LinearAlgebra/Matrix/Dual.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Dual.lean
@@ -10,8 +10,7 @@ import Mathlib.LinearAlgebra.Matrix.ToLin
 /-!
 # Dual space, linear maps and matrices.
 
-This file contains some results on the matrix corresponding to the
-transpose of a linear map (in the dual space).
+This file contains some results about matrices and dual spaces.
 
 ## Tags
 
@@ -42,3 +41,13 @@ theorem Matrix.toLin_transpose (M : Matrix ι₁ ι₂ K) : Matrix.toLin B₁.du
   rw [LinearMap.toMatrix_toLin, LinearMap.toMatrix_transpose, LinearMap.toMatrix_toLin]
 
 end Transpose
+
+/-- The dot product as a linear equivalence to the dual. -/
+@[simps] def dotProductEquiv (R n : Type*) [CommRing R] [Fintype n] [DecidableEq n] :
+    (n → R) ≃ₗ[R] Module.Dual R (n → R) where
+  toFun v := ⟨⟨dotProduct v, dotProduct_add v⟩, fun t ↦ dotProduct_smul t v⟩
+  map_add' v w := by ext; simp
+  map_smul' t v := by ext; simp
+  invFun f i := f (LinearMap.single R _ i 1)
+  left_inv v := by simp
+  right_inv f := by ext; simp

--- a/Mathlib/LinearAlgebra/PerfectPairing/Basic.lean
+++ b/Mathlib/LinearAlgebra/PerfectPairing/Basic.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Oliver Nash
 -/
 import Mathlib.LinearAlgebra.Dual.Lemmas
+import Mathlib.LinearAlgebra.Matrix.Dual
+import Mathlib.LinearAlgebra.Matrix.ToLinearEquiv
 
 /-!
 # Perfect pairings of modules
@@ -284,6 +286,21 @@ def toPerfectPairing : PerfectPairing R N M where
   bijective_right := e.flip.bijective
 
 end LinearEquiv
+
+namespace Matrix
+
+variable {R n : Type*} [CommRing R] [Fintype n] [DecidableEq n]
+  (A : Matrix n n R) (h : Invertible A)
+
+def toPerfectPairing :
+    PerfectPairing R (n → R) (n → R) :=
+  ((A.toLinearEquiv' h).trans (dotProductEquiv R n)).toPerfectPairing
+
+@[simp] lemma _root_.Matrix.toPerfectPairing_apply_apply (v w : n → R) :
+    A.toPerfectPairing h v w = A *ᵥ v ⬝ᵥ w :=
+  rfl
+
+end Matrix
 
 /-- A perfect pairing induces a perfect pairing between dual spaces. -/
 def PerfectPairing.dual (p : PerfectPairing R M N) :

--- a/Mathlib/LinearAlgebra/PerfectPairing/Basic.lean
+++ b/Mathlib/LinearAlgebra/PerfectPairing/Basic.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Oliver Nash
 -/
 import Mathlib.LinearAlgebra.Dual.Lemmas
-import Mathlib.LinearAlgebra.Matrix.Dual
-import Mathlib.LinearAlgebra.Matrix.ToLinearEquiv
 
 /-!
 # Perfect pairings of modules
@@ -286,21 +284,6 @@ def toPerfectPairing : PerfectPairing R N M where
   bijective_right := e.flip.bijective
 
 end LinearEquiv
-
-namespace Matrix
-
-variable {R n : Type*} [CommRing R] [Fintype n] [DecidableEq n]
-  (A : Matrix n n R) (h : Invertible A)
-
-def toPerfectPairing :
-    PerfectPairing R (n → R) (n → R) :=
-  ((A.toLinearEquiv' h).trans (dotProductEquiv R n)).toPerfectPairing
-
-@[simp] lemma _root_.Matrix.toPerfectPairing_apply_apply (v w : n → R) :
-    A.toPerfectPairing h v w = A *ᵥ v ⬝ᵥ w :=
-  rfl
-
-end Matrix
 
 /-- A perfect pairing induces a perfect pairing between dual spaces. -/
 def PerfectPairing.dual (p : PerfectPairing R M N) :

--- a/Mathlib/LinearAlgebra/PerfectPairing/Matrix.lean
+++ b/Mathlib/LinearAlgebra/PerfectPairing/Matrix.lean
@@ -1,0 +1,34 @@
+/-
+Copyright (c) 2025 Oliver Nash. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Oliver Nash
+-/
+import Mathlib.LinearAlgebra.PerfectPairing.Basic
+import Mathlib.LinearAlgebra.Matrix.Dual
+import Mathlib.LinearAlgebra.Matrix.ToLinearEquiv
+
+/-!
+# Perfect pairings and matrices
+
+The file contains results connecting perfect pairings and matrices.
+
+## Main definitions
+* `Matrix.toPerfectPairing`: regard an invertible matrix as a perfect pairing.
+
+-/
+
+namespace Matrix
+
+variable {R n : Type*} [CommRing R] [Fintype n] [DecidableEq n]
+  (A : Matrix n n R) (h : Invertible A)
+
+/-- We may regard an invertible matrix as a perfect pairing. -/
+def toPerfectPairing :
+    PerfectPairing R (n → R) (n → R) :=
+  ((A.toLinearEquiv' h).trans (dotProductEquiv R n)).toPerfectPairing
+
+@[simp] lemma _root_.Matrix.toPerfectPairing_apply_apply (v w : n → R) :
+    A.toPerfectPairing h v w = A *ᵥ v ⬝ᵥ w :=
+  rfl
+
+end Matrix

--- a/Mathlib/LinearAlgebra/PerfectPairing/Matrix.lean
+++ b/Mathlib/LinearAlgebra/PerfectPairing/Matrix.lean
@@ -27,7 +27,7 @@ def toPerfectPairing :
     PerfectPairing R (n → R) (n → R) :=
   ((A.toLinearEquiv' h).trans (dotProductEquiv R n)).toPerfectPairing
 
-@[simp] lemma _root_.Matrix.toPerfectPairing_apply_apply (v w : n → R) :
+@[simp] lemma toPerfectPairing_apply_apply (v w : n → R) :
     A.toPerfectPairing h v w = A *ᵥ v ⬝ᵥ w :=
   rfl
 


### PR DESCRIPTION
Using this we can do things like:
```lean
attribute [simp] Matrix.one_fin_two
#check !![2, -3; -1, 2].toPerfectPairing ⟨!![2, 3; 1, 2], by simp, by simp⟩ -- Works
```
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
