### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/Matrix/Determinant/TotallyUnimodular):

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/Determinant/TotallyUnimodular.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/TotallyUnimodular.lean
@@ -98,6 +98,21 @@ lemma reindex_isTotallyUnimodular (A : Matrix m n R) (em : m ≃ m') (en : n ≃
   ⟨fun hA => by simpa [Equiv.symm_apply_eq] using hA.reindex em.symm en.symm,
    fun hA => hA.reindex _ _⟩
 
+/-- If `A` has no rows, then it is totally unimodular. -/
+@[simp]
+lemma emptyRows_isTotallyUnimodular [IsEmpty m] (A : Matrix m n R) :
+    A.IsTotallyUnimodular := by
+  intro k f _ _ _
+  cases k with
+  | zero => use 1; rw [submatrix_empty, det_fin_zero, SignType.coe_one]
+  | succ => exact (IsEmpty.false (f 0)).elim
+
+/-- If `A` has no columns, then it is totally unimodular. -/
+@[simp]
+lemma emptyCols_isTotallyUnimodular [IsEmpty n] (A : Matrix m n R) :
+    A.IsTotallyUnimodular :=
+  A.transpose.emptyRows_isTotallyUnimodular.transpose
+
 /-- If `A` is totally unimodular and each row of `B` is all zeros except for at most a single `1` or
 a single `-1` then `fromRows A B` is totally unimodular. -/
 lemma IsTotallyUnimodular.fromRows_unitlike [DecidableEq n] {A : Matrix m n R} {B : Matrix m' n R}


### PR DESCRIPTION
Empty matrices are totally unimodular.
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
