### PR TITLE
[Merged by Bors] - feat: add simp to lemma `Fin.coe_ofNat_eq_mod`

### DIFF
--- a/Archive/Imo/Imo2024Q5.lean
+++ b/Archive/Imo/Imo2024Q5.lean
@@ -562,6 +562,8 @@ lemma row2_mem_monsterCells_monsterData12 (hN : 2 ≤ N) {c₁ c₂ : Fin (N + 1
   exact (monsterData12_apply_row2 hN h).symm
 
 lemma Strategy.not_forcesWinIn_two (s : Strategy N) (hN : 2 ≤ N) : ¬ s.ForcesWinIn 2 := by
+  have : NeZero N := ⟨by omega⟩
+  have : 0 < N := by omega
   simp only [ForcesWinIn, WinsIn, Set.mem_range, not_forall, not_exists, Option.ne_none_iff_isSome]
   let m1 : Cell N := (s Fin.elim0).findFstEq 1
   let m2 : Cell N := (s ![m1]).findFstEq 2
@@ -570,7 +572,6 @@ lemma Strategy.not_forcesWinIn_two (s : Strategy N) (hN : 2 ≤ N) : ¬ s.Forces
   have h2r : m2.1 = 2 := Path.findFstEq_fst _ _
   have h1 : m1 ∈ m.monsterCells := by
     convert row1_mem_monsterCells_monsterData12 hN m1.2 m2.2
-  have h2 : ((2 : Fin (N + 2)) : ℕ) = 2 := Nat.mod_eq_of_lt (by omega : 2 < N + 2)
   refine ⟨m, fun i ↦ ?_⟩
   fin_cases i
   · simp only [Strategy.play_zero, Path.firstMonster_eq_of_findFstEq_mem h1, Option.isSome_some]
@@ -582,15 +583,13 @@ lemma Strategy.not_forcesWinIn_two (s : Strategy N) (hN : 2 ≤ N) : ¬ s.Forces
     · rw [Path.firstMonster_isSome]
       refine ⟨m1, ?_, h1⟩
       have h' : m1 = (⟨(((2 : Fin (N + 2)) : ℕ) - 1 : ℕ), by omega⟩, m2.2) := by
-        simp [h2, Prod.ext_iff, h1r, h2r, h]
+        simpa [Prod.ext_iff, h1r, h2r, h]
       nth_rw 2 [h']
-      refine Path.findFstEq_fst_sub_one_mem _ ?_
-      rw [ne_eq, Fin.ext_iff, h2]
-      norm_num
+      exact Path.findFstEq_fst_sub_one_mem _ two_ne_zero
     · rw [Path.firstMonster_isSome]
       refine ⟨m2, Path.findFstEq_mem_cells _ _, ?_⟩
       convert row2_mem_monsterCells_monsterData12 hN h using 1
-      simp [Prod.ext_iff, h2r, Fin.ext_iff, h2]
+      simpa [Prod.ext_iff, h2r, Fin.ext_iff]
 
 lemma Strategy.ForcesWinIn.three_le {s : Strategy N} {k : ℕ} (hf : s.ForcesWinIn k)
     (hN : 2 ≤ N) : 3 ≤ k := by

--- a/Mathlib/AlgebraicTopology/DoldKan/Faces.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Faces.lean
@@ -87,8 +87,7 @@ theorem comp_Hσ_eq {Y : C} {n a q : ℕ} {φ : Y ⟶ X _⦋n + 1⦌} (v : Highe
       dsimp [Fin.natAdd, Fin.cast]
       omega
     · intro h
-      rw [Fin.pred_eq_iff_eq_succ, Fin.ext_iff] at h
-      dsimp [Fin.cast] at h
+      replace h : a + 3 + k = 1 := by simp [Fin.pred_eq_iff_eq_succ, Fin.ext_iff] at h
       omega
     · dsimp [Fin.cast, Fin.pred]
       rw [Nat.add_right_comm, Nat.add_sub_assoc (by norm_num : 1 ≤ 3)]

--- a/Mathlib/Analysis/CStarAlgebra/SpecialFunctions/PosPart.lean
+++ b/Mathlib/Analysis/CStarAlgebra/SpecialFunctions/PosPart.lean
@@ -70,10 +70,8 @@ lemma exists_sum_four_nonneg {A : Type*} [NonUnitalCStarAlgebra A] [PartialOrder
     · exact CStarAlgebra.norm_negPart_le _ |>.trans <| realPart.norm_le a
     · exact CStarAlgebra.norm_negPart_le _ |>.trans <| imaginaryPart.norm_le a
   · nth_rw 1 [← CStarAlgebra.linear_combination_nonneg a]
-    simp [Fin.sum_univ_four, sub_eq_add_neg]
-    rw [add_add_add_comm]
-    have : ((3 : Fin 4) : ℕ) = 3 := rfl -- ugh, seriously, why can't `norm_num` do this?
-    match_scalars
-    all_goals simp [this, I_pow_three]
+    simp only [Fin.sum_univ_four, Fin.coe_ofNat_eq_mod, Matrix.cons_val, Nat.reduceMod, I_sq,
+      I_pow_three]
+    module
 
 end CStarAlgebra

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -293,7 +293,6 @@ section Add
 ### addition, numerals, and coercion from Nat
 -/
 
-@[simp]
 theorem val_one' (n : ℕ) [NeZero n] : ((1 : Fin n) : ℕ) = 1 % n :=
   rfl
 
@@ -302,7 +301,7 @@ theorem val_one'' {n : ℕ} : ((1 : Fin (n + 1)) : ℕ) = 1 % (n + 1) :=
   rfl
 
 instance nontrivial {n : ℕ} [NeZero n] : Nontrivial (Fin (n + 1)) where
-  exists_pair_ne := ⟨0, 1, (ne_iff_vne 0 1).mpr (by simp [val_one, val_zero, NeZero.ne])⟩
+  exists_pair_ne := ⟨0, 1, (ne_iff_vne 0 1).mpr (by simp [val_one', val_zero, NeZero.ne])⟩
 
 theorem nontrivial_iff_two_le : Nontrivial (Fin n) ↔ 2 ≤ n := by
   rcases n with (_ | _ | n) <;>
@@ -1490,9 +1489,15 @@ theorem coe_natCast_eq_mod (m n : ℕ) [NeZero m] :
     ((n : Fin m) : ℕ) = n % m :=
   rfl
 
+@[simp]
 theorem coe_ofNat_eq_mod (m n : ℕ) [NeZero m] :
     ((ofNat(n) : Fin m) : ℕ) = ofNat(n) % m :=
   rfl
+
+instance [NeZero n] [NeZero ofNat(m)] : NeZero (ofNat(m) : Fin (n + ofNat(m))) := by
+  suffices m % (n + m) = m by simpa [neZero_iff, Fin.ext_iff, OfNat.ofNat, this] using NeZero.ne m
+  apply Nat.mod_eq_of_lt
+  simpa using zero_lt_of_ne_zero (NeZero.ne n)
 
 section Mul
 

--- a/Mathlib/Data/Fin/Parity.lean
+++ b/Mathlib/Data/Fin/Parity.lean
@@ -71,7 +71,7 @@ lemma odd_iff_of_even [NeZero n] (hn : Even n) : Odd k ↔ Odd k.val := by
   rcases hn with ⟨n, rfl⟩
   refine ⟨?_, odd_of_val⟩
   rintro ⟨l, rfl⟩
-  rw [val_add, val_mul, val_one', show Fin.val 2 = 2 % _ from rfl]
+  rw [val_add, val_mul, coe_ofNat_eq_mod, coe_ofNat_eq_mod]
   simp only [Nat.mod_mul_mod, Nat.add_mod_mod, Nat.mod_add_mod, Nat.odd_iff]
   rw [Nat.mod_mod_of_dvd _ ⟨n, (two_mul n).symm⟩, ← Nat.odd_iff, Nat.odd_add_one,
     Nat.not_odd_iff_even]

--- a/Mathlib/Data/Fin/Rev.lean
+++ b/Mathlib/Data/Fin/Rev.lean
@@ -65,7 +65,7 @@ theorem lt_rev_iff {i j : Fin n} : i < rev j ↔ j < rev i := by
 theorem le_rev_iff {i j : Fin n} : i ≤ rev j ↔ j ≤ rev i := by
   rw [← rev_le_rev, rev_rev]
 
-@[simp] theorem val_rev_zero [NeZero n] : ((rev 0 : Fin n) : ℕ) = n.pred := rfl
+theorem val_rev_zero [NeZero n] : ((rev 0 : Fin n) : ℕ) = n.pred := rfl
 
 theorem rev_pred {i : Fin (n + 1)} (h : i ≠ 0) (h' := rev_ne_iff.mpr ((rev_last _).symm ▸ h)) :
     rev (pred i h) = castPred (rev i) h' := by

--- a/Mathlib/GroupTheory/CommutingProbability.lean
+++ b/Mathlib/GroupTheory/CommutingProbability.lean
@@ -181,7 +181,8 @@ lemma commProb_nil : commProb (Product []) = 1 := by
 
 lemma commProb_cons (n : ℕ) (l : List ℕ) :
     commProb (Product (n :: l)) = commProb (DihedralGroup n) * commProb (Product l) := by
-  simp [commProb_pi, Fin.prod_univ_succ, Fin.val_zero]
+  simp only [commProb_pi, Fin.prod_univ_succ, Fin.getElem_fin, Fin.val_succ, Fin.val_zero,
+    List.getElem_cons_zero, List.length_cons, List.getElem_cons_succ]
 
 /-- Construction of a group with commuting probability `1 / n`. -/
 theorem commProb_reciprocal (n : ℕ) :

--- a/Mathlib/GroupTheory/Perm/Fin.lean
+++ b/Mathlib/GroupTheory/Perm/Fin.lean
@@ -299,7 +299,8 @@ theorem cycleType_cycleRange {n : ℕ} [NeZero n] {i : Fin n} (h0 : i ≠ 0) :
   exact cycleType_finRotate
 
 theorem isThreeCycle_cycleRange_two {n : ℕ} : IsThreeCycle (cycleRange 2 : Perm (Fin (n + 3))) := by
-  rw [IsThreeCycle, cycleType_cycleRange] <;> simp [Fin.ext_iff]
+  rw [IsThreeCycle, cycleType_cycleRange two_ne_zero]
+  simp
 
 end Fin
 

--- a/Mathlib/RingTheory/ChainOfDivisors.lean
+++ b/Mathlib/RingTheory/ChainOfDivisors.lean
@@ -67,7 +67,7 @@ theorem exists_chain_of_prime_pow {p : Associates M} {n : ℕ} (hn : n ≠ 0) (h
       c 1 = p ∧ StrictMono c ∧ ∀ {r : Associates M}, r ≤ p ^ n ↔ ∃ i, r = c i := by
   refine ⟨fun i => p ^ (i : ℕ), ?_, fun n m h => ?_, @fun y => ⟨fun h => ?_, ?_⟩⟩
   · dsimp only
-    rw [Fin.val_one', Nat.mod_eq_of_lt, pow_one]
+    rw [Fin.coe_ofNat_eq_mod, Nat.mod_eq_of_lt, pow_one]
     exact Nat.lt_succ_of_le (Nat.one_le_iff_ne_zero.mpr hn)
   · exact Associates.dvdNotUnit_iff_lt.mp
         ⟨pow_ne_zero n hp.ne_zero, p ^ (m - n : ℕ),

--- a/MathlibTest/matrix.lean
+++ b/MathlibTest/matrix.lean
@@ -142,9 +142,9 @@ example {α : Type _} [CommRing α] {a b c d : α} :
   simp? [Matrix.det_succ_row_zero, Fin.sum_univ_succ] says
     simp only [det_succ_row_zero, Nat.succ_eq_add_one, Nat.reduceAdd, Fin.isValue, of_apply,
       cons_val', cons_val_fin_one, cons_val_zero, det_unique, Fin.default_eq_zero, submatrix_apply,
-      Fin.succ_zero_eq_one, cons_val_one, Fin.sum_univ_succ, Fin.val_zero, pow_zero, one_mul,
-      Fin.zero_succAbove, Finset.univ_unique, Fin.val_succ, Fin.val_eq_zero, zero_add, pow_one,
-      cons_val_succ, neg_mul, ne_eq, Fin.succ_ne_zero, not_false_eq_true,
+      Fin.succ_zero_eq_one, cons_val_one, Fin.sum_univ_succ, Fin.coe_ofNat_eq_mod, Nat.zero_mod,
+      pow_zero, one_mul, Fin.zero_succAbove, Finset.univ_unique, Fin.val_succ, Fin.val_eq_zero,
+      zero_add, pow_one, cons_val_succ, neg_mul, ne_eq, Fin.succ_ne_zero, not_false_eq_true,
       Fin.succAbove_ne_zero_zero, Finset.sum_neg_distrib, Finset.sum_const, Finset.card_singleton,
       one_smul]
   ring
@@ -156,11 +156,12 @@ example {α : Type _} [CommRing α] {a b c d e f g h i : α} :
     simp only [det_succ_row_zero, Nat.succ_eq_add_one, Nat.reduceAdd, Fin.isValue, of_apply,
       cons_val', cons_val_fin_one, cons_val_zero, submatrix_apply, Fin.succ_zero_eq_one,
       cons_val_one, submatrix_submatrix, det_unique, Fin.default_eq_zero, Function.comp_apply,
-      Fin.succ_one_eq_two, cons_val, Fin.sum_univ_succ, Fin.val_zero, pow_zero, one_mul,
-      Fin.zero_succAbove, Finset.univ_unique, Fin.val_succ, Fin.val_eq_zero, zero_add, pow_one,
-      neg_mul, ne_eq, Fin.succ_ne_zero, not_false_eq_true, Fin.succAbove_ne_zero_zero,
-      Finset.sum_neg_distrib, Finset.sum_singleton, cons_val_succ, Fin.succ_succAbove_one, even_two,
-      Even.neg_pow, one_pow, Finset.sum_const, Finset.card_singleton, one_smul]
+      Fin.succ_one_eq_two, cons_val, Fin.sum_univ_succ, Fin.coe_ofNat_eq_mod, Nat.zero_mod,
+      pow_zero, one_mul, Fin.zero_succAbove, Finset.univ_unique, Fin.val_succ, Fin.val_eq_zero,
+      zero_add, pow_one, neg_mul, ne_eq, Fin.succ_ne_zero, not_false_eq_true,
+      Fin.succAbove_ne_zero_zero, Finset.sum_neg_distrib, Finset.sum_singleton, cons_val_succ,
+      Fin.succ_succAbove_one, even_two, Even.neg_pow, one_pow, Finset.sum_const,
+      Finset.card_singleton, one_smul]
   ring
 
 example {R : Type*} [Semiring R] {a b c d : R} :


### PR DESCRIPTION
One consequence is that simp can now prove things like this:
```lean
example : (3 : Fin 10).val = 3 := by simp
example : (4 : Fin 10).val = 4 := by simp
example : (5 : Fin 10).val = 5 := by simp
```
previously this only this only worked up to `(2 : Fin 10).val = 2` (via lemmas like `Fin.val_two`).

---

Migrated from https://github.com/leanprover-community/mathlib4/pull/25315

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
