### PR TITLE
[Merged by Bors] - ci: Alternative method to determine the PR metadata from forks

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -542,7 +542,7 @@ jobs:
         shell: bash
         run: |
           echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || join(github.event.pull_request.labels, ',') }}" >> $GITHUB_OUTPUT
+          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || join(github.event.pull_request.labels.*.name, ',') }}" >> $GITHUB_OUTPUT
 
       - if: contains(steps.PR.outputs.pr_labels, 'bench-after-CI')
         name: If `bench-after-CI` is present, add a `!bench` comment.

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -542,7 +542,7 @@ jobs:
         shell: bash
         run: |
           echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || github.event.pull_request.labels }}" >> $GITHUB_OUTPUT
+          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || join(github.event.pull_request.labels, ',') }}" >> $GITHUB_OUTPUT
 
       - if: contains(steps.PR.outputs.pr_labels, 'bench-after-CI')
         name: If `bench-after-CI` is present, add a `!bench` comment.

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -540,7 +540,7 @@ jobs:
       # Combine the output from the previous action with the metadata supplied by GitHub itself.
       - id: PR
         shell: bash
-        runs: |
+        run: |
           echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" >> $GITHUB_OUTPUT
           echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || github.event.pull_request.labels }}" >> $GITHUB_OUTPUT
 

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -533,6 +533,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Only return if PR is still open
           filterOutClosed: true
+          # We need to pass in the commit that CI is actually running on.
+          # Otherwise, PRs from forks will not see the right metadata.
+          # See also: https://github.com/8BitJonny/gh-get-current-pr/issues/293
+          sha: "${{ PR_BRANCH_REF }}"
 
       - if: contains(steps.PR.outputs.pr_labels, 'bench-after-CI')
         name: If `bench-after-CI` is present, add a `!bench` comment.

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -525,7 +525,10 @@ jobs:
     needs: [style_lint, build, post_steps]
     runs-on: ubuntu-latest
     steps:
-      - id: PR
+      # This action is used to determine the PR metadata in the event of a push.
+      # If it is called from a PR from a fork, it will find nothing/irrelevant data.
+      - if: github.event_name != 'pull_request_target'
+        id: PR_from_push
         uses: 8BitJonny/gh-get-current-pr@08e737c57a3a4eb24cec6487664b243b77eb5e36 # 3.0.0
         # TODO: this may not work properly if the same commit is pushed to multiple branches:
         # https://github.com/8BitJonny/gh-get-current-pr/issues/8
@@ -533,10 +536,13 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Only return if PR is still open
           filterOutClosed: true
-          # We need to pass in the commit that CI is actually running on.
-          # Otherwise, PRs from forks will not see the right metadata.
-          # See also: https://github.com/8BitJonny/gh-get-current-pr/issues/293
-          sha: "${{ PR_BRANCH_REF }}"
+
+      # Combine the output from the previous action with the metadata supplied by GitHub itself.
+      - id: PR
+        shell: bash
+        runs: |
+          echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || github.event.pull_request.labels }}" >> $GITHUB_OUTPUT
 
       - if: contains(steps.PR.outputs.pr_labels, 'bench-after-CI')
         name: If `bench-after-CI` is present, add a `!bench` comment.

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -552,7 +552,7 @@ jobs:
         shell: bash
         run: |
           echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || join(github.event.pull_request.labels, ',') }}" >> $GITHUB_OUTPUT
+          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || join(github.event.pull_request.labels.*.name, ',') }}" >> $GITHUB_OUTPUT
 
       - if: contains(steps.PR.outputs.pr_labels, 'bench-after-CI')
         name: If `bench-after-CI` is present, add a `!bench` comment.

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -552,7 +552,7 @@ jobs:
         shell: bash
         run: |
           echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || github.event.pull_request.labels }}" >> $GITHUB_OUTPUT
+          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || join(github.event.pull_request.labels, ',') }}" >> $GITHUB_OUTPUT
 
       - if: contains(steps.PR.outputs.pr_labels, 'bench-after-CI')
         name: If `bench-after-CI` is present, add a `!bench` comment.

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -550,7 +550,7 @@ jobs:
       # Combine the output from the previous action with the metadata supplied by GitHub itself.
       - id: PR
         shell: bash
