### PR TITLE
ci: specify leanprover-community/mathlib4 when checking out master

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           ref: master
           path: master-branch
+          repository: leanprover-community/mathlib4
 
       # Checkout the PR branch into a subdirectory
       - name: Checkout PR branch

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -78,6 +78,7 @@ jobs:
         with:
           ref: master
           path: master-branch
+          repository: leanprover-community/mathlib4
 
       # Checkout the PR branch into a subdirectory
       - name: Checkout PR branch

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,7 @@ jobs:
         with:
           ref: master
           path: master-branch
+          repository: leanprover-community/mathlib4
 
       # Checkout the PR branch into a subdirectory
       - name: Checkout PR branch

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -82,6 +82,7 @@ jobs:
         with:
           ref: master
           path: master-branch
+          repository: leanprover-community/mathlib4
 
       # Checkout the PR branch into a subdirectory
       - name: Checkout PR branch


### PR DESCRIPTION
This PR makes it explicit that we want to run CI against the `master` branch from `leanprover-community/mathlib4` instead of another repo.

The new mathlib4-nightly-testing repo should run CI on the nightly branches as if they are already part of the `master` branch. But when checking them out, it defaults to looking for the branch in `leanprover-community/mathlib4-nightly-testing`, which does not exist. So a simple fix is to make the upstream repo name explicit.

A potential disadvantage: it will be harder to test CI changes by opening a pull request against one's own fork. (Which is what I did to test a few CI changes before).

---

This change makes sense to me but maybe there is a better option? I don't think we want to have custom CI in the other repo, because it will get obliterated next time we do an update.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
