### PR TITLE
[Merged by Bors] - fix: eliminate metadata in linarith

### DIFF
--- a/Mathlib/Tactic/Linarith/Parsing.lean
+++ b/Mathlib/Tactic/Linarith/Parsing.lean
@@ -180,7 +180,8 @@ and forces some functions that call it into `MetaM` as well.
 -/
 
 partial def linearFormOfExpr (red : TransparencyMode) (m : ExprMap) (e : Expr) :
-    MetaM (ExprMap × Sum) :=
+    MetaM (ExprMap × Sum) := do
+  let e ← whnfR e
   match e.numeral? with
   | some 0 => return ⟨m, TreeMap.empty⟩
   | some (n+1) => return ⟨m, scalar (n+1)⟩

--- a/MathlibTest/linarith.lean
+++ b/MathlibTest/linarith.lean
@@ -733,6 +733,6 @@ example (x : ℤ) : 0 ≤ x * tightlyWrapped x := by nlinarith
 
 end findSquares
 
--- `Expr.mdata` should be ignored by linraith
+-- `Expr.mdata` should be ignored by linarith
 example (x : Int) (h : x = -2) : x = no_index(-2) := by
   linarith [h]

--- a/MathlibTest/linarith.lean
+++ b/MathlibTest/linarith.lean
@@ -712,6 +712,7 @@ example {x1 x2 x3 x4 x5 x6 x7 x8 : ℚ} :
     x7 - x5 < 0 → False := by
   intros
   linarith (config := { oracle := .fourierMotzkin })
+
 section findSquares
 
 private abbrev wrapped (z : ℤ) : ℤ := z
@@ -731,3 +732,7 @@ failed
 example (x : ℤ) : 0 ≤ x * tightlyWrapped x := by nlinarith
 
 end findSquares
+
+-- `Expr.mdata` should be ignored by linraith
+example (x : Int) (h : x = -2) : x = no_index(-2) := by
+  linarith [h]


### PR DESCRIPTION
Otherwise this interferes with the `answer()` elaborator from formal-conjectures.

Diagnosed using #25500.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
