### PR TITLE
[Merged by Bors] - feat: add emoji reaction for PRs which were migrated to a fork

### DIFF
--- a/.github/workflows/zulip_emoji_closed_pr.yaml
+++ b/.github/workflows/zulip_emoji_closed_pr.yaml
@@ -62,5 +62,5 @@ jobs:
         run: |
           # ${{ github.event.action }} is either "closed" or "reopened"
           # We add the "closed-pr" emoji to the message, if it is "closed"
-          # and to remove the emoji if the action is "reopen".
+          # and remove the emoji if the action is "reopen".
           python scripts/zulip_emoji_reactions.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "${{ github.event.action }}" "none" "${{ github.event.pull_request.number }}"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -152,6 +152,8 @@ please do not add new entries to these files. PRs removing (the need for) entrie
   This reaction is ✌️ (`:peace_sign:`) for delegated, `:bors:` for PRs sent to bors,
   `:merge` for merged PRs, ✍️ (`:writing:`) for PRs awaiting-author,
   🔨 (`:hammer:`) for maintainer-merged PRs and `:closed-pr:` for closed PRs.
+  PRs which were migrated to a fork (as indicated by the `migrated-to-fork` label)
+  additionally receive a reaction ... (`skip_forward`).
   Two of these are custom emojis configured on zulip.
 - `late_importers.sh` is the main script used by the `latest_import.yml` action: it formats
   the `linter.minImports` output, summarizing the data in a table.  See the module docs of

--- a/scripts/migrate_to_fork.py
+++ b/scripts/migrate_to_fork.py
@@ -569,6 +569,7 @@ def create_new_pr_from_fork(branch: str, username: str, old_pr: Optional[Dict[st
 
                 original_body = pr_details.get('body', '') or ''
                 labels = pr_details.get('labels', [])
+                labels.append('migrated-to-fork')
 
                 # Prepare the new body with migration notice
                 if original_body.strip():

--- a/scripts/migrate_to_fork.py
+++ b/scripts/migrate_to_fork.py
@@ -570,6 +570,7 @@ def create_new_pr_from_fork(branch: str, username: str, old_pr: Optional[Dict[st
                 original_body = pr_details.get('body', '') or ''
                 labels = pr_details.get('labels', [])
                 labels.append('migrated-to-fork')
+                labels.append('migrated-from-branch')  # Add label for new PR
 
                 # Prepare the new body with migration notice
                 if original_body.strip():
@@ -661,6 +662,12 @@ def close_old_pr_and_comment(old_pr: Dict[str, Any], new_pr_url: str) -> None:
                     '--repo', 'leanprover-community/mathlib4',
                     '--body', comment])
         print_success("Added comment to old PR")
+
+        # Add migrated-to-fork label to old PR
+        run_command(['gh', 'pr', 'edit', str(old_pr['number']),
+                    '--repo', 'leanprover-community/mathlib4',
+                    '--add-label', 'migrated-to-fork'])
+        print_success("Added migrated-to-fork label to old PR")
 
         # Close old PR
         run_command(['gh', 'pr', 'close', str(old_pr['number']),

--- a/scripts/zulip_emoji_reactions.py
+++ b/scripts/zulip_emoji_reactions.py
@@ -125,6 +125,8 @@ for message in messages:
                 remove_reaction('maintainer-merge', 'hammer')
             continue
 
+        # We should never remove any "this PR was migrated from a fork" reaction.
+
         # Otherwise, remove all previous mutually exclusive emoji reactions.
         # If the emoji is a custom emoji, add the fields `emoji_code` and `reaction_type` as well.
         print("Removing previous reactions, if present.")
@@ -150,6 +152,8 @@ for message in messages:
             case 'labeled':
                 if LABEL_NAME == 'awaiting-author':
                     add_reaction('awaiting-author', 'writing')
+                elif LABEL_NAME == 'migrated-from-fork':
+                    add_reaction('migrated-to-fork', 'skip_forward')
             case 'unlabeled':
                 if LABEL_NAME == 'awaiting-author':
                     print('awaiting-author removed')

--- a/scripts/zulip_emoji_reactions.py
+++ b/scripts/zulip_emoji_reactions.py
@@ -152,8 +152,8 @@ for message in messages:
             case 'labeled':
                 if LABEL_NAME == 'awaiting-author':
                     add_reaction('awaiting-author', 'writing')
-                elif LABEL_NAME == 'migrated-from-fork':
-                    add_reaction('migrated-to-fork', 'skip_forward')
+                elif LABEL_NAME == 'migrated-from-branch':
+                    add_reaction('migrated-from-branch', 'skip_forward')
             case 'unlabeled':
                 if LABEL_NAME == 'awaiting-author':
                     print('awaiting-author removed')


### PR DESCRIPTION
This PR adds emoji reactions for PRs that were migrated to a fork-based workflow.

Changes:
1. In \`migrate_to_fork.py\`:
   - Add \`migrated-from-branch\` label to the new PR
   - Add \`migrated-to-fork\` label to the old PR

2. In \`zulip_emoji_reactions.py\`:
   - Add reaction handling for the \`migrated-from-branch\` label
   - Use consistent naming between labels and reactions

The workflow is now:
1. When a PR is migrated to a fork:
   - The old PR gets labeled with \`migrated-to-fork\`
   - The new PR gets labeled with \`migrated-from-branch\`
2. When the \`migrated-from-branch\` label is added, a \`skip_forward\` emoji reaction is added to the PR message in Zulip