### PR TITLE
[Merged by Bors] - refactor: make `Matrix.kroneckerTMulAlgEquiv` heterogeneous

### DIFF
--- a/Mathlib/Data/Matrix/Kronecker.lean
+++ b/Mathlib/Data/Matrix/Kronecker.lean
@@ -46,7 +46,7 @@ These require `open Kronecker`:
 namespace Matrix
 open scoped RightActions
 
-variable {R α α' β β' γ γ' : Type*}
+variable {R S α α' β β' γ γ' : Type*}
 variable {l m n p : Type*} {q r : Type*} {l' m' n' p' : Type*}
 
 section KroneckerMap
@@ -182,10 +182,12 @@ theorem kroneckerMap_assoc₁ {δ ξ ω : Type*} (f : α → β → γ) (g : γ 
 
 /-- When `f` is bilinear then `Matrix.kroneckerMap f` is also bilinear. -/
 @[simps!]
-def kroneckerMapBilinear [CommSemiring R] [AddCommMonoid α] [AddCommMonoid β] [AddCommMonoid γ]
-    [Module R α] [Module R β] [Module R γ] (f : α →ₗ[R] β →ₗ[R] γ) :
-    Matrix l m α →ₗ[R] Matrix n p β →ₗ[R] Matrix (l × n) (m × p) γ :=
-  LinearMap.mk₂ R (kroneckerMap fun r s => f r s) (kroneckerMap_add_left _ <| f.map_add₂)
+def kroneckerMapBilinear [Semiring S] [Semiring R]
+    [AddCommMonoid α] [AddCommMonoid β] [AddCommMonoid γ]
+    [Module R α] [Module R γ] [Module S β] [Module S γ] [SMulCommClass S R γ]
+    (f : α →ₗ[R] β →ₗ[S] γ) :
+    Matrix l m α →ₗ[R] Matrix n p β →ₗ[S] Matrix (l × n) (m × p) γ :=
+  LinearMap.mk₂' R S (kroneckerMap fun r s => f r s) (kroneckerMap_add_left _ <| f.map_add₂)
     (fun _ => kroneckerMap_smul_left _ _ <| f.map_smul₂ _)
     (kroneckerMap_add_right _ fun a => (f a).map_add) fun r =>
     kroneckerMap_smul_right _ _ fun a => (f a).map_smul r
@@ -193,9 +195,10 @@ def kroneckerMapBilinear [CommSemiring R] [AddCommMonoid α] [AddCommMonoid β] 
 /-- `Matrix.kroneckerMapBilinear` commutes with `*` if `f` does.
 
 This is primarily used with `R = ℕ` to prove `Matrix.mul_kronecker_mul`. -/
-theorem kroneckerMapBilinear_mul_mul [CommSemiring R] [Fintype m] [Fintype m']
+theorem kroneckerMapBilinear_mul_mul [Semiring S] [Semiring R] [Fintype m] [Fintype m']
     [NonUnitalNonAssocSemiring α] [NonUnitalNonAssocSemiring β] [NonUnitalNonAssocSemiring γ]
-    [Module R α] [Module R β] [Module R γ] (f : α →ₗ[R] β →ₗ[R] γ)
+    [Module R α] [Module R γ] [Module S β] [Module S γ] [SMulCommClass S R γ]
+    (f : α →ₗ[R] β →ₗ[S] γ)
     (h_comm : ∀ a b a' b', f (a * b) (a' * b') = f a a' * f b b') (A : Matrix l m α)
     (B : Matrix m n α) (A' : Matrix l' m' β) (B' : Matrix m' n' β) :
     kroneckerMapBilinear f (A * B) (A' * B') =
@@ -208,9 +211,11 @@ theorem kroneckerMapBilinear_mul_mul [CommSemiring R] [Fintype m] [Fintype m']
 /-- `trace` distributes over `Matrix.kroneckerMapBilinear`.
 
 This is primarily used with `R = ℕ` to prove `Matrix.trace_kronecker`. -/
-theorem trace_kroneckerMapBilinear [CommSemiring R] [Fintype m] [Fintype n] [AddCommMonoid α]
-    [AddCommMonoid β] [AddCommMonoid γ] [Module R α] [Module R β] [Module R γ]
-    (f : α →ₗ[R] β →ₗ[R] γ) (A : Matrix m m α) (B : Matrix n n β) :
+theorem trace_kroneckerMapBilinear [Semiring S] [Semiring R] [Fintype m] [Fintype n]
+    [AddCommMonoid α] [AddCommMonoid β] [AddCommMonoid γ]
+    [Module R α] [Module R γ] [Module S β] [Module S γ] [SMulCommClass S R γ]
+    (f : α →ₗ[R] β →ₗ[S] γ)
+    (A : Matrix m m α) (B : Matrix n n β) :
     trace (kroneckerMapBilinear f A B) = f (trace A) (trace B) := by
   simp_rw [Matrix.trace, Matrix.diag, kroneckerMapBilinear_apply_apply, LinearMap.map_sum₂,
     map_sum, ← Finset.univ_product_univ, Finset.sum_product, kroneckerMap_apply]
@@ -218,10 +223,10 @@ theorem trace_kroneckerMapBilinear [CommSemiring R] [Fintype m] [Fintype n] [Add
 /-- `determinant` of `Matrix.kroneckerMapBilinear`.
 
 This is primarily used with `R = ℕ` to prove `Matrix.det_kronecker`. -/
-theorem det_kroneckerMapBilinear [CommSemiring R] [Fintype m] [Fintype n] [DecidableEq m]
-    [DecidableEq n] [NonAssocSemiring α] [NonAssocSemiring β] [CommRing γ] [Module R α] [Module R β]
-    [Module R γ]
-    (f : α →ₗ[R] β →ₗ[R] γ) (h_comm : ∀ a b a' b', f (a * b) (a' * b') = f a a' * f b b')
+theorem det_kroneckerMapBilinear  [Semiring S] [Semiring R] [Fintype m] [Fintype n] [DecidableEq m]
+    [DecidableEq n] [NonAssocSemiring α] [NonAssocSemiring β] [CommRing γ] [Module R α] [Module S β]
+    [Module R γ] [Module S γ] [SMulCommClass S R γ]
+    (f : α →ₗ[R] β →ₗ[S] γ) (h_comm : ∀ a b a' b', f (a * b) (a' * b') = f a a' * f b b')
     (A : Matrix m m α) (B : Matrix n n β) :
     det (kroneckerMapBilinear f A B) =
       det (A.map fun a => f a 1) ^ Fintype.card n * det (B.map fun b => f 1 b) ^ Fintype.card m :=
@@ -408,7 +413,8 @@ section Module
 
 suppress_compilation
 
-variable [CommSemiring R] [AddCommMonoid α] [AddCommMonoid β] [AddCommMonoid γ]
+variable [CommSemiring R]
+variable [AddCommMonoid α] [AddCommMonoid β] [AddCommMonoid γ]
 variable [Module R α] [Module R β] [Module R γ]
 
 /-- The Kronecker tensor product. This is just a shorthand for `kroneckerMap (⊗ₜ)`.
@@ -430,14 +436,16 @@ theorem kroneckerTMul_apply (A : Matrix l m α) (B : Matrix n p β) (i₁ i₂ j
     (A ⊗ₖₜ B) (i₁, i₂) (j₁, j₂) = A i₁ j₁ ⊗ₜ[R] B i₂ j₂ :=
   rfl
 
+variable (S) in
 /-- `Matrix.kronecker` as a bilinear map. -/
-def kroneckerTMulBilinear :
-    Matrix l m α →ₗ[R] Matrix n p β →ₗ[R] Matrix (l × n) (m × p) (α ⊗[R] β) :=
-  kroneckerMapBilinear (TensorProduct.mk R α β)
+def kroneckerTMulBilinear [Semiring S] [Module S α]  [SMulCommClass R S α] :
+    Matrix l m α →ₗ[S] Matrix n p β →ₗ[R] Matrix (l × n) (m × p) (α ⊗[R] β) :=
+  kroneckerMapBilinear (AlgebraTensorModule.mk _ _ α β)
 
 @[simp]
-theorem kroneckerTMulBilinear_apply (A : Matrix l m α) (B : Matrix n p β) :
-    kroneckerTMulBilinear R A B = A ⊗ₖₜ B := rfl
+theorem kroneckerTMulBilinear_apply [Semiring S] [Module S α]  [SMulCommClass R S α]
+    (A : Matrix l m α) (B : Matrix n p β) :
+    kroneckerTMulBilinear R S A B = A ⊗ₖₜ[R] B := rfl
 
 /-! What follows is a copy, in order, of every `Matrix.kroneckerMap` lemma above that has
 hypotheses which can be filled by properties of `⊗ₜ`. -/
@@ -453,16 +461,19 @@ theorem add_kroneckerTMul (A₁ A₂ : Matrix l m α) (B : Matrix n p α) :
     (A₁ + A₂) ⊗ₖₜ[R] B = A₁ ⊗ₖₜ B + A₂ ⊗ₖₜ B :=
   kroneckerMap_add_left _ add_tmul _ _ _
 
-theorem kroneckerTMul_add (A : Matrix l m α) (B₁ B₂ : Matrix n p α) :
+theorem kroneckerTMul_add (A : Matrix l m α) (B₁ B₂ : Matrix n p β) :
     A ⊗ₖₜ[R] (B₁ + B₂) = A ⊗ₖₜ B₁ + A ⊗ₖₜ B₂ :=
   kroneckerMap_add_right _ tmul_add _ _ _
 
-theorem smul_kroneckerTMul (r : R) (A : Matrix l m α) (B : Matrix n p α) :
-    (r • A) ⊗ₖₜ[R] B = r • A ⊗ₖₜ B :=
+theorem smul_kroneckerTMul [Monoid S] [DistribMulAction S α] [SMulCommClass R S α]
+    (r : S) (A : Matrix l m α) (B : Matrix n p β) :
+    (r • A) ⊗ₖₜ[R] B = r • A ⊗ₖₜ[R] B :=
   kroneckerMap_smul_left _ _ (fun _ _ => smul_tmul' _ _ _) _ _
 
-theorem kroneckerTMul_smul (r : R) (A : Matrix l m α) (B : Matrix n p α) :
-    A ⊗ₖₜ[R] (r • B) = r • A ⊗ₖₜ B :=
+theorem kroneckerTMul_smul [Monoid S] [DistribMulAction S α] [DistribMulAction S β]
+    [SMul S R] [SMulCommClass R S α] [IsScalarTower S R α] [IsScalarTower S R β]
+    (r : S) (A : Matrix l m α) (B : Matrix n p β) :
+    A ⊗ₖₜ[R] (r • B) = r • A ⊗ₖₜ[R] B :=
   kroneckerMap_smul_right _ _ (fun _ _ => tmul_smul _ _ _) _ _
 
 theorem single_kroneckerTMul_single
@@ -474,15 +485,15 @@ theorem single_kroneckerTMul_single
 @[deprecated (since := "2025-05-05")]
 alias stdBasisMatrix_kroneckerTMul_stdBasisMatrix := single_kroneckerTMul_single
 
-theorem diagonal_kroneckerTMul_diagonal [DecidableEq m] [DecidableEq n] (a : m → α) (b : n → α) :
+theorem diagonal_kroneckerTMul_diagonal [DecidableEq m] [DecidableEq n] (a : m → α) (b : n → β) :
     diagonal a ⊗ₖₜ[R] diagonal b = diagonal fun mn => a mn.1 ⊗ₜ b mn.2 :=
   kroneckerMap_diagonal_diagonal _ (zero_tmul _) (tmul_zero _) _ _
 
-theorem kroneckerTMul_diagonal [DecidableEq n] (A : Matrix l m α) (b : n → α) :
+theorem kroneckerTMul_diagonal [DecidableEq n] (A : Matrix l m α) (b : n → β) :
     A ⊗ₖₜ[R] diagonal b = blockDiagonal fun i => A.map fun a => a ⊗ₜ[R] b i :=
   kroneckerMap_diagonal_right _ (tmul_zero _) _ _
 
-theorem diagonal_kroneckerTMul [DecidableEq l] (a : l → α) (B : Matrix m n α) :
+theorem diagonal_kroneckerTMul [DecidableEq l] (a : l → α) (B : Matrix m n β) :
     diagonal a ⊗ₖₜ[R] B =
       Matrix.reindex (Equiv.prodComm _ _) (Equiv.prodComm _ _)
         (blockDiagonal fun i => B.map fun b => a i ⊗ₜ[R] b) :=

--- a/Mathlib/Data/Matrix/Kronecker.lean
+++ b/Mathlib/Data/Matrix/Kronecker.lean
@@ -223,7 +223,7 @@ theorem trace_kroneckerMapBilinear [Semiring S] [Semiring R] [Fintype m] [Fintyp
 /-- `determinant` of `Matrix.kroneckerMapBilinear`.
 
 This is primarily used with `R = ℕ` to prove `Matrix.det_kronecker`. -/
-theorem det_kroneckerMapBilinear  [Semiring S] [Semiring R] [Fintype m] [Fintype n] [DecidableEq m]
+theorem det_kroneckerMapBilinear [Semiring S] [Semiring R] [Fintype m] [Fintype n] [DecidableEq m]
     [DecidableEq n] [NonAssocSemiring α] [NonAssocSemiring β] [CommRing γ] [Module R α] [Module S β]
     [Module R γ] [Module S γ] [SMulCommClass S R γ]
     (f : α →ₗ[R] β →ₗ[S] γ) (h_comm : ∀ a b a' b', f (a * b) (a' * b') = f a a' * f b b')
@@ -438,12 +438,12 @@ theorem kroneckerTMul_apply (A : Matrix l m α) (B : Matrix n p β) (i₁ i₂ j
 
 variable (S) in
 /-- `Matrix.kronecker` as a bilinear map. -/
-def kroneckerTMulBilinear [Semiring S] [Module S α]  [SMulCommClass R S α] :
+def kroneckerTMulBilinear [Semiring S] [Module S α] [SMulCommClass R S α] :
     Matrix l m α →ₗ[S] Matrix n p β →ₗ[R] Matrix (l × n) (m × p) (α ⊗[R] β) :=
   kroneckerMapBilinear (AlgebraTensorModule.mk _ _ α β)
 
 @[simp]
-theorem kroneckerTMulBilinear_apply [Semiring S] [Module S α]  [SMulCommClass R S α]
+theorem kroneckerTMulBilinear_apply [Semiring S] [Module S α] [SMulCommClass R S α]
     (A : Matrix l m α) (B : Matrix n p β) :
     kroneckerTMulBilinear R S A B = A ⊗ₖₜ[R] B := rfl
 

--- a/Mathlib/RingTheory/MatrixAlgebra.lean
+++ b/Mathlib/RingTheory/MatrixAlgebra.lean
@@ -24,28 +24,29 @@ suppress_compilation
 
 open TensorProduct Algebra.TensorProduct Matrix
 
-variable {l m n p : Type*} {R A B M N : Type*}
+variable {l m n p : Type*} {R S A B M N : Type*}
 section Module
 
-variable [CommSemiring R] [AddCommMonoid M] [AddCommMonoid N] [Semiring A] [Semiring B]
-variable [Module R M] [Module R N] [Algebra R A] [Algebra R B]
+variable [CommSemiring R] [Semiring S] [Semiring A] [Semiring B] [AddCommMonoid M] [AddCommMonoid N]
+variable [Algebra R S] [Algebra R A] [Algebra R B] [Module R M] [Module S M] [Module R N]
+variable [IsScalarTower R S M]
 variable [Fintype l] [Fintype m] [Fintype n] [Fintype p]
 variable [DecidableEq l] [DecidableEq m] [DecidableEq n] [DecidableEq p]
 
 open Kronecker
 
-variable (l m n p R M N)
+variable (l m n p R S A M N)
 
 attribute [local ext] ext_linearMap
 
 /-- `Matrix.kroneckerTMul` as a linear equivalence, when the two arguments are tensored. -/
 def kroneckerTMulLinearEquiv :
-    Matrix l m M ⊗[R] Matrix n p N ≃ₗ[R] Matrix (l × n) (m × p) (M ⊗[R] N) :=
+    Matrix l m M ⊗[R] Matrix n p N ≃ₗ[S] Matrix (l × n) (m × p) (M ⊗[R] N) :=
   .ofLinear
-    (TensorProduct.lift <| kroneckerTMulBilinear _)
-    ((LinearMap.lsum R _ R fun ii => LinearMap.lsum R _ R fun jj => TensorProduct.map
-      (singleLinearMap R ii.1 jj.1) (singleLinearMap R ii.2 jj.2))
-      ∘ₗ (ofLinearEquiv R).symm.toLinearMap)
+    (AlgebraTensorModule.lift <| kroneckerTMulBilinear R S)
+    ((LinearMap.lsum S _ R fun ii => LinearMap.lsum S _ R fun jj => AlgebraTensorModule.map
+       (singleLinearMap S ii.1 jj.1) (singleLinearMap R ii.2 jj.2))
+      ∘ₗ (ofLinearEquiv S).symm.toLinearMap)
     (by
       ext : 4
       simp [-LinearMap.lsum_apply, LinearMap.lsum_piSingle,
@@ -57,12 +58,12 @@ def kroneckerTMulLinearEquiv :
 
 @[simp]
 theorem kroneckerTMulLinearEquiv_tmul (a : Matrix l m M) (b : Matrix n p N) :
-    kroneckerTMulLinearEquiv l m n p R M N (a ⊗ₜ b) = a ⊗ₖₜ b := rfl
+    kroneckerTMulLinearEquiv l m n p R S M N (a ⊗ₜ b) = a ⊗ₖₜ b := rfl
 
 @[simp]
 theorem kroneckerTMulAlgEquiv_symm_single_tmul
     (ia : l) (ja : m) (ib : n) (jb : p) (a : M) (b : N) :
-    (kroneckerTMulLinearEquiv l m n p R M N).symm (single (ia, ib) (ja, jb) (a ⊗ₜ b)) =
+    (kroneckerTMulLinearEquiv l m n p R S M N).symm (single (ia, ib) (ja, jb) (a ⊗ₜ b)) =
       single ia ja a ⊗ₜ single ib jb b := by
   rw [LinearEquiv.symm_apply_eq, kroneckerTMulLinearEquiv_tmul,
     single_kroneckerTMul_single]
@@ -71,17 +72,17 @@ theorem kroneckerTMulAlgEquiv_symm_single_tmul
 alias kroneckerTMulAlgEquiv_symm_stdBasisMatrix_tmul := kroneckerTMulAlgEquiv_symm_single_tmul
 
 @[simp]
-theorem kroneckerTMulLinearEquiv_one :
-    kroneckerTMulLinearEquiv m m n n R A B 1 = 1 := by simp [Algebra.TensorProduct.one_def]
+theorem kroneckerTMulLinearEquiv_one [Module S A] [IsScalarTower R S A] :
+    kroneckerTMulLinearEquiv m m n n R S A B 1 = 1 := by simp [Algebra.TensorProduct.one_def]
 
 /-- Note this can't be stated for rectangular matrices because there is no
 `HMul (TensorProduct R _ _) (TensorProduct R _ _) (TensorProduct R _ _)` instance. -/
 @[simp]
-theorem kroneckerTMulLinearEquiv_mul :
+theorem kroneckerTMulLinearEquiv_mul [Module S A] [IsScalarTower R S A] :
     ∀ x y : Matrix m m A ⊗[R] Matrix n n B,
-      kroneckerTMulLinearEquiv m m n n R A B (x * y) =
-        kroneckerTMulLinearEquiv m m n n R A B x * kroneckerTMulLinearEquiv m m n n R A B y :=
-  (kroneckerTMulLinearEquiv m m n n R A B).toLinearMap.map_mul_iff.2 <| by
+      kroneckerTMulLinearEquiv m m n n R S A B (x * y) =
+        kroneckerTMulLinearEquiv m m n n R S A B x * kroneckerTMulLinearEquiv m m n n R S A B y :=
+  (kroneckerTMulLinearEquiv m m n n R S A B).toLinearMap.restrictScalars R |>.map_mul_iff.2 <| by
     ext : 10
     simp [single_kroneckerTMul_single, mul_kroneckerTMul_mul]
 
@@ -223,25 +224,28 @@ theorem matrixEquivTensor_apply_symm (a : A) (M : Matrix n n R) :
 namespace Matrix
 open scoped Kronecker
 
-variable (m) (B) [Fintype m] [DecidableEq m]
+variable (m) (S B)
+variable [CommSemiring S] [Algebra R S] [Algebra S A] [IsScalarTower R S A]
+variable [Fintype m] [DecidableEq m]
 
 /-- `Matrix.kroneckerTMul` as an algebra equivalence, when the two arguments are tensored. -/
 def kroneckerTMulAlgEquiv :
-    Matrix m m A ⊗[R] Matrix n n B ≃ₐ[R] Matrix (m × n) (m × n) (A ⊗[R] B) :=
-  .ofLinearEquiv (kroneckerTMulLinearEquiv m m n n R A B)
-    (kroneckerTMulLinearEquiv_one _ _ _)
-    (kroneckerTMulLinearEquiv_mul _ _ _)
+    Matrix m m A ⊗[R] Matrix n n B ≃ₐ[S] Matrix (m × n) (m × n) (A ⊗[R] B) :=
+  .ofLinearEquiv (kroneckerTMulLinearEquiv m m n n R S A B)
+    (kroneckerTMulLinearEquiv_one _ _ _ _ _)
+    (kroneckerTMulLinearEquiv_mul _ _ _ _ _)
 
 variable {m n A B}
 
 @[simp]
 theorem kroneckerTMulAlgEquiv_apply (x : Matrix m m A ⊗[R] Matrix n n B) :
-    (kroneckerTMulAlgEquiv m n R A B) x = kroneckerTMulLinearEquiv m m n n R A B x :=
+    (kroneckerTMulAlgEquiv m n R S A B) x = kroneckerTMulLinearEquiv m m n n R S A B x :=
   rfl
 
 @[simp]
 theorem kroneckerTMulAlgEquiv_symm_apply (x : Matrix (m × n) (m × n) (A ⊗[R] B)) :
-    (kroneckerTMulAlgEquiv m n R A B).symm x = (kroneckerTMulLinearEquiv m m n n R A B).symm x :=
+    (kroneckerTMulAlgEquiv m n R S A B).symm x =
+      (kroneckerTMulLinearEquiv m m n n R S A B).symm x :=
   rfl
 
 end Matrix

--- a/Mathlib/RingTheory/MatrixAlgebra.lean
+++ b/Mathlib/RingTheory/MatrixAlgebra.lean
@@ -16,8 +16,8 @@ import Mathlib.RingTheory.TensorProduct.Basic
 
 * `matrixEquivTensor : Matrix n n A ≃ₐ[R] (A ⊗[R] Matrix n n R)`.
 * `Matrix.kroneckerTMulAlgEquiv :
-    Matrix m m A ⊗[R] Matrix n n B ≃ₐ[R] Matrix (m × n) (m × n) (A ⊗[R] B)`,
-  where the forward map is the (tensor-ified) kronecker product.
+    Matrix m m A ⊗[R] Matrix n n B ≃ₐ[S] Matrix (m × n) (m × n) (A ⊗[R] B)`,
+  where the forward map is the (tensor-ified) Kronecker product.
 -/
 
 suppress_compilation

--- a/Mathlib/RingTheory/MatrixAlgebra.lean
+++ b/Mathlib/RingTheory/MatrixAlgebra.lean
@@ -45,7 +45,7 @@ def kroneckerTMulLinearEquiv :
   .ofLinear
     (AlgebraTensorModule.lift <| kroneckerTMulBilinear R S)
     ((LinearMap.lsum S _ R fun ii => LinearMap.lsum S _ R fun jj => AlgebraTensorModule.map
-       (singleLinearMap S ii.1 jj.1) (singleLinearMap R ii.2 jj.2))
+      (singleLinearMap S ii.1 jj.1) (singleLinearMap R ii.2 jj.2))
       ∘ₗ (ofLinearEquiv S).symm.toLinearMap)
     (by
       ext : 4


### PR DESCRIPTION
This generalizes as
```diff
-Matrix m m A ⊗[R] Matrix n n B ≃ₐ[R] Matrix (m × n) (m × n) (A ⊗[R] B)
+Matrix m m A ⊗[R] Matrix n n B ≃ₐ[S] Matrix (m × n) (m × n) (A ⊗[R] B)
```
where R / S / A is a tower of algebras. Notably, when `A` is commutative this allows `S := A`.

The module version is similarly generalized.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
