### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Extensive): pullbacks distribute over finite coproducts

### DIFF
--- a/Mathlib/CategoryTheory/EffectiveEpi/Extensive.lean
+++ b/Mathlib/CategoryTheory/EffectiveEpi/Extensive.lean
@@ -25,7 +25,7 @@ theorem effectiveEpi_desc_iff_effectiveEpiFamily {α : Type} [Finite α]
     {B : C} (X : α → C) (π : (a : α) → X a ⟶ B) :
     EffectiveEpi (Sigma.desc π) ↔ EffectiveEpiFamily X π := by
   exact ⟨fun h ↦ ⟨⟨@effectiveEpiFamilyStructOfEffectiveEpiDesc _ _ _ _ X π _ h _ _ (fun g ↦
-    (FinitaryPreExtensive.sigma_desc_iso (fun a ↦ Sigma.ι X a) g inferInstance).epi_of_iso)⟩⟩,
+    (FinitaryPreExtensive.isIso_sigmaDesc_fst (fun a ↦ Sigma.ι X a) g inferInstance).epi_of_iso)⟩⟩,
     fun _ ↦ inferInstance⟩
 
 variable {D : Type*} [Category D] [FinitaryPreExtensive D]

--- a/Mathlib/CategoryTheory/Extensive.lean
+++ b/Mathlib/CategoryTheory/Extensive.lean
@@ -528,23 +528,40 @@ instance FinitaryPreExtensive.hasPullbacks_of_inclusions [FinitaryPreExtensive C
   apply FinitaryPreExtensive.hasPullbacks_of_is_coproduct (c := Cofan.mk Z i)
   exact @IsColimit.ofPointIso (t := Cofan.mk Z i) (P := _) (i := hi)
 
-lemma FinitaryPreExtensive.sigma_desc_iso [FinitaryPreExtensive C] {α : Type} [Finite α] {X : C}
-    {Z : α → C} (π : (a : α) → Z a ⟶ X) {Y : C} (f : Y ⟶ X) (hπ : IsIso (Sigma.desc π)) :
+lemma FinitaryPreExtensive.isIso_sigmaDesc_fst [FinitaryPreExtensive C] {α : Type} [Finite α]
+    {X : C} {Z : α → C} (π : (a : α) → Z a ⟶ X) {Y : C} (f : Y ⟶ X) (hπ : IsIso (Sigma.desc π)) :
     IsIso (Sigma.desc ((fun _ ↦ pullback.fst _ _) : (a : α) → pullback f (π a) ⟶ _)) := by
-  suffices IsColimit (Cofan.mk _ ((fun _ ↦ pullback.fst _ _) : (a : α) → pullback f (π a) ⟶ _)) by
-    change IsIso (this.coconePointUniqueUpToIso (getColimitCocone _).2).inv
-    infer_instance
-  let this : IsColimit (Cofan.mk X π) := by
-    refine @IsColimit.ofPointIso (t := Cofan.mk X π) (P := coproductIsCoproduct Z) (i := ?_)
-    convert hπ
-    simp [coproductIsCoproduct]
-  refine (FinitaryPreExtensive.isUniversal_finiteCoproducts this
-    (Cofan.mk _ ((fun _ ↦ pullback.fst _ _) : (a : α) → pullback f (π a) ⟶ _))
-    (Discrete.natTrans fun i ↦ pullback.snd _ _) f ?_
-    (NatTrans.equifibered_of_discrete _) ?_).some
-  · ext
-    simp [pullback.condition]
-  · exact fun j ↦ IsPullback.of_hasPullback f (π j.as)
+  let c := (Cofan.mk _ ((fun _ ↦ pullback.fst _ _) : (a : α) → pullback f (π a) ⟶ _))
+  apply c.isColimit_iff_isIso_sigmaDesc.mpr
+  have hau : IsUniversalColimit (Cofan.mk X π) := FinitaryPreExtensive.isUniversal_finiteCoproducts
+    ((Cofan.isColimit_iff_isIso_sigmaDesc _).mp hπ).some
+  refine hau.nonempty_isColimit_of_pullbackCone_left _ (𝟙 _) _ _ (fun i ↦ ?_)
+    (PullbackCone.mk (𝟙 _) f (by simp)) (IsPullback.id_horiz f).isLimit _ (Iso.refl _)
+    (by simp) (by simp [c]) (by simp [pullback.condition, c])
+  exact pullback.isLimit _ _
+
+@[deprecated (since := "2025-06-20")]
+alias FinitaryPreExtensive.sigma_desc_iso := FinitaryPreExtensive.isIso_sigmaDesc_fst
+
+/-- If `C` has pullbacks and is finitary (pre-)extensive, pullbacks distribute over finite
+coproducts, i.e., `∐ (Xᵢ ×[S] Xⱼ) ≅ (∐ Xᵢ) ×[S] (∐ Xⱼ)`. -/
+instance FinitaryPreExtensive.isIso_sigmaDesc_map [HasPullbacks C] [FinitaryPreExtensive C]
+    {ι ι' : Type*} [Finite ι] [Finite ι'] {S : C} {X : ι → C} {Y : ι' → C}
+    (f : ∀ i, X i ⟶ S) (g : ∀ i, Y i ⟶ S) :
+    IsIso (Sigma.desc fun (p : ι × ι') ↦
+      pullback.map (f p.1) (g p.2) (Sigma.desc f) (Sigma.desc g) (Sigma.ι _ p.1)
+        (Sigma.ι _ p.2) (𝟙 S) (by simp) (by simp)) := by
+  let c : Cofan _ := Cofan.mk _ <| fun (p : ι × ι') ↦
+      pullback.map (f p.1) (g p.2) (Sigma.desc f) (Sigma.desc g) (Sigma.ι _ p.1)
+        (Sigma.ι _ p.2) (𝟙 S) (by simp) (by simp)
+  apply c.isColimit_iff_isIso_sigmaDesc.mpr
+  refine IsUniversalColimit.nonempty_isColimit_prod_of_pullbackCone
+      (a := Cofan.mk _ <| fun i ↦ Sigma.ι _ i) (b := Cofan.mk _ <| fun i ↦ Sigma.ι _ i)
+      ?_ ?_ f g (Sigma.desc f) (Sigma.desc g) (fun i j ↦ (pullback.cone (f i) (g j)))
+      (fun i j ↦ pullback.isLimit (f i) (g j)) (pullback.cone _ _) ?_ (Iso.refl _)
+  · exact FinitaryPreExtensive.isUniversal_finiteCoproducts (coproductIsCoproduct X)
+  · exact FinitaryPreExtensive.isUniversal_finiteCoproducts (coproductIsCoproduct Y)
+  · exact pullback.isLimit (Sigma.desc f) (Sigma.desc g)
 
 end FiniteCoproducts
 

--- a/Mathlib/CategoryTheory/Extensive.lean
+++ b/Mathlib/CategoryTheory/Extensive.lean
@@ -544,7 +544,8 @@ lemma FinitaryPreExtensive.isIso_sigmaDesc_fst [FinitaryPreExtensive C] {α : Ty
 alias FinitaryPreExtensive.sigma_desc_iso := FinitaryPreExtensive.isIso_sigmaDesc_fst
 
 /-- If `C` has pullbacks and is finitary (pre-)extensive, pullbacks distribute over finite
-coproducts, i.e., `∐ (Xᵢ ×[S] Xⱼ) ≅ (∐ Xᵢ) ×[S] (∐ Xⱼ)`. -/
+coproducts, i.e., `∐ (Xᵢ ×[S] Xⱼ) ≅ (∐ Xᵢ) ×[S] (∐ Xⱼ)`.
+For an `IsPullback` version, see `FinitaryPreExtensive.isPullback_sigmaDesc`. -/
 instance FinitaryPreExtensive.isIso_sigmaDesc_map [HasPullbacks C] [FinitaryPreExtensive C]
     {ι ι' : Type*} [Finite ι] [Finite ι'] {S : C} {X : ι → C} {Y : ι' → C}
     (f : ∀ i, X i ⟶ S) (g : ∀ i, Y i ⟶ S) :
@@ -562,6 +563,31 @@ instance FinitaryPreExtensive.isIso_sigmaDesc_map [HasPullbacks C] [FinitaryPreE
   · exact FinitaryPreExtensive.isUniversal_finiteCoproducts (coproductIsCoproduct X)
   · exact FinitaryPreExtensive.isUniversal_finiteCoproducts (coproductIsCoproduct Y)
   · exact pullback.isLimit (Sigma.desc f) (Sigma.desc g)
+
+/-- If `C` has pullbacks and is finitary (pre-)extensive, pullbacks distribute over finite
+coproducts, i.e., `∐ (Xᵢ ×[S] Xⱼ) ≅ (∐ Xᵢ) ×[S] (∐ Xⱼ)`.
+For a variant, see `FinitaryPreExtensive.isIso_sigmaDesc_map`. -/
+instance FinitaryPreExtensive.isPullback_sigmaι [HasPullbacks C] [FinitaryPreExtensive C]
+    {ι ι' : Type*} [Finite ι] [Finite ι'] {S : C} {X : ι → C} {Y : ι' → C}
+    (f : ∀ i, X i ⟶ S) (g : ∀ i, Y i ⟶ S) :
+    IsPullback
+      (Limits.Sigma.desc fun (p : ι × ι') ↦ pullback.fst (f p.1) (g p.2) ≫ Sigma.ι X p.1)
+      (Limits.Sigma.desc fun (p : ι × ι') ↦ pullback.snd (f p.1) (g p.2) ≫ Sigma.ι Y p.2)
+      (Limits.Sigma.desc f) (Limits.Sigma.desc g) := by
+  let c : Cofan _ := Cofan.mk _ <| fun (p : ι × ι') ↦
+      pullback.map (f p.1) (g p.2) (Sigma.desc f) (Sigma.desc g) (Sigma.ι _ p.1)
+        (Sigma.ι _ p.2) (𝟙 S) (by simp) (by simp)
+  convert IsUniversalColimit.isPullback_prod_of_isColimit
+      (d := Cofan.mk _ (Sigma.ι fun (p : ι × ι') ↦ pullback (f p.1) (g p.2)))
+      (hd := coproductIsCoproduct (fun (p : ι × ι') ↦ pullback (f p.1) (g p.2)))
+      (a := Cofan.mk _ <| fun i ↦ Sigma.ι _ i) (b := Cofan.mk _ <| fun i ↦ Sigma.ι _ i)
+      ?_ ?_ f g (Sigma.desc f) (Sigma.desc g) (fun i j ↦ IsPullback.of_hasPullback (f i) (g j))
+  · ext
+    simp [Cofan.IsColimit.desc, Sigma.ι, coproductIsCoproduct]
+  · ext
+    simp [Cofan.IsColimit.desc, Sigma.ι, coproductIsCoproduct]
+  · exact FinitaryPreExtensive.isUniversal_finiteCoproducts (coproductIsCoproduct X)
+  · exact FinitaryPreExtensive.isUniversal_finiteCoproducts (coproductIsCoproduct Y)
 
 end FiniteCoproducts
 

--- a/Mathlib/CategoryTheory/Extensive.lean
+++ b/Mathlib/CategoryTheory/Extensive.lean
@@ -567,7 +567,7 @@ instance FinitaryPreExtensive.isIso_sigmaDesc_map [HasPullbacks C] [FinitaryPreE
 /-- If `C` has pullbacks and is finitary (pre-)extensive, pullbacks distribute over finite
 coproducts, i.e., `∐ (Xᵢ ×[S] Xⱼ) ≅ (∐ Xᵢ) ×[S] (∐ Xⱼ)`.
 For a variant, see `FinitaryPreExtensive.isIso_sigmaDesc_map`. -/
-instance FinitaryPreExtensive.isPullback_sigmaι [HasPullbacks C] [FinitaryPreExtensive C]
+lemma FinitaryPreExtensive.isPullback_sigmaDesc [HasPullbacks C] [FinitaryPreExtensive C]
     {ι ι' : Type*} [Finite ι] [Finite ι'] {S : C} {X : ι → C} {Y : ι' → C}
     (f : ∀ i, X i ⟶ S) (g : ∀ i, Y i ⟶ S) :
     IsPullback

--- a/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
@@ -828,4 +828,30 @@ end
 
 end Reindex
 
+section Fubini
+
+variable {ι ι' : Type*} {X : ι → ι' → C}
+
+/-- A product over products is a product indexed by a product. -/
+def Fan.IsLimit.prod (c : ∀ i : ι, Fan (fun j : ι' ↦ X i j)) (hc : ∀ i : ι, IsLimit (c i))
+    (c' : Fan (fun i : ι ↦ (c i).pt)) (hc' : IsLimit c') :
+    (IsLimit <| Fan.mk c'.pt fun p : ι × ι' ↦ c'.proj _ ≫ (c p.1).proj p.2) := by
+  refine mkFanLimit _ (fun t ↦ ?_) ?_ fun t m hm ↦ ?_
+  · exact Fan.IsLimit.desc hc' fun i ↦ Fan.IsLimit.desc (hc i) fun j ↦ t.proj (i, j)
+  · simp
+  · refine Fan.IsLimit.hom_ext hc' _ _ fun i ↦ ?_
+    exact Fan.IsLimit.hom_ext (hc i) _ _ fun j ↦ (by simpa using hm (i, j))
+
+/-- A coproduct over coproducts is a coproduct indexed by a product. -/
+def Cofan.IsColimit.prod (c : ∀ i : ι, Cofan (fun j : ι' ↦ X i j)) (hc : ∀ i : ι, IsColimit (c i))
+    (c' : Cofan (fun i : ι ↦ (c i).pt)) (hc' : IsColimit c') :
+    (IsColimit <| Cofan.mk c'.pt fun p : ι × ι' ↦ (c p.1).inj p.2 ≫ c'.inj _) := by
+  refine mkCofanColimit _ (fun t ↦ ?_) ?_ fun t m hm ↦ ?_
+  · exact Cofan.IsColimit.desc hc' fun i ↦ Cofan.IsColimit.desc (hc i) fun j ↦ t.inj (i, j)
+  · simp
+  · refine Cofan.IsColimit.hom_ext hc' _ _ fun i ↦ ?_
+    exact Cofan.IsColimit.hom_ext (hc i) _ _ fun j ↦ (by simpa using hm (i, j))
+
+end Fubini
+
 end CategoryTheory.Limits

--- a/Mathlib/CategoryTheory/Limits/VanKampen.lean
+++ b/Mathlib/CategoryTheory/Limits/VanKampen.lean
@@ -794,12 +794,15 @@ lemma IsUniversalColimit.nonempty_isColimit_of_pullbackCone_left
     refine IsPullback.of_right ?_ (by simp [he₂]) (IsPullback.of_isLimit ht)
     simpa [hu] using (IsPullback.of_isLimit (hs j.1))
 
-include hau in
+section
+
+variable {P : ι → C} (q₁ : ∀ i, P i ⟶ B) (q₂ : ∀ i, P i ⟶ X i)
+  (hP : ∀ i, IsPullback (q₁ i) (q₂ i) v (f i))
+
+include hau hP in
 /-- Pullbacks distribute over universal coproducts on the left: This is the isomorphism
 `∐ (B ×[S] Xᵢ) ≅ B ×[S] (∐ Xᵢ)`. -/
 lemma IsUniversalColimit.nonempty_isColimit_of_isPullback_left
-    {P : ι → C} (q₁ : ∀ i, P i ⟶ B) (q₂ : ∀ i, P i ⟶ X i)
-    (hP : ∀ i, IsPullback (q₁ i) (q₂ i) v (f i))
     {Z : C} {p₁ : Z ⟶ B} {p₂ : Z ⟶ a.pt} (h : IsPullback p₁ p₂ v u)
     (d : Cofan P) (e : d.pt ≅ Z)
     (hu : ∀ i, a.inj i ≫ u = f i := by aesop_cat)
@@ -808,6 +811,28 @@ lemma IsUniversalColimit.nonempty_isColimit_of_isPullback_left
     Nonempty (IsColimit d) :=
   hau.nonempty_isColimit_of_pullbackCone_left f u v (fun i ↦ (hP i).cone)
     (fun i ↦ (hP i).isLimit) h.cone h.isLimit d e
+
+include hau hP in
+/-- Pullbacks distribute over universal coproducts on the left: This is the isomorphism
+`∐ (B ×[S] Xᵢ) ≅ B ×[S] (∐ Xᵢ)`. -/
+lemma IsUniversalColimit.isPullback_of_isColimit_left {d : Cofan P} (hd : IsColimit d)
+    (hu : ∀ i, a.inj i ≫ u = f i := by aesop_cat)
+    [HasPullback v u] :
+    IsPullback (Cofan.IsColimit.desc hd q₁) (Cofan.IsColimit.desc hd (q₂ · ≫ a.inj _))
+      v u := by
+  let c : Cofan P := Cofan.mk (pullback v u)
+    fun i ↦ pullback.lift (q₁ i) (q₂ i ≫ a.inj i) (by simp [(hP i).w, hu])
+  obtain ⟨hc⟩ := hau.nonempty_isColimit_of_isPullback_left f u
+    v q₁ q₂ hP (IsPullback.of_hasPullback _ _) c (Iso.refl _)
+  refine (IsPullback.of_hasPullback v u).of_iso
+      ?_ (Iso.refl _) (Iso.refl _) (Iso.refl _) ?_ ?_ (by simp) (by simp)
+  · exact hc.coconePointUniqueUpToIso hd
+  · refine Cofan.IsColimit.hom_ext hc _ _ fun i ↦ ?_
+    simpa [Cofan.inj, Cofan.IsColimit.desc] using pullback.lift_fst _ _ _
+  · refine Cofan.IsColimit.hom_ext hc _ _ fun i ↦ ?_
+    simpa [Cofan.inj, Cofan.IsColimit.desc] using pullback.lift_snd _ _ _
+
+end
 
 include hau in
 /-- Pullbacks distribute over universal coproducts on the right: This is the isomorphism
@@ -832,12 +857,15 @@ lemma IsUniversalColimit.nonempty_isColimit_of_pullbackCone_right
     refine IsPullback.of_right ?_ (by simp) (IsPullback.of_isLimit ht).flip
     simpa [hu] using (IsPullback.of_isLimit (hs j.1)).flip
 
-include hau in
+section
+
+variable {P : ι → C} (q₁ : ∀ i, P i ⟶ X i) (q₂ : ∀ i, P i ⟶ B)
+  (hP : ∀ i, IsPullback (q₁ i) (q₂ i) (f i) v)
+
+include hau hP in
 /-- Pullbacks distribute over universal coproducts on the right: This is the isomorphism
 `∐ (Xᵢ ×[S] B) ≅ (∐ Xᵢ) ×[S] B`. -/
 lemma IsUniversalColimit.nonempty_isColimit_of_isPullback_right
-    {P : ι → C} (q₁ : ∀ i, P i ⟶ X i) (q₂ : ∀ i, P i ⟶ B)
-    (hP : ∀ i, IsPullback (q₁ i) (q₂ i) (f i) v)
     {Z : C} {p₁ : Z ⟶ a.pt} {p₂ : Z ⟶ B} (h : IsPullback p₁ p₂ u v)
     (d : Cofan P) (e : d.pt ≅ Z)
     (hu : ∀ i, a.inj i ≫ u = f i := by aesop_cat)
@@ -847,12 +875,36 @@ lemma IsUniversalColimit.nonempty_isColimit_of_isPullback_right
   hau.nonempty_isColimit_of_pullbackCone_right f u v (fun i ↦ (hP i).cone)
     (fun i ↦ (hP i).isLimit) h.cone h.isLimit d e
 
+include hau hP in
+/-- Pullbacks distribute over universal coproducts on the right: This is the isomorphism
+`∐ (Xᵢ ×[S] B) ≅ (∐ Xᵢ) ×[S] B`. -/
+lemma IsUniversalColimit.isPullback_of_isColimit_right {d : Cofan P} (hd : IsColimit d)
+    (hu : ∀ i, a.inj i ≫ u = f i := by aesop_cat)
+    [HasPullback u v] :
+    IsPullback (Cofan.IsColimit.desc hd (q₁ · ≫ a.inj _)) (Cofan.IsColimit.desc hd q₂)
+      u v := by
+  let c : Cofan P := Cofan.mk (pullback u v)
+    fun i ↦ pullback.lift (q₁ i ≫ a.inj i) (q₂ i) (by simp [(hP i).w, hu])
+  obtain ⟨hc⟩ := hau.nonempty_isColimit_of_isPullback_right f u
+    v q₁ q₂ hP (IsPullback.of_hasPullback _ _) c (Iso.refl _)
+  refine (IsPullback.of_hasPullback u v).of_iso
+      ?_ (Iso.refl _) (Iso.refl _) (Iso.refl _) ?_ ?_ (by simp) (by simp)
+  · exact hc.coconePointUniqueUpToIso hd
+  · refine Cofan.IsColimit.hom_ext hc _ _ fun i ↦ ?_
+    simpa [Cofan.inj, Cofan.IsColimit.desc] using pullback.lift_fst _ _ _
+  · refine Cofan.IsColimit.hom_ext hc _ _ fun i ↦ ?_
+    simpa [Cofan.inj, Cofan.IsColimit.desc] using pullback.lift_snd _ _ _
+
+end
+
+variable {Y : ι' → C} {b : Cofan Y} (hbu : IsUniversalColimit b)
+  (f : ∀ i, X i ⟶ S) (g : ∀ i, Y i ⟶ S) (u : a.pt ⟶ S) (v : b.pt ⟶ S)
+  [∀ i, HasPullback (f i) v]
+
+include hau hbu in
 /-- Pullbacks distribute over universal coproducts in both arguments: This is the isomorphism
 `∐ (Xᵢ ×[S] Xⱼ) ≅ (∐ Xᵢ) ×[S] (∐ Xⱼ)`. -/
-lemma IsUniversalColimit.nonempty_isColimit_prod_of_pullbackCone {X : ι → C}
-    {Y : ι' → C} {a : Cofan X} (hau : IsUniversalColimit a)
-    {b : Cofan Y} (hbu : IsUniversalColimit b)
-    (f : ∀ i, X i ⟶ S) (g : ∀ i, Y i ⟶ S) (u : a.pt ⟶ S) (v : b.pt ⟶ S) [∀ i, HasPullback (f i) v]
+lemma IsUniversalColimit.nonempty_isColimit_prod_of_pullbackCone
     (s : ∀ (i : ι) (j : ι'), PullbackCone (f i) (g j))
     (hs : ∀ i j, IsLimit (s i j)) (t : PullbackCone u v) (ht : IsLimit t)
     {d : Cofan (fun p : ι × ι' ↦ (s p.1 p.2).pt)} (e : d.pt ≅ t.pt)
@@ -879,12 +931,10 @@ lemma IsUniversalColimit.nonempty_isColimit_prod_of_pullbackCone {X : ι → C}
   · exact hau.nonempty_isColimit_of_pullbackCone_right _ u _ _ (fun _ ↦ pullback.isLimit _ _)
       t ht _ (Iso.refl _)
 
+include hau hbu in
 /-- Pullbacks distribute over universal coproducts in both arguments: This is the isomorphism
 `∐ (Xᵢ ×[S] Xⱼ) ≅ (∐ Xᵢ) ×[S] (∐ Xⱼ)`. -/
-lemma IsUniversalColimit.nonempty_isColimit_prod_of_isPullback {X : ι → C}
-    {Y : ι' → C} {a : Cofan X} (hau : IsUniversalColimit a)
-    {b : Cofan Y} (hbu : IsUniversalColimit b)
-    (f : ∀ i, X i ⟶ S) (g : ∀ i, Y i ⟶ S) (u : a.pt ⟶ S) (v : b.pt ⟶ S) [∀ i, HasPullback (f i) v]
+lemma IsUniversalColimit.nonempty_isColimit_prod_of_isPullback
     {P : ι × ι' → C} {q₁ : ∀ i j, P (i, j) ⟶ X i} {q₂ : ∀ i j, P (i, j) ⟶ Y j}
     (hP : ∀ i j, IsPullback (q₁ i j) (q₂ i j) (f i) (g j))
     {Z : C} {p₁ : Z ⟶ a.pt} {p₂ : Z ⟶ b.pt} (h : IsPullback p₁ p₂ u v)
@@ -896,6 +946,28 @@ lemma IsUniversalColimit.nonempty_isColimit_prod_of_isPullback {X : ι → C}
     Nonempty (IsColimit d) :=
   IsUniversalColimit.nonempty_isColimit_prod_of_pullbackCone hau hbu f g u v
     (fun i j ↦ (hP i j).cone) (fun i j ↦ (hP i j).isLimit) h.cone h.isLimit e
+
+include hau hbu in
+lemma IsUniversalColimit.isPullback_prod_of_isColimit [HasPullback u v]
+    {P : ι × ι' → C} {q₁ : ∀ i j, P (i, j) ⟶ X i} {q₂ : ∀ i j, P (i, j) ⟶ Y j}
+    (hP : ∀ i j, IsPullback (q₁ i j) (q₂ i j) (f i) (g j)) (d : Cofan P) (hd : IsColimit d)
+    (hu : ∀ i, a.inj i ≫ u = f i := by aesop_cat)
+    (hv : ∀ i, b.inj i ≫ v = g i := by aesop_cat) :
+    IsPullback
+      (Cofan.IsColimit.desc hd (fun p ↦ q₁ p.1 p.2 ≫ a.inj _))
+      (Cofan.IsColimit.desc hd (fun p ↦ q₂ p.1 p.2 ≫ b.inj _)) u v := by
+  let c : Cofan P := Cofan.mk (pullback u v)
+    fun p ↦ pullback.lift (q₁ p.1 p.2 ≫ a.inj p.1) (q₂ p.1 p.2 ≫ b.inj _)
+      (by simp [(hP p.1 p.2).w, hu, hv])
+  obtain ⟨hc⟩ := hau.nonempty_isColimit_prod_of_isPullback hbu f g u
+    v hP (IsPullback.of_hasPullback _ _) (d := c) (Iso.refl _)
+  refine (IsPullback.of_hasPullback u v).of_iso
+      ?_ (Iso.refl _) (Iso.refl _) (Iso.refl _) ?_ ?_ (by simp) (by simp)
+  · exact hc.coconePointUniqueUpToIso hd
+  · refine Cofan.IsColimit.hom_ext hc _ _ fun i ↦ ?_
+    simpa [Cofan.inj, Cofan.IsColimit.desc] using pullback.lift_fst _ _ _
+  · refine Cofan.IsColimit.hom_ext hc _ _ fun i ↦ ?_
+    simpa [Cofan.inj, Cofan.IsColimit.desc] using pullback.lift_snd _ _ _
 
 end CoproductsPullback
 

--- a/Mathlib/CategoryTheory/Limits/VanKampen.lean
+++ b/Mathlib/CategoryTheory/Limits/VanKampen.lean
@@ -795,6 +795,21 @@ lemma IsUniversalColimit.nonempty_isColimit_of_pullbackCone_left
     simpa [hu] using (IsPullback.of_isLimit (hs j.1))
 
 include hau in
+/-- Pullbacks distribute over universal coproducts on the left: This is the isomorphism
+`∐ (B ×[S] Xᵢ) ≅ B ×[S] (∐ Xᵢ)`. -/
+lemma IsUniversalColimit.nonempty_isColimit_of_isPullback_left
+    {P : ι → C} (q₁ : ∀ i, P i ⟶ B) (q₂ : ∀ i, P i ⟶ X i)
+    (hP : ∀ i, IsPullback (q₁ i) (q₂ i) v (f i))
+    {Z : C} {p₁ : Z ⟶ B} {p₂ : Z ⟶ a.pt} (h : IsPullback p₁ p₂ v u)
+    (d : Cofan P) (e : d.pt ≅ Z)
+    (hu : ∀ i, a.inj i ≫ u = f i := by aesop_cat)
+    (he₁ : ∀ i, d.inj i ≫ e.hom ≫ p₁ = q₁ i := by aesop_cat)
+    (he₂ : ∀ i, d.inj i ≫ e.hom ≫ p₂ = q₂ i ≫ a.inj i := by aesop_cat) :
+    Nonempty (IsColimit d) :=
+  hau.nonempty_isColimit_of_pullbackCone_left f u v (fun i ↦ (hP i).cone)
+    (fun i ↦ (hP i).isLimit) h.cone h.isLimit d e
+
+include hau in
 /-- Pullbacks distribute over universal coproducts on the right: This is the isomorphism
 `∐ (Xᵢ ×[S] B) ≅ (∐ Xᵢ) ×[S] B`. -/
 lemma IsUniversalColimit.nonempty_isColimit_of_pullbackCone_right
@@ -817,6 +832,21 @@ lemma IsUniversalColimit.nonempty_isColimit_of_pullbackCone_right
     refine IsPullback.of_right ?_ (by simp) (IsPullback.of_isLimit ht).flip
     simpa [hu] using (IsPullback.of_isLimit (hs j.1)).flip
 
+include hau in
+/-- Pullbacks distribute over universal coproducts on the right: This is the isomorphism
+`∐ (Xᵢ ×[S] B) ≅ (∐ Xᵢ) ×[S] B`. -/
+lemma IsUniversalColimit.nonempty_isColimit_of_isPullback_right
+    {P : ι → C} (q₁ : ∀ i, P i ⟶ X i) (q₂ : ∀ i, P i ⟶ B)
+    (hP : ∀ i, IsPullback (q₁ i) (q₂ i) (f i) v)
+    {Z : C} {p₁ : Z ⟶ a.pt} {p₂ : Z ⟶ B} (h : IsPullback p₁ p₂ u v)
+    (d : Cofan P) (e : d.pt ≅ Z)
+    (hu : ∀ i, a.inj i ≫ u = f i := by aesop_cat)
+    (he₁ : ∀ i, d.inj i ≫ e.hom ≫ p₁ = q₁ i ≫ a.inj i := by aesop_cat)
+    (he₂ : ∀ i, d.inj i ≫ e.hom ≫ p₂ = q₂ i := by aesop_cat) :
+    Nonempty (IsColimit d) :=
+  hau.nonempty_isColimit_of_pullbackCone_right f u v (fun i ↦ (hP i).cone)
+    (fun i ↦ (hP i).isLimit) h.cone h.isLimit d e
+
 /-- Pullbacks distribute over universal coproducts in both arguments: This is the isomorphism
 `∐ (Xᵢ ×[S] Xⱼ) ≅ (∐ Xᵢ) ×[S] (∐ Xⱼ)`. -/
 lemma IsUniversalColimit.nonempty_isColimit_prod_of_pullbackCone {X : ι → C}
@@ -828,8 +858,8 @@ lemma IsUniversalColimit.nonempty_isColimit_prod_of_pullbackCone {X : ι → C}
     {d : Cofan (fun p : ι × ι' ↦ (s p.1 p.2).pt)} (e : d.pt ≅ t.pt)
     (hu : ∀ i, a.inj i ≫ u = f i := by aesop_cat)
     (hv : ∀ i, b.inj i ≫ v = g i := by aesop_cat)
-    (he₁ : ∀ p, d.inj p ≫ e.hom ≫ t.fst = (s _ _).fst ≫ a.inj _ := by aesop_cat)
-    (he₂ : ∀ p, d.inj p ≫ e.hom ≫ t.snd = (s _ _).snd ≫ b.inj _ := by aesop_cat) :
+    (he₁ : ∀ i j, d.inj (i, j) ≫ e.hom ≫ t.fst = (s _ _).fst ≫ a.inj _ := by aesop_cat)
+    (he₂ : ∀ i j, d.inj (i, j) ≫ e.hom ≫ t.snd = (s _ _).snd ≫ b.inj _ := by aesop_cat) :
     Nonempty (IsColimit d) := by
   let c (i : ι) : Cofan (fun j : ι' ↦ (s i j).pt) :=
     Cofan.mk (pullback (f i) v) fun j ↦ pullback.lift (s i j).fst ((s i j).snd ≫ b.inj j)
@@ -848,6 +878,24 @@ lemma IsUniversalColimit.nonempty_isColimit_prod_of_pullbackCone {X : ι → C}
       (pullback.isLimit _ _) _ (Iso.refl _)
   · exact hau.nonempty_isColimit_of_pullbackCone_right _ u _ _ (fun _ ↦ pullback.isLimit _ _)
       t ht _ (Iso.refl _)
+
+/-- Pullbacks distribute over universal coproducts in both arguments: This is the isomorphism
+`∐ (Xᵢ ×[S] Xⱼ) ≅ (∐ Xᵢ) ×[S] (∐ Xⱼ)`. -/
+lemma IsUniversalColimit.nonempty_isColimit_prod_of_isPullback {X : ι → C}
+    {Y : ι' → C} {a : Cofan X} (hau : IsUniversalColimit a)
+    {b : Cofan Y} (hbu : IsUniversalColimit b)
+    (f : ∀ i, X i ⟶ S) (g : ∀ i, Y i ⟶ S) (u : a.pt ⟶ S) (v : b.pt ⟶ S) [∀ i, HasPullback (f i) v]
+    {P : ι × ι' → C} {q₁ : ∀ i j, P (i, j) ⟶ X i} {q₂ : ∀ i j, P (i, j) ⟶ Y j}
+    (hP : ∀ i j, IsPullback (q₁ i j) (q₂ i j) (f i) (g j))
+    {Z : C} {p₁ : Z ⟶ a.pt} {p₂ : Z ⟶ b.pt} (h : IsPullback p₁ p₂ u v)
+    {d : Cofan P} (e : d.pt ≅ Z)
+    (hu : ∀ i, a.inj i ≫ u = f i := by aesop_cat)
+    (hv : ∀ i, b.inj i ≫ v = g i := by aesop_cat)
+    (he₁ : ∀ i j, d.inj (i, j) ≫ e.hom ≫ p₁ = q₁ _ _ ≫ a.inj _ := by aesop_cat)
+    (he₂ : ∀ i j, d.inj (i, j) ≫ e.hom ≫ p₂ = q₂ _ _ ≫ b.inj _ := by aesop_cat) :
+    Nonempty (IsColimit d) :=
+  IsUniversalColimit.nonempty_isColimit_prod_of_pullbackCone hau hbu f g u v
+    (fun i j ↦ (hP i j).cone) (fun i j ↦ (hP i j).isLimit) h.cone h.isLimit e
 
 end CoproductsPullback
 

--- a/Mathlib/CategoryTheory/Limits/VanKampen.lean
+++ b/Mathlib/CategoryTheory/Limits/VanKampen.lean
@@ -765,4 +765,90 @@ theorem mono_of_cofan_isVanKampen [HasInitial C] {ι : Type*} {F : Discrete ι �
 
 end FiniteCoproducts
 
+section CoproductsPullback
+
+variable {ι ι' : Type*} {S : C}
+variable {B : C} {X : ι → C} {a : Cofan X} (hau : IsUniversalColimit a) (f : ∀ i, X i ⟶ S)
+  (u : a.pt ⟶ S) (v : B ⟶ S)
+
+include hau in
+/-- Pullbacks distribute over universal coproducts on the left: This is the isomorphism
+`∐ (B ×[S] Xᵢ) ≅ B ×[S] (∐ Xᵢ)`. -/
+lemma IsUniversalColimit.nonempty_isColimit_of_pullbackCone_left
+    (s : ∀ i, PullbackCone v (f i)) (hs : ∀ i, IsLimit (s i))
+    (t : PullbackCone v u) (ht : IsLimit t) (d : Cofan (fun i : ι ↦ (s i).pt)) (e : d.pt ≅ t.pt)
+    (hu : ∀ i, a.inj i ≫ u = f i := by aesop_cat)
+    (he₁ : ∀ i, d.inj i ≫ e.hom ≫ t.fst = (s i).fst := by aesop_cat)
+    (he₂ : ∀ i, d.inj i ≫ e.hom ≫ t.snd = (s i).snd ≫ a.inj i := by aesop_cat) :
+    Nonempty (IsColimit d) := by
+  let iso : d ≅ (Cofan.mk _ fun i : ι ↦ PullbackCone.IsLimit.lift ht
+      (s i).fst ((s i).snd ≫ a.inj i) (by simp [hu, (s i).condition])) :=
+    Cofan.ext e <| fun p ↦ PullbackCone.IsLimit.hom_ext ht (by simp [he₁]) (by simp [he₂])
+  rw [(IsColimit.equivIsoColimit iso).nonempty_congr]
+  refine hau _ (Discrete.natTrans fun i ↦ (s i.as).snd) t.snd ?_ ?_ fun j ↦ ?_
+  · ext; simp [Cofan.inj]
+  · exact NatTrans.equifibered_of_discrete _
+  · simp only [Discrete.functor_obj_eq_as, Cofan.mk_pt, Functor.const_obj_obj, Cofan.mk_ι_app,
+      Discrete.natTrans_app]
+    rw [← Cofan.inj]
+    refine IsPullback.of_right ?_ (by simp [he₂]) (IsPullback.of_isLimit ht)
+    simpa [hu] using (IsPullback.of_isLimit (hs j.1))
+
+include hau in
+/-- Pullbacks distribute over universal coproducts on the right: This is the isomorphism
+`∐ (Xᵢ ×[S] B) ≅ (∐ Xᵢ) ×[S] B`. -/
+lemma IsUniversalColimit.nonempty_isColimit_of_pullbackCone_right
+    (s : ∀ i, PullbackCone (f i) v) (hs : ∀ i, IsLimit (s i))
+    (t : PullbackCone u v) (ht : IsLimit t) (d : Cofan (fun i : ι ↦ (s i).pt)) (e : d.pt ≅ t.pt)
+    (hu : ∀ i, a.inj i ≫ u = f i := by aesop_cat)
+    (he₁ : ∀ i, d.inj i ≫ e.hom ≫ t.fst = (s i).fst ≫ a.inj i := by aesop_cat)
+    (he₂ : ∀ i, d.inj i ≫ e.hom ≫ t.snd = (s i).snd := by aesop_cat) :
+    Nonempty (IsColimit d) := by
+  let iso : d ≅ (Cofan.mk _ fun i : ι ↦ PullbackCone.IsLimit.lift ht
+      ((s i).fst ≫ a.inj i) ((s i).snd) (by simp [hu, (s i).condition])) :=
+    Cofan.ext e <| fun p ↦ PullbackCone.IsLimit.hom_ext ht (by simp [he₁]) (by simp [he₂])
+  rw [(IsColimit.equivIsoColimit iso).nonempty_congr]
+  refine hau _ (Discrete.natTrans fun i ↦ (s i.as).fst) t.fst ?_ ?_ fun j ↦ ?_
+  · ext; simp [Cofan.inj]
+  · exact NatTrans.equifibered_of_discrete _
+  · simp only [Discrete.functor_obj_eq_as, Cofan.mk_pt, Functor.const_obj_obj, Cofan.mk_ι_app,
+      Discrete.natTrans_app]
+    rw [← Cofan.inj]
+    refine IsPullback.of_right ?_ (by simp) (IsPullback.of_isLimit ht).flip
+    simpa [hu] using (IsPullback.of_isLimit (hs j.1)).flip
+
+/-- Pullbacks distribute over universal coproducts in both arguments: This is the isomorphism
+`∐ (Xᵢ ×[S] Xⱼ) ≅ (∐ Xᵢ) ×[S] (∐ Xⱼ)`. -/
+lemma IsUniversalColimit.nonempty_isColimit_prod_of_pullbackCone {X : ι → C}
+    {Y : ι' → C} {a : Cofan X} (hau : IsUniversalColimit a)
+    {b : Cofan Y} (hbu : IsUniversalColimit b)
+    (f : ∀ i, X i ⟶ S) (g : ∀ i, Y i ⟶ S) (u : a.pt ⟶ S) (v : b.pt ⟶ S) [∀ i, HasPullback (f i) v]
+    (s : ∀ (i : ι) (j : ι'), PullbackCone (f i) (g j))
+    (hs : ∀ i j, IsLimit (s i j)) (t : PullbackCone u v) (ht : IsLimit t)
+    {d : Cofan (fun p : ι × ι' ↦ (s p.1 p.2).pt)} (e : d.pt ≅ t.pt)
+    (hu : ∀ i, a.inj i ≫ u = f i := by aesop_cat)
+    (hv : ∀ i, b.inj i ≫ v = g i := by aesop_cat)
+    (he₁ : ∀ p, d.inj p ≫ e.hom ≫ t.fst = (s _ _).fst ≫ a.inj _ := by aesop_cat)
+    (he₂ : ∀ p, d.inj p ≫ e.hom ≫ t.snd = (s _ _).snd ≫ b.inj _ := by aesop_cat) :
+    Nonempty (IsColimit d) := by
+  let c (i : ι) : Cofan (fun j : ι' ↦ (s i j).pt) :=
+    Cofan.mk (pullback (f i) v) fun j ↦ pullback.lift (s i j).fst ((s i j).snd ≫ b.inj j)
+      (by simp [hv, (s i j).condition])
+  let c' : Cofan (fun i : ι ↦ (c i).pt) :=
+    Cofan.mk t.pt fun i ↦
+      PullbackCone.IsLimit.lift ht (pullback.fst _ _ ≫ a.inj i) (pullback.snd _ _)
+      (by simp [hu, pullback.condition])
+  let iso : d ≅ Cofan.mk c'.pt fun p : ι × ι' ↦ (c p.1).inj p.2 ≫ c'.inj _ := by
+    refine Cofan.ext e <| fun p ↦ PullbackCone.IsLimit.hom_ext ht ?_ ?_
+    · simp [c', c, he₁]
+    · simp [c', c, he₂]
+  rw [(IsColimit.equivIsoColimit iso).nonempty_congr]
+  refine ⟨Cofan.IsColimit.prod c (fun i ↦ Nonempty.some ?_) c' (Nonempty.some ?_)⟩
+  · exact hbu.nonempty_isColimit_of_pullbackCone_left _ v _ _ (hs i) (pullback.cone _ _)
+      (pullback.isLimit _ _) _ (Iso.refl _)
+  · exact hau.nonempty_isColimit_of_pullbackCone_right _ u _ _ (fun _ ↦ pullback.isLimit _ _)
+      t ht _ (Iso.refl _)
+
+end CoproductsPullback
+
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Sites/Coherent/Basic.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/Basic.lean
@@ -142,7 +142,8 @@ def extensiveCoverage [FinitaryPreExtensive C] : Coverage C where
     let π' : (a : α) → Z' a ⟶ Y := fun a ↦ pullback.fst _ _
     refine ⟨@Presieve.ofArrows C _ _ α Z' π', ⟨?_, ?_⟩⟩
     · constructor
-      exact ⟨hα, Z', π', ⟨by simp only, FinitaryPreExtensive.sigma_desc_iso (fun x => π x) f h_iso⟩⟩
+      exact ⟨hα, Z', π', ⟨by simp only,
+        FinitaryPreExtensive.isIso_sigmaDesc_fst (fun x => π x) f h_iso⟩⟩
     · intro W g hg
       rcases hg with ⟨a⟩
       refine ⟨Z a, pullback.snd _ _, π a, ?_, by rw [CategoryTheory.Limits.pullback.condition]⟩

--- a/Mathlib/CategoryTheory/Sites/Coherent/Comparison.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/Comparison.lean
@@ -43,7 +43,7 @@ instance [FinitaryPreExtensive C] [Preregular C] : Precoherent C where
     let X₂ := fun a ↦ pullback g' (Sigma.ι X₁ a)
     let π₂ := fun a ↦ pullback.fst g' (Sigma.ι X₁ a) ≫ g
     let π' := fun a ↦ pullback.fst g' (Sigma.ι X₁ a)
-    have _ := FinitaryPreExtensive.sigma_desc_iso (fun a ↦ Sigma.ι X₁ a) g' inferInstance
+    have _ := FinitaryPreExtensive.isIso_sigmaDesc_fst (fun a ↦ Sigma.ι X₁ a) g' inferInstance
     refine ⟨X₂, π₂, ?_, ?_⟩
     · have : (Sigma.desc π' ≫ g) = Sigma.desc π₂ := by ext; simp [π₂, π']
       rw [← effectiveEpi_desc_iff_effectiveEpiFamily, ← this]


### PR DESCRIPTION
More generally, we show that this holds whenever the coproduct is a universal colimit.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
