### PR TITLE
[Merged by Bors] - refactor(Data/NNRat/BigOperators): generalize `coe` big operator lemmas

### DIFF
--- a/Mathlib/Data/NNRat/BigOperators.lean
+++ b/Mathlib/Data/NNRat/BigOperators.lean
@@ -16,7 +16,7 @@ namespace NNRat
 
 section DivisionSemiring
 
-variable (K : Type*) [DivisionSemiring K] [CharZero K]
+variable {K : Type*} [DivisionSemiring K] [CharZero K]
 
 @[norm_cast]
 theorem cast_listSum (l : List ℚ≥0) : (l.sum : K) = (l.map (↑)).sum :=
@@ -46,7 +46,7 @@ end DivisionSemiring
 
 section Semifield
 
-variable (K : Type*) [Semifield K] [CharZero K]
+variable {K : Type*} [Semifield K] [CharZero K]
 
 @[norm_cast]
 theorem cast_multisetProd (s : Multiset ℚ≥0) : (s.prod : K) = (s.map (↑)).prod :=

--- a/Mathlib/Data/NNRat/BigOperators.lean
+++ b/Mathlib/Data/NNRat/BigOperators.lean
@@ -16,36 +16,36 @@ namespace NNRat
 
 section DivisionSemiring
 
-variable {β : Type} [DivisionSemiring β] [CharZero β]
+variable {K : Type} [DivisionSemiring K] [CharZero K]
 
 @[norm_cast]
-theorem coe_list_sum (l : List ℚ≥0) : (l.sum : β) = (l.map (↑)).sum :=
+theorem coe_list_sum (l : List ℚ≥0) : (l.sum : K) = (l.map (↑)).sum :=
   map_list_sum (castHom _) _
 
 @[norm_cast]
-theorem coe_list_prod (l : List ℚ≥0) : (l.prod : β) = (l.map (↑)).prod :=
+theorem coe_list_prod (l : List ℚ≥0) : (l.prod : K) = (l.map (↑)).prod :=
   map_list_prod (castHom _) _
 
 @[norm_cast]
-theorem coe_multiset_sum (s : Multiset ℚ≥0) : (s.sum : β) = (s.map (↑)).sum :=
+theorem coe_multiset_sum (s : Multiset ℚ≥0) : (s.sum : K) = (s.map (↑)).sum :=
   map_multiset_sum (castHom _) _
 
 @[norm_cast]
-theorem coe_sum {s : Finset α} {f : α → ℚ≥0} : ↑(∑ a ∈ s, f a) = ∑ a ∈ s, (f a : β) :=
+theorem coe_sum {s : Finset α} {f : α → ℚ≥0} : ↑(∑ a ∈ s, f a) = ∑ a ∈ s, (f a : K) :=
   map_sum (castHom _) _ _
 
 end DivisionSemiring
 
 section Semifield
 
-variable {β : Type} [Semifield β] [CharZero β]
+variable {K : Type} [Semifield K] [CharZero K]
 
 @[norm_cast]
-theorem coe_multiset_prod (s : Multiset ℚ≥0) : (s.prod : β) = (s.map (↑)).prod :=
+theorem coe_multiset_prod (s : Multiset ℚ≥0) : (s.prod : K) = (s.map (↑)).prod :=
   map_multiset_prod (castHom _) _
 
 @[norm_cast]
-theorem coe_prod {s : Finset α} {f : α → ℚ≥0} : ↑(∏ a ∈ s, f a) = ∏ a ∈ s, (f a : β) :=
+theorem coe_prod {s : Finset α} {f : α → ℚ≥0} : ↑(∏ a ∈ s, f a) = ∏ a ∈ s, (f a : K) :=
   map_prod (castHom _) _ _
 
 end Semifield

--- a/Mathlib/Data/NNRat/BigOperators.lean
+++ b/Mathlib/Data/NNRat/BigOperators.lean
@@ -53,7 +53,7 @@ end Semifield
 section Rat
 
 theorem toNNRat_sum_of_nonneg {s : Finset α} {f : α → ℚ} (hf : ∀ a, a ∈ s → 0 ≤ f a) :
