### PR TITLE
[Merged by Bors] - chore(CI): test building tools when their source code changes

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -156,12 +156,15 @@ jobs:
               - 'scripts/mk_all.lean'
             lint_style:
               - 'scripts/lint-style.lean'
+              - 'Mathlib/Tactic/Linter/TextBased.lean'
             shake:
               - 'Shake/**'
             longest_pole:
               - 'LongestPole/**'
             mathlib_test:
               - 'MathlibTest/**'
+            docs:
+              - 'docs/**'
 
       - name: build pr-branch tools (test)
         if: steps.tool_changes.outputs.changes != '[]'

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -141,6 +141,61 @@ jobs:
           ls .lake/build/bin/check-yaml
           ls .lake/packages/importGraph/.lake/build/bin/graph
 
+      - name: Check for changes to tool source files
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: tool_changes
+        with:
+          filters: |
+            cache:
+              - 'Cache/**'
+            autolabel:
+              - 'scripts/autolabel.lean'
+            check_yaml:
+              - 'scripts/check-yaml.lean'
+            mk_all:
+              - 'scripts/mk_all.lean'
+            lint_style:
+              - 'scripts/lint-style.lean'
+            shake:
+              - 'Shake/**'
+            longest_pole:
+              - 'LongestPole/**'
+            mathlib_test:
+              - 'MathlibTest/**'
+
+      - name: build pr-branch tools (test)
+        if: steps.tool_changes.outputs.changes != '[]'
+        # Test building the tools from the PR branch to ensure any modifications work correctly
+        # This runs inside landrun for security
+        run: |
+          cd pr-branch
+          echo "Tool source files have been modified, building affected tools from PR branch..."
+
+          # Define mapping from filter names to tools to build (only for exceptions)
+          declare -A TOOLS_TO_BUILD=(
+            ["check_yaml"]="check-yaml"
+            ["lint_style"]="lint-style"
+            ["longest_pole"]="pole unused"
+            ["mathlib_test"]="mathlib_test_executable"
+          )
+
+          # Parse the changes array and build corresponding tools
+          changes='${{ steps.tool_changes.outputs.changes }}'
+          echo "Changed filters: $changes"
+
+          # Loop through each changed filter
+          for filter in $(echo "$changes" | jq -r '.[]'); do
+            echo "Processing filter: $filter"
+            # Use dictionary value if exists, otherwise use filter name as tool name
+            if [[ -n "${TOOLS_TO_BUILD[$filter]}" ]]; then
+              tools="${TOOLS_TO_BUILD[$filter]}"
+            else
+              tools="$filter"
+            fi
+            echo "Building $tools..."
+            lake build $tools
+          done
+
       - name: cleanup .cache/mathlib
         # This needs write access to .cache/mathlib, so can't be run inside landrun.
         # However it is only using the `master` version of `cache`, so is safe to run outside landrun.

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -186,7 +186,7 @@ jobs:
           # Loop through each changed filter
           for filter in $(echo "$changes" | jq -r '.[]'); do
             echo "Processing filter: $filter"
-            # Use dictionary value if exists, otherwise use filter name as tool name
+            # Use dictionary value if it exists, otherwise use filter name as tool name
             if [[ -n "${TOOLS_TO_BUILD[$filter]}" ]]; then
               tools="${TOOLS_TO_BUILD[$filter]}"
             else

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -145,6 +145,7 @@ jobs:
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: tool_changes
         with:
+          working-directory: 'pr-branch'
           filters: |
             cache:
               - 'Cache/**'

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -155,6 +155,7 @@ jobs:
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: tool_changes
         with:
+          working-directory: 'pr-branch'
           filters: |
             cache:
               - 'Cache/**'

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -166,12 +166,15 @@ jobs:
               - 'scripts/mk_all.lean'
             lint_style:
               - 'scripts/lint-style.lean'
+              - 'Mathlib/Tactic/Linter/TextBased.lean'
             shake:
               - 'Shake/**'
             longest_pole:
               - 'LongestPole/**'
             mathlib_test:
               - 'MathlibTest/**'
+            docs:
+              - 'docs/**'
 
       - name: build pr-branch tools (test)
         if: steps.tool_changes.outputs.changes != '[]'
@@ -196,7 +199,7 @@ jobs:
           # Loop through each changed filter
           for filter in $(echo "$changes" | jq -r '.[]'); do
             echo "Processing filter: $filter"
-            # Use dictionary value if exists, otherwise use filter name as tool name
+            # Use dictionary value if it exists, otherwise use filter name as tool name
             if [[ -n "${TOOLS_TO_BUILD[$filter]}" ]]; then
               tools="${TOOLS_TO_BUILD[$filter]}"
             else

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -151,6 +151,61 @@ jobs:
           ls .lake/build/bin/check-yaml
           ls .lake/packages/importGraph/.lake/build/bin/graph
 
