### PR TITLE
[Merged by Bors] - chore(Data/Set/Basic): deprecate lemmas that abuse the `Set α := α → Prop` defeq

### DIFF
--- a/Mathlib/Algebra/BigOperators/Associated.lean
+++ b/Mathlib/Algebra/BigOperators/Associated.lean
@@ -97,16 +97,15 @@ theorem divisor_closure_eq_closure [CancelCommMonoidWithZero α]
     · rcases ha₁.exists_right_inv with ⟨k, hk⟩
       refine hind x (y*k) ?_ hs ?_
       · simp only [← mul_assoc, ← hprod, ← Multiset.prod_cons, mul_comm]
-        refine multiset_prod_mem _ _ (Multiset.forall_mem_cons.2 ⟨subset_closure (Set.mem_def.2 ?_),
-          Multiset.forall_mem_cons.2 ⟨subset_closure (Set.mem_def.2 ?_), (fun t ht =>
-          subset_closure (hs t ht))⟩⟩)
+        refine multiset_prod_mem _ _ (Multiset.forall_mem_cons.2 ⟨subset_closure ?_,
+          Multiset.forall_mem_cons.2 ⟨subset_closure ?_, fun t ht => subset_closure (hs t ht)⟩⟩)
         · left; exact isUnit_of_mul_eq_one_right _ _ hk
         · left; exact ha₁
       · rw [← mul_one s.prod, ← hk, ← mul_assoc, ← mul_assoc, mul_eq_mul_right_iff, mul_comm]
         left; exact hprod
     · rcases ha₂.dvd_mul.1 (Dvd.intro _ hprod) with ⟨c, hc⟩ | ⟨c, hc⟩
       · rw [hc]; rw [hc, mul_assoc] at hprod
-        refine Submonoid.mul_mem _ (subset_closure (Set.mem_def.2 ?_))
+        refine Submonoid.mul_mem _ (subset_closure ?_)
           (hind _ _ ?_ hs (mul_left_cancel₀ ha₂.ne_zero hprod))
         · right; exact ha₂
         rw [← mul_left_cancel₀ ha₂.ne_zero hprod]

--- a/Mathlib/Algebra/Polynomial/EraseLead.lean
+++ b/Mathlib/Algebra/Polynomial/EraseLead.lean
@@ -366,7 +366,7 @@ theorem card_support_eq {n : ℕ} :
         Function.extend Fin.castSucc x fun _ => f.leadingCoeff, ?_, ?_, ?_⟩
     · intro i j hij
       have hi : i ∈ Set.range (Fin.castSucc : Fin n → Fin (n + 1)) := by
-        rw [Fin.range_castSucc, Set.mem_def]
+        simp only [Fin.range_castSucc, Nat.succ_eq_add_one, Set.mem_setOf_eq]
         exact lt_of_lt_of_le hij (Nat.lt_succ_iff.mp j.2)
       obtain ⟨i, rfl⟩ := hi
       rw [Fin.strictMono_castSucc.injective.extend_apply]

--- a/Mathlib/CategoryTheory/Sites/Pretopology.lean
+++ b/Mathlib/CategoryTheory/Sites/Pretopology.lean
@@ -128,11 +128,9 @@ theorem mem_toGrothendieck (K : Pretopology C) (X S) :
 See [MM92] Chapter III, Section 2, Equations (3,4).
 -/
 def ofGrothendieck (J : GrothendieckTopology C) : Pretopology C where
-  coverings X R := Sieve.generate R ∈ J X
+  coverings X := {R | Sieve.generate R ∈ J X}
   has_isos X Y f i := J.covering_of_eq_top (by simp)
-  pullbacks X Y f R hR := by
-    simp only [Set.mem_def, Sieve.pullbackArrows_comm]
-    apply J.pullback_stable f hR
+  pullbacks X Y f R hR := by simpa [Sieve.pullbackArrows_comm] using J.pullback_stable f hR
   transitive X S Ti hS hTi := by
     apply J.transitive hS
     intro Y f

--- a/Mathlib/Combinatorics/SimpleGraph/Diam.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Diam.lean
@@ -400,8 +400,7 @@ def center (G : SimpleGraph α) : Set α :=
 lemma center_nonempty [Nonempty α] : G.center.Nonempty :=
   exists_eccent_eq_radius
 
