### PR TITLE
[Merged by Bors] - fix: revert insecure `shell=True` guessing in migrate_to_fork

### DIFF
--- a/scripts/migrate_to_fork.py
+++ b/scripts/migrate_to_fork.py
@@ -89,16 +89,7 @@ def print_error(message: str) -> None:
 def run_command(cmd: List[str], capture_output: bool = True, check: bool = True) -> subprocess.CompletedProcess:
     """Run a command and return the result with Windows compatibility."""
     try:
-        # On Windows, we need to use shell=True for some commands
-        use_shell = platform.system() == 'Windows' and any(c in cmd[0] for c in ['|', '>', '<', '&'])
-
-        # Convert command to string if using shell
-        if use_shell:
-            cmd_str = ' '.join(cmd)
-            result = subprocess.run(cmd_str, shell=True, capture_output=capture_output, text=True, check=check)
-        else:
-            result = subprocess.run(cmd, capture_output=capture_output, text=True, check=check)
-        return result
+        return subprocess.run(cmd, capture_output=capture_output, text=True, check=check)
     except subprocess.CalledProcessError as e:
         if not check:
             return e


### PR DESCRIPTION
This wasn't justified or reviewed in #25890, and could have resulted in arbitrary code execution in the face of malicious branch names or comment bodies.

In reality i think this code is currently unreachable, but that's no excuse for keeping it!


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
