### PR TITLE
[Merged by Bors] - feat: additional API for `prod_subset_prod`

### DIFF
--- a/Mathlib/Data/Set/Prod.lean
+++ b/Mathlib/Data/Set/Prod.lean
@@ -357,16 +357,10 @@ theorem prod_subset_prod_iff' (h : (s ×ˢ t).Nonempty) : s ×ˢ t ⊆ s₁ ×ˢ
   exact h.ne_empty
 
 theorem prod_subset_prod_iff_left (h : t.Nonempty) : s ×ˢ t ⊆ s₁ ×ˢ t ↔ s ⊆ s₁ := by
-  rw [prod_subset_prod_iff, ← or_assoc, or_iff_left h.ne_empty, and_iff_left subset_rfl,
-    or_iff_left_of_imp]
-  intro heq
-  simp [heq]
+  simp +contextual [prod_subset_prod_iff, or_iff_left h.ne_empty]
 
 theorem prod_subset_prod_iff_right (h : s.Nonempty) : s ×ˢ t ⊆ s ×ˢ t₁ ↔ t ⊆ t₁ := by
-  rw [prod_subset_prod_iff, or_comm (a := s = ∅), ← or_assoc, or_iff_left h.ne_empty,
-    and_iff_right subset_rfl, or_iff_left_of_imp]
-  intro heq
-  simp [heq]
+  simp +contextual [prod_subset_prod_iff, or_comm (a := s = ∅), or_iff_left h.ne_empty]
 
 theorem prod_eq_prod_iff_of_nonempty (h : (s ×ˢ t).Nonempty) :
     s ×ˢ t = s₁ ×ˢ t₁ ↔ s = s₁ ∧ t = t₁ := by

--- a/Mathlib/Data/Set/Prod.lean
+++ b/Mathlib/Data/Set/Prod.lean
@@ -50,9 +50,13 @@ theorem prod_mono (hs : s₁ ⊆ s₂) (ht : t₁ ⊆ t₂) : s₁ ×ˢ t₁ ⊆
 theorem prod_mono_left (hs : s₁ ⊆ s₂) : s₁ ×ˢ t ⊆ s₂ ×ˢ t :=
   prod_mono hs Subset.rfl
 
+alias prod_subset_prod_left := prod_mono_left
+
 @[gcongr]
 theorem prod_mono_right (ht : t₁ ⊆ t₂) : s ×ˢ t₁ ⊆ s ×ˢ t₂ :=
   prod_mono Subset.rfl ht
+
+alias prod_subset_prod_right := prod_mono_right
 
 @[simp]
 theorem prod_self_subset_prod_self : s₁ ×ˢ s₁ ⊆ s₂ ×ˢ s₂ ↔ s₁ ⊆ s₂ :=
@@ -351,12 +355,6 @@ theorem prod_subset_prod_iff' (h : (s ×ˢ t).Nonempty) : s ×ˢ t ⊆ s₁ ×ˢ
   rw [prod_subset_prod_iff, or_iff_left]
   rw [← Set.prod_eq_empty_iff]
   exact h.ne_empty
-
-theorem prod_subset_prod_left (h : s ⊆ s₁) : s ×ˢ t ⊆ s₁ ×ˢ t :=
-  prod_subset_prod_iff.mpr <| Or.inl ⟨h, subset_rfl⟩
-
-theorem prod_subset_prod_right (h : t ⊆ t₁) : s ×ˢ t ⊆ s ×ˢ t₁ :=
-  prod_subset_prod_iff.mpr <| Or.inl ⟨subset_rfl, h⟩
 
 theorem prod_subset_prod_iff_left (h : t.Nonempty) : s ×ˢ t ⊆ s₁ ×ˢ t ↔ s ⊆ s₁ := by
   rw [prod_subset_prod_iff, ← or_assoc, or_iff_left h.ne_empty, and_iff_left subset_rfl,

--- a/Mathlib/Data/Set/Prod.lean
+++ b/Mathlib/Data/Set/Prod.lean
@@ -347,6 +347,29 @@ theorem prod_subset_prod_iff : s ×ˢ t ⊆ s₁ ×ˢ t₁ ↔ s ⊆ s₁ ∧ t 
     simp only [st.1.ne_empty, st.2.ne_empty, or_false] at H
     exact prod_mono H.1 H.2
 
+theorem prod_subset_prod_iff' (h : (s ×ˢ t).Nonempty) : s ×ˢ t ⊆ s₁ ×ˢ t₁ ↔ s ⊆ s₁ ∧ t ⊆ t₁ := by
+  rw [prod_subset_prod_iff, or_iff_left]
+  rw [← Set.prod_eq_empty_iff]
+  exact h.ne_empty
+
+theorem prod_subset_prod_left (h : s ⊆ s₁) : s ×ˢ t ⊆ s₁ ×ˢ t :=
+  prod_subset_prod_iff.mpr <| Or.inl ⟨h, subset_rfl⟩
+
+theorem prod_subset_prod_right (h : t ⊆ t₁) : s ×ˢ t ⊆ s ×ˢ t₁ :=
+  prod_subset_prod_iff.mpr <| Or.inl ⟨subset_rfl, h⟩
+
+theorem prod_subset_prod_iff_left (h : t.Nonempty) : s ×ˢ t ⊆ s₁ ×ˢ t ↔ s ⊆ s₁ := by
+  rw [prod_subset_prod_iff, ← or_assoc, or_iff_left h.ne_empty, and_iff_left subset_rfl,
+    or_iff_left_of_imp]
+  intro heq
+  simp [heq]
+
+theorem prod_subset_prod_iff_right (h : s.Nonempty) : s ×ˢ t ⊆ s ×ˢ t₁ ↔ t ⊆ t₁ := by
+  rw [prod_subset_prod_iff, or_comm (a := s = ∅), ← or_assoc, or_iff_left h.ne_empty,
+    and_iff_right subset_rfl, or_iff_left_of_imp]
+  intro heq
+  simp [heq]
+
 theorem prod_eq_prod_iff_of_nonempty (h : (s ×ˢ t).Nonempty) :
     s ×ˢ t = s₁ ×ˢ t₁ ↔ s = s₁ ∧ t = t₁ := by
   constructor


### PR DESCRIPTION
I add a few corollaries of `Set.prod_subset_prod_iff` to make it more user friendly.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