-    (∑ a ∈ s, f a).toNNRat = ∑ a ∈ s,(f a).toNNRat := by
+    (∑ a ∈ s, f a).toNNRat = ∑ a ∈ s, (f a).toNNRat := by
   rw [← coe_inj, coe_sum, Rat.coe_toNNRat _ (Finset.sum_nonneg hf)]
   exact Finset.sum_congr rfl fun x hxs ↦ by rw [Rat.coe_toNNRat _ (hf x hxs)]
 

--- a/Mathlib/Data/NNRat/BigOperators.lean
+++ b/Mathlib/Data/NNRat/BigOperators.lean
@@ -16,7 +16,7 @@ namespace NNRat
 
 section DivisionSemiring
 
-variable {K : Type} [DivisionSemiring K] [CharZero K]
+variable (K : Type*) [DivisionSemiring K] [CharZero K]
 
 @[norm_cast]
 theorem cast_listSum (l : List ℚ≥0) : (l.sum : K) = (l.map (↑)).sum :=
@@ -28,7 +28,7 @@ theorem cast_listSum (l : List ℚ≥0) : (l.sum : K) = (l.map (↑)).sum :=
 theorem cast_listProd (l : List ℚ≥0) : (l.prod : K) = (l.map (↑)).prod :=
   map_list_prod (castHom _) _
 
-@[deprecated (since := "2025-06-30")] alias cast_list_prod := cast_listProd
+@[deprecated (since := "2025-06-30")] alias coe_list_prod := cast_listProd
 
 @[norm_cast]
 theorem cast_multisetSum (s : Multiset ℚ≥0) : (s.sum : K) = (s.map (↑)).sum :=
@@ -37,7 +37,7 @@ theorem cast_multisetSum (s : Multiset ℚ≥0) : (s.sum : K) = (s.map (↑)).su
 @[deprecated (since := "2025-06-30")] alias coe_multiset_sum := cast_multisetSum
 
 @[norm_cast]
-theorem cast_sum {s : Finset α} {f : α → ℚ≥0} : ↑(∑ a ∈ s, f a) = ∑ a ∈ s, (f a : K) :=
+theorem cast_sum (s : Finset α) (f : α → ℚ≥0) : ↑(∑ a ∈ s, f a) = ∑ a ∈ s, (f a : K) :=
   map_sum (castHom _) _ _
 
 @[deprecated (since := "2025-06-30")] alias coe_sum := cast_sum
@@ -46,7 +46,7 @@ end DivisionSemiring
 
 section Semifield
 
-variable {K : Type} [Semifield K] [CharZero K]
+variable (K : Type*) [Semifield K] [CharZero K]
 
 @[norm_cast]
 theorem cast_multisetProd (s : Multiset ℚ≥0) : (s.prod : K) = (s.map (↑)).prod :=
@@ -55,7 +55,7 @@ theorem cast_multisetProd (s : Multiset ℚ≥0) : (s.prod : K) = (s.map (↑)).
 @[deprecated (since := "2025-06-30")] alias coe_multiset_prod := cast_multisetProd
 
 @[norm_cast]
-theorem cast_prod {s : Finset α} {f : α → ℚ≥0} : ↑(∏ a ∈ s, f a) = ∏ a ∈ s, (f a : K) :=
+theorem cast_prod (s : Finset α) (f : α → ℚ≥0) : ↑(∏ a ∈ s, f a) = ∏ a ∈ s, (f a : K) :=
   map_prod (castHom _) _ _
 
 @[deprecated (since := "2025-06-30")] alias coe_prod := cast_prod

--- a/Mathlib/Data/NNRat/BigOperators.lean
+++ b/Mathlib/Data/NNRat/BigOperators.lean
@@ -14,38 +14,54 @@ variable {α : Type*}
 
 namespace NNRat
 
-@[norm_cast]
-theorem coe_list_sum (l : List ℚ≥0) : (l.sum : ℚ) = (l.map (↑)).sum :=
-  map_list_sum coeHom _
+section DivisionSemiring
+
+variable {β : Type} [DivisionSemiring β] [CharZero β]
 
 @[norm_cast]
-theorem coe_list_prod (l : List ℚ≥0) : (l.prod : ℚ) = (l.map (↑)).prod :=
-  map_list_prod coeHom _
+theorem coe_list_sum (l : List ℚ≥0) : (l.sum : β) = (l.map (↑)).sum :=
+  map_list_sum (castHom _) _
 
 @[norm_cast]
