### PR TITLE
[Merged by Bors] - add some lemmas about `Nat.gcd`

### DIFF
--- a/Mathlib/Algebra/Group/Nat/Defs.lean
+++ b/Mathlib/Algebra/Group/Nat/Defs.lean
@@ -70,22 +70,4 @@ set_option linter.style.commandStart true
 -- We set the simp priority slightly lower than default; later more general lemmas will replace it.
 @[simp 900] protected lemma nsmul_eq_mul (m n : ℕ) : m • n = m * n := rfl
 
-lemma div_mul_div {m n k : ℕ} (hn : n > 0) (hkm : m ∣ k) (hkn : n ∣ m) :
-    (k / m) * (m / n) = k / n := by
-  refine Eq.symm (Nat.div_eq_of_eq_mul_left hn ?_)
-  rw [mul_assoc, Nat.div_mul_cancel hkn, Nat.div_mul_cancel hkm]
-
-lemma div_dvd_div' {m n k : ℕ} (hn : n > 0) (hkm : m ∣ k) (hkn : n ∣ m) :
-    k / m ∣ k / n := Exists.intro (m / n) (Eq.symm (div_mul_div hn hkm hkn))
-
-lemma lcm_div_div {m n k : ℕ} (hm : m > 0) (hn : n > 0) (hkm : m ∣ k) (hkn : n ∣ k) :
-    (k / m).lcm (k / n) = k / (m.gcd n) := by
-  rw [Nat.lcm_eq_iff]
-  exact ⟨div_dvd_div' (gcd_pos_of_pos_left n hm) hkm (Nat.gcd_dvd_left m n),
-        div_dvd_div' (gcd_pos_of_pos_left n hm) hkn (Nat.gcd_dvd_right m n), fun c hmc hnc ↦ by
-    rw [Nat.div_dvd_iff_dvd_mul hkm hm] at hmc
-    rw [Nat.div_dvd_iff_dvd_mul hkn hn] at hnc
-    simpa [Nat.div_dvd_iff_dvd_mul (Nat.dvd_trans (Nat.gcd_dvd_left m n) hkm)
-      (gcd_pos_of_pos_left n hm), Nat.gcd_mul_right m c n] using (Nat.dvd_gcd hmc hnc) ⟩
-
 end Nat

--- a/Mathlib/Algebra/Group/Nat/Defs.lean
+++ b/Mathlib/Algebra/Group/Nat/Defs.lean
@@ -70,4 +70,22 @@ set_option linter.style.commandStart true
 -- We set the simp priority slightly lower than default; later more general lemmas will replace it.
 @[simp 900] protected lemma nsmul_eq_mul (m n : ℕ) : m • n = m * n := rfl
 
+lemma div_mul_div {m n k : ℕ} (hn : n > 0) (hkm : m ∣ k) (hkn : n ∣ m) :
+    (k / m) * (m / n) = k / n := by
+  refine Eq.symm (Nat.div_eq_of_eq_mul_left hn ?_)
+  rw [mul_assoc, Nat.div_mul_cancel hkn, Nat.div_mul_cancel hkm]
+
+lemma div_dvd_div' {m n k : ℕ} (hn : n > 0) (hkm : m ∣ k) (hkn : n ∣ m) :
+    k / m ∣ k / n := Exists.intro (m / n) (Eq.symm (div_mul_div hn hkm hkn))
+
+lemma lcm_div_div {m n k : ℕ} (hm : m > 0) (hn : n > 0) (hkm : m ∣ k) (hkn : n ∣ k) :
+    (k / m).lcm (k / n) = k / (m.gcd n) := by
+  rw [Nat.lcm_eq_iff]
+  exact ⟨div_dvd_div' (gcd_pos_of_pos_left n hm) hkm (Nat.gcd_dvd_left m n),
+        div_dvd_div' (gcd_pos_of_pos_left n hm) hkn (Nat.gcd_dvd_right m n), fun c hmc hnc ↦ by
+    rw [Nat.div_dvd_iff_dvd_mul hkm hm] at hmc
+    rw [Nat.div_dvd_iff_dvd_mul hkn hn] at hnc
+    simpa [Nat.div_dvd_iff_dvd_mul (Nat.dvd_trans (Nat.gcd_dvd_left m n) hkm)
+      (gcd_pos_of_pos_left n hm), Nat.gcd_mul_right m c n] using (Nat.dvd_gcd hmc hnc) ⟩
+
 end Nat

--- a/Mathlib/Data/Nat/GCD/Basic.lean
+++ b/Mathlib/Data/Nat/GCD/Basic.lean
@@ -231,21 +231,20 @@ theorem gcd_mul_gcd_eq_iff_dvd_mul_of_coprime (hcop : Coprime n m) :
 lemma div_mul_div (hkm : m ∣ k) (hkn : n ∣ m) : (k / m) * (m / n) = k / n := by
   rcases n.eq_zero_or_pos with hn | hn
   · simp [hn]
