### PR TITLE
[Merged by Bors] - refactor: simplify `(f₁ ⊗ₘ f₂) ≫ (g₁ ⊗ₘ g₂)` to `(f₁ ≫ g₁) ⊗ₘ (f₂ ≫ g₂)`

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Monoidal/Basic.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Monoidal/Basic.lean
@@ -72,8 +72,9 @@ theorem id_tensorHom_id (M N : ModuleCat R) :
 
 @[deprecated (since := "2025-07-14")] alias tensor_id := id_tensorHom_id
 
-theorem tensor_comp {X₁ Y₁ Z₁ X₂ Y₂ Z₂ : ModuleCat R} (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (g₁ : Y₁ ⟶ Z₁)
-    (g₂ : Y₂ ⟶ Z₂) : tensorHom (f₁ ≫ g₁) (f₂ ≫ g₂) = tensorHom f₁ f₂ ≫ tensorHom g₁ g₂ := by
+theorem tensorHom_comp_tensorHom {X₁ Y₁ Z₁ X₂ Y₂ Z₂ : ModuleCat R} (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂)
+    (g₁ : Y₁ ⟶ Z₁) (g₂ : Y₂ ⟶ Z₂) :
+    tensorHom f₁ f₂ ≫ tensorHom g₁ g₂ = tensorHom (f₁ ≫ g₁) (f₂ ≫ g₂) := by
   ext : 1
   -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): even with high priority `ext` fails to find this.
   apply TensorProduct.ext
@@ -157,7 +158,7 @@ open MonoidalCategory
 
 instance monoidalCategory : MonoidalCategory (ModuleCat.{u} R) := MonoidalCategory.ofTensorHom
   (id_tensorHom_id := fun M N ↦ id_tensorHom_id M N)
-  (tensor_comp := fun f g h ↦ MonoidalCategory.tensor_comp f g h)
+  (tensorHom_comp_tensorHom := fun f g h ↦ MonoidalCategory.tensorHom_comp_tensorHom f g h)
   (associator_naturality := fun f g h ↦ MonoidalCategory.associator_naturality f g h)
   (leftUnitor_naturality := fun f ↦ MonoidalCategory.leftUnitor_naturality f)
   (rightUnitor_naturality := fun f ↦ rightUnitor_naturality f)

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/Monoidal.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/Monoidal.lean
@@ -110,7 +110,7 @@ noncomputable instance monoidalCategory :
     MonoidalCategory (PresheafOfModules.{u} (R ⋙ forget₂ _ _)) where
   tensorHom_def _ _ := by ext1; apply tensorHom_def
   id_tensorHom_id _ _ := by ext1; apply id_tensorHom_id
-  tensor_comp _ _ _ _ := by ext1; apply tensor_comp
+  tensorHom_comp_tensorHom _ _ _ _ := by ext1; apply tensorHom_comp_tensorHom
   whiskerLeft_id M₁ M₂ := by
     ext1 X
     apply MonoidalCategory.whiskerLeft_id (C := ModuleCat (R.obj X))

--- a/Mathlib/CategoryTheory/Bicategory/End.lean
+++ b/Mathlib/CategoryTheory/Bicategory/End.lean
@@ -41,7 +41,7 @@ instance (X : C) : MonoidalCategory (X ⟶ X) where
   associator f g h := α_ f g h
   leftUnitor f := λ_ f
   rightUnitor f := ρ_ f
-  tensor_comp := by
+  tensorHom_comp_tensorHom := by
     intros
     dsimp only
     rw [Bicategory.whiskerLeft_comp, Bicategory.comp_whiskerRight, Category.assoc, Category.assoc,

--- a/Mathlib/CategoryTheory/Dialectica/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Dialectica/Monoidal.lean
@@ -87,9 +87,9 @@ theorem id_tensorHom_id (X₁ X₂ : Dial C) : (𝟙 X₁ ⊗ₘ 𝟙 X₂ : _ �
 
 @[deprecated (since := "2025-07-14")] alias tensor_id := id_tensorHom_id
 
-theorem tensor_comp {X₁ Y₁ Z₁ X₂ Y₂ Z₂ : Dial C}
+theorem tensorHom_comp_tensorHom {X₁ Y₁ Z₁ X₂ Y₂ Z₂ : Dial C}
     (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (g₁ : Y₁ ⟶ Z₁) (g₂ : Y₂ ⟶ Z₂) :
-    tensorHom (f₁ ≫ g₁) (f₂ ≫ g₂) = tensorHom f₁ f₂ ≫ tensorHom g₁ g₂ := by
+    (f₁ ⊗ₘ f₂) ≫ (g₁ ⊗ₘ g₂) = (f₁ ≫ g₁) ⊗ₘ (f₂ ≫ g₂) := by
   ext <;> simp; ext <;> simp <;> (rw [← Category.assoc]; congr 1; simp)
 
 theorem associator_naturality {X₁ X₂ X₃ Y₁ Y₂ Y₃ : Dial C}
@@ -118,7 +118,7 @@ theorem triangle (X Y : Dial C) :
 instance : MonoidalCategory (Dial C) :=
   .ofTensorHom
     (id_tensorHom_id := id_tensorHom_id)
-    (tensor_comp := tensor_comp)
+    (tensorHom_comp_tensorHom := tensorHom_comp_tensorHom)
     (associator_naturality := associator_naturality)
     (leftUnitor_naturality := leftUnitor_naturality)
     (rightUnitor_naturality := rightUnitor_naturality)

--- a/Mathlib/CategoryTheory/Enriched/Basic.lean
+++ b/Mathlib/CategoryTheory/Enriched/Basic.lean
@@ -352,7 +352,7 @@ def forget (F : EnrichedFunctor W C D) :
   map_comp f g := by
     dsimp
     apply_fun ForgetEnrichment.homTo W
-    · simp only [Iso.cancel_iso_inv_left, Category.assoc, tensor_comp,
+    · simp only [Iso.cancel_iso_inv_left, Category.assoc, ← tensorHom_comp_tensorHom,
         ForgetEnrichment.homTo_homOf, EnrichedFunctor.map_comp, ForgetEnrichment.homTo_comp]
       rfl
     · intro f g w; apply_fun ForgetEnrichment.homOf W at w; simpa using w
@@ -489,8 +489,8 @@ def enrichedNatTransYoneda (F G : EnrichedFunctor V C D) : Vᵒᵖ ⥤ Type max 
         have p := σ.naturality X Y
         dsimp at p ⊢
         rw [← id_tensor_comp_tensor_id (f.unop ≫ σ.app Y) _, id_tensor_comp, Category.assoc,
-          Category.assoc, ← braiding_naturality_assoc, id_tensor_comp_tensor_id_assoc, p, ←
-          tensor_comp_assoc, Category.id_comp] }
+          Category.assoc, ← braiding_naturality_assoc, id_tensor_comp_tensor_id_assoc, p,
+          tensorHom_comp_tensorHom_assoc, Category.id_comp] }
 
 -- TODO assuming `[HasLimits C]` construct the actual object of natural transformations
 -- and show that the functor category is `V`-enriched.

--- a/Mathlib/CategoryTheory/Enriched/FunctorCategory.lean
+++ b/Mathlib/CategoryTheory/Enriched/FunctorCategory.lean
@@ -172,7 +172,7 @@ lemma homEquiv_comp (f : F₁ ⟶ F₂) (g : F₂ ⟶ F₃) :
     enrichedComp V F₁ F₂ F₃ := by
   ext j
   simp only [homEquiv_apply_π, NatTrans.comp_app, eHomEquiv_comp, assoc,
-    enrichedComp_π, Functor.op_obj, ← tensor_comp_assoc]
+    enrichedComp_π, Functor.op_obj, tensorHom_comp_tensorHom_assoc]
 
 end
 
@@ -386,7 +386,7 @@ noncomputable def functorEnrichedComp [HasFunctorEnrichedHom V F₁ F₂]
     dsimp
     rw [assoc, assoc, enrichedComp_π]
     dsimp
-    rw [← tensor_comp_assoc]
+    rw [tensorHom_comp_tensorHom_assoc]
     simp
 
 @[reassoc (attr := simp)]
@@ -446,7 +446,7 @@ lemma functorHomEquiv_comp [HasFunctorEnrichedHom V F₁ F₂] [HasEnrichedHom V
   dsimp
   ext k
   rw [homEquiv_comp, assoc, assoc, assoc, assoc, assoc, end_.lift_π, enrichedComp_π]
-  simp [← tensor_comp_assoc]
+  simp [tensorHom_comp_tensorHom_assoc]
 
 attribute [local instance] functorEnrichedCategory
 

--- a/Mathlib/CategoryTheory/Enriched/Ordinary/Basic.lean
+++ b/Mathlib/CategoryTheory/Enriched/Ordinary/Basic.lean
@@ -231,7 +231,8 @@ noncomputable def TransportEnrichment.enrichedOrdinaryCategory
     EnrichedOrdinaryCategory W (TransportEnrichment F C) where
   homEquiv {X Y} := (eHomEquiv V (C := C)).trans <| Equiv.ofBijective _ (h (Hom (C := C) X Y))
   homEquiv_comp f g := by
-    simp [eHomEquiv_comp, eComp_eq, tensorHom_def (Functor.LaxMonoidal.ε F), unitors_inv_equal]
+    simp [← tensorHom_comp_tensorHom, eHomEquiv_comp, eComp_eq,
+      tensorHom_def (Functor.LaxMonoidal.ε F), unitors_inv_equal]
 
 section Equiv
 
@@ -257,7 +258,7 @@ def TransportEnrichment.forgetEnrichmentEquivFunctor :
       ← Functor.LaxMonoidal.left_unitality_inv, Category.assoc, Category.assoc, Category.assoc,
       Category.assoc, ← Functor.LaxMonoidal.μ_natural_assoc, ← TransportEnrichment.eComp_eq,
       ← ForgetEnrichment.homOf_comp, leftUnitor_inv_naturality_assoc, ← tensorHom_def'_assoc,
-      ← tensor_comp_assoc]
+      tensorHom_comp_tensorHom_assoc]
     rfl
 
 /-- The inverse functor that makes up `TransportEnrichment.forgetEnrichmentEquiv`. -/
