### PR TITLE
[Merged by Bors] - fix: make one defeq check in `fun_prop` at reducible transparency

### DIFF
--- a/Mathlib/Tactic/FunProp/FunctionData.lean
+++ b/Mathlib/Tactic/FunProp/FunctionData.lean
@@ -251,8 +251,7 @@ def FunctionData.nontrivialDecomposition (fData : FunctionData) : MetaM (Option 
 
     -- check if is non-triviality
     let f' ← fData.toExpr
-    if (← withReducibleAndInstances <| isDefEq f' f) ||
-       (← withReducibleAndInstances <| isDefEq f' g) then
+    if ← withReducibleAndInstances <| isDefEq f' f <||> isDefEq f' g) then
       return none
 
     return (f, g)

--- a/Mathlib/Tactic/FunProp/FunctionData.lean
+++ b/Mathlib/Tactic/FunProp/FunctionData.lean
@@ -251,7 +251,8 @@ def FunctionData.nontrivialDecomposition (fData : FunctionData) : MetaM (Option 
 
     -- check if is non-triviality
     let f' ← fData.toExpr
-    if (← isDefEq f' f) || (← isDefEq f' g) then
+    if (← withReducibleAndInstances <| isDefEq f' f) ||
+       (← withReducibleAndInstances <| isDefEq f' g) then
       return none
 
     return (f, g)

--- a/Mathlib/Tactic/FunProp/FunctionData.lean
+++ b/Mathlib/Tactic/FunProp/FunctionData.lean
@@ -251,7 +251,7 @@ def FunctionData.nontrivialDecomposition (fData : FunctionData) : MetaM (Option 
 
     -- check if is non-triviality
     let f' ← fData.toExpr
-    if ← withReducibleAndInstances <| isDefEq f' f <||> isDefEq f' g) then
+    if (← withReducibleAndInstances <| isDefEq f' f <||> isDefEq f' g) then
       return none
 
     return (f, g)

--- a/MathlibTest/fun_prop_dev.lean
+++ b/MathlibTest/fun_prop_dev.lean
@@ -620,3 +620,12 @@ info: Con
 -/
 #guard_msgs in
 #print_fun_prop_theorems HAdd.hAdd Con
+
+
+def fst (x : α×β) := x.1
+def snd (x : α×β) := x.2
+
+-- make sure that `fun_prop` can't see through `fst` and `snd`
+example (f : α → β → γ) (hf : Con ↿f) : Con (fun x : α×β => f (fst x) (snd x)) := by
+  fail_if_success fun_prop
+  apply silentSorry


### PR DESCRIPTION
`fun_prop`  was running one defeq check at default transparency which led to defeq abuse.

---


The example where I encountered this problem
```
import Mathlib

open ContDiff

-- @[irreducible]
def WithLp.fst {E F p} (x : WithLp p (E × F)) : E := (WithLp.equiv p (E × F) x).1
-- @[irreducible]
def WithLp.snd {E F p} (x : WithLp p (E × F)) : F := (WithLp.equiv p (E × F) x).2

variable {𝕜} [RCLike 𝕜]

@[fun_prop]
theorem WithLp.fst_contDiff
  {E} [NormedAddCommGroup E] [NormedSpace 𝕜 E] {F} [NormedAddCommGroup F] [NormedSpace 𝕜 F] :
  ContDiff 𝕜 ∞ (fun xy : WithLp 2 (E×F) => xy.fst) := sorry

@[fun_prop]
theorem WithLp.snd_contDiff
  {E} [NormedAddCommGroup E] [NormedSpace 𝕜 E] {F} [NormedAddCommGroup F] [NormedSpace 𝕜 F] :
  ContDiff 𝕜 ∞ (fun xy : WithLp 2 (E×F) => xy.snd) := sorry

example (L : ℝ → ℝ → ℝ → ℝ) (hL : ContDiff ℝ ∞ ↿L) (t : ℝ) :
    ContDiff ℝ ∞ ↿(fun (t : ℝ)  (xy : WithLp 2 (ℝ×ℝ)) => L t xy.fst xy.snd) := by

  set_option trace.Meta.Tactic.fun_prop true in
  fun_prop 
```
`fun_prop` fails if `WithLp.fst/snd` are not marked as `irreducible`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
