### PR TITLE
feat: extract and sanitize LEAN_GITHASH for cache upload

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -252,6 +252,18 @@ jobs:
           cd pr-branch
           du .lake/build/lib/lean/Mathlib || echo "This code should be unreachable"
 
+      - name: extract and sanitize LEAN_GITHASH
+        run: |
+          cd pr-branch
+          # Run lake env and extract LEAN_GITHASH
+          LEAN_GITHASH_RAW=$(lake env | grep "LEAN_GITHASH" | cut -d'=' -f2)
+          # Sanitize by keeping only alphanumeric characters, hyphens, and underscores
+          LEAN_GITHASH=$(echo "$LEAN_GITHASH_RAW" | sed 's/[^a-zA-Z0-9_-]//g')
+          echo "Raw LEAN_GITHASH: $LEAN_GITHASH_RAW"
+          echo "Sanitized LEAN_GITHASH: $LEAN_GITHASH"
+          # Export to GITHUB_ENV for use in subsequent steps
+          echo "LEAN_GITHASH=$LEAN_GITHASH" >> "$GITHUB_ENV"
+
       # The cache secrets are available here, so we must not run any untrusted code.
       - name: upload cache
         # We only upload the cache if the build started (whether succeeding, failing, or cancelled)
@@ -272,6 +284,7 @@ jobs:
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
           MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
+          LEAN_GITHASH: ${{ env.LEAN_GITHASH }}
 
       - name: check the cache
         # We need network access to download dependencies

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -262,6 +262,18 @@ jobs:
           cd pr-branch
           du .lake/build/lib/lean/Mathlib || echo "This code should be unreachable"
 
+      - name: extract and sanitize LEAN_GITHASH
+        run: |
+          cd pr-branch
+          # Run lake env and extract LEAN_GITHASH
+          LEAN_GITHASH_RAW=$(lake env | grep "LEAN_GITHASH" | cut -d'=' -f2)
+          # Sanitize by keeping only alphanumeric characters, hyphens, and underscores
+          LEAN_GITHASH=$(echo "$LEAN_GITHASH_RAW" | sed 's/[^a-zA-Z0-9_-]//g')
+          echo "Raw LEAN_GITHASH: $LEAN_GITHASH_RAW"
+          echo "Sanitized LEAN_GITHASH: $LEAN_GITHASH"
+          # Export to GITHUB_ENV for use in subsequent steps
+          echo "LEAN_GITHASH=$LEAN_GITHASH" >> "$GITHUB_ENV"
+
       # The cache secrets are available here, so we must not run any untrusted code.
       - name: upload cache
         # We only upload the cache if the build started (whether succeeding, failing, or cancelled)
@@ -282,6 +294,7 @@ jobs:
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
           MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
+          LEAN_GITHASH: ${{ env.LEAN_GITHASH }}
 
       - name: check the cache
         # We need network access to download dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -269,6 +269,18 @@ jobs:
           cd pr-branch
           du .lake/build/lib/lean/Mathlib || echo "This code should be unreachable"
 
+      - name: extract and sanitize LEAN_GITHASH
+        run: |
+          cd pr-branch
+          # Run lake env and extract LEAN_GITHASH
+          LEAN_GITHASH_RAW=$(lake env | grep "LEAN_GITHASH" | cut -d'=' -f2)
+          # Sanitize by keeping only alphanumeric characters, hyphens, and underscores
+          LEAN_GITHASH=$(echo "$LEAN_GITHASH_RAW" | sed 's/[^a-zA-Z0-9_-]//g')
+          echo "Raw LEAN_GITHASH: $LEAN_GITHASH_RAW"
+          echo "Sanitized LEAN_GITHASH: $LEAN_GITHASH"
+          # Export to GITHUB_ENV for use in subsequent steps
+          echo "LEAN_GITHASH=$LEAN_GITHASH" >> "$GITHUB_ENV"
+
       # The cache secrets are available here, so we must not run any untrusted code.
       - name: upload cache
         # We only upload the cache if the build started (whether succeeding, failing, or cancelled)
@@ -289,6 +301,7 @@ jobs:
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
           MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
+          LEAN_GITHASH: ${{ env.LEAN_GITHASH }}
 
       - name: check the cache
         # We need network access to download dependencies

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -266,6 +266,18 @@ jobs:
           cd pr-branch
           du .lake/build/lib/lean/Mathlib || echo "This code should be unreachable"
 
+      - name: extract and sanitize LEAN_GITHASH
+        run: |
+          cd pr-branch
+          # Run lake env and extract LEAN_GITHASH
+          LEAN_GITHASH_RAW=$(lake env | grep "LEAN_GITHASH" | cut -d'=' -f2)
+          # Sanitize by keeping only alphanumeric characters, hyphens, and underscores
+          LEAN_GITHASH=$(echo "$LEAN_GITHASH_RAW" | sed 's/[^a-zA-Z0-9_-]//g')
+          echo "Raw LEAN_GITHASH: $LEAN_GITHASH_RAW"
+          echo "Sanitized LEAN_GITHASH: $LEAN_GITHASH"
+          # Export to GITHUB_ENV for use in subsequent steps
+          echo "LEAN_GITHASH=$LEAN_GITHASH" >> "$GITHUB_ENV"
+
       # The cache secrets are available here, so we must not run any untrusted code.
       - name: upload cache
         # We only upload the cache if the build started (whether succeeding, failing, or cancelled)
@@ -286,6 +298,7 @@ jobs:
         env:
           MATHLIB_CACHE_SAS: ${{ secrets.MATHLIB_CACHE_SAS }}
           MATHLIB_CACHE_S3_TOKEN: ${{ secrets.MATHLIB_CACHE_S3_TOKEN }}
+          LEAN_GITHASH: ${{ env.LEAN_GITHASH }}
 
       - name: check the cache
         # We need network access to download dependencies

--- a/Cache/Hashing.lean
+++ b/Cache/Hashing.lean
@@ -103,7 +103,10 @@ def getRootHash : CacheM UInt64 := do
     mathlibDepPath / "lake-manifest.json"]
   let hashes ← rootFiles.mapM fun path =>
     hashFileContents <$> IO.FS.readFile path
-  return hash (rootHashGeneration :: hash Lean.githash :: hashes)
+  let githash ← match (← IO.getEnv "LEAN_GITHASH") with
+    | some envGithash => pure envGithash
+    | none => pure Lean.githash
+  return hash (rootHashGeneration :: hash githash :: hashes)
 
 /--
 Computes the hash of a file, which mixes:


### PR DESCRIPTION
Our current CI is failing on `nightly-testing` because we are running `cache` from the `master` branch, and this uses `Lean.githash`, so all the hashes are wrong.

This PR adds a new step to the CI workflow that extracts and sanitizes the LEAN_GITHASH value for use during cache upload. Changes include: new CI step to extract LEAN_GITHASH from lake env, sanitize the hash value, make it available as environment variable in upload cache step, update Cache/Hashing.lean to use LEAN_GITHASH env var when available, and regenerate all workflow files from the master template.
