### PR TITLE
[Merged by Bors] - feat: use grind in Data/Option/NAry

### DIFF
--- a/Mathlib/Data/Option/NAry.lean
+++ b/Mathlib/Data/Option/NAry.lean
@@ -31,6 +31,9 @@ open Function
 
 namespace Option
 
+-- Allow `grind` to case split on `Option` in this file.
+attribute [local grind cases] Option
+
 variable {α β γ δ : Type*} {f : α → β → γ} {a : Option α} {b : Option β} {c : Option γ}
 
 /-- The image of a binary function `f : α → β → γ` as a function `Option α → Option β → Option γ`.
@@ -44,15 +47,15 @@ theorem map₂_def {α β γ : Type u} (f : α → β → γ) (a : Option α) (b
     map₂ f a b = f <$> a <*> b := by
   cases a <;> rfl
 
-@[simp]
+@[simp, grind =]
 theorem map₂_some_some (f : α → β → γ) (a : α) (b : β) : map₂ f (some a) (some b) = f a b := rfl
 
 theorem map₂_coe_coe (f : α → β → γ) (a : α) (b : β) : map₂ f a b = f a b := rfl
 
-@[simp]
+@[simp, grind =]
 theorem map₂_none_left (f : α → β → γ) (b : Option β) : map₂ f none b = none := rfl
 
-@[simp]
+@[simp, grind =]
 theorem map₂_none_right (f : α → β → γ) (a : Option α) : map₂ f a none = none := by cases a <;> rfl
 
 @[simp]
@@ -62,40 +65,40 @@ theorem map₂_coe_left (f : α → β → γ) (a : α) (b : Option β) : map₂
 -- Porting note: This proof was `rfl` in Lean3, but now is not.
 @[simp]
 theorem map₂_coe_right (f : α → β → γ) (a : Option α) (b : β) :
-    map₂ f a b = a.map fun a => f a b := by cases a <;> rfl
+    map₂ f a b = a.map fun a => f a b := by grind
 
 theorem mem_map₂_iff {c : γ} : c ∈ map₂ f a b ↔ ∃ a' b', a' ∈ a ∧ b' ∈ b ∧ f a' b' = c := by
-  simp [map₂, bind_eq_some_iff]
+  grind
 
 /-- `simp`-normal form of `mem_map₂_iff`. -/
 @[simp]
 theorem map₂_eq_some_iff {c : γ} :
     map₂ f a b = some c ↔ ∃ a' b', a' ∈ a ∧ b' ∈ b ∧ f a' b' = c := by
-  simp [map₂, bind_eq_some_iff]
+  grind
 
 @[simp]
 theorem map₂_eq_none_iff : map₂ f a b = none ↔ a = none ∨ b = none := by
-  cases a <;> cases b <;> simp
+  grind
 
 theorem map₂_swap (f : α → β → γ) (a : Option α) (b : Option β) :
-    map₂ f a b = map₂ (fun a b => f b a) b a := by cases a <;> cases b <;> rfl
+    map₂ f a b = map₂ (fun a b => f b a) b a := by grind
 
 theorem map_map₂ (f : α → β → γ) (g : γ → δ) :
-    (map₂ f a b).map g = map₂ (fun a b => g (f a b)) a b := by cases a <;> cases b <;> rfl
+    (map₂ f a b).map g = map₂ (fun a b => g (f a b)) a b := by grind
 
 theorem map₂_map_left (f : γ → β → δ) (g : α → γ) :
-    map₂ f (a.map g) b = map₂ (fun a b => f (g a) b) a b := by cases a <;> rfl
+    map₂ f (a.map g) b = map₂ (fun a b => f (g a) b) a b := by grind
 
 theorem map₂_map_right (f : α → γ → δ) (g : β → γ) :
-    map₂ f a (b.map g) = map₂ (fun a b => f a (g b)) a b := by cases b <;> rfl
+    map₂ f a (b.map g) = map₂ (fun a b => f a (g b)) a b := by grind
 
 @[simp]
 theorem map₂_curry (f : α × β → γ) (a : Option α) (b : Option β) :
-    map₂ (curry f) a b = Option.map f (map₂ Prod.mk a b) := (map_map₂ _ _).symm
+    map₂ (curry f) a b = Option.map f (map₂ Prod.mk a b) := by grind
 
 @[simp]
 theorem map_uncurry (f : α → β → γ) (x : Option (α × β)) :
-    x.map (uncurry f) = map₂ f (x.map Prod.fst) (x.map Prod.snd) := by cases x <;> rfl
+    x.map (uncurry f) = map₂ f (x.map Prod.fst) (x.map Prod.snd) := by grind
 
 /-!
 ### Algebraic replacement rules
@@ -110,26 +113,22 @@ variable {α' β' δ' ε ε' : Type*}
 
 theorem map₂_assoc {f : δ → γ → ε} {g : α → β → δ} {f' : α → ε' → ε} {g' : β → γ → ε'}
     (h_assoc : ∀ a b c, f (g a b) c = f' a (g' b c)) :