-theorem coe_multiset_sum (s : Multiset ℚ≥0) : (s.sum : ℚ) = (s.map (↑)).sum :=
-  map_multiset_sum coeHom _
+theorem coe_list_prod (l : List ℚ≥0) : (l.prod : β) = (l.map (↑)).prod :=
+  map_list_prod (castHom _) _
 
 @[norm_cast]
-theorem coe_multiset_prod (s : Multiset ℚ≥0) : (s.prod : ℚ) = (s.map (↑)).prod :=
-  map_multiset_prod coeHom _
+theorem coe_multiset_sum (s : Multiset ℚ≥0) : (s.sum : β) = (s.map (↑)).sum :=
+  map_multiset_sum (castHom _) _
 
 @[norm_cast]
-theorem coe_sum {s : Finset α} {f : α → ℚ≥0} : ↑(∑ a ∈ s, f a) = ∑ a ∈ s, (f a : ℚ) :=
-  map_sum coeHom _ _
+theorem coe_sum {s : Finset α} {f : α → ℚ≥0} : ↑(∑ a ∈ s, f a) = ∑ a ∈ s, (f a : β) :=
+  map_sum (castHom _) _ _
+
+end DivisionSemiring
+
+section Semifield
+
+variable {β : Type} [Semifield β] [CharZero β]
+
+@[norm_cast]
+lemma coe_multiset_prod (s : Multiset ℚ≥0) : (s.prod : β) = (s.map (↑)).prod :=
+  map_multiset_prod (castHom _) _
+
+@[norm_cast]
+theorem coe_prod {s : Finset α} {f : α → ℚ≥0} : ↑(∏ a ∈ s, f a) = ∏ a ∈ s, (f a : β) :=
+  map_prod (castHom _) _ _
+
+end Semifield
+
+section Rat
 
 theorem toNNRat_sum_of_nonneg {s : Finset α} {f : α → ℚ} (hf : ∀ a, a ∈ s → 0 ≤ f a) :
-    (∑ a ∈ s, f a).toNNRat = ∑ a ∈ s, (f a).toNNRat := by
+    (∑ a ∈ s, f a).toNNRat = ∑ a ∈ s,(f a).toNNRat := by
   rw [← coe_inj, coe_sum, Rat.coe_toNNRat _ (Finset.sum_nonneg hf)]
   exact Finset.sum_congr rfl fun x hxs ↦ by rw [Rat.coe_toNNRat _ (hf x hxs)]
-
-@[norm_cast]
-theorem coe_prod {s : Finset α} {f : α → ℚ≥0} : ↑(∏ a ∈ s, f a) = ∏ a ∈ s, (f a : ℚ) :=
-  map_prod coeHom _ _
 
 theorem toNNRat_prod_of_nonneg {s : Finset α} {f : α → ℚ} (hf : ∀ a ∈ s, 0 ≤ f a) :
     (∏ a ∈ s, f a).toNNRat = ∏ a ∈ s, (f a).toNNRat := by
   rw [← coe_inj, coe_prod, Rat.coe_toNNRat _ (Finset.prod_nonneg hf)]
   exact Finset.prod_congr rfl fun x hxs ↦ by rw [Rat.coe_toNNRat _ (hf x hxs)]
+
+end Rat
 
 end NNRat

--- a/Mathlib/Data/NNRat/BigOperators.lean
+++ b/Mathlib/Data/NNRat/BigOperators.lean
@@ -19,20 +19,28 @@ section DivisionSemiring
 variable {K : Type} [DivisionSemiring K] [CharZero K]
 
 @[norm_cast]
-theorem coe_list_sum (l : List ℚ≥0) : (l.sum : K) = (l.map (↑)).sum :=
+theorem cast_listSum (l : List ℚ≥0) : (l.sum : K) = (l.map (↑)).sum :=
   map_list_sum (castHom _) _
 
+@[deprecated (since := "2025-06-30")] alias coe_list_sum := cast_listSum
+
 @[norm_cast]
-theorem coe_list_prod (l : List ℚ≥0) : (l.prod : K) = (l.map (↑)).prod :=
+theorem cast_listProd (l : List ℚ≥0) : (l.prod : K) = (l.map (↑)).prod :=
   map_list_prod (castHom _) _
 
-@[norm_cast]
-theorem coe_multiset_sum (s : Multiset ℚ≥0) : (s.sum : K) = (s.map (↑)).sum :=
-  map_multiset_sum (castHom _) _
+@[deprecated (since := "2025-06-30")] alias cast_list_prod := cast_listProd
 
 @[norm_cast]
