### PR TITLE
[Merged by Bors] - feat(Algebra/Polynomial/Degree/IsMonicOfDegree): new file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -952,6 +952,7 @@ import Mathlib.Algebra.Polynomial.CoeffMem
 import Mathlib.Algebra.Polynomial.Degree.CardPowDegree
 import Mathlib.Algebra.Polynomial.Degree.Definitions
 import Mathlib.Algebra.Polynomial.Degree.Domain
+import Mathlib.Algebra.Polynomial.Degree.IsMonicOfDegree
 import Mathlib.Algebra.Polynomial.Degree.Lemmas
 import Mathlib.Algebra.Polynomial.Degree.Monomial
 import Mathlib.Algebra.Polynomial.Degree.Operations

--- a/Mathlib/Algebra/Polynomial/Degree/IsMonicOfDegree.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/IsMonicOfDegree.lean
@@ -18,40 +18,42 @@ We also provide some basic API.
 
 namespace Polynomial
 
+variable {R : Type*}
+
 /-- This says that `p` has `natDegree` `n` and is monic. -/
-def IsMonicOfDegree {R : Type*} [Semiring R] (p : R[X]) (n : ℕ) : Prop :=
+def IsMonicOfDegree [Semiring R] (p : R[X]) (n : ℕ) : Prop :=
   p.natDegree = n ∧ p.Monic
 
-lemma IsMonicOfDegree.monic {R : Type*} [Semiring R] {p : R[X]} {n : ℕ}
+lemma IsMonicOfDegree.monic [Semiring R] {p : R[X]} {n : ℕ}
     (h : IsMonicOfDegree p n) :
     p.Monic :=
   h.2
 
-lemma IsMonicOfDegree.natDegree_eq {R : Type*} [Semiring R] {p : R[X]} {n : ℕ}
+lemma IsMonicOfDegree.natDegree_eq [Semiring R] {p : R[X]} {n : ℕ}
     (h : IsMonicOfDegree p n) :
     p.natDegree = n :=
   h.1
 
-lemma IsMonicOfDegree.ne_zero {R : Type*} [Semiring R] [Nontrivial R] {p : R[X]} {n : ℕ}
+lemma IsMonicOfDegree.ne_zero [Semiring R] [Nontrivial R] {p : R[X]} {n : ℕ}
     (h : IsMonicOfDegree p n) :
     p ≠ 0 :=
   h.2.ne_zero
 
 @[simp]
-lemma isMonicOfDegree_zero {R : Type*} [Semiring R] {p : R[X]} :
+lemma isMonicOfDegree_zero [Semiring R] {p : R[X]} :
     IsMonicOfDegree p 0 ↔ p = 1 := by
   simp only [IsMonicOfDegree]
   refine ⟨fun ⟨H₁, H₂⟩ ↦ eq_one_of_monic_natDegree_zero H₂ H₁, fun H ↦ ?_⟩
   subst H
   simp
 
-lemma IsMonicOfDegree.leadingCoeff_eq {R : Type*} [Semiring R] {p : R[X]} {n : ℕ}
+lemma IsMonicOfDegree.leadingCoeff_eq [Semiring R] {p : R[X]} {n : ℕ}
     (hp : IsMonicOfDegree p n) :
     p.leadingCoeff = 1 :=
   Monic.def.mp hp.monic
 
 @[simp]
-lemma isMonicOfDegree_iff_of_subsingleton {R : Type*} [Semiring R] [Subsingleton R]
+lemma isMonicOfDegree_iff_of_subsingleton [Semiring R] [Subsingleton R]
     (p : R[X]) (n : ℕ) :
     IsMonicOfDegree p n ↔ n = 0 := by
   rw [Subsingleton.eq_one p]
