### PR TITLE
[Merged by Bors] - feat: add lemmas for `C(α, β)` and `α →ᵇ β` regarding `edist` and `‖·‖ₑ`

### DIFF
--- a/Mathlib/Topology/ContinuousMap/Bounded/Basic.lean
+++ b/Mathlib/Topology/ContinuousMap/Bounded/Basic.lean
@@ -217,6 +217,12 @@ theorem dist_eq_iSup : dist f g = ⨆ x : α, dist (f x) (g x) := by
 theorem nndist_eq_iSup : nndist f g = ⨆ x : α, nndist (f x) (g x) :=
   Subtype.ext <| dist_eq_iSup.trans <| by simp_rw [val_eq_coe, coe_iSup, coe_nndist]
 
+theorem edist_eq_iSup : edist f g = ⨆ x, edist (f x) (g x) := by
+  simp_rw [edist_nndist, nndist_eq_iSup]
+  refine ENNReal.coe_iSup ⟨nndist f g, ?_⟩
+  rintro - ⟨x, hx, rfl⟩
+  exact nndist_coe_le_nndist x
+
 theorem tendsto_iff_tendstoUniformly {ι : Type*} {F : ι → α →ᵇ β} {f : α →ᵇ β} {l : Filter ι} :
     Tendsto F l (𝓝 f) ↔ TendstoUniformly (fun i => F i) f l :=
   Iff.intro

--- a/Mathlib/Topology/ContinuousMap/Bounded/Normed.lean
+++ b/Mathlib/Topology/ContinuousMap/Bounded/Normed.lean
@@ -225,6 +225,9 @@ theorem nnnorm_const_eq [Nonempty α] (b : β) : ‖const α b‖₊ = ‖b‖�
 theorem nnnorm_eq_iSup_nnnorm : ‖f‖₊ = ⨆ x : α, ‖f x‖₊ :=
   Subtype.ext <| (norm_eq_iSup_norm f).trans <| by simp_rw [val_eq_coe, NNReal.coe_iSup, coe_nnnorm]
 
+theorem enorm_eq_iSup_enorm : ‖f‖ₑ = ⨆ x, ‖f x‖ₑ := by
+  simpa only [← edist_zero_eq_enorm] using edist_eq_iSup
+
 theorem abs_diff_coe_le_dist : ‖f x - g x‖ ≤ dist f g := by
   rw [dist_eq_norm]
   exact (f - g).norm_coe_le_norm x

--- a/Mathlib/Topology/ContinuousMap/Compact.lean
+++ b/Mathlib/Topology/ContinuousMap/Compact.lean
@@ -127,6 +127,18 @@ theorem dist_lt_iff (C0 : (0 : ℝ) < C) : dist f g < C ↔ ∀ x : α, dist (f 
   rw [← dist_mkOfCompact, dist_lt_iff_of_compact C0]
   simp only [mkOfCompact_apply]
 
+theorem dist_eq_iSup : dist f g = ⨆ x, dist (f x) (g x) := by
+  simp [← isometryEquivBoundedOfCompact α β |>.dist_eq f g,
+    BoundedContinuousFunction.dist_eq_iSup]
+
+theorem nndist_eq_iSup : nndist f g = ⨆ x, nndist (f x) (g x) := by
+  simp [← isometryEquivBoundedOfCompact α β |>.nndist_eq f g,
+    BoundedContinuousFunction.nndist_eq_iSup]
+
+theorem edist_eq_iSup : edist f g = ⨆ (x : α), edist (f x) (g x) := by
+  simp [← isometryEquivBoundedOfCompact α β |>.edist_eq f g,
+    BoundedContinuousFunction.edist_eq_iSup]
+
 instance {R} [Zero R] [Zero β] [PseudoMetricSpace R] [SMul R β] [IsBoundedSMul R β] :
     IsBoundedSMul R C(α, β) where
   dist_smul_pair' r f g := by
@@ -209,6 +221,9 @@ theorem nnnorm_eq_iSup_nnnorm : ‖f‖₊ = ⨆ x : α, ‖f x‖₊ :=
 
 theorem norm_eq_iSup_norm : ‖f‖ = ⨆ x : α, ‖f x‖ :=
   (mkOfCompact f).norm_eq_iSup_norm
+
+theorem enorm_eq_iSup_enorm : ‖f‖ₑ = ⨆ x, ‖f x‖ₑ :=
+  (mkOfCompact f).enorm_eq_iSup_enorm
 
 -- A version with better keys
 instance {X : Type*} [TopologicalSpace X] (K : TopologicalSpace.Compacts X) :

--- a/Mathlib/Topology/ContinuousMap/ContinuousMapZero.lean
+++ b/Mathlib/Topology/ContinuousMap/ContinuousMapZero.lean
@@ -367,6 +367,10 @@ variable {α : Type*} {𝕜 : Type*} {R : Type*} [TopologicalSpace α] [CompactS
 noncomputable instance [MetricSpace R] [Zero R]: MetricSpace C(α, R)₀ :=
   ContinuousMapZero.isUniformEmbedding_toContinuousMap.comapMetricSpace _
 
+lemma isometry_toContinuousMap [MetricSpace R] [Zero R] :
+    Isometry (toContinuousMap : C(α, R)₀ → C(α, R)) :=
+  fun _ _ ↦ rfl
+
 noncomputable instance [NormedAddCommGroup R] : Norm C(α, R)₀ where
   norm f := ‖(f : C(α, R))‖
 


### PR DESCRIPTION
The analogues of `BoundedContinuousFunction.dist_eq_iSup` for `C(α, β)` and the `edist` and `‖·‖ₑ` variants were missing (probably because the latter came after the former historically). This also add the fact that the coercion `C(α, β)₀ → C(α, β)` is an isometry.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
