### PR TITLE
ci: enable bors and maintainer commands for PRs from forks

### DIFF
--- a/.github/workflows/bors_trigger.yml
+++ b/.github/workflows/bors_trigger.yml
@@ -1,0 +1,87 @@
+name: Bors Command Trigger
+
+on:
+  # the PR receives a comment
+  issue_comment:
+    types: [created]
+  # the PR receives a review
+  pull_request_review:
+    # whether or not it is accompanied by a comment
+    types: [submitted]
+  # the PR receives a review comment
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  trigger_bors:
+    name: Parse and trigger bors commands
+    runs-on: ubuntu-latest
+    if: github.repository == 'leanprover-community/mathlib4'
+    steps:
+      - name: Parse bors command
+        id: parse_command
+        env:
+          AUTHOR: ${{ github.event.comment.user.login }}${{ github.event.review.user.login }}
+          COMMENT_EVENT: ${{ github.event.comment.body }}
+          COMMENT_REVIEW: ${{ github.event.review.body }}
+        run: |
+          COMMENT="${COMMENT_EVENT}${COMMENT_REVIEW}"
+          # we strip `\r` since line endings from GitHub contain this character
+          COMMENT="${COMMENT//$'\r'/}"
+          # for debugging, we print some information
+          printf '%s' "${COMMENT}" | hexdump -cC
+          printf 'Comment:"%s"\n' "${COMMENT}"
+          m_or_d="$(printf '%s' "${COMMENT}" |
+            sed -n 's=^bors  *\(merge\|r+\) *$=ready-to-merge=p; s=^bors  *\(delegate\|d+\|d\=\).*=delegated=p' | head -1)"
+
+          remove_labels="$(printf '%s' "${COMMENT}" |
+            sed -n 's=^bors  *\(merge\|r\|d\)- *$=remove-labels=p' | head -1)"
+
+          printf $'"bors delegate" or "bors merge" found? \'%s\'\n' "${m_or_d}"
+          printf $'"bors r-" or "bors d-" found? \'%s\'\n' "${remove_labels}"
+          printf $'AUTHOR: \'%s\'\n' "${AUTHOR}"
+          printf $'PR_NUMBER: \'%s\'\n' "${{ github.event.issue.number }}${{ github.event.pull_request.number }}"
+          printf $'%s' "${{ github.event.issue.number }}${{ github.event.pull_request.number }}" | hexdump -cC
+
+          printf $'mOrD=%s\n' "${m_or_d}" >> "${GITHUB_OUTPUT}"
+          printf $'removeLabels=%s\n' "${remove_labels}" >> "${GITHUB_OUTPUT}"
+          if [ "${AUTHOR}" == 'leanprover-community-mathlib4-bot' ] ||
+             [ "${AUTHOR}" == 'leanprover-community-bot-assistant' ]
+          then
+            printf $'bot=true\n'
+            printf $'bot=true\n' >> "${GITHUB_OUTPUT}"
+          else
+            printf $'bot=false\n'
+            printf $'bot=false\n' >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Dispatch to main bors workflow
+        if: ${{ steps.parse_command.outputs.mOrD != '' || steps.parse_command.outputs.removeLabels != '' }}
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const payload = {
+              event_type: 'bors-command',
+              client_payload: {
+                author: process.env.AUTHOR,
+                pr_number: process.env.PR_NUMBER,
+                mOrD: process.env.M_OR_D,
+                removeLabels: process.env.REMOVE_LABELS,
+                bot: process.env.BOT
+              }
+            };
+
+            console.log('Dispatching with payload:', JSON.stringify(payload, null, 2));
+
+            await github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ...payload
+            });
+        env:
+          AUTHOR: ${{ github.event.comment.user.login }}${{ github.event.review.user.login }}
+          PR_NUMBER: ${{ github.event.issue.number }}${{ github.event.pull_request.number }}
+          M_OR_D: ${{ steps.parse_command.outputs.mOrD }}
+          REMOVE_LABELS: ${{ steps.parse_command.outputs.removeLabels }}
+          BOT: ${{ steps.parse_command.outputs.bot }}

