### PR TITLE
fix(Algebra/Notation/Pi): fix variable explicitness

### DIFF
--- a/Mathlib/Algebra/Group/Pi/Basic.lean
+++ b/Mathlib/Algebra/Group/Pi/Basic.lean
@@ -201,7 +201,7 @@ theorem mulSingle_op₂ (op : ∀ i, M i → N i → O i) (h : ∀ i, op i 1 1 =
     mulSingle i (op i x₁ x₂) = fun j => op j (mulSingle i x₁ j) (mulSingle i x₂ j) :=
   Eq.symm <| funext <| apply_mulSingle₂ op h i x₁ x₂
 
-variable (f)
+variable (M)
 
 @[to_additive]
 theorem mulSingle_injective (i : ι) : Function.Injective (mulSingle i : M i → ∀ i, M i) :=
@@ -209,7 +209,7 @@ theorem mulSingle_injective (i : ι) : Function.Injective (mulSingle i : M i →
 
 @[to_additive (attr := simp)]
 theorem mulSingle_inj (i : ι) {x y : M i} : mulSingle i x = mulSingle i y ↔ x = y :=
-  (Pi.mulSingle_injective _).eq_iff
+  (Pi.mulSingle_injective _ _).eq_iff
 
 variable {M : Type*} [One M]
 

--- a/Mathlib/Data/DFinsupp/Defs.lean
+++ b/Mathlib/Data/DFinsupp/Defs.lean
@@ -474,7 +474,7 @@ theorem single_eq_of_ne {i i' b} (h : i ≠ i') : (single i b : Π₀ i, β i) i
   simp only [single_apply, dif_neg h]
 
 theorem single_injective {i} : Function.Injective (single i : β i → Π₀ i, β i) := fun _ _ H =>
-  Pi.single_injective i <| DFunLike.coe_injective.eq_iff.mpr H
+  Pi.single_injective _ i <| DFunLike.coe_injective.eq_iff.mpr H
 
 /-- Like `Finsupp.single_eq_single_iff`, but with a `HEq` due to dependent types -/
 theorem single_eq_single_iff (i j : ι) (xi : β i) (xj : β j) :

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -1202,6 +1202,6 @@ section single
 lemma orderOf_piMulSingle {ι : Type*} [DecidableEq ι] {M : ι → Type*} [(i : ι) → Monoid (M i)]
     (i : ι) (g : M i) :
     orderOf (Pi.mulSingle i g) = orderOf g :=
-  orderOf_injective (MonoidHom.mulSingle M i) (Pi.mulSingle_injective i) g
+  orderOf_injective (MonoidHom.mulSingle M i) (Pi.mulSingle_injective M i) g
 
 end single

--- a/Mathlib/LinearAlgebra/Pi.lean
+++ b/Mathlib/LinearAlgebra/Pi.lean
@@ -320,7 +320,7 @@ theorem single_eq_pi_diag (i : ι) : single R φ i = pi (diag i) := by
   rfl
 
 theorem ker_single (i : ι) : ker (single R φ i) = ⊥ :=
-  ker_eq_bot_of_injective <| Pi.single_injective _
+  ker_eq_bot_of_injective <| Pi.single_injective _ _
 
 theorem proj_comp_single (i j : ι) : (proj i).comp (single R φ j) = diag j i := by
   rw [single_eq_pi_diag, proj_pi]


### PR DESCRIPTION
This was missed in #25040.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
