### PR TITLE
[Merged by Bors] - chore(Data/Fin/Basic): split off Embedding definitions for Fin

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2906,6 +2906,7 @@ import Mathlib.Data.EReal.Operations
 import Mathlib.Data.Erased
 import Mathlib.Data.FP.Basic
 import Mathlib.Data.Fin.Basic
+import Mathlib.Data.Fin.Embedding
 import Mathlib.Data.Fin.Fin2
 import Mathlib.Data.Fin.FlagRange
 import Mathlib.Data.Fin.Parity

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -171,16 +171,6 @@ theorem min_val {a : Fin n} : min (a : ℕ) n = a := by simp
 
 theorem max_val {a : Fin n} : max (a : ℕ) n = n := by simp
 
-/-- The inclusion map `Fin n → ℕ` is an embedding. -/
-@[simps -fullyApplied apply]
-def valEmbedding : Fin n ↪ ℕ :=
-  ⟨val, val_injective⟩
-
-@[simp]
-theorem equivSubtype_symm_trans_valEmbedding :
-    equivSubtype.symm.toEmbedding.trans valEmbedding = Embedding.subtype (· < n) :=
-  rfl
-
 /-- Use the ordering on `Fin n` for checking recursive definitions.
 
 For example, the following definition is not accepted by the termination checker,
@@ -439,18 +429,6 @@ section Succ
 
 lemma succ_injective (n : ℕ) : Injective (@Fin.succ n) := fun a b ↦ by simp [Fin.ext_iff]
 
-/-- `Fin.succ` as an `Embedding` -/
-def succEmb (n : ℕ) : Fin n ↪ Fin (n + 1) where
-  toFun := succ
-  inj' := succ_injective _
-
-@[simp]
-theorem coe_succEmb : ⇑(succEmb n) = Fin.succ :=
-  rfl
-
-@[deprecated (since := "2025-04-12")]
-alias val_succEmb := coe_succEmb
-
 @[simp]
 theorem exists_succ_eq {x : Fin (n + 1)} : (∃ y, Fin.succ y = x) ↔ x ≠ 0 :=
   ⟨fun ⟨_, hy⟩ => hy ▸ succ_ne_zero _, x.cases (fun h => h.irrefl.elim) (fun _ _ => ⟨_, rfl⟩)⟩
@@ -502,34 +480,6 @@ lemma castLE_injective (hmn : m ≤ n) : Injective (castLE hmn) :=
 lemma castAdd_injective (m n : ℕ) : Injective (@Fin.castAdd m n) := castLE_injective _
 
 lemma castSucc_injective (n : ℕ) : Injective (@Fin.castSucc n) := castAdd_injective _ _
-
-/-- `Fin.castLE` as an `Embedding`, `castLEEmb h i` embeds `i` into a larger `Fin` type. -/
-@[simps apply]
-def castLEEmb (h : n ≤ m) : Fin n ↪ Fin m where
-  toFun := castLE h
-  inj' := castLE_injective _
-
-@[simp, norm_cast] lemma coe_castLEEmb {m n} (hmn : m ≤ n) : castLEEmb hmn = castLE hmn := rfl
-
-/- The next proof can be golfed a lot using `Fintype.card`.
-It is written this way to define `ENat.card` and `Nat.card` without a `Fintype` dependency
-(not done yet). -/
-lemma nonempty_embedding_iff : Nonempty (Fin n ↪ Fin m) ↔ n ≤ m := by
-  refine ⟨fun h ↦ ?_, fun h ↦ ⟨castLEEmb h⟩⟩
-  induction n generalizing m with
-  | zero => exact m.zero_le
-  | succ n ihn =>
-    obtain ⟨e⟩ := h
-    rcases exists_eq_succ_of_ne_zero (pos_iff_nonempty.2 (Nonempty.map e inferInstance)).ne'
-      with ⟨m, rfl⟩
-    refine Nat.succ_le_succ <| ihn ⟨?_⟩
-    refine ⟨fun i ↦ (e.setValue 0 0 i.succ).pred (mt e.setValue_eq_iff.1 i.succ_ne_zero),
-      fun i j h ↦ ?_⟩
-    simpa only [pred_inj, EmbeddingLike.apply_eq_iff_eq, succ_inj] using h
-
-lemma equiv_iff_eq : Nonempty (Fin m ≃ Fin n) ↔ m = n :=
-  ⟨fun ⟨e⟩ ↦ le_antisymm (nonempty_embedding_iff.1 ⟨e⟩) (nonempty_embedding_iff.1 ⟨e.symm⟩),
-    fun h ↦ h ▸ ⟨.refl _⟩⟩
 
 @[simp] lemma castLE_castSucc {n m} (i : Fin n) (h : n + 1 ≤ m) :
     i.castSucc.castLE h = i.castLE (Nat.le_of_succ_le h) :=
