### PR TITLE
[Merged by Bors] - feat(Logic/Equiv/Fin): add `finSumNatEquiv`

### DIFF
--- a/Mathlib/Logic/Equiv/Fin/Basic.lean
+++ b/Mathlib/Logic/Equiv/Fin/Basic.lean
@@ -248,7 +248,7 @@ theorem finSumFinEquiv_symm_last : finSumFinEquiv.symm (Fin.last n) = Sum.inr 0 
   finSumFinEquiv_symm_apply_natAdd 0
 
 /-- Equivalence between `Fin n ⊕ ℕ` and `ℕ` that sends `inl (a : Fin n)` to
-`(a : ℕ)` and `inr a` to `a + n`. -/
+`(a : ℕ)` and `inr a` to `n + a`. -/
 def finSumNatEquiv (n : ℕ) : Fin n ⊕ ℕ ≃ ℕ where
   toFun := Sum.elim Fin.val (n + ·)
   invFun i := if hi : i < n then .inl ⟨i, hi⟩ else .inr (i - n)
@@ -273,21 +273,19 @@ def finSumNatEquiv (n : ℕ) : Fin n ⊕ ℕ ≃ ℕ where
     (finSumNatEquiv n).symm i = .inr (i - n) := dif_neg (Nat.not_lt_of_ge hi)
 
 theorem finSumNatEquiv_symm_apply_fin (i : Fin n) :
-    (finSumNatEquiv n).symm i = Sum.inl i := by simp
+    (finSumNatEquiv n).symm i = .inl i := by simp
 
 theorem finSumNatEquiv_symm_apply_add_left (i : ℕ) :
     (finSumNatEquiv n).symm (i + n) = .inr i := by simp
 
 theorem finSumNatEquiv_symm_apply_add_right (i : ℕ) :
-    (finSumNatEquiv n).symm (n + i) = Sum.inr i := by simp
+    (finSumNatEquiv n).symm (n + i) = .inr i := by simp
 
 @[simp] theorem isLeft_finSumNatEquiv_symm_apply (i : ℕ) :
     ((finSumNatEquiv n).symm i).isLeft = decide (i < n) := by
   rcases i.lt_or_ge n with hi | hi
-  · simp_rw [finSumNatEquiv_symm_apply_of_lt hi, hi]
-    rfl
-  · simp_rw [finSumNatEquiv_symm_apply_of_ge hi, hi.not_gt]
-    rfl
+  · simp_rw [finSumNatEquiv_symm_apply_of_lt hi, hi, Sum.isLeft_inl, decide_true]
+  · simp_rw [finSumNatEquiv_symm_apply_of_ge hi, hi.not_gt, Sum.isLeft_inr, decide_false]
 
 @[simp] theorem isRight_finSumNatEquiv_symm_apply (i : ℕ) :
     ((finSumNatEquiv n).symm i).isRight = decide (n ≤ i) := by

--- a/Mathlib/Logic/Equiv/Fin/Basic.lean
+++ b/Mathlib/Logic/Equiv/Fin/Basic.lean
@@ -247,6 +247,47 @@ theorem finSumFinEquiv_symm_apply_natAdd (x : Fin n) :
 theorem finSumFinEquiv_symm_last : finSumFinEquiv.symm (Fin.last n) = Sum.inr 0 :=
   finSumFinEquiv_symm_apply_natAdd 0
 
