### PR TITLE
[Merged by Bors] - refactor(RingTheory/Ideal/Colon): generalize `Ideal.mem_colon_singleton`

### DIFF
--- a/Mathlib/RingTheory/Ideal/Colon.lean
+++ b/Mathlib/RingTheory/Ideal/Colon.lean
@@ -19,7 +19,7 @@ namespace Submodule
 
 open Pointwise
 
-variable {R M M' F G : Type*}
+variable {R M : Type*}
 
 section Semiring
 
@@ -61,9 +61,7 @@ end Semiring
 section CommSemiring
 
 variable [CommSemiring R] [AddCommMonoid M] [Module R M]
-variable {N N₁ N₂ P P₁ P₂ : Submodule R M}
-
-variable {R M : Type*} [CommRing R] [AddCommGroup M] [Module R M] {N P : Submodule R M}
+variable {N P : Submodule R M}
 
 theorem mem_colon' {r} : r ∈ N.colon P ↔ P ≤ comap (r • (LinearMap.id : M →ₗ[R] M)) N :=
   mem_colon
@@ -82,8 +80,7 @@ theorem iInf_colon_iSup (ι₁ : Sort*) (f : ι₁ → Submodule R M) (ι₂ : S
                 this
 
 @[simp]
-theorem mem_colon_singleton {N : Submodule R M} {x : M} {r : R} :
-    r ∈ N.colon (Submodule.span R {x}) ↔ r • x ∈ N :=
+theorem mem_colon_singleton {x : M} {r : R} : r ∈ N.colon (Submodule.span R {x}) ↔ r • x ∈ N :=
   calc
     r ∈ N.colon (Submodule.span R {x}) ↔ ∀ a : R, r • a • x ∈ N := by
       simp [Submodule.mem_colon, Submodule.mem_span_singleton]
@@ -99,7 +96,7 @@ end CommSemiring
 section Ring
 
 variable [Ring R] [AddCommGroup M] [Module R M]
-variable {N N₁ N₂ P P₁ P₂ : Submodule R M}
+variable {N P : Submodule R M}
 
 @[simp]
 lemma annihilator_map_mkQ_eq_colon : annihilator (P.map N.mkQ) = N.colon P := by
@@ -108,8 +105,7 @@ lemma annihilator_map_mkQ_eq_colon : annihilator (P.map N.mkQ) = N.colon P := by
   exact ⟨fun H p hp ↦ (Quotient.mk_eq_zero N).1 (H (Quotient.mk p) (mem_map_of_mem hp)),
     fun H _ ⟨p, hp, hpm⟩ ↦ hpm ▸ ((Quotient.mk_eq_zero N).2 <| H p hp)⟩
 
-theorem annihilator_quotient {N : Submodule R M} :
-    Module.annihilator R (M ⧸ N) = N.colon ⊤ := by
+theorem annihilator_quotient : Module.annihilator R (M ⧸ N) = N.colon ⊤ := by
   simp_rw [SetLike.ext_iff, Module.mem_annihilator, ← annihilator_map_mkQ_eq_colon, mem_annihilator,
     map_top, LinearMap.range_eq_top.mpr (mkQ_surjective N), mem_top, forall_true_left,
     forall_const]


### PR DESCRIPTION
This PR generalizes a bit the assumptions of `Ideal.mem_colon_singleton`, changing `CommRing R` and `AddCommGroup M` to `CommSemiring R` and `AddCommMonoid R`. It also removes some unused variables from `Mathlib/RingTheory/Ideal/Colon.lean`.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
