### PR TITLE
[Merged by Bors] - chore: for models with corners, weaken `transDiffeomomorph` to `transContinuousLinearEquiv`

### DIFF
--- a/Mathlib/Geometry/Manifold/Diffeomorph.lean
+++ b/Mathlib/Geometry/Manifold/Diffeomorph.lean
@@ -412,30 +412,49 @@ def transContinuousLinearEquiv : ModelWithCorners 𝕜 E' H where
   continuous_toFun := e.continuous.comp I.continuous
   continuous_invFun := I.continuous_symm.comp e.symm.continuous
 
+@[deprecated (since := "2025-06-12")] alias transDiffeomorph := transContinuousLinearEquiv
+
 @[simp, mfld_simps]
 theorem coe_transContinuousLinearEquiv : ⇑(I.transContinuousLinearEquiv e) = e ∘ I :=
   rfl
+
+@[deprecated (since := "2025-06-12")] alias coe_transDiffeomorph := coe_transContinuousLinearEquiv
 
 @[simp, mfld_simps]
 theorem coe_transContinuousLinearEquiv_symm :
     ⇑(I.transContinuousLinearEquiv e).symm = I.symm ∘ e.symm := rfl
 
+@[deprecated (since := "2025-06-12")]
+alias coe_transDiffeomorph_symm := coe_transContinuousLinearEquiv_symm
+
 theorem transContinuousLinearEquiv_range : range (I.transContinuousLinearEquiv e) = e '' range I :=
   range_comp e I
+
+@[deprecated (since := "2025-06-12")]
+alias transDiffeomorph_range := transContinuousLinearEquiv_range
 
 theorem coe_extChartAt_transContinuousLinearEquiv (x : M) :
     ⇑(extChartAt (I.transContinuousLinearEquiv e) x) = e ∘ extChartAt I x :=
   rfl
 
+@[deprecated (since := "2025-06-12")]
+alias coe_extChartAt_transDiffeomorph := coe_extChartAt_transContinuousLinearEquiv
+
 theorem coe_extChartAt_transContinuousLinearEquiv_symm (x : M) :
     ⇑(extChartAt (I.transContinuousLinearEquiv e) x).symm = (extChartAt I x).symm ∘ e.symm :=
   rfl
+
+@[deprecated (since := "2025-06-12")]
+alias coe_extChartAt_transDiffeomorph_symm := coe_extChartAt_transContinuousLinearEquiv_symm
 
 theorem extChartAt_transContinuousLinearEquiv_target (x : M) :
     (extChartAt (I.transContinuousLinearEquiv e) x).target
       = e.symm ⁻¹' (extChartAt I x).target := by
   simp only [range_comp, preimage_preimage, ContinuousLinearEquiv.image_eq_preimage, mfld_simps]
   rfl
+
+@[deprecated (since := "2025-06-12")]
+alias extChartAt_transDiffeomorph_target := extChartAt_transContinuousLinearEquiv_target
 
 end ModelWithCorners
 
@@ -473,6 +492,9 @@ def toTransContinuousLinearEquiv (e : E ≃L[𝕜] F) : M ≃ₘ^n⟮I, I.transC
     exact ⟨(extChartAt _ x).map_source (mem_extChartAt_source x), trivial, by
       simp only [e.symm_apply_apply, Equiv.refl_symm, Equiv.coe_refl, mfld_simps]⟩
 
+@[deprecated (since := "2025-06-12")]
+alias _root_.Diffeomorph.toTransDiffeomorph := toTransContinuousLinearEquiv
+
 variable {I M}
 
 @[simp]