-lemma mem_center_iff (u : α) : u ∈ G.center ↔ G.eccent u = G.radius :=
-  Set.mem_def
+lemma mem_center_iff (u : α) : u ∈ G.center ↔ G.eccent u = G.radius := .rfl
 
 lemma center_eq_univ_iff_radius_eq_ediam [Nonempty α] :
     G.center = Set.univ ↔ G.radius = G.ediam := by

--- a/Mathlib/Combinatorics/SimpleGraph/Finite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Finite.lean
@@ -496,9 +496,8 @@ theorem card_edgeFinset_induce_support :
   card_edgeFinset_induce_of_support_subset subset_rfl
 
 theorem map_neighborFinset_induce [DecidableEq V] (v : s) :
-    ((G.induce s).neighborFinset v).map (.subtype s)
-      = G.neighborFinset v ∩ s.toFinset := by
-  ext; simp [Set.mem_def]
+    ((G.induce s).neighborFinset v).map (.subtype (· ∈ s)) = G.neighborFinset v ∩ s.toFinset := by
+  ext; simp
 
 theorem map_neighborFinset_induce_of_neighborSet_subset {v : s} (h : G.neighborSet v ⊆ s) :
     ((G.induce s).neighborFinset v).map (.subtype s) = G.neighborFinset v := by

