### PR TITLE
[Merged by Bors] - feat(Bicategory/Functor/LocallyDiscrete): add `Functor.toPseudofunctor`

### DIFF
--- a/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
@@ -100,6 +100,22 @@ def oplaxFunctorOfIsLocallyDiscrete
 
 section
 
+end
+
+variable {C D : Type*} [Category C] [Category D] (F : C ⥤ D)
+
+/--
+If `B` is a strict bicategory and `I` is a (1-)category, any functor (of 1-categories) `I ⥤ B` can
+be promoted to a pseudofunctor from `LocallyDiscrete I` to `B`.
+-/
+@[simps! obj map mapId mapComp]
+def Functor.toPseudoFunctor' : Pseudofunctor (LocallyDiscrete C) (LocallyDiscrete D) :=
+  pseudofunctorOfIsLocallyDiscrete
+    (fun ⟨X⟩ ↦.mk <| F.obj X) (fun ⟨f⟩ ↦ (F.map f).toLoc)
+    (fun ⟨X⟩ ↦ eqToIso (by simp)) (fun f g ↦ eqToIso (by simp))
+
+section
+
 variable {I B : Type*} [Category I] [Bicategory B] [Strict B] (F : I ⥤ B)
 
 attribute [local simp]

--- a/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
@@ -100,19 +100,29 @@ def oplaxFunctorOfIsLocallyDiscrete
 
 section
 
-end
-
 variable {C D : Type*} [Category C] [Category D] (F : C ⥤ D)
 
 /--
-If `B` is a strict bicategory and `I` is a (1-)category, any functor (of 1-categories) `I ⥤ B` can
-be promoted to a pseudofunctor from `LocallyDiscrete I` to `B`.
+A functor between two categories `C` and `D` can be lifted to a pseudofunctor between the
+corresponding locally discrete bicategories.
 -/
 @[simps! obj map mapId mapComp]
-def Functor.toPseudoFunctor' : Pseudofunctor (LocallyDiscrete C) (LocallyDiscrete D) :=
+def Functor.toPseudoFunctor : Pseudofunctor (LocallyDiscrete C) (LocallyDiscrete D) :=
   pseudofunctorOfIsLocallyDiscrete
     (fun ⟨X⟩ ↦.mk <| F.obj X) (fun ⟨f⟩ ↦ (F.map f).toLoc)
     (fun ⟨X⟩ ↦ eqToIso (by simp)) (fun f g ↦ eqToIso (by simp))
+
+/--
+A functor between two categories `C` and `D` can be lifted to an oplax functor between the
+corresponding locally discrete bicategories.
+
+This is just an abbreviation of `Functor.toPseudoFunctor.toOplax`.
+-/
+@[simps! obj map mapId mapComp]
+abbrev Functor.toOplaxFunctor : OplaxFunctor (LocallyDiscrete C) (LocallyDiscrete D) :=
+  F.toPseudoFunctor.toOplax
+
+end
 
 section
 
@@ -126,7 +136,7 @@ If `B` is a strict bicategory and `I` is a (1-)category, any functor (of 1-categ
 be promoted to a pseudofunctor from `LocallyDiscrete I` to `B`.
 -/
 @[simps! obj map mapId mapComp]
-def Functor.toPseudoFunctor : Pseudofunctor (LocallyDiscrete I) B :=
+def Functor.toPseudoFunctor' : Pseudofunctor (LocallyDiscrete I) B :=
   pseudofunctorOfIsLocallyDiscrete
     (fun ⟨X⟩ ↦ F.obj X) (fun ⟨f⟩ ↦ F.map f)
     (fun ⟨X⟩ ↦ eqToIso (by simp)) (fun f g ↦ eqToIso (by simp))
@@ -136,10 +146,8 @@ If `B` is a strict bicategory and `I` is a (1-)category, any functor (of 1-categ
 be promoted to an oplax functor from `LocallyDiscrete I` to `B`.
 -/
 @[simps! obj map mapId mapComp]
-def Functor.toOplaxFunctor : OplaxFunctor (LocallyDiscrete I) B :=
-  oplaxFunctorOfIsLocallyDiscrete
-    (fun ⟨X⟩ ↦ F.obj X) (fun ⟨f⟩ ↦ F.map f)
-    (fun ⟨X⟩ ↦ eqToHom (by simp)) (fun f g ↦ eqToHom (by simp))
+abbrev Functor.toOplaxFunctor' : OplaxFunctor (LocallyDiscrete I) B :=
+  F.toPseudoFunctor'.toOplax
 
 end
 


### PR DESCRIPTION
We add `Functor.toPseudofunctor` which takes a functor between categories and returns the corresponding pseudofunctor between locally discrete categories. Previously, `Functor.toPseudofunctor` took a functor from a category to a _strict_ bicategory, and returned the corresponding pseudofunctor. Since this new construction works for all functors, I suggest that this takes the name `Functor.toPseudofunctor` and the latter gets renamed to `Functor.toPseudofunctor'`. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
