### PR TITLE
feat: interactions between complete lattices and group operations

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4693,6 +4693,7 @@ import Mathlib.Order.CompleteLattice.Basic
 import Mathlib.Order.CompleteLattice.Chain
 import Mathlib.Order.CompleteLattice.Defs
 import Mathlib.Order.CompleteLattice.Finset
+import Mathlib.Order.CompleteLattice.Group
 import Mathlib.Order.CompleteLattice.Lemmas
 import Mathlib.Order.CompleteLattice.SetLike
 import Mathlib.Order.CompleteLatticeIntervals

--- a/Mathlib/Order/CompleteLattice/Group.lean
+++ b/Mathlib/Order/CompleteLattice/Group.lean
@@ -1,0 +1,35 @@
+/-
+Copyright (c) 2025 Jireh Loreaux. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jireh Loreaux
+-/
+import Mathlib.Algebra.Order.Monoid.Unbundled.Basic
+import Mathlib.Algebra.Order.Monoid.Unbundled.OrderDual
+import Mathlib.Order.CompleteLattice.Basic
+
+/-! # Complete lattices and groups -/
+
+variable {α : Type*} {ι : Sort*} {κ : ι → Sort*}
+  [CompleteLattice α] [Mul α] [MulLeftMono α] [MulRightMono α]
+
+@[to_additive]
+lemma iSup_mul_le (u v : ι → α) :
+    ⨆ i, u i * v i ≤ (⨆ i, u i) * ⨆ i, v i :=
+  iSup_le fun _ ↦ mul_le_mul' (le_iSup _ _) (le_iSup _ _)
+
+@[to_additive]
+lemma le_iInf_mul (u v : ι → α) :
+    (⨅ i, u i) * ⨅ i, v i ≤ ⨅ i, u i * v i :=
+  iSup_mul_le (α := αᵒᵈ) _ _
+
+@[to_additive]
+lemma iSup₂_mul_le (u v : (i : ι) → κ i → α) :
+    ⨆ (i) (j), u i j * v i j ≤ (⨆ (i) (j), u i j) * ⨆ (i) (j), v i j := by
+  refine le_trans ?_ (iSup_mul_le _ _)
+  gcongr
+  exact iSup_mul_le _ _
+
+@[to_additive]
+lemma le_iInf₂_mul (u v : (i : ι) → κ i → α) :
+    (⨅ (i) (j), u i j) * ⨅ (i) (j), v i j ≤ ⨅ (i) (j), u i j * v i j :=
+  iSup₂_mul_le (α := αᵒᵈ) _ _


### PR DESCRIPTION
Stnadard lemmas relating suprema and infima on complete lattices to multiplication and addition.

+ `⨆ i, u i * v i ≤ (⨆ i, u i) * ⨆ i, v i`
+ `⨆ (i) (j), u i j * v i j ≤ (⨆ (i) (j), u i j) * ⨆ (i) (j), v i j`

and their `to_additive` counterparts.

---

[Loogle](https://loogle.lean-lang.org/?q=%7C-+⨆+i%2C+%3Fu+i+*+%3Fv+i+≤+_) [tells](https://loogle.lean-lang.org/?q=%7C-+⨆+i%2C+%3Fu+i+%2B+%3Fv+i+≤+_) me that we only have these for conditionally complete lattices, and a special case of the first one for ENNReal

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
