### PR TITLE
[Merged by Bors] - chore: add a pointwise version of `setLIntegral_congr_fun`, append `ae` to the current version

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/JapaneseBracket.lean
+++ b/Mathlib/Analysis/SpecialFunctions/JapaneseBracket.lean
@@ -101,7 +101,7 @@ theorem finite_integral_one_add_norm {r : ℝ} (hnr : (finrank ℝ E : ℝ) < r)
     ext x
     simp only [mem_setOf_eq, mem_closedBall_zero_iff]
     exact le_rpow_one_add_norm_iff_norm_le hr (mem_Ioi.mp ht) x
-  rw [setLIntegral_congr_fun measurableSet_Ioi (Eventually.of_forall h_int)]
+  rw [setLIntegral_congr_fun measurableSet_Ioi h_int]
   set f := fun t : ℝ ↦ μ (Metric.closedBall (0 : E) (t ^ (-r⁻¹) - 1))
   set mB := μ (Metric.ball (0 : E) 1)
   -- the next two inequalities are in fact equalities but we don't need that
@@ -115,7 +115,7 @@ theorem finite_integral_one_add_norm {r : ℝ} (hnr : (finrank ℝ E : ℝ) < r)
       refine μ.addHaar_closedBall (0 : E) ?_
       rw [sub_nonneg]
       exact Real.one_le_rpow_of_pos_of_le_one_of_nonpos ht.1 ht.2 (by simp [hr.le])
