### PR TITLE
[Merged by Bors] - chore: rewrite maintainer_*.yml to work from forks

### DIFF
--- a/.github/workflows/maintainer_bors.yml
+++ b/.github/workflows/maintainer_bors.yml
@@ -21,6 +21,7 @@ jobs:
       AUTHOR: ${{ github.event.comment.user.login }}${{ github.event.review.user.login }}
       COMMENT_EVENT: ${{ github.event.comment.body }}
       COMMENT_REVIEW: ${{ github.event.review.body }}
+      PR_NUMBER: ${{ github.event.issue.number }}${{ github.event.pull_request.number }}
     name: Add ready-to-merge or delegated label
     runs-on: ubuntu-latest
     if: github.repository == 'leanprover-community/mathlib4'
@@ -28,14 +29,6 @@ jobs:
       - name: Find bors merge/delegate
         id: merge_or_delegate
         run: |
-          # don't try to run if we don't have access to necessary secrets
-          if [[ -z '${{ secrets.TRIAGE_TOKEN }}' ]]
-          then
-            printf 'No access to secrets, aborting.'
-            printf 'mOrD=' > "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
           COMMENT="${COMMENT_EVENT}${COMMENT_REVIEW}"
           # we strip `\r` since line endings from GitHub contain this character
           COMMENT="${COMMENT//$'\r'/}"
@@ -51,8 +44,8 @@ jobs:
           printf $'"bors delegate" or "bors merge" found? \'%s\'\n' "${m_or_d}"
           printf $'"bors r-" or "bors d-" found? \'%s\'\n' "${remove_labels}"
           printf $'AUTHOR: \'%s\'\n' "${AUTHOR}"
-          printf $'PR_NUMBER: \'%s\'\n' "${{ github.event.issue.number }}${{ github.event.pull_request.number }}"
-          printf $'%s' "${{ github.event.issue.number }}${{ github.event.pull_request.number }}" | hexdump -cC
+          printf $'PR_NUMBER: \'%s\'\n' "${PR_NUMBER}"
+          printf $'%s' "${PR_NUMBER}" | hexdump -cC
 
           printf $'mOrD=%s\n' "${m_or_d}" >> "${GITHUB_OUTPUT}"
           printf $'removeLabels=%s\n' "${remove_labels}" >> "${GITHUB_OUTPUT}"
@@ -61,23 +54,66 @@ jobs:
           then
             printf $'bot=true\n'
             printf $'bot=true\n' >> "${GITHUB_OUTPUT}"
+            BOT='true'
           else
             printf $'bot=false\n'
             printf $'bot=false\n' >> "${GITHUB_OUTPUT}"
+            BOT='false'
           fi
 
+          # write an artifact with all data needed below if we don't have access to necessary secrets
+          if [[ -z '${{ secrets.TRIAGE_TOKEN }}' ]]
+          then
+            printf 'No access to secrets, writing to file.'
+            jq -n \
+              --arg author "${AUTHOR}" \
+              --arg pr_number "${PR_NUMBER}" \
+              --arg comment "${COMMENT}" \
+              --arg bot "${BOT}" \
+              --arg remove_labels "${remove_labels}" \
+              --arg m_or_d "${m_or_d}" \
+              '{
+                author: $author,
+                pr_number: $pr_number,
+                comment: $comment,
+                bot: $bot,
+                remove_labels: $remove_labels,
+                m_or_d: $m_or_d,
+              }' > artifact-data.json
+            echo "Generated JSON artifact:"
+            cat artifact-data.json
+
+            printf 'secrets=' >> "${GITHUB_OUTPUT}"
+            exit 0
+          else
+            printf 'secrets=true\n' >> "${GITHUB_OUTPUT}"
+          fi
+
+      # upload artifact if we have no access to secrets
+      - if: ${{ steps.merge_or_delegate.outputs.secrets == '' &&
+          (! steps.merge_or_delegate.outputs.mOrD == '' || ! steps.merge_or_delegate.outputs.removeLabels == '') }}
+        name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: workflow-data
+          path: artifact-data.json
+          retention-days: 5
+
+      # Run the following steps only if we have access to secrets / write perms on GITHUB_TOKEN
       - name: Check whether user is a mathlib admin
         id: user_permission
