### PR TITLE
[Merged by Bors] - feat(Data/Sign): even and odd powers

### DIFF
--- a/Mathlib/Data/Sign.lean
+++ b/Mathlib/Data/Sign.lean
@@ -145,12 +145,12 @@ def fin3Equiv : SignType ≃* Fin 3 where
   map_mul' a b := by
     cases a <;> cases b <;> rfl
 
-theorem pow_odd (s : SignType) (n : ℕ) (hn : Odd n) : s ^ n = s := by
+theorem pow_odd (s : SignType) {n : ℕ} (hn : Odd n) : s ^ n = s := by
   obtain ⟨k, rfl⟩ := hn
   rw [pow_add, pow_one, pow_mul, sq]
   cases s <;> simp
 
-theorem zpow_odd (s : SignType) (z : ℤ) (hz : Odd z) : s ^ z = s := by
+theorem zpow_odd (s : SignType) {z : ℤ} (hz : Odd z) : s ^ z = s := by
   obtain rfl | hs := eq_or_ne s 0
   · rw [zero_zpow]
     rintro rfl

--- a/Mathlib/Data/Sign.lean
+++ b/Mathlib/Data/Sign.lean
@@ -145,6 +145,28 @@ def fin3Equiv : SignType ≃* Fin 3 where
   map_mul' a b := by
     cases a <;> cases b <;> rfl
 
+theorem pow_odd (s : SignType) (n : ℕ) (hn : Odd n) : s ^ n = s := by
+  obtain ⟨k, rfl⟩ := hn
+  rw [pow_add, pow_one, pow_mul, sq]
+  cases s <;> simp
+
+theorem zpow_odd (s : SignType) (z : ℤ) (hz : Odd z) : s ^ z = s := by
+  obtain rfl | hs := eq_or_ne s 0
+  · rw [zero_zpow]
+    rintro rfl
+    simp at hz
+  obtain ⟨k, rfl⟩ := hz
+  rw [zpow_add₀ hs, zpow_one, zpow_mul, zpow_two]
+  cases s <;> simp
+
+lemma pow_even (s : SignType) {n : ℕ} (hn : Even n) (hs : s ≠ 0) :
+    s ^ n = 1 := by
+  cases s <;> simp_all
+
+lemma zpow_even (s : SignType) {z : ℤ} (hz : Even z) (hs : s ≠ 0) :
+    s ^ z = 1 := by
+  cases s <;> simp_all [Even.neg_one_zpow]
+
 section CaseBashing
 
 theorem nonneg_iff {a : SignType} : 0 ≤ a ↔ a = 0 ∨ a = 1 := by decide +revert


### PR DESCRIPTION
Odd powers are the identity function, even powers on non-zero signs are always `1`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
