### PR TITLE
[Merged by Bors] - feat(RingTheory/Valuation/Extension): add algebra instances

### DIFF
--- a/Mathlib/RingTheory/Valuation/Extension.lean
+++ b/Mathlib/RingTheory/Valuation/Extension.lean
@@ -191,8 +191,7 @@ instance : IsLocalHom (algebraMap K₀ L₀) := instIsLocalHomValuationInteger
 
 lemma algebraMap_mem_maximalIdeal_iff {x : K₀} :
     algebraMap K₀ L₀ x ∈ (maximalIdeal L₀) ↔ x ∈ maximalIdeal K₀ := by
-  simp only [mem_maximalIdeal_iff, coe_algebraMap_valuationSubring_eq,
-    val_map_lt_one_iff vK vL]
+  simp [mem_maximalIdeal, map_mem_nonunits_iff, _root_.mem_nonunits_iff]
 
 lemma maximalIdeal_comap_algebraMap_eq_maximalIdeal :
     (maximalIdeal L₀).comap (algebraMap K₀ L₀) = maximalIdeal K₀ :=
@@ -201,7 +200,8 @@ lemma maximalIdeal_comap_algebraMap_eq_maximalIdeal :
 instance : Ideal.LiesOver (maximalIdeal L₀) (maximalIdeal K₀) :=
   ⟨(maximalIdeal_comap_algebraMap_eq_maximalIdeal _ _).symm⟩
 
-noncomputable instance : Algebra (ResidueField K₀) (ResidueField L₀) := inferInstance
+noncomputable instance instAlgebra_residueField :
+    Algebra (ResidueField K₀) (ResidueField L₀) := inferInstance
 
 lemma algebraMap_residue_eq_residue_algebraMap (x : K₀) :
     (algebraMap (ResidueField K₀) (ResidueField L₀)) (IsLocalRing.residue K₀ x) =

--- a/Mathlib/RingTheory/Valuation/Extension.lean
+++ b/Mathlib/RingTheory/Valuation/Extension.lean
@@ -200,9 +200,6 @@ lemma maximalIdeal_comap_algebraMap_eq_maximalIdeal :
 instance : Ideal.LiesOver (maximalIdeal L₀) (maximalIdeal K₀) :=
   ⟨(maximalIdeal_comap_algebraMap_eq_maximalIdeal _ _).symm⟩
 
-noncomputable instance instAlgebra_residueField :
-    Algebra (ResidueField K₀) (ResidueField L₀) := inferInstance
-
 lemma algebraMap_residue_eq_residue_algebraMap (x : K₀) :
     (algebraMap (ResidueField K₀) (ResidueField L₀)) (IsLocalRing.residue K₀ x) =
       IsLocalRing.residue L₀ (algebraMap K₀ L₀ x) :=

--- a/Mathlib/RingTheory/Valuation/Extension.lean
+++ b/Mathlib/RingTheory/Valuation/Extension.lean
@@ -166,7 +166,7 @@ variable {K L Γ₀ Γ₁ : outParam Type*} [Field K] [Field L] [Algebra K L]
   [LinearOrderedCommGroupWithZero Γ₀] [LinearOrderedCommGroupWithZero Γ₁] (vK : Valuation K Γ₀)
    (vL : Valuation L Γ₁) [vK.HasExtension vL]
 
-local notation "K₀" => vK.valuationSubring
+local notation "K₀" => Valuation.valuationSubring vK
 local notation "L₀" => Valuation.valuationSubring vL
 
 lemma algebraMap_mem_valuationSubring (x : K₀) : algebraMap K L x ∈ L₀ := by
@@ -190,26 +190,36 @@ lemma coe_algebraMap_valuationSubring_eq (x : K₀) :
 
 instance instIsScalarTower_valuationSubring : IsScalarTower K₀ K L := by
   refine IsScalarTower.of_algebraMap_smul ?_
-  intro k l
-  have hkl : k • l = (k : K) • l := rfl
-  simp [Algebra.smul_def, hkl]
+  intro k
+  simp [Algebra.smul_def, Subring.smul_def k]
 
 instance instIsScalarTower_valuationSubring' : IsScalarTower K₀ L₀ L := by
   refine IsScalarTower.of_algebraMap_smul ?_
-  intro k l
-  have hkl : k • l = (k : K) • l := rfl
-  simp [Algebra.smul_def, hkl]
+  intro k
+  simp [Algebra.smul_def, Subring.smul_def k]
 
 lemma algebraMap_mem_maximalIdeal_iff {x : K₀} :
     algebraMap K₀ L₀ x ∈ (maximalIdeal L₀) ↔ x ∈ maximalIdeal K₀ := by
   simp only [mem_maximalIdeal_iff, coe_algebraMap_valuationSubring_eq,
     val_map_lt_one_iff vK vL]
 
