### PR TITLE
[Merged by Bors] - chore: migrate zulip_emoji_closed and zulip_emoji_labeling to pull_request_target

### DIFF
--- a/.github/workflows/zulip_emoji_closed_pr.yaml
+++ b/.github/workflows/zulip_emoji_closed_pr.yaml
@@ -3,9 +3,14 @@ name: Add "closed-pr" emoji in Zulip
 
 # triggers the action when
 on:
-  pull_request:
+  pull_request_target:
     # the pull request is closed or reopened, to add or remove the emoji
     types: [closed, reopened]
+
+# Limit permissions for GITHUB_TOKEN for the entire workflow
+permissions:
+  contents: read # minimum permissions for actions/checkout & actions/setup-python
+  # All other permissions are implicitly 'none'
 
 jobs:
   add_closed_pr_emoji:
@@ -15,7 +20,7 @@ jobs:
 
     name: Add closed-pr emoji in Zulip
     runs-on: ubuntu-latest
-    if: github.repository == 'leanprover-community/mathlib4' && !github.event.pull_request.head.repo.fork
+    if: github.repository == 'leanprover-community/mathlib4'
     steps:
       - name: Debugging information
         run: |
@@ -43,6 +48,7 @@ jobs:
                 github.event_name == 'reopened' }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          ref: master
           sparse-checkout: |
             scripts/zulip_emoji_reactions.py
 

--- a/.github/workflows/zulip_emoji_labelling.yaml
+++ b/.github/workflows/zulip_emoji_labelling.yaml
@@ -1,17 +1,24 @@
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled, unlabeled]
+
+# Limit permissions for GITHUB_TOKEN for the entire workflow
+permissions:
+  contents: read # minimum permissions for actions/checkout & actions/setup-python
+  # All other permissions are implicitly 'none'
+
 jobs:
   # When a PR is (un)labelled with awaiting-author or maintainer-merge,
   # add resp. remove the matching emoji reaction from zulip messages.
   set_pr_emoji:
     if: (github.event.label.name == 'awaiting-author' || github.event.label.name == 'maintainer-merge') &&
-        github.repository == 'leanprover-community/mathlib4' && !github.event.pull_request.head.repo.fork
+        github.repository == 'leanprover-community/mathlib4'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout mathlib repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
+          ref: master
           sparse-checkout: |
             scripts/zulip_emoji_reactions.py
 


### PR DESCRIPTION
and reenable on PRs from forks


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
