### PR TITLE
feat(Data/Nat/Factors): added lemmas including `primeFactorsList_length_ne_zero`

### DIFF
--- a/Mathlib/Data/Nat/Factors.lean
+++ b/Mathlib/Data/Nat/Factors.lean
@@ -128,20 +128,17 @@ theorem primeFactorsList_eq_nil (n : ℕ) : n.primeFactorsList = [] ↔ n = 0 �
     · exact primeFactorsList_zero
     · exact primeFactorsList_one
 
-theorem primeFactorsList_length_ne_zero (n : ℕ) : n.primeFactorsList.length ≠ 0 ↔ 2 ≤ n := by
+theorem length_primeFactorsList_ne_zero (n : ℕ) : n.primeFactorsList.length ≠ 0 ↔ 2 ≤ n := by
   simp; omega
 
 @[simp]
 theorem primeFactorsList_length_eq_one (n : ℕ) : n.primeFactorsList.length = 1 ↔ n.Prime := by
   refine ⟨fun h ↦ ?_, fun h ↦ primeFactorsList_prime h ▸ rfl⟩
-  rcases List.length_eq_one_iff.mp h with ⟨p, hp⟩
+  obtain ⟨p, hp⟩ := List.length_eq_one_iff.mp h
   have : p = n := by
-    have : 2 ≤ n := n.primeFactorsList_length_ne_zero.mp (by simp +decide only [h])
-    have h₁ := n.prod_primeFactorsList (by omega)
-    simp only [hp, List.prod_singleton] at h₁
-    exact h₁
-  rw [this, primeFactorsList_prime_iff] at hp
-  exact hp
+    have : 2 ≤ n := n.length_primeFactorsList_ne_zero.mp (by simp +decide only [h])
+    simpa [hp, List.prod_singleton] using n.prod_primeFactorsList (by omega)
+  simpa [this, primeFactorsList_prime_iff] using hp
 
 open scoped List in
 theorem eq_of_perm_primeFactorsList {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0)

--- a/Mathlib/Data/Nat/Factors.lean
+++ b/Mathlib/Data/Nat/Factors.lean
@@ -123,6 +123,10 @@ theorem primeFactorsList_eq_nil (n : ℕ) : n.primeFactorsList = [] ↔ n = 0 �
     · exact primeFactorsList_zero
     · exact primeFactorsList_one
 
+@[simp]
+theorem primeFactorsList_length_ne_zero (n : ℕ) : n.primeFactorsList.length ≠ 0 ↔ 2 ≤ n := by
+  simp; omega
+
 open scoped List in
 theorem eq_of_perm_primeFactorsList {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0)
     (h : a.primeFactorsList ~ b.primeFactorsList) : a = b := by

--- a/Mathlib/Data/Nat/Factors.lean
+++ b/Mathlib/Data/Nat/Factors.lean
@@ -4,11 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 -/
 import Mathlib.Algebra.BigOperators.Ring.List
-import Mathlib.Data.Nat.GCD.Basic
-import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Data.List.Perm.Subperm
 import Mathlib.Data.List.Prime
 import Mathlib.Data.List.Sort
-import Mathlib.Data.List.Perm.Subperm
+import Mathlib.Data.Nat.GCD.Basic
+import Mathlib.Data.Nat.Prime.Basic
 
 /-!
 # Prime numbers
@@ -83,6 +83,11 @@ theorem primeFactorsList_prime {p : ℕ} (hp : Nat.Prime p) : p.primeFactorsList
   have : Nat.minFac p = p := (Nat.prime_def_minFac.mp hp).2
   simp only [this, primeFactorsList, Nat.div_self (Nat.Prime.pos hp)]
 
+theorem primeFactorsList_prime_iff {p : ℕ} : p.primeFactorsList = [p] ↔ p.Prime := by
+  refine ⟨fun h ↦ ?_, primeFactorsList_prime⟩
+  apply h ▸ prime_of_mem_primeFactorsList
+  exact List.mem_singleton_self _
+
 theorem primeFactorsList_chain {n : ℕ} :
     ∀ {a}, (∀ p, Prime p → p ∣ n → a ≤ p) → List.Chain (· ≤ ·) a (primeFactorsList n) := by
   match n with
@@ -123,9 +128,20 @@ theorem primeFactorsList_eq_nil (n : ℕ) : n.primeFactorsList = [] ↔ n = 0 �
     · exact primeFactorsList_zero
     · exact primeFactorsList_one
 
-@[simp]
 theorem primeFactorsList_length_ne_zero (n : ℕ) : n.primeFactorsList.length ≠ 0 ↔ 2 ≤ n := by
   simp; omega
+
+@[simp]
+theorem primeFactorsList_length_eq_one (n : ℕ) : n.primeFactorsList.length = 1 ↔ n.Prime := by
+  refine ⟨fun h ↦ ?_, fun h ↦ primeFactorsList_prime h ▸ rfl⟩
+  rcases List.length_eq_one_iff.mp h with ⟨p, hp⟩
+  have : p = n := by
+    have : 2 ≤ n := n.primeFactorsList_length_ne_zero.mp (by simp +decide only [h])
+    have h₁ := n.prod_primeFactorsList (by omega)
+    simp only [hp, List.prod_singleton] at h₁
+    exact h₁
+  rw [this, primeFactorsList_prime_iff] at hp
+  exact hp
 
 open scoped List in
 theorem eq_of_perm_primeFactorsList {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0)
@@ -314,3 +330,5 @@ theorem four_dvd_or_exists_odd_prime_and_dvd_of_two_lt {n : ℕ} (n2 : 2 < n) :
   · exact Or.inr ⟨p, hp, hdvd, hodd⟩
 
 end Nat
+
+#min_imports

--- a/Mathlib/Data/Nat/Factors.lean
+++ b/Mathlib/Data/Nat/Factors.lean
@@ -331,4 +331,3 @@ theorem four_dvd_or_exists_odd_prime_and_dvd_of_two_lt {n : ℕ} (n2 : 2 < n) :
 
 end Nat
 
-#min_imports


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Added lemmas `primeFactorsList_length_ne_zero`, `primeFactorsList_prime_iff`, and `primeFactorsList_length_eq_one`.

```lean
theorem primeFactorsList_length_ne_zero (n : ℕ) : n.primeFactorsList.length ≠ 0 ↔ 2 ≤ n

theorem primeFactorsList_prime_iff {p : ℕ} : p.primeFactorsList = [p] ↔ p.Prime

@[simp]
theorem primeFactorsList_length_eq_one (n : ℕ) : n.primeFactorsList.length = 1 ↔ n.Prime
```

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)


