### PR TITLE
feat(CategoryTheory/Category/Cat): cartesian closed instance on small categories

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1941,6 +1941,7 @@ import Mathlib.CategoryTheory.Category.Bipointed
 import Mathlib.CategoryTheory.Category.Cat
 import Mathlib.CategoryTheory.Category.Cat.Adjunction
 import Mathlib.CategoryTheory.Category.Cat.AsSmall
+import Mathlib.CategoryTheory.Category.Cat.CartesianClosed
 import Mathlib.CategoryTheory.Category.Cat.Colimit
 import Mathlib.CategoryTheory.Category.Cat.Limit
 import Mathlib.CategoryTheory.Category.Cat.Op

--- a/Mathlib/CategoryTheory/Category/Cat.lean
+++ b/Mathlib/CategoryTheory/Category/Cat.lean
@@ -183,6 +183,21 @@ def equivOfIso {C D : Cat} (γ : C ≅ D) : C ≌ D where
   unitIso := eqToIso <| Eq.symm γ.hom_inv_id
   counitIso := eqToIso γ.inv_hom_id
 
+/-- Under certain hypotheses, an equivalence of categories actually
+defines an isomorphism in `Cat`. -/
+@[simps]
+def isoOfEquiv {C D : Cat.{v, u}} (e : C ≌ D)
+    (h₁ : ∀ (X : C), e.inverse.obj (e.functor.obj X) = X)
+    (h₂ : ∀ (X : C), e.unitIso.hom.app X = eqToHom (h₁ X).symm)
+    (h₃ : ∀ (Y : D), e.functor.obj (e.inverse.obj Y) = Y)
+    (h₄ : ∀ (Y : D), e.counitIso.hom.app Y = eqToHom (h₃ Y)) :
+    C ≅ D where
+  hom := e.functor
+  inv := e.inverse
+  hom_inv_id := (Functor.ext_of_iso e.unitIso (fun X ↦ (h₁ X).symm) h₂).symm
+  inv_hom_id := (Functor.ext_of_iso e.counitIso h₃ h₄)
+
+
 end
 
 end Cat

--- a/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
@@ -110,9 +110,18 @@ instance closed : Closed (Cat.of C) where
       homEquiv_naturality_right :=
         comp_flip_curry_eq }
 
-@[simps!]
 instance cartesianClosed : CartesianClosed Cat.{u, u} where
   closed C := closed C
+
+@[simp]
+lemma cartesianClosed_closed_rightAdj_obj {D : Type u} [Category.{u} D] :
+    ((Closed.rightAdj (C := Cat.{u,u}) (Cat.of C)).obj (Cat.of D)) = Cat.of (C ⥤ D) := rfl
+
+-- (((CategoryTheory.Closed.rightAdj C).map F).obj G).obj X
+
+-- (((CategoryTheory.Closed.rightAdj C).map F).obj G).map f
+
+-- (((CategoryTheory.Closed.rightAdj C).map F).map α).app X
 
 end
 

--- a/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
@@ -45,6 +45,7 @@ variable {B : Type u₁} [Category.{v₁} B] {C : Type u₂} [Category.{v₂} C]
   [Category.{v₃} D] {E : Type u₄} [Category.{v₄} E]
 
 /-- The isomorphism of categories of bifunctors given by currying. -/
+@[simps]
 def curryingIso : C ⥤ D ⥤ E ≅ C × D ⥤ E where
   hom F := uncurry.obj F
   inv G := curry.obj G

--- a/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
@@ -51,21 +51,21 @@ def curryingIso : C ⥤ D ⥤ E ≅ C × D ⥤ E where
 
 /-- The isomorphism of categories of bifunctors given by flipping the arguments. -/
 @[simps]
-def flipIso : C ⥤ D ⥤ E ≅ D ⥤ C ⥤ E where
+def flippingIso : C ⥤ D ⥤ E ≅ D ⥤ C ⥤ E where
   hom F := F.flip
   inv F := F.flip
   hom_inv_id := types_ext _ _ (fun _ ↦ rfl)
   inv_hom_id := types_ext _ _ (fun _ ↦ rfl)
 
 /-- The equivalence of types of bifunctors given by currying. -/
