### PR TITLE
[Merged by Bors] - feat: the centraliser of a normal subgroup is normal

### DIFF
--- a/Mathlib/GroupTheory/Subgroup/Centralizer.lean
+++ b/Mathlib/GroupTheory/Subgroup/Centralizer.lean
@@ -69,13 +69,13 @@ theorem map_centralizer_le_centralizer_image (s : Set G) (f : G →* G') :
   rw [← map_mul, ← map_mul, hg h hh]
 
 @[to_additive]
-protected instance Normal.centralizer [H.Normal] : (centralizer H : Subgroup G).Normal where
+instance normal_centralizer [H.Normal] : (centralizer H : Subgroup G).Normal where
   conj_mem g hg i h hh := by
     simpa [-mul_left_inj, -mul_right_inj, mul_assoc]
       using congr(i * $(hg _ <| ‹H.Normal›.conj_mem _ hh i⁻¹) * i⁻¹)
 
 @[to_additive]
-instance Characteristic.centralizer [hH : H.Characteristic] :
+instance characteristic_centralizer [hH : H.Characteristic] :
     (centralizer (H : Set G)).Characteristic := by
   refine Subgroup.characteristic_iff_comap_le.mpr fun ϕ g hg h hh => ϕ.injective ?_
   rw [map_mul, map_mul]

--- a/Mathlib/GroupTheory/Subgroup/Centralizer.lean
+++ b/Mathlib/GroupTheory/Subgroup/Centralizer.lean
@@ -69,7 +69,13 @@ theorem map_centralizer_le_centralizer_image (s : Set G) (f : G →* G') :
   rw [← map_mul, ← map_mul, hg h hh]
 
 @[to_additive]
-instance Centralizer.characteristic [hH : H.Characteristic] :
+protected instance Normal.centralizer [H.Normal] : (centralizer H : Subgroup G).Normal where
+  conj_mem g hg i h hh := by
+    simpa [-mul_left_inj, -mul_right_inj, mul_assoc]
+      using congr(i * $(hg _ <| ‹H.Normal›.conj_mem _ hh i⁻¹) * i⁻¹)
+
+@[to_additive]
+instance Characteristic.centralizer [hH : H.Characteristic] :
     (centralizer (H : Set G)).Characteristic := by
   refine Subgroup.characteristic_iff_comap_le.mpr fun ϕ g hg h hh => ϕ.injective ?_
   rw [map_mul, map_mul]


### PR DESCRIPTION
This is part of the introductory statements in Matthew Tointon's Approximate Groups.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
