### PR TITLE
fix: provide instance of `BoundedOrder` in `CompleteLattice`

### DIFF
--- a/Mathlib/Algebra/Algebra/Subalgebra/Lattice.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Lattice.lean
@@ -45,8 +45,6 @@ protected def gi : GaloisInsertion (adjoin R : Set A → Subalgebra R A) (↑) w
 
 instance : CompleteLattice (Subalgebra R A) where
   __ := GaloisInsertion.liftCompleteLattice Algebra.gi
-  bot := (Algebra.ofId R A).range
-  bot_le _S := fun _a ⟨_r, hr⟩ => hr ▸ algebraMap_mem _ _
 
 theorem sup_def (S T : Subalgebra R A) : S ⊔ T = adjoin R (S ∪ T : Set A) := rfl
 

--- a/Mathlib/Algebra/Field/Subfield/Basic.lean
+++ b/Mathlib/Algebra/Field/Subfield/Basic.lean
@@ -276,8 +276,6 @@ theorem isGLB_sInf (S : Set (Subfield K)) : IsGLB S (sInf S) := by
 /-- Subfields of a ring form a complete lattice. -/
 instance : CompleteLattice (Subfield K) :=
   { completeLatticeOfInf (Subfield K) isGLB_sInf with
-    top := ⊤
-    le_top := fun _ _ _ => trivial
     inf := (· ⊓ ·)
     inf_le_left := fun _ _ _ => And.left
     inf_le_right := fun _ _ _ => And.right

--- a/Mathlib/Algebra/Group/Subgroup/Lattice.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Lattice.lean
@@ -241,10 +241,6 @@ theorem coe_iInf {ι : Sort*} {S : ι → Subgroup G} : (↑(⨅ i, S i) : Set G
 instance : CompleteLattice (Subgroup G) :=
   { completeLatticeOfInf (Subgroup G) fun _s =>
       IsGLB.of_image SetLike.coe_subset_coe isGLB_biInf with
-    bot := ⊥
-    bot_le := fun S _x hx => (mem_bot.1 hx).symm ▸ S.one_mem
-    top := ⊤
-    le_top := fun _S x _hx => mem_top x
     inf := (· ⊓ ·)
     le_inf := fun _a _b _c ha hb _x hx => ⟨ha hx, hb hx⟩
     inf_le_left := fun _a _b _x => And.left

--- a/Mathlib/Algebra/Group/Submonoid/Basic.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Basic.lean
@@ -96,10 +96,6 @@ instance : CompleteLattice (Submonoid M) :=
         isGLB_biInf with
     le := (· ≤ ·)
     lt := (· < ·)
-    bot := ⊥
-    bot_le := fun S _ hx => (mem_bot.1 hx).symm ▸ S.one_mem
-    top := ⊤
-    le_top := fun _ x _ => mem_top x
     inf := (· ⊓ ·)
     sInf := InfSet.sInf
     le_inf := fun _ _ _ ha hb _ hx => ⟨ha hx, hb hx⟩

--- a/Mathlib/Algebra/Group/Subsemigroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subsemigroup/Basic.lean
@@ -84,10 +84,6 @@ instance : CompleteLattice (Subsemigroup M) :=
       IsGLB.of_image SetLike.coe_subset_coe isGLB_biInf with
     le := (· ≤ ·)
     lt := (· < ·)
-    bot := ⊥
-    bot_le := fun _ _ hx => (notMem_bot hx).elim
-    top := ⊤
-    le_top := fun _ x _ => mem_top x
     inf := (· ⊓ ·)
     sInf := InfSet.sInf
     le_inf := fun _ _ _ ha hb _ hx => ⟨ha hx, hb hx⟩

--- a/Mathlib/Algebra/Lie/Subalgebra.lean
+++ b/Mathlib/Algebra/Lie/Subalgebra.lean
@@ -478,13 +478,6 @@ We provide explicit values for the fields `bot`, `top`, `inf` to get more conven
 than we would otherwise obtain from `completeLatticeOfInf`. -/
 instance completeLattice : CompleteLattice (LieSubalgebra R L) :=
   { completeLatticeOfInf _ sInf_glb with
-    bot := ⊥
-    bot_le := fun N _ h ↦ by
-      rw [mem_bot] at h
-      rw [h]
-      exact N.zero_mem'
-    top := ⊤
-    le_top := fun _ _ _ ↦ trivial
     inf := (· ⊓ ·)
     le_inf := fun _ _ _ h₁₂ h₁₃ _ hm ↦ ⟨h₁₂ hm, h₁₃ hm⟩
     inf_le_left := fun _ _ _ ↦ And.left

--- a/Mathlib/Algebra/Star/Subalgebra.lean
+++ b/Mathlib/Algebra/Star/Subalgebra.lean
@@ -623,8 +623,6 @@ variable [Semiring B] [Algebra R B] [StarRing B] [StarModule R B]
 
 instance completeLattice : CompleteLattice (StarSubalgebra R A) where
   __ := GaloisInsertion.liftCompleteLattice StarAlgebra.gi
-  bot := { toSubalgebra := ⊥, star_mem' := fun ⟨r, hr⟩ => ⟨star r, hr ▸ algebraMap_star_comm _⟩ }
-  bot_le S := (bot_le : ⊥ ≤ S.toSubalgebra)
 
 instance inhabited : Inhabited (StarSubalgebra R A) :=
   ⟨⊤⟩

--- a/Mathlib/Data/Setoid/Basic.lean
+++ b/Mathlib/Data/Setoid/Basic.lean
@@ -179,10 +179,6 @@ instance completeLattice : CompleteLattice (Setoid α) :=
     inf_le_left := fun _ _ _ _ h => h.1
     inf_le_right := fun _ _ _ _ h => h.2
     le_inf := fun _ _ _ h1 h2 _ _ h => ⟨h1 h, h2 h⟩
-    top := ⟨fun _ _ => True, ⟨fun _ => trivial, fun h => h, fun h1 _ => h1⟩⟩
-    le_top := fun _ _ _ _ => trivial
-    bot := ⟨(· = ·), ⟨fun _ => rfl, fun h => h.symm, fun h1 h2 => h1.trans h2⟩⟩
-    bot_le := fun r x _ h => h ▸ r.2.1 x }
 
 @[simp]
 theorem top_def : ⇑(⊤ : Setoid α) = ⊤ :=

--- a/Mathlib/Order/CompleteLattice/Basic.lean
+++ b/Mathlib/Order/CompleteLattice/Basic.lean
@@ -1364,7 +1364,3 @@ protected abbrev Function.Injective.completeLattice [Max α] [Min α] [SupSet α
   sSup_le _ _ h := (map_sSup _).trans_le <| iSup₂_le h
   sInf_le _ a h := (map_sInf _).trans_le <| iInf₂_le a h
   le_sInf _ _ h := (le_iInf₂ h).trans (map_sInf _).ge
-  top := ⊤
-  le_top _ := (@le_top β _ _ _).trans map_top.ge
-  bot := ⊥
-  bot_le _ := map_bot.le.trans bot_le

--- a/Mathlib/Order/CompleteLattice/Basic.lean
+++ b/Mathlib/Order/CompleteLattice/Basic.lean
@@ -1198,7 +1198,6 @@ instance Pi.infSet {α : Type*} {β : α → Type*} [∀ i, InfSet (β i)] : Inf
 
 instance Pi.instCompleteLattice {α : Type*} {β : α → Type*} [∀ i, CompleteLattice (β i)] :
     CompleteLattice (∀ i, β i) where
-  __ := instBoundedOrder
   le_sSup s f hf := fun i => le_iSup (fun f : s => (f : ∀ i, β i) i) ⟨f, hf⟩
   sInf_le s f hf := fun i => iInf_le (fun f : s => (f : ∀ i, β i) i) ⟨f, hf⟩
   sSup_le _ _ hf := fun i => iSup_le fun g => hf g g.2 i
@@ -1356,8 +1355,8 @@ congr_arg₂ Prod.mk (congr_arg sSup <| fst_image_prod _ ht) (congr_arg sSup <| 
 protected abbrev Function.Injective.completeLattice [Max α] [Min α] [SupSet α] [InfSet α] [Top α]
     [Bot α] [CompleteLattice β] (f : α → β) (hf : Function.Injective f)
     (map_sup : ∀ a b, f (a ⊔ b) = f a ⊔ f b) (map_inf : ∀ a b, f (a ⊓ b) = f a ⊓ f b)
-    (map_sSup : ∀ s, f (sSup s) = ⨆ a ∈ s, f a) (map_sInf : ∀ s, f (sInf s) = ⨅ a ∈ s, f a)
-    (map_top : f ⊤ = ⊤) (map_bot : f ⊥ = ⊥) : CompleteLattice α where
+    (map_sSup : ∀ s, f (sSup s) = ⨆ a ∈ s, f a) (map_sInf : ∀ s, f (sInf s) = ⨅ a ∈ s, f a) :
+    CompleteLattice α where
   -- we cannot use BoundedOrder.lift here as the `LE` instance doesn't exist yet
   __ := hf.lattice f map_sup map_inf
   le_sSup _ a h := (le_iSup₂ a h).trans (map_sSup _).ge

--- a/Mathlib/Order/CompleteLattice/Defs.lean
+++ b/Mathlib/Order/CompleteLattice/Defs.lean
@@ -157,16 +157,14 @@ instance {α : Type*} [CompleteSemilatticeSup α] : CompleteSemilatticeInf αᵒ
 
 /-- A complete lattice is a bounded lattice which has suprema and infima for every subset. -/
 class CompleteLattice (α : Type*) extends Lattice α, CompleteSemilatticeSup α,
-  CompleteSemilatticeInf α, Top α, Bot α where
-  /-- Any element is less than the top one. -/
-  protected le_top : ∀ x : α, x ≤ ⊤
-  /-- Any element is more than the bottom one. -/
-  protected bot_le : ∀ x : α, ⊥ ≤ x
+  CompleteSemilatticeInf α where
 
 -- see Note [lower instance priority]
-instance (priority := 100) CompleteLattice.toBoundedOrder [CompleteLattice α] :
-    BoundedOrder α :=
-  { ‹CompleteLattice α› with }
+instance (priority := 100) CompleteLattice.toBoundedOrder [CompleteLattice α] : BoundedOrder α where
+  top := sInf ∅
+  bot := sSup ∅
+  le_top (a : α) := isGLB_empty_iff.1 (isGLB_sInf ∅) a
+  bot_le (a : α) := isLUB_empty_iff.1 (isLUB_sSup ∅) a
 
 /-- Create a `CompleteLattice` from a `PartialOrder` and `InfSet`
 that returns the greatest lower bound of a set. Usually this constructor provides
@@ -186,10 +184,6 @@ instance : CompleteLattice my_T where
 def completeLatticeOfInf (α : Type*) [H1 : PartialOrder α] [H2 : InfSet α]
     (isGLB_sInf : ∀ s : Set α, IsGLB s (sInf s)) : CompleteLattice α where
   __ := H1; __ := H2
-  bot := sInf univ
-  bot_le _ := (isGLB_sInf univ).1 trivial
-  top := sInf ∅
-  le_top a := (isGLB_sInf ∅).2 <| by simp
   sup a b := sInf { x : α | a ≤ x ∧ b ≤ x }
   inf a b := sInf {a, b}
   le_inf a b c hab hac := by
@@ -233,10 +227,6 @@ instance : CompleteLattice my_T where
 def completeLatticeOfSup (α : Type*) [H1 : PartialOrder α] [H2 : SupSet α]
     (isLUB_sSup : ∀ s : Set α, IsLUB s (sSup s)) : CompleteLattice α where
   __ := H1; __ := H2
-  top := sSup univ
-  le_top _ := (isLUB_sSup univ).1 trivial
-  bot := sSup ∅
-  bot_le x := (isLUB_sSup ∅).2 <| by simp
   sup a b := sSup {a, b}
   sup_le a b c hac hbc := (isLUB_sSup _).2 (by simp [*])
   le_sup_left _ _ := (isLUB_sSup _).1 <| mem_insert _ _

--- a/Mathlib/Order/FixedPoints.lean
+++ b/Mathlib/Order/FixedPoints.lean
@@ -261,10 +261,6 @@ instance completeLattice : CompleteLattice (fixedPoints f) where
   __ := inferInstanceAs (SemilatticeSup (fixedPoints f))
   __ := inferInstanceAs (CompleteSemilatticeInf (fixedPoints f))
   __ := inferInstanceAs (CompleteSemilatticeSup (fixedPoints f))
-  top := ⟨f.gfp, f.isFixedPt_gfp⟩
-  bot := ⟨f.lfp, f.isFixedPt_lfp⟩
-  le_top x := f.le_gfp x.2.ge
-  bot_le x := f.lfp_le x.2.le
 
 open OmegaCompletePartialOrder fixedPoints
 


### PR DESCRIPTION
The `BoundedOrder` instance from `CompleteLattice` can be deduced rather than assume by taking `top := sInf ∅` and `bot := sSup ∅` and using `isGLB_empty_iff` and `isLUB_empty_iff`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
