### PR TITLE
[Merged by Bors] - feat(FieldTheory/Galois/IsGaloisGroup): Remove finiteness assumption from `card_eq_finrank`

### DIFF
--- a/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
+++ b/Mathlib/FieldTheory/Galois/IsGaloisGroup.lean
@@ -44,11 +44,17 @@ instance of_isGalois [FiniteDimensional K L] [IsGalois K L] : IsGaloisGroup (L �
   commutes := inferInstance
   isInvariant := ⟨fun x ↦ (IsGalois.mem_bot_iff_fixed x).mpr⟩
 
-theorem card_eq_finrank [Finite G] [IsGaloisGroup G K L] : Nat.card G = Module.finrank K L := by
-  have : Fintype G := Fintype.ofFinite G
-  have : FaithfulSMul G L := faithful K
-  rw [← IntermediateField.finrank_bot', ← fixedPoints_eq_bot G, Nat.card_eq_fintype_card]
-  exact (FixedPoints.finrank_eq_card G L).symm
+theorem card_eq_finrank [IsGaloisGroup G K L] : Nat.card G = Module.finrank K L := by
+  rcases fintypeOrInfinite G with _ | hG
+  · have : FaithfulSMul G L := faithful K
+    rw [← IntermediateField.finrank_bot', ← fixedPoints_eq_bot G, Nat.card_eq_fintype_card]
+    exact (FixedPoints.finrank_eq_card G L).symm
+  · rw [Nat.card_eq_zero_of_infinite, eq_comm]
+    contrapose! hG
+    rw [not_infinite_iff_finite]
+    have : FiniteDimensional K L := FiniteDimensional.of_finrank_pos (Nat.zero_lt_of_ne_zero hG)
+    exact Finite.of_injective (MulSemiringAction.toAlgAut G K L)
+      (fun _ _ ↦ (faithful K).eq_of_smul_eq_smul ∘ DFunLike.ext_iff.mp)
 
 theorem finiteDimensional [Finite G] [IsGaloisGroup G K L] : FiniteDimensional K L :=
   FiniteDimensional.of_finrank_pos (card_eq_finrank G K L ▸ Nat.card_pos)


### PR DESCRIPTION
This PR removes the finiteness assumption from `IsGaloisGroup.card_eq_finrank`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
