### PR TITLE
[Merged by Bors] - chore: use `landrun` to sandbox CI builds

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -25,6 +25,16 @@ jobs:
     if: github.repository MAIN_OR_FORK 'leanprover-community/mathlib4'
     name: BuildJOB_NAME
     runs-on: RUNS_ON
+    outputs:
+      build-outcome: ${{ steps.build.outcome }}
+      archive-outcome: ${{ steps.archive.outcome }}
+      counterexamples-outcome: ${{ steps.counterexamples.outcome }}
+      get-cache-outcome: ${{ steps.get.outcome }}
+      lint-outcome: ${{ steps.lint.outcome }}
+      mk_all-outcome: ${{ steps.mk_all.outcome }}
+      noisy-outcome: ${{ steps.noisy.outcome }}
+      shake-outcome: ${{ steps.shake.outcome }}
+      test-outcome: ${{ steps.test.outcome }}
     defaults: # On Hoskinson runners, landrun is already installed.
       run:
         shell: landrun --rox /usr --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT -- bash -euxo pipefail {0}
@@ -294,11 +304,17 @@ jobs:
           ../master-branch/.lake/build/bin/cache get Archive.lean
           ../master-branch/.lake/build/bin/cache get Counterexamples.lean
 
-      - name: build archive and counterexamples
+      - name: build archive
         id: archive
         run: |
           cd pr-branch
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive Counterexamples"
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive"
+
+      - name: build counterexamples
+        id: counterexamples
+        run: |
+          cd pr-branch
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Counterexamples"
 
       # The cache secrets are available here, so we must not run any untrusted code.
       - name: put archive and counterexamples cache
@@ -455,7 +471,7 @@ jobs:
       # https://leanprover.zulipchat.com/#narrow/stream/345428-mathlib-reviewers/topic/lean4checker
 
       - name: checkout lean4checker