-@[simps]
+@[simps!]
 def curryingEquiv : C ⥤ D ⥤ E ≃ C × D ⥤ E :=
   curryingIso.toEquiv
 
 /-- The flipped equivalence of types of bifunctors given by currying. -/
-@[simps]
+@[simps!]
 def curryingFlipEquiv : D ⥤ C ⥤ E ≃ C × D ⥤ E :=
-  (flipIso ≪≫ curryingIso).toEquiv
+  (flippingIso ≪≫ curryingIso).toEquiv
 
 /-- Natural isomorphism witnessing `comp_flip_uncurry_eq`. -/
 @[simps!]

--- a/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
@@ -93,8 +93,6 @@ lemma comp_flip_curry_eq (F : C × B ⥤ D) (G : D ⥤ E) :
     (curry.obj (F ⋙ G)).flip =
       (curry.obj F).flip ⋙ (Cat.exp (Cat.of C)).map G.toCatHom :=
   Functor.ext_of_iso (compFlipCurryIso F G) (by aesop_cat) (by aesop_cat)
-      (curry.obj F).flip ⋙ (Cat.exp (Cat.of C)).map G.toCatHom :=
-  Functor.ext_of_iso (compFlipCurryIso F G) (by aesop_cat) (by aesop_cat)
 
 end
 

--- a/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
@@ -103,13 +103,12 @@ variable (C : Type u) [Category.{u} C]
 
 instance closed : Closed (Cat.of C) where
   rightAdj := exp C
-  adj := Adjunction.mkOfHomEquiv {
-    homEquiv _ _ := curryingFlipEquiv.symm
-    homEquiv_naturality_left_symm :=
-      comp_flip_uncurry_eq
-    homEquiv_naturality_right :=
-      comp_flip_curry_eq
-  }
+  adj := Adjunction.mkOfHomEquiv 
+    { homEquiv _ _ := curryingFlipEquiv.symm
+      homEquiv_naturality_left_symm :=
+        comp_flip_uncurry_eq
+      homEquiv_naturality_right :=
+        comp_flip_curry_eq }
 
 @[simps!]
 instance cartesianClosed : CartesianClosed Cat.{u, u} where

--- a/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
@@ -71,7 +71,7 @@ def curryingFlipEquiv : D ⥤ C ⥤ E ≃ C × D ⥤ E :=
 @[simps!]
 def compFlipUncurryIso (F : B ⥤ D) (G : D ⥤ C ⥤ E) :
     uncurry.obj (F ⋙ G).flip ≅ (𝟭 C).prod F ⋙ uncurry.obj G.flip :=
-  NatIso.ofComponents (fun _ ↦ eqToIso rfl)
+  .refl _
 
 lemma comp_flip_uncurry_eq (F : B ⥤ D) (G : D ⥤ C ⥤ E) :
     uncurry.obj (F ⋙ G).flip = (𝟭 C).prod F ⋙ uncurry.obj G.flip :=

