### PR TITLE
[Merged by Bors] - feat: closure of rationals in real intervals

### DIFF
--- a/Mathlib/Algebra/Order/Archimedean/Basic.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Basic.lean
@@ -413,6 +413,9 @@ theorem exists_rat_btwn {x y : K} (h : x < y) : ∃ q : ℚ, x < q ∧ (q : K) <
     subst H
     cases n0
 
+theorem exists_rat_mem_uIoo {x y : K} (h : x ≠ y) : ∃ q : ℚ, ↑q ∈ Set.uIoo x y :=
+  exists_rat_btwn (min_lt_max.mpr h)
+
 theorem exists_pow_btwn {n : ℕ} (hn : n ≠ 0) {x y : K} (h : x < y) (hy : 0 < y) :
     ∃ q : K, 0 < q ∧ x < q ^ n ∧ q ^ n < y := by
   have ⟨δ, δ_pos, cont⟩ := uniform_continuous_npow_on_bounded (max 1 y)

--- a/Mathlib/Topology/Instances/Real/Lemmas.lean
+++ b/Mathlib/Topology/Instances/Real/Lemmas.lean
@@ -90,16 +90,27 @@ theorem Real.exists_seq_rat_strictAnti_tendsto (x : ℝ) :
 
 section
 
+theorem closure_ordConnected_inter_rat {s : Set ℝ} (conn : s.OrdConnected) (nt : s.Nontrivial) :
+    closure (s ∩ .range Rat.cast) = closure s :=
+  (closure_mono inter_subset_left).antisymm <| isClosed_closure.closure_subset_iff.mpr fun x hx ↦
+    Real.mem_closure_iff.mpr fun ε ε_pos ↦ by
+      have ⟨z, hz, ne⟩ := nt.exists_ne x
+      refine ne.lt_or_gt.elim (fun lt ↦ ?_) fun lt ↦ ?_
+      · have ⟨q, h₁, h₂⟩ := exists_rat_btwn (max_lt lt (sub_lt_self x ε_pos))
+        rw [max_lt_iff] at h₁
+        refine ⟨q, ⟨conn.out hz hx ⟨h₁.1.le, h₂.le⟩, q, rfl⟩, ?_⟩
+        simpa only [abs_sub_comm, abs_of_pos (sub_pos.mpr h₂), sub_lt_comm] using h₁.2
+      · have ⟨q, h₁, h₂⟩ := exists_rat_btwn (lt_min lt (lt_add_of_pos_right x ε_pos))
+        rw [lt_min_iff] at h₂
+        refine ⟨q, ⟨conn.out hx hz ⟨h₁.le, h₂.1.le⟩, q, rfl⟩, ?_⟩
+        simpa only [abs_of_pos (sub_pos.2 h₁), sub_lt_iff_lt_add'] using h₂.2
+
 theorem closure_of_rat_image_lt {q : ℚ} :
-    closure (((↑) : ℚ → ℝ) '' { x | q < x }) = { r | ↑q ≤ r } :=
-  Subset.antisymm
-    (isClosed_Ici.closure_subset_iff.2
-      (image_subset_iff.2 fun p (h : q < p) => by simpa using h.le))
-    fun x hx => mem_closure_iff_nhds.2 fun _ ht =>
-      let ⟨ε, ε0, hε⟩ := Metric.mem_nhds_iff.1 ht
-      let ⟨p, h₁, h₂⟩ := exists_rat_btwn ((lt_add_iff_pos_right x).2 ε0)
-      ⟨p, hε <| by rwa [mem_ball, Real.dist_eq, abs_of_pos (sub_pos.2 h₁), sub_lt_iff_lt_add'],
-        mem_image_of_mem _ <| Rat.cast_lt.1 <| lt_of_le_of_lt hx.out h₁⟩
+    closure (((↑) : ℚ → ℝ) '' { x | q < x }) = { r | ↑q ≤ r } := by
+  convert closure_ordConnected_inter_rat (ordConnected_Ioi (a := (q : ℝ))) _ using 1
+  · congr!; aesop
+  · exact (closure_Ioi _).symm
+  · exact ⟨q + 1, show (q : ℝ) < _ by linarith, q + 2, show (q : ℝ) < _ by linarith, by simp⟩
 
 /- TODO(Mario): Put these back only if needed later
 lemma closure_of_rat_image_le_eq {q : ℚ} : closure ((coe : ℚ → ℝ) '' {x | q ≤ x}) = {r | ↑q ≤ r} :=


### PR DESCRIPTION
Show that any `OrdConnected` set of real numbers has the same closure as the set of rational numbers in it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
