### PR TITLE
[Merged by Bors] - feat(AlgebraicGeometry): Add global preorder instance for schemes

### DIFF
--- a/Mathlib/AlgebraicGeometry/AffineSpace.lean
+++ b/Mathlib/AlgebraicGeometry/AffineSpace.lean
@@ -466,9 +466,9 @@ lemma spec_le_iff (R : CommRingCat) (p q : Spec R) :
 
 /--
 One should bear this equality in mind when breaking the `Spec R/ PrimeSpectrum R` abstraction
-boundary.
+boundary, since these instances are not definitionally equal.
 -/
-lemma preorder_instance_eq_spec (R : CommRingCat) :
+example (R : CommRingCat) :
   inferInstance (α := Preorder (Spec R)) =
   inferInstance (α := Preorder (PrimeSpectrum R)ᵒᵈ) := by aesop (add simp spec_le_iff)
 

--- a/Mathlib/AlgebraicGeometry/AffineSpace.lean
+++ b/Mathlib/AlgebraicGeometry/AffineSpace.lean
@@ -462,7 +462,7 @@ lemma not_isIntegralHom [Nonempty S] [Nonempty n] : ¬ IsIntegralHom (𝔸(n; S)
   simp [isIntegralHom_over_iff_isEmpty]
 
 /--
-One should bare this equality in mind when breaking the `Spec R/ PrimeSpectrum R` abstraction
+One should bear this equality in mind when breaking the `Spec R/ PrimeSpectrum R` abstraction
 boundary.
 -/
 lemma preorder_instance_eq_spec (R : CommRingCat) :

--- a/Mathlib/AlgebraicGeometry/AffineSpace.lean
+++ b/Mathlib/AlgebraicGeometry/AffineSpace.lean
@@ -465,7 +465,7 @@ lemma spec_le_iff (R : CommRingCat) (p q : Spec R) :
    p ≤ q ↔ q.asIdeal ≤ p.asIdeal := by aesop (add simp PrimeSpectrum.le_iff_specializes)
 
 /--
-One should bare this equality in mind when breaking the `Spec R/ PrimeSpectrum R` abstraction
+One should bear this equality in mind when breaking the `Spec R/ PrimeSpectrum R` abstraction
 boundary.
 -/
 lemma preorder_instance_eq_spec (R : CommRingCat) :

--- a/Mathlib/AlgebraicGeometry/AffineSpace.lean
+++ b/Mathlib/AlgebraicGeometry/AffineSpace.lean
@@ -465,7 +465,7 @@ lemma spec_le_iff (R : CommRingCat) (p q : Spec R) :
    p ≤ q ↔ q.asIdeal ≤ p.asIdeal := by aesop (add simp PrimeSpectrum.le_iff_specializes)
 
 /--
-One should bear this equality in mind when breaking the `Spec R/ PrimeSpectrum R` abstraction
+One should bare this equality in mind when breaking the `Spec R/ PrimeSpectrum R` abstraction
 boundary.
 -/
 lemma preorder_instance_eq_spec (R : CommRingCat) :

--- a/Mathlib/AlgebraicGeometry/AffineSpace.lean
+++ b/Mathlib/AlgebraicGeometry/AffineSpace.lean
@@ -461,13 +461,16 @@ lemma isIntegralHom_over_iff_isEmpty : IsIntegralHom (𝔸(n; S) ↘ S) ↔ IsEm
 lemma not_isIntegralHom [Nonempty S] [Nonempty n] : ¬ IsIntegralHom (𝔸(n; S) ↘ S) := by
   simp [isIntegralHom_over_iff_isEmpty]
 
+lemma spec_le_iff (R : CommRingCat) (p q : Spec R) :
+   p ≤ q ↔ q.asIdeal ≤ p.asIdeal := by aesop (add simp PrimeSpectrum.le_iff_specializes)
+
 /--
 One should bare this equality in mind when breaking the `Spec R/ PrimeSpectrum R` abstraction
 boundary.
 -/
 lemma preorder_instance_eq_spec (R : CommRingCat) :
-  inferInstance (i := PartialOrder (Spec R)) =
-  inferInstance (i := PartialOrder (PrimeSpectrum R)) := by rfl
+  inferInstance (α := Preorder (Spec R)) =
+  inferInstance (α := Preorder (PrimeSpectrum R)ᵒᵈ) := by aesop (add simp spec_le_iff)
 
 end instances
 

--- a/Mathlib/AlgebraicGeometry/AffineSpace.lean
+++ b/Mathlib/AlgebraicGeometry/AffineSpace.lean
@@ -461,6 +461,14 @@ lemma isIntegralHom_over_iff_isEmpty : IsIntegralHom (𝔸(n; S) ↘ S) ↔ IsEm
 lemma not_isIntegralHom [Nonempty S] [Nonempty n] : ¬ IsIntegralHom (𝔸(n; S) ↘ S) := by
   simp [isIntegralHom_over_iff_isEmpty]
 
+/--
+One should bare this equality in mind when breaking the `Spec R/ PrimeSpectrum R` abstraction
+boundary.
+-/
+lemma preorder_instance_eq_spec (R : CommRingCat) :
+  inferInstance (i := PartialOrder (Spec R)) =
+  inferInstance (i := PartialOrder (PrimeSpectrum R)) := by rfl
+
 end instances
 
 end AffineSpace

--- a/Mathlib/AlgebraicGeometry/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/Scheme.lean
@@ -117,6 +117,9 @@ lemma Hom.continuous {X Y : Scheme} (f : X.Hom Y) : Continuous f.base := f.base.
 protected abbrev sheaf (X : Scheme) :=
   X.toSheafedSpace.sheaf
 
+/--
+We give schemes the specialization preorder by default.
+-/
 instance {X : Scheme.{u}} : Preorder X := specializationPreorder X
 
 lemma le_iff_specializes {X : Scheme.{u}} {a b : X} : a ≤ b ↔ b ⤳ a := by rfl

--- a/Mathlib/AlgebraicGeometry/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/Scheme.lean
@@ -10,7 +10,7 @@ import Mathlib.CategoryTheory.Elementwise
 /-!
 # The category of schemes
 
-A scheme is a locally ringed space such that every point is contained in some open set
+A scheme is a locally ringed space such that every ptat is contained in some open set
 where there is an isomorphism of presheaves between the restriction to that open set,
 and the structure sheaf of `Spec R`, for some commutative ring `R`.
 
@@ -116,6 +116,8 @@ lemma Hom.continuous {X Y : Scheme} (f : X.Hom Y) : Continuous f.base := f.base.
 /-- The structure sheaf of a scheme. -/
 protected abbrev sheaf (X : Scheme) :=
   X.toSheafedSpace.sheaf
+
+instance instanceSchemePreord {X : Scheme} : Preorder X := specializationPreorder X
 
 namespace Hom
 

--- a/Mathlib/AlgebraicGeometry/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/Scheme.lean
@@ -117,7 +117,9 @@ lemma Hom.continuous {X Y : Scheme} (f : X.Hom Y) : Continuous f.base := f.base.
 protected abbrev sheaf (X : Scheme) :=
   X.toSheafedSpace.sheaf
 
-instance {X : Scheme} : Preorder X := specializationPreorder X
+instance {X : Scheme.{u}} : Preorder X := specializationPreorder X
+
+lemma le_iff_specializes {X : Scheme.{u}} {a b : X} : a ≤ b ↔ b ⤳ a := by rfl
 
 namespace Hom
 

--- a/Mathlib/AlgebraicGeometry/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/Scheme.lean
@@ -10,7 +10,7 @@ import Mathlib.CategoryTheory.Elementwise
 /-!
 # The category of schemes
 
-A scheme is a locally ringed space such that every ptat is contained in some open set
+A scheme is a locally ringed space such that every point is contained in some open set
 where there is an isomorphism of presheaves between the restriction to that open set,
 and the structure sheaf of `Spec R`, for some commutative ring `R`.
 
@@ -117,7 +117,7 @@ lemma Hom.continuous {X Y : Scheme} (f : X.Hom Y) : Continuous f.base := f.base.
 protected abbrev sheaf (X : Scheme) :=
   X.toSheafedSpace.sheaf
 
-instance instanceSchemePreord {X : Scheme} : Preorder X := specializationPreorder X
+instance {X : Scheme} : Preorder X := specializationPreorder X
 
 namespace Hom
 


### PR DESCRIPTION
In this PR we added a default preorder instance for schemes, defined to be the specialization order as discussed here: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/dimension.20function.20for.20schemes/near/524997376 for discussion 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