-    map₂ f (map₂ g a b) c = map₂ f' a (map₂ g' b c) := by
-  cases a <;> cases b <;> cases c <;> simp [h_assoc]
+    map₂ f (map₂ g a b) c = map₂ f' a (map₂ g' b c) := by grind
 
 theorem map₂_comm {g : β → α → γ} (h_comm : ∀ a b, f a b = g b a) : map₂ f a b = map₂ g b a := by
-  cases a <;> cases b <;> simp [h_comm]
+  grind
 
 theorem map₂_left_comm {f : α → δ → ε} {g : β → γ → δ} {f' : α → γ → δ'} {g' : β → δ' → ε}
     (h_left_comm : ∀ a b c, f a (g b c) = g' b (f' a c)) :
-    map₂ f a (map₂ g b c) = map₂ g' b (map₂ f' a c) := by
-  cases a <;> cases b <;> cases c <;> simp [h_left_comm]
+    map₂ f a (map₂ g b c) = map₂ g' b (map₂ f' a c) := by grind
 
 theorem map₂_right_comm {f : δ → γ → ε} {g : α → β → δ} {f' : α → γ → δ'} {g' : δ' → β → ε}
     (h_right_comm : ∀ a b c, f (g a b) c = g' (f' a c) b) :
-    map₂ f (map₂ g a b) c = map₂ g' (map₂ f' a c) b := by
-  cases a <;> cases b <;> cases c <;> simp [h_right_comm]
+    map₂ f (map₂ g a b) c = map₂ g' (map₂ f' a c) b := by grind
 
 theorem map_map₂_distrib {g : γ → δ} {f' : α' → β' → δ} {g₁ : α → α'} {g₂ : β → β'}
     (h_distrib : ∀ a b, g (f a b) = f' (g₁ a) (g₂ b)) :
-    (map₂ f a b).map g = map₂ f' (a.map g₁) (b.map g₂) := by
-  cases a <;> cases b <;> simp [h_distrib]
+    (map₂ f a b).map g = map₂ f' (a.map g₁) (b.map g₂) := by grind
 
 /-!
 The following symmetric restatement are needed because unification has a hard time figuring all the
@@ -139,59 +138,55 @@ functions if you symmetrize on the spot. This is also how the other n-ary APIs d
 /-- Symmetric statement to `Option.map₂_map_left_comm`. -/
 theorem map_map₂_distrib_left {g : γ → δ} {f' : α' → β → δ} {g' : α → α'}
     (h_distrib : ∀ a b, g (f a b) = f' (g' a) b) :
-    (map₂ f a b).map g = map₂ f' (a.map g') b := by cases a <;> cases b <;> simp [h_distrib]
+    (map₂ f a b).map g = map₂ f' (a.map g') b := by grind
 
 /-- Symmetric statement to `Option.map_map₂_right_comm`. -/
 theorem map_map₂_distrib_right {g : γ → δ} {f' : α → β' → δ} {g' : β → β'}
     (h_distrib : ∀ a b, g (f a b) = f' a (g' b)) : (map₂ f a b).map g = map₂ f' a (b.map g') := by
