### PR TITLE
feat: faster implementation of `Nat.primeFactorsList` + `@[csimp]` lemma

### DIFF
--- a/Mathlib/Data/Nat/Factors.lean
+++ b/Mathlib/Data/Nat/Factors.lean
@@ -311,11 +311,21 @@ theorem four_dvd_or_exists_odd_prime_and_dvd_of_two_lt {n : ℕ} (n2 : 2 < n) :
 
 section computation
 
+/--
+A version of `Nat.primeFactorsList` that evaluates faster in the virtual machine.
+For mathematical purposes, use `Nat.primeFactorsList` instead,
+and see `Nat.primeFactorsListFast_eq_primeFactorsList`.
+-/
 def primeFactorsListFast (n : Nat) : List Nat :=
   if n < 2 then []
   else if 2 ∣ n then 2 :: primeFactorsListFast (n / 2)
   else go n ⟨3, by decide⟩
 where
+  /--
+  An auxiliary definition for `Nat.primeFactorsListFast`,
+  that remembers the progress on `Nat.minFac`, in order to avoid starting again from zero
+  for each new factor.
+  -/
   go (n : Nat) (d : { k : Nat // 1 < k }) : List Nat :=
     if _ : n < 2 then [] else
     have hd : 1 < minFacAux n d.1 := by

--- a/Mathlib/Data/Nat/Factors.lean
+++ b/Mathlib/Data/Nat/Factors.lean
@@ -314,7 +314,7 @@ section computation
 /--
 A version of `Nat.primeFactorsList` that evaluates faster in the virtual machine.
 For mathematical purposes, use `Nat.primeFactorsList` instead,
-and see `Nat.primeFactorsListFast_eq_primeFactorsList`.
+and see `Nat.primeFactorsList_eq_primeFactorsListFast`.
 -/
 def primeFactorsListFast (n : Nat) : List Nat :=
   if n < 2 then []
@@ -339,7 +339,7 @@ where
     minFacAux n d :: go (n / minFacAux n d) ⟨minFacAux n d, hd⟩
 
 @[csimp]
-theorem primeFactorsListFast_eq_primeFactorsList :
+theorem primeFactorsList_eq_primeFactorsListFast :
     primeFactorsList = primeFactorsListFast := by
   funext n
   fun_induction primeFactorsListFast n with


### PR DESCRIPTION
Add a function `Nat.primeFactorsListFast` that `#eval`s faster, and a `@[csimp]` lemma `Nat.primeFactorsList_eq_primeFactorsListFast` that shows `Nat.primeFactorsList = Nat.primeFactorsListFast`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
