### PR TITLE
[Merged by Bors] - feat(NumberTheory/Cyclotomic/Basic): generalize some results for cyclotomic field

### DIFF
--- a/Mathlib/FieldTheory/SeparableClosure.lean
+++ b/Mathlib/FieldTheory/SeparableClosure.lean
@@ -207,6 +207,9 @@ algebraic closure. It is indeed a separable closure (`IsSepClosure`) by
 or `IsSepClosure.isGalois`, and every separable extension embeds into it (`IsSepClosed.lift`). -/
 abbrev SeparableClosure : Type _ := separableClosure F (AlgebraicClosure F)
 
+instance SeparableClosure.isSepClosed : IsSepClosed (SeparableClosure F) :=
+  (inferInstanceAs (IsSepClosure F (SeparableClosure F))).sep_closed
+
 /-- `F(S) / F` is a separable extension if and only if all elements of `S` are
 separable elements. -/
 theorem IntermediateField.isSeparable_adjoin_iff_isSeparable {S : Set E} :

--- a/Mathlib/NumberTheory/Cyclotomic/Basic.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Basic.lean
@@ -5,7 +5,7 @@ Authors: Riccardo Brasca
 -/
 import Mathlib.RingTheory.Polynomial.Cyclotomic.Roots
 import Mathlib.NumberTheory.NumberField.Basic
-import Mathlib.FieldTheory.Galois.Basic
+import Mathlib.FieldTheory.SeparableClosure
 
 /-!
 # Cyclotomic extensions
@@ -276,15 +276,26 @@ theorem equiv {C : Type*} [CommRing C] [Algebra A C] [h : IsCyclotomicExtension 
   haveI : IsScalarTower A B C := IsScalarTower.of_algHom f.toAlgHom
   exact (iff_union_singleton_one _ _ _).2 (trans S {1} A B C f.injective)
 
-protected
-theorem neZero [h : IsCyclotomicExtension {n} A B] [IsDomain B] : NeZero (n : B) := by
-  obtain ⟨⟨r, hr⟩, -⟩ := (iff_singleton n A B).1 h
-  exact hr.neZero'
+theorem neZero_of_mem [IsCyclotomicExtension S A B] [IsDomain B] (hn : n ∈ S) : NeZero (n : B) :=
+  (exists_isPrimitiveRoot A B hn NeZero.out).choose_spec.neZero'
+
+theorem neZero_of_mem' [IsCyclotomicExtension S A B] [IsDomain B] (hn : n ∈ S) : NeZero (n : A) :=
+  (neZero_of_mem n S A B hn).nat_of_neZero (algebraMap A B)
 
 protected
-theorem neZero' [IsCyclotomicExtension {n} A B] [IsDomain B] : NeZero (n : A) := by
-  have := IsCyclotomicExtension.neZero n A B
-  exact NeZero.nat_of_neZero (algebraMap A B)
+theorem neZero [IsCyclotomicExtension {n} A B] [IsDomain B] : NeZero (n : B) :=
+  neZero_of_mem n {n} A B (mem_singleton n)
+
+protected
+theorem neZero' [IsCyclotomicExtension {n} A B] [IsDomain B] : NeZero (n : A) :=
+  neZero_of_mem' n {n} A B (mem_singleton n)
+
+/-- A cyclotomic extension is integral. -/
+theorem integral [IsCyclotomicExtension S A B] : Algebra.IsIntegral A B := by
+  rw [← (Subalgebra.equivOfEq _ _ ((IsCyclotomicExtension.iff_adjoin_eq_top S A B).1 ‹_›).2
+    |>.trans Subalgebra.topEquiv).isIntegral_iff]
+  exact Algebra.IsIntegral.adjoin fun x ⟨n, hn, h1, h2⟩ ↦
+    ⟨X ^ n - 1, monic_X_pow_sub_C 1 h1, by simp [h2]⟩
 
 end Basic
 
@@ -335,12 +346,6 @@ theorem numberField [h : NumberField K] [Finite S] [IsCyclotomicExtension S K L]
       haveI := charZero_of_injective_algebraMap (algebraMap K L).injective
       haveI := IsCyclotomicExtension.finite S K L
       exact Module.Finite.trans K _ }
