### PR TITLE
chore: deprime `induction` in `AlgebraicTopology/CategoryTheory`

### DIFF
--- a/Mathlib/AlgebraicTopology/DoldKan/Decomposition.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Decomposition.lean
@@ -50,10 +50,12 @@ the $y_i$ are in degree $n$. -/
 theorem decomposition_Q (n q : ℕ) :
     ((Q q).f (n + 1) : X _⦋n + 1⦌ ⟶ X _⦋n + 1⦌) =
       ∑ i : Fin (n + 1) with i.val < q, (P i).f (n + 1) ≫ X.δ i.rev.succ ≫ X.σ (Fin.rev i) := by
-  induction' q with q hq
-  · simp only [Q_zero, HomologicalComplex.zero_f_apply, Nat.not_lt_zero,
+  induction q with
+  | zero =>
+    simp only [Q_zero, HomologicalComplex.zero_f_apply, Nat.not_lt_zero,
       Finset.filter_False, Finset.sum_empty]
-  · by_cases hqn : q + 1 ≤ n + 1
+  | succ q hq =>
+    by_cases hqn : q + 1 ≤ n + 1
     swap
     · rw [Q_is_eventually_constant (show n + 1 ≤ q by omega), hq]
       congr 1

--- a/Mathlib/AlgebraicTopology/DoldKan/Degeneracies.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Degeneracies.lean
@@ -53,19 +53,13 @@ theorem HigherFacesVanish.comp_σ {Y : C} {X : SimplicialObject C} {n b q : ℕ}
 
 theorem σ_comp_P_eq_zero (X : SimplicialObject C) {n q : ℕ} (i : Fin (n + 1)) (hi : n + 1 ≤ i + q) :
     X.σ i ≫ (P q).f (n + 1) = 0 := by
-  revert i hi
-  induction' q with q hq
-  · intro i (hi : n + 1 ≤ i)
-    omega
-  · intro i (hi : n + 1 ≤ i + q + 1)
+  induction q generalizing i with
+  | zero => omega
+  | succ q hq =>
     by_cases h : n + 1 ≤ (i : ℕ) + q
     · rw [P_succ, HomologicalComplex.comp_f, ← assoc, hq i h, zero_comp]
-    · replace hi : n = i + q := by
-        obtain ⟨j, hj⟩ := le_iff_exists_add.mp hi
-        rw [← Nat.lt_succ_iff, Nat.succ_eq_add_one, hj, not_lt, add_le_iff_nonpos_right,
-          nonpos_iff_eq_zero] at h
-        rw [← add_left_inj 1, hj, left_eq_add, h]
-      rcases n with _|n
+    · replace hi : n = i + q := by omega
+      rcases n with _ | n
       · fin_cases i
         dsimp at h hi
         rw [show q = 0 by omega]

--- a/Mathlib/AlgebraicTopology/DoldKan/NCompGamma.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/NCompGamma.lean
@@ -36,7 +36,7 @@ variable {C : Type*} [Category C] [Preadditive C]
 theorem PInfty_comp_map_mono_eq_zero (X : SimplicialObject C) {n : ℕ} {Δ' : SimplexCategory}
     (i : Δ' ⟶ ⦋n⦌) [hi : Mono i] (h₁ : Δ'.len ≠ n) (h₂ : ¬Isδ₀ i) :
     PInfty.f n ≫ X.map i.op = 0 := by
-  induction' Δ' using SimplexCategory.rec with m
+  induction Δ' using SimplexCategory.rec with | _ m
   obtain ⟨k, hk⟩ := Nat.exists_eq_add_of_lt (len_lt_of_mono i fun h => by
         rw [← h] at h₁
         exact h₁ rfl)
@@ -80,8 +80,8 @@ theorem Γ₀_obj_termwise_mapMono_comp_PInfty (X : SimplicialObject C) {Δ Δ' 
     (i : Δ ⟶ Δ') [Mono i] :
     Γ₀.Obj.Termwise.mapMono (AlternatingFaceMapComplex.obj X) i ≫ PInfty.f Δ.len =
       PInfty.f Δ'.len ≫ X.map i.op := by
-  induction' Δ using SimplexCategory.rec with n
-  induction' Δ' using SimplexCategory.rec with n'
+  induction Δ using SimplexCategory.rec with | _ n
+  induction Δ' using SimplexCategory.rec with | _ n'
   dsimp
   -- We start with the case `i` is an identity
   by_cases h : n = n'

--- a/Mathlib/AlgebraicTopology/DoldKan/Projections.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Projections.lean
@@ -53,9 +53,10 @@ lemma P_succ (q : ℕ) : (P (q+1) : K[X] ⟶ K[X]) = P q ≫ (𝟙 _ + Hσ q) :=
 /-- All the `P q` coincide with `𝟙 _` in degree 0. -/
 @[simp]
 theorem P_f_0_eq (q : ℕ) : ((P q).f 0 : X _⦋0⦌ ⟶ X _⦋0⦌) = 𝟙 _ := by
-  induction' q with q hq
-  · rfl
-  · simp only [P_succ, HomologicalComplex.add_f_apply, HomologicalComplex.comp_f,
+  induction q with
+  | zero => rfl
+  | succ q hq =>
+    simp only [P_succ, HomologicalComplex.add_f_apply, HomologicalComplex.comp_f,
       HomologicalComplex.id_f, id_comp, hq, Hσ_eq_zero, add_zero]
 
 /-- `Q q` is the complement projection associated to `P q` -/
@@ -95,10 +96,12 @@ theorem of_P : ∀ q n : ℕ, HigherFacesVanish q ((P q).f (n + 1) : X _⦋n + 1
 @[reassoc]
 theorem comp_P_eq_self {Y : C} {n q : ℕ} {φ : Y ⟶ X _⦋n + 1⦌} (v : HigherFacesVanish q φ) :
     φ ≫ (P q).f (n + 1) = φ := by
-  induction' q with q hq
-  · simp only [P_zero]
+  induction q with
+  | zero =>
+    simp only [P_zero]
     apply comp_id
-  · simp only [P_succ, comp_add, HomologicalComplex.comp_f, HomologicalComplex.add_f_apply,
+  | succ q hq =>
+    simp only [P_succ, comp_add, HomologicalComplex.comp_f, HomologicalComplex.add_f_apply,
       comp_id, ← assoc, hq v.of_succ, add_eq_left]
     by_cases hqn : n < q
     · exact v.of_succ.comp_Hσ_eq_zero hqn
@@ -147,10 +150,12 @@ theorem Q_idem (q : ℕ) : (Q q : K[X] ⟶ K[X]) ≫ Q q = Q q := by
 def natTransP (q : ℕ) : alternatingFaceMapComplex C ⟶ alternatingFaceMapComplex C where
   app _ := P q
   naturality _ _ f := by
-    induction' q with q hq
-    · dsimp [alternatingFaceMapComplex]
+    induction q with
+    | zero =>
+      dsimp [alternatingFaceMapComplex]
       simp only [P_zero, id_comp, comp_id]
-    · simp only [P_succ, add_comp, comp_add, assoc, comp_id, hq, reassoc_of% hq]
+    | succ q hq =>
+      simp only [P_succ, add_comp, comp_add, assoc, comp_id, hq, reassoc_of% hq]
       -- `erw` is needed to see through `natTransHσ q).app = Hσ q`
       erw [(natTransHσ q).naturality f]
       rfl
@@ -176,10 +181,12 @@ def natTransQ (q : ℕ) : alternatingFaceMapComplex C ⟶ alternatingFaceMapComp
 theorem map_P {D : Type*} [Category D] [Preadditive D] (G : C ⥤ D) [G.Additive]
     (X : SimplicialObject C) (q n : ℕ) :
     G.map ((P q : K[X] ⟶ _).f n) = (P q : K[((whiskering C D).obj G).obj X] ⟶ _).f n := by
-  induction' q with q hq
-  · simp only [P_zero]
+  induction q with
+  | zero =>
+    simp only [P_zero]
     apply G.map_id
-  · simp only [P_succ, comp_add, HomologicalComplex.comp_f, HomologicalComplex.add_f_apply,
+  | succ q hq =>
+    simp only [P_succ, comp_add, HomologicalComplex.comp_f, HomologicalComplex.add_f_apply,
       comp_id, Functor.map_add, Functor.map_comp, hq, map_Hσ]
 
 theorem map_Q {D : Type*} [Category D] [Preadditive D] (G : C ⥤ D) [G.Additive]

--- a/Mathlib/AlgebraicTopology/SimplexCategory/MorphismProperty.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/MorphismProperty.lean
@@ -33,8 +33,8 @@ lemma Truncated.morphismProperty_eq_top
     W = ⊤ := by
   ext ⟨a, ha⟩ ⟨b, hb⟩ f
   simp only [MorphismProperty.top_apply, iff_true]
-  induction' a using SimplexCategory.rec with a
-  induction' b using SimplexCategory.rec with b
+  induction a using SimplexCategory.rec with | _ a
+  induction b using SimplexCategory.rec with | _ b
   dsimp at ha hb
   generalize h : a + b = c
   induction c generalizing a b with

--- a/Mathlib/AlgebraicTopology/SimplicialObject/Split.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialObject/Split.lean
@@ -85,9 +85,7 @@ instance : Fintype (IndexSet Δ) :=
         A.e.toOrderHom⟩ :
       IndexSet Δ → Sigma fun k : Fin (Δ.unop.len + 1) => Fin (Δ.unop.len + 1) → Fin (k + 1))
     (by
-      rintro ⟨Δ₁, α₁⟩ ⟨Δ₂, α₂⟩ h₁
-      induction' Δ₁ using Opposite.rec with Δ₁
-      induction' Δ₂ using Opposite.rec with Δ₂
+      rintro ⟨⟨Δ₁⟩, α₁⟩ ⟨⟨Δ₂⟩, α₂⟩ h₁
       simp only [unop_op, Sigma.mk.inj_iff, Fin.mk.injEq] at h₁
       have h₂ : Δ₁ = Δ₂ := by
         ext1
@@ -247,11 +245,10 @@ theorem hom_ext' {Z : C} {Δ : SimplexCategoryᵒᵖ} (f g : X.obj Δ ⟶ Z)
   Cofan.IsColimit.hom_ext (s.isColimit Δ) _ _ h
 
 theorem hom_ext (f g : X ⟶ Y) (h : ∀ n : ℕ, s.φ f n = s.φ g n) : f = g := by
-  ext Δ
+  ext ⟨Δ⟩
   apply s.hom_ext'
   intro A
-  induction' Δ using Opposite.rec with Δ
-  induction' Δ using SimplexCategory.rec with n
+  induction Δ using SimplexCategory.rec with | _ n
   dsimp
   simp only [s.cofan_inj_comp_app, h]
 

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Degenerate.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Degenerate.lean
@@ -115,7 +115,7 @@ lemma isIso_of_nonDegenerate (x : X.nonDegenerate n)
     (y : X.obj (op m)) (hy : X.map f.op y = x) :
     IsIso f := by
   obtain ⟨x, hx⟩ := x
-  induction' m using SimplexCategory.rec with m
+  induction m using SimplexCategory.rec with | _ m
   rw [mem_nonDegenerate_iff_notMem_degenerate] at hx
   by_contra!
   refine hx ⟨_ ,?_, f, y, hy⟩

--- a/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
@@ -86,7 +86,7 @@ in a nerve can be recovered from the underlying ReflPrefunctor. -/
 def toNerve₂.mk.app (n : SimplexCategory.Truncated 2) :
     X.obj (op n) ⟶ (nerveFunctor₂.obj (Cat.of C)).obj (op n) := by
   obtain ⟨n, hn⟩ := n
-  induction' n using SimplexCategory.rec with n
+  induction n using SimplexCategory.rec with | _ n
   match n with
   | 0 => exact fun x => .mk₀ (F.obj x)
   | 1 => exact fun f => .mk₁ (F.map ⟨f, rfl, rfl⟩)
@@ -299,7 +299,7 @@ theorem toNerve₂.ext (F G : X ⟶ nerveFunctor₂.obj (Cat.of C))
   have eq₁ (x : X _⦋1⦌₂) : F.app (op ⦋1⦌₂) x = G.app (op ⦋1⦌₂) x :=
     congr((($hyp).map ⟨x, rfl, rfl⟩).1)
   ext ⟨⟨n, hn⟩⟩ x
-  induction' n using SimplexCategory.rec with n
+  induction n using SimplexCategory.rec with | _ n
   match n with
   | 0 => apply eq₀
   | 1 => apply eq₁

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplex.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplex.lean
@@ -215,7 +215,7 @@ lemma face_eq_ofSimplex {n : ℕ} (S : Finset (Fin (n + 1))) (m : ℕ) (e : Fin 
           e.toOrderEmbedding.toOrderHom)) := by
   apply le_antisymm
   · rintro ⟨k⟩ x hx
-    induction' k using SimplexCategory.rec with k
+    induction k using SimplexCategory.rec with | _ k
     rw [mem_face_iff] at hx
     let φ : Fin (k + 1) →o S :=
       { toFun i := ⟨x i, hx i⟩
@@ -245,7 +245,7 @@ def faceRepresentableBy {n : ℕ} (S : Finset (Fin (n + 1)))
         ext i : 3
         apply e.symm_apply_apply
       right_inv := fun ⟨x, hx⟩ ↦ by
-        induction' j using SimplexCategory.rec with j
+        induction j using SimplexCategory.rec with | _ j
         dsimp
         ext i : 2
         exact congr_arg Subtype.val

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/EnoughInjectives.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/EnoughInjectives.lean
@@ -134,7 +134,7 @@ lemma exists_pushouts
 lemma exists_larger_subobject {X : C} (A : Subobject X) (hA : A ≠ ⊤) :
     ∃ (A' : Subobject X) (h : A < A'),
       (generatingMonomorphisms G).pushouts (Subobject.ofLE A A' h.le) := by
-  induction' A using Subobject.ind with Y f _
+  induction A using Subobject.ind with | _ f
   obtain ⟨X', i, p', hi, hi', hp', fac⟩ := exists_pushouts hG f
     (by simpa only [Subobject.isIso_iff_mk_eq_top] using hA)
   refine ⟨Subobject.mk p', Subobject.mk_lt_mk_of_comm i fac hi',

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/Subobject.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/Subobject.lean
@@ -62,8 +62,8 @@ lemma subobjectMk_of_isColimit_eq_iSup :
   apply le_antisymm
   · rw [le_iSup_iff]
     intro s H
-    induction' s using Subobject.ind with Z g _
-    let c' : Cocone (F ⋙ MonoOver.forget _ ⋙ Over.forget _) := Cocone.mk Z
+    induction s using Subobject.ind with | _ g
+    let c' : Cocone (F ⋙ MonoOver.forget _ ⋙ Over.forget _) := Cocone.mk _
       { app j := Subobject.ofMkLEMk _ _ (H j)
         naturality j j' f := by
           dsimp

--- a/Mathlib/CategoryTheory/Action/Concrete.lean
+++ b/Mathlib/CategoryTheory/Action/Concrete.lean
@@ -123,7 +123,7 @@ def toEndHom [N.Normal] : G →* End (G ⧸ₐ N) where
       simpa [mul_assoc] using Subgroup.Normal.conj_mem ‹_› _ (QuotientGroup.leftRel_apply.mp h) _
     comm := fun (g : G) ↦ by
       ext (x : G ⧸ N)
-      induction' x using Quotient.inductionOn with x
+      obtain ⟨x⟩ := x
       simp only [FintypeCat.comp_apply, Action.FintypeCat.ofMulAction_apply, Quotient.lift_mk]
       show Quotient.lift (fun σ ↦ ⟦σ * v⁻¹⟧) _ (⟦g • x⟧) = _
       simp only [smul_eq_mul, Quotient.lift_mk, mul_assoc]
@@ -132,12 +132,12 @@ def toEndHom [N.Normal] : G →* End (G ⧸ₐ N) where
   map_one' := by
     apply Action.hom_ext
     ext (x : G ⧸ N)
-    induction' x using Quotient.inductionOn with x
-    simp
+    obtain ⟨x⟩ := x
+    simp; rfl
   map_mul' σ τ := by
     apply Action.hom_ext
     ext (x : G ⧸ N)
-    induction' x using Quotient.inductionOn with x
+    obtain ⟨x⟩ := x
     show ⟦x * (σ * τ)⁻¹⟧ = ⟦x * τ⁻¹ * σ⁻¹⟧
     rw [mul_inv_rev, mul_assoc]
 
@@ -148,7 +148,7 @@ variable {N} in
 lemma toEndHom_trivial_of_mem [N.Normal] {n : G} (hn : n ∈ N) : toEndHom N n = 𝟙 (G ⧸ₐ N) := by
   apply Action.hom_ext
   ext (x : G ⧸ N)
-  induction' x using Quotient.inductionOn with μ
+  obtain ⟨μ⟩ := x
   exact Quotient.sound ((QuotientGroup.leftRel_apply).mpr <| by simpa)
 
 /-- If `H` and `N` are subgroups of a group `G` with `N` normal, there is a canonical
@@ -169,7 +169,7 @@ def quotientToQuotientOfLE [Fintype (G ⧸ H)] (h : N ≤ H) : (G ⧸ₐ N) ⟶ 
     (QuotientGroup.leftRel_apply).mpr (h <| (QuotientGroup.leftRel_apply).mp hab)
   comm g := by
     ext (x : G ⧸ N)
-    induction' x using Quotient.inductionOn with μ
+    obtain ⟨μ⟩ := x
     rfl
 
 @[simp]

--- a/Mathlib/CategoryTheory/Action/Concrete.lean
+++ b/Mathlib/CategoryTheory/Action/Concrete.lean
@@ -132,8 +132,8 @@ def toEndHom [N.Normal] : G →* End (G ⧸ₐ N) where
   map_one' := by
     apply Action.hom_ext
     ext (x : G ⧸ N)
-    obtain ⟨x⟩ := x
-    simp; rfl
+    induction x using Quotient.inductionOn
+    simp
   map_mul' σ τ := by
     apply Action.hom_ext
     ext (x : G ⧸ N)

--- a/Mathlib/CategoryTheory/Action/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Action/Monoidal.lean
@@ -244,10 +244,11 @@ variable {G}
 theorem diagonalSuccIsoTensorTrivial_hom_hom_apply {n : ℕ} (f : Fin (n + 1) → G) :
     (diagonalSuccIsoTensorTrivial G n).hom.hom f =
       (f 0, fun i => (f (Fin.castSucc i))⁻¹ * f i.succ) := by
-  induction' n with n hn
-  · exact Prod.ext rfl (funext fun x => Fin.elim0 x)
-  · refine Prod.ext rfl (funext fun x => ?_)
-    induction' x using Fin.cases
+  induction n with
+  | zero => exact Prod.ext rfl (funext fun x => Fin.elim0 x)
+  | succ n hn =>
+    refine Prod.ext rfl (funext fun x => ?_)
+    induction x using Fin.cases
     <;> simp_all only [tensorObj_V, diagonalSuccIsoTensorTrivial, Iso.trans_hom, tensorIso_hom,
       Iso.refl_hom, id_tensorHom, comp_hom, whiskerLeft_hom, types_comp_apply, whiskerLeft_apply,
       leftRegularTensorIso_hom_hom, tensor_ρ, tensor_apply, ofMulAction_apply]
@@ -257,12 +258,14 @@ theorem diagonalSuccIsoTensorTrivial_hom_hom_apply {n : ℕ} (f : Fin (n + 1) �
 theorem diagonalSuccIsoTensorTrivial_inv_hom_apply {n : ℕ} (g : G) (f : Fin n → G) :
     (diagonalSuccIsoTensorTrivial G n).inv.hom (g, f) =
       (g • Fin.partialProd f : Fin (n + 1) → G) := by
-  induction' n with n hn generalizing g
-  · funext (x : Fin 1)
+  induction n generalizing g with
+  | zero =>
+    funext (x : Fin 1)
     simp [diagonalSuccIsoTensorTrivial, diagonalOneIsoLeftRegular, Subsingleton.elim x 0,
       ofMulAction_V]
-  · funext x
-    induction' x using Fin.cases
+  | succ n hn =>
+    funext x
+    induction x using Fin.cases
     <;> simp_all only [diagonalSuccIsoTensorTrivial, Iso.trans_inv, comp_hom, mkIso_inv_hom,
         tensorObj_V, types_comp_apply, leftRegularTensorIso_inv_hom, tensor_ρ, tensor_apply,
         ofMulAction_apply]

--- a/Mathlib/CategoryTheory/ComposableArrows.lean
+++ b/Mathlib/CategoryTheory/ComposableArrows.lean
@@ -175,12 +175,12 @@ def homMk {F G : ComposableArrows C n} (app : ∀ i, F.obj i ⟶ G.obj i)
       obtain ⟨k, hk⟩ := Nat.le.dest hij'
       exact this k i j hk (by valid)
     intro k
-    induction' k with k hk
-    · intro i j hj hj'
+    induction k with intro i j hj hj'
+    | zero =>
       simp only [add_zero] at hj
       obtain rfl := hj
       rw [F.map'_self i, G.map'_self i, id_comp, comp_id]
-    · intro i j hj hj'
+    | succ k hk =>
       rw [← add_assoc] at hj
       subst hj
       rw [F.map'_comp i (i + k) (i + k + 1), G.map'_comp i (i + k) (i + k + 1), assoc,
@@ -836,11 +836,9 @@ variable (obj : Fin (n + 1) → C) (mapSucc : ∀ (i : Fin n), obj i.castSucc �
 lemma mkOfObjOfMapSucc_exists : ∃ (F : ComposableArrows C n) (e : ∀ i, F.obj i ≅ obj i),
     ∀ (i : ℕ) (hi : i < n), mapSucc ⟨i, hi⟩ =
       (e ⟨i, _⟩).inv ≫ F.map' i (i + 1) ≫ (e ⟨i + 1, _⟩).hom := by
-  revert obj mapSucc
-  induction' n with n hn
-  · intro obj _
-    exact ⟨mk₀ (obj 0), fun 0 => Iso.refl _, fun i hi => by simp at hi⟩
-  · intro obj mapSucc
+  induction n with
+  | zero => exact ⟨mk₀ (obj 0), fun 0 => Iso.refl _, fun i hi => by simp at hi⟩
+  | succ n hn =>
     obtain ⟨F, e, h⟩ := hn (fun i => obj i.succ) (fun i => mapSucc i.succ)
     refine ⟨F.precomp (mapSucc 0 ≫ (e 0).inv), fun i => match i with
       | 0 => Iso.refl _

--- a/Mathlib/CategoryTheory/Extensive.lean
+++ b/Mathlib/CategoryTheory/Extensive.lean
@@ -448,9 +448,10 @@ theorem FinitaryExtensive.isVanKampen_finiteCoproducts_Fin [FinitaryExtensive C]
     Functor.hext (fun _ ↦ rfl) (by rintro ⟨i⟩ ⟨j⟩ ⟨⟨rfl : i = j⟩⟩; simp [f])
   clear_value f
   subst this
-  induction' n with n IH
-  · exact isVanKampenColimit_of_isEmpty _ hc
-  · apply IsVanKampenColimit.of_iso _
+  induction n with
+  | zero => exact isVanKampenColimit_of_isEmpty _ hc
+  | succ n IH =>
+    apply IsVanKampenColimit.of_iso _
       ((extendCofanIsColimit f (coproductIsCoproduct _) (coprodIsCoprod _ _)).uniqueUpToIso hc)
     apply @isVanKampenColimit_extendCofan _ _ _ _ _ _ _ _ ?_
     · apply IH

--- a/Mathlib/CategoryTheory/Filtered/Basic.lean
+++ b/Mathlib/CategoryTheory/Filtered/Basic.lean
@@ -205,9 +205,10 @@ variable [IsFiltered C]
 -/
 theorem sup_objs_exists (O : Finset C) : ∃ S : C, ∀ {X}, X ∈ O → Nonempty (X ⟶ S) := by
   classical
-  induction' O using Finset.induction with X O' nm h
-  · exact ⟨Classical.choice IsFiltered.nonempty, by intro; simp⟩
-  · obtain ⟨S', w'⟩ := h
+  induction O using Finset.induction with
+  | empty => exact ⟨Classical.choice IsFiltered.nonempty, by intro; simp⟩
+  | insert X O' nm h =>
+    obtain ⟨S', w'⟩ := h
     use max X S'
     rintro Y mY
     obtain rfl | h := eq_or_ne Y X
@@ -227,10 +228,12 @@ theorem sup_exists :
         (⟨X, Y, mX, mY, f⟩ : Σ' (X Y : C) (_ : X ∈ O) (_ : Y ∈ O), X ⟶ Y) ∈ H →
           f ≫ T mY = T mX := by
   classical
-  induction' H using Finset.induction with h' H' nmf h''
-  · obtain ⟨S, f⟩ := sup_objs_exists O
+  induction H using Finset.induction with
+  | empty =>
+    obtain ⟨S, f⟩ := sup_objs_exists O
     exact ⟨S, fun mX => (f mX).some, by rintro - - - - - ⟨⟩⟩
-  · obtain ⟨X, Y, mX, mY, f⟩ := h'
+  | insert h' H' nmf h'' =>
+    obtain ⟨X, Y, mX, mY, f⟩ := h'
     obtain ⟨S', T', w'⟩ := h''
     refine ⟨coeq (f ≫ T' mY) (T' mX), fun mZ => T' mZ ≫ coeqHom (f ≫ T' mY) (T' mX), ?_⟩
     intro X' Y' mX' mY' f' mf'
@@ -662,9 +665,10 @@ variable [IsCofiltered C]
 -/
 theorem inf_objs_exists (O : Finset C) : ∃ S : C, ∀ {X}, X ∈ O → Nonempty (S ⟶ X) := by
   classical
-  induction' O using Finset.induction with X O' nm h
-  · exact ⟨Classical.choice IsCofiltered.nonempty, by intro; simp⟩
-  · obtain ⟨S', w'⟩ := h
+  induction O using Finset.induction with
+  | empty => exact ⟨Classical.choice IsCofiltered.nonempty, by intro; simp⟩
+  | insert X O' nm h =>
+    obtain ⟨S', w'⟩ := h
     use min X S'
     rintro Y mY
     obtain rfl | h := eq_or_ne Y X
@@ -684,10 +688,12 @@ theorem inf_exists :
         (⟨X, Y, mX, mY, f⟩ : Σ' (X Y : C) (_ : X ∈ O) (_ : Y ∈ O), X ⟶ Y) ∈ H →
           T mX ≫ f = T mY := by
   classical
-  induction' H using Finset.induction with h' H' nmf h''
-  · obtain ⟨S, f⟩ := inf_objs_exists O
+  induction H using Finset.induction with
+  | empty =>
+    obtain ⟨S, f⟩ := inf_objs_exists O
     exact ⟨S, fun mX => (f mX).some, by rintro - - - - - ⟨⟩⟩
-  · obtain ⟨X, Y, mX, mY, f⟩ := h'
+  | insert h' H' nmf h'' =>
+    obtain ⟨X, Y, mX, mY, f⟩ := h'
     obtain ⟨S', T', w'⟩ := h''
     refine ⟨eq (T' mX ≫ f) (T' mY), fun mZ => eqHom (T' mX ≫ f) (T' mY) ≫ T' mZ, ?_⟩
     intro X' Y' mX' mY' f' mf'

--- a/Mathlib/CategoryTheory/Galois/Decomposition.lean
+++ b/Mathlib/CategoryTheory/Galois/Decomposition.lean
@@ -77,7 +77,7 @@ private lemma has_decomp_connected_components_aux (F : C ⥤ FintypeCat.{w}) [Fi
     (n : ℕ) : ∀ (X : C), n = Nat.card (F.obj X) → ∃ (ι : Type) (f : ι → C)
     (g : (i : ι) → (f i) ⟶ X) (_ : IsColimit (Cofan.mk X g)),
     (∀ i, IsConnected (f i)) ∧ Finite ι := by
-  induction' n using Nat.strongRecOn with n hi
+  induction n using Nat.strongRecOn with | _ n hi
   intro X hn
   by_cases h : IsConnected X
   · exact has_decomp_connected_components_aux_conn X

--- a/Mathlib/CategoryTheory/Galois/EssSurj.lean
+++ b/Mathlib/CategoryTheory/Galois/EssSurj.lean
@@ -152,7 +152,7 @@ private def coconeQuotientDiag :
     rw [← cancel_epi (u.inv), Iso.inv_hom_id_assoc]
     apply Action.hom_ext
     ext (x : Aut F ⧸ U.toSubgroup)
-    induction' m, x using Quotient.inductionOn₂ with σ μ
+    induction m, x using Quotient.inductionOn₂ with | _ σ μ
     suffices h : ⟦μ * σ⁻¹⟧ = ⟦μ⟧ by
       simp only [quotientToQuotientOfLE_hom_mk, quotientDiag_map,
         functorToAction_map_quotientToEndObjectHom V _ u]
@@ -179,7 +179,7 @@ private def coconeQuotientDiagDesc
     simp only [← h2, const_obj_obj, Action.comp_hom, FintypeCat.comp_apply]
   comm g := by
     ext (x : Aut F ⧸ V.toSubgroup)
-    induction' x using Quotient.inductionOn with σ
+    obtain ⟨σ⟩ := x
     simp only [const_obj_obj]
     show (((Aut F ⧸ₐ U.toSubgroup).ρ g ≫ u.inv.hom) ≫ (s.ι.app (SingleObj.star _)).hom) ⟦σ⟧ =
       ((s.ι.app (SingleObj.star _)).hom ≫ s.pt.ρ g) (u.inv.hom ⟦σ⟧)
@@ -197,14 +197,14 @@ private def coconeQuotientDiagIsColimit :
     apply (cancel_epi u.inv).mp
     apply Action.hom_ext
     ext (x : Aut F ⧸ U.toSubgroup)
-    induction' x using Quotient.inductionOn with σ
+    obtain ⟨σ⟩ := x
     simp
     rfl
   uniq s f hf := by
     apply Action.hom_ext
     ext (x : Aut F ⧸ V.toSubgroup)
-    induction' x using Quotient.inductionOn with σ
-    simp [← hf (SingleObj.star _)]
+    obtain ⟨σ⟩ := x
+    simp [← hf (SingleObj.star _)]; rfl
 
 end
 
@@ -224,7 +224,7 @@ lemma exists_lift_of_quotient_openSubgroup (V : OpenSubgroup (Aut F)) :
   have h1 (σ : Aut F) (σinU : σ ∈ U) : σ.hom.app A = 𝟙 (F.obj A) := by
     have hi : (Aut F ⧸ₐ MulAction.stabilizer (Aut F) a).ρ σ = 𝟙 _ := by
       refine FintypeCat.hom_ext _ _ (fun x ↦ ?_)
-      induction' x using Quotient.inductionOn with τ
+      obtain ⟨τ⟩ := x
       show ⟦σ * τ⟧ = ⟦τ⟧
       apply Quotient.sound
       apply (QuotientGroup.leftRel_apply).mpr

--- a/Mathlib/CategoryTheory/Limits/Shapes/Equalizers.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Equalizers.lean
@@ -145,11 +145,11 @@ def walkingParallelPairOpEquiv : WalkingParallelPair ≌ WalkingParallelPairᵒ�
       (by rintro _ _ (_ | _ | _) <;> simp)
   counitIso :=
     NatIso.ofComponents (fun j => eqToIso (by
-            induction' j with X
+            obtain ⟨X⟩ := j
             cases X <;> rfl))
       (fun {i} {j} f => by
-      induction' i with i
-      induction' j with j
+      obtain ⟨i⟩ := i
+      obtain ⟨j⟩ := j
       let g := f.unop
       have : f = g.op := rfl
       rw [this]

--- a/Mathlib/CategoryTheory/Limits/Shapes/SequentialProduct.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/SequentialProduct.lean
@@ -72,9 +72,10 @@ lemma functorMap_commSq_aux {n m k : ℕ} (h : n ≤ m) (hh : ¬(k < m)) :
       eqToHom (functorObj_eq_neg (by omega : ¬(k < n))) =
         (Pi.π (fun i ↦ if _ : i < m then M i else N i) k) ≫
           eqToHom (functorObj_eq_neg hh) := by
-  induction' h using Nat.leRec with m h ih
-  · simp
-  · specialize ih (by omega)
+  induction h using Nat.leRec with
+  | refl => simp
+  | @le_succ_of_le m h ih =>
+    specialize ih (by omega)
     have : homOfLE (by omega : n ≤ m + 1) =
         homOfLE (by omega : n ≤ m) ≫ homOfLE (by omega : m ≤ m + 1) := by simp
     rw [this, op_comp, Functor.map_comp]
@@ -174,9 +175,10 @@ noncomputable def isLimit : IsLimit (cone f) where
       simp only [Functor.const_obj_obj, Functor.ofOpSequence_obj, homOfLE_leOfHom, le_refl,
         Category.assoc]
       congr
-      induction' hh using Nat.leRec with n hh ih
-      · simp
-      · have : homOfLE (Nat.le_succ_of_le hh) = homOfLE hh ≫ homOfLE (Nat.le_succ n) := by simp
+      induction hh using Nat.leRec with
+      | refl => simp
+      | @le_succ_of_le n hh ih =>
+        have : homOfLE (Nat.le_succ_of_le hh) = homOfLE hh ≫ homOfLE (Nat.le_succ n) := by simp
         rw [this, op_comp, Functor.map_comp]
         simp only [Functor.ofOpSequence_obj, Nat.succ_eq_add_one, homOfLE_leOfHom,
           Functor.ofOpSequence_map_homOfLE_succ, le_refl, Category.assoc]

--- a/Mathlib/CategoryTheory/Limits/Types/Colimits.lean
+++ b/Mathlib/CategoryTheory/Limits/Types/Colimits.lean
@@ -227,7 +227,7 @@ def colimitCoconeIsColimit (F : J ⥤ Type max v u) : IsColimit (colimitCocone F
       exact (congr_fun (Cocone.w s f) x).symm
   uniq s m hm := by
     funext x
-    induction' x using Quot.ind with x
+    obtain ⟨x⟩ := x
     exact congr_fun (hm x.1) x.2
 
 end TypeMax

--- a/Mathlib/CategoryTheory/Limits/VanKampen.lean
+++ b/Mathlib/CategoryTheory/Limits/VanKampen.lean
@@ -633,7 +633,7 @@ theorem isUniversalColimit_extendCofan {n : ℕ} (f : Fin (n + 1) → C)
   rintro ⟨j⟩
   simp only [Discrete.functor_obj, limit.lift_π, PullbackCone.mk_pt,
     PullbackCone.mk_π_app, Category.comp_id]
-  induction' j using Fin.inductionOn
+  induction j using Fin.inductionOn
   · simp only [Fin.cases_zero]
   · simp only [Fin.cases_succ]
 
@@ -687,13 +687,14 @@ theorem isVanKampenColimit_extendCofan {n : ℕ} (f : Fin (n + 1) → C)
         (fun i ↦ Sigma.ι (fun (j : Fin n) ↦ (Discrete.functor F').obj ⟨j.succ⟩) _ ≫ f₂))) _ ?_
       intro ⟨j⟩
       simp only [Discrete.functor_obj, Cofan.mk_pt, Functor.const_obj_obj, Cofan.mk_ι_app]
-      induction' j using Fin.inductionOn with j _
+      induction j using Fin.inductionOn
       · simp only [Fin.cases_zero, m₁]
       · simp only [← m₂, colimit.ι_desc_assoc, Discrete.functor_obj,
           Cofan.mk_pt, Cofan.mk_ι_app, Fin.cases_succ]
-  induction' j using Fin.inductionOn with j _
-  · exact t₂' ⟨WalkingPair.left⟩
-  · have t₁' := (@t₁ (Discrete.functor (fun j ↦ F.obj ⟨j.succ⟩)) (Cofan.mk _ _) (Discrete.natTrans
+  induction j using Fin.inductionOn with
+  | zero => exact t₂' ⟨WalkingPair.left⟩
+  | succ j _ =>
+    have t₁' := (@t₁ (Discrete.functor (fun j ↦ F.obj ⟨j.succ⟩)) (Cofan.mk _ _) (Discrete.natTrans
       fun i ↦ α.app _) (Sigma.desc (fun j ↦ α.app _ ≫ c₁.inj _)) ?_
       (NatTrans.equifibered_of_discrete _)).mp ⟨coproductIsCoproduct _⟩ ⟨j⟩
     rotate_left

--- a/Mathlib/CategoryTheory/Quotient.lean
+++ b/Mathlib/CategoryTheory/Quotient.lean
@@ -148,8 +148,7 @@ protected theorem sound {a b : C} {f₁ f₂ : a ⟶ b} (h : r f₁ f₂) :
 lemma compClosure_iff_self [h : Congruence r] {X Y : C} (f g : X ⟶ Y) :
     CompClosure r f g ↔ r f g := by
   constructor
-  · intro hfg
-    induction' hfg with m m' hm
+  · rintro ⟨hfg⟩
     exact Congruence.compLeft _ (Congruence.compRight _ (by assumption))
   · exact CompClosure.of _ _ _
 

--- a/Mathlib/CategoryTheory/Sites/Sheaf.lean
+++ b/Mathlib/CategoryTheory/Sites/Sheaf.lean
@@ -453,11 +453,11 @@ instance sheafHomHasZSMul : SMul ℤ (P ⟶ Q) where
     Sheaf.Hom.mk
       { app := fun U => n • f.1.app U
         naturality := fun U V i => by
-          induction' n with n ih n ih
-          · simp only [zero_smul, comp_zero, zero_comp]
-          · simpa only [add_zsmul, one_zsmul, comp_add, NatTrans.naturality, add_comp,
+          induction n with
+          | zero => simp only [zero_smul, comp_zero, zero_comp]
+          | succ n ih => simpa only [add_zsmul, one_zsmul, comp_add, NatTrans.naturality, add_comp,
               add_left_inj]
-          · simpa only [sub_smul, one_zsmul, comp_sub, NatTrans.naturality, sub_comp,
+          | pred n ih => simpa only [sub_smul, one_zsmul, comp_sub, NatTrans.naturality, sub_comp,
               sub_left_inj] using ih }
 
 instance : Sub (P ⟶ Q) where sub f g := Sheaf.Hom.mk <| f.1 - g.1

--- a/Mathlib/CategoryTheory/Subobject/Basic.lean
+++ b/Mathlib/CategoryTheory/Subobject/Basic.lean
@@ -533,12 +533,12 @@ def pullback (f : X ⟶ Y) : Subobject Y ⥤ Subobject X :=
   lower (MonoOver.pullback f)
 
 theorem pullback_id (x : Subobject X) : (pullback (𝟙 X)).obj x = x := by
-  induction' x using Quotient.inductionOn' with f
+  obtain ⟨f⟩ := x
   exact Quotient.sound ⟨MonoOver.pullbackId.app f⟩
 
 theorem pullback_comp (f : X ⟶ Y) (g : Y ⟶ Z) (x : Subobject Z) :
     (pullback (f ≫ g)).obj x = (pullback f).obj ((pullback g).obj x) := by
-  induction' x using Quotient.inductionOn' with t
+  obtain ⟨t⟩ := x
   exact Quotient.sound ⟨(MonoOver.pullbackComp _ _).app t⟩
 
 theorem pullback_obj_mk {A B X Y : C} {f : Y ⟶ X} {i : A ⟶ X} [Mono i]
@@ -605,19 +605,18 @@ lemma map_mk {A X Y : C} (i : A ⟶ X) [Mono i] (f : X ⟶ Y) [Mono f] :
   rfl
 
 theorem map_id (x : Subobject X) : (map (𝟙 X)).obj x = x := by
-  induction' x using Quotient.inductionOn' with f
+  obtain ⟨f⟩ := x
   exact Quotient.sound ⟨(MonoOver.mapId _).app f⟩
 
 theorem map_comp (f : X ⟶ Y) (g : Y ⟶ Z) [Mono f] [Mono g] (x : Subobject X) :
     (map (f ≫ g)).obj x = (map g).obj ((map f).obj x) := by
-  induction' x using Quotient.inductionOn' with t
+  obtain ⟨t⟩ := x
   exact Quotient.sound ⟨(MonoOver.mapComp _ _).app t⟩
 
 lemma map_obj_injective {X Y : C} (f : X ⟶ Y) [Mono f] :
-    Function.Injective (Subobject.map f).obj := by
-  intro X₁ X₂ h
-  induction' X₁ using Subobject.ind with X₁ i₁ _
-  induction' X₂ using Subobject.ind with X₂ i₂ _
+    Function.Injective (Subobject.map f).obj := fun X₁ X₂ h ↦ by
+  induction X₁ using Subobject.ind
+  induction X₂ using Subobject.ind
   simp only [map_mk] at h
   exact mk_eq_mk_of_comm _ _ (isoOfMkEqMk _ _ h) (by simp [← cancel_mono f])
 

--- a/Mathlib/CategoryTheory/Subobject/FactorThru.lean
+++ b/Mathlib/CategoryTheory/Subobject/FactorThru.lean
@@ -84,7 +84,7 @@ theorem factors_comp_arrow {X Y : C} {P : Subobject Y} (f : X ⟶ P) : P.Factors
 
 theorem factors_of_factors_right {X Y Z : C} {P : Subobject Z} (f : X ⟶ Y) {g : Y ⟶ Z}
     (h : P.Factors g) : P.Factors (f ≫ g) := by
-  induction' P using Quotient.ind' with P
+  obtain ⟨P⟩ := P
   obtain ⟨g, rfl⟩ := h
   exact ⟨f ≫ g, by simp⟩
 

--- a/Mathlib/CategoryTheory/Subobject/Lattice.lean
+++ b/Mathlib/CategoryTheory/Subobject/Lattice.lean
@@ -410,7 +410,7 @@ theorem finset_inf_arrow_factors {I : Type*} {B : C} (s : Finset I) (P : I → S
 theorem inf_eq_map_pullback' {A : C} (f₁ : MonoOver A) (f₂ : Subobject A) :
     (Subobject.inf.obj (Quotient.mk'' f₁)).obj f₂ =
       (Subobject.map f₁.arrow).obj ((Subobject.pullback f₁.arrow).obj f₂) := by
-  induction' f₂ using Quotient.inductionOn' with f₂
+  obtain ⟨f₂⟩ := f₂
   rfl
 
 theorem inf_eq_map_pullback {A : C} (f₁ : MonoOver A) (f₂ : Subobject A) :

--- a/Mathlib/CategoryTheory/Triangulated/TStructure/Basic.lean
+++ b/Mathlib/CategoryTheory/Triangulated/TStructure/Basic.lean
@@ -126,9 +126,9 @@ lemma le_monotone : Monotone t.le := by
     rw [← h, Nat.cast_add, ← add_assoc]
     exact (ha n).trans (hb (n+a))
   intro a
-  induction' a with a ha
-  · exact H_zero
-  · exact H_add a 1 _ rfl ha H_one
+  induction a with
+  | zero => exact H_zero
+  | succ a ha => exact H_add a 1 _ rfl ha H_one
 
 lemma ge_antitone : Antitone t.ge := by
   let H := fun (a : ℕ) => ∀ (n : ℤ), t.ge (n + a) ≤ t.ge n
@@ -149,9 +149,9 @@ lemma ge_antitone : Antitone t.ge := by
     rw [← h, Nat.cast_add, ← add_assoc ]
     exact (hb (n + a)).trans (ha n)
   intro a
-  induction' a with a ha
-  · exact H_zero
-  · exact H_add a 1 _ rfl ha H_one
+  induction a with
+  | zero => exact H_zero
+  | succ a ha => exact H_add a 1 _ rfl ha H_one
 
 /-- Given a t-structure `t` on a pretriangulated category `C`, the property `t.IsLE X n`
 holds if `X : C` is `≤ n` for the t-structure. -/


### PR DESCRIPTION
Most replacements that are also in #23676 have been copied over, but some have been optimised further.