### PR TITLE
chore(CategoryTheory/Limits/Shape/End): define coends

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Shapes/End.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/End.lean
@@ -12,12 +12,11 @@ In this file, given a functor `F : Jᵒᵖ ⥤ J ⥤ C`, we define its end `end_
 which is a suitable multiequalizer of the objects `(F.obj (op j)).obj j` for all `j : J`.
 For this shape of limits, cones are named wedges: the corresponding type is `Wedge F`.
 
+We also introduce `coend_ F` as multicoequalizers of
+`(F.obj (op j)).obj j` for all `j : J`. In this cases, cocones are named cowedges.
+
 ## References
 * https://ncatlab.org/nlab/show/end
-
-## TODO
-
-* define coends
 
 -/
 
@@ -41,6 +40,15 @@ def multicospanShapeEnd : MulticospanShape where
   fst f := f.left
   snd f := f.right
 
+variable (J) in
+/-- The shape of multicoequalizer diagrams involved in the definition of coends. -/
+@[simps]
+def multispanShapeCoend : MultispanShape where
+  L := Arrow J
+  R := J
+  fst f := f.left
+  snd f := f.right
+
 /-- Given `F : Jᵒᵖ ⥤ J ⥤ C`, this is the multicospan index which shall be used
 to define the end of `F`. -/
 @[simps]
@@ -49,6 +57,15 @@ def multicospanIndexEnd : MulticospanIndex (multicospanShapeEnd J) C where
   right f := (F.obj (op f.left)).obj f.right
   fst f := (F.obj (op f.left)).map f.hom
   snd f := (F.map f.hom.op).app f.right
+
+/-- Given `F : Jᵒᵖ ⥤ J ⥤ C`, this is the multispan used to define the coend
+of `F`. -/
+@[simps]
+def multispanIndexCoend : MultispanIndex (multispanShapeCoend J) C where
+  left f := (F.obj (op f.right)).obj f.left
+  right j := (F.obj (op j)).obj j
+  fst f := (F.map f.hom.op).app f.left
+  snd f := (F.obj (op f.right)).map f.hom
 
 /-- Given `F : Jᵒᵖ ⥤ J ⥤ C`, a wedge for `F` is a type of cones (specifically
 the type of multiforks for `multicospanIndexEnd F`):
@@ -104,6 +121,59 @@ end IsLimit
 
 end Wedge
 
+/-- Given `F : Jᵒᵖ ⥤ J ⥤ C`, a cowedge for `F` is a type of cocones
+(specifically the type of multicoforks for `multispanIndexCoend F`):
+the point of a universal cowedge is the coend of `F`. -/
+abbrev Cowedge := Multicofork (multispanIndexCoend F)
+
+namespace Cowedge
+
+variable {F}
+
+section Constructor
+
+variable (pt : C) (ι : ∀ (j : J), (F.obj (op j)).obj j ⟶ pt)
+  (hι : ∀ ⦃i j : J⦄ (f : i ⟶ j), (F.map f.op).app i ≫ ι i = (F.obj (op j)).map f ≫ ι j)
+
+/-- Constructor for wedges. -/
+@[simps! pt]
+abbrev mk : Cowedge F :=
+  Multicofork.ofπ _ pt ι (fun f ↦ hι f.hom)
+
+@[simp]
+lemma mk_π (j : J) : (mk pt ι hι).π j = ι j := rfl
+
+end Constructor
+
+@[reassoc]
+lemma condition (c : Cowedge F) {i j : J} (f : i ⟶ j) :
+    (F.map f.op).app i ≫ c.π i = (F.obj (op j)).map f ≫ c.π j :=
+  Multicofork.condition c (Arrow.mk f)
+
+namespace IsColimit
+
+variable {c : Cowedge F} (hc : IsColimit c)
+
+lemma hom_ext (hc : IsColimit c) {X : C} {f g : c.pt ⟶ X} (h : ∀ j, c.π j ≫ f = c.π j ≫ g) :
+    f = g :=
+  Multicofork.IsColimit.hom_ext hc h
+
+/-- Construct a morphism from the coend using its universal property. -/
+def desc (hc : IsColimit c) {X : C} (f : ∀ j, (F.obj (op j)).obj j ⟶ X)
+    (hf : ∀ ⦃i j : J⦄ (g : i ⟶ j), (F.map g.op).app i ≫ f i = (F.obj (op j)).map g ≫ f j) :
+    c.pt ⟶ X :=
+  Multicofork.IsColimit.desc hc f (fun _ ↦ hf _)
+
+@[reassoc (attr := simp)]
+lemma π_desc (hc : IsColimit c) {X : C} (f : ∀ j, (F.obj (op j)).obj j ⟶ X)
+    (hf : ∀ ⦃i j : J⦄ (g : i ⟶ j), (F.map g.op).app i ≫ f i = (F.obj (op j)).map g ≫ f j) (j : J) :
+    c.π j ≫ desc hc f hf = f j := by
+  apply IsColimit.fac
+
+end IsColimit
+
+end Cowedge
+
 section End
 
 /-- Given `F : Jᵒᵖ ⥤ J ⥤ C`, this property asserts the existence of the end of `F`. -/
@@ -126,9 +196,12 @@ lemma end_.condition {i j : J} (f : i ⟶ j) :
 variable {F}
 
 @[ext]
-lemma hom_ext {X : C} {f g : X ⟶ end_ F} (h : ∀ j, f ≫ end_.π F j = g ≫ end_.π F j) :
+lemma end_.hom_ext {X : C} {f g : X ⟶ end_ F} (h : ∀ j, f ≫ end_.π F j = g ≫ end_.π F j) :
     f = g :=
   Multiequalizer.hom_ext _ _ _ (fun _ ↦ h _)
+
+@[deprecated (since := "2025-06-06")] alias _root_.CategoryTheory.Limits.hom_ext :=
+  end_.hom_ext
 
 section
 
@@ -146,6 +219,50 @@ lemma end_.lift_π (j : J) : lift f hf ≫ π F j = f j := by
 end
 
 end End
+
+section Coend
+
+/-- Given `F : Jᵒᵖ ⥤ J ⥤ C`, this property asserts the existence of the end of `F`. -/
+abbrev HasCoend := HasMulticoequalizer (multispanIndexCoend F)
+
+variable [HasCoend F]
+
+/-- The end of a functor `F : Jᵒᵖ ⥤ J ⥤ C`. -/
+noncomputable def coend_ : C := multicoequalizer (multispanIndexCoend F)
+
+/-- Given `F : Jᵒᵖ ⥤ J ⥤ C`, this is the inclusion `(F.obj (op j)).obj j ⟶ coend_ F`
+for any `j : J`. -/
+noncomputable def coend_.ι (j : J) : (F.obj (op j)).obj j ⟶ coend_ F :=
+  Multicoequalizer.π (multispanIndexCoend F) _
+
+@[reassoc]
+lemma coend_.condition {i j : J} (f : i ⟶ j) :
+     (F.map f.op).app i ≫ ι F i  = (F.obj (op j)).map f ≫ ι F j := by
+  apply Cowedge.condition
+
+variable {F}
+
+@[ext]
+lemma coend_.hom_ext {X : C} {f g : coend_ F ⟶ X} (h : ∀ j, coend_.ι F j ≫ f = coend_.ι F j ≫ g) :
+    f = g :=
+  Multicoequalizer.hom_ext _ _ _ (fun _ ↦ h _)
+
+section
+
+variable {X : C} (f : ∀ j, (F.obj (op j)).obj j ⟶ X)
+  (hf : ∀ ⦃i j : J⦄ (g : i ⟶ j), (F.map g.op).app i ≫ f i = (F.obj (op j)).map g ≫ f j)
+
+/-- Constructor for morphisms to the end of a functor. -/
+noncomputable def coend_.desc : coend_ F ⟶ X :=
+  Cowedge.IsColimit.desc (colimit.isColimit _) f hf
+
+@[reassoc (attr := simp)]
+lemma coend_.ι_desc (j : J) : ι F j ≫ desc f hf = f j := by
+  apply IsColimit.fac
+
+end
+
+end Coend
 
 end Limits
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/End.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/End.lean
@@ -12,7 +12,7 @@ In this file, given a functor `F : Jᵒᵖ ⥤ J ⥤ C`, we define its end `end_
 which is a suitable multiequalizer of the objects `(F.obj (op j)).obj j` for all `j : J`.
 For this shape of limits, cones are named wedges: the corresponding type is `Wedge F`.
 
