### PR TITLE
[Merged by Bors] - feat: decidable equality for `Quiver.Path`

### DIFF
--- a/Mathlib/Combinatorics/Quiver/Path.lean
+++ b/Mathlib/Combinatorics/Quiver/Path.lean
@@ -193,6 +193,75 @@ theorem toList_injective (a : V) : ∀ b, Injective (toList : Path a b → List 
 theorem toList_inj {p q : Path a b} : p.toList = q.toList ↔ p = q :=
   (toList_injective _ _).eq_iff
 
+
+section BoundedPath
+
+variable {V : Type*} [Quiver V]
+
+/-- A bounded path is a path with a uniform bound on its length. -/
+def BoundedPaths (v w : V) (n : ℕ) : Sort _ :=
+  { p : Path v w // p.length ≤ n }
+
+/-- Bounded paths of length zero between two vertices are subsingletons. -/
+instance instSubsingletonBddPaths (v w : V) : Subsingleton (BoundedPaths v w 0) where
+  allEq := fun ⟨p, hp⟩ ⟨q, hq⟩ =>
+   match v, w, p, q with
+   | _, _, .nil, .nil => rfl
+   | _, _, .cons _ _, _ => by simp [Quiver.Path.length] at hp
+   | _, _, _, .cons _ _ => by simp [Quiver.Path.length] at hq
+
+/-- Bounded paths of length zero between two vertices have decidable equality. -/
+def decidableEqBddPathsZero (v w : V) : DecidableEq (BoundedPaths v w 0) :=
+  fun _ _ => isTrue <| Subsingleton.elim _ _
+
+/-- Given decidable equality on paths of length up to `n`, we can construct
+decidable equality on paths of length up to `n + 1`. -/
+def decidableEqBddPathsOfDecidableEq (n : ℕ) (h₁ : DecidableEq V)
+    (h₂ : ∀ (v w : V), DecidableEq (v ⟶  w)) (h₃ : ∀ (v w : V), DecidableEq (BoundedPaths v w n))
+    (v w : V) : DecidableEq (BoundedPaths v w (n + 1)) :=
+  fun ⟨p, hp⟩ ⟨q, hq⟩ =>
+    match v, w, p, q with
+    | _, _, .nil, .nil => isTrue rfl
+    | _, _, .nil, .cons _ _ => isFalse fun h => Quiver.Path.noConfusion <| Subtype.mk.inj h
+    | _, _, .cons _ _, .nil => isFalse fun h => Quiver.Path.noConfusion <| Subtype.mk.inj h
+    | _, _, .cons (b := v') p' α, .cons (b := v'') q' β =>
+      match v', v'', h₁ v' v'' with
+      | _, _, isTrue (Eq.refl _) =>
+        if h : α = β then
+          have hp' : p'.length ≤ n := by simp [Quiver.Path.length] at hp; omega
+          have hq' : q'.length ≤ n := by simp [Quiver.Path.length] at hq; omega
+          if h'' : (⟨p', hp'⟩ : BoundedPaths _ _ n) = ⟨q', hq'⟩ then
+            isTrue <| by
+              apply Subtype.ext
+              dsimp
+              rw [h, show p' = q' from Subtype.mk.inj h'']
+          else
+            isFalse fun h =>
+              h'' <| Subtype.ext <| eq_of_heq <| (Quiver.Path.cons.inj <| Subtype.mk.inj h).2.1
+        else
+          isFalse fun h' =>
+            h <| eq_of_heq (Quiver.Path.cons.inj <| Subtype.mk.inj h').2.2
+      | _, _, isFalse h => isFalse fun h' =>
+        h (Quiver.Path.cons.inj <| Subtype.mk.inj h').1
+
+/-- Equality is decidable on all uniformly bounded paths given decidable
+equality on the vertices and the arrows. -/
+instance decidableEqBoundedPaths [DecidableEq V] [∀ (v w : V), DecidableEq (v ⟶ w)]
+    (n : ℕ) : (v w : V) → DecidableEq (BoundedPaths v w n) :=
+  n.rec decidableEqBddPathsZero
+    fun n decEq => decidableEqBddPathsOfDecidableEq n inferInstance inferInstance decEq
+
+/-- Equality is decidable on paths in a quiver given decidable equality on the vertices and
+arrows. -/
+instance instDecidableEq [DecidableEq V] [∀ (v w : V), DecidableEq (v ⟶ w)] :
+    (v w : V) → DecidableEq (Path v w) := fun v w p q =>
+  let m := max p.length q.length
+  let p' : BoundedPaths v w m := ⟨p, Nat.le_max_left ..⟩
+  let q' : BoundedPaths v w m := ⟨q, Nat.le_max_right ..⟩
+  decidable_of_iff (p' = q') Subtype.ext_iff
+
+end BoundedPath
+
 end Path
 
 end Quiver

--- a/Mathlib/Combinatorics/Quiver/Path.lean
+++ b/Mathlib/Combinatorics/Quiver/Path.lean
@@ -202,7 +202,7 @@ variable {V : Type*} [Quiver V]
 def BoundedPaths (v w : V) (n : ℕ) : Sort _ :=
   { p : Path v w // p.length ≤ n }
 
-/-- Bounded paths of length zero between two vertices are subsingletons. -/
+/-- Bounded paths of length zero between two vertices form a subsingleton. -/
 instance instSubsingletonBddPaths (v w : V) : Subsingleton (BoundedPaths v w 0) where
   allEq := fun ⟨p, hp⟩ ⟨q, hq⟩ =>
    match v, w, p, q with


### PR DESCRIPTION
Given a quiver with decidable equality on its vertices and arrows, we construct an instance of decidable equality for `Quiver.Path`. We proceed through a recursion on the length of the path utilizing an intermediate subtype of uniformly bounded paths `Quiver.Path.BoundedPath`.

This was motivated by doing computations on small quivers with Lean.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
