### PR TITLE
[Merged by Bors] - chore: remove acceptSuggestionOnEnter option

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,6 @@
   "editor.insertSpaces": true,
   "editor.tabSize": 2,
   "editor.rulers" : [100],
-  "editor.acceptSuggestionOnEnter": "off",
   "files.encoding": "utf8",
   "files.eol": "\n",
   "files.insertFinalNewline": true,


### PR DESCRIPTION
Reverts #12749.

Discussion on zulip: [#mathlib4 > propose removing module docstring code suggestion @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/propose.20removing.20module.20docstring.20code.20suggestion/near/452477171)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
