### PR TITLE
[Merged by Bors] - feat: more lemmas on lattices within intervals

### DIFF
--- a/Mathlib/Order/LatticeIntervals.lean
+++ b/Mathlib/Order/LatticeIntervals.lean
@@ -35,9 +35,20 @@ namespace Ico
 instance semilatticeInf [SemilatticeInf α] {a b : α} : SemilatticeInf (Ico a b) :=
   Subtype.semilatticeInf fun _ _ hx hy => ⟨le_inf hx.1 hy.1, lt_of_le_of_lt inf_le_left hx.2⟩
 
+@[simp, norm_cast]
+protected lemma coe_inf [SemilatticeInf α] {a b : α} {x y : Ico a b} :
+    (↑(x ⊓ y) : α) = (x : α) ⊓ (y : α) :=
+  rfl
 /-- `Ico a b` has a bottom element whenever `a < b`. -/
-protected abbrev orderBot [PartialOrder α] {a b : α} (h : a < b) : OrderBot (Ico a b) :=
-  (isLeast_Ico h).orderBot
+instance orderBot [PartialOrder α] {a b : α} [Fact (a < b)] : OrderBot (Ico a b) :=
+  (isLeast_Ico Fact.out).orderBot
+
+@[simp, norm_cast]
+protected lemma coe_bot [PartialOrder α] {a b : α} [Fact (a < b)] : ↑(⊥ : Ico a b) = a := rfl
+
+protected lemma disjoint_iff [SemilatticeInf α] {a b : α} [Fact (a < b)] {x y : Ico a b} :
+    Disjoint x y ↔ (x : α) ⊓ (y : α) = a := by
+  simp [_root_.disjoint_iff, Subtype.ext_iff]
 
 end Ico
 
@@ -46,6 +57,11 @@ namespace Iio
 instance semilatticeInf [SemilatticeInf α] {a : α} : SemilatticeInf (Iio a) :=
   Subtype.semilatticeInf fun _ _ hx _ => lt_of_le_of_lt inf_le_left hx
 
+@[simp, norm_cast]
+protected lemma coe_inf [SemilatticeInf α] {a : α} {x y : Iio a} :
+    (↑(x ⊓ y) : α) = (x : α) ⊓ (y : α) :=
+  rfl
+
 end Iio
 
 namespace Ioc
@@ -53,9 +69,21 @@ namespace Ioc
 instance semilatticeSup [SemilatticeSup α] {a b : α} : SemilatticeSup (Ioc a b) :=
   Subtype.semilatticeSup fun _ _ hx hy => ⟨lt_of_lt_of_le hx.1 le_sup_left, sup_le hx.2 hy.2⟩
 
+@[simp, norm_cast]
+protected lemma coe_sup [SemilatticeSup α] {a b : α} {x y : Ioc a b} :
+    (↑(x ⊔ y) : α) = (x : α) ⊔ (y : α) :=
+  rfl
+
 /-- `Ioc a b` has a top element whenever `a < b`. -/
-protected abbrev orderTop [PartialOrder α] {a b : α} (h : a < b) : OrderTop (Ioc a b) :=
-  (isGreatest_Ioc h).orderTop
+instance orderTop [PartialOrder α] {a b : α} [Fact (a < b)] : OrderTop (Ioc a b) :=
+  (isGreatest_Ioc Fact.out).orderTop
+
+@[simp, norm_cast]
+protected lemma coe_top [PartialOrder α] {a b : α} [Fact (a < b)] : ↑(⊤ : Ioc a b) = b := rfl
+
+protected lemma codisjoint_iff [SemilatticeSup α] {a b : α} [Fact (a < b)] {x y : Ioc a b} :
+    Codisjoint x y ↔ (x : α) ⊔ (y : α) = b := by
+  simp [_root_.codisjoint_iff, Subtype.ext_iff]
 
 end Ioc
 