-        if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
+        if: ${{ (always() && needs.build.outputs.build-outcome == 'success' || needs.build.outputs.build-outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
         shell: bash
         run: |
           git clone https://github.com/leanprover/lean4checker
@@ -470,7 +486,7 @@ jobs:
           fi
 
       - name: run leanchecker on itself
-        if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
+        if: ${{ (always() && needs.build.outputs.build-outcome == 'success' || needs.build.outputs.build-outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
         run: |
           cd lean4checker
           # Build lean4checker using the same toolchain

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -25,8 +25,12 @@ jobs:
     if: github.repository MAIN_OR_FORK 'leanprover-community/mathlib4'
     name: BuildJOB_NAME
     runs-on: RUNS_ON
+    defaults: # On Hoskinson runners, landrun is already installed.
+      run:
+        shell: landrun --rox /usr --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT -- bash -euxo pipefail {0}
     steps:
       - name: cleanup
+        shell: bash    # This *just* deletes old files, so is safe to run outside landrun.
         run: |
           find . -name . -o -prune -exec rm -rf -- {} +
           # Delete all but the 5 most recent toolchains.
@@ -42,17 +46,89 @@ jobs:
       - name: 'Setup jq'
         uses: dcarbone/install-jq-action@f0e10f46ff84f4d32178b4b76e1ef180b16f82c3 # v3.1.1
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Configure Lean
-        uses: leanprover/lean-action@f807b338d95de7813c5c50d018f1c23c9b93b4ec # 2025-04-24
+      # Checkout the master branch into a subdirectory
+      - name: Checkout master branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          auto-config: false
-          use-github-cache: false
-          use-mathlib-cache: false
-          reinstall-transient-toolchain: true
+          ref: master
+          path: master-branch
+
+      # Checkout the PR branch into a subdirectory
+      - name: Checkout PR branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: pr-branch
+
+      - name: Prepare DownstreamTest directory
+        shell: bash
+        run: |
+          echo "Copying lean-toolchain to DownstreamTest..."
+          cd pr-branch
+          # Ensure DownstreamTest/.lake/ directory exists, since landrun will need it later
+          mkdir -p DownstreamTest/.lake/
+          cd DownstreamTest
+          cp ../lean-toolchain .
+          echo "lean-toolchain copied successfully to DownstreamTest."
+
+      # Create empty directories so landrun doesn't complain
+      - name: Create empty directories
+        shell: bash # We need to run this outside landrun, as it is a prerequisite for landrun!
+        run: |
+          mkdir -p pr-branch/.lake/
+          mkdir -p .cache/mathlib/
+          mkdir -p _work
+
+      # NOTE: if you copy this, consider using `leanprover/lean-action` instead.
+      # We install manually, to avoid running lean outside landrun.
+      - name: install elan
+        shell: bash
+        run: |
+          set -o pipefail
+          curl -o elan-init.sh -sSfL https://elan.lean-lang.org/elan-init.sh
+          chmod +x elan-init.sh
+          ./elan-init.sh -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
+
+      - name: set toolchain directory
+        shell: bash
+        run: |
+          cd pr-branch
+          # Get the lake binary path from elan and extract toolchain directory
+          LAKE_PATH=$(elan which lake)
+          echo "Lake path: $LAKE_PATH"
+
+          # Extract the toolchain directory by removing /bin/lake from the end
+          TOOLCHAIN_DIR=$(dirname "$LAKE_PATH")
+          TOOLCHAIN_DIR=$(dirname "$TOOLCHAIN_DIR")
+          echo "Toolchain directory: $TOOLCHAIN_DIR"
+
+          # Set it as an environment variable for subsequent steps
+          echo "TOOLCHAIN_DIR=$TOOLCHAIN_DIR" >> "$GITHUB_ENV"
+
+      - name: set LEAN_SRC_PATH
+        shell: bash
+        run: |
+          # Construct the LEAN_SRC_PATH using the toolchain directory
+          LEAN_SRC_PATH=".:$TOOLCHAIN_DIR/src/lean/lake:.lake/packages/Cli:.lake/packages/batteries:.lake/packages/Qq:.lake/packages/aesop:.lake/packages/proofwidgets:.lake/packages/importGraph:.lake/packages/LeanSearchClient:.lake/packages/plausible"
+          echo "LEAN_SRC_PATH=$LEAN_SRC_PATH"
+
+          # Set it as an environment variable for subsequent steps
+          echo "LEAN_SRC_PATH=$LEAN_SRC_PATH" >> "$GITHUB_ENV"
+
+      - name: build master-branch tools
+        shell: bash # We're only building the `master` branch version of the tools, so don't need to run inside landrun.
+        run: |
+          cd master-branch
+          lake build cache mk_all check-yaml graph
+          ls .lake/build/bin/cache
+          ls .lake/build/bin/mk_all
+          ls .lake/build/bin/check-yaml
+          ls .lake/packages/importGraph/.lake/build/bin/graph
 
       - name: cleanup .cache/mathlib
+        # This needs write access to .cache/mathlib, so can't be run inside landrun.
+        # However it is only using the `master` version of `cache`, so is safe to run outside landrun.
+        shell: bash
         run: |
           # Define the cache directory path
           CACHE_DIR="$HOME/.cache/mathlib"
@@ -70,117 +146,226 @@ jobs:
           # Check if size exceeds 10GB
           if [ "$DIR_SIZE" -gt "10737418240" ]; then
             echo "Cache size exceeds threshold, running lake exe cache clean"
-            lake exe cache clean || echo "lake did not work"
+            # We use the master-branch version of `cache`.
+            cd master-branch
+            lake exe cache clean
           fi
 
-      - name: build cache
+      - name: download dependencies
+        # We need network access to download dependencies
+        # We run this inside landrun, but restrict disk access.
+        # Landrun argument notes:
+        # - we give --rox access to `~/.elan` and `~/actions-runner/_work` (GitHub CI needs this)
+        # - we give --unrestricted-network as we need this to download dependencies
+        # - git needs read only access to `/etc`.
+        shell: landrun --unrestricted-network --rox /etc --rox /usr --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT -- bash -euxo pipefail {0}
         run: |
-          lake build cache
+          cd pr-branch
+          lake env
 
-      - name: get cache
-        id: get
+      - name: get cache (1/3 - setup and initial fetch)
+        id: get_cache_part1_setup
+        shell: bash # only runs `cache get` from `master-branch`, so doesn't need to be inside landrun
         run: |
+          cd pr-branch
+          echo "Removing old Mathlib build directories prior to cache fetch..."
           rm -rf .lake/build/lib/lean/Mathlib
-          # useful pre v4.18: the following command is only present for compatibility reasons
-          rm -rf .lake/build/lib/Mathlib/
+
           # Fail quickly if the cache is completely cold, by checking for Mathlib.Init
-          lake exe cache get Mathlib/Init.lean
-          lake build --no-build Mathlib.Init && lake exe cache get || echo "No cache for 'Mathlib.Init' available"
+          echo "Attempting to fetch olean for Mathlib/Init.lean from cache..."
+          ../master-branch/.lake/build/bin/cache get Mathlib/Init.lean
+
+      - name: get cache (2/3 - test Mathlib.Init cache)
+        id: get_cache_part2_test
+        continue-on-error: true # Allow workflow to proceed to Part 3 to check outcome
+        # This step uses the job's default shell, which is landrun-wrapped bash
+        run: |
+          cd pr-branch
+
+          echo "Attempting: lake build --no-build Mathlib.Init (this runs under landrun)"
+          lake build --no-build Mathlib.Init
+
+      - name: get cache (3/3 - finalize cache operation)
+        id: get
+        shell: bash # only runs `cache get` from `master-branch`, so doesn't need to be inside landrun
+        run: |
+          cd pr-branch
+          if [[ "${{ steps.get_cache_part2_test.outcome }}" == "success" ]]; then
+            echo "Fetching all remaining cache..."
+
+            ../master-branch/.lake/build/bin/cache get
+          else
+            echo "WARNING: 'lake build --no-build Mathlib.Init' failed."
+            echo "No cache for 'Mathlib.Init' available or it could not be prepared."
+          fi
 
       - name: update {Mathlib, Tactic, Counterexamples, Archive}.lean
         id: mk_all
+        continue-on-error: true # Allow workflow to continue, outcome checked later
+        # This only runs `mk_all --check` from the `master-branch`, so doesn't need to be inside landrun
+        shell: bash
         run: |
+          cd pr-branch
 
-          if ! lake exe mk_all --check
-          then
-            echo "Not all lean files are in the import all files"
-            echo "mk_all=false" >> "${GITHUB_OUTPUT}"
-          else
-            echo "mk_all=true" >> "${GITHUB_OUTPUT}"
-          fi
+          echo "Running mk_all --check (from master-branch)..."
+          LAKE_HOME="$TOOLCHAIN_DIR" ../master-branch/.lake/build/bin/mk_all --check
 
-      - name: build mathlib
-        id: build
+      - name: begin gh-problem-match-wrap for build step
         uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
         with:
+          action: add # In order to be able to run a multiline script, we need to add/remove the problem matcher before and after.
           linters: lean
-          run: |
-            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
+      - name: build mathlib
+        id: build
+        run: |
+          cd pr-branch
+          # Test curl - should fail when landrun network isolation is working
+          if curl --silent --head --fail https://www.example.com/ >/dev/null 2>&1; then
+            echo "ERROR: curl to example.com succeeded, but it should fail when landrun is working correctly!"
+            exit 1
+          else
+            echo "curl to example.com failed as expected - landrun network isolation is working"
+          fi
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
+      - name: end gh-problem-match-wrap for build step
+        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
+        with:
+          action: remove
+          linters: lean
 
       - name: print the sizes of the oleans
         run: |
-          du .lake/build/lib/lean/Mathlib ||
-            # This path was the correct path before v4.18: it is here just for compatibility reasons
-            du .lake/build/lib/Mathlib || echo "This code should be unreachable"
+          cd pr-branch
+          du .lake/build/lib/lean/Mathlib || echo "This code should be unreachable"
 
+      # The cache secrets are available here, so we must not run any untrusted code.
       - name: upload cache
         # We only upload the cache if the build started (whether succeeding, failing, or cancelled)
         # but not if any earlier step failed or was cancelled.
         # See discussion at https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Some.20files.20not.20found.20in.20the.20cache/near/407183836
         if: ${{ always() && steps.get.outcome == 'success' }}
+        shell: bash
         run: |
+          cd pr-branch
+
+          # Use the trusted cache tool from master-branch
           # TODO: this is not doing anything currently, and needs to be integrated with put-unpacked
-          # lake exe cache commit || true
+          # ../master-branch/.lake/build/bin/cache commit || true
           # run this in CI if it gets an incorrect lake hash for existing cache files somehow
-          # lake exe cache put!
+          # ../master-branch/.lake/build/bin/cache put!
           # do not try to upload files just downloaded
-          lake exe cache put-unpacked
+          ../master-branch/.lake/build/bin/cache put-unpacked
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
           MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
 
       - name: check the cache
+        # We need network access to download dependencies
+        # We run this inside landrun, but restrict disk access as usual.
+        shell: landrun --unrestricted-network --rox /usr --rw /dev --rox /etc --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib -rw pr-branch/.lake/ --rw pr-branch/DownstreamTest/ --env PATH --env HOME --env GITHUB_OUTPUT -- bash -euxo pipefail {0}
         run: |
+          cd pr-branch
+
           # Because the `lean-pr-testing-NNNN` branches use toolchains that are "updated in place"
           # the cache mechanism is unreliable, so we don't test it if we are on such a branch.
           if [[ ! $(cat lean-toolchain) =~ ^leanprover/lean4-pr-releases:pr-release-[0-9]+$ ]]; then
             cd DownstreamTest
-            cp ../lean-toolchain .
             MATHLIB_NO_CACHE_ON_UPDATE=1 lake update
-            lake exe cache get || (sleep 1; lake exe cache get)
+
+            lake env ../../master-branch/.lake/build/bin/cache get || (sleep 1; lake env ../../master-branch/.lake/build/bin/cache get)
+
             # We need to run `lake build ProofWidgets` here to retrieve ProofWidgets via Reservoir.
             lake build ProofWidgets
             lake build --no-build Mathlib
           fi
 
-      - name: build archive
+      # Note: we should not be including `Archive` and `Counterexamples` in the cache.
+      # We do this for now for the sake of not rebuilding them in every CI run
+      # even when they are not touched.
+      # Since `Archive` and `Counterexamples` files have very simple dependencies,
+      # it should be possible to determine whether they need to be built without actually
+      # storing and transferring oleans over the network.
+      # Hopefully a future re-implementation of `cache` will obviate the present need for this hack.
+
+      - name: fetch archive and counterexamples cache
+        shell: bash
+        run: |
+          cd pr-branch
+          ../master-branch/.lake/build/bin/cache get Archive.lean
+          ../master-branch/.lake/build/bin/cache get Counterexamples.lean
+
+      - name: build archive and counterexamples
         id: archive
         run: |
-          # Note: we should not be including `Archive` and `Counterexamples` in the cache.
-          # We do this for now for the sake of not rebuilding them in every CI run
-          # even when they are not touched.
-          # Since `Archive` and `Counterexamples` files have very simple dependencies,
-          # it should be possible to determine whether they need to be built without actually
-          # storing and transferring oleans over the network.
-          # Hopefully a future re-implementation of `cache` will obviate the present need for this hack.
-          lake exe cache get Archive.lean
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive"
-          lake exe cache put Archive.lean
-        env:
-          MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
-          MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
+          cd pr-branch
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive Counterexamples"
 
-      - name: build counterexamples
-        id: counterexamples
+      # The cache secrets are available here, so we must not run any untrusted code.
+      - name: put archive and counterexamples cache
+        shell: bash
         run: |
-          lake exe cache get Counterexamples.lean
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Counterexamples"
-          lake exe cache put Counterexamples.lean
+          cd pr-branch
+          ../master-branch/.lake/build/bin/cache put Archive.lean
+          ../master-branch/.lake/build/bin/cache put Counterexamples.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
           MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
 
       - name: Check {Mathlib, Tactic, Counterexamples, Archive}.lean
+        if: always()
         run: |
-          if [ ${{ steps.mk_all.outputs.mk_all }} == "false" ]
-          then
+          if [[ "${{ steps.mk_all.outcome }}" != "success" ]]; then
             echo "Please run 'lake exe mk_all' to regenerate the import all files"
             exit 1
+          else
+            echo "'mk_all --check' passed successfully."
           fi
+
+      - name: begin gh-problem-match-wrap for test step
+        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
+        with:
+          action: add # In order to be able to run a multiline script, we need to add/remove the problem matcher before and after.
+          linters: lean
+      - name: test mathlib
+        id: test
+        run: |
+          cd pr-branch
+          lake --iofail test
+      - name: end gh-problem-match-wrap for test step
+        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
+        with:
+          action: remove
+          linters: lean
+
+      - name: begin gh-problem-match-wrap for shake and lint steps
+        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
+        with:
+          action: add # In order to be able to run a multiline script, we need to add/remove the problem matcher before and after.
+          linters: gcc
+
+      - name: check for unused imports
+        id: shake
+        run: |
+          cd pr-branch
+          env LEAN_ABORT_ON_PANIC=1 lake exe shake --gh-style
+
+      - name: lint mathlib
+        if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
+        id: lint
+        run: |
+          cd pr-branch
+          env LEAN_ABORT_ON_PANIC=1 lake exe runLinter Mathlib
+
+      - name: end gh-problem-match-wrap for shake and lint steps
+        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
+        with:
+          action: remove
+          linters: gcc
 
       - name: check for noisy stdout lines
         id: noisy
         run: |
+          cd pr-branch
           buildMsgs="$(
             ##  we exploit `lake`s replay feature: since the cache is present, running
             ##  `lake build` will reproduce all the outputs without having to recompute
@@ -195,13 +380,57 @@ jobs:
             exit 1
           fi
 
+      - name: Post comments for lean-pr-testing-NNNN and batteries-pr-testing-NNNN branches
+        if: always()
+        shell: bash
+        env:
+          TOKEN: ${{ secrets.LEAN_PR_TESTING }}
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+          WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
+          NOISY_OUTCOME: ${{ steps.noisy.outcome }}
+          ARCHIVE_OUTCOME: ${{ steps.archive.outcome }}
+          COUNTEREXAMPLES_OUTCOME: ${{ steps.counterexamples.outcome }}
+          LINT_OUTCOME: ${{ steps.lint.outcome }}
+          TEST_OUTCOME: ${{ steps.test.outcome }}
+        run: |
+          master-branch/scripts/lean-pr-testing-comments.sh lean
+          master-branch/scripts/lean-pr-testing-comments.sh batteries
+
+  post_steps:
+    name: Post-Build StepJOB_NAME
+    needs: [build]
+    runs-on: ubuntu-latest # Note these steps run on disposable GitHub runners, so no landrun sandboxing is needed.
+    steps:
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Configure Lean
+        uses: leanprover/lean-action@f807b338d95de7813c5c50d018f1c23c9b93b4ec # 2025-04-24
+        with:
+          auto-config: false # Don't run `lake build`, `lake test`, or `lake lint` automatically.
+          use-github-cache: false
+          use-mathlib-cache: true
+          reinstall-transient-toolchain: true
+
+      - name: get cache for Archive and Counterexamples
+        run: |
+          lake exe cache get Archive Counterexamples
+
+      - name: verify that everything was available in the cache
+        run: |
+          lake build --no-build Mathlib
+          lake build --no-build Archive
+          lake build --no-build Counterexamples
+
       - name: check declarations in db files
         run: |
           python3 scripts/yaml_check.py docs/100.yaml docs/1000.yaml docs/overview.yaml docs/undergrad.yaml
           lake exe check-yaml
 
       - name: generate our import graph
-        run: lake exe graph
+        run: |
+          lake exe graph
 
       - name: upload the import graph
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -220,52 +449,14 @@ jobs:
         run: |
           lake build Batteries Qq Aesop ProofWidgets Plausible
 
-      - name: test mathlib
-        id: test
-        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
-        with:
-          linters: lean
-          run:
-            lake --iofail test
-
-      - name: check for unused imports
-        id: shake
-        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
-        with:
-          linters: gcc
-          run: env LEAN_ABORT_ON_PANIC=1 lake exe shake --gh-style
-
-      - name: lint mathlib
-        if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
-        id: lint
-        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
-        with:
-          linters: gcc
-          run: env LEAN_ABORT_ON_PANIC=1 lake exe runLinter Mathlib
-
       # We no longer run `lean4checker` in regular CI, as it is quite expensive for little benefit.
       # Instead we run it in a cron job on master: see `lean4checker.yml`.
       # Output is posted to the zulip topic
       # https://leanprover.zulipchat.com/#narrow/stream/345428-mathlib-reviewers/topic/lean4checker
 
-      - name: Post comments for lean-pr-testing-NNNN and batteries-pr-testing-NNNN branches
-        if: always()
-        env:
-          TOKEN: ${{ secrets.LEAN_PR_TESTING }}
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-          WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          BUILD_OUTCOME: ${{ steps.build.outcome }}
-          NOISY_OUTCOME: ${{ steps.noisy.outcome }}
-          ARCHIVE_OUTCOME: ${{ steps.archive.outcome }}
-          COUNTEREXAMPLES_OUTCOME: ${{ steps.counterexamples.outcome }}
-          LINT_OUTCOME: ${{ steps.lint.outcome }}
-          TEST_OUTCOME: ${{ steps.test.outcome }}
-        run: |
-          scripts/lean-pr-testing-comments.sh lean
-          scripts/lean-pr-testing-comments.sh batteries
-
-      - name: build lean4checker, but only run it on itself
+      - name: checkout lean4checker
         if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
+        shell: bash
         run: |
           git clone https://github.com/leanprover/lean4checker
           cd lean4checker
@@ -277,6 +468,11 @@ jobs:
           else
             git checkout master
           fi
+
+      - name: run leanchecker on itself
+        if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
+        run: |
+          cd lean4checker
           # Build lean4checker using the same toolchain
           cp ../lean-toolchain .
           lake build
@@ -294,7 +490,7 @@ jobs:
   final:
     name: Post-CI jobJOB_NAME
     if: github.repository MAIN_OR_FORK 'leanprover-community/mathlib4'
-    needs: [style_lint, build]
+    needs: [style_lint, build, post_steps]
     runs-on: ubuntu-latest
     steps:
       - id: PR

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -35,6 +35,16 @@ jobs:
     if: github.repository == 'leanprover-community/mathlib4'
     name: Build
     runs-on: bors
+    outputs:
+      build-outcome: ${{ steps.build.outcome }}
+      archive-outcome: ${{ steps.archive.outcome }}
+      counterexamples-outcome: ${{ steps.counterexamples.outcome }}
+      get-cache-outcome: ${{ steps.get.outcome }}
+      lint-outcome: ${{ steps.lint.outcome }}
+      mk_all-outcome: ${{ steps.mk_all.outcome }}
+      noisy-outcome: ${{ steps.noisy.outcome }}
+      shake-outcome: ${{ steps.shake.outcome }}
+      test-outcome: ${{ steps.test.outcome }}
     defaults: # On Hoskinson runners, landrun is already installed.
       run:
         shell: landrun --rox /usr --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT -- bash -euxo pipefail {0}
@@ -304,11 +314,17 @@ jobs:
           ../master-branch/.lake/build/bin/cache get Archive.lean
           ../master-branch/.lake/build/bin/cache get Counterexamples.lean
 
-      - name: build archive and counterexamples
+      - name: build archive
         id: archive
         run: |
           cd pr-branch
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive Counterexamples"
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive"
+
+      - name: build counterexamples
+        id: counterexamples
+        run: |
+          cd pr-branch
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Counterexamples"
 
       # The cache secrets are available here, so we must not run any untrusted code.
       - name: put archive and counterexamples cache
@@ -465,7 +481,7 @@ jobs:
       # https://leanprover.zulipchat.com/#narrow/stream/345428-mathlib-reviewers/topic/lean4checker
 
       - name: checkout lean4checker
-        if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
+        if: ${{ (always() && needs.build.outputs.build-outcome == 'success' || needs.build.outputs.build-outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
         shell: bash
         run: |
           git clone https://github.com/leanprover/lean4checker
@@ -480,7 +496,7 @@ jobs:
           fi
 
       - name: run leanchecker on itself
-        if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
+        if: ${{ (always() && needs.build.outputs.build-outcome == 'success' || needs.build.outputs.build-outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
         run: |
           cd lean4checker
           # Build lean4checker using the same toolchain

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -35,8 +35,12 @@ jobs:
     if: github.repository == 'leanprover-community/mathlib4'
     name: Build
     runs-on: bors
+    defaults: # On Hoskinson runners, landrun is already installed.
+      run:
+        shell: landrun --rox /usr --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT -- bash -euxo pipefail {0}
     steps:
       - name: cleanup
+        shell: bash    # This *just* deletes old files, so is safe to run outside landrun.
         run: |
           find . -name . -o -prune -exec rm -rf -- {} +
           # Delete all but the 5 most recent toolchains.
@@ -52,17 +56,89 @@ jobs:
       - name: 'Setup jq'
         uses: dcarbone/install-jq-action@f0e10f46ff84f4d32178b4b76e1ef180b16f82c3 # v3.1.1
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Configure Lean
-        uses: leanprover/lean-action@f807b338d95de7813c5c50d018f1c23c9b93b4ec # 2025-04-24
+      # Checkout the master branch into a subdirectory
+      - name: Checkout master branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          auto-config: false
-          use-github-cache: false
-          use-mathlib-cache: false
-          reinstall-transient-toolchain: true
+          ref: master
+          path: master-branch
+
+      # Checkout the PR branch into a subdirectory
+      - name: Checkout PR branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: pr-branch
+
+      - name: Prepare DownstreamTest directory
+        shell: bash
+        run: |
+          echo "Copying lean-toolchain to DownstreamTest..."
+          cd pr-branch
+          # Ensure DownstreamTest/.lake/ directory exists, since landrun will need it later
+          mkdir -p DownstreamTest/.lake/
+          cd DownstreamTest
+          cp ../lean-toolchain .
+          echo "lean-toolchain copied successfully to DownstreamTest."
+
+      # Create empty directories so landrun doesn't complain
+      - name: Create empty directories
+        shell: bash # We need to run this outside landrun, as it is a prerequisite for landrun!
+        run: |
+          mkdir -p pr-branch/.lake/
+          mkdir -p .cache/mathlib/
+          mkdir -p _work
+
+      # NOTE: if you copy this, consider using `leanprover/lean-action` instead.
+      # We install manually, to avoid running lean outside landrun.
+      - name: install elan
+        shell: bash
+        run: |
+          set -o pipefail
+          curl -o elan-init.sh -sSfL https://elan.lean-lang.org/elan-init.sh
+          chmod +x elan-init.sh
+          ./elan-init.sh -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
+
+      - name: set toolchain directory
+        shell: bash
+        run: |
+          cd pr-branch
+          # Get the lake binary path from elan and extract toolchain directory
+          LAKE_PATH=$(elan which lake)
+          echo "Lake path: $LAKE_PATH"
+
+          # Extract the toolchain directory by removing /bin/lake from the end
+          TOOLCHAIN_DIR=$(dirname "$LAKE_PATH")
+          TOOLCHAIN_DIR=$(dirname "$TOOLCHAIN_DIR")
+          echo "Toolchain directory: $TOOLCHAIN_DIR"
+
+          # Set it as an environment variable for subsequent steps
+          echo "TOOLCHAIN_DIR=$TOOLCHAIN_DIR" >> "$GITHUB_ENV"
+
+      - name: set LEAN_SRC_PATH
+        shell: bash
+        run: |
+          # Construct the LEAN_SRC_PATH using the toolchain directory
+          LEAN_SRC_PATH=".:$TOOLCHAIN_DIR/src/lean/lake:.lake/packages/Cli:.lake/packages/batteries:.lake/packages/Qq:.lake/packages/aesop:.lake/packages/proofwidgets:.lake/packages/importGraph:.lake/packages/LeanSearchClient:.lake/packages/plausible"
+          echo "LEAN_SRC_PATH=$LEAN_SRC_PATH"
+
+          # Set it as an environment variable for subsequent steps
+          echo "LEAN_SRC_PATH=$LEAN_SRC_PATH" >> "$GITHUB_ENV"
+
+      - name: build master-branch tools
+        shell: bash # We're only building the `master` branch version of the tools, so don't need to run inside landrun.
+        run: |
+          cd master-branch
+          lake build cache mk_all check-yaml graph
+          ls .lake/build/bin/cache
+          ls .lake/build/bin/mk_all
+          ls .lake/build/bin/check-yaml
+          ls .lake/packages/importGraph/.lake/build/bin/graph
 
       - name: cleanup .cache/mathlib
+        # This needs write access to .cache/mathlib, so can't be run inside landrun.
+        # However it is only using the `master` version of `cache`, so is safe to run outside landrun.
+        shell: bash
         run: |
           # Define the cache directory path
           CACHE_DIR="$HOME/.cache/mathlib"
@@ -80,117 +156,226 @@ jobs:
           # Check if size exceeds 10GB
           if [ "$DIR_SIZE" -gt "10737418240" ]; then
             echo "Cache size exceeds threshold, running lake exe cache clean"
-            lake exe cache clean || echo "lake did not work"
+            # We use the master-branch version of `cache`.
+            cd master-branch
+            lake exe cache clean
           fi
 
-      - name: build cache
+      - name: download dependencies
+        # We need network access to download dependencies
+        # We run this inside landrun, but restrict disk access.
+        # Landrun argument notes:
+        # - we give --rox access to `~/.elan` and `~/actions-runner/_work` (GitHub CI needs this)
+        # - we give --unrestricted-network as we need this to download dependencies
+        # - git needs read only access to `/etc`.
+        shell: landrun --unrestricted-network --rox /etc --rox /usr --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT -- bash -euxo pipefail {0}
         run: |
-          lake build cache
+          cd pr-branch
+          lake env
 
-      - name: get cache
-        id: get
+      - name: get cache (1/3 - setup and initial fetch)
+        id: get_cache_part1_setup
+        shell: bash # only runs `cache get` from `master-branch`, so doesn't need to be inside landrun
         run: |
+          cd pr-branch
+          echo "Removing old Mathlib build directories prior to cache fetch..."
           rm -rf .lake/build/lib/lean/Mathlib
-          # useful pre v4.18: the following command is only present for compatibility reasons
-          rm -rf .lake/build/lib/Mathlib/
+
           # Fail quickly if the cache is completely cold, by checking for Mathlib.Init
-          lake exe cache get Mathlib/Init.lean
-          lake build --no-build Mathlib.Init && lake exe cache get || echo "No cache for 'Mathlib.Init' available"
+          echo "Attempting to fetch olean for Mathlib/Init.lean from cache..."
+          ../master-branch/.lake/build/bin/cache get Mathlib/Init.lean
+
+      - name: get cache (2/3 - test Mathlib.Init cache)
+        id: get_cache_part2_test
+        continue-on-error: true # Allow workflow to proceed to Part 3 to check outcome
+        # This step uses the job's default shell, which is landrun-wrapped bash
+        run: |
+          cd pr-branch
+
+          echo "Attempting: lake build --no-build Mathlib.Init (this runs under landrun)"
+          lake build --no-build Mathlib.Init
+
+      - name: get cache (3/3 - finalize cache operation)
+        id: get
+        shell: bash # only runs `cache get` from `master-branch`, so doesn't need to be inside landrun
+        run: |
+          cd pr-branch
+          if [[ "${{ steps.get_cache_part2_test.outcome }}" == "success" ]]; then
+            echo "Fetching all remaining cache..."
+
+            ../master-branch/.lake/build/bin/cache get
+          else
+            echo "WARNING: 'lake build --no-build Mathlib.Init' failed."
+            echo "No cache for 'Mathlib.Init' available or it could not be prepared."
+          fi
 
       - name: update {Mathlib, Tactic, Counterexamples, Archive}.lean
         id: mk_all
+        continue-on-error: true # Allow workflow to continue, outcome checked later
+        # This only runs `mk_all --check` from the `master-branch`, so doesn't need to be inside landrun
+        shell: bash
         run: |
+          cd pr-branch
 
-          if ! lake exe mk_all --check
-          then
-            echo "Not all lean files are in the import all files"
-            echo "mk_all=false" >> "${GITHUB_OUTPUT}"
-          else
-            echo "mk_all=true" >> "${GITHUB_OUTPUT}"
-          fi
+          echo "Running mk_all --check (from master-branch)..."
+          LAKE_HOME="$TOOLCHAIN_DIR" ../master-branch/.lake/build/bin/mk_all --check
 
-      - name: build mathlib
-        id: build
+      - name: begin gh-problem-match-wrap for build step
         uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
         with:
+          action: add # In order to be able to run a multiline script, we need to add/remove the problem matcher before and after.
           linters: lean
-          run: |
-            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
+      - name: build mathlib
+        id: build
+        run: |
+          cd pr-branch
+          # Test curl - should fail when landrun network isolation is working
+          if curl --silent --head --fail https://www.example.com/ >/dev/null 2>&1; then
+            echo "ERROR: curl to example.com succeeded, but it should fail when landrun is working correctly!"
+            exit 1
+          else
+            echo "curl to example.com failed as expected - landrun network isolation is working"
+          fi
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
+      - name: end gh-problem-match-wrap for build step
+        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
+        with:
+          action: remove
+          linters: lean
 
       - name: print the sizes of the oleans
         run: |
-          du .lake/build/lib/lean/Mathlib ||
-            # This path was the correct path before v4.18: it is here just for compatibility reasons
-            du .lake/build/lib/Mathlib || echo "This code should be unreachable"
+          cd pr-branch
+          du .lake/build/lib/lean/Mathlib || echo "This code should be unreachable"
 
+      # The cache secrets are available here, so we must not run any untrusted code.
       - name: upload cache
         # We only upload the cache if the build started (whether succeeding, failing, or cancelled)
         # but not if any earlier step failed or was cancelled.
         # See discussion at https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Some.20files.20not.20found.20in.20the.20cache/near/407183836
         if: ${{ always() && steps.get.outcome == 'success' }}
+        shell: bash
         run: |
+          cd pr-branch
+
+          # Use the trusted cache tool from master-branch
           # TODO: this is not doing anything currently, and needs to be integrated with put-unpacked
-          # lake exe cache commit || true
+          # ../master-branch/.lake/build/bin/cache commit || true
           # run this in CI if it gets an incorrect lake hash for existing cache files somehow
-          # lake exe cache put!
+          # ../master-branch/.lake/build/bin/cache put!
           # do not try to upload files just downloaded
-          lake exe cache put-unpacked
+          ../master-branch/.lake/build/bin/cache put-unpacked
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
           MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
 
       - name: check the cache
+        # We need network access to download dependencies
+        # We run this inside landrun, but restrict disk access as usual.
+        shell: landrun --unrestricted-network --rox /usr --rw /dev --rox /etc --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib -rw pr-branch/.lake/ --rw pr-branch/DownstreamTest/ --env PATH --env HOME --env GITHUB_OUTPUT -- bash -euxo pipefail {0}
         run: |
+          cd pr-branch
+
           # Because the `lean-pr-testing-NNNN` branches use toolchains that are "updated in place"
           # the cache mechanism is unreliable, so we don't test it if we are on such a branch.
           if [[ ! $(cat lean-toolchain) =~ ^leanprover/lean4-pr-releases:pr-release-[0-9]+$ ]]; then
             cd DownstreamTest
-            cp ../lean-toolchain .
             MATHLIB_NO_CACHE_ON_UPDATE=1 lake update
-            lake exe cache get || (sleep 1; lake exe cache get)
+
+            lake env ../../master-branch/.lake/build/bin/cache get || (sleep 1; lake env ../../master-branch/.lake/build/bin/cache get)
+
             # We need to run `lake build ProofWidgets` here to retrieve ProofWidgets via Reservoir.
             lake build ProofWidgets
             lake build --no-build Mathlib
           fi
 
-      - name: build archive
+      # Note: we should not be including `Archive` and `Counterexamples` in the cache.
+      # We do this for now for the sake of not rebuilding them in every CI run
+      # even when they are not touched.
+      # Since `Archive` and `Counterexamples` files have very simple dependencies,
+      # it should be possible to determine whether they need to be built without actually
+      # storing and transferring oleans over the network.
+      # Hopefully a future re-implementation of `cache` will obviate the present need for this hack.
+
+      - name: fetch archive and counterexamples cache
+        shell: bash
+        run: |
+          cd pr-branch
+          ../master-branch/.lake/build/bin/cache get Archive.lean
+          ../master-branch/.lake/build/bin/cache get Counterexamples.lean
+
+      - name: build archive and counterexamples
         id: archive
         run: |
-          # Note: we should not be including `Archive` and `Counterexamples` in the cache.
-          # We do this for now for the sake of not rebuilding them in every CI run
-          # even when they are not touched.
-          # Since `Archive` and `Counterexamples` files have very simple dependencies,
-          # it should be possible to determine whether they need to be built without actually
-          # storing and transferring oleans over the network.
-          # Hopefully a future re-implementation of `cache` will obviate the present need for this hack.
-          lake exe cache get Archive.lean
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive"
-          lake exe cache put Archive.lean
-        env:
-          MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
-          MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
+          cd pr-branch
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive Counterexamples"
 
-      - name: build counterexamples
-        id: counterexamples
+      # The cache secrets are available here, so we must not run any untrusted code.
+      - name: put archive and counterexamples cache
+        shell: bash
         run: |
-          lake exe cache get Counterexamples.lean
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Counterexamples"
-          lake exe cache put Counterexamples.lean
+          cd pr-branch
+          ../master-branch/.lake/build/bin/cache put Archive.lean
+          ../master-branch/.lake/build/bin/cache put Counterexamples.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
           MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
 
       - name: Check {Mathlib, Tactic, Counterexamples, Archive}.lean
+        if: always()
         run: |
-          if [ ${{ steps.mk_all.outputs.mk_all }} == "false" ]
-          then
+          if [[ "${{ steps.mk_all.outcome }}" != "success" ]]; then
             echo "Please run 'lake exe mk_all' to regenerate the import all files"
             exit 1
+          else
+            echo "'mk_all --check' passed successfully."
           fi
+
+      - name: begin gh-problem-match-wrap for test step
+        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
+        with:
+          action: add # In order to be able to run a multiline script, we need to add/remove the problem matcher before and after.
+          linters: lean
+      - name: test mathlib
+        id: test
+        run: |
+          cd pr-branch
+          lake --iofail test
+      - name: end gh-problem-match-wrap for test step
+        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
+        with:
+          action: remove
+          linters: lean
+
+      - name: begin gh-problem-match-wrap for shake and lint steps
+        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
+        with:
+          action: add # In order to be able to run a multiline script, we need to add/remove the problem matcher before and after.
+          linters: gcc
+
+      - name: check for unused imports
+        id: shake
+        run: |
+          cd pr-branch
+          env LEAN_ABORT_ON_PANIC=1 lake exe shake --gh-style
+
+      - name: lint mathlib
+        if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
+        id: lint
+        run: |
+          cd pr-branch
+          env LEAN_ABORT_ON_PANIC=1 lake exe runLinter Mathlib
+
+      - name: end gh-problem-match-wrap for shake and lint steps
+        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
+        with:
+          action: remove
+          linters: gcc
 
       - name: check for noisy stdout lines
         id: noisy
         run: |
+          cd pr-branch
           buildMsgs="$(
             ##  we exploit `lake`s replay feature: since the cache is present, running
             ##  `lake build` will reproduce all the outputs without having to recompute
@@ -205,13 +390,57 @@ jobs:
             exit 1
           fi
 
+      - name: Post comments for lean-pr-testing-NNNN and batteries-pr-testing-NNNN branches
+        if: always()
+        shell: bash
+        env:
+          TOKEN: ${{ secrets.LEAN_PR_TESTING }}
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+          WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
+          NOISY_OUTCOME: ${{ steps.noisy.outcome }}
+          ARCHIVE_OUTCOME: ${{ steps.archive.outcome }}
+          COUNTEREXAMPLES_OUTCOME: ${{ steps.counterexamples.outcome }}
+          LINT_OUTCOME: ${{ steps.lint.outcome }}
+          TEST_OUTCOME: ${{ steps.test.outcome }}
+        run: |
+          master-branch/scripts/lean-pr-testing-comments.sh lean
+          master-branch/scripts/lean-pr-testing-comments.sh batteries
+
+  post_steps:
+    name: Post-Build Step
+    needs: [build]
+    runs-on: ubuntu-latest # Note these steps run on disposable GitHub runners, so no landrun sandboxing is needed.
+    steps:
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Configure Lean
+        uses: leanprover/lean-action@f807b338d95de7813c5c50d018f1c23c9b93b4ec # 2025-04-24
+        with:
+          auto-config: false # Don't run `lake build`, `lake test`, or `lake lint` automatically.
+          use-github-cache: false
+          use-mathlib-cache: true
+          reinstall-transient-toolchain: true
+
+      - name: get cache for Archive and Counterexamples
+        run: |
+          lake exe cache get Archive Counterexamples
+
+      - name: verify that everything was available in the cache
+        run: |
+          lake build --no-build Mathlib
+          lake build --no-build Archive
+          lake build --no-build Counterexamples
+
       - name: check declarations in db files
         run: |
           python3 scripts/yaml_check.py docs/100.yaml docs/1000.yaml docs/overview.yaml docs/undergrad.yaml
           lake exe check-yaml
 
       - name: generate our import graph
-        run: lake exe graph
+        run: |
+          lake exe graph
 
       - name: upload the import graph
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -230,52 +459,14 @@ jobs:
         run: |
           lake build Batteries Qq Aesop ProofWidgets Plausible
 
-      - name: test mathlib
-        id: test
-        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
-        with:
-          linters: lean
-          run:
-            lake --iofail test
-
-      - name: check for unused imports
-        id: shake
-        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
-        with:
-          linters: gcc
-          run: env LEAN_ABORT_ON_PANIC=1 lake exe shake --gh-style
-
-      - name: lint mathlib
-        if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
-        id: lint
-        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
-        with:
-          linters: gcc
-          run: env LEAN_ABORT_ON_PANIC=1 lake exe runLinter Mathlib
-
       # We no longer run `lean4checker` in regular CI, as it is quite expensive for little benefit.
       # Instead we run it in a cron job on master: see `lean4checker.yml`.
       # Output is posted to the zulip topic
       # https://leanprover.zulipchat.com/#narrow/stream/345428-mathlib-reviewers/topic/lean4checker
 
-      - name: Post comments for lean-pr-testing-NNNN and batteries-pr-testing-NNNN branches
-        if: always()
-        env:
-          TOKEN: ${{ secrets.LEAN_PR_TESTING }}
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-          WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          BUILD_OUTCOME: ${{ steps.build.outcome }}
-          NOISY_OUTCOME: ${{ steps.noisy.outcome }}
-          ARCHIVE_OUTCOME: ${{ steps.archive.outcome }}
-          COUNTEREXAMPLES_OUTCOME: ${{ steps.counterexamples.outcome }}
-          LINT_OUTCOME: ${{ steps.lint.outcome }}
-          TEST_OUTCOME: ${{ steps.test.outcome }}
-        run: |
-          scripts/lean-pr-testing-comments.sh lean
-          scripts/lean-pr-testing-comments.sh batteries
-
-      - name: build lean4checker, but only run it on itself
+      - name: checkout lean4checker
         if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
+        shell: bash
         run: |
           git clone https://github.com/leanprover/lean4checker
           cd lean4checker
@@ -287,6 +478,11 @@ jobs:
           else
             git checkout master
           fi
+
+      - name: run leanchecker on itself
+        if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
+        run: |
+          cd lean4checker
           # Build lean4checker using the same toolchain
           cp ../lean-toolchain .
           lake build
@@ -304,7 +500,7 @@ jobs:
   final:
     name: Post-CI job
     if: github.repository == 'leanprover-community/mathlib4'
-    needs: [style_lint, build]
+    needs: [style_lint, build, post_steps]
     runs-on: ubuntu-latest
     steps:
       - id: PR

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,16 @@ jobs:
     if: github.repository == 'leanprover-community/mathlib4'
     name: Build
     runs-on: pr
+    outputs:
+      build-outcome: ${{ steps.build.outcome }}
+      archive-outcome: ${{ steps.archive.outcome }}
+      counterexamples-outcome: ${{ steps.counterexamples.outcome }}
+      get-cache-outcome: ${{ steps.get.outcome }}
+      lint-outcome: ${{ steps.lint.outcome }}
+      mk_all-outcome: ${{ steps.mk_all.outcome }}
+      noisy-outcome: ${{ steps.noisy.outcome }}
+      shake-outcome: ${{ steps.shake.outcome }}
+      test-outcome: ${{ steps.test.outcome }}
     defaults: # On Hoskinson runners, landrun is already installed.
       run:
         shell: landrun --rox /usr --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT -- bash -euxo pipefail {0}
@@ -311,11 +321,17 @@ jobs:
           ../master-branch/.lake/build/bin/cache get Archive.lean
           ../master-branch/.lake/build/bin/cache get Counterexamples.lean
 
-      - name: build archive and counterexamples
+      - name: build archive
         id: archive
         run: |
           cd pr-branch
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive Counterexamples"
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive"
+
+      - name: build counterexamples
+        id: counterexamples
+        run: |
+          cd pr-branch
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Counterexamples"
 
       # The cache secrets are available here, so we must not run any untrusted code.
       - name: put archive and counterexamples cache
@@ -472,7 +488,7 @@ jobs:
       # https://leanprover.zulipchat.com/#narrow/stream/345428-mathlib-reviewers/topic/lean4checker
 
       - name: checkout lean4checker
-        if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
+        if: ${{ (always() && needs.build.outputs.build-outcome == 'success' || needs.build.outputs.build-outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
         shell: bash
         run: |
           git clone https://github.com/leanprover/lean4checker
@@ -487,7 +503,7 @@ jobs:
           fi
 
       - name: run leanchecker on itself
-        if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
+        if: ${{ (always() && needs.build.outputs.build-outcome == 'success' || needs.build.outputs.build-outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
         run: |
           cd lean4checker
           # Build lean4checker using the same toolchain

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,8 +42,12 @@ jobs:
     if: github.repository == 'leanprover-community/mathlib4'
     name: Build
     runs-on: pr
+    defaults: # On Hoskinson runners, landrun is already installed.
+      run:
+        shell: landrun --rox /usr --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT -- bash -euxo pipefail {0}
     steps:
       - name: cleanup
+        shell: bash    # This *just* deletes old files, so is safe to run outside landrun.
         run: |
           find . -name . -o -prune -exec rm -rf -- {} +
           # Delete all but the 5 most recent toolchains.
@@ -59,17 +63,89 @@ jobs:
       - name: 'Setup jq'
         uses: dcarbone/install-jq-action@f0e10f46ff84f4d32178b4b76e1ef180b16f82c3 # v3.1.1
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Configure Lean
-        uses: leanprover/lean-action@f807b338d95de7813c5c50d018f1c23c9b93b4ec # 2025-04-24
+      # Checkout the master branch into a subdirectory
+      - name: Checkout master branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          auto-config: false
-          use-github-cache: false
-          use-mathlib-cache: false
-          reinstall-transient-toolchain: true
+          ref: master
+          path: master-branch
+
+      # Checkout the PR branch into a subdirectory
+      - name: Checkout PR branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: pr-branch
+
+      - name: Prepare DownstreamTest directory
+        shell: bash
+        run: |
+          echo "Copying lean-toolchain to DownstreamTest..."
+          cd pr-branch
+          # Ensure DownstreamTest/.lake/ directory exists, since landrun will need it later
+          mkdir -p DownstreamTest/.lake/
+          cd DownstreamTest
+          cp ../lean-toolchain .
+          echo "lean-toolchain copied successfully to DownstreamTest."
+
+      # Create empty directories so landrun doesn't complain
+      - name: Create empty directories
+        shell: bash # We need to run this outside landrun, as it is a prerequisite for landrun!
+        run: |
+          mkdir -p pr-branch/.lake/
+          mkdir -p .cache/mathlib/
+          mkdir -p _work
+
+      # NOTE: if you copy this, consider using `leanprover/lean-action` instead.
+      # We install manually, to avoid running lean outside landrun.
+      - name: install elan
+        shell: bash
+        run: |
+          set -o pipefail
+          curl -o elan-init.sh -sSfL https://elan.lean-lang.org/elan-init.sh
+          chmod +x elan-init.sh
+          ./elan-init.sh -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
+
+      - name: set toolchain directory
+        shell: bash
+        run: |
+          cd pr-branch
+          # Get the lake binary path from elan and extract toolchain directory
+          LAKE_PATH=$(elan which lake)
+          echo "Lake path: $LAKE_PATH"
+
+          # Extract the toolchain directory by removing /bin/lake from the end
+          TOOLCHAIN_DIR=$(dirname "$LAKE_PATH")
+          TOOLCHAIN_DIR=$(dirname "$TOOLCHAIN_DIR")
+          echo "Toolchain directory: $TOOLCHAIN_DIR"
+
+          # Set it as an environment variable for subsequent steps
+          echo "TOOLCHAIN_DIR=$TOOLCHAIN_DIR" >> "$GITHUB_ENV"
+
+      - name: set LEAN_SRC_PATH
+        shell: bash
+        run: |
+          # Construct the LEAN_SRC_PATH using the toolchain directory
+          LEAN_SRC_PATH=".:$TOOLCHAIN_DIR/src/lean/lake:.lake/packages/Cli:.lake/packages/batteries:.lake/packages/Qq:.lake/packages/aesop:.lake/packages/proofwidgets:.lake/packages/importGraph:.lake/packages/LeanSearchClient:.lake/packages/plausible"
+          echo "LEAN_SRC_PATH=$LEAN_SRC_PATH"
+
+          # Set it as an environment variable for subsequent steps
+          echo "LEAN_SRC_PATH=$LEAN_SRC_PATH" >> "$GITHUB_ENV"
+
+      - name: build master-branch tools
+        shell: bash # We're only building the `master` branch version of the tools, so don't need to run inside landrun.
+        run: |
+          cd master-branch
+          lake build cache mk_all check-yaml graph
+          ls .lake/build/bin/cache
+          ls .lake/build/bin/mk_all
+          ls .lake/build/bin/check-yaml
+          ls .lake/packages/importGraph/.lake/build/bin/graph
 
       - name: cleanup .cache/mathlib
+        # This needs write access to .cache/mathlib, so can't be run inside landrun.
+        # However it is only using the `master` version of `cache`, so is safe to run outside landrun.
+        shell: bash
         run: |
           # Define the cache directory path
           CACHE_DIR="$HOME/.cache/mathlib"
@@ -87,117 +163,226 @@ jobs:
           # Check if size exceeds 10GB
           if [ "$DIR_SIZE" -gt "10737418240" ]; then
             echo "Cache size exceeds threshold, running lake exe cache clean"
-            lake exe cache clean || echo "lake did not work"
+            # We use the master-branch version of `cache`.
+            cd master-branch
+            lake exe cache clean
           fi
 
-      - name: build cache
+      - name: download dependencies
+        # We need network access to download dependencies
+        # We run this inside landrun, but restrict disk access.
+        # Landrun argument notes:
+        # - we give --rox access to `~/.elan` and `~/actions-runner/_work` (GitHub CI needs this)
+        # - we give --unrestricted-network as we need this to download dependencies
+        # - git needs read only access to `/etc`.
+        shell: landrun --unrestricted-network --rox /etc --rox /usr --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT -- bash -euxo pipefail {0}
         run: |
-          lake build cache
+          cd pr-branch
+          lake env
 
-      - name: get cache
-        id: get
+      - name: get cache (1/3 - setup and initial fetch)
+        id: get_cache_part1_setup
+        shell: bash # only runs `cache get` from `master-branch`, so doesn't need to be inside landrun
         run: |
+          cd pr-branch
+          echo "Removing old Mathlib build directories prior to cache fetch..."
           rm -rf .lake/build/lib/lean/Mathlib
-          # useful pre v4.18: the following command is only present for compatibility reasons
-          rm -rf .lake/build/lib/Mathlib/
+
           # Fail quickly if the cache is completely cold, by checking for Mathlib.Init
-          lake exe cache get Mathlib/Init.lean
-          lake build --no-build Mathlib.Init && lake exe cache get || echo "No cache for 'Mathlib.Init' available"
+          echo "Attempting to fetch olean for Mathlib/Init.lean from cache..."
+          ../master-branch/.lake/build/bin/cache get Mathlib/Init.lean
+
+      - name: get cache (2/3 - test Mathlib.Init cache)
+        id: get_cache_part2_test
+        continue-on-error: true # Allow workflow to proceed to Part 3 to check outcome
+        # This step uses the job's default shell, which is landrun-wrapped bash
+        run: |
+          cd pr-branch
+
+          echo "Attempting: lake build --no-build Mathlib.Init (this runs under landrun)"
+          lake build --no-build Mathlib.Init
+
+      - name: get cache (3/3 - finalize cache operation)
+        id: get
+        shell: bash # only runs `cache get` from `master-branch`, so doesn't need to be inside landrun
+        run: |
+          cd pr-branch
+          if [[ "${{ steps.get_cache_part2_test.outcome }}" == "success" ]]; then
+            echo "Fetching all remaining cache..."
+
+            ../master-branch/.lake/build/bin/cache get
+          else
+            echo "WARNING: 'lake build --no-build Mathlib.Init' failed."
+            echo "No cache for 'Mathlib.Init' available or it could not be prepared."
+          fi
 
       - name: update {Mathlib, Tactic, Counterexamples, Archive}.lean
         id: mk_all
+        continue-on-error: true # Allow workflow to continue, outcome checked later
+        # This only runs `mk_all --check` from the `master-branch`, so doesn't need to be inside landrun
+        shell: bash
         run: |
+          cd pr-branch
 
-          if ! lake exe mk_all --check
-          then
-            echo "Not all lean files are in the import all files"
-            echo "mk_all=false" >> "${GITHUB_OUTPUT}"
-          else
-            echo "mk_all=true" >> "${GITHUB_OUTPUT}"
-          fi
+          echo "Running mk_all --check (from master-branch)..."
+          LAKE_HOME="$TOOLCHAIN_DIR" ../master-branch/.lake/build/bin/mk_all --check
 
-      - name: build mathlib
-        id: build
+      - name: begin gh-problem-match-wrap for build step
         uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
         with:
+          action: add # In order to be able to run a multiline script, we need to add/remove the problem matcher before and after.
           linters: lean
-          run: |
-            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
+      - name: build mathlib
+        id: build
+        run: |
+          cd pr-branch
+          # Test curl - should fail when landrun network isolation is working
+          if curl --silent --head --fail https://www.example.com/ >/dev/null 2>&1; then
+            echo "ERROR: curl to example.com succeeded, but it should fail when landrun is working correctly!"
+            exit 1
+          else
+            echo "curl to example.com failed as expected - landrun network isolation is working"
+          fi
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
+      - name: end gh-problem-match-wrap for build step
+        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
+        with:
+          action: remove
+          linters: lean
 
       - name: print the sizes of the oleans
         run: |
-          du .lake/build/lib/lean/Mathlib ||
-            # This path was the correct path before v4.18: it is here just for compatibility reasons
-            du .lake/build/lib/Mathlib || echo "This code should be unreachable"
+          cd pr-branch
+          du .lake/build/lib/lean/Mathlib || echo "This code should be unreachable"
 
+      # The cache secrets are available here, so we must not run any untrusted code.
       - name: upload cache
         # We only upload the cache if the build started (whether succeeding, failing, or cancelled)
         # but not if any earlier step failed or was cancelled.
         # See discussion at https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Some.20files.20not.20found.20in.20the.20cache/near/407183836
         if: ${{ always() && steps.get.outcome == 'success' }}
+        shell: bash
         run: |
+          cd pr-branch
+
+          # Use the trusted cache tool from master-branch
           # TODO: this is not doing anything currently, and needs to be integrated with put-unpacked
-          # lake exe cache commit || true
+          # ../master-branch/.lake/build/bin/cache commit || true
           # run this in CI if it gets an incorrect lake hash for existing cache files somehow
-          # lake exe cache put!
+          # ../master-branch/.lake/build/bin/cache put!
           # do not try to upload files just downloaded
-          lake exe cache put-unpacked
+          ../master-branch/.lake/build/bin/cache put-unpacked
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
           MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
 
       - name: check the cache
+        # We need network access to download dependencies
+        # We run this inside landrun, but restrict disk access as usual.
+        shell: landrun --unrestricted-network --rox /usr --rw /dev --rox /etc --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib -rw pr-branch/.lake/ --rw pr-branch/DownstreamTest/ --env PATH --env HOME --env GITHUB_OUTPUT -- bash -euxo pipefail {0}
         run: |
+          cd pr-branch
+
           # Because the `lean-pr-testing-NNNN` branches use toolchains that are "updated in place"
           # the cache mechanism is unreliable, so we don't test it if we are on such a branch.
           if [[ ! $(cat lean-toolchain) =~ ^leanprover/lean4-pr-releases:pr-release-[0-9]+$ ]]; then
             cd DownstreamTest
-            cp ../lean-toolchain .
             MATHLIB_NO_CACHE_ON_UPDATE=1 lake update
-            lake exe cache get || (sleep 1; lake exe cache get)
+
+            lake env ../../master-branch/.lake/build/bin/cache get || (sleep 1; lake env ../../master-branch/.lake/build/bin/cache get)
+
             # We need to run `lake build ProofWidgets` here to retrieve ProofWidgets via Reservoir.
             lake build ProofWidgets
             lake build --no-build Mathlib
           fi
 
-      - name: build archive
+      # Note: we should not be including `Archive` and `Counterexamples` in the cache.
+      # We do this for now for the sake of not rebuilding them in every CI run
+      # even when they are not touched.
+      # Since `Archive` and `Counterexamples` files have very simple dependencies,
+      # it should be possible to determine whether they need to be built without actually
+      # storing and transferring oleans over the network.
+      # Hopefully a future re-implementation of `cache` will obviate the present need for this hack.
+
+      - name: fetch archive and counterexamples cache
+        shell: bash
+        run: |
+          cd pr-branch
+          ../master-branch/.lake/build/bin/cache get Archive.lean
+          ../master-branch/.lake/build/bin/cache get Counterexamples.lean
+
+      - name: build archive and counterexamples
         id: archive
         run: |
-          # Note: we should not be including `Archive` and `Counterexamples` in the cache.
-          # We do this for now for the sake of not rebuilding them in every CI run
-          # even when they are not touched.
-          # Since `Archive` and `Counterexamples` files have very simple dependencies,
-          # it should be possible to determine whether they need to be built without actually
-          # storing and transferring oleans over the network.
-          # Hopefully a future re-implementation of `cache` will obviate the present need for this hack.
-          lake exe cache get Archive.lean
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive"
-          lake exe cache put Archive.lean
-        env:
-          MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
-          MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
+          cd pr-branch
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive Counterexamples"
 
-      - name: build counterexamples
-        id: counterexamples
+      # The cache secrets are available here, so we must not run any untrusted code.
+      - name: put archive and counterexamples cache
+        shell: bash
         run: |
-          lake exe cache get Counterexamples.lean
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Counterexamples"
-          lake exe cache put Counterexamples.lean
+          cd pr-branch
+          ../master-branch/.lake/build/bin/cache put Archive.lean
+          ../master-branch/.lake/build/bin/cache put Counterexamples.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
           MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
 
       - name: Check {Mathlib, Tactic, Counterexamples, Archive}.lean
+        if: always()
         run: |
-          if [ ${{ steps.mk_all.outputs.mk_all }} == "false" ]
-          then
+          if [[ "${{ steps.mk_all.outcome }}" != "success" ]]; then
             echo "Please run 'lake exe mk_all' to regenerate the import all files"
             exit 1
+          else
+            echo "'mk_all --check' passed successfully."
           fi
+
+      - name: begin gh-problem-match-wrap for test step
+        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
+        with:
+          action: add # In order to be able to run a multiline script, we need to add/remove the problem matcher before and after.
+          linters: lean
+      - name: test mathlib
+        id: test
+        run: |
+          cd pr-branch
+          lake --iofail test
+      - name: end gh-problem-match-wrap for test step
+        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
+        with:
+          action: remove
+          linters: lean
+
+      - name: begin gh-problem-match-wrap for shake and lint steps
+        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
+        with:
+          action: add # In order to be able to run a multiline script, we need to add/remove the problem matcher before and after.
+          linters: gcc
+
+      - name: check for unused imports
+        id: shake
+        run: |
+          cd pr-branch
+          env LEAN_ABORT_ON_PANIC=1 lake exe shake --gh-style
+
+      - name: lint mathlib
+        if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
+        id: lint
+        run: |
+          cd pr-branch
+          env LEAN_ABORT_ON_PANIC=1 lake exe runLinter Mathlib
+
+      - name: end gh-problem-match-wrap for shake and lint steps
+        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
+        with:
+          action: remove
+          linters: gcc
 
       - name: check for noisy stdout lines
         id: noisy
         run: |
+          cd pr-branch
           buildMsgs="$(
             ##  we exploit `lake`s replay feature: since the cache is present, running
             ##  `lake build` will reproduce all the outputs without having to recompute
@@ -212,13 +397,57 @@ jobs:
             exit 1
           fi
 
+      - name: Post comments for lean-pr-testing-NNNN and batteries-pr-testing-NNNN branches
+        if: always()
+        shell: bash
+        env:
+          TOKEN: ${{ secrets.LEAN_PR_TESTING }}
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+          WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
+          NOISY_OUTCOME: ${{ steps.noisy.outcome }}
+          ARCHIVE_OUTCOME: ${{ steps.archive.outcome }}
+          COUNTEREXAMPLES_OUTCOME: ${{ steps.counterexamples.outcome }}
+          LINT_OUTCOME: ${{ steps.lint.outcome }}
+          TEST_OUTCOME: ${{ steps.test.outcome }}
+        run: |
+          master-branch/scripts/lean-pr-testing-comments.sh lean
+          master-branch/scripts/lean-pr-testing-comments.sh batteries
+
+  post_steps:
+    name: Post-Build Step
+    needs: [build]
+    runs-on: ubuntu-latest # Note these steps run on disposable GitHub runners, so no landrun sandboxing is needed.
+    steps:
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Configure Lean
+        uses: leanprover/lean-action@f807b338d95de7813c5c50d018f1c23c9b93b4ec # 2025-04-24
+        with:
+          auto-config: false # Don't run `lake build`, `lake test`, or `lake lint` automatically.
+          use-github-cache: false
+          use-mathlib-cache: true
+          reinstall-transient-toolchain: true
+
+      - name: get cache for Archive and Counterexamples
+        run: |
+          lake exe cache get Archive Counterexamples
+
+      - name: verify that everything was available in the cache
+        run: |
+          lake build --no-build Mathlib
+          lake build --no-build Archive
+          lake build --no-build Counterexamples
+
       - name: check declarations in db files
         run: |
           python3 scripts/yaml_check.py docs/100.yaml docs/1000.yaml docs/overview.yaml docs/undergrad.yaml
           lake exe check-yaml
 
       - name: generate our import graph
-        run: lake exe graph
+        run: |
+          lake exe graph
 
       - name: upload the import graph
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -237,52 +466,14 @@ jobs:
         run: |
           lake build Batteries Qq Aesop ProofWidgets Plausible
 
-      - name: test mathlib
-        id: test
-        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
-        with:
-          linters: lean
-          run:
-            lake --iofail test
-
-      - name: check for unused imports
-        id: shake
-        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
-        with:
-          linters: gcc
-          run: env LEAN_ABORT_ON_PANIC=1 lake exe shake --gh-style
-
-      - name: lint mathlib
-        if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
-        id: lint
-        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
-        with:
-          linters: gcc
-          run: env LEAN_ABORT_ON_PANIC=1 lake exe runLinter Mathlib
-
       # We no longer run `lean4checker` in regular CI, as it is quite expensive for little benefit.
       # Instead we run it in a cron job on master: see `lean4checker.yml`.
       # Output is posted to the zulip topic
       # https://leanprover.zulipchat.com/#narrow/stream/345428-mathlib-reviewers/topic/lean4checker
 
-      - name: Post comments for lean-pr-testing-NNNN and batteries-pr-testing-NNNN branches
-        if: always()
-        env:
-          TOKEN: ${{ secrets.LEAN_PR_TESTING }}
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-          WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          BUILD_OUTCOME: ${{ steps.build.outcome }}
-          NOISY_OUTCOME: ${{ steps.noisy.outcome }}
-          ARCHIVE_OUTCOME: ${{ steps.archive.outcome }}
-          COUNTEREXAMPLES_OUTCOME: ${{ steps.counterexamples.outcome }}
-          LINT_OUTCOME: ${{ steps.lint.outcome }}
-          TEST_OUTCOME: ${{ steps.test.outcome }}
-        run: |
-          scripts/lean-pr-testing-comments.sh lean
-          scripts/lean-pr-testing-comments.sh batteries
-
-      - name: build lean4checker, but only run it on itself
+      - name: checkout lean4checker
         if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
+        shell: bash
         run: |
           git clone https://github.com/leanprover/lean4checker
           cd lean4checker
@@ -294,6 +485,11 @@ jobs:
           else
             git checkout master
           fi
+
+      - name: run leanchecker on itself
+        if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
+        run: |
+          cd lean4checker
           # Build lean4checker using the same toolchain
           cp ../lean-toolchain .
           lake build
@@ -311,7 +507,7 @@ jobs:
   final:
     name: Post-CI job
     if: github.repository == 'leanprover-community/mathlib4'
-    needs: [style_lint, build]
+    needs: [style_lint, build, post_steps]
     runs-on: ubuntu-latest
     steps:
       - id: PR

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -39,6 +39,16 @@ jobs:
     if: github.repository != 'leanprover-community/mathlib4'
     name: Build (fork)
     runs-on: ubuntu-latest
+    outputs:
+      build-outcome: ${{ steps.build.outcome }}
+      archive-outcome: ${{ steps.archive.outcome }}
+      counterexamples-outcome: ${{ steps.counterexamples.outcome }}
+      get-cache-outcome: ${{ steps.get.outcome }}
+      lint-outcome: ${{ steps.lint.outcome }}
+      mk_all-outcome: ${{ steps.mk_all.outcome }}
+      noisy-outcome: ${{ steps.noisy.outcome }}
+      shake-outcome: ${{ steps.shake.outcome }}
+      test-outcome: ${{ steps.test.outcome }}
     defaults: # On Hoskinson runners, landrun is already installed.
       run:
         shell: landrun --rox /usr --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT -- bash -euxo pipefail {0}
@@ -308,11 +318,17 @@ jobs:
           ../master-branch/.lake/build/bin/cache get Archive.lean
           ../master-branch/.lake/build/bin/cache get Counterexamples.lean
 
-      - name: build archive and counterexamples
+      - name: build archive
         id: archive
         run: |
           cd pr-branch
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive Counterexamples"
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive"
+
+      - name: build counterexamples
+        id: counterexamples
+        run: |
+          cd pr-branch
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Counterexamples"
 
       # The cache secrets are available here, so we must not run any untrusted code.
       - name: put archive and counterexamples cache
@@ -469,7 +485,7 @@ jobs:
       # https://leanprover.zulipchat.com/#narrow/stream/345428-mathlib-reviewers/topic/lean4checker
 
       - name: checkout lean4checker
-        if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
+        if: ${{ (always() && needs.build.outputs.build-outcome == 'success' || needs.build.outputs.build-outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
         shell: bash
         run: |
           git clone https://github.com/leanprover/lean4checker
@@ -484,7 +500,7 @@ jobs:
           fi
 
       - name: run leanchecker on itself
-        if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
+        if: ${{ (always() && needs.build.outputs.build-outcome == 'success' || needs.build.outputs.build-outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
         run: |
           cd lean4checker
           # Build lean4checker using the same toolchain

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -39,8 +39,12 @@ jobs:
     if: github.repository != 'leanprover-community/mathlib4'
     name: Build (fork)
     runs-on: ubuntu-latest
+    defaults: # On Hoskinson runners, landrun is already installed.
+      run:
+        shell: landrun --rox /usr --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT -- bash -euxo pipefail {0}
     steps:
       - name: cleanup
+        shell: bash    # This *just* deletes old files, so is safe to run outside landrun.
         run: |
           find . -name . -o -prune -exec rm -rf -- {} +
           # Delete all but the 5 most recent toolchains.
@@ -56,17 +60,89 @@ jobs:
       - name: 'Setup jq'
         uses: dcarbone/install-jq-action@f0e10f46ff84f4d32178b4b76e1ef180b16f82c3 # v3.1.1
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Configure Lean
-        uses: leanprover/lean-action@f807b338d95de7813c5c50d018f1c23c9b93b4ec # 2025-04-24
+      # Checkout the master branch into a subdirectory
+      - name: Checkout master branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          auto-config: false
-          use-github-cache: false
-          use-mathlib-cache: false
-          reinstall-transient-toolchain: true
+          ref: master
+          path: master-branch
+
+      # Checkout the PR branch into a subdirectory
+      - name: Checkout PR branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: pr-branch
+
+      - name: Prepare DownstreamTest directory
+        shell: bash
+        run: |
+          echo "Copying lean-toolchain to DownstreamTest..."
+          cd pr-branch
+          # Ensure DownstreamTest/.lake/ directory exists, since landrun will need it later
+          mkdir -p DownstreamTest/.lake/
+          cd DownstreamTest
+          cp ../lean-toolchain .
+          echo "lean-toolchain copied successfully to DownstreamTest."
+
+      # Create empty directories so landrun doesn't complain
+      - name: Create empty directories
+        shell: bash # We need to run this outside landrun, as it is a prerequisite for landrun!
+        run: |
+          mkdir -p pr-branch/.lake/
+          mkdir -p .cache/mathlib/
+          mkdir -p _work
+
+      # NOTE: if you copy this, consider using `leanprover/lean-action` instead.
+      # We install manually, to avoid running lean outside landrun.
+      - name: install elan
+        shell: bash
+        run: |
+          set -o pipefail
+          curl -o elan-init.sh -sSfL https://elan.lean-lang.org/elan-init.sh
+          chmod +x elan-init.sh
+          ./elan-init.sh -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "${GITHUB_PATH}"
+
+      - name: set toolchain directory
+        shell: bash
+        run: |
+          cd pr-branch
+          # Get the lake binary path from elan and extract toolchain directory
+          LAKE_PATH=$(elan which lake)
+          echo "Lake path: $LAKE_PATH"
+
+          # Extract the toolchain directory by removing /bin/lake from the end
+          TOOLCHAIN_DIR=$(dirname "$LAKE_PATH")
+          TOOLCHAIN_DIR=$(dirname "$TOOLCHAIN_DIR")
+          echo "Toolchain directory: $TOOLCHAIN_DIR"
+
+          # Set it as an environment variable for subsequent steps
+          echo "TOOLCHAIN_DIR=$TOOLCHAIN_DIR" >> "$GITHUB_ENV"
+
+      - name: set LEAN_SRC_PATH
+        shell: bash
+        run: |
+          # Construct the LEAN_SRC_PATH using the toolchain directory
+          LEAN_SRC_PATH=".:$TOOLCHAIN_DIR/src/lean/lake:.lake/packages/Cli:.lake/packages/batteries:.lake/packages/Qq:.lake/packages/aesop:.lake/packages/proofwidgets:.lake/packages/importGraph:.lake/packages/LeanSearchClient:.lake/packages/plausible"
+          echo "LEAN_SRC_PATH=$LEAN_SRC_PATH"
+
+          # Set it as an environment variable for subsequent steps
+          echo "LEAN_SRC_PATH=$LEAN_SRC_PATH" >> "$GITHUB_ENV"
+
+      - name: build master-branch tools
+        shell: bash # We're only building the `master` branch version of the tools, so don't need to run inside landrun.
+        run: |
+          cd master-branch
+          lake build cache mk_all check-yaml graph
+          ls .lake/build/bin/cache
+          ls .lake/build/bin/mk_all
+          ls .lake/build/bin/check-yaml
+          ls .lake/packages/importGraph/.lake/build/bin/graph
 
       - name: cleanup .cache/mathlib
+        # This needs write access to .cache/mathlib, so can't be run inside landrun.
+        # However it is only using the `master` version of `cache`, so is safe to run outside landrun.
+        shell: bash
         run: |
           # Define the cache directory path
           CACHE_DIR="$HOME/.cache/mathlib"
@@ -84,117 +160,226 @@ jobs:
           # Check if size exceeds 10GB
           if [ "$DIR_SIZE" -gt "10737418240" ]; then
             echo "Cache size exceeds threshold, running lake exe cache clean"
-            lake exe cache clean || echo "lake did not work"
+            # We use the master-branch version of `cache`.
+            cd master-branch
+            lake exe cache clean
           fi
 
-      - name: build cache
+      - name: download dependencies
+        # We need network access to download dependencies
+        # We run this inside landrun, but restrict disk access.
+        # Landrun argument notes:
+        # - we give --rox access to `~/.elan` and `~/actions-runner/_work` (GitHub CI needs this)
+        # - we give --unrestricted-network as we need this to download dependencies
+        # - git needs read only access to `/etc`.
+        shell: landrun --unrestricted-network --rox /etc --rox /usr --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT -- bash -euxo pipefail {0}
         run: |
-          lake build cache
+          cd pr-branch
+          lake env
 
-      - name: get cache
-        id: get
+      - name: get cache (1/3 - setup and initial fetch)
+        id: get_cache_part1_setup
+        shell: bash # only runs `cache get` from `master-branch`, so doesn't need to be inside landrun
         run: |
+          cd pr-branch
+          echo "Removing old Mathlib build directories prior to cache fetch..."
           rm -rf .lake/build/lib/lean/Mathlib
-          # useful pre v4.18: the following command is only present for compatibility reasons
-          rm -rf .lake/build/lib/Mathlib/
+
           # Fail quickly if the cache is completely cold, by checking for Mathlib.Init
-          lake exe cache get Mathlib/Init.lean
-          lake build --no-build Mathlib.Init && lake exe cache get || echo "No cache for 'Mathlib.Init' available"
+          echo "Attempting to fetch olean for Mathlib/Init.lean from cache..."
+          ../master-branch/.lake/build/bin/cache get Mathlib/Init.lean
+
+      - name: get cache (2/3 - test Mathlib.Init cache)
+        id: get_cache_part2_test
+        continue-on-error: true # Allow workflow to proceed to Part 3 to check outcome
+        # This step uses the job's default shell, which is landrun-wrapped bash
+        run: |
+          cd pr-branch
+
+          echo "Attempting: lake build --no-build Mathlib.Init (this runs under landrun)"
+          lake build --no-build Mathlib.Init
+
+      - name: get cache (3/3 - finalize cache operation)
+        id: get
+        shell: bash # only runs `cache get` from `master-branch`, so doesn't need to be inside landrun
+        run: |
+          cd pr-branch
+          if [[ "${{ steps.get_cache_part2_test.outcome }}" == "success" ]]; then
+            echo "Fetching all remaining cache..."
+
+            ../master-branch/.lake/build/bin/cache get
+          else
+            echo "WARNING: 'lake build --no-build Mathlib.Init' failed."
+            echo "No cache for 'Mathlib.Init' available or it could not be prepared."
+          fi
 
       - name: update {Mathlib, Tactic, Counterexamples, Archive}.lean
         id: mk_all
+        continue-on-error: true # Allow workflow to continue, outcome checked later
+        # This only runs `mk_all --check` from the `master-branch`, so doesn't need to be inside landrun
+        shell: bash
         run: |
+          cd pr-branch
 
-          if ! lake exe mk_all --check
-          then
-            echo "Not all lean files are in the import all files"
-            echo "mk_all=false" >> "${GITHUB_OUTPUT}"
-          else
-            echo "mk_all=true" >> "${GITHUB_OUTPUT}"
-          fi
+          echo "Running mk_all --check (from master-branch)..."
+          LAKE_HOME="$TOOLCHAIN_DIR" ../master-branch/.lake/build/bin/mk_all --check
 
-      - name: build mathlib
-        id: build
+      - name: begin gh-problem-match-wrap for build step
         uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
         with:
+          action: add # In order to be able to run a multiline script, we need to add/remove the problem matcher before and after.
           linters: lean
-          run: |
-            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
+      - name: build mathlib
+        id: build
+        run: |
+          cd pr-branch
+          # Test curl - should fail when landrun network isolation is working
+          if curl --silent --head --fail https://www.example.com/ >/dev/null 2>&1; then
+            echo "ERROR: curl to example.com succeeded, but it should fail when landrun is working correctly!"
+            exit 1
+          else
+            echo "curl to example.com failed as expected - landrun network isolation is working"
+          fi
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
+      - name: end gh-problem-match-wrap for build step
+        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
+        with:
+          action: remove
+          linters: lean
 
       - name: print the sizes of the oleans
         run: |
-          du .lake/build/lib/lean/Mathlib ||
-            # This path was the correct path before v4.18: it is here just for compatibility reasons
-            du .lake/build/lib/Mathlib || echo "This code should be unreachable"
+          cd pr-branch
+          du .lake/build/lib/lean/Mathlib || echo "This code should be unreachable"
 
+      # The cache secrets are available here, so we must not run any untrusted code.
       - name: upload cache
         # We only upload the cache if the build started (whether succeeding, failing, or cancelled)
         # but not if any earlier step failed or was cancelled.
         # See discussion at https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Some.20files.20not.20found.20in.20the.20cache/near/407183836
         if: ${{ always() && steps.get.outcome == 'success' }}
+        shell: bash
         run: |
+          cd pr-branch
+
+          # Use the trusted cache tool from master-branch
           # TODO: this is not doing anything currently, and needs to be integrated with put-unpacked
-          # lake exe cache commit || true
+          # ../master-branch/.lake/build/bin/cache commit || true
           # run this in CI if it gets an incorrect lake hash for existing cache files somehow
-          # lake exe cache put!
+          # ../master-branch/.lake/build/bin/cache put!
           # do not try to upload files just downloaded
-          lake exe cache put-unpacked
+          ../master-branch/.lake/build/bin/cache put-unpacked
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
           MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
 
       - name: check the cache
+        # We need network access to download dependencies
+        # We run this inside landrun, but restrict disk access as usual.
+        shell: landrun --unrestricted-network --rox /usr --rw /dev --rox /etc --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib -rw pr-branch/.lake/ --rw pr-branch/DownstreamTest/ --env PATH --env HOME --env GITHUB_OUTPUT -- bash -euxo pipefail {0}
         run: |
+          cd pr-branch
+
           # Because the `lean-pr-testing-NNNN` branches use toolchains that are "updated in place"
           # the cache mechanism is unreliable, so we don't test it if we are on such a branch.
           if [[ ! $(cat lean-toolchain) =~ ^leanprover/lean4-pr-releases:pr-release-[0-9]+$ ]]; then
             cd DownstreamTest
-            cp ../lean-toolchain .
             MATHLIB_NO_CACHE_ON_UPDATE=1 lake update
-            lake exe cache get || (sleep 1; lake exe cache get)
+
+            lake env ../../master-branch/.lake/build/bin/cache get || (sleep 1; lake env ../../master-branch/.lake/build/bin/cache get)
+
             # We need to run `lake build ProofWidgets` here to retrieve ProofWidgets via Reservoir.
             lake build ProofWidgets
             lake build --no-build Mathlib
           fi
 
-      - name: build archive
+      # Note: we should not be including `Archive` and `Counterexamples` in the cache.
+      # We do this for now for the sake of not rebuilding them in every CI run
+      # even when they are not touched.
+      # Since `Archive` and `Counterexamples` files have very simple dependencies,
+      # it should be possible to determine whether they need to be built without actually
+      # storing and transferring oleans over the network.
+      # Hopefully a future re-implementation of `cache` will obviate the present need for this hack.
+
+      - name: fetch archive and counterexamples cache
+        shell: bash
+        run: |
+          cd pr-branch
+          ../master-branch/.lake/build/bin/cache get Archive.lean
+          ../master-branch/.lake/build/bin/cache get Counterexamples.lean
+
+      - name: build archive and counterexamples
         id: archive
         run: |
-          # Note: we should not be including `Archive` and `Counterexamples` in the cache.
-          # We do this for now for the sake of not rebuilding them in every CI run
-          # even when they are not touched.
-          # Since `Archive` and `Counterexamples` files have very simple dependencies,
-          # it should be possible to determine whether they need to be built without actually
-          # storing and transferring oleans over the network.
-          # Hopefully a future re-implementation of `cache` will obviate the present need for this hack.
-          lake exe cache get Archive.lean
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive"
-          lake exe cache put Archive.lean
-        env:
-          MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
-          MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
+          cd pr-branch
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Archive Counterexamples"
 
-      - name: build counterexamples
-        id: counterexamples
+      # The cache secrets are available here, so we must not run any untrusted code.
+      - name: put archive and counterexamples cache
+        shell: bash
         run: |
-          lake exe cache get Counterexamples.lean
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build Counterexamples"
-          lake exe cache put Counterexamples.lean
+          cd pr-branch
+          ../master-branch/.lake/build/bin/cache put Archive.lean
+          ../master-branch/.lake/build/bin/cache put Counterexamples.lean
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
           MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
 
       - name: Check {Mathlib, Tactic, Counterexamples, Archive}.lean
+        if: always()
         run: |
-          if [ ${{ steps.mk_all.outputs.mk_all }} == "false" ]
-          then
+          if [[ "${{ steps.mk_all.outcome }}" != "success" ]]; then
             echo "Please run 'lake exe mk_all' to regenerate the import all files"
             exit 1
+          else
+            echo "'mk_all --check' passed successfully."
           fi
+
+      - name: begin gh-problem-match-wrap for test step
+        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
+        with:
+          action: add # In order to be able to run a multiline script, we need to add/remove the problem matcher before and after.
+          linters: lean
+      - name: test mathlib
+        id: test
+        run: |
+          cd pr-branch
+          lake --iofail test
+      - name: end gh-problem-match-wrap for test step
+        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
+        with:
+          action: remove
+          linters: lean
+
+      - name: begin gh-problem-match-wrap for shake and lint steps
+        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
+        with:
+          action: add # In order to be able to run a multiline script, we need to add/remove the problem matcher before and after.
+          linters: gcc
+
+      - name: check for unused imports
+        id: shake
+        run: |
+          cd pr-branch
+          env LEAN_ABORT_ON_PANIC=1 lake exe shake --gh-style
+
+      - name: lint mathlib
+        if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
+        id: lint
+        run: |
+          cd pr-branch
+          env LEAN_ABORT_ON_PANIC=1 lake exe runLinter Mathlib
+
+      - name: end gh-problem-match-wrap for shake and lint steps
+        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
+        with:
+          action: remove
+          linters: gcc
 
       - name: check for noisy stdout lines
         id: noisy
         run: |
+          cd pr-branch
           buildMsgs="$(
             ##  we exploit `lake`s replay feature: since the cache is present, running
             ##  `lake build` will reproduce all the outputs without having to recompute
@@ -209,13 +394,57 @@ jobs:
             exit 1
           fi
 
+      - name: Post comments for lean-pr-testing-NNNN and batteries-pr-testing-NNNN branches
+        if: always()
+        shell: bash
+        env:
+          TOKEN: ${{ secrets.LEAN_PR_TESTING }}
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+          WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
+          NOISY_OUTCOME: ${{ steps.noisy.outcome }}
+          ARCHIVE_OUTCOME: ${{ steps.archive.outcome }}
+          COUNTEREXAMPLES_OUTCOME: ${{ steps.counterexamples.outcome }}
+          LINT_OUTCOME: ${{ steps.lint.outcome }}
+          TEST_OUTCOME: ${{ steps.test.outcome }}
+        run: |
+          master-branch/scripts/lean-pr-testing-comments.sh lean
+          master-branch/scripts/lean-pr-testing-comments.sh batteries
+
+  post_steps:
+    name: Post-Build Step (fork)
+    needs: [build]
+    runs-on: ubuntu-latest # Note these steps run on disposable GitHub runners, so no landrun sandboxing is needed.
+    steps:
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Configure Lean
+        uses: leanprover/lean-action@f807b338d95de7813c5c50d018f1c23c9b93b4ec # 2025-04-24
+        with:
+          auto-config: false # Don't run `lake build`, `lake test`, or `lake lint` automatically.
+          use-github-cache: false
+          use-mathlib-cache: true
+          reinstall-transient-toolchain: true
+
+      - name: get cache for Archive and Counterexamples
+        run: |
+          lake exe cache get Archive Counterexamples
+
+      - name: verify that everything was available in the cache
+        run: |
+          lake build --no-build Mathlib
+          lake build --no-build Archive
+          lake build --no-build Counterexamples
+
       - name: check declarations in db files
         run: |
           python3 scripts/yaml_check.py docs/100.yaml docs/1000.yaml docs/overview.yaml docs/undergrad.yaml
           lake exe check-yaml
 
       - name: generate our import graph
-        run: lake exe graph
+        run: |
+          lake exe graph
 
       - name: upload the import graph
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -234,52 +463,14 @@ jobs:
         run: |
           lake build Batteries Qq Aesop ProofWidgets Plausible
 
-      - name: test mathlib
-        id: test
-        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
-        with:
-          linters: lean
-          run:
-            lake --iofail test
-
-      - name: check for unused imports
-        id: shake
-        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
-        with:
-          linters: gcc
-          run: env LEAN_ABORT_ON_PANIC=1 lake exe shake --gh-style
-
-      - name: lint mathlib
-        if: ${{ always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure' }}
-        id: lint
-        uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
-        with:
-          linters: gcc
-          run: env LEAN_ABORT_ON_PANIC=1 lake exe runLinter Mathlib
-
       # We no longer run `lean4checker` in regular CI, as it is quite expensive for little benefit.
       # Instead we run it in a cron job on master: see `lean4checker.yml`.
       # Output is posted to the zulip topic
       # https://leanprover.zulipchat.com/#narrow/stream/345428-mathlib-reviewers/topic/lean4checker
 
-      - name: Post comments for lean-pr-testing-NNNN and batteries-pr-testing-NNNN branches
-        if: always()
-        env:
-          TOKEN: ${{ secrets.LEAN_PR_TESTING }}
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-          WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          BUILD_OUTCOME: ${{ steps.build.outcome }}
-          NOISY_OUTCOME: ${{ steps.noisy.outcome }}
-          ARCHIVE_OUTCOME: ${{ steps.archive.outcome }}
-          COUNTEREXAMPLES_OUTCOME: ${{ steps.counterexamples.outcome }}
-          LINT_OUTCOME: ${{ steps.lint.outcome }}
-          TEST_OUTCOME: ${{ steps.test.outcome }}
-        run: |
-          scripts/lean-pr-testing-comments.sh lean
-          scripts/lean-pr-testing-comments.sh batteries
-
-      - name: build lean4checker, but only run it on itself
+      - name: checkout lean4checker
         if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
+        shell: bash
         run: |
           git clone https://github.com/leanprover/lean4checker
           cd lean4checker
@@ -291,6 +482,11 @@ jobs:
           else
             git checkout master
           fi
+
+      - name: run leanchecker on itself
+        if: ${{ (always() && steps.build.outcome == 'success' || steps.build.outcome == 'failure') && contains(github.event.pull_request.changed_files, 'lean-toolchain') }}
+        run: |
+          cd lean4checker
           # Build lean4checker using the same toolchain
           cp ../lean-toolchain .
           lake build
@@ -308,7 +504,7 @@ jobs:
   final:
     name: Post-CI job (fork)
     if: github.repository != 'leanprover-community/mathlib4'
-    needs: [style_lint, build]
+    needs: [style_lint, build, post_steps]
     runs-on: ubuntu-latest
     steps:
       - id: PR

--- a/scripts/lean-pr-testing-comments.sh
+++ b/scripts/lean-pr-testing-comments.sh
@@ -20,7 +20,7 @@ fi
 # env:
 #   TOKEN: ${{ secrets.LEAN_PR_TESTING }}
 #   GITHUB_CONTEXT: ${{ toJson(github) }}
-#   WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+#   WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}
 #   BUILD_OUTCOME: ${{ steps.build.outcome }}
 #   NOISY_OUTCOME: ${{ steps.noisy.outcome }}
 #   ARCHIVE_OUTCOME: ${{ steps.archive.outcome }}

--- a/scripts/lean-pr-testing-comments.sh
+++ b/scripts/lean-pr-testing-comments.sh
@@ -20,7 +20,7 @@ fi
 # env:
 #   TOKEN: ${{ secrets.LEAN_PR_TESTING }}
 #   GITHUB_CONTEXT: ${{ toJson(github) }}
-#   WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}
+#   WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 #   BUILD_OUTCOME: ${{ steps.build.outcome }}
 #   NOISY_OUTCOME: ${{ steps.noisy.outcome }}
 #   ARCHIVE_OUTCOME: ${{ steps.archive.outcome }}


### PR DESCRIPTION
This PR modifies Mathlib CI so that all steps that run on persistent leanprover-community and/or Hoskinson Center hosted machines, or which interact with repository secrets, use `landrun` based sandboxing when interacting with any user code. (Note that some CI steps still run on disposable GitHub based runners, and these steps do not use sandboxing.)

Once this is deployed we will switch CI builds from the `push` trigger to the `pull_request_target` trigger. This will enable us to accept PRs from forks, no longer requiring contributors to ask for write access on the main repository.