### PR TITLE
[Merged by Bors] - docs: fix one LaTeX formula in Hilbert's Theorem 90

### DIFF
--- a/Mathlib/RepresentationTheory/GroupCohomology/Hilbert90.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Hilbert90.lean
@@ -10,8 +10,8 @@ import Mathlib.RepresentationTheory.GroupCohomology.LowDegree
 # Hilbert's Theorem 90
 
 Let `L/K` be a finite extension of fields. Then this file proves Noether's generalization of
-Hilbert's Theorem 90: that the 1st group cohomology $H^1(Aut_K(L), Lˣ)$ is trivial. We state it
-both in terms of $H^1$ and in terms of cocycles being coboundaries.
+Hilbert's Theorem 90: that the 1st group cohomology $H^1(Aut_K(L), L^\times)$ is trivial. We state
+it both in terms of $H^1$ and in terms of cocycles being coboundaries.
 
 Hilbert's original statement was that if $L/K$ is Galois, and $Gal(L/K)$ is cyclic, generated
 by an element `σ`, then for every `x : L` such that $N_{L/K}(x) = 1,$ there exists `y : L` such


### PR DESCRIPTION
In Lean code, the units type is written as `` `Lˣ` ``, but in LaTeX formulas, it is conventionally written as `$L^\times$`.
On the [Hilbert's Theorem 90 page](https://leanprover-community.github.io/mathlib4_docs/Mathlib/RepresentationTheory/GroupCohomology/Hilbert90.html), one LaTex formula uses `Lˣ`, which appears slightly unnatural compared to other formulas on the same page.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