@@ -63,6 +91,11 @@ namespace Ioi
 
 instance semilatticeSup [SemilatticeSup α] {a : α} : SemilatticeSup (Ioi a) :=
   Subtype.semilatticeSup fun _ _ hx _ => lt_of_lt_of_le hx le_sup_left
+
+@[simp, norm_cast]
+protected lemma coe_sup [SemilatticeSup α] {a : α} {x y : Ioi a} :
+    (↑(x ⊔ y) : α) = (x : α) ⊔ (y : α) :=
+  rfl
 
 end Ioi
 
@@ -128,13 +161,8 @@ protected lemma isCompl_iff [Lattice α] [OrderBot α] {x y : Iic a} :
 
 protected lemma complementedLattice_iff [Lattice α] [OrderBot α] :
     ComplementedLattice (Iic a) ↔ ∀ b, b ≤ a → ∃ c ≤ a, b ⊓ c = ⊥ ∧ b ⊔ c = a := by
-  refine ⟨fun h b hb ↦ ?_, fun h ↦ ⟨fun ⟨x, hx⟩ ↦ ?_⟩⟩
-  · obtain ⟨⟨c, hc₁⟩, hc⟩ := exists_isCompl (⟨b, hb⟩ : Iic a)
-    obtain ⟨hc₂, hc₃⟩ := Set.Iic.isCompl_iff.mp hc
-    exact ⟨c, hc₁, disjoint_iff.mp hc₂, hc₃⟩
-  · simp_rw [Set.Iic.isCompl_iff]
-    obtain ⟨c, hc₁, hc₂, hc₃⟩ := h x hx
-    exact ⟨⟨c, hc₁⟩, disjoint_iff.mpr hc₂, hc₃⟩
+  simp_rw [complementedLattice_iff, Iic.isCompl_iff, Subtype.forall, Subtype.exists, disjoint_iff,
+    exists_prop, Set.mem_Iic]
 
 end Iic
 
@@ -143,8 +171,18 @@ namespace Ici
 instance semilatticeInf [SemilatticeInf α] {a : α} : SemilatticeInf (Ici a) :=
   Subtype.semilatticeInf fun _ _ hx hy => le_inf hx hy
 
+@[simp, norm_cast]
+protected lemma coe_inf [SemilatticeInf α] {a : α} {x y : Ici a} :
+    (↑(x ⊓ y) : α) = (x : α) ⊓ (y : α) :=
+  rfl
+
 instance semilatticeSup [SemilatticeSup α] {a : α} : SemilatticeSup (Ici a) :=
   Subtype.semilatticeSup fun _ _ hx _ => le_trans hx le_sup_left
+
+@[simp, norm_cast]
+protected lemma coe_sup [SemilatticeSup α] {a : α} {x y : Ici a} :
+    (↑(x ⊔ y) : α) = (x : α) ⊔ (y : α) :=
+  rfl
 
 instance lattice [Lattice α] {a : α} : Lattice (Ici a) :=
   { Ici.semilatticeInf, Ici.semilatticeSup with }
