### PR TITLE
[Merged by Bors] - chore: Add grind tags for `Set.mem_Ixx`

### DIFF
--- a/Mathlib/Order/Interval/Set/Defs.lean
+++ b/Mathlib/Order/Interval/Set/Defs.lean
@@ -30,49 +30,49 @@ variable {α : Type*} [Preorder α] {a b x : α}
 /-- `Ioo a b` is the left-open right-open interval $(a, b)$. -/
 def Ioo (a b : α) := { x | a < x ∧ x < b }
 
-@[simp] theorem mem_Ioo : x ∈ Ioo a b ↔ a < x ∧ x < b := Iff.rfl
+@[simp, grind =] theorem mem_Ioo : x ∈ Ioo a b ↔ a < x ∧ x < b := Iff.rfl
 theorem Ioo_def (a b : α) : { x | a < x ∧ x < b } = Ioo a b := rfl
 
 /-- `Ico a b` is the left-closed right-open interval $[a, b)$. -/
 def Ico (a b : α) := { x | a ≤ x ∧ x < b }
 
-@[simp] theorem mem_Ico : x ∈ Ico a b ↔ a ≤ x ∧ x < b := Iff.rfl
+@[simp, grind =] theorem mem_Ico : x ∈ Ico a b ↔ a ≤ x ∧ x < b := Iff.rfl
 theorem Ico_def (a b : α) : { x | a ≤ x ∧ x < b } = Ico a b := rfl
 
 /-- `Iio b` is the left-infinite right-open interval $(-∞, b)$. -/
 def Iio (b : α) := { x | x < b }
 
-@[simp] theorem mem_Iio : x ∈ Iio b ↔ x < b := Iff.rfl
+@[simp, grind =] theorem mem_Iio : x ∈ Iio b ↔ x < b := Iff.rfl
 theorem Iio_def (a : α) : { x | x < a } = Iio a := rfl
 
 /-- `Icc a b` is the left-closed right-closed interval $[a, b]$. -/
 def Icc (a b : α) := { x | a ≤ x ∧ x ≤ b }
 
-@[simp] theorem mem_Icc : x ∈ Icc a b ↔ a ≤ x ∧ x ≤ b := Iff.rfl
+@[simp, grind =] theorem mem_Icc : x ∈ Icc a b ↔ a ≤ x ∧ x ≤ b := Iff.rfl
 theorem Icc_def (a b : α) : { x | a ≤ x ∧ x ≤ b } = Icc a b := rfl
 
 /-- `Iic b` is the left-infinite right-closed interval $(-∞, b]$. -/
 def Iic (b : α) := { x | x ≤ b }
 
-@[simp] theorem mem_Iic : x ∈ Iic b ↔ x ≤ b := Iff.rfl
+@[simp, grind =] theorem mem_Iic : x ∈ Iic b ↔ x ≤ b := Iff.rfl
 theorem Iic_def (b : α) : { x | x ≤ b } = Iic b := rfl
 
 /-- `Ioc a b` is the left-open right-closed interval $(a, b]$. -/
 def Ioc (a b : α) := { x | a < x ∧ x ≤ b }
 
-@[simp] theorem mem_Ioc : x ∈ Ioc a b ↔ a < x ∧ x ≤ b := Iff.rfl
+@[simp, grind =] theorem mem_Ioc : x ∈ Ioc a b ↔ a < x ∧ x ≤ b := Iff.rfl
 theorem Ioc_def (a b : α) : { x | a < x ∧ x ≤ b } = Ioc a b := rfl
 
 /-- `Ici a` is the left-closed right-infinite interval $[a, ∞)$. -/
 def Ici (a : α) := { x | a ≤ x }
 
-@[simp] theorem mem_Ici : x ∈ Ici a ↔ a ≤ x := Iff.rfl
+@[simp, grind =] theorem mem_Ici : x ∈ Ici a ↔ a ≤ x := Iff.rfl
 theorem Ici_def (a : α) : { x | a ≤ x } = Ici a := rfl
 
 /-- `Ioi a` is the left-open right-infinite interval $(a, ∞)$. -/
 def Ioi (a : α) := { x | a < x }
 
-@[simp] theorem mem_Ioi : x ∈ Ioi a ↔ a < x := Iff.rfl
+@[simp, grind =] theorem mem_Ioi : x ∈ Ioi a ↔ a < x := Iff.rfl
 theorem Ioi_def (a : α) : { x | a < x } = Ioi a := rfl
 
 /-- We say that a set `s : Set α` is `OrdConnected` if for all `x y ∈ s` it includes the


### PR DESCRIPTION
This adds `grind` tags to the various `Set.mem_Ixx` lemmas, which should let the grind linarith module discharge goals of this form.

I went with the convervative option of only including the `grind =` pattern, which only fires on the LHS of these lemmas. One could also consider having patterns going the other way as well (i.e. `grind _=_` for `mem_Ioi` or multi-patterns for `mem_Ioo` and so on).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.
To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
