### PR TITLE
fix(CI): make autolabel run on `pull_request_target`

### DIFF
--- a/.github/workflows/add_label_from_diff.yaml
+++ b/.github/workflows/add_label_from_diff.yaml
@@ -1,7 +1,7 @@
 name: Autolabel PRs
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
   push:
     paths:

--- a/.github/workflows/add_label_from_diff.yaml
+++ b/.github/workflows/add_label_from_diff.yaml
@@ -23,7 +23,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          path: pr-branch
+
+      # Checkout the master branch into a subdirectory
+      - name: Checkout master branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # When testing the scripts, comment out the "ref: master"
+          ref: master
+          path: master-branch
       - name: Configure Lean
         uses: leanprover/lean-action@f807b338d95de7813c5c50d018f1c23c9b93b4ec # 2025-04-24
         with:
@@ -32,6 +42,7 @@ jobs:
           use-mathlib-cache: false
       - name: lake exe autolabel
         run: |
+          cd pr-branch
           # the checkout dance, to avoid a detached head
           git checkout master
           git checkout -

--- a/.github/workflows/add_label_from_diff.yaml
+++ b/.github/workflows/add_label_from_diff.yaml
@@ -20,20 +20,18 @@ jobs:
       pull-requests: write
       contents: read
     steps:
-      - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-          path: pr-branch
-
       # Checkout the master branch into a subdirectory
       - name: Checkout master branch
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # When testing the scripts, comment out the "ref: master"
           ref: master
-          path: master-branch
+      # Checkout the PR branch
+      - name: Checkout PR branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
       - name: Configure Lean
         uses: leanprover/lean-action@f807b338d95de7813c5c50d018f1c23c9b93b4ec # 2025-04-24
         with:
@@ -42,7 +40,6 @@ jobs:
           use-mathlib-cache: false
       - name: lake exe autolabel
         run: |
-          cd pr-branch
           # the checkout dance, to avoid a detached head
           git checkout master
           git checkout -


### PR DESCRIPTION
Mentioned by Bryan [here](https://github.com/leanprover-community/mathlib4/pull/25599#issuecomment-2954240919).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
