### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Products/Basic): alternative constructor for morphisms in products

### DIFF
--- a/Mathlib/CategoryTheory/Limits/ColimitLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/ColimitLimit.lean
@@ -34,14 +34,14 @@ variable {J : Type u₁} {K : Type u₂} [Category.{v₁} J] [Category.{v₂} K]
 variable {C : Type u} [Category.{v} C]
 variable (F : J × K ⥤ C)
 
-open CategoryTheory.prod
+open CategoryTheory.prod Prod
 
 theorem map_id_left_eq_curry_map {j : J} {k k' : K} {f : k ⟶ k'} :
-    F.map (Prod.mkHom (𝟙 j) f) = ((curry.obj F).obj j).map f :=
+    F.map (𝟙 j ×ₘ f) = ((curry.obj F).obj j).map f :=
   rfl
 
 theorem map_id_right_eq_curry_swap_map {j j' : J} {f : j ⟶ j'} {k : K} :
-    F.map (Prod.mkHom f (𝟙 k)) = ((curry.obj (Prod.swap K J ⋙ F)).obj k).map f :=
+    F.map (f ×ₘ 𝟙 k) = ((curry.obj (Prod.swap K J ⋙ F)).obj k).map f :=
   rfl
 
 variable [HasLimitsOfShape J C]

--- a/Mathlib/CategoryTheory/Limits/ColimitLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/ColimitLimit.lean
@@ -37,11 +37,11 @@ variable (F : J × K ⥤ C)
 open CategoryTheory.prod
 
 theorem map_id_left_eq_curry_map {j : J} {k k' : K} {f : k ⟶ k'} :
