### PR TITLE
[Merged by Bors] - feat: more RestrictedProduct API

### DIFF
--- a/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
@@ -374,14 +374,14 @@ given maps on the factors. -/
 def map {G H : ι → Type*}
     {C : (i : ι) → Set (G i)}
     {D : (i : ι) → Set (H i)} (φ : (i : ι) → G i → H i)
-    (hφ : ∀ᶠ i in 𝓕, Set.MapsTo (φ i) (C i) (D i))
+    (hφ : ∀ᶠ i in 𝓕, MapsTo (φ i) (C i) (D i))
     (x : Πʳ i, [G i, C i]_[𝓕]) : (Πʳ i, [H i, D i]_[𝓕]) :=
   mapAlong G H id Filter.tendsto_id φ hφ x
 
 @[simp]
 lemma map_apply {G H : ι → Type*} {C : (i : ι) → Set (G i)}
     {D : (i : ι) → Set (H i)} (φ : (i : ι) → G i → H i)
-    (hφ : ∀ᶠ i in 𝓕, Set.MapsTo (φ i) (C i) (D i))
+    (hφ : ∀ᶠ i in 𝓕, MapsTo (φ i) (C i) (D i))
     (x : Πʳ i, [G i, C i]_[𝓕]) (j : ι) :
     x.map φ hφ j = φ j (x j) :=
   rfl

--- a/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
@@ -256,20 +256,11 @@ lemma zpow_apply [Π i, DivInvMonoid (R i)] [∀ i, SubgroupClass (S i) (R i)]
     (x : Πʳ i, [R i, B i]_[𝓕]) (n : ℤ) (i : ι) : (x ^ n) i = x i ^ n :=
   rfl
 
-@[to_additive]
 instance [Π i, AddMonoidWithOne (R i)] [∀ i, AddSubmonoidWithOneClass (S i) (R i)] :
     NatCast (Πʳ i, [R i, B i]_[𝓕]) where
   natCast n := ⟨fun _ ↦ n, .of_forall fun _ ↦ natCast_mem _ n⟩
 
 @[to_additive]
