### PR TITLE
[Merged by Bors] - doc: Fix swapped doc strings for mabs_div_lt_of_one_le_of_lt

### DIFF
--- a/Mathlib/Algebra/Order/Group/Abs.lean
+++ b/Mathlib/Algebra/Order/Group/Abs.lean
@@ -127,8 +127,8 @@ theorem mabs_div_le_of_one_le_of_le {a b n : G} (one_le_a : 1 ≤ a) (a_le_n : a
   rw [mabs_div_le_iff, div_le_iff_le_mul, div_le_iff_le_mul]
   exact ⟨le_mul_of_le_of_one_le a_le_n one_le_b, le_mul_of_le_of_one_le b_le_n one_le_a⟩
 
-/-- `|a - b| < n` if `0 ≤ a < n` and `0 ≤ b < n`. -/
-@[to_additive "`|a / b|ₘ < n` if `1 ≤ a < n` and `1 ≤ b < n`."]
+/-- `|a / b|ₘ < n` if `1 ≤ a < n` and `1 ≤ b < n`. -/
+@[to_additive "`|a - b| < n` if `0 ≤ a < n` and `0 ≤ b < n`."]
 theorem mabs_div_lt_of_one_le_of_lt {a b n : G} (one_le_a : 1 ≤ a) (a_lt_n : a < n)
     (one_le_b : 1 ≤ b) (b_lt_n : b < n) : |a / b|ₘ < n := by
   rw [mabs_div_lt_iff, div_lt_iff_lt_mul, div_lt_iff_lt_mul]


### PR DESCRIPTION
Fix the swapped doc strings for `mabs_div_lt_of_one_le_of_lt` and its additive version

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
