### PR TITLE
[Merged by Bors] - feat(RingTheory/Valuation/Integers): nontrivial_iff

### DIFF
--- a/Mathlib/RingTheory/Valuation/Integers.lean
+++ b/Mathlib/RingTheory/Valuation/Integers.lean
@@ -96,7 +96,20 @@ theorem le_of_dvd (hv : Integers v O) {x y : O} (h : x ∣ y) :
   rw [← mul_one (v (algebraMap O R x)), hz, RingHom.map_mul, v.map_mul]
   exact mul_le_mul_left' (hv.2 z) _
 
+lemma nontrivial_iff (hv : v.Integers O) : Nontrivial O ↔ Nontrivial R := by
+  constructor <;> intro h
+  · exact hv.hom_inj.nontrivial
+  · obtain ⟨o0, ho0⟩ := hv.exists_of_le_one (r := 0) (by simp)
+    obtain ⟨o1, ho1⟩ := hv.exists_of_le_one (r := 1) (by simp)
+    refine ⟨o0, o1, ?_⟩
+    rintro rfl
+    simp [ho1] at ho0
+
 end Integers
+
+lemma integers_nontrivial (v : Valuation R Γ₀) :
+    Nontrivial v.integer ↔ Nontrivial R :=
+  (Valuation.integer.integers v).nontrivial_iff
 
 end CommRing
 


### PR DESCRIPTION
valuation subring is nontrivial iff ring is nontrivial
stated using Integers to be more general

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