+      - name: Check for changes to tool source files
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: tool_changes
+        with:
+          filters: |
+            cache:
+              - 'Cache/**'
+            autolabel:
+              - 'scripts/autolabel.lean'
+            check_yaml:
+              - 'scripts/check-yaml.lean'
+            mk_all:
+              - 'scripts/mk_all.lean'
+            lint_style:
+              - 'scripts/lint-style.lean'
+            shake:
+              - 'Shake/**'
+            longest_pole:
+              - 'LongestPole/**'
+            mathlib_test:
+              - 'MathlibTest/**'
+
+      - name: build pr-branch tools (test)
+        if: steps.tool_changes.outputs.changes != '[]'
+        # Test building the tools from the PR branch to ensure any modifications work correctly
+        # This runs inside landrun for security
+        run: |
+          cd pr-branch
+          echo "Tool source files have been modified, building affected tools from PR branch..."
+
+          # Define mapping from filter names to tools to build (only for exceptions)
+          declare -A TOOLS_TO_BUILD=(
+            ["check_yaml"]="check-yaml"
+            ["lint_style"]="lint-style"
+            ["longest_pole"]="pole unused"
+            ["mathlib_test"]="mathlib_test_executable"
+          )
+
+          # Parse the changes array and build corresponding tools
+          changes='${{ steps.tool_changes.outputs.changes }}'
+          echo "Changed filters: $changes"
+
+          # Loop through each changed filter
+          for filter in $(echo "$changes" | jq -r '.[]'); do
+            echo "Processing filter: $filter"
+            # Use dictionary value if exists, otherwise use filter name as tool name
+            if [[ -n "${TOOLS_TO_BUILD[$filter]}" ]]; then
+              tools="${TOOLS_TO_BUILD[$filter]}"
+            else
+              tools="$filter"
+            fi
+            echo "Building $tools..."
+            lake build $tools
+          done
+
       - name: cleanup .cache/mathlib
         # This needs write access to .cache/mathlib, so can't be run inside landrun.
         # However it is only using the `master` version of `cache`, so is safe to run outside landrun.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,6 +158,61 @@ jobs:
           ls .lake/build/bin/check-yaml
           ls .lake/packages/importGraph/.lake/build/bin/graph
 
+      - name: Check for changes to tool source files
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: tool_changes
+        with:
+          filters: |
+            cache:
+              - 'Cache/**'
+            autolabel:
+              - 'scripts/autolabel.lean'
+            check_yaml:
+              - 'scripts/check-yaml.lean'
+            mk_all:
+              - 'scripts/mk_all.lean'
+            lint_style:
+              - 'scripts/lint-style.lean'
+            shake:
+              - 'Shake/**'
+            longest_pole:
+              - 'LongestPole/**'
+            mathlib_test:
+              - 'MathlibTest/**'
+
+      - name: build pr-branch tools (test)
+        if: steps.tool_changes.outputs.changes != '[]'
+        # Test building the tools from the PR branch to ensure any modifications work correctly
+        # This runs inside landrun for security
+        run: |
+          cd pr-branch
+          echo "Tool source files have been modified, building affected tools from PR branch..."
+
+          # Define mapping from filter names to tools to build (only for exceptions)
+          declare -A TOOLS_TO_BUILD=(
+            ["check_yaml"]="check-yaml"
+            ["lint_style"]="lint-style"
+            ["longest_pole"]="pole unused"
+            ["mathlib_test"]="mathlib_test_executable"
+          )
+
+          # Parse the changes array and build corresponding tools
+          changes='${{ steps.tool_changes.outputs.changes }}'
+          echo "Changed filters: $changes"
+
+          # Loop through each changed filter
+          for filter in $(echo "$changes" | jq -r '.[]'); do
+            echo "Processing filter: $filter"
+            # Use dictionary value if exists, otherwise use filter name as tool name
+            if [[ -n "${TOOLS_TO_BUILD[$filter]}" ]]; then
+              tools="${TOOLS_TO_BUILD[$filter]}"
+            else
+              tools="$filter"
+            fi
+            echo "Building $tools..."
+            lake build $tools
+          done
+
       - name: cleanup .cache/mathlib
         # This needs write access to .cache/mathlib, so can't be run inside landrun.
         # However it is only using the `master` version of `cache`, so is safe to run outside landrun.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,6 +162,7 @@ jobs:
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: tool_changes
         with:
+          working-directory: 'pr-branch'
           filters: |
             cache:
               - 'Cache/**'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,12 +173,15 @@ jobs:
               - 'scripts/mk_all.lean'
             lint_style:
               - 'scripts/lint-style.lean'