-
-/-- A finite cyclotomic extension of an integral noetherian domain is integral -/
-theorem integral [IsDomain B] [IsNoetherianRing A] [Finite S] [IsCyclotomicExtension S A B] :
-    Algebra.IsIntegral A B :=
-  have := IsCyclotomicExtension.finite S A B
-  ⟨isIntegral_of_noetherian inferInstance⟩
 
 /-- If `S` is finite and `IsCyclotomicExtension S K A`, then `finiteDimensional K A`. -/
 theorem finiteDimensional (C : Type z) [Finite S] [CommRing C] [Algebra K C] [IsDomain C]
@@ -439,6 +444,97 @@ theorem splits_cyclotomic [IsCyclotomicExtension S K L] (hS : n ∈ S) :
 
 variable (n S)
 
+theorem isSeparable [IsCyclotomicExtension S K L] : Algebra.IsSeparable K L := by
+  have := integral S K L
+  have h := (IsCyclotomicExtension.iff_adjoin_eq_top S K L).1 ‹_› |>.2
+  rw [← IntermediateField.adjoin_algebraic_toSubalgebra
+    fun b _ ↦ Algebra.IsAlgebraic.isAlgebraic b, ← IntermediateField.top_toSubalgebra] at h
+  rw [← AlgEquiv.Algebra.isSeparable_iff <|
+    (IntermediateField.equivOfEq (IntermediateField.toSubalgebra_injective h)).trans
+      IntermediateField.topEquiv, IntermediateField.isSeparable_adjoin_iff_isSeparable]
+  rintro b ⟨n, hn, h1, h2⟩
+  have := NeZero.mk h1
+  have := Polynomial.X_pow_sub_one_separable_iff.2 (neZero_of_mem' n S K L hn).out
+  exact this.of_dvd <| minpoly.dvd K b <| by simp [h2]
+
+theorem nonempty_algEquiv_adjoin [IsCyclotomicExtension S K L]
+    (M : Type*) [Field M] [Algebra K M] [IsSepClosed M] :
+    Nonempty (L ≃ₐ[K] IntermediateField.adjoin K {x : M | ∃ n ∈ S, n ≠ 0 ∧ x ^ n = 1}) := by
+  have := isSeparable S K L
+  let i : L →ₐ[K] M := IsSepClosed.lift
+  refine ⟨(show L ≃ₐ[K] i.fieldRange from AlgEquiv.ofInjectiveField i).trans
+    (IntermediateField.equivOfEq (le_antisymm ?_ ?_))⟩
+  · rintro x (hx : x ∈ i.range)
+    let e := Subalgebra.equivOfEq _ _ ((IsCyclotomicExtension.iff_adjoin_eq_top S K L).1 ‹_›).2
+      |>.trans Subalgebra.topEquiv
+    have hrange : i.range = (i.comp (AlgHomClass.toAlgHom e)).range := by
+      ext x
+      simp only [AlgHom.mem_range, AlgHom.coe_comp, AlgHom.coe_coe, Function.comp_apply]
+      constructor
+      · rintro ⟨y, rfl⟩; exact ⟨e.symm y, by simp⟩
+      · rintro ⟨y, rfl⟩; exact ⟨e y, rfl⟩
+    rw [hrange, AlgHom.mem_range] at hx
+    obtain ⟨⟨y, hy⟩, rfl⟩ := hx
+    induction hy using Algebra.adjoin_induction with
+    | mem x hx =>
+      obtain ⟨n, hn, h1, h2⟩ := hx
+      apply IntermediateField.subset_adjoin
+      use n, hn, h1
+      rw [← map_pow, ← map_one (i.comp (AlgHomClass.toAlgHom e))]
+      congr 1
+      apply_fun _ using Subtype.val_injective
+      simpa
+    | algebraMap x =>
+      convert IntermediateField.algebraMap_mem _ x
+      exact AlgHom.commutes _ x
+    | add x y hx hy ihx ihy =>
+      convert add_mem ihx ihy
+      exact map_add (i.comp (AlgHomClass.toAlgHom e)) ⟨x, hx⟩ ⟨y, hy⟩
+    | mul x y hx hy ihx ihy =>
+      convert mul_mem ihx ihy
+      exact map_mul (i.comp (AlgHomClass.toAlgHom e)) ⟨x, hx⟩ ⟨y, hy⟩
+  · rw [IntermediateField.adjoin_le_iff]
+    rintro x ⟨n, hn, h1, h2⟩
+    have := NeZero.mk h1
+    obtain ⟨y, hy⟩ := exists_isPrimitiveRoot K L hn h1
+    obtain ⟨m, -, rfl⟩ := (hy.map_of_injective (f := i) i.injective).eq_pow_of_pow_eq_one h2
+    exact ⟨y ^ m, by simp⟩
+
+theorem isGalois [IsCyclotomicExtension S K L] : IsGalois K L := by
+  rw [isGalois_iff]
+  use isSeparable S K L
+  obtain ⟨i⟩ := nonempty_algEquiv_adjoin S K L (AlgebraicClosure K)
+  rw [i.transfer_normal, IntermediateField.normal_iff_forall_map_le]
+  intro f x hx
+  change x ∈ IntermediateField.toSubalgebra _ at hx
+  rw [IntermediateField.toSubalgebra_map, Subalgebra.mem_map] at hx
+  obtain ⟨y, hy, rfl⟩ := hx
+  change y ∈ IntermediateField.adjoin _ _ at hy
+  induction hy using IntermediateField.adjoin_induction with
+  | mem x hx =>
+    obtain ⟨n, hn, h1, h2⟩ := hx
+    apply IntermediateField.subset_adjoin
+    use n, hn, h1
+    rw [← map_pow, ← map_one f, h2]
+  | algebraMap x =>
+    convert IntermediateField.algebraMap_mem _ x
+    exact AlgHom.commutes _ x
+  | add x y hx hy ihx ihy =>
+    rw [map_add]
+    exact add_mem ihx ihy
+  | mul x y hx hy ihx ihy =>
+    rw [map_mul]
+    exact mul_mem ihx ihy
+  | inv x hx ihx =>
+    rw [map_inv₀]
+    exact inv_mem ihx
+
+/-- Any two cyclotomic extensions with respect to `S` are isomorphic. -/
+noncomputable def algEquiv [IsCyclotomicExtension S K L]
+    (L' : Type*) [Field L'] [Algebra K L'] [IsCyclotomicExtension S K L'] : L ≃ₐ[K] L' :=
+  (nonempty_algEquiv_adjoin S K L (AlgebraicClosure K)).some.trans
+    (nonempty_algEquiv_adjoin S K L' (AlgebraicClosure K)).some.symm
+
 section Singleton
 
 variable [IsCyclotomicExtension {n} K L]
@@ -456,21 +552,7 @@ theorem isSplittingField_X_pow_sub_one : IsSplittingField K L (X ^ n - 1) :=
         and_iff_right_iff_imp, Polynomial.map_sub, Polynomial.map_pow, Polynomial.map_one]
       exact fun _ => X_pow_sub_C_ne_zero (NeZero.pos n) (1 : L) }
 
