### PR TITLE
[Merged by Bors] - chore: disable scheduled runs of stale issues workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,5 @@
 name: 'Close stale issues and PRs'
 on:
-  schedule:
-    - cron: '30 1 * * *' # every day at 01:30 UTC
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    if: github.repository == 'leanprover-community/mathlib4'
     steps:
       # until https://github.com/actions/stale/pull/1145 is merged
       - uses: asterisk/github-actions-stale@1b80269ed4fffa62ade5d212089f005f03cde943 # branch: main-only-matching-filter


### PR DESCRIPTION
There's no point in having this run on schedule while it's still in limbo.

---

This also seems to have been [completely broken](https://github.com/leanprover-community/mathlib4/actions/workflows/stale.yml) since #21681, since the search string is too long. Maybe we should just delete this.