### PR TITLE
[Merged by Bors] - feat(MeasureTheory): convolution of measures with densities 

### DIFF
--- a/Mathlib/MeasureTheory/Group/Convolution.lean
+++ b/Mathlib/MeasureTheory/Group/Convolution.lean
@@ -38,11 +38,16 @@ scoped[MeasureTheory] infixr:80 " ∗ₘ " => MeasureTheory.Measure.mconv
 scoped[MeasureTheory] infixr:80 " ∗ " => MeasureTheory.Measure.conv
 
 @[to_additive]
+theorem lintegral_mconv_eq_lintegral_prod [MeasurableMul₂ M] {μ ν : Measure M}
+    {f : M → ℝ≥0∞} (hf : Measurable f):
+    ∫⁻ z, f z ∂(μ ∗ₘ ν) = ∫⁻ z, f (z.1 * z.2) ∂(μ.prod ν) := by
+  rw[mconv, lintegral_map hf measurable_mul]
+
+@[to_additive]
 theorem lintegral_mconv [MeasurableMul₂ M] {μ ν : Measure M} [SFinite ν]
     {f : M → ℝ≥0∞} (hf : Measurable f) :
     ∫⁻ z, f z ∂(μ ∗ₘ ν) = ∫⁻ x, ∫⁻ y, f (x * y) ∂ν ∂μ := by
-  rw [mconv, lintegral_map hf measurable_mul, lintegral_prod]
-  fun_prop
+  rw [lintegral_mconv_eq_lintegral_prod hf, lintegral_prod _ (by fun_prop)]
 
 @[to_additive]
 lemma dirac_mconv [MeasurableMul₂ M] (x : M) (μ : Measure M) [SFinite μ] :

--- a/Mathlib/MeasureTheory/Group/Convolution.lean
+++ b/Mathlib/MeasureTheory/Group/Convolution.lean
@@ -41,7 +41,7 @@ scoped[MeasureTheory] infixr:80 " ∗ " => MeasureTheory.Measure.conv
 theorem lintegral_mconv_eq_lintegral_prod [MeasurableMul₂ M] {μ ν : Measure M}
     {f : M → ℝ≥0∞} (hf : Measurable f):
     ∫⁻ z, f z ∂(μ ∗ₘ ν) = ∫⁻ z, f (z.1 * z.2) ∂(μ.prod ν) := by
-  rw[mconv, lintegral_map hf measurable_mul]
+  rw [mconv, lintegral_map hf measurable_mul]
 
 @[to_additive]
 theorem lintegral_mconv [MeasurableMul₂ M] {μ ν : Measure M} [SFinite ν]

--- a/Mathlib/MeasureTheory/Measure/WithDensity.lean
+++ b/Mathlib/MeasureTheory/Measure/WithDensity.lean
@@ -704,10 +704,8 @@ lemma IsLocallyFiniteMeasure.withDensity_ofReal {f : α → ℝ} (hf : Continuou
 
 section Conv
 
-variable {G : Type*} [Group G] [MeasureSpace G] [MeasurableMul₂ G]
+variable {G : Type*} [Group G] [MeasureSpace G] [MeasurableMul₂ G] [MeasurableInv G]
   {μ : Measure G} [SFinite μ] [IsMulLeftInvariant μ]
-
-set_option trace.Meta.Tactic.fun_prop true
 
 @[to_additive]
 theorem mconv_withDensity_eq_mlconvolution₀ {f g : G → ℝ≥0∞}

--- a/Mathlib/MeasureTheory/Measure/WithDensity.lean
+++ b/Mathlib/MeasureTheory/Measure/WithDensity.lean
@@ -5,7 +5,8 @@ Authors: Mario Carneiro, Johannes Hölzl
 -/
 import Mathlib.MeasureTheory.Integral.Lebesgue.Countable
 import Mathlib.MeasureTheory.Measure.Decomposition.Exhaustion
-import Mathlib.MeasureTheory.Measure.Prod
+import Mathlib.MeasureTheory.Group.Convolution
+import Mathlib.Analysis.LConvolution
 
 /-!
 # Measure with a given density with respect to another measure
@@ -700,5 +701,33 @@ lemma IsLocallyFiniteMeasure.withDensity_coe {f : α → ℝ≥0} (hf : Continuo
 lemma IsLocallyFiniteMeasure.withDensity_ofReal {f : α → ℝ} (hf : Continuous f) :
     IsLocallyFiniteMeasure (μ.withDensity fun x ↦ .ofReal (f x)) :=
   .withDensity_coe <| continuous_real_toNNReal.comp hf
+
+section Conv
+
+variable {G : Type*} [Group G] [MeasureSpace G] [MeasurableMul₂ G]
+  {μ : Measure G} [SFinite μ] [IsMulLeftInvariant μ]
+
+@[to_additive]
+theorem mconv_withDensity_eq_mlconvolution₀ {f g : G → ℝ≥0∞}
+    (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) :
+    μ.withDensity f ∗ₘ μ.withDensity g = μ.withDensity (f ⋆ₘₗ[μ] g) := by
+  refine ext_of_lintegral _ fun φ hφ ↦ ?_
+  rw [lintegral_mconv_eq_lintegral_prod hφ, prod_withDensity₀ hf hg,
+    lintegral_withDensity_eq_lintegral_mul₀,
+    lintegral_withDensity_eq_lintegral_mul₀, lintegral_prod,
+    lintegral_congr (fun x ↦ by apply (lintegral_mul_left_eq_self _ x⁻¹).symm),
+    lintegral_lintegral_swap]
+  · simp only [Pi.mul_apply, mul_inv_cancel_left, mlconvolution_def]
+    conv in (∫⁻ _ , _ ∂μ) * φ _ => rw[(lintegral_mul_const'' _ (by fun_prop)).symm]
+  all_goals first | fun_prop | simp; fun_prop
+
+@[to_additive]
+theorem mconv_withDensity_eq_mlconvolution {f g : G → ℝ≥0∞}
+    (hf : Measurable f) (hg : Measurable g) :
+    μ.withDensity f ∗ₘ μ.withDensity g = μ.withDensity (f ⋆ₘₗ[μ] g) :=
+  mconv_withDensity_eq_mlconvolution₀ hf.aemeasurable hg.aemeasurable
+
+end Conv
+
 
 end MeasureTheory

--- a/Mathlib/MeasureTheory/Measure/WithDensity.lean
+++ b/Mathlib/MeasureTheory/Measure/WithDensity.lean
@@ -729,5 +729,4 @@ theorem mconv_withDensity_eq_mlconvolution {f g : G → ℝ≥0∞}
 
 end Conv
 
-
 end MeasureTheory

--- a/Mathlib/MeasureTheory/Measure/WithDensity.lean
+++ b/Mathlib/MeasureTheory/Measure/WithDensity.lean
@@ -707,6 +707,8 @@ section Conv
 variable {G : Type*} [Group G] [MeasureSpace G] [MeasurableMul₂ G]
   {μ : Measure G} [SFinite μ] [IsMulLeftInvariant μ]
 
+set_option trace.Meta.Tactic.fun_prop true
+
 @[to_additive]
 theorem mconv_withDensity_eq_mlconvolution₀ {f g : G → ℝ≥0∞}
     (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) :


### PR DESCRIPTION
Add theorems which state that the `mconv` of two measures with densities is the measure with density given by the `mlconvolution` of their densities. 