### PR TITLE
[Merged by Bors] - fix(RefinedDiscrTree): remove funny `transparency` handling

### DIFF
--- a/Mathlib/Lean/Meta/RefinedDiscrTree/Basic.lean
+++ b/Mathlib/Lean/Meta/RefinedDiscrTree/Basic.lean
@@ -157,9 +157,6 @@ structure ExprInfo where
   localInsts : LocalInstances
   /-- The `Meta.Config` used by this entry. -/
   cfg : Config
-  /-- The current transparency level. Recall that unification uses the `default`
-  transparency level when unifying implicit arguments. So we index implicit arguments -/
-  transparency : TransparencyMode
 
 /-- Creates an `ExprInfo` using the current context. -/
 def mkExprInfo (expr : Expr) (bvars : List FVarId) : MetaM ExprInfo :=
@@ -168,7 +165,6 @@ def mkExprInfo (expr : Expr) (bvars : List FVarId) : MetaM ExprInfo :=
     lctx := ← getLCtx
     localInsts := ← getLocalInstances
     cfg := ← getConfig
-    transparency := ← getTransparency
   }
 
 /-- The possible values that can appear in the stack -/

--- a/Mathlib/Lean/Meta/RefinedDiscrTree/Encode.lean
+++ b/Mathlib/Lean/Meta/RefinedDiscrTree/Encode.lean
@@ -193,9 +193,9 @@ private partial def evalLazyEntryAux (entry : LazyEntry) (eta : Bool) :
     match stackEntry with
     | .star =>
       return some [(.star, entry)]
-    | .expr { expr, bvars, lctx, localInsts, cfg, transparency } =>
+    | .expr { expr, bvars, lctx, localInsts, cfg } =>
       withLCtx lctx localInsts do
-      withConfig (fun _ => cfg) do withTransparency transparency do
+      withConfig (fun _ => cfg) do
         if eta then
           return some (← encodingStepWithEta expr false entry |>.run { bvars := bvars })
         else
@@ -216,11 +216,7 @@ where
         if ← isIgnoredArg arg d bi then
           loop b (i+1) j (.star :: entries)
         else
-          -- Recall that on implicit arguments `isDefEq` switches to `default` transparency.
-          -- We don't want such strong reducibility, but `instances` transparency can be useful.
-          let info ← (if bi.isExplicit then id else withReducibleAndInstances) do
-            mkExprInfo arg bvars
-          loop b (i+1) j (.expr info :: entries)
+          loop b (i+1) j (.expr (← mkExprInfo arg bvars) :: entries)
       let rec reduce := do
         match ← whnfD (fnType.instantiateRevRange j i args) with
         | .forallE _ d b bi => cont i d b bi
@@ -245,9 +241,9 @@ If `entry.previous.isSome`, then replace it with `none`, and add the required en
 to entry.stack`.
 -/
 private def processPrevious (entry : LazyEntry) : MetaM LazyEntry := do
-  let some { expr, bvars, lctx, localInsts, cfg, transparency } := entry.previous | return entry
+  let some { expr, bvars, lctx, localInsts, cfg } := entry.previous | return entry
   let entry := { entry with previous := none }
-  withLCtx lctx localInsts do withConfig (fun _ => cfg) do withTransparency transparency do
+  withLCtx lctx localInsts do withConfig (fun _ => cfg) do
   expr.withApp fun fn args => do
 
     let stackArgs (entry : LazyEntry) : MetaM LazyEntry := do

--- a/Mathlib/Probability/ProductMeasure.lean
+++ b/Mathlib/Probability/ProductMeasure.lean
@@ -84,6 +84,7 @@ theorem piContent_eq_measure_pi [Fintype ι] {s : Set (Π i, X i)} (hs : Measura
       invFun i := ⟨i, mem_univ i⟩ }
   have : s = cylinder univ (MeasurableEquiv.piCongrLeft X e ⁻¹' s) := rfl
   nth_rw 1 [this]
+  dsimp [e]
   rw [piContent_cylinder _ (hs.preimage (by fun_prop)), ← Measure.pi_map_piCongrLeft e,
     ← Measure.map_apply (by fun_prop) hs]; rfl
 


### PR DESCRIPTION
This PR fixes some funny behaviour of `RefinedDiscrTree` discovered at #26484.

This PR aligns the behaviour with Lean core's `DiscrTree`. The original reason for this special treatment was to avoid a mathlib breakage. But now it turns out that this special trearment also causes a mathlib breakage (but this one is harder to fix).

The breakage that was the original reason for this behaviour is easily fixed using a `dsimp`.

#26484 depends on this PR

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
