### PR TITLE
[Merged by Bors] - style: `++` notation for `List.Vector`

### DIFF
--- a/Mathlib/Data/Vector/Basic.lean
+++ b/Mathlib/Data/Vector/Basic.lean
@@ -728,16 +728,16 @@ theorem replicate_succ (val : α) :
 section Append
 variable (ys : Vector α m)
 
-@[simp] lemma get_append_cons_zero : get (append (x ::ᵥ xs) ys) 0 = x := rfl
+@[simp] lemma get_append_cons_zero : get (x ::ᵥ xs ++ ys) 0 = x := rfl
 
 @[simp]
 theorem get_append_cons_succ {i : Fin (n + m)} {h} :
-    get (append (x ::ᵥ xs) ys) ⟨i+1, h⟩ = get (append xs ys) i :=
+    get (x ::ᵥ xs ++ ys) ⟨i+1, h⟩ = get (xs ++ ys) i :=
   rfl
 
 @[simp]
-theorem append_nil : append xs nil = xs := by
-  cases xs; simp [append]
+theorem append_nil : xs ++ (nil : Vector α 0) = xs := by
+  cases xs; simp only [append_def, append_nil]
 
 end Append
 

--- a/Mathlib/Data/Vector/Defs.lean
+++ b/Mathlib/Data/Vector/Defs.lean
@@ -88,7 +88,7 @@ def get (l : Vector α n) (i : Fin n) : α :=
   l.1.get <| i.cast l.2.symm
 
 instance {n m : Nat} : HAppend (Vector α n) (Vector α m) (Vector α (n + m)) where
-  hAppend := fun | ⟨l₁, h₁⟩, ⟨l₂, h₂⟩ => ⟨l₁ ++ l₂, by simp [*]⟩
+  hAppend | ⟨l₁, h₁⟩, ⟨l₂, h₂⟩ => ⟨l₁ ++ l₂, by simp [*]⟩
 
 lemma append_def {n m : Nat}:
     (HAppend.hAppend : Vector α n → Vector α m → Vector α (n + m)) =

--- a/Mathlib/Data/Vector/Defs.lean
+++ b/Mathlib/Data/Vector/Defs.lean
@@ -87,7 +87,16 @@ def toList (v : Vector α n) : List α :=
 def get (l : Vector α n) (i : Fin n) : α :=
   l.1.get <| i.cast l.2.symm
 
+instance {n m : Nat} : HAppend (Vector α n) (Vector α m) (Vector α (n + m)) where
+  hAppend := fun | ⟨l₁, h₁⟩, ⟨l₂, h₂⟩ => ⟨l₁ ++ l₂, by simp [*]⟩
+
+lemma append_def {n m : Nat}:
+    (HAppend.hAppend : Vector α n → Vector α m → Vector α (n + m)) =
+      fun | ⟨l₁, h₁⟩, ⟨l₂, h₂⟩ => ⟨l₁ ++ l₂, by simp [*]⟩ :=
+  rfl
+
 /-- Appending a vector to another. -/
+@[deprecated "use `++` instead" (since := "2025-06-05")]
 def append {n m : Nat} : Vector α n → Vector α m → Vector α (n + m)
   | ⟨l₁, h₁⟩, ⟨l₂, h₂⟩ => ⟨l₁ ++ l₂, by simp [*]⟩
 
@@ -179,13 +188,12 @@ section Shift
 /-- `shiftLeftFill v i` is the vector obtained by left-shifting `v` `i` times and padding with the
     `fill` argument. If `v.length < i` then this will return `replicate n fill`. -/
 def shiftLeftFill (v : Vector α n) (i : ℕ) (fill : α) : Vector α n :=
-  Vector.congr (by simp) <|
-    append (drop i v) (replicate (min n i) fill)
+  Vector.congr (by simp) (drop i v ++ replicate (min n i) fill)
 
 /-- `shiftRightFill v i` is the vector obtained by right-shifting `v` `i` times and padding with the
     `fill` argument. If `v.length < i` then this will return `replicate n fill`. -/
 def shiftRightFill (v : Vector α n) (i : ℕ) (fill : α) : Vector α n :=
-  Vector.congr (by omega) <| append (replicate (min n i) fill) (take (n - i) v)
+  Vector.congr (by omega) (replicate (min n i) fill ++ take (n - i) v)
 
 end Shift
 
@@ -224,7 +232,7 @@ theorem toList_cons (a : α) (v : Vector α n) : toList (cons a v) = a :: toList
 /-- Appending of vectors corresponds under `toList` to appending of lists. -/
 @[simp]
 theorem toList_append {n m : ℕ} (v : Vector α n) (w : Vector α m) :
-    toList (append v w) = toList v ++ toList w := by
+    toList (v ++ w) = toList v ++ toList w := by
   cases v
   cases w
   rfl

--- a/Mathlib/Data/Vector/Snoc.lean
+++ b/Mathlib/Data/Vector/Snoc.lean
@@ -24,7 +24,7 @@ variable {α β σ φ : Type*} {n : ℕ} {x : α} {s : σ} (xs : Vector α n)
 
 /-- Append a single element to the end of a vector -/
 def snoc : Vector α n → α → Vector α (n+1) :=
-  fun xs x => append xs (x ::ᵥ Vector.nil)
+  fun xs x => xs ++ x ::ᵥ Vector.nil
 
 /-! ## Simplification lemmas -/
 
@@ -51,7 +51,7 @@ theorem reverse_snoc : reverse (xs.snoc x) = x ::ᵥ (reverse xs) := by
   cases xs
   simp only [reverse, snoc, cons, toList_mk]
   congr
-  simp [toList, Vector.append, Append.append]
+  simp [toList, append_def]
 
 theorem replicate_succ_to_snoc (val : α) :
     replicate (n+1) val = (replicate n val).snoc val := by


### PR DESCRIPTION
In Mathlib 3, the `++` notation was homogeneous so couldn't be used for `List.Vector.append : List.Vector α n → List.Vector α m → List.Vector α (n + m)`.
Now we can use this `++` notation, as `_root_.Vector` use it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
