### PR TITLE
[Merged by Bors] - chore: use `inherit_doc` in the notations for `CovBy` and `WCovBy`

### DIFF
--- a/Mathlib/Order/Defs/PartialOrder.lean
+++ b/Mathlib/Order/Defs/PartialOrder.lean
@@ -128,7 +128,7 @@ def decidableLTOfDecidableLE [DecidableLE α] : DecidableLT α
     else isFalse fun hab' => hab (le_of_lt hab')
 
 /-- `WCovBy a b` means that `a = b` or `b` covers `a`.
-This means that `a ≤ b` and there is no element in between.
+This means that `a ≤ b` and there is no element in between. This is denoted `a ⩿ b`.
 -/
 def WCovBy (a b : α) : Prop :=
   a ≤ b ∧ ∀ ⦃c⦄, a < c → ¬c < b
@@ -136,7 +136,8 @@ def WCovBy (a b : α) : Prop :=
 @[inherit_doc]
 infixl:50 " ⩿ " => WCovBy
 
-/-- `CovBy a b` means that `b` covers `a`: `a < b` and there is no element in between. -/
+/-- `CovBy a b` means that `b` covers `a`. This means that `a < b` and there is no element in
+between. This is denoted `a ⋖ b`. -/
 def CovBy {α : Type*} [LT α] (a b : α) : Prop :=
   a < b ∧ ∀ ⦃c⦄, a < c → ¬c < b
 

--- a/Mathlib/Order/Defs/PartialOrder.lean
+++ b/Mathlib/Order/Defs/PartialOrder.lean
@@ -133,14 +133,14 @@ This means that `a ≤ b` and there is no element in between.
 def WCovBy (a b : α) : Prop :=
   a ≤ b ∧ ∀ ⦃c⦄, a < c → ¬c < b
 
-/-- Notation for `WCovBy a b`. -/
+@[inherit_doc]
 infixl:50 " ⩿ " => WCovBy
 
 /-- `CovBy a b` means that `b` covers `a`: `a < b` and there is no element in between. -/
 def CovBy {α : Type*} [LT α] (a b : α) : Prop :=
   a < b ∧ ∀ ⦃c⦄, a < c → ¬c < b
 
-/-- Notation for `CovBy a b`. -/
+@[inherit_doc]
 infixl:50 " ⋖ " => CovBy
 
 end Preorder


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
