### PR TITLE
[Merged by Bors] - feat: basic translations between `X →o Y` and `X ⥤ Y`

### DIFF
--- a/Mathlib/CategoryTheory/Category/Preorder.lean
+++ b/Mathlib/CategoryTheory/Category/Preorder.lean
@@ -204,7 +204,7 @@ def equivFunctor : (X →o Y) ≃ (X ⥤ Y) where
 of functors `X ⥤ Y`, where `X` and `Y` are preorder categories. -/
 @[simps! functor_obj_obj inverse_obj unitIso_hom_app unitIso_inv_app counitIso_inv_app_app
   counitIso_hom_app_app]
-def equivalence : (X →o Y) ≌ (X ⥤ Y) where
+def equivalenceFunctor : (X →o Y) ≌ (X ⥤ Y) where
   functor :=
     { obj f := f.toFunctor
       map f := { app a := f.down.down a |>.hom } }

--- a/Mathlib/CategoryTheory/Category/Preorder.lean
+++ b/Mathlib/CategoryTheory/Category/Preorder.lean
@@ -207,10 +207,10 @@ of functors `X ⥤ Y`, where `X` and `Y` are preorder categories. -/
 def equivalenceFunctor : (X →o Y) ≌ (X ⥤ Y) where
   functor :=
     { obj f := f.toFunctor
-      map f := { app _ := homOfLE (leOfHom f _) } }
+      map f := { app x := homOfLE <| leOfHom f x } }
   inverse :=
     { obj F := F.toOrderHom
-      map f := homOfLE (fun i ↦ leOfHom (f.app i) ) }
+      map f := homOfLE fun x ↦ leOfHom <| f.app x }
   unitIso := Iso.refl _
   counitIso := Iso.refl _
 

--- a/Mathlib/CategoryTheory/Category/Preorder.lean
+++ b/Mathlib/CategoryTheory/Category/Preorder.lean
@@ -207,10 +207,10 @@ of functors `X ⥤ Y`, where `X` and `Y` are preorder categories. -/
 def equivalenceFunctor : (X →o Y) ≌ (X ⥤ Y) where
   functor :=
     { obj f := f.toFunctor
-      map f := { app a := f.down.down a |>.hom } }
+      map f := { app _ := homOfLE (leOfHom f _) } }
   inverse :=
     { obj F := F.toOrderHom
-      map f := ⟨⟨fun i ↦ f.app i |>.down.down⟩⟩ }
+      map f := homOfLE (fun i ↦ leOfHom (f.app i) ) }
   unitIso := Iso.refl _
   counitIso := Iso.refl _
 

--- a/Mathlib/CategoryTheory/Category/Preorder.lean
+++ b/Mathlib/CategoryTheory/Category/Preorder.lean
@@ -193,8 +193,6 @@ open CategoryTheory
 /-- An `OrderHom` as a functor `X ⥤ Y` between preorder categories. -/
 abbrev toFunctor (f : X →o Y) : X ⥤ Y := f.monotone.functor
 
-variable (X Y)
-
 /-- The equivalence between `X →o Y` and the type of functors `X ⥤ Y` between preorder categories
 `X` and `Y`. -/
 @[simps]