-    rw [setLIntegral_congr_fun measurableSet_Ioc (ae_of_all _ h_int'),
+    rw [setLIntegral_congr_fun measurableSet_Ioc h_int',
       lintegral_mul_const' _ _ measure_ball_lt_top.ne]
     exact ENNReal.mul_lt_top
       (finite_integral_rpow_sub_one_pow_aux (finrank ℝ E) hnr) measure_ball_lt_top
@@ -123,7 +123,7 @@ theorem finite_integral_one_add_norm {r : ℝ} (hnr : (finrank ℝ E : ℝ) < r)
     have h_int'' : ∀ t ∈ Ioi (1 : ℝ), f t = 0 := fun t ht => by
       simp only [f, closedBall_rpow_sub_one_eq_empty_aux E hr ht, measure_empty]
     -- The integral over the constant zero function is finite:
-    rw [setLIntegral_congr_fun measurableSet_Ioi (ae_of_all volume <| h_int''), lintegral_const 0,
+    rw [setLIntegral_congr_fun measurableSet_Ioi h_int'', lintegral_const 0,
       zero_mul]
     exact WithTop.top_pos
 

--- a/Mathlib/Analysis/SpecialFunctions/PolarCoord.lean
+++ b/Mathlib/Analysis/SpecialFunctions/PolarCoord.lean
@@ -162,8 +162,8 @@ theorem lintegral_comp_polarCoord_symm (f : ℝ × ℝ → ℝ≥0∞) :
       · simp_rw [det_fderivPolarCoordSymm]; rfl
       exacts [polarCoord.symm.injOn, measurableSet_Ioi.prod measurableSet_Ioo]
     _ = ∫⁻ (p : ℝ × ℝ) in polarCoord.target, ENNReal.ofReal p.1 • f (polarCoord.symm p) := by
-      refine setLIntegral_congr_fun polarCoord.open_target.measurableSet ?_
-      filter_upwards with _ hx using by rw [abs_of_pos hx.1]
+      refine setLIntegral_congr_fun polarCoord.open_target.measurableSet (fun x hx ↦ ?_)
+      rw [abs_of_pos hx.1]
 
 end Real
 
@@ -286,8 +286,7 @@ theorem lintegral_comp_pi_polarCoord_symm (f : (ι → ℝ × ℝ) → ℝ≥0�
   convert (lintegral_image_eq_lintegral_abs_det_fderiv_mul volume measurableSet_pi_polarCoord_target
     (fun p _ ↦ (hasFDerivAt_pi_polarCoord_symm p).hasFDerivWithinAt)
       injOn_pi_polarCoord_symm f).symm using 1
-  refine setLIntegral_congr_fun measurableSet_pi_polarCoord_target ?_
-  filter_upwards with x hx
+  refine setLIntegral_congr_fun measurableSet_pi_polarCoord_target (fun x hx ↦ ?_)
   simp_rw [det_fderivPiPolarCoordSymm, Finset.abs_prod, ENNReal.ofReal_prod_of_nonneg (fun _ _ ↦
     abs_nonneg _), abs_fst_of_mem_pi_polarCoord_target hx]
 

--- a/Mathlib/MeasureTheory/Covering/Differentiation.lean
+++ b/Mathlib/MeasureTheory/Covering/Differentiation.lean
@@ -815,8 +815,8 @@ theorem ae_tendsto_lintegral_enorm_sub_div'_of_integrable {f : α → E} (hf : I
     filter_upwards [v.eventually_filterAt_subset_of_nhds (IsOpen.mem_nhds (A.set_mem n) xn),
       v.eventually_filterAt_measurableSet x] with a ha h'a
     congr 1
-    apply setLIntegral_congr_fun h'a
-    filter_upwards with y hy using (by simp only [ha hy, indicator_of_mem])
+    apply setLIntegral_congr_fun h'a (fun y hy ↦ ?_)
+    simp only [ha hy, indicator_of_mem]
   apply ENNReal.tendsto_nhds_zero.2 fun ε εpos => ?_
   obtain ⟨c, ct, xc⟩ : ∃ c ∈ t, ‖f x - c‖ₑ < ε / 2 := by
     simp_rw [← edist_eq_enorm_sub]
@@ -875,7 +875,7 @@ theorem ae_tendsto_lintegral_enorm_sub_div {f : α → E} (hf : LocallyIntegrabl
   filter_upwards [v.eventually_filterAt_subset_of_nhds ((u_open n).mem_nhds hn),
     v.eventually_filterAt_measurableSet x] with a ha h'a
   congr 1
-  refine setLIntegral_congr_fun h'a (Eventually.of_forall (fun y hy ↦ ?_))
+  refine setLIntegral_congr_fun h'a (fun y hy ↦ ?_)
   rw [indicator_of_mem (ha hy) f, indicator_of_mem hn f]
 
 @[deprecated (since := "2025-01-22")]

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL2.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL2.lean
@@ -365,7 +365,7 @@ theorem setLIntegral_nnnorm_condExpL2_indicator_le (hm : m ≤ m0) (hs : Measura
   calc
     ∫⁻ a in t, ‖(condExpL2 E' 𝕜 hm (indicatorConstLp 2 hs hμs x) : α → E') a‖₊ ∂μ =
         ∫⁻ a in t, ‖(condExpL2 ℝ ℝ hm (indicatorConstLp 2 hs hμs 1) : α → ℝ) a • x‖₊ ∂μ :=
-      setLIntegral_congr_fun (hm t ht)
+      setLIntegral_congr_fun_ae (hm t ht)
         ((condExpL2_indicator_ae_eq_smul 𝕜 hm hs hμs x).mono fun a ha _ => by rw [ha])
     _ = (∫⁻ a in t, ‖(condExpL2 ℝ ℝ hm (indicatorConstLp 2 hs hμs 1) : α → ℝ) a‖₊ ∂μ) * ‖x‖₊ := by
       simp_rw [nnnorm_smul, ENNReal.coe_mul]
@@ -464,7 +464,7 @@ theorem setLIntegral_nnnorm_condExpIndSMul_le (hm : m ≤ m0) (hs : MeasurableSe
   calc
     ∫⁻ a in t, ‖condExpIndSMul hm hs hμs x a‖₊ ∂μ =
         ∫⁻ a in t, ‖(condExpL2 ℝ ℝ hm (indicatorConstLp 2 hs hμs 1) : α → ℝ) a • x‖₊ ∂μ :=
-      setLIntegral_congr_fun (hm t ht)
+      setLIntegral_congr_fun_ae (hm t ht)
         ((condExpIndSMul_ae_eq_smul hm hs hμs x).mono fun a ha _ => by rw [ha])
     _ = (∫⁻ a in t, ‖(condExpL2 ℝ ℝ hm (indicatorConstLp 2 hs hμs 1) : α → ℝ) a‖₊ ∂μ) * ‖x‖₊ := by
       simp_rw [nnnorm_smul, ENNReal.coe_mul]

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -828,14 +828,13 @@ protected lemma MemLp.piecewise {f : α → ε} [DecidablePred (· ∈ s)] {g} (
   rw [eLpNorm_lt_top_iff_lintegral_rpow_enorm_lt_top hp_zero hp_top, ← lintegral_add_compl _ hs,
     ENNReal.add_lt_top]
   constructor
-  · have h : ∀ᵐ x ∂μ, x ∈ s → ‖Set.piecewise s f g x‖ₑ ^ p.toReal = ‖f x‖ₑ ^ p.toReal := by
-      filter_upwards with a ha using by simp [ha]
+  · have h (x) (hx : x ∈ s) : ‖Set.piecewise s f g x‖ₑ ^ p.toReal = ‖f x‖ₑ ^ p.toReal := by
+      simp [hx]
     rw [setLIntegral_congr_fun hs h]
     exact lintegral_rpow_enorm_lt_top_of_eLpNorm_lt_top hp_zero hp_top hf.2
-  · have h : ∀ᵐ x ∂μ, x ∈ sᶜ → ‖Set.piecewise s f g x‖ₑ ^ p.toReal = ‖g x‖ₑ ^ p.toReal := by
-      filter_upwards with a ha
-      have ha' : a ∉ s := ha
-      simp [ha']
+  · have h (x) (hx : x ∈ sᶜ) : ‖Set.piecewise s f g x‖ₑ ^ p.toReal = ‖g x‖ₑ ^ p.toReal := by
+      have hx' : x ∉ s := hx
+      simp [hx']
     rw [setLIntegral_congr_fun hs.compl h]
     exact lintegral_rpow_enorm_lt_top_of_eLpNorm_lt_top hp_zero hp_top hg.2
 

--- a/Mathlib/MeasureTheory/Integral/Average.lean
+++ b/Mathlib/MeasureTheory/Integral/Average.lean
@@ -140,7 +140,11 @@ theorem setLAverage_congr (h : s =ᵐ[μ] t) : ⨍⁻ x in s, f x ∂μ = ⨍⁻
 
 @[deprecated (since := "2025-04-22")] alias setLaverage_congr := setLAverage_congr
 
-theorem setLAverage_congr_fun (hs : MeasurableSet s) (h : ∀ᵐ x ∂μ, x ∈ s → f x = g x) :
+theorem setLAverage_congr_fun_ae (hs : MeasurableSet s) (h : ∀ᵐ x ∂μ, x ∈ s → f x = g x) :
+    ⨍⁻ x in s, f x ∂μ = ⨍⁻ x in s, g x ∂μ := by
+  simp only [laverage_eq, setLIntegral_congr_fun_ae hs h]
+
+theorem setLAverage_congr_fun (hs : MeasurableSet s) (h : EqOn f g s) :
     ⨍⁻ x in s, f x ∂μ = ⨍⁻ x in s, g x ∂μ := by
   simp only [laverage_eq, setLIntegral_congr_fun hs h]
 

--- a/Mathlib/MeasureTheory/Integral/Layercake.lean
+++ b/Mathlib/MeasureTheory/Integral/Layercake.lean
@@ -342,7 +342,7 @@ theorem lintegral_comp_eq_lintegral_meas_le_mul_of_measurable (μ : Measure α)
     have meas : MeasurableSet {a | M < f a} := measurableSet_lt measurable_const f_mble
     have I : ∫⁻ ω in {a | M < f a}ᶜ, ENNReal.ofReal (∫ t in (0).. f ω, g t) ∂μ
              = ∫⁻ _ in {a | M < f a}ᶜ, 0 ∂μ := by
-      apply setLIntegral_congr_fun meas.compl (Eventually.of_forall (fun s hs ↦ ?_))
+      apply setLIntegral_congr_fun meas.compl (fun s hs ↦ ?_)
       have : ∫ (t : ℝ) in (0)..f s, g t = ∫ (t : ℝ) in (0)..f s, 0 := by
         simp_rw [intervalIntegral.integral_of_le (f_nonneg s)]
         apply integral_congr_ae
@@ -363,7 +363,7 @@ theorem lintegral_comp_eq_lintegral_meas_le_mul_of_measurable (μ : Measure α)
       simp [ht]
     have B2 : ∫⁻ t in Ioi M, μ {a : α | t ≤ f a} * ENNReal.ofReal (g t)
               = ∫⁻ t in Ioi M, ν {a : α | t ≤ f a} * ENNReal.ofReal (g t) := by
-      apply setLIntegral_congr_fun measurableSet_Ioi (Eventually.of_forall (fun t ht ↦ ?_))
+      apply setLIntegral_congr_fun measurableSet_Ioi (fun t ht ↦ ?_)
       rw [Measure.restrict_apply (measurableSet_le measurable_const f_mble)]
       congr 3
       exact (inter_eq_left.2 (fun a ha ↦ (mem_Ioi.1 ht).trans_le ha)).symm
@@ -526,7 +526,7 @@ theorem Integrable.integral_eq_integral_meas_lt
       (fun t ↦ μ.real {a : α | t < f a}) ?_ ?_
     · rw [aux]
       congr 1
-      apply setLIntegral_congr_fun measurableSet_Ioi (Eventually.of_forall _)
+      apply setLIntegral_congr_fun measurableSet_Ioi
       exact fun t t_pos ↦ ENNReal.ofReal_toReal (rhs_integrand_finite t t_pos).ne
     · exact Eventually.of_forall (fun x ↦ by positivity)
     · apply Measurable.aestronglyMeasurable

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
@@ -261,11 +261,19 @@ theorem lintegral_congr {f g : α → ℝ≥0∞} (h : ∀ a, f a = g a) : ∫�
 theorem setLIntegral_congr {f : α → ℝ≥0∞} {s t : Set α} (h : s =ᵐ[μ] t) :
     ∫⁻ x in s, f x ∂μ = ∫⁻ x in t, f x ∂μ := by rw [Measure.restrict_congr_set h]
 
-theorem setLIntegral_congr_fun {f g : α → ℝ≥0∞} {s : Set α} (hs : MeasurableSet s)
+theorem setLIntegral_congr_fun_ae {f g : α → ℝ≥0∞} {s : Set α} (hs : MeasurableSet s)
     (hfg : ∀ᵐ x ∂μ, x ∈ s → f x = g x) : ∫⁻ x in s, f x ∂μ = ∫⁻ x in s, g x ∂μ := by
   rw [lintegral_congr_ae]
   rw [EventuallyEq]
   rwa [ae_restrict_iff' hs]
+
+theorem setLIntegral_congr_fun {f g : α → ℝ≥0∞} {s : Set α} (hs : MeasurableSet s)
+    (hfg : EqOn f g s) : ∫⁻ x in s, f x ∂μ = ∫⁻ x in s, g x ∂μ :=
+  setLIntegral_congr_fun_ae hs <| Eventually.of_forall hfg
+
+lemma setLIntegral_eq_zero {f : α → ℝ≥0∞} {s : Set α} (hs : MeasurableSet s) (h's : EqOn f 0 s) :
+    ∫⁻ x in s, f x ∂μ = 0 := by
+  simp [setLIntegral_congr_fun hs h's]
 
 section
 
@@ -506,7 +514,7 @@ lemma setLIntegral_eq_of_support_subset {s : Set α} {f : α → ℝ≥0∞} (hs
 
 theorem setLIntegral_eq_const {f : α → ℝ≥0∞} (hf : Measurable f) (r : ℝ≥0∞) :
     ∫⁻ x in { x | f x = r }, f x ∂μ = r * μ { x | f x = r } := by
-  have : ∀ᵐ x ∂μ, x ∈ { x | f x = r } → f x = r := ae_of_all μ fun _ hx => hx
+  have : ∀ x ∈ { x | f x = r }, f x = r := fun _ hx => hx
   rw [setLIntegral_congr_fun _ this]
   · rw [lintegral_const, Measure.restrict_apply MeasurableSet.univ, Set.univ_inter]
   · exact hf (measurableSet_singleton r)
@@ -596,8 +604,8 @@ lemma lintegral_piecewise (hs : MeasurableSet s) (f g : α → ℝ≥0∞) [∀ 
     ∫⁻ a, s.piecewise f g a ∂μ = ∫⁻ a in s, f a ∂μ + ∫⁻ a in sᶜ, g a ∂μ := by
   rw [← lintegral_add_compl _ hs]
   congr 1
-  · exact setLIntegral_congr_fun hs <| ae_of_all μ fun _ ↦ Set.piecewise_eq_of_mem _ _ _
-  · exact setLIntegral_congr_fun hs.compl <| ae_of_all μ fun _ ↦ Set.piecewise_eq_of_notMem _ _ _
+  · exact setLIntegral_congr_fun hs <| fun _ ↦ Set.piecewise_eq_of_mem _ _ _
+  · exact setLIntegral_congr_fun hs.compl <| fun _ ↦ Set.piecewise_eq_of_notMem _ _ _
 
 theorem setLIntegral_compl {f : α → ℝ≥0∞} {s : Set α} (hsm : MeasurableSet s)
     (hfs : ∫⁻ x in s, f x ∂μ ≠ ∞) :
@@ -619,8 +627,8 @@ theorem lintegral_max {f g : α → ℝ≥0∞} (hf : Measurable f) (hg : Measur
   rw [← lintegral_add_compl (fun x => max (f x) (g x)) hm]
   simp only [← compl_setOf, ← not_le]
   refine congr_arg₂ (· + ·) (setLIntegral_congr_fun hm ?_) (setLIntegral_congr_fun hm.compl ?_)
-  exacts [ae_of_all _ fun x => max_eq_right (a := f x) (b := g x),
-    ae_of_all _ fun x (hx : ¬ f x ≤ g x) => max_eq_left (not_le.1 hx).le]
+  exacts [fun x => max_eq_right (a := f x) (b := g x),
+    fun x (hx : ¬ f x ≤ g x) => max_eq_left (not_le.1 hx).le]
 
 theorem setLIntegral_max {f g : α → ℝ≥0∞} (hf : Measurable f) (hg : Measurable g) (s : Set α) :
     ∫⁻ x in s, max (f x) (g x) ∂μ =

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Sub.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Sub.lean
@@ -167,7 +167,7 @@ theorem exists_setLIntegral_compl_lt {f : α → ℝ≥0∞} (hf : ∫⁻ a, f a
   calc
     ∫⁻ a in (support g)ᶜ, f a ∂μ
       = ∫⁻ a in (support g)ᶜ, f a - g a ∂μ := setLIntegral_congr_fun
-      (measurableSet_support hg_meas).compl <| ae_of_all _ <| by intro; simp_all
+      (measurableSet_support hg_meas).compl <| by intro; simp_all
     _ ≤ ∫⁻ a, f a - g a ∂μ := setLIntegral_le_lintegral _ _
     _ = ∫⁻ a, f a ∂μ - ∫⁻ a, g a ∂μ :=
       lintegral_sub hg_meas (ne_top_of_le_ne_top hf <| lintegral_mono hgf) (ae_of_all _ hgf)

--- a/Mathlib/MeasureTheory/Measure/Decomposition/RadonNikodym.lean
+++ b/Mathlib/MeasureTheory/Measure/Decomposition/RadonNikodym.lean
@@ -453,7 +453,8 @@ lemma _root_.MeasurableEmbedding.map_withDensity_rnDeriv (hf : MeasurableEmbeddi
   ext s hs
   rw [hf.map_apply, withDensity_apply _ (hf.measurable hs), withDensity_apply _ hs,
     setLIntegral_map hs (Measure.measurable_rnDeriv _ _) hf.measurable]
-  exact setLIntegral_congr_fun (hf.measurable hs) (fun a ha ↦ ha.symm)
+  refine setLIntegral_congr_fun_ae (hf.measurable hs) ?_
+  filter_upwards [hf.rnDeriv_map μ ν] with a ha _ using ha.symm
 
 lemma _root_.MeasurableEmbedding.singularPart_map (hf : MeasurableEmbedding f)
     (μ ν : Measure α) [SigmaFinite μ] [SigmaFinite ν] :

--- a/Mathlib/MeasureTheory/Measure/Decomposition/RadonNikodym.lean
+++ b/Mathlib/MeasureTheory/Measure/Decomposition/RadonNikodym.lean
@@ -453,8 +453,7 @@ lemma _root_.MeasurableEmbedding.map_withDensity_rnDeriv (hf : MeasurableEmbeddi
   ext s hs
   rw [hf.map_apply, withDensity_apply _ (hf.measurable hs), withDensity_apply _ hs,
     setLIntegral_map hs (Measure.measurable_rnDeriv _ _) hf.measurable]
-  refine setLIntegral_congr_fun (hf.measurable hs) ?_
-  filter_upwards [hf.rnDeriv_map μ ν] with a ha _ using ha.symm
+  exact setLIntegral_congr_fun (hf.measurable hs) (fun a ha ↦ ha.symm)
 
 lemma _root_.MeasurableEmbedding.singularPart_map (hf : MeasurableEmbedding f)
     (μ ν : Measure α) [SigmaFinite μ] [SigmaFinite ν] :

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/PolarCoord.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/PolarCoord.lean
@@ -155,8 +155,7 @@ theorem lintegral_comp_polarCoordReal_symm (f : realMixedSpace K → ℝ≥0∞)
       (polarCoordReal K).open_target.measurableSet
       (fun x _ ↦ (hasFDerivAt_polarCoordReal_symm K x).hasFDerivWithinAt)
       (polarCoordReal K).symm.injOn f]
-  refine setLIntegral_congr_fun (polarCoordReal K).open_target.measurableSet ?_
-  filter_upwards with x hx
+  refine setLIntegral_congr_fun (polarCoordReal K).open_target.measurableSet (fun x hx ↦ ?_)
   simp_rw [det_fderivPolarCoordRealSymm, Finset.abs_prod,
     ENNReal.ofReal_prod_of_nonneg (fun _ _ ↦ abs_nonneg _), abs_of_mem_polarCoordReal_target K hx]
 

--- a/Mathlib/Probability/Distributions/Exponential.lean
+++ b/Mathlib/Probability/Distributions/Exponential.lean
@@ -136,8 +136,8 @@ lemma lintegral_exponentialPDF_eq_antiDeriv {r : ℝ} (hr : 0 < r) (x : ℝ) :
     rw [lintegral_Iic_eq_lintegral_Iio_add_Icc _ h, lintegral_exponentialPDF_of_nonpos (le_refl 0),
       zero_add]
     simp only [exponentialPDF_eq]
-    rw [setLIntegral_congr_fun measurableSet_Icc
-        (by intro a ⟨(hle : _ ≤ a), _⟩; rw [if_pos hle])]
+    rw [setLIntegral_congr_fun measurableSet_Icc (g := fun x ↦ ENNReal.ofReal (r * rexp (-(r * x))))
+      (by intro a ha; simp [ha.1])]
     rw [← ENNReal.toReal_eq_toReal _ ENNReal.ofReal_ne_top, ← integral_eq_lintegral_of_nonneg_ae
         (Eventually.of_forall fun _ ↦ le_of_lt (mul_pos hr (exp_pos _)))]
     · have : ∫ a in uIoc 0 x, r * rexp (-(r * a)) = ∫ a in (0)..x, r * rexp (-(r * a)) := by

--- a/Mathlib/Probability/Distributions/Exponential.lean
+++ b/Mathlib/Probability/Distributions/Exponential.lean
@@ -131,13 +131,13 @@ lemma lintegral_exponentialPDF_eq_antiDeriv {r : ℝ} (hr : 0 < r) (x : ℝ) :
   case neg =>
     simp only [exponentialPDF_eq]
     rw [setLIntegral_congr_fun measurableSet_Iic, lintegral_zero, ENNReal.ofReal_zero]
-    exact ae_of_all _ fun a (_ : a ≤ _) ↦ by rw [if_neg (by linarith), ENNReal.ofReal_eq_zero]
+    exact fun a (_ : a ≤ _) ↦ by rw [if_neg (by linarith), ENNReal.ofReal_eq_zero]
   case pos =>
     rw [lintegral_Iic_eq_lintegral_Iio_add_Icc _ h, lintegral_exponentialPDF_of_nonpos (le_refl 0),
       zero_add]
     simp only [exponentialPDF_eq]
-    rw [setLIntegral_congr_fun measurableSet_Icc (ae_of_all _
-        (by intro a ⟨(hle : _ ≤ a), _⟩; rw [if_pos hle]))]
+    rw [setLIntegral_congr_fun measurableSet_Icc
+        (by intro a ⟨(hle : _ ≤ a), _⟩; rw [if_pos hle])]
     rw [← ENNReal.toReal_eq_toReal _ ENNReal.ofReal_ne_top, ← integral_eq_lintegral_of_nonneg_ae
         (Eventually.of_forall fun _ ↦ le_of_lt (mul_pos hr (exp_pos _)))]
     · have : ∫ a in uIoc 0 x, r * rexp (-(r * a)) = ∫ a in (0)..x, r * rexp (-(r * a)) := by

--- a/Mathlib/Probability/Distributions/Gamma.lean
+++ b/Mathlib/Probability/Distributions/Gamma.lean
@@ -66,7 +66,7 @@ lemma lintegral_gammaPDF_of_nonpos {x a r : ℝ} (hx : x ≤ 0) :
   rw [setLIntegral_congr_fun (g := fun _ ↦ 0) measurableSet_Iio]
   · rw [lintegral_zero, ← ENNReal.ofReal_zero]
   · simp only [gammaPDF_eq, ENNReal.ofReal_eq_zero]
-    filter_upwards with a (_ : a < _)
+    intro a (_ : a < _)
     rw [if_neg (by linarith)]
 
 /-- The gamma pdf is measurable. -/
@@ -101,10 +101,10 @@ lemma lintegral_gammaPDF_eq_one {a r : ℝ} (ha : 0 < a) (hr : 0 < r) :
     ∫⁻ x, gammaPDF a r x = 1 := by
   have leftSide : ∫⁻ x in Iio 0, gammaPDF a r x = 0 := by
     rw [setLIntegral_congr_fun measurableSet_Iio
-      (ae_of_all _ (fun x (hx : x < 0) ↦ gammaPDF_of_neg hx)), lintegral_zero]
+      (fun x (hx : x < 0) ↦ gammaPDF_of_neg hx), lintegral_zero]
   have rightSide : ∫⁻ x in Ici 0, gammaPDF a r x =
       ∫⁻ x in Ici 0, ENNReal.ofReal (r ^ a / Gamma a * x ^ (a - 1) * exp (-(r * x))) :=
-    setLIntegral_congr_fun measurableSet_Ici (ae_of_all _ (fun _ ↦ gammaPDF_of_nonneg))
+    setLIntegral_congr_fun measurableSet_Ici (fun _ ↦ gammaPDF_of_nonneg)
   rw [← ENNReal.toReal_eq_one_iff, ← lintegral_add_compl _ measurableSet_Ici, compl_Ici,
     leftSide, rightSide, add_zero, ← integral_eq_lintegral_of_nonneg_ae]
   · simp_rw [integral_Ici_eq_integral_Ioi, mul_assoc]

--- a/Mathlib/Probability/Distributions/Gamma.lean
+++ b/Mathlib/Probability/Distributions/Gamma.lean
@@ -65,8 +65,8 @@ lemma lintegral_gammaPDF_of_nonpos {x a r : ℝ} (hx : x ≤ 0) :
     ∫⁻ y in Iio x, gammaPDF a r y = 0 := by
   rw [setLIntegral_congr_fun (g := fun _ ↦ 0) measurableSet_Iio]
   · rw [lintegral_zero, ← ENNReal.ofReal_zero]
-  · simp only [gammaPDF_eq, ENNReal.ofReal_eq_zero]
-    intro a (_ : a < _)
+  · intro a (_ : a < _)
+    simp only [gammaPDF_eq, ENNReal.ofReal_eq_zero]
     rw [if_neg (by linarith)]
 
 /-- The gamma pdf is measurable. -/

--- a/Mathlib/Probability/Distributions/Pareto.lean
+++ b/Mathlib/Probability/Distributions/Pareto.lean
@@ -55,7 +55,7 @@ lemma lintegral_paretoPDF_of_le (hx : x ≤ t) :
   rw [setLIntegral_congr_fun (g := fun _ ↦ 0) measurableSet_Iio]
   · rw [lintegral_zero, ← ENNReal.ofReal_zero]
   · simp only [paretoPDF_eq, ge_iff_le, ENNReal.ofReal_eq_zero]
-    filter_upwards with a (_ : a < _)
+    intro a (_ : a < _)
     rw [if_neg (by linarith)]
 
 /-- The Pareto pdf is measurable. -/
@@ -99,7 +99,7 @@ lemma lintegral_paretoPDF_eq_one (ht : 0 < t) (hr : 0 < r) :
   have leftSide : ∫⁻ x in Iio t, paretoPDF t r x = 0 := lintegral_paretoPDF_of_le (le_refl t)
   have rightSide : ∫⁻ x in Ici t, paretoPDF t r x =
       ∫⁻ x in Ici t, ENNReal.ofReal (r * t ^ r * x ^ (-(r + 1))) :=
-    setLIntegral_congr_fun measurableSet_Ici (ae_of_all _ (fun _ ↦ paretoPDF_of_le))
+    setLIntegral_congr_fun measurableSet_Ici (fun _ ↦ paretoPDF_of_le)
   rw [← ENNReal.toReal_eq_one_iff, ← lintegral_add_compl _ measurableSet_Ici, compl_Ici,
     leftSide, rightSide, add_zero, ← integral_eq_lintegral_of_nonneg_ae]
   · rw [integral_Ici_eq_integral_Ioi, integral_const_mul, integral_Ioi_rpow_of_lt _ ht]

--- a/Mathlib/Probability/Distributions/Pareto.lean
+++ b/Mathlib/Probability/Distributions/Pareto.lean
@@ -54,8 +54,8 @@ lemma lintegral_paretoPDF_of_le (hx : x ≤ t) :
     ∫⁻ y in Iio x, paretoPDF t r y = 0 := by
   rw [setLIntegral_congr_fun (g := fun _ ↦ 0) measurableSet_Iio]
   · rw [lintegral_zero, ← ENNReal.ofReal_zero]
-  · simp only [paretoPDF_eq, ge_iff_le, ENNReal.ofReal_eq_zero]
-    intro a (_ : a < _)
+  · intro a (_ : a < _)
+    simp only [paretoPDF_eq, ge_iff_le, ENNReal.ofReal_eq_zero]
     rw [if_neg (by linarith)]
 
 /-- The Pareto pdf is measurable. -/

--- a/Mathlib/Probability/Kernel/Composition/CompProd.lean
+++ b/Mathlib/Probability/Kernel/Composition/CompProd.lean
@@ -281,12 +281,12 @@ lemma compProd_deterministic_apply [MeasurableSingletonClass γ] {f : α × β �
   rw [← lintegral_add_compl _ ht]
   convert add_zero _
   · suffices ∀ b ∈ tᶜ, (if f (x, b) ∈ Prod.mk b ⁻¹' s then (1 : ℝ≥0∞) else 0) = 0 by
-      rw [setLIntegral_congr_fun ht.compl (ae_of_all _ this), lintegral_zero]
+      rw [setLIntegral_congr_fun ht.compl this, lintegral_zero]
     intro b hb
     simp only [t, Set.mem_compl_iff, Set.mem_setOf_eq] at hb
     simp [hb]
   · suffices ∀ b ∈ t, (if f (x, b) ∈ Prod.mk b ⁻¹' s then (1 : ℝ≥0∞) else 0) = 1 by
-      rw [setLIntegral_congr_fun ht (ae_of_all _ this), setLIntegral_one]
+      rw [setLIntegral_congr_fun ht this, setLIntegral_one]
     intro b hb
     simp only [t, Set.mem_setOf_eq] at hb
     simp [hb]

--- a/Mathlib/Probability/Kernel/Disintegration/CDFToKernel.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/CDFToKernel.lean
@@ -562,13 +562,13 @@ lemma lintegral_toKernel_mem [IsFiniteKernel κ] (hf : IsCondKernelCDF f κ ν)
     rw [← lintegral_add_compl _ ht₁]
     have h_eq1 : ∫⁻ x in t₁, hf.toKernel f (a, x) (Prod.mk x ⁻¹' t₁ ×ˢ t₂) ∂(ν a)
         = ∫⁻ x in t₁, hf.toKernel f (a, x) t₂ ∂(ν a) := by
-      refine setLIntegral_congr_fun ht₁ (Eventually.of_forall fun a ha ↦ ?_)
+      refine setLIntegral_congr_fun ht₁ (fun a ha ↦ ?_)
       rw [mk_preimage_prod_right ha]
     have h_eq2 :
         ∫⁻ x in t₁ᶜ, hf.toKernel f (a, x) (Prod.mk x ⁻¹' t₁ ×ˢ t₂) ∂(ν a) = 0 := by
       suffices h_eq_zero :
           ∀ x ∈ t₁ᶜ, hf.toKernel f (a, x) (Prod.mk x ⁻¹' t₁ ×ˢ t₂) = 0 by
-        rw [setLIntegral_congr_fun ht₁.compl (Eventually.of_forall h_eq_zero)]
+        rw [setLIntegral_congr_fun ht₁.compl h_eq_zero]
         simp only [lintegral_const, zero_mul]
       intro a hat₁
       rw [mem_compl_iff] at hat₁

--- a/Mathlib/Probability/Kernel/Disintegration/Density.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Density.lean
@@ -221,7 +221,7 @@ lemma setIntegral_densityProcess_of_mem (hκν : fst κ ≤ ν) [hν : IsFiniteK
   congr
   have : ∫⁻ x in u, κ a (countablePartitionSet n x ×ˢ s) / ν a (countablePartitionSet n x) ∂(ν a)
       = ∫⁻ _ in u, κ a (u ×ˢ s) / ν a u ∂(ν a) := by
-    refine setLIntegral_congr_fun hu_meas (ae_of_all _ (fun t ht ↦ ?_))
+    refine setLIntegral_congr_fun hu_meas (fun t ht ↦ ?_)
     rw [countablePartitionSet_of_mem hu ht]
   rw [this]
   simp only [MeasureTheory.lintegral_const, MeasurableSet.univ, Measure.restrict_apply, univ_inter]

--- a/Mathlib/Probability/Kernel/Posterior.lean
+++ b/Mathlib/Probability/Kernel/Posterior.lean
@@ -281,7 +281,7 @@ lemma posterior_eq_withDensity (h_ac : ∀ᵐ ω ∂μ, κ ω ≪ κ ∘ₘ μ) 
   filter_upwards [rnDeriv_posterior_symm h_ac, absolutelyContinuous_posterior h_ac] with x h h_ac'
   ext s hs
   rw [← Measure.setLIntegral_rnDeriv h_ac', withDensity_apply _ hs]
-  refine setLIntegral_congr_fun hs ?_
+  refine setLIntegral_congr_fun_ae hs ?_
   filter_upwards [h, Kernel.rnDeriv_eq_rnDeriv_measure (κ := κ†μ) (η := Kernel.const 𝓧 μ) (a := x)]
     with ω h h_eq hωs
   rw [← h, h_eq, Kernel.const_apply]

--- a/Mathlib/Probability/Kernel/RadonNikodym.lean
+++ b/Mathlib/Probability/Kernel/RadonNikodym.lean
@@ -137,7 +137,7 @@ lemma setLIntegral_rnDerivAux (κ η : Kernel α γ) [IsFiniteKernel κ] [IsFini
   split_ifs with hα
   · have h_ac : κ a ≪ (κ + η) a := Measure.absolutelyContinuous_of_le (h_le a)
     rw [← Measure.setLIntegral_rnDeriv h_ac]
-    refine setLIntegral_congr_fun hs ?_
+    refine setLIntegral_congr_fun_ae hs ?_
     filter_upwards [Measure.rnDeriv_lt_top (κ a) ((κ + η) a)] with x hx_lt _
     rw [ENNReal.ofReal_toReal hx_lt.ne]
   · have := hαγ.countableOrCountablyGenerated.resolve_left hα
@@ -312,7 +312,7 @@ lemma singularPart_of_subset_mutuallySingularSetSlice [IsFiniteKernel κ]
       ↑(Real.toNNReal (1 - rnDerivAux κ (κ + η) a x)) * rnDeriv κ η a x
       ∂(κ + η) a
     = ∫⁻ _ in s, 1 ∂(κ + η) a := by
-        refine setLIntegral_congr_fun hsm ?_
+        refine setLIntegral_congr_fun_ae hsm ?_
         have h_le : κ ≤ κ + η := le_add_of_nonneg_right bot_le
         filter_upwards [rnDerivAux_le_one h_le] with x hx hxs
         have h_eq_one : rnDerivAux κ (κ + η) a x = 1 := le_antisymm hx (hs' x hxs)
@@ -359,7 +359,7 @@ lemma withDensity_rnDeriv_of_subset_compl_mutuallySingularSetSlice
       (ENNReal.ofReal (rnDerivAux κ (κ + η) a x) /
         ENNReal.ofReal (1 - rnDerivAux κ (κ + η) a x)) ∂(κ + η) a
   _ = ∫⁻ x in s, ENNReal.ofReal (rnDerivAux κ (κ + η) a x) ∂(κ + η) a := by
-      refine setLIntegral_congr_fun hsm (ae_of_all _ fun x hx ↦ ?_)
+      refine setLIntegral_congr_fun hsm (fun x hx ↦ ?_)
       rw [ofNNReal_toNNReal, ← ENNReal.ofReal_div_of_pos, div_eq_inv_mul, ← ENNReal.ofReal_mul,
         ← mul_assoc, mul_inv_cancel₀, one_mul]
       · rw [ne_eq, sub_eq_zero]
@@ -586,14 +586,14 @@ lemma rnDeriv_add (κ ν η : Kernel α γ) [IsFiniteKernel κ] [IsFiniteKernel 
 lemma setLIntegral_rnDeriv_le {κ η : Kernel α γ} [IsFiniteKernel κ] [IsFiniteKernel η]
     {a : α} {s : Set γ} (hs : MeasurableSet s) :
     ∫⁻ c in s, κ.rnDeriv η a c ∂η a ≤ κ a s := by
-  rw [setLIntegral_congr_fun hs ((κ.rnDeriv_eq_rnDeriv_measure).mono (fun x hx _ ↦ hx)),
+  rw [setLIntegral_congr_fun_ae hs ((κ.rnDeriv_eq_rnDeriv_measure).mono (fun x hx _ ↦ hx)),
     ← withDensity_apply' _ s]
   exact (κ a).withDensity_rnDeriv_le _ _
 
 lemma setLIntegral_rnDeriv {κ η : Kernel α γ} [IsFiniteKernel κ] [IsFiniteKernel η]
     {a : α} (h : κ a ≪ η a) {s : Set γ} (hs : MeasurableSet s) :
     ∫⁻ c in s, κ.rnDeriv η a c ∂η a = κ a s := by
-  rw [setLIntegral_congr_fun hs ((κ.rnDeriv_eq_rnDeriv_measure).mono (fun x hx _ ↦ hx)),
+  rw [setLIntegral_congr_fun_ae hs ((κ.rnDeriv_eq_rnDeriv_measure).mono (fun x hx _ ↦ hx)),
     ← withDensity_apply _ hs, (κ a).withDensity_rnDeriv_eq _ h]
 
 lemma lintegral_rnDeriv {κ η : Kernel α γ} [IsFiniteKernel κ] [IsFiniteKernel η]


### PR DESCRIPTION
In this way, we match the API for the Bochner integral. And we simplify most calls to the previous version, which were using `ae_of_all` 90% of the times.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
