### PR TITLE
[Merged by Bors] - feat(Set/Monotone): convenience special cases for monotonicity on insert

### DIFF
--- a/Mathlib/Data/Set/Monotone.lean
+++ b/Mathlib/Data/Set/Monotone.lean
@@ -126,30 +126,29 @@ end Monotone
 
 section strictMono
 
-variable [Preorder α] [Preorder β] {f : α → β}
+variable [Preorder α] [Preorder β] {f : α → β} {s : Set α}
 
 @[simp]
-theorem strictMono_restrict {f : α → β} {s : Set α} :
+theorem strictMono_restrict :
     StrictMono (s.restrict f) ↔ StrictMonoOn f s := by simp [Set.restrict, StrictMono, StrictMonoOn]
 
 alias ⟨_root_.StrictMono.of_restrict, _root_.StrictMonoOn.restrict⟩ := strictMono_restrict
 
-theorem StrictMono.codRestrict {f : α → β} (hf : StrictMono f)
+theorem StrictMono.codRestrict (hf : StrictMono f)
     {s : Set β} (hs : ∀ x, f x ∈ s) : StrictMono (Set.codRestrict f s hs) :=
   hf
 
-lemma strictMonoOn_insert_iff {s : Set α} {a : α} :
+lemma strictMonoOn_insert_iff {a : α} :
     StrictMonoOn f (insert a s) ↔
        (∀ b ∈ s, b < a → f b < f a) ∧ (∀ b ∈ s, a < b → f a < f b) ∧ StrictMonoOn f s := by
   simp [StrictMonoOn, forall_and]
 
-lemma strictAntiOn_insert_iff {s : Set α} {a : α} :
+lemma strictAntiOn_insert_iff {a : α} :
     StrictAntiOn f (insert a s) ↔
        (∀ b ∈ s, b < a → f a < f b) ∧ (∀ b ∈ s, a < b → f b < f a) ∧ StrictAntiOn f s :=
   @strictMonoOn_insert_iff α βᵒᵈ _ _ _ _ _
 
-lemma strictMonoOn_insert_iff_of_forall_le
-    (s : Set α) (a : α) (ha : ∀ x ∈ s, x ≤ a) :
+lemma strictMonoOn_insert_iff_of_forall_le {a : α} (ha : ∀ x ∈ s, x ≤ a) :
     StrictMonoOn f (insert a s) ↔ (∀ b ∈ s, b < a → f b < f a) ∧ StrictMonoOn f s := by
   rw [strictMonoOn_insert_iff]
   have : ∀ b ∈ s, a < b → f a < f b := by
@@ -157,8 +156,7 @@ lemma strictMonoOn_insert_iff_of_forall_le
     cases (ha _ hb).not_gt hab
   tauto
 
-lemma strictMonoOn_insert_iff_of_forall_ge
-    (s : Set α) (a : α) (ha : ∀ x ∈ s, a ≤ x) :
+lemma strictMonoOn_insert_iff_of_forall_ge {a : α} (ha : ∀ x ∈ s, a ≤ x) :
     StrictMonoOn f (insert a s) ↔ (∀ b ∈ s, a < b → f a < f b) ∧ StrictMonoOn f s := by
   rw [strictMonoOn_insert_iff]
   have : ∀ b ∈ s, b < a → f b < f a := by
@@ -166,8 +164,7 @@ lemma strictMonoOn_insert_iff_of_forall_ge
     cases (ha _ hb).not_gt hab
   tauto
 
-lemma strictAntiOn_insert_iff_of_forall_le
-    (s : Set α) (a : α) (ha : ∀ x ∈ s, x ≤ a) :
+lemma strictAntiOn_insert_iff_of_forall_le {a : α} (ha : ∀ x ∈ s, x ≤ a) :
     StrictAntiOn f (insert a s) ↔ (∀ b ∈ s, b < a → f a < f b) ∧ StrictAntiOn f s := by
   rw [strictAntiOn_insert_iff]
   have : ∀ b ∈ s, a < b → f b < f a := by
@@ -175,8 +172,7 @@ lemma strictAntiOn_insert_iff_of_forall_le
     cases (ha _ hb).not_gt hab
   tauto
 
-lemma strictAntiOn_insert_iff_of_mem_lowerBounds
-    (s : Set α) (a : α) (ha : ∀ x ∈ s, a ≤ x) :
+lemma strictAntiOn_insert_iff_of_forall_ge {a : α} (ha : ∀ x ∈ s, a ≤ x) :
     StrictAntiOn f (insert a s) ↔ (∀ b ∈ s, a < b → f b < f a) ∧ StrictAntiOn f s := by
   rw [strictAntiOn_insert_iff]
   have : ∀ b ∈ s, b < a → f a < f b := by

