### PR TITLE
[Merged by Bors] - chore: shortcut instance `CompleteLattice α → PartialOrder α`

### DIFF
--- a/Mathlib/Order/CompleteLattice/Defs.lean
+++ b/Mathlib/Order/CompleteLattice/Defs.lean
@@ -159,6 +159,13 @@ instance {α : Type*} [CompleteSemilatticeSup α] : CompleteSemilatticeInf αᵒ
 class CompleteLattice (α : Type*) extends Lattice α, CompleteSemilatticeSup α,
     CompleteSemilatticeInf α, BoundedOrder α
 
+-- Shortcut instance to ensure that the path
+-- `CompleteLattice α → CompletePartialOrder α → PartialOrder α` isn't taken,
+-- as it tricks `#min_imports` into believing `Order.CompletePartialOrder` is a necessary import.
+-- See note [lower instance priority]
+instance (priority := 100) CompleteLattice.toPartialOrder' [CompleteLattice α] : PartialOrder α :=
+  inferInstance
+
 /-- Create a `CompleteLattice` from a `PartialOrder` and `InfSet`
 that returns the greatest lower bound of a set. Usually this constructor provides
 poor definitional equalities.  If other fields are known explicitly, they should be


### PR DESCRIPTION
This avoids using the path `CompleteLattice α → CompletePartialOrder α → PartialOrder α` that goes through `Order.CompletePartialOrder` and makes it appear used to our automation, such as `shake` or `#min_imports`.

This is a followup to #25358.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
