### PR TITLE
[Merged by Bors] - chore(AlgebraicGeometry/Limits): undeprecate `sigmaOpenCover`

### DIFF
--- a/Mathlib/AlgebraicGeometry/Limits.lean
+++ b/Mathlib/AlgebraicGeometry/Limits.lean
@@ -183,9 +183,11 @@ lemma disjoint_opensRange_sigmaι (i j : ι) (h : i ≠ j) :
   obtain ⟨rfl⟩ := (sigmaι_eq_iff _ _ _ _ _).mp hy
   cases h rfl
 
-/-- The open cover of the coproduct. -/
-@[deprecated (since := "2025-06-02")]
-noncomputable alias sigmaOpenCover := Scheme.IsLocallyDirected.openCover
+/-- The cover of `∐ X` by the `Xᵢ`. -/
+@[simps!]
+noncomputable def sigmaOpenCover [Small.{u} σ] : (∐ g).OpenCover :=
+  (Scheme.IsLocallyDirected.openCover (Discrete.functor g)).copy σ g (Sigma.ι _)
+  (discreteEquiv.symm) (fun _ ↦ Iso.refl _) (fun _ ↦ rfl)
 
 /-- The underlying topological space of the coproduct is homeomorphic to the disjoint union. -/
 noncomputable


### PR DESCRIPTION
The replacement has the indexing type wrapped in `Discrete` which is inconvenient in practice.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
