### PR TITLE
Test: Draft Status Migration

### DIFF
--- a/test_draft_migration.md
+++ b/test_draft_migration.md
@@ -1,0 +1,8 @@
+# Test Draft Status Migration
+
+This is a test file created to verify that the migration script preserves draft status when migrating PRs from the main repository to fork-based PRs.
+
+## Test Steps
+1. Create draft PR on main repo
+2. Run migration script
+3. Verify new PR is also draft


### PR DESCRIPTION
This is a test PR to verify that the migration script preserves draft status when migrating from main repo to fork-based PRs.

---

*This PR continues the work from #25798.*

*Original PR: https://github.com/leanprover-community/mathlib4/pull/25798*