--- a/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
@@ -1,0 +1,111 @@
+/-
+Copyright (c) 2025 Emily Riehl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Emily Riehl
+-/
+import Mathlib.CategoryTheory.Closed.Cartesian
+import Mathlib.CategoryTheory.Functor.Currying
+import Mathlib.CategoryTheory.Monoidal.Cartesian.Cat
+
+/-!
+# Cartesian closed structure on `Cat`
+
+The category of small categories is cartesian closed, with the exponential at a category `C`
+defined by the functor category mapping out of `C`.
+
+Adjoint transposition is defined by currying and uncurrying.
+
+-/
+
+universe v u v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
+
+namespace CategoryTheory
+
+open Functor
+
+namespace Cat
+
+variable (C : Type u) [Category.{v} C]
+
+/-- A category `C` induces a functor from `Cat` to itself defined
+by forming the category of functors out of `C`. -/
+def exp : Cat ⥤ Cat where
+  obj D := Cat.of (C ⥤ D)
+  map F := {
+    obj G := G ⋙ F
+    map α := whiskerRight α F
+  }
+
+end Cat
+
+section
+
+variable {B : Type u₁} [Category.{v₁} B] {C : Type u₂} [Category.{v₂} C] {D : Type u₃}
+  [Category.{v₃} D] {E : Type u₄} [Category.{v₄} E]
+
+/-- The isomorphism of categories of bifunctors given by currying. -/
+def curryingIso : C ⥤ D ⥤ E ≅ C × D ⥤ E where
+  hom F := uncurry.obj F
+  inv G := curry.obj G
+  hom_inv_id := types_ext _ _ (fun F ↦ curry_obj_uncurry_obj F)
+  inv_hom_id := types_ext _ _ (fun F ↦ uncurry_obj_curry_obj F)
+
+/-- The isomorphism of categories of bifunctors given by flipping the arguments. -/
+def flipIso : C ⥤ D ⥤ E ≅ D ⥤ C ⥤ E where
+  hom F := F.flip
+  inv F := F.flip
+  hom_inv_id := types_ext _ _ (fun _ ↦ rfl)
+  inv_hom_id := types_ext _ _ (fun _ ↦ rfl)
+
+/-- The equivalence of types of bifunctors given by currying. -/
+def curryingEquiv : C ⥤ D ⥤ E ≃ C × D ⥤ E :=
+  curryingIso.toEquiv
+
+/-- The flipped equivalence of types of bifunctors given by currying. -/
+def curryingFlipEquiv : D ⥤ C ⥤ E ≃ C × D ⥤ E :=
+  (flipIso ≪≫ curryingIso).toEquiv
+
+lemma comp_flip_uncurry_eq (F : B ⥤ D) (G : D ⥤ C ⥤ E) :
+    uncurry.obj (F ⋙ G).flip = (𝟭 C).prod F ⋙ (uncurry.obj G.flip) :=
+  Functor.ext (by simp) (fun ⟨c₁, b₁⟩ ⟨c₂, b₂⟩ ⟨f₁, f₂⟩ => by simp)
+
+end
+
+section
+variable {B C D E: Type u} [Category.{u} B] [Category.{u} C]
+  [Category.{u} D] [Category.{u} E]
+
+lemma comp_flip_curry_eq (F : C × B ⥤ D) (G : D ⥤ E) :
+    (curry.obj (F ⋙ G)).flip =
+      (curry.obj F).flip ⋙ (Cat.exp (Cat.of C)).map G.toCatHom := by
+  refine Functor.ext (fun _ ↦ rfl) ?_
+  · intro X Y f
+    simp only [Cat.of_α, comp_obj, eqToHom_refl, Functor.comp_map, Category.comp_id,
+      Category.id_comp]
+    rfl
+
+end
+
+namespace Cat
+
+section
+variable (C : Type u) [Category.{u} C]
+
+instance closed : Closed (Cat.of C) where
+  rightAdj := exp C
+  adj := Adjunction.mkOfHomEquiv {
+    homEquiv _ _ := curryingFlipEquiv.symm
+    homEquiv_naturality_left_symm :=
+      comp_flip_uncurry_eq
+    homEquiv_naturality_right :=
+      comp_flip_curry_eq
+  }
+
+instance cartesianClosed : CartesianClosed Cat.{u, u} where
+  closed C := closed C
+
+end
+
+end Cat
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
@@ -117,11 +117,11 @@ instance cartesianClosed : CartesianClosed Cat.{u, u} where
 lemma cartesianClosed_closed_rightAdj_obj {D : Type u} [Category.{u} D] :
     ((Closed.rightAdj (C := Cat.{u,u}) (Cat.of C)).obj (Cat.of D)) = Cat.of (C ⥤ D) := rfl
 
