### PR TITLE
[Merged by Bors] - feat: `compute_degree` attempts to solve `f.natDegree < d`

### DIFF
--- a/Mathlib/Tactic/ComputeDegree.lean
+++ b/Mathlib/Tactic/ComputeDegree.lean
@@ -12,7 +12,7 @@ import Mathlib.Algebra.Polynomial.Degree.Lemmas
 
 This file defines two related tactics: `compute_degree` and `monicity`.
 
-Using `compute_degree` when the goal is of one of the five forms
+Using `compute_degree` when the goal is of one of the seven forms
 *  `natDegree f ≤ d` (or `<`),
 *  `degree f ≤ d` (or `<`),
 *  `natDegree f = d`,
@@ -255,7 +255,7 @@ def twoHeadsArgs (e : Expr) : Name × Name × (Name ⊕ Name) × List Bool := Id
 
 /--
 `getCongrLemma (lhs_name, rel_name, Mvars?)` returns the name of a lemma that preprocesses
-one of the five target
+one of the seven target
 *  `natDegree f ≤ d`;
 *  `natDegree f < d`;
 *  `natDegree f = d`.

--- a/Mathlib/Tactic/ComputeDegree.lean
+++ b/Mathlib/Tactic/ComputeDegree.lean
@@ -255,10 +255,10 @@ def twoHeadsArgs (e : Expr) : Name × Name × (Name ⊕ Name) × List Bool := Id
 
 /--
 `getCongrLemma (lhs_name, rel_name, Mvars?)` returns the name of a lemma that preprocesses
-one of the seven target
+one of the seven targets
 *  `natDegree f ≤ d`;
 *  `natDegree f < d`;
-*  `natDegree f = d`.
+*  `natDegree f = d`;
 *  `degree f ≤ d`;
 *  `degree f < d`;
 *  `degree f = d`.

--- a/Mathlib/Tactic/ComputeDegree.lean
+++ b/Mathlib/Tactic/ComputeDegree.lean
@@ -13,8 +13,8 @@ import Mathlib.Algebra.Polynomial.Degree.Lemmas
 This file defines two related tactics: `compute_degree` and `monicity`.
 
 Using `compute_degree` when the goal is of one of the five forms
-*  `natDegree f ≤ d`,
-*  `degree f ≤ d`,
+*  `natDegree f ≤ d` (or `<`),
+*  `degree f ≤ d` (or `<`),
 *  `natDegree f = d`,
 *  `degree f = d`,
 *  `coeff f d = r`, if `d` is the degree of `f`,
@@ -48,6 +48,13 @@ See the doc-strings for more details.
 
 Assume that `f : R[X]` is a polynomial with coefficients in a semiring `R` and
 `d` is either in `ℕ` or in `WithBot ℕ`.
+
+If the goal has the form `natDegree f < d`, then we convert it to two separate goals:
+* `natDegree f ≤ ?_`, on which we apply the following steps;
+* `?_ < d`;
+where `?_` is a metavariable that `compute_degree` computes in its process.
+We proceed similarly for `degree f < d`.
+
 If the goal has the form `natDegree f = d`, then we convert it to three separate goals:
 * `natDegree f ≤ d`;
 * `coeff f d = r`;
@@ -199,18 +206,18 @@ section Tactic
 open Lean Elab Tactic Meta Expr
 
 /-- `twoHeadsArgs e` takes an `Expr`ession `e` as input and recurses into `e` to make sure
-the `e` looks like `lhs ≤ rhs` or `lhs = rhs` and that `lhs` is one of
+that `e` looks like `lhs ≤ rhs`, `lhs < rhs` or `lhs = rhs` and that `lhs` is one of
 `natDegree f, degree f, coeff f d`.
 It returns
 * the function being applied on the LHS (`natDegree`, `degree`, or `coeff`),
-  or else `.anonymous` if it's none of these.
-* the name of the relation (`Eq` or `LE.le`), or else `.anonymous` if it's none of these.
+  or else `.anonymous` if it's none of these;
+* the name of the relation (`Eq`, `LE.le` or `LT.lt`), or else `.anonymous` if it's none of these;
 * either
-  * `.inl zero`, `.inl one`, or `.inl many` if the polynomial in a numeral
-  * or `.inr` of the head symbol of `f`
-  * or `.inl .anonymous` if inapplicable
-* if it exists, whether the `rhs` is a metavariable
-* if the LHS is `coeff f d`, whether `d` is a metavariable
+  * `.inl zero`, `.inl one`, or `.inl many` if the polynomial in a numeral;
+  * or `.inr` of the head symbol of `f`;
+  * or `.inl .anonymous` if inapplicable;
+* if it exists, whether the `rhs` is a metavariable;
+* if the LHS is `coeff f d`, whether `d` is a metavariable.
 
 This is all the data needed to figure out whether `compute_degree` can make progress on `e`
 and, if so, which lemma it should apply.
