### PR TITLE
[Merged by Bors] - chore: move all nightly-testing infrastructure to a fork

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -413,6 +413,8 @@ jobs:
           COUNTEREXAMPLES_OUTCOME: ${{ steps.counterexamples.outcome }}
           LINT_OUTCOME: ${{ steps.lint.outcome }}
           TEST_OUTCOME: ${{ steps.test.outcome }}
+          MATHLIB_REPO: leanprover-community/mathlib4
+          NIGHTLY_TESTING_REPO: leanprover-community/mathlib4-nightly-testing
         run: |
           master-branch/scripts/lean-pr-testing-comments.sh lean
           master-branch/scripts/lean-pr-testing-comments.sh batteries

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -413,7 +413,6 @@ jobs:
           COUNTEREXAMPLES_OUTCOME: ${{ steps.counterexamples.outcome }}
           LINT_OUTCOME: ${{ steps.lint.outcome }}
           TEST_OUTCOME: ${{ steps.test.outcome }}
-          MATHLIB_REPO: leanprover-community/mathlib4
           NIGHTLY_TESTING_REPO: leanprover-community/mathlib4-nightly-testing
         run: |
           master-branch/scripts/lean-pr-testing-comments.sh lean

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -423,7 +423,6 @@ jobs:
           COUNTEREXAMPLES_OUTCOME: ${{ steps.counterexamples.outcome }}
           LINT_OUTCOME: ${{ steps.lint.outcome }}
           TEST_OUTCOME: ${{ steps.test.outcome }}
-          MATHLIB_REPO: leanprover-community/mathlib4
           NIGHTLY_TESTING_REPO: leanprover-community/mathlib4-nightly-testing
         run: |
           master-branch/scripts/lean-pr-testing-comments.sh lean

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -423,6 +423,8 @@ jobs:
           COUNTEREXAMPLES_OUTCOME: ${{ steps.counterexamples.outcome }}
           LINT_OUTCOME: ${{ steps.lint.outcome }}
           TEST_OUTCOME: ${{ steps.test.outcome }}
+          MATHLIB_REPO: leanprover-community/mathlib4
+          NIGHTLY_TESTING_REPO: leanprover-community/mathlib4-nightly-testing
         run: |
           master-branch/scripts/lean-pr-testing-comments.sh lean
           master-branch/scripts/lean-pr-testing-comments.sh batteries

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ permissions:
 
 jobs:
   build:
-    if: github.repository == 'leanprover-community/mathlib4'
+    if: github.repository == 'leanprover-community/mathlib4' || github.repository == 'leanprover-community/mathlib4-nightly-testing'
     name: Build
     runs-on: pr
     outputs:
@@ -438,7 +438,7 @@ jobs:
 
   post_steps:
     name: Post-Build Step
-    if: github.repository == 'leanprover-community/mathlib4'
+    if: github.repository == 'leanprover-community/mathlib4' || github.repository == 'leanprover-community/mathlib4-nightly-testing'
     needs: [build]
     runs-on: ubuntu-latest # Note these steps run on disposable GitHub runners, so no landrun sandboxing is needed.
     steps:
@@ -522,7 +522,7 @@ jobs:
 
   style_lint:
     name: Lint style
-    if: github.repository == 'leanprover-community/mathlib4'
+    if: github.repository == 'leanprover-community/mathlib4' || github.repository == 'leanprover-community/mathlib4-nightly-testing'
     runs-on: ubuntu-latest
     steps:
       - uses: leanprover-community/lint-style-action@d29fb3b12c1c834450680b3c544f63fe0237a2e2 # 2025-06-20
@@ -533,7 +533,7 @@ jobs:
 
   build_and_lint:
     name: CI Success
-    if: github.repository == 'leanprover-community/mathlib4'
+    if: github.repository == 'leanprover-community/mathlib4' || github.repository == 'leanprover-community/mathlib4-nightly-testing'
     needs: [style_lint, post_steps]
     runs-on: ubuntu-latest
     steps:
