### PR TITLE
feat(Analysis/Convex): Lifting convex sets along scalar towers

### DIFF
--- a/Mathlib/Analysis/Convex/Basic.lean
+++ b/Mathlib/Analysis/Convex/Basic.lean
@@ -318,6 +318,23 @@ end LinearOrderedAddCommMonoid
 
 end Module
 
+section IsScalarTower
+
+variable [IsOrderedRing 𝕜] [Module 𝕜 E]
+variable (R : Type*) [Semiring R] [PartialOrder R] [Module R E]
+variable [Module R 𝕜] [IsScalarTower R 𝕜 E] [SMulPosMono R 𝕜]
+
+/-- Lift the convexity of a set up through a scalar tower. -/
+theorem lift {s : Set E} (hs : Convex 𝕜 s) : Convex R s := by
+  intro x hx y hy a b ha hb hab
+  suffices (a • (1 : 𝕜)) • x + (b • (1 : 𝕜)) • y ∈ s by simpa using this
+  apply hs hx hy
+  · exact zero_smul R (1 : 𝕜) ▸ smul_le_smul_of_nonneg_right ha zero_le_one
+  · exact zero_smul R (1 : 𝕜) ▸ smul_le_smul_of_nonneg_right hb zero_le_one
+  · simpa [add_smul] using congrArg (· • (1 : 𝕜)) hab
+
+end IsScalarTower
+
 end AddCommMonoid
 
 section LinearOrderedAddCommMonoid

--- a/Mathlib/Analysis/Convex/Basic.lean
+++ b/Mathlib/Analysis/Convex/Basic.lean
@@ -325,7 +325,7 @@ variable (R : Type*) [Semiring R] [PartialOrder R] [Module R E]
 variable [Module R 𝕜] [IsScalarTower R 𝕜 E] [SMulPosMono R 𝕜]
 
 /-- Lift the convexity of a set up through a scalar tower. -/
-theorem lift {s : Set E} (hs : Convex 𝕜 s) : Convex R s := by
+theorem Convex.lift {s : Set E} (hs : Convex 𝕜 s) : Convex R s := by
   intro x hx y hy a b ha hb hab
   suffices (a • (1 : 𝕜)) • x + (b • (1 : 𝕜)) • y ∈ s by simpa using this
   apply hs hx hy


### PR DESCRIPTION
Add the fact that, if `IsScalarTower X Y Z`, and a set `s : Set Z` is `Convex Y', then it's also `Convex X`. (With appropriate assumptions).

---

@j-loreaux mentioned that maybe it's worth having facts in here for `segment`, `openSegment`; I can also think of `affineSegment`, `Wbtw`, and `Sbtw`. The relevant facts being that `Wbtw` and `Sbtw` can be lifted like `Convex` can, and that the relevant `*segment` sets give subsets on the other ring.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