--- a/.github/workflows/maintainer_bors.yml
+++ b/.github/workflows/maintainer_bors.yml
@@ -2,61 +2,34 @@ name: Add "ready-to-merge" and "delegated" label
 
 # triggers the action when
 on:
-  # the PR receives a comment
-  issue_comment:
-    types: [created]
-  # the PR receives a review
-  pull_request_review:
-    # whether or not it is accompanied by a comment
-    types: [submitted]
-  # the PR receives a review comment
-  pull_request_review_comment:
-    types: [created]
+  repository_dispatch:
+    types: [bors-command]
 
 jobs:
   add_ready_to_merge_label:
-    # we set some variables. The ones of the form `${{ X }}${{ Y }}` are typically not
-    # both set simultaneously: depending on the event that triggers the PR, usually only one is set
+    # we set some variables from the dispatched payload
     env:
-      AUTHOR: ${{ github.event.comment.user.login }}${{ github.event.review.user.login }}
-      COMMENT_EVENT: ${{ github.event.comment.body }}
-      COMMENT_REVIEW: ${{ github.event.review.body }}
+      AUTHOR: ${{ github.event.client_payload.author }}
     name: Add ready-to-merge or delegated label
     runs-on: ubuntu-latest
     if: github.repository == 'leanprover-community/mathlib4'
     steps:
-      - name: Find bors merge/delegate
+      - name: Set merge or delegate outputs from payload
         id: merge_or_delegate
         run: |
-          COMMENT="${COMMENT_EVENT}${COMMENT_REVIEW}"
-          # we strip `\r` since line endings from GitHub contain this character
-          COMMENT="${COMMENT//$'\r'/}"
-          # for debugging, we print some information
-          printf '%s' "${COMMENT}" | hexdump -cC
-          printf 'Comment:"%s"\n' "${COMMENT}"
-          m_or_d="$(printf '%s' "${COMMENT}" |
-            sed -n 's=^bors  *\(merge\|r+\) *$=ready-to-merge=p; s=^bors  *\(delegate\|d+\|d\=\).*=delegated=p' | head -1)"
-
-          remove_labels="$(printf '%s' "${COMMENT}" |
-            sed -n 's=^bors  *\(merge\|r\|d\)- *$=remove-labels=p' | head -1)"
+          # Get values from the dispatched payload
+          m_or_d="${{ github.event.client_payload.mOrD }}"
+          remove_labels="${{ github.event.client_payload.removeLabels }}"
+          bot="${{ github.event.client_payload.bot }}"
 
           printf $'"bors delegate" or "bors merge" found? \'%s\'\n' "${m_or_d}"
           printf $'"bors r-" or "bors d-" found? \'%s\'\n' "${remove_labels}"
           printf $'AUTHOR: \'%s\'\n' "${AUTHOR}"
-          printf $'PR_NUMBER: \'%s\'\n' "${{ github.event.issue.number }}${{ github.event.pull_request.number }}"
-          printf $'%s' "${{ github.event.issue.number }}${{ github.event.pull_request.number }}" | hexdump -cC
+          printf $'PR_NUMBER: \'%s\'\n' "${{ github.event.client_payload.pr_number }}"
 
           printf $'mOrD=%s\n' "${m_or_d}" >> "${GITHUB_OUTPUT}"
           printf $'removeLabels=%s\n' "${remove_labels}" >> "${GITHUB_OUTPUT}"
-          if [ "${AUTHOR}" == 'leanprover-community-mathlib4-bot' ] ||
-             [ "${AUTHOR}" == 'leanprover-community-bot-assistant' ]
-          then
-            printf $'bot=true\n'
-            printf $'bot=true\n' >> "${GITHUB_OUTPUT}"
-          else
-            printf $'bot=false\n'
-            printf $'bot=false\n' >> "${GITHUB_OUTPUT}"
-          fi
+          printf $'bot=%s\n' "${bot}" >> "${GITHUB_OUTPUT}"
 
       - name: Check whether user is a mathlib admin
         id: user_permission
@@ -74,7 +47,7 @@ jobs:
         with:
           route: POST /repos/:repository/issues/:issue_number/labels
           repository: ${{ github.repository }}
