### PR TITLE
[Merged by Bors] - feat(SimpleGraph): weaker condition for paths in acyclic graphs

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
@@ -190,34 +190,34 @@ theorem isTree_iff_existsUnique_path :
 lemma IsTree.existsUnique_path (hG : G.IsTree) : ∀ v w, ∃! p : G.Walk v w, p.IsPath :=
   (isTree_iff_existsUnique_path.1 hG).2
 
-theorem IsAcyclic.isPath_iff_chain' [DecidableEq V] (hG : G.IsAcyclic) {v w : V}
-    (p : G.Walk v w) : p.IsPath ↔ List.Chain' (fun x y ↦ x ≠ y) p.edges := by
-  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
-  · exact List.Pairwise.chain' <| edges_nodup_of_support_nodup <| p.isPath_def |>.mp h
-  · induction p with
-    | nil => simp
-    | @cons u' v' w' head tail ih =>
-      rw [edges_cons] at h
-      have hcc := List.chain'_cons'.mp h
-      refine cons_isPath_iff head tail |>.mpr ⟨ih hcc.2, ?_⟩
-      rcases tail.length.eq_zero_or_pos with h' | h'
-      · simp [nil_iff_support_eq.mp (nil_iff_length_eq.mpr h'), head.ne]
-      · by_contra hh
-        apply hG <| cons head (tail.takeUntil u' hh)
-        simp only [isCycle_def, isTrail_def, edges_cons, List.nodup_cons]
-        have : cons head (tail.takeUntil u' hh) |>.support.tail.Nodup := by
-          refine tail.isPath_def.mp (ih hcc.2) |>.sublist <| List.IsInfix.sublist ?_
-          exact ⟨[], (tail.dropUntil u' hh).support.tail, by simp [← support_append]⟩
-        refine ⟨⟨?_, edges_nodup_of_support_nodup this⟩, ⟨by simp, this⟩⟩
-        by_contra hhh
-        refine hcc.1 s(u', v') ?_ rfl
-        rw [← tail.cons_tail_eq (by simp [not_nil_iff_lt_length, h'])]
-        have := IsPath.mk' this |>.eq_snd_of_mem_edges (by simp [head.ne.symm]) (Sym2.eq_swap ▸ hhh)
-        simp [this, snd_takeUntil head.ne]
+theorem IsAcyclic.isPath_iff_chain' [DecidableEq V] (hG : G.IsAcyclic) {v w : V} (p : G.Walk v w) :
+     p.IsPath ↔ List.Chain' (fun x y ↦ x ≠ y) p.edges := by
+  refine ⟨fun h ↦ List.Pairwise.chain' <| edges_nodup_of_support_nodup <| p.isPath_def.mp h,
+          fun h ↦ ?_⟩
+  induction p with
+  | nil => simp
+  | @cons u' v' _ head tail ih =>
+    have hcc := List.chain'_cons'.mp (edges_cons _ _ ▸ h)
+    refine cons_isPath_iff head tail |>.mpr ⟨ih hcc.2, ?_⟩
+    rcases tail.length.eq_zero_or_pos with h' | h'
+    · simp [nil_iff_support_eq.mp (nil_iff_length_eq.mpr h'), head.ne]
+    · by_contra hh
+      apply hG <| cons head (tail.takeUntil u' hh)
+      simp only [isCycle_def, isTrail_def, edges_cons, List.nodup_cons]
+      have : cons head (tail.takeUntil u' hh) |>.support.tail.Nodup :=
+        tail.isPath_def.mp (ih hcc.2) |>.sublist <| List.IsInfix.sublist
+          ⟨[], (tail.dropUntil u' hh).support.tail, by simp [← support_append]⟩
+      refine ⟨⟨?_, edges_nodup_of_support_nodup this⟩, ⟨by simp, this⟩⟩
+      by_contra hhh
+      refine hcc.1 s(u', v') ?_ rfl
+      rw [← tail.cons_tail_eq (by simp [not_nil_iff_lt_length, h'])]
+      have := IsPath.mk' this |>.eq_snd_of_mem_edges (by simp [head.ne.symm]) (Sym2.eq_swap ▸ hhh)
+      simp [this, snd_takeUntil head.ne]
 
-theorem IsAcyclic.isPath_of_isTrail [DecidableEq V] (hG : G.IsAcyclic) {v w : V} {p : G.Walk v w}
-    (h : p.IsTrail) : p.IsPath :=
-  hG.isPath_iff_chain' p |>.mpr <| List.Pairwise.chain' <| p.isTrail_def |>.mp h
+theorem IsAcyclic.isPath_iff_isTrail [DecidableEq V] (hG : G.IsAcyclic) {v w : V} {p : G.Walk v w} :
+    p.IsTrail ↔ p.IsPath :=
+  ⟨fun h ↦ hG.isPath_iff_chain' p |>.mpr <| List.Pairwise.chain' <| p.isTrail_def.mp h,
+   IsPath.toIsTrail⟩
 
 lemma IsTree.card_edgeFinset [Fintype V] [Fintype G.edgeSet] (hG : G.IsTree) :
     Finset.card G.edgeFinset + 1 = Fintype.card V := by

--- a/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
@@ -191,7 +191,7 @@ lemma IsTree.existsUnique_path (hG : G.IsTree) : ∀ v w, ∃! p : G.Walk v w, p
   (isTree_iff_existsUnique_path.1 hG).2
 
 theorem IsAcyclic.isPath_iff_chain' [DecidableEq V] (hG : G.IsAcyclic) {v w : V}
-    (p : G.Walk v w) : p.IsPath ↔ List.Chain' (fun x y => x ≠ y) p.edges := by
+    (p : G.Walk v w) : p.IsPath ↔ List.Chain' (fun x y ↦ x ≠ y) p.edges := by
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
   · exact List.Pairwise.chain' <| edges_nodup_of_support_nodup <| p.isPath_def |>.mp h
   · induction p with

--- a/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
@@ -190,6 +190,36 @@ theorem isTree_iff_existsUnique_path :
 lemma IsTree.existsUnique_path (hG : G.IsTree) : ∀ v w, ∃! p : G.Walk v w, p.IsPath :=
   (isTree_iff_existsUnique_path.1 hG).2
 
+theorem IsAcyclic.isPath_iff_chain' [DecidableEq V] (hG : G.IsAcyclic) {v w : V}
+    (p : G.Walk v w) : p.IsPath ↔ List.Chain' (fun x y => x ≠ y) p.edges := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  · exact List.Pairwise.chain' <| edges_nodup_of_support_nodup <| p.isPath_def |>.mp h
+  · induction p with
+    | nil => simp
+    | @cons u' v' w' head tail ih =>
+      rw [edges_cons] at h
+      have hcc := List.chain'_cons'.mp h
+      refine cons_isPath_iff head tail |>.mpr ⟨ih hcc.2, ?_⟩
+      rcases show tail.length = 0 ∨ 0 < tail.length by omega with h' | h'
+      · simp [nil_iff_support_eq.mp (nil_iff_length_eq.mpr h'), head.ne]
+      · by_contra hh
+        apply hG <| cons head <| tail.takeUntil u' hh
+        simp only [isCycle_def, isTrail_def, edges_cons, List.nodup_cons]
+        have : cons head (tail.takeUntil u' hh) |>.support.tail.Nodup := by
+          refine tail.isPath_def.mp (ih hcc.2) |>.sublist <| List.IsInfix.sublist ?_
+          exact ⟨[], (tail.dropUntil u' hh).support.tail, by simp [← support_append]⟩
+        refine ⟨⟨?_, edges_nodup_of_support_nodup this⟩, ⟨by simp, this⟩⟩
+        by_contra hhh
+        refine hcc.1 s(u', v') ?_ rfl
+        rw [← tail.cons_tail_eq (by simp [not_nil_iff_lt_length, h'])]
+        have := IsPath.mk' this |>.eq_snd_of_mem_edges (by simp [head.ne.symm]) (Sym2.eq_swap ▸ hhh)
+        rw [snd_takeUntil head.ne] at this
+        simp [this]
+
+theorem IsAcyclic.isPath_of_isTrail [DecidableEq V] (hG : G.IsAcyclic) {v w : V} {p : G.Walk v w}
+    (h : p.IsTrail) : p.IsPath :=
+  hG.isPath_iff_chain' p |>.mpr <| List.Pairwise.chain' <| p.isTrail_def |>.mp h
+
 lemma IsTree.card_edgeFinset [Fintype V] [Fintype G.edgeSet] (hG : G.IsTree) :
     Finset.card G.edgeFinset + 1 = Fintype.card V := by
   have := hG.isConnected.nonempty

--- a/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
@@ -196,7 +196,7 @@ theorem IsAcyclic.isPath_iff_isChain [DecidableEq V] (hG : G.IsAcyclic) {v w : V
   induction p with
   | nil => simp
   | @cons u' v' _ head tail ih =>
-    have hcc := List.isChain_cons'.mp (edges_cons _ _ ▸ h)
+    have hcc := List.isChain_cons.mp (edges_cons _ _ ▸ h)
     refine cons_isPath_iff head tail |>.mpr ⟨ih hcc.2, ?_⟩
     rcases tail.length.eq_zero_or_pos with h' | h'
     · simp [nil_iff_support_eq.mp (nil_iff_length_eq.mpr h'), head.ne]
@@ -214,9 +214,9 @@ theorem IsAcyclic.isPath_iff_isChain [DecidableEq V] (hG : G.IsAcyclic) {v w : V
       have := IsPath.mk' this |>.eq_snd_of_mem_edges (by simp [head.ne.symm]) (Sym2.eq_swap ▸ hhh)
       simp [this, snd_takeUntil head.ne]
 
-theorem IsAcyclic.isTrail_iff_isPath [DecidableEq V] (hG : G.IsAcyclic) {v w : V} (p : G.Walk v w) :
-    p.IsTrail ↔ p.IsPath :=
-  ⟨fun h ↦ hG.isPath_iff_isChain p |>.mpr <| p.isTrail_def.mp h |>.isChain, IsPath.isTrail⟩
+theorem IsAcyclic.isPath_iff_isTrail [DecidableEq V] (hG : G.IsAcyclic) {v w : V} (p : G.Walk v w) :
+    p.IsPath ↔ p.IsTrail :=
+  ⟨IsPath.isTrail, fun h ↦ hG.isPath_iff_isChain p |>.mpr <| p.isTrail_def.mp h |>.isChain⟩
 
 lemma IsTree.card_edgeFinset [Fintype V] [Fintype G.edgeSet] (hG : G.IsTree) :
     Finset.card G.edgeFinset + 1 = Fintype.card V := by

--- a/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
@@ -214,7 +214,7 @@ theorem IsAcyclic.isPath_iff_chain' [DecidableEq V] (hG : G.IsAcyclic) {v w : V}
       have := IsPath.mk' this |>.eq_snd_of_mem_edges (by simp [head.ne.symm]) (Sym2.eq_swap ▸ hhh)
       simp [this, snd_takeUntil head.ne]
 
-theorem IsAcyclic.isPath_iff_isTrail [DecidableEq V] (hG : G.IsAcyclic) {v w : V} {p : G.Walk v w} :
+theorem IsAcyclic.isTrail_iff_isPath [DecidableEq V] (hG : G.IsAcyclic) {v w : V} (p : G.Walk v w) :
     p.IsTrail ↔ p.IsPath :=
   ⟨fun h ↦ hG.isPath_iff_chain' p |>.mpr <| List.Pairwise.chain' <| p.isTrail_def.mp h,
    IsPath.toIsTrail⟩

--- a/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Acyclic.lean
@@ -200,10 +200,10 @@ theorem IsAcyclic.isPath_iff_chain' [DecidableEq V] (hG : G.IsAcyclic) {v w : V}
       rw [edges_cons] at h
       have hcc := List.chain'_cons'.mp h
       refine cons_isPath_iff head tail |>.mpr ⟨ih hcc.2, ?_⟩
-      rcases show tail.length = 0 ∨ 0 < tail.length by omega with h' | h'
+      rcases tail.length.eq_zero_or_pos with h' | h'
       · simp [nil_iff_support_eq.mp (nil_iff_length_eq.mpr h'), head.ne]
       · by_contra hh
-        apply hG <| cons head <| tail.takeUntil u' hh
+        apply hG <| cons head (tail.takeUntil u' hh)
         simp only [isCycle_def, isTrail_def, edges_cons, List.nodup_cons]
         have : cons head (tail.takeUntil u' hh) |>.support.tail.Nodup := by
           refine tail.isPath_def.mp (ih hcc.2) |>.sublist <| List.IsInfix.sublist ?_
@@ -213,8 +213,7 @@ theorem IsAcyclic.isPath_iff_chain' [DecidableEq V] (hG : G.IsAcyclic) {v w : V}
         refine hcc.1 s(u', v') ?_ rfl
         rw [← tail.cons_tail_eq (by simp [not_nil_iff_lt_length, h'])]
         have := IsPath.mk' this |>.eq_snd_of_mem_edges (by simp [head.ne.symm]) (Sym2.eq_swap ▸ hhh)
-        rw [snd_takeUntil head.ne] at this
-        simp [this]
+        simp [this, snd_takeUntil head.ne]
 
 theorem IsAcyclic.isPath_of_isTrail [DecidableEq V] (hG : G.IsAcyclic) {v w : V} {p : G.Walk v w}
     (h : p.IsTrail) : p.IsPath :=

--- a/Mathlib/Combinatorics/SimpleGraph/Paths.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Paths.lean
@@ -397,6 +397,19 @@ lemma IsPath.getVert_injOn_iff (p : G.Walk u v) : Set.InjOn p.getVert {i | i ≤
       (by rwa [getVert_cons _ _ n.add_one_ne_zero, getVert_zero])
     omega
 
+theorem IsPath.eq_snd_of_mem_edges {p : G.Walk u v} (hp : p.IsPath) (hnil : ¬p.Nil)
+    (hmem : s(u, w) ∈ p.edges) : w = p.snd := by
+  rw [← cons_tail_eq _ hnil, edges_cons, List.mem_cons, Sym2.eq, Sym2.rel_iff'] at hmem
+  rcases hmem with h | h
+  · rcases h <;> simp_all
+  · have : u ∉ p.tail.support := by induction p <;> simp_all
+    simp [fst_mem_support_of_mem_edges _ h] at this
+
+theorem IsPath.eq_penultimate_of_mem_edges {p : G.Walk u v} (hp : p.IsPath) (hnil : ¬p.Nil)
+    (hmem : s(v, w) ∈ p.edges) : w = p.penultimate := by
+  have := (isPath_reverse_iff p).mpr hp |>.eq_snd_of_mem_edges (w := w)
+  simp_all
+
 /-! ### About cycles -/
 
 -- TODO: These results could possibly be less laborious with a periodic function getCycleVert

--- a/Mathlib/Combinatorics/SimpleGraph/Paths.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Paths.lean
@@ -400,15 +400,12 @@ lemma IsPath.getVert_injOn_iff (p : G.Walk u v) : Set.InjOn p.getVert {i | i ≤
 theorem IsPath.eq_snd_of_mem_edges {p : G.Walk u v} (hp : p.IsPath) (hnil : ¬p.Nil)
     (hmem : s(u, w) ∈ p.edges) : w = p.snd := by
   rw [← cons_tail_eq _ hnil, edges_cons, List.mem_cons, Sym2.eq, Sym2.rel_iff'] at hmem
-  rcases hmem with h | h
-  · rcases h <;> simp_all
-  · have : u ∉ p.tail.support := by induction p <;> simp_all
-    simp [fst_mem_support_of_mem_edges _ h] at this
+  have : u ∉ p.tail.support := by induction p <;> simp_all
+  grind [fst_mem_support_of_mem_edges]
 
 theorem IsPath.eq_penultimate_of_mem_edges {p : G.Walk u v} (hp : p.IsPath) (hnil : ¬p.Nil)
     (hmem : s(v, w) ∈ p.edges) : w = p.penultimate := by
-  have := (isPath_reverse_iff p).mpr hp |>.eq_snd_of_mem_edges (w := w)
-  simp_all
+  simpa [hnil, hmem] using isPath_reverse_iff p |>.mpr hp |>.eq_snd_of_mem_edges (w := w)
 
 /-! ### About cycles -/
 


### PR DESCRIPTION
`IsAcyclic.isPath_iff_chain'` defines a weaker condition for proving that a walk is a path, in particular it shows that rather than proving that all vertices in the support of a walk are distinct, one must only show that consecutive edges are distinct (e.g. every other vertex must be distinct.) This leads to a simple corollary that trails are also paths in acyclic graphs.

I had a need for this when formalizing Cayley graphs, since this condition maps cleanly onto words in free groups being reduced.

---

*This PR continues the work from #25630.*

*Original PR: https://github.com/leanprover-community/mathlib4/pull/25630*