### PR TITLE
fix: add label when landrun fails

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -240,7 +240,8 @@ jobs:
           else
             echo "curl to example.com failed as expected - landrun network isolation is working"
           fi
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI" ||
+            echo "landrun=fail" >> "$GITHUB_OUTPUT"
       - name: end gh-problem-match-wrap for build step
         uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
         with:
@@ -261,7 +262,21 @@ jobs:
         shell: bash
         run: |
           cd pr-branch
-
+          if [ "${{ steps.build.outputs.landrun }}" == 'fail' ]
+          then
+            printf $'landrun error: removing cache...\n'
+            rm -rf .lake
+            # we use curl rather than octokit/request-action so that the job won't fail
+            # (and send an annoying email) if the labels don't exist
+            printf $'landrun error: adding permission-denied label...\n'
+            curl --request POST \
+              --header 'Accept: application/vnd.github+json' \
+              --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels \
+              --data '{"labels":["permission-denied"]}'
+            exit 2
+          fi
           # Use the trusted cache tool from master-branch
           # TODO: this is not doing anything currently, and needs to be integrated with put-unpacked
           # ../master-branch/.lake/build/bin/cache commit || true

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -250,7 +250,8 @@ jobs:
           else
             echo "curl to example.com failed as expected - landrun network isolation is working"
           fi
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI" ||
+            echo "landrun=fail" >> "$GITHUB_OUTPUT"
       - name: end gh-problem-match-wrap for build step
         uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
         with:
@@ -271,7 +272,21 @@ jobs:
         shell: bash
         run: |
           cd pr-branch
-
+          if [ "${{ steps.build.outputs.landrun }}" == 'fail' ]
+          then
+            printf $'landrun error: removing cache...\n'
+            rm -rf .lake
+            # we use curl rather than octokit/request-action so that the job won't fail
+            # (and send an annoying email) if the labels don't exist
+            printf $'landrun error: adding permission-denied label...\n'
+            curl --request POST \
+              --header 'Accept: application/vnd.github+json' \
+              --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels \
+              --data '{"labels":["permission-denied"]}'
+            exit 2
+          fi
           # Use the trusted cache tool from master-branch
           # TODO: this is not doing anything currently, and needs to be integrated with put-unpacked
           # ../master-branch/.lake/build/bin/cache commit || true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -257,7 +257,8 @@ jobs:
           else
             echo "curl to example.com failed as expected - landrun network isolation is working"
           fi
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI" ||
+            echo "landrun=fail" >> "$GITHUB_OUTPUT"
       - name: end gh-problem-match-wrap for build step
         uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
         with:
@@ -278,7 +279,21 @@ jobs:
         shell: bash
         run: |
           cd pr-branch
-
+          if [ "${{ steps.build.outputs.landrun }}" == 'fail' ]
+          then
+            printf $'landrun error: removing cache...\n'
+            rm -rf .lake
+            # we use curl rather than octokit/request-action so that the job won't fail
+            # (and send an annoying email) if the labels don't exist
+            printf $'landrun error: adding permission-denied label...\n'
+            curl --request POST \
+              --header 'Accept: application/vnd.github+json' \
+              --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels \
+              --data '{"labels":["permission-denied"]}'
+            exit 2
+          fi
           # Use the trusted cache tool from master-branch
           # TODO: this is not doing anything currently, and needs to be integrated with put-unpacked
           # ../master-branch/.lake/build/bin/cache commit || true

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -254,7 +254,8 @@ jobs:
           else
             echo "curl to example.com failed as expected - landrun network isolation is working"
           fi
-          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI"
+          bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI" ||
+            echo "landrun=fail" >> "$GITHUB_OUTPUT"
       - name: end gh-problem-match-wrap for build step
         uses: leanprover-community/gh-problem-matcher-wrap@20007cb926a46aa324653a387363b52f07709845 # 2025-04-23
         with:
@@ -275,7 +276,21 @@ jobs:
         shell: bash
         run: |
           cd pr-branch
-
+          if [ "${{ steps.build.outputs.landrun }}" == 'fail' ]
+          then
+            printf $'landrun error: removing cache...\n'
+            rm -rf .lake
+            # we use curl rather than octokit/request-action so that the job won't fail
+            # (and send an annoying email) if the labels don't exist
+            printf $'landrun error: adding permission-denied label...\n'
+            curl --request POST \
+              --header 'Accept: application/vnd.github+json' \
+              --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels \
+              --data '{"labels":["permission-denied"]}'
+            exit 2
+          fi
           # Use the trusted cache tool from master-branch
           # TODO: this is not doing anything currently, and needs to be integrated with put-unpacked
           # ../master-branch/.lake/build/bin/cache commit || true


### PR DESCRIPTION
Adds the `permission-denied` label on PRs that get blocked by landrun.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
