### PR TITLE
[Merged by Bors] - fix: only run jobs in the fork workflow for PRs from forks

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -422,6 +422,7 @@ jobs:
 
   post_steps:
     name: Post-Build StepJOB_NAME
+    if: FORK_CONDITION
     needs: [build]
     runs-on: ubuntu-latest # Note these steps run on disposable GitHub runners, so no landrun sandboxing is needed.
     steps:
@@ -503,6 +504,7 @@ jobs:
 
   style_lint:
     name: Lint styleJOB_NAME
+    if: FORK_CONDITION
     runs-on: ubuntu-latest
     steps:
       - uses: leanprover-community/lint-style-action@f2e7272aad56233a642b08fe974cf09dd664b0c8 # 2025-05-22

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -432,6 +432,7 @@ jobs:
 
   post_steps:
     name: Post-Build Step
+    if: true
     needs: [build]
     runs-on: ubuntu-latest # Note these steps run on disposable GitHub runners, so no landrun sandboxing is needed.
     steps:
@@ -513,6 +514,7 @@ jobs:
 
   style_lint:
     name: Lint style
+    if: true
     runs-on: ubuntu-latest
     steps:
       - uses: leanprover-community/lint-style-action@f2e7272aad56233a642b08fe974cf09dd664b0c8 # 2025-05-22

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -439,6 +439,7 @@ jobs:
 
   post_steps:
     name: Post-Build Step
+    if: true
     needs: [build]
     runs-on: ubuntu-latest # Note these steps run on disposable GitHub runners, so no landrun sandboxing is needed.
     steps:
@@ -520,6 +521,7 @@ jobs:
 
   style_lint:
     name: Lint style
+    if: true
     runs-on: ubuntu-latest
     steps:
       - uses: leanprover-community/lint-style-action@f2e7272aad56233a642b08fe974cf09dd664b0c8 # 2025-05-22

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -436,6 +436,7 @@ jobs:
 
   post_steps:
     name: Post-Build Step (fork)
+    if: github.event.pull_request.head.repo.fork
     needs: [build]
     runs-on: ubuntu-latest # Note these steps run on disposable GitHub runners, so no landrun sandboxing is needed.
     steps:
@@ -517,6 +518,7 @@ jobs:
 
   style_lint:
     name: Lint style (fork)
+    if: github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     steps:
       - uses: leanprover-community/lint-style-action@f2e7272aad56233a642b08fe974cf09dd664b0c8 # 2025-05-22


### PR DESCRIPTION
Currently, the "Style Lint (fork)" job is triggered even for PRs from branches in this repo. We add the fork conditional to all jobs in order to fix this.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
