### PR TITLE
[Merged by Bors] - fix(Cache): check for urls in the remote before querying for the url 

### DIFF
--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -28,10 +28,19 @@ def extractRepoFromUrl (url : String) : Option String := do
   let pos ← url.revFindAux (fun c => c == '/'  || c == ':') pos
   return url.extract (url.next pos) url.endPos
 
+/-- Spot check if a URL is valid for a git remote -/
+def isRemoteURL (url : String) : Bool :=
+  "https://".isPrefixOf url || "http://".isPrefixOf url || "git@github.com:".isPrefixOf url
+
 /--
 Helper function to get repository from a remote name
 -/
 def getRepoFromRemote (mathlibDepPath : FilePath) (remoteName : String) (errorContext : String) : IO String := do
+  IO.println s!"Is {remoteName} a remote URL? {isRemoteURL remoteName}"
+  -- Remove the previous print statement and uncomment when confident
+  -- if isRemoteURL remoteName then
+  --   return remoteName
+  -- else
   let out ← IO.Process.output
     {cmd := "git", args := #["remote", "get-url", remoteName], cwd := mathlibDepPath}
   unless out.exitCode == 0 do

--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -37,7 +37,7 @@ Helper function to get repository from a remote name
 -/
 def getRepoFromRemote (mathlibDepPath : FilePath) (remoteName : String) (errorContext : String) : IO String := do
   IO.println s!"Is {remoteName} a remote URL? {isRemoteURL remoteName}"
-  -- Remove the previous print statement and uncomment when confident
+  -- Remove the print statement above and uncomment the lines below when confident
   -- if isRemoteURL remoteName then
   --   return remoteName
   -- else


### PR DESCRIPTION
It can happen, as with `gh pr checkout`, that the remote is not a regular name but a URL. Currently, `getRepoFromRemote` calls `git remote get-url` which chokes on an actual URL breaking the logic for getting the repo name.

Here we provide a basic spot check for whether the remote is already a URL. If so, we return it directly. Otherwise, we continue with the existing logic.

Note: we comment out any actually changes to the logic but include a print statement to show what the logic would have been. We do this out of an abundance of caution, as we don't want to break existing CI. This needs to be tested sufficiently and then the commented code can be uncommented.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
