### PR TITLE
[Merged by Bors] - fix: specify PR branch ref explicitly

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -73,8 +73,7 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          # need to specify this explicitly for pull_request_target
-          ref: "${{ github.event.pull_request.merge_commit_sha }}"
+          ref: "${{ PR_BRANCH_REF }}"
           path: pr-branch
 
       - name: Prepare DownstreamTest directory

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -73,6 +73,8 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          # need to specify this explicitly for pull_request_target
+          ref: "${{ github.event.pull_request.merge_commit_sha }}"
           path: pr-branch
 
       - name: Prepare DownstreamTest directory

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          ref: "${{ github.sha }}"
           path: pr-branch
 
       - name: Prepare DownstreamTest directory

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,7 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          ref: "${{ github.sha }}"
           path: pr-branch
 
       - name: Prepare DownstreamTest directory

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: "${{ github.event.pull_request.head.sha }}"
+          ref: "${{ github.event.pull_request.merge_commit_sha }}"
           path: pr-branch
 
       - name: Prepare DownstreamTest directory

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -87,6 +87,7 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          ref: "${{ github.event.pull_request.head.sha }}"
           path: pr-branch
 
       - name: Prepare DownstreamTest directory

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: "${{ github.event.pull_request.merge_commit_sha }}"
+          ref: "${{ github.event.pull_request.head.sha }}"
           path: pr-branch
 
       - name: Prepare DownstreamTest directory

--- a/.github/workflows/mk_build_yml.sh
+++ b/.github/workflows/mk_build_yml.sh
@@ -39,7 +39,7 @@ on:
 
 name: continuous integration
 EOF
-  include 1 pr "true" "" ubuntu-latest
+  include "github.sha" pr "true" "" ubuntu-latest
 }
 
 bors_yml() {
@@ -54,7 +54,7 @@ on:
 
 name: continuous integration (staging)
 EOF
-  include 1 bors "true" "" bors
+  include "github.sha" bors "true" "" bors
 }
 
 build_fork_yml() {
@@ -73,14 +73,12 @@ on:
 
 name: continuous integration (mathlib forks)
 EOF
-  include 0 pr "github.event.pull_request.head.repo.fork" " (fork)" ubuntu-latest
+  include "github.event.pull_request.head.sha" pr "github.event.pull_request.head.repo.fork" " (fork)" ubuntu-latest
 }
-
-# Note (2025-06-06): IS_SELF_HOSTED is no longer used in `build.in.yml`, and should be removed.
 
 include() {
   sed "
-    s/IS_SELF_HOSTED/$1/g;
+    s/PR_BRANCH_REF/$1/g;
     s/RUNS_ON/$2/g;
     s/FORK_CONDITION/$3/g;
     s/JOB_NAME/$4/g;

--- a/.github/workflows/mk_build_yml.sh
+++ b/.github/workflows/mk_build_yml.sh
@@ -73,7 +73,7 @@ on:
 
 name: continuous integration (mathlib forks)
 EOF
-  include "github.event.pull_request.head.sha" pr "github.event.pull_request.head.repo.fork" " (fork)" ubuntu-latest
+  include "github.event.pull_request.merge_commit_sha" pr "github.event.pull_request.head.repo.fork" " (fork)" ubuntu-latest
 }
 
 include() {

--- a/.github/workflows/mk_build_yml.sh
+++ b/.github/workflows/mk_build_yml.sh
@@ -73,7 +73,7 @@ on:
 
 name: continuous integration (mathlib forks)
 EOF
-  include "github.event.pull_request.merge_commit_sha" pr "github.event.pull_request.head.repo.fork" " (fork)" ubuntu-latest
+  include "github.event.pull_request.head.sha" pr "github.event.pull_request.head.repo.fork" " (fork)" ubuntu-latest
 }
 
 include() {


### PR DESCRIPTION
In `build_fork.yml`, the checked-out ref is the head of the base branch, but we need it to point to the head of the PR branch.

---

cf. the example runs for #25516: the [checkout master](https://github.com/leanprover-community/mathlib4/actions/runs/15483466658/job/43593405339?pr=25516#step:4:72) and [checkout pr-branch](https://github.com/leanprover-community/mathlib4/actions/runs/15483466658/job/43593405339?pr=25516#step:5:69) steps checked out the same commit.