### PR TITLE
[Merged by Bors] - chore(CategoryTheory): unprime `CatCommSq.iso'`

### DIFF
--- a/Mathlib/CategoryTheory/CatCommSq.lean
+++ b/Mathlib/CategoryTheory/CatCommSq.lean
@@ -25,38 +25,35 @@ open Category
 
 variable {C₁ C₂ C₃ C₄ C₅ C₆ : Type*} [Category C₁] [Category C₂] [Category C₃] [Category C₄]
   [Category C₅] [Category C₆]
-  (T : C₁ ⥤ C₂) (L : C₁ ⥤ C₃) (R : C₂ ⥤ C₄) (B : C₃ ⥤ C₄)
 
 /-- `CatCommSq T L R B` expresses that there is a 2-commutative square of functors, where
 the functors `T`, `L`, `R` and `B` are respectively the left, top, right and bottom functors
 of the square. -/
 @[ext]
-class CatCommSq where
-  /-- the isomorphism corresponding to a 2-commutative diagram -/
-  iso' : T ⋙ R ≅ L ⋙ B
+class CatCommSq (T : C₁ ⥤ C₂) (L : C₁ ⥤ C₃) (R : C₂ ⥤ C₄) (B : C₃ ⥤ C₄) where
+  /-- Assuming `[CatCommSq T L R B]`, `iso T L R B` is the isomorphism `T ⋙ R ≅ L ⋙ B`
+  given by the 2-commutative square. -/
+  iso (T) (L) (R) (B) : T ⋙ R ≅ L ⋙ B
+
+variable (T : C₁ ⥤ C₂) (L : C₁ ⥤ C₃) (R : C₂ ⥤ C₄) (B : C₃ ⥤ C₄)
 
 namespace CatCommSq
 
-/-- Assuming `[CatCommSq T L R B]`, `iso T L R B` is the isomorphism `T ⋙ R ≅ L ⋙ B`
-given by the 2-commutative square. -/
--- This only exists to change the explicitness of the binders of the `iso'` field.
-abbrev iso [h : CatCommSq T L R B] : T ⋙ R ≅ L ⋙ B := h.iso'
-
 /-- Horizontal composition of 2-commutative squares -/
-@[simps! iso'_hom_app iso'_inv_app]
+@[simps!]
 def hComp (T₁ : C₁ ⥤ C₂) (T₂ : C₂ ⥤ C₃) (V₁ : C₁ ⥤ C₄) (V₂ : C₂ ⥤ C₅) (V₃ : C₃ ⥤ C₆)
     (B₁ : C₄ ⥤ C₅) (B₂ : C₅ ⥤ C₆) [CatCommSq T₁ V₁ V₂ B₁] [CatCommSq T₂ V₂ V₃ B₂] :
     CatCommSq (T₁ ⋙ T₂) V₁ V₃ (B₁ ⋙ B₂) where
-  iso' := Functor.associator _ _ _ ≪≫ isoWhiskerLeft T₁ (iso T₂ V₂ V₃ B₂) ≪≫
+  iso := Functor.associator _ _ _ ≪≫ isoWhiskerLeft T₁ (iso T₂ V₂ V₃ B₂) ≪≫
     (Functor.associator _ _ _).symm ≪≫ isoWhiskerRight (iso T₁ V₁ V₂ B₁) B₂ ≪≫
     Functor.associator _ _ _
 
 /-- Vertical composition of 2-commutative squares -/
-@[simps! iso'_hom_app iso'_inv_app]
+@[simps!]
 def vComp (L₁ : C₁ ⥤ C₂) (L₂ : C₂ ⥤ C₃) (H₁ : C₁ ⥤ C₄) (H₂ : C₂ ⥤ C₅) (H₃ : C₃ ⥤ C₆)
     (R₁ : C₄ ⥤ C₅) (R₂ : C₅ ⥤ C₆) [CatCommSq H₁ L₁ R₁ H₂] [CatCommSq H₂ L₂ R₂ H₃] :
     CatCommSq H₁ (L₁ ⋙ L₂) (R₁ ⋙ R₂) H₃ where
-  iso' := (Functor.associator _ _ _).symm ≪≫ isoWhiskerRight (iso H₁ L₁ R₁ H₂) R₂ ≪≫
+  iso := (Functor.associator _ _ _).symm ≪≫ isoWhiskerRight (iso H₁ L₁ R₁ H₂) R₂ ≪≫
       Functor.associator _ _ _ ≪≫ isoWhiskerLeft L₁ (iso H₂ L₂ R₂ H₃) ≪≫
       (Functor.associator _ _ _).symm
 
@@ -65,9 +62,9 @@ section
 variable (T : C₁ ≌ C₂) (L : C₁ ⥤ C₃) (R : C₂ ⥤ C₄) (B : C₃ ≌ C₄)
 
 /-- Horizontal inverse of a 2-commutative square -/
