### PR TITLE
[Merged by Bors] - feat(Mathlib/Data/Fin/Pigeonhole): pigeonhole-like results for Fin

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2919,6 +2919,7 @@ import Mathlib.Data.Fin.Embedding
 import Mathlib.Data.Fin.Fin2
 import Mathlib.Data.Fin.FlagRange
 import Mathlib.Data.Fin.Parity
+import Mathlib.Data.Fin.Pigeonhole
 import Mathlib.Data.Fin.Rev
 import Mathlib.Data.Fin.SuccPred
 import Mathlib.Data.Fin.Tuple.Basic

--- a/Mathlib/Data/Fin/Pigeonhole.lean
+++ b/Mathlib/Data/Fin/Pigeonhole.lean
@@ -20,15 +20,15 @@ variable {m n : ℕ}
 If we have an injective map from `Fin m` to `Fin n`, then `m ≤ n`.
 See also `Fintype.card_le_of_injective` for the generalisation to arbitrary finite types.
 -/
-theorem le_of_injective (f : Fin m → Fin n) (hf : f.Injective) : m ≤ n :=
-  Fintype.card_fin m ▸ Fintype.card_fin n ▸ Fintype.card_le_of_injective f hf
+theorem le_of_injective (f : Fin m → Fin n) (hf : f.Injective) : m ≤ n := by
+  simpa using Fintype.card_le_of_injective f hf
 
 /--
 If we have an embedding from `Fin m` to `Fin n`, then `m ≤ n`.
 See also `Fintype.card_le_of_embedding` for the generalisation to arbitrary finite types.
 -/
-theorem le_of_embedding (f : Fin m ↪ Fin n) : m ≤ n :=
-  Fintype.card_fin m ▸ Fintype.card_fin n ▸ Fintype.card_le_of_embedding f
+theorem le_of_embedding (f : Fin m ↪ Fin n) : m ≤ n := by
+  simpa using Fintype.card_le_of_embedding f
 
 /--
 If we have an injective map from `Fin m` to `Fin n` whose image does not contain everything,
@@ -36,15 +36,15 @@ then `m < n`. See also `Fintype.card_lt_of_injective_of_notMem` for the generali
 arbitrary finite types.
 -/
 theorem lt_of_injective_of_notMem (f : Fin m → Fin n) (hf : f.Injective) {b : Fin n}
-    (hb : b ∉ Set.range f) : m < n :=
-  Fintype.card_fin m ▸ Fintype.card_fin n ▸ Fintype.card_lt_of_injective_of_notMem f hf hb
+    (hb : b ∉ Set.range f) : m < n := by
+  simpa using Fintype.card_lt_of_injective_of_notMem f hf hb
 
 /--
 If we have a surjective map from `Fin m` to `Fin n`, then `m ≥ n`.
 See also `Fintype.card_le_of_surjective` for the generalisation to arbitrary finite types.
 -/
-theorem le_of_surjective (f : Fin m → Fin n) (hf : Function.Surjective f) : n ≤ m :=
-  Fintype.card_fin m ▸ Fintype.card_fin n ▸ Fintype.card_le_of_surjective f hf
+theorem le_of_surjective (f : Fin m → Fin n) (hf : Function.Surjective f) : n ≤ m := by
+  simpa using Fintype.card_le_of_surjective f hf
 
 /--
 Any map from `Fin m` reaches at most `m` different values.
@@ -52,7 +52,6 @@ See also `Fintype.card_range_le` for the generalisation to an arbitrary finite t
 -/
 theorem card_range_le {α : Type*} [Fintype α] [DecidableEq α] (f : Fin m → α) :
     Fintype.card (Set.range f) ≤ m := by
-  convert Fintype.card_range_le f
-  exact (Fintype.card_fin m).symm
+  simpa using Fintype.card_range_le f
 
 end Fin

--- a/Mathlib/Data/Fin/Pigeonhole.lean
+++ b/Mathlib/Data/Fin/Pigeonhole.lean
@@ -17,23 +17,41 @@ namespace Fin
 variable {m n : ℕ}
 
 /--
-If we have an injective map from `Fin m` to `Fin n`, we must have that `m ≤ n`. See also
-`Fintype.card_le_of_injective` for the generalisation to arbitrary finite types.
+If we have an injective map from `Fin m` to `Fin n`, then `m ≤ n`.
+See also `Fintype.card_le_of_injective` for the generalisation to arbitrary finite types.
 -/
 theorem le_of_injective (f : Fin m → Fin n) (hf : f.Injective) : m ≤ n :=
   Fintype.card_fin m ▸ Fintype.card_fin n ▸ Fintype.card_le_of_injective f hf
 
+/--
+If we have an embedding from `Fin m` to `Fin n`, then `m ≤ n`.
+See also `Fintype.card_le_of_embedding` for the generalisation to arbitrary finite types.
+-/
 theorem le_of_embedding (f : Fin m ↪ Fin n) : m ≤ n :=
   Fintype.card_fin m ▸ Fintype.card_fin n ▸ Fintype.card_le_of_embedding f
 
+/--
+If we have an injective map from `Fin m` to `Fin n` whose image does not contain everything,
+then `m < n`. See also `Fintype.card_lt_of_injective_of_notMem` for the generalisation to
+arbitrary finite types.
+-/
 theorem lt_of_injective_of_notMem (f : Fin m → Fin n) (hf : f.Injective) {b : Fin n}
     (hb : b ∉ Set.range f) : m < n :=
   Fintype.card_fin m ▸ Fintype.card_fin n ▸ Fintype.card_lt_of_injective_of_notMem f hf hb
 
