### PR TITLE
[Merged by Bors] - feat(FieldTheory/Galois/IsGaloisGroup): Predicate for `G` being a Galois group for `L/K`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3547,6 +3547,7 @@ import Mathlib.FieldTheory.Fixed
 import Mathlib.FieldTheory.Galois.Basic
 import Mathlib.FieldTheory.Galois.GaloisClosure
 import Mathlib.FieldTheory.Galois.Infinite
+import Mathlib.FieldTheory.Galois.IsGaloisGroup
 import Mathlib.FieldTheory.Galois.Profinite
 import Mathlib.FieldTheory.IntermediateField.Adjoin.Algebra
 import Mathlib.FieldTheory.IntermediateField.Adjoin.Basic
@@ -5254,6 +5255,7 @@ import Mathlib.RingTheory.IntegralClosure.IsIntegralClosure.Basic
 import Mathlib.RingTheory.IntegralClosure.IsIntegralClosure.Defs
 import Mathlib.RingTheory.IntegralDomain
 import Mathlib.RingTheory.Invariant
+import Mathlib.RingTheory.Invariant.Defs
 import Mathlib.RingTheory.Invariant.Basic
 import Mathlib.RingTheory.Invariant.Profinite
 import Mathlib.RingTheory.IsAdjoinRoot

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5255,8 +5255,8 @@ import Mathlib.RingTheory.IntegralClosure.IsIntegralClosure.Basic
 import Mathlib.RingTheory.IntegralClosure.IsIntegralClosure.Defs
 import Mathlib.RingTheory.IntegralDomain
 import Mathlib.RingTheory.Invariant
-import Mathlib.RingTheory.Invariant.Defs
 import Mathlib.RingTheory.Invariant.Basic
+import Mathlib.RingTheory.Invariant.Defs
 import Mathlib.RingTheory.Invariant.Profinite
 import Mathlib.RingTheory.IsAdjoinRoot
 import Mathlib.RingTheory.IsPrimary

--- a/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
+++ b/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
@@ -57,6 +57,6 @@ theorem finiteDimensional [Finite G] [IsGaloisGroup G K L] : FiniteDimensional K
     have := finiteDimensional G K L
     rw [Nat.bijective_iff_injective_and_card, card_eq_finrank G K L,
       Nat.card_eq_fintype_card, IsGalois.card_aut_eq_finrank K L]
-    exact ⟨fun _ _ h ↦ (faithful K).eq_of_smul_eq_smul (DFunLike.ext_iff.mp h), rfl⟩)
+    exact ⟨fun _ _ ↦ (faithful K).eq_of_smul_eq_smul ∘ DFunLike.ext_iff.mp, rfl⟩)
 
 end IsGaloisGroup

--- a/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
+++ b/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
@@ -30,12 +30,12 @@ theorem fixedPoints_eq_bot [IsGaloisGroup G K L] :
   rw [eq_bot_iff]
   exact Algebra.IsInvariant.isInvariant
 
-/-- If `G` is a Galois group for `L/K`, then `L/K` is a Galois extension. -/
+/-- If `G` is a finite Galois group for `L/K`, then `L/K` is a Galois extension. -/
 theorem isGalois [Finite G] [IsGaloisGroup G K L] : IsGalois K L := by
   rw [← isGalois_iff_isGalois_bot, ← fixedPoints_eq_bot G]
   exact IsGalois.of_fixed_field L G
 
-/-- If `L/K` is a Galois extension, then `L ≃ₐ[K] L` is a Galois group for `L/K`. -/
+/-- If `L/K` is a finite Galois extension, then `L ≃ₐ[K] L` is a Galois group for `L/K`. -/
 theorem of_isGalois [FiniteDimensional K L] [IsGalois K L] : IsGaloisGroup (L ≃ₐ[K] L) K L where
   faithful := inferInstance
   commutes := inferInstance

--- a/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
+++ b/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
@@ -13,7 +13,8 @@ Give an action of a group `G` on an extension of fields `L/K`, we introduce a pr
 `IsGaloisGroup G K L`.
 -/
 
