### PR TITLE
[Merged by Bors] - feat: behavior of unique differentiablity under field extension

### DIFF
--- a/Mathlib/Analysis/Calculus/TangentCone.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone.lean
@@ -547,8 +547,8 @@ theorem UniqueDiffOn.univ_pi (ι : Type*) [Finite ι] (E : ι → Type*)
   UniqueDiffOn.pi _ _ _ _ fun i _ => h i
 
 /--
-Given `x ∈ s` and a field extension `𝕜 ⊆ 𝕜'`, the tangent of `s` at `x` with
-respect to `𝕜` is contained in the tangent of `s` at `x` with respect to `𝕜'`.
+Given `x ∈ s` and a field extension `𝕜 ⊆ 𝕜'`, the tangent cone of `s` at `x` with
+respect to `𝕜` is contained in the tangent cone of `s` at `x` with respect to `𝕜'`.
 -/
 theorem tangentConeAt_mono_field : tangentConeAt 𝕜 s x ⊆ tangentConeAt 𝕜' s x := by
   intro α hα

--- a/Mathlib/Analysis/Calculus/TangentCone.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone.lean
@@ -547,6 +547,25 @@ theorem UniqueDiffOn.univ_pi (ι : Type*) [Finite ι] (E : ι → Type*)
   UniqueDiffOn.pi _ _ _ _ fun i _ => h i
 
 /--