-        runs: |
+        run: |
           echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" >> $GITHUB_OUTPUT
           echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || github.event.pull_request.labels }}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -535,7 +535,10 @@ jobs:
     needs: [style_lint, build, post_steps]
     runs-on: ubuntu-latest
     steps:
-      - id: PR
+      # This action is used to determine the PR metadata in the event of a push.
+      # If it is called from a PR from a fork, it will find nothing/irrelevant data.
+      - if: github.event_name != 'pull_request_target'
+        id: PR_from_push
         uses: 8BitJonny/gh-get-current-pr@08e737c57a3a4eb24cec6487664b243b77eb5e36 # 3.0.0
         # TODO: this may not work properly if the same commit is pushed to multiple branches:
         # https://github.com/8BitJonny/gh-get-current-pr/issues/8
@@ -543,10 +546,13 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Only return if PR is still open
           filterOutClosed: true
-          # We need to pass in the commit that CI is actually running on.
-          # Otherwise, PRs from forks will not see the right metadata.
-          # See also: https://github.com/8BitJonny/gh-get-current-pr/issues/293
-          sha: "${{ github.sha }}"
+
+      # Combine the output from the previous action with the metadata supplied by GitHub itself.
+      - id: PR
+        shell: bash
+        runs: |
+          echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || github.event.pull_request.labels }}" >> $GITHUB_OUTPUT
 
       - if: contains(steps.PR.outputs.pr_labels, 'bench-after-CI')
         name: If `bench-after-CI` is present, add a `!bench` comment.

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -543,6 +543,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Only return if PR is still open
           filterOutClosed: true
+          # We need to pass in the commit that CI is actually running on.
+          # Otherwise, PRs from forks will not see the right metadata.
+          # See also: https://github.com/8BitJonny/gh-get-current-pr/issues/293
+          sha: "${{ github.sha }}"
 
       - if: contains(steps.PR.outputs.pr_labels, 'bench-after-CI')
         name: If `bench-after-CI` is present, add a `!bench` comment.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -542,7 +542,10 @@ jobs:
     needs: [style_lint, build, post_steps]
     runs-on: ubuntu-latest
     steps:
-      - id: PR
+      # This action is used to determine the PR metadata in the event of a push.
+      # If it is called from a PR from a fork, it will find nothing/irrelevant data.
+      - if: github.event_name != 'pull_request_target'
+        id: PR_from_push
         uses: 8BitJonny/gh-get-current-pr@08e737c57a3a4eb24cec6487664b243b77eb5e36 # 3.0.0
         # TODO: this may not work properly if the same commit is pushed to multiple branches:
         # https://github.com/8BitJonny/gh-get-current-pr/issues/8
@@ -550,10 +553,13 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Only return if PR is still open
           filterOutClosed: true
-          # We need to pass in the commit that CI is actually running on.
-          # Otherwise, PRs from forks will not see the right metadata.
-          # See also: https://github.com/8BitJonny/gh-get-current-pr/issues/293
-          sha: "${{ github.sha }}"
+
+      # Combine the output from the previous action with the metadata supplied by GitHub itself.
+      - id: PR
+        shell: bash
+        runs: |
+          echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || github.event.pull_request.labels }}" >> $GITHUB_OUTPUT
 
       - if: contains(steps.PR.outputs.pr_labels, 'bench-after-CI')
         name: If `bench-after-CI` is present, add a `!bench` comment.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -559,7 +559,7 @@ jobs:
         shell: bash
         run: |
           echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || github.event.pull_request.labels }}" >> $GITHUB_OUTPUT
+          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || join(github.event.pull_request.labels, ',') }}" >> $GITHUB_OUTPUT
 
       - if: contains(steps.PR.outputs.pr_labels, 'bench-after-CI')
         name: If `bench-after-CI` is present, add a `!bench` comment.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -557,7 +557,7 @@ jobs:
       # Combine the output from the previous action with the metadata supplied by GitHub itself.
       - id: PR
         shell: bash
-        runs: |
+        run: |
           echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" >> $GITHUB_OUTPUT
           echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || github.event.pull_request.labels }}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -550,6 +550,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Only return if PR is still open
           filterOutClosed: true
