### PR TITLE
[Merged by Bors] - feat: don't use `Lean.githash` in `cache` hashing

### DIFF
--- a/Cache/Hashing.lean
+++ b/Cache/Hashing.lean
@@ -91,9 +91,6 @@ Computes the root hash, which mixes the hashes of the content of:
 * `lake-manifest.json`
 
 and the hash of `Lean.githash`.
-
-(We hash `Lean.githash` in case the toolchain changes even though `lean-toolchain` hasn't.
-This happens with the `lean-pr-testing-NNNN` toolchains when Lean 4 PRs are updated.)
 -/
 def getRootHash : CacheM UInt64 := do
   let mathlibDepPath := (← read).mathlibDepPath
@@ -103,7 +100,7 @@ def getRootHash : CacheM UInt64 := do
     mathlibDepPath / "lake-manifest.json"]
   let hashes ← rootFiles.mapM fun path =>
     hashFileContents <$> IO.FS.readFile path
-  return hash (rootHashGeneration :: hash Lean.githash :: hashes)
+  return hash (rootHashGeneration :: hashes)
 
 /--
 Computes the hash of a file, which mixes:


### PR DESCRIPTION
This PR removes the `Lean.githash` component of `cache`s hashing function.

This enables running `cache` compiled on one toolchain against a checkout on another toolchain.

However, this (as advertised in the deleted comment) will break CI for the `lean-pr-testing-NNNN` toolchains. This is not an urgent issue as CI for these is presumed broken anyway as a result of recent CI upgrades. We will fix this shortly by tagging the `lean-pr-testing-NNNN` toolchains with an embedded hash, e.g. `lean-pr-testing-1234-ab57ce3`.