@@ -543,7 +543,7 @@ jobs:
 
   final:
     name: Post-CI job
-    if: github.repository == 'leanprover-community/mathlib4'
+    if: github.repository == 'leanprover-community/mathlib4' || github.repository == 'leanprover-community/mathlib4-nightly-testing'
     needs: [style_lint, build, post_steps]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -430,7 +430,6 @@ jobs:
           COUNTEREXAMPLES_OUTCOME: ${{ steps.counterexamples.outcome }}
           LINT_OUTCOME: ${{ steps.lint.outcome }}
           TEST_OUTCOME: ${{ steps.test.outcome }}
-          MATHLIB_REPO: leanprover-community/mathlib4
           NIGHTLY_TESTING_REPO: leanprover-community/mathlib4-nightly-testing
         run: |
           master-branch/scripts/lean-pr-testing-comments.sh lean

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -430,6 +430,8 @@ jobs:
           COUNTEREXAMPLES_OUTCOME: ${{ steps.counterexamples.outcome }}
           LINT_OUTCOME: ${{ steps.lint.outcome }}
           TEST_OUTCOME: ${{ steps.test.outcome }}
+          MATHLIB_REPO: leanprover-community/mathlib4
+          NIGHTLY_TESTING_REPO: leanprover-community/mathlib4-nightly-testing
         run: |
           master-branch/scripts/lean-pr-testing-comments.sh lean
           master-branch/scripts/lean-pr-testing-comments.sh batteries

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -427,6 +427,8 @@ jobs:
           COUNTEREXAMPLES_OUTCOME: ${{ steps.counterexamples.outcome }}
           LINT_OUTCOME: ${{ steps.lint.outcome }}
           TEST_OUTCOME: ${{ steps.test.outcome }}
+          MATHLIB_REPO: leanprover-community/mathlib4
+          NIGHTLY_TESTING_REPO: leanprover-community/mathlib4-nightly-testing
         run: |
           master-branch/scripts/lean-pr-testing-comments.sh lean
           master-branch/scripts/lean-pr-testing-comments.sh batteries

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -427,7 +427,6 @@ jobs:
           COUNTEREXAMPLES_OUTCOME: ${{ steps.counterexamples.outcome }}
           LINT_OUTCOME: ${{ steps.lint.outcome }}
           TEST_OUTCOME: ${{ steps.test.outcome }}
-          MATHLIB_REPO: leanprover-community/mathlib4
           NIGHTLY_TESTING_REPO: leanprover-community/mathlib4-nightly-testing
         run: |
           master-branch/scripts/lean-pr-testing-comments.sh lean

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -3,6 +3,10 @@ name: Daily CI Workflow
 # running some expensive CI checks that we don't want to run on every PR.
 # It reports results via Zulip.
 
+# This script requires that the ZULIP_API_KEY secret is available in both
+# `leanprover-community/mathlib4` and `leanprover-community/mathlib4-nightly-testing`
+# repositories.
+
 on:
   schedule:
     - cron: '0 0 * * *'   # Runs at 00:00 UTC every day
@@ -15,7 +19,7 @@ env:
 jobs:
   check-lean4checker:
     runs-on: ubuntu-latest
-    if: github.repository == 'leanprover-community/mathlib4'
+    if: github.repository == 'leanprover-community/mathlib4' || github.repository == 'leanprover-community/mathlib4-nightly-testing'
     strategy:
       matrix:
         branch_type: [master, nightly]

--- a/.github/workflows/discover-lean-pr-testing.yml
+++ b/.github/workflows/discover-lean-pr-testing.yml
@@ -10,12 +10,12 @@ on:
 jobs:
   discover-lean-pr-testing:
     runs-on: ubuntu-latest
+    if: github.repository == 'leanprover-community/mathlib4-nightly-testing'
 
     steps:
     - name: Checkout mathlib4 repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
