### PR TITLE
[Merged by Bors] - chore: reorder arguments in `pathComponentIn`

### DIFF
--- a/Mathlib/Geometry/Manifold/ChartedSpace.lean
+++ b/Mathlib/Geometry/Manifold/ChartedSpace.lean
@@ -683,7 +683,7 @@ theorem ChartedSpace.locPathConnectedSpace [LocPathConnectedSpace H] : LocPathCo
   let e := chartAt H x
   let t := s ∩ e.source
   have ht : t ∈ 𝓝 x := Filter.inter_mem hs (chart_source_mem_nhds _ _)
-  refine ⟨e.symm '' pathComponentIn (e x) (e '' t), ⟨?_, ?_⟩, (?_ : _ ⊆ t).trans inter_subset_left⟩
+  refine ⟨e.symm '' pathComponentIn (e '' t) (e x), ⟨?_, ?_⟩, (?_ : _ ⊆ t).trans inter_subset_left⟩
   · nth_rewrite 1 [← e.left_inv (mem_chart_source _ _)]
     apply e.symm.image_mem_nhds (by simp [e])
     exact pathComponentIn_mem_nhds <| e.image_mem_nhds (mem_chart_source _ _) ht

--- a/Mathlib/Topology/Connected/LocPathConnected.lean
+++ b/Mathlib/Topology/Connected/LocPathConnected.lean
@@ -210,7 +210,7 @@ instance Sigma.locPathConnectedSpace {X : ι → Type*}
     [(i : ι) → TopologicalSpace (X i)] [(i : ι) → LocPathConnectedSpace (X i)] :
     LocPathConnectedSpace ((i : ι) × X i) := by
   rw [locPathConnectedSpace_iff_pathComponentIn_mem_nhds]; intro x u hu hxu; rw [mem_nhds_iff]
