### PR TITLE
[Merged by Bors] - feat: add path component of the identity in a locally path connected topological group, as an open normal subgroup

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6077,6 +6077,7 @@ import Mathlib.Topology.Connected.Basic
 import Mathlib.Topology.Connected.Clopen
 import Mathlib.Topology.Connected.LocPathConnected
 import Mathlib.Topology.Connected.LocallyConnected
+import Mathlib.Topology.Connected.PathComponentOne
 import Mathlib.Topology.Connected.PathConnected
 import Mathlib.Topology.Connected.Separation
 import Mathlib.Topology.Connected.TotallyDisconnected

--- a/Mathlib/Topology/Connected/LocPathConnected.lean
+++ b/Mathlib/Topology/Connected/LocPathConnected.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Ben Eltschig
 -/
 import Mathlib.Topology.Connected.PathConnected
-import Mathlib.Topology.Algebra.OpenSubgroup
 
 /-!
 # Locally path-connected spaces
@@ -220,30 +219,3 @@ instance Sigma.locPathConnectedSpace {X : ι → Type*}
   · exact ⟨x.2, mem_pathComponentIn_self hxu, rfl⟩
 
 end LocPathConnectedSpace
-
-section PathComponentOne
-
-variable (G : Type*) [TopologicalSpace G]
-
-/-- The path component of the identity in a locally path connected topological group,
-as an open normal subgroup. It is, in fact, clopen. -/
-@[to_additive (attr := simps!)
-"The path component of the identity in a locally path connected additive topological group,
-as an open normal additive subgroup. It is, in fact, clopen."]
-def OpenNormalSubgroup.pathComponentOne [Group G]
-    [IsTopologicalGroup G] [LocPathConnectedSpace G] :
-    OpenNormalSubgroup (G) where
-  toSubgroup := .pathComponentOne G
-  isOpen' := .pathComponent 1
-  isNormal' := .pathComponentOne G
-
-namespace OpenNormalSubgroup
-
-@[to_additive]
-instance [Group G] [IsTopologicalGroup G] [LocPathConnectedSpace G] :
-    IsClosed (OpenNormalSubgroup.pathComponentOne G : Set G) :=
-  .pathComponent 1
-
-end OpenNormalSubgroup
-
-end PathComponentOne

--- a/Mathlib/Topology/Connected/LocPathConnected.lean
+++ b/Mathlib/Topology/Connected/LocPathConnected.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Ben Eltschig
 -/
 import Mathlib.Topology.Connected.PathConnected
+import Mathlib.Topology.Algebra.OpenSubgroup
 
 /-!
 # Locally path-connected spaces
@@ -219,3 +220,30 @@ instance Sigma.locPathConnectedSpace {X : ι → Type*}
   · exact ⟨x.2, mem_pathComponentIn_self hxu, rfl⟩
 
 end LocPathConnectedSpace
+
+section PathComponentOne
+
+variable (G : Type*) [TopologicalSpace G]
+
+/-- The path component of the identity in a locally path connected topological group,
+as an open normal subgroup. It is, in fact, clopen. -/
+@[to_additive (attr := simps!)
+"The path component of the identity in a locally path connected additive topological group,
+as an open normal additive subgroup. It is, in fact, clopen."]
+def OpenNormalSubgroup.pathComponentOne [Group G]
+    [IsTopologicalGroup G] [LocPathConnectedSpace G] :
+    OpenNormalSubgroup (G) where
+  toSubgroup := .pathComponentOne G
+  isOpen' := .pathComponent 1
+  isNormal' := .pathComponentOne G
+
+namespace OpenNormalSubgroup
+
+@[to_additive]
+instance [Group G] [IsTopologicalGroup G] [LocPathConnectedSpace G] :
+    IsClosed (OpenNormalSubgroup.pathComponentOne G : Set G) :=
+  .pathComponent 1
+
+end OpenNormalSubgroup
+
+end PathComponentOne

--- a/Mathlib/Topology/Connected/PathComponentOne.lean
+++ b/Mathlib/Topology/Connected/PathComponentOne.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2025 Jireh Loreaux. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jireh Loreaux
+-/
 import Mathlib.Topology.Algebra.OpenSubgroup
 import Mathlib.Topology.Connected.LocPathConnected
 

--- a/Mathlib/Topology/Connected/PathComponentOne.lean
+++ b/Mathlib/Topology/Connected/PathComponentOne.lean
@@ -1,0 +1,36 @@
+import Mathlib.Topology.Algebra.OpenSubgroup
+import Mathlib.Topology.Connected.LocPathConnected
+
+/-! # The path component of the identity in a locally path connected topological group
+
+This file defines the path component of the identity is an `OpenNormalSubgroup` when the ambient
+topological group is locally path connected. We place this in a separate file to avoid importing
+additional algebra into the topology hierarchy.
+-/
+
+section PathComponentOne
+
+variable (G : Type*) [TopologicalSpace G]
+
+/-- The path component of the identity in a locally path connected topological group,
+as an open normal subgroup. It is, in fact, clopen. -/
+@[to_additive (attr := simps!)
+"The path component of the identity in a locally path connected additive topological group,
+as an open normal additive subgroup. It is, in fact, clopen."]
+def OpenNormalSubgroup.pathComponentOne [Group G]
+    [IsTopologicalGroup G] [LocPathConnectedSpace G] :
+    OpenNormalSubgroup (G) where
+  toSubgroup := .pathComponentOne G
+  isOpen' := .pathComponent 1
+  isNormal' := .pathComponentOne G
+
+namespace OpenNormalSubgroup
+
+@[to_additive]
+instance [Group G] [IsTopologicalGroup G] [LocPathConnectedSpace G] :
+    IsClosed (OpenNormalSubgroup.pathComponentOne G : Set G) :=
+  .pathComponent 1
+
+end OpenNormalSubgroup
+
+end PathComponentOne

--- a/Mathlib/Topology/Connected/PathConnected.lean
+++ b/Mathlib/Topology/Connected/PathConnected.lean
@@ -77,6 +77,19 @@ theorem Joined.mul {M : Type*} [Mul M] [TopologicalSpace M] [ContinuousMul M]
     {a b c d : M} (hs : Joined a b) (ht : Joined c d) : Joined (a * c) (b * d) :=
   ⟨hs.somePath.mul ht.somePath⟩
 
+@[to_additive]
+theorem Joined.listProd {M : Type*} [MulOneClass M] [TopologicalSpace M] [ContinuousMul M]
+    {l l' : List M} (h : List.Forall₂ Joined l l') :
+    Joined l.prod l'.prod := by
+  induction h with
+  | nil => rfl
+  | cons h₁ _ h₂ => exact h₁.mul h₂
+
+@[to_additive]
+theorem Joined.inv {G : Type*} [Inv G] [TopologicalSpace G] [ContinuousInv G]
+    {x y : G} (h : Joined x y) : Joined x⁻¹ y⁻¹ :=
+  ⟨h.somePath.inv⟩
+
 variable (X)
 
 /-- The setoid corresponding the equivalence relation of being joined by a continuous path. -/
@@ -201,6 +214,12 @@ theorem JoinedIn.mul {M : Type*} [Mul M] [TopologicalSpace M] [ContinuousMul M]
     JoinedIn (s * t) (a * c) (b * d) :=
   ⟨hs.somePath.mul ht.somePath, fun t ↦ Set.mul_mem_mul (hs.somePath_mem t) (ht.somePath_mem t)⟩
 
+@[to_additive]
+theorem JoinedIn.inv {G : Type*} [InvolutiveInv G] [TopologicalSpace G] [ContinuousInv G]
+    {s : Set G} {a b : G} (hs : JoinedIn s a b) :
+    JoinedIn s⁻¹ a⁻¹ b⁻¹ :=
+  ⟨hs.somePath.inv, fun t ↦ Set.inv_mem_inv.mpr (hs.somePath_mem t)⟩
+
 /-! ### Path component -/
 
 /-- The path component of `x` is the set of points that can be joined to `x`. -/
@@ -267,6 +286,31 @@ theorem pathComponentIn_mono {G : Set X} (h : F ⊆ G) :
     pathComponentIn x F ⊆ pathComponentIn x G :=
   fun _ ⟨γ, hγ⟩ ↦ ⟨γ, fun t ↦ h (hγ t)⟩
 
+/-! ### Path component of the identity in a group -/
+
+/-- The path component of the identity in a topological monoid, as a submonoid. -/
+@[to_additive (attr := simps)
+"The path component of the identity in an additive topological monoid, as an additive submonoid."]
+def Submonoid.pathComponentOne (M : Type*) [Monoid M] [TopologicalSpace M] [ContinuousMul M] :
+    Submonoid M where
+  carrier := pathComponent (1 : M)
+  mul_mem' {m₁ m₂} hm₁ hm₂ := by simpa using hm₁.mul hm₂
+  one_mem' := mem_pathComponent_self 1
+
+/-- The path component of the identity in a topological group, as a subgroup. -/
+@[to_additive (attr := simps!)
+"The path component of the identity in an additive topological group, as an additive subgroup."]
+def Subgroup.pathComponentOne (G : Type*) [Group G] [TopologicalSpace G] [IsTopologicalGroup G] :
+    Subgroup G where
+  toSubmonoid := .pathComponentOne G
+  inv_mem' {g} hg := by simpa using hg.inv
+
+/-- The path component of the identity in a topological group is normal. -/
+@[to_additive]
+instance Subgroup.Normal.pathComponentOne (G : Type*) [Group G] [TopologicalSpace G]
+    [IsTopologicalGroup G] : (Subgroup.pathComponentOne G).Normal where
+  conj_mem _ := fun ⟨γ⟩ g ↦ ⟨⟨⟨(g * γ · * g⁻¹), by fun_prop⟩, by simp, by simp⟩⟩
+
 /-! ### Path connected sets -/
 
 
@@ -312,6 +356,13 @@ theorem IsPathConnected.mul {M : Type*} [Mul M] [TopologicalSpace M] [Continuous
     IsPathConnected (s * t) :=
   let ⟨a, ha_mem, ha⟩ := hs; let ⟨b, hb_mem, hb⟩ := ht
   ⟨a * b, mul_mem_mul ha_mem hb_mem, Set.forall_mem_image2.2 fun _x hx _y hy ↦ (ha hx).mul (hb hy)⟩
+
+@[to_additive]
+theorem IsPathConnected.inv {G : Type*} [InvolutiveInv G] [TopologicalSpace G] [ContinuousInv G]
+    {s : Set G} (hs : IsPathConnected s) :
+    IsPathConnected s⁻¹ :=
+  let ⟨a, ha_mem, ha⟩ := hs
+  ⟨a⁻¹, inv_mem_inv.mpr ha_mem, fun x hx ↦ by simpa using ha (mem_inv.mp hx) |>.map continuous_inv⟩
 
 /-- If `f : X → Y` is an inducing map, `f(F)` is path-connected iff `F` is. -/
 nonrec theorem Topology.IsInducing.isPathConnected_iff {f : X → Y} (hf : IsInducing f) :

--- a/Mathlib/Topology/Path.lean
+++ b/Mathlib/Topology/Path.lean
@@ -495,20 +495,20 @@ theorem trans_pi_eq_pi_trans (γ₀ : ∀ i, Path (as i) (bs i)) (γ₁ : ∀ i,
 
 end Pi
 
-/-! #### Pointwise multiplication/addition of two paths in a topological (additive) group -/
+/-! #### Pointwise operations on paths in a topological (additive) group -/
 
 
-/-- Pointwise multiplication of paths in a topological group. The additive version is probably more
-useful. -/
-@[to_additive "Pointwise addition of paths in a topological additive group."]
+/-- Pointwise multiplication of paths in a topological group. -/
+@[to_additive (attr := simps!) "Pointwise addition of paths in a topological additive group."]
 protected def mul [Mul X] [ContinuousMul X] {a₁ b₁ a₂ b₂ : X} (γ₁ : Path a₁ b₁) (γ₂ : Path a₂ b₂) :
     Path (a₁ * a₂) (b₁ * b₂) :=
   (γ₁.prod γ₂).map continuous_mul
 
-@[to_additive (attr := simp)]
-protected theorem mul_apply [Mul X] [ContinuousMul X] {a₁ b₁ a₂ b₂ : X} (γ₁ : Path a₁ b₁)
-    (γ₂ : Path a₂ b₂) (t : unitInterval) : (γ₁.mul γ₂) t = γ₁ t * γ₂ t :=
-  rfl
+/-- Pointwise inversion of paths in a topological group. -/
+@[to_additive (attr := simps!) "Pointwise negation of paths in a topological group."]
+def inv {a b : X} [Inv X] [ContinuousInv X] (γ : Path a b) :
+    Path a⁻¹ b⁻¹ :=
+  γ.map continuous_inv
 
 /-! #### Truncating a path -/
 


### PR DESCRIPTION
---

Original PR: #25266

From [LeanOA](https://github.com/j-loreaux/LeanOA)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
