### PR TITLE
[Merged by Bors] - chore: deprecate Mathlib.Algebra.Ring.Hom.Basic

### DIFF
--- a/Mathlib/Algebra/Ring/Hom/Basic.lean
+++ b/Mathlib/Algebra/Ring/Hom/Basic.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Amelia Livingston, Jireh Loreaux
 -/
 
-import Mathlib.Algebra.Ring.Hom.Defs
+import Mathlib.Algebra.Ring.Hom.InjSurj
+import Mathlib.Deprecated.RingHom
+import Mathlib.Tactic.Linter.DeprecatedModule
 
 deprecated_module (since := "2025-06-09")

--- a/Mathlib/Algebra/Ring/Hom/Basic.lean
+++ b/Mathlib/Algebra/Ring/Hom/Basic.lean
@@ -6,12 +6,4 @@ Authors: Amelia Livingston, Jireh Loreaux
 
 import Mathlib.Algebra.Ring.Hom.Defs
 
-/-!
-# Additional lemmas about homomorphisms of semirings and rings
--/
-
-assert_not_exists RelIso Field
-
-namespace RingHom
-
-end RingHom
+deprecated_module (since := "2025-06-09")


### PR DESCRIPTION
It was emptied in #25447.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
