### PR TITLE
[Merged by Bors] - feat: make `reassoc_of%` be able to defer `Category` instance

### DIFF
--- a/Mathlib/Tactic/CategoryTheory/IsoReassoc.lean
+++ b/Mathlib/Tactic/CategoryTheory/IsoReassoc.lean
@@ -25,9 +25,8 @@ open Mathlib.Tactic
 
 namespace CategoryTheory
 
-variable {C : Type*} [Category C]
-
-theorem Iso.eq_whisker {X Y : C} {f g : X ≅ Y} (w : f = g) {Z : C} (h : Y ≅ Z) :
+theorem Iso.eq_whisker {C : Type*} [Category C]
+    {X Y : C} {f g : X ≅ Y} (w : f = g) {Z : C} (h : Y ≅ Z) :
     f ≪≫ h = g ≪≫ h := by rw [w]
 
 /-- Simplify an expression using only the axioms of a groupoid. -/
@@ -42,8 +41,22 @@ Given an equation `f = g` between isomorphisms `X ≅ Y` in a category,
 produce the equation `∀ {Z} (h : Y ≅ Z), f ≪≫ h = g ≪≫ h`,
 but with compositions fully right associated, identities removed, and functors applied.
 -/
-def reassocExprIso (e : Expr) : MetaM Expr := do
-  simpType categoryIsoSimp (← mkAppM ``Iso.eq_whisker #[e])
+def reassocExprIso (e : Expr) : MetaM (Expr × Array MVarId) := do
+  let lem₀ ← mkConstWithFreshMVarLevels ``Iso.eq_whisker
+  let (args, _, _) ← forallMetaBoundedTelescope (← inferType lem₀) 7
+  let inst := args[1]!
+  inst.mvarId!.setKind .synthetic
+  let w := args[6]!
+  let eTy ← inferType e
+  let wTy ← inferType w
+  unless ← isDefEq eTy wTy do
+    throwError "Cannot create reassociation lemma, proof {← mkHasTypeButIsExpectedMsg eTy wTy}"
+  w.mvarId!.assign e
+  -- Ensure the `Category` instance is available to the simp lemmas.
+  withLetDecl `inst (← inst.mvarId!.getType) inst fun inst' => do
+    let pf ← simpType categoryIsoSimp (mkAppN lem₀ args)
+    let pf := (← pf.abstractM #[inst']).instantiate1 inst
+    return (← mkLetFVars #[inst'] pf, #[inst.mvarId!])
 
 initialize registerReassocExpr reassocExprIso
 

--- a/MathlibTest/CategoryTheory/Reassoc.lean
+++ b/MathlibTest/CategoryTheory/Reassoc.lean
@@ -31,6 +31,22 @@ info: Tests.Reassoc.foo_iso_assoc.{v₁, u₁} {C : Type u₁} [Category.{v₁, 
 #guard_msgs in
 #check foo_iso_assoc
 
+/-!
+Test that `reassoc_of% foo` works even though the category is not yet known.
+-/
+example {x y z w : C} (f : x ⟶ y) (g : y ⟶ z) (h' : z ⟶ w) (h : x ⟶ z) (hfg : f ≫ g = h) :
+    f ≫ g ≫ h' = h ≫ h' := by
+  rw [reassoc_of% foo]
+  exact hfg
+
+/-!
+Test that `reassoc_of% foo_iso` works even though the category is not yet known.
+-/
+example {x y z w : C} (f : x ≅ y) (g : y ≅ z) (h' : z ≅ w) (h : x ≅ z) (hfg : f ≪≫ g = h) :
+    f ≪≫ g ≪≫ h' = h ≪≫ h' := by
+  rw [reassoc_of% foo_iso]
+  exact hfg
+
 /-- error: `reassoc` can only be used on terms about equality of (iso)morphisms -/
 #guard_msgs in
 @[reassoc]


### PR DESCRIPTION
This PR modifies the elaboration of `reassoc_of%` so that the `Category` instance can be synthesized later, like any other instance metavariable, rather than needing to be synthesized up front, when the category itself might not yet be known.

This fixes an issue reported by Robert Maxton [on Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/reassoc_of.25.20misleading.20error/near/524678383), where in the following `reassoc_of% Sigma.ι_desc` was failing.
```lean
import Mathlib.CategoryTheory.Limits.Shapes.Products

open CategoryTheory Limits
set_option autoImplicit true

variable {C : Type u} [Category.{v, u} C]
         {β : Type w} {f : β → C} [HasCoproduct f] {P : C}
         (p : (b : β) → f b ⟶ P) (b : β)

example {Q : C} (g : P ⟶ Q) : Sigma.ι f b ≫ Sigma.desc p ≫ g = p b ≫ g := by
  rw [reassoc_of% Sigma.ι_desc]
```
Without this PR, a workaround is writing `reassoc_of% @Sigma.ι_desc`.

The PR adds `Lean.Meta.withEnsuringLocalInstance` for temporarily adding a metavariable as a local instance if it can't yet be synthesized.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
