### PR TITLE
[Merged by Bors] - feat(FieldTheory/IntermediateField/Algebraic): Containment of intermediate fields implies divisibility of `finrank`

### DIFF
--- a/Mathlib/FieldTheory/IntermediateField/Algebraic.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Algebraic.lean
@@ -97,6 +97,22 @@ theorem eq_of_le_of_finrank_eq' [FiniteDimensional F L] (h_le : F ≤ E)
     (h_finrank : finrank F L = finrank E L) : F = E :=
   eq_of_le_of_finrank_le' h_le h_finrank.le
 
+theorem finrank_dvd_of_le_left (h : F ≤ E) : finrank E L ∣ finrank F L := by
+  let _ := (inclusion h).toRingHom.toAlgebra
+  have : IsScalarTower F E L := IsScalarTower.of_algebraMap_eq fun x ↦ rfl
+  exact Dvd.intro_left (finrank F E) (finrank_mul_finrank F E L)
+
+theorem finrank_dvd_of_le_right (h : F ≤ E) : finrank K F ∣ finrank K E := by
+  let _ := (inclusion h).toRingHom.toAlgebra
+  have : IsScalarTower K F E := IsScalarTower.of_algebraMap_eq fun x ↦ rfl
+  exact Dvd.intro (finrank F E) (finrank_mul_finrank K F E)
+
+theorem finrank_le_of_le_left [FiniteDimensional F L] (h : F ≤ E) : finrank E L ≤ finrank F L :=
+  Nat.le_of_dvd Module.finrank_pos (finrank_dvd_of_le_left h)
+
+theorem finrank_le_of_le_right [FiniteDimensional K E] (h : F ≤ E) : finrank K F ≤ finrank K E :=
+  Nat.le_of_dvd Module.finrank_pos (finrank_dvd_of_le_right h)
+
 /-- Mapping a finite dimensional intermediate field along an algebra equivalence gives
 a finite-dimensional intermediate field. -/
 instance finiteDimensional_map (f : L →ₐ[K] L) [FiniteDimensional K E] :


### PR DESCRIPTION
This PR proves divisibility and inequality of `finrank` from containment of intermediate fields.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
