### PR TITLE
[Merged by Bors] - refactor(Topology/Instances): split AddCircle to remove dependence on reals

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6197,8 +6197,9 @@ import Mathlib.Topology.Homotopy.Path
 import Mathlib.Topology.Homotopy.Product
 import Mathlib.Topology.IndicatorConstPointwise
 import Mathlib.Topology.Inseparable
-import Mathlib.Topology.Instances.AddCircle
+import Mathlib.Topology.Instances.AddCircle.Defs
 import Mathlib.Topology.Instances.AddCircle.DenseSubgroup
+import Mathlib.Topology.Instances.AddCircle.Real
 import Mathlib.Topology.Instances.CantorSet
 import Mathlib.Topology.Instances.Complex
 import Mathlib.Topology.Instances.Discrete

--- a/Mathlib/Algebra/Category/Grp/Injective.lean
+++ b/Mathlib/Algebra/Category/Grp/Injective.lean
@@ -9,7 +9,7 @@ import Mathlib.Algebra.EuclideanDomain.Int
 import Mathlib.Algebra.Category.ModuleCat.Injective
 import Mathlib.CategoryTheory.Preadditive.Injective.Basic
 import Mathlib.RingTheory.PrincipalIdealDomain
-import Mathlib.Topology.Instances.AddCircle
+import Mathlib.Topology.Instances.AddCircle.Defs
 
 /-!
 # Injective objects in the category of abelian groups

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -6,6 +6,7 @@ Authors: Oliver Nash
 import Mathlib.Algebra.DirectSum.LinearMap
 import Mathlib.Algebra.Lie.Weights.Cartan
 import Mathlib.RingTheory.Finiteness.Nilpotent
+import Mathlib.Data.Int.Interval
 
 /-!
 # Chains of roots and weights

--- a/Mathlib/Algebra/Module/CharacterModule.lean
+++ b/Mathlib/Algebra/Module/CharacterModule.lean
@@ -6,7 +6,7 @@ Authors: Jujian Zhang, Junyan Xu
 
 import Mathlib.Algebra.Category.ModuleCat.Basic
 import Mathlib.Algebra.Category.Grp.Injective
-import Mathlib.Topology.Instances.AddCircle
+import Mathlib.Topology.Instances.AddCircle.Defs
 import Mathlib.LinearAlgebra.Isomorphisms
 
 /-!

--- a/Mathlib/Analysis/Fourier/FiniteAbelian/PontryaginDuality.lean
+++ b/Mathlib/Analysis/Fourier/FiniteAbelian/PontryaginDuality.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.DirectSum.AddChar
 import Mathlib.Analysis.Fourier.FiniteAbelian.Orthogonality
 import Mathlib.Analysis.SpecialFunctions.Complex.Circle
 import Mathlib.GroupTheory.FiniteAbelian.Basic
+import Mathlib.Topology.Instances.AddCircle.Real
 
 /-!
 # Pontryagin duality for finite abelian groups

--- a/Mathlib/Analysis/Normed/Group/AddCircle.lean
+++ b/Mathlib/Analysis/Normed/Group/AddCircle.lean
@@ -5,7 +5,7 @@ Authors: Oliver Nash
 -/
 import Mathlib.Analysis.Normed.Group.Quotient
 import Mathlib.Analysis.NormedSpace.Pointwise
-import Mathlib.Topology.Instances.AddCircle
+import Mathlib.Topology.Instances.AddCircle.Real
 
 /-!
 # The additive circle as a normed group

--- a/Mathlib/Analysis/Normed/Unbundled/SmoothingSeminorm.lean
+++ b/Mathlib/Analysis/Normed/Unbundled/SmoothingSeminorm.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Order.GroupWithZero.Bounds
 import Mathlib.Analysis.Normed.Unbundled.RingSeminorm
 import Mathlib.Analysis.SpecialFunctions.Pow.Continuity
 import Mathlib.Topology.MetricSpace.Sequences
