### PR TITLE
[Merged by Bors] - feat: constructor with default value for ContinuousMap[Zero]

### DIFF
--- a/Mathlib/Topology/CompactOpen.lean
+++ b/Mathlib/Topology/CompactOpen.lean
@@ -415,6 +415,11 @@ theorem continuous_of_continuous_uncurry (f : X → C(Y, Z))
     (h : Continuous (Function.uncurry fun x y => f x y)) : Continuous f :=
   (curry ⟨_, h⟩).2
 
+theorem continuousOn_of_continuousOn_uncurry {s : Set X} (f : X → C(Y, Z))
+    (h : ContinuousOn (Function.uncurry fun x y => f x y) (s ×ˢ univ)) : ContinuousOn f s :=
+  continuousOn_iff_continuous_restrict.mpr <| continuous_of_continuous_uncurry _ <|
+    h.comp_continuous (continuous_subtype_val.prodMap continuous_id) (fun x ↦ ⟨x.1.2, trivial⟩)
+
 /-- The currying process is a continuous map between function spaces. -/
 theorem continuous_curry [LocallyCompactSpace (X × Y)] :
     Continuous (curry : C(X × Y, Z) → C(X, C(Y, Z))) := by
@@ -453,6 +458,58 @@ theorem coe_const' : (const' : Y → C(X, Y)) = const X :=
 
 theorem continuous_const' : Continuous (const X : Y → C(X, Y)) :=
   const'.continuous
+
+section mkD
+
+/-- A variant of `ContinuousMap.continuous_of_continuous_uncurry` in terms of
+`ContinuousMap.mkD`.
+Of course, in this particular setting, `fun x ↦ mkD (f x) g` is just `f`,
+but the `mkD` spelling appears naturally in the context of `C(α, β)`-valued integration. -/
+lemma continuous_mkD_of_uncurry
+    (f : T → X → Y) (g : C(X, Y)) (f_cont : Continuous (Function.uncurry f)) :
+    Continuous (fun x ↦ mkD (f x) g) := by
+  have (x) : Continuous (f x) := f_cont.comp (Continuous.prodMk_right x)
+  refine continuous_of_continuous_uncurry _ ?_
+  conv in mkD _ _ => rw [mkD_of_continuous (this x)]
+  exact f_cont
+
+open Set in
+lemma continuousOn_mkD_of_uncurry {s : Set T}
+    (f : T → X → Y) (g : C(X, Y)) (f_cont : ContinuousOn (Function.uncurry f) (s ×ˢ univ)) :
+    ContinuousOn (fun x ↦ mkD (f x) g) s := by
+  have (x) (hx : x ∈ s) : Continuous (f x) := f_cont.comp_continuous
+    (Continuous.prodMk_right x) fun _ ↦ ⟨hx, trivial⟩
+  simp_rw [continuousOn_iff_continuous_restrict, s.restrict_def]
+  refine continuous_of_continuous_uncurry _ ?_
+  conv in mkD _ _ => rw [mkD_of_continuous (this x x.2)]
+  exact f_cont.comp_continuous (.prodMap continuous_subtype_val continuous_id)
+    fun xz ↦ ⟨xz.1.2, trivial⟩
+
+open Set in
+lemma continuous_mkD_restrict_of_uncurry {t : Set X}
+    (f : T → X → Y) (g : C(t, Y)) (f_cont : ContinuousOn (Function.uncurry f) (univ ×ˢ t)) :
+    Continuous (fun x ↦ mkD (t.restrict (f x)) g) := by
+  have (x) : ContinuousOn (f x) t :=
+    f_cont.comp (Continuous.prodMk_right x).continuousOn fun _ hz ↦ ⟨trivial, hz⟩
+  refine continuous_of_continuous_uncurry _ ?_
+  conv in mkD _ _ => rw [mkD_of_continuousOn (this x)]
+  exact f_cont.comp_continuous (.prodMap continuous_id continuous_subtype_val)
+    fun xz ↦ ⟨trivial, xz.2.2⟩
+
+open Set in
+lemma continuousOn_mkD_restrict_of_uncurry {s : Set T} {t : Set X}
+    (f : T → X → Y) (g : C(t, Y))
+    (f_cont : ContinuousOn (Function.uncurry f) (s ×ˢ t)) :
+    ContinuousOn (fun x ↦ mkD (t.restrict (f x)) g) s := by
+  have (x) (hx : x ∈ s) : ContinuousOn (f x) t :=
+    f_cont.comp (Continuous.prodMk_right x).continuousOn fun _ hz ↦ ⟨hx, hz⟩
+  simp_rw [continuousOn_iff_continuous_restrict, s.restrict_def]
+  refine continuous_of_continuous_uncurry _ ?_
+  conv in mkD _ _ => rw [mkD_of_continuousOn (this x x.2)]
+  exact f_cont.comp_continuous (.prodMap continuous_subtype_val continuous_subtype_val)
+    fun xz ↦ ⟨xz.1.2, xz.2.2⟩
+
+end mkD
 
 end Curry
 

