### PR TITLE
[Merged by Bors] - chore(Data/Finsupp/Basic): split file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3004,6 +3004,7 @@ import Mathlib.Data.Finsupp.MonomialOrder.DegLex
 import Mathlib.Data.Finsupp.Multiset
 import Mathlib.Data.Finsupp.NeLocus
 import Mathlib.Data.Finsupp.Notation
+import Mathlib.Data.Finsupp.Option
 import Mathlib.Data.Finsupp.Order
 import Mathlib.Data.Finsupp.PWO
 import Mathlib.Data.Finsupp.Pointwise

--- a/Mathlib/Algebra/MvPolynomial/Equiv.lean
+++ b/Mathlib/Algebra/MvPolynomial/Equiv.lean
@@ -8,6 +8,7 @@ import Mathlib.Algebra.MvPolynomial.Degrees
 import Mathlib.Algebra.MvPolynomial.Rename
 import Mathlib.Algebra.Polynomial.AlgebraMap
 import Mathlib.Algebra.Polynomial.Degree.Lemmas
+import Mathlib.Data.Finsupp.Option
 import Mathlib.Logic.Equiv.Fin.Basic
 
 /-!

--- a/Mathlib/Data/Finsupp/Basic.lean
+++ b/Mathlib/Data/Finsupp/Basic.lean
@@ -5,7 +5,6 @@ Authors: Johannes Hölzl, Kim Morrison
 -/
 import Mathlib.Algebra.BigOperators.Finsupp.Basic
 import Mathlib.Algebra.BigOperators.Group.Finset.Preimage
-import Mathlib.Algebra.Module.Defs
 import Mathlib.Data.Rat.BigOperators
 
 /-!
@@ -18,8 +17,6 @@ import Mathlib.Data.Rat.BigOperators
 * `Finsupp.mapDomain`: maps the domain of a `Finsupp` by a function and by summing.
 * `Finsupp.comapDomain`: postcomposition of a `Finsupp` with a function injective on the preimage
   of its support.
-* `Finsupp.some`: restrict a finitely supported function on `Option α` to a finitely supported
-  function on `α`.
 * `Finsupp.filter`: `filter p f` is the finitely supported function that is `f a` if `p a` is true
   and 0 otherwise.
 * `Finsupp.frange`: the image of a finitely supported function on its support.
@@ -30,9 +27,6 @@ import Mathlib.Data.Rat.BigOperators
 This file is a `noncomputable theory` and uses classical logic throughout.
 
 ## TODO
-
-* This file is currently ~1600 lines long and is quite a miscellany of definitions and lemmas,
-  so it should be divided into smaller pieces.
 
 * Expand the list of definitions and important lemmas to the module docstring.
 
@@ -719,100 +713,6 @@ end FInjective
 
 end ComapDomain
 