-        if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' || ! steps.merge_or_delegate.outputs.removeLabels == '' }}
+        if: ${{ ! steps.merge_or_delegate.outputs.secrets == '' &&
+          (! steps.merge_or_delegate.outputs.mOrD == '' || ! steps.merge_or_delegate.outputs.removeLabels == '') }}
         uses: actions-cool/check-user-permission@7b90a27f92f3961b368376107661682c441f6103 # v2.3.0
         with:
           require: 'admin'
 
       - name: Add ready-to-merge or delegated label
         id: add_label
-        if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' &&
+        if: ${{ ! steps.merge_or_delegate.outputs.secrets == '' &&
+          (! steps.merge_or_delegate.outputs.mOrD == '' &&
           ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.merge_or_delegate.outputs.bot == 'true' ) }}
+            steps.merge_or_delegate.outputs.bot == 'true' )) }}
         uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # v2.4.0
         with:
           route: POST /repos/:repository/issues/:issue_number/labels
@@ -89,9 +125,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
 
-      - if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' &&
+      - if: ${{ ! steps.merge_or_delegate.outputs.secrets == '' &&
+          (! steps.merge_or_delegate.outputs.mOrD == '' &&
           ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.merge_or_delegate.outputs.bot == 'true' ) }}
+            steps.merge_or_delegate.outputs.bot == 'true' )) }}
         id: remove_labels
         name: Remove "awaiting-author" and "maintainer-merge"
         # we use curl rather than octokit/request-action so that the job won't fail
@@ -104,8 +141,9 @@ jobs:
           done
 
       - name: On bors r/d-, remove ready-to-merge or delegated label
-        if: ${{ ! steps.merge_or_delegate.outputs.removeLabels == '' &&
-          steps.user_permission.outputs.require-result == 'true' }}
+        if: ${{ ! steps.merge_or_delegate.outputs.secrets == '' &&
+          (! steps.merge_or_delegate.outputs.removeLabels == '' &&
+          steps.user_permission.outputs.require-result == 'true') }}
         # we use curl rather than octokit/request-action so that the job won't fail
         # (and send an annoying email) if the labels don't exist
         run: |
@@ -116,24 +154,27 @@ jobs:
           done
 
       - name: Set up Python
-        if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' &&
+        if: ${{ ! steps.merge_or_delegate.outputs.secrets == '' &&
+          (! steps.merge_or_delegate.outputs.mOrD == '' &&
           ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.merge_or_delegate.outputs.bot == 'true' ) }}
+            steps.merge_or_delegate.outputs.bot == 'true' )) }}
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.x'
 
       - name: Install dependencies
-        if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' &&
+        if: ${{ ! steps.merge_or_delegate.outputs.secrets == '' &&
+          (! steps.merge_or_delegate.outputs.mOrD == '' &&
           ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.merge_or_delegate.outputs.bot == 'true' ) }}
+            steps.merge_or_delegate.outputs.bot == 'true' )) }}
         run: |
           python -m pip install --upgrade pip
           pip install zulip
 
-      - if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' &&
+      - if: ${{ ! steps.merge_or_delegate.outputs.secrets == '' &&
+          (! steps.merge_or_delegate.outputs.mOrD == '' &&
           ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.merge_or_delegate.outputs.bot == 'true' ) }}
+            steps.merge_or_delegate.outputs.bot == 'true' )) }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: master
@@ -141,9 +182,10 @@ jobs:
             scripts/zulip_emoji_reactions.py
 
       - name: update zulip emoji reactions
-        if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' &&
+        if: ${{ ! steps.merge_or_delegate.outputs.secrets == '' &&
+          (! steps.merge_or_delegate.outputs.mOrD == '' &&
           ( steps.user_permission.outputs.require-result == 'true' ||
-            steps.merge_or_delegate.outputs.bot == 'true' ) }}
+            steps.merge_or_delegate.outputs.bot == 'true' )) }}
         env:
           ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
           ZULIP_EMAIL: github-mathlib4-bot@leanprover.zulipchat.com

--- a/.github/workflows/maintainer_bors.yml
+++ b/.github/workflows/maintainer_bors.yml
@@ -64,7 +64,7 @@ jobs:
           # write an artifact with all data needed below if we don't have access to necessary secrets
           if [[ -z '${{ secrets.TRIAGE_TOKEN }}' ]]
           then
