### PR TITLE
[Merged by Bors] - feat(gcongr): fix pattern elaborator and @[gcongr] for lemmas introducing binders

### DIFF
--- a/Mathlib/Order/Filter/Basic.lean
+++ b/Mathlib/Order/Filter/Basic.lean
@@ -622,6 +622,11 @@ theorem Eventually.mono {p q : α → Prop} {f : Filter α} (hp : ∀ᶠ x in f,
     (hq : ∀ x, p x → q x) : ∀ᶠ x in f, q x :=
   hp.mp (Eventually.of_forall hq)
 
+@[gcongr]
+theorem GCongr.eventually_mono {p q : α → Prop} {f : Filter α} (h : ∀ x, p x → q x) :
+    (∀ᶠ x in f, p x) → ∀ᶠ x in f, q x :=
+  (·.mono h)
+
 theorem forall_eventually_of_eventually_forall {f : Filter α} {p : α → β → Prop}
     (h : ∀ᶠ x in f, ∀ y, p x y) : ∀ y, ∀ᶠ x in f, p x y :=
   fun y => h.mono fun _ h => h y
@@ -722,6 +727,11 @@ theorem Frequently.filter_mono {p : α → Prop} {f g : Filter α} (h : ∃ᶠ x
 theorem Frequently.mono {p q : α → Prop} {f : Filter α} (h : ∃ᶠ x in f, p x)
     (hpq : ∀ x, p x → q x) : ∃ᶠ x in f, q x :=
   h.mp (Eventually.of_forall hpq)
+
+@[gcongr]
+theorem GCongr.frequently_mono {p q : α → Prop} {f : Filter α} (h : ∀ x, p x → q x) :
+    (∃ᶠ x in f, p x) → ∃ᶠ x in f, q x :=
+  (·.mono h)
 
 theorem Frequently.and_eventually {p q : α → Prop} {f : Filter α} (hp : ∃ᶠ x in f, p x)
     (hq : ∀ᶠ x in f, q x) : ∃ᶠ x in f, p x ∧ q x := by

--- a/Mathlib/Tactic/GCongr/Core.lean
+++ b/Mathlib/Tactic/GCongr/Core.lean
@@ -6,6 +6,7 @@ Authors: Mario Carneiro, Heather Macbeth, Jovan Gerbscheid
 import Lean
 import Batteries.Lean.Except
 import Batteries.Tactic.Exact
+import Mathlib.Lean.Elab.Term
 import Mathlib.Tactic.GCongr.ForwardAttr
 import Mathlib.Order.Defs.PartialOrder
 import Mathlib.Order.Defs.Unbundled
@@ -585,7 +586,7 @@ elab "gcongr" template:(colGt term)?
     | throwError "gcongr failed, not a relation"
   -- Elaborate the template (e.g. `x * ?_ + _`), if the user gave one
   let template ← template.mapM fun e => do
-    let template ← Term.elabTerm e (← inferType lhs)
+    let template ← Term.elabPattern e (← inferType lhs)
     unless ← containsHole template do
       throwError "invalid template {template}, it doesn't contain any `?_`"
     pure template

--- a/Mathlib/Tactic/GCongr/CoreAttrs.lean
+++ b/Mathlib/Tactic/GCongr/CoreAttrs.lean
@@ -12,15 +12,20 @@ In this file we add `gcongr` attribute to lemmas in `Lean.Init`.
 We may add lemmas from other files imported by `Mathlib/Tactic/GCongr/Core` later.
 -/
 
--- `imp_trans` doesn't exist in lean core??
-lemma imp_trans {a b c : Prop} (h : a → b) : (b → c) → a → c := fun g ha => g (h ha)
+variable {a b c : Prop}
 
-lemma imp_trans' {a b c : Prop} (h : b → c) : (a → b) → a → c := fun g ha => h (g ha)
+lemma GCongr.imp_trans (h : a → b) : (b → c) → a → c := fun g ha => g (h ha)
+
+lemma GCongr.imp_right_mono (h : a → b → c) : (a → b) → a → c :=
+  fun h' ha => h ha (h' ha)
+
+lemma GCongr.and_right_mono (h : a → b → c) : (a ∧ b) → a ∧ c :=
+  fun ⟨ha, hb⟩ => ⟨ha, h ha hb⟩
 
 attribute [gcongr] mt
   Or.imp Or.imp_left Or.imp_right
-  And.imp And.imp_left And.imp_right
-  imp_imp_imp imp_trans imp_trans'
+  And.imp And.imp_left GCongr.and_right_mono
+  imp_imp_imp GCongr.imp_trans GCongr.imp_right_mono
   forall_imp Exists.imp
   Nat.succ_le_succ
   List.Sublist.append List.Sublist.append_left List.Sublist.append_right

--- a/MathlibTest/GCongr/inequalities.lean
+++ b/MathlibTest/GCongr/inequalities.lean
@@ -258,4 +258,8 @@ example {a b : ℕ} (h1 : a ≤ 0) (h2 : 0 ≤ b)  : b < a + 1 → 0 < 0 + 1 := 
 example {a b : ℕ} (h1 : a ≤ 0) (_h2 : 0 ≤ b) : b < a + 1 → b < 0 + 1 := by gcongr
 example {a b : ℕ} (_h1 : a ≤ 0) (h2 : 0 ≤ b) : b < a + 1 → 0 < a + 1 := by gcongr
 
+/-! Test that `gcongr` with a pattern doesn't complain about type class inference problems. -/
+
+example {a b : ℕ} (h1 : a ≤ 0) (h2 : 0 ≤ b) : b ≤ a + 1 → 0 ≤ 0 + 1 := by gcongr ?_ ≤ ?_ + _
+
 end GCongrTests

--- a/MathlibTest/peel.lean
+++ b/MathlibTest/peel.lean
@@ -270,3 +270,34 @@ and
 #guard_msgs in
 example (h : ∀ᶠ n : ℕ in atTop, 0 ≤ n) : ∀ᶠ n : ℕ in atBot, 0 ≤ n := by
   peel 1 h
+
+/-! Testing **gcongr** on peel goals -/
+
+example (p q : ℝ → ℝ → Prop) (h : ∀ ε > 0, ∃ δ > 0, p ε δ)
+    (hpq : ∀ x y, x > 0 → y > 0 → p x y → q x y) :
+    ∀ ε > 0, ∃ δ > 0, q ε δ := by
+  revert h
+  gcongr with ε hε δ hδ
+  exact hpq ε δ hε hδ
+
+example (x y : ℚ) (h : ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x + n = y + ε) :
+    ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N, x - ε = y - n := by
+  revert h
+  gcongr ∀ ε > 0, ∃ N, ∀ n ≥ _, ?_ with ε hε _ n hn
+  intro this
+  guard_hyp this : x + ↑n = y + ε
+  guard_target =ₐ x - ε = y - n
+  linarith
+
+example {f : ℝ → ℝ} (h : ∀ x : ℝ, ∀ᶠ y in 𝓝 x, |f y - f x| ≤ |y - x|) :
+    ∀ x : ℝ, ∀ᶠ y in 𝓝 x, |f y - f x| ^ 2 ≤ |y - x| ^ 2 := by
+  revert h
+  gcongr ∀ x, ∀ᶠ y in _, ?_
+  intro
+  gcongr
+
+example (α : Type*) (f g : Filter α) (p q : α → α → Prop) (h : ∀ᶠ x in f, ∃ᶠ y in g, p x y)
+    (h₁ : ∀ x y, p x y → q x y) : ∀ᶠ x in f, ∃ᶠ y in g, q x y := by
+  revert h
+  gcongr
+  apply h₁


### PR DESCRIPTION
This PR adds @[gcongr] tags so that
- `gcongr` can move inside Eventually and Frequently,
- moving inside of `∀ ε > 0,` or `∃ ε > 0,` adds the hypothesis/condition to the local context.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