-          issue_number: ${{ github.event.issue.number }}${{ github.event.pull_request.number }}
+          issue_number: ${{ github.event.client_payload.pr_number }}
           labels: '["${{ steps.merge_or_delegate.outputs.mOrD }}"]'
         env:
           GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
@@ -89,7 +62,7 @@ jobs:
         run: |
           for label in awaiting-author maintainer-merge; do
             curl --request DELETE \
-              --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}${{ github.event.pull_request.number }}/labels/${label}" \
+              --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.client_payload.pr_number }}/labels/${label}" \
               --header 'authorization: Bearer ${{ secrets.TRIAGE_TOKEN }}'
           done
 
@@ -101,7 +74,7 @@ jobs:
         run: |
           for label in ready-to-merge delegated; do
             curl --request DELETE \
-              --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}${{ github.event.pull_request.number }}/labels/${label}" \
+              --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.client_payload.pr_number }}/labels/${label}" \
               --header 'authorization: Bearer ${{ secrets.TRIAGE_TOKEN }}'
           done
 
@@ -135,4 +108,4 @@ jobs:
           ZULIP_EMAIL: github-mathlib4-bot@leanprover.zulipchat.com
           ZULIP_SITE: https://leanprover.zulipchat.com
         run: |
-          python scripts/zulip_emoji_reactions.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "${{ steps.merge_or_delegate.outputs.mOrD }}" "${{ steps.merge_or_delegate.outputs.mOrD }}" "${{ github.event.issue.number }}${{ github.event.pull_request.number }}"
+          python scripts/zulip_emoji_reactions.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "${{ steps.merge_or_delegate.outputs.mOrD }}" "${{ steps.merge_or_delegate.outputs.mOrD }}" "${{ github.event.client_payload.pr_number }}"

--- a/.github/workflows/maintainer_bors.yml
+++ b/.github/workflows/maintainer_bors.yml
@@ -27,9 +27,11 @@ jobs:
           printf $'AUTHOR: \'%s\'\n' "${AUTHOR}"
           printf $'PR_NUMBER: \'%s\'\n' "${{ github.event.client_payload.pr_number }}"
 
-          printf $'mOrD=%s\n' "${m_or_d}" >> "${GITHUB_OUTPUT}"
-          printf $'removeLabels=%s\n' "${remove_labels}" >> "${GITHUB_OUTPUT}"
-          printf $'bot=%s\n' "${bot}" >> "${GITHUB_OUTPUT}"
+          {
+            printf $'mOrD=%s\n' "${m_or_d}"
+            printf $'removeLabels=%s\n' "${remove_labels}"
+            printf $'bot=%s\n' "${bot}"
+          } >> "${GITHUB_OUTPUT}"
 
       - name: Check whether user is a mathlib admin
         id: user_permission

--- a/.github/workflows/maintainer_merge.yml
+++ b/.github/workflows/maintainer_merge.yml
@@ -2,55 +2,37 @@ name: Maintainer merge
 
 # triggers the action when
 on:
-  # the PR receives a comment
-  issue_comment:
-    types: [created, edited]
-  # the PR receives a review
-  pull_request_review:
-    # whether or not it is accompanied by a comment
-    types: [submitted]
-  # the PR receives a review comment
-  pull_request_review_comment:
-    types: [created, edited]
+  repository_dispatch:
+    types: [maintainer-command]
 
 jobs:
   ping_zulip:
-    # we set some variables. The ones of the form `${{ X }}${{ Y }}` are typically not
-    # both set simultaneously: depending on the event that triggers the PR, usually only one is set
+    # we set some variables from the dispatched payload
     env:
