### PR TITLE
feat: weekly report on PRs to website and blog

### DIFF
--- a/.github/workflows/weekly_blog_and_website_report.yml
+++ b/.github/workflows/weekly_blog_and_website_report.yml
@@ -30,7 +30,7 @@ jobs:
         do
           printf 'PRs in %s\n' "${site}"
           cd "${site}"
-          printf $'%s<<EOF\n%s\nEOF' "${site}" "$(./scripts/formatGhPrList.sh "${site}")" | tee "$GITHUB_OUTPUT"
+          printf $'%s<<EOF\n%s\nEOF' "${site}" "$(./scripts/formatGhPrList.sh "${site}")" | tee -a "$GITHUB_OUTPUT"
           cd ..
         done
 

--- a/.github/workflows/weekly_blog_and_website_report.yml
+++ b/.github/workflows/weekly_blog_and_website_report.yml
@@ -1,0 +1,53 @@
+name: Weekly blog and website report
+
+on:
+  schedule:
+    - cron: '0 4 * * WED'  # Run at 04:00 UTC every Wednesday
+  workflow_dispatch:
+
+jobs:
+  run-script:
+    runs-on: ubuntu-latest
+    if: github.repository == 'leanprover-community/mathlib4'
+
+    steps:
+    - name: Checkout website
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        repository: 'leanprover-community/leanprover-community.github.io'
+        path: website
+
+    - name: Checkout blog
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        repository: 'leanprover-community/leanprover-community.github.io'
+        path: blog
+
+    - name: Produce tables
+      id: tables
+      run: |
+        for site in website blog
+        do
+          printf 'PRs in %s\n' "${site}"
+          cd "${site}"
+          printf $'%s<<EOF\n%s\nEOF' "${site}" "$(./scripts/formatGhPrList.sh "${site}")" | tee "$GITHUB_OUTPUT"
+          cd ..
+        done
+
+    - name: Post output to Zulip
+      uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
+      with:
+        api-key: ${{ secrets.ZULIP_API_KEY }}
+        email: 'github-mathlib4-bot@leanprover.zulipchat.com'
+        organization-url: 'https://leanprover.zulipchat.com'
+        to: 'mathlib reviewers'
+        type: 'stream'
+        topic: 'blog and website PRs'
+        content: |
+          ###  Open website PRs
+
+          ${{ steps.tables.outputs.website }}
+
+          ###  Open blog PRs
+
+          ${{ steps.tables.outputs.table }}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -121,7 +121,7 @@ to learn about it as well!
 
 **Blog and website maintenance**
 - `scripts/formatGhPrList.sh` formats the output of `gh pr list` into an `md` table that is
-  the posted weekly to Zulip.
+  then posted weekly to Zulip.
 
 **Mathlib tactics**
 - `polyrith_sage.py`, `polyrith_sage_helper.py` are required for `polyrith`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -119,6 +119,10 @@ to learn about it as well!
   Prints the list of the 10 longest Lean files in `Mathlib`.
   This output is automatically posted to zulip once a week.
 
+**Blog and website maintenance**
+- `scripts/formatGhPrList.sh` formats the output of `gh pr list` into an `md` table that is
+  the posted weekly to Zulip.
+
 **Mathlib tactics**
 - `polyrith_sage.py`, `polyrith_sage_helper.py` are required for `polyrith`
   to communication with the Sage server.

--- a/scripts/formatGhPrList.sh
+++ b/scripts/formatGhPrList.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Running `./formatGhPrList.sh <linkifier>` produces an .md-formatted table
+# of all the issues in the current repository.
+# Assuming that `<linkifier>#NNN` is a valid Zulip linkifier, the PRs will be clickable links.
+
+repo="${1:-linkifier}"
+
+gh pr list |
+  awk -F$'\t' -v link="${repo}#" 'BEGIN{
+    OFS="|"
+    print "", " ID ", " TITLE ", " DATE ", " STATUS ", ""
+    print "", " - ", " - ", " - ", " - ", ""
+  }
+    #(NR == 1){link=""}
+    #(!(NR == 1)){link=lk}
+    # skip the 3rd field, containing the branch name
+    {
+      date=$5
+      gsub(/T.*/, "", date)
+      print "", link $1, $2, date, $4, ""
+    }'


### PR DESCRIPTION
Produces a weekly report of the open PRs to the [website](https://github.com/leanprover-community/leanprover-community.github.io) and the [blog](https://github.com/leanprover-community/blog) and posts it to Zulip.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
