### PR TITLE
[Merged by Bors] - chore: deprecate `Grp_.mk'`

### DIFF
--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Grp_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Grp_.lean
@@ -119,11 +119,11 @@ lemma essImage_yonedaGrp :
     exact ⟨G.X, ⟨Functor.representableByEquiv.symm (isoWhiskerRight α (forget _))⟩⟩
   · rintro ⟨X, ⟨e⟩⟩
     letI := Grp_Class.ofRepresentableBy X F e
-    exact ⟨.mk' X, ⟨yonedaGrpObjIsoOfRepresentableBy X F e⟩⟩
+    exact ⟨⟨X⟩, ⟨yonedaGrpObjIsoOfRepresentableBy X F e⟩⟩
 
 @[reassoc]
 lemma Grp_Class.comp_inv (f : X ⟶ Y) (g : Y ⟶ G) : f ≫ g⁻¹ = (f ≫ g)⁻¹ :=
-  ((yonedaGrp.obj <| .mk' G).map f.op).hom.map_inv g
+  ((yonedaGrp.obj ⟨G⟩).map f.op).hom.map_inv g
 
 @[reassoc]
 lemma Grp_Class.inv_comp (f : X ⟶ G) (g : G ⟶ H) [IsMon_Hom g] : f⁻¹ ≫ g = (f ≫ g)⁻¹ := by

--- a/Mathlib/CategoryTheory/Monoidal/Grp_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Grp_.lean
@@ -80,11 +80,7 @@ def trivial : Grp_ C :=
 instance : Inhabited (Grp_ C) where
   default := trivial C
 
-/-- Make a group object from `Grp_Class`. -/
-@[simps X]
-def mk' (X : C) [Grp_Class X] : Grp_ C where
-  __ := Mon_.mk X
-  grp := { inv := Grp_Class.inv (X := X) }
+@[deprecated (since := "2025-06-15")] alias mk' := mk
 
 instance : Category (Grp_ C) :=
   InducedCategory.category Grp_.toMon_
@@ -247,13 +243,13 @@ theorem inv_hom [Grp_Class A] [Grp_Class B] (f : A ⟶ B) [IsMon_Hom f] : ι ≫
 lemma toMon_Class_injective {X : C} :
     Function.Injective (@Grp_Class.toMon_Class C ‹_› ‹_› X) := by
   intro h₁ h₂ e
-  let X₁ : Grp_ C := @Grp_.mk' _ _ _ X h₁
-  let X₂ : Grp_ C := @Grp_.mk' _ _ _ X h₂
-  suffices ι[X₁.X] = ι[X₂.X] by cases h₁; cases h₂; subst e this; rfl
+  let X₁ : Grp_ C := @Grp_.mk _ _ _ X h₁
+  let X₂ : Grp_ C := @Grp_.mk _ _ _ X h₂
+  suffices h₁.inv = h₂.inv by cases h₁; congr!
   apply lift_left_mul_ext (𝟙 _)
-  rw [left_inv, show μ[X₁.X] = μ[X₂.X] from congr(($e).mul),
-    show η[X₁.X] = η[X₂.X] from congr(($e).one)]
-  exact (left_inv X₂.X).symm
+  rw [left_inv]
+  convert @left_inv _ _ _ _ h₁ using 2
+  exacts [congr(($e.symm).mul), congr(($e.symm).one)]
 
 @[ext]
 lemma _root_.Grp_Class.ext {X : C} (h₁ h₂ : Grp_Class X)


### PR DESCRIPTION
Since Yuma's refactor (#24646), `Grp_.mk'` has exactly the same type signature as `Grp_.mk`.

From Toric


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
