### PR TITLE
[Merged by Bors] - feat: fix definition of `IsIntegralCurveOn` for consistency

### DIFF
--- a/Mathlib/Geometry/Manifold/IntegralCurve/Basic.lean
+++ b/Mathlib/Geometry/Manifold/IntegralCurve/Basic.lean
@@ -83,11 +83,9 @@ lemma isIntegralCurveAt_iff :
     rw [IsIntegralCurveAt, Filter.eventually_iff_exists_mem] at h
     obtain ⟨s, hs, h⟩ := h
     exact ⟨s, hs, fun t ht ↦ (h t ht).hasMFDerivWithinAt⟩
-  · intro h
+  · rintro ⟨s, hs, h⟩
     rw [IsIntegralCurveAt, Filter.eventually_iff_exists_mem]
-    obtain ⟨s, hs, h⟩ := h
-    rw [mem_nhds_iff] at hs
-    obtain ⟨s', h1, h2, h3⟩ := hs
+    obtain ⟨s', h1, h2, h3⟩ := mem_nhds_iff.mp hs
     refine ⟨s', h2.mem_nhds h3, ?_⟩
     intro t ht
     apply (h t (h1 ht)).hasMFDerivAt
@@ -103,9 +101,7 @@ lemma isIntegralCurveAt_iff' :
   · intro ⟨s, hs, h⟩
     rw [Metric.mem_nhds_iff] at hs
     obtain ⟨ε, hε, hε'⟩ := hs