+import Mathlib.Topology.UnitInterval
 
 /-!
 # smoothingSeminorm

--- a/Mathlib/Analysis/SpecialFunctions/Complex/CircleAddChar.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/CircleAddChar.lean
@@ -6,6 +6,7 @@ Authors: David Loeffler
 import Mathlib.Analysis.SpecialFunctions.Complex.Circle
 import Mathlib.NumberTheory.LegendreSymbol.AddCharacter
 import Mathlib.RingTheory.RootsOfUnity.AlgebraicallyClosed
+import Mathlib.Topology.Instances.AddCircle.Real
 
 /-!
 # Additive characters valued in the unit circle

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/Periodic.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/Periodic.lean
@@ -7,6 +7,7 @@ import Mathlib.MeasureTheory.Measure.Lebesgue.EqHaar
 import Mathlib.MeasureTheory.Measure.Haar.Quotient
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 import Mathlib.Topology.Algebra.Order.Floor
+import Mathlib.Topology.Instances.AddCircle.Real
 
 /-!
 # Integrals of periodic functions

--- a/Mathlib/Topology/Instances/AddCircle/Defs.lean
+++ b/Mathlib/Topology/Instances/AddCircle/Defs.lean
@@ -7,7 +7,6 @@ import Mathlib.Algebra.Order.ToIntervalMod
 import Mathlib.Algebra.Ring.AddAut
 import Mathlib.Data.Nat.Totient
 import Mathlib.GroupTheory.Divisible
-import Mathlib.Topology.Connected.PathConnected
 import Mathlib.Topology.IsLocalHomeomorph
 import Mathlib.Topology.Instances.ZMultiples
 
@@ -518,38 +517,13 @@ end FiniteOrderPoints
 
 end LinearOrderedField
 
