### PR TITLE
[Merged by Bors] - refactor: make `Rel` less see-through

### DIFF
--- a/Mathlib/Combinatorics/Hall/Basic.lean
+++ b/Mathlib/Combinatorics/Hall/Basic.lean
@@ -36,7 +36,7 @@ The core of this module is constructing the inverse system: for every finite sub
 
 * `Finset.all_card_le_biUnion_card_iff_exists_injective` is in terms of `t : ι → Finset α`.
 * `Fintype.all_card_le_rel_image_card_iff_exists_injective` is in terms of a relation
-  `r : α → β → Prop` such that `Rel.image r {a}` is a finite set for all `a : α`.
+  `r : α → β → Prop` such that `R.image {a}` is a finite set for all `a : α`.
 * `Fintype.all_card_le_filter_rel_iff_exists_injective` is in terms of a relation
   `r : α → β → Prop` on finite types, with the Hall condition given in terms of
   `finset.univ.filter`.
@@ -51,6 +51,7 @@ Hall's Marriage Theorem, indexed families
 -/
 
 open Finset Function CategoryTheory
+open scoped Rel
 
 universe u v
 
@@ -156,9 +157,9 @@ theorem Finset.all_card_le_biUnion_card_iff_exists_injective {ι : Type u} {α :
 
 /-- Given a relation such that the image of every singleton set is finite, then the image of every
 finite set is finite. -/
-instance {α : Type u} {β : Type v} [DecidableEq β] (r : α → β → Prop)
-    [∀ a : α, Fintype (Rel.image r {a})] (A : Finset α) : Fintype (Rel.image r A) := by
-  have h : Rel.image r A = (A.biUnion fun a => (Rel.image r {a}).toFinset : Set β) := by
+instance {α : Type u} {β : Type v} [DecidableEq β] (R : Rel α β)
+    [∀ a : α, Fintype (R.image {a})] (A : Finset α) : Fintype (R.image A) := by
+  have h : R.image A = (A.biUnion fun a => (R.image {a}).toFinset : Set β) := by
     ext
     simp [Rel.image]
   rw [h]
@@ -172,20 +173,20 @@ a transversal of the relation (an injective function `α → β` whose graph is
 a subrelation of the relation) iff every subset of
 `k` terms of `α` is related to at least `k` terms of `β`.
 
-Note: if `[Fintype β]`, then there exist instances for `[∀ (a : α), Fintype (Rel.image r {a})]`.
+Note: if `[Fintype β]`, then there exist instances for `[∀ (a : α), Fintype (R.image {a})]`.
 -/
 theorem Fintype.all_card_le_rel_image_card_iff_exists_injective {α : Type u} {β : Type v}
-    [DecidableEq β] (r : α → β → Prop) [∀ a : α, Fintype (Rel.image r {a})] :
-    (∀ A : Finset α, #A ≤ Fintype.card (Rel.image r A)) ↔
-      ∃ f : α → β, Function.Injective f ∧ ∀ x, r x (f x) := by
-  let r' a := (Rel.image r {a}).toFinset
-  have h : ∀ A : Finset α, Fintype.card (Rel.image r A) = #(A.biUnion r') := by
+    [DecidableEq β] (R : Rel α β) [∀ a : α, Fintype (R.image {a})] :
+    (∀ A : Finset α, #A ≤ Fintype.card (R.image A)) ↔
+      ∃ f : α → β, Function.Injective f ∧ ∀ x, x ~[R] f x := by
+  let r' a := (R.image {a}).toFinset
+  have h : ∀ A : Finset α, Fintype.card (R.image A) = #(A.biUnion r') := by
     intro A
     rw [← Set.toFinset_card]
     apply congr_arg
     ext b
     simp [r', Rel.image]
-  have h' : ∀ (f : α → β) (x), r x (f x) ↔ f x ∈ r' x := by simp [r', Rel.image]
+  have h' : ∀ (f : α → β) (x), x ~[R] f x ↔ f x ∈ r' x := by simp [r', Rel.image]
   simp only [h, h']
   apply Finset.all_card_le_biUnion_card_iff_exists_injective
 

--- a/Mathlib/Combinatorics/SimpleGraph/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Basic.lean
@@ -388,13 +388,13 @@ end Order
 
 /-- `G.support` is the set of vertices that form edges in `G`. -/
 def support : Set V :=
-  Rel.dom G.Adj
+  Rel.dom {(u, v) : V × V | G.Adj u v}
 
 theorem mem_support {v : V} : v ∈ G.support ↔ ∃ w, G.Adj v w :=
   Iff.rfl
 
 theorem support_mono {G G' : SimpleGraph V} (h : G ≤ G') : G.support ⊆ G'.support :=
-  Rel.dom_mono h
+  Rel.dom_mono fun _uv huv ↦ h huv
 
 /-- `G.neighborSet v` is the set of vertices adjacent to `v` in `G`. -/
 def neighborSet (v : V) : Set V := {w | G.Adj v w}

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
@@ -184,7 +184,7 @@ lemma Preconnected.support_eq_univ [Nontrivial V] {G : SimpleGraph V}
   obtain ⟨p⟩ := h v w
   cases p with
   | nil => contradiction
-  | @cons _ w => use w
+  | @cons _ w => exact ⟨w, ‹_›⟩
 
 lemma adj_of_mem_walk_support {G : SimpleGraph V} {u v : V} (p : G.Walk u v) (hp : ¬p.Nil) {x : V}
     (hx : x ∈ p.support) : ∃y ∈ p.support, G.Adj x y := by

--- a/Mathlib/Combinatorics/SimpleGraph/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Subgraph.lean
@@ -202,7 +202,7 @@ def IsInduced (G' : Subgraph G) : Prop :=
   ⟨coe_adj_sub _ _ _, hG' a.2 b.2⟩
 
 /-- `H.support` is the set of vertices that form edges in the subgraph `H`. -/
-def support (H : Subgraph G) : Set V := Rel.dom H.Adj
+def support (H : Subgraph G) : Set V := Rel.dom {(v, w) | H.Adj v w}
 
 theorem mem_support (H : Subgraph G) {v : V} : v ∈ H.support ↔ ∃ w, H.Adj v w := Iff.rfl
 
@@ -564,7 +564,7 @@ def _root_.SimpleGraph.toSubgraph (H : SimpleGraph V) (h : H ≤ G) : G.Subgraph
   symm := H.symm
 
 theorem support_mono {H H' : Subgraph G} (h : H ≤ H') : H.support ⊆ H'.support :=
-  Rel.dom_mono h.2
+  Rel.dom_mono fun _ hvw ↦ h.2 hvw
 
 theorem _root_.SimpleGraph.toSubgraph.isSpanning (H : SimpleGraph V) (h : H ≤ G) :
     (toSubgraph H h).IsSpanning :=

--- a/Mathlib/Data/PFun.lean
+++ b/Mathlib/Data/PFun.lean
@@ -142,7 +142,7 @@ def graph (f : α →. β) : Set (α × β) :=
 
 /-- Graph of a partial function as a relation. `x` and `y` are related iff `f x` is defined and
 "equals" `y`. -/
-def graph' (f : α →. β) : Rel α β := fun x y => y ∈ f x
+def graph' (f : α →. β) : Rel α β := {(x, y) : α × β | y ∈ f x}
 
 /-- The range of a partial function is the set of values
   `f x` where `x` is in the domain of `f`. -/
@@ -352,17 +352,16 @@ theorem mem_image (y : β) (s : Set α) : y ∈ f.image s ↔ ∃ x ∈ s, y ∈
   Iff.rfl
 
 theorem image_mono {s t : Set α} (h : s ⊆ t) : f.image s ⊆ f.image t :=
-  Rel.image_mono _ h
+  Rel.image_mono h
 
 theorem image_inter (s t : Set α) : f.image (s ∩ t) ⊆ f.image s ∩ f.image t :=
-  Rel.image_inter _ s t
+  Rel.image_inter_subset _
 
 theorem image_union (s t : Set α) : f.image (s ∪ t) = f.image s ∪ f.image t :=
   Rel.image_union _ s t
 
 /-- Preimage of a set under a partial function. -/
-def preimage (s : Set β) : Set α :=
-  Rel.image (fun x y => x ∈ f y) s
+def preimage (s : Set β) : Set α := f.graph'.preimage s
 
 theorem Preimage_def (s : Set β) : f.preimage s = { x | ∃ y ∈ s, y ∈ f x } :=
   rfl
@@ -375,10 +374,10 @@ theorem preimage_subset_dom (s : Set β) : f.preimage s ⊆ f.Dom := fun _ ⟨y,
   Part.dom_iff_mem.mpr ⟨y, fxy⟩
 
 theorem preimage_mono {s t : Set β} (h : s ⊆ t) : f.preimage s ⊆ f.preimage t :=
-  Rel.preimage_mono _ h
+  Rel.preimage_mono h
 
 theorem preimage_inter (s t : Set β) : f.preimage (s ∩ t) ⊆ f.preimage s ∩ f.preimage t :=
-  Rel.preimage_inter _ s t
+  Rel.preimage_inter_subset _
 
 theorem preimage_union (s t : Set β) : f.preimage (s ∪ t) = f.preimage s ∪ f.preimage t :=
   Rel.preimage_union _ s t
@@ -403,7 +402,7 @@ theorem compl_dom_subset_core (s : Set β) : f.Domᶜ ⊆ f.core s := fun x hx y
   absurd ((mem_dom f x).mpr ⟨y, fxy⟩) hx
 
 theorem core_mono {s t : Set β} (h : s ⊆ t) : f.core s ⊆ f.core t :=
-  Rel.core_mono _ h
+  Rel.core_mono h
 
 theorem core_inter (s t : Set β) : f.core (s ∩ t) = f.core s ∩ f.core t :=
   Rel.core_inter _ s t
@@ -428,7 +427,7 @@ theorem preimage_eq (f : α →. β) (s : Set β) : f.preimage s = f.core s ∩ 
   Set.eq_of_subset_of_subset (Set.subset_inter (f.preimage_subset_core s) (f.preimage_subset_dom s))
     fun x ⟨xcore, xdom⟩ =>
     let y := (f x).get xdom
-    have ys : y ∈ s := xcore _ (Part.get_mem _)
+    have ys : y ∈ s := xcore (Part.get_mem _)
     show x ∈ f.preimage s from ⟨(f x).get xdom, ys, Part.get_mem _⟩
 
 theorem core_eq (f : α →. β) (s : Set β) : f.core s = f.preimage s ∪ f.Domᶜ := by

--- a/Mathlib/Data/Rel.lean
+++ b/Mathlib/Data/Rel.lean
@@ -4,362 +4,335 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad
 -/
 import Mathlib.Data.Set.BooleanAlgebra
-import Mathlib.Tactic.AdaptationNote
 
 /-!
-# Relations
+# Relations as sets of pairs
 
-This file defines bundled relations. A relation between `α` and `β` is a function `α → β → Prop`.
-Relations are also known as set-valued functions, or partial multifunctions.
+This file provides API to regard relations between `α` and `β`  as sets of pairs `Set (α × β)`.
+
+This is in particular useful in the study of uniform spaces, which are topological spaces equipped
+with a *uniformity*, namely a filter of pairs `α × α` whose elements can be viewed as "proximity"
+relations.
 
 ## Main declarations
 
-* `Rel α β`: Relation between `α` and `β`.
-* `Rel.inv`: `r.inv` is the `Rel β α` obtained by swapping the arguments of `r`.
-* `Rel.dom`: Domain of a relation. `x ∈ r.dom` iff there exists `y` such that `r x y`.
-* `Rel.codom`: Codomain, aka range, of a relation. `y ∈ r.codom` iff there exists `x` such that
-  `r x y`.
-* `Rel.comp`: Relation composition. Note that the arguments order follows the `CategoryTheory/`
-  one, so `r.comp s x z ↔ ∃ y, r x y ∧ s y z`.
-* `Rel.image`: Image of a set under a relation. `r.image s` is the set of `f x` over all `x ∈ s`.
-* `Rel.preimage`: Preimage of a set under a relation. Note that `r.preimage = r.inv.image`.
-* `Rel.core`: Core of a set. For `s : Set β`, `r.core s` is the set of `x : α` such that all `y`
-  related to `x` are in `s`.
-* `Rel.restrict_domain`: Domain-restriction of a relation to a subtype.
+* `Rel α β`: Type of relations between `α` and `β`.
+* `Rel.inv`: Turn `R : Rel α β` into `R.inv : Rel β α` by swapping the arguments.
+* `Rel.dom`: Domain of a relation. `a ∈ R.dom` iff there exists `b` such that `a ~[R] b`.
+* `Rel.cod`: Codomain of a relation. `b ∈ R.cod` iff there exists `a` such that `a ~[R] b`.
+* `Rel.id`: The identity relation `Rel α α`.
+* `Rel.comp`: Relation composition. Note that the arguments order follows the category theory
+  convention, namely `(R ○ S) a c ↔ ∃ b, a ~[R] b ∧ b ~[S] z`.
+* `Rel.image`: Image of a set under a relation. `b ∈ image R s` iff there exists `a ∈ s`
+  such that `a ~[R] b`.
+  If `R` is the graph of `f` (`a ~[R] b ↔ f a = b`), then `R.image = Set.image f`.
+* `Rel.preimage`: Preimage of a set under a relation. `a ∈ preimage R t` iff there exists `b ∈ t`
+  such that `a ~[R] b`.
+  If `R` is the graph of `f` (`a ~[R] b ↔ f a = b`), then `R.preimage = Set.preimage f`.
+* `Rel.core`: Core of a set. For `t : Set β`, `a ∈ R.core t` iff all `b` related to `a` are in `t`.
+* `Rel.restrictDomain`: Domain-restriction of a relation to a subtype.
 * `Function.graph`: Graph of a function as a relation.
 
-## TODO
+## Implementation notes
 
-The `Rel.comp` function uses the notation `r • s`, rather than the more common `r ∘ s` for things
-named `comp`. This is because the latter is already used for function composition, and causes a
-clash. A better notation should be found, perhaps a variant of `r ∘r s` or `r; s`.
+There is tension throughout the library between considering relations between `α` and `β` simply as
+`α → β → Prop`, or as a bundled object `Rel α β` with dedicated operations and API.
 
+The former approach is used almost everywhere as it is very lightweight and has arguably native
+support from core Lean features, but it cracks at the seams whenever one starts talking about
+operations on relations. For example:
+* composition of relations `R : α → β → Prop`, `S : β → γ → Prop` is
+  `Relation.Comp R S := fun a c ↦ ∃ b, R a b ∧ S b c`
+* map of a relation `R : α → β → Prop` under `f : α → γ`, `g : β → δ` is
+  `Relation.map R f g := fun c d ↦ ∃ a b, r a b ∧ f a = c ∧ g b = d`.
+
+The latter approach is embodied by `Rel α β`, with dedicated notation like `○` for composition.
+
+Previously, `Rel` suffered from the leakage of its definition as
+```
+def Rel (α β : Type*) := α → β → Prop
+```
+The fact that `Rel` wasn't an `abbrev` confuses automation. But simply making it an `abbrev` would
+have killed the point of having a separate less see-through type to perform relation operations on,
+so we instead redefined
+```
+def Rel (α β : Type*) := Set (α × β) → Prop
+```
+This extra level of indirection guides automation correctly and prevents (some kinds of) leakage.
+
+Simultaneously, uniform spaces need a theory of relations on a type `α` as elements of
+`Set (α × α)`, and the new definition of `Rel` fulfills this role quite well.
 -/
 
-variable {α β γ : Type*}
+variable {α β γ δ : Type*}
 
-/-- A relation on `α` and `β`, aka a set-valued function, aka a partial multifunction -/
-def Rel (α β : Type*) :=
-  α → β → Prop
--- The `CompleteLattice, Inhabited` instances should be constructed by a deriving handler.
--- https://github.com/leanprover-community/mathlib4/issues/380
+/-- A relation on `α` and `β`, aka a set-valued function, aka a partial multifunction.
 
-instance : CompleteLattice (Rel α β) := show CompleteLattice (α → β → Prop) from inferInstance
-instance : Inhabited (Rel α β) := show Inhabited (α → β → Prop) from inferInstance
+We represent them as sets due to how relations are used in the context of uniform spaces. -/
+abbrev Rel (α β : Type*) := Set (α × β)
 
 namespace Rel
+variable {R r₁ r₂ : Rel α β} {S : Rel β γ} {s s₁ s₂ : Set α} {t t₁ t₂ : Set β} {u : Set γ}
+  {a a₁ a₂ : α} {b : β} {c : γ}
 
-variable (r : Rel α β)
+/-- Notation for apply a relation `R : Rel α β` to `a : α`, `b : β`, scoped to the `Rel` namespace.
 
-@[ext] theorem ext {r s : Rel α β} : (∀ a, r a = s a) → r = s := funext
+Since `Rel α β := Set (α × β)`, `a ~[R] b` is simply notation for `(a, b) ∈ R`, but this should
+be considered an implementation detail. -/
+scoped notation:50 a:50 " ~[" R "] " b:50 => (a, b) ∈ R
 
-/-- The inverse relation : `r.inv x y ↔ r y x`. Note that this is *not* a groupoid inverse. -/
-def inv : Rel β α :=
-  flip r
+variable (R) in
+/-- The inverse relation : `R.inv x y ↔ R y x`. Note that this is *not* a groupoid inverse. -/
+def inv (R : Rel α β) : Rel β α := Prod.swap ⁻¹' R
 
-theorem inv_def (x : α) (y : β) : r.inv y x ↔ r x y :=
-  Iff.rfl
+@[simp] lemma mem_inv : b ~[R.inv] a ↔ a ~[R] b := .rfl
 
-theorem inv_inv : inv (inv r) = r := by
-  ext x y
-  rfl
+@[simp] lemma inv_inv : R.inv.inv = R := rfl
 
-/-- Domain of a relation -/
-def dom := { x | ∃ y, r x y }
+@[gcongr] lemma inv_mono (h : r₁ ⊆ r₂) : r₁.inv ⊆ r₂.inv := fun (_a, _b) hab ↦ h hab
 
-theorem dom_mono {r s : Rel α β} (h : r ≤ s) : dom r ⊆ dom s := fun a ⟨b, hx⟩ => ⟨b, h a b hx⟩
+@[simp] lemma inv_empty : (∅ : Rel α β).inv = ∅ := rfl
+@[simp] lemma inv_univ : inv (.univ : Rel α β) = .univ := rfl
 
-/-- Codomain aka range of a relation -/
-def codom := { y | ∃ x, r x y }
+variable (R) in
+/-- Domain of a relation. -/
+def dom : Set α := {a | ∃ b, a ~[R] b}
 
-theorem codom_inv : r.inv.codom = r.dom := by
-  ext x
-  rfl
+variable (R) in
+/-- Codomain of a relation, aka range. -/
+def cod : Set β := {b | ∃ a, a ~[R] b}
 
-theorem dom_inv : r.inv.dom = r.codom := by
-  ext x
-  rfl
+@[simp] lemma mem_dom : a ∈ R.dom ↔ ∃ b, a ~[R] b := .rfl
+@[simp] lemma mem_cod : b ∈ R.cod ↔ ∃ a, a ~[R] b := .rfl
 
-/-- Composition of relation; note that it follows the `CategoryTheory/` order of arguments. -/
-def comp (r : Rel α β) (s : Rel β γ) : Rel α γ := fun x z => ∃ y, r x y ∧ s y z
+@[gcongr] lemma dom_mono (h : r₁ ≤ r₂) : r₁.dom ⊆ r₂.dom := fun _a ⟨b, hab⟩ ↦ ⟨b, h hab⟩
+@[gcongr] lemma cod_mono (h : r₁ ≤ r₂) : r₁.cod ⊆ r₂.cod := fun _b ⟨a, hab⟩ ↦ ⟨a, h hab⟩
 
-/-- Local syntax for composition of relations. -/
--- TODO: this could be replaced with `local infixr:90 " ∘ " => Rel.comp`.
-local infixr:90 " • " => Rel.comp
-
-theorem comp_assoc {δ : Type*} (r : Rel α β) (s : Rel β γ) (t : Rel γ δ) :
-    (r • s) • t = r • (s • t) := by
-  unfold comp; ext (x w); constructor
-  · rintro ⟨z, ⟨y, rxy, syz⟩, tzw⟩; exact ⟨y, rxy, z, syz, tzw⟩
-  · rintro ⟨y, rxy, z, syz, tzw⟩; exact ⟨z, ⟨y, rxy, syz⟩, tzw⟩
-
-@[simp]
-theorem comp_right_id (r : Rel α β) : r • @Eq β = r := by
-  unfold comp
-  ext y
-  simp
-
-@[simp]
-theorem comp_left_id (r : Rel α β) : @Eq α • r = r := by
-  unfold comp
-  ext x
-  simp
+@[simp] lemma dom_empty : (∅ : Rel α β).dom = ∅ := by aesop
+@[simp] lemma cod_empty : (∅ : Rel α β).cod = ∅ := by aesop
 
-@[simp]
-theorem comp_right_bot (r : Rel α β) : r • (⊥ : Rel β γ) = ⊥ := by
-  ext x y
-  simp [comp, Bot.bot]
+@[simp] lemma dom_univ [Nonempty β] : dom (.univ : Rel α β) = .univ := by aesop
+@[simp] lemma cod_univ [Nonempty α] : cod (.univ : Rel α β) = .univ := by aesop
 
-@[simp]
-theorem comp_left_bot (r : Rel α β) : (⊥ : Rel γ α) • r = ⊥ := by
-  ext x y
-  simp [comp, Bot.bot]
+@[simp] lemma cod_inv : R.inv.cod = R.dom := rfl
+@[simp] lemma dom_inv : R.inv.dom = R.cod := rfl
 
-@[simp]
-theorem comp_right_top (r : Rel α β) : r • (⊤ : Rel β γ) = fun x _ ↦ x ∈ r.dom := by
-  ext x z
-  simp [comp, Top.top, dom]
+/-- The identity relation. -/
+protected def id : Rel α α := {(a₁, a₂) | a₁ = a₂}
 
-@[simp]
-theorem comp_left_top (r : Rel α β) : (⊤ : Rel γ α) • r = fun _ y ↦ y ∈ r.codom := by
-  ext x z
-  simp [comp, Top.top, codom]
+@[simp] lemma mem_id : a₁ ~[Rel.id] a₂ ↔ a₁ = a₂ := .rfl
 
-theorem inv_id : inv (@Eq α) = @Eq α := by
-  ext x y
-  constructor <;> apply Eq.symm
+@[simp] lemma inv_id : (.id : Rel α α).inv = .id := by aesop
 
-theorem inv_comp (r : Rel α β) (s : Rel β γ) : inv (r • s) = inv s • inv r := by
-  ext x z
-  simp [comp, inv, flip, and_comm]
+/-- Composition of relation.
 
-@[simp]
-theorem inv_bot : (⊥ : Rel α β).inv = (⊥ : Rel β α) := by
-  simp [Bot.bot, inv, Function.flip_def]
+Note that this follows the `CategoryTheory` order of arguments. -/
+def comp (R : Rel α β) (S : Rel β γ) : Rel α γ := {(a, c) | ∃ b, a ~[R] b ∧ b ~[S] c}
 
-@[simp]
-theorem inv_top : (⊤ : Rel α β).inv = (⊤ : Rel β α) := by
-  simp [Top.top, inv, Function.flip_def]
+@[inherit_doc] scoped infixl:62 " ○ " => comp
 
-/-- Image of a set under a relation -/
-def image (s : Set α) : Set β := { y | ∃ x ∈ s, r x y }
+@[simp] lemma mem_comp : a ~[R ○ S] c ↔ ∃ b, a ~[R] b ∧ b ~[S] c := .rfl
 
-theorem mem_image (y : β) (s : Set α) : y ∈ image r s ↔ ∃ x ∈ s, r x y :=
-  Iff.rfl
+lemma comp_assoc (R : Rel α β) (S : Rel β γ) (t : Rel γ δ) : (R ○ S) ○ t = R ○ (S ○ t) := by aesop
 
-open scoped Relator in
-theorem image_subset : ((· ⊆ ·) ⇒ (· ⊆ ·)) r.image r.image := fun _ _ h _ ⟨x, xs, rxy⟩ =>
-  ⟨x, h xs, rxy⟩
-
-theorem image_mono : Monotone r.image :=
-  r.image_subset
-
-theorem image_inter (s t : Set α) : r.image (s ∩ t) ⊆ r.image s ∩ r.image t :=
-  r.image_mono.map_inf_le s t
-
-theorem image_union (s t : Set α) : r.image (s ∪ t) = r.image s ∪ r.image t :=
-  le_antisymm
-    (fun _y ⟨x, xst, rxy⟩ =>
-      xst.elim (fun xs => Or.inl ⟨x, ⟨xs, rxy⟩⟩) fun xt => Or.inr ⟨x, ⟨xt, rxy⟩⟩)
-    (r.image_mono.le_map_sup s t)
-
-@[simp]
-theorem image_id (s : Set α) : image (@Eq α) s = s := by
-  ext x
-  simp [mem_image]
-
-theorem image_comp (s : Rel β γ) (t : Set α) : image (r • s) t = image s (image r t) := by
-  ext z; simp only [mem_image]; constructor
-  · rintro ⟨x, xt, y, rxy, syz⟩; exact ⟨y, ⟨x, xt, rxy⟩, syz⟩
-  · rintro ⟨y, ⟨x, xt, rxy⟩, syz⟩; exact ⟨x, xt, y, rxy, syz⟩
-
-theorem image_univ : r.image Set.univ = r.codom := by
-  ext y
-  simp [mem_image, codom]
-
-@[simp]
-theorem image_empty : r.image ∅ = ∅ := by
-  ext x
-  simp [mem_image]
-
-@[simp]
-theorem image_bot (s : Set α) : (⊥ : Rel α β).image s = ∅ := by
-  rw [Set.eq_empty_iff_forall_notMem]
-  intro x h
-  simp [mem_image, Bot.bot] at h
-
-@[simp]
-theorem image_top {s : Set α} (h : Set.Nonempty s) :
-    (⊤ : Rel α β).image s = Set.univ :=
-  Set.eq_univ_of_forall fun _ ↦ ⟨h.some, by simp [h.some_mem, Top.top]⟩
-
-/-- Preimage of a set under a relation `r`. Same as the image of `s` under `r.inv` -/
-def preimage (s : Set β) : Set α :=
-  r.inv.image s
-
-theorem mem_preimage (x : α) (s : Set β) : x ∈ r.preimage s ↔ ∃ y ∈ s, r x y :=
-  Iff.rfl
-
-theorem preimage_def (s : Set β) : preimage r s = { x | ∃ y ∈ s, r x y } :=
-  Set.ext fun _ => mem_preimage _ _ _
-
-theorem preimage_mono {s t : Set β} (h : s ⊆ t) : r.preimage s ⊆ r.preimage t :=
-  image_mono _ h
-
-theorem preimage_inter (s t : Set β) : r.preimage (s ∩ t) ⊆ r.preimage s ∩ r.preimage t :=
-  image_inter _ s t
-
-theorem preimage_union (s t : Set β) : r.preimage (s ∪ t) = r.preimage s ∪ r.preimage t :=
-  image_union _ s t
-
-theorem preimage_id (s : Set α) : preimage (@Eq α) s = s := by
-  simp only [preimage, inv_id, image_id]
-
-theorem preimage_comp (s : Rel β γ) (t : Set γ) :
-    preimage (r • s) t = preimage r (preimage s t) := by simp only [preimage, inv_comp, image_comp]
-
-theorem preimage_univ : r.preimage Set.univ = r.dom := by rw [preimage, image_univ, codom_inv]
-
-@[simp]
-theorem preimage_empty : r.preimage ∅ = ∅ := by rw [preimage, image_empty]
-
-@[simp]
-theorem preimage_inv (s : Set α) : r.inv.preimage s = r.image s := by rw [preimage, inv_inv]
-
-@[simp]
-theorem preimage_bot (s : Set β) : (⊥ : Rel α β).preimage s = ∅ := by
-  rw [preimage, inv_bot, image_bot]
-
-@[simp]
-theorem preimage_top {s : Set β} (h : Set.Nonempty s) :
-    (⊤ : Rel α β).preimage s = Set.univ := by rwa [← inv_top, preimage, inv_inv, image_top]
-
-theorem image_eq_dom_of_codomain_subset {s : Set β} (h : r.codom ⊆ s) : r.preimage s = r.dom := by
-  rw [← preimage_univ]
-  apply Set.eq_of_subset_of_subset
-  · exact image_subset _ (Set.subset_univ _)
-  · intro x hx
-    simp only [mem_preimage, Set.mem_univ, true_and] at hx
-    rcases hx with ⟨y, ryx⟩
-    have hy : y ∈ s := h ⟨x, ryx⟩
-    exact ⟨y, ⟨hy, ryx⟩⟩
-
-theorem preimage_eq_codom_of_domain_subset {s : Set α} (h : r.dom ⊆ s) : r.image s = r.codom := by
-  apply r.inv.image_eq_dom_of_codomain_subset (by rwa [← codom_inv] at h)
-
-theorem image_inter_dom_eq (s : Set α) : r.image (s ∩ r.dom) = r.image s := by
-  apply Set.eq_of_subset_of_subset
-  · apply r.image_mono (by simp)
-  · intro x h
-    rw [mem_image] at *
-    rcases h with ⟨y, hy, ryx⟩
-    use y
-    suffices h : y ∈ r.dom by simp_all only [Set.mem_inter_iff, and_self]
-    rw [dom, Set.mem_setOf_eq]
-    use x
-
-@[simp]
-theorem preimage_inter_codom_eq (s : Set β) : r.preimage (s ∩ r.codom) = r.preimage s := by
-  rw [← dom_inv, preimage, preimage, image_inter_dom_eq]
-
-theorem inter_dom_subset_preimage_image (s : Set α) : s ∩ r.dom ⊆ r.preimage (r.image s) := by
-  intro x hx
-  simp only [Set.mem_inter_iff, dom] at hx
-  rcases hx with ⟨hx, ⟨y, rxy⟩⟩
-  use y
-  simp only [image, Set.mem_setOf_eq]
-  exact ⟨⟨x, hx, rxy⟩, rxy⟩
-
-theorem image_preimage_subset_inter_codom (s : Set β) : s ∩ r.codom ⊆ r.image (r.preimage s) := by
-  rw [← dom_inv, ← preimage_inv]
-  apply inter_dom_subset_preimage_image
-
-/-- Core of a set `s : Set β` w.r.t `r : Rel α β` is the set of `x : α` that are related *only*
-to elements of `s`. Other generalization of `Function.preimage`. -/
-def core (s : Set β) := { x | ∀ y, r x y → y ∈ s }
-
-theorem mem_core (x : α) (s : Set β) : x ∈ r.core s ↔ ∀ y, r x y → y ∈ s :=
-  Iff.rfl
-
-open scoped Relator in
-theorem core_subset : ((· ⊆ ·) ⇒ (· ⊆ ·)) r.core r.core := fun _s _t h _x h' y rxy => h (h' y rxy)
-
-theorem core_mono : Monotone r.core :=
-  r.core_subset
-
-theorem core_inter (s t : Set β) : r.core (s ∩ t) = r.core s ∩ r.core t :=
-  Set.ext (by simp [mem_core, imp_and, forall_and])
-
-theorem core_union (s t : Set β) : r.core s ∪ r.core t ⊆ r.core (s ∪ t) :=
-  r.core_mono.le_map_sup s t
-
-@[simp]
-theorem core_univ : r.core Set.univ = Set.univ :=
-  Set.ext (by simp [mem_core])
-
-theorem core_id (s : Set α) : core (@Eq α) s = s := by simp [core]
-
-theorem core_comp (s : Rel β γ) (t : Set γ) : core (r • s) t = core r (core s t) := by
-  ext x; simp only [core, comp, forall_exists_index, and_imp, Set.mem_setOf_eq]; constructor
-  · exact fun h y rxy z => h z y rxy
-  · exact fun h z y rzy => h y rzy z
+@[simp] lemma comp_id (R : Rel α β) : R ○ .id = R := by aesop
+@[simp] lemma id_comp (R : Rel α β) : .id ○ R = R := by aesop
 
+@[simp] lemma inv_comp (R : Rel α β) (S : Rel β γ) : (R ○ S).inv = S.inv ○ R.inv := by aesop
+
+@[simp] lemma comp_empty (R : Rel α β) : R ○ (∅ : Rel β γ) = ∅ := by aesop
+@[simp] lemma empty_comp (S : Rel β γ) : (∅ : Rel α β) ○ S = ∅ := by aesop
+
+@[simp] lemma comp_univ (R : Rel α β) : R ○ (.univ : Rel β γ) = {(a, _c) : α × γ | a ∈ R.dom} := by
+  aesop
+
+@[simp] lemma univ_comp (S : Rel β γ) : (.univ : Rel α β) ○ S = {(_b, c) : α × γ | c ∈ S.cod} := by
+  aesop
+
+variable (R s) in
+/-- Image of a set under a relation. -/
+def image : Set β := {b | ∃ a ∈ s, a ~[R] b}
+
+variable (R t) in
+/-- Preimage of a set `t` under a relation `R`. Same as the image of `t` under `R.inv`. -/
+def preimage : Set α := {a | ∃ b ∈ t, a ~[R] b}
+
+@[simp] lemma mem_image : b ∈ image R s ↔ ∃ a ∈ s, a ~[R] b := .rfl
+@[simp] lemma mem_preimage : a ∈ preimage R t ↔ ∃ b ∈ t, a ~[R] b := .rfl
+
+@[gcongr] lemma image_subset_image (hs : s₁ ⊆ s₂) : image R s₁ ⊆ image R s₂ :=
+  fun _ ⟨a, ha, hab⟩ ↦ ⟨a, hs ha, hab⟩
+
+@[gcongr] lemma preimage_subset_preimage (ht : t₁ ⊆ t₂) : preimage R t₁ ⊆ preimage R t₂ :=
+  fun _ ⟨a, ha, hab⟩ ↦ ⟨a, ht ha, hab⟩
+
+variable (R t) in
+@[simp] lemma image_inv : R.inv.image t = preimage R t := rfl
+
+variable (R s) in
+@[simp] lemma preimage_inv : R.inv.preimage s = image R s := rfl
+
+lemma image_mono : Monotone R.image := fun _ _ ↦ image_subset_image
+lemma preimage_mono : Monotone R.preimage := fun _ _ ↦ preimage_subset_preimage
+
+@[simp] lemma image_empty_right : image R ∅ = ∅ := by aesop
+@[simp] lemma preimage_empty_right : preimage R ∅ = ∅ := by aesop
+
+@[simp] lemma image_univ_right : image R .univ = R.cod := by aesop
+@[simp] lemma preimage_univ_right : preimage R .univ = R.dom := by aesop
+
+variable (R) in
+lemma image_inter_subset : image R (s₁ ∩ s₂) ⊆ image R s₁ ∩ image R s₂ := image_mono.map_inf_le ..
+
+variable (R) in
+lemma preimage_inter_subset : preimage R (t₁ ∩ t₂) ⊆ preimage R t₁ ∩ preimage R t₂ :=
+  preimage_mono.map_inf_le ..
+
+variable (R s₁ s₂) in
+lemma image_union : image R (s₁ ∪ s₂) = image R s₁ ∪ image R s₂ := by aesop
+
+variable (R t₁ t₂) in
+lemma preimage_union : preimage R (t₁ ∪ t₂) = preimage R t₁ ∪ preimage R t₂ := by aesop
+
+variable (s) in
+@[simp] lemma image_id : image .id s = s := by aesop
+
+variable (s) in
+@[simp] lemma preimage_id : preimage .id s = s := by aesop
+
+variable (R S s) in
+lemma image_comp : image (R ○ S) s = image S (image R s) := by aesop
+
+variable (R S u) in
+lemma preimage_comp : preimage (R ○ S) u = preimage R (preimage S u) := by aesop
+
+variable (s) in
+@[simp] lemma image_empty_left : image (∅ : Rel α β) s = ∅ := by aesop
+
+variable (t) in
+@[simp] lemma preimage_empty_left : preimage (∅ : Rel α β) t = ∅ := by aesop
+
+@[simp] lemma image_univ_left (hs : s.Nonempty) : image (.univ : Rel α β) s = .univ := by aesop
+@[simp] lemma preimage_univ_left (ht : t.Nonempty) : preimage (.univ : Rel α β) t = .univ := by
+  aesop
+
+lemma image_eq_cod_of_dom_subset (h : R.cod ⊆ t) : R.preimage t = R.dom := by aesop
+lemma preimage_eq_dom_of_cod_subset (h : R.cod ⊆ t) : R.preimage t = R.dom := by aesop
+
+variable (R s) in
+@[simp] lemma image_inter_dom : image R (s ∩ R.dom) = image R s := by aesop
+
+variable (R t) in
+@[simp] lemma preimage_inter_cod : preimage R (t ∩ R.cod) = preimage R t := by aesop
+
+lemma inter_dom_subset_preimage_image : s ∩ R.dom ⊆ R.preimage (image R s) := by
+  aesop (add simp [Set.subset_def])
+
+lemma inter_cod_subset_image_preimage : t ∩ R.cod ⊆ image R (R.preimage t) := by
+  aesop (add simp [Set.subset_def])
+
+variable (R t) in
+/-- Core of a set `S : Set β` w.R.t `R : Rel α β` is the set of `x : α` that are related *only*
+to elements of `S`. Other generalization of `Function.preimage`. -/
+def core : Set α := {a | ∀ ⦃b⦄, a ~[R] b → b ∈ t}
+
+@[simp] lemma mem_core : a ∈ R.core t ↔ ∀ ⦃b⦄, a ~[R] b → b ∈ t := .rfl
+
+@[gcongr]
+lemma core_subset_core (ht : t₁ ⊆ t₂) : R.core t₁ ⊆ R.core t₂ := fun _a ha _b hab ↦ ht <| ha hab
+
+lemma core_mono : Monotone R.core := fun _ _ ↦ core_subset_core
+
+variable (R t₁ t₂) in
+lemma core_inter : R.core (t₁ ∩ t₂) = R.core t₁ ∩ R.core t₂ := by aesop
+
+lemma core_union_subset : R.core t₁ ∪ R.core t₂ ⊆ R.core (t₁ ∪ t₂) := core_mono.le_map_sup ..
+
+@[simp] lemma core_univ : R.core Set.univ = Set.univ := by aesop
+
+variable (t) in
+@[simp] lemma core_id : core .id t = t := by aesop
+
+variable (R S u) in
+lemma core_comp : core (R ○ S) u = core R (core S u) := by aesop
+
+lemma image_subset_iff : image R s ⊆ t ↔ s ⊆ core R t := by aesop (add simp [Set.subset_def])
+
+lemma image_core_gc : GaloisConnection R.image R.core := fun _ _ ↦ image_subset_iff
+
+variable (R s) in
 /-- Restrict the domain of a relation to a subtype. -/
-def restrictDomain (s : Set α) : Rel { x // x ∈ s } β := fun x y => r x.val y
+def restrictDomain : Rel s β := {(a, b) | ↑a ~[R] b}
 
-theorem image_subset_iff (s : Set α) (t : Set β) : image r s ⊆ t ↔ s ⊆ core r t :=
-  Iff.intro (fun h x xs _y rxy => h ⟨x, xs, rxy⟩) fun h y ⟨_x, xs, rxy⟩ => h xs y rxy
+variable {R : Rel α α} {S : Rel β β} {a b c : α}
 
-theorem image_core_gc : GaloisConnection r.image r.core :=
-  image_subset_iff _
+variable (R) in
+/-- A relation `R` is transitive if `a ~[R] b` and `b ~[R] c` together imply `a ~[R] c`. -/
+protected abbrev IsTrans : Prop := IsTrans α (· ~[R] ·)
+
+variable (R) in
+protected lemma trans [R.IsTrans] (hab : a ~[R] b) (hbc : b ~[R] c) : a ~[R] c :=
+  trans_of (· ~[R] ·) hab hbc
+
+instance {R : α → α → Prop} [IsTrans α R] : Rel.IsTrans {(a, b) | R a b} := ‹_›
+
+variable (R) in
+/-- A relation `R` is irreflexive if `¬ a ~[R] a`. -/
+protected abbrev IsIrrefl : Prop := IsIrrefl α (· ~[R] ·)
+
+variable (R a) in
+protected lemma irrefl [R.IsIrrefl] : ¬ a ~[R] a := irrefl_of (· ~[R] ·) _
+
+instance {R : α → α → Prop} [IsIrrefl α R] : Rel.IsIrrefl {(a, b) | R a b} := ‹_›
+
+variable (R) in
+/-- A relation `R` on a type `α` is well-founded if all elements of `α` are accessible within `R`.
+-/
+abbrev IsWellFounded : Prop := WellFounded (· ~[R] ·)
+
+variable (R S) in
+/-- A relation homomorphism with respect to a given pair of relations `R` and `S` s is a function
+`f : α → β` such that `a ~[R] b → f a ~[s] f b`. -/
+abbrev Hom := (· ~[R] ·) →r (· ~[S] ·)
 
 end Rel
 
+open scoped Rel
+
 namespace Function
+variable {f : α → β} {a : α} {b : β}
 
 /-- The graph of a function as a relation. -/
-def graph (f : α → β) : Rel α β := fun x y => f x = y
+def graph (f : α → β) : Rel α β := {(a, b) | f a = b}
 
-@[simp] lemma graph_def (f : α → β) (x y) : f.graph x y ↔ (f x = y) := Iff.rfl
+@[simp] lemma mem_graph : a ~[f.graph] b ↔ f a = b := .rfl
 
 theorem graph_injective : Injective (graph : (α → β) → Rel α β) := by
-  intro _ g h
-  ext x
-  have h2 := congr_fun₂ h x (g x)
-  simp only [graph_def, eq_iff_iff, iff_true] at h2
-  exact h2
+  aesop (add simp [Injective, Set.ext_iff])
 
 @[simp] lemma graph_inj {f g : α → β} : f.graph = g.graph ↔ f = g := graph_injective.eq_iff
 
-theorem graph_id : graph id = @Eq α := by simp +unfoldPartialApp [graph]
+@[simp] lemma graph_id : graph (id : α → α) = .id := by aesop
 
-theorem graph_comp {f : β → γ} {g : α → β} : graph (f ∘ g) = Rel.comp (graph g) (graph f) := by
-  ext x y
-  simp [Rel.comp]
+theorem graph_comp (f : β → γ) (g : α → β) : graph (f ∘ g) = graph g ○ graph f := by aesop
 
 end Function
 
 theorem Equiv.graph_inv (f : α ≃ β) : (f.symm : β → α).graph = Rel.inv (f : α → β).graph := by
-  ext x y
-  aesop (add norm Rel.inv_def)
+  aesop
 
-theorem Relation.is_graph_iff (r : Rel α β) : (∃! f, Function.graph f = r) ↔ ∀ x, ∃! y, r x y := by
-  unfold Function.graph
+lemma Rel.exists_graph_eq_iff (R : Rel α β) :
+    (∃! f, Function.graph f = R) ↔ ∀ a, ∃! b, a ~[R] b := by
   constructor
   · rintro ⟨f, rfl, _⟩ x
-    use f x
-    simp only [forall_eq', and_self]
-  · intro h
-    choose f hf using fun x ↦ (h x).exists
-    use f
-    constructor
-    · ext x _
-      constructor
-      · rintro rfl
-        exact hf x
-      · exact (h x).unique (hf x)
-    · rintro _ rfl
-      exact funext hf
+    aesop
+  intro h
+  choose f hf using fun x ↦ (h x).exists
+  refine ⟨f, ?_, by aesop⟩
+  ext ⟨a, b⟩
+  constructor
+  · aesop
+  · exact (h _).unique (hf _)
 
 namespace Set
 
@@ -367,7 +340,7 @@ theorem image_eq (f : α → β) (s : Set α) : f '' s = (Function.graph f).imag
   rfl
 
 theorem preimage_eq (f : α → β) (s : Set β) : f ⁻¹' s = (Function.graph f).preimage s := by
-  simp [Set.preimage, Rel.preimage, Rel.inv, flip, Rel.image]
+  simp [Set.preimage, Rel.preimage]
 
 theorem preimage_eq_core (f : α → β) (s : Set β) : f ⁻¹' s = (Function.graph f).core s := by
   simp [Set.preimage, Rel.core]

--- a/Mathlib/Data/Rel.lean
+++ b/Mathlib/Data/Rel.lean
@@ -87,12 +87,16 @@ def inv (R : Rel α β) : Rel β α := Prod.swap ⁻¹' R
 
 @[simp] lemma mem_inv : b ~[R.inv] a ↔ a ~[R] b := .rfl
 
+@[deprecated (since := "2025-07-06")] alias inv_def := mem_inv
+
 @[simp] lemma inv_inv : R.inv.inv = R := rfl
 
 @[gcongr] lemma inv_mono (h : r₁ ⊆ r₂) : r₁.inv ⊆ r₂.inv := fun (_a, _b) hab ↦ h hab
 
 @[simp] lemma inv_empty : (∅ : Rel α β).inv = ∅ := rfl
 @[simp] lemma inv_univ : inv (.univ : Rel α β) = .univ := rfl
+
+@[deprecated (since := "2025-07-06")] alias inv_bot := inv_empty
 
 variable (R) in
 /-- Domain of a relation. -/
@@ -101,6 +105,8 @@ def dom : Set α := {a | ∃ b, a ~[R] b}
 variable (R) in
 /-- Codomain of a relation, aka range. -/
 def cod : Set β := {b | ∃ a, a ~[R] b}
+
+@[deprecated (since := "2025-07-06")] alias codom := cod
 
 @[simp] lemma mem_dom : a ∈ R.dom ↔ ∃ b, a ~[R] b := .rfl
 @[simp] lemma mem_cod : b ∈ R.cod ↔ ∃ a, a ~[R] b := .rfl
@@ -116,6 +122,8 @@ def cod : Set β := {b | ∃ a, a ~[R] b}
 
 @[simp] lemma cod_inv : R.inv.cod = R.dom := rfl
 @[simp] lemma dom_inv : R.inv.dom = R.cod := rfl
+
+@[deprecated (since := "2025-07-06")] alias codom_inv := cod_inv
 
 /-- The identity relation. -/
 protected def id : Rel α α := {(a₁, a₂) | a₁ = a₂}
@@ -148,6 +156,9 @@ lemma comp_assoc (R : Rel α β) (S : Rel β γ) (t : Rel γ δ) : (R ○ S) ○
 
 @[simp] lemma univ_comp (S : Rel β γ) : (.univ : Rel α β) ○ S = {(_b, c) : α × γ | c ∈ S.cod} := by
   aesop
+
+@[deprecated (since := "2025-07-06")] alias comp_right_top := comp_univ
+@[deprecated (since := "2025-07-06")] alias comp_left_top := univ_comp
 
 variable (R s) in
 /-- Image of a set under a relation. -/
@@ -184,12 +195,18 @@ lemma preimage_mono : Monotone R.preimage := fun _ _ ↦ preimage_subset_preimag
 variable (R) in
 lemma image_inter_subset : image R (s₁ ∩ s₂) ⊆ image R s₁ ∩ image R s₂ := image_mono.map_inf_le ..
 
+@[deprecated (since := "2025-07-06")] alias preimage_top := image_inter_subset
+
 variable (R) in
 lemma preimage_inter_subset : preimage R (t₁ ∩ t₂) ⊆ preimage R t₁ ∩ preimage R t₂ :=
   preimage_mono.map_inf_le ..
 
+@[deprecated (since := "2025-07-06")] alias image_eq_dom_of_codomain_subset := preimage_inter_subset
+
 variable (R s₁ s₂) in
 lemma image_union : image R (s₁ ∪ s₂) = image R s₁ ∪ image R s₂ := by aesop
+
+@[deprecated (since := "2025-07-06")] alias preimage_eq_codom_of_domain_subset := image_union
 
 variable (R t₁ t₂) in
 lemma preimage_union : preimage R (t₁ ∪ t₂) = preimage R t₁ ∪ preimage R t₂ := by aesop
@@ -212,6 +229,8 @@ variable (s) in
 variable (t) in
 @[simp] lemma preimage_empty_left : preimage (∅ : Rel α β) t = ∅ := by aesop
 
+@[deprecated (since := "2025-07-06")] alias preimage_bot := preimage_empty_left
+
 @[simp] lemma image_univ_left (hs : s.Nonempty) : image (.univ : Rel α β) s = .univ := by aesop
 @[simp] lemma preimage_univ_left (ht : t.Nonempty) : preimage (.univ : Rel α β) t = .univ := by
   aesop
@@ -225,11 +244,16 @@ variable (R s) in
 variable (R t) in
 @[simp] lemma preimage_inter_cod : preimage R (t ∩ R.cod) = preimage R t := by aesop
 
+@[deprecated (since := "2025-07-06")] alias preimage_inter_codom_eq := preimage_inter_cod
+
 lemma inter_dom_subset_preimage_image : s ∩ R.dom ⊆ R.preimage (image R s) := by
   aesop (add simp [Set.subset_def])
 
 lemma inter_cod_subset_image_preimage : t ∩ R.cod ⊆ image R (R.preimage t) := by
   aesop (add simp [Set.subset_def])
+
+@[deprecated (since := "2025-07-06")]
+alias image_preimage_subset_inter_codom := inter_cod_subset_image_preimage
 
 variable (R t) in
 /-- Core of a set `S : Set β` w.R.t `R : Rel α β` is the set of `x : α` that are related *only*
@@ -307,6 +331,8 @@ def graph (f : α → β) : Rel α β := {(a, b) | f a = b}
 
 @[simp] lemma mem_graph : a ~[f.graph] b ↔ f a = b := .rfl
 
+@[deprecated (since := "2025-07-06")] alias graph_def := mem_graph
+
 theorem graph_injective : Injective (graph : (α → β) → Rel α β) := by
   aesop (add simp [Injective, Set.ext_iff])
 
@@ -333,6 +359,8 @@ lemma Rel.exists_graph_eq_iff (R : Rel α β) :
   constructor
   · aesop
   · exact (h _).unique (hf _)
+
+@[deprecated (since := "2025-07-06")] alias Relation.is_graph_iff := Rel.exists_graph_eq_iff
 
 namespace Set
 

--- a/Mathlib/Order/Filter/Partial.lean
+++ b/Mathlib/Order/Filter/Partial.lean
@@ -56,7 +56,7 @@ that `Rel.core` generalizes `Set.preimage`. -/
 def rmap (r : Rel α β) (l : Filter α) : Filter β where
   sets := { s | r.core s ∈ l }
   univ_sets := by simp
-  sets_of_superset hs st := mem_of_superset hs (Rel.core_mono _ st)
+  sets_of_superset hs st := mem_of_superset hs (Rel.core_mono st)
   inter_sets hs ht := by
     simp only [Set.mem_setOf_eq]
     convert inter_mem hs ht
@@ -91,14 +91,14 @@ theorem rtendsto_def (r : Rel α β) (l₁ : Filter α) (l₂ : Filter β) :
 /-- One way of taking the inverse map of a filter under a relation. One generalization of
 `Filter.comap` to relations. Note that `Rel.core` generalizes `Set.preimage`. -/
 def rcomap (r : Rel α β) (f : Filter β) : Filter α where
-  sets := Rel.image (fun s t => r.core s ⊆ t) f.sets
+  sets := Rel.image {(s, t) : _ × _ | r.core s ⊆ t} f.sets
   univ_sets := ⟨Set.univ, univ_mem, Set.subset_univ _⟩
   sets_of_superset := fun ⟨a', ha', ma'a⟩ ab => ⟨a', ha', ma'a.trans ab⟩
   inter_sets := fun ⟨a', ha₁, ha₂⟩ ⟨b', hb₁, hb₂⟩ =>
     ⟨a' ∩ b', inter_mem ha₁ hb₁, (r.core_inter a' b').subset.trans (Set.inter_subset_inter ha₂ hb₂)⟩
 
 theorem rcomap_sets (r : Rel α β) (f : Filter β) :
-    (rcomap r f).sets = Rel.image (fun s t => r.core s ⊆ t) f.sets :=
+    (rcomap r f).sets = Rel.image {(s, t) : _ × _ | r.core s ⊆ t} f.sets :=
   rfl
 
 theorem rcomap_rcomap (r : Rel α β) (s : Rel β γ) (l : Filter γ) :
@@ -107,7 +107,7 @@ theorem rcomap_rcomap (r : Rel α β) (s : Rel β γ) (l : Filter γ) :
     ext t; simp only [rcomap_sets, Rel.image, Filter.mem_sets, Set.mem_setOf_eq, Rel.core_comp]
     constructor
     · rintro ⟨u, ⟨v, vsets, hv⟩, h⟩
-      exact ⟨v, vsets, Set.Subset.trans (Rel.core_mono _ hv) h⟩
+      exact ⟨v, vsets, Set.Subset.trans (Rel.core_mono hv) h⟩
     rintro ⟨t, tsets, ht⟩
     exact ⟨Rel.core s t, ⟨t, tsets, Set.Subset.rfl⟩, ht⟩
 
@@ -129,12 +129,11 @@ theorem rtendsto_iff_le_rcomap (r : Rel α β) (l₁ : Filter α) (l₂ : Filter
 /-- One way of taking the inverse map of a filter under a relation. Generalization of `Filter.comap`
 to relations. -/
 def rcomap' (r : Rel α β) (f : Filter β) : Filter α where
-  sets := Rel.image (fun s t => r.preimage s ⊆ t) f.sets
+  sets := Rel.image {(s, t) : _ × _ | r.preimage s ⊆ t} f.sets
   univ_sets := ⟨Set.univ, univ_mem, Set.subset_univ _⟩
   sets_of_superset := fun ⟨a', ha', ma'a⟩ ab => ⟨a', ha', ma'a.trans ab⟩
   inter_sets := fun ⟨a', ha₁, ha₂⟩ ⟨b', hb₁, hb₂⟩ =>
-    ⟨a' ∩ b', inter_mem ha₁ hb₁,
-      (@Rel.preimage_inter _ _ r _ _).trans (Set.inter_subset_inter ha₂ hb₂)⟩
+    ⟨a' ∩ b', inter_mem ha₁ hb₁, r.preimage_inter_subset.trans (Set.inter_subset_inter ha₂ hb₂)⟩
 
 @[simp]
 theorem mem_rcomap' (r : Rel α β) (l : Filter β) (s : Set α) :
@@ -142,7 +141,7 @@ theorem mem_rcomap' (r : Rel α β) (l : Filter β) (s : Set α) :
   Iff.rfl
 
 theorem rcomap'_sets (r : Rel α β) (f : Filter β) :
-    (rcomap' r f).sets = Rel.image (fun s t => r.preimage s ⊆ t) f.sets :=
+    (rcomap' r f).sets = Rel.image {(s, t) | r.preimage s ⊆ t} f.sets :=
   rfl
 
 @[simp]
@@ -152,7 +151,7 @@ theorem rcomap'_rcomap' (r : Rel α β) (s : Rel β γ) (l : Filter γ) :
     simp only [mem_rcomap', Rel.preimage_comp]
     constructor
     · rintro ⟨u, ⟨v, vsets, hv⟩, h⟩
-      exact ⟨v, vsets, (Rel.preimage_mono _ hv).trans h⟩
+      exact ⟨v, vsets, (Rel.preimage_mono hv).trans h⟩
     rintro ⟨t, tsets, ht⟩
     exact ⟨s.preimage t, ⟨t, tsets, Set.Subset.rfl⟩, ht⟩
 
@@ -178,7 +177,7 @@ theorem tendsto_iff_rtendsto (l₁ : Filter α) (l₂ : Filter β) (f : α → �
 
 theorem tendsto_iff_rtendsto' (l₁ : Filter α) (l₂ : Filter β) (f : α → β) :
     Tendsto f l₁ l₂ ↔ RTendsto' (Function.graph f) l₁ l₂ := by
-  simp [tendsto_def, Function.graph, rtendsto'_def, Rel.preimage_def, Set.preimage]
+  simp [tendsto_def, Function.graph, rtendsto'_def, Rel.preimage, Set.preimage]
 
 /-! ### Partial functions -/
 

--- a/Mathlib/Order/JordanHolder.lean
+++ b/Mathlib/Order/JordanHolder.lean
@@ -131,7 +131,7 @@ the top. For a composition series `s`, `s.last` is the largest element of the se
 and `s.head` is the least element.
 -/
 abbrev CompositionSeries (X : Type u) [Lattice X] [JordanHolderLattice X] : Type u :=
-  RelSeries (IsMaximal (X := X))
+  RelSeries {(x, y) : X × X | IsMaximal x y}
 
 namespace CompositionSeries
 
@@ -226,9 +226,11 @@ theorem lt_last_of_mem_eraseLast {s : CompositionSeries X} {x : X} (h : 0 < s.le
 
 theorem isMaximal_eraseLast_last {s : CompositionSeries X} (h : 0 < s.length) :
     IsMaximal s.eraseLast.last s.last := by
-  have : s.length - 1 + 1 = s.length := by grind
   rw [last_eraseLast, last]
-  convert s.step ⟨s.length - 1, by omega⟩; ext; simp [this]
+  have := s.step ⟨s.length - 1, by omega⟩
+  simp only [Fin.castSucc_mk, Fin.succ_mk, mem_setOf_eq] at this
+  convert this using 3
+  exact (tsub_add_cancel_of_le h).symm
 
 theorem eq_snoc_eraseLast {s : CompositionSeries X} (h : 0 < s.length) :
     s = snoc (eraseLast s) s.last (isMaximal_eraseLast_last h) := by

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -122,8 +122,8 @@ dual order, in order to easily transfer theorems between `height` and `coheight`
 -/
 lemma coheight_eq (a : α) :
     coheight a = ⨆ (p : LTSeries α) (_ : a ≤ p.head), (p.length : ℕ∞) := by
-  apply Equiv.iSup_congr ⟨RelSeries.reverse, RelSeries.reverse, RelSeries.reverse_reverse,
-    RelSeries.reverse_reverse⟩
+  apply Equiv.iSup_congr ⟨RelSeries.reverse, RelSeries.reverse, fun _ ↦ RelSeries.reverse_reverse _,
+    fun _ ↦ RelSeries.reverse_reverse _⟩
   congr! 1
 
 lemma height_le_iff {a : α} {n : ℕ∞} :
@@ -173,8 +173,8 @@ lemma coheight_eq_iSup_head_eq (a : α) :
     coheight a = ⨆ (p : LTSeries α) (_ : p.head = a), ↑(p.length) := by
   change height (α := αᵒᵈ) a = ⨆ (p : LTSeries α) (_ : p.head = a), ↑(p.length)
   rw [height_eq_iSup_last_eq]
-  apply Equiv.iSup_congr ⟨RelSeries.reverse, RelSeries.reverse, RelSeries.reverse_reverse,
-    RelSeries.reverse_reverse⟩
+  apply Equiv.iSup_congr ⟨RelSeries.reverse, RelSeries.reverse, fun _ ↦ RelSeries.reverse_reverse _,
+    fun _ ↦ RelSeries.reverse_reverse _⟩
   simp
 
 /--
@@ -385,7 +385,7 @@ lemma height_eq_iSup_lt_height (x : α) : height x = ⨆ y < x, height y + 1 := 
     | zero => simp
     | succ n =>
       apply le_iSup_of_le p.eraseLast.last
-      apply le_iSup_of_le (by rw [← hp]; apply RelSeries.eraseLast_last_rel_last _ (by omega))
+      apply le_iSup_of_le (by rw [← hp]; exact p.eraseLast_last_rel_last (by omega))
       rw [height_add_const]
       apply le_iSup₂_of_le p.eraseLast (by rfl) (by simp [hlen])
   · apply iSup₂_le; intro y hyx
@@ -520,7 +520,7 @@ lemma height_eq_coe_iff_minimal_le_height {a : α} {n : ℕ} :
       simp_all [minimal_iff_forall_lt]
     simp only [not_lt, top_le_iff, height_eq_top_iff] at hfin
     obtain ⟨p, rfl, hp⟩ := hfin (n+1)
-    use p.eraseLast.last, RelSeries.eraseLast_last_rel_last _ (by omega)
+    use p.eraseLast.last, p.eraseLast_last_rel_last (by omega)
     simpa [hp] using length_le_height_last (p := p.eraseLast)
 
 /-- The elements of finite coheight `n` are the maximal elements among those of coheight `≥ n`. -/
@@ -985,7 +985,7 @@ lemma krullDim_int : krullDim ℤ = ⊤ := krullDim_of_noMaxOrder ..
         · exact p.monotone (Fin.le_last _)
         · rw [RelSeries.last] at hlast
           simp [hlast])
-      step := fun i => by simpa only [WithTop.untop_lt_iff, WithTop.coe_untop] using p.step i }
+      step := fun i => by simpa [WithTop.untop_lt_iff, WithTop.coe_untop] using p.step i }
     have hlast' : p'.last = x := by
       simp only [p', RelSeries.last, WithTop.untop_eq_iff, ← hlast]
     suffices p'.length ≤ height p'.last by

--- a/Mathlib/Order/Rel/GaloisConnection.lean
+++ b/Mathlib/Order/Rel/GaloisConnection.lean
@@ -40,13 +40,13 @@ namespace Rel
 
 open OrderDual
 
-/-- `leftDual` maps any set `J` of elements of type `α` to the set `{b : β | ∀ a ∈ J, R a b}` of
-elements `b` of type `β` such that `R a b` for every element `a` of `J`. -/
-def leftDual (J : Set α) : Set β := {b : β | ∀ ⦃a⦄, a ∈ J → R a b}
+/-- `leftDual` maps any set `J` of elements of type `α` to the set `{b : β | ∀ a ∈ J, a ~[R] b}` of
+elements `b` of type `β` such that `a ~[R] b` for every element `a` of `J`. -/
+def leftDual (J : Set α) : Set β := {b : β | ∀ ⦃a⦄, a ∈ J → a ~[R] b}
 
-/-- `rightDual` maps any set `I` of elements of type `β` to the set `{a : α | ∀ b ∈ I, R a b}`
-of elements `a` of type `α` such that `R a b` for every element `b` of `I`. -/
-def rightDual (I : Set β) : Set α := {a : α | ∀ ⦃b⦄, b ∈ I → R a b}
+/-- `rightDual` maps any set `I` of elements of type `β` to the set `{a : α | ∀ b ∈ I, a ~[R] b}`
+of elements `a` of type `α` such that `a ~[R] b` for every element `b` of `I`. -/
+def rightDual (I : Set β) : Set α := {a : α | ∀ ⦃b⦄, b ∈ I → a ~[R] b}
 
 /-- The pair of functions `toDual ∘ leftDual` and `rightDual ∘ ofDual` forms a Galois connection. -/
 theorem gc_leftDual_rightDual : GaloisConnection (toDual ∘ R.leftDual) (R.rightDual ∘ ofDual) :=

--- a/Mathlib/Order/RelSeries.lean
+++ b/Mathlib/Order/RelSeries.lean
@@ -18,6 +18,8 @@ If `r` is a relation on `α` then a relation series of length `n` is a series
 
 -/
 
+open scoped Rel
+
 variable {α : Type*} (r : Rel α α)
 variable {β : Type*} (s : Rel β β)
 
@@ -31,7 +33,7 @@ structure RelSeries where
   /-- The underlying function of a relation series -/
   toFun : Fin (length + 1) → α
   /-- Adjacent elements are related -/
-  step : ∀ (i : Fin length), r (toFun (Fin.castSucc i)) (toFun i.succ)
+  step : ∀ (i : Fin length), toFun (Fin.castSucc i) ~[r] toFun i.succ
 
 namespace RelSeries
 
@@ -66,12 +68,12 @@ lemma ext {x y : RelSeries r} (length_eq : x.length = y.length)
   subst length_eq toFun_eq
   rfl
 
-lemma rel_of_lt [IsTrans α r] (x : RelSeries r) {i j : Fin (x.length + 1)} (h : i < j) :
-    r (x i) (x j) :=
-  (Fin.liftFun_iff_succ r).mpr x.step h
+lemma rel_of_lt [r.IsTrans] (x : RelSeries r) {i j : Fin (x.length + 1)} (h : i < j) :
+    x i ~[r] x j :=
+  (Fin.liftFun_iff_succ (· ~[r] ·)).mpr x.step h
 
-lemma rel_or_eq_of_le [IsTrans α r] (x : RelSeries r) {i j : Fin (x.length + 1)} (h : i ≤ j) :
-    r (x i) (x j) ∨ x i = x j :=
+lemma rel_or_eq_of_le [r.IsTrans] (x : RelSeries r) {i j : Fin (x.length + 1)} (h : i ≤ j) :
+    x i ~[r] x j ∨ x i = x j :=
   (Fin.lt_or_eq_of_le h).imp (x.rel_of_lt ·) (by rw [·])
 
 /--
@@ -82,7 +84,7 @@ series of `s`
 def ofLE (x : RelSeries r) {s : Rel α α} (h : r ≤ s) : RelSeries s where
   length := x.length
   toFun := x
-  step _ := h _ _ <| x.step _
+  step _ := h <| x.step _
 
 lemma coe_ofLE (x : RelSeries r) {s : Rel α α} (h : r ≤ s) :
     (x.ofLE h : _ → _) = x := rfl
@@ -98,7 +100,7 @@ lemma length_toList (x : RelSeries r) : x.toList.length = x.length + 1 :=
 lemma toList_singleton (x : α) : (singleton r x).toList = [x] :=
   rfl
 
-lemma toList_chain' (x : RelSeries r) : x.toList.Chain' r := by
+lemma toList_chain' (x : RelSeries r) : x.toList.Chain' (· ~[r] ·) := by
   rw [List.chain'_iff_get]
   intros i h
   convert x.step ⟨i, by simpa [toList] using h⟩ <;> apply List.get_ofFn
@@ -108,14 +110,14 @@ lemma toList_ne_nil (x : RelSeries r) : x.toList ≠ [] := fun m =>
 
 /-- Every nonempty list satisfying the chain condition gives a relation series -/
 @[simps]
-def fromListChain' (x : List α) (x_ne_nil : x ≠ []) (hx : x.Chain' r) : RelSeries r where
+def fromListChain' (x : List α) (x_ne_nil : x ≠ []) (hx : x.Chain' (· ~[r] ·)) : RelSeries r where
   length := x.length - 1
   toFun i := x[Fin.cast (Nat.succ_pred_eq_of_pos <| List.length_pos_iff.mpr x_ne_nil) i]
   step i := List.chain'_iff_get.mp hx i i.2
 
 /-- Relation series of `r` and nonempty list of `α` satisfying `r`-chain condition bijectively
 corresponds to each other. -/
-protected def Equiv : RelSeries r ≃ {x : List α | x ≠ [] ∧ x.Chain' r} where
+protected def Equiv : RelSeries r ≃ {x : List α | x ≠ [] ∧ x.Chain' (· ~[r] ·)} where
   toFun x := ⟨_, x.toList_ne_nil, x.toList_chain'⟩
   invFun x := fromListChain' _ x.2.1 x.2.2
   left_inv x := ext (by simp [toList]) <| by ext; dsimp; apply List.get_ofFn
@@ -199,19 +201,19 @@ theorem length_ne_zero_of_nontrivial (h : {x | x ∈ s}.Nontrivial) : s.length �
 theorem length_pos_of_nontrivial (h : {x | x ∈ s}.Nontrivial) : 0 < s.length :=
   Nat.pos_iff_ne_zero.mpr <| length_ne_zero_of_nontrivial h
 
-theorem length_ne_zero (irrefl : Irreflexive r) : s.length ≠ 0 ↔ {x | x ∈ s}.Nontrivial := by
-  refine ⟨fun h ↦ ⟨s 0, by simp [mem_def], s 1, by simp [mem_def], fun rid ↦ irrefl (s 0) ?_⟩,
-    length_ne_zero_of_nontrivial⟩
+theorem length_ne_zero [r.IsIrrefl] : s.length ≠ 0 ↔ {x | x ∈ s}.Nontrivial := by
+  refine ⟨fun h ↦ ⟨s 0, by simp [mem_def], s 1, by simp [mem_def],
+    fun rid ↦ r.irrefl (s 0) ?_⟩, length_ne_zero_of_nontrivial⟩
   nth_rw 2 [rid]
   convert s.step ⟨0, by omega⟩
   ext
   simpa [Nat.pos_iff_ne_zero]
 
-theorem length_pos (irrefl : Irreflexive r) : 0 < s.length ↔ {x | x ∈ s}.Nontrivial :=
-  Nat.pos_iff_ne_zero.trans <| length_ne_zero irrefl
+theorem length_pos [r.IsIrrefl] : 0 < s.length ↔ {x | x ∈ s}.Nontrivial :=
+  Nat.pos_iff_ne_zero.trans length_ne_zero
 
-lemma length_eq_zero (irrefl : Irreflexive r) : s.length = 0 ↔ {x | x ∈ s}.Subsingleton := by
-  rw [← not_ne_iff, length_ne_zero irrefl, Set.not_nontrivial_iff]
+lemma length_eq_zero [r.IsIrrefl] : s.length = 0 ↔ {x | x ∈ s}.Subsingleton := by
+  rw [← not_ne_iff, length_ne_zero, Set.not_nontrivial_iff]
 
 /-- Start of a series, i.e. for `a₀ -r→ a₁ -r→ ... -r→ aₙ`, its head is `a₀`.
 
@@ -255,13 +257,12 @@ lemma toList_getElem_zero_eq_head (p : RelSeries r) : p.toList[0] = p.head :=
   p.toList_getElem_eq_apply_of_lt_length (by simp)
 
 @[simp]
-lemma toList_fromListChain' (l : List α) (l_ne_nil : l ≠ []) (hl : l.Chain' r) :
+lemma toList_fromListChain' (l : List α) (l_ne_nil : l ≠ []) (hl : l.Chain' (· ~[r] ·)) :
     (fromListChain' l l_ne_nil hl).toList = l :=
   Subtype.ext_iff.mp <| RelSeries.Equiv.right_inv ⟨l, ⟨l_ne_nil, hl⟩⟩
 
 @[simp]
-lemma head_fromListChain' (l : List α) (l_ne_nil : l ≠ [])
-    (hl : l.Chain' r) :
+lemma head_fromListChain' (l : List α) (l_ne_nil : l ≠ []) (hl : l.Chain' (· ~[r] ·)) :
     (fromListChain' l l_ne_nil hl).head = l.head l_ne_nil := by
   simp [← apply_zero, List.getElem_zero_eq_head]
 
@@ -279,7 +280,7 @@ such that `r aₙ b₀`, then there is a chain of length `n + m + 1` given by
 `a₀ -r→ a₁ -r→ ... -r→ aₙ -r→ b₀ -r→ b₁ -r→ ... -r→ bₘ`.
 -/
 @[simps length]
-def append (p q : RelSeries r) (connect : r p.last q.head) : RelSeries r where
+def append (p q : RelSeries r) (connect : p.last ~[r] q.head) : RelSeries r where
   length := p.length + q.length + 1
   toFun := Fin.append p q ∘ Fin.cast (by omega)
   step i := by
@@ -290,7 +291,7 @@ def append (p q : RelSeries r) (connect : r p.last q.head) : RelSeries r where
       · convert Fin.append_left p q _
       · convert Fin.append_right p q _; rfl
     · set x := _; set y := _
-      change r (Fin.append p q x) (Fin.append p q y)
+      change Fin.append p q x ~[r] Fin.append p q y
       have hx : x = Fin.natAdd _ ⟨i - (p.length + 1), Nat.sub_lt_left_of_lt_add hi <|
           i.2.trans <| by omega⟩ := by
         ext; dsimp [x, y]; rw [Nat.add_sub_cancel']; exact hi
@@ -307,7 +308,7 @@ def append (p q : RelSeries r) (connect : r p.last q.head) : RelSeries r where
         Nat.add_assoc _ 1, add_comm 1, Nat.sub_add_cancel]
       exact hi
 
-lemma append_apply_left (p q : RelSeries r) (connect : r p.last q.head)
+lemma append_apply_left (p q : RelSeries r) (connect : p.last ~[r] q.head)
     (i : Fin (p.length + 1)) :
     p.append q connect ((i.castAdd (q.length + 1)).cast (by dsimp; omega)) = p i := by
   delta append
@@ -315,7 +316,7 @@ lemma append_apply_left (p q : RelSeries r) (connect : r p.last q.head)
   convert Fin.append_left _ _ _
 
 open Fin.NatCast in -- TODO: can this be removed?
-lemma append_apply_right (p q : RelSeries r) (connect : r p.last q.head)
+lemma append_apply_right (p q : RelSeries r) (connect : p.last ~[r] q.head)
     (i : Fin (q.length + 1)) :
     p.append q connect (i.natAdd p.length + 1) = q i := by
   delta append
@@ -328,11 +329,11 @@ lemma append_apply_right (p q : RelSeries r) (connect : r p.last q.head)
   simp only [Nat.mod_add_mod, Nat.one_mod, Nat.mod_succ_eq_iff_lt]
   omega
 
-@[simp] lemma head_append (p q : RelSeries r) (connect : r p.last q.head) :
+@[simp] lemma head_append (p q : RelSeries r) (connect : p.last ~[r] q.head) :
     (p.append q connect).head = p.head :=
   append_apply_left p q connect 0
 
-@[simp] lemma last_append (p q : RelSeries r) (connect : r p.last q.head) :
+@[simp] lemma last_append (p q : RelSeries r) (connect : p.last ~[r] q.head) :
     (p.append q connect).last = q.last := by
   delta last
   convert append_apply_right p q connect (Fin.last _)
@@ -341,7 +342,7 @@ lemma append_apply_right (p q : RelSeries r) (connect : r p.last q.head)
   simp only [append_length, Fin.val_last, Fin.natAdd_last, Nat.one_mod, Nat.mod_add_mod,
     Nat.mod_succ]
 
-lemma append_assoc (p q w : RelSeries r) (hpq : r p.last q.head) (hqw : r q.last w.head) :
+lemma append_assoc (p q w : RelSeries r) (hpq : p.last ~[r] q.head) (hqw : q.last ~[r] w.head) :
     (p.append q hpq).append w (by simpa) = p.append (q.append w hqw) (by simpa) := by
   ext
   · simp only [append_length, Nat.add_left_inj]
@@ -349,7 +350,7 @@ lemma append_assoc (p q w : RelSeries r) (hpq : r p.last q.head) (hqw : r q.last
   · simp [append, Fin.append_assoc]
 
 @[simp]
-lemma toList_append (p q : RelSeries r) (connect : r p.last q.head) :
+lemma toList_append (p q : RelSeries r) (connect : p.last ~[r] q.head) :
     (p.append q connect).toList = p.toList ++ q.toList := by
   apply List.ext_getElem
   · simp
@@ -372,17 +373,17 @@ For two types `α, β` and relation on them `r, s`, if `f : α → β` preserves
 `a₀ -r→ a₁ -r→ ... -r→ aₙ ↦ f a₀ -s→ f a₁ -s→ ... -s→ f aₙ`
 -/
 @[simps length]
-def map (p : RelSeries r) (f : r →r s) : RelSeries s where
+def map (p : RelSeries r) (f : r.Hom s) : RelSeries s where
   length := p.length
   toFun := f.1.comp p
   step := (f.2 <| p.step ·)
 
-@[simp] lemma map_apply (p : RelSeries r) (f : r →r s) (i : Fin (p.length + 1)) :
+@[simp] lemma map_apply (p : RelSeries r) (f : r.Hom s) (i : Fin (p.length + 1)) :
     p.map f i = f (p i) := rfl
 
-@[simp] lemma head_map (p : RelSeries r) (f : r →r s) : (p.map f).head = f p.head := rfl
+@[simp] lemma head_map (p : RelSeries r) (f : r.Hom s) : (p.map f).head = f p.head := rfl
 
-@[simp] lemma last_map (p : RelSeries r) (f : r →r s) : (p.map f).last = f p.last := rfl
+@[simp] lemma last_map (p : RelSeries r) (f : r.Hom s) : (p.map f).last = f p.last := rfl
 
 /--
 If `a₀ -r→ a₁ -r→ ... -r→ aₙ` is an `r`-series and `a` is such that
@@ -392,11 +393,11 @@ is another `r`-series
 -/
 @[simps]
 def insertNth (p : RelSeries r) (i : Fin p.length) (a : α)
-    (prev_connect : r (p (Fin.castSucc i)) a) (connect_next : r a (p i.succ)) : RelSeries r where
+    (prev_connect : p (Fin.castSucc i) ~[r] a) (connect_next : a ~[r] p i.succ) : RelSeries r where
   length := p.length + 1
   toFun := (Fin.castSucc i.succ).insertNth a p
   step m := by
-    set x := _; set y := _; change r x y
+    set x := _; set y := _; change x ~[r] y
     obtain hm | hm | hm := lt_trichotomy m.1 i.1
     · convert p.step ⟨m, hm.trans i.2⟩
       · change Fin.insertNth _ _ _ _ = _
@@ -447,11 +448,11 @@ A relation series `a₀ -r→ a₁ -r→ ... -r→ aₙ` of `r` gives a relation
 by reversing the series `aₙ ←r- aₙ₋₁ ←r- ... ←r- a₁ ←r- a₀`.
 -/
 @[simps length]
-def reverse (p : RelSeries r) : RelSeries (fun (a b : α) ↦ r b a) where
+def reverse (p : RelSeries r) : RelSeries r.inv where
   length := p.length
   toFun := p ∘ Fin.rev
   step i := by
-    rw [Function.comp_apply, Function.comp_apply]
+    rw [Function.comp_apply, Function.comp_apply, Rel.mem_inv]
     have hi : i.1 + 1 ≤ p.length := by omega
     convert p.step ⟨p.length - (i.1 + 1), Nat.sub_lt_self (by omega) hi⟩
     · ext; simp
@@ -476,18 +477,18 @@ Given a series `a₀ -r→ a₁ -r→ ... -r→ aₙ` and an `a` such that `a₀
 a series of length `n+1`: `a -r→ a₀ -r→ a₁ -r→ ... -r→ aₙ`.
 -/
 @[simps! length]
-def cons (p : RelSeries r) (newHead : α) (rel : r newHead p.head) : RelSeries r :=
+def cons (p : RelSeries r) (newHead : α) (rel : newHead ~[r] p.head) : RelSeries r :=
   (singleton r newHead).append p rel
 
-@[simp] lemma head_cons (p : RelSeries r) (newHead : α) (rel : r newHead p.head) :
+@[simp] lemma head_cons (p : RelSeries r) (newHead : α) (rel : newHead ~[r] p.head) :
     (p.cons newHead rel).head = newHead := rfl
 
-@[simp] lemma last_cons (p : RelSeries r) (newHead : α) (rel : r newHead p.head) :
+@[simp] lemma last_cons (p : RelSeries r) (newHead : α) (rel : newHead ~[r] p.head) :
     (p.cons newHead rel).last = p.last := by
   delta cons
   rw [last_append]
 
-lemma cons_cast_succ (s : RelSeries r) (a : α) (h : r a s.head) (i : Fin (s.length + 1)) :
+lemma cons_cast_succ (s : RelSeries r) (a : α) (h : a ~[r] s.head) (i : Fin (s.length + 1)) :
     (s.cons a h) (.cast (by simp) (.succ i)) = s i := by
   dsimp [cons]
   convert append_apply_right (singleton r a) s h i
@@ -496,24 +497,24 @@ lemma cons_cast_succ (s : RelSeries r) (a : α) (h : r a s.head) (i : Fin (s.len
   simpa using (Nat.mod_eq_of_lt (by simp)).symm
 
 @[simp]
-lemma append_singleton_left (p : RelSeries r) (x : α) (hx : r x p.head) :
+lemma append_singleton_left (p : RelSeries r) (x : α) (hx : x ~[r] p.head) :
     (singleton r x).append p hx = p.cons x hx :=
   rfl
 
 @[simp]
-lemma toList_cons (p : RelSeries r) (x : α) (hx : r x p.head) :
+lemma toList_cons (p : RelSeries r) (x : α) (hx : x ~[r] p.head) :
     (p.cons x hx).toList = x :: p.toList := by
   rw [cons, toList_append]
   simp
 
 lemma fromListChain'_cons (l : List α) (l_ne_nil : l ≠ [])
-    (hl : l.Chain' r) (x : α) (hx : r x (l.head l_ne_nil)) :
+    (hl : l.Chain' (· ~[r] ·)) (x : α) (hx : x ~[r] l.head l_ne_nil) :
     fromListChain' (x :: l) (by simp) (hl.cons_of_ne_nil l_ne_nil hx) =
       (fromListChain' l l_ne_nil hl).cons x (by simpa) := by
   apply toList_injective
   simp
 
-lemma append_cons {p q : RelSeries r} {x : α} (hx : r x p.head) (hq : r p.last q.head) :
+lemma append_cons {p q : RelSeries r} {x : α} (hx : x ~[r] p.head) (hq : p.last ~[r] q.head) :
     (p.cons x hx).append q (by simpa) = (p.append q hq).cons x (by simpa) := by
   simp only [cons]
   rw [append_assoc]
@@ -523,31 +524,31 @@ Given a series `a₀ -r→ a₁ -r→ ... -r→ aₙ` and an `a` such that `aₙ
 a series of length `n+1`: `a₀ -r→ a₁ -r→ ... -r→ aₙ -r→ a`.
 -/
 @[simps! length]
-def snoc (p : RelSeries r) (newLast : α) (rel : r p.last newLast) : RelSeries r :=
+def snoc (p : RelSeries r) (newLast : α) (rel : p.last ~[r] newLast) : RelSeries r :=
   p.append (singleton r newLast) rel
 
-@[simp] lemma head_snoc (p : RelSeries r) (newLast : α) (rel : r p.last newLast) :
+@[simp] lemma head_snoc (p : RelSeries r) (newLast : α) (rel : p.last ~[r] newLast) :
     (p.snoc newLast rel).head = p.head := by
   delta snoc; rw [head_append]
 
-@[simp] lemma last_snoc (p : RelSeries r) (newLast : α) (rel : r p.last newLast) :
+@[simp] lemma last_snoc (p : RelSeries r) (newLast : α) (rel : p.last ~[r] newLast) :
     (p.snoc newLast rel).last = newLast := last_append _ _ _
 
-lemma snoc_cast_castSucc (s : RelSeries r) (a : α) (h : r s.last a) (i : Fin (s.length + 1)) :
+lemma snoc_cast_castSucc (s : RelSeries r) (a : α) (h : s.last ~[r] a) (i : Fin (s.length + 1)) :
     (s.snoc a h) (.cast (by simp) (.castSucc i)) = s i :=
   append_apply_left s (singleton r a) h i
 
 -- This lemma is useful because `last_snoc` is about `Fin.last (p.snoc _ _).length`, but we often
 -- see `Fin.last (p.length + 1)` in practice. They are equal by definition, but sometimes simplifier
 -- does not pick up `last_snoc`
-@[simp] lemma last_snoc' (p : RelSeries r) (newLast : α) (rel : r p.last newLast) :
+@[simp] lemma last_snoc' (p : RelSeries r) (newLast : α) (rel : p.last ~[r] newLast) :
     p.snoc newLast rel (Fin.last (p.length + 1)) = newLast := last_append _ _ _
 
-@[simp] lemma snoc_castSucc (s : RelSeries r) (a : α) (connect : r s.last a)
+@[simp] lemma snoc_castSucc (s : RelSeries r) (a : α) (connect : s.last ~[r] a)
     (i : Fin (s.length + 1)) : snoc s a connect (Fin.castSucc i) = s i :=
   Fin.append_left _ _ i
 
-lemma mem_snoc {p : RelSeries r} {newLast : α} {rel : r p.last newLast} {x : α} :
+lemma mem_snoc {p : RelSeries r} {newLast : α} {rel : p.last ~[r] newLast} {x : α} :
     x ∈ p.snoc newLast rel ↔ x ∈ p ∨ x = newLast := by
   simp only [snoc, append, singleton_length, Nat.add_zero, Nat.reduceAdd, Fin.cast_refl,
     Function.comp_id, mem_def, Set.mem_range]
@@ -596,7 +597,7 @@ lemma toList_tail {p : RelSeries r} (hp : p.length ≠ 0) : (p.tail hp).toList =
     simp_all [Fin.tail]
 
 @[simp]
-lemma tail_cons (p : RelSeries r) (x : α) (hx : r x p.head) :
+lemma tail_cons (p : RelSeries r) (x : α) (hx : x ~[r] p.head) :
     (p.cons x hx).tail (by simp) = p := by
   apply toList_injective
   simp
@@ -616,7 +617,7 @@ since `(p.cons x hx).tail _ = p` is not a definitional equality.
 @[elab_as_elim]
 def inductionOn (motive : RelSeries r → Sort*)
     (singleton : (x : α) → motive (RelSeries.singleton r x))
-    (cons : (p : RelSeries r) → (x : α) → (hx : r x p.head) → (hp : motive p) →
+    (cons : (p : RelSeries r) → (x : α) → (hx : x ~[r] p.head) → (hp : motive p) →
       motive (p.cons x hx)) (p : RelSeries r) :
     motive p := by
   let this {n : ℕ} (heq : p.length = n) : motive p := by
@@ -635,7 +636,7 @@ def inductionOn (motive : RelSeries r → Sort*)
   exact this rfl
 
 @[simp]
-lemma toList_snoc (p : RelSeries r) (newLast : α) (rel : r p.last newLast) :
+lemma toList_snoc (p : RelSeries r) (newLast : α) (rel : p.last ~[r] newLast) :
     (p.snoc newLast rel).toList = p.toList ++ [newLast] := by
   simp [snoc]
 
@@ -655,7 +656,7 @@ def eraseLast (p : RelSeries r) : RelSeries r where
 
 /-- In a non-trivial series `p`, the last element of `p.eraseLast` is related to `p.last` -/
 lemma eraseLast_last_rel_last (p : RelSeries r) (h : p.length ≠ 0) :
-    r p.eraseLast.last p.last := by
+    p.eraseLast.last ~[r] p.last := by
   simp only [last, Fin.last, eraseLast_length, eraseLast_toFun]
   convert p.step ⟨p.length - 1, by omega⟩
   simp only [Fin.succ_mk]; omega
@@ -681,7 +682,7 @@ and to show that when `p` holds for `xs` it also holds for `xs` appended with on
 @[elab_as_elim]
 def inductionOn' (motive : RelSeries r → Sort*)
     (singleton : (x : α) → motive (RelSeries.singleton r x))
-    (snoc : (p : RelSeries r) → (x : α) → (hx : r p.last x) → (hp : motive p) →
+    (snoc : (p : RelSeries r) → (x : α) → (hx : p.last ~[r] x) → (hp : motive p) →
       motive (p.snoc x hx)) (p : RelSeries r) :
     motive p := by
   let this {n : ℕ} (heq : p.length = n) : motive p := by
@@ -815,39 +816,34 @@ lemma Rel.finiteDimensional_or_infiniteDimensional [Nonempty α] :
   rw [← not_finiteDimensional_iff]
   exact em r.FiniteDimensional
 
-instance Rel.FiniteDimensional.swap [FiniteDimensional r] : FiniteDimensional (Function.swap r) :=
-  ⟨.reverse (.longestOf r), fun s ↦ s.reverse.length_le_length_longestOf⟩
+instance Rel.FiniteDimensional.inv [FiniteDimensional r] : FiniteDimensional r.inv :=
+  ⟨.reverse (.longestOf r), fun s ↦ s.reverse.length_le_length_longestOf r⟩
 
 variable {r} in
 @[simp]
-lemma Rel.finiteDimensional_swap_iff :
-    FiniteDimensional (Function.swap r) ↔ FiniteDimensional r :=
-  ⟨fun _ ↦ .swap _, fun _ ↦ .swap _⟩
+lemma Rel.finiteDimensional_inv : FiniteDimensional r.inv ↔ FiniteDimensional r :=
+  ⟨fun _ ↦ .inv r.inv, fun _ ↦ .inv _⟩
 
-instance Rel.InfiniteDimensional.swap [InfiniteDimensional r] :
-    InfiniteDimensional (Function.swap r) :=
+instance Rel.InfiniteDimensional.inv [InfiniteDimensional r] : InfiniteDimensional r.inv :=
   ⟨fun n ↦ ⟨.reverse (.withLength r n), RelSeries.length_withLength r n⟩⟩
 
 variable {r} in
 @[simp]
-lemma Rel.infiniteDimensional_swap_iff :
-    InfiniteDimensional (Function.swap r) ↔ InfiniteDimensional r :=
-  ⟨fun _ ↦ .swap _, fun _ ↦ .swap _⟩
+lemma Rel.infiniteDimensional_inv : InfiniteDimensional r.inv ↔ InfiniteDimensional r :=
+  ⟨fun _ ↦ .inv r.inv, fun _ ↦ .inv _⟩
 
-lemma Rel.wellFounded_swap_of_finiteDimensional [Rel.FiniteDimensional r] :
-    WellFounded (Function.swap r) := by
-  rw [WellFounded.wellFounded_iff_no_descending_seq]
+lemma Rel.IsWellFounded.inv_of_finiteDimensional [r.FiniteDimensional] : r.inv.IsWellFounded := by
+  rw [IsWellFounded, WellFounded.wellFounded_iff_no_descending_seq]
   refine ⟨fun ⟨f, hf⟩ ↦ ?_⟩
   let s := RelSeries.mk (r := r) ((RelSeries.longestOf r).length + 1) (f ·) (hf ·)
   exact (RelSeries.longestOf r).length.lt_succ_self.not_ge s.length_le_length_longestOf
 
-lemma Rel.wellFounded_of_finiteDimensional [Rel.FiniteDimensional r] : WellFounded r :=
-  have : (Rel.FiniteDimensional (Function.swap r)) := Rel.finiteDimensional_swap_iff.mp ‹_›
-  wellFounded_swap_of_finiteDimensional (Function.swap r)
+lemma Rel.IsWellFounded.of_finiteDimensional [Rel.FiniteDimensional r] : r.IsWellFounded :=
+  .inv_of_finiteDimensional r.inv
 
 /-- A type is finite dimensional if its `LTSeries` has bounded length. -/
 abbrev FiniteDimensionalOrder (γ : Type*) [Preorder γ] :=
-  Rel.FiniteDimensional ((· < ·) : γ → γ → Prop)
+  Rel.FiniteDimensional {(a, b) : γ × γ | a < b}
 
 instance FiniteDimensionalOrder.ofUnique (γ : Type*) [Preorder γ] [Unique γ] :
     FiniteDimensionalOrder γ where
@@ -857,7 +853,7 @@ instance FiniteDimensionalOrder.ofUnique (γ : Type*) [Preorder γ] [Unique γ] 
 
 /-- A type is infinite dimensional if it has `LTSeries` of at least arbitrary length -/
 abbrev InfiniteDimensionalOrder (γ : Type*) [Preorder γ] :=
-  Rel.InfiniteDimensional ((· < ·) : γ → γ → Prop)
+  Rel.InfiniteDimensional {(a, b) : γ × γ | a < b}
 
 section LTSeries
 
@@ -865,7 +861,7 @@ variable (α) [Preorder α] [Preorder β]
 /--
 If `α` is a preorder, a LTSeries is a relation series of the less than relation.
 -/
-abbrev LTSeries := RelSeries ((· < ·) : Rel α α)
+abbrev LTSeries := RelSeries {(a, b) : α × α | a < b}
 
 namespace LTSeries
 
@@ -985,7 +981,7 @@ def range (n : ℕ) : LTSeries ℕ where
 in a bidirectionally well-founded order. -/
 theorem exists_relSeries_covBy
     {α} [PartialOrder α] [WellFoundedLT α] [WellFoundedGT α] (s : LTSeries α) :
-    ∃ (t : RelSeries (α := α) (· ⋖ ·)) (i : Fin (s.length + 1) ↪ Fin (t.length + 1)),
+    ∃ (t : RelSeries {(a, b) : α × α | a ⋖ b}) (i : Fin (s.length + 1) ↪ Fin (t.length + 1)),
       t ∘ i = s ∧ i 0 = 0 ∧ i (.last _) = .last _ := by
   obtain ⟨n, s, h⟩ := s
   induction n with
@@ -994,7 +990,7 @@ theorem exists_relSeries_covBy
     obtain ⟨t₁, i, ht, hi₁, hi₂⟩ := IH (s ∘ Fin.castSucc) fun _ ↦ h _
     obtain ⟨t₂, h₁, m, h₂, ht₂⟩ :=
       exists_covBy_seq_of_wellFoundedLT_wellFoundedGT_of_le (h (.last _)).le
-    let t₃ : RelSeries (α := α) (· ⋖ ·) := ⟨m, (t₂ ·), fun i ↦ by simpa using ht₂ i⟩
+    let t₃ : RelSeries {(a, b) : α × α | a ⋖ b} := ⟨m, (t₂ ·), fun i ↦ by simpa using ht₂ i⟩
     have H : t₁.last = t₂ 0 := (congr(t₁ $hi₂.symm).trans (congr_fun ht _)).trans h₁.symm
     refine ⟨t₁.smash t₃ H, ⟨Fin.snoc (Fin.castLE (by simp) ∘ i) (.last _), ?_⟩, ?_, ?_, ?_⟩
     · refine Fin.lastCases (Fin.lastCases (fun _ ↦ rfl) fun j eq ↦ ?_) fun j ↦ Fin.lastCases
@@ -1012,7 +1008,7 @@ theorem exists_relSeries_covBy
 
 theorem exists_relSeries_covBy_and_head_eq_bot_and_last_eq_bot
     {α} [PartialOrder α] [BoundedOrder α] [WellFoundedLT α] [WellFoundedGT α] (s : LTSeries α) :
-    ∃ (t : RelSeries (α := α) (· ⋖ ·)) (i : Fin (s.length + 1) ↪ Fin (t.length + 1)),
+    ∃ (t : RelSeries {(a, b) : α × α | a ⋖ b}) (i : Fin (s.length + 1) ↪ Fin (t.length + 1)),
       t ∘ i = s ∧ t.head = ⊥ ∧ t.last = ⊤ := by
   wlog h₁ : s.head = ⊥
   · obtain ⟨t, i, hi, ht⟩ := this (s.cons ⊥ (bot_lt_iff_ne_bot.mpr h₁)) rfl

--- a/Mathlib/Order/RelSeries.lean
+++ b/Mathlib/Order/RelSeries.lean
@@ -824,6 +824,9 @@ variable {r} in
 lemma Rel.finiteDimensional_inv : FiniteDimensional r.inv ↔ FiniteDimensional r :=
   ⟨fun _ ↦ .inv r.inv, fun _ ↦ .inv _⟩
 
+@[deprecated (since := "2025-07-06")]
+alias Rel.finiteDimensional_swap_iff := Rel.finiteDimensional_inv
+
 instance Rel.InfiniteDimensional.inv [InfiniteDimensional r] : InfiniteDimensional r.inv :=
   ⟨fun n ↦ ⟨.reverse (.withLength r n), RelSeries.length_withLength r n⟩⟩
 
@@ -832,14 +835,23 @@ variable {r} in
 lemma Rel.infiniteDimensional_inv : InfiniteDimensional r.inv ↔ InfiniteDimensional r :=
   ⟨fun _ ↦ .inv r.inv, fun _ ↦ .inv _⟩
 
+@[deprecated (since := "2025-07-06")]
+alias Rel.infiniteDimensional_swap_iff := Rel.infiniteDimensional_inv
+
 lemma Rel.IsWellFounded.inv_of_finiteDimensional [r.FiniteDimensional] : r.inv.IsWellFounded := by
   rw [IsWellFounded, WellFounded.wellFounded_iff_no_descending_seq]
   refine ⟨fun ⟨f, hf⟩ ↦ ?_⟩
   let s := RelSeries.mk (r := r) ((RelSeries.longestOf r).length + 1) (f ·) (hf ·)
   exact (RelSeries.longestOf r).length.lt_succ_self.not_ge s.length_le_length_longestOf
 
+@[deprecated (since := "2025-07-06")]
+alias Rel.wellFounded_swap_of_finiteDimensional := Rel.IsWellFounded.inv_of_finiteDimensional
+
 lemma Rel.IsWellFounded.of_finiteDimensional [Rel.FiniteDimensional r] : r.IsWellFounded :=
   .inv_of_finiteDimensional r.inv
+
+@[deprecated (since := "2025-07-06")]
+alias Rel.wellFounded_of_finiteDimensional := Rel.IsWellFounded.of_finiteDimensional
 
 /-- A type is finite dimensional if its `LTSeries` has bounded length. -/
 abbrev FiniteDimensionalOrder (γ : Type*) [Preorder γ] :=

--- a/Mathlib/RingTheory/Ideal/AssociatedPrime/Finiteness.lean
+++ b/Mathlib/RingTheory/Ideal/AssociatedPrime/Finiteness.lean
@@ -83,7 +83,7 @@ a chain of submodules `0 = M₀ ≤ M₁ ≤ M₂ ≤ ... ≤ Mₙ = M` of `M`, 
 `Mᵢ₊₁ / Mᵢ` is isomorphic to `A / pᵢ` for some prime ideal `pᵢ` of `A`. -/
 @[stacks 00L0]
 theorem IsNoetherianRing.exists_relSeries_isQuotientEquivQuotientPrime :
-    ∃ s : RelSeries (Submodule.IsQuotientEquivQuotientPrime (A := A) (M := M)),
+    ∃ s : RelSeries {(N₁, N₂) | Submodule.IsQuotientEquivQuotientPrime (A := A) (M := M) N₁ N₂},
       s.head = ⊥ ∧ s.last = ⊤ := by
   refine WellFoundedGT.induction_top ⟨⊥, .singleton _ ⊥, rfl, rfl⟩ ?_
   rintro N hN ⟨s, hs₁, hs₂⟩

--- a/Mathlib/RingTheory/Length.lean
+++ b/Mathlib/RingTheory/Length.lean
@@ -68,8 +68,7 @@ lemma Module.length_compositionSeries (s : CompositionSeries (Submodule R M)) (h
   have := (isFiniteLength_iff_isNoetherian_isArtinian.mp H).2
   rw [← WithBot.coe_inj, Module.coe_length]
   apply le_antisymm
-  · let s' := s.map (β := Submodule R M) (s := (· < ·)) ⟨id, fun h ↦ h.1⟩
-    exact (Order.LTSeries.length_le_krullDim s')
+  · exact (Order.LTSeries.length_le_krullDim <| s.map ⟨id, fun h ↦ h.1⟩)
   · rw [Order.krullDim, iSup_le_iff]
     intro t
     refine WithBot.coe_le_coe.mpr ?_
@@ -92,7 +91,10 @@ lemma Module.length_ne_top_iff : Module.length R M ≠ ⊤ ↔ IsFiniteLength R 
   refine ⟨fun h ↦ ?_, fun H ↦ ?_⟩
   · rw [length_ne_top_iff_finiteDimensionalOrder] at h
     rw [isFiniteLength_iff_isNoetherian_isArtinian, isNoetherian_iff, isArtinian_iff]
-    exact ⟨Rel.wellFounded_swap_of_finiteDimensional _, Rel.wellFounded_of_finiteDimensional _⟩
+    let R : Rel (Submodule R M) (Submodule R M) :=
+      {(N₁, N₂) : Submodule R M × Submodule R M | N₁ < N₂}
+    change R.inv.IsWellFounded ∧ R.IsWellFounded
+    exact ⟨.of_finiteDimensional R.inv, .of_finiteDimensional R⟩
   · obtain ⟨s, hs₁, hs₂⟩ := isFiniteLength_iff_exists_compositionSeries.mp H
     rw [← length_compositionSeries s hs₁ hs₂]
     simp

--- a/Mathlib/RingTheory/Spectrum/Prime/LTSeries.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/LTSeries.lean
@@ -77,7 +77,7 @@ theorem exist_ltSeries_mem_one_of_mem_last (p : LTSeries (PrimeSpectrum R))
     x ∈ (q 1).asIdeal ∧ p.length = q.length ∧ p.head = q.head ∧ p.last = q.last := by
   generalize hp : p.length = n
   induction' n with n hn generalizing p
-  · use RelSeries.singleton (· < ·) p.last
+  · use RelSeries.singleton _ p.last
     simp only [RelSeries.singleton_toFun, hx, RelSeries.singleton_length, RelSeries.head,
       RelSeries.last_singleton, and_true, true_and]
     rw [show 0 = Fin.last p.length from Fin.zero_eq_mk.mpr hp, RelSeries.last]
@@ -99,7 +99,7 @@ theorem exist_ltSeries_mem_one_of_mem_last (p : LTSeries (PrimeSpectrum R))
       simp only [RelSeries.snoc_length, RelSeries.eraseLast_length, hp]
       exact Nat.succ_pred_eq_of_ne_zero h0
   refine ⟨Q.snoc p.last ?_, ?_, ?_, ?_, ?_⟩
-  · simp only [← hl, RelSeries.last_snoc, hq]
+  · simp [← hl, RelSeries.last_snoc, hq]
   · have h1 : 1 = (1 : Fin (Q.length + 1)).castSucc := by
       have h : 1 < Q.length + 1 := by
         rw [← hQ]


### PR DESCRIPTION
There is tension throughout the library between considering relations between `α` and `β` simply as `α → β → Prop`, or as a bundled object `Rel α β` with dedicated operations and API.

The former approach is used almost everywhere as it is very lightweight and has arguably native support from core Lean features, but it cracks at the seams whenever one starts talking about operations on relations. For example:
* composition of relations `R : α → β → Prop`, `S : β → γ → Prop` is the unwieldy `Relation.Comp R S := fun a c ↦ ∃ b, R a b ∧ S b c`
* map of a relation `R : α → β → Prop`, under `f : α → γ`, `g : β → δ` is the monstruous `Relation.map R f g := fun c d ↦ ∃ a b, r a b ∧ f a = c ∧ g b = d`.

The latter approach is embodied by the existing type `Rel α β`, with dedicated notation like `○` for composition. It makes it much easier to reason about operations relations, but currently its API suffers from the leakage of its definition as
```
def Rel (α β : Type*) := α → β → Prop
```
The fact that `Rel` isn't an `abbrev` confuses automation. But simply making it an `abbrev` would kill the point of having a separate less see-through type to perform relation operations on.

A final point, and the original motivation for this refactor, is that uniform spaces need a theory of relations on a type `α` as elements of  `Set (α × α)`. This cannot be worked around, since `Set (α × α)` is the type of elements of a filter on `α × α`. This theory is already developed in `Topology.UniformSpace.Defs`, and duplicates the existing `Rel` material.

This PR is a proposal to refactor `Rel` to be less see-through by redefining it as
```
abbrev Rel (α β : Type*) := Set (α × β)
```

This has several advantages:
* The use of `α × β` means that one can't abuse the defeq of `Rel α β` with the function type `α → β → Prop`.
* Instead, we get to provide an explicit notation `a ~[R] b` that very closely follows the paper convention `a ~R b` of using relations as infixes. This notation is scoped to the `Rel` namespace.
* The use of `Set` is an extra layer of indirection to avoid automation confusing `Rel α β` with `α × β → Prop`.
* It can directly be used in the theory of uniform spaces because of the syntactic equality between `Rel α α` and `Set (α × α)`.
* A relation can still be defined from an explicit function `α → β → Prop`, with nice notation: What was previously `fun a b ↦ R a b` becomes `{(a, b) | R a b}`.
* In general, fallout is manageably small and easily fixed by inserting the `{(a, b) | R a b}` and `a ~[R] b` notations.

The benefits can be seen in places like `CategoryTheory.Category.RelCat` where automation is significantly improved, or `Combinatorics.Hall.Basic` where defeq abuse is avoided and dot notation becomes available.

[Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Uniform.20spaces.20and.20relations.20as.20sets)

---

- [x] depends on: #25593

I will add deprecations once CI passes and people agree this is a step forward.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
