### PR TITLE
[Merged by Bors] - feat(MeasureTheory): LIntegral is zero if the function is ae zero 

### DIFF
--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
@@ -277,6 +277,10 @@ lemma setLIntegral_eq_zero {f : α → ℝ≥0∞} {s : Set α} (hs : Measurable
 
 section
 
+theorem lintegral_eq_zero_of_ae_eq_zero {α : Type*} [MeasurableSpace α] {μ : Measure α}
+    {f : α → ℝ≥0∞} : f =ᵐ[μ] 0 →  ∫⁻ a, f a ∂μ = 0 :=
+  fun h ↦ (lintegral_congr_ae h).trans lintegral_zero
+
 /-- The Lebesgue integral is zero iff the function is a.e. zero.
 
 The measurability assumption is necessary, otherwise there are counterexamples: for instance, the
@@ -286,7 +290,7 @@ theorem lintegral_eq_zero_iff' {f : α → ℝ≥0∞} (hf : AEMeasurable f μ) 
     ∫⁻ a, f a ∂μ = 0 ↔ f =ᵐ[μ] 0 := by
   -- The proof implicitly uses Markov's inequality,
   -- but it has been inlined for the sake of imports
-  refine ⟨fun h ↦ ?_, fun h ↦ (lintegral_congr_ae h).trans lintegral_zero⟩
+  refine ⟨fun h ↦ ?_, lintegral_eq_zero_of_ae_eq_zero⟩
   have meas_levels_0 : ∀ ε > 0, μ { x | ε ≤ f x } = 0 := fun ε εpos ↦ by
     by_contra! h'; rw [← zero_lt_iff] at h'
     refine ((mul_pos_iff.mpr ⟨εpos, h'⟩).trans_le ?_).ne' h

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
@@ -277,9 +277,9 @@ lemma setLIntegral_eq_zero {f : α → ℝ≥0∞} {s : Set α} (hs : Measurable
 
 section
 
-theorem lintegral_eq_zero_of_ae_eq_zero {f : α → ℝ≥0∞} :
-    f =ᵐ[μ] 0 →  ∫⁻ a, f a ∂μ = 0 :=
-  fun h ↦ (lintegral_congr_ae h).trans lintegral_zero
+theorem lintegral_eq_zero_of_ae_eq_zero {f : α → ℝ≥0∞} (h : f =ᵐ[μ] 0) :
+    ∫⁻ a, f a ∂μ = 0 :=
+  (lintegral_congr_ae h).trans lintegral_zero
 
 /-- The Lebesgue integral is zero iff the function is a.e. zero.
 

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Basic.lean
@@ -277,8 +277,8 @@ lemma setLIntegral_eq_zero {f : α → ℝ≥0∞} {s : Set α} (hs : Measurable
 
 section
 
-theorem lintegral_eq_zero_of_ae_eq_zero {α : Type*} [MeasurableSpace α] {μ : Measure α}
-    {f : α → ℝ≥0∞} : f =ᵐ[μ] 0 →  ∫⁻ a, f a ∂μ = 0 :=
+theorem lintegral_eq_zero_of_ae_eq_zero {f : α → ℝ≥0∞} :
+    f =ᵐ[μ] 0 →  ∫⁻ a, f a ∂μ = 0 :=
   fun h ↦ (lintegral_congr_ae h).trans lintegral_zero
 
 /-- The Lebesgue integral is zero iff the function is a.e. zero.


### PR DESCRIPTION
Adds a theorem for one of the directions of `lintegral_eq_zero_iff` which doesn't require `AEMeasurable` (unlike the other direction)