### PR TITLE
[Merged by Bors] - chore: disable build.yml and bors.yml on forks

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -38,7 +38,7 @@ permissions:
 
 jobs:
   build:
-    if: true
+    if: github.repository == 'leanprover-community/mathlib4'
     name: Build
     runs-on: bors
     outputs:
@@ -429,7 +429,7 @@ jobs:
 
   post_steps:
     name: Post-Build Step
-    if: true
+    if: github.repository == 'leanprover-community/mathlib4'
     needs: [build]
     runs-on: ubuntu-latest # Note these steps run on disposable GitHub runners, so no landrun sandboxing is needed.
     steps:
@@ -511,7 +511,7 @@ jobs:
 
   style_lint:
     name: Lint style
-    if: true
+    if: github.repository == 'leanprover-community/mathlib4'
     runs-on: ubuntu-latest
     steps:
       - uses: leanprover-community/lint-style-action@f2e7272aad56233a642b08fe974cf09dd664b0c8 # 2025-05-22
@@ -521,7 +521,7 @@ jobs:
 
   build_and_lint:
     name: CI Success
-    if: true
+    if: github.repository == 'leanprover-community/mathlib4'
     needs: [style_lint, post_steps]
     runs-on: ubuntu-latest
     steps:
@@ -531,7 +531,7 @@ jobs:
 
   final:
     name: Post-CI job
-    if: true
+    if: github.repository == 'leanprover-community/mathlib4'
     needs: [style_lint, build, post_steps]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ permissions:
 
 jobs:
   build:
-    if: true
+    if: github.repository == 'leanprover-community/mathlib4'
     name: Build
     runs-on: pr
     outputs:
@@ -436,7 +436,7 @@ jobs:
 
   post_steps:
     name: Post-Build Step
-    if: true
+    if: github.repository == 'leanprover-community/mathlib4'
     needs: [build]
     runs-on: ubuntu-latest # Note these steps run on disposable GitHub runners, so no landrun sandboxing is needed.
     steps:
@@ -518,7 +518,7 @@ jobs:
 
   style_lint:
     name: Lint style
-    if: true
+    if: github.repository == 'leanprover-community/mathlib4'
     runs-on: ubuntu-latest
     steps:
       - uses: leanprover-community/lint-style-action@f2e7272aad56233a642b08fe974cf09dd664b0c8 # 2025-05-22
@@ -528,7 +528,7 @@ jobs:
 
   build_and_lint:
     name: CI Success
-    if: true
+    if: github.repository == 'leanprover-community/mathlib4'
     needs: [style_lint, post_steps]
     runs-on: ubuntu-latest
     steps:
@@ -538,7 +538,7 @@ jobs:
 
   final:
     name: Post-CI job
-    if: true
+    if: github.repository == 'leanprover-community/mathlib4'
     needs: [style_lint, build, post_steps]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/mk_build_yml.sh
+++ b/.github/workflows/mk_build_yml.sh
@@ -54,7 +54,7 @@ on:
 
 name: continuous integration (staging)
 EOF
-  include "github.sha" bors "true" "" bors
+  include "github.sha" bors "github.repository == 'leanprover-community\/mathlib4'" "" bors
 }
 
 build_fork_yml() {

--- a/.github/workflows/mk_build_yml.sh
+++ b/.github/workflows/mk_build_yml.sh
@@ -39,7 +39,7 @@ on:
 
 name: continuous integration
 EOF
-  include "github.sha" pr "true" "" ubuntu-latest
+  include "github.sha" pr "github.repository == 'leanprover-community\/mathlib4'" "" ubuntu-latest
 }
 
 bors_yml() {


### PR DESCRIPTION
They just end up waiting 24 hours for a self-hosted runner and then end up getting canceled anyways. Cf. [log](https://github.com/bryangingechen/mathlib4/actions/runs/15574059821). (It doesn't really matter for `bors.yml` since people aren't likely to push to a branch named `staging` in their forks, but we may as well make things consistent.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