-        repository: leanprover-community/mathlib4
         ref: nightly-testing
         fetch-depth: 0  # Fetch all branches
 
@@ -177,7 +177,7 @@ jobs:
             COMPARE_BASE="$LATEST_TAG"
           fi
 
-          GITHUB_DIFF="https://github.com/leanprover-community/mathlib4/compare/$COMPARE_BASE...lean-pr-testing-$PR_NUMBER"
+          GITHUB_DIFF="https://github.com/${{ github.repository }}/compare/$COMPARE_BASE...lean-pr-testing-$PR_NUMBER"
 
           echo "Attempting to merge branch: $BRANCH (PR #$PR_NUMBER)"
           echo "Using diff URL: $GITHUB_DIFF (comparing with $COMPARE_BASE)"

--- a/.github/workflows/discover-lean-pr-testing.yml
+++ b/.github/workflows/discover-lean-pr-testing.yml
@@ -217,7 +217,7 @@ jobs:
         if [ -n "$SUCCESSFUL_MERGES" ]; then
           MESSAGE+=$'### ✅ Successfully merged branches into \'nightly-testing\':\n\n'
           for MERGE_INFO in $SUCCESSFUL_MERGES; do
-            IFS='|' read -r PR_NUMBER GITHUB_DIFF BRANCH <<< "$MERGE_INFO"
+            IFS='|' read -r PR_NUMBER GITHUB_DIFF _ <<< "$MERGE_INFO"
             MESSAGE+=$(printf -- '- [lean-pr-testing-%s](%s) (adaptations for lean#%s)' "$PR_NUMBER" "$GITHUB_DIFF" "$PR_NUMBER")$'\n\n'
           done
           MESSAGE+=$'\n'
@@ -229,7 +229,7 @@ jobs:
         if [ -n "$FAILED_MERGES" ]; then
           MESSAGE+=$'### ❌ Failed merges:\n\nThe following branches need to be merged manually into \'nightly-testing\':\n\n'
           for MERGE_INFO in $FAILED_MERGES; do
-            IFS='|' read -r PR_NUMBER GITHUB_DIFF BRANCH <<< "$MERGE_INFO"
+            IFS='|' read -r PR_NUMBER GITHUB_DIFF _ <<< "$MERGE_INFO"
             MESSAGE+=$(printf '- [lean-pr-testing-%s](%s) (adaptations for lean#%s)' "$PR_NUMBER" "$GITHUB_DIFF" "$PR_NUMBER")$'\n\n'
             MESSAGE+=$'```bash\n'
             MESSAGE+=$(printf 'scripts/merge-lean-testing-pr.sh %s' "$PR_NUMBER")$'\n'

--- a/.github/workflows/mk_build_yml.sh
+++ b/.github/workflows/mk_build_yml.sh
@@ -39,7 +39,7 @@ on:
 
 name: continuous integration
 EOF
