### PR TITLE
[Merged by Bors] - feat: real numbers are square if non-negative

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Pow/Complex.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Complex.lean
@@ -184,6 +184,8 @@ lemma sq_cpow_two_inv {x : ℂ} (hx : 0 < x.re) : (x ^ (2 : ℕ)) ^ (2⁻¹ : �
   pow_cpow_ofNat_inv (neg_pi_div_two_lt_arg_iff.2 <| .inl hx)
     (arg_le_pi_div_two_iff.2 <| .inl hx.le)
 
+@[simp] lemma isSquare (x : ℂ) : IsSquare x := ⟨x ^ (2⁻¹ : ℂ), by simp [← sq]⟩
+
 theorem mul_cpow_ofReal_nonneg {a b : ℝ} (ha : 0 ≤ a) (hb : 0 ≤ b) (r : ℂ) :
     ((a : ℂ) * (b : ℂ)) ^ r = (a : ℂ) ^ r * (b : ℂ) ^ r := by
   rcases eq_or_ne r 0 with (rfl | hr)

--- a/Mathlib/Data/Real/Sqrt.lean
+++ b/Mathlib/Data/Real/Sqrt.lean
@@ -96,7 +96,7 @@ alias ⟨_, sqrt_pos_of_pos⟩ := sqrt_pos
 
 attribute [bound] sqrt_pos_of_pos
 
-@[simp] theorem isSquare (r : ℝ≥0) : IsSquare r := ⟨_, mul_self_sqrt _ |>.symm⟩
+@[simp] theorem isSquare (x : ℝ≥0) : IsSquare x := ⟨_, mul_self_sqrt _ |>.symm⟩
 
 end NNReal
 
@@ -264,7 +264,7 @@ lemma sqrt_le_sqrt_iff' (hx : 0 < x) : √x ≤ √y ↔ x ≤ y := by
 @[simp] lemma sqrt_le_one : √x ≤ 1 ↔ x ≤ 1 := by
   rw [← sqrt_one, sqrt_le_sqrt_iff zero_le_one, sqrt_one]
 
-@[simp] lemma isSquare_iff {x : ℝ} : IsSquare x ↔ 0 ≤ x :=
+@[simp] lemma isSquare_iff : IsSquare x ↔ 0 ≤ x :=
   ⟨(·.nonneg), (⟨√x, mul_self_sqrt · |>.symm⟩)⟩
 
 end Real

--- a/Mathlib/Data/Real/Sqrt.lean
+++ b/Mathlib/Data/Real/Sqrt.lean
@@ -96,6 +96,8 @@ alias ⟨_, sqrt_pos_of_pos⟩ := sqrt_pos
 
 attribute [bound] sqrt_pos_of_pos
 
+@[simp] theorem isSquare (r : ℝ≥0) : IsSquare r := ⟨_, mul_self_sqrt _ |>.symm⟩
+
 end NNReal
 
 namespace Real
@@ -261,6 +263,9 @@ lemma sqrt_le_sqrt_iff' (hx : 0 < x) : √x ≤ √y ↔ x ≤ y := by
 
 @[simp] lemma sqrt_le_one : √x ≤ 1 ↔ x ≤ 1 := by
   rw [← sqrt_one, sqrt_le_sqrt_iff zero_le_one, sqrt_one]
+
+@[simp] lemma isSquare_iff {r : ℝ} : IsSquare r ↔ 0 ≤ r :=
+  ⟨(·.nonneg), (√r, mul_self_sqrt · |>.symm)⟩
 
 end Real
 

--- a/Mathlib/Data/Real/Sqrt.lean
+++ b/Mathlib/Data/Real/Sqrt.lean
@@ -264,8 +264,8 @@ lemma sqrt_le_sqrt_iff' (hx : 0 < x) : √x ≤ √y ↔ x ≤ y := by
 @[simp] lemma sqrt_le_one : √x ≤ 1 ↔ x ≤ 1 := by
   rw [← sqrt_one, sqrt_le_sqrt_iff zero_le_one, sqrt_one]
 
-@[simp] lemma isSquare_iff {r : ℝ} : IsSquare r ↔ 0 ≤ r :=
-  ⟨(·.nonneg), (√r, mul_self_sqrt · |>.symm)⟩
+@[simp] lemma isSquare_iff {x : ℝ} : IsSquare x ↔ 0 ≤ x :=
+  ⟨(·.nonneg), (⟨√x, mul_self_sqrt · |>.symm⟩)⟩
 
 end Real
 


### PR DESCRIPTION
Obviously it's pretty useless to talk about `IsSquare` on `Real` on purpose, but these lemmas mean that if done accidentally, lean can help simplify the goal to `False`.

Also the complex version for good measure.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
