### PR TITLE
refactor: generalize `OreSet` to work for bimodules

### DIFF
--- a/Mathlib/Algebra/Module/LocalizedModule/Basic.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule/Basic.lean
@@ -142,7 +142,6 @@ theorem subsingleton (h : 0 ∈ S) : Subsingleton (LocalizedModule S M) := by
   induction a,b using LocalizedModule.induction_on₂
   exact mk_eq.mpr ⟨⟨0, h⟩, by simp only [Submonoid.mk_smul, zero_smul]⟩
 
-@[simp]
 theorem zero_mk (s : S) : mk (0 : M) s = 0 := by simp [mk]
 
 theorem mk_add_mk {m1 m2 : M} {s1 s2 : S} :

--- a/Mathlib/Algebra/Module/LocalizedModule/Basic.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule/Basic.lean
@@ -156,8 +156,8 @@ The multiplication on the localized module.
 Note that this gives a diamond with the instance on `R[S⁻¹]` (which does not require commutativity),
 but is defeq to it under `with_reducible_and_instances`.
 -/
-protected def mul {A : Type*} [Semiring A] [Algebra R A] {S : Submonoid R}
-    (m₁ m₂ : LocalizedModule S A) : LocalizedModule S A :=
+instance {A : Type*} [Semiring A] [Algebra R A] {S : Submonoid R} : Mul (LocalizedModule S A) where
+  mul m₁ m₂ :=
   liftOn₂ m₁ m₂ (fun x₁ x₂ => LocalizedModule.mk (x₁.1 * x₂.1) (x₂.2 * x₁.2)) (by
     rintro ⟨a₁, s₁⟩ ⟨a₂, s₂⟩ ⟨b₁, t₁⟩ ⟨b₂, t₂⟩ ⟨u₁, e₁⟩ ⟨u₂, e₂⟩
     simp only [mul_comm s₂ s₁, mul_comm t₂ t₁]
@@ -166,10 +166,17 @@ protected def mul {A : Type*} [Semiring A] [Algebra R A] {S : Submonoid R}
     dsimp [Submonoid.smul_def] at *
     simp only [mul_smul_mul_comm, e₁, e₂])
 
+
+example {A : Type*} [Semiring A] [Algebra R A] {S : Submonoid R} :
+    let foo :=  LocalizedModule.instMul (A := A) (S := S)
+    let bar : Mul (OreLocalization S A) := OreLocalization.instMul
+    bar = foo := by
+  with_reducible_and_instances rfl
+
+
 instance (priority := 900) {A : Type*} [Semiring A] [Algebra R A] {S : Submonoid R} :
     Monoid (LocalizedModule S A) where
   __ := inferInstanceAs (One (LocalizedModule S A))
-  mul := LocalizedModule.mul
   one_mul := by
     rintro ⟨a, s⟩
     with_unfolding_all exact mk_eq.mpr ⟨1, by simp only [one_mul, mul_one, one_smul]⟩

--- a/Mathlib/Algebra/Module/LocalizedModule/Basic.lean
+++ b/Mathlib/Algebra/Module/LocalizedModule/Basic.lean
@@ -6,6 +6,7 @@ Authors: Andrew Yang, Jujian Zhang
 import Mathlib.Algebra.Algebra.Tower
 import Mathlib.Algebra.Equiv.TransferInstance
 import Mathlib.RingTheory.Localization.Defs
+import Mathlib.RingTheory.OreLocalization.Ring
 
 /-!
 # Localized Module
@@ -49,6 +50,19 @@ for some (u : S), u * (s2 • m1 - s1 • m2) = 0 -/
 def r (a b : M × S) : Prop :=
   ∃ u : S, u • b.2 • a.1 = u • a.2 • b.1
 
