### PR TITLE
[Merged by Bors] - feat: first main theorem of value distribution theory

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1487,6 +1487,7 @@ import Mathlib.Analysis.Complex.UpperHalfPlane.MoebiusAction
 import Mathlib.Analysis.Complex.UpperHalfPlane.Topology
 import Mathlib.Analysis.Complex.ValueDistribution.CharacteristicFunction
 import Mathlib.Analysis.Complex.ValueDistribution.CountingFunction
+import Mathlib.Analysis.Complex.ValueDistribution.FirstMainTheorem
 import Mathlib.Analysis.Complex.ValueDistribution.ProximityFunction
 import Mathlib.Analysis.ConstantSpeed
 import Mathlib.Analysis.Convex.AmpleSet

--- a/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/FirstMainTheorem.lean
@@ -1,0 +1,83 @@
+/-
+Copyright (c) 2025 Stefan Kebekus. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Stefan Kebekus
+-/
+import Mathlib.Analysis.Complex.ValueDistribution.CharacteristicFunction
+
+/-!
+# The First Main Theorem of Value Distribution Theory
+
+The First Main Theorem of Value Distribution Theory is a two-part statement, establishing invariance
+of the characteristic function `characteristic f ⊤` under modifications of `f`.
+
+- If `f` is meromorphic on the complex plane, then the characteristic functions for the value `⊤` of
+  the function `f` and `f⁻¹` agree up to a constant, see Proposition 2.1 on p. 168 of [Lang,
+  *Introduction to Complex Hyperbolic Spaces*][MR886677].
+
+- If `f` is meromorphic on the complex plane, then the characteristic functions for the value `⊤` of
+  the function `f` and `f - const` agree up to a constant, see Proposition 2.2 on p. 168 of [Lang,
+  *Introduction to Complex Hyperbolic Spaces*][MR886677]
+
+See Section~VI.2 of [Lang, *Introduction to Complex Hyperbolic Spaces*][MR886677] or Section~1.1 of
+[Noguchi-Winkelmann, *Nevanlinna Theory in Several Complex Variables and Diophantine
+Approximation*][MR3156076] for a detailed discussion.
+
+### TODO
+
+- Formalize the first part of the First Main Theorem, which is the more substantial part of the
+  statement.
+-/
+namespace ValueDistribution
+
+variable
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
+  {f : ℂ → E} {a₀ : E}
+
+open Asymptotics Filter Real
+
+/-!
+## Second Part of the First Main Theorem
+-/
+
+/--
+Second part of the First Main Theorem of Value Distribution Theory, quantitative version: If `f` is
+meromorphic on the complex plane, then the characteristic functions (for value `⊤`) of `f` and `f -
+a₀` differ at most by `log⁺ ‖a₀‖ + log 2`.
+-/
+theorem abs_characteristic_sub_characteristic_shift_le {r : ℝ} (h : MeromorphicOn f ⊤) :
+    |characteristic f ⊤ r - characteristic (f · - a₀) ⊤ r| ≤ log⁺ ‖a₀‖ + log 2 := by
+  have h₁f : CircleIntegrable (fun x ↦ log⁺ ‖f x‖) 0 r :=
+    circleIntegrable_posLog_norm_meromorphicOn (fun x a ↦ h x trivial)
+  have h₂f : CircleIntegrable (fun x ↦ log⁺ ‖f x - a₀‖) 0 r := by
+    apply circleIntegrable_posLog_norm_meromorphicOn
+    apply MeromorphicOn.sub (fun x a => h x trivial) (MeromorphicOn.const a₀)
+  rw [← Pi.sub_apply, characteristic_sub_characteristic_eq_proximity_sub_proximity h]
+  simp only [proximity, reduceDIte, Pi.sub_apply, ← circleAverage_sub h₁f h₂f]
+  apply le_trans abs_circleAverage_le_circleAverage_abs
+  apply circleAverage_mono_on_of_le_circle
+  · apply (h₁f.sub h₂f).abs
+  · intro θ hθ
+    simp only [Pi.abs_apply, Pi.sub_apply]
+    by_cases h : 0 ≤ log⁺ ‖f θ‖ - log⁺ ‖f θ - a₀‖
+    · simpa [abs_of_nonneg h, sub_le_iff_le_add, add_comm (log⁺ ‖a₀‖ + log 2), ← add_assoc]
+        using (posLog_norm_add_le (f θ - a₀) a₀)
+    · simp [abs_of_nonpos (le_of_not_ge h), neg_sub, sub_le_iff_le_add,
+        add_comm (log⁺ ‖a₀‖ + log 2), ← add_assoc]
+      convert posLog_norm_add_le (-f θ) (a₀) using 2
+      · rw [← norm_neg]
+        abel_nf
+      · simp
+
+/--
+Second part of the First Main Theorem of Value Distribution Theory, qualitative version: If `f` is
+meromorphic on the complex plane, then the characteristic functions for the value `⊤` of the
+function `f` and `f - a₀` agree asymptotically up to a bounded function.
+-/
+theorem abs_characteristic_sub_characteristic_shift_eqO (h : MeromorphicOn f ⊤) :
+    |characteristic f ⊤ - characteristic (f · - a₀) ⊤| =O[atTop] (1 : ℝ → ℝ) := by
+  simp_rw [isBigO_iff', eventually_atTop]
+  use log⁺ ‖a₀‖ + log 2, add_pos_of_nonneg_of_pos posLog_nonneg (log_pos one_lt_two), 0
+  simp [abs_characteristic_sub_characteristic_shift_le h]
+
+end ValueDistribution

--- a/Mathlib/Analysis/Complex/ValueDistribution/ProximityFunction.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/ProximityFunction.lean
@@ -99,9 +99,6 @@ f⁻¹ ⊤` is the circle average of `log ‖f ·‖`.
 theorem proximity_sub_proximity_inv_eq_circleAverage {f : ℂ → ℂ} (h₁f : MeromorphicOn f ⊤) :
     proximity f ⊤ - proximity f⁻¹ ⊤ = circleAverage (log ‖f ·‖) 0 := by
   ext R
-  have : CircleIntegrable (log⁺ ‖f ·‖⁻¹) 0 R := by
-    simp_rw [← norm_inv]
-    apply circleIntegrable_posLog_norm_meromorphicOn (h₁f.inv.mono_set (by tauto))
   simp only [proximity, ↓reduceDIte, Pi.inv_apply, norm_inv, Pi.sub_apply]
   rw [← circleAverage_sub]
   · simp_rw [← posLog_sub_posLog_inv]

--- a/Mathlib/Analysis/Complex/ValueDistribution/ProximityFunction.lean
+++ b/Mathlib/Analysis/Complex/ValueDistribution/ProximityFunction.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Stefan Kebekus
 -/
 import Mathlib.Algebra.Order.WithTop.Untop0
-import Mathlib.Analysis.SpecialFunctions.Log.PosLog
+import Mathlib.Analysis.SpecialFunctions.Integrability.LogMeromorphic
 import Mathlib.MeasureTheory.Integral.CircleAverage
+
 
 /-!
 # The Proximity Function of Value Distribution Theory
@@ -90,5 +91,23 @@ For complex-valued `f`, establish a simple relation between the proximity functi
 -/
 theorem proximity_inv {f : ℂ → ℂ} : proximity f⁻¹ ⊤ = proximity f 0 := by
   simp [proximity_zero, proximity_top]
+
+/--
+For complex-valued `f`, the difference between `proximity f ⊤` and `proximity
+f⁻¹ ⊤` is the circle average of `log ‖f ·‖`.
+-/
+theorem proximity_sub_proximity_inv_eq_circleAverage {f : ℂ → ℂ} (h₁f : MeromorphicOn f ⊤) :
+    proximity f ⊤ - proximity f⁻¹ ⊤ = circleAverage (log ‖f ·‖) 0 := by
+  ext R
+  have : CircleIntegrable (log⁺ ‖f ·‖⁻¹) 0 R := by
+    simp_rw [← norm_inv]
+    apply circleIntegrable_posLog_norm_meromorphicOn (h₁f.inv.mono_set (by tauto))
+  simp only [proximity, ↓reduceDIte, Pi.inv_apply, norm_inv, Pi.sub_apply]
+  rw [← circleAverage_sub]
+  · simp_rw [← posLog_sub_posLog_inv]
+    rfl
+  · apply circleIntegrable_posLog_norm_meromorphicOn (h₁f.mono_set (by tauto))
+  · simp_rw [← norm_inv]
+    apply circleIntegrable_posLog_norm_meromorphicOn  (h₁f.inv.mono_set (by tauto))
 
 end ValueDistribution

--- a/Mathlib/Analysis/SpecialFunctions/Log/PosLog.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/PosLog.lean
@@ -159,4 +159,18 @@ multiple summands. -/
 theorem posLog_add {a b : ℝ} : log⁺ (a + b) ≤ log 2 + log⁺ a + log⁺ b := by
   convert posLog_sum Finset.univ ![a, b] using 1 <;> simp [add_assoc]
 
+/--
+Variant of `posLog_add` for norms of elements in normed additive commutative groups, using
+monotonicity of `log⁺` and the triangle inequality.
+-/
+lemma posLog_norm_add_le {E : Type*} [NormedAddCommGroup E] (a b : E) :
+    log⁺ ‖a + b‖ ≤ log⁺ ‖a‖ + log⁺ ‖b‖ + log 2 := by
+  calc log⁺ ‖a + b‖
+  _ ≤ log⁺ (‖a‖ + ‖b‖) := by
+    apply monotoneOn_posLog _ _ (norm_add_le a b)
+    <;> simp [add_nonneg (norm_nonneg a) (norm_nonneg b)]
+  _ ≤ log⁺ ‖a‖ + log⁺ ‖b‖ + log 2 := by
+    convert posLog_add using 1
+    ring
+
 end Real

--- a/Mathlib/MeasureTheory/Integral/CircleAverage.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleAverage.lean
@@ -118,6 +118,59 @@ theorem circleAverage_congr_codiscreteWithin
   apply codiscreteWithin.mono (by tauto) (circleMap_preimage_codiscrete hR hf)
 
 /-!
+## Constant Functions
+-/
+
+/--
+The circle average of a constant function equals the constant.
+-/
+theorem circleAverage_const [CompleteSpace E] (a : E) (c : ℂ) (R : ℝ) :
+    circleAverage (fun _ ↦ a) c R = a := by
+  simp only [circleAverage, intervalIntegral.integral_const, ← smul_assoc, sub_zero, smul_eq_mul]
+  ring_nf
+  simp [mul_inv_cancel₀ pi_ne_zero]
+
+/--
+If `f x` equals `a` on for every point of the circle, then the circle average of `f` equals `a`.
+-/
+theorem circleAverage_const_on_circle [CompleteSpace E] {a : E}
+    (hf : ∀ x ∈ Metric.sphere c |R|, f x = a) :
+    circleAverage f c R = a := by
+  rw [circleAverage]
+  conv =>
+    left; arg 2; arg 1
+    intro θ
+    rw [hf (circleMap c R θ) (circleMap_mem_sphere' c R θ)]
+  apply circleAverage_const a c R
+
+/-!
+## Inequalities
+-/
+
+/--
+If `f x` is smaller than `a` on for every point of the circle, then the circle average of `f` is
+smaller than `a`.
+-/
+theorem circleAverage_mono_on_of_le_circle {f : ℂ → ℝ} {a : ℝ} (hf : CircleIntegrable f c R)
+    (h₂f : ∀ x ∈ Metric.sphere c |R|, f x ≤ a) :
+    circleAverage f c R ≤ a := by
+  rw [← circleAverage_const a c |R|, circleAverage, circleAverage, smul_eq_mul, smul_eq_mul,
+    mul_le_mul_iff_of_pos_left (inv_pos.2 two_pi_pos)]
+  apply intervalIntegral.integral_mono_on_of_le_Ioo (le_of_lt two_pi_pos) hf
+  · apply intervalIntegrable_const
+  · exact fun θ _ ↦ h₂f (circleMap c R θ) (circleMap_mem_sphere' c R θ)
+
+/--
+Analogue of `intervalIntegral.abs_integral_le_integral_abs`: The absolute value of a circle average
+is less than or equal to the circle average of the absolute value of the function.
+-/
+theorem abs_circleAverage_le_circleAverage_abs {f : ℂ → ℝ} :
+    |circleAverage f c R| ≤ circleAverage |f| c R := by
+  rw [circleAverage, circleAverage, smul_eq_mul, smul_eq_mul, abs_mul,
+    abs_of_pos (inv_pos.2 two_pi_pos), mul_le_mul_iff_of_pos_left (inv_pos.2 two_pi_pos)]
+  exact intervalIntegral.abs_integral_le_integral_abs (le_of_lt two_pi_pos)
+
+/-!
 ## Behaviour with Respect to Arithmetic Operations
 -/
 
@@ -147,5 +200,13 @@ theorem circleAverage_sum {ι : Type*} {s : Finset ι} {f : ι → ℂ → E}
     circleAverage (∑ i ∈ s, f i) c R = ∑ i ∈ s, circleAverage (f i) c R := by
   unfold circleAverage
   simp [← Finset.smul_sum, intervalIntegral.integral_finset_sum h]
+
+/-- Circle averages commute with subtraction. -/
+theorem circleAverage_sub (hf₁ : CircleIntegrable f₁ c R) (hf₂ : CircleIntegrable f₂ c R) :
+    circleAverage (f₁ - f₂) c R = circleAverage f₁ c R - circleAverage f₂ c R := by
+  rw [circleAverage, circleAverage, circleAverage, ← smul_sub]
+  congr
+  apply intervalIntegral.integral_sub hf₁ hf₂
+
 
 end Real

--- a/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
@@ -179,6 +179,13 @@ namespace CircleIntegrable
 
 variable {f g : ℂ → E} {c : ℂ} {R : ℝ}
 
+/--
+Analogue of `IntervalIntegrable.abs`: If a real-valued function `f` is circle integrable, then so is
+`|f|`.
+-/
+theorem abs {f : ℂ → ℝ} (hf : CircleIntegrable f c R) :
+    CircleIntegrable |f| c R := IntervalIntegrable.abs hf
+
 nonrec theorem add (hf : CircleIntegrable f c R) (hg : CircleIntegrable g c R) :
     CircleIntegrable (f + g) c R :=
   hf.add hg


### PR DESCRIPTION
The First Main Theorem of Value Distribution Theory is a two-part statement, establishing invariance of the characteristic function `characteristic f ⊤` under modifications of `f`. This PR implements the second half of the first main theorem. The first half, which is the more substantial part of the statement, will come in a later PR.
 
This material is used in [Project VD](https://github.com/kebekus/ProjectVD), which aims to formalize Value Distribution Theory for meromorphic functions on the complex plane.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