--- a/Mathlib/Data/Set/Monotone.lean
+++ b/Mathlib/Data/Set/Monotone.lean
@@ -126,25 +126,63 @@ end Monotone
 
 section strictMono
 
+variable [Preorder α] [Preorder β] {f : α → β}
+
 @[simp]
-theorem strictMono_restrict [Preorder α] [Preorder β] {f : α → β} {s : Set α} :
+theorem strictMono_restrict {f : α → β} {s : Set α} :
     StrictMono (s.restrict f) ↔ StrictMonoOn f s := by simp [Set.restrict, StrictMono, StrictMonoOn]
 
 alias ⟨_root_.StrictMono.of_restrict, _root_.StrictMonoOn.restrict⟩ := strictMono_restrict
 
-theorem StrictMono.codRestrict [Preorder α] [Preorder β] {f : α → β} (hf : StrictMono f)
+theorem StrictMono.codRestrict {f : α → β} (hf : StrictMono f)
     {s : Set β} (hs : ∀ x, f x ∈ s) : StrictMono (Set.codRestrict f s hs) :=
   hf
 
-lemma strictMonoOn_insert_iff [Preorder α] [Preorder β] {f : α → β} {s : Set α} {a : α} :
+lemma strictMonoOn_insert_iff {s : Set α} {a : α} :
     StrictMonoOn f (insert a s) ↔
        (∀ b ∈ s, b < a → f b < f a) ∧ (∀ b ∈ s, a < b → f a < f b) ∧ StrictMonoOn f s := by
   simp [StrictMonoOn, forall_and]
 
-lemma strictAntiOn_insert_iff [Preorder α] [Preorder β] {f : α → β} {s : Set α} {a : α} :
+lemma strictAntiOn_insert_iff {s : Set α} {a : α} :
     StrictAntiOn f (insert a s) ↔
        (∀ b ∈ s, b < a → f a < f b) ∧ (∀ b ∈ s, a < b → f b < f a) ∧ StrictAntiOn f s :=
   @strictMonoOn_insert_iff α βᵒᵈ _ _ _ _ _
+
+lemma strictMonoOn_insert_iff_of_forall_le
+    (s : Set α) (a : α) (ha : ∀ x ∈ s, x ≤ a) :
+    StrictMonoOn f (insert a s) ↔ (∀ b ∈ s, b < a → f b < f a) ∧ StrictMonoOn f s := by
+  rw [strictMonoOn_insert_iff]
+  have : ∀ b ∈ s, a < b → f a < f b := by
+    intro b hb hab
+    cases (ha _ hb).not_gt hab
+  tauto
+
+lemma strictMonoOn_insert_iff_of_forall_ge
+    (s : Set α) (a : α) (ha : ∀ x ∈ s, a ≤ x) :
+    StrictMonoOn f (insert a s) ↔ (∀ b ∈ s, a < b → f a < f b) ∧ StrictMonoOn f s := by
+  rw [strictMonoOn_insert_iff]
+  have : ∀ b ∈ s, b < a → f b < f a := by
+    intro b hb hab
+    cases (ha _ hb).not_gt hab
+  tauto
+
+lemma strictAntiOn_insert_iff_of_forall_le
+    (s : Set α) (a : α) (ha : ∀ x ∈ s, x ≤ a) :
+    StrictAntiOn f (insert a s) ↔ (∀ b ∈ s, b < a → f a < f b) ∧ StrictAntiOn f s := by
+  rw [strictAntiOn_insert_iff]
+  have : ∀ b ∈ s, a < b → f b < f a := by
+    intro b hb hab
+    cases (ha _ hb).not_gt hab
+  tauto
+
+lemma strictAntiOn_insert_iff_of_mem_lowerBounds
+    (s : Set α) (a : α) (ha : ∀ x ∈ s, a ≤ x) :
+    StrictAntiOn f (insert a s) ↔ (∀ b ∈ s, a < b → f b < f a) ∧ StrictAntiOn f s := by
+  rw [strictAntiOn_insert_iff]
+  have : ∀ b ∈ s, b < a → f a < f b := by
+    intro b hb hab
+    cases (ha _ hb).not_gt hab
+  tauto
 
 end strictMono
 


### PR DESCRIPTION
Add four special case lemmas to describe monotonicity on `insert` in the case where the new element is above or below all existing ones.

Also make better use of `variable`. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
