### PR TITLE
chore/refactor(CategoryTheory/Monoidal/Functor): deprime LaxMonoidal and OplaxMonoidal fields

### DIFF
--- a/Mathlib/CategoryTheory/Action/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Action/Monoidal.lean
@@ -113,37 +113,28 @@ end
 noncomputable section
 
 /-- Upgrading the functor `Action V G ⥤ (SingleObj G ⥤ V)` to a monoidal functor. -/
-instance : (FunctorCategoryEquivalence.functor (V := V) (G := G)).Monoidal :=
+@[simps!]
+instance FunctorCategoryEquivalence.functorMonoidal :
+    (FunctorCategoryEquivalence.functor (V := V) (G := G)).Monoidal :=
   inferInstanceAs (Monoidal.equivalenceTransported
     (Action.functorCategoryEquivalence V G).symm).inverse.Monoidal
 
-instance : (functorCategoryEquivalence V G).functor.Monoidal := by
+@[simps!]
+instance functorCategoryEquivalenceFunctorMonoidal :
+    (functorCategoryEquivalence V G).functor.Monoidal := by
   dsimp only [functorCategoryEquivalence_functor]; infer_instance
 
 /-- Upgrading the functor `(SingleObj G ⥤ V) ⥤ Action V G` to a monoidal functor. -/
-instance : (FunctorCategoryEquivalence.inverse (V := V) (G := G)).Monoidal :=
+@[simps!]
+instance FunctorCategoryEquivalence.inverseMonoidal :
+    (FunctorCategoryEquivalence.inverse (V := V) (G := G)).Monoidal :=
   inferInstanceAs (Monoidal.equivalenceTransported
     (Action.functorCategoryEquivalence V G).symm).functor.Monoidal
 
-instance : (functorCategoryEquivalence V G).inverse.Monoidal := by
+@[simps!]
+instance functorCategoryEquivalenceInverseMonoidal :
+    (functorCategoryEquivalence V G).inverse.Monoidal := by
   dsimp only [functorCategoryEquivalence_inverse]; infer_instance
-
-@[simp]
-lemma FunctorCategoryEquivalence.functor_ε :
-    ε (FunctorCategoryEquivalence.functor (V := V) (G := G)) = 𝟙 _ := rfl
-
-@[simp]
-lemma FunctorCategoryEquivalence.functor_η :
-    η (FunctorCategoryEquivalence.functor (V := V) (G := G)) = 𝟙 _ := rfl
-
-@[simp]
-lemma FunctorCategoryEquivalence.functor_μ (A B : Action V G) :
-    μ FunctorCategoryEquivalence.functor A B = 𝟙 _ := rfl
-
-@[simp]
-lemma FunctorCategoryEquivalence.functor_δ (A B : Action V G) :
-    δ FunctorCategoryEquivalence.functor A B = 𝟙 _ := rfl
-
 
 variable (H : Type*) [Group H]
 
@@ -284,19 +275,19 @@ open Functor.LaxMonoidal Functor.OplaxMonoidal Functor.Monoidal
 /-- A lax monoidal functor induces a lax monoidal functor between
 the categories of `G`-actions within those categories. -/
 instance [F.LaxMonoidal] : (F.mapAction G).LaxMonoidal where
-  ε' :=
+  ε :=
     { hom := ε F
       comm := fun g => by
         dsimp [FunctorCategoryEquivalence.inverse, Functor.mapAction]
         rw [Category.id_comp, F.map_id, Category.comp_id] }
-  μ' X Y :=
+  μ X Y :=
     { hom := μ F X.V Y.V
       comm := fun g => μ_natural F (X.ρ g) (Y.ρ g) }
-  μ'_natural_left _ _ := by ext; simp
-  μ'_natural_right _ _ := by ext; simp
-  associativity' _ _ _ := by ext; simp
-  left_unitality' _ := by ext; simp
-  right_unitality' _ := by ext; simp
+  μ_natural_left _ _ := by ext; simp
+  μ_natural_right _ _ := by ext; simp
+  associativity _ _ _ := by ext; simp
+  left_unitality _ := by ext; simp
+  right_unitality _ := by ext; simp
 
 @[simp]
 lemma mapAction_ε_hom [F.LaxMonoidal] : (ε (F.mapAction G)).hom = ε F := rfl
@@ -308,19 +299,19 @@ lemma mapAction_μ_hom [F.LaxMonoidal] (X Y : Action V G) :
 /-- An oplax monoidal functor induces an oplax monoidal functor between
 the categories of `G`-actions within those categories. -/
 instance [F.OplaxMonoidal] : (F.mapAction G).OplaxMonoidal where
-  η' :=
+  η :=
     { hom := η F
       comm := fun g => by
         dsimp [FunctorCategoryEquivalence.inverse, Functor.mapAction]
         rw [map_id, Category.id_comp, Category.comp_id] }
-  δ' X Y :=
+  δ X Y :=
     { hom := δ F X.V Y.V
       comm := fun g => (δ_natural F (X.ρ g) (Y.ρ g)).symm }
-  δ'_natural_left _ _ := by ext; simp
-  δ'_natural_right _ _ := by ext; simp
-  oplax_associativity' _ _ _ := by ext; simp
-  oplax_left_unitality' _ := by ext; simp
-  oplax_right_unitality' _ := by ext; simp
+  δ_natural_left _ _ := by ext; simp
+  δ_natural_right _ _ := by ext; simp
+  oplax_associativity _ _ _ := by ext; simp
+  oplax_left_unitality _ := by ext; simp
+  oplax_right_unitality _ := by ext; simp
 
 @[simp]
 lemma mapAction_η_hom [F.OplaxMonoidal] : (η (F.mapAction G)).hom = η F := rfl

