### PR TITLE
fix(Algebra): `MulMemClass.mul_mem` should not be `aesop safe`

### DIFF
--- a/Mathlib/Algebra/Group/Subsemigroup/Defs.lean
+++ b/Mathlib/Algebra/Group/Subsemigroup/Defs.lean
@@ -70,7 +70,9 @@ export AddMemClass (add_mem)
 
 attribute [to_additive] MulMemClass
 
-attribute [aesop safe apply (rule_sets := [SetLike])] mul_mem add_mem
+-- `mul_mem` is not the only way to prove `a * b ∈ s` (counterexample: `Ideal.mul_mem_left`)
+-- so we have to add a `unsafe apply` attribute for `aesop`.
+attribute [aesop unsafe apply (rule_sets := [SetLike])] mul_mem add_mem
 
 /-- A subsemigroup of a magma `M` is a subset closed under multiplication. -/
 structure Subsemigroup (M : Type*) [Mul M] where

--- a/Mathlib/RingTheory/Ideal/Defs.lean
+++ b/Mathlib/RingTheory/Ideal/Defs.lean
@@ -54,9 +54,11 @@ protected theorem add_mem : a ∈ I → b ∈ I → a + b ∈ I :=
 
 variable (a)
 
+@[aesop unsafe apply (rule_sets := [SetLike])]
 theorem mul_mem_left : b ∈ I → a * b ∈ I :=
   Submodule.smul_mem I a
 
+@[aesop unsafe apply (rule_sets := [SetLike])]
 theorem mul_mem_right {α} {a : α} (b : α) [Semiring α] (I : Ideal α) [I.IsTwoSided]
     (h : a ∈ I) : a * b ∈ I :=
   IsTwoSided.mul_mem_of_left b h


### PR DESCRIPTION
The `@[aesop safe apply]` attribute only applies to implications that preserve provability. So for `mul_mem (ha : a ∈ s) (hb : b ∈ s) : a * b ∈ s`, there are ways to prove `a * b ∈ s` while `b ∉ s`, such as when `s` is an ideal and `a ∈ s`.

So, instead give `MulMemClass.mul_mem` and `AddMemClass.add_mem` the unsafe attribute, and add `Ideal.mul_mem_left` and `Ideal.mul_mem_right` to the aesop with the same `unsafe` attribute. Now we can prove membership of ideals a bit more easily.

Original PR: https://github.com/leanprover-community/mathlib4/pull/24112