### PR TITLE
[Merged by Bors] - feat: Add definition of `symmEquiv`

### DIFF
--- a/Mathlib/Algebra/Group/Equiv/Defs.lean
+++ b/Mathlib/Algebra/Group/Equiv/Defs.lean
@@ -441,8 +441,8 @@ end trans
 @[to_additive (attr := simps!)
 "`AddEquiv.symm` defines an equivalence between `α ≃+ β` and `β ≃+ α`"]
 def symmEquiv (P Q : Type*) [Mul P] [Mul Q] : (P ≃* Q) ≃ (Q ≃* P) where
-  toFun := MulEquiv.symm
-  invFun := MulEquiv.symm
+  toFun := .symm
+  invFun := .symm
 
 end Mul
 

--- a/Mathlib/Algebra/Group/Equiv/Defs.lean
+++ b/Mathlib/Algebra/Group/Equiv/Defs.lean
@@ -437,6 +437,12 @@ theorem self_trans_symm (e : M ≃* N) : e.trans e.symm = refl M :=
 
 end trans
 
+/-- `MulEquiv.symm` defines an equivalence between `α ≃* β` and `β ≃* α`. -/
+@[to_additive (attr := simps!)]
+def symmEquiv (P Q : Type*) [Mul P] [Mul Q] : (P ≃* Q) ≃ (Q ≃* P) where
+  toFun := MulEquiv.symm
+  invFun := MulEquiv.symm
+
 end Mul
 
 /-!

--- a/Mathlib/Algebra/Group/Equiv/Defs.lean
+++ b/Mathlib/Algebra/Group/Equiv/Defs.lean
@@ -438,7 +438,8 @@ theorem self_trans_symm (e : M ≃* N) : e.trans e.symm = refl M :=
 end trans
 
 /-- `MulEquiv.symm` defines an equivalence between `α ≃* β` and `β ≃* α`. -/
-@[to_additive (attr := simps!)]
+@[to_additive (attr := simps!)
+"`AddEquiv.symm` defines an equivalence between `α ≃+ β` and `β ≃+ α`"]
 def symmEquiv (P Q : Type*) [Mul P] [Mul Q] : (P ≃* Q) ≃ (Q ≃* P) where
   toFun := MulEquiv.symm
   invFun := MulEquiv.symm

--- a/Mathlib/Algebra/Module/Equiv/Defs.lean
+++ b/Mathlib/Algebra/Module/Equiv/Defs.lean
@@ -318,8 +318,8 @@ notation3:80 (name := transNotation) e₁:80 " ≪≫ₗ " e₂:81 =>
 /-- `LinearEquiv.symm` defines an equivalence between `α ≃ₛₗ[σ] β` and `β ≃ₛₗ[σ] α`. -/
 @[simps!]
 def symmEquiv : (M ≃ₛₗ[σ] M₂) ≃ (M₂ ≃ₛₗ[σ'] M) where
-  toFun := LinearEquiv.symm
-  invFun := LinearEquiv.symm
+  toFun := .symm
+  invFun := .symm
 
 variable {e₁₂} {e₂₃}
 

--- a/Mathlib/Algebra/Module/Equiv/Defs.lean
+++ b/Mathlib/Algebra/Module/Equiv/Defs.lean
@@ -315,6 +315,12 @@ notation3:80 (name := transNotation) e₁:80 " ≪≫ₗ " e₂:81 =>
     RingHomInvPair.ids RingHomInvPair.ids RingHomInvPair.ids RingHomInvPair.ids RingHomInvPair.ids
     RingHomInvPair.ids e₁ e₂
 
+/-- `MulEquiv.symm` defines an equivalence between `α ≃* β` and `β ≃* α`. -/
+@[simps!]
+def symmEquiv : (M ≃ₛₗ[σ] M₂) ≃ (M₂ ≃ₛₗ[σ'] M) where
+  toFun := LinearEquiv.symm
+  invFun := LinearEquiv.symm
+
 variable {e₁₂} {e₂₃}
 
 theorem coe_toAddEquiv : e.toAddEquiv = e :=

--- a/Mathlib/Algebra/Module/Equiv/Defs.lean
+++ b/Mathlib/Algebra/Module/Equiv/Defs.lean
@@ -315,7 +315,7 @@ notation3:80 (name := transNotation) e₁:80 " ≪≫ₗ " e₂:81 =>
     RingHomInvPair.ids RingHomInvPair.ids RingHomInvPair.ids RingHomInvPair.ids RingHomInvPair.ids
     RingHomInvPair.ids e₁ e₂
 
-/-- `MulEquiv.symm` defines an equivalence between `α ≃* β` and `β ≃* α`. -/
+/-- `LinearEquiv.symm` defines an equivalence between `α ≃ₛₗ[σ] β` and `β ≃ₛₗ[σ] α`. -/
 @[simps!]
 def symmEquiv : (M ≃ₛₗ[σ] M₂) ≃ (M₂ ≃ₛₗ[σ'] M) where
   toFun := LinearEquiv.symm

--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -166,8 +166,8 @@ instance : Trans Equiv Equiv Equiv where
 /-- `Equiv.symm` defines an equivalence between `α ≃ β` and `β ≃ α`. -/
 @[simps!]
 def symmEquiv (α β : Sort*) : (α ≃ β) ≃ (β ≃ α) where
-  toFun := Equiv.symm
-  invFun := Equiv.symm
+  toFun := .symm
+  invFun := .symm
 
 @[simp, mfld_simps] theorem toFun_as_coe (e : α ≃ β) : e.toFun = e := rfl
 

--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -163,6 +163,12 @@ protected def trans (e₁ : α ≃ β) (e₂ : β ≃ γ) : α ≃ γ :=
 instance : Trans Equiv Equiv Equiv where
   trans := Equiv.trans
 
+/-- `Equiv.symm` defines an equivalence between `α ≃ β` and `β ≃ α`. -/
+@[simps!]
+def symmEquiv (α β : Sort*) : (α ≃ β) ≃ (β ≃ α) where
+  toFun := Equiv.symm
+  invFun := Equiv.symm
+
 @[simp, mfld_simps] theorem toFun_as_coe (e : α ≃ β) : e.toFun = e := rfl
 
 @[simp, mfld_simps] theorem invFun_as_coe (e : α ≃ β) : e.invFun = e.symm := rfl


### PR DESCRIPTION
Add an equivalence version of `Equiv.symm` and similar operations.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
