### PR TITLE
[Merged by Bors] - fix: change test in build_fork.yml

### DIFF
--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -42,7 +42,7 @@ permissions:
 
 jobs:
   build:
-    if: github.repository != 'leanprover-community/mathlib4'
+    if: github.repository == 'leanprover-community/mathlib4'
     name: Build (fork)
     runs-on: pr
     outputs:
@@ -525,7 +525,7 @@ jobs:
 
   final:
     name: Post-CI job (fork)
-    if: github.repository != 'leanprover-community/mathlib4'
+    if: github.repository == 'leanprover-community/mathlib4'
     needs: [style_lint, build, post_steps]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/mk_build_yml.sh
+++ b/.github/workflows/mk_build_yml.sh
@@ -73,7 +73,7 @@ on:
 
 name: continuous integration (mathlib forks)
 EOF
-  include 0 pr != " (fork)" ubuntu-latest
+  include 0 pr == " (fork)" ubuntu-latest
 }
 
 # Note (2025-06-06): IS_SELF_HOSTED is no longer used in `build.in.yml`, and should be removed.


### PR DESCRIPTION
Now that we use `pull_request_target`, in `build_fork.yml` the `github.repository` is set to `'leanprover-community/mathlib4'`, so we need to change the polarity of the test! 