### PR TITLE
feat: Enumeration of NonemptyInterval

### DIFF
--- a/Mathlib/Data/Sym/Sym2/Fin.lean
+++ b/Mathlib/Data/Sym/Sym2/Fin.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2025 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+-/
+import Mathlib.Data.Sym.Sym2.Order
+import Mathlib.Data.Nat.Sqrt
+import Mathlib.Data.Nat.Choose.Bounds
+
+private def chooseTwoInv (x) := (Nat.sqrt (8 * x + 1) - 1) / 2
+theorem choose_two_le (x) : (chooseTwoInv x + 1).choose 2 ≤ x := by
+  sorry
+
+
+@[simps!]
+def nonemptyIntervalFinEquiv {n} :
+    NonemptyInterval (Fin n) ≃o Fin ((n + 1).choose 2) where
+  toFun x := ⟨((x.1.2 + 1 : Nat).choose 2 + x.1.1 : ℕ), sorry⟩
+  invFun x :=
+    have hy : chooseTwoInv _ < _ := sorry
+    ⟨(⟨x.1 - (chooseTwoInv x.1 + 1).choose 2, by
+      apply Nat.sub_lt_left_of_lt_add
+      · apply choose_two_le
+      refine x.prop.trans_le ?_
+      simp [Nat.choose_two_right]
+      apply Nat.div_le_of_le_mul
+      sorry⟩, ⟨chooseTwoInv _, hy⟩), sorry⟩
+  left_inv
+  | ⟨(a, b), p⟩ => by
+    ext <;> dsimp
+    · sorry
+    · sorry
+  right_inv x := by
+    ext
+    refine Nat.add_sub_of_le (choose_two_le _)
+  map_rel_iff' {m n} := by
+    sorry
+
+/-- The numbering of the elements of `Sym2 (Fin n)` in lexicographic order. -/
+@[simps!]
+def Sym2.equivFin {n} : Sym2 (Fin n) ≃ Fin ((n + 1).choose 2) :=
+  Sym2.sortEquiv.trans nonemptyIntervalFinEquiv.toEquiv
+
+open Sym2
+
+#eval! [s(0,0), s(0,1), s(1,1), s(0,2), s(1,2), s(2,2)].map (equivFin (n := 3) )
+#guard ∀ i : Fin _, equivFin (equivFin (n := 50).symm i) = i

--- a/Mathlib/Data/Sym/Sym2/Order.lean
+++ b/Mathlib/Data/Sym/Sym2/Order.lean
@@ -5,6 +5,7 @@ Authors: Eric Wieser
 -/
 import Mathlib.Data.Sym.Sym2
 import Mathlib.Order.Lattice
+import Mathlib.Order.Interval.Basic
 
 /-!
 # Sorting the elements of `Sym2`
@@ -32,15 +33,15 @@ protected theorem inf_le_sup [Lattice α] (s : Sym2 α) : s.inf ≤ s.sup := by
 
 /-- In a linear order, symmetric squares are canonically identified with ordered pairs. -/
 @[simps!]
-def sortEquiv [LinearOrder α] : Sym2 α ≃ { p : α × α // p.1 ≤ p.2 } where
+def sortEquiv [LinearOrder α] : Sym2 α ≃ NonemptyInterval α where
   toFun s := ⟨(s.inf, s.sup), Sym2.inf_le_sup _⟩
-  invFun p := Sym2.mk p
+  invFun p := Sym2.mk p.toProd
   left_inv := Sym2.ind fun a b => mk_eq_mk_iff.mpr <| by
     cases le_total a b with
     | inl h => simp [h]
     | inr h => simp [h]
-  right_inv := Subtype.rec <| Prod.rec fun x y hxy =>
-    Subtype.ext <| Prod.ext (by simp [hxy]) (by simp [hxy])
+  right_inv := NonemptyInterval.rec <| Prod.rec fun x y hxy =>
+    NonemptyInterval.ext <| Prod.ext (by simp [hxy]) (by simp [hxy])
 
 /-- In a linear order, two symmetric squares are equal if and only if
 they have the same infimum and supremum. -/


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
