### PR TITLE
[Merged by Bors] - refactor: make `SimpleGraph.incMatrix` computable

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/IncMatrix.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/IncMatrix.lean
@@ -51,28 +51,28 @@ variable (R : Type*) {α : Type*} (G : SimpleGraph α)
 
 /-- `G.incMatrix R` is the `α × Sym2 α` matrix whose `(a, e)`-entry is `1` if `e` is incident to
 `a` and `0` otherwise. -/
-noncomputable def incMatrix [Zero R] [One R] : Matrix α (Sym2 α) R := fun a =>
-  (G.incidenceSet a).indicator 1
+def incMatrix [Zero R] [One R] [DecidableEq α] [DecidableRel G.Adj] : Matrix α (Sym2 α) R :=
+  .of fun a e =>
+    if e ∈ (G.incidenceSet a) then 1 else 0
 
 variable {R}
 
-theorem incMatrix_apply [Zero R] [One R] {a : α} {e : Sym2 α} :
-    G.incMatrix R a e = (G.incidenceSet a).indicator 1 e :=
+theorem incMatrix_apply [Zero R] [One R] [DecidableEq α] [DecidableRel G.Adj] {a : α} {e : Sym2 α} :
+    G.incMatrix R a e = (G.incidenceSet a).indicator 1 e := by
+  simp only [incMatrix, Set.indicator, Pi.one_apply]
   rfl
 
 /-- Entries of the incidence matrix can be computed given additional decidable instances. -/
 theorem incMatrix_apply' [Zero R] [One R] [DecidableEq α] [DecidableRel G.Adj] {a : α}
-    {e : Sym2 α} : G.incMatrix R a e = if e ∈ G.incidenceSet a then 1 else 0 := by
-  simp only [incMatrix, Set.indicator, Pi.one_apply]
+    {e : Sym2 α} : G.incMatrix R a e = if e ∈ G.incidenceSet a then 1 else 0 := rfl
 
 section MulZeroOneClass
 
-variable [MulZeroOneClass R] {a b : α} {e : Sym2 α}
+variable [MulZeroOneClass R] [DecidableEq α] [DecidableRel G.Adj] {a b : α} {e : Sym2 α}
 
 theorem incMatrix_apply_mul_incMatrix_apply : G.incMatrix R a e * G.incMatrix R b e =
     (G.incidenceSet a ∩ G.incidenceSet b).indicator 1 e := by
