### PR TITLE
[Merged by Bors] - chore: register the fact that a topological space that is `T₀` and `R₀` is `T₁` as a typeclass instance

### DIFF
--- a/Mathlib/Topology/Separation/Basic.lean
+++ b/Mathlib/Topology/Separation/Basic.lean
@@ -489,7 +489,7 @@ instance (priority := 100) [T1Space X] : R0Space X :=
 instance : T1Space (CofiniteTopology X) :=
   t1Space_iff_continuous_cofinite_of.mpr continuous_id
 
-theorem t1Space_of_t0Space_of_r0Space [T0Space X] [R0Space X] : T1Space X :=
+instance (priority := 80) [T0Space X] [R0Space X] : T1Space X :=
   t1Space_iff_t0Space_and_r0Space.mpr ⟨‹T0Space X›, ‹R0Space X›⟩
 
 theorem t1Space_antitone {X} : Antitone (@T1Space X) := fun a _ h _ =>

--- a/Mathlib/Topology/Separation/GDelta.lean
+++ b/Mathlib/Topology/Separation/GDelta.lean
@@ -126,7 +126,6 @@ class T6Space (X : Type u) [TopologicalSpace X] : Prop extends T0Space X, Perfec
 -- see Note [lower instance priority]
 /-- A `T₆` space is a `T₅` space. -/
 instance (priority := 100) T6Space.toT5Space [T6Space X] : T5Space X where
-  toT1Space := t1Space_of_t0Space_of_r0Space
 
 end PerfectlyNormal
 


### PR DESCRIPTION
As [instT2SpaceOfR1SpaceOfT0Space](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/Separation/Hausdorff.html#instT2SpaceOfR1SpaceOfT0Space).
I forgot to do this in my PR(#26064).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