+lemma oreEqv_iff_r : (OreLocalization.oreEqv S M).r = r S M := by
+  ext a b
+  constructor
+  · rintro ⟨u, v, h₁, h₂⟩
+    use u
+    simp only [Submonoid.smul_def, smul_smul, h₂]
+    rw [mul_comm, mul_smul, ← h₁, mul_comm, mul_smul]
+    rfl
+  · rintro ⟨u, hu⟩
+    use u * a.2, u * b.2
+    rw [mul_smul, ← hu, mul_smul, Submonoid.coe_mul, mul_assoc, mul_assoc, mul_comm (a.2 : R)]
+    exact ⟨rfl, rfl⟩
+
 theorem r.isEquiv : IsEquiv _ (r S M) :=
   { refl := fun ⟨m, s⟩ => ⟨1, by rw [one_smul]⟩
     trans := fun ⟨m1, s1⟩ ⟨m2, s2⟩ ⟨m3, s3⟩ ⟨u1, hu1⟩ ⟨u2, hu2⟩ => by
@@ -72,19 +86,21 @@ example {R} [CommSemiring R] (S : Submonoid R) : ⇑(Localization.r' S) = Locali
 /-- If `S` is a multiplicative subset of a ring `R` and `M` an `R`-module, then
 we can localize `M` by `S`.
 -/
-def _root_.LocalizedModule : Type max u v :=
-  Quotient (r.setoid S M)
+abbrev _root_.LocalizedModule : Type max u v :=
+  OreLocalization S M
 
 section
 
 variable {M S}
 
 /-- The canonical map sending `(m, s) ↦ m/s` -/
-def mk (m : M) (s : S) : LocalizedModule S M :=
-  Quotient.mk' ⟨m, s⟩
+abbrev mk (m : M) (s : S) : LocalizedModule S M := m /ₒ s
 
-theorem mk_eq {m m' : M} {s s' : S} : mk m s = mk m' s' ↔ ∃ u : S, u • s' • m = u • s • m' :=
-  Quotient.eq'
+theorem mk_eq {m m' : M} {s s' : S} : mk m s = mk m' s' ↔ ∃ u : S, u • s' • m = u • s • m' := by
+  rw [mk, mk, OreLocalization.oreDiv_eq_iff]
+  show _ ↔ r S M (m, s) (m', s')
+  rw [← oreEqv_iff_r]
+  rfl
 
 @[elab_as_elim, induction_eliminator, cases_eliminator]
 theorem induction_on {β : LocalizedModule S M → Prop} (h : ∀ (m : M) (s : S), β (mk m s)) :
@@ -103,7 +119,7 @@ theorem induction_on₂ {β : LocalizedModule S M → LocalizedModule S M → Pr
 -/
 def liftOn {α : Type*} (x : LocalizedModule S M) (f : M × S → α)
     (wd : ∀ (p p' : M × S), p ≈ p' → f p = f p') : α :=
-  Quotient.liftOn x f wd
+  Quotient.liftOn x f (by simpa only [r.setoid, ← oreEqv_iff_r S M] using wd)
 
 theorem liftOn_mk {α : Type*} {f : M × S → α} (wd : ∀ (p p' : M × S), p ≈ p' → f p = f p')
     (m : M) (s : S) : liftOn (mk m s) f wd = f ⟨m, s⟩ := by convert Quotient.liftOn_mk f wd ⟨m, s⟩
@@ -113,15 +129,12 @@ theorem liftOn_mk {α : Type*} {f : M × S → α} (wd : ∀ (p p' : M × S), p 
 -/
 def liftOn₂ {α : Type*} (x y : LocalizedModule S M) (f : M × S → M × S → α)
     (wd : ∀ (p q p' q' : M × S), p ≈ p' → q ≈ q' → f p q = f p' q') : α :=
-  Quotient.liftOn₂ x y f wd
+  Quotient.liftOn₂ x y f (by simpa only [r.setoid, ← oreEqv_iff_r S M] using wd)
 
 theorem liftOn₂_mk {α : Type*} (f : M × S → M × S → α)
     (wd : ∀ (p q p' q' : M × S), p ≈ p' → q ≈ q' → f p q = f p' q') (m m' : M)
     (s s' : S) : liftOn₂ (mk m s) (mk m' s') f wd = f ⟨m, s⟩ ⟨m', s'⟩ := by
   convert Quotient.liftOn₂_mk f wd _ _
-
-instance : Zero (LocalizedModule S M) :=
-  ⟨mk 0 1⟩
 
 /-- If `S` contains `0` then the localization at `S` is trivial. -/
 theorem subsingleton (h : 0 ∈ S) : Subsingleton (LocalizedModule S M) := by
@@ -130,172 +143,102 @@ theorem subsingleton (h : 0 ∈ S) : Subsingleton (LocalizedModule S M) := by
   exact mk_eq.mpr ⟨⟨0, h⟩, by simp only [Submonoid.mk_smul, zero_smul]⟩
 
 @[simp]
-theorem zero_mk (s : S) : mk (0 : M) s = 0 :=
-  mk_eq.mpr ⟨1, by rw [one_smul, smul_zero, smul_zero, one_smul]⟩
-
-instance : Add (LocalizedModule S M) where
-  add p1 p2 :=
-    liftOn₂ p1 p2 (fun x y => mk (y.2 • x.1 + x.2 • y.1) (x.2 * y.2)) <|
-      fun ⟨m1, s1⟩ ⟨m2, s2⟩ ⟨m1', s1'⟩ ⟨m2', s2'⟩ ⟨u1, hu1⟩ ⟨u2, hu2⟩ =>
-          mk_eq.mpr
-            ⟨u1 * u2, by
-              -- Put everything in the same shape, sorting the terms using `simp`
-              have hu1' := congr_arg ((u2 * s2 * s2') • ·) hu1
-              have hu2' := congr_arg ((u1 * s1 * s1') • ·) hu2
-              simp only [smul_add, ← mul_smul, smul_assoc, mul_assoc, mul_comm,
-                mul_left_comm] at hu1' hu2' ⊢
-              rw [hu1', hu2']⟩
+theorem zero_mk (s : S) : mk (0 : M) s = 0 := by simp [mk]
 
 theorem mk_add_mk {m1 m2 : M} {s1 s2 : S} :
-    mk m1 s1 + mk m2 s2 = mk (s2 • m1 + s1 • m2) (s1 * s2) :=
-  mk_eq.mpr <| ⟨1, rfl⟩
+    mk m1 s1 + mk m2 s2 = mk (s2 • m1 + s1 • m2) (s1 * s2) := by
+  simp [mk, OreLocalization.oreDiv_add_oreDiv, mul_comm s1 s2, Submonoid.smul_def]
 
-private theorem add_assoc' (x y z : LocalizedModule S M) : x + y + z = x + (y + z) := by
-  induction' x with mx sx
-  induction' y with my sy
-  induction' z with mz sz
-  simp only [mk_add_mk, smul_add]
-  refine mk_eq.mpr ⟨1, ?_⟩
-  rw [one_smul, one_smul]
-  congr 1
-  · rw [mul_assoc]
-  · rw [eq_comm, mul_comm, add_assoc, mul_smul, mul_smul, ← mul_smul sx sz, mul_comm, mul_smul]
+theorem mk_neg {M : Type*} [AddCommGroup M] [Module R M] {m : M} {s : S} :
+    mk (-m) s = -mk m s := by simp [mk]
 
-private theorem add_comm' (x y : LocalizedModule S M) : x + y = y + x :=
-  LocalizedModule.induction_on₂ (fun m m' s s' => by rw [mk_add_mk, mk_add_mk, add_comm, mul_comm])
-    x y
+/--
+The multiplication on the localized module.
+Note that this gives a diamond with the instance on `R[S⁻¹]` (which does not require commutativity),
+but is defeq to it under `with_reducible_and_instances`.
+-/
+protected def mul {A : Type*} [Semiring A] [Algebra R A] {S : Submonoid R}
+    (m₁ m₂ : LocalizedModule S A) : LocalizedModule S A :=
+  liftOn₂ m₁ m₂ (fun x₁ x₂ => LocalizedModule.mk (x₁.1 * x₂.1) (x₂.2 * x₁.2)) (by
+    rintro ⟨a₁, s₁⟩ ⟨a₂, s₂⟩ ⟨b₁, t₁⟩ ⟨b₂, t₂⟩ ⟨u₁, e₁⟩ ⟨u₂, e₂⟩
+    simp only [mul_comm s₂ s₁, mul_comm t₂ t₁]
+    rw [mk_eq]
+    use u₁ * u₂
+    dsimp [Submonoid.smul_def] at *
+    simp only [mul_smul_mul_comm, e₁, e₂])
 
-private theorem zero_add' (x : LocalizedModule S M) : 0 + x = x :=
-  induction_on
-    (fun m s => by
-      rw [← zero_mk s, mk_add_mk, smul_zero, zero_add, mk_eq]
-      exact ⟨1, by rw [one_smul, mul_smul, one_smul]⟩)
-    x
+instance (priority := 900) {A : Type*} [Semiring A] [Algebra R A] {S : Submonoid R} :
+    Monoid (LocalizedModule S A) where
+  __ := inferInstanceAs (One (LocalizedModule S A))
+  mul := LocalizedModule.mul
+  one_mul := by
+    rintro ⟨a, s⟩
+    with_unfolding_all exact mk_eq.mpr ⟨1, by simp only [one_mul, mul_one, one_smul]⟩
+  mul_one := by
+    rintro ⟨a, s⟩
+    with_unfolding_all exact mk_eq.mpr ⟨1, by simp only [mul_one, one_smul, one_mul]⟩
+  mul_assoc := by with_unfolding_all
+    rintro ⟨a₁, s₁⟩ ⟨a₂, s₂⟩ ⟨a₃, s₃⟩
+    apply mk_eq.mpr _
+    use 1
+    simp only [one_mul, smul_smul, ← mul_assoc, mul_right_comm]
 
-private theorem add_zero' (x : LocalizedModule S M) : x + 0 = x :=
-  induction_on
-    (fun m s => by
-      rw [← zero_mk s, mk_add_mk, smul_zero, add_zero, mk_eq]
-      exact ⟨1, by rw [one_smul, mul_smul, one_smul]⟩)
-    x
+example : OreLocalization.instMonoid = LocalizedModule.instMonoid (A := R) (S := S) := by
+  with_reducible_and_instances rfl
 
-instance hasNatSMul : SMul ℕ (LocalizedModule S M) where smul n := nsmulRec n
-
-private theorem nsmul_zero' (x : LocalizedModule S M) : (0 : ℕ) • x = 0 :=
-  LocalizedModule.induction_on (fun _ _ => rfl) x
-
-private theorem nsmul_succ' (n : ℕ) (x : LocalizedModule S M) : n.succ • x = n • x + x :=
-  LocalizedModule.induction_on (fun _ _ => rfl) x
-
-instance : AddCommMonoid (LocalizedModule S M) where
-  add := (· + ·)
-  add_assoc := add_assoc'
-  zero := 0
-  zero_add := zero_add'
-  add_zero := add_zero'
-  nsmul := (· • ·)
-  nsmul_zero := nsmul_zero'
-  nsmul_succ := nsmul_succ'
-  add_comm := add_comm'
-
-instance {M : Type*} [AddCommGroup M] [Module R M] : Neg (LocalizedModule S M) where
-  neg p :=
-    liftOn p (fun x => LocalizedModule.mk (-x.1) x.2) fun ⟨m1, s1⟩ ⟨m2, s2⟩ ⟨u, hu⟩ => by
-      rw [mk_eq]
-      exact ⟨u, by simpa⟩
-
-instance {M : Type*} [AddCommGroup M] [Module R M] : AddCommGroup (LocalizedModule S M) :=
-  { show AddCommMonoid (LocalizedModule S M) by infer_instance with
-    neg_add_cancel := by
-      rintro ⟨m, s⟩
-      change
-        (liftOn (mk m s) (fun x => mk (-x.1) x.2) fun ⟨m1, s1⟩ ⟨m2, s2⟩ ⟨u, hu⟩ => by
-              rw [mk_eq]
-              exact ⟨u, by simpa⟩) +
-            mk m s =
-          0
-      rw [liftOn_mk, mk_add_mk]
-      simp
-    -- TODO: fix the diamond
-    zsmul := zsmulRec }
-
-theorem mk_neg {M : Type*} [AddCommGroup M] [Module R M] {m : M} {s : S} : mk (-m) s = -mk m s :=
-  rfl
-
-instance {A : Type*} [Semiring A] [Algebra R A] {S : Submonoid R} :
-    Monoid (LocalizedModule S A) :=
-  { mul := fun m₁ m₂ =>
-      liftOn₂ m₁ m₂ (fun x₁ x₂ => LocalizedModule.mk (x₁.1 * x₂.1) (x₁.2 * x₂.2))
-        (by
-          rintro ⟨a₁, s₁⟩ ⟨a₂, s₂⟩ ⟨b₁, t₁⟩ ⟨b₂, t₂⟩ ⟨u₁, e₁⟩ ⟨u₂, e₂⟩
-          rw [mk_eq]
-          use u₁ * u₂
-          dsimp only at e₁ e₂ ⊢
-          rw [eq_comm]
-          trans (u₁ • t₁ • a₁) • u₂ • t₂ • a₂
-          on_goal 1 => rw [e₁, e₂]
-          on_goal 2 => rw [eq_comm]
-          all_goals
-            rw [smul_smul, mul_mul_mul_comm, ← smul_eq_mul, ← smul_eq_mul (α := A),
-              smul_smul_smul_comm, mul_smul, mul_smul])
-    one := mk 1 (1 : S)
-    one_mul := by
-      rintro ⟨a, s⟩
-      exact mk_eq.mpr ⟨1, by simp only [one_mul, one_smul]⟩
-    mul_one := by
-      rintro ⟨a, s⟩
-      exact mk_eq.mpr ⟨1, by simp only [mul_one, one_smul]⟩
-    mul_assoc := by
-      rintro ⟨a₁, s₁⟩ ⟨a₂, s₂⟩ ⟨a₃, s₃⟩
-      apply mk_eq.mpr _
-      use 1
-      simp only [one_mul, smul_smul, ← mul_assoc, mul_right_comm] }
-
-instance {A : Type*} [Semiring A] [Algebra R A] {S : Submonoid R} :
-    Semiring (LocalizedModule S A) :=
-  { show (AddCommMonoid (LocalizedModule S A)) by infer_instance,
-    show (Monoid (LocalizedModule S A)) by infer_instance with
-    left_distrib := by
-      rintro ⟨a₁, s₁⟩ ⟨a₂, s₂⟩ ⟨a₃, s₃⟩
-      apply mk_eq.mpr _
-      use 1
-      simp only [one_mul, smul_add, mul_add, mul_smul_comm, smul_smul, ← mul_assoc,
-        mul_right_comm]
-    right_distrib := by
-      rintro ⟨a₁, s₁⟩ ⟨a₂, s₂⟩ ⟨a₃, s₃⟩
-      apply mk_eq.mpr _
-      use 1
-      simp only [one_mul, smul_add, add_mul, smul_smul, ← mul_assoc, smul_mul_assoc,
-        mul_right_comm]
-    zero_mul := by
-      rintro ⟨a, s⟩
-      exact mk_eq.mpr ⟨1, by simp only [zero_mul, smul_zero]⟩
-    mul_zero := by
-      rintro ⟨a, s⟩
-      exact mk_eq.mpr ⟨1, by simp only [mul_zero, smul_zero]⟩ }
-
-instance {A : Type*} [CommSemiring A] [Algebra R A] {S : Submonoid R} :
-    CommSemiring (LocalizedModule S A) :=
-  { show Semiring (LocalizedModule S A) by infer_instance with
-    mul_comm := by
-      rintro ⟨a₁, s₁⟩ ⟨a₂, s₂⟩
-      exact mk_eq.mpr ⟨1, by simp only [one_smul, mul_comm]⟩ }
-
-instance {A : Type*} [Ring A] [Algebra R A] {S : Submonoid R} :
-    Ring (LocalizedModule S A) :=
-  { inferInstanceAs (AddCommGroup (LocalizedModule S A)),
-    inferInstanceAs (Semiring (LocalizedModule S A)) with }
-
-instance {A : Type*} [CommRing A] [Algebra R A] {S : Submonoid R} :
-    CommRing (LocalizedModule S A) :=
-  { show (Ring (LocalizedModule S A)) by infer_instance with
-    mul_comm := by
-      rintro ⟨a₁, s₁⟩ ⟨a₂, s₂⟩
-      exact mk_eq.mpr ⟨1, by simp only [one_smul, mul_comm]⟩ }
+/-- A variant of `mk_mul_mk` that is `rfl` but has a stranger multiplication order. -/
+theorem mk_mul_mk' {A : Type*} [Semiring A] [Algebra R A] {a₁ a₂ : A} {s₁ s₂ : S} :
+    mk a₁ s₁ * mk a₂ s₂ = mk (a₁ * a₂) (s₂ * s₁) := rfl
 
 theorem mk_mul_mk {A : Type*} [Semiring A] [Algebra R A] {a₁ a₂ : A} {s₁ s₂ : S} :
-    mk a₁ s₁ * mk a₂ s₂ = mk (a₁ * a₂) (s₁ * s₂) :=
-  rfl
+    mk a₁ s₁ * mk a₂ s₂ = mk (a₁ * a₂) (s₁ * s₂) := by rw [mk_mul_mk', mul_comm s₁ s₂]
+
+instance (priority := 900) {A : Type*} [Semiring A] [Algebra R A] {S : Submonoid R} :
+    Semiring (LocalizedModule S A) where
+  __ := inferInstanceAs (AddCommMonoid (LocalizedModule S A))
+  __ := inferInstanceAs (Monoid (LocalizedModule S A))
+  left_distrib := by
+    rintro ⟨a₁, s₁⟩ ⟨a₂, s₂⟩ ⟨a₃, s₃⟩
+    show a₁ /ₒ s₁ * (a₂ /ₒ s₂ + a₃ /ₒ s₃) = a₁ /ₒ s₁ * (a₂ /ₒ s₂) + a₁ /ₒ s₁ * (a₃ /ₒ s₃)
+    rw [← mk, ← mk, ← mk, mk_mul_mk, mk_mul_mk, mk_add_mk, mk_mul_mk, mk_add_mk]
+    apply mk_eq.mpr _
+    use 1
+    simp only [← mul_assoc, mul_right_comm, mul_add, mul_smul_comm, smul_add, smul_smul, one_mul]
+  right_distrib := by
+    rintro ⟨a₁, s₁⟩ ⟨a₂, s₂⟩ ⟨a₃, s₃⟩
+    show (a₁ /ₒ s₁ + a₂ /ₒ s₂) * (a₃ /ₒ s₃) = a₁ /ₒ s₁ * (a₃ /ₒ s₃) + a₂ /ₒ s₂ * (a₃ /ₒ s₃)
+    rw [← mk, ← mk, ← mk, mk_mul_mk, mk_mul_mk, mk_add_mk, mk_mul_mk, mk_add_mk]
+    apply mk_eq.mpr _
+    use 1
+    simp only [one_mul, smul_add, add_mul, smul_smul, ← mul_assoc, smul_mul_assoc,
+      mul_right_comm]
+  zero_mul := by with_unfolding_all
+    rintro ⟨a, s⟩
+    exact mk_eq.mpr ⟨1, by simp only [zero_mul, smul_zero]⟩
+  mul_zero := by with_unfolding_all
+    rintro ⟨a, s⟩
+    exact mk_eq.mpr ⟨1, by simp only [mul_zero, smul_zero]⟩
+
+instance (priority := 900) {A : Type*} [CommSemiring A] [Algebra R A] {S : Submonoid R} :
+    CommSemiring (LocalizedModule S A) where
+  __ := inferInstanceAs (Semiring (LocalizedModule S A))
+  mul_comm := by
+    rintro ⟨a₁, s₁⟩ ⟨a₂, s₂⟩
+    exact mk_eq.mpr ⟨1, by simp only [one_smul, mul_comm]⟩
+
+instance (priority := 900) {A : Type*} [Ring A] [Algebra R A] {S : Submonoid R} :
+    Ring (LocalizedModule S A) where
+  __ := inferInstanceAs (AddCommGroup (LocalizedModule S A))
+  __ := inferInstanceAs (Semiring (LocalizedModule S A))
+
+instance (priority := 900) {A : Type*} [CommRing A] [Algebra R A] {S : Submonoid R} :
+    CommRing (LocalizedModule S A) where
+  __ := inferInstanceAs (Ring (LocalizedModule S A))
+  __ := inferInstanceAs (CommSemiring (LocalizedModule S A))
+
+example {R : Type*} [CommRing R] {S : Submonoid R} :
+    (LocalizedModule.instCommRing : CommRing R[S⁻¹]) = OreLocalization.instCommRing := by
+  with_reducible_and_instances rfl
 
 noncomputable instance : SMul T (LocalizedModule S M) where
   smul x p :=
@@ -323,9 +266,8 @@ theorem mk'_smul_mk (r : R) (m : M) (s s' : S) :
     mul_comm _ (s' : R), mul_assoc, hc]
 
 theorem mk_smul_mk (r : R) (m : M) (s t : S) :
-    Localization.mk r s • mk m t = mk (r • m) (s * t) := by
-  rw [Localization.mk_eq_mk']
-  exact mk'_smul_mk ..
+    Localization.mk r s • mk m t = mk (r • m) (s * t) :=
+  (OreLocalization.oreDiv_smul_char _ _ _ _ _ _ (mul_comm _ _)).trans (by rw [mul_comm])
 
 variable {T}
 
@@ -394,11 +336,10 @@ theorem mk_cancel (s : S) (m : M) : mk (s • m) s = mk m 1 :=
 theorem mk_cancel_common_right (s s' : S) (m : M) : mk (s' • m) (s * s') = mk m s :=
   mk_eq.mpr ⟨1, by simp [mul_smul]⟩
 
-noncomputable instance isModule' : Module R (LocalizedModule S M) :=
-  { Module.compHom (LocalizedModule S M) <| algebraMap R (Localization S) with }
-
 theorem smul'_mk (r : R) (s : S) (m : M) : r • mk m s = mk (r • m) s := by
-  simpa only [one_mul] using mk_smul_mk r m 1 s
+  refine (OreLocalization.smul_oreDiv _ _ _).trans ?_
+  show (r • 1 : R) • m /ₒ s = _
+  rw [smul_assoc, one_smul]
 
 lemma smul_eq_iff_of_mem
     (r : R) (hr : r ∈ S) (x y : LocalizedModule S M) :
@@ -434,11 +375,13 @@ theorem mul_smul' {A : Type*} [Semiring A] [Algebra R A] (x : T) (p₁ p₂ : Lo
 
 variable (T)
 
-noncomputable instance {A : Type*} [Semiring A] [Algebra R A] : Algebra T (LocalizedModule S A) :=
+noncomputable instance (priority := 900) {A : Type*} [Semiring A] [Algebra R A] :
+    Algebra T (LocalizedModule S A) :=
   Algebra.ofModule smul'_mul mul_smul'
 
 theorem algebraMap_mk' {A : Type*} [Semiring A] [Algebra R A] (a : R) (s : S) :
     algebraMap _ _ (IsLocalization.mk' T a s) = mk (algebraMap R A a) s := by
+  with_unfolding_all
   rw [Algebra.algebraMap_eq_smul_one]
   change _ • mk _ _ = _
   rw [mk'_smul_mk, Algebra.algebraMap_eq_smul_one, mul_one]
@@ -454,22 +397,28 @@ instance : IsScalarTower R T (LocalizedModule S M) where
     rw [← IsLocalization.mk'_sec (M := S) T x, IsLocalization.smul_mk', mk'_smul_mk, mk'_smul_mk,
       smul'_mk, mul_smul]
 
-noncomputable instance algebra' {A : Type*} [Semiring A] [Algebra R A] :
+/-- The ring homomorphism from `R` to `R[S⁻¹]`, mapping `r : R` to the fraction `r /ₒ 1`. -/
+abbrev numeratorRingHom {A : Type*} [Semiring A] [Algebra R A] : A →+* A[S⁻¹] where
+  toFun r := mk r 1
+  map_one' := by simp [OreLocalization.one_def]
+  map_mul' := by simp [mk_mul_mk]
+  map_zero' := by simp
+  map_add' := by simp [mk_add_mk]
+
+noncomputable instance (priority := 900) algebra' {A : Type*} [Semiring A] [Algebra R A] :
     Algebra R (LocalizedModule S A) where
-  algebraMap := (algebraMap (Localization S) (LocalizedModule S A)).comp
-    (algebraMap R <| Localization S)
-  commutes' := by
-    intro r x
+  algebraMap := numeratorRingHom.comp (algebraMap R A)
+  commutes' r x := by
     induction x using induction_on with | _ a s => _
-    dsimp
-    rw [← Localization.mk_one_eq_algebraMap, algebraMap_mk, mk_mul_mk, mk_mul_mk, mul_comm,
-      Algebra.commutes]
-  smul_def' := by
-    intro r x
+    show mk _ _ * mk _ _ = mk _ _ * mk _ _
+    rw [mk_mul_mk, mk_mul_mk, mul_comm, Algebra.commutes]
+  smul_def' r x := by
     induction x using induction_on with | _ a s => _
-    dsimp
-    rw [← Localization.mk_one_eq_algebraMap, algebraMap_mk, mk_mul_mk, smul'_mk,
-      Algebra.smul_def, one_mul]
+    show _ • mk _ _ = mk _ _ * mk _ _
+    rw [mk_mul_mk, smul'_mk, Algebra.smul_def, one_mul]
+
+example : (algebra' : Algebra R (LocalizedModule S R)) = OreLocalization.instAlgebra := by
+  with_reducible_and_instances rfl
 
 section
 
@@ -481,7 +430,7 @@ variable (S M)
 noncomputable def mkLinearMap : M →ₗ[R] LocalizedModule S M where
   toFun m := mk m 1
   map_add' x y := by simp [mk_add_mk]
-  map_smul' _ _ := (smul'_mk _ _ _).symm
+  map_smul' r m := by simp [mk, OreLocalization.smul_oreDiv]
 
 end
 
@@ -500,15 +449,13 @@ noncomputable def divBy (s : S) : LocalizedModule S M →ₗ[R] LocalizedModule 
       smul_comm _ s, ← smul_add, mul_left_comm s t₁ t₂, mk_cancel_common_left s]
   map_smul' r x := by
     refine x.induction_on (fun _ _ ↦ ?_)
-    change liftOn (mk _ _) _ _ = r • (liftOn (mk _ _) _ _)
-    simp_rw [liftOn_mk, mul_assoc, ← smul_def]
+    simp_rw [smul'_mk, liftOn_mk, smul'_mk]
     congr!
 
 theorem divBy_mul_by (s : S) (p : LocalizedModule S M) :
     divBy s (algebraMap R (Module.End R (LocalizedModule S M)) s p) = p :=
   p.induction_on fun m t => by
-    rw [Module.algebraMap_end_apply, divBy_apply, ← algebraMap_smul (Localization S) (s : R),
-      smul_def, LocalizedModule.liftOn_mk, mul_assoc, ← smul_def, algebraMap_smul, smul'_mk,
+    rw [Module.algebraMap_end_apply, divBy_apply, smul'_mk, liftOn_mk,
       ← Submonoid.smul_def, mk_cancel_common_right _ s]
 
 theorem mul_by_divBy (s : S) (p : LocalizedModule S M) :

--- a/Mathlib/AlgebraicGeometry/Modules/Tilde.lean
+++ b/Mathlib/AlgebraicGeometry/Modules/Tilde.lean
@@ -81,17 +81,26 @@ theorem isLocallyFraction_pred {U : Opens (PrimeSpectrum.Top R)}
   rfl
 
 /- M_x is an O_SpecR(U)-module when x is in U -/
-noncomputable instance (U : (Opens (PrimeSpectrum.Top R))ᵒᵖ) (x : U.unop):
-    Module ((Spec.structureSheaf R).val.obj U) (Localizations M x):=
+noncomputable instance (U : (Opens (PrimeSpectrum.Top R))ᵒᵖ) (x : U.unop) :
+    Module ((Spec.structureSheaf R).val.obj U) (Localizations M x) :=
   Module.compHom (R := (Localization.AtPrime x.1.asIdeal)) _
     ((StructureSheaf.openToLocalization R U.unop x x.2).hom)
+
+instance (U : (Opens (PrimeSpectrum.Top R))ᵒᵖ) (x : U.unop) :
+    IsScalarTower R (Localization.AtPrime x.1.asIdeal) (Localizations M x) :=
+  OreLocalization.instIsScalarTower_1 ..
+
+instance (U : (Opens (PrimeSpectrum.Top R))ᵒᵖ) (x : U.unop) :
+    IsScalarTower R ((Spec.structureSheaf R).val.obj U) (Localizations M x) :=
+  .of_algebraMap_smul fun r m ↦
+    IsScalarTower.algebraMap_smul (Localization.AtPrime x.1.asIdeal) r m
 
 @[simp]
 lemma sections_smul_localizations_def
     {U : (Opens (PrimeSpectrum.Top R))ᵒᵖ} (x : U.unop)
     (r : (Spec.structureSheaf R).val.obj U)
     (m : Localizations M ↑x) :
-  r • m = r.1 x • m := rfl
+  r • m = (by exact r.1 x : Localization.AtPrime _) • m := rfl
 
 /--
 For any `R`-module `M` and any open subset `U ⊆ Spec R`, `M^~(U)` is an `𝒪_{Spec R}(U)`-submodule
@@ -129,7 +138,8 @@ noncomputable def sectionsSubmodule (U : (Opens (PrimeSpectrum R))ᵒᵖ) :
     · simp only [Opens.coe_inf, Pi.smul_apply, LinearMapClass.map_smul, Opens.apply_def] at wa wr ⊢
       rw [mul_comm, ← Algebra.smul_def] at wr
       rw [sections_smul_localizations_def, ← wa, ← mul_smul, ← smul_assoc, mul_comm sr, mul_smul,
-        wr, mul_comm rr, Algebra.smul_def, ← map_mul]
+        wr, mul_comm rr, Algebra.smul_def,
+        ← IsScalarTower.algebraMap_smul (R := R) (Localization.AtPrime y.1.asIdeal), map_mul]
       rfl
 
 end Tilde
@@ -187,7 +197,8 @@ theorem res_apply (U V : Opens (PrimeSpectrum.Top R)) (i : V ⟶ U)
 
 lemma smul_section_apply (r : R) (U : Opens (PrimeSpectrum.Top R))
     (s : (tildeInModuleCat M).1.obj (op U)) (x : U) :
-    (r • s).1 x = r • (s.1 x) := rfl
+    (r • s).1 x = r • (s.1 x) :=
+  IsScalarTower.algebraMap_smul ((Spec.structureSheaf R).val.obj (op U)) r (s.1 x)
 
 lemma smul_stalk_no_nonzero_divisor {x : PrimeSpectrum R}
     (r : x.asIdeal.primeCompl) (st : (tildeInModuleCat M).stalk x) (hst : r.1 • st = 0) :
@@ -196,7 +207,8 @@ lemma smul_stalk_no_nonzero_divisor {x : PrimeSpectrum R}
     _ _ _ ⟨op ⟨PrimeSpectrum.basicOpen r.1, r.2⟩, fun U i s hs ↦ Subtype.eq <| funext fun pt ↦ ?_⟩
     _ hst
   apply LocalizedModule.eq_zero_of_smul_eq_zero _ (i.unop pt).2 _
-    (congr_fun (Subtype.ext_iff.1 hs) pt)
+  simp [← smul_section_apply, hs]
+  rfl
 
 /--
 If `U` is an open subset of `Spec R`, this is the morphism of `R`-modules from `M` to
@@ -212,9 +224,10 @@ noncomputable def toOpen (U : Opens (PrimeSpectrum.Top R)) :
       ⟨U, x.2, 𝟙 _, f, 1, fun y ↦ ⟨(Ideal.ne_top_iff_one _).1 y.1.2.1, by simp⟩⟩⟩
     map_add' := fun f g => Subtype.eq <| funext fun x ↦ LinearMap.map_add _ _ _
     map_smul' := fun r m => by
+      apply Subtype.val_injective
+      ext x
       simp only [isLocallyFraction_pred, LocalizedModule.mkLinearMap_apply, LinearMapClass.map_smul,
-        RingHom.id_apply]
-      rfl }
+        RingHom.id_apply, smul_section_apply] }
 
 @[simp]
 theorem toOpen_res (U V : Opens (PrimeSpectrum.Top R)) (i : V ⟶ U) :
@@ -243,7 +256,8 @@ lemma isUnit_toStalk (x : PrimeSpectrum.Top R) (r : x.asIdeal.primeCompl) :
         simpa only [Module.algebraMap_end_apply, ← map_smul] using
           germ_ext (C := ModuleCat R) (W := O) (hxW := ⟨mem, r.2⟩) (iWU := 𝟙 _)
             (iWV := homOfLE inf_le_left) _ <|
-          Subtype.eq <| funext fun y ↦ smul_eq_iff_of_mem (S := y.1.1.primeCompl) r _ _ _ |>.2 rfl⟩
+          Subtype.eq <| funext fun y ↦ by
+            simp [smul_section_apply, ← smul_assoc, Localization.smul_mk]; rfl⟩
   obtain ⟨V, mem_V, iV, num, den, hV⟩ := s.2 ⟨q.1, q.2.1⟩
   refine ⟨V ⊓ O, ⟨mem_V, q.2⟩, homOfLE inf_le_right, num, r * den, fun y ↦ ?_⟩
   obtain ⟨h1, h2⟩ := hV ⟨y, y.2.1⟩
@@ -276,7 +290,7 @@ noncomputable def openToLocalization
     (Y := ModuleCat.of R (LocalizedModule x.asIdeal.primeCompl M))
   { toFun := fun s => (s.1 ⟨x, hx⟩ :)
     map_add' := fun _ _ => rfl
-    map_smul' := fun _ _ => rfl }
+    map_smul' := fun _ _ => by simp [smul_section_apply] }
 
 /--
 The morphism of `R`-modules from the stalk of `M^~` at `x` to the localization of `M` at the
@@ -373,12 +387,11 @@ theorem localizationToStalk_mk (x : PrimeSpectrum.Top R) (f : M) (s : x.asIdeal.
   · exact homOfLE le_top
   · exact 𝟙 _
   refine Subtype.eq <| funext fun y => show LocalizedModule.mk f 1 = _ from ?_
-  #adaptation_note /-- https://github.com/leanprover/lean4/pull/6024
-    added this refine hack to be able to add type hint in `change` -/
-  refine (?_ : @Eq ?ty _ _)
-  change LocalizedModule.mk f 1 = (s.1 • LocalizedModule.mk f _ : ?ty)
-  rw [LocalizedModule.smul'_mk, LocalizedModule.mk_eq]
-  exact ⟨1, by simp⟩
+  dsimp
+  simp only [CategoryTheory.Functor.map_id, hom_id, map_smul, LinearMap.id_coe, id_eq,
+    smul_section_apply, isLocallyFraction_pred, Opens.val_apply, LocalizedModule.mkLinearMap_apply,
+    const_apply, LocalizedModule.smul'_mk]
+  exact (LocalizedModule.mk_cancel ⟨s.1, _⟩ f).symm
 
 /--
 The isomorphism of `R`-modules from the stalk of `M^~` at `x` to the localization of `M` at the

--- a/Mathlib/GroupTheory/OreLocalization/Basic.lean
+++ b/Mathlib/GroupTheory/OreLocalization/Basic.lean
@@ -40,7 +40,7 @@ open OreLocalization
 
 namespace OreLocalization
 
-variable {R : Type*} [Monoid R] (S : Submonoid R) [OreSet S] (X) [MulAction R X]
+variable {R : Type*} [Monoid R] (S : Submonoid R) [OreSet S R] (X) [MulAction R X]
 
 /-- The setoid on `R × S` used for the Ore localization. -/
 @[to_additive AddOreLocalization.oreEqv "The setoid on `R × S` used for the Ore localization."]
@@ -51,6 +51,7 @@ def oreEqv : Setoid (X × S) where
     · rintro ⟨r, s⟩ ⟨r', s'⟩ ⟨u, v, hru, hsu⟩; dsimp only at *
       rcases oreCondition (s : R) s' with ⟨r₂, s₂, h₁⟩
       rcases oreCondition r₂ u with ⟨r₃, s₃, h₂⟩
+      simp only [smul_eq_mul, op_smul_eq_mul] at h₁ h₂
       have : r₃ * v * s = s₃ * s₂ * s := by
         -- Porting note: the proof used `assoc_rw`
         rw [mul_assoc _ (s₂ : R), h₁, ← mul_assoc, h₂, mul_assoc, ← hsu, ← mul_assoc]
@@ -58,6 +59,7 @@ def oreEqv : Setoid (X × S) where
       refine ⟨w * (s₃ * s₂), w * (r₃ * u), ?_, ?_⟩ <;>
         simp only [Submonoid.coe_mul, Submonoid.smul_def, ← hw]
       · simp only [mul_smul, hru, ← Submonoid.smul_def]
+        sorry
       · simp only [mul_assoc, hsu]
     · rintro ⟨r₁, s₁⟩ ⟨r₂, s₂⟩ ⟨r₃, s₃⟩ ⟨u, v, hur₁, hs₁u⟩ ⟨u', v', hur₂, hs₂u⟩
       rcases oreCondition v' u with ⟨r', s', h⟩; dsimp only at *
@@ -71,7 +73,7 @@ end OreLocalization
 /-- The Ore localization of a monoid and a submonoid fulfilling the Ore condition. -/
 @[to_additive AddOreLocalization "The Ore localization of an additive monoid and a submonoid
 fulfilling the Ore condition."]
-def OreLocalization {R : Type*} [Monoid R] (S : Submonoid R) [OreSet S]
+def OreLocalization {R : Type*} [Monoid R] (S : Submonoid R) [OreSet S R]
     (X : Type*) [MulAction R X] :=
   Quotient (OreLocalization.oreEqv S X)
 
@@ -79,7 +81,7 @@ namespace OreLocalization
 
 section Monoid
 
-variable (R : Type*) [Monoid R] (S : Submonoid R) [OreSet S]
+variable (R : Type*) [Monoid R] (S : Submonoid R) [OreSet S R]
 
 @[inherit_doc OreLocalization]
 scoped syntax:1075 term noWs atomic("[" term "⁻¹" noWs "]") : term
@@ -224,7 +226,7 @@ private theorem smul'_char (r₁ : R) (r₂ : X) (s₁ s₂ : S) (u : S) (v : R)
 
 /-- The multiplication on the Ore localization of monoids. -/
 @[to_additive]
-private abbrev smul'' (r : R) (s : S) : X[S⁻¹] → X[S⁻¹] :=
+private abbrev smul''  {A} [MulAction R A] (r : X) (s : S) : X[S⁻¹] → X[S⁻¹] :=
   liftExpand (smul' r s) fun r₁ r₂ s' hs => by
     rcases oreCondition r s' with ⟨r₁', s₁', h₁⟩
     rw [smul'_char _ _ _ _ _ _ h₁]
@@ -247,7 +249,7 @@ private abbrev smul'' (r : R) (s : S) : X[S⁻¹] → X[S⁻¹] :=
 /-- The scalar multiplication on the Ore localization of monoids. -/
 @[to_additive
   "the vector addition on the Ore localization of additive monoids."]
-protected abbrev smul (y : R[S⁻¹]) (x : X[S⁻¹]) : X[S⁻¹] :=
+protected abbrev smul {A} [MulAction R A] (y : A[S⁻¹]) (x : X[S⁻¹]) : X[S⁻¹] :=
   liftExpand (smul'' · · x) (fun r₁ r₂ s hs => by
     cases x with | _ x s₂
     show OreLocalization.smul' r₁ s x s₂ = OreLocalization.smul' (r₂ * r₁) ⟨_, hs⟩ x s₂
@@ -273,7 +275,7 @@ instance : SMul R[S⁻¹] X[S⁻¹] :=
   ⟨OreLocalization.smul⟩
 
 @[to_additive]
-instance : Mul R[S⁻¹] :=
+instance {A} [MulAction R A] : Mul A[S⁻¹] :=
   ⟨OreLocalization.smul⟩
 
 @[to_additive]

--- a/Mathlib/GroupTheory/OreLocalization/Basic.lean
+++ b/Mathlib/GroupTheory/OreLocalization/Basic.lean
@@ -196,7 +196,7 @@ theorem lift₂Expand_of {C : Sort*} {P : X → S → X → S → C}
   rfl
 
 @[to_additive]
-private def smul' (r₁ : R) (s₁ : S) (r₂ : X) (s₂ : S) : X[S⁻¹] :=
+private abbrev smul' (r₁ : R) (s₁ : S) (r₂ : X) (s₂ : S) : X[S⁻¹] :=
   oreNum r₁ s₂ • r₂ /ₒ (oreDenom r₁ s₂ * s₁)
 
 @[to_additive]
@@ -224,7 +224,7 @@ private theorem smul'_char (r₁ : R) (r₂ : X) (s₁ s₂ : S) (u : S) (v : R)
 
 /-- The multiplication on the Ore localization of monoids. -/
 @[to_additive]
-private def smul'' (r : R) (s : S) : X[S⁻¹] → X[S⁻¹] :=
+private abbrev smul'' (r : R) (s : S) : X[S⁻¹] → X[S⁻¹] :=
   liftExpand (smul' r s) fun r₁ r₂ s' hs => by
     rcases oreCondition r s' with ⟨r₁', s₁', h₁⟩
     rw [smul'_char _ _ _ _ _ _ h₁]
@@ -245,11 +245,10 @@ private def smul'' (r : R) (s : S) : X[S⁻¹] → X[S⁻¹] :=
     rw [mul_assoc (s₄' : R), h₃, ← mul_assoc]
 
 /-- The scalar multiplication on the Ore localization of monoids. -/
-@[to_additive (attr := irreducible)
+@[to_additive
   "the vector addition on the Ore localization of additive monoids."]
-protected def smul : R[S⁻¹] → X[S⁻¹] → X[S⁻¹] :=
-  liftExpand smul'' fun r₁ r₂ s hs => by
-    ext x
+protected abbrev smul (y : R[S⁻¹]) (x : X[S⁻¹]) : X[S⁻¹] :=
+  liftExpand (smul'' · · x) (fun r₁ r₂ s hs => by
     cases x with | _ x s₂
     show OreLocalization.smul' r₁ s x s₂ = OreLocalization.smul' (r₂ * r₁) ⟨_, hs⟩ x s₂
     rcases oreCondition r₁ s₂ with ⟨r₁', s₁', h₁⟩
@@ -267,7 +266,7 @@ protected def smul : R[S⁻¹] → X[S⁻¹] → X[S⁻¹] :=
     simp only [Submonoid.smul_def, Submonoid.coe_mul, smul_smul, mul_assoc, h₄]
     congr 1
     ext; simp only [Submonoid.coe_mul, ← mul_assoc]
-    rw [mul_assoc _ r₃', ← h₃, ← mul_assoc, ← mul_assoc]
+    rw [mul_assoc _ r₃', ← h₃, ← mul_assoc, ← mul_assoc]) y
 
 @[to_additive]
 instance : SMul R[S⁻¹] X[S⁻¹] :=
@@ -321,14 +320,14 @@ def oreDivMulChar' (r₁ r₂ : R) (s₁ s₂ : S) :
 
 /-- `1` in the localization, defined as `1 /ₒ 1`. -/
 @[to_additive (attr := irreducible) "`0` in the additive localization, defined as `0 -ₒ 0`."]
-protected def one : R[S⁻¹] := 1 /ₒ 1
+protected def one [One X] : X[S⁻¹] := 1 /ₒ 1
 
 @[to_additive]
-instance : One R[S⁻¹] :=
+instance [One X] : One X[S⁻¹] :=
   ⟨OreLocalization.one⟩
 
 @[to_additive]
-protected theorem one_def : (1 : R[S⁻¹]) = 1 /ₒ 1 := by
+protected theorem one_def [One X] : (1 : X[S⁻¹]) = 1 /ₒ 1 := by
   with_unfolding_all rfl
 
 @[to_additive]
@@ -378,10 +377,9 @@ protected theorem mul_assoc (x y z : R[S⁻¹]) : x * y * z = x * (y * z) :=
   OreLocalization.mul_smul x y z
 
 /-- `npow` of `OreLocalization` -/
-@[to_additive (attr := irreducible) "`nsmul` of `AddOreLocalization`"]
-protected def npow : ℕ → R[S⁻¹] → R[S⁻¹] := npowRec
+@[to_additive "`nsmul` of `AddOreLocalization`"]
+protected abbrev npow : ℕ → R[S⁻¹] → R[S⁻¹] := npowRec
 
-unseal OreLocalization.npow in
 @[to_additive]
 instance : Monoid R[S⁻¹] where
   one_mul := OreLocalization.one_mul
@@ -445,7 +443,7 @@ def numeratorUnit (s : S) : Units R[S⁻¹] where
 fraction `r /ₒ 1`. -/
 @[to_additive "The additive homomorphism from `R` to `AddOreLocalization R S`,
   mapping `r : R` to the difference `r -ₒ 0`."]
-def numeratorHom : R →* R[S⁻¹] where
+abbrev numeratorHom : R →* R[S⁻¹] where
   toFun r := r /ₒ 1
   map_one' := by with_unfolding_all rfl
   map_mul' _ _ := mul_div_one.symm

--- a/Mathlib/GroupTheory/OreLocalization/OreSet.lean
+++ b/Mathlib/GroupTheory/OreLocalization/OreSet.lean
@@ -117,6 +117,14 @@ instance (priority := 100) oreSetComm {R} [CommMonoid R] (S : Submonoid R) : Ore
   oreDenom _ s := s
   ore_eq r s := by rw [mul_comm]
 
+@[to_additive (attr := simp) AddOreLocalization.addOreSetComm_oreMin]
+lemma oreSetComm_oreNum {R : Type*} [CommMonoid R] (S : Submonoid R) (r : R) (s : S) :
+    oreNum r s = r := rfl
+
+@[to_additive (attr := simp) AddOreLocalization.addOreSetComm_oreSubtra]
+lemma oreSetComm_oreDenom {R : Type*} [CommMonoid R] (S : Submonoid R) (r : R) (s : S) :
+    oreDenom r s = s := rfl
+
 end Monoid
 
 end OreLocalization

--- a/Mathlib/GroupTheory/OreLocalization/OreSet.lean
+++ b/Mathlib/GroupTheory/OreLocalization/OreSet.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jakob von Raumer, Kevin Klinge
 -/
 import Mathlib.Algebra.Group.Submonoid.Defs
+import Mathlib.Algebra.Group.Action.Opposite
 
 /-!
 
@@ -19,21 +20,27 @@ This defines left Ore sets on arbitrary monoids.
 
 assert_not_exists RelIso
 
+universe u v
+
 namespace AddOreLocalization
 
 /-- A submonoid `S` of an additive monoid `R` is (left) Ore if common summands on the right can be
 turned into common summands on the left, and if each pair of `r : R` and `s : S` admits an Ore
 minuend `v : R` and an Ore subtrahend `u : S` such that `u + r = v + s`. -/
-class AddOreSet {R : Type*} [AddMonoid R] (S : AddSubmonoid R) where
+class AddOreSet {R : Type u} [AddMonoid R] (S : AddSubmonoid R) (M : Type v)
+    [AddAction R M] [AddAction Rᵃᵒᵖ M] where
   /-- Common summands on the right can be turned into common summands on the left, a weak form of
 cancellability. -/
-  ore_right_cancel : ∀ (r₁ r₂ : R) (s : S), r₁ + s = r₂ + s → ∃ s' : S, s' + r₁ = s' + r₂
+  ore_right_cancel :
+    ∀ (r₁ r₂ : M) (s : S),
+      AddOpposite.op (s : R) +ᵥ r₁ = AddOpposite.op (s : R) +ᵥ r₂ →
+        ∃ s' : S, (s' : R) +ᵥ r₁ = (s' : R) +ᵥ r₂
   /-- The Ore minuend of a difference. -/
-  oreMin : R → S → R
+  oreMin : M → S → M
   /-- The Ore subtrahend of a difference. -/
-  oreSubtra : R → S → S
+  oreSubtra : M → S → S
   /-- The Ore condition of a difference, expressed in terms of `oreMin` and `oreSubtra`. -/
-  ore_eq : ∀ (r : R) (s : S), oreSubtra r s + r = oreMin r s + s
+  ore_eq : ∀ (r : M) (s : S), (oreSubtra r s : R) +ᵥ r = AddOpposite.op (s : R) +ᵥ (oreMin r s : M)
 
 end AddOreLocalization
 
@@ -41,46 +48,52 @@ namespace OreLocalization
 
 section Monoid
 
+open scoped RightActions
+
+
 /-- A submonoid `S` of a monoid `R` is (left) Ore if common factors on the right can be turned
 into common factors on the left, and if each pair of `r : R` and `s : S` admits an Ore numerator
 `v : R` and an Ore denominator `u : S` such that `u * r = v * s`. -/
 @[to_additive AddOreLocalization.AddOreSet]
-class OreSet {R : Type*} [Monoid R] (S : Submonoid R) where
+class OreSet {R : Type u} [Monoid R] (S : Submonoid R) (M : Type v)
+    [MulAction R M] [MulAction Rᵐᵒᵖ M] where
   /-- Common factors on the right can be turned into common factors on the left, a weak form of
 cancellability. -/
-  ore_right_cancel : ∀ (r₁ r₂ : R) (s : S), r₁ * s = r₂ * s → ∃ s' : S, s' * r₁ = s' * r₂
+  ore_right_cancel :
+    ∀ (r₁ r₂ : M) (s : S), r₁ <• (s : R) = r₂ <• (s : R) → ∃ s' : S, (s' : R) • r₁ = (s' : R) • r₂
   /-- The Ore numerator of a fraction. -/
-  oreNum : R → S → R
+  oreNum : M → S → M
   /-- The Ore denominator of a fraction. -/
-  oreDenom : R → S → S
+  oreDenom : M → S → S
   /-- The Ore condition of a fraction, expressed in terms of `oreNum` and `oreDenom`. -/
-  ore_eq : ∀ (r : R) (s : S), oreDenom r s * r = oreNum r s * s
+  ore_eq : ∀ (r : M) (s : S), (oreDenom r s : R) • r = oreNum r s <• (s : R)
 
 -- TODO: use this once it's available.
 -- run_cmd to_additive.map_namespace `OreLocalization `AddOreLocalization
 
-variable {R : Type*} [Monoid R] {S : Submonoid R} [OreSet S]
+variable {R M: Type*} [Monoid R] [MulAction R M] [MulAction Rᵐᵒᵖ M] {S : Submonoid R} [OreSet S M]
 
 /-- Common factors on the right can be turned into common factors on the left, a weak form of
 cancellability. -/
 @[to_additive AddOreLocalization.ore_right_cancel]
-theorem ore_right_cancel (r₁ r₂ : R) (s : S) (h : r₁ * s = r₂ * s) : ∃ s' : S, s' * r₁ = s' * r₂ :=
+theorem ore_right_cancel (r₁ r₂ : M) (s : S) (h : r₁ <• (s : R) = r₂ <• (s : R)) :
+    ∃ s' : S, (s' : R) • r₁ = (s' : R) • r₂  :=
   OreSet.ore_right_cancel r₁ r₂ s h
 
 /-- The Ore numerator of a fraction. -/
 @[to_additive AddOreLocalization.oreMin "The Ore minuend of a difference."]
-def oreNum (r : R) (s : S) : R :=
+def oreNum (r : M) (s : S) : M :=
   OreSet.oreNum r s
 
 /-- The Ore denominator of a fraction. -/
 @[to_additive AddOreLocalization.oreSubtra "The Ore subtrahend of a difference."]
-def oreDenom (r : R) (s : S) : S :=
+def oreDenom (r : M) (s : S) : S :=
   OreSet.oreDenom r s
 
 /-- The Ore condition of a fraction, expressed in terms of `oreNum` and `oreDenom`. -/
 @[to_additive AddOreLocalization.add_ore_eq
   "The Ore condition of a difference, expressed in terms of `oreMin` and `oreSubtra`."]
-theorem ore_eq (r : R) (s : S) : oreDenom r s * r = oreNum r s * s :=
+theorem ore_eq (r : M) (s : S) : (oreDenom r s : R) • r = oreNum r s <• (s : R) :=
   OreSet.ore_eq r s
 
 /-- The Ore condition bundled in a sigma type. This is useful in situations where we want to obtain
@@ -88,20 +101,18 @@ both witnesses and the condition for a given fraction. -/
 @[to_additive AddOreLocalization.addOreCondition
   "The Ore condition bundled in a sigma type. This is useful in situations where we want to obtain
 both witnesses and the condition for a given difference."]
-def oreCondition (r : R) (s : S) : Σ'r' : R, Σ's' : S, s' * r = r' * s :=
+def oreCondition (r : M) (s : S) : Σ'r' : M, Σ's' : S, (s' : R) • r = r' <• (s : R) :=
   ⟨oreNum r s, oreDenom r s, ore_eq r s⟩
 
 /-- The trivial submonoid is an Ore set. -/
 @[to_additive AddOreLocalization.addOreSetBot]
-instance oreSetBot : OreSet (⊥ : Submonoid R) where
+instance oreSetBot : OreSet (⊥ : Submonoid R) M where
   ore_right_cancel _ _ s h :=
     ⟨s, by
       rcases s with ⟨s, hs⟩
       rw [Submonoid.mem_bot] at hs
       subst hs
-      rw [mul_one, mul_one] at h
-      subst h
-      rfl⟩
+      simpa using h⟩
   oreNum r _ := r
   oreDenom _ s := s
   ore_eq _ s := by
@@ -111,11 +122,12 @@ instance oreSetBot : OreSet (⊥ : Submonoid R) where
 
 /-- Every submonoid of a commutative monoid is an Ore set. -/
 @[to_additive AddOreLocalization.addOreSetComm]
-instance (priority := 100) oreSetComm {R} [CommMonoid R] (S : Submonoid R) : OreSet S where
-  ore_right_cancel m n s h := ⟨s, by rw [mul_comm (s : R) n, mul_comm (s : R) m, h]⟩
+instance (priority := 100) oreSetComm {R} [CommMonoid R] [MulAction R M] [MulAction Rᵐᵒᵖ M]
+    [IsCentralScalar R M] (S : Submonoid R) : OreSet S M where
+  ore_right_cancel m n s h := ⟨s, by simpa [op_smul_eq_smul] using h⟩
   oreNum r _ := r
   oreDenom _ s := s
-  ore_eq r s := by rw [mul_comm]
+  ore_eq r s := by rw [op_smul_eq_smul]
 
 @[to_additive (attr := simp) AddOreLocalization.addOreSetComm_oreMin]
 lemma oreSetComm_oreNum {R : Type*} [CommMonoid R] (S : Submonoid R) (r : R) (s : S) :

--- a/Mathlib/RingTheory/OreLocalization/Ring.lean
+++ b/Mathlib/RingTheory/OreLocalization/Ring.lean
@@ -109,7 +109,7 @@ lemma nsmul_eq_nsmul (n : ℕ) (x : X[S⁻¹]) :
 
 /-- The ring homomorphism from `R` to `R[S⁻¹]`, mapping `r : R` to the fraction `r /ₒ 1`. -/
 @[simps!]
-def numeratorRingHom : R →+* R[S⁻¹] where
+abbrev numeratorRingHom : R →+* R[S⁻¹] where
   __ := numeratorHom
   map_zero' := by with_unfolding_all exact OreLocalization.zero_def
   map_add' _ _ := add_oreDiv.symm

--- a/Mathlib/RingTheory/TensorProduct/Nontrivial.lean
+++ b/Mathlib/RingTheory/TensorProduct/Nontrivial.lean
@@ -34,6 +34,7 @@ theorem nontrivial_of_algebraMap_injective_of_isDomain
   let fb : FR →ₐ[R] FB := IsFractionRing.liftAlgHom (g := Algebra.ofId R FB)
     ((IsFractionRing.injective B FB).comp hb)
   algebraize_only [fa.toRingHom, fb.toRingHom]
+  letI : CompatibleSMul FR R FA FB := CompatibleSMul.isScalarTower
   exact Algebra.TensorProduct.mapOfCompatibleSMul FR R FA FB |>.comp
     (Algebra.TensorProduct.map (IsScalarTower.toAlgHom R A FA) (IsScalarTower.toAlgHom R B FB))
     |>.toRingHom.domain_nontrivial


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
