### PR TITLE
[Merged by Bors] - chore(aesop_cat): update comment

### DIFF
--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -111,16 +111,16 @@ open Lean Meta Elab.Tactic in
 `rfl_cat` is a macro for `intros; rfl` which is attempted in `aesop_cat` before
 doing the more expensive `aesop` tactic.
 
-This gives a speedup because `simp` (called by `aesop`) is too slow.
-There is a fix for this slowness in https://github.com/leanprover/lean4/pull/7428.
-So, when that is resolved, the performance impact of `rfl_cat` should be measured again.
+This gives a speedup because `simp` (called by `aesop`) can be very slow.
+https://github.com/leanprover-community/mathlib4/pull/25475 contains recent measurements.
 
 Implementation notes:
 * `refine id ?_`:
   In some cases it is important that the type of the proof matches the expected type exactly.
   e.g. if the goal is `2 = 1 + 1`, the `rfl` tactic will give a proof of type `2 = 2`.
   Starting a proof with `refine id ?_` is a trick to make sure that the proof has exactly
-  the expected type, in this case `2 = 1 + 1`. See also https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/changing.20a.20proof.20can.20break.20a.20later.20proof
+  the expected type, in this case `2 = 1 + 1`. See also
+  https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/changing.20a.20proof.20can.20break.20a.20later.20proof
 * `apply_rfl`:
   `rfl` is a macro that attempts both `eq_refl` and `apply_rfl`. Since `apply_rfl`
   subsumes `eq_refl`, we can use `apply_rfl` instead. This fails twice as fast as `rfl`.

--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -112,7 +112,7 @@ open Lean Meta Elab.Tactic in
 doing the more expensive `aesop` tactic.
 
 This gives a speedup because `simp` (called by `aesop`) can be very slow.
-https://github.com/leanprover-community/mathlib4/pull/25475 contains recent measurements.
+https://github.com/leanprover-community/mathlib4/pull/25475 contains measurements from June 2025.
 
 Implementation notes:
 * `refine id ?_`:


### PR DESCRIPTION
Since mathlib includes leanprover/lean4#7448, update the comment accordingly. #25475 shows that this fast-path is still beneficial: so leave it, but update its comment accordingly.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
