### PR TITLE
[Merged by Bors] - feat: version of `prod_range_induction` with weaker assumptions

### DIFF
--- a/Archive/Wiedijk100Theorems/InverseTriangleSum.lean
+++ b/Archive/Wiedijk100Theorems/InverseTriangleSum.lean
@@ -32,5 +32,6 @@ theorem Theorems100.inverse_triangle_sum :
   apply sum_range_induction _ _ rfl
   rintro (_ | _)
   · norm_num
-  field_simp
-  ring_nf
+  · field_simp
+    ring_nf
+    simp

--- a/Archive/Wiedijk100Theorems/InverseTriangleSum.lean
+++ b/Archive/Wiedijk100Theorems/InverseTriangleSum.lean
@@ -26,9 +26,8 @@ discrete_sum
 open Finset
 
 /-- **Sum of the Reciprocals of the Triangular Numbers** -/
-theorem Theorems100.inverse_triangle_sum :
-    ∀ n, ∑ k ∈ range n, (2 : ℚ) / (k * (k + 1)) = if n = 0 then 0 else 2 - (2 : ℚ) / n := by
-  intro n
+theorem Theorems100.inverse_triangle_sum (n : ℕ) :
+    ∑ k ∈ range n, (2 : ℚ) / (k * (k + 1)) = if n = 0 then 0 else 2 - (2 : ℚ) / n := by
   apply sum_range_induction _ _ rfl
   rintro (_ | _)
   · norm_num

--- a/Archive/Wiedijk100Theorems/InverseTriangleSum.lean
+++ b/Archive/Wiedijk100Theorems/InverseTriangleSum.lean
@@ -28,8 +28,9 @@ open Finset
 /-- **Sum of the Reciprocals of the Triangular Numbers** -/
 theorem Theorems100.inverse_triangle_sum :
     ∀ n, ∑ k ∈ range n, (2 : ℚ) / (k * (k + 1)) = if n = 0 then 0 else 2 - (2 : ℚ) / n := by
-  refine sum_range_induction _ _ rfl ?_
+  intro n
+  apply sum_range_induction _ _ rfl
   rintro (_ | _)
   · norm_num
   field_simp
