### PR TITLE
[Merged by Bors] - chore: remove simp attribute from variable change formulas for Weierstrass cubics

### DIFF
--- a/Mathlib/AlgebraicGeometry/EllipticCurve/IsomOfJ.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/IsomOfJ.lean
@@ -80,7 +80,7 @@ private lemma exists_variableChange_of_char_two_of_j_eq_zero
     field_simp
   · field_simp [variableChange_a₄, a₁_of_isCharTwoJEqZeroNF, a₂_of_isCharTwoJEqZeroNF]
     linear_combination hs + (s ^ 4 - s * t - E.a₃ * s) * CharP.cast_eq_zero F 2
-  · field_simp [variableChange_a₄, a₁_of_isCharTwoJEqZeroNF, a₂_of_isCharTwoJEqZeroNF]
+  · field_simp [variableChange_a₆, a₁_of_isCharTwoJEqZeroNF, a₂_of_isCharTwoJEqZeroNF]
     linear_combination ht - (t ^ 2 + E.a₃ * t) * CharP.cast_eq_zero F 2
 
 private lemma exists_variableChange_of_char_two (heq : E.j = E'.j) :
@@ -257,10 +257,10 @@ private lemma exists_variableChange_of_char_ne_two_or_three
       exact ⟨ha₆, ha₆'⟩
     use ⟨Units.mk0 u hu0, 0, 0, 0⟩
     ext
-    · simp
-    · simp
-    · simp
-    · simp [ha₄, ha₄']
+    · simp [variableChange_a₁]
+    · simp [variableChange_a₂]
+    · simp [variableChange_a₃]
+    · simp [ha₄, ha₄', variableChange_a₄]
     · simp_rw [variableChange_a₆, a₁_of_isShortNF, a₂_of_isShortNF, a₃_of_isShortNF,
         ha₄, Units.val_inv_eq_inv_val, Units.val_mk0, inv_pow, inv_mul_eq_div, hu]
       field_simp
@@ -282,13 +282,13 @@ private lemma exists_variableChange_of_char_ne_two_or_three
       exact ⟨ha₄, ha₄'⟩
     use ⟨Units.mk0 u hu0, 0, 0, 0⟩
     ext
-    · simp
-    · simp
-    · simp
+    · simp [variableChange_a₁]
+    · simp [variableChange_a₂]
+    · simp [variableChange_a₃]
     · simp_rw [variableChange_a₄, a₁_of_isShortNF, a₂_of_isShortNF, a₃_of_isShortNF,
         Units.val_inv_eq_inv_val, Units.val_mk0, inv_pow, inv_mul_eq_div, hu]
       field_simp
-    · simp [ha₆, ha₆']
+    · simp [ha₆, ha₆', variableChange_a₆]
   have ha₄' : E'.a₄ ≠ 0 := fun h ↦ by
     rw [h, zero_pow three_ne_zero, zero_mul, mul_eq_zero,
       pow_eq_zero_iff two_ne_zero, pow_eq_zero_iff three_ne_zero] at heq
@@ -311,9 +311,9 @@ private lemma exists_variableChange_of_char_ne_two_or_three
     exact ⟨ha₄, ha₄'⟩
   use ⟨Units.mk0 u hu0, 0, 0, 0⟩
   ext
-  · simp
-  · simp
-  · simp
+  · simp [variableChange_a₁]
+  · simp [variableChange_a₂]
+  · simp [variableChange_a₃]
   · simp_rw [variableChange_a₄, a₁_of_isShortNF, a₂_of_isShortNF, a₃_of_isShortNF,
       Units.val_inv_eq_inv_val, Units.val_mk0, inv_pow, inv_mul_eq_div, hu4]
     field_simp

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/NormalForms.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/NormalForms.lean
@@ -163,7 +163,7 @@ a normal form of characteristic ≠ 2, provided that 2 is invertible in the ring
 def toCharNeTwoNF : VariableChange R := ⟨1, 0, ⅟2 * -W.a₁, ⅟2 * -W.a₃⟩
 
 instance toCharNeTwoNF_spec : (W.toCharNeTwoNF • W).IsCharNeTwoNF := by
-  constructor <;> simp
+  constructor <;> simp [variableChange_a₁, variableChange_a₃]
 
 theorem exists_variableChange_isCharNeTwoNF : ∃ C : VariableChange R, (C • W).IsCharNeTwoNF :=
   ⟨_, W.toCharNeTwoNF_spec⟩
@@ -265,7 +265,7 @@ def toShortNF : VariableChange R :=
 
 instance toShortNF_spec : (W.toShortNF • W).IsShortNF := by
   rw [toShortNF, mul_smul]
-  constructor <;> simp
+  constructor <;> simp [variableChange_a₁, variableChange_a₂, variableChange_a₃]
 
 theorem exists_variableChange_isShortNF : ∃ C : VariableChange R, (C • W).IsShortNF :=
   ⟨_, W.toShortNF_spec⟩
@@ -420,10 +420,10 @@ theorem toCharThreeNF_spec_of_b₂_ne_zero (hb₂ : W.b₂ ≠ 0) :
   set W' := W.toShortNFOfCharThree • W
   haveI : W'.IsCharNeTwoNF := W.toCharNeTwoNF_spec
   constructor
-  · simp
-  · simp
+  · simp [variableChange_a₁]
+  · simp [variableChange_a₃]
   · have ha₂ : W'.a₂ ≠ 0 := W.toShortNFOfCharThree_a₂ ▸ hb₂
-    field_simp [ha₂]
+    field_simp [ha₂, variableChange_a₄]
     linear_combination (W'.a₄ * W'.a₂ ^ 2 + W'.a₄ ^ 2) * CharP.cast_eq_zero F 3
 
 theorem toCharThreeNF_spec_of_b₂_eq_zero (hb₂ : W.b₂ = 0) : (W.toCharThreeNF • W).IsShortNF := by
@@ -651,7 +651,7 @@ def toCharTwoJEqZeroNF : VariableChange R := ⟨1, W.a₂, 0, 0⟩
 theorem toCharTwoJEqZeroNF_spec (ha₁ : W.a₁ = 0) :
     (W.toCharTwoJEqZeroNF • W).IsCharTwoJEqZeroNF := by
   constructor
-  · simp [toCharTwoJEqZeroNF, ha₁]
+  · simp [toCharTwoJEqZeroNF, ha₁, variableChange_a₁]
   · simp_rw [toCharTwoJEqZeroNF, variableChange_a₂, inv_one, Units.val_one]
     linear_combination 2 * W.a₂ * CharP.cast_eq_zero R 2
 
@@ -666,10 +666,10 @@ def toCharTwoJNeZeroNF (W : WeierstrassCurve F) (ha₁ : W.a₁ ≠ 0) : Variabl
 theorem toCharTwoJNeZeroNF_spec (ha₁ : W.a₁ ≠ 0) :
     (W.toCharTwoJNeZeroNF ha₁ • W).IsCharTwoJNeZeroNF := by
   constructor
-  · simp [toCharTwoJNeZeroNF, ha₁]
-  · field_simp [toCharTwoJNeZeroNF]
+  · simp [toCharTwoJNeZeroNF, ha₁, variableChange_a₁]
+  · field_simp [toCharTwoJNeZeroNF, variableChange_a₃]
     linear_combination (W.a₃ * W.a₁ ^ 3 + W.a₁ ^ 2 * W.a₄ + W.a₃ ^ 2) * CharP.cast_eq_zero F 2
-  · field_simp [toCharTwoJNeZeroNF]
+  · field_simp [toCharTwoJNeZeroNF, variableChange_a₄]
     linear_combination (W.a₁ ^ 4 * W.a₃ ^ 2 + W.a₁ ^ 5 * W.a₃ * W.a₂) * CharP.cast_eq_zero F 2
 
 /-- For a `WeierstrassCurve` defined over a field of characteristic = 2,

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/VariableChange.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/VariableChange.lean
@@ -170,59 +170,47 @@ instance : MulAction (VariableChange R) (WeierstrassCurve R) where
           - C.r * C.t * C.u⁻¹ ^ 6 * ↑C'.u⁻¹ * (C'.s * 2 + W.a₁) * pow_mul_pow_eq_one 5 C'.u.inv_mul
           + C.u⁻¹ ^ 6 * (C.r ^ 3 - C.t ^ 2) * pow_mul_pow_eq_one 6 C'.u.inv_mul
 
-@[simp]
 lemma variableChange_a₁ : (C • W).a₁ = C.u⁻¹ * (W.a₁ + 2 * C.s) := rfl
 
-@[simp]
 lemma variableChange_a₂ : (C • W).a₂ = C.u⁻¹ ^ 2 * (W.a₂ - C.s * W.a₁ + 3 * C.r - C.s ^ 2) := rfl
 
-@[simp]
 lemma variableChange_a₃ : (C • W).a₃ = C.u⁻¹ ^ 3 * (W.a₃ + C.r * W.a₁ + 2 * C.t) := rfl
 
-@[simp]
 lemma variableChange_a₄ : (C • W).a₄ =
     C.u⁻¹ ^ 4 * (W.a₄ - C.s * W.a₃ + 2 * C.r * W.a₂ - (C.t + C.r * C.s) * W.a₁ + 3 * C.r ^ 2
       - 2 * C.s * C.t) := rfl
 
-@[simp]
 lemma variableChange_a₆ : (C • W).a₆ =
     C.u⁻¹ ^ 6 * (W.a₆ + C.r * W.a₄ + C.r ^ 2 * W.a₂ + C.r ^ 3 - C.t * W.a₃ - C.t ^ 2
       - C.r * C.t * W.a₁) := rfl
 
-@[simp]
 lemma variableChange_b₂ : (C • W).b₂ = C.u⁻¹ ^ 2 * (W.b₂ + 12 * C.r) := by
   simp only [b₂, variableChange_a₁, variableChange_a₂]
   ring1
 
-@[simp]
 lemma variableChange_b₄ : (C • W).b₄ = C.u⁻¹ ^ 4 * (W.b₄ + C.r * W.b₂ + 6 * C.r ^ 2) := by
   simp only [b₂, b₄, variableChange_a₁, variableChange_a₃, variableChange_a₄]
   ring1
 
-@[simp]
 lemma variableChange_b₆ : (C • W).b₆ =
     C.u⁻¹ ^ 6 * (W.b₆ + 2 * C.r * W.b₄ + C.r ^ 2 * W.b₂ + 4 * C.r ^ 3) := by
   simp only [b₂, b₄, b₆, variableChange_a₃, variableChange_a₆]
   ring1
 
-@[simp]
 lemma variableChange_b₈ : (C • W).b₈ = C.u⁻¹ ^ 8 *
     (W.b₈ + 3 * C.r * W.b₆ + 3 * C.r ^ 2 * W.b₄ + C.r ^ 3 * W.b₂ + 3 * C.r ^ 4) := by
   simp only [b₂, b₄, b₆, b₈, variableChange_a₁, variableChange_a₂, variableChange_a₃,
     variableChange_a₄, variableChange_a₆]
   ring1
 
-@[simp]
 lemma variableChange_c₄ : (C • W).c₄ = C.u⁻¹ ^ 4 * W.c₄ := by
   simp only [c₄, variableChange_b₂, variableChange_b₄]
   ring1
 
-@[simp]
 lemma variableChange_c₆ : (C • W).c₆ = C.u⁻¹ ^ 6 * W.c₆ := by
   simp only [c₆, variableChange_b₂, variableChange_b₄, variableChange_b₆]
   ring1
 
-@[simp]
 lemma variableChange_Δ : (C • W).Δ = C.u⁻¹ ^ 12 * W.Δ := by
   simp only [b₂, b₄, b₆, b₈, Δ, variableChange_a₁, variableChange_a₂, variableChange_a₃,
     variableChange_a₄, variableChange_a₆]
@@ -235,7 +223,6 @@ instance : (C • W).IsElliptic := by
   exact (C.u⁻¹.isUnit.pow 12).mul W.isUnit_Δ
 
 set_option linter.docPrime false in
-@[simp]
 lemma variableChange_Δ' : (C • W).Δ' = C.u⁻¹ ^ 12 * W.Δ' := by
   simp_rw [Units.ext_iff, Units.val_mul, coe_Δ', variableChange_Δ, Units.val_pow_eq_pow_val]
 


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Zulip: [#mathlib4 > &#96;@&#91;simp&#93;&#96; for variable changes in Elliptic curves](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/.60.40.5Bsimp.5D.60.20for.20variable.20changes.20in.20Elliptic.20curves/with/521714805)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
