### PR TITLE
[Merged by Bors] - chore(CategoryTheory): unsimp `Mon_Class.tensorObj.one_def`

### DIFF
--- a/Mathlib/Algebra/Category/CoalgCat/ComonEquivalence.lean
+++ b/Mathlib/Algebra/Category/CoalgCat/ComonEquivalence.lean
@@ -126,9 +126,10 @@ theorem tensorObj_comul (K L : CoalgCat R) :
   rw [ofComonObjCoalgebraStruct_comul]
   dsimp only [Equivalence.symm_inverse, comonEquivalence_functor, toComon_obj]
   simp only [Comon_.monoidal_tensorObj_comon_comul, Equivalence.symm_inverse,
-    comonEquivalence_functor, toComon_obj, toComonObj_X, ModuleCat.of_coe, comul_def,
-    tensorμ_eq_tensorTensorTensorComm, ModuleCat.hom_comp, ModuleCat.hom_ofHom,
-    LinearEquiv.comp_toLinearMap_eq_iff]
+    comonEquivalence_functor, toComon_obj, toComonObj_X, ModuleCat.of_coe,
+    Mon_Class.tensorObj.mul_def, unop_comp, unop_tensorObj, unop_tensorHom,
+    BraidedCategory.unop_tensorμ, tensorμ_eq_tensorTensorTensorComm, ModuleCat.hom_comp,
+    ModuleCat.hom_ofHom, LinearEquiv.comp_toLinearMap_eq_iff]
   rfl
 
 theorem tensorHom_toLinearMap (f : M →ₗc[R] N) (g : P →ₗc[R] Q) :
@@ -150,6 +151,7 @@ theorem rightUnitor_hom_toLinearMap :
 
 open TensorProduct
 
+attribute [local simp] Mon_Class.tensorObj.one_def Mon_Class.tensorObj.mul_def in
 theorem comul_tensorObj :
     Coalgebra.comul (R := R) (A := (CoalgCat.of R M ⊗ CoalgCat.of R N : CoalgCat R))
       = Coalgebra.comul (A := M ⊗[R] N) := by
@@ -158,6 +160,7 @@ theorem comul_tensorObj :
     AlgebraTensorModule.tensorTensorTensorComm_eq]
   rfl
 
+attribute [local simp] Mon_Class.tensorObj.one_def Mon_Class.tensorObj.mul_def in
 theorem comul_tensorObj_tensorObj_right :
     Coalgebra.comul (R := R) (A := (CoalgCat.of R M ⊗
       (CoalgCat.of R N ⊗ CoalgCat.of R P) : CoalgCat R))
@@ -168,6 +171,7 @@ theorem comul_tensorObj_tensorObj_right :
     AlgebraTensorModule.tensorTensorTensorComm_eq]
   rfl
 
+attribute [local simp] Mon_Class.tensorObj.one_def Mon_Class.tensorObj.mul_def in
 theorem comul_tensorObj_tensorObj_left :
     Coalgebra.comul (R := R)
       (A := ((CoalgCat.of R M ⊗ CoalgCat.of R N) ⊗ CoalgCat.of R P : CoalgCat R))

--- a/Mathlib/CategoryTheory/Monoidal/Bimon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Bimon_.lean
@@ -144,16 +144,13 @@ theorem ofMon_Comon_ObjX_mul (M : Mon_ (Comon_ C)) :
     μ[(ofMon_Comon_ObjX M).X] = 𝟙 (M.X.X ⊗ M.X.X) ≫ μ[M.X].hom :=
   rfl
 
+attribute [local simp] Mon_Class.tensorObj.one_def Mon_Class.tensorObj.mul_def tensorμ in
 /-- The object level part of the backward direction of `Comon_ (Mon_ C) ≌ Mon_ (Comon_ C)` -/
 @[simps]
 def ofMon_Comon_Obj (M : Mon_ (Comon_ C)) : Bimon_ C where
   X := ofMon_Comon_ObjX M
-  comon :=
-    { counit :=
-        { hom := ε[M.X.X] }
-      comul :=
-        { hom := Δ[M.X.X]
-          mul_hom := by simp [tensorμ] } }
+  comon.counit.hom := ε[M.X.X]
+  comon.comul.hom := Δ[M.X.X]
 
 variable (C) in
 /-- The backward direction of `Comon_ (Mon_ C) ≌ Mon_ (Comon_ C)` -/
@@ -277,6 +274,7 @@ instance (M : Bimon_ C) : Bimon_Class M.X.X where
   comul_assoc' := by
     simp_rw [← Bimon_ClassAux_comul, Comon_Class.comul_assoc]
 
+attribute [local simp] Mon_Class.tensorObj.one_def in
 @[reassoc]
 theorem one_comul (M : C) [Bimon_Class M] :
     η[M] ≫ Δ[M] = (λ_ _).inv ≫ (η[M] ⊗ η[M]) := by