+def finSumNatEquiv (n : ℕ) : Fin n ⊕ ℕ ≃ ℕ where
+  toFun := Sum.elim Fin.val (· + n)
+  invFun i := if hi : i < n then Sum.inl ⟨i, hi⟩ else Sum.inr (i - n)
+  left_inv i := i.casesOn
+    (fun _ => dif_pos (Fin.is_lt _))
+    (fun _ => (dif_neg (n.le_add_left _).not_gt).trans <| congrArg _ <| Nat.add_sub_cancel _ _)
+  right_inv i := (apply_dite _ _ _ _).trans <| (i.lt_or_ge n).by_cases
+    (fun hi => dif_pos hi)
+    (fun hi => (dif_neg hi.not_gt).trans <| Nat.sub_add_cancel hi)
+
+@[simp] theorem finSumNatEquiv_apply_left (i : Fin n) :
+    (finSumNatEquiv n) (Sum.inl i) = i := rfl
+
+@[simp] theorem finSumNatEquiv_apply_right (i : ℕ) :
+    (finSumNatEquiv n) (Sum.inr i) = i + n := rfl
+
+@[simp] theorem finSumNatEquiv_symm_apply_of_lt {i : ℕ} (hi : i < n) :
+    (finSumNatEquiv n).symm i = Sum.inl ⟨i, hi⟩ := dif_pos hi
+
+@[simp] theorem finSumNatEquiv_symm_apply_of_ge {i : ℕ} (hi : n ≤ i) :
+    (finSumNatEquiv n).symm i = Sum.inr (i - n) := dif_neg (Nat.not_lt_of_ge hi)
+
+theorem finSumNatEquiv_symm_apply_fin (i : Fin n) :
+    (finSumNatEquiv n).symm i = Sum.inl i := by simp
+
+theorem finSumNatEquiv_symm_apply_add_left (i : ℕ) :
+    (finSumNatEquiv n).symm (i + n) = Sum.inr i := by simp
+
+theorem finSumNatEquiv_symm_apply_add_right (i : ℕ) :
+    (finSumNatEquiv n).symm (n + i) = Sum.inr i := by simp
+
+theorem isLeft_finSumNatEquiv_symm_apply (i : ℕ) :
+    ((finSumNatEquiv n).symm i).isLeft ↔ i < n :=
+  ⟨(fun hi => finSumNatEquiv_symm_apply_of_ge
+    (Nat.ge_of_not_lt hi) ▸ Bool.noConfusion).mtr,
+    fun h => finSumNatEquiv_symm_apply_of_lt h ▸ rfl⟩
+
+theorem isRight_finSumNatEquiv_symm_apply (i : ℕ) :
+    ((finSumNatEquiv n).symm i).isRight ↔ n ≤ i := by
+  simp_rw [← not_lt, ← isLeft_finSumNatEquiv_symm_apply, Sum.not_isLeft]
+
 /-- The equivalence between `Fin (m + n)` and `Fin (n + m)` which rotates by `n`. -/
 def finAddFlip : Fin (m + n) ≃ Fin (n + m) :=
   (finSumFinEquiv.symm.trans (Equiv.sumComm _ _)).trans finSumFinEquiv

--- a/Mathlib/Logic/Equiv/Fin/Basic.lean
+++ b/Mathlib/Logic/Equiv/Fin/Basic.lean
@@ -247,6 +247,8 @@ theorem finSumFinEquiv_symm_apply_natAdd (x : Fin n) :
 theorem finSumFinEquiv_symm_last : finSumFinEquiv.symm (Fin.last n) = Sum.inr 0 :=
   finSumFinEquiv_symm_apply_natAdd 0
 
+/-- Equivalence between `Fin n ⊕ ℕ` and `ℕ` that sends `inl (a : Fin n)` to
+  `(a : ℕ)` and `inr a` to `a + n`. -/
 def finSumNatEquiv (n : ℕ) : Fin n ⊕ ℕ ≃ ℕ where
   toFun := Sum.elim Fin.val (· + n)
   invFun i := if hi : i < n then Sum.inl ⟨i, hi⟩ else Sum.inr (i - n)

--- a/Mathlib/Logic/Equiv/Fin/Basic.lean
+++ b/Mathlib/Logic/Equiv/Fin/Basic.lean
@@ -248,47 +248,51 @@ theorem finSumFinEquiv_symm_last : finSumFinEquiv.symm (Fin.last n) = Sum.inr 0 
   finSumFinEquiv_symm_apply_natAdd 0
 
 /-- Equivalence between `Fin n ⊕ ℕ` and `ℕ` that sends `inl (a : Fin n)` to
-  `(a : ℕ)` and `inr a` to `a + n`. -/
+`(a : ℕ)` and `inr a` to `a + n`. -/
 def finSumNatEquiv (n : ℕ) : Fin n ⊕ ℕ ≃ ℕ where
-  toFun := Sum.elim Fin.val (· + n)
-  invFun i := if hi : i < n then Sum.inl ⟨i, hi⟩ else Sum.inr (i - n)
-  left_inv i := i.casesOn
+  toFun := Sum.elim Fin.val (n + ·)
+  invFun i := if hi : i < n then .inl ⟨i, hi⟩ else .inr (i - n)
+  left_inv i := (i.casesOn
     (fun _ => dif_pos (Fin.is_lt _))
-    (fun _ => (dif_neg (n.le_add_left _).not_gt).trans <| congrArg _ <| Nat.add_sub_cancel _ _)
+    (fun _ => (dif_neg (Nat.le_add_right _ _).not_gt).trans <|
+      congrArg _ (Nat.add_sub_cancel_left _ _)))
   right_inv i := (apply_dite _ _ _ _).trans <| (i.lt_or_ge n).by_cases
     (fun hi => dif_pos hi)