--- (((CategoryTheory.Closed.rightAdj C).map F).obj G).obj X
-
--- (((CategoryTheory.Closed.rightAdj C).map F).obj G).map f
-
--- (((CategoryTheory.Closed.rightAdj C).map F).map α).app X
+@[simp]
+lemma cartesianClosed_closed_rightAdj_map {D E : Type u}
+    [Category.{u} D] [Category.{u} E] {F : D ⥤ E} :
+    (CategoryTheory.Closed.rightAdj (C := Cat.{u,u}) (Cat.of C)).map F.toCatHom
+      = (whiskeringRight _ _ _).obj F := rfl
 
 end
 

--- a/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
@@ -52,6 +52,7 @@ def curryingIso : C ⥤ D ⥤ E ≅ C × D ⥤ E where
   inv_hom_id := types_ext _ _ (fun F ↦ uncurry_obj_curry_obj F)
 
 /-- The isomorphism of categories of bifunctors given by flipping the arguments. -/
+@[simps]
 def flipIso : C ⥤ D ⥤ E ≅ D ⥤ C ⥤ E where
   hom F := F.flip
   inv F := F.flip

--- a/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
@@ -87,7 +87,7 @@ variable {B C D E : Type u} [Category.{u} B] [Category.{u} C]
 @[simps!]
 def compFlipCurryIso (F : C × B ⥤ D) (G : D ⥤ E) :
     (curry.obj (F ⋙ G)).flip ≅ (curry.obj F).flip ⋙ (Cat.exp (Cat.of C)).map G.toCatHom :=
-  NatIso.ofComponents (fun _ ↦ eqToIso rfl)
+  .refl _
 
 lemma comp_flip_curry_eq (F : C × B ⥤ D) (G : D ⥤ E) :
     (curry.obj (F ⋙ G)).flip =
@@ -103,7 +103,7 @@ variable (C : Type u) [Category.{u} C]
 
 instance closed : Closed (Cat.of C) where
   rightAdj := exp C
-  adj := Adjunction.mkOfHomEquiv 
+  adj := Adjunction.mkOfHomEquiv
     { homEquiv _ _ := curryingFlipEquiv.symm
       homEquiv_naturality_left_symm :=
         comp_flip_uncurry_eq

--- a/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
@@ -59,6 +59,7 @@ def flipIso : C ⥤ D ⥤ E ≅ D ⥤ C ⥤ E where
   inv_hom_id := types_ext _ _ (fun _ ↦ rfl)
 
 /-- The equivalence of types of bifunctors given by currying. -/
+@[simps]
 def curryingEquiv : C ⥤ D ⥤ E ≃ C × D ⥤ E :=
   curryingIso.toEquiv
 

--- a/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
@@ -111,6 +111,7 @@ instance closed : Closed (Cat.of C) where
       comp_flip_curry_eq
   }
 
+@[simps!]
 instance cartesianClosed : CartesianClosed Cat.{u, u} where
   closed C := closed C
 

--- a/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
@@ -29,6 +29,7 @@ variable (C : Type u) [Category.{v} C]
 
 /-- A category `C` induces a functor from `Cat` to itself defined
 by forming the category of functors out of `C`. -/
