### PR TITLE
feat(CategoryTheory): add dinatural transformations (continued)

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2033,6 +2033,7 @@ import Mathlib.CategoryTheory.Countable
 import Mathlib.CategoryTheory.Dialectica.Basic
 import Mathlib.CategoryTheory.Dialectica.Monoidal
 import Mathlib.CategoryTheory.DifferentialObject
+import Mathlib.CategoryTheory.DinatTrans
 import Mathlib.CategoryTheory.Discrete.Basic
 import Mathlib.CategoryTheory.Discrete.SumsProducts
 import Mathlib.CategoryTheory.Distributive.Cartesian

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2086,6 +2086,7 @@ import Mathlib.CategoryTheory.FinCategory.Basic
 import Mathlib.CategoryTheory.FintypeCat
 import Mathlib.CategoryTheory.FullSubcategory
 import Mathlib.CategoryTheory.Functor.Basic
+import Mathlib.CategoryTheory.Functor.Bifunctor
 import Mathlib.CategoryTheory.Functor.Category
 import Mathlib.CategoryTheory.Functor.Const
 import Mathlib.CategoryTheory.Functor.Currying

--- a/Mathlib/CategoryTheory/DinatTrans.lean
+++ b/Mathlib/CategoryTheory/DinatTrans.lean
@@ -38,9 +38,9 @@ structure DinatTrans (F G : Cᵒᵖ ⥤ C ⥤ D) : Type max u₁ v₂ where
   app (X : C) : F.obj₂ (op X) X ⟶ G.obj₂ (op X) X
   /-- The commutativity square for a given morphism. -/
   dinaturality {X Y : C} (f : X ⟶ Y) :
-      (F.map f.op).app X ≫ app X ≫ (G.obj (op X)).map f =
-      (F.obj (op Y)).map f ≫ app Y ≫ (G.map f.op).app Y := by
-        aesop_cat
+    (F.map f.op).app X ≫ app X ≫ (G.obj (op X)).map f =
+    (F.obj (op Y)).map f ≫ app Y ≫ (G.map f.op).app Y := by
+      aesop_cat
 
 attribute [reassoc (attr := simp)] DinatTrans.dinaturality
 

--- a/Mathlib/CategoryTheory/DinatTrans.lean
+++ b/Mathlib/CategoryTheory/DinatTrans.lean
@@ -36,8 +36,8 @@ structure DinatTrans (F G : Cᵒᵖ × C ⥤ D) : Type max u₁ v₂ where
   /-- The commutativity square for a given morphism. -/
   dinaturality {X Y : C} (f : X ⟶ Y) :
       F.map (f.op ×ₘ 𝟙 _) ≫ app X ≫ G.map (𝟙 (op _) ×ₘ f) =
-      F.map (𝟙 (op _) ×ₘ f) ≫ app Y ≫ G.map (f.op ×ₘ 𝟙 _) :=
-        by aesop_cat
+      F.map (𝟙 (op _) ×ₘ f) ≫ app Y ≫ G.map (f.op ×ₘ 𝟙 _) := by 
+    aesop_cat
 
 attribute [reassoc (attr := simp)] DinatTrans.dinaturality
 
@@ -57,13 +57,14 @@ variable {F G H : Cᵒᵖ × C ⥤ D}
 @[simps]
 def DinatTrans.compNatTrans (δ : F ⤞ G) (α : G ⟶ H) : F ⤞ H where
   app X := δ.app X ≫ α.app (op X, X)
-  dinaturality f := by simp; rw [←α.naturality, reassoc_of% δ.dinaturality f,←α.naturality]
+  dinaturality f := by rw [Category.assoc, ← α.naturality, reassoc_of% δ.dinaturality f, 
+    Category.assoc, ← α.naturality]
 
 /-- Pre-composition with a natural transformation. -/
 @[simps]
 def DinatTrans.precompNatTrans (δ : G ⤞ H) (α : F ⟶ G) : F ⤞ H where
   app X := α.app (op X, X) ≫ δ.app X
-  dinaturality {X Y} f := by simp only [Category.assoc, NatTrans.naturality_assoc, dinaturality]
+  dinaturality := by simp
 
 /-- Opposite of a dinatural transformation. -/
 @[simps]

--- a/Mathlib/CategoryTheory/DinatTrans.lean
+++ b/Mathlib/CategoryTheory/DinatTrans.lean
@@ -3,7 +3,7 @@ Copyright (c) 2023 Andrea Laretto. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrea Laretto
 -/
-import Mathlib.CategoryTheory.Products.Bifunctor
+import Mathlib.CategoryTheory.Functor.Bifunctor
 
 /-!
 # Dinatural transformations
@@ -32,24 +32,22 @@ variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
 
 open Opposite
 
-/-- Dinatural transformations between two (di)functors. -/
+/-- Dinatural transformations between two difunctors. -/
 structure DinatTrans (F G : Cᵒᵖ ⥤ C ⥤ D) : Type max u₁ v₂ where
   /-- The component of a natural transformation. -/
   app (X : C) : F.obj₂ (op X) X ⟶ G.obj₂ (op X) X
   /-- The commutativity square for a given morphism. -/
   dinaturality {X Y : C} (f : X ⟶ Y) :
       (F.map f.op).app X ≫ app X ≫ (G.obj (op X)).map f =
-      (F.obj (op Y)).map f ≫ app Y ≫ (G.map f.op).app Y :=
-        by aesop_cat
+      (F.obj (op Y)).map f ≫ app Y ≫ (G.map f.op).app Y := by
+        aesop_cat
 
 attribute [reassoc (attr := simp)] DinatTrans.dinaturality
 
+namespace DinatTrans
+
 /-- Notation for dinatural transformations. -/
 scoped infixr:50 " ⤞ " => DinatTrans
-
-/-- Opposite of a difunctor. -/
-@[simps!]
-def Functor.diop (F : Cᵒᵖ ⥤ C ⥤ D) : Cᵒᵖ ⥤ C ⥤ Dᵒᵖ := F.biop.flip
 
 variable {E : Type u₃} [Category.{v₃} E] {F : Type u₄} [Category.{v₄} F]
 
@@ -57,8 +55,7 @@ variable {F G H : Cᵒᵖ ⥤ C ⥤ D}
 
 /-- Post-composition with a natural transformation. -/
 @[simps]
