### PR TITLE
[Merged by Bors] - feat(SimpleGraph): Small refactor + helper lemma

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -766,7 +766,7 @@ lemma getVert_eq_support_getElem {u v : V} {n : ℕ} (p : G.Walk u v) (h : n ≤
       exact getVert_eq_support_getElem _ (Nat.sub_le_of_le_add h)
 
 lemma getVert_eq_support_getElem? {u v : V} {n : ℕ} (p : G.Walk u v) (h : n ≤ p.length) :
-    p.getVert n = p.support[n]? := by
+    some (p.getVert n) = p.support[n]? := by
   rw [getVert_eq_support_getElem p h, ← List.getElem?_eq_getElem]
 
 @[deprecated (since := "2025-06-10")]

--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -767,9 +767,9 @@ lemma getVert_eq_support_getElem {u v : V} {n : ℕ} (p : G.Walk u v) (h2 : n �
         simp only [hn, ↓reduceDIte]
         exact getVert_eq_support_getElem q (Nat.sub_le_of_le_add h2)
 
-lemma getVert_eq_support_getElem? {u v : V} {n : ℕ} (p : G.Walk u v) (h2 : n ≤ p.length) :
+lemma getVert_eq_support_getElem? {u v : V} {n : ℕ} (p : G.Walk u v) (h : n ≤ p.length) :
     p.getVert n = p.support[n]? := by
-  rw [getVert_eq_support_getElem p h2, ← List.getElem?_eq_getElem]
+  rw [getVert_eq_support_getElem p h, ← List.getElem?_eq_getElem]
 
 @[deprecated (since := "2025-06-10")]
 alias getVert_eq_support_get? := getVert_eq_support_getElem?

--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -574,20 +574,6 @@ theorem subset_support_append_right {V : Type u} {G : SimpleGraph V} {u v w : V}
   intro h
   simp +contextual only [mem_support_append_iff, or_true, imp_true_iff]
 
-lemma getVert_eq_support_get? {u v n} (p : G.Walk u v) (h2 : n ≤ p.length) :
-    p.getVert n = p.support[n]? := by
-  match p with
-  | .nil => simp_all
-  | .cons h q =>
-    simp only [Walk.support_cons]
-    by_cases hn : n = 0
-    · simp only [hn, getVert_zero, List.length_cons, Nat.zero_lt_succ, List.getElem?_eq_getElem,
-      List.getElem_cons_zero]
-    · push_neg at hn
-      nth_rewrite 2 [← Nat.sub_one_add_one hn]
-      rw [Walk.getVert_cons q h hn, List.getElem?_cons_succ]
-      exact getVert_eq_support_get? q (Nat.sub_le_of_le_add (Walk.length_cons _ _ ▸ h2))
-
 theorem coe_support {u v : V} (p : G.Walk u v) :
     (p.support : Multiset V) = {u} + p.support.tail := by cases p <;> rfl
 
@@ -769,12 +755,31 @@ theorem edges_nodup_of_support_nodup {u v : V} {p : G.Walk u v} (h : p.support.N
     simp only [edges_cons, support_cons, List.nodup_cons] at h ⊢
     exact ⟨fun h' => h.1 (fst_mem_support_of_mem_edges p' h'), ih h.2⟩
 
+lemma getVert_eq_support_getElem {u v : V} {n : ℕ} (p : G.Walk u v) (h2 : n ≤ p.length) :
+    p.getVert n = p.support[n]'(by rw [length_support]; omega) := by
+  induction p with
+  | nil => simp_all
+  | cons h q ih =>
+      simp only [Walk.support_cons]
+      by_cases hn : n = 0
+      · simp only [hn, getVert_zero, List.getElem_cons_zero]
+      · rw [Walk.getVert_cons q h hn, List.getElem_cons]
+        simp only [hn, ↓reduceDIte]
+        exact getVert_eq_support_getElem q (Nat.sub_le_of_le_add h2)
+
+lemma getVert_eq_support_getElem? {u v : V} {n : ℕ} (p : G.Walk u v) (h2 : n ≤ p.length) :
+    p.getVert n = p.support[n]? := by
+  rw [getVert_eq_support_getElem p h2, ← List.getElem?_eq_getElem]
+
+@[deprecated (since := "2025-06-10")]
+alias getVert_eq_support_get? := getVert_eq_support_getElem?
+
 theorem nodup_tail_support_reverse {u : V} {p : G.Walk u u} :
     p.reverse.support.tail.Nodup ↔ p.support.tail.Nodup := by
   rw [Walk.support_reverse]
   refine List.nodup_tail_reverse p.support ?h
-  rw [← getVert_eq_support_get? _ (by omega), List.getLast?_eq_getElem?,
-    ← getVert_eq_support_get? _ (by rw [Walk.length_support]; omega)]
+  rw [← getVert_eq_support_getElem? _ (by omega), List.getLast?_eq_getElem?,
+    ← getVert_eq_support_getElem? _ (by rw [Walk.length_support]; omega)]
   aesop
 
 theorem edges_injective {u v : V} : Function.Injective (Walk.edges : G.Walk u v → List (Sym2 V))

--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -755,17 +755,15 @@ theorem edges_nodup_of_support_nodup {u v : V} {p : G.Walk u v} (h : p.support.N
     simp only [edges_cons, support_cons, List.nodup_cons] at h ⊢
     exact ⟨fun h' => h.1 (fst_mem_support_of_mem_edges p' h'), ih h.2⟩
 
-lemma getVert_eq_support_getElem {u v : V} {n : ℕ} (p : G.Walk u v) (h2 : n ≤ p.length) :
-    p.getVert n = p.support[n]'(by rw [length_support]; omega) := by
-  induction p with
-  | nil => simp_all
-  | cons h q ih =>
-      simp only [Walk.support_cons]
-      by_cases hn : n = 0
-      · simp only [hn, getVert_zero, List.getElem_cons_zero]
-      · rw [Walk.getVert_cons q h hn, List.getElem_cons]
-        simp only [hn, ↓reduceDIte]
-        exact getVert_eq_support_getElem q (Nat.sub_le_of_le_add h2)
+lemma Walk.getVert_eq_support_getElem {u v : V} {n : ℕ} (p : G.Walk u v) (h : n ≤ p.length) :
+    p.getVert n = p.support[n]'(p.length_support ▸ Nat.lt_add_one_of_le h) := by
+  cases p with
+  | nil => simp
+  | cons => cases n with
+    | zero => simp
+    | succ n =>
+      simp_rw [support_cons, getVert_cons _ _ n.zero_ne_add_one.symm, List.getElem_cons]
+      exact getVert_eq_support_getElem _ (Nat.sub_le_of_le_add h)
 
 lemma getVert_eq_support_getElem? {u v : V} {n : ℕ} (p : G.Walk u v) (h : n ≤ p.length) :
     p.getVert n = p.support[n]? := by

--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -755,7 +755,7 @@ theorem edges_nodup_of_support_nodup {u v : V} {p : G.Walk u v} (h : p.support.N
     simp only [edges_cons, support_cons, List.nodup_cons] at h ⊢
     exact ⟨fun h' => h.1 (fst_mem_support_of_mem_edges p' h'), ih h.2⟩
 
-lemma Walk.getVert_eq_support_getElem {u v : V} {n : ℕ} (p : G.Walk u v) (h : n ≤ p.length) :
+lemma getVert_eq_support_getElem {u v : V} {n : ℕ} (p : G.Walk u v) (h : n ≤ p.length) :
     p.getVert n = p.support[n]'(p.length_support ▸ Nat.lt_add_one_of_le h) := by
   cases p with
   | nil => simp


### PR DESCRIPTION
There exists a `Walk.getVert_eq_support_get?` lemma to relate `Walk.getVert` and `Walk.support[]?`. Small refactor: this should be named `_getElem?` instead of `_get?`.

Further, I add another lemma that relates `getVert` to `support[]` (without the `?`) and then derive the `getElem?` theorem from it, to simplify cases when you are working with `support[]`.