### PR TITLE
[Merged by Bors] - feat: allow contributors to remove labels with comments

### DIFF
--- a/.github/workflows/labels_from_comment.yml
+++ b/.github/workflows/labels_from_comment.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Add label based on comment
+    - name: Add / remove label based on comment
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -24,6 +24,17 @@ jobs:
 
           const awaitingAuthor = commentLines.includes('awaiting-author');
           const wip = commentLines.includes('WIP');
+
+          const removeAwaitingAuthor = commentLines.includes('-awaiting-author');
+          const removeWip = commentLines.includes('-WIP');
+
+          if (removeAwatingAuthor) {
+            await github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'awaiting-author' }).catch(() => {});
+          }
+
+          if (removeWip) {
+            await github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'WIP' }).catch(() => {});
+          }
 
           if (awaitingAuthor || wip) {
             await github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'awaiting-author' }).catch(() => {});


### PR DESCRIPTION
Currently contributors can **add** the awaiting-author and WIP labels via comments, but they cannot remove them. This adds that functionality to our workflow.

---

Question: are there other labels that authors will need to be able to manipulate?