### PR TITLE
[Merged by Bors] - perf: replace `measurability` by `fun_prop`

### DIFF
--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Countable.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Countable.lean
@@ -190,7 +190,7 @@ theorem exists_measurable_le_forall_setLIntegral_eq [SFinite μ] (f : α → ℝ
   -- Let `φ` be the pointwise supremum of the functions $g_{n}$.
   -- Clearly, `φ` is a measurable function and `φ ≤ f`.
   set φ : α → ℝ≥0∞ := fun x ↦ ⨆ n, g n x
-  have hφm : Measurable φ := by measurability
+  have hφm : Measurable φ := by fun_prop
   have hφle : φ ≤ f := fun x ↦ iSup_le (hgf · x)
   refine ⟨φ, hφm, hφle, fun s ↦ ?_⟩
   -- Now we show the inequality between set integrals.

--- a/Mathlib/MeasureTheory/Measure/Decomposition/Lebesgue.lean
+++ b/Mathlib/MeasureTheory/Measure/Decomposition/Lebesgue.lean
@@ -976,7 +976,7 @@ nonrec instance (priority := 100) haveLebesgueDecomposition_of_sigmaFinite
     _ = .sum fun n ↦ .restrict μ (s n) := by
       simp_rw [ξ, f, withDensity_indicator (hsm _), singularPart_add_rnDeriv]
     _ = μ := sum_restrict_disjointed_spanningSets ..
-  exact ⟨⟨(.sum ξ, ∑' n, f n), by measurability, hξ, hadd.symm⟩⟩
+  exact ⟨⟨(.sum ξ, ∑' n, f n), by fun_prop, hξ, hadd.symm⟩⟩
 
 section rnDeriv
 

--- a/Mathlib/Probability/Distributions/Geometric.lean
+++ b/Mathlib/Probability/Distributions/Geometric.lean
@@ -69,7 +69,7 @@ def geometricPMF (hp_pos : 0 < p) (hp_le_one : p ≤ 1) : PMF ℕ :=
 /-- The geometric pmf is measurable. -/
 @[fun_prop, measurability]
 lemma measurable_geometricPMFReal : Measurable (geometricPMFReal p) := by
-  measurability
+  fun_prop
 
 @[fun_prop, measurability]
 lemma stronglyMeasurable_geometricPMFReal : StronglyMeasurable (geometricPMFReal p) :=

--- a/Mathlib/Probability/Distributions/Poisson.lean
+++ b/Mathlib/Probability/Distributions/Poisson.lean
@@ -64,7 +64,7 @@ def poissonPMF (r : ℝ≥0) : PMF ℕ := by
 
 /-- The Poisson pmf is measurable. -/
 @[fun_prop, measurability]
-lemma measurable_poissonPMFReal (r : ℝ≥0) : Measurable (poissonPMFReal r) := by measurability
+lemma measurable_poissonPMFReal (r : ℝ≥0) : Measurable (poissonPMFReal r) := by fun_prop
 
 @[fun_prop, measurability]
 lemma stronglyMeasurable_poissonPMFReal (r : ℝ≥0) : StronglyMeasurable (poissonPMFReal r) :=


### PR DESCRIPTION
Replace `measurability` by `fun_prop` where it made a visible difference in elaboration time.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