-/-! ### Declarations about finitely supported functions whose support is an `Option` type -/
-
-
-section Option
-
-/-- Restrict a finitely supported function on `Option α` to a finitely supported function on `α`. -/
-def some [Zero M] (f : Option α →₀ M) : α →₀ M :=
-  f.comapDomain Option.some fun _ => by simp
-
-@[simp]
-theorem some_apply [Zero M] (f : Option α →₀ M) (a : α) : f.some a = f (Option.some a) :=
-  rfl
-
-@[simp]
-theorem some_zero [Zero M] : (0 : Option α →₀ M).some = 0 := by
-  ext
-  simp
-
-@[simp]
-theorem some_add [AddZeroClass M] (f g : Option α →₀ M) : (f + g).some = f.some + g.some := by
-  ext
-  simp
-
-@[simp]
-theorem some_single_none [Zero M] (m : M) : (single none m : Option α →₀ M).some = 0 := by
-  ext
-  simp
-
-@[simp]
-theorem some_single_some [Zero M] (a : α) (m : M) :
-    (single (Option.some a) m : Option α →₀ M).some = single a m := by
-  classical
-    ext b
-    simp [single_apply]
-
-@[simp]
-theorem embDomain_some_some [Zero M] (f : α →₀ M) (x) : f.embDomain .some (.some x) = f x := by
-  simp [← Function.Embedding.some_apply]
-
-@[simp]
-theorem some_update_none [Zero M] (f : Option α →₀ M) (a : M) :
-    (f.update .none a).some = f.some := by
-  ext
-  simp [Finsupp.update]
-
-/-- `Finsupp`s from `Option` are equivalent to
-pairs of an element and a `Finsupp` on the original type. -/
-@[simps]
-noncomputable
-def optionEquiv [Zero M] : (Option α →₀ M) ≃ M × (α →₀ M) where
-  toFun P := (P .none, P.some)
-  invFun P := (P.2.embDomain .some).update .none P.1
-  left_inv P := by ext (_|a) <;> simp [Finsupp.update]
-  right_inv P := by ext <;> simp [Finsupp.update]
-
-@[to_additive]
-theorem prod_option_index [AddZeroClass M] [CommMonoid N] (f : Option α →₀ M)
-    (b : Option α → M → N) (h_zero : ∀ o, b o 0 = 1)
-    (h_add : ∀ o m₁ m₂, b o (m₁ + m₂) = b o m₁ * b o m₂) :
-    f.prod b = b none (f none) * f.some.prod fun a => b (Option.some a) := by
-  classical
-    induction f using induction_linear with
-    | zero => simp [some_zero, h_zero]
-    | add f₁ f₂ h₁ h₂ =>
-      rw [Finsupp.prod_add_index, h₁, h₂, some_add, Finsupp.prod_add_index]
-      · simp only [h_add, Pi.add_apply, Finsupp.coe_add]
-        rw [mul_mul_mul_comm]
-      all_goals simp [h_zero, h_add]
-    | single a m => cases a <;> simp [h_zero, h_add]
-
-theorem sum_option_index_smul [Semiring R] [AddCommMonoid M] [Module R M] (f : Option α →₀ R)
-    (b : Option α → M) :
-    (f.sum fun o r => r • b o) = f none • b none + f.some.sum fun a r => r • b (Option.some a) :=
-  f.sum_option_index _ (fun _ => zero_smul _ _) fun _ _ _ => add_smul _ _ _
-
-theorem eq_option_embedding_update_none_iff [Zero M] {n : Option α →₀ M} {m : α →₀ M} {i : M} :
-    (n = (embDomain Embedding.some m).update none i) ↔
-      n none = i ∧ n.some = m := by
-  classical
-  rw [Finsupp.ext_iff, Option.forall, Finsupp.ext_iff]
-  apply and_congr
-  · simp
-  · apply forall_congr'
-    intro
-    simp only [coe_update, ne_eq, reduceCtorEq, not_false_eq_true, update_of_ne, some_apply]
-    rw [← Embedding.some_apply, embDomain_apply, Embedding.some_apply]
-
-@[simp] lemma some_embDomain_some [Zero M] (f : α →₀ M) : (f.embDomain .some).some = f := by
-  ext; rw [some_apply]; exact embDomain_apply _ _ _
-
-@[simp] lemma embDomain_some_none [Zero M] (f : α →₀ M) : f.embDomain .some .none = 0 :=
-  embDomain_notin_range _ _ _ (by simp)
-
-end Option
 
 /-! ### Declarations about `Finsupp.filter` -/
 