--- a/Mathlib/Topology/ContinuousMap/Basic.lean
+++ b/Mathlib/Topology/ContinuousMap/Basic.lean
@@ -289,6 +289,51 @@ def restrictPreimage (f : C(α, β)) (s : Set β) : C(f ⁻¹' s, s) :=
 
 end Restrict
 
+section mkD
+
+/--
+Interpret `f : α → β` as an element of `C(α, β)`, falling back to the default value
+`default : C(α, β)` if `f` is not continuous.
+This is mainly intended to be used for `C(α, β)`-valued integration. For example, if a family of
+functions `f : ι → α → β` satisfies that `f i` is continuous for almost every `i`, you can write
+the `C(α, β)`-valued integral "`∫ i, f i`" as `∫ i, ContinuousMap.mkD (f i) 0`.
+-/
+noncomputable def mkD (f : α → β) (default : C(α, β)) : C(α, β) :=
+  open scoped Classical in
+  if h : Continuous f then ⟨_, h⟩ else default
+
+lemma mkD_of_continuous {f : α → β} {g : C(α, β)} (hf : Continuous f) :
+    mkD f g = ⟨f, hf⟩ := by
+  simp only [mkD, hf, ↓reduceDIte]
+
+lemma mkD_of_not_continuous {f : α → β} {g : C(α, β)} (hf : ¬ Continuous f) :
+    mkD f g = g := by
+  simp only [mkD, hf, ↓reduceDIte]
+
+lemma mkD_apply_of_continuous {f : α → β} {g : C(α, β)} {x : α} (hf : Continuous f) :
+    mkD f g x = f x := by
+  rw [mkD_of_continuous hf]
+  rfl
+
+lemma mkD_of_continuousOn {s : Set α} {f : α → β} {g : C(s, β)}
+    (hf : ContinuousOn f s) :
+    mkD (s.restrict f) g = ⟨s.restrict f, hf.restrict⟩ :=
+  mkD_of_continuous hf.restrict
+
+lemma mkD_of_not_continuousOn {s : Set α} {f : α → β} {g : C(s, β)}
+    (hf : ¬ ContinuousOn f s) :
+    mkD (s.restrict f) g = g := by
+  rw [continuousOn_iff_continuous_restrict] at hf
+  exact mkD_of_not_continuous hf
+
+lemma mkD_apply_of_continuousOn {s : Set α} {f : α → β} {g : C(s, β)} {x : s}
+    (hf : ContinuousOn f s) :
+    mkD (s.restrict f) g x = f x := by
+  rw [mkD_of_continuousOn hf]
+  rfl
+
+end mkD
+
 section Gluing
 
 variable {ι : Type*} (S : ι → Set α) (φ : ∀ i : ι, C(S i, β))


### PR DESCRIPTION
This is motivated by #26041, where we need to do ContinuousMap[Zero]-valued integration. To make this more natural (e.g by allowing the continuity for almost-every parameter), we introduce constructors for ContinuousMap[Zero] which do not assume continuity, but return a prescribed default value when the argument is not continuous.

This may also allow a bit of simplification in the basic API for the continuous functional calculus.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
