### PR TITLE
feat: add an ext lemma for the opposite category

### DIFF
--- a/Mathlib/AlgebraicTopology/SimplicialObject/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialObject/Basic.lean
@@ -921,13 +921,8 @@ def simplicialToCosimplicialAugmented :
   obj X := X.unop.rightOp
   map f :=
     { left := f.unop.right.op
-      right := NatTrans.rightOp f.unop.left
-      w := by
-        ext x
-        dsimp
-        simp_rw [← op_comp]
-        congr 1
-        exact (congr_app f.unop.w (op x)).symm }
+      right := f.unop.left.rightOp
+      w := by ext x; exact (congr_app f.unop.w (op x)).symm }
 
 /-- A functorial version of `Cosimplicial_object.Augmented.leftOp`. -/
 @[simps]

--- a/Mathlib/CategoryTheory/Abelian/Opposite.lean
+++ b/Mathlib/CategoryTheory/Abelian/Opposite.lean
@@ -32,6 +32,9 @@ section
 variable {C}
 variable {X Y : C} (f : X ⟶ Y) {A B : Cᵒᵖ} (g : A ⟶ B)
 
+-- this isn't helpful here
+attribute [-ext] Quiver.Hom.unop_ext
+
 -- TODO: Generalize (this will work whenever f has a cokernel)
 -- (The abelian case is probably sufficient for most applications.)
 /-- The kernel of `f.op` is the opposite of `cokernel f`. -/

--- a/Mathlib/CategoryTheory/Category/RelCat.lean
+++ b/Mathlib/CategoryTheory/Category/RelCat.lean
@@ -118,17 +118,6 @@ open Opposite
 def opFunctor : RelCat ⥤ RelCatᵒᵖ where
   obj X := op X
   map {_ _} r := .op <| .ofRel r.rel.inv
-  map_id X := by
-    congr
-    simp only [unop_op, RelCat.rel_id]
-    ext x y
-    exact Eq.comm
-  map_comp {X Y Z} f g := by
-    unfold Category.opposite
-    congr
-    ext x y
-    apply exists_congr
-    exact fun a => And.comm
 
 /-- The other direction of `opFunctor`. -/
 def unopFunctor : RelCatᵒᵖ ⥤ RelCat where

--- a/Mathlib/CategoryTheory/GuitartExact/Opposite.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/Opposite.lean
@@ -58,12 +58,8 @@ def inverse :
       f.hom.right.op f.left.hom.op (Quiver.Hom.unop_inj (StructuredArrow.w f.hom)))
   map {f f'} φ :=
     (StructuredArrow.homMk
-      (CostructuredArrow.homMk (φ.left.right.op)
-        (Quiver.Hom.unop_inj (by exact StructuredArrow.w φ.left)))
-          (by
-            ext
-            exact Quiver.Hom.unop_inj
-              ((StructuredArrow.proj _ _).congr_map (CostructuredArrow.w φ)))).op
+      (CostructuredArrow.homMk (φ.left.right.op) (by ext; exact StructuredArrow.w φ.left))
+      (by ext; exact (StructuredArrow.proj _ _).congr_map (CostructuredArrow.w φ))).op
 
 end structuredArrowRightwardsOpEquivalence
 

--- a/Mathlib/CategoryTheory/Limits/Opposites.lean
+++ b/Mathlib/CategoryTheory/Limits/Opposites.lean
@@ -758,15 +758,9 @@ def opProdIsoCoprod : op (A ⨯ B) ≅ (op A ⨿ op B) where
   hom := (prod.lift coprod.inl.unop coprod.inr.unop).op
   inv := coprod.desc prod.fst.op prod.snd.op
   hom_inv_id := by
-    apply Quiver.Hom.unop_inj
     ext <;>
     · simp only [limit.lift_π]
       apply Quiver.Hom.op_inj
-      simp
-  inv_hom_id := by
-    ext <;>
-    · simp only [colimit.ι_desc_assoc]
-      apply Quiver.Hom.unop_inj
       simp
 
 @[reassoc (attr := simp)]

--- a/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
@@ -691,10 +691,7 @@ def piConst [Limits.HasProducts.{w} C] : C ⥤ Type wᵒᵖ ⥤ C where
 def piConstAdj [Limits.HasProducts.{v} C] (X : C) :
     (piConst.obj X).rightOp ⊣ yoneda.obj X where
   unit := { app n i := Limits.Pi.π (fun _ : n ↦ X) i }
-  counit :=
-  { app Y := (Limits.Pi.lift id).op,
-    naturality _ _ _ := by apply Quiver.Hom.unop_inj; aesop_cat }
-  left_triangle_components _ := by apply Quiver.Hom.unop_inj; aesop_cat
+  counit := { app Y := (Limits.Pi.lift id).op }
 
 /-- The functor sending `(X, n)` to the coproduct of copies of `X` indexed by `n`. -/
 @[simps]

