### PR TITLE
[Merged by Bors] - fix(grewrite): `grw` not working on goals with `syntheticOpaque` mvars

### DIFF
--- a/Mathlib/Tactic/GCongr/Core.lean
+++ b/Mathlib/Tactic/GCongr/Core.lean
@@ -421,10 +421,12 @@ partial def _root_.Lean.MVarId.gcongr
     -- then try to resolve the goal by the provided tactic `mainGoalDischarger`;
     -- if this fails, stop and report the existing goal.
     if let .mvar mvarId := tpl.getAppFn then
-      if let .syntheticOpaque ← mvarId.getKind then
-        try mainGoalDischarger g; return (true, names, #[])
-        catch ex =>
-          if GRewriteHole.isSome then throw ex else return (false, names, #[g])
+      if let some hole := GRewriteHole then
+        if hole == mvarId then mainGoalDischarger g; return (true, names, #[])
+      else
+        if let .syntheticOpaque ← mvarId.getKind then
+          try mainGoalDischarger g; return (true, names, #[])
+          catch _ => return (false, names, #[g])
     -- (ii) if the template is *not* `?_` then continue on.
   -- Check that the goal is of the form `rel (lhsHead _ ... _) (rhsHead _ ... _)`
   let rel ← withReducible g.getType'

--- a/Mathlib/Tactic/GRewrite/Core.lean
+++ b/Mathlib/Tactic/GRewrite/Core.lean
@@ -116,11 +116,12 @@ def _root_.Lean.MVarId.grewrite (goal : MVarId) (e : Expr) (hrel : Expr)
         are rewritten, or specify what the rewritten expression should be and use 'gcongr'."
     let eNew ← if rhs.hasBinderNameHint then eNew.resolveBinderNameHint else pure eNew
     -- construct the implication proof using `gcongr`
-    let template := eAbst.instantiate1 (← mkFreshExprSyntheticOpaqueMVar default)
+    let hole ← mkFreshExprMVar default
+    let template := eAbst.instantiate1 hole
     let mkImp (e₁ e₂ : Expr) : Expr := .forallE `_a e₁ e₂ .default
     let imp := if forwardImp then mkImp e eNew else mkImp eNew e
     let gcongrGoal ← mkFreshExprMVar imp
-    let (_, _, sideGoals) ← gcongrGoal.mvarId!.gcongr template [] (inGRewrite := true)
+    let (_, _, sideGoals) ← gcongrGoal.mvarId!.gcongr template [] (GRewriteHole := hole.mvarId!)
       (mainGoalDischarger := GRewrite.dischargeMain hrel)
     -- post-process the metavariables
     postprocessAppMVars `grewrite goal newMVars binderInfos

--- a/Mathlib/Tactic/GRewrite/Core.lean
+++ b/Mathlib/Tactic/GRewrite/Core.lean
@@ -121,7 +121,7 @@ def _root_.Lean.MVarId.grewrite (goal : MVarId) (e : Expr) (hrel : Expr)
     let mkImp (e₁ e₂ : Expr) : Expr := .forallE `_a e₁ e₂ .default
     let imp := if forwardImp then mkImp e eNew else mkImp eNew e
     let gcongrGoal ← mkFreshExprMVar imp
-    let (_, _, sideGoals) ← gcongrGoal.mvarId!.gcongr template [] (GRewriteHole := hole.mvarId!)
+    let (_, _, sideGoals) ← gcongrGoal.mvarId!.gcongr template [] (grewriteHole := hole.mvarId!)
       (mainGoalDischarger := GRewrite.dischargeMain hrel)
     -- post-process the metavariables
     postprocessAppMVars `grewrite goal newMVars binderInfos

--- a/MathlibTest/GRewrite.lean
+++ b/MathlibTest/GRewrite.lean
@@ -294,3 +294,9 @@ example (h : p → q) (h' : q → r) : p → r := by
   exact h'
 
 end apply
+
+example : ∃ n, n < 2 := by
+  refine ⟨?_, ?_⟩
+  swap
+  grw [← one_lt_two]
+  apply zero_lt_one

--- a/MathlibTest/GRewrite.lean
+++ b/MathlibTest/GRewrite.lean
@@ -295,8 +295,9 @@ example (h : p → q) (h' : q → r) : p → r := by
 
 end apply
 
+-- previously, `grw` failed to rewrite in expressions with syntheticOpaque metavariables
 example : ∃ n, n < 2 := by
   refine ⟨?_, ?_⟩
-  swap
-  grw [← one_lt_two]
-  apply zero_lt_one
+  on_goal 2 => grw [← one_lt_two]
+  exact 0
+  refine zero_lt_one

--- a/MathlibTest/GRewrite.lean
+++ b/MathlibTest/GRewrite.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2023 Sebastian Zimmer. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Sebastian Zimmer, Mario Carneiro, Heather Macbeth
+Authors: Sebastian Zimmer, Mario Carneiro, Heather Macbeth, Jovan Gerbscheid
 -/
 import Mathlib.Data.Int.ModEq
 import Mathlib.Tactic.GRewrite


### PR DESCRIPTION
The `gcongr` tactic looks for syntheticOpaque metavariables in the template and interprets them as holes. If the target of `grewrite` already contains syntheticOpaque metavariables, then the produced template is 'corrupted' by these metavariables. This PR fixes this by letting `grewrite` tell `gcongr` exactly which metavariable is the hole.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