+          # We need to pass in the commit that CI is actually running on.
+          # Otherwise, PRs from forks will not see the right metadata.
+          # See also: https://github.com/8BitJonny/gh-get-current-pr/issues/293
+          sha: "${{ github.sha }}"
 
       - if: contains(steps.PR.outputs.pr_labels, 'bench-after-CI')
         name: If `bench-after-CI` is present, add a `!bench` comment.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -559,7 +559,7 @@ jobs:
         shell: bash
         run: |
           echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || join(github.event.pull_request.labels, ',') }}" >> $GITHUB_OUTPUT
+          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || join(github.event.pull_request.labels.*.name, ',') }}" >> $GITHUB_OUTPUT
 
       - if: contains(steps.PR.outputs.pr_labels, 'bench-after-CI')
         name: If `bench-after-CI` is present, add a `!bench` comment.

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -547,6 +547,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Only return if PR is still open
           filterOutClosed: true
+          # We need to pass in the commit that CI is actually running on.
+          # Otherwise, PRs from forks will not see the right metadata.
+          # See also: https://github.com/8BitJonny/gh-get-current-pr/issues/293
+          sha: "${{ github.event.pull_request.head.sha }}"
 
       - if: contains(steps.PR.outputs.pr_labels, 'bench-after-CI')
         name: If `bench-after-CI` is present, add a `!bench` comment.

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -556,7 +556,7 @@ jobs:
         shell: bash
         run: |
           echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || github.event.pull_request.labels }}" >> $GITHUB_OUTPUT
+          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || join(github.event.pull_request.labels, ',') }}" >> $GITHUB_OUTPUT
 
       - if: contains(steps.PR.outputs.pr_labels, 'bench-after-CI')
         name: If `bench-after-CI` is present, add a `!bench` comment.

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -539,7 +539,10 @@ jobs:
     needs: [style_lint, build, post_steps]
     runs-on: ubuntu-latest
     steps:
-      - id: PR
+      # This action is used to determine the PR metadata in the event of a push.
+      # If it is called from a PR from a fork, it will find nothing/irrelevant data.
+      - if: github.event_name != 'pull_request_target'
+        id: PR_from_push
         uses: 8BitJonny/gh-get-current-pr@08e737c57a3a4eb24cec6487664b243b77eb5e36 # 3.0.0
         # TODO: this may not work properly if the same commit is pushed to multiple branches:
         # https://github.com/8BitJonny/gh-get-current-pr/issues/8
@@ -547,10 +550,13 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Only return if PR is still open
           filterOutClosed: true
-          # We need to pass in the commit that CI is actually running on.
-          # Otherwise, PRs from forks will not see the right metadata.
-          # See also: https://github.com/8BitJonny/gh-get-current-pr/issues/293
-          sha: "${{ github.event.pull_request.head.sha }}"
+
+      # Combine the output from the previous action with the metadata supplied by GitHub itself.
+      - id: PR
+        shell: bash
+        runs: |
+          echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || github.event.pull_request.labels }}" >> $GITHUB_OUTPUT
 
       - if: contains(steps.PR.outputs.pr_labels, 'bench-after-CI')
         name: If `bench-after-CI` is present, add a `!bench` comment.

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -556,7 +556,7 @@ jobs:
         shell: bash
         run: |
           echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || join(github.event.pull_request.labels, ',') }}" >> $GITHUB_OUTPUT
+          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || join(github.event.pull_request.labels.*.name, ',') }}" >> $GITHUB_OUTPUT
 
       - if: contains(steps.PR.outputs.pr_labels, 'bench-after-CI')
         name: If `bench-after-CI` is present, add a `!bench` comment.

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -554,7 +554,7 @@ jobs:
       # Combine the output from the previous action with the metadata supplied by GitHub itself.
       - id: PR
         shell: bash
-        runs: |
+        run: |
           echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" >> $GITHUB_OUTPUT
           echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || github.event.pull_request.labels }}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
The GitHub action we use to determine PR metadata (used to change labels and take actions based on existing labels) does not work for PRs from forks. If it is a PR from a fork, then the workflow context already contains the required data. I could not find an action that has the required functionality and supports both forks and non-fork pushes. So we write a little bit of code to select the right data source.

Test PR: https://github.com/leanprover-community/mathlib4/pull/25807.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
