### PR TITLE
feat(Topology/StoneCech): exists_continuous_surjection_from_StoneCech_to_dense_range

### DIFF
--- a/Mathlib/Topology/StoneCech.lean
+++ b/Mathlib/Topology/StoneCech.lean
@@ -389,6 +389,24 @@ lemma eq_if_stoneCechUnit_eq {a b : α} {f : α → β} (hcf : Continuous f)
   rw [← congrFun (stoneCechExtend_extends hcf), ← congrFun (stoneCechExtend_extends hcf)]
   exact congrArg (stoneCechExtend hcf) h
 
+lemma exists_continuous_surjection_from_StoneCech_to_dense_range
+    {f : α → β} (df : DenseRange f) (cf : Continuous f) :
+    ∃ g : C(StoneCech α, β),
+      Function.Surjective g ∧ g ∘ stoneCechUnit = f := by
+  use ⟨stoneCechExtend cf, continuous_stoneCechExtend cf⟩
+  apply And.intro
+  focus
+    have cnt : IsCompact (range (stoneCechExtend cf)) := by
+      rw [← Set.image_univ]
+      exact IsCompact.image isCompact_univ (continuous_stoneCechExtend cf)
+    have dns : Dense (range (stoneCechExtend cf)) := by
+      rw [← stoneCechExtend_extends cf] at df
+      exact DenseRange.of_comp df
+    simp only [ContinuousMap.coe_mk]
+    rw [← Set.range_eq_univ, ← IsClosed.closure_eq (IsCompact.isClosed cnt)]
+    exact Dense.closure_eq dns
+  exact stoneCechExtend_extends cf
+
 end Extension
 
 end StoneCech


### PR DESCRIPTION
This lemma formalises the following version of the maximality property of the Stone–Čech compactification: If `f : α → β` is a continuous map from a topological space `α` to a Hausdorff space `β` with dense range, then there exists a continuous surjection from `StoneCech α` to `β` extending `f`. In particular, `StoneCech α` is the “largest” compact Hausdorff space into which `α` densely embeds, in the sense that any other such space is a continuous image of it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
