### PR TITLE
[Merged by Bors] - feat(RingTheory/KrullDimension/PID): remove domain condition in `IsPrincipalIdealRing.krullDimLE_one`

### DIFF
--- a/Mathlib/RingTheory/KrullDimension/PID.lean
+++ b/Mathlib/RingTheory/KrullDimension/PID.lean
@@ -12,12 +12,22 @@ import Mathlib.RingTheory.PrincipalIdealDomain
 In this file, we proved some results about the dimension of a principal ideal domain.
 -/
 
-instance IsPrincipalIdealRing.krullDimLE_one (R : Type*) [CommRing R] [IsDomain R]
+instance IsPrincipalIdealRing.krullDimLE_one (R : Type*) [CommRing R]
     [IsPrincipalIdealRing R] : Ring.KrullDimLE 1 R := by
-  rw [Ring.krullDimLE_one_iff]
-  apply fun I hI ↦ Classical.or_iff_not_imp_left.mpr fun hI' ↦
-    IsPrime.to_maximal_ideal (hpi := hI) ?_
-  simp_all [IsDomain.minimalPrimes_eq_singleton_bot]
+  refine Ring.krullDimLE_one_iff.2 fun I hI ↦ or_iff_not_imp_left.2 fun hI' ↦ ?_
+  rw [minimalPrimes_eq_minimals, Set.notMem_setOf_iff, not_minimal_iff_exists_lt hI] at hI'
+  obtain ⟨P, hlt, hP⟩ := hI'
+  have := IsPrincipalIdealRing.of_surjective (Ideal.Quotient.mk P) Ideal.Quotient.mk_surjective
+  have : (I.map (Ideal.Quotient.mk P)).IsMaximal := by
+    have := Ideal.map_isPrime_of_surjective (f := Ideal.Quotient.mk P) Ideal.Quotient.mk_surjective
+      (I := I) (by simpa using hlt.le)
+    refine IsPrime.to_maximal_ideal ?_
+    rw [ne_eq, Ideal.map_eq_bot_iff_le_ker, Ideal.mk_ker]
+    exact hlt.not_ge
+  have := Ideal.comap_isMaximal_of_surjective (Ideal.Quotient.mk P) Ideal.Quotient.mk_surjective
+    (K := I.map (Ideal.Quotient.mk P))
+  simpa [Ideal.comap_map_of_surjective' (Ideal.Quotient.mk P) Ideal.Quotient.mk_surjective,
+    hlt.le] using this
 
 theorem IsPrincipalIdealRing.ringKrullDim_eq_one (R : Type*) [CommRing R] [IsDomain R]
     [IsPrincipalIdealRing R] (h : ¬ IsField R) : ringKrullDim R = 1 := by


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Migrated from #25702