### PR TITLE
[Merged by Bors] - feat: `mon_tauto`, a simp set to prove tautologies about a monoid object

### DIFF
--- a/Mathlib/CategoryTheory/Monoidal/Mon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Mon_.lean
@@ -16,6 +16,13 @@ We define monoids in a monoidal category `C` and show that the category of monoi
 the category of lax monoidal functors from the unit monoidal category to `C`.  We also show that if
 `C` is braided, then the category of monoids is naturally monoidal.
 
+## Simp set for monoid object tautologies
+
+In this file, we also provide a simp set called `mon_tauto` whose goal is to prove all tautologies
+about morphisms from some (tensor) power of `M` to `M`, where `M` is a (commutative) monoid object
+in a (braided) monoidal category.
+
+Please read the documentation in `Mathlib/Tactic/Attr/Register.lean` for full details.
 -/
 
 universe w v₁ v₂ v₃ u₁ u₂ u₃ u
@@ -42,6 +49,7 @@ class Mon_Class (X : C) where
   mul_assoc (X) : (mul ▷ X) ≫ mul = (α_ X X X).hom ≫ (X ◁ mul) ≫ mul := by cat_disch
 
 namespace Mon_Class
+variable {M X Y : C} [Mon_Class M]
 
 @[inherit_doc] scoped notation "μ" => Mon_Class.mul
 @[inherit_doc] scoped notation "μ["M"]" => Mon_Class.mul (X := M)
@@ -67,6 +75,58 @@ theorem ext {X : C} (h₁ h₂ : Mon_Class X) (H : h₁.mul = h₂.mul) : h₁ =
 end Mon_Class
 
 open scoped Mon_Class
