### PR TITLE
[Merged by Bors] - fix(C): autolabel applies the label using curl

### DIFF
--- a/.github/workflows/add_label_from_diff.yaml
+++ b/.github/workflows/add_label_from_diff.yaml
@@ -26,7 +26,6 @@ jobs:
           use-github-cache: false
           use-mathlib-cache: false
       - name: lake exe autolabel
-        id: autolabel
         run: |
           # the checkout dance, to avoid a detached head
           git checkout master
@@ -39,6 +38,8 @@ jobs:
           if [ -n "${label}" ]
           then
             printf 'Applying label %s\n' "${label}"
+            # we use curl rather than octokit/request-action so that the job won't fail
+            # (and send an annoying email) if the labels don't exist
             curl --request POST \
               --header 'Accept: application/vnd.github+json' \
               --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \

--- a/.github/workflows/add_label_from_diff.yaml
+++ b/.github/workflows/add_label_from_diff.yaml
@@ -1,7 +1,7 @@
 name: Autolabel PRs
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
   push:
     paths:
@@ -14,11 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     # Don't run on forks, where we wouldn't have permissions to add the label anyway.
     if: github.repository == 'leanprover-community/mathlib4'
-    permissions:
-      issues: write
-      checks: write
-      pull-requests: write
-      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -31,12 +26,27 @@ jobs:
           use-github-cache: false
           use-mathlib-cache: false
       - name: lake exe autolabel
+        id: autolabel
         run: |
           # the checkout dance, to avoid a detached head
           git checkout master
           git checkout -
-          lake exe autolabel "$NUMBER"
+          labels="$(lake exe autolabel)"
+          printf '%s\n' "${labels}"
+          # extract
+          label="$(printf '%s' "${labels}" | sed -n 's=.*#\[\([^,]*\)\].*=\1=p')"
+          printf 'label: "%s"\n' "${label}"
+          if [ -n "${label}" ]
+          then
+            printf 'Applying label %s\n' "${label}"
+            curl --request POST \
+              --header 'Accept: application/vnd.github+json' \
+              --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels \
+              --data "{'labels':[${label}]}"
+          else
+            echo "There is no single label that we could apply, so we are not applying any label."
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          NUMBER: ${{ github.event.number }}

--- a/scripts/autolabel.lean
+++ b/scripts/autolabel.lean
@@ -293,9 +293,11 @@ unsafe def main (args : List String): IO UInt32 := do
     -- return 3
 
   -- get the modified files
+  println "Computing 'git diff --name-only origin/master...HEAD'"
   let gitDiff ← IO.Process.run {
     cmd := "git",
     args := #["diff", "--name-only", "origin/master...HEAD"] }
+  println s!"---\n{gitDiff}\n---"
   let modifiedFiles : Array FilePath := (gitDiff.splitOn "\n").toArray.map (⟨·⟩)
 
   -- find labels covering the modified files


### PR DESCRIPTION
We no longer rely on `autolabel` to add the label via `gh`, but use a commandline `curl` instead.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