-def DinatTrans.compNatTrans (δ : F ⤞ G) (α : G ⟶ H) : F ⤞ H
-    where
+def compNatTrans (δ : F ⤞ G) (α : G ⟶ H) : F ⤞ H where
   app X := δ.app X ≫ α.app₂ (op X) X
   dinaturality f := by
     rw [Category.assoc, Category.assoc, ← NatTrans.naturality_app,
@@ -66,16 +63,15 @@ def DinatTrans.compNatTrans (δ : F ⤞ G) (α : G ⟶ H) : F ⤞ H
 
 /-- Pre-composition with a natural transformation. -/
 @[simps]
-def DinatTrans.precompNatTrans (δ : G ⤞ H) (α : F ⟶ G) : F ⤞ H
-    where
+def precompNatTrans (δ : G ⤞ H) (α : F ⟶ G) : F ⤞ H where
   app X := α.app₂ (op X) X ≫ δ.app X
 
 /-- Opposite of a dinatural transformation. -/
 @[simps]
-def DinatTrans.op (α : F ⤞ G) : G.diop ⤞ F.diop
-    where
+def op (α : F ⤞ G) : G.diop ⤞ F.diop where
   app X := (α.app X).op
   dinaturality f := Quiver.Hom.unop_inj <| by
     convert α.dinaturality f using 1 <;> exact Category.assoc _ _ _
 
+end DinatTrans
 end CategoryTheory

--- a/Mathlib/CategoryTheory/DinatTrans.lean
+++ b/Mathlib/CategoryTheory/DinatTrans.lean
@@ -9,7 +9,7 @@ import Mathlib.CategoryTheory.Products.Bifunctor
 # Dinatural transformations
 
 Dinatural transformations are special kinds of transformations between
-functors `F G : Cᵒᵖ × C ⥤ D` which depend both covariantly and contravariantly
+functors `F G : Cᵒᵖ ⥤ C ⥤ D` which depend both covariantly and contravariantly
 on the same category (also known as difunctors).
 
 A dinatural transformation is a family of morphisms given only on *the diagonal* of the two
@@ -18,6 +18,10 @@ functors, and is such that a certain naturality hexagon commutes.
 Note that dinatural transformations cannot be composed with each other (since the outer
 hexagon does not commute in general), but can still be "pre/post-composed" with
 ordinary natural transformations.
+
+## References
+
+* <https://ncatlab.org/nlab/show/dinatural+transformation>
 -/
 
 namespace CategoryTheory
@@ -26,50 +30,51 @@ universe v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
 
 variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
 
-open Opposite Bifunctor
-open scoped Prod
+open Opposite
 
 /-- Dinatural transformations between two (di)functors. -/
-structure DinatTrans (F G : Cᵒᵖ × C ⥤ D) : Type max u₁ v₂ where
+structure DinatTrans (F G : Cᵒᵖ ⥤ C ⥤ D) : Type max u₁ v₂ where
   /-- The component of a natural transformation. -/
-  app (X : C) : F.obj ⟨op X, X⟩ ⟶ G.obj ⟨op X, X⟩
+  app (X : C) : F.obj₂ (op X) X ⟶ G.obj₂ (op X) X
   /-- The commutativity square for a given morphism. -/
   dinaturality {X Y : C} (f : X ⟶ Y) :
-      F.map (f.op ×ₘ 𝟙 _) ≫ app X ≫ G.map (𝟙 (op _) ×ₘ f) =
-      F.map (𝟙 (op _) ×ₘ f) ≫ app Y ≫ G.map (f.op ×ₘ 𝟙 _) := by 
-    aesop_cat
+      (F.map f.op).app X ≫ app X ≫ (G.obj (op X)).map f =
+      (F.obj (op Y)).map f ≫ app Y ≫ (G.map f.op).app Y :=
+        by aesop_cat
 
 attribute [reassoc (attr := simp)] DinatTrans.dinaturality
 
 /-- Notation for dinatural transformations. -/
-infixr:50 " ⤞ " => DinatTrans
+scoped infixr:50 " ⤞ " => DinatTrans
 
 /-- Opposite of a difunctor. -/
 @[simps!]
-def Functor.diop (F : Cᵒᵖ × C ⥤ D) : Cᵒᵖ × C ⥤ Dᵒᵖ :=
-  prod (𝟭 Cᵒᵖ) (opOp C) ⋙ flip (biop F)
+def Functor.diop (F : Cᵒᵖ ⥤ C ⥤ D) : Cᵒᵖ ⥤ C ⥤ Dᵒᵖ := F.biop.flip
 
 variable {E : Type u₃} [Category.{v₃} E] {F : Type u₄} [Category.{v₄} F]
 
-variable {F G H : Cᵒᵖ × C ⥤ D}
+variable {F G H : Cᵒᵖ ⥤ C ⥤ D}
 
 /-- Post-composition with a natural transformation. -/
 @[simps]
-def DinatTrans.compNatTrans (δ : F ⤞ G) (α : G ⟶ H) : F ⤞ H where
-  app X := δ.app X ≫ α.app (op X, X)
-  dinaturality f := by rw [Category.assoc, ← α.naturality, reassoc_of% δ.dinaturality f, 
-    Category.assoc, ← α.naturality]
+def DinatTrans.compNatTrans (δ : F ⤞ G) (α : G ⟶ H) : F ⤞ H
+    where
+  app X := δ.app X ≫ α.app₂ (op X) X
+  dinaturality f := by
+    rw [Category.assoc, Category.assoc, ← NatTrans.naturality_app,
+      ← δ.dinaturality_assoc f, NatTrans.naturality]
 
 /-- Pre-composition with a natural transformation. -/
 @[simps]
-def DinatTrans.precompNatTrans (δ : G ⤞ H) (α : F ⟶ G) : F ⤞ H where
-  app X := α.app (op X, X) ≫ δ.app X
-  dinaturality := by simp
+def DinatTrans.precompNatTrans (δ : G ⤞ H) (α : F ⟶ G) : F ⤞ H
+    where
+  app X := α.app₂ (op X) X ≫ δ.app X
 
 /-- Opposite of a dinatural transformation. -/
 @[simps]
-def DinatTrans.op (α : F ⤞ G) : G.diop ⤞ F.diop where
-  app X := by simp; exact (α.app X).op
+def DinatTrans.op (α : F ⤞ G) : G.diop ⤞ F.diop
+    where
+  app X := (α.app X).op
   dinaturality f := Quiver.Hom.unop_inj <| by
     convert α.dinaturality f using 1 <;> exact Category.assoc _ _ _
 

--- a/Mathlib/CategoryTheory/DinatTrans.lean
+++ b/Mathlib/CategoryTheory/DinatTrans.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2023 Andrea Laretto. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrea Laretto
+-/
+import Mathlib.CategoryTheory.Products.Bifunctor
+
+/-!
+# Dinatural transformations
+
+Dinatural transformations are special kinds of transformations between
+functors `F G : Cᵒᵖ × C ⥤ D` which depend both covariantly and contravariantly
+on the same category (also known as difunctors).
+
+A dinatural transformation is a family of morphisms given only on *the diagonal* of the two
+functors, and is such that a certain naturality hexagon commutes.
+
+Note that dinatural transformations cannot be composed with each other (since the outer
+hexagon does not commute in general), but can still be "pre/post-composed" with
+ordinary natural transformations.
+-/
+
+namespace CategoryTheory
+
+universe v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
+
+variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
+
+open Opposite Bifunctor
+open scoped Prod
+
+/-- Dinatural transformations between two (di)functors. -/
+structure DinatTrans (F G : Cᵒᵖ × C ⥤ D) : Type max u₁ v₂ where
+  /-- The component of a natural transformation. -/
+  app (X : C) : F.obj ⟨op X, X⟩ ⟶ G.obj ⟨op X, X⟩
+  /-- The commutativity square for a given morphism. -/
+  dinaturality {X Y : C} (f : X ⟶ Y) :
+      F.map (f.op ×ₘ 𝟙 _) ≫ app X ≫ G.map (𝟙 (op _) ×ₘ f) =
+      F.map (𝟙 (op _) ×ₘ f) ≫ app Y ≫ G.map (f.op ×ₘ 𝟙 _) :=
+        by aesop_cat
+
+attribute [reassoc (attr := simp)] DinatTrans.dinaturality
+
+/-- Notation for dinatural transformations. -/
+infixr:50 " ⤞ " => DinatTrans
+
+/-- Opposite of a difunctor. -/
+@[simps!]
+def Functor.diop (F : Cᵒᵖ × C ⥤ D) : Cᵒᵖ × C ⥤ Dᵒᵖ :=
+  prod (𝟭 Cᵒᵖ) (opOp C) ⋙ flip (biop F)
+
+variable {E : Type u₃} [Category.{v₃} E] {F : Type u₄} [Category.{v₄} F]
+
+variable {F G H : Cᵒᵖ × C ⥤ D}
+
+/-- Post-composition with a natural transformation. -/
+@[simps]
+def DinatTrans.compNatTrans (δ : F ⤞ G) (α : G ⟶ H) : F ⤞ H where
+  app X := δ.app X ≫ α.app (op X, X)
+  dinaturality f := by simp; rw [←α.naturality, reassoc_of% δ.dinaturality f,←α.naturality]
+
+/-- Pre-composition with a natural transformation. -/
+@[simps]
+def DinatTrans.precompNatTrans (δ : G ⤞ H) (α : F ⟶ G) : F ⤞ H where
+  app X := α.app (op X, X) ≫ δ.app X
+  dinaturality {X Y} f := by simp only [Category.assoc, NatTrans.naturality_assoc, dinaturality]
+
+/-- Opposite of a dinatural transformation. -/
+@[simps]
+def DinatTrans.op (α : F ⤞ G) : G.diop ⤞ F.diop where
+  app X := by simp; exact (α.app X).op
+  dinaturality f := Quiver.Hom.unop_inj <| by
+    convert α.dinaturality f using 1 <;> exact Category.assoc _ _ _
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Functor/Bifunctor.lean
+++ b/Mathlib/CategoryTheory/Functor/Bifunctor.lean
@@ -49,27 +49,15 @@ def Functor.biop (F : Cᵒᵖ ⥤ D ⥤ E) : C ⥤ Dᵒᵖ ⥤ Eᵒᵖ := F.righ
 abbrev Functor.diop (F : Cᵒᵖ ⥤ C ⥤ D) : Cᵒᵖ ⥤ C ⥤ Dᵒᵖ := F.biop.flip
 
 @[simp]
-theorem map_id' (F : C ⥤ D ⥤ E) (X : C) (Y : D) :
+theorem Functor.map₂_id (F : C ⥤ D ⥤ E) (X : C) (Y : D) :
     F.map₂ (𝟙 X) (𝟙 Y) = 𝟙 (F.obj₂ X Y) := by simp
 
 @[simp]
-theorem map_id (F : C ⥤ D ⥤ E) (X : C) (Y : D) :
-    F.map₂ (𝟙 X) (𝟙 Y) = 𝟙 (F.obj₂ X Y) := by simp
-
-@[simp]
-theorem map_id_comp (F : C ⥤ D ⥤ E) (W : C) {X Y Z : D} (f : X ⟶ Y) (g : Y ⟶ Z) :
+theorem Functor.map₂_id_comp (F : C ⥤ D ⥤ E) (W : C) {X Y Z : D} (f : X ⟶ Y) (g : Y ⟶ Z) :
     F.map₂ (𝟙 W) (f ≫ g) = F.map₂ (𝟙 W) f ≫ F.map₂ (𝟙 W) g := by simp
 
 @[simp]
-theorem map_comp_id (F : C ⥤ D ⥤ E) (X Y Z : C) (W : D) (f : X ⟶ Y) (g : Y ⟶ Z) :
+theorem Functor.map₂_comp_id (F : C ⥤ D ⥤ E) (X Y Z : C) (W : D) (f : X ⟶ Y) (g : Y ⟶ Z) :
     F.map₂ (f ≫ g) (𝟙 W) = F.map₂ f (𝟙 W) ≫ F.map₂ g (𝟙 W) := by simp
-
-@[simp]
-theorem diagonal (F : C ⥤ D ⥤ E) (X X' : C) (f : X ⟶ X') (Y Y' : D) (g : Y ⟶ Y') :
-    F.map₂ (𝟙 X) g ≫ F.map₂ f (𝟙 Y') = F.map₂ f g := by simp
-
-@[simp]
-theorem diagonal' (F : C ⥤ D ⥤ E) (X X' : C) (f : X ⟶ X') (Y Y' : D) (g : Y ⟶ Y') :
-    F.map₂ f (𝟙 Y) ≫ F.map₂ (𝟙 X') g = F.map₂ f g := by simp
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Functor/Bifunctor.lean
+++ b/Mathlib/CategoryTheory/Functor/Bifunctor.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2025 Fernando Chu. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Fernando Chu
+-/
+import Mathlib.CategoryTheory.Functor.Category
+import Mathlib.CategoryTheory.Opposites
+
+/-!
+# Bifunctors
+
+We develop some basic lemmas and APIs about (curried) bifunctors. See also
+`CategoryTheory.Bifunctor`.
+-/
+
+open CategoryTheory Opposite
+
+universe v₁ v₂ v₃ u₁ u₂ u₃
+variable {C : Type u₁} {D : Type u₂} {E : Type u₃}
+variable [Category.{v₁} C] [Category.{v₂} D] [Category.{v₃} E]
+
+namespace CategoryTheory
+
+variable {C₁ C₂ : C} {D₁ D₂ : D} {E₁ E₂ : E}
+
+/-- Action of two-variable functors on objects. -/
+abbrev Functor.obj₂ (F : C ⥤ D ⥤ E) (A : C) (B : D) : E := (F.obj A).obj B
+
+/-- Action of two-variable functors on objects. -/
+@[simp]
+def Functor.map₂ (F : C ⥤ D ⥤ E) {A B : C} {X Y : D} (f : A ⟶ B) (g : X ⟶ Y) :
+    F.obj₂ A X ⟶ F.obj₂ B Y :=
+  (F.map f).app X ≫ (F.obj B).map g
+
+/-- Apply a natural transformation between bifunctors to two objects. -/
+abbrev NatTrans.app₂ {F G : C ⥤ D ⥤ E} (α : F ⟶ G) (X : C) (Y : D) :
+    F.obj₂ X Y ⟶ G.obj₂ X Y :=
+  (α.app X).app Y
+
+@[reassoc, simp]
+lemma NatTrans.comp_app₂ {H G K : C ⥤ D ⥤ E} (α : H ⟶ G) (β : G ⟶ K) (X : C) (Y : D) :
+    (α ≫ β).app₂ X Y = α.app₂ X Y ≫ β.app₂ X Y := rfl
+
+/-- Opposite of a bifunctor. -/
+@[simps!]
+def Functor.biop (F : Cᵒᵖ ⥤ D ⥤ E) : C ⥤ Dᵒᵖ ⥤ Eᵒᵖ := F.rightOp ⋙ Functor.opHom _ _
+
+/-- Opposite of a difunctor. -/
+abbrev Functor.diop (F : Cᵒᵖ ⥤ C ⥤ D) : Cᵒᵖ ⥤ C ⥤ Dᵒᵖ := F.biop.flip
+
+@[simp]
+theorem map_id' (F : C ⥤ D ⥤ E) (X : C) (Y : D) :
+    F.map₂ (𝟙 X) (𝟙 Y) = 𝟙 (F.obj₂ X Y) := by simp
+
+@[simp]
+theorem map_id (F : C ⥤ D ⥤ E) (X : C) (Y : D) :
+    F.map₂ (𝟙 X) (𝟙 Y) = 𝟙 (F.obj₂ X Y) := by simp
+
+@[simp]
+theorem map_id_comp (F : C ⥤ D ⥤ E) (W : C) {X Y Z : D} (f : X ⟶ Y) (g : Y ⟶ Z) :
+    F.map₂ (𝟙 W) (f ≫ g) = F.map₂ (𝟙 W) f ≫ F.map₂ (𝟙 W) g := by simp
+
+@[simp]
+theorem map_comp_id (F : C ⥤ D ⥤ E) (X Y Z : C) (W : D) (f : X ⟶ Y) (g : Y ⟶ Z) :
+    F.map₂ (f ≫ g) (𝟙 W) = F.map₂ f (𝟙 W) ≫ F.map₂ g (𝟙 W) := by simp
+
+@[simp]
+theorem diagonal (F : C ⥤ D ⥤ E) (X X' : C) (f : X ⟶ X') (Y Y' : D) (g : Y ⟶ Y') :
+    F.map₂ (𝟙 X) g ≫ F.map₂ f (𝟙 Y') = F.map₂ f g := by simp
+
+@[simp]
+theorem diagonal' (F : C ⥤ D ⥤ E) (X X' : C) (f : X ⟶ X') (Y Y' : D) (g : Y ⟶ Y') :
+    F.map₂ f (𝟙 Y) ≫ F.map₂ (𝟙 X') g = F.map₂ f g := by simp
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Functor/Bifunctor.lean
+++ b/Mathlib/CategoryTheory/Functor/Bifunctor.lean
@@ -3,7 +3,6 @@ Copyright (c) 2025 Fernando Chu. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrea Laretto, Fernando Chu
 -/
-import Mathlib.CategoryTheory.Functor.Category
 import Mathlib.CategoryTheory.Opposites
 
 /-!
@@ -37,12 +36,33 @@ abbrev Functor.mapₗ (F : C ⥤ D ⥤ E) {A B : C} (f : A ⟶ B) (X : D) :
     F.obj₂ A X ⟶ F.obj₂ B X :=
   (F.map f).app X
 
+@[simp, reassoc]
+lemma Functor.mapₗ_comp (F : C ⥤ D ⥤ E) {A B T : C} (f : A ⟶ B) (g : B ⟶ T) (X : D) :
+    F.mapₗ (f ≫ g) X = F.mapₗ f X ≫ F.mapₗ g X := by
+  simp [Functor.mapₗ]
+
+@[simp, reassoc]
+lemma Functor.mapₗ_id (F : C ⥤ D ⥤ E) {A : C} (X : D) :
+    F.mapₗ (𝟙 A) X = 𝟙 (F.obj₂ A X) := by
+  simp [Functor.mapₗ]
+
 /-- Action of two-variable functors on a morphism in the right argument. -/
 abbrev Functor.mapᵣ (F : C ⥤ D ⥤ E) (A : C) {X Y : D} (g : X ⟶ Y) :
     F.obj₂ A X ⟶ F.obj₂ A Y :=
   (F.obj A).map g
 
+@[simp, reassoc]
+lemma Functor.mapᵣ_comp (F : C ⥤ D ⥤ E) (A : C) {X Y Z : D} (f : X ⟶ Y) (g : Y ⟶ Z) :
+    F.mapᵣ A (f ≫ g) = F.mapᵣ A f ≫ F.mapᵣ A g := by
+  simp [Functor.mapᵣ]
+
+@[simp, reassoc]
+lemma Functor.mapᵣ_id (F : C ⥤ D ⥤ E) (A : C) {X : D} :
+    F.mapᵣ A (𝟙 X) = 𝟙 (F.obj₂ A X) := by
+  simp [Functor.mapᵣ]
+
 /-- Apply a natural transformation between bifunctors to two objects. -/
+@[simp]
 abbrev NatTrans.app₂ {F G : C ⥤ D ⥤ E} (α : F ⟶ G) (X : C) (Y : D) :
     F.obj₂ X Y ⟶ G.obj₂ X Y :=
   (α.app X).app Y

--- a/Mathlib/CategoryTheory/Functor/Bifunctor.lean
+++ b/Mathlib/CategoryTheory/Functor/Bifunctor.lean
@@ -48,16 +48,4 @@ def Functor.biop (F : Cᵒᵖ ⥤ D ⥤ E) : C ⥤ Dᵒᵖ ⥤ Eᵒᵖ := F.righ
 /-- Opposite of a difunctor. -/
 abbrev Functor.diop (F : Cᵒᵖ ⥤ C ⥤ D) : Cᵒᵖ ⥤ C ⥤ Dᵒᵖ := F.biop.flip
 
-@[simp]
-theorem Functor.map₂_id (F : C ⥤ D ⥤ E) (X : C) (Y : D) :
-    F.map₂ (𝟙 X) (𝟙 Y) = 𝟙 (F.obj₂ X Y) := by simp
-
-@[simp]
-theorem Functor.map₂_id_comp (F : C ⥤ D ⥤ E) (W : C) {X Y Z : D} (f : X ⟶ Y) (g : Y ⟶ Z) :
-    F.map₂ (𝟙 W) (f ≫ g) = F.map₂ (𝟙 W) f ≫ F.map₂ (𝟙 W) g := by simp
-
-@[simp]
-theorem Functor.map₂_comp_id (F : C ⥤ D ⥤ E) (X Y Z : C) (W : D) (f : X ⟶ Y) (g : Y ⟶ Z) :
-    F.map₂ (f ≫ g) (𝟙 W) = F.map₂ f (𝟙 W) ≫ F.map₂ g (𝟙 W) := by simp
-
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Functor/Bifunctor.lean
+++ b/Mathlib/CategoryTheory/Functor/Bifunctor.lean
@@ -32,11 +32,11 @@ def Functor.map₂ (F : C ⥤ D ⥤ E) {A B : C} {X Y : D} (f : A ⟶ B) (g : X 
     F.obj₂ A X ⟶ F.obj₂ B Y :=
   (F.map f).app X ≫ (F.obj B).map g
 
-abbrev Functor.mapₗ (F : C ⥤ D ⥤ E) {A B : C} {X : D} (f : A ⟶ B) :
+abbrev Functor.mapₗ (F : C ⥤ D ⥤ E) {A B : C} (f : A ⟶ B) (X : D) :
     F.obj₂ A X ⟶ F.obj₂ B X :=
   (F.map f).app X
 
-abbrev Functor.mapᵣ (F : C ⥤ D ⥤ E) {A : C} {X Y : D} (g : X ⟶ Y) :
+abbrev Functor.mapᵣ (F : C ⥤ D ⥤ E) (A : C) {X Y : D} (g : X ⟶ Y) :
     F.obj₂ A X ⟶ F.obj₂ A Y :=
   (F.obj A).map g
 

--- a/Mathlib/CategoryTheory/Functor/Bifunctor.lean
+++ b/Mathlib/CategoryTheory/Functor/Bifunctor.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Fernando Chu. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Fernando Chu
+Authors: Andrea Laretto, Fernando Chu
 -/
 import Mathlib.CategoryTheory.Functor.Category
 import Mathlib.CategoryTheory.Opposites

--- a/Mathlib/CategoryTheory/Functor/Bifunctor.lean
+++ b/Mathlib/CategoryTheory/Functor/Bifunctor.lean
@@ -26,16 +26,18 @@ variable {C₁ C₂ : C} {D₁ D₂ : D} {E₁ E₂ : E}
 /-- Action of two-variable functors on objects. -/
 abbrev Functor.obj₂ (F : C ⥤ D ⥤ E) (A : C) (B : D) : E := (F.obj A).obj B
 
-/-- Action of two-variable functors on objects. -/
+/-- Action of two-variable functors on morphisms. -/
 @[simp]
 def Functor.map₂ (F : C ⥤ D ⥤ E) {A B : C} {X Y : D} (f : A ⟶ B) (g : X ⟶ Y) :
     F.obj₂ A X ⟶ F.obj₂ B Y :=
   (F.map f).app X ≫ (F.obj B).map g
 
+/-- Action of two-variable functors on a morphism in the left argument. -/
 abbrev Functor.mapₗ (F : C ⥤ D ⥤ E) {A B : C} (f : A ⟶ B) (X : D) :
     F.obj₂ A X ⟶ F.obj₂ B X :=
   (F.map f).app X
 
+/-- Action of two-variable functors on a morphism in the right argument. -/
 abbrev Functor.mapᵣ (F : C ⥤ D ⥤ E) (A : C) {X Y : D} (g : X ⟶ Y) :
     F.obj₂ A X ⟶ F.obj₂ A Y :=
   (F.obj A).map g

--- a/Mathlib/CategoryTheory/Functor/Bifunctor.lean
+++ b/Mathlib/CategoryTheory/Functor/Bifunctor.lean
@@ -32,6 +32,14 @@ def Functor.map₂ (F : C ⥤ D ⥤ E) {A B : C} {X Y : D} (f : A ⟶ B) (g : X 
     F.obj₂ A X ⟶ F.obj₂ B Y :=
   (F.map f).app X ≫ (F.obj B).map g
 
+abbrev Functor.mapₗ (F : C ⥤ D ⥤ E) {A B : C} {X : D} (f : A ⟶ B) :
+    F.obj₂ A X ⟶ F.obj₂ B X :=
+  (F.map f).app X
+
+abbrev Functor.mapᵣ (F : C ⥤ D ⥤ E) {A : C} {X Y : D} (g : X ⟶ Y) :
+    F.obj₂ A X ⟶ F.obj₂ A Y :=
+  (F.obj A).map g
+
 /-- Apply a natural transformation between bifunctors to two objects. -/
 abbrev NatTrans.app₂ {F G : C ⥤ D ⥤ E} (α : F ⟶ G) (X : C) (Y : D) :
     F.obj₂ X Y ⟶ G.obj₂ X Y :=

--- a/Mathlib/CategoryTheory/Functor/Bifunctor.lean
+++ b/Mathlib/CategoryTheory/Functor/Bifunctor.lean
@@ -51,16 +51,6 @@ abbrev Functor.mapᵣ (F : C ⥤ D ⥤ E) (A : C) {X Y : D} (g : X ⟶ Y) :
     F.obj₂ A X ⟶ F.obj₂ A Y :=
   (F.obj A).map g
 
-@[simp, reassoc]
-lemma Functor.mapᵣ_comp (F : C ⥤ D ⥤ E) (A : C) {X Y Z : D} (f : X ⟶ Y) (g : Y ⟶ Z) :
-    F.mapᵣ A (f ≫ g) = F.mapᵣ A f ≫ F.mapᵣ A g := by
-  simp [Functor.mapᵣ]
-
-@[simp, reassoc]
-lemma Functor.mapᵣ_id (F : C ⥤ D ⥤ E) (A : C) {X : D} :
-    F.mapᵣ A (𝟙 X) = 𝟙 (F.obj₂ A X) := by
-  simp [Functor.mapᵣ]
-
 /-- Apply a natural transformation between bifunctors to two objects. -/
 @[simp]
 abbrev NatTrans.app₂ {F G : C ⥤ D ⥤ E} (α : F ⟶ G) (X : C) (Y : D) :

--- a/Mathlib/CategoryTheory/Functor/Category.lean
+++ b/Mathlib/CategoryTheory/Functor/Category.lean
@@ -78,7 +78,7 @@ theorem app_naturality {F G : C ⥤ D ⥤ E} (T : F ⟶ G) (X : C) {Y Z : D} (f 
     (F.obj X).map f ≫ (T.app X).app Z = (T.app X).app Y ≫ (G.obj X).map f :=
   (T.app X).naturality f
 
-@[reassoc]
+@[reassoc (attr := simp)]
 theorem naturality_app {F G : C ⥤ D ⥤ E} (T : F ⟶ G) (Z : D) {X Y : C} (f : X ⟶ Y) :
     (F.map f).app Z ≫ (T.app Y).app Z = (T.app X).app Z ≫ (G.map f).app Z :=
   congr_fun (congr_arg app (T.naturality f)) Z

--- a/Mathlib/CategoryTheory/Functor/Category.lean
+++ b/Mathlib/CategoryTheory/Functor/Category.lean
@@ -143,17 +143,14 @@ protected def flip (F : C ⥤ D ⥤ E) : D ⥤ C ⥤ E where
       map := fun f => (F.map f).app k, }
   map f := { app := fun j => (F.obj j).map f }
 
-
-/-- The left unitor, a natural isomorphism `((𝟭 _) ⋙ F) ≅ F`.
--/
+/-- The left unitor, a natural isomorphism `((𝟭 _) ⋙ F) ≅ F`. -/
 @[simps]
 def leftUnitor (F : C ⥤ D) :
     𝟭 C ⋙ F ≅ F where
   hom := { app := fun X => 𝟙 (F.obj X) }
   inv := { app := fun X => 𝟙 (F.obj X) }
 
-/-- The right unitor, a natural isomorphism `(F ⋙ (𝟭 B)) ≅ F`.
--/
+/-- The right unitor, a natural isomorphism `(F ⋙ (𝟭 B)) ≅ F`. -/
 @[simps]
 def rightUnitor (F : C ⥤ D) :
     F ⋙ 𝟭 D ≅ F where

--- a/Mathlib/CategoryTheory/Functor/Trifunctor.lean
+++ b/Mathlib/CategoryTheory/Functor/Trifunctor.lean
@@ -3,7 +3,8 @@ Copyright (c) 2023 Joël Riou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
-import Mathlib.CategoryTheory.Functor.Category
+import Mathlib.CategoryTheory.Functor.Bifunctor
+
 /-!
 # Trifunctors obtained by composition of bifunctors
 
@@ -19,6 +20,27 @@ objects `X₁ : C₁`, `X₂ : C₂` and `X₃ : C₃` to `(F.obj X₁).obj ((G�
 
 namespace CategoryTheory
 
+section
+
+universe v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
+variable {C : Type u₁} {D : Type u₂} {E : Type u₃} {F : Type u₄}
+variable [Category.{v₁} C] [Category.{v₂} D] [Category.{v₃} E] [Category.{v₄} F]
+
+/-- Action of three-variable functors on objects. -/
+abbrev Functor.obj₃ (H : C ⥤ D ⥤ E ⥤ F) (A : C) (B : D) (C : E) : F :=
+  ((H.obj A).obj B).obj C
+
+/-- Apply a natural transformation between bifunctors in three variables to three objects. -/
+abbrev NatTrans.app₃ {H G : C ⥤ D ⥤ E ⥤ F} (α : H ⟶ G) (X : C) (Y : D) (Z : E) :
+    H.obj₃ X Y Z ⟶ G.obj₃ X Y Z :=
+  ((α.app X).app Y).app Z
+
+@[reassoc, simp]
+lemma comp_app₃ {H G K : C ⥤ D ⥤ E ⥤ F} (α : H ⟶ G) (β : G ⟶ K) (X : C) (Y : D)
+    (Z : E) : (α ≫ β).app₃ X Y Z = α.app₃ X Y Z ≫ β.app₃ X Y Z := rfl
+
+end
+
 variable {C₁ C₂ C₃ C₄ C₁₂ C₂₃ : Type*} [Category C₁] [Category C₂] [Category C₃]
   [Category C₄] [Category C₁₂] [Category C₂₃]
 
@@ -29,8 +51,8 @@ section bifunctorComp₁₂Functor
 def bifunctorComp₁₂Obj (F₁₂ : C₁ ⥤ C₂ ⥤ C₁₂) (G : C₁₂ ⥤ C₃ ⥤ C₄) (X₁ : C₁) :
     C₂ ⥤ C₃ ⥤ C₄ where
   obj X₂ :=
-    { obj := fun X₃ => (G.obj ((F₁₂.obj X₁).obj X₂)).obj X₃
-      map := fun {_ _} φ => (G.obj ((F₁₂.obj X₁).obj X₂)).map φ }
+    { obj := fun X₃ => G.obj₂ (F₁₂.obj₂ X₁ X₂) X₃
+      map := fun {_ _} φ => G.map₂ (𝟙 (F₁₂.obj₂ X₁ X₂)) φ }
   map {X₂ Y₂} φ :=
     { app := fun X₃ => (G.map ((F₁₂.obj X₁).map φ)).app X₃ }
 

--- a/Mathlib/CategoryTheory/Functor/Trifunctor.lean
+++ b/Mathlib/CategoryTheory/Functor/Trifunctor.lean
@@ -3,6 +3,7 @@ Copyright (c) 2023 Joël Riou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
+import Mathlib.CategoryTheory.Functor.Category
 import Mathlib.CategoryTheory.Functor.Bifunctor
 
 /-!
@@ -51,8 +52,8 @@ section bifunctorComp₁₂Functor
 def bifunctorComp₁₂Obj (F₁₂ : C₁ ⥤ C₂ ⥤ C₁₂) (G : C₁₂ ⥤ C₃ ⥤ C₄) (X₁ : C₁) :
     C₂ ⥤ C₃ ⥤ C₄ where
   obj X₂ :=
-    { obj := fun X₃ => G.obj₂ (F₁₂.obj₂ X₁ X₂) X₃
-      map := fun {_ _} φ => (G.obj (F₁₂.obj₂ X₁ X₂)).map φ }
+    { obj := fun X₃ => (G.obj ((F₁₂.obj X₁).obj X₂)).obj X₃
+      map := fun {_ _} φ => (G.obj ((F₁₂.obj X₁).obj X₂)).map φ }
   map {X₂ Y₂} φ :=
     { app := fun X₃ => (G.map ((F₁₂.obj X₁).map φ)).app X₃ }
 

--- a/Mathlib/CategoryTheory/Functor/Trifunctor.lean
+++ b/Mathlib/CategoryTheory/Functor/Trifunctor.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
 import Mathlib.CategoryTheory.Functor.Category
-import Mathlib.CategoryTheory.Functor.Bifunctor
 
 /-!
 # Trifunctors obtained by composition of bifunctors

--- a/Mathlib/CategoryTheory/Functor/Trifunctor.lean
+++ b/Mathlib/CategoryTheory/Functor/Trifunctor.lean
@@ -52,7 +52,7 @@ def bifunctorComp₁₂Obj (F₁₂ : C₁ ⥤ C₂ ⥤ C₁₂) (G : C₁₂ �
     C₂ ⥤ C₃ ⥤ C₄ where
   obj X₂ :=
     { obj := fun X₃ => G.obj₂ (F₁₂.obj₂ X₁ X₂) X₃
-      map := fun {_ _} φ => G.map₂ (𝟙 (F₁₂.obj₂ X₁ X₂)) φ }
+      map := fun {_ _} φ => (G.obj (F₁₂.obj₂ X₁ X₂)).map φ }
   map {X₂ Y₂} φ :=
     { app := fun X₃ => (G.map ((F₁₂.obj X₁).map φ)).app X₃ }
 

--- a/Mathlib/CategoryTheory/Products/Bifunctor.lean
+++ b/Mathlib/CategoryTheory/Products/Bifunctor.lean
@@ -9,7 +9,6 @@ import Mathlib.CategoryTheory.Products.Basic
 # Lemmas about functors out of product categories.
 -/
 
-
 open CategoryTheory Opposite
 
 universe v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
@@ -56,47 +55,3 @@ def flip (F : C × D ⥤ E) : D × C ⥤ E :=
   Prod.swap D C ⋙ F
 
 end CategoryTheory.Bifunctor
-
-namespace CategoryTheory.Functor
-
-/-- Opposite of a bifunctor. -/
-@[simps!]
-def biop (F : Cᵒᵖ ⥤ D ⥤ E) : C ⥤ Dᵒᵖ ⥤ Eᵒᵖ := F.rightOp ⋙ Functor.opHom _ _
-
-end CategoryTheory.Functor
-
-namespace CategoryTheory
-
-variable {C₁ C₂ : C} {D₁ D₂ : D} {E₁ E₂ : E}
-
-/-- Action of two-variable functors on objects. -/
-abbrev Functor.obj₂ (H : C ⥤ D ⥤ E) (A : C) (B : D) : E := (H.obj A).obj B
-
-/-- Action of three-variable functors on objects. -/
-abbrev Functor.obj₃ (H : C ⥤ D ⥤ E ⥤ F) (A : C) (B : D) (C : E) : F :=
-  ((H.obj A).obj B).obj C
-
-/-- Apply a natural transformation between bifunctors to two objects. -/
-abbrev NatTrans.app₂ {F G : C ⥤ D ⥤ E} (α : NatTrans F G) (X : C) (Y : D) :
-    F.obj₂ X Y ⟶ G.obj₂ X Y :=
-  (α.app X).app Y
-
-/-- Apply a natural transformation between bifunctors in three variables to three objects. -/
-abbrev NatTrans.app₃ {H G : C ⥤ D ⥤ E ⥤ F} (α : NatTrans H G) (X : C) (Y : D) (Z : E) :
-    H.obj₃ X Y Z ⟶ G.obj₃ X Y Z :=
-  ((α.app X).app Y).app Z
-
-/- Natural transformations between functors with many variables. -/
-namespace NatTrans
-
-@[reassoc, simp]
-lemma comp_app₂ {H G K : C ⥤ D ⥤ E} (α : H ⟶ G) (β : G ⟶ K) (X : C) (Y : D) :
-    (α ≫ β).app₂ X Y = α.app₂ X Y ≫ β.app₂ X Y := rfl
-
-@[reassoc, simp]
-lemma comp_app₃ {H G K : C ⥤ D ⥤ E ⥤ F} (α : H ⟶ G) (β : G ⟶ K) (X : C) (Y : D)
-    (Z : E) : (α ≫ β).app₃ X Y Z = α.app₃ X Y Z ≫ β.app₃ X Y Z := rfl
-
-end NatTrans
-
-end CategoryTheory

--- a/Mathlib/CategoryTheory/Products/Bifunctor.lean
+++ b/Mathlib/CategoryTheory/Products/Bifunctor.lean
@@ -98,3 +98,5 @@ lemma comp_app₃ {H G K : C ⥤ D ⥤ E ⥤ F} (α : H ⟶ G) (β : G ⟶ K) (X
     (Z : E) : (α ≫ β).app₃ X Y Z = α.app₃ X Y Z ≫ β.app₃ X Y Z := rfl
 
 end NatTrans
+
+end CategoryTheory

--- a/Mathlib/CategoryTheory/Products/Bifunctor.lean
+++ b/Mathlib/CategoryTheory/Products/Bifunctor.lean
@@ -11,9 +11,10 @@ import Mathlib.CategoryTheory.Products.Basic
 
 open CategoryTheory Opposite
 
-universe v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
-variable {C : Type u₁} {D : Type u₂} {E : Type u₃} {F : Type u₄}
-variable [Category.{v₁} C] [Category.{v₂} D] [Category.{v₃} E] [Category.{v₄} F]
+universe v₁ v₂ v₃ u₁ u₂ u₃
+
+variable {C : Type u₁} {D : Type u₂} {E : Type u₃}
+variable [Category.{v₁} C] [Category.{v₂} D] [Category.{v₃} E]
 
 namespace CategoryTheory.Bifunctor
 

--- a/Mathlib/CategoryTheory/Products/Bifunctor.lean
+++ b/Mathlib/CategoryTheory/Products/Bifunctor.lean
@@ -10,7 +10,7 @@ import Mathlib.CategoryTheory.Products.Basic
 -/
 
 
-open CategoryTheory
+open CategoryTheory Opposite
 
 namespace CategoryTheory.Bifunctor
 
@@ -45,5 +45,15 @@ theorem diagonal (F : C × D ⥤ E) (X X' : C) (f : X ⟶ X') (Y Y' : D) (g : Y 
 theorem diagonal' (F : C × D ⥤ E) (X X' : C) (f : X ⟶ X') (Y Y' : D) (g : Y ⟶ Y') :
     F.map (f ×ₘ 𝟙 Y) ≫ F.map (𝟙 X' ×ₘ g) = F.map (f ×ₘ g) := by
   rw [← Functor.map_comp, prod_comp, Category.id_comp, Category.comp_id]
+
+/-- Opposite of a bifunctor -/
+@[simps!]
+def biop (F : C × D ⥤ E) : Cᵒᵖ × Dᵒᵖ ⥤ Eᵒᵖ :=
+  (prodOpEquiv C).inverse ⋙ F.op
+
+/-- Flipping of arguments of a bifunctor -/
+@[simps!]
+def flip (F : C × D ⥤ E) : D × C ⥤ E :=
+  Prod.swap D C ⋙ F
 
 end CategoryTheory.Bifunctor

--- a/Mathlib/CategoryTheory/Products/Bifunctor.lean
+++ b/Mathlib/CategoryTheory/Products/Bifunctor.lean
@@ -12,12 +12,11 @@ import Mathlib.CategoryTheory.Products.Basic
 
 open CategoryTheory Opposite
 
+universe v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
+variable {C : Type u₁} {D : Type u₂} {E : Type u₃} {F : Type u₄}
+variable [Category.{v₁} C] [Category.{v₂} D] [Category.{v₃} E] [Category.{v₄} F]
+
 namespace CategoryTheory.Bifunctor
-
-universe v₁ v₂ v₃ u₁ u₂ u₃
-
-variable {C : Type u₁} {D : Type u₂} {E : Type u₃}
-variable [Category.{v₁} C] [Category.{v₂} D] [Category.{v₃} E]
 
 open scoped Prod
 
@@ -57,3 +56,45 @@ def flip (F : C × D ⥤ E) : D × C ⥤ E :=
   Prod.swap D C ⋙ F
 
 end CategoryTheory.Bifunctor
+
+namespace CategoryTheory.Functor
+
+/-- Opposite of a bifunctor. -/
+@[simps!]
+def biop (F : Cᵒᵖ ⥤ D ⥤ E) : C ⥤ Dᵒᵖ ⥤ Eᵒᵖ := F.rightOp ⋙ Functor.opHom _ _
+
+end CategoryTheory.Functor
+
+namespace CategoryTheory
+
+variable {C₁ C₂ : C} {D₁ D₂ : D} {E₁ E₂ : E}
+
+/-- Action of two-variable functors on objects. -/
+abbrev Functor.obj₂ (H : C ⥤ D ⥤ E) (A : C) (B : D) : E := (H.obj A).obj B
+
+/-- Action of three-variable functors on objects. -/
+abbrev Functor.obj₃ (H : C ⥤ D ⥤ E ⥤ F) (A : C) (B : D) (C : E) : F :=
+  ((H.obj A).obj B).obj C
+
+/-- Apply a natural transformation between bifunctors to two objects. -/
+abbrev NatTrans.app₂ {F G : C ⥤ D ⥤ E} (α : NatTrans F G) (X : C) (Y : D) :
+    F.obj₂ X Y ⟶ G.obj₂ X Y :=
+  (α.app X).app Y
+
+/-- Apply a natural transformation between bifunctors in three variables to three objects. -/
+abbrev NatTrans.app₃ {H G : C ⥤ D ⥤ E ⥤ F} (α : NatTrans H G) (X : C) (Y : D) (Z : E) :
+    H.obj₃ X Y Z ⟶ G.obj₃ X Y Z :=
+  ((α.app X).app Y).app Z
+
+/- Natural transformations between functors with many variables. -/
+namespace NatTrans
+
+@[reassoc, simp]
+lemma comp_app₂ {H G K : C ⥤ D ⥤ E} (α : H ⟶ G) (β : G ⟶ K) (X : C) (Y : D) :
+    (α ≫ β).app₂ X Y = α.app₂ X Y ≫ β.app₂ X Y := rfl
+
+@[reassoc, simp]
+lemma comp_app₃ {H G K : C ⥤ D ⥤ E ⥤ F} (α : H ⟶ G) (β : G ⟶ K) (X : C) (Y : D)
+    (Z : E) : (α ≫ β).app₃ X Y Z = α.app₃ X Y Z ≫ β.app₃ X Y Z := rfl
+
+end NatTrans


### PR DESCRIPTION
This work is a slight refactor of https://github.com/leanprover-community/mathlib4/pull/8118, with permission by @iwilare.
I reverted back to using uncurried functors, using the newly introduced [api for products](https://github.com/leanprover-community/mathlib4/pull/26206). My reasons for this are: 1) that is the most common approach on the literature and 2) the api will be closer to the apis for dinatural in enriched categories, where there may be no currying available. 

I did very little, credits go to the other two authors.

Co-authored-by: [Andrea Laretto](https://github.com/iwilare) [iwilare@gmail.com](mailto:iwilare@gmail.com)
Co-authored-by:  [Brendan Seamas Murphy](https://github.com/Shamrock-Frost) [bsmurphy@math.utah.edu](mailto:bsmurphy@math.utah.edu)

I made a new PR since I couldn't figure out how to commit into the already existing PR, not sure if I'm following best practices for this.