### PR TITLE
feat(MeasureTheory/Measure/): Hausdorff measure under orthogonal proj…

### DIFF
--- a/Mathlib/MeasureTheory/Measure/Hausdorff-orthogonal-projection.lean
+++ b/Mathlib/MeasureTheory/Measure/Hausdorff-orthogonal-projection.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2025 Francesco Nishanil Chotuck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Francesco Nishanil Chotuck
+-/
+
+import Mathlib.MeasureTheory.Measure.Haar.Disintegration
+import Mathlib.MeasureTheory.Measure.Hausdorff
+import Mathlib.Order.CompletePartialOrder
+
+/-!
+# Orthogonal Projections and Hausdorff Measure
+
+This file proves that Hausdorff measure is non-increasing under orthogonal projection
+onto a finite-dimensional Euclidean subspace.
+
+## Main results
+
+* `hausdorffMeasure_orthogonalProjection_le`: The `s`-dimensional Hausdorff
+  measure of the projection of a set is at most the measure of the original set.
+
+## References
+
+This formalisation is based on Lemma 3.5 from:
+
+- Julian Fox, *Besicovitch Sets, Kakeya Sets, and Their Properties*,
+  University of Chicago REU, 2021.
+  https://math.uchicago.edu/~may/REU2021/REUPapers/Fox.pdf
+-/
+
+open ENNReal MeasureTheory
+
+/--
+In a finite-dimensional Euclidean space, the norm of the orthogonal projection
+of a vector `v` onto a subspace `V` is less than or equal to the norm of `v`.
+-/
+lemma norm_orthogonalProjection_le (n : ℕ)
+  (V : Submodule ℝ (EuclideanSpace ℝ (Fin n)))
+  (v : EuclideanSpace ℝ (Fin n)) :
+    ‖orthogonalProjection V v‖ ≤ ‖v‖ := by
+  -- Use the definition of operator norm to bound the projection of v
+  have h₁ : ‖orthogonalProjection V v‖ ≤ ‖orthogonalProjection V‖ * ‖v‖ := by
+    apply ContinuousLinearMap.le_opNorm
+  -- Use the known fact that the operator norm of an orthogonal projection is at most 1
+  have h₂ : ‖orthogonalProjection V‖ ≤ 1 := by
+    apply orthogonalProjection_norm_le
+  -- Combine the inequalities to obtain the final bound
+  have h₃ : ‖orthogonalProjection V‖ * ‖v‖ ≤ ‖v‖ := by
+    calc
+      ‖orthogonalProjection V‖ * ‖v‖ ≤ 1 * ‖v‖ := by
+        gcongr
+      _ = ‖v‖ := by
+        simp only [one_mul]
+  exact le_trans h₁ h₃
+
+/--
+The orthogonal projection onto a subspace `V` in a finite-dimensional Euclidean space
+is a `1`-Lipschitz function.
+-/
+lemma lipschitzWith_orthogonalProjection (n : ℕ)
+  (V : Submodule ℝ (EuclideanSpace ℝ (Fin n))) :
+    LipschitzWith 1 (orthogonalProjection V) := by
+  -- Apply the constructor for a function being 1-Lipschitz
+  apply LipschitzWith.mk_one
+  intro x y
+  -- Express distances using the norm
+  rw [dist_eq_norm, dist_eq_norm]
+  -- Use linearity of projection to factor out subtraction
+  calc
+    ‖orthogonalProjection V x - orthogonalProjection V y‖
+      = ‖orthogonalProjection V (x - y)‖ := by
+        simp only [AddSubgroupClass.coe_norm, AddSubgroupClass.coe_sub, map_sub]
+    -- Apply previously proven bound on the projection of a vector
+    _ ≤ ‖x - y‖ := by apply norm_orthogonalProjection_le
+
+variable (n k : ℕ) (W : Submodule ℝ (EuclideanSpace ℝ (Fin n))) (A : Set (EuclideanSpace ℝ (Fin n)))
+  (h : Module.finrank ℝ W = k)
+
+/--
+Let `A` be a subset of `ℝⁿ` and `W` a `k`-dimensional subspace. Then the `s`-dimensional
+Hausdorff measure of the orthogonal projection of `A` onto `W` is less than or equal to the
+`s`-dimensional Hausdorff measure of `A`.
+-/
+lemma hausdorffMeasure_orthogonalProjection_le (s: NNReal) (hs : 0 ≤ s.toReal):
+    μH[s.toReal] (orthogonalProjection W '' A) ≤ μH[s.toReal] A := by
+  -- Orthogonal projection is 1-Lipschitz in Euclidean space.
+  have h_Lipschitz : LipschitzWith 1 (orthogonalProjection W) := by
+    apply lipschitzWith_orthogonalProjection
+  -- Apply the general inequality for Hausdorff measure under Lipschitz maps.
+  -- Since the Lipschitz constant is 1, the multiplicative factor is 1^s = 1.
+  have h : μH[s.toReal] (orthogonalProjection W '' A)
+      ≤ (1 : ENNReal) ^ (s.toReal) * μH[s.toReal] A := by
+    apply LipschitzWith.hausdorffMeasure_image_le
+    exact h_Lipschitz
+    exact hs
+  -- Simplify the bound using 1^s = 1 and 1 · μH = μH.
+  simp only [one_rpow, one_mul] at h
+  exact h


### PR DESCRIPTION
Formalises Lemma 3.5 from:

Julian Fox, *Besicovitch Sets, Kakeya Sets, and Their Properties*   UChicago REU 2021, https://math.uchicago.edu/~may/REU2021/REUPapers/Fox.pdf

Adds:
* `hausdorffMeasure_orthogonalProjection_le` – the s-dimensional Hausdorff measure is non-increasing under orthogonal projection in Euclidean space.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
