### PR TITLE
[Merged by Bors] - chore: use `grind` instead of `cc`

### DIFF
--- a/Mathlib/Data/Matrix/Block.lean
+++ b/Mathlib/Data/Matrix/Block.lean
@@ -605,7 +605,7 @@ theorem blockDiagonal'_transpose (M : ∀ i, Matrix (m' i) (n' i) α) :
     (blockDiagonal' M)ᵀ = blockDiagonal' fun k => (M k)ᵀ := by
   ext ⟨ii, ix⟩ ⟨ji, jx⟩
   simp only [transpose_apply, blockDiagonal'_apply]
-  split_ifs <;> cc
+  split_ifs <;> grind
 
 @[simp]
 theorem blockDiagonal'_conjTranspose {α} [AddMonoid α] [StarAddMonoid α]

--- a/Mathlib/Logic/Embedding/Basic.lean
+++ b/Mathlib/Logic/Embedding/Basic.lean
@@ -172,7 +172,7 @@ def setValue {α β : Sort*} (f : α ↪ β) (a : α) (b : β) [∀ a', Decidabl
   ⟨fun a' => if a' = a then b else if f a' = b then f a else f a', by
     intro x y h
     simp only at h
-    split_ifs at h <;> (try subst b) <;> (try simp only [f.injective.eq_iff] at *) <;> cc⟩
+    split_ifs at h <;> (try subst b) <;> (try simp only [f.injective.eq_iff] at *) <;> grind⟩
 
 @[simp]
 theorem setValue_eq {α β} (f : α ↪ β) (a : α) (b : β) [∀ a', Decidable (a' = a)]

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -7,7 +7,6 @@ import Mathlib.Data.Sum.Basic
 import Mathlib.Logic.Equiv.Option
 import Mathlib.Logic.Equiv.Sum
 import Mathlib.Logic.Function.Conjugate
-import Mathlib.Tactic.CC
 import Mathlib.Tactic.Lift
 
 /-!
@@ -636,10 +635,10 @@ theorem swapCore_self (r a : α) : swapCore a a r = r := by
   split_ifs <;> simp [*]
 
 theorem swapCore_swapCore (r a b : α) : swapCore a b (swapCore a b r) = r := by
-  unfold swapCore; split_ifs <;> cc
+  unfold swapCore; split_ifs <;> grind
 
 theorem swapCore_comm (r a b : α) : swapCore a b r = swapCore b a r := by
-  unfold swapCore; split_ifs <;> cc
+  unfold swapCore; split_ifs <;> grind
 
 /-- `swap a b` is the permutation that swaps `a` and `b` and
   leaves other values as is. -/

--- a/MathlibTest/grind/ac.lean
+++ b/MathlibTest/grind/ac.lean
@@ -1,0 +1,41 @@
+section CCAC1
+
+example (a b c : Nat) (f : Nat → Nat) : f (a + b + c) = f (c + b + a) := by
+  grind
+
+example (a b c : Nat) (f : Nat → Nat) : a + b = c → f (c + c) = f (a + b + c) := by
+  grind
+
+end CCAC1
+
+section CCAC2
+
+example (a b c d : Nat) (f : Nat → Nat → Nat) : b + a = d → f (a + b + c) a = f (c + d) a := by
+  grind
+
+end CCAC2
+
+section CCAC3
+
+example (a b c d e : Nat) (f : Nat → Nat → Nat) :
+    b + a = d → b + c = e → f (a + b + c) (a + b + c) = f (c + d) (a + e) := by
+  grind
+
+example (a b c d e : Nat) (f : Nat → Nat → Nat) :
+    b + a = d + d → b + c = e + e → f (a + b + c) (a + b + c) = f (c + d + d) (e + a + e) := by
+  grind
+
+section
+universe u
+variable {α : Type u}
+variable (op : α → α → α)
+variable [Std.Associative op]
+variable [Std.Commutative op]
+
+example (a b c d e : α) (f : α → α → α) :
+    op b a = op d d → op b c = op e e →
+    f (op a (op b c)) (op (op a b) c) = f (op (op c d) d) (op e (op a e)) := by
+  grind [Std.Associative, Std.Commutative]
+end
+
+end CCAC3

--- a/MathlibTest/grind/cc.lean
+++ b/MathlibTest/grind/cc.lean
@@ -1,0 +1,33 @@
+example (a₁ a₂ b₁ b₂ c d : Nat) :
+        a₁ = c → a₂ = c →
+        b₁ = d → d = b₂ →
+        a₁ + b₁ + a₁ = a₂ + b₂ + c := by
+  grind
+
+example (a b c : Prop) : (a ↔ b) → ((a ∧ (c ∨ b)) ↔ (b ∧ (c ∨ a))) := by
+  grind
+
+example (a b c d : Prop)
+    [d₁ : Decidable a] [d₂ : Decidable b] [d₃ : Decidable c] [d₄ : Decidable d] :
+    (a ↔ b) → (c ↔ d) →
+      ((if (a ∧ c) then True else False) ↔ (if (b ∧ d) then True else False)) := by
+  grind
+
+example (a b : Nat) : (a = b) = (b = a) := by
+  grind
+
+section Lean3Issue1442
+
+def Rel : Int × Int → Int × Int → Prop
+  | (n₁, d₁), (n₂, d₂) => n₁ * d₂ = n₂ * d₁
+
+def mul' : Int × Int → Int × Int → Int × Int
+  | (n₁, d₁), (n₂, d₂) => ⟨n₁ * n₂, d₁ * d₂⟩
+
+example : ∀ (a b c d : Int × Int), Rel a c → Rel b d → Rel (mul' a b) (mul' c d) :=
+  fun (n₁, d₁) (n₂, d₂) (n₃, d₃) (n₄, d₄) =>
+    fun (h₁ : n₁ * d₃ = n₃ * d₁) (h₂ : n₂ * d₄ = n₄ * d₂) =>
+      show (n₁ * n₂) * (d₃ * d₄) = (n₃ * n₄) * (d₁ * d₂) by
+        grind
+
+end Lean3Issue1442


### PR DESCRIPTION
This PR removes uses of `cc` in Mathlib, replacing them with `grind`. It also adds some `grind` test cases derived from the test cases for `cc`. 

Note that there are `cc` test cases which grind can not (and will not; by design avoiding higher order unification) solve, but there is nothing in the library itself that uses these capabilities.