### PR TITLE
[Merged by Bors] - feat: Alexandrov discrete implies locally path-connected

### DIFF
--- a/Mathlib/Topology/AlexandrovDiscrete.lean
+++ b/Mathlib/Topology/AlexandrovDiscrete.lean
@@ -184,6 +184,17 @@ lemma gc_nhdsKer_interior : GaloisConnection (nhdsKer : Set α → Set α) inter
 
 @[deprecated (since := "2025-07-09")] alias principal_exterior := principal_nhdsKer
 
+lemma principal_nhdsKer_singleton (a : α) : 𝓟 (nhdsKer {a}) = 𝓝 a := by
+  rw [principal_nhdsKer, nhdsSet_singleton]
+
+lemma nhdsSet_basis_nhdsKer (s : Set α) :
+    (𝓝ˢ s).HasBasis (fun _ : Unit => True) (fun _ => nhdsKer s) :=
+  principal_nhdsKer s ▸ hasBasis_principal (nhdsKer s)
+
+lemma nhds_basis_nhdsKer_singleton (a : α) :
+    (𝓝 a).HasBasis (fun _ : Unit => True) (fun _ => nhdsKer {a}) :=
+  principal_nhdsKer_singleton a ▸ hasBasis_principal (nhdsKer {a})
+
 lemma isOpen_iff_forall_specializes : IsOpen s ↔ ∀ x y, x ⤳ y → y ∈ s → x ∈ s := by
   simp only [← nhdsKer_subset_iff_isOpen, Set.subset_def, mem_nhdsKer_iff_specializes, exists_imp,
     and_imp, @forall_swap (_ ⤳ _)]

--- a/Mathlib/Topology/Connected/LocPathConnected.lean
+++ b/Mathlib/Topology/Connected/LocPathConnected.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Ben Eltschig
 -/
 import Mathlib.Topology.Connected.PathConnected
+import Mathlib.Topology.AlexandrovDiscrete
 
 /-!
 # Locally path-connected spaces
@@ -217,5 +218,15 @@ instance Sigma.locPathConnectedSpace {X : ι → Type*}
     · exact (image_mono pathComponentIn_subset).trans (u.image_preimage_subset _)
   · exact isOpenMap_sigmaMk _ <| (hu.preimage continuous_sigmaMk).pathComponentIn _
   · exact ⟨x.2, mem_pathComponentIn_self hxu, rfl⟩
+
+instance AlexandrovDiscrete.locPathConnectedSpace [AlexandrovDiscrete X] :
+    LocPathConnectedSpace X := by
+  apply LocPathConnectedSpace.of_bases nhds_basis_nhdsKer_singleton
+  simp only [forall_const, IsPathConnected, mem_nhdsKer_singleton]
+  intro x
+  exists x, specializes_rfl
+  intro y hy
+  symm
+  apply hy.joinedIn <;> rewrite [mem_nhdsKer_singleton] <;> [assumption; rfl]
 
 end LocPathConnectedSpace


### PR DESCRIPTION
The primary motivation for this theorem is to deduce path-connectedness from connectedness in finite topological spaces:
```lean
import Mathlib.Topology.Connected.LocPathConnected

example {X : Type*} [TopologicalSpace X] [Finite X] [ConnectedSpace X] : PathConnectedSpace X := by
  rw [pathConnectedSpace_iff_connectedSpace]; assumption
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
