### PR TITLE
feat(LinearAlgebra/Projection): add results about inverse of `Submodule.prodEquivOfIsCompl`

### DIFF
--- a/Mathlib/LinearAlgebra/Projection.lean
+++ b/Mathlib/LinearAlgebra/Projection.lean
@@ -128,9 +128,9 @@ theorem prodEquivOfIsCompl_symm_apply_snd_eq_zero (h : IsCompl p q) {x : E} :
     mem_left_iff_eq_zero_of_disjoint h.disjoint]
 
 theorem prodEquivOfIsCompl_symm_apply (h : IsCompl p q)
-      (x y z : E) (hy : y ∈ p) (hz : z ∈ q) (hx : x = y + z) :
-    (prodEquivOfIsCompl p q h).symm x = ⟨⟨y, hy⟩, ⟨z, hz⟩⟩ := by
-  rw [LinearEquiv.symm_apply_eq, coe_prodEquivOfIsCompl', hx]
+      (x y z : E) (hy : y ∈ p) (hz : z ∈ q) (hx : y + z = x) :
+    (prodEquivOfIsCompl p q h).symm x = ⟨⟨y, hy⟩, ⟨z, hz⟩⟩ :=
+  (LinearEquiv.symm_apply_eq _).2 hx.symm
 
 theorem prodEquivOfIsCompl_symm_add (h : IsCompl p q) (x : E) :
     x = ((prodEquivOfIsCompl p q h).symm x).1.val + ((prodEquivOfIsCompl p q h).symm x).2.val :=

--- a/Mathlib/LinearAlgebra/Projection.lean
+++ b/Mathlib/LinearAlgebra/Projection.lean
@@ -133,10 +133,8 @@ theorem prodEquivOfIsCompl_symm_apply (h : IsCompl p q)
   rw [LinearEquiv.symm_apply_eq, coe_prodEquivOfIsCompl', hx]
 
 theorem prodEquivOfIsCompl_symm_add (h : IsCompl p q) (x : E) :
-    x = ((prodEquivOfIsCompl p q h).symm x).1.val + ((prodEquivOfIsCompl p q h).symm x).2.val := by
-  obtain ⟨y, hy, z, hz, hx⟩ := Submodule.exists_add_eq_of_codisjoint h.codisjoint x
-  rw [prodEquivOfIsCompl_symm_apply p q h x y z hy hz hx.symm]
-  exact hx.symm
+    x = ((prodEquivOfIsCompl p q h).symm x).1.val + ((prodEquivOfIsCompl p q h).symm x).2.val :=
+  ((prodEquivOfIsCompl p q h).apply_symm_apply x).symm
 
 @[simp]
 theorem prodComm_trans_prodEquivOfIsCompl (h : IsCompl p q) :

--- a/Mathlib/LinearAlgebra/Projection.lean
+++ b/Mathlib/LinearAlgebra/Projection.lean
@@ -127,6 +127,17 @@ theorem prodEquivOfIsCompl_symm_apply_snd_eq_zero (h : IsCompl p q) {x : E} :
   rw [coe_prodEquivOfIsCompl', Submodule.add_mem_iff_right _ (Submodule.coe_mem _),
     mem_left_iff_eq_zero_of_disjoint h.disjoint]
 
+theorem prodEquivOfIsCompl_symm_apply (h : IsCompl p q)
+      (x y z : E) (hy : y ∈ p) (hz : z ∈ q) (hx : x = y + z) :
+    (prodEquivOfIsCompl p q h).symm x = ⟨⟨y, hy⟩, ⟨z, hz⟩⟩ := by
+  rw [LinearEquiv.symm_apply_eq, coe_prodEquivOfIsCompl', hx]
+
+theorem prodEquivOfIsCompl_symm_add (h : IsCompl p q) (x : E) :
+    x = ((prodEquivOfIsCompl p q h).symm x).1.val + ((prodEquivOfIsCompl p q h).symm x).2.val := by
+  obtain ⟨y, hy, z, hz, hx⟩ := Submodule.exists_add_eq_of_codisjoint h.codisjoint x
+  rw [prodEquivOfIsCompl_symm_apply p q h x y z hy hz hx.symm]
+  exact hx.symm
+
 @[simp]
 theorem prodComm_trans_prodEquivOfIsCompl (h : IsCompl p q) :
     LinearEquiv.prodComm R q p ≪≫ₗ prodEquivOfIsCompl p q h = prodEquivOfIsCompl q p h.symm :=

--- a/Mathlib/LinearAlgebra/Projection.lean
+++ b/Mathlib/LinearAlgebra/Projection.lean
@@ -132,11 +132,12 @@ theorem prodEquivOfIsCompl_symm_apply (h : IsCompl p q)
     (prodEquivOfIsCompl p q h).symm x = ⟨⟨y, hy⟩, ⟨z, hz⟩⟩ := by
   rw [LinearEquiv.symm_apply_eq, coe_prodEquivOfIsCompl', hx]
 
+@[simp]
 theorem prodEquivOfIsCompl_symm_add (h : IsCompl p q) (x : E) :
-    x = ((prodEquivOfIsCompl p q h).symm x).1.val + ((prodEquivOfIsCompl p q h).symm x).2.val := by
+    ((prodEquivOfIsCompl p q h).symm x).1.val + ((prodEquivOfIsCompl p q h).symm x).2.val = x := by
   obtain ⟨y, hy, z, hz, hx⟩ := Submodule.exists_add_eq_of_codisjoint h.codisjoint x
   rw [prodEquivOfIsCompl_symm_apply p q h x y z hy hz hx.symm]
-  exact hx.symm
+  exact hx
 
 @[simp]
 theorem prodComm_trans_prodEquivOfIsCompl (h : IsCompl p q) :


### PR DESCRIPTION
Add two theorems `Submodule.prodEquivOfIsCompl_symm_apply` and `Submodule.prodEquivOfIsCompl_symm_add`, which are API for `Submodule.prodEquivOfIsCompl`.

We believe these theorems are useful; for example, we have used their statements in a [classification formalization project](https://github.com/LieLean/LowDimSolvClassification).

Co-authored by: 
- [Viviana del Barco](https://github.com/vdelbarc)
- [Gustavo Infanti](https://github.com/GuQOliveira)
- [Exequiel Rivas](https://github.com/erivas)

---

I am not sure whether the `prodEquivOfIsCompl_symm_apply` theorem should be tagged with `@[simp]`; this might lead to confluence issues. Opinions are welcome!


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
