### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/Basis/MulOpposite): basis of an opposite space

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3878,6 +3878,7 @@ import Mathlib.LinearAlgebra.Basis.Defs
 import Mathlib.LinearAlgebra.Basis.Exact
 import Mathlib.LinearAlgebra.Basis.Fin
 import Mathlib.LinearAlgebra.Basis.Flag
+import Mathlib.LinearAlgebra.Basis.MulOpposite
 import Mathlib.LinearAlgebra.Basis.Prod
 import Mathlib.LinearAlgebra.Basis.SMul
 import Mathlib.LinearAlgebra.Basis.Submodule

--- a/Mathlib/LinearAlgebra/Basis/MulOpposite.lean
+++ b/Mathlib/LinearAlgebra/Basis/MulOpposite.lean
@@ -49,8 +49,10 @@ instance Module.Free.mulOpposite [Semiring R] [AddCommMonoid H] [Module R H]
   let ⟨b⟩ := exists_basis (R := R) (M := H)
   of_basis b.2.mulOpposite
 
-theorem MulOpposite.finrank [Semiring R] [AddCommMonoid H] [Module R H] :
-    Module.finrank R Hᵐᵒᵖ = Module.finrank R Hᵐᵒᵖ := rfl
+theorem MulOpposite.finrank [DivisionRing R] [AddCommGroup H] [Module R H] :
+    Module.finrank R Hᵐᵒᵖ = Module.finrank R H := by
+  let b := Basis.ofVectorSpace R H
+  rw [Module.finrank_eq_nat_card_basis b, Module.finrank_eq_nat_card_basis b.mulOpposite]
 
 theorem MulOpposite.rank [Semiring R] [StrongRankCondition R] [AddCommMonoid H] [Module R H]
     [Module.Free R H] : Module.rank R Hᵐᵒᵖ = Module.rank R H :=

--- a/Mathlib/LinearAlgebra/Basis/MulOpposite.lean
+++ b/Mathlib/LinearAlgebra/Basis/MulOpposite.lean
@@ -30,10 +30,11 @@ theorem mulOpposite_repr_eq (b : Basis ι R H) :
     b.mulOpposite.repr = (MulOpposite.opLinearEquiv R).symm.trans b.repr := rfl
 
 @[simp]
-theorem mulOpposite_repr_apply (b : Basis ι R H) (x : Hᵐᵒᵖ) :
-    b.mulOpposite.repr x = b.repr (MulOpposite.unop x) := rfl
+theorem mulOpposite_repr_unop (b : Basis ι R H) (x : Hᵐᵒᵖ) :
+    b.repr (MulOpposite.unop x) = b.mulOpposite.repr x := rfl
 
-theorem mulOpposite_repr_apply' (b : Basis ι R H) (x : H) :
+@[simp]
+theorem mulOpposite_repr_op (b : Basis ι R H) (x : H) :
     b.mulOpposite.repr (MulOpposite.op x) = b.repr x := rfl
 
 end Basis

