### PR TITLE
[Merged by Bors] - feat(data): List.Chain' helper lemmas

### DIFF
--- a/Mathlib/Data/List/Chain.lean
+++ b/Mathlib/Data/List/Chain.lean
@@ -310,10 +310,11 @@ theorem Chain'.imp_head {x y} (h : ∀ {z}, R x z → R y z) {l} (hl : Chain' R 
   hl.tail.cons' fun _ hz => h <| hl.rel_head? hz
 
 theorem chain'_getElem (h : List.Chain' R l) (n : ℕ) (h' : n + 1 < l.length) :
-    R l[n] l[n+1] :=
+    R l[n] l[n + 1] :=
   chain'_pair.mp <| Chain'.infix h ⟨l.take n, l.drop (n + 2), by simp⟩
 
-theorem chain'_of_not (h : ¬List.Chain' R l) : ∃ n : ℕ, ∃ h : n + 1 < l.length, ¬R l[n] l[n+1] := by
+theorem chain'_of_not (h : ¬List.Chain' R l) :
+    ∃ n : ℕ, ∃ h : n + 1 < l.length, ¬R l[n] l[n + 1] := by
   contrapose! h
   induction l with
   | nil => simp
@@ -327,7 +328,7 @@ theorem chain'_of_not (h : ¬List.Chain' R l) : ∃ n : ℕ, ∃ h : n + 1 < l.l
           obtain ⟨_, rfl⟩ := getElem?_eq_some_iff.mp yh
           have := h 0 (by rw [length_cons]; omega)
           rwa [getElem_cons_zero] at this
-      · refine ih (fun n h' => ?_)
+      · refine ih (fun n h' ↦ ?_)
         have := h (n + 1) (by rw [length_cons]; omega)
         simpa using this
 

--- a/Mathlib/Data/List/Chain.lean
+++ b/Mathlib/Data/List/Chain.lean
@@ -309,9 +309,9 @@ theorem Chain'.imp_head {x y} (h : ∀ {z}, R x z → R y z) {l} (hl : Chain' R 
     Chain' R (y :: l) :=
   hl.tail.cons' fun _ hz => h <| hl.rel_head? hz
 
-theorem chain'_getElem (h : List.Chain' R l) (n : ℕ) (h' : n + 1 < l.length) :
+protected theorem Chain'.getElem (h : List.Chain' R l) (n : ℕ) (h' : n + 1 < l.length) :
     R l[n] l[n + 1] :=
-  chain'_pair.mp <| Chain'.infix h ⟨l.take n, l.drop (n + 2), by simp⟩
+  chain'_pair.mp <| h.infix ⟨l.take n, l.drop (n + 2), by simp⟩
 
 theorem chain'_of_not (h : ¬List.Chain' R l) :
     ∃ n : ℕ, ∃ h : n + 1 < l.length, ¬R l[n] l[n + 1] := by
@@ -332,7 +332,7 @@ theorem chain'_of_not (h : ¬List.Chain' R l) :
 
 theorem chain'_iff_forall_getElem :
     Chain' R l ↔ ∀ (n : ℕ) (h : n + 1 < l.length), R l[n] l[n + 1] := by
-  refine ⟨chain'_getElem, fun h ↦ ?_⟩
+  refine ⟨Chain'.getElem, fun h ↦ ?_⟩
   contrapose! h
   exact chain'_of_not h
 

--- a/Mathlib/Data/List/Chain.lean
+++ b/Mathlib/Data/List/Chain.lean
@@ -332,9 +332,9 @@ theorem chain'_of_not (h : ¬List.Chain' R l) :
         have := h (n + 1) (by rw [length_cons]; omega)
         simpa using this
 
-theorem chain'_iff_forall_getElem {R} {l : List α} :
+theorem chain'_iff_forall_getElem :
     Chain' R l ↔ ∀ (n : ℕ) (h : n + 1 < l.length), R l[n] l[n + 1] := by
