### PR TITLE
[Merged by Bors] - feat: make the `labels_from_comment` action more extensible

### DIFF
--- a/.github/workflows/labels_from_comment.yml
+++ b/.github/workflows/labels_from_comment.yml
@@ -41,7 +41,7 @@ jobs:
         printf '%s' "${COMMENT}" | hexdump -cC
         printf 'Comment:"%s"\n' "${COMMENT}"
 
-        for i in ${!labelArray[@]}; do
+        for i in "${!labelArray[@]}"; do
           inComment=""
           label="${labelArray[$i]}"
           printf $'\nProcessing label \'%s\'\n' "${label}"
@@ -61,7 +61,7 @@ jobs:
             # we use curl rather than octokit/request-action so that the job won't fail
             # (and send an annoying email) if the labels don't exist
             curl --request "${req}" \
-              --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/"${label}" \
+              --url "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/${label}" \
               --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
             printf $'%s %s done\n' "${inComment}" "${req}"
 

--- a/.github/workflows/labels_from_comment.yml
+++ b/.github/workflows/labels_from_comment.yml
@@ -30,13 +30,6 @@ jobs:
         # trim leading/trailing whitespace and collapse "internal" whitespace
         COMMENT="$(printf '%s' "${COMMENT}" | awk '{$1=$1};1')"
 
-        # If, after trimming whitespace, the comment spans more than one line, we do not act.
-        if [ "$(wc -l <<< "${COMMENT}")" -ne 1 ]
-        then
-          printf $'The comment contains more than a single line: exiting.\n'
-          exit 0
-        fi
-
         # for debugging, we print some information
         printf '%s' "${COMMENT}" | hexdump -cC
         printf 'Comment:"%s"\n' "${COMMENT}"
@@ -45,7 +38,8 @@ jobs:
           inComment=""
           label="${labelArray[$i]}"
           printf $'\nProcessing label \'%s\'\n' "${label}"
-          inComment="$(printf '%s' "${COMMENT}" | grep "[-]\?${label}$")"
+          # extract the last line that, up to leading/trailing whitespace, matches the current label
+          inComment="$(printf '%s' "${COMMENT}" | grep "[-]\?${label}$" | tail -1)"
           if [ -n "${inComment}" ]
           then
             printf $'Found \'%s\'\n' "${inComment}"

--- a/.github/workflows/labels_from_comment.yml
+++ b/.github/workflows/labels_from_comment.yml
@@ -15,14 +15,14 @@ permissions:
 
 jobs:
   update-label:
+    env:
+      COMMENT: ${{ github.event.comment.body }}
     runs-on: ubuntu-latest
 
     steps:
     - name: Add / remove label based on comment
       run: |
         labelArray=("awaiting-author" "WIP" "easy")
-
-        COMMENT="${{ github.event.comment.body }}"
 
         # we strip `\r` since line endings from GitHub contain this character
         COMMENT="${COMMENT//$'\r'/}"

--- a/.github/workflows/labels_from_comment.yml
+++ b/.github/workflows/labels_from_comment.yml
@@ -1,6 +1,5 @@
-# This workflow allows any user to add one of the `awaiting-author`, or `WIP` labels,
+# This workflow allows any user to add or remove one of the labels in the array `labelArray`
 # by commenting on the PR or issue.
-# Other labels from this set are removed automatically at the same time.
 
 name: Label PR based on Comment
 
@@ -8,42 +7,66 @@ on:
   issue_comment:
     types: [created]
 
+# Limit permissions for GITHUB_TOKEN for the entire workflow
+permissions:
+  contents: read
+  pull-requests: write  # Only allow PR comments/labels
+  # All other permissions are implicitly 'none'
+
 jobs:
   update-label:
-    if: github.event.issue.pull_request && (contains(github.event.comment.body, 'awaiting-author') || contains(github.event.comment.body, 'WIP'))
     runs-on: ubuntu-latest
 
     steps:
     - name: Add / remove label based on comment
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: |
-          const { owner, repo, number: issue_number  } = context.issue;
-          const commentLines = context.payload.comment.body.split(/\r?\n/);
+      run: |
+        labelArray=("awaiting-author" "WIP" "easy")
 