-variable (G K L : Type*) [Group G] [Field K] [Field L] [Algebra K L] [MulSemiringAction G L]
+variable (G H K L : Type*) [Group G] [Group H] [Field K] [Field L] [Algebra K L]
+  [MulSemiringAction G L] [MulSemiringAction H L]
 
 /-- `G` is a Galois group for `L/K` if the action on `L` is faithful with fixed field `K`. -/
 class IsGaloisGroup where
@@ -36,7 +37,7 @@ theorem isGalois [Finite G] [IsGaloisGroup G K L] : IsGalois K L := by
   exact IsGalois.of_fixed_field L G
 
 /-- If `L/K` is a finite Galois extension, then `L ≃ₐ[K] L` is a Galois group for `L/K`. -/
-theorem of_isGalois [FiniteDimensional K L] [IsGalois K L] : IsGaloisGroup (L ≃ₐ[K] L) K L where
+instance of_isGalois [FiniteDimensional K L] [IsGalois K L] : IsGaloisGroup (L ≃ₐ[K] L) K L where
   faithful := inferInstance
   commutes := inferInstance
   isInvariant := ⟨fun x ↦ (IsGalois.mem_bot_iff_fixed x).mpr⟩
@@ -58,5 +59,18 @@ theorem finiteDimensional [Finite G] [IsGaloisGroup G K L] : FiniteDimensional K
     rw [Nat.bijective_iff_injective_and_card, card_eq_finrank G K L,
       Nat.card_eq_fintype_card, IsGalois.card_aut_eq_finrank K L]
     exact ⟨fun _ _ ↦ (faithful K).eq_of_smul_eq_smul ∘ DFunLike.ext_iff.mp, rfl⟩)
+
+/-- If `G` and `H` are finite Galois groups for `L/K`, then `G` is isomorphic to `H`. -/
+@[simps!]
+noncomputable def mulEquivCongr [IsGaloisGroup G K L] [Finite G]
+    [IsGaloisGroup H K L] [Finite H] : G ≃* H :=
+  (mulEquivAlgEquiv G K L).trans (mulEquivAlgEquiv H K L).symm
+
+@[simp]
+theorem mulEquivCongr_apply_smul [IsGaloisGroup G K L] [Finite G]
+    [IsGaloisGroup H K L] [Finite H] (g : G) (x : L) : mulEquivCongr G H K L g • x = g • x := by
+  rw [← mulEquivAlgEquiv_apply_apply G K L g x,
+    ← MulEquiv.apply_symm_apply (mulEquivAlgEquiv H K L) (mulEquivAlgEquiv G K L g),
+    mulEquivAlgEquiv_apply_apply, mulEquivAlgEquiv_symm_apply, mulEquivCongr_apply]
 
 end IsGaloisGroup

--- a/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
+++ b/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
@@ -9,14 +9,16 @@ import Mathlib.RingTheory.Invariant.Defs
 /-!
 # Predicate for Galois Groups
 
-Give an action of a group `G` on an extension of fields `L/K`, we introduce a predicate
-`IsGaloisGroup G K L`.
+Given an action of a group `G` on an extension of fields `L/K`, we introduce a predicate
+`IsGaloisGroup G K L` saying that `G` acts faithfull on `L` with fixed field `K`. In particular,
+we do not assume that `L` is an algebraic extension of `K`.
 -/
 
 variable (G H K L : Type*) [Group G] [Group H] [Field K] [Field L] [Algebra K L]
   [MulSemiringAction G L] [MulSemiringAction H L]
 
-/-- `G` is a Galois group for `L/K` if the action on `L` is faithful with fixed field `K`. -/
+/-- `G` is a Galois group for `L/K` if the action on `L` is faithful with fixed field `K`.
+In particular, we do not assume that `L` is an algebraic extension of `K`. -/
 class IsGaloisGroup where
   faithful : FaithfulSMul G L
   commutes : SMulCommClass G K L

--- a/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
+++ b/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
@@ -10,7 +10,7 @@ import Mathlib.RingTheory.Invariant.Defs
 # Predicate for Galois Groups
 
 Given an action of a group `G` on an extension of fields `L/K`, we introduce a predicate
-`IsGaloisGroup G K L` saying that `G` acts faithfull on `L` with fixed field `K`. In particular,
+`IsGaloisGroup G K L` saying that `G` acts faithfully on `L` with fixed field `K`. In particular,
 we do not assume that `L` is an algebraic extension of `K`.
 -/
 