-/-- Any two `n`-th cyclotomic extensions are isomorphic. -/
-def algEquiv (L' : Type*) [Field L'] [Algebra K L'] [IsCyclotomicExtension {n} K L'] :
-    L ≃ₐ[K] L' :=
-  let h₁ := isSplittingField_X_pow_sub_one n K L
-  let h₂ := isSplittingField_X_pow_sub_one n K L'
-  (@IsSplittingField.algEquiv K L _ _ _ (X ^ n - 1) h₁).trans
-    (@IsSplittingField.algEquiv K L' _ _ _ (X ^ n - 1) h₂).symm
-
 scoped[Cyclotomic] attribute [instance] IsCyclotomicExtension.isSplittingField_X_pow_sub_one
-
-include n in
-theorem isGalois : IsGalois K L :=
-  letI := isSplittingField_X_pow_sub_one n K L
-  IsGalois.of_separable_splitting_field (X_pow_sub_one_separable_iff.2
-    (IsCyclotomicExtension.neZero' n K L).1)
 
 /-- If `IsCyclotomicExtension {n} K L`, then `L` is the splitting field of `cyclotomic n K`. -/
 theorem splitting_field_cyclotomic : IsSplittingField K L (cyclotomic n K) :=
@@ -541,18 +623,13 @@ variable [Algebra A K]
 
 section CyclotomicRing
 
-/-- If `K` is the fraction field of `A`, the `A`-algebra structure on `CyclotomicField n K`.
+/-- If `K` is an `A`-algebra, the `A`-algebra structure on `CyclotomicField n K`.
 -/
-@[nolint unusedArguments]
 instance CyclotomicField.algebraBase : Algebra A (CyclotomicField n K) :=
   SplittingField.algebra' (cyclotomic n K)
 
 /-- Ensure there are no diamonds when `A = ℤ` but there are `reducible_and_instances` https://github.com/leanprover-community/mathlib4/issues/10906 -/
 example : Ring.toIntAlgebra (CyclotomicField n ℚ) = CyclotomicField.algebraBase _ _ _ := rfl
-
-instance CyclotomicField.algebra' {R : Type*} [CommRing R] [Algebra R K] :
-    Algebra R (CyclotomicField n K) :=
-  SplittingField.algebra' (cyclotomic n K)
 
 instance {R : Type*} [CommRing R] [Algebra R K] : IsScalarTower R K (CyclotomicField n K) :=
   SplittingField.isScalarTower _
@@ -688,24 +765,34 @@ end CyclotomicRing
 
 end IsDomain
 
-section IsAlgClosed
+-- TODO: move to suitable place
+theorem Polynomial.separable_cyclotomic (n : ℕ) (K : Type*) [Field K] [NeZero (n : K)] :
+    (cyclotomic n K).Separable :=
+  .of_dvd (separable_X_pow_sub_C 1 NeZero.out one_ne_zero) (cyclotomic.dvd_X_pow_sub_one n K)
 
-variable [IsAlgClosed K]
+section IsSepClosed
 
-/-- Algebraically closed fields are `S`-cyclotomic extensions over themselves if
+variable [IsSepClosed K]
+
+/-- Separably closed fields are `S`-cyclotomic extensions over themselves if
 `NeZero ((a : ℕ) : K))` for all nonzero `a ∈ S`. -/
-theorem IsAlgClosed.isCyclotomicExtension (h : ∀ a ∈ S, a ≠ 0 → NeZero (a : K)) :
+theorem IsSepClosed.isCyclotomicExtension (h : ∀ a ∈ S, a ≠ 0 → NeZero (a : K)) :
     IsCyclotomicExtension S K K := by
-  rw [IsCyclotomicExtension.eq_self_sdiff_zero]
   refine ⟨@fun a ha ha' ↦ ?_, Algebra.eq_top_iff.mp <| Subsingleton.elim _ _⟩
-  obtain ⟨r, hr⟩ := IsAlgClosed.exists_aeval_eq_zero K _
-    (degree_cyclotomic_pos a K (Nat.pos_of_ne_zero ha')).ne'
-  have : NeZero (a : K) := h a (mem_of_mem_diff ha) ha'
-  exact ⟨r,  by rwa [coe_aeval_eq_eval, ← IsRoot.def, isRoot_cyclotomic_iff] at hr⟩
+  have := h a ha ha'
+  obtain ⟨r, hr⟩ := IsSepClosed.exists_aeval_eq_zero K _
+    (degree_cyclotomic_pos a K (Nat.pos_of_ne_zero ha')).ne' (separable_cyclotomic a K)
+  exact ⟨r, by rwa [coe_aeval_eq_eval, ← IsRoot.def, isRoot_cyclotomic_iff] at hr⟩
 
-instance IsAlgClosedOfCharZero.isCyclotomicExtension [CharZero K] :
+@[deprecated (since := "2025-06-22")]
+alias IsAlgClosed.isCyclotomicExtension := IsSepClosed.isCyclotomicExtension
+
+instance IsSepClosedOfCharZero.isCyclotomicExtension [CharZero K] :
     ∀ S, IsCyclotomicExtension S K K := fun S => by
   rw [IsCyclotomicExtension.eq_self_sdiff_zero]
-  exact IsAlgClosed.isCyclotomicExtension _ K fun _ _ h ↦ ⟨Nat.cast_ne_zero.mpr h⟩
+  exact IsSepClosed.isCyclotomicExtension _ K fun _ _ h ↦ ⟨Nat.cast_ne_zero.mpr h⟩
 
-end IsAlgClosed
+@[deprecated (since := "2025-06-22")]
+alias IsAlgClosedOfCharZero.isCyclotomicExtension := IsSepClosedOfCharZero.isCyclotomicExtension
+
+end IsSepClosed

--- a/Mathlib/NumberTheory/Cyclotomic/Basic.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Basic.lean
@@ -564,13 +564,10 @@ noncomputable def algEquiv [IsCyclotomicExtension S K L]
     (nonempty_algEquiv_adjoin_of_isSepClosed S K L' (AlgebraicClosure K)).some.symm
 
 theorem nonempty_algEquiv_adjoin_of_exists_isPrimitiveRoot [IsCyclotomicExtension S K L]
-    (M : Type*) [Field M] [Algebra K M] [IsSepClosed M]
-    (h : ∀ n ∈ S, n ≠ 0 → ∃ r : M, IsPrimitiveRoot r n) :
-    Nonempty (L ≃ₐ[K] IntermediateField.adjoin K {x : M | ∃ n ∈ S, n ≠ 0 ∧ x ^ n = 1}) := by
-  let L' := IntermediateField.adjoin K {x : M | ∃ n ∈ S, n ≠ 0 ∧ x ^ n = 1}
-  have : IsCyclotomicExtension S K L' :=
-    IntermediateField.isCyclotomicExtension_adjoin_of_exists_isPrimitiveRoot S K M h
-  exact ⟨algEquiv S K L L'⟩
+    (M : Type*) [Field M] [Algebra K M] (h : ∀ n ∈ S, n ≠ 0 → ∃ r : M, IsPrimitiveRoot r n) :
+    Nonempty (L ≃ₐ[K] IntermediateField.adjoin K {x : M | ∃ n ∈ S, n ≠ 0 ∧ x ^ n = 1}) :=
+  have := IntermediateField.isCyclotomicExtension_adjoin_of_exists_isPrimitiveRoot S K M h
+  ⟨algEquiv S K L _⟩
 
 section Singleton
 

--- a/Mathlib/NumberTheory/Cyclotomic/Discriminant.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Discriminant.lean
@@ -62,7 +62,7 @@ theorem discr_prime_pow_ne_two [IsCyclotomicExtension {p ^ (k + 1)} K L] [hp : F
       (-1) ^ ((p ^ (k + 1)).totient / 2) * p ^ (p ^ k * ((p - 1) * (k + 1) - 1)) := by
   haveI hne := IsCyclotomicExtension.neZero' (p ^ (k + 1)) K L
   haveI mf : Module.Finite K L := finiteDimensional {p ^ (k + 1)} K L
-  haveI se : Algebra.IsSeparable K L := (isGalois (p ^ (k + 1)) K L).to_isSeparable
+  haveI se : Algebra.IsSeparable K L := isSeparable {p ^ (k + 1)} K L
   rw [discr_powerBasis_eq_norm, finrank L hirr, hζ.powerBasis_gen _,
     ← hζ.minpoly_eq_cyclotomic_of_irreducible hirr, totient_prime_pow hp.out (succ_pos k),
     Nat.add_one_sub_one]

--- a/Mathlib/NumberTheory/Cyclotomic/PrimitiveRoots.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/PrimitiveRoots.lean
@@ -333,7 +333,7 @@ theorem sub_one_norm_eq_eval_cyclotomic [IsCyclotomicExtension {n} K L] (h : 2 <
   obtain ⟨z, hz⟩ := IsAlgClosed.exists_root _ (degree_cyclotomic_pos n E (NeZero.pos _)).ne.symm
   apply (algebraMap K E).injective
   letI := IsCyclotomicExtension.finiteDimensional {n} K L
-  letI := IsCyclotomicExtension.isGalois n K L
+  letI := IsCyclotomicExtension.isGalois {n} K L
   rw [norm_eq_prod_embeddings]
   conv_lhs =>
     congr
@@ -417,7 +417,7 @@ theorem norm_pow_sub_one_of_prime_pow_ne_two {k s : ℕ} (hζ : IsPrimitiveRoot 
     convert hη using 1
     rw [Nat.sub_add_comm hs]
   have := IsCyclotomicExtension.finiteDimensional {p ^ (k + 1)} K L
-  have := IsCyclotomicExtension.isGalois (p ^ (k + 1)) K L
+  have := IsCyclotomicExtension.isGalois {p ^ (k + 1)} K L
   rw [norm_eq_norm_adjoin K]
   have H := hη.sub_one_norm_isPrimePow ?_ hirr₁ htwo
   swap; · exact hpri.1.isPrimePow.pow (Nat.succ_ne_zero _)

--- a/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
@@ -296,14 +296,14 @@ private lemma ringChar_ne : ringChar ℂ ≠ ringChar F := by
 /-- A primitive additive character on the finite field `F` with values in `ℂ`. -/
 noncomputable def FiniteField.primitiveChar_to_Complex : AddChar F ℂ := by
   letI ch := primitiveChar F ℂ <| ringChar_ne F
-  refine  MonoidHom.compAddChar ?_ ch.char
-  exact (IsCyclotomicExtension.algEquiv {ch.n} ℂ (CyclotomicField ch.n ℂ) ℂ).toMonoidHom
+  refine MonoidHom.compAddChar ?_ ch.char
+  exact (IsCyclotomicExtension.algEquiv {(ch.n : ℕ)} ℂ (CyclotomicField ch.n ℂ) ℂ).toMonoidHom
 
 lemma FiniteField.primitiveChar_to_Complex_isPrimitive :
     (primitiveChar_to_Complex F).IsPrimitive := by
   refine IsPrimitive.compMulHom_of_isPrimitive (PrimitiveAddChar.prim _) ?_
   let nn := (primitiveChar F ℂ <| ringChar_ne F).n
-  exact (IsCyclotomicExtension.algEquiv {nn} ℂ (CyclotomicField nn ℂ) ℂ).injective
+  exact (IsCyclotomicExtension.algEquiv {(nn : ℕ)} ℂ (CyclotomicField nn ℂ) ℂ).injective
 
 end Field
 

--- a/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
@@ -297,13 +297,13 @@ private lemma ringChar_ne : ringChar ℂ ≠ ringChar F := by
 noncomputable def FiniteField.primitiveChar_to_Complex : AddChar F ℂ := by
   letI ch := primitiveChar F ℂ <| ringChar_ne F
   refine  MonoidHom.compAddChar ?_ ch.char
-  exact (IsCyclotomicExtension.algEquiv {ch.n.1} ℂ (CyclotomicField ch.n ℂ) ℂ).toMonoidHom
+  exact (IsCyclotomicExtension.algEquiv {ch.n} ℂ (CyclotomicField ch.n ℂ) ℂ).toMonoidHom
 
 lemma FiniteField.primitiveChar_to_Complex_isPrimitive :
     (primitiveChar_to_Complex F).IsPrimitive := by
   refine IsPrimitive.compMulHom_of_isPrimitive (PrimitiveAddChar.prim _) ?_
   let nn := (primitiveChar F ℂ <| ringChar_ne F).n
-  exact (IsCyclotomicExtension.algEquiv {nn.1} ℂ (CyclotomicField nn ℂ) ℂ).injective
+  exact (IsCyclotomicExtension.algEquiv {nn} ℂ (CyclotomicField nn ℂ) ℂ).injective
 
 end Field
 

--- a/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
@@ -297,13 +297,13 @@ private lemma ringChar_ne : ringChar ℂ ≠ ringChar F := by
 noncomputable def FiniteField.primitiveChar_to_Complex : AddChar F ℂ := by
   letI ch := primitiveChar F ℂ <| ringChar_ne F
   refine  MonoidHom.compAddChar ?_ ch.char
-  exact (IsCyclotomicExtension.algEquiv ch.n ℂ (CyclotomicField ch.n ℂ) ℂ).toMonoidHom
+  exact (IsCyclotomicExtension.algEquiv {ch.n.1} ℂ (CyclotomicField ch.n ℂ) ℂ).toMonoidHom
 
 lemma FiniteField.primitiveChar_to_Complex_isPrimitive :
     (primitiveChar_to_Complex F).IsPrimitive := by
   refine IsPrimitive.compMulHom_of_isPrimitive (PrimitiveAddChar.prim _) ?_
   let nn := (primitiveChar F ℂ <| ringChar_ne F).n
-  exact (IsCyclotomicExtension.algEquiv nn ℂ (CyclotomicField nn ℂ) ℂ).injective
+  exact (IsCyclotomicExtension.algEquiv {nn.1} ℂ (CyclotomicField nn ℂ) ℂ).injective
 
 end Field
 

--- a/Mathlib/RingTheory/RootsOfUnity/AlgebraicallyClosed.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/AlgebraicallyClosed.lean
@@ -9,23 +9,61 @@ import Mathlib.NumberTheory.Cyclotomic.Basic
 /-!
 # Instances for HasEnoughRootsOfUnity
 
-We provide an instance for `HasEnoughRootsOfUnity F n` when `F` is an algebraically closed field
+We provide an instance for `HasEnoughRootsOfUnity F n` when `F` is a separably closed field
 and `n` is not divisible by the characteristic. In particular, when `F` has characteristic zero,
 this hold for all `n ≠ 0`.
 -/
 
-namespace IsAlgClosed
+variable (F : Type*) [Field F] (n k : ℕ) [NeZero (n : F)]
 
-/-- An algebraically closed field `F` satisfies `HasEnoughRootsOfUnity F n` for all `n`
+namespace IsSepClosed
+
+variable [IsSepClosed F]
+
+/-- A separably closed field `F` satisfies `HasEnoughRootsOfUnity F n` for all `n`
 that are not divisible by the characteristic of `F`. -/
-instance hasEnoughRootsOfUnity (F : Type*) [Field F] [IsAlgClosed F] (n : ℕ) [i : NeZero (n : F)] :
-    HasEnoughRootsOfUnity F n where
+instance hasEnoughRootsOfUnity : HasEnoughRootsOfUnity F n where
   prim := by
     have : NeZero n := .of_neZero_natCast F
-    have := isCyclotomicExtension {n} F fun _ h _ ↦ Set.mem_singleton_iff.mp h ▸ i
+    have := isCyclotomicExtension {n} F fun _ h _ ↦ Set.mem_singleton_iff.mp h ▸ ‹NeZero (n : F)›
     exact IsCyclotomicExtension.exists_isPrimitiveRoot (S := {n}) F _ rfl (NeZero.ne _)
   cyc :=
     have : NeZero n := .of_neZero_natCast F
     rootsOfUnity.isCyclic F n
 
-end IsAlgClosed
+instance hasEnoughRootsOfUnity_pow : HasEnoughRootsOfUnity F (n ^ k) :=
+  have : NeZero ((n ^ k : ℕ) : F) := by exact_mod_cast ‹NeZero (n : F)›.pow
+  inferInstance
+
+end IsSepClosed
+
+@[deprecated (since := "2025-06-22")]
+alias IsAlgClosed.hasEnoughRootsOfUnity := IsSepClosed.hasEnoughRootsOfUnity
+
+namespace AlgebraicClosure
+
+instance hasEnoughRootsOfUnity : HasEnoughRootsOfUnity (AlgebraicClosure F) n :=
+  have : NeZero (n : AlgebraicClosure F) :=
+    ‹NeZero (n : F)›.of_injective (algebraMap F (AlgebraicClosure F)).injective
+  inferInstance
+
+instance hasEnoughRootsOfUnity_pow : HasEnoughRootsOfUnity (AlgebraicClosure F) (n ^ k) :=
+  have : NeZero (n : AlgebraicClosure F) :=
+    ‹NeZero (n : F)›.of_injective (algebraMap F (AlgebraicClosure F)).injective
+  inferInstance
+
+end AlgebraicClosure
+
+namespace SeparableClosure
+
+instance hasEnoughRootsOfUnity : HasEnoughRootsOfUnity (SeparableClosure F) n :=
+  have : NeZero (n : SeparableClosure F) :=
+    ‹NeZero (n : F)›.of_injective (algebraMap F (SeparableClosure F)).injective
+  inferInstance
+
+instance hasEnoughRootsOfUnity_pow : HasEnoughRootsOfUnity (SeparableClosure F) (n ^ k) :=
+  have : NeZero (n : SeparableClosure F) :=
+    ‹NeZero (n : F)›.of_injective (algebraMap F (SeparableClosure F)).injective
+  inferInstance
+
+end SeparableClosure


### PR DESCRIPTION
- generalize `IsCyclotomicExtension.neZero[']` to `IsCyclotomicExtension.neZero_of_mem[']` which states that any non-zero element in `S` is non-zero in the ring
- generalize `IsCyclotomicExtension.integral` to any ring, without Noetherian and finiteness of `S`
- add `IsCyclotomicExtension.isSeparable` that any cyclotomic extension is separable
- add `IsCyclotomicExtension.nonempty_algEquiv_adjoin_of_(isSepClosed|exists_isPrimitiveRoot)` that any cyclotomic extension is isomorphic to a field extension adjoin roots of unity
- add `(Algebra|IntermediateField).isCyclotomicExtension_adjoin_of_exists_isPrimitiveRoot` that an algebra or field extension adjoin roots of unity is cyclotomic
- generalize `IsCyclotomicExtension.isGalois` to any cyclotomic extension
- generalize `IsCyclotomicExtension.algEquiv` to any cyclotomic extension
- remove duplicated instance `CyclotomicField.algebra'` (was different in mathlib3, but becomes the same in mathlib4)
- generalize some results from `IsAlgClosed` to `IsSepClosed`
- add a missing instance `SeparableClosure.isSepClosed`
- add some more instances for `HasEnoughRootsOfUnity`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