-  include "github.sha" pr "github.repository == 'leanprover-community\/mathlib4'" "" ubuntu-latest
+  include "github.sha" pr "github.repository == 'leanprover-community\/mathlib4' || github.repository == 'leanprover-community\/mathlib4-nightly-testing'" "" ubuntu-latest
 }
 
 bors_yml() {

--- a/.github/workflows/nightly_bump_toolchain.yml
+++ b/.github/workflows/nightly_bump_toolchain.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   update-toolchain:
     runs-on: ubuntu-latest
-    if: github.repository == 'leanprover-community/mathlib4'
+    if: github.repository == 'leanprover-community/mathlib4-nightly-testing'
     steps:
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/nightly_detect_failure.yml
+++ b/.github/workflows/nightly_detect_failure.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   handle_failure:
 
-    if: ${{ github.repository == 'leanprover-community/mathlib4' &&
+    if: ${{ github.repository == 'leanprover-community/mathlib4-nightly-testing' &&
             github.event.workflow_run.conclusion == 'failure' &&
             github.event.workflow_run.head_branch == 'nightly-testing' }}
     runs-on: ubuntu-latest
@@ -29,7 +29,9 @@ jobs:
           You can `git fetch; git checkout nightly-testing` and push a fix.
 
   handle_success:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'nightly-testing' }}
+    if: ${{ github.repository == 'leanprover-community/mathlib4-nightly-testing' &&
+            github.event.workflow_run.conclusion == 'success' &&
+            github.event.workflow_run.head_branch == 'nightly-testing' }}
     runs-on: ubuntu-latest
 
     steps:
@@ -257,6 +259,7 @@ jobs:
         SHA: ${{ env.SHA }}
         GH_TOKEN: ${{ secrets.NIGHTLY_TESTING }}
         ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
+        MATHLIB_REPO: leanprover-community/mathlib4
       run: |
         echo "Current version: ${NIGHTLY}"
         echo "Target bump branch: ${BUMP_BRANCH}"

--- a/.github/workflows/nightly_detect_failure.yml
+++ b/.github/workflows/nightly_detect_failure.yml
@@ -259,7 +259,6 @@ jobs:
         SHA: ${{ env.SHA }}
         GH_TOKEN: ${{ secrets.NIGHTLY_TESTING }}
         ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
-        MATHLIB_REPO: leanprover-community/mathlib4
       run: |
         echo "Current version: ${NIGHTLY}"
         echo "Target bump branch: ${BUMP_BRANCH}"

--- a/.github/workflows/nightly_merge_master.yml
+++ b/.github/workflows/nightly_merge_master.yml
@@ -12,11 +12,19 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'leanprover-community/mathlib4'
     steps:
-      - name: Checkout repository
+      - name: Checkout nightly-testing from fork
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
+          repository: leanprover-community/mathlib4-nightly-testing
+          ref: nightly-testing
+          path: nightly-testing
           token: ${{ secrets.NIGHTLY_TESTING }}
+      - name: Checkout master from main repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: master
+          path: upstream
+          fetch-depth: 1
 
       - name: Configure Lean
         uses: leanprover/lean-action@f807b338d95de7813c5c50d018f1c23c9b93b4ec # 2025-04-24
@@ -27,15 +35,19 @@ jobs:
 
       - name: Configure Git User
         run: |
+          cd nightly-testing
           git config user.name "leanprover-community-mathlib4-bot"
           git config user.email "leanprover-community-mathlib4-bot@users.noreply.github.com"
 
       - name: Merge master to nightly favoring nightly changes
         run: |
-          git checkout nightly-testing
+          cd nightly-testing
+          git remote add upstream ../upstream
+          git fetch upstream
+          # Merge master into nightly-testing, resolving conflicts in favor of nightly-testing
           # If the merge goes badly, we proceed anyway via '|| true'.
           # CI will report failures on the 'nightly-testing' branch direct to Zulip.
-          git merge master --strategy-option ours --no-commit --allow-unrelated-histories || true
+          git merge upstream/master --strategy-option ours --no-commit --allow-unrelated-histories || true
           # We aggressively run `lake update`, to avoid having to do this by hand.
           # When Batteries changes break Mathlib, this will likely show up on nightly-testing first.
           lake update
@@ -43,4 +55,5 @@ jobs:
           # If there's nothing to do (because there are no new commits from master),
           # that's okay, hence the '|| true'.
           git commit -m "Merge master into nightly-testing" || true
+          # Push to the mathlib4-nightly-testing fork
           git push origin nightly-testing

--- a/scripts/create-adaptation-pr.sh
+++ b/scripts/create-adaptation-pr.sh
@@ -47,17 +47,6 @@ setup_remotes() {
     echo "Adding remote 'nightly-testing' for leanprover-community/mathlib4-nightly-testing"
     git remote add nightly-testing https://github.com/leanprover-community/mathlib4-nightly-testing.git
     NIGHTLY_REMOTE="nightly-testing"
-  else
-    # Verify the nightly-testing remote points to the correct repository
-    NIGHTLY_URL=$(git remote get-url "$NIGHTLY_REMOTE")
-    if [[ "$NIGHTLY_URL" != *"leanprover-community/mathlib4-nightly-testing"* ]]; then
-      echo "Error: Remote '$NIGHTLY_REMOTE' points to '$NIGHTLY_URL'"
-      echo "Expected: https://github.com/leanprover-community/mathlib4-nightly-testing.git"
-      echo ""
-      echo "Please fix the remote configuration:"
-      echo "  git remote set-url $NIGHTLY_REMOTE https://github.com/leanprover-community/mathlib4-nightly-testing.git"
-      exit 1
-    fi
   fi
 
   echo "Remote configuration:"

--- a/scripts/create-adaptation-pr.sh
+++ b/scripts/create-adaptation-pr.sh
@@ -52,10 +52,6 @@ setup_remotes() {
   echo "Remote configuration:"
   echo "  Main repository ($MAIN_REMOTE): leanprover-community/mathlib4"
   echo "  Nightly testing ($NIGHTLY_REMOTE): leanprover-community/mathlib4-nightly-testing"
-
-  # Set global variables for use in the script
-  MAIN_REMOTE_NAME="$MAIN_REMOTE"
-  NIGHTLY_REMOTE_NAME="$NIGHTLY_REMOTE"
 }
 
 # Function to display usage
@@ -133,14 +129,14 @@ echo
 echo "### [auto] checkout master and pull the latest changes"
 
 git checkout master
-git pull $MAIN_REMOTE_NAME master
+git pull $MAIN_REMOTE master
 
 echo
-echo "### [auto] checkout 'bump/$BUMPVERSION' and merge the latest changes from '$MAIN_REMOTE_NAME/master'"
+echo "### [auto] checkout 'bump/$BUMPVERSION' and merge the latest changes from '$MAIN_REMOTE/master'"
 
 git checkout "bump/$BUMPVERSION"
-git pull $MAIN_REMOTE_NAME "bump/$BUMPVERSION"
-git merge --no-edit $MAIN_REMOTE_NAME/master || true # ignore error if there are conflicts
+git pull $MAIN_REMOTE "bump/$BUMPVERSION"
+git merge --no-edit $MAIN_REMOTE/master || true # ignore error if there are conflicts
 
 # Check if there are merge conflicts
 if git diff --name-only --diff-filter=U | grep -q .; then
@@ -169,7 +165,7 @@ fi
 while git diff --name-only --diff-filter=U | grep -q . || ! git diff-index --quiet HEAD --; do
   echo
   echo "### [user] Conflict resolution"
-  echo "We are merging the latest changes from '$MAIN_REMOTE_NAME/master' into 'bump/$BUMPVERSION'"
+  echo "We are merging the latest changes from '$MAIN_REMOTE/master' into 'bump/$BUMPVERSION'"
   echo "There seem to be conflicts or uncommitted files"
   echo ""
   echo "  1) Open `pwd` in a new terminal and run 'git status'"
@@ -226,7 +222,7 @@ pr_title="chore: adaptations for nightly-$NIGHTLYDATE"
 # as the user might have inadvertently already committed changes
 # In general, we do not want this command to fail.
 git commit --allow-empty -m "$pr_title"
-git push --set-upstream $NIGHTLY_REMOTE_NAME "bump/nightly-$NIGHTLYDATE"
+git push --set-upstream $NIGHTLY_REMOTE "bump/nightly-$NIGHTLYDATE"
 
 # Check if there is a diff between bump/nightly-$NIGHTLYDATE and bump/$BUMPVERSION
 if git diff --name-only bump/$BUMPVERSION bump/nightly-$NIGHTLYDATE | grep -q .; then
@@ -280,7 +276,7 @@ echo
 echo "### [auto] checkout the 'nightly-testing' branch and merge the new branch into it"
 
 git checkout nightly-testing
-git pull $NIGHTLY_REMOTE_NAME nightly-testing
+git pull $NIGHTLY_REMOTE nightly-testing
 git merge --no-edit "bump/nightly-$NIGHTLYDATE" || true # ignore error if there are conflicts
 
 # Check if there are merge conflicts
@@ -322,7 +318,7 @@ done
 
 echo "All conflicts resolved and committed."
 echo "Proceeding with git push..."
-git push $NIGHTLY_REMOTE_NAME nightly-testing
+git push $NIGHTLY_REMOTE nightly-testing
 
 echo
 echo "### [auto] finished: checkout the original branch"

--- a/scripts/create-adaptation-pr.sh
+++ b/scripts/create-adaptation-pr.sh
@@ -20,6 +20,55 @@ IFS=$'\n\t'
 # Default values
 AUTO="no"
 
+# Set MATHLIB_REPO to current repository if not provided
+if [ -z "${MATHLIB_REPO:-}" ]; then
+  MATHLIB_REPO="leanprover-community/mathlib4"
+fi
+
+# Function to validate and setup remotes
+setup_remotes() {
+  echo "### Validating remote configuration..."
+
+  # Check if we have a remote for the main mathlib4 repository
+  MAIN_REMOTE=$(find_remote "leanprover-community/mathlib4")
+  if [ -z "$MAIN_REMOTE" ]; then
+    echo "Error: Could not find remote for leanprover-community/mathlib4"
+    echo "Available remotes:"
+    git remote -v
+    echo ""
+    echo "Please add a remote for the main repository:"
+    echo "  git remote add origin https://github.com/leanprover-community/mathlib4.git"
+    exit 1
+  fi
+
+  # Check if we have a remote for the nightly-testing fork
+  NIGHTLY_REMOTE=$(find_remote "leanprover-community/mathlib4-nightly-testing")
+  if [ -z "$NIGHTLY_REMOTE" ]; then
+    echo "Adding remote 'nightly-testing' for leanprover-community/mathlib4-nightly-testing"
+    git remote add nightly-testing https://github.com/leanprover-community/mathlib4-nightly-testing.git
+    NIGHTLY_REMOTE="nightly-testing"
+  else
+    # Verify the nightly-testing remote points to the correct repository
+    NIGHTLY_URL=$(git remote get-url "$NIGHTLY_REMOTE")
+    if [[ "$NIGHTLY_URL" != *"leanprover-community/mathlib4-nightly-testing"* ]]; then
+      echo "Error: Remote '$NIGHTLY_REMOTE' points to '$NIGHTLY_URL'"
+      echo "Expected: https://github.com/leanprover-community/mathlib4-nightly-testing.git"
+      echo ""
+      echo "Please fix the remote configuration:"
+      echo "  git remote set-url $NIGHTLY_REMOTE https://github.com/leanprover-community/mathlib4-nightly-testing.git"
+      exit 1
+    fi
+  fi
+
+  echo "Remote configuration:"
+  echo "  Main repository ($MAIN_REMOTE): leanprover-community/mathlib4"
+  echo "  Nightly testing ($NIGHTLY_REMOTE): leanprover-community/mathlib4-nightly-testing"
+
+  # Set global variables for use in the script
+  MAIN_REMOTE_NAME="$MAIN_REMOTE"
+  NIGHTLY_REMOTE_NAME="$NIGHTLY_REMOTE"
+}
+
 # Function to display usage
 usage() {
   echo "Usage: $0 <BUMPVERSION> <NIGHTLYDATE>"
@@ -81,16 +130,8 @@ if ! command -v gh &> /dev/null; then
     exit 1
 fi
 
-# Find the appropriate remotes
-UPSTREAM_REMOTE=$(find_remote "leanprover-community/mathlib4")
-if [ -z "$UPSTREAM_REMOTE" ]; then
-  echo "Error: Could not find remote for leanprover-community/mathlib4"
-  echo "Available remotes:"
-  git remote -v
-  exit 1
-fi
-
-echo "Using remote '$UPSTREAM_REMOTE' for leanprover-community/mathlib4"
+# Setup and validate remotes
+setup_remotes
 
 echo "### Creating a PR for the nightly adaptation for $NIGHTLYDATE"
 
@@ -103,14 +144,14 @@ echo
 echo "### [auto] checkout master and pull the latest changes"
 
 git checkout master
-git pull
+git pull $MAIN_REMOTE_NAME master
 
 echo
-echo "### [auto] checkout 'bump/$BUMPVERSION' and merge the latest changes from '$UPSTREAM_REMOTE/master'"
+echo "### [auto] checkout 'bump/$BUMPVERSION' and merge the latest changes from '$MAIN_REMOTE_NAME/master'"
 
 git checkout "bump/$BUMPVERSION"
-git pull
-git merge --no-edit $UPSTREAM_REMOTE/master || true # ignore error if there are conflicts
+git pull $MAIN_REMOTE_NAME "bump/$BUMPVERSION"
+git merge --no-edit $MAIN_REMOTE_NAME/master || true # ignore error if there are conflicts
 
 # Check if there are merge conflicts
 if git diff --name-only --diff-filter=U | grep -q .; then
@@ -139,7 +180,7 @@ fi
 while git diff --name-only --diff-filter=U | grep -q . || ! git diff-index --quiet HEAD --; do
   echo
   echo "### [user] Conflict resolution"
-  echo "We are merging the latest changes from '$UPSTREAM_REMOTE/master' into 'bump/$BUMPVERSION'"
+  echo "We are merging the latest changes from '$MAIN_REMOTE_NAME/master' into 'bump/$BUMPVERSION'"
   echo "There seem to be conflicts or uncommitted files"
   echo ""
   echo "  1) Open `pwd` in a new terminal and run 'git status'"
@@ -196,7 +237,7 @@ pr_title="chore: adaptations for nightly-$NIGHTLYDATE"
 # as the user might have inadvertently already committed changes
 # In general, we do not want this command to fail.
 git commit --allow-empty -m "$pr_title"
-git push --set-upstream $UPSTREAM_REMOTE "bump/nightly-$NIGHTLYDATE"
+git push --set-upstream $NIGHTLY_REMOTE_NAME "bump/nightly-$NIGHTLYDATE"
 
 # Check if there is a diff between bump/nightly-$NIGHTLYDATE and bump/$BUMPVERSION
 if git diff --name-only bump/$BUMPVERSION bump/nightly-$NIGHTLYDATE | grep -q .; then
@@ -205,7 +246,7 @@ if git diff --name-only bump/$BUMPVERSION bump/nightly-$NIGHTLYDATE | grep -q .;
   echo "### [auto] create a PR for the new branch"
   echo "Creating a pull request. Setting the base of the PR to 'bump/$BUMPVERSION'"
   echo "Running the following 'gh' command to do this:"
-  gh_command="gh pr create -t \"$pr_title\" -b '' -B bump/$BUMPVERSION --repo leanprover-community/mathlib4"
+  gh_command="gh pr create -t \"$pr_title\" -b '' -B bump/$BUMPVERSION --repo leanprover-community/mathlib4-nightly-testing"
   echo "> $gh_command"
   gh_output=$(eval $gh_command)
   # Extract the PR number from the output
@@ -250,7 +291,7 @@ echo
 echo "### [auto] checkout the 'nightly-testing' branch and merge the new branch into it"
 
 git checkout nightly-testing
-git pull
+git pull $NIGHTLY_REMOTE_NAME nightly-testing
 git merge --no-edit "bump/nightly-$NIGHTLYDATE" || true # ignore error if there are conflicts
 
 # Check if there are merge conflicts
@@ -292,7 +333,7 @@ done
 
 echo "All conflicts resolved and committed."
 echo "Proceeding with git push..."
-git push
+git push $NIGHTLY_REMOTE_NAME nightly-testing
 
 echo
 echo "### [auto] finished: checkout the original branch"

--- a/scripts/lean-pr-testing-comments.sh
+++ b/scripts/lean-pr-testing-comments.sh
@@ -13,6 +13,16 @@ if [ -z "$1" ]; then
   exit 1
 fi
 
+# Set MATHLIB_REPO to current repository if not provided
+if [ -z "${MATHLIB_REPO:-}" ]; then
+  MATHLIB_REPO="leanprover-community/mathlib4"
+fi
+
+# Set NIGHTLY_TESTING_REPO for comparison URLs (where the branches and tags actually live)
+if [ -z "${NIGHTLY_TESTING_REPO:-}" ]; then
+  NIGHTLY_TESTING_REPO="leanprover-community/mathlib4-nightly-testing"
+fi
+
 # TODO: The whole script ought to be rewritten in javascript, to avoid having to use curl for API calls.
 #
 # This is not meant to be run from the command line, only from CI.
@@ -99,7 +109,7 @@ if [[ "$branch_name" =~ ^$branch_prefix-([0-9]+)$ ]]; then
       -d '{"labels":["breaks-mathlib"]}'
   fi
 
-  branch="[$branch_prefix-$pr_number](https://github.com/leanprover-community/mathlib4/compare/$base_branch...$branch_prefix-$pr_number)"
+  branch="[$branch_prefix-$pr_number](https://github.com/$NIGHTLY_TESTING_REPO/compare/$base_branch...$branch_prefix-$pr_number)"
   # Depending on the success/failure, set the appropriate message
   if [ "$LINT_OUTCOME" == "cancelled" ] || [ "$TEST_OUTCOME" == "cancelled" ] || [ "$COUNTEREXAMPLES_OUTCOME" == "cancelled" ] || [ "$ARCHIVE_OUTCOME" == "cancelled" ] || [ "$NOISY_OUTCOME" == "cancelled" ] || [ "$BUILD_OUTCOME" == "cancelled" ]; then
     message="- 🟡 Mathlib branch $branch build against this PR was cancelled. ($current_time) [View Log]($WORKFLOW_URL)"

--- a/scripts/lean-pr-testing-comments.sh
+++ b/scripts/lean-pr-testing-comments.sh
@@ -13,11 +13,6 @@ if [ -z "$1" ]; then
   exit 1
 fi
 
-# Set MATHLIB_REPO to current repository if not provided
-if [ -z "${MATHLIB_REPO:-}" ]; then
-  MATHLIB_REPO="leanprover-community/mathlib4"
-fi
-
 # Set NIGHTLY_TESTING_REPO for comparison URLs (where the branches and tags actually live)
 if [ -z "${NIGHTLY_TESTING_REPO:-}" ]; then
   NIGHTLY_TESTING_REPO="leanprover-community/mathlib4-nightly-testing"


### PR DESCRIPTION
This PR moves all of our nightly-testing infrastructure to the fork at https://github.com/leanprover-community/mathlib4-nightly-testing. I have migrated all the relevant branches (nightly-testing, nightly-testing-YYYY-MM-DD, lean-pr-testing-NNNN, batteries-pr-testing-NNNN, bump/v4.X.0, bump/nightly-YYYY-MM-DD) across to the fork, but not yet deleted them from the main repository. I've installed what I think are the necessary secrets (discussed in the CI admins channel).

This is presumably going to be horribly broken... Some parts are generated with some AI assistance, but I've tried to read carefully! In any case, skeptical review appreciated, but we're probably going to have to do a certain amount of testing in production as usual.