--- a/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
+++ b/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
@@ -63,16 +63,13 @@ theorem finiteDimensional [Finite G] [IsGaloisGroup G K L] : FiniteDimensional K
     exact ⟨fun _ _ ↦ (faithful K).eq_of_smul_eq_smul ∘ DFunLike.ext_iff.mp, rfl⟩)
 
 /-- If `G` and `H` are finite Galois groups for `L/K`, then `G` is isomorphic to `H`. -/
-@[simps!]
 noncomputable def mulEquivCongr [IsGaloisGroup G K L] [Finite G]
     [IsGaloisGroup H K L] [Finite H] : G ≃* H :=
   (mulEquivAlgEquiv G K L).trans (mulEquivAlgEquiv H K L).symm
 
 @[simp]
 theorem mulEquivCongr_apply_smul [IsGaloisGroup G K L] [Finite G]
-    [IsGaloisGroup H K L] [Finite H] (g : G) (x : L) : mulEquivCongr G H K L g • x = g • x := by
-  rw [← mulEquivAlgEquiv_apply_apply G K L g x,
-    ← MulEquiv.apply_symm_apply (mulEquivAlgEquiv H K L) (mulEquivAlgEquiv G K L g),
-    mulEquivAlgEquiv_apply_apply, mulEquivAlgEquiv_symm_apply, mulEquivCongr_apply]
+    [IsGaloisGroup H K L] [Finite H] (g : G) (x : L) : mulEquivCongr G H K L g • x = g • x :=
+  AlgEquiv.ext_iff.mp ((mulEquivAlgEquiv H K L).apply_symm_apply (mulEquivAlgEquiv G K L g)) x
 
 end IsGaloisGroup

--- a/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
+++ b/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
@@ -68,8 +68,8 @@ noncomputable def mulEquivCongr [IsGaloisGroup G K L] [Finite G]
   (mulEquivAlgEquiv G K L).trans (mulEquivAlgEquiv H K L).symm
 
 @[simp]
-theorem mulEquivCongr_apply_smul [IsGaloisGroup G K L] [Finite G]
-    [IsGaloisGroup H K L] [Finite H] (g : G) (x : L) : mulEquivCongr G H K L g • x = g • x :=
+theorem mulEquivCongr_apply_smul [IsGaloisGroup G K L] [Finite G] [IsGaloisGroup H K L] [Finite H]
+    (g : G) (x : L) : mulEquivCongr G H K L g • x = g • x :=
   AlgEquiv.ext_iff.mp ((mulEquivAlgEquiv H K L).apply_symm_apply (mulEquivAlgEquiv G K L g)) x
 
 end IsGaloisGroup

--- a/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
+++ b/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
@@ -21,11 +21,9 @@ class IsGaloisGroup where
   commutes : SMulCommClass G K L
   isInvariant : Algebra.IsInvariant K L G
 
+attribute [instance low] IsGaloisGroup.commutes IsGaloisGroup.isInvariant
+
 namespace IsGaloisGroup
-
-instance [h : IsGaloisGroup G K L] : SMulCommClass G K L := h.commutes
-
-instance [h : IsGaloisGroup G K L] : Algebra.IsInvariant K L G := h.isInvariant
 
 theorem fixedPoints_eq_bot [IsGaloisGroup G K L] :
     FixedPoints.intermediateField G = (⊥ : IntermediateField K L) := by