@@ -59,14 +61,14 @@ lemma isMonicOfDegree_iff_of_subsingleton {R : Type*} [Semiring R] [Subsingleton
   · rwa [natDegree_one, eq_comm] at H
   · rw [H, isMonicOfDegree_zero]
 
-lemma isMonicOfDegree_iff {R : Type*} [Semiring R] [Nontrivial R] (p : R[X]) (n : ℕ) :
+lemma isMonicOfDegree_iff [Semiring R] [Nontrivial R] (p : R[X]) (n : ℕ) :
     IsMonicOfDegree p n ↔ p.natDegree ≤ n ∧ p.coeff n = 1 := by
   simp only [IsMonicOfDegree]
   refine ⟨fun ⟨H₁, H₂⟩ ↦ ⟨H₁.le, H₁ ▸ Monic.coeff_natDegree H₂⟩, fun ⟨H₁, H₂⟩ ↦ ⟨?_, ?_⟩⟩
   · exact natDegree_eq_of_le_of_coeff_ne_zero H₁ <| H₂ ▸ one_ne_zero
   · exact monic_of_natDegree_le_of_coeff_eq_one n H₁ H₂
 
-lemma IsMonicOfDegree.exists_natDegree_lt {R : Type*} [Semiring R] {p : R[X]} {n : ℕ}
+lemma IsMonicOfDegree.exists_natDegree_lt [Semiring R] {p : R[X]} {n : ℕ}
     (hn : n ≠ 0)  (hp : IsMonicOfDegree p n) :
     ∃ q : R[X], p = X ^ n + q ∧ q.natDegree < n := by
   refine ⟨p.eraseLead, ?_, ?_⟩
@@ -76,13 +78,13 @@ lemma IsMonicOfDegree.exists_natDegree_lt {R : Type*} [Semiring R] {p : R[X]} {n
     rw [hp.natDegree_eq]
     omega
 
-lemma IsMonicOfDegree.natDegree_sub_X_pow {R : Type*} [Ring R] {p : R[X]} {n : ℕ} (hn : n ≠ 0)
+lemma IsMonicOfDegree.natDegree_sub_X_pow [Ring R] {p : R[X]} {n : ℕ} (hn : n ≠ 0)
     (hp : IsMonicOfDegree p n) :
     (p - X ^ n).natDegree < n := by
   obtain ⟨q, hq₁, hq₂⟩ := hp.exists_natDegree_lt hn
   simpa [hq₁]
 
-lemma IsMonicOfDegree.natDegree_sub_lt {R : Type*} [Ring R] {p q : R[X]} {n : ℕ} (hn : n ≠ 0)
+lemma IsMonicOfDegree.natDegree_sub_lt [Ring R] {p q : R[X]} {n : ℕ} (hn : n ≠ 0)
     (hp : IsMonicOfDegree p n) (hq : IsMonicOfDegree q n) :
     (p - q).natDegree < n := by
   rw [← sub_sub_sub_cancel_right p q (X ^ n)]
@@ -92,7 +94,7 @@ lemma IsMonicOfDegree.natDegree_sub_lt {R : Type*} [Ring R] {p q : R[X]} {n : �
   set q' := q - X ^ n
   compute_degree!
 
-lemma IsMonicOfDegree.mul {R : Type*} [Semiring R] {p q : R[X]} {m n : ℕ}
+lemma IsMonicOfDegree.mul [Semiring R] {p q : R[X]} {m n : ℕ}
     (hp : IsMonicOfDegree p m) (hq : IsMonicOfDegree q n) :
     IsMonicOfDegree (p * q) (m + n) := by
   rcases subsingleton_or_nontrivial R with H | H
@@ -104,7 +106,7 @@ lemma IsMonicOfDegree.mul {R : Type*} [Semiring R] {p q : R[X]} {m n : ℕ}
     exact one_ne_zero
   rw [natDegree_mul' this, hp.1, hq.1]
 
-lemma IsMonicOfDegree.pow {R : Type*} [Semiring R] {p : R[X]} {m : ℕ} (hp : IsMonicOfDegree p m)
+lemma IsMonicOfDegree.pow [Semiring R] {p : R[X]} {m : ℕ} (hp : IsMonicOfDegree p m)
     (n : ℕ) :
     IsMonicOfDegree (p ^ n) (m * n) := by
   induction n with
@@ -120,11 +122,11 @@ lemma isMonicOfDegree_X_pow (R : Type*) [Semiring R] [Nontrivial R] (n : ℕ) :
     IsMonicOfDegree ((X : R[X]) ^ n) n :=
   (isMonicOfDegree_iff ..).mpr ⟨natDegree_X_pow_le n, coeff_X_pow_self n⟩
 
-lemma isMonicOfDegree_monomial_one {R : Type*} [Semiring R] [Nontrivial R] (n : ℕ) :
+lemma isMonicOfDegree_monomial_one [Semiring R] [Nontrivial R] (n : ℕ) :
     IsMonicOfDegree (monomial n (1 : R)) n := by
   simpa only [monomial_one_right_eq_X_pow] using isMonicOfDegree_X_pow R n
 
-lemma IsMonicOfDegree.coeff_eq {R : Type*} [Semiring R] {p q : R[X]} {n : ℕ}
+lemma IsMonicOfDegree.coeff_eq [Semiring R] {p q : R[X]} {n : ℕ}
     (hp : IsMonicOfDegree p n) (hq : IsMonicOfDegree q n) {m : ℕ} (hm : n ≤ m) :
     p.coeff m = q.coeff m := by
   nontriviality R
@@ -135,7 +137,7 @@ lemma IsMonicOfDegree.coeff_eq {R : Type*} [Semiring R] {p q : R[X]} {n : ℕ}
     replace hq : q.natDegree < m := hq.1.trans_lt hm
     rw [coeff_eq_zero_of_natDegree_lt hp, coeff_eq_zero_of_natDegree_lt hq]
 
-lemma IsMonicOfDegree.of_mul_left {R : Type*} [Semiring R] {p q : R[X]} {m n : ℕ}
+lemma IsMonicOfDegree.of_mul_left [Semiring R] {p q : R[X]} {m n : ℕ}
     (hp : IsMonicOfDegree p m) (hpq : IsMonicOfDegree (p * q) (m + n)) :
     IsMonicOfDegree q n := by
   rcases subsingleton_or_nontrivial R with H | H
@@ -150,7 +152,7 @@ lemma IsMonicOfDegree.of_mul_left {R : Type*} [Semiring R] {p q : R[X]} {m n : �
   rw [natDegree_mul' h, hp.1] at this
   exact (Nat.add_left_cancel this.symm).symm
 
-lemma IsMonicOfDegree.of_mul_right {R : Type*} [Semiring R]  {p q : R[X]} {m n : ℕ}
+lemma IsMonicOfDegree.of_mul_right [Semiring R]  {p q : R[X]} {m n : ℕ}
     (hq : IsMonicOfDegree q n) (hpq : IsMonicOfDegree (p * q) (m + n)) :
     IsMonicOfDegree p m := by
   rcases subsingleton_or_nontrivial R with H | H
@@ -165,7 +167,7 @@ lemma IsMonicOfDegree.of_mul_right {R : Type*} [Semiring R]  {p q : R[X]} {m n :
   rw [natDegree_mul' h, hq.1] at this
   exact (Nat.add_right_cancel this.symm).symm
 
-lemma IsMonicOfDegree.add_right {R : Type*} [Semiring R] {p q : R[X]} {n : ℕ}
+lemma IsMonicOfDegree.add_right [Semiring R] {p q : R[X]} {n : ℕ}
     (hp : IsMonicOfDegree p n) (hq : q.natDegree < n) :
     IsMonicOfDegree (p + q) n := by
   rcases subsingleton_or_nontrivial R with H | H
@@ -175,19 +177,19 @@ lemma IsMonicOfDegree.add_right {R : Type*} [Semiring R] {p q : R[X]} {n : ℕ}
   · rw [coeff_add_eq_left_of_lt hq]
     exact ((isMonicOfDegree_iff p n).mp hp).2
 
-lemma IsMonicOfDegree.sub {R : Type*} [Ring R] {p q : R[X]} {n : ℕ}
+lemma IsMonicOfDegree.sub [Ring R] {p q : R[X]} {n : ℕ}
     (hp : IsMonicOfDegree p n) (hq : q.natDegree < n) :
     IsMonicOfDegree (p - q) n := by
   rw [sub_eq_add_neg]
   exact hp.add_right <| (natDegree_neg q) ▸ hq
 
-lemma IsMonicOfDegree.add_left {R : Type*} [Semiring R] {p q : R[X]} {n : ℕ}
+lemma IsMonicOfDegree.add_left [Semiring R] {p q : R[X]} {n : ℕ}
     (hp : p.natDegree < n) (hq : IsMonicOfDegree q n) :
     IsMonicOfDegree (p + q) n := by
   rw [add_comm]
   exact hq.add_right hp
 
-lemma IsMonicOfDegree.of_dvd_add {R : Type*} [CommRing R] {a b r : R[X]} {m n : ℕ} (hmn : n ≤ m)
+lemma IsMonicOfDegree.of_dvd_add [CommRing R] {a b r : R[X]} {m n : ℕ} (hmn : n ≤ m)
     (ha : IsMonicOfDegree a m) (hb : IsMonicOfDegree b n) (hr : r.natDegree < m) (h : b ∣ a + r) :
     ∃ q : R[X], IsMonicOfDegree q (m - n) ∧ a = q * b - r := by
   obtain ⟨q, hq⟩ :=exists_eq_mul_left_of_dvd  h
@@ -195,14 +197,14 @@ lemma IsMonicOfDegree.of_dvd_add {R : Type*} [CommRing R] {a b r : R[X]} {m n : 
   rw [← hq, show m - n + n = m by omega]
   exact ha.add_right hr
 
-lemma IsMonicOfDegree.of_dvd_sub {R : Type*} [CommRing R] {a b r : R[X]} {m n : ℕ} (hmn : n ≤ m)
+lemma IsMonicOfDegree.of_dvd_sub [CommRing R] {a b r : R[X]} {m n : ℕ} (hmn : n ≤ m)
     (ha : IsMonicOfDegree a m) (hb : IsMonicOfDegree b n) (hr : r.natDegree < m) (h : b ∣ a - r) :
     ∃ q : R[X], IsMonicOfDegree q (m - n) ∧ a = q * b + r := by
   convert ha.of_dvd_add hmn hb ?_ h using 4 with q
   · rw [sub_neg_eq_add]
   · rwa [natDegree_neg]
 
-lemma IsMonicOfDegree.comp {R : Type*} [Semiring R] {p q : R[X]} {m n : ℕ} (hn : n ≠ 0)
+lemma IsMonicOfDegree.comp [Semiring R] {p q : R[X]} {m n : ℕ} (hn : n ≠ 0)
     (hp : IsMonicOfDegree p m) (hq : IsMonicOfDegree q n) :
     IsMonicOfDegree (p.comp q) (m * n) := by
   rcases subsingleton_or_nontrivial R with h | h
@@ -213,15 +215,15 @@ lemma IsMonicOfDegree.comp {R : Type*} [Semiring R] {p q : R[X]} {m n : ℕ} (hn
   rw [coeff_comp_degree_mul_degree (hq.natDegree_eq ▸ hn), hp.leadingCoeff_eq, hq.leadingCoeff_eq,
     one_pow, one_mul]
 
-lemma isMonicOfDegree_X_add_one {R : Type*} [Semiring R] [Nontrivial R] (r : R) :
+lemma isMonicOfDegree_X_add_one [Semiring R] [Nontrivial R] (r : R) :
     IsMonicOfDegree (X + C r) 1 :=
   (isMonicOfDegree_X R).add_right (by compute_degree!)
 
-lemma isMonicOfDegree_X_sub_one {R : Type*} [Ring R] [Nontrivial R] (r : R) :
+lemma isMonicOfDegree_X_sub_one [Ring R] [Nontrivial R] (r : R) :
     IsMonicOfDegree (X - C r) 1 :=
   (isMonicOfDegree_X R).sub (by compute_degree!)
 
-lemma isMonicOfDegree_one_iff {R : Type*} [Semiring R] [Nontrivial R] {f : R[X]} :
+lemma isMonicOfDegree_one_iff [Semiring R] [Nontrivial R] {f : R[X]} :
     IsMonicOfDegree f 1 ↔ ∃ r : R, f = X + C r := by
   refine ⟨fun H ↦ ?_, fun ⟨r, H⟩ ↦ H ▸ isMonicOfDegree_X_add_one r⟩
   refine ⟨f.coeff 0, ?_⟩
@@ -230,7 +232,7 @@ lemma isMonicOfDegree_one_iff {R : Type*} [Semiring R] [Nontrivial R] {f : R[X]}
   · simp
   · exact H.coeff_eq (isMonicOfDegree_X_add_one _) (by omega)
 
-lemma IsMonicOfDegree.aeval_add {R : Type*} [CommRing R] {p : R[X]} {n : ℕ}
+lemma IsMonicOfDegree.aeval_add [CommRing R] {p : R[X]} {n : ℕ}
     (hp : IsMonicOfDegree p n) (r : R) :
     IsMonicOfDegree (aeval (X + C r) p) n := by
   rcases subsingleton_or_nontrivial R with H | H
@@ -238,23 +240,23 @@ lemma IsMonicOfDegree.aeval_add {R : Type*} [CommRing R] {p : R[X]} {n : ℕ}
   rw [← mul_one n]
   exact hp.comp one_ne_zero (isMonicOfDegree_X_add_one r)
 
-lemma IsMonicOfDegree.aeval_sub {R : Type*} [CommRing R] {p : R[X]} {n : ℕ}
+lemma IsMonicOfDegree.aeval_sub [CommRing R] {p : R[X]} {n : ℕ}
     (hp : IsMonicOfDegree p n) (r : R) :
     IsMonicOfDegree (aeval (X - C r) p) n := by
   rw [sub_eq_add_neg, ← map_neg]
   exact aeval_add hp (-r)
 
-lemma isMonicOfDegree_add_add_two {R : Type*} [CommSemiring R] [Nontrivial R] (a b : R) :
+lemma isMonicOfDegree_add_add_two [CommSemiring R] [Nontrivial R] (a b : R) :
     IsMonicOfDegree (X ^ 2 + C a * X + C b) 2 := by
   rw [add_assoc]
   exact (isMonicOfDegree_X_pow R 2).add_right <| by compute_degree!
 
-lemma isMonicOfDegree_sub_add_two {R : Type*} [CommRing R] [Nontrivial R] (a b : R) :
+lemma isMonicOfDegree_sub_add_two [CommRing R] [Nontrivial R] (a b : R) :
     IsMonicOfDegree (X ^ 2 - C a * X + C b) 2 := by
   rw [sub_add]
   exact (isMonicOfDegree_X_pow R 2).add_right <| by compute_degree!
 
-lemma isMonicOfDegree_two_iff {R : Type*} [CommSemiring R] [Nontrivial R] {f : R[X]} :
+lemma isMonicOfDegree_two_iff [CommSemiring R] [Nontrivial R] {f : R[X]} :
     IsMonicOfDegree f 2 ↔ ∃ a b : R, f = X ^ 2 + C a * X + C b := by
   refine ⟨fun H ↦ ?_, fun ⟨a, b, h⟩ ↦ h ▸ isMonicOfDegree_add_add_two a b⟩
   refine ⟨f.coeff 1, f.coeff 0, ext fun n ↦ ?_⟩
@@ -265,7 +267,7 @@ lemma isMonicOfDegree_two_iff {R : Type*} [CommSemiring R] [Nontrivial R] {f : R
   · exact H.coeff_eq (isMonicOfDegree_add_add_two ..) (by omega)
 
 /-- A version of `Polynomial.isMonicOfDegree_two_iff` with negated middle coefficient. -/
-lemma isMonicOfDegree_two_iff' {R : Type*} [CommRing R] [Nontrivial R] {f : R[X]} :
+lemma isMonicOfDegree_two_iff' [CommRing R] [Nontrivial R] {f : R[X]} :
     IsMonicOfDegree f 2 ↔ ∃ a b : R, f = X ^ 2 - C a * X + C b := by
   refine ⟨fun H ↦ ?_, fun ⟨a, b, h⟩ ↦ h ▸ isMonicOfDegree_sub_add_two a b⟩
   simp only [sub_eq_add_neg, ← neg_mul, ← map_neg]

--- a/Mathlib/Algebra/Polynomial/Degree/IsMonicOfDegree.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/IsMonicOfDegree.lean
@@ -1,0 +1,269 @@
+/-
+Copyright (c) 2025 Michael Stoll. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michael Stoll
+-/
+import Mathlib.Algebra.Polynomial.AlgebraMap
+import Mathlib.Algebra.Polynomial.BigOperators
+import Mathlib.Tactic.ComputeDegree
+
+/-!
+# Monic polynomials of given degree
+
+This file defines the predicate `Polynomial.IsMonicOfDegree p n` that states that
+the polynomial `p` is monic and has degree `n` (i.e., `p.natDegree = n`.)
+
+We also provide some basic API.
+-/
+
+namespace Polynomial
+
+/-- This says that `p` has `natDegree` `n` and is monic. -/
+def IsMonicOfDegree {R : Type*} [Semiring R] (p : R[X]) (n : ℕ) : Prop :=
+  p.natDegree = n ∧ p.Monic
+
+lemma IsMonicOfDegree.monic {R : Type*} [Semiring R] {p : R[X]} {n : ℕ}
+    (h : IsMonicOfDegree p n) :
+    p.Monic :=
+  h.2
+
+lemma IsMonicOfDegree.natDegree_eq {R : Type*} [Semiring R] {p : R[X]} {n : ℕ}
+    (h : IsMonicOfDegree p n) :
+    p.natDegree = n :=
+  h.1
+
+lemma IsMonicOfDegree.ne_zero {R : Type*} [Semiring R] [Nontrivial R] {p : R[X]} {n : ℕ}
+    (h : IsMonicOfDegree p n) :
+    p ≠ 0 :=
+  h.2.ne_zero
+
+@[simp]
+lemma isMonicOfDegree_zero {R : Type*} [Semiring R] {p : R[X]} :
+    IsMonicOfDegree p 0 ↔ p = 1 := by
+  simp only [IsMonicOfDegree]
+  refine ⟨fun ⟨H₁, H₂⟩ ↦ eq_one_of_monic_natDegree_zero H₂ H₁, fun H ↦ ?_⟩
+  subst H
+  simp
+
+lemma IsMonicOfDegree.leadingCoeff_eq {R : Type*} [Semiring R] {p : R[X]} {n : ℕ}
+    (hp : IsMonicOfDegree p n) :
+    p.leadingCoeff = 1 :=
+  Monic.def.mp hp.monic
+
+@[simp]
+lemma isMonicOfDegree_iff_of_subsingleton {R : Type*} [Semiring R] [Subsingleton R]
+    (p : R[X]) (n : ℕ) :
+    IsMonicOfDegree p n ↔ n = 0 := by
+  rw [Subsingleton.eq_one p]
+  refine ⟨fun ⟨H, _⟩ ↦ ?_, fun H ↦ ?_⟩
+  · rwa [natDegree_one, eq_comm] at H
+  · rw [H, isMonicOfDegree_zero]
+
+lemma isMonicOfDegree_iff {R : Type*} [Semiring R] [Nontrivial R] (p : R[X]) (n : ℕ) :
+    IsMonicOfDegree p n ↔ p.natDegree ≤ n ∧ p.coeff n = 1 := by
+  simp only [IsMonicOfDegree]
+  refine ⟨fun ⟨H₁, H₂⟩ ↦ ⟨H₁.le, H₁ ▸ Monic.coeff_natDegree H₂⟩, fun ⟨H₁, H₂⟩ ↦ ⟨?_, ?_⟩⟩
+  · exact natDegree_eq_of_le_of_coeff_ne_zero H₁ <| H₂ ▸ one_ne_zero
+  · exact monic_of_natDegree_le_of_coeff_eq_one n H₁ H₂
+
+lemma IsMonicOfDegree.exists_natDegree_lt {R : Type*} [Semiring R] {p : R[X]} {n : ℕ}
+    (hn : n ≠ 0)  (hp : IsMonicOfDegree p n) :
+    ∃ q : R[X], p = X ^ n + q ∧ q.natDegree < n := by
+  refine ⟨_, hp.natDegree_eq ▸ hp.monic.as_sum, LE.le.trans_lt ?_ (Nat.sub_one_lt hn)⟩
+  refine natDegree_sum_le_of_forall_le _ _ fun i hi ↦ ?_
+  have : i ≤ n - 1 := by rw [Finset.mem_range] at hi; omega
+  compute_degree!
+
+lemma IsMonicOfDegree.natDegree_sub_X_pow {R : Type*} [Ring R] {p : R[X]} {n : ℕ} (hn : n ≠ 0)
+    (hp : IsMonicOfDegree p n) :
+    (p - X ^ n).natDegree < n := by
+  obtain ⟨q, hq₁, hq₂⟩ := hp.exists_natDegree_lt hn
+  simpa [hq₁]
+
+lemma IsMonicOfDegree.natDegree_sub_lt {R : Type*} [Ring R] {p q : R[X]} {n : ℕ} (hn : n ≠ 0)
+    (hp : IsMonicOfDegree p n) (hq : IsMonicOfDegree q n) :
+    (p - q).natDegree < n := by
+  rw [← sub_sub_sub_cancel_right p q (X ^ n)]
+  replace hp := hp.natDegree_sub_X_pow hn
+  replace hq := hq.natDegree_sub_X_pow hn
+  set p' := p - X ^ n -- do not confuse `compute_degree!`
+  set q' := q - X ^ n
+  compute_degree!
+
+lemma IsMonicOfDegree.mul {R : Type*} [Semiring R] {p q : R[X]} {m n : ℕ}
+    (hp : IsMonicOfDegree p m) (hq : IsMonicOfDegree q n) :
+    IsMonicOfDegree (p * q) (m + n) := by
+  rcases subsingleton_or_nontrivial R with H | H
+  · simp only [isMonicOfDegree_iff_of_subsingleton, Nat.add_eq_zero] at hp hq ⊢
+    exact ⟨hp, hq⟩
+  refine ⟨?_, hp.2.mul hq.2⟩
+  have : p.leadingCoeff * q.leadingCoeff ≠ 0 := by
+    rw [hp.leadingCoeff_eq, hq.leadingCoeff_eq, one_mul]
+    exact one_ne_zero
+  rw [natDegree_mul' this, hp.1, hq.1]
+
+lemma IsMonicOfDegree.pow {R : Type*} [Semiring R] {p : R[X]} {m : ℕ} (hp : IsMonicOfDegree p m)
+    (n : ℕ) :
+    IsMonicOfDegree (p ^ n) (m * n) := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [pow_succ, mul_add, mul_one]
+    exact ih.mul hp
+
+lemma isMonicOfDegree_X (R : Type*) [Semiring R] [Nontrivial R] : IsMonicOfDegree (X : R[X]) 1 :=
+  (isMonicOfDegree_iff ..).mpr ⟨natDegree_X_le, coeff_X_one⟩
+
+lemma isMonicOfDegree_X_pow (R : Type*) [Semiring R] [Nontrivial R] (n : ℕ) :
+    IsMonicOfDegree ((X : R[X]) ^ n) n :=
+  (isMonicOfDegree_iff ..).mpr ⟨natDegree_X_pow_le n, coeff_X_pow_self n⟩
+
+lemma IsMonicOfDegree.coeff_eq {R : Type*} [Semiring R] {p q : R[X]} {n : ℕ}
+    (hp : IsMonicOfDegree p n) (hq : IsMonicOfDegree q n) {m : ℕ} (hm : n ≤ m) :
+    p.coeff m = q.coeff m := by
+  nontriviality R
+  rw [isMonicOfDegree_iff] at hp hq
+  rcases eq_or_lt_of_le hm with rfl | hm
+  · rw [hp.2, hq.2]
+  · replace hp : p.natDegree < m := hp.1.trans_lt hm
+    replace hq : q.natDegree < m := hq.1.trans_lt hm
+    rw [coeff_eq_zero_of_natDegree_lt hp, coeff_eq_zero_of_natDegree_lt hq]
+
+lemma IsMonicOfDegree.of_mul_left {R : Type*} [Semiring R] {p q : R[X]} {m n : ℕ}
+    (hp : IsMonicOfDegree p m) (hpq : IsMonicOfDegree (p * q) (m + n)) :
+    IsMonicOfDegree q n := by
+  rcases subsingleton_or_nontrivial R with H | H
+  · simp only [isMonicOfDegree_iff_of_subsingleton, Nat.add_eq_zero] at hpq ⊢
+    exact hpq.2
+  have h₂ : q.Monic := hp.2.of_mul_monic_left hpq.2
+  refine ⟨?_, h₂⟩
+  have := hpq.1
+  have h : p.leadingCoeff * q.leadingCoeff ≠ 0 := by
+    rw [hp.leadingCoeff_eq, h₂.leadingCoeff, one_mul]
+    exact one_ne_zero
+  rw [natDegree_mul' h, hp.1] at this
+  exact (Nat.add_left_cancel this.symm).symm
+
+lemma IsMonicOfDegree.of_mul_right {R : Type*} [Semiring R]  {p q : R[X]} {m n : ℕ}
+    (hq : IsMonicOfDegree q n) (hpq : IsMonicOfDegree (p * q) (m + n)) :
+    IsMonicOfDegree p m := by
+  rcases subsingleton_or_nontrivial R with H | H
+  · simp only [isMonicOfDegree_iff_of_subsingleton, Nat.add_eq_zero] at hpq ⊢
+    exact hpq.1
+  have h₂ : p.Monic := hq.2.of_mul_monic_right hpq.2
+  refine ⟨?_, h₂⟩
+  have := hpq.1
+  have h : p.leadingCoeff * q.leadingCoeff ≠ 0 := by
+    rw [h₂.leadingCoeff, hq.leadingCoeff_eq, one_mul]
+    exact one_ne_zero
+  rw [natDegree_mul' h, hq.1] at this
+  exact (Nat.add_right_cancel this.symm).symm
+
+lemma IsMonicOfDegree.add_right {R : Type*} [Semiring R] {p q : R[X]} {n : ℕ}
+    (hp : IsMonicOfDegree p n) (hq : q.natDegree < n) :
+    IsMonicOfDegree (p + q) n := by
+  rcases subsingleton_or_nontrivial R with H | H
+  · simpa using hp
+  refine (isMonicOfDegree_iff ..).mpr ⟨?_, ?_⟩
+  · exact natDegree_add_le_of_degree_le hp.natDegree_eq.le hq.le
+  · rw [coeff_add_eq_left_of_lt hq]
+    exact ((isMonicOfDegree_iff p n).mp hp).2
+
+lemma IsMonicOfDegree.sub {R : Type*} [Ring R] {p q : R[X]} {n : ℕ}
+    (hp : IsMonicOfDegree p n) (hq : q.natDegree < n) :
+    IsMonicOfDegree (p - q) n := by
+  rw [sub_eq_add_neg]
+  exact hp.add_right <| (natDegree_neg q) ▸ hq
+
+lemma IsMonicOfDegree.add_left {R : Type*} [Semiring R] {p q : R[X]} {n : ℕ}
+    (hp : p.natDegree < n) (hq : IsMonicOfDegree q n) :
+    IsMonicOfDegree (p + q) n := by
+  rw [add_comm]
+  exact hq.add_right hp
+
+lemma IsMonicOfDegree.of_dvd_add {R : Type*} [CommRing R] {a b r : R[X]} {m n : ℕ} (hmn : n ≤ m)
+    (ha : IsMonicOfDegree a m) (hb : IsMonicOfDegree b n) (hr : r.natDegree < m) (h : b ∣ a + r) :
+    ∃ q : R[X], IsMonicOfDegree q (m - n) ∧ a = q * b - r := by
+  obtain ⟨q, hq⟩ :=exists_eq_mul_left_of_dvd  h
+  refine ⟨q, hb.of_mul_right ?_, eq_sub_iff_add_eq.mpr hq⟩
+  rw [← hq, show m - n + n = m by omega]
+  exact ha.add_right hr
+
+lemma IsMonicOfDegree.of_dvd_sub {R : Type*} [CommRing R] {a b r : R[X]} {m n : ℕ} (hmn : n ≤ m)
+    (ha : IsMonicOfDegree a m) (hb : IsMonicOfDegree b n) (hr : r.natDegree < m) (h : b ∣ a - r) :
+    ∃ q : R[X], IsMonicOfDegree q (m - n) ∧ a = q * b + r := by
+  convert ha.of_dvd_add hmn hb ?_ h using 4 with q
+  · rw [sub_neg_eq_add]
+  · rwa [natDegree_neg]
+
+lemma IsMonicOfDegree.comp {R : Type*} [Semiring R] {p q : R[X]} {m n : ℕ} (hn : n ≠ 0)
+    (hp : IsMonicOfDegree p m) (hq : IsMonicOfDegree q n) :
+    IsMonicOfDegree (p.comp q) (m * n) := by
+  rcases subsingleton_or_nontrivial R with h | h
+  · simp only [isMonicOfDegree_iff_of_subsingleton, mul_eq_zero] at hp ⊢
+    exact .inl hp
+  rw [← hp.natDegree_eq, ← hq.natDegree_eq]
+  refine (isMonicOfDegree_iff ..).mpr ⟨natDegree_comp_le, ?_⟩
+  rw [coeff_comp_degree_mul_degree (hq.natDegree_eq ▸ hn), hp.leadingCoeff_eq, hq.leadingCoeff_eq,
+    one_pow, one_mul]
+
+lemma isMonicOfDegree_X_add_one {R : Type*} [Semiring R] [Nontrivial R] (r : R) :
+    IsMonicOfDegree (X + C r) 1 :=
+  (isMonicOfDegree_X R).add_right (by compute_degree!)
+
+lemma isMonicOfDegree_X_sub_one {R : Type*} [Ring R] [Nontrivial R] (r : R) :
+    IsMonicOfDegree (X - C r) 1 :=
+  (isMonicOfDegree_X R).sub (by compute_degree!)
+
+lemma isMonicOfDegree_one_iff {R : Type*} [Semiring R] [Nontrivial R] {f : R[X]} :
+    IsMonicOfDegree f 1 ↔ ∃ r : R, f = X + C r := by
+  refine ⟨fun H ↦ ?_, fun ⟨r, H⟩ ↦ H ▸ isMonicOfDegree_X_add_one r⟩
+  refine ⟨f.coeff 0, ?_⟩
+  ext1 n
+  rcases n.eq_zero_or_pos with rfl | hn
+  · simp
+  · exact H.coeff_eq (isMonicOfDegree_X_add_one _) (by omega)
+
+lemma IsMonicOfDegree.aeval_add {R : Type*} [CommRing R] {p : R[X]} {n : ℕ}
+    (hp : IsMonicOfDegree p n) (r : R) :
+    IsMonicOfDegree (aeval (X + C r) p) n := by
+  rcases subsingleton_or_nontrivial R with H | H
+  · simpa using hp
+  rw [← mul_one n]
+  exact hp.comp one_ne_zero (isMonicOfDegree_X_add_one r)
+
+lemma IsMonicOfDegree.aeval_sub {R : Type*} [CommRing R] {p : R[X]} {n : ℕ}
+    (hp : IsMonicOfDegree p n) (r : R) :
+    IsMonicOfDegree (aeval (X - C r) p) n := by
+  rw [sub_eq_add_neg, ← map_neg]
+  exact aeval_add hp (-r)
+
+lemma isMonicOfDegree_add_add_two {R : Type*} [CommSemiring R] [Nontrivial R] (a b : R) :
+    IsMonicOfDegree (X ^ 2 + C a * X + C b) 2 := by
+  rw [add_assoc]
+  exact (isMonicOfDegree_X_pow R 2).add_right <| by compute_degree!
+
+lemma isMonicOfDegree_sub_add_two {R : Type*} [CommRing R] [Nontrivial R] (a b : R) :
+    IsMonicOfDegree (X ^ 2 - C a * X + C b) 2 := by
+  rw [sub_add]
+  exact (isMonicOfDegree_X_pow R 2).add_right <| by compute_degree!
+
+lemma isMonicOfDegree_two_iff {R : Type*} [CommSemiring R] [Nontrivial R] {f : R[X]} :
+    IsMonicOfDegree f 2 ↔ ∃ a b : R, f = X ^ 2 + C a * X + C b := by
+  refine ⟨fun H ↦ ?_, fun ⟨a, b, h⟩ ↦ h ▸ isMonicOfDegree_add_add_two a b⟩
+  refine ⟨f.coeff 1, f.coeff 0, ext fun n ↦ ?_⟩
+  rcases lt_trichotomy n 1 with hn | rfl | hn
+  · obtain rfl : n = 0 := Nat.lt_one_iff.mp hn
+    simp
+  · simp
+  · exact H.coeff_eq (isMonicOfDegree_add_add_two ..) (by omega)
+
+/-- A version of `Polynomial.isMonicOfDegree_two_iff` with negated middle coefficient. -/
+lemma isMonicOfDegree_two_iff' {R : Type*} [CommRing R] [Nontrivial R] {f : R[X]} :
+    IsMonicOfDegree f 2 ↔ ∃ a b : R, f = X ^ 2 - C a * X + C b := by
+  refine ⟨fun H ↦ ?_, fun ⟨a, b, h⟩ ↦ h ▸ isMonicOfDegree_sub_add_two a b⟩
+  simp only [sub_eq_add_neg, ← neg_mul, ← map_neg]
+  obtain ⟨a, b, h⟩ := isMonicOfDegree_two_iff.mp H
+  exact ⟨-a, b, (neg_neg a).symm ▸ h⟩
+
+end Polynomial

--- a/Mathlib/Algebra/Polynomial/Degree/IsMonicOfDegree.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/IsMonicOfDegree.lean
@@ -31,7 +31,7 @@ structure IsMonicOfDegree (p : R[X]) (n : ℕ) : Prop where
   monic : p.Monic
 
 @[simp]
-lemma isMonicOfDegree_zero {p : R[X]} : IsMonicOfDegree p 0 ↔ p = 1 := by
+lemma isMonicOfDegree_zero_iff {p : R[X]} : IsMonicOfDegree p 0 ↔ p = 1 := by
   simp only [isMonicOfDegree_iff']
   refine ⟨fun ⟨H₁, H₂⟩ ↦ eq_one_of_monic_natDegree_zero H₂ H₁, fun H ↦ ?_⟩
   subst H
@@ -47,7 +47,7 @@ lemma isMonicOfDegree_iff_of_subsingleton [Subsingleton R] {p : R[X]} {n : ℕ} 
   rw [Subsingleton.eq_one p]
   refine ⟨fun ⟨H, _⟩ ↦ ?_, fun H ↦ ?_⟩
   · rwa [natDegree_one, eq_comm] at H
-  · rw [H, isMonicOfDegree_zero]
+  · rw [H, isMonicOfDegree_zero_iff]
 
 lemma isMonicOfDegree_iff [Nontrivial R] (p : R[X]) (n : ℕ) :
     IsMonicOfDegree p n ↔ p.natDegree ≤ n ∧ p.coeff n = 1 := by

--- a/Mathlib/Algebra/Polynomial/Degree/IsMonicOfDegree.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/IsMonicOfDegree.lean
@@ -25,15 +25,10 @@ section Semiring
 variable [Semiring R]
 
 /-- This says that `p` has `natDegree` `n` and is monic. -/
-def IsMonicOfDegree (p : R[X]) (n : ℕ) : Prop :=
-  p.natDegree = n ∧ p.Monic
-
-lemma IsMonicOfDegree.monic {p : R[X]} {n : ℕ} (h : IsMonicOfDegree p n) : p.Monic :=
-  h.2
-
-lemma IsMonicOfDegree.natDegree_eq {p : R[X]} {n : ℕ} (h : IsMonicOfDegree p n) :
-    p.natDegree = n :=
-  h.1
+@[mk_iff isMonicOfDegree_iff']
+structure IsMonicOfDegree (p : R[X]) (n : ℕ) : Prop where
+  natDegree_eq : p.natDegree = n
+  monic : p.Monic
 
 lemma IsMonicOfDegree.ne_zero [Nontrivial R] {p : R[X]} {n : ℕ} (h : IsMonicOfDegree p n) :
     p ≠ 0 :=
@@ -41,7 +36,7 @@ lemma IsMonicOfDegree.ne_zero [Nontrivial R] {p : R[X]} {n : ℕ} (h : IsMonicOf
 
 @[simp]
 lemma isMonicOfDegree_zero {p : R[X]} : IsMonicOfDegree p 0 ↔ p = 1 := by
-  simp only [IsMonicOfDegree]
+  simp only [isMonicOfDegree_iff']
   refine ⟨fun ⟨H₁, H₂⟩ ↦ eq_one_of_monic_natDegree_zero H₂ H₁, fun H ↦ ?_⟩
   subst H
   simp
@@ -60,7 +55,7 @@ lemma isMonicOfDegree_iff_of_subsingleton [Subsingleton R] {p : R[X]} {n : ℕ} 
 
 lemma isMonicOfDegree_iff [Nontrivial R] (p : R[X]) (n : ℕ) :
     IsMonicOfDegree p n ↔ p.natDegree ≤ n ∧ p.coeff n = 1 := by
-  simp only [IsMonicOfDegree]
+  simp only [isMonicOfDegree_iff']
   refine ⟨fun ⟨H₁, H₂⟩ ↦ ⟨H₁.le, H₁ ▸ Monic.coeff_natDegree H₂⟩, fun ⟨H₁, H₂⟩ ↦ ⟨?_, ?_⟩⟩
   · exact natDegree_eq_of_le_of_coeff_ne_zero H₁ <| H₂ ▸ one_ne_zero
   · exact monic_of_natDegree_le_of_coeff_eq_one n H₁ H₂

--- a/Mathlib/Algebra/Polynomial/Degree/IsMonicOfDegree.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/IsMonicOfDegree.lean
@@ -20,40 +20,44 @@ namespace Polynomial
 
 variable {R : Type*}
 
+section Semiring
+
+variable [Semiring R]
+
 /-- This says that `p` has `natDegree` `n` and is monic. -/
-def IsMonicOfDegree [Semiring R] (p : R[X]) (n : ℕ) : Prop :=
+def IsMonicOfDegree (p : R[X]) (n : ℕ) : Prop :=
   p.natDegree = n ∧ p.Monic
 
-lemma IsMonicOfDegree.monic [Semiring R] {p : R[X]} {n : ℕ}
+lemma IsMonicOfDegree.monic {p : R[X]} {n : ℕ}
     (h : IsMonicOfDegree p n) :
     p.Monic :=
   h.2
 
-lemma IsMonicOfDegree.natDegree_eq [Semiring R] {p : R[X]} {n : ℕ}
+lemma IsMonicOfDegree.natDegree_eq {p : R[X]} {n : ℕ}
     (h : IsMonicOfDegree p n) :
     p.natDegree = n :=
   h.1
 
-lemma IsMonicOfDegree.ne_zero [Semiring R] [Nontrivial R] {p : R[X]} {n : ℕ}
+lemma IsMonicOfDegree.ne_zero [Nontrivial R] {p : R[X]} {n : ℕ}
     (h : IsMonicOfDegree p n) :
     p ≠ 0 :=
   h.2.ne_zero
 
 @[simp]
-lemma isMonicOfDegree_zero [Semiring R] {p : R[X]} :
+lemma isMonicOfDegree_zero {p : R[X]} :
     IsMonicOfDegree p 0 ↔ p = 1 := by
   simp only [IsMonicOfDegree]
   refine ⟨fun ⟨H₁, H₂⟩ ↦ eq_one_of_monic_natDegree_zero H₂ H₁, fun H ↦ ?_⟩
   subst H
   simp
 
-lemma IsMonicOfDegree.leadingCoeff_eq [Semiring R] {p : R[X]} {n : ℕ}
+lemma IsMonicOfDegree.leadingCoeff_eq {p : R[X]} {n : ℕ}
     (hp : IsMonicOfDegree p n) :
     p.leadingCoeff = 1 :=
   Monic.def.mp hp.monic
 
 @[simp]
-lemma isMonicOfDegree_iff_of_subsingleton [Semiring R] [Subsingleton R]
+lemma isMonicOfDegree_iff_of_subsingleton [Subsingleton R]
     (p : R[X]) (n : ℕ) :
     IsMonicOfDegree p n ↔ n = 0 := by
   rw [Subsingleton.eq_one p]
@@ -61,14 +65,14 @@ lemma isMonicOfDegree_iff_of_subsingleton [Semiring R] [Subsingleton R]
   · rwa [natDegree_one, eq_comm] at H
   · rw [H, isMonicOfDegree_zero]
 
-lemma isMonicOfDegree_iff [Semiring R] [Nontrivial R] (p : R[X]) (n : ℕ) :
+lemma isMonicOfDegree_iff [Nontrivial R] (p : R[X]) (n : ℕ) :
     IsMonicOfDegree p n ↔ p.natDegree ≤ n ∧ p.coeff n = 1 := by
   simp only [IsMonicOfDegree]
   refine ⟨fun ⟨H₁, H₂⟩ ↦ ⟨H₁.le, H₁ ▸ Monic.coeff_natDegree H₂⟩, fun ⟨H₁, H₂⟩ ↦ ⟨?_, ?_⟩⟩
   · exact natDegree_eq_of_le_of_coeff_ne_zero H₁ <| H₂ ▸ one_ne_zero
   · exact monic_of_natDegree_le_of_coeff_eq_one n H₁ H₂
 
-lemma IsMonicOfDegree.exists_natDegree_lt [Semiring R] {p : R[X]} {n : ℕ}
+lemma IsMonicOfDegree.exists_natDegree_lt {p : R[X]} {n : ℕ}
     (hn : n ≠ 0)  (hp : IsMonicOfDegree p n) :
     ∃ q : R[X], p = X ^ n + q ∧ q.natDegree < n := by
   refine ⟨p.eraseLead, ?_, ?_⟩
@@ -78,23 +82,7 @@ lemma IsMonicOfDegree.exists_natDegree_lt [Semiring R] {p : R[X]} {n : ℕ}
     rw [hp.natDegree_eq]
     omega
 
-lemma IsMonicOfDegree.natDegree_sub_X_pow [Ring R] {p : R[X]} {n : ℕ} (hn : n ≠ 0)
-    (hp : IsMonicOfDegree p n) :
-    (p - X ^ n).natDegree < n := by
-  obtain ⟨q, hq₁, hq₂⟩ := hp.exists_natDegree_lt hn
-  simpa [hq₁]
-
-lemma IsMonicOfDegree.natDegree_sub_lt [Ring R] {p q : R[X]} {n : ℕ} (hn : n ≠ 0)
-    (hp : IsMonicOfDegree p n) (hq : IsMonicOfDegree q n) :
-    (p - q).natDegree < n := by
-  rw [← sub_sub_sub_cancel_right p q (X ^ n)]
-  replace hp := hp.natDegree_sub_X_pow hn
-  replace hq := hq.natDegree_sub_X_pow hn
-  set p' := p - X ^ n -- do not confuse `compute_degree!`
-  set q' := q - X ^ n
-  compute_degree!
-
-lemma IsMonicOfDegree.mul [Semiring R] {p q : R[X]} {m n : ℕ}
+lemma IsMonicOfDegree.mul {p q : R[X]} {m n : ℕ}
     (hp : IsMonicOfDegree p m) (hq : IsMonicOfDegree q n) :
     IsMonicOfDegree (p * q) (m + n) := by
   rcases subsingleton_or_nontrivial R with H | H
@@ -106,7 +94,7 @@ lemma IsMonicOfDegree.mul [Semiring R] {p q : R[X]} {m n : ℕ}
     exact one_ne_zero
   rw [natDegree_mul' this, hp.1, hq.1]
 
-lemma IsMonicOfDegree.pow [Semiring R] {p : R[X]} {m : ℕ} (hp : IsMonicOfDegree p m)
+lemma IsMonicOfDegree.pow {p : R[X]} {m : ℕ} (hp : IsMonicOfDegree p m)
     (n : ℕ) :
     IsMonicOfDegree (p ^ n) (m * n) := by
   induction n with
@@ -115,18 +103,20 @@ lemma IsMonicOfDegree.pow [Semiring R] {p : R[X]} {m : ℕ} (hp : IsMonicOfDegre
     rw [pow_succ, mul_add, mul_one]
     exact ih.mul hp
 
-lemma isMonicOfDegree_X (R : Type*) [Semiring R] [Nontrivial R] : IsMonicOfDegree (X : R[X]) 1 :=
+variable (R) in
+lemma isMonicOfDegree_X [Nontrivial R] : IsMonicOfDegree (X : R[X]) 1 :=
   (isMonicOfDegree_iff ..).mpr ⟨natDegree_X_le, coeff_X_one⟩
 
-lemma isMonicOfDegree_X_pow (R : Type*) [Semiring R] [Nontrivial R] (n : ℕ) :
+variable (R)  in
+lemma isMonicOfDegree_X_pow [Nontrivial R] (n : ℕ) :
     IsMonicOfDegree ((X : R[X]) ^ n) n :=
   (isMonicOfDegree_iff ..).mpr ⟨natDegree_X_pow_le n, coeff_X_pow_self n⟩
 
-lemma isMonicOfDegree_monomial_one [Semiring R] [Nontrivial R] (n : ℕ) :
+lemma isMonicOfDegree_monomial_one [Nontrivial R] (n : ℕ) :
     IsMonicOfDegree (monomial n (1 : R)) n := by
   simpa only [monomial_one_right_eq_X_pow] using isMonicOfDegree_X_pow R n
 
-lemma IsMonicOfDegree.coeff_eq [Semiring R] {p q : R[X]} {n : ℕ}
+lemma IsMonicOfDegree.coeff_eq {p q : R[X]} {n : ℕ}
     (hp : IsMonicOfDegree p n) (hq : IsMonicOfDegree q n) {m : ℕ} (hm : n ≤ m) :
     p.coeff m = q.coeff m := by
   nontriviality R
@@ -137,7 +127,7 @@ lemma IsMonicOfDegree.coeff_eq [Semiring R] {p q : R[X]} {n : ℕ}
     replace hq : q.natDegree < m := hq.1.trans_lt hm
     rw [coeff_eq_zero_of_natDegree_lt hp, coeff_eq_zero_of_natDegree_lt hq]
 
-lemma IsMonicOfDegree.of_mul_left [Semiring R] {p q : R[X]} {m n : ℕ}
+lemma IsMonicOfDegree.of_mul_left {p q : R[X]} {m n : ℕ}
     (hp : IsMonicOfDegree p m) (hpq : IsMonicOfDegree (p * q) (m + n)) :
     IsMonicOfDegree q n := by
   rcases subsingleton_or_nontrivial R with H | H
@@ -152,7 +142,7 @@ lemma IsMonicOfDegree.of_mul_left [Semiring R] {p q : R[X]} {m n : ℕ}
   rw [natDegree_mul' h, hp.1] at this
   exact (Nat.add_left_cancel this.symm).symm
 
-lemma IsMonicOfDegree.of_mul_right [Semiring R]  {p q : R[X]} {m n : ℕ}
+lemma IsMonicOfDegree.of_mul_right  {p q : R[X]} {m n : ℕ}
     (hq : IsMonicOfDegree q n) (hpq : IsMonicOfDegree (p * q) (m + n)) :
     IsMonicOfDegree p m := by
   rcases subsingleton_or_nontrivial R with H | H
@@ -167,7 +157,7 @@ lemma IsMonicOfDegree.of_mul_right [Semiring R]  {p q : R[X]} {m n : ℕ}
   rw [natDegree_mul' h, hq.1] at this
   exact (Nat.add_right_cancel this.symm).symm
 
-lemma IsMonicOfDegree.add_right [Semiring R] {p q : R[X]} {n : ℕ}
+lemma IsMonicOfDegree.add_right {p q : R[X]} {n : ℕ}
     (hp : IsMonicOfDegree p n) (hq : q.natDegree < n) :
     IsMonicOfDegree (p + q) n := by
   rcases subsingleton_or_nontrivial R with H | H
@@ -177,34 +167,13 @@ lemma IsMonicOfDegree.add_right [Semiring R] {p q : R[X]} {n : ℕ}
   · rw [coeff_add_eq_left_of_lt hq]
     exact ((isMonicOfDegree_iff p n).mp hp).2
 
-lemma IsMonicOfDegree.sub [Ring R] {p q : R[X]} {n : ℕ}
-    (hp : IsMonicOfDegree p n) (hq : q.natDegree < n) :
-    IsMonicOfDegree (p - q) n := by
-  rw [sub_eq_add_neg]
-  exact hp.add_right <| (natDegree_neg q) ▸ hq
-
-lemma IsMonicOfDegree.add_left [Semiring R] {p q : R[X]} {n : ℕ}
+lemma IsMonicOfDegree.add_left {p q : R[X]} {n : ℕ}
     (hp : p.natDegree < n) (hq : IsMonicOfDegree q n) :
     IsMonicOfDegree (p + q) n := by
   rw [add_comm]
   exact hq.add_right hp
 
-lemma IsMonicOfDegree.of_dvd_add [CommRing R] {a b r : R[X]} {m n : ℕ} (hmn : n ≤ m)
-    (ha : IsMonicOfDegree a m) (hb : IsMonicOfDegree b n) (hr : r.natDegree < m) (h : b ∣ a + r) :
-    ∃ q : R[X], IsMonicOfDegree q (m - n) ∧ a = q * b - r := by
-  obtain ⟨q, hq⟩ :=exists_eq_mul_left_of_dvd  h
-  refine ⟨q, hb.of_mul_right ?_, eq_sub_iff_add_eq.mpr hq⟩
-  rw [← hq, show m - n + n = m by omega]
-  exact ha.add_right hr
-
-lemma IsMonicOfDegree.of_dvd_sub [CommRing R] {a b r : R[X]} {m n : ℕ} (hmn : n ≤ m)
-    (ha : IsMonicOfDegree a m) (hb : IsMonicOfDegree b n) (hr : r.natDegree < m) (h : b ∣ a - r) :
-    ∃ q : R[X], IsMonicOfDegree q (m - n) ∧ a = q * b + r := by
-  convert ha.of_dvd_add hmn hb ?_ h using 4 with q
-  · rw [sub_neg_eq_add]
-  · rwa [natDegree_neg]
-
-lemma IsMonicOfDegree.comp [Semiring R] {p q : R[X]} {m n : ℕ} (hn : n ≠ 0)
+lemma IsMonicOfDegree.comp {p q : R[X]} {m n : ℕ} (hn : n ≠ 0)
     (hp : IsMonicOfDegree p m) (hq : IsMonicOfDegree q n) :
     IsMonicOfDegree (p.comp q) (m * n) := by
   rcases subsingleton_or_nontrivial R with h | h
@@ -215,15 +184,11 @@ lemma IsMonicOfDegree.comp [Semiring R] {p q : R[X]} {m n : ℕ} (hn : n ≠ 0)
   rw [coeff_comp_degree_mul_degree (hq.natDegree_eq ▸ hn), hp.leadingCoeff_eq, hq.leadingCoeff_eq,
     one_pow, one_mul]
 
-lemma isMonicOfDegree_X_add_one [Semiring R] [Nontrivial R] (r : R) :
+lemma isMonicOfDegree_X_add_one [Nontrivial R] (r : R) :
     IsMonicOfDegree (X + C r) 1 :=
   (isMonicOfDegree_X R).add_right (by compute_degree!)
 
-lemma isMonicOfDegree_X_sub_one [Ring R] [Nontrivial R] (r : R) :
-    IsMonicOfDegree (X - C r) 1 :=
-  (isMonicOfDegree_X R).sub (by compute_degree!)
-
-lemma isMonicOfDegree_one_iff [Semiring R] [Nontrivial R] {f : R[X]} :
+lemma isMonicOfDegree_one_iff [Nontrivial R] {f : R[X]} :
     IsMonicOfDegree f 1 ↔ ∃ r : R, f = X + C r := by
   refine ⟨fun H ↦ ?_, fun ⟨r, H⟩ ↦ H ▸ isMonicOfDegree_X_add_one r⟩
   refine ⟨f.coeff 0, ?_⟩
@@ -232,31 +197,12 @@ lemma isMonicOfDegree_one_iff [Semiring R] [Nontrivial R] {f : R[X]} :
   · simp
   · exact H.coeff_eq (isMonicOfDegree_X_add_one _) (by omega)
 
-lemma IsMonicOfDegree.aeval_add [CommRing R] {p : R[X]} {n : ℕ}
-    (hp : IsMonicOfDegree p n) (r : R) :
-    IsMonicOfDegree (aeval (X + C r) p) n := by
-  rcases subsingleton_or_nontrivial R with H | H
-  · simpa using hp
-  rw [← mul_one n]
-  exact hp.comp one_ne_zero (isMonicOfDegree_X_add_one r)
-
-lemma IsMonicOfDegree.aeval_sub [CommRing R] {p : R[X]} {n : ℕ}
-    (hp : IsMonicOfDegree p n) (r : R) :
-    IsMonicOfDegree (aeval (X - C r) p) n := by
-  rw [sub_eq_add_neg, ← map_neg]
-  exact aeval_add hp (-r)
-
-lemma isMonicOfDegree_add_add_two [CommSemiring R] [Nontrivial R] (a b : R) :
+lemma isMonicOfDegree_add_add_two [Nontrivial R] (a b : R) :
     IsMonicOfDegree (X ^ 2 + C a * X + C b) 2 := by
   rw [add_assoc]
   exact (isMonicOfDegree_X_pow R 2).add_right <| by compute_degree!
 
-lemma isMonicOfDegree_sub_add_two [CommRing R] [Nontrivial R] (a b : R) :
-    IsMonicOfDegree (X ^ 2 - C a * X + C b) 2 := by
-  rw [sub_add]
-  exact (isMonicOfDegree_X_pow R 2).add_right <| by compute_degree!
-
-lemma isMonicOfDegree_two_iff [CommSemiring R] [Nontrivial R] {f : R[X]} :
+lemma isMonicOfDegree_two_iff [Nontrivial R] {f : R[X]} :
     IsMonicOfDegree f 2 ↔ ∃ a b : R, f = X ^ 2 + C a * X + C b := by
   refine ⟨fun H ↦ ?_, fun ⟨a, b, h⟩ ↦ h ▸ isMonicOfDegree_add_add_two a b⟩
   refine ⟨f.coeff 1, f.coeff 0, ext fun n ↦ ?_⟩
@@ -266,12 +212,86 @@ lemma isMonicOfDegree_two_iff [CommSemiring R] [Nontrivial R] {f : R[X]} :
   · simp
   · exact H.coeff_eq (isMonicOfDegree_add_add_two ..) (by omega)
 
+end Semiring
+
+section Ring
+
+variable [Ring R]
+
+lemma IsMonicOfDegree.natDegree_sub_X_pow {p : R[X]} {n : ℕ} (hn : n ≠ 0)
+    (hp : IsMonicOfDegree p n) :
+    (p - X ^ n).natDegree < n := by
+  obtain ⟨q, hq₁, hq₂⟩ := hp.exists_natDegree_lt hn
+  simpa [hq₁]
+
+lemma IsMonicOfDegree.natDegree_sub_lt {p q : R[X]} {n : ℕ} (hn : n ≠ 0)
+    (hp : IsMonicOfDegree p n) (hq : IsMonicOfDegree q n) :
+    (p - q).natDegree < n := by
+  rw [← sub_sub_sub_cancel_right p q (X ^ n)]
+  replace hp := hp.natDegree_sub_X_pow hn
+  replace hq := hq.natDegree_sub_X_pow hn
+  set p' := p - X ^ n -- do not confuse `compute_degree!`
+  set q' := q - X ^ n
+  compute_degree!
+
+lemma IsMonicOfDegree.sub {p q : R[X]} {n : ℕ}
+    (hp : IsMonicOfDegree p n) (hq : q.natDegree < n) :
+    IsMonicOfDegree (p - q) n := by
+  rw [sub_eq_add_neg]
+  exact hp.add_right <| (natDegree_neg q) ▸ hq
+
+lemma isMonicOfDegree_X_sub_one [Nontrivial R] (r : R) :
+    IsMonicOfDegree (X - C r) 1 :=
+  (isMonicOfDegree_X R).sub (by compute_degree!)
+
+lemma isMonicOfDegree_sub_add_two [Nontrivial R] (a b : R) :
+    IsMonicOfDegree (X ^ 2 - C a * X + C b) 2 := by
+  rw [sub_add]
+  exact (isMonicOfDegree_X_pow R 2).add_right <| by compute_degree!
+
 /-- A version of `Polynomial.isMonicOfDegree_two_iff` with negated middle coefficient. -/
-lemma isMonicOfDegree_two_iff' [CommRing R] [Nontrivial R] {f : R[X]} :
+lemma isMonicOfDegree_two_iff' [Nontrivial R] {f : R[X]} :
     IsMonicOfDegree f 2 ↔ ∃ a b : R, f = X ^ 2 - C a * X + C b := by
   refine ⟨fun H ↦ ?_, fun ⟨a, b, h⟩ ↦ h ▸ isMonicOfDegree_sub_add_two a b⟩
   simp only [sub_eq_add_neg, ← neg_mul, ← map_neg]
   obtain ⟨a, b, h⟩ := isMonicOfDegree_two_iff.mp H
   exact ⟨-a, b, (neg_neg a).symm ▸ h⟩
+
+end Ring
+
+section CommRing
+
+variable [CommRing R]
+
+lemma IsMonicOfDegree.of_dvd_add {a b r : R[X]} {m n : ℕ} (hmn : n ≤ m)
+    (ha : IsMonicOfDegree a m) (hb : IsMonicOfDegree b n) (hr : r.natDegree < m) (h : b ∣ a + r) :
+    ∃ q : R[X], IsMonicOfDegree q (m - n) ∧ a = q * b - r := by
+  obtain ⟨q, hq⟩ := exists_eq_mul_left_of_dvd  h
+  refine ⟨q, hb.of_mul_right ?_, eq_sub_iff_add_eq.mpr hq⟩
+  rw [← hq, show m - n + n = m by omega]
+  exact ha.add_right hr
+
+lemma IsMonicOfDegree.of_dvd_sub {a b r : R[X]} {m n : ℕ} (hmn : n ≤ m)
+    (ha : IsMonicOfDegree a m) (hb : IsMonicOfDegree b n) (hr : r.natDegree < m) (h : b ∣ a - r) :
+    ∃ q : R[X], IsMonicOfDegree q (m - n) ∧ a = q * b + r := by
+  convert ha.of_dvd_add hmn hb ?_ h using 4 with q
+  · rw [sub_neg_eq_add]
+  · rwa [natDegree_neg]
+
+lemma IsMonicOfDegree.aeval_add {p : R[X]} {n : ℕ}
+    (hp : IsMonicOfDegree p n) (r : R) :
+    IsMonicOfDegree (aeval (X + C r) p) n := by
+  rcases subsingleton_or_nontrivial R with H | H
+  · simpa using hp
+  rw [← mul_one n]
+  exact hp.comp one_ne_zero (isMonicOfDegree_X_add_one r)
+
+lemma IsMonicOfDegree.aeval_sub {p : R[X]} {n : ℕ}
+    (hp : IsMonicOfDegree p n) (r : R) :
+    IsMonicOfDegree (aeval (X - C r) p) n := by
+  rw [sub_eq_add_neg, ← map_neg]
+  exact aeval_add hp (-r)
+
+end CommRing
 
 end Polynomial

--- a/Mathlib/Algebra/Polynomial/Degree/IsMonicOfDegree.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/IsMonicOfDegree.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Stoll
 -/
 import Mathlib.Algebra.Polynomial.AlgebraMap
-import Mathlib.Algebra.Polynomial.BigOperators
+import Mathlib.Algebra.Polynomial.Monic
 import Mathlib.Tactic.ComputeDegree
 
 /-!
@@ -69,10 +69,12 @@ lemma isMonicOfDegree_iff {R : Type*} [Semiring R] [Nontrivial R] (p : R[X]) (n 
 lemma IsMonicOfDegree.exists_natDegree_lt {R : Type*} [Semiring R] {p : R[X]} {n : ℕ}
     (hn : n ≠ 0)  (hp : IsMonicOfDegree p n) :
     ∃ q : R[X], p = X ^ n + q ∧ q.natDegree < n := by
-  refine ⟨_, hp.natDegree_eq ▸ hp.monic.as_sum, LE.le.trans_lt ?_ (Nat.sub_one_lt hn)⟩
-  refine natDegree_sum_le_of_forall_le _ _ fun i hi ↦ ?_
-  have : i ≤ n - 1 := by rw [Finset.mem_range] at hi; omega
-  compute_degree!
+  refine ⟨p.eraseLead, ?_, ?_⟩
+  · nth_rewrite 1 [← p.eraseLead_add_C_mul_X_pow]
+    rw [add_comm, hp.natDegree_eq, hp.leadingCoeff_eq, map_one, one_mul]
+  · refine p.eraseLead_natDegree_le.trans_lt ?_
+    rw [hp.natDegree_eq]
+    omega
 
 lemma IsMonicOfDegree.natDegree_sub_X_pow {R : Type*} [Ring R] {p : R[X]} {n : ℕ} (hn : n ≠ 0)
     (hp : IsMonicOfDegree p n) :
@@ -117,6 +119,10 @@ lemma isMonicOfDegree_X (R : Type*) [Semiring R] [Nontrivial R] : IsMonicOfDegre
 lemma isMonicOfDegree_X_pow (R : Type*) [Semiring R] [Nontrivial R] (n : ℕ) :
     IsMonicOfDegree ((X : R[X]) ^ n) n :=
   (isMonicOfDegree_iff ..).mpr ⟨natDegree_X_pow_le n, coeff_X_pow_self n⟩
+
+lemma isMonicOfDegree_monomial_one {R : Type*} [Semiring R] [Nontrivial R] (n : ℕ) :
+    IsMonicOfDegree (monomial n (1 : R)) n := by
+  simpa only [monomial_one_right_eq_X_pow] using isMonicOfDegree_X_pow R n
 
 lemma IsMonicOfDegree.coeff_eq {R : Type*} [Semiring R] {p q : R[X]} {n : ℕ}
     (hp : IsMonicOfDegree p n) (hq : IsMonicOfDegree q n) {m : ℕ} (hm : n ≤ m) :

--- a/Mathlib/Algebra/Polynomial/Degree/IsMonicOfDegree.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/IsMonicOfDegree.lean
@@ -28,37 +28,30 @@ variable [Semiring R]
 def IsMonicOfDegree (p : R[X]) (n : ℕ) : Prop :=
   p.natDegree = n ∧ p.Monic
 
-lemma IsMonicOfDegree.monic {p : R[X]} {n : ℕ}
-    (h : IsMonicOfDegree p n) :
-    p.Monic :=
+lemma IsMonicOfDegree.monic {p : R[X]} {n : ℕ} (h : IsMonicOfDegree p n) : p.Monic :=
   h.2
 
-lemma IsMonicOfDegree.natDegree_eq {p : R[X]} {n : ℕ}
-    (h : IsMonicOfDegree p n) :
+lemma IsMonicOfDegree.natDegree_eq {p : R[X]} {n : ℕ} (h : IsMonicOfDegree p n) :
     p.natDegree = n :=
   h.1
 
-lemma IsMonicOfDegree.ne_zero [Nontrivial R] {p : R[X]} {n : ℕ}
-    (h : IsMonicOfDegree p n) :
+lemma IsMonicOfDegree.ne_zero [Nontrivial R] {p : R[X]} {n : ℕ} (h : IsMonicOfDegree p n) :
     p ≠ 0 :=
   h.2.ne_zero
 
 @[simp]
-lemma isMonicOfDegree_zero {p : R[X]} :
-    IsMonicOfDegree p 0 ↔ p = 1 := by
+lemma isMonicOfDegree_zero {p : R[X]} : IsMonicOfDegree p 0 ↔ p = 1 := by
   simp only [IsMonicOfDegree]
   refine ⟨fun ⟨H₁, H₂⟩ ↦ eq_one_of_monic_natDegree_zero H₂ H₁, fun H ↦ ?_⟩
   subst H
   simp
 
-lemma IsMonicOfDegree.leadingCoeff_eq {p : R[X]} {n : ℕ}
-    (hp : IsMonicOfDegree p n) :
+lemma IsMonicOfDegree.leadingCoeff_eq {p : R[X]} {n : ℕ} (hp : IsMonicOfDegree p n) :
     p.leadingCoeff = 1 :=
   Monic.def.mp hp.monic
 
 @[simp]
-lemma isMonicOfDegree_iff_of_subsingleton [Subsingleton R]
-    (p : R[X]) (n : ℕ) :
+lemma isMonicOfDegree_iff_of_subsingleton [Subsingleton R] (p : R[X]) (n : ℕ) :
     IsMonicOfDegree p n ↔ n = 0 := by
   rw [Subsingleton.eq_one p]
   refine ⟨fun ⟨H, _⟩ ↦ ?_, fun H ↦ ?_⟩
@@ -72,8 +65,8 @@ lemma isMonicOfDegree_iff [Nontrivial R] (p : R[X]) (n : ℕ) :
   · exact natDegree_eq_of_le_of_coeff_ne_zero H₁ <| H₂ ▸ one_ne_zero
   · exact monic_of_natDegree_le_of_coeff_eq_one n H₁ H₂
 
-lemma IsMonicOfDegree.exists_natDegree_lt {p : R[X]} {n : ℕ}
-    (hn : n ≠ 0)  (hp : IsMonicOfDegree p n) :
+lemma IsMonicOfDegree.exists_natDegree_lt {p : R[X]} {n : ℕ} (hn : n ≠ 0)
+    (hp : IsMonicOfDegree p n) :
     ∃ q : R[X], p = X ^ n + q ∧ q.natDegree < n := by
   refine ⟨p.eraseLead, ?_, ?_⟩
   · nth_rewrite 1 [← p.eraseLead_add_C_mul_X_pow]
@@ -82,8 +75,8 @@ lemma IsMonicOfDegree.exists_natDegree_lt {p : R[X]} {n : ℕ}
     rw [hp.natDegree_eq]
     omega
 
-lemma IsMonicOfDegree.mul {p q : R[X]} {m n : ℕ}
-    (hp : IsMonicOfDegree p m) (hq : IsMonicOfDegree q n) :
+lemma IsMonicOfDegree.mul {p q : R[X]} {m n : ℕ} (hp : IsMonicOfDegree p m)
+    (hq : IsMonicOfDegree q n) :
     IsMonicOfDegree (p * q) (m + n) := by
   rcases subsingleton_or_nontrivial R with H | H
   · simp only [isMonicOfDegree_iff_of_subsingleton, Nat.add_eq_zero] at hp hq ⊢
@@ -94,8 +87,7 @@ lemma IsMonicOfDegree.mul {p q : R[X]} {m n : ℕ}
     exact one_ne_zero
   rw [natDegree_mul' this, hp.1, hq.1]
 
-lemma IsMonicOfDegree.pow {p : R[X]} {m : ℕ} (hp : IsMonicOfDegree p m)
-    (n : ℕ) :
+lemma IsMonicOfDegree.pow {p : R[X]} {m : ℕ} (hp : IsMonicOfDegree p m) (n : ℕ) :
     IsMonicOfDegree (p ^ n) (m * n) := by
   induction n with
   | zero => simp
@@ -116,8 +108,8 @@ lemma isMonicOfDegree_monomial_one [Nontrivial R] (n : ℕ) :
     IsMonicOfDegree (monomial n (1 : R)) n := by
   simpa only [monomial_one_right_eq_X_pow] using isMonicOfDegree_X_pow R n
 
-lemma IsMonicOfDegree.coeff_eq {p q : R[X]} {n : ℕ}
-    (hp : IsMonicOfDegree p n) (hq : IsMonicOfDegree q n) {m : ℕ} (hm : n ≤ m) :
+lemma IsMonicOfDegree.coeff_eq {p q : R[X]} {n : ℕ} (hp : IsMonicOfDegree p n)
+    (hq : IsMonicOfDegree q n) {m : ℕ} (hm : n ≤ m) :
     p.coeff m = q.coeff m := by
   nontriviality R
   rw [isMonicOfDegree_iff] at hp hq
@@ -127,8 +119,8 @@ lemma IsMonicOfDegree.coeff_eq {p q : R[X]} {n : ℕ}
     replace hq : q.natDegree < m := hq.1.trans_lt hm
     rw [coeff_eq_zero_of_natDegree_lt hp, coeff_eq_zero_of_natDegree_lt hq]
 
-lemma IsMonicOfDegree.of_mul_left {p q : R[X]} {m n : ℕ}
-    (hp : IsMonicOfDegree p m) (hpq : IsMonicOfDegree (p * q) (m + n)) :
+lemma IsMonicOfDegree.of_mul_left {p q : R[X]} {m n : ℕ} (hp : IsMonicOfDegree p m)
+    (hpq : IsMonicOfDegree (p * q) (m + n)) :
     IsMonicOfDegree q n := by
   rcases subsingleton_or_nontrivial R with H | H
   · simp only [isMonicOfDegree_iff_of_subsingleton, Nat.add_eq_zero] at hpq ⊢
@@ -142,8 +134,8 @@ lemma IsMonicOfDegree.of_mul_left {p q : R[X]} {m n : ℕ}
   rw [natDegree_mul' h, hp.1] at this
   exact (Nat.add_left_cancel this.symm).symm
 
-lemma IsMonicOfDegree.of_mul_right  {p q : R[X]} {m n : ℕ}
-    (hq : IsMonicOfDegree q n) (hpq : IsMonicOfDegree (p * q) (m + n)) :
+lemma IsMonicOfDegree.of_mul_right  {p q : R[X]} {m n : ℕ} (hq : IsMonicOfDegree q n)
+    (hpq : IsMonicOfDegree (p * q) (m + n)) :
     IsMonicOfDegree p m := by
   rcases subsingleton_or_nontrivial R with H | H
   · simp only [isMonicOfDegree_iff_of_subsingleton, Nat.add_eq_zero] at hpq ⊢
@@ -157,8 +149,8 @@ lemma IsMonicOfDegree.of_mul_right  {p q : R[X]} {m n : ℕ}
   rw [natDegree_mul' h, hq.1] at this
   exact (Nat.add_right_cancel this.symm).symm
 
-lemma IsMonicOfDegree.add_right {p q : R[X]} {n : ℕ}
-    (hp : IsMonicOfDegree p n) (hq : q.natDegree < n) :
+lemma IsMonicOfDegree.add_right {p q : R[X]} {n : ℕ} (hp : IsMonicOfDegree p n)
+    (hq : q.natDegree < n) :
     IsMonicOfDegree (p + q) n := by
   rcases subsingleton_or_nontrivial R with H | H
   · simpa using hp
@@ -167,14 +159,14 @@ lemma IsMonicOfDegree.add_right {p q : R[X]} {n : ℕ}
   · rw [coeff_add_eq_left_of_lt hq]
     exact ((isMonicOfDegree_iff p n).mp hp).2
 
-lemma IsMonicOfDegree.add_left {p q : R[X]} {n : ℕ}
-    (hp : p.natDegree < n) (hq : IsMonicOfDegree q n) :
+lemma IsMonicOfDegree.add_left {p q : R[X]} {n : ℕ} (hp : p.natDegree < n)
+    (hq : IsMonicOfDegree q n) :
     IsMonicOfDegree (p + q) n := by
   rw [add_comm]
   exact hq.add_right hp
 
-lemma IsMonicOfDegree.comp {p q : R[X]} {m n : ℕ} (hn : n ≠ 0)
-    (hp : IsMonicOfDegree p m) (hq : IsMonicOfDegree q n) :
+lemma IsMonicOfDegree.comp {p q : R[X]} {m n : ℕ} (hn : n ≠ 0) (hp : IsMonicOfDegree p m)
+    (hq : IsMonicOfDegree q n) :
     IsMonicOfDegree (p.comp q) (m * n) := by
   rcases subsingleton_or_nontrivial R with h | h
   · simp only [isMonicOfDegree_iff_of_subsingleton, mul_eq_zero] at hp ⊢
@@ -184,8 +176,7 @@ lemma IsMonicOfDegree.comp {p q : R[X]} {m n : ℕ} (hn : n ≠ 0)
   rw [coeff_comp_degree_mul_degree (hq.natDegree_eq ▸ hn), hp.leadingCoeff_eq, hq.leadingCoeff_eq,
     one_pow, one_mul]
 
-lemma isMonicOfDegree_X_add_one [Nontrivial R] (r : R) :
-    IsMonicOfDegree (X + C r) 1 :=
+lemma isMonicOfDegree_X_add_one [Nontrivial R] (r : R) : IsMonicOfDegree (X + C r) 1 :=
   (isMonicOfDegree_X R).add_right (by compute_degree!)
 
 lemma isMonicOfDegree_one_iff [Nontrivial R] {f : R[X]} :
@@ -224,8 +215,8 @@ lemma IsMonicOfDegree.natDegree_sub_X_pow {p : R[X]} {n : ℕ} (hn : n ≠ 0)
   obtain ⟨q, hq₁, hq₂⟩ := hp.exists_natDegree_lt hn
   simpa [hq₁]
 
-lemma IsMonicOfDegree.natDegree_sub_lt {p q : R[X]} {n : ℕ} (hn : n ≠ 0)
-    (hp : IsMonicOfDegree p n) (hq : IsMonicOfDegree q n) :
+lemma IsMonicOfDegree.natDegree_sub_lt {p q : R[X]} {n : ℕ} (hn : n ≠ 0) (hp : IsMonicOfDegree p n)
+    (hq : IsMonicOfDegree q n) :
     (p - q).natDegree < n := by
   rw [← sub_sub_sub_cancel_right p q (X ^ n)]
   replace hp := hp.natDegree_sub_X_pow hn
@@ -234,14 +225,12 @@ lemma IsMonicOfDegree.natDegree_sub_lt {p q : R[X]} {n : ℕ} (hn : n ≠ 0)
   set q' := q - X ^ n
   compute_degree!
 
-lemma IsMonicOfDegree.sub {p q : R[X]} {n : ℕ}
-    (hp : IsMonicOfDegree p n) (hq : q.natDegree < n) :
+lemma IsMonicOfDegree.sub {p q : R[X]} {n : ℕ} (hp : IsMonicOfDegree p n) (hq : q.natDegree < n) :
     IsMonicOfDegree (p - q) n := by
   rw [sub_eq_add_neg]
   exact hp.add_right <| (natDegree_neg q) ▸ hq
 
-lemma isMonicOfDegree_X_sub_one [Nontrivial R] (r : R) :
-    IsMonicOfDegree (X - C r) 1 :=
+lemma isMonicOfDegree_X_sub_one [Nontrivial R] (r : R) : IsMonicOfDegree (X - C r) 1 :=
   (isMonicOfDegree_X R).sub (by compute_degree!)
 
 lemma isMonicOfDegree_sub_add_two [Nontrivial R] (a b : R) :
@@ -263,31 +252,29 @@ section CommRing
 
 variable [CommRing R]
 
-lemma IsMonicOfDegree.of_dvd_add {a b r : R[X]} {m n : ℕ} (hmn : n ≤ m)
-    (ha : IsMonicOfDegree a m) (hb : IsMonicOfDegree b n) (hr : r.natDegree < m) (h : b ∣ a + r) :
+lemma IsMonicOfDegree.of_dvd_add {a b r : R[X]} {m n : ℕ} (hmn : n ≤ m) (ha : IsMonicOfDegree a m)
+    (hb : IsMonicOfDegree b n) (hr : r.natDegree < m) (h : b ∣ a + r) :
     ∃ q : R[X], IsMonicOfDegree q (m - n) ∧ a = q * b - r := by
   obtain ⟨q, hq⟩ := exists_eq_mul_left_of_dvd  h
   refine ⟨q, hb.of_mul_right ?_, eq_sub_iff_add_eq.mpr hq⟩
   rw [← hq, show m - n + n = m by omega]
   exact ha.add_right hr
 
-lemma IsMonicOfDegree.of_dvd_sub {a b r : R[X]} {m n : ℕ} (hmn : n ≤ m)
-    (ha : IsMonicOfDegree a m) (hb : IsMonicOfDegree b n) (hr : r.natDegree < m) (h : b ∣ a - r) :
+lemma IsMonicOfDegree.of_dvd_sub {a b r : R[X]} {m n : ℕ} (hmn : n ≤ m) (ha : IsMonicOfDegree a m)
+    (hb : IsMonicOfDegree b n) (hr : r.natDegree < m) (h : b ∣ a - r) :
     ∃ q : R[X], IsMonicOfDegree q (m - n) ∧ a = q * b + r := by
   convert ha.of_dvd_add hmn hb ?_ h using 4 with q
   · rw [sub_neg_eq_add]
   · rwa [natDegree_neg]
 
-lemma IsMonicOfDegree.aeval_add {p : R[X]} {n : ℕ}
-    (hp : IsMonicOfDegree p n) (r : R) :
+lemma IsMonicOfDegree.aeval_add {p : R[X]} {n : ℕ} (hp : IsMonicOfDegree p n) (r : R) :
     IsMonicOfDegree (aeval (X + C r) p) n := by
   rcases subsingleton_or_nontrivial R with H | H
   · simpa using hp
   rw [← mul_one n]
   exact hp.comp one_ne_zero (isMonicOfDegree_X_add_one r)
 
-lemma IsMonicOfDegree.aeval_sub {p : R[X]} {n : ℕ}
-    (hp : IsMonicOfDegree p n) (r : R) :
+lemma IsMonicOfDegree.aeval_sub {p : R[X]} {n : ℕ} (hp : IsMonicOfDegree p n) (r : R) :
     IsMonicOfDegree (aeval (X - C r) p) n := by
   rw [sub_eq_add_neg, ← map_neg]
   exact aeval_add hp (-r)

--- a/Mathlib/Algebra/Polynomial/Degree/IsMonicOfDegree.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/IsMonicOfDegree.lean
@@ -32,7 +32,7 @@ structure IsMonicOfDegree (p : R[X]) (n : ℕ) : Prop where
 
 lemma IsMonicOfDegree.ne_zero [Nontrivial R] {p : R[X]} {n : ℕ} (h : IsMonicOfDegree p n) :
     p ≠ 0 :=
-  h.2.ne_zero
+  h.monic.ne_zero
 
 @[simp]
 lemma isMonicOfDegree_zero {p : R[X]} : IsMonicOfDegree p 0 ↔ p = 1 := by
@@ -76,11 +76,11 @@ lemma IsMonicOfDegree.mul {p q : R[X]} {m n : ℕ} (hp : IsMonicOfDegree p m)
   rcases subsingleton_or_nontrivial R with H | H
   · simp only [isMonicOfDegree_iff_of_subsingleton, Nat.add_eq_zero] at hp hq ⊢
     exact ⟨hp, hq⟩
-  refine ⟨?_, hp.2.mul hq.2⟩
+  refine ⟨?_, hp.monic.mul hq.monic⟩
   have : p.leadingCoeff * q.leadingCoeff ≠ 0 := by
     rw [hp.leadingCoeff_eq, hq.leadingCoeff_eq, one_mul]
     exact one_ne_zero
-  rw [natDegree_mul' this, hp.1, hq.1]
+  rw [natDegree_mul' this, hp.natDegree_eq, hq.natDegree_eq]
 
 lemma IsMonicOfDegree.pow {p : R[X]} {m : ℕ} (hp : IsMonicOfDegree p m) (n : ℕ) :
     IsMonicOfDegree (p ^ n) (m * n) := by
@@ -120,13 +120,13 @@ lemma IsMonicOfDegree.of_mul_left {p q : R[X]} {m n : ℕ} (hp : IsMonicOfDegree
   rcases subsingleton_or_nontrivial R with H | H
   · simp only [isMonicOfDegree_iff_of_subsingleton, Nat.add_eq_zero] at hpq ⊢
     exact hpq.2
-  have h₂ : q.Monic := hp.2.of_mul_monic_left hpq.2
+  have h₂ : q.Monic := hp.monic.of_mul_monic_left hpq.monic
   refine ⟨?_, h₂⟩
-  have := hpq.1
+  have := hpq.natDegree_eq
   have h : p.leadingCoeff * q.leadingCoeff ≠ 0 := by
     rw [hp.leadingCoeff_eq, h₂.leadingCoeff, one_mul]
     exact one_ne_zero
-  rw [natDegree_mul' h, hp.1] at this
+  rw [natDegree_mul' h, hp.natDegree_eq] at this
   exact (Nat.add_left_cancel this.symm).symm
 
 lemma IsMonicOfDegree.of_mul_right  {p q : R[X]} {m n : ℕ} (hq : IsMonicOfDegree q n)
@@ -135,13 +135,13 @@ lemma IsMonicOfDegree.of_mul_right  {p q : R[X]} {m n : ℕ} (hq : IsMonicOfDegr
   rcases subsingleton_or_nontrivial R with H | H
   · simp only [isMonicOfDegree_iff_of_subsingleton, Nat.add_eq_zero] at hpq ⊢
     exact hpq.1
-  have h₂ : p.Monic := hq.2.of_mul_monic_right hpq.2
+  have h₂ : p.Monic := hq.monic.of_mul_monic_right hpq.monic
   refine ⟨?_, h₂⟩
-  have := hpq.1
+  have := hpq.natDegree_eq
   have h : p.leadingCoeff * q.leadingCoeff ≠ 0 := by
     rw [h₂.leadingCoeff, hq.leadingCoeff_eq, one_mul]
     exact one_ne_zero
-  rw [natDegree_mul' h, hq.1] at this
+  rw [natDegree_mul' h, hq.natDegree_eq] at this
   exact (Nat.add_right_cancel this.symm).symm
 
 lemma IsMonicOfDegree.add_right {p q : R[X]} {n : ℕ} (hp : IsMonicOfDegree p n)

--- a/Mathlib/Algebra/Polynomial/Degree/IsMonicOfDegree.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/IsMonicOfDegree.lean
@@ -30,10 +30,6 @@ structure IsMonicOfDegree (p : R[X]) (n : ℕ) : Prop where
   natDegree_eq : p.natDegree = n
   monic : p.Monic
 
-lemma IsMonicOfDegree.ne_zero [Nontrivial R] {p : R[X]} {n : ℕ} (h : IsMonicOfDegree p n) :
-    p ≠ 0 :=
-  h.monic.ne_zero
-
 @[simp]
 lemma isMonicOfDegree_zero {p : R[X]} : IsMonicOfDegree p 0 ↔ p = 1 := by
   simp only [isMonicOfDegree_iff']
@@ -89,19 +85,6 @@ lemma IsMonicOfDegree.pow {p : R[X]} {m : ℕ} (hp : IsMonicOfDegree p m) (n : �
   | succ n ih =>
     rw [pow_succ, mul_add, mul_one]
     exact ih.mul hp
-
-variable (R) in
-lemma isMonicOfDegree_X [Nontrivial R] : IsMonicOfDegree (X : R[X]) 1 :=
-  (isMonicOfDegree_iff ..).mpr ⟨natDegree_X_le, coeff_X_one⟩
-
-variable (R)  in
-lemma isMonicOfDegree_X_pow [Nontrivial R] (n : ℕ) :
-    IsMonicOfDegree ((X : R[X]) ^ n) n :=
-  (isMonicOfDegree_iff ..).mpr ⟨natDegree_X_pow_le n, coeff_X_pow_self n⟩
-
-lemma isMonicOfDegree_monomial_one [Nontrivial R] (n : ℕ) :
-    IsMonicOfDegree (monomial n (1 : R)) n := by
-  simpa only [monomial_one_right_eq_X_pow] using isMonicOfDegree_X_pow R n
 
 lemma IsMonicOfDegree.coeff_eq {p q : R[X]} {n : ℕ} (hp : IsMonicOfDegree p n)
     (hq : IsMonicOfDegree q n) {m : ℕ} (hm : n ≤ m) :
@@ -171,11 +154,26 @@ lemma IsMonicOfDegree.comp {p q : R[X]} {m n : ℕ} (hn : n ≠ 0) (hp : IsMonic
   rw [coeff_comp_degree_mul_degree (hq.natDegree_eq ▸ hn), hp.leadingCoeff_eq, hq.leadingCoeff_eq,
     one_pow, one_mul]
 
-lemma isMonicOfDegree_X_add_one [Nontrivial R] (r : R) : IsMonicOfDegree (X + C r) 1 :=
+variable [Nontrivial R]
+
+lemma IsMonicOfDegree.ne_zero {p : R[X]} {n : ℕ} (h : IsMonicOfDegree p n) : p ≠ 0 :=
+  h.monic.ne_zero
+
+variable (R) in
+lemma isMonicOfDegree_X : IsMonicOfDegree (X : R[X]) 1 :=
+  (isMonicOfDegree_iff ..).mpr ⟨natDegree_X_le, coeff_X_one⟩
+
+variable (R)  in
+lemma isMonicOfDegree_X_pow (n : ℕ) : IsMonicOfDegree ((X : R[X]) ^ n) n :=
+  (isMonicOfDegree_iff ..).mpr ⟨natDegree_X_pow_le n, coeff_X_pow_self n⟩
+
+lemma isMonicOfDegree_monomial_one (n : ℕ) : IsMonicOfDegree (monomial n (1 : R)) n := by
+  simpa only [monomial_one_right_eq_X_pow] using isMonicOfDegree_X_pow R n
+
+lemma isMonicOfDegree_X_add_one (r : R) : IsMonicOfDegree (X + C r) 1 :=
   (isMonicOfDegree_X R).add_right (by compute_degree!)
 
-lemma isMonicOfDegree_one_iff [Nontrivial R] {f : R[X]} :
-    IsMonicOfDegree f 1 ↔ ∃ r : R, f = X + C r := by
+lemma isMonicOfDegree_one_iff {f : R[X]} : IsMonicOfDegree f 1 ↔ ∃ r : R, f = X + C r := by
   refine ⟨fun H ↦ ?_, fun ⟨r, H⟩ ↦ H ▸ isMonicOfDegree_X_add_one r⟩
   refine ⟨f.coeff 0, ?_⟩
   ext1 n
@@ -183,12 +181,11 @@ lemma isMonicOfDegree_one_iff [Nontrivial R] {f : R[X]} :
   · simp
   · exact H.coeff_eq (isMonicOfDegree_X_add_one _) (by omega)
 
-lemma isMonicOfDegree_add_add_two [Nontrivial R] (a b : R) :
-    IsMonicOfDegree (X ^ 2 + C a * X + C b) 2 := by
+lemma isMonicOfDegree_add_add_two (a b : R) : IsMonicOfDegree (X ^ 2 + C a * X + C b) 2 := by
   rw [add_assoc]
   exact (isMonicOfDegree_X_pow R 2).add_right <| by compute_degree!
 
-lemma isMonicOfDegree_two_iff [Nontrivial R] {f : R[X]} :
+lemma isMonicOfDegree_two_iff {f : R[X]} :
     IsMonicOfDegree f 2 ↔ ∃ a b : R, f = X ^ 2 + C a * X + C b := by
   refine ⟨fun H ↦ ?_, fun ⟨a, b, h⟩ ↦ h ▸ isMonicOfDegree_add_add_two a b⟩
   refine ⟨f.coeff 1, f.coeff 0, ext fun n ↦ ?_⟩
@@ -225,16 +222,17 @@ lemma IsMonicOfDegree.sub {p q : R[X]} {n : ℕ} (hp : IsMonicOfDegree p n) (hq 
   rw [sub_eq_add_neg]
   exact hp.add_right <| (natDegree_neg q) ▸ hq
 
-lemma isMonicOfDegree_X_sub_one [Nontrivial R] (r : R) : IsMonicOfDegree (X - C r) 1 :=
+variable [Nontrivial R]
+
+lemma isMonicOfDegree_X_sub_one (r : R) : IsMonicOfDegree (X - C r) 1 :=
   (isMonicOfDegree_X R).sub (by compute_degree!)
 
-lemma isMonicOfDegree_sub_add_two [Nontrivial R] (a b : R) :
-    IsMonicOfDegree (X ^ 2 - C a * X + C b) 2 := by
+lemma isMonicOfDegree_sub_add_two (a b : R) : IsMonicOfDegree (X ^ 2 - C a * X + C b) 2 := by
   rw [sub_add]
   exact (isMonicOfDegree_X_pow R 2).add_right <| by compute_degree!
 
 /-- A version of `Polynomial.isMonicOfDegree_two_iff` with negated middle coefficient. -/
-lemma isMonicOfDegree_two_iff' [Nontrivial R] {f : R[X]} :
+lemma isMonicOfDegree_two_iff' {f : R[X]} :
     IsMonicOfDegree f 2 ↔ ∃ a b : R, f = X ^ 2 - C a * X + C b := by
   refine ⟨fun H ↦ ?_, fun ⟨a, b, h⟩ ↦ h ▸ isMonicOfDegree_sub_add_two a b⟩
   simp only [sub_eq_add_neg, ← neg_mul, ← map_neg]

--- a/Mathlib/Algebra/Polynomial/Degree/IsMonicOfDegree.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/IsMonicOfDegree.lean
@@ -51,7 +51,7 @@ lemma IsMonicOfDegree.leadingCoeff_eq {p : R[X]} {n : ℕ} (hp : IsMonicOfDegree
   Monic.def.mp hp.monic
 
 @[simp]
-lemma isMonicOfDegree_iff_of_subsingleton [Subsingleton R] (p : R[X]) (n : ℕ) :
+lemma isMonicOfDegree_iff_of_subsingleton [Subsingleton R] {p : R[X]} {n : ℕ} :
     IsMonicOfDegree p n ↔ n = 0 := by
   rw [Subsingleton.eq_one p]
   refine ⟨fun ⟨H, _⟩ ↦ ?_, fun H ↦ ?_⟩


### PR DESCRIPTION
This adds a predicate `Polynomial.IsMonicOfDegree p n` expressing that the polynomial `p` is monic and has `natDegree` equal to `n` and provides some API for it.

Bundling the two properties is quite convenient (e.g., showing that the product of two monic polynomials of degrees `m` and `n` is monic of degree `m+n` needs a few lines with the currently available API) and proved very helpful for formalizing a proof of the Gelfand-Mazur theorem over the reals.

See also here on Zulip : [#mathlib4 > Gelfand-Mazur theorem @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Gelfand-Mazur.20theorem/near/525404185).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