--- a/Mathlib/CategoryTheory/Monoidal/Braided/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided/Basic.lean
@@ -371,8 +371,8 @@ variable {E : Type u₃} [Category.{v₃} E] [MonoidalCategory E] [BraidedCatego
 which preserves the braiding.
 -/
 class Functor.LaxBraided (F : C ⥤ D) extends F.LaxMonoidal where
-  braided : ∀ X Y : C, μ F X Y ≫ F.map (β_ X Y).hom =
-    (β_ (F.obj X) (F.obj Y)).hom ≫ μ F Y X := by aesop_cat
+  braided : ∀ X Y : C, μ X Y ≫ F.map (β_ X Y).hom =
+    (β_ (F.obj X) (F.obj Y)).hom ≫ μ Y X := by aesop_cat
 
 namespace Functor.LaxBraided
 

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Basic.lean
@@ -814,13 +814,13 @@ omit [F.OplaxMonoidal] in
 This is not made an instance because it would create a diamond for the oplax monoidal structure on
 the identity and composition of functors. -/
 def ofChosenFiniteProducts (F : C ⥤ D) : F.OplaxMonoidal where
-  η' := terminalComparison F
-  δ' X Y := prodComparison F X Y
-  δ'_natural_left f X' := by ext <;> simp [← Functor.map_comp]
-  δ'_natural_right X g := by ext <;> simp [← Functor.map_comp]
-  oplax_associativity' _ _ _ := by ext <;> simp [← Functor.map_comp]
-  oplax_left_unitality' _ := by ext; simp [← Functor.map_comp]
-  oplax_right_unitality' _ := by ext; simp [← Functor.map_comp]
+  η := terminalComparison F
+  δ X Y := prodComparison F X Y
+  δ_natural_left f X := by ext <;> simp [← Functor.map_comp]
+  δ_natural_right X g := by ext <;> simp [← Functor.map_comp]
+  oplax_associativity _ _ _ := by ext <;> simp [← Functor.map_comp]
+  oplax_left_unitality _ := by ext; simp [← Functor.map_comp]
+  oplax_right_unitality _ := by ext; simp [← Functor.map_comp]
 
 omit [F.OplaxMonoidal] in
 /-- Any functor between cartesian-monoidal categories is oplax monoidal in a unique way. -/
@@ -828,7 +828,7 @@ instance : Subsingleton F.OplaxMonoidal where
   allEq a b := by
     ext1
     · exact toUnit_unique _ _
-    · ext1; ext1; rw [← δ, ← δ, δ_of_cartesianMonoidalCategory, δ_of_cartesianMonoidalCategory]
+    · ext1; ext1; rw [δ_of_cartesianMonoidalCategory, δ_of_cartesianMonoidalCategory]
 
 end OplaxMonoidal
 

--- a/Mathlib/CategoryTheory/Monoidal/CommMon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CommMon_.lean
@@ -261,8 +261,8 @@ def commMonToLaxBraidedObj (A : CommMon_ C) :
     Discrete PUnit.{u + 1} ⥤ C := (Functor.const _).obj A.X
 
 instance (A : CommMon_ C) : (commMonToLaxBraidedObj A).LaxMonoidal where
-  ε' := η[A.X]
-  μ' _ _ := μ[A.X]
+  ε := η[A.X]
+  «μ» _ _ := μ[A.X]
 
 open Functor.LaxMonoidal
 

--- a/Mathlib/CategoryTheory/Monoidal/Functor.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Functor.lean
@@ -546,7 +546,7 @@ def toLaxMonoidal : F.LaxMonoidal where
   right_unitality := h.right_unitality
 
 /-- The oplax monoidal functor structure induced by a `Functor.CoreMonoidal` structure. -/
-@[simps]
+@[simps -isSimp]
 def toOplaxMonoidal : F.OplaxMonoidal where
   η := h.εIso.inv
   δ X Y := (h.μIso X Y).inv

--- a/Mathlib/CategoryTheory/Monoidal/Functor.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Functor.lean
@@ -47,7 +47,7 @@ variable {C : Type u₁} [Category.{v₁} C] [MonoidalCategory.{v₁} C]
   {D : Type u₂} [Category.{v₂} D] [MonoidalCategory.{v₂} D]
   {E : Type u₃} [Category.{v₃} E] [MonoidalCategory.{v₃} E]
   {C' : Type u₁'} [Category.{v₁'} C']
-  (F : C ⥤ D) (G : D ⥤ E)
+
 
 namespace Functor
 
@@ -59,70 +59,43 @@ namespace Functor
 equipped with morphisms `ε : 𝟙_ D ⟶ F.obj (𝟙_ C)` and `μ X Y : F.obj X ⊗ F.obj Y ⟶ F.obj (X ⊗ Y)`,
 satisfying the appropriate coherences. -/
 @[ext]
-class LaxMonoidal where
-  /-- unit morphism -/
-  ε' : 𝟙_ D ⟶ F.obj (𝟙_ C)
-  /-- tensorator -/
-  μ' : ∀ X Y : C, F.obj X ⊗ F.obj Y ⟶ F.obj (X ⊗ Y)
-  μ'_natural_left :
+class LaxMonoidal (F : C ⥤ D) where
+  /-- the unit morphism of a lax monoidal functor -/
+  ε (F) : 𝟙_ D ⟶ F.obj (𝟙_ C)
+  /-- the tensorator of a lax monoidal functor -/
+  μ (F) : ∀ X Y : C, F.obj X ⊗ F.obj Y ⟶ F.obj (X ⊗ Y)
+  μ_natural_left (F) :
     ∀ {X Y : C} (f : X ⟶ Y) (X' : C),
-      F.map f ▷ F.obj X' ≫ μ' Y X' = μ' X X' ≫ F.map (f ▷ X') := by
+      F.map f ▷ F.obj X' ≫ μ Y X' = μ X X' ≫ F.map (f ▷ X') := by
     aesop_cat
-  μ'_natural_right :
+  μ_natural_right (F) :
     ∀ {X Y : C} (X' : C) (f : X ⟶ Y) ,
-      F.obj X' ◁ F.map f ≫ μ' X' Y = μ' X' X ≫ F.map (X' ◁ f) := by
+      F.obj X' ◁ F.map f ≫ μ X' Y = μ X' X ≫ F.map (X' ◁ f) := by
     aesop_cat
   /-- associativity of the tensorator -/
-  associativity' :
+  associativity (F) :
     ∀ X Y Z : C,
-      μ' X Y ▷ F.obj Z ≫ μ' (X ⊗ Y) Z ≫ F.map (α_ X Y Z).hom =
-        (α_ (F.obj X) (F.obj Y) (F.obj Z)).hom ≫ F.obj X ◁ μ' Y Z ≫ μ' X (Y ⊗ Z) := by
+      μ X Y ▷ F.obj Z ≫ μ (X ⊗ Y) Z ≫ F.map (α_ X Y Z).hom =
+        (α_ (F.obj X) (F.obj Y) (F.obj Z)).hom ≫ F.obj X ◁ μ Y Z ≫ μ X (Y ⊗ Z) := by
     aesop_cat
   -- unitality
-  left_unitality' :
-    ∀ X : C, (λ_ (F.obj X)).hom = ε' ▷ F.obj X ≫ μ' (𝟙_ C) X ≫ F.map (λ_ X).hom := by
+  left_unitality (F) :
+    ∀ X : C, (λ_ (F.obj X)).hom = ε ▷ F.obj X ≫ μ (𝟙_ C) X ≫ F.map (λ_ X).hom := by
       aesop_cat
-  right_unitality' :
-    ∀ X : C, (ρ_ (F.obj X)).hom = F.obj X ◁ ε' ≫ μ' X (𝟙_ C) ≫ F.map (ρ_ X).hom := by
+  right_unitality (F) :
+    ∀ X : C, (ρ_ (F.obj X)).hom = F.obj X ◁ ε ≫ μ X (𝟙_ C) ≫ F.map (ρ_ X).hom := by
     aesop_cat
 
 namespace LaxMonoidal
 
+attribute [reassoc (attr := simp)] μ_natural_left μ_natural_right
+  associativity
+
+attribute [simp, reassoc] right_unitality left_unitality
+
 section
 
-variable [F.LaxMonoidal]
-
-/-- the unit morphism of a lax monoidal functor -/
-def ε : 𝟙_ D ⟶ F.obj (𝟙_ C) := ε'
-
-/-- the tensorator of a lax monoidal functor -/
-def μ (X Y : C) : F.obj X ⊗ F.obj Y ⟶ F.obj (X ⊗ Y) := μ' X Y
-
-@[reassoc (attr := simp)]
-lemma μ_natural_left {X Y : C} (f : X ⟶ Y) (X' : C) :
-    F.map f ▷ F.obj X' ≫ μ F Y X' = μ F X X' ≫ F.map (f ▷ X') := by
-  apply μ'_natural_left
-
-@[reassoc (attr := simp)]
-lemma μ_natural_right {X Y : C} (X' : C) (f : X ⟶ Y) :
-    F.obj X' ◁ F.map f ≫ μ F X' Y = μ F X' X ≫ F.map (X' ◁ f) := by
-  apply μ'_natural_right
-
-@[reassoc (attr := simp)]
-lemma associativity (X Y Z : C) :
-    μ F X Y ▷ F.obj Z ≫ μ F (X ⊗ Y) Z ≫ F.map (α_ X Y Z).hom =
-        (α_ (F.obj X) (F.obj Y) (F.obj Z)).hom ≫ F.obj X ◁ μ F Y Z ≫ μ F X (Y ⊗ Z) := by
-  apply associativity'
-
-@[simp, reassoc]
-lemma left_unitality (X : C) :
-    (λ_ (F.obj X)).hom = ε F ▷ F.obj X ≫ μ F (𝟙_ C) X ≫ F.map (λ_ X).hom := by
-  apply left_unitality'
-
-@[simp, reassoc]
-lemma right_unitality (X : C) :
-    (ρ_ (F.obj X)).hom = F.obj X ◁ ε F ≫ μ F X (𝟙_ C) ≫ F.map (ρ_ X).hom := by
-  apply right_unitality'
+variable (F : C ⥤ D) [F.LaxMonoidal]
 
 @[reassoc (attr := simp)]
 theorem μ_natural {X Y X' Y' : C} (f : X ⟶ Y) (g : X' ⟶ Y') :