-  ring
+  ring_nf

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
@@ -604,25 +604,15 @@ theorem prod_multiset_count_of_subset [DecidableEq M] (m : Multiset M) (s : Fins
   apply prod_list_count_of_subset l s
 
 /-- For any product along `{0, ..., n - 1}` of a commutative-monoid-valued function, we can verify
-that it's equal to a different function just by checking ratios of adjacent terms.
+that it's equal to a different function just by checking ratios of adjacent terms up to `n`.
 
 This is a multiplicative discrete analogue of the fundamental theorem of calculus. -/
 @[to_additive "For any sum along `{0, ..., n - 1}` of a commutative-monoid-valued function, we can
-verify that it's equal to a different function just by checking differences of adjacent terms.
+verify that it's equal to a different function just by checking differences of adjacent terms up to
+`n`.
 
 This is a discrete analogue of the fundamental theorem of calculus."]
 theorem prod_range_induction (f s : ℕ → M) (base : s 0 = 1)
-    (step : ∀ n, s (n + 1) = s n * f n) (n : ℕ) :
-    ∏ k ∈ Finset.range n, f k = s n := by
-  induction n with
-  | zero => rw [Finset.prod_range_zero, base]
-  | succ k hk => simp only [hk, Finset.prod_range_succ, step, mul_comm]
-
-/-- A version of `Finset.prod_range_induction` where the ratios of adjacent terms only needs to be
-checked for terms up to `n` -/
-@[to_additive "A version of `Finset.sum_range_induction` where the differences of adjacent terms
-only needs to be checked for terms up to `n`"]
-theorem prod_range_induction' (f s : ℕ → M) (base : s 0 = 1)
     (n : ℕ) (step : ∀ k < n, s (k + 1) = s k * f k) :
     ∏ k ∈ Finset.range n, f k = s n := by
   induction n with
@@ -934,7 +924,7 @@ lemma sum_range_tsub {f : ℕ → M} (h : Monotone f) (n : ℕ) :
   apply sum_range_induction
   case base => apply tsub_eq_of_eq_add; rw [zero_add]
   case step =>
-    intro n
+    intro n _
     have h₁ : f n ≤ f (n + 1) := h (Nat.le_succ _)
     have h₂ : f 0 ≤ f n := h (Nat.zero_le _)
     rw [tsub_add_eq_add_tsub h₂, add_tsub_cancel_of_le h₁]

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
@@ -618,6 +618,19 @@ theorem prod_range_induction (f s : ℕ → M) (base : s 0 = 1)
   | zero => rw [Finset.prod_range_zero, base]
   | succ k hk => simp only [hk, Finset.prod_range_succ, step, mul_comm]
 
+/-- A version of `Finset.prod_range_induction` where the ratios of adjacent terms only needs to be
+checked for terms up to `n` -/
+@[to_additive "A version of `Finset.sum_range_induction` where the differences of adjacent terms
+only needs to be checked for terms up to `n`"]
+theorem prod_range_induction' (f s : ℕ → M) (base : s 0 = 1)
+    (n : ℕ) (step : ∀ k < n, s (k + 1) = s k * f k) :
+    ∏ k ∈ Finset.range n, f k = s n := by
+  induction n with
+  | zero => rw [Finset.prod_range_zero, base]
+  | succ k hk =>
+    rw [Finset.prod_range_succ, step _ (Nat.lt_succ_self _), hk]
+    exact fun _ hl ↦ step _ (Nat.lt_succ_of_lt hl)
+
 @[to_additive (attr := simp)]
 theorem prod_const (b : M) : ∏ _x ∈ s, b = b ^ #s :=
   (congr_arg _ <| s.val.map_const b).trans <| Multiset.prod_replicate #s b

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -651,7 +651,7 @@ lemma coeff_pow (k n : ℕ) (φ : R⟦X⟧) :
     coeff R n (φ ^ k) = ∑ l ∈ finsuppAntidiag (range k) n, ∏ i ∈ range k, coeff R (l i) φ := by
   have h₁ (i : ℕ) : Function.const ℕ φ i = φ := rfl
   have h₂ (i : ℕ) : ∏ j ∈ range i, Function.const ℕ φ j = φ ^ i := by
-    apply prod_range_induction (fun _ => φ) (fun i => φ ^ i) rfl (fun _ => congrFun rfl) i
+    apply prod_range_induction (fun _ => φ) (fun i => φ ^ i) rfl i (fun _ => congrFun rfl)
   rw [← h₂, ← h₁ k]
   apply coeff_prod (f := Function.const ℕ φ) (d := n) (s := range k)
 

--- a/Mathlib/RingTheory/PowerSeries/Basic.lean
+++ b/Mathlib/RingTheory/PowerSeries/Basic.lean
@@ -651,7 +651,7 @@ lemma coeff_pow (k n : ℕ) (φ : R⟦X⟧) :
     coeff R n (φ ^ k) = ∑ l ∈ finsuppAntidiag (range k) n, ∏ i ∈ range k, coeff R (l i) φ := by
   have h₁ (i : ℕ) : Function.const ℕ φ i = φ := rfl
   have h₂ (i : ℕ) : ∏ j ∈ range i, Function.const ℕ φ j = φ ^ i := by
-    apply prod_range_induction (fun _ => φ) (fun i => φ ^ i) rfl (congrFun rfl) i
+    apply prod_range_induction (fun _ => φ) (fun i => φ ^ i) rfl (fun _ => congrFun rfl) i
   rw [← h₂, ← h₁ k]
   apply coeff_prod (f := Function.const ℕ φ) (d := n) (s := range k)
 


### PR DESCRIPTION
`prod_range_induction` currently requires ratios of adjacent terms to be checked for the entire sequence, but we only need to check terms up to `n`. I relax this assumption in `prod_range_induction`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