@@ -600,22 +550,6 @@ theorem cast_eq_cast (h : n = m) : (Fin.cast h : Fin n → Fin m) = _root_.cast 
   subst h
   ext
   rfl
-
-/-- `Fin.castAdd` as an `Embedding`, `castAddEmb m i` embeds `i : Fin n` in `Fin (n+m)`.
-See also `Fin.natAddEmb` and `Fin.addNatEmb`. -/
-def castAddEmb (m) : Fin n ↪ Fin (n + m) := castLEEmb (le_add_right n m)
-
-@[simp]
-lemma coe_castAddEmb (m) : (castAddEmb m : Fin n → Fin (n + m)) = castAdd m := rfl
-
-lemma castAddEmb_apply (m) (i : Fin n) : castAddEmb m i = castAdd m i := rfl
-
-/-- `Fin.castSucc` as an `Embedding`, `castSuccEmb i` embeds `i : Fin n` in `Fin (n+1)`. -/
-def castSuccEmb : Fin n ↪ Fin (n + 1) := castAddEmb _
-
-@[simp, norm_cast] lemma coe_castSuccEmb : (castSuccEmb : Fin n → Fin (n + 1)) = Fin.castSucc := rfl
-
-lemma castSuccEmb_apply (i : Fin n) : castSuccEmb i = i.castSucc := rfl
 
 theorem castSucc_le_succ {n} (i : Fin n) : i.castSucc ≤ i.succ := Nat.le_succ i
 
@@ -719,18 +653,6 @@ theorem coe_of_injective_castSucc_symm {n : ℕ} (i : Fin n.succ) (hi) :
     ((Equiv.ofInjective castSucc (castSucc_injective _)).symm ⟨i, hi⟩ : ℕ) = i := by
   rw [← coe_castSucc]
   exact congr_arg val (Equiv.apply_ofInjective_symm _ _)
-
-/-- `Fin.addNat` as an `Embedding`, `addNatEmb m i` adds `m` to `i`, generalizes `Fin.succ`. -/
-@[simps! apply]
-def addNatEmb (m) : Fin n ↪ Fin (n + m) where
-  toFun := (addNat · m)
-  inj' a b := by simp [Fin.ext_iff]
-
-/-- `Fin.natAdd` as an `Embedding`, `natAddEmb n i` adds `n` to `i` "on the left". -/
-@[simps! apply]
-def natAddEmb (n) {m} : Fin m ↪ Fin (n + m) where
-  toFun := natAdd n
-  inj' a b := by simp [Fin.ext_iff]
 
 theorem castSucc_castAdd (i : Fin n) : castSucc (castAdd m i) = castAdd (m + 1) i := rfl
 
@@ -1029,12 +951,6 @@ lemma succAbove_right_injective : Injective p.succAbove := by
 /-- Given a fixed pivot `p : Fin (n + 1)`, `p.succAbove` is injective. -/
 lemma succAbove_right_inj : p.succAbove i = p.succAbove j ↔ i = j :=
   succAbove_right_injective.eq_iff
-
-/-- `Fin.succAbove p` as an `Embedding`. -/
-@[simps!]
-def succAboveEmb (p : Fin (n + 1)) : Fin n ↪ Fin (n + 1) := ⟨p.succAbove, succAbove_right_injective⟩
-
-@[simp, norm_cast] lemma coe_succAboveEmb (p : Fin (n + 1)) : p.succAboveEmb = p.succAbove := rfl
 
 @[simp]
 lemma succAbove_ne_zero_zero [NeZero n] {a : Fin (n + 1)} (ha : a ≠ 0) : a.succAbove 0 = 0 := by
@@ -1523,5 +1439,3 @@ protected theorem zero_mul' [NeZero n] (k : Fin n) : (0 : Fin n) * k = 0 := by
 end Mul
 
 end Fin