-    (fun hi => (dif_neg hi.not_gt).trans <| Nat.sub_add_cancel hi)
+    (fun hi => (dif_neg hi.not_gt).trans <| Nat.add_sub_cancel' hi)
 
 @[simp] theorem finSumNatEquiv_apply_left (i : Fin n) :
-    (finSumNatEquiv n) (Sum.inl i) = i := rfl
+    finSumNatEquiv n (.inl i) = i := rfl
 
 @[simp] theorem finSumNatEquiv_apply_right (i : ℕ) :
-    (finSumNatEquiv n) (Sum.inr i) = i + n := rfl
+    finSumNatEquiv n (.inr i) = n + i := rfl
 
 @[simp] theorem finSumNatEquiv_symm_apply_of_lt {i : ℕ} (hi : i < n) :
-    (finSumNatEquiv n).symm i = Sum.inl ⟨i, hi⟩ := dif_pos hi
+    (finSumNatEquiv n).symm i = .inl ⟨i, hi⟩ := dif_pos hi
 
 @[simp] theorem finSumNatEquiv_symm_apply_of_ge {i : ℕ} (hi : n ≤ i) :
-    (finSumNatEquiv n).symm i = Sum.inr (i - n) := dif_neg (Nat.not_lt_of_ge hi)
+    (finSumNatEquiv n).symm i = .inr (i - n) := dif_neg (Nat.not_lt_of_ge hi)
 
 theorem finSumNatEquiv_symm_apply_fin (i : Fin n) :
     (finSumNatEquiv n).symm i = Sum.inl i := by simp
 
 theorem finSumNatEquiv_symm_apply_add_left (i : ℕ) :
-    (finSumNatEquiv n).symm (i + n) = Sum.inr i := by simp
+    (finSumNatEquiv n).symm (i + n) = .inr i := by simp
 
 theorem finSumNatEquiv_symm_apply_add_right (i : ℕ) :
     (finSumNatEquiv n).symm (n + i) = Sum.inr i := by simp
 
-theorem isLeft_finSumNatEquiv_symm_apply (i : ℕ) :
-    ((finSumNatEquiv n).symm i).isLeft ↔ i < n :=
-  ⟨(fun hi => finSumNatEquiv_symm_apply_of_ge
-    (Nat.ge_of_not_lt hi) ▸ Bool.noConfusion).mtr,
-    fun h => finSumNatEquiv_symm_apply_of_lt h ▸ rfl⟩
+@[simp] theorem isLeft_finSumNatEquiv_symm_apply (i : ℕ) :
+    ((finSumNatEquiv n).symm i).isLeft = decide (i < n) := by
+  rcases i.lt_or_ge n with hi | hi
+  · simp_rw [finSumNatEquiv_symm_apply_of_lt hi, hi]
+    rfl
+  · simp_rw [finSumNatEquiv_symm_apply_of_ge hi, hi.not_gt]
+    rfl
 
-theorem isRight_finSumNatEquiv_symm_apply (i : ℕ) :
-    ((finSumNatEquiv n).symm i).isRight ↔ n ≤ i := by
-  simp_rw [← not_lt, ← isLeft_finSumNatEquiv_symm_apply, Sum.not_isLeft]
+@[simp] theorem isRight_finSumNatEquiv_symm_apply (i : ℕ) :
+    ((finSumNatEquiv n).symm i).isRight = decide (n ≤ i) := by
+  simp_rw [← not_lt, decide_not, ← isLeft_finSumNatEquiv_symm_apply]
+  cases (finSumNatEquiv n).symm i <;> rfl
 
 /-- The equivalence between `Fin (m + n)` and `Fin (n + m)` which rotates by `n`. -/
 def finAddFlip : Fin (m + n) ≃ Fin (n + m) :=


### PR DESCRIPTION
Adds an equivalence between `Fin n ⊕ ℕ` and `ℕ`.

---
I found myself essentially re-implementing this a couple of times by proxy while working on other work and I think it will be useful to actually have.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