--- a/Mathlib/CategoryTheory/Category/Preorder.lean
+++ b/Mathlib/CategoryTheory/Category/Preorder.lean
@@ -180,7 +180,7 @@ theorem monotone (f : X ⥤ Y) : Monotone f.obj := fun _ _ hxy => (f.map hxy.hom
 
 /-- A functor `X ⥤ Y` between preorder categories as an `OrderHom`. -/
 @[simps!]
-def toOrderHom (F : X ⥤ Y) : (X →o Y) where
+def toOrderHom (F : X ⥤ Y) : X →o Y where
   toFun := F.obj
   monotone' := F.monotone
 

--- a/Mathlib/CategoryTheory/Category/Preorder.lean
+++ b/Mathlib/CategoryTheory/Category/Preorder.lean
@@ -172,49 +172,47 @@ section Preorder
 
 variable {X : Type u} {Y : Type v} [Preorder X] [Preorder Y]
 
-namespace CategoryTheory
+namespace CategoryTheory.Functor
 
 /-- A functor between preorder categories is monotone. -/
 @[mono]
-theorem Functor.monotone (f : X ⥤ Y) : Monotone f.obj := fun _ _ hxy => (f.map hxy.hom).le
+theorem monotone (f : X ⥤ Y) : Monotone f.obj := fun _ _ hxy => (f.map hxy.hom).le
 
-end CategoryTheory
+/-- A functor `X ⥤ Y` between preorder categories as an `OrderHom`. -/
+@[simps!]
+def toOrderHom (F : X ⥤ Y) : (X →o Y) where
+  toFun := F.obj
+  monotone' := F.monotone
+
+end CategoryTheory.Functor
 
 namespace OrderHom
 
 open CategoryTheory
 
 /-- An `OrderHom` as a functor `X ⥤ Y` between preorder categories. -/
-def toFunctor (f : X →o Y) : X ⥤ Y := f.monotone.functor
+abbrev toFunctor (f : X →o Y) : X ⥤ Y := f.monotone.functor
 
-/-- A functor `X ⥤ Y` between preorder categories as an `OrderHom`. -/
-def ofFunctor (F : X ⥤ Y) : (X →o Y) where
-  toFun := F.obj
-  monotone' := F.monotone
+variable (X Y)
 
 /-- The equivalence between `X →o Y` and the type of functors `X ⥤ Y` between preorder categories
 `X` and `Y`. -/
+@[simps]
 def equivFunctor : (X →o Y) ≃ (X ⥤ Y) where
   toFun := toFunctor
-  invFun := ofFunctor
-
-/-- The functor from the category of monotone functions `X →o Y` to the category of functors
-`X ⥤ Y` where `X` and `Y` are preorder categories. -/
-def Functor.toFunctor : (X →o Y) ⥤ (X ⥤ Y) where
-  obj := OrderHom.toFunctor
-  map f := { app a := f.down.down a |>.hom }
-
-/-- The functor from the category of functors `X ⥤ Y` where `X` and `Y` are preorder categories to
-the category of monotone functions `X →o Y`. -/
-def Functor.ofFunctor : (X ⥤ Y) ⥤ (X →o Y) where
-  obj := OrderHom.ofFunctor
-  map f := ⟨⟨fun i ↦ f.app i |>.down.down⟩⟩
+  invFun F := F.toOrderHom
 
 /-- The categorical equivalence beween the category of monotone functions `X →o Y` and the category
-of functors `X ⥤ Y` where `X` and `Y` are preorder categories. -/
+of functors `X ⥤ Y`, where `X` and `Y` are preorder categories. -/
+@[simps! functor_obj_obj inverse_obj unitIso_hom_app unitIso_inv_app counitIso_inv_app_app
+  counitIso_hom_app_app]
 def equivalence : (X →o Y) ≌ (X ⥤ Y) where
-  functor := Functor.toFunctor
-  inverse := Functor.ofFunctor
+  functor :=
+    { obj f := f.toFunctor
+      map f := { app a := f.down.down a |>.hom } }
+  inverse :=
+    { obj F := F.toOrderHom
+      map f := ⟨⟨fun i ↦ f.app i |>.down.down⟩⟩ }
   unitIso := Iso.refl _
   counitIso := Iso.refl _
 

--- a/Mathlib/CategoryTheory/Category/Preorder.lean
+++ b/Mathlib/CategoryTheory/Category/Preorder.lean
@@ -198,21 +198,17 @@ def equivFunctor : (X →o Y) ≃ (X ⥤ Y) where
   toFun := toFunctor
   invFun := ofFunctor
 
-namespace Functor
-
 /-- The functor from the category of monotone functions `X →o Y` to the category of functors
 `X ⥤ Y` where `X` and `Y` are preorder categories. -/
-def toFunctor : (X →o Y) ⥤ (X ⥤ Y) where
+def Functor.toFunctor : (X →o Y) ⥤ (X ⥤ Y) where
   obj := OrderHom.toFunctor
   map f := { app a := f.down.down a |>.hom }
 
 /-- The functor from the category of functors `X ⥤ Y` where `X` and `Y` are preorder categories to
 the category of monotone functions `X →o Y`. -/
-def ofFunctor : (X ⥤ Y) ⥤ (X →o Y) where
+def Functor.ofFunctor : (X ⥤ Y) ⥤ (X →o Y) where
   obj := OrderHom.ofFunctor
   map f := ⟨⟨fun i ↦ f.app i |>.down.down⟩⟩
-
-end Functor
 
 /-- The categorical equivalence beween the category of monotone functions `X →o Y` and the category
 of functors `X ⥤ Y` where `X` and `Y` are preorder categories. -/

--- a/Mathlib/CategoryTheory/Category/Preorder.lean
+++ b/Mathlib/CategoryTheory/Category/Preorder.lean
@@ -171,20 +171,67 @@ def OrderIso.equivalence (e : X ≃o Y) : X ≌ Y where
 
 end
 
-namespace CategoryTheory
-
 section Preorder
 
 variable {X : Type u} {Y : Type v} [Preorder X] [Preorder Y]
 
-/-- A functor between preorder categories is monotone.
--/
+namespace CategoryTheory
+
+/-- A functor between preorder categories is monotone. -/
 @[mono]
 theorem Functor.monotone (f : X ⥤ Y) : Monotone f.obj := fun _ _ hxy => (f.map hxy.hom).le
+
+end CategoryTheory
+
+namespace OrderHom
+
+open CategoryTheory
+
+/-- An `OrderHom` as a functor `X ⥤ Y` between preorder categories. -/
+def toFunctor (f : X →o Y) : X ⥤ Y := f.monotone.functor
+
+/-- A functor `X ⥤ Y` between preorder categories as an `OrderHom`. -/
+def ofFunctor (F : X ⥤ Y) : (X →o Y) where
+  toFun := F.obj
+  monotone' := F.monotone
+
+/-- The equivalence between `X →o Y` and the type of functors `X ⥤ Y` between preorder categories
+`X` and `Y`. -/
+def equivFunctor : (X →o Y) ≃ (X ⥤ Y) where
+  toFun := toFunctor
+  invFun := ofFunctor
+
+namespace Functor
+
+/-- The functor from the category of monotone functions `X →o Y` to the category of functors
+`X ⥤ Y` where `X` and `Y` are preorder categories. -/
+def toFunctor : (X →o Y) ⥤ (X ⥤ Y) where
+  obj := OrderHom.toFunctor
+  map f := { app a := f.down.down a |>.hom }
+
+/-- The functor from the category of functors `X ⥤ Y` where `X` and `Y` are preorder categories to
+the category of monotone functions `X →o Y`. -/
+def ofFunctor : (X ⥤ Y) ⥤ (X →o Y) where
+  obj := OrderHom.ofFunctor
+  map f := ⟨⟨fun i ↦ f.app i |>.down.down⟩⟩
+
+end Functor
+
+/-- The categorical equivalence beween the category of monotone functions `X →o Y` and the category
+of functors `X ⥤ Y` where `X` and `Y` are preorder categories. -/
+def equivalence : (X →o Y) ≌ (X ⥤ Y) where
+  functor := Functor.toFunctor
+  inverse := Functor.ofFunctor
+  unitIso := Iso.refl _
+  counitIso := Iso.refl _
+
+end OrderHom
 
 end Preorder
 
 section PartialOrder
+
+namespace CategoryTheory
 
 variable {X : Type u} {Y : Type v} [PartialOrder X] [PartialOrder Y]
 
@@ -214,9 +261,9 @@ theorem Equivalence.toOrderIso_symm_apply (e : X ≌ Y) (y : Y) :
     e.toOrderIso.symm y = e.inverse.obj y :=
   rfl
 
-end PartialOrder
-
 end CategoryTheory
+
+end PartialOrder
 
 open CategoryTheory
 

--- a/Mathlib/CategoryTheory/Category/Preorder.lean
+++ b/Mathlib/CategoryTheory/Category/Preorder.lean
@@ -57,8 +57,7 @@ open Opposite
 
 variable {X : Type u} [Preorder X]
 
-/-- Express an inequality as a morphism in the corresponding preorder category.
--/
+/-- Express an inequality as a morphism in the corresponding preorder category. -/
 def homOfLE {x y : X} (h : x ≤ y) : x ⟶ y :=
   ULift.up (PLift.up h)
 
@@ -74,8 +73,7 @@ theorem homOfLE_comp {x y z : X} (h : x ≤ y) (k : y ≤ z) :
     homOfLE h ≫ homOfLE k = homOfLE (h.trans k) :=
   rfl
 
-/-- Extract the underlying inequality from a morphism in a preorder category.
--/
+/-- Extract the underlying inequality from a morphism in a preorder category. -/
 theorem leOfHom {x y : X} (h : x ⟶ y) : x ≤ y :=
   h.down.down
 
@@ -147,8 +145,7 @@ open CategoryTheory
 
 variable {X : Type u} {Y : Type v} [Preorder X] [Preorder Y]
 
-/-- A monotone function between preorders induces a functor between the associated categories.
--/
+/-- A monotone function between preorders induces a functor between the associated categories. -/
 def Monotone.functor {f : X → Y} (h : Monotone f) : X ⥤ Y where
   obj := f
   map g := CategoryTheory.homOfLE (h g.le)
@@ -238,8 +235,7 @@ variable {X : Type u} {Y : Type v} [PartialOrder X] [PartialOrder Y]
 theorem Iso.to_eq {x y : X} (f : x ≅ y) : x = y :=
   le_antisymm f.hom.le f.inv.le
 
-/-- A categorical equivalence between partial orders is just an order isomorphism.
--/
+/-- A categorical equivalence between partial orders is just an order isomorphism. -/
 def Equivalence.toOrderIso (e : X ≌ Y) : X ≃o Y where
   toFun := e.functor.obj
   invFun := e.inverse.obj


### PR DESCRIPTION
Adds basic definitions translating between `X →o Y` and `X ⥤ Y` where `X` and `Y` are regarded as `Preorder` categories.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