--- a/Mathlib/CategoryTheory/Opposites.lean
+++ b/Mathlib/CategoryTheory/Opposites.lean
@@ -583,8 +583,6 @@ isomorphism between the original functors `F ≅ G`. -/
 protected def op (α : F ≅ G) : G.op ≅ F.op where
   hom := NatTrans.op α.hom
   inv := NatTrans.op α.inv
-  hom_inv_id := by ext; dsimp; rw [← op_comp]; rw [α.inv_hom_id_app]; rfl
-  inv_hom_id := by ext; dsimp; rw [← op_comp]; rw [α.hom_inv_id_app]; rfl
 
 @[simp]
 theorem op_refl : NatIso.op (Iso.refl F) = Iso.refl F.op := rfl
@@ -701,9 +699,6 @@ def op (e : C ≌ D) : Cᵒᵖ ≌ Dᵒᵖ where
   inverse := e.inverse.op
   unitIso := (NatIso.op e.unitIso).symm
   counitIso := (NatIso.op e.counitIso).symm
-  functor_unitIso_comp X := by
-    apply Quiver.Hom.unop_inj
-    simp
 
 /-- An equivalence between opposite categories gives an equivalence between the original categories.
 -/
@@ -773,14 +768,7 @@ variable (D : Type u₂) [Category.{v₂} D]
 def opUnopEquiv : (C ⥤ D)ᵒᵖ ≌ Cᵒᵖ ⥤ Dᵒᵖ where
   functor := opHom _ _
   inverse := opInv _ _
-  unitIso :=
-    NatIso.ofComponents (fun F => F.unop.opUnopIso.op)
-      (by
-        intro F G f
-        dsimp [opUnopIso]
-        rw [show f = f.unop.op by simp, ← op_comp, ← op_comp]
-        congr 1
-        aesop_cat)
+  unitIso := NatIso.ofComponents (fun F => F.unop.opUnopIso.op)
   counitIso := NatIso.ofComponents fun F => F.unopOpIso
 
 /-- The equivalence of functor categories induced by `leftOp` and `rightOp`.
@@ -793,14 +781,7 @@ def leftOpRightOpEquiv : (Cᵒᵖ ⥤ D)ᵒᵖ ≌ C ⥤ Dᵒᵖ where
   inverse :=
     { obj := fun F => op F.leftOp
       map := fun η => η.leftOp.op }
-  unitIso :=
-    NatIso.ofComponents (fun F => F.unop.rightOpLeftOpIso.op)
-      (by
-        intro F G η
-        dsimp
-        rw [show η = η.unop.op by simp, ← op_comp, ← op_comp]
-        congr 1
-        aesop_cat)
+  unitIso := NatIso.ofComponents (fun F => F.unop.rightOpLeftOpIso.op)
   counitIso := NatIso.ofComponents fun F => F.leftOpRightOpIso
 
 instance {F : C ⥤ D} [EssSurj F] : EssSurj F.op where

--- a/Mathlib/CategoryTheory/Triangulated/Opposite/Functor.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Opposite/Functor.lean
@@ -57,7 +57,8 @@ noncomputable scoped instance commShift_adjunction_op_int {G : D ⥤ C} [G.CommS
       NatTrans.PullbackShift.natIsoComp, PullbackShift.functor, PullbackShift.natTrans,
       OppositeShift.adjunction, OppositeShift.natTrans, NatTrans.OppositeShift.natIsoId,
       NatTrans.OppositeShift.natIsoComp, OppositeShift.functor]
-    simp only [Int.reduceNeg, Category.comp_id, Category.id_comp]
+    rw [unop_id]
+    simp only [id_comp, comp_id]
   rw [eq]
   exact inferInstanceAs (Adjunction.CommShift (PullbackShift.adjunction
     (AddMonoidHom.mk' (fun (n : ℤ) => -n) (by intros; dsimp; omega))

--- a/Mathlib/Combinatorics/Quiver/Basic.lean
+++ b/Mathlib/Combinatorics/Quiver/Basic.lean
@@ -66,6 +66,12 @@ def Hom.opEquiv {V} [Quiver V] {X Y : V} :
   toFun := Opposite.op
   invFun := Opposite.unop
 
+/-- To show that two Homs from the opposite category agree, it suffices to show they agree
+in the original category. -/
+@[ext]
+theorem Hom.unop_ext {V} [Quiver V] {X Y : Vᵒᵖ} {f g : X ⟶ Y} (h : f.unop = g.unop) : f = g :=
+  Hom.opEquiv.symm.injective h
+
 /-- A type synonym for a quiver with no arrows. -/
 def Empty (V : Type u) : Type u := V
 


### PR DESCRIPTION
This powers up `aesop_cat`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
