### PR TITLE
[Merged by Bors] - feat: Add `Matrix.liftLinear`

### DIFF
--- a/Mathlib/Data/Matrix/Basis.lean
+++ b/Mathlib/Data/Matrix/Basis.lean
@@ -198,7 +198,7 @@ variable [Module R α] [Module R β] [Module S β] [SMulCommClass R S β]
 
 /-- Families of linear maps acting on each element are equivalent to linear maps from a matrix.
 
-This can be thought of as the matrix versoin of `LinearMap.lsum`. -/
+This can be thought of as the matrix version of `LinearMap.lsum`. -/
 def liftLinear : (m → n → α →ₗ[R] β) ≃ₗ[S] (Matrix m n α →ₗ[R] β) :=
   LinearEquiv.piCongrRight (fun _ => LinearMap.lsum R _ S) ≪≫ₗ LinearMap.lsum R _ S ≪≫ₗ
     LinearEquiv.congrLeft _ _ (ofLinearEquiv _)

--- a/Mathlib/Data/Matrix/Basis.lean
+++ b/Mathlib/Data/Matrix/Basis.lean
@@ -191,44 +191,35 @@ theorem ext_linearMap
   LinearMap.toAddMonoidHom_injective <| ext_addMonoidHom fun i j =>
     congrArg LinearMap.toAddMonoidHom <| h i j
 
-variable {R} (S) in
+section liftLinear
+variable {R} (S)
+variable [Fintype m] [Fintype n] [Semiring R] [Semiring S] [AddCommMonoid α] [AddCommMonoid β]
+variable [Module R α] [Module R β] [Module S β] [SMulCommClass R S β]
+
 /-- Families of linear maps acting on each element are equivalent to linear maps from a matrix.
 
 This can be thought of as the matrix versoin of `LinearMap.lsum`. -/
-def liftLinear
-    [Fintype m] [Fintype n] [Semiring R] [Semiring S] [AddCommMonoid α] [AddCommMonoid β]
-    [Module R α] [Module R β] [Module S β] [SMulCommClass R S β] :
-    (m → n → α →ₗ[R] β) ≃ₗ[S] (Matrix m n α →ₗ[R] β) :=
-  LinearEquiv.piCongrRight (fun _ => LinearMap.lsum R _ S)
-    ≪≫ₗ LinearMap.lsum R _ S ≪≫ₗ LinearEquiv.congrLeft _ _ (ofLinearEquiv _)
+def liftLinear : (m → n → α →ₗ[R] β) ≃ₗ[S] (Matrix m n α →ₗ[R] β) :=
+  LinearEquiv.piCongrRight (fun _ => LinearMap.lsum R _ S) ≪≫ₗ LinearMap.lsum R _ S ≪≫ₗ
+    LinearEquiv.congrLeft _ _ (ofLinearEquiv _)
 
-variable {R} (S) in
 @[simp]
-theorem liftLinear_piSingle
-    [Fintype m] [Fintype n] [Semiring R] [Semiring S] [AddCommMonoid α] [AddCommMonoid β]
-    [Module R α] [Module R β] [Module S β] [SMulCommClass R S β]
-    (f : m → n → α →ₗ[R] β) (i : m) (j : n) (a : α) :
+theorem liftLinear_piSingle (f : m → n → α →ₗ[R] β) (i : m) (j : n) (a : α) :
     liftLinear S f (Matrix.single i j a) = f i j a := by
   dsimp [liftLinear, -LinearMap.lsum_apply, LinearEquiv.congrLeft, LinearEquiv.piCongrRight]
   simp_rw [of_symm_single, LinearMap.lsum_piSingle]
 
-variable {R} (S) in
 @[simp]
-theorem liftLinear_comp_singleLinearMap
-    [Fintype m] [Fintype n] [Semiring R] [Semiring S] [AddCommMonoid α] [AddCommMonoid β]
-    [Module R α] [Module R β] [Module S β] [SMulCommClass R S β]
-    (f : m → n → α →ₗ[R] β) (i : m) (j : n) :
+theorem liftLinear_comp_singleLinearMap (f : m → n → α →ₗ[R] β) (i : m) (j : n) :
     liftLinear S f ∘ₗ Matrix.singleLinearMap _ i j = f i j :=
   LinearMap.ext <| liftLinear_piSingle S f i j
 
-variable {R} (S) in
 @[simp]
-theorem liftLinear_singleLinearMap
-    [Fintype m] [Fintype n] [Semiring R] [Semiring S] [AddCommMonoid α]
-    [Module R α] [Module S α] [SMulCommClass R S α] :
-    liftLinear S (Matrix.singleLinearMap R) = .id (M := Matrix m n α) := by
-  ext
-  simp
+theorem liftLinear_singleLinearMap [Module S α] [SMulCommClass R S α] :
+    liftLinear S (Matrix.singleLinearMap R) = .id (M := Matrix m n α) :=
+  ext_linearMap _ <| liftLinear_comp_singleLinearMap _ _
+
+end liftLinear
 
 end ext
 

--- a/Mathlib/Data/Matrix/Basis.lean
+++ b/Mathlib/Data/Matrix/Basis.lean
@@ -15,7 +15,7 @@ at position `(i, j)`, and zeroes elsewhere.
 assert_not_exists Matrix.trace
 
 variable {l m n o : Type*}
-variable {R α β : Type*}
+variable {R S α β γ : Type*}
 
 namespace Matrix
 
