### PR TITLE
[Merged by Bors] - feat: register more tactics for `hint`

### DIFF
--- a/Mathlib/Tactic/ComputeDegree.lean
+++ b/Mathlib/Tactic/ComputeDegree.lean
@@ -504,3 +504,8 @@ macro "monicity!" : tactic =>
 end Tactic
 
 end Mathlib.Tactic.ComputeDegree
+
+/-!
+ We register `compute_degree` with the `hint` tactic.
+ -/
+register_hint compute_degree

--- a/Mathlib/Tactic/FieldSimp.lean
+++ b/Mathlib/Tactic/FieldSimp.lean
@@ -213,3 +213,8 @@ elab_rules : tactic
   _ ← simpLocation r.ctx {} dis loc
 
 end Mathlib.Tactic.FieldSimp
+
+/-!
+ We register `field_simp` with the `hint` tactic.
+ -/
+register_hint field_simp

--- a/Mathlib/Tactic/Finiteness.lean
+++ b/Mathlib/Tactic/Finiteness.lean
@@ -67,3 +67,8 @@ macro (name := finiteness_nonterminal) "finiteness_nonterminal" c:Aesop.tactic_c
     (config := { introsTransparency? := some .reducible, terminal := false, enableSimp := false,
                  warnOnNonterminal := false  })
     (rule_sets := [$(Lean.mkIdent `finiteness):ident, -default, -builtin]))
+
+/-!
+ We register `finiteness` with the `hint` tactic.
+ -/
+register_hint finiteness

--- a/MathlibTest/hint.lean
+++ b/MathlibTest/hint.lean
@@ -1,6 +1,10 @@
-import Mathlib.Tactic.Common
-import Mathlib.Tactic.Linarith
+import Mathlib.Data.ENNReal.Basic
 import Mathlib.Data.Nat.Prime.Defs
+import Mathlib.Tactic.Common
+import Mathlib.Tactic.ComputeDegree
+import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.Finiteness
+import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.TautoSet
 
 /--
@@ -29,13 +33,14 @@ example {P Q R : Prop} (x : P ∧ Q ∧ R ∧ R) : Q ∧ P ∧ R := by hint
 /--
 info: Try these:
 • linarith
+• field_simp
 -/
 #guard_msgs in
 example {a b : ℚ} (h : a < b) : ¬ b < a := by hint
 
 /--
 info: Try these:
-• norm_num
+• ring
 -/
 #guard_msgs in
 example : 37^2 - 35^2 = 72 * 2 := by hint
@@ -43,6 +48,7 @@ example : 37^2 - 35^2 = 72 * 2 := by hint
 /--
 info: Try these:
 • decide
+• ring_nf
 • norm_num
 -/
 #guard_msgs in
@@ -51,6 +57,8 @@ example : Nat.Prime 37 := by hint
 /--
 info: Try these:
 • aesop
+• ring_nf
+• field_simp
 • norm_num
 • simp_all only [zero_le, and_true]
 -/
@@ -94,6 +102,8 @@ example {α} (A B C : Set α) (h1 : A ⊆ B ∪ C) : (A ∩ B) ∪ (A ∩ C) = A
 /--
 info: Try these:
 • aesop
+• ring_nf
+• field_simp
 • norm_num
 • simp_all only [Nat.not_ofNat_le_one]
 ---
@@ -103,3 +113,33 @@ warning: declaration uses 'sorry'
 example : 2 ≤ 1 := by hint
 
 end tauto_set
+
+section compute_degree
+/--
+info: Try these:
+• compute_degree
+-/
+#guard_msgs in
+open Polynomial in
+example : natDegree ((X + 1) : Nat[X]) ≤ 1 := by hint
+end compute_degree
+
+section field_simp
+/--
+info: Try these:
+• field_simp
+• ring_nf
+-/
+#guard_msgs in
+example (R : Type) (a b : R) [CommRing R] (u₁ : Rˣ) : a /ₚ u₁ + b /ₚ u₁ = (a + b) /ₚ u₁ := by hint
+end field_simp
+
+section finiteness
+/--
+info: Try these:
+• finiteness
+-/
+#guard_msgs in
+open ENNReal in
+example : (1 : ℝ≥0∞) < ∞ := by hint
+end finiteness


### PR DESCRIPTION
The following example shows test cases that `hint` now supports, which were unsupported prior to this PR:

```
import Mathlib

-- The tactics registered in this PR
register_hint compute_degree
register_hint field_simp
register_hint finiteness

-- "hint" now correctly suggests "compute_degree" which closes the goal (no closing tactic suggested prior to this PR)
open Polynomial in
example : natDegree ((X + 1) : Nat[X]) ≤ 1 := by hint

-- "hint" now correctly suggests "field_simp" which closes the goal (no closing tactic suggested prior to this PR)
example (R : Type) (a b : R) [CommRing R] (u₁ : Rˣ) : a /ₚ u₁ + b /ₚ u₁ = (a + b) /ₚ u₁ := by hint

-- "hint" now correctly suggests "finiteness" which closes the goal (no closing tactic suggested prior to this PR)
example (a : ℝ) : (ENNReal.ofReal (1 + a ^ 2))⁻¹ < ⊤ := by hint
```