### PR TITLE
[Merged by Bors] - feat(RepresentationTheory/*): prerequisites for the bar resolution

### DIFF
--- a/Mathlib/Algebra/BigOperators/Fin.lean
+++ b/Mathlib/Algebra/BigOperators/Fin.lean
@@ -463,6 +463,30 @@ theorem partialProd_right_inv {G : Type*} [Group G] (f : Fin n → G) (i : Fin n
     (partialProd f (Fin.castSucc i))⁻¹ * partialProd f i.succ = f i := by
   rw [partialProd_succ, inv_mul_cancel_left]
 
+@[to_additive]
+lemma partialProd_contractNth {G : Type*} [Monoid G] {n : ℕ}
+    (g : Fin (n + 1) → G) (a : Fin (n + 1)) :
+    partialProd (contractNth a (· * ·) g) = partialProd g ∘ a.succ.succAbove := by
+  ext i
+  refine inductionOn i ?_ ?_
+  · simp only [partialProd_zero, Function.comp_apply, succ_succAbove_zero]
+  · intro i hi
+    simp only [Function.comp_apply, succ_succAbove_succ] at *
+    rw [partialProd_succ, partialProd_succ, hi]
+    rcases lt_trichotomy (i : ℕ) a with (h | h | h)
+    · rw [succAbove_of_castSucc_lt, contractNth_apply_of_lt _ _ _ _ h,
+        succAbove_of_castSucc_lt] <;>
+      simp only [lt_def, coe_castSucc, val_succ] <;>
+      omega
+    · rw [succAbove_of_castSucc_lt, contractNth_apply_of_eq _ _ _ _ h,
+        succAbove_of_le_castSucc, castSucc_fin_succ, partialProd_succ, mul_assoc] <;>
+      simp only [castSucc_lt_succ_iff, le_def, coe_castSucc] <;>
+      omega
+    · rw [succAbove_of_le_castSucc, succAbove_of_le_castSucc, contractNth_apply_of_gt _ _ _ _ h,
+        castSucc_fin_succ] <;>
+      simp only [le_def, Nat.succ_eq_add_one, val_succ, coe_castSucc] <;>
+      omega
+
 /-- Let `(g₀, g₁, ..., gₙ)` be a tuple of elements in `Gⁿ⁺¹`.
 Then if `k < j`, this says `(g₀g₁...gₖ₋₁)⁻¹ * g₀g₁...gₖ = gₖ`.
 If `k = j`, it says `(g₀g₁...gₖ₋₁)⁻¹ * g₀g₁...gₖ₊₁ = gₖgₖ₊₁`.

--- a/Mathlib/RepresentationTheory/GroupCohomology/Basic.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Basic.lean
@@ -83,10 +83,11 @@ variable [Monoid G]
 /-- The complex `Hom(P, A)`, where `P` is the standard resolution of `k` as a trivial `k`-linear
 `G`-representation. -/
 abbrev linearYonedaObjResolution (A : Rep k G) : CochainComplex (ModuleCat.{u} k) ℕ :=
-  (groupCohomology.resolution k G).linearYonedaObj k A
+  (Rep.standardComplex k G).linearYonedaObj k A
 
-theorem linearYonedaObjResolution_d_apply {A : Rep k G} (i j : ℕ) (x : (resolution k G).X i ⟶ A) :
-    (linearYonedaObjResolution A).d i j x = (resolution k G).d j i ≫ x :=
+theorem linearYonedaObjResolution_d_apply
+    {A : Rep k G} (i j : ℕ) (x : (Rep.standardComplex k G).X i ⟶ A) :
+    (linearYonedaObjResolution A).d i j x = (Rep.standardComplex k G).d j i ≫ x :=
   rfl
 
 end groupCohomology
@@ -144,9 +145,9 @@ theorem d_eq :
   -- https://github.com/leanprover-community/mathlib4/issues/5026
   -- https://github.com/leanprover-community/mathlib4/issues/5164
   change d n A f g = diagonalHomEquiv (n + 1) A
-    ((resolution k G).d (n + 1) n ≫ (diagonalHomEquiv n A).symm f) g
-  rw [diagonalHomEquiv_apply, Action.comp_hom, ConcreteCategory.comp_apply, resolution.d_eq]
-  erw [resolution.d_of (Fin.partialProd g)]
+    ((standardComplex k G).d (n + 1) n ≫ (diagonalHomEquiv n A).symm f) g
+  rw [diagonalHomEquiv_apply, Action.comp_hom, ConcreteCategory.comp_apply, standardComplex.d_eq]
+  erw [standardComplex.d_of (Fin.partialProd g)]
   simp only [map_sum, ← Finsupp.smul_single_one _ ((-1 : k) ^ _)]
   -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
   erw [d_apply, @Fin.sum_univ_succ _ _ (n + 1), Fin.val_zero, pow_zero, one_smul,
@@ -248,7 +249,7 @@ abbrev groupCohomologyπ [Group G] (A : Rep k G) (n : ℕ) :
 
 /-- The `n`th group cohomology of a `k`-linear `G`-representation `A` is isomorphic to
 `Extⁿ(k, A)` (taken in `Rep k G`), where `k` is a trivial `k`-linear `G`-representation. -/
-def groupCohomologyIsoExt [Group G] (A : Rep k G) (n : ℕ) :
+def groupCohomologyIsoExt [Group G] [DecidableEq G] (A : Rep k G) (n : ℕ) :
     groupCohomology A n ≅ ((Ext k (Rep k G) n).obj (Opposite.op <| Rep.trivial k G k)).obj A :=
   isoOfQuasiIsoAt (HomotopyEquiv.ofIso (inhomogeneousCochainsIso A)).hom n ≪≫
     (extIso k G A n).symm

--- a/Mathlib/RepresentationTheory/GroupCohomology/Basic.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Basic.lean
@@ -252,4 +252,4 @@ abbrev groupCohomologyπ [Group G] (A : Rep k G) (n : ℕ) :
 def groupCohomologyIsoExt [Group G] [DecidableEq G] (A : Rep k G) (n : ℕ) :
     groupCohomology A n ≅ ((Ext k (Rep k G) n).obj (Opposite.op <| Rep.trivial k G k)).obj A :=
   isoOfQuasiIsoAt (HomotopyEquiv.ofIso (inhomogeneousCochainsIso A)).hom n ≪≫
-    (extIso k G A n).symm
+    (Rep.standardResolution.extIso k G A n).symm

--- a/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
@@ -399,7 +399,7 @@ def compForgetAugmentedIso :
       standardComplex.forget₂ToModuleCat k G :=
   eqToIso
     (Functor.congr_obj (map_alternatingFaceMapComplex (forget₂ (Rep k G) (ModuleCat.{u} k))).symm
-      (classifyingSpaceUniversalCover G ⋙ Rep.linearization k G))
+      (classifyingSpaceUniversalCover G ⋙ linearization k G))
 
 /-- As a complex of `k`-modules, the standard resolution of the trivial `G`-representation `k` is
 homotopy equivalent to the complex which is `k` at 0 and 0 elsewhere. -/
@@ -433,8 +433,7 @@ theorem forget₂ToModuleCatHomotopyEquiv_f_0_eq :
   simp [Unique.eq_default (terminal.from _), single_apply, if_pos (Subsingleton.elim _ _)]
 
 theorem d_comp_ε : (standardComplex k G).d 1 0 ≫ ε k G = 0 := by
-  ext : 1
-  refine ModuleCat.hom_ext <| LinearMap.ext fun x => ?_
+  ext : 3
   have : (forget₂ToModuleCat k G).d 1 0
       ≫ (forget₂ (Rep k G) (ModuleCat.{u} k)).map (ε k G) = 0 := by
     rw [← forget₂ToModuleCatHomotopyEquiv_f_0_eq,
@@ -467,10 +466,9 @@ instance : QuasiIso (εToSingle₀ k G) := by
   apply quasiIso_forget₂_εToSingle₀
 
 end Exactness
-
 end standardComplex
 
-open standardComplex HomologicalComplex.Hom
+open HomologicalComplex.Hom standardComplex
 
 variable [Group G] [DecidableEq G]
 
@@ -482,15 +480,15 @@ def standardResolution : ProjectiveResolution (Rep.trivial k G k) where
 @[deprecated (since := "2025-06-06")]
 alias groupCohomology.projectiveResolution := Rep.standardResolution
 
-instance : EnoughProjectives (Rep k G) :=
-  Rep.equivalenceModuleMonoidAlgebra.enoughProjectives_iff.2 ModuleCat.enoughProjectives
-
 /-- Given a `k`-linear `G`-representation `V`, `Extⁿ(k, V)` (where `k` is a trivial `k`-linear
 `G`-representation) is isomorphic to the `n`th cohomology group of `Hom(P, V)`, where `P` is the
 standard resolution of `k` called `standardComplex k G`. -/
-def _root_.groupCohomology.extIso (V : Rep k G) (n : ℕ) :
+def standardResolution.extIso (V : Rep k G) (n : ℕ) :
     ((Ext k (Rep k G) n).obj (Opposite.op <| Rep.trivial k G k)).obj V ≅
       ((standardComplex k G).linearYonedaObj k V).homology n :=
   (standardResolution k G).isoExt n V
+
+@[deprecated (since := "2025-06-06")]
+alias groupCohomology.extIso := Rep.standardResolution.extIso
 
 end Rep

--- a/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
@@ -8,22 +8,27 @@ import Mathlib.AlgebraicTopology.ExtraDegeneracy
 import Mathlib.CategoryTheory.Abelian.Ext
 import Mathlib.GroupTheory.GroupAction.Ring
 import Mathlib.RepresentationTheory.Rep
+import Mathlib.RingTheory.TensorProduct.Free
 import Mathlib.CategoryTheory.Functor.ReflectsIso.Balanced
 
 /-!
-# The standard and bar resolutions of `k` as a trivial `k`-linear `G`-representation
+# The structure of the `k[G]`-module `k[Gⁿ]`
 
-Given a commutative ring `k` and a group `G`, this file defines two projective resolutions of `k`
-as a trivial `k`-linear `G`-representation.
+This file contains facts about an important `k[G]`-module structure on `k[Gⁿ]`, where `k` is a
+commutative ring and `G` is a group. The module structure arises from the representation
+`G →* End(k[Gⁿ])` induced by the diagonal action of `G` on `Gⁿ.`
 
-The first one, the standard resolution, has objects `k[Gⁿ⁺¹]` equipped with the diagonal
-representation, and differential defined by `(g₀, ..., gₙ) ↦ ∑ (-1)ⁱ • (g₀, ..., ĝᵢ, ..., gₙ)`.
+In particular, we define an isomorphism of `k`-linear `G`-representations between `k[Gⁿ⁺¹]` and
+`k[G] ⊗ₖ k[Gⁿ]` (on which `G` acts by `ρ(g₁)(g₂ ⊗ x) = (g₁ * g₂) ⊗ x`).
 
-We define this as the alternating face map complex associated to an appropriate simplicial
-`k`-linear `G`-representation. This simplicial object is the `linearization` of the simplicial
-`G`-set given by the universal cover of the classifying space of `G`, `EG`. We prove this
-simplicial `G`-set `EG` is isomorphic to the Čech nerve of the natural arrow of `G`-sets
-`G ⟶ {pt}`.
+This allows us to define a `k[G]`-basis on `k[Gⁿ⁺¹]`, by mapping the natural `k[G]`-basis of
+`k[G] ⊗ₖ k[Gⁿ]` along the isomorphism.
+
+We then define the standard resolution of `k` as a trivial representation, by
+taking the alternating face map complex associated to an appropriate simplicial `k`-linear
+`G`-representation. This simplicial object is the `Rep.linearization` of the simplicial `G`-set
+given by the universal cover of the classifying space of `G`, `EG`. We prove this simplicial
+`G`-set `EG` is isomorphic to the Čech nerve of the natural arrow of `G`-sets `G ⟶ {pt}`.
 
 We then use this isomorphism to deduce that as a complex of `k`-modules, the standard resolution
 of `k` as a trivial `G`-representation is homotopy equivalent to the complex with `k` at 0 and 0
@@ -31,24 +36,6 @@ elsewhere.
 
 Putting this material together allows us to define `Rep.standardResolution`, the
 standard projective resolution of `k` as a trivial `k`-linear `G`-representation.
-
-We then construct the bar resolution. The `n`th object in this complex is the representation on
-`Gⁿ →₀ k[G]` defined pointwise by the left regular representation on `k[G]`. The differentials are
-defined by sending `(g₀, ..., gₙ)` to
-`g₀·(g₁, ..., gₙ) + ∑ (-1)ʲ⁺¹·(g₀, ..., gⱼgⱼ₊₁, ..., gₙ) + (-1)ⁿ⁺¹·(g₀, ..., gₙ₋₁)` for
-`j = 0, ... , n - 1`.
-
-In `RepresentationTheory.Rep` we define an isomorphism `Rep.diagonalSuccIsoFree` between
-`k[Gⁿ⁺¹] ≅ (Gⁿ →₀ k[G])` sending `(g₀, ..., gₙ) ↦ g₀·(g₀⁻¹g₁, ..., gₙ₋₁⁻¹gₙ)`.
-
-We show that this isomorphism defines a commutative square with the bar resolution differential and
-the standard resolution differential, and thus conclude that the bar resolution differential
-squares to zero and that `Rep.diagonalSuccIsoFree` defines an isomorphism between the two
-complexes. We carry the exactness properties across this isomorphism to conclude the bar resolution
-is a projective resolution too, in `Rep.barResolution`.
-
-In `RepresentationTheory.GroupCohomology.Basic`, we then use `Rep.barResolution` to define the
-inhomogeneous cochains of a representation, useful for computing group cohomology.
 
 ## Main definitions
 
@@ -352,9 +339,6 @@ def Rep.standardComplex [Monoid G] :=
   (AlgebraicTopology.alternatingFaceMapComplex (Rep k G)).obj
     (classifyingSpaceUniversalCover G ⋙ Rep.linearization k G)
 
-@[deprecated (since := "2025-06-06")]
-alias groupCohomology.resolution := Rep.standardComplex
-
 namespace Rep.standardComplex
 
 open classifyingSpaceUniversalCover AlgebraicTopology CategoryTheory.Limits
@@ -491,9 +475,6 @@ variable [Group G] [DecidableEq G]
 def standardResolution : ProjectiveResolution (Rep.trivial k G k) where
   complex := standardComplex k G
   π := εToSingle₀ k G
-
-@[deprecated (since := "2025-06-06")]
-alias groupCohomology.projectiveResolution := Rep.standardResolution
 
 instance : EnoughProjectives (Rep k G) :=
   Rep.equivalenceModuleMonoidAlgebra.enoughProjectives_iff.2 ModuleCat.enoughProjectives

--- a/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
@@ -90,33 +90,33 @@ open scoped TensorProduct
 
 open Representation
 
-@[deprecated (since := "2025-02-06")]
+@[deprecated (since := "2025-06-02")]
 alias groupCohomology.resolution.actionDiagonalSucc := Action.diagonalSuccIsoTensorTrivial
 
-@[deprecated (since := "2025-02-06")]
+@[deprecated (since := "2025-06-02")]
 alias groupCohomology.resolution.actionDiagonalSucc_hom_apply :=
   Action.diagonalSuccIsoTensorTrivial_hom_hom_apply
 
-@[deprecated (since := "2025-02-06")]
+@[deprecated (since := "2025-06-02")]
 alias groupCohomology.resolution.actionDiagonalSucc_inv_apply :=
   Action.diagonalSuccIsoTensorTrivial_inv_hom_apply
 
-@[deprecated (since := "2025-02-06")]
+@[deprecated (since := "2025-06-02")]
 alias groupCohomology.resolution.diagonalSucc := Rep.diagonalSuccIsoTensorTrivial
 
-@[deprecated (since := "2025-02-06")]
+@[deprecated (since := "2025-06-02")]
 alias groupCohomology.resolution.diagonalSucc_hom_single :=
   Rep.diagonalSuccIsoTensorTrivial_hom_hom_single
 
-@[deprecated (since := "2025-02-06")]
+@[deprecated (since := "2025-06-02")]
 alias groupCohomology.resolution.diagonalSucc_inv_single_single :=
   Rep.diagonalSuccIsoTensorTrivial_inv_hom_single_single
 
-@[deprecated (since := "2025-02-06")]
+@[deprecated (since := "2025-06-02")]
 alias groupCohomology.resolution.diagonalSucc_inv_single_left :=
   Rep.diagonalSuccIsoTensorTrivial_inv_hom_single_left
 
-@[deprecated (since := "2025-02-06")]
+@[deprecated (since := "2025-06-02")]
 alias groupCohomology.resolution.diagonalSucc_inv_single_right :=
   Rep.diagonalSuccIsoTensorTrivial_inv_hom_single_right
 
@@ -124,6 +124,7 @@ alias groupCohomology.resolution.diagonalSucc_inv_single_right :=
 the lefthand side is `TensorProduct.leftModule`, whilst that of the righthand side comes from
 `Representation.asModule`. Allows us to use `Algebra.TensorProduct.basis` to get a `k[G]`-basis
 of the righthand side. -/
+@[deprecated "We now favour `Representation.finsuppLEquivFreeAsModule`" (since := "2025-06-04")]
 def ofMulActionBasisAux :
     MonoidAlgebra k G ⊗[k] ((Fin n → G) →₀ k) ≃ₗ[MonoidAlgebra k G]
       (ofMulAction k G (Fin (n + 1) → G)).asModule :=
@@ -150,6 +151,7 @@ def ofMulActionBasisAux :
 
 /-- A `k[G]`-basis of `k[Gⁿ⁺¹]`, coming from the `k[G]`-linear isomorphism
 `k[G] ⊗ₖ k[Gⁿ] ≃ k[Gⁿ⁺¹].` -/
+@[deprecated "We now favour `Representation.freeAsModuleBasis`" (since := "2025-06-04")]
 def ofMulActionBasis :
     Basis (Fin n → G) (MonoidAlgebra k G) (ofMulAction k G (Fin (n + 1) → G)).asModule :=
   Basis.map
@@ -157,6 +159,7 @@ def ofMulActionBasis :
       (Finsupp.basisSingleOne : Basis (Fin n → G) k ((Fin n → G) →₀ k)))
     (ofMulActionBasisAux k G n)
 
+@[deprecated "We now favour `Representation.free_asModule_free`" (since := "2025-06-04")]
 theorem ofMulAction_free :
     Module.Free (MonoidAlgebra k G) (ofMulAction k G (Fin (n + 1) → G)).asModule :=
   Module.Free.of_basis (ofMulActionBasis k G n)
@@ -173,6 +176,7 @@ open groupCohomology.resolution
 
 /-- Given a `k`-linear `G`-representation `A`, the set of representation morphisms
 `Hom(k[Gⁿ⁺¹], A)` is `k`-linearly isomorphic to the set of functions `Gⁿ → A`. -/
+@[deprecated "We now favour `Rep.freeLiftEquiv`" (since := "2025-06-04")]
 noncomputable def diagonalHomEquiv :
     (Rep.diagonal k G (n + 1) ⟶ A) ≃ₗ[k] (Fin n → G) → A :=
   Linear.homCongr k

--- a/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
@@ -339,6 +339,9 @@ def Rep.standardComplex [Monoid G] :=
   (AlgebraicTopology.alternatingFaceMapComplex (Rep k G)).obj
     (classifyingSpaceUniversalCover G ⋙ Rep.linearization k G)
 
+@[deprecated (since := "2025-06-06")]
+alias groupCohomology.resolution := Rep.standardComplex
+
 namespace Rep.standardComplex
 
 open classifyingSpaceUniversalCover AlgebraicTopology CategoryTheory.Limits
@@ -476,6 +479,9 @@ def standardResolution : ProjectiveResolution (Rep.trivial k G k) where
   complex := standardComplex k G
   π := εToSingle₀ k G
 
+@[deprecated (since := "2025-06-06")]
+alias groupCohomology.projectiveResolution := Rep.standardResolution
+
 instance : EnoughProjectives (Rep k G) :=
   Rep.equivalenceModuleMonoidAlgebra.enoughProjectives_iff.2 ModuleCat.enoughProjectives
 
@@ -486,82 +492,5 @@ def _root_.groupCohomology.extIso (V : Rep k G) (n : ℕ) :
     ((Ext k (Rep k G) n).obj (Opposite.op <| Rep.trivial k G k)).obj V ≅
       ((standardComplex k G).linearYonedaObj k V).homology n :=
   (standardResolution k G).isoExt n V
-
-namespace barComplex
-
-open Rep Finsupp
-
-variable (n)
-
-/-- The differential from `Gⁿ⁺¹ →₀ k[G]` to `Gⁿ →₀ k[G]` in the bar resolution of `k` as a trivial
-`k`-linear `G`-representation. It sends `(g₀, ..., gₙ)` to
-`g₀·(g₁, ..., gₙ) + ∑ (-1)ʲ⁺¹·(g₀, ..., gⱼgⱼ₊₁, ..., gₙ) + (-1)ⁿ⁺¹·(g₀, ..., gₙ₋₁)` for
-`j = 0, ... , n - 1`. -/
-def d : free k G Gⁿ⁺¹ ⟶ free k G Gⁿ :=
-  freeLift _ fun g => single (fun i => g i.succ) (single (g 0) 1) +
-    Finset.univ.sum fun j : Fin (n + 1) =>
-      single (Fin.contractNth j (· * ·) g) (single (1 : G) ((-1 : k) ^ ((j : ℕ) + 1)))
-
-variable {k G} in
-lemma d_single (x : Gⁿ⁺¹) :
-    (d k G n).hom (single x (single 1 1)) = single (fun i => x i.succ) (Finsupp.single (x 0) 1) +
-      Finset.univ.sum fun j : Fin (n + 1) =>
-        single (Fin.contractNth j (· * ·) x)  (single (1 : G) ((-1 : k) ^ ((j : ℕ) + 1))) := by
-  simp [d]
-
-lemma d_comp_diagonalSuccIsoFree_inv_eq :
-    d k G n ≫ (diagonalSuccIsoFree k G n).inv =
-      (diagonalSuccIsoFree k G (n + 1)).inv ≫ (standardComplex k G).d (n + 1) n :=
-  free_ext _ _ fun i => by
-    have := d_single (k := k) (G := G)
-    have := @diagonalSuccIsoFree_inv_hom_single_single k G _
-    simp_all only [ModuleCat.hom_comp, Action.comp_hom, LinearMap.coe_comp, Function.comp_apply,
-      map_add, map_sum]
-    simpa [standardComplex.d_eq, standardComplex.d_of (k := k) (Fin.partialProd i),
-      Fin.sum_univ_succ, Fin.partialProd_contractNth]
-      using congr(single $(by ext j; exact (Fin.partialProd_succ' i j).symm) 1)
-
-end barComplex
-
-open barComplex
-
-/-- The projective resolution of `k` as a trivial `k`-linear `G`-representation with `n`th
-differential `(Gⁿ⁺¹ →₀ k[G]) → (Gⁿ →₀ k[G])` sending `(g₀, ..., gₙ)` to
-`g₀·(g₁, ..., gₙ) + ∑ (-1)ʲ⁺¹·(g₀, ..., gⱼgⱼ₊₁, ..., gₙ) + (-1)ⁿ⁺¹·(g₀, ..., gₙ₋₁)` for
-`j = 0, ... , n - 1`. -/
-noncomputable abbrev barComplex : ChainComplex (Rep k G) ℕ :=
-  ChainComplex.of (fun n => free k G (Fin n → G)) (fun n => d k G n) fun _ => by
-    ext x
-    simp [(diagonalSuccIsoFree k G _).comp_inv_eq.1 (d_comp_diagonalSuccIsoFree_inv_eq k G _)]
-
-namespace barComplex
-
-@[simp]
-theorem d_def : (barComplex k G).d (n + 1) n = d k G n := ChainComplex.of_d _ _ _ _
-
-/-- Isomorphism between the bar resolution and standard resolution, with `n`th map
-`(Gⁿ →₀ k[G]) → k[Gⁿ⁺¹]` sending `(g₁, ..., gₙ) ↦ (1, g₁, g₁g₂, ..., g₁...gₙ)`. -/
-def isoStandardComplex : barComplex k G ≅ standardComplex k G :=
-  HomologicalComplex.Hom.isoOfComponents (fun i => (diagonalSuccIsoFree k G i).symm) fun i j => by
-    rintro (rfl : j + 1 = i)
-    simp only [ChainComplex.of_x, Iso.symm_hom, d_def, d_comp_diagonalSuccIsoFree_inv_eq]
-
-end barComplex
-
-/-- The chain complex `barComplex k G` as a projective resolution of `k` as a trivial
-`k`-linear `G`-representation. -/
-@[simps complex]
-def barResolution : ProjectiveResolution (Rep.trivial k G k) where
-  complex := barComplex k G
-  projective n := inferInstanceAs <| Projective (free k G (Fin n → G))
-  π := (isoStandardComplex k G).hom ≫ standardComplex.εToSingle₀ k G
-
-/-- Given a `k`-linear `G`-representation `V`, `Extⁿ(k, V)` (where `k` is the trivial `k`-linear
-`G`-representation) is isomorphic to the `n`th cohomology group of `Hom(P, V)`, where `P` is the
-bar resolution of `k`. -/
-def barResolution.extIso (V : Rep k G) (n : ℕ) :
-    ((Ext k (Rep k G) n).obj (Opposite.op <| Rep.trivial k G k)).obj V ≅
-      ((barComplex k G).linearYonedaObj k V).homology n :=
-  (barResolution k G).isoExt n V
 
 end Rep

--- a/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
@@ -8,7 +8,6 @@ import Mathlib.AlgebraicTopology.ExtraDegeneracy
 import Mathlib.CategoryTheory.Abelian.Ext
 import Mathlib.GroupTheory.GroupAction.Ring
 import Mathlib.RepresentationTheory.Rep
-import Mathlib.RingTheory.TensorProduct.Free
 import Mathlib.CategoryTheory.Functor.ReflectsIso.Balanced
 
 /-!

--- a/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
@@ -8,27 +8,22 @@ import Mathlib.AlgebraicTopology.ExtraDegeneracy
 import Mathlib.CategoryTheory.Abelian.Ext
 import Mathlib.GroupTheory.GroupAction.Ring
 import Mathlib.RepresentationTheory.Rep
-import Mathlib.RingTheory.TensorProduct.Free
 import Mathlib.CategoryTheory.Functor.ReflectsIso.Balanced
 
 /-!
-# The structure of the `k[G]`-module `k[Gⁿ]`
+# The standard and bar resolutions of `k` as a trivial `k`-linear `G`-representation
 
-This file contains facts about an important `k[G]`-module structure on `k[Gⁿ]`, where `k` is a
-commutative ring and `G` is a group. The module structure arises from the representation
-`G →* End(k[Gⁿ])` induced by the diagonal action of `G` on `Gⁿ.`
+Given a commutative ring `k` and a group `G`, this file defines two projective resolutions of `k`
+as a trivial `k`-linear `G`-representation.
 
-In particular, we define an isomorphism of `k`-linear `G`-representations between `k[Gⁿ⁺¹]` and
-`k[G] ⊗ₖ k[Gⁿ]` (on which `G` acts by `ρ(g₁)(g₂ ⊗ x) = (g₁ * g₂) ⊗ x`).
+The first one, the standard resolution, has objects `k[Gⁿ⁺¹]` equipped with the diagonal
+representation, and differential defined by `(g₀, ..., gₙ) ↦ ∑ (-1)ⁱ • (g₀, ..., ĝᵢ, ..., gₙ)`.
 
-This allows us to define a `k[G]`-basis on `k[Gⁿ⁺¹]`, by mapping the natural `k[G]`-basis of
-`k[G] ⊗ₖ k[Gⁿ]` along the isomorphism.
-
-We then define the standard resolution of `k` as a trivial representation, by
-taking the alternating face map complex associated to an appropriate simplicial `k`-linear
-`G`-representation. This simplicial object is the `Rep.linearization` of the simplicial `G`-set
-given by the universal cover of the classifying space of `G`, `EG`. We prove this simplicial
-`G`-set `EG` is isomorphic to the Čech nerve of the natural arrow of `G`-sets `G ⟶ {pt}`.
+We define this as the alternating face map complex associated to an appropriate simplicial
+`k`-linear `G`-representation. This simplicial object is the `linearization` of the simplicial
+`G`-set given by the universal cover of the classifying space of `G`, `EG`. We prove this
+simplicial `G`-set `EG` is isomorphic to the Čech nerve of the natural arrow of `G`-sets
+`G ⟶ {pt}`.
 
 We then use this isomorphism to deduce that as a complex of `k`-modules, the standard resolution
 of `k` as a trivial `G`-representation is homotopy equivalent to the complex with `k` at 0 and 0
@@ -36,6 +31,24 @@ elsewhere.
 
 Putting this material together allows us to define `Rep.standardResolution`, the
 standard projective resolution of `k` as a trivial `k`-linear `G`-representation.
+
+We then construct the bar resolution. The `n`th object in this complex is the representation on
+`Gⁿ →₀ k[G]` defined pointwise by the left regular representation on `k[G]`. The differentials are
+defined by sending `(g₀, ..., gₙ)` to
+`g₀·(g₁, ..., gₙ) + ∑ (-1)ʲ⁺¹·(g₀, ..., gⱼgⱼ₊₁, ..., gₙ) + (-1)ⁿ⁺¹·(g₀, ..., gₙ₋₁)` for
+`j = 0, ... , n - 1`.
+
+In `RepresentationTheory.Rep` we define an isomorphism `Rep.diagonalSuccIsoFree` between
+`k[Gⁿ⁺¹] ≅ (Gⁿ →₀ k[G])` sending `(g₀, ..., gₙ) ↦ g₀·(g₀⁻¹g₁, ..., gₙ₋₁⁻¹gₙ)`.
+
+We show that this isomorphism defines a commutative square with the bar resolution differential and
+the standard resolution differential, and thus conclude that the bar resolution differential
+squares to zero and that `Rep.diagonalSuccIsoFree` defines an isomorphism between the two
+complexes. We carry the exactness properties across this isomorphism to conclude the bar resolution
+is a projective resolution too, in `Rep.barResolution`.
+
+In `RepresentationTheory.GroupCohomology.Basic`, we then use `Rep.barResolution` to define the
+inhomogeneous cochains of a representation, useful for computing group cohomology.
 
 ## Main definitions
 
@@ -339,6 +352,9 @@ def Rep.standardComplex [Monoid G] :=
   (AlgebraicTopology.alternatingFaceMapComplex (Rep k G)).obj
     (classifyingSpaceUniversalCover G ⋙ Rep.linearization k G)
 
+@[deprecated (since := "2025-06-06")]
+alias groupCohomology.resolution := Rep.standardComplex
+
 namespace Rep.standardComplex
 
 open classifyingSpaceUniversalCover AlgebraicTopology CategoryTheory.Limits
@@ -475,6 +491,9 @@ variable [Group G] [DecidableEq G]
 def standardResolution : ProjectiveResolution (Rep.trivial k G k) where
   complex := standardComplex k G
   π := εToSingle₀ k G
+
+@[deprecated (since := "2025-06-06")]
+alias groupCohomology.projectiveResolution := Rep.standardResolution
 
 instance : EnoughProjectives (Rep k G) :=
   Rep.equivalenceModuleMonoidAlgebra.enoughProjectives_iff.2 ModuleCat.enoughProjectives

--- a/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
+++ b/Mathlib/RepresentationTheory/GroupCohomology/Resolution.lean
@@ -34,15 +34,15 @@ We then use this isomorphism to deduce that as a complex of `k`-modules, the sta
 of `k` as a trivial `G`-representation is homotopy equivalent to the complex with `k` at 0 and 0
 elsewhere.
 
-Putting this material together allows us to define `groupCohomology.projectiveResolution`, the
+Putting this material together allows us to define `Rep.standardResolution`, the
 standard projective resolution of `k` as a trivial `k`-linear `G`-representation.
 
 ## Main definitions
 
  * `groupCohomology.resolution.ofMulActionBasis`
  * `classifyingSpaceUniversalCover`
- * `groupCohomology.resolution.forget₂ToModuleCatHomotopyEquiv`
- * `groupCohomology.projectiveResolution`
+ * `Rep.standardComplex.forget₂ToModuleCatHomotopyEquiv`
+ * `Rep.standardResolution`
 
 ## Implementation notes
 
@@ -176,7 +176,6 @@ open groupCohomology.resolution
 
 /-- Given a `k`-linear `G`-representation `A`, the set of representation morphisms
 `Hom(k[Gⁿ⁺¹], A)` is `k`-linearly isomorphic to the set of functions `Gⁿ → A`. -/
-@[deprecated "We now favour `Rep.freeLiftEquiv`" (since := "2025-06-04")]
 noncomputable def diagonalHomEquiv :
     (Rep.diagonal k G (n + 1) ⟶ A) ≃ₗ[k] (Fin n → G) → A :=
   Linear.homCongr k
@@ -341,11 +340,11 @@ variable (k)
 
 /-- The standard resolution of `k` as a trivial representation, defined as the alternating
 face map complex of a simplicial `k`-linear `G`-representation. -/
-def groupCohomology.resolution [Monoid G] :=
+def Rep.standardComplex [Monoid G] :=
   (AlgebraicTopology.alternatingFaceMapComplex (Rep k G)).obj
     (classifyingSpaceUniversalCover G ⋙ Rep.linearization k G)
 
-namespace groupCohomology.resolution
+namespace Rep.standardComplex
 
 open classifyingSpaceUniversalCover AlgebraicTopology CategoryTheory.Limits
 
@@ -371,30 +370,26 @@ variable (k G)
 
 /-- The `n`th object of the standard resolution of `k` is definitionally isomorphic to `k[Gⁿ⁺¹]`
 equipped with the representation induced by the diagonal action of `G`. -/
-def xIso (n : ℕ) : (groupCohomology.resolution k G).X n ≅ Rep.ofMulAction k G (Fin (n + 1) → G) :=
+def xIso (n : ℕ) : (standardComplex k G).X n ≅ Rep.ofMulAction k G (Fin (n + 1) → G) :=
   Iso.refl _
 
-instance x_projective (G : Type u) [Group G] (n : ℕ) :
-    Projective ((groupCohomology.resolution k G).X n) :=
-  Rep.equivalenceModuleMonoidAlgebra.toAdjunction.projective_of_map_projective _ <|
-    @ModuleCat.projective_of_free.{u} _ _
-      (ModuleCat.of (MonoidAlgebra k G) (Representation.ofMulAction k G (Fin (n + 1) → G)).asModule)
-      _ (ofMulActionBasis k G n)
+instance x_projective (G : Type u) [Group G] [DecidableEq G] (n : ℕ) :
+    Projective ((standardComplex k G).X n) :=
+  inferInstanceAs <| Projective (Rep.diagonal k G (n + 1))
 
 /-- Simpler expression for the differential in the standard resolution of `k` as a
 `G`-representation. It sends `(g₀, ..., gₙ₊₁) ↦ ∑ (-1)ⁱ • (g₀, ..., ĝᵢ, ..., gₙ₊₁)`. -/
-theorem d_eq (n : ℕ) : ((groupCohomology.resolution k G).d (n + 1) n).hom =
+theorem d_eq (n : ℕ) : ((standardComplex k G).d (n + 1) n).hom =
     ModuleCat.ofHom (d k G (n + 1)) := by
   refine ModuleCat.hom_ext <| Finsupp.lhom_ext' fun (x : Fin (n + 2) → G) => LinearMap.ext_ring ?_
-  simp [Action.ofMulAction_V, groupCohomology.resolution, SimplicialObject.δ,
+  simp [Action.ofMulAction_V, standardComplex, SimplicialObject.δ,
     ← Int.cast_smul_eq_zsmul k ((-1) ^ _ : ℤ), SimplexCategory.δ, Fin.succAboveOrderEmb]
 
 section Exactness
 
 /-- The standard resolution of `k` as a trivial representation as a complex of `k`-modules. -/
 def forget₂ToModuleCat :=
-  ((forget₂ (Rep k G) (ModuleCat.{u} k)).mapHomologicalComplex _).obj
-    (groupCohomology.resolution k G)
+  ((forget₂ (Rep k G) (ModuleCat.{u} k)).mapHomologicalComplex _).obj (standardComplex k G)
 
 /-- If we apply the free functor `Type u ⥤ ModuleCat.{u} k` to the universal cover of the
 classifying space of `G` as a simplicial set, then take the alternating face map complex, the result
@@ -403,7 +398,7 @@ is isomorphic to the standard resolution of the trivial `G`-representation `k` a
 def compForgetAugmentedIso :
     AlternatingFaceMapComplex.obj
         (SimplicialObject.Augmented.drop.obj (compForgetAugmented.toModule k G)) ≅
-      groupCohomology.resolution.forget₂ToModuleCat k G :=
+      standardComplex.forget₂ToModuleCat k G :=
   eqToIso
     (Functor.congr_obj (map_alternatingFaceMapComplex (forget₂ (Rep k G) (ModuleCat.{u} k))).symm
       (classifyingSpaceUniversalCover G ⋙ Rep.linearization k G))
@@ -411,7 +406,7 @@ def compForgetAugmentedIso :
 /-- As a complex of `k`-modules, the standard resolution of the trivial `G`-representation `k` is
 homotopy equivalent to the complex which is `k` at 0 and 0 elsewhere. -/
 def forget₂ToModuleCatHomotopyEquiv :
-    HomotopyEquiv (groupCohomology.resolution.forget₂ToModuleCat k G)
+    HomotopyEquiv (standardComplex.forget₂ToModuleCat k G)
       ((ChainComplex.single₀ (ModuleCat k)).obj ((forget₂ (Rep k G) _).obj <| Rep.trivial k G k)) :=
   (HomotopyEquiv.ofIso (compForgetAugmentedIso k G).symm).trans <|
     (SimplicialObject.Augmented.ExtraDegeneracy.homotopyEquiv
@@ -424,42 +419,22 @@ def forget₂ToModuleCatHomotopyEquiv :
 /-- The hom of `k`-linear `G`-representations `k[G¹] → k` sending `∑ nᵢgᵢ ↦ ∑ nᵢ`. -/
 def ε : Rep.ofMulAction k G (Fin 1 → G) ⟶ Rep.trivial k G k where
   hom := ModuleCat.ofHom <| Finsupp.linearCombination _ fun _ => (1 : k)
-  comm g := ModuleCat.hom_ext <| Finsupp.lhom_ext' fun _ => LinearMap.ext_ring (by
-    show
-      Finsupp.linearCombination k (fun _ => (1 : k)) (Finsupp.mapDomain _ (Finsupp.single _ _)) =
-        Finsupp.linearCombination k (fun _ => (1 : k)) (Finsupp.single _ _)
-    simp only [Finsupp.mapDomain_single, Finsupp.linearCombination_single])
+  comm _ := ModuleCat.hom_ext <| Finsupp.lhom_ext' fun _ => LinearMap.ext_ring
+    (by simp [ModuleCat.endRingEquiv])
 
 /-- The homotopy equivalence of complexes of `k`-modules between the standard resolution of `k` as
 a trivial `G`-representation, and the complex which is `k` at 0 and 0 everywhere else, acts as
 `∑ nᵢgᵢ ↦ ∑ nᵢ : k[G¹] → k` at 0. -/
 theorem forget₂ToModuleCatHomotopyEquiv_f_0_eq :
     (forget₂ToModuleCatHomotopyEquiv k G).1.f 0 = (forget₂ (Rep k G) _).map (ε k G) := by
-  show (HomotopyEquiv.hom _ ≫ HomotopyEquiv.hom _ ≫ HomotopyEquiv.hom _).f 0 = _
-  simp only [HomologicalComplex.comp_f]
-  dsimp
-  convert Category.id_comp (X := (forget₂ToModuleCat k G).X 0) _
-  · dsimp only [HomotopyEquiv.ofIso, compForgetAugmentedIso]
-    simp only [Iso.symm_hom, eqToIso.inv, HomologicalComplex.eqToHom_f, eqToHom_refl]
-  ext : 1
-  trans (linearCombination _ fun _ => (1 : k)).comp ((ModuleCat.free k).map (terminal.from _)).hom
-  · erw [Finsupp.lmapDomain_linearCombination (α := Fin 1 → G) (R := k) (α' := ⊤_ Type u)
-        (v := fun _ => (1 : k)) (v' := fun _ => (1 : k))
-        (terminal.from
-          ((classifyingSpaceUniversalCover G).obj (Opposite.op (SimplexCategory.mk 0))).V)
-        LinearMap.id fun i => rfl,
-      LinearMap.id_comp]
-    rfl
-  · rw [ModuleCat.hom_comp]
-    congr
-    · ext x
-      dsimp +unfoldPartialApp [HomotopyEquiv.ofIso,
-        Finsupp.LinearEquiv.finsuppUnique]
-      rw [@Unique.eq_default _ Types.terminalIso.toEquiv.unique x]
-      simp
-    · exact @Subsingleton.elim _ (@Unique.instSubsingleton _ (Limits.uniqueToTerminal _)) _ _
+  refine ModuleCat.hom_ext <| Finsupp.lhom_ext fun (x : Fin 1 → G) r => ?_
+  show mapDomain _ _ _ = Finsupp.linearCombination _ _ _
+  simp only [HomotopyEquiv.ofIso, Iso.symm_hom, compForgetAugmented, compForgetAugmentedIso,
+    eqToIso.inv, HomologicalComplex.eqToHom_f]
+  show mapDomain _ (single x r) _ = _
+  simp [Unique.eq_default (terminal.from _), single_apply, if_pos (Subsingleton.elim _ _)]
 
-theorem d_comp_ε : (groupCohomology.resolution k G).d 1 0 ≫ ε k G = 0 := by
+theorem d_comp_ε : (standardComplex k G).d 1 0 ≫ ε k G = 0 := by
   ext : 1
   refine ModuleCat.hom_ext <| LinearMap.ext fun x => ?_
   have : (forget₂ToModuleCat k G).d 1 0
@@ -472,8 +447,8 @@ theorem d_comp_ε : (groupCohomology.resolution k G).d 1 0 ≫ ε k G = 0 := by
 /-- The chain map from the standard resolution of `k` to `k[0]` given by `∑ nᵢgᵢ ↦ ∑ nᵢ` in
 degree zero. -/
 def εToSingle₀ :
-    groupCohomology.resolution k G ⟶ (ChainComplex.single₀ _).obj (Rep.trivial k G k) :=
-  ((groupCohomology.resolution k G).toSingle₀Equiv _).symm ⟨ε k G, d_comp_ε k G⟩
+    standardComplex k G ⟶ (ChainComplex.single₀ _).obj (Rep.trivial k G k) :=
+  ((standardComplex k G).toSingle₀Equiv _).symm ⟨ε k G, d_comp_ε k G⟩
 
 theorem εToSingle₀_comp_eq :
     ((forget₂ _ (ModuleCat.{u} k)).mapHomologicalComplex _).map (εToSingle₀ k G) ≫
@@ -495,15 +470,15 @@ instance : QuasiIso (εToSingle₀ k G) := by
 
 end Exactness
 
-end groupCohomology.resolution
+end standardComplex
 
-open groupCohomology.resolution HomologicalComplex.Hom
+open standardComplex HomologicalComplex.Hom
 
-variable [Group G]
+variable [Group G] [DecidableEq G]
 
 /-- The standard projective resolution of `k` as a trivial `k`-linear `G`-representation. -/
-def groupCohomology.projectiveResolution : ProjectiveResolution (Rep.trivial k G k) where
-  complex := resolution k G
+def standardResolution : ProjectiveResolution (Rep.trivial k G k) where
+  complex := standardComplex k G
   π := εToSingle₀ k G
 
 instance : EnoughProjectives (Rep k G) :=
@@ -511,8 +486,10 @@ instance : EnoughProjectives (Rep k G) :=
 
 /-- Given a `k`-linear `G`-representation `V`, `Extⁿ(k, V)` (where `k` is a trivial `k`-linear
 `G`-representation) is isomorphic to the `n`th cohomology group of `Hom(P, V)`, where `P` is the
-standard resolution of `k` called `groupCohomology.resolution k G`. -/
-def groupCohomology.extIso (V : Rep k G) (n : ℕ) :
+standard resolution of `k` called `standardComplex k G`. -/
+def _root_.groupCohomology.extIso (V : Rep k G) (n : ℕ) :
     ((Ext k (Rep k G) n).obj (Opposite.op <| Rep.trivial k G k)).obj V ≅
-      ((groupCohomology.resolution k G).linearYonedaObj k V).homology n :=
-  (groupCohomology.projectiveResolution k G).isoExt n V
+      ((standardComplex k G).linearYonedaObj k V).homology n :=
+  (standardResolution k G).isoExt n V
+
+end Rep

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -8,6 +8,7 @@ import Mathlib.Algebra.Category.ModuleCat.EpiMono
 import Mathlib.Algebra.Category.ModuleCat.Limits
 import Mathlib.Algebra.Category.ModuleCat.Colimits
 import Mathlib.Algebra.Category.ModuleCat.Monoidal.Symmetric
+import Mathlib.Algebra.Category.ModuleCat.Projective
 import Mathlib.CategoryTheory.Elementwise
 import Mathlib.CategoryTheory.Action.Monoidal
 import Mathlib.RepresentationTheory.Basic
@@ -296,6 +297,25 @@ noncomputable abbrev leftRegular : Rep k G :=
 /-- The `k`-linear `G`-representation on `k[Gⁿ]`, induced by left multiplication. -/
 noncomputable abbrev diagonal (n : ℕ) : Rep k G :=
   ofMulAction k G (Fin n → G)
+
+/-- The natural isomorphism between the representations on `k[G¹]` and `k[G]` induced by left
+multiplication in `G`. -/
+@[simps! hom_hom inv_hom]
+def diagonalOneIsoLeftRegular :
+    diagonal k G 1 ≅ leftRegular k G :=
+  Action.mkIso (Finsupp.domLCongr <| Equiv.funUnique (Fin 1) G).toModuleIso fun _ =>
+    ModuleCat.hom_ext <| Finsupp.lhom_ext fun _ _ => by simp [diagonal, ModuleCat.endRingEquiv]
+
+/-- When `H = {1}`, the `G`-representation on `k[H]` induced by an action of `G` on `H` is
+isomorphic to the trivial representation on `k`. -/
+@[simps! hom_hom inv_hom]
+def ofMulActionSubsingletonIsoTrivial
+    (H : Type u) [Subsingleton H] [MulOneClass H] [MulAction G H] :
+    ofMulAction k G H ≅ trivial k G k :=
+  letI : Unique H := uniqueOfSubsingleton 1
+  Action.mkIso (Finsupp.LinearEquiv.finsuppUnique _ _ _).toModuleIso fun _ =>
+    ModuleCat.hom_ext <| Finsupp.lhom_ext fun _ _ => by
+      simp [Subsingleton.elim _ (1 : H), ModuleCat.endRingEquiv]
 
 /-- The linearization of a type `H` with a `G`-action is definitionally isomorphic to the
 `k`-linear `G`-representation on `k[H]` induced by the `G`-action on `H`. -/
@@ -824,5 +844,31 @@ def equivalenceModuleMonoidAlgebra : Rep k G ≌ ModuleCat.{u} (MonoidAlgebra k 
 
 -- TODO Verify that the equivalence with `ModuleCat (MonoidAlgebra k G)` is a monoidal functor.
 end
+instance : EnoughProjectives (Rep k G) :=
+  equivalenceModuleMonoidAlgebra.enoughProjectives_iff.2 ModuleCat.enoughProjectives.{u}
 
+instance free_projective {G α : Type u} [Group G] :
+    Projective (free k G α) :=
+  equivalenceModuleMonoidAlgebra.toAdjunction.projective_of_map_projective _ <|
+    @ModuleCat.projective_of_free.{u} _ _
+      (ModuleCat.of (MonoidAlgebra k G) (Representation.free k G α).asModule)
+      _ (Representation.freeAsModuleBasis k G α)
+
+section
+
+variable {G : Type u} [Group G] {n : ℕ} [DecidableEq (Fin n → G)]
+
+instance diagonal_succ_projective :
+    Projective (diagonal k G (n + 1)) :=
+  Projective.of_iso (diagonalSuccIsoFree k G n).symm inferInstance
+
+instance leftRegular_projective :
+    Projective (leftRegular k G) :=
+  Projective.of_iso (diagonalOneIsoLeftRegular k G) inferInstance
+
+instance trivial_projective_of_subsingleton [Subsingleton G] :
+    Projective (trivial k G k) :=
+  Projective.of_iso (ofMulActionSubsingletonIsoTrivial _ _ (Fin 1 → G)) diagonal_succ_projective
+
+end
 end Rep

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -844,6 +844,7 @@ def equivalenceModuleMonoidAlgebra : Rep k G ≌ ModuleCat.{u} (MonoidAlgebra k 
 
 -- TODO Verify that the equivalence with `ModuleCat (MonoidAlgebra k G)` is a monoidal functor.
 end
+
 instance : EnoughProjectives (Rep k G) :=
   equivalenceModuleMonoidAlgebra.enoughProjectives_iff.2 ModuleCat.enoughProjectives.{u}
 


### PR DESCRIPTION
The second of 3 PRs refactoring group cohomology to use the bar resolution. Given a comm ring `k` and a group `G`, this is the projective resolution of `k` as a trivial `G`-representation whose `n`th object is 
`Gⁿ →₀ k[G]` with representation defined pointwise by the left regular representation on k[G], and whose differentials send `(g₀, ..., gₙ)` to `g₀·(g₁, ..., gₙ) + ∑ (-1)ʲ⁺¹·(g₀, ..., gⱼgⱼ₊₁, ..., gₙ) + (-1)ⁿ⁺¹·(g₀, ..., gₙ₋₁)` for `j = 0, ... , n - 1`.
The refactor means we can reuse this material to set up group homology.

In #21736  we defined an isomorphism `Rep.diagonalSuccIsoFree` between the objects in the standard resolution and bar resolution. In the next PR, #21738, we show that this isomorphism defines a commutative square with the respective differentials, and thus conclude that the bar resolution differential squares to zero and that the 2 complexes are isomorphic. We carry the exactness properties across this isomorphism to conclude the bar resolution is a projective resolution too, in `Rep.barResolution`.

In this PR we factor out some material from #21738, to make it easier to review.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
