### PR TITLE
[Merged by Bors] - chore(PR summary): use `git checkout --` and verbose logs in PR summary

### DIFF
--- a/.github/workflows/PR_summary.yml
+++ b/.github/workflows/PR_summary.yml
@@ -66,7 +66,8 @@ jobs:
         git fetch origin ${{ github.base_ref }}  # fetch the base branch
 
         # Get the list of all changed files.
-        git diff --name-only origin/${{ github.base_ref }}... > changed_files.txt
+        echo "Saving the changed files to 'changed_files.txt'..."
+        git diff --name-only origin/${{ github.base_ref }}... | tee changed_files.txt
 
         # Get all files which were removed or renamed.
         echo "Checking for removed files..."
@@ -129,18 +130,19 @@ jobs:
         git checkout master
         git checkout -
         currentHash="$(git rev-parse HEAD)"
+        printf 'currentHash=%s\n' "${currentHash}"
 
-        # Compute the counts for the HEAD of the PR
+        echo "Compute the counts for the HEAD of the PR"
         python ../master-branch/scripts/count-trans-deps.py "Mathlib/" > head.json
 
         # Checkout the merge base
         git checkout "$(git merge-base master ${{ github.event.pull_request.head.sha }})"
 
-        # Compute the counts for the merge base
+        echo "Compute the counts for the merge base"
         python ../master-branch/scripts/count-trans-deps.py "Mathlib/" > base.json
 
         # switch back to the current branch: the `declarations_diff` script should be here
-        git checkout "${currentHash}"
+        git switch -
 
     - name: Post or update the summary comment
       env:
@@ -153,13 +155,13 @@ jobs:
 
         graphAndHighPercentReports=$(python ../master-branch/scripts/import-graph-report.py base.json head.json changed_files.txt)
 
-        ## Import count comment
+        echo "Produce import count comment"
         importCount=$(
           printf '%s\n' "${graphAndHighPercentReports}" | sed '/^Import changes exceeding/Q'
           ../master-branch/scripts/import_trans_difference.sh
         )
 
-        ## High percentage imports
+        echo "Produce high percentage imports"
         high_percentages=$(
           printf '%s\n' "${graphAndHighPercentReports}" | sed -n '/^Import changes exceeding/,$p'
         )
@@ -179,7 +181,7 @@ jobs:
           importCount="$(printf '#### Import changes for modified files\n\n%s\n' "${importCount}")"
         fi
 
-        ## Declarations' diff comment
+        echo "Compute Declarations' diff comment"
         declDiff=$(../master-branch/scripts/declarations_diff.sh)
         if [ "$(printf '%s' "${declDiff}" | wc -l)" -gt 15 ]
         then
@@ -190,14 +192,15 @@ jobs:
         git checkout "${BRANCH_NAME}"
         currentHash="$(git rev-parse HEAD)"
         hashURL="https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}/commits/${currentHash}"
+        printf 'hashURL: %s' "${hashURL}"
 
-        ## Technical debt changes
+        echo "Compute technical debt changes"
         techDebtVar="$(../master-branch/scripts/technical-debt-metrics.sh pr_summary)"
 
         # store in a file, to avoid "long arguments" error.
         printf '%s [%s](%s)%s\n\n%s\n\n---\n\n%s\n\n---\n\n%s\n' "${title}" "$(git rev-parse --short HEAD)" "${hashURL}" "${high_percentages}" "${importCount}" "${declDiff}" "${techDebtVar}" > please_merge_master.md
 
-        # At the end, include any errors about removed or renamed files without deprecation.
+        echo "Include any errors about removed or renamed files without deprecation."
         if [ -s moved_without_deprecation.txt ]
         then
           printf '\n\n---\n\n' >> please_merge_master.md

--- a/.github/workflows/PR_summary.yml
+++ b/.github/workflows/PR_summary.yml
@@ -142,7 +142,7 @@ jobs:
         python ../master-branch/scripts/count-trans-deps.py "Mathlib/" > base.json
 
         # switch back to the current branch: the `declarations_diff` script should be here
-        git switch -
+        git checkout "${currentHash}" --
 
     - name: Post or update the summary comment
       env:


### PR DESCRIPTION
Change a `git checkout <something>` with `git checkout <something> --`, as I think that it is the source of [this failure](https://github.com/leanprover-community/mathlib4/actions/runs/15493257573/job/43623655650?pr=25540).

Also, make logs more verbose in CI for PR summary.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
