### PR TITLE
[Merged by Bors] - chore(CI): reverts #29593

### DIFF
--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -36,9 +36,11 @@ def isRemoteURL (url : String) : Bool :=
 Helper function to get repository from a remote name
 -/
 def getRepoFromRemote (mathlibDepPath : FilePath) (remoteName : String) (errorContext : String) : IO String := do
-  if isRemoteURL remoteName then
-    return remoteName
-  else
+  IO.println s!"Is {remoteName} a remote URL? {isRemoteURL remoteName}"
+  -- Remove the print statement above and uncomment the lines below when confident
+  -- if isRemoteURL remoteName then
+  --   return remoteName
+  -- else
   let out ← IO.Process.output
     {cmd := "git", args := #["remote", "get-url", remoteName], cwd := mathlibDepPath}
   unless out.exitCode == 0 do


### PR DESCRIPTION
This reverts commit #26593 due to complications with the `--repo` flag in CI. CI gets the name of the user cache from the `repoOwner/branch` but `Cache` internally uses `repoOwner/mathlib4` which causes a mismatch.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
