### PR TITLE
[Merged by Bors] - debug(Cache): add print statements to test output of current vs quoted argument of git 

### DIFF
--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -160,6 +160,13 @@ def getRemoteRepo (mathlibDepPath : FilePath) : IO RepoInfo := do
         let prRefPattern := s!"refs/remotes/{mathlibRemoteName}/pr/*"
         let refsInfo ← IO.Process.output
           {cmd := "git", args := #["for-each-ref", "--contains", commit, prRefPattern, "--format=%(refname)"], cwd := mathlibDepPath}
+        -- The code below is for debugging purposes currently
+        IO.println s!"`git for-each-ref --contains {commit} {prRefPattern} --format=%(refname)` returned:
+        {refsInfo.stdout.trim} with exit code {refsInfo.exitCode} and stderr: {refsInfo.stderr.trim}."
+        let refsInfo' ← IO.Process.output
+          {cmd := "git", args := #["for-each-ref", "--contains", commit, prRefPattern, "--format=\"%(refname)\""], cwd := mathlibDepPath}
+        IO.println s!"`git for-each-ref --contains {commit} {prRefPattern} --format=\"%(refname)\"` returned:
+        {refsInfo'.stdout.trim} with exit code {refsInfo'.exitCode} and stderr: {refsInfo'.stderr.trim}."
 
         if refsInfo.exitCode == 0 && !refsInfo.stdout.trim.isEmpty then
           let prRefs := refsInfo.stdout.trim.split (· == '\n')


### PR DESCRIPTION
It appears [that](https://git-scm.com/docs/git-for-each-ref) the argument `%(ref-name)` needs quotes to be interpreted as a string.

This PR compares the outputs with and without the quotes and prints the results. We will check behavior in CI to evaluate the impact of this change.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
