### PR TITLE
[Merged by Bors] - feat: improve API for isolated zeros of analytic functions

### DIFF
--- a/Mathlib/Analysis/Analytic/IsolatedZeros.lean
+++ b/Mathlib/Analysis/Analytic/IsolatedZeros.lean
@@ -337,10 +337,12 @@ theorem AnalyticAt.map_nhdsNE {x : 𝕜} {f : 𝕜 → E} (hfx : AnalyticAt 𝕜
     (h₂f : ¬EventuallyConst f (𝓝 x)) :
     (𝓝[≠] x).map f ≤ (𝓝[≠] f x) := fun _ hs ↦ mem_map.1 (preimage_of_nhdsNE hfx h₂f hs)
 
-/-- Preimages of codiscrete sets: if `f` is analytic on a neighbourhood of `U` and not locally
-constant, then the preimage of any subset codiscrete within `f '' U` is codiscrete within `U`.
+/--
+Preimages of codiscrete sets: if `f` is analytic on a neighbourhood of `U` and not locally constant,
+then the preimage of any subset codiscrete within `f '' U` is codiscrete within `U`.
 
-Applications might want to use the theorem `Filter.codiscreteWithin.mono`.
+See `AnalyticOnNhd.preimage_zero_codiscreteWithin` for the special case that `s` is the complement
+of zero. Applications might want to use the theorem `Filter.codiscreteWithin.mono`.
 -/
 theorem AnalyticOnNhd.preimage_mem_codiscreteWithin {U : Set 𝕜} {s : Set E} {f : 𝕜 → E}
     (hfU : AnalyticOnNhd 𝕜 f U) (h₂f : ∀ x ∈ U, ¬EventuallyConst f (𝓝 x))

--- a/Mathlib/Analysis/Analytic/Order.lean
+++ b/Mathlib/Analysis/Analytic/Order.lean
@@ -336,11 +336,11 @@ end NontriviallyNormedField
 
 namespace AnalyticOnNhd
 
-variable {U : Set 𝕜} {f : 𝕜 → E} (hf : AnalyticOnNhd 𝕜 f U)
-include hf
+variable {U : Set 𝕜} {f : 𝕜 → E}
 
 /-- The set where an analytic function has infinite order is clopen in its domain of analyticity. -/
-theorem isClopen_setOf_analyticOrderAt_eq_top : IsClopen {u : U | analyticOrderAt f u = ⊤} := by
+theorem isClopen_setOf_analyticOrderAt_eq_top  (hf : AnalyticOnNhd 𝕜 f U) :
+    IsClopen {u : U | analyticOrderAt f u = ⊤} := by
   constructor
   · rw [← isOpen_compl_iff, isOpen_iff_forall_mem_open]
     intro z hz
@@ -383,7 +383,7 @@ theorem isClopen_setOf_analyticOrderAt_eq_top : IsClopen {u : U | analyticOrderA
 
 /-- On a connected set, there exists a point where a meromorphic function `f` has finite order iff
 `f` has finite order at every point. -/
-theorem exists_analyticOrderAt_ne_top_iff_forall (hU : IsConnected U) :
+theorem exists_analyticOrderAt_ne_top_iff_forall (hf : AnalyticOnNhd 𝕜 f U) (hU : IsConnected U) :
     (∃ u : U, analyticOrderAt f u ≠ ⊤) ↔ (∀ u : U, analyticOrderAt f u ≠ ⊤) := by
   have : ConnectedSpace U := Subtype.connectedSpace hU
   obtain ⟨v⟩ : Nonempty U := inferInstance
@@ -393,22 +393,67 @@ theorem exists_analyticOrderAt_ne_top_iff_forall (hU : IsConnected U) :
 
 /-- On a preconnected set, a meromorphic function has finite order at one point if it has finite
 order at another point. -/
-theorem analyticOrderAt_ne_top_of_isPreconnected {x y : 𝕜} (hU : IsPreconnected U) (h₁x : x ∈ U)
-    (hy : y ∈ U) (h₂x : analyticOrderAt f x ≠ ⊤) : analyticOrderAt f y ≠ ⊤ :=
+theorem analyticOrderAt_ne_top_of_isPreconnected {x y : 𝕜} (hf : AnalyticOnNhd 𝕜 f U)
+    (hU : IsPreconnected U) (h₁x : x ∈ U) (hy : y ∈ U) (h₂x : analyticOrderAt f x ≠ ⊤) :
+    analyticOrderAt f y ≠ ⊤ :=
   (hf.exists_analyticOrderAt_ne_top_iff_forall ⟨nonempty_of_mem h₁x, hU⟩).1 (by use ⟨x, h₁x⟩)
     ⟨y, hy⟩
 
 /-- The set where an analytic function has zero or infinite order is discrete within its domain of
 analyticity. -/
-theorem codiscrete_setOf_analyticOrderAt_eq_zero_or_top :
+theorem codiscrete_setOf_analyticOrderAt_eq_zero_or_top (hf : AnalyticOnNhd 𝕜 f U) :
     {u : U | analyticOrderAt f u = 0 ∨ analyticOrderAt f u = ⊤} ∈ Filter.codiscrete U := by
-  rw [mem_codiscrete_subtype_iff_mem_codiscreteWithin, mem_codiscreteWithin]
+  simp_rw [mem_codiscrete_subtype_iff_mem_codiscreteWithin, mem_codiscreteWithin,
+    disjoint_principal_right]
   intro x hx
-  rw [Filter.disjoint_principal_right]
   rcases (hf x hx).eventually_eq_zero_or_eventually_ne_zero with h₁f | h₁f
   · filter_upwards [eventually_nhdsWithin_of_eventually_nhds h₁f.eventually_nhds] with a ha
-    simp +contextual [analyticOrderAt_eq_top, ha]
+    simp [analyticOrderAt_eq_top, ha]
   · filter_upwards [h₁f] with a ha
     simp +contextual [(hf a _).analyticOrderAt_eq_zero, ha]
+
+/--
+The set where an analytic function has zero or infinite order is discrete within its domain of
+analyticity.
+-/
+theorem codiscreteWithin_setOf_analyticOrderAt_eq_zero_or_top (hf : AnalyticOnNhd 𝕜 f U) :
+    {u : 𝕜 | analyticOrderAt f u = 0 ∨ analyticOrderAt f u = ⊤} ∈ codiscreteWithin U := by
+  simp_rw [mem_codiscreteWithin, disjoint_principal_right]
+  intro x hx
+  rcases (hf x hx).eventually_eq_zero_or_eventually_ne_zero with h₁f | h₁f
+  · filter_upwards [eventually_nhdsWithin_of_eventually_nhds h₁f.eventually_nhds] with a ha
+    simp [analyticOrderAt_eq_top, ha]
+  · filter_upwards [h₁f] with a ha
+    simp +contextual [(hf a _).analyticOrderAt_eq_zero, ha]
+
+/--
+If an analytic function `f` is not constantly zero on a connected set `U`, then its set of zeros is
+codiscrete within `U`.
+
+See `AnalyticOnNhd.preimage_mem_codiscreteWithin` for a more general statement in preimages of
+codiscrete sets.
+-/
+theorem preimage_zero_codiscreteWithin {x : 𝕜} (h₁f : AnalyticOnNhd 𝕜 f U) (h₂f : f x ≠ 0)
+    (hU : IsConnected U) (hx : x ∈ U) :
+    f ⁻¹' {0}ᶜ ∈ codiscreteWithin U := by
+  filter_upwards [h₁f.codiscreteWithin_setOf_analyticOrderAt_eq_zero_or_top,
+    self_mem_codiscreteWithin U] with a ha h₂a
+  rw [← (h₁f x hx).analyticOrderAt_eq_zero] at h₂f
+  have {u : U} : analyticOrderAt f u ≠ ⊤ := by
+    apply (h₁f.exists_analyticOrderAt_ne_top_iff_forall hU).1
+    use ⟨x, hx⟩
+    simp_all
+  simp_all [(h₁f a h₂a).analyticOrderAt_eq_zero]
+
+/--
+If an analytic function `f` is not constantly zero on `𝕜`, then its set of zeros is codiscrete.
+
+See `AnalyticOnNhd.preimage_mem_codiscreteWithin` for a more general statement in preimages of
+codiscrete sets.
+-/
+theorem preimage_zero_codiscrete [ConnectedSpace 𝕜] {x : 𝕜} (hf : AnalyticOnNhd 𝕜 f Set.univ)
+    (hx : f x ≠ 0) :
+    f ⁻¹' {0}ᶜ ∈ codiscrete 𝕜 :=
+  hf.preimage_zero_codiscreteWithin hx isConnected_univ trivial
 
 end AnalyticOnNhd

--- a/Mathlib/Analysis/Analytic/Order.lean
+++ b/Mathlib/Analysis/Analytic/Order.lean
@@ -433,8 +433,8 @@ codiscrete within `U`.
 See `AnalyticOnNhd.preimage_mem_codiscreteWithin` for a more general statement in preimages of
 codiscrete sets.
 -/
-theorem preimage_zero_codiscreteWithin {x : 𝕜} (h₁f : AnalyticOnNhd 𝕜 f U) (h₂f : f x ≠ 0)
-    (hU : IsConnected U) (hx : x ∈ U) :
+theorem preimage_zero_mem_codiscreteWithin {x : 𝕜} (h₁f : AnalyticOnNhd 𝕜 f U) (h₂f : f x ≠ 0)
+    (hx : x ∈ U) (hU : IsConnected U) :
     f ⁻¹' {0}ᶜ ∈ codiscreteWithin U := by
   filter_upwards [h₁f.codiscreteWithin_setOf_analyticOrderAt_eq_zero_or_top,
     self_mem_codiscreteWithin U] with a ha h₂a
@@ -451,9 +451,9 @@ If an analytic function `f` is not constantly zero on `𝕜`, then its set of ze
 See `AnalyticOnNhd.preimage_mem_codiscreteWithin` for a more general statement in preimages of
 codiscrete sets.
 -/
-theorem preimage_zero_codiscrete [ConnectedSpace 𝕜] {x : 𝕜} (hf : AnalyticOnNhd 𝕜 f Set.univ)
+theorem preimage_zero_mem_codiscrete [ConnectedSpace 𝕜] {x : 𝕜} (hf : AnalyticOnNhd 𝕜 f Set.univ)
     (hx : f x ≠ 0) :
     f ⁻¹' {0}ᶜ ∈ codiscrete 𝕜 :=
-  hf.preimage_zero_codiscreteWithin hx isConnected_univ trivial
+  hf.preimage_zero_mem_codiscreteWithin hx trivial isConnected_univ
 
 end AnalyticOnNhd


### PR DESCRIPTION
Use the new definition `analyticOrderAt` to provide a version of `AnalyticOnNhd.codiscrete_setOf_analyticOrderAt_eq_zero_or_top` that is easier to use, since it avoids hassle with subtypes and subsets. Provide easy-to-use special cases about the discreteness of the zero locus of analytic functions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
