### PR TITLE
feat(Data/Finset/Card,Data/Set/Finite/Basic): TODO needs a better title

### DIFF
--- a/Mathlib/Data/Finset/Card.lean
+++ b/Mathlib/Data/Finset/Card.lean
@@ -381,6 +381,11 @@ lemma card_nbij' (i : α → β) (j : β → α) (hi : ∀ a ∈ s, i a ∈ t) (
     (left_inv : ∀ a ∈ s, j (i a) = a) (right_inv : ∀ a ∈ t, i (j a) = a) : #s = #t :=
   card_bij' (fun a _ ↦ i a) (fun b _ ↦ j b) hi hj left_inv right_inv
 
+/-- `Finset.card_nbij` can lead to `Finset.card_bijOn` -/
+theorem card_bijOn {s : Finset α} {t : Finset β}
+    (i : α → β) (h : Set.BijOn i s t) : s.card = t.card :=
+  Finset.card_nbij i h.mapsTo h.injOn h.surjOn
+
 /-- Specialization of `Finset.card_nbij'` that automatically fills in most arguments.
 
 See `Fintype.card_equiv` for the version where `s` and `t` are `univ`. -/

--- a/Mathlib/Data/Set/Finite/Basic.lean
+++ b/Mathlib/Data/Set/Finite/Basic.lean
@@ -631,7 +631,7 @@ theorem exists_subset_image_finite_and {f : α → β} {s : Set α} {p : Set β 
 
 theorem finset_subset_preimage_of_finite_image
     {s : Set α} {f : α → β} (h : (f '' s).Finite) :
-    ∃ (s' : Finset α), ↑s' ⊆ s ∧ f '' s' = f '' s ∧ s'.card = h.toFinset.card := by
+    ∃ s' : Finset α, ↑s' ⊆ s ∧ f '' s' = f '' s ∧ s'.card = h.toFinset.card := by
   have ⟨s', hs', hs'₁⟩ := Set.exists_subset_bijOn s f
   have h' := Set.Finite.of_finite_image (hs'₁.image_eq.symm ▸ h) hs'₁.injOn
   use h'.toFinset

--- a/Mathlib/Data/Set/Finite/Basic.lean
+++ b/Mathlib/Data/Set/Finite/Basic.lean
@@ -629,6 +629,16 @@ theorem exists_subset_image_finite_and {f : α → β} {s : Set α} {p : Set β 
     Finset.subset_set_image_iff]
   aesop
 
+theorem finset_subset_preimage_of_finite_image
+    {s : Set α} {f : α → β} (h : (f '' s).Finite) :
+    ∃ (s' : Finset α), ↑s' ⊆ s ∧ f '' s' = f '' s ∧ s'.card = h.toFinset.card := by
+  have ⟨s', hs', hs'₁⟩ := Set.exists_subset_bijOn s f
+  have h' := Set.Finite.of_finite_image (hs'₁.image_eq.symm ▸ h) hs'₁.injOn
+  use h'.toFinset
+  rw [Set.Finite.coe_toFinset]
+  exact ⟨hs', hs'₁.image_eq, Finset.card_bijOn _ <|
+    h.coe_toFinset.symm ▸ h'.coe_toFinset.symm ▸ hs'₁⟩
+
 theorem finite_range_ite {p : α → Prop} [DecidablePred p] {f g : α → β} (hf : (range f).Finite)
     (hg : (range g).Finite) : (range fun x => if p x then f x else g x).Finite :=
   (hf.union hg).subset range_ite_subset


### PR DESCRIPTION
 add `card_bijOn` and `finset_subset_preimage_of_finite_image`

Add `card_bijOn`: proves that for a bijection between finsets, their cardinalities are equal
Add `finset_subset_preimage_of_finite_image`: constructs a finset subset preserving image cardinality

Co-authored-by:  Junyu Guo <hagb@hagb.name>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by:  Junyu Guo @Hagb <hagb@hagb.name>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