-  cases a <;> cases b <;> simp [h_distrib]
+  grind
 
 /-- Symmetric statement to `Option.map_map₂_distrib_left`. -/
 theorem map₂_map_left_comm {f : α' → β → γ} {g : α → α'} {f' : α → β → δ} {g' : δ → γ}
     (h_left_comm : ∀ a b, f (g a) b = g' (f' a b)) : map₂ f (a.map g) b = (map₂ f' a b).map g' := by
-  cases a <;> cases b <;> simp [h_left_comm]
+  grind
 
 /-- Symmetric statement to `Option.map_map₂_distrib_right`. -/
 theorem map_map₂_right_comm {f : α → β' → γ} {g : β → β'} {f' : α → β → δ} {g' : δ → γ}
     (h_right_comm : ∀ a b, f a (g b) = g' (f' a b)) :
-    map₂ f a (b.map g) = (map₂ f' a b).map g' := by cases a <;> cases b <;> simp [h_right_comm]
+    map₂ f a (b.map g) = (map₂ f' a b).map g' := by grind
 
 theorem map_map₂_antidistrib {g : γ → δ} {f' : β' → α' → δ} {g₁ : β → β'} {g₂ : α → α'}
     (h_antidistrib : ∀ a b, g (f a b) = f' (g₁ b) (g₂ a)) :
-    (map₂ f a b).map g = map₂ f' (b.map g₁) (a.map g₂) := by
-  cases a <;> cases b <;> simp [h_antidistrib]
+    (map₂ f a b).map g = map₂ f' (b.map g₁) (a.map g₂) := by grind
 
 /-- Symmetric statement to `Option.map₂_map_left_anticomm`. -/
 theorem map_map₂_antidistrib_left {g : γ → δ} {f' : β' → α → δ} {g' : β → β'}
     (h_antidistrib : ∀ a b, g (f a b) = f' (g' b) a) :
-    (map₂ f a b).map g = map₂ f' (b.map g') a := by
-  cases a <;> cases b <;> simp [h_antidistrib]
+    (map₂ f a b).map g = map₂ f' (b.map g') a := by grind
 
 /-- Symmetric statement to `Option.map_map₂_right_anticomm`. -/
 theorem map_map₂_antidistrib_right {g : γ → δ} {f' : β → α' → δ} {g' : α → α'}
     (h_antidistrib : ∀ a b, g (f a b) = f' b (g' a)) :
-    (map₂ f a b).map g = map₂ f' b (a.map g') := by cases a <;> cases b <;> simp [h_antidistrib]
+    (map₂ f a b).map g = map₂ f' b (a.map g') := by grind
 
 /-- Symmetric statement to `Option.map_map₂_antidistrib_left`. -/
 theorem map₂_map_left_anticomm {f : α' → β → γ} {g : α → α'} {f' : β → α → δ} {g' : δ → γ}
     (h_left_anticomm : ∀ a b, f (g a) b = g' (f' b a)) :
-    map₂ f (a.map g) b = (map₂ f' b a).map g' := by cases a <;> cases b <;> simp [h_left_anticomm]
+    map₂ f (a.map g) b = (map₂ f' b a).map g' := by grind
 
 /-- Symmetric statement to `Option.map_map₂_antidistrib_right`. -/
 theorem map_map₂_right_anticomm {f : α → β' → γ} {g : β → β'} {f' : β → α → δ} {g' : δ → γ}
     (h_right_anticomm : ∀ a b, f a (g b) = g' (f' b a)) :
-    map₂ f a (b.map g) = (map₂ f' b a).map g' := by cases a <;> cases b <;> simp [h_right_anticomm]
+    map₂ f a (b.map g) = (map₂ f' b a).map g' := by grind
 
 /-- If `a` is a left identity for a binary operation `f`, then `some a` is a left identity for
 `Option.map₂ f`. -/
 lemma map₂_left_identity {f : α → β → β} {a : α} (h : ∀ b, f a b = b) (o : Option β) :
-    map₂ f (some a) o = o := by
-  cases o; exacts [rfl, congr_arg some (h _)]
+    map₂ f (some a) o = o := by grind
 
 /-- If `b` is a right identity for a binary operation `f`, then `some b` is a right identity for
 `Option.map₂ f`. -/
 lemma map₂_right_identity {f : α → β → α} {b : β} (h : ∀ a, f a b = a) (o : Option α) :
-    map₂ f o (some b) = o := by
-  simp [h, map₂]
+    map₂ f o (some b) = o := by grind
 
 end Option


### PR DESCRIPTION
This PR shortens some easy proofs in `Data/Option/NAry` using `grind` (and a local `[grind cases Option]` attribute for case bashing).