### PR TITLE
[Merged by Bors] - feat: `CanLift` instance from `ConvexCone` to `ProperCone`

### DIFF
--- a/Mathlib/Analysis/Convex/Cone/Basic.lean
+++ b/Mathlib/Analysis/Convex/Cone/Basic.lean
@@ -165,19 +165,19 @@ This section proves topological results about convex cones.
 namespace ConvexCone
 variable {𝕜 E : Type*} [TopologicalSpace 𝕜] [Semifield 𝕜] [LinearOrder 𝕜] [OrderTopology 𝕜]
   [DenselyOrdered 𝕜] [NoMaxOrder 𝕜] [AddCommGroup E] [TopologicalSpace E] [Module 𝕜 E]
-  [ContinuousSMul 𝕜 E] {S : ConvexCone 𝕜 E}
+  [ContinuousSMul 𝕜 E] {C : ConvexCone 𝕜 E}
 
-lemma Pointed.of_nonempty_of_isClosed (hS : (S : Set E).Nonempty) (hSclos : IsClosed (S : Set E)) :
-    S.Pointed := by
-  obtain ⟨x, hx⟩ := hS
+lemma Pointed.of_nonempty_of_isClosed (hC : (C : Set E).Nonempty) (hSclos : IsClosed (C : Set E)) :
+    C.Pointed := by
+  obtain ⟨x, hx⟩ := hC
   let f : 𝕜 → E := (· • x)
-  -- The closure of `f (0, ∞)` is a subset of `K`
-  have hfS : closure (f '' Set.Ioi 0) ⊆ S :=
-    hSclos.closure_subset_iff.2 <| by rintro _ ⟨_, h, rfl⟩; exact S.smul_mem h hx
+  -- The closure of `f (0, ∞)` is a subset of `C`
+  have hfS : closure (f '' Set.Ioi 0) ⊆ C :=
+    hSclos.closure_subset_iff.2 <| by rintro _ ⟨_, h, rfl⟩; exact C.smul_mem h hx
   -- `f` is continuous at `0` from the right
   have fc : ContinuousWithinAt f (Set.Ioi (0 : 𝕜)) 0 :=
     (continuous_id.smul continuous_const).continuousWithinAt
-  -- `0 ∈ closure f (0, ∞) ⊆ K, 0 ∈ K`
+  -- `0 ∈ closure f (0, ∞) ⊆ C, 0 ∈ C`
   simpa [f, Pointed, ← SetLike.mem_coe] using hfS <| fc.mem_closure_image <| by simp
 
 @[deprecated (since := "2025-04-18")]

--- a/Mathlib/Analysis/Convex/Cone/Basic.lean
+++ b/Mathlib/Analysis/Convex/Cone/Basic.lean
@@ -186,7 +186,7 @@ alias pointed_of_nonempty_of_isClosed := Pointed.of_nonempty_of_isClosed
 variable [IsOrderedRing 𝕜]
 
 instance canLift : CanLift (ConvexCone 𝕜 E) (ProperCone 𝕜 E) (↑)
-     fun C ↦ (C : Set E).Nonempty ∧ IsClosed (C : Set E) where
+    fun C ↦ (C : Set E).Nonempty ∧ IsClosed (C : Set E) where
   prf C hC := ⟨⟨C.toPointedCone <| .of_nonempty_of_isClosed hC.1 hC.2, hC.2⟩, rfl⟩
 
 end ConvexCone

--- a/Mathlib/Analysis/Convex/Cone/Basic.lean
+++ b/Mathlib/Analysis/Convex/Cone/Basic.lean
@@ -6,7 +6,7 @@ Authors: Apurva Nakade, Yaël Dillies
 import Mathlib.Analysis.Convex.Cone.Closure
 import Mathlib.Topology.Algebra.Module.ClosedSubmodule
 import Mathlib.Topology.Algebra.Order.Module
-import Mathlib.Topology.Order.OrderClosed
+import Mathlib.Topology.Order.DenselyOrdered
 
 /-!
 # Proper cones
@@ -17,10 +17,17 @@ cone. We then prove Farkas' lemma for conic programs following the proof in the 
 Farkas' lemma is equivalent to strong duality. So, once we have the definitions of conic and
 linear programs, the results from this file can be used to prove duality theorems.
 