-theorem coe_sum {s : Finset α} {f : α → ℚ≥0} : ↑(∑ a ∈ s, f a) = ∑ a ∈ s, (f a : K) :=
+theorem cast_multisetSum (s : Multiset ℚ≥0) : (s.sum : K) = (s.map (↑)).sum :=
+  map_multiset_sum (castHom _) _
+
+@[deprecated (since := "2025-06-30")] alias coe_multiset_sum := cast_multisetSum
+
+@[norm_cast]
+theorem cast_sum {s : Finset α} {f : α → ℚ≥0} : ↑(∑ a ∈ s, f a) = ∑ a ∈ s, (f a : K) :=
   map_sum (castHom _) _ _
+
+@[deprecated (since := "2025-06-30")] alias coe_sum := cast_sum
 
 end DivisionSemiring
 
@@ -41,12 +49,16 @@ section Semifield
 variable {K : Type} [Semifield K] [CharZero K]
 
 @[norm_cast]
-theorem coe_multiset_prod (s : Multiset ℚ≥0) : (s.prod : K) = (s.map (↑)).prod :=
+theorem cast_multisetProd (s : Multiset ℚ≥0) : (s.prod : K) = (s.map (↑)).prod :=
   map_multiset_prod (castHom _) _
 
+@[deprecated (since := "2025-06-30")] alias coe_multiset_prod := cast_multisetProd
+
 @[norm_cast]
-theorem coe_prod {s : Finset α} {f : α → ℚ≥0} : ↑(∏ a ∈ s, f a) = ∏ a ∈ s, (f a : K) :=
+theorem cast_prod {s : Finset α} {f : α → ℚ≥0} : ↑(∏ a ∈ s, f a) = ∏ a ∈ s, (f a : K) :=
   map_prod (castHom _) _ _
+
+@[deprecated (since := "2025-06-30")] alias coe_prod := cast_prod
 
 end Semifield
 
@@ -54,12 +66,12 @@ section Rat
 
 theorem toNNRat_sum_of_nonneg {s : Finset α} {f : α → ℚ} (hf : ∀ a, a ∈ s → 0 ≤ f a) :
     (∑ a ∈ s, f a).toNNRat = ∑ a ∈ s, (f a).toNNRat := by
-  rw [← coe_inj, coe_sum, Rat.coe_toNNRat _ (Finset.sum_nonneg hf)]
+  rw [← coe_inj, cast_sum, Rat.coe_toNNRat _ (Finset.sum_nonneg hf)]
   exact Finset.sum_congr rfl fun x hxs ↦ by rw [Rat.coe_toNNRat _ (hf x hxs)]
 
 theorem toNNRat_prod_of_nonneg {s : Finset α} {f : α → ℚ} (hf : ∀ a ∈ s, 0 ≤ f a) :
     (∏ a ∈ s, f a).toNNRat = ∏ a ∈ s, (f a).toNNRat := by
-  rw [← coe_inj, coe_prod, Rat.coe_toNNRat _ (Finset.prod_nonneg hf)]
+  rw [← coe_inj, cast_prod, Rat.coe_toNNRat _ (Finset.prod_nonneg hf)]
   exact Finset.prod_congr rfl fun x hxs ↦ by rw [Rat.coe_toNNRat _ (hf x hxs)]
 
 end Rat

--- a/Mathlib/Data/NNRat/BigOperators.lean
+++ b/Mathlib/Data/NNRat/BigOperators.lean
@@ -41,7 +41,7 @@ section Semifield
 variable {β : Type} [Semifield β] [CharZero β]
 
 @[norm_cast]
-lemma coe_multiset_prod (s : Multiset ℚ≥0) : (s.prod : β) = (s.map (↑)).prod :=
+theorem coe_multiset_prod (s : Multiset ℚ≥0) : (s.prod : β) = (s.map (↑)).prod :=
   map_multiset_prod (castHom _) _
 
 @[norm_cast]


### PR DESCRIPTION
This refactor generalizes the `norm_cast` lemmas for sums and products of coercion of `ℚ≥0` elements.

Previously, these lemmas were stated only for coercion to `ℚ`. This change generalizes the target type `β` to any `[DivisionSemiring β]` with `[CharZero β]` for sums, and any `[Semifield β]` with `[CharZero β]` for products. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
