### PR TITLE
[Merged by Bors] - chore: add `fun_` variants for Fréchet derivative of addition and like

### DIFF
--- a/Mathlib/Analysis/Calculus/ContDiff/FaaDiBruno.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/FaaDiBruno.lean
@@ -986,7 +986,7 @@ theorem HasFTaylorSeriesUpToOn.comp {n : WithTop ℕ∞} {g : F → G} {f : E �
     have B : HasFDerivWithinAt (fun x ↦ (q (f x)).taylorComp (p x) m)
         (∑ c : OrderedFinpartition m, ∑ i : Option (Fin c.length),
           ((q (f x)).compAlongOrderedFinpartition (p x) (c.extend i)).curryLeft) s x :=
-      HasFDerivWithinAt.sum (fun c _ ↦ A c)
+      HasFDerivWithinAt.fun_sum (fun c _ ↦ A c)
     suffices ∑ c : OrderedFinpartition m, ∑ i : Option (Fin c.length),
           ((q (f x)).compAlongOrderedFinpartition (p x) (c.extend i)) =
         (q (f x)).taylorComp (p x) (m + 1) by

--- a/Mathlib/Analysis/Calculus/ContDiff/Operations.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Operations.lean
@@ -282,7 +282,7 @@ theorem iteratedFDerivWithin_neg_apply {f : E → F} (hu : UniqueDiffOn 𝕜 s) 
       _ = fderivWithin 𝕜 (-iteratedFDerivWithin 𝕜 i f s) s x (h 0) (Fin.tail h) := by
         rw [fderivWithin_congr' (@hi) hx]; rfl
       _ = -(fderivWithin 𝕜 (iteratedFDerivWithin 𝕜 i f s) s) x (h 0) (Fin.tail h) := by
-        rw [Pi.neg_def, fderivWithin_neg (hu x hx)]; rfl
+        rw [fderivWithin_neg (hu x hx)]; rfl
       _ = -(iteratedFDerivWithin 𝕜 (i + 1) f s) x h := rfl
 
 theorem iteratedFDeriv_neg_apply {i : ℕ} {f : E → F} :

--- a/Mathlib/Analysis/Calculus/Deriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Add.lean
@@ -175,11 +175,11 @@ variable {ι : Type*} {u : Finset ι} {A : ι → 𝕜 → F} {A' : ι → F}
 
 theorem HasDerivAtFilter.sum (h : ∀ i ∈ u, HasDerivAtFilter (A i) (A' i) x L) :
     HasDerivAtFilter (fun y => ∑ i ∈ u, A i y) (∑ i ∈ u, A' i) x L := by
-  simpa [ContinuousLinearMap.sum_apply] using (HasFDerivAtFilter.sum h).hasDerivAtFilter
+  simpa [ContinuousLinearMap.sum_apply] using (HasFDerivAtFilter.fun_sum h).hasDerivAtFilter
 
 theorem HasStrictDerivAt.sum (h : ∀ i ∈ u, HasStrictDerivAt (A i) (A' i) x) :
     HasStrictDerivAt (fun y => ∑ i ∈ u, A i y) (∑ i ∈ u, A' i) x := by
-  simpa [ContinuousLinearMap.sum_apply] using (HasStrictFDerivAt.sum h).hasStrictDerivAt
+  simpa [ContinuousLinearMap.sum_apply] using (HasStrictFDerivAt.fun_sum h).hasStrictDerivAt
 
 theorem HasDerivWithinAt.sum (h : ∀ i ∈ u, HasDerivWithinAt (A i) (A' i) s x) :
     HasDerivWithinAt (fun y => ∑ i ∈ u, A i y) (∑ i ∈ u, A' i) s x :=
@@ -221,11 +221,11 @@ nonrec theorem HasStrictDerivAt.neg (h : HasStrictDerivAt f f' x) :
 
 theorem derivWithin.neg : derivWithin (fun y => -f y) s x = -derivWithin f s x := by
   by_cases hsx : UniqueDiffWithinAt 𝕜 s x
-  · simp only [derivWithin, fderivWithin_neg hsx, ContinuousLinearMap.neg_apply]
+  · simp only [derivWithin, fderivWithin_fun_neg hsx, ContinuousLinearMap.neg_apply]
   · simp [derivWithin_zero_of_not_uniqueDiffWithinAt hsx]
 
 theorem deriv.neg : deriv (fun y => -f y) x = -deriv f x := by
-  simp only [deriv, fderiv_neg, ContinuousLinearMap.neg_apply]
+  simp only [deriv, fderiv_fun_neg, ContinuousLinearMap.neg_apply]
 
 @[simp]
 theorem deriv.neg' : (deriv fun y => -f y) = fun x => -deriv f x :=
@@ -310,7 +310,7 @@ theorem HasStrictDerivAt.sub (hf : HasStrictDerivAt f f' x) (hg : HasStrictDeriv
 theorem derivWithin_sub (hf : DifferentiableWithinAt 𝕜 f s x)
     (hg : DifferentiableWithinAt 𝕜 g s x) :
     derivWithin (fun y => f y - g y) s x = derivWithin f s x - derivWithin g s x := by
-  simp only [sub_eq_add_neg, derivWithin_add hf hg.neg, derivWithin.neg]
+  simp only [sub_eq_add_neg, derivWithin_add hf hg.fun_neg, derivWithin.neg]
 
 @[simp]
 theorem deriv_sub (hf : DifferentiableAt 𝕜 f x) (hg : DifferentiableAt 𝕜 g x) :

--- a/Mathlib/Analysis/Calculus/FDeriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Add.lean
@@ -43,61 +43,100 @@ variable {R : Type*} [Semiring R] [Module R F] [SMulCommClass 𝕜 R F] [Continu
 /-! ### Derivative of a function multiplied by a constant -/
 
 @[fun_prop]
-theorem HasStrictFDerivAt.const_smul (h : HasStrictFDerivAt f f' x) (c : R) :
+theorem HasStrictFDerivAt.fun_const_smul (h : HasStrictFDerivAt f f' x) (c : R) :
     HasStrictFDerivAt (fun x => c • f x) (c • f') x :=
   (c • (1 : F →L[𝕜] F)).hasStrictFDerivAt.comp x h
 
-theorem HasFDerivAtFilter.const_smul (h : HasFDerivAtFilter f f' x L) (c : R) :
+@[fun_prop]
+theorem HasStrictFDerivAt.const_smul (h : HasStrictFDerivAt f f' x) (c : R) :
+    HasStrictFDerivAt (c • f) (c • f') x :=
+  h.fun_const_smul c
+
+theorem HasFDerivAtFilter.fun_const_smul (h : HasFDerivAtFilter f f' x L) (c : R) :
     HasFDerivAtFilter (fun x => c • f x) (c • f') x L :=
   (c • (1 : F →L[𝕜] F)).hasFDerivAtFilter.comp x h tendsto_map
 
+theorem HasFDerivAtFilter.const_smul (h : HasFDerivAtFilter f f' x L) (c : R) :
+    HasFDerivAtFilter (c • f) (c • f') x L :=
+  h.fun_const_smul c
+
 @[fun_prop]
-nonrec theorem HasFDerivWithinAt.const_smul (h : HasFDerivWithinAt f f' s x) (c : R) :
+nonrec theorem HasFDerivWithinAt.fun_const_smul (h : HasFDerivWithinAt f f' s x) (c : R) :
     HasFDerivWithinAt (fun x => c • f x) (c • f') s x :=
   h.const_smul c
 
 @[fun_prop]
-nonrec theorem HasFDerivAt.const_smul (h : HasFDerivAt f f' x) (c : R) :
+nonrec theorem HasFDerivWithinAt.const_smul (h : HasFDerivWithinAt f f' s x) (c : R) :
+    HasFDerivWithinAt (c • f) (c • f') s x :=
+  h.const_smul c
+
+@[fun_prop]
+nonrec theorem HasFDerivAt.fun_const_smul (h : HasFDerivAt f f' x) (c : R) :
     HasFDerivAt (fun x => c • f x) (c • f') x :=
   h.const_smul c
 
 @[fun_prop]
-theorem DifferentiableWithinAt.const_smul (h : DifferentiableWithinAt 𝕜 f s x) (c : R) :
+nonrec theorem HasFDerivAt.const_smul (h : HasFDerivAt f f' x) (c : R) :
+    HasFDerivAt (c • f) (c • f') x :=
+  h.const_smul c
+
+@[fun_prop]
+theorem DifferentiableWithinAt.fun_const_smul (h : DifferentiableWithinAt 𝕜 f s x) (c : R) :
     DifferentiableWithinAt 𝕜 (fun y => c • f y) s x :=
   (h.hasFDerivWithinAt.const_smul c).differentiableWithinAt
 
 @[fun_prop]
-theorem DifferentiableAt.const_smul (h : DifferentiableAt 𝕜 f x) (c : R) :
+theorem DifferentiableWithinAt.const_smul (h : DifferentiableWithinAt 𝕜 f s x) (c : R) :
+    DifferentiableWithinAt 𝕜 (c • f) s x :=
+  h.fun_const_smul c
+
+@[fun_prop]
+theorem DifferentiableAt.fun_const_smul (h : DifferentiableAt 𝕜 f x) (c : R) :
     DifferentiableAt 𝕜 (fun y => c • f y) x :=
   (h.hasFDerivAt.const_smul c).differentiableAt
 
 @[fun_prop]
-theorem DifferentiableOn.const_smul (h : DifferentiableOn 𝕜 f s) (c : R) :
+theorem DifferentiableAt.const_smul (h : DifferentiableAt 𝕜 f x) (c : R) :
+    DifferentiableAt 𝕜 (c • f) x :=
+  (h.hasFDerivAt.const_smul c).differentiableAt
+
+@[fun_prop]
+theorem DifferentiableOn.fun_const_smul (h : DifferentiableOn 𝕜 f s) (c : R) :
     DifferentiableOn 𝕜 (fun y => c • f y) s := fun x hx => (h x hx).const_smul c
 
 @[fun_prop]
-theorem Differentiable.const_smul (h : Differentiable 𝕜 f) (c : R) :
+theorem DifferentiableOn.const_smul (h : DifferentiableOn 𝕜 f s) (c : R) :
+    DifferentiableOn 𝕜 (c • f) s := fun x hx => (h x hx).const_smul c
+
+@[fun_prop]
+theorem Differentiable.fun_const_smul (h : Differentiable 𝕜 f) (c : R) :
     Differentiable 𝕜 fun y => c • f y := fun x => (h x).const_smul c
 
-theorem fderivWithin_const_smul (hxs : UniqueDiffWithinAt 𝕜 s x)
+@[fun_prop]
+theorem Differentiable.const_smul (h : Differentiable 𝕜 f) (c : R) :
+    Differentiable 𝕜 (c • f) := fun x => (h x).const_smul c
+
+theorem fderivWithin_fun_const_smul (hxs : UniqueDiffWithinAt 𝕜 s x)
     (h : DifferentiableWithinAt 𝕜 f s x) (c : R) :
     fderivWithin 𝕜 (fun y => c • f y) s x = c • fderivWithin 𝕜 f s x :=
   (h.hasFDerivWithinAt.const_smul c).fderivWithin hxs
 
-/-- Version of `fderivWithin_const_smul` written with `c • f` instead of `fun y ↦ c • f y`. -/
-theorem fderivWithin_const_smul' (hxs : UniqueDiffWithinAt 𝕜 s x)
+theorem fderivWithin_const_smul (hxs : UniqueDiffWithinAt 𝕜 s x)
     (h : DifferentiableWithinAt 𝕜 f s x) (c : R) :
     fderivWithin 𝕜 (c • f) s x = c • fderivWithin 𝕜 f s x :=
-  fderivWithin_const_smul hxs h c
+  fderivWithin_fun_const_smul hxs h c
 
-theorem fderiv_const_smul (h : DifferentiableAt 𝕜 f x) (c : R) :
+@[deprecated (since := "2025-06-14")] alias fderivWithin_const_smul' := fderivWithin_const_smul
+
+theorem fderiv_fun_const_smul (h : DifferentiableAt 𝕜 f x) (c : R) :
     fderiv 𝕜 (fun y => c • f y) x = c • fderiv 𝕜 f x :=
   (h.hasFDerivAt.const_smul c).fderiv
 
-/-- Version of `fderiv_const_smul` written with `c • f` instead of `fun y ↦ c • f y`. -/
-theorem fderiv_const_smul' (h : DifferentiableAt 𝕜 f x) (c : R) :
+theorem fderiv_const_smul (h : DifferentiableAt 𝕜 f x) (c : R) :
     fderiv 𝕜 (c • f) x = c • fderiv 𝕜 f x :=
   (h.hasFDerivAt.const_smul c).fderiv
+
+@[deprecated (since := "2025-06-14")] alias fderiv_const_smul' := fderiv_const_smul
 
 end ConstSMul
 
@@ -107,67 +146,104 @@ section Add
 
 
 @[fun_prop]
-nonrec theorem HasStrictFDerivAt.add (hf : HasStrictFDerivAt f f' x)
+nonrec theorem HasStrictFDerivAt.fun_add (hf : HasStrictFDerivAt f f' x)
     (hg : HasStrictFDerivAt g g' x) : HasStrictFDerivAt (fun y => f y + g y) (f' + g') x :=
    .of_isLittleO <| (hf.isLittleO.add hg.isLittleO).congr_left fun y => by
     simp only [LinearMap.sub_apply, LinearMap.add_apply, map_sub, map_add, add_apply]
     abel
 
-theorem HasFDerivAtFilter.add (hf : HasFDerivAtFilter f f' x L)
+@[fun_prop]
+nonrec theorem HasStrictFDerivAt.add (hf : HasStrictFDerivAt f f' x)
+    (hg : HasStrictFDerivAt g g' x) : HasStrictFDerivAt (f + g) (f' + g') x :=
+  hf.fun_add hg
+
+theorem HasFDerivAtFilter.fun_add (hf : HasFDerivAtFilter f f' x L)
     (hg : HasFDerivAtFilter g g' x L) : HasFDerivAtFilter (fun y => f y + g y) (f' + g') x L :=
   .of_isLittleO <| (hf.isLittleO.add hg.isLittleO).congr_left fun _ => by
     simp only [LinearMap.sub_apply, LinearMap.add_apply, map_sub, map_add, add_apply]
     abel
 
+theorem HasFDerivAtFilter.add (hf : HasFDerivAtFilter f f' x L)
+    (hg : HasFDerivAtFilter g g' x L) : HasFDerivAtFilter (f + g) (f' + g') x L :=
+  hf.fun_add hg
+
 @[fun_prop]
-nonrec theorem HasFDerivWithinAt.add (hf : HasFDerivWithinAt f f' s x)
+nonrec theorem HasFDerivWithinAt.fun_add (hf : HasFDerivWithinAt f f' s x)
     (hg : HasFDerivWithinAt g g' s x) : HasFDerivWithinAt (fun y => f y + g y) (f' + g') s x :=
   hf.add hg
 
 @[fun_prop]
-nonrec theorem HasFDerivAt.add (hf : HasFDerivAt f f' x) (hg : HasFDerivAt g g' x) :
+nonrec theorem HasFDerivWithinAt.add (hf : HasFDerivWithinAt f f' s x)
+    (hg : HasFDerivWithinAt g g' s x) : HasFDerivWithinAt (f + g) (f' + g') s x :=
+  hf.add hg
+
+@[fun_prop]
+nonrec theorem HasFDerivAt.fun_add (hf : HasFDerivAt f f' x) (hg : HasFDerivAt g g' x) :
     HasFDerivAt (fun x => f x + g x) (f' + g') x :=
   hf.add hg
 
 @[fun_prop]
-theorem DifferentiableWithinAt.add (hf : DifferentiableWithinAt 𝕜 f s x)
+nonrec theorem HasFDerivAt.add (hf : HasFDerivAt f f' x) (hg : HasFDerivAt g g' x) :
+    HasFDerivAt (f + g) (f' + g') x :=
+  hf.add hg
+
+@[fun_prop]
+theorem DifferentiableWithinAt.fun_add (hf : DifferentiableWithinAt 𝕜 f s x)
     (hg : DifferentiableWithinAt 𝕜 g s x) : DifferentiableWithinAt 𝕜 (fun y => f y + g y) s x :=
   (hf.hasFDerivWithinAt.add hg.hasFDerivWithinAt).differentiableWithinAt
 
+@[fun_prop]
+theorem DifferentiableWithinAt.add (hf : DifferentiableWithinAt 𝕜 f s x)
+    (hg : DifferentiableWithinAt 𝕜 g s x) : DifferentiableWithinAt 𝕜 (f + g) s x :=
+  (hf.hasFDerivWithinAt.add hg.hasFDerivWithinAt).differentiableWithinAt
+
 @[simp, fun_prop]
-theorem DifferentiableAt.add (hf : DifferentiableAt 𝕜 f x) (hg : DifferentiableAt 𝕜 g x) :
+theorem DifferentiableAt.fun_add (hf : DifferentiableAt 𝕜 f x) (hg : DifferentiableAt 𝕜 g x) :
     DifferentiableAt 𝕜 (fun y => f y + g y) x :=
   (hf.hasFDerivAt.add hg.hasFDerivAt).differentiableAt
 
+@[simp, fun_prop]
+theorem DifferentiableAt.add (hf : DifferentiableAt 𝕜 f x) (hg : DifferentiableAt 𝕜 g x) :
+    DifferentiableAt 𝕜 (f + g) x :=
+  (hf.hasFDerivAt.add hg.hasFDerivAt).differentiableAt
+
+@[fun_prop]
+theorem DifferentiableOn.fun_add (hf : DifferentiableOn 𝕜 f s) (hg : DifferentiableOn 𝕜 g s) :
+    DifferentiableOn 𝕜 (fun y => f y + g y) s := fun x hx => (hf x hx).add (hg x hx)
+
 @[fun_prop]
 theorem DifferentiableOn.add (hf : DifferentiableOn 𝕜 f s) (hg : DifferentiableOn 𝕜 g s) :
-    DifferentiableOn 𝕜 (fun y => f y + g y) s := fun x hx => (hf x hx).add (hg x hx)
+    DifferentiableOn 𝕜 (f + g) s := fun x hx => (hf x hx).add (hg x hx)
+
+@[simp, fun_prop]
+theorem Differentiable.fun_add (hf : Differentiable 𝕜 f) (hg : Differentiable 𝕜 g) :
+    Differentiable 𝕜 fun y => f y + g y := fun x => (hf x).add (hg x)
 
 @[simp, fun_prop]
 theorem Differentiable.add (hf : Differentiable 𝕜 f) (hg : Differentiable 𝕜 g) :
-    Differentiable 𝕜 fun y => f y + g y := fun x => (hf x).add (hg x)
+    Differentiable 𝕜 (f + g) := fun x => (hf x).add (hg x)
 
-theorem fderivWithin_add (hxs : UniqueDiffWithinAt 𝕜 s x) (hf : DifferentiableWithinAt 𝕜 f s x)
+theorem fderivWithin_fun_add (hxs : UniqueDiffWithinAt 𝕜 s x) (hf : DifferentiableWithinAt 𝕜 f s x)
     (hg : DifferentiableWithinAt 𝕜 g s x) :
     fderivWithin 𝕜 (fun y => f y + g y) s x = fderivWithin 𝕜 f s x + fderivWithin 𝕜 g s x :=
   (hf.hasFDerivWithinAt.add hg.hasFDerivWithinAt).fderivWithin hxs
 
-/-- Version of `fderivWithin_add` where the function is written as `f + g` instead
-of `fun y ↦ f y + g y`. -/
-theorem fderivWithin_add' (hxs : UniqueDiffWithinAt 𝕜 s x) (hf : DifferentiableWithinAt 𝕜 f s x)
+theorem fderivWithin_add (hxs : UniqueDiffWithinAt 𝕜 s x) (hf : DifferentiableWithinAt 𝕜 f s x)
     (hg : DifferentiableWithinAt 𝕜 g s x) :
     fderivWithin 𝕜 (f + g) s x = fderivWithin 𝕜 f s x + fderivWithin 𝕜 g s x :=
-  fderivWithin_add hxs hf hg
+  fderivWithin_fun_add hxs hf hg
 
-theorem fderiv_add (hf : DifferentiableAt 𝕜 f x) (hg : DifferentiableAt 𝕜 g x) :
+@[deprecated (since := "2025-06-14")] alias fderivWithin_add' := fderivWithin_add
+
+theorem fderiv_fun_add (hf : DifferentiableAt 𝕜 f x) (hg : DifferentiableAt 𝕜 g x) :
     fderiv 𝕜 (fun y => f y + g y) x = fderiv 𝕜 f x + fderiv 𝕜 g x :=
   (hf.hasFDerivAt.add hg.hasFDerivAt).fderiv
 
-/-- Version of `fderiv_add` where the function is written as `f + g` instead
-of `fun y ↦ f y + g y`. -/
-theorem fderiv_add' (hf : DifferentiableAt 𝕜 f x) (hg : DifferentiableAt 𝕜 g x) :
+theorem fderiv_add (hf : DifferentiableAt 𝕜 f x) (hg : DifferentiableAt 𝕜 g x) :
     fderiv 𝕜 (f + g) x = fderiv 𝕜 f x + fderiv 𝕜 g x :=
-  fderiv_add hf hg
+  fderiv_fun_add hf hg
+
+@[deprecated (since := "2025-06-14")] alias fderiv_add' := fderiv_add
 
 @[simp]
 theorem hasFDerivAtFilter_add_const_iff (c : F) :
@@ -321,55 +397,104 @@ section Sum
 variable {ι : Type*} {u : Finset ι} {A : ι → E → F} {A' : ι → E →L[𝕜] F}
 
 @[fun_prop]
-theorem HasStrictFDerivAt.sum (h : ∀ i ∈ u, HasStrictFDerivAt (A i) (A' i) x) :
+theorem HasStrictFDerivAt.fun_sum (h : ∀ i ∈ u, HasStrictFDerivAt (A i) (A' i) x) :
     HasStrictFDerivAt (fun y => ∑ i ∈ u, A i y) (∑ i ∈ u, A' i) x := by
   simp only [hasStrictFDerivAt_iff_isLittleO] at *
   convert IsLittleO.sum h
   simp [Finset.sum_sub_distrib, ContinuousLinearMap.sum_apply]
 
-theorem HasFDerivAtFilter.sum (h : ∀ i ∈ u, HasFDerivAtFilter (A i) (A' i) x L) :
+@[fun_prop]
+theorem HasStrictFDerivAt.sum (h : ∀ i ∈ u, HasStrictFDerivAt (A i) (A' i) x) :
+    HasStrictFDerivAt (∑ i ∈ u, A i) (∑ i ∈ u, A' i) x := by
+  convert HasStrictFDerivAt.fun_sum h; simp
+
+theorem HasFDerivAtFilter.fun_sum (h : ∀ i ∈ u, HasFDerivAtFilter (A i) (A' i) x L) :
     HasFDerivAtFilter (fun y => ∑ i ∈ u, A i y) (∑ i ∈ u, A' i) x L := by
   simp only [hasFDerivAtFilter_iff_isLittleO] at *
   convert IsLittleO.sum h
   simp [ContinuousLinearMap.sum_apply]
 
+theorem HasFDerivAtFilter.sum (h : ∀ i ∈ u, HasFDerivAtFilter (A i) (A' i) x L) :
+    HasFDerivAtFilter (∑ i ∈ u, A i) (∑ i ∈ u, A' i) x L := by
+  convert HasFDerivAtFilter.fun_sum h; simp
+
+@[fun_prop]
+theorem HasFDerivWithinAt.fun_sum (h : ∀ i ∈ u, HasFDerivWithinAt (A i) (A' i) s x) :
+    HasFDerivWithinAt (fun y => ∑ i ∈ u, A i y) (∑ i ∈ u, A' i) s x :=
+  HasFDerivAtFilter.fun_sum h
+
 @[fun_prop]
 theorem HasFDerivWithinAt.sum (h : ∀ i ∈ u, HasFDerivWithinAt (A i) (A' i) s x) :
-    HasFDerivWithinAt (fun y => ∑ i ∈ u, A i y) (∑ i ∈ u, A' i) s x :=
+    HasFDerivWithinAt (∑ i ∈ u, A i) (∑ i ∈ u, A' i) s x :=
   HasFDerivAtFilter.sum h
+
+@[fun_prop]
+theorem HasFDerivAt.fun_sum (h : ∀ i ∈ u, HasFDerivAt (A i) (A' i) x) :
+    HasFDerivAt (fun y => ∑ i ∈ u, A i y) (∑ i ∈ u, A' i) x :=
+  HasFDerivAtFilter.fun_sum h
 
 @[fun_prop]
 theorem HasFDerivAt.sum (h : ∀ i ∈ u, HasFDerivAt (A i) (A' i) x) :
-    HasFDerivAt (fun y => ∑ i ∈ u, A i y) (∑ i ∈ u, A' i) x :=
+    HasFDerivAt (∑ i ∈ u, A i) (∑ i ∈ u, A' i) x :=
   HasFDerivAtFilter.sum h
 
 @[fun_prop]
-theorem DifferentiableWithinAt.sum (h : ∀ i ∈ u, DifferentiableWithinAt 𝕜 (A i) s x) :
+theorem DifferentiableWithinAt.fun_sum (h : ∀ i ∈ u, DifferentiableWithinAt 𝕜 (A i) s x) :
     DifferentiableWithinAt 𝕜 (fun y => ∑ i ∈ u, A i y) s x :=
+  HasFDerivWithinAt.differentiableWithinAt <|
+    HasFDerivWithinAt.fun_sum fun i hi => (h i hi).hasFDerivWithinAt
+
+@[fun_prop]
+theorem DifferentiableWithinAt.sum (h : ∀ i ∈ u, DifferentiableWithinAt 𝕜 (A i) s x) :
+    DifferentiableWithinAt 𝕜 (∑ i ∈ u, A i) s x :=
   HasFDerivWithinAt.differentiableWithinAt <|
     HasFDerivWithinAt.sum fun i hi => (h i hi).hasFDerivWithinAt
 
 @[simp, fun_prop]
-theorem DifferentiableAt.sum (h : ∀ i ∈ u, DifferentiableAt 𝕜 (A i) x) :
+theorem DifferentiableAt.fun_sum (h : ∀ i ∈ u, DifferentiableAt 𝕜 (A i) x) :
     DifferentiableAt 𝕜 (fun y => ∑ i ∈ u, A i y) x :=
+  HasFDerivAt.differentiableAt <| HasFDerivAt.fun_sum fun i hi => (h i hi).hasFDerivAt
+
+@[simp, fun_prop]
+theorem DifferentiableAt.sum (h : ∀ i ∈ u, DifferentiableAt 𝕜 (A i) x) :
+    DifferentiableAt 𝕜 (∑ i ∈ u, A i) x :=
   HasFDerivAt.differentiableAt <| HasFDerivAt.sum fun i hi => (h i hi).hasFDerivAt
 
 @[fun_prop]
-theorem DifferentiableOn.sum (h : ∀ i ∈ u, DifferentiableOn 𝕜 (A i) s) :
+theorem DifferentiableOn.fun_sum (h : ∀ i ∈ u, DifferentiableOn 𝕜 (A i) s) :
     DifferentiableOn 𝕜 (fun y => ∑ i ∈ u, A i y) s := fun x hx =>
+  DifferentiableWithinAt.fun_sum fun i hi => h i hi x hx
+
+@[fun_prop]
+theorem DifferentiableOn.sum (h : ∀ i ∈ u, DifferentiableOn 𝕜 (A i) s) :
+    DifferentiableOn 𝕜 (∑ i ∈ u, A i) s := fun x hx =>
   DifferentiableWithinAt.sum fun i hi => h i hi x hx
 
 @[simp, fun_prop]
+theorem Differentiable.fun_sum (h : ∀ i ∈ u, Differentiable 𝕜 (A i)) :
+    Differentiable 𝕜 fun y => ∑ i ∈ u, A i y :=
+  fun x => DifferentiableAt.fun_sum fun i hi => h i hi x
+
+@[simp, fun_prop]
 theorem Differentiable.sum (h : ∀ i ∈ u, Differentiable 𝕜 (A i)) :
-    Differentiable 𝕜 fun y => ∑ i ∈ u, A i y := fun x => DifferentiableAt.sum fun i hi => h i hi x
+    Differentiable 𝕜 (∑ i ∈ u, A i) := fun x => DifferentiableAt.sum fun i hi => h i hi x
+
+theorem fderivWithin_fun_sum (hxs : UniqueDiffWithinAt 𝕜 s x)
+    (h : ∀ i ∈ u, DifferentiableWithinAt 𝕜 (A i) s x) :
+    fderivWithin 𝕜 (fun y => ∑ i ∈ u, A i y) s x = ∑ i ∈ u, fderivWithin 𝕜 (A i) s x :=
+  (HasFDerivWithinAt.fun_sum fun i hi => (h i hi).hasFDerivWithinAt).fderivWithin hxs
 
 theorem fderivWithin_sum (hxs : UniqueDiffWithinAt 𝕜 s x)
     (h : ∀ i ∈ u, DifferentiableWithinAt 𝕜 (A i) s x) :
-    fderivWithin 𝕜 (fun y => ∑ i ∈ u, A i y) s x = ∑ i ∈ u, fderivWithin 𝕜 (A i) s x :=
+    fderivWithin 𝕜 (∑ i ∈ u, A i) s x = ∑ i ∈ u, fderivWithin 𝕜 (A i) s x :=
   (HasFDerivWithinAt.sum fun i hi => (h i hi).hasFDerivWithinAt).fderivWithin hxs
 
-theorem fderiv_sum (h : ∀ i ∈ u, DifferentiableAt 𝕜 (A i) x) :
+theorem fderiv_fun_sum (h : ∀ i ∈ u, DifferentiableAt 𝕜 (A i) x) :
     fderiv 𝕜 (fun y => ∑ i ∈ u, A i y) x = ∑ i ∈ u, fderiv 𝕜 (A i) x :=
+  (HasFDerivAt.fun_sum fun i hi => (h i hi).hasFDerivAt).fderiv
+
+theorem fderiv_sum (h : ∀ i ∈ u, DifferentiableAt 𝕜 (A i) x) :
+    fderiv 𝕜 (∑ i ∈ u, A i) x = ∑ i ∈ u, fderiv 𝕜 (A i) x :=
   (HasFDerivAt.sum fun i hi => (h i hi).hasFDerivAt).fderiv
 
 end Sum
@@ -380,58 +505,114 @@ section Neg
 
 
 @[fun_prop]
-theorem HasStrictFDerivAt.neg (h : HasStrictFDerivAt f f' x) :
+theorem HasStrictFDerivAt.fun_neg (h : HasStrictFDerivAt f f' x) :
     HasStrictFDerivAt (fun x => -f x) (-f') x :=
   (-1 : F →L[𝕜] F).hasStrictFDerivAt.comp x h
 
-theorem HasFDerivAtFilter.neg (h : HasFDerivAtFilter f f' x L) :
+@[fun_prop]
+theorem HasStrictFDerivAt.neg (h : HasStrictFDerivAt f f' x) :
+    HasStrictFDerivAt (-f) (-f') x :=
+  (-1 : F →L[𝕜] F).hasStrictFDerivAt.comp x h
+
+theorem HasFDerivAtFilter.fun_neg (h : HasFDerivAtFilter f f' x L) :
     HasFDerivAtFilter (fun x => -f x) (-f') x L :=
   (-1 : F →L[𝕜] F).hasFDerivAtFilter.comp x h tendsto_map
 
+theorem HasFDerivAtFilter.neg (h : HasFDerivAtFilter f f' x L) :
+    HasFDerivAtFilter (-f) (-f') x L :=
+  (-1 : F →L[𝕜] F).hasFDerivAtFilter.comp x h tendsto_map
+
 @[fun_prop]
-nonrec theorem HasFDerivWithinAt.neg (h : HasFDerivWithinAt f f' s x) :
+nonrec theorem HasFDerivWithinAt.fun_neg (h : HasFDerivWithinAt f f' s x) :
     HasFDerivWithinAt (fun x => -f x) (-f') s x :=
   h.neg
 
 @[fun_prop]
-nonrec theorem HasFDerivAt.neg (h : HasFDerivAt f f' x) : HasFDerivAt (fun x => -f x) (-f') x :=
+nonrec theorem HasFDerivWithinAt.neg (h : HasFDerivWithinAt f f' s x) :
+    HasFDerivWithinAt (-f) (-f') s x :=
   h.neg
 
 @[fun_prop]
-theorem DifferentiableWithinAt.neg (h : DifferentiableWithinAt 𝕜 f s x) :
+nonrec theorem HasFDerivAt.fun_neg (h : HasFDerivAt f f' x) : HasFDerivAt (fun x => -f x) (-f') x :=
+  h.neg
+
+@[fun_prop]
+nonrec theorem HasFDerivAt.neg (h : HasFDerivAt f f' x) : HasFDerivAt (-f) (-f') x :=
+  h.neg
+
+@[fun_prop]
+theorem DifferentiableWithinAt.fun_neg (h : DifferentiableWithinAt 𝕜 f s x) :
     DifferentiableWithinAt 𝕜 (fun y => -f y) s x :=
   h.hasFDerivWithinAt.neg.differentiableWithinAt
 
+@[fun_prop]
+theorem DifferentiableWithinAt.neg (h : DifferentiableWithinAt 𝕜 f s x) :
+    DifferentiableWithinAt 𝕜 (-f) s x :=
+  h.hasFDerivWithinAt.neg.differentiableWithinAt
+
+@[simp]
+theorem differentiableWithinAt_fun_neg_iff :
+    DifferentiableWithinAt 𝕜 (fun y => -f y) s x ↔ DifferentiableWithinAt 𝕜 f s x :=
+  ⟨fun h => by simpa only [neg_neg] using h.fun_neg, fun h => h.neg⟩
+
 @[simp]
 theorem differentiableWithinAt_neg_iff :
-    DifferentiableWithinAt 𝕜 (fun y => -f y) s x ↔ DifferentiableWithinAt 𝕜 f s x :=
+    DifferentiableWithinAt 𝕜 (-f) s x ↔ DifferentiableWithinAt 𝕜 f s x :=
   ⟨fun h => by simpa only [neg_neg] using h.neg, fun h => h.neg⟩
 
 @[fun_prop]
-theorem DifferentiableAt.neg (h : DifferentiableAt 𝕜 f x) : DifferentiableAt 𝕜 (fun y => -f y) x :=
+theorem DifferentiableAt.fun_neg (h : DifferentiableAt 𝕜 f x) :
+    DifferentiableAt 𝕜 (fun y => -f y) x :=
+  h.hasFDerivAt.neg.differentiableAt
+
+@[fun_prop]
+theorem DifferentiableAt.neg (h : DifferentiableAt 𝕜 f x) : DifferentiableAt 𝕜 (-f) x :=
   h.hasFDerivAt.neg.differentiableAt
 
 @[simp]
-theorem differentiableAt_neg_iff : DifferentiableAt 𝕜 (fun y => -f y) x ↔ DifferentiableAt 𝕜 f x :=
+theorem differentiableAt_fun_neg_iff :
+    DifferentiableAt 𝕜 (fun y => -f y) x ↔ DifferentiableAt 𝕜 f x :=
+  ⟨fun h => by simpa only [neg_neg] using h.fun_neg, fun h => h.neg⟩
+
+@[simp]
+theorem differentiableAt_neg_iff : DifferentiableAt 𝕜 (-f) x ↔ DifferentiableAt 𝕜 f x :=
   ⟨fun h => by simpa only [neg_neg] using h.neg, fun h => h.neg⟩
 
 @[fun_prop]
-theorem DifferentiableOn.neg (h : DifferentiableOn 𝕜 f s) : DifferentiableOn 𝕜 (fun y => -f y) s :=
+theorem DifferentiableOn.fun_neg (h : DifferentiableOn 𝕜 f s) :
+    DifferentiableOn 𝕜 (fun y => -f y) s :=
+  fun x hx => (h x hx).neg
+
+@[fun_prop]
+theorem DifferentiableOn.neg (h : DifferentiableOn 𝕜 f s) : DifferentiableOn 𝕜 (-f) s :=
   fun x hx => (h x hx).neg
 
 @[simp]
-theorem differentiableOn_neg_iff : DifferentiableOn 𝕜 (fun y => -f y) s ↔ DifferentiableOn 𝕜 f s :=
+theorem differentiableOn_fun_neg_iff :
+    DifferentiableOn 𝕜 (fun y => -f y) s ↔ DifferentiableOn 𝕜 f s :=
+  ⟨fun h => by simpa only [neg_neg] using h.fun_neg, fun h => h.neg⟩
+
+@[simp]
+theorem differentiableOn_neg_iff : DifferentiableOn 𝕜 (-f) s ↔ DifferentiableOn 𝕜 f s :=
   ⟨fun h => by simpa only [neg_neg] using h.neg, fun h => h.neg⟩
 
 @[fun_prop]
-theorem Differentiable.neg (h : Differentiable 𝕜 f) : Differentiable 𝕜 fun y => -f y := fun x =>
+theorem Differentiable.fun_neg (h : Differentiable 𝕜 f) : Differentiable 𝕜 fun y => -f y := fun x =>
+  (h x).neg
+
+@[fun_prop]
+theorem Differentiable.neg (h : Differentiable 𝕜 f) : Differentiable 𝕜 (-f) := fun x =>
   (h x).neg
 
 @[simp]
-theorem differentiable_neg_iff : (Differentiable 𝕜 fun y => -f y) ↔ Differentiable 𝕜 f :=
+theorem differentiable_fun_neg_iff : (Differentiable 𝕜 fun y => -f y) ↔ Differentiable 𝕜 f :=
+  ⟨fun h => by simpa only [neg_neg] using h.fun_neg, fun h => h.neg⟩
+
+@[simp]
+theorem differentiable_neg_iff : Differentiable 𝕜 (-f) ↔ Differentiable 𝕜 f :=
   ⟨fun h => by simpa only [neg_neg] using h.neg, fun h => h.neg⟩
 
-theorem fderivWithin_neg (hxs : UniqueDiffWithinAt 𝕜 s x) :
+theorem fderivWithin_fun_neg (hxs : UniqueDiffWithinAt 𝕜 s x) :
     fderivWithin 𝕜 (fun y => -f y) s x = -fderivWithin 𝕜 f s x := by
   classical
   by_cases h : DifferentiableWithinAt 𝕜 f s x
@@ -440,18 +621,21 @@ theorem fderivWithin_neg (hxs : UniqueDiffWithinAt 𝕜 s x) :
       fderivWithin_zero_of_not_differentiableWithinAt, neg_zero]
     simpa
 
-/-- Version of `fderivWithin_neg` where the function is written `-f` instead of `fun y ↦ - f y`. -/
-theorem fderivWithin_neg' (hxs : UniqueDiffWithinAt 𝕜 s x) :
+theorem fderivWithin_neg (hxs : UniqueDiffWithinAt 𝕜 s x) :
     fderivWithin 𝕜 (-f) s x = -fderivWithin 𝕜 f s x :=
-  fderivWithin_neg hxs
+  fderivWithin_fun_neg hxs
+
+@[deprecated (since := "2025-06-14")] alias fderivWithin_neg' := fderivWithin_neg
 
 @[simp]
-theorem fderiv_neg : fderiv 𝕜 (fun y => -f y) x = -fderiv 𝕜 f x := by
-  simp only [← fderivWithin_univ, fderivWithin_neg uniqueDiffWithinAt_univ]
+theorem fderiv_fun_neg : fderiv 𝕜 (fun y => -f y) x = -fderiv 𝕜 f x := by
+  simp only [← fderivWithin_univ, fderivWithin_fun_neg uniqueDiffWithinAt_univ]
 
 /-- Version of `fderiv_neg` where the function is written `-f` instead of `fun y ↦ - f y`. -/
-theorem fderiv_neg' : fderiv 𝕜 (-f) x = -fderiv 𝕜 f x :=
-  fderiv_neg
+theorem fderiv_neg : fderiv 𝕜 (-f) x = -fderiv 𝕜 f x :=
+  fderiv_fun_neg
+
+@[deprecated (since := "2025-06-14")] alias fderiv_neg' := fderiv_neg
 
 end Neg
 
@@ -461,126 +645,224 @@ section Sub
 
 
 @[fun_prop]
-theorem HasStrictFDerivAt.sub (hf : HasStrictFDerivAt f f' x) (hg : HasStrictFDerivAt g g' x) :
+theorem HasStrictFDerivAt.fun_sub (hf : HasStrictFDerivAt f f' x) (hg : HasStrictFDerivAt g g' x) :
     HasStrictFDerivAt (fun x => f x - g x) (f' - g') x := by
   simpa only [sub_eq_add_neg] using hf.add hg.neg
 
-theorem HasFDerivAtFilter.sub (hf : HasFDerivAtFilter f f' x L) (hg : HasFDerivAtFilter g g' x L) :
+@[fun_prop]
+theorem HasStrictFDerivAt.sub (hf : HasStrictFDerivAt f f' x) (hg : HasStrictFDerivAt g g' x) :
+    HasStrictFDerivAt (f - g) (f' - g') x :=
+  hf.fun_sub hg
+
+theorem HasFDerivAtFilter.fun_sub (hf : HasFDerivAtFilter f f' x L)
+    (hg : HasFDerivAtFilter g g' x L) :
     HasFDerivAtFilter (fun x => f x - g x) (f' - g') x L := by
   simpa only [sub_eq_add_neg] using hf.add hg.neg
 
+theorem HasFDerivAtFilter.sub (hf : HasFDerivAtFilter f f' x L) (hg : HasFDerivAtFilter g g' x L) :
+    HasFDerivAtFilter (f - g) (f' - g') x L :=
+  hf.fun_sub hg
+
 @[fun_prop]
-nonrec theorem HasFDerivWithinAt.sub (hf : HasFDerivWithinAt f f' s x)
+nonrec theorem HasFDerivWithinAt.fun_sub (hf : HasFDerivWithinAt f f' s x)
     (hg : HasFDerivWithinAt g g' s x) : HasFDerivWithinAt (fun x => f x - g x) (f' - g') s x :=
   hf.sub hg
 
 @[fun_prop]
-nonrec theorem HasFDerivAt.sub (hf : HasFDerivAt f f' x) (hg : HasFDerivAt g g' x) :
+nonrec theorem HasFDerivWithinAt.sub (hf : HasFDerivWithinAt f f' s x)
+    (hg : HasFDerivWithinAt g g' s x) : HasFDerivWithinAt (f - g) (f' - g') s x :=
+  hf.sub hg
+
+@[fun_prop]
+nonrec theorem HasFDerivAt.fun_sub (hf : HasFDerivAt f f' x) (hg : HasFDerivAt g g' x) :
     HasFDerivAt (fun x => f x - g x) (f' - g') x :=
   hf.sub hg
 
 @[fun_prop]
-theorem DifferentiableWithinAt.sub (hf : DifferentiableWithinAt 𝕜 f s x)
+nonrec theorem HasFDerivAt.sub (hf : HasFDerivAt f f' x) (hg : HasFDerivAt g g' x) :
+    HasFDerivAt (f - g) (f' - g') x :=
+  hf.sub hg
+
+@[fun_prop]
+theorem DifferentiableWithinAt.fun_sub (hf : DifferentiableWithinAt 𝕜 f s x)
     (hg : DifferentiableWithinAt 𝕜 g s x) : DifferentiableWithinAt 𝕜 (fun y => f y - g y) s x :=
   (hf.hasFDerivWithinAt.sub hg.hasFDerivWithinAt).differentiableWithinAt
 
+@[fun_prop]
+theorem DifferentiableWithinAt.sub (hf : DifferentiableWithinAt 𝕜 f s x)
+    (hg : DifferentiableWithinAt 𝕜 g s x) : DifferentiableWithinAt 𝕜 (f - g) s x :=
+  hf.fun_sub hg
+
 @[simp, fun_prop]
-theorem DifferentiableAt.sub (hf : DifferentiableAt 𝕜 f x) (hg : DifferentiableAt 𝕜 g x) :
+theorem DifferentiableAt.fun_sub (hf : DifferentiableAt 𝕜 f x) (hg : DifferentiableAt 𝕜 g x) :
     DifferentiableAt 𝕜 (fun y => f y - g y) x :=
   (hf.hasFDerivAt.sub hg.hasFDerivAt).differentiableAt
 
+@[simp, fun_prop]
+theorem DifferentiableAt.sub (hf : DifferentiableAt 𝕜 f x) (hg : DifferentiableAt 𝕜 g x) :
+    DifferentiableAt 𝕜 (f - g) x :=
+  hf.fun_sub hg
+
 @[simp]
-lemma DifferentiableAt.add_iff_left (hg : DifferentiableAt 𝕜 g x) :
+lemma DifferentiableAt.fun_add_iff_left (hg : DifferentiableAt 𝕜 g x) :
     DifferentiableAt 𝕜 (fun y => f y + g y) x ↔ DifferentiableAt 𝕜 f x := by
   refine ⟨fun h ↦ ?_, fun hf ↦ hf.add hg⟩
-  simpa only [add_sub_cancel_right] using h.sub hg
+  simpa only [add_sub_cancel_right] using h.fun_sub hg
+
+@[simp]
+lemma DifferentiableAt.add_iff_left (hg : DifferentiableAt 𝕜 g x) :
+    DifferentiableAt 𝕜 (f + g) x ↔ DifferentiableAt 𝕜 f x :=
+  hg.fun_add_iff_left
+
+@[simp]
+lemma DifferentiableAt.fun_add_iff_right (hg : DifferentiableAt 𝕜 f x) :
+    DifferentiableAt 𝕜 (fun y => f y + g y) x ↔ DifferentiableAt 𝕜 g x := by
+  simp only [add_comm (f _), hg.fun_add_iff_left]
 
 @[simp]
 lemma DifferentiableAt.add_iff_right (hg : DifferentiableAt 𝕜 f x) :
-    DifferentiableAt 𝕜 (fun y => f y + g y) x ↔ DifferentiableAt 𝕜 g x := by
-  simp only [add_comm (f _), hg.add_iff_left]
+    DifferentiableAt 𝕜 (f + g) x ↔ DifferentiableAt 𝕜 g x :=
+  hg.fun_add_iff_right
+
+@[simp]
+lemma DifferentiableAt.fun_sub_iff_left (hg : DifferentiableAt 𝕜 g x) :
+    DifferentiableAt 𝕜 (fun y => f y - g y) x ↔ DifferentiableAt 𝕜 f x := by
+  simp only [sub_eq_add_neg, differentiableAt_fun_neg_iff, hg, fun_add_iff_left]
 
 @[simp]
 lemma DifferentiableAt.sub_iff_left (hg : DifferentiableAt 𝕜 g x) :
-    DifferentiableAt 𝕜 (fun y => f y - g y) x ↔ DifferentiableAt 𝕜 f x := by
-  simp only [sub_eq_add_neg, differentiableAt_neg_iff, hg, add_iff_left]
+    DifferentiableAt 𝕜 (f - g) x ↔ DifferentiableAt 𝕜 f x :=
+  hg.fun_sub_iff_left
+
+@[simp]
+lemma DifferentiableAt.fun_sub_iff_right (hg : DifferentiableAt 𝕜 f x) :
+    DifferentiableAt 𝕜 (fun y => f y - g y) x ↔ DifferentiableAt 𝕜 g x := by
+  simp only [sub_eq_add_neg, hg, fun_add_iff_right, differentiableAt_fun_neg_iff]
 
 @[simp]
 lemma DifferentiableAt.sub_iff_right (hg : DifferentiableAt 𝕜 f x) :
-    DifferentiableAt 𝕜 (fun y => f y - g y) x ↔ DifferentiableAt 𝕜 g x := by
-  simp only [sub_eq_add_neg, hg, add_iff_right, differentiableAt_neg_iff]
+    DifferentiableAt 𝕜 (f - g) x ↔ DifferentiableAt 𝕜 g x :=
+  hg.fun_sub_iff_right
+
+@[fun_prop]
+theorem DifferentiableOn.fun_sub (hf : DifferentiableOn 𝕜 f s) (hg : DifferentiableOn 𝕜 g s) :
+    DifferentiableOn 𝕜 (fun y => f y - g y) s := fun x hx => (hf x hx).sub (hg x hx)
 
 @[fun_prop]
 theorem DifferentiableOn.sub (hf : DifferentiableOn 𝕜 f s) (hg : DifferentiableOn 𝕜 g s) :
-    DifferentiableOn 𝕜 (fun y => f y - g y) s := fun x hx => (hf x hx).sub (hg x hx)
+    DifferentiableOn 𝕜 (f - g) s := fun x hx => (hf x hx).sub (hg x hx)
+
+@[simp]
+lemma DifferentiableOn.fun_add_iff_left (hg : DifferentiableOn 𝕜 g s) :
+    DifferentiableOn 𝕜 (fun y => f y + g y) s ↔ DifferentiableOn 𝕜 f s := by
+  refine ⟨fun h ↦ ?_, fun hf ↦ hf.add hg⟩
+  simpa only [add_sub_cancel_right] using h.fun_sub hg
 
 @[simp]
 lemma DifferentiableOn.add_iff_left (hg : DifferentiableOn 𝕜 g s) :
-    DifferentiableOn 𝕜 (fun y => f y + g y) s ↔ DifferentiableOn 𝕜 f s := by
-  refine ⟨fun h ↦ ?_, fun hf ↦ hf.add hg⟩
-  simpa only [add_sub_cancel_right] using h.sub hg
+    DifferentiableOn 𝕜 (f + g) s ↔ DifferentiableOn 𝕜 f s :=
+  hg.fun_add_iff_left
+
+@[simp]
+lemma DifferentiableOn.fun_add_iff_right (hg : DifferentiableOn 𝕜 f s) :
+    DifferentiableOn 𝕜 (fun y => f y + g y) s ↔ DifferentiableOn 𝕜 g s := by
+  simp only [add_comm (f _), hg.fun_add_iff_left]
 
 @[simp]
 lemma DifferentiableOn.add_iff_right (hg : DifferentiableOn 𝕜 f s) :
-    DifferentiableOn 𝕜 (fun y => f y + g y) s ↔ DifferentiableOn 𝕜 g s := by
-  simp only [add_comm (f _), hg.add_iff_left]
+    DifferentiableOn 𝕜 (f + g) s ↔ DifferentiableOn 𝕜 g s :=
+  hg.fun_add_iff_right
+
+@[simp]
+lemma DifferentiableOn.fun_sub_iff_left (hg : DifferentiableOn 𝕜 g s) :
+    DifferentiableOn 𝕜 (fun y => f y - g y) s ↔ DifferentiableOn 𝕜 f s := by
+  simp only [sub_eq_add_neg, differentiableOn_fun_neg_iff, hg, fun_add_iff_left]
 
 @[simp]
 lemma DifferentiableOn.sub_iff_left (hg : DifferentiableOn 𝕜 g s) :
-    DifferentiableOn 𝕜 (fun y => f y - g y) s ↔ DifferentiableOn 𝕜 f s := by
-  simp only [sub_eq_add_neg, differentiableOn_neg_iff, hg, add_iff_left]
+    DifferentiableOn 𝕜 (f - g) s ↔ DifferentiableOn 𝕜 f s :=
+  hg.fun_sub_iff_left
+
+@[simp]
+lemma DifferentiableOn.fun_sub_iff_right (hg : DifferentiableOn 𝕜 f s) :
+    DifferentiableOn 𝕜 (fun y => f y - g y) s ↔ DifferentiableOn 𝕜 g s := by
+  simp only [sub_eq_add_neg, differentiableOn_fun_neg_iff, hg, fun_add_iff_right]
 
 @[simp]
 lemma DifferentiableOn.sub_iff_right (hg : DifferentiableOn 𝕜 f s) :
-    DifferentiableOn 𝕜 (fun y => f y - g y) s ↔ DifferentiableOn 𝕜 g s := by
-  simp only [sub_eq_add_neg, differentiableOn_neg_iff, hg, add_iff_right]
+    DifferentiableOn 𝕜 (f - g) s ↔ DifferentiableOn 𝕜 g s :=
+  hg.fun_sub_iff_right
+
+@[simp, fun_prop]
+theorem Differentiable.fun_sub (hf : Differentiable 𝕜 f) (hg : Differentiable 𝕜 g) :
+    Differentiable 𝕜 fun y => f y - g y := fun x => (hf x).sub (hg x)
 
 @[simp, fun_prop]
 theorem Differentiable.sub (hf : Differentiable 𝕜 f) (hg : Differentiable 𝕜 g) :
-    Differentiable 𝕜 fun y => f y - g y := fun x => (hf x).sub (hg x)
+    Differentiable 𝕜 (f - g) := fun x => (hf x).sub (hg x)
+
+@[simp]
+lemma Differentiable.fun_add_iff_left (hg : Differentiable 𝕜 g) :
+    Differentiable 𝕜 (fun y => f y + g y) ↔ Differentiable 𝕜 f := by
+  refine ⟨fun h ↦ ?_, fun hf ↦ hf.add hg⟩
+  simpa only [add_sub_cancel_right] using h.fun_sub hg
 
 @[simp]
 lemma Differentiable.add_iff_left (hg : Differentiable 𝕜 g) :
-    Differentiable 𝕜 (fun y => f y + g y) ↔ Differentiable 𝕜 f := by
-  refine ⟨fun h ↦ ?_, fun hf ↦ hf.add hg⟩
-  simpa only [add_sub_cancel_right] using h.sub hg
+    Differentiable 𝕜 (f + g) ↔ Differentiable 𝕜 f :=
+  hg.fun_add_iff_left
+
+@[simp]
+lemma Differentiable.fun_add_iff_right (hg : Differentiable 𝕜 f) :
+    Differentiable 𝕜 (fun y => f y + g y) ↔ Differentiable 𝕜 g := by
+  simp only [add_comm (f _), hg.fun_add_iff_left]
 
 @[simp]
 lemma Differentiable.add_iff_right (hg : Differentiable 𝕜 f) :
-    Differentiable 𝕜 (fun y => f y + g y) ↔ Differentiable 𝕜 g := by
-  simp only [add_comm (f _), hg.add_iff_left]
+    Differentiable 𝕜 (f + g) ↔ Differentiable 𝕜 g :=
+  hg.fun_add_iff_right
+
+@[simp]
+lemma Differentiable.fun_sub_iff_left (hg : Differentiable 𝕜 g) :
+    Differentiable 𝕜 (fun y => f y - g y) ↔ Differentiable 𝕜 f := by
+  simp only [sub_eq_add_neg, differentiable_fun_neg_iff, hg, fun_add_iff_left]
 
 @[simp]
 lemma Differentiable.sub_iff_left (hg : Differentiable 𝕜 g) :
-    Differentiable 𝕜 (fun y => f y - g y) ↔ Differentiable 𝕜 f := by
-  simp only [sub_eq_add_neg, differentiable_neg_iff, hg, add_iff_left]
+    Differentiable 𝕜 (f - g) ↔ Differentiable 𝕜 f :=
+  hg.fun_sub_iff_left
+
+@[simp]
+lemma Differentiable.fun_sub_iff_right (hg : Differentiable 𝕜 f) :
+    Differentiable 𝕜 (fun y => f y - g y) ↔ Differentiable 𝕜 g := by
+  simp only [sub_eq_add_neg, differentiable_fun_neg_iff, hg, fun_add_iff_right]
 
 @[simp]
 lemma Differentiable.sub_iff_right (hg : Differentiable 𝕜 f) :
-    Differentiable 𝕜 (fun y => f y - g y) ↔ Differentiable 𝕜 g := by
-  simp only [sub_eq_add_neg, differentiable_neg_iff, hg, add_iff_right]
+    Differentiable 𝕜 (f - g) ↔ Differentiable 𝕜 g :=
+  hg.fun_sub_iff_right
 
-theorem fderivWithin_sub (hxs : UniqueDiffWithinAt 𝕜 s x) (hf : DifferentiableWithinAt 𝕜 f s x)
+theorem fderivWithin_fun_sub (hxs : UniqueDiffWithinAt 𝕜 s x) (hf : DifferentiableWithinAt 𝕜 f s x)
     (hg : DifferentiableWithinAt 𝕜 g s x) :
     fderivWithin 𝕜 (fun y => f y - g y) s x = fderivWithin 𝕜 f s x - fderivWithin 𝕜 g s x :=
   (hf.hasFDerivWithinAt.sub hg.hasFDerivWithinAt).fderivWithin hxs
 
-/-- Version of `fderivWithin_sub` where the function is written as `f - g` instead
-of `fun y ↦ f y - g y`. -/
-theorem fderivWithin_sub' (hxs : UniqueDiffWithinAt 𝕜 s x) (hf : DifferentiableWithinAt 𝕜 f s x)
+theorem fderivWithin_sub (hxs : UniqueDiffWithinAt 𝕜 s x) (hf : DifferentiableWithinAt 𝕜 f s x)
     (hg : DifferentiableWithinAt 𝕜 g s x) :
     fderivWithin 𝕜 (f - g) s x = fderivWithin 𝕜 f s x - fderivWithin 𝕜 g s x :=
-  fderivWithin_sub hxs hf hg
+  fderivWithin_fun_sub hxs hf hg
 
-theorem fderiv_sub (hf : DifferentiableAt 𝕜 f x) (hg : DifferentiableAt 𝕜 g x) :
+@[deprecated (since := "2025-06-14")] alias fderivWithin_sub' := fderivWithin_sub
+
+theorem fderiv_fun_sub (hf : DifferentiableAt 𝕜 f x) (hg : DifferentiableAt 𝕜 g x) :
     fderiv 𝕜 (fun y => f y - g y) x = fderiv 𝕜 f x - fderiv 𝕜 g x :=
   (hf.hasFDerivAt.sub hg.hasFDerivAt).fderiv
 
-/-- Version of `fderiv_sub` where the function is written as `f - g` instead
-of `fun y ↦ f y - g y`. -/
-theorem fderiv_sub' (hf : DifferentiableAt 𝕜 f x) (hg : DifferentiableAt 𝕜 g x) :
+theorem fderiv_sub (hf : DifferentiableAt 𝕜 f x) (hg : DifferentiableAt 𝕜 g x) :
     fderiv 𝕜 (f - g) x = fderiv 𝕜 f x - fderiv 𝕜 g x :=
-  fderiv_sub hf hg
+  fderiv_fun_sub hf hg
+
+@[deprecated (since := "2025-06-14")] alias fderiv_sub' := fderiv_sub
 
 @[simp]
 theorem hasFDerivAtFilter_sub_const_iff (c : F) :
@@ -694,7 +976,7 @@ theorem Differentiable.const_sub (hf : Differentiable 𝕜 f) (c : F) :
 
 theorem fderivWithin_const_sub (hxs : UniqueDiffWithinAt 𝕜 s x) (c : F) :
     fderivWithin 𝕜 (fun y => c - f y) s x = -fderivWithin 𝕜 f s x := by
-  simp only [sub_eq_add_neg, fderivWithin_const_add, fderivWithin_neg, hxs]
+  simp only [sub_eq_add_neg, fderivWithin_const_add, fderivWithin_fun_neg, hxs]
 
 theorem fderiv_const_sub (c : F) : fderiv 𝕜 (fun y => c - f y) x = -fderiv 𝕜 f x := by
   simp only [← fderivWithin_univ, fderivWithin_const_sub uniqueDiffWithinAt_univ]

--- a/Mathlib/Analysis/Calculus/FDeriv/Analytic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Analytic.lean
@@ -664,7 +664,7 @@ theorem hasFTaylorSeriesUpTo_iteratedFDeriv :
       have A : HasFDerivAt (f.iteratedFDeriv n) (∑ e : Fin n ↪ ι,
           ((iteratedFDerivComponent f e.toEquivRange).linearDeriv (Pi.compRightL 𝕜 _ Subtype.val x))
             ∘L (Pi.compRightL 𝕜 _ Subtype.val)) x := by
-        apply HasFDerivAt.sum (fun s _hs ↦ ?_)
+        apply HasFDerivAt.fun_sum (fun s _hs ↦ ?_)
         exact (ContinuousMultilinearMap.hasFDerivAt _ _).comp x (ContinuousLinearMap.hasFDerivAt _)
       rwa [← H] at A
     ext v m

--- a/Mathlib/Analysis/Calculus/MeanValue.lean
+++ b/Mathlib/Analysis/Calculus/MeanValue.lean
@@ -622,7 +622,7 @@ theorem _root_.IsOpen.exists_eq_add_of_fderiv_eq (hs : IsOpen s) (hs' : IsPrecon
     (hf' : s.EqOn (fderiv 𝕜 f) (fderiv 𝕜 g)) : ∃ a, s.EqOn f (g · + a) := by
   simp_rw [Set.EqOn, ← sub_eq_iff_eq_add']
   refine hs.exists_is_const_of_fderiv_eq_zero hs' (hf.sub hg) fun x hx ↦ ?_
-  rw [fderiv_sub (hf.differentiableAt (hs.mem_nhds hx)) (hg.differentiableAt (hs.mem_nhds hx)),
+  rw [fderiv_fun_sub (hf.differentiableAt (hs.mem_nhds hx)) (hg.differentiableAt (hs.mem_nhds hx)),
     hf' hx, sub_self, Pi.zero_apply]
 
 /-- If two functions have equal Fréchet derivatives at every point of a connected open set,

--- a/Mathlib/Analysis/Calculus/SmoothSeries.lean
+++ b/Mathlib/Analysis/Calculus/SmoothSeries.lean
@@ -48,7 +48,7 @@ theorem summable_of_summable_hasFDerivAt_of_isPreconnected (hu : Summable u) (hs
     (tendstoUniformlyOn_tsum hu hf').uniformCauchySeqOn
   refine cauchy_map_of_uniformCauchySeqOn_fderiv (f := fun t x ↦ ∑ i ∈ t, f i x)
     hs h's A (fun t y hy => ?_) hx₀ hx hf0
-  exact HasFDerivAt.sum fun i _ => hf i y hy
+  exact HasFDerivAt.fun_sum fun i _ => hf i y hy
 
 /-- Consider a series of functions `∑' n, f n x` on a preconnected open set. If the series converges
 at a point, and all functions in the series are differentiable with a summable bound on the
@@ -77,7 +77,7 @@ theorem hasFDerivAt_tsum_of_isPreconnected (hu : Summable u) (hs : IsOpen s)
       exact summable_of_summable_hasFDerivAt_of_isPreconnected hu hs h's hf hf' hx₀ hf0 hy
     refine hasFDerivAt_of_tendstoUniformlyOn hs (tendstoUniformlyOn_tsum hu hf')
       (fun t y hy => ?_) A hx
-    exact HasFDerivAt.sum fun n _ => hf n y hy
+    exact HasFDerivAt.fun_sum fun n _ => hf n y hy
 
 /-- Consider a series of functions `∑' n, f n x` on a preconnected open set. If the series converges
 at a point, and all functions in the series are differentiable with a summable bound on the

--- a/Mathlib/Analysis/Calculus/VectorField.lean
+++ b/Mathlib/Analysis/Calculus/VectorField.lean
@@ -86,7 +86,7 @@ lemma lieBracketWithin_smul_left {c : 𝕜} (hV : DifferentiableWithinAt 𝕜 V 
     lieBracketWithin 𝕜 (c • V) W s x =
       c • lieBracketWithin 𝕜 V W s x := by
   simp only [lieBracketWithin, Pi.add_apply, map_add, Pi.smul_apply, map_smul, smul_sub]
-  rw [fderivWithin_const_smul' hs hV]
+  rw [fderivWithin_const_smul hs hV]
   rfl
 
 lemma lieBracket_smul_left {c : 𝕜} (hV : DifferentiableAt 𝕜 V x) :
@@ -99,7 +99,7 @@ lemma lieBracketWithin_smul_right {c : 𝕜} (hW : DifferentiableWithinAt 𝕜 W
     lieBracketWithin 𝕜 V (c • W) s x =
       c • lieBracketWithin 𝕜 V W s x := by
   simp only [lieBracketWithin, Pi.add_apply, map_add, Pi.smul_apply, map_smul, smul_sub]
-  rw [fderivWithin_const_smul' hs hW]
+  rw [fderivWithin_const_smul hs hW]
   rfl
 
 lemma lieBracket_smul_right {c : 𝕜} (hW : DifferentiableAt 𝕜 W x) :
@@ -112,14 +112,14 @@ lemma lieBracketWithin_add_left (hV : DifferentiableWithinAt 𝕜 V s x)
     lieBracketWithin 𝕜 (V + V₁) W s x =
       lieBracketWithin 𝕜 V W s x + lieBracketWithin 𝕜 V₁ W s x := by
   simp only [lieBracketWithin, Pi.add_apply, map_add]
-  rw [fderivWithin_add' hs hV hV₁, ContinuousLinearMap.add_apply]
+  rw [fderivWithin_add hs hV hV₁, ContinuousLinearMap.add_apply]
   abel
 
 lemma lieBracket_add_left (hV : DifferentiableAt 𝕜 V x) (hV₁ : DifferentiableAt 𝕜 V₁ x) :
     lieBracket 𝕜 (V + V₁) W  x =
       lieBracket 𝕜 V W x + lieBracket 𝕜 V₁ W x := by
   simp only [lieBracket, Pi.add_apply, map_add]
-  rw [fderiv_add' hV hV₁, ContinuousLinearMap.add_apply]
+  rw [fderiv_add hV hV₁, ContinuousLinearMap.add_apply]
   abel
 
 lemma lieBracketWithin_add_right (hW : DifferentiableWithinAt 𝕜 W s x)
@@ -127,14 +127,14 @@ lemma lieBracketWithin_add_right (hW : DifferentiableWithinAt 𝕜 W s x)
     lieBracketWithin 𝕜 V (W + W₁) s x =
       lieBracketWithin 𝕜 V W s x + lieBracketWithin 𝕜 V W₁ s x := by
   simp only [lieBracketWithin, Pi.add_apply, map_add]
-  rw [fderivWithin_add' hs hW hW₁, ContinuousLinearMap.add_apply]
+  rw [fderivWithin_add hs hW hW₁, ContinuousLinearMap.add_apply]
   abel
 
 lemma lieBracket_add_right (hW : DifferentiableAt 𝕜 W x) (hW₁ : DifferentiableAt 𝕜 W₁ x) :
     lieBracket 𝕜 V (W + W₁) x =
       lieBracket 𝕜 V W x + lieBracket 𝕜 V W₁ x := by
   simp only [lieBracket, Pi.add_apply, map_add]
-  rw [fderiv_add' hW hW₁, ContinuousLinearMap.add_apply]
+  rw [fderiv_add hW hW₁, ContinuousLinearMap.add_apply]
   abel
 
 lemma lieBracketWithin_swap : lieBracketWithin 𝕜 V W s = - lieBracketWithin 𝕜 W V s := by
@@ -314,9 +314,9 @@ lemma leibniz_identity_lieBracketWithin_of_isSymmSndFDerivWithinAt
         (fderivWithin 𝕜 (fderivWithin 𝕜 U s) s x).flip (V x) := by
     refine fderivWithin_clm_apply (hs x hx) ?_ (hV.differentiableWithinAt one_le_two)
     exact (hU.fderivWithin_right hs le_rfl hx).differentiableWithinAt le_rfl
-  rw [fderivWithin_sub (hs x hx) (aux₁ hV hW) (aux₁ hW hV)]
-  rw [fderivWithin_sub (hs x hx) (aux₁ hU hV) (aux₁ hV hU)]
-  rw [fderivWithin_sub (hs x hx) (aux₁ hU hW) (aux₁ hW hU)]
+  rw [fderivWithin_fun_sub (hs x hx) (aux₁ hV hW) (aux₁ hW hV)]
+  rw [fderivWithin_fun_sub (hs x hx) (aux₁ hU hV) (aux₁ hV hU)]
+  rw [fderivWithin_fun_sub (hs x hx) (aux₁ hU hW) (aux₁ hW hU)]
   rw [aux₂ hW hV, aux₂ hV hW, aux₂ hV hU, aux₂ hU hV, aux₂ hW hU, aux₂ hU hW]
   simp only [ContinuousLinearMap.coe_sub', Pi.sub_apply, ContinuousLinearMap.add_apply,
     ContinuousLinearMap.coe_comp', Function.comp_apply, ContinuousLinearMap.flip_apply, h'V.eq,

--- a/Mathlib/Analysis/Complex/LocallyUniformLimit.lean
+++ b/Mathlib/Analysis/Complex/LocallyUniformLimit.lean
@@ -171,7 +171,7 @@ theorem differentiableOn_tsum_of_summable_norm {u : ι → ℝ} (hu : Summable u
   classical
   have hc := (tendstoUniformlyOn_tsum hu hF_le).tendstoLocallyUniformlyOn
   refine hc.differentiableOn (Eventually.of_forall fun s => ?_) hU
-  exact DifferentiableOn.sum fun i _ => hf i
+  exact DifferentiableOn.fun_sum fun i _ => hf i
 
 /-- If the terms in the sum `∑' (i : ι), F i` are uniformly bounded on `U` by a
 summable function, then the sum of `deriv F i` at a point in `U` is the derivative of the
@@ -183,7 +183,7 @@ theorem hasSum_deriv_of_summable_norm {u : ι → ℝ} (hu : Summable u)
   rw [HasSum]
   have hc := (tendstoUniformlyOn_tsum hu hF_le).tendstoLocallyUniformlyOn
   convert (hc.deriv (Eventually.of_forall fun s =>
-    DifferentiableOn.sum fun i _ => hf i) hU).tendsto_at hz using 1
+    DifferentiableOn.fun_sum fun i _ => hf i) hU).tendsto_at hz using 1
   ext1 s
   exact (deriv_sum fun i _ => (hf i).differentiableAt (hU.mem_nhds hz)).symm
 

--- a/Mathlib/Analysis/SpecialFunctions/BinaryEntropy.lean
+++ b/Mathlib/Analysis/SpecialFunctions/BinaryEntropy.lean
@@ -172,10 +172,10 @@ lemma differentiableAt_binEntropy_iff_ne_zero_one :
     DifferentiableAt ℝ binEntropy p ↔ p ≠ 0 ∧ p ≠ 1 := by
   refine ⟨fun h ↦ ⟨?_, ?_⟩, fun h ↦ differentiableAt_binEntropy h.1 h.2⟩
     <;> rintro rfl <;> unfold binEntropy at h
-  · rw [DifferentiableAt.add_iff_left] at h
+  · rw [DifferentiableAt.fun_add_iff_left] at h
     · simp [log_inv, mul_neg, ← neg_mul, ← negMulLog_def, differentiableAt_negMulLog_iff] at h
     · fun_prop (disch := simp)
-  · rw [DifferentiableAt.add_iff_right, differentiableAt_iff_comp_const_sub (b := 1)] at h
+  · rw [DifferentiableAt.fun_add_iff_right, differentiableAt_iff_comp_const_sub (b := 1)] at h
     · simp [log_inv, mul_neg, ← neg_mul, ← negMulLog_def, differentiableAt_negMulLog_iff] at h
     · fun_prop (disch := simp)
 

--- a/Mathlib/Analysis/SpecialFunctions/Integrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals.lean
@@ -546,7 +546,7 @@ theorem integral_sin : ∫ x in a..b, sin x = cos a - cos b := by
   rw [integral_deriv_eq_sub' fun x => -cos x]
   · ring
   · norm_num
-  · simp only [differentiableAt_neg_iff, differentiableAt_cos, implies_true]
+  · simp only [differentiableAt_fun_neg_iff, differentiableAt_cos, implies_true]
   · exact continuousOn_sin
 
 @[simp]

--- a/Mathlib/Analysis/SpecialFunctions/Log/NegMulLog.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/NegMulLog.lean
@@ -167,7 +167,7 @@ lemma differentiableAt_negMulLog_iff {x : ℝ} : DifferentiableAt ℝ negMulLog 
   constructor
   · unfold negMulLog
     intro h eq0
-    simp only [neg_mul, differentiableAt_neg_iff, eq0] at h
+    simp only [neg_mul, differentiableAt_fun_neg_iff, eq0] at h
     exact not_DifferentiableAt_log_mul_zero h
   · intro hx
     have : x ∈ ({0} : Set ℝ)ᶜ := by

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/InverseDeriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/InverseDeriv.lean
@@ -81,7 +81,7 @@ theorem differentiableWithinAt_arcsin_Iic {x : ℝ} :
     DifferentiableWithinAt ℝ arcsin (Iic x) x ↔ x ≠ 1 := by
   refine ⟨fun h => ?_, fun h => (hasDerivWithinAt_arcsin_Iic h).differentiableWithinAt⟩
   rw [← neg_neg x, ← image_neg_Ici] at h
-  have := (h.comp (-x) differentiableWithinAt_id.neg (mapsTo_image _ _)).neg
+  have := (h.comp (-x) differentiableWithinAt_id.fun_neg (mapsTo_image _ _)).fun_neg
   simpa [(· ∘ ·), differentiableWithinAt_arcsin_Ici] using this
 
 theorem differentiableAt_arcsin {x : ℝ} : DifferentiableAt ℝ arcsin x ↔ x ≠ -1 ∧ x ≠ 1 :=

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaEven.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaEven.lean
@@ -651,7 +651,7 @@ lemma differentiable_hurwitzZetaEven_sub_hurwitzZetaEven (a b : UnitAddCircle) :
   intro z
   rcases ne_or_eq z 1 with hz | rfl
   · exact (differentiableAt_hurwitzZetaEven a hz).sub (differentiableAt_hurwitzZetaEven b hz)
-  · convert (differentiableAt_hurwitzZetaEven_sub_one_div a).sub
+  · convert (differentiableAt_hurwitzZetaEven_sub_one_div a).fun_sub
       (differentiableAt_hurwitzZetaEven_sub_one_div b) using 2 with s
     abel
 

--- a/Mathlib/NumberTheory/LSeries/ZMod.lean
+++ b/Mathlib/NumberTheory/LSeries/ZMod.lean
@@ -120,8 +120,8 @@ lemma differentiableAt_LFunction (Φ : ZMod N → ℂ) (s : ℂ) (hs : s ≠ 1 �
     DifferentiableAt ℂ (LFunction Φ) s := by
   refine .mul (by fun_prop) ?_
   rcases ne_or_eq s 1 with hs' | rfl
-  · exact .sum fun j _ ↦ (differentiableAt_hurwitzZeta _ hs').const_mul _
-  · have := DifferentiableAt.sum (u := univ) fun j _ ↦
+  · exact .fun_sum fun j _ ↦ (differentiableAt_hurwitzZeta _ hs').const_mul _
+  · have := DifferentiableAt.fun_sum (u := univ) fun j _ ↦
       (differentiableAt_hurwitzZeta_sub_one_div (toAddCircle j)).const_mul (Φ j)
     simpa only [mul_sub, sum_sub_distrib, ← sum_mul, hs.neg_resolve_left rfl, zero_mul, sub_zero]
 
@@ -335,7 +335,7 @@ noncomputable def completedLFunction₀ (Φ : ZMod N → ℂ) (s : ℂ) : ℂ :=
 lemma differentiable_completedLFunction₀ (Φ : ZMod N → ℂ) :
     Differentiable ℂ (completedLFunction₀ Φ) := by
   refine .add ?_ ?_ <;>
-  refine .mul (by fun_prop) (.sum fun i _ ↦ .const_mul ?_ _)
+  refine .mul (by fun_prop) (.fun_sum fun i _ ↦ .const_mul ?_ _)
   exacts [differentiable_completedHurwitzZetaEven₀ _, differentiable_completedHurwitzZetaOdd _]
 
 lemma completedLFunction_eq (Φ : ZMod N → ℂ) (s : ℂ) :

--- a/Mathlib/NumberTheory/ModularForms/EisensteinSeries/MDifferentiable.lean
+++ b/Mathlib/NumberTheory/ModularForms/EisensteinSeries/MDifferentiable.lean
@@ -55,7 +55,7 @@ theorem eisensteinSeries_SIF_MDifferentiable {k : ℤ} {N : ℕ} (hk : 3 ≤ k) 
   refine DifferentiableOn.differentiableAt ?_
     ((isOpen_lt continuous_const Complex.continuous_im).mem_nhds τ.2)
   exact (eisensteinSeries_tendstoLocallyUniformlyOn hk a).differentiableOn
-    (Eventually.of_forall fun s ↦ DifferentiableOn.sum
+    (Eventually.of_forall fun s ↦ DifferentiableOn.fun_sum
       fun _ _ ↦ eisSummand_extension_differentiableOn _ _)
         (isOpen_lt continuous_const continuous_im)
 


### PR DESCRIPTION
This follows the new convention explained at https://leanprover-community.github.io/contribute/naming.html#unexpanded-and-expanded-forms-of-functions

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
