### PR TITLE
[Merged by Bors] - refactor(GroupTheory/SpecificGroups): Switch import order between `KleinFour` and `Dihedral`

### DIFF
--- a/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Dihedral.lean
@@ -8,6 +8,7 @@ import Mathlib.Data.ZMod.Basic
 import Mathlib.GroupTheory.Exponent
 import Mathlib.GroupTheory.GroupAction.CardCommute
 import Mathlib.GroupTheory.SpecificGroups.Cyclic
+import Mathlib.GroupTheory.SpecificGroups.KleinFour
 
 /-!
 # Dihedral Groups
@@ -233,6 +234,10 @@ lemma not_isCyclic (h1 : n ≠ 1) : ¬ IsCyclic (DihedralGroup n) := fun h => by
 lemma isCyclic_iff : IsCyclic (DihedralGroup n) ↔ n = 1 where
   mp := not_imp_not.mp not_isCyclic
   mpr h := h ▸ isCyclic_of_prime_card (p := 2) nat_card
+
+instance : IsKleinFour (DihedralGroup 2) where
+  card_four := DihedralGroup.nat_card
+  exponent_two := DihedralGroup.exponent
 
 /-- If n is odd, then the Dihedral group of order $2n$ has $n(n+3)$ pairs (represented as
 $n + n + n + n*n$) of commuting elements. -/

--- a/Mathlib/GroupTheory/SpecificGroups/KleinFour.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/KleinFour.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Newell Jensen
 -/
 import Mathlib.GroupTheory.SpecificGroups.Cyclic
-import Mathlib.GroupTheory.SpecificGroups.Dihedral
 
 /-!
 # Klein Four Group
@@ -59,10 +58,6 @@ attribute [simp] IsKleinFour.card_four IsKleinFour.exponent_two
 instance : IsAddKleinFour (ZMod 2 × ZMod 2) where
   card_four := by simp
   exponent_two := by simp [AddMonoid.exponent_prod]
-
-instance : IsKleinFour (DihedralGroup 2) where
-  card_four := by simp only [Nat.card_eq_fintype_card]; rfl
-  exponent_two := by simp [DihedralGroup.exponent]
 
 instance {G : Type*} [Group G] [IsKleinFour G] : IsAddKleinFour (Additive G) where
   card_four := by rw [← IsKleinFour.card_four (G := G)]; congr!


### PR DESCRIPTION
In general, it seems that more complicated groups should import less complicated groups. So the instance `IsKleinFour (DihedralGroup 2)` should be in `Dihedral` rather than in `IsKleinFour`. Analogous to how `IsCyclic (DihedralGroup 1)` is in `Dihedral` rather than `Cyclic`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