@@ -190,6 +190,45 @@ theorem ext_linearMap
     f = g :=
   LinearMap.toAddMonoidHom_injective <| ext_addMonoidHom fun i j =>
     congrArg LinearMap.toAddMonoidHom <| h i j
+
+variable {R} (S) in
+/-- Families of linear maps acting on each element are equivalent to linear maps from a matrix.
+
+This can be thought of as the matrix versoin of `LinearMap.lsum`. -/
+def liftLinear
+    [Fintype m] [Fintype n] [Semiring R] [Semiring S] [AddCommMonoid α] [AddCommMonoid β]
+    [Module R α] [Module R β] [Module S β] [SMulCommClass R S β] :
+    (m → n → α →ₗ[R] β) ≃ₗ[S] (Matrix m n α →ₗ[R] β) :=
+  LinearEquiv.piCongrRight (fun _ => LinearMap.lsum R _ S)
+    ≪≫ₗ LinearMap.lsum R _ S ≪≫ₗ LinearEquiv.congrLeft _ _ (ofLinearEquiv _)
+
+variable {R} (S) in
+@[simp]
+theorem liftLinear_piSingle
+    [Fintype m] [Fintype n] [Semiring R] [Semiring S] [AddCommMonoid α] [AddCommMonoid β]
+    [Module R α] [Module R β] [Module S β] [SMulCommClass R S β]
+    (f : m → n → α →ₗ[R] β) (i : m) (j : n) (a : α) :
+    liftLinear S f (Matrix.single i j a) = f i j a := by
+  dsimp [liftLinear, -LinearMap.lsum_apply, LinearEquiv.congrLeft, LinearEquiv.piCongrRight]
+  simp_rw [of_symm_single, LinearMap.lsum_piSingle]
+
+variable {R} (S) in
+@[simp]
+theorem liftLinear_comp_singleLinearMap
+    [Fintype m] [Fintype n] [Semiring R] [Semiring S] [AddCommMonoid α] [AddCommMonoid β]
+    [Module R α] [Module R β] [Module S β] [SMulCommClass R S β]
+    (f : m → n → α →ₗ[R] β) (i : m) (j : n) :
+    liftLinear S f ∘ₗ Matrix.singleLinearMap _ i j = f i j :=
+  LinearMap.ext <| liftLinear_piSingle S f i j
+
+variable {R} (S) in
+@[simp]
+theorem liftLinear_singleLinearMap
+    [Fintype m] [Fintype n] [Semiring R] [Semiring S] [AddCommMonoid α]
+    [Module R α] [Module S α] [SMulCommClass R S α] :
+    liftLinear S (Matrix.singleLinearMap R) = .id (M := Matrix m n α) := by
+  ext
+  simp
 
 end ext
 

--- a/Mathlib/LinearAlgebra/Pi.lean
+++ b/Mathlib/LinearAlgebra/Pi.lean
@@ -238,9 +238,9 @@ theorem lsum_piSingle (S) [AddCommMonoid M] [Module R M] [Fintype ι] [Semiring 
   simp_rw [lsum_apply, sum_apply, comp_apply, proj_apply, apply_single, Fintype.sum_pi_single']
 
 @[simp high]
-theorem lsum_single {ι R : Type*} [Fintype ι] [DecidableEq ι] [CommSemiring R] {M : ι → Type*}
-    [(i : ι) → AddCommMonoid (M i)] [(i : ι) → Module R (M i)] :
-    LinearMap.lsum R M R (LinearMap.single R M) = LinearMap.id :=
+theorem lsum_single (S) [Fintype ι] [Semiring S]
+    [∀ i, Module S (φ i)] [∀ i, SMulCommClass R S (φ i)] :
+    LinearMap.lsum R φ S (LinearMap.single R φ) = LinearMap.id :=
   LinearMap.ext fun x => by simp [Finset.univ_sum_single]
 
 variable {R φ}

--- a/Mathlib/RingTheory/MatrixAlgebra.lean
+++ b/Mathlib/RingTheory/MatrixAlgebra.lean
@@ -44,17 +44,14 @@ def kroneckerTMulLinearEquiv :
     Matrix l m M ⊗[R] Matrix n p N ≃ₗ[S] Matrix (l × n) (m × p) (M ⊗[R] N) :=
   .ofLinear
     (AlgebraTensorModule.lift <| kroneckerTMulBilinear R S)
-    ((LinearMap.lsum S _ R fun ii => LinearMap.lsum S _ R fun jj => AlgebraTensorModule.map
-      (singleLinearMap S ii.1 jj.1) (singleLinearMap R ii.2 jj.2))
-      ∘ₗ (ofLinearEquiv S).symm.toLinearMap)
+    (Matrix.liftLinear R fun ii jj =>
+      AlgebraTensorModule.map (singleLinearMap S ii.1 jj.1) (singleLinearMap R ii.2 jj.2))
     (by
       ext : 4
-      simp [-LinearMap.lsum_apply, LinearMap.lsum_piSingle,
-        single_kroneckerTMul_single])
+      simp [single_kroneckerTMul_single])
     (by
       ext : 5
-      simp [-LinearMap.lsum_apply, LinearMap.lsum_piSingle,
-        single_kroneckerTMul_single])
+      simp [single_kroneckerTMul_single])
 
 @[simp]
 theorem kroneckerTMulLinearEquiv_tmul (a : Matrix l m M) (b : Matrix n p N) :


### PR DESCRIPTION
This behaves similarly to `LinearMap.lsum`, and slightly golfs an existing definition.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