-          const awaitingAuthor = commentLines.includes('awaiting-author');
-          const wip = commentLines.includes('WIP');
+        COMMENT="${{ github.event.comment.body }}"
 
-          const removeAwaitingAuthor = commentLines.includes('-awaiting-author');
-          const removeWip = commentLines.includes('-WIP');
+        # we strip `\r` since line endings from GitHub contain this character
+        COMMENT="${COMMENT//$'\r'/}"
 
-          if (removeAwaitingAuthor) {
-            await github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'awaiting-author' }).catch(() => {});
-          }
+        # trim leading/trailing whitespace and collapse "internal" whitespace
+        COMMENT="$(printf '%s' "${COMMENT}" | awk '{$1=$1};1')"
 
-          if (removeWip) {
-            await github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'WIP' }).catch(() => {});
-          }
+        # If, after trimming whitespace, the comment spans more than one line, we do not act.
+        if [ "$(wc -l <<< "${COMMENT}")" -ne 1 ]
+        then
+          printf $'The comment contains more than a single line: exiting.\n'
+          exit 0
+        fi
 
-          if (awaitingAuthor || wip) {
-            await github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'awaiting-author' }).catch(() => {});
-            await github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'WIP' }).catch(() => {});
-          }
+        # for debugging, we print some information
+        printf '%s' "${COMMENT}" | hexdump -cC
+        printf 'Comment:"%s"\n' "${COMMENT}"
 
-          if (awaitingAuthor) {
-            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['awaiting-author'] });
-          }
-          if (wip) {
-            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['WIP'] });
-          }
+        for i in ${!labelArray[@]}; do
+          inComment=""
+          label="${labelArray[$i]}"
+          printf $'\nProcessing label \'%s\'\n' "${label}"
+          inComment="$(printf '%s' "${COMMENT}" | grep "[-]\?${label}$")"
+          if [ -n "${inComment}" ]
+          then
+            printf $'Found \'%s\'\n' "${inComment}"
+            if [ "${inComment:0:1}" == "-" ]
+            then
+              printf $'Removing label \'%s\'\n' "${label}"
+              req="DELETE"
+            else
+              printf $'Adding label \'%s\'\n' "${label}"
+              req="POST"
+            fi
+
+            # we use curl rather than octokit/request-action so that the job won't fail
+            # (and send an annoying email) if the labels don't exist
+            curl --request "${req}" \
+              --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/"${label}" \
+              --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+            printf $'%s %s done\n' "${inComment}" "${req}"
+
+          else
+            printf $'Label \'%s\' not found.\n' "${label}"
+          fi
+
+        done

--- a/.github/workflows/labels_from_comment.yml
+++ b/.github/workflows/labels_from_comment.yml
@@ -1,5 +1,8 @@
 # This workflow allows any user to add or remove one of the labels in the array `labelArray`
 # by commenting on the PR or issue.
+# The script reacts to lines in the comment whose entire content is, up to whitespace,
+# the label name, optionally preceded by `-`.
+# For each label, the bot follows the instruction of the *last* line that matches the label.
 
 name: Label PR based on Comment
 


### PR DESCRIPTION
The revised version of this script manages the labels `awaiting-author`, `WIP` and `easy` from comments.  If a PR comment contains of one of the three mentioned labels, optionally preceded by a single `-` *as a complete line*, then the action will add/remove the corresponding label.  If multiple lines match the same label, only the latest mention will be used.

The line may contain whitespace, besides the sign and the label, but nothing else.

For instance, if the comment is
```
A
 awaiting-author
-easy
some WIP text
       easy  
-awaiting-author
```
then the script would
* *add* the `easy` label;
* *remove* the `awaiting-author` label;
* do nothing with the `WIP` label, since it does not appear alone on any line.

Note: the previous action would automatically remove all remaining labels, since the old set was mutually exclusive.  The expectation is that the current set of labels will be increased, so that mutual exclusivity is no longer expected.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