-            printf 'No access to secrets, writing to file.'
+            printf 'No access to secrets, writing to file.\n'
             jq -n \
               --arg author "${AUTHOR}" \
               --arg pr_number "${PR_NUMBER}" \

--- a/.github/workflows/maintainer_bors.yml
+++ b/.github/workflows/maintainer_bors.yml
@@ -81,6 +81,8 @@ jobs:
         uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # v2.4.0
         with:
           route: POST /repos/:repository/issues/:issue_number/labels
+          # Unexpected input warning from the following is expected:
+          # https://github.com/octokit/request-action?tab=readme-ov-file#warnings
           repository: ${{ github.repository }}
           issue_number: ${{ github.event.issue.number }}${{ github.event.pull_request.number }}
           labels: '["${{ steps.merge_or_delegate.outputs.mOrD }}"]'
@@ -129,8 +131,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install zulip
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' &&
+          ( steps.user_permission.outputs.require-result == 'true' ||
+            steps.merge_or_delegate.outputs.bot == 'true' ) }}
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          ref: master
           sparse-checkout: |
             scripts/zulip_emoji_reactions.py
 

--- a/.github/workflows/maintainer_bors_wf_run.yml
+++ b/.github/workflows/maintainer_bors_wf_run.yml
@@ -50,7 +50,7 @@ jobs:
               echo "bot=$bot"
               echo "removeLabels=$remove_labels"
               echo "mOrD=$m_or_d"
-            } >> "$GITHUB_OUTPUT"
+            } | tee -a "$GITHUB_OUTPUT"
           else
             echo "JSON artifact file not found!"
             exit 1

--- a/.github/workflows/maintainer_bors_wf_run.yml
+++ b/.github/workflows/maintainer_bors_wf_run.yml
@@ -61,6 +61,7 @@ jobs:
         if: ${{ ! steps.extract-data.outputs.mOrD == '' || ! steps.extract-data.outputs.removeLabels == '' }}
         uses: actions-cool/check-user-permission@7b90a27f92f3961b368376107661682c441f6103 # v2.3.0
         with:
+          username: ${{ steps.extract-data.outputs.author }}
           require: 'admin'
 
       - name: Add ready-to-merge or delegated label