-    refine ⟨ε, hε, ?_⟩
-    intro t ht
-    exact (h t (hε' ht)).mono hε'
+    refine ⟨ε, hε, fun t ht ↦ (h t (hε' ht)).mono hε'⟩
   · intro ⟨ε, hε, h⟩
     exact ⟨Metric.ball t₀ ε, Metric.ball_mem_nhds _ hε, h⟩
 

--- a/Mathlib/Geometry/Manifold/IntegralCurve/Basic.lean
+++ b/Mathlib/Geometry/Manifold/IntegralCurve/Basic.lean
@@ -52,14 +52,14 @@ variable
   {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
 
 /-- If `γ : ℝ → M` is $C^1$ on `s : Set ℝ` and `v` is a vector field on `M`,
-`IsIntegralCurveOn γ v s` means `γ t` is tangent to `v (γ t)` for all `t ∈ s`. The value of `γ`
-outside of `s` is irrelevant and considered junk. -/
+`IsIntegralCurveOn γ v s` means `γ t` is tangent to `v (γ t)` within `s` for all `t ∈ s`. The value
+of `γ` outside of `s` is irrelevant and considered junk. -/
 def IsIntegralCurveOn (γ : ℝ → M) (v : (x : M) → TangentSpace I x) (s : Set ℝ) : Prop :=
   ∀ t ∈ s, HasMFDerivWithinAt 𝓘(ℝ, ℝ) I γ s t ((1 : ℝ →L[ℝ] ℝ).smulRight <| v (γ t))
 
 /-- If `v` is a vector field on `M` and `t₀ : ℝ`, `IsIntegralCurveAt γ v t₀` means `γ : ℝ → M` is a
 local integral curve of `v` in a neighbourhood containing `t₀`. The value of `γ` outside of this
-interval is irrelevant and considered junk. -/
+neighbourhood is irrelevant and considered junk. -/
 def IsIntegralCurveAt (γ : ℝ → M) (v : (x : M) → TangentSpace I x) (t₀ : ℝ) : Prop :=
   ∀ᶠ t in 𝓝 t₀, HasMFDerivAt 𝓘(ℝ, ℝ) I γ t ((1 : ℝ →L[ℝ] ℝ).smulRight <| v (γ t))
 

--- a/Mathlib/Geometry/Manifold/IntegralCurve/Basic.lean
+++ b/Mathlib/Geometry/Manifold/IntegralCurve/Basic.lean
@@ -122,9 +122,6 @@ lemma isIntegralCurve_iff_isIntegralCurveAt :
 lemma IsIntegralCurveOn.mono (h : IsIntegralCurveOn γ v s) (hs : s' ⊆ s) :
     IsIntegralCurveOn γ v s' := fun t ht ↦ (h t (hs ht)).mono hs
 
--- lemma IsIntegralCurveOn.of_union (h : IsIntegralCurveOn γ v s) (h' : IsIntegralCurveOn γ v s') :
---     IsIntegralCurveOn γ v (s ∪ s') := fun _ ↦ fun | .inl ht => (h _ ht) | .inr ht => h' _ ht
-
 lemma IsIntegralCurveAt.hasMFDerivAt (h : IsIntegralCurveAt γ v t₀) :
     HasMFDerivAt 𝓘(ℝ, ℝ) I γ t₀ ((1 : ℝ →L[ℝ] ℝ).smulRight (v (γ t₀))) :=
   have ⟨_, hs, h⟩ := isIntegralCurveAt_iff.mp h
@@ -147,6 +144,9 @@ lemma isIntegralCurveOn_iff_isIntegralCurveAt (hs : IsOpen s) :
 
 lemma IsIntegralCurveOn.continuousWithinAt (hγ : IsIntegralCurveOn γ v s) (ht : t₀ ∈ s) :
     ContinuousWithinAt γ s t₀ := (hγ t₀ ht).1
+
+@[deprecated (since := "2025-06-29")] alias IsIntegralCurveOn.continuousAt :=
+  IsIntegralCurveOn.continuousWithinAt
 
 lemma IsIntegralCurveOn.continuousOn (hγ : IsIntegralCurveOn γ v s) :
     ContinuousOn γ s := fun t ht ↦ (hγ t ht).continuousWithinAt
@@ -178,6 +178,9 @@ lemma IsIntegralCurveOn.hasDerivWithinAt (hγ : IsIntegralCurveOn γ v s) {t : �
     ← ContinuousLinearMap.one_apply (R₁ := ℝ) a, ← ContinuousLinearMap.smulRight_apply,
     mfderiv_chartAt_eq_tangentCoordChange hsrc]
   rfl
+
+@[deprecated (since := "2025-06-29")] alias IsIntegralCurveOn.hasDerivAt :=
+  IsIntegralCurveOn.hasDerivWithinAt
 
 lemma IsIntegralCurveAt.eventually_hasDerivAt (hγ : IsIntegralCurveAt γ v t₀) :
     ∀ᶠ t in 𝓝 t₀, HasDerivAt ((extChartAt I (γ t₀)) ∘ γ)

--- a/Mathlib/Geometry/Manifold/IntegralCurve/Basic.lean
+++ b/Mathlib/Geometry/Manifold/IntegralCurve/Basic.lean
@@ -55,7 +55,7 @@ variable
 `IsIntegralCurveOn γ v s` means `γ t` is tangent to `v (γ t)` for all `t ∈ s`. The value of `γ`
 outside of `s` is irrelevant and considered junk. -/
 def IsIntegralCurveOn (γ : ℝ → M) (v : (x : M) → TangentSpace I x) (s : Set ℝ) : Prop :=
-  ∀ t ∈ s, HasMFDerivAt 𝓘(ℝ, ℝ) I γ t ((1 : ℝ →L[ℝ] ℝ).smulRight <| v (γ t))
+  ∀ t ∈ s, HasMFDerivWithinAt 𝓘(ℝ, ℝ) I γ s t ((1 : ℝ →L[ℝ] ℝ).smulRight <| v (γ t))
 
 /-- If `v` is a vector field on `M` and `t₀ : ℝ`, `IsIntegralCurveAt γ v t₀` means `γ : ℝ → M` is a
 local integral curve of `v` in a neighbourhood containing `t₀`. The value of `γ` outside of this
@@ -71,40 +71,64 @@ def IsIntegralCurve (γ : ℝ → M) (v : (x : M) → TangentSpace I x) : Prop :
 variable {γ γ' : ℝ → M} {v : (x : M) → TangentSpace I x} {s s' : Set ℝ} {t₀ : ℝ}
 
 lemma IsIntegralCurve.isIntegralCurveOn (h : IsIntegralCurve γ v) (s : Set ℝ) :
-    IsIntegralCurveOn γ v s := fun t _ ↦ h t
+    IsIntegralCurveOn γ v s := fun t _ ↦ (h t).hasMFDerivWithinAt
 
 lemma isIntegralCurve_iff_isIntegralCurveOn : IsIntegralCurve γ v ↔ IsIntegralCurveOn γ v univ :=
-  ⟨fun h ↦ h.isIntegralCurveOn _, fun h t ↦ h t (mem_univ _)⟩
+  ⟨fun h ↦ h.isIntegralCurveOn _, fun h t ↦ (h t (mem_univ _)).hasMFDerivAt Filter.univ_mem⟩
 
 lemma isIntegralCurveAt_iff :
     IsIntegralCurveAt γ v t₀ ↔ ∃ s ∈ 𝓝 t₀, IsIntegralCurveOn γ v s := by
-  simp_rw [IsIntegralCurveOn, ← Filter.eventually_iff_exists_mem, IsIntegralCurveAt]
+  constructor
+  · intro h
+    rw [IsIntegralCurveAt, Filter.eventually_iff_exists_mem] at h
+    obtain ⟨s, hs, h⟩ := h
+    exact ⟨s, hs, fun t ht ↦ (h t ht).hasMFDerivWithinAt⟩
+  · intro h
+    rw [IsIntegralCurveAt, Filter.eventually_iff_exists_mem]
+    obtain ⟨s, hs, h⟩ := h
+    rw [mem_nhds_iff] at hs
+    obtain ⟨s', h1, h2, h3⟩ := hs
+    refine ⟨s', h2.mem_nhds h3, ?_⟩
+    intro t ht
+    apply (h t (h1 ht)).hasMFDerivAt
+    rw [mem_nhds_iff]
+    exact ⟨s', h1, h2, ht⟩
 
 /-- `γ` is an integral curve for `v` at `t₀` iff `γ` is an integral curve on some interval
 containing `t₀`. -/
 lemma isIntegralCurveAt_iff' :
     IsIntegralCurveAt γ v t₀ ↔ ∃ ε > 0, IsIntegralCurveOn γ v (Metric.ball t₀ ε) := by
-  simp_rw [IsIntegralCurveOn, ← Metric.eventually_nhds_iff_ball, IsIntegralCurveAt]
+  rw [isIntegralCurveAt_iff]
+  constructor
+  · intro ⟨s, hs, h⟩
+    rw [Metric.mem_nhds_iff] at hs
+    obtain ⟨ε, hε, hε'⟩ := hs
+    refine ⟨ε, hε, ?_⟩
+    intro t ht
+    exact (h t (hε' ht)).mono hε'
+  · intro ⟨ε, hε, h⟩
+    exact ⟨Metric.ball t₀ ε, Metric.ball_mem_nhds _ hε, h⟩
 
 lemma IsIntegralCurve.isIntegralCurveAt (h : IsIntegralCurve γ v) (t : ℝ) :
-    IsIntegralCurveAt γ v t := isIntegralCurveAt_iff.mpr ⟨univ, Filter.univ_mem, fun t _ ↦ h t⟩
+    IsIntegralCurveAt γ v t :=
+  isIntegralCurveAt_iff.mpr ⟨univ, Filter.univ_mem, fun t _ ↦ (h t).hasMFDerivWithinAt⟩
 
 lemma isIntegralCurve_iff_isIntegralCurveAt :
     IsIntegralCurve γ v ↔ ∀ t : ℝ, IsIntegralCurveAt γ v t :=
   ⟨fun h ↦ h.isIntegralCurveAt, fun h t ↦ by
     obtain ⟨s, hs, h⟩ := isIntegralCurveAt_iff.mp (h t)
-    exact h t (mem_of_mem_nhds hs)⟩
+    exact h t (mem_of_mem_nhds hs) |>.hasMFDerivAt hs⟩
 
 lemma IsIntegralCurveOn.mono (h : IsIntegralCurveOn γ v s) (hs : s' ⊆ s) :
-    IsIntegralCurveOn γ v s' := fun t ht ↦ h t (mem_of_mem_of_subset ht hs)
+    IsIntegralCurveOn γ v s' := fun t ht ↦ (h t (hs ht)).mono hs
 
-lemma IsIntegralCurveOn.of_union (h : IsIntegralCurveOn γ v s) (h' : IsIntegralCurveOn γ v s') :
-    IsIntegralCurveOn γ v (s ∪ s') := fun _ ↦ fun | .inl ht => h _ ht | .inr ht => h' _ ht
+-- lemma IsIntegralCurveOn.of_union (h : IsIntegralCurveOn γ v s) (h' : IsIntegralCurveOn γ v s') :
+--     IsIntegralCurveOn γ v (s ∪ s') := fun _ ↦ fun | .inl ht => (h _ ht) | .inr ht => h' _ ht
 
 lemma IsIntegralCurveAt.hasMFDerivAt (h : IsIntegralCurveAt γ v t₀) :
     HasMFDerivAt 𝓘(ℝ, ℝ) I γ t₀ ((1 : ℝ →L[ℝ] ℝ).smulRight (v (γ t₀))) :=
   have ⟨_, hs, h⟩ := isIntegralCurveAt_iff.mp h
-  h t₀ (mem_of_mem_nhds hs)
+  h t₀ (mem_of_mem_nhds hs) |>.hasMFDerivAt hs
 
 lemma IsIntegralCurveOn.isIntegralCurveAt (h : IsIntegralCurveOn γ v s) (hs : s ∈ 𝓝 t₀) :
     IsIntegralCurveAt γ v t₀ := isIntegralCurveAt_iff.mpr ⟨s, hs, h⟩
@@ -113,40 +137,41 @@ lemma IsIntegralCurveOn.isIntegralCurveAt (h : IsIntegralCurveOn γ v s) (hs : s
 lemma IsIntegralCurveAt.isIntegralCurveOn (h : ∀ t ∈ s, IsIntegralCurveAt γ v t) :
     IsIntegralCurveOn γ v s := by
   intros t ht
-  obtain ⟨s, hs, h⟩ := isIntegralCurveAt_iff.mp (h t ht)
-  exact h t (mem_of_mem_nhds hs)
+  apply HasMFDerivAt.hasMFDerivWithinAt
+  obtain ⟨s', hs', h⟩ := Filter.eventually_iff_exists_mem.mp (h t ht)
+  exact h _ (mem_of_mem_nhds hs')
 
 lemma isIntegralCurveOn_iff_isIntegralCurveAt (hs : IsOpen s) :
     IsIntegralCurveOn γ v s ↔ ∀ t ∈ s, IsIntegralCurveAt γ v t :=
   ⟨fun h _ ht ↦ h.isIntegralCurveAt (hs.mem_nhds ht), IsIntegralCurveAt.isIntegralCurveOn⟩
 
-lemma IsIntegralCurveOn.continuousAt (hγ : IsIntegralCurveOn γ v s) (ht : t₀ ∈ s) :
-    ContinuousAt γ t₀ := (hγ t₀ ht).1
+lemma IsIntegralCurveOn.continuousWithinAt (hγ : IsIntegralCurveOn γ v s) (ht : t₀ ∈ s) :
+    ContinuousWithinAt γ s t₀ := (hγ t₀ ht).1
 
 lemma IsIntegralCurveOn.continuousOn (hγ : IsIntegralCurveOn γ v s) :
-    ContinuousOn γ s := fun t ht ↦ (hγ t ht).1.continuousWithinAt
+    ContinuousOn γ s := fun t ht ↦ (hγ t ht).continuousWithinAt
 
 lemma IsIntegralCurveAt.continuousAt (hγ : IsIntegralCurveAt γ v t₀) :
     ContinuousAt γ t₀ :=
   have ⟨_, hs, hγ⟩ := isIntegralCurveAt_iff.mp hγ
-  hγ.continuousAt <| mem_of_mem_nhds hs
+  hγ.continuousWithinAt (mem_of_mem_nhds hs) |>.continuousAt hs
 
 lemma IsIntegralCurve.continuous (hγ : IsIntegralCurve γ v) : Continuous γ :=
-  continuous_iff_continuousAt.mpr fun _ ↦ (hγ.isIntegralCurveOn univ).continuousAt (mem_univ _)
+  continuous_iff_continuousAt.mpr fun t ↦ (hγ.isIntegralCurveAt t).continuousAt
 
 variable [IsManifold I 1 M]
 
 /-- If `γ` is an integral curve of a vector field `v`, then `γ t` is tangent to `v (γ t)` when
 expressed in the local chart around the initial point `γ t₀`. -/
-lemma IsIntegralCurveOn.hasDerivAt (hγ : IsIntegralCurveOn γ v s) {t : ℝ} (ht : t ∈ s)
+lemma IsIntegralCurveOn.hasDerivWithinAt (hγ : IsIntegralCurveOn γ v s) {t : ℝ} (ht : t ∈ s)
     (hsrc : γ t ∈ (extChartAt I (γ t₀)).source) :
-    HasDerivAt ((extChartAt I (γ t₀)) ∘ γ)
-      (tangentCoordChange I (γ t) (γ t₀) (γ t) (v (γ t))) t := by
-  -- turn `HasDerivAt` into comp of `HasMFDerivAt`
-  have hsrc := extChartAt_source I (γ t₀) ▸ hsrc
-  rw [hasDerivAt_iff_hasFDerivAt, ← hasMFDerivAt_iff_hasFDerivAt]
-  apply (HasMFDerivAt.comp t
-    (hasMFDerivAt_extChartAt (I := I) hsrc) (hγ _ ht)).congr_mfderiv
+    HasDerivWithinAt ((extChartAt I (γ t₀)) ∘ γ)
+      (tangentCoordChange I (γ t) (γ t₀) (γ t) (v (γ t))) s t := by
+  -- turn `HasDerivWithinAt` into comp of `HasMFDerivWithinAt`
+  replace hsrc := extChartAt_source I (γ t₀) ▸ hsrc
+  rw [hasDerivWithinAt_iff_hasFDerivWithinAt, ← hasMFDerivWithinAt_iff_hasFDerivWithinAt]
+  apply (HasMFDerivWithinAt.comp t (hasMFDerivWithinAt_extChartAt (I := I) hsrc) (hγ _ ht)
+    (Set.subset_preimage_image _ _)).congr_mfderiv
   rw [ContinuousLinearMap.ext_iff]
   intro a
   rw [ContinuousLinearMap.comp_apply, ContinuousLinearMap.smulRight_apply, map_smul,

--- a/Mathlib/Geometry/Manifold/IntegralCurve/ExistUnique.lean
+++ b/Mathlib/Geometry/Manifold/IntegralCurve/ExistUnique.lean
@@ -90,6 +90,7 @@ theorem exists_isIntegralCurveAt_of_contMDiffAt [CompleteSpace E]
     mem_of_mem_of_subset hf3' (extChartAt I x₀).target_subset_preimage_source
   have hft2 := mem_extChartAt_source (I := I) xₜ
   -- express the derivative of the integral curve in the local chart
+  apply HasMFDerivAt.hasMFDerivWithinAt
   refine ⟨(continuousAt_extChartAt_symm'' hf3').comp h.continuousAt,
     HasDerivWithinAt.hasFDerivWithinAt ?_⟩
   simp only [mfld_simps, hasDerivWithinAt_univ]
@@ -201,12 +202,12 @@ theorem isIntegralCurveOn_Ioo_eqOn_of_contMDiff (ht₀ : t₀ ∈ Ioo a b)
       rintro ⟨_, ht⟩
       apply ContinuousAt.comp _ continuousAt_subtype_val
       rw [Subtype.coe_mk]
-      exact hγ.continuousAt ht
+      exact hγ.continuousWithinAt ht |>.continuousAt (Ioo_mem_nhds ht.1 ht.2)
     · rw [continuous_iff_continuousAt]
       rintro ⟨_, ht⟩
       apply ContinuousAt.comp _ continuousAt_subtype_val
       rw [Subtype.coe_mk]
-      exact hγ'.continuousAt ht
+      exact hγ'.continuousWithinAt ht |>.continuousAt (Ioo_mem_nhds ht.1 ht.2)
   · rw [isOpen_iff_mem_nhds]
     intro t₁ ht₁
     have hmem := Ioo_mem_nhds ht₁.2.1 ht₁.2.2

--- a/Mathlib/Geometry/Manifold/IntegralCurve/Transform.lean
+++ b/Mathlib/Geometry/Manifold/IntegralCurve/Transform.lean
@@ -38,10 +38,16 @@ lemma IsIntegralCurveOn.comp_add (hγ : IsIntegralCurveOn γ v s) (dt : ℝ) :
   rw [comp_apply, ← ContinuousLinearMap.comp_id (ContinuousLinearMap.smulRight 1 (v (γ (t + dt))))]
   rw [mem_vadd_set_iff_neg_vadd_mem, neg_neg, vadd_eq_add, add_comm,
     ← mem_setOf (p := fun t ↦ t + dt ∈ s)] at ht
-  apply HasMFDerivAt.comp t (hγ (t + dt) ht)
-  refine ⟨(continuous_add_right _).continuousAt, ?_⟩
+  have : -dt +ᵥ s ⊆ (fun x ↦ x + dt) ⁻¹' s := by
+    intro t' ht'
+    rw [Set.mem_vadd_set] at ht'
+    obtain ⟨t'', ht'', heq⟩ := ht'
+    rw [vadd_eq_add, neg_add_eq_iff_eq_add, add_comm] at heq
+    rwa [Set.mem_preimage, ← heq]
+  apply HasMFDerivWithinAt.comp t (hγ (t + dt) ht) _ this
+  refine ⟨(continuous_add_right _).continuousWithinAt, ?_⟩
   simp only [mfld_simps, hasFDerivWithinAt_univ]
-  exact (hasFDerivAt_id _).add_const _
+  exact (hasFDerivWithinAt_id _ _).add_const _
 
 lemma isIntegralCurveOn_comp_add {dt : ℝ} :
     IsIntegralCurveOn γ v s ↔ IsIntegralCurveOn (γ ∘ (· + dt)) v (-dt +ᵥ s) := by
@@ -101,9 +107,15 @@ lemma IsIntegralCurveOn.comp_mul (hγ : IsIntegralCurveOn γ v s) (a : ℝ) :
     IsIntegralCurveOn (γ ∘ (· * a)) (a • v) { t | t * a ∈ s } := by
   intros t ht
   rw [comp_apply, Pi.smul_apply, ← ContinuousLinearMap.smulRight_comp]
-  refine HasMFDerivAt.comp t (hγ (t * a) ht) ⟨(continuous_mul_right _).continuousAt, ?_⟩
+  have : {t | t * a ∈ s} ⊆ (fun x ↦ x * a) ⁻¹' s := by
+    intro t' ht'
+    rw [Set.mem_setOf] at ht'
+    rw [Set.mem_preimage]
+    exact ht'
+  refine HasMFDerivWithinAt.comp t (hγ (t * a) ht)
+    ⟨(continuous_mul_right _).continuousWithinAt, ?_⟩ this
   simp only [mfld_simps, hasFDerivWithinAt_univ]
-  exact HasFDerivAt.mul_const' (hasFDerivAt_id _) _
+  exact HasFDerivWithinAt.mul_const' (hasFDerivWithinAt_id _ _) _
 
 lemma isIntegralCurveOn_comp_mul_ne_zero {a : ℝ} (ha : a ≠ 0) :
     IsIntegralCurveOn γ v s ↔ IsIntegralCurveOn (γ ∘ (· * a)) (a • v) { t | t * a ∈ s } := by

--- a/Mathlib/Geometry/Manifold/IntegralCurve/Transform.lean
+++ b/Mathlib/Geometry/Manifold/IntegralCurve/Transform.lean
@@ -39,11 +39,8 @@ lemma IsIntegralCurveOn.comp_add (hγ : IsIntegralCurveOn γ v s) (dt : ℝ) :
   rw [mem_vadd_set_iff_neg_vadd_mem, neg_neg, vadd_eq_add, add_comm,
     ← mem_setOf (p := fun t ↦ t + dt ∈ s)] at ht
   have : -dt +ᵥ s ⊆ (fun x ↦ x + dt) ⁻¹' s := by
-    intro t' ht'
-    rw [Set.mem_vadd_set] at ht'
-    obtain ⟨t'', ht'', heq⟩ := ht'
-    rw [vadd_eq_add, neg_add_eq_iff_eq_add, add_comm] at heq
-    rwa [Set.mem_preimage, ← heq]
+    rw [Set.preimage, Set.subset_setOf]
+    simp_rw [Set.mem_neg_vadd_set_iff, vadd_eq_add, add_comm dt, imp_self, forall_true_iff]
   apply HasMFDerivWithinAt.comp t (hγ (t + dt) ht) _ this
   refine ⟨(continuous_add_right _).continuousWithinAt, ?_⟩
   simp only [mfld_simps, hasFDerivWithinAt_univ]
@@ -107,13 +104,8 @@ lemma IsIntegralCurveOn.comp_mul (hγ : IsIntegralCurveOn γ v s) (a : ℝ) :
     IsIntegralCurveOn (γ ∘ (· * a)) (a • v) { t | t * a ∈ s } := by
   intros t ht
   rw [comp_apply, Pi.smul_apply, ← ContinuousLinearMap.smulRight_comp]
-  have : {t | t * a ∈ s} ⊆ (fun x ↦ x * a) ⁻¹' s := by
-    intro t' ht'
-    rw [Set.mem_setOf] at ht'
-    rw [Set.mem_preimage]
-    exact ht'
   refine HasMFDerivWithinAt.comp t (hγ (t * a) ht)
-    ⟨(continuous_mul_right _).continuousWithinAt, ?_⟩ this
+    ⟨(continuous_mul_right _).continuousWithinAt, ?_⟩ subset_rfl
   simp only [mfld_simps, hasFDerivWithinAt_univ]
   exact HasFDerivWithinAt.mul_const' (hasFDerivWithinAt_id _ _) _
 

--- a/Mathlib/Geometry/Manifold/IntegralCurve/Transform.lean
+++ b/Mathlib/Geometry/Manifold/IntegralCurve/Transform.lean
@@ -102,7 +102,7 @@ lemma IsIntegralCurveOn.comp_mul (hγ : IsIntegralCurveOn γ v s) (a : ℝ) :
   rw [comp_apply, Pi.smul_apply, ← ContinuousLinearMap.smulRight_comp]
   refine HasMFDerivWithinAt.comp t (hγ (t * a) ht)
     ⟨(continuous_mul_right _).continuousWithinAt, ?_⟩ subset_rfl
-  simp only [mfld_simps, hasFDerivWithinAt_univ]
+  simp only [mfld_simps]
   exact HasFDerivWithinAt.mul_const' (hasFDerivWithinAt_id _ _) _
 
 lemma isIntegralCurveOn_comp_mul_ne_zero {a : ℝ} (ha : a ≠ 0) :

--- a/Mathlib/Geometry/Manifold/IntegralCurve/Transform.lean
+++ b/Mathlib/Geometry/Manifold/IntegralCurve/Transform.lean
@@ -38,7 +38,7 @@ lemma IsIntegralCurveOn.comp_add (hγ : IsIntegralCurveOn γ v s) (dt : ℝ) :
   rw [comp_apply, ← ContinuousLinearMap.comp_id (ContinuousLinearMap.smulRight 1 (v (γ (t + dt))))]
   apply HasMFDerivWithinAt.comp t (hγ (t + dt) ht) _ subset_rfl
   refine ⟨(continuous_add_right _).continuousWithinAt, ?_⟩
-  simp only [mfld_simps, hasFDerivWithinAt_univ]
+  simp only [mfld_simps]
   exact (hasFDerivWithinAt_id _ _).add_const _
 
 lemma isIntegralCurveOn_comp_add {dt : ℝ} :

--- a/Mathlib/Geometry/Manifold/IntegralCurve/Transform.lean
+++ b/Mathlib/Geometry/Manifold/IntegralCurve/Transform.lean
@@ -20,7 +20,7 @@ curve.
 integral curve, vector field
 -/
 
-open Function Set Pointwise
+open Function Set
 
 variable
   {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
@@ -33,29 +33,24 @@ variable
 section Translation
 
 lemma IsIntegralCurveOn.comp_add (hγ : IsIntegralCurveOn γ v s) (dt : ℝ) :
-    IsIntegralCurveOn (γ ∘ (· + dt)) v (-dt +ᵥ s) := by
+    IsIntegralCurveOn (γ ∘ (· + dt)) v { t | t + dt ∈ s } := by
   intros t ht
   rw [comp_apply, ← ContinuousLinearMap.comp_id (ContinuousLinearMap.smulRight 1 (v (γ (t + dt))))]
-  rw [mem_vadd_set_iff_neg_vadd_mem, neg_neg, vadd_eq_add, add_comm,
-    ← mem_setOf (p := fun t ↦ t + dt ∈ s)] at ht
-  have : -dt +ᵥ s ⊆ (fun x ↦ x + dt) ⁻¹' s := by
-    rw [Set.preimage, Set.subset_setOf]
-    simp_rw [Set.mem_neg_vadd_set_iff, vadd_eq_add, add_comm dt, imp_self, forall_true_iff]
-  apply HasMFDerivWithinAt.comp t (hγ (t + dt) ht) _ this
+  apply HasMFDerivWithinAt.comp t (hγ (t + dt) ht) _ subset_rfl
   refine ⟨(continuous_add_right _).continuousWithinAt, ?_⟩
   simp only [mfld_simps, hasFDerivWithinAt_univ]
   exact (hasFDerivWithinAt_id _ _).add_const _
 
 lemma isIntegralCurveOn_comp_add {dt : ℝ} :
-    IsIntegralCurveOn γ v s ↔ IsIntegralCurveOn (γ ∘ (· + dt)) v (-dt +ᵥ s) := by
+    IsIntegralCurveOn γ v s ↔ IsIntegralCurveOn (γ ∘ (· + dt)) v { t | t + dt ∈ s } := by
   refine ⟨fun hγ ↦ hγ.comp_add _, fun hγ ↦ ?_⟩
   convert hγ.comp_add (-dt)
   · ext t
-    simp only [Function.comp_apply, neg_add_cancel_right]
-  · simp only [neg_neg, vadd_neg_vadd]
+    simp
+  · simp
 
 lemma isIntegralCurveOn_comp_sub {dt : ℝ} :
-    IsIntegralCurveOn γ v s ↔ IsIntegralCurveOn (γ ∘ (· - dt)) v (dt +ᵥ s) := by
+    IsIntegralCurveOn γ v s ↔ IsIntegralCurveOn (γ ∘ (· - dt)) v { t | t - dt ∈ s } := by
   simpa using isIntegralCurveOn_comp_add (dt := -dt)
 
 lemma IsIntegralCurveAt.comp_add (hγ : IsIntegralCurveAt γ v t₀) (dt : ℝ) :
@@ -64,7 +59,8 @@ lemma IsIntegralCurveAt.comp_add (hγ : IsIntegralCurveAt γ v t₀) (dt : ℝ) 
   obtain ⟨ε, hε, h⟩ := hγ
   refine ⟨ε, hε, ?_⟩
   convert h.comp_add dt
-  rw [Metric.vadd_ball, vadd_eq_add, neg_add_eq_sub]
+  rw [Metric.ball]
+  simp_rw [Metric.mem_ball, Real.dist_eq, ← sub_add, add_sub_right_comm]
 
 lemma isIntegralCurveAt_comp_add {dt : ℝ} :
     IsIntegralCurveAt γ v t₀ ↔ IsIntegralCurveAt (γ ∘ (· + dt)) v (t₀ - dt) := by

--- a/Mathlib/Geometry/Manifold/IntegralCurve/UniformTime.lean
+++ b/Mathlib/Geometry/Manifold/IntegralCurve/UniformTime.lean
@@ -189,9 +189,8 @@ lemma exists_isIntegralCurve_of_isIntegralCurveOn [BoundarylessManifold I M]
   set γ2 := γ2_aux ∘ (· - (asup - ε / 2)) with γ2_def
   have heq2 : γ2 (asup - ε / 2) = γ (asup - ε / 2) := by simp [γ2_def, h2_aux]
   -- rewrite shifted Ioo as Ioo
-  rw [neg_sub] at hγ1
-  rw [Real.Ioo_eq_ball, neg_add_cancel, zero_div, sub_neg_eq_add, add_self_div_two,
-    Metric.vadd_ball, vadd_eq_add, add_zero, Real.ball_eq_Ioo] at hγ1 hγ2
+  simp_rw [Set.mem_Ioo, ← sub_lt_iff_lt_add, ← lt_sub_iff_add_lt, ← Set.mem_Ioo] at hγ1
+  simp_rw [Set.mem_Ioo, lt_sub_iff_add_lt, sub_lt_iff_lt_add, ← Set.mem_Ioo] at hγ2
   -- to help `linarith`
   have hεle : ε ≤ asup := le_csSup hbdd (h x)
   -- extend `γ` on the left by `γ1` and on the right by `γ2`


### PR DESCRIPTION
I change the definition of `IsIntegralCurveOn` to use `HasMFDerivWithinAt`, rather than `HasMFDerivAt`, so as to make this definition consistent with `DifferentiableOn` and `ContinuousOn`. While the API around it slightly changes, there is no effect on the statement of any downstream lemmas.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
