### PR TITLE
[Merged by Bors] - feat: initial use of `@[grind]` in `Logic/Equiv`

### DIFF
--- a/Mathlib/Data/Prod/PProd.lean
+++ b/Mathlib/Data/Prod/PProd.lean
@@ -14,6 +14,9 @@ open Function
 
 variable {α β γ δ : Sort*}
 
+#adaptation_note /-- this will not be needed after nightly-2025-07-01 -/
+attribute [grind cases eager] PProd
+
 namespace PProd
 
 def mk.injArrow {α : Type*} {β : Type*} {x₁ : α} {y₁ : β} {x₂ : α} {y₂ : β} :

--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -109,7 +109,7 @@ instance : FunLike (α ≃ β) α β where
 lemma _root_.EquivLike.coe_coe {F} [EquivLike F α β] (e : F) :
     ((e : α ≃ β) : α → β) = e := rfl
 
-@[simp] theorem coe_fn_mk (f : α → β) (g l r) : (Equiv.mk f g l r : α → β) = f :=
+@[simp, grind =] theorem coe_fn_mk (f : α → β) (g l r) : (Equiv.mk f g l r : α → β) = f :=
   rfl
 
 /-- The map `(r ≃ s) → (r → s)` is injective. -/
@@ -233,9 +233,9 @@ theorem Perm.coe_subsingleton {α : Type*} [Subsingleton α] (e : Perm α) : (e 
 
 @[simp] theorem trans_apply (f : α ≃ β) (g : β ≃ γ) (a : α) : (f.trans g) a = g (f a) := rfl
 
-@[simp] theorem apply_symm_apply (e : α ≃ β) (x : β) : e (e.symm x) = x := e.right_inv x
+@[simp, grind =] theorem apply_symm_apply (e : α ≃ β) (x : β) : e (e.symm x) = x := e.right_inv x
 
-@[simp] theorem symm_apply_apply (e : α ≃ β) (x : α) : e.symm (e x) = x := e.left_inv x
+@[simp, grind =] theorem symm_apply_apply (e : α ≃ β) (x : α) : e.symm (e x) = x := e.left_inv x
 
 @[simp] theorem symm_comp_self (e : α ≃ β) : e.symm ∘ e = id := funext e.symm_apply_apply
 

--- a/Mathlib/Logic/Equiv/Prod.lean
+++ b/Mathlib/Logic/Equiv/Prod.lean
@@ -5,6 +5,7 @@ Authors: Leonardo de Moura, Mario Carneiro
 -/
 import Mathlib.Logic.Equiv.Defs
 import Mathlib.Tactic.Contrapose
+import Mathlib.Data.Prod.PProd
 
 /-!
 # Equivalence between product types
@@ -43,8 +44,8 @@ def pprodEquivProd {α β} : PProd α β ≃ α × β where
 def pprodCongr (e₁ : α ≃ β) (e₂ : γ ≃ δ) : PProd α γ ≃ PProd β δ where
   toFun x := ⟨e₁ x.1, e₂ x.2⟩
   invFun x := ⟨e₁.symm x.1, e₂.symm x.2⟩
-  left_inv := fun ⟨x, y⟩ => by simp
-  right_inv := fun ⟨x, y⟩ => by simp
+  left_inv := by grind
+  right_inv := by grind
 
 /-- Combine two equivalences using `PProd` in the domain and `Prod` in the codomain. -/
 @[simps! apply symm_apply]
@@ -229,12 +230,8 @@ between `β₁ × α₁` and `β₂ × α₁`. -/
 def prodCongrLeft : β₁ × α₁ ≃ β₂ × α₁ where
   toFun ab := ⟨e ab.2 ab.1, ab.2⟩
   invFun ab := ⟨(e ab.2).symm ab.1, ab.2⟩
-  left_inv := by
-    rintro ⟨a, b⟩
-    simp
-  right_inv := by
-    rintro ⟨a, b⟩
-    simp
+  left_inv := by grind
+  right_inv := by grind
 
 @[simp]
 theorem prodCongrLeft_apply (b : β₁) (a : α₁) : prodCongrLeft e (b, a) = (e a b, a) :=
@@ -250,12 +247,8 @@ between `α₁ × β₁` and `α₁ × β₂`. -/
 def prodCongrRight : α₁ × β₁ ≃ α₁ × β₂ where
   toFun ab := ⟨ab.1, e ab.1 ab.2⟩
   invFun ab := ⟨ab.1, (e ab.1).symm ab.2⟩
-  left_inv := by
-    rintro ⟨a, b⟩
-    simp
-  right_inv := by
-    rintro ⟨a, b⟩
-    simp
+  left_inv := by grind
+  right_inv := by grind
 
 @[simp]
 theorem prodCongrRight_apply (a : α₁) (b : β₁) : prodCongrRight e (a, b) = (a, e a b) :=
@@ -298,12 +291,8 @@ theorem sigmaEquivProd_sigmaCongrRight :
 def prodShear (e₁ : α₁ ≃ α₂) (e₂ : α₁ → β₁ ≃ β₂) : α₁ × β₁ ≃ α₂ × β₂ where
   toFun := fun x : α₁ × β₁ => (e₁ x.1, e₂ x.1 x.2)
   invFun := fun y : α₂ × β₂ => (e₁.symm y.1, (e₂ <| e₁.symm y.1).symm y.2)
-  left_inv := by
-    rintro ⟨x₁, y₁⟩
-    simp only [symm_apply_apply]
-  right_inv := by
-    rintro ⟨x₁, y₁⟩
-    simp only [apply_symm_apply]
+  left_inv := by grind
+  right_inv := by grind
 
 end prodCongr
 
@@ -316,20 +305,8 @@ variable {α₁ β₁ : Type*} [DecidableEq α₁] (a : α₁) (e : Perm β₁)
 def prodExtendRight : Perm (α₁ × β₁) where
   toFun ab := if ab.fst = a then (a, e ab.snd) else ab
   invFun ab := if ab.fst = a then (a, e.symm ab.snd) else ab
-  left_inv := by
-    rintro ⟨k', x⟩
-    dsimp only
-    split_ifs with h₁ h₂
-    · simp [h₁]
-    · simp at h₂
-    · simp
-  right_inv := by
-    rintro ⟨k', x⟩
-    dsimp only
-    split_ifs with h₁ h₂
-    · simp [h₁]
-    · simp at h₂
-    · simp
+  left_inv := by grind
+  right_inv := by grind
 
 @[simp]
 theorem prodExtendRight_apply_eq (b : β₁) : prodExtendRight a e (a, b) = (a, e b) :=
@@ -346,11 +323,7 @@ theorem eq_of_prodExtendRight_ne {e : Perm β₁} {a a' : α₁} {b : β₁}
 
 @[simp]
 theorem fst_prodExtendRight (ab : α₁ × β₁) : (prodExtendRight a e ab).fst = ab.fst := by
-  rw [prodExtendRight]
-  dsimp
-  split_ifs with h
-  · rw [h]
-  · rfl
+  grind [prodExtendRight]
 
 end Perm
 
@@ -439,26 +412,22 @@ theorem sumProdDistrib_symm_apply_right {α β γ} (b : β × γ) :
 equivalent to the sum of products `Σ i, (α i × β)`. -/
 @[simps apply symm_apply]
 def sigmaProdDistrib {ι} (α : ι → Type*) (β) : (Σ i, α i) × β ≃ Σ i, α i × β :=
-  ⟨fun p => ⟨p.1.1, (p.1.2, p.2)⟩, fun p => (⟨p.1, p.2.1⟩, p.2.2), fun p => by
-    rcases p with ⟨⟨_, _⟩, _⟩
-    rfl, fun p => by
-    rcases p with ⟨_, ⟨_, _⟩⟩
-    rfl⟩
+  ⟨fun p => ⟨p.1.1, (p.1.2, p.2)⟩, fun p => (⟨p.1, p.2.1⟩, p.2.2), by grind, by grind⟩
 
 /-- The product `Bool × α` is equivalent to `α ⊕ α`. -/
 @[simps]
 def boolProdEquivSum (α) : Bool × α ≃ α ⊕ α where
-  toFun p := p.1.casesOn (inl p.2) (inr p.2)
+  toFun p := if p.1 then (inr p.2) else (inl p.2)
   invFun := Sum.elim (Prod.mk false) (Prod.mk true)
   left_inv := by rintro ⟨_ | _, _⟩ <;> rfl
   right_inv := by rintro (_ | _) <;> rfl
 
 /-- The function type `Bool → α` is equivalent to `α × α`. -/
 @[simps]
-def boolArrowEquivProd (α) : (Bool → α) ≃ α × α where
+def boolArrowEquivProd (α : Type*) : (Bool → α) ≃ α × α where
   toFun f := (f false, f true)
-  invFun p b := b.casesOn p.1 p.2
-  left_inv _ := funext <| Bool.forall_bool.2 ⟨rfl, rfl⟩
+  invFun p b := if b then p.2 else p.1
+  left_inv _ := by grind
 
 end
 
@@ -495,14 +464,8 @@ def piEquivPiSubtypeProd {α : Type*} (p : α → Prop) (β : α → Type*) [Dec
   invFun f x := if h : p x then f.1 ⟨x, h⟩ else f.2 ⟨x, h⟩
   right_inv := by
     rintro ⟨f, g⟩
-    ext1 <;>
-      · ext y
-        rcases y with ⟨val, property⟩
-        simp only [property, dif_pos, dif_neg, not_false_iff, Subtype.coe_mk]
-  left_inv f := by
-    ext x
-    by_cases h : p x <;>
-      · simp only [h, dif_neg, dif_pos, not_false_iff]
+    ext1 <;> grind
+  left_inv f := by grind
 
 /-- A product of types can be split as the binary product of one of the types and the product
   of all the remaining types. -/
@@ -511,15 +474,8 @@ def piSplitAt {α : Type*} [DecidableEq α] (i : α) (β : α → Type*) :
     (∀ j, β j) ≃ β i × ∀ j : { j // j ≠ i }, β j where
   toFun f := ⟨f i, fun j => f j⟩
   invFun f j := if h : j = i then h.symm.rec f.1 else f.2 ⟨j, h⟩
-  right_inv f := by
-    ext x
-    exacts [dif_pos rfl, (dif_neg x.2).trans (by cases x; rfl)]
-  left_inv f := by
-    ext x
-    dsimp only
-    split_ifs with h
-    · subst h; rfl
-    · rfl
+  right_inv f := by ext x <;> grind
+  left_inv f := by grind
 
 /-- A product of copies of a type can be split as the binary product of one copy and the product
   of all the remaining copies. -/

--- a/Mathlib/Logic/Function/Defs.lean
+++ b/Mathlib/Logic/Function/Defs.lean
@@ -82,6 +82,7 @@ theorem Bijective.comp {g : β → φ} {f : α → β} : Bijective g → Bijecti
   | ⟨h_ginj, h_gsurj⟩, ⟨h_finj, h_fsurj⟩ => ⟨h_ginj.comp h_finj, h_gsurj.comp h_fsurj⟩
 
 /-- `LeftInverse g f` means that `g` is a left inverse to `f`. That is, `g ∘ f = id`. -/
+@[grind ]
 def LeftInverse (g : β → α) (f : α → β) : Prop :=
   ∀ x, g (f x) = x
 
@@ -90,6 +91,7 @@ def HasLeftInverse (f : α → β) : Prop :=
   ∃ finv : β → α, LeftInverse finv f
 
 /-- `RightInverse g f` means that `g` is a right inverse to `f`. That is, `f ∘ g = id`. -/
+@[grind ]
 def RightInverse (g : β → α) (f : α → β) : Prop :=
   LeftInverse f g
 

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -348,12 +348,9 @@
   ["Mathlib.Algebra.DirectSum.Internal"],
   "Mathlib.RingTheory.KrullDimension.Basic":
   ["Mathlib.Algebra.MvPolynomial.CommRing", "Mathlib.Algebra.Polynomial.Basic"],
-  "Mathlib.RingTheory.IntegralClosure.IsIntegral.Defs":
-  ["Mathlib.Tactic.Algebraize"],
   "Mathlib.RingTheory.Ideal.Norm.AbsNorm":
   ["Mathlib.LinearAlgebra.FreeModule.IdealQuotient"],
-  "Mathlib.RingTheory.Finiteness.Defs":
-  ["Mathlib.Data.Finsupp.Defs", "Mathlib.Tactic.Algebraize"],
+  "Mathlib.RingTheory.Finiteness.Defs": ["Mathlib.Data.Finsupp.Defs"],
   "Mathlib.RingTheory.Adjoin.Basic": ["Mathlib.LinearAlgebra.Finsupp.SumProd"],
   "Mathlib.RepresentationTheory.FdRep":
   ["Mathlib.CategoryTheory.Monoidal.Rigid.Braided"],
@@ -385,6 +382,7 @@
   "Mathlib.Logic.Nontrivial.Defs": ["Mathlib.Init.Logic"],
   "Mathlib.Logic.Function.Defs": ["Mathlib.Tactic.AdaptationNote"],
   "Mathlib.Logic.Function.Basic": ["Batteries.Tactic.Init"],
+  "Mathlib.Logic.Equiv.Prod": ["Mathlib.Data.Prod.PProd"],
   "Mathlib.Logic.Equiv.Defs":
   ["Mathlib.Data.Bool.Basic", "Mathlib.Data.Subtype"],
   "Mathlib.Logic.Basic": ["Batteries.Tactic.Trans"],


### PR DESCRIPTION
This PR begins using `grind` in `Logic/Equiv`.