-  refine ⟨(Sigma.mk x.1) '' (pathComponentIn x.2 ((Sigma.mk x.1) ⁻¹' u)), ?_, ?_, ?_⟩
+  refine ⟨(Sigma.mk x.1) '' (pathComponentIn ((Sigma.mk x.1) ⁻¹' u) x.2), ?_, ?_, ?_⟩
   · apply IsPathConnected.subset_pathComponentIn
     · exact (isPathConnected_pathComponentIn (by exact hxu)).image continuous_sigmaMk
     · exact ⟨x.2, mem_pathComponentIn_self hxu, rfl⟩

--- a/Mathlib/Topology/Connected/LocPathConnected.lean
+++ b/Mathlib/Topology/Connected/LocPathConnected.lean
@@ -64,8 +64,8 @@ theorem LocPathConnectedSpace.of_bases {p : X → ι → Prop} {s : X → ι →
 
 variable [LocPathConnectedSpace X]
 
-protected theorem IsOpen.pathComponentIn (x : X) (hF : IsOpen F) :
-    IsOpen (pathComponentIn x F) := by
+protected theorem IsOpen.pathComponentIn (hF : IsOpen F) (x : X) :
+    IsOpen (pathComponentIn F x) := by
   rw [isOpen_iff_mem_nhds]
   intro y hy
   let ⟨s, hs⟩ := (path_connected_basis y).mem_iff.mp (hF.mem_nhds (pathComponentIn_subset hy))
@@ -89,9 +89,9 @@ protected theorem IsClosed.pathComponent (x : X) : IsClosed (pathComponent x) :=
 protected theorem IsClopen.pathComponent (x : X) : IsClopen (pathComponent x) :=
   ⟨.pathComponent x, .pathComponent x⟩
 
-lemma pathComponentIn_mem_nhds (hF : F ∈ 𝓝 x) : pathComponentIn x F ∈ 𝓝 x := by
+lemma pathComponentIn_mem_nhds (hF : F ∈ 𝓝 x) : pathComponentIn F x ∈ 𝓝 x := by
   let ⟨u, huF, hu, hxu⟩ := mem_nhds_iff.mp hF
-  exact mem_nhds_iff.mpr ⟨pathComponentIn x u, pathComponentIn_mono huF,
+  exact mem_nhds_iff.mpr ⟨pathComponentIn u x, pathComponentIn_mono huF,
     hu.pathComponentIn x, mem_pathComponentIn_self hxu⟩
 
 theorem pathConnectedSpace_iff_connectedSpace : PathConnectedSpace X ↔ ConnectedSpace X := by
@@ -110,7 +110,7 @@ theorem isOpen_isPathConnected_basis (x : X) :
     (𝓝 x).HasBasis (fun s : Set X ↦ IsOpen s ∧ x ∈ s ∧ IsPathConnected s) id := by
   refine ⟨fun s ↦ ⟨fun hs ↦ ?_, fun ⟨u, hu⟩ ↦ mem_nhds_iff.mpr ⟨u, hu.2, hu.1.1, hu.1.2.1⟩⟩⟩
   have ⟨u, hus, hu, hxu⟩ := mem_nhds_iff.mp hs
-  exact ⟨pathComponentIn x u, ⟨hu.pathComponentIn _, ⟨mem_pathComponentIn_self hxu,
+  exact ⟨pathComponentIn u x, ⟨hu.pathComponentIn _, ⟨mem_pathComponentIn_self hxu,
     isPathConnected_pathComponentIn hxu⟩⟩, pathComponentIn_subset.trans hus⟩
 
 theorem Topology.IsOpenEmbedding.locPathConnectedSpace {e : Y → X} (he : IsOpenEmbedding e) :
@@ -139,17 +139,17 @@ instance : LocallyConnectedSpace X := by
 
 /-- A space is locally path-connected iff all path components of open subsets are open. -/
 lemma locPathConnectedSpace_iff_isOpen_pathComponentIn {X : Type*} [TopologicalSpace X] :
-    LocPathConnectedSpace X ↔ ∀ (x : X) (u : Set X), IsOpen u → IsOpen (pathComponentIn x u) :=
+    LocPathConnectedSpace X ↔ ∀ (x : X) (u : Set X), IsOpen u → IsOpen (pathComponentIn u x) :=
   ⟨fun _ _ _ hu ↦ hu.pathComponentIn _, fun h ↦ ⟨fun x ↦ ⟨fun s ↦ by
     refine ⟨fun hs ↦ ?_, fun ⟨_, ht⟩ ↦ Filter.mem_of_superset ht.1.1 ht.2⟩
     let ⟨u, hu⟩ := mem_nhds_iff.mp hs
-    exact ⟨pathComponentIn x u, ⟨(h x u hu.2.1).mem_nhds (mem_pathComponentIn_self hu.2.2),
+    exact ⟨pathComponentIn u x, ⟨(h x u hu.2.1).mem_nhds (mem_pathComponentIn_self hu.2.2),
       isPathConnected_pathComponentIn hu.2.2⟩, pathComponentIn_subset.trans hu.1⟩⟩⟩⟩
 
 /-- A space is locally path-connected iff all path components of open subsets are neighbourhoods. -/
 lemma locPathConnectedSpace_iff_pathComponentIn_mem_nhds {X : Type*} [TopologicalSpace X] :
     LocPathConnectedSpace X ↔
-    ∀ x : X, ∀ u : Set X, IsOpen u → x ∈ u → pathComponentIn x u ∈ nhds x := by
+    ∀ x : X, ∀ u : Set X, IsOpen u → x ∈ u → pathComponentIn u x ∈ nhds x := by
   rw [locPathConnectedSpace_iff_isOpen_pathComponentIn]
   simp_rw [forall_comm (β := Set X), ← imp_forall_iff]
   refine forall_congr' fun u ↦ imp_congr_right fun _ ↦ ?_
@@ -164,7 +164,7 @@ lemma LocPathConnectedSpace.coinduced {Y : Type*} (f : X → Y) :
   refine locPathConnectedSpace_iff_isOpen_pathComponentIn.mpr fun y u hu ↦
     isOpen_coinduced.mpr <| isOpen_iff_mem_nhds.mpr fun x hx ↦ ?_
   have hx' := preimage_mono pathComponentIn_subset hx
-  refine mem_nhds_iff.mpr ⟨pathComponentIn x (f ⁻¹' u), ?_,
+  refine mem_nhds_iff.mpr ⟨pathComponentIn (f ⁻¹' u) x, ?_,
     (hu.preimage hf).pathComponentIn _, mem_pathComponentIn_self hx'⟩
   rw [← image_subset_iff, ← pathComponentIn_congr hx]
   exact ((isPathConnected_pathComponentIn hx').image hf).subset_pathComponentIn
@@ -190,14 +190,14 @@ instance Sum.locPathConnectedSpace.{u} {X Y : Type u} [TopologicalSpace X] [Topo
     LocPathConnectedSpace (X ⊕ Y) := by
   rw [locPathConnectedSpace_iff_pathComponentIn_mem_nhds]; intro x u hu hxu; rw [mem_nhds_iff]
   obtain x | y := x
-  · refine ⟨Sum.inl '' (pathComponentIn x (Sum.inl ⁻¹' u)), ?_, ?_, ?_⟩
+  · refine ⟨Sum.inl '' (pathComponentIn (Sum.inl ⁻¹' u) x), ?_, ?_, ?_⟩
     · apply IsPathConnected.subset_pathComponentIn
       · exact (isPathConnected_pathComponentIn (by exact hxu)).image continuous_inl
       · exact ⟨x, mem_pathComponentIn_self hxu, rfl⟩
       · exact (image_mono pathComponentIn_subset).trans (u.image_preimage_subset _)
     · exact isOpenMap_inl _ <| (hu.preimage continuous_inl).pathComponentIn _
     · exact ⟨x, mem_pathComponentIn_self hxu, rfl⟩
-  · refine ⟨Sum.inr '' (pathComponentIn y (Sum.inr ⁻¹' u)), ?_, ?_, ?_⟩
+  · refine ⟨Sum.inr '' (pathComponentIn (Sum.inr ⁻¹' u) y), ?_, ?_, ?_⟩
     · apply IsPathConnected.subset_pathComponentIn
       · exact (isPathConnected_pathComponentIn (by exact hxu)).image continuous_inr
       · exact ⟨y, mem_pathComponentIn_self hxu, rfl⟩

--- a/Mathlib/Topology/Connected/PathConnected.lean
+++ b/Mathlib/Topology/Connected/PathConnected.lean
@@ -257,33 +257,33 @@ theorem pathComponent_subset_component (x : X) : pathComponent x ⊆ connectedCo
   (isConnected_range h.somePath.continuous).subset_connectedComponent ⟨0, by simp⟩ ⟨1, by simp⟩
 
 /-- The path component of `x` in `F` is the set of points that can be joined to `x` in `F`. -/
-def pathComponentIn (x : X) (F : Set X) :=
+def pathComponentIn (F : Set X) (x : X) :=
   { y | JoinedIn F x y }
 
 @[simp]
-theorem pathComponentIn_univ (x : X) : pathComponentIn x univ = pathComponent x := by
+theorem pathComponentIn_univ (x : X) : pathComponentIn univ x = pathComponent x := by
   simp [pathComponentIn, pathComponent, JoinedIn, Joined, exists_true_iff_nonempty]
 
 theorem Joined.mem_pathComponent (hyz : Joined y z) (hxy : y ∈ pathComponent x) :
     z ∈ pathComponent x :=
   hxy.trans hyz
 
-theorem mem_pathComponentIn_self (h : x ∈ F) : x ∈ pathComponentIn x F :=
+theorem mem_pathComponentIn_self (h : x ∈ F) : x ∈ pathComponentIn F x :=
   JoinedIn.refl h
 
-theorem pathComponentIn_subset : pathComponentIn x F ⊆ F :=
+theorem pathComponentIn_subset : pathComponentIn F x ⊆ F :=
   fun _ hy ↦ hy.target_mem
 
-theorem pathComponentIn_nonempty_iff : (pathComponentIn x F).Nonempty ↔ x ∈ F :=
+theorem pathComponentIn_nonempty_iff : (pathComponentIn F x).Nonempty ↔ x ∈ F :=
   ⟨fun ⟨_, ⟨γ, hγ⟩⟩ ↦ γ.source ▸ hγ 0, fun hx ↦ ⟨x, mem_pathComponentIn_self hx⟩⟩
 
-theorem pathComponentIn_congr (h : x ∈ pathComponentIn y F) :
-    pathComponentIn x F = pathComponentIn y F := by
+theorem pathComponentIn_congr (h : x ∈ pathComponentIn F y) :
+    pathComponentIn F x = pathComponentIn F y := by
   ext; exact ⟨h.trans, h.symm.trans⟩
 
 @[gcongr]
 theorem pathComponentIn_mono {G : Set X} (h : F ⊆ G) :
-    pathComponentIn x F ⊆ pathComponentIn x G :=
+    pathComponentIn F x ⊆ pathComponentIn G x :=
   fun _ ⟨γ, hγ⟩ ↦ ⟨γ, fun t ↦ h (hγ t)⟩
 
 /-! ### Path component of the identity in a group -/
@@ -318,7 +318,7 @@ instance Subgroup.Normal.pathComponentOne (G : Type*) [Group G] [TopologicalSpac
 def IsPathConnected (F : Set X) : Prop :=
   ∃ x ∈ F, ∀ ⦃y⦄, y ∈ F → JoinedIn F x y
 
-theorem isPathConnected_iff_eq : IsPathConnected F ↔ ∃ x ∈ F, pathComponentIn x F = F := by
+theorem isPathConnected_iff_eq : IsPathConnected F ↔ ∃ x ∈ F, pathComponentIn F x = F := by
   constructor <;> rintro ⟨x, x_in, h⟩ <;> use x, x_in
   · ext y
     exact ⟨fun hy => hy.mem.2, @h _⟩
@@ -394,7 +394,7 @@ theorem IsPathConnected.subset_pathComponent (h : IsPathConnected F) (x_in : x �
     F ⊆ pathComponent x := fun _y y_in => h.mem_pathComponent x_in y_in
 
 theorem IsPathConnected.subset_pathComponentIn {s : Set X} (hs : IsPathConnected s)
-    (hxs : x ∈ s) (hsF : s ⊆ F) : s ⊆ pathComponentIn x F :=
+    (hxs : x ∈ s) (hsF : s ⊆ F) : s ⊆ pathComponentIn F x :=
   fun y hys ↦ (hs.joinedIn x hxs y hys).mono hsF
 
 theorem isPathConnected_singleton (x : X) : IsPathConnected ({x} : Set X) := by
@@ -402,7 +402,7 @@ theorem isPathConnected_singleton (x : X) : IsPathConnected ({x} : Set X) := by
   rintro y rfl
   exact JoinedIn.refl rfl
 
-theorem isPathConnected_pathComponentIn (h : x ∈ F) : IsPathConnected (pathComponentIn x F) :=
+theorem isPathConnected_pathComponentIn (h : x ∈ F) : IsPathConnected (pathComponentIn F x) :=
   ⟨x, mem_pathComponentIn_self h, fun _ ⟨γ, hγ⟩ ↦ by
     refine ⟨γ, fun t ↦
       ⟨(γ.truncateOfLE t.2.1).cast (γ.extend_zero.symm) (γ.extend_extends' t).symm, fun t' ↦ ?_⟩⟩


### PR DESCRIPTION
`pathComponentIn x F` and `connectedComponentIn F x` have opposite argument orders. I choose to reorder the arguments in `pathComponentIn` for no strong reason. Perhaps one can read, "the path component in F at x".

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
