### PR TITLE
[Merged by Bors] - chore(Algebra.Order.Group.Cyclic): generalize Subgroup.genLTOne

### DIFF
--- a/Mathlib/Algebra/Order/Group/Cyclic.lean
+++ b/Mathlib/Algebra/Order/Group/Cyclic.lean
@@ -8,7 +8,8 @@ import Mathlib.GroupTheory.SpecificGroups.Cyclic
 /-!
 # Cyclic linearly ordered groups
 
-This file contains basic results about cyclic linearly ordered groups and their subgroups.
+This file contains basic results about cyclic linearly ordered groups and cyclic subgroups of
+linearly ordered groups.
 
 The definitions `LinearOrderedCommGroup.Subgroup.genLTOne` (*resp.*
 `LinearOrderedCommGroup.genLTOone`) yields a generator of a non-trivial subgroup of a linearly
@@ -22,14 +23,15 @@ namespace LinearOrderedCommGroup
 
 open LinearOrderedCommGroup
 
-variable {G : Type*} [CommGroup G] [LinearOrder G] [IsOrderedMonoid G] [IsCyclic G]
+variable {G : Type*} [CommGroup G] [LinearOrder G] [IsOrderedMonoid G]
+
 namespace Subgroup
 
-variable (H : Subgroup G) [Nontrivial H]
+variable (H : Subgroup G) [Nontrivial H] [hH : IsCyclic H]
 
 @[to_additive exists_neg_generator]
 lemma exists_generator_lt_one : ∃ (a : G), a < 1 ∧ Subgroup.zpowers a = H := by
-  obtain ⟨a, ha⟩ := H.isCyclic_iff_exists_zpowers_eq_top.mp H.isCyclic
+  obtain ⟨a, ha⟩ := H.isCyclic_iff_exists_zpowers_eq_top.mp hH
   obtain ha1 | rfl | ha1 := lt_trichotomy a 1
   · exact ⟨a, ha1, ha⟩
   · rw [Subgroup.zpowers_one_eq_bot] at ha
@@ -44,16 +46,18 @@ commutative group, this is a negative generator of the subgroup."]
 protected noncomputable def genLTOne : G := H.exists_generator_lt_one.choose
 
 @[to_additive negGen_neg]
-lemma genLTOne_lt_one (H : Subgroup G) [Nontrivial H] : H.genLTOne < 1 :=
+lemma genLTOne_lt_one : H.genLTOne < 1 :=
   H.exists_generator_lt_one.choose_spec.1
 
 @[to_additive (attr := simp) negGen_zmultiples_eq_top]
-lemma genLTOne_zpowers_eq_top (H : Subgroup G) [Nontrivial H] : Subgroup.zpowers H.genLTOne = H :=
+lemma genLTOne_zpowers_eq_top : Subgroup.zpowers H.genLTOne = H :=
   H.exists_generator_lt_one.choose_spec.2
 
 end Subgroup
 
-variable (G) [Nontrivial G]
+section IsCyclic
+
+variable (G) [Nontrivial G] [IsCyclic G]
 
 /-- Given a cyclic linearly ordered commutative group, this is a generator that is `< 1`. -/
 @[to_additive negGen "Given an additive cyclic linearly ordered commutative group, this is a
@@ -62,5 +66,7 @@ noncomputable def genLTOne : G := (⊤ : Subgroup G).genLTOne
 
 @[to_additive (attr := simp) negGen_eq_of_top]
 lemma genLTOne_eq_of_top : genLTOne G = (⊤ : Subgroup G).genLTOne := rfl
+
+end IsCyclic
 
 end LinearOrderedCommGroup


### PR DESCRIPTION
Generalize `Subgroup.genLTOne` so that it assumes that the subgroup itself is cyclic, rather than the ambient group.

Co-authored-by: @faenuccio

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