@@ -152,27 +125,27 @@ end
 
 section
 
-variable {F}
+variable {F : C ⥤ D}
     /- unit morphism -/
-    (ε' : 𝟙_ D ⟶ F.obj (𝟙_ C))
+    (ε : 𝟙_ D ⟶ F.obj (𝟙_ C))
     /- tensorator -/
-    (μ' : ∀ X Y : C, F.obj X ⊗ F.obj Y ⟶ F.obj (X ⊗ Y))
-    (μ'_natural :
+    (μ : ∀ X Y : C, F.obj X ⊗ F.obj Y ⟶ F.obj (X ⊗ Y))
+    (μ_natural :
       ∀ {X Y X' Y' : C} (f : X ⟶ Y) (g : X' ⟶ Y'),
-        (F.map f ⊗ F.map g) ≫ μ' Y Y' = μ' X X' ≫ F.map (f ⊗ g) := by
+        (F.map f ⊗ F.map g) ≫ μ Y Y' = μ X X' ≫ F.map (f ⊗ g) := by
       aesop_cat)
     /- associativity of the tensorator -/
-    (associativity' :
+    (associativity :
       ∀ X Y Z : C,
-        (μ' X Y ⊗ 𝟙 (F.obj Z)) ≫ μ' (X ⊗ Y) Z ≫ F.map (α_ X Y Z).hom =
-          (α_ (F.obj X) (F.obj Y) (F.obj Z)).hom ≫ (𝟙 (F.obj X) ⊗ μ' Y Z) ≫ μ' X (Y ⊗ Z) := by
+        (μ X Y ⊗ 𝟙 (F.obj Z)) ≫ μ (X ⊗ Y) Z ≫ F.map (α_ X Y Z).hom =
+          (α_ (F.obj X) (F.obj Y) (F.obj Z)).hom ≫ (𝟙 (F.obj X) ⊗ μ Y Z) ≫ μ X (Y ⊗ Z) := by
       aesop_cat)
     /- unitality -/
-    (left_unitality' :
-      ∀ X : C, (λ_ (F.obj X)).hom = (ε' ⊗ 𝟙 (F.obj X)) ≫ μ' (𝟙_ C) X ≫ F.map (λ_ X).hom := by
+    (left_unitality :
+      ∀ X : C, (λ_ (F.obj X)).hom = (ε ⊗ 𝟙 (F.obj X)) ≫ μ (𝟙_ C) X ≫ F.map (λ_ X).hom := by
         aesop_cat)
-    (right_unitality' :
-      ∀ X : C, (ρ_ (F.obj X)).hom = (𝟙 (F.obj X) ⊗ ε') ≫ μ' X (𝟙_ C) ≫ F.map (ρ_ X).hom := by
+    (right_unitality :
+      ∀ X : C, (ρ_ (F.obj X)).hom = (𝟙 (F.obj X) ⊗ ε) ≫ μ X (𝟙_ C) ≫ F.map (ρ_ X).hom := by
         aesop_cat)
 
 /--
@@ -180,60 +153,52 @@ A constructor for lax monoidal functors whose axioms are described by `tensorHom
 `whiskerLeft` and `whiskerRight`.
 -/
 def ofTensorHom : F.LaxMonoidal where
-  ε' := ε'
-  μ' := μ'
-  μ'_natural_left := fun f X' => by
-    simp_rw [← tensorHom_id, ← F.map_id, μ'_natural]
-  μ'_natural_right := fun X' f => by
-    simp_rw [← id_tensorHom, ← F.map_id, μ'_natural]
-  associativity' := fun X Y Z => by
-    simp_rw [← tensorHom_id, ← id_tensorHom, associativity']
-  left_unitality' := fun X => by
-    simp_rw [← tensorHom_id, left_unitality']
-  right_unitality' := fun X => by
-    simp_rw [← id_tensorHom, right_unitality']
+  ε := ε
+  μ := μ
+  μ_natural_left := fun f X' => by
+    simp_rw [← tensorHom_id, ← F.map_id, μ_natural]
+  μ_natural_right := fun X' f => by
+    simp_rw [← id_tensorHom, ← F.map_id, μ_natural]
+  associativity := fun X Y Z => by
+    simp_rw [← tensorHom_id, ← id_tensorHom, associativity]
+  left_unitality := fun X => by
+    simp_rw [← tensorHom_id, left_unitality]
+  right_unitality := fun X => by
+    simp_rw [← id_tensorHom, right_unitality]
 
 lemma ofTensorHom_ε :
-    letI := (ofTensorHom ε' μ' μ'_natural associativity' left_unitality' right_unitality')
-    ε F = ε' := rfl
+    letI := (ofTensorHom ε μ μ_natural associativity left_unitality right_unitality)
+    ε = ε := rfl
 
 lemma ofTensorHom_μ :
-    letI := (ofTensorHom ε' μ' μ'_natural associativity' left_unitality' right_unitality')
-    μ F = μ' := rfl
+    letI := (ofTensorHom ε μ μ_natural associativity left_unitality right_unitality)
+    μ = μ := rfl
 
 end
 
+@[simps]
 instance id : (𝟭 C).LaxMonoidal where
-  ε' := 𝟙 _
-  μ' _ _ := 𝟙 _
-
-@[simp]
-lemma id_ε : ε (𝟭 C) = 𝟙 _ := rfl
-
-@[simp]
-lemma id_μ (X Y : C) : μ (𝟭 C) X Y = 𝟙 _ := rfl
+  ε := 𝟙 _
+  μ _ _ := 𝟙 _
 
 section
 
+variable (F : C ⥤ D) (G : D ⥤ E)
+
 variable [F.LaxMonoidal] [G.LaxMonoidal]
 
+@[simps]
 instance comp : (F ⋙ G).LaxMonoidal where
-  ε' := ε G ≫ G.map (ε F)
-  μ' X Y := μ G _ _ ≫ G.map (μ F X Y)
-  μ'_natural_left _ _ := by
+  ε := ε G ≫ G.map (ε F)
+  μ X Y := μ G _ _ ≫ G.map (μ F X Y)
+  μ_natural_left _ _ := by
     simp_rw [comp_obj, F.comp_map, μ_natural_left_assoc, assoc, ← G.map_comp, μ_natural_left]
-  μ'_natural_right _ _ := by
+  μ_natural_right _ _ := by
     simp_rw [comp_obj, F.comp_map, μ_natural_right_assoc, assoc, ← G.map_comp, μ_natural_right]
-  associativity' _ _ _ := by
+  associativity _ _ _ := by
     dsimp
     simp_rw [comp_whiskerRight, assoc, μ_natural_left_assoc, MonoidalCategory.whiskerLeft_comp,
       assoc, μ_natural_right_assoc, ← associativity_assoc, ← G.map_comp, associativity]
-
-@[simp]
-lemma comp_ε : ε (F ⋙ G) = ε G ≫ G.map (ε F) := rfl
-
-@[simp]
-lemma comp_μ (X Y : C) : μ (F ⋙ G) X Y = μ G _ _ ≫ G.map (μ F X Y) := rfl
 
 end
 
@@ -243,70 +208,49 @@ end LaxMonoidal
 equipped with morphisms `η : F.obj (𝟙_ C) ⟶ 𝟙 _D` and `δ X Y : F.obj (X ⊗ Y) ⟶ F.obj X ⊗ F.obj Y`,
 satisfying the appropriate coherences. -/
 @[ext]
-class OplaxMonoidal where
-  /-- counit morphism -/
-  η' : F.obj (𝟙_ C) ⟶ 𝟙_ D
-  /-- cotensorator -/
-  δ' : ∀ X Y : C, F.obj (X ⊗ Y) ⟶ F.obj X ⊗ F.obj Y
-  δ'_natural_left :
+class OplaxMonoidal (F : C ⥤ D) where
+  /-- the counit morphism of a lax monoidal functor -/
+  η (F) : F.obj (𝟙_ C) ⟶ 𝟙_ D
+  /-- the cotensorator of an oplax monoidal functor -/
+  δ (F) : ∀ X Y : C, F.obj (X ⊗ Y) ⟶ F.obj X ⊗ F.obj Y
+  δ_natural_left (F) :
     ∀ {X Y : C} (f : X ⟶ Y) (X' : C),
-      δ' X X' ≫ F.map f ▷ F.obj X' = F.map (f ▷ X') ≫ δ' Y X' := by
+      δ X X' ≫ F.map f ▷ F.obj X' = F.map (f ▷ X') ≫ δ Y X' := by
     aesop_cat
-  δ'_natural_right :
+  δ_natural_right (F) :
     ∀ {X Y : C} (X' : C) (f : X ⟶ Y) ,
-      δ' X' X ≫ F.obj X' ◁ F.map f = F.map (X' ◁ f) ≫ δ' X' Y := by
+      δ X' X ≫ F.obj X' ◁ F.map f = F.map (X' ◁ f) ≫ δ X' Y := by
     aesop_cat
   /-- associativity of the tensorator -/
-  oplax_associativity' :
+  oplax_associativity (F) :
     ∀ X Y Z : C,
-      δ' (X ⊗ Y) Z ≫ δ' X Y ▷ F.obj Z ≫ (α_ (F.obj X) (F.obj Y) (F.obj Z)).hom =
-        F.map (α_ X Y Z).hom ≫ δ' X (Y ⊗ Z) ≫ F.obj X ◁ δ' Y Z := by
+      δ (X ⊗ Y) Z ≫ δ X Y ▷ F.obj Z ≫ (α_ (F.obj X) (F.obj Y) (F.obj Z)).hom =
+        F.map (α_ X Y Z).hom ≫ δ X (Y ⊗ Z) ≫ F.obj X ◁ δ Y Z := by
     aesop_cat
   -- unitality
-  oplax_left_unitality' :
-    ∀ X : C, (λ_ (F.obj X)).inv = F.map (λ_ X).inv ≫ δ' (𝟙_ C) X ≫ η' ▷ F.obj X := by
+  oplax_left_unitality (F) :
+    ∀ X : C, (λ_ (F.obj X)).inv = F.map (λ_ X).inv ≫ δ (𝟙_ C) X ≫ η ▷ F.obj X := by
       aesop_cat
-  oplax_right_unitality' :
-    ∀ X : C, (ρ_ (F.obj X)).inv = F.map (ρ_ X).inv ≫ δ' X (𝟙_ C) ≫ F.obj X ◁ η' := by
+  oplax_right_unitality (F) :
+    ∀ X : C, (ρ_ (F.obj X)).inv = F.map (ρ_ X).inv ≫ δ X (𝟙_ C) ≫ F.obj X ◁ η := by
       aesop_cat
 
 namespace OplaxMonoidal
 
+attribute [reassoc (attr := simp)] δ_natural_left δ_natural_right
+
+@[reassoc (attr := simp)]
+alias associativity := oplax_associativity
+
+@[simp, reassoc]
+alias left_unitality := oplax_left_unitality
+
+@[simp, reassoc]
+alias right_unitality := oplax_right_unitality
+
 section
 
-variable [F.OplaxMonoidal]
-
-/-- the counit morphism of a lax monoidal functor -/
-def η : F.obj (𝟙_ C) ⟶ 𝟙_ D := η'
-
-/-- the cotensorator of an oplax monoidal functor -/
-def δ (X Y : C) : F.obj (X ⊗ Y) ⟶ F.obj X ⊗ F.obj Y := δ' X Y
-
-@[reassoc (attr := simp)]
-lemma δ_natural_left {X Y : C} (f : X ⟶ Y) (X' : C) :
-    δ F X X' ≫ F.map f ▷ F.obj X' = F.map (f ▷ X') ≫ δ F Y X' := by
-  apply δ'_natural_left
-
-@[reassoc (attr := simp)]
-lemma δ_natural_right {X Y : C} (X' : C) (f : X ⟶ Y) :
-    δ F X' X ≫ F.obj X' ◁ F.map f = F.map (X' ◁ f) ≫ δ F X' Y := by
-  apply δ'_natural_right
-
-@[reassoc (attr := simp)]
-lemma associativity (X Y Z : C) :
-    δ F (X ⊗ Y) Z ≫ δ F X Y ▷ F.obj Z ≫ (α_ (F.obj X) (F.obj Y) (F.obj Z)).hom =
-      F.map (α_ X Y Z).hom ≫ δ F X (Y ⊗ Z) ≫ F.obj X ◁ δ F Y Z := by
-  apply oplax_associativity'
-
-@[simp, reassoc]
-lemma left_unitality (X : C) :
-    (λ_ (F.obj X)).inv = F.map (λ_ X).inv ≫ δ F (𝟙_ C) X ≫ η F ▷ F.obj X := by
-  apply oplax_left_unitality'
-
-@[simp, reassoc]
-lemma right_unitality (X : C) :
-    (ρ_ (F.obj X)).inv = F.map (ρ_ X).inv ≫ δ F X (𝟙_ C) ≫ F.obj X ◁ η F := by
-  apply oplax_right_unitality'
+variable (F : C ⥤ D) [F.OplaxMonoidal]
 
 @[reassoc (attr := simp)]
 theorem δ_natural {X Y X' Y' : C} (f : X ⟶ Y) (g : X' ⟶ Y') :
@@ -334,40 +278,30 @@ theorem associativity_inv (X Y Z : C) :
 
 end
 
+@[simps]
 instance id : (𝟭 C).OplaxMonoidal where
-  η' := 𝟙 _
-  δ' _ _ := 𝟙 _
-
-@[simp]
-lemma id_η : η (𝟭 C) = 𝟙 _ := rfl
-
-@[simp]
-lemma id_δ (X Y : C) : δ (𝟭 C) X Y = 𝟙 _ := rfl
+  η := 𝟙 _
+  δ _ _ := 𝟙 _
 
 section
 
-variable [F.OplaxMonoidal] [G.OplaxMonoidal]
+variable (F : C ⥤ D) (G : D ⥤ E) [F.OplaxMonoidal] [G.OplaxMonoidal]
 
+@[simps]
 instance comp : (F ⋙ G).OplaxMonoidal where
-  η' := G.map (η F) ≫ η G
-  δ' X Y := G.map (δ F X Y) ≫ δ G _ _
-  δ'_natural_left {X Y} f X' := by
+  η := G.map (η F) ≫ η G
+  δ X Y := G.map (δ F X Y) ≫ δ G _ _
+  δ_natural_left {X Y} f X' := by
     dsimp
     rw [assoc, δ_natural_left, ← G.map_comp_assoc, δ_natural_left, map_comp, assoc]
-  δ'_natural_right _ _ := by
+  δ_natural_right _ _ := by
     dsimp
     rw [assoc, δ_natural_right, ← G.map_comp_assoc, δ_natural_right, map_comp, assoc]
-  oplax_associativity' X Y Z := by
+  oplax_associativity X Y Z := by
     dsimp
     rw [comp_whiskerRight, assoc, assoc, assoc, δ_natural_left_assoc, associativity,
       ← G.map_comp_assoc, ← G.map_comp_assoc, assoc, associativity, map_comp, map_comp,
       assoc, assoc, MonoidalCategory.whiskerLeft_comp, δ_natural_right_assoc]
-
-@[simp]
-lemma comp_η : η (F ⋙ G) = G.map (η F) ≫ η G := rfl
-
-@[simp]
-lemma comp_δ (X Y : C) : δ (F ⋙ G) X Y = G.map (δ F X Y) ≫ δ G _ _ := rfl
 
 end
 
@@ -378,11 +312,11 @@ open LaxMonoidal OplaxMonoidal
 /-- A functor between monoidal categories is monoidal if it is lax and oplax monoidals,
 and both data give inverse isomorphisms. -/
 @[ext]
-class Monoidal extends F.LaxMonoidal, F.OplaxMonoidal where
-  ε_η : ε F ≫ η F = 𝟙 _ := by aesop_cat
-  η_ε : η F ≫ ε F = 𝟙 _ := by aesop_cat
-  μ_δ (X Y : C) : μ F X Y ≫ δ F X Y = 𝟙 _ := by aesop_cat
-  δ_μ (X Y : C) : δ F X Y ≫ μ F X Y = 𝟙 _ := by aesop_cat
+class Monoidal (F : C ⥤ D) extends F.LaxMonoidal, F.OplaxMonoidal where
+  ε_η (F) : ε ≫ η = 𝟙 _ := by aesop_cat
+  η_ε (F) : η ≫ ε = 𝟙 _ := by aesop_cat
+  μ_δ (F) (X Y : C) : μ X Y ≫ δ X Y = 𝟙 _ := by aesop_cat
+  δ_μ (F) (X Y : C) : δ X Y ≫ μ X Y = 𝟙 _ := by aesop_cat
 
 namespace Monoidal
 
@@ -390,7 +324,7 @@ attribute [reassoc (attr := simp)] ε_η η_ε μ_δ δ_μ
 
 section
 
-variable [F.Monoidal]
+variable (F : C ⥤ D) [F.Monoidal]
 
 /-- The isomorphism `𝟙_ D ≅ F.obj (𝟙_ C)` when `F` is a monoidal functor. -/
 @[simps]
@@ -524,6 +458,8 @@ end
 
 instance : (𝟭 C).Monoidal where
 
+variable (F : C ⥤ D) (G : D ⥤ E)
+
 instance [F.Monoidal] [G.Monoidal] : (F ⋙ G).Monoidal where
   ε_η := by simp
   η_ε := by simp
@@ -534,32 +470,33 @@ lemma toLaxMonoidal_injective : Function.Injective
     (@Monoidal.toLaxMonoidal _ _ _ _ _ _ _ : F.Monoidal → F.LaxMonoidal) := by
   intro a b eq
   ext1
-  · exact congr(($eq).ε')
-  · exact congr(($eq).μ')
-  · rw [← cancel_epi (εIso _).hom, ← η, ← η]
+  · exact congr(($eq).ε)
+  · exact congr(($eq).μ)
+  · rw [← cancel_epi (εIso _).hom]
     rw [εIso_hom, ε_η, ← @ε_η _ _ _ _ _ _ _ a, ← εIso_hom]
-    exact congr(($eq.symm).ε' ≫ _)
+    exact congr(($eq.symm).ε ≫ _)
   · ext
-    rw [← cancel_epi (μIso F _ _).hom, ← δ, ← δ]
+    rw [← cancel_epi (μIso F _ _).hom]
     rw [μIso_hom, μ_δ, ← @μ_δ _ _ _ _ _ _ _ a, ← μIso_hom]
-    exact congr(($eq.symm).μ' _ _ ≫ _)
+    exact congr(($eq.symm).μ _ _ ≫ _)
 
 lemma toOplaxMonoidal_injective : Function.Injective
     (@Monoidal.toOplaxMonoidal _ _ _ _ _ _ _ : F.Monoidal → F.OplaxMonoidal) := by
   intro a b eq
   ext1
-  · rw [← cancel_mono (εIso _).inv, ← ε, ← ε]
+  · rw [← cancel_mono (εIso _).inv]
     rw [εIso_inv, ε_η, ← @ε_η _ _ _ _ _ _ _ a, ← εIso_inv]
-    exact congr(_ ≫ ($eq.symm).η')
+    exact congr(_ ≫ ($eq.symm).η)
   · ext
-    rw [← cancel_mono (μIso F _ _).inv, ← μ, ← μ]
+    rw [← cancel_mono (μIso F _ _).inv]
     rw [μIso_inv, μ_δ, ← @μ_δ _ _ _ _ _ _ _ a, ← μIso_inv]
-    exact congr(_ ≫ ($eq.symm).δ' _ _)
-  · exact congr(($eq).η')
-  · exact congr(($eq).δ')
+    exact congr(_ ≫ ($eq.symm).δ _ _)
+  · exact congr(($eq).η)
+  · exact congr(($eq).δ)
 
 end Monoidal
 
+variable (F : C ⥤ D)
 /-- Structure which is a helper in order to show that a functor is monoidal. It
 consists of isomorphisms `εIso` and `μIso` such that the morphisms `.hom` induced
 by these isomorphisms satisfy the axioms of lax monoidal functors. -/
@@ -601,48 +538,34 @@ attribute [reassoc] left_unitality right_unitality
 variable {F} (h : F.CoreMonoidal)
 
 /-- The lax monoidal functor structure induced by a `Functor.CoreMonoidal` structure. -/
+@[simps -isSimp]
 def toLaxMonoidal : F.LaxMonoidal where
-  ε' := h.εIso.hom
-  μ' X Y := (h.μIso X Y).hom
-  left_unitality' := h.left_unitality
-  right_unitality' := h.right_unitality
-
-lemma toLaxMonoidal_ε :
-    letI := h.toLaxMonoidal
-    LaxMonoidal.ε F = h.εIso.hom := rfl
-
-lemma toLaxMonoidal_μ (X Y : C) :
-    letI := h.toLaxMonoidal
-    LaxMonoidal.μ F X Y = (h.μIso X Y).hom := rfl
+  ε := h.εIso.hom
+  μ X Y := (h.μIso X Y).hom
+  left_unitality := h.left_unitality
+  right_unitality := h.right_unitality
 
 /-- The oplax monoidal functor structure induced by a `Functor.CoreMonoidal` structure. -/
+@[simps]
 def toOplaxMonoidal : F.OplaxMonoidal where
-  η' := h.εIso.inv
-  δ' X Y := (h.μIso X Y).inv
-  δ'_natural_left _ _ := by
+  η := h.εIso.inv
+  δ X Y := (h.μIso X Y).inv
+  δ_natural_left _ _ := by
     rw [← cancel_epi (h.μIso _ _).hom, Iso.hom_inv_id_assoc,
       ← h.μIso_hom_natural_left_assoc, Iso.hom_inv_id, comp_id]
-  δ'_natural_right _ _ := by
+  δ_natural_right _ _ := by
     rw [← cancel_epi (h.μIso _ _).hom, Iso.hom_inv_id_assoc,
       ← h.μIso_hom_natural_right_assoc, Iso.hom_inv_id, comp_id]
-  oplax_associativity' X Y Z := by
+  oplax_associativity X Y Z := by
     rw [← cancel_epi (h.μIso (X ⊗ Y) Z).hom, Iso.hom_inv_id_assoc,
       ← cancel_epi ((h.μIso X Y).hom ▷ F.obj Z), hom_inv_whiskerRight_assoc,
       associativity_assoc, Iso.hom_inv_id_assoc, whiskerLeft_hom_inv, comp_id]
-  oplax_left_unitality' _ := by
+  oplax_left_unitality _ := by
     rw [← cancel_epi (λ_ _).hom, Iso.hom_inv_id, h.left_unitality, assoc, assoc,
       Iso.map_hom_inv_id_assoc, Iso.hom_inv_id_assoc,hom_inv_whiskerRight]
-  oplax_right_unitality' _ := by
+  oplax_right_unitality _ := by
     rw [← cancel_epi (ρ_ _).hom, Iso.hom_inv_id, h.right_unitality, assoc, assoc,
       Iso.map_hom_inv_id_assoc, Iso.hom_inv_id_assoc, whiskerLeft_hom_inv]
-
-lemma toOplaxMonoidal_η :
-    letI := h.toOplaxMonoidal
-    OplaxMonoidal.η F = h.εIso.inv := rfl
-
-lemma toOplaxMonoidal_δ  (X Y : C) :
-    letI := h.toOplaxMonoidal
-    OplaxMonoidal.δ F X Y = (h.μIso X Y).inv := rfl
 
 attribute [local simp] toLaxMonoidal_ε toLaxMonoidal_μ toOplaxMonoidal_η toOplaxMonoidal_δ in
 /-- The monoidal functor structure induced by a `Functor.CoreMonoidal` structure. -/
@@ -662,6 +585,7 @@ noncomputable def ofLaxMonoidal [F.LaxMonoidal] [IsIso (ε F)] [∀ X Y, IsIso (
 
 /-- The `Functor.CoreMonoidal` structure given by an oplax monoidal functor such
 that `η` and `δ` are isomorphisms. -/
+@[simps]
 noncomputable def ofOplaxMonoidal [F.OplaxMonoidal] [IsIso (η F)] [∀ X Y, IsIso (δ F X Y)] :
     F.CoreMonoidal where
   εIso := (asIso (η F)).symm
@@ -694,31 +618,31 @@ section
 variable [F.LaxMonoidal] [G.LaxMonoidal]
 
 instance : (prod F G).LaxMonoidal where
-  ε' := (ε F, ε G)
-  μ' X Y := (μ F _ _, μ G _ _)
-  μ'_natural_left _ _ := by
+  ε := (ε F, ε G)
+  μ X Y := (μ F _ _, μ G _ _)
+  μ_natural_left _ _ := by
     ext
     all_goals
       simp only [prod_obj, prodMonoidal_tensorObj, prod_map,
         prodMonoidal_whiskerRight, prod_comp, μ_natural_left]
-  μ'_natural_right _ _ := by
+  μ_natural_right _ _ := by
     ext
     all_goals
       simp only [prod_obj, prodMonoidal_tensorObj, prod_map, prodMonoidal_whiskerLeft, prod_comp,
         μ_natural_right]
-  associativity' _ _ _ := by
+  associativity _ _ _ := by
     ext
     all_goals
       simp only [prod_obj, prodMonoidal_tensorObj, prodMonoidal_whiskerRight,
         prodMonoidal_associator, Iso.prod_hom, prod_map, prod_comp,
         LaxMonoidal.associativity, prodMonoidal_whiskerLeft]
-  left_unitality' _ := by
+  left_unitality _ := by
     ext
     all_goals
       simp only [prodMonoidal_tensorUnit, prod_obj, prodMonoidal_tensorObj,
         prodMonoidal_leftUnitor_hom_fst, LaxMonoidal.left_unitality, prodMonoidal_whiskerRight,
         prod_map, prodMonoidal_leftUnitor_hom_snd, prod_comp]
-  right_unitality' _ := by
+  right_unitality _ := by
     ext
     all_goals
       simp only [prod_obj, prodMonoidal_tensorUnit, prodMonoidal_tensorObj,
@@ -737,8 +661,8 @@ section
 variable [F.OplaxMonoidal] [G.OplaxMonoidal]
 
 instance : (prod F G).OplaxMonoidal where
-  η' := (η F, η G)
-  δ' X Y := (δ F _ _, δ G _ _)
+  η := (η F, η G)
+  δ X Y := (δ F _ _, δ G _ _)
 
 @[simp] lemma prod_η_fst : (η (prod F G)).1 = η F := rfl
 @[simp] lemma prod_η_snd : (η (prod F G)).2 = η G := rfl
@@ -829,15 +753,9 @@ instance OplaxMonoidal.prod' : (prod' F G).OplaxMonoidal :=
 
 end
 
-@[simp, reassoc]
-lemma prod_comp_fst {C D : Type*} [Category C] [Category D]
-    {X Y Z : C × D} (f : X ⟶ Y) (g : Y ⟶ Z) :
-    (f ≫ g).1 = f.1 ≫ g.1 := rfl
-
-@[simp, reassoc]
-lemma prod_comp_snd {C D : Type*} [Category C] [Category D]
-    {X Y Z : C × D} (f : X ⟶ Y) (g : Y ⟶ Z) :
-    (f ≫ g).2 = f.2 ≫ g.2 := rfl
+@[deprecated (since := "2025-06-08")] alias prod_comp_fst := CategoryTheory.prod_comp_fst
+@[deprecated (since := "2025-06-08")] alias prod_comp_snd := CategoryTheory.prod_comp_snd
+-- TODO: when clearing these deprecations, remove the `CategoryTheory.` in the proof below.
 
 /-- The functor `C ⥤ D × E` obtained from two monoidal functors is monoidal. -/
 instance Monoidal.prod' [F.Monoidal] [G.Monoidal] :
@@ -845,27 +763,27 @@ instance Monoidal.prod' [F.Monoidal] [G.Monoidal] :
   -- automation should work, but it is terribly slow
   ε_η := by
     ext
-    · simp only [prod_comp_fst, prod'_ε_fst, prod'_η_fst, ε_η,
+    · simp only [CategoryTheory.prod_comp_fst, prod'_ε_fst, prod'_η_fst, ε_η,
         prodMonoidal_tensorUnit, prod_id]
-    · simp only [prod_comp_snd, prod'_ε_snd, prod'_η_snd, ε_η,
+    · simp only [CategoryTheory.prod_comp_snd, prod'_ε_snd, prod'_η_snd, ε_η,
         prodMonoidal_tensorUnit, prod_id]
   η_ε := by
     ext
-    · simp only [prod_comp_fst, prod'_ε_fst, prod'_η_fst, η_ε,
+    · simp only [CategoryTheory.prod_comp_fst, prod'_ε_fst, prod'_η_fst, η_ε,
         prod_id, prod'_obj]
-    · simp only [prod_comp_snd, prod'_ε_snd, prod'_η_snd, η_ε,
+    · simp only [CategoryTheory.prod_comp_snd, prod'_ε_snd, prod'_η_snd, η_ε,
         prod_id, prod'_obj]
   μ_δ _ _ := by
     ext
-    · simp only [prod_comp_fst, prod'_μ_fst, prod'_δ_fst, μ_δ,
+    · simp only [CategoryTheory.prod_comp_fst, prod'_μ_fst, prod'_δ_fst, μ_δ,
         prod'_obj, prodMonoidal_tensorObj, prod_id]
-    · simp only [prod_comp_snd, prod'_μ_snd, prod'_δ_snd, μ_δ,
+    · simp only [CategoryTheory.prod_comp_snd, prod'_μ_snd, prod'_δ_snd, μ_δ,
         prod'_obj, prodMonoidal_tensorObj, prod_id]
   δ_μ _ _ := by
     ext
-    · simp only [prod_comp_fst, prod'_μ_fst, prod'_δ_fst, δ_μ,
+    · simp only [CategoryTheory.prod_comp_fst, prod'_μ_fst, prod'_δ_fst, δ_μ,
         prod'_obj, prod_id]
-    · simp only [prod_comp_snd, prod'_μ_snd, prod'_δ_snd, δ_μ,
+    · simp only [CategoryTheory.prod_comp_snd, prod'_μ_snd, prod'_δ_snd, δ_μ,
         prod'_obj, prod_id]
 
 end Prod'
@@ -882,22 +800,23 @@ section LaxMonoidal
 variable [F.OplaxMonoidal]
 
 /-- The right adjoint of an oplax monoidal functor is lax monoidal. -/
+@[simps]
 def rightAdjointLaxMonoidal : G.LaxMonoidal where
-  ε' := adj.homEquiv _ _ (η F)
-  μ' X Y := adj.homEquiv _ _ (δ F _ _ ≫ (adj.counit.app X ⊗ adj.counit.app Y))
-  μ'_natural_left {X Y} f X' := by
+  ε := adj.homEquiv _ _ (η F)
+  μ X Y := adj.homEquiv _ _ (δ F _ _ ≫ (adj.counit.app X ⊗ adj.counit.app Y))
+  μ_natural_left {X Y} f X' := by
     simp only [Adjunction.homEquiv_apply, ← adj.unit_naturality_assoc, ← G.map_comp, assoc,
       ← δ_natural_left_assoc F]
     suffices F.map (G.map f) ▷ F.obj (G.obj X') ≫ _ =
       (adj.counit.app X ⊗ adj.counit.app X') ≫ _ by rw [this]
     simpa using NatTrans.whiskerRight_app_tensor_app adj.counit adj.counit (f := f) X'
-  μ'_natural_right {X' Y'} X g := by
+  μ_natural_right {X' Y'} X g := by
     simp only [Adjunction.homEquiv_apply, ← adj.unit_naturality_assoc, ← G.map_comp,
       assoc, ← δ_natural_right_assoc F]
     suffices F.obj (G.obj X) ◁ F.map (G.map g) ≫ _ =
       (adj.counit.app X ⊗ adj.counit.app X') ≫ _ by rw [this]
     simpa using NatTrans.whiskerLeft_app_tensor_app adj.counit adj.counit (f := g) _
-  associativity' X Y Z := (adj.homEquiv _ _).symm.injective (by
+  associativity X Y Z := (adj.homEquiv _ _).symm.injective (by
     simp only [homEquiv_unit, comp_obj, map_comp, comp_whiskerRight, assoc, homEquiv_counit,
       counit_naturality, id_obj, counit_naturality_assoc, left_triangle_components_assoc,
       MonoidalCategory.whiskerLeft_comp]
@@ -915,7 +834,7 @@ def rightAdjointLaxMonoidal : G.LaxMonoidal where
       ← MonoidalCategory.whiskerLeft_comp_assoc, assoc, assoc,
       counit_naturality, counit_naturality_assoc, left_triangle_components_assoc,
       MonoidalCategory.whiskerLeft_comp, assoc, tensorHom_def, whisker_exchange])
-  left_unitality' X := (adj.homEquiv _ _).symm.injective (by
+  left_unitality X := (adj.homEquiv _ _).symm.injective (by
     rw [homEquiv_counit, homEquiv_counit, homEquiv_unit, homEquiv_unit, comp_whiskerRight,
       map_comp, map_comp, map_comp, map_comp, map_comp, map_comp, assoc, assoc, assoc, assoc,
       assoc, counit_naturality, counit_naturality_assoc, counit_naturality_assoc,
@@ -924,7 +843,7 @@ def rightAdjointLaxMonoidal : G.LaxMonoidal where
       ← MonoidalCategory.comp_whiskerRight_assoc, assoc, counit_naturality,
       left_triangle_components_assoc, id_whiskerLeft, assoc, assoc, Iso.inv_hom_id, comp_id,
       left_unitality_hom_assoc])
-  right_unitality' X := (adj.homEquiv _ _).symm.injective (by
+  right_unitality X := (adj.homEquiv _ _).symm.injective (by
     rw [homEquiv_counit, homEquiv_unit, MonoidalCategory.whiskerLeft_comp, homEquiv_unit,
       homEquiv_counit, map_comp, map_comp, map_comp, map_comp, map_comp, map_comp,
       assoc, assoc, assoc, assoc, assoc, counit_naturality, counit_naturality_assoc,
@@ -933,14 +852,6 @@ def rightAdjointLaxMonoidal : G.LaxMonoidal where
       ← MonoidalCategory.whiskerLeft_comp_assoc, ← MonoidalCategory.whiskerLeft_comp_assoc,
       assoc, counit_naturality, left_triangle_components_assoc, MonoidalCategory.whiskerRight_id,
       assoc, assoc, Iso.inv_hom_id, comp_id, right_unitality_hom_assoc])
-
-lemma rightAdjointLaxMonoidal_ε :
-    letI := adj.rightAdjointLaxMonoidal
-    ε G = adj.homEquiv _ _ (η F) := rfl
-
-lemma rightAdjointLaxMonoidal_μ (X Y : D) :
-    letI := adj.rightAdjointLaxMonoidal
-    μ G X Y = adj.homEquiv _ _ (δ F _ _ ≫ (adj.counit.app X ⊗ adj.counit.app Y)) := rfl
 
 /-- When `adj : F ⊣ G` is an adjunction, with `F` oplax monoidal and `G` lax-monoidal,
 this typeclass expresses compatibilities between the adjunction and the (op)lax

--- a/Mathlib/CategoryTheory/Monoidal/Limits.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Limits.lean
@@ -34,11 +34,11 @@ open Functor.LaxMonoidal
 
 instance : (lim (J := J) (C := C)).LaxMonoidal :=
   Functor.LaxMonoidal.ofTensorHom
-    (ε' :=
+    (ε :=
       limit.lift _
         { pt := _
           π := { app := fun _ => 𝟙 _ } })
-    (μ' := fun F G ↦
+    (μ := fun F G ↦
       limit.lift (F ⊗ G)
         { pt := limit F ⊗ limit G
           π :=
@@ -46,11 +46,11 @@ instance : (lim (J := J) (C := C)).LaxMonoidal :=
               naturality := fun j j' f => by
                 dsimp
                 simp only [Category.id_comp, ← tensor_comp, limit.w] } })
-    (μ'_natural := fun f g ↦ limit.hom_ext (fun j ↦ by
+    (μ_natural := fun f g ↦ limit.hom_ext (fun j ↦ by
       dsimp
       simp only [limit.lift_π, Cones.postcompose_obj_π, Monoidal.tensorHom_app, limit.lift_map,
         NatTrans.comp_app, Category.assoc, ← tensor_comp, limMap_π]))
-    (associativity' := fun F G H ↦ limit.hom_ext (fun j ↦ by
+    (associativity := fun F G H ↦ limit.hom_ext (fun j ↦ by
       dsimp
       simp only [tensorHom_id, limit.lift_map, Category.assoc, limit.lift_π,
         id_tensorHom]
@@ -68,7 +68,7 @@ instance : (lim (J := J) (C := C)).LaxMonoidal :=
         ← associator_naturality_middle_assoc,
         ← associator_naturality_right, ← comp_whiskerRight_assoc,
         ← tensorHom_def, ← tensorHom_def_assoc]))
-    (left_unitality' := fun F ↦ limit.hom_ext (fun j ↦ by
+    (left_unitality := fun F ↦ limit.hom_ext (fun j ↦ by
       dsimp
       simp only [tensorHom_id, limit.lift_map, Category.assoc, limit.lift_π]
       dsimp
@@ -76,7 +76,7 @@ instance : (lim (J := J) (C := C)).LaxMonoidal :=
         Iso.inv_hom_id, Category.comp_id, ← comp_whiskerRight_assoc]
       erw [limit.lift_π]
       rw [id_whiskerRight, Category.id_comp]))
-    (right_unitality' := fun F ↦ limit.hom_ext (fun j ↦ by
+    (right_unitality := fun F ↦ limit.hom_ext (fun j ↦ by
       dsimp
       simp only [id_tensorHom, limit.lift_map, Category.assoc, limit.lift_π]
       dsimp

--- a/Mathlib/CategoryTheory/Monoidal/Mon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Mon_.lean
@@ -415,8 +415,8 @@ def monToLaxMonoidalObj (A : Mon_ C) :
     Discrete PUnit.{u + 1} ⥤ C := (Functor.const _).obj A.X
 
 instance (A : Mon_ C) : (monToLaxMonoidalObj A).LaxMonoidal where
-  ε' := η[A.X]
-  μ' := fun _ _ => μ[A.X]
+  ε := η[A.X]
+  «μ» _ _ := μ[A.X]
 
 @[simp]
 lemma monToLaxMonoidalObj_ε (A : Mon_ C) :

--- a/Mathlib/CategoryTheory/Monoidal/OfHasFiniteProducts.lean
+++ b/Mathlib/CategoryTheory/Monoidal/OfHasFiniteProducts.lean
@@ -265,11 +265,11 @@ variable {D : Type*} [Category D] (F : C ⥤ D)
 
 attribute [local simp] associator_hom_fst
 instance : F.OplaxMonoidal where
-  η' := terminalComparison F
-  δ' X Y := prodComparison F X Y
-  δ'_natural_left _ _ := by simp [prodComparison_natural]
-  δ'_natural_right _ _ := by simp [prodComparison_natural]
-  oplax_associativity' _ _ _ := by
+  η := terminalComparison F
+  δ X Y := prodComparison F X Y
+  δ_natural_left _ _ := by simp [prodComparison_natural]
+  δ_natural_right _ _ := by simp [prodComparison_natural]
+  oplax_associativity _ _ _ := by
     dsimp
     ext
     · dsimp
@@ -287,8 +287,8 @@ instance : F.OplaxMonoidal where
         Functor.map_comp]
       erw [associator_hom_snd_snd, associator_hom_snd_snd]
       simp
-  oplax_left_unitality' _ := by ext; simp [← Functor.map_comp]
-  oplax_right_unitality' _ := by ext; simp [← Functor.map_comp]
+  oplax_left_unitality _ := by ext; simp [← Functor.map_comp]
+  oplax_right_unitality _ := by ext; simp [← Functor.map_comp]
 
 open Functor.OplaxMonoidal
 

--- a/Mathlib/CategoryTheory/Monoidal/Opposite.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Opposite.lean
@@ -364,21 +364,23 @@ def MonoidalOpposite.tensorRightUnmopIso (X : Cᴹᵒᵖ) :
     tensorRight (unmop X) ≅ mopFunctor C ⋙ tensorLeft X ⋙ unmopFunctor C :=
   Iso.refl _
 
+@[simps]
 instance monoidalOpOp : (opOp C).Monoidal where
-  ε' := 𝟙 _
-  η' := 𝟙 _
-  μ' X Y := 𝟙 _
-  δ' X Y := 𝟙 _
+  ε := 𝟙 _
+  η := 𝟙 _
+  μ X Y := 𝟙 _
+  δ X Y := 𝟙 _
   ε_η := Category.comp_id _
   η_ε := Category.comp_id _
   μ_δ X Y := Category.comp_id _
   δ_μ X Y := Category.comp_id _
 
+@[simps]
 instance monoidalUnopUnop : (unopUnop C).Monoidal where
-  ε' := 𝟙 _
-  η' := 𝟙 _
-  μ' X Y := 𝟙 _
-  δ' X Y := 𝟙 _
+  ε := 𝟙 _
+  η := 𝟙 _
+  μ X Y := 𝟙 _
+  δ X Y := 𝟙 _
   ε_η := Category.comp_id _
   η_ε := Category.comp_id _
   μ_δ X Y := Category.comp_id _
@@ -387,14 +389,14 @@ instance monoidalUnopUnop : (unopUnop C).Monoidal where
 instance : (opOpEquivalence C).functor.Monoidal := monoidalUnopUnop
 instance : (opOpEquivalence C).inverse.Monoidal := monoidalOpOp
 
-@[simp] lemma opOp_ε : ε (opOp C) = 𝟙 (𝟙_ Cᵒᵖᵒᵖ) := rfl
-@[simp] lemma opOp_η : η (opOp C) = 𝟙 _ := rfl
-@[simp] lemma unopUnop_ε : ε (unopUnop C) = 𝟙 _ := rfl
-@[simp] lemma unopUnop_η : η (unopUnop C) = 𝟙 _ := rfl
-@[simp] lemma opOp_μ (X Y) : μ (opOp C) X Y = 𝟙 _ := rfl
-@[simp] lemma opOp_δ (X Y) : δ (opOp C) X Y = 𝟙 _ := rfl
-@[simp] lemma unopUnop_μ (X Y) : μ (unopUnop C) X Y = 𝟙 _ := rfl
-@[simp] lemma unopUnop_δ (X Y) : δ (unopUnop C) X Y = 𝟙 _ := rfl
+@[deprecated (since := "2025-06-08")] alias opOp_ε := monoidalOpOp_ε
+@[deprecated (since := "2025-06-08")] alias opOp_η := monoidalOpOp_η
+@[deprecated (since := "2025-06-08")] alias unopUnop_ε := monoidalUnopUnop_ε
+@[deprecated (since := "2025-06-08")] alias unopUnop_η := monoidalUnopUnop_η
+@[deprecated (since := "2025-06-08")] alias opOp_μ := monoidalOpOp_μ
+@[deprecated (since := "2025-06-08")] alias opOp_δ := monoidalOpOp_δ
+@[deprecated (since := "2025-06-08")] alias unopUnop_μ := monoidalUnopUnop_μ
+@[deprecated (since := "2025-06-08")] alias unopUnop_δ := monoidalUnopUnop_δ
 
 instance : (opOpEquivalence C).IsMonoidal where
   leftAdjoint_ε := by simp [Adjunction.homEquiv, opOpEquivalence]

--- a/Mathlib/CategoryTheory/Monoidal/Types/Coyoneda.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Types/Coyoneda.lean
@@ -19,10 +19,10 @@ open Opposite MonoidalCategory
 instance (C : Type u) [Category.{v} C] [MonoidalCategory C] :
     (coyoneda.obj (op (𝟙_ C))).LaxMonoidal :=
   Functor.LaxMonoidal.ofTensorHom
-    (ε' := fun _ => 𝟙 _)
-    (μ' := fun X Y p ↦ (λ_ (𝟙_ C)).inv ≫ (p.1 ⊗ p.2))
-    (μ'_natural := by aesop_cat)
-    (associativity' := fun X Y Z => by
+    (ε := fun _ => 𝟙 _)
+    (μ := fun X Y p ↦ (λ_ (𝟙_ C)).inv ≫ (p.1 ⊗ p.2))
+    (μ_natural := by aesop_cat)
+    (associativity := fun X Y Z => by
       ext ⟨⟨f, g⟩, h⟩; dsimp at f g h
       dsimp; simp only [Iso.cancel_iso_inv_left, Category.assoc]
       conv_lhs =>
@@ -30,11 +30,11 @@ instance (C : Type u) [Category.{v} C] [MonoidalCategory C] :
           ← Category.assoc, unitors_inv_equal, tensorHom_id, triangle_assoc_comp_right_inv]
       conv_rhs => rw [← Category.id_comp f, tensor_comp]
       simp)
-    (left_unitality' := by
+    (left_unitality := by
       intros
       ext ⟨⟨⟩, f⟩; dsimp at f
       simp)
-    (right_unitality' := fun X => by
+    (right_unitality := fun X => by
       ext ⟨f, ⟨⟩⟩; dsimp at f
       simp [unitors_inv_equal])
 


### PR DESCRIPTION
Discussed in #25628. We use the new language feature that allows to change expliciteness of binders in the definition of classes. Hence, the "primed" versions of `Functor.LaxMonoidal.μ`, `Functor.LaxMonoidal.ε`, `Functor.OplaxMonoidal.δ` and `Functor.OplaxMonoidal.η` are not needed anymore, as well as the primed version of attached lemmas.

This refactor introduces a bunch of deprecations, as `simps` now become a viable attribute for `LaxMonoidal` and `OplaxMonoidal` classes. These attribute are not systematically applied though, as in some cases the name of the lemmas might be bad. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