--- a/Mathlib/Data/Fintype/List.lean
+++ b/Mathlib/Data/Fintype/List.lean
@@ -100,7 +100,7 @@ instance fintypeNodupList [Fintype α] : Fintype { l : List α // l.Nodup } := b
     constructor
     · intro h
       rcases h with ⟨f, hf⟩
-      convert  Set.mem_def.mpr f.nodup
+      convert f.nodup
       rw [hf]
       rfl
     · intro h

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -225,15 +225,18 @@ theorem notMem_setOf_iff {a : α} {p : α → Prop} : a ∉ { x | p x } ↔ ¬p 
 theorem setOf_mem_eq {s : Set α} : { x | x ∈ s } = s :=
   rfl
 
-@[deprecated "This lemma abuses the `Set α := α → Prop`" (since := "2025-06-10")]
+@[deprecated "This lemma abuses the `Set α := α → Prop` defeq.
+If you think you need it you have already taken a wrong turn." (since := "2025-06-10")]
 theorem setOf_set {s : Set α} : setOf s = s :=
   rfl
 
-@[deprecated "This lemma abuses the `Set α := α → Prop`" (since := "2025-06-10")]
+@[deprecated "This lemma abuses the `Set α := α → Prop` defeq.
+If you think you need it you have already taken a wrong turn." (since := "2025-06-10")]
 theorem setOf_app_iff {p : α → Prop} {x : α} : { x | p x } x ↔ p x :=
   Iff.rfl
 
-@[deprecated "This lemma abuses the `Set α := α → Prop`" (since := "2025-06-10")]
+@[deprecated "This lemma abuses the `Set α := α → Prop` defeq.
+If you think you need it you have already taken a wrong turn." (since := "2025-06-10")]
 theorem mem_def {a : α} {s : Set α} : a ∈ s ↔ s a :=
   Iff.rfl
 

--- a/Mathlib/Data/Set/Basic.lean
+++ b/Mathlib/Data/Set/Basic.lean
@@ -225,12 +225,15 @@ theorem notMem_setOf_iff {a : α} {p : α → Prop} : a ∉ { x | p x } ↔ ¬p 
 theorem setOf_mem_eq {s : Set α} : { x | x ∈ s } = s :=
   rfl
 
+@[deprecated "This lemma abuses the `Set α := α → Prop`" (since := "2025-06-10")]
 theorem setOf_set {s : Set α} : setOf s = s :=
   rfl
 
+@[deprecated "This lemma abuses the `Set α := α → Prop`" (since := "2025-06-10")]
 theorem setOf_app_iff {p : α → Prop} {x : α} : { x | p x } x ↔ p x :=
   Iff.rfl
 
+@[deprecated "This lemma abuses the `Set α := α → Prop`" (since := "2025-06-10")]
 theorem mem_def {a : α} {s : Set α} : a ∈ s ↔ s a :=
   Iff.rfl
 

--- a/Mathlib/FieldTheory/AxGrothendieck.lean
+++ b/Mathlib/FieldTheory/AxGrothendieck.lean
@@ -145,7 +145,7 @@ theorem realize_genericPolyMapSurjOnOfInjOn
     (K ⊨ genericPolyMapSurjOnOfInjOn φ mons) ↔
       ∀ (v : α → K) (p : { p : ι → MvPolynomial ι K // (∀ i, (p i).support ⊆ mons i) }),
         let f : (ι → K) → (ι → K) := fun v i => eval v (p.1 i)
-        let S : Set (ι → K) := fun x => φ.Realize (Sum.elim v x)
+        let S : Set (ι → K) := {x | φ.Realize (Sum.elim v x)}
         S.MapsTo f S → S.InjOn f → S.SurjOn f S := by
   classical
   have injOnAlt : ∀ {S : Set (ι → K)} (f : (ι → K) → (ι → K)),
@@ -157,7 +157,7 @@ theorem realize_genericPolyMapSurjOnOfInjOn
     Finset.mem_univ, realize_bdEqual, Term.realize_relabel, true_imp_iff,
     Equiv.forall_congr_left (Equiv.curry (Fin 2) ι K), Equiv.curry_symm_apply, Function.uncurry,
     Fin.forall_fin_succ_pi, Fin.forall_fin_zero_pi, realize_iExs, realize_inf, Sum.forall_sum,
-    Set.MapsTo, Set.mem_def, injOnAlt, funext_iff, Set.SurjOn, Set.image, setOf,
+    Set.MapsTo, Set.mem_setOf_eq, injOnAlt, funext_iff, Set.SurjOn, Set.image,
     Set.subset_def, Equiv.forall_congr_left (mvPolynomialSupportLEEquiv mons)]
   simp +singlePass only [← Sum.elim_comp_inl_inr]
   -- was `simp` and very slow (https://github.com/leanprover-community/mathlib4/issues/19751)

--- a/Mathlib/MeasureTheory/Measure/Haar/Basic.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/Basic.lean
@@ -193,11 +193,9 @@ theorem index_union_le (K₁ K₂ : Compacts G) {V : Set G} (hV : (interior V).N
   rcases index_elim K₁.2 hV with ⟨s, h1s, h2s⟩
   rcases index_elim K₂.2 hV with ⟨t, h1t, h2t⟩
   rw [← h2s, ← h2t]
-  refine le_trans ?_ (Finset.card_union_le _ _)
-  apply Nat.sInf_le; refine ⟨_, ?_, rfl⟩; rw [mem_setOf_eq]
-  apply union_subset <;> refine Subset.trans (by assumption) ?_ <;>
-    apply biUnion_subset_biUnion_left <;> intro g hg <;> simp only [mem_def] at hg <;>
-    simp only [mem_def, Multiset.mem_union, Finset.union_val, hg, or_true, true_or]
+  refine le_trans (Nat.sInf_le ⟨_, ?_, rfl⟩) (Finset.card_union_le _ _)
+  rw [mem_setOf_eq, Finset.set_biUnion_union]
+  gcongr
 
 @[to_additive addIndex_union_eq]
 theorem index_union_eq (K₁ K₂ : Compacts G) {V : Set G} (hV : (interior V).Nonempty)

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/VolumeOfBalls.lean
@@ -331,9 +331,9 @@ theorem volume_ball (x : EuclideanSpace ℝ ι) (r : ℝ) :
       rw [Measure.addHaar_ball _ _ hr, this, ofReal_pow hr, finrank_euclideanSpace]
     rw [← ((volume_preserving_measurableEquiv _).symm).measure_preimage
       measurableSet_ball.nullMeasurableSet]
-    convert (volume_sum_rpow_lt_one ι one_le_two) using 4
-    · simp_rw [ball_zero_eq _ zero_le_one, one_pow, Real.rpow_two, sq_abs,
-        Set.setOf_app_iff]
+    simp only [Set.preimage, ball_zero_eq _ zero_le_one, one_pow, Set.mem_setOf_eq]
+    convert volume_sum_rpow_lt_one ι one_le_two using 4
+    · simp [one_pow, Real.rpow_two, sq_abs, EuclideanSpace.measurableEquiv]
     · rw [Gamma_add_one (by norm_num), Gamma_one_half_eq, ← mul_assoc, mul_div_cancel₀ _
         two_ne_zero, one_mul]
 

--- a/Mathlib/NumberTheory/SumPrimeReciprocals.lean
+++ b/Mathlib/NumberTheory/SumPrimeReciprocals.lean
@@ -76,8 +76,8 @@ theorem not_summable_one_div_on_primes :
     (fun n _ ↦ indicator_nonneg (fun p _ ↦ by positivity) _) h' using 2 with p hp
   obtain ⟨hp₁, hp₂⟩ := mem_setOf_eq ▸ Finset.mem_sdiff.mp hp
   have hpp := prime_of_mem_primesBelow hp₁
-  refine (indicator_of_mem (mem_def.mpr ⟨hpp, ?_⟩) fun n : ℕ ↦ (1 / n : ℝ)).symm
-  exact not_lt.mp <| (not_and_or.mp <| (not_congr mem_primesBelow).mp hp₂).neg_resolve_right hpp
+  refine (indicator_of_mem ?_ fun n : ℕ ↦ (1 / n : ℝ)).symm
+  exact ⟨hpp, by simpa [primesBelow, hpp] using hp₂⟩
 
 /-- The sum over the reciprocals of the primes diverges. -/
 theorem Nat.Primes.not_summable_one_div : ¬ Summable (fun p : Nat.Primes ↦ (1 / p : ℝ)) := by

--- a/Mathlib/RingTheory/KrullDimension/Basic.lean
+++ b/Mathlib/RingTheory/KrullDimension/Basic.lean
@@ -125,10 +125,9 @@ theorem nilradical_le_jacobson (R) [CommRing R] : nilradical R ≤ Ring.jacobson
   nilradical_eq_sInf R ▸ le_sInf fun _I hI ↦ sInf_le (Ideal.IsMaximal.isPrime ⟨hI⟩)
 
 theorem Ring.jacobson_eq_nilradical_of_krullDimLE_zero (R) [CommRing R] [KrullDimLE 0 R] :
-    jacobson R = nilradical R := by
-  refine (nilradical_le_jacobson R).antisymm' (nilradical_eq_sInf R ▸ le_sInf fun I hI ↦ sInf_le ?_)
-  rw [Set.mem_def, Set.setOf_app_iff] at hI
-  exact Ideal.IsMaximal.out
+    jacobson R = nilradical R :=
+  (nilradical_le_jacobson R).antisymm' <| nilradical_eq_sInf R ▸ le_sInf fun I (_ : I.IsPrime) ↦
+    sInf_le Ideal.IsMaximal.out
 
 end Zero
 

--- a/Mathlib/Topology/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Topology/OmegaCompletePartialOrder.lean
@@ -129,10 +129,5 @@ theorem scottContinuous_of_continuous {α β} [OmegaCompletePartialOrder α]
   tauto
 
 theorem continuous_of_scottContinuous {α β} [OmegaCompletePartialOrder α]
-    [OmegaCompletePartialOrder β] (f : Scott α → Scott β)
-    (hf : ωScottContinuous f) : Continuous f := by
-  rw [continuous_def]
-  intro s hs
-  dsimp only [IsOpen, TopologicalSpace.IsOpen, Scott.IsOpen]
-  simp_rw [mem_preimage, mem_def, ← Function.comp_def]
-  apply ωScottContinuous.comp hs hf
+    [OmegaCompletePartialOrder β] (f : Scott α → Scott β) (hf : ωScottContinuous f) :
+    Continuous f := by rw [continuous_def]; exact fun s hs ↦ hs.comp hf

--- a/Mathlib/Topology/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Topology/OmegaCompletePartialOrder.lean
@@ -130,4 +130,5 @@ theorem scottContinuous_of_continuous {α β} [OmegaCompletePartialOrder α]
 
 theorem continuous_of_scottContinuous {α β} [OmegaCompletePartialOrder α]
     [OmegaCompletePartialOrder β] (f : Scott α → Scott β) (hf : ωScottContinuous f) :
-    Continuous f := by rw [continuous_def]; exact fun s hs ↦ hs.comp hf
+    Continuous f := by
+  rw [continuous_def]; exact fun s hs ↦ hs.comp hf


### PR DESCRIPTION



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
