### PR TITLE
[Merged by Bors] - feat: remove `[DecidableEq α]` from `Finset.Nontrivial.instDecidablePred`

### DIFF
--- a/Mathlib/Data/Finset/Insert.lean
+++ b/Mathlib/Data/Finset/Insert.lean
@@ -219,9 +219,14 @@ instance (i : α) : Unique ({i} : Finset α) where
 @[simp]
 lemma default_singleton (i : α) : ((default : ({i} : Finset α)) : α) = i := rfl
 
-instance Nontrivial.instDecidablePred [DecidableEq α] :
-    DecidablePred (Finset.Nontrivial (α := α)) :=
-  inferInstanceAs (DecidablePred fun s ↦ ∃ a ∈ s, ∃ b ∈ s, a ≠ b)
+instance Nontrivial.instDecidablePred : DecidablePred (Finset.Nontrivial (α := α)) := fun s =>
+  Quotient.recOnSubsingleton (motive := fun (s : Multiset α) =>
+      (h : s.Nodup) → Decidable (Finset.Nontrivial ⟨s, h⟩))
+    s.val (fun l h => match l with
+      | [] => isFalse (by simp)
+      | [_] => isFalse (by simp [Finset.toSet])
+      | a :: b :: _ => isTrue ⟨a, by simp, b, by simp,
+        List.ne_of_not_mem_cons (List.nodup_cons.mp h).left⟩) s.nodup
 
 end Singleton
 

--- a/Mathlib/Data/Finset/Insert.lean
+++ b/Mathlib/Data/Finset/Insert.lean
@@ -219,11 +219,11 @@ instance (i : α) : Unique ({i} : Finset α) where
 @[simp]
 lemma default_singleton (i : α) : ((default : ({i} : Finset α)) : α) = i := rfl
 
-/-
-We don't use `Finset.one_lt_card_iff_nontrivial`
-because `Finset.card` is defined in a different file.
--/
 instance Nontrivial.instDecidablePred : DecidablePred (Finset.Nontrivial (α := α)) := fun s =>
+  /-
+  We don't use `Finset.one_lt_card_iff_nontrivial`
+  because `Finset.card` is defined in a different file.
+  -/
   Quotient.recOnSubsingleton (motive := fun (s : Multiset α) =>
       (h : s.Nodup) → Decidable (Finset.Nontrivial ⟨s, h⟩))
     s.val (fun l h => match l with

--- a/Mathlib/Data/Finset/Insert.lean
+++ b/Mathlib/Data/Finset/Insert.lean
@@ -219,6 +219,10 @@ instance (i : α) : Unique ({i} : Finset α) where
 @[simp]
 lemma default_singleton (i : α) : ((default : ({i} : Finset α)) : α) = i := rfl
 
+/-
+We don't use `Finset.one_lt_card_iff_nontrivial`
+because `Finset.card` is defined in a different file.
+-/
 instance Nontrivial.instDecidablePred : DecidablePred (Finset.Nontrivial (α := α)) := fun s =>
   Quotient.recOnSubsingleton (motive := fun (s : Multiset α) =>
       (h : s.Nodup) → Decidable (Finset.Nontrivial ⟨s, h⟩))


### PR DESCRIPTION
Change the instance `Finset.Nontrivial.instDecidablePred` to not require `[DecidableEq α]`.

I noticed this when I tried to show that a finset given as a multiset with nodup proof is nontrivial, and it failed because the reals don't have decidable equality.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
