### PR TITLE
[Merged by Bors] - fix: handle remote conflicts in migrate_to_fork.py

### DIFF
--- a/scripts/migrate_to_fork.py
+++ b/scripts/migrate_to_fork.py
@@ -371,23 +371,23 @@ def setup_remotes(username: str, fork_url: str, auto_accept: bool = False) -> st
             print_success("Origin remote (fork) already configured correctly")
             fork_remote_name = 'origin'
     else:
-        # Check if origin exists and is not the fork
+        # No fork remote found - need to add one
+        # Check if 'origin' is available for the fork
         if 'origin' in remotes:
-            if f'{username}/mathlib4' not in remotes['origin']:
-                print(f"Current origin: {remotes['origin']}")
-                if yes_no_prompt("Replace existing 'origin' with your fork?", auto_accept=auto_accept):
-                    run_command(['git', 'remote', 'remove', 'origin'])
-                    run_command(['git', 'remote', 'add', 'origin', fork_url])
-                    print_success("Set origin to your fork")
-                    fork_remote_name = 'origin'
-                else:
-                    run_command(['git', 'remote', 'add', 'fork', fork_url])
-                    print_warning("Added fork as 'fork' remote instead of 'origin'")
-                    fork_remote_name = 'fork'
-            else:
-                print_success("Origin already points to your fork")
+            # 'origin' exists but doesn't point to user's fork
+            print(f"Current origin: {remotes['origin']}")
+            if yes_no_prompt("Replace existing 'origin' with your fork?", auto_accept=auto_accept):
+                run_command(['git', 'remote', 'remove', 'origin'])
+                run_command(['git', 'remote', 'add', 'origin', fork_url])
+                print_success("Set origin to your fork")
                 fork_remote_name = 'origin'
+            else:
+                # User wants to keep existing origin, use 'fork' instead
+                run_command(['git', 'remote', 'add', 'fork', fork_url])
+                print_warning("Added fork as 'fork' remote instead of 'origin'")
+                fork_remote_name = 'fork'
         else:
+            # 'origin' doesn't exist, safe to add it
             run_command(['git', 'remote', 'add', 'origin', fork_url])
             print_success("Added origin remote pointing to your fork")
             fork_remote_name = 'origin'

--- a/scripts/migrate_to_fork.py
+++ b/scripts/migrate_to_fork.py
@@ -382,10 +382,10 @@ def setup_remotes(username: str, fork_url: str, auto_accept: bool = False) -> st
                 print_success("Set origin to your fork")
                 fork_remote_name = 'origin'
             else:
-                # User wants to keep existing origin, use 'fork' instead
-                run_command(['git', 'remote', 'add', 'fork', fork_url])
-                print_warning("Added fork as 'fork' remote instead of 'origin'")
-                fork_remote_name = 'fork'
+                # User wants to keep existing origin, ask for alternative name
+                fork_remote_name = get_user_input("What would you like to name the remote for your fork?", "fork")
+                run_command(['git', 'remote', 'add', fork_remote_name, fork_url])
+                print_success(f"Added fork as '{fork_remote_name}' remote")
         else:
             # 'origin' doesn't exist, safe to add it
             run_command(['git', 'remote', 'add', 'origin', fork_url])


### PR DESCRIPTION
This PR fixes a bug in the fork migration script where it would try to remove the 'origin' remote twice in certain scenarios. When a user's main repository remote was named 'origin' (pointing to leanprover-community/mathlib4), the script would: (1) Rename 'origin' to 'upstream' (removing the old 'origin'), (2) Later try to remove 'origin' again when setting up the fork remote, (3) Fail with error: 'No such remote: origin'. The solution adds proper logic to handle the case where user declines to rename their upstream remote, checks if 'origin' remote exists before trying to add/remove it, offers fallback to use 'fork' remote name if user wants to keep existing 'origin', and ensures the script returns the correct remote name for the fork in all scenarios. This resolves the 'No such remote: origin' error.

(AI generated.)