### PR TITLE
[Merged by Bors] - fix: solve auth-scope-related issues in migrate_to_fork script 

### DIFF
--- a/scripts/migrate_to_fork.py
+++ b/scripts/migrate_to_fork.py
@@ -95,9 +95,9 @@ def run_command(cmd: List[str], capture_output: bool = True, check: bool = True)
         # Convert command to string if using shell
         if use_shell:
             cmd_str = ' '.join(cmd)
-            result = subprocess.run(cmd_str, shell=True, capture_output=capture_output, text=True, check=check)
+            result = subprocess.run(cmd_str, shell=True, capture_output=capture_output, text=True, encoding="utf8", check=check)
         else:
-            result = subprocess.run(cmd, capture_output=capture_output, text=True, check=check)
+            result = subprocess.run(cmd, capture_output=capture_output, text=True, encoding="utf8", check=check)
         return result
     except subprocess.CalledProcessError as e:
         if not check:

--- a/scripts/migrate_to_fork.py
+++ b/scripts/migrate_to_fork.py
@@ -188,8 +188,10 @@ def check_gh_token_scopes() -> bool:
             print_warning("Could not verify token scopes, but basic API access works")
             return True
 
-        # Parse the output to check for required scopes
-        auth_output = result.stdout
+        # Hackily check the output for required scopes
+        # Versions of gh before v2.31.0 print this info on stderr, not stdout.
+        # See https://github.com/cli/cli/issues/7447
+        auth_output = result.stdout + result.stderr
         if 'repo' not in auth_output:  # or 'workflow' not in auth_output:
             print_error("GitHub CLI token lacks required scopes.")
             print("Required scopes: repo, workflow")


### PR DESCRIPTION
Attempt to fix two issues with the `migrate_to_fork.py` script.

Issue one: [#mathlib4 > Feedback on scripts/migrate_to_fork.py @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Feedback.20on.20scripts.2Fmigrate_to_fork.2Epy/near/524059014)

It seems to be caused by `gh auth status` printing to stderr instead of stdout,
which was fixed in `gh` version 2.31.0. Thanks to @MichaelStollBayreuth for help with the investigation.

Issue two: [#mathlib4 > Feedback on scripts/migrate_to_fork.py @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Feedback.20on.20scripts.2Fmigrate_to_fork.2Epy/near/523889406)

I'm not sure if my patch actually fixes this problem, but I suspect it's caused
by non-utf-8 parsing of utf-8 gh output. The gh output includes non-ascii
characters, namely the check mark(s) in front of some lines. However, I didn't
get confirmation that this fixes the issue. The issue may also be linked with
issue one.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