-variable (p : ℝ)
-
-instance pathConnectedSpace : PathConnectedSpace <| AddCircle p :=
-  (inferInstance : PathConnectedSpace (Quotient _))
-
-/-- The "additive circle" `ℝ ⧸ (ℤ ∙ p)` is compact. -/
-instance compactSpace [Fact (0 < p)] : CompactSpace <| AddCircle p := by
-  rw [← isCompact_univ_iff, ← coe_image_Icc_eq p 0]
-  exact isCompact_Icc.image (AddCircle.continuous_mk' p)
-
-/-- The action on `ℝ` by right multiplication of its the subgroup `zmultiples p` (the multiples of
-`p:ℝ`) is properly discontinuous. -/
-instance : ProperlyDiscontinuousVAdd (zmultiples p).op ℝ :=
-  (zmultiples p).properlyDiscontinuousVAdd_opposite_of_tendsto_cofinite
-    (AddSubgroup.tendsto_zmultiples_subtype_cofinite p)
-
 end AddCircle
-
-section UnitAddCircle
-
-/-- The unit circle `ℝ ⧸ ℤ`. -/
-abbrev UnitAddCircle :=
-  AddCircle (1 : ℝ)
-
-end UnitAddCircle
 
 section IdentifyIccEnds
 
 /-! This section proves that for any `a`, the natural map from `[a, a + p] ⊂ 𝕜` to `AddCircle p`
 gives an identification of `AddCircle p`, as a topological space, with the quotient of `[a, a + p]`
 by the equivalence relation identifying the endpoints. -/
-
 
 namespace AddCircle
 
@@ -661,44 +635,3 @@ theorem liftIco_zero_continuous [TopologicalSpace B] {f : 𝕜 → B} (hf : f 0 
 end AddCircle
 
 end IdentifyIccEnds
-
-namespace ZMod
-
-variable {N : ℕ} [NeZero N]
-
-/-- The `AddMonoidHom` from `ZMod N` to `ℝ / ℤ` sending `j mod N` to `j / N mod 1`. -/
-noncomputable def toAddCircle : ZMod N →+ UnitAddCircle :=
-  lift N ⟨AddMonoidHom.mk' (fun j ↦ ↑(j / N : ℝ)) (by simp [add_div]),
-    by simp [div_self (NeZero.ne _)]⟩
-
-lemma toAddCircle_intCast (j : ℤ) :
-    toAddCircle (j : ZMod N) = ↑(j / N : ℝ) := by
-  simp [toAddCircle]
-
-lemma toAddCircle_natCast (j : ℕ) :
-    toAddCircle (j : ZMod N) = ↑(j / N : ℝ) := by
-  simpa using toAddCircle_intCast (N := N) j
-
-/--
-Explicit formula for `toCircle j`. Note that this is "evil" because it uses `ZMod.val`. Where
-possible, it is recommended to lift `j` to `ℤ` and use `toAddCircle_intCast` instead.
--/
-lemma toAddCircle_apply (j : ZMod N) :
-    toAddCircle j = ↑(j.val / N : ℝ) := by
-  rw [← toAddCircle_natCast, natCast_zmod_val]
-
-variable (N) in
-lemma toAddCircle_injective : Function.Injective (toAddCircle : ZMod N → _) := by
-  intro x y hxy
-  have : (0 : ℝ) < N := Nat.cast_pos.mpr (NeZero.pos _)
-  rwa [toAddCircle_apply, toAddCircle_apply, AddCircle.coe_eq_coe_iff_of_mem_Ico,
-    div_left_inj' this.ne', Nat.cast_inj, (val_injective N).eq_iff] at hxy <;>
-  exact ⟨by positivity, by simpa only [zero_add, div_lt_one this, Nat.cast_lt] using val_lt _⟩
-
-@[simp] lemma toAddCircle_inj {j k : ZMod N} : toAddCircle j = toAddCircle k ↔ j = k :=
-  (toAddCircle_injective N).eq_iff
-
-@[simp] lemma toAddCircle_eq_zero {j : ZMod N} : toAddCircle j = 0 ↔ j = 0 :=
-  map_eq_zero_iff _ (toAddCircle_injective N)
-
-end ZMod

--- a/Mathlib/Topology/Instances/AddCircle/Defs.lean
+++ b/Mathlib/Topology/Instances/AddCircle/Defs.lean
@@ -7,8 +7,10 @@ import Mathlib.Algebra.Order.ToIntervalMod
 import Mathlib.Algebra.Ring.AddAut
 import Mathlib.Data.Nat.Totient
 import Mathlib.GroupTheory.Divisible
+import Mathlib.Topology.Algebra.IsUniformGroup.Basic
+import Mathlib.Topology.Algebra.Order.Field
 import Mathlib.Topology.IsLocalHomeomorph
-import Mathlib.Topology.Instances.ZMultiples
+import Mathlib.Topology.Order.T5
 
 /-!
 # The additive circle
@@ -366,13 +368,16 @@ theorem coe_equivIco_mk_apply (x : 𝕜) :
 
 instance : DivisibleBy (AddCircle p) ℤ where
   div x n := (↑((n : 𝕜)⁻¹ * (equivIco p 0 x : 𝕜)) : AddCircle p)
-  div_zero x := by
-    simp only [algebraMap.coe_zero, Int.cast_zero, inv_zero, zero_mul, QuotientAddGroup.mk_zero]
+  div_zero x := by simp
   div_cancel {n} x hn := by
     replace hn : (n : 𝕜) ≠ 0 := by norm_cast
     change n • QuotientAddGroup.mk' _ ((n : 𝕜)⁻¹ * ↑(equivIco p 0 x)) = x
     rw [← map_zsmul, ← smul_mul_assoc, zsmul_eq_mul, mul_inv_cancel₀ hn, one_mul]
     exact (equivIco p 0).symm_apply_apply x
+
+omit [IsStrictOrderedRing 𝕜] in
+@[simp] lemma coe_fract (x : 𝕜) : (↑(Int.fract x) : AddCircle (1 : 𝕜)) = x := by
+  simp [← Int.self_sub_floor]
 
 end FloorRing
 
@@ -628,9 +633,6 @@ theorem liftIco_continuous [TopologicalSpace B] {f : 𝕜 → B} (hf : f a = f (
 theorem liftIco_zero_continuous [TopologicalSpace B] {f : 𝕜 → B} (hf : f 0 = f p)
     (hc : ContinuousOn f <| Icc 0 p) : Continuous (liftIco p 0 f) :=
   liftIco_continuous (by rwa [zero_add] : f 0 = f (0 + p)) (by rwa [zero_add])
-
-@[simp] lemma coe_fract (x : ℝ) : (↑(Int.fract x) : AddCircle (1 : ℝ)) = x := by
-  simp [← Int.self_sub_floor]
 
 end AddCircle
 

--- a/Mathlib/Topology/Instances/AddCircle/DenseSubgroup.lean
+++ b/Mathlib/Topology/Instances/AddCircle/DenseSubgroup.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
 import Mathlib.Data.Real.Irrational
-import Mathlib.Topology.Instances.AddCircle
+import Mathlib.Topology.Instances.AddCircle.Defs
 import Mathlib.Topology.Algebra.Order.Archimedean
 
 /-!

--- a/Mathlib/Topology/Instances/AddCircle/Real.lean
+++ b/Mathlib/Topology/Instances/AddCircle/Real.lean
@@ -5,6 +5,7 @@ Authors: Oliver Nash
 -/
 import Mathlib.Topology.Connected.PathConnected
 import Mathlib.Topology.Instances.AddCircle.Defs
+import Mathlib.Topology.Instances.ZMultiples
 
 /-!
 # The additive circle over `ℝ`

--- a/Mathlib/Topology/Instances/AddCircle/Real.lean
+++ b/Mathlib/Topology/Instances/AddCircle/Real.lean
@@ -1,0 +1,87 @@
+/-
+Copyright (c) 2022 Oliver Nash. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Oliver Nash
+-/
+import Mathlib.Topology.Connected.PathConnected
+import Mathlib.Topology.Instances.AddCircle.Defs
+
+/-!
+# The additive circle over `ℝ`
+
+Results specific to the additive circle over `ℝ`.
+-/
+
+
+noncomputable section
+
+open AddCommGroup Set Function AddSubgroup TopologicalSpace Topology
+
+namespace AddCircle
+
+variable (p : ℝ)
+
+instance pathConnectedSpace : PathConnectedSpace <| AddCircle p :=
+  (inferInstance : PathConnectedSpace (Quotient _))
+
+/-- The "additive circle" `ℝ ⧸ (ℤ ∙ p)` is compact. -/
+instance compactSpace [Fact (0 < p)] : CompactSpace <| AddCircle p := by
+  rw [← isCompact_univ_iff, ← coe_image_Icc_eq p 0]
+  exact isCompact_Icc.image (AddCircle.continuous_mk' p)
+
+/-- The action on `ℝ` by right multiplication of its the subgroup `zmultiples p` (the multiples of
+`p:ℝ`) is properly discontinuous. -/
+instance : ProperlyDiscontinuousVAdd (zmultiples p).op ℝ :=
+  (zmultiples p).properlyDiscontinuousVAdd_opposite_of_tendsto_cofinite
+    (AddSubgroup.tendsto_zmultiples_subtype_cofinite p)
+
+end AddCircle
+
+section UnitAddCircle
+
+/-- The unit circle `ℝ ⧸ ℤ`. -/
+abbrev UnitAddCircle :=
+  AddCircle (1 : ℝ)
+
+end UnitAddCircle
+
+namespace ZMod
+
+variable {N : ℕ} [NeZero N]
+
+/-- The `AddMonoidHom` from `ZMod N` to `ℝ / ℤ` sending `j mod N` to `j / N mod 1`. -/
+noncomputable def toAddCircle : ZMod N →+ UnitAddCircle :=
+  lift N ⟨AddMonoidHom.mk' (fun j ↦ ↑(j / N : ℝ)) (by simp [add_div]),
+    by simp [div_self (NeZero.ne _)]⟩
+
+lemma toAddCircle_intCast (j : ℤ) :
+    toAddCircle (j : ZMod N) = ↑(j / N : ℝ) := by
+  simp [toAddCircle]
+
+lemma toAddCircle_natCast (j : ℕ) :
+    toAddCircle (j : ZMod N) = ↑(j / N : ℝ) := by
+  simpa using toAddCircle_intCast (N := N) j
+
+/--
+Explicit formula for `toCircle j`. Note that this is "evil" because it uses `ZMod.val`. Where
+possible, it is recommended to lift `j` to `ℤ` and use `toAddCircle_intCast` instead.
+-/
+lemma toAddCircle_apply (j : ZMod N) :
+    toAddCircle j = ↑(j.val / N : ℝ) := by
+  rw [← toAddCircle_natCast, natCast_zmod_val]
+
+variable (N) in
+lemma toAddCircle_injective : Function.Injective (toAddCircle : ZMod N → _) := by
+  intro x y hxy
+  have : (0 : ℝ) < N := Nat.cast_pos.mpr (NeZero.pos _)
+  rwa [toAddCircle_apply, toAddCircle_apply, AddCircle.coe_eq_coe_iff_of_mem_Ico,
+    div_left_inj' this.ne', Nat.cast_inj, (val_injective N).eq_iff] at hxy <;>
+  exact ⟨by positivity, by simpa only [zero_add, div_lt_one this, Nat.cast_lt] using val_lt _⟩
+
+@[simp] lemma toAddCircle_inj {j k : ZMod N} : toAddCircle j = toAddCircle k ↔ j = k :=
+  (toAddCircle_injective N).eq_iff
+
+@[simp] lemma toAddCircle_eq_zero {j : ZMod N} : toAddCircle j = 0 ↔ j = 0 :=
+  map_eq_zero_iff _ (toAddCircle_injective N)
+
+end ZMod

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -193,7 +193,10 @@
   "Mathlib.Util.WithWeakNamespace",
   "Qq"],
  "ignoreAll":
- ["Batteries.Tactic.Basic", "Mathlib.Mathport.Syntax", "Mathlib.Tactic.Linter", "Mathlib.Init"],
+ ["Batteries.Tactic.Basic",
+  "Mathlib.Mathport.Syntax",
+  "Mathlib.Tactic.Linter",
+  "Mathlib.Init"],
  "ignore":
  {"Mathlib.Util.Notation3": ["Lean.Elab.BuiltinCommand"],
   "Mathlib.Topology.UniformSpace.Defs": ["Mathlib.Tactic.Monotonicity.Basic"],
@@ -478,6 +481,8 @@
   ["Mathlib.Tactic.CategoryTheory.Bicategory.Basic"],
   "Mathlib.Analysis.Normed.Operator.LinearIsometry":
   ["Mathlib.Algebra.Star.Basic"],
+  "Mathlib.Analysis.Normed.Group.AddCircle":
+  ["Mathlib.Topology.Instances.AddCircle.Real"],
   "Mathlib.Analysis.InnerProductSpace.PiL2": ["Mathlib.Util.Superscript"],
   "Mathlib.Analysis.InnerProductSpace.Defs": ["Mathlib.Data.Complex.Basic"],
   "Mathlib.Analysis.Distribution.SchwartzSpace": ["Mathlib.Tactic.MoveAdd"],


### PR DESCRIPTION
This is just a small thing I noticed while prepping a student's work for submission: splitting up the file defining `AddCircle`, in order to avoid various algebra files having a spurious dependence on path-connectedness.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