@@ -224,6 +231,7 @@ def twoHeadsArgs (e : Expr) : Name × Name × (Name ⊕ Name) × List Bool := Id
   let (eq_or_le, lhs, rhs) ← match e.getAppFnArgs with
     | (na@``Eq, #[_, lhs, rhs])       => pure (na, lhs, rhs)
     | (na@``LE.le, #[_, _, lhs, rhs]) => pure (na, lhs, rhs)
+    | (na@``LT.lt, #[_, _, lhs, rhs]) => pure (na, lhs, rhs)
     | _ => return (.anonymous, .anonymous, .inl .anonymous, [])
   let (ndeg_or_deg_or_coeff, pol, and?) ← match lhs.getAppFnArgs with
     | (na@``Polynomial.natDegree, #[_, _, pol])     => (na, pol, [rhs.isMVar])
@@ -249,13 +257,15 @@ def twoHeadsArgs (e : Expr) : Name × Name × (Name ⊕ Name) × List Bool := Id
 `getCongrLemma (lhs_name, rel_name, Mvars?)` returns the name of a lemma that preprocesses
 one of the five target
 *  `natDegree f ≤ d`;
+*  `natDegree f < d`;
 *  `natDegree f = d`.
 *  `degree f ≤ d`;
+*  `degree f < d`;
 *  `degree f = d`.
 *  `coeff f d = r`.
 
 The end goals are of the form
-* `natDegree f ≤ ?_`, `degree f ≤ ?_`, `coeff f ?_ = ?_`, with fresh metavariables;
+* `natDegree f ≤ ?_`, `degree f ≤ ?_`, `coeff f ?_ = ?_`, or `?_ < d` with fresh metavariables;
 * `coeff f m ≠ s` with `m, s` not necessarily metavariables;
 * several equalities/inequalities between expressions and assignments for metavariables.
 
@@ -270,6 +280,7 @@ the congruence lemma that it returns.
 def getCongrLemma (twoH : Name × Name × List Bool) (debug : Bool := false) : Name :=
   let nam := match twoH with
     | (_,           ``LE.le, [rhs]) => if rhs then ``id else ``le_trans
+    | (_,           ``LT.lt, [rhs]) => if rhs then ``id else ``lt_of_le_of_lt
     | (``natDegree, ``Eq, [rhs])    => if rhs then ``id else ``natDegree_eq_of_le_of_coeff_ne_zero'
     | (``degree,    ``Eq, [rhs])    => if rhs then ``id else ``degree_eq_of_le_of_coeff_ne_zero'
     | (``coeff,     ``Eq, [rhs, c]) =>
@@ -433,12 +444,12 @@ def miscomputedDegree? (deg : Expr) : List Expr → List MessageData
 `compute_degree` is a tactic to solve goals of the form
 *  `natDegree f = d`,
 *  `degree f = d`,
-*  `natDegree f ≤ d`,
-*  `degree f ≤ d`,
+*  `natDegree f ≤ d` (or `<`),
+*  `degree f ≤ d` (or `<`),
 *  `coeff f d = r`, if `d` is the degree of `f`.
 
-The tactic may leave goals of the form `d' = d`, `d' ≤ d`, or `r ≠ 0`, where `d'` in `ℕ` or
-`WithBot ℕ` is the tactic's guess of the degree, and `r` is the coefficient's guess of the
+The tactic may leave goals of the form `d' = d`, `d' ≤ d`, `d' < d`, or `r ≠ 0`, where `d'` in `ℕ`
+or `WithBot ℕ` is the tactic's guess of the degree, and `r` is the coefficient's guess of the
 leading coefficient of `f`.
 
 `compute_degree` applies `norm_num` to the left-hand side of all side goals, trying to close them.
@@ -462,7 +473,7 @@ elab_rules : tactic | `(tactic| compute_degree $[!%$bang]?) => focus <| withMain
   let twoH := twoHeadsArgs gt
   match twoH with
     | (_, .anonymous, _) => throwError m!"'compute_degree' inapplicable. \
-        The goal{indentD gt}\nis expected to be '≤' or '='."
+        The goal{indentD gt}\nis expected to be '≤', '<' or '='."
     | (.anonymous, _, _) => throwError m!"'compute_degree' inapplicable. \
         The LHS must be an application of 'natDegree', 'degree', or 'coeff'."
     | _ =>

--- a/MathlibTest/ComputeDegree.lean
+++ b/MathlibTest/ComputeDegree.lean
@@ -79,7 +79,7 @@ example : natDegree (X + X ^ 2 : ℕ[X]) = 0 := by compute_degree!
 /--
 error: 'compute_degree' inapplicable. The goal
   X.natDegree ≠ 0
-is expected to be '≤' or '='.
+is expected to be '≤', '<' or '='.
 -/
 #guard_msgs in
 example : natDegree (X : ℕ[X]) ≠ 0 := by compute_degree!

--- a/MathlibTest/ComputeDegree.lean
+++ b/MathlibTest/ComputeDegree.lean
@@ -243,3 +243,13 @@ variable [CommRing R] [Nontrivial R] in
 example : (X ^ 2 + 2 • X + C 1 : R[X]).natDegree = 2 := by
   compute_degree!
   simp [coeff_X]
+
+example : (C 1 + X * 3 * (X + 3) ^ 4 : Polynomial ℤ).natDegree < 10 := by
+  compute_degree!
+
+example : (C 1 + X * 3 * (X + 3) ^ 4 : Polynomial ℤ).degree < 10 := by
+  compute_degree!
+
+variable [CommRing R] in
+example : (X ^ 2 + 2 • X + C 1 : R[X]).natDegree < 3 := by
+  compute_degree!


### PR DESCRIPTION
Add support for proving goals of the form `f.natDegree < d` and `f.degree < d` in `compute_degree`.

[#mathlib4 > Strange behavior of compute_degree @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Strange.20behavior.20of.20compute_degree/near/524831602)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
