### PR TITLE
feat(MeasureTheory/Measure): bound Hausdorff measure under orthogonal…

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4375,6 +4375,7 @@ import Mathlib.MeasureTheory.Measure.Haar.Quotient
 import Mathlib.MeasureTheory.Measure.Haar.Unique
 import Mathlib.MeasureTheory.Measure.HasOuterApproxClosed
 import Mathlib.MeasureTheory.Measure.Hausdorff
+import Mathlib.MeasureTheory.Measure.HausdorffProjectionLe
 import Mathlib.MeasureTheory.Measure.IntegralCharFun
 import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
 import Mathlib.MeasureTheory.Measure.Lebesgue.Complex


### PR DESCRIPTION
feat(MeasureTheory/Measure): bound Hausdorff measure under orthogonal projection

Formalisation that Hausdorff measure is non-increasing under orthogonal projection onto a finite-dimensional Euclidean subspace.

This includes:
* a bound on the norm of orthogonal projections;
* a proof that orthogonal projection is 1-Lipschitz;
* the main result: the `s`-dimensional Hausdorff measure of the projection of a set is less than or equal to that of the original set.

This formalises Lemma 3.5 from Julian Fox’s REU paper:  
*Besicovitch Sets, Kakeya Sets, and Their Properties*, UChicago REU, 2021.  
<https://math.uchicago.edu/~may/REU2021/REUPapers/Fox.pdf>

Footer:

_No breaking changes._

Dependencies:

_None._


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
