### PR TITLE
[Merged by Bors] - add `git fetch --prune` step

### DIFF
--- a/scripts/migrate_to_fork.py
+++ b/scripts/migrate_to_fork.py
@@ -324,9 +324,11 @@ def setup_remotes(username: str, fork_url: str, auto_accept: bool = False) -> st
     """
     print_step(4, "Setting up git remotes")
 
-    # this will remove tracking branches corresponding to branches on origin whose names
-    # differ only in case:
-    run_command(['git', 'fetch', '--prune'])
+    # This will sync the local references with the upstream ones and delete refs to branches that
+    # don’t exist anymore on upstream repos.
+    # In particular, this will ensure the branches with duplicate names up to case that were recently
+    # deleted on the main repository do not cause trouble in the migration.
+    run_command(['git', 'fetch', '--all', '--prune'])
 
     remotes = get_current_remotes()
 

--- a/scripts/migrate_to_fork.py
+++ b/scripts/migrate_to_fork.py
@@ -324,6 +324,10 @@ def setup_remotes(username: str, fork_url: str, auto_accept: bool = False) -> st
     """
     print_step(4, "Setting up git remotes")
 
+    # this will remove tracking branches corresponding to branches on origin whose names
+    # differ only in case:
+    run_command(['git', 'fetch', '--prune'])
+
     remotes = get_current_remotes()
 
     # Determine URL format based on SSH availability


### PR DESCRIPTION
Workaround for case-sensitivity problems in branch names. The branches with offending names have now been removed /renamed on the mathlib repo, but the change does not automatically propagate to local repos unless `git fetch --prune` is run; hence this PR adds that step to the migrate script.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
