### PR TITLE
[Merged by Bors] - chore(Algebra/BigOperators): rename variables away from greek letters

### DIFF
--- a/Mathlib/Algebra/BigOperators/Associated.lean
+++ b/Mathlib/Algebra/BigOperators/Associated.lean
@@ -17,16 +17,16 @@ and products of multisets, finsets, and finsupps.
 
 assert_not_exists Field
 
-variable {α β γ δ : Type*}
+variable {ι M M₀ : Type*}
 
 -- the same local notation used in `Algebra.Associated`
 local infixl:50 " ~ᵤ " => Associated
 
 namespace Prime
 
-variable [CommMonoidWithZero α] {p : α}
+variable [CommMonoidWithZero M₀] {p : M₀}
 
-theorem exists_mem_multiset_dvd (hp : Prime p) {s : Multiset α} : p ∣ s.prod → ∃ a ∈ s, p ∣ a :=
+theorem exists_mem_multiset_dvd (hp : Prime p) {s : Multiset M₀} : p ∣ s.prod → ∃ a ∈ s, p ∣ a :=
   Multiset.induction_on s (fun h => (hp.not_dvd_one h).elim) fun a s ih h =>
     have : p ∣ a * s.prod := by simpa using h
     match hp.dvd_or_dvd this with
@@ -35,12 +35,12 @@ theorem exists_mem_multiset_dvd (hp : Prime p) {s : Multiset α} : p ∣ s.prod 
       let ⟨a, has, h⟩ := ih h
       ⟨a, Multiset.mem_cons_of_mem has, h⟩
 
-theorem exists_mem_multiset_map_dvd (hp : Prime p) {s : Multiset β} {f : β → α} :
+theorem exists_mem_multiset_map_dvd (hp : Prime p) {s : Multiset ι} {f : ι → M₀} :
     p ∣ (s.map f).prod → ∃ a ∈ s, p ∣ f a := fun h => by
   simpa only [exists_prop, Multiset.mem_map, exists_exists_and_eq_and] using
     hp.exists_mem_multiset_dvd h
 
-theorem exists_mem_finset_dvd (hp : Prime p) {s : Finset β} {f : β → α} :
+theorem exists_mem_finset_dvd (hp : Prime p) {s : Finset ι} {f : ι → M₀} :
     p ∣ s.prod f → ∃ i ∈ s, p ∣ f i :=
   hp.exists_mem_multiset_map_dvd
 
@@ -66,8 +66,8 @@ theorem Associated.prod {M : Type*} [CommMonoid M] {ι : Type*} (s : Finset ι) 
     exact Associated.mul_mul (h j (Finset.mem_insert_self j s))
       (IH (fun i hi ↦ h i (Finset.mem_insert_of_mem hi)))
 
-theorem exists_associated_mem_of_dvd_prod [CancelCommMonoidWithZero α] {p : α} (hp : Prime p)
-    {s : Multiset α} : (∀ r ∈ s, Prime r) → p ∣ s.prod → ∃ q ∈ s, p ~ᵤ q :=
+theorem exists_associated_mem_of_dvd_prod [CancelCommMonoidWithZero M₀] {p : M₀} (hp : Prime p)
+    {s : Multiset M₀} : (∀ r ∈ s, Prime r) → p ∣ s.prod → ∃ q ∈ s, p ~ᵤ q :=
   Multiset.induction_on s (by simp [mt isUnit_iff_dvd_one.2 hp.not_unit]) fun a s ih hs hps => by
     rw [Multiset.prod_cons] at hps
     rcases hp.dvd_or_dvd hps with h | h
@@ -77,11 +77,11 @@ theorem exists_associated_mem_of_dvd_prod [CancelCommMonoidWithZero α] {p : α}
       exact ⟨q, Multiset.mem_cons.2 (Or.inr hq₁), hq₂⟩
 
 open Submonoid in
-/-- Let x, y ∈ α. If x * y can be written as a product of units and prime elements, then x can be
+/-- Let x, y ∈ M₀. If x * y can be written as a product of units and prime elements, then x can be
 written as a product of units and prime elements. -/
-theorem divisor_closure_eq_closure [CancelCommMonoidWithZero α]
-    (x y : α) (hxy : x * y ∈ closure { r : α | IsUnit r ∨ Prime r}) :
-    x ∈ closure { r : α | IsUnit r ∨ Prime r} := by
+theorem divisor_closure_eq_closure [CancelCommMonoidWithZero M₀]
+    (x y : M₀) (hxy : x * y ∈ closure { r : M₀ | IsUnit r ∨ Prime r}) :
+    x ∈ closure { r : M₀ | IsUnit r ∨ Prime r} := by
   obtain ⟨m, hm, hprod⟩ := exists_multiset_of_mem_closure hxy
   induction m using Multiset.induction generalizing x y with
   | empty =>
@@ -115,8 +115,8 @@ theorem divisor_closure_eq_closure [CancelCommMonoidWithZero α]
       rw [← mul_left_cancel₀ ha₂.ne_zero hprod]
       exact multiset_prod_mem _ _ (fun t ht => subset_closure (hs t ht))
 
-theorem Multiset.prod_primes_dvd [CancelCommMonoidWithZero α]
-    [∀ a : α, DecidablePred (Associated a)] {s : Multiset α} (n : α) (h : ∀ a ∈ s, Prime a)
+theorem Multiset.prod_primes_dvd [CancelCommMonoidWithZero M₀]
+    [∀ a : M₀, DecidablePred (Associated a)] {s : Multiset M₀} (n : M₀) (h : ∀ a ∈ s, Prime a)
     (div : ∀ a ∈ s, a ∣ n) (uniq : ∀ a, s.countP (Associated a) ≤ 1) : s.prod ∣ n := by
   induction s using Multiset.induction_on generalizing n with
   | empty => simp only [Multiset.prod_zero, one_dvd]
@@ -136,8 +136,8 @@ theorem Multiset.prod_primes_dvd [CancelCommMonoidWithZero α]
       Multiset.countP_pos] at this
     exact this ⟨b, b_in_s, assoc.symm⟩
 