--- a/Mathlib/CategoryTheory/Monoidal/Hopf_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Hopf_.lean
@@ -163,7 +163,7 @@ theorem antipode_comul₁ (A : C) [Hopf_Class A] :
     rw [Bimon_.compatibility]
   slice_lhs 1 3 =>
     rw [antipode_left]
-  simp
+  simp [Mon_Class.tensorObj.one_def]
 
 /--
 Auxiliary calculation for `antipode_comul`.

--- a/Mathlib/CategoryTheory/Monoidal/Mon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Mon_.lean
@@ -626,7 +626,9 @@ theorem mul_rightUnitor {M : C} [Mon_Class M] :
 
 namespace tensorObj
 
-@[simps]
+-- We don't want `tensorObj.one_def` to be simp as it would loop with `IsMon_Hom.one_hom` applied
+-- to `(λ_ N.X).inv`.
+@[simps -isSimp]
 instance {M N : C} [Mon_Class M] [Mon_Class N] : Mon_Class (M ⊗ N) where
   one := (λ_ (𝟙_ C)).inv ≫ (η ⊗ η)
   mul := tensorμ M N M N ≫ (μ ⊗ μ)

--- a/Mathlib/CategoryTheory/Monoidal/Mon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Mon_.lean
@@ -644,10 +644,10 @@ variable {X Y Z W : C} [Mon_Class X] [Mon_Class Y] [Mon_Class Z] [Mon_Class W]
 
 instance {f : X ⟶ Y} {g : Z ⟶ W} [IsMon_Hom f] [IsMon_Hom g] : IsMon_Hom (f ⊗ g) where
   one_hom := by
-    dsimp
+    dsimp [tensorObj.one_def]
     slice_lhs 2 3 => rw [← tensor_comp, one_hom, one_hom]
   mul_hom := by
-    dsimp
+    dsimp [tensorObj.mul_def]
     slice_rhs 1 2 => rw [tensorμ_natural]
     slice_lhs 2 3 => rw [← tensor_comp, mul_hom, mul_hom, tensor_comp]
     simp only [Category.assoc]
@@ -751,7 +751,9 @@ theorem tensor_mul (M N : Mon_ C) : μ[(M ⊗ N).X] =
 instance monMonoidal : MonoidalCategory (Mon_ C) where
   tensorHom_def := by intros; ext; simp [tensorHom_def]
 
-@[simps!]
+-- We don't want `tensorObj.one_def` to be simp as it would loop with `IsMon_Hom.one_hom` applied
+-- to `(λ_ N.X).inv`.
+@[simps! -isSimp]
 instance {M N : C} [Mon_Class M] [Mon_Class N] : Mon_Class (M ⊗ N) :=
   inferInstanceAs <| Mon_Class (Mon_.mk M ⊗ Mon_.mk N).X
 
@@ -790,7 +792,7 @@ namespace Mon_Class
 
 theorem mul_braiding (X Y : C) [Mon_Class X] [Mon_Class Y] :
     μ ≫ (β_ X Y).hom = ((β_ X Y).hom ⊗ (β_ X Y).hom) ≫ μ := by
-  dsimp
+  dsimp [tensorObj.mul_def]
   simp only [tensorμ, Category.assoc, BraidedCategory.braiding_naturality,
     BraidedCategory.braiding_tensor_right, BraidedCategory.braiding_tensor_left,
     comp_whiskerRight, whisker_assoc, MonoidalCategory.whiskerLeft_comp, pentagon_assoc,


### PR DESCRIPTION
This lemma loops with `IsMon_Hom.one_hom` applied to `(λ_ N.X).inv`, as evidenced by the following trace:
```
[Meta.Tactic.simp.rewrite] Mon_Class.tensorObj.one_def:1000:
      Mon_Class.one
    ==>
      (λ_ (𝟙_ C)).inv ≫ (Mon_Class.one ⊗ Mon_Class.one)
[Meta.Tactic.simp.rewrite] id_tensorHom:1000:
      𝟙 (𝟙_ C) ⊗ Mon_Class.one
    ==>
      𝟙_ C ◁ Mon_Class.one
[Meta.Tactic.simp.rewrite] id_whiskerLeft:1000:
      𝟙_ C ◁ Mon_Class.one
    ==>
      (λ_ (𝟙_ C)).hom ≫ Mon_Class.one ≫ (λ_ N.X).inv
[Meta.Tactic.simp.rewrite] IsMon_Hom.one_hom:1000:
      Mon_Class.one ≫ (λ_ N.X).inv
    ==>
      Mon_Class.one
```

Alternatively, `one_hom` is fine since it is the equivalent of `map_one` while `one_def` is not fine since it is the equivalent of `Algebra.TensorProduct.one_def`.

Do the same thing for the `mul` lemmas and the `Mon_` versions.

From Toric


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