+
+namespace Mathlib.Tactic.MonTauto
+variable {C : Type u₁} [Category.{v₁} C] [MonoidalCategory C]
+  {M W X X₁ X₂ X₃ Y Y₁ Y₂ Y₃ Z Z₁ Z₂ : C} [Mon_Class M]
+
+attribute [mon_tauto] Category.id_comp Category.comp_id Category.assoc
+  id_tensorHom_id tensorμ tensorδ
+  leftUnitor_tensor_hom leftUnitor_tensor_hom_assoc
+  leftUnitor_tensor_inv leftUnitor_tensor_inv_assoc
+  rightUnitor_tensor_hom rightUnitor_tensor_hom_assoc
+  rightUnitor_tensor_inv rightUnitor_tensor_inv_assoc
+
+attribute [mon_tauto ←] tensorHom_id id_tensorHom tensor_comp tensor_comp_assoc
+
+@[reassoc (attr := mon_tauto)]
+lemma associator_hom_comp_tensorHom_tensorHom (f : X₁ ⟶ X₂) (g : Y₁ ⟶ Y₂) (h : Z₁ ⟶ Z₂) :
+    (α_ X₁ Y₁ Z₁).hom ≫ (f ⊗ₘ g ⊗ₘ h) = ((f ⊗ₘ g) ⊗ₘ h) ≫ (α_ X₂ Y₂ Z₂).hom := by simp
+
+@[reassoc (attr := mon_tauto)]
+lemma associator_inv_comp_tensorHom_tensorHom (f : X₁ ⟶ X₂) (g : Y₁ ⟶ Y₂) (h : Z₁ ⟶ Z₂) :
+    (α_ X₁ Y₁ Z₁).inv ≫ ((f ⊗ₘ g) ⊗ₘ h) = (f ⊗ₘ g ⊗ₘ h) ≫ (α_ X₂ Y₂ Z₂).inv := by simp
+
+@[reassoc (attr := mon_tauto)]
+lemma associator_hom_comp_tensorHom_tensorHom_comp (f : X₁ ⟶ X₂) (g : Y₁ ⟶ Y₂) (h : Z₁ ⟶ Z₂)
+    (gh : Y₂ ⊗ Z₂ ⟶ W) :
+    (α_ X₁ Y₁ Z₁).hom ≫ (f ⊗ₘ ((g ⊗ₘ h) ≫ gh)) =
+      ((f ⊗ₘ g) ⊗ₘ h) ≫ (α_ X₂ Y₂ Z₂).hom ≫ (𝟙 _ ⊗ₘ gh) := by simp [tensorHom_def]
+
+@[reassoc (attr := mon_tauto)]
+lemma associator_inv_comp_tensorHom_tensorHom_comp (f : X₁ ⟶ X₂) (g : Y₁ ⟶ Y₂) (h : Z₁ ⟶ Z₂)
+    (fg : X₂ ⊗ Y₂ ⟶ W) :
+    (α_ X₁ Y₁ Z₁).inv ≫ (((f ⊗ₘ g) ≫ fg) ⊗ₘ h) =
+      (f ⊗ₘ g ⊗ₘ h) ≫ (α_ X₂ Y₂ Z₂).inv ≫ (fg ⊗ₘ 𝟙 _) := by simp [tensorHom_def']
+
+@[mon_tauto] lemma eq_one_mul : (λ_ M).hom = (η ⊗ₘ 𝟙 M) ≫ μ := by simp
+@[mon_tauto] lemma eq_mul_one : (ρ_ M).hom = (𝟙 M ⊗ₘ η) ≫ μ := by simp
+
+@[reassoc (attr := mon_tauto)] lemma leftUnitor_inv_one_tensor_mul (f : X₁ ⟶ M) :
+    (λ_ _).inv ≫ (η ⊗ₘ f) ≫ μ = f := by simp [tensorHom_def']
+
+@[reassoc (attr := mon_tauto)] lemma rightUnitor_inv_tensor_one_mul (f : X₁ ⟶ M) :
+    (ρ_ _).inv ≫ (f ⊗ₘ η) ≫ μ = f := by simp [tensorHom_def]
+
+@[reassoc (attr := mon_tauto)]
+lemma mul_assoc_hom (f : X ⟶ M) :
+    (α_ X M M).hom ≫ (f ⊗ₘ μ) ≫ μ = ((f ⊗ₘ 𝟙 M) ≫ μ ⊗ₘ 𝟙 M) ≫ μ := by simp [tensorHom_def]
+
+@[reassoc (attr := mon_tauto)]
+lemma mul_assoc_inv (f : X ⟶ M) :
+    (α_ M M X).inv ≫ (μ ⊗ₘ f) ≫ μ = (𝟙 M ⊗ₘ (𝟙 M ⊗ₘ f) ≫ μ) ≫ μ  := by simp [tensorHom_def']
+
+end Mathlib.Tactic.MonTauto
 
 variable {M N O : C} [Mon_Class M] [Mon_Class N] [Mon_Class O]
 
@@ -842,12 +902,26 @@ open scoped Mon_Class
 
 namespace IsCommMon
 
-attribute [reassoc (attr := simp)] mul_comm
+attribute [reassoc (attr := simp, mon_tauto)] mul_comm
+
+variable (M) in
+@[reassoc (attr := simp, mon_tauto)]
+lemma mul_comm' [IsCommMon M] : (β_ M M).inv ≫ μ = μ := by simp [← cancel_epi (β_ M M).hom]
 
 instance : IsCommMon (𝟙_ C) where
   mul_comm := by dsimp; rw [braiding_leftUnitor, unitors_equal]
 
 end IsCommMon
+
+variable (M) in
+@[reassoc (attr := simp)]
+lemma Mon_Class.mul_mul_mul_comm [IsCommMon M] :
+    tensorμ M M M M ≫ (μ ⊗ₘ μ) ≫ μ = (μ ⊗ₘ μ) ≫ μ := by simp only [mon_tauto]
+
+variable (M) in
+@[reassoc (attr := simp)]
+lemma Mon_Class.mul_mul_mul_comm' [IsCommMon M] :
+    tensorδ M M M M ≫ (μ ⊗ₘ μ) ≫ μ = (μ ⊗ₘ μ) ≫ μ := by simp only [mon_tauto]
 
 end
 

--- a/Mathlib/Tactic/Attr/Register.lean
+++ b/Mathlib/Tactic/Attr/Register.lean
@@ -96,3 +96,40 @@ register_simp_attr enat_to_nat_coe
 
 /-- A simp set for the `pnat_to_nat` tactic. -/
 register_simp_attr pnat_to_nat_coe
+
+/-- `mon_tauto` is a simp set to prove tautologies about morphisms from some (tensor) power of `M`
+to `M`, where `M` is a (commutative) monoid object in a (braided) monoidal category.
+
+**This `simp` set is incompatible with the standard simp set.**
+If you want to use it, make sure to add the following to your simp call to disable the problematic
+default simp lemmas:
+```
+-MonoidalCategory.whiskerLeft_id, -MonoidalCategory.id_whiskerRight,
+-MonoidalCategory.tensor_comp, -MonoidalCategory.tensor_comp_assoc,
+-Mon_Class.mul_assoc, -Mon_Class.mul_assoc_assoc
+```
+
+The general algorithm it follows is to push the associators `α_` and commutators `β_` inwards until
+they cancel against the right sequence of multiplications.
+
+This approach is justified by the fact that a tautology in the language of (commutative) monoid
+objects "remembers" how it was proved: Every use of a (commutative) monoid object axiom inserts a
+unitor, associator or commutator, and proving a tautology simply amounts to undoing those moves as
+prescribed by the presence of unitors, associators and commutators in its expression.
+
+This simp set is opiniated about its normal form, which is why it cannot be used concurrently with
+some of the simp lemmas in the standard simp set:
+* It eliminates all mentions of whiskers by rewriting them to tensored homs,
+  which goes against `whiskerLeft_id` and `id_whiskerRight`:
+  `X ◁ f = 𝟙 X ⊗ₘ f`, `f ▷ X = 𝟙 X ⊗ₘ f`.
+  This goes against `whiskerLeft_id` and `id_whiskerRight` in the standard simp set.
+* It collapses compositions of tensored homs to the tensored hom of the compositions,
+  which goes against `tensor_comp`:
+  `(f₁ ⊗ₘ g₁) ≫ (f₂ ⊗ₘ g₂) = (f₁ ≫ f₂) ⊗ₘ (g₁ ≫ g₂)`. TODO: Isn't this direction Just Better?
+* It cancels the associators against multiplications,
+  which goes against `mul_assoc`:
+  `(α_ M M M).hom ≫ (𝟙 M ⊗ₘ μ) ≫ μ = (μ ⊗ₘ 𝟙 M) ≫ μ`,
+  `(α_ M M M).inv ≫ (μ ⊗ₘ 𝟙 M) ≫ μ = (𝟙 M ⊗ₘ μ) ≫ μ`
+* It unfolds non-primitive coherence isomorphisms, like the tensor strengths `tensorμ`, `tensorδ`.
+-/
+register_simp_attr mon_tauto

--- a/MathlibTest/CategoryTheory/Monoidal/MonTauto.lean
+++ b/MathlibTest/CategoryTheory/Monoidal/MonTauto.lean
@@ -1,0 +1,36 @@
+import Mathlib.CategoryTheory.Monoidal.Mon_
+
+open CategoryTheory MonoidalCategory
+open scoped Mon_Class
+
+variable {C : Type*} [Category C] [MonoidalCategory C] {M N : C} [Mon_Class M] [Mon_Class N]
+
+example : η ▷ M ≫ μ = (λ_ M).hom := by simp only [mon_tauto]
+example : M ◁ η ≫ μ = (ρ_ M).hom := by simp only [mon_tauto]
+example : μ ▷ M ≫ μ = (α_ M M M).hom ≫ M ◁ μ ≫ μ := by simp only [mon_tauto]
+example : M ◁ μ ≫ μ = (α_ M M M).inv ≫ μ ▷ M ≫ μ := by simp only [mon_tauto]
+
+example : M ◁ M ◁ ((ρ_ (M ⊗ M)).inv ≫ (M ⊗ M) ◁ η) ≫
+    (α_ _ _ _).inv ≫ (M ⊗ M) ◁ (μ ▷ M) ≫ μ ▷ (M ⊗ M) ≫ M ◁ μ ≫ μ =
+    (α_ _ _ _).inv ≫ (μ ⊗ₘ μ) ≫ μ := by
+  simp only [mon_tauto]
+
+example : (α_ (𝟙_ C) M M).hom ▷ M ≫ (α_ (𝟙_ C) (M ⊗ M) M).hom ≫ (𝟙_ C) ◁ (α_ M M M).hom ≫
+    (λ_ _).hom ≫ M ◁ μ ≫ μ =
+    (α_ ((𝟙_ C) ⊗ M) M M).hom ≫ (α_ (𝟙_ C) M (M ⊗ M)).hom ≫ (λ_ _).hom ≫ M ◁ μ ≫ μ := by
+  simp only [mon_tauto]
+
+example : (α_ M (𝟙_ _) (M ⊗ M)).hom ≫ M ◁ (λ_ (M ⊗ M)).hom ≫ M ◁ μ ≫ μ =
+    (ρ_ M).hom ▷ (M ⊗ M) ≫ M ◁ μ ≫ μ := by
+  simp only [mon_tauto]
+
+example : M ◁ (λ_ (M ⊗ M)).inv ≫ (α_ M (𝟙_ _) (M ⊗ M)).inv ≫
+    (ρ_ M).hom ▷ (M ⊗ M) ≫ _ ◁ μ ≫ μ = _ ◁ μ ≫ μ := by
+  simp only [mon_tauto]
+
+variable [BraidedCategory C] [IsCommMon M] [IsCommMon N]
+
+example : (β_ M M).hom ≫ μ = μ := by simp only [mon_tauto]
+example : (β_ M M).inv ≫ μ = μ := by simp only [mon_tauto]
+example : tensorμ M M M M ≫ (μ ⊗ₘ μ) ≫ μ = (μ ⊗ₘ μ) ≫ μ := by simp only [mon_tauto]
+example : tensorδ M M M M ≫ (μ ⊗ₘ μ) ≫ μ = (μ ⊗ₘ μ) ≫ μ := by simp only [mon_tauto]

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -479,8 +479,11 @@
   "Mathlib.CategoryTheory.Preadditive.Basic": ["Mathlib.Algebra.Module.End"],
   "Mathlib.CategoryTheory.Monoidal.Rigid.Basic":
   ["Mathlib.Tactic.CategoryTheory.Monoidal.Basic"],
+  "Mathlib.CategoryTheory.Monoidal.Mon_":
+  ["Mathlib.CategoryTheory.Monoidal.Attr"],
   "Mathlib.CategoryTheory.Monoidal.Braided.Basic":
   ["Mathlib.Tactic.CategoryTheory.Monoidal.Basic"],
+  "Mathlib.CategoryTheory.Monoidal.Attr": ["Lean.LabelAttribute"],
   "Mathlib.CategoryTheory.Limits.Shapes.FiniteLimits":
   ["Mathlib.CategoryTheory.Limits.Shapes.Pullback.HasPullback",
    "Mathlib.CategoryTheory.Limits.Shapes.Pullbacks"],


### PR DESCRIPTION
This simp set proves all tautologies involving (commutative) monoid objects in a (braided) monoidal category.

The general algorithm it follows is to push the associators `α_` and commutators `β_` inwards until they cancel against the right sequence of multiplications.

This approach is justified by the fact that a tautology in the language of (commutative) monoid objects "remembers" how it was proved: Every use of a (commutative) monoid object axiom inserts a unitor, associator or commutator, and proving a tautology simply amounts to undoing those moves as prescribed by the presence of unitors, associators and commutators in its expression.

This simp set is opiniated about its normal form and therefore cannot be used concurrently to some of the simp lemmas in the standard simp set.

As an example, we prove `tensorμ M M M M ≫ (μ ⊗ₘ μ) ≫ μ = (μ ⊗ₘ μ) ≫ μ`, the categorical equivalent of `mul_mul_mul_comm`.

From Toric

Co-authored-by: Andrew Yang <the.erd.one@gmail.com>


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
- [x] depends on: #26102

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
