### PR TITLE
feat: projections and injections for WithLp

### DIFF
--- a/Mathlib/Analysis/Normed/Lp/PiLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/PiLp.lean
@@ -1015,10 +1015,8 @@ lemma sum_single' (x : PiLp p β) :
   simp_rw [single_apply, ← toLp_sum, LinearMap.sum_single_apply]
   ext; simp
 
-@[simp]
-lemma comp_inl_add_comp_inr {γ : Type*} [AddCommGroup γ] [Module 𝕜 γ]
-    (L : PiLp p β →ₗ[𝕜] γ) (x : PiLp p β) :
-    ∑ i, L (PiLp.single p 𝕜 (x i)) = L x := by
+lemma comp_inl_add_comp_inr {γ : Type*} [AddCommGroup γ] [Module 𝕜 γ] (L : PiLp p β →ₗ[𝕜] γ)
+    (x : PiLp p β) : ∑ i, L (PiLp.single p 𝕜 (x i)) = L x := by
   simp [← map_sum, sum_single', -single_apply]
 
 end Single

--- a/Mathlib/Analysis/Normed/Lp/PiLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/PiLp.lean
@@ -998,6 +998,7 @@ theorem edist_equiv_symm_single_same (i : ι) (b₁ b₂ : β i) :
   edist_toLp_single_same _ _ _ _ _
 
 variable (𝕜) {β} in
+/-- The canonical injection from `β i` to `PiLp p β` as a linear isometry. -/
 protected def single {i : ι} : β i →ₗᵢ[𝕜] PiLp p β where
   toLinearMap := (WithLp.linearEquiv p 𝕜 (Π i, β i)).symm.toLinearMap.comp (.single 𝕜 β i)
   norm_map' x := norm_toLp_single p β i x
@@ -1005,16 +1006,20 @@ protected def single {i : ι} : β i →ₗᵢ[𝕜] PiLp p β where
 @[simp]
 lemma single_apply {i : ι} (x : β i) : PiLp.single p 𝕜 x = toLp p (Pi.single i x) := rfl
 
-lemma inl_add_inr (x : Π i, β i) :
+lemma sum_single (x : Π i, β i) :
     ∑ i, PiLp.single p 𝕜 (x i) = toLp p x := by
-  simp_rw [single_apply, ← toLp_sum, Fintype.sum_pi_single']
-  simp
+  simp_rw [single_apply, ← toLp_sum, LinearMap.sum_single_apply]
+
+lemma sum_single' (x : PiLp p β) :
+    ∑ i, PiLp.single p 𝕜 (x i) = x := by
+  simp_rw [single_apply, ← toLp_sum, LinearMap.sum_single_apply]
+  ext; simp
 
 @[simp]
-lemma comp_inl_add_comp_inr {γ : Type*}
-    [AddCommGroup γ] [Module 𝕜 γ] (L : WithLp p (α × β) →ₗ[𝕜] γ) (x : WithLp p (α × β)) :
-    L (WithLp.inl p 𝕜 α β x.fst) + L (WithLp.inr p 𝕜 α β x.snd) = L x := by
-  simp [← map_add, inl_add_inr, -inl_apply, -inr_apply]
+lemma comp_inl_add_comp_inr {γ : Type*} [AddCommGroup γ] [Module 𝕜 γ]
+    (L : PiLp p β →ₗ[𝕜] γ) (x : PiLp p β) :
+    ∑ i, L (PiLp.single p 𝕜 (x i)) = L x := by
+  simp [← map_sum, sum_single', -single_apply]
 
 end Single
 

--- a/Mathlib/Analysis/Normed/Lp/PiLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/PiLp.lean
@@ -997,6 +997,25 @@ theorem edist_equiv_symm_single_same (i : ι) (b₁ b₂ : β i) :
       edist b₁ b₂ :=
   edist_toLp_single_same _ _ _ _ _
 
+variable (𝕜) {β} in
+protected def single {i : ι} : β i →ₗᵢ[𝕜] PiLp p β where
+  toLinearMap := (WithLp.linearEquiv p 𝕜 (Π i, β i)).symm.toLinearMap.comp (.single 𝕜 β i)
+  norm_map' x := norm_toLp_single p β i x
+
+@[simp]
+lemma single_apply {i : ι} (x : β i) : PiLp.single p 𝕜 x = toLp p (Pi.single i x) := rfl
+
+lemma inl_add_inr (x : Π i, β i) :
+    ∑ i, PiLp.single p 𝕜 (x i) = toLp p x := by
+  simp_rw [single_apply, ← toLp_sum, Fintype.sum_pi_single']
+  simp
+
+@[simp]
+lemma comp_inl_add_comp_inr {γ : Type*}
+    [AddCommGroup γ] [Module 𝕜 γ] (L : WithLp p (α × β) →ₗ[𝕜] γ) (x : WithLp p (α × β)) :
+    L (WithLp.inl p 𝕜 α β x.fst) + L (WithLp.inr p 𝕜 α β x.snd) = L x := by
+  simp [← map_add, inl_add_inr, -inl_apply, -inr_apply]
+
 end Single
 
 /-- When `p = ∞`, this lemma does not hold without the additional assumption `Nonempty ι` because

--- a/Mathlib/Analysis/Normed/Lp/PiLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/PiLp.lean
@@ -1015,7 +1015,11 @@ lemma sum_single' (x : PiLp p β) :
   simp_rw [single_apply, ← toLp_sum, LinearMap.sum_single_apply]
   ext; simp
 
-lemma comp_inl_add_comp_inr {γ : Type*} [AddCommGroup γ] [Module 𝕜 γ] (L : PiLp p β →ₗ[𝕜] γ)
+lemma sum_comp_single {γ : Type*} [AddCommGroup γ] [Module 𝕜 γ] (L : PiLp p β →ₗ[𝕜] γ)
+    (x : Π i, β i) : ∑ i, L (PiLp.single p 𝕜 (x i)) = L (toLp p x) := by
+  simp [← map_sum, sum_single, -single_apply]
+
+lemma sum_comp_single' {γ : Type*} [AddCommGroup γ] [Module 𝕜 γ] (L : PiLp p β →ₗ[𝕜] γ)
     (x : PiLp p β) : ∑ i, L (PiLp.single p 𝕜 (x i)) = L x := by
   simp [← map_sum, sum_single', -single_apply]
 

--- a/Mathlib/Analysis/Normed/Lp/ProdLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/ProdLp.lean
@@ -539,28 +539,6 @@ lemma prodContinuousLinearEquiv_apply :
 lemma prodContinuousLinearEquiv_symm_apply :
     ⇑(prodContinuousLinearEquiv p 𝕜 α β).symm = toLp p := rfl
 
-protected def inl : α →L[𝕜] WithLp p (α × β) :=
-  (WithLp.prodContinuousLinearEquiv p 𝕜 α β).symm.toContinuousLinearMap.comp (.inl 𝕜 α β)
-
-protected def inr : β →L[𝕜] WithLp p (α × β) :=
-  (WithLp.prodContinuousLinearEquiv p 𝕜 α β).symm.toContinuousLinearMap.comp (.inr 𝕜 α β)
-
-@[simp]
-lemma inl_apply (x : α) : WithLp.inl p 𝕜 α β x = toLp p (x, 0) := rfl
-
-@[simp]
-lemma inr_apply (x : β) : WithLp.inr p 𝕜 α β x = toLp p (0, x) := rfl
-
-lemma inl_add_inr (x : α) (y : β) :
-    WithLp.inl p 𝕜 α β x + WithLp.inr p 𝕜 α β y = toLp p (x, y) := by
-  rw [inl_apply, inr_apply, ← WithLp.prodContinuousLinearEquiv_symm_apply p 𝕜 α β, ← map_add]
-  simp
-
-lemma comp_inl_add_comp_inr {γ : Type*} [TopologicalSpace γ]
-    [AddCommGroup γ] [Module 𝕜 γ] (L : WithLp p (α × β) →L[𝕜] γ) (x : WithLp p (α × β)) :
-    L.comp (WithLp.inl p 𝕜 α β) x.fst + L.comp (WithLp.inr p 𝕜 α β) x.snd = L x := by
-  simp [← map_add, inl_add_inr, -inl_apply, -inr_apply]
-
 protected def fstCLM : WithLp p (α × β) →L[𝕜] α :=
   (ContinuousLinearMap.fst 𝕜 α β).comp
     (WithLp.prodContinuousLinearEquiv p 𝕜 α β).toContinuousLinearMap
@@ -962,6 +940,33 @@ theorem edist_equiv_symm_snd (y₁ y₂ : β) :
     edist ((WithLp.equiv p (α × β)).symm (0, y₁)) ((WithLp.equiv p (α × β)).symm (0, y₂)) =
       edist y₁ y₂ :=
   edist_toLp_snd _ _ _ _ _
+
+variable [Semiring 𝕜] [Module 𝕜 α] [Module 𝕜 β]
+
+protected def inl : α →ₗᵢ[𝕜] WithLp p (α × β) where
+  toLinearMap := (WithLp.linearEquiv p 𝕜 (α × β)).symm.comp (.inl 𝕜 α β)
+  norm_map' x := norm_toLp_fst p α β x
+
+protected def inr : β →ₗᵢ[𝕜] WithLp p (α × β) where
+  toLinearMap := (WithLp.linearEquiv p 𝕜 (α × β)).symm.comp (.inr 𝕜 α β)
+  norm_map' x := norm_toLp_snd p α β x
+
+@[simp]
+lemma inl_apply (x : α) : WithLp.inl p 𝕜 α β x = toLp p (x, 0) := rfl
+
+@[simp]
+lemma inr_apply (x : β) : WithLp.inr p 𝕜 α β x = toLp p (0, x) := rfl
+
+lemma inl_add_inr (x : α) (y : β) :
+    WithLp.inl p 𝕜 α β x + WithLp.inr p 𝕜 α β y = toLp p (x, y) := by
+  rw [inl_apply, inr_apply, ← WithLp.prodContinuousLinearEquiv_symm_apply p 𝕜 α β, ← map_add]
+  simp
+
+@[simp]
+lemma comp_inl_add_comp_inr {γ : Type*}
+    [AddCommGroup γ] [Module 𝕜 γ] (L : WithLp p (α × β) →ₗ[𝕜] γ) (x : WithLp p (α × β)) :
+    L (WithLp.inl p 𝕜 α β x.fst) + L (WithLp.inr p 𝕜 α β x.snd) = L x := by
+  simp [← map_add, inl_add_inr, -inl_apply, -inr_apply]
 
 end Single
 

--- a/Mathlib/Analysis/Normed/Lp/ProdLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/ProdLp.lean
@@ -52,12 +52,12 @@ variable {p 𝕜 α β}
 variable [Semiring 𝕜] [AddCommGroup α] [AddCommGroup β]
 variable (x y : WithLp p (α × β)) (c : 𝕜)
 
-/-- The projection on the first coordinate in `WithLp`. If `x : WithLp p (α × β)`, you
-shoudl always write `x.fst` instead of `x.1` to avoid defeq abuse. -/
+/-- The projection on the first coordinate in `WithLp`. If `x : WithLp p (α × β)`, one
+should always write `x.fst` instead of `x.1` to avoid defeq abuse. -/
 protected def fst (x : WithLp p (α × β)) : α := (ofLp x).fst
 
-/-- The projection on the scond coordinate in `WithLp`. If `x : WithLp p (α × β)`, you
-shoudl always write `x.snd` instead of `x.2` to avoid defeq abuse. -/
+/-- The projection on the second coordinate in `WithLp`. If `x : WithLp p (α × β)`, one
+should always write `x.snd` instead of `x.2` to avoid defeq abuse. -/
 protected def snd (x : WithLp p (α × β)) : β := (ofLp x).snd
 
 @[simp]

--- a/Mathlib/Analysis/Normed/Lp/ProdLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/ProdLp.lean
@@ -959,7 +959,7 @@ lemma inr_apply (x : β) : WithLp.inr p 𝕜 α β x = toLp p (0, x) := rfl
 
 lemma inl_add_inr (x : α) (y : β) :
     WithLp.inl p 𝕜 α β x + WithLp.inr p 𝕜 α β y = toLp p (x, y) := by
-  rw [inl_apply, inr_apply, ← WithLp.prodContinuousLinearEquiv_symm_apply p 𝕜 α β, ← map_add]
+  rw [inl_apply, inr_apply, ← toLp_add]
   simp
 
 @[simp]

--- a/Mathlib/Analysis/Normed/Lp/ProdLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/ProdLp.lean
@@ -52,6 +52,9 @@ variable {p 𝕜 α β}
 variable [Semiring 𝕜] [AddCommGroup α] [AddCommGroup β]
 variable (x y : WithLp p (α × β)) (c : 𝕜)
 
+protected def fst (x : WithLp p (α × β)) : α := (ofLp x).fst
+protected def snd (x : WithLp p (α × β)) : β := (ofLp x).snd
+
 @[simp]
 theorem zero_fst : (0 : WithLp p (α × β)).fst = 0 :=
   rfl
@@ -107,6 +110,7 @@ variable {p α β}
 @[simp] lemma toLp_snd (x : α × β) : (toLp p x).snd = x.snd := rfl
 @[simp] lemma ofLp_fst (x : WithLp p (α × β)) : (ofLp x).fst = x.fst := rfl
 @[simp] lemma ofLp_snd (x : WithLp p (α × β)) : (ofLp x).snd = x.snd := rfl
+@[simp] lemma toLp_fst_snd (x : WithLp p (α × β)) : toLp p (x.fst, x.snd) = x := rfl
 
 @[deprecated ofLp_fst (since := "2024-04-27")]
 theorem equiv_fst (x : WithLp p (α × β)) : (WithLp.equiv p (α × β) x).fst = x.fst :=
@@ -529,6 +533,52 @@ def prodContinuousLinearEquiv : WithLp p (α × β) ≃L[𝕜] α × β where
   continuous_toFun := continuous_id
   continuous_invFun := continuous_id
 
+lemma prodContinuousLinearEquiv_apply :
+    ⇑(prodContinuousLinearEquiv p 𝕜 α β) = ofLp := rfl
+
+lemma prodContinuousLinearEquiv_symm_apply :
+    ⇑(prodContinuousLinearEquiv p 𝕜 α β).symm = toLp p := rfl
+
+protected def inl : α →L[𝕜] WithLp p (α × β) :=
+  (WithLp.prodContinuousLinearEquiv p 𝕜 α β).symm.toContinuousLinearMap.comp (.inl 𝕜 α β)
+
+protected def inr : β →L[𝕜] WithLp p (α × β) :=
+  (WithLp.prodContinuousLinearEquiv p 𝕜 α β).symm.toContinuousLinearMap.comp (.inr 𝕜 α β)
+
+@[simp]
+lemma inl_apply (x : α) : WithLp.inl p 𝕜 α β x = toLp p (x, 0) := rfl
+
+@[simp]
+lemma inr_apply (x : β) : WithLp.inr p 𝕜 α β x = toLp p (0, x) := rfl
+
+lemma inl_add_inr (x : α) (y : β) :
+    WithLp.inl p 𝕜 α β x + WithLp.inr p 𝕜 α β y = toLp p (x, y) := by
+  rw [inl_apply, inr_apply, ← WithLp.prodContinuousLinearEquiv_symm_apply p 𝕜 α β, ← map_add]
+  simp
+
+lemma comp_inl_add_comp_inr {γ : Type*} [TopologicalSpace γ]
+    [AddCommGroup γ] [Module 𝕜 γ] (L : WithLp p (α × β) →L[𝕜] γ) (x : WithLp p (α × β)) :
+    L.comp (WithLp.inl p 𝕜 α β) x.fst + L.comp (WithLp.inr p 𝕜 α β) x.snd = L x := by
+  simp [← map_add, inl_add_inr, -inl_apply, -inr_apply]
+
+protected def fstCLM : WithLp p (α × β) →L[𝕜] α :=
+  (ContinuousLinearMap.fst 𝕜 α β).comp
+    (WithLp.prodContinuousLinearEquiv p 𝕜 α β).toContinuousLinearMap
+
+protected def sndCLM : WithLp p (α × β) →L[𝕜] β :=
+  (ContinuousLinearMap.snd 𝕜 α β).comp
+    (WithLp.prodContinuousLinearEquiv p 𝕜 α β).toContinuousLinearMap
+
+lemma coe_fstCLM : ⇑(WithLp.fstCLM p 𝕜 α β) = WithLp.fst := rfl
+
+lemma coe_sndCLM : ⇑(WithLp.sndCLM p 𝕜 α β) = WithLp.snd := rfl
+
+@[simp]
+lemma fstCLM_apply (x : WithLp p (α × β)) : WithLp.fstCLM p 𝕜 α β x = x.fst := rfl
+
+@[simp]
+lemma sndCLM_apply (x : WithLp p (α × β)) : WithLp.sndCLM p 𝕜 α β x = x.snd := rfl
+
 end ContinuousLinearEquiv
 
 /-! Throughout the rest of the file, we assume `1 ≤ p` -/
@@ -712,7 +762,7 @@ theorem prod_nnnorm_eq_sup (f : WithLp ∞ (α × β)) : ‖f‖₊ = ‖f.fst�
   norm_cast
 
 @[simp] lemma prod_nnnorm_ofLp (f : WithLp ∞ (α × β)) : ‖ofLp f‖₊ = ‖f‖₊ := by
-  rw [prod_nnnorm_eq_sup, Prod.nnnorm_def, ofLp_fst, ofLp_snd]
+  rw [prod_nnnorm_eq_sup f, Prod.nnnorm_def, ofLp_fst, ofLp_snd]
 
 @[deprecated prod_nnnorm_ofLp (since := "2024-04-27")]
 theorem prod_nnnorm_equiv (f : WithLp ∞ (α × β)) : ‖WithLp.equiv ⊤ _ f‖₊ = ‖f‖₊ :=
@@ -967,9 +1017,9 @@ def idemFst : AddMonoid.End (WithLp p (α × β)) := (AddMonoidHom.inl α β).co
 /-- Projection on `WithLp p (α × β)` with range `β` and kernel `α` -/
 def idemSnd : AddMonoid.End (WithLp p (α × β)) := (AddMonoidHom.inr α β).comp (AddMonoidHom.snd α β)
 
-lemma idemFst_apply (x : WithLp p (α × β)) : idemFst x = toLp p (x.1, 0) := rfl
+lemma idemFst_apply (x : WithLp p (α × β)) : idemFst x = toLp p (x.fst, 0) := rfl
 
-lemma idemSnd_apply (x : WithLp p (α × β)) : idemSnd x = toLp p (0, x.2) := rfl
+lemma idemSnd_apply (x : WithLp p (α × β)) : idemSnd x = toLp p (0, x.snd) := rfl
 
 @[simp]
 lemma idemFst_add_idemSnd :
@@ -987,14 +1037,14 @@ lemma idemSnd_compl : (1 : AddMonoid.End (WithLp p (α × β))) - idemSnd = idem
 
 theorem prod_norm_eq_idemFst_sup_idemSnd (x : WithLp ∞ (α × β)) :
     ‖x‖ = max ‖idemFst x‖ ‖idemSnd x‖ := by
-  rw [WithLp.prod_norm_eq_sup, ← WithLp.norm_toLp_fst ∞ α β x.1,
-    ← WithLp.norm_toLp_snd ∞ α β x.2]
+  rw [WithLp.prod_norm_eq_sup, ← WithLp.norm_toLp_fst ∞ α β x.fst,
+    ← WithLp.norm_toLp_snd ∞ α β x.snd]
   rfl
 
 lemma prod_norm_eq_add_idemFst [Fact (1 ≤ p)] (hp : 0 < p.toReal) (x : WithLp p (α × β)) :
     ‖x‖ = (‖idemFst x‖ ^ p.toReal + ‖idemSnd x‖ ^ p.toReal) ^ (1 / p.toReal) := by
-  rw [WithLp.prod_norm_eq_add hp, ← WithLp.norm_toLp_fst p α β x.1,
-    ← WithLp.norm_toLp_snd p α β x.2]
+  rw [WithLp.prod_norm_eq_add hp, ← WithLp.norm_toLp_fst p α β x.fst,
+    ← WithLp.norm_toLp_snd p α β x.snd]
   rfl
 
 lemma prod_norm_eq_idemFst_of_L1 (x : WithLp 1 (α × β)) : ‖x‖ = ‖idemFst x‖ + ‖idemSnd x‖ := by

--- a/Mathlib/Analysis/Normed/Lp/ProdLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/ProdLp.lean
@@ -538,10 +538,10 @@ def prodContinuousLinearEquiv : WithLp p (α × β) ≃L[𝕜] α × β where
   continuous_toFun := continuous_id
   continuous_invFun := continuous_id
 
-lemma prodContinuousLinearEquiv_apply :
+lemma coe_prodContinuousLinearEquiv :
     ⇑(prodContinuousLinearEquiv p 𝕜 α β) = ofLp := rfl
 
-lemma prodContinuousLinearEquiv_symm_apply :
+lemma coe_prodContinuousLinearEquiv_symm :
     ⇑(prodContinuousLinearEquiv p 𝕜 α β).symm = toLp p := rfl
 
 /-- The projection on the first coordinate in `WithLp` as continuous linear map. -/

--- a/Mathlib/Analysis/Normed/Lp/ProdLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/ProdLp.lean
@@ -52,7 +52,12 @@ variable {p 𝕜 α β}
 variable [Semiring 𝕜] [AddCommGroup α] [AddCommGroup β]
 variable (x y : WithLp p (α × β)) (c : 𝕜)
 
+/-- The projection on the first coordinate in `WithLp`. If `x : WithLp p (α × β)`, you
+shoudl always write `x.fst` instead of `x.1` to avoid defeq abuse. -/
 protected def fst (x : WithLp p (α × β)) : α := (ofLp x).fst
+
+/-- The projection on the scond coordinate in `WithLp`. If `x : WithLp p (α × β)`, you
+shoudl always write `x.snd` instead of `x.2` to avoid defeq abuse. -/
 protected def snd (x : WithLp p (α × β)) : β := (ofLp x).snd
 
 @[simp]
@@ -539,10 +544,12 @@ lemma prodContinuousLinearEquiv_apply :
 lemma prodContinuousLinearEquiv_symm_apply :
     ⇑(prodContinuousLinearEquiv p 𝕜 α β).symm = toLp p := rfl
 
+/-- The projection on the first coordinate in `WithLp` as continuous linear map. -/
 protected def fstCLM : WithLp p (α × β) →L[𝕜] α :=
   (ContinuousLinearMap.fst 𝕜 α β).comp
     (WithLp.prodContinuousLinearEquiv p 𝕜 α β).toContinuousLinearMap
 
+/-- The projection on the second coordinate in `WithLp` as continuous linear map. -/
 protected def sndCLM : WithLp p (α × β) →L[𝕜] β :=
   (ContinuousLinearMap.snd 𝕜 α β).comp
     (WithLp.prodContinuousLinearEquiv p 𝕜 α β).toContinuousLinearMap
@@ -943,10 +950,12 @@ theorem edist_equiv_symm_snd (y₁ y₂ : β) :
 
 variable [Semiring 𝕜] [Module 𝕜 α] [Module 𝕜 β]
 
+/-- The canonical injection from `α` to `x : WithLp p (α × β)`, as a linear isometry. -/
 protected def inl : α →ₗᵢ[𝕜] WithLp p (α × β) where
   toLinearMap := (WithLp.linearEquiv p 𝕜 (α × β)).symm.comp (.inl 𝕜 α β)
   norm_map' x := norm_toLp_fst p α β x
 
+/-- The canonical injection from `β` to `x : WithLp p (α × β)`, as a linear isometry. -/
 protected def inr : β →ₗᵢ[𝕜] WithLp p (α × β) where
   toLinearMap := (WithLp.linearEquiv p 𝕜 (α × β)).symm.comp (.inr 𝕜 α β)
   norm_map' x := norm_toLp_snd p α β x

--- a/Mathlib/Analysis/Normed/Lp/ProdLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/ProdLp.lean
@@ -971,7 +971,6 @@ lemma inl_add_inr (x : α) (y : β) :
   rw [inl_apply, inr_apply, ← toLp_add]
   simp
 
-@[simp]
 lemma comp_inl_add_comp_inr {γ : Type*}
     [AddCommGroup γ] [Module 𝕜 γ] (L : WithLp p (α × β) →ₗ[𝕜] γ) (x : WithLp p (α × β)) :
     L (WithLp.inl p 𝕜 α β x.fst) + L (WithLp.inr p 𝕜 α β x.snd) = L x := by

--- a/Mathlib/Analysis/Normed/Lp/WithLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/WithLp.lean
@@ -125,6 +125,12 @@ variable [AddCommGroup V]
 @[simp] lemma toLp_add (x y : V) : toLp p (x + y) = toLp p x + toLp p y := rfl
 @[simp] lemma ofLp_add (x y : WithLp p V) : ofLp (x + y) = ofLp x + ofLp y := rfl
 
+@[simp] lemma ofLp_sum {ι : Type*} [Fintype ι] (x : ι → WithLp p V) :
+    ofLp (∑ i, x i) = ∑ i, ofLp (x i) := rfl
+
+@[simp] lemma toLp_sum {ι : Type*} [Fintype ι] (x : ι → V) :
+    toLp p (∑ i, x i) = ∑ i, toLp p (x i) := rfl
+
 @[simp] lemma toLp_sub (x y : V) : toLp p (x - y) = toLp p x - toLp p y := rfl
 @[simp] lemma ofLp_sub (x y : WithLp p V) : ofLp (x - y) = ofLp x - ofLp y := rfl
 

--- a/Mathlib/LinearAlgebra/Pi.lean
+++ b/Mathlib/LinearAlgebra/Pi.lean
@@ -142,6 +142,11 @@ lemma single_apply [DecidableEq ι] {i : ι} (v : φ i) :
     single R φ i v = Pi.single i v :=
   rfl
 
+lemma sum_single_apply [Fintype ι] [DecidableEq ι] (v : Π i, φ i) :
+     ∑ i, Pi.single i (v i) = v := by
+   ext i
+   simp [single_apply, Fintype.sum_pi_single]
+
 @[simp]
 theorem coe_single [DecidableEq ι] (i : ι) :
     ⇑(single R φ i : φ i →ₗ[R] (i : ι) → φ i) = Pi.single i :=

--- a/Mathlib/LinearAlgebra/Pi.lean
+++ b/Mathlib/LinearAlgebra/Pi.lean
@@ -145,7 +145,7 @@ lemma single_apply [DecidableEq ι] {i : ι} (v : φ i) :
 lemma sum_single_apply [Fintype ι] [DecidableEq ι] (v : Π i, φ i) :
      ∑ i, Pi.single i (v i) = v := by
    ext i
-   simp [single_apply, Fintype.sum_pi_single]
+   simp
 
 @[simp]
 theorem coe_single [DecidableEq ι] (i : ι) :


### PR DESCRIPTION
Introduce `WithLp.fst` and `WithLp.snd` to avoid defeq abuse by writing `x.1` when `x : WithLp p (α × β)`. Also add a `ContinuousLinearMap` version.
Introduce `WithLp.inl` (resp. `WithLp.inr`) as a linear isometry from `α` (resp. β) to `WithLp p (α × β)`.
Introduce `PiLp.single` as a linear isometry from `β i` to `PiLp p β`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