@@ -173,6 +211,19 @@ theorem coe_top [Preorder α] [OrderTop α] {a : α} : ↑(⊤ : Ici a) = (⊤ :
 instance boundedOrder [Preorder α] [OrderTop α] {a : α} : BoundedOrder (Ici a) :=
   { Ici.orderTop, Ici.orderBot with }
 
+
+protected lemma disjoint_iff [SemilatticeInf α] {a : α} {x y : Ici a} :
+    Disjoint x y ↔ ↑x ⊓ ↑y = a := by
+  simp [_root_.disjoint_iff, Subtype.ext_iff]
+
+protected lemma codisjoint_iff [SemilatticeSup α] [OrderTop α] {a : α} {x y : Ici a} :
+    Codisjoint x y ↔ Codisjoint (x : α) (y : α) := by
+  simp [_root_.codisjoint_iff, Subtype.ext_iff]
+
+protected lemma isCompl_iff [Lattice α] [OrderTop α] {a : α} {x y : Ici a} :
+    IsCompl x y ↔ (x : α) ⊓ (y : α) = a ∧ Codisjoint (x : α) (y : α) := by
+  rw [_root_.isCompl_iff, Ici.disjoint_iff, Ici.codisjoint_iff]
+
 end Ici
 
 namespace Icc
@@ -182,30 +233,50 @@ variable {a b : α}
 instance semilatticeInf [SemilatticeInf α] : SemilatticeInf (Icc a b) :=
   Subtype.semilatticeInf fun _ _ hx hy => ⟨le_inf hx.1 hy.1, le_trans inf_le_left hx.2⟩
 
+@[simp, norm_cast]
+protected lemma coe_inf [SemilatticeInf α] {x y : Icc a b} :
+    (↑(x ⊓ y) : α) = (x : α) ⊓ (y : α) :=
+  rfl
+
 instance semilatticeSup [SemilatticeSup α] : SemilatticeSup (Icc a b) :=
   Subtype.semilatticeSup fun _ _ hx hy => ⟨le_trans hx.1 le_sup_left, sup_le hx.2 hy.2⟩
+
+@[simp, norm_cast]
+protected lemma coe_sup [SemilatticeSup α] {x y : Icc a b} :
+    (↑(x ⊔ y) : α) = (x : α) ⊔ (y : α) :=
+  rfl
 
 instance lattice [Lattice α] : Lattice (Icc a b) :=
   { Icc.semilatticeInf, Icc.semilatticeSup with }
 
-variable [Preorder α] [Fact (a ≤ b)]
-
 /-- `Icc a b` has a bottom element whenever `a ≤ b`. -/
-instance : OrderBot (Icc a b) :=
+instance [Preorder α] [Fact (a ≤ b)] : OrderBot (Icc a b) :=
   (isLeast_Icc Fact.out).orderBot
 
 @[simp, norm_cast]
-theorem coe_bot : ↑(⊥ : Icc a b) = a := rfl
+theorem coe_bot [Preorder α] [Fact (a ≤ b)] : ↑(⊥ : Icc a b) = a := rfl
 
 /-- `Icc a b` has a top element whenever `a ≤ b`. -/
-instance : OrderTop (Icc a b) :=
+instance [Preorder α] [Fact (a ≤ b)] : OrderTop (Icc a b) :=
   (isGreatest_Icc Fact.out).orderTop
 
 @[simp, norm_cast]
-theorem coe_top : ↑(⊤ : Icc a b) = b := rfl
+theorem coe_top [Preorder α] [Fact (a ≤ b)] : ↑(⊤ : Icc a b) = b := rfl
 
 /-- `Icc a b` is a `BoundedOrder` whenever `a ≤ b`. -/
-instance : BoundedOrder (Icc a b) where
+instance [Preorder α] [Fact (a ≤ b)] : BoundedOrder (Icc a b) where
+
+protected lemma disjoint_iff [SemilatticeInf α] [Fact (a ≤ b)] {x y : Icc a b} :
+    Disjoint x y ↔ ↑x ⊓ ↑y = a := by
+  simp [_root_.disjoint_iff, Subtype.ext_iff]
+
+protected lemma codisjoint_iff [SemilatticeSup α] [Fact (a ≤ b)] {x y : Icc a b} :
+    Codisjoint x y ↔ ↑x ⊔ (y : α) = b := by
+  simp [_root_.codisjoint_iff, Subtype.ext_iff]
+
+protected lemma isCompl_iff [Lattice α] [Fact (a ≤ b)] {x y : Icc a b} :
+    IsCompl x y ↔ (x : α) ⊓ (y : α) = a ∧ (x : α) ⊔ (y : α) = b := by
+  rw [_root_.isCompl_iff, Icc.disjoint_iff, Icc.codisjoint_iff]
 
 end Icc
 

--- a/Mathlib/Order/LatticeIntervals.lean
+++ b/Mathlib/Order/LatticeIntervals.lean
@@ -45,7 +45,7 @@ instance orderBot [PartialOrder α] {a b : α} [Fact (a < b)] : OrderBot (Ico a 
   (isLeast_Ico Fact.out).orderBot
 
 @[simp, norm_cast]
-protected lemma coe_bot [PartialOrder α] {a b : α} [Fact (a < b)] : ↑(⊥ : Ico a b) = a := rfl
+protected lemma coe_bot [PartialOrder α] (a b : α) [Fact (a < b)] : ↑(⊥ : Ico a b) = a := rfl
 
 protected lemma disjoint_iff [SemilatticeInf α] {a b : α} [Fact (a < b)] {x y : Ico a b} :
     Disjoint x y ↔ ↑x ⊓ ↑y = a := by
@@ -80,7 +80,7 @@ instance orderTop [PartialOrder α] {a b : α} [Fact (a < b)] : OrderTop (Ioc a 
   (isGreatest_Ioc Fact.out).orderTop
 
 @[simp, norm_cast]
-protected lemma coe_top [PartialOrder α] {a b : α} [Fact (a < b)] : ↑(⊤ : Ioc a b) = b := rfl
+protected lemma coe_top [PartialOrder α] (a b : α) [Fact (a < b)] : ↑(⊤ : Ioc a b) = b := rfl
 
 protected lemma codisjoint_iff [SemilatticeSup α] {a b : α} [Fact (a < b)] {x y : Ioc a b} :
     Codisjoint x y ↔ ↑x ⊔ ↑y = b := by
@@ -128,9 +128,8 @@ instance orderTop [Preorder α] :
   top := ⟨a, le_refl a⟩
   le_top x := x.prop
 
-@[simp]
-theorem coe_top [Preorder α] : (⊤ : Iic a) = a :=
-  rfl
+@[simp, norm_cast]
+protected lemma coe_top [Preorder α] (a : α) : (⊤ : Iic a) = a := rfl
 
 protected lemma eq_top_iff [Preorder α] {x : Iic a} :
     x = ⊤ ↔ (x : α) = a := by
@@ -141,9 +140,8 @@ instance orderBot [Preorder α] [OrderBot α] :
   bot := ⟨⊥, bot_le⟩
   bot_le := fun ⟨_, _⟩ => Subtype.mk_le_mk.2 bot_le
 
-@[simp]
-theorem coe_bot [Preorder α] [OrderBot α] : (⊥ : Iic a) = (⊥ : α) :=
-  rfl
+@[simp, norm_cast]
+protected lemma coe_bot [Preorder α] [OrderBot α] (a : α) : (⊥ : Iic a) = (⊥ : α) := rfl
 
 instance [Preorder α] [OrderBot α] : BoundedOrder (Iic a) :=
   { Iic.orderTop, Iic.orderBot with }
@@ -196,18 +194,16 @@ instance orderBot [Preorder α] {a : α} :
   bot := ⟨a, le_refl a⟩
   bot_le x := x.prop
 
-@[simp]
-theorem coe_bot [Preorder α] {a : α} : ↑(⊥ : Ici a) = a :=
-  rfl
+@[simp, norm_cast]
+protected lemma coe_bot [Preorder α] (a : α) : ↑(⊥ : Ici a) = a := rfl
 
 instance orderTop [Preorder α] [OrderTop α] {a : α} :
     OrderTop (Ici a) where
   top := ⟨⊤, le_top⟩
   le_top := fun ⟨_, _⟩ => Subtype.mk_le_mk.2 le_top
 
-@[simp]
-theorem coe_top [Preorder α] [OrderTop α] {a : α} : ↑(⊤ : Ici a) = (⊤ : α) :=
-  rfl
+@[simp, norm_cast]
+protected lemma coe_top [Preorder α] [OrderTop α] (a : α) : ↑(⊤ : Ici a) = (⊤ : α) := rfl
 
 instance boundedOrder [Preorder α] [OrderTop α] {a : α} : BoundedOrder (Ici a) :=
   { Ici.orderTop, Ici.orderBot with }
@@ -254,14 +250,14 @@ instance [Preorder α] [Fact (a ≤ b)] : OrderBot (Icc a b) :=
   (isLeast_Icc Fact.out).orderBot
 
 @[simp, norm_cast]
-theorem coe_bot [Preorder α] [Fact (a ≤ b)] : ↑(⊥ : Icc a b) = a := rfl
+protected lemma coe_bot [Preorder α] (a b : α) [Fact (a ≤ b)] : ↑(⊥ : Icc a b) = a := rfl
 
 /-- `Icc a b` has a top element whenever `a ≤ b`. -/
 instance [Preorder α] [Fact (a ≤ b)] : OrderTop (Icc a b) :=
   (isGreatest_Icc Fact.out).orderTop
 
 @[simp, norm_cast]
-theorem coe_top [Preorder α] [Fact (a ≤ b)] : ↑(⊤ : Icc a b) = b := rfl
+protected lemma coe_top [Preorder α] (a b : α) [Fact (a ≤ b)] : ↑(⊤ : Icc a b) = b := rfl
 
 /-- `Icc a b` is a `BoundedOrder` whenever `a ≤ b`. -/
 instance [Preorder α] [Fact (a ≤ b)] : BoundedOrder (Icc a b) where

--- a/Mathlib/Order/LatticeIntervals.lean
+++ b/Mathlib/Order/LatticeIntervals.lean
@@ -37,8 +37,9 @@ instance semilatticeInf [SemilatticeInf α] {a b : α} : SemilatticeInf (Ico a b
 
 @[simp, norm_cast]
 protected lemma coe_inf [SemilatticeInf α] {a b : α} {x y : Ico a b} :
-    (↑(x ⊓ y) : α) = (x : α) ⊓ (y : α) :=
+    ↑(x ⊓ y) = (↑x ⊓ ↑y : α) :=
   rfl
+
 /-- `Ico a b` has a bottom element whenever `a < b`. -/
 instance orderBot [PartialOrder α] {a b : α} [Fact (a < b)] : OrderBot (Ico a b) :=
   (isLeast_Ico Fact.out).orderBot
@@ -47,7 +48,7 @@ instance orderBot [PartialOrder α] {a b : α} [Fact (a < b)] : OrderBot (Ico a 
 protected lemma coe_bot [PartialOrder α] {a b : α} [Fact (a < b)] : ↑(⊥ : Ico a b) = a := rfl
 
 protected lemma disjoint_iff [SemilatticeInf α] {a b : α} [Fact (a < b)] {x y : Ico a b} :
-    Disjoint x y ↔ (x : α) ⊓ (y : α) = a := by
+    Disjoint x y ↔ ↑x ⊓ ↑y = a := by
   simp [_root_.disjoint_iff, Subtype.ext_iff]
 
 end Ico
@@ -59,7 +60,7 @@ instance semilatticeInf [SemilatticeInf α] {a : α} : SemilatticeInf (Iio a) :=
 
 @[simp, norm_cast]
 protected lemma coe_inf [SemilatticeInf α] {a : α} {x y : Iio a} :
-    (↑(x ⊓ y) : α) = (x : α) ⊓ (y : α) :=
+    ↑(x ⊓ y) = (↑x ⊓ ↑y : α) :=
   rfl
 
 end Iio
@@ -71,7 +72,7 @@ instance semilatticeSup [SemilatticeSup α] {a b : α} : SemilatticeSup (Ioc a b
 
 @[simp, norm_cast]
 protected lemma coe_sup [SemilatticeSup α] {a b : α} {x y : Ioc a b} :
-    (↑(x ⊔ y) : α) = (x : α) ⊔ (y : α) :=
+    ↑(x ⊔ y) = (↑x ⊔ ↑y : α) :=
   rfl
 
 /-- `Ioc a b` has a top element whenever `a < b`. -/
@@ -82,7 +83,7 @@ instance orderTop [PartialOrder α] {a b : α} [Fact (a < b)] : OrderTop (Ioc a 
 protected lemma coe_top [PartialOrder α] {a b : α} [Fact (a < b)] : ↑(⊤ : Ioc a b) = b := rfl
 
 protected lemma codisjoint_iff [SemilatticeSup α] {a b : α} [Fact (a < b)] {x y : Ioc a b} :
-    Codisjoint x y ↔ (x : α) ⊔ (y : α) = b := by
+    Codisjoint x y ↔ ↑x ⊔ ↑y = b := by
   simp [_root_.codisjoint_iff, Subtype.ext_iff]
 
 end Ioc
@@ -94,7 +95,7 @@ instance semilatticeSup [SemilatticeSup α] {a : α} : SemilatticeSup (Ioi a) :=
 
 @[simp, norm_cast]
 protected lemma coe_sup [SemilatticeSup α] {a : α} {x y : Ioi a} :
-    (↑(x ⊔ y) : α) = (x : α) ⊔ (y : α) :=
+    ↑(x ⊔ y) = (↑x ⊔ ↑y : α) :=
   rfl
 
 end Ioi
@@ -108,7 +109,7 @@ instance semilatticeInf [SemilatticeInf α] : SemilatticeInf (Iic a) :=
 
 @[simp, norm_cast]
 protected lemma coe_inf [SemilatticeInf α] {x y : Iic a} :
-    (↑(x ⊓ y) : α) = (x : α) ⊓ (y : α) :=
+    ↑(x ⊓ y) = (↑x ⊓ ↑y : α) :=
   rfl
 
 instance semilatticeSup [SemilatticeSup α] : SemilatticeSup (Iic a) :=
@@ -116,7 +117,7 @@ instance semilatticeSup [SemilatticeSup α] : SemilatticeSup (Iic a) :=
 
 @[simp, norm_cast]
 protected lemma coe_sup [SemilatticeSup α] {x y : Iic a} :
-    (↑(x ⊔ y) : α) = (x : α) ⊔ (y : α) :=
+    ↑(x ⊔ y) = (↑x ⊔ ↑y : α) :=
   rfl
 
 instance [Lattice α] : Lattice (Iic a) :=
@@ -152,11 +153,11 @@ protected lemma disjoint_iff [SemilatticeInf α] [OrderBot α] {x y : Iic a} :
   simp [_root_.disjoint_iff, Subtype.ext_iff]
 
 protected lemma codisjoint_iff [SemilatticeSup α] {x y : Iic a} :
-    Codisjoint x y ↔ (x : α) ⊔ (y : α) = a := by
+    Codisjoint x y ↔ ↑x ⊔ ↑y = a := by
   simpa only [_root_.codisjoint_iff] using Iic.eq_top_iff
 
 protected lemma isCompl_iff [Lattice α] [OrderBot α] {x y : Iic a} :
-    IsCompl x y ↔ Disjoint (x : α) (y : α) ∧ (x : α) ⊔ (y : α) = a := by
+    IsCompl x y ↔ Disjoint (x : α) (y : α) ∧ ↑x ⊔ ↑y = a := by
   rw [_root_.isCompl_iff, Iic.disjoint_iff, Iic.codisjoint_iff]
 
 protected lemma complementedLattice_iff [Lattice α] [OrderBot α] :
@@ -173,7 +174,7 @@ instance semilatticeInf [SemilatticeInf α] {a : α} : SemilatticeInf (Ici a) :=
 
 @[simp, norm_cast]
 protected lemma coe_inf [SemilatticeInf α] {a : α} {x y : Ici a} :
-    (↑(x ⊓ y) : α) = (x : α) ⊓ (y : α) :=
+    ↑(x ⊓ y) = (↑x ⊓ ↑y : α) :=
   rfl
 
 instance semilatticeSup [SemilatticeSup α] {a : α} : SemilatticeSup (Ici a) :=
@@ -181,7 +182,7 @@ instance semilatticeSup [SemilatticeSup α] {a : α} : SemilatticeSup (Ici a) :=
 
 @[simp, norm_cast]
 protected lemma coe_sup [SemilatticeSup α] {a : α} {x y : Ici a} :
-    (↑(x ⊔ y) : α) = (x : α) ⊔ (y : α) :=
+    ↑(x ⊔ y) = (↑x ⊔ ↑y : α) :=
   rfl
 
 instance lattice [Lattice α] {a : α} : Lattice (Ici a) :=
@@ -211,7 +212,6 @@ theorem coe_top [Preorder α] [OrderTop α] {a : α} : ↑(⊤ : Ici a) = (⊤ :
 instance boundedOrder [Preorder α] [OrderTop α] {a : α} : BoundedOrder (Ici a) :=
   { Ici.orderTop, Ici.orderBot with }
 
-
 protected lemma disjoint_iff [SemilatticeInf α] {a : α} {x y : Ici a} :
     Disjoint x y ↔ ↑x ⊓ ↑y = a := by
   simp [_root_.disjoint_iff, Subtype.ext_iff]
@@ -221,7 +221,7 @@ protected lemma codisjoint_iff [SemilatticeSup α] [OrderTop α] {a : α} {x y :
   simp [_root_.codisjoint_iff, Subtype.ext_iff]
 
 protected lemma isCompl_iff [Lattice α] [OrderTop α] {a : α} {x y : Ici a} :
-    IsCompl x y ↔ (x : α) ⊓ (y : α) = a ∧ Codisjoint (x : α) (y : α) := by
+    IsCompl x y ↔ ↑x ⊓ ↑y = a ∧ Codisjoint (x : α) (y : α) := by
   rw [_root_.isCompl_iff, Ici.disjoint_iff, Ici.codisjoint_iff]
 
 end Ici
@@ -235,7 +235,7 @@ instance semilatticeInf [SemilatticeInf α] : SemilatticeInf (Icc a b) :=
 
 @[simp, norm_cast]
 protected lemma coe_inf [SemilatticeInf α] {x y : Icc a b} :
-    (↑(x ⊓ y) : α) = (x : α) ⊓ (y : α) :=
+    ↑(x ⊓ y) = (↑x ⊓ ↑y : α) :=
   rfl
 
 instance semilatticeSup [SemilatticeSup α] : SemilatticeSup (Icc a b) :=
@@ -243,7 +243,7 @@ instance semilatticeSup [SemilatticeSup α] : SemilatticeSup (Icc a b) :=
 
 @[simp, norm_cast]
 protected lemma coe_sup [SemilatticeSup α] {x y : Icc a b} :
-    (↑(x ⊔ y) : α) = (x : α) ⊔ (y : α) :=
+    ↑(x ⊔ y) = (↑x ⊔ ↑y : α) :=
   rfl
 
 instance lattice [Lattice α] : Lattice (Icc a b) :=
@@ -275,7 +275,7 @@ protected lemma codisjoint_iff [SemilatticeSup α] [Fact (a ≤ b)] {x y : Icc a
   simp [_root_.codisjoint_iff, Subtype.ext_iff]
 
 protected lemma isCompl_iff [Lattice α] [Fact (a ≤ b)] {x y : Icc a b} :
-    IsCompl x y ↔ (x : α) ⊓ (y : α) = a ∧ (x : α) ⊔ (y : α) = b := by
+    IsCompl x y ↔ ↑x ⊓ ↑y = a ∧ ↑x ⊔ ↑y = b := by
   rw [_root_.isCompl_iff, Icc.disjoint_iff, Icc.codisjoint_iff]
 
 end Icc


### PR DESCRIPTION
We had these already for `Icc`, this adds them for the other intervals.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
