### PR TITLE
[Merged by Bors] - feat: add algebra shims for Grind.Nat/IntModule

### DIFF
--- a/Mathlib/Algebra/Group/Basic.lean
+++ b/Mathlib/Algebra/Group/Basic.lean
@@ -1062,3 +1062,33 @@ lemma hom_coe_pow {F : Type*} [Monoid F] (c : F → M → M) (h1 : c 1 = id)
     rw [pow_zero, h1]
     rfl
   | n + 1 => by rw [pow_succ, iterate_succ, hmul, hom_coe_pow c h1 hmul f n]
+
+/-!
+# Instances for `grind`.
+-/
+
+open Lean
+
+variable (α : Type*)
+
+instance AddCommMonoid.toGrindNatModule [s : AddCommMonoid α] :
+    Grind.NatModule α :=
+  { s with
+    hMul := s.nsmul
+    zero_hmul := AddMonoid.nsmul_zero
+    one_hmul := one_nsmul
+    add_hmul n m a := add_nsmul a n m
+    hmul_zero := nsmul_zero
+    hmul_add n a b := nsmul_add a b n
+    mul_hmul n m a := mul_nsmul' a n m }
+
+instance AddCommGroup.toGrindIntModule [s : AddCommGroup α] :
+    Grind.IntModule α :=
+  { s with
+    hMul := s.zsmul
+    zero_hmul := SubNegMonoid.zsmul_zero'
+    one_hmul := one_zsmul
+    add_hmul n m a := add_zsmul a n m
+    hmul_zero := zsmul_zero
+    hmul_add n a b := zsmul_add a b n
+    mul_hmul n m a := mul_zsmul a n m }

--- a/Mathlib/Algebra/NoZeroSMulDivisors/Defs.lean
+++ b/Mathlib/Algebra/NoZeroSMulDivisors/Defs.lean
@@ -96,3 +96,8 @@ lemma noZeroSMulDivisors_int_iff_isAddTorsionFree [AddCommGroup G] :
 
 alias ⟨IsAddTorsionFree.of_noZeroSMulDivisors_nat, _⟩ := noZeroSMulDivisors_nat_iff_isAddTorsionFree
 alias ⟨IsAddTorsionFree.of_noZeroSMulDivisors_int, _⟩ := noZeroSMulDivisors_int_iff_isAddTorsionFree
+
+instance [AddCommMonoid M] [NoZeroSMulDivisors ℕ M] : Lean.Grind.NoNatZeroDivisors M where
+  no_nat_zero_divisors n x hn hx := by
+    rw [← smul_eq_zero_iff_right hn]
+    exact hx


### PR DESCRIPTION
This PR adds shims so `grind` will understand Mathlib's `AddCommMonoid` and `AddCommGroup`. (Subsequent shims will connect up the order structures for modules and rings.)