-    F.map ((𝟙 j, f) : (j, k) ⟶ (j, k')) = ((curry.obj F).obj j).map f :=
+    F.map (Prod.mkHom (𝟙 j) f) = ((curry.obj F).obj j).map f :=
   rfl
 
 theorem map_id_right_eq_curry_swap_map {j j' : J} {f : j ⟶ j'} {k : K} :
-    F.map ((f, 𝟙 k) : (j, k) ⟶ (j', k)) = ((curry.obj (Prod.swap K J ⋙ F)).obj k).map f :=
+    F.map (Prod.mkHom f (𝟙 k)) = ((curry.obj (Prod.swap K J ⋙ F)).obj k).map f :=
   rfl
 
 variable [HasLimitsOfShape J C]

--- a/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean
@@ -88,8 +88,8 @@ theorem colimitLimitToLimitColimit_injective :
     let g : ∀ j, ky ⟶ k j := fun j => (h j).choose_spec.choose_spec.choose
     -- where the images of the components of the representatives become equal:
     have w :
-      ∀ j, F.map (Prod.mkHom (𝟙 j) (f j)) (limit.π ((curry.obj (swap K J ⋙ F)).obj kx) j x) =
-          F.map (Prod.mkHom (𝟙 j) (g j)) (limit.π ((curry.obj (swap K J ⋙ F)).obj ky) j y) :=
+      ∀ j, F.map (𝟙 j ×ₘ f j) (limit.π ((curry.obj (swap K J ⋙ F)).obj kx) j x) =
+          F.map (𝟙 j ×ₘ g j) (limit.π ((curry.obj (swap K J ⋙ F)).obj ky) j y) :=
       fun j => (h j).choose_spec.choose_spec.choose_spec
     -- We now use that `K` is filtered, picking some point to the right of all these
     -- morphisms `f j` and `g j`.
@@ -186,8 +186,8 @@ theorem colimitLimitToLimitColimit_surjective :
     -- `(f, g j)` and `(𝟙 j', g j')`, both represent the same element in the colimit.
     have w :
       ∀ {j j' : J} (f : j ⟶ j'),
-        colimit.ι ((curry.obj F).obj j') k' (F.map (Prod.mkHom (𝟙 j') (g j')) (y j')) =
-          colimit.ι ((curry.obj F).obj j') k' (F.map (Prod.mkHom f (g j)) (y j)) := by
+        colimit.ι ((curry.obj F).obj j') k' (F.map (𝟙 j' ×ₘ g j') (y j')) =
+          colimit.ι ((curry.obj F).obj j') k' (F.map (f ×ₘ g j) (y j)) := by
       intro j j' f
       simp only [Colimit.w_apply, ← Bifunctor.diagonal', ← curry_obj_obj_map, ← curry_obj_map_app]
       rw [types_comp_apply, Colimit.w_apply, e, ← Limit.w_apply.{u₁, v, u₁} f, ← e]
@@ -203,11 +203,11 @@ theorem colimitLimitToLimitColimit_surjective :
       (w f).choose_spec.choose_spec.choose
     have wf :
       ∀ {j j'} (f : j ⟶ j'),
-        F.map (Prod.mkHom (𝟙 j') (g j' ≫ gf f)) (y j') = F.map (Prod.mkHom f (g j ≫ hf f)) (y j) :=
+        F.map (𝟙 j' ×ₘ (g j' ≫ gf f)) (y j') = F.map (f ×ₘ (g j ≫ hf f)) (y j) :=
       fun {j j'} f => by
       have q :
-        ((curry.obj F).obj j').map (gf f) (F.map (Prod.mkHom (𝟙 j') (g j')) (y j')) =
-          ((curry.obj F).obj j').map (hf f) (F.map (Prod.mkHom f (g j)) (y j)) :=
+        ((curry.obj F).obj j').map (gf f) (F.map (𝟙 j' ×ₘ g j') (y j')) =
+          ((curry.obj F).obj j').map (hf f) (F.map (f ×ₘ g j) (y j)) :=
         (w f).choose_spec.choose_spec.choose_spec
       dsimp only [curry_obj_obj_map, curry_obj_obj_map] at q
       simp_rw [← FunctorToTypes.map_comp_apply, CategoryStruct.comp] at q
@@ -275,24 +275,24 @@ theorem colimitLimitToLimitColimit_surjective :
       apply Limit.mk
       swap
       ·-- We construct the elements as the images of the `y j`.
-        exact fun j => F.map (Prod.mkHom (𝟙 j) (g j ≫ gf (𝟙 j) ≫ i (𝟙 j))) (y j)
+        exact fun j => F.map (𝟙 j ×ₘ (g j ≫ gf (𝟙 j) ≫ i (𝟙 j))) (y j)
       · -- After which it's just a calculation, using `s` and `wf`, to see they are coherent.
         dsimp
         intro j j' f
         simp only [← FunctorToTypes.map_comp_apply, prod_comp, id_comp, comp_id]
         calc
-          F.map (Prod.mkHom f (g j ≫ gf (𝟙 j) ≫ i (𝟙 j))) (y j) =
-              F.map (Prod.mkHom f (g j ≫ hf f ≫ i f)) (y j) := by
+          F.map (f ×ₘ (g j ≫ gf (𝟙 j) ≫ i (𝟙 j))) (y j) =
+              F.map (f ×ₘ (g j ≫ hf f ≫ i f)) (y j) := by
             rw [s (𝟙 j) f]
           _ =
-              F.map (Prod.mkHom (𝟙 j') (i f)) (F.map (Prod.mkHom f (g j ≫ hf f)) (y j)) := by
+              F.map (𝟙 j' ×ₘ i f) (F.map (f ×ₘ (g j ≫ hf f)) (y j)) := by
             rw [← FunctorToTypes.map_comp_apply, prod_comp, comp_id, assoc]
           _ =
-              F.map (Prod.mkHom (𝟙 j') (i f)) (F.map (Prod.mkHom (𝟙 j') (g j' ≫ gf f)) (y j')) := by
+              F.map (𝟙 j' ×ₘ i f) (F.map (𝟙 j' ×ₘ (g j' ≫ gf f)) (y j')) := by
             rw [← wf f]
-          _ = F.map (Prod.mkHom (𝟙 j') (g j' ≫ gf f ≫ i f)) (y j') := by
+          _ = F.map (𝟙 j' ×ₘ (g j' ≫ gf f ≫ i f)) (y j') := by
             rw [← FunctorToTypes.map_comp_apply, prod_comp, id_comp, assoc]
-          _ = F.map (Prod.mkHom (𝟙 j') (g j' ≫ gf (𝟙 j') ≫ i (𝟙 j'))) (y j') := by
+          _ = F.map (𝟙 j' ×ₘ (g j' ≫ gf (𝟙 j') ≫ i (𝟙 j'))) (y j') := by
             rw [s f (𝟙 j'), ← s (𝟙 j') (𝟙 j')]
     -- Finally we check that this maps to `x`.
     · -- We can do this componentwise:

--- a/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean
@@ -88,10 +88,8 @@ theorem colimitLimitToLimitColimit_injective :
     let g : ∀ j, ky ⟶ k j := fun j => (h j).choose_spec.choose_spec.choose
     -- where the images of the components of the representatives become equal:
     have w :
-      ∀ j, F.map ((𝟙 j, f j) :
-        (j, kx) ⟶ (j, k j)) (limit.π ((curry.obj (swap K J ⋙ F)).obj kx) j x) =
-          F.map ((𝟙 j, g j) : (j, ky) ⟶ (j, k j))
-            (limit.π ((curry.obj (swap K J ⋙ F)).obj ky) j y) :=
+      ∀ j, F.map (Prod.mkHom (𝟙 j) (f j)) (limit.π ((curry.obj (swap K J ⋙ F)).obj kx) j x) =
+          F.map (Prod.mkHom (𝟙 j) (g j)) (limit.π ((curry.obj (swap K J ⋙ F)).obj ky) j y) :=
       fun j => (h j).choose_spec.choose_spec.choose_spec
     -- We now use that `K` is filtered, picking some point to the right of all these
     -- morphisms `f j` and `g j`.
@@ -205,8 +203,7 @@ theorem colimitLimitToLimitColimit_surjective :
       (w f).choose_spec.choose_spec.choose
     have wf :
       ∀ {j j'} (f : j ⟶ j'),
-        F.map ((𝟙 j', g j' ≫ gf f) : (j', k j') ⟶ (j', kf f)) (y j') =
-          F.map ((f, g j ≫ hf f) : (j, k j) ⟶ (j', kf f)) (y j) :=
+        F.map (Prod.mkHom (𝟙 j') (g j' ≫ gf f)) (y j') = F.map (Prod.mkHom f (g j ≫ hf f)) (y j) :=
       fun {j j'} f => by
       have q :
         ((curry.obj F).obj j').map (gf f) (F.map (Prod.mkHom (𝟙 j') (g j')) (y j')) =
@@ -278,7 +275,7 @@ theorem colimitLimitToLimitColimit_surjective :
       apply Limit.mk
       swap
       ·-- We construct the elements as the images of the `y j`.
-        exact fun j => F.map (⟨𝟙 j, g j ≫ gf (𝟙 j) ≫ i (𝟙 j)⟩ : (j, k j) ⟶ (j, k'')) (y j)
+        exact fun j => F.map (Prod.mkHom (𝟙 j) (g j ≫ gf (𝟙 j) ≫ i (𝟙 j))) (y j)
       · -- After which it's just a calculation, using `s` and `wf`, to see they are coherent.
         dsimp
         intro j j' f

--- a/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean
@@ -27,9 +27,7 @@ colimit (over `K`) of the limits (over `J`) with the limit of the colimits is an
 -/
 
 -- Various pieces of algebra that have previously been spuriously imported here:
-assert_not_exists map_ne_zero Field
--- TODO: We should morally be able to strengthen this to `assert_not_exists GroupWithZero`, but
--- finiteness currently relies on more algebra than it needs.
+assert_not_exists map_ne_zero Field GroupWithZero
 
 universe w v₁ v₂ v u₁ u₂ u
 
@@ -190,15 +188,12 @@ theorem colimitLimitToLimitColimit_surjective :
     -- `(f, g j)` and `(𝟙 j', g j')`, both represent the same element in the colimit.
     have w :
       ∀ {j j' : J} (f : j ⟶ j'),
-        colimit.ι ((curry.obj F).obj j') k' (F.map ((𝟙 j', g j') : (j', k j') ⟶ (j', k')) (y j')) =
-          colimit.ι ((curry.obj F).obj j') k' (F.map ((f, g j) : (j, k j) ⟶ (j', k')) (y j)) := by
+        colimit.ι ((curry.obj F).obj j') k' (F.map (Prod.mkHom (𝟙 j') (g j')) (y j')) =
+          colimit.ι ((curry.obj F).obj j') k' (F.map (Prod.mkHom f (g j)) (y j)) := by
       intro j j' f
-      have t : (f, g j) =
-          (((f, 𝟙 (k j)) : (j, k j) ⟶ (j', k j)) ≫ (𝟙 j', g j) : (j, k j) ⟶ (j', k')) := by
-        simp only [id_comp, comp_id, prod_comp]
-      erw [Colimit.w_apply, t, FunctorToTypes.map_comp_apply, Colimit.w_apply, e,
-        ← Limit.w_apply.{u₁, v, u₁} f, ← e]
-      simp only [Functor.comp_map, Types.Colimit.ι_map_apply, curry_obj_map_app]
+      simp only [Colimit.w_apply, ← Bifunctor.diagonal', ← curry_obj_obj_map, ← curry_obj_map_app]
+      rw [types_comp_apply, Colimit.w_apply, e, ← Limit.w_apply.{u₁, v, u₁} f, ← e]
+      simp [Types.Colimit.ι_map_apply]
     -- Because `K` is filtered, we can restate this as saying that
     -- for each such `f`, there is some place to the right of `k'`
     -- where these images of `y j` and `y j'` become equal.
@@ -214,8 +209,8 @@ theorem colimitLimitToLimitColimit_surjective :
           F.map ((f, g j ≫ hf f) : (j, k j) ⟶ (j', kf f)) (y j) :=
       fun {j j'} f => by
       have q :
-        ((curry.obj F).obj j').map (gf f) (F.map ((𝟙 j', g j') : (j', k j') ⟶ (j', k')) (y j')) =
-          ((curry.obj F).obj j').map (hf f) (F.map ((f, g j) : (j, k j) ⟶ (j', k')) (y j)) :=
+        ((curry.obj F).obj j').map (gf f) (F.map (Prod.mkHom (𝟙 j') (g j')) (y j')) =
+          ((curry.obj F).obj j').map (hf f) (F.map (Prod.mkHom f (g j)) (y j)) :=
         (w f).choose_spec.choose_spec.choose_spec
       dsimp only [curry_obj_obj_map, curry_obj_obj_map] at q
       simp_rw [← FunctorToTypes.map_comp_apply, CategoryStruct.comp] at q
@@ -289,20 +284,18 @@ theorem colimitLimitToLimitColimit_surjective :
         intro j j' f
         simp only [← FunctorToTypes.map_comp_apply, prod_comp, id_comp, comp_id]
         calc
-          F.map ((f, g j ≫ gf (𝟙 j) ≫ i (𝟙 j)) : (j, k j) ⟶ (j', k'')) (y j) =
-              F.map ((f, g j ≫ hf f ≫ i f) : (j, k j) ⟶ (j', k'')) (y j) := by
+          F.map (Prod.mkHom f (g j ≫ gf (𝟙 j) ≫ i (𝟙 j))) (y j) =
+              F.map (Prod.mkHom f (g j ≫ hf f ≫ i f)) (y j) := by
             rw [s (𝟙 j) f]
           _ =
-              F.map ((𝟙 j', i f) : (j', kf f) ⟶ (j', k''))
-                (F.map ((f, g j ≫ hf f) : (j, k j) ⟶ (j', kf f)) (y j)) := by
+              F.map (Prod.mkHom (𝟙 j') (i f)) (F.map (Prod.mkHom f (g j ≫ hf f)) (y j)) := by
             rw [← FunctorToTypes.map_comp_apply, prod_comp, comp_id, assoc]
           _ =
-              F.map ((𝟙 j', i f) : (j', kf f) ⟶ (j', k''))
-                (F.map ((𝟙 j', g j' ≫ gf f) : (j', k j') ⟶ (j', kf f)) (y j')) := by
+              F.map (Prod.mkHom (𝟙 j') (i f)) (F.map (Prod.mkHom (𝟙 j') (g j' ≫ gf f)) (y j')) := by
             rw [← wf f]
-          _ = F.map ((𝟙 j', g j' ≫ gf f ≫ i f) : (j', k j') ⟶ (j', k'')) (y j') := by
+          _ = F.map (Prod.mkHom (𝟙 j') (g j' ≫ gf f ≫ i f)) (y j') := by
             rw [← FunctorToTypes.map_comp_apply, prod_comp, id_comp, assoc]
-          _ = F.map ((𝟙 j', g j' ≫ gf (𝟙 j') ≫ i (𝟙 j')) : (j', k j') ⟶ (j', k'')) (y j') := by
+          _ = F.map (Prod.mkHom (𝟙 j') (g j' ≫ gf (𝟙 j') ≫ i (𝟙 j'))) (y j') := by
             rw [s f (𝟙 j'), ← s (𝟙 j') (𝟙 j')]
     -- Finally we check that this maps to `x`.
     · -- We can do this componentwise:

--- a/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean
@@ -27,7 +27,7 @@ colimit (over `K`) of the limits (over `J`) with the limit of the colimits is an
 -/
 
 -- Various pieces of algebra that have previously been spuriously imported here:
-assert_not_exists map_ne_zero Field GroupWithZero
+assert_not_exists map_ne_zero MonoidWithZero
 
 universe w v₁ v₂ v u₁ u₂ u
 

--- a/Mathlib/CategoryTheory/Limits/Fubini.lean
+++ b/Mathlib/CategoryTheory/Limits/Fubini.lean
@@ -456,9 +456,11 @@ noncomputable def coconeOfHasColimitCurryCompColim : Cocone G :=
       naturality {x y} := fun ⟨f₁, f₂⟩ ↦ by
         have := (Q.obj y.1).w f₂
         dsimp [Q] at this ⊢
-        rw [← colimit.w (F := curry.obj G ⋙ colim) (f := f₁)]
-        simp [Category.assoc, Category.comp_id, Prod.fac' (f₁, f₂),
-          G.map_comp, ι_colimMap_assoc, curry_obj_map_app, reassoc_of% this] } }
+        rw [← colimit.w (F := curry.obj G ⋙ colim) (f := f₁),
+          Category.assoc, Category.comp_id, Prod.fac' (f₁, f₂),
+          G.map_comp_assoc, ← curry_obj_map_app, ← curry_obj_obj_map]
+        dsimp
+        simp [ι_colimMap_assoc, curry_obj_map_app, reassoc_of% this]} }
 
 
 /-- The cocone `coconeOfHasColimitCurryCompColim` is in fact a limit cocone.

--- a/Mathlib/CategoryTheory/Limits/Fubini.lean
+++ b/Mathlib/CategoryTheory/Limits/Fubini.lean
@@ -135,6 +135,7 @@ def coneOfConeCurry {D : DiagramOfCones (curry.obj G)} (Q : ∀ j, IsLimit (D.ob
           π := { app k := c.π.app (j, k) } }
       naturality {_ j'} _ := (Q j').hom_ext (by simp) }
 
+open scoped Prod in
 /-- Given a diagram `D` of colimit cocones over the `F.obj j`, and a cocone over `uncurry.obj F`,
 we can construct a cocone over the diagram consisting of the cocone points from `D`.
 -/
@@ -153,7 +154,7 @@ def coconeOfCoconeUncurry {D : DiagramOfCocones F} (Q : ∀ j, IsColimit (D.obj 
                   conv_lhs =>
                     arg 1; equals (F.map (𝟙 _)).app _ ≫  (F.obj j).map f =>
                       simp
-                  conv_lhs => arg 1; rw [← uncurry_obj_map F (Prod.mkHom (𝟙 j) f)]
+                  conv_lhs => arg 1; rw [← uncurry_obj_map F (𝟙 j ×ₘ f)]
                   rw [c.w] } }
       naturality := fun j j' f =>
         (Q j).hom_ext

--- a/Mathlib/CategoryTheory/Limits/Fubini.lean
+++ b/Mathlib/CategoryTheory/Limits/Fubini.lean
@@ -153,7 +153,7 @@ def coconeOfCoconeUncurry {D : DiagramOfCocones F} (Q : ∀ j, IsColimit (D.obj 
                   conv_lhs =>
                     arg 1; equals (F.map (𝟙 _)).app _ ≫  (F.obj j).map f =>
                       simp
-                  conv_lhs => arg 1; rw [← uncurry_obj_map F ((𝟙 j,f) : (j,k) ⟶ (j,k'))]
+                  conv_lhs => arg 1; rw [← uncurry_obj_map F (Prod.mkHom (𝟙 j) f)]
                   rw [c.w] } }
       naturality := fun j j' f =>
         (Q j).hom_ext

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution.lean
@@ -99,21 +99,21 @@ variable {x x' y y' : C}
 lemma unit_naturality (f : x ⟶ x') (g : y ⟶ y') :
     (F.map f ⊗ₘ G.map g) ≫ (unit F G).app (x', y') =
     (unit F G).app (x, y) ≫ (F ⊛ G).map (f ⊗ₘ g) := by
-  simpa [tensorHom_def] using (unit F G).naturality ((f, g) : (x, y) ⟶ (x', y'))
+  simpa [tensorHom_def] using (unit F G).naturality (Prod.mkHom f g)
 
 variable (y) in
 @[reassoc (attr := simp)]
 lemma whiskerRight_comp_unit_app (f : x ⟶ x') :
     F.map f ▷ G.obj y ≫ (unit F G).app (x', y) =
     (unit F G).app (x, y) ≫ (F ⊛ G).map (f ▷ y) := by
-  simpa [tensorHom_def] using (unit F G).naturality ((f, 𝟙 _) : (x, y) ⟶ (x', y))
+  simpa [tensorHom_def] using (unit F G).naturality (Prod.mkHom f (𝟙 _))
 
 variable (x) in
 @[reassoc (attr := simp)]
 lemma whiskerLeft_comp_unit_app (g : y ⟶ y') :
     F.obj x ◁ G.map g ≫ (unit F G).app (x, y') =
     (unit F G).app (x, y) ≫ (F ⊛ G).map (x ◁ g) := by
-  simpa [tensorHom_def] using (unit F G).naturality ((𝟙 _, g) : (x, y) ⟶ (x, y'))
+  simpa [tensorHom_def] using (unit F G).naturality (Prod.mkHom (𝟙 _) g)
 
 end unit
 
@@ -126,7 +126,7 @@ variable {F' G' : C ⥤ V} [DayConvolution F' G']
 /-- The morphism between day convolutions (provided they exist) induced by a pair of morphisms. -/
 def map (f : F ⟶ F') (g : G ⟶ G') : F ⊛ G ⟶ F' ⊛ G' :=
   Functor.descOfIsLeftKanExtension (F ⊛ G) (unit F G) (F' ⊛ G') <|
-    (externalProductBifunctor C C V).map ((f, g) : (F, G) ⟶ (F', G')) ≫ unit F' G'
+    (externalProductBifunctor C C V).map (Prod.mkHom f g) ≫ unit F' G'
 
 variable (f : F ⟶ F') (g : G ⟶ G') (x y : C)
 
@@ -136,7 +136,7 @@ lemma unit_app_map_app :
     (f.app x ⊗ₘ g.app y) ≫ (unit F' G').app (x, y) := by
   simpa [tensorHom_def] using
     (Functor.descOfIsLeftKanExtension_fac_app (F ⊛ G) (unit F G) (F' ⊛ G') <|
-      (externalProductBifunctor C C V).map ((f, g) : (F, G) ⟶ (F', G')) ≫ unit F' G') (x, y)
+      (externalProductBifunctor C C V).map (Prod.mkHom f g) ≫ unit F' G') (x, y)
 
 end map
 

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution.lean
@@ -61,6 +61,8 @@ class DayConvolution (F G : C ⥤ V) where
 
 namespace DayConvolution
 
+open scoped Prod
+
 section
 
 /-- A notation for the Day convolution of two functors. -/
@@ -99,21 +101,21 @@ variable {x x' y y' : C}
 lemma unit_naturality (f : x ⟶ x') (g : y ⟶ y') :
     (F.map f ⊗ₘ G.map g) ≫ (unit F G).app (x', y') =
     (unit F G).app (x, y) ≫ (F ⊛ G).map (f ⊗ₘ g) := by
-  simpa [tensorHom_def] using (unit F G).naturality (Prod.mkHom f g)
+  simpa [tensorHom_def] using (unit F G).naturality (f ×ₘ g)
 
 variable (y) in
 @[reassoc (attr := simp)]
 lemma whiskerRight_comp_unit_app (f : x ⟶ x') :
     F.map f ▷ G.obj y ≫ (unit F G).app (x', y) =
     (unit F G).app (x, y) ≫ (F ⊛ G).map (f ▷ y) := by
-  simpa [tensorHom_def] using (unit F G).naturality (Prod.mkHom f (𝟙 _))
+  simpa [tensorHom_def] using (unit F G).naturality (f ×ₘ 𝟙 _)
 
 variable (x) in
 @[reassoc (attr := simp)]
 lemma whiskerLeft_comp_unit_app (g : y ⟶ y') :
     F.obj x ◁ G.map g ≫ (unit F G).app (x, y') =
     (unit F G).app (x, y) ≫ (F ⊛ G).map (x ◁ g) := by
-  simpa [tensorHom_def] using (unit F G).naturality (Prod.mkHom (𝟙 _) g)
+  simpa [tensorHom_def] using (unit F G).naturality (𝟙 _ ×ₘ g)
 
 end unit
 
@@ -126,7 +128,7 @@ variable {F' G' : C ⥤ V} [DayConvolution F' G']
 /-- The morphism between day convolutions (provided they exist) induced by a pair of morphisms. -/
 def map (f : F ⟶ F') (g : G ⟶ G') : F ⊛ G ⟶ F' ⊛ G' :=
   Functor.descOfIsLeftKanExtension (F ⊛ G) (unit F G) (F' ⊛ G') <|
-    (externalProductBifunctor C C V).map (Prod.mkHom f g) ≫ unit F' G'
+    (externalProductBifunctor C C V).map (f ×ₘ g) ≫ unit F' G'
 
 variable (f : F ⟶ F') (g : G ⟶ G') (x y : C)
 
@@ -136,7 +138,7 @@ lemma unit_app_map_app :
     (f.app x ⊗ₘ g.app y) ≫ (unit F' G').app (x, y) := by
   simpa [tensorHom_def] using
     (Functor.descOfIsLeftKanExtension_fac_app (F ⊛ G) (unit F G) (F' ⊛ G') <|
-      (externalProductBifunctor C C V).map (Prod.mkHom f g) ≫ unit F' G') (x, y)
+      (externalProductBifunctor C C V).map (f ×ₘ g) ≫ unit F' G') (x, y)
 
 end map
 

--- a/Mathlib/CategoryTheory/Products/Basic.lean
+++ b/Mathlib/CategoryTheory/Products/Basic.lean
@@ -66,21 +66,11 @@ namespace Prod
 /-- Construct a morphism in a product category by giving its constituent components.
 This constructor should be preferred over `Prod.mk`, because lean infers better the
 source and target of the resulting morphism. -/
-@[simps]
 abbrev mkHom {X₁ X₂ : C} {Y₁ Y₂ : D} (f : X₁ ⟶ X₂) (g : Y₁ ⟶ Y₂) : (X₁, Y₁) ⟶ (X₂, Y₂) :=
   ⟨f,g⟩
 
 @[inherit_doc Prod.mkHom]
 scoped infixr:70 " ×ₘ " => Prod.mkHom
-
-@[reassoc (attr := simp)]
-lemma mkHom_comp {X₁ X₂ X₃ : C} {Y₁ Y₂ Y₃ : D}
-    (f : X₁ ⟶ X₂) (g : Y₁ ⟶ Y₂) (f' : X₂ ⟶ X₃) (g' : Y₂ ⟶ Y₃) :
-    (f ×ₘ g) ≫ (f' ×ₘ g') = (f ≫ f') ×ₘ (g ≫ g') :=
-  rfl
-
-@[simp]
-lemma mkHom_id {X : C} {Y : D} : (𝟙 X) ×ₘ (𝟙 Y) = 𝟙 (X, Y) := rfl
 
 end Prod
 

--- a/Mathlib/CategoryTheory/Products/Basic.lean
+++ b/Mathlib/CategoryTheory/Products/Basic.lean
@@ -57,9 +57,27 @@ theorem prod_comp {P Q R : C} {S T U : D} (f : (P, S) ⟶ (Q, T)) (g : (Q, T) �
     f ≫ g = (f.1 ≫ g.1, f.2 ≫ g.2) :=
   rfl
 
+section
+
+variable {C D}
+
+/-- Construct a morphism in a product category by giving its constituent components.
+This constructor should be preffered over `Prod.mk`, because lean infers better the
+source and target of the resulting morphism. -/
 @[simps]
 def Prod.mkHom {X₁ X₂ : C} {Y₁ Y₂ : D} (f : X₁ ⟶ X₂) (g : Y₁ ⟶ Y₂) : (X₁, Y₁) ⟶ (X₂, Y₂) :=
   ⟨f,g⟩
+
+@[reassoc (attr := simp)]
+lemma Prod.mkHom_comp {X₁ X₂ X₃ : C} {Y₁ Y₂ Y₃ : D}
+    (f : X₁ ⟶ X₂) (g : Y₁ ⟶ Y₂) (f' : X₂ ⟶ X₃) (g' : Y₂ ⟶ Y₃) :
+    Prod.mkHom f g ≫ Prod.mkHom f' g' = Prod.mkHom (f ≫ f') (g ≫ g') :=
+  rfl
+
+@[simp]
+lemma Prod.mkHom_id {X : C} {Y : D} : Prod.mkHom (𝟙 X) (𝟙 Y) = 𝟙 (X, Y) := rfl
+
+end
 
 theorem isIso_prod_iff {P Q : C} {S T : D} {f : (P, S) ⟶ (Q, T)} :
     IsIso f ↔ IsIso f.1 ∧ IsIso f.2 := by
@@ -175,13 +193,13 @@ variable {C D}
 followed by a morphism whose right component is an identity. -/
 @[reassoc]
 lemma fac {x y : C × D} (f : x ⟶ y) :
-    f = ((𝟙 x.1, f.2) : _ ⟶ ⟨x.1, y.2⟩) ≫ (f.1, 𝟙 y.2) := by aesop
+    f = Prod.mkHom (𝟙 x.1) f.2 ≫ Prod.mkHom f.1 (𝟙 y.2) := by aesop
 
 /-- Any morphism in a product factors as a morphsim whose right component is an identity
 followed by a morphism whose left component is an identity. -/
 @[reassoc]
 lemma fac' {x y : C × D} (f : x ⟶ y) :
-    f = ((f.1, 𝟙 x.2) : _ ⟶ ⟨y.1, x.2⟩) ≫ (𝟙 y.1, f.2) := by aesop
+    f = Prod.mkHom f.1 (𝟙 x.2) ≫ Prod.mkHom (𝟙 y.1) f.2 := by aesop
 
 end Prod
 

--- a/Mathlib/CategoryTheory/Products/Basic.lean
+++ b/Mathlib/CategoryTheory/Products/Basic.lean
@@ -62,7 +62,7 @@ section
 variable {C D}
 
 /-- Construct a morphism in a product category by giving its constituent components.
-This constructor should be preffered over `Prod.mk`, because lean infers better the
+This constructor should be preferred over `Prod.mk`, because lean infers better the
 source and target of the resulting morphism. -/
 @[simps]
 def Prod.mkHom {X₁ X₂ : C} {Y₁ Y₂ : D} (f : X₁ ⟶ X₂) (g : Y₁ ⟶ Y₂) : (X₁, Y₁) ⟶ (X₂, Y₂) :=

--- a/Mathlib/CategoryTheory/Products/Basic.lean
+++ b/Mathlib/CategoryTheory/Products/Basic.lean
@@ -57,12 +57,9 @@ theorem prod_comp {P Q R : C} {S T U : D} (f : (P, S) ⟶ (Q, T)) (g : (Q, T) �
     f ≫ g = (f.1 ≫ g.1, f.2 ≫ g.2) :=
   rfl
 
-section
-
-variable {C D}
-
 namespace Prod
 
+variable {C D} in
 /-- Construct a morphism in a product category by giving its constituent components.
 This constructor should be preferred over `Prod.mk`, because lean infers better the
 source and target of the resulting morphism. -/
@@ -73,9 +70,6 @@ abbrev mkHom {X₁ X₂ : C} {Y₁ Y₂ : D} (f : X₁ ⟶ X₂) (g : Y₁ ⟶ Y
 scoped infixr:70 " ×ₘ " => Prod.mkHom
 
 end Prod
-
-end
-
 theorem isIso_prod_iff {P Q : C} {S T : D} {f : (P, S) ⟶ (Q, T)} :
     IsIso f ↔ IsIso f.1 ∧ IsIso f.2 := by
   constructor

--- a/Mathlib/CategoryTheory/Products/Basic.lean
+++ b/Mathlib/CategoryTheory/Products/Basic.lean
@@ -61,21 +61,28 @@ section
 
 variable {C D}
 
+namespace Prod
+
 /-- Construct a morphism in a product category by giving its constituent components.
 This constructor should be preferred over `Prod.mk`, because lean infers better the
 source and target of the resulting morphism. -/
 @[simps]
-abbrev Prod.mkHom {X₁ X₂ : C} {Y₁ Y₂ : D} (f : X₁ ⟶ X₂) (g : Y₁ ⟶ Y₂) : (X₁, Y₁) ⟶ (X₂, Y₂) :=
+abbrev mkHom {X₁ X₂ : C} {Y₁ Y₂ : D} (f : X₁ ⟶ X₂) (g : Y₁ ⟶ Y₂) : (X₁, Y₁) ⟶ (X₂, Y₂) :=
   ⟨f,g⟩
 
+@[inherit_doc Prod.mkHom]
+scoped infixr:70 " ×ₘ " => Prod.mkHom
+
 @[reassoc (attr := simp)]
-lemma Prod.mkHom_comp {X₁ X₂ X₃ : C} {Y₁ Y₂ Y₃ : D}
+lemma mkHom_comp {X₁ X₂ X₃ : C} {Y₁ Y₂ Y₃ : D}
     (f : X₁ ⟶ X₂) (g : Y₁ ⟶ Y₂) (f' : X₂ ⟶ X₃) (g' : Y₂ ⟶ Y₃) :
-    Prod.mkHom f g ≫ Prod.mkHom f' g' = Prod.mkHom (f ≫ f') (g ≫ g') :=
+    (f ×ₘ g) ≫ (f' ×ₘ g') = (f ≫ f') ×ₘ (g ≫ g') :=
   rfl
 
 @[simp]
-lemma Prod.mkHom_id {X : C} {Y : D} : Prod.mkHom (𝟙 X) (𝟙 Y) = 𝟙 (X, Y) := rfl
+lemma mkHom_id {X : C} {Y : D} : (𝟙 X) ×ₘ (𝟙 Y) = 𝟙 (X, Y) := rfl
+
+end Prod
 
 end
 
@@ -192,14 +199,12 @@ variable {C D}
 /-- Any morphism in a product factors as a morphsim whose left component is an identity
 followed by a morphism whose right component is an identity. -/
 @[reassoc]
-lemma fac {x y : C × D} (f : x ⟶ y) :
-    f = Prod.mkHom (𝟙 x.1) f.2 ≫ Prod.mkHom f.1 (𝟙 y.2) := by aesop
+lemma fac {x y : C × D} (f : x ⟶ y) : f = (𝟙 x.1 ×ₘ f.2) ≫ (f.1 ×ₘ (𝟙 y.2)) := by aesop
 
 /-- Any morphism in a product factors as a morphsim whose right component is an identity
 followed by a morphism whose left component is an identity. -/
 @[reassoc]
-lemma fac' {x y : C × D} (f : x ⟶ y) :
-    f = Prod.mkHom f.1 (𝟙 x.2) ≫ Prod.mkHom (𝟙 y.1) f.2 := by aesop
+lemma fac' {x y : C × D} (f : x ⟶ y) : f = (f.1 ×ₘ 𝟙 x.2) ≫ ((𝟙 y.1) ×ₘ f.2) := by aesop
 
 end Prod
 

--- a/Mathlib/CategoryTheory/Products/Basic.lean
+++ b/Mathlib/CategoryTheory/Products/Basic.lean
@@ -65,7 +65,7 @@ variable {C D}
 This constructor should be preferred over `Prod.mk`, because lean infers better the
 source and target of the resulting morphism. -/
 @[simps]
-def Prod.mkHom {X₁ X₂ : C} {Y₁ Y₂ : D} (f : X₁ ⟶ X₂) (g : Y₁ ⟶ Y₂) : (X₁, Y₁) ⟶ (X₂, Y₂) :=
+abbrev Prod.mkHom {X₁ X₂ : C} {Y₁ Y₂ : D} (f : X₁ ⟶ X₂) (g : Y₁ ⟶ Y₂) : (X₁, Y₁) ⟶ (X₂, Y₂) :=
   ⟨f,g⟩
 
 @[reassoc (attr := simp)]

--- a/Mathlib/CategoryTheory/Products/Basic.lean
+++ b/Mathlib/CategoryTheory/Products/Basic.lean
@@ -57,6 +57,10 @@ theorem prod_comp {P Q R : C} {S T U : D} (f : (P, S) ⟶ (Q, T)) (g : (Q, T) �
     f ≫ g = (f.1 ≫ g.1, f.2 ≫ g.2) :=
   rfl
 
+@[simps]
+def Prod.mkHom {X₁ X₂ : C} {Y₁ Y₂ : D} (f : X₁ ⟶ X₂) (g : Y₁ ⟶ Y₂) : (X₁, Y₁) ⟶ (X₂, Y₂) :=
+  ⟨f,g⟩
+
 theorem isIso_prod_iff {P Q : C} {S T : D} {f : (P, S) ⟶ (Q, T)} :
     IsIso f ↔ IsIso f.1 ∧ IsIso f.2 := by
   constructor

--- a/Mathlib/CategoryTheory/Products/Bifunctor.lean
+++ b/Mathlib/CategoryTheory/Products/Bifunctor.lean
@@ -29,21 +29,21 @@ theorem map_id (F : C × D ⥤ E) (X : C) (Y : D) :
 @[simp]
 theorem map_id_comp (F : C × D ⥤ E) (W : C) {X Y Z : D} (f : X ⟶ Y) (g : Y ⟶ Z) :
     F.map (𝟙 W ×ₘ (f ≫ g)) = F.map (𝟙 W ×ₘ f) ≫ F.map (𝟙 W ×ₘ g) := by
-  rw [← Functor.map_comp, Prod.mkHom_comp, Category.comp_id]
+  rw [← Functor.map_comp, prod_comp, Category.comp_id]
 
 @[simp]
 theorem map_comp_id (F : C × D ⥤ E) (X Y Z : C) (W : D) (f : X ⟶ Y) (g : Y ⟶ Z) :
     F.map ((f ≫ g) ×ₘ 𝟙 W) = F.map (f ×ₘ 𝟙 W) ≫ F.map (g ×ₘ 𝟙 W) := by
-  rw [← Functor.map_comp, Prod.mkHom_comp, Category.comp_id]
+  rw [← Functor.map_comp, prod_comp, Category.comp_id]
 
 @[simp]
 theorem diagonal (F : C × D ⥤ E) (X X' : C) (f : X ⟶ X') (Y Y' : D) (g : Y ⟶ Y') :
     F.map (𝟙 X ×ₘ g) ≫ F.map (f ×ₘ 𝟙 Y') = F.map (f ×ₘ g) := by
-  rw [← Functor.map_comp, Prod.mkHom_comp, Category.id_comp, Category.comp_id]
+  rw [← Functor.map_comp, prod_comp, Category.id_comp, Category.comp_id]
 
 @[simp]
 theorem diagonal' (F : C × D ⥤ E) (X X' : C) (f : X ⟶ X') (Y Y' : D) (g : Y ⟶ Y') :
     F.map (f ×ₘ 𝟙 Y) ≫ F.map (𝟙 X' ×ₘ g) = F.map (f ×ₘ g) := by
-  rw [← Functor.map_comp, Prod.mkHom_comp, Category.id_comp, Category.comp_id]
+  rw [← Functor.map_comp, prod_comp, Category.id_comp, Category.comp_id]
 
 end CategoryTheory.Bifunctor

--- a/Mathlib/CategoryTheory/Products/Bifunctor.lean
+++ b/Mathlib/CategoryTheory/Products/Bifunctor.lean
@@ -19,33 +19,31 @@ universe v₁ v₂ v₃ u₁ u₂ u₃
 variable {C : Type u₁} {D : Type u₂} {E : Type u₃}
 variable [Category.{v₁} C] [Category.{v₂} D] [Category.{v₃} E]
 
+open scoped Prod
+
 @[simp]
 theorem map_id (F : C × D ⥤ E) (X : C) (Y : D) :
-    F.map (Prod.mkHom (𝟙 X) (𝟙 Y)) = 𝟙 (F.obj (X, Y)) :=
+    F.map ((𝟙 X) ×ₘ (𝟙 Y)) = 𝟙 (F.obj (X, Y)) :=
   F.map_id (X, Y)
 
 @[simp]
 theorem map_id_comp (F : C × D ⥤ E) (W : C) {X Y Z : D} (f : X ⟶ Y) (g : Y ⟶ Z) :
-    F.map (Prod.mkHom (𝟙 W) (f ≫ g)) =
-      F.map (Prod.mkHom (𝟙 W) f) ≫ F.map (Prod.mkHom (𝟙 W) g) := by
+    F.map (𝟙 W ×ₘ (f ≫ g)) = F.map (𝟙 W ×ₘ f) ≫ F.map (𝟙 W ×ₘ g) := by
   rw [← Functor.map_comp, Prod.mkHom_comp, Category.comp_id]
 
 @[simp]
 theorem map_comp_id (F : C × D ⥤ E) (X Y Z : C) (W : D) (f : X ⟶ Y) (g : Y ⟶ Z) :
-    F.map (Prod.mkHom (f ≫ g) (𝟙 W)) =
-      F.map (Prod.mkHom f (𝟙 W)) ≫ F.map (Prod.mkHom g (𝟙 W)) := by
+    F.map ((f ≫ g) ×ₘ 𝟙 W) = F.map (f ×ₘ 𝟙 W) ≫ F.map (g ×ₘ 𝟙 W) := by
   rw [← Functor.map_comp, Prod.mkHom_comp, Category.comp_id]
 
 @[simp]
 theorem diagonal (F : C × D ⥤ E) (X X' : C) (f : X ⟶ X') (Y Y' : D) (g : Y ⟶ Y') :
-    F.map (Prod.mkHom (𝟙 X) g) ≫ F.map (Prod.mkHom f (𝟙 Y')) =
-      F.map (Prod.mkHom f g) := by
+    F.map (𝟙 X ×ₘ g) ≫ F.map (f ×ₘ 𝟙 Y') = F.map (f ×ₘ g) := by
   rw [← Functor.map_comp, Prod.mkHom_comp, Category.id_comp, Category.comp_id]
 
 @[simp]
 theorem diagonal' (F : C × D ⥤ E) (X X' : C) (f : X ⟶ X') (Y Y' : D) (g : Y ⟶ Y') :
-    F.map (Prod.mkHom f (𝟙 Y)) ≫ F.map (Prod.mkHom (𝟙 X') g) =
-      F.map (Prod.mkHom f g) := by
+    F.map (f ×ₘ 𝟙 Y) ≫ F.map (𝟙 X' ×ₘ g) = F.map (f ×ₘ g) := by
   rw [← Functor.map_comp, Prod.mkHom_comp, Category.id_comp, Category.comp_id]
 
 end CategoryTheory.Bifunctor

--- a/Mathlib/CategoryTheory/Products/Bifunctor.lean
+++ b/Mathlib/CategoryTheory/Products/Bifunctor.lean
@@ -21,31 +21,31 @@ variable [Category.{v₁} C] [Category.{v₂} D] [Category.{v₃} E]
 
 @[simp]
 theorem map_id (F : C × D ⥤ E) (X : C) (Y : D) :
-    F.map ((𝟙 X, 𝟙 Y) : (X, Y) ⟶ (X, Y)) = 𝟙 (F.obj (X, Y)) :=
+    F.map (Prod.mkHom (𝟙 X) (𝟙 Y)) = 𝟙 (F.obj (X, Y)) :=
   F.map_id (X, Y)
 
 @[simp]
 theorem map_id_comp (F : C × D ⥤ E) (W : C) {X Y Z : D} (f : X ⟶ Y) (g : Y ⟶ Z) :
-    F.map ((𝟙 W, f ≫ g) : (W, X) ⟶ (W, Z)) =
-      F.map ((𝟙 W, f) : (W, X) ⟶ (W, Y)) ≫ F.map ((𝟙 W, g) : (W, Y) ⟶ (W, Z)) := by
-  rw [← Functor.map_comp, prod_comp, Category.comp_id]
+    F.map (Prod.mkHom (𝟙 W) (f ≫ g)) =
+      F.map (Prod.mkHom (𝟙 W) f) ≫ F.map (Prod.mkHom (𝟙 W) g) := by
+  rw [← Functor.map_comp, Prod.mkHom_comp, Category.comp_id]
 
 @[simp]
 theorem map_comp_id (F : C × D ⥤ E) (X Y Z : C) (W : D) (f : X ⟶ Y) (g : Y ⟶ Z) :
-    F.map ((f ≫ g, 𝟙 W) : (X, W) ⟶ (Z, W)) =
-      F.map ((f, 𝟙 W) : (X, W) ⟶ (Y, W)) ≫ F.map ((g, 𝟙 W) : (Y, W) ⟶ (Z, W)) := by
-  rw [← Functor.map_comp, prod_comp, Category.comp_id]
+    F.map (Prod.mkHom (f ≫ g) (𝟙 W)) =
+      F.map (Prod.mkHom f (𝟙 W)) ≫ F.map (Prod.mkHom g (𝟙 W)) := by
+  rw [← Functor.map_comp, Prod.mkHom_comp, Category.comp_id]
 
 @[simp]
 theorem diagonal (F : C × D ⥤ E) (X X' : C) (f : X ⟶ X') (Y Y' : D) (g : Y ⟶ Y') :
-    F.map ((𝟙 X, g) : (X, Y) ⟶ (X, Y')) ≫ F.map ((f, 𝟙 Y') : (X, Y') ⟶ (X', Y')) =
-      F.map ((f, g) : (X, Y) ⟶ (X', Y')) := by
-  rw [← Functor.map_comp, prod_comp, Category.id_comp, Category.comp_id]
+    F.map (Prod.mkHom (𝟙 X) g) ≫ F.map (Prod.mkHom f (𝟙 Y')) =
+      F.map (Prod.mkHom f g) := by
+  rw [← Functor.map_comp, Prod.mkHom_comp, Category.id_comp, Category.comp_id]
 
 @[simp]
 theorem diagonal' (F : C × D ⥤ E) (X X' : C) (f : X ⟶ X') (Y Y' : D) (g : Y ⟶ Y') :
-    F.map ((f, 𝟙 Y) : (X, Y) ⟶ (X', Y)) ≫ F.map ((𝟙 X', g) : (X', Y) ⟶ (X', Y')) =
-      F.map ((f, g) : (X, Y) ⟶ (X', Y')) := by
-  rw [← Functor.map_comp, prod_comp, Category.id_comp, Category.comp_id]
+    F.map (Prod.mkHom f (𝟙 Y)) ≫ F.map (Prod.mkHom (𝟙 X') g) =
+      F.map (Prod.mkHom f g) := by
+  rw [← Functor.map_comp, Prod.mkHom_comp, Category.id_comp, Category.comp_id]
 
 end CategoryTheory.Bifunctor


### PR DESCRIPTION
In many instances, constructing morphisms is painful and requires extra type annotations to get lean to accept 
`(f, g)` as a valid morphism in a product category. This is an attempt to provide a constructor that works better.

See [#mathlib4 > product of morphisms in product category](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/product.20of.20morphisms.20in.20product.20category/with/465083415)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