+lemma maximalIdeal_comap_algebraMap_eq_maximalIdeal :
+    (maximalIdeal L₀).comap (algebraMap K₀ L₀) = maximalIdeal K₀ :=
+  Ideal.ext fun _ ↦ by rw [Ideal.mem_comap, algebraMap_mem_maximalIdeal_iff]
+
+instance : Ideal.LiesOver (maximalIdeal L₀) (maximalIdeal K₀) :=
+  ⟨(maximalIdeal_comap_algebraMap_eq_maximalIdeal _ _).symm⟩
+
 instance : Algebra (ResidueField K₀) (ResidueField L₀) :=
   (Ideal.Quotient.lift (maximalIdeal K₀)
     ((Ideal.Quotient.mk (maximalIdeal L₀)).comp (algebraMap K₀ L₀))
     (fun _ hx ↦ Ideal.Quotient.eq_zero_iff_mem.mpr
       ((algebraMap_mem_maximalIdeal_iff vK vL).mpr hx))).toAlgebra
+
+lemma algebraMap_residue_eq_residue_algebraMap (x : K₀) :
+    (algebraMap (ResidueField K₀) (ResidueField L₀)) (IsLocalRing.residue K₀ x) =
+      IsLocalRing.residue L₀ (algebraMap K₀ L₀ x) :=
+  rfl
 
 end AlgebraInstances
 

--- a/Mathlib/RingTheory/Valuation/Extension.lean
+++ b/Mathlib/RingTheory/Valuation/Extension.lean
@@ -175,28 +175,19 @@ lemma algebraMap_mem_valuationSubring (x : K₀) : algebraMap K L x ∈ L₀ := 
   exact x.2
 
 instance instAlgebra_valuationSubring : Algebra K₀ L₀ :=
-  let f : K₀ →+* L₀ := {
-    toFun := fun x ↦ ⟨algebraMap K L x, algebraMap_mem_valuationSubring vK vL x⟩
-    map_one'  := by simp [_root_.map_one, ← @OneMemClass.coe_eq_one]
-    map_mul'  := by simp [MulMemClass.coe_mul, _root_.map_mul, MulMemClass.mk_mul_mk, implies_true]
-    map_zero' := by simp [← ZeroMemClass.coe_eq_zero, _root_.map_zero]
-    map_add'  := by simp only [AddMemClass.coe_add, _root_.map_add, AddMemClass.mk_add_mk,
-      implies_true] }
-  f.toAlgebra
+  inferInstanceAs (Algebra vK.integer vL.integer)
 
 @[simp]
 lemma coe_algebraMap_valuationSubring_eq (x : K₀) :
   (algebraMap K₀ L₀ x : L) = algebraMap K L (x : K) := rfl
 
-instance instIsScalarTower_valuationSubring : IsScalarTower K₀ K L := by
-  refine IsScalarTower.of_algebraMap_smul ?_
-  intro k
-  simp [Algebra.smul_def, Subring.smul_def k]
+instance instIsScalarTower_valuationSubring : IsScalarTower K₀ K L :=
+  inferInstanceAs (IsScalarTower vK.integer K L)
 
-instance instIsScalarTower_valuationSubring' : IsScalarTower K₀ L₀ L := by
-  refine IsScalarTower.of_algebraMap_smul ?_
-  intro k
-  simp [Algebra.smul_def, Subring.smul_def k]
+instance instIsScalarTower_valuationSubring' : IsScalarTower K₀ L₀ L :=
+  instIsScalarTowerInteger
+
+instance : IsLocalHom (algebraMap K₀ L₀) := instIsLocalHomValuationInteger
 
 lemma algebraMap_mem_maximalIdeal_iff {x : K₀} :
     algebraMap K₀ L₀ x ∈ (maximalIdeal L₀) ↔ x ∈ maximalIdeal K₀ := by
@@ -210,11 +201,7 @@ lemma maximalIdeal_comap_algebraMap_eq_maximalIdeal :
 instance : Ideal.LiesOver (maximalIdeal L₀) (maximalIdeal K₀) :=
   ⟨(maximalIdeal_comap_algebraMap_eq_maximalIdeal _ _).symm⟩
 
-instance : Algebra (ResidueField K₀) (ResidueField L₀) :=
-  (Ideal.Quotient.lift (maximalIdeal K₀)
-    ((Ideal.Quotient.mk (maximalIdeal L₀)).comp (algebraMap K₀ L₀))
-    (fun _ hx ↦ Ideal.Quotient.eq_zero_iff_mem.mpr
-      ((algebraMap_mem_maximalIdeal_iff vK vL).mpr hx))).toAlgebra
+noncomputable instance : Algebra (ResidueField K₀) (ResidueField L₀) := inferInstance
 
 lemma algebraMap_residue_eq_residue_algebraMap (x : K₀) :
     (algebraMap (ResidueField K₀) (ResidueField L₀)) (IsLocalRing.residue K₀ x) =


### PR DESCRIPTION
Provide algebra instances for valuation subrings and residue fields. 

Co-authored-by: @faenuccio 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
