### PR TITLE
[Merged by Bors] - chore: run CI on PRs from forks using pull_request_target

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -20,6 +20,12 @@ concurrency:
   # cancel any running workflow with the same label
   cancel-in-progress: true
 
+# Limit permissions for the entire workflow
+permissions:
+  contents: read
+  pull-requests: write  # Only allow PR comments/labels
+  # All other permissions are implicitly 'none'
+
 jobs:
   build:
     if: github.repository MAIN_OR_FORK 'leanprover-community/mathlib4'

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -20,7 +20,7 @@ concurrency:
   # cancel any running workflow with the same label
   cancel-in-progress: true
 
-# Limit permissions for the entire workflow
+# Limit permissions for GITHUB_TOKEN for the entire workflow
 permissions:
   contents: read
   pull-requests: write  # Only allow PR comments/labels

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -30,6 +30,12 @@ concurrency:
   # cancel any running workflow with the same label
   cancel-in-progress: true
 
+# Limit permissions for the entire workflow
+permissions:
+  contents: read
+  pull-requests: write  # Only allow PR comments/labels
+  # All other permissions are implicitly 'none'
+
 jobs:
   build:
     if: github.repository == 'leanprover-community/mathlib4'

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -30,7 +30,7 @@ concurrency:
   # cancel any running workflow with the same label
   cancel-in-progress: true
 
-# Limit permissions for the entire workflow
+# Limit permissions for GITHUB_TOKEN for the entire workflow
 permissions:
   contents: read
   pull-requests: write  # Only allow PR comments/labels

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ concurrency:
   # cancel any running workflow with the same label
   cancel-in-progress: true
 
-# Limit permissions for the entire workflow
+# Limit permissions for GITHUB_TOKEN for the entire workflow
 permissions:
   contents: read
   pull-requests: write  # Only allow PR comments/labels

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,12 @@ concurrency:
   # cancel any running workflow with the same label
   cancel-in-progress: true
 
+# Limit permissions for the entire workflow
+permissions:
+  contents: read
+  pull-requests: write  # Only allow PR comments/labels
+  # All other permissions are implicitly 'none'
+
 jobs:
   build:
     if: github.repository == 'leanprover-community/mathlib4'

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -5,7 +5,7 @@
 # .github/workflows/mk_build_yml.sh to update.
 
 # Forks of mathlib and other projects should be able to use build_fork.yml directly
-# The jobs in this file run on GitHub-hosted workers and will only be run from external forks
+# The jobs in this file run on self-hosted workers and will be run from external forks
 
 on:
   pull_request_target:
@@ -34,7 +34,7 @@ concurrency:
   # cancel any running workflow with the same label
   cancel-in-progress: true
 
-# Limit permissions for the entire workflow
+# Limit permissions for GITHUB_TOKEN for the entire workflow
 permissions:
   contents: read
   pull-requests: write  # Only allow PR comments/labels

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -8,7 +8,7 @@
 # The jobs in this file run on GitHub-hosted workers and will only be run from external forks
 
 on:
-  push:
+  pull_request_target:
     branches-ignore:
       # ignore tmp branches used by bors
       - 'staging.tmp*'
@@ -34,11 +34,17 @@ concurrency:
   # cancel any running workflow with the same label
   cancel-in-progress: true
 
+# Limit permissions for the entire workflow
+permissions:
+  contents: read
+  pull-requests: write  # Only allow PR comments/labels
+  # All other permissions are implicitly 'none'
+
 jobs:
   build:
     if: github.repository != 'leanprover-community/mathlib4'
     name: Build (fork)
-    runs-on: ubuntu-latest
+    runs-on: pr
     outputs:
       build-outcome: ${{ steps.build.outcome }}
       archive-outcome: ${{ steps.archive.outcome }}

--- a/.github/workflows/mk_build_yml.sh
+++ b/.github/workflows/mk_build_yml.sh
@@ -63,7 +63,7 @@ build_fork_yml() {
 # The jobs in this file run on GitHub-hosted workers and will only be run from external forks
 
 on:
-  push:
+  pull_request_target:
     branches-ignore:
       # ignore tmp branches used by bors
       - 'staging.tmp*'
@@ -73,8 +73,10 @@ on:
 
 name: continuous integration (mathlib forks)
 EOF
-  include 0 ubuntu-latest != " (fork)" ubuntu-latest
+  include 0 pr != " (fork)" ubuntu-latest
 }
+
+# Note (2025-06-06): IS_SELF_HOSTED is no longer used in `build.in.yml`, and should be removed.
 
 include() {
   sed "

--- a/.github/workflows/mk_build_yml.sh
+++ b/.github/workflows/mk_build_yml.sh
@@ -60,7 +60,7 @@ EOF
 build_fork_yml() {
   header
   cat <<EOF
-# The jobs in this file run on GitHub-hosted workers and will only be run from external forks
+# The jobs in this file run on self-hosted workers and will be run from external forks
 
 on:
   pull_request_target:

--- a/Mathlib/Computability/AkraBazzi/AkraBazzi.lean
+++ b/Mathlib/Computability/AkraBazzi/AkraBazzi.lean
@@ -1469,7 +1469,6 @@ theorem isBigO_asympBound : T =O[atTop] asympBound g a b := by
                 tendsto_natCast_atTop_atTop
          _ = asympBound g a b := by simp
 
-
 /-- The **Akra-Bazzi theorem**: `T ∈ Ω(n^p (1 + ∑_u^n g(u) / u^{p+1}))` -/
 theorem isBigO_symm_asympBound : asympBound g a b =O[atTop] T := by
   calc asympBound g a b = (fun n => 1 * asympBound g a b n) := by simp

--- a/Mathlib/Computability/AkraBazzi/AkraBazzi.lean
+++ b/Mathlib/Computability/AkraBazzi/AkraBazzi.lean
@@ -1469,6 +1469,7 @@ theorem isBigO_asympBound : T =O[atTop] asympBound g a b := by
                 tendsto_natCast_atTop_atTop
          _ = asympBound g a b := by simp
 
+
 /-- The **Akra-Bazzi theorem**: `T ∈ Ω(n^p (1 + ∑_u^n g(u) / u^{p+1}))` -/
 theorem isBigO_symm_asympBound : asympBound g a b =O[atTop] T := by
   calc asympBound g a b = (fun n => 1 * asympBound g a b n) := by simp


### PR DESCRIPTION
This PR:
* reduces the default permissions for the GITHUB_TOKEN to 
```
permissions:
  contents: read
  pull-requests: write  # Only allow PR comments/labels
```
* has PRs from forks run under `pull_request_target`
* runs CI for PRs from forks on our hosted CI runners