### PR TITLE
[Merged by Bors] - fix: download oleans from main cache before fork cache

### DIFF
--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -229,9 +229,9 @@ def getFiles
   else
     let repo ← getRemoteRepo (← read).mathlibDepPath
     IO.println s!"Mathlib repository: {repo}"
-    downloadFiles repo hashMap forceDownload parallel (warnOnMissing := false)
     unless repo == MATHLIBREPO do
-      downloadFiles MATHLIBREPO hashMap forceDownload parallel (warnOnMissing := true)
+      downloadFiles MATHLIBREPO hashMap forceDownload parallel (warnOnMissing := false)
+    downloadFiles repo hashMap forceDownload parallel (warnOnMissing := true)
   if decompress then
     IO.unpackCache hashMap forceUnpack
   else


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