--- a/.github/workflows/maintainer_bors_wf_run.yml
+++ b/.github/workflows/maintainer_bors_wf_run.yml
@@ -1,0 +1,139 @@
+name: Add "ready-to-merge" and "delegated" label (workflow_run)
+
+on:
+  workflow_run:
+    workflows: ['Add "ready-to-merge" and "delegated" label']
+    types:
+      - completed
+
+
+jobs:
+  add_ready_to_merge_label:
+    name: Add ready-to-merge or delegated label
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'leanprover-community/mathlib4' && github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Download artifact
+        id: download-artifact
+        uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5 # v11
+        with:
+          workflow: maintainer_bors.yml
+          name: workflow-data
+          path: ./artifacts
+          if_no_artifact_found: ignore
+          # Use the workflow run that triggered this workflow
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - if: ${{ steps.download-artifact.outputs.found_artifact == 'true' }}
+        name: Extract data from JSON artifact
+        id: extract-data
+        run: |
+          # Read the JSON artifact file and extract data
+          if [ -f "./artifacts/artifact-data.json" ]; then
+            echo "JSON artifact found, extracting data..."
+            echo "Full JSON artifact content:"
+            cat ./artifacts/artifact-data.json
+
+            # Extract specific values using jq
+            author=$(jq -r '.author' ./artifacts/artifact-data.json)
+            pr_number=$(jq -r '.pr_number' ./artifacts/artifact-data.json)
+            comment=$(jq -r '.comment' ./artifacts/artifact-data.json)
+            bot=$(jq -r '.bot' ./artifacts/artifact-data.json)
+            remove_labels=$(jq -r '.remove_labels' ./artifacts/artifact-data.json)
+            m_or_d=$(jq -r '.m_or_d' ./artifacts/artifact-data.json)
+
+            # Set as step outputs for use in later steps
+            echo "author=$author" > "$GITHUB_OUTPUT"
+            echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+            echo "comment=$comment" >> "$GITHUB_OUTPUT"
+            echo "bot=$bot" >> "$GITHUB_OUTPUT"
+            echo "removeLabels=$remove_labels" >> "$GITHUB_OUTPUT"
+            echo "mOrD=$m_or_d" >> "$GITHUB_OUTPUT"
+          else
+            echo "JSON artifact file not found!"
+            exit 1
+          fi
+
+      - name: Check whether user is a mathlib admin
+        id: user_permission
+        if: ${{ ! steps.extract-data.outputs.mOrD == '' || ! steps.extract-data.outputs.removeLabels == '' }}
+        uses: actions-cool/check-user-permission@7b90a27f92f3961b368376107661682c441f6103 # v2.3.0
+        with:
+          require: 'admin'
+
+      - name: Add ready-to-merge or delegated label
+        id: add_label
+        if: ${{ ! steps.extract-data.outputs.mOrD == '' &&
+          ( steps.user_permission.outputs.require-result == 'true' ||
+            steps.extract-data.outputs.bot == 'true' ) }}
+        uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # v2.4.0
+        with:
+          route: POST /repos/:repository/issues/:issue_number/labels
+          # Unexpected input warning from the following is expected:
+          # https://github.com/octokit/request-action?tab=readme-ov-file#warnings
+          repository: ${{ github.repository }}
+          issue_number: ${{ steps.extract-data.outputs.pr_number }}
+          labels: '["${{ steps.extract-data.outputs.mOrD }}"]'
+        env:
+          GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
+
+      - if: ${{ ! steps.extract-data.outputs.mOrD == '' &&
+          ( steps.user_permission.outputs.require-result == 'true' ||
+            steps.extract-data.outputs.bot == 'true' ) }}
+        id: remove_labels
+        name: Remove "awaiting-author" and "maintainer-merge"
+        # we use curl rather than octokit/request-action so that the job won't fail
+        # (and send an annoying email) if the labels don't exist
+        run: |
+          for label in awaiting-author maintainer-merge; do
+            curl --request DELETE \
+              --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.extract-data.outputs.pr_number }}/labels/${label}" \
+              --header 'authorization: Bearer ${{ secrets.TRIAGE_TOKEN }}'
+          done
+
+      - name: On bors r/d-, remove ready-to-merge or delegated label
+        if: ${{ ! steps.extract-data.outputs.removeLabels == '' && steps.user_permission.outputs.require-result == 'true' }}
+        # we use curl rather than octokit/request-action so that the job won't fail
+        # (and send an annoying email) if the labels don't exist
+        run: |
+          for label in ready-to-merge delegated; do
+            curl --request DELETE \
+              --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.extract-data.outputs.pr_number }}/labels/${label}" \
+              --header 'authorization: Bearer ${{ secrets.TRIAGE_TOKEN }}'
+          done
+
+      - name: Set up Python
+        if: ${{ ! steps.extract-data.outputs.mOrD == '' &&
+          ( steps.user_permission.outputs.require-result == 'true' ||
+            steps.extract-data.outputs.bot == 'true' ) }}
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        if: ${{ ! steps.extract-data.outputs.mOrD == '' &&
+          ( steps.user_permission.outputs.require-result == 'true' ||
+            steps.extract-data.outputs.bot == 'true' ) }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install zulip
+
+      - if: ${{ ! steps.extract-data.outputs.mOrD == '' &&
+          ( steps.user_permission.outputs.require-result == 'true' ||
+            steps.extract-data.outputs.bot == 'true' ) }}
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: master
+          sparse-checkout: |
+            scripts/zulip_emoji_reactions.py
+
+      - name: update zulip emoji reactions
+        if: ${{ ! steps.extract-data.outputs.mOrD == '' &&
+          ( steps.user_permission.outputs.require-result == 'true' ||
+            steps.extract-data.outputs.bot == 'true' ) }}
+        env:
+          ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
+          ZULIP_EMAIL: github-mathlib4-bot@leanprover.zulipchat.com
+          ZULIP_SITE: https://leanprover.zulipchat.com
+        run: |
+          python scripts/zulip_emoji_reactions.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "${{ steps.extract-data.outputs.mOrD }}" "${{ steps.extract-data.outputs.mOrD }}" "${{ steps.extract-data.outputs.pr_number }}"

--- a/.github/workflows/maintainer_bors_wf_run.yml
+++ b/.github/workflows/maintainer_bors_wf_run.yml
@@ -43,12 +43,14 @@ jobs:
             m_or_d=$(jq -r '.m_or_d' ./artifacts/artifact-data.json)
 
             # Set as step outputs for use in later steps
-            echo "author=$author" > "$GITHUB_OUTPUT"
-            echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
-            echo "comment=$comment" >> "$GITHUB_OUTPUT"
-            echo "bot=$bot" >> "$GITHUB_OUTPUT"
-            echo "removeLabels=$remove_labels" >> "$GITHUB_OUTPUT"
-            echo "mOrD=$m_or_d" >> "$GITHUB_OUTPUT"
+            {
+              echo "author=$author"
+              echo "pr_number=$pr_number"
+              echo "comment=$comment"
+              echo "bot=$bot"
+              echo "removeLabels=$remove_labels"
+              echo "mOrD=$m_or_d"
+            } >> "$GITHUB_OUTPUT"
           else
             echo "JSON artifact file not found!"
             exit 1

--- a/.github/workflows/maintainer_merge.yml
+++ b/.github/workflows/maintainer_merge.yml
@@ -102,7 +102,7 @@ jobs:
           organization: leanprover-community # optional. Default value ${{ github.repository_owner }}
                   # Organization to get membership from.
           team: 'mathlib-reviewers'
-          username: ${{ github.actor }}
+          username: ${{ env.AUTHOR }}
           GITHUB_TOKEN: ${{ secrets.MATHLIB_REVIEWERS_TEAM_KEY }} # (Requires scope: `read:org`)
 
       - name: Checkout

--- a/.github/workflows/maintainer_merge.yml
+++ b/.github/workflows/maintainer_merge.yml
@@ -60,23 +60,23 @@ jobs:
 
           printf $'mOrD=%s\n' "${m_or_d}" > "${GITHUB_OUTPUT}"
 
-      - name: Check whether user is part of mathlib-reviewers team
-        if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' }}
-        uses: TheModdingInquisition/actions-team-membership@a69636a92bc927f32c3910baac06bacc949c984c # v1.0
+      - if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' }}
+        name: Check whether user is part of mathlib-reviewers team
+        uses: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662 # v3.0.0
+        id: actorTeams
         with:
-          organization: 'leanprover-community'
-          team: 'mathlib-reviewers' # required. The team to check for
-          token: ${{ secrets.MATHLIB_REVIEWERS_TEAM_KEY }} # required. Personal Access Token with the `read:org` permission
-          comment: 'You seem to not be authorized' # optional. A comment to post if the user is not part of the team.
-                                                   # This feature is only applicable in an issue (or PR) context
-          exit: true # optional. If the action should exit if the user is not part of the team. Defaults to true.
+          organization: leanprover-community # optional. Default value ${{ github.repository_owner }}
+                  # Organization to get membership from.
+          team: 'mathlib-reviewers'
+          username: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.MATHLIB_REVIEWERS_TEAM_KEY }} # (Requires scope: `read:org`)
 
       - name: Checkout