@@ -281,7 +282,7 @@ def TransportEnrichment.forgetEnrichmentEquivInverse :
     slice_rhs 1 3 =>
       rw [← Functor.LaxMonoidal.left_unitality_inv, Category.assoc, Category.assoc,
         ← Functor.LaxMonoidal.μ_natural, ← leftUnitor_inv_comp_tensorHom_assoc,
-        ← tensor_comp_assoc]
+        tensorHom_comp_tensorHom_assoc]
     simp [← h]
 
 /-- If `D` is a `V`-enriched category, then forgetting the enrichment and transporting the resulting

--- a/Mathlib/CategoryTheory/GradedObject/Braiding.lean
+++ b/Mathlib/CategoryTheory/GradedObject/Braiding.lean
@@ -78,7 +78,7 @@ lemma hexagon_forward [HasTensor X Y] [HasTensor Y X] [HasTensor Y Z]
     ιTensorObj₃'_associator_hom, Iso.inv_hom_id_assoc]
   conv_rhs => rw [ιTensorObj₃'_eq X Y Z i₁ i₂ i₃ k h _ rfl, assoc, ι_tensorHom_assoc,
     ← MonoidalCategory.tensorHom_id,
-    ← MonoidalCategory.tensor_comp_assoc, id_comp, ι_tensorObjDesc,
+    MonoidalCategory.tensorHom_comp_tensorHom_assoc, id_comp, ι_tensorObjDesc,
     categoryOfGradedObjects_id, MonoidalCategory.comp_tensor_id, assoc,
     MonoidalCategory.tensorHom_id, MonoidalCategory.tensorHom_id,
     ← ιTensorObj₃'_eq_assoc Y X Z i₂ i₁ i₃ k
@@ -116,7 +116,7 @@ lemma hexagon_reverse [HasTensor X Y] [HasTensor Y Z] [HasTensor Z X]
     ιTensorObj₃_associator_inv, Iso.hom_inv_id_assoc]
   conv_rhs => rw [ιTensorObj₃_eq X Y Z i₁ i₂ i₃ k h _ rfl, assoc, ι_tensorHom_assoc,
     ← MonoidalCategory.id_tensorHom,
-    ← MonoidalCategory.tensor_comp_assoc, id_comp, ι_tensorObjDesc,
+    MonoidalCategory.tensorHom_comp_tensorHom_assoc, id_comp, ι_tensorObjDesc,
     categoryOfGradedObjects_id, MonoidalCategory.id_tensor_comp, assoc,
     MonoidalCategory.id_tensorHom, MonoidalCategory.id_tensorHom,
     ← ιTensorObj₃_eq_assoc X Z Y i₁ i₃ i₂ k

--- a/Mathlib/CategoryTheory/GradedObject/Monoidal.lean
+++ b/Mathlib/CategoryTheory/GradedObject/Monoidal.lean
@@ -122,9 +122,9 @@ lemma id_tensorHom_id (X Y : GradedObject I C) [HasTensor X Y] :
 @[deprecated (since := "2025-07-14")] alias tensor_id := id_tensorHom_id
 
 @[reassoc]
-lemma tensor_comp {X₁ X₂ X₃ Y₁ Y₂ Y₃ : GradedObject I C} (f₁ : X₁ ⟶ X₂) (f₂ : X₂ ⟶ X₃)
+lemma tensorHom_comp_tensorHom {X₁ X₂ X₃ Y₁ Y₂ Y₃ : GradedObject I C} (f₁ : X₁ ⟶ X₂) (f₂ : X₂ ⟶ X₃)
     (g₁ : Y₁ ⟶ Y₂) (g₂ : Y₂ ⟶ Y₃) [HasTensor X₁ Y₁] [HasTensor X₂ Y₂] [HasTensor X₃ Y₃] :
-    tensorHom (f₁ ≫ f₂) (g₁ ≫ g₂) = tensorHom f₁ g₁ ≫ tensorHom f₂ g₂ := by
+    tensorHom f₁ g₁ ≫ tensorHom f₂ g₂ = tensorHom (f₁ ≫ f₂) (g₁ ≫ g₂) := by
   dsimp only [tensorHom, mapBifunctorMapMap]
   rw [← mapMap_comp]
   apply congr_mapMap
@@ -138,13 +138,13 @@ noncomputable def tensorIso {X₁ X₂ Y₁ Y₂ : GradedObject I C} (e : X₁ �
     tensorObj X₁ Y₁ ≅ tensorObj X₂ Y₂ where
   hom := tensorHom e.hom e'.hom
   inv := tensorHom e.inv e'.inv
-  hom_inv_id := by simp only [← tensor_comp, Iso.hom_inv_id, id_tensorHom_id]
-  inv_hom_id := by simp only [← tensor_comp, Iso.inv_hom_id, id_tensorHom_id]
+  hom_inv_id := by simp [tensorHom_comp_tensorHom]
+  inv_hom_id := by simp [tensorHom_comp_tensorHom]
 
 lemma tensorHom_def {X₁ X₂ Y₁ Y₂ : GradedObject I C} (f : X₁ ⟶ X₂) (g : Y₁ ⟶ Y₂)
     [HasTensor X₁ Y₁] [HasTensor X₂ Y₂] [HasTensor X₂ Y₁] :
     tensorHom f g = whiskerRight f Y₁ ≫ whiskerLeft X₂ g := by
-  rw [← tensor_comp, id_comp, comp_id]
+  rw [tensorHom_comp_tensorHom, id_comp, comp_id]
 
 /-- This is the addition map `I × I × I → I` for an additive monoid `I`. -/
 def r₁₂₃ : I × I × I → I := fun ⟨i, j, k⟩ => i + j + k
@@ -219,8 +219,8 @@ lemma ιTensorObj₃_tensorHom (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (f�
       (f₁ i₁ ⊗ₘ f₂ i₂ ⊗ₘ f₃ i₃) ≫ ιTensorObj₃ Y₁ Y₂ Y₃ i₁ i₂ i₃ j h := by
   rw [ιTensorObj₃_eq _ _ _ i₁ i₂ i₃ j h _  rfl,
     ιTensorObj₃_eq _ _ _ i₁ i₂ i₃ j h _  rfl, assoc, ι_tensorHom,
-    ← id_tensorHom, ← id_tensorHom, ← MonoidalCategory.tensor_comp_assoc, ι_tensorHom,
-    ← MonoidalCategory.tensor_comp_assoc, id_comp, comp_id]
+    ← id_tensorHom, ← id_tensorHom, MonoidalCategory.tensorHom_comp_tensorHom_assoc, ι_tensorHom,
+    MonoidalCategory.tensorHom_comp_tensorHom_assoc, id_comp, comp_id]
 
 @[ext (iff := false)]
 lemma tensorObj₃_ext {j : I} {A : C} (f g : tensorObj X₁ (tensorObj X₂ X₃) j ⟶ A)
@@ -263,8 +263,8 @@ lemma ιTensorObj₃'_tensorHom (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (f
       ((f₁ i₁ ⊗ₘ f₂ i₂) ⊗ₘ f₃ i₃) ≫ ιTensorObj₃' Y₁ Y₂ Y₃ i₁ i₂ i₃ j h := by
   rw [ιTensorObj₃'_eq _ _ _ i₁ i₂ i₃ j h _  rfl,
     ιTensorObj₃'_eq _ _ _ i₁ i₂ i₃ j h _  rfl, assoc, ι_tensorHom,
-    ← tensorHom_id, ← tensorHom_id, ← MonoidalCategory.tensor_comp_assoc, id_comp,
-    ι_tensorHom, ← MonoidalCategory.tensor_comp_assoc, comp_id]
+    ← tensorHom_id, ← tensorHom_id, MonoidalCategory.tensorHom_comp_tensorHom_assoc, id_comp,
+    ι_tensorHom, MonoidalCategory.tensorHom_comp_tensorHom_assoc, comp_id]
 
 @[ext (iff := false)]
 lemma tensorObj₃'_ext {j : I} {A : C} (f g : tensorObj (tensorObj X₁ X₂) X₃ j ⟶ A)
@@ -457,9 +457,8 @@ lemma pentagon : tensorHom (associator X₁ X₂ X₃).hom (𝟙 X₄) ≫
     (associator (tensorObj X₁ X₂) X₃ X₄).hom ≫ (associator X₁ X₂ (tensorObj X₃ X₄)).hom := by
   rw [← cancel_epi (associator (tensorObj X₁ X₂) X₃ X₄).inv,
     ← cancel_epi (associator X₁ X₂ (tensorObj X₃ X₄)).inv, Iso.inv_hom_id_assoc,
-    Iso.inv_hom_id, ← pentagon_inv_assoc, ← tensor_comp_assoc, id_comp, Iso.inv_hom_id,
-    id_tensorHom_id, id_comp, Iso.inv_hom_id_assoc, ← tensor_comp, id_comp, Iso.inv_hom_id,
-    id_tensorHom_id]
+    Iso.inv_hom_id, ← pentagon_inv_assoc]
+  simp [tensorHom_comp_tensorHom, tensorHom_comp_tensorHom_assoc]
 
 end Pentagon
 
@@ -591,7 +590,7 @@ noncomputable instance monoidalCategory : MonoidalCategory (GradedObject I C) wh
   leftUnitor_naturality := Monoidal.leftUnitor_naturality
   rightUnitor X := Monoidal.rightUnitor X
   rightUnitor_naturality := Monoidal.rightUnitor_naturality
-  tensor_comp f₁ f₂ g₁ g₂ := Monoidal.tensor_comp f₁ g₁ f₂ g₂
+  tensorHom_comp_tensorHom f₁ f₂ g₁ g₂ := Monoidal.tensorHom_comp_tensorHom f₁ g₁ f₂ g₂
   pentagon X₁ X₂ X₃ X₄ := Monoidal.pentagon X₁ X₂ X₃ X₄
   triangle X₁ X₂ := Monoidal.triangle X₁ X₂
 

--- a/Mathlib/CategoryTheory/Localization/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Localization/Monoidal.lean
@@ -407,7 +407,7 @@ noncomputable instance :
     MonoidalCategory (LocalizedMonoidal L W ε) where
   tensorHom_def := by intros; simp [monoidalCategoryStruct]
   id_tensorHom_id := by intros; simp [monoidalCategoryStruct]
-  tensor_comp := by intros; simp [monoidalCategoryStruct]
+  tensorHom_comp_tensorHom := by intros; simp [monoidalCategoryStruct]
   whiskerLeft_id := by intros; simp [monoidalCategoryStruct]
   id_whiskerRight := by intros; simp [monoidalCategoryStruct]
   associator_naturality {X₁ X₂ X₃ Y₁ Y₂ Y₃} f₁ f₂ f₃ := by apply associator_naturality

--- a/Mathlib/CategoryTheory/Monoidal/Braided/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided/Basic.lean
@@ -408,7 +408,7 @@ def ofNatIso {F G : C ⥤ D} (i : F ≅ G) [F.LaxBraided] [G.LaxMonoidal]
     [NatTrans.IsMonoidal i.hom] : G.LaxBraided where
   braided X Y := by
     have (X Y : C) : μ G X Y = (i.inv.app X ⊗ₘ i.inv.app Y) ≫ μ F X Y ≫ i.hom.app _ := by
-      simp [NatTrans.IsMonoidal.tensor X Y, ← tensor_comp_assoc]
+      simp [NatTrans.IsMonoidal.tensor X Y, tensorHom_comp_tensorHom_assoc]
     rw [this X Y, this Y X, ← braiding_naturality_assoc, ← Functor.LaxBraided.braided_assoc]
     simp
 
@@ -604,11 +604,14 @@ theorem tensorμ_natural {X₁ X₂ Y₁ Y₂ U₁ U₂ V₁ V₂ : C} (f₁ : X
   simp_rw [← id_tensorHom, ← tensorHom_id]
   slice_lhs 1 2 => rw [associator_naturality]
   slice_lhs 2 3 =>
-    rw [← tensor_comp, comp_id f₁, ← id_comp f₁, associator_inv_naturality, tensor_comp]
+    rw [tensorHom_comp_tensorHom, comp_id f₁, ← id_comp f₁, associator_inv_naturality,
+      ← tensorHom_comp_tensorHom]
   slice_lhs 3 4 =>
-    rw [← tensor_comp, ← tensor_comp, comp_id f₁, ← id_comp f₁, comp_id g₂, ← id_comp g₂,
-      braiding_naturality, tensor_comp, tensor_comp]
-  slice_lhs 4 5 => rw [← tensor_comp, comp_id f₁, ← id_comp f₁, associator_naturality, tensor_comp]
+    rw [tensorHom_comp_tensorHom, tensorHom_comp_tensorHom, comp_id f₁, ← id_comp f₁, comp_id g₂,
+      ← id_comp g₂, braiding_naturality, ← tensorHom_comp_tensorHom, ← tensorHom_comp_tensorHom]
+  slice_lhs 4 5 =>
+    rw [tensorHom_comp_tensorHom, comp_id f₁, ← id_comp f₁, associator_naturality,
+      ← tensorHom_comp_tensorHom]
   slice_lhs 5 6 => rw [associator_inv_naturality]
   simp only [assoc]
 

--- a/Mathlib/CategoryTheory/Monoidal/Braided/Reflection.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided/Reflection.lean
@@ -60,7 +60,8 @@ private lemma adjRetraction_is_retraction (c : C) (d : D)
   simp only [id_obj, comp_obj, adjRetractionAux, Functor.map_inv, Functor.comp_map,
     braiding_naturality_right_assoc]
   slice_lhs 2 3 =>
-    simp only [← id_tensorHom, ← tensorHom_id, ← tensor_comp, Category.id_comp, Category.comp_id]
+    simp only [← id_tensorHom, ← tensorHom_id, tensorHom_comp_tensorHom, Category.id_comp,
+      Category.comp_id]
   slice_lhs 2 4 =>
     rw [← adj.unit_naturality_assoc]
   simp
@@ -102,7 +103,7 @@ theorem isIso_tfae : List.TFAE
     -- and conclude.
     have : (adj.unit.app d) ⊗ₘ (adj.unit.app d') =
         (adj.unit.app d ▷ d') ≫ (((L ⋙ R).obj _) ◁ adj.unit.app d') := by
-      simp [← tensorHom_id, ← id_tensorHom, ← tensor_comp]
+      simp [← tensorHom_id, ← id_tensorHom, tensorHom_comp_tensorHom]
     rw [this, map_comp]
     infer_instance
   tfae_have 4 → 1

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Basic.lean
@@ -91,8 +91,8 @@ lemma id_tensorHom_id (X Y : C) : tensorHom ℬ (𝟙 X) (𝟙 Y) = 𝟙 (tensor
 
 @[deprecated (since := "2025-07-14")] alias tensor_id := id_tensorHom_id
 
-lemma tensor_comp (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (g₁ : Y₁ ⟶ Z₁) (g₂ : Y₂ ⟶ Z₂) :
-    tensorHom ℬ (f₁ ≫ g₁) (f₂ ≫ g₂) = tensorHom ℬ f₁ f₂ ≫ tensorHom ℬ g₁ g₂ :=
+lemma tensorHom_comp_tensorHom (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (g₁ : Y₁ ⟶ Z₁) (g₂ : Y₂ ⟶ Z₂) :
+    tensorHom ℬ f₁ f₂ ≫ tensorHom ℬ g₁ g₂ = tensorHom ℬ (f₁ ≫ g₁) (f₂ ≫ g₂) :=
   (ℬ _ _).isLimit.hom_ext <| by rintro ⟨_ | _⟩ <;> simp [tensorHom]
 
 lemma pentagon (W X Y Z : C) :
@@ -157,7 +157,7 @@ abbrev ofChosenFiniteProducts : CartesianMonoidalCategory C :=
   {
   toMonoidalCategory := .ofTensorHom
     (id_tensorHom_id := id_tensorHom_id ℬ)
-    (tensor_comp := tensor_comp ℬ)
+    (tensorHom_comp_tensorHom := tensorHom_comp_tensorHom ℬ)
     (pentagon := pentagon ℬ)
     (triangle := triangle 𝒯 ℬ)
     (leftUnitor_naturality := leftUnitor_naturality 𝒯 ℬ)

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Mon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Mon_.lean
@@ -52,8 +52,7 @@ attribute [local simp] tensorObj.one_def tensorObj.mul_def
 instance : IsMonHom (fst M N) where
 instance : IsMonHom (snd M N) where
 
-instance {f : M ⟶ N} {g : M ⟶ O} [IsMonHom f] [IsMonHom g] : IsMonHom (lift f g) where
-  mul_hom := by ext <;> simp [← tensor_comp_assoc]
+instance {f : M ⟶ N} {g : M ⟶ O} [IsMon_Hom f] [IsMon_Hom g] : IsMonHom (lift f g) where
 
 instance [IsCommMonObj M] : IsMonHom μ[M] where
   one_hom := by simp [toUnit_unique (ρ_ (𝟙_ C)).hom (λ_ (𝟙_ C)).hom]

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Mon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Mon_.lean
@@ -52,7 +52,7 @@ attribute [local simp] tensorObj.one_def tensorObj.mul_def
 instance : IsMonHom (fst M N) where
 instance : IsMonHom (snd M N) where
 
-instance {f : M ⟶ N} {g : M ⟶ O} [IsMon_Hom f] [IsMon_Hom g] : IsMonHom (lift f g) where
+instance {f : M ⟶ N} {g : M ⟶ O} [IsMonHom f] [IsMonHom g] : IsMonHom (lift f g) where
 
 instance [IsCommMonObj M] : IsMonHom μ[M] where
   one_hom := by simp [toUnit_unique (ρ_ (𝟙_ C)).hom (λ_ (𝟙_ C)).hom]

--- a/Mathlib/CategoryTheory/Monoidal/Category.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Category.lean
@@ -160,12 +160,12 @@ class MonoidalCategory (C : Type u) [𝒞 : Category.{v} C] extends MonoidalCate
   /-- Tensor product of identity maps is the identity: `𝟙 X₁ ⊗ₘ 𝟙 X₂ = 𝟙 (X₁ ⊗ X₂)` -/
   id_tensorHom_id : ∀ X₁ X₂ : C, 𝟙 X₁ ⊗ₘ 𝟙 X₂ = 𝟙 (X₁ ⊗ X₂) := by cat_disch
   /--
-  Tensor product of compositions is composition of tensor products:
-  `(f₁ ≫ g₁) ⊗ₘ (f₂ ≫ g₂) = (f₁ ⊗ₘ f₂) ≫ (g₁ ⊗ₘ g₂)`
+  Composition of tensor products is tensor product of compositions:
+  `(f₁ ⊗ₘ f₂) ≫ (g₁ ⊗ₘ g₂) = (f₁ ≫ g₁) ⊗ₘ (f₂ ≫ g₂)`
   -/
-  tensor_comp :
+  tensorHom_comp_tensorHom :
     ∀ {X₁ Y₁ Z₁ X₂ Y₂ Z₂ : C} (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (g₁ : Y₁ ⟶ Z₁) (g₂ : Y₂ ⟶ Z₂),
-      (f₁ ≫ g₁) ⊗ₘ (f₂ ≫ g₂) = (f₁ ⊗ₘ f₂) ≫ (g₁ ⊗ₘ g₂) := by
+      (f₁ ⊗ₘ f₂) ≫ (g₁ ⊗ₘ g₂) = (f₁ ≫ g₁) ⊗ₘ (f₂ ≫ g₂) := by
     cat_disch
   whiskerLeft_id : ∀ (X Y : C), X ◁ 𝟙 Y = 𝟙 (X ⊗ Y) := by
     cat_disch
@@ -206,8 +206,7 @@ class MonoidalCategory (C : Type u) [𝒞 : Category.{v} C] extends MonoidalCate
 attribute [reassoc] MonoidalCategory.tensorHom_def
 attribute [reassoc, simp] MonoidalCategory.whiskerLeft_id
 attribute [reassoc, simp] MonoidalCategory.id_whiskerRight
-attribute [reassoc] MonoidalCategory.tensor_comp
-attribute [simp] MonoidalCategory.tensor_comp
+attribute [reassoc (attr := simp)] MonoidalCategory.tensorHom_comp_tensorHom
 attribute [reassoc] MonoidalCategory.associator_naturality
 attribute [reassoc] MonoidalCategory.leftUnitor_naturality
 attribute [reassoc] MonoidalCategory.rightUnitor_naturality
@@ -231,7 +230,7 @@ theorem tensorHom_id {X₁ X₂ : C} (f : X₁ ⟶ X₂) (Y : C) :
 @[reassoc, simp]
 theorem whiskerLeft_comp (W : C) {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) :
     W ◁ (f ≫ g) = W ◁ f ≫ W ◁ g := by
-  simp only [← id_tensorHom, ← tensor_comp, comp_id]
+  simp [← id_tensorHom]
 
 @[reassoc, simp]
 theorem id_whiskerLeft {X Y : C} (f : X ⟶ Y) :
@@ -248,7 +247,7 @@ theorem tensor_whiskerLeft (X Y : C) {Z Z' : C} (f : Z ⟶ Z') :
 @[reassoc, simp]
 theorem comp_whiskerRight {W X Y : C} (f : W ⟶ X) (g : X ⟶ Y) (Z : C) :
     (f ≫ g) ▷ Z = f ▷ Z ≫ g ▷ Z := by
-  simp only [← tensorHom_id, ← tensor_comp, id_comp]
+  simp [← tensorHom_id]
 
 @[reassoc, simp]
 theorem whiskerRight_id {X Y : C} (f : X ⟶ Y) :
@@ -272,7 +271,7 @@ theorem whisker_assoc (X : C) {Y Y' : C} (f : Y ⟶ Y') (Z : C) :
 @[reassoc]
 theorem whisker_exchange {W X Y Z : C} (f : W ⟶ X) (g : Y ⟶ Z) :
     W ◁ g ≫ f ▷ Z = f ▷ Y ≫ X ◁ g := by
-  simp only [← id_tensorHom, ← tensorHom_id, ← tensor_comp, id_comp, comp_id]
+  simp [← id_tensorHom, ← tensorHom_id]
 
 @[reassoc]
 theorem tensorHom_def' {X₁ Y₁ X₂ Y₂ : C} (f : X₁ ⟶ Y₁) (g : X₂ ⟶ Y₂) :
@@ -407,8 +406,8 @@ def tensorIso {X Y X' Y' : C} (f : X ≅ Y)
     (g : X' ≅ Y') : X ⊗ X' ≅ Y ⊗ Y' where
   hom := f.hom ⊗ₘ g.hom
   inv := f.inv ⊗ₘ g.inv
-  hom_inv_id := by rw [← tensor_comp, Iso.hom_inv_id, Iso.hom_inv_id, ← id_tensorHom_id]
-  inv_hom_id := by rw [← tensor_comp, Iso.inv_hom_id, Iso.inv_hom_id, ← id_tensorHom_id]
+  hom_inv_id := by simp [Iso.hom_inv_id, Iso.hom_inv_id]
+  inv_hom_id := by simp [Iso.inv_hom_id, Iso.inv_hom_id]
 
 /-- Notation for `tensorIso`, the tensor product of isomorphisms -/
 scoped infixr:70 " ⊗ᵢ " => tensorIso
@@ -674,45 +673,37 @@ theorem id_tensor_associator_inv_naturality {X Y Z X' : C} (f : X ⟶ X') :
     (f ⊗ₘ 𝟙 (Y ⊗ Z)) ≫ (α_ X' Y Z).inv = (α_ X Y Z).inv ≫ ((f ⊗ₘ 𝟙 Y) ⊗ₘ 𝟙 Z) := by
   rw [← id_tensorHom_id, associator_inv_naturality]
 
-@[reassoc (attr := simp)]
+@[reassoc]
 theorem hom_inv_id_tensor {V W X Y Z : C} (f : V ≅ W) (g : X ⟶ Y) (h : Y ⟶ Z) :
-    (f.hom ⊗ₘ g) ≫ (f.inv ⊗ₘ h) = (𝟙 V ⊗ₘ g) ≫ (𝟙 V ⊗ₘ h) := by
-  rw [← tensor_comp, f.hom_inv_id]; simp [id_tensorHom]
+    (f.hom ⊗ₘ g) ≫ (f.inv ⊗ₘ h) = (𝟙 V ⊗ₘ g) ≫ (𝟙 V ⊗ₘ h) := by simp
 
-@[reassoc (attr := simp)]
+@[reassoc]
 theorem inv_hom_id_tensor {V W X Y Z : C} (f : V ≅ W) (g : X ⟶ Y) (h : Y ⟶ Z) :
-    (f.inv ⊗ₘ g) ≫ (f.hom ⊗ₘ h) = (𝟙 W ⊗ₘ g) ≫ (𝟙 W ⊗ₘ h) := by
-  rw [← tensor_comp, f.inv_hom_id]; simp [id_tensorHom]
+    (f.inv ⊗ₘ g) ≫ (f.hom ⊗ₘ h) = (𝟙 W ⊗ₘ g) ≫ (𝟙 W ⊗ₘ h) := by simp
 
-@[reassoc (attr := simp)]
+@[reassoc]
 theorem tensor_hom_inv_id {V W X Y Z : C} (f : V ≅ W) (g : X ⟶ Y) (h : Y ⟶ Z) :
-    (g ⊗ₘ f.hom) ≫ (h ⊗ₘ f.inv) = (g ⊗ₘ 𝟙 V) ≫ (h ⊗ₘ 𝟙 V) := by
-  rw [← tensor_comp, f.hom_inv_id]; simp [tensorHom_id]
+    (g ⊗ₘ f.hom) ≫ (h ⊗ₘ f.inv) = (g ⊗ₘ 𝟙 V) ≫ (h ⊗ₘ 𝟙 V) := by simp
 
-@[reassoc (attr := simp)]
+@[reassoc]
 theorem tensor_inv_hom_id {V W X Y Z : C} (f : V ≅ W) (g : X ⟶ Y) (h : Y ⟶ Z) :
-    (g ⊗ₘ f.inv) ≫ (h ⊗ₘ f.hom) = (g ⊗ₘ 𝟙 W) ≫ (h ⊗ₘ 𝟙 W) := by
-  rw [← tensor_comp, f.inv_hom_id]; simp [tensorHom_id]
+    (g ⊗ₘ f.inv) ≫ (h ⊗ₘ f.hom) = (g ⊗ₘ 𝟙 W) ≫ (h ⊗ₘ 𝟙 W) := by simp
 
-@[reassoc (attr := simp)]
+@[reassoc]
 theorem hom_inv_id_tensor' {V W X Y Z : C} (f : V ⟶ W) [IsIso f] (g : X ⟶ Y) (h : Y ⟶ Z) :
-    (f ⊗ₘ g) ≫ (inv f ⊗ₘ h) = (𝟙 V ⊗ₘ g) ≫ (𝟙 V ⊗ₘ h) := by
-  rw [← tensor_comp, IsIso.hom_inv_id]; simp [id_tensorHom]
+    (f ⊗ₘ g) ≫ (inv f ⊗ₘ h) = (𝟙 V ⊗ₘ g) ≫ (𝟙 V ⊗ₘ h) := by simp
 
-@[reassoc (attr := simp)]
+@[reassoc]
 theorem inv_hom_id_tensor' {V W X Y Z : C} (f : V ⟶ W) [IsIso f] (g : X ⟶ Y) (h : Y ⟶ Z) :
-    (inv f ⊗ₘ g) ≫ (f ⊗ₘ h) = (𝟙 W ⊗ₘ g) ≫ (𝟙 W ⊗ₘ h) := by
-  rw [← tensor_comp, IsIso.inv_hom_id]; simp [id_tensorHom]
+    (inv f ⊗ₘ g) ≫ (f ⊗ₘ h) = (𝟙 W ⊗ₘ g) ≫ (𝟙 W ⊗ₘ h) := by simp
 
-@[reassoc (attr := simp)]
+@[reassoc]
 theorem tensor_hom_inv_id' {V W X Y Z : C} (f : V ⟶ W) [IsIso f] (g : X ⟶ Y) (h : Y ⟶ Z) :
-    (g ⊗ₘ f) ≫ (h ⊗ₘ inv f) = (g ⊗ₘ 𝟙 V) ≫ (h ⊗ₘ 𝟙 V) := by
-  rw [← tensor_comp, IsIso.hom_inv_id]; simp [tensorHom_id]
+    (g ⊗ₘ f) ≫ (h ⊗ₘ inv f) = (g ⊗ₘ 𝟙 V) ≫ (h ⊗ₘ 𝟙 V) := by simp
 
-@[reassoc (attr := simp)]
+@[reassoc]
 theorem tensor_inv_hom_id' {V W X Y Z : C} (f : V ⟶ W) [IsIso f] (g : X ⟶ Y) (h : Y ⟶ Z) :
-    (g ⊗ₘ inv f) ≫ (h ⊗ₘ f) = (g ⊗ₘ 𝟙 W) ≫ (h ⊗ₘ 𝟙 W) := by
-  rw [← tensor_comp, IsIso.inv_hom_id]; simp [tensorHom_id]
+    (g ⊗ₘ inv f) ≫ (h ⊗ₘ f) = (g ⊗ₘ 𝟙 W) ≫ (h ⊗ₘ 𝟙 W) := by simp
 
 /--
 A constructor for monoidal categories that requires `tensorHom` instead of `whiskerLeft` and
@@ -725,9 +716,9 @@ abbrev ofTensorHom [MonoidalCategoryStruct C]
       cat_disch)
     (tensorHom_id : ∀ {X₁ X₂ : C} (f : X₁ ⟶ X₂) (Y : C), tensorHom f (𝟙 Y) = whiskerRight f Y := by
       cat_disch)
-    (tensor_comp :
+    (tensorHom_comp_tensorHom :
       ∀ {X₁ Y₁ Z₁ X₂ Y₂ Z₂ : C} (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (g₁ : Y₁ ⟶ Z₁) (g₂ : Y₂ ⟶ Z₂),
-        tensorHom (f₁ ≫ g₁) (f₂ ≫ g₂) = tensorHom f₁ f₂ ≫ tensorHom g₁ g₂ := by
+        (f₁ ⊗ₘ f₂) ≫ (g₁ ⊗ₘ g₂) = (f₁ ≫ g₁) ⊗ₘ (f₂ ≫ g₂) := by
           cat_disch)
     (associator_naturality :
       ∀ {X₁ X₂ X₃ Y₁ Y₂ Y₃ : C} (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (f₃ : X₃ ⟶ Y₃),
@@ -754,7 +745,7 @@ abbrev ofTensorHom [MonoidalCategoryStruct C]
           tensorHom (rightUnitor X).hom (𝟙 Y) := by
             cat_disch) :
       MonoidalCategory C where
-  tensorHom_def := by intros; simp [← id_tensorHom, ← tensorHom_id, ← tensor_comp]
+  tensorHom_def := by intros; simp [← id_tensorHom, ← tensorHom_id, tensorHom_comp_tensorHom]
   whiskerLeft_id := by intros; simp [← id_tensorHom, ← id_tensorHom_id]
   id_whiskerRight := by intros; simp [← tensorHom_id, id_tensorHom_id]
   pentagon := by intros; simp [← id_tensorHom, ← tensorHom_id, pentagon]
@@ -770,13 +761,11 @@ theorem id_tensor_comp (f : W ⟶ X) (g : X ⟶ Y) : 𝟙 Z ⊗ₘ f ≫ g = (�
 
 @[reassoc]
 theorem id_tensor_comp_tensor_id (f : W ⟶ X) (g : Y ⟶ Z) : (𝟙 Y ⊗ₘ f) ≫ (g ⊗ₘ 𝟙 X) = g ⊗ₘ f := by
-  rw [← tensor_comp]
-  simp
+  simp [tensorHom_def']
 
 @[reassoc]
 theorem tensor_id_comp_id_tensor (f : W ⟶ X) (g : Y ⟶ Z) : (g ⊗ₘ 𝟙 W) ≫ (𝟙 Z ⊗ₘ f) = g ⊗ₘ f := by
-  rw [← tensor_comp]
-  simp
+  simp [tensorHom_def]
 
 theorem tensor_left_iff {X Y : C} (f g : X ⟶ Y) : 𝟙 (𝟙_ C) ⊗ₘ f = 𝟙 (𝟙_ C) ⊗ₘ g ↔ f = g := by simp
 
@@ -1019,8 +1008,7 @@ variable {J : Type*} [Category J] {C : Type*} [Category C] [MonoidalCategory C]
 @[reassoc]
 lemma tensor_naturality {X Y X' Y' : J} (f : X ⟶ Y) (g : X' ⟶ Y') :
     (F.map f ⊗ₘ G.map g) ≫ (α.app Y ⊗ₘ β.app Y') =
-      (α.app X ⊗ₘ β.app X') ≫ (F'.map f ⊗ₘ G'.map g) := by
-  simp only [← tensor_comp, naturality]
+      (α.app X ⊗ₘ β.app X') ≫ (F'.map f ⊗ₘ G'.map g) := by simp
 
 @[reassoc]
 lemma whiskerRight_app_tensor_app {X Y : J} (f : X ⟶ Y) (X' : J) :
@@ -1056,7 +1044,7 @@ abbrev MonoidalCategory.fullSubcategory
   rightUnitor X := P.fullyFaithfulι.preimageIso (ρ_ X.1)
   tensorHom_def := tensorHom_def (C := C)
   id_tensorHom_id X Y := id_tensorHom_id X.1 Y.1
-  tensor_comp := tensor_comp (C := C)
+  tensorHom_comp_tensorHom := tensorHom_comp_tensorHom (C := C)
   whiskerLeft_id X Y := MonoidalCategory.whiskerLeft_id X.1 Y.1
   id_whiskerRight X Y := MonoidalCategory.id_whiskerRight X.1 Y.1
   associator_naturality := associator_naturality (C := C)

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution.lean
@@ -894,7 +894,7 @@ def monoidalOfLawfulDayConvolutionMonoidalCategoryStruct
         tensorHom_id, id_whiskerRight, Category.id_comp]
       dsimp [DayConvolution.convolution]
       simp)
-    (tensor_comp := fun _ _ _ _ => by
+    (tensorHom_comp_tensorHom := fun _ _ _ _ => by
       apply Functor.Faithful.map_injective (F := ι C V D)
       simp only [ι_map_tensorHom_hom_eq_tensorHom, Functor.map_comp]
       apply (corepresentableBy (ι C V D|>.obj _) (ι C V D|>.obj _)).homEquiv.injective

--- a/Mathlib/CategoryTheory/Monoidal/Free/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Basic.lean
@@ -95,9 +95,9 @@ inductive HomEquiv : ∀ {X Y : F C}, (X ⟶ᵐ Y) → (X ⟶ᵐ Y) → Prop
   | assoc {X Y U V : F C} (f : X ⟶ᵐ U) (g : U ⟶ᵐ V) (h : V ⟶ᵐ Y) :
       HomEquiv ((f.comp g).comp h) (f.comp (g.comp h))
   | id_tensorHom_id {X Y} : HomEquiv ((Hom.id X).tensor (Hom.id Y)) (Hom.id _)
-  | tensor_comp {X₁ Y₁ Z₁ X₂ Y₂ Z₂ : F C} (f₁ : X₁ ⟶ᵐ Y₁) (f₂ : X₂ ⟶ᵐ Y₂) (g₁ : Y₁ ⟶ᵐ Z₁)
-      (g₂ : Y₂ ⟶ᵐ Z₂) :
-    HomEquiv ((f₁.comp g₁).tensor (f₂.comp g₂)) ((f₁.tensor f₂).comp (g₁.tensor g₂))
+  | tensorHom_comp_tensorHom {X₁ Y₁ Z₁ X₂ Y₂ Z₂ : F C} (f₁ : X₁ ⟶ᵐ Y₁) (f₂ : X₂ ⟶ᵐ Y₂)
+      (g₁ : Y₁ ⟶ᵐ Z₁) (g₂ : Y₂ ⟶ᵐ Z₂) :
+    HomEquiv ((f₁.tensor f₂).comp (g₁.tensor g₂)) ((f₁.comp g₁).tensor (f₂.comp g₂))
   | whiskerLeft_id (X Y) : HomEquiv ((Hom.id Y).whiskerLeft X) (Hom.id (X.tensor Y))
   | id_whiskerRight (X Y) : HomEquiv ((Hom.id X).whiskerRight Y) (Hom.id (X.tensor Y))
   | α_hom_inv {X Y Z} : HomEquiv ((Hom.α_hom X Y Z).comp (Hom.α_inv X Y Z)) (Hom.id _)
@@ -157,9 +157,9 @@ instance : MonoidalCategory (F C) where
     rintro ⟨f⟩ ⟨g⟩
     exact Quotient.sound (tensorHom_def _ _)
   id_tensorHom_id _ _ := Quot.sound id_tensorHom_id
-  tensor_comp {X₁ Y₁ Z₁ X₂ Y₂ Z₂} := by
+  tensorHom_comp_tensorHom {X₁ Y₁ Z₁ X₂ Y₂ Z₂} := by
     rintro ⟨f₁⟩ ⟨f₂⟩ ⟨g₁⟩ ⟨g₂⟩
-    exact Quotient.sound (tensor_comp _ _ _ _)
+    exact Quotient.sound (tensorHom_comp_tensorHom _ _ _ _)
   whiskerLeft_id X Y := Quot.sound (HomEquiv.whiskerLeft_id X Y)
   id_whiskerRight X Y := Quot.sound (HomEquiv.id_whiskerRight X Y)
   tensorUnit := FreeMonoidalCategory.unit
@@ -323,7 +323,8 @@ def projectMap (X Y : F C) : (X ⟶ Y) → (projectObj f X ⟶ projectObj f Y) :
     | id_comp => dsimp only [projectMapAux]; rw [Category.id_comp]
     | assoc => dsimp only [projectMapAux]; rw [Category.assoc]
     | id_tensorHom_id => dsimp only [projectMapAux]; rw [MonoidalCategory.id_tensorHom_id]; rfl
-    | tensor_comp => dsimp only [projectMapAux]; rw [MonoidalCategory.tensor_comp]
+    | tensorHom_comp_tensorHom =>
+      dsimp only [projectMapAux]; rw [MonoidalCategory.tensorHom_comp_tensorHom]
     | whiskerLeft_id =>
         dsimp only [projectMapAux, projectObj]
         rw [MonoidalCategory.whiskerLeft_id]

--- a/Mathlib/CategoryTheory/Monoidal/Functor.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Functor.lean
@@ -937,8 +937,7 @@ lemma unit_app_tensor_comp_map_δ (X Y : C) :
     adj.unit.app (X ⊗ Y) ≫ G.map (δ F X Y) = (adj.unit.app X ⊗ₘ adj.unit.app Y) ≫ μ G _ _ := by
   rw [IsMonoidal.leftAdjoint_μ (adj := adj), homEquiv_unit]
   dsimp
-  simp only [← adj.unit_naturality_assoc, ← Functor.map_comp, ← δ_natural_assoc,
-    ← tensor_comp, left_triangle_components, tensorHom_id, id_whiskerRight, comp_id]
+  simp [← adj.unit_naturality_assoc, ← Functor.map_comp, ← δ_natural_assoc]
 
 @[reassoc]
 lemma map_ε_comp_counit_app_unit : F.map (ε G) ≫ adj.counit.app (𝟙_ D) = η F := by
@@ -968,7 +967,8 @@ instance isMonoidal_comp {F' : D ⥤ E} {G' : E ⥤ D} (adj' : F' ⊣ G')
     dsimp only [comp_obj, comp_μ, id_obj, comp_δ]
     rw [Equiv.symm_apply_apply]
     dsimp [homEquiv]
-    rw [comp_counit_app, comp_counit_app, comp_counit_app, assoc, tensor_comp, δ_natural_assoc]
+    rw [comp_counit_app, comp_counit_app, comp_counit_app, assoc, ← tensorHom_comp_tensorHom,
+      δ_natural_assoc]
     dsimp
     rw [← adj'.map_μ_comp_counit_app_tensor, ← map_comp_assoc, ← map_comp_assoc,
       ← map_comp_assoc, ← adj.map_μ_comp_counit_app_tensor, assoc,
@@ -1119,10 +1119,8 @@ instance isMonoidal_symm [e.inverse.Monoidal] [e.IsMonoidal] :
   leftAdjoint_μ X Y := by
     simp only [toAdjunction, Adjunction.homEquiv_unit]
     dsimp [symm]
-    rw [map_comp, counitIso_inv_app_tensor_comp_functor_map_δ_inverse_assoc,
-      ← Functor.map_comp, ← tensor_comp, Iso.hom_inv_id_app, Iso.hom_inv_id_app]
-    dsimp
-    rw [tensorHom_id, id_whiskerRight, map_id, comp_id]
+    rw [map_comp, counitIso_inv_app_tensor_comp_functor_map_δ_inverse_assoc]
+    simp [← map_comp]
 
 section
 
@@ -1185,27 +1183,27 @@ def coreMonoidalTransport {F G : C ⥤ D} [F.Monoidal] (i : F ≅ G) : G.CoreMon
     simp only [← Category.assoc]
     congr 1
     slice_lhs 3 4 =>
-      rw [← tensorHom_id, ← tensor_comp]
+      rw [← tensorHom_id, tensorHom_comp_tensorHom]
       simp only [Iso.hom_inv_id_app, Category.id_comp, id_tensorHom]
     simp only [Category.assoc]
     rw [← whisker_exchange_assoc]
     simp only [tensor_whiskerLeft, Functor.LaxMonoidal.associativity, Category.assoc,
       Iso.inv_hom_id_assoc]
     rw [← tensorHom_id, associator_naturality_assoc]
-    simp [← id_tensorHom, -tensorHom_id, -tensor_comp, ← tensor_comp_assoc]
+    simp [← id_tensorHom, -tensorHom_id]
   left_unitality X := by
     simp only [Iso.trans_hom, εIso_hom, Iso.app_hom, ← tensorHom_id, tensorIso_hom, Iso.symm_hom,
-      μIso_hom, Category.assoc, ← tensor_comp_assoc, Iso.hom_inv_id_app, Category.comp_id,
-      Category.id_comp]
+      μIso_hom, Category.assoc, tensorHom_comp_tensorHom_assoc, Iso.hom_inv_id_app,
+      Category.comp_id, Category.id_comp]
     rw [← i.hom.naturality, ← Category.comp_id (i.inv.app X),
-      ← Category.id_comp (Functor.LaxMonoidal.ε F), tensor_comp]
+      ← Category.id_comp (Functor.LaxMonoidal.ε F), ← tensorHom_comp_tensorHom]
     simp
   right_unitality X := by
     simp only [Iso.trans_hom, εIso_hom, Iso.app_hom, ← id_tensorHom, tensorIso_hom, Iso.symm_hom,
-      μIso_hom, Category.assoc, ← tensor_comp_assoc, Category.id_comp, Iso.hom_inv_id_app,
-      Category.comp_id]
+      μIso_hom, Category.assoc, tensorHom_comp_tensorHom_assoc, Category.id_comp,
+      Iso.hom_inv_id_app, Category.comp_id]
     rw [← i.hom.naturality, ← Category.comp_id (i.inv.app X),
-      ← Category.id_comp (Functor.LaxMonoidal.ε F), tensor_comp]
+      ← Category.id_comp (Functor.LaxMonoidal.ε F), ← tensorHom_comp_tensorHom]
     simp
 
 /--

--- a/Mathlib/CategoryTheory/Monoidal/FunctorCategory.lean
+++ b/Mathlib/CategoryTheory/Monoidal/FunctorCategory.lean
@@ -49,7 +49,8 @@ Tensor product of natural transformations into `D`, when `D` is monoidal.
 @[simps]
 def tensorHom : tensorObj F F' ⟶ tensorObj G G' where
   app X := α.app X ⊗ₘ β.app X
-  naturality X Y f := by dsimp; rw [← tensor_comp, α.naturality, β.naturality, tensor_comp]
+  naturality X Y f := by
+    dsimp; rw [tensorHom_comp_tensorHom, α.naturality, β.naturality, ← tensorHom_comp_tensorHom]
 
 /-- (An auxiliary definition for `functorCategoryMonoidal`.) -/
 @[simps]

--- a/Mathlib/CategoryTheory/Monoidal/Internal/Limits.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Internal/Limits.lean
@@ -61,12 +61,12 @@ the proposed cone over a functor `F : J ⥤ Mon C` is a limit cone.
 def limitConeIsLimit (F : J ⥤ Mon C) : IsLimit (limitCone F) where
   lift s :=
     { hom := limit.lift (F ⋙ Mon.forget C) ((Mon.forget C).mapCone s)
-      isMonHom_hom.mul_hom := limit.hom_ext (fun j ↦ by
+      isMonHom_hom.mul_hom := limit.hom_ext fun j ↦ by
         dsimp
         simp only [Category.assoc, limit.lift_π, Functor.mapCone_pt, forget_obj,
           Functor.mapCone_π_app, forget_map, IsMonHom.mul_hom, limMap_π, tensorObj_obj,
           Functor.comp_obj, MonFunctorCategoryEquivalence.inverseObj_mon_mul_app, lim_μ_π_assoc,
-          lim_obj, ← tensor_comp_assoc]) }
+          lim_obj, tensorHom_comp_tensorHom_assoc] }
   fac s h := by ext; simp
   uniq s m w := by
     ext1

--- a/Mathlib/CategoryTheory/Monoidal/Limits/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Limits/Basic.lean
@@ -45,11 +45,11 @@ instance : (lim (J := J) (C := C)).LaxMonoidal :=
             { app := fun j => limit.π F j ⊗ₘ limit.π G j
               naturality := fun j j' f => by
                 dsimp
-                simp only [Category.id_comp, ← tensor_comp, limit.w] } })
+                simp only [Category.id_comp, tensorHom_comp_tensorHom, limit.w] } })
     (μ_natural := fun f g ↦ limit.hom_ext (fun j ↦ by
       dsimp
       simp only [limit.lift_π, Cones.postcompose_obj_π, Monoidal.tensorHom_app, limit.lift_map,
-        NatTrans.comp_app, Category.assoc, ← tensor_comp, limMap_π]))
+        NatTrans.comp_app, Category.assoc, tensorHom_comp_tensorHom, limMap_π]))
     (associativity := fun F G H ↦ limit.hom_ext (fun j ↦ by
       dsimp
       simp only [tensorHom_id, limit.lift_map, Category.assoc, limit.lift_π,

--- a/Mathlib/CategoryTheory/Monoidal/Mon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Mon_.lean
@@ -76,7 +76,7 @@ def ofIso (e : M ≅ X) : MonObj X where
     simp only [MonoidalCategory.whiskerLeft_comp, tensorHom_def', Category.assoc,
       whiskerLeft_hom_inv_assoc, Iso.inv_hom_id]
     simp [← tensorHom_def'_assoc, rightUnitor_inv_comp_tensorHom_assoc]
-  mul_assoc := by simpa [← id_tensorHom, ← tensorHom_id, ← tensor_comp_assoc,
+  mul_assoc := by simpa [← id_tensorHom, ← tensorHom_id,
       -associator_conjugation, associator_naturality_assoc] using
       congr(((e.inv ⊗ₘ e.inv) ⊗ₘ e.inv) ≫ $(MonObj.mul_assoc M) ≫ e.hom)
 
@@ -104,12 +104,13 @@ variable {C : Type u₁} [Category.{v₁} C] [MonoidalCategory C]
 
 attribute [mon_tauto] Category.id_comp Category.comp_id Category.assoc
   id_tensorHom_id tensorμ tensorδ
+  tensorHom_comp_tensorHom tensorHom_comp_tensorHom_assoc
   leftUnitor_tensor_hom leftUnitor_tensor_hom_assoc
   leftUnitor_tensor_inv leftUnitor_tensor_inv_assoc
   rightUnitor_tensor_hom rightUnitor_tensor_hom_assoc
   rightUnitor_tensor_inv rightUnitor_tensor_inv_assoc
 
-attribute [mon_tauto ←] tensorHom_id id_tensorHom tensor_comp tensor_comp_assoc
+attribute [mon_tauto ←] tensorHom_id id_tensorHom
 
 @[reassoc (attr := mon_tauto)]
 lemma associator_hom_comp_tensorHom_tensorHom (f : X₁ ⟶ X₂) (g : Y₁ ⟶ Y₂) (h : Z₁ ⟶ Z₂) :
@@ -660,9 +661,9 @@ theorem one_associator {M N P : C} [MonObj M] [MonObj N] [MonObj P] :
     ((λ_ (𝟙_ C)).inv ≫ ((λ_ (𝟙_ C)).inv ≫ (η[M] ⊗ₘ η[N]) ⊗ₘ η[P])) ≫ (α_ M N P).hom =
       (λ_ (𝟙_ C)).inv ≫ (η[M] ⊗ₘ (λ_ (𝟙_ C)).inv ≫ (η[N] ⊗ₘ η[P])) := by
   simp only [Category.assoc, Iso.cancel_iso_inv_left]
-  slice_lhs 1 3 => rw [← Category.id_comp (η : 𝟙_ C ⟶ P), tensor_comp]
+  slice_lhs 1 3 => rw [← Category.id_comp (η : 𝟙_ C ⟶ P), ← tensorHom_comp_tensorHom]
   slice_lhs 2 3 => rw [associator_naturality]
-  slice_rhs 1 2 => rw [← Category.id_comp η, tensor_comp]
+  slice_rhs 1 2 => rw [← Category.id_comp η, ← tensorHom_comp_tensorHom]
   slice_lhs 1 2 => rw [tensorHom_id, ← leftUnitor_tensor_inv]
   rw [← cancel_epi (λ_ (𝟙_ C)).inv]
   slice_lhs 1 2 => rw [leftUnitor_inv_naturality]
@@ -686,7 +687,7 @@ theorem Mon_tensor_one_mul (M N : C) [MonObj M] [MonObj N] :
       (λ_ (M ⊗ N)).hom := by
   simp only [comp_whiskerRight_assoc]
   slice_lhs 2 3 => rw [tensorμ_natural_left]
-  slice_lhs 3 4 => rw [← tensor_comp, one_mul, one_mul]
+  slice_lhs 3 4 => rw [tensorHom_comp_tensorHom, one_mul, one_mul]
   symm
   exact tensor_left_unitality M N
 
@@ -696,7 +697,7 @@ theorem Mon_tensor_mul_one (M N : C) [MonObj M] [MonObj N] :
       (ρ_ (M ⊗ N)).hom := by
   simp only [whiskerLeft_comp_assoc]
   slice_lhs 2 3 => rw [tensorμ_natural_right]
-  slice_lhs 3 4 => rw [← tensor_comp, mul_one, mul_one]
+  slice_lhs 3 4 => rw [tensorHom_comp_tensorHom, mul_one, mul_one]
   symm
   exact tensor_right_unitality M N
 
@@ -708,7 +709,9 @@ theorem Mon_tensor_mul_assoc (M N : C) [MonObj M] [MonObj N] :
           tensorμ M N M N ≫ (μ ⊗ₘ μ) := by
   simp only [comp_whiskerRight_assoc, whiskerLeft_comp_assoc]
   slice_lhs 2 3 => rw [tensorμ_natural_left]
-  slice_lhs 3 4 => rw [← tensor_comp, mul_assoc, mul_assoc, tensor_comp, tensor_comp]
+  slice_lhs 3 4 =>
+    rw [tensorHom_comp_tensorHom, mul_assoc, mul_assoc, ← tensorHom_comp_tensorHom,
+      ← tensorHom_comp_tensorHom]
   slice_lhs 1 3 => rw [tensor_associativity]
   slice_lhs 3 4 => rw [← tensorμ_natural_right]
   simp
@@ -721,9 +724,9 @@ theorem mul_associator {M N P : C} [MonObj M] [MonObj N] [MonObj P] :
         tensorμ M (N ⊗ P) M (N ⊗ P) ≫
           (μ ⊗ₘ tensorμ N P N P ≫ (μ ⊗ₘ μ)) := by
   simp only [Category.assoc]
-  slice_lhs 2 3 => rw [← Category.id_comp μ[P], tensor_comp]
+  slice_lhs 2 3 => rw [← Category.id_comp μ[P], ← tensorHom_comp_tensorHom]
   slice_lhs 3 4 => rw [associator_naturality]
-  slice_rhs 3 4 => rw [← Category.id_comp μ, tensor_comp]
+  slice_rhs 3 4 => rw [← Category.id_comp μ, ← tensorHom_comp_tensorHom]
   simp only [tensorHom_id, id_tensorHom]
   slice_lhs 1 3 => rw [associator_monoidal]
   simp only [Category.assoc]
@@ -731,7 +734,7 @@ theorem mul_associator {M N P : C} [MonObj M] [MonObj N] [MonObj P] :
 theorem mul_leftUnitor {M : C} [MonObj M] :
     (tensorμ (𝟙_ C) M (𝟙_ C) M ≫ ((λ_ (𝟙_ C)).hom ⊗ₘ μ)) ≫ (λ_ M).hom =
       ((λ_ M).hom ⊗ₘ (λ_ M).hom) ≫ μ := by
-  rw [← Category.comp_id (λ_ (𝟙_ C)).hom, ← Category.id_comp μ, tensor_comp]
+  rw [← Category.comp_id (λ_ (𝟙_ C)).hom, ← Category.id_comp μ, ← tensorHom_comp_tensorHom]
   simp only [tensorHom_id, id_tensorHom]
   slice_lhs 3 4 => rw [leftUnitor_naturality]
   slice_lhs 1 3 => rw [← leftUnitor_monoidal]
@@ -740,7 +743,7 @@ theorem mul_leftUnitor {M : C} [MonObj M] :
 theorem mul_rightUnitor {M : C} [MonObj M] :
     (tensorμ M (𝟙_ C) M (𝟙_ C) ≫ (μ ⊗ₘ (λ_ (𝟙_ C)).hom)) ≫ (ρ_ M).hom =
       ((ρ_ M).hom ⊗ₘ (ρ_ M).hom) ≫ μ := by
-  rw [← Category.id_comp μ, ← Category.comp_id (λ_ (𝟙_ C)).hom, tensor_comp]
+  rw [← Category.id_comp μ, ← Category.comp_id (λ_ (𝟙_ C)).hom, ← tensorHom_comp_tensorHom]
   simp only [tensorHom_id, id_tensorHom]
   slice_lhs 3 4 => rw [rightUnitor_naturality]
   slice_lhs 1 3 => rw [← rightUnitor_monoidal]
@@ -767,11 +770,11 @@ variable {X Y Z W : C} [MonObj X] [MonObj Y] [MonObj Z] [MonObj W]
 instance {f : X ⟶ Y} {g : Z ⟶ W} [IsMonHom f] [IsMonHom g] : IsMonHom (f ⊗ₘ g) where
   one_hom := by
     dsimp [tensorObj.one_def]
-    slice_lhs 2 3 => rw [← tensor_comp, one_hom, one_hom]
+    slice_lhs 2 3 => rw [tensorHom_comp_tensorHom, one_hom, one_hom]
   mul_hom := by
     dsimp [tensorObj.mul_def]
     slice_rhs 1 2 => rw [tensorμ_natural]
-    slice_lhs 2 3 => rw [← tensor_comp, mul_hom, mul_hom, tensor_comp]
+    slice_lhs 2 3 => rw [tensorHom_comp_tensorHom, mul_hom, mul_hom, ← tensorHom_comp_tensorHom]
     simp only [Category.assoc]
 
 instance : IsMonHom (𝟙 X) where
@@ -1003,7 +1006,7 @@ instance [IsCommMonObj M] [IsCommMonObj N] : IsCommMonObj (M ⊗ N) where
   mul_comm := by
     simp [← IsIso.inv_comp_eq, tensorμ, ← associator_inv_naturality_left_assoc,
       ← associator_naturality_right_assoc, SymmetricCategory.braiding_swap_eq_inv_braiding M N,
-      ← tensorHom_def_assoc, -whiskerRight_tensor, -tensor_whiskerLeft, ← tensor_comp,
+      ← tensorHom_def_assoc, -whiskerRight_tensor, -tensor_whiskerLeft,
       MonObj.tensorObj.mul_def, ← whiskerLeft_comp_assoc, -whiskerLeft_comp]
 
 end SymmetricCategory

--- a/Mathlib/CategoryTheory/Monoidal/NaturalTransformation.lean
+++ b/Mathlib/CategoryTheory/Monoidal/NaturalTransformation.lean
@@ -60,7 +60,7 @@ instance hcomp {G₁ G₂ : D ⥤ E} [G₁.LaxMonoidal] [G₂.LaxMonoidal] (τ' 
     simp only [comp_obj, comp_ε, hcomp_app, assoc, naturality_assoc, unit_assoc, ← map_comp, unit]
   tensor X Y := by
     simp only [comp_obj, comp_μ, hcomp_app, assoc, naturality_assoc,
-      tensor_assoc, tensor_comp, μ_natural_assoc]
+      tensor_assoc, ← tensorHom_comp_tensorHom, μ_natural_assoc]
     simp only [← map_comp, tensor]
 
 instance (F : C ⥤ D) [F.LaxMonoidal] : NatTrans.IsMonoidal F.leftUnitor.hom where
@@ -103,7 +103,7 @@ instance : NatTrans.IsMonoidal e.inv where
   unit := by rw [← NatTrans.IsMonoidal.unit (τ := e.hom), assoc, hom_inv_id_app, comp_id]
   tensor X Y := by
     rw [← cancel_mono (e.hom.app (X ⊗ Y)), assoc, assoc, inv_hom_id_app, comp_id,
-      NatTrans.IsMonoidal.tensor, ← MonoidalCategory.tensor_comp_assoc,
+      NatTrans.IsMonoidal.tensor, MonoidalCategory.tensorHom_comp_tensorHom_assoc,
       inv_hom_id_app, inv_hom_id_app, tensorHom_id, id_whiskerRight, id_comp]
 
 end Iso

--- a/Mathlib/CategoryTheory/Monoidal/Opposite.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Opposite.lean
@@ -158,6 +158,7 @@ instance monoidalCategoryOp : MonoidalCategory Cᵒᵖ where
   whiskerRight f X := (f.unop ▷ X.unop).op
   tensorHom f g := (f.unop ⊗ₘ g.unop).op
   tensorHom_def _ _ := Quiver.Hom.unop_inj (tensorHom_def' _ _)
+  tensorHom_comp_tensorHom _ _ _ _ := Quiver.Hom.unop_inj <| by simp
   tensorUnit := op (𝟙_ C)
   associator X Y Z := (α_ (unop X) (unop Y) (unop Z)).symm.op
   leftUnitor X := (λ_ (unop X)).symm.op
@@ -237,6 +238,7 @@ instance monoidalCategoryMop : MonoidalCategory Cᴹᵒᵖ where
   whiskerRight f X := (X.unmop ◁ f.unmop).mop
   tensorHom f g := (g.unmop ⊗ₘ f.unmop).mop
   tensorHom_def _ _ := Quiver.Hom.unmop_inj (tensorHom_def' _ _)
+  tensorHom_comp_tensorHom _ _ _ _ := Quiver.Hom.unmop_inj <| by simp
   tensorUnit := mop (𝟙_ C)
   associator X Y Z := (α_ (unmop Z) (unmop Y) (unmop X)).symm.mop
   leftUnitor X := (ρ_ (unmop X)).mop

--- a/Mathlib/CategoryTheory/Monoidal/Preadditive.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Preadditive.lean
@@ -118,7 +118,7 @@ instance (X : C) : PreservesFiniteBiproducts (tensorLeft X) where
         { preserves := fun {b} i => ⟨isBilimitOfTotal _ (by
             dsimp
             simp_rw [← id_tensorHom]
-            simp only [← tensor_comp, Category.comp_id, ← tensor_sum, ← id_tensorHom_id,
+            simp only [tensorHom_comp_tensorHom, Category.comp_id, ← tensor_sum, ← id_tensorHom_id,
               IsBilimit.total i])⟩ } }
 
 instance (X : C) : PreservesFiniteBiproducts (tensorRight X) where
@@ -128,7 +128,7 @@ instance (X : C) : PreservesFiniteBiproducts (tensorRight X) where
         { preserves := fun {b} i => ⟨isBilimitOfTotal _ (by
             dsimp
             simp_rw [← tensorHom_id]
-            simp only [← tensor_comp, Category.comp_id, ← sum_tensor, ← id_tensorHom_id,
+            simp only [tensorHom_comp_tensorHom, Category.comp_id, ← sum_tensor, ← id_tensorHom_id,
                IsBilimit.total i])⟩ } }
 
 variable [HasFiniteBiproducts C]

--- a/Mathlib/CategoryTheory/Monoidal/Transport.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Transport.lean
@@ -84,7 +84,7 @@ def induced [MonoidalCategoryStruct D] (F : D ⥤ C) [F.Faithful]
     rw [fData.tensorHom_eq, Functor.map_comp, fData.whiskerRight_eq, fData.whiskerLeft_eq]
     simp only [tensorHom_def, assoc, Iso.hom_inv_id_assoc]
   id_tensorHom_id X₁ X₂ := F.map_injective <| by cases fData; cat_disch
-  tensor_comp {X₁ Y₁ Z₁ X₂ Y₂ Z₂} f₁ f₂ g₁ g₂ := F.map_injective <| by cases fData; cat_disch
+  tensorHom_comp_tensorHom f₁ f₂ g₁ g₂ := F.map_injective <| by cases fData; cat_disch
   whiskerLeft_id X Y := F.map_injective <| by simp [fData.whiskerLeft_eq]
   id_whiskerRight X Y := F.map_injective <| by simp [fData.whiskerRight_eq]
   triangle X Y := F.map_injective <| by cases fData; cat_disch

--- a/Mathlib/CategoryTheory/Monoidal/Types/Coyoneda.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Types/Coyoneda.lean
@@ -26,9 +26,9 @@ instance (C : Type u) [Category.{v} C] [MonoidalCategory C] :
       ext ⟨⟨f, g⟩, h⟩; dsimp at f g h
       dsimp; simp only [Iso.cancel_iso_inv_left, Category.assoc]
       conv_lhs =>
-        rw [← Category.id_comp h, tensor_comp, Category.assoc, associator_naturality,
+        rw [← Category.id_comp h, ← tensorHom_comp_tensorHom, Category.assoc, associator_naturality,
           ← Category.assoc, unitors_inv_equal, tensorHom_id, triangle_assoc_comp_right_inv]
-      conv_rhs => rw [← Category.id_comp f, tensor_comp]
+      conv_rhs => rw [← Category.id_comp f, ← tensorHom_comp_tensorHom]
       simp)
     (left_unitality := by
       intros


### PR DESCRIPTION
... instead of the other way around. This is motivated by the fact that homs happening "in parallel" is a non-concept (time along a branch can always be reparametrised), while homs happening "in series" is a well-defined concept. One should not simp the well-defined concept into the non-concept but instead the other way around.

This is also motivated by the advent of the `mon_tauto` simp set in #26057.

From Toric

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
