### PR TITLE
[Merged by Bors] - chore: unprime the Prop-valued fields of `Grp_Class`

### DIFF
--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Grp_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Grp_.lean
@@ -31,7 +31,7 @@ def Grp_Class.ofRepresentableBy (F : Cᵒᵖ ⥤ Grp.{w}) (α : (F ⋙ forget _)
     Grp_Class X where
   __ := Mon_Class.ofRepresentableBy X (F ⋙ forget₂ Grp MonCat) α
   inv := α.homEquiv.symm (α.homEquiv (𝟙 _))⁻¹
-  left_inv' := by
+  left_inv := by
     change lift (α.homEquiv.symm (α.homEquiv (𝟙 X))⁻¹) (𝟙 X) ≫
       α.homEquiv.symm (α.homEquiv (fst X X) * α.homEquiv (snd X X)) =
         toUnit X ≫ α.homEquiv.symm 1
@@ -40,7 +40,7 @@ def Grp_Class.ofRepresentableBy (F : Cᵒᵖ ⥤ Grp.{w}) (α : (F ⋙ forget _)
     simp only [Functor.comp_map, ConcreteCategory.forget_map_eq_coe, map_one, map_mul]
     simp only [← ConcreteCategory.forget_map_eq_coe, ← Functor.comp_map, ← α.homEquiv_comp]
     simp [← Functor.comp_obj]
-  right_inv' := by
+  right_inv := by
     change lift (𝟙 X) (α.homEquiv.symm (α.homEquiv (𝟙 X))⁻¹) ≫
       α.homEquiv.symm (α.homEquiv (fst X X) * α.homEquiv (snd X X)) =
         toUnit X ≫ α.homEquiv.symm 1

--- a/Mathlib/CategoryTheory/Monoidal/Grp_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Grp_.lean
@@ -30,8 +30,8 @@ section
 class Grp_Class (X : C) extends Mon_Class X where
   /-- The inverse in a group object -/
   inv : X ⟶ X
-  left_inv' : lift inv (𝟙 X) ≫ mul = toUnit _ ≫ one := by aesop_cat
-  right_inv' : lift (𝟙 X) inv ≫ mul = toUnit _ ≫ one := by aesop_cat
+  left_inv (X) : lift inv (𝟙 X) ≫ mul = toUnit _ ≫ one := by aesop_cat
+  right_inv (X) : lift (𝟙 X) inv ≫ mul = toUnit _ ≫ one := by aesop_cat
 
 namespace Mon_Class
 
@@ -42,11 +42,7 @@ end Mon_Class
 
 namespace Grp_Class
 
-@[reassoc (attr := simp)]
-theorem left_inv (X : C) [Grp_Class X] : lift ι (𝟙 X) ≫ μ = toUnit _ ≫ η := left_inv'
-
-@[reassoc (attr := simp)]
-theorem right_inv (X : C) [Grp_Class X] : lift (𝟙 X) ι ≫ μ = toUnit _ ≫ η := right_inv'
+attribute [reassoc (attr := simp)] left_inv right_inv
 
 @[simps inv]
 instance : Grp_Class (𝟙_ C) where
@@ -347,10 +343,10 @@ noncomputable def mapGrp : Grp_ C ⥤ Grp_ D where
     { F.mapMon.obj A.toMon_ with
       grp :=
       { inv := F.map ι[A.X]
-        left_inv' := by
+        left_inv := by
           simp [← Functor.map_id, Functor.Monoidal.lift_μ_assoc,
             Functor.Monoidal.toUnit_ε_assoc, ← Functor.map_comp]
-        right_inv' := by
+        right_inv := by
           simp [← Functor.map_id, Functor.Monoidal.lift_μ_assoc,
             Functor.Monoidal.toUnit_ε_assoc, ← Functor.map_comp] } }
   map f := F.mapMon.map f

--- a/Mathlib/CategoryTheory/Monoidal/Internal/Types/Grp_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Internal/Types/Grp_.lean
@@ -38,10 +38,10 @@ noncomputable def inverse : Grp.{u} ⥤ Grp_ (Type u) where
     { MonTypeEquivalenceMon.inverse.obj ((forget₂ Grp MonCat).obj A) with
       grp :=
         { inv := ((·⁻¹) : A → A)
-          left_inv' := by
+          left_inv := by
             ext x
             exact inv_mul_cancel (G := A) x
-          right_inv' := by
+          right_inv := by
             ext x
             exact mul_inv_cancel (G := A) x } }
   map f := MonTypeEquivalenceMon.inverse.map ((forget₂ Grp MonCat).map f)


### PR DESCRIPTION
Follow up to #26102

From Toric


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