-  refine ⟨chain'_getElem, fun h => ?_⟩
+  refine ⟨chain'_getElem, fun h ↦ ?_⟩
   contrapose! h
   exact chain'_of_not h
 

--- a/Mathlib/Data/List/Chain.lean
+++ b/Mathlib/Data/List/Chain.lean
@@ -309,6 +309,28 @@ theorem Chain'.imp_head {x y} (h : ∀ {z}, R x z → R y z) {l} (hl : Chain' R 
     Chain' R (y :: l) :=
   hl.tail.cons' fun _ hz => h <| hl.rel_head? hz
 
+theorem chain'_getElem (h : List.Chain' R l) (n : ℕ) (h' : n + 1 < l.length) :
+    R l[n] l[n+1] :=
+  chain'_pair.mp <| Chain'.infix h ⟨l.take n, l.drop (n + 2), by simp⟩
+
+theorem chain'_of_not (h : ¬List.Chain' R l) : ∃ n : ℕ, ∃ h : n + 1 < l.length, ¬R l[n] l[n+1] := by
+  contrapose! h
+  induction l with
+  | nil => simp
+  | cons head tail ih =>
+      rw [chain'_cons']
+      constructor
+      · by_cases h' : tail.length = 0
+        · simp [eq_nil_iff_length_eq_zero.mpr h']
+        · intro y yh
+          simp only [head?_eq_getElem?, Option.mem_def] at yh
+          obtain ⟨_, rfl⟩ := getElem?_eq_some_iff.mp yh
+          have := h 0 (by rw [length_cons]; omega)
+          rwa [getElem_cons_zero] at this
+      · refine ih (fun n h' => ?_)
+        have := h (n + 1) (by rw [length_cons]; omega)
+        simpa using this
+
 theorem chain'_reverse : ∀ {l}, Chain' R (reverse l) ↔ Chain' (flip R) l
   | [] => Iff.rfl
   | [a] => by simp only [chain'_singleton, reverse_singleton]

--- a/Mathlib/Data/List/Chain.lean
+++ b/Mathlib/Data/List/Chain.lean
@@ -332,6 +332,12 @@ theorem chain'_of_not (h : ¬List.Chain' R l) :
         have := h (n + 1) (by rw [length_cons]; omega)
         simpa using this
 
+theorem chain'_iff_forall_getElem {R} {l : List α} :
+    Chain' R l ↔ ∀ (n : ℕ) (h : n + 1 < l.length), R l[n] l[n + 1] := by
+  refine ⟨chain'_getElem, fun h => ?_⟩
+  contrapose! h
+  exact chain'_of_not h
+
 theorem chain'_reverse : ∀ {l}, Chain' R (reverse l) ↔ Chain' (flip R) l
   | [] => Iff.rfl
   | [a] => by simp only [chain'_singleton, reverse_singleton]

--- a/Mathlib/Data/List/Chain.lean
+++ b/Mathlib/Data/List/Chain.lean
@@ -319,12 +319,10 @@ theorem chain'_of_not (h : ¬List.Chain' R l) :
   induction l with
   | nil => simp
   | cons head tail ih =>
-      rw [chain'_cons']
-      constructor
+      refine List.chain'_cons'.mpr ⟨fun y yh ↦ ?_, ?_⟩
       · by_cases h' : tail.length = 0
-        · simp [eq_nil_iff_length_eq_zero.mpr h']
-        · intro y yh
-          simp only [head?_eq_getElem?, Option.mem_def] at yh
+        · simp [List.eq_nil_iff_length_eq_zero.mpr h'] at yh
+        · simp only [head?_eq_getElem?, Option.mem_def] at yh
           obtain ⟨_, rfl⟩ := getElem?_eq_some_iff.mp yh
           have := h 0 (by rw [length_cons]; omega)
           rwa [getElem_cons_zero] at this


### PR DESCRIPTION
Add two helpers lemmas to go from a List.Chain' hypothesis to a concrete
predicate about two consecutive elements, one in the positive and one in
the negative.