--- a/Mathlib/LinearAlgebra/Basis/MulOpposite.lean
+++ b/Mathlib/LinearAlgebra/Basis/MulOpposite.lean
@@ -44,7 +44,7 @@ instance FiniteDimensional.mulOpposite [DivisionRing R] [AddCommGroup H] [Module
   (Basis.ofVectorSpace R H).mulOpposite
   (Basis.ofVectorSpaceIndex R H).toFinite
 
-instance Module.Free.mulOpposite [Semiring R] [AddCommMonoid H] [Module R H]
+instance [Semiring R] [AddCommMonoid H] [Module R H]
     [Module.Free R H] : Module.Free R Hᵐᵒᵖ :=
   let ⟨b⟩ := exists_basis (R := R) (M := H)
   of_basis b.2.mulOpposite

--- a/Mathlib/LinearAlgebra/Basis/MulOpposite.lean
+++ b/Mathlib/LinearAlgebra/Basis/MulOpposite.lean
@@ -12,9 +12,11 @@ This file defines the basis of an opposite space and shows
 that the opposite space is finite-dimensional and free when the original space is.
 -/
 
+variable {R H : Type*}
+
 namespace Basis
 
-variable {ι R H : Type*} [Semiring R] [AddCommMonoid H] [Module R H]
+variable {ι : Type*} [Semiring R] [AddCommMonoid H] [Module R H]
 
 /-- the mulOpposite of a basis: `b.mulOpposite i ↦ MulOpposite.op (b i)` -/
 noncomputable def mulOpposite (b : Basis ι R H) : Basis ι R Hᵐᵒᵖ :=
@@ -36,12 +38,19 @@ theorem mulOpposite_repr_apply' (b : Basis ι R H) (x : H) :
 
 end Basis
 
-instance FiniteDimensional.mulOpposite {R H : Type*} [DivisionRing R] [AddCommGroup H] [Module R H]
+instance FiniteDimensional.mulOpposite [DivisionRing R] [AddCommGroup H] [Module R H]
     [FiniteDimensional R H] : FiniteDimensional R Hᵐᵒᵖ := FiniteDimensional.of_finite_basis
   (Basis.ofVectorSpace R H).mulOpposite
   (Basis.ofVectorSpaceIndex R H).toFinite
 
-instance Module.Free.mulOpposite {R H : Type*} [Semiring R] [AddCommMonoid H] [Module R H]
+instance Module.Free.mulOpposite [Semiring R] [AddCommMonoid H] [Module R H]
     [Module.Free R H] : Module.Free R Hᵐᵒᵖ :=
   let ⟨b⟩ := exists_basis (R := R) (M := H)
   of_basis b.2.mulOpposite
+
+theorem MulOpposite.finrank [Semiring R] [AddCommMonoid H] [Module R H] :
+    Module.finrank R Hᵐᵒᵖ = Module.finrank R Hᵐᵒᵖ := rfl
+
+theorem MulOpposite.rank [Semiring R] [StrongRankCondition R] [AddCommMonoid H] [Module R H]
+    [Module.Free R H] : Module.rank R Hᵐᵒᵖ = Module.rank R H :=
+  LinearEquiv.nonempty_equiv_iff_rank_eq.mp ⟨(MulOpposite.opLinearEquiv R).symm⟩

--- a/Mathlib/LinearAlgebra/Basis/MulOpposite.lean
+++ b/Mathlib/LinearAlgebra/Basis/MulOpposite.lean
@@ -16,44 +16,49 @@ variable {R H : Type*}
 
 namespace Basis
 
+open MulOpposite
+
 variable {ι : Type*} [Semiring R] [AddCommMonoid H] [Module R H]
 
-/-- the mulOpposite of a basis: `b.mulOpposite i ↦ MulOpposite.op (b i)` -/
+/-- The multiplicative opposite of a basis: `b.mulOpposite i ↦ op (b i)`. -/
 noncomputable def mulOpposite (b : Basis ι R H) : Basis ι R Hᵐᵒᵖ :=
-  b.map (MulOpposite.opLinearEquiv R)
+  b.map (opLinearEquiv R)
 
 @[simp]
 theorem mulOpposite_apply (b : Basis ι R H) (i : ι) :
-    b.mulOpposite i = MulOpposite.op (b i) := rfl
+    b.mulOpposite i = op (b i) := rfl
 
 theorem mulOpposite_repr_eq (b : Basis ι R H) :
-    b.mulOpposite.repr = (MulOpposite.opLinearEquiv R).symm.trans b.repr := rfl
+    b.mulOpposite.repr = (opLinearEquiv R).symm.trans b.repr := rfl
 
 @[simp]
 theorem mulOpposite_repr_unop (b : Basis ι R H) (x : Hᵐᵒᵖ) :
-    b.repr (MulOpposite.unop x) = b.mulOpposite.repr x := rfl
+    b.repr (unop x) = b.mulOpposite.repr x := rfl
 
 @[simp]
 theorem mulOpposite_repr_op (b : Basis ι R H) (x : H) :
-    b.mulOpposite.repr (MulOpposite.op x) = b.repr x := rfl
+    b.mulOpposite.repr (op x) = b.repr x := rfl
 
 end Basis
 
-instance FiniteDimensional.mulOpposite [DivisionRing R] [AddCommGroup H] [Module R H]
+namespace MulOpposite
+
+instance [DivisionRing R] [AddCommGroup H] [Module R H]
     [FiniteDimensional R H] : FiniteDimensional R Hᵐᵒᵖ := FiniteDimensional.of_finite_basis
-  (Basis.ofVectorSpace R H).mulOpposite
-  (Basis.ofVectorSpaceIndex R H).toFinite
+  (Basis.ofVectorSpace R H).mulOpposite (Basis.ofVectorSpaceIndex R H).toFinite
 
 instance [Semiring R] [AddCommMonoid H] [Module R H]
     [Module.Free R H] : Module.Free R Hᵐᵒᵖ :=
-  let ⟨b⟩ := exists_basis (R := R) (M := H)
-  of_basis b.2.mulOpposite
+  let ⟨b⟩ := Module.Free.exists_basis (R := R) (M := H)
+  Module.Free.of_basis b.2.mulOpposite
 
-theorem MulOpposite.finrank [DivisionRing R] [AddCommGroup H] [Module R H] :
+theorem rank [Semiring R] [StrongRankCondition R] [AddCommMonoid H] [Module R H]
+    [Module.Free R H] : Module.rank R Hᵐᵒᵖ = Module.rank R H :=
+  LinearEquiv.nonempty_equiv_iff_rank_eq.mp ⟨(opLinearEquiv R).symm⟩
+
+theorem finrank [DivisionRing R] [AddCommGroup H] [Module R H] :
     Module.finrank R Hᵐᵒᵖ = Module.finrank R H := by
   let b := Basis.ofVectorSpace R H
   rw [Module.finrank_eq_nat_card_basis b, Module.finrank_eq_nat_card_basis b.mulOpposite]
 
-theorem MulOpposite.rank [Semiring R] [StrongRankCondition R] [AddCommMonoid H] [Module R H]
-    [Module.Free R H] : Module.rank R Hᵐᵒᵖ = Module.rank R H :=
-  LinearEquiv.nonempty_equiv_iff_rank_eq.mp ⟨(MulOpposite.opLinearEquiv R).symm⟩
+end MulOpposite

--- a/Mathlib/LinearAlgebra/Basis/MulOpposite.lean
+++ b/Mathlib/LinearAlgebra/Basis/MulOpposite.lean
@@ -32,7 +32,7 @@ theorem mulOpposite_repr_eq (b : Basis ι R H) :
     b.mulOpposite.repr = (opLinearEquiv R).symm.trans b.repr := rfl
 
 @[simp]
-theorem mulOpposite_repr_unop (b : Basis ι R H) (x : Hᵐᵒᵖ) :
+theorem repr_unop_eq_mulOpposite_repr (b : Basis ι R H) (x : Hᵐᵒᵖ) :
     b.repr (unop x) = b.mulOpposite.repr x := rfl
 
 @[simp]

--- a/Mathlib/LinearAlgebra/Basis/MulOpposite.lean
+++ b/Mathlib/LinearAlgebra/Basis/MulOpposite.lean
@@ -1,0 +1,47 @@
+/-
+Copyright (c) 2025 Monica Omar. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Monica Omar
+-/
+import Mathlib.LinearAlgebra.FiniteDimensional.Defs
+
+/-!
+# Basis of an opposite space
+
+This file defines the basis of an opposite space and shows
+that the opposite space is finite-dimensional and free when the original space is.
+-/
+
+namespace Basis
+
+variable {ι R H : Type*} [Semiring R] [AddCommMonoid H] [Module R H]
+
+noncomputable def mulOpposite (b : Basis ι R H) : Basis ι R Hᵐᵒᵖ :=
+b.map (MulOpposite.opLinearEquiv R)
+
+@[simp]
+theorem mulOpposite_apply (b : Basis ι R H) (i : ι) :
+  b.mulOpposite i = MulOpposite.op (b i) := rfl
+
+theorem mulOpposite_repr_eq (b : Basis ι R H) :
+  b.mulOpposite.repr = (MulOpposite.opLinearEquiv R).symm.trans b.repr := rfl
+
+@[simp]
+theorem mulOpposite_repr_apply (b : Basis ι R H) (x : Hᵐᵒᵖ) :
+  b.mulOpposite.repr x = b.repr (MulOpposite.unop x) := rfl
+
+theorem mulOpposite_repr_apply' (b : Basis ι R H) (x : H) :
+  b.mulOpposite.repr (MulOpposite.op x) = b.repr x := rfl
+
+end Basis
+
+instance {R H : Type*} [DivisionRing R] [AddCommGroup H] [Module R H]
+  [FiniteDimensional R H] : FiniteDimensional R Hᵐᵒᵖ :=
+FiniteDimensional.of_finite_basis
+  (Basis.ofVectorSpace R H).mulOpposite
+  (Basis.ofVectorSpaceIndex R H).toFinite
+
+instance Module.Free.mulOpposite {R H : Type*} [Semiring R] [AddCommMonoid H] [Module R H]
+  [Module.Free R H] : Module.Free R Hᵐᵒᵖ :=
+  let ⟨b⟩ := exists_basis (R := R) (M := H)
+  of_basis b.2.mulOpposite

--- a/Mathlib/LinearAlgebra/Basis/MulOpposite.lean
+++ b/Mathlib/LinearAlgebra/Basis/MulOpposite.lean
@@ -18,7 +18,7 @@ variable {ι R H : Type*} [Semiring R] [AddCommMonoid H] [Module R H]
 
 /-- the mulOpposite of a basis: `b.mulOpposite i ↦ MulOpposite.op (b i)` -/
 noncomputable def mulOpposite (b : Basis ι R H) : Basis ι R Hᵐᵒᵖ :=
-b.map (MulOpposite.opLinearEquiv R)
+  b.map (MulOpposite.opLinearEquiv R)
 
 @[simp]
 theorem mulOpposite_apply (b : Basis ι R H) (i : ι) :

--- a/Mathlib/LinearAlgebra/Basis/MulOpposite.lean
+++ b/Mathlib/LinearAlgebra/Basis/MulOpposite.lean
@@ -36,7 +36,7 @@ theorem mulOpposite_repr_apply' (b : Basis ι R H) (x : H) :
 
 end Basis
 
-instance {R H : Type*} [DivisionRing R] [AddCommGroup H] [Module R H]
+instance FiniteDimensional.mulOpposite {R H : Type*} [DivisionRing R] [AddCommGroup H] [Module R H]
   [FiniteDimensional R H] : FiniteDimensional R Hᵐᵒᵖ :=
 FiniteDimensional.of_finite_basis
   (Basis.ofVectorSpace R H).mulOpposite

--- a/Mathlib/LinearAlgebra/Basis/MulOpposite.lean
+++ b/Mathlib/LinearAlgebra/Basis/MulOpposite.lean
@@ -22,27 +22,26 @@ b.map (MulOpposite.opLinearEquiv R)
 
 @[simp]
 theorem mulOpposite_apply (b : Basis ι R H) (i : ι) :
-  b.mulOpposite i = MulOpposite.op (b i) := rfl
+    b.mulOpposite i = MulOpposite.op (b i) := rfl
 
 theorem mulOpposite_repr_eq (b : Basis ι R H) :
-  b.mulOpposite.repr = (MulOpposite.opLinearEquiv R).symm.trans b.repr := rfl
+    b.mulOpposite.repr = (MulOpposite.opLinearEquiv R).symm.trans b.repr := rfl
 
 @[simp]
 theorem mulOpposite_repr_apply (b : Basis ι R H) (x : Hᵐᵒᵖ) :
-  b.mulOpposite.repr x = b.repr (MulOpposite.unop x) := rfl
+    b.mulOpposite.repr x = b.repr (MulOpposite.unop x) := rfl
 
 theorem mulOpposite_repr_apply' (b : Basis ι R H) (x : H) :
-  b.mulOpposite.repr (MulOpposite.op x) = b.repr x := rfl
+    b.mulOpposite.repr (MulOpposite.op x) = b.repr x := rfl
 
 end Basis
 
 instance FiniteDimensional.mulOpposite {R H : Type*} [DivisionRing R] [AddCommGroup H] [Module R H]
-  [FiniteDimensional R H] : FiniteDimensional R Hᵐᵒᵖ :=
-FiniteDimensional.of_finite_basis
+    [FiniteDimensional R H] : FiniteDimensional R Hᵐᵒᵖ := FiniteDimensional.of_finite_basis
   (Basis.ofVectorSpace R H).mulOpposite
   (Basis.ofVectorSpaceIndex R H).toFinite
 
 instance Module.Free.mulOpposite {R H : Type*} [Semiring R] [AddCommMonoid H] [Module R H]
-  [Module.Free R H] : Module.Free R Hᵐᵒᵖ :=
+    [Module.Free R H] : Module.Free R Hᵐᵒᵖ :=
   let ⟨b⟩ := exists_basis (R := R) (M := H)
   of_basis b.2.mulOpposite

--- a/Mathlib/LinearAlgebra/Basis/MulOpposite.lean
+++ b/Mathlib/LinearAlgebra/Basis/MulOpposite.lean
@@ -16,6 +16,7 @@ namespace Basis
 
 variable {ι R H : Type*} [Semiring R] [AddCommMonoid H] [Module R H]
 
+/-- the mulOpposite of a basis: `b.mulOpposite i ↦ MulOpposite.op (b i)` -/
 noncomputable def mulOpposite (b : Basis ι R H) : Basis ι R Hᵐᵒᵖ :=
 b.map (MulOpposite.opLinearEquiv R)
 


### PR DESCRIPTION
This adds the definition of `Basis.mulOpposite` and shows finite-dimensionality and freeness of `Hᵐᵒᵖ`.

For motivation, see #25951.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