--- a/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
+++ b/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2024 Thomas Browning. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Thomas Browning
+-/
+import Mathlib.FieldTheory.Galois.Basic
+import Mathlib.RingTheory.Invariant.Defs
+
+/-!
+# Predicate for Galois Groups
+
+Give an action of a group `G` on an extension of fields `L/K`, we introduce a predicate
+`IsGaloisGroup G K L`.
+-/
+
+variable (G K L : Type*) [Group G] [Field K] [Field L] [Algebra K L] [MulSemiringAction G L]
+
+/-- `G` is a Galois group for `L/K` if the action on `L` is faithful with fixed field `K`. -/
+class IsGaloisGroup where
+  faithful : FaithfulSMul G L
+  commutes : SMulCommClass G K L
+  isInvariant : Algebra.IsInvariant K L G
+
+namespace IsGaloisGroup
+
+instance [h : IsGaloisGroup G K L] : SMulCommClass G K L := h.commutes
+
+instance [h : IsGaloisGroup G K L] : Algebra.IsInvariant K L G := h.isInvariant
+
+theorem fixedPoints_eq_bot [IsGaloisGroup G K L] :
+    FixedPoints.intermediateField G = (⊥ : IntermediateField K L) := by
+  rw [eq_bot_iff]
+  exact Algebra.IsInvariant.isInvariant
+
+/-- If `G` is a Galois group for `L/K`, then `L/K` is a Galois extension. -/
+theorem isGalois [Finite G] [IsGaloisGroup G K L] : IsGalois K L := by
+  rw [← isGalois_iff_isGalois_bot, ← fixedPoints_eq_bot G]
+  exact IsGalois.of_fixed_field L G
+
+/-- If `L/K` is a Galois extension, then `L ≃ₐ[K] L` is a Galois group for `L/K`. -/
+theorem of_isGalois [FiniteDimensional K L] [IsGalois K L] : IsGaloisGroup (L ≃ₐ[K] L) K L where
+  faithful := inferInstance
+  commutes := inferInstance
+  isInvariant := ⟨fun x ↦ (IsGalois.mem_bot_iff_fixed x).mpr⟩
+
+theorem card_eq_finrank [Finite G] [IsGaloisGroup G K L] : Nat.card G = Module.finrank K L := by
+  have : Fintype G := Fintype.ofFinite G
+  have : FaithfulSMul G L := IsGaloisGroup.faithful K
+  rw [← IntermediateField.finrank_bot', ← fixedPoints_eq_bot G, Nat.card_eq_fintype_card]
+  exact (FixedPoints.finrank_eq_card G L).symm
+
+end IsGaloisGroup

--- a/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
+++ b/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
@@ -21,9 +21,9 @@ class IsGaloisGroup where
   commutes : SMulCommClass G K L
   isInvariant : Algebra.IsInvariant K L G
 
-attribute [instance low] IsGaloisGroup.commutes IsGaloisGroup.isInvariant
-
 namespace IsGaloisGroup
+
+attribute [instance low] commutes isInvariant
 
 theorem fixedPoints_eq_bot [IsGaloisGroup G K L] :
     FixedPoints.intermediateField G = (⊥ : IntermediateField K L) := by
@@ -43,8 +43,20 @@ theorem of_isGalois [FiniteDimensional K L] [IsGalois K L] : IsGaloisGroup (L �
 
 theorem card_eq_finrank [Finite G] [IsGaloisGroup G K L] : Nat.card G = Module.finrank K L := by
   have : Fintype G := Fintype.ofFinite G
-  have : FaithfulSMul G L := IsGaloisGroup.faithful K
+  have : FaithfulSMul G L := faithful K
   rw [← IntermediateField.finrank_bot', ← fixedPoints_eq_bot G, Nat.card_eq_fintype_card]
   exact (FixedPoints.finrank_eq_card G L).symm
+
+theorem finiteDimensional [Finite G] [IsGaloisGroup G K L] : FiniteDimensional K L :=
+  FiniteDimensional.of_finrank_pos (card_eq_finrank G K L ▸ Nat.card_pos)
+
+/-- If `G` is a finite Galois group for `L/K`, then `G` is isomorphic to `L ≃ₐ[K] L`. -/
+@[simps!] noncomputable def mulEquivAlgEquiv [IsGaloisGroup G K L] [Finite G] : G ≃* (L ≃ₐ[K] L) :=
+  MulEquiv.ofBijective (MulSemiringAction.toAlgAut G K L) (by
+    have := isGalois G K L
+    have := finiteDimensional G K L
+    rw [Nat.bijective_iff_injective_and_card, card_eq_finrank G K L,
+      Nat.card_eq_fintype_card, IsGalois.card_aut_eq_finrank K L]
+    exact ⟨fun _ _ h ↦ (faithful K).eq_of_smul_eq_smul (DFunLike.ext_iff.mp h), rfl⟩)
 
 end IsGaloisGroup

--- a/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
+++ b/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2024 Thomas Browning. All rights reserved.
+Copyright (c) 2025 Thomas Browning. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Thomas Browning
 -/

--- a/Mathlib/RingTheory/Invariant/Basic.lean
+++ b/Mathlib/RingTheory/Invariant/Basic.lean
@@ -3,6 +3,7 @@ Copyright (c) 2024 Thomas Browning. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Thomas Browning
 -/
+import Mathlib.RingTheory.Invariant.Defs
 import Mathlib.RingTheory.IntegralClosure.IntegralRestrict
 
 /-!
@@ -36,19 +37,6 @@ If `Q` is a prime ideal of `B` lying over a prime ideal `P` of `A`, then
 -/
 
 open scoped Pointwise
-
-namespace Algebra
-
-variable (A B G : Type*) [CommSemiring A] [Semiring B] [Algebra A B]
-  [Group G] [MulSemiringAction G B]
-
-/-- An action of a group `G` on an extension of rings `B/A` is invariant if every fixed point of
-`B` lies in the image of `A`. The converse statement that every point in the image of `A` is fixed
-by `G` is `smul_algebraMap` (assuming `SMulCommClass A B G`). -/
-@[mk_iff] class IsInvariant : Prop where
-  isInvariant : ∀ b : B, (∀ g : G, g • b = b) → ∃ a : A, algebraMap A B a = b
-
-end Algebra
 
 section Galois
 

--- a/Mathlib/RingTheory/Invariant/Defs.lean
+++ b/Mathlib/RingTheory/Invariant/Defs.lean
@@ -1,0 +1,30 @@
+/-
+Copyright (c) 2024 Thomas Browning. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Thomas Browning
+-/
+import Mathlib.Algebra.Algebra.Defs
+
+/-!
+# Invariant Extensions of Rings
+
+Given an extension of rings `B/A` and an action of `G` on `B`, we introduce a predicate
+`Algebra.IsInvariant A B G` which states that every fixed point of `B` lies in the image of `A`.
+
+The main application is in algebraic number theory, where `G := Gal(L/K)` is the galois group
+of some finite galois extension of number fields, and `A := 𝓞K` and `B := 𝓞L` are their ring of
+integers.
+-/
+
+namespace Algebra
+
+variable (A B G : Type*) [CommSemiring A] [Semiring B] [Algebra A B]
+  [Group G] [MulSemiringAction G B]
+
+/-- An action of a group `G` on an extension of rings `B/A` is invariant if every fixed point of
+`B` lies in the image of `A`. The converse statement that every point in the image of `A` is fixed
+by `G` is `smul_algebraMap` (assuming `SMulCommClass A B G`). -/
+@[mk_iff] class IsInvariant : Prop where
+  isInvariant : ∀ b : B, (∀ g : G, g • b = b) → ∃ a : A, algebraMap A B a = b
+
+end Algebra

--- a/Mathlib/RingTheory/Invariant/Defs.lean
+++ b/Mathlib/RingTheory/Invariant/Defs.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2024 Thomas Browning. All rights reserved.
+Copyright (c) 2025 Thomas Browning. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Thomas Browning
 -/
@@ -12,7 +12,7 @@ Given an extension of rings `B/A` and an action of `G` on `B`, we introduce a pr
 `Algebra.IsInvariant A B G` which states that every fixed point of `B` lies in the image of `A`.
 
 The main application is in algebraic number theory, where `G := Gal(L/K)` is the galois group
-of some finite galois extension of number fields, and `A := 𝓞K` and `B := 𝓞L` are their ring of
+of some finite galois extension of number fields, and `A := 𝓞K` and `B := 𝓞L` are their rings of
 integers.
 -/
 

--- a/Mathlib/RingTheory/Invariant/Defs.lean
+++ b/Mathlib/RingTheory/Invariant/Defs.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Thomas Browning. All rights reserved.
+Copyright (c) 2024 Thomas Browning. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Thomas Browning
 -/


### PR DESCRIPTION
This PR introduces a predicate for a group `G` being a Galois group for an extension `L/K`, per this discussion: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Galois.20Theory.20in.20mathlib

The point is that `L ≃ₐ[K] L` is not always the most natural Galois group (e.g., `B ≃ₐ[A] B` might be more natural in Algebraic Number Theory, or `G/H` when `H` is a normal subgroup of `G` with fixed field `L`), so it seems reasonable to build out this more general API.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