-        if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' }}
+        if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Determine Zulip topic
-        if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' }}
+        if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
         id: determine_topic
         run: |
           ./scripts/get_tlabel.sh "/repos/leanprover-community/mathlib4/issues/${PR_NUMBER}" >> "$GITHUB_OUTPUT"
@@ -84,7 +84,7 @@ jobs:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Form the message
-        if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' }}
+        if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
         id: form_the_message
         run: |
           # for debugging, we print the available variables
@@ -97,7 +97,7 @@ jobs:
           printf 'title<<EOF\n%s\nEOF' "${message}" | tee "$GITHUB_OUTPUT"
 
       - name: Send message on Zulip
-        if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' }}
+        if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
         with:
           api-key: ${{ secrets.ZULIP_API_KEY }}
@@ -109,7 +109,7 @@ jobs:
           content: ${{ steps.form_the_message.outputs.title }}
 
       - name: Add comment to PR
-        if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' }}
+        if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
         uses: GrantBirki/comment@608e41b19bc973020ec0e189ebfdae935d7fe0cc # v2.1.1
         with:
           # if a comment triggers the action, then `issue.number` is set
@@ -119,7 +119,7 @@ jobs:
             🚀 Pull request has been placed on the maintainer queue by ${{ github.event.comment.user.login }}${{ github.event.review.user.login }}.
 
       - name: Add label to PR
