### PR TITLE
[Merged by Bors] - perf(Linter/Whitespace): use string slices more

### DIFF
--- a/Mathlib/Tactic/Linter/Whitespace.lean
+++ b/Mathlib/Tactic/Linter/Whitespace.lean
@@ -161,45 +161,45 @@ def parallelScanAux (as : Array FormatError) (L M : String.Slice) : Array Format
   -- original syntax, and for the same amount of characters in the pretty-printed one, since the
   -- pretty-printer *erases* the line break at the end of a single line comment.
   if L.take 3 == "/--".toSlice && M.take 3 == "/--".toSlice then
-    parallelScanAux as (L.drop 3).copy (M.drop 3).copy else
+    parallelScanAux as (L.drop 3) (M.drop 3) else
   if L.take 2 == "--".toSlice then
     let newL := L.dropWhile (· != '\n')
-    let diff := L.positions.count - newL.copy.length
+    let diff := L.positions.count - newL.positions.count
     -- Assumption: if `L` contains an embedded inline comment, so does `M`
     -- (modulo additional whitespace).
     -- This holds because we call this function with `M` being a pretty-printed version of `L`.
     -- If the pretty-printer changes in the future, this code may need to be adjusted.
     let newM := M.dropWhile (· != '-') |>.drop diff
-    parallelScanAux as newL.trimAsciiStart.copy newM.trimAsciiStart.copy else
+    parallelScanAux as newL.trimAsciiStart newM.trimAsciiStart else
   if L.take 2 == "-/".toSlice then
     let newL := L.drop 2 |>.trimAsciiStart
     let newM := M.drop 2 |>.trimAsciiStart
-    parallelScanAux as newL.copy newM.copy else
+    parallelScanAux as newL newM else
   let ls := L.drop 1
   let ms := M.drop 1
   match L.front, M.front with
   | ' ', m =>
     if m.isWhitespace then
-      parallelScanAux as ls.copy ms.trimAsciiStart.copy
+      parallelScanAux as ls ms.trimAsciiStart
     else
-      parallelScanAux (pushFormatError as (mkFormatError L M "extra space")) ls.copy M
+      parallelScanAux (pushFormatError as (mkFormatError L M "extra space")) ls M
   | '\n', m =>
     if m.isWhitespace then
-      parallelScanAux as ls.trimAsciiStart.copy ms.trimAsciiStart.copy
+      parallelScanAux as ls.trimAsciiStart ms.trimAsciiStart
     else
       parallelScanAux
-        (pushFormatError as (mkFormatError L M "remove line break")) ls.trimAsciiStart.copy M
+        (pushFormatError as (mkFormatError L M "remove line break")) ls.trimAsciiStart M
   | l, m => -- `l` is not whitespace
     if l == m then
-      parallelScanAux as ls.copy ms.copy
+      parallelScanAux as ls ms
     else
       if m.isWhitespace then
         parallelScanAux
-          (pushFormatError as (mkFormatError L M "missing space")) L ms.trimAsciiStart.copy
+          (pushFormatError as (mkFormatError L M "missing space")) L ms.trimAsciiStart
     else
       -- If this code is reached, then `L` and `M` differ by something other than whitespace.
       -- This should not happen in practice.
-      pushFormatError as (mkFormatError ls.copy ms.copy "Oh no! (Unreachable?)")
+      pushFormatError as (mkFormatError ls ms "Oh no! (Unreachable?)")
 
 @[inherit_doc parallelScanAux]
 def parallelScan (src fmt : String.Slice) : Array FormatError :=


### PR DESCRIPTION
This will hopefully avoid some overhead from copying strings around (even if the overall effect is small).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