+Given `x ∈ s` and a field extension `𝕜 ⊆ 𝕜'`, the tangent of `s` at `x` with
+respect to `𝕜` is contained in the tangent of `s` at `x` with respect to `𝕜'`.
+-/
+theorem tangentConeAt_mono_field : tangentConeAt 𝕜 s x ⊆ tangentConeAt 𝕜' s x := by
+  intro α hα
+  simp [tangentConeAt] at hα ⊢
+  obtain ⟨c, d, ⟨a, h₁a⟩, h₁, h₂⟩ := hα
+  use ((algebraMap 𝕜 𝕜') ∘ c), d
+  constructor
+  · use a
+  · constructor
+    · intro β hβ
+      rw [mem_map, mem_atTop_sets]
+      obtain ⟨n, hn⟩ := mem_atTop_sets.1
+        (mem_map.1 (h₁ (algebraMap_cobounded_le_cobounded (𝕜 := 𝕜) (𝕜' := 𝕜') hβ)))
+      use n, fun _ _ ↦ by simp_all
+    · simpa
+
+/--
 Assume that `E` is a normed vector space over normed fields `𝕜 ⊆ 𝕜'` and that `x ∈ s` is a point
 of unique differentiability with respect to the set `s` and the smaller field `𝕜`, then `x` is also
 a point of unique differentiability with respect to the set `s` and the larger field `𝕜`.
@@ -556,21 +575,7 @@ theorem UniqueDiffWithinAt.mono_field (h₂s : UniqueDiffWithinAt 𝕜 s x) :
   simp_all only [uniqueDiffWithinAt_iff, and_true]
   apply Dense.mono _ h₂s.1
   trans ↑(Submodule.span 𝕜 (tangentConeAt 𝕜' s x))
-  · apply Submodule.span_mono
-    intro α hα
-    simp [tangentConeAt] at hα ⊢
-    obtain ⟨c, d, ⟨a, h₁a⟩, h₁, h₂⟩ := hα
-    use ((algebraMap 𝕜 𝕜') ∘ c), d
-    constructor
-    · use a
-    · constructor
-      · intro β hβ
-        rw [mem_map, mem_atTop_sets]
-        obtain ⟨n, hn⟩ := mem_atTop_sets.1
-          (mem_map.1 (h₁ (algebraMap_cobounded_le_cobounded (𝕜 := 𝕜) (𝕜' := 𝕜') hβ)))
-        use n, fun _ _ ↦ by simp_all
-      · simpa
-  · simp
+  <;> simp [Submodule.span_mono tangentConeAt_mono_field]
 
 /--
 Assume that `E` is a normed vector space over normed fields `𝕜 ⊆ 𝕜'` and all points of `s` are

--- a/Mathlib/Analysis/Calculus/TangentCone.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone.lean
@@ -552,7 +552,8 @@ respect to `𝕜` is contained in the tangent cone of `s` at `x` with respect to
 -/
 theorem tangentConeAt_mono_field : tangentConeAt 𝕜 s x ⊆ tangentConeAt 𝕜' s x := by
   intro α hα
-  simp [tangentConeAt] at hα ⊢
+  simp only [tangentConeAt, eventually_atTop, ge_iff_le, tendsto_norm_atTop_iff_cobounded,
+    mem_setOf_eq] at hα ⊢
   obtain ⟨c, d, ⟨a, h₁a⟩, h₁, h₂⟩ := hα
   use ((algebraMap 𝕜 𝕜') ∘ c), d
   constructor

--- a/Mathlib/Analysis/Calculus/TangentCone.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone.lean
@@ -568,7 +568,7 @@ theorem tangentConeAt_mono_field : tangentConeAt 𝕜 s x ⊆ tangentConeAt 𝕜
 /--
 Assume that `E` is a normed vector space over normed fields `𝕜 ⊆ 𝕜'` and that `x ∈ s` is a point
 of unique differentiability with respect to the set `s` and the smaller field `𝕜`, then `x` is also
-a point of unique differentiability with respect to the set `s` and the larger field `𝕜`.
+a point of unique differentiability with respect to the set `s` and the larger field `𝕜'`.
 -/
 theorem UniqueDiffWithinAt.mono_field (h₂s : UniqueDiffWithinAt 𝕜 s x) :
     UniqueDiffWithinAt 𝕜' s x := by

--- a/Mathlib/Analysis/Calculus/TangentCone.lean
+++ b/Mathlib/Analysis/Calculus/TangentCone.lean
@@ -436,7 +436,8 @@ theorem UniqueDiffWithinAt.congr_pt (h : UniqueDiffWithinAt 𝕜 s x) (hy : x = 
 end TVS
 
 section Normed
-variable [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+variable {𝕜' : Type*} [NontriviallyNormedField 𝕜'] [NormedAlgebra 𝕜 𝕜']
+variable [NormedAddCommGroup E] [NormedSpace 𝕜 E] [NormedSpace 𝕜' E] [IsScalarTower 𝕜 𝕜' E]
 variable [NormedAddCommGroup F] [NormedSpace 𝕜 F]
 variable {x y : E} {s t : Set E}
 
@@ -544,6 +545,40 @@ theorem UniqueDiffOn.univ_pi (ι : Type*) [Finite ι] (E : ι → Type*)
     [∀ i, NormedAddCommGroup (E i)] [∀ i, NormedSpace 𝕜 (E i)] (s : ∀ i, Set (E i))
     (h : ∀ i, UniqueDiffOn 𝕜 (s i)) : UniqueDiffOn 𝕜 (Set.pi univ s) :=
   UniqueDiffOn.pi _ _ _ _ fun i _ => h i
+
+/--
+Assume that `E` is a normed vector space over normed fields `𝕜 ⊆ 𝕜'` and that `x ∈ s` is a point
+of unique differentiability with respect to the set `s` and the smaller field `𝕜`, then `x` is also
+a point of unique differentiability with respect to the set `s` and the larger field `𝕜`.
+-/
+theorem UniqueDiffWithinAt.mono_field (h₂s : UniqueDiffWithinAt 𝕜 s x) :
+    UniqueDiffWithinAt 𝕜' s x := by
+  simp_all only [uniqueDiffWithinAt_iff, and_true]
+  apply Dense.mono _ h₂s.1
+  trans ↑(Submodule.span 𝕜 (tangentConeAt 𝕜' s x))
+  · apply Submodule.span_mono
+    intro α hα
+    simp [tangentConeAt] at hα ⊢
+    obtain ⟨c, d, ⟨a, h₁a⟩, h₁, h₂⟩ := hα
+    use ((algebraMap 𝕜 𝕜') ∘ c), d
+    constructor
+    · use a
+    · constructor
+      · intro β hβ
+        rw [mem_map, mem_atTop_sets]
+        obtain ⟨n, hn⟩ := mem_atTop_sets.1
+          (mem_map.1 (h₁ (algebraMap_cobounded_le_cobounded (𝕜 := 𝕜) (𝕜' := 𝕜') hβ)))
+        use n, fun _ _ ↦ by simp_all
+      · simpa
+  · simp
+
+/--
+Assume that `E` is a normed vector space over normed fields `𝕜 ⊆ 𝕜'` and all points of `s` are
+points of unique differentiability with respect to the smaller field `𝕜`, then they are also points
+of unique differentiability with respect to the larger field `𝕜`.
+-/
+theorem UniqueDiffOn.mono_field (h₂s : UniqueDiffOn 𝕜 s) :
+    UniqueDiffOn 𝕜' s := fun x hx ↦ (h₂s x hx).mono_field
 
 end Normed
 

--- a/Mathlib/Analysis/Normed/Module/Basic.lean
+++ b/Mathlib/Analysis/Normed/Module/Basic.lean
@@ -288,6 +288,19 @@ end NNReal
 
 variable (𝕜)
 
+/--
+Preimages of cobounded sets under the algebra map are cobounded.
+-/
+theorem algebraMap_cobounded_le_cobounded [NormOneClass 𝕜'] :
+    Filter.map (algebraMap 𝕜 𝕜') (Bornology.cobounded 𝕜) ≤ Bornology.cobounded 𝕜' := by
+  intro c hc
+  rw [Filter.mem_map, ← Bornology.isCobounded_def, ← Bornology.isBounded_compl_iff,
+    isBounded_iff_forall_norm_le]
+  obtain ⟨s, hs⟩ := isBounded_iff_forall_norm_le.1
+    (Bornology.isBounded_compl_iff.2 (Bornology.isCobounded_def.1 hc))
+  use s
+  exact fun x hx ↦ by simpa [norm_algebraMap, norm_one] using hs ((algebraMap 𝕜 𝕜') x) hx
+
 /-- In a normed algebra, the inclusion of the base field in the extended field is an isometry. -/
 theorem algebraMap_isometry [NormOneClass 𝕜'] : Isometry (algebraMap 𝕜 𝕜') := by
   refine Isometry.of_dist_eq fun x y => ?_

--- a/Mathlib/Analysis/RCLike/TangentCone.lean
+++ b/Mathlib/Analysis/RCLike/TangentCone.lean
@@ -20,20 +20,12 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] [h𝕜 : IsRCLikeNormedFi
 theorem tangentConeAt_real_subset_isRCLikeNormedField :
     tangentConeAt ℝ s x ⊆ tangentConeAt 𝕜 s x := by
   letI := h𝕜.rclike
-  rintro y ⟨c, d, d_mem, c_lim, hcd⟩
-  let c' : ℕ → 𝕜 := fun n ↦ c n
-  refine ⟨c', d, d_mem, by simpa [c'] using c_lim, ?_⟩
-  convert hcd using 2 with n
-  simp [c']
+  exact tangentConeAt_mono_field
 
 theorem UniqueDiffWithinAt.of_real (hs : UniqueDiffWithinAt ℝ s x) :
     UniqueDiffWithinAt 𝕜 s x := by
-  refine ⟨?_, hs.mem_closure⟩
-  letI : RCLike 𝕜 := h𝕜.rclike
-  apply hs.dense_tangentConeAt.mono
-  have : (Submodule.span ℝ (tangentConeAt ℝ s x) : Set E)
-      ⊆ (Submodule.span 𝕜 (tangentConeAt ℝ s x)) := Submodule.span_subset_span _ _ _
-  exact this.trans (Submodule.span_mono tangentConeAt_real_subset_isRCLikeNormedField)
+  letI := h𝕜.rclike
+  exact hs.mono_field
 
 theorem UniqueDiffOn.of_real (hs : UniqueDiffOn ℝ s) :
     UniqueDiffOn 𝕜 s :=


### PR DESCRIPTION
If `s` is a domain of unique differentiability for a field `k`, then it is also a domain of unique differentiability for larger fields.

This PR provides material required to implement a reviewer's suggestion in https://github.com/leanprover-community/mathlib4/pull/26353

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