@@ -481,23 +503,40 @@ theorem contMDiffWithinAt_transContinuousLinearEquiv_right {f : M' → M} {x s} 
       ↔ ContMDiffWithinAt I' I n f s x :=
   (toTransContinuousLinearEquiv I M e).contMDiffWithinAt_diffeomorph_comp_iff le_rfl
 
+@[deprecated (since := "2025-06-12")]
+alias _root_.Diffeomorph.contMDiffWithinAt_transDiffeomorph_right :=
+contMDiffWithinAt_transContinuousLinearEquiv_right
+
 @[simp]
 theorem contMDiffAt_transContinuousLinearEquiv_right {f : M' → M} {x} :
     ContMDiffAt I' (I.transContinuousLinearEquiv e) n f x ↔ ContMDiffAt I' I n f x :=
   (toTransContinuousLinearEquiv I M e).contMDiffAt_diffeomorph_comp_iff le_rfl
+
+@[deprecated (since := "2025-06-12")]
+alias _root_.Diffeomorph.contMDiffAt_transDiffeomorph_right :=
+contMDiffAt_transContinuousLinearEquiv_right
 
 @[simp]
 theorem contMDiffOn_transContinuousLinearEquiv_right {f : M' → M} {s} :
     ContMDiffOn I' (I.transContinuousLinearEquiv e) n f s ↔ ContMDiffOn I' I n f s :=
   (toTransContinuousLinearEquiv I M e).contMDiffOn_diffeomorph_comp_iff le_rfl
 
+@[deprecated (since := "2025-06-12")]
+alias _root_.Diffeomorph.contMDiffOn_transDiffeomorph_right :=
+contMDiffOn_transContinuousLinearEquiv_right
+
 @[simp]
 theorem contMDiff_transContinuousLinearEquiv_right {f : M' → M} :
     ContMDiff I' (I.transContinuousLinearEquiv e) n f ↔ ContMDiff I' I n f :=
   (toTransContinuousLinearEquiv I M e).contMDiff_diffeomorph_comp_iff le_rfl
 
+@[deprecated (since := "2025-06-12")]
+alias _root_.Diffeomorph.contMDiff_transDiffeomorph_right :=
+contMDiff_transContinuousLinearEquiv_right
+
 @[deprecated (since := "2024-11-21")]
-alias smooth_transContinuousLinearEquiv_right := contMDiff_transContinuousLinearEquiv_right
+alias _root_.Diffeomorph.smooth_transDiffeomorph_right :=
+contMDiff_transContinuousLinearEquiv_right
 
 @[simp]
 theorem contMDiffWithinAt_transContinuousLinearEquiv_left {f : M → M'} {x s} :
@@ -505,23 +544,40 @@ theorem contMDiffWithinAt_transContinuousLinearEquiv_left {f : M → M'} {x s} :
       ↔ ContMDiffWithinAt I I' n f s x :=
   ((toTransContinuousLinearEquiv I M e).contMDiffWithinAt_comp_diffeomorph_iff le_rfl).symm
 
+@[deprecated (since := "2025-06-12")]
+alias _root_.Diffeomorph.contMDiffWithinAt_transDiffeomorph_left :=
+contMDiffWithinAt_transContinuousLinearEquiv_left
+
 @[simp]
 theorem contMDiffAt_transContinuousLinearEquiv_left {f : M → M'} {x} :
     ContMDiffAt (I.transContinuousLinearEquiv e) I' n f x ↔ ContMDiffAt I I' n f x :=
   ((toTransContinuousLinearEquiv I M e).contMDiffAt_comp_diffeomorph_iff le_rfl).symm
+
+@[deprecated (since := "2025-06-12")]
+alias _root_.Diffeomorph.contMDiffAt_transDiffeomorph_left :=
+contMDiffAt_transContinuousLinearEquiv_left
 
 @[simp]
 theorem contMDiffOn_transContinuousLinearEquiv_left {f : M → M'} {s} :
     ContMDiffOn (I.transContinuousLinearEquiv e) I' n f s ↔ ContMDiffOn I I' n f s :=
   ((toTransContinuousLinearEquiv I M e).contMDiffOn_comp_diffeomorph_iff le_rfl).symm
 
+@[deprecated (since := "2025-06-12")]
+alias _root_.Diffeomorph.contMDiffOn_transDiffeomorph_left :=
+contMDiffOn_transContinuousLinearEquiv_left
+
 @[simp]
 theorem contMDiff_transContinuousLinearEquiv_left {f : M → M'} :
     ContMDiff (I.transContinuousLinearEquiv e) I' n f ↔ ContMDiff I I' n f :=
   ((toTransContinuousLinearEquiv I M e).contMDiff_comp_diffeomorph_iff le_rfl).symm
 
+@[deprecated (since := "2025-06-12")]
+alias _root_.Diffeomorph.contMDiff_transDiffeomorph_left :=
+contMDiff_transContinuousLinearEquiv_left
+
 @[deprecated (since := "2024-11-21")]
-alias smooth_transContinuousLinearEquiv_left := contMDiff_transContinuousLinearEquiv_left
+alias _root_.Diffeomorph.smooth_transContinuousLinearEquiv_left :=
+contMDiff_transContinuousLinearEquiv_left
 
 end ContinuousLinearEquiv
 

--- a/Mathlib/Geometry/Manifold/Diffeomorph.lean
+++ b/Mathlib/Geometry/Manifold/Diffeomorph.lean
@@ -12,17 +12,17 @@ This file implements diffeomorphisms.
 
 ## Definitions
 
-* `Diffeomorph I I' M M' n`:  `n`-times continuously differentiable diffeomorphism between
+* `Diffeomorph I I' M M' n`: `n`-times continuously differentiable diffeomorphism between
   `M` and `M'` with respect to I and I'; we do not introduce a separate definition for the case
-  `n = ∞`; we use notation instead.
+  `n = ∞` or `n = ω`; we use notation instead.
 * `Diffeomorph.toHomeomorph`: reinterpret a diffeomorphism as a homeomorphism.
 * `ContinuousLinearEquiv.toDiffeomorph`: reinterpret a continuous equivalence as
   a diffeomorphism.
-* `ModelWithCorners.transDiffeomorph`: compose a given `ModelWithCorners` with a diffeomorphism
-  between the old and the new target spaces. Useful, e.g, to turn any finite dimensional manifold
-  into a manifold modelled on a Euclidean space.
-* `Diffeomorph.toTransDiffeomorph`: the identity diffeomorphism between `M` with model `I` and `M`
-  with model `I.trans_diffeomorph e`.
+* `ModelWithCorners.transContinuousLinearEquiv`: compose a given `ModelWithCorners` with a
+  continuous linear equiv between the old and the new target spaces. Useful, e.g, to turn any
+  finite dimensional manifold into a manifold modelled on a Euclidean space.
+* `Diffeomorph.toTransContinuousLinearEquiv`: the identity diffeomorphism between `M` with
+  model `I` and `M` with model `I.transContinuousLinearEquiv e`.
 
 This file also provides diffeomorphisms related to products and disjoint unions.
 * `Diffeomorph.prodCongr`: the product of two diffeomorphisms
@@ -351,14 +351,16 @@ theorem uniqueMDiffOn_preimage (h : M ≃ₘ^n⟮I, J⟯ N) (hn : 1 ≤ n) {s : 
     UniqueMDiffOn I (h ⁻¹' s) ↔ UniqueMDiffOn J s :=
   h.symm_image_eq_preimage s ▸ h.symm.uniqueMDiffOn_image hn
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: should use `E ≃ₘ^n[𝕜] F` notation
+-- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215):
+-- TODO: should use `E ≃ₘ^n[𝕜] F` notation
 @[simp]
 theorem uniqueDiffOn_image (h : E ≃ₘ^n⟮𝓘(𝕜, E), 𝓘(𝕜, F)⟯ F) (hn : 1 ≤ n) {s : Set E} :
     UniqueDiffOn 𝕜 (h '' s) ↔ UniqueDiffOn 𝕜 s := by
   simp only [← uniqueMDiffOn_iff_uniqueDiffOn, uniqueMDiffOn_image, hn]
 
 @[simp]
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO: should use `E ≃ₘ^n[𝕜] F` notation
+-- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215):
+-- TODO: should use `E ≃ₘ^n[𝕜] F` notation
 theorem uniqueDiffOn_preimage (h : E ≃ₘ^n⟮𝓘(𝕜, E), 𝓘(𝕜, F)⟯ F) (hn : 1 ≤ n) {s : Set F} :
     UniqueDiffOn 𝕜 (h ⁻¹' s) ↔ UniqueDiffOn 𝕜 s :=
   h.symm_image_eq_preimage s ▸ h.symm.uniqueDiffOn_image hn
@@ -391,15 +393,13 @@ end ContinuousLinearEquiv
 
 namespace ModelWithCorners
 
-variable (I) (e : E ≃ₘ^n⟮𝓘(𝕜, E), 𝓘(𝕜, E')⟯ E') [NeZero n]
+variable (I) (e : E ≃L[𝕜] E')
 
-/-- Apply a diffeomorphism (e.g., a continuous linear equivalence) to the model vector space. -/
-def transDiffeomorph : ModelWithCorners 𝕜 E' H where
+/-- Apply a continuous linear equivalence to the model vector space. -/
+def transContinuousLinearEquiv : ModelWithCorners 𝕜 E' H where
   toPartialEquiv := I.toPartialEquiv.trans e.toEquiv.toPartialEquiv
   source_eq := by simp
-  uniqueDiffOn' := by
-    have hn : 1 ≤ n := ENat.one_le_iff_ne_zero_withTop.mpr (NeZero.ne n)
-    simp [I.uniqueDiffOn, hn]
+  uniqueDiffOn' := by simp [I.uniqueDiffOn]
   target_subset_closure_interior := by
     simp only [PartialEquiv.trans_target, Equiv.toPartialEquiv_target,
       Equiv.toPartialEquiv_symm_apply, Diffeomorph.toEquiv_coe_symm, target_eq, univ_inter]
@@ -413,115 +413,119 @@ def transDiffeomorph : ModelWithCorners 𝕜 E' H where
   continuous_invFun := I.continuous_symm.comp e.symm.continuous
 
 @[simp, mfld_simps]
-theorem coe_transDiffeomorph : ⇑(I.transDiffeomorph e) = e ∘ I :=
+theorem coe_transContinuousLinearEquiv : ⇑(I.transContinuousLinearEquiv e) = e ∘ I :=
   rfl
 
 @[simp, mfld_simps]
-theorem coe_transDiffeomorph_symm : ⇑(I.transDiffeomorph e).symm = I.symm ∘ e.symm :=
-  rfl
+theorem coe_transContinuousLinearEquiv_symm :
+    ⇑(I.transContinuousLinearEquiv e).symm = I.symm ∘ e.symm := rfl
 
-theorem transDiffeomorph_range : range (I.transDiffeomorph e) = e '' range I :=
+theorem transContinuousLinearEquiv_range : range (I.transContinuousLinearEquiv e) = e '' range I :=
   range_comp e I
 
-theorem coe_extChartAt_transDiffeomorph (x : M) :
-    ⇑(extChartAt (I.transDiffeomorph e) x) = e ∘ extChartAt I x :=
+theorem coe_extChartAt_transContinuousLinearEquiv (x : M) :
+    ⇑(extChartAt (I.transContinuousLinearEquiv e) x) = e ∘ extChartAt I x :=
   rfl
 
-theorem coe_extChartAt_transDiffeomorph_symm (x : M) :
-    ⇑(extChartAt (I.transDiffeomorph e) x).symm = (extChartAt I x).symm ∘ e.symm :=
+theorem coe_extChartAt_transContinuousLinearEquiv_symm (x : M) :
+    ⇑(extChartAt (I.transContinuousLinearEquiv e) x).symm = (extChartAt I x).symm ∘ e.symm :=
   rfl
 
-theorem extChartAt_transDiffeomorph_target (x : M) :
-    (extChartAt (I.transDiffeomorph e) x).target = e.symm ⁻¹' (extChartAt I x).target := by
-  simp only [e.range_comp, preimage_preimage, mfld_simps]; rfl
+theorem extChartAt_transContinuousLinearEquiv_target (x : M) :
+    (extChartAt (I.transContinuousLinearEquiv e) x).target
+      = e.symm ⁻¹' (extChartAt I x).target := by
+  simp only [range_comp, preimage_preimage, ContinuousLinearEquiv.image_eq_preimage, mfld_simps]
+  rfl
 
 end ModelWithCorners
 
-namespace Diffeomorph
+namespace ContinuousLinearEquiv
 
-section
+variable (e : E ≃L[𝕜] F)
 
-variable [NeZero n] (e : E ≃ₘ^n⟮𝓘(𝕜, E), 𝓘(𝕜, F)⟯ F)
-
-instance instIsManifoldTransDiffeomorph [IsManifold I n M] :
-    IsManifold (I.transDiffeomorph e) n M := by
-  refine isManifold_of_contDiffOn (I.transDiffeomorph e) n M fun e₁ e₂ h₁ h₂ => ?_
+instance instIsManifoldtransContinuousLinearEquiv [IsManifold I n M] :
+    IsManifold (I.transContinuousLinearEquiv e) n M := by
+  refine isManifold_of_contDiffOn (I.transContinuousLinearEquiv e) n M fun e₁ e₂ h₁ h₂ => ?_
   refine e.contDiff.comp_contDiffOn
       (((contDiffGroupoid n I).compatible h₁ h₂).1.comp e.symm.contDiff.contDiffOn ?_)
-  simp only [mapsTo_iff_subset_preimage]
-  mfld_set_tac
+  simp [preimage_comp, range_comp, mapsTo_iff_subset_preimage,
+    ContinuousLinearEquiv.image_eq_preimage]
 
 variable (I M)
 
 /-- The identity diffeomorphism between a manifold with model `I` and the same manifold
 with model `I.trans_diffeomorph e`. -/
-def toTransDiffeomorph (e : E ≃ₘ^n⟮𝓘(𝕜, E), 𝓘(𝕜, F)⟯ F) : M ≃ₘ^n⟮I, I.transDiffeomorph e⟯ M where
+def toTransContinuousLinearEquiv (e : E ≃L[𝕜] F) : M ≃ₘ^n⟮I, I.transContinuousLinearEquiv e⟯ M where
   toEquiv := Equiv.refl M
   contMDiff_toFun x := by
     refine contMDiffWithinAt_iff'.2 ⟨continuousWithinAt_id, ?_⟩
     refine e.contDiff.contDiffWithinAt.congr_of_mem (fun y hy ↦ ?_) ?_
-    · simp only [Equiv.coe_refl, id, (· ∘ ·), I.coe_extChartAt_transDiffeomorph,
+    · simp only [Equiv.coe_refl, id, (· ∘ ·), I.coe_extChartAt_transContinuousLinearEquiv,
         (extChartAt I x).right_inv hy.1]
     · exact
       ⟨(extChartAt I x).map_source (mem_extChartAt_source x), trivial, by simp only [mfld_simps]⟩
   contMDiff_invFun x := by
     refine contMDiffWithinAt_iff'.2 ⟨continuousWithinAt_id, ?_⟩
     refine e.symm.contDiff.contDiffWithinAt.congr_of_mem (fun y hy => ?_) ?_
-    · simp only [mem_inter_iff, I.extChartAt_transDiffeomorph_target] at hy
+    · simp only [mem_inter_iff, I.extChartAt_transContinuousLinearEquiv_target] at hy
       simp only [Equiv.coe_refl, Equiv.refl_symm, id, (· ∘ ·),
-        I.coe_extChartAt_transDiffeomorph_symm, (extChartAt I x).right_inv hy.1]
+        I.coe_extChartAt_transContinuousLinearEquiv_symm, (extChartAt I x).right_inv hy.1]
     exact ⟨(extChartAt _ x).map_source (mem_extChartAt_source x), trivial, by
       simp only [e.symm_apply_apply, Equiv.refl_symm, Equiv.coe_refl, mfld_simps]⟩
 
 variable {I M}
 
 @[simp]
-theorem contMDiffWithinAt_transDiffeomorph_right {f : M' → M} {x s} :
-    ContMDiffWithinAt I' (I.transDiffeomorph e) n f s x ↔ ContMDiffWithinAt I' I n f s x :=
-  (toTransDiffeomorph I M e).contMDiffWithinAt_diffeomorph_comp_iff le_rfl
+theorem contMDiffWithinAt_transContinuousLinearEquiv_right {f : M' → M} {x s} :
+    ContMDiffWithinAt I' (I.transContinuousLinearEquiv e) n f s x
+      ↔ ContMDiffWithinAt I' I n f s x :=
+  (toTransContinuousLinearEquiv I M e).contMDiffWithinAt_diffeomorph_comp_iff le_rfl
 
 @[simp]
-theorem contMDiffAt_transDiffeomorph_right {f : M' → M} {x} :
-    ContMDiffAt I' (I.transDiffeomorph e) n f x ↔ ContMDiffAt I' I n f x :=
-  (toTransDiffeomorph I M e).contMDiffAt_diffeomorph_comp_iff le_rfl
+theorem contMDiffAt_transContinuousLinearEquiv_right {f : M' → M} {x} :
+    ContMDiffAt I' (I.transContinuousLinearEquiv e) n f x ↔ ContMDiffAt I' I n f x :=
+  (toTransContinuousLinearEquiv I M e).contMDiffAt_diffeomorph_comp_iff le_rfl
 
 @[simp]
-theorem contMDiffOn_transDiffeomorph_right {f : M' → M} {s} :
-    ContMDiffOn I' (I.transDiffeomorph e) n f s ↔ ContMDiffOn I' I n f s :=
-  (toTransDiffeomorph I M e).contMDiffOn_diffeomorph_comp_iff le_rfl
+theorem contMDiffOn_transContinuousLinearEquiv_right {f : M' → M} {s} :
+    ContMDiffOn I' (I.transContinuousLinearEquiv e) n f s ↔ ContMDiffOn I' I n f s :=
+  (toTransContinuousLinearEquiv I M e).contMDiffOn_diffeomorph_comp_iff le_rfl
 
 @[simp]
-theorem contMDiff_transDiffeomorph_right {f : M' → M} :
-    ContMDiff I' (I.transDiffeomorph e) n f ↔ ContMDiff I' I n f :=
-  (toTransDiffeomorph I M e).contMDiff_diffeomorph_comp_iff le_rfl
+theorem contMDiff_transContinuousLinearEquiv_right {f : M' → M} :
+    ContMDiff I' (I.transContinuousLinearEquiv e) n f ↔ ContMDiff I' I n f :=
+  (toTransContinuousLinearEquiv I M e).contMDiff_diffeomorph_comp_iff le_rfl
 
 @[deprecated (since := "2024-11-21")]
-alias smooth_transDiffeomorph_right := contMDiff_transDiffeomorph_right
+alias smooth_transContinuousLinearEquiv_right := contMDiff_transContinuousLinearEquiv_right
 
 @[simp]
-theorem contMDiffWithinAt_transDiffeomorph_left {f : M → M'} {x s} :
-    ContMDiffWithinAt (I.transDiffeomorph e) I' n f s x ↔ ContMDiffWithinAt I I' n f s x :=
-  ((toTransDiffeomorph I M e).contMDiffWithinAt_comp_diffeomorph_iff le_rfl).symm
+theorem contMDiffWithinAt_transContinuousLinearEquiv_left {f : M → M'} {x s} :
+    ContMDiffWithinAt (I.transContinuousLinearEquiv e) I' n f s x
+      ↔ ContMDiffWithinAt I I' n f s x :=
+  ((toTransContinuousLinearEquiv I M e).contMDiffWithinAt_comp_diffeomorph_iff le_rfl).symm
 
 @[simp]
-theorem contMDiffAt_transDiffeomorph_left {f : M → M'} {x} :
-    ContMDiffAt (I.transDiffeomorph e) I' n f x ↔ ContMDiffAt I I' n f x :=
-  ((toTransDiffeomorph I M e).contMDiffAt_comp_diffeomorph_iff le_rfl).symm
+theorem contMDiffAt_transContinuousLinearEquiv_left {f : M → M'} {x} :
+    ContMDiffAt (I.transContinuousLinearEquiv e) I' n f x ↔ ContMDiffAt I I' n f x :=
+  ((toTransContinuousLinearEquiv I M e).contMDiffAt_comp_diffeomorph_iff le_rfl).symm
 
 @[simp]
-theorem contMDiffOn_transDiffeomorph_left {f : M → M'} {s} :
-    ContMDiffOn (I.transDiffeomorph e) I' n f s ↔ ContMDiffOn I I' n f s :=
-  ((toTransDiffeomorph I M e).contMDiffOn_comp_diffeomorph_iff le_rfl).symm
+theorem contMDiffOn_transContinuousLinearEquiv_left {f : M → M'} {s} :
+    ContMDiffOn (I.transContinuousLinearEquiv e) I' n f s ↔ ContMDiffOn I I' n f s :=
+  ((toTransContinuousLinearEquiv I M e).contMDiffOn_comp_diffeomorph_iff le_rfl).symm
 
 @[simp]
-theorem contMDiff_transDiffeomorph_left {f : M → M'} :
-    ContMDiff (I.transDiffeomorph e) I' n f ↔ ContMDiff I I' n f :=
-  ((toTransDiffeomorph I M e).contMDiff_comp_diffeomorph_iff le_rfl).symm
+theorem contMDiff_transContinuousLinearEquiv_left {f : M → M'} :
+    ContMDiff (I.transContinuousLinearEquiv e) I' n f ↔ ContMDiff I I' n f :=
+  ((toTransContinuousLinearEquiv I M e).contMDiff_comp_diffeomorph_iff le_rfl).symm
 
 @[deprecated (since := "2024-11-21")]
-alias smooth_transDiffeomorph_left := contMDiff_transDiffeomorph_left
+alias smooth_transContinuousLinearEquiv_left := contMDiff_transContinuousLinearEquiv_left
 
-end
+end ContinuousLinearEquiv
+
+namespace Diffeomorph
 
 section Constructions
 


### PR DESCRIPTION
This is needed before we can switch the definition of models with corners in #23658, as general diffeomorphisms don't send convex sets to convex sets. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
