### PR TITLE
[Merged by Bors] - feat: easier to use FTC-2 versions for `C^1` functions

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4309,6 +4309,7 @@ import Mathlib.MeasureTheory.Integral.IntegrationByParts
 import Mathlib.MeasureTheory.Integral.IntervalAverage
 import Mathlib.MeasureTheory.Integral.IntervalIntegral
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.ContDiff
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.IntegrationByParts
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.Periodic

--- a/Mathlib/Analysis/Normed/Operator/LinearIsometry.lean
+++ b/Mathlib/Analysis/Normed/Operator/LinearIsometry.lean
@@ -197,6 +197,10 @@ theorem norm_map (x : E) : ‖f x‖ = ‖x‖ :=
 theorem nnnorm_map (x : E) : ‖f x‖₊ = ‖x‖₊ :=
   NNReal.eq <| norm_map f x
 
+@[simp] -- Should be replaced with `SemilinearIsometryClass.enorm_map` when https://github.com/leanprover/lean4/issues/3107 is fixed.
+theorem enorm_map (x : E) : ‖f x‖ₑ = ‖x‖ₑ := by
+  simp [enorm]
+
 protected theorem isometry : Isometry f :=
   AddMonoidHomClass.isometry_of_norm f.toLinearMap (norm_map _)
 

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/ContDiff.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/ContDiff.lean
@@ -1,0 +1,111 @@
+/-
+Copyright (c) 2025 Sébastien Gouëzel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sébastien Gouëzel
+-/
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
+import Mathlib.Analysis.Calculus.ContDiff.Basic
+
+/-! # Fundamental theorem of calculus for `C^1` functions
+
+We give versions of the second fundamental theorem of calculus under the strong assumption
+that the function is `C^1` on the interval. This is restrictive, but satisfied in many situations.
+-/
+
+noncomputable section
+
+open MeasureTheory Set Filter Function Asymptotics
+
+open scoped Topology ENNReal Interval NNReal
+
+variable {ι 𝕜 E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {f : ℝ → E} {a b : ℝ}
+
+namespace intervalIntegral
+
+variable [CompleteSpace E]
+
+/-- Fundamental theorem of calculus-2: If `f : ℝ → E` is `C^1` on `[a, b]`,
+then `∫ y in a..b, deriv f y` equals `f b - f a`. -/
+theorem integral_deriv_of_contDiffOn_Icc (h : ContDiffOn ℝ 1 f (Icc a b)) (hab : a ≤ b) :
+    ∫ x in a..b, deriv f x = f b - f a := by
+  rcases hab.eq_or_lt with rfl | h'ab
+  · simp
+  apply integral_eq_sub_of_hasDerivAt_of_le hab
+  · apply h.continuousOn
+  · intro x hx
+    apply DifferentiableAt.hasDerivAt
+    apply ((h x ⟨hx.1.le, hx.2.le⟩).differentiableWithinAt le_rfl).differentiableAt
+    apply Icc_mem_nhds hx.1 hx.2
+  · have := (h.derivWithin (m := 0) (uniqueDiffOn_Icc h'ab) (by simp)).continuousOn
+    apply (this.intervalIntegrable_of_Icc (μ := volume) hab).congr
+    simp only [hab, uIoc_of_le]
+    rw [← restrict_Ioo_eq_restrict_Ioc]
+    filter_upwards [self_mem_ae_restrict measurableSet_Ioo] with x hx
+    exact derivWithin_of_mem_nhds (Icc_mem_nhds hx.1 hx.2)
+
+/-- Fundamental theorem of calculus-2: If `f : ℝ → E` is `C^1` on `[a, b]`,
+then `∫ y in a..b, derivWithin f (Icc a b) y` equals `f b - f a`. -/
+theorem integral_derivWithin_Icc_of_contDiffOn_Icc (h : ContDiffOn ℝ 1 f (Icc a b)) (hab : a ≤ b) :
+    ∫ x in a..b, derivWithin f (Icc a b) x = f b - f a := by
+  rw [← integral_deriv_of_contDiffOn_Icc h hab]
+  rw [integral_of_le hab, integral_of_le hab]
+  apply MeasureTheory.integral_congr_ae
+  rw [← restrict_Ioo_eq_restrict_Ioc]
+  filter_upwards [self_mem_ae_restrict measurableSet_Ioo] with x hx
+  exact derivWithin_of_mem_nhds (Icc_mem_nhds hx.1 hx.2)
+
+/-- Fundamental theorem of calculus-2: If `f : ℝ → E` is `C^1` on `[a, b]`,
+then `∫ y in a..b, deriv f y` equals `f b - f a`. -/
+theorem integral_deriv_of_contDiffOn_uIcc (h : ContDiffOn ℝ 1 f (uIcc a b)) :
+    ∫ x in a..b, deriv f x = f b - f a := by
+  rcases le_or_gt a b with hab | hab
+  · simp only [uIcc_of_le hab] at h
+    apply integral_deriv_of_contDiffOn_Icc h hab
+  · simp only [uIcc_of_ge hab.le] at h
+    rw [integral_symm, integral_deriv_of_contDiffOn_Icc h hab.le]
+    abel
+
+/-- Fundamental theorem of calculus-2: If `f : ℝ → E` is `C^1` on `[a, b]`,
+then `∫ y in a..b, derivWithin f (uIcc a b) y` equals `f b - f a`. -/
+theorem integral_derivWithin_uIcc_of_contDiffOn_uIcc (h : ContDiffOn ℝ 1 f (uIcc a b)) :
+    ∫ x in a..b, derivWithin f (uIcc a b) x = f b - f a := by
+  rcases le_or_gt a b with hab | hab
+  · simp only [uIcc_of_le hab] at h ⊢
+    apply integral_derivWithin_Icc_of_contDiffOn_Icc h hab
+  · simp only [uIcc_of_ge hab.le] at h ⊢
+    rw [integral_symm, integral_derivWithin_Icc_of_contDiffOn_Icc h hab.le]
+    abel
+
+end intervalIntegral
+
+theorem enorm_sub_le_lintegral_deriv_of_contDiffOn_Icc (h : ContDiffOn ℝ 1 f (Icc a b))
+    (hab : a ≤ b) :
+    ‖f b - f a‖ₑ ≤ ∫⁻ x in Icc a b, ‖deriv f x‖ₑ := by
+  /- We want to write `f b - f a = ∫ x in Icc a b, deriv f x` and use the inequality between
+  norm of integral and integral of norm. There is a small difficulty that this formula is not
+  true when `E` is not complete, so we need to go first to the completion, and argue there. -/
+  let g := UniformSpace.Completion.toComplₗᵢ (𝕜 := ℝ) (E := E)
+  have : ‖(g ∘ f) b - (g ∘ f) a‖ₑ = ‖f b - f a‖ₑ := by
+    rw [← edist_eq_enorm_sub, Function.comp_def, g.isometry.edist_eq, edist_eq_enorm_sub]
+  rw [← this,
+    ← intervalIntegral.integral_deriv_of_contDiffOn_Icc (g.contDiff.comp_contDiffOn h) hab,
+    intervalIntegral.integral_of_le hab, restrict_Ioc_eq_restrict_Icc]
+  apply (enorm_integral_le_lintegral_enorm _).trans
+  apply lintegral_mono_ae
+  rw [← restrict_Ioo_eq_restrict_Icc]
+  filter_upwards [self_mem_ae_restrict measurableSet_Ioo] with x hx
+  rw [fderiv_comp_deriv]; rotate_left
+  · exact (g.contDiff.differentiable le_rfl).differentiableAt
+  · exact ((h x ⟨hx.1.le, hx.2.le⟩).contDiffAt (Icc_mem_nhds hx.1 hx.2)).differentiableAt le_rfl
+  have : fderiv ℝ g (f x) = g.toContinuousLinearMap := g.toContinuousLinearMap.fderiv
+  simp [this]
+
+theorem enorm_sub_le_lintegral_derivWithin_Icc_of_contDiffOn_Icc (h : ContDiffOn ℝ 1 f (Icc a b))
+    (hab : a ≤ b) :
+    ‖f b - f a‖ₑ ≤ ∫⁻ x in Icc a b, ‖derivWithin f (Icc a b) x‖ₑ := by
+  apply (enorm_sub_le_lintegral_deriv_of_contDiffOn_Icc h hab).trans_eq
+  apply lintegral_congr_ae
+  rw [← restrict_Ioo_eq_restrict_Icc]
+  filter_upwards [self_mem_ae_restrict measurableSet_Ioo] with x hx
+  rw [derivWithin_of_mem_nhds (Icc_mem_nhds hx.1 hx.2)]

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/ContDiff.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/ContDiff.lean
@@ -3,8 +3,8 @@ Copyright (c) 2025 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
-import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
 import Mathlib.Analysis.Calculus.ContDiff.Basic
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
 
 /-! # Fundamental theorem of calculus for `C^1` functions
 
@@ -31,12 +31,11 @@ theorem integral_deriv_of_contDiffOn_Icc (h : ContDiffOn ℝ 1 f (Icc a b)) (hab
     ∫ x in a..b, deriv f x = f b - f a := by
   rcases hab.eq_or_lt with rfl | h'ab
   · simp
-  apply integral_eq_sub_of_hasDerivAt_of_le hab
-  · apply h.continuousOn
+  apply integral_eq_sub_of_hasDerivAt_of_le hab h.continuousOn
   · intro x hx
     apply DifferentiableAt.hasDerivAt
     apply ((h x ⟨hx.1.le, hx.2.le⟩).differentiableWithinAt le_rfl).differentiableAt
-    apply Icc_mem_nhds hx.1 hx.2
+    exact Icc_mem_nhds hx.1 hx.2
   · have := (h.derivWithin (m := 0) (uniqueDiffOn_Icc h'ab) (by simp)).continuousOn
     apply (this.intervalIntegrable_of_Icc (μ := volume) hab).congr
     simp only [hab, uIoc_of_le]
@@ -61,7 +60,7 @@ theorem integral_deriv_of_contDiffOn_uIcc (h : ContDiffOn ℝ 1 f (uIcc a b)) :
     ∫ x in a..b, deriv f x = f b - f a := by
   rcases le_or_gt a b with hab | hab
   · simp only [uIcc_of_le hab] at h
-    apply integral_deriv_of_contDiffOn_Icc h hab
+    exact integral_deriv_of_contDiffOn_Icc h hab
   · simp only [uIcc_of_ge hab.le] at h
     rw [integral_symm, integral_deriv_of_contDiffOn_Icc h hab.le]
     abel
@@ -72,12 +71,14 @@ theorem integral_derivWithin_uIcc_of_contDiffOn_uIcc (h : ContDiffOn ℝ 1 f (uI
     ∫ x in a..b, derivWithin f (uIcc a b) x = f b - f a := by
   rcases le_or_gt a b with hab | hab
   · simp only [uIcc_of_le hab] at h ⊢
-    apply integral_derivWithin_Icc_of_contDiffOn_Icc h hab
+    exact integral_derivWithin_Icc_of_contDiffOn_Icc h hab
   · simp only [uIcc_of_ge hab.le] at h ⊢
     rw [integral_symm, integral_derivWithin_Icc_of_contDiffOn_Icc h hab.le]
     abel
 
 end intervalIntegral
+
+open intervalIntegral
 
 theorem enorm_sub_le_lintegral_deriv_of_contDiffOn_Icc (h : ContDiffOn ℝ 1 f (Icc a b))
     (hab : a ≤ b) :
@@ -88,9 +89,8 @@ theorem enorm_sub_le_lintegral_deriv_of_contDiffOn_Icc (h : ContDiffOn ℝ 1 f (
   let g := UniformSpace.Completion.toComplₗᵢ (𝕜 := ℝ) (E := E)
   have : ‖(g ∘ f) b - (g ∘ f) a‖ₑ = ‖f b - f a‖ₑ := by
     rw [← edist_eq_enorm_sub, Function.comp_def, g.isometry.edist_eq, edist_eq_enorm_sub]
-  rw [← this,
-    ← intervalIntegral.integral_deriv_of_contDiffOn_Icc (g.contDiff.comp_contDiffOn h) hab,
-    intervalIntegral.integral_of_le hab, restrict_Ioc_eq_restrict_Icc]
+  rw [← this, ← integral_deriv_of_contDiffOn_Icc (g.contDiff.comp_contDiffOn h) hab,
+    integral_of_le hab, restrict_Ioc_eq_restrict_Icc]
   apply (enorm_integral_le_lintegral_enorm _).trans
   apply lintegral_mono_ae
   rw [← restrict_Ioo_eq_restrict_Icc]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
