### PR TITLE
[Merged by Bors] - fix(Tactic/DeprecateTo): get date from Lean

### DIFF
--- a/Mathlib/Tactic/DeprecateTo.lean
+++ b/Mathlib/Tactic/DeprecateTo.lean
@@ -6,6 +6,7 @@ Authors: Damiano Testa
 import Lean.Meta.Tactic.TryThis
 import Mathlib.Lean.Expr.Basic
 import Mathlib.Tactic.Lemma
+import Std.Time
 
 /-!
 #  `deprecate to` -- a deprecation tool
@@ -43,9 +44,12 @@ open Lean Elab Term Command
 /-- Produce the syntax for the command `@[deprecated (since := "YYYY-MM-DD")] alias n := id`. -/
 def mkDeprecationStx (id : TSyntax `ident) (n : Name) (dat : Option String := none) :
     CommandElabM (TSyntax `command) := do
-  let dat := ← match dat with
-                | none => IO.Process.run { cmd := "date", args := #["-I"] }
-                | some s => return s
+  let dat := ←
+    match dat with
+      | none => do
+        let now ← Std.Time.ZonedDateTime.now
+        return Std.Time.Formats.leanDate.formatBuilder now.year now.month now.day
+      | some s => return s
   let nd := mkNode `str #[mkAtom ("\"" ++ dat.trimRight ++ "\"")]
   `(command| @[deprecated (since := $nd)] alias $(mkIdent n) := $id)
 

--- a/Mathlib/Tactic/DeprecateTo.lean
+++ b/Mathlib/Tactic/DeprecateTo.lean
@@ -47,8 +47,7 @@ def mkDeprecationStx (id : TSyntax `ident) (n : Name) (dat : Option String := no
   let dat := ←
     match dat with
       | none => do
-        let now ← Std.Time.ZonedDateTime.now
-        return Std.Time.Formats.leanDate.formatBuilder now.year now.month now.day
+        return s!"{(← Std.Time.ZonedDateTime.now).toPlainDate}"
       | some s => return s
   let nd := mkNode `str #[mkAtom ("\"" ++ dat.trimRight ++ "\"")]
   `(command| @[deprecated (since := $nd)] alias $(mkIdent n) := $id)

--- a/Mathlib/Tactic/DeprecateTo.lean
+++ b/Mathlib/Tactic/DeprecateTo.lean
@@ -6,7 +6,7 @@ Authors: Damiano Testa
 import Lean.Meta.Tactic.TryThis
 import Mathlib.Lean.Expr.Basic
 import Mathlib.Tactic.Lemma
-import Std.Time
+import Std.Time.Format
 
 /-!
 #  `deprecate to` -- a deprecation tool


### PR DESCRIPTION
Fixes an issue I encountered on windows where `IO.Process.run { cmd := "date", args := #["-I"] }` exits with an error `no such file or directory (error code: 2)`, making this tactic unusable.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