-@[simps! iso'_hom_app iso'_inv_app]
+@[simps!]
 def hInv (_ : CatCommSq T.functor L R B.functor) : CatCommSq T.inverse R L B.inverse where
-  iso' := isoWhiskerLeft _ (L.rightUnitor.symm ≪≫ isoWhiskerLeft L B.unitIso ≪≫
+  iso := isoWhiskerLeft _ (L.rightUnitor.symm ≪≫ isoWhiskerLeft L B.unitIso ≪≫
       (Functor.associator _ _ _).symm ≪≫
       isoWhiskerRight (iso T.functor L R B.functor).symm B.inverse ≪≫
       Functor.associator _ _ _  ) ≪≫ (Functor.associator _ _ _).symm ≪≫
@@ -78,10 +75,10 @@ lemma hInv_hInv (h : CatCommSq T.functor L R B.functor) :
   ext X
   rw [← cancel_mono (B.functor.map (L.map (T.unitIso.hom.app X)))]
   rw [← Functor.comp_map]
-  erw [← h.iso'.hom.naturality (T.unitIso.hom.app X)]
-  rw [hInv_iso'_hom_app]
+  erw [← h.iso.hom.naturality (T.unitIso.hom.app X)]
+  rw [hInv_iso_hom_app]
   simp only [Equivalence.symm_functor]
-  rw [hInv_iso'_inv_app]
+  rw [hInv_iso_inv_app]
   dsimp
   simp only [Functor.comp_obj, assoc, ← Functor.map_comp, Iso.inv_hom_id_app,
     Equivalence.counitInv_app_functor, Functor.map_id]
@@ -104,9 +101,9 @@ section
 variable (T : C₁ ⥤ C₂) (L : C₁ ≌ C₃) (R : C₂ ≌ C₄) (B : C₃ ⥤ C₄)
 
 /-- Vertical inverse of a 2-commutative square -/
-@[simps! iso'_hom_app iso'_inv_app]
+@[simps!]
 def vInv (_ : CatCommSq T L.functor R.functor B) : CatCommSq B L.inverse R.inverse T where
-  iso' := isoWhiskerRight (B.leftUnitor.symm ≪≫ isoWhiskerRight L.counitIso.symm B ≪≫
+  iso := isoWhiskerRight (B.leftUnitor.symm ≪≫ isoWhiskerRight L.counitIso.symm B ≪≫
       Functor.associator _ _ _ ≪≫
       isoWhiskerLeft L.inverse (iso T L.functor R.functor B).symm) R.inverse ≪≫
       Functor.associator _ _ _ ≪≫ isoWhiskerLeft _ (Functor.associator _ _ _) ≪≫
@@ -116,8 +113,9 @@ def vInv (_ : CatCommSq T L.functor R.functor B) : CatCommSq B L.inverse R.inver
 lemma vInv_vInv (h : CatCommSq T L.functor R.functor B) :
     vInv B L.symm R.symm T (vInv T L R B h) = h := by
   ext X
-  rw [vInv_iso'_hom_app, vInv_iso'_inv_app]
+  rw [vInv_iso_hom_app]
   dsimp
+  rw [vInv_iso_inv_app]
   rw [← cancel_mono (B.map (L.functor.map (NatTrans.app L.unitIso.hom X)))]
   rw [← Functor.comp_map]
   erw [← (iso T L.functor R.functor B).hom.naturality (L.unitIso.hom.app X)]

--- a/Mathlib/CategoryTheory/GuitartExact/VerticalComposition.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/VerticalComposition.lean
@@ -132,7 +132,7 @@ lemma vComp_iff_of_equivalences (eL : C₂ ≌ C₃) (eR : D₂ ≌ D₃)
         simp only [Functor.comp_obj, vComp'_app, Iso.trans_inv, isoWhiskerLeft_inv, Iso.symm_inv,
           assoc, NatTrans.comp_app, Functor.id_obj, Functor.rightUnitor_inv_app,
           CategoryTheory.whiskerLeft_app, Functor.associator_inv_app, comp_id, id_comp, vComp_app,
-          Functor.map_comp, Equivalence.inv_fun_map, CatCommSq.vInv_iso'_hom_app, Iso.trans_hom,
+          Functor.map_comp, Equivalence.inv_fun_map, CatCommSq.vInv_iso_hom_app, Iso.trans_hom,
           isoWhiskerLeft_hom, Iso.symm_hom, Functor.associator_hom_app, Functor.rightUnitor_hom_app,
           Iso.hom_inv_id_app_assoc, w'', α, β, this]
       simp only [hw', ← eR.inverse.map_comp_assoc, w'', this, β, α]

--- a/Mathlib/CategoryTheory/Localization/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Localization/Adjunction.lean
@@ -42,7 +42,7 @@ namespace Localization
 /-- Auxiliary definition of the unit morphism for the adjunction `Adjunction.localization` -/
 noncomputable def ε : 𝟭 D₁ ⟶ G' ⋙ F' := by
   letI : Lifting L₁ W₁ ((G ⋙ F) ⋙ L₁) (G' ⋙ F') :=
-    Lifting.mk (CatCommSq.hComp G F L₁ L₂ L₁ G' F').iso'.symm
+    Lifting.mk (CatCommSq.hComp G F L₁ L₂ L₁ G' F').iso.symm
   exact Localization.liftNatTrans L₁ W₁ L₁ ((G ⋙ F) ⋙ L₁) (𝟭 D₁) (G' ⋙ F')
     (whiskerRight adj.unit L₁)
 
@@ -51,15 +51,15 @@ lemma ε_app (X₁ : C₁) :
       L₁.map (adj.unit.app X₁) ≫ (CatCommSq.iso F L₂ L₁ F').hom.app (G.obj X₁) ≫
         F'.map ((CatCommSq.iso G L₁ L₂ G').hom.app X₁) := by
   letI : Lifting L₁ W₁ ((G ⋙ F) ⋙ L₁) (G' ⋙ F') :=
-    Lifting.mk (CatCommSq.hComp G F L₁ L₂ L₁ G' F').iso'.symm
+    Lifting.mk (CatCommSq.hComp G F L₁ L₂ L₁ G' F').iso.symm
   simp only [ε, liftNatTrans_app, Lifting.iso, Iso.symm,
     Functor.id_obj, Functor.comp_obj, Lifting.id_iso', Functor.rightUnitor_hom_app,
-      whiskerRight_app, CatCommSq.hComp_iso'_hom_app, id_comp]
+      whiskerRight_app, CatCommSq.hComp_iso_hom_app, id_comp]
 
 /-- Auxiliary definition of the counit morphism for the adjunction `Adjunction.localization` -/
 noncomputable def η : F' ⋙ G' ⟶ 𝟭 D₂ := by
   letI : Lifting L₂ W₂ ((F ⋙ G) ⋙ L₂) (F' ⋙ G') :=
-    Lifting.mk (CatCommSq.hComp F G L₂ L₁ L₂ F' G').iso'.symm
+    Lifting.mk (CatCommSq.hComp F G L₂ L₁ L₂ F' G').iso.symm
   exact liftNatTrans L₂ W₂ ((F ⋙ G) ⋙ L₂) L₂ (F' ⋙ G') (𝟭 D₂) (whiskerRight adj.counit L₂)
 
 lemma η_app (X₂ : C₂) :
@@ -68,8 +68,8 @@ lemma η_app (X₂ : C₂) :
         (CatCommSq.iso G L₁ L₂ G').inv.app (F.obj X₂) ≫
         L₂.map (adj.counit.app X₂) := by
   letI : Lifting L₂ W₂ ((F ⋙ G) ⋙ L₂) (F' ⋙ G') :=
-    Lifting.mk (CatCommSq.hComp F G L₂ L₁ L₂ F' G').iso'.symm
-  simp only [η, liftNatTrans_app, Lifting.iso, Iso.symm, CatCommSq.hComp_iso'_inv_app,
+    Lifting.mk (CatCommSq.hComp F G L₂ L₁ L₂ F' G').iso.symm
+  simp only [η, liftNatTrans_app, Lifting.iso, Iso.symm, CatCommSq.hComp_iso_inv_app,
     whiskerRight_app, Lifting.id_iso', Functor.rightUnitor_inv_app, comp_id, assoc]
 
 end Localization

--- a/Mathlib/CategoryTheory/Localization/FiniteProducts.lean
+++ b/Mathlib/CategoryTheory/Localization/FiniteProducts.lean
@@ -56,11 +56,11 @@ noncomputable def compLimitFunctorIso :
 instance :
     CatCommSq (Functor.const (Discrete J)) L
       ((whiskeringRight (Discrete J) C D).obj L) (Functor.const (Discrete J)) where
-  iso' := (Functor.compConstIso _ _).symm
+  iso := (Functor.compConstIso _ _).symm
 
 noncomputable instance :
     CatCommSq lim ((whiskeringRight (Discrete J) C D).obj L) L (limitFunctor L W J) where
-  iso' := (compLimitFunctorIso L W J).symm
+  iso := (compLimitFunctorIso L W J).symm
 
 /-- The adjunction between the constant functor `D ⥤ (Discrete J ⥤ D)`
 and `limitFunctor L W J`. -/


### PR DESCRIPTION
Make it so `CatCommSq` can now directly be defined by its iso, rather than having to define a `iso'` and record manually lemmas.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