-        if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' }}
+        if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           # labels added by GITHUB_TOKEN won't trigger the Zulip emoji workflow

--- a/.github/workflows/maintainer_merge.yml
+++ b/.github/workflows/maintainer_merge.yml
@@ -34,14 +34,6 @@ jobs:
       - name: Find maintainer merge/delegate
         id: merge_or_delegate
         run: |
-          # don't try to run if we don't have access to necessary secrets
-          if [[ -z '${{ secrets.MATHLIB_REVIEWERS_TEAM_KEY }}' ]]
-          then
-            printf 'No access to secrets, aborting.'
-            printf 'mOrD=' > "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
           echo "PR author: ${PR_AUTHOR}"
           COMMENT="${COMMENT_EVENT}${COMMENT_REVIEW}"
 
@@ -60,7 +52,49 @@ jobs:
 
           printf $'mOrD=%s\n' "${m_or_d}" > "${GITHUB_OUTPUT}"
 
-      - if: ${{ ! steps.merge_or_delegate.outputs.mOrD == '' }}
+          # write an artifact with all data needed below if we don't have access to necessary secrets
+          if [[ -z '${{ secrets.MATHLIB_REVIEWERS_TEAM_KEY }}' ]]
+          then
+            printf 'No access to secrets, writing to file.'
+            jq -n \
+              --arg author "${AUTHOR}" \
+              --arg pr_author "${PR_AUTHOR}" \
+              --arg pr_number "${PR_NUMBER}" \
+              --arg comment "${COMMENT}" \
+              --arg pr_title "${PR_TITLE_ISSUE}${PR_TITLE_PR}" \
+              --arg pr_url "${PR_URL}" \
+              --arg event_name "${EVENT_NAME}" \
+              --arg m_or_d "${m_or_d}" \
+              '{
+                author: $author,
+                pr_author: $pr_author,
+                pr_number: $pr_number,
+                comment: $comment,
+                pr_title: $pr_title,
+                pr_url: $pr_url,
+                event_name: $event_name,
+                m_or_d: $m_or_d,
+              }' > artifact-data.json
+            echo "Generated JSON artifact:"
+            cat artifact-data.json
+
+            printf 'secrets=' >> "${GITHUB_OUTPUT}"
+            exit 0
+          else
+            printf 'secrets=true\n' >> "${GITHUB_OUTPUT}"
+          fi
+
+      # upload artifact if we have no access to secrets
+      - if: ${{ steps.merge_or_delegate.outputs.secrets == '' && ! steps.merge_or_delegate.outputs.mOrD == '' }}
+        name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: workflow-data
+          path: artifact-data.json
+          retention-days: 5
+
+      # Run the following steps only if we have access to secrets / write perms on GITHUB_TOKEN
+      - if: ${{ ! steps.merge_or_delegate.outputs.secrets == '' && ! steps.merge_or_delegate.outputs.mOrD == '' }}
         name: Check whether user is part of mathlib-reviewers team
         uses: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662 # v3.0.0
         id: actorTeams

--- a/.github/workflows/maintainer_merge.yml
+++ b/.github/workflows/maintainer_merge.yml
@@ -55,7 +55,7 @@ jobs:
           # write an artifact with all data needed below if we don't have access to necessary secrets
           if [[ -z '${{ secrets.MATHLIB_REVIEWERS_TEAM_KEY }}' ]]
           then
-            printf 'No access to secrets, writing to file.'
+            printf 'No access to secrets, writing to file.\n'
             jq -n \
               --arg author "${AUTHOR}" \
               --arg pr_author "${PR_AUTHOR}" \

--- a/.github/workflows/maintainer_merge.yml
+++ b/.github/workflows/maintainer_merge.yml
@@ -74,6 +74,11 @@ jobs:
       - name: Checkout
         if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: master
+          sparse-checkout: |
+            scripts/get_tlabel.py
+            scripts/maintainer_merge_message.py
 
       - name: Determine Zulip topic
         if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}

--- a/.github/workflows/maintainer_merge_wf_run.yml
+++ b/.github/workflows/maintainer_merge_wf_run.yml
@@ -45,14 +45,16 @@ jobs:
             m_or_d=$(jq -r '.m_or_d' ./artifacts/artifact-data.json)
 
             # Set as step outputs for use in later steps