+One can turn `C : PointedCone R E` + `hC : IsClosed C` into `C : ProperCone R E` in a tactic block
+by doing `lift C to ProperCone R E using hC`.
+
+One can also turn `C : ConvexCone 𝕜 E` + `hC : Set.Nonempty C ∧ IsClosed C` into
+`C : ProperCone 𝕜 E` in a tactic block by doing `lift C to ProperCone 𝕜 E using hC`,
+assuming `𝕜` is a dense topological field.
+
 ## TODO
 
 The next steps are:
-- Add convex_cone_class that extends set_like and replace the below instance
+- Add `ConvexConeClass` that extends `SetLike` and replace the below instance
 - Define primal and dual cone programs and prove weak duality.
 - Prove regular and strong duality for cone programs using Farkas' lemma (see reference).
 - Define linear programs and prove LP duality as a special case of cone duality.
@@ -148,3 +155,38 @@ def positive : ProperCone R E where
 
 end PositiveCone
 end ProperCone
+
+/-!
+### Topological properties of convex cones
+
+This section proves topological results about convex cones.
+-/
+
+namespace ConvexCone
+variable {𝕜 E : Type*} [TopologicalSpace 𝕜] [Semifield 𝕜] [LinearOrder 𝕜] [OrderTopology 𝕜]
+  [DenselyOrdered 𝕜] [NoMaxOrder 𝕜] [AddCommGroup E] [TopologicalSpace E] [Module 𝕜 E]
+  [ContinuousSMul 𝕜 E] {S : ConvexCone 𝕜 E}
+
+lemma Pointed.of_nonempty_of_isClosed (hS : (S : Set E).Nonempty) (hSclos : IsClosed (S : Set E)) :
+    S.Pointed := by
+  obtain ⟨x, hx⟩ := hS
+  let f : 𝕜 → E := (· • x)
+  -- The closure of `f (0, ∞)` is a subset of `K`
+  have hfS : closure (f '' Set.Ioi 0) ⊆ S :=
+    hSclos.closure_subset_iff.2 <| by rintro _ ⟨_, h, rfl⟩; exact S.smul_mem h hx
+  -- `f` is continuous at `0` from the right
+  have fc : ContinuousWithinAt f (Set.Ioi (0 : 𝕜)) 0 :=
+    (continuous_id.smul continuous_const).continuousWithinAt
+  -- `0 ∈ closure f (0, ∞) ⊆ K, 0 ∈ K`
+  simpa [f, Pointed, ← SetLike.mem_coe] using hfS <| fc.mem_closure_image <| by simp
+
+@[deprecated (since := "2025-04-18")]
+alias pointed_of_nonempty_of_isClosed := Pointed.of_nonempty_of_isClosed
+
+variable [IsOrderedRing 𝕜]
+
+instance canLift : CanLift (ConvexCone 𝕜 E) (ProperCone 𝕜 E) (↑)
+     fun C ↦ (C : Set E).Nonempty ∧ IsClosed (C : Set E) where
+  prf C hC := ⟨⟨C.toPointedCone <| .of_nonempty_of_isClosed hC.1 hC.2, hC.2⟩, rfl⟩
+
+end ConvexCone

