### PR TITLE
feat(SimpleGraph): ext for walks based on `getVert` and `support`

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -1110,7 +1110,6 @@ lemma ext_getVert {u v} {p q : G.Walk u v} (h : ∀ k, p.getVert k = q.getVert k
       rw [getVert_nil, getVert_cons_succ, getVert_zero] at h
       exact ((G.loopless _) (h ▸ ha)).elim
     | cons hb q =>
-      expose_names
       have h₁ := h 1
       rw [getVert_cons_succ, getVert_zero] at h₁
       specialize ih (q := (cons hb q).tail.copy h₁.symm rfl)

--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -1132,7 +1132,7 @@ lemma ext_getVert {u v} {p q : G.Walk u v} (h : ∀ k, p.getVert k = q.getVert k
   have : q.length ≤ p.length := by
     by_contra!
     exact (q.adj_getVert_succ this).ne (by simp [← h, getVert_of_length_le])
-  exact ext_getVert (hpq.antisymm this) fun k _ ↦ h k
+  exact ext_getVert_le_length (hpq.antisymm this) fun k _ ↦ h k
 
 end Walk
 

--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -1091,6 +1091,36 @@ theorem exists_boundary_dart {u v : V} (p : G.Walk u v) (S : Set V) (uS : u ∈ 
   | .cons h q =>
     simp only [getVert_cons_succ, tail_cons_eq, getVert_cons]
     exact getVert_copy q n (getVert_zero q).symm rfl
+
+@[ext]
+lemma ext_getVert {u v} {p q : G.Walk u v} (h : ∀ k, p.getVert k = q.getVert k) :
+    p = q := by
+  induction p with
+  | nil =>
+    cases q with
+    | nil => rfl
+    | cons ha =>
+      specialize h 1
+      rw [getVert_nil, getVert_cons_succ, getVert_zero] at h
+      exact ((G.loopless _) (h ▸ ha)).elim
+  | cons ha _ ih =>
+    cases q with
+    | nil =>
+      specialize h 1
+      rw [getVert_nil, getVert_cons_succ, getVert_zero] at h
+      exact ((G.loopless _) (h ▸ ha)).elim
+    | cons hb q =>
+      expose_names
+      have h₁ := h 1
+      rw [getVert_cons_succ, getVert_zero] at h₁
+      specialize ih (q := (cons hb q).tail.copy h₁.symm rfl)
+      simp only [getVert_copy, getVert_tail] at ih
+      specialize ih fun k ↦ by
+        rw [getVert_cons_succ]
+        specialize h (k + 1)
+        rwa [getVert_cons_succ, getVert_cons_succ] at h
+      simp [ih]
+
 end Walk
 
 /-! ### Mapping walks -/

--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -1109,7 +1109,7 @@ lemma ext_support {u v} {p q : G.Walk u v} (h : p.support = q.support) :
       have : (p.copy h rfl).support = q.support := by simpa
       simp [← ih this]
 
-lemma ext_getVert {u v} {p q : G.Walk u v} (hl : p.length = q.length)
+lemma ext_getVert_le_length {u v} {p q : G.Walk u v} (hl : p.length = q.length)
     (h : ∀ k ≤ p.length, p.getVert k = q.getVert k) :
     p = q := by
   suffices ∀ k : ℕ, p.support[k]? = q.support[k]? by
@@ -1125,7 +1125,7 @@ lemma ext_getVert {u v} {p q : G.Walk u v} (hl : p.length = q.length)
     rw [← length_support, ← List.getElem?_eq_none_iff] at hk ht
     rw [hk, ht]
 
-lemma ext_getVert' {u v} {p q : G.Walk u v} (h : ∀ k, p.getVert k = q.getVert k) :
+lemma ext_getVert {u v} {p q : G.Walk u v} (h : ∀ k, p.getVert k = q.getVert k) :
     p = q := by
   wlog hpq : p.length ≤ q.length generalizing p q
   · exact (this (fun k ↦ (h k).symm) (le_of_not_ge hpq)).symm

--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -1098,10 +1098,10 @@ lemma ext_support {u v} {p q : G.Walk u v} (h : p.support = q.support) :
   | nil =>
     rw [← nil_iff_eq_nil, nil_iff_support_eq]
     exact support_nil ▸ h
-  | @cons _ u _ ha q ih =>
+  | cons ha q ih =>
     cases p with
     | nil => simp at h
-    | @cons _ v _ _ p =>
+    | cons _ p =>
       simp only [support_cons, List.cons.injEq, true_and] at h
       apply List.getElem_of_eq at h
       specialize h (i := 0) (by simp)


### PR DESCRIPTION
Two walks are the same if they agree under `getVert` or `support`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