@@ -1511,5 +1411,3 @@ theorem sigmaFinsuppAddEquivPiFinsupp_apply {α : Type*} {ιs : η → Type*} [A
 end Sigma
 
 end Finsupp
-
-set_option linter.style.longFile 1700

--- a/Mathlib/Data/Finsupp/Option.lean
+++ b/Mathlib/Data/Finsupp/Option.lean
@@ -1,0 +1,124 @@
+/-
+Copyright (c) 2017 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Kim Morrison
+-/
+import Mathlib.Data.Finsupp.Basic
+import Mathlib.Algebra.Module.Defs
+
+/-!
+# Declarations about finitely supported functions whose support is an `Option` type p
+
+## Main declarations
+
+* `Finsupp.some`: restrict a finitely supported function on `Option α` to a finitely supported
+  function on `α`.
+
+## Implementation notes
+
+This file is a `noncomputable theory` and uses classical logic throughout.
+
+-/
+
+
+noncomputable section
+
+open Finset Function
+
+variable {α β γ ι M M' N P G H R S : Type*}
+
+namespace Finsupp
+
+section Option
+
+/-- Restrict a finitely supported function on `Option α` to a finitely supported function on `α`. -/
+def some [Zero M] (f : Option α →₀ M) : α →₀ M :=
+  f.comapDomain Option.some fun _ => by simp
+
+@[simp]
+theorem some_apply [Zero M] (f : Option α →₀ M) (a : α) : f.some a = f (Option.some a) :=
+  rfl
+
+@[simp]
+theorem some_zero [Zero M] : (0 : Option α →₀ M).some = 0 := by
+  ext
+  simp
+
+@[simp]
+theorem some_add [AddZeroClass M] (f g : Option α →₀ M) : (f + g).some = f.some + g.some := by
+  ext
+  simp
+
+@[simp]
+theorem some_single_none [Zero M] (m : M) : (single none m : Option α →₀ M).some = 0 := by
+  ext
+  simp
+
+@[simp]
+theorem some_single_some [Zero M] (a : α) (m : M) :
+    (single (Option.some a) m : Option α →₀ M).some = single a m := by
+  classical
+    ext b
+    simp [single_apply]
+
+@[simp]
+theorem embDomain_some_some [Zero M] (f : α →₀ M) (x) : f.embDomain .some (.some x) = f x := by
+  simp [← Function.Embedding.some_apply]
+
+@[simp]
+theorem some_update_none [Zero M] (f : Option α →₀ M) (a : M) :
+    (f.update .none a).some = f.some := by
+  ext
+  simp [Finsupp.update]
+
+/-- `Finsupp`s from `Option` are equivalent to
+pairs of an element and a `Finsupp` on the original type. -/
+@[simps]
+noncomputable
+def optionEquiv [Zero M] : (Option α →₀ M) ≃ M × (α →₀ M) where
+  toFun P := (P .none, P.some)
+  invFun P := (P.2.embDomain .some).update .none P.1
+  left_inv P := by ext (_|a) <;> simp [Finsupp.update]
+  right_inv P := by ext <;> simp [Finsupp.update]
+
+@[to_additive]
+theorem prod_option_index [AddZeroClass M] [CommMonoid N] (f : Option α →₀ M)
+    (b : Option α → M → N) (h_zero : ∀ o, b o 0 = 1)
+    (h_add : ∀ o m₁ m₂, b o (m₁ + m₂) = b o m₁ * b o m₂) :
+    f.prod b = b none (f none) * f.some.prod fun a => b (Option.some a) := by
+  classical
+    induction f using induction_linear with
+    | zero => simp [some_zero, h_zero]
+    | add f₁ f₂ h₁ h₂ =>
+      rw [Finsupp.prod_add_index, h₁, h₂, some_add, Finsupp.prod_add_index]
+      · simp only [h_add, Pi.add_apply, Finsupp.coe_add]
+        rw [mul_mul_mul_comm]
+      all_goals simp [h_zero, h_add]
+    | single a m => cases a <;> simp [h_zero, h_add]
+
+theorem sum_option_index_smul [Semiring R] [AddCommMonoid M] [Module R M] (f : Option α →₀ R)
+    (b : Option α → M) :
+    (f.sum fun o r => r • b o) = f none • b none + f.some.sum fun a r => r • b (Option.some a) :=
+  f.sum_option_index _ (fun _ => zero_smul _ _) fun _ _ _ => add_smul _ _ _
+
+theorem eq_option_embedding_update_none_iff [Zero M] {n : Option α →₀ M} {m : α →₀ M} {i : M} :
+    (n = (embDomain Embedding.some m).update none i) ↔
+      n none = i ∧ n.some = m := by
+  classical
+  rw [Finsupp.ext_iff, Option.forall, Finsupp.ext_iff]
+  apply and_congr
+  · simp
+  · apply forall_congr'
+    intro
+    simp only [coe_update, ne_eq, reduceCtorEq, not_false_eq_true, update_of_ne, some_apply]
+    rw [← Embedding.some_apply, embDomain_apply, Embedding.some_apply]
+
+@[simp] lemma some_embDomain_some [Zero M] (f : α →₀ M) : (f.embDomain .some).some = f := by
+  ext; rw [some_apply]; exact embDomain_apply _ _ _
+
+@[simp] lemma embDomain_some_none [Zero M] (f : α →₀ M) : f.embDomain .some .none = 0 :=
+  embDomain_notin_range _ _ _ (by simp)
+
+end Option
+
+end Finsupp

--- a/Mathlib/Data/Finsupp/Option.lean
+++ b/Mathlib/Data/Finsupp/Option.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2017 Johannes Hölzl. All rights reserved.
+Copyright (c) 2021 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Johannes Hölzl, Kim Morrison
+Authors: Kim Morrison
 -/
 import Mathlib.Data.Finsupp.Basic
 import Mathlib.Algebra.Module.Defs

--- a/Mathlib/LinearAlgebra/Finsupp/LinearCombination.lean
+++ b/Mathlib/LinearAlgebra/Finsupp/LinearCombination.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl
 -/
 import Mathlib.Algebra.Module.Submodule.Equiv
 import Mathlib.LinearAlgebra.Finsupp.Supported
+import Mathlib.Data.Finsupp.Option
 
 /-!
 # `Finsupp.linearCombination`

--- a/Mathlib/LinearAlgebra/Finsupp/LinearCombination.lean
+++ b/Mathlib/LinearAlgebra/Finsupp/LinearCombination.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
 import Mathlib.Algebra.Module.Submodule.Equiv
-import Mathlib.LinearAlgebra.Finsupp.Supported
 import Mathlib.Data.Finsupp.Option
+import Mathlib.LinearAlgebra.Finsupp.Supported
 
 /-!
 # `Finsupp.linearCombination`


### PR DESCRIPTION
This PR splits off a new file `Option.lean` from `Data/Finsupp/Basic.lean`. These definitions relate to finitely-supported functions on an `Option` type. This split anticipates #25920 adding more definitions on this subject to this new file.

This also eliminates a too-long file linter, reducing tech debt.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
