### PR TITLE
[Merged by Bors] - fix: remove unused `DecidableEq` arguments

### DIFF
--- a/Mathlib/RepresentationTheory/Homological/GroupCohomology/Basic.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupCohomology/Basic.lean
@@ -119,7 +119,7 @@ end inhomogeneousCochains
 
 namespace groupCohomology
 
-variable [Group G] [DecidableEq G] (n) (A : Rep k G)
+variable [Group G] (n) (A : Rep k G)
 
 open inhomogeneousCochains Rep
 
@@ -129,6 +129,7 @@ which calculates the group cohomology of `A`. -/
 noncomputable abbrev inhomogeneousCochains : CochainComplex (ModuleCat k) ℕ :=
   CochainComplex.of (fun n => ModuleCat.of k ((Fin n → G) → A))
     (fun n => inhomogeneousCochains.d A n) fun n => by
+    classical
     simp only [d_eq]
     slice_lhs 3 4 => { rw [Iso.hom_inv_id] }
     slice_lhs 2 4 => { rw [Category.id_comp, ((barComplex k G).linearYonedaObj k A).d_comp_d] }
@@ -149,7 +150,7 @@ theorem inhomogeneousCochains.d_comp_d :
 
 /-- Given a `k`-linear `G`-representation `A`, the complex of inhomogeneous cochains is isomorphic
 to `Hom(P, A)`, where `P` is the bar resolution of `k` as a trivial `G`-representation. -/
-def inhomogeneousCochainsIso :
+def inhomogeneousCochainsIso [DecidableEq G] :
     inhomogeneousCochains A ≅ (barComplex k G).linearYonedaObj k A := by
   refine HomologicalComplex.Hom.isoOfComponents
     (fun i => (Rep.freeLiftLEquiv (Fin i → G) A).toModuleIso.symm) ?_
@@ -176,12 +177,12 @@ open groupCohomology
 
 /-- The group cohomology of a `k`-linear `G`-representation `A`, as the cohomology of its complex
 of inhomogeneous cochains. -/
-def groupCohomology [Group G] [DecidableEq G] (A : Rep k G) (n : ℕ) : ModuleCat k :=
+def groupCohomology [Group G] (A : Rep k G) (n : ℕ) : ModuleCat k :=
   (inhomogeneousCochains A).homology n
 
 /-- The natural map from `n`-cocycles to `n`th group cohomology for a `k`-linear
 `G`-representation `A`. -/
-abbrev groupCohomology.π [Group G] [DecidableEq G] (A : Rep k G) (n : ℕ) :
+abbrev groupCohomology.π [Group G] (A : Rep k G) (n : ℕ) :
     groupCohomology.cocycles A n ⟶ groupCohomology A n :=
   (inhomogeneousCochains A).homologyπ n
 
@@ -189,7 +190,7 @@ abbrev groupCohomology.π [Group G] [DecidableEq G] (A : Rep k G) (n : ℕ) :
 noncomputable alias groupCohomologyπ := groupCohomology.π
 
 @[elab_as_elim]
-theorem groupCohomology_induction_on [Group G] [DecidableEq G] {A : Rep k G} {n : ℕ}
+theorem groupCohomology_induction_on [Group G] {A : Rep k G} {n : ℕ}
     {C : groupCohomology A n → Prop} (x : groupCohomology A n)
     (h : ∀ x : cocycles A n, C (π A n x)) : C x := by
   rcases (ModuleCat.epi_iff_surjective (π A n)).1 inferInstance x with ⟨y, rfl⟩

--- a/Mathlib/RepresentationTheory/Homological/GroupCohomology/Functoriality.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupCohomology/Functoriality.lean
@@ -545,7 +545,6 @@ alias H2π_comp_H2Map := H2π_comp_map
 
 end H2
 
--- variable [DecidableEq G]
 
 variable (k G) in
 /-- The functor sending a representation to its complex of inhomogeneous cochains. -/