+@[simps]
 def exp : Cat ⥤ Cat where
   obj D := Cat.of (C ⥤ D)
   map F := {

--- a/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
@@ -80,7 +80,7 @@ def compFlipCurryIso (F : C × B ⥤ D) (G : D ⥤ E) :
 lemma comp_flip_curry_eq (F : C × B ⥤ D) (G : D ⥤ E) :
     (curry.obj (F ⋙ G)).flip =
       (curry.obj F).flip ⋙ (Cat.exp (Cat.of C)).map G.toCatHom :=
-  Functor.ext_of_iso (compFlipCurryIso F G) (by aesop_cat) (by aesop_cat)
+  rfl
 
 end
 

--- a/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
@@ -32,10 +32,7 @@ by forming the category of functors out of `C`. -/
 @[simps]
 def exp : Cat ⥤ Cat where
   obj D := Cat.of (C ⥤ D)
-  map F := {
-    obj G := G ⋙ F
-    map α := whiskerRight α F
-  }
+  map F :=   map F := (whiskeringRight _ _ _).obj F
 
 end Cat
 

--- a/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
@@ -74,7 +74,7 @@ def compFlipUncurryIso (F : B ⥤ D) (G : D ⥤ C ⥤ E) :
   NatIso.ofComponents (fun _ ↦ eqToIso rfl)
 
 lemma comp_flip_uncurry_eq (F : B ⥤ D) (G : D ⥤ C ⥤ E) :
-    uncurry.obj (F ⋙ G).flip = (𝟭 C).prod F ⋙ (uncurry.obj G.flip) :=
+    uncurry.obj (F ⋙ G).flip = (𝟭 C).prod F ⋙ uncurry.obj G.flip :=
   Functor.ext_of_iso (compFlipUncurryIso F G) (by aesop_cat) (by aesop_cat)
 
 end

--- a/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
@@ -96,6 +96,8 @@ lemma comp_flip_curry_eq (F : C × B ⥤ D) (G : D ⥤ E) :
     (curry.obj (F ⋙ G)).flip =
       (curry.obj F).flip ⋙ (Cat.exp (Cat.of C)).map G.toCatHom :=
   Functor.ext_of_iso (compFlipCurryIso F G) (by aesop_cat) (by aesop_cat)
+      (curry.obj F).flip ⋙ (Cat.exp (Cat.of C)).map G.toCatHom :=
+  Functor.ext_of_iso (compFlipCurryIso F G) (by aesop_cat) (by aesop_cat)
 
 end
 

--- a/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
@@ -70,7 +70,7 @@ def curryingFlipEquiv : D ⥤ C ⥤ E ≃ C × D ⥤ E :=
 /-- Natural isomorphism witnessing `comp_flip_uncurry_eq`. -/
 @[simps!]
 def compFlipUncurryIso (F : B ⥤ D) (G : D ⥤ C ⥤ E) :
-    uncurry.obj (F ⋙ G).flip ≅ (𝟭 C).prod F ⋙ (uncurry.obj G.flip) :=
+    uncurry.obj (F ⋙ G).flip ≅ (𝟭 C).prod F ⋙ uncurry.obj G.flip :=
   NatIso.ofComponents (fun _ ↦ eqToIso rfl)
 
 lemma comp_flip_uncurry_eq (F : B ⥤ D) (G : D ⥤ C ⥤ E) :

--- a/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
@@ -70,9 +70,15 @@ def curryingEquiv : C ⥤ D ⥤ E ≃ C × D ⥤ E :=
 def curryingFlipEquiv : D ⥤ C ⥤ E ≃ C × D ⥤ E :=
   (flipIso ≪≫ curryingIso).toEquiv
 
+/-- Natural isomorphism witnessing `comp_flip_uncurry_eq`. -/
+@[simps!]
+def compFlipUncurryIso (F : B ⥤ D) (G : D ⥤ C ⥤ E) :
+    uncurry.obj (F ⋙ G).flip ≅ (𝟭 C).prod F ⋙ (uncurry.obj G.flip) :=
+  NatIso.ofComponents (fun _ ↦ eqToIso rfl)
+
 lemma comp_flip_uncurry_eq (F : B ⥤ D) (G : D ⥤ C ⥤ E) :
     uncurry.obj (F ⋙ G).flip = (𝟭 C).prod F ⋙ (uncurry.obj G.flip) :=
-  Functor.ext (by simp) (fun ⟨c₁, b₁⟩ ⟨c₂, b₂⟩ ⟨f₁, f₂⟩ => by simp)
+  Functor.ext_of_iso (compFlipUncurryIso F G) (by aesop_cat) (by aesop_cat)
 
 end
 

--- a/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
@@ -21,7 +21,7 @@ universe v u v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
 
 namespace CategoryTheory
 
-open Functor
+open Functor Cat
 
 namespace Cat
 
@@ -42,30 +42,39 @@ variable {B : Type u₁} [Category.{v₁} B] {C : Type u₂} [Category.{v₂} C]
   [Category.{v₃} D] {E : Type u₄} [Category.{v₄} E]
 
 /-- The isomorphism of categories of bifunctors given by currying. -/
-@[simps]
-def curryingIso : C ⥤ D ⥤ E ≅ C × D ⥤ E where
-  hom F := uncurry.obj F
-  inv G := curry.obj G
-  hom_inv_id := types_ext _ _ (fun F ↦ curry_obj_uncurry_obj F)
-  inv_hom_id := types_ext _ _ (fun F ↦ uncurry_obj_curry_obj F)
+@[simps!]
+def curryingIso : Cat.of (C ⥤ D ⥤ E) ≅ Cat.of (C × D ⥤ E) :=
+  isoOfEquiv CategoryTheory.currying
+    Functor.curry_obj_uncurry_obj (by aesop)
+    Functor.uncurry_obj_curry_obj (by aesop)
 
 /-- The isomorphism of categories of bifunctors given by flipping the arguments. -/
-@[simps]
-def flippingIso : C ⥤ D ⥤ E ≅ D ⥤ C ⥤ E where
-  hom F := F.flip
-  inv F := F.flip
-  hom_inv_id := types_ext _ _ (fun _ ↦ rfl)
-  inv_hom_id := types_ext _ _ (fun _ ↦ rfl)
+@[simps!]
+def flippingIso : Cat.of (C ⥤ D ⥤ E) ≅ Cat.of (D ⥤ C ⥤ E) :=
+  isoOfEquiv CategoryTheory.flipping
+    Functor.flip_flip (by aesop)
+    Functor.flip_flip (by aesop)
+
+/-- The equivalence of types of bifunctors giving by flipping the arguments. -/
+@[simps!]
+def flippingEquiv : C ⥤ D ⥤ E ≃ D ⥤ C ⥤ E where
+  toFun F := F.flip
+  invFun F := F.flip
+  left_inv := fun _ ↦ rfl
+  right_inv := fun _ ↦ rfl
 
 /-- The equivalence of types of bifunctors given by currying. -/
 @[simps!]
-def curryingEquiv : C ⥤ D ⥤ E ≃ C × D ⥤ E :=
-  curryingIso.toEquiv
+def curryingEquiv : C ⥤ D ⥤ E ≃ C × D ⥤ E where
+  toFun F := uncurry.obj F
+  invFun G := curry.obj G
+  left_inv := fun F ↦ curry_obj_uncurry_obj F
+  right_inv := fun G ↦ uncurry_obj_curry_obj G
 
 /-- The flipped equivalence of types of bifunctors given by currying. -/
 @[simps!]
 def curryingFlipEquiv : D ⥤ C ⥤ E ≃ C × D ⥤ E :=
-  (flippingIso ≪≫ curryingIso).toEquiv
+  flippingEquiv.trans curryingEquiv
 
 /-- Natural isomorphism witnessing `comp_flip_uncurry_eq`. -/
 @[simps!]

--- a/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
@@ -32,7 +32,7 @@ by forming the category of functors out of `C`. -/
 @[simps]
 def exp : Cat ⥤ Cat where
   obj D := Cat.of (C ⥤ D)
-  map F :=   map F := (whiskeringRight _ _ _).obj F
+  map F := (whiskeringRight _ _ _).obj F
 
 end Cat
 

--- a/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
@@ -63,6 +63,7 @@ def curryingEquiv : C ⥤ D ⥤ E ≃ C × D ⥤ E :=
   curryingIso.toEquiv
 
 /-- The flipped equivalence of types of bifunctors given by currying. -/
+@[simps]
 def curryingFlipEquiv : D ⥤ C ⥤ E ≃ C × D ⥤ E :=
   (flipIso ≪≫ curryingIso).toEquiv
 

--- a/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
@@ -83,7 +83,7 @@ lemma comp_flip_uncurry_eq (F : B ⥤ D) (G : D ⥤ C ⥤ E) :
 end
 
 section
-variable {B C D E: Type u} [Category.{u} B] [Category.{u} C]
+variable {B C D E : Type u} [Category.{u} B] [Category.{u} C]
   [Category.{u} D] [Category.{u} E]
 
 lemma comp_flip_curry_eq (F : C × B ⥤ D) (G : D ⥤ E) :

--- a/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
@@ -86,14 +86,16 @@ section
 variable {B C D E : Type u} [Category.{u} B] [Category.{u} C]
   [Category.{u} D] [Category.{u} E]
 
+/-- Natural isomorphism witnessing `comp_flip_curry_eq`. -/
+@[simps!]
+def compFlipCurryIso (F : C × B ⥤ D) (G : D ⥤ E) :
+    (curry.obj (F ⋙ G)).flip ≅ (curry.obj F).flip ⋙ (Cat.exp (Cat.of C)).map G.toCatHom :=
+  NatIso.ofComponents (fun _ ↦ eqToIso rfl)
+
 lemma comp_flip_curry_eq (F : C × B ⥤ D) (G : D ⥤ E) :
     (curry.obj (F ⋙ G)).flip =
-      (curry.obj F).flip ⋙ (Cat.exp (Cat.of C)).map G.toCatHom := by
-  refine Functor.ext (fun _ ↦ rfl) ?_
-  · intro X Y f
-    simp only [Cat.of_α, comp_obj, eqToHom_refl, Functor.comp_map, Category.comp_id,
-      Category.id_comp]
-    rfl
+      (curry.obj F).flip ⋙ (Cat.exp (Cat.of C)).map G.toCatHom :=
+  Functor.ext_of_iso (compFlipCurryIso F G) (by aesop_cat) (by aesop_cat)
 
 end
 

--- a/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
@@ -63,7 +63,7 @@ def compFlipUncurryIso (F : B ⥤ D) (G : D ⥤ C ⥤ E) :
 
 lemma comp_flip_uncurry_eq (F : B ⥤ D) (G : D ⥤ C ⥤ E) :
     uncurry.obj (F ⋙ G).flip = (𝟭 C).prod F ⋙ uncurry.obj G.flip :=
-  Functor.ext_of_iso (compFlipUncurryIso F G) (by aesop_cat) (by aesop_cat)
+  rfl
 
 end
 

--- a/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/CartesianClosed.lean
@@ -55,27 +55,6 @@ def flippingIso : Cat.of (C ⥤ D ⥤ E) ≅ Cat.of (D ⥤ C ⥤ E) :=
     Functor.flip_flip (by aesop)
     Functor.flip_flip (by aesop)
 
-/-- The equivalence of types of bifunctors giving by flipping the arguments. -/
-@[simps!]
-def flippingEquiv : C ⥤ D ⥤ E ≃ D ⥤ C ⥤ E where
-  toFun F := F.flip
-  invFun F := F.flip
-  left_inv := fun _ ↦ rfl
-  right_inv := fun _ ↦ rfl
-
-/-- The equivalence of types of bifunctors given by currying. -/
-@[simps!]
-def curryingEquiv : C ⥤ D ⥤ E ≃ C × D ⥤ E where
-  toFun F := uncurry.obj F
-  invFun G := curry.obj G
-  left_inv := fun F ↦ curry_obj_uncurry_obj F
-  right_inv := fun G ↦ uncurry_obj_curry_obj G
-
-/-- The flipped equivalence of types of bifunctors given by currying. -/
-@[simps!]
-def curryingFlipEquiv : D ⥤ C ⥤ E ≃ C × D ⥤ E :=
-  flippingEquiv.trans curryingEquiv
-
 /-- Natural isomorphism witnessing `comp_flip_uncurry_eq`. -/
 @[simps!]
 def compFlipUncurryIso (F : B ⥤ D) (G : D ⥤ C ⥤ E) :

--- a/Mathlib/CategoryTheory/Functor/Currying.lean
+++ b/Mathlib/CategoryTheory/Functor/Currying.lean
@@ -90,6 +90,16 @@ def currying : C ⥤ D ⥤ E ≌ C × D ⥤ E where
       dsimp at f₁ f₂ ⊢
       simp only [← F.map_comp, prod_comp, Category.comp_id, Category.id_comp]))
 