-  refine Eq.symm (Nat.div_eq_of_eq_mul_left hn ?_)
+  refine (Nat.div_eq_of_eq_mul_left hn ?_).symm
   rw [mul_assoc, Nat.div_mul_cancel hkn, Nat.div_mul_cancel hkm]
 
-lemma div_dvd_div_left (hkm : m ∣ k) (hkn : n ∣ m) : k / m ∣ k / n := by
-  use m / n
-  exact Eq.symm (div_mul_div hkm hkn)
+lemma div_dvd_div_left (hkm : m ∣ k) (hkn : n ∣ m) : k / m ∣ k / n :=
+  ⟨_, (div_mul_div hkm hkn).symm⟩
 
 lemma div_lcm_eq_div_gcd (hkm : m ∣ k) (hkn : n ∣ k) : (k / m).lcm (k / n) = k / (m.gcd n) := by
   rw [Nat.lcm_eq_iff]
   refine ⟨div_dvd_div_left hkm (Nat.gcd_dvd_left m n),
         div_dvd_div_left hkn (Nat.gcd_dvd_right m n), fun c hmc hnc ↦ ?_⟩
   rcases m.eq_zero_or_pos with hm | hm
-  · simp [show c = 0 by simpa [hm] using hmc, hmc]
+  · simp_all
   rcases n.eq_zero_or_pos with hn | hn
-  · simp [show c = 0 by simpa [hn] using  hnc, hnc]
+  · simp_all
   rw [Nat.div_dvd_iff_dvd_mul hkm hm] at hmc
   rw [Nat.div_dvd_iff_dvd_mul hkn hn] at hnc
   simpa [Nat.div_dvd_iff_dvd_mul (Nat.dvd_trans (Nat.gcd_dvd_left m n) hkm)

--- a/Mathlib/Data/Nat/GCD/Basic.lean
+++ b/Mathlib/Data/Nat/GCD/Basic.lean
@@ -220,12 +220,35 @@ theorem Coprime.mul_add_mul_ne_mul {m n a b : ℕ} (cop : Coprime m n) (ha : a �
   refine mul_ne_zero hb.2 ha.2 (eq_zero_of_mul_eq_self_left (ne_of_gt (add_le_add ha.1 hb.1)) ?_)
   rw [← mul_assoc, ← h, Nat.add_mul, Nat.add_mul, mul_comm _ n, ← mul_assoc, mul_comm y]
 
-variable {x n m : ℕ}
+variable {x n m k : ℕ}
 
 theorem gcd_mul_gcd_eq_iff_dvd_mul_of_coprime (hcop : Coprime n m) :
     gcd x n * gcd x m = x ↔ x ∣ n * m := by
   refine ⟨fun h ↦ ?_, (dvd_antisymm ?_ <| dvd_gcd_mul_gcd_iff_dvd_mul.mpr ·)⟩
   refine h ▸ Nat.mul_dvd_mul ?_ ?_ <;> exact x.gcd_dvd_right _
   refine (hcop.gcd_both x x).mul_dvd_of_dvd_of_dvd ?_ ?_ <;> exact x.gcd_dvd_left _
+
+lemma div_mul_div (hkm : m ∣ k) (hkn : n ∣ m) : (k / m) * (m / n) = k / n := by
+  rcases n.eq_zero_or_pos with hn | hn
+  · simp [hn]
+  refine Eq.symm (Nat.div_eq_of_eq_mul_left hn ?_)
+  rw [mul_assoc, Nat.div_mul_cancel hkn, Nat.div_mul_cancel hkm]
+
+lemma div_dvd_div_left (hkm : m ∣ k) (hkn : n ∣ m) : k / m ∣ k / n := by
+  use m / n
+  exact Eq.symm (div_mul_div hkm hkn)
+
+lemma div_lcm_eq_div_gcd (hkm : m ∣ k) (hkn : n ∣ k) : (k / m).lcm (k / n) = k / (m.gcd n) := by
+  rw [Nat.lcm_eq_iff]
+  refine ⟨div_dvd_div_left hkm (Nat.gcd_dvd_left m n),
+        div_dvd_div_left hkn (Nat.gcd_dvd_right m n), fun c hmc hnc ↦ ?_⟩
+  rcases m.eq_zero_or_pos with hm | hm
+  · simp [show c = 0 by simpa [hm] using hmc, hmc]
+  rcases n.eq_zero_or_pos with hn | hn
+  · simp [show c = 0 by simpa [hn] using  hnc, hnc]
+  rw [Nat.div_dvd_iff_dvd_mul hkm hm] at hmc
+  rw [Nat.div_dvd_iff_dvd_mul hkn hn] at hnc
+  simpa [Nat.div_dvd_iff_dvd_mul (Nat.dvd_trans (Nat.gcd_dvd_left m n) hkm)
+    (gcd_pos_of_pos_left n hm), Nat.gcd_mul_right m c n] using (Nat.dvd_gcd hmc hnc)
 
 end Nat


### PR DESCRIPTION
add some lemmas about `Nat.gcd`

$lcm(\frac{k}{m}, \frac{k}{n}) = k / \gcd(m, n)$
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
