### PR TITLE
[Merged by Bors] - feat: add mulEquivHaarChar

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4380,6 +4380,7 @@ import Mathlib.MeasureTheory.Measure.Haar.Basic
 import Mathlib.MeasureTheory.Measure.Haar.Disintegration
 import Mathlib.MeasureTheory.Measure.Haar.DistribChar
 import Mathlib.MeasureTheory.Measure.Haar.InnerProductSpace
+import Mathlib.MeasureTheory.Measure.Haar.MulEquivHaarChar
 import Mathlib.MeasureTheory.Measure.Haar.NormedSpace
 import Mathlib.MeasureTheory.Measure.Haar.OfBasis
 import Mathlib.MeasureTheory.Measure.Haar.Quotient

--- a/Mathlib/MeasureTheory/Group/Measure.lean
+++ b/Mathlib/MeasureTheory/Group/Measure.lean
@@ -742,8 +742,8 @@ theorem IsHaarMeasure.smul {c : ℝ≥0∞} (cpos : c ≠ 0) (ctop : c ≠ ∞) 
     toIsOpenPosMeasure := isOpenPosMeasure_smul μ cpos }
 
 @[to_additive IsAddHaarMeasure.nnreal_smul]
-lemma IsHaarMeasure.nnreal_smul {c : ℝ≥0} (hc : 0 < c) : IsHaarMeasure (c • μ) :=
-  .smul _ (by simp [hc.ne']) (Option.some_ne_none _)
+lemma IsHaarMeasure.nnreal_smul {c : ℝ≥0} (hc : c ≠ 0) : IsHaarMeasure (c • μ) :=
+  .smul _ (by simp [hc]) (Option.some_ne_none _)
 
 /-- If a left-invariant measure gives positive mass to some compact set with nonempty interior, then
 it is a Haar measure. -/

--- a/Mathlib/MeasureTheory/Group/Measure.lean
+++ b/Mathlib/MeasureTheory/Group/Measure.lean
@@ -741,6 +741,10 @@ theorem IsHaarMeasure.smul {c : ℝ≥0∞} (cpos : c ≠ 0) (ctop : c ≠ ∞) 
   { lt_top_of_isCompact := fun _K hK => ENNReal.mul_lt_top ctop.lt_top hK.measure_lt_top
     toIsOpenPosMeasure := isOpenPosMeasure_smul μ cpos }
 
+@[to_additive IsAddHaarMeasure.nnreal_smul]
+lemma IsHaarMeasure.nnreal_smul {c : ℝ≥0} (hc : 0 < c) : IsHaarMeasure (c • μ) :=
+  .smul _ (by simp [hc.ne']) (Option.some_ne_none _)
+
 /-- If a left-invariant measure gives positive mass to some compact set with nonempty interior, then
 it is a Haar measure. -/
 @[to_additive

--- a/Mathlib/MeasureTheory/Measure/Haar/MulEquivHaarChar.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/MulEquivHaarChar.lean
@@ -9,7 +9,7 @@ import Mathlib.MeasureTheory.Measure.Haar.Unique
 # Scaling Haar measure by a continuous isomorphism
 
 If `G` is a locally compact topological group and `μ` is a regular Haar measure
-on `G`, then an isomorphism `φ : G ≃ₜ* G` scales this factor by some positive
+on `G`, then an isomorphism `φ : G ≃ₜ* G` scales this measure by some positive
 real constant which we call `mulEquivHaarChar φ`.
 
 ## Main definitions
@@ -30,9 +30,9 @@ variable {G : Type*} [Group G] [TopologicalSpace G] [MeasurableSpace G]
     [BorelSpace G] [IsTopologicalGroup G] [LocallyCompactSpace G]
 
 /-- If `φ : G ≃ₜ* G` then `mulEquivHaarChar φ` is the positive real factor by which
-`φ` scales Haar measure on `G`. -/
+`φ` scales Haar measures on `G`. -/
 @[to_additive "If `φ : A ≃ₜ+ A` then `addEquivAddHaarChar φ` is the positive
-real factor by which `φ` scales Haar measure on `A`."]
+real factor by which `φ` scales Haar measures on `A`."]
 noncomputable def mulEquivHaarChar (φ : G ≃ₜ* G) : ℝ≥0 :=
   haarScalarFactor haar (haar.map φ)
 
@@ -55,22 +55,22 @@ lemma mulEquivHaarChar_eq (μ : Measure G) [IsHaarMeasure μ]
   simp_rw [MeasureTheory.Measure.map_smul]
   exact haarScalarFactor_smul_smul _ _ (haarScalarFactor_pos_of_isHaarMeasure haar μ).ne'
 
-@[to_additive]
-lemma mulEquivHaarChar_map (μ : Measure G)
+@[to_additive addEquivAddHaarChar_smul_map]
+lemma mulEquivHaarChar_smul_map (μ : Measure G)
     [IsHaarMeasure μ] [Regular μ] (φ : G ≃ₜ* G) :
     mulEquivHaarChar φ • μ.map φ = μ := by
   rw [mulEquivHaarChar_eq μ φ]
-  have : Regular (map φ μ) := (Regular.map_iff φ.toHomeomorph).mpr inferInstance
+  have : Regular (map φ μ) := Regular.map φ.toHomeomorph
   exact (isMulLeftInvariant_eq_smul_of_regular μ (map φ μ)).symm
 
-@[to_additive]
+@[to_additive addEquivAddHaarChar_smul_eq_comap]
 lemma mulEquivHaarChar_smul_eq_comap (μ : Measure G)
     [IsHaarMeasure μ] [Regular μ] (φ : G ≃ₜ* G) :
     (mulEquivHaarChar φ) • μ = μ.comap φ := by
   let e := φ.toHomeomorph.toMeasurableEquiv
   rw [show ⇑φ = ⇑e from rfl, ← e.map_symm, show ⇑e.symm = ⇑φ.symm from rfl]
-  have : (map (φ.symm) μ).Regular := (Regular.map_iff φ.symm.toHomeomorph).mpr inferInstance
-  rw [← mulEquivHaarChar_map (map φ.symm μ) φ, map_map]
+  have : (map (φ.symm) μ).Regular := Regular.map φ.symm.toHomeomorph
+  rw [← mulEquivHaarChar_smul_map (map φ.symm μ) φ, map_map]
   · simp
   · fun_prop
   · fun_prop
@@ -79,17 +79,17 @@ lemma mulEquivHaarChar_smul_eq_comap (μ : Measure G)
 lemma mulEquivHaarChar_smul_integral_map (μ : Measure G)
     [IsHaarMeasure μ] [Regular μ] {f : G → ℝ} (φ : G ≃ₜ* G) :
     mulEquivHaarChar φ • ∫ a, f a ∂(μ.map φ) = ∫ a, f a ∂μ := by
-  nth_rw 2 [← mulEquivHaarChar_map μ φ]
+  nth_rw 2 [← mulEquivHaarChar_smul_map μ φ]
   simp
 
-@[to_additive addEquivAddHaarChar_smul_integral_comap]
+@[to_additive integral_comap_eq_addEquivAddHaarChar_smul]
 lemma integral_comap_eq_mulEquivHaarChar_smul (μ : Measure G)
     [IsHaarMeasure μ] [Regular μ] {f : G → ℝ} (φ : G ≃ₜ* G) :
     ∫ a, f a ∂(μ.comap φ) = mulEquivHaarChar φ • ∫ a, f a ∂μ := by
   let e := φ.toHomeomorph.toMeasurableEquiv
   change ∫ a, f a ∂(comap e μ) = mulEquivHaarChar φ • ∫ a, f a ∂μ
   have : (map (e.symm) μ).IsHaarMeasure := φ.symm.isHaarMeasure_map μ
-  have : (map (e.symm) μ).Regular := (Regular.map_iff φ.symm.toHomeomorph).2 inferInstance
+  have : (map (e.symm) μ).Regular := Regular.map φ.symm.toHomeomorph
   rw [← e.map_symm, ← mulEquivHaarChar_smul_integral_map (map e.symm μ) φ,
     map_map (by exact φ.toHomeomorph.toMeasurableEquiv.measurable) e.symm.measurable]
   -- congr -- breaks to_additive
@@ -100,7 +100,7 @@ lemma integral_comap_eq_mulEquivHaarChar_smul (μ : Measure G)
 lemma mulEquivHaarChar_smul_preimage
     (μ : Measure G) [IsHaarMeasure μ] [Regular μ] {X : Set G} (φ : G ≃ₜ* G) :
     mulEquivHaarChar φ • μ (φ ⁻¹' X) = μ X := by
-  nth_rw 2 [← mulEquivHaarChar_map μ φ]
+  nth_rw 2 [← mulEquivHaarChar_smul_map μ φ]
   simp only [smul_apply, nnreal_smul_coe_apply]
   exact congr_arg _ <| (MeasurableEquiv.map_apply φ.toMeasurableEquiv X).symm
 
@@ -113,8 +113,8 @@ lemma mulEquivHaarChar_refl :
 lemma mulEquivHaarChar_trans {φ ψ : G ≃ₜ* G} :
     mulEquivHaarChar (ψ.trans φ) = mulEquivHaarChar ψ * mulEquivHaarChar φ := by
   rw [mulEquivHaarChar_eq haar ψ, mulEquivHaarChar_eq haar (ψ.trans φ)]
-  have hφ : Measurable φ := φ.toHomeomorph.measurable
-  have hψ : Measurable ψ := ψ.toHomeomorph.measurable
+  have hφ : Measurable φ := by fun_prop
+  have hψ : Measurable ψ := by fun_prop
   simp_rw [ContinuousMulEquiv.coe_trans, ← map_map hφ hψ]
   have h_reg : (haar.map ψ).Regular := Regular.map ψ.toHomeomorph
   rw [MeasureTheory.Measure.haarScalarFactor_eq_mul haar (haar.map ψ),

--- a/Mathlib/MeasureTheory/Measure/Haar/MulEquivHaarChar.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/MulEquivHaarChar.lean
@@ -34,7 +34,7 @@ variable {G : Type*} [Group G] [TopologicalSpace G] [MeasurableSpace G]
 @[to_additive "If `φ : A ≃ₜ+ A` then `addEquivAddHaarChar φ` is the positive
 real factor by which `φ` scales Haar measure on `A`."]
 noncomputable def mulEquivHaarChar (φ : G ≃ₜ* G) : ℝ≥0 :=
-  haarScalarFactor haar (map φ haar)
+  haarScalarFactor haar (haar.map φ)
 
 @[to_additive]
 lemma mulEquivHaarChar_pos (φ : G ≃ₜ* G) : 0 < mulEquivHaarChar φ :=
@@ -43,7 +43,7 @@ lemma mulEquivHaarChar_pos (φ : G ≃ₜ* G) : 0 < mulEquivHaarChar φ :=
 @[to_additive]
 lemma mulEquivHaarChar_eq (μ : Measure G) [IsHaarMeasure μ]
     [Regular μ] (φ : G ≃ₜ* G) :
-    mulEquivHaarChar φ = haarScalarFactor μ (map φ μ) := by
+    mulEquivHaarChar φ = haarScalarFactor μ (μ.map φ) := by
   have smul := isMulLeftInvariant_eq_smul_of_regular haar μ
   unfold mulEquivHaarChar
   conv =>
@@ -53,44 +53,44 @@ lemma mulEquivHaarChar_eq (μ : Measure G) [IsHaarMeasure μ]
     enter [1, 2, 2]
     rw [smul]
   simp_rw [MeasureTheory.Measure.map_smul]
-  exact haarScalarFactor_smul_smul _ _ (haarScalarFactor_pos_of_isHaarMeasure haar μ)
+  exact haarScalarFactor_smul_smul _ _ (haarScalarFactor_pos_of_isHaarMeasure haar μ).ne'
 
 @[to_additive]
 lemma mulEquivHaarChar_map (μ : Measure G)
     [IsHaarMeasure μ] [Regular μ] (φ : G ≃ₜ* G) :
-    (mulEquivHaarChar φ) • map φ μ = μ := by
+    mulEquivHaarChar φ • μ.map φ = μ := by
   rw [mulEquivHaarChar_eq μ φ]
-  haveI : Regular (map φ μ) := (Regular.map_iff φ.toHomeomorph).mpr inferInstance
+  have : Regular (map φ μ) := (Regular.map_iff φ.toHomeomorph).mpr inferInstance
   exact (isMulLeftInvariant_eq_smul_of_regular μ (map φ μ)).symm
 
 @[to_additive]
-lemma mulEquivHaarChar_comap (μ : Measure G)
+lemma mulEquivHaarChar_smul_eq_comap (μ : Measure G)
     [IsHaarMeasure μ] [Regular μ] (φ : G ≃ₜ* G) :
-    (mulEquivHaarChar φ) • μ = comap φ μ := by
+    (mulEquivHaarChar φ) • μ = μ.comap φ := by
   let e := φ.toHomeomorph.toMeasurableEquiv
   rw [show ⇑φ = ⇑e from rfl, ← e.map_symm, show ⇑e.symm = ⇑φ.symm from rfl]
-  haveI : (map (φ.symm) μ).Regular := (Regular.map_iff φ.symm.toHomeomorph).mpr inferInstance
+  have : (map (φ.symm) μ).Regular := (Regular.map_iff φ.symm.toHomeomorph).mpr inferInstance
   rw [← mulEquivHaarChar_map (map φ.symm μ) φ, map_map]
   · simp
-  · exact φ.toHomeomorph.toMeasurableEquiv.measurable
-  · exact e.symm.measurable
+  · fun_prop
+  · fun_prop
 
 @[to_additive addEquivAddHaarChar_smul_integral_map]
 lemma mulEquivHaarChar_smul_integral_map (μ : Measure G)
     [IsHaarMeasure μ] [Regular μ] {f : G → ℝ} (φ : G ≃ₜ* G) :
-    ∫ (a : G), f a ∂μ = (mulEquivHaarChar φ) • ∫ a, f a ∂(map φ μ) := by
-  nth_rw 1 [← mulEquivHaarChar_map μ φ]
+    mulEquivHaarChar φ • ∫ a, f a ∂(μ.map φ) = ∫ a, f a ∂μ := by
+  nth_rw 2 [← mulEquivHaarChar_map μ φ]
   simp
 
 @[to_additive addEquivAddHaarChar_smul_integral_comap]
-lemma mulEquivHaarChar_smul_integral_comap (μ : Measure G)
+lemma integral_comap_eq_mulEquivHaarChar_smul (μ : Measure G)
     [IsHaarMeasure μ] [Regular μ] {f : G → ℝ} (φ : G ≃ₜ* G) :
-    ∫ (a : G), f a ∂(comap φ μ) = (mulEquivHaarChar φ) • ∫ a, f a ∂μ := by
+    ∫ a, f a ∂(μ.comap φ) = mulEquivHaarChar φ • ∫ a, f a ∂μ := by
   let e := φ.toHomeomorph.toMeasurableEquiv
-  change ∫ (a : G), f a ∂(comap e μ) = (mulEquivHaarChar φ) • ∫ a, f a ∂μ
-  haveI : (map (e.symm) μ).IsHaarMeasure := φ.symm.isHaarMeasure_map μ
-  haveI : (map (e.symm) μ).Regular := (Regular.map_iff φ.symm.toHomeomorph).2 inferInstance
-  rw [← e.map_symm, mulEquivHaarChar_smul_integral_map (map e.symm μ) φ,
+  change ∫ a, f a ∂(comap e μ) = mulEquivHaarChar φ • ∫ a, f a ∂μ
+  have : (map (e.symm) μ).IsHaarMeasure := φ.symm.isHaarMeasure_map μ
+  have : (map (e.symm) μ).Regular := (Regular.map_iff φ.symm.toHomeomorph).2 inferInstance
+  rw [← e.map_symm, ← mulEquivHaarChar_smul_integral_map (map e.symm μ) φ,
     map_map (by exact φ.toHomeomorph.toMeasurableEquiv.measurable) e.symm.measurable]
   -- congr -- breaks to_additive
   rw [show ⇑φ ∘ ⇑e.symm = id by ext; simp [e]]
@@ -99,12 +99,12 @@ lemma mulEquivHaarChar_smul_integral_comap (μ : Measure G)
 @[to_additive addEquivAddHaarChar_smul_preimage]
 lemma mulEquivHaarChar_smul_preimage
     (μ : Measure G) [IsHaarMeasure μ] [Regular μ] {X : Set G} (φ : G ≃ₜ* G) :
-    μ X = (mulEquivHaarChar φ) • μ (φ ⁻¹' X) := by
-  nth_rw 1 [← mulEquivHaarChar_map μ φ]
+    mulEquivHaarChar φ • μ (φ ⁻¹' X) = μ X := by
+  nth_rw 2 [← mulEquivHaarChar_map μ φ]
   simp only [smul_apply, nnreal_smul_coe_apply]
-  exact congr_arg _ <| MeasurableEquiv.map_apply φ.toMeasurableEquiv X
+  exact congr_arg _ <| (MeasurableEquiv.map_apply φ.toMeasurableEquiv X).symm
 
-@[to_additive]
+@[to_additive (attr := simp)]
 lemma mulEquivHaarChar_refl :
     mulEquivHaarChar (ContinuousMulEquiv.refl G) = 1 := by
   simp [mulEquivHaarChar, Function.id_def]

--- a/Mathlib/MeasureTheory/Measure/Haar/MulEquivHaarChar.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/MulEquivHaarChar.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2025 Kevin Buzzard. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kevin Buzzard
+-/
+import Mathlib.MeasureTheory.Measure.Haar.Unique
+
+/-!
+# Scaling Haar measure by a continuous isomorphism
+
+If `G` is a locally compact topological group and `μ` is a regular Haar measure
+on `G`, then an isomorphism `φ : G ≃ₜ* G` scales this factor by some positive
+real constant which we call `mulEquivHaarChar φ`.
+
+## Main definitions
+
+* `mulEquivHaarChar φ`: the positive real such that `(mulEquivHaarChar φ) • map φ μ = μ`
+  for `μ` a regular Haar measure.
+* `addEquivAddHaarChar φ`: the additive version.
+
+-/
+
+open MeasureTheory.Measure
+
+open scoped NNReal Pointwise ENNReal
+
+namespace MeasureTheory
+
+variable {G : Type*} [Group G] [TopologicalSpace G] [MeasurableSpace G]
+    [BorelSpace G] [IsTopologicalGroup G] [LocallyCompactSpace G]
+
+/-- If `φ : G ≃ₜ* G` then `mulEquivHaarChar φ` is the positive real factor by which
+`φ` scales Haar measure on `G`. -/
+@[to_additive "If `φ : A ≃ₜ+ A` then `addEquivAddHaarChar φ` is the positive
+real factor by which `φ` scales Haar measure on `A`."]
+noncomputable def mulEquivHaarChar (φ : G ≃ₜ* G) : ℝ≥0 :=
+  haarScalarFactor haar (map φ haar)
+
+@[to_additive]
+lemma mulEquivHaarChar_pos (φ : G ≃ₜ* G) : 0 < mulEquivHaarChar φ :=
+  haarScalarFactor_pos_of_isHaarMeasure _ _
+
+@[to_additive]
+lemma mulEquivHaarChar_eq (μ : Measure G) [IsHaarMeasure μ]
+    [Regular μ] (φ : G ≃ₜ* G) :
+    mulEquivHaarChar φ = haarScalarFactor μ (map φ μ) := by
+  have smul := isMulLeftInvariant_eq_smul_of_regular haar μ
+  unfold mulEquivHaarChar
+  conv =>
+    enter [1, 1]
+    rw [smul]
+  conv =>
+    enter [1, 2, 2]
+    rw [smul]
+  simp_rw [MeasureTheory.Measure.map_smul]
+  exact haarScalarFactor_smul_smul _ _ (haarScalarFactor_pos_of_isHaarMeasure haar μ)
+
+@[to_additive]
+lemma mulEquivHaarChar_map (μ : Measure G)
+    [IsHaarMeasure μ] [Regular μ] (φ : G ≃ₜ* G) :
+    (mulEquivHaarChar φ) • map φ μ = μ := by
+  rw [mulEquivHaarChar_eq μ φ]
+  haveI : Regular (map φ μ) := (Regular.map_iff φ.toHomeomorph).mpr inferInstance
+  exact (isMulLeftInvariant_eq_smul_of_regular μ (map φ μ)).symm
+
+@[to_additive]
+lemma mulEquivHaarChar_comap (μ : Measure G)
+    [IsHaarMeasure μ] [Regular μ] (φ : G ≃ₜ* G) :
+    (mulEquivHaarChar φ) • μ = comap φ μ := by
+  let e := φ.toHomeomorph.toMeasurableEquiv
+  rw [show ⇑φ = ⇑e from rfl, ← e.map_symm, show ⇑e.symm = ⇑φ.symm from rfl]
+  haveI : (map (φ.symm) μ).Regular := (Regular.map_iff φ.symm.toHomeomorph).mpr inferInstance
+  rw [← mulEquivHaarChar_map (map φ.symm μ) φ, map_map]
+  · simp
+  · exact φ.toHomeomorph.toMeasurableEquiv.measurable
+  · exact e.symm.measurable
+
+@[to_additive addEquivAddHaarChar_smul_integral_map]
+lemma mulEquivHaarChar_smul_integral_map (μ : Measure G)
+    [IsHaarMeasure μ] [Regular μ] {f : G → ℝ} (φ : G ≃ₜ* G) :
+    ∫ (a : G), f a ∂μ = (mulEquivHaarChar φ) • ∫ a, f a ∂(map φ μ) := by
+  nth_rw 1 [← mulEquivHaarChar_map μ φ]
+  simp
+
+@[to_additive addEquivAddHaarChar_smul_integral_comap]
+lemma mulEquivHaarChar_smul_integral_comap (μ : Measure G)
+    [IsHaarMeasure μ] [Regular μ] {f : G → ℝ} (φ : G ≃ₜ* G) :
+    ∫ (a : G), f a ∂(comap φ μ) = (mulEquivHaarChar φ) • ∫ a, f a ∂μ := by
+  let e := φ.toHomeomorph.toMeasurableEquiv
+  change ∫ (a : G), f a ∂(comap e μ) = (mulEquivHaarChar φ) • ∫ a, f a ∂μ
+  haveI : (map (e.symm) μ).IsHaarMeasure := φ.symm.isHaarMeasure_map μ
+  haveI : (map (e.symm) μ).Regular := (Regular.map_iff φ.symm.toHomeomorph).2 inferInstance
+  rw [← e.map_symm, mulEquivHaarChar_smul_integral_map (map e.symm μ) φ,
+    map_map (by exact φ.toHomeomorph.toMeasurableEquiv.measurable) e.symm.measurable]
+  -- congr -- breaks to_additive
+  rw [show ⇑φ ∘ ⇑e.symm = id by ext; simp [e]]
+  simp
+
+@[to_additive addEquivAddHaarChar_smul_preimage]
+lemma mulEquivHaarChar_smul_preimage
+    (μ : Measure G) [IsHaarMeasure μ] [Regular μ] {X : Set G} (φ : G ≃ₜ* G) :
+    μ X = (mulEquivHaarChar φ) • μ (φ ⁻¹' X) := by
+  nth_rw 1 [← mulEquivHaarChar_map μ φ]
+  simp only [smul_apply, nnreal_smul_coe_apply]
+  exact congr_arg _ <| MeasurableEquiv.map_apply φ.toMeasurableEquiv X
+
+@[to_additive]
+lemma mulEquivHaarChar_refl :
+    mulEquivHaarChar (ContinuousMulEquiv.refl G) = 1 := by
+  simp [mulEquivHaarChar, Function.id_def]
+
+@[to_additive]
+lemma mulEquivHaarChar_trans {φ ψ : G ≃ₜ* G} :
+    mulEquivHaarChar (ψ.trans φ) = mulEquivHaarChar ψ * mulEquivHaarChar φ := by
+  rw [mulEquivHaarChar_eq haar ψ, mulEquivHaarChar_eq haar (ψ.trans φ)]
+  have hφ : Measurable φ := φ.toHomeomorph.measurable
+  have hψ : Measurable ψ := ψ.toHomeomorph.measurable
+  simp_rw [ContinuousMulEquiv.coe_trans, ← map_map hφ hψ]
+  have h_reg : (haar.map ψ).Regular := Regular.map ψ.toHomeomorph
+  rw [MeasureTheory.Measure.haarScalarFactor_eq_mul haar (haar.map ψ),
+    ← mulEquivHaarChar_eq (haar.map ψ)]
+
+end MeasureTheory

--- a/Mathlib/MeasureTheory/Measure/Haar/Unique.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/Unique.lean
@@ -347,7 +347,7 @@ lemma haarScalarFactor_smul [LocallyCompactSpace G] (μ' μ : Measure G) [IsHaar
 lemma mul_haarScalarFactor_smul [LocallyCompactSpace G] (μ' μ : Measure G)
     [IsHaarMeasure μ] [IsFiniteMeasureOnCompacts μ'] [IsMulLeftInvariant μ'] {c : ℝ≥0}
     (hc : c ≠ 0) :
-    have : IsHaarMeasure (c • μ) := IsHaarMeasure.nnreal_smul _ hc
+    haveI : IsHaarMeasure (c • μ) := IsHaarMeasure.nnreal_smul _ hc
     c * haarScalarFactor μ' (c • μ) = haarScalarFactor μ' μ := by
   have : IsHaarMeasure (c • μ) := IsHaarMeasure.nnreal_smul _ hc
   obtain ⟨⟨g, g_cont⟩, g_comp, g_nonneg, g_one⟩ :

--- a/Mathlib/MeasureTheory/Measure/Haar/Unique.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/Unique.lean
@@ -365,7 +365,7 @@ lemma mul_haarScalarFactor_smul [LocallyCompactSpace G] (μ' μ : Measure G)
     _ = μ'.haarScalarFactor μ :=
       (haarScalarFactor_eq_integral_div _ _ g_cont g_comp int_g_ne_zero).symm
 
-@[to_additive]
+@[to_additive addHaarScalarFactor_smul_smul]
 lemma haarScalarFactor_smul_smul [LocallyCompactSpace G] (μ' μ : Measure G)
     [IsHaarMeasure μ] [IsFiniteMeasureOnCompacts μ'] [IsMulLeftInvariant μ'] {c : ℝ≥0}
     (hc : c ≠ 0) :

--- a/Mathlib/MeasureTheory/Measure/Haar/Unique.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/Unique.lean
@@ -346,10 +346,10 @@ lemma haarScalarFactor_smul [LocallyCompactSpace G] (μ' μ : Measure G) [IsHaar
 @[to_additive mul_addHaarScalarFactor_smul]
 lemma mul_haarScalarFactor_smul [LocallyCompactSpace G] (μ' μ : Measure G)
     [IsHaarMeasure μ] [IsFiniteMeasureOnCompacts μ'] [IsMulLeftInvariant μ'] {c : ℝ≥0}
-    (hc : 0 < c) :
-    haveI : IsHaarMeasure (c • μ) := IsHaarMeasure.nnreal_smul _ hc
+    (hc : c ≠ 0) :
+    have : IsHaarMeasure (c • μ) := IsHaarMeasure.nnreal_smul _ hc
     c * haarScalarFactor μ' (c • μ) = haarScalarFactor μ' μ := by
-  haveI : IsHaarMeasure (c • μ) := IsHaarMeasure.nnreal_smul _ hc
+  have : IsHaarMeasure (c • μ) := IsHaarMeasure.nnreal_smul _ hc
   obtain ⟨⟨g, g_cont⟩, g_comp, g_nonneg, g_one⟩ :
     ∃ g : C(G, ℝ), HasCompactSupport g ∧ 0 ≤ g ∧ g 1 ≠ 0 := exists_continuous_nonneg_pos 1
   have int_g_ne_zero : ∫ x, g x ∂μ ≠ 0 :=
@@ -357,18 +357,18 @@ lemma mul_haarScalarFactor_smul [LocallyCompactSpace G] (μ' μ : Measure G)
   apply NNReal.coe_injective
   calc
     c * haarScalarFactor μ' (c • μ) = c * ((∫ x, g x ∂μ') / ∫ x, g x ∂(c • μ)) :=
-      by rw [haarScalarFactor_eq_integral_div _ _ g_cont g_comp (by simp [int_g_ne_zero, hc.ne'])]
+      by rw [haarScalarFactor_eq_integral_div _ _ g_cont g_comp (by simp [int_g_ne_zero, hc])]
     _ = c * ((∫ x, g x ∂μ') / (c • ∫ x, g x ∂μ)) := by simp
     _ = (∫ x, g x ∂μ') / (∫ x, g x ∂μ) := by
       rw [NNReal.smul_def, smul_eq_mul, ← mul_div_assoc]
-      exact mul_div_mul_left (∫ (x : G), g x ∂μ') (∫ (x : G), g x ∂μ) (by simp [hc.ne'])
+      exact mul_div_mul_left (∫ (x : G), g x ∂μ') (∫ (x : G), g x ∂μ) (by simp [hc])
     _ = μ'.haarScalarFactor μ :=
       (haarScalarFactor_eq_integral_div _ _ g_cont g_comp int_g_ne_zero).symm
 
 @[to_additive]
 lemma haarScalarFactor_smul_smul [LocallyCompactSpace G] (μ' μ : Measure G)
     [IsHaarMeasure μ] [IsFiniteMeasureOnCompacts μ'] [IsMulLeftInvariant μ'] {c : ℝ≥0}
-    (hc : 0 < c) :
+    (hc : c ≠ 0) :
     haveI : IsHaarMeasure (c • μ) := IsHaarMeasure.nnreal_smul _ hc
     haarScalarFactor (c • μ') (c • μ) = haarScalarFactor μ' μ := by
   rw [haarScalarFactor_smul, smul_eq_mul, mul_haarScalarFactor_smul _ _ hc]

--- a/Mathlib/MeasureTheory/Measure/Haar/Unique.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/Unique.lean
@@ -343,6 +343,36 @@ lemma haarScalarFactor_smul [LocallyCompactSpace G] (μ' μ : Measure G) [IsHaar
     _ = c • haarScalarFactor μ' μ := by
       rw [← haarScalarFactor_eq_integral_div _ _ g_cont g_comp int_g_ne_zero]
 
+@[to_additive mul_addHaarScalarFactor_smul]
+lemma mul_haarScalarFactor_smul [LocallyCompactSpace G] (μ' μ : Measure G)
+    [IsHaarMeasure μ] [IsFiniteMeasureOnCompacts μ'] [IsMulLeftInvariant μ'] {c : ℝ≥0}
+    (hc : 0 < c) :
+    haveI : IsHaarMeasure (c • μ) := IsHaarMeasure.nnreal_smul _ hc
+    c * haarScalarFactor μ' (c • μ) = haarScalarFactor μ' μ := by
+  haveI : IsHaarMeasure (c • μ) := IsHaarMeasure.nnreal_smul _ hc
+  obtain ⟨⟨g, g_cont⟩, g_comp, g_nonneg, g_one⟩ :
+    ∃ g : C(G, ℝ), HasCompactSupport g ∧ 0 ≤ g ∧ g 1 ≠ 0 := exists_continuous_nonneg_pos 1
+  have int_g_ne_zero : ∫ x, g x ∂μ ≠ 0 :=
+    ne_of_gt (g_cont.integral_pos_of_hasCompactSupport_nonneg_nonzero g_comp g_nonneg g_one)
+  apply NNReal.coe_injective
+  calc
+    c * haarScalarFactor μ' (c • μ) = c * ((∫ x, g x ∂μ') / ∫ x, g x ∂(c • μ)) :=
+      by rw [haarScalarFactor_eq_integral_div _ _ g_cont g_comp (by simp [int_g_ne_zero, hc.ne'])]
+    _ = c * ((∫ x, g x ∂μ') / (c • ∫ x, g x ∂μ)) := by simp
+    _ = (∫ x, g x ∂μ') / (∫ x, g x ∂μ) := by
+      rw [NNReal.smul_def, smul_eq_mul, ← mul_div_assoc]
+      exact mul_div_mul_left (∫ (x : G), g x ∂μ') (∫ (x : G), g x ∂μ) (by simp [hc.ne'])
+    _ = μ'.haarScalarFactor μ :=
+      (haarScalarFactor_eq_integral_div _ _ g_cont g_comp int_g_ne_zero).symm
+
+@[to_additive]
+lemma haarScalarFactor_smul_smul [LocallyCompactSpace G] (μ' μ : Measure G)
+    [IsHaarMeasure μ] [IsFiniteMeasureOnCompacts μ'] [IsMulLeftInvariant μ'] {c : ℝ≥0}
+    (hc : 0 < c) :
+    haveI : IsHaarMeasure (c • μ) := IsHaarMeasure.nnreal_smul _ hc
+    haarScalarFactor (c • μ') (c • μ) = haarScalarFactor μ' μ := by
+  rw [haarScalarFactor_smul, smul_eq_mul, mul_haarScalarFactor_smul _ _ hc]
+
 @[to_additive (attr := simp)]
 lemma haarScalarFactor_self (μ : Measure G) [IsHaarMeasure μ] :
     haarScalarFactor μ μ = 1 := by


### PR DESCRIPTION
API for the positive real factor by which an continuous multiplicative equivalence scales a regular Haar measure on a locally compact topological group. 

From FLT.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
