### PR TITLE
[Merged by Bors] - chore: split Mathlib/Topology/Algebra/RestrictedProduct

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5990,7 +5990,8 @@ import Mathlib.Topology.Algebra.PontryaginDual
 import Mathlib.Topology.Algebra.ProperAction.Basic
 import Mathlib.Topology.Algebra.ProperAction.ProperlyDiscontinuous
 import Mathlib.Topology.Algebra.ProperConstSMul
-import Mathlib.Topology.Algebra.RestrictedProduct
+import Mathlib.Topology.Algebra.RestrictedProduct.Basic
+import Mathlib.Topology.Algebra.RestrictedProduct.TopologicalSpace
 import Mathlib.Topology.Algebra.Ring.Basic
 import Mathlib.Topology.Algebra.Ring.Compact
 import Mathlib.Topology.Algebra.Ring.Ideal

--- a/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
+++ b/Mathlib/RingTheory/DedekindDomain/FiniteAdeleRing.lean
@@ -5,7 +5,7 @@ Authors: María Inés de Frutos-Fernández
 -/
 import Mathlib.RingTheory.DedekindDomain.AdicValuation
 import Mathlib.RingTheory.DedekindDomain.Factorization
-import Mathlib.Topology.Algebra.RestrictedProduct
+import Mathlib.Topology.Algebra.RestrictedProduct.TopologicalSpace
 
 /-!
 # The finite adèle ring of a Dedekind domain