+/-- The equivalence of functor categories given by flipping. -/
+@[simps!]
+def flipping : C ⥤ D ⥤ E ≌ D ⥤ C ⥤ E where
+  functor := flipFunctor _ _ _
+  inverse := flipFunctor _ _ _
+  unitIso := NatIso.ofComponents (fun _ ↦ NatIso.ofComponents
+    (fun _ ↦ NatIso.ofComponents (fun _ ↦ Iso.refl _)))
+  counitIso := NatIso.ofComponents (fun _ ↦ NatIso.ofComponents
+    (fun _ ↦ NatIso.ofComponents (fun _ ↦ Iso.refl _)))
+
 /-- The functor `uncurry : (C ⥤ D ⥤ E) ⥤ C × D ⥤ E` is fully faithful. -/
 def fullyFaithfulUncurry : (uncurry : (C ⥤ D ⥤ E) ⥤ C × D ⥤ E).FullyFaithful :=
   currying.fullyFaithfulFunctor

--- a/Mathlib/CategoryTheory/Functor/Currying.lean
+++ b/Mathlib/CategoryTheory/Functor/Currying.lean
@@ -74,7 +74,6 @@ def curry : (C × D ⥤ E) ⥤ C ⥤ D ⥤ E where
         ext; dsimp [curryObj]
         rw [NatTrans.naturality] }
 
