### PR TITLE
[Merged by Bors] - chore(Data/Finsupp/Option): golf

### DIFF
--- a/Mathlib/Data/Finsupp/Option.lean
+++ b/Mathlib/Data/Finsupp/Option.lean
@@ -81,6 +81,10 @@ def optionEquiv [Zero M] : (Option α →₀ M) ≃ M × (α →₀ M) where
   left_inv P := by ext (_|a) <;> simp [Finsupp.update]
   right_inv P := by ext <;> simp [Finsupp.update]
 
+theorem eq_option_embedding_update_none_iff [Zero M] {n : Option α →₀ M} {m : α →₀ M} {i : M} :
+    n = (embDomain Embedding.some m).update none i ↔ n none = i ∧ n.some = m :=
+  (optionEquiv.apply_eq_iff_eq_symm_apply (y := (_, _))).symm.trans Prod.ext_iff
+
 @[to_additive]
 theorem prod_option_index [AddZeroClass M] [CommMonoid N] (f : Option α →₀ M)
     (b : Option α → M → N) (h_zero : ∀ o, b o 0 = 1)
@@ -100,18 +104,6 @@ theorem sum_option_index_smul [Semiring R] [AddCommMonoid M] [Module R M] (f : O
     (b : Option α → M) :
     (f.sum fun o r => r • b o) = f none • b none + f.some.sum fun a r => r • b (Option.some a) :=
   f.sum_option_index _ (fun _ => zero_smul _ _) fun _ _ _ => add_smul _ _ _
-
-theorem eq_option_embedding_update_none_iff [Zero M] {n : Option α →₀ M} {m : α →₀ M} {i : M} :
-    (n = (embDomain Embedding.some m).update none i) ↔
-      n none = i ∧ n.some = m := by
-  classical
-  rw [Finsupp.ext_iff, Option.forall, Finsupp.ext_iff]
-  apply and_congr
-  · simp
-  · apply forall_congr'
-    intro
-    simp only [coe_update, ne_eq, reduceCtorEq, not_false_eq_true, update_of_ne, some_apply]
-    rw [← Embedding.some_apply, embDomain_apply, Embedding.some_apply]
 
 @[simp] lemma some_embDomain_some [Zero M] (f : α →₀ M) : (f.embDomain .some).some = f := by
   ext; rw [some_apply]; exact embDomain_apply _ _ _


### PR DESCRIPTION
Also moves the golfed proof next to the def it is morally part of.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
