### PR TITLE
[Merged by Bors] - feat: extra `Module.IsTorsionFree` instances

### DIFF
--- a/Mathlib/Algebra/Module/Torsion/Free.lean
+++ b/Mathlib/Algebra/Module/Torsion/Free.lean
@@ -23,13 +23,14 @@ If furthermore the base ring is a domain, this is equivalent to the naïve
 
 open Module
 
-variable {R M N : Type*}
+variable {R S M N : Type*}
 
 section Semiring
-variable [Semiring R]
+variable [Semiring R] [Semiring S]
 
 section AddCommMonoid
-variable [AddCommMonoid M] [Module R M] [AddCommMonoid N] [Module R N] {r : R} {m m₁ m₂ : M}
+variable [AddCommMonoid M] [Module R M] [Module S M] [AddCommMonoid N] [Module R N]
+  {r : R} {m m₁ m₂ : M}
 
 variable (R M) in
 /-- A `R`-module `M` is torsion-free if scalar multiplication by an element `r : R` is injective if
@@ -53,6 +54,9 @@ lemma Function.Injective.moduleIsTorsionFree [IsTorsionFree R N] (f : M → N) (
 instance IsAddTorsionFree.to_isTorsionFree_nat [IsAddTorsionFree M] : IsTorsionFree ℕ M where
   isSMulRegular n hn := nsmul_right_injective (by simpa [isRegular_iff_ne_zero] using hn)
 
+instance Subsingleton.to_moduleIsTorsionFree [Subsingleton M] : IsTorsionFree R M where
+  isSMulRegular _ _ := Function.injective_of_subsingleton _
+
 variable [IsTorsionFree R M]
 
 variable (M) in
@@ -67,6 +71,14 @@ protected lemma IsRegular.smul_right_injective (hr : IsRegular r) : ((r • ·) 
 
 protected lemma IsRegular.smul_ne_zero_iff_right (hr : IsRegular r) : r • m ≠ 0 ↔ m ≠ 0 :=
   hr.smul_eq_zero_iff_right.ne
+
+variable (R) in
+lemma Module.IsTorsionFree.trans [Module S R] [IsTorsionFree S R] [IsScalarTower S R R]
+    [SMulCommClass S R R] [IsScalarTower S R M] : IsTorsionFree S M where
+  isSMulRegular s hs x y hxy := by
+    refine (?_ : IsRegular (s • 1 : R)).isSMulRegular (by simpa using hxy)
+    exact ⟨fun x y hxy ↦ hs.isSMulRegular <| by simpa using hxy,
+      fun x y hxy ↦ hs.isSMulRegular <| by simpa using hxy⟩
 
 variable [IsDomain R]
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