+              - 'Mathlib/Tactic/Linter/TextBased.lean'
             shake:
               - 'Shake/**'
             longest_pole:
               - 'LongestPole/**'
             mathlib_test:
               - 'MathlibTest/**'
+            docs:
+              - 'docs/**'
 
       - name: build pr-branch tools (test)
         if: steps.tool_changes.outputs.changes != '[]'
@@ -203,7 +206,7 @@ jobs:
           # Loop through each changed filter
           for filter in $(echo "$changes" | jq -r '.[]'); do
             echo "Processing filter: $filter"
-            # Use dictionary value if exists, otherwise use filter name as tool name
+            # Use dictionary value if it exists, otherwise use filter name as tool name
             if [[ -n "${TOOLS_TO_BUILD[$filter]}" ]]; then
               tools="${TOOLS_TO_BUILD[$filter]}"
             else

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -155,6 +155,61 @@ jobs:
           ls .lake/build/bin/check-yaml
           ls .lake/packages/importGraph/.lake/build/bin/graph
 
+      - name: Check for changes to tool source files
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: tool_changes
+        with:
+          filters: |
+            cache:
+              - 'Cache/**'
+            autolabel:
+              - 'scripts/autolabel.lean'
+            check_yaml:
+              - 'scripts/check-yaml.lean'
+            mk_all:
+              - 'scripts/mk_all.lean'
+            lint_style:
+              - 'scripts/lint-style.lean'
+            shake:
+              - 'Shake/**'
+            longest_pole:
+              - 'LongestPole/**'
+            mathlib_test:
+              - 'MathlibTest/**'
+
+      - name: build pr-branch tools (test)
+        if: steps.tool_changes.outputs.changes != '[]'
+        # Test building the tools from the PR branch to ensure any modifications work correctly
+        # This runs inside landrun for security
+        run: |
+          cd pr-branch
+          echo "Tool source files have been modified, building affected tools from PR branch..."
+
+          # Define mapping from filter names to tools to build (only for exceptions)
+          declare -A TOOLS_TO_BUILD=(
+            ["check_yaml"]="check-yaml"
+            ["lint_style"]="lint-style"
+            ["longest_pole"]="pole unused"
+            ["mathlib_test"]="mathlib_test_executable"
+          )
+
+          # Parse the changes array and build corresponding tools
+          changes='${{ steps.tool_changes.outputs.changes }}'
+          echo "Changed filters: $changes"
+
+          # Loop through each changed filter
+          for filter in $(echo "$changes" | jq -r '.[]'); do
+            echo "Processing filter: $filter"
+            # Use dictionary value if exists, otherwise use filter name as tool name
+            if [[ -n "${TOOLS_TO_BUILD[$filter]}" ]]; then
+              tools="${TOOLS_TO_BUILD[$filter]}"
+            else
+              tools="$filter"
+            fi
+            echo "Building $tools..."
+            lake build $tools
+          done
+
       - name: cleanup .cache/mathlib
         # This needs write access to .cache/mathlib, so can't be run inside landrun.
         # However it is only using the `master` version of `cache`, so is safe to run outside landrun.

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -159,6 +159,7 @@ jobs:
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: tool_changes
         with:
+          working-directory: 'pr-branch'
           filters: |
             cache:
               - 'Cache/**'

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -170,12 +170,15 @@ jobs:
               - 'scripts/mk_all.lean'
             lint_style:
               - 'scripts/lint-style.lean'
+              - 'Mathlib/Tactic/Linter/TextBased.lean'
             shake:
               - 'Shake/**'
             longest_pole:
               - 'LongestPole/**'
             mathlib_test:
               - 'MathlibTest/**'
+            docs:
+              - 'docs/**'
 
       - name: build pr-branch tools (test)
         if: steps.tool_changes.outputs.changes != '[]'
@@ -200,7 +203,7 @@ jobs:
           # Loop through each changed filter
           for filter in $(echo "$changes" | jq -r '.[]'); do
             echo "Processing filter: $filter"
-            # Use dictionary value if exists, otherwise use filter name as tool name
+            # Use dictionary value if it exists, otherwise use filter name as tool name
             if [[ -n "${TOOLS_TO_BUILD[$filter]}" ]]; then
               tools="${TOOLS_TO_BUILD[$filter]}"
             else


### PR DESCRIPTION
Add conditional build step that detects changes to tool source files
(Cache/, scripts/*.lean, Shake/, LongestPole/, MathlibTest/) and builds
only the affected tools from the PR branch to catch compilation errors
early. Uses dorny/paths-filter for efficient change detection and
builds tools individually for clearer error messages.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
