### PR TITLE
[Merged by Bors] - feat: topology on `PiLp`

### DIFF
--- a/Mathlib/Analysis/Normed/Lp/PiLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/PiLp.lean
@@ -434,6 +434,17 @@ end Aux
 
 /-! ### Instances on finite `L^p` products -/
 
+instance topologicalSpace [∀ i, TopologicalSpace (β i)] : TopologicalSpace (PiLp p β) :=
+  inferInstanceAs <| TopologicalSpace (Π i, β i)
+
+@[fun_prop, continuity]
+theorem continuous_equiv [∀ i, TopologicalSpace (β i)] : Continuous (WithLp.equiv p (Π i, β i)) :=
+  continuous_id
+
+@[fun_prop, continuity]
+theorem continuous_equiv_symm [∀ i, TopologicalSpace (β i)] :
+    Continuous (WithLp.equiv p (Π i, β i)).symm :=
+  continuous_id
 
 instance uniformSpace [∀ i, UniformSpace (β i)] : UniformSpace (PiLp p β) :=
   Pi.uniformSpace _
@@ -446,14 +457,9 @@ theorem uniformContinuous_equiv_symm [∀ i, UniformSpace (β i)] :
     UniformContinuous (WithLp.equiv p (∀ i, β i)).symm :=
   uniformContinuous_id
 
-@[continuity]
-theorem continuous_equiv [∀ i, UniformSpace (β i)] : Continuous (WithLp.equiv p (∀ i, β i)) :=
-  continuous_id
-
-@[continuity]
-theorem continuous_equiv_symm [∀ i, UniformSpace (β i)] :
-    Continuous (WithLp.equiv p (∀ i, β i)).symm :=
-  continuous_id
+instance completeSpace [∀ i, UniformSpace (β i)] [∀ i, CompleteSpace (β i)] :
+    CompleteSpace (PiLp p β) :=
+  inferInstanceAs <| CompleteSpace (Π i, β i)
 
 instance bornology [∀ i, Bornology (β i)] : Bornology (PiLp p β) :=
   Pi.instBornology

--- a/Mathlib/Analysis/Normed/Lp/PiLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/PiLp.lean
@@ -446,6 +446,10 @@ theorem continuous_equiv_symm [∀ i, TopologicalSpace (β i)] :
     Continuous (WithLp.equiv p (Π i, β i)).symm :=
   continuous_id
 
+instance secondCountableTopology [Countable ι] [∀ i, TopologicalSpace (β i)]
+    [∀ i, SecondCountableTopology (β i)] : SecondCountableTopology (PiLp p β) :=
+  inferInstanceAs <| SecondCountableTopology (Π i, β i)
+
 instance uniformSpace [∀ i, UniformSpace (β i)] : UniformSpace (PiLp p β) :=
   Pi.uniformSpace _
 

--- a/Mathlib/Analysis/Normed/Lp/ProdLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/ProdLp.lean
@@ -466,6 +466,11 @@ variable [T0Space α] [T0Space β]
 instance instProdT0Space : T0Space (WithLp p (α × β)) :=
   Prod.instT0Space
 
+variable [SecondCountableTopology α] [SecondCountableTopology β]
+
+instance secondCountableTopology : SecondCountableTopology (WithLp p (α × β)) :=
+  inferInstanceAs <| SecondCountableTopology (α × β)
+
 end TopologicalSpace
 
 section UniformSpace


### PR DESCRIPTION
Add a topology on `PiLp`, along with a `CompleteSpace` instance.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