-
-set_option linter.style.longFile 1700

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis, Keeley Hoek
 -/
 import Mathlib.Data.Int.DivMod
-import Mathlib.Logic.Embedding.Basic
 import Mathlib.Logic.Equiv.Set
 import Mathlib.Tactic.Common
 

--- a/Mathlib/Data/Fin/Embedding.lean
+++ b/Mathlib/Data/Fin/Embedding.lean
@@ -1,0 +1,144 @@
+/-
+Copyright (c) 2017 Robert Y. Lewis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Y. Lewis, Keeley Hoek
+-/
+import Mathlib.Data.Fin.Basic
+
+/-!
+# Embeddings of `Fin n`
+
+`Fin n` is the type whose elements are natural numbers smaller than `n`.
+This file defines embeddings between `Fin n` and other types,
+
+## Main definitions
+
+* `Fin.valEmbedding` : coercion to natural numbers as an `Embedding`;
+* `Fin.succEmb` : `Fin.succ` as an `Embedding`;
+* `Fin.castLEEmb h` : `Fin.castLE` as an `Embedding`, embed `Fin n` into `Fin m`, `h : n ≤ m`;
+* `finCongr` : `Fin.cast` as an `Equiv`, equivalence between `Fin n` and `Fin m` when `n = m`;
+* `Fin.castAddEmb m` : `Fin.castAdd` as an `Embedding`, embed `Fin n` into `Fin (n+m)`;
+* `Fin.castSuccEmb` : `Fin.castSucc` as an `Embedding`, embed `Fin n` into `Fin (n+1)`;
+* `Fin.addNatEmb m i` : `Fin.addNat` as an `Embedding`, add `m` on `i` on the right,
+  generalizes `Fin.succ`;
+* `Fin.natAddEmb n i` : `Fin.natAdd` as an `Embedding`, adds `n` on `i` on the left;
+
+-/
+
+assert_not_exists Monoid Finset
+
+open Fin Nat Function
+
+namespace Fin
+
+variable {n m : ℕ}
+
+section Order
+
+/-!
+### order
+-/
+
+/-- The inclusion map `Fin n → ℕ` is an embedding. -/
+@[simps -fullyApplied apply]
+def valEmbedding : Fin n ↪ ℕ :=
+  ⟨val, val_injective⟩
+
+@[simp]
+theorem equivSubtype_symm_trans_valEmbedding :
+    equivSubtype.symm.toEmbedding.trans valEmbedding = Embedding.subtype (· < n) :=
+  rfl
+
+end Order
+
+section Succ
+
+/-!
+### succ and casts into larger Fin types
+-/
+
+/-- `Fin.succ` as an `Embedding` -/
+def succEmb (n : ℕ) : Fin n ↪ Fin (n + 1) where
+  toFun := succ
+  inj' := succ_injective _
+
+@[simp]
+theorem coe_succEmb : ⇑(succEmb n) = Fin.succ :=
+  rfl
+
+@[deprecated (since := "2025-04-12")]
+alias val_succEmb := coe_succEmb
+
+attribute [simp] castSucc_inj
+
+/-- `Fin.castLE` as an `Embedding`, `castLEEmb h i` embeds `i` into a larger `Fin` type. -/
+@[simps apply]
+def castLEEmb (h : n ≤ m) : Fin n ↪ Fin m where
+  toFun := castLE h
+  inj' := castLE_injective _
+
+@[simp, norm_cast] lemma coe_castLEEmb {m n} (hmn : m ≤ n) : castLEEmb hmn = castLE hmn := rfl
+
+/- The next proof can be golfed a lot using `Fintype.card`.
+It is written this way to define `ENat.card` and `Nat.card` without a `Fintype` dependency
+(not done yet). -/
+lemma nonempty_embedding_iff : Nonempty (Fin n ↪ Fin m) ↔ n ≤ m := by
+  refine ⟨fun h ↦ ?_, fun h ↦ ⟨castLEEmb h⟩⟩
+  induction n generalizing m with
+  | zero => exact m.zero_le
+  | succ n ihn =>
+    obtain ⟨e⟩ := h
+    rcases exists_eq_succ_of_ne_zero (pos_iff_nonempty.2 (Nonempty.map e inferInstance)).ne'
+      with ⟨m, rfl⟩
+    refine Nat.succ_le_succ <| ihn ⟨?_⟩
+    refine ⟨fun i ↦ (e.setValue 0 0 i.succ).pred (mt e.setValue_eq_iff.1 i.succ_ne_zero),
+      fun i j h ↦ ?_⟩
+    simpa only [pred_inj, EmbeddingLike.apply_eq_iff_eq, succ_inj] using h
+
+lemma equiv_iff_eq : Nonempty (Fin m ≃ Fin n) ↔ m = n :=
+  ⟨fun ⟨e⟩ ↦ le_antisymm (nonempty_embedding_iff.1 ⟨e⟩) (nonempty_embedding_iff.1 ⟨e.symm⟩),
+    fun h ↦ h ▸ ⟨.refl _⟩⟩
+
+/-- `Fin.castAdd` as an `Embedding`, `castAddEmb m i` embeds `i : Fin n` in `Fin (n+m)`.
+See also `Fin.natAddEmb` and `Fin.addNatEmb`. -/
+def castAddEmb (m) : Fin n ↪ Fin (n + m) := castLEEmb (le_add_right n m)
+
+@[simp]
+lemma coe_castAddEmb (m) : (castAddEmb m : Fin n → Fin (n + m)) = castAdd m := rfl
+
+lemma castAddEmb_apply (m) (i : Fin n) : castAddEmb m i = castAdd m i := rfl
+
+/-- `Fin.castSucc` as an `Embedding`, `castSuccEmb i` embeds `i : Fin n` in `Fin (n+1)`. -/
+def castSuccEmb : Fin n ↪ Fin (n + 1) := castAddEmb _
+
+@[simp, norm_cast] lemma coe_castSuccEmb : (castSuccEmb : Fin n → Fin (n + 1)) = Fin.castSucc := rfl
+
+lemma castSuccEmb_apply (i : Fin n) : castSuccEmb i = i.castSucc := rfl
+
+/-- `Fin.addNat` as an `Embedding`, `addNatEmb m i` adds `m` to `i`, generalizes `Fin.succ`. -/
+@[simps! apply]
+def addNatEmb (m) : Fin n ↪ Fin (n + m) where
+  toFun := (addNat · m)
+  inj' a b := by simp [Fin.ext_iff]
+
+/-- `Fin.natAdd` as an `Embedding`, `natAddEmb n i` adds `n` to `i` "on the left". -/
+@[simps! apply]
+def natAddEmb (n) {m} : Fin m ↪ Fin (n + m) where
+  toFun := natAdd n
+  inj' a b := by simp [Fin.ext_iff]
+
+end Succ
+
+section SuccAbove
+
+variable {p : Fin (n + 1)}
+
+/-- `Fin.succAbove p` as an `Embedding`. -/
+@[simps!]
+def succAboveEmb (p : Fin (n + 1)) : Fin n ↪ Fin (n + 1) := ⟨p.succAbove, succAbove_right_injective⟩
+
+@[simp, norm_cast] lemma coe_succAboveEmb (p : Fin (n + 1)) : p.succAboveEmb = p.succAbove := rfl
+
+end SuccAbove
+
+end Fin

--- a/Mathlib/Data/Fin/Embedding.lean
+++ b/Mathlib/Data/Fin/Embedding.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis, Keeley Hoek
 -/
 import Mathlib.Data.Fin.Basic
+import Mathlib.Logic.Embedding.Basic
 
 /-!
 # Embeddings of `Fin n`

--- a/Mathlib/Data/Finset/Fin.lean
+++ b/Mathlib/Data/Finset/Fin.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Kim Morrison, Johan Commelin
 -/
 import Mathlib.Data.Finset.Card
-import Mathlib.Data.Fin.Basic
+import Mathlib.Data.Fin.Embedding
 
 /-!
 # Finsets in `Fin n`

--- a/Mathlib/Order/Fin/Basic.lean
+++ b/Mathlib/Order/Fin/Basic.lean
@@ -3,6 +3,7 @@ Copyright (c) 2017 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis, Keeley Hoek
 -/
+import Mathlib.Data.Fin.Embedding
 import Mathlib.Data.Fin.Rev
 import Mathlib.Order.Hom.Basic
 


### PR DESCRIPTION
This PR addresses Tech debt by splitting of embedding-related definitions from Fin.Basic

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