-  classical simp only [incMatrix, Set.indicator_apply, ite_zero_mul_ite_zero, Pi.one_apply, mul_one,
-    Set.mem_inter_iff]
+  simp [incMatrix_apply',  Set.indicator_apply, ← ite_and, and_comm]
 
 theorem incMatrix_apply_mul_incMatrix_apply_of_not_adj (hab : a ≠ b) (h : ¬G.Adj a b) :
     G.incMatrix R a e * G.incMatrix R b e = 0 := by
@@ -102,30 +102,28 @@ end MulZeroOneClass
 
 section NonAssocSemiring
 
-variable [NonAssocSemiring R] {a : α} {e : Sym2 α}
+variable [NonAssocSemiring R] [DecidableEq α] [DecidableRel G.Adj] {a : α} {e : Sym2 α}
 
 theorem sum_incMatrix_apply [Fintype (Sym2 α)] [Fintype (neighborSet G a)] :
     ∑ e, G.incMatrix R a e = G.degree a := by
-  classical simp [incMatrix_apply', sum_boole, Set.filter_mem_univ_eq_toFinset]
+  simp [incMatrix_apply', sum_boole, Set.filter_mem_univ_eq_toFinset]
 
 theorem incMatrix_mul_transpose_diag [Fintype (Sym2 α)] [Fintype (neighborSet G a)] :
     (G.incMatrix R * (G.incMatrix R)ᵀ) a a = G.degree a := by
-  classical
   rw [← sum_incMatrix_apply]
   simp only [mul_apply, incMatrix_apply', transpose_apply, mul_ite, mul_one, mul_zero]
   simp_all only [ite_true, sum_boole]
 
 theorem sum_incMatrix_apply_of_mem_edgeSet [Fintype α] :
     e ∈ G.edgeSet → ∑ a, G.incMatrix R a e = 2 := by
-  classical
-    refine e.ind ?_
-    intro a b h
-    rw [mem_edgeSet] at h
-    rw [← Nat.cast_two, ← card_pair h.ne]
-    simp only [incMatrix_apply', sum_boole, mk'_mem_incidenceSet_iff, h]
-    congr 2
-    ext e
-    simp only [mem_filter, mem_univ, true_and, mem_insert, mem_singleton]
+  refine e.ind ?_
+  intro a b h
+  rw [mem_edgeSet] at h
+  rw [← Nat.cast_two, ← card_pair h.ne]
+  simp only [incMatrix_apply', sum_boole, mk'_mem_incidenceSet_iff, h]
+  congr 2
+  ext e
+  simp only [mem_filter, mem_univ, true_and, mem_insert, mem_singleton]
 
 theorem sum_incMatrix_apply_of_notMem_edgeSet [Fintype α] (h : e ∉ G.edgeSet) :
     ∑ a, G.incMatrix R a e = 0 :=
@@ -136,45 +134,43 @@ alias sum_incMatrix_apply_of_not_mem_edgeSet := sum_incMatrix_apply_of_notMem_ed
 
 theorem incMatrix_transpose_mul_diag [Fintype α] [Decidable (e ∈ G.edgeSet)] :
     ((G.incMatrix R)ᵀ * G.incMatrix R) e e = if e ∈ G.edgeSet then 2 else 0 := by
-  classical
-    simp only [Matrix.mul_apply, incMatrix_apply', transpose_apply, ite_zero_mul_ite_zero, one_mul,
-      sum_boole, and_self_iff]
-    split_ifs with h
-    · revert h
-      refine e.ind ?_
-      intro v w h
-      rw [← Nat.cast_two, ← card_pair (G.ne_of_adj h)]
-      simp only [mk'_mem_incidenceSet_iff, G.mem_edgeSet.mp h, true_and, mem_univ, forall_true_left,
-        forall_eq_or_imp, forall_eq, and_self, mem_singleton, ne_eq]
-      congr 2
-      ext u
-      simp
-    · revert h
-      refine e.ind ?_
-      intro v w h
-      simp [mk'_mem_incidenceSet_iff, G.mem_edgeSet.not.mp h]
+  simp only [Matrix.mul_apply, incMatrix_apply', transpose_apply, ite_zero_mul_ite_zero, one_mul,
+    sum_boole, and_self_iff]
+  split_ifs with h
+  · revert h
+    refine e.ind ?_
+    intro v w h
+    rw [← Nat.cast_two, ← card_pair (G.ne_of_adj h)]
+    simp only [mk'_mem_incidenceSet_iff, G.mem_edgeSet.mp h, true_and, mem_univ, forall_true_left,
+      forall_eq_or_imp, forall_eq, and_self, mem_singleton, ne_eq]
+    congr 2
+    ext u
+    simp
+  · revert h
+    refine e.ind ?_
+    intro v w h
+    simp [mk'_mem_incidenceSet_iff, G.mem_edgeSet.not.mp h]
 
 end NonAssocSemiring
 
 section Semiring
 
-variable [Fintype (Sym2 α)] [Semiring R] {a b : α}
+variable [Fintype (Sym2 α)] [DecidableEq α] [DecidableRel G.Adj] [Semiring R] {a b : α}
 
 theorem incMatrix_mul_transpose_apply_of_adj (h : G.Adj a b) :
     (G.incMatrix R * (G.incMatrix R)ᵀ) a b = (1 : R) := by
-  classical
-    simp_rw [Matrix.mul_apply, Matrix.transpose_apply, incMatrix_apply_mul_incMatrix_apply,
-      Set.indicator_apply, Pi.one_apply, sum_boole]
-    convert @Nat.cast_one R _
-    convert card_singleton s(a, b)
-    rw [← coe_eq_singleton, coe_filter_univ]
-    exact G.incidenceSet_inter_incidenceSet_of_adj h
+  simp_rw [Matrix.mul_apply, Matrix.transpose_apply, incMatrix_apply_mul_incMatrix_apply,
+    Set.indicator_apply, Pi.one_apply, sum_boole]
+  convert @Nat.cast_one R _
+  convert card_singleton s(a, b)
+  rw [← coe_eq_singleton, coe_filter_univ]
+  exact G.incidenceSet_inter_incidenceSet_of_adj h
 
-theorem incMatrix_mul_transpose
-    [∀ a, Fintype (neighborSet G a)] [DecidableEq α] [DecidableRel G.Adj] :
-    G.incMatrix R * (G.incMatrix R)ᵀ = fun a b =>
-      if a = b then (G.degree a : R) else if G.Adj a b then 1 else 0 := by
+theorem incMatrix_mul_transpose [∀ a, Fintype (neighborSet G a)] :
+    G.incMatrix R * (G.incMatrix R)ᵀ =
+      of fun a b => if a = b then (G.degree a : R) else if G.Adj a b then 1 else 0 := by
   ext a b
+  dsimp
   split_ifs with h h'
   · subst b
     exact incMatrix_mul_transpose_diag (R := R) G

--- a/Mathlib/Combinatorics/SimpleGraph/IncMatrix.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/IncMatrix.lean
@@ -53,7 +53,7 @@ variable (R : Type*) {α : Type*} (G : SimpleGraph α)
 `a` and `0` otherwise. -/
 def incMatrix [Zero R] [One R] [DecidableEq α] [DecidableRel G.Adj] : Matrix α (Sym2 α) R :=
   .of fun a e =>
-    if e ∈ (G.incidenceSet a) then 1 else 0
+    if e ∈ G.incidenceSet a then 1 else 0
 
 variable {R}
 


### PR DESCRIPTION
This came up in a project at "Autoformalization for the Working Mathematician" at ICERM.

There are no downstream uses of this file, nor is there any implementation note explaining why `noncomputable` is used here; so let's make `#eval` work:
```lean
-- now works
#eval (⊤ : SimpleGraph (Fin 3)).incMatrix ℕ * ((⊤ : SimpleGraph (Fin 3)).incMatrix ℕ)ᵀ
```

This also adds some missing `Matrix.of`s.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

If we actually wanted to print the matrix, we'd need to reindex by the equiv in #25683!