-theorem Finset.prod_primes_dvd [CancelCommMonoidWithZero α] [Subsingleton αˣ] {s : Finset α} (n : α)
-    (h : ∀ a ∈ s, Prime a) (div : ∀ a ∈ s, a ∣ n) : (∏ p ∈ s, p) ∣ n := by
+theorem Finset.prod_primes_dvd [CancelCommMonoidWithZero M₀] [Subsingleton M₀ˣ] {s : Finset M₀}
+    (n : M₀) (h : ∀ a ∈ s, Prime a) (div : ∀ a ∈ s, a ∣ n) : ∏ p ∈ s, p ∣ n := by
   classical
     exact
       Multiset.prod_primes_dvd n (by simpa only [Multiset.map_id', Finset.mem_def] using h)
@@ -150,29 +150,29 @@ namespace Associates
 
 section CommMonoid
 
-variable [CommMonoid α]
+variable [CommMonoid M]
 
-theorem prod_mk {p : Multiset α} : (p.map Associates.mk).prod = Associates.mk p.prod :=
+theorem prod_mk {p : Multiset M} : (p.map Associates.mk).prod = Associates.mk p.prod :=
   Multiset.induction_on p (by simp) fun a s ih => by simp [ih, Associates.mk_mul_mk]
 
-theorem finset_prod_mk {p : Finset β} {f : β → α} :
+theorem finset_prod_mk {p : Finset ι} {f : ι → M} :
     (∏ i ∈ p, Associates.mk (f i)) = Associates.mk (∏ i ∈ p, f i) := by
   rw [Finset.prod_eq_multiset_prod, ← Function.comp_def, ← Multiset.map_map, prod_mk,
     ← Finset.prod_eq_multiset_prod]
 
-theorem rel_associated_iff_map_eq_map {p q : Multiset α} :
+theorem rel_associated_iff_map_eq_map {p q : Multiset M} :
     Multiset.Rel Associated p q ↔ p.map Associates.mk = q.map Associates.mk := by
   rw [← Multiset.rel_eq, Multiset.rel_map]
   simp only [mk_eq_mk_iff_associated]
 
-theorem prod_eq_one_iff {p : Multiset (Associates α)} :
-    p.prod = 1 ↔ ∀ a ∈ p, (a : Associates α) = 1 :=
+theorem prod_eq_one_iff {p : Multiset (Associates M)} :
+    p.prod = 1 ↔ ∀ a ∈ p, (a : Associates M) = 1 :=
   Multiset.induction_on p (by simp)
     (by simp +contextual [mul_eq_one, or_imp, forall_and])
 
-theorem prod_le_prod {p q : Multiset (Associates α)} (h : p ≤ q) : p.prod ≤ q.prod := by
-  haveI := Classical.decEq (Associates α)
-  haveI := Classical.decEq α
+theorem prod_le_prod {p q : Multiset (Associates M)} (h : p ≤ q) : p.prod ≤ q.prod := by
+  haveI := Classical.decEq (Associates M)
+  haveI := Classical.decEq M
   suffices p.prod ≤ (p + (q - p)).prod by rwa [add_tsub_cancel_of_le h] at this
   suffices p.prod * 1 ≤ p.prod * (q - p).prod by simpa
   exact mul_mono (le_refl p.prod) one_le
@@ -181,9 +181,9 @@ end CommMonoid
 
 section CancelCommMonoidWithZero
 
-variable [CancelCommMonoidWithZero α]
+variable [CancelCommMonoidWithZero M₀]
 
-theorem exists_mem_multiset_le_of_prime {s : Multiset (Associates α)} {p : Associates α}
+theorem exists_mem_multiset_le_of_prime {s : Multiset (Associates M₀)} {p : Associates M₀}
     (hp : Prime p) : p ≤ s.prod → ∃ a ∈ s, p ≤ a :=
   Multiset.induction_on s (fun ⟨_, eq⟩ => (hp.ne_one (mul_eq_one.1 eq.symm).1).elim)
     fun a s ih h =>
@@ -200,7 +200,7 @@ end Associates
 
 namespace Multiset
 
-theorem prod_ne_zero_of_prime [CancelCommMonoidWithZero α] [Nontrivial α] (s : Multiset α)
+theorem prod_ne_zero_of_prime [CancelCommMonoidWithZero M₀] [Nontrivial M₀] (s : Multiset M₀)
     (h : ∀ x ∈ s, Prime x) : s.prod ≠ 0 :=
   Multiset.prod_ne_zero fun h0 => Prime.ne_zero (h 0 h0) rfl
 
@@ -212,21 +212,21 @@ section CommMonoidWithZero
 
 variable {M : Type*} [CommMonoidWithZero M]
 
-theorem Prime.dvd_finset_prod_iff {S : Finset α} {p : M} (pp : Prime p) (g : α → M) :
+theorem Prime.dvd_finset_prod_iff {S : Finset M₀} {p : M} (pp : Prime p) (g : M₀ → M) :
     p ∣ S.prod g ↔ ∃ a ∈ S, p ∣ g a :=
   ⟨pp.exists_mem_finset_dvd, fun ⟨_, ha1, ha2⟩ => dvd_trans ha2 (dvd_prod_of_mem g ha1)⟩
 
-theorem Prime.not_dvd_finset_prod {S : Finset α} {p : M} (pp : Prime p) {g : α → M}
+theorem Prime.not_dvd_finset_prod {S : Finset M₀} {p : M} (pp : Prime p) {g : M₀ → M}
     (hS : ∀ a ∈ S, ¬p ∣ g a) : ¬p ∣ S.prod g := by
   exact mt (Prime.dvd_finset_prod_iff pp _).1 <| not_exists.2 fun a => not_and.2 (hS a)
 
-theorem Prime.dvd_finsuppProd_iff {f : α →₀ M} {g : α → M → ℕ} {p : ℕ} (pp : Prime p) :
+theorem Prime.dvd_finsuppProd_iff {f : M₀ →₀ M} {g : M₀ → M → ℕ} {p : ℕ} (pp : Prime p) :
     p ∣ f.prod g ↔ ∃ a ∈ f.support, p ∣ g a (f a) :=
   Prime.dvd_finset_prod_iff pp _
 
 @[deprecated (since := "2025-04-06")] alias Prime.dvd_finsupp_prod_iff := Prime.dvd_finsuppProd_iff
 
-theorem Prime.not_dvd_finsuppProd {f : α →₀ M} {g : α → M → ℕ} {p : ℕ} (pp : Prime p)
+theorem Prime.not_dvd_finsuppProd {f : M₀ →₀ M} {g : M₀ → M → ℕ} {p : ℕ} (pp : Prime p)
     (hS : ∀ a ∈ f.support, ¬p ∣ g a (f a)) : ¬p ∣ f.prod g :=
   Prime.not_dvd_finset_prod pp hS
 

--- a/Mathlib/Algebra/BigOperators/Fin.lean
+++ b/Mathlib/Algebra/BigOperators/Fin.lean
@@ -92,7 +92,7 @@ alias sum_univ_get := sum_univ_getElem
 alias prod_univ_get := prod_univ_getElem
 
 @[to_additive (attr := simp)]
-theorem prod_univ_fun_getElem (l : List M) (f : M → M) :
+theorem prod_univ_fun_getElem (l : List ι) (f : ι → M) :
     ∏ i : Fin l.length, f l[i.1] = (l.map f).prod := by
   simp [Finset.prod_eq_multiset_prod]
 

--- a/Mathlib/Algebra/BigOperators/Fin.lean
+++ b/Mathlib/Algebra/BigOperators/Fin.lean
@@ -27,7 +27,7 @@ assert_not_exists Field
 
 open Finset
 
-variable {M M : Type*}
+variable {ι M : Type*}
 
 namespace Finset
 
@@ -120,7 +120,7 @@ theorem prod_univ_two (f : Fin 2 → M) : ∏ i, f i = f 0 * f 1 := by
   simp [prod_univ_succ]
 
 @[to_additive]
-theorem prod_univ_two' (f : M → M) (a b : M) : ∏ i, f (![a, b] i) = f a * f b :=
+theorem prod_univ_two' (f : ι → M) (a b : ι) : ∏ i, f (![a, b] i) = f a * f b :=
   prod_univ_two _
 
 @[to_additive]

--- a/Mathlib/Algebra/BigOperators/Fin.lean
+++ b/Mathlib/Algebra/BigOperators/Fin.lean
@@ -27,7 +27,7 @@ assert_not_exists Field
 
 open Finset
 
-variable {α M : Type*}
+variable {M M : Type*}
 
 namespace Finset
 
@@ -92,7 +92,7 @@ alias sum_univ_get := sum_univ_getElem
 alias prod_univ_get := prod_univ_getElem
 
 @[to_additive (attr := simp)]
-theorem prod_univ_fun_getElem (l : List α) (f : α → M) :
+theorem prod_univ_fun_getElem (l : List M) (f : M → M) :
     ∏ i : Fin l.length, f l[i.1] = (l.map f).prod := by
   simp [Finset.prod_eq_multiset_prod]
 
@@ -120,7 +120,7 @@ theorem prod_univ_two (f : Fin 2 → M) : ∏ i, f i = f 0 * f 1 := by
   simp [prod_univ_succ]
 
 @[to_additive]
-theorem prod_univ_two' (f : α → M) (a b : α) : ∏ i, f (![a, b] i) = f a * f b :=
+theorem prod_univ_two' (f : M → M) (a b : M) : ∏ i, f (![a, b] i) = f a * f b :=
   prod_univ_two _
 
 @[to_additive]
@@ -428,24 +428,24 @@ lemma sum_neg_one_pow (R : Type*) [Ring R] (m : ℕ) :
 
 section PartialProd
 
-variable [Monoid α] {n : ℕ}
+variable [Monoid M] {n : ℕ}
 
 /-- For `f = (a₁, ..., aₙ)` in `αⁿ`, `partialProd f` is `(1, a₁, a₁a₂, ..., a₁...aₙ)` in `αⁿ⁺¹`. -/
 @[to_additive "For `f = (a₁, ..., aₙ)` in `αⁿ`, `partialSum f` is\n
 `(0, a₁, a₁ + a₂, ..., a₁ + ... + aₙ)` in `αⁿ⁺¹`."]
-def partialProd (f : Fin n → α) (i : Fin (n + 1)) : α :=
+def partialProd (f : Fin n → M) (i : Fin (n + 1)) : M :=
   ((List.ofFn f).take i).prod
 
 @[to_additive (attr := simp)]
-theorem partialProd_zero (f : Fin n → α) : partialProd f 0 = 1 := by simp [partialProd]
+theorem partialProd_zero (f : Fin n → M) : partialProd f 0 = 1 := by simp [partialProd]
 
 @[to_additive]
-theorem partialProd_succ (f : Fin n → α) (j : Fin n) :
+theorem partialProd_succ (f : Fin n → M) (j : Fin n) :
     partialProd f j.succ = partialProd f (Fin.castSucc j) * f j := by
   simp [partialProd, List.take_succ]
 
 @[to_additive]
-theorem partialProd_succ' (f : Fin (n + 1) → α) (j : Fin (n + 1)) :
+theorem partialProd_succ' (f : Fin (n + 1) → M) (j : Fin (n + 1)) :
     partialProd f j.succ = f 0 * partialProd (Fin.tail f) j := by
   simp [partialProd]
   rfl
@@ -671,10 +671,10 @@ namespace List
 
 section CommMonoid
 
-variable [CommMonoid α]
+variable [CommMonoid M]
 
 @[to_additive]
-theorem prod_take_ofFn {n : ℕ} (f : Fin n → α) (i : ℕ) :
+theorem prod_take_ofFn {n : ℕ} (f : Fin n → M) (i : ℕ) :
     ((ofFn f).take i).prod = ∏ j with j.val < i, f j := by
   induction i with
   | zero =>
@@ -700,7 +700,7 @@ theorem prod_take_ofFn {n : ℕ} (f : Fin n → α) (i : ℕ) :
       simp [← A, B, IH]
 
 @[to_additive]
-theorem prod_ofFn {n : ℕ} {f : Fin n → α} : (ofFn f).prod = ∏ i, f i :=
+theorem prod_ofFn {n : ℕ} {f : Fin n → M} : (ofFn f).prod = ∏ i, f i :=
   Fin.prod_ofFn f
 
 end CommMonoid

--- a/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
@@ -303,7 +303,7 @@ theorem prod_inv [Zero M] [CommGroup G] {f : α →₀ M} {h : α → M → G} :
 @[simp]
 theorem sum_sub [Zero M] [SubtractionCommMonoid G] {f : α →₀ M} {h₁ h₂ : α → M → G} :
     (f.sum fun a b => h₁ a b - h₂ a b) = f.sum h₁ - f.sum h₂ :=
-  Finset.sum_sub_distrib
+  Finset.sum_sub_distrib ..
 
 /-- Taking the product under `h` is an additive-to-multiplicative homomorphism of finsupps,
 if `h` is an additive-to-multiplicative homomorphism on the support.

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
@@ -18,14 +18,14 @@ In this file we define products and sums indexed by finite sets (specifically, `
 
 We introduce the following notation.
 
-Let `s` be a `Finset α`, and `f : α → β` a function.
+Let `s` be a `Finset ι`, and `f : ι → β` a function.
 
 * `∏ x ∈ s, f x` is notation for `Finset.prod s f` (assuming `β` is a `CommMonoid`)
 * `∑ x ∈ s, f x` is notation for `Finset.sum s f` (assuming `β` is an `AddCommMonoid`)
 * `∏ x, f x` is notation for `Finset.prod Finset.univ f`
-  (assuming `α` is a `Fintype` and `β` is a `CommMonoid`)
+  (assuming `ι` is a `Fintype` and `β` is a `CommMonoid`)
 * `∑ x, f x` is notation for `Finset.sum Finset.univ f`
-  (assuming `α` is a `Fintype` and `β` is an `AddCommMonoid`)
+  (assuming `ι` is a `Fintype` and `β` is an `AddCommMonoid`)
 * `∏ x ∈ s with p x, f x` is notation for `Finset.prod (Finset.filter p s) f`.
 * `∑ x ∈ s with p x, f x` is notation for `Finset.sum (Finset.filter p s) f`.
 * `∏ (x ∈ s) (y ∈ t), f x y` is notation for `Finset.prod (s ×ˢ t) (fun ⟨x, y⟩ ↦ f x y)`.
@@ -46,7 +46,7 @@ assert_not_exists MonoidWithZero
 assert_not_exists MulAction
 assert_not_exists OrderedCommMonoid
 
-variable {ι κ α β γ : Type*}
+variable {ι κ M N G α : Type*}
 
 open Fin Function
 
@@ -61,16 +61,16 @@ of the finite set `s`.
 
 When the index type is a `Fintype`, the notation `∑ x, f x`, is a shorthand for
 `∑ x ∈ Finset.univ, f x`."]
-protected def prod [CommMonoid β] (s : Finset α) (f : α → β) : β :=
+protected def prod [CommMonoid M] (s : Finset ι) (f : ι → M) : M :=
   (s.1.map f).prod
 
 @[to_additive (attr := simp)]
-theorem prod_mk [CommMonoid β] (s : Multiset α) (hs : s.Nodup) (f : α → β) :
-    (⟨s, hs⟩ : Finset α).prod f = (s.map f).prod :=
+theorem prod_mk [CommMonoid M] (s : Multiset ι) (hs : s.Nodup) (f : ι → M) :
+    (⟨s, hs⟩ : Finset ι).prod f = (s.map f).prod :=
   rfl
 
 @[to_additive (attr := simp)]
-theorem prod_val [CommMonoid α] (s : Finset α) : s.1.prod = s.prod id := by
+theorem prod_val [CommMonoid M] (s : Finset M) : s.1.prod = s.prod id := by
   rw [Finset.prod, Multiset.map_id]
 
 end Finset
@@ -340,77 +340,77 @@ end BigOperators
 
 namespace Finset
 
-variable {s s₁ s₂ : Finset α} {a : α} {f g : α → β}
+variable {s s₁ s₂ : Finset ι} {a : ι} {f g : ι → M}
 
 @[to_additive]
-theorem prod_eq_multiset_prod [CommMonoid β] (s : Finset α) (f : α → β) :
+theorem prod_eq_multiset_prod [CommMonoid M] (s : Finset ι) (f : ι → M) :
     ∏ x ∈ s, f x = (s.1.map f).prod :=
   rfl
 
 @[to_additive (attr := simp)]
-lemma prod_map_val [CommMonoid β] (s : Finset α) (f : α → β) : (s.1.map f).prod = ∏ a ∈ s, f a :=
+lemma prod_map_val [CommMonoid M] (s : Finset ι) (f : ι → M) : (s.1.map f).prod = ∏ a ∈ s, f a :=
   rfl
 
 @[simp]
-theorem sum_multiset_singleton (s : Finset α) : ∑ a ∈ s, {a} = s.val := by
+theorem sum_multiset_singleton (s : Finset ι) : ∑ a ∈ s, {a} = s.val := by
   simp only [sum_eq_multiset_sum, Multiset.sum_map_singleton]
 
 end Finset
 
 @[to_additive (attr := simp)]
-theorem map_prod [CommMonoid β] [CommMonoid γ] {G : Type*} [FunLike G β γ] [MonoidHomClass G β γ]
-    (g : G) (f : α → β) (s : Finset α) : g (∏ x ∈ s, f x) = ∏ x ∈ s, g (f x) := by
+theorem map_prod [CommMonoid M] [CommMonoid N] {G : Type*} [FunLike G M N] [MonoidHomClass G M N]
+    (g : G) (f : ι → M) (s : Finset ι) : g (∏ x ∈ s, f x) = ∏ x ∈ s, g (f x) := by
   simp only [Finset.prod_eq_multiset_prod, map_multiset_prod, Multiset.map_map]; rfl
 
-variable {s s₁ s₂ : Finset α} {a : α} {f g : α → β}
+variable {s s₁ s₂ : Finset ι} {a : ι} {f g : ι → M}
 
 namespace Finset
 
 section CommMonoid
 
-variable [CommMonoid β]
+variable [CommMonoid M]
 
 @[to_additive (attr := simp)]
 theorem prod_empty : ∏ x ∈ ∅, f x = 1 :=
   rfl
 
 @[to_additive]
-theorem prod_of_isEmpty [IsEmpty α] (s : Finset α) : ∏ i ∈ s, f i = 1 := by
+theorem prod_of_isEmpty [IsEmpty ι] (s : Finset ι) : ∏ i ∈ s, f i = 1 := by
   rw [eq_empty_of_isEmpty s, prod_empty]
 
 @[to_additive (attr := simp)]
-theorem prod_const_one : (∏ _x ∈ s, (1 : β)) = 1 := by
+theorem prod_const_one : (∏ _x ∈ s, (1 : M)) = 1 := by
   simp only [Finset.prod, Multiset.map_const', Multiset.prod_replicate, one_pow]
 
 @[to_additive (attr := simp)]
-theorem prod_map (s : Finset α) (e : α ↪ γ) (f : γ → β) :
+theorem prod_map (s : Finset ι) (e : ι ↪ κ) (f : κ → M) :
     ∏ x ∈ s.map e, f x = ∏ x ∈ s, f (e x) := by
   rw [Finset.prod, Finset.map_val, Multiset.map_map]; rfl
 
 section ToList
 
 @[to_additive (attr := simp)]
-theorem prod_map_toList (s : Finset α) (f : α → β) : (s.toList.map f).prod = s.prod f := by
+theorem prod_map_toList (s : Finset ι) (f : ι → M) : (s.toList.map f).prod = s.prod f := by
   rw [Finset.prod, ← Multiset.prod_coe, ← Multiset.map_coe, Finset.coe_toList]
 
 @[deprecated (since := "2025-04-09")] alias prod_to_list := prod_map_toList
 @[deprecated (since := "2025-04-09")] alias sum_to_list := sum_map_toList
 
 @[to_additive (attr := simp)]
-theorem prod_toList {α : Type*} [CommMonoid α] (s : Finset α) :
+theorem prod_toList {M : Type*} [CommMonoid M] (s : Finset M) :
     s.toList.prod = ∏ x ∈ s, x := by
   simpa using s.prod_map_toList id
 
 end ToList
 
 @[to_additive]
-theorem _root_.Equiv.Perm.prod_comp (σ : Equiv.Perm α) (s : Finset α) (f : α → β)
+theorem _root_.Equiv.Perm.prod_comp (σ : Equiv.Perm ι) (s : Finset ι) (f : ι → M)
     (hs : { a | σ a ≠ a } ⊆ s) : (∏ x ∈ s, f (σ x)) = ∏ x ∈ s, f x := by
   convert (prod_map s σ.toEmbedding f).symm
   exact (map_perm hs).symm
 
 @[to_additive]
-theorem _root_.Equiv.Perm.prod_comp' (σ : Equiv.Perm α) (s : Finset α) (f : α → α → β)
+theorem _root_.Equiv.Perm.prod_comp' (σ : Equiv.Perm ι) (s : Finset ι) (f : ι → ι → M)
     (hs : { a | σ a ≠ a } ⊆ s) : (∏ x ∈ s, f (σ x) x) = ∏ x ∈ s, f x (σ.symm x) := by
   convert σ.prod_comp s (fun x => f x (σ.symm x)) hs
   rw [Equiv.symm_apply_apply]
@@ -423,10 +423,10 @@ namespace Finset
 
 section CommMonoid
 
-variable [CommMonoid β]
+variable [CommMonoid M]
 
 section bij
-variable {ι κ α : Type*} [CommMonoid α] {s : Finset ι} {t : Finset κ} {f : ι → α} {g : κ → α}
+variable {s : Finset ι} {t : Finset κ} {f : ι → M} {g : κ → M}
 
 /-- Reorder a product.
 
@@ -537,7 +537,7 @@ lemma prod_bijective (e : ι → κ) (he : e.Bijective) (hst : ∀ i, i ∈ s �
 end bij
 
 @[to_additive]
-theorem prod_hom_rel [CommMonoid γ] {r : β → γ → Prop} {f : α → β} {g : α → γ} {s : Finset α}
+theorem prod_hom_rel [CommMonoid N] {r : M → N → Prop} {f : ι → M} {g : ι → N} {s : Finset ι}
     (h₁ : r 1 1) (h₂ : ∀ a b c, r b c → r (f a * b) (g a * c)) :
     r (∏ x ∈ s, f x) (∏ x ∈ s, g x) := by
   delta Finset.prod
@@ -546,34 +546,34 @@ theorem prod_hom_rel [CommMonoid γ] {r : β → γ → Prop} {f : α → β} {g
 variable (f s)
 
 @[to_additive]
-theorem prod_coe_sort_eq_attach (f : s → β) : ∏ i : s, f i = ∏ i ∈ s.attach, f i :=
+theorem prod_coe_sort_eq_attach (f : s → M) : ∏ i : s, f i = ∏ i ∈ s.attach, f i :=
   rfl
 
 variable {f s}
 
 @[to_additive]
-theorem prod_ite_index (p : Prop) [Decidable p] (s t : Finset α) (f : α → β) :
+theorem prod_ite_index (p : Prop) [Decidable p] (s t : Finset ι) (f : ι → M) :
     ∏ x ∈ if p then s else t, f x = if p then ∏ x ∈ s, f x else ∏ x ∈ t, f x :=
   apply_ite (fun s => ∏ x ∈ s, f x) _ _ _
 
 @[to_additive (attr := simp)]
-theorem prod_ite_irrel (p : Prop) [Decidable p] (s : Finset α) (f g : α → β) :
+theorem prod_ite_irrel (p : Prop) [Decidable p] (s : Finset ι) (f g : ι → M) :
     ∏ x ∈ s, (if p then f x else g x) = if p then ∏ x ∈ s, f x else ∏ x ∈ s, g x := by
   split_ifs with h <;> rfl
 
 @[to_additive (attr := simp)]
-theorem prod_dite_irrel (p : Prop) [Decidable p] (s : Finset α) (f : p → α → β) (g : ¬p → α → β) :
+theorem prod_dite_irrel (p : Prop) [Decidable p] (s : Finset ι) (f : p → ι → M) (g : ¬p → ι → M) :
     ∏ x ∈ s, (if h : p then f h x else g h x) =
       if h : p then ∏ x ∈ s, f h x else ∏ x ∈ s, g h x := by
   split_ifs with h <;> rfl
 
 @[to_additive]
-theorem ite_prod_one (p : Prop) [Decidable p] (s : Finset α) (f : α → β) :
+theorem ite_prod_one (p : Prop) [Decidable p] (s : Finset ι) (f : ι → M) :
     (if p then (∏ x ∈ s, f x) else 1) = ∏ x ∈ s, if p then f x else 1 := by
   simp only [prod_ite_irrel, prod_const_one]
 
 @[to_additive]
-theorem ite_one_prod (p : Prop) [Decidable p] (s : Finset α) (f : α → β) :
+theorem ite_one_prod (p : Prop) [Decidable p] (s : Finset ι) (f : ι → M) :
     (if p then 1 else (∏ x ∈ s, f x)) = ∏ x ∈ s, if p then 1 else f x := by
   simp only [prod_ite_irrel, prod_const_one]
 
@@ -582,11 +582,11 @@ theorem nonempty_of_prod_ne_one (h : ∏ x ∈ s, f x ≠ 1) : s.Nonempty :=
   s.eq_empty_or_nonempty.elim (fun H => False.elim <| h <| H.symm ▸ prod_empty) id
 
 @[to_additive]
-theorem prod_range_zero (f : ℕ → β) : ∏ k ∈ range 0, f k = 1 := by rw [range_zero, prod_empty]
+theorem prod_range_zero (f : ℕ → M) : ∏ k ∈ range 0, f k = 1 := by rw [range_zero, prod_empty]
 
 open List
 
-theorem sum_filter_count_eq_countP [DecidableEq α] (p : α → Prop) [DecidablePred p] (l : List α) :
+theorem sum_filter_count_eq_countP [DecidableEq ι] (p : ι → Prop) [DecidablePred p] (l : List ι) :
     ∑ x ∈ l.toFinset with p x, l.count x = l.countP p := by
   simp [Finset.sum, sum_map_count_dedup_filter_eq_countP p l]
 
@@ -594,7 +594,7 @@ open Multiset
 
 
 @[to_additive]
-theorem prod_mem_multiset [DecidableEq α] (m : Multiset α) (f : { x // x ∈ m } → β) (g : α → β)
+theorem prod_mem_multiset [DecidableEq ι] (m : Multiset ι) (f : { x // x ∈ m } → M) (g : ι → M)
     (hfg : ∀ x, f x = g x) : ∏ x : { x // x ∈ m }, f x = ∏ x ∈ m.toFinset, g x := by
   refine prod_bij' (fun x _ ↦ x) (fun x hx ↦ ⟨x, Multiset.mem_toFinset.1 hx⟩) ?_ ?_ ?_ ?_ ?_ <;>
     simp [hfg]
@@ -603,7 +603,7 @@ theorem prod_mem_multiset [DecidableEq α] (m : Multiset α) (f : { x // x ∈ m
 the property is multiplicative and holds on factors. -/
 @[to_additive "To prove a property of a sum, it suffices to prove that
 the property is additive and holds on summands."]
-theorem prod_induction {M : Type*} [CommMonoid M] (f : α → M) (p : M → Prop)
+theorem prod_induction {M : Type*} [CommMonoid M] (f : ι → M) (p : M → Prop)
     (hom : ∀ a b, p a → p b → p (a * b)) (unit : p 1) (base : ∀ x ∈ s, p <| f x) :
     p <| ∏ x ∈ s, f x :=
   Multiset.prod_induction _ _ hom unit (Multiset.forall_mem_map_iff.mpr base)
@@ -612,14 +612,14 @@ theorem prod_induction {M : Type*} [CommMonoid M] (f : α → M) (p : M → Prop
 the property is multiplicative and holds on factors. -/
 @[to_additive "To prove a property of a sum, it suffices to prove that
 the property is additive and holds on summands."]
-theorem prod_induction_nonempty {M : Type*} [CommMonoid M] (f : α → M) (p : M → Prop)
+theorem prod_induction_nonempty {M : Type*} [CommMonoid M] (f : ι → M) (p : M → Prop)
     (hom : ∀ a b, p a → p b → p (a * b)) (nonempty : s.Nonempty) (base : ∀ x ∈ s, p <| f x) :
     p <| ∏ x ∈ s, f x :=
   Multiset.prod_induction_nonempty p hom (by simp [nonempty_iff_ne_empty.mp nonempty])
     (Multiset.forall_mem_map_iff.mpr base)
 
 @[to_additive]
-theorem prod_pow (s : Finset α) (n : ℕ) (f : α → β) : ∏ x ∈ s, f x ^ n = (∏ x ∈ s, f x) ^ n :=
+theorem prod_pow (s : Finset ι) (n : ℕ) (f : ι → M) : ∏ x ∈ s, f x ^ n = (∏ x ∈ s, f x) ^ n :=
   Multiset.prod_map_pow
 
 theorem prod_dvd_prod_of_subset {ι M : Type*} [CommMonoid M] (s t : Finset ι) (f : ι → M)
@@ -634,60 +634,60 @@ open MulOpposite
 
 /-- Moving to the opposite additive commutative monoid commutes with summing. -/
 @[simp]
-theorem op_sum [AddCommMonoid β] {s : Finset α} (f : α → β) :
+theorem op_sum [AddCommMonoid M] {s : Finset ι} (f : ι → M) :
     op (∑ x ∈ s, f x) = ∑ x ∈ s, op (f x) :=
-  map_sum (opAddEquiv : β ≃+ βᵐᵒᵖ) _ _
+  map_sum (opAddEquiv : M ≃+ Mᵐᵒᵖ) _ _
 
 @[simp]
-theorem unop_sum [AddCommMonoid β] {s : Finset α} (f : α → βᵐᵒᵖ) :
+theorem unop_sum [AddCommMonoid M] {s : Finset ι} (f : ι → Mᵐᵒᵖ) :
     unop (∑ x ∈ s, f x) = ∑ x ∈ s, unop (f x) :=
-  map_sum (opAddEquiv : β ≃+ βᵐᵒᵖ).symm _ _
+  map_sum (opAddEquiv : M ≃+ Mᵐᵒᵖ).symm _ _
 
 end Opposite
 
 section DivisionCommMonoid
 
-variable [DivisionCommMonoid β]
+variable [DivisionCommMonoid G]
 
 @[to_additive (attr := simp)]
-theorem prod_inv_distrib : (∏ x ∈ s, (f x)⁻¹) = (∏ x ∈ s, f x)⁻¹ :=
+theorem prod_inv_distrib (f : ι → G) : (∏ x ∈ s, (f x)⁻¹) = (∏ x ∈ s, f x)⁻¹ :=
   Multiset.prod_map_inv
 
 @[to_additive (attr := simp)]
-theorem prod_div_distrib : ∏ x ∈ s, f x / g x = (∏ x ∈ s, f x) / ∏ x ∈ s, g x :=
+theorem prod_div_distrib (f g : ι → G) : ∏ x ∈ s, f x / g x = (∏ x ∈ s, f x) / ∏ x ∈ s, g x :=
   Multiset.prod_map_div
 
 @[to_additive]
-theorem prod_zpow (f : α → β) (s : Finset α) (n : ℤ) : ∏ a ∈ s, f a ^ n = (∏ a ∈ s, f a) ^ n :=
+theorem prod_zpow (f : ι → G) (s : Finset ι) (n : ℤ) : ∏ a ∈ s, f a ^ n = (∏ a ∈ s, f a) ^ n :=
   Multiset.prod_map_zpow
 
 end DivisionCommMonoid
 
-theorem sum_nat_mod (s : Finset α) (n : ℕ) (f : α → ℕ) :
+theorem sum_nat_mod (s : Finset ι) (n : ℕ) (f : ι → ℕ) :
     (∑ i ∈ s, f i) % n = (∑ i ∈ s, f i % n) % n :=
   (Multiset.sum_nat_mod _ _).trans <| by rw [Finset.sum, Multiset.map_map]; rfl
 
-theorem prod_nat_mod (s : Finset α) (n : ℕ) (f : α → ℕ) :
+theorem prod_nat_mod (s : Finset ι) (n : ℕ) (f : ι → ℕ) :
     (∏ i ∈ s, f i) % n = (∏ i ∈ s, f i % n) % n :=
   (Multiset.prod_nat_mod _ _).trans <| by rw [Finset.prod, Multiset.map_map]; rfl
 
-theorem sum_int_mod (s : Finset α) (n : ℤ) (f : α → ℤ) :
+theorem sum_int_mod (s : Finset ι) (n : ℤ) (f : ι → ℤ) :
     (∑ i ∈ s, f i) % n = (∑ i ∈ s, f i % n) % n :=
   (Multiset.sum_int_mod _ _).trans <| by rw [Finset.sum, Multiset.map_map]; rfl
 
-theorem prod_int_mod (s : Finset α) (n : ℤ) (f : α → ℤ) :
+theorem prod_int_mod (s : Finset ι) (n : ℤ) (f : ι → ℤ) :
     (∏ i ∈ s, f i) % n = (∏ i ∈ s, f i % n) % n :=
   (Multiset.prod_int_mod _ _).trans <| by rw [Finset.prod, Multiset.map_map]; rfl
 
 end Finset
 
 namespace Fintype
-variable {ι κ α : Type*} [Fintype ι] [Fintype κ]
+variable [Fintype ι] [Fintype κ]
 
 open Finset
 
 section CommMonoid
-variable [CommMonoid α]
+variable [CommMonoid M]
 
 /-- `Fintype.prod_bijective` is a variant of `Finset.prod_bij` that accepts `Function.Bijective`.
 
@@ -696,7 +696,7 @@ See `Function.Bijective.prod_comp` for a version without `h`. -/
 `Function.Bijective`.
 
 See `Function.Bijective.sum_comp` for a version without `h`. "]
-lemma prod_bijective (e : ι → κ) (he : e.Bijective) (f : ι → α) (g : κ → α)
+lemma prod_bijective (e : ι → κ) (he : e.Bijective) (f : ι → M) (g : κ → M)
     (h : ∀ x, f x = g (e x)) : ∏ x, f x = ∏ x, g x :=
   prod_equiv (.ofBijective e he) (by simp) (by simp [h])
 
@@ -711,35 +711,33 @@ See `Equiv.prod_comp` for a version without `h`.
 automatically fills in most arguments.
 
 See `Equiv.sum_comp` for a version without `h`."]
-lemma prod_equiv (e : ι ≃ κ) (f : ι → α) (g : κ → α) (h : ∀ x, f x = g (e x)) :
+lemma prod_equiv (e : ι ≃ κ) (f : ι → M) (g : κ → M) (h : ∀ x, f x = g (e x)) :
     ∏ x, f x = ∏ x, g x := prod_bijective _ e.bijective _ _ h
 
 @[to_additive]
-lemma _root_.Function.Bijective.prod_comp {e : ι → κ} (he : e.Bijective) (g : κ → α) :
+lemma _root_.Function.Bijective.prod_comp {e : ι → κ} (he : e.Bijective) (g : κ → M) :
     ∏ i, g (e i) = ∏ i, g i := prod_bijective _ he _ _ fun _ ↦ rfl
 
 @[to_additive]
-lemma _root_.Equiv.prod_comp (e : ι ≃ κ) (g : κ → α) : ∏ i, g (e i) = ∏ i, g i :=
+lemma _root_.Equiv.prod_comp (e : ι ≃ κ) (g : κ → M) : ∏ i, g (e i) = ∏ i, g i :=
   prod_equiv e _ _ fun _ ↦ rfl
 
 @[to_additive]
-theorem prod_empty {α β : Type*} [CommMonoid β] [IsEmpty α] [Fintype α] (f : α → β) :
-    ∏ x : α, f x = 1 :=
-  Finset.prod_of_isEmpty _
+theorem prod_empty [IsEmpty ι] (f : ι → M) : ∏ x : ι, f x = 1 := prod_of_isEmpty _
 
 end CommMonoid
 end Fintype
 
 namespace Finset
-variable [CommMonoid α]
+variable [CommMonoid M]
 
 @[to_additive (attr := simp)]
-lemma prod_attach_univ [Fintype ι] (f : {i // i ∈ @univ ι _} → α) :
+lemma prod_attach_univ [Fintype ι] (f : {i // i ∈ @univ ι _} → M) :
     ∏ i ∈ univ.attach, f i = ∏ i, f ⟨i, mem_univ _⟩ :=
   Fintype.prod_equiv (Equiv.subtypeUnivEquiv mem_univ) _ _ <| by simp
 
 @[to_additive]
-theorem prod_erase_attach [DecidableEq ι] {s : Finset ι} (f : ι → α) (i : ↑s) :
+theorem prod_erase_attach [DecidableEq ι] {s : Finset ι} (f : ι → M) (i : ↑s) :
     ∏ j ∈ s.attach.erase i, f ↑j = ∏ j ∈ s.erase ↑i, f j := by
   rw [← Function.Embedding.coe_subtype, ← prod_map]
   simp [attach_map_val]
@@ -775,23 +773,24 @@ theorem disjoint_sum_right {a : Multiset α} {i : Multiset (Multiset α)} :
     Disjoint a i.sum ↔ ∀ b ∈ i, Disjoint a b := by
   simpa only [disjoint_comm (a := a)] using disjoint_sum_left
 
-theorem disjoint_finset_sum_left {β : Type*} {i : Finset β} {f : β → Multiset α} {a : Multiset α} :
+theorem disjoint_finset_sum_left {i : Finset ι} {f : ι → Multiset α} {a : Multiset α} :
     Disjoint (i.sum f) a ↔ ∀ b ∈ i, Disjoint (f b) a := by
   convert @disjoint_sum_left _ a (map f i.val)
   simp
 
-theorem disjoint_finset_sum_right {β : Type*} {i : Finset β} {f : β → Multiset α}
+theorem disjoint_finset_sum_right {i : Finset ι} {f : ι → Multiset α}
     {a : Multiset α} : Disjoint a (i.sum f) ↔ ∀ b ∈ i, Disjoint a (f b) := by
   simpa only [disjoint_comm] using disjoint_finset_sum_left
 
 variable [DecidableEq α]
 
-theorem count_sum' {s : Finset β} {a : α} {f : β → Multiset α} :
+theorem count_sum' {s : Finset ι} {a : α} {f : ι → Multiset α} :
     count a (∑ x ∈ s, f x) = ∑ x ∈ s, count a (f x) := by
   dsimp only [Finset.sum]
   rw [count_sum]
 
-theorem toFinset_prod_dvd_prod [CommMonoid α] (S : Multiset α) : S.toFinset.prod id ∣ S.prod := by
+theorem toFinset_prod_dvd_prod [DecidableEq M] [CommMonoid M] (S : Multiset M) :
+    S.toFinset.prod id ∣ S.prod := by
   rw [Finset.prod_eq_multiset_prod]
   refine Multiset.prod_dvd_prod_of_le ?_
   simp [Multiset.dedup_le S]
@@ -799,7 +798,7 @@ theorem toFinset_prod_dvd_prod [CommMonoid α] (S : Multiset α) : S.toFinset.pr
 end Multiset
 
 @[simp, norm_cast]
-theorem Units.coe_prod {M : Type*} [CommMonoid M] (f : α → Mˣ) (s : Finset α) :
+theorem Units.coe_prod [CommMonoid M] (f : α → Mˣ) (s : Finset α) :
     (↑(∏ i ∈ s, f i) : M) = ∏ i ∈ s, (f i : M) :=
   map_prod (Units.coeHom M) _ _
 
@@ -811,48 +810,48 @@ open Additive Multiplicative
 
 section Monoid
 
-variable [Monoid α]
+variable [Monoid M]
 
 @[simp]
-theorem ofMul_list_prod (s : List α) : ofMul s.prod = (s.map ofMul).sum := by simp [ofMul]; rfl
+theorem ofMul_list_prod (s : List M) : ofMul s.prod = (s.map ofMul).sum := by simp [ofMul]; rfl
 
 @[simp]
-theorem toMul_list_sum (s : List (Additive α)) : s.sum.toMul = (s.map toMul).prod := by
+theorem toMul_list_sum (s : List (Additive M)) : s.sum.toMul = (s.map toMul).prod := by
   simp [toMul, ofMul]; rfl
 
 end Monoid
 
 section AddMonoid
 
-variable [AddMonoid α]
+variable [AddMonoid M]
 
 @[simp]
-theorem ofAdd_list_prod (s : List α) : ofAdd s.sum = (s.map ofAdd).prod := by simp [ofAdd]; rfl
+theorem ofAdd_list_prod (s : List M) : ofAdd s.sum = (s.map ofAdd).prod := by simp [ofAdd]; rfl
 
 @[simp]
-theorem toAdd_list_sum (s : List (Multiplicative α)) : s.prod.toAdd = (s.map toAdd).sum := by
+theorem toAdd_list_sum (s : List (Multiplicative M)) : s.prod.toAdd = (s.map toAdd).sum := by
   simp [toAdd, ofAdd]; rfl
 
 end AddMonoid
 
 section CommMonoid
 
-variable [CommMonoid α]
+variable [CommMonoid M]
 
 @[simp]
-theorem ofMul_multiset_prod (s : Multiset α) : ofMul s.prod = (s.map ofMul).sum := by
+theorem ofMul_multiset_prod (s : Multiset M) : ofMul s.prod = (s.map ofMul).sum := by
   simp [ofMul]; rfl
 
 @[simp]
-theorem toMul_multiset_sum (s : Multiset (Additive α)) : s.sum.toMul = (s.map toMul).prod := by
+theorem toMul_multiset_sum (s : Multiset (Additive M)) : s.sum.toMul = (s.map toMul).prod := by
   simp [toMul, ofMul]; rfl
 
 @[simp]
-theorem ofMul_prod (s : Finset ι) (f : ι → α) : ofMul (∏ i ∈ s, f i) = ∑ i ∈ s, ofMul (f i) :=
+theorem ofMul_prod (s : Finset ι) (f : ι → M) : ofMul (∏ i ∈ s, f i) = ∑ i ∈ s, ofMul (f i) :=
   rfl
 
 @[simp]
-theorem toMul_sum (s : Finset ι) (f : ι → Additive α) :
+theorem toMul_sum (s : Finset ι) (f : ι → Additive M) :
     (∑ i ∈ s, f i).toMul = ∏ i ∈ s, (f i).toMul :=
   rfl
 
@@ -860,23 +859,23 @@ end CommMonoid
 
 section AddCommMonoid
 
-variable [AddCommMonoid α]
+variable [AddCommMonoid M]
 
 @[simp]
-theorem ofAdd_multiset_prod (s : Multiset α) : ofAdd s.sum = (s.map ofAdd).prod := by
+theorem ofAdd_multiset_prod (s : Multiset M) : ofAdd s.sum = (s.map ofAdd).prod := by
   simp [ofAdd]; rfl
 
 @[simp]
-theorem toAdd_multiset_sum (s : Multiset (Multiplicative α)) :
+theorem toAdd_multiset_sum (s : Multiset (Multiplicative M)) :
     s.prod.toAdd = (s.map toAdd).sum := by
   simp [toAdd, ofAdd]; rfl
 
 @[simp]
-theorem ofAdd_sum (s : Finset ι) (f : ι → α) : ofAdd (∑ i ∈ s, f i) = ∏ i ∈ s, ofAdd (f i) :=
+theorem ofAdd_sum (s : Finset ι) (f : ι → M) : ofAdd (∑ i ∈ s, f i) = ∏ i ∈ s, ofAdd (f i) :=
   rfl
 
 @[simp]
-theorem toAdd_prod (s : Finset ι) (f : ι → Multiplicative α) :
+theorem toAdd_prod (s : Finset ι) (f : ι → Multiplicative M) :
     (∏ i ∈ s, f i).toAdd = ∑ i ∈ s, (f i).toAdd :=
   rfl
 

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Lemmas.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Lemmas.lean
@@ -15,36 +15,36 @@ The lemmas in this file have been moved out of
 `Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean` to reduce its imports.
 -/
 
-variable {ι α β γ : Type*}
+variable {ι κ M N β : Type*}
 
 @[to_additive]
-theorem MonoidHom.coe_finset_prod [MulOneClass β] [CommMonoid γ] (f : α → β →* γ) (s : Finset α) :
+theorem MonoidHom.coe_finset_prod [MulOneClass M] [CommMonoid N] (f : ι → M →* N) (s : Finset ι) :
     ⇑(∏ x ∈ s, f x) = ∏ x ∈ s, ⇑(f x) :=
-  map_prod (MonoidHom.coeFn β γ) _ _
+  map_prod (MonoidHom.coeFn M N) _ _
 
 /-- See also `Finset.prod_apply`, with the same conclusion but with the weaker hypothesis
-`f : α → β → γ` -/
+`f : α → M → N` -/
 @[to_additive (attr := simp)
   "See also `Finset.sum_apply`, with the same conclusion but with the weaker hypothesis
-  `f : α → β → γ`"]
-theorem MonoidHom.finset_prod_apply [MulOneClass β] [CommMonoid γ] (f : α → β →* γ) (s : Finset α)
-    (b : β) : (∏ x ∈ s, f x) b = ∏ x ∈ s, f x b :=
+  `f : α → M → N`"]
+theorem MonoidHom.finset_prod_apply [MulOneClass M] [CommMonoid N] (f : ι → M →* N) (s : Finset ι)
+    (b : M) : (∏ x ∈ s, f x) b = ∏ x ∈ s, f x b :=
   map_prod (MonoidHom.eval b) _ _
 
 namespace Finset
 
-variable [CommMonoid β]
+variable [CommMonoid M]
 
 open Function in
 @[to_additive]
-lemma mulSupport_prod (s : Finset ι) (f : ι → α → β) :
+lemma mulSupport_prod (s : Finset ι) (f : ι → κ → M) :
     mulSupport (fun x ↦ ∏ i ∈ s, f i x) ⊆ ⋃ i ∈ s, mulSupport (f i) := by
   simp only [mulSupport_subset_iff', Set.mem_iUnion, not_exists, notMem_mulSupport]
   exact fun x ↦ prod_eq_one
 
 @[to_additive]
-lemma isSquare_prod {s : Finset ι} [CommMonoid α] (f : ι → α)
-    (h : ∀ c ∈ s, IsSquare (f c)) : IsSquare (∏ i ∈ s, f i) := by
+lemma isSquare_prod {s : Finset ι} (f : ι → M) (h : ∀ c ∈ s, IsSquare (f c)) :
+    IsSquare (∏ i ∈ s, f i) := by
   rw [isSquare_iff_exists_sq]
   use (∏ (x : s), ((isSquare_iff_exists_sq _).mp (h _ x.2)).choose)
   rw [@sq, ← Finset.prod_mul_distrib, ← Finset.prod_coe_sort]

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Piecewise.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Piecewise.lean
@@ -12,17 +12,17 @@ import Mathlib.Data.Finset.Piecewise
 This file proves lemmas on the sum and product of piecewise functions, including `ite` and `dite`.
 -/
 
-variable {ι κ α β γ : Type*} {s : Finset α}
+variable {ι κ M β γ : Type*} {s : Finset ι}
 
 namespace Finset
 
 section CommMonoid
 
-variable [CommMonoid β]
+variable [CommMonoid M]
 
 @[to_additive]
-theorem prod_apply_dite {s : Finset α} {p : α → Prop} {hp : DecidablePred p}
-    [DecidablePred fun x => ¬p x] (f : ∀ x : α, p x → γ) (g : ∀ x : α, ¬p x → γ) (h : γ → β) :
+theorem prod_apply_dite {p : ι → Prop} {hp : DecidablePred p}
+    [DecidablePred fun x => ¬p x] (f : ∀ x : ι, p x → γ) (g : ∀ x : ι, ¬p x → γ) (h : γ → M) :
     (∏ x ∈ s, h (if hx : p x then f x hx else g x hx)) =
       (∏ x : {x ∈ s | p x}, h (f x.1 <| by simpa using (mem_filter.mp x.2).2)) *
         ∏ x : {x ∈ s | ¬p x}, h (g x.1 <| by simpa using (mem_filter.mp x.2).2) :=
@@ -41,66 +41,66 @@ theorem prod_apply_dite {s : Finset α} {p : α → Prop} {hp : DecidablePred p}
         (prod_congr rfl fun x _hx => congr_arg h (dif_neg <| by simpa using (mem_filter.mp x.2).2))
 
 @[to_additive]
-theorem prod_apply_ite {s : Finset α} {p : α → Prop} {_hp : DecidablePred p} (f g : α → γ)
-    (h : γ → β) :
+theorem prod_apply_ite {s : Finset ι} {p : ι → Prop} {_hp : DecidablePred p} (f g : ι → γ)
+    (h : γ → M) :
     (∏ x ∈ s, h (if p x then f x else g x)) =
       (∏ x ∈ s with p x, h (f x)) * ∏ x ∈ s with ¬p x, h (g x) :=
   (prod_apply_dite _ _ _).trans <| congr_arg₂ _ (prod_attach _ (h ∘ f)) (prod_attach _ (h ∘ g))
 
 @[to_additive]
-theorem prod_dite {s : Finset α} {p : α → Prop} {hp : DecidablePred p} (f : ∀ x : α, p x → β)
-    (g : ∀ x : α, ¬p x → β) :
+theorem prod_dite {s : Finset ι} {p : ι → Prop} {hp : DecidablePred p} (f : ∀ x : ι, p x → M)
+    (g : ∀ x : ι, ¬p x → M) :
     ∏ x ∈ s, (if hx : p x then f x hx else g x hx) =
       (∏ x : {x ∈ s | p x}, f x.1 (by simpa using (mem_filter.mp x.2).2)) *
         ∏ x : {x ∈ s | ¬p x}, g x.1 (by simpa using (mem_filter.mp x.2).2) := by
   simp [prod_apply_dite _ _ fun x => x]
 
 @[to_additive]
-theorem prod_ite {s : Finset α} {p : α → Prop} {hp : DecidablePred p} (f g : α → β) :
+theorem prod_ite {s : Finset ι} {p : ι → Prop} {hp : DecidablePred p} (f g : ι → M) :
     ∏ x ∈ s, (if p x then f x else g x) = (∏ x ∈ s with p x, f x) * ∏ x ∈ s with ¬p x, g x := by
   simp [prod_apply_ite _ _ fun x => x]
 
 @[to_additive]
-lemma prod_dite_of_false {p : α → Prop} {_ : DecidablePred p} (h : ∀ i ∈ s, ¬ p i)
-    (f : ∀ i, p i → β) (g : ∀ i, ¬ p i → β) :
+lemma prod_dite_of_false {p : ι → Prop} {_ : DecidablePred p} (h : ∀ i ∈ s, ¬ p i)
+    (f : ∀ i, p i → M) (g : ∀ i, ¬ p i → M) :
     ∏ i ∈ s, (if hi : p i then f i hi else g i hi) = ∏ i : s, g i.1 (h _ i.2) := by
   refine prod_bij' (fun x hx => ⟨x, hx⟩) (fun x _ ↦ x) ?_ ?_ ?_ ?_ ?_ <;> aesop
 
 @[to_additive]
-lemma prod_ite_of_false {p : α → Prop} {_ : DecidablePred p} (h : ∀ x ∈ s, ¬p x) (f g : α → β) :
+lemma prod_ite_of_false {p : ι → Prop} {_ : DecidablePred p} (h : ∀ x ∈ s, ¬p x) (f g : ι → M) :
     ∏ x ∈ s, (if p x then f x else g x) = ∏ x ∈ s, g x :=
   (prod_dite_of_false h _ _).trans (prod_attach _ _)
 
 @[to_additive]
-lemma prod_dite_of_true {p : α → Prop} {_ : DecidablePred p} (h : ∀ i ∈ s, p i) (f : ∀ i, p i → β)
-    (g : ∀ i, ¬ p i → β) :
+lemma prod_dite_of_true {p : ι → Prop} {_ : DecidablePred p} (h : ∀ i ∈ s, p i) (f : ∀ i, p i → M)
+    (g : ∀ i, ¬ p i → M) :
     ∏ i ∈ s, (if hi : p i then f i hi else g i hi) = ∏ i : s, f i.1 (h _ i.2) := by
   refine prod_bij' (fun x hx => ⟨x, hx⟩) (fun x _ ↦ x) ?_ ?_ ?_ ?_ ?_ <;> aesop
 
 @[to_additive]
-lemma prod_ite_of_true {p : α → Prop} {_ : DecidablePred p} (h : ∀ x ∈ s, p x) (f g : α → β) :
+lemma prod_ite_of_true {p : ι → Prop} {_ : DecidablePred p} (h : ∀ x ∈ s, p x) (f g : ι → M) :
     ∏ x ∈ s, (if p x then f x else g x) = ∏ x ∈ s, f x :=
   (prod_dite_of_true h _ _).trans (prod_attach _ _)
 
 @[to_additive]
-theorem prod_apply_ite_of_false {p : α → Prop} {hp : DecidablePred p} (f g : α → γ) (k : γ → β)
+theorem prod_apply_ite_of_false {p : ι → Prop} {hp : DecidablePred p} (f g : ι → γ) (k : γ → M)
     (h : ∀ x ∈ s, ¬p x) : (∏ x ∈ s, k (if p x then f x else g x)) = ∏ x ∈ s, k (g x) := by
   simp_rw [apply_ite k]
   exact prod_ite_of_false h _ _
 
 @[to_additive]
-theorem prod_apply_ite_of_true {p : α → Prop} {hp : DecidablePred p} (f g : α → γ) (k : γ → β)
+theorem prod_apply_ite_of_true {p : ι → Prop} {hp : DecidablePred p} (f g : ι → γ) (k : γ → M)
     (h : ∀ x ∈ s, p x) : (∏ x ∈ s, k (if p x then f x else g x)) = ∏ x ∈ s, k (f x) := by
   simp_rw [apply_ite k]
   exact prod_ite_of_true h _ _
 
 @[to_additive (attr := simp)]
-theorem prod_ite_mem [DecidableEq α] (s t : Finset α) (f : α → β) :
+theorem prod_ite_mem [DecidableEq ι] (s t : Finset ι) (f : ι → M) :
     ∏ i ∈ s, (if i ∈ t then f i else 1) = ∏ i ∈ s ∩ t, f i := by
   rw [← Finset.prod_filter, Finset.filter_mem_eq_inter]
 
 @[to_additive]
-lemma prod_attach_eq_prod_dite [Fintype α] (s : Finset α) (f : s → β) [DecidablePred (· ∈ s)] :
+lemma prod_attach_eq_prod_dite [Fintype ι] (s : Finset ι) (f : s → M) [DecidablePred (· ∈ s)] :
     ∏ i ∈ s.attach, f i = ∏ i, if h : i ∈ s then f ⟨i, h⟩ else 1 := by
   rw [Finset.prod_dite, Finset.univ_eq_attach, Finset.prod_const_one, mul_one]
   congr
@@ -109,7 +109,7 @@ lemma prod_attach_eq_prod_dite [Fintype α] (s : Finset α) (f : s → β) [Deci
   · apply Function.hfunext <;> simp +contextual [Subtype.heq_iff_coe_eq]
 
 @[to_additive (attr := simp)]
-theorem prod_dite_eq [DecidableEq α] (s : Finset α) (a : α) (b : ∀ x : α, a = x → β) :
+theorem prod_dite_eq [DecidableEq ι] (s : Finset ι) (a : ι) (b : ∀ x : ι, a = x → M) :
     ∏ x ∈ s, (if h : a = x then b x h else 1) = ite (a ∈ s) (b a rfl) 1 := by
   split_ifs with h
   · rw [Finset.prod_eq_single a, dif_pos rfl]
@@ -124,7 +124,7 @@ theorem prod_dite_eq [DecidableEq α] (s : Finset α) (a : α) (b : ∀ x : α, 
     contradiction
 
 @[to_additive (attr := simp)]
-theorem prod_dite_eq' [DecidableEq α] (s : Finset α) (a : α) (b : ∀ x : α, x = a → β) :
+theorem prod_dite_eq' [DecidableEq ι] (s : Finset ι) (a : ι) (b : ∀ x : ι, x = a → M) :
     ∏ x ∈ s, (if h : x = a then b x h else 1) = ite (a ∈ s) (b a rfl) 1 := by
   split_ifs with h
   · rw [Finset.prod_eq_single a, dif_pos rfl]
@@ -139,7 +139,7 @@ theorem prod_dite_eq' [DecidableEq α] (s : Finset α) (a : α) (b : ∀ x : α,
     contradiction
 
 @[to_additive (attr := simp)]
-theorem prod_ite_eq [DecidableEq α] (s : Finset α) (a : α) (b : α → β) :
+theorem prod_ite_eq [DecidableEq ι] (s : Finset ι) (a : ι) (b : ι → M) :
     (∏ x ∈ s, ite (a = x) (b x) 1) = ite (a ∈ s) (b a) 1 :=
   prod_dite_eq s a fun x _ => b x
 
@@ -151,73 +151,73 @@ The difference with `Finset.prod_ite_eq` is that the arguments to `Eq` are swapp
 test on the index and whose alternative is `0` has value either the term at that index or `0`.
 
 The difference with `Finset.sum_ite_eq` is that the arguments to `Eq` are swapped."]
-theorem prod_ite_eq' [DecidableEq α] (s : Finset α) (a : α) (b : α → β) :
+theorem prod_ite_eq' [DecidableEq ι] (s : Finset ι) (a : ι) (b : ι → M) :
     (∏ x ∈ s, ite (x = a) (b x) 1) = ite (a ∈ s) (b a) 1 :=
   prod_dite_eq' s a fun x _ => b x
 
 @[to_additive]
-theorem prod_ite_eq_of_mem [DecidableEq α] (s : Finset α) (a : α) (b : α → β) (h : a ∈ s) :
+theorem prod_ite_eq_of_mem [DecidableEq ι] (s : Finset ι) (a : ι) (b : ι → M) (h : a ∈ s) :
     (∏ x ∈ s, if a = x then b x else 1) = b a := by
   simp only [prod_ite_eq, if_pos h]
 
 /-- The difference with `Finset.prod_ite_eq_of_mem` is that the arguments to `Eq` are swapped. -/
 @[to_additive]
-theorem prod_ite_eq_of_mem' [DecidableEq α] (s : Finset α) (a : α) (b : α → β) (h : a ∈ s) :
+theorem prod_ite_eq_of_mem' [DecidableEq ι] (s : Finset ι) (a : ι) (b : ι → M) (h : a ∈ s) :
     (∏ x ∈ s, if x = a then b x else 1) = b a := by
   simp only [prod_ite_eq', if_pos h]
 
 @[to_additive (attr := simp)]
-theorem prod_pi_mulSingle' [DecidableEq α] (a : α) (x : β) (s : Finset α) :
+theorem prod_pi_mulSingle' [DecidableEq ι] (a : ι) (x : M) (s : Finset ι) :
     ∏ a' ∈ s, Pi.mulSingle a x a' = if a ∈ s then x else 1 :=
   prod_dite_eq' _ _ _
 
 @[to_additive (attr := simp)]
-theorem prod_pi_mulSingle {β : α → Type*} [DecidableEq α] [∀ a, CommMonoid (β a)] (a : α)
-    (f : ∀ a, β a) (s : Finset α) :
+theorem prod_pi_mulSingle {M : ι → Type*} [DecidableEq ι] [∀ a, CommMonoid (M a)] (a : ι)
+    (f : ∀ a, M a) (s : Finset ι) :
     (∏ a' ∈ s, Pi.mulSingle a' (f a') a) = if a ∈ s then f a else 1 :=
   prod_dite_eq _ _ _
 
 @[to_additive]
-theorem prod_piecewise [DecidableEq α] (s t : Finset α) (f g : α → β) :
+theorem prod_piecewise [DecidableEq ι] (s t : Finset ι) (f g : ι → M) :
     (∏ x ∈ s, (t.piecewise f g) x) = (∏ x ∈ s ∩ t, f x) * ∏ x ∈ s \ t, g x := by
   simp only [piecewise]
   rw [prod_ite, filter_mem_eq_inter, ← sdiff_eq_filter]
 
 @[to_additive]
-theorem prod_inter_mul_prod_diff [DecidableEq α] (s t : Finset α) (f : α → β) :
+theorem prod_inter_mul_prod_diff [DecidableEq ι] (s t : Finset ι) (f : ι → M) :
     (∏ x ∈ s ∩ t, f x) * ∏ x ∈ s \ t, f x = ∏ x ∈ s, f x := by
   convert (s.prod_piecewise t f f).symm
   simp +unfoldPartialApp [Finset.piecewise]
 
 @[to_additive]
-theorem prod_eq_mul_prod_diff_singleton [DecidableEq α] {s : Finset α} {i : α} (h : i ∈ s)
-    (f : α → β) : ∏ x ∈ s, f x = f i * ∏ x ∈ s \ {i}, f x := by
+theorem prod_eq_mul_prod_diff_singleton [DecidableEq ι] {s : Finset ι} {i : ι} (h : i ∈ s)
+    (f : ι → M) : ∏ x ∈ s, f x = f i * ∏ x ∈ s \ {i}, f x := by
   convert (s.prod_inter_mul_prod_diff {i} f).symm
   simp [h]
 
 @[to_additive]
-theorem prod_eq_prod_diff_singleton_mul [DecidableEq α] {s : Finset α} {i : α} (h : i ∈ s)
-    (f : α → β) : ∏ x ∈ s, f x = (∏ x ∈ s \ {i}, f x) * f i := by
+theorem prod_eq_prod_diff_singleton_mul [DecidableEq ι] {s : Finset ι} {i : ι} (h : i ∈ s)
+    (f : ι → M) : ∏ x ∈ s, f x = (∏ x ∈ s \ {i}, f x) * f i := by
   rw [prod_eq_mul_prod_diff_singleton h, mul_comm]
 
 @[to_additive]
-theorem _root_.Fintype.prod_eq_mul_prod_compl [DecidableEq α] [Fintype α] (a : α) (f : α → β) :
+theorem _root_.Fintype.prod_eq_mul_prod_compl [DecidableEq ι] [Fintype ι] (a : ι) (f : ι → M) :
     ∏ i, f i = f a * ∏ i ∈ {a}ᶜ, f i :=
   prod_eq_mul_prod_diff_singleton (mem_univ a) f
 
 @[to_additive]
-theorem _root_.Fintype.prod_eq_prod_compl_mul [DecidableEq α] [Fintype α] (a : α) (f : α → β) :
+theorem _root_.Fintype.prod_eq_prod_compl_mul [DecidableEq ι] [Fintype ι] (a : ι) (f : ι → M) :
     ∏ i, f i = (∏ i ∈ {a}ᶜ, f i) * f a :=
   prod_eq_prod_diff_singleton_mul (mem_univ a) f
 
-theorem dvd_prod_of_mem (f : α → β) {a : α} {s : Finset α} (ha : a ∈ s) : f a ∣ ∏ i ∈ s, f i := by
+theorem dvd_prod_of_mem (f : ι → M) {a : ι} {s : Finset ι} (ha : a ∈ s) : f a ∣ ∏ i ∈ s, f i := by
   classical
     rw [Finset.prod_eq_mul_prod_diff_singleton ha]
     exact dvd_mul_right _ _
 
 @[to_additive]
-theorem prod_update_of_notMem [DecidableEq α] {s : Finset α} {i : α} (h : i ∉ s) (f : α → β)
-    (b : β) : ∏ x ∈ s, Function.update f i b x = ∏ x ∈ s, f x := by
+theorem prod_update_of_notMem [DecidableEq ι] {s : Finset ι} {i : ι} (h : i ∉ s) (f : ι → M)
+    (b : M) : ∏ x ∈ s, Function.update f i b x = ∏ x ∈ s, f x := by
   apply prod_congr rfl
   intros j hj
   have : j ≠ i := by
@@ -231,15 +231,15 @@ theorem prod_update_of_notMem [DecidableEq α] {s : Finset α} {i : α} (h : i �
 alias prod_update_of_not_mem := prod_update_of_notMem
 
 @[to_additive]
-theorem prod_update_of_mem [DecidableEq α] {s : Finset α} {i : α} (h : i ∈ s) (f : α → β) (b : β) :
+theorem prod_update_of_mem [DecidableEq ι] {s : Finset ι} {i : ι} (h : i ∈ s) (f : ι → M) (b : M) :
     ∏ x ∈ s, Function.update f i b x = b * ∏ x ∈ s \ singleton i, f x := by
   rw [update_eq_piecewise, prod_piecewise]
   simp [h]
 
 /-- See also `Finset.prod_ite_zero`. -/
 @[to_additive "See also `Finset.sum_boole`."]
-theorem prod_ite_one (s : Finset α) (p : α → Prop) [DecidablePred p]
-    (h : ∀ i ∈ s, ∀ j ∈ s, p i → p j → i = j) (a : β) :
+theorem prod_ite_one (s : Finset ι) (p : ι → Prop) [DecidablePred p]
+    (h : ∀ i ∈ s, ∀ j ∈ s, p i → p j → i = j) (a : M) :
     ∏ i ∈ s, ite (p i) a 1 = ite (∃ i ∈ s, p i) a 1 := by
   split_ifs with h
   · obtain ⟨i, hi, hpi⟩ := h
@@ -250,7 +250,7 @@ theorem prod_ite_one (s : Finset α) (p : α → Prop) [DecidablePred p]
     exact fun i hi => if_neg (h i hi)
 
 @[to_additive sum_boole_nsmul]
-theorem prod_pow_boole [DecidableEq α] (s : Finset α) (f : α → β) (a : α) :
+theorem prod_pow_boole [DecidableEq ι] (s : Finset ι) (f : ι → M) (a : ι) :
     (∏ x ∈ s, f x ^ ite (a = x) 1 0) = ite (a ∈ s) (f a) 1 := by simp
 
 end CommMonoid
@@ -264,46 +264,46 @@ namespace Fintype
 
 open Finset
 
-variable [CommMonoid α] [Fintype ι]
+variable [CommMonoid M] [Fintype ι]
 
 @[to_additive]
 lemma prod_ite_eq_ite_exists (p : ι → Prop) [DecidablePred p] (h : ∀ i j, p i → p j → i = j)
-    (a : α) : ∏ i, ite (p i) a 1 = ite (∃ i, p i) a 1 := by
+    (a : M) : ∏ i, ite (p i) a 1 = ite (∃ i, p i) a 1 := by
   simp [prod_ite_one univ p (by simpa using h)]
 
 variable [DecidableEq ι]
 
 @[to_additive]
-lemma prod_ite_mem (s : Finset ι) (f : ι → α) : ∏ i, (if i ∈ s then f i else 1) = ∏ i ∈ s, f i := by
+lemma prod_ite_mem (s : Finset ι) (f : ι → M) : ∏ i, (if i ∈ s then f i else 1) = ∏ i ∈ s, f i := by
   simp
 
 /-- See also `Finset.prod_dite_eq`. -/
-@[to_additive "See also `Finset.sum_dite_eq`."] lemma prod_dite_eq (i : ι) (f : ∀ j, i = j → α) :
+@[to_additive "See also `Finset.sum_dite_eq`."] lemma prod_dite_eq (i : ι) (f : ∀ j, i = j → M) :
     ∏ j, (if h : i = j then f j h else 1) = f i rfl := by
   rw [Finset.prod_dite_eq, if_pos (mem_univ _)]
 
 /-- See also `Finset.prod_dite_eq'`. -/
-@[to_additive "See also `Finset.sum_dite_eq'`."] lemma prod_dite_eq' (i : ι) (f : ∀ j, j = i → α) :
+@[to_additive "See also `Finset.sum_dite_eq'`."] lemma prod_dite_eq' (i : ι) (f : ∀ j, j = i → M) :
     ∏ j, (if h : j = i then f j h else 1) = f i rfl := by
   rw [Finset.prod_dite_eq', if_pos (mem_univ _)]
 
 /-- See also `Finset.prod_ite_eq`. -/
 @[to_additive "See also `Finset.sum_ite_eq`."]
-lemma prod_ite_eq (i : ι) (f : ι → α) : ∏ j, (if i = j then f j else 1) = f i := by
+lemma prod_ite_eq (i : ι) (f : ι → M) : ∏ j, (if i = j then f j else 1) = f i := by
   rw [Finset.prod_ite_eq, if_pos (mem_univ _)]
 
 /-- See also `Finset.prod_ite_eq'`. -/
 @[to_additive "See also `Finset.sum_ite_eq'`."]
-lemma prod_ite_eq' (i : ι) (f : ι → α) : ∏ j, (if j = i then f j else 1) = f i := by
+lemma prod_ite_eq' (i : ι) (f : ι → M) : ∏ j, (if j = i then f j else 1) = f i := by
   rw [Finset.prod_ite_eq', if_pos (mem_univ _)]
 
 /-- See also `Finset.prod_pi_mulSingle`. -/
 @[to_additive "See also `Finset.sum_pi_single`."]
-lemma prod_pi_mulSingle {α : ι → Type*} [∀ i, CommMonoid (α i)] (i : ι) (f : ∀ i, α i) :
+lemma prod_pi_mulSingle {M : ι → Type*} [∀ i, CommMonoid (M i)] (i : ι) (f : ∀ i, M i) :
     ∏ j, Pi.mulSingle j (f j) i = f i := prod_dite_eq _ _
 
 /-- See also `Finset.prod_pi_mulSingle'`. -/
 @[to_additive "See also `Finset.sum_pi_single'`."]
-lemma prod_pi_mulSingle' (i : ι) (a : α) : ∏ j, Pi.mulSingle i a j = a := prod_dite_eq' _ _
+lemma prod_pi_mulSingle' (i : ι) (a : M) : ∏ j, Pi.mulSingle i a j = a := prod_dite_eq' _ _
 
 end Fintype

--- a/Mathlib/Algebra/BigOperators/Group/List/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Group/List/Basic.lean
@@ -86,7 +86,7 @@ theorem prod_hom₂ (l : List ι) (f : M → N → P) (hf : ∀ a b c d, f (a * 
     ← l.foldr_hom₂ f _ _ (fun x y => f (f₁ x) (f₂ x) * y) _ _ (by simp [hf]), hf']
 
 @[to_additive (attr := simp)]
-theorem prod_map_mul {α : Type*} [CommMonoid α] {l : List ι} {f g : ι → α} :
+theorem prod_map_mul {M : Type*} [CommMonoid M] {l : List ι} {f g : ι → M} :
     (l.map fun i => f i * g i).prod = (l.map f).prod * (l.map g).prod :=
   l.prod_hom₂ (· * ·) mul_mul_mul_comm (mul_one _) _ _
 
@@ -402,39 +402,39 @@ section Alternating
 
 section
 
-variable [One α] [Mul α] [Inv α]
+variable [One G] [Mul G] [Inv G]
 
 @[to_additive (attr := simp)]
-theorem alternatingProd_nil : alternatingProd ([] : List α) = 1 :=
+theorem alternatingProd_nil : alternatingProd ([] : List G) = 1 :=
   rfl
 
 @[to_additive (attr := simp)]
-theorem alternatingProd_singleton (a : α) : alternatingProd [a] = a :=
+theorem alternatingProd_singleton (a : G) : alternatingProd [a] = a :=
   rfl
 
 @[to_additive]
-theorem alternatingProd_cons_cons' (a b : α) (l : List α) :
+theorem alternatingProd_cons_cons' (a b : G) (l : List G) :
     alternatingProd (a :: b :: l) = a * b⁻¹ * alternatingProd l :=
   rfl
 
 end
 
 @[to_additive]
-theorem alternatingProd_cons_cons [DivInvMonoid α] (a b : α) (l : List α) :
+theorem alternatingProd_cons_cons [DivInvMonoid G] (a b : G) (l : List G) :
     alternatingProd (a :: b :: l) = a / b * alternatingProd l := by
   rw [div_eq_mul_inv, alternatingProd_cons_cons']
 
-variable [CommGroup α]
+variable [CommGroup G]
 
 @[to_additive]
 theorem alternatingProd_cons' :
-    ∀ (a : α) (l : List α), alternatingProd (a :: l) = a * (alternatingProd l)⁻¹
+    ∀ (a : G) (l : List G), alternatingProd (a :: l) = a * (alternatingProd l)⁻¹
   | a, [] => by rw [alternatingProd_nil, inv_one, mul_one, alternatingProd_singleton]
   | a, b :: l => by
     rw [alternatingProd_cons_cons', alternatingProd_cons' b l, mul_inv, inv_inv, mul_assoc]
 
 @[to_additive (attr := simp)]
-theorem alternatingProd_cons (a : α) (l : List α) :
+theorem alternatingProd_cons (a : G) (l : List G) :
     alternatingProd (a :: l) = a / alternatingProd l := by
   rw [div_eq_mul_inv, alternatingProd_cons']
 

--- a/Mathlib/Algebra/BigOperators/Group/List/Lemmas.lean
+++ b/Mathlib/Algebra/BigOperators/Group/List/Lemmas.lean
@@ -40,7 +40,7 @@ theorem prod_isUnit : ∀ {L : List M}, (∀ m ∈ L, IsUnit m) → IsUnit L.pro
     exact IsUnit.mul (u h mem_cons_self) (prod_isUnit fun m mt => u m (mem_cons_of_mem h mt))
 
 @[to_additive]
-theorem prod_isUnit_iff {α : Type*} [CommMonoid α] {L : List α} :
+theorem prod_isUnit_iff {M : Type*} [CommMonoid M] {L : List M} :
     IsUnit L.prod ↔ ∀ m ∈ L, IsUnit m := by
   refine ⟨fun h => ?_, prod_isUnit⟩
   induction L with
@@ -173,11 +173,11 @@ theorem Sublist.prod_dvd_prod [CommMonoid M] {l₁ l₂ : List M} (h : l₁ <+ l
 
 section Alternating
 
-variable [CommGroup α]
+variable [CommGroup G]
 
 @[to_additive]
 theorem alternatingProd_append :
-    ∀ l₁ l₂ : List α,
+    ∀ l₁ l₂ : List G,
       alternatingProd (l₁ ++ l₂) = alternatingProd l₁ * alternatingProd l₂ ^ (-1 : ℤ) ^ length l₁
   | [], l₂ => by simp
   | a :: l₁, l₂ => by
@@ -186,7 +186,7 @@ theorem alternatingProd_append :
 
 @[to_additive]
 theorem alternatingProd_reverse :
-    ∀ l : List α, alternatingProd (reverse l) = alternatingProd l ^ (-1 : ℤ) ^ (length l + 1)
+    ∀ l : List G, alternatingProd (reverse l) = alternatingProd l ^ (-1 : ℤ) ^ (length l + 1)
   | [] => by simp only [alternatingProd_nil, one_zpow, reverse_nil]
   | a :: l => by
     simp_rw [reverse_cons, alternatingProd_append, alternatingProd_reverse,

--- a/Mathlib/Algebra/BigOperators/Group/Multiset/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Multiset/Basic.lean
@@ -24,7 +24,7 @@ and sums indexed by finite sets.
 
 assert_not_exists MonoidWithZero
 
-variable {F ι κ M N O : Type*}
+variable {F ι κ G M N O : Type*}
 
 namespace Multiset
 
@@ -177,11 +177,11 @@ end AddCommMonoid
 
 section DivisionCommMonoid
 
-variable [DivisionCommMonoid M] {m : Multiset ι} {f g : ι → M}
+variable [DivisionCommMonoid G] {m : Multiset ι} {f g : ι → G}
 
 @[to_additive]
-theorem prod_map_inv' (m : Multiset M) : (m.map Inv.inv).prod = m.prod⁻¹ :=
-  m.prod_hom (invMonoidHom : M →* M)
+theorem prod_map_inv' (m : Multiset G) : (m.map Inv.inv).prod = m.prod⁻¹ :=
+  m.prod_hom (invMonoidHom : G →* G)
 
 @[to_additive (attr := simp)]
 theorem prod_map_inv : (m.map fun i => (f i)⁻¹).prod = (m.map f).prod⁻¹ := by
@@ -193,7 +193,7 @@ theorem prod_map_div : (m.map fun i => f i / g i).prod = (m.map f).prod / (m.map
 
 @[to_additive]
 theorem prod_map_zpow {n : ℤ} : (m.map fun i => f i ^ n).prod = (m.map f).prod ^ n := by
-  convert (m.map f).prod_hom (zpowGroupHom n : M →* M)
+  convert (m.map f).prod_hom (zpowGroupHom n : G →* G)
   simp only [map_map, Function.comp_apply, zpowGroupHom_apply]
 
 end DivisionCommMonoid

--- a/Mathlib/Algebra/BigOperators/Group/Multiset/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Multiset/Basic.lean
@@ -24,16 +24,16 @@ and sums indexed by finite sets.
 
 assert_not_exists MonoidWithZero
 
-variable {F ι α β β' γ : Type*}
+variable {F ι M N ι γ : Type*}
 
 namespace Multiset
 
 section CommMonoid
 
-variable [CommMonoid α] [CommMonoid β] {s t : Multiset α} {a : α} {m : Multiset ι} {f g : ι → α}
+variable [CommMonoid M] [CommMonoid N] {s t : Multiset M} {a : M} {m : Multiset ι} {f g : ι → M}
 
 @[to_additive (attr := simp)]
-theorem prod_erase [DecidableEq α] (h : a ∈ s) : a * (s.erase a).prod = s.prod := by
+theorem prod_erase [DecidableEq M] (h : a ∈ s) : a * (s.erase a).prod = s.prod := by
   rw [← s.coe_toList, coe_erase, prod_coe, prod_coe, List.prod_erase (mem_toList.2 h)]
 
 @[to_additive (attr := simp)]
@@ -43,11 +43,11 @@ theorem prod_map_erase [DecidableEq ι] {a : ι} (h : a ∈ m) :
     List.prod_map_erase f (mem_toList.2 h)]
 
 @[to_additive (attr := simp)]
-theorem prod_add (s t : Multiset α) : prod (s + t) = prod s * prod t :=
+theorem prod_add (s t : Multiset M) : prod (s + t) = prod s * prod t :=
   Quotient.inductionOn₂ s t fun l₁ l₂ => by simp
 
 @[to_additive]
-theorem prod_nsmul (m : Multiset α) : ∀ n : ℕ, (n • m).prod = m.prod ^ n
+theorem prod_nsmul (m : Multiset M) : ∀ n : ℕ, (n • m).prod = m.prod ^ n
   | 0 => by
     rw [zero_nsmul, pow_zero]
     rfl
@@ -65,43 +65,43 @@ theorem prod_map_eq_pow_single [DecidableEq ι] (i : ι)
   simp [List.prod_map_eq_pow_single i f hf]
 
 @[to_additive]
-theorem prod_eq_pow_single [DecidableEq α] (a : α) (h : ∀ a' ≠ a, a' ∈ s → a' = 1) :
+theorem prod_eq_pow_single [DecidableEq M] (a : M) (h : ∀ a' ≠ a, a' ∈ s → a' = 1) :
     s.prod = a ^ s.count a := by
   induction s using Quotient.inductionOn; simp [List.prod_eq_pow_single a h]
 
 @[to_additive]
-lemma prod_eq_one (h : ∀ x ∈ s, x = (1 : α)) : s.prod = 1 := by
+lemma prod_eq_one (h : ∀ x ∈ s, x = (1 : M)) : s.prod = 1 := by
   induction s using Quotient.inductionOn; simp [List.prod_eq_one h]
 
 @[to_additive]
-theorem prod_hom_ne_zero {s : Multiset α} (hs : s ≠ 0) {F : Type*} [FunLike F α β]
-    [MulHomClass F α β] (f : F) :
+theorem prod_hom_ne_zero {s : Multiset M} (hs : s ≠ 0) {F : Type*} [FunLike F M N]
+    [MulHomClass F M N] (f : F) :
     (s.map f).prod = f s.prod := by
   induction s using Quot.inductionOn; aesop (add simp List.prod_hom_nonempty)
 
 @[to_additive]
-theorem prod_hom (s : Multiset α) {F : Type*} [FunLike F α β]
-    [MonoidHomClass F α β] (f : F) :
+theorem prod_hom (s : Multiset M) {F : Type*} [FunLike F M N]
+    [MonoidHomClass F M N] (f : F) :
     (s.map f).prod = f s.prod :=
   Quotient.inductionOn s fun l => by simp only [l.prod_hom f, quot_mk_to_coe, map_coe, prod_coe]
 
 @[to_additive]
-theorem prod_hom' (s : Multiset ι) {F : Type*} [FunLike F α β]
-    [MonoidHomClass F α β] (f : F)
-    (g : ι → α) : (s.map fun i => f <| g i).prod = f (s.map g).prod := by
+theorem prod_hom' (s : Multiset ι) {F : Type*} [FunLike F M N]
+    [MonoidHomClass F M N] (f : F)
+    (g : ι → M) : (s.map fun i => f <| g i).prod = f (s.map g).prod := by
   convert (s.map g).prod_hom f
   exact (map_map _ _ _).symm
 
 @[to_additive]
-theorem prod_hom₂_ne_zero [CommMonoid γ] {s : Multiset ι} (hs : s ≠ 0) (f : α → β → γ)
-    (hf : ∀ a b c d, f (a * b) (c * d) = f a c * f b d) (f₁ : ι → α) (f₂ : ι → β) :
+theorem prod_hom₂_ne_zero [CommMonoid γ] {s : Multiset ι} (hs : s ≠ 0) (f : M → N → γ)
+    (hf : ∀ a b c d, f (a * b) (c * d) = f a c * f b d) (f₁ : ι → M) (f₂ : ι → N) :
     (s.map fun i => f (f₁ i) (f₂ i)).prod = f (s.map f₁).prod (s.map f₂).prod := by
   induction s using Quotient.inductionOn; aesop (add simp List.prod_hom₂_nonempty)
 
 @[to_additive]
-theorem prod_hom₂ [CommMonoid γ] (s : Multiset ι) (f : α → β → γ)
-    (hf : ∀ a b c d, f (a * b) (c * d) = f a c * f b d) (hf' : f 1 1 = 1) (f₁ : ι → α)
-    (f₂ : ι → β) : (s.map fun i => f (f₁ i) (f₂ i)).prod = f (s.map f₁).prod (s.map f₂).prod :=
+theorem prod_hom₂ [CommMonoid γ] (s : Multiset ι) (f : M → N → γ)
+    (hf : ∀ a b c d, f (a * b) (c * d) = f a c * f b d) (hf' : f 1 1 = 1) (f₁ : ι → M)
+    (f₂ : ι → N) : (s.map fun i => f (f₁ i) (f₂ i)).prod = f (s.map f₁).prod (s.map f₂).prod :=
   Quotient.inductionOn s fun l => by
     simp only [l.prod_hom₂ f hf hf', quot_mk_to_coe, map_coe, prod_coe]
 
@@ -111,10 +111,10 @@ theorem prod_map_mul : (m.map fun i => f i * g i).prod = (m.map f).prod * (m.map
 
 @[to_additive]
 theorem prod_map_pow {n : ℕ} : (m.map fun i => f i ^ n).prod = (m.map f).prod ^ n :=
-  m.prod_hom' (powMonoidHom n : α →* α) f
+  m.prod_hom' (powMonoidHom n : M →* M) f
 
 @[to_additive]
-theorem prod_map_prod_map (m : Multiset β') (n : Multiset γ) {f : β' → γ → α} :
+theorem prod_map_prod_map (m : Multiset ι) (n : Multiset γ) {f : ι → γ → M} :
     prod (m.map fun a => prod <| n.map fun b => f a b) =
       prod (n.map fun b => prod <| m.map fun a => f a b) :=
   Multiset.induction_on m (by simp) fun a m ih => by simp [ih]
@@ -124,34 +124,34 @@ theorem prod_dvd_prod_of_le (h : s ≤ t) : s.prod ∣ t.prod := by
   simp only [prod_add, dvd_mul_right]
 
 @[to_additive]
-lemma _root_.map_multiset_prod [FunLike F α β] [MonoidHomClass F α β] (f : F) (s : Multiset α) :
+lemma _root_.map_multiset_prod [FunLike F M N] [MonoidHomClass F M N] (f : F) (s : Multiset M) :
     f s.prod = (s.map f).prod := (s.prod_hom f).symm
 
 @[to_additive]
-lemma _root_.map_multiset_ne_zero_prod [FunLike F α β] [MulHomClass F α β] (f : F)
-    {s : Multiset α} (hs : s ≠ 0):
+lemma _root_.map_multiset_ne_zero_prod [FunLike F M N] [MulHomClass F M N] (f : F)
+    {s : Multiset M} (hs : s ≠ 0):
     f s.prod = (s.map f).prod := (s.prod_hom_ne_zero hs f).symm
 
 @[to_additive]
-protected lemma _root_.MonoidHom.map_multiset_prod (f : α →* β) (s : Multiset α) :
+protected lemma _root_.MonoidHom.map_multiset_prod (f : M →* N) (s : Multiset M) :
     f s.prod = (s.map f).prod := (s.prod_hom f).symm
 
 @[to_additive]
-protected lemma _root_.MulHom.map_multiset_ne_zero_prod (f : α →ₙ* β) (s : Multiset α)
+protected lemma _root_.MulHom.map_multiset_ne_zero_prod (f : M →ₙ* N) (s : Multiset M)
     (hs : s ≠ 0) : f s.prod = (s.map f).prod := (s.prod_hom_ne_zero hs f).symm
 
 lemma dvd_prod : a ∈ s → a ∣ s.prod :=
   Quotient.inductionOn s (fun l a h ↦ by simpa using List.dvd_prod h) a
 
-@[to_additive] lemma fst_prod (s : Multiset (α × β)) : s.prod.1 = (s.map Prod.fst).prod :=
+@[to_additive] lemma fst_prod (s : Multiset (M × N)) : s.prod.1 = (s.map Prod.fst).prod :=
   map_multiset_prod (MonoidHom.fst _ _) _
 
-@[to_additive] lemma snd_prod (s : Multiset (α × β)) : s.prod.2 = (s.map Prod.snd).prod :=
+@[to_additive] lemma snd_prod (s : Multiset (M × N)) : s.prod.2 = (s.map Prod.snd).prod :=
   map_multiset_prod (MonoidHom.snd _ _) _
 
 end CommMonoid
 
-theorem prod_dvd_prod_of_dvd [CommMonoid β] {S : Multiset α} (g1 g2 : α → β)
+theorem prod_dvd_prod_of_dvd [CommMonoid N] {S : Multiset M} (g1 g2 : M → N)
     (h : ∀ a ∈ S, g1 a ∣ g2 a) : (Multiset.map g1 S).prod ∣ (Multiset.map g2 S).prod := by
   apply Multiset.induction_on' S
   · simp
@@ -160,28 +160,28 @@ theorem prod_dvd_prod_of_dvd [CommMonoid β] {S : Multiset α} (g1 g2 : α → �
 
 section AddCommMonoid
 
-variable [AddCommMonoid α]
+variable [AddCommMonoid M]
 
 /-- `Multiset.sum`, the sum of the elements of a multiset, promoted to a morphism of
 `AddCommMonoid`s. -/
-def sumAddMonoidHom : Multiset α →+ α where
+def sumAddMonoidHom : Multiset M →+ M where
   toFun := sum
   map_zero' := sum_zero
   map_add' := sum_add
 
 @[simp]
-theorem coe_sumAddMonoidHom : (sumAddMonoidHom : Multiset α → α) = sum :=
+theorem coe_sumAddMonoidHom : (sumAddMonoidHom : Multiset M → M) = sum :=
   rfl
 
 end AddCommMonoid
 
 section DivisionCommMonoid
 
-variable [DivisionCommMonoid α] {m : Multiset ι} {f g : ι → α}
+variable [DivisionCommMonoid M] {m : Multiset ι} {f g : ι → M}
 
 @[to_additive]
-theorem prod_map_inv' (m : Multiset α) : (m.map Inv.inv).prod = m.prod⁻¹ :=
-  m.prod_hom (invMonoidHom : α →* α)
+theorem prod_map_inv' (m : Multiset M) : (m.map Inv.inv).prod = m.prod⁻¹ :=
+  m.prod_hom (invMonoidHom : M →* M)
 
 @[to_additive (attr := simp)]
 theorem prod_map_inv : (m.map fun i => (f i)⁻¹).prod = (m.map f).prod⁻¹ := by
@@ -193,13 +193,13 @@ theorem prod_map_div : (m.map fun i => f i / g i).prod = (m.map f).prod / (m.map
 
 @[to_additive]
 theorem prod_map_zpow {n : ℤ} : (m.map fun i => f i ^ n).prod = (m.map f).prod ^ n := by
-  convert (m.map f).prod_hom (zpowGroupHom n : α →* α)
+  convert (m.map f).prod_hom (zpowGroupHom n : M →* M)
   simp only [map_map, Function.comp_apply, zpowGroupHom_apply]
 
 end DivisionCommMonoid
 
 @[simp]
-theorem sum_map_singleton (s : Multiset α) : (s.map fun a => ({a} : Multiset α)).sum = s :=
+theorem sum_map_singleton (s : Multiset M) : (s.map fun a => ({a} : Multiset M)).sum = s :=
   Multiset.induction_on s (by simp) (by simp)
 
 theorem sum_nat_mod (s : Multiset ℕ) (n : ℕ) : s.sum % n = (s.map (· % n)).sum % n := by
@@ -216,9 +216,9 @@ theorem prod_int_mod (s : Multiset ℤ) (n : ℤ) : s.prod % n = (s.map (· % n)
 
 section OrderedSub
 
-theorem sum_map_tsub [AddCommMonoid α] [PartialOrder α] [ExistsAddOfLE α]
-    [CovariantClass α α (· + ·) (· ≤ ·)] [ContravariantClass α α (· + ·) (· ≤ ·)] [Sub α]
-    [OrderedSub α] (l : Multiset ι) {f g : ι → α} (hfg : ∀ x ∈ l, g x ≤ f x) :
+theorem sum_map_tsub [AddCommMonoid M] [PartialOrder M] [ExistsAddOfLE M]
+    [CovariantClass M M (· + ·) (· ≤ ·)] [ContravariantClass M M (· + ·) (· ≤ ·)] [Sub M]
+    [OrderedSub M] (l : Multiset ι) {f g : ι → M} (hfg : ∀ x ∈ l, g x ≤ f x) :
     (l.map fun x ↦ f x - g x).sum = (l.map f).sum - (l.map g).sum :=
   eq_tsub_of_add_eq <| by
     rw [← sum_map_add]

--- a/Mathlib/Algebra/BigOperators/Group/Multiset/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Multiset/Basic.lean
@@ -24,7 +24,7 @@ and sums indexed by finite sets.
 
 assert_not_exists MonoidWithZero
 
-variable {F ι M N ι γ : Type*}
+variable {F ι κ M N O : Type*}
 
 namespace Multiset
 
@@ -93,13 +93,13 @@ theorem prod_hom' (s : Multiset ι) {F : Type*} [FunLike F M N]
   exact (map_map _ _ _).symm
 
 @[to_additive]
-theorem prod_hom₂_ne_zero [CommMonoid γ] {s : Multiset ι} (hs : s ≠ 0) (f : M → N → γ)
+theorem prod_hom₂_ne_zero [CommMonoid O] {s : Multiset ι} (hs : s ≠ 0) (f : M → N → O)
     (hf : ∀ a b c d, f (a * b) (c * d) = f a c * f b d) (f₁ : ι → M) (f₂ : ι → N) :
     (s.map fun i => f (f₁ i) (f₂ i)).prod = f (s.map f₁).prod (s.map f₂).prod := by
   induction s using Quotient.inductionOn; aesop (add simp List.prod_hom₂_nonempty)
 
 @[to_additive]
-theorem prod_hom₂ [CommMonoid γ] (s : Multiset ι) (f : M → N → γ)
+theorem prod_hom₂ [CommMonoid O] (s : Multiset ι) (f : M → N → O)
     (hf : ∀ a b c d, f (a * b) (c * d) = f a c * f b d) (hf' : f 1 1 = 1) (f₁ : ι → M)
     (f₂ : ι → N) : (s.map fun i => f (f₁ i) (f₂ i)).prod = f (s.map f₁).prod (s.map f₂).prod :=
   Quotient.inductionOn s fun l => by
@@ -114,7 +114,7 @@ theorem prod_map_pow {n : ℕ} : (m.map fun i => f i ^ n).prod = (m.map f).prod 
   m.prod_hom' (powMonoidHom n : M →* M) f
 
 @[to_additive]
-theorem prod_map_prod_map (m : Multiset ι) (n : Multiset γ) {f : ι → γ → M} :
+theorem prod_map_prod_map (m : Multiset ι) (n : Multiset κ) {f : ι → κ → M} :
     prod (m.map fun a => prod <| n.map fun b => f a b) =
       prod (n.map fun b => prod <| m.map fun a => f a b) :=
   Multiset.induction_on m (by simp) fun a m ih => by simp [ih]

--- a/Mathlib/Algebra/BigOperators/Group/Multiset/Defs.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Multiset/Defs.lean
@@ -23,83 +23,83 @@ and sums indexed by finite sets.
 
 assert_not_exists MonoidWithZero
 
-variable {F ι α β β' γ : Type*}
+variable {F ι M N : Type*}
 
 namespace Multiset
 
 section CommMonoid
 
-variable [CommMonoid α] [CommMonoid β] {s t : Multiset α} {a : α} {m : Multiset ι} {f g : ι → α}
+variable [CommMonoid M] [CommMonoid N] {s t : Multiset M} {a : M} {m : Multiset ι} {f g : ι → M}
 
-/-- Product of a multiset given a commutative monoid structure on `α`.
+/-- Product of a multiset given a commutative monoid structure on `M`.
   `prod {a, b, c} = a * b * c` -/
 @[to_additive
-      "Sum of a multiset given a commutative additive monoid structure on `α`.
+      "Sum of a multiset given a commutative additive monoid structure on `M`.
       `sum {a, b, c} = a + b + c`"]
-def prod : Multiset α → α :=
+def prod : Multiset M → M :=
   foldr (· * ·) 1
 
 @[to_additive]
-theorem prod_eq_foldr (s : Multiset α) :
+theorem prod_eq_foldr (s : Multiset M) :
     prod s = foldr (· * ·) 1 s :=
   rfl
 
 @[to_additive]
-theorem prod_eq_foldl (s : Multiset α) :
+theorem prod_eq_foldl (s : Multiset M) :
     prod s = foldl (· * ·) 1 s :=
   (foldr_swap _ _ _).trans (by simp [mul_comm])
 
 @[to_additive (attr := simp, norm_cast)]
-theorem prod_coe (l : List α) : prod ↑l = l.prod := rfl
+theorem prod_coe (l : List M) : prod ↑l = l.prod := rfl
 
 @[to_additive (attr := simp)]
-theorem prod_toList (s : Multiset α) : s.toList.prod = s.prod := by
+theorem prod_toList (s : Multiset M) : s.toList.prod = s.prod := by
   conv_rhs => rw [← coe_toList s]
   rw [prod_coe]
 
 @[to_additive (attr := simp)]
-theorem prod_zero : @prod α _ 0 = 1 :=
+theorem prod_zero : @prod M _ 0 = 1 :=
   rfl
 
 @[to_additive (attr := simp)]
-theorem prod_cons (a : α) (s) : prod (a ::ₘ s) = a * prod s :=
+theorem prod_cons (a : M) (s) : prod (a ::ₘ s) = a * prod s :=
   foldr_cons _ _ _ _
 
 @[to_additive (attr := simp)]
-theorem prod_singleton (a : α) : prod {a} = a := by
+theorem prod_singleton (a : M) : prod {a} = a := by
   simp only [mul_one, prod_cons, ← cons_zero, prod_zero]
 
 @[to_additive]
-theorem prod_pair (a b : α) : ({a, b} : Multiset α).prod = a * b := by
+theorem prod_pair (a b : M) : ({a, b} : Multiset M).prod = a * b := by
   rw [insert_eq_cons, prod_cons, prod_singleton]
 
 @[to_additive (attr := simp)]
-theorem prod_replicate (n : ℕ) (a : α) : (replicate n a).prod = a ^ n := by
+theorem prod_replicate (n : ℕ) (a : M) : (replicate n a).prod = a ^ n := by
   simp [replicate, List.prod_replicate]
 
 @[to_additive]
-theorem pow_count [DecidableEq α] (a : α) : a ^ s.count a = (s.filter (Eq a)).prod := by
+theorem pow_count [DecidableEq M] (a : M) : a ^ s.count a = (s.filter (Eq a)).prod := by
   rw [filter_eq, prod_replicate]
 
 @[to_additive]
-theorem prod_hom_rel (s : Multiset ι) {r : α → β → Prop} {f : ι → α} {g : ι → β}
+theorem prod_hom_rel (s : Multiset ι) {r : M → N → Prop} {f : ι → M} {g : ι → N}
     (h₁ : r 1 1) (h₂ : ∀ ⦃a b c⦄, r b c → r (f a * b) (g a * c)) :
     r (s.map f).prod (s.map g).prod :=
   Quotient.inductionOn s fun l => by
     simp only [l.prod_hom_rel h₁ h₂, quot_mk_to_coe, map_coe, prod_coe]
 
 @[to_additive]
-theorem prod_map_one : prod (m.map fun _ => (1 : α)) = 1 := by
+theorem prod_map_one : prod (m.map fun _ => (1 : M)) = 1 := by
   rw [map_const', prod_replicate, one_pow]
 
 @[to_additive]
-theorem prod_induction (p : α → Prop) (s : Multiset α) (p_mul : ∀ a b, p a → p b → p (a * b))
+theorem prod_induction (p : M → Prop) (s : Multiset M) (p_mul : ∀ a b, p a → p b → p (a * b))
     (p_one : p 1) (p_s : ∀ a ∈ s, p a) : p s.prod := by
   rw [prod_eq_foldr]
   exact foldr_induction (· * ·) 1 p s p_mul p_one p_s
 
 @[to_additive]
-theorem prod_induction_nonempty (p : α → Prop) (p_mul : ∀ a b, p a → p b → p (a * b)) (hs : s ≠ ∅)
+theorem prod_induction_nonempty (p : M → Prop) (p_mul : ∀ a b, p a → p b → p (a * b)) (hs : s ≠ ∅)
     (p_s : ∀ a ∈ s, p a) : p s.prod := by
   induction s using Multiset.induction_on with
   | empty => simp at hs

--- a/Mathlib/Algebra/BigOperators/GroupWithZero/Action.lean
+++ b/Mathlib/Algebra/BigOperators/GroupWithZero/Action.lean
@@ -23,68 +23,68 @@ Note that analogous lemmas for `Module`s like `Finset.sum_smul` appear in other 
 -/
 
 
-variable {α β γ : Type*}
+variable {M N γ : Type*}
 
 section
 
-variable [AddMonoid β] [DistribSMul α β]
+variable [AddMonoid N] [DistribSMul M N]
 
-theorem List.smul_sum {r : α} {l : List β} : r • l.sum = (l.map (r • ·)).sum :=
-  map_list_sum (DistribSMul.toAddMonoidHom β r) l
+theorem List.smul_sum {r : M} {l : List N} : r • l.sum = (l.map (r • ·)).sum :=
+  map_list_sum (DistribSMul.toAddMonoidHom N r) l
 
 end
 
 section
 
-variable [Monoid α] [Monoid β] [MulDistribMulAction α β]
+variable [Monoid M] [Monoid N] [MulDistribMulAction M N]
 
-theorem List.smul_prod' {r : α} {l : List β} : r • l.prod = (l.map (r • ·)).prod :=
-  map_list_prod (MulDistribMulAction.toMonoidHom β r) l
+theorem List.smul_prod' {r : M} {l : List N} : r • l.prod = (l.map (r • ·)).prod :=
+  map_list_prod (MulDistribMulAction.toMonoidHom N r) l
 
 end
 
 section
 
-variable [AddCommMonoid β] [DistribSMul α β] {r : α}
+variable [AddCommMonoid N] [DistribSMul M N] {r : M}
 
-theorem Multiset.smul_sum {s : Multiset β} : r • s.sum = (s.map (r • ·)).sum :=
-  (DistribSMul.toAddMonoidHom β r).map_multiset_sum s
+theorem Multiset.smul_sum {s : Multiset N} : r • s.sum = (s.map (r • ·)).sum :=
+  (DistribSMul.toAddMonoidHom N r).map_multiset_sum s
 
-theorem Finset.smul_sum {f : γ → β} {s : Finset γ} :
+theorem Finset.smul_sum {f : γ → N} {s : Finset γ} :
     (r • ∑ x ∈ s, f x) = ∑ x ∈ s, r • f x :=
-  map_sum (DistribSMul.toAddMonoidHom β r) f s
+  map_sum (DistribSMul.toAddMonoidHom N r) f s
 
-theorem smul_finsum_mem {f : γ → β} {s : Set γ} (hs : s.Finite) :
+theorem smul_finsum_mem {f : γ → N} {s : Set γ} (hs : s.Finite) :
     r • ∑ᶠ x ∈ s, f x = ∑ᶠ x ∈ s, r • f x :=
-  (DistribSMul.toAddMonoidHom β r).map_finsum_mem f hs
+  (DistribSMul.toAddMonoidHom N r).map_finsum_mem f hs
 
 end
 
 section
 
-variable [Monoid α] [CommMonoid β] [MulDistribMulAction α β]
+variable [Monoid M] [CommMonoid N] [MulDistribMulAction M N]
 
-theorem Multiset.smul_prod' {r : α} {s : Multiset β} : r • s.prod = (s.map (r • ·)).prod :=
-  (MulDistribMulAction.toMonoidHom β r).map_multiset_prod s
+theorem Multiset.smul_prod' {r : M} {s : Multiset N} : r • s.prod = (s.map (r • ·)).prod :=
+  (MulDistribMulAction.toMonoidHom N r).map_multiset_prod s
 
-theorem Finset.smul_prod' {r : α} {f : γ → β} {s : Finset γ} :
+theorem Finset.smul_prod' {r : M} {f : γ → N} {s : Finset γ} :
     (r • ∏ x ∈ s, f x) = ∏ x ∈ s, r • f x :=
-  map_prod (MulDistribMulAction.toMonoidHom β r) f s
+  map_prod (MulDistribMulAction.toMonoidHom N r) f s
 
-theorem smul_finprod' {ι : Sort*} [Finite ι] {f : ι → β} (r : α) :
+theorem smul_finprod' {ι : Sort*} [Finite ι] {f : ι → N} (r : M) :
     r • ∏ᶠ x : ι, f x = ∏ᶠ x : ι, r • (f x) := by
   cases nonempty_fintype (PLift ι)
   simp only [finprod_eq_prod_plift_of_mulSupport_subset (s := Finset.univ) (by simp),
     Finset.smul_prod']
 
-variable {G : Type*} [Group G] [MulDistribMulAction G β]
+variable {G : Type*} [Group G] [MulDistribMulAction G N]
 
-theorem Finset.smul_prod_perm [Fintype G] (b : β) (g : G) :
+theorem Finset.smul_prod_perm [Fintype G] (b : N) (g : G) :
     (g • ∏ h : G, h • b) = ∏ h : G, h • b := by
   simp only [smul_prod', smul_smul]
   exact Finset.prod_bijective (g * ·) (Group.mulLeft_bijective g) (by simp) (fun _ _ ↦ rfl)
 
-theorem smul_finprod_perm [Finite G] (b : β) (g : G) :
+theorem smul_finprod_perm [Finite G] (b : N) (g : G) :
     (g • ∏ᶠ h : G, h • b) = ∏ᶠ h : G, h • b := by
   cases nonempty_fintype G
   simp only [finprod_eq_prod_of_fintype, Finset.smul_prod_perm]
@@ -94,8 +94,8 @@ end
 namespace List
 
 @[to_additive]
-theorem smul_prod [Monoid α] [MulOneClass β] [MulAction α β] [IsScalarTower α β β]
-    [SMulCommClass α β β] (l : List β) (m : α) :
+theorem smul_prod [Monoid M] [MulOneClass N] [MulAction M N] [IsScalarTower M N N]
+    [SMulCommClass M N N] (l : List N) (m : M) :
     m ^ l.length • l.prod = (l.map (m • ·)).prod := by
   induction l with
   | nil => simp
@@ -106,8 +106,8 @@ end List
 namespace Multiset
 
 @[to_additive]
-theorem smul_prod [Monoid α] [CommMonoid β] [MulAction α β] [IsScalarTower α β β]
-    [SMulCommClass α β β] (s : Multiset β) (b : α) :
+theorem smul_prod [Monoid M] [CommMonoid N] [MulAction M N] [IsScalarTower M N N]
+    [SMulCommClass M N N] (s : Multiset N) (b : M) :
     b ^ card s • s.prod = (s.map (b • ·)).prod :=
   Quot.induction_on s <| by simp [List.smul_prod]
 
@@ -116,17 +116,17 @@ end Multiset
 namespace Finset
 
 theorem smul_prod
-    [CommMonoid β] [Monoid α] [MulAction α β] [IsScalarTower α β β] [SMulCommClass α β β]
-    (s : Finset β) (b : α) (f : β → β) :
+    [CommMonoid N] [Monoid M] [MulAction M N] [IsScalarTower M N N] [SMulCommClass M N N]
+    (s : Finset N) (b : M) (f : N → N) :
     b ^ s.card • ∏ x ∈ s, f x = ∏ x ∈ s, b • f x := by
-  have : Multiset.map (fun (x : β) ↦ b • f x) s.val =
+  have : Multiset.map (fun (x : N) ↦ b • f x) s.val =
       Multiset.map (fun x ↦ b • x) (Multiset.map f s.val) := by
     simp only [Multiset.map_map, Function.comp_apply]
   simp_rw [prod_eq_multiset_prod, card_def, this, ← Multiset.smul_prod _ b, Multiset.card_map]
 
 theorem prod_smul
-    [CommMonoid β] [CommMonoid α] [MulAction α β] [IsScalarTower α β β] [SMulCommClass α β β]
-    (s : Finset β) (b : β → α) (f : β → β) :
+    [CommMonoid N] [CommMonoid M] [MulAction M N] [IsScalarTower M N N] [SMulCommClass M N N]
+    (s : Finset N) (b : N → M) (f : N → N) :
     ∏ i ∈ s, b i • f i = (∏ i ∈ s, b i) • ∏ i ∈ s, f i := by
   induction s using Finset.cons_induction_on with
   | empty =>  simp

--- a/Mathlib/Algebra/BigOperators/Intervals.lean
+++ b/Mathlib/Algebra/BigOperators/Intervals.lean
@@ -3,13 +3,10 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
-import Mathlib.Algebra.BigOperators.Group.Finset.Sigma
+import Mathlib.Algebra.Order.BigOperators.Group.LocallyFinite
 import Mathlib.Algebra.Order.Interval.Finset.Basic
-import Mathlib.Algebra.Order.Interval.Finset.SuccPred
 import Mathlib.Algebra.Order.Sub.Basic
 import Mathlib.Data.Nat.Factorial.Basic
-import Mathlib.Data.Nat.SuccPred
-import Mathlib.Order.Interval.Finset.Nat
 
 /-!
 # Results about big operators over intervals

--- a/Mathlib/Algebra/BigOperators/Intervals.lean
+++ b/Mathlib/Algebra/BigOperators/Intervals.lean
@@ -52,12 +52,6 @@ theorem prod_Ico_succ_top {a b : ℕ} (hab : a ≤ b) (f : ℕ → M) :
   rw [← Finset.insert_Ico_right_eq_Ico_add_one hab, prod_insert right_notMem_Ico, mul_comm]
 
 @[to_additive]
-theorem prod_eq_prod_Ico_succ_bot {a b : ℕ} (hab : a < b) (f : ℕ → M) :
-    ∏ k ∈ Ico a b, f k = f a * ∏ k ∈ Ico (a + 1) b, f k := by
-  have ha : a ∉ Ico (a + 1) b := by simp
-  rw [← prod_insert ha, ← Finset.insert_Ico_add_one_left_eq_Ico  hab]
-
-@[to_additive]
 theorem prod_Ico_consecutive (f : ℕ → M) {m n k : ℕ} (hmn : m ≤ n) (hnk : n ≤ k) :
     ((∏ i ∈ Ico m n, f i) * ∏ i ∈ Ico n k, f i) = ∏ i ∈ Ico m k, f i :=
   Ico_union_Ico_eq_Ico hmn hnk ▸ Eq.symm (prod_union (Ico_disjoint_Ico_consecutive m n k))

--- a/Mathlib/Algebra/BigOperators/Intervals.lean
+++ b/Mathlib/Algebra/BigOperators/Intervals.lean
@@ -19,7 +19,7 @@ We prove results about big operators over intervals.
 
 open Nat
 
-variable {α M : Type*}
+variable {α G M : Type*}
 
 namespace Finset
 
@@ -101,7 +101,7 @@ theorem prod_Ico_eq_div {δ : Type*} [CommGroup δ] (f : ℕ → δ) {m n : ℕ}
   simpa only [div_eq_mul_inv] using prod_Ico_eq_mul_inv f h
 
 @[to_additive]
-theorem prod_range_div_prod_range {α : Type*} [CommGroup α] {f : ℕ → α} {n m : ℕ} (hnm : n ≤ m) :
+theorem prod_range_div_prod_range {G : Type*} [CommGroup G] {f : ℕ → G} {n m : ℕ} (hnm : n ≤ m) :
     ((∏ k ∈ range m, f k) / ∏ k ∈ range n, f k) = ∏ k ∈ range m with n ≤ k, f k := by
   rw [← prod_Ico_eq_div f hnm]
   congr

--- a/Mathlib/Algebra/BigOperators/Pi.lean
+++ b/Mathlib/Algebra/BigOperators/Pi.lean
@@ -21,42 +21,42 @@ of monoids and groups
 
 open scoped Finset
 
-variable {ι κ α : Type*}
+variable {ι κ M N R α : Type*}
 
 namespace Pi
 
 @[to_additive]
-theorem list_prod_apply {α : Type*} {β : α → Type*} [∀ a, Monoid (β a)] (a : α)
-    (l : List (∀ a, β a)) : l.prod a = (l.map fun f : ∀ a, β a ↦ f a).prod :=
-  map_list_prod (evalMonoidHom β a) _
+theorem list_prod_apply {α : Type*} {M : α → Type*} [∀ a, Monoid (M a)] (a : α)
+    (l : List (∀ a, M a)) : l.prod a = (l.map fun f : ∀ a, M a ↦ f a).prod :=
+  map_list_prod (evalMonoidHom M a) _
 
 @[to_additive]
-theorem multiset_prod_apply {α : Type*} {β : α → Type*} [∀ a, CommMonoid (β a)] (a : α)
-    (s : Multiset (∀ a, β a)) : s.prod a = (s.map fun f : ∀ a, β a ↦ f a).prod :=
-  (evalMonoidHom β a).map_multiset_prod _
+theorem multiset_prod_apply {α : Type*} {M : α → Type*} [∀ a, CommMonoid (M a)] (a : α)
+    (s : Multiset (∀ a, M a)) : s.prod a = (s.map fun f : ∀ a, M a ↦ f a).prod :=
+  (evalMonoidHom M a).map_multiset_prod _
 
 end Pi
 
 @[to_additive (attr := simp)]
-theorem Finset.prod_apply {α : Type*} {β : α → Type*} {γ} [∀ a, CommMonoid (β a)] (a : α)
-    (s : Finset γ) (g : γ → ∀ a, β a) : (∏ c ∈ s, g c) a = ∏ c ∈ s, g c a :=
-  map_prod (Pi.evalMonoidHom β a) _ _
+theorem Finset.prod_apply {α : Type*} {M : α → Type*} [∀ a, CommMonoid (M a)] (a : α)
+    (s : Finset ι) (g : ι → ∀ a, M a) : (∏ c ∈ s, g c) a = ∏ c ∈ s, g c a :=
+  map_prod (Pi.evalMonoidHom M a) _ _
 
 /-- An 'unapplied' analogue of `Finset.prod_apply`. -/
 @[to_additive "An 'unapplied' analogue of `Finset.sum_apply`."]
-theorem Finset.prod_fn {α : Type*} {β : α → Type*} {γ} [∀ a, CommMonoid (β a)] (s : Finset γ)
-    (g : γ → ∀ a, β a) : ∏ c ∈ s, g c = fun a ↦ ∏ c ∈ s, g c a :=
+theorem Finset.prod_fn {α : Type*} {M : α → Type*} {ι} [∀ a, CommMonoid (M a)] (s : Finset ι)
+    (g : ι → ∀ a, M a) : ∏ c ∈ s, g c = fun a ↦ ∏ c ∈ s, g c a :=
   funext fun _ ↦ Finset.prod_apply _ _ _
 
 @[to_additive]
-theorem Fintype.prod_apply {α : Type*} {β : α → Type*} {γ : Type*} [Fintype γ]
-    [∀ a, CommMonoid (β a)] (a : α) (g : γ → ∀ a, β a) : (∏ c, g c) a = ∏ c, g c a :=
+theorem Fintype.prod_apply {α : Type*} {M : α → Type*} [Fintype ι] [∀ a, CommMonoid (M a)] (a : α)
+    (g : ι → ∀ a, M a) : (∏ c, g c) a = ∏ c, g c a :=
   Finset.prod_apply a Finset.univ g
 
 @[to_additive prod_mk_sum]
-theorem prod_mk_prod {α β γ : Type*} [CommMonoid α] [CommMonoid β] (s : Finset γ) (f : γ → α)
-    (g : γ → β) : (∏ x ∈ s, f x, ∏ x ∈ s, g x) = ∏ x ∈ s, (f x, g x) :=
-  haveI := Classical.decEq γ
+theorem prod_mk_prod [CommMonoid M] [CommMonoid N] (s : Finset ι) (f : ι → M) (g : ι → N) :
+    (∏ x ∈ s, f x, ∏ x ∈ s, g x) = ∏ x ∈ s, (f x, g x) :=
+  haveI := Classical.decEq ι
   Finset.induction_on s rfl (by simp +contextual [Prod.ext_iff])
 
 /-- decomposing `x : ι → R` as a sum along the canonical basis -/
@@ -66,9 +66,9 @@ theorem pi_eq_sum_univ {ι : Type*} [Fintype ι] [DecidableEq ι] {R : Type*} [N
   simp
 
 section CommSemiring
-variable [CommSemiring α]
+variable [CommSemiring R]
 
-lemma prod_indicator_apply (s : Finset ι) (f : ι → Set κ) (g : ι → κ → α) (j : κ) :
+lemma prod_indicator_apply (s : Finset ι) (f : ι → Set κ) (g : ι → κ → R) (j : κ) :
     ∏ i ∈ s, (f i).indicator (g i) j = (⋂ x ∈ s, f x).indicator (∏ i ∈ s, g i) j := by
   rw [Set.indicator]
   split_ifs with hj
@@ -79,32 +79,32 @@ lemma prod_indicator_apply (s : Finset ι) (f : ι → Set κ) (g : ι → κ �
   · obtain ⟨i, hi, hj⟩ := by simpa using hj
     exact Finset.prod_eq_zero hi <| Set.indicator_of_notMem hj _
 
-lemma prod_indicator (s : Finset ι) (f : ι → Set κ) (g : ι → κ → α) :
+lemma prod_indicator (s : Finset ι) (f : ι → Set κ) (g : ι → κ → R) :
     ∏ i ∈ s, (f i).indicator (g i) = (⋂ x ∈ s, f x).indicator (∏ i ∈ s, g i) := by
   ext a; simpa using prod_indicator_apply ..
 
-lemma prod_indicator_const_apply (s : Finset ι) (f : ι → Set κ) (g : κ → α) (j : κ) :
+lemma prod_indicator_const_apply (s : Finset ι) (f : ι → Set κ) (g : κ → R) (j : κ) :
     ∏ i ∈ s, (f i).indicator g j = (⋂ x ∈ s, f x).indicator (g ^ #s) j := by
   simp [prod_indicator_apply]
 
-lemma prod_indicator_const (s : Finset ι) (f : ι → Set κ) (g : κ → α) :
+lemma prod_indicator_const (s : Finset ι) (f : ι → Set κ) (g : κ → R) :
     ∏ i ∈ s, (f i).indicator g = (⋂ x ∈ s, f x).indicator (g ^ #s) := by simp [prod_indicator]
 
 end CommSemiring
 
 section MulSingle
 
-variable {I : Type*} [DecidableEq I] {Z : I → Type*}
-variable [∀ i, CommMonoid (Z i)]
+variable {I : Type*} [DecidableEq I] {M : I → Type*}
+variable [∀ i, CommMonoid (M i)]
 
 @[to_additive]
-theorem Finset.univ_prod_mulSingle [Fintype I] (f : ∀ i, Z i) :
+theorem Finset.univ_prod_mulSingle [Fintype I] (f : ∀ i, M i) :
     (∏ i, Pi.mulSingle i (f i)) = f := by
   ext a
   simp
 
 @[to_additive]
-theorem MonoidHom.functions_ext [Finite I] (G : Type*) [CommMonoid G] (g h : (∀ i, Z i) →* G)
+theorem MonoidHom.functions_ext [Finite I] (G : Type*) [CommMonoid G] (g h : (∀ i, M i) →* G)
     (H : ∀ i x, g (Pi.mulSingle i x) = h (Pi.mulSingle i x)) : g = h := by
   cases nonempty_fintype I
   ext k
@@ -116,9 +116,9 @@ note [partially-applied ext lemmas]. -/
 @[to_additive (attr := ext)
       "\nThis is used as the ext lemma instead of `AddMonoidHom.functions_ext` for reasons
       explained in note [partially-applied ext lemmas]."]
-theorem MonoidHom.functions_ext' [Finite I] (M : Type*) [CommMonoid M] (g h : (∀ i, Z i) →* M)
-    (H : ∀ i, g.comp (MonoidHom.mulSingle Z i) = h.comp (MonoidHom.mulSingle Z i)) : g = h :=
-  g.functions_ext M h fun i => DFunLike.congr_fun (H i)
+theorem MonoidHom.functions_ext' [Finite I] (N : Type*) [CommMonoid N] (g h : (∀ i, M i) →* N)
+    (H : ∀ i, g.comp (MonoidHom.mulSingle M i) = h.comp (MonoidHom.mulSingle M i)) : g = h :=
+  g.functions_ext N h fun i => DFunLike.congr_fun (H i)
 
 end MulSingle
 
@@ -126,28 +126,28 @@ section RingHom
 
 open Pi
 
-variable {I : Type*} [DecidableEq I] {f : I → Type*}
-variable [∀ i, NonAssocSemiring (f i)]
+variable {I : Type*} [DecidableEq I] {R : I → Type*}
+variable [∀ i, NonAssocSemiring (R i)]
 
 @[ext]
-theorem RingHom.functions_ext [Finite I] (G : Type*) [NonAssocSemiring G] (g h : (∀ i, f i) →+* G)
-    (H : ∀ (i : I) (x : f i), g (single i x) = h (single i x)) : g = h :=
+theorem RingHom.functions_ext [Finite I] (G : Type*) [NonAssocSemiring G] (g h : (∀ i, R i) →+* G)
+    (H : ∀ (i : I) (x : R i), g (single i x) = h (single i x)) : g = h :=
   RingHom.coe_addMonoidHom_injective <|
-    @AddMonoidHom.functions_ext I _ f _ _ G _ (g : (∀ i, f i) →+ G) h H
+    @AddMonoidHom.functions_ext I _ R _ _ G _ (g : (∀ i, R i) →+ G) h H
 
 end RingHom
 
 namespace Prod
 
-variable {α β γ : Type*} [CommMonoid α] [CommMonoid β] {s : Finset γ} {f : γ → α × β}
+variable [CommMonoid M] [CommMonoid N] {s : Finset ι} {f : ι → M × N}
 
 @[to_additive]
 theorem fst_prod : (∏ c ∈ s, f c).1 = ∏ c ∈ s, (f c).1 :=
-  map_prod (MonoidHom.fst α β) f s
+  map_prod (MonoidHom.fst ..) f s
 
 @[to_additive]
 theorem snd_prod : (∏ c ∈ s, f c).2 = ∏ c ∈ s, (f c).2 :=
-  map_prod (MonoidHom.snd α β) f s
+  map_prod (MonoidHom.snd ..) f s
 
 end Prod
 

--- a/Mathlib/Algebra/BigOperators/Pi.lean
+++ b/Mathlib/Algebra/BigOperators/Pi.lean
@@ -104,7 +104,7 @@ theorem Finset.univ_prod_mulSingle [Fintype I] (f : ∀ i, M i) :
   simp
 
 @[to_additive]
-theorem MonoidHom.functions_ext [Finite I] (G : Type*) [CommMonoid G] (g h : (∀ i, M i) →* G)
+theorem MonoidHom.functions_ext [Finite I] (N : Type*) [CommMonoid N] (g h : (∀ i, M i) →* N)
     (H : ∀ i x, g (Pi.mulSingle i x) = h (Pi.mulSingle i x)) : g = h := by
   cases nonempty_fintype I
   ext k
@@ -130,10 +130,10 @@ variable {I : Type*} [DecidableEq I] {R : I → Type*}
 variable [∀ i, NonAssocSemiring (R i)]
 
 @[ext]
-theorem RingHom.functions_ext [Finite I] (G : Type*) [NonAssocSemiring G] (g h : (∀ i, R i) →+* G)
+theorem RingHom.functions_ext [Finite I] (S : Type*) [NonAssocSemiring S] (g h : (∀ i, R i) →+* S)
     (H : ∀ (i : I) (x : R i), g (single i x) = h (single i x)) : g = h :=
   RingHom.coe_addMonoidHom_injective <|
-    @AddMonoidHom.functions_ext I _ R _ _ G _ (g : (∀ i, R i) →+ G) h H
+    @AddMonoidHom.functions_ext I _ R _ _ S _ (g : (∀ i, R i) →+ S) h H
 
 end RingHom
 

--- a/Mathlib/Algebra/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Ring/Finset.lean
@@ -22,54 +22,55 @@ assert_not_exists Field
 
 open Fintype
 
-variable {ι ι' α β γ : Type*} {κ : ι → Type*} {s s₁ s₂ : Finset ι} {i : ι} {a : α} {f g : ι → α}
+variable {ι ι' M₀ R α : Type*} {κ : ι → Type*} {s s₁ s₂ : Finset ι} {i : ι} {a : α} {f g : ι → α}
 
 namespace Finset
 
-lemma prod_neg [CommMonoid α] [HasDistribNeg α] : ∏ x ∈ s, -f x = (-1) ^ #s * ∏ x ∈ s, f x := by
+lemma prod_neg [CommMonoid M₀] [HasDistribNeg M₀] (f : ι → M₀) :
+    ∏ x ∈ s, -f x = (-1) ^ #s * ∏ x ∈ s, f x := by
   simpa using (s.1.map f).prod_map_neg
 
 section AddCommMonoidWithOne
-variable [AddCommMonoidWithOne α]
+variable [AddCommMonoidWithOne R]
 
 lemma natCast_card_filter (p) [DecidablePred p] (s : Finset ι) :
-    (#{x ∈ s | p x} : α) = ∑ a ∈ s, if p a then (1 : α) else 0 := by
+    (#{x ∈ s | p x} : R) = ∑ a ∈ s, if p a then (1 : R) else 0 := by
   rw [sum_ite, sum_const_zero, add_zero, sum_const, nsmul_one]
 
 @[simp] lemma sum_boole (p) [DecidablePred p] (s : Finset ι) :
-    (∑ x ∈ s, if p x then 1 else 0 : α) = #{x ∈ s | p x} :=
+    (∑ x ∈ s, if p x then 1 else 0 : R) = #{x ∈ s | p x} :=
   (natCast_card_filter _ _).symm
 
 end AddCommMonoidWithOne
 
 section NonUnitalNonAssocSemiring
-variable [NonUnitalNonAssocSemiring α]
+variable [NonUnitalNonAssocSemiring R]
 
-lemma sum_mul (s : Finset ι) (f : ι → α) (a : α) :
+lemma sum_mul (s : Finset ι) (f : ι → R) (a : R) :
     (∑ i ∈ s, f i) * a = ∑ i ∈ s, f i * a := map_sum (AddMonoidHom.mulRight a) _ s
 
-lemma mul_sum (s : Finset ι) (f : ι → α) (a : α) :
+lemma mul_sum (s : Finset ι) (f : ι → R) (a : R) :
     a * ∑ i ∈ s, f i = ∑ i ∈ s, a * f i := map_sum (AddMonoidHom.mulLeft a) _ s
 
-lemma sum_mul_sum {κ : Type*} (s : Finset ι) (t : Finset κ) (f : ι → α) (g : κ → α) :
+lemma sum_mul_sum {κ : Type*} (s : Finset ι) (t : Finset κ) (f : ι → R) (g : κ → R) :
     (∑ i ∈ s, f i) * ∑ j ∈ t, g j = ∑ i ∈ s, ∑ j ∈ t, f i * g j := by
   simp_rw [sum_mul, ← mul_sum]
 
-lemma _root_.Fintype.sum_mul_sum {κ : Type*} [Fintype ι] [Fintype κ] (f : ι → α) (g : κ → α) :
+lemma _root_.Fintype.sum_mul_sum {κ : Type*} [Fintype ι] [Fintype κ] (f : ι → R) (g : κ → R) :
     (∑ i, f i) * ∑ j, g j = ∑ i, ∑ j, f i * g j :=
   Finset.sum_mul_sum _ _ _ _
 
-lemma _root_.Commute.sum_right (s : Finset ι) (f : ι → α) (b : α)
+lemma _root_.Commute.sum_right (s : Finset ι) (f : ι → R) (b : R)
     (h : ∀ i ∈ s, Commute b (f i)) : Commute b (∑ i ∈ s, f i) :=
   (Commute.multiset_sum_right _ _) fun b hb => by
     obtain ⟨i, hi, rfl⟩ := Multiset.mem_map.mp hb
     exact h _ hi
 
-lemma _root_.Commute.sum_left (s : Finset ι) (f : ι → α) (b : α)
+lemma _root_.Commute.sum_left (s : Finset ι) (f : ι → R) (b : R)
     (h : ∀ i ∈ s, Commute (f i) b) : Commute (∑ i ∈ s, f i) b :=
   ((Commute.sum_right _ _ _) fun _i hi => (h _ hi).symm).symm
 
-lemma sum_range_succ_mul_sum_range_succ (m n : ℕ) (f g : ℕ → α) :
+lemma sum_range_succ_mul_sum_range_succ (m n : ℕ) (f g : ℕ → R) :
     (∑ i ∈ range (m + 1), f i) * ∑ i ∈ range (n + 1), g i =
       (∑ i ∈ range m, f i) * ∑ i ∈ range n, g i +
         f m * ∑ i ∈ range n, g i + (∑ i ∈ range m, f i) * g n + f m * g n := by
@@ -78,7 +79,7 @@ lemma sum_range_succ_mul_sum_range_succ (m n : ℕ) (f g : ℕ → α) :
 end NonUnitalNonAssocSemiring
 
 section NonUnitalSemiring
-variable [NonUnitalSemiring α]
+variable [NonUnitalSemiring R] {f : ι → R} {a : R}
 
 lemma dvd_sum (h : ∀ i ∈ s, a ∣ f i) : a ∣ ∑ i ∈ s, f i :=
   Multiset.dvd_sum fun y hy => by rcases Multiset.mem_map.1 hy with ⟨x, hx, rfl⟩; exact h x hx
@@ -86,22 +87,22 @@ lemma dvd_sum (h : ∀ i ∈ s, a ∣ f i) : a ∣ ∑ i ∈ s, f i :=
 end NonUnitalSemiring
 
 section NonAssocSemiring
-variable [NonAssocSemiring α] [DecidableEq ι]
+variable [NonAssocSemiring R] [DecidableEq ι]
 
-lemma sum_mul_boole (s : Finset ι) (f : ι → α) (i : ι) :
+lemma sum_mul_boole (s : Finset ι) (f : ι → R) (i : ι) :
     ∑ j ∈ s, f j * ite (i = j) 1 0 = ite (i ∈ s) (f i) 0 := by simp
 
-lemma sum_boole_mul (s : Finset ι) (f : ι → α) (i : ι) :
+lemma sum_boole_mul (s : Finset ι) (f : ι → R) (i : ι) :
     ∑ j ∈ s, ite (i = j) 1 0 * f j = ite (i ∈ s) (f i) 0 := by simp
 
 end NonAssocSemiring
 
 section CommSemiring
-variable [CommSemiring α]
+variable [CommSemiring R]
 
 /-- If `f = g = h` everywhere but at `i`, where `f i = g i + h i`, then the product of `f` over `s`
   is the sum of the products of `g` and `h`. -/
-theorem prod_add_prod_eq {s : Finset ι} {i : ι} {f g h : ι → α} (hi : i ∈ s)
+theorem prod_add_prod_eq {s : Finset ι} {i : ι} {f g h : ι → R} (hi : i ∈ s)
     (h1 : g i + h i = f i) (h2 : ∀ j ∈ s, j ≠ i → g j = f j) (h3 : ∀ j ∈ s, j ≠ i → h j = f j) :
     (∏ i ∈ s, g i) + ∏ i ∈ s, h i = ∏ i ∈ s, f i := by
   classical
@@ -113,7 +114,7 @@ variable [DecidableEq ι]
 
 /-- The product over a sum can be written as a sum over the product of sets, `Finset.Pi`.
   `Finset.prod_univ_sum` is an alternative statement when the product is over `univ`. -/
-lemma prod_sum (s : Finset ι) (t : ∀ i, Finset (κ i)) (f : ∀ i, κ i → α) :
+lemma prod_sum (s : Finset ι) (t : ∀ i, Finset (κ i)) (f : ∀ i, κ i → R) :
     ∏ a ∈ s, ∑ b ∈ t a, f a b = ∑ p ∈ s.pi t, ∏ x ∈ s.attach, f x.1 (p x.1 x.2) := by
   classical
   induction s using Finset.induction with
@@ -146,21 +147,21 @@ lemma prod_sum (s : Finset ι) (t : ∀ i, Finset (κ i)) (f : ∀ i, κ i → �
 /-- The product over `univ` of a sum can be written as a sum over the product of sets,
 `Fintype.piFinset`. `Finset.prod_sum` is an alternative statement when the product is not
 over `univ`. -/
-lemma prod_univ_sum [Fintype ι] (t : ∀ i, Finset (κ i)) (f : ∀ i, κ i → α) :
+lemma prod_univ_sum [Fintype ι] (t : ∀ i, Finset (κ i)) (f : ∀ i, κ i → R) :
     ∏ i, ∑ j ∈ t i, f i j = ∑ x ∈ piFinset t, ∏ i, f i (x i) := by
   simp only [prod_attach_univ, prod_sum, Finset.sum_univ_pi]
 
-lemma sum_prod_piFinset {κ : Type*} [Fintype ι] (s : Finset κ) (g : ι → κ → α) :
+lemma sum_prod_piFinset {κ : Type*} [Fintype ι] (s : Finset κ) (g : ι → κ → R) :
     ∑ f ∈ piFinset fun _ : ι ↦ s, ∏ i, g i (f i) = ∏ i, ∑ j ∈ s, g i j := by
   rw [← prod_univ_sum]
 
-lemma sum_pow' (s : Finset ι') (f : ι' → α) (n : ℕ) :
+lemma sum_pow' (s : Finset ι') (f : ι' → R) (n : ℕ) :
     (∑ a ∈ s, f a) ^ n = ∑ p ∈ piFinset fun _i : Fin n ↦ s, ∏ i, f (p i) := by
   convert @prod_univ_sum (Fin n) _ _ _ _ _ (fun _i ↦ s) fun _i d ↦ f d; simp
 
 /-- The product of `f a + g a` over all of `s` is the sum over the powerset of `s` of the product of
 `f` over a subset `t` times the product of `g` over the complement of `t` -/
-theorem prod_add (f g : ι → α) (s : Finset ι) :
+theorem prod_add (f g : ι → R) (s : Finset ι) :
     ∏ i ∈ s, (f i + g i) = ∑ t ∈ s.powerset, (∏ i ∈ t, f i) * ∏ i ∈ s \ t, g i := by
   classical
   calc
@@ -185,16 +186,16 @@ theorem prod_add (f g : ι → α) (s : Finset ι) :
 
 end DecidableEq
 
-theorem prod_one_add {f : ι → α} (s : Finset ι) :
+theorem prod_one_add {f : ι → R} (s : Finset ι) :
     ∏ i ∈ s, (1 + f i) = ∑ t ∈ s.powerset, ∏ i ∈ t, f i := by
-  classical simp only [add_comm (1 : α), prod_add, prod_const_one, mul_one]
+  classical simp only [add_comm (1 : R), prod_add, prod_const_one, mul_one]
 
-theorem prod_add_one {f : ι → α} (s : Finset ι) :
+theorem prod_add_one {f : ι → R} (s : Finset ι) :
     ∏ i ∈ s, (f i + 1) = ∑ t ∈ s.powerset, ∏ i ∈ t, f i := by
   classical simp only [prod_add, prod_const_one, mul_one]
 
 /-- `∏ i, (f i + g i) = (∏ i, f i) + ∑ i, g i * (∏ j < i, f j + g j) * (∏ j > i, f j)`. -/
-theorem prod_add_ordered [LinearOrder ι] (s : Finset ι) (f g : ι → α) :
+theorem prod_add_ordered [LinearOrder ι] (s : Finset ι) (f g : ι → R) :
     ∏ i ∈ s, (f i + g i) =
       (∏ i ∈ s, f i) +
         ∑ i ∈ s, g i * (∏ j ∈ s with j < i, (f j + g j)) * ∏ j ∈ s with i < j, f j := by
@@ -217,7 +218,7 @@ theorem prod_add_ordered [LinearOrder ι] (s : Finset ι) (f g : ι → α) :
 
 /-- Summing `a ^ #t * b ^ (n - #t)` over all finite subsets `t` of a finset `s`
 gives `(a + b) ^ #s`. -/
-theorem sum_pow_mul_eq_add_pow (a b : α) (s : Finset ι) :
+theorem sum_pow_mul_eq_add_pow (a b : R) (s : Finset ι) :
     (∑ t ∈ s.powerset, a ^ #t * b ^ (#s - #t)) = (a + b) ^ #s := by
   classical
   rw [← prod_const, prod_add]
@@ -228,27 +229,27 @@ theorem sum_pow_mul_eq_add_pow (a b : α) (s : Finset ι) :
 gives `(a + b)^n`. The "good" proof involves expanding along all coordinates using the fact that
 `x^n` is multilinear, but multilinear maps are only available now over rings, so we give instead
 a proof reducing to the usual binomial theorem to have a result over semirings. -/
-lemma _root_.Fintype.sum_pow_mul_eq_add_pow (ι : Type*) [Fintype ι] (a b : α) :
+lemma _root_.Fintype.sum_pow_mul_eq_add_pow (ι : Type*) [Fintype ι] (a b : R) :
     ∑ s : Finset ι, a ^ #s * b ^ (Fintype.card ι - #s) = (a + b) ^ Fintype.card ι :=
   Finset.sum_pow_mul_eq_add_pow _ _ _
 
 @[norm_cast]
-theorem prod_natCast (s : Finset ι) (f : ι → ℕ) : ↑(∏ i ∈ s, f i : ℕ) = ∏ i ∈ s, (f i : α) :=
-  map_prod (Nat.castRingHom α) f s
+theorem prod_natCast (s : Finset ι) (f : ι → ℕ) : ↑(∏ i ∈ s, f i : ℕ) = ∏ i ∈ s, (f i : R) :=
+  map_prod (Nat.castRingHom R) f s
 
 end CommSemiring
 
 section CommRing
-variable [CommRing α]
+variable [CommRing R]
 
 /-- The product of `f i - g i` over all of `s` is the sum over the powerset of `s` of the product of
 `g` over a subset `t` times the product of `f` over the complement of `t` times `(-1) ^ #t`. -/
-lemma prod_sub [DecidableEq ι] (f g : ι → α) (s : Finset ι) :
+lemma prod_sub [DecidableEq ι] (f g : ι → R) (s : Finset ι) :
     ∏ i ∈ s, (f i - g i) = ∑ t ∈ s.powerset, (-1) ^ #t * (∏ i ∈ s \ t, f i) * ∏ i ∈ t, g i := by
   simp [sub_eq_neg_add, prod_add, prod_neg, mul_right_comm]
 
 /-- `∏ i, (f i - g i) = (∏ i, f i) - ∑ i, g i * (∏ j < i, f j - g j) * (∏ j > i, f j)`. -/
-lemma prod_sub_ordered [LinearOrder ι] (s : Finset ι) (f g : ι → α) :
+lemma prod_sub_ordered [LinearOrder ι] (s : Finset ι) (f g : ι → R) :
     ∏ i ∈ s, (f i - g i) =
       (∏ i ∈ s, f i) -
         ∑ i ∈ s, g i * (∏ j ∈ s with j < i, (f j - g j)) * ∏ j ∈ s with i < j, f j := by
@@ -258,13 +259,13 @@ lemma prod_sub_ordered [LinearOrder ι] (s : Finset ι) (f g : ι → α) :
 
 /-- `∏ i, (1 - f i) = 1 - ∑ i, f i * (∏ j < i, 1 - f j)`. This formula is useful in construction of
 a partition of unity from a collection of “bump” functions. -/
-theorem prod_one_sub_ordered [LinearOrder ι] (s : Finset ι) (f : ι → α) :
+theorem prod_one_sub_ordered [LinearOrder ι] (s : Finset ι) (f : ι → R) :
     ∏ i ∈ s, (1 - f i) = 1 - ∑ i ∈ s, f i * ∏ j ∈ s with j < i, (1 - f j) := by
   rw [prod_sub_ordered]
   simp
 
 theorem prod_range_natCast_sub (n k : ℕ) :
-    ∏ i ∈ range k, (n - i : α) = (∏ i ∈ range k, (n - i) : ℕ) := by
+    ∏ i ∈ range k, (n - i : R) = (∏ i ∈ range k, (n - i) : ℕ) := by
   rw [prod_natCast]
   rcases le_or_gt k n with hkn | hnk
   · exact prod_congr rfl fun i hi => (Nat.cast_sub <| (mem_range.1 hi).le.trans hkn).symm
@@ -277,18 +278,18 @@ end Finset
 open Finset
 
 namespace Fintype
-variable {ι κ α : Type*} [Fintype ι] [Fintype κ] [CommSemiring α]
+variable {ι κ R : Type*} [Fintype ι] [Fintype κ] [CommSemiring R]
 
-lemma sum_pow (f : ι → α) (n : ℕ) : (∑ a, f a) ^ n = ∑ p : Fin n → ι, ∏ i, f (p i) := by
+lemma sum_pow (f : ι → R) (n : ℕ) : (∑ a, f a) ^ n = ∑ p : Fin n → ι, ∏ i, f (p i) := by
   simp [sum_pow']
 
 variable [DecidableEq ι]
 
 /-- A product of sums can be written as a sum of products. -/
-lemma prod_sum {κ : ι → Type*} [∀ i, Fintype (κ i)] (f : ∀ i, κ i → α) :
+lemma prod_sum {κ : ι → Type*} [∀ i, Fintype (κ i)] (f : ∀ i, κ i → R) :
     ∏ i, ∑ j, f i j = ∑ x : ∀ i, κ i, ∏ i, f i (x i) := Finset.prod_univ_sum _ _
 
-lemma prod_add (f g : ι → α) : ∏ a, (f a + g a) = ∑ t, (∏ a ∈ t, f a) * ∏ a ∈ tᶜ, g a := by
+lemma prod_add (f g : ι → R) : ∏ a, (f a + g a) = ∑ t, (∏ a ∈ t, f a) * ∏ a ∈ tᶜ, g a := by
   simpa [compl_eq_univ_sdiff] using Finset.prod_add f g univ
 
 end Fintype
@@ -304,31 +305,31 @@ protected lemma sum_div (hf : ∀ i ∈ s, n ∣ f i) : (∑ i ∈ s, f i) / n =
   rw [Nat.div_mul_cancel (hf _ hs)]
 
 @[simp, norm_cast]
-lemma cast_list_sum [AddMonoidWithOne β] (s : List ℕ) : (↑s.sum : β) = (s.map (↑)).sum :=
-  map_list_sum (castAddMonoidHom β) _
+lemma cast_list_sum [AddMonoidWithOne R] (s : List ℕ) : (↑s.sum : R) = (s.map (↑)).sum :=
+  map_list_sum (castAddMonoidHom R) _
 
 @[simp, norm_cast]
-lemma cast_list_prod [Semiring β] (s : List ℕ) : (↑s.prod : β) = (s.map (↑)).prod :=
-  map_list_prod (castRingHom β) _
+lemma cast_list_prod [Semiring R] (s : List ℕ) : (↑s.prod : R) = (s.map (↑)).prod :=
+  map_list_prod (castRingHom R) _
 
 @[simp, norm_cast]
-lemma cast_multiset_sum [AddCommMonoidWithOne β] (s : Multiset ℕ) :
-    (↑s.sum : β) = (s.map (↑)).sum :=
-  map_multiset_sum (castAddMonoidHom β) _
+lemma cast_multiset_sum [AddCommMonoidWithOne R] (s : Multiset ℕ) :
+    (↑s.sum : R) = (s.map (↑)).sum :=
+  map_multiset_sum (castAddMonoidHom R) _
 
 @[simp, norm_cast]
-lemma cast_multiset_prod [CommSemiring β] (s : Multiset ℕ) : (↑s.prod : β) = (s.map (↑)).prod :=
-  map_multiset_prod (castRingHom β) _
+lemma cast_multiset_prod [CommSemiring R] (s : Multiset ℕ) : (↑s.prod : R) = (s.map (↑)).prod :=
+  map_multiset_prod (castRingHom R) _
 
 @[simp, norm_cast]
-lemma cast_sum [AddCommMonoidWithOne β] (s : Finset α) (f : α → ℕ) :
-    ↑(∑ x ∈ s, f x : ℕ) = ∑ x ∈ s, (f x : β) :=
-  map_sum (castAddMonoidHom β) _ _
+lemma cast_sum [AddCommMonoidWithOne R] (s : Finset α) (f : α → ℕ) :
+    ↑(∑ x ∈ s, f x : ℕ) = ∑ x ∈ s, (f x : R) :=
+  map_sum (castAddMonoidHom R) _ _
 
 @[simp, norm_cast]
-lemma cast_prod [CommSemiring β] (f : α → ℕ) (s : Finset α) :
-    (↑(∏ i ∈ s, f i) : β) = ∏ i ∈ s, (f i : β) :=
-  map_prod (castRingHom β) _ _
+lemma cast_prod [CommSemiring R] (f : α → ℕ) (s : Finset α) :
+    (↑(∏ i ∈ s, f i) : R) = ∏ i ∈ s, (f i : R) :=
+  map_prod (castRingHom R) _ _
 
 end Nat
 
@@ -343,17 +344,17 @@ protected lemma sum_div (hf : ∀ i ∈ s, n ∣ f i) : (∑ i ∈ s, f i) / n =
   rw [Int.ediv_mul_cancel (hf _ hs)]
 
 @[simp, norm_cast]
-lemma cast_list_sum [AddGroupWithOne β] (s : List ℤ) : (↑s.sum : β) = (s.map (↑)).sum :=
-  map_list_sum (castAddHom β) _
+lemma cast_list_sum [AddGroupWithOne R] (s : List ℤ) : (↑s.sum : R) = (s.map (↑)).sum :=
+  map_list_sum (castAddHom R) _
 
 @[simp, norm_cast]
-lemma cast_list_prod [Ring β] (s : List ℤ) : (↑s.prod : β) = (s.map (↑)).prod :=
-  map_list_prod (castRingHom β) _
+lemma cast_list_prod [Ring R] (s : List ℤ) : (↑s.prod : R) = (s.map (↑)).prod :=
+  map_list_prod (castRingHom R) _
 
 @[simp, norm_cast]
-lemma cast_multiset_sum [AddCommGroupWithOne β] (s : Multiset ℤ) :
-    (↑s.sum : β) = (s.map (↑)).sum :=
-  map_multiset_sum (castAddHom β) _
+lemma cast_multiset_sum [AddCommGroupWithOne R] (s : Multiset ℤ) :
+    (↑s.sum : R) = (s.map (↑)).sum :=
+  map_multiset_sum (castAddHom R) _
 
 @[simp, norm_cast]
 lemma cast_multiset_prod {R : Type*} [CommRing R] (s : Multiset ℤ) :
@@ -361,9 +362,9 @@ lemma cast_multiset_prod {R : Type*} [CommRing R] (s : Multiset ℤ) :
   map_multiset_prod (castRingHom R) _
 
 @[simp, norm_cast]
-lemma cast_sum [AddCommGroupWithOne β] (s : Finset α) (f : α → ℤ) :
-    ↑(∑ x ∈ s, f x : ℤ) = ∑ x ∈ s, (f x : β) :=
-  map_sum (castAddHom β) _ _
+lemma cast_sum [AddCommGroupWithOne R] (s : Finset α) (f : α → ℤ) :
+    ↑(∑ x ∈ s, f x : ℤ) = ∑ x ∈ s, (f x : R) :=
+  map_sum (castAddHom R) _ _
 
 @[simp, norm_cast]
 lemma cast_prod {R : Type*} [CommRing R] (f : α → ℤ) (s : Finset α) :

--- a/Mathlib/Algebra/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Ring/Finset.lean
@@ -22,7 +22,7 @@ assert_not_exists Field
 
 open Fintype
 
-variable {ι ι' M R α : Type*} {κ : ι → Type*} {s s₁ s₂ : Finset ι} {i : ι} {a : α} {f g : ι → α}
+variable {ι κ M R : Type*} {s s₁ s₂ : Finset ι} {i : ι}
 
 namespace Finset
 
@@ -52,11 +52,11 @@ lemma sum_mul (s : Finset ι) (f : ι → R) (a : R) :
 lemma mul_sum (s : Finset ι) (f : ι → R) (a : R) :
     a * ∑ i ∈ s, f i = ∑ i ∈ s, a * f i := map_sum (AddMonoidHom.mulLeft a) _ s
 
-lemma sum_mul_sum {κ : Type*} (s : Finset ι) (t : Finset κ) (f : ι → R) (g : κ → R) :
+lemma sum_mul_sum (s : Finset ι) (t : Finset κ) (f : ι → R) (g : κ → R) :
     (∑ i ∈ s, f i) * ∑ j ∈ t, g j = ∑ i ∈ s, ∑ j ∈ t, f i * g j := by
   simp_rw [sum_mul, ← mul_sum]
 
-lemma _root_.Fintype.sum_mul_sum {κ : Type*} [Fintype ι] [Fintype κ] (f : ι → R) (g : κ → R) :
+lemma _root_.Fintype.sum_mul_sum [Fintype ι] [Fintype κ] (f : ι → R) (g : κ → R) :
     (∑ i, f i) * ∑ j, g j = ∑ i, ∑ j, f i * g j :=
   Finset.sum_mul_sum _ _ _ _
 
@@ -114,7 +114,7 @@ variable [DecidableEq ι]
 
 /-- The product over a sum can be written as a sum over the product of sets, `Finset.Pi`.
   `Finset.prod_univ_sum` is an alternative statement when the product is over `univ`. -/
-lemma prod_sum (s : Finset ι) (t : ∀ i, Finset (κ i)) (f : ∀ i, κ i → R) :
+lemma prod_sum {κ : ι → Type*} (s : Finset ι) (t : ∀ i, Finset (κ i)) (f : ∀ i, κ i → R) :
     ∏ a ∈ s, ∑ b ∈ t a, f a b = ∑ p ∈ s.pi t, ∏ x ∈ s.attach, f x.1 (p x.1 x.2) := by
   classical
   induction s using Finset.induction with
@@ -147,15 +147,15 @@ lemma prod_sum (s : Finset ι) (t : ∀ i, Finset (κ i)) (f : ∀ i, κ i → R
 /-- The product over `univ` of a sum can be written as a sum over the product of sets,
 `Fintype.piFinset`. `Finset.prod_sum` is an alternative statement when the product is not
 over `univ`. -/
-lemma prod_univ_sum [Fintype ι] (t : ∀ i, Finset (κ i)) (f : ∀ i, κ i → R) :
+lemma prod_univ_sum {κ : ι → Type*} [Fintype ι] (t : ∀ i, Finset (κ i)) (f : ∀ i, κ i → R) :
     ∏ i, ∑ j ∈ t i, f i j = ∑ x ∈ piFinset t, ∏ i, f i (x i) := by
   simp only [prod_attach_univ, prod_sum, Finset.sum_univ_pi]
 
-lemma sum_prod_piFinset {κ : Type*} [Fintype ι] (s : Finset κ) (g : ι → κ → R) :
+lemma sum_prod_piFinset [Fintype ι] (s : Finset κ) (g : ι → κ → R) :
     ∑ f ∈ piFinset fun _ : ι ↦ s, ∏ i, g i (f i) = ∏ i, ∑ j ∈ s, g i j := by
   rw [← prod_univ_sum]
 
-lemma sum_pow' (s : Finset ι') (f : ι' → R) (n : ℕ) :
+lemma sum_pow' (s : Finset κ) (f : κ → R) (n : ℕ) :
     (∑ a ∈ s, f a) ^ n = ∑ p ∈ piFinset fun _i : Fin n ↦ s, ∏ i, f (p i) := by
   convert @prod_univ_sum (Fin n) _ _ _ _ _ (fun _i ↦ s) fun _i d ↦ f d; simp
 
@@ -322,12 +322,12 @@ lemma cast_multiset_prod [CommSemiring R] (s : Multiset ℕ) : (↑s.prod : R) =
   map_multiset_prod (castRingHom R) _
 
 @[simp, norm_cast]
-lemma cast_sum [AddCommMonoidWithOne R] (s : Finset α) (f : α → ℕ) :
+lemma cast_sum [AddCommMonoidWithOne R] (s : Finset ι) (f : ι → ℕ) :
     ↑(∑ x ∈ s, f x : ℕ) = ∑ x ∈ s, (f x : R) :=
   map_sum (castAddMonoidHom R) _ _
 
 @[simp, norm_cast]
-lemma cast_prod [CommSemiring R] (f : α → ℕ) (s : Finset α) :
+lemma cast_prod [CommSemiring R] (f : ι → ℕ) (s : Finset ι) :
     (↑(∏ i ∈ s, f i) : R) = ∏ i ∈ s, (f i : R) :=
   map_prod (castRingHom R) _ _
 
@@ -362,12 +362,12 @@ lemma cast_multiset_prod {R : Type*} [CommRing R] (s : Multiset ℤ) :
   map_multiset_prod (castRingHom R) _
 
 @[simp, norm_cast]
-lemma cast_sum [AddCommGroupWithOne R] (s : Finset α) (f : α → ℤ) :
+lemma cast_sum [AddCommGroupWithOne R] (s : Finset ι) (f : ι → ℤ) :
     ↑(∑ x ∈ s, f x : ℤ) = ∑ x ∈ s, (f x : R) :=
   map_sum (castAddHom R) _ _
 
 @[simp, norm_cast]
-lemma cast_prod {R : Type*} [CommRing R] (f : α → ℤ) (s : Finset α) :
+lemma cast_prod {R : Type*} [CommRing R] (f : ι → ℤ) (s : Finset ι) :
     (↑(∏ i ∈ s, f i) : R) = ∏ i ∈ s, (f i : R) :=
   map_prod (Int.castRingHom R) _ _
 

--- a/Mathlib/Algebra/BigOperators/Ring/Finset.lean
+++ b/Mathlib/Algebra/BigOperators/Ring/Finset.lean
@@ -22,11 +22,11 @@ assert_not_exists Field
 
 open Fintype
 
-variable {ι ι' M₀ R α : Type*} {κ : ι → Type*} {s s₁ s₂ : Finset ι} {i : ι} {a : α} {f g : ι → α}
+variable {ι ι' M R α : Type*} {κ : ι → Type*} {s s₁ s₂ : Finset ι} {i : ι} {a : α} {f g : ι → α}
 
 namespace Finset
 
-lemma prod_neg [CommMonoid M₀] [HasDistribNeg M₀] (f : ι → M₀) :
+lemma prod_neg [CommMonoid M] [HasDistribNeg M] (f : ι → M) :
     ∏ x ∈ s, -f x = (-1) ^ #s * ∏ x ∈ s, f x := by
   simpa using (s.1.map f).prod_map_neg
 

--- a/Mathlib/Algebra/BigOperators/Ring/Multiset.lean
+++ b/Mathlib/Algebra/BigOperators/Ring/Multiset.lean
@@ -11,34 +11,34 @@ import Mathlib.Data.Multiset.Sections
 /-! # Lemmas about `Multiset.sum` and `Multiset.prod` requiring extra algebra imports -/
 
 
-variable {ι α β : Type*}
+variable {ι R M₀ β : Type*}
 
 namespace Multiset
 section CommMonoid
-variable [CommMonoid α] [HasDistribNeg α]
+variable [CommMonoid R] [HasDistribNeg R]
 
-@[simp] lemma prod_map_neg (s : Multiset α) : (s.map Neg.neg).prod = (-1) ^ card s * s.prod :=
+@[simp] lemma prod_map_neg (s : Multiset R) : (s.map Neg.neg).prod = (-1) ^ card s * s.prod :=
   Quotient.inductionOn s (by simp)
 
 end CommMonoid
 
 section CommMonoidWithZero
-variable [CommMonoidWithZero α] {s : Multiset α}
+variable [CommMonoidWithZero M₀] {s : Multiset M₀}
 
-lemma prod_eq_zero (h : (0 : α) ∈ s) : s.prod = 0 := by
+lemma prod_eq_zero (h : (0 : M₀) ∈ s) : s.prod = 0 := by
   rcases Multiset.exists_cons_of_mem h with ⟨s', hs'⟩; simp [hs', Multiset.prod_cons]
 
-variable [NoZeroDivisors α] [Nontrivial α] {s : Multiset α}
+variable [NoZeroDivisors M₀] [Nontrivial M₀] {s : Multiset M₀}
 
-@[simp] lemma prod_eq_zero_iff : s.prod = 0 ↔ (0 : α) ∈ s :=
+@[simp] lemma prod_eq_zero_iff : s.prod = 0 ↔ (0 : M₀) ∈ s :=
   Quotient.inductionOn s fun l ↦ by rw [quot_mk_to_coe, prod_coe]; exact List.prod_eq_zero_iff
 
-lemma prod_ne_zero (h : (0 : α) ∉ s) : s.prod ≠ 0 := mt prod_eq_zero_iff.1 h
+lemma prod_ne_zero (h : (0 : M₀) ∉ s) : s.prod ≠ 0 := mt prod_eq_zero_iff.1 h
 
 end CommMonoidWithZero
 
 section NonUnitalNonAssocSemiring
-variable [NonUnitalNonAssocSemiring α] {a : α} {s : Multiset ι} {f : ι → α}
+variable [NonUnitalNonAssocSemiring M₀] {a : M₀} {s : Multiset ι} {f : ι → M₀}
 
 lemma sum_map_mul_left : sum (s.map fun i ↦ a * f i) = a * sum (s.map f) :=
   Multiset.induction_on s (by simp) fun i s ih => by simp [ih, mul_add]
@@ -49,7 +49,7 @@ lemma sum_map_mul_right : sum (s.map fun i ↦ f i * a) = sum (s.map f) * a :=
 end NonUnitalNonAssocSemiring
 
 section NonUnitalSemiring
-variable [NonUnitalSemiring α] {s : Multiset α} {a : α}
+variable [NonUnitalSemiring M₀] {s : Multiset M₀} {a : M₀}
 
 lemma dvd_sum : (∀ x ∈ s, a ∣ x) → a ∣ s.sum :=
   Multiset.induction_on s (fun _ ↦ dvd_zero _) fun x s ih h ↦ by
@@ -59,14 +59,14 @@ lemma dvd_sum : (∀ x ∈ s, a ∣ x) → a ∣ s.sum :=
 end NonUnitalSemiring
 
 section CommSemiring
-variable [CommSemiring α]
+variable [CommSemiring M₀]
 
-lemma prod_map_sum {s : Multiset (Multiset α)} :
+lemma prod_map_sum {s : Multiset (Multiset M₀)} :
     prod (s.map sum) = sum ((Sections s).map prod) :=
   Multiset.induction_on s (by simp) fun a s ih ↦ by
     simp [ih, map_bind, sum_map_mul_left, sum_map_mul_right]
 
-lemma prod_map_add {s : Multiset ι} {f g : ι → α} :
+lemma prod_map_add {s : Multiset ι} {f g : ι → M₀} :
     prod (s.map fun i ↦ f i + g i) =
       sum ((antidiagonal s).map fun p ↦ (p.1.map f).prod * (p.2.map g).prod) := by
   refine s.induction_on ?_ fun a s ih ↦ ?_
@@ -83,14 +83,14 @@ open Multiset
 
 namespace Commute
 
-variable [NonUnitalNonAssocSemiring α] (s : Multiset α)
+variable [NonUnitalNonAssocSemiring R] (s : Multiset R)
 
-theorem multiset_sum_right (a : α) (h : ∀ b ∈ s, Commute a b) : Commute a s.sum := by
+theorem multiset_sum_right (a : R) (h : ∀ b ∈ s, Commute a b) : Commute a s.sum := by
   induction s using Quotient.inductionOn
   rw [quot_mk_to_coe, sum_coe]
   exact Commute.list_sum_right _ _ h
 
-theorem multiset_sum_left (b : α) (h : ∀ a ∈ s, Commute a b) : Commute s.sum b :=
+theorem multiset_sum_left (b : R) (h : ∀ a ∈ s, Commute a b) : Commute s.sum b :=
   ((Commute.multiset_sum_right _ _) fun _ ha => (h _ ha).symm).symm
 
 end Commute

--- a/Mathlib/Algebra/BigOperators/Ring/Multiset.lean
+++ b/Mathlib/Algebra/BigOperators/Ring/Multiset.lean
@@ -38,7 +38,7 @@ lemma prod_ne_zero (h : (0 : M₀) ∉ s) : s.prod ≠ 0 := mt prod_eq_zero_iff.
 end CommMonoidWithZero
 
 section NonUnitalNonAssocSemiring
-variable [NonUnitalNonAssocSemiring M₀] {a : M₀} {s : Multiset ι} {f : ι → M₀}
+variable [NonUnitalNonAssocSemiring R] {a : R} {s : Multiset ι} {f : ι → R}
 
 lemma sum_map_mul_left : sum (s.map fun i ↦ a * f i) = a * sum (s.map f) :=
   Multiset.induction_on s (by simp) fun i s ih => by simp [ih, mul_add]

--- a/Mathlib/Algebra/BigOperators/Ring/Multiset.lean
+++ b/Mathlib/Algebra/BigOperators/Ring/Multiset.lean
@@ -11,13 +11,13 @@ import Mathlib.Data.Multiset.Sections
 /-! # Lemmas about `Multiset.sum` and `Multiset.prod` requiring extra algebra imports -/
 
 
-variable {ι R M₀ β : Type*}
+variable {ι M M₀ R : Type*}
 
 namespace Multiset
 section CommMonoid
-variable [CommMonoid R] [HasDistribNeg R]
+variable [CommMonoid M] [HasDistribNeg M]
 
-@[simp] lemma prod_map_neg (s : Multiset R) : (s.map Neg.neg).prod = (-1) ^ card s * s.prod :=
+@[simp] lemma prod_map_neg (s : Multiset M) : (s.map Neg.neg).prod = (-1) ^ card s * s.prod :=
   Quotient.inductionOn s (by simp)
 
 end CommMonoid
@@ -49,7 +49,7 @@ lemma sum_map_mul_right : sum (s.map fun i ↦ f i * a) = sum (s.map f) * a :=
 end NonUnitalNonAssocSemiring
 
 section NonUnitalSemiring
-variable [NonUnitalSemiring M₀] {s : Multiset M₀} {a : M₀}
+variable [NonUnitalSemiring R] {s : Multiset R} {a : R}
 
 lemma dvd_sum : (∀ x ∈ s, a ∣ x) → a ∣ s.sum :=
   Multiset.induction_on s (fun _ ↦ dvd_zero _) fun x s ih h ↦ by
@@ -59,14 +59,14 @@ lemma dvd_sum : (∀ x ∈ s, a ∣ x) → a ∣ s.sum :=
 end NonUnitalSemiring
 
 section CommSemiring
-variable [CommSemiring M₀]
+variable [CommSemiring R]
 
-lemma prod_map_sum {s : Multiset (Multiset M₀)} :
+lemma prod_map_sum {s : Multiset (Multiset R)} :
     prod (s.map sum) = sum ((Sections s).map prod) :=
   Multiset.induction_on s (by simp) fun a s ih ↦ by
     simp [ih, map_bind, sum_map_mul_left, sum_map_mul_right]
 
-lemma prod_map_add {s : Multiset ι} {f g : ι → M₀} :
+lemma prod_map_add {s : Multiset ι} {f g : ι → R} :
     prod (s.map fun i ↦ f i + g i) =
       sum ((antidiagonal s).map fun p ↦ (p.1.map f).prod * (p.2.map g).prod) := by
   refine s.induction_on ?_ fun a s ih ↦ ?_

--- a/Mathlib/Algebra/BigOperators/Sym.lean
+++ b/Mathlib/Algebra/BigOperators/Sym.lean
@@ -15,8 +15,8 @@ namespace Finset
 
 open Multiset
 
-theorem sum_sym2_filter_not_isDiag {ι α} [LinearOrder ι] [AddCommMonoid α]
-    (s : Finset ι) (p : Sym2 ι → α) :
+theorem sum_sym2_filter_not_isDiag {ι M} [LinearOrder ι] [AddCommMonoid M]
+    (s : Finset ι) (p : Sym2 ι → M) :
     ∑ i ∈ s.sym2 with ¬ i.IsDiag, p i = ∑ i ∈ s.offDiag with i.1 < i.2, p s(i.1, i.2) := by
   rw [Finset.offDiag_filter_lt_eq_filter_le]
   conv_rhs => rw [← Finset.sum_subtype_eq_sum_filter]

--- a/Mathlib/Algebra/BigOperators/WithTop.lean
+++ b/Mathlib/Algebra/BigOperators/WithTop.lean
@@ -14,7 +14,7 @@ This file proves results about finite sums over monoids extended by a bottom or 
 
 open Finset
 
-variable {ι M : Type*}
+variable {ι M M₀ : Type*}
 
 namespace WithTop
 section AddCommMonoid
@@ -39,15 +39,15 @@ variable [LT M]
 end AddCommMonoid
 
 section CommMonoidWithZero
-variable [CommMonoidWithZero M] [NoZeroDivisors M] [Nontrivial M] [DecidableEq M]
-  {s : Finset ι} {f : ι → WithTop M}
+variable [CommMonoidWithZero M₀] [NoZeroDivisors M₀] [Nontrivial M₀] [DecidableEq M₀]
+  {s : Finset ι} {f : ι → WithTop M₀}
 
 /-- A product of finite terms is finite. -/
 lemma prod_ne_top (h : ∀ i ∈ s, f i ≠ ⊤) : ∏ i ∈ s, f i ≠ ⊤ :=
   prod_induction f (· ≠ ⊤) (fun _ _ ↦ mul_ne_top) coe_ne_top h
 
 /-- A product of finite terms is finite. -/
-lemma prod_lt_top [LT M] (h : ∀ i ∈ s, f i < ⊤) : ∏ i ∈ s, f i < ⊤ :=
+lemma prod_lt_top [LT M₀] (h : ∀ i ∈ s, f i < ⊤) : ∏ i ∈ s, f i < ⊤ :=
   prod_induction f (· < ⊤) (fun _ _ ↦ mul_lt_top) (coe_lt_top _) h
 
 end CommMonoidWithZero
@@ -77,15 +77,15 @@ lemma sum_lt_bot (h : ∀ i ∈ s, f i ≠ ⊥) : ⊥ < ∑ i ∈ s, f i :=
 end AddCommMonoid
 
 section CommMonoidWithZero
-variable [CommMonoidWithZero M] [NoZeroDivisors M] [Nontrivial M] [DecidableEq M]
-  {s : Finset ι} {f : ι → WithBot M}
+variable [CommMonoidWithZero M₀] [NoZeroDivisors M₀] [Nontrivial M₀] [DecidableEq M₀]
+  {s : Finset ι} {f : ι → WithBot M₀}
 
 /-- A product of finite terms is finite. -/
 lemma prod_ne_bot (h : ∀ i ∈ s, f i ≠ ⊥) : ∏ i ∈ s, f i ≠ ⊥ :=
   prod_induction f (· ≠ ⊥) (fun _ _ ↦ mul_ne_bot) coe_ne_bot h
 
 /-- A product of finite terms is finite. -/
-lemma bot_lt_prod [LT M] (h : ∀ i ∈ s, ⊥ < f i) : ⊥ < ∏ i ∈ s, f i :=
+lemma bot_lt_prod [LT M₀] (h : ∀ i ∈ s, ⊥ < f i) : ⊥ < ∏ i ∈ s, f i :=
   prod_induction f (⊥ < ·) (fun _ _ ↦ bot_lt_mul) (bot_lt_coe _) h
 
 end CommMonoidWithZero

--- a/Mathlib/Algebra/BigOperators/WithTop.lean
+++ b/Mathlib/Algebra/BigOperators/WithTop.lean
@@ -14,14 +14,14 @@ This file proves results about finite sums over monoids extended by a bottom or 
 
 open Finset
 
-variable {ι α : Type*}
+variable {ι M : Type*}
 
 namespace WithTop
 section AddCommMonoid
-variable [AddCommMonoid α] {s : Finset ι} {f : ι → WithTop α}
+variable [AddCommMonoid M] {s : Finset ι} {f : ι → WithTop M}
 
-@[simp, norm_cast] lemma coe_sum (s : Finset ι) (f : ι → α) :
-    ∑ i ∈ s, f i = ∑ i ∈ s, (f i : WithTop α) := map_sum addHom f s
+@[simp, norm_cast] lemma coe_sum (s : Finset ι) (f : ι → M) :
+    ∑ i ∈ s, f i = ∑ i ∈ s, (f i : WithTop M) := map_sum addHom f s
 
 /-- A sum is infinite iff one term is infinite. -/
 @[simp] lemma sum_eq_top : ∑ i ∈ s, f i = ⊤ ↔ ∃ i ∈ s, f i = ⊤ := by
@@ -30,7 +30,7 @@ variable [AddCommMonoid α] {s : Finset ι} {f : ι → WithTop α}
 /-- A sum is finite iff all terms are finite. -/
 lemma sum_ne_top : ∑ i ∈ s, f i ≠ ⊤ ↔ ∀ i ∈ s, f i ≠ ⊤ := by simp
 
-variable [LT α]
+variable [LT M]
 
 /-- A sum is finite iff all terms are finite. -/
 @[simp] lemma sum_lt_top : ∑ i ∈ s, f i < ⊤ ↔ ∀ i ∈ s, f i < ⊤ := by
@@ -39,15 +39,15 @@ variable [LT α]
 end AddCommMonoid
 
 section CommMonoidWithZero
-variable [CommMonoidWithZero α] [NoZeroDivisors α] [Nontrivial α] [DecidableEq α]
-  {s : Finset ι} {f : ι → WithTop α}
+variable [CommMonoidWithZero M] [NoZeroDivisors M] [Nontrivial M] [DecidableEq M]
+  {s : Finset ι} {f : ι → WithTop M}
 
 /-- A product of finite terms is finite. -/
 lemma prod_ne_top (h : ∀ i ∈ s, f i ≠ ⊤) : ∏ i ∈ s, f i ≠ ⊤ :=
   prod_induction f (· ≠ ⊤) (fun _ _ ↦ mul_ne_top) coe_ne_top h
 
 /-- A product of finite terms is finite. -/
-lemma prod_lt_top [LT α] (h : ∀ i ∈ s, f i < ⊤) : ∏ i ∈ s, f i < ⊤ :=
+lemma prod_lt_top [LT M] (h : ∀ i ∈ s, f i < ⊤) : ∏ i ∈ s, f i < ⊤ :=
   prod_induction f (· < ⊤) (fun _ _ ↦ mul_lt_top) (coe_lt_top _) h
 
 end CommMonoidWithZero
@@ -55,16 +55,16 @@ end WithTop
 
 namespace WithBot
 section AddCommMonoid
-variable [AddCommMonoid α] {s : Finset ι} {f : ι → WithBot α}
+variable [AddCommMonoid M] {s : Finset ι} {f : ι → WithBot M}
 
-@[simp, norm_cast] lemma coe_sum (s : Finset ι) (f : ι → α) :
-    ∑ i ∈ s, f i = ∑ i ∈ s, (f i : WithBot α) := map_sum addHom f s
+@[simp, norm_cast] lemma coe_sum (s : Finset ι) (f : ι → M) :
+    ∑ i ∈ s, f i = ∑ i ∈ s, (f i : WithBot M) := map_sum addHom f s
 
 /-- A sum is infinite iff one term is infinite. -/
 lemma sum_eq_bot_iff : ∑ i ∈ s, f i = ⊥ ↔ ∃ i ∈ s, f i = ⊥ := by
   induction s using Finset.cons_induction <;> simp [*]
 
-variable [LT α]
+variable [LT M]
 
 /-- A sum is finite iff all terms are finite. -/
 lemma bot_lt_sum_iff : ⊥ < ∑ i ∈ s, f i ↔ ∀ i ∈ s, ⊥ < f i := by
@@ -77,15 +77,15 @@ lemma sum_lt_bot (h : ∀ i ∈ s, f i ≠ ⊥) : ⊥ < ∑ i ∈ s, f i :=
 end AddCommMonoid
 
 section CommMonoidWithZero
-variable [CommMonoidWithZero α] [NoZeroDivisors α] [Nontrivial α] [DecidableEq α]
-  {s : Finset ι} {f : ι → WithBot α}
+variable [CommMonoidWithZero M] [NoZeroDivisors M] [Nontrivial M] [DecidableEq M]
+  {s : Finset ι} {f : ι → WithBot M}
 
 /-- A product of finite terms is finite. -/
 lemma prod_ne_bot (h : ∀ i ∈ s, f i ≠ ⊥) : ∏ i ∈ s, f i ≠ ⊥ :=
   prod_induction f (· ≠ ⊥) (fun _ _ ↦ mul_ne_bot) coe_ne_bot h
 
 /-- A product of finite terms is finite. -/
-lemma bot_lt_prod [LT α] (h : ∀ i ∈ s, ⊥ < f i) : ⊥ < ∏ i ∈ s, f i :=
+lemma bot_lt_prod [LT M] (h : ∀ i ∈ s, ⊥ < f i) : ⊥ < ∏ i ∈ s, f i :=
   prod_induction f (⊥ < ·) (fun _ _ ↦ bot_lt_mul) (bot_lt_coe _) h
 
 end CommMonoidWithZero

--- a/Mathlib/Data/Complex/Exponential.lean
+++ b/Mathlib/Data/Complex/Exponential.lean
@@ -213,7 +213,7 @@ theorem exp_multiset_sum (s : Multiset ℝ) : exp s.sum = (s.map exp).prod :=
 
 theorem exp_sum {α : Type*} (s : Finset α) (f : α → ℝ) :
     exp (∑ x ∈ s, f x) = ∏ x ∈ s, exp (f x) :=
-  map_prod (β := Multiplicative ℝ) expMonoidHom f s
+  map_prod (M := Multiplicative ℝ) expMonoidHom f s
 
 lemma exp_nsmul (x : ℝ) (n : ℕ) : exp (n • x) = exp x ^ n :=
   @MonoidHom.map_pow (Multiplicative ℝ) ℝ _ _  expMonoidHom _ _

--- a/Mathlib/Data/Complex/Exponential.lean
+++ b/Mathlib/Data/Complex/Exponential.lean
@@ -137,7 +137,7 @@ theorem exp_multiset_sum (s : Multiset ℂ) : exp s.sum = (s.map exp).prod :=
 
 theorem exp_sum {α : Type*} (s : Finset α) (f : α → ℂ) :
     exp (∑ x ∈ s, f x) = ∏ x ∈ s, exp (f x) :=
-  map_prod (β := Multiplicative ℂ) expMonoidHom f s
+  map_prod (M := Multiplicative ℂ) expMonoidHom f s
 
 lemma exp_nsmul (x : ℂ) (n : ℕ) : exp (n • x) = exp x ^ n :=
   @MonoidHom.map_pow (Multiplicative ℂ) ℂ _ _  expMonoidHom _ _

--- a/Mathlib/FieldTheory/Finite/Polynomial.lean
+++ b/Mathlib/FieldTheory/Finite/Polynomial.lean
@@ -128,14 +128,9 @@ theorem map_restrict_dom_evalₗ : (restrictDegree σ K (Fintype.card K - 1)).ma
   refine ⟨∑ n : σ → K, e n • indicator n, ?_, ?_⟩
   · exact sum_mem fun c _ => smul_mem _ _ (indicator_mem_restrictDegree _)
   · ext n
-    simp only [_root_.map_sum, @Finset.sum_apply (σ → K) (fun _ => K) _ _ _ _ _, Pi.smul_apply,
-      map_smul]
-    simp only [evalₗ_apply]
-    trans
-    · refine Finset.sum_eq_single n (fun b _ h => ?_) ?_
-      · rw [eval_indicator_apply_eq_zero _ _ h.symm, smul_zero]
-      · exact fun h => (h <| Finset.mem_univ n).elim
-    · rw [eval_indicator_apply_eq_one, smul_eq_mul, mul_one]
+    simp only [evalₗ_apply, map_sum, smul_eval]
+    rw [Finset.sum_eq_single n] <;>
+      aesop (add simp [eval_indicator_apply_eq_zero, eval_indicator_apply_eq_one, eq_comm])
 
 end
 

--- a/Mathlib/LinearAlgebra/Matrix/Trace.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Trace.lean
@@ -126,11 +126,11 @@ variable [AddCommGroup R]
 
 @[simp]
 theorem trace_sub (A B : Matrix n n R) : trace (A - B) = trace A - trace B :=
-  Finset.sum_sub_distrib
+  Finset.sum_sub_distrib ..
 
 @[simp]
 theorem trace_neg (A : Matrix n n R) : trace (-A) = -trace A :=
-  Finset.sum_neg_distrib
+  Finset.sum_neg_distrib ..
 
 end AddCommGroup
 

--- a/Mathlib/NumberTheory/LegendreSymbol/JacobiSymbol.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/JacobiSymbol.lean
@@ -149,7 +149,7 @@ theorem one_left (b : ℕ) : J(1 | b) = 1 :=
 /-- The Jacobi symbol is multiplicative in its first argument. -/
 theorem mul_left (a₁ a₂ : ℤ) (b : ℕ) : J(a₁ * a₂ | b) = J(a₁ | b) * J(a₂ | b) := by
   simp_rw [jacobiSym, List.pmap_eq_map_attach, legendreSym.mul _ _ _]
-  exact List.prod_map_mul (α := ℤ) (l := (primeFactorsList b).attach)
+  exact List.prod_map_mul (l := (primeFactorsList b).attach)
     (f := fun x ↦ @legendreSym x {out := prime_of_mem_primeFactorsList x.2} a₁)
     (g := fun x ↦ @legendreSym x {out := prime_of_mem_primeFactorsList x.2} a₂)
 

--- a/Mathlib/NumberTheory/SumPrimeReciprocals.lean
+++ b/Mathlib/NumberTheory/SumPrimeReciprocals.lean
@@ -35,7 +35,7 @@ lemma Nat.roughNumbersUpTo_card_le' (N k : ℕ) :
       N * (N.succ.primesBelow \ k.primesBelow).sum (fun p ↦ (1 : ℝ) / p) := by
   simp_rw [Finset.mul_sum, mul_one_div]
   exact (Nat.cast_le.mpr <| roughNumbersUpTo_card_le N k).trans <|
-    (cast_sum (β := ℝ) ..) ▸ Finset.sum_le_sum fun n _ ↦ cast_div_le
+    (cast_sum ..) ▸ Finset.sum_le_sum fun n _ ↦ cast_div_le
 
 /-- The sum over primes `k ≤ p ≤ 4^(π(k-1)+1)` over `1/p` (as a real number) is at least `1/2`. -/
 lemma one_half_le_sum_primes_ge_one_div (k : ℕ) :

--- a/Mathlib/NumberTheory/SumPrimeReciprocals.lean
+++ b/Mathlib/NumberTheory/SumPrimeReciprocals.lean
@@ -35,7 +35,7 @@ lemma Nat.roughNumbersUpTo_card_le' (N k : ℕ) :
       N * (N.succ.primesBelow \ k.primesBelow).sum (fun p ↦ (1 : ℝ) / p) := by
   simp_rw [Finset.mul_sum, mul_one_div]
   exact (Nat.cast_le.mpr <| roughNumbersUpTo_card_le N k).trans <|
-    (cast_sum ..) ▸ Finset.sum_le_sum fun n _ ↦ cast_div_le
+    cast_sum (R := ℝ) .. ▸ Finset.sum_le_sum fun n _ ↦ cast_div_le
 
 /-- The sum over primes `k ≤ p ≤ 4^(π(k-1)+1)` over `1/p` (as a real number) is at least `1/2`. -/
 lemma one_half_le_sum_primes_ge_one_div (k : ℕ) :


### PR DESCRIPTION
Uniformise the variables to `ι`, `κ` for the indexing types, `M`, `N` for monoids, `G` for groups, `M₀` for monoids with zero, `R` for (semi)rings.

Also delete a duplicated lemma which suddenly became problematic.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