-      AUTHOR: ${{ github.event.comment.user.login }}${{ github.event.review.user.login }}
-      PR_AUTHOR: ${{ github.event.issue.user.login }}${{ github.event.pull_request.user.login }}
-      PR_NUMBER: ${{ github.event.issue.number }}${{ github.event.pull_request.number }}
-      COMMENT_EVENT: ${{ github.event.comment.body }}
-      COMMENT_REVIEW: ${{ github.event.review.body }}
-      PR_TITLE_ISSUE: ${{ github.event.issue.title }}
-      PR_TITLE_PR: ${{ github.event.pull_request.title }}
-      PR_URL: ${{ github.event.issue.html_url }}${{ github.event.pull_request.html_url }}
-      EVENT_NAME: ${{ github.event_name }}
+      AUTHOR: ${{ github.event.client_payload.author }}
+      PR_AUTHOR: ${{ github.event.client_payload.pr_author }}
+      PR_NUMBER: ${{ github.event.client_payload.pr_number }}
+      COMMENT_EVENT: ${{ github.event.client_payload.comment_event }}
+      COMMENT_REVIEW: ${{ github.event.client_payload.comment_review }}
+      PR_TITLE_ISSUE: ${{ github.event.client_payload.pr_title_issue }}
+      PR_TITLE_PR: ${{ github.event.client_payload.pr_title_pr }}
+      PR_URL: ${{ github.event.client_payload.pr_url }}
+      EVENT_NAME: ${{ github.event.client_payload.event_name }}
     name: Ping maintainers on Zulip
     runs-on: ubuntu-latest
     if: github.repository == 'leanprover-community/mathlib4'
     steps:
-      - name: Find maintainer merge/delegate
+      - name: Set merge or delegate outputs from payload
         id: merge_or_delegate
         run: |
           echo "PR author: ${PR_AUTHOR}"
-          COMMENT="${COMMENT_EVENT}${COMMENT_REVIEW}"
 
-          # we strip `\r` since line endings from GitHub contain this character
-          COMMENT="${COMMENT//$'\r'/}"
-
-          # for debugging, we print some information
-          printf '%s' "${COMMENT}" | hexdump -cC
-          printf 'Comment:"%s"\n' "${COMMENT}"
-
-          m_or_d="$(printf '%s' "${COMMENT}" |
-            # captures `maintainer merge/delegate` as well as an optional `?`, ignoring subsequent spaces
-            sed -n 's=^maintainer  *\(merge\|delegate\)\(?\?\) *$=\1\2=p' | head -1)"
+          # Get values from the dispatched payload
+          m_or_d="${{ github.event.client_payload.mOrD }}"
 
           printf $'"maintainer delegate" or "maintainer merge" found? \'%s\'\n' "${m_or_d}"
 
-          printf $'mOrD=%s\n' "${m_or_d}" > "${GITHUB_OUTPUT}"
+          printf $'mOrD=%s\n' "${m_or_d}" >> "${GITHUB_OUTPUT}"
 
       - name: Check whether user is part of mathlib-reviewers team
         if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' }}
@@ -80,7 +62,7 @@ jobs:
         id: form_the_message
         run: |
           # for debugging, we print the available variables
-          echo "github.event.action: '${{ github.event.action }}'"
+          echo "github.event.action: '${{ github.event.client_payload.github_event_action }}'"
 
           echo ""
           message="$(
@@ -104,11 +86,10 @@ jobs:
         if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' }}
         uses: GrantBirki/comment@608e41b19bc973020ec0e189ebfdae935d7fe0cc # v2.1.1
         with:
-          # if a comment triggers the action, then `issue.number` is set
-          # if a review or review comment triggers the action, then `pull_request.number` is set
-          issue-number: ${{ github.event.issue.number }}${{ github.event.pull_request.number }}
+          # Use the PR number from the dispatched payload
+          issue-number: ${{ github.event.client_payload.pr_number }}
           body: |
-            🚀 Pull request has been placed on the maintainer queue by ${{ github.event.comment.user.login }}${{ github.event.review.user.login }}.
+            🚀 Pull request has been placed on the maintainer queue by ${{ github.event.client_payload.author }}.
 
       - name: Add label to PR
         if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' }}
@@ -117,5 +98,7 @@ jobs:
           # labels added by GITHUB_TOKEN won't trigger the Zulip emoji workflow
           github-token: ${{secrets.TRIAGE_TOKEN}}
           script: |
-            const { owner, repo, number: issue_number } = context.issue;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = ${{ github.event.client_payload.pr_number }};
             await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['maintainer-merge'] });