-instance [Π i, AddGroup (R i)] [∀ i, AddSubgroupClass (S i) (R i)] :
-    AddGroup (Πʳ i, [R i, B i]_[𝓕]) :=
-  haveI : ∀ i, SMulMemClass (S i) ℤ (R i) := fun _ ↦ AddSubgroupClass.zsmulMemClass
-  haveI : ∀ i, SMulMemClass (S i) ℕ (R i) := fun _ ↦ AddSubmonoidClass.nsmulMemClass
-  DFunLike.coe_injective.addGroup _ rfl (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ _ ↦ rfl)
-    (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
-
-@[to_additive existing]
 instance [Π i, Group (R i)] [∀ i, SubgroupClass (S i) (R i)] :
     Group (Πʳ i, [R i, B i]_[𝓕]) :=
   DFunLike.coe_injective.group _ rfl (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ _ ↦ rfl)
@@ -372,24 +363,25 @@ sending `A₁ (f j)` into `A₂ j` for an `𝓕₂`-large set of `j`'s.
 
 See also `mapMonoidHom`, `mapAddMonoidHom` and `mapRingHom` for variants.
 -/
-def map (x : Πʳ i, [R₁ i, A₁ i]_[𝓕₁]) : Πʳ j, [R₂ j, A₂ j]_[𝓕₂] := ⟨fun j ↦ φ j (x (f j)), by
+def mapAlong (x : Πʳ i, [R₁ i, A₁ i]_[𝓕₁]) : Πʳ j, [R₂ j, A₂ j]_[𝓕₂] :=
+  ⟨fun j ↦ φ j (x (f j)), by
   filter_upwards [hf.eventually x.2, hφ] using fun _ h1 h2 ↦ h2 h1⟩
 
 @[simp]
 lemma map_apply (x : Πʳ i, [R₁ i, A₁ i]_[𝓕₁]) (j : ι₂) :
-    x.map R₁ R₂ f hf φ hφ j = φ j (x (f j)) :=
+    x.mapAlong R₁ R₂ f hf φ hφ j = φ j (x (f j)) :=
   rfl
 
 -- variant of `map` where the index set is constant
 
 /-- The maps between restricted products over a fixed index type,
 given maps on the factors. -/
-def congrRight {G H : ι → Type*}
+def map {G H : ι → Type*}
     {C : (i : ι) → Set (G i)}
     {D : (i : ι) → Set (H i)} (φ : (i : ι) → G i → H i)
     (hφ : ∀ᶠ i in 𝓕, Set.MapsTo (φ i) (C i) (D i))
     (x : Πʳ i, [G i, C i]_[𝓕]) : (Πʳ i, [H i, D i]_[𝓕]) :=
-  map G H id Filter.tendsto_id φ hφ x
+  mapAlong G H id Filter.tendsto_id φ hφ x
 
 end set
 
@@ -412,8 +404,8 @@ needed is a function `f : ι₂ → ι₁` such that `𝓕₂` tends to `𝓕₁
 additive monoid homomorphisms `φ j : R₁ (f j) → R₂ j` sending `B₁ (f j)` into `B₂ j` for
 an `𝓕₂`-large set of `j`'s.
 "]
-def mapMonoidHom : Πʳ i, [R₁ i, B₁ i]_[𝓕₁] →* Πʳ j, [R₂ j, B₂ j]_[𝓕₂] where
-  toFun := map R₁ R₂ f hf (fun j r ↦ φ j r) hφ
+def mapAlongMonoidHom : Πʳ i, [R₁ i, B₁ i]_[𝓕₁] →* Πʳ j, [R₂ j, B₂ j]_[𝓕₂] where
+  toFun := mapAlong R₁ R₂ f hf (fun j r ↦ φ j r) hφ
   map_one' := by
     ext i
     exact map_one (φ i)
@@ -422,8 +414,8 @@ def mapMonoidHom : Πʳ i, [R₁ i, B₁ i]_[𝓕₁] →* Πʳ j, [R₂ j, B₂
     exact map_mul (φ i) _ _
 
 @[to_additive (attr := simp)]
-lemma mapMonoidHom_apply (x : Πʳ i, [R₁ i, B₁ i]_[𝓕₁]) (j : ι₂) :
-    x.mapMonoidHom R₁ R₂ f hf φ hφ j = φ j (x (f j)) :=
+lemma mapAlongMonoidHom_apply (x : Πʳ i, [R₁ i, B₁ i]_[𝓕₁]) (j : ι₂) :
+    x.mapAlongMonoidHom R₁ R₂ f hf φ hφ j = φ j (x (f j)) :=
   rfl
 
 end monoid
@@ -440,13 +432,13 @@ Given two restricted products `Πʳ (i : ι₁), [R₁ i, B₁ i]_[𝓕₁]` and
 function `f : ι₂ → ι₁` such that `𝓕₂` tends to `𝓕₁` along `f`, and ring homomorphisms
 `φ j : R₁ (f j) → R₂ j` sending `B₁ (f j)` into `B₂ j` for an `𝓕₂`-large set of `j`'s.
 -/
-def mapRingHom : Πʳ i, [R₁ i, B₁ i]_[𝓕₁] →+* Πʳ j, [R₂ j, B₂ j]_[𝓕₂] where
-  __ := mapMonoidHom R₁ R₂ f hf (fun j ↦ φ j) hφ
-  __ := mapAddMonoidHom R₁ R₂ f hf (fun j ↦ φ j) hφ
+def mapAlongRingHom : Πʳ i, [R₁ i, B₁ i]_[𝓕₁] →+* Πʳ j, [R₂ j, B₂ j]_[𝓕₂] where
+  __ := mapAlongMonoidHom R₁ R₂ f hf (fun j ↦ φ j) hφ
+  __ := mapAlongAddMonoidHom R₁ R₂ f hf (fun j ↦ φ j) hφ
 
 @[simp]
-lemma mapRingHom_apply (x : Πʳ i, [R₁ i, B₁ i]_[𝓕₁]) (j : ι₂) :
-    x.mapRingHom R₁ R₂ f hf φ hφ j = φ j (x (f j)) :=
+lemma mapAlongRingHom_apply (x : Πʳ i, [R₁ i, B₁ i]_[𝓕₁]) (j : ι₂) :
+    x.mapAlongRingHom R₁ R₂ f hf φ hφ j = φ j (x (f j)) :=
   rfl
 
 end ring

--- a/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
@@ -357,11 +357,11 @@ variable (φ : ∀ j, R₁ (f j) → R₂ j) (hφ : ∀ᶠ j in 𝓕₂, MapsTo 
 
 /--
 Given two restricted products `Πʳ (i : ι₁), [R₁ i, A₁ i]_[𝓕₁]` and `Πʳ (j : ι₂), [R₂ j, A₂ j]_[𝓕₂]`,
-`RestrictedProduct.map` gives a function between them. The data needed is a function `f : ι₂ → ι₁`
-such that `𝓕₂` tends to `𝓕₁` along `f`, and functions `φ j : R₁ (f j) → R₂ j`
+`RestrictedProduct.mapAlong` gives a function between them. The data needed is a
+function `f : ι₂ → ι₁` such that `𝓕₂` tends to `𝓕₁` along `f`, and functions `φ j : R₁ (f j) → R₂ j`
 sending `A₁ (f j)` into `A₂ j` for an `𝓕₂`-large set of `j`'s.
 
-See also `mapMonoidHom`, `mapAddMonoidHom` and `mapRingHom` for variants.
+See also `mapAlongMonoidHom`, `mapAlongAddMonoidHom` and `mapAlongRingHom` for variants.
 -/
 def mapAlong (x : Πʳ i, [R₁ i, A₁ i]_[𝓕₁]) : Πʳ j, [R₂ j, A₂ j]_[𝓕₂] :=
   ⟨fun j ↦ φ j (x (f j)), by
@@ -372,7 +372,7 @@ lemma map_apply (x : Πʳ i, [R₁ i, A₁ i]_[𝓕₁]) (j : ι₂) :
     x.mapAlong R₁ R₂ f hf φ hφ j = φ j (x (f j)) :=
   rfl
 
--- variant of `map` where the index set is constant
+-- variant of `mapAlong` where the index set is constant
 
 /-- The maps between restricted products over a fixed index type,
 given maps on the factors. -/
@@ -392,16 +392,16 @@ variable [Π i, Monoid (R₁ i)] [Π i, Monoid (R₂ i)] [∀ i, SubmonoidClass 
     (hφ : ∀ᶠ j in 𝓕₂, MapsTo (φ j) (B₁ (f j)) (B₂ j))
 
 /--
-Given two restricted products `Πʳ (i : ι₁), [R₁ i, B₁ i]_[𝓕₁]` and `Πʳ (j : ι₂), [R₂ j, B₂ j]_[𝓕₂]`,
-`RestrictedProduct.mapMonoidHom` gives a monoid homomorphism between them. The data needed is a
-function `f : ι₂ → ι₁` such that `𝓕₂` tends to `𝓕₁` along `f`, and monoid homomorphisms
-`φ j : R₁ (f j) → R₂ j` sending `B₁ (f j)` into `B₂ j` for an `𝓕₂`-large set of `j`'s.
+Given two restricted products `Πʳ (i : ι₁), [R₁ i, B₁ i]_[𝓕₁]` and `Πʳ (j : ι₂), [R₂ j, B₂ j]_[𝓕₂]`
+of monoids, `RestrictedProduct.mapAlongMonoidHom` gives a monoid homomorphism between them.
+The data needed is a function `f : ι₂ → ι₁` such that `𝓕₂` tends to `𝓕₁` along `f`, and monoid
+homomorphisms `φ j : R₁ (f j) → R₂ j` sending `B₁ (f j)` into `B₂ j` for an `𝓕₂`-large set of `j`'s.
 -/
 @[to_additive "
-Given two restricted products `Πʳ (i : ι₁), [R₁ i, B₁ i]_[𝓕₁]` and `Πʳ (j : ι₂), [R₂ j, B₂ j]_[𝓕₂]`,
-`RestrictedProduct.mapAddMonoidHom` gives a additive monoid homomorphism between them. The data
-needed is a function `f : ι₂ → ι₁` such that `𝓕₂` tends to `𝓕₁` along `f`, and
-additive monoid homomorphisms `φ j : R₁ (f j) → R₂ j` sending `B₁ (f j)` into `B₂ j` for
+Given two restricted products `Πʳ (i : ι₁), [R₁ i, B₁ i]_[𝓕₁]` and `Πʳ (j : ι₂), [R₂ j, B₂ j]_[𝓕₂]`
+of additive monoids, `RestrictedProduct.mapAlongAddMonoidHom` gives a additive monoid homomorphism
+between them. The data needed is a function `f : ι₂ → ι₁` such that `𝓕₂` tends to `𝓕₁` along `f`,
+and additive monoid homomorphisms `φ j : R₁ (f j) → R₂ j` sending `B₁ (f j)` into `B₂ j` for
 an `𝓕₂`-large set of `j`'s.
 "]
 def mapAlongMonoidHom : Πʳ i, [R₁ i, B₁ i]_[𝓕₁] →* Πʳ j, [R₂ j, B₂ j]_[𝓕₂] where
@@ -427,8 +427,9 @@ variable [Π i, Ring (R₁ i)] [Π i, Ring (R₂ i)] [∀ i, SubringClass (S₁ 
     (hφ : ∀ᶠ j in 𝓕₂, MapsTo (φ j) (B₁ (f j)) (B₂ j))
 
 /--
-Given two restricted products `Πʳ (i : ι₁), [R₁ i, B₁ i]_[𝓕₁]` and `Πʳ (j : ι₂), [R₂ j, B₂ j]_[𝓕₂]`,
-`RestrictedProduct.mapRingHom` gives a ring homomorphism between them. The data needed is a
+Given two restricted products of rings `Πʳ (i : ι₁), [R₁ i, B₁ i]_[𝓕₁]` and
+`Πʳ (j : ι₂), [R₂ j, B₂ j]_[𝓕₂]`, `RestrictedProduct.mapAlongRingHom` gives a
+ring homomorphism between them. The data needed is a
 function `f : ι₂ → ι₁` such that `𝓕₂` tends to `𝓕₁` along `f`, and ring homomorphisms
 `φ j : R₁ (f j) → R₂ j` sending `B₁ (f j)` into `B₂ j` for an `𝓕₂`-large set of `j`'s.
 -/

--- a/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
@@ -227,12 +227,7 @@ lemma pow_apply [Π i, Monoid (R i)] [∀ i, SubmonoidClass (S i) (R i)]
     (x : Πʳ i, [R i, B i]_[𝓕]) (n : ℕ) (i : ι) : (x ^ n) i = x i ^ n :=
   rfl
 
-instance [Π i, AddMonoid (R i)] [∀ i, AddSubmonoidClass (S i) (R i)] :
-    AddMonoid (Πʳ i, [R i, B i]_[𝓕]) :=
-  haveI : ∀ i, SMulMemClass (S i) ℕ (R i) := fun _ ↦ AddSubmonoidClass.nsmulMemClass
-  DFunLike.coe_injective.addMonoid _ rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
-
-@[to_additive existing]
+@[to_additive]
 instance [Π i, Monoid (R i)] [∀ i, SubmonoidClass (S i) (R i)] :
     Monoid (Πʳ i, [R i, B i]_[𝓕]) :=
   DFunLike.coe_injective.monoid _ rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
@@ -368,7 +363,7 @@ def mapAlong (x : Πʳ i, [R₁ i, A₁ i]_[𝓕₁]) : Πʳ j, [R₂ j, A₂ j]
   filter_upwards [hf.eventually x.2, hφ] using fun _ h1 h2 ↦ h2 h1⟩
 
 @[simp]
-lemma map_apply (x : Πʳ i, [R₁ i, A₁ i]_[𝓕₁]) (j : ι₂) :
+lemma mapAlong_apply (x : Πʳ i, [R₁ i, A₁ i]_[𝓕₁]) (j : ι₂) :
     x.mapAlong R₁ R₂ f hf φ hφ j = φ j (x (f j)) :=
   rfl
 
@@ -382,6 +377,14 @@ def map {G H : ι → Type*}
     (hφ : ∀ᶠ i in 𝓕, Set.MapsTo (φ i) (C i) (D i))
     (x : Πʳ i, [G i, C i]_[𝓕]) : (Πʳ i, [H i, D i]_[𝓕]) :=
   mapAlong G H id Filter.tendsto_id φ hφ x
+
+@[simp]
+lemma map_apply {G H : ι → Type*} {C : (i : ι) → Set (G i)}
+    {D : (i : ι) → Set (H i)} (φ : (i : ι) → G i → H i)
+    (hφ : ∀ᶠ i in 𝓕, Set.MapsTo (φ i) (C i) (D i))
+    (x : Πʳ i, [G i, C i]_[𝓕]) (j : ι) :
+    x.map φ hφ j = φ j (x j) :=
+  rfl
 
 end set
 

--- a/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Ring.Pi
 import Mathlib.Algebra.Ring.Subring.Defs
 import Mathlib.GroupTheory.GroupAction.SubMulAction
 import Mathlib.Order.Filter.Cofinite -- for `Πʳ i, [R i, A i]` notation, confuses shake
+import Mathlib.Algebra.Module.Pi
 
 /-!
 # Restricted products of sets, groups and rings
@@ -94,6 +95,15 @@ variable {𝓕 𝓖 : Filter ι}
 instance : DFunLike (Πʳ i, [R i, A i]_[𝓕]) ι R where
   coe x i := x.1 i
   coe_injective' _ _ := Subtype.ext
+
+variable {R A} in
+/-- Constructor for `RestrictedProduct`. -/
+abbrev mk (x : Π i, R i) (hx : ∀ᶠ i in 𝓕, x i ∈ A i) : Πʳ i, [R i, A i]_[𝓕] :=
+  ⟨x, hx⟩
+
+@[simp]
+lemma mk_apply (x : Π i, R i) (hx : ∀ᶠ i in 𝓕, x i ∈ A i) (i : ι) :
+    (mk x hx) i = x i := rfl
 
 @[ext]
 lemma ext {x y :  Πʳ i, [R i, A i]_[𝓕]} (h : ∀ i, x i = y i) : x = y :=
@@ -203,10 +213,16 @@ lemma div_apply [Π i, DivInvMonoid (R i)] [∀ i, SubgroupClass (S i) (R i)]
     (x y : Πʳ i, [R i, B i]_[𝓕]) (i : ι) : (x / y) i = x i / y i :=
   rfl
 
+instance instNSMul [Π i, AddMonoid (R i)] [∀ i, AddSubmonoidClass (S i) (R i)] :
+    SMul ℕ (Πʳ i, [R i, B i]_[𝓕]) where
+  smul n x := ⟨fun i ↦ n • (x i), x.2.mono fun _ hi ↦ nsmul_mem hi n⟩
+
+@[to_additive existing instNSMul]
 instance [Π i, Monoid (R i)] [∀ i, SubmonoidClass (S i) (R i)] :
     Pow (Πʳ i, [R i, B i]_[𝓕]) ℕ where
   pow x n := ⟨fun i ↦ x i ^ n, x.2.mono fun _ hi ↦ pow_mem hi n⟩
 
+@[to_additive]
 lemma pow_apply [Π i, Monoid (R i)] [∀ i, SubmonoidClass (S i) (R i)]
     (x : Πʳ i, [R i, B i]_[𝓕]) (n : ℕ) (i : ι) : (x ^ n) i = x i ^ n :=
   rfl
@@ -220,6 +236,11 @@ instance [Π i, AddMonoid (R i)] [∀ i, AddSubmonoidClass (S i) (R i)] :
 instance [Π i, Monoid (R i)] [∀ i, SubmonoidClass (S i) (R i)] :
     Monoid (Πʳ i, [R i, B i]_[𝓕]) :=
   DFunLike.coe_injective.monoid _ rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+
+@[to_additive]
+instance [Π i, CommMonoid (R i)] [∀ i, SubmonoidClass (S i) (R i)] :
+    CommMonoid (Πʳ i, [R i, B i]_[𝓕]) :=
+  DFunLike.coe_injective.commMonoid _ rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
 
 instance [Π i, DivInvMonoid (R i)] [∀ i, SubgroupClass (S i) (R i)] :
     Pow (Πʳ i, [R i, B i]_[𝓕]) ℤ where
@@ -258,6 +279,22 @@ instance [Π i, Ring (R i)] [∀ i, SubringClass (S i) (R i)] :
 instance [Π i, CommRing (R i)] [∀ i, SubringClass (S i) (R i)] :
     CommRing (Πʳ i, [R i, B i]_[𝓕]) where
   mul_comm _ _ := DFunLike.coe_injective <| funext (fun _ ↦ mul_comm _ _)
+
+variable {R} in
+/-- The coercion from the restricted product of monoids `A i` to the (normal) product
+is a monoid homomorphism. -/
+@[to_additive "The coercion from the restricted product of additive monoids `A i` to the
+(normal) product is an additive monoid homomorphism."]
+def coeMonoidHom [∀ i, Monoid (R i)] [∀ i, SubmonoidClass (S i) (R i)] :
+    Πʳ i, [R i, B i]_[𝓕] →* Π i, R i where
+  toFun := (↑)
+  map_one' := rfl
+  map_mul' _ _ := rfl
+
+instance {R₀ : Type*} [Semiring R₀] [Π i, AddCommMonoid (R i)] [Π i, Module R₀ (R i)]
+    [∀ i, AddSubmonoidClass (S i) (R i)] [∀ i, SMulMemClass (S i) R₀ (R i)] :
+  Module R₀ (Πʳ i, [R i, B i]_[𝓕]) :=
+  DFunLike.coe_injective.module R₀ (M := Π i, R i) coeAddMonoidHom (fun _ _ ↦ rfl)
 
 end Algebra
 
@@ -328,6 +365,17 @@ def map (x : Πʳ i, [R₁ i, A₁ i]_[𝓕₁]) : Πʳ j, [R₂ j, A₂ j]_[�
 lemma map_apply (x : Πʳ i, [R₁ i, A₁ i]_[𝓕₁]) (j : ι₂) :
     x.map R₁ R₂ f hf φ hφ j = φ j (x (f j)) :=
   rfl
+
+-- variant of `map` where the index set is constant
+
+/-- The maps between restricted products over a fixed index type,
+given maps on the factors. -/
+def congrRight {G H : ι → Type*}
+    {C : (i : ι) → Set (G i)}
+    {D : (i : ι) → Set (H i)} (φ : (i : ι) → G i → H i)
+    (hφ : ∀ᶠ i in 𝓕, Set.MapsTo (φ i) (C i) (D i))
+    (x : Πʳ i, [G i, C i]_[𝓕]) : (Πʳ i, [H i, D i]_[𝓕]) :=
+  map G H id Filter.tendsto_id φ hφ x
 
 end set
 

--- a/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
@@ -242,22 +242,26 @@ instance [Π i, CommMonoid (R i)] [∀ i, SubmonoidClass (S i) (R i)] :
     CommMonoid (Πʳ i, [R i, B i]_[𝓕]) :=
   DFunLike.coe_injective.commMonoid _ rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
 
+instance instZSMul [Π i, SubNegMonoid (R i)] [∀ i, AddSubgroupClass (S i) (R i)] :
+    SMul ℤ (Πʳ i, [R i, B i]_[𝓕]) where
+  smul n x := ⟨fun i ↦ n • x i, x.2.mono fun _ hi ↦ zsmul_mem hi n⟩
+
+@[to_additive existing instZSMul]
 instance [Π i, DivInvMonoid (R i)] [∀ i, SubgroupClass (S i) (R i)] :
     Pow (Πʳ i, [R i, B i]_[𝓕]) ℤ where
   pow x n := ⟨fun i ↦ x i ^ n, x.2.mono fun _ hi ↦ zpow_mem hi n⟩
 
+@[to_additive]
 lemma zpow_apply [Π i, DivInvMonoid (R i)] [∀ i, SubgroupClass (S i) (R i)]
     (x : Πʳ i, [R i, B i]_[𝓕]) (n : ℤ) (i : ι) : (x ^ n) i = x i ^ n :=
   rfl
 
+@[to_additive]
 instance [Π i, AddMonoidWithOne (R i)] [∀ i, AddSubmonoidWithOneClass (S i) (R i)] :
     NatCast (Πʳ i, [R i, B i]_[𝓕]) where
   natCast n := ⟨fun _ ↦ n, .of_forall fun _ ↦ natCast_mem _ n⟩
 
-instance [Π i, Ring (R i)] [∀ i, SubringClass (S i) (R i)] :
-    IntCast (Πʳ i, [R i, B i]_[𝓕]) where
-  intCast n := ⟨fun _ ↦ n, .of_forall fun _ ↦ intCast_mem _ n⟩
-
+@[to_additive]
 instance [Π i, AddGroup (R i)] [∀ i, AddSubgroupClass (S i) (R i)] :
     AddGroup (Πʳ i, [R i, B i]_[𝓕]) :=
   haveI : ∀ i, SMulMemClass (S i) ℤ (R i) := fun _ ↦ AddSubgroupClass.zsmulMemClass
@@ -270,6 +274,16 @@ instance [Π i, Group (R i)] [∀ i, SubgroupClass (S i) (R i)] :
     Group (Πʳ i, [R i, B i]_[𝓕]) :=
   DFunLike.coe_injective.group _ rfl (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ _ ↦ rfl)
     (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+
+@[to_additive]
+instance [Π i, CommGroup (R i)] [∀ i, SubgroupClass (S i) (R i)] :
+    CommGroup (Πʳ i, [R i, B i]_[𝓕]) :=
+  DFunLike.coe_injective.commGroup _ rfl (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ _ ↦ rfl)
+    (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+
+instance [Π i, Ring (R i)] [∀ i, SubringClass (S i) (R i)] :
+    IntCast (Πʳ i, [R i, B i]_[𝓕]) where
+  intCast n := ⟨fun _ ↦ n, .of_forall fun _ ↦ intCast_mem _ n⟩
 
 instance [Π i, Ring (R i)] [∀ i, SubringClass (S i) (R i)] :
     Ring (Πʳ i, [R i, B i]_[𝓕]) :=

--- a/Mathlib/Topology/Algebra/RestrictedProduct/TopologicalSpace.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct/TopologicalSpace.lean
@@ -650,7 +650,7 @@ variable (f : ι₂ → ι₁) (hf : Tendsto f 𝓕₂ 𝓕₁)
 
 variable (φ : ∀ j, R₁ (f j) → R₂ j) (hφ : ∀ᶠ j in 𝓕₂, MapsTo (φ j) (A₁ (f j)) (A₂ j))
 
-theorem map_continuous (φ_cont : ∀ j, Continuous (φ j)) :
+theorem mapAlong_continuous (φ_cont : ∀ j, Continuous (φ j)) :
     Continuous (mapAlong R₁ R₂ f hf φ hφ) := by
   rw [continuous_dom]
   intro S hS

--- a/Mathlib/Topology/Algebra/RestrictedProduct/TopologicalSpace.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct/TopologicalSpace.lean
@@ -650,7 +650,8 @@ variable (f : ι₂ → ι₁) (hf : Tendsto f 𝓕₂ 𝓕₁)
 
 variable (φ : ∀ j, R₁ (f j) → R₂ j) (hφ : ∀ᶠ j in 𝓕₂, MapsTo (φ j) (A₁ (f j)) (A₂ j))
 
-theorem map_continuous (φ_cont : ∀ j, Continuous (φ j)) : Continuous (map R₁ R₂ f hf φ hφ) := by
+theorem map_continuous (φ_cont : ∀ j, Continuous (φ j)) :
+    Continuous (mapAlong R₁ R₂ f hf φ hφ) := by
   rw [continuous_dom]
   intro S hS
   set T := f ⁻¹' S ∩ {j | MapsTo (φ j) (A₁ (f j)) (A₂ j)}
@@ -659,8 +660,8 @@ theorem map_continuous (φ_cont : ∀ j, Continuous (φ j)) : Continuous (map R�
     exact inter_mem (hf hS) hφ
   have hf' : Tendsto f (𝓟 T) (𝓟 S) := by aesop
   have hφ' : ∀ᶠ j in 𝓟 T, MapsTo (φ j) (A₁ (f j)) (A₂ j) := by aesop
-  have key : map R₁ R₂ f hf φ hφ ∘ inclusion R₁ A₁ hS =
-      inclusion R₂ A₂ hT ∘ map R₁ R₂ f hf' φ hφ' := rfl
+  have key : mapAlong R₁ R₂ f hf φ hφ ∘ inclusion R₁ A₁ hS =
+      inclusion R₂ A₂ hT ∘ mapAlong R₁ R₂ f hf' φ hφ' := rfl
   rw [key]
   exact continuous_inclusion _ |>.comp <|
     continuous_rng_of_principal.mpr <|


### PR DESCRIPTION
A constructor, more algebra boilerplate (e.g. `SMul ℕ` on a restricted product of `AddMonoid`s, restricted product of `CommMonoid`s is a `CommMonoid`, restricted product of `R`-modules wrt `R`-submodules is an `R`-module, variant of `map` when the index set doesn't change). 

From the FLT project.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