-We also introduce `coend_ F` as multicoequalizers of
+We also introduce `coend F` as multicoequalizers of
 `(F.obj (op j)).obj j` for all `j : J`. In this cases, cocones are named cowedges.
 
 ## References
@@ -228,22 +228,22 @@ abbrev HasCoend := HasMulticoequalizer (multispanIndexCoend F)
 variable [HasCoend F]
 
 /-- The end of a functor `F : Jᵒᵖ ⥤ J ⥤ C`. -/
-noncomputable def coend_ : C := multicoequalizer (multispanIndexCoend F)
+noncomputable def coend : C := multicoequalizer (multispanIndexCoend F)
 
-/-- Given `F : Jᵒᵖ ⥤ J ⥤ C`, this is the inclusion `(F.obj (op j)).obj j ⟶ coend_ F`
+/-- Given `F : Jᵒᵖ ⥤ J ⥤ C`, this is the inclusion `(F.obj (op j)).obj j ⟶ coend F`
 for any `j : J`. -/
-noncomputable def coend_.ι (j : J) : (F.obj (op j)).obj j ⟶ coend_ F :=
+noncomputable def coend.ι (j : J) : (F.obj (op j)).obj j ⟶ coend F :=
   Multicoequalizer.π (multispanIndexCoend F) _
 
 @[reassoc]
