### PR TITLE
feat(CategoryTheory/Limits): Fubini for products

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
@@ -844,6 +844,7 @@ section
 variable {ι : Type*} {ι' : ι → Type*} {X : (i : ι) → (ι' i) → C}
   {c : ∀ (i : ι), Fan (X i)} {c' : Fan fun i : ι => (c i).pt} 
 
+/-- The product of products is a product over the sigma type. -/
 def Fan.IsLimit.mkSigma (hc : ∀ i, IsLimit (c i)) (hc' : IsLimit c') :
     IsLimit (Fan.mk c'.pt fun p : (i : ι) × ι' i => c'.proj p.1 ≫ (c p.1).proj p.2) := by
   refine mkFanLimit _ (fun s => ?_) (fun s p => ?_) (fun s m hm => ?_)

--- a/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
@@ -839,4 +839,20 @@ end
 
 end Reindex
 
+section 
+
+variable {ι : Type*} {ι' : ι → Type*} {X : (i : ι) → (ι' i) → C}
+  {c : ∀ (i : ι), Fan (X i)} {c' : Fan fun i : ι => (c i).pt} 
+
+def Fan.IsLimit.mkSigma (hc : ∀ i, IsLimit (c i)) (hc' : IsLimit c') :
+    IsLimit (Fan.mk c'.pt fun p : (i : ι) × ι' i => c'.proj p.1 ≫ (c p.1).proj p.2) := by
+  refine mkFanLimit _ (fun s => ?_) (fun s p => ?_) (fun s m hm => ?_)
+  · refine Fan.IsLimit.desc hc' fun i => ?_
+    exact Fan.IsLimit.desc (hc i) fun j => s.proj ⟨i, j⟩ 
+  · simp 
+  · refine Fan.IsLimit.hom_ext hc' _ _ fun i => ?_
+    refine Fan.IsLimit.hom_ext (hc i) _ _ fun j => by simpa using hm ⟨i, j⟩
+
+end
+
 end CategoryTheory.Limits


### PR DESCRIPTION
We show that the product of products is a product indexed by the sigma type.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
