### PR TITLE
[Merged by Bors] - chore: verify statements listed in 1000.yaml and similar actually exist

### DIFF
--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -796,8 +796,8 @@ Q766722:
 
 Q776578:
   title: Artin–Wedderburn theorem
-  # using proof_wanted, in Mathlib/RingTheory/SimpleModule.lean
-  statement: isSemisimpleRing_iff_pi_matrix_divisionRing
+  # in Mathlib/RingTheory/SimpleModule/Basic.lean
+  comment: "statement is formalized using proof_wanted (isSemisimpleRing_iff_pi_matrix_divisionRing)"
   # WIP formalisation, but not complete yet (January 1, 2025)
 
 Q777924:

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -796,8 +796,8 @@ Q766722:
 
 Q776578:
   title: Artin–Wedderburn theorem
-  # in Mathlib/RingTheory/SimpleModule/Basic.lean
-  comment: "statement is formalized using proof_wanted (isSemisimpleRing_iff_pi_matrix_divisionRing)"
+  # using proof_wanted, in Mathlib/RingTheory/SimpleModule.lean
+  statement: isSemisimpleRing_iff_pi_matrix_divisionRing
   # WIP formalisation, but not complete yet (January 1, 2025)
 
 Q777924:

--- a/scripts/yaml_check.py
+++ b/scripts/yaml_check.py
@@ -170,6 +170,8 @@ for index, entry in thousand.items():
             print(f"For key {index} ({title}): did you mean `decl` instead of `decls`?")
             errors += 1
         thousand_decls = thousand_decls + [(f"{index} {title}", d) for d in entry["decls"]]
+    elif "statement" in entry:
+        thousand_decls.append((f"{index} {title}", entry["statement"]))
 
 overview_decls = tiered_extract(overview)
 assert all(len(n) >= 3 for n, _ in overview_decls), "Expected more nesting"


### PR DESCRIPTION
`yaml_check.py` was not adding entries in `1000.yaml` with only a `statement` field to its `1000.json` output, so they were not being checked by `check-yaml.lean`. This caused an error in the Artin–Wedderburn theorem entry to be missed, which is currently breaking the 1000+ theorems page on the website.

This PR fixes the error in `1000.yaml` and fixes `yaml_check.py`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
