### PR TITLE
[Merged by Bors] - chore: check auto-merge-after-CI label actor

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -563,6 +563,71 @@ jobs:
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
       - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')
+        name: Get PR label timeline data
+        # 'auto-merge-after-CI' must be within the last 100 labels added (could be increased to 250 if needed)
+        # query from https://stackoverflow.com/a/67939355
+        # unfortunately we cannot query only for 'auto-merge-after-CI' events
+        # so we have to process this with jq in the next step
+        id: get-timeline
+        uses: octokit/graphql-action@8ad880e4d437783ea2ab17010324de1075228110 # v2.3.2
+        with:
+          query: |
+            query($owner: String!, $name: String!, $number: Int!) {
+              repository(owner: $owner, name: $name) {
+                pullRequest(number: $number) {
+                  timelineItems(itemTypes: LABELED_EVENT, last: 100) {
+                    nodes {
+                      ... on LabeledEvent {
+                        createdAt
+                        actor { login }
+                        label { name }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          owner: leanprover-community
+          name: mathlib4
+          number: ${{ steps.PR.outputs.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract label actor username
+        id: get-label-actor
+        run: |
+          # Parse the GraphQL response and filter for the specific label
+          USERNAME=$(echo '${{ steps.get-timeline.outputs.data }}' | jq -r '
+            .repository.pullRequest.timelineItems.nodes
+            | map(select(.label.name == "auto-merge-after-CI"))
+            | sort_by(.createdAt)
+            | last
+            | .actor.login // empty
+          ')
+
+          # Validate username format (GitHub usernames are alphanumeric + hyphens, max 39 chars)
+          if [[ -z "$USERNAME" ]]; then
+            echo "Error: No actor found for the specified label"
+            exit 1
+          elif ! [[ "$USERNAME" =~ ^[a-zA-Z0-9-]{1,39}$ ]]; then
+            echo "Error: Invalid username format: $USERNAME"
+            exit 1
+          fi
+
+          echo "username=$USERNAME" >> $GITHUB_OUTPUT
+          echo "Found label actor: $USERNAME"
+
+      - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')
+        name: check team membership
+        uses: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662 # v3.0.0
+        id: actorTeams
+        with:
+          organization: leanprover-community # optional. Default value ${{ github.repository_owner }}
+                  # Organization to get membership from.
+          username: ${{ steps.get-label-actor.outputs.username }}
+          GITHUB_TOKEN: ${{ secrets.MATHLIB_REVIEWERS_TEAM_KEY }} # (Requires scope: `read:org`)
+
+      - if: ${{ contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI') && (contains(steps.actorTeams.outputs.teams, 'mathlib-maintainers') || contains(steps.actorTeams.outputs.teams.teams, 'bot-users')) }}
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@608e41b19bc973020ec0e189ebfdae935d7fe0cc # v2.1.1
         with:

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -541,8 +541,8 @@ jobs:
       - id: PR
         shell: bash
         run: |
-          echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || join(github.event.pull_request.labels.*.name, ',') }}" >> "$GITHUB_OUTPUT"
+          echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" | tee -a "$GITHUB_OUTPUT"
+          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || join(github.event.pull_request.labels.*.name, ',') }}" | tee -a "$GITHUB_OUTPUT"
 
       - if: contains(steps.PR.outputs.pr_labels, 'bench-after-CI')
         name: If `bench-after-CI` is present, add a `!bench` comment.

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -541,8 +541,8 @@ jobs:
       - id: PR
         shell: bash
         run: |
-          echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || join(github.event.pull_request.labels.*.name, ',') }}" >> $GITHUB_OUTPUT
+          echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || join(github.event.pull_request.labels.*.name, ',') }}" >> "$GITHUB_OUTPUT"
 
       - if: contains(steps.PR.outputs.pr_labels, 'bench-after-CI')
         name: If `bench-after-CI` is present, add a `!bench` comment.
@@ -614,7 +614,7 @@ jobs:
             exit 1
           fi
 
-          echo "username=$USERNAME" >> $GITHUB_OUTPUT
+          echo "username=$USERNAME" >> "$GITHUB_OUTPUT"
           echo "Found label actor: $USERNAME"
 
       - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -627,7 +627,7 @@ jobs:
           username: ${{ steps.get-label-actor.outputs.username }}
           GITHUB_TOKEN: ${{ secrets.MATHLIB_REVIEWERS_TEAM_KEY }} # (Requires scope: `read:org`)
 
-      - if: ${{ contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI') && (contains(steps.actorTeams.outputs.teams, 'mathlib-maintainers') || contains(steps.actorTeams.outputs.teams.teams, 'bot-users')) }}
+      - if: ${{ contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI') && (contains(steps.actorTeams.outputs.teams, 'mathlib-maintainers') || contains(steps.actorTeams.outputs.teams, 'bot-users')) }}
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@608e41b19bc973020ec0e189ebfdae935d7fe0cc # v2.1.1
         with:

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -597,6 +597,7 @@ jobs:
         id: get-label-actor
         run: |
           # Parse the GraphQL response and filter for the specific label
+          echo '${{ steps.get-timeline.outputs.data }}'
           USERNAME=$(echo '${{ steps.get-timeline.outputs.data }}' | jq -r '
             .repository.pullRequest.timelineItems.nodes
             | map(select(.label.name == "auto-merge-after-CI"))
@@ -606,6 +607,7 @@ jobs:
           ')
 
           # Validate username format (GitHub usernames are alphanumeric + hyphens, max 39 chars)
+          printf 'USERNAME: %s\n' "$USERNAME"
           if [[ -z "$USERNAME" ]]; then
             echo "Error: No actor found for the specified label"
             exit 1

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -573,6 +573,71 @@ jobs:
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
       - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')
+        name: Get PR label timeline data
+        # 'auto-merge-after-CI' must be within the last 100 labels added (could be increased to 250 if needed)
+        # query from https://stackoverflow.com/a/67939355
+        # unfortunately we cannot query only for 'auto-merge-after-CI' events
+        # so we have to process this with jq in the next step
+        id: get-timeline
+        uses: octokit/graphql-action@8ad880e4d437783ea2ab17010324de1075228110 # v2.3.2
+        with:
+          query: |
+            query($owner: String!, $name: String!, $number: Int!) {
+              repository(owner: $owner, name: $name) {
+                pullRequest(number: $number) {
+                  timelineItems(itemTypes: LABELED_EVENT, last: 100) {
+                    nodes {
+                      ... on LabeledEvent {
+                        createdAt
+                        actor { login }
+                        label { name }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          owner: leanprover-community
+          name: mathlib4
+          number: ${{ steps.PR.outputs.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract label actor username
+        id: get-label-actor
+        run: |
+          # Parse the GraphQL response and filter for the specific label
+          USERNAME=$(echo '${{ steps.get-timeline.outputs.data }}' | jq -r '
+            .repository.pullRequest.timelineItems.nodes
+            | map(select(.label.name == "auto-merge-after-CI"))
+            | sort_by(.createdAt)
+            | last
+            | .actor.login // empty
+          ')
+
+          # Validate username format (GitHub usernames are alphanumeric + hyphens, max 39 chars)
+          if [[ -z "$USERNAME" ]]; then
+            echo "Error: No actor found for the specified label"
+            exit 1
+          elif ! [[ "$USERNAME" =~ ^[a-zA-Z0-9-]{1,39}$ ]]; then
+            echo "Error: Invalid username format: $USERNAME"
+            exit 1
+          fi
+
+          echo "username=$USERNAME" >> $GITHUB_OUTPUT
+          echo "Found label actor: $USERNAME"
+
+      - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')
+        name: check team membership
+        uses: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662 # v3.0.0
+        id: actorTeams
+        with:
+          organization: leanprover-community # optional. Default value ${{ github.repository_owner }}
+                  # Organization to get membership from.
+          username: ${{ steps.get-label-actor.outputs.username }}
+          GITHUB_TOKEN: ${{ secrets.MATHLIB_REVIEWERS_TEAM_KEY }} # (Requires scope: `read:org`)
+
+      - if: ${{ contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI') && (contains(steps.actorTeams.outputs.teams, 'mathlib-maintainers') || contains(steps.actorTeams.outputs.teams.teams, 'bot-users')) }}
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@608e41b19bc973020ec0e189ebfdae935d7fe0cc # v2.1.1
         with:

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -551,8 +551,8 @@ jobs:
       - id: PR
         shell: bash
         run: |
-          echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || join(github.event.pull_request.labels.*.name, ',') }}" >> "$GITHUB_OUTPUT"
+          echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" | tee -a "$GITHUB_OUTPUT"
+          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || join(github.event.pull_request.labels.*.name, ',') }}" | tee -a "$GITHUB_OUTPUT"
 
       - if: contains(steps.PR.outputs.pr_labels, 'bench-after-CI')
         name: If `bench-after-CI` is present, add a `!bench` comment.

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -551,8 +551,8 @@ jobs:
       - id: PR
         shell: bash
         run: |
-          echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || join(github.event.pull_request.labels.*.name, ',') }}" >> $GITHUB_OUTPUT
+          echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || join(github.event.pull_request.labels.*.name, ',') }}" >> "$GITHUB_OUTPUT"
 
       - if: contains(steps.PR.outputs.pr_labels, 'bench-after-CI')
         name: If `bench-after-CI` is present, add a `!bench` comment.
@@ -624,7 +624,7 @@ jobs:
             exit 1
           fi
 
-          echo "username=$USERNAME" >> $GITHUB_OUTPUT
+          echo "username=$USERNAME" >> "$GITHUB_OUTPUT"
           echo "Found label actor: $USERNAME"
 
       - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -607,6 +607,7 @@ jobs:
         id: get-label-actor
         run: |
           # Parse the GraphQL response and filter for the specific label
+          echo '${{ steps.get-timeline.outputs.data }}'
           USERNAME=$(echo '${{ steps.get-timeline.outputs.data }}' | jq -r '
             .repository.pullRequest.timelineItems.nodes
             | map(select(.label.name == "auto-merge-after-CI"))
@@ -616,6 +617,7 @@ jobs:
           ')
 
           # Validate username format (GitHub usernames are alphanumeric + hyphens, max 39 chars)
+          printf 'USERNAME: %s\n' "$USERNAME"
           if [[ -z "$USERNAME" ]]; then
             echo "Error: No actor found for the specified label"
             exit 1

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -637,7 +637,7 @@ jobs:
           username: ${{ steps.get-label-actor.outputs.username }}
           GITHUB_TOKEN: ${{ secrets.MATHLIB_REVIEWERS_TEAM_KEY }} # (Requires scope: `read:org`)
 
-      - if: ${{ contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI') && (contains(steps.actorTeams.outputs.teams, 'mathlib-maintainers') || contains(steps.actorTeams.outputs.teams.teams, 'bot-users')) }}
+      - if: ${{ contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI') && (contains(steps.actorTeams.outputs.teams, 'mathlib-maintainers') || contains(steps.actorTeams.outputs.teams, 'bot-users')) }}
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@608e41b19bc973020ec0e189ebfdae935d7fe0cc # v2.1.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -614,6 +614,7 @@ jobs:
         id: get-label-actor
         run: |
           # Parse the GraphQL response and filter for the specific label
+          echo '${{ steps.get-timeline.outputs.data }}'
           USERNAME=$(echo '${{ steps.get-timeline.outputs.data }}' | jq -r '
             .repository.pullRequest.timelineItems.nodes
             | map(select(.label.name == "auto-merge-after-CI"))
@@ -623,6 +624,7 @@ jobs:
           ')
 
           # Validate username format (GitHub usernames are alphanumeric + hyphens, max 39 chars)
+          printf 'USERNAME: %s\n' "$USERNAME"
           if [[ -z "$USERNAME" ]]; then
             echo "Error: No actor found for the specified label"
             exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -558,8 +558,8 @@ jobs:
       - id: PR
         shell: bash
         run: |
-          echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || join(github.event.pull_request.labels.*.name, ',') }}" >> "$GITHUB_OUTPUT"
+          echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" | tee -a "$GITHUB_OUTPUT"
+          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || join(github.event.pull_request.labels.*.name, ',') }}" | tee -a "$GITHUB_OUTPUT"
 
       - if: contains(steps.PR.outputs.pr_labels, 'bench-after-CI')
         name: If `bench-after-CI` is present, add a `!bench` comment.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -644,7 +644,7 @@ jobs:
           username: ${{ steps.get-label-actor.outputs.username }}
           GITHUB_TOKEN: ${{ secrets.MATHLIB_REVIEWERS_TEAM_KEY }} # (Requires scope: `read:org`)
 
-      - if: ${{ contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI') && (contains(steps.actorTeams.outputs.teams, 'mathlib-maintainers') || contains(steps.actorTeams.outputs.teams.teams, 'bot-users')) }}
+      - if: ${{ contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI') && (contains(steps.actorTeams.outputs.teams, 'mathlib-maintainers') || contains(steps.actorTeams.outputs.teams, 'bot-users')) }}
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@608e41b19bc973020ec0e189ebfdae935d7fe0cc # v2.1.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -558,8 +558,8 @@ jobs:
       - id: PR
         shell: bash
         run: |
-          echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || join(github.event.pull_request.labels.*.name, ',') }}" >> $GITHUB_OUTPUT
+          echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || join(github.event.pull_request.labels.*.name, ',') }}" >> "$GITHUB_OUTPUT"
 
       - if: contains(steps.PR.outputs.pr_labels, 'bench-after-CI')
         name: If `bench-after-CI` is present, add a `!bench` comment.
@@ -631,7 +631,7 @@ jobs:
             exit 1
           fi
 
-          echo "username=$USERNAME" >> $GITHUB_OUTPUT
+          echo "username=$USERNAME" >> "$GITHUB_OUTPUT"
           echo "Found label actor: $USERNAME"
 
       - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -580,6 +580,71 @@ jobs:
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
       - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')
+        name: Get PR label timeline data
+        # 'auto-merge-after-CI' must be within the last 100 labels added (could be increased to 250 if needed)
+        # query from https://stackoverflow.com/a/67939355
+        # unfortunately we cannot query only for 'auto-merge-after-CI' events
+        # so we have to process this with jq in the next step
+        id: get-timeline
+        uses: octokit/graphql-action@8ad880e4d437783ea2ab17010324de1075228110 # v2.3.2
+        with:
+          query: |
+            query($owner: String!, $name: String!, $number: Int!) {
+              repository(owner: $owner, name: $name) {
+                pullRequest(number: $number) {
+                  timelineItems(itemTypes: LABELED_EVENT, last: 100) {
+                    nodes {
+                      ... on LabeledEvent {
+                        createdAt
+                        actor { login }
+                        label { name }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          owner: leanprover-community
+          name: mathlib4
+          number: ${{ steps.PR.outputs.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract label actor username
+        id: get-label-actor
+        run: |
+          # Parse the GraphQL response and filter for the specific label
+          USERNAME=$(echo '${{ steps.get-timeline.outputs.data }}' | jq -r '
+            .repository.pullRequest.timelineItems.nodes
+            | map(select(.label.name == "auto-merge-after-CI"))
+            | sort_by(.createdAt)
+            | last
+            | .actor.login // empty
+          ')
+
+          # Validate username format (GitHub usernames are alphanumeric + hyphens, max 39 chars)
+          if [[ -z "$USERNAME" ]]; then
+            echo "Error: No actor found for the specified label"
+            exit 1
+          elif ! [[ "$USERNAME" =~ ^[a-zA-Z0-9-]{1,39}$ ]]; then
+            echo "Error: Invalid username format: $USERNAME"
+            exit 1
+          fi
+
+          echo "username=$USERNAME" >> $GITHUB_OUTPUT
+          echo "Found label actor: $USERNAME"
+
+      - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')
+        name: check team membership
+        uses: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662 # v3.0.0
+        id: actorTeams
+        with:
+          organization: leanprover-community # optional. Default value ${{ github.repository_owner }}
+                  # Organization to get membership from.
+          username: ${{ steps.get-label-actor.outputs.username }}
+          GITHUB_TOKEN: ${{ secrets.MATHLIB_REVIEWERS_TEAM_KEY }} # (Requires scope: `read:org`)
+
+      - if: ${{ contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI') && (contains(steps.actorTeams.outputs.teams, 'mathlib-maintainers') || contains(steps.actorTeams.outputs.teams.teams, 'bot-users')) }}
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@608e41b19bc973020ec0e189ebfdae935d7fe0cc # v2.1.1
         with:

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -611,6 +611,7 @@ jobs:
         id: get-label-actor
         run: |
           # Parse the GraphQL response and filter for the specific label
+          echo '${{ steps.get-timeline.outputs.data }}'
           USERNAME=$(echo '${{ steps.get-timeline.outputs.data }}' | jq -r '
             .repository.pullRequest.timelineItems.nodes
             | map(select(.label.name == "auto-merge-after-CI"))
@@ -620,6 +621,7 @@ jobs:
           ')
 
           # Validate username format (GitHub usernames are alphanumeric + hyphens, max 39 chars)
+          printf 'USERNAME: %s\n' "$USERNAME"
           if [[ -z "$USERNAME" ]]; then
             echo "Error: No actor found for the specified label"
             exit 1

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -577,6 +577,71 @@ jobs:
             --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
 
       - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')
+        name: Get PR label timeline data
+        # 'auto-merge-after-CI' must be within the last 100 labels added (could be increased to 250 if needed)
+        # query from https://stackoverflow.com/a/67939355
+        # unfortunately we cannot query only for 'auto-merge-after-CI' events
+        # so we have to process this with jq in the next step
+        id: get-timeline
+        uses: octokit/graphql-action@8ad880e4d437783ea2ab17010324de1075228110 # v2.3.2
+        with:
+          query: |
+            query($owner: String!, $name: String!, $number: Int!) {
+              repository(owner: $owner, name: $name) {
+                pullRequest(number: $number) {
+                  timelineItems(itemTypes: LABELED_EVENT, last: 100) {
+                    nodes {
+                      ... on LabeledEvent {
+                        createdAt
+                        actor { login }
+                        label { name }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          owner: leanprover-community
+          name: mathlib4
+          number: ${{ steps.PR.outputs.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract label actor username
+        id: get-label-actor
+        run: |
+          # Parse the GraphQL response and filter for the specific label
+          USERNAME=$(echo '${{ steps.get-timeline.outputs.data }}' | jq -r '
+            .repository.pullRequest.timelineItems.nodes
+            | map(select(.label.name == "auto-merge-after-CI"))
+            | sort_by(.createdAt)
+            | last
+            | .actor.login // empty
+          ')
+
+          # Validate username format (GitHub usernames are alphanumeric + hyphens, max 39 chars)
+          if [[ -z "$USERNAME" ]]; then
+            echo "Error: No actor found for the specified label"
+            exit 1
+          elif ! [[ "$USERNAME" =~ ^[a-zA-Z0-9-]{1,39}$ ]]; then
+            echo "Error: Invalid username format: $USERNAME"
+            exit 1
+          fi
+
+          echo "username=$USERNAME" >> $GITHUB_OUTPUT
+          echo "Found label actor: $USERNAME"
+
+      - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')
+        name: check team membership
+        uses: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662 # v3.0.0
+        id: actorTeams
+        with:
+          organization: leanprover-community # optional. Default value ${{ github.repository_owner }}
+                  # Organization to get membership from.
+          username: ${{ steps.get-label-actor.outputs.username }}
+          GITHUB_TOKEN: ${{ secrets.MATHLIB_REVIEWERS_TEAM_KEY }} # (Requires scope: `read:org`)
+
+      - if: ${{ contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI') && (contains(steps.actorTeams.outputs.teams, 'mathlib-maintainers') || contains(steps.actorTeams.outputs.teams.teams, 'bot-users')) }}
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@608e41b19bc973020ec0e189ebfdae935d7fe0cc # v2.1.1
         with:

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -641,7 +641,7 @@ jobs:
           username: ${{ steps.get-label-actor.outputs.username }}
           GITHUB_TOKEN: ${{ secrets.MATHLIB_REVIEWERS_TEAM_KEY }} # (Requires scope: `read:org`)
 
-      - if: ${{ contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI') && (contains(steps.actorTeams.outputs.teams, 'mathlib-maintainers') || contains(steps.actorTeams.outputs.teams.teams, 'bot-users')) }}
+      - if: ${{ contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI') && (contains(steps.actorTeams.outputs.teams, 'mathlib-maintainers') || contains(steps.actorTeams.outputs.teams, 'bot-users')) }}
         name: If `auto-merge-after-CI` is present, add a `bors merge` comment.
         uses: GrantBirki/comment@608e41b19bc973020ec0e189ebfdae935d7fe0cc # v2.1.1
         with:

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -555,8 +555,8 @@ jobs:
       - id: PR
         shell: bash
         run: |
-          echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || join(github.event.pull_request.labels.*.name, ',') }}" >> $GITHUB_OUTPUT
+          echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || join(github.event.pull_request.labels.*.name, ',') }}" >> "$GITHUB_OUTPUT"
 
       - if: contains(steps.PR.outputs.pr_labels, 'bench-after-CI')
         name: If `bench-after-CI` is present, add a `!bench` comment.
@@ -628,7 +628,7 @@ jobs:
             exit 1
           fi
 
-          echo "username=$USERNAME" >> $GITHUB_OUTPUT
+          echo "username=$USERNAME" >> "$GITHUB_OUTPUT"
           echo "Found label actor: $USERNAME"
 
       - if: contains(steps.PR.outputs.pr_labels, 'auto-merge-after-CI')

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -555,8 +555,8 @@ jobs:
       - id: PR
         shell: bash
         run: |
-          echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || join(github.event.pull_request.labels.*.name, ',') }}" >> "$GITHUB_OUTPUT"
+          echo "number=${{ steps.PR_from_push.outputs.number || github.event.pull_request.number }}" | tee -a "$GITHUB_OUTPUT"
+          echo "pr_labels=${{ steps.PR_from_push.outputs.pr_labels || join(github.event.pull_request.labels.*.name, ',') }}" | tee -a "$GITHUB_OUTPUT"
 
       - if: contains(steps.PR.outputs.pr_labels, 'bench-after-CI')
         name: If `bench-after-CI` is present, add a `!bench` comment.


### PR DESCRIPTION
This adds a few steps to our build job so that the `bors merge` comment will only be added if the user who added `auto-merge-after-CI` is in an allowed team (currently "mathlib-maintainers" and "bot-users").

---

I had help from Claude, but I checked everything myself. This still needs some more testing which we may have to do once this is merged.