### PR TITLE
[Merged by Bors] - chore(GroupTheory/Coprod/Basic): use `to_additive`

### DIFF
--- a/Mathlib/GroupTheory/Coprod/Basic.lean
+++ b/Mathlib/GroupTheory/Coprod/Basic.lean
@@ -731,12 +731,14 @@ theorem coprodAssoc_symm_apply_inr_inr (x : P) :
 variable (M)
 
 /-- Isomorphism between `M ∗ PUnit` and `M`. -/
-@[to_additive (attr := simps! -fullyApplied)]
+@[to_additive (attr := simps! -fullyApplied)
+  "Isomorphism between `AddMonoid.Coprod M PUnit` and `M`."]
 def coprodPUnit : M ∗ PUnit ≃* M :=
   MonoidHom.toMulEquiv fst inl (hom_ext rfl <| Subsingleton.elim _ _) fst_comp_inl
 
 /-- Isomorphism between `PUnit ∗ M` and `M`. -/
-@[to_additive (attr := simps! -fullyApplied)]
+@[to_additive (attr := simps! -fullyApplied)
+  "Isomorphism between `AddMonoid.Coprod PUnit M` and `M`."]
 def punitCoprod : PUnit ∗ M ≃* M :=
   MonoidHom.toMulEquiv snd inr (hom_ext (Subsingleton.elim _ _) rfl) snd_comp_inr
 

--- a/Mathlib/GroupTheory/Coprod/Basic.lean
+++ b/Mathlib/GroupTheory/Coprod/Basic.lean
@@ -661,9 +661,9 @@ variable {K : Type*} [Group K]
 
 end Group
 
-end Coprod
+end Monoid.Coprod
 
-open Coprod
+open Monoid Coprod
 
 namespace MulEquiv
 
@@ -731,35 +731,13 @@ theorem coprodAssoc_symm_apply_inr_inr (x : P) :
 variable (M)
 
 /-- Isomorphism between `M ∗ PUnit` and `M`. -/
-@[simps! -fullyApplied]
+@[to_additive (attr := simps! -fullyApplied)]
 def coprodPUnit : M ∗ PUnit ≃* M :=
   MonoidHom.toMulEquiv fst inl (hom_ext rfl <| Subsingleton.elim _ _) fst_comp_inl
 
 /-- Isomorphism between `PUnit ∗ M` and `M`. -/
-@[simps! -fullyApplied]
+@[to_additive (attr := simps! -fullyApplied)]
 def punitCoprod : PUnit ∗ M ≃* M :=
   MonoidHom.toMulEquiv snd inr (hom_ext (Subsingleton.elim _ _) rfl) snd_comp_inr
 
 end MulEquiv
-
--- TODO: use `to_additive` to generate the next 2 `AddEquiv`s
-
-namespace AddEquiv
-
-variable {M : Type*} [AddMonoid M]
-
-/-- Isomorphism between `M ∗ PUnit` and `M`. -/
-@[simps! -fullyApplied]
-def coprodUnit : AddMonoid.Coprod M PUnit ≃+ M :=
-  AddMonoidHom.toAddEquiv AddMonoid.Coprod.fst AddMonoid.Coprod.inl
-    (AddMonoid.Coprod.hom_ext rfl <| Subsingleton.elim _ _) AddMonoid.Coprod.fst_comp_inl
-
-/-- Isomorphism between `PUnit ∗ M` and `M`. -/
-@[simps! -fullyApplied]
-def punitCoprod : AddMonoid.Coprod PUnit M ≃+ M :=
-  AddMonoidHom.toAddEquiv AddMonoid.Coprod.snd AddMonoid.Coprod.inr
-    (AddMonoid.Coprod.hom_ext (Subsingleton.elim _ _) rfl) AddMonoid.Coprod.snd_comp_inr
-
-end AddEquiv
-
-end Monoid


### PR DESCRIPTION
This PR add a use of `to_additive`. It also fixes a `namespace` problem. As written in the doc-comment of the file, we can see that the old namespacing was wrong. (and this caused the name to not properly additivise)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