-            echo "author=$author" > "$GITHUB_OUTPUT"
-            echo "pr_author=$pr_author" >> "$GITHUB_OUTPUT"
-            echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
-            echo "comment=$comment" >> "$GITHUB_OUTPUT"
-            echo "pr_title=$pr_title" >> "$GITHUB_OUTPUT"
-            echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
-            echo "event_name=$event_name" >> "$GITHUB_OUTPUT"
-            echo "mOrD=$m_or_d" >> "$GITHUB_OUTPUT"
+            {
+              echo "author=$author"
+              echo "pr_author=$pr_author"
+              echo "pr_number=$pr_number"
+              echo "comment=$comment"
+              echo "pr_title=$pr_title"
+              echo "pr_url=$pr_url"
+              echo "event_name=$event_name"
+              echo "mOrD=$m_or_d"
+            } >> "$GITHUB_OUTPUT"
           else
             echo "JSON artifact file not found!"
             exit 1

--- a/.github/workflows/maintainer_merge_wf_run.yml
+++ b/.github/workflows/maintainer_merge_wf_run.yml
@@ -1,0 +1,137 @@
+name: Maintainer merge (workflow_run)
+
+# triggers the action when
+on:
+  workflow_run:
+    workflows: ["Maintainer merge"]
+    types:
+      - completed
+
+jobs:
+  ping_zulip:
+    name: Ping maintainers on Zulip
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'leanprover-community/mathlib4' && github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Download artifact
+        id: download-artifact
+        uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5 # v11
+        with:
+          workflow: maintainer_merge.yml
+          name: workflow-data
+          path: ./artifacts
+          if_no_artifact_found: ignore
+          # Use the workflow run that triggered this workflow
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - if: ${{ steps.download-artifact.outputs.found_artifact == 'true' }}
+        name: Extract data from JSON artifact
+        id: extract-data
+        run: |
+          # Read the JSON artifact file and extract data
+          if [ -f "./artifacts/artifact-data.json" ]; then
+            echo "JSON artifact found, extracting data..."
+            echo "Full JSON artifact content:"
+            cat ./artifacts/artifact-data.json
+
+            # Extract specific values using jq
+            author=$(jq -r '.author' ./artifacts/artifact-data.json)
+            pr_author=$(jq -r '.pr_author' ./artifacts/artifact-data.json)
+            pr_number=$(jq -r '.pr_number' ./artifacts/artifact-data.json)
+            comment=$(jq -r '.comment' ./artifacts/artifact-data.json)
+            pr_title=$(jq -r '.pr_title' ./artifacts/artifact-data.json)
+            pr_url=$(jq -r '.pr_url' ./artifacts/artifact-data.json)
+            event_name=$(jq -r '.event_name' ./artifacts/artifact-data.json)
+            m_or_d=$(jq -r '.m_or_d' ./artifacts/artifact-data.json)
+
+            # Set as step outputs for use in later steps
+            echo "author=$author" > "$GITHUB_OUTPUT"
+            echo "pr_author=$pr_author" >> "$GITHUB_OUTPUT"
+            echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+            echo "comment=$comment" >> "$GITHUB_OUTPUT"
+            echo "pr_title=$pr_title" >> "$GITHUB_OUTPUT"
+            echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
+            echo "event_name=$event_name" >> "$GITHUB_OUTPUT"
+            echo "mOrD=$m_or_d" >> "$GITHUB_OUTPUT"
+          else
+            echo "JSON artifact file not found!"
+            exit 1
+          fi
+
+      - if: ${{ ! steps.extract-data.outputs.mOrD == '' }}
+        name: Check whether user is part of mathlib-reviewers team
+        uses: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662 # v3.0.0
+        id: actorTeams
+        with:
+          organization: leanprover-community # optional. Default value ${{ github.repository_owner }}
+                  # Organization to get membership from.
+          team: 'mathlib-reviewers'
+          username: ${{ steps.extract-data.outputs.author }}
+          GITHUB_TOKEN: ${{ secrets.MATHLIB_REVIEWERS_TEAM_KEY }} # (Requires scope: `read:org`)
+
+      - name: Checkout
+        if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: master
+          sparse-checkout: |
+            scripts/get_tlabel.py
+            scripts/maintainer_merge_message.py
+
+      - name: Determine Zulip topic
+        if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
+        id: determine_topic
+        run: |
+          ./scripts/get_tlabel.sh "/repos/leanprover-community/mathlib4/issues/${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          PR_NUMBER: ${{ steps.extract-data.outputs.pr_number }}
+
+      - name: Form the message
+        if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
+        id: form_the_message
+        run: |
+          message="$(
+            ./scripts/maintainer_merge_message.sh "${AUTHOR}" "${{ steps.extract-data.outputs.mOrD }}" "${EVENT_NAME}" "${PR_NUMBER}" "${PR_URL}" "${PR_TITLE}" "${COMMENT}" "${PR_AUTHOR}"
+          )"
+          printf 'title<<EOF\n%s\nEOF' "${message}" | tee "$GITHUB_OUTPUT"
+        env:
+          EVENT_NAME: ${{ steps.extract-data.outputs.event_name }}
+          PR_NUMBER: ${{ steps.extract-data.outputs.pr_number }}
+          PR_URL: ${{ steps.extract-data.outputs.pr_url }}
+          PR_TITLE: ${{ steps.extract-data.outputs.pr_title }}
+          COMMENT: ${{ steps.extract-data.outputs.comment }}
+          PR_AUTHOR: ${{ steps.extract-data.outputs.pr_author }}
+
+      - name: Send message on Zulip
+        if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
+        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
+        with:
+          api-key: ${{ secrets.ZULIP_API_KEY }}
+          email: 'github-mathlib4-bot@leanprover.zulipchat.com'
+          organization-url: 'https://leanprover.zulipchat.com'
+          to: 'mathlib reviewers'
+          type: 'stream'
+          topic: ${{ steps.determine_topic.outputs.topic }}
+          content: ${{ steps.form_the_message.outputs.title }}
+
+      - name: Add comment to PR
+        if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
+        uses: GrantBirki/comment@608e41b19bc973020ec0e189ebfdae935d7fe0cc # v2.1.1
+        with:
+          # if a comment triggers the action, then `issue.number` is set
+          # if a review or review comment triggers the action, then `pull_request.number` is set
+          issue-number: ${{ steps.extract-data.outputs.pr_number }}
+          body: |
+            🚀 Pull request has been placed on the maintainer queue by ${{ steps.extract-data.outputs.author }}.
+
+      - name: Add label to PR
+        if: ${{ steps.actorTeams.outputs.isTeamMember == 'true' }}
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          # labels added by GITHUB_TOKEN won't trigger the Zulip emoji workflow
+          github-token: ${{secrets.TRIAGE_TOKEN}}
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = ${{ steps.extract-data.outputs.pr_number }};
+            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['maintainer-merge'] });