--- a/.github/workflows/maintainer_trigger.yml
+++ b/.github/workflows/maintainer_trigger.yml
@@ -1,0 +1,92 @@
+name: Maintainer Command Trigger
+
+on:
+  # the PR receives a comment
+  issue_comment:
+    types: [created, edited]
+  # the PR receives a review
+  pull_request_review:
+    # whether or not it is accompanied by a comment
+    types: [submitted]
+  # the PR receives a review comment
+  pull_request_review_comment:
+    types: [created, edited]
+
+jobs:
+  trigger_maintainer:
+    name: Parse and trigger maintainer commands
+    runs-on: ubuntu-latest
+    if: github.repository == 'leanprover-community/mathlib4'
+    steps:
+      - name: Parse maintainer command
+        id: parse_command
+        env:
+          AUTHOR: ${{ github.event.comment.user.login }}${{ github.event.review.user.login }}
+          PR_AUTHOR: ${{ github.event.issue.user.login }}${{ github.event.pull_request.user.login }}
+          PR_NUMBER: ${{ github.event.issue.number }}${{ github.event.pull_request.number }}
+          COMMENT_EVENT: ${{ github.event.comment.body }}
+          COMMENT_REVIEW: ${{ github.event.review.body }}
+          PR_TITLE_ISSUE: ${{ github.event.issue.title }}
+          PR_TITLE_PR: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.issue.html_url }}${{ github.event.pull_request.html_url }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          echo "PR author: ${PR_AUTHOR}"
+          COMMENT="${COMMENT_EVENT}${COMMENT_REVIEW}"
+
+          # we strip `\r` since line endings from GitHub contain this character
+          COMMENT="${COMMENT//$'\r'/}"
+
+          # for debugging, we print some information
+          printf '%s' "${COMMENT}" | hexdump -cC
+          printf 'Comment:"%s"\n' "${COMMENT}"
+
+          m_or_d="$(printf '%s' "${COMMENT}" |
+            # captures `maintainer merge/delegate` as well as an optional `?`, ignoring subsequent spaces
+            sed -n 's=^maintainer  *\(merge\|delegate\)\(?\?\) *$=\1\2=p' | head -1)"
+
+          printf $'"maintainer delegate" or "maintainer merge" found? \'%s\'\n' "${m_or_d}"
+
+          printf $'mOrD=%s\n' "${m_or_d}" >> "${GITHUB_OUTPUT}"
+
+      - name: Dispatch to main maintainer workflow
+        if: ${{ steps.parse_command.outputs.mOrD != '' }}
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const payload = {
+              event_type: 'maintainer-command',
+              client_payload: {
+                author: process.env.AUTHOR,
+                pr_author: process.env.PR_AUTHOR,
+                pr_number: process.env.PR_NUMBER,
+                mOrD: process.env.M_OR_D,
+                comment_event: process.env.COMMENT_EVENT,
+                comment_review: process.env.COMMENT_REVIEW,
+                pr_title_issue: process.env.PR_TITLE_ISSUE,
+                pr_title_pr: process.env.PR_TITLE_PR,
+                pr_url: process.env.PR_URL,
+                event_name: process.env.EVENT_NAME,
+                github_event_action: context.payload.action
+              }
+            };
+
+            console.log('Dispatching maintainer command with payload:', JSON.stringify(payload, null, 2));
+
+            await github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ...payload
+            });
+        env:
+          AUTHOR: ${{ github.event.comment.user.login }}${{ github.event.review.user.login }}
+          PR_AUTHOR: ${{ github.event.issue.user.login }}${{ github.event.pull_request.user.login }}
+          PR_NUMBER: ${{ github.event.issue.number }}${{ github.event.pull_request.number }}
+          M_OR_D: ${{ steps.parse_command.outputs.mOrD }}
+          COMMENT_EVENT: ${{ github.event.comment.body }}
+          COMMENT_REVIEW: ${{ github.event.review.body }}
+          PR_TITLE_ISSUE: ${{ github.event.issue.title }}
+          PR_TITLE_PR: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.issue.html_url }}${{ github.event.pull_request.html_url }}
+          EVENT_NAME: ${{ github.event_name }}


### PR DESCRIPTION
This PR fixes the issue where fork PRs couldn't add/remove labels or zulip emojis. The solution is to split both workflows into a trigger + main workflow using `repository_dispatch`.