--- a/Mathlib/Analysis/Convex/Cone/InnerDual.lean
+++ b/Mathlib/Analysis/Convex/Cone/InnerDual.lean
@@ -176,7 +176,7 @@ theorem ConvexCone.hyperplane_separation_of_nonempty_of_isClosed_of_notMem (K : 
     rwa [add_sub_cancel_right, real_inner_comm, ← neg_nonneg, neg_eq_neg_one_mul,
       ← real_inner_smul_right, neg_smul, one_smul, neg_sub] at hinner
   · -- as `K` is closed and non-empty, it is pointed
-    have hinner₀ := hinner 0 (.of_nonempty_of_isClosed ne hc : K.Pointed)
+    have hinner₀ := hinner 0 (.of_nonempty_of_isClosed (C := K) ne hc)
     -- the rest of the proof is a straightforward calculation
     rw [zero_sub, inner_neg_right, Right.neg_nonpos_iff] at hinner₀
     have hbz : b - z ≠ 0 := by

--- a/Mathlib/Analysis/Convex/Cone/InnerDual.lean
+++ b/Mathlib/Analysis/Convex/Cone/InnerDual.lean
@@ -176,7 +176,7 @@ theorem ConvexCone.hyperplane_separation_of_nonempty_of_isClosed_of_notMem (K : 
     rwa [add_sub_cancel_right, real_inner_comm, ← neg_nonneg, neg_eq_neg_one_mul,
       ← real_inner_smul_right, neg_smul, one_smul, neg_sub] at hinner
   · -- as `K` is closed and non-empty, it is pointed
-    have hinner₀ := hinner 0 (.of_nonempty_of_isClosed (C := K) ne hc)
+    have hinner₀ := hinner 0 (ConvexCone.Pointed.of_nonempty_of_isClosed (C := K) ne hc)
     -- the rest of the proof is a straightforward calculation
     rw [zero_sub, inner_neg_right, Right.neg_nonpos_iff] at hinner₀
     have hbz : b - z ≠ 0 := by

--- a/Mathlib/Analysis/Convex/Cone/InnerDual.lean
+++ b/Mathlib/Analysis/Convex/Cone/InnerDual.lean
@@ -122,25 +122,6 @@ theorem isClosed_innerDualCone : IsClosed (s.innerDualCone : Set H) := by
   rw [h]
   exact isClosed_Ici.preimage (continuous_const.inner continuous_id')
 
-theorem ConvexCone.pointed_of_nonempty_of_isClosed (K : ConvexCone ℝ H) (ne : (K : Set H).Nonempty)
-    (hc : IsClosed (K : Set H)) : K.Pointed := by
-  obtain ⟨x, hx⟩ := ne
-  let f : ℝ → H := (· • x)
-  -- f (0, ∞) is a subset of K
-  have fI : f '' Set.Ioi 0 ⊆ (K : Set H) := by
-    rintro _ ⟨_, h, rfl⟩
-    exact K.smul_mem (Set.mem_Ioi.1 h) hx
-  -- closure of f (0, ∞) is a subset of K
-  have clf : closure (f '' Set.Ioi 0) ⊆ (K : Set H) := hc.closure_subset_iff.2 fI
-  -- f is continuous at 0 from the right
-  have fc : ContinuousWithinAt f (Set.Ioi (0 : ℝ)) 0 :=
-    (continuous_id.smul continuous_const).continuousWithinAt
-  -- 0 belongs to the closure of the f (0, ∞)
-  have mem₀ := fc.mem_closure_image (by rw [closure_Ioi (0 : ℝ), mem_Ici])
-  -- as 0 ∈ closure f (0, ∞) and closure f (0, ∞) ⊆ K, 0 ∈ K.
-  have f₀ : f 0 = 0 := zero_smul ℝ x
-  simpa only [f₀, ConvexCone.Pointed, ← SetLike.mem_coe] using mem_of_subset_of_mem clf mem₀
-
 namespace PointedCone
 
 /-- The inner dual cone of a pointed cone is a pointed cone. -/
@@ -195,7 +176,7 @@ theorem ConvexCone.hyperplane_separation_of_nonempty_of_isClosed_of_notMem (K : 
     rwa [add_sub_cancel_right, real_inner_comm, ← neg_nonneg, neg_eq_neg_one_mul,
       ← real_inner_smul_right, neg_smul, one_smul, neg_sub] at hinner
   · -- as `K` is closed and non-empty, it is pointed
-    have hinner₀ := hinner 0 (K.pointed_of_nonempty_of_isClosed ne hc)
+    have hinner₀ := hinner 0 (.of_nonempty_of_isClosed ne hc : K.Pointed)
     -- the rest of the proof is a straightforward calculation
     rw [zero_sub, inner_neg_right, Right.neg_nonpos_iff] at hinner₀
     have hbz : b - z ≠ 0 := by


### PR DESCRIPTION
For this, move `ConvexCone.pointed_of_nonempty_of_mem` earlier and rename it to `ConvexCone.Pointed.of_nonempty_of_mem`.

From Toric


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