--- a/Mathlib/RepresentationTheory/Homological/GroupCohomology/Functoriality.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupCohomology/Functoriality.lean
@@ -42,8 +42,6 @@ theorem congr {f₁ f₂ : G →* H} (h : f₁ = f₂) {φ : (Action.res _ f₁)
   subst h
   rfl
 
-variable [DecidableEq G] [DecidableEq H]
-
 /-- Given a group homomorphism `f : G →* H` and a representation morphism `φ : Res(f)(A) ⟶ B`,
 this is the chain map sending `x : Hⁿ → A` to `(g : Gⁿ) ↦ φ (x (f ∘ g))`. -/
 @[simps! -isSimp f f_hom]
@@ -72,8 +70,8 @@ lemma cochainsMap_id_f_hom_eq_compLeft {A B : Rep k G} (f : A ⟶ B) (i : ℕ) :
 alias cochainsMap_id_f_eq_compLeft := cochainsMap_id_f_hom_eq_compLeft
 
 @[reassoc]
-lemma cochainsMap_comp {G H K : Type u} [Group G] [DecidableEq G] [Group H] [DecidableEq H]
-    [Group K] [DecidableEq K] {A : Rep k K} {B : Rep k H} {C : Rep k G} (f : H →* K) (g : G →* H)
+lemma cochainsMap_comp {G H K : Type u} [Group G] [Group H]
+    [Group K] {A : Rep k K} {B : Rep k H} {C : Rep k G} (f : H →* K) (g : G →* H)
     (φ : (Action.res _ f).obj A ⟶ B) (ψ : (Action.res _ g).obj B ⟶ C) :
     cochainsMap (f.comp g) ((Action.res _ g).map φ ≫ ψ) =
       cochainsMap f φ ≫ cochainsMap g ψ := by
@@ -120,8 +118,8 @@ lemma cocyclesMap_id : cocyclesMap (MonoidHom.id G) (𝟙 B) n = 𝟙 _ :=
   HomologicalComplex.cyclesMap_id _ _
 
 @[reassoc]
-lemma cocyclesMap_comp {G H K : Type u} [Group G] [DecidableEq G] [Group H] [DecidableEq H]
-    [Group K] [DecidableEq K] {A : Rep k K} {B : Rep k H} {C : Rep k G} (f : H →* K) (g : G →* H)
+lemma cocyclesMap_comp {G H K : Type u} [Group G] [Group H]
+    [Group K] {A : Rep k K} {B : Rep k H} {C : Rep k G} (f : H →* K) (g : G →* H)
     (φ : (Action.res _ f).obj A ⟶ B) (ψ : (Action.res _ g).obj B ⟶ C) (n : ℕ) :
     cocyclesMap (f.comp g) ((Action.res _ g).map φ ≫ ψ) n =
       cocyclesMap f φ n ≫ cocyclesMap g ψ n := by
@@ -149,8 +147,8 @@ theorem π_map (n : ℕ) :
 lemma map_id : map (MonoidHom.id G) (𝟙 B) n = 𝟙 _ := HomologicalComplex.homologyMap_id _ _
 
 @[reassoc]
-lemma map_comp {G H K : Type u} [Group G] [DecidableEq G] [Group H] [DecidableEq H]
-    [Group K] [DecidableEq K] {A : Rep k K} {B : Rep k H} {C : Rep k G} (f : H →* K) (g : G →* H)
+lemma map_comp {G H K : Type u} [Group G] [Group H]
+    [Group K] {A : Rep k K} {B : Rep k H} {C : Rep k G} (f : H →* K) (g : G →* H)
     (φ : (Action.res _ f).obj A ⟶ B) (ψ : (Action.res _ g).obj B ⟶ C) (n : ℕ) :
     map (f.comp g) ((Action.res _ g).map φ ≫ ψ) n = map f φ n ≫ map g ψ n := by
   simp [map, ← HomologicalComplex.homologyMap_comp, ← cochainsMap_comp]
@@ -242,8 +240,6 @@ alias H0Map_comp := map_comp
 
 @[deprecated (since := "2025-06-09")]
 alias H0Map_id_comp := map_id_comp
-
-variable [DecidableEq G] [DecidableEq H]
 
 @[reassoc (attr := simp), elementwise (attr := simp)]
 theorem map_H0Iso_hom_f :
@@ -344,7 +340,6 @@ lemma coe_mapOneCocycles (x) :
 @[deprecated (since := "2025-05-09")]
 alias mapOneCocycles_comp_subtype := mapOneCocycles_comp_i
 
-variable [DecidableEq G] [DecidableEq H] in
 @[reassoc (attr := simp), elementwise (attr := simp)]
 lemma cocyclesMap_comp_isoOneCocycles_hom :
     cocyclesMap f φ 1 ≫ (isoOneCocycles B).hom = (isoOneCocycles A).hom ≫ mapOneCocycles f φ := by
@@ -372,8 +367,6 @@ alias H1Map_comp := map_comp
 @[deprecated (since := "2025-06-09")]
 alias H1Map_id_comp := map_id_comp
 
-variable [DecidableEq G] [DecidableEq H]
-
 @[reassoc (attr := simp), elementwise (attr := simp)]
 lemma H1π_comp_map :
     H1π A ≫ map f φ 1 = mapOneCocycles f φ ≫ H1π B := by
@@ -392,7 +385,7 @@ alias H1Map_one := map_1_one
 
 section InfRes
 
-variable (A : Rep k G) (S : Subgroup G) [S.Normal] [DecidableEq (G ⧸ S)]
+variable (A : Rep k G) (S : Subgroup G) [S.Normal]
 
 /-- The short complex `H¹(G ⧸ S, A^S) ⟶ H¹(G, A) ⟶ H¹(S, A)`. -/
 @[simps X₁ X₂ X₃ f g]
@@ -522,7 +515,6 @@ lemma coe_mapTwoCocycles (x) :
 @[deprecated (since := "2025-05-09")]
 alias mapTwoCocycles_comp_subtype := mapTwoCocycles_comp_i
 
-variable [DecidableEq G] [DecidableEq H] in
 @[reassoc (attr := simp), elementwise (attr := simp)]
 lemma cocyclesMap_comp_isoTwoCocycles_hom :
     cocyclesMap f φ 2 ≫ (isoTwoCocycles B).hom = (isoTwoCocycles A).hom ≫ mapTwoCocycles f φ := by
@@ -543,7 +535,6 @@ alias H2Map_comp := map_comp
 @[deprecated (since := "2025-06-09")]
 alias H2Map_id_comp := map_id_comp
 
-variable [DecidableEq G] [DecidableEq H] in
 @[reassoc (attr := simp), elementwise (attr := simp)]
 lemma H2π_comp_map :
     H2π A ≫ map f φ 2 = mapTwoCocycles f φ ≫ H2π B := by
@@ -554,7 +545,7 @@ alias H2π_comp_H2Map := H2π_comp_map
 
 end H2
 
-variable [DecidableEq G]
+-- variable [DecidableEq G]
 
 variable (k G) in
 /-- The functor sending a representation to its complex of inhomogeneous cochains. -/

--- a/Mathlib/RepresentationTheory/Homological/GroupCohomology/Hilbert90.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupCohomology/Hilbert90.lean
@@ -99,8 +99,7 @@ variable (K L : Type) [Field K] [Field L] [Algebra K L] [FiniteDimensional K L]
 
 /-- Noether's generalization of Hilbert's Theorem 90: given a finite extension of fields `L/K`, the
 first group cohomology `H¹(Aut_K(L), Lˣ)` is trivial. -/
-noncomputable instance H1ofAutOnUnitsUnique [DecidableEq (L ≃ₐ[K] L)] :
-    Unique (H1 (Rep.ofAlgebraAutOnUnits K L)) where
+noncomputable instance H1ofAutOnUnitsUnique : Unique (H1 (Rep.ofAlgebraAutOnUnits K L)) where
   default := 0
   uniq := fun a => H1_induction_on a fun x => (H1π_eq_zero_iff _).2 <| by
     refine (oneCoboundariesOfIsMulOneCoboundary ?_).2

--- a/Mathlib/RepresentationTheory/Homological/GroupCohomology/LowDegree.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupCohomology/LowDegree.lean
@@ -62,8 +62,6 @@ namespace groupCohomology
 
 section Cochains
 
-variable [DecidableEq G]
-
 /-- The 0th object in the complex of inhomogeneous cochains of `A : Rep k G` is isomorphic
 to `A` as a `k`-module. -/
 def zeroCochainsIso : (inhomogeneousCochains A).X 0 ≅ A.V :=
@@ -147,8 +145,6 @@ def dTwo : ModuleCat.of k (G × G → A) ⟶ ModuleCat.of k (G × G × G → A) 
         rw [map_add, add_sub_add_comm (A.ρ _ _), add_sub_assoc, add_sub_add_comm, add_add_add_comm,
           add_sub_assoc, add_sub_assoc]
     map_smul' r x := funext fun g => by dsimp; simp only [map_smul, smul_add, smul_sub] }
-
-variable [DecidableEq G]
 
 /-- Let `C(G, A)` denote the complex of inhomogeneous cochains of `A : Rep k G`. This lemma
 says `dZero` gives a simpler expression for the 0th differential: that is, the following
@@ -243,7 +239,6 @@ theorem eq_dTwo_comp_inv :
       dTwo A ≫ (threeCochainsIso A).inv :=
   (CommSq.horiz_inv ⟨comp_dTwo_eq A⟩).w
 
-omit [DecidableEq G] in
 @[reassoc (attr := simp), elementwise (attr := simp)]
 theorem dZero_comp_dOne : dZero A ≫ dOne A = 0 := by
   ext
@@ -251,7 +246,6 @@ theorem dZero_comp_dOne : dZero A ≫ dOne A = 0 := by
 
 @[deprecated (since := "2025-05-14")] alias dOne_comp_dZero := dZero_comp_dOne
 
-omit [DecidableEq G] in
 @[reassoc (attr := simp), elementwise (attr := simp)]
 theorem dOne_comp_dTwo : dOne A ≫ dTwo A = 0 := by
   ext f g
@@ -769,8 +763,6 @@ lemma shortComplexH0_exact : (shortComplexH0 A).Exact := by
   rw [← sub_eq_zero]
   exact congr_fun hx g
 
-variable [DecidableEq G]
-
 /-- The arrow `A --dZero--> Fun(G, A)` is isomorphic to the differential
 `(inhomogeneousCochains A).d 0 1` of the complex of inhomogeneous cochains of `A`. -/
 @[simps! hom_left hom_right inv_left inv_right]
@@ -811,8 +803,6 @@ end zeroCocyclesIso
 
 section isoOneCocycles
 
-variable [DecidableEq G]
-
 /-- The short complex `A --dZero--> Fun(G, A) --dOne--> Fun(G × G, A)` is isomorphic to the 1st
 short complex associated to the complex of inhomogeneous cochains of `A`. -/
 @[simps! hom inv]
@@ -851,8 +841,6 @@ lemma toCocycles_comp_isoOneCocycles_hom :
 end isoOneCocycles
 
 section isoTwoCocycles
-
-variable [DecidableEq G]
 
 /-- The short complex `Fun(G, A) --dOne--> Fun(G × G, A) --dTwo--> Fun(G × G × G, A)` is
 isomorphic to the 2nd short complex associated to the complex of inhomogeneous cochains of `A`. -/
@@ -894,8 +882,6 @@ end isoTwoCocycles
 end CocyclesIso
 
 section Cohomology
-
-variable [DecidableEq G]
 
 section H0
 


### PR DESCRIPTION
One proof needed this, but should have used `classical` instead. This propagated to huge swathes of API.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
