### PR TITLE
[Merged by Bors] - chore: fix WithLp defeq abuse

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/ProdL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/ProdL2.lean
@@ -43,7 +43,9 @@ variable {E F}
 
 @[simp]
 theorem prod_inner_apply (x y : WithLp 2 (E × F)) :
-    ⟪x, y⟫_𝕜 = ⟪x.fst, y.fst⟫_𝕜 + ⟪x.snd, y.snd⟫_𝕜 := rfl
+    ⟪x, y⟫_𝕜 =
+      ⟪(WithLp.equiv 2 (E × F) x).fst, (WithLp.equiv 2 (E × F) y).fst⟫_𝕜 +
+      ⟪(WithLp.equiv 2 (E × F) x).snd, (WithLp.equiv 2 (E × F) y).snd⟫_𝕜 := rfl
 
 end WithLp
 
@@ -63,9 +65,9 @@ def prod (v : OrthonormalBasis ι₁ 𝕜 E) (w : OrthonormalBasis ι₂ 𝕜 F)
     · unfold Pairwise
       simp only [ne_eq, Basis.map_apply, Basis.prod_apply, LinearMap.coe_inl,
         OrthonormalBasis.coe_toBasis, LinearMap.coe_inr, WithLp.linearEquiv_symm_apply,
-        WithLp.prod_inner_apply, WithLp.equiv_symm_fst, WithLp.equiv_symm_snd, Sum.forall,
-        Sum.elim_inl, Function.comp_apply, inner_zero_right, add_zero, Sum.elim_inr, zero_add,
-        Sum.inl.injEq, not_false_eq_true, inner_zero_left, forall_true_left, implies_true, and_true,
+        WithLp.prod_inner_apply, Equiv.apply_symm_apply, Sum.forall, Sum.elim_inl,
+        Function.comp_apply, inner_zero_right, add_zero, Sum.elim_inr, zero_add, Sum.inl.injEq,
+        reduceCtorEq, not_false_eq_true, inner_zero_left, imp_self, implies_true, and_true,
         Sum.inr.injEq, true_and]
       exact ⟨v.orthonormal.2, w.orthonormal.2⟩)
 


### PR DESCRIPTION
The lemma [WithLp.prod_inner_apply](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/InnerProductSpace/ProdL2.html#WithLp.prod_inner_apply) contained `x.1` with `x : WithLp 2 (E × F)`. Replace it with `(WithLp.equiv 2 (E × F) x).fst`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