-
 -- create projection simp lemmas even though this isn't a `{ .. }`.
 /-- The equivalence of functor categories given by currying/uncurrying.
 -/
@@ -178,6 +177,27 @@ lemma uncurry_obj_curry_obj_flip_flip' (F₁ : B ⥤ C) (F₂ : D ⥤ E) (G : C 
   Functor.ext (by simp) (fun ⟨x₁, x₂⟩ ⟨y₁, y₂⟩ ⟨f₁, f₂⟩ => by
     dsimp
     simp only [Category.id_comp, Category.comp_id, ← G.map_comp, prod_comp])
+
+/-- The equivalence of types of bifunctors giving by flipping the arguments. -/
+@[simps!]
+def flippingEquiv : C ⥤ D ⥤ E ≃ D ⥤ C ⥤ E where
+  toFun F := F.flip
+  invFun F := F.flip
+  left_inv := fun _ ↦ rfl
+  right_inv := fun _ ↦ rfl
+
+/-- The equivalence of types of bifunctors given by currying. -/
+@[simps!]
+def curryingEquiv : C ⥤ D ⥤ E ≃ C × D ⥤ E where
+  toFun F := uncurry.obj F
+  invFun G := curry.obj G
+  left_inv := fun F ↦ curry_obj_uncurry_obj F
+  right_inv := fun G ↦ uncurry_obj_curry_obj G
+
+/-- The flipped equivalence of types of bifunctors given by currying. -/
+@[simps!]
+def curryingFlipEquiv : D ⥤ C ⥤ E ≃ C × D ⥤ E :=
+  flippingEquiv.trans curryingEquiv
 
 end Functor
 

--- a/Mathlib/CategoryTheory/Functor/Currying.lean
+++ b/Mathlib/CategoryTheory/Functor/Currying.lean
@@ -13,8 +13,9 @@ We define `curry : ((C × D) ⥤ E) ⥤ (C ⥤ (D ⥤ E))` and `uncurry : (C ⥤
 and verify that they provide an equivalence of categories
 `currying : (C ⥤ (D ⥤ E)) ≌ ((C × D) ⥤ E)`.
 
+This is used elsewhere to equip the category of small categories with a cartesian closed structure
+`cartesianClosed : CartesianClosed Cat.{u, u}`.
 -/
-
 
 namespace CategoryTheory
 
@@ -72,6 +73,7 @@ def curry : (C × D ⥤ E) ⥤ C ⥤ D ⥤ E where
       naturality := fun X X' f => by
         ext; dsimp [curryObj]
         rw [NatTrans.naturality] }
+
 
 -- create projection simp lemmas even though this isn't a `{ .. }`.
 /-- The equivalence of functor categories given by currying/uncurrying.


### PR DESCRIPTION
The category of small categories is cartesian closed, with exponentials defined by functor categories. Adjoint transposition is defined by currying and uncurrying.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