--- a/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
@@ -1,0 +1,398 @@
+/-
+Copyright (c) 2025 Anatole Dedecker. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anatole Dedecker
+-/
+import Mathlib.Algebra.Ring.Pi
+import Mathlib.Algebra.Ring.Subring.Defs
+import Mathlib.GroupTheory.GroupAction.SubMulAction
+import Mathlib.Order.Filter.Cofinite -- for `Πʳ i, [R i, A i]` notation, confuses shake
+
+/-!
+# Restricted products of sets, groups and rings
+
+We define the **restricted product** of `R : ι → Type*` of types, relative to
+a family of subsets `A : (i : ι) → Set (R i)` and a filter `𝓕 : Filter ι`. This
+is the set of all `x : Π i, R i` such that the set `{j | x j ∈ A j}` belongs to `𝓕`.
+We denote it by `Πʳ i, [R i, A i]_[𝓕]`.
+
+The main case of interest, which we shall refer to as the "classical restricted product",
+is that of `𝓕 = cofinite`. Recall that this is the filter of all subsets of `ι`, which are
+*cofinite* in the sense that they have finite complement.
+Hence, the associated restricted product is the set of all `x : Π i, R i` such that
+`x j ∈ A j` for all but finitely many `j`s. We denote it simply by `Πʳ i, [R i, A i]`.
+
+Another notable case is that of the principal filter `𝓕 = 𝓟 s` corresponding to some subset `s`
+of `ι`. The associated restricted product `Πʳ i, [R i, A i]_[𝓟 s]` is the set of all
+`x : Π i, R i` such that `x j ∈ A j` for all `j ∈ s`. Put another way, this is just
+`(Π i ∈ s, A i) × (Π i ∉ s, R i)`, modulo the obvious isomorphism.
+
+We endow these types with the obvious algebraic structures. We also show various compatibility
+results.
+
+See also the file Mathlib.Topology.Algebra.RestrictedProduct.TopologicalSpace , which
+puts the structure of a topological space on a restricted product of topological spaces.
+
+## Main definitions
+
+* `RestrictedProduct`: the restricted product of a family `R` of types, relative to a family `A` of
+  subsets and a filter `𝓕` on the indexing set. This is denoted `Πʳ i, [R i, A i]_[𝓕]`,
+  or simply `Πʳ i, [R i, A i]` when `𝓕 = cofinite`.
+* `RestrictedProduct.instDFunLike`: interpret an element of `Πʳ i, [R i, A i]_[𝓕]` as an element
+  of `Π i, R i` using the `DFunLike` machinery.
+* `RestrictedProduct.structureMap`: the inclusion map from `Π i, A i` to `Πʳ i, [R i, A i]_[𝓕]`.
+
+## Notation
+
+* `Πʳ i, [R i, A i]_[𝓕]` is `RestrictedProduct R A 𝓕`.
+* `Πʳ i, [R i, A i]` is `RestrictedProduct R A cofinite`.
+
+## Tags
+
+restricted product, adeles, ideles
+-/
+
+open Set Filter
+
+variable {ι : Type*}
+variable (R : ι → Type*) (A : (i : ι) → Set (R i))
+
+/-!
+## Definition and elementary maps
+-/
+
+/-- The **restricted product** of a family `R : ι → Type*` of types, relative to subsets
+`A : (i : ι) → Set (R i)` and the filter `𝓕 : Filter ι`, is the set of all `x : Π i, R i`
+such that the set `{j | x j ∈ A j}` belongs to `𝓕`. We denote it by `Πʳ i, [R i, A i]_[𝓕]`.
+
+The most common use case is with `𝓕 = cofinite`, in which case the restricted product is the set
+of all `x : Π i, R i` such that `x j ∈ A j` for all but finitely many `j`. We denote it simply
+by `Πʳ i, [R i, A i]`.
+
+Similarly, if `S` is a principal filter, the restricted product `Πʳ i, [R i, A i]_[𝓟 s]`
+is the set of all `x : Π i, R i` such that `∀ j ∈ S, x j ∈ A j`. -/
+def RestrictedProduct (𝓕 : Filter ι) : Type _ := {x : Π i, R i // ∀ᶠ i in 𝓕, x i ∈ A i}
+
+open Batteries.ExtendedBinder
+
+/-- `Πʳ i, [R i, A i]_[𝓕]` is `RestrictedProduct R A 𝓕`. -/
+scoped[RestrictedProduct]
+notation3 "Πʳ "(...)", ""["r:(scoped R => R)", "a:(scoped A => A)"]_[" f "]" =>
+  RestrictedProduct r a f
+
+/-- `Πʳ i, [R i, A i]` is `RestrictedProduct R A cofinite`. -/
+scoped[RestrictedProduct]
+notation3"Πʳ "(...)", ""["r:(scoped R => R)", "a:(scoped A => A)"]" =>
+  RestrictedProduct r a cofinite
+
+namespace RestrictedProduct
+
+open scoped RestrictedProduct
+
+variable {𝓕 𝓖 : Filter ι}
+
+instance : DFunLike (Πʳ i, [R i, A i]_[𝓕]) ι R where
+  coe x i := x.1 i
+  coe_injective' _ _ := Subtype.ext
+
+@[ext]
+lemma ext {x y :  Πʳ i, [R i, A i]_[𝓕]} (h : ∀ i, x i = y i) : x = y :=
+  Subtype.ext <| funext h
+
+lemma range_coe :
+    range ((↑) : Πʳ i, [R i, A i]_[𝓕] → Π i, R i) = {x | ∀ᶠ i in 𝓕, x i ∈ A i} :=
+  Subtype.range_val_subtype
+
+lemma range_coe_principal {S : Set ι} :
+    range ((↑) : Πʳ i, [R i, A i]_[𝓟 S] → Π i, R i) = S.pi A :=
+  range_coe R A
+
+@[simp] lemma eventually (x : Πʳ i, [R i, A i]_[𝓕]) : ∀ᶠ i in 𝓕, x i ∈ A i := x.2
+
+variable (𝓕) in
+/-- The *structure map* of the restricted product is the obvious inclusion from `Π i, A i`
+into `Πʳ i, [R i, A i]_[𝓕]`. -/
+def structureMap (x : Π i, A i) : Πʳ i, [R i, A i]_[𝓕] :=
+  ⟨fun i ↦ x i, .of_forall fun i ↦ (x i).2⟩
+
+/-- If `𝓕 ≤ 𝓖`, the restricted product `Πʳ i, [R i, A i]_[𝓖]` is naturally included in
+`Πʳ i, [R i, A i]_[𝓕]`. This is the corresponding map. -/
+def inclusion (h : 𝓕 ≤ 𝓖) (x : Πʳ i, [R i, A i]_[𝓖]) :
+    Πʳ i, [R i, A i]_[𝓕] :=
+  ⟨x, x.2.filter_mono h⟩
+
+variable (𝓕) in
+lemma inclusion_eq_id : inclusion R A (le_refl 𝓕) = id := rfl
+
+lemma exists_inclusion_eq_of_eventually (h : 𝓕 ≤ 𝓖) {x : Πʳ i, [R i, A i]_[𝓕]}
+    (hx𝓖 : ∀ᶠ i in 𝓖, x i ∈ A i) :
+    ∃ x' : Πʳ i, [R i, A i]_[𝓖], inclusion R A h x' = x :=
+  ⟨⟨x.1, hx𝓖⟩, rfl⟩
+
+lemma exists_structureMap_eq_of_forall {x : Πʳ i, [R i, A i]_[𝓕]}
+    (hx : ∀ i, x.1 i ∈ A i) :
+    ∃ x' : Π i, A i, structureMap R A 𝓕 x' = x :=
+  ⟨fun i ↦ ⟨x i, hx i⟩, rfl⟩
+
+lemma range_inclusion (h : 𝓕 ≤ 𝓖) :
+    Set.range (inclusion R A h) = {x | ∀ᶠ i in 𝓖, x i ∈ A i} :=
+  subset_antisymm (range_subset_iff.mpr fun x ↦ x.2)
+    (fun _ hx ↦ mem_range.mpr <| exists_inclusion_eq_of_eventually R A h hx)
+
+lemma range_structureMap :
+    Set.range (structureMap R A 𝓕) = {f | ∀ i, f.1 i ∈ A i} :=
+  subset_antisymm (range_subset_iff.mpr fun x i ↦ (x i).2)
+    (fun _ hx ↦ mem_range.mpr <| exists_structureMap_eq_of_forall R A hx)
+
+section Algebra
+/-!
+## Algebraic instances on restricted products
+
+In this section, we endow the restricted product with its algebraic instances.
+To avoid any unnecessary coercions, we use subobject classes for the subset `B i` of each `R i`.
+-/
+
+variable {S : ι → Type*} -- subobject type
+variable [Π i, SetLike (S i) (R i)]
+variable {B : Π i, S i}
+
+@[to_additive]
+instance [Π i, One (R i)] [∀ i, OneMemClass (S i) (R i)] : One (Πʳ i, [R i, B i]_[𝓕]) where
+  one := ⟨fun _ ↦ 1, .of_forall fun _ ↦ one_mem _⟩
+
+@[to_additive (attr := simp)]
+lemma one_apply [Π i, One (R i)] [∀ i, OneMemClass (S i) (R i)] (i : ι) :
+    (1 : Πʳ i, [R i, B i]_[𝓕]) i = 1 :=
+  rfl
+
+@[to_additive]
+instance [Π i, Inv (R i)] [∀ i, InvMemClass (S i) (R i)] : Inv (Πʳ i, [R i, B i]_[𝓕]) where
+  inv x := ⟨fun i ↦ (x i)⁻¹, x.2.mono fun _ ↦ inv_mem⟩
+
+@[to_additive (attr := simp)]
+lemma inv_apply [Π i, Inv (R i)] [∀ i, InvMemClass (S i) (R i)]
+    (x : Πʳ i, [R i, B i]_[𝓕]) (i : ι) : (x⁻¹) i = (x i)⁻¹ :=
+  rfl
+
+@[to_additive]
+instance [Π i, Mul (R i)] [∀ i, MulMemClass (S i) (R i)] : Mul (Πʳ i, [R i, B i]_[𝓕]) where
+  mul x y := ⟨fun i ↦ x i * y i, y.2.mp (x.2.mono fun _ ↦ mul_mem)⟩
+
+@[to_additive (attr := simp)]
+lemma mul_apply [Π i, Mul (R i)] [∀ i, MulMemClass (S i) (R i)]
+    (x y : Πʳ i, [R i, B i]_[𝓕]) (i : ι) : (x * y) i = x i * y i :=
+  rfl
+
+@[to_additive]
+instance {G : Type*} [Π i, SMul G (R i)] [∀ i, SMulMemClass (S i) G (R i)] :
+    SMul G (Πʳ i, [R i, B i]_[𝓕]) where
+  smul g x := ⟨fun i ↦ g • (x i), x.2.mono fun _ ↦ SMulMemClass.smul_mem g⟩
+
+@[to_additive (attr := simp)]
+lemma smul_apply {G : Type*} [Π i, SMul G (R i)] [∀ i, SMulMemClass (S i) G (R i)] (g : G)
+    (x : Πʳ i, [R i, B i]_[𝓕]) (i : ι) : (g • x) i = g • x i :=
+  rfl
+
+@[to_additive]
+instance [Π i, DivInvMonoid (R i)] [∀ i, SubgroupClass (S i) (R i)] :
+    Div (Πʳ i, [R i, B i]_[𝓕]) where
+  div x y := ⟨fun i ↦ x i / y i, y.2.mp (x.2.mono fun _ ↦ div_mem)⟩
+
+@[to_additive (attr := simp)]
+lemma div_apply [Π i, DivInvMonoid (R i)] [∀ i, SubgroupClass (S i) (R i)]
+    (x y : Πʳ i, [R i, B i]_[𝓕]) (i : ι) : (x / y) i = x i / y i :=
+  rfl
+
+instance [Π i, Monoid (R i)] [∀ i, SubmonoidClass (S i) (R i)] :
+    Pow (Πʳ i, [R i, B i]_[𝓕]) ℕ where
+  pow x n := ⟨fun i ↦ x i ^ n, x.2.mono fun _ hi ↦ pow_mem hi n⟩
+
+lemma pow_apply [Π i, Monoid (R i)] [∀ i, SubmonoidClass (S i) (R i)]
+    (x : Πʳ i, [R i, B i]_[𝓕]) (n : ℕ) (i : ι) : (x ^ n) i = x i ^ n :=
+  rfl
+
+instance [Π i, AddMonoid (R i)] [∀ i, AddSubmonoidClass (S i) (R i)] :
+    AddMonoid (Πʳ i, [R i, B i]_[𝓕]) :=
+  haveI : ∀ i, SMulMemClass (S i) ℕ (R i) := fun _ ↦ AddSubmonoidClass.nsmulMemClass
+  DFunLike.coe_injective.addMonoid _ rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+
+@[to_additive existing]
+instance [Π i, Monoid (R i)] [∀ i, SubmonoidClass (S i) (R i)] :
+    Monoid (Πʳ i, [R i, B i]_[𝓕]) :=
+  DFunLike.coe_injective.monoid _ rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+
+instance [Π i, DivInvMonoid (R i)] [∀ i, SubgroupClass (S i) (R i)] :
+    Pow (Πʳ i, [R i, B i]_[𝓕]) ℤ where
+  pow x n := ⟨fun i ↦ x i ^ n, x.2.mono fun _ hi ↦ zpow_mem hi n⟩
+
+lemma zpow_apply [Π i, DivInvMonoid (R i)] [∀ i, SubgroupClass (S i) (R i)]
+    (x : Πʳ i, [R i, B i]_[𝓕]) (n : ℤ) (i : ι) : (x ^ n) i = x i ^ n :=
+  rfl
+
+instance [Π i, AddMonoidWithOne (R i)] [∀ i, AddSubmonoidWithOneClass (S i) (R i)] :
+    NatCast (Πʳ i, [R i, B i]_[𝓕]) where
+  natCast n := ⟨fun _ ↦ n, .of_forall fun _ ↦ natCast_mem _ n⟩
+
+instance [Π i, Ring (R i)] [∀ i, SubringClass (S i) (R i)] :
+    IntCast (Πʳ i, [R i, B i]_[𝓕]) where
+  intCast n := ⟨fun _ ↦ n, .of_forall fun _ ↦ intCast_mem _ n⟩
+
+instance [Π i, AddGroup (R i)] [∀ i, AddSubgroupClass (S i) (R i)] :
+    AddGroup (Πʳ i, [R i, B i]_[𝓕]) :=
+  haveI : ∀ i, SMulMemClass (S i) ℤ (R i) := fun _ ↦ AddSubgroupClass.zsmulMemClass
+  haveI : ∀ i, SMulMemClass (S i) ℕ (R i) := fun _ ↦ AddSubmonoidClass.nsmulMemClass
+  DFunLike.coe_injective.addGroup _ rfl (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ _ ↦ rfl)
+    (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+
+@[to_additive existing]
+instance [Π i, Group (R i)] [∀ i, SubgroupClass (S i) (R i)] :
+    Group (Πʳ i, [R i, B i]_[𝓕]) :=
+  DFunLike.coe_injective.group _ rfl (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ _ ↦ rfl)
+    (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+
+instance [Π i, Ring (R i)] [∀ i, SubringClass (S i) (R i)] :
+    Ring (Πʳ i, [R i, B i]_[𝓕]) :=
+  DFunLike.coe_injective.ring _ rfl rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ ↦ rfl)
+    (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ ↦ rfl)
+
+instance [Π i, CommRing (R i)] [∀ i, SubringClass (S i) (R i)] :
+    CommRing (Πʳ i, [R i, B i]_[𝓕]) where
+  mul_comm _ _ := DFunLike.coe_injective <| funext (fun _ ↦ mul_comm _ _)
+
+end Algebra
+
+section eval
+
+variable {S : ι → Type*}
+variable [Π i, SetLike (S i) (R i)]
+variable {B : Π i, S i}
+
+/-- `RestrictedProduct.evalMonoidHom j` is the monoid homomorphism from the restricted
+product `Πʳ i, [R i, B i]_[𝓕]` to the component `R j`.
+-/
+@[to_additive "`RestrictedProduct.evalAddMonoidHom j` is the monoid homomorphism from the restricted
+product `Πʳ i, [R i, B i]_[𝓕]` to the component `R j`."]
+def evalMonoidHom (j : ι) [Π i, Monoid (R i)] [∀ i, SubmonoidClass (S i) (R i)] :
+    (Πʳ i, [R i, B i]_[𝓕]) →* R j where
+  toFun x := x j
+  map_one' := rfl
+  map_mul' _ _ := rfl
+
+@[simp]
+lemma evalMonoidHom_apply [Π i, Monoid (R i)] [∀ i, SubmonoidClass (S i) (R i)]
+    (x : Πʳ i, [R i, B i]_[𝓕]) (j : ι) : evalMonoidHom R j x = x j :=
+  rfl
+
+/-- `RestrictedProduct.evalRingHom j` is the ring homomorphism from the restricted
+product `Πʳ i, [R i, B i]_[𝓕]` to the component `R j`.
+-/
+def evalRingHom (j : ι) [Π i, Ring (R i)] [∀ i, SubringClass (S i) (R i)] :
+    (Πʳ i, [R i, B i]_[𝓕]) →+* R j where
+  __ := evalMonoidHom R j
+  __ := evalAddMonoidHom R j
+
+@[simp]
+lemma evalRingHom_apply [Π i, Ring (R i)] [∀ i, SubringClass (S i) (R i)]
+    (x : Πʳ i, [R i, B i]_[𝓕]) (j : ι) : evalRingHom R j x = x j :=
+  rfl
+
+end eval
+
+section map
+
+variable {ι₁ ι₂ : Type*}
+variable (R₁ : ι₁ → Type*) (R₂ : ι₂ → Type*)
+variable {𝓕₁ : Filter ι₁} {𝓕₂ : Filter ι₂}
+variable {A₁ : (i : ι₁) → Set (R₁ i)} {A₂ : (i : ι₂) → Set (R₂ i)}
+variable {S₁ : ι₁ → Type*} {S₂ : ι₂ → Type*}
+variable [Π i, SetLike (S₁ i) (R₁ i)] [Π j, SetLike (S₂ j) (R₂ j)]
+variable {B₁ : Π i, S₁ i} {B₂ : Π j, S₂ j}
+variable (f : ι₂ → ι₁) (hf : Tendsto f 𝓕₂ 𝓕₁)
+
+section set
+
+variable (φ : ∀ j, R₁ (f j) → R₂ j) (hφ : ∀ᶠ j in 𝓕₂, MapsTo (φ j) (A₁ (f j)) (A₂ j))
+
+/--
+Given two restricted products `Πʳ (i : ι₁), [R₁ i, A₁ i]_[𝓕₁]` and `Πʳ (j : ι₂), [R₂ j, A₂ j]_[𝓕₂]`,
+`RestrictedProduct.map` gives a function between them. The data needed is a function `f : ι₂ → ι₁`
+such that `𝓕₂` tends to `𝓕₁` along `f`, and functions `φ j : R₁ (f j) → R₂ j`
+sending `A₁ (f j)` into `A₂ j` for an `𝓕₂`-large set of `j`'s.
+
+See also `mapMonoidHom`, `mapAddMonoidHom` and `mapRingHom` for variants.
+-/
+def map (x : Πʳ i, [R₁ i, A₁ i]_[𝓕₁]) : Πʳ j, [R₂ j, A₂ j]_[𝓕₂] := ⟨fun j ↦ φ j (x (f j)), by
+  filter_upwards [hf.eventually x.2, hφ] using fun _ h1 h2 ↦ h2 h1⟩
+
+@[simp]
+lemma map_apply (x : Πʳ i, [R₁ i, A₁ i]_[𝓕₁]) (j : ι₂) :
+    x.map R₁ R₂ f hf φ hφ j = φ j (x (f j)) :=
+  rfl
+
+end set
+
+section monoid
+
+variable [Π i, Monoid (R₁ i)] [Π i, Monoid (R₂ i)] [∀ i, SubmonoidClass (S₁ i) (R₁ i)]
+    [∀ i, SubmonoidClass (S₂ i) (R₂ i)] (φ : ∀ j, R₁ (f j) →* R₂ j)
+    (hφ : ∀ᶠ j in 𝓕₂, MapsTo (φ j) (B₁ (f j)) (B₂ j))
+
+/--
+Given two restricted products `Πʳ (i : ι₁), [R₁ i, B₁ i]_[𝓕₁]` and `Πʳ (j : ι₂), [R₂ j, B₂ j]_[𝓕₂]`,
+`RestrictedProduct.mapMonoidHom` gives a monoid homomorphism between them. The data needed is a
+function `f : ι₂ → ι₁` such that `𝓕₂` tends to `𝓕₁` along `f`, and monoid homomorphisms
+`φ j : R₁ (f j) → R₂ j` sending `B₁ (f j)` into `B₂ j` for an `𝓕₂`-large set of `j`'s.
+-/
+@[to_additive "
+Given two restricted products `Πʳ (i : ι₁), [R₁ i, B₁ i]_[𝓕₁]` and `Πʳ (j : ι₂), [R₂ j, B₂ j]_[𝓕₂]`,
+`RestrictedProduct.mapAddMonoidHom` gives a additive monoid homomorphism between them. The data
+needed is a function `f : ι₂ → ι₁` such that `𝓕₂` tends to `𝓕₁` along `f`, and
+additive monoid homomorphisms `φ j : R₁ (f j) → R₂ j` sending `B₁ (f j)` into `B₂ j` for
+an `𝓕₂`-large set of `j`'s.
+"]
+def mapMonoidHom : Πʳ i, [R₁ i, B₁ i]_[𝓕₁] →* Πʳ j, [R₂ j, B₂ j]_[𝓕₂] where
+  toFun := map R₁ R₂ f hf (fun j r ↦ φ j r) hφ
+  map_one' := by
+    ext i
+    exact map_one (φ i)
+  map_mul' x y := by
+    ext i
+    exact map_mul (φ i) _ _
+
+@[to_additive (attr := simp)]
+lemma mapMonoidHom_apply (x : Πʳ i, [R₁ i, B₁ i]_[𝓕₁]) (j : ι₂) :
+    x.mapMonoidHom R₁ R₂ f hf φ hφ j = φ j (x (f j)) :=
+  rfl
+
+end monoid
+
+section ring
+
+variable [Π i, Ring (R₁ i)] [Π i, Ring (R₂ i)] [∀ i, SubringClass (S₁ i) (R₁ i)]
+    [∀ i, SubringClass (S₂ i) (R₂ i)] (φ : ∀ j, R₁ (f j) →+* R₂ j)
+    (hφ : ∀ᶠ j in 𝓕₂, MapsTo (φ j) (B₁ (f j)) (B₂ j))
+
+/--
+Given two restricted products `Πʳ (i : ι₁), [R₁ i, B₁ i]_[𝓕₁]` and `Πʳ (j : ι₂), [R₂ j, B₂ j]_[𝓕₂]`,
+`RestrictedProduct.mapRingHom` gives a ring homomorphism between them. The data needed is a
+function `f : ι₂ → ι₁` such that `𝓕₂` tends to `𝓕₁` along `f`, and ring homomorphisms
+`φ j : R₁ (f j) → R₂ j` sending `B₁ (f j)` into `B₂ j` for an `𝓕₂`-large set of `j`'s.
+-/
+def mapRingHom : Πʳ i, [R₁ i, B₁ i]_[𝓕₁] →+* Πʳ j, [R₂ j, B₂ j]_[𝓕₂] where
+  __ := mapMonoidHom R₁ R₂ f hf (fun j ↦ φ j) hφ
+  __ := mapAddMonoidHom R₁ R₂ f hf (fun j ↦ φ j) hφ
+
+@[simp]
+lemma mapRingHom_apply (x : Πʳ i, [R₁ i, B₁ i]_[𝓕₁]) (j : ι₂) :
+    x.mapRingHom R₁ R₂ f hf φ hφ j = φ j (x (f j)) :=
+  rfl
+
+end ring
+
+end map
+
+section Topology
+
+end Topology
+
+end RestrictedProduct

--- a/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
@@ -391,8 +391,4 @@ end ring
 
 end map
 
-section Topology
-
-end Topology
-
 end RestrictedProduct

--- a/Mathlib/Topology/Algebra/RestrictedProduct/TopologicalSpace.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct/TopologicalSpace.lean
@@ -4,28 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anatole Dedecker
 -/
 import Mathlib.Topology.Algebra.Group.Pointwise
+import Mathlib.Topology.Algebra.RestrictedProduct.Basic
 import Mathlib.Topology.Algebra.Ring.Basic
 
 /-!
-# Restricted products of sets, groups and rings, and their topology
+# Restricted products of topological spaces, groups and rings.
 
-We define the **restricted product** of `R : ι → Type*` of types, relative to
-a family of subsets `A : (i : ι) → Set (R i)` and a filter `𝓕 : Filter ι`. This
-is the set of all `x : Π i, R i` such that the set `{j | x j ∈ A j}` belongs to `𝓕`.
-We denote it by `Πʳ i, [R i, A i]_[𝓕]`.
-
-The main case of interest, which we shall refer to as the "classical restricted product",
-is that of `𝓕 = cofinite`. Recall that this is the filter of all subsets of `ι`, which are
-*cofinite* in the sense that they have finite complement.
-Hence, the associated restricted product is the set of all `x : Π i, R i` such that
-`x j ∈ A j` for all but finitely many `j`s. We denote it simply by `Πʳ i, [R i, A i]`.
-
-Another notable case is that of the principal filter `𝓕 = 𝓟 s` corresponding to some subset `s`
-of `ι`. The associated restricted product `Πʳ i, [R i, A i]_[𝓟 s]` is the set of all
-`x : Π i, R i` such that `x j ∈ A j` for all `j ∈ s`. Put another way, this is just
-`(Π i ∈ s, A i) × (Π i ∉ s, R i)`, modulo the obvious isomorphism.
-
-We endow these types with the obvious algebraic structures, as well as their natural topology,
+We endow a restricted product of topological spaces with a natural topology,
 which we describe below. We also show various compatibility results.
 
 In particular, with the theory of adeles in mind, we show that if each `R i` is a locally compact
@@ -34,13 +19,8 @@ compact, then `Πʳ i, [R i, A i]` is a locally compact topological ring.
 
 ## Main definitions
 
-* `RestrictedProduct`: the restricted product of a family `R` of types, relative to a family `A` of
-  subsets and a filter `𝓕` on the indexing set. This is denoted `Πʳ i, [R i, A i]_[𝓕]`,
-  or simply `Πʳ i, [R i, A i]` when `𝓕 = cofinite`.
-* `RestrictedProduct.instDFunLike`: interpret an element of `Πʳ i, [R i, A i]_[𝓕]` as an element
-  of `Π i, R i` using the `DFunLike` machinery.
-* `RestrictedProduct.structureMap`: the inclusion map from `Π i, A i` to `Πʳ i, [R i, A i]_[𝓕]`.
-* `RestrictedProduct.topologicalSpace`: the `TopologicalSpace` instance on `Πʳ i, [R i, A i]_[𝓕]`.
+* `RestrictedProduct.topologicalSpace`: the `TopologicalSpace` instance on
+  the restricted product `Πʳ i, [R i, A i]_[𝓕]`.
 
 ## Topology on the restricted product
 
@@ -95,11 +75,6 @@ is continuous.
   group with `A i` an open subgroup. Assume also that all but finitely many `A i`s are compact.
   Then the restricted product `Πʳ i, [R i, A i]` is a locally compact group.
 
-## Notation
-
-* `Πʳ i, [R i, A i]_[𝓕]` is `RestrictedProduct R A 𝓕`.
-* `Πʳ i, [R i, A i]` is `RestrictedProduct R A cofinite`.
-
 ## Implementation details
 
 Outside of principal filters and the cofinite filter, the topology we define on the restricted
@@ -117,339 +92,11 @@ open Set Topology Filter
 variable {ι : Type*}
 variable (R : ι → Type*) (A : (i : ι) → Set (R i))
 
-/-!
-## Definition and elementary maps
--/
-
-/-- The **restricted product** of a family `R : ι → Type*` of types, relative to subsets
-`A : (i : ι) → Set (R i)` and the filter `𝓕 : Filter ι`, is the set of all `x : Π i, R i`
-such that the set `{j | x j ∈ A j}` belongs to `𝓕`. We denote it by `Πʳ i, [R i, A i]_[𝓕]`.
-
-The most common use case is with `𝓕 = cofinite`, in which case the restricted product is the set
-of all `x : Π i, R i` such that `x j ∈ A j` for all but finitely many `j`. We denote it simply
-by `Πʳ i, [R i, A i]`.
-
-Similarly, if `S` is a principal filter, the restricted product `Πʳ i, [R i, A i]_[𝓟 s]`
-is the set of all `x : Π i, R i` such that `∀ j ∈ S, x j ∈ A j`. -/
-def RestrictedProduct (𝓕 : Filter ι) : Type _ := {x : Π i, R i // ∀ᶠ i in 𝓕, x i ∈ A i}
-
-open Batteries.ExtendedBinder
-
-/-- `Πʳ i, [R i, A i]_[𝓕]` is `RestrictedProduct R A 𝓕`. -/
-scoped[RestrictedProduct]
-notation3 "Πʳ "(...)", ""["r:(scoped R => R)", "a:(scoped A => A)"]_[" f "]" =>
-  RestrictedProduct r a f
-
-/-- `Πʳ i, [R i, A i]` is `RestrictedProduct R A cofinite`. -/
-scoped[RestrictedProduct]
-notation3"Πʳ "(...)", ""["r:(scoped R => R)", "a:(scoped A => A)"]" =>
-  RestrictedProduct r a cofinite
-
 namespace RestrictedProduct
 
 open scoped RestrictedProduct
 
 variable {𝓕 𝓖 : Filter ι}
-
-instance : DFunLike (Πʳ i, [R i, A i]_[𝓕]) ι R where
-  coe x i := x.1 i
-  coe_injective' _ _ := Subtype.ext
-
-@[ext]
-lemma ext {x y :  Πʳ i, [R i, A i]_[𝓕]} (h : ∀ i, x i = y i) : x = y :=
-  Subtype.ext <| funext h
-
-lemma range_coe :
-    range ((↑) : Πʳ i, [R i, A i]_[𝓕] → Π i, R i) = {x | ∀ᶠ i in 𝓕, x i ∈ A i} :=
-  Subtype.range_val_subtype
-
-lemma range_coe_principal {S : Set ι} :
-    range ((↑) : Πʳ i, [R i, A i]_[𝓟 S] → Π i, R i) = S.pi A :=
-  range_coe R A
-
-@[simp] lemma eventually (x : Πʳ i, [R i, A i]_[𝓕]) : ∀ᶠ i in 𝓕, x i ∈ A i := x.2
-
-variable (𝓕) in
-/-- The *structure map* of the restricted product is the obvious inclusion from `Π i, A i`
-into `Πʳ i, [R i, A i]_[𝓕]`. -/
-def structureMap (x : Π i, A i) : Πʳ i, [R i, A i]_[𝓕] :=
-  ⟨fun i ↦ x i, .of_forall fun i ↦ (x i).2⟩
-
-/-- If `𝓕 ≤ 𝓖`, the restricted product `Πʳ i, [R i, A i]_[𝓖]` is naturally included in
-`Πʳ i, [R i, A i]_[𝓕]`. This is the corresponding map. -/
-def inclusion (h : 𝓕 ≤ 𝓖) (x : Πʳ i, [R i, A i]_[𝓖]) :
-    Πʳ i, [R i, A i]_[𝓕] :=
-  ⟨x, x.2.filter_mono h⟩
-
-variable (𝓕) in
-lemma inclusion_eq_id : inclusion R A (le_refl 𝓕) = id := rfl
-
-lemma exists_inclusion_eq_of_eventually (h : 𝓕 ≤ 𝓖) {x : Πʳ i, [R i, A i]_[𝓕]}
-    (hx𝓖 : ∀ᶠ i in 𝓖, x i ∈ A i) :
-    ∃ x' : Πʳ i, [R i, A i]_[𝓖], inclusion R A h x' = x :=
-  ⟨⟨x.1, hx𝓖⟩, rfl⟩
-
-lemma exists_structureMap_eq_of_forall {x : Πʳ i, [R i, A i]_[𝓕]}
-    (hx : ∀ i, x.1 i ∈ A i) :
-    ∃ x' : Π i, A i, structureMap R A 𝓕 x' = x :=
-  ⟨fun i ↦ ⟨x i, hx i⟩, rfl⟩
-
-lemma range_inclusion (h : 𝓕 ≤ 𝓖) :
-    Set.range (inclusion R A h) = {x | ∀ᶠ i in 𝓖, x i ∈ A i} :=
-  subset_antisymm (range_subset_iff.mpr fun x ↦ x.2)
-    (fun _ hx ↦ mem_range.mpr <| exists_inclusion_eq_of_eventually R A h hx)
-
-lemma range_structureMap :
-    Set.range (structureMap R A 𝓕) = {f | ∀ i, f.1 i ∈ A i} :=
-  subset_antisymm (range_subset_iff.mpr fun x i ↦ (x i).2)
-    (fun _ hx ↦ mem_range.mpr <| exists_structureMap_eq_of_forall R A hx)
-
-section Algebra
-/-!
-## Algebraic instances on restricted products
-
-In this section, we endow the restricted product with its algebraic instances.
-To avoid any unnecessary coercions, we use subobject classes for the subset `B i` of each `R i`.
--/
-
-variable {S : ι → Type*} -- subobject type
-variable [Π i, SetLike (S i) (R i)]
-variable {B : Π i, S i}
-
-@[to_additive]
-instance [Π i, One (R i)] [∀ i, OneMemClass (S i) (R i)] : One (Πʳ i, [R i, B i]_[𝓕]) where
-  one := ⟨fun _ ↦ 1, .of_forall fun _ ↦ one_mem _⟩
-
-@[to_additive (attr := simp)]
-lemma one_apply [Π i, One (R i)] [∀ i, OneMemClass (S i) (R i)] (i : ι) :
-    (1 : Πʳ i, [R i, B i]_[𝓕]) i = 1 :=
-  rfl
-
-@[to_additive]
-instance [Π i, Inv (R i)] [∀ i, InvMemClass (S i) (R i)] : Inv (Πʳ i, [R i, B i]_[𝓕]) where
-  inv x := ⟨fun i ↦ (x i)⁻¹, x.2.mono fun _ ↦ inv_mem⟩
-
-@[to_additive (attr := simp)]
-lemma inv_apply [Π i, Inv (R i)] [∀ i, InvMemClass (S i) (R i)]
-    (x : Πʳ i, [R i, B i]_[𝓕]) (i : ι) : (x⁻¹) i = (x i)⁻¹ :=
-  rfl
-
-@[to_additive]
-instance [Π i, Mul (R i)] [∀ i, MulMemClass (S i) (R i)] : Mul (Πʳ i, [R i, B i]_[𝓕]) where
-  mul x y := ⟨fun i ↦ x i * y i, y.2.mp (x.2.mono fun _ ↦ mul_mem)⟩
-
-@[to_additive (attr := simp)]
-lemma mul_apply [Π i, Mul (R i)] [∀ i, MulMemClass (S i) (R i)]
-    (x y : Πʳ i, [R i, B i]_[𝓕]) (i : ι) : (x * y) i = x i * y i :=
-  rfl
-
-@[to_additive]
-instance {G : Type*} [Π i, SMul G (R i)] [∀ i, SMulMemClass (S i) G (R i)] :
-    SMul G (Πʳ i, [R i, B i]_[𝓕]) where
-  smul g x := ⟨fun i ↦ g • (x i), x.2.mono fun _ ↦ SMulMemClass.smul_mem g⟩
-
-@[to_additive (attr := simp)]
-lemma smul_apply {G : Type*} [Π i, SMul G (R i)] [∀ i, SMulMemClass (S i) G (R i)] (g : G)
-    (x : Πʳ i, [R i, B i]_[𝓕]) (i : ι) : (g • x) i = g • x i :=
-  rfl
-
-@[to_additive]
-instance [Π i, DivInvMonoid (R i)] [∀ i, SubgroupClass (S i) (R i)] :
-    Div (Πʳ i, [R i, B i]_[𝓕]) where
-  div x y := ⟨fun i ↦ x i / y i, y.2.mp (x.2.mono fun _ ↦ div_mem)⟩
-
-@[to_additive (attr := simp)]
-lemma div_apply [Π i, DivInvMonoid (R i)] [∀ i, SubgroupClass (S i) (R i)]
-    (x y : Πʳ i, [R i, B i]_[𝓕]) (i : ι) : (x / y) i = x i / y i :=
-  rfl
-
-instance [Π i, Monoid (R i)] [∀ i, SubmonoidClass (S i) (R i)] :
-    Pow (Πʳ i, [R i, B i]_[𝓕]) ℕ where
-  pow x n := ⟨fun i ↦ x i ^ n, x.2.mono fun _ hi ↦ pow_mem hi n⟩
-
-lemma pow_apply [Π i, Monoid (R i)] [∀ i, SubmonoidClass (S i) (R i)]
-    (x : Πʳ i, [R i, B i]_[𝓕]) (n : ℕ) (i : ι) : (x ^ n) i = x i ^ n :=
-  rfl
-
-instance [Π i, AddMonoid (R i)] [∀ i, AddSubmonoidClass (S i) (R i)] :
-    AddMonoid (Πʳ i, [R i, B i]_[𝓕]) :=
-  haveI : ∀ i, SMulMemClass (S i) ℕ (R i) := fun _ ↦ AddSubmonoidClass.nsmulMemClass
-  DFunLike.coe_injective.addMonoid _ rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
-
-@[to_additive existing]
-instance [Π i, Monoid (R i)] [∀ i, SubmonoidClass (S i) (R i)] :
-    Monoid (Πʳ i, [R i, B i]_[𝓕]) :=
-  DFunLike.coe_injective.monoid _ rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
-
-instance [Π i, DivInvMonoid (R i)] [∀ i, SubgroupClass (S i) (R i)] :
-    Pow (Πʳ i, [R i, B i]_[𝓕]) ℤ where
-  pow x n := ⟨fun i ↦ x i ^ n, x.2.mono fun _ hi ↦ zpow_mem hi n⟩
-
-lemma zpow_apply [Π i, DivInvMonoid (R i)] [∀ i, SubgroupClass (S i) (R i)]
-    (x : Πʳ i, [R i, B i]_[𝓕]) (n : ℤ) (i : ι) : (x ^ n) i = x i ^ n :=
-  rfl
-
-instance [Π i, AddMonoidWithOne (R i)] [∀ i, AddSubmonoidWithOneClass (S i) (R i)] :
-    NatCast (Πʳ i, [R i, B i]_[𝓕]) where
-  natCast n := ⟨fun _ ↦ n, .of_forall fun _ ↦ natCast_mem _ n⟩
-
-instance [Π i, Ring (R i)] [∀ i, SubringClass (S i) (R i)] :
-    IntCast (Πʳ i, [R i, B i]_[𝓕]) where
-  intCast n := ⟨fun _ ↦ n, .of_forall fun _ ↦ intCast_mem _ n⟩
-
-instance [Π i, AddGroup (R i)] [∀ i, AddSubgroupClass (S i) (R i)] :
-    AddGroup (Πʳ i, [R i, B i]_[𝓕]) :=
-  haveI : ∀ i, SMulMemClass (S i) ℤ (R i) := fun _ ↦ AddSubgroupClass.zsmulMemClass
-  haveI : ∀ i, SMulMemClass (S i) ℕ (R i) := fun _ ↦ AddSubmonoidClass.nsmulMemClass
-  DFunLike.coe_injective.addGroup _ rfl (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ _ ↦ rfl)
-    (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
-
-@[to_additive existing]
-instance [Π i, Group (R i)] [∀ i, SubgroupClass (S i) (R i)] :
-    Group (Πʳ i, [R i, B i]_[𝓕]) :=
-  DFunLike.coe_injective.group _ rfl (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ _ ↦ rfl)
-    (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
-
-instance [Π i, Ring (R i)] [∀ i, SubringClass (S i) (R i)] :
-    Ring (Πʳ i, [R i, B i]_[𝓕]) :=
-  DFunLike.coe_injective.ring _ rfl rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ ↦ rfl)
-    (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ ↦ rfl)
-
-instance [Π i, CommRing (R i)] [∀ i, SubringClass (S i) (R i)] :
-    CommRing (Πʳ i, [R i, B i]_[𝓕]) where
-  mul_comm _ _ := DFunLike.coe_injective <| funext (fun _ ↦ mul_comm _ _)
-
-end Algebra
-
-section eval
-
-variable {S : ι → Type*}
-variable [Π i, SetLike (S i) (R i)]
-variable {B : Π i, S i}
-
-/-- `RestrictedProduct.evalMonoidHom j` is the monoid homomorphism from the restricted
-product `Πʳ i, [R i, B i]_[𝓕]` to the component `R j`.
--/
-@[to_additive "`RestrictedProduct.evalAddMonoidHom j` is the monoid homomorphism from the restricted
-product `Πʳ i, [R i, B i]_[𝓕]` to the component `R j`."]
-def evalMonoidHom (j : ι) [Π i, Monoid (R i)] [∀ i, SubmonoidClass (S i) (R i)] :
-    (Πʳ i, [R i, B i]_[𝓕]) →* R j where
-  toFun x := x j
-  map_one' := rfl
-  map_mul' _ _ := rfl
-
-@[simp]
-lemma evalMonoidHom_apply [Π i, Monoid (R i)] [∀ i, SubmonoidClass (S i) (R i)]
-    (x : Πʳ i, [R i, B i]_[𝓕]) (j : ι) : evalMonoidHom R j x = x j :=
-  rfl
-
-/-- `RestrictedProduct.evalRingHom j` is the ring homomorphism from the restricted
-product `Πʳ i, [R i, B i]_[𝓕]` to the component `R j`.
--/
-def evalRingHom (j : ι) [Π i, Ring (R i)] [∀ i, SubringClass (S i) (R i)] :
-    (Πʳ i, [R i, B i]_[𝓕]) →+* R j where
-  __ := evalMonoidHom R j
-  __ := evalAddMonoidHom R j
-
-@[simp]
-lemma evalRingHom_apply [Π i, Ring (R i)] [∀ i, SubringClass (S i) (R i)]
-    (x : Πʳ i, [R i, B i]_[𝓕]) (j : ι) : evalRingHom R j x = x j :=
-  rfl
-
-end eval
-
-section map
-
-variable {ι₁ ι₂ : Type*}
-variable (R₁ : ι₁ → Type*) (R₂ : ι₂ → Type*)
-variable {𝓕₁ : Filter ι₁} {𝓕₂ : Filter ι₂}
-variable {A₁ : (i : ι₁) → Set (R₁ i)} {A₂ : (i : ι₂) → Set (R₂ i)}
-variable {S₁ : ι₁ → Type*} {S₂ : ι₂ → Type*}
-variable [Π i, SetLike (S₁ i) (R₁ i)] [Π j, SetLike (S₂ j) (R₂ j)]
-variable {B₁ : Π i, S₁ i} {B₂ : Π j, S₂ j}
-variable (f : ι₂ → ι₁) (hf : Tendsto f 𝓕₂ 𝓕₁)
-
-section set
-
-variable (φ : ∀ j, R₁ (f j) → R₂ j) (hφ : ∀ᶠ j in 𝓕₂, MapsTo (φ j) (A₁ (f j)) (A₂ j))
-
-/--
-Given two restricted products `Πʳ (i : ι₁), [R₁ i, A₁ i]_[𝓕₁]` and `Πʳ (j : ι₂), [R₂ j, A₂ j]_[𝓕₂]`,
-`RestrictedProduct.map` gives a function between them. The data needed is a function `f : ι₂ → ι₁`
-such that `𝓕₂` tends to `𝓕₁` along `f`, and functions `φ j : R₁ (f j) → R₂ j`
-sending `A₁ (f j)` into `A₂ j` for an `𝓕₂`-large set of `j`'s.
-
-See also `mapMonoidHom`, `mapAddMonoidHom` and `mapRingHom` for variants.
--/
-def map (x : Πʳ i, [R₁ i, A₁ i]_[𝓕₁]) : Πʳ j, [R₂ j, A₂ j]_[𝓕₂] := ⟨fun j ↦ φ j (x (f j)), by
-  filter_upwards [hf.eventually x.2, hφ] using fun _ h1 h2 ↦ h2 h1⟩
-
-@[simp]
-lemma map_apply (x : Πʳ i, [R₁ i, A₁ i]_[𝓕₁]) (j : ι₂) :
-    x.map R₁ R₂ f hf φ hφ j = φ j (x (f j)) :=
-  rfl
-
-end set
-
-section monoid
-
-variable [Π i, Monoid (R₁ i)] [Π i, Monoid (R₂ i)] [∀ i, SubmonoidClass (S₁ i) (R₁ i)]
-    [∀ i, SubmonoidClass (S₂ i) (R₂ i)] (φ : ∀ j, R₁ (f j) →* R₂ j)
-    (hφ : ∀ᶠ j in 𝓕₂, MapsTo (φ j) (B₁ (f j)) (B₂ j))
-
-/--
-Given two restricted products `Πʳ (i : ι₁), [R₁ i, B₁ i]_[𝓕₁]` and `Πʳ (j : ι₂), [R₂ j, B₂ j]_[𝓕₂]`,
-`RestrictedProduct.mapMonoidHom` gives a monoid homomorphism between them. The data needed is a
-function `f : ι₂ → ι₁` such that `𝓕₂` tends to `𝓕₁` along `f`, and monoid homomorphisms
-`φ j : R₁ (f j) → R₂ j` sending `B₁ (f j)` into `B₂ j` for an `𝓕₂`-large set of `j`'s.
--/
-@[to_additive "
-Given two restricted products `Πʳ (i : ι₁), [R₁ i, B₁ i]_[𝓕₁]` and `Πʳ (j : ι₂), [R₂ j, B₂ j]_[𝓕₂]`,
-`RestrictedProduct.mapAddMonoidHom` gives a additive monoid homomorphism between them. The data
-needed is a function `f : ι₂ → ι₁` such that `𝓕₂` tends to `𝓕₁` along `f`, and
-additive monoid homomorphisms `φ j : R₁ (f j) → R₂ j` sending `B₁ (f j)` into `B₂ j` for
-an `𝓕₂`-large set of `j`'s.
-"]
-def mapMonoidHom : Πʳ i, [R₁ i, B₁ i]_[𝓕₁] →* Πʳ j, [R₂ j, B₂ j]_[𝓕₂] where
-  toFun := map R₁ R₂ f hf (fun j r ↦ φ j r) hφ
-  map_one' := by
-    ext i
-    exact map_one (φ i)
-  map_mul' x y := by
-    ext i
-    exact map_mul (φ i) _ _
-
-@[to_additive (attr := simp)]
-lemma mapMonoidHom_apply (x : Πʳ i, [R₁ i, B₁ i]_[𝓕₁]) (j : ι₂) :
-    x.mapMonoidHom R₁ R₂ f hf φ hφ j = φ j (x (f j)) :=
-  rfl
-
-end monoid
-
-section ring
-
-variable [Π i, Ring (R₁ i)] [Π i, Ring (R₂ i)] [∀ i, SubringClass (S₁ i) (R₁ i)]
-    [∀ i, SubringClass (S₂ i) (R₂ i)] (φ : ∀ j, R₁ (f j) →+* R₂ j)
-    (hφ : ∀ᶠ j in 𝓕₂, MapsTo (φ j) (B₁ (f j)) (B₂ j))
-
-/--
-Given two restricted products `Πʳ (i : ι₁), [R₁ i, B₁ i]_[𝓕₁]` and `Πʳ (j : ι₂), [R₂ j, B₂ j]_[𝓕₂]`,
-`RestrictedProduct.mapRingHom` gives a ring homomorphism between them. The data needed is a
-function `f : ι₂ → ι₁` such that `𝓕₂` tends to `𝓕₁` along `f`, and ring homomorphisms
-`φ j : R₁ (f j) → R₂ j` sending `B₁ (f j)` into `B₂ j` for an `𝓕₂`-large set of `j`'s.
--/
-def mapRingHom : Πʳ i, [R₁ i, B₁ i]_[𝓕₁] →+* Πʳ j, [R₂ j, B₂ j]_[𝓕₂] where
-  __ := mapMonoidHom R₁ R₂ f hf (fun j ↦ φ j) hφ
-  __ := mapAddMonoidHom R₁ R₂ f hf (fun j ↦ φ j) hφ
-
-@[simp]
-lemma mapRingHom_apply (x : Πʳ i, [R₁ i, B₁ i]_[𝓕₁]) (j : ι₂) :
-    x.mapRingHom R₁ R₂ f hf φ hφ j = φ j (x (f j)) :=
-  rfl
-
-end ring
-
-end map
 
 section Topology
 /-!

--- a/Mathlib/Topology/Algebra/RestrictedProduct/TopologicalSpace.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct/TopologicalSpace.lean
@@ -8,10 +8,12 @@ import Mathlib.Topology.Algebra.RestrictedProduct.Basic
 import Mathlib.Topology.Algebra.Ring.Basic
 
 /-!
-# Restricted products of topological spaces, groups and rings.
+# Restricted products of topological spaces, topological groups and rings
 
 We endow a restricted product of topological spaces with a natural topology,
-which we describe below. We also show various compatibility results.
+which we describe below. We also show various compatibility results when we change
+filters, and extend the construction of restricted products of algebraic structures
+to the topological setting.
 
 In particular, with the theory of adeles in mind, we show that if each `R i` is a locally compact
 topological ring with open subring `A i`, and if all but finitely many of the `A i`s are also

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -212,6 +212,8 @@
   "Mathlib.Topology.Defs.Basic": ["Mathlib.Tactic.FunProp"],
   "Mathlib.Topology.Category.UniformSpace":
   ["Mathlib.CategoryTheory.Monad.Limits"],
+  "Mathlib.Topology.Algebra.RestrictedProduct.Basic":
+  ["Mathlib.Order.Filter.Cofinite"],
   "Mathlib.Topology.Algebra.Nonarchimedean.AdicTopology":
   ["Mathlib.Topology.Algebra.UniformRing"],
   "Mathlib.Tactic.Widget.StringDiagram":


### PR DESCRIPTION
`Mathlib/Topology/Algebra/RestrictedProduct.lean` is over 1000 lines and we have over 500 lines more of restricted product API in FLT with more to come, so I thought I would split sooner rather than later.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

This PR is nothing more than a split with no additions or deletions.