--- a/.github/workflows/maintainer_merge_wf_run.yml
+++ b/.github/workflows/maintainer_merge_wf_run.yml
@@ -54,7 +54,7 @@ jobs:
               echo "pr_url=$pr_url"
               echo "event_name=$event_name"
               echo "mOrD=$m_or_d"
-            } >> "$GITHUB_OUTPUT"
+            } | tee -a "$GITHUB_OUTPUT"
           else
             echo "JSON artifact file not found!"
             exit 1


### PR DESCRIPTION
In #25675, the `maintainer_merge.yml` and `maintainer_bors.yml` workflows were partially disabled for PRs from forks because workflows triggered by `pull_request_review` and `pull_request_review_comment` for PRs from forks do not get access to secrets. Here we add back that functionality as follows:
- If the workflow does not have access to secrets, we upload the necessary data to a workflow artifact, and then skip the rest of the steps
- (If the workflow does have access to secrets, the behavior should be unchanged.)
- We add new downstream workflow `maintainer_[merge/bors]_wf_run.yml` which triggers on completion of the original workflow via `workflow_run` (inspired by #25649)
  - If the artifact exists, we download and extract the data from it
  - then use the data to carry out the steps we were unable to before.
  - This is possible because `workflow_run` workflows have access to secrets.

It might be cleaner to have all paths go through the second workflow, however I decided to try to leave as much of the original code alone as possible. Also, changing to always do the main steps in another workflow run would also slow down the labeling in the cases that already work.

---

This probably can't be tested in full without being merged to `master`; however, before doing so it'd be good to check over the scripts for typos / incorrectly named outputs, etc.

Written with a little bit of help from Claude.