-lemma coend_.condition {i j : J} (f : i ⟶ j) :
+lemma coend.condition {i j : J} (f : i ⟶ j) :
      (F.map f.op).app i ≫ ι F i  = (F.obj (op j)).map f ≫ ι F j := by
   apply Cowedge.condition
 
 variable {F}
 
 @[ext]
-lemma coend_.hom_ext {X : C} {f g : coend_ F ⟶ X} (h : ∀ j, coend_.ι F j ≫ f = coend_.ι F j ≫ g) :
+lemma coend.hom_ext {X : C} {f g : coend F ⟶ X} (h : ∀ j, coend.ι F j ≫ f = coend.ι F j ≫ g) :
     f = g :=
   Multicoequalizer.hom_ext _ _ _ (fun _ ↦ h _)
 
@@ -253,11 +253,11 @@ variable {X : C} (f : ∀ j, (F.obj (op j)).obj j ⟶ X)
   (hf : ∀ ⦃i j : J⦄ (g : i ⟶ j), (F.map g.op).app i ≫ f i = (F.obj (op j)).map g ≫ f j)
 
 /-- Constructor for morphisms to the end of a functor. -/
-noncomputable def coend_.desc : coend_ F ⟶ X :=
+noncomputable def coend.desc : coend F ⟶ X :=
   Cowedge.IsColimit.desc (colimit.isColimit _) f hf
 
 @[reassoc (attr := simp)]
-lemma coend_.ι_desc (j : J) : ι F j ≫ desc f hf = f j := by
+lemma coend.ι_desc (j : J) : ι F j ≫ desc f hf = f j := by
   apply IsColimit.fac
 
 end

--- a/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
@@ -601,13 +601,26 @@ def IsColimit.mk (desc : ∀ E : Multicofork I, K.pt ⟶ E.pt)
       intro i
       apply hm }
 
-variable {K} in
+variable {K}
+
 lemma IsColimit.hom_ext (hK : IsColimit K) {T : C} {f g : K.pt ⟶ T}
     (h : ∀ a, K.π a ≫ f = K.π a ≫ g) : f = g := by
   apply hK.hom_ext
   rintro (_ | _) <;> simp [h]
 
-variable [HasCoproduct I.left] [HasCoproduct I.right]
+/-- Constructor for morphisms from the point of a colimit multicofork. -/
+def IsColimit.desc (hK : IsColimit K) {T : C} (k : ∀ a, I.right a ⟶ T)
+    (hk : ∀ b, I.fst b ≫ k (J.fst b) = I.snd b ≫ k (J.snd b)) :
+    K.pt ⟶ T :=
+  hK.desc (Multicofork.ofπ _ _ k hk)
+
+@[reassoc (attr := simp)]
+lemma IsColimit.fac (hK : IsColimit K) {T : C} (k : ∀ a, I.right a ⟶ T)
+    (hk : ∀ b, I.fst b ≫ k (J.fst b) = I.snd b ≫ k (J.snd b)) (a : J.R) :
+    K.π a ≫ IsColimit.desc hK k hk = k a :=
+  hK.fac _ _
+
+variable (K) [HasCoproduct I.left] [HasCoproduct I.right]
 
 @[reassoc (attr := simp)]
 theorem sigma_condition : I.fstSigmaMap ≫ Sigma.desc K.π = I.sndSigmaMap ≫ Sigma.desc K.π := by


### PR DESCRIPTION
The content of `CategoryTheory/Limits/Shapes/End` was not dualized, so only ends where defined, but not coends.

This PR dualizes the content of the file: we introduce `Cowedge`s as special kinds of `Multicofork`s, and define the `coend_ F` as the colimit of a canonical cowedge we can build from `F : Jᵒᵖ ⥤ J ⥤ C`.
Also, we rename `CategoryTheory.Limits.hom_ext` to `CategoryTheory.Limits.end_.hom_ext`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
