### PR TITLE
[Merged by Bors] - refactor(MeasureTheory/PMF): Removing `MasurableSet` hypotheses 

### DIFF
--- a/Mathlib/Probability/Distributions/Uniform.lean
+++ b/Mathlib/Probability/Distributions/Uniform.lean
@@ -276,7 +276,7 @@ open scoped Classical in
 @[simp]
 theorem toMeasure_uniformOfFinset_apply [MeasurableSpace α] (ht : MeasurableSet t) :
     (uniformOfFinset s hs).toMeasure t = #{x ∈ s | x ∈ t} / #s :=
-  (toMeasure_apply_eq_toOuterMeasure_apply _ t ht).trans (toOuterMeasure_uniformOfFinset_apply hs t)
+  (toMeasure_apply_eq_toOuterMeasure_apply _ ht).trans (toOuterMeasure_uniformOfFinset_apply hs t)
 
 end Measure
 
@@ -382,7 +382,7 @@ open scoped Classical in
 @[simp]
 theorem toMeasure_ofMultiset_apply [MeasurableSpace α] (ht : MeasurableSet t) :
     (ofMultiset s hs).toMeasure t = (∑' x, (s.filter (· ∈ t)).count x : ℝ≥0∞) / (Multiset.card s) :=
-  (toMeasure_apply_eq_toOuterMeasure_apply _ t ht).trans (toOuterMeasure_ofMultiset_apply hs t)
+  (toMeasure_apply_eq_toOuterMeasure_apply _ ht).trans (toOuterMeasure_ofMultiset_apply hs t)
 
 end Measure
 

--- a/Mathlib/Probability/ProbabilityMassFunction/Basic.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Basic.lean
@@ -274,13 +274,13 @@ theorem toMeasure_apply_eq_toOuterMeasure (s : Set α) : p.toMeasure s = p.toOut
 theorem toMeasure_apply_finset (s : Finset α) : p.toMeasure s = ∑ x ∈ s, p x :=
   (p.toMeasure_apply_eq_toOuterMeasure s).trans (p.toOuterMeasure_apply_finset s)
 
-theorem toMeasure_apply_eq_tsum : p.toMeasure s = ∑' x, s.indicator p x :=
+theorem toMeasure_apply_eq_tsum (s : Set α) : p.toMeasure s = ∑' x, s.indicator p x :=
   (p.toMeasure_apply_eq_toOuterMeasure s).trans (p.toOuterMeasure_apply s)
 
 @[deprecated (since := "2025-06-23")] alias toMeasure_apply_of_finite := toMeasure_apply_eq_tsum
 
 @[simp]
-theorem toMeasure_apply_fintype [Fintype α] : p.toMeasure s = ∑ x, s.indicator p x :=
+theorem toMeasure_apply_fintype (s : Set α) [Fintype α] : p.toMeasure s = ∑ x, s.indicator p x :=
   (p.toMeasure_apply_eq_toOuterMeasure s).trans (p.toOuterMeasure_apply_fintype s)
 
 end MeasurableSingletonClass

--- a/Mathlib/Probability/ProbabilityMassFunction/Basic.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Basic.lean
@@ -206,11 +206,11 @@ section Measure
 /-- Since every set is Carathéodory-measurable under `PMF.toOuterMeasure`,
   we can further extend this `OuterMeasure` to a `Measure` on `α`. -/
 def toMeasure [MeasurableSpace α] (p : PMF α) : Measure α :=
-  p.toOuterMeasure.toMeasure ((toOuterMeasure_caratheodory p).symm ▸ le_top)
+  p.toOuterMeasure.toMeasure (p.toOuterMeasure_caratheodory.symm ▸ le_top)
 
-variable [MeasurableSpace α] (p : PMF α) (s : Set α)
+variable [MeasurableSpace α] (p : PMF α) {s : Set α}
 
-theorem toOuterMeasure_apply_le_toMeasure_apply : p.toOuterMeasure s ≤ p.toMeasure s :=
+theorem toOuterMeasure_apply_le_toMeasure_apply (s : Set α) : p.toOuterMeasure s ≤ p.toMeasure s :=
   le_toMeasure_apply p.toOuterMeasure _ s
 
 theorem toMeasure_apply_eq_toOuterMeasure_apply (hs : MeasurableSet s) :
@@ -218,40 +218,38 @@ theorem toMeasure_apply_eq_toOuterMeasure_apply (hs : MeasurableSet s) :
   toMeasure_apply p.toOuterMeasure _ hs
 
 theorem toMeasure_apply (hs : MeasurableSet s) : p.toMeasure s = ∑' x, s.indicator p x :=
-  (p.toMeasure_apply_eq_toOuterMeasure_apply s hs).trans (p.toOuterMeasure_apply s)
+  (p.toMeasure_apply_eq_toOuterMeasure_apply hs).trans (p.toOuterMeasure_apply s)
 
 theorem toMeasure_apply_singleton (a : α) (h : MeasurableSet ({a} : Set α)) :
     p.toMeasure {a} = p a := by
-  simp [toMeasure_apply_eq_toOuterMeasure_apply _ _ h, toOuterMeasure_apply_singleton]
+  simp [p.toMeasure_apply_eq_toOuterMeasure_apply h, toOuterMeasure_apply_singleton]
 
 theorem toMeasure_apply_eq_zero_iff (hs : MeasurableSet s) :
     p.toMeasure s = 0 ↔ Disjoint p.support s := by
-  rw [toMeasure_apply_eq_toOuterMeasure_apply p s hs, toOuterMeasure_apply_eq_zero_iff]
+  rw [p.toMeasure_apply_eq_toOuterMeasure_apply hs, toOuterMeasure_apply_eq_zero_iff]
 
 theorem toMeasure_apply_eq_one_iff (hs : MeasurableSet s) : p.toMeasure s = 1 ↔ p.support ⊆ s :=
-  (p.toMeasure_apply_eq_toOuterMeasure_apply s hs).symm ▸ p.toOuterMeasure_apply_eq_one_iff s
+  (p.toMeasure_apply_eq_toOuterMeasure_apply hs).symm ▸ p.toOuterMeasure_apply_eq_one_iff s
 
-@[simp]
-theorem toMeasure_apply_inter_support (hs : MeasurableSet s) (hp : MeasurableSet p.support) :
-    p.toMeasure (s ∩ p.support) = p.toMeasure s := by
-  simp [p.toMeasure_apply_eq_toOuterMeasure_apply s hs,
-    p.toMeasure_apply_eq_toOuterMeasure_apply _ (hs.inter hp)]
-
-@[simp]
-theorem restrict_toMeasure_support [MeasurableSingletonClass α] (p : PMF α) :
-    Measure.restrict (toMeasure p) (support p) = toMeasure p := by
-  ext s hs
-  apply (MeasureTheory.Measure.restrict_apply hs).trans
-  apply toMeasure_apply_inter_support p s hs p.support_countable.measurableSet
-
-theorem toMeasure_mono {s t : Set α} (hs : MeasurableSet s) (ht : MeasurableSet t)
+theorem toMeasure_mono {t : Set α} (hs : MeasurableSet s)
     (h : s ∩ p.support ⊆ t) : p.toMeasure s ≤ p.toMeasure t := by
-  simpa only [p.toMeasure_apply_eq_toOuterMeasure_apply, hs, ht] using toOuterMeasure_mono p h
+  rw [p.toMeasure_apply_eq_toOuterMeasure_apply hs]
+  exact (p.toOuterMeasure_mono h).trans (p.toOuterMeasure_apply_le_toMeasure_apply t)
 
-theorem toMeasure_apply_eq_of_inter_support_eq {s t : Set α} (hs : MeasurableSet s)
+@[simp]
+theorem toMeasure_apply_inter_support (hs : MeasurableSet s) :
+    p.toMeasure (s ∩ p.support) = p.toMeasure s :=
+  (measure_mono s.inter_subset_left).antisymm (p.toMeasure_mono hs (refl _))
+
+@[simp]
+theorem restrict_toMeasure_support : p.toMeasure.restrict p.support = p.toMeasure := by
+  ext s hs
+  rw [Measure.restrict_apply hs, p.toMeasure_apply_inter_support hs]
+
+theorem toMeasure_apply_eq_of_inter_support_eq {t : Set α} (hs : MeasurableSet s)
     (ht : MeasurableSet t) (h : s ∩ p.support = t ∩ p.support) : p.toMeasure s = p.toMeasure t := by
   simpa only [p.toMeasure_apply_eq_toOuterMeasure_apply, hs, ht] using
-    toOuterMeasure_apply_eq_of_inter_support_eq p h
+    p.toOuterMeasure_apply_eq_of_inter_support_eq h
 
 section MeasurableSingletonClass
 
@@ -267,18 +265,23 @@ theorem toMeasure_injective : (toMeasure : PMF α → Measure α).Injective := b
 theorem toMeasure_inj {p q : PMF α} : p.toMeasure = q.toMeasure ↔ p = q :=
   toMeasure_injective.eq_iff
 
+theorem toMeasure_apply_eq_toOuterMeasure (s : Set α) : p.toMeasure s = p.toOuterMeasure s := by
+  have hs := (p.support_countable.mono s.inter_subset_right).measurableSet
+  rw [← restrict_toMeasure_support, Measure.restrict_apply' p.support_countable.measurableSet,
+    p.toMeasure_apply_eq_toOuterMeasure_apply hs, toOuterMeasure_apply_inter_support]
+
 @[simp]
 theorem toMeasure_apply_finset (s : Finset α) : p.toMeasure s = ∑ x ∈ s, p x :=
-  (p.toMeasure_apply_eq_toOuterMeasure_apply s s.measurableSet).trans
-    (p.toOuterMeasure_apply_finset s)
+  (p.toMeasure_apply_eq_toOuterMeasure s).trans (p.toOuterMeasure_apply_finset s)
 
-theorem toMeasure_apply_of_finite (hs : s.Finite) : p.toMeasure s = ∑' x, s.indicator p x :=
-  (p.toMeasure_apply_eq_toOuterMeasure_apply s hs.measurableSet).trans (p.toOuterMeasure_apply s)
+theorem toMeasure_apply_eq_tsum : p.toMeasure s = ∑' x, s.indicator p x :=
+  (p.toMeasure_apply_eq_toOuterMeasure s).trans (p.toOuterMeasure_apply s)
+
+@[deprecated (since := "2025-06-23")] alias toMeasure_apply_of_finite := toMeasure_apply_eq_tsum
 
 @[simp]
 theorem toMeasure_apply_fintype [Fintype α] : p.toMeasure s = ∑ x, s.indicator p x :=
-  (p.toMeasure_apply_eq_toOuterMeasure_apply s s.toFinite.measurableSet).trans
-    (p.toOuterMeasure_apply_fintype s)
+  (p.toMeasure_apply_eq_toOuterMeasure s).trans (p.toOuterMeasure_apply_fintype s)
 
 end MeasurableSingletonClass
 
@@ -313,7 +316,7 @@ theorem toPMF_apply (x : α) : μ.toPMF x = μ {x} := rfl
 @[simp]
 theorem toPMF_toMeasure : μ.toPMF.toMeasure = μ :=
   Measure.ext fun s hs => by
-    rw [μ.toPMF.toMeasure_apply s hs, ← μ.tsum_indicator_apply_singleton s hs]
+    rw [μ.toPMF.toMeasure_apply hs, ← μ.tsum_indicator_apply_singleton s hs]
     rfl
 
 end Measure

--- a/Mathlib/Probability/ProbabilityMassFunction/Constructions.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Constructions.lean
@@ -89,8 +89,8 @@ variable {mα : MeasurableSpace α} {mβ : MeasurableSpace β}
 @[simp]
 theorem toMeasure_map_apply (hf : Measurable f)
     (hs : MeasurableSet s) : (p.map f).toMeasure s = p.toMeasure (f ⁻¹' s) := by
-  rw [toMeasure_apply_eq_toOuterMeasure_apply _ s hs,
-    toMeasure_apply_eq_toOuterMeasure_apply _ (f ⁻¹' s) (measurableSet_preimage hf hs)]
+  rw [toMeasure_apply_eq_toOuterMeasure_apply _ hs,
+    toMeasure_apply_eq_toOuterMeasure_apply _ (measurableSet_preimage hf hs)]
   exact toOuterMeasure_map_apply f p s
 
 @[simp]
@@ -189,7 +189,7 @@ theorem toOuterMeasure_ofFinset_apply :
 @[simp]
 theorem toMeasure_ofFinset_apply [MeasurableSpace α] (ht : MeasurableSet t) :
     (ofFinset f s h h').toMeasure t = ∑' x, t.indicator f x :=
-  (toMeasure_apply_eq_toOuterMeasure_apply _ t ht).trans (toOuterMeasure_ofFinset_apply h h' t)
+  (toMeasure_apply_eq_toOuterMeasure_apply _ ht).trans (toOuterMeasure_ofFinset_apply h h' t)
 
 end Measure
 
@@ -231,7 +231,7 @@ theorem toOuterMeasure_ofFintype_apply : (ofFintype f h).toOuterMeasure s = ∑'
 @[simp]
 theorem toMeasure_ofFintype_apply [MeasurableSpace α] (hs : MeasurableSet s) :
     (ofFintype f h).toMeasure s = ∑' x, s.indicator f x :=
-  (toMeasure_apply_eq_toOuterMeasure_apply _ s hs).trans (toOuterMeasure_ofFintype_apply h s)
+  (toMeasure_apply_eq_toOuterMeasure_apply _ hs).trans (toOuterMeasure_ofFintype_apply h s)
 
 end Measure
 

--- a/Mathlib/Probability/ProbabilityMassFunction/Monad.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Monad.lean
@@ -81,7 +81,7 @@ open scoped Classical in
 @[simp]
 theorem toMeasure_pure_apply (hs : MeasurableSet s) :
     (pure a).toMeasure s = if a ∈ s then 1 else 0 :=
-  (toMeasure_apply_eq_toOuterMeasure_apply (pure a) s hs).trans (toOuterMeasure_pure_apply a s)
+  (toMeasure_apply_eq_toOuterMeasure_apply (pure a) hs).trans (toOuterMeasure_pure_apply a s)
 
 theorem toMeasure_pure : (pure a).toMeasure = Measure.dirac a :=
   Measure.ext fun s hs => by rw [toMeasure_pure_apply a s hs, Measure.dirac_apply' a hs]; rfl
@@ -170,10 +170,10 @@ theorem toOuterMeasure_bind_apply :
 @[simp]
 theorem toMeasure_bind_apply [MeasurableSpace β] (hs : MeasurableSet s) :
     (p.bind f).toMeasure s = ∑' a, p a * (f a).toMeasure s :=
-  (toMeasure_apply_eq_toOuterMeasure_apply (p.bind f) s hs).trans
+  (toMeasure_apply_eq_toOuterMeasure_apply (p.bind f) hs).trans
     ((toOuterMeasure_bind_apply p f s).trans
       (tsum_congr fun a =>
-        congr_arg (fun x => p a * x) (toMeasure_apply_eq_toOuterMeasure_apply (f a) s hs).symm))
+        congr_arg (fun x => p a * x) (toMeasure_apply_eq_toOuterMeasure_apply (f a) hs).symm))
 
 end Measure
 
@@ -304,7 +304,7 @@ theorem toOuterMeasure_bindOnSupport_apply :
 theorem toMeasure_bindOnSupport_apply [MeasurableSpace β] (hs : MeasurableSet s) :
     (p.bindOnSupport f).toMeasure s =
       ∑' a, p a * if h : p a = 0 then 0 else (f a h).toMeasure s := by
-  simp only [toMeasure_apply_eq_toOuterMeasure_apply _ _ hs, toOuterMeasure_bindOnSupport_apply]
+  simp only [toMeasure_apply_eq_toOuterMeasure_apply _ hs, toOuterMeasure_bindOnSupport_apply]
 
 end Measure
 


### PR DESCRIPTION
This commit introduces the following generalizations:
- `toMeasure_mono` no longer requires the target set `t` to be measurable.
- `toMeasure_apply_inter_support` no longer requires `p.support` to be measurable.
- `restrict_toMeasure_support` no longer requires a `[MeasurableSingletonClass α]` instance.

In the `[MeasurableSingletonClass α]` context, a new lemma `toMeasure_apply_eq_toOuterMeasure` is added. It shows that `p.toMeasure s = p.toOuterMeasure s` for *any* set `s`.

This lemma is then used to shorten the proofs for:
- `toMeasure_apply_finset`
- `toMeasure_apply_fintype`

A new lemma `toMeasure_apply_eq_tsum` replaces `toMeasure_apply_of_finite`, since the finite assumption is  no longer required.

Additionally, as suggested during review, the argument `s : Set α` is now implicit in several lemmas, as it is inferable from the `hs : MeasurableSet s` hypothesis.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
