### PR TITLE
[Merged by Bors] - feat: improve quality of proofs generated by `congr(...)`, add caching, add support for overapplied functions

### DIFF
--- a/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
@@ -306,8 +306,8 @@ theorem toNerve₂.ext (F G : X ⟶ nerveFunctor₂.obj (Cat.of C))
   | 2 =>
     apply Functor.hext (fun i : Fin 3 => ?_) (fun (i j : Fin 3) k => ?_)
     · let pt : ⦋0⦌₂ ⟶ ⦋2⦌₂ := SimplexCategory.const _ _ i
-      refine congr((($(F.naturality pt.op) x)).obj 0).symm.trans ?_
-      refine .trans ?_ congr((($(G.naturality pt.op) x)).obj 0)
+      refine congr(($(F.naturality pt.op) x).obj 0).symm.trans ?_
+      refine .trans ?_ congr(($(G.naturality pt.op) x).obj 0)
       exact congr($(eq₀ _).obj 0)
     · let ar : ⦋1⦌₂ ⟶ ⦋2⦌₂ := mkOfLe _ _ k.le
       have h1 := congr_arg_heq (fun x => x.map' 0 1) (congr_fun (F.naturality (op ar)) x)

--- a/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
@@ -306,8 +306,8 @@ theorem toNerve₂.ext (F G : X ⟶ nerveFunctor₂.obj (Cat.of C))
   | 2 =>
     apply Functor.hext (fun i : Fin 3 => ?_) (fun (i j : Fin 3) k => ?_)
     · let pt : ⦋0⦌₂ ⟶ ⦋2⦌₂ := SimplexCategory.const _ _ i
-      refine congr(($(congr_fun (F.naturality pt.op) x)).obj 0).symm.trans ?_
-      refine .trans ?_ congr(($(congr_fun (G.naturality pt.op) x)).obj 0)
+      refine congr((($(F.naturality pt.op) x)).obj 0).symm.trans ?_
+      refine .trans ?_ congr((($(G.naturality pt.op) x)).obj 0)
       exact congr($(eq₀ _).obj 0)
     · let ar : ⦋1⦌₂ ⟶ ⦋2⦌₂ := mkOfLe _ _ k.le
       have h1 := congr_arg_heq (fun x => x.map' 0 1) (congr_fun (F.naturality (op ar)) x)

--- a/Mathlib/Tactic/TermCongr.lean
+++ b/Mathlib/Tactic/TermCongr.lean
@@ -448,13 +448,25 @@ def mkCongrOfCHole? (mvarCounterSaved : Nat) (lhs rhs : Expr) : MetaM (Option Co
     throwCongrEx lhs rhs "Left-hand side lost its congruence hole annotation."
   | none, none => return none
 
-/-- Walks along both `lhs` and `rhs` simultaneously to create a congruence lemma between them.
+/--
+Given two applications of the same arity, returns the longest shared prefix,
+or else their head functions.
+-/
+private def getJointAppFns (e e' : Expr) : Expr × Expr :=
+  if e == e' then
+    (e, e)
+  else
+    match e, e' with
+    | .app f _, .app f' _ => getJointAppFns f f'
+    | _,        _         => (e, e')
 
-Where they are desynchronized, we fall back to the base case (using `CongrResult.mkDefault'`)
-since it's likely due to unification with the expected type,
-from `_` placeholders or implicit arguments being filled in. -/
-partial def mkCongrOf (depth : Nat) (mvarCounterSaved : Nat) (lhs rhs : Expr) :
-    MetaM CongrResult := do
+abbrev M := MonadCacheT (Expr × Expr) CongrResult MetaM
+
+mutual
+
+/-- Implementation of `mkCongrOf`, with caching. -/
+partial def mkCongrOfAux (depth : Nat) (mvarCounterSaved : Nat) (lhs rhs : Expr) :
+    M CongrResult := do
   trace[Elab.congr] "mkCongrOf: {depth}, {lhs}, {rhs}, {(← mkFreshExprMVar none).mvarId!}"
   if depth > 1000 then
     throwError "congr(...) internal error: out of gas"
@@ -463,143 +475,191 @@ partial def mkCongrOf (depth : Nat) (mvarCounterSaved : Nat) (lhs rhs : Expr) :
   -- end up with congruence holes, so they indeed might need a nontrivial congruence.
   let lhs ← instantiateMVars lhs
   let rhs ← instantiateMVars rhs
-  if let some res ← mkCongrOfCHole? mvarCounterSaved lhs rhs then
-    trace[Elab.congr] "hole processing succeeded"
-    return res
-  if (hasCHole mvarCounterSaved lhs).isNone && (hasCHole mvarCounterSaved rhs).isNone then
-    -- It's safe to fastforward if the lhs and rhs are defeq and have no congruence holes.
-    -- This is more conservative than necessary since congruence holes might only be inside proofs.
-    if ← isDefEq lhs rhs then
-      return {lhs, rhs, pf? := none}
-  if ← (isProof lhs <||> isProof rhs) then
-    -- We don't want to look inside proofs at all.
-    return ← CongrResult.mkDefault lhs rhs
-  match lhs, rhs with
-  | .app .., .app .. =>
-    trace[Elab.congr] "app"
-    let arity := lhs.getAppNumArgs
-    unless arity == rhs.getAppNumArgs do
-      trace[Elab.congr] "app desync (arity)"
-      return ← CongrResult.mkDefault' mvarCounterSaved lhs rhs
-    let f := lhs.getAppFn
-    let f' := rhs.getAppFn
-    unless ← isDefEq (← inferType f) (← inferType f') do
-      trace[Elab.congr] "app desync (function types)"
-      return ← CongrResult.mkDefault' mvarCounterSaved lhs rhs
-    let fnRes ← mkCongrOf (depth + 1) mvarCounterSaved f f'
-    trace[Elab.congr] "mkCongrOf functions {f}, {f'} has isRfl = {fnRes.isRfl}"
-    if !fnRes.isRfl then
-      -- If there's a nontrivial proof, then since mkHCongrWithArity fixes the function
-      -- we need to handle this ourselves.
-      let lhs := mkAppN fnRes.lhs lhs.getAppArgs
-      let lhs' := mkAppN fnRes.rhs lhs.getAppArgs
-      let rhs := mkAppN fnRes.rhs rhs.getAppArgs
-      let mut pf ← fnRes.eq
-      for arg in lhs.getAppArgs do
-        pf ← mkCongrFun pf arg
-      let res1 := CongrResult.mk' lhs lhs' pf
-      let res2 ← mkCongrOf (depth + 1) mvarCounterSaved lhs' rhs
-      return res1.trans res2
-    let thm ← mkHCongrWithArity' fnRes.lhs arity
-    let mut args := #[]
-    let mut lhsArgs := #[]
-    let mut rhsArgs := #[]
-    let mut nontriv : Bool := false
-    for lhs' in lhs.getAppArgs, rhs' in rhs.getAppArgs, kind in thm.argKinds do
-      match kind with
-      | .eq =>
-        let res ← mkCongrOf (depth + 1) mvarCounterSaved lhs' rhs'
-        nontriv := nontriv || !res.isRfl
-        args := args |>.push res.lhs |>.push res.rhs |>.push (← res.eq)
-        lhsArgs := lhsArgs.push res.lhs
-        rhsArgs := rhsArgs.push res.rhs
-      | .heq =>
-        let res ← mkCongrOf (depth + 1) mvarCounterSaved lhs' rhs'
-        nontriv := nontriv || !res.isRfl
-        args := args |>.push res.lhs |>.push res.rhs |>.push (← res.heq)
-        lhsArgs := lhsArgs.push res.lhs
-        rhsArgs := rhsArgs.push res.rhs
-      | .subsingletonInst =>
-        -- Warning: we're not processing any congruence holes here.
-        -- Users shouldn't be intentionally placing them in such arguments anyway.
-        -- We can't throw an error because these arguments might incidentally have
-        -- congruence holes by unification.
-        nontriv := true
-        let lhs := removeCHoles lhs'
-        let rhs := removeCHoles rhs'
-        args := args |>.push lhs |>.push rhs
-        lhsArgs := lhsArgs.push lhs
-        rhsArgs := rhsArgs.push rhs
-      | _ => panic! "unexpected hcongr argument kind"
-    let lhs := mkAppN fnRes.lhs lhsArgs
-    let rhs := mkAppN fnRes.rhs rhsArgs
-    if nontriv then
-      return CongrResult.mk' lhs rhs (mkAppN thm.proof args)
-    else
-      -- `lhs` and `rhs` *should* be defeq, but use `mkDefault` just to be safe.
-      CongrResult.mkDefault lhs rhs
-  | .lam .., .lam .. =>
-    trace[Elab.congr] "lam"
-    let resDom ← mkCongrOf (depth + 1) mvarCounterSaved lhs.bindingDomain! rhs.bindingDomain!
-    -- We do not yet support congruences in the binding domain for lambdas.
-    discard <| resDom.defeq
-    withLocalDecl lhs.bindingName! lhs.bindingInfo! resDom.lhs fun x => do
-      let lhsb := lhs.bindingBody!.instantiate1 x
-      let rhsb := rhs.bindingBody!.instantiate1 x
-      let resBody ← mkCongrOf (depth + 1) mvarCounterSaved lhsb rhsb
-      let lhs ← mkLambdaFVars #[x] resBody.lhs
-      let rhs ← mkLambdaFVars #[x] resBody.rhs
-      if resBody.isRfl then
-        return {lhs, rhs, pf? := none}
-      else
-        let pf ← mkLambdaFVars #[x] (← resBody.eq)
-        return CongrResult.mk' lhs rhs (← mkAppM ``funext #[pf])
-  | .forallE .., .forallE .. =>
-    trace[Elab.congr] "forallE"
-    let resDom ← mkCongrOf (depth + 1) mvarCounterSaved lhs.bindingDomain! rhs.bindingDomain!
-    if lhs.isArrow && rhs.isArrow then
-      let resBody ← mkCongrOf (depth + 1) mvarCounterSaved lhs.bindingBody! rhs.bindingBody!
-      let lhs := Expr.forallE lhs.bindingName! resDom.lhs resBody.lhs lhs.bindingInfo!
-      let rhs := Expr.forallE rhs.bindingName! resDom.rhs resBody.rhs rhs.bindingInfo!
-      if resDom.isRfl && resBody.isRfl then
-        return {lhs, rhs, pf? := none}
-      else
-        return CongrResult.mk' lhs rhs (← mkImpCongr (← resDom.eq) (← resBody.eq))
-    else
-      -- We do not yet support congruences in the binding domain for dependent pi types.
+  checkCache (lhs, rhs) fun _ => do
+    if let some res ← mkCongrOfCHole? mvarCounterSaved lhs rhs then
+      trace[Elab.congr] "hole processing succeeded"
+      return res
+    if lhs == rhs then
+      return { lhs, rhs, pf? := none }
+    if (hasCHole mvarCounterSaved lhs).isNone && (hasCHole mvarCounterSaved rhs).isNone then
+      -- It's safe to fastforward if the lhs and rhs are defeq and have no congruence holes.
+      -- This is more conservative than necessary since congruence holes might only be inside
+      -- proofs, and it is OK to ignore these.
+      if ← isDefEq lhs rhs then
+        return { lhs, rhs, pf? := none }
+    if ← (isProof lhs <||> isProof rhs) then
+      -- We don't want to look inside proofs at all.
+      return ← CongrResult.mkDefault lhs rhs
+    match lhs, rhs with
+    | .app .., .app .. =>
+      mkCongrOfApp depth mvarCounterSaved lhs rhs
+    | .lam .., .lam .. =>
+      trace[Elab.congr] "lam"
+      let resDom ← mkCongrOfAux (depth + 1) mvarCounterSaved lhs.bindingDomain! rhs.bindingDomain!
+      -- We do not yet support congruences in the binding domain for lambdas.
       discard <| resDom.defeq
       withLocalDecl lhs.bindingName! lhs.bindingInfo! resDom.lhs fun x => do
         let lhsb := lhs.bindingBody!.instantiate1 x
         let rhsb := rhs.bindingBody!.instantiate1 x
-        let resBody ← mkCongrOf (depth + 1) mvarCounterSaved lhsb rhsb
-        let lhs ← mkForallFVars #[x] resBody.lhs
-        let rhs ← mkForallFVars #[x] resBody.rhs
+        let resBody ← mkCongrOfAux (depth + 1) mvarCounterSaved lhsb rhsb
+        let lhs ← mkLambdaFVars #[x] resBody.lhs
+        let rhs ← mkLambdaFVars #[x] resBody.rhs
         if resBody.isRfl then
           return {lhs, rhs, pf? := none}
         else
           let pf ← mkLambdaFVars #[x] (← resBody.eq)
-          return CongrResult.mk' lhs rhs (← mkAppM ``pi_congr #[pf])
-  | .letE .., .letE .. =>
-    trace[Elab.congr] "letE"
-    -- Just zeta reduce for now. Could look at `Lean.Meta.Simp.simp.simpLet`
-    let lhs := lhs.letBody!.instantiate1 lhs.letValue!
-    let rhs := rhs.letBody!.instantiate1 rhs.letValue!
-    mkCongrOf (depth + 1) mvarCounterSaved lhs rhs
-  | .mdata _ lhs', .mdata _ rhs' =>
-    trace[Elab.congr] "mdata"
-    let res ← mkCongrOf (depth + 1) mvarCounterSaved lhs' rhs'
-    return {res with lhs := lhs.updateMData! res.lhs, rhs := rhs.updateMData! res.rhs}
-  | .proj n1 i1 e1, .proj n2 i2 e2 =>
-    trace[Elab.congr] "proj"
-    -- Only handles defeq at the moment.
-    unless n1 == n2 && i1 == i2 do
-      throwCongrEx lhs rhs "Incompatible primitive projections"
-    let res ← mkCongrOf (depth + 1) mvarCounterSaved e1 e2
-    discard <| res.defeq
-    return {lhs := lhs.updateProj! res.lhs, rhs := rhs.updateProj! res.rhs, pf? := none}
-  | _, _ =>
-    trace[Elab.congr] "base case"
-    CongrResult.mkDefault' mvarCounterSaved lhs rhs
+          return CongrResult.mk' lhs rhs (← mkAppM ``funext #[pf])
+    | .forallE .., .forallE .. =>
+      trace[Elab.congr] "forallE"
+      let resDom ← mkCongrOfAux (depth + 1) mvarCounterSaved lhs.bindingDomain! rhs.bindingDomain!
+      if lhs.isArrow && rhs.isArrow then
+        let resBody ← mkCongrOfAux (depth + 1) mvarCounterSaved lhs.bindingBody! rhs.bindingBody!
+        let lhs := Expr.forallE lhs.bindingName! resDom.lhs resBody.lhs lhs.bindingInfo!
+        let rhs := Expr.forallE rhs.bindingName! resDom.rhs resBody.rhs rhs.bindingInfo!
+        if resDom.isRfl && resBody.isRfl then
+          return {lhs, rhs, pf? := none}
+        else
+          return CongrResult.mk' lhs rhs (← mkImpCongr (← resDom.eq) (← resBody.eq))
+      else
+        -- We do not yet support congruences in the binding domain for dependent pi types.
+        discard <| resDom.defeq
+        withLocalDecl lhs.bindingName! lhs.bindingInfo! resDom.lhs fun x => do
+          let lhsb := lhs.bindingBody!.instantiate1 x
+          let rhsb := rhs.bindingBody!.instantiate1 x
+          let resBody ← mkCongrOfAux (depth + 1) mvarCounterSaved lhsb rhsb
+          let lhs ← mkForallFVars #[x] resBody.lhs
+          let rhs ← mkForallFVars #[x] resBody.rhs
+          if resBody.isRfl then
+            return {lhs, rhs, pf? := none}
+          else
+            let pf ← mkLambdaFVars #[x] (← resBody.eq)
+            return CongrResult.mk' lhs rhs (← mkAppM ``pi_congr #[pf])
+    | .letE .., .letE .. =>
+      trace[Elab.congr] "letE"
+      -- Just zeta reduce for now. Could look at `Lean.Meta.Simp.simp.simpLet`
+      let lhs := lhs.letBody!.instantiate1 lhs.letValue!
+      let rhs := rhs.letBody!.instantiate1 rhs.letValue!
+      mkCongrOfAux (depth + 1) mvarCounterSaved lhs rhs
+    | .mdata _ lhs', .mdata _ rhs' =>
+      trace[Elab.congr] "mdata"
+      let res ← mkCongrOfAux (depth + 1) mvarCounterSaved lhs' rhs'
+      return {res with lhs := lhs.updateMData! res.lhs, rhs := rhs.updateMData! res.rhs}
+    | .proj n1 i1 e1, .proj n2 i2 e2 =>
+      trace[Elab.congr] "proj"
+      -- Only handles defeq at the moment.
+      unless n1 == n2 && i1 == i2 do
+        throwCongrEx lhs rhs "Incompatible primitive projections"
+      let res ← mkCongrOfAux (depth + 1) mvarCounterSaved e1 e2
+      discard <| res.defeq
+      return {lhs := lhs.updateProj! res.lhs, rhs := rhs.updateProj! res.rhs, pf? := none}
+    | _, _ =>
+      trace[Elab.congr] "base case"
+      CongrResult.mkDefault' mvarCounterSaved lhs rhs
+
+/--
+Generate congruence for applications `lhs` and `rhs`.
+Key detail: functions might be *overapplied* due to the values of their arguments.
+For example, `id id 2` is overapplied.
+To handle these, we need to segment the applications into their natural arities,
+since `mkHCongrWithArity'` does not know how to generate congruence lemmas for the overapplied case.
+-/
+partial def mkCongrOfApp (depth : Nat) (mvarCounterSaved : Nat) (lhs rhs : Expr) :
+    M CongrResult := do
+  -- Even if a function is being rewritten (e.g. with `f x = g`), both sides should have the same
+  -- number of arguments since there will be a cHole around both `f x` and `g`.
+  let arity := lhs.getAppNumArgs
+  trace[Elab.congr] "app, arity {arity}"
+  unless arity == rhs.getAppNumArgs do
+    trace[Elab.congr] "app desync (arity)"
+    return ← CongrResult.mkDefault' mvarCounterSaved lhs rhs
+  -- Optimization: congruences often have a shared prefix (e.g. some type parameters an instances)
+  -- so if there's a shared prefix we use it.
+  let (f, f') := getJointAppFns lhs rhs
+  let arity := arity - f.getAppNumArgs
+  trace[Elab.congr] "app, updated arity {arity}"
+  if f != f' then
+    unless ← isDefEq (← inferType f) (← inferType f') do
+      trace[Elab.congr] "app desync (function types)"
+      return ← CongrResult.mkDefault' mvarCounterSaved lhs rhs
+  let info ← getFunInfoNArgs f arity
+  -- Sometimes functions are "overapplied", meaning the natural arity of the function is less
+  -- than `arity`. In this case, we need to split the congruence up, since `mkHCongrWithArity'`
+  -- can't work when it is given too high of an arity.
+  if info.getArity < arity then
+    let overage := arity - info.getArity
+    trace[Elab.congr] "app overapplied with overage of {overage}"
+    -- Insert an mdata node to split up the application and then try `mkCongrOfApp` again.
+    -- The mdata changes the effective arity of the application.
+    let lhs' := mkAppN (.mdata {} (lhs.getBoundedAppFn overage)) (lhs.getBoundedAppArgs overage)
+    let rhs' := mkAppN (.mdata {} (rhs.getBoundedAppFn overage)) (rhs.getBoundedAppArgs overage)
+    return ← mkCongrOfApp (depth + 1) mvarCounterSaved lhs' rhs'
+  let fnRes ← mkCongrOfAux (depth + 1) mvarCounterSaved f f'
+  trace[Elab.congr] "mkCongrOf functions {f}, {f'} has isRfl = {fnRes.isRfl}"
+  let lhsFnArgs := lhs.getBoundedAppArgs arity
+  let rhsFnArgs := rhs.getBoundedAppArgs arity
+  if !fnRes.isRfl then
+    -- If there's a nontrivial proof, then since mkHCongrWithArity fixes the function
+    -- we need to handle this ourselves.
+    let lhs := mkAppN fnRes.lhs lhsFnArgs
+    let lhs' := mkAppN fnRes.rhs lhsFnArgs
+    let rhs := mkAppN fnRes.rhs rhsFnArgs
+    let mut pf ← fnRes.eq
+    for arg in lhsFnArgs do
+      pf ← mkCongrFun pf arg
+    let res1 := CongrResult.mk' lhs lhs' pf
+    let res2 ← mkCongrOfAux (depth + 1) mvarCounterSaved lhs' rhs
+    return res1.trans res2
+  let thm ← mkHCongrWithArity' fnRes.lhs arity
+  let mut args := #[]
+  let mut lhsArgs := #[]
+  let mut rhsArgs := #[]
+  let mut nontriv : Bool := false
+  for lhs' in lhsFnArgs, rhs' in rhsFnArgs, kind in thm.argKinds do
+    match kind with
+    | .eq =>
+      let res ← mkCongrOfAux (depth + 1) mvarCounterSaved lhs' rhs'
+      nontriv := nontriv || !res.isRfl
+      args := args |>.push res.lhs |>.push res.rhs |>.push (← res.eq)
+      lhsArgs := lhsArgs.push res.lhs
+      rhsArgs := rhsArgs.push res.rhs
+    | .heq =>
+      let res ← mkCongrOfAux (depth + 1) mvarCounterSaved lhs' rhs'
+      nontriv := nontriv || !res.isRfl
+      args := args |>.push res.lhs |>.push res.rhs |>.push (← res.heq)
+      lhsArgs := lhsArgs.push res.lhs
+      rhsArgs := rhsArgs.push res.rhs
+    | .subsingletonInst =>
+      -- Warning: we're not processing any congruence holes here.
+      -- Users shouldn't be intentionally placing them in such arguments anyway.
+      -- We can't throw an error because these arguments might incidentally have
+      -- congruence holes by unification.
+      nontriv := true
+      let lhs := removeCHoles lhs'
+      let rhs := removeCHoles rhs'
+      args := args |>.push lhs |>.push rhs
+      lhsArgs := lhsArgs.push lhs
+      rhsArgs := rhsArgs.push rhs
+    | _ => panic! "unexpected hcongr argument kind"
+  let lhs := mkAppN fnRes.lhs lhsArgs
+  let rhs := mkAppN fnRes.rhs rhsArgs
+  if nontriv then
+    return CongrResult.mk' lhs rhs (mkAppN thm.proof args)
+  else
+    -- `lhs` and `rhs` *should* be defeq, but use `mkDefault` just to be safe.
+    CongrResult.mkDefault lhs rhs
+
+end
+
+/--
+Walks along both `lhs` and `rhs` simultaneously to create a congruence lemma between them.
+
+Where they are desynchronized, we fall back to the base case (using `CongrResult.mkDefault'`)
+since it's likely due to unification with the expected type,
+from `_` placeholders or implicit arguments being filled in.
+-/
+partial def mkCongrOf (depth : Nat) (mvarCounterSaved : Nat) (lhs rhs : Expr) :
+    MetaM CongrResult :=
+  mkCongrOfAux depth mvarCounterSaved lhs rhs |>.run
 
 /-! ### Elaborating congruence quotations -/
 

--- a/Mathlib/Tactic/TermCongr.lean
+++ b/Mathlib/Tactic/TermCongr.lean
@@ -453,8 +453,8 @@ def mkCongrOfCHole? (mvarCounterSaved : Nat) (lhs rhs : Expr) : MetaM (Option Co
   | none, none => return none
 
 /--
-Given two applications of the same arity, returns the longest shared prefix,
-or else their head functions.
+Given two applications of the same arity, gives `Expr.getAppFn` of both,
+but if these functions are equal, gives the longest common prefix.
 -/
 private def getJointAppFns (e e' : Expr) : Expr × Expr :=
   if e == e' then

--- a/MathlibTest/TermCongr.lean
+++ b/MathlibTest/TermCongr.lean
@@ -182,6 +182,13 @@ lemma test (n n' : Nat) (h : n = n') (hn : n = n) (hn' : n' = n') :
   guard_hyp this :ₛ f n hn = f n' hn'
   exact congr(f $h _) -- with expected type
 
+/-!
+Regression test for #25851. Make sure hcongr doesn't force the final result to be an equality.
+-/
+example (a a' : Nat) (h : a = a') (n : Fin a) (n' : Fin a') (hn : HEq n n') :
+    HEq (f n rfl) (f n' rfl) :=
+  congr(f (α := Fin $h) $hn rfl)
+
 end SubsingletonDependence
 
 section limitations

--- a/MathlibTest/TermCongr.lean
+++ b/MathlibTest/TermCongr.lean
@@ -55,6 +55,11 @@ example [Decidable p] (x y : Nat) (h : x = y) : True := by
   guard_hyp this :ₛ (if p then 1 else x) = (if p then 1 else y)
   trivial
 
+example [Decidable p] (x y : Nat) (h : x = y) : True := by
+  have := congr(if p then $h else 1)
+  guard_hyp this :ₛ (if p then x else 1) = (if p then y else 1)
+  trivial
+
 example (x y z w : Nat) (h : x = y) (h' : z = w) : 1 + x * z^2 = 1 + y * w^2 := by
   refine congr(1 + $(?_) * $(?_)^2)
   · exact h
@@ -71,6 +76,9 @@ example (p q : Prop) (h : p = q) : p ↔ q := by
   refine congr($(?_))
   guard_target = p ↔ q
   exact congr($h)
+
+example (p p' q q' : Prop) (hp : p ↔ p') (hq : q ↔ q') : (p → q) ↔ (p' → q') :=
+  congr($hp → $hq)
 
 example (p q : Prop) (h : p = q) : Nonempty p = Nonempty q := congr(Nonempty $h)
 
@@ -158,6 +166,7 @@ def f {α : Type} [DecidableEq α] (n : α) (_ : n = n) : α := n
 lemma test (n n' : Nat) (h : n = n') (hn : n = n) (hn' : n' = n') :
     f n hn = f n' hn' := by
   have := congr(f $h ‹_›) -- without expected type
+  guard_hyp this :ₛ f n hn = f n' hn'
   exact congr(f $h _) -- with expected type
 
 end SubsingletonDependence

--- a/MathlibTest/TermCongr.lean
+++ b/MathlibTest/TermCongr.lean
@@ -119,6 +119,34 @@ example (f g : Nat → Nat → Prop) (h : f = g) :
     (∀ x, ∃ y, f x y) ↔ (∀ x, ∃ y, g x y) :=
   congr(∀ _, ∃ _, $(by rw [h]))
 
+namespace Overapplied
+/-!
+Overapplied functions need to be handled too. This one is for `Subtype.val`, which has arity 3,
+but in examples (3) and (4) it's used with arity 4.
+-/
+
+def T1 (A : Nat → Type) := ∀ n, A n
+def T2 (A : Nat → Type) := { f : ∀ n, A n // f = f }
+
+example {A : Nat → Type} (f g : ∀ n, A n) (h : f = g) (n : Nat) : f n = g n := by
+  have := congr($h n) -- (1) worked, not overapplied
+  exact this
+
+example {A : Nat → Type} (f g : T1 A) (h : f = g) (n : Nat) : f n = g n := by
+  have := congr($h n) -- (2) worked, not overapplied
+  exact this
+
+example {A : Nat → Type} (f g : T2 A) (h : f = g) (n : Nat) : f.1 n = g.1 n := by
+  have := congr($h.1 n) -- (3) didn't work, is overapplied
+  exact this
+
+example {A : Nat → Type} (f g : T2 A) (h : f = g) (n : Nat) : f.1 n = g.1 n := by
+  have hh := congr($h.1) -- works
+  have := congr($hh n) -- (4) didn't work, is overapplied
+  exact this
+
+end Overapplied
+
 namespace SubsingletonDependence
 /-!
 The congruence theorem generator had a bug that leaked fvars.

--- a/MathlibTest/TermCongr.lean
+++ b/MathlibTest/TermCongr.lean
@@ -153,6 +153,19 @@ example {A : Nat → Type} (f g : T2 A) (h : f = g) (n : Nat) : f.1 n = g.1 n :=
   have := congr($hh n) -- (4) didn't work, is overapplied
   exact this
 
+/-!
+A couple more over-applied functions.
+-/
+axiom fn {α : Type} (x : α) (h : x = x) : α
+
+example (f g : Nat → Nat) (h : f = g) (m n : Nat) (h' : m = n) :
+    fn f rfl m = fn g rfl n :=
+  congr(fn $h _ $h')
+
+example (f g : Nat → Nat) (h : f = g) (m n : Nat) (h' : m = n) :
+    fn (fn f rfl) rfl m = fn (fn g rfl) rfl n :=
+  congr(fn (fn $h _) _ $h')
+
 end Overapplied
 
 namespace SubsingletonDependence


### PR DESCRIPTION
This PR makes the following improvements to the `congr(...)` term elaborator:
- It now uses `congr`/`congrFun` as much as possible instead of creating giant HEq-based congruence proofs.
- It now looks for common prefixes for applications, to skip unnecessary work proving that these parts of an application are equal.
- Intermediate results are cached.
- Overapplied functions are now supported.

An overapplied function is a function with more arguments than the arity of the function itself. For example, in `id id 2` the first `id is overapplied. The return type is conditionally a pi type depending on the values of the arguments.

Fixes Jz Pan's issue reported [on Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Strange.20error.20on.20.60congr.60.20macro/near/523998660).

Modifies a couple uses of `congr(...)` in `SimplicialSet.NerveAdjunction` to take more advantage of it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
