### PR TITLE
[Merged by Bors] - chore(RingTheory/TensorProduct/Pi): change `CommSemiring` to `Semiring`

### DIFF
--- a/Mathlib/RingTheory/TensorProduct/Pi.lean
+++ b/Mathlib/RingTheory/TensorProduct/Pi.lean
@@ -20,9 +20,9 @@ open TensorProduct
 
 namespace Algebra.TensorProduct
 
-variable (R S A : Type*) [CommSemiring R] [CommSemiring S] [Algebra R S] [CommSemiring A]
+variable (R S A : Type*) [CommSemiring R] [CommSemiring S] [Algebra R S] [Semiring A]
   [Algebra R A] [Algebra S A] [IsScalarTower R S A]
-variable {ι : Type*} (B : ι → Type*) [∀ i, CommSemiring (B i)] [∀ i, Algebra R (B i)]
+variable {ι : Type*} (B : ι → Type*) [∀ i, Semiring (B i)] [∀ i, Algebra R (B i)]
 
 @[simp]
 lemma piRightHom_one : piRightHom R S A B 1 = 1 := rfl


### PR DESCRIPTION
We change `CommSemiring A` to `Semiring A` and `[∀ i, CommSemiring (B i)]` to `[∀ i, Semiring (B i)]`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