+/--
+If we have a surjective map from `Fin m` to `Fin n`, then `m ≥ n`.
+See also `Fintype.card_le_of_surjective` for the generalisation to arbitrary finite types.
+-/
 theorem le_of_surjective (f : Fin m → Fin n) (hf : Function.Surjective f) : n ≤ m :=
   Fintype.card_fin m ▸ Fintype.card_fin n ▸ Fintype.card_le_of_surjective f hf
 
-theorem card_range_le (f : Fin m → Fin n) : Fintype.card (Set.range f) ≤ m := by
+/--
+Any map from `Fin m` reaches at most `m` different values.
+See also `Fintype.card_range_le` for the generalisation to an arbitrary finite type.
+-/
+theorem card_range_le {α : Type*} [Fintype α] [DecidableEq α] (f : Fin m → α) :
+    Fintype.card (Set.range f) ≤ m := by
   convert Fintype.card_range_le f
   exact (Fintype.card_fin m).symm
 

--- a/Mathlib/Data/Fin/Pigeonhole.lean
+++ b/Mathlib/Data/Fin/Pigeonhole.lean
@@ -16,6 +16,10 @@ namespace Fin
 
 variable {m n : ℕ}
 
+/--
+If we have an injective map from `Fin m` to `Fin n`, we must have that `m ≤ n`. See also
+`Fintype.card_le_of_injective` for the generalisation to arbitrary finite types.
+-/
 theorem le_of_injective (f : Fin m → Fin n) (hf : f.Injective) : m ≤ n :=
   Fintype.card_fin m ▸ Fintype.card_fin n ▸ Fintype.card_le_of_injective f hf
 

--- a/Mathlib/Data/Fin/Pigeonhole.lean
+++ b/Mathlib/Data/Fin/Pigeonhole.lean
@@ -1,0 +1,35 @@
+/-
+Copyright (c) 2025 Martin Dvorak. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Martin Dvorak
+-/
+import Mathlib.Data.Fintype.Card
+
+/-!
+# Pigeonhole-like results for Fin
+This adapts Pigeonhole-like results from `Mathlib.Data.Fintype.Card` to the setting where the map
+has the type `f : Fin m → Fin n`.
+-/
+
+namespace Fin
+
+variable {m n : ℕ}
+
+theorem le_of_injective (f : Fin m → Fin n) (hf : f.Injective) : m ≤ n :=
+  Fintype.card_fin m ▸ Fintype.card_fin n ▸ Fintype.card_le_of_injective f hf
+
+theorem le_of_embedding (f : Fin m ↪ Fin n) : m ≤ n :=
+  Fintype.card_fin m ▸ Fintype.card_fin n ▸ Fintype.card_le_of_embedding f
+
+theorem lt_of_injective_of_notMem (f : Fin m → Fin n) (hf : f.Injective) {b : Fin n}
+    (hb : b ∉ Set.range f) : m < n :=
+  Fintype.card_fin m ▸ Fintype.card_fin n ▸ Fintype.card_lt_of_injective_of_notMem f hf hb
+
+theorem le_of_surjective (f : Fin m → Fin n) (hf : Function.Surjective f) : n ≤ m :=
+  Fintype.card_fin m ▸ Fintype.card_fin n ▸ Fintype.card_le_of_surjective f hf
+
+theorem card_range_le (f : Fin m → Fin n) : Fintype.card (Set.range f) ≤ m := by
+  convert Fintype.card_range_le f
+  exact (Fintype.card_fin m).symm
+
+end Fin

--- a/Mathlib/Data/Fin/Pigeonhole.lean
+++ b/Mathlib/Data/Fin/Pigeonhole.lean
@@ -7,6 +7,7 @@ import Mathlib.Data.Fintype.Card
 
 /-!
 # Pigeonhole-like results for Fin
+
 This adapts Pigeonhole-like results from `Mathlib.Data.Fintype.Card` to the setting where the map
 has the type `f : Fin m → Fin n`.
 -/


### PR DESCRIPTION
Consider the following settings:

```
import Mathlib

example (X Y : Type) [Fintype X] [Fintype Y] (f : X → Y) (hf : f.Injective) :
    Fintype.card X ≤ Fintype.card Y := by
  hint

example (m n : ℕ) (f : Fin m → Fin n) (hf : f.Injective) :
    m ≤ n := by
  hint

example (X Y : Type) [Fintype X] [Fintype Y] (f : X ↪ Y) :
    Fintype.card X ≤ Fintype.card Y := by
  hint

example (m n : ℕ) (f : Fin m ↪ Fin n) :
    m ≤ n := by
  hint
```

The 1st and 3rd `hint` succeed, but the 2nd a 4th `hint` fail.

The problem is obviously that `exact?` does not see through `Fintype.card (Fin n) = n` when searching for appropriate lemma.
It may seem to not be a problem, as it will rarely derail experienced Mathlib users — after all, experienced Leaners usually go directly for the `Finset` or `Fintype` version.

However, beginners frequently work with `Fin` and they will expect stuff like
```
theorem le_of_injective (f : Fin m → Fin n) (hf : f.Injective) : m ≤ n
```
to exist; therefore, when `hint` or `exact?` fails, it is a very unpleasant surprise.

This PR addressed this issue; not to provide useful content for advanced users, but to make Mathlib more useful for beginners.

---

copied from #22792 where I lost push rights and needed to deprecate a name

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
