### PR TITLE
[Merged by Bors] - chore(CategoryTheory): rename `whiskerLeft` to `Functor.whiskerLeft`

### DIFF
--- a/Mathlib/Algebra/Category/ContinuousCohomology/Basic.lean
+++ b/Mathlib/Algebra/Category/ContinuousCohomology/Basic.lean
@@ -41,7 +41,7 @@ See `ContinuousCohomology.MultiInd.d`.
 - Show that short exact sequences induces long exact sequences in certain scenarios.
 -/
 
-open CategoryTheory ContinuousMap
+open CategoryTheory Functor ContinuousMap
 
 variable (R G : Type*) [CommRing R] [Group G] [TopologicalSpace R]
 

--- a/Mathlib/Algebra/Category/Grp/LeftExactFunctor.lean
+++ b/Mathlib/Algebra/Category/Grp/LeftExactFunctor.lean
@@ -48,9 +48,10 @@ private noncomputable local instance : BraidedCategory C := .ofCartesianMonoidal
 
 /-- Implementation, see `leftExactFunctorForgetEquivalence`. -/
 noncomputable def inverseAux : (C ⥤ₗ Type v) ⥤ C ⥤ AddCommGrp.{v} :=
-  Functor.mapCommGrpFunctor ⋙ (whiskeringLeft _ _ _).obj Preadditive.commGrpEquivalence.functor ⋙
-    (whiskeringRight _ _ _).obj
-      (commGrpTypeEquivalenceCommGrp.functor ⋙ commGroupAddCommGroupEquivalence.functor)
+  Functor.mapCommGrpFunctor ⋙
+    (Functor.whiskeringLeft _ _ _).obj Preadditive.commGrpEquivalence.functor ⋙
+      (Functor.whiskeringRight _ _ _).obj
+        (commGrpTypeEquivalenceCommGrp.functor ⋙ commGroupAddCommGroupEquivalence.functor)
 
 instance (F : C ⥤ₗ Type v) : PreservesFiniteLimits (inverseAux.obj F) where
   preservesFiniteLimits J _ _ :=

--- a/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
@@ -930,9 +930,11 @@ lemma extendScalarsComp_hom_app_one_tmul (M : ModuleCat R₁) (m : M) :
 
 @[reassoc]
 lemma extendScalars_assoc :
-    (extendScalarsComp (f₂₃.comp f₁₂) f₃₄).hom ≫ whiskerRight (extendScalarsComp f₁₂ f₂₃).hom _ =
-      (extendScalarsComp f₁₂ (f₃₄.comp f₂₃)).hom ≫ whiskerLeft _ (extendScalarsComp f₂₃ f₃₄).hom ≫
-        (Functor.associator _ _ _).inv := by
+    (extendScalarsComp (f₂₃.comp f₁₂) f₃₄).hom ≫
+      Functor.whiskerRight (extendScalarsComp f₁₂ f₂₃).hom _ =
+        (extendScalarsComp f₁₂ (f₃₄.comp f₂₃)).hom ≫
+          Functor.whiskerLeft _ (extendScalarsComp f₂₃ f₃₄).hom ≫
+            (Functor.associator _ _ _).inv := by
   ext M m
   have h₁ := extendScalarsComp_hom_app_one_tmul (f₂₃.comp f₁₂) f₃₄ M m
   have h₂ := extendScalarsComp_hom_app_one_tmul f₁₂ (f₃₄.comp f₂₃) M m
@@ -947,16 +949,18 @@ lemma extendScalars_assoc :
 that is needed in the definition `CommRingCat.moduleCatExtendScalarsPseudofunctor`
 in the file `Algebra.Category.ModuleCat.Pseudofunctor` -/
 lemma extendScalars_assoc' :
-    (extendScalarsComp (f₂₃.comp f₁₂) f₃₄).hom ≫ whiskerRight (extendScalarsComp f₁₂ f₂₃).hom _ ≫
-      (Functor.associator _ _ _).hom ≫ whiskerLeft _ (extendScalarsComp f₂₃ f₃₄).inv ≫
-        (extendScalarsComp f₁₂ (f₃₄.comp f₂₃)).inv = 𝟙 _ := by
+    (extendScalarsComp (f₂₃.comp f₁₂) f₃₄).hom ≫
+      Functor.whiskerRight (extendScalarsComp f₁₂ f₂₃).hom _ ≫
+        (Functor.associator _ _ _).hom ≫
+          Functor.whiskerLeft _ (extendScalarsComp f₂₃ f₃₄).inv ≫
+            (extendScalarsComp f₁₂ (f₃₄.comp f₂₃)).inv = 𝟙 _ := by
   rw [extendScalars_assoc_assoc]
-  simp only [Iso.inv_hom_id_assoc, ← whiskerLeft_comp_assoc, Iso.hom_inv_id,
-    whiskerLeft_id', Category.id_comp]
+  simp only [Iso.inv_hom_id_assoc, ← Functor.whiskerLeft_comp_assoc, Iso.hom_inv_id,
+    Functor.whiskerLeft_id', Category.id_comp]
 
 @[reassoc]
 lemma extendScalars_id_comp :
-    (extendScalarsComp (RingHom.id R₁) f₁₂).hom ≫ whiskerRight (extendScalarsId R₁).hom _ ≫
+    (extendScalarsComp (RingHom.id R₁) f₁₂).hom ≫ Functor.whiskerRight (extendScalarsId R₁).hom _ ≫
       (Functor.leftUnitor _).hom = 𝟙 _ := by
   ext M m
   dsimp
@@ -967,7 +971,7 @@ lemma extendScalars_id_comp :
 
 @[reassoc]
 lemma extendScalars_comp_id :
-    (extendScalarsComp f₁₂ (RingHom.id R₂)).hom ≫ whiskerLeft _ (extendScalarsId R₂).hom ≫
+    (extendScalarsComp f₁₂ (RingHom.id R₂)).hom ≫ Functor.whiskerLeft _ (extendScalarsId R₂).hom ≫
       (Functor.rightUnitor _).hom = 𝟙 _ := by
   ext M m
   dsimp

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/Colimits.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/Colimits.lean
@@ -63,25 +63,25 @@ taking a colimit in the category of modules over `R.obj X` for all `X`. -/
 @[simps]
 noncomputable def colimitPresheafOfModules : PresheafOfModules R where
   obj X := colimit (F ⋙ evaluation R X)
-  map {_ Y} f := colimMap (whiskerLeft F (restriction R f)) ≫
+  map {_ Y} f := colimMap (Functor.whiskerLeft F (restriction R f)) ≫
     (preservesColimitIso (ModuleCat.restrictScalars (R.map f).hom) (F ⋙ evaluation R Y)).inv
   map_id X := colimit.hom_ext (fun j => by
     dsimp
-    rw [ι_colimMap_assoc, whiskerLeft_app, restriction_app]
+    rw [ι_colimMap_assoc, Functor.whiskerLeft_app, restriction_app]
     -- Here we should rewrite using `Functor.assoc` but that gives a "motive is type-incorrect"
     erw [ι_preservesColimitIso_inv (G := ModuleCat.restrictScalars (R.map (𝟙 X)).hom)]
     rw [ModuleCat.restrictScalarsId'App_inv_naturality, map_id]
     dsimp)
   map_comp {X Y Z} f g := colimit.hom_ext (fun j => by
     dsimp
-    rw [ι_colimMap_assoc, whiskerLeft_app, restriction_app, assoc, ι_colimMap_assoc]
+    rw [ι_colimMap_assoc, Functor.whiskerLeft_app, restriction_app, assoc, ι_colimMap_assoc]
     -- Here we should rewrite using `Functor.assoc` but that gives a "motive is type-incorrect"
     erw [ι_preservesColimitIso_inv (G := ModuleCat.restrictScalars (R.map (f ≫ g)).hom),
       ι_preservesColimitIso_inv_assoc (G := ModuleCat.restrictScalars (R.map f).hom)]
     rw [← Functor.map_comp_assoc, ι_colimMap_assoc]
     erw [ι_preservesColimitIso_inv (G := ModuleCat.restrictScalars (R.map g).hom)]
     rw [map_comp, ModuleCat.restrictScalarsComp'_inv_app, assoc, assoc,
-      whiskerLeft_app, whiskerLeft_app, restriction_app, restriction_app]
+      Functor.whiskerLeft_app, Functor.whiskerLeft_app, restriction_app, restriction_app]
     simp only [Functor.map_comp, assoc]
     rfl)
 

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/Free.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/Free.lean
@@ -78,21 +78,21 @@ noncomputable def freeAdjunctionUnit : F ⟶ (freeObj (R := R) F).presheaf ⋙ f
 /-- The bijection `(freeObj F ⟶ G) ≃ (F ⟶ G.presheaf ⋙ forget _)` when
 `F` is a presheaf of types and `G` a presheaf of modules. -/
 noncomputable def freeHomEquiv : (freeObj F ⟶ G) ≃ (F ⟶ G.presheaf ⋙ forget _) where
-  toFun ψ := freeAdjunctionUnit R F ≫ whiskerRight ((toPresheaf _).map ψ) _
+  toFun ψ := freeAdjunctionUnit R F ≫ Functor.whiskerRight ((toPresheaf _).map ψ) _
   invFun φ := freeObjDesc φ
   left_inv ψ := by ext1 X; dsimp; ext x; simp [toPresheaf]
   right_inv φ := by ext; simp [toPresheaf]
 
 lemma free_hom_ext {ψ ψ' : freeObj F ⟶ G}
-    (h : freeAdjunctionUnit R F ≫ whiskerRight ((toPresheaf _).map ψ) _ =
-      freeAdjunctionUnit R F ≫ whiskerRight ((toPresheaf _).map ψ') _ ) : ψ = ψ' :=
+    (h : freeAdjunctionUnit R F ≫ Functor.whiskerRight ((toPresheaf _).map ψ) _ =
+      freeAdjunctionUnit R F ≫ Functor.whiskerRight ((toPresheaf _).map ψ') _ ) : ψ = ψ' :=
   freeHomEquiv.injective h
 
 variable (R) in
 /-- The free presheaf of modules functor is left adjoint to the forget functor
 `PresheafOfModules.{u} R ⥤ Cᵒᵖ ⥤ Type u`. -/
 noncomputable def freeAdjunction :
-    free.{u} R ⊣ (toPresheaf R ⋙ (whiskeringRight _ _ _).obj (forget Ab)) :=
+    free.{u} R ⊣ (toPresheaf R ⋙ (Functor.whiskeringRight _ _ _).obj (forget Ab)) :=
   Adjunction.mkOfHomEquiv
     { homEquiv := fun _ _ ↦ freeHomEquiv
       homEquiv_naturality_left_symm := fun {F₁ F₂ G} f g ↦

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/Limits.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/Limits.lean
@@ -63,7 +63,7 @@ taking a limit in the category of modules over `R.obj X` for all `X`. -/
 @[simps]
 noncomputable def limitPresheafOfModules : PresheafOfModules R where
   obj X := limit (F ⋙ evaluation R X)
-  map {_ Y} f := limMap (whiskerLeft F (restriction R f)) ≫
+  map {_ Y} f := limMap (Functor.whiskerLeft F (restriction R f)) ≫
     (preservesLimitIso (ModuleCat.restrictScalars (R.map f).hom) (F ⋙ evaluation R Y)).inv
   map_id X := by
     dsimp
@@ -71,7 +71,7 @@ noncomputable def limitPresheafOfModules : PresheafOfModules R where
     apply limit.hom_ext
     intro j
     dsimp
-    simp only [limMap_π, Functor.comp_obj, evaluation_obj, whiskerLeft_app,
+    simp only [limMap_π, Functor.comp_obj, evaluation_obj, Functor.whiskerLeft_app,
       restriction_app, assoc]
     -- Here we should rewrite using `Functor.assoc` but that gives a "motive is type-incorrect"
     erw [preservesLimitIso_hom_π]
@@ -84,7 +84,7 @@ noncomputable def limitPresheafOfModules : PresheafOfModules R where
       comp_id]
     apply limit.hom_ext
     intro j
-    simp only [Functor.comp_obj, evaluation_obj, limMap_π, whiskerLeft_app, restriction_app,
+    simp only [Functor.comp_obj, evaluation_obj, limMap_π, Functor.whiskerLeft_app, restriction_app,
       map_comp, ModuleCat.restrictScalarsComp'_inv_app, Functor.map_comp, assoc]
     -- Here we should rewrite using `Functor.assoc` but that gives a "motive is type-incorrect"
     erw [preservesLimitIso_hom_π]

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/Pushforward.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/Pushforward.lean
@@ -56,7 +56,7 @@ def pushforward₀ (R : Dᵒᵖ ⥤ RingCat.{u}) :
 /-- The pushforward of presheaves of modules commutes with the forgetful functor
 to presheaves of abelian groups. -/
 noncomputable def pushforward₀CompToPresheaf (R : Dᵒᵖ ⥤ RingCat.{u}) :
-    pushforward₀.{v} F R ⋙ toPresheaf _ ≅ toPresheaf _ ⋙ (whiskeringLeft _ _ _).obj F.op :=
+    pushforward₀.{v} F R ⋙ toPresheaf _ ≅ toPresheaf _ ⋙ (Functor.whiskeringLeft _ _ _).obj F.op :=
   Iso.refl _
 
 variable {F}
@@ -72,7 +72,7 @@ noncomputable def pushforward : PresheafOfModules.{v} R ⥤ PresheafOfModules.{v
 /-- The pushforward of presheaves of modules commutes with the forgetful functor
 to presheaves of abelian groups. -/
 noncomputable def pushforwardCompToPresheaf :
-    pushforward.{v} φ ⋙ toPresheaf _ ≅ toPresheaf _ ⋙ (whiskeringLeft _ _ _).obj F.op :=
+    pushforward.{v} φ ⋙ toPresheaf _ ≅ toPresheaf _ ⋙ (Functor.whiskeringLeft _ _ _).obj F.op :=
   Iso.refl _
 
 lemma pushforward_obj_map_apply (M : PresheafOfModules.{v} R) {X Y : Cᵒᵖ} (f : X ⟶ Y)

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/Sheafify.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/Sheafify.lean
@@ -24,7 +24,7 @@ and the presheaf of modules.
 
 universe w v v₁ u₁ u
 
-open CategoryTheory
+open CategoryTheory Functor
 
 variable {C : Type u₁} [Category.{v₁} C] {J : GrothendieckTopology C}
 
@@ -246,8 +246,8 @@ protected lemma smul_add : smul α φ r (m + m') = smul α φ r m + smul α φ r
   rw [(A.val.map f.op).hom.map_add, map_smul_eq α φ r m f.op r₀ hr₀ m₀ hm₀,
     map_smul_eq α φ r m' f.op r₀ hr₀ m₀' hm₀',
     map_smul_eq α φ r (m + m') f.op r₀ hr₀ (m₀ + m₀')
-      (by rw [map_add, map_add, hm₀, hm₀']),
-    smul_add, map_add]
+      (by rw [_root_.map_add, _root_.map_add, hm₀, hm₀']),
+    smul_add, _root_.map_add]
 
 protected lemma add_smul : smul α φ (r + r') m = smul α φ r m + smul α φ r' m := by
   let S := Presheaf.imageSieve α r ⊓ Presheaf.imageSieve α r' ⊓ Presheaf.imageSieve φ m
@@ -259,8 +259,8 @@ protected lemma add_smul : smul α φ (r + r') m = smul α φ r m + smul α φ r
     ⟨r₀' : R₀.obj _, (hr₀' : (α.app (Opposite.op Y)) r₀' = (R.val.map f.op) r')⟩⟩, ⟨m₀, hm₀⟩⟩
   rw [(A.val.map f.op).hom.map_add, map_smul_eq α φ r m f.op r₀ hr₀ m₀ hm₀,
     map_smul_eq α φ r' m f.op r₀' hr₀' m₀ hm₀,
-    map_smul_eq α φ (r + r') m f.op (r₀ + r₀') (by rw [map_add, map_add, hr₀, hr₀'])
-      m₀ hm₀, add_smul, map_add]
+    map_smul_eq α φ (r + r') m f.op (r₀ + r₀') (by rw [_root_.map_add, _root_.map_add, hr₀, hr₀'])
+      m₀ hm₀, add_smul, _root_.map_add]
 
 protected lemma mul_smul : smul α φ (r * r') m = smul α φ r (smul α φ r' m) := by
   let S := Presheaf.imageSieve α r ⊓ Presheaf.imageSieve α r' ⊓ Presheaf.imageSieve φ m

--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf/Colimits.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf/Colimits.lean
@@ -29,7 +29,8 @@ instance [HasColimitsOfShape K (PresheafOfModules.{v} R.val)] :
     HasColimitsOfShape K (SheafOfModules.{v} R) where
   has_colimit F := by
     let e : F ≅ (F ⋙ forget R) ⋙ PresheafOfModules.sheafification (𝟙 R.val) :=
-      isoWhiskerLeft F (asIso (PresheafOfModules.sheafificationAdjunction (𝟙 R.val)).counit).symm
+      Functor.isoWhiskerLeft F
+        (asIso (PresheafOfModules.sheafificationAdjunction (𝟙 R.val)).counit).symm
     exact hasColimit_of_iso e
 
 end SheafOfModules

--- a/Mathlib/Algebra/Homology/DerivedCategory/Basic.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Basic.lean
@@ -199,11 +199,11 @@ noncomputable instance : IsTriangulated (DerivedCategory C) :=
 instance : (Qh (C := C)).mapArrow.EssSurj :=
   Localization.essSurj_mapArrow _ (HomotopyCategory.subcategoryAcyclic C).W
 
-instance {D : Type*} [Category D] : ((whiskeringLeft _ _ D).obj (Qh (C := C))).Full :=
+instance {D : Type*} [Category D] : ((Functor.whiskeringLeft _ _ D).obj (Qh (C := C))).Full :=
   inferInstanceAs
     (Localization.whiskeringLeftFunctor' _ (HomotopyCategory.quasiIso _ _) D).Full
 
-instance {D : Type*} [Category D] : ((whiskeringLeft _ _ D).obj (Qh (C := C))).Faithful :=
+instance {D : Type*} [Category D] : ((Functor.whiskeringLeft _ _ D).obj (Qh (C := C))).Faithful :=
   inferInstanceAs
     (Localization.whiskeringLeftFunctor' _ (HomotopyCategory.quasiIso _ _) D).Faithful
 

--- a/Mathlib/Algebra/Homology/DerivedCategory/FullyFaithful.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/FullyFaithful.lean
@@ -25,9 +25,9 @@ variable (C : Type u) [Category.{v} C] [Abelian C] [HasDerivedCategory.{w} C]
 `DerivedCateogry.singleFunctor C n ⋙ DerivedCateogry.homologyFunctor C n ≅ 𝟭 C` -/
 noncomputable def singleFunctorCompHomologyFunctorIso (n : ℤ) :
     singleFunctor C n ⋙ homologyFunctor C n ≅ 𝟭 C :=
-  isoWhiskerRight ((SingleFunctors.evaluation _ _ n).mapIso
+  Functor.isoWhiskerRight ((SingleFunctors.evaluation _ _ n).mapIso
     (singleFunctorsPostcompQIso C)) _ ≪≫ Functor.associator _ _ _ ≪≫
-    isoWhiskerLeft _ (homologyFunctorFactors C n) ≪≫
+    Functor.isoWhiskerLeft _ (homologyFunctorFactors C n) ≪≫
       (HomologicalComplex.homologyFunctorSingleIso _ _ _)
 
 instance (n : ℤ) : (singleFunctor C n).Faithful where

--- a/Mathlib/Algebra/Homology/GrothendieckAbelian.lean
+++ b/Mathlib/Algebra/Homology/GrothendieckAbelian.lean
@@ -49,9 +49,9 @@ instance hasExactColimitsOfShape (J : Type w) [Category.{w'} J] [HasFiniteLimits
   preservesFiniteLimits :=
     ⟨fun K _ _ ↦ ⟨fun {F} ↦ ⟨fun hc ↦ ⟨isLimitOfEval _ _ (fun i ↦ by
       let e := preservesColimitNatIso (J := J) (eval C c i)
-      exact (IsLimit.postcomposeHomEquiv (isoWhiskerLeft F e) _).1
+      exact (IsLimit.postcomposeHomEquiv (Functor.isoWhiskerLeft F e) _).1
         (IsLimit.ofIsoLimit
-          (isLimitOfPreserves ((whiskeringRight J _ _).obj (eval C c i) ⋙ colim) hc)
+          (isLimitOfPreserves ((Functor.whiskeringRight J _ _).obj (eval C c i) ⋙ colim) hc)
           (Cones.ext (e.symm.app _) (fun k ↦ (NatIso.naturality_2 e.symm _).symm))))⟩⟩⟩⟩
 
 instance ab5OfSize [HasFilteredColimitsOfSize.{w', w} C] [HasFiniteLimits C]

--- a/Mathlib/Algebra/Homology/HomotopyCategory.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory.lean
@@ -83,10 +83,10 @@ instance [HasZeroObject V] : HasZeroObject (HomotopyCategory V c) :=
   ⟨(quotient V c).obj 0, by
     rw [IsZero.iff_id_eq_zero, ← (quotient V c).map_id, id_zero, Functor.map_zero]⟩
 
-instance {D : Type*} [Category D] : ((whiskeringLeft _ _ D).obj (quotient V c)).Full :=
+instance {D : Type*} [Category D] : ((Functor.whiskeringLeft _ _ D).obj (quotient V c)).Full :=
   Quotient.full_whiskeringLeft_functor _ _
 
-instance {D : Type*} [Category D] : ((whiskeringLeft _ _ D).obj (quotient V c)).Faithful :=
+instance {D : Type*} [Category D] : ((Functor.whiskeringLeft _ _ D).obj (quotient V c)).Faithful :=
   Quotient.faithful_whiskeringLeft_functor _ _
 
 variable {V c}

--- a/Mathlib/Algebra/Homology/HomotopyCategory/ShiftSequence.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/ShiftSequence.lean
@@ -80,9 +80,9 @@ variable (C) in
 noncomputable def shiftIso (n a a' : ℤ) (ha' : n + a = a') :
     (CategoryTheory.shiftFunctor _ n) ⋙ homologyFunctor C (ComplexShape.up ℤ) a ≅
       homologyFunctor C (ComplexShape.up ℤ) a' :=
-  isoWhiskerLeft _ (homologyFunctorIso C (ComplexShape.up ℤ) a) ≪≫
+  Functor.isoWhiskerLeft _ (homologyFunctorIso C (ComplexShape.up ℤ) a) ≪≫
     (Functor.associator _ _ _).symm ≪≫
-    isoWhiskerRight (shiftShortComplexFunctorIso C n a a' ha')
+    Functor.isoWhiskerRight (shiftShortComplexFunctorIso C n a a' ha')
       (ShortComplex.homologyFunctor C) ≪≫
     (homologyFunctorIso C (ComplexShape.up ℤ) a').symm
 

--- a/Mathlib/Algebra/Homology/Localization.lean
+++ b/Mathlib/Algebra/Homology/Localization.lean
@@ -183,7 +183,7 @@ the homology functor on `HomotopyCategory C c`. -/
 noncomputable def homologyFunctorFactorsh (i : ι) :
     Qh ⋙ homologyFunctor C c i ≅ HomotopyCategory.homologyFunctor C c i :=
   Quotient.natIsoLift _ ((Functor.associator _ _ _).symm ≪≫
-    isoWhiskerRight (quotientCompQhIso C c) _ ≪≫
+    Functor.isoWhiskerRight (quotientCompQhIso C c) _ ≪≫
     homologyFunctorFactors C c i  ≪≫ (HomotopyCategory.homologyFunctorFactors C c i).symm)
 
 section

--- a/Mathlib/Algebra/Homology/ShortComplex/FunctorEquivalence.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/FunctorEquivalence.lean
@@ -16,7 +16,7 @@ that `C` has zero morphisms), then there is an equivalence of categories
 
 namespace CategoryTheory
 
-open Limits
+open Limits Functor
 
 variable (J C : Type*) [Category J] [Category C] [HasZeroMorphisms C]
 

--- a/Mathlib/Algebra/Homology/ShortComplex/HomologicalComplex.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/HomologicalComplex.lean
@@ -469,7 +469,7 @@ noncomputable def homologyFunctorIso' [CategoryWithHomology C]
     (hi : c.prev j = i) (hk : c.next j = k) :
     homologyFunctor C c j ≅
       shortComplexFunctor' C c i j k ⋙ ShortComplex.homologyFunctor C :=
-  homologyFunctorIso C c j ≪≫ isoWhiskerRight (natIsoSc' C c i j k hi hk) _
+  homologyFunctorIso C c j ≪≫ Functor.isoWhiskerRight (natIsoSc' C c i j k hi hk) _
 
 instance [CategoryWithHomology C] : (homologyFunctor C c i).PreservesZeroMorphisms where
 instance [CategoryWithHomology C] : (opcyclesFunctor C c i).PreservesZeroMorphisms where

--- a/Mathlib/Algebra/Homology/ShortComplex/Limits.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Limits.lean
@@ -18,7 +18,7 @@ of a certain shape `J`, then it is also the case of the category `ShortComplex C
 
 namespace CategoryTheory
 
-open Category Limits
+open Category Limits Functor
 
 variable {J C : Type*} [Category J] [Category C] [HasZeroMorphisms C]
   {F : J ⥤ ShortComplex C}

--- a/Mathlib/AlgebraicGeometry/AffineScheme.lean
+++ b/Mathlib/AlgebraicGeometry/AffineScheme.lean
@@ -207,7 +207,7 @@ noncomputable instance Γ_preservesLimits : PreservesLimits Γ.{u}.rightOp := in
 noncomputable instance forgetToScheme_preservesLimits : PreservesLimits forgetToScheme := by
   apply (config := { allowSynthFailures := true })
     @preservesLimits_of_natIso _ _ _ _ _ _
-      (isoWhiskerRight equivCommRingCat.unitIso forgetToScheme).symm
+      (Functor.isoWhiskerRight equivCommRingCat.unitIso forgetToScheme).symm
   change PreservesLimits (equivCommRingCat.functor ⋙ Scheme.Spec)
   infer_instance
 

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -69,7 +69,7 @@ lemma Scheme.nonempty_of_isLimit [IsCofilteredOrEmpty I]
         MorphismProperty.pullback_snd _ _ inferInstance
       isAffine_of_isAffineHom (pullback.snd (D.map i'.hom) (𝒰.map j))
     have (i' : _) : Nonempty (F.obj i') := H i'.hom
-    let e : F ⟶ (F ⋙ Scheme.Γ.rightOp) ⋙ Scheme.Spec := whiskerLeft F ΓSpec.adjunction.unit
+    let e : F ⟶ (F ⋙ Scheme.Γ.rightOp) ⋙ Scheme.Spec := Functor.whiskerLeft F ΓSpec.adjunction.unit
     have (i : _) : IsIso (e.app i) := IsAffine.affine
     have : IsIso e := NatIso.isIso_of_isIso_app e
     let c' : LimitCone F := ⟨_, (IsLimit.postcomposeInvEquiv (asIso e) _).symm
@@ -81,8 +81,8 @@ lemma Scheme.nonempty_of_isLimit [IsCofilteredOrEmpty I]
         simp
       exact CommRingCat.FilteredColimits.nontrivial
         (isColimitCoconeLeftOpOfCone _ (limit.isLimit (F ⋙ Scheme.Γ.rightOp)))
-    let α : F ⟶ Over.forget _ ⋙ D := whiskerRight
-      (whiskerLeft (Over.post D) (Over.mapPullbackAdj (𝒰.map j)).counit) (Over.forget _)
+    let α : F ⟶ Over.forget _ ⋙ D := Functor.whiskerRight
+      (Functor.whiskerLeft (Over.post D) (Over.mapPullbackAdj (𝒰.map j)).counit) (Over.forget _)
     exact this.map (((Functor.Initial.isLimitWhiskerEquiv (Over.forget i) c).symm hc).lift
         ((Cones.postcompose α).obj c'.1)).base
 

--- a/Mathlib/AlgebraicGeometry/Spec.lean
+++ b/Mathlib/AlgebraicGeometry/Spec.lean
@@ -115,7 +115,7 @@ theorem Spec.sheafedSpaceMap_comp {R S T : CommRingCat.{u}} (f : R ⟶ S) (g : S
     ext
     -- Porting note: was one liner
     -- `dsimp, rw category_theory.functor.map_id, rw category.comp_id, erw comap_comp f g, refl`
-    rw [NatTrans.comp_app, sheafedSpaceMap_c_app, whiskerRight_app, eqToHom_refl]
+    rw [NatTrans.comp_app, sheafedSpaceMap_c_app, Functor.whiskerRight_app, eqToHom_refl]
     erw [(sheafedSpaceObj T).presheaf.map_id]
     dsimp only [CommRingCat.hom_comp, RingHom.coe_comp, Function.comp_apply]
     rw [comap_comp]

--- a/Mathlib/AlgebraicTopology/DoldKan/Compatibility.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Compatibility.lean
@@ -39,7 +39,7 @@ unit and counit isomorphisms of `equivalence`.
 -/
 
 
-open CategoryTheory CategoryTheory.Category
+open CategoryTheory CategoryTheory.Category Functor
 
 namespace AlgebraicTopology
 

--- a/Mathlib/AlgebraicTopology/DoldKan/Equivalence.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Equivalence.lean
@@ -149,11 +149,11 @@ def comparisonN : (N : SimplicialObject A ⥤ _) ≅ Idempotents.DoldKan.N :=
   calc
     N ≅ N ⋙ 𝟭 _ := Functor.leftUnitor N
     _ ≅ N ⋙ (toKaroubiEquivalence _).functor ⋙ (toKaroubiEquivalence _).inverse :=
-          isoWhiskerLeft _ (toKaroubiEquivalence _).unitIso
+          Functor.isoWhiskerLeft _ (toKaroubiEquivalence _).unitIso
     _ ≅ (N ⋙ (toKaroubiEquivalence _).functor) ⋙ (toKaroubiEquivalence _).inverse :=
           Iso.refl _
     _ ≅ N₁ ⋙ (toKaroubiEquivalence _).inverse :=
-          isoWhiskerRight (N₁_iso_normalizedMooreComplex_comp_toKaroubi A).symm _
+          Functor.isoWhiskerRight (N₁_iso_normalizedMooreComplex_comp_toKaroubi A).symm _
     _ ≅ Idempotents.DoldKan.N := Iso.refl _
 
 /-- The Dold-Kan equivalence for abelian categories -/

--- a/Mathlib/AlgebraicTopology/DoldKan/GammaCompN.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/GammaCompN.lean
@@ -22,7 +22,7 @@ suppress_compilation
 
 noncomputable section
 
-open CategoryTheory CategoryTheory.Category CategoryTheory.Limits
+open CategoryTheory CategoryTheory.Category CategoryTheory.Functor CategoryTheory.Limits
   CategoryTheory.Idempotents Opposite SimplicialObject Simplicial
 
 namespace AlgebraicTopology

--- a/Mathlib/AlgebraicTopology/DoldKan/NCompGamma.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/NCompGamma.lean
@@ -160,13 +160,13 @@ end Γ₂N₁
 /-- The compatibility isomorphism relating `N₂ ⋙ Γ₂` and `N₁ ⋙ Γ₂`. -/
 @[simps! hom_app inv_app]
 def Γ₂N₂ToKaroubiIso : toKaroubi (SimplicialObject C) ⋙ N₂ ⋙ Γ₂ ≅ N₁ ⋙ Γ₂ :=
-  (Functor.associator _ _ _).symm ≪≫ isoWhiskerRight toKaroubiCompN₂IsoN₁ Γ₂
+  (Functor.associator _ _ _).symm ≪≫ Functor.isoWhiskerRight toKaroubiCompN₂IsoN₁ Γ₂
 
 namespace Γ₂N₂
 
 /-- The natural transformation `N₂ ⋙ Γ₂ ⟶ 𝟭 (SimplicialObject C)`. -/
 def natTrans : (N₂ : Karoubi (SimplicialObject C) ⥤ _) ⋙ Γ₂ ⟶ 𝟭 _ :=
-  ((whiskeringLeft _ _ _).obj (toKaroubi (SimplicialObject C))).preimage
+  ((Functor.whiskeringLeft _ _ _).obj (toKaroubi (SimplicialObject C))).preimage
     (Γ₂N₂ToKaroubiIso.hom ≫ Γ₂N₁.natTrans)
 
 theorem natTrans_app_f_app (P : Karoubi (SimplicialObject C)) :

--- a/Mathlib/AlgebraicTopology/SimplexCategory/Augmented.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/Augmented.lean
@@ -59,7 +59,7 @@ dropping the augmentation corresponds to precomposition with
 @[simps!]
 def equivAugmentedCosimplicialObjectFunctorCompDropIso :
     equivAugmentedCosimplicialObject.functor ⋙ CosimplicialObject.Augmented.drop ≅
-    (whiskeringLeft _ _ C).obj inclusion :=
+    (Functor.whiskeringLeft _ _ C).obj inclusion :=
   .refl _
 
 /-- Through the equivalence `(AugmentedSimplexCategory ⥤ C) ≌ CosimplicialObject.Augmented C`,
@@ -93,7 +93,7 @@ dropping the augmentation corresponds to precomposition with
 @[simps!]
 def equivAugmentedSimplicialObjectFunctorCompDropIso :
     equivAugmentedSimplicialObject.functor ⋙ SimplicialObject.Augmented.drop ≅
-    (whiskeringLeft _ _ C).obj inclusion.op :=
+    (Functor.whiskeringLeft _ _ C).obj inclusion.op :=
   .refl _
 
 /-- Through the equivalence `(AugmentedSimplexCategory ⥤ C) ≌ CosimplicialObject.Augmented C`,

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Path.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Path.lean
@@ -132,12 +132,12 @@ def spine (m : ℕ) (h : m ≤ n + 1 := by omega) (Δ : X _⦋m⦌ₙ₊₁) : P
   arrow i := X.map (tr (mkOfSucc i)).op Δ
   arrow_src i := by
     dsimp only [tr, trunc, SimplicialObject.Truncated.trunc, incl,
-      whiskeringLeft_obj_obj, id_eq, Functor.comp_map, Functor.op_map,
+      Functor.whiskeringLeft_obj_obj, id_eq, Functor.comp_map, Functor.op_map,
       Quiver.Hom.unop_op]
     rw [← FunctorToTypes.map_comp_apply, ← op_comp, ← tr_comp, δ_one_mkOfSucc]
   arrow_tgt i := by
     dsimp only [tr, trunc, SimplicialObject.Truncated.trunc, incl,
-      whiskeringLeft_obj_obj, id_eq, Functor.comp_map, Functor.op_map,
+      Functor.whiskeringLeft_obj_obj, id_eq, Functor.comp_map, Functor.op_map,
       Quiver.Hom.unop_op]
     rw [← FunctorToTypes.map_comp_apply, ← op_comp, ← tr_comp, δ_zero_mkOfSucc]
 

--- a/Mathlib/AlgebraicTopology/SingularHomology/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SingularHomology/Basic.lean
@@ -37,12 +37,12 @@ def SSet.singularChainComplexFunctor [Limits.HasCoproducts.{w} C] :
 /-- The singular chain complex functor with coefficients in `C`. -/
 def singularChainComplexFunctor :
     C ⥤ TopCat.{0} ⥤ ChainComplex C ℕ :=
-  SSet.singularChainComplexFunctor.{0} C ⋙ (whiskeringLeft _ _ _).obj TopCat.toSSet
+  SSet.singularChainComplexFunctor.{0} C ⋙ (Functor.whiskeringLeft _ _ _).obj TopCat.toSSet
 
 /-- The `n`-th singular homology functor with coefficients in `C`. -/
 def singularHomologyFunctor : C ⥤ TopCat.{0} ⥤ C :=
   singularChainComplexFunctor C ⋙
-    (whiskeringRight _ _ _).obj (HomologicalComplex.homologyFunctor _ _ n)
+    (Functor.whiskeringRight _ _ _).obj (HomologicalComplex.homologyFunctor _ _ n)
 
 section TotallyDisconnectedSpace
 

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckAxioms/Basic.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckAxioms/Basic.lean
@@ -49,7 +49,7 @@ individual axioms. An `AB4` category is an _abelian_ category satisfying `AB4`, 
 
 namespace CategoryTheory
 
-open Limits
+open Limits Functor
 
 attribute [instance] comp_preservesFiniteLimits comp_preservesFiniteColimits
 

--- a/Mathlib/CategoryTheory/Abelian/LeftDerived.lean
+++ b/Mathlib/CategoryTheory/Abelian/LeftDerived.lean
@@ -169,7 +169,7 @@ a natural transformation `F ⟶ G` between additive functors. -/
 noncomputable def NatTrans.leftDerivedToHomotopyCategory
     {F G : C ⥤ D} [F.Additive] [G.Additive] (α : F ⟶ G) :
     F.leftDerivedToHomotopyCategory ⟶ G.leftDerivedToHomotopyCategory :=
-  whiskerLeft _ (NatTrans.mapHomotopyCategory α (ComplexShape.down ℕ))
+  Functor.whiskerLeft _ (NatTrans.mapHomotopyCategory α (ComplexShape.down ℕ))
 
 lemma ProjectiveResolution.leftDerivedToHomotopyCategory_app_eq
     {F G : C ⥤ D} [F.Additive] [G.Additive] (α : F ⟶ G) {X : C} (P : ProjectiveResolution X) :
@@ -205,13 +205,13 @@ lemma NatTrans.leftDerivedToHomotopyCategory_comp {F G H : C ⥤ D} (α : F ⟶ 
 noncomputable def NatTrans.leftDerived
     {F G : C ⥤ D} [F.Additive] [G.Additive] (α : F ⟶ G) (n : ℕ) :
     F.leftDerived n ⟶ G.leftDerived n :=
-  whiskerRight (NatTrans.leftDerivedToHomotopyCategory α) _
+  Functor.whiskerRight (NatTrans.leftDerivedToHomotopyCategory α) _
 
 @[simp]
 theorem NatTrans.leftDerived_id (F : C ⥤ D) [F.Additive] (n : ℕ) :
     NatTrans.leftDerived (𝟙 F) n = 𝟙 (F.leftDerived n) := by
   dsimp only [leftDerived]
-  simp only [leftDerivedToHomotopyCategory_id, whiskerRight_id']
+  simp only [leftDerivedToHomotopyCategory_id, Functor.whiskerRight_id']
   rfl
 
 @[simp, reassoc]

--- a/Mathlib/CategoryTheory/Abelian/RightDerived.lean
+++ b/Mathlib/CategoryTheory/Abelian/RightDerived.lean
@@ -170,7 +170,7 @@ a natural transformation `F ⟶ G` between additive functors. -/
 noncomputable def NatTrans.rightDerivedToHomotopyCategory
     {F G : C ⥤ D} [F.Additive] [G.Additive] (α : F ⟶ G) :
     F.rightDerivedToHomotopyCategory ⟶ G.rightDerivedToHomotopyCategory :=
-  whiskerLeft _ (NatTrans.mapHomotopyCategory α (ComplexShape.up ℕ))
+  Functor.whiskerLeft _ (NatTrans.mapHomotopyCategory α (ComplexShape.up ℕ))
 
 lemma InjectiveResolution.rightDerivedToHomotopyCategory_app_eq
     {F G : C ⥤ D} [F.Additive] [G.Additive] (α : F ⟶ G) {X : C} (P : InjectiveResolution X) :
@@ -207,13 +207,13 @@ induced by a natural transformation. -/
 noncomputable def NatTrans.rightDerived
     {F G : C ⥤ D} [F.Additive] [G.Additive] (α : F ⟶ G) (n : ℕ) :
     F.rightDerived n ⟶ G.rightDerived n :=
-  whiskerRight (NatTrans.rightDerivedToHomotopyCategory α) _
+  Functor.whiskerRight (NatTrans.rightDerivedToHomotopyCategory α) _
 
 @[simp]
 theorem NatTrans.rightDerived_id (F : C ⥤ D) [F.Additive] (n : ℕ) :
     NatTrans.rightDerived (𝟙 F) n = 𝟙 (F.rightDerived n) := by
   dsimp only [rightDerived]
-  simp only [rightDerivedToHomotopyCategory_id, whiskerRight_id']
+  simp only [rightDerivedToHomotopyCategory_id, Functor.whiskerRight_id']
   rfl
 
 @[simp, reassoc]

--- a/Mathlib/CategoryTheory/Adhesive.lean
+++ b/Mathlib/CategoryTheory/Adhesive.lean
@@ -319,7 +319,7 @@ theorem adhesive_of_reflective [HasPullbacks D] [Adhesive C] [HasPullbacks C] [H
   have := Adhesive.van_kampen (IsPushout.of_hasPushout (Gr.map f) (Gr.map g))
   rw [IsPushout.isVanKampen_iff] at this ⊢
   refine (IsVanKampenColimit.precompose_isIso_iff
-    (isoWhiskerLeft _ (asIso adj.counit) ≪≫ Functor.rightUnitor _).hom).mp ?_
+    (Functor.isoWhiskerLeft _ (asIso adj.counit) ≪≫ Functor.rightUnitor _).hom).mp ?_
   refine ((this.precompose_isIso (spanCompIso _ _ _).hom).map_reflective adj).of_iso
     (IsColimit.uniqueUpToIso ?_ ?_)
   · exact isColimitOfPreserves Gl ((IsColimit.precomposeHomEquiv _ _).symm <| pushoutIsPushout _ _)

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -75,7 +75,7 @@ Conversely `Equivalence.toAdjunction` recovers the underlying adjunction from an
 
 namespace CategoryTheory
 
-open Category
+open Category Functor
 
 -- declare the `v`'s first; see `CategoryTheory.Category` for an explanation
 universe v₁ v₂ v₃ u₁ u₂ u₃
@@ -134,12 +134,12 @@ end Functor
 /-- The adjunction associated to a functor known to be a left adjoint. -/
 noncomputable def Adjunction.ofIsLeftAdjoint (left : C ⥤ D) [left.IsLeftAdjoint] :
     left ⊣ left.rightAdjoint :=
-  Functor.IsLeftAdjoint.exists_rightAdjoint.choose_spec.some
+  IsLeftAdjoint.exists_rightAdjoint.choose_spec.some
 
 /-- The adjunction associated to a functor known to be a right adjoint. -/
 noncomputable def Adjunction.ofIsRightAdjoint (right : C ⥤ D) [right.IsRightAdjoint] :
     right.leftAdjoint ⊣ right :=
-  Functor.IsRightAdjoint.exists_leftAdjoint.choose_spec.some
+  IsRightAdjoint.exists_leftAdjoint.choose_spec.some
 
 namespace Adjunction
 
@@ -365,13 +365,13 @@ structure CoreUnitCounit (F : C ⥤ D) (G : D ⥤ C) where
   /-- Equality of the composition of the unit, associator, and counit with the identity
   `F ⟶ (F G) F ⟶ F (G F) ⟶ F = NatTrans.id F` -/
   left_triangle :
-    whiskerRight unit F ≫ (Functor.associator F G F).hom ≫ whiskerLeft F counit =
+    whiskerRight unit F ≫ (associator F G F).hom ≫ whiskerLeft F counit =
       NatTrans.id (𝟭 C ⋙ F) := by
     aesop_cat
   /-- Equality of the composition of the unit, associator, and counit with the identity
   `G ⟶ G (F G) ⟶ (F G) F ⟶ G = NatTrans.id G` -/
   right_triangle :
-    whiskerLeft G unit ≫ (Functor.associator G F G).inv ≫ whiskerRight counit G =
+    whiskerLeft G unit ≫ (associator G F G).inv ≫ whiskerRight counit G =
       NatTrans.id (G ⋙ 𝟭 C) := by
     aesop_cat
 
@@ -509,8 +509,8 @@ def comp : F ⋙ H ⊣ I ⋙ G :=
   mk' {
     homEquiv := fun _ _ ↦ Equiv.trans (adj₂.homEquiv _ _) (adj₁.homEquiv _ _)
     unit := adj₁.unit ≫ whiskerRight (F.rightUnitor.inv ≫ whiskerLeft F adj₂.unit ≫
-      (Functor.associator _ _ _ ).inv) G ≫ (Functor.associator _ _ _).hom
-    counit := (Functor.associator _ _ _ ).inv ≫ whiskerRight ((Functor.associator _ _ _ ).hom ≫
+      (associator _ _ _ ).inv) G ≫ (associator _ _ _).hom
+    counit := (associator _ _ _ ).inv ≫ whiskerRight ((associator _ _ _ ).hom ≫
       whiskerLeft _ adj₁.counit ≫ I.rightUnitor.hom) _ ≫ adj₂.counit }
 
 @[simp, reassoc]

--- a/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
+++ b/Mathlib/CategoryTheory/Adjunction/FullyFaithful.lean
@@ -36,7 +36,7 @@ namespace CategoryTheory.Adjunction
 
 universe v₁ v₂ u₁ u₂
 
-open Category
+open Category Functor
 
 open Opposite
 

--- a/Mathlib/CategoryTheory/Adjunction/Lifting/Left.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Lifting/Left.lean
@@ -194,10 +194,10 @@ lemma isRightAdjoint_triangle_lift_monadic (U : B ⥤ C) [MonadicRightAdjoint U]
       infer_instance
     refine ((Adjunction.ofIsRightAdjoint
       (R' ⋙ (Monad.comparison (monadicAdjunction U)).inv)).ofNatIsoRight ?_).isRightAdjoint
-    exact isoWhiskerLeft R (Monad.comparison _).asEquivalence.unitIso.symm ≪≫ R.rightUnitor
+    exact Functor.isoWhiskerLeft R (Monad.comparison _).asEquivalence.unitIso.symm ≪≫ R.rightUnitor
   let this : (R' ⋙ Monad.forget (monadicAdjunction U).toMonad).IsRightAdjoint := by
     refine ((Adjunction.ofIsRightAdjoint (R ⋙ U)).ofNatIsoRight ?_).isRightAdjoint
-    exact isoWhiskerLeft R (Monad.comparisonForget (monadicAdjunction U)).symm
+    exact Functor.isoWhiskerLeft R (Monad.comparisonForget (monadicAdjunction U)).symm
   let this : ∀ X, RegularEpi ((Monad.adj (monadicAdjunction U).toMonad).counit.app X) := by
     intro X
     simp only [Monad.adj_counit]

--- a/Mathlib/CategoryTheory/Adjunction/Lifting/Right.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Lifting/Right.lean
@@ -186,10 +186,10 @@ lemma isLeftAdjoint_triangle_lift_comonadic (F : B ⥤ A) [ComonadicLeftAdjoint 
       infer_instance
     refine ((Adjunction.ofIsLeftAdjoint
       (L' ⋙ (Comonad.comparison (comonadicAdjunction F)).inv)).ofNatIsoLeft ?_).isLeftAdjoint
-    exact isoWhiskerLeft L (Comonad.comparison _).asEquivalence.unitIso.symm ≪≫ L.leftUnitor
+    exact Functor.isoWhiskerLeft L (Comonad.comparison _).asEquivalence.unitIso.symm ≪≫ L.leftUnitor
   let this : (L' ⋙ Comonad.forget (comonadicAdjunction F).toComonad).IsLeftAdjoint := by
     refine ((Adjunction.ofIsLeftAdjoint (L ⋙ F)).ofNatIsoLeft ?_).isLeftAdjoint
-    exact isoWhiskerLeft L (Comonad.comparisonForget (comonadicAdjunction F)).symm
+    exact Functor.isoWhiskerLeft L (Comonad.comparisonForget (comonadicAdjunction F)).symm
   let this : ∀ X, RegularMono ((Comonad.adj (comonadicAdjunction F).toComonad).unit.app X) := by
     intro X
     simp only [Comonad.adj_unit]

--- a/Mathlib/CategoryTheory/Adjunction/Mates.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Mates.lean
@@ -149,9 +149,10 @@ theorem mateEquiv_vcomp (α : TwoSquare G₁ L₁ L₂ H₁) (β : TwoSquare G�
     (mateEquiv adj₁ adj₃) (α ≫ₕ β) = (mateEquiv adj₁ adj₂ α) ≫ᵥ (mateEquiv adj₂ adj₃ β) := by
   unfold hComp vComp mateEquiv
   ext b
-  simp only [comp_obj, Equiv.coe_fn_mk, whiskerLeft_comp, whiskerLeft_twice, whiskerRight_comp,
-    assoc, comp_app, whiskerLeft_app, whiskerRight_app, associator_hom_app, map_id,
-    associator_inv_app, id_obj, Functor.comp_map, id_comp, whiskerRight_twice, comp_id]
+  simp only [comp_obj, Equiv.coe_fn_mk, whiskerLeft_comp, whiskerLeft_twice, assoc,
+    whiskerRight_comp, comp_app, Functor.whiskerLeft_app, Functor.whiskerRight_app,
+    associator_hom_app, map_id, associator_inv_app, id_obj, Functor.comp_map, id_comp,
+    whiskerRight_twice, comp_id]
   slice_rhs 1 4 => rw [← assoc, ← assoc, ← unit_naturality (adj₃)]
   rw [L₃.map_comp, R₃.map_comp]
   slice_rhs 2 4 =>
@@ -458,9 +459,10 @@ theorem mateEquiv_conjugateEquiv_vcomp {L₁ : A ⥤ B} {R₁ : B ⥤ A} {L₂ :
   unfold TwoSquare.whiskerRight TwoSquare.whiskerBottom conjugateEquiv
   have vcompb := congr_app vcomp b
   simp only [comp_obj, id_obj, whiskerLeft_comp, assoc, mateEquiv_apply, whiskerLeft_twice,
-    whiskerRight_comp, comp_app, whiskerLeft_app, whiskerRight_app, associator_hom_app, map_id,
-    leftUnitor_hom_app, rightUnitor_inv_app, associator_inv_app, Functor.id_map, Functor.comp_map,
-    id_comp, whiskerRight_twice, comp_id] at vcompb
+    Iso.hom_inv_id_assoc, whiskerRight_comp, comp_app, Functor.whiskerLeft_app,
+    Functor.whiskerRight_app, associator_hom_app, map_id, associator_inv_app, leftUnitor_hom_app,
+    rightUnitor_inv_app, Functor.id_map, Functor.comp_map, id_comp, whiskerRight_twice,
+    comp_id] at vcompb
   simpa [mateEquiv]
 
 /-- The mates equivalence commutes with this composition, essentially by `mateEquiv_vcomp`. -/
@@ -475,9 +477,10 @@ theorem conjugateEquiv_mateEquiv_vcomp {L₁ : A ⥤ B} {R₁ : B ⥤ A} {L₂ :
   unfold TwoSquare.whiskerLeft TwoSquare.whiskerTop conjugateEquiv
   have vcompb := congr_app vcomp b
   simp only [comp_obj, id_obj, whiskerRight_comp, assoc, mateEquiv_apply, whiskerLeft_comp,
-    whiskerLeft_twice, comp_app, whiskerLeft_app, whiskerRight_app, associator_hom_app, map_id,
-    associator_inv_app, leftUnitor_hom_app, rightUnitor_inv_app, Functor.comp_map, Functor.id_map,
-    id_comp, whiskerRight_twice, comp_id] at vcompb
+    whiskerLeft_twice, comp_app, Functor.whiskerLeft_app, Functor.whiskerRight_app,
+    associator_hom_app, map_id, associator_inv_app, leftUnitor_hom_app, rightUnitor_inv_app,
+    Functor.comp_map, Functor.id_map, id_comp, whiskerRight_twice, Iso.inv_hom_id_assoc,
+    comp_id] at vcompb
   simpa [mateEquiv]
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Adjunction/Parametrized.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Parametrized.lean
@@ -37,7 +37,7 @@ universe v₁ v₂ v₃ u₁ u₂ u₃
 
 namespace CategoryTheory
 
-open Opposite
+open Opposite Functor
 
 variable {C₁ : Type u₁} {C₂ : Type u₂} {C₃ : Type u₃}
   [Category.{v₁} C₁] [Category.{v₂} C₂] [Category.{v₃} C₃]

--- a/Mathlib/CategoryTheory/Adjunction/Unique.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Unique.lean
@@ -20,7 +20,7 @@ This file shows that adjoints are unique up to natural isomorphism.
 
 -/
 
-open CategoryTheory
+open CategoryTheory Functor
 
 variable {C D : Type*} [Category C] [Category D]
 

--- a/Mathlib/CategoryTheory/Adjunction/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Whiskering.lean
@@ -17,7 +17,7 @@ and the functor categories `E ⥤ C` and `D ⥤ C`.
 
 namespace CategoryTheory.Adjunction
 
-open CategoryTheory
+open CategoryTheory Functor
 
 variable (C : Type*) {D E : Type*} [Category C] [Category D] [Category E] {F : D ⥤ E} {G : E ⥤ D}
 
@@ -28,11 +28,11 @@ protected def whiskerRight (adj : F ⊣ G) :
     (whiskeringRight C D E).obj F ⊣ (whiskeringRight C E D).obj G where
   unit :=
     { app := fun X =>
-        (Functor.rightUnitor _).inv ≫ whiskerLeft X adj.unit ≫ (Functor.associator _ _ _).inv
+        (rightUnitor _).inv ≫ whiskerLeft X adj.unit ≫ (associator _ _ _).inv
       naturality := by intros; ext; simp }
   counit :=
     { app := fun X =>
-        (Functor.associator _ _ _).hom ≫ whiskerLeft X adj.counit ≫ (Functor.rightUnitor _).hom
+        (associator _ _ _).hom ≫ whiskerLeft X adj.counit ≫ (rightUnitor _).hom
       naturality := by intros; ext; simp }
 
 /-- Given an adjunction `F ⊣ G`, this provides the natural adjunction
@@ -42,10 +42,10 @@ protected def whiskerLeft (adj : F ⊣ G) :
     (whiskeringLeft E D C).obj G ⊣ (whiskeringLeft D E C).obj F where
   unit :=
     { app := fun X =>
-        (Functor.leftUnitor _).inv ≫ whiskerRight adj.unit X ≫ (Functor.associator _ _ _).hom }
+        (leftUnitor _).inv ≫ whiskerRight adj.unit X ≫ (associator _ _ _).hom }
   counit :=
     { app := fun X =>
-        (Functor.associator _ _ _).inv ≫ whiskerRight adj.counit X ≫ (Functor.leftUnitor _).hom }
+        (associator _ _ _).inv ≫ whiskerRight adj.counit X ≫ (leftUnitor _).hom }
   left_triangle_components X := by ext; simp [← X.map_comp]
   right_triangle_components X := by ext; simp [← X.map_comp]
 

--- a/Mathlib/CategoryTheory/CatCommSq.lean
+++ b/Mathlib/CategoryTheory/CatCommSq.lean
@@ -21,7 +21,7 @@ Future work: using this notion in the development of the localization of categor
 
 namespace CategoryTheory
 
-open Category
+open Category Functor
 
 variable {C₁ C₂ C₃ C₄ C₅ C₆ : Type*} [Category C₁] [Category C₂] [Category C₃] [Category C₄]
   [Category C₅] [Category C₆]
@@ -54,18 +54,18 @@ lemma iso_inv_naturality [h : CatCommSq T L R B] {x y : C₁} (f : x ⟶ y) :
 def hComp (T₁ : C₁ ⥤ C₂) (T₂ : C₂ ⥤ C₃) (V₁ : C₁ ⥤ C₄) (V₂ : C₂ ⥤ C₅) (V₃ : C₃ ⥤ C₆)
     (B₁ : C₄ ⥤ C₅) (B₂ : C₅ ⥤ C₆) [CatCommSq T₁ V₁ V₂ B₁] [CatCommSq T₂ V₂ V₃ B₂] :
     CatCommSq (T₁ ⋙ T₂) V₁ V₃ (B₁ ⋙ B₂) where
-  iso := Functor.associator _ _ _ ≪≫ isoWhiskerLeft T₁ (iso T₂ V₂ V₃ B₂) ≪≫
-    (Functor.associator _ _ _).symm ≪≫ isoWhiskerRight (iso T₁ V₁ V₂ B₁) B₂ ≪≫
-    Functor.associator _ _ _
+  iso := associator _ _ _ ≪≫ isoWhiskerLeft T₁ (iso T₂ V₂ V₃ B₂) ≪≫
+    (associator _ _ _).symm ≪≫ isoWhiskerRight (iso T₁ V₁ V₂ B₁) B₂ ≪≫
+    associator _ _ _
 
 /-- Vertical composition of 2-commutative squares -/
 @[simps!]
 def vComp (L₁ : C₁ ⥤ C₂) (L₂ : C₂ ⥤ C₃) (H₁ : C₁ ⥤ C₄) (H₂ : C₂ ⥤ C₅) (H₃ : C₃ ⥤ C₆)
     (R₁ : C₄ ⥤ C₅) (R₂ : C₅ ⥤ C₆) [CatCommSq H₁ L₁ R₁ H₂] [CatCommSq H₂ L₂ R₂ H₃] :
     CatCommSq H₁ (L₁ ⋙ L₂) (R₁ ⋙ R₂) H₃ where
-  iso := (Functor.associator _ _ _).symm ≪≫ isoWhiskerRight (iso H₁ L₁ R₁ H₂) R₂ ≪≫
-      Functor.associator _ _ _ ≪≫ isoWhiskerLeft L₁ (iso H₂ L₂ R₂ H₃) ≪≫
-      (Functor.associator _ _ _).symm
+  iso := (associator _ _ _).symm ≪≫ isoWhiskerRight (iso H₁ L₁ R₁ H₂) R₂ ≪≫
+      associator _ _ _ ≪≫ isoWhiskerLeft L₁ (iso H₂ L₂ R₂ H₃) ≪≫
+      (associator _ _ _).symm
 
 section
 
@@ -75,10 +75,10 @@ variable (T : C₁ ≌ C₂) (L : C₁ ⥤ C₃) (R : C₂ ⥤ C₄) (B : C₃ �
 @[simps!]
 def hInv (_ : CatCommSq T.functor L R B.functor) : CatCommSq T.inverse R L B.inverse where
   iso := isoWhiskerLeft _ (L.rightUnitor.symm ≪≫ isoWhiskerLeft L B.unitIso ≪≫
-      (Functor.associator _ _ _).symm ≪≫
+      (associator _ _ _).symm ≪≫
       isoWhiskerRight (iso T.functor L R B.functor).symm B.inverse ≪≫
-      Functor.associator _ _ _  ) ≪≫ (Functor.associator _ _ _).symm ≪≫
-      isoWhiskerRight T.counitIso _ ≪≫ Functor.leftUnitor _
+      associator _ _ _  ) ≪≫ (associator _ _ _).symm ≪≫
+      isoWhiskerRight T.counitIso _ ≪≫ leftUnitor _
 
 lemma hInv_hInv (h : CatCommSq T.functor L R B.functor) :
     hInv T.symm R L B.symm (hInv T L R B h) = h := by
@@ -114,11 +114,11 @@ variable (T : C₁ ⥤ C₂) (L : C₁ ≌ C₃) (R : C₂ ≌ C₄) (B : C₃ �
 @[simps!]
 def vInv (_ : CatCommSq T L.functor R.functor B) : CatCommSq B L.inverse R.inverse T where
   iso := isoWhiskerRight (B.leftUnitor.symm ≪≫ isoWhiskerRight L.counitIso.symm B ≪≫
-      Functor.associator _ _ _ ≪≫
+      associator _ _ _ ≪≫
       isoWhiskerLeft L.inverse (iso T L.functor R.functor B).symm) R.inverse ≪≫
-      Functor.associator _ _ _ ≪≫ isoWhiskerLeft _ (Functor.associator _ _ _) ≪≫
-      (Functor.associator _ _ _ ).symm ≪≫ isoWhiskerLeft _ R.unitIso.symm ≪≫
-      Functor.rightUnitor _
+      associator _ _ _ ≪≫ isoWhiskerLeft _ (associator _ _ _) ≪≫
+      (associator _ _ _ ).symm ≪≫ isoWhiskerLeft _ R.unitIso.symm ≪≫
+      rightUnitor _
 
 lemma vInv_vInv (h : CatCommSq T L.functor R.functor B) :
     vInv B L.symm R.symm T (vInv T L R B h) = h := by

--- a/Mathlib/CategoryTheory/Category/Cat.lean
+++ b/Mathlib/CategoryTheory/Category/Cat.lean
@@ -26,7 +26,7 @@ universe v u
 
 namespace CategoryTheory
 
-open Bicategory
+open Bicategory Functor
 
 -- intended to be used with explicit universe parameters
 /-- Category of categories. -/

--- a/Mathlib/CategoryTheory/Center/Localization.lean
+++ b/Mathlib/CategoryTheory/Center/Localization.lean
@@ -30,13 +30,13 @@ namespace CatCenter
 to `W : MorphismProperty D`, this is the induced element in `CatCenter D`
 obtained by localization. -/
 noncomputable def localization : CatCenter D :=
-  Localization.liftNatTrans L W L L (𝟭 D) (𝟭 D) (whiskerRight r L)
+  Localization.liftNatTrans L W L L (𝟭 D) (𝟭 D) (Functor.whiskerRight r L)
 
 @[simp]
 lemma localization_app (X : C) :
     (r.localization L W).app (L.obj X) = L.map (r.app X) := by
   dsimp [localization]
-  simp only [Localization.liftNatTrans_app, Functor.id_obj, whiskerRight_app,
+  simp only [Localization.liftNatTrans_app, Functor.id_obj, Functor.whiskerRight_app,
     NatTrans.naturality, Functor.comp_map, Functor.id_map, Iso.hom_inv_id_app_assoc]
 
 include W

--- a/Mathlib/CategoryTheory/Closed/Functor.lean
+++ b/Mathlib/CategoryTheory/Closed/Functor.lean
@@ -54,7 +54,8 @@ We will show that if `C` and `D` are cartesian closed, then this morphism is an 
 `A` iff `F` is a cartesian closed functor, i.e. it preserves exponentials.
 -/
 def frobeniusMorphism (h : L ⊣ F) (A : C) : TwoSquare (tensorLeft (F.obj A)) L L (tensorLeft A) :=
-  prodComparisonNatTrans L (F.obj A) ≫ whiskerLeft _ ((curriedTensor C).map (h.counit.app _))
+  prodComparisonNatTrans L (F.obj A) ≫
+    Functor.whiskerLeft _ ((curriedTensor C).map (h.counit.app _))
 
 /-- If `F` is full and faithful and has a left adjoint `L` which preserves binary products, then the
 Frobenius morphism is an isomorphism.
@@ -112,8 +113,8 @@ theorem expComparison_whiskerLeft {A A' : C} (f : A' ⟶ A) :
   apply congr_arg
   ext B
   simp only [Functor.comp_obj, curriedTensor_obj_obj, prodComparisonNatIso_inv,
-    NatTrans.comp_app, whiskerLeft_app, curriedTensor_map_app, NatIso.isIso_inv_app,
-    whiskerRight_app, IsIso.eq_inv_comp, prodComparisonNatTrans_app]
+    NatTrans.comp_app, Functor.whiskerLeft_app, curriedTensor_map_app, NatIso.isIso_inv_app,
+    Functor.whiskerRight_app, IsIso.eq_inv_comp, prodComparisonNatTrans_app]
   rw [← prodComparison_inv_natural_whiskerRight F f]
   simp
 
@@ -131,17 +132,18 @@ theorem frobeniusMorphism_mate (h : L ⊣ F) (A : C) :
   unfold expComparison frobeniusMorphism
   have conjeq := iterated_mateEquiv_conjugateEquiv h h
     (exp.adjunction (F.obj A)) (exp.adjunction A)
-    (prodComparisonNatTrans L (F.obj A) ≫ whiskerLeft L ((curriedTensor C).map (h.counit.app A)))
+    (prodComparisonNatTrans L (F.obj A) ≫
+      Functor.whiskerLeft L ((curriedTensor C).map (h.counit.app A)))
   rw [← conjeq]
   congr 1
   apply congr_arg
   ext B
   unfold mateEquiv
-  simp only [Functor.comp_obj, curriedTensor_obj_obj, Functor.id_obj, Equiv.coe_fn_mk,
-    whiskerLeft_comp, whiskerLeft_twice, whiskerRight_comp, assoc, NatTrans.comp_app,
-    whiskerLeft_app, curriedTensor_obj_obj, whiskerRight_app, prodComparisonNatTrans_app,
-    curriedTensor_map_app, Functor.comp_map, curriedTensor_obj_map, prodComparisonNatIso_inv,
-    NatIso.isIso_inv_app]
+  simp only [Functor.comp_obj, curriedTensor_obj_obj, Equiv.coe_fn_mk, Functor.whiskerLeft_comp,
+    Functor.whiskerLeft_twice, Functor.whiskerRight_comp, assoc, NatTrans.comp_app,
+    Functor.whiskerLeft_app, Functor.whiskerRight_app, prodComparisonNatTrans_app,
+    curriedTensor_map_app, Functor.id_obj, Functor.comp_map, curriedTensor_obj_map,
+    prodComparisonNatIso_inv, NatIso.isIso_inv_app]
   rw [← F.map_comp, ← F.map_comp]
   simp only [Functor.map_comp]
   apply IsIso.eq_inv_of_inv_hom_id

--- a/Mathlib/CategoryTheory/Closed/Types.lean
+++ b/Mathlib/CategoryTheory/Closed/Types.lean
@@ -58,7 +58,7 @@ def cartesianClosedFunctorToTypes {C : Type u₁} [Category.{v₁} C] :
     CartesianClosed (C ⥤ Type (max u₁ v₁ u₂)) :=
   let e : (ULiftHom.{max u₁ v₁ u₂} (ULift.{max u₁ v₁ u₂} C)) ⥤ Type (max u₁ v₁ u₂) ≌
       C ⥤ Type (max u₁ v₁ u₂) :=
-      Functor.asEquivalence ((whiskeringLeft _ _ _).obj
+      Functor.asEquivalence ((Functor.whiskeringLeft _ _ _).obj
         (ULift.equivalence.trans ULiftHom.equiv).functor)
   cartesianClosedOfEquiv e
 
@@ -72,7 +72,7 @@ instance {C : Type u₁} [Category.{v₁} C] : CartesianClosed (C ⥤ Type (max 
 instance {C : Type u₁} [Category.{v₁} C] [EssentiallySmall.{v₁} C] :
     CartesianClosed (C ⥤ Type v₁) :=
   let e : (SmallModel C) ⥤ Type v₁ ≌ C ⥤ Type v₁ :=
-    Functor.asEquivalence ((whiskeringLeft _ _ _).obj (equivSmallModel _).functor)
+    Functor.asEquivalence ((Functor.whiskeringLeft _ _ _).obj (equivSmallModel _).functor)
   cartesianClosedOfEquiv e
 
 end CartesianClosed

--- a/Mathlib/CategoryTheory/Comma/Presheaf/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Presheaf/Basic.lean
@@ -615,7 +615,7 @@ theorem CostructuredArrow.overEquivPresheafCostructuredArrow_functor_map_toOverC
 def CostructuredArrow.toOverCompCoyoneda (A : Cᵒᵖ ⥤ Type v) :
     (CostructuredArrow.toOver yoneda A).op ⋙ coyoneda ≅
     yoneda.op ⋙ coyoneda ⋙
-      (whiskeringLeft _ _ _).obj (overEquivPresheafCostructuredArrow A).functor :=
+      (Functor.whiskeringLeft _ _ _).obj (overEquivPresheafCostructuredArrow A).functor :=
   NatIso.ofComponents (fun X => NatIso.ofComponents (fun Y =>
     (overEquivPresheafCostructuredArrow A).fullyFaithfulFunctor.homEquiv.toIso ≪≫
       (Iso.homCongr

--- a/Mathlib/CategoryTheory/Comma/Presheaf/Colimit.lean
+++ b/Mathlib/CategoryTheory/Comma/Presheaf/Colimit.lean
@@ -39,19 +39,20 @@ noncomputable def CostructuredArrow.toOverCompYonedaColimit :
     ≅ yoneda.op ⋙ yoneda.obj (E.obj (colimit F)) :=
         CostructuredArrow.toOverCompYoneda A _
   _ ≅ yoneda.op ⋙ yoneda.obj (colimit (F ⋙ E)) :=
-        isoWhiskerLeft yoneda.op (yoneda.mapIso (preservesColimitIso _ F))
+        Functor.isoWhiskerLeft yoneda.op (yoneda.mapIso (preservesColimitIso _ F))
   _ ≅ yoneda.op ⋙ colimit ((F ⋙ E) ⋙ yoneda) :=
         yonedaYonedaColimit _
   _ ≅ yoneda.op ⋙ ((F ⋙ E) ⋙ yoneda).flip ⋙ colim :=
-        isoWhiskerLeft _ (colimitIsoFlipCompColim _)
-  _ ≅ (yoneda.op ⋙ coyoneda ⋙ (whiskeringLeft _ _ _).obj E) ⋙
-          (whiskeringLeft _ _ _).obj F ⋙ colim :=
+        Functor.isoWhiskerLeft _ (colimitIsoFlipCompColim _)
+  _ ≅ (yoneda.op ⋙ coyoneda ⋙ (Functor.whiskeringLeft _ _ _).obj E) ⋙
+          (Functor.whiskeringLeft _ _ _).obj F ⋙ colim :=
         Iso.refl _
-  _ ≅ (CostructuredArrow.toOver yoneda A).op ⋙ coyoneda ⋙ (whiskeringLeft _ _ _).obj F ⋙ colim :=
-        isoWhiskerRight (CostructuredArrow.toOverCompCoyoneda _).symm _
+  _ ≅ (CostructuredArrow.toOver yoneda A).op ⋙ coyoneda ⋙
+          (Functor.whiskeringLeft _ _ _).obj F ⋙ colim :=
+        Functor.isoWhiskerRight (CostructuredArrow.toOverCompCoyoneda _).symm _
   _ ≅ (CostructuredArrow.toOver yoneda A).op ⋙ (F ⋙ yoneda).flip ⋙ colim :=
         Iso.refl _
   _ ≅ (CostructuredArrow.toOver yoneda A).op ⋙ colimit (F ⋙ yoneda) :=
-      isoWhiskerLeft _ (colimitIsoFlipCompColim _).symm
+      Functor.isoWhiskerLeft _ (colimitIsoFlipCompColim _).symm
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Comma/StructuredArrow/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/StructuredArrow/Basic.lean
@@ -327,8 +327,8 @@ def map₂CompMap₂Iso {C' : Type u₆} [Category.{v₆} C'] {D' : Type u₅} [
     (β' : R'' ⋙ G' ⟶ F' ⋙ R) :
     map₂ α' β' ⋙ map₂ α β ≅
     map₂ (α ≫ G.map α')
-      ((Functor.associator _ _ _).inv ≫ whiskerRight β' _ ≫ (Functor.associator _ _ _).hom ≫
-        whiskerLeft _ β ≫ (Functor.associator _ _ _).inv) :=
+      ((Functor.associator _ _ _).inv ≫ Functor.whiskerRight β' _ ≫ (Functor.associator _ _ _).hom ≫
+        Functor.whiskerLeft _ β ≫ (Functor.associator _ _ _).inv) :=
   NatIso.ofComponents (fun X => isoMk (Iso.refl _))
 
 end

--- a/Mathlib/CategoryTheory/Comma/StructuredArrow/Functor.lean
+++ b/Mathlib/CategoryTheory/Comma/StructuredArrow/Functor.lean
@@ -99,7 +99,8 @@ composed with fibers of `grothendieckProj L` are isomorphic to the projection `p
 @[simps!]
 def mapCompιCompGrothendieckProj {X Y : D} (f : X ⟶ Y) :
     CostructuredArrow.map f ⋙ Grothendieck.ι (functor L) Y ⋙ grothendieckProj L ≅ proj L X :=
-  isoWhiskerLeft (CostructuredArrow.map f) (ιCompGrothendieckPrecompFunctorToCommaCompFst L (𝟭 _) Y)
+  Functor.isoWhiskerLeft (CostructuredArrow.map f)
+    (ιCompGrothendieckPrecompFunctorToCommaCompFst L (𝟭 _) Y)
 
 /-- The functor `CostructuredArrow.pre` induces a natural transformation
 `CostructuredArrow.functor (S ⋙ T) ⟶ CostructuredArrow.functor T` for `S : C ⥤ D` and

--- a/Mathlib/CategoryTheory/ComposableArrows.lean
+++ b/Mathlib/CategoryTheory/ComposableArrows.lean
@@ -433,7 +433,7 @@ a functor `Fin (n + 1) ⥤ Fin (m + 1)`. -/
 def whiskerLeftFunctor (Φ : Fin (n + 1) ⥤ Fin (m + 1)) :
     ComposableArrows C m ⥤ ComposableArrows C n where
   obj F := F.whiskerLeft Φ
-  map f := CategoryTheory.whiskerLeft Φ f
+  map f := Functor.whiskerLeft Φ f
 
 /-- The functor `Fin n ⥤ Fin (n + 1)` which sends `i` to `i.succ`. -/
 @[simps]

--- a/Mathlib/CategoryTheory/Core.lean
+++ b/Mathlib/CategoryTheory/Core.lean
@@ -23,6 +23,8 @@ but this is not functorial with respect to `F`.
 
 namespace CategoryTheory
 
+open Functor
+
 universe v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
 
 -- morphism levels before object levels. See note [CategoryTheory universes].

--- a/Mathlib/CategoryTheory/Distributive/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Distributive/Monoidal.lean
@@ -253,7 +253,7 @@ attribute [local instance] endofunctorMonoidalCategory
 /-- The monoidal structure on the category of endofunctors is left distributive. -/
 instance isMonoidalLeftDistrib.of_endofunctors : IsMonoidalLeftDistrib (C ⥤ C) where
   preservesBinaryCoproducts_tensorLeft F :=
-    inferInstanceAs (PreservesColimitsOfShape _ ((whiskeringLeft C C C).obj F))
+    inferInstanceAs (PreservesColimitsOfShape _ ((Functor.whiskeringLeft C C C).obj F))
 
 end Endofunctors
 

--- a/Mathlib/CategoryTheory/Enriched/FunctorCategory.lean
+++ b/Mathlib/CategoryTheory/Enriched/FunctorCategory.lean
@@ -30,7 +30,7 @@ universe v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
 
 namespace CategoryTheory.Enriched.FunctorCategory
 
-open Category MonoidalCategory Limits
+open Category MonoidalCategory Limits Functor
 
 variable (V : Type u₁) [Category.{v₁} V] [MonoidalCategory V]
   {C : Type u₂} [Category.{v₂} C] {J : Type u₃} [Category.{v₃} J]

--- a/Mathlib/CategoryTheory/Extensive.lean
+++ b/Mathlib/CategoryTheory/Extensive.lean
@@ -360,7 +360,7 @@ theorem finitaryExtensive_of_reflective
   constructor
   intros X Y c hc
   apply (IsVanKampenColimit.precompose_isIso_iff
-    (isoWhiskerLeft _ (asIso adj.counit) ≪≫ Functor.rightUnitor _).hom).mp
+    (Functor.isoWhiskerLeft _ (asIso adj.counit) ≪≫ Functor.rightUnitor _).hom).mp
   have : ∀ (Z : C) (i : Discrete WalkingPair) (f : Z ⟶ (colimit.cocone (pair X Y ⋙ Gr)).pt),
         PreservesLimit (cospan f ((colimit.cocone (pair X Y ⋙ Gr)).ι.app i)) Gl := by
     have : pair X Y ⋙ Gr = pair (Gr.obj X) (Gr.obj Y) := by

--- a/Mathlib/CategoryTheory/FiberedCategory/BasedCategory.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/BasedCategory.lean
@@ -253,7 +253,7 @@ and natural transformations. -/
 @[simps]
 def whiskerLeft {𝒵 : BasedCategory.{v₄, u₄} 𝒮} (F : 𝒳 ⥤ᵇ 𝒴) {G H : 𝒴 ⥤ᵇ 𝒵} (α : G ⟶ H) :
     F ⋙ G ⟶ F ⋙ H where
-  toNatTrans := CategoryTheory.whiskerLeft F.toFunctor α.toNatTrans
+  toNatTrans := Functor.whiskerLeft F.toFunctor α.toNatTrans
   isHomLift' := fun a ↦ α.isHomLift (F.w_obj a)
 
 /-- Right-whiskering in the bicategory `BasedCategory` is given by whiskering the underlying
@@ -261,7 +261,7 @@ functors and natural transformations. -/
 @[simps]
 def whiskerRight {𝒵 : BasedCategory.{v₄, u₄} 𝒮} {F G : 𝒳 ⥤ᵇ 𝒴} (α : F ⟶ G) (H : 𝒴 ⥤ᵇ 𝒵) :
     F ⋙ H ⟶ G ⋙ H where
-  toNatTrans := CategoryTheory.whiskerRight α.toNatTrans H.toFunctor
+  toNatTrans := Functor.whiskerRight α.toNatTrans H.toFunctor
   isHomLift' := fun _ ↦ BasedFunctor.preserves_isHomLift _ _ _
 
 end

--- a/Mathlib/CategoryTheory/Filtered/Small.lean
+++ b/Mathlib/CategoryTheory/Filtered/Small.lean
@@ -156,7 +156,7 @@ noncomputable instance : (inclusion F).Full :=
 /-- The factorization through a small filtered category is in fact a factorization, up to natural
     isomorphism. -/
 noncomputable def factoringCompInclusion : factoring F ⋙ inclusion F ≅ F :=
-  isoWhiskerLeft _ (isoWhiskerRight (Equivalence.unitIso _).symm _)
+  Functor.isoWhiskerLeft _ (Functor.isoWhiskerRight (Equivalence.unitIso _).symm _)
 
 instance : IsFilteredOrEmpty (SmallFilteredIntermediate F) :=
   IsFilteredOrEmpty.of_equivalence (equivSmallModel _)
@@ -295,7 +295,7 @@ noncomputable instance : (inclusion F).Full :=
 /-- The factorization through a small filtered category is in fact a factorization, up to natural
     isomorphism. -/
 noncomputable def factoringCompInclusion : factoring F ⋙ inclusion F ≅ F :=
-  isoWhiskerLeft _ (isoWhiskerRight (Equivalence.unitIso _).symm _)
+  Functor.isoWhiskerLeft _ (Functor.isoWhiskerRight (Equivalence.unitIso _).symm _)
 
 instance : IsCofilteredOrEmpty (SmallCofilteredIntermediate F) :=
   IsCofilteredOrEmpty.of_equivalence (equivSmallModel _)

--- a/Mathlib/CategoryTheory/Functor/Currying.lean
+++ b/Mathlib/CategoryTheory/Functor/Currying.lean
@@ -18,6 +18,8 @@ and verify that they provide an equivalence of categories
 
 namespace CategoryTheory
 
+namespace Functor
+
 universe v₁ v₂ v₃ v₄ v₅ u₁ u₂ u₃ u₄ u₅
 
 variable {B : Type u₁} [Category.{v₁} B] {C : Type u₂} [Category.{v₂} C] {D : Type u₃}
@@ -127,8 +129,6 @@ applying `whiskeringRight` and currying back
 def whiskeringRight₂ : (C ⥤ D ⥤ E) ⥤ (B ⥤ C) ⥤ (B ⥤ D) ⥤ B ⥤ E :=
   uncurry ⋙
     whiskeringRight _ _ _ ⋙ (whiskeringLeft _ _ _).obj (prodFunctorToFunctorProd _ _ _) ⋙ curry
-
-namespace Functor
 
 variable {B C D E}
 

--- a/Mathlib/CategoryTheory/Functor/CurryingThree.lean
+++ b/Mathlib/CategoryTheory/Functor/CurryingThree.lean
@@ -18,6 +18,8 @@ We study the equivalence of categories
 
 namespace CategoryTheory
 
+namespace Functor
+
 variable {C₁ C₂ C₁₂ C₃ C₂₃ D₁ D₂ D₃ E : Type*}
   [Category C₁] [Category C₂] [Category C₃] [Category C₁₂] [Category C₂₃]
   [Category D₁] [Category D₂] [Category D₃] [Category E]
@@ -96,5 +98,7 @@ def bifunctorComp₂₃Iso (F : C₁ ⥤ C₂₃ ⥤ E) (G₂₃ : C₂ ⥤ C₃
       uncurry.obj (uncurry.obj G₂₃ ⋙ F.flip).flip)) :=
   NatIso.ofComponents (fun _ ↦ NatIso.ofComponents (fun _ ↦
     NatIso.ofComponents (fun _ ↦ Iso.refl _)))
+
+end Functor
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Functor/Flat.lean
+++ b/Mathlib/CategoryTheory/Functor/Flat.lean
@@ -203,9 +203,11 @@ theorem uniq {K : J ⥤ C} {c : Cone K} (hc : IsLimit c) (s : Cone (K ⋙ F))
   let α₂ : (F.mapCone c).toStructuredArrow ⋙ map f₂ ⟶ s.toStructuredArrow :=
     { app := fun X => eqToHom (by simp [← h₂]) }
   let c₁ : Cone (s.toStructuredArrow ⋙ pre s.pt K F) :=
-    (Cones.postcompose (whiskerRight α₁ (pre s.pt K F) :)).obj (c.toStructuredArrowCone F f₁)
+    (Cones.postcompose (Functor.whiskerRight α₁ (pre s.pt K F) :)).obj
+      (c.toStructuredArrowCone F f₁)
   let c₂ : Cone (s.toStructuredArrow ⋙ pre s.pt K F) :=
-    (Cones.postcompose (whiskerRight α₂ (pre s.pt K F) :)).obj (c.toStructuredArrowCone F f₂)
+    (Cones.postcompose (Functor.whiskerRight α₂ (pre s.pt K F) :)).obj
+      (c.toStructuredArrowCone F f₂)
   -- The two cones can then be combined and we may obtain a cone over the two cones since
   -- `StructuredArrow s.pt F` is cofiltered.
   let c₀ := IsCofiltered.cone (biconeMk _ c₁ c₂)
@@ -295,7 +297,7 @@ The evaluation of `F.lan` at `X` is the colimit over the costructured arrows ove
 noncomputable def lanEvaluationIsoColim (F : C ⥤ D) (X : D)
     [∀ X : D, HasColimitsOfShape (CostructuredArrow F X) E] :
     F.lan ⋙ (evaluation D E).obj X ≅
-      (whiskeringLeft _ _ E).obj (CostructuredArrow.proj F X) ⋙ colim :=
+      (Functor.whiskeringLeft _ _ E).obj (CostructuredArrow.proj F X) ⋙ colim :=
   NatIso.ofComponents (fun G =>
     IsColimit.coconePointUniqueUpToIso
     (Functor.isPointwiseLeftKanExtensionLeftKanExtensionUnit F G X)
@@ -309,7 +311,7 @@ noncomputable def lanEvaluationIsoColim (F : C ⥤ D) (X : D)
       simp only [Category.assoc] at h₁ ⊢
       simp only [Functor.lan, Functor.lanUnit] at h₂ ⊢
       rw [reassoc_of% h₁, NatTrans.naturality_assoc, ← reassoc_of% h₂, h₁,
-        ι_colimMap, whiskerLeft_app]
+        ι_colimMap, Functor.whiskerLeft_app]
       rfl)
 
 variable [HasForget.{u₁} E] [HasLimits E] [HasColimits E]

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -32,7 +32,7 @@ are obtained as `leftKanExtension L F` and `rightKanExtension L F`.
 
 namespace CategoryTheory
 
-open Category Limits
+open Category Limits Functor
 
 namespace Functor
 
@@ -363,10 +363,10 @@ variable {F F'}
 
 lemma isLeftKanExtension_iff_postcomp₁ (α : F ⟶ L' ⋙ F') :
     F'.IsLeftKanExtension α ↔ (G ⋙ F').IsLeftKanExtension
-      (α ≫ whiskerRight e.inv _ ≫ (Functor.associator _ _ _).hom) := by
+      (α ≫ whiskerRight e.inv _ ≫ (associator _ _ _).hom) := by
   let eq : (LeftExtension.mk _ α).IsUniversal ≃
       (LeftExtension.mk _
-        (α ≫ whiskerRight e.inv _ ≫ (Functor.associator _ _ _).hom)).IsUniversal :=
+        (α ≫ whiskerRight e.inv _ ≫ (associator _ _ _).hom)).IsUniversal :=
     (LeftExtension.isUniversalPostcomp₁Equiv G e F _).trans
     (IsInitial.equivOfIso (StructuredArrow.isoMk (Iso.refl _)))
   constructor
@@ -375,10 +375,10 @@ lemma isLeftKanExtension_iff_postcomp₁ (α : F ⟶ L' ⋙ F') :
 
 lemma isRightKanExtension_iff_postcomp₁ (α : L' ⋙ F' ⟶ F) :
     F'.IsRightKanExtension α ↔ (G ⋙ F').IsRightKanExtension
-      ((Functor.associator _ _ _).inv ≫ whiskerRight e.hom F' ≫ α) := by
+      ((associator _ _ _).inv ≫ whiskerRight e.hom F' ≫ α) := by
   let eq : (RightExtension.mk _ α).IsUniversal ≃
     (RightExtension.mk _
-      ((Functor.associator _ _ _).inv ≫ whiskerRight e.hom F' ≫ α)).IsUniversal :=
+      ((associator _ _ _).inv ≫ whiskerRight e.hom F' ≫ α)).IsUniversal :=
   (RightExtension.isUniversalPostcomp₁Equiv G e F _).trans
     (IsTerminal.equivOfIso (CostructuredArrow.isoMk (Iso.refl _)))
   constructor
@@ -399,7 +399,7 @@ def LeftExtension.postcompose₂ : LeftExtension L F ⥤ LeftExtension L (F ⋙ 
   StructuredArrow.map₂
     (F := (whiskeringRight _ _ _).obj G)
     (G := (whiskeringRight _ _ _).obj G)
-    (𝟙 _) ({app _ := (Functor.associator _ _ _).hom})
+    (𝟙 _) ({app _ := (associator _ _ _).hom})
 
 /-- Given a right extension `E` of `F : C ⥤ H` along `L : C ⥤ D` and a functor `G : H ⥤ D'`,
 `E.postcompose₂ G` is the extension of `F ⋙ G` along `L` obtained by whiskering by `G`
@@ -409,7 +409,7 @@ def RightExtension.postcompose₂ : RightExtension L F ⥤ RightExtension L (F �
   CostructuredArrow.map₂
     (F := (whiskeringRight _ _ _).obj G)
     (G := (whiskeringRight _ _ _).obj G)
-    ({app _ := Functor.associator _ _ _|>.inv}) (𝟙 _)
+    ({app _ := associator _ _ _|>.inv}) (𝟙 _)
 
 variable {L F} {F' : D ⥤ H}
 /-- An isomorphism to describe the action of `LeftExtension.postcompose₂` on terms of the form
@@ -417,7 +417,7 @@ variable {L F} {F' : D ⥤ H}
 @[simps!]
 def LeftExtension.postcompose₂ObjMkIso (α : F ⟶ L ⋙ F') :
     (LeftExtension.postcompose₂ L F G).obj (.mk F' α) ≅
-    .mk (F' ⋙ G) <| CategoryTheory.whiskerRight α G ≫ (Functor.associator _ _ _).hom :=
+    .mk (F' ⋙ G) <| whiskerRight α G ≫ (associator _ _ _).hom :=
   StructuredArrow.isoMk (.refl _)
 
 /-- An isomorphism to describe the action of `RightExtension.postcompose₂` on terms of the form
@@ -425,8 +425,7 @@ def LeftExtension.postcompose₂ObjMkIso (α : F ⟶ L ⋙ F') :
 @[simps!]
 def RightExtension.postcompose₂ObjMkIso (α : L ⋙ F' ⟶ F) :
     (RightExtension.postcompose₂ L F G).obj (.mk F' α) ≅
-    .mk (F' ⋙ G) <| (Functor.associator _ _ _).inv ≫
-      CategoryTheory.whiskerRight α G :=
+    .mk (F' ⋙ G) <| (associator _ _ _).inv ≫ whiskerRight α G :=
   CostructuredArrow.isoMk (.refl _)
 
 end
@@ -471,9 +470,9 @@ variable {F L}
 
 lemma isLeftKanExtension_iff_precomp (α : F ⟶ L ⋙ F') :
     F'.IsLeftKanExtension α ↔ F'.IsLeftKanExtension
-      (whiskerLeft G α ≫ (Functor.associator _ _ _).inv) := by
+      (whiskerLeft G α ≫ (associator _ _ _).inv) := by
   let eq : (LeftExtension.mk _ α).IsUniversal ≃ (LeftExtension.mk _
-      (whiskerLeft G α ≫ (Functor.associator _ _ _).inv)).IsUniversal :=
+      (whiskerLeft G α ≫ (associator _ _ _).inv)).IsUniversal :=
     (LeftExtension.isUniversalPrecompEquiv L F G _).trans
     (IsInitial.equivOfIso (StructuredArrow.isoMk (Iso.refl _)))
   constructor
@@ -482,9 +481,9 @@ lemma isLeftKanExtension_iff_precomp (α : F ⟶ L ⋙ F') :
 
 lemma isRightKanExtension_iff_precomp (α : L ⋙ F' ⟶ F) :
     F'.IsRightKanExtension α ↔
-      F'.IsRightKanExtension ((Functor.associator _ _ _).hom ≫ whiskerLeft G α) := by
+      F'.IsRightKanExtension ((associator _ _ _).hom ≫ whiskerLeft G α) := by
   let eq : (RightExtension.mk _ α).IsUniversal ≃ (RightExtension.mk _
-      ((Functor.associator _ _ _).hom ≫ whiskerLeft G α)).IsUniversal :=
+      ((associator _ _ _).hom ≫ whiskerLeft G α)).IsUniversal :=
     (RightExtension.isUniversalPrecompEquiv L F G _).trans
     (IsTerminal.equivOfIso (CostructuredArrow.isoMk (Iso.refl _)))
   constructor

--- a/Mathlib/CategoryTheory/Functor/TwoSquare.lean
+++ b/Mathlib/CategoryTheory/Functor/TwoSquare.lean
@@ -34,7 +34,7 @@ universe v₁ v₂ v₃ v₄ v₅ v₆ v₇ v₈ v₉ u₁ u₂ u₃ u₄ u₅ u
 
 namespace CategoryTheory
 
-open Category
+open Category Functor
 
 variable {C₁ : Type u₁} {C₂ : Type u₂} {C₃ : Type u₃} {C₄ : Type u₄}
   [Category.{v₁} C₁] [Category.{v₂} C₂] [Category.{v₃} C₃] [Category.{v₄} C₄]
@@ -122,8 +122,8 @@ variable {C₅ : Type u₅} {C₆ : Type u₆} {C₇ : Type u₇} {C₈ : Type u
 @[simps!]
 def hComp (w : TwoSquare T L R B) (w' : TwoSquare T' R R' B') :
     TwoSquare (T ⋙ T') L R' (B ⋙ B') :=
-  .mk _ _ _ _ <| (Functor.associator _ _ _).hom ≫ (whiskerLeft T w'.natTrans) ≫
-    (Functor.associator _ _ _).inv ≫ (whiskerRight w.natTrans B') ≫ (Functor.associator _ _ _).hom
+  .mk _ _ _ _ <| (associator _ _ _).hom ≫ (whiskerLeft T w'.natTrans) ≫
+    (associator _ _ _).inv ≫ (whiskerRight w.natTrans B') ≫ (associator _ _ _).hom
 
 /-- Notation for the horizontal composition of 2-squares. -/
 scoped infixr:80 " ≫ₕ " => hComp -- type as \gg\_h
@@ -132,8 +132,8 @@ scoped infixr:80 " ≫ₕ " => hComp -- type as \gg\_h
 @[simps!]
 def vComp (w : TwoSquare T L R B) (w' : TwoSquare B L' R'' B'') :
     TwoSquare T (L ⋙ L') (R ⋙ R'') B'' :=
-  .mk _ _ _ _ <| (Functor.associator _ _ _).hom ≫ (whiskerRight w.natTrans R'') ≫
-    (Functor.associator _ _ _).inv ≫ (whiskerLeft L w'.natTrans) ≫ (Functor.associator _ _ _).hom
+  .mk _ _ _ _ <| (associator _ _ _).hom ≫ (whiskerRight w.natTrans R'') ≫
+    (associator _ _ _).inv ≫ (whiskerLeft L w'.natTrans) ≫ (associator _ _ _).hom
 
 /-- Notation for the vertical composition of 2-squares. -/
 scoped infixr:80 " ≫ᵥ " => vComp -- type as \gg\_v
@@ -149,8 +149,8 @@ lemma hCompVCompHComp (w₁ : TwoSquare T L R B) (w₂ : TwoSquare T' R R' B')
     (w₁ ≫ₕ w₂) ≫ᵥ (w₃ ≫ₕ w₄) = (w₁ ≫ᵥ w₃) ≫ₕ (w₂ ≫ᵥ w₄) := by
   unfold hComp vComp whiskerLeft whiskerRight
   ext c
-  simp only [Functor.comp_obj, NatTrans.comp_app, Functor.associator_hom_app,
-    Functor.associator_inv_app, comp_id, id_comp, Functor.map_comp, assoc]
+  simp only [comp_obj, NatTrans.comp_app, associator_hom_app, associator_inv_app, comp_id, id_comp,
+    map_comp, assoc]
   slice_rhs 2 3 =>
     rw [← Functor.comp_map _ B₃, ← w₄.naturality]
   simp

--- a/Mathlib/CategoryTheory/Generator/Preadditive.lean
+++ b/Mathlib/CategoryTheory/Generator/Preadditive.lean
@@ -48,7 +48,7 @@ theorem Preadditive.isCoseparator_iff (G : C) :
 theorem isSeparator_iff_faithful_preadditiveCoyoneda (G : C) :
     IsSeparator G ↔ (preadditiveCoyoneda.obj (op G)).Faithful := by
   rw [isSeparator_iff_faithful_coyoneda_obj, ← whiskering_preadditiveCoyoneda, Functor.comp_obj,
-    whiskeringRight_obj_obj]
+    Functor.whiskeringRight_obj_obj]
   exact ⟨fun h => Functor.Faithful.of_comp _ (forget AddCommGrp),
     fun h => Functor.Faithful.comp _ _⟩
 
@@ -61,7 +61,7 @@ theorem isSeparator_iff_faithful_preadditiveCoyonedaObj (G : C) :
 theorem isCoseparator_iff_faithful_preadditiveYoneda (G : C) :
     IsCoseparator G ↔ (preadditiveYoneda.obj G).Faithful := by
   rw [isCoseparator_iff_faithful_yoneda_obj, ← whiskering_preadditiveYoneda, Functor.comp_obj,
-    whiskeringRight_obj_obj]
+    Functor.whiskeringRight_obj_obj]
   exact ⟨fun h => Functor.Faithful.of_comp _ (forget AddCommGrp),
     fun h => Functor.Faithful.comp _ _⟩
 

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -52,6 +52,8 @@ universe w u v u₁ v₁ u₂ v₂
 
 namespace CategoryTheory
 
+open Functor
+
 variable {C : Type u} [Category.{v} C]
 variable {D : Type u₁} [Category.{v₁} D]
 variable (F : C ⥤ Cat.{v₂, u₂})

--- a/Mathlib/CategoryTheory/GuitartExact/VerticalComposition.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/VerticalComposition.lean
@@ -123,18 +123,18 @@ lemma vComp_iff_of_equivalences (eL : C₂ ≌ C₃) (eR : D₂ ≌ D₃)
     letI : CatCommSq H₃ eL.inverse eR.inverse H₂ := CatCommSq.vInvEquiv _ _ _ _ inferInstance
     let w'' := CatCommSq.iso H₃ eL.inverse eR.inverse H₂
     let α : (L₁ ⋙ eL.functor) ⋙ eL.inverse ≅ L₁ :=
-      Functor.associator _ _ _ ≪≫ isoWhiskerLeft L₁ eL.unitIso.symm ≪≫ L₁.rightUnitor
+      Functor.associator _ _ _ ≪≫ Functor.isoWhiskerLeft L₁ eL.unitIso.symm ≪≫ L₁.rightUnitor
     let β : (R₁ ⋙ eR.functor) ⋙ eR.inverse ≅ R₁ :=
-      Functor.associator _ _ _ ≪≫ isoWhiskerLeft R₁ eR.unitIso.symm ≪≫ R₁.rightUnitor
+      Functor.associator _ _ _ ≪≫ Functor.isoWhiskerLeft R₁ eR.unitIso.symm ≪≫ R₁.rightUnitor
     have : w = (w ≫ᵥ w'.hom).vComp' w''.hom α β := by
       ext X₁
       simp? [w'', α, β] says
-        simp only [Functor.comp_obj, vComp'_app, Iso.trans_inv, isoWhiskerLeft_inv, Iso.symm_inv,
-          assoc, NatTrans.comp_app, Functor.id_obj, Functor.rightUnitor_inv_app,
-          CategoryTheory.whiskerLeft_app, Functor.associator_inv_app, comp_id, id_comp, vComp_app,
+        simp only [Functor.comp_obj, vComp'_app, Iso.trans_inv, Functor.isoWhiskerLeft_inv,
+          Iso.symm_inv, assoc, NatTrans.comp_app, Functor.id_obj, Functor.rightUnitor_inv_app,
+          Functor.whiskerLeft_app, Functor.associator_inv_app, comp_id, id_comp, vComp_app,
           Functor.map_comp, Equivalence.inv_fun_map, CatCommSq.vInv_iso_hom_app, Iso.trans_hom,
-          isoWhiskerLeft_hom, Iso.symm_hom, Functor.associator_hom_app, Functor.rightUnitor_hom_app,
-          Iso.hom_inv_id_app_assoc, w'', α, β, this]
+          Functor.isoWhiskerLeft_hom, Iso.symm_hom, Functor.associator_hom_app,
+          Functor.rightUnitor_hom_app, Iso.hom_inv_id_app_assoc, w'', this, α, β]
       simp only [hw', ← eR.inverse.map_comp_assoc]
       rw [Equivalence.counitInv_app_functor, ← Functor.comp_map, ← NatTrans.naturality_assoc]
       simp [← H₂.map_comp]

--- a/Mathlib/CategoryTheory/Idempotents/FunctorCategories.lean
+++ b/Mathlib/CategoryTheory/Idempotents/FunctorCategories.lean
@@ -133,7 +133,7 @@ equals the functor `(J ⥤ C) ⥤ (J ⥤ Karoubi C)` given by the composition wi
 `toKaroubi C : C ⥤ Karoubi C`. -/
 theorem toKaroubi_comp_karoubiFunctorCategoryEmbedding :
     toKaroubi _ ⋙ karoubiFunctorCategoryEmbedding J C =
-      (whiskeringRight J _ _).obj (toKaroubi C) := by
+      (Functor.whiskeringRight J _ _).obj (toKaroubi C) := by
   apply Functor.ext
   · intro X Y f
     ext j

--- a/Mathlib/CategoryTheory/Idempotents/FunctorExtension.lean
+++ b/Mathlib/CategoryTheory/Idempotents/FunctorExtension.lean
@@ -24,7 +24,7 @@ namespace CategoryTheory
 
 namespace Idempotents
 
-open Category Karoubi
+open Category Karoubi Functor
 
 variable {C D E : Type*} [Category C] [Category D] [Category E]
 

--- a/Mathlib/CategoryTheory/IsConnected.lean
+++ b/Mathlib/CategoryTheory/IsConnected.lean
@@ -46,7 +46,7 @@ universe w₁ w₂ v₁ v₂ u₁ u₂
 
 noncomputable section
 
-open CategoryTheory.Category
+open CategoryTheory.Category CategoryTheory.Functor
 
 open Opposite
 

--- a/Mathlib/CategoryTheory/Join/Basic.lean
+++ b/Mathlib/CategoryTheory/Join/Basic.lean
@@ -37,6 +37,8 @@ universe v₁ v₂ v₃ v₄ v₅ v₆ u₁ u₂ u₃ u₄ u₅ u₆
 
 namespace CategoryTheory
 
+open Functor
+
 /-- Elements of `Join C D` are either elements of `C` or elements of `D`. -/
 -- Impl. : We are not defining it as a type alias for `C ⊕ D` so that we can have
 -- aesop to call cases on `Join C D`

--- a/Mathlib/CategoryTheory/Join/Opposites.lean
+++ b/Mathlib/CategoryTheory/Join/Opposites.lean
@@ -15,7 +15,7 @@ The equivalence gets characterized in both directions.
 -/
 
 namespace CategoryTheory.Join
-open Opposite
+open Opposite Functor
 
 universe v₁ v₂ u₁ u₂
 
@@ -76,13 +76,13 @@ lemma opEquiv_functor_map_op_edge (c : C) (d : D) :
 @[simps!]
 def InclLeftCompRightOpOpEquivFunctor :
     inclLeft C D ⋙ (opEquiv C D).functor.rightOp ≅ (inclRight _ _).rightOp :=
-  isoWhiskerLeft _ (Functor.leftOpRightOpIso _) ≪≫ mkFunctorLeft _ _ _
+  isoWhiskerLeft _ (leftOpRightOpIso _) ≪≫ mkFunctorLeft _ _ _
 
 /-- Characterize (up to a rightOp) the action of the right inclusion on `Join.opEquivFunctor`. -/
 @[simps!]
 def InclRightCompRightOpOpEquivFunctor :
     inclRight C D ⋙ (opEquiv C D).functor.rightOp ≅ (inclLeft _ _).rightOp :=
-  isoWhiskerLeft _ (Functor.leftOpRightOpIso _) ≪≫ mkFunctorRight _ _ _
+  isoWhiskerLeft _ (leftOpRightOpIso _) ≪≫ mkFunctorRight _ _ _
 
 variable {D} in
 @[simp]

--- a/Mathlib/CategoryTheory/Join/Pseudofunctor.lean
+++ b/Mathlib/CategoryTheory/Join/Pseudofunctor.lean
@@ -19,7 +19,7 @@ universe v₁ v₂ u₁ u₂
 
 namespace CategoryTheory.Join
 
-open Bicategory
+open Bicategory Functor
 
 -- The proof gets too slow if we put it in a single `pseudofunctor` constructor,
 -- so we break down the component proofs for the pseudofunctors over several lemmas.

--- a/Mathlib/CategoryTheory/Limits/ColimitLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/ColimitLimit.lean
@@ -26,7 +26,7 @@ is that when `C = Type`, filtered colimits commute with finite limits.
 
 universe v₁ v₂ v u₁ u₂ u
 
-open CategoryTheory
+open CategoryTheory Functor
 
 namespace CategoryTheory.Limits
 

--- a/Mathlib/CategoryTheory/Limits/Comma.lean
+++ b/Mathlib/CategoryTheory/Limits/Comma.lean
@@ -23,7 +23,7 @@ The duals of all the above are also given.
 
 namespace CategoryTheory
 
-open Category Limits
+open Category Limits Functor
 
 universe w' w v₁ v₂ v₃ u₁ u₂ u₃
 

--- a/Mathlib/CategoryTheory/Limits/Constructions/Filtered.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/Filtered.lean
@@ -160,7 +160,7 @@ end
 with `colim`. -/
 def liftToFinsetEvaluationIso [HasFiniteCoproducts C] (I : Finset (Discrete α)) :
     liftToFinset C α ⋙ (evaluation _ _).obj I ≅
-    (whiskeringLeft _ _ _).obj (Discrete.functor (·.val)) ⋙ colim (J := Discrete I) :=
+    (Functor.whiskeringLeft _ _ _).obj (Discrete.functor (·.val)) ⋙ colim (J := Discrete I) :=
   NatIso.ofComponents (fun _ => HasColimit.isoOfNatIso (Discrete.natIso fun _ => Iso.refl _))
     fun _ => by dsimp; ext; simp
 
@@ -253,7 +253,7 @@ def liftToFinsetLimIso [HasLimitsOfShape (Finset (Discrete α))ᵒᵖ C]
 with `colim`. -/
 def liftToFinsetEvaluationIso (I : Finset (Discrete α)) :
     liftToFinset C α ⋙ (evaluation _ _).obj ⟨I⟩ ≅
-    (whiskeringLeft _ _ _).obj (Discrete.functor (·.val)) ⋙ lim (J := Discrete I) :=
+    (Functor.whiskeringLeft _ _ _).obj (Discrete.functor (·.val)) ⋙ lim (J := Discrete I) :=
   NatIso.ofComponents (fun _ => HasLimit.isoOfNatIso (Discrete.natIso fun _ => Iso.refl _))
     fun _ => by dsimp; ext; simp
 

--- a/Mathlib/CategoryTheory/Limits/Creates.lean
+++ b/Mathlib/CategoryTheory/Limits/Creates.lean
@@ -15,7 +15,7 @@ limits for `K`.
 -/
 
 
-open CategoryTheory CategoryTheory.Limits
+open CategoryTheory CategoryTheory.Limits CategoryTheory.Functor
 
 noncomputable section
 

--- a/Mathlib/CategoryTheory/Limits/ExactFunctor.lean
+++ b/Mathlib/CategoryTheory/Limits/ExactFunctor.lean
@@ -225,11 +225,11 @@ variable (C D E)
 /-- Whiskering a left exact functor by a left exact functor yields a left exact functor. -/
 @[simps! obj_obj obj_map map_app_app]
 def LeftExactFunctor.whiskeringLeft : (C ⥤ₗ D) ⥤ (D ⥤ₗ E) ⥤ (C ⥤ₗ E) where
-  obj F := ObjectProperty.lift _ (forget _ _ ⋙ (CategoryTheory.whiskeringLeft C D E).obj F.obj)
+  obj F := ObjectProperty.lift _ (forget _ _ ⋙ (Functor.whiskeringLeft C D E).obj F.obj)
     (fun G => by dsimp; exact comp_preservesFiniteLimits _ _)
   map {F G} η :=
-    { app := fun H => ((CategoryTheory.whiskeringLeft C D E).map η).app H.obj
-      naturality := fun _ _ f => ((CategoryTheory.whiskeringLeft C D E).map η).naturality f }
+    { app := fun H => ((Functor.whiskeringLeft C D E).map η).app H.obj
+      naturality := fun _ _ f => ((Functor.whiskeringLeft C D E).map η).naturality f }
   map_id X := by
     rw [ObjectProperty.FullSubcategory.id_def]
     aesop_cat
@@ -240,20 +240,20 @@ def LeftExactFunctor.whiskeringLeft : (C ⥤ₗ D) ⥤ (D ⥤ₗ E) ⥤ (C ⥤�
 /-- Whiskering a left exact functor by a left exact functor yields a left exact functor. -/
 @[simps! obj_obj obj_map map_app_app]
 def LeftExactFunctor.whiskeringRight : (D ⥤ₗ E) ⥤ (C ⥤ₗ D) ⥤ (C ⥤ₗ E) where
-  obj F := ObjectProperty.lift _ (forget _ _ ⋙ (CategoryTheory.whiskeringRight C D E).obj F.obj)
+  obj F := ObjectProperty.lift _ (forget _ _ ⋙ (Functor.whiskeringRight C D E).obj F.obj)
     (fun G => by dsimp; exact comp_preservesFiniteLimits _ _)
   map {F G} η :=
-    { app := fun H => ((CategoryTheory.whiskeringRight C D E).map η).app H.obj
-      naturality := fun _ _ f => ((CategoryTheory.whiskeringRight C D E).map η).naturality f }
+    { app := fun H => ((Functor.whiskeringRight C D E).map η).app H.obj
+      naturality := fun _ _ f => ((Functor.whiskeringRight C D E).map η).naturality f }
 
 /-- Whiskering a right exact functor by a right exact functor yields a right exact functor. -/
 @[simps! obj_obj obj_map map_app_app]
 def RightExactFunctor.whiskeringLeft : (C ⥤ᵣ D) ⥤ (D ⥤ᵣ E) ⥤ (C ⥤ᵣ E) where
-  obj F := ObjectProperty.lift _ (forget _ _ ⋙ (CategoryTheory.whiskeringLeft C D E).obj F.obj)
+  obj F := ObjectProperty.lift _ (forget _ _ ⋙ (Functor.whiskeringLeft C D E).obj F.obj)
     (fun G => by dsimp; exact comp_preservesFiniteColimits _ _)
   map {F G} η :=
-    { app := fun H => ((CategoryTheory.whiskeringLeft C D E).map η).app H.obj
-      naturality := fun _ _ f => ((CategoryTheory.whiskeringLeft C D E).map η).naturality f }
+    { app := fun H => ((Functor.whiskeringLeft C D E).map η).app H.obj
+      naturality := fun _ _ f => ((Functor.whiskeringLeft C D E).map η).naturality f }
   map_id X := by
     rw [ObjectProperty.FullSubcategory.id_def]
     aesop_cat
@@ -264,21 +264,21 @@ def RightExactFunctor.whiskeringLeft : (C ⥤ᵣ D) ⥤ (D ⥤ᵣ E) ⥤ (C ⥤�
 /-- Whiskering a right exact functor by a right exact functor yields a right exact functor. -/
 @[simps! obj_obj obj_map map_app_app]
 def RightExactFunctor.whiskeringRight : (D ⥤ᵣ E) ⥤ (C ⥤ᵣ D) ⥤ (C ⥤ᵣ E) where
-  obj F := ObjectProperty.lift _ (forget _ _ ⋙ (CategoryTheory.whiskeringRight C D E).obj F.obj)
+  obj F := ObjectProperty.lift _ (forget _ _ ⋙ (Functor.whiskeringRight C D E).obj F.obj)
     (fun G => by dsimp; exact comp_preservesFiniteColimits _ _)
   map {F G} η :=
-    { app := fun H => ((CategoryTheory.whiskeringRight C D E).map η).app H.obj
-      naturality := fun _ _ f => ((CategoryTheory.whiskeringRight C D E).map η).naturality f }
+    { app := fun H => ((Functor.whiskeringRight C D E).map η).app H.obj
+      naturality := fun _ _ f => ((Functor.whiskeringRight C D E).map η).naturality f }
 
 /-- Whiskering an exact functor by an exact functor yields an exact functor. -/
 @[simps! obj_obj obj_map map_app_app]
 def ExactFunctor.whiskeringLeft : (C ⥤ₑ D) ⥤ (D ⥤ₑ E) ⥤ (C ⥤ₑ E) where
-  obj F := ObjectProperty.lift _ (forget _ _ ⋙ (CategoryTheory.whiskeringLeft C D E).obj F.obj)
+  obj F := ObjectProperty.lift _ (forget _ _ ⋙ (Functor.whiskeringLeft C D E).obj F.obj)
     (fun G => ⟨by dsimp; exact comp_preservesFiniteLimits _ _,
       by dsimp; exact comp_preservesFiniteColimits _ _⟩)
   map {F G} η :=
-    { app := fun H => ((CategoryTheory.whiskeringLeft C D E).map η).app H.obj
-      naturality := fun _ _ f => ((CategoryTheory.whiskeringLeft C D E).map η).naturality f }
+    { app := fun H => ((Functor.whiskeringLeft C D E).map η).app H.obj
+      naturality := fun _ _ f => ((Functor.whiskeringLeft C D E).map η).naturality f }
   map_id X := by
     rw [ObjectProperty.FullSubcategory.id_def]
     aesop_cat
@@ -289,12 +289,12 @@ def ExactFunctor.whiskeringLeft : (C ⥤ₑ D) ⥤ (D ⥤ₑ E) ⥤ (C ⥤ₑ E)
 /-- Whiskering an exact functor by an exact functor yields an exact functor. -/
 @[simps! obj_obj obj_map map_app_app]
 def ExactFunctor.whiskeringRight : (D ⥤ₑ E) ⥤ (C ⥤ₑ D) ⥤ (C ⥤ₑ E) where
-  obj F := ObjectProperty.lift _ (forget _ _ ⋙ (CategoryTheory.whiskeringRight C D E).obj F.obj)
+  obj F := ObjectProperty.lift _ (forget _ _ ⋙ (Functor.whiskeringRight C D E).obj F.obj)
     (fun G => ⟨by dsimp; exact comp_preservesFiniteLimits _ _,
       by dsimp; exact comp_preservesFiniteColimits _ _⟩)
   map {F G} η :=
-    { app := fun H => ((CategoryTheory.whiskeringRight C D E).map η).app H.obj
-      naturality := fun _ _ f => ((CategoryTheory.whiskeringRight C D E).map η).naturality f }
+    { app := fun H => ((Functor.whiskeringRight C D E).map η).app H.obj
+      naturality := fun _ _ f => ((Functor.whiskeringRight C D E).map η).naturality f }
 
 end
 

--- a/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean
@@ -32,7 +32,7 @@ assert_not_exists map_ne_zero MonoidWithZero
 universe w v₁ v₂ v u₁ u₂ u
 
 open CategoryTheory CategoryTheory.Category CategoryTheory.Limits.Types
-  CategoryTheory.Limits.Types.FilteredColimit
+  CategoryTheory.Limits.Types.FilteredColimit CategoryTheory.Functor
 
 namespace CategoryTheory.Limits
 

--- a/Mathlib/CategoryTheory/Limits/Fubini.lean
+++ b/Mathlib/CategoryTheory/Limits/Fubini.lean
@@ -35,7 +35,7 @@ All statements have their counterpart for colimits.
 -/
 
 
-open CategoryTheory
+open CategoryTheory Functor
 
 namespace CategoryTheory.Limits
 

--- a/Mathlib/CategoryTheory/Limits/FunctorCategory/EpiMono.lean
+++ b/Mathlib/CategoryTheory/Limits/FunctorCategory/EpiMono.lean
@@ -20,7 +20,7 @@ universe v v' v'' u u' u''
 
 namespace CategoryTheory
 
-open Limits
+open Limits Functor
 
 variable {K : Type u} [Category.{v} K] {C : Type u'} [Category.{v'} C]
   {D : Type u''} [Category.{v''} D] {F G : K ⥤ C} (f : F ⟶ G)

--- a/Mathlib/CategoryTheory/Limits/IndYoneda.lean
+++ b/Mathlib/CategoryTheory/Limits/IndYoneda.lean
@@ -142,7 +142,7 @@ of `F` evaluated at `D`. This variant is for contravariant diagrams, see
 noncomputable def colimitCoyonedaHomIsoLimit :
     (colimit (D.rightOp ⋙ coyoneda) ⟶ F) ≅ limit (D ⋙ F ⋙ uliftFunctor.{u₁}) :=
   colimitHomIsoLimitYoneda _ F ≪≫
-    HasLimit.isoOfNatIso (isoWhiskerLeft (D ⋙ Prod.sectL C F) (coyonedaLemma C))
+    HasLimit.isoOfNatIso (Functor.isoWhiskerLeft (D ⋙ Prod.sectL C F) (coyonedaLemma C))
 
 @[simp]
 lemma colimitCoyonedaHomIsoLimit_π_apply (f : colimit (D.rightOp ⋙ coyoneda) ⟶ F) (i : I) :
@@ -196,7 +196,7 @@ contravariant version. -/
 noncomputable def colimitYonedaHomIsoLimit :
       (colimit (D.unop ⋙ yoneda) ⟶ F) ≅ limit (D ⋙ F ⋙ uliftFunctor.{u₁}) :=
   colimitHomIsoLimitYoneda _ _ ≪≫
-    HasLimit.isoOfNatIso (isoWhiskerLeft (D ⋙ Prod.sectL _ _) (yonedaLemma C))
+    HasLimit.isoOfNatIso (Functor.isoWhiskerLeft (D ⋙ Prod.sectL _ _) (yonedaLemma C))
 
 @[simp]
 lemma colimitYonedaHomIsoLimit_π_apply (f : colimit (D.unop ⋙ yoneda) ⟶ F) (i : Iᵒᵖ) :
@@ -248,7 +248,7 @@ of `F` evaluated at `D`. This variant is for covariant diagrams, see
 noncomputable def colimitCoyonedaHomIsoLimit' :
     (colimit (D.op ⋙ coyoneda) ⟶ F) ≅ limit (D ⋙ F ⋙ uliftFunctor.{u₁}) :=
   colimitHomIsoLimitYoneda' _ F ≪≫
-    HasLimit.isoOfNatIso (isoWhiskerLeft (D ⋙ Prod.sectL C F) (coyonedaLemma C))
+    HasLimit.isoOfNatIso (Functor.isoWhiskerLeft (D ⋙ Prod.sectL C F) (coyonedaLemma C))
 
 @[simp]
 lemma colimitCoyonedaHomIsoLimit'_π_apply (f : colimit (D.op ⋙ coyoneda) ⟶ F) (i : I) :
@@ -299,7 +299,7 @@ covariant version. -/
 noncomputable def colimitYonedaHomIsoLimit' :
     (colimit (D.leftOp ⋙ yoneda) ⟶ F) ≅ limit (D ⋙ F ⋙ uliftFunctor.{u₁}) :=
   colimitHomIsoLimitYoneda' _ F ≪≫
-    HasLimit.isoOfNatIso (isoWhiskerLeft (D ⋙ Prod.sectL _ _) (yonedaLemma C))
+    HasLimit.isoOfNatIso (Functor.isoWhiskerLeft (D ⋙ Prod.sectL _ _) (yonedaLemma C))
 
 @[simp]
 lemma colimitYonedaHomIsoLimit'_π_apply (f : colimit (D.leftOp ⋙ yoneda) ⟶ F) (i : I) :

--- a/Mathlib/CategoryTheory/Limits/Indization/Category.lean
+++ b/Mathlib/CategoryTheory/Limits/Indization/Category.lean
@@ -57,7 +57,7 @@ universe w v u
 
 namespace CategoryTheory
 
-open Limits
+open Limits Functor
 
 variable {C : Type u} [Category.{v} C]
 

--- a/Mathlib/CategoryTheory/Limits/Indization/Equalizers.lean
+++ b/Mathlib/CategoryTheory/Limits/Indization/Equalizers.lean
@@ -50,8 +50,8 @@ This is Proposition 6.1.16(i) in [Kashiwara2006].
 -/
 theorem isIndObject_limit_comp_yoneda_comp_colim
     (hF : ∀ i, IsIndObject (limit (F.flip.obj i ⋙ yoneda))) :
-    IsIndObject (limit (F ⋙ (whiskeringRight _ _ _).obj yoneda ⋙ colim)) := by
-  let G : J ⥤ I ⥤ (Cᵒᵖ ⥤ Type v) := F ⋙ (whiskeringRight _ _ _).obj yoneda
+    IsIndObject (limit (F ⋙ (Functor.whiskeringRight _ _ _).obj yoneda ⋙ colim)) := by
+  let G : J ⥤ I ⥤ (Cᵒᵖ ⥤ Type v) := F ⋙ (Functor.whiskeringRight _ _ _).obj yoneda
   apply IsIndObject.map (HasLimit.isoOfNatIso (colimitFlipIsoCompColim G)).hom
   apply IsIndObject.map (colimitLimitIso G).hom
   apply isIndObject_colimit

--- a/Mathlib/CategoryTheory/Limits/Indization/FilteredColimits.lean
+++ b/Mathlib/CategoryTheory/Limits/Indization/FilteredColimits.lean
@@ -26,7 +26,7 @@ universe v u
 
 namespace CategoryTheory.Limits
 
-open CategoryTheory CategoryTheory.CostructuredArrow
+open CategoryTheory CategoryTheory.CostructuredArrow CategoryTheory.Functor
 
 variable {C : Type u} [Category.{v} C]
 
@@ -94,7 +94,8 @@ theorem isFiltered [IsFiltered I] (hF : ∀ i, IsIndObject (F.obj i)) :
   -- We begin by remarking that `lim Hom_{Over (colimit F)}(yG·, 𝟙 (colimit F))` is nonempty,
   -- simply because `𝟙 (colimit F)` is the terminal object. Here `y` is the functor
   -- `CostructuredArrow yoneda (colimit F) ⥤ Over (colimit F)` induced by `yoneda`.
-  have h₁ : Nonempty (limit (G.op ⋙ (toOver _ _).op ⋙ yoneda.obj (Over.mk (𝟙 (colimit F))))) :=
+  have h₁ : Nonempty (limit (G.op ⋙ (CostructuredArrow.toOver _ _).op ⋙
+      yoneda.obj (Over.mk (𝟙 (colimit F))))) :=
     ⟨Types.Limit.mk _ (fun j => Over.mkIdTerminal.from _) (by simp)⟩
   -- `𝟙 (colimit F)` is the colimit of the diagram in `Over (colimit F)` given by the arrows of
   -- the form `Fi ⟶ colimit F`. Thus, pulling the colimit out of the hom functor and commuting
@@ -115,11 +116,11 @@ theorem isFiltered [IsFiltered I] (hF : ∀ i, IsIndObject (F.obj i)) :
   -- `lim_j Hom_{Over (colimit F)}(yGj, colimit.ι F i) ≅`
   --   `colim_k lim_j Hom_{Over (colimit F)}(yGj, yHk)`, and so we find `k` such that the limit
   -- is non-empty.
-  obtain ⟨k, hk⟩ : ∃ k, Nonempty (limit (G.op ⋙ (toOver yoneda (colimit F)).op ⋙
-      yoneda.obj ((toOver yoneda (colimit F)).obj <|
+  obtain ⟨k, hk⟩ : ∃ k, Nonempty (limit (G.op ⋙ (CostructuredArrow.toOver yoneda (colimit F)).op ⋙
+      yoneda.obj ((CostructuredArrow.toOver yoneda (colimit F)).obj <|
         (pre P.F yoneda (colimit F)).obj <| (map (colimit.ι F i)).obj <| mk _))) :=
     exists_nonempty_limit_obj_of_isColimit F G _ hc _ (Iso.refl _) hi
-  have htO : (toOver yoneda (colimit F)).FullyFaithful := .ofFullyFaithful _
+  have htO : (CostructuredArrow.toOver yoneda (colimit F)).FullyFaithful := .ofFullyFaithful _
   -- Since the inclusion `y : CostructuredArrow yoneda (colimit F) ⥤ Over (colimit F)` is fully
   -- faithful, `lim_j Hom_{Over (colimit F)}(yGj, yHk) ≅`
   --   `lim_j Hom_{CostructuredArrow yoneda (colimit F)}(Gj, Hk)` and so `Hk` is the object we're

--- a/Mathlib/CategoryTheory/Limits/Indization/ParallelPair.lean
+++ b/Mathlib/CategoryTheory/Limits/Indization/ParallelPair.lean
@@ -23,7 +23,7 @@ universe v₁ v₂ v₃ u₁ u₂ u₃
 
 namespace CategoryTheory
 
-open Limits
+open Limits Functor
 
 variable {C : Type u₁} [Category.{v₁} C]
 

--- a/Mathlib/CategoryTheory/Limits/Preserves/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Basic.lean
@@ -245,7 +245,7 @@ preservesLimit_of_preserves_limit_cone h hF
 lemma preservesLimit_of_iso_diagram {K₁ K₂ : J ⥤ C} (F : C ⥤ D) (h : K₁ ≅ K₂)
     [PreservesLimit K₁ F] : PreservesLimit K₂ F where
   preserves {c} t := ⟨by
-    apply IsLimit.postcomposeInvEquiv (isoWhiskerRight h F :) _ _
+    apply IsLimit.postcomposeInvEquiv (Functor.isoWhiskerRight h F :) _ _
     have := (IsLimit.postcomposeInvEquiv h c).symm t
     apply IsLimit.ofIsoLimit (isLimitOfPreserves F this)
     exact Cones.ext (Iso.refl _)⟩
@@ -349,7 +349,7 @@ lemma preservesColimit_of_iso_diagram {K₁ K₂ : J ⥤ C} (F : C ⥤ D) (h : K
     [PreservesColimit K₁ F] :
     PreservesColimit K₂ F where
   preserves {c} t := ⟨by
-    apply IsColimit.precomposeHomEquiv (isoWhiskerRight h F :) _ _
+    apply IsColimit.precomposeHomEquiv (Functor.isoWhiskerRight h F :) _ _
     have := (IsColimit.precomposeHomEquiv h c).symm t
     apply IsColimit.ofIsoColimit (isColimitOfPreserves F this)
     exact Cocones.ext (Iso.refl _)⟩
@@ -686,7 +686,7 @@ lemma reflectsLimit_of_iso_diagram {K₁ K₂ : J ⥤ C} (F : C ⥤ D) (h : K₁
     ReflectsLimit K₂ F where
   reflects {c} t := ⟨by
     apply IsLimit.postcomposeInvEquiv h c (isLimitOfReflects F _)
-    apply ((IsLimit.postcomposeInvEquiv (isoWhiskerRight h F :) _).symm t).ofIsoLimit _
+    apply ((IsLimit.postcomposeInvEquiv (Functor.isoWhiskerRight h F :) _).symm t).ofIsoLimit _
     exact Cones.ext (Iso.refl _)⟩
 
 @[deprecated "use reflectsLimit_of_iso_diagram" (since := "2024-11-19")]
@@ -861,7 +861,7 @@ lemma reflectsColimit_of_iso_diagram {K₁ K₂ : J ⥤ C} (F : C ⥤ D) (h : K�
     ReflectsColimit K₂ F where
   reflects {c} t := ⟨by
     apply IsColimit.precomposeHomEquiv h c (isColimitOfReflects F _)
-    apply ((IsColimit.precomposeHomEquiv (isoWhiskerRight h F :) _).symm t).ofIsoColimit _
+    apply ((IsColimit.precomposeHomEquiv (Functor.isoWhiskerRight h F :) _).symm t).ofIsoColimit _
     exact Cocones.ext (Iso.refl _)⟩
 
 @[deprecated "use reflectsColimit_of_iso_diagram" (since := "2024-11-19")]

--- a/Mathlib/CategoryTheory/Limits/Preserves/Bifunctor.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Bifunctor.lean
@@ -21,7 +21,7 @@ out of this typeclass.
 
 namespace CategoryTheory
 
-open Category Limits
+open Category Limits Functor
 
 variable {J₁ J₂ : Type*} [Category J₁] [Category J₂]
   {C₁ C₂ C : Type*} [Category C₁] [Category C₂] [Category C]

--- a/Mathlib/CategoryTheory/Limits/Preserves/FunctorCategory.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/FunctorCategory.lean
@@ -34,7 +34,7 @@ noncomputable section
 
 namespace CategoryTheory
 
-open Category Limits
+open Category Limits Functor
 
 section
 

--- a/Mathlib/CategoryTheory/Limits/Preserves/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Grothendieck.lean
@@ -18,6 +18,8 @@ universe v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
 
 namespace CategoryTheory
 
+open Functor
+
 namespace Limits
 
 noncomputable section
@@ -40,9 +42,9 @@ def fiberwiseColimitLimitIso (K : J ⥤ Grothendieck F ⥤ H)
        (limitCompWhiskeringLeftIsoCompLimit K (Grothendieck.ι F c)).symm ≪≫
       preservesLimitIso colim _ ≪≫
       HasLimit.isoOfNatIso
-        (Functor.associator _ _ _ ≪≫
+        (associator _ _ _ ≪≫
         isoWhiskerLeft _ (fiberwiseColimCompEvaluationIso _).symm ≪≫
-        (Functor.associator _ _ _).symm) ≪≫
+        (associator _ _ _).symm) ≪≫
       (limitObjIsoLimitCompEvaluation _ c).symm)
     fun {c₁ c₂} f => by
       simp only [fiberwiseColimit_obj, fiberwiseColimit_map, Iso.trans_hom, Iso.symm_hom,
@@ -73,7 +75,7 @@ instance preservesLimitsOfShape_colim_grothendieck [HasColimitsOfShape C H] [Has
           preservesLimitIso colim (K ⋙ fiberwiseColim _ _)
     _ ≅ limit (K ⋙ colim) :=
       HasLimit.isoOfNatIso
-       (Functor.associator _ _ _ ≪≫ isoWhiskerLeft _ fiberwiseColimCompColimIso)
+       (associator _ _ _ ≪≫ isoWhiskerLeft _ fiberwiseColimCompColimIso)
   haveI : IsIso (limit.post K colim) := by
     convert Iso.isIso_hom i₂
     ext

--- a/Mathlib/CategoryTheory/Limits/Preserves/Limits.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Limits.lean
@@ -81,13 +81,13 @@ variable [PreservesLimitsOfShape J G] [HasLimitsOfShape J D] [HasLimitsOfShape J
 /-- If `C, D` has all limits of shape `J`, and `G` preserves them, then `preservesLimitsIso` is
 functorial wrt `F`. -/
 @[simps!]
-def preservesLimitNatIso : lim ⋙ G ≅ (whiskeringRight J C D).obj G ⋙ lim :=
+def preservesLimitNatIso : lim ⋙ G ≅ (Functor.whiskeringRight J C D).obj G ⋙ lim :=
   NatIso.ofComponents (fun F => preservesLimitIso G F)
     (by
       intro _ _ f
       apply limit.hom_ext; intro j
       dsimp
-      simp only [preservesLimitIso_hom_π, whiskerRight_app, limMap_π, Category.assoc,
+      simp only [preservesLimitIso_hom_π, Functor.whiskerRight_app, limMap_π, Category.assoc,
         preservesLimitIso_hom_π_assoc, ← G.map_comp])
 
 end
@@ -157,7 +157,7 @@ variable [PreservesColimitsOfShape J G] [HasColimitsOfShape J D] [HasColimitsOfS
 /-- If `C, D` has all colimits of shape `J`, and `G` preserves them, then `preservesColimitIso`
 is functorial wrt `F`. -/
 @[simps!]
-def preservesColimitNatIso : colim ⋙ G ≅ (whiskeringRight J C D).obj G ⋙ colim :=
+def preservesColimitNatIso : colim ⋙ G ≅ (Functor.whiskeringRight J C D).obj G ⋙ colim :=
   NatIso.ofComponents (fun F => preservesColimitIso G F)
     (by
       intro _ _ f
@@ -165,7 +165,7 @@ def preservesColimitNatIso : colim ⋙ G ≅ (whiskeringRight J C D).obj G ⋙ c
       apply colimit.hom_ext; intro j
       dsimp
       rw [ι_colimMap_assoc]
-      simp only [ι_preservesColimitIso_inv, whiskerRight_app,
+      simp only [ι_preservesColimitIso_inv, Functor.whiskerRight_app,
         ι_preservesColimitIso_inv_assoc, ← G.map_comp]
       rw [ι_colimMap])
 

--- a/Mathlib/CategoryTheory/Limits/Preserves/Presheaf.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Presheaf.lean
@@ -39,7 +39,7 @@ is small, we leave this as a TODO.
 * [F. Borceux, *Handbook of Categorical Algebra 1*][borceux-vol1], Proposition 6.1.2
 -/
 
-open CategoryTheory Limits
+open CategoryTheory Limits Functor
 
 universe v u
 

--- a/Mathlib/CategoryTheory/Limits/Preserves/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Yoneda.lean
@@ -31,7 +31,7 @@ universe v₁ v₂ v₃ u₁ u₂ u₃
 
 namespace CategoryTheory
 
-open CategoryTheory.Limits Opposite
+open CategoryTheory.Limits Opposite Functor
 
 variable {C : Type u₁} [Category.{v₁} C]
 

--- a/Mathlib/CategoryTheory/Limits/Presheaf.lean
+++ b/Mathlib/CategoryTheory/Limits/Presheaf.lean
@@ -66,7 +66,7 @@ Defined as in [MM92], Chapter I, Section 5, Theorem 2.
 -/
 @[simps!]
 def restrictedYoneda : ℰ ⥤ Cᵒᵖ ⥤ Type v₁ :=
-  yoneda ⋙ (whiskeringLeft _ _ (Type v₁)).obj (Functor.op A)
+  yoneda ⋙ (Functor.whiskeringLeft _ _ (Type v₁)).obj (Functor.op A)
 
 /-- Auxiliary definition for `restrictedYonedaHomEquiv`. -/
 def restrictedYonedaHomEquiv' (P : Cᵒᵖ ⥤ Type v₁) (E : ℰ) :
@@ -271,9 +271,9 @@ lemma isLeftKanExtension_along_yoneda_iff :
     apply IsColimit.ofWhiskerEquivalence (CategoryOfElements.costructuredArrowYonedaEquivalence _)
     let e : CategoryOfElements.toCostructuredArrow P ⋙ CostructuredArrow.proj yoneda P ⋙ A ≅
         functorToRepresentables P ⋙ L :=
-      isoWhiskerLeft _ (isoWhiskerLeft _ (asIso α)) ≪≫
-        isoWhiskerLeft _ (Functor.associator _ _ _).symm ≪≫
-        (Functor.associator _ _ _).symm ≪≫ isoWhiskerRight (Iso.refl _) L
+      Functor.isoWhiskerLeft _ (Functor.isoWhiskerLeft _ (asIso α)) ≪≫
+        Functor.isoWhiskerLeft _ (Functor.associator _ _ _).symm ≪≫
+        (Functor.associator _ _ _).symm ≪≫ Functor.isoWhiskerRight (Iso.refl _) L
     apply (IsColimit.precomposeHomEquiv e.symm _).1
     exact IsColimit.ofIsoColimit (isColimitOfPreserves L (colimitOfRepresentable P))
       (Cocones.ext (Iso.refl _))
@@ -421,11 +421,11 @@ lemma yonedaEquiv_presheafHom_yoneda_obj (X : C) :
 
 @[reassoc (attr := simp)]
 lemma presheafHom_naturality {P Q : Cᵒᵖ ⥤ Type v₁} (f : P ⟶ Q) :
-    presheafHom φ P ≫ whiskerLeft F.op (G.map f) = f ≫ presheafHom φ Q :=
+    presheafHom φ P ≫ Functor.whiskerLeft F.op (G.map f) = f ≫ presheafHom φ Q :=
   hom_ext_yoneda (fun X p => yonedaEquiv.injective (by
     rw [← assoc p f, yonedaEquiv_ι_presheafHom, ← assoc,
       yonedaEquiv_comp, yonedaEquiv_ι_presheafHom,
-      whiskerLeft_app, Functor.map_comp, FunctorToTypes.comp]
+      Functor.whiskerLeft_app, Functor.map_comp, FunctorToTypes.comp]
     dsimp))
 
 variable [∀ (P : Cᵒᵖ ⥤ Type v₁), F.op.HasLeftKanExtension P]
@@ -483,7 +483,7 @@ lemma hom_ext {Φ : yoneda.LeftExtension (F ⋙ yoneda)}
   have eq₂ := congr_fun (congr_app (congr_app (StructuredArrow.w g) x.unop.1.unop)
     (F.op.obj x.unop.1)) (𝟙 _)
   dsimp at eq₁ eq₂ eq ⊢
-  simp only [reassoc_of% eq, ← whiskerLeft_comp]
+  simp only [reassoc_of% eq, ← Functor.whiskerLeft_comp]
   congr 2
   simp only [← cancel_epi ((compYonedaIsoYonedaCompLan F).hom.app x.unop.1.unop),
     NatTrans.naturality]
@@ -496,7 +496,7 @@ end compYonedaIsoYonedaCompLan
 variable [∀ (P : Cᵒᵖ ⥤ Type v₁), F.op.HasLeftKanExtension P]
 
 noncomputable instance (Φ : StructuredArrow (F ⋙ yoneda)
-    ((whiskeringLeft C (Cᵒᵖ ⥤ Type v₁) (Dᵒᵖ ⥤ Type v₁)).obj yoneda)) :
+    ((Functor.whiskeringLeft C (Cᵒᵖ ⥤ Type v₁) (Dᵒᵖ ⥤ Type v₁)).obj yoneda)) :
     Unique (Functor.LeftExtension.mk F.op.lan (compYonedaIsoYonedaCompLan F).hom ⟶ Φ) where
   default := compYonedaIsoYonedaCompLan.extensionHom Φ
   uniq _ := compYonedaIsoYonedaCompLan.hom_ext _ _
@@ -567,7 +567,7 @@ theorem final_toCostructuredArrow_comp_pre {c : Cocone (F ⋙ yoneda)} (hc : IsC
     apply IsTerminal.ofIso this
     refine ?_ ≪≫ (preservesColimitIso (overEquivPresheafCostructuredArrow c.pt).inverse _).symm
     apply HasColimit.isoOfNatIso
-    exact isoWhiskerLeft _
+    exact Functor.isoWhiskerLeft _
       (CostructuredArrow.toOverCompOverEquivPresheafCostructuredArrow c.pt).isoCompInverse
   apply IsTerminal.ofIso Over.mkIdTerminal
   let isc : IsColimit ((Over.forget _).mapCocone _) := isColimitOfPreserves _

--- a/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Grothendieck.lean
@@ -24,6 +24,8 @@ universe v₁ v₂ v₃ u₁ u₂ u₃
 
 namespace CategoryTheory
 
+open Functor
+
 namespace Limits
 
 variable {C : Type u₁} [Category.{v₁} C]
@@ -39,7 +41,7 @@ variable [∀ {X Y : C} (f : X ⟶ Y), HasColimit (F.map f ⋙ Grothendieck.ι F
 @[local instance]
 lemma hasColimit_ι_comp : ∀ X, HasColimit (Grothendieck.ι F X ⋙ G) :=
   fun X => hasColimit_of_iso (F := F.map (𝟙 _) ⋙ Grothendieck.ι F X ⋙ G) <|
-    (Functor.leftUnitor (Grothendieck.ι F X ⋙ G)).symm ≪≫
+    (leftUnitor (Grothendieck.ι F X ⋙ G)).symm ≪≫
     (isoWhiskerRight (eqToIso (F.map_id X).symm) (Grothendieck.ι F X ⋙ G))
 
 /-- A functor taking a colimit on each fiber of a functor `G : Grothendieck F ⥤ H`. -/
@@ -47,7 +49,7 @@ lemma hasColimit_ι_comp : ∀ X, HasColimit (Grothendieck.ι F X ⋙ G) :=
 def fiberwiseColimit : C ⥤ H where
   obj X := colimit (Grothendieck.ι F X ⋙ G)
   map {X Y} f := colimMap (whiskerRight (Grothendieck.ιNatTrans f) G ≫
-    (Functor.associator _ _ _).hom) ≫ colimit.pre (Grothendieck.ι F Y ⋙ G) (F.map f)
+    (associator _ _ _).hom) ≫ colimit.pre (Grothendieck.ι F Y ⋙ G) (F.map f)
   map_id X := by
     ext d
     simp only [Functor.comp_obj, Grothendieck.ιNatTrans, Grothendieck.ι_obj, ι_colimMap_assoc,

--- a/Mathlib/CategoryTheory/Limits/Shapes/Preorder/TransfiniteCompositionOfShape.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Preorder/TransfiniteCompositionOfShape.lean
@@ -90,7 +90,7 @@ def ofOrderIso {J' : Type w'} [LinearOrder J'] [OrderBot J']
     TransfiniteCompositionOfShape J' f where
   F := e.equivalence.functor ⋙ c.F
   isoBot := c.F.mapIso (eqToIso e.map_bot) ≪≫ c.isoBot
-  incl := whiskerLeft e.equivalence.functor c.incl
+  incl := Functor.whiskerLeft e.equivalence.functor c.incl
   isColimit := IsColimit.whiskerEquivalence (c.isColimit) e.equivalence
 
 /-- If `f` is a transfinite composition of shape `J`, then `F.map f` also is
@@ -101,7 +101,7 @@ noncomputable def map (F : C ⥤ D) [PreservesWellOrderContinuousOfShape J F]
     TransfiniteCompositionOfShape J (F.map f) where
   F := c.F ⋙ F
   isoBot := F.mapIso c.isoBot
-  incl := whiskerRight c.incl F ≫ (Functor.constComp _ _ _).hom
+  incl := Functor.whiskerRight c.incl F ≫ (Functor.constComp _ _ _).hom
   isColimit :=
     IsColimit.ofIsoColimit (isColimitOfPreserves F c.isColimit)
       (Cocones.ext (Iso.refl _))
@@ -130,7 +130,7 @@ noncomputable def ici (j : J) :
   F := (Subtype.mono_coe (Set.Ici j)).functor ⋙ c.F
   isWellOrderContinuous := Functor.IsWellOrderContinuous.restriction_setIci _
   isoBot := Iso.refl _
-  incl := whiskerLeft _ c.incl
+  incl := Functor.whiskerLeft _ c.incl
   isColimit := (Functor.Final.isColimitWhiskerEquiv
     ((Subtype.mono_coe (Set.Ici j)).functor) _).2 c.isColimit
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Categorical/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Categorical/Basic.lean
@@ -189,6 +189,8 @@ end
 
 section
 
+open Functor
+
 variable (X : Type u₄) [Category.{v₄} X]
 
 variable (F G) in
@@ -249,9 +251,9 @@ def toCatCommSqOver : (X ⥤ F ⊡ G) ⥤ CatCommSqOver F G X where
     { fst := J ⋙ π₁ F G
       snd := J ⋙ π₂ F G
       iso :=
-        Functor.associator _ _ _ ≪≫
+        associator _ _ _ ≪≫
           isoWhiskerLeft J (catCommSq F G).iso ≪≫
-          (Functor.associator _ _ _).symm }
+          (associator _ _ _).symm }
   map {J J'} F :=
     { fst := whiskerRight F (π₁ _ _)
       snd := whiskerRight F (π₂ _ _) }
@@ -298,12 +300,12 @@ the projections, and compatible with the canonical 2-commutative square . -/
 def mkNatIso {J K : X ⥤ F ⊡ G}
     (e₁ : J ⋙ π₁ F G ≅ K ⋙ π₁ F G) (e₂ : J ⋙ π₂ F G ≅ K ⋙ π₂ F G)
     (coh :
-      whiskerRight e₁.hom F ≫ (Functor.associator _ _ _).hom ≫
+      whiskerRight e₁.hom F ≫ (associator _ _ _).hom ≫
         whiskerLeft K (CatCommSq.iso (π₁ F G) (π₂ F G) F G).hom ≫
-        (Functor.associator _ _ _).inv =
-      (Functor.associator _ _ _).hom ≫
+        (associator _ _ _).inv =
+      (associator _ _ _).hom ≫
         whiskerLeft J (CatCommSq.iso (π₁ F G) (π₂ F G) F G).hom ≫
-        (Functor.associator _ _ _).inv ≫
+        (associator _ _ _).inv ≫
         whiskerRight e₂.hom G := by aesop_cat) :
     J ≅ K :=
   NatIso.ofComponents
@@ -331,12 +333,12 @@ section
 variable {J K : X ⥤ F ⊡ G}
     (e₁ : J ⋙ π₁ F G ≅ K ⋙ π₁ F G) (e₂ : J ⋙ π₂ F G ≅ K ⋙ π₂ F G)
     (coh :
-      whiskerRight e₁.hom F ≫ (Functor.associator _ _ _).hom ≫
+      whiskerRight e₁.hom F ≫ (associator _ _ _).hom ≫
         whiskerLeft K (CatCommSq.iso (π₁ F G) (π₂ F G) F G).hom ≫
-        (Functor.associator _ _ _).inv =
-      (Functor.associator _ _ _).hom ≫
+        (associator _ _ _).inv =
+      (associator _ _ _).hom ≫
         whiskerLeft J (CatCommSq.iso (π₁ F G) (π₂ F G) F G).hom ≫
-        (Functor.associator _ _ _).inv ≫
+        (associator _ _ _).inv ≫
         whiskerRight e₂.hom G := by aesop_cat)
 
 @[simp]

--- a/Mathlib/CategoryTheory/Limits/Shapes/Reflexive.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Reflexive.lean
@@ -470,7 +470,7 @@ lemma whiskerRightMkNatTrans {F G : WalkingReflexivePair ⥤ C}
     {h₂ : F.map right ≫ e₀ = e₁ ≫ G.map right}
     {h₃ : F.map reflexion ≫ e₁ = e₀ ≫ G.map reflexion}
     {D : Type u₂} [Category.{v₂} D] (H : C ⥤ D) :
-    whiskerRight (mkNatTrans e₀ e₁ : F ⟶ G) H =
+    Functor.whiskerRight (mkNatTrans e₀ e₁ : F ⟶ G) H =
       mkNatTrans (H.map e₀) (H.map e₁)
           (by simp only [Functor.comp_obj, Functor.comp_map, ← Functor.map_comp, h₁])
           (by simp only [Functor.comp_obj, Functor.comp_map, ← Functor.map_comp, h₂])

--- a/Mathlib/CategoryTheory/Limits/VanKampen.lean
+++ b/Mathlib/CategoryTheory/Limits/VanKampen.lean
@@ -28,7 +28,7 @@ import Mathlib.CategoryTheory.Limits.Constructions.FiniteProductsOfBinaryProduct
 -/
 
 
-open CategoryTheory.Limits
+open CategoryTheory.Limits CategoryTheory.Functor
 
 namespace CategoryTheory
 

--- a/Mathlib/CategoryTheory/Linear/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Linear/Yoneda.lean
@@ -21,7 +21,7 @@ TODO: In fact, `linearYoneda` itself is additive and `R`-linear.
 
 universe w v u
 
-open Opposite
+open Opposite CategoryTheory.Functor
 
 namespace CategoryTheory
 

--- a/Mathlib/CategoryTheory/Localization/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Localization/Adjunction.lean
@@ -22,7 +22,7 @@ induced adjunction `Adjunction.localization L₁ W₁ L₂ W₂ G' F' : G' ⊣ F
 
 namespace CategoryTheory
 
-open Localization Category
+open Localization Category Functor
 
 namespace Adjunction
 

--- a/Mathlib/CategoryTheory/Localization/Bifunctor.lean
+++ b/Mathlib/CategoryTheory/Localization/Bifunctor.lean
@@ -29,7 +29,7 @@ which lifts `F`.
 
 namespace CategoryTheory
 
-open Category
+open Category Functor
 
 variable {C₁ C₂ D₁ D₂ E E' : Type*} [Category C₁] [Category C₂]
   [Category D₁] [Category D₂] [Category E] [Category E']
@@ -85,7 +85,7 @@ noncomputable def Lifting₂.snd (X₂ : C₂) :
 
 noncomputable instance Lifting₂.uncurry [Lifting₂ L₁ L₂ W₁ W₂ F F'] :
     Lifting (L₁.prod L₂) (W₁.prod W₂) (uncurry.obj F) (uncurry.obj F') where
-  iso' := CategoryTheory.uncurry.mapIso (Lifting₂.iso L₁ L₂ W₁ W₂ F F')
+  iso' := Functor.uncurry.mapIso (Lifting₂.iso L₁ L₂ W₁ W₂ F F')
 
 end
 

--- a/Mathlib/CategoryTheory/Localization/Construction.lean
+++ b/Mathlib/CategoryTheory/Localization/Construction.lean
@@ -38,7 +38,7 @@ uniqueness is expressed by `uniq`.
 
 noncomputable section
 
-open CategoryTheory.Category
+open CategoryTheory.Category CategoryTheory.Functor
 
 namespace CategoryTheory
 

--- a/Mathlib/CategoryTheory/Localization/DerivabilityStructure/Basic.lean
+++ b/Mathlib/CategoryTheory/Localization/DerivabilityStructure/Basic.lean
@@ -58,7 +58,7 @@ universe v₁ v₂ u₁ u₂
 
 namespace CategoryTheory
 
-open Category Localization
+open Category Localization Functor
 
 variable {C₁ : Type u₁} {C₂ : Type u₂} [Category.{v₁} C₁] [Category.{v₂} C₂]
   {W₁ : MorphismProperty C₁} {W₂ : MorphismProperty C₂}
@@ -95,7 +95,7 @@ lemma isRightDerivabilityStructure_iff [Φ.HasRightResolutions] (e : Φ.functor 
   let e₁ : W₁.Q ⋙ E₁.functor ≅ L₁ := compUniqFunctor W₁.Q L₁ W₁
   let e₂ : W₂.Q ⋙ E₂.functor ≅ L₂ := compUniqFunctor W₂.Q L₂ W₂
   let e'' : (Φ.functor ⋙ W₂.Q) ⋙ E₂.functor ≅ (W₁.Q ⋙ E₁.functor) ⋙ F :=
-    Functor.associator _ _ _ ≪≫ isoWhiskerLeft _ e₂ ≪≫ e ≪≫ isoWhiskerRight e₁.symm F
+    associator _ _ _ ≪≫ isoWhiskerLeft _ e₂ ≪≫ e ≪≫ isoWhiskerRight e₁.symm F
   let e''' : Φ.localizedFunctor W₁.Q W₂.Q ⋙ E₂.functor ≅ E₁.functor ⋙ F :=
     liftNatIso W₁.Q W₁ _ _ _ _ e''
   have : TwoSquare.vComp' e'.hom e'''.hom e₁ e₂ = e.hom := by

--- a/Mathlib/CategoryTheory/Localization/FiniteProducts.lean
+++ b/Mathlib/CategoryTheory/Localization/FiniteProducts.lean
@@ -23,7 +23,7 @@ universe v₁ v₂ u₁ u₂
 
 namespace CategoryTheory
 
-open Limits
+open Limits Functor
 
 namespace Localization
 

--- a/Mathlib/CategoryTheory/Localization/HomEquiv.lean
+++ b/Mathlib/CategoryTheory/Localization/HomEquiv.lean
@@ -74,7 +74,7 @@ lemma homMap_apply (G : D₁ ⥤ D₂) (e : Φ.functor ⋙ L₂ ≅ L₁ ⋙ G) 
   change e'.hom.app X ≫ G'.map f ≫ e'.inv.app Y = _
   letI : Localization.Lifting L₁ W₁ (Φ.functor ⋙ L₂) G := ⟨e.symm⟩
   let α : G' ≅ G := Localization.liftNatIso L₁ W₁ (L₁ ⋙ G') (Φ.functor ⋙ L₂) _ _ e'.symm
-  have : e = e' ≪≫ isoWhiskerLeft _ α := by
+  have : e = e' ≪≫ Functor.isoWhiskerLeft _ α := by
     ext X
     dsimp [α]
     rw [Localization.liftNatTrans_app]
@@ -97,8 +97,8 @@ lemma homMap_homMap (f : L₁.obj X ⟶ L₁.obj Y) :
   let e' : Ψ.functor ⋙ L₃ ≅ L₂ ⋙ G' := CatCommSq.iso _ _ _ _
   rw [Φ.homMap_apply L₁ L₂ G e, Ψ.homMap_apply L₂ L₃ G' e',
     (Φ.comp Ψ).homMap_apply L₁ L₃ (G ⋙ G')
-      (Functor.associator _ _ _ ≪≫ isoWhiskerLeft _ e' ≪≫
-      (Functor.associator _ _ _).symm ≪≫ isoWhiskerRight e _ ≪≫
+      (Functor.associator _ _ _ ≪≫ Functor.isoWhiskerLeft _ e' ≪≫
+      (Functor.associator _ _ _).symm ≪≫ Functor.isoWhiskerRight e _ ≪≫
       Functor.associator _ _ _)]
   dsimp
   simp only [Functor.map_comp, assoc, comp_id, id_comp]

--- a/Mathlib/CategoryTheory/Localization/LocalizerMorphism.lean
+++ b/Mathlib/CategoryTheory/Localization/LocalizerMorphism.lean
@@ -28,7 +28,7 @@ universe v₁ v₂ v₃ v₄ v₄' v₅ v₅' v₆ u₁ u₂ u₃ u₄ u₄' u�
 
 namespace CategoryTheory
 
-open Localization
+open Localization Functor
 
 variable {C₁ : Type u₁} {C₂ : Type u₂} {C₃ : Type u₃} {D₁ : Type u₄} {D₂ : Type u₅}
   [Category.{v₁} C₁] [Category.{v₂} C₂] [Category.{v₃} C₃] [Category.{v₄} D₁] [Category.{v₅} D₂]
@@ -108,13 +108,13 @@ lemma isEquivalence_imp [G.IsEquivalence] : G'.IsEquivalence :=
   let e : L₁ ⋙ G ⋙ E₂.functor ≅ L₁ ⋙ E₁.functor ⋙ G' :=
     calc
       L₁ ⋙ G ⋙ E₂.functor ≅ Φ.functor ⋙ L₂ ⋙ E₂.functor :=
-          (Functor.associator _ _ _).symm ≪≫
+          (associator _ _ _).symm ≪≫
             isoWhiskerRight (CatCommSq.iso Φ.functor L₁ L₂ G).symm E₂.functor ≪≫
-            Functor.associator _ _ _
+            associator _ _ _
       _ ≅ Φ.functor ⋙ L₂' := isoWhiskerLeft Φ.functor (compUniqFunctor L₂ L₂' W₂)
       _ ≅ L₁' ⋙ G' := CatCommSq.iso Φ.functor L₁' L₂' G'
       _ ≅ L₁ ⋙ E₁.functor ⋙ G' :=
-            isoWhiskerRight (compUniqFunctor L₁ L₁' W₁).symm G' ≪≫ Functor.associator _ _ _
+            isoWhiskerRight (compUniqFunctor L₁ L₁' W₁).symm G' ≪≫ associator _ _ _
   have := Functor.isEquivalence_of_iso
     (liftNatIso L₁ W₁ _ _ (G ⋙ E₂.functor) (E₁.functor ⋙ G') e)
   Functor.isEquivalence_of_comp_left E₁.functor G'
@@ -155,7 +155,7 @@ lemma IsLocalizedEquivalence.of_isLocalization_of_isLocalization
     [(Φ.functor ⋙ L₂).IsLocalization W₁] :
     IsLocalizedEquivalence Φ := by
   have : CatCommSq Φ.functor (Φ.functor ⋙ L₂) L₂ (𝟭 D₂) :=
-    CatCommSq.mk (Functor.rightUnitor _).symm
+    CatCommSq.mk (rightUnitor _).symm
   exact IsLocalizedEquivalence.mk' Φ (Φ.functor ⋙ L₂) L₂ (𝟭 D₂)
 
 /-- When the underlying functor `Φ.functor` of `Φ : LocalizerMorphism W₁ W₂` is
@@ -165,9 +165,9 @@ lemma IsLocalizedEquivalence.of_equivalence [Φ.functor.IsEquivalence]
     (h : W₂ ≤ W₁.map Φ.functor) : IsLocalizedEquivalence Φ := by
   haveI : Functor.IsLocalization (Φ.functor ⋙ MorphismProperty.Q W₂) W₁ := by
     refine Functor.IsLocalization.of_equivalence_source W₂.Q W₂ (Φ.functor ⋙ W₂.Q) W₁
-      (Functor.asEquivalence Φ.functor).symm ?_ (Φ.inverts W₂.Q)
-      ((Functor.associator _ _ _).symm ≪≫ isoWhiskerRight ((Equivalence.unitIso _).symm) _ ≪≫
-        Functor.leftUnitor _)
+      (asEquivalence Φ.functor).symm ?_ (Φ.inverts W₂.Q)
+      ((associator _ _ _).symm ≪≫ isoWhiskerRight ((Equivalence.unitIso _).symm) _ ≪≫
+        leftUnitor _)
     erw [W₁.isoClosure.inverseImage_equivalence_functor_eq_map_inverse]
     rw [MorphismProperty.map_isoClosure]
     exact h

--- a/Mathlib/CategoryTheory/Localization/LocallySmall.lean
+++ b/Mathlib/CategoryTheory/Localization/LocallySmall.lean
@@ -19,6 +19,8 @@ the category `D` is locally `w`-small.
 
 universe w v₁ v₂ u₁ u₂
 
+open CategoryTheory.Functor
+
 namespace CategoryTheory.MorphismProperty
 
 variable {C : Type u₁} [Category.{v₁} C] (W : MorphismProperty C)
@@ -54,7 +56,7 @@ noncomputable irreducible_def hasLocalizationOfLocallySmall'
   have : (inducedFunctor L.obj).IsEquivalence := { }
   let e := (inducedFunctor L.obj).asEquivalence
   let e' : (L' ⋙ e.functor) ⋙ e.inverse ≅ L' :=
-    Functor.associator _ _ _ ≪≫ isoWhiskerLeft L' e.unitIso.symm ≪≫ L'.rightUnitor
+    associator _ _ _ ≪≫ isoWhiskerLeft L' e.unitIso.symm ≪≫ L'.rightUnitor
   have : L'.IsLocalization W :=
     Functor.IsLocalization.of_iso W (L₁ := L ⋙ e.inverse) e'
   exact hasLocalizationOfLocallySmall.{w} W L'

--- a/Mathlib/CategoryTheory/Localization/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Localization/Monoidal.lean
@@ -85,7 +85,7 @@ instance : (L').IsLocalization W := inferInstanceAs (L.IsLocalization W)
 
 lemma isInvertedBy₂ :
     MorphismProperty.IsInvertedBy₂ W W
-      (curriedTensor C ⋙ (whiskeringRight C C D).obj L') := by
+      (curriedTensor C ⋙ (Functor.whiskeringRight C C D).obj L') := by
   rintro ⟨X₁, Y₁⟩ ⟨X₂, Y₂⟩ ⟨f₁, f₂⟩ ⟨hf₁, hf₂⟩
   have := Localization.inverts L' W _ (W.whiskerRight_mem f₁ hf₁ Y₁)
   have := Localization.inverts L' W _ (W.whiskerLeft_mem X₂ f₂ hf₂)
@@ -97,17 +97,17 @@ noncomputable def tensorBifunctor :
     LocalizedMonoidal L W ε ⥤ LocalizedMonoidal L W ε ⥤ LocalizedMonoidal L W ε :=
   Localization.lift₂ _ (isInvertedBy₂ L W ε) L L
 
-noncomputable instance : Lifting₂ L' L' W W (curriedTensor C ⋙ (whiskeringRight C C
+noncomputable instance : Lifting₂ L' L' W W (curriedTensor C ⋙ (Functor.whiskeringRight C C
     (LocalizedMonoidal L W ε)).obj L') (tensorBifunctor L W ε) :=
-  inferInstanceAs (Lifting₂ L L W W (curriedTensor C ⋙ (whiskeringRight C C D).obj L')
+  inferInstanceAs (Lifting₂ L L W W (curriedTensor C ⋙ (Functor.whiskeringRight C C D).obj L')
     (Localization.lift₂ _ (isInvertedBy₂ L W ε) L L))
 
 /-- The bifunctor `tensorBifunctor` on `LocalizedMonoidal L W ε` is induced by
 `curriedTensor C`. -/
 noncomputable abbrev tensorBifunctorIso :
-    (((whiskeringLeft₂ D).obj L').obj L').obj (tensorBifunctor L W ε) ≅
+    (((Functor.whiskeringLeft₂ D).obj L').obj L').obj (tensorBifunctor L W ε) ≅
       (Functor.postcompose₂.obj L').obj (curriedTensor C) :=
-  Lifting₂.iso L' L' W W (curriedTensor C ⋙ (whiskeringRight C C
+  Lifting₂.iso L' L' W W (curriedTensor C ⋙ (Functor.whiskeringRight C C
     (LocalizedMonoidal L W ε)).obj L') (tensorBifunctor L W ε)
 
 noncomputable instance (X : C) :
@@ -123,14 +123,14 @@ noncomputable def leftUnitor : (tensorBifunctor L W ε).obj unit ≅ 𝟭 _ :=
   (tensorBifunctor L W ε).mapIso ε.symm ≪≫
     Localization.liftNatIso L' W (tensorLeft (𝟙_ C) ⋙ L') L'
       ((tensorBifunctor L W ε).obj ((L').obj (𝟙_ _))) _
-        (isoWhiskerRight (leftUnitorNatIso C) _ ≪≫ L.leftUnitor)
+        (Functor.isoWhiskerRight (leftUnitorNatIso C) _ ≪≫ L.leftUnitor)
 
 /-- The right unitor in the localized monoidal category `LocalizedMonoidal L W ε`. -/
 noncomputable def rightUnitor : (tensorBifunctor L W ε).flip.obj unit ≅ 𝟭 _ :=
   (tensorBifunctor L W ε).flip.mapIso ε.symm ≪≫
     Localization.liftNatIso L' W (tensorRight (𝟙_ C) ⋙ L') L'
       ((tensorBifunctor L W ε).flip.obj ((L').obj (𝟙_ _))) _
-        (isoWhiskerRight (rightUnitorNatIso C) _ ≪≫ L.leftUnitor)
+        (Functor.isoWhiskerRight (rightUnitorNatIso C) _ ≪≫ L.leftUnitor)
 
 /-- The associator in the localized monoidal category `LocalizedMonoidal L W ε`. -/
 noncomputable def associator :

--- a/Mathlib/CategoryTheory/Localization/Predicate.lean
+++ b/Mathlib/CategoryTheory/Localization/Predicate.lean
@@ -35,7 +35,7 @@ noncomputable section
 
 namespace CategoryTheory
 
-open Category
+open Category Functor
 
 variable {C D : Type*} [Category C] [Category D] (L : C ⥤ D) (W : MorphismProperty C) (E : Type*)
   [Category E]
@@ -187,9 +187,9 @@ def compEquivalenceFromModelInverseIso : L ⋙ (equivalenceFromModel L W).invers
     L ⋙ (equivalenceFromModel L W).inverse ≅ _ :=
       isoWhiskerRight (qCompEquivalenceFromModelFunctorIso L W).symm _
     _ ≅ W.Q ⋙ (equivalenceFromModel L W).functor ⋙ (equivalenceFromModel L W).inverse :=
-      (Functor.associator _ _ _)
+      (associator _ _ _)
     _ ≅ W.Q ⋙ 𝟭 _ := isoWhiskerLeft _ (equivalenceFromModel L W).unitIso.symm
-    _ ≅ W.Q := Functor.rightUnitor _
+    _ ≅ W.Q := rightUnitor _
 
 theorem essSurj (W) [L.IsLocalization W] : L.EssSurj :=
   ⟨fun X =>
@@ -359,7 +359,7 @@ instance compRight {E' : Type*} [Category E'] (F : C ⥤ E) (F' : D ⥤ E) [Lift
 
 @[simps]
 instance id : Lifting L W L (𝟭 D) :=
-  ⟨Functor.rightUnitor L⟩
+  ⟨rightUnitor L⟩
 
 @[simps]
 instance compLeft (F : D ⥤ E) : Localization.Lifting L W (L ⋙ F) F := ⟨Iso.refl _⟩
@@ -441,7 +441,7 @@ compatible with the localization functors. -/
 def compUniqFunctor : L₁ ⋙ (uniq L₁ L₂ W').functor ≅ L₂ :=
   calc
     L₁ ⋙ (uniq L₁ L₂ W').functor ≅ (L₁ ⋙ (equivalenceFromModel L₁ W').inverse) ⋙
-      (equivalenceFromModel L₂ W').functor := (Functor.associator _ _ _).symm
+      (equivalenceFromModel L₂ W').functor := (associator _ _ _).symm
     _ ≅ W'.Q ⋙ (equivalenceFromModel L₂ W').functor :=
       isoWhiskerRight (compEquivalenceFromModelInverseIso L₁ W') _
     _ ≅ L₂ := qCompEquivalenceFromModelFunctorIso L₂ W'

--- a/Mathlib/CategoryTheory/Localization/Prod.lean
+++ b/Mathlib/CategoryTheory/Localization/Prod.lean
@@ -29,6 +29,8 @@ universe v₁ v₂ v₃ v₄ v₅ u₁ u₂ u₃ u₄ u₅
 
 namespace CategoryTheory
 
+open Functor
+
 variable {C₁ : Type u₁} {C₂ : Type u₂} {D₁ : Type u₃} {D₂ : Type u₄}
   [Category.{v₁} C₁] [Category.{v₂} C₂] [Category.{v₃} D₁] [Category.{v₄} D₂]
   (L₁ : C₁ ⥤ D₁) {W₁ : MorphismProperty C₁}

--- a/Mathlib/CategoryTheory/Localization/SmallHom.lean
+++ b/Mathlib/CategoryTheory/Localization/SmallHom.lean
@@ -264,9 +264,9 @@ lemma equiv_smallHomMap (G : D₁ ⥤ D₂) (e : Φ.functor ⋙ L₂ ≅ L₁ �
     SmallHom.equiv_equiv_symm W₂ W₂.Q L₂ E₂ α₂]
   change α₂.inv.app _ ≫ E₂.map (β.hom.app X ≫ G'.map g ≫ β.inv.app Y) ≫ _ = _
   let γ : G' ⋙ E₂ ≅ E₁ ⋙ G := liftNatIso W₁.Q W₁ (W₁.Q ⋙ G' ⋙ E₂) (W₁.Q ⋙ E₁ ⋙ G) _ _
-    ((Functor.associator _ _ _).symm ≪≫ isoWhiskerRight β.symm E₂ ≪≫
-      Functor.associator _ _ _ ≪≫ isoWhiskerLeft _ α₂ ≪≫ e ≪≫
-      isoWhiskerRight α₁.symm G ≪≫ Functor.associator _ _ _)
+    ((Functor.associator _ _ _).symm ≪≫ Functor.isoWhiskerRight β.symm E₂ ≪≫
+      Functor.associator _ _ _ ≪≫ Functor.isoWhiskerLeft _ α₂ ≪≫ e ≪≫
+      Functor.isoWhiskerRight α₁.symm G ≪≫ Functor.associator _ _ _)
   have hγ : ∀ (X : C₁), γ.hom.app (W₁.Q.obj X) =
       E₂.map (β.inv.app X) ≫ α₂.hom.app (Φ.functor.obj X) ≫
         e.hom.app X ≫ G.map (α₁.inv.app X) := fun X ↦ by

--- a/Mathlib/CategoryTheory/Localization/Trifunctor.lean
+++ b/Mathlib/CategoryTheory/Localization/Trifunctor.lean
@@ -20,6 +20,8 @@ The main result in this file is that we can localize "associator" isomorphisms
 
 namespace CategoryTheory
 
+open Functor
+
 variable {C₁ C₂ C₃ C₁₂ C₂₃ D₁ D₂ D₃ D₁₂ D₂₃ C D E : Type*}
   [Category C₁] [Category C₂] [Category C₃] [Category D₁] [Category D₂] [Category D₃]
   [Category C₁₂] [Category C₂₃] [Category D₁₂] [Category D₂₃]

--- a/Mathlib/CategoryTheory/Monad/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Monad/Adjunction.lean
@@ -27,7 +27,7 @@ Finally we prove that reflective functors are `MonadicRightAdjoint` and coreflec
 
 namespace CategoryTheory
 
-open Category
+open Category Functor
 
 universe v₁ v₂ u₁ u₂
 

--- a/Mathlib/CategoryTheory/Monad/Limits.lean
+++ b/Mathlib/CategoryTheory/Monad/Limits.lean
@@ -26,7 +26,7 @@ This is generalised to the case of a comonadic functor `D ⥤ C`.
 
 namespace CategoryTheory
 
-open Category
+open Category Functor
 
 open CategoryTheory.Limits
 

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Basic.lean
@@ -611,8 +611,9 @@ def prodComparisonNatTrans (A : C) :
       prodComparison_snd, prodComparison_snd_assoc, whiskerLeft_snd, ← F.map_comp]
 
 theorem prodComparisonNatTrans_comp :
-    prodComparisonNatTrans (F ⋙ G) A = whiskerRight (prodComparisonNatTrans F A) G ≫
-      whiskerLeft F (prodComparisonNatTrans G (F.obj A)) := by ext; simp [prodComparison_comp]
+    prodComparisonNatTrans (F ⋙ G) A = Functor.whiskerRight (prodComparisonNatTrans F A) G ≫
+      Functor.whiskerLeft F (prodComparisonNatTrans G (F.obj A)) := by
+  ext; simp [prodComparison_comp]
 
 @[simp]
 lemma prodComparisonNatTrans_id :
@@ -622,8 +623,8 @@ lemma prodComparisonNatTrans_id :
 `prodComparison`. -/
 @[simps]
 def prodComparisonBifunctorNatTrans :
-    curriedTensor C ⋙ (whiskeringRight _ _ _).obj F ⟶
-      F ⋙ curriedTensor D ⋙ (whiskeringLeft _ _ _).obj F where
+    curriedTensor C ⋙ (Functor.whiskeringRight _ _ _).obj F ⟶
+      F ⋙ curriedTensor D ⋙ (Functor.whiskeringLeft _ _ _).obj F where
   app A := prodComparisonNatTrans F A
   naturality x y f := by
     ext z
@@ -632,9 +633,11 @@ def prodComparisonBifunctorNatTrans :
 variable {E : Type u₂} [Category.{v₂} E] [CartesianMonoidalCategory E] (G : D ⥤ E)
 
 theorem prodComparisonBifunctorNatTrans_comp : prodComparisonBifunctorNatTrans (F ⋙ G) =
-      whiskerRight (prodComparisonBifunctorNatTrans F) ((whiskeringRight _ _ _).obj G) ≫
-        whiskerLeft F (whiskerRight (prodComparisonBifunctorNatTrans G)
-          ((whiskeringLeft _ _ _).obj F)) := by ext; simp [prodComparison_comp]
+    Functor.whiskerRight
+      (prodComparisonBifunctorNatTrans F) ((Functor.whiskeringRight _ _ _).obj G) ≫
+        Functor.whiskerLeft F (Functor.whiskerRight (prodComparisonBifunctorNatTrans G)
+          ((Functor.whiskeringLeft _ _ _).obj F)) := by
+  ext; simp [prodComparison_comp]
 
 instance (A : C) [∀ B, IsIso (prodComparison F A B)] : IsIso (prodComparisonNatTrans F A) := by
   letI : ∀ X, IsIso ((prodComparisonNatTrans F A).app X) := by assumption
@@ -700,8 +703,8 @@ noncomputable def prodComparisonNatIso (A : C) [∀ B, PreservesLimit (pair A B)
 `prodComparison F A B` is an isomorphism. -/
 @[simps! hom inv]
 noncomputable def prodComparisonBifunctorNatIso [∀ A B, PreservesLimit (pair A B) F] :
-    curriedTensor C ⋙ (whiskeringRight _ _ _).obj F ≅
-      F ⋙ curriedTensor D ⋙ (whiskeringLeft _ _ _).obj F :=
+    curriedTensor C ⋙ (Functor.whiskeringRight _ _ _).obj F ≅
+      F ⋙ curriedTensor D ⋙ (Functor.whiskeringLeft _ _ _).obj F :=
   asIso (prodComparisonBifunctorNatTrans F)
 
 end PreservesLimitPairs

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Grp_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Grp_.lean
@@ -105,11 +105,11 @@ lemma yonedaGrp_naturality (α : yonedaGrpObj G ⟶ yonedaGrpObj H) (f : X ⟶ Y
 
 /-- The yoneda embedding for `Grp_C` is fully faithful. -/
 def yonedaGrpFullyFaithful : yonedaGrp (C := C).FullyFaithful where
-  preimage {G H} α := yonedaMonFullyFaithful.preimage (whiskerRight α (forget₂ Grp MonCat))
+  preimage {G H} α := yonedaMonFullyFaithful.preimage (Functor.whiskerRight α (forget₂ Grp MonCat))
   map_preimage {G H} α := by
     ext X : 3
     exact congr(($(yonedaMonFullyFaithful.map_preimage (X := G.toMon_) (Y := H.toMon_)
-      (whiskerRight α (forget₂ Grp MonCat))).app X).hom)
+      (Functor.whiskerRight α (forget₂ Grp MonCat))).app X).hom)
   preimage_map := yonedaMonFullyFaithful.preimage_map
 
 instance : yonedaGrp (C := C).Full := yonedaGrpFullyFaithful.full
@@ -120,7 +120,7 @@ lemma essImage_yonedaGrp :
   ext F
   constructor
   · rintro ⟨G, ⟨α⟩⟩
-    exact ⟨G.X, ⟨Functor.representableByEquiv.symm (isoWhiskerRight α (forget _))⟩⟩
+    exact ⟨G.X, ⟨Functor.representableByEquiv.symm (Functor.isoWhiskerRight α (forget _))⟩⟩
   · rintro ⟨X, ⟨e⟩⟩
     letI := Grp_Class.ofRepresentableBy X F e
     exact ⟨⟨X⟩, ⟨yonedaGrpObjIsoOfRepresentableBy X F e⟩⟩

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Mon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Mon_.lean
@@ -223,7 +223,7 @@ lemma essImage_yonedaMon :
   ext F
   constructor
   · rintro ⟨M, ⟨α⟩⟩
-    exact ⟨M.X, ⟨Functor.representableByEquiv.symm (isoWhiskerRight α (forget _))⟩⟩
+    exact ⟨M.X, ⟨Functor.representableByEquiv.symm (Functor.isoWhiskerRight α (forget _))⟩⟩
   · rintro ⟨X, ⟨e⟩⟩
     letI := Mon_Class.ofRepresentableBy X F e
     exact ⟨Mon_.mk X, ⟨yonedaMonObjIsoOfRepresentableBy X F e⟩⟩

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution.lean
@@ -83,12 +83,12 @@ def uniqueUpToIso (h : DayConvolution F G) (h' : DayConvolution F G) :
 
 @[reassoc (attr := simp)]
 lemma unit_uniqueUpToIso_hom (h : DayConvolution F G) (h' : DayConvolution F G) :
-    h.unit ≫ CategoryTheory.whiskerLeft (tensor C) (h.uniqueUpToIso h').hom = h'.unit := by
+    h.unit ≫ Functor.whiskerLeft (tensor C) (h.uniqueUpToIso h').hom = h'.unit := by
   simp [uniqueUpToIso]
 
 @[reassoc (attr := simp)]
 lemma unit_uniqueUpToIso_inv (h : DayConvolution F G) (h' : DayConvolution F G) :
-    h'.unit ≫ CategoryTheory.whiskerLeft (tensor C) (h.uniqueUpToIso h').inv = h.unit := by
+    h'.unit ≫ Functor.whiskerLeft (tensor C) (h.uniqueUpToIso h').inv = h.unit := by
   simp [uniqueUpToIso]
 
 variable (F G) [DayConvolution F G]
@@ -148,7 +148,7 @@ variable (F G)
 corepresented by `F ⊛ G`. -/
 @[simps!]
 def corepresentableBy :
-    (whiskeringLeft _ _ _).obj (tensor C) ⋙ coyoneda.obj (.op <| F ⊠ G)|>.CorepresentableBy
+    (Functor.whiskeringLeft _ _ _).obj (tensor C) ⋙ coyoneda.obj (.op <| F ⊠ G)|>.CorepresentableBy
       (F ⊛ G) where
   homEquiv := Functor.homEquivOfIsLeftKanExtension _ (unit F G) _
   homEquiv_comp := by aesop

--- a/Mathlib/CategoryTheory/Monoidal/End.lean
+++ b/Mathlib/CategoryTheory/Monoidal/End.lean
@@ -36,8 +36,8 @@ opposite of the one usually considered in the literature.
 -/
 def endofunctorMonoidalCategory : MonoidalCategory (C ⥤ C) where
   tensorObj F G := F ⋙ G
-  whiskerLeft X _ _ F := whiskerLeft X F
-  whiskerRight F X := whiskerRight F X
+  whiskerLeft X _ _ F := Functor.whiskerLeft X F
+  whiskerRight F X := Functor.whiskerRight F X
   tensorHom α β := α ◫ β
   tensorUnit := 𝟭 C
   associator F G H := Functor.associator F G H
@@ -99,7 +99,7 @@ variable [MonoidalCategory C]
 instance : (tensoringRight C).Monoidal :=
   Functor.CoreMonoidal.toMonoidal
     { εIso := (rightUnitorNatIso C).symm
-      μIso := fun X Y => (isoWhiskerRight (curriedAssociatorNatIso C)
+      μIso := fun X Y => (Functor.isoWhiskerRight (curriedAssociatorNatIso C)
       ((evaluation C (C ⥤ C)).obj X ⋙ (evaluation C C).obj Y)) }
 
 @[simp] lemma tensoringRight_ε :

--- a/Mathlib/CategoryTheory/Monoidal/ExternalProduct.lean
+++ b/Mathlib/CategoryTheory/Monoidal/ExternalProduct.lean
@@ -18,6 +18,8 @@ universe v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
 
 namespace CategoryTheory.MonoidalCategory
 
+open CategoryTheory.Functor
+
 variable (J₁ : Type u₁) (J₂ : Type u₂) (C : Type u₃)
     [Category.{v₁} J₁] [Category.{v₂} J₂] [Category.{v₃} C] [MonoidalCategory C]
 
@@ -25,13 +27,13 @@ variable (J₁ : Type u₁) (J₂ : Type u₂) (C : Type u₃)
 `K₁ : J₁ ⥤ C` and `K₂ : J₂ ⥤ C`, this is the bifunctor `j₁ ↦ j₂ ↦ K₁ j₁ ⊗ K₂ j₂`. -/
 @[simps!]
 def externalProductBifunctorCurried : (J₁ ⥤ C) ⥤ (J₂ ⥤ C) ⥤ J₁ ⥤ J₂ ⥤ C :=
-  (Functor.postcompose₂.obj <| (evaluation _ _).obj <| curriedTensor C).obj <| whiskeringLeft₂ C
+  (postcompose₂.obj <| (evaluation _ _).obj <| curriedTensor C).obj <| whiskeringLeft₂ C
 
 /-- The external product bifunctor: given diagrams
 `K₁ : J₁ ⥤ C` and `K₂ : J₂ ⥤ C`, this is the bifunctor `(j₁, j₂) ↦ K₁ j₁ ⊗ K₂ j₂`. -/
 @[simps!]
 def externalProductBifunctor : ((J₁ ⥤ C) × (J₂ ⥤ C)) ⥤ J₁ × J₂ ⥤ C :=
-  uncurry.obj <| (Functor.postcompose₂.obj <| uncurry).obj <|
+  uncurry.obj <| (postcompose₂.obj <| uncurry).obj <|
     externalProductBifunctorCurried J₁ J₂ C
 
 variable {J₁ J₂ C}
@@ -78,7 +80,7 @@ def externalProductSwap [BraidedCategory C] :
 /-- A version of `externalProductSwap` phrased in terms of the curried functors. -/
 @[simps!]
 def externalProductFlip [BraidedCategory C] :
-    (Functor.postcompose₂.obj <| flipFunctor _ _ _).obj
+    (postcompose₂.obj <| flipFunctor _ _ _).obj
       (externalProductBifunctorCurried J₁ J₂ C) ≅
     (externalProductBifunctorCurried J₂ J₁ C).flip :=
   NatIso.ofComponents <| fun _ ↦ NatIso.ofComponents <|

--- a/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
@@ -38,7 +38,7 @@ universe u
 
 namespace CategoryTheory
 
-open MonoidalCategory
+open MonoidalCategory Functor
 
 namespace FreeMonoidalCategory
 
@@ -120,7 +120,7 @@ def normalizeMapAux : ∀ {X Y : F C}, (X ⟶ᵐ Y) → (normalizeObj' X ⟶ nor
   | _, _, l_inv _ => by dsimp; exact Discrete.natTrans (fun _ => 𝟙 _)
   | _, _, ρ_hom _ => by dsimp; exact Discrete.natTrans (fun _ => 𝟙 _)
   | _, _, ρ_inv _ => by dsimp; exact Discrete.natTrans (fun _ => 𝟙 _)
-  | _, _, (@comp _ _ _ _ f g) => normalizeMapAux f ≫ normalizeMapAux g
+  | _, _, (@Hom.comp _ _ _ _ f g) => normalizeMapAux f ≫ normalizeMapAux g
   | _, _, (@Hom.tensor _ T _ _ W f g) =>
     Discrete.natTrans <| fun ⟨X⟩ => (normalizeMapAux g).app ⟨normalizeObj T X⟩ ≫
       (normalizeObj' W).map ((normalizeMapAux f).app ⟨X⟩)
@@ -317,7 +317,7 @@ def inverseAux : ∀ {X Y : F C}, (X ⟶ᵐ Y) → (Y ⟶ᵐ X)
   | _, _, ρ_inv _ => ρ_hom _
   | _, _, l_hom _ => l_inv _
   | _, _, l_inv _ => l_hom _
-  | _, _, comp f g => (inverseAux g).comp (inverseAux f)
+  | _, _, Hom.comp f g => (inverseAux g).comp (inverseAux f)
   | _, _, Hom.whiskerLeft X f => (inverseAux f).whiskerLeft X
   | _, _, Hom.whiskerRight f X => (inverseAux f).whiskerRight X
   | _, _, Hom.tensor f g => (inverseAux f).tensor (inverseAux g)

--- a/Mathlib/CategoryTheory/Monoidal/Internal/FunctorCategory.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Internal/FunctorCategory.lean
@@ -246,7 +246,7 @@ def inverse : (C ⥤ CommMon_ D) ⥤ CommMon_ (C ⥤ D) where
   obj F :=
     { (monFunctorCategoryEquivalence C D).inverse.obj (F ⋙ CommMon_.forget₂Mon_ D) with
       comm := { mul_comm := by ext X; exact IsCommMon.mul_comm (F.obj X).X } }
-  map α := (monFunctorCategoryEquivalence C D).inverse.map (whiskerRight α _)
+  map α := (monFunctorCategoryEquivalence C D).inverse.map (Functor.whiskerRight α _)
 
 /-- The unit for the equivalence `CommMon_ (C ⥤ D) ≌ C ⥤ CommMon_ D`.
 -/

--- a/Mathlib/CategoryTheory/MorphismProperty/FunctorCategory.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/FunctorCategory.lean
@@ -44,7 +44,7 @@ instance IsStableUnderLimitsOfShape.functorCategory
   condition X₁ X₂ _ _ hc₁ hc₂ f hf φ hφ j :=
     MorphismProperty.limitsOfShape_le _
       (limitsOfShape.mk' (X₁ ⋙ (evaluation _ _ ).obj j) (X₂ ⋙ (evaluation _ _ ).obj j)
-      _ _ (isLimitOfPreserves _ hc₁) (isLimitOfPreserves _ hc₂) (whiskerRight f _)
+      _ _ (isLimitOfPreserves _ hc₁) (isLimitOfPreserves _ hc₂) (Functor.whiskerRight f _)
       (fun k ↦ hf k j) (φ.app j) (fun k ↦ congr_app (hφ k) j))
 
 instance IsStableUnderColimitsOfShape.functorCategory
@@ -54,7 +54,7 @@ instance IsStableUnderColimitsOfShape.functorCategory
   condition X₁ X₂ _ _ hc₁ hc₂ f hf φ hφ j :=
     MorphismProperty.colimitsOfShape_le _
       (colimitsOfShape.mk' (X₁ ⋙ (evaluation _ _ ).obj j) (X₂ ⋙ (evaluation _ _ ).obj j)
-      _ _ (isColimitOfPreserves _ hc₁) (isColimitOfPreserves _ hc₂) (whiskerRight f _)
+      _ _ (isColimitOfPreserves _ hc₁) (isColimitOfPreserves _ hc₂) (Functor.whiskerRight f _)
       (fun k ↦ hf k j) (φ.app j) (fun k ↦ congr_app (hφ k) j))
 
 instance [W.IsStableUnderBaseChange] (J : Type u'') [Category.{v''} J] [HasPullbacks C] :

--- a/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Limits.lean
@@ -476,9 +476,9 @@ lemma colimitsOfShape_le_of_final {J' : Type*} [Category J'] (F : J ⥤ J') [F.F
   have h₁' : IsColimit (c₁.whisker F) := (Functor.Final.isColimitWhiskerEquiv F c₁).symm h₁
   have h₂' : IsColimit (c₂.whisker F) := (Functor.Final.isColimitWhiskerEquiv F c₂).symm h₂
   have : h₁.desc (Cocone.mk c₂.pt (f ≫ c₂.ι)) =
-      h₁'.desc (Cocone.mk c₂.pt (whiskerLeft _ f ≫ (c₂.whisker F).ι)) :=
+      h₁'.desc (Cocone.mk c₂.pt (Functor.whiskerLeft _ f ≫ (c₂.whisker F).ι)) :=
     h₁'.hom_ext (fun j ↦ by
-      have := h₁'.fac (Cocone.mk c₂.pt (whiskerLeft F f ≫ whiskerLeft F c₂.ι)) j
+      have := h₁'.fac (Cocone.mk c₂.pt (Functor.whiskerLeft F f ≫ Functor.whiskerLeft F c₂.ι)) j
       dsimp at this ⊢
       simp [this])
   rw [this]

--- a/Mathlib/CategoryTheory/Opposites.lean
+++ b/Mathlib/CategoryTheory/Opposites.lean
@@ -58,6 +58,8 @@ end Quiver
 
 namespace CategoryTheory
 
+open Functor
+
 variable [Category.{v₁} C]
 
 /-- The opposite category. -/

--- a/Mathlib/CategoryTheory/Pi/Basic.lean
+++ b/Mathlib/CategoryTheory/Pi/Basic.lean
@@ -17,6 +17,8 @@ We define the pointwise category structure on indexed families of objects in a c
 
 namespace CategoryTheory
 
+open Functor
+
 universe w₀ w₁ w₂ v₁ v₂ v₃ u₁ u₂ u₃
 
 variable {I : Type w₀} {J : Type w₁} (C : I → Type u₁) [∀ i, Category.{v₁} (C i)]
@@ -313,18 +315,18 @@ attribute [local simp] eqToHom_map
 @[simps]
 noncomputable def Pi.equivalenceOfEquiv (e : J ≃ I) :
     (∀ j, C (e j)) ≌ (∀ i, C i) where
-  functor := Functor.pi' (fun i => Pi.eval _ (e.symm i) ⋙
+  functor := pi' (fun i => Pi.eval _ (e.symm i) ⋙
     (Pi.eqToEquivalence C (by simp)).functor)
   inverse := Functor.pi' (fun i' => Pi.eval _ (e i'))
-  unitIso := NatIso.pi' (fun i' => Functor.leftUnitor _ ≪≫
+  unitIso := NatIso.pi' (fun i' => leftUnitor _ ≪≫
     (Pi.evalCompEqToEquivalenceFunctor (fun j => C (e j)) (e.symm_apply_apply i')).symm ≪≫
     isoWhiskerLeft _ ((Pi.eqToEquivalenceFunctorIso C e (e.symm_apply_apply i')).symm) ≪≫
-    (Functor.pi'CompEval _ _).symm ≪≫ isoWhiskerLeft _ (Functor.pi'CompEval _ _).symm ≪≫
-    (Functor.associator _ _ _).symm)
-  counitIso := NatIso.pi' (fun i => (Functor.associator _ _ _).symm ≪≫
-    isoWhiskerRight (Functor.pi'CompEval _ _) _ ≪≫
+    (pi'CompEval _ _).symm ≪≫ isoWhiskerLeft _ (pi'CompEval _ _).symm ≪≫
+    (associator _ _ _).symm)
+  counitIso := NatIso.pi' (fun i => (associator _ _ _).symm ≪≫
+    isoWhiskerRight (pi'CompEval _ _) _ ≪≫
     Pi.evalCompEqToEquivalenceFunctor C (e.apply_symm_apply i) ≪≫
-    (Functor.leftUnitor _).symm)
+    (leftUnitor _).symm)
 
 /-- A product of categories indexed by `Option J` identifies to a binary product. -/
 @[simps]

--- a/Mathlib/CategoryTheory/Preadditive/Mat.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Mat.lean
@@ -455,7 +455,7 @@ def equivalenceSelfOfHasFiniteBiproductsAux [HasFiniteBiproducts C] :
     embedding C ⋙ 𝟭 (Mat_ C) ≅ embedding C ⋙ lift (𝟭 C) ⋙ embedding C :=
   Functor.rightUnitor _ ≪≫
     (Functor.leftUnitor _).symm ≪≫
-      isoWhiskerRight (embeddingLiftIso _).symm _ ≪≫ Functor.associator _ _ _
+      Functor.isoWhiskerRight (embeddingLiftIso _).symm _ ≪≫ Functor.associator _ _ _
 
 /--
 A preadditive category that already has finite biproducts is equivalent to its additive envelope.

--- a/Mathlib/CategoryTheory/Preadditive/Yoneda/Basic.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Yoneda/Basic.lean
@@ -25,7 +25,7 @@ embedding in the expected way and deduce that the preadditive Yoneda embedding i
 
 universe v u u₁
 
-open CategoryTheory.Preadditive Opposite CategoryTheory.Limits
+open CategoryTheory.Preadditive Opposite CategoryTheory.Limits CategoryTheory.Functor
 
 noncomputable section
 

--- a/Mathlib/CategoryTheory/Products/Basic.lean
+++ b/Mathlib/CategoryTheory/Products/Basic.lean
@@ -27,6 +27,8 @@ and products of functors and natural transformations, written `F.prod G` and `α
 
 namespace CategoryTheory
 
+open Functor
+
 -- declare the `v`'s first; see `CategoryTheory.Category` for an explanation
 universe v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
 

--- a/Mathlib/CategoryTheory/Quotient.lean
+++ b/Mathlib/CategoryTheory/Quotient.lean
@@ -29,6 +29,8 @@ instance (C) [Quiver C] : Inhabited (HomRel C) where
 
 namespace CategoryTheory
 
+open Functor
+
 section
 
 variable {C D : Type*} [Category C] [Category D] (F : C ⥤ D)

--- a/Mathlib/CategoryTheory/Shift/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Shift/Adjunction.lean
@@ -232,11 +232,11 @@ lemma mk' (h : NatTrans.CommShift adj.unit A) :
   commShift_counit := ⟨fun a ↦ by
     ext
     simp only [Functor.comp_obj, Functor.id_obj, NatTrans.comp_app,
-      Functor.commShiftIso_comp_hom_app, whiskerRight_app, assoc, whiskerLeft_app,
+      Functor.commShiftIso_comp_hom_app, Functor.whiskerRight_app, assoc, Functor.whiskerLeft_app,
       Functor.commShiftIso_id_hom_app, comp_id]
     refine (compatibilityCounit_of_compatibilityUnit adj _ _ (fun X ↦ ?_) _).symm
     simpa only [NatTrans.comp_app,
-      Functor.commShiftIso_id_hom_app, whiskerRight_app, id_comp,
+      Functor.commShiftIso_id_hom_app, Functor.whiskerRight_app, id_comp,
       Functor.commShiftIso_comp_hom_app] using congr_app (h.shift_comm a) X⟩
 
 variable [adj.CommShift A]

--- a/Mathlib/CategoryTheory/Shift/Basic.lean
+++ b/Mathlib/CategoryTheory/Shift/Basic.lean
@@ -39,6 +39,8 @@ which are stated in lemmas like `shiftFunctorAdd'_assoc`, `shiftFunctorAdd'_zero
 
 namespace CategoryTheory
 
+open Functor
+
 noncomputable section
 
 universe v u
@@ -217,7 +219,7 @@ variable (C)
 variable [HasShift C A]
 
 lemma shiftFunctorAdd'_zero_add (a : A) :
-    shiftFunctorAdd' C 0 a a (zero_add a) = (Functor.leftUnitor _).symm ≪≫
+    shiftFunctorAdd' C 0 a a (zero_add a) = (leftUnitor _).symm ≪≫
     isoWhiskerRight (shiftFunctorZero C A).symm (shiftFunctor C a) := by
   ext X
   dsimp [shiftFunctorAdd', shiftFunctorZero, shiftFunctor]
@@ -226,7 +228,7 @@ lemma shiftFunctorAdd'_zero_add (a : A) :
   rfl
 
 lemma shiftFunctorAdd'_add_zero (a : A) :
-    shiftFunctorAdd' C a 0 a (add_zero a) = (Functor.rightUnitor _).symm ≪≫
+    shiftFunctorAdd' C a 0 a (add_zero a) = (rightUnitor _).symm ≪≫
     isoWhiskerLeft (shiftFunctor C a) (shiftFunctorZero C A).symm := by
   ext
   dsimp [shiftFunctorAdd', shiftFunctorZero, shiftFunctor]
@@ -237,7 +239,7 @@ lemma shiftFunctorAdd'_add_zero (a : A) :
 lemma shiftFunctorAdd'_assoc (a₁ a₂ a₃ a₁₂ a₂₃ a₁₂₃ : A)
     (h₁₂ : a₁ + a₂ = a₁₂) (h₂₃ : a₂ + a₃ = a₂₃) (h₁₂₃ : a₁ + a₂ + a₃ = a₁₂₃) :
     shiftFunctorAdd' C a₁₂ a₃ a₁₂₃ (by rw [← h₁₂, h₁₂₃]) ≪≫
-      isoWhiskerRight (shiftFunctorAdd' C a₁ a₂ a₁₂ h₁₂) _ ≪≫ Functor.associator _ _ _ =
+      isoWhiskerRight (shiftFunctorAdd' C a₁ a₂ a₁₂ h₁₂) _ ≪≫ associator _ _ _ =
     shiftFunctorAdd' C a₁ a₂₃ a₁₂₃ (by rw [← h₂₃, ← add_assoc, h₁₂₃]) ≪≫
       isoWhiskerLeft _ (shiftFunctorAdd' C a₂ a₃ a₂₃ h₂₃) := by
   subst h₁₂ h₂₃ h₁₂₃
@@ -254,7 +256,7 @@ lemma shiftFunctorAdd'_assoc (a₁ a₂ a₃ a₁₂ a₂₃ a₁₂₃ : A)
 
 lemma shiftFunctorAdd_assoc (a₁ a₂ a₃ : A) :
     shiftFunctorAdd C (a₁ + a₂) a₃ ≪≫
-      isoWhiskerRight (shiftFunctorAdd C a₁ a₂) _ ≪≫ Functor.associator _ _ _ =
+      isoWhiskerRight (shiftFunctorAdd C a₁ a₂) _ ≪≫ associator _ _ _ =
     shiftFunctorAdd' C a₁ (a₂ + a₃) _ (add_assoc a₁ a₂ a₃).symm ≪≫
       isoWhiskerLeft _ (shiftFunctorAdd C a₂ a₃) := by
   ext X
@@ -668,7 +670,7 @@ namespace hasShift
 /-- auxiliary definition for `FullyFaithful.hasShift` -/
 def zero : s 0 ≅ 𝟭 C :=
   (hF.whiskeringRight C).preimageIso ((i 0) ≪≫ isoWhiskerLeft F (shiftFunctorZero D A) ≪≫
-    Functor.rightUnitor _ ≪≫ (Functor.leftUnitor _).symm)
+    rightUnitor _ ≪≫ (leftUnitor _).symm)
 
 @[simp]
 lemma map_zero_hom_app (X : C) :
@@ -685,9 +687,9 @@ lemma map_zero_inv_app (X : C) :
 /-- auxiliary definition for `FullyFaithful.hasShift` -/
 def add (a b : A) : s (a + b) ≅ s a ⋙ s b :=
   (hF.whiskeringRight C).preimageIso (i (a + b) ≪≫ isoWhiskerLeft _ (shiftFunctorAdd D a b) ≪≫
-      (Functor.associator _ _ _).symm ≪≫ (isoWhiskerRight (i a).symm _) ≪≫
-      Functor.associator _ _ _ ≪≫ (isoWhiskerLeft _ (i b).symm) ≪≫
-      (Functor.associator _ _ _).symm)
+      (associator _ _ _).symm ≪≫ (isoWhiskerRight (i a).symm _) ≪≫
+      associator _ _ _ ≪≫ (isoWhiskerLeft _ (i b).symm) ≪≫
+      (associator _ _ _).symm)
 
 @[simp]
 lemma map_add_hom_app (a b : A) (X : C) :

--- a/Mathlib/CategoryTheory/Shift/CommShift.lean
+++ b/Mathlib/CategoryTheory/Shift/CommShift.lean
@@ -265,8 +265,8 @@ variable {C D E J : Type*} [Category C] [Category D] [Category E] [Category J]
 which commute with a shift by an additive monoid `A`, this typeclass
 asserts a compatibility of `τ` with these shifts. -/
 class CommShift : Prop where
-  shift_comm (a : A) : (F₁.commShiftIso a).hom ≫ whiskerRight τ _ =
-    whiskerLeft _ τ ≫ (F₂.commShiftIso a).hom := by aesop_cat
+  shift_comm (a : A) : (F₁.commShiftIso a).hom ≫ Functor.whiskerRight τ _ =
+    Functor.whiskerLeft _ τ ≫ (F₂.commShiftIso a).hom := by aesop_cat
 
 section
 
@@ -274,8 +274,8 @@ variable {A} [NatTrans.CommShift τ A]
 
 @[reassoc]
 lemma shift_comm (a : A) :
-    (F₁.commShiftIso a).hom ≫ whiskerRight τ _ =
-      whiskerLeft _ τ ≫ (F₂.commShiftIso a).hom := by
+    (F₁.commShiftIso a).hom ≫ Functor.whiskerRight τ _ =
+      Functor.whiskerLeft _ τ ≫ (F₂.commShiftIso a).hom := by
   apply CommShift.shift_comm
 
 @[reassoc]
@@ -329,16 +329,15 @@ instance comp [NatTrans.CommShift τ A] [NatTrans.CommShift τ' A] :
     NatTrans.CommShift (τ ≫ τ') A where
 
 instance whiskerRight [NatTrans.CommShift τ A] :
-    NatTrans.CommShift (whiskerRight τ G) A := ⟨fun a => by
+    NatTrans.CommShift (Functor.whiskerRight τ G) A := ⟨fun a => by
   ext X
-  simp only [whiskerRight_twice, Functor.associator_hom_app, Functor.associator_inv_app, id_comp,
-    comp_id, comp_app, whiskerRight_app, Functor.comp_map, whiskerLeft_app,
-    Functor.commShiftIso_comp_hom_app, Category.assoc,
-    ← Functor.commShiftIso_hom_naturality,
-    ← G.map_comp_assoc, shift_app_comm]⟩
+  simp only [Functor.whiskerRight_twice, comp_app, Functor.commShiftIso_comp_hom_app,
+    Functor.associator_hom_app, Functor.whiskerRight_app, Functor.comp_map,
+    Functor.associator_inv_app, comp_id, id_comp, assoc, ← Functor.commShiftIso_hom_naturality, ←
+    G.map_comp_assoc, shift_app_comm, Functor.whiskerLeft_app]⟩
 
 instance whiskerLeft [NatTrans.CommShift τ'' A] :
-    NatTrans.CommShift (whiskerLeft F₁ τ'') A where
+    NatTrans.CommShift (Functor.whiskerLeft F₁ τ'') A where
 
 instance associator : CommShift (Functor.associator F₁ G H).hom A where
 
@@ -425,10 +424,10 @@ lemma NatTrans.CommShift.verticalComposition {C₁ C₂ C₃ D₁ D₂ D₃ : Ty
     [G₁₂.CommShift A] [G₂₃.CommShift A] [G₁₃.CommShift A] [CommShift β A]
     [L₁.CommShift A] [L₂.CommShift A] [L₃.CommShift A]
     [CommShift e₁₂ A] [CommShift e₂₃ A]
-    (h₁₃ : e₁₃ = CategoryTheory.whiskerRight α L₃ ≫ (Functor.associator _ _ _).hom ≫
-      CategoryTheory.whiskerLeft F₁₂ e₂₃ ≫ (Functor.associator _ _ _).inv ≫
-        CategoryTheory.whiskerRight e₁₂ G₂₃ ≫ (Functor.associator _ _ _).hom ≫
-          CategoryTheory.whiskerLeft L₁ β) : CommShift e₁₃ A := by
+    (h₁₃ : e₁₃ = Functor.whiskerRight α L₃ ≫ (Functor.associator _ _ _).hom ≫
+      Functor.whiskerLeft F₁₂ e₂₃ ≫ (Functor.associator _ _ _).inv ≫
+        Functor.whiskerRight e₁₂ G₂₃ ≫ (Functor.associator _ _ _).hom ≫
+          Functor.whiskerLeft L₁ β) : CommShift e₁₃ A := by
   subst h₁₃
   infer_instance
 

--- a/Mathlib/CategoryTheory/Shift/Induced.lean
+++ b/Mathlib/CategoryTheory/Shift/Induced.lean
@@ -25,6 +25,8 @@ used for both quotient and localized shifts.
 
 namespace CategoryTheory
 
+open Functor
+
 variable {C D : Type _} [Category C] [Category D]
   (F : C ⥤ D) {A : Type _} [AddMonoid A] [HasShift C A]
   (s : A → D ⥤ D) (i : ∀ a, F ⋙ s a ≅ shiftFunctor C a ⋙ F)

--- a/Mathlib/CategoryTheory/Shift/InducedShiftSequence.lean
+++ b/Mathlib/CategoryTheory/Shift/InducedShiftSequence.lean
@@ -26,7 +26,7 @@ homotopy category of cochain complexes (TODO), and also on the derived category 
 
 -/
 
-open CategoryTheory Category
+open CategoryTheory Category Functor
 
 namespace CategoryTheory
 

--- a/Mathlib/CategoryTheory/Shift/Localization.lean
+++ b/Mathlib/CategoryTheory/Shift/Localization.lean
@@ -233,7 +233,7 @@ instance NatTrans.commShift_iso_hom_of_localization :
   constructor
   intro a
   ext X
-  simp only [comp_app, whiskerRight_app, whiskerLeft_app,
+  simp only [comp_app, Functor.whiskerRight_app, Functor.whiskerLeft_app,
     Functor.commShiftIso_comp_hom_app,
     Functor.commShiftOfLocalization_iso_hom_app,
     Category.assoc, ← Functor.map_comp, ← Functor.map_comp_assoc,

--- a/Mathlib/CategoryTheory/Shift/Quotient.lean
+++ b/Mathlib/CategoryTheory/Shift/Quotient.lean
@@ -70,9 +70,9 @@ variable {A}
 noncomputable def iso (a : A) :
     shiftFunctor (Quotient r) a ⋙ lift r F hF ≅ lift r F hF ⋙ shiftFunctor D a :=
   natIsoLift r ((Functor.associator _ _ _).symm ≪≫
-    isoWhiskerRight ((functor r).commShiftIso a).symm _ ≪≫
-    Functor.associator _ _ _ ≪≫ isoWhiskerLeft _ (lift.isLift r F hF) ≪≫ F.commShiftIso a ≪≫
-    isoWhiskerRight (lift.isLift r F hF).symm _ ≪≫ Functor.associator _ _ _)
+    Functor.isoWhiskerRight ((functor r).commShiftIso a).symm _ ≪≫
+    Functor.associator _ _ _ ≪≫ Functor.isoWhiskerLeft _ (lift.isLift r F hF) ≪≫ F.commShiftIso a ≪≫
+    Functor.isoWhiskerRight (lift.isLift r F hF).symm _ ≪≫ Functor.associator _ _ _)
 
 @[simp]
 lemma iso_hom_app (a : A) (X : C) :

--- a/Mathlib/CategoryTheory/Shift/SingleFunctors.lean
+++ b/Mathlib/CategoryTheory/Shift/SingleFunctors.lean
@@ -25,7 +25,7 @@ which sends an object `X : C` to a complex where `X` sits in a single degree.
 
 -/
 
-open CategoryTheory Category ZeroObject Limits
+open CategoryTheory Category ZeroObject Limits Functor
 
 variable (C D E E' : Type*) [Category C] [Category D] [Category E] [Category E']
   (A : Type*) [AddMonoid A] [HasShift D A] [HasShift E A] [HasShift E' A]

--- a/Mathlib/CategoryTheory/Sigma/Basic.lean
+++ b/Mathlib/CategoryTheory/Sigma/Basic.lean
@@ -212,7 +212,7 @@ variable {I} {K : Type w₃}
 @[simps!]
 def mapComp (f : K → J) (g : J → I) : map (fun x ↦ C (g x)) f ⋙ (map C g :) ≅ map C (g ∘ f) :=
   (descUniq _ _) fun k =>
-    (isoWhiskerRight (inclCompMap (fun i => C (g i)) f k) (map C g :) :) ≪≫ inclCompMap _ _ _
+    (Functor.isoWhiskerRight (inclCompMap _ f k) (map C g :) :) ≪≫ inclCompMap _ g (f k)
 
 end
 

--- a/Mathlib/CategoryTheory/Sites/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Sites/Adjunction.lean
@@ -17,7 +17,7 @@ categories of sheaves. We also show that `G` preserves sheafification.
 
 namespace CategoryTheory
 
-open GrothendieckTopology Limits Opposite
+open GrothendieckTopology Limits Opposite Functor
 
 universe v₁ v₂ u₁ u₂
 

--- a/Mathlib/CategoryTheory/Sites/Coherent/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/Equivalence.lean
@@ -58,7 +58,7 @@ theorem precoherent_isSheaf_iff (e : C ≌ D) (F : Cᵒᵖ ⥤ A) : haveI := e.p
   refine ⟨fun hF ↦ ((e.sheafCongrPrecoherent A).functor.obj ⟨F, hF⟩).cond, fun hF ↦ ?_⟩
   rw [isSheaf_of_iso_iff (P' := e.functor.op ⋙ e.inverse.op ⋙ F)]
   · exact (e.sheafCongrPrecoherent A).inverse.obj ⟨e.inverse.op ⋙ F, hF⟩ |>.cond
-  · exact isoWhiskerRight e.op.unitIso F
+  · exact Functor.isoWhiskerRight e.op.unitIso F
 
 /--
 The coherent sheaf condition on an essentially small site can be checked after precomposing with
@@ -106,7 +106,7 @@ theorem preregular_isSheaf_iff (e : C ≌ D) (F : Cᵒᵖ ⥤ A) : haveI := e.pr
   refine ⟨fun hF ↦ ((e.sheafCongrPreregular A).functor.obj ⟨F, hF⟩).cond, fun hF ↦ ?_⟩
   rw [isSheaf_of_iso_iff (P' := e.functor.op ⋙ e.inverse.op ⋙ F)]
   · exact (e.sheafCongrPreregular A).inverse.obj ⟨e.inverse.op ⋙ F, hF⟩ |>.cond
-  · exact isoWhiskerRight e.op.unitIso F
+  · exact Functor.isoWhiskerRight e.op.unitIso F
 
 /--
 The regular sheaf condition on an essentially small site can be checked after precomposing with

--- a/Mathlib/CategoryTheory/Sites/Coherent/LocallySurjective.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/LocallySurjective.lean
@@ -75,7 +75,7 @@ lemma extensiveTopology.surjective_of_isLocallySurjective_sheaf_of_types [Finita
   intro ⟨a⟩
   simp only [Functor.comp_obj, Discrete.opposite_inverse_obj, Functor.op_obj, Discrete.functor_obj,
     Functor.mapCone_pt, Cone.whisker_pt, Cocone.op_pt, Cofan.mk_pt, Functor.const_obj_obj,
-    Functor.mapCone_π_app, Cone.whisker_π, Cocone.op_π, whiskerLeft_app, NatTrans.op_app,
+    Functor.mapCone_π_app, Cone.whisker_π, Cocone.op_π, Functor.whiskerLeft_app, NatTrans.op_app,
     Cofan.mk_ι_app]
   rw [← (h' a).choose_spec]
   erw [← NatTrans.naturality_apply (φ := f)]
@@ -93,7 +93,8 @@ lemma extensiveTopology.presheafIsLocallySurjective_iff [FinitaryPreExtensive C]
         ∀ (X : C), Function.Surjective (f.app (op X)) := by
   constructor
   · rw [Presheaf.isLocallySurjective_iff_whisker_forget (J := extensiveTopology C)]
-    exact fun h _ ↦ surjective_of_isLocallySurjective_sheaf_of_types (whiskerRight f (forget D)) h
+    exact fun h _ ↦
+      surjective_of_isLocallySurjective_sheaf_of_types (Functor.whiskerRight f (forget D)) h
   · intro h
     refine ⟨fun {X} y ↦ ?_⟩
     obtain ⟨x, hx⟩ := h X y

--- a/Mathlib/CategoryTheory/Sites/CompatiblePlus.lean
+++ b/Mathlib/CategoryTheory/Sites/CompatiblePlus.lean
@@ -20,7 +20,7 @@ noncomputable section
 
 namespace CategoryTheory.GrothendieckTopology
 
-open CategoryTheory Limits Opposite
+open CategoryTheory Limits Opposite Functor
 
 universe w₁ w₂ v u
 

--- a/Mathlib/CategoryTheory/Sites/CompatibleSheafification.lean
+++ b/Mathlib/CategoryTheory/Sites/CompatibleSheafification.lean
@@ -18,7 +18,7 @@ namespace CategoryTheory.GrothendieckTopology
 
 open CategoryTheory
 
-open CategoryTheory.Limits
+open CategoryTheory.Limits CategoryTheory.Functor
 
 open Opposite
 
@@ -55,7 +55,7 @@ noncomputable def sheafificationWhiskerLeftIso (P : Cᵒᵖ ⥤ D)
         PreservesLimit (W.index P).multicospan F] :
     (whiskeringLeft _ _ E).obj (J.sheafify P) ≅
     (whiskeringLeft _ _ _).obj P ⋙ J.sheafification E := by
-  refine J.plusFunctorWhiskerLeftIso _ ≪≫ ?_ ≪≫ Functor.associator _ _ _
+  refine J.plusFunctorWhiskerLeftIso _ ≪≫ ?_ ≪≫ associator _ _ _
   refine isoWhiskerRight ?_ _
   exact J.plusFunctorWhiskerLeftIso _
 
@@ -82,10 +82,10 @@ the sheafification of `P ⋙ F`, functorially in `P`. -/
 noncomputable def sheafificationWhiskerRightIso :
     J.sheafification D ⋙ (whiskeringRight _ _ _).obj F ≅
       (whiskeringRight _ _ _).obj F ⋙ J.sheafification E := by
-  refine Functor.associator _ _ _ ≪≫ ?_
+  refine associator _ _ _ ≪≫ ?_
   refine isoWhiskerLeft (J.plusFunctor D) (J.plusFunctorWhiskerRightIso _) ≪≫ ?_
-  refine ?_ ≪≫ Functor.associator _ _ _
-  refine (Functor.associator _ _ _).symm ≪≫ ?_
+  refine ?_ ≪≫ associator _ _ _
+  refine (associator _ _ _).symm ≪≫ ?_
   exact isoWhiskerRight (J.plusFunctorWhiskerRightIso _) (J.plusFunctor E)
 
 @[simp]

--- a/Mathlib/CategoryTheory/Sites/ConcreteSheafification.lean
+++ b/Mathlib/CategoryTheory/Sites/ConcreteSheafification.lean
@@ -480,7 +480,7 @@ theorem sheafification_map {P Q : Cᵒᵖ ⥤ D} (η : P ⟶ Q) :
 /-- The canonical map from `P` to its sheafification, as a natural transformation.
 *Note:* We only show this is a sheaf under additional hypotheses on `D`. -/
 noncomputable def toSheafification : 𝟭 _ ⟶ sheafification J D :=
-  J.toPlusNatTrans D ≫ whiskerRight (J.toPlusNatTrans D) (J.plusFunctor D)
+  J.toPlusNatTrans D ≫ Functor.whiskerRight (J.toPlusNatTrans D) (J.plusFunctor D)
 
 @[simp]
 theorem toSheafification_app (P : Cᵒᵖ ⥤ D) :

--- a/Mathlib/CategoryTheory/Sites/EpiMono.lean
+++ b/Mathlib/CategoryTheory/Sites/EpiMono.lean
@@ -23,7 +23,7 @@ universe w v' u' v u
 
 namespace CategoryTheory
 
-open Category ConcreteCategory
+open Category ConcreteCategory Functor
 
 variable {C : Type u} [Category.{v} C] (J : GrothendieckTopology C)
   (A : Type u') [Category.{v'} A] {FA : A → A → Type*} {CA : A → Type w}

--- a/Mathlib/CategoryTheory/Sites/LeftExact.lean
+++ b/Mathlib/CategoryTheory/Sites/LeftExact.lean
@@ -272,7 +272,7 @@ def plusPlusSheafIsoPresheafToSheaf : plusPlusSheaf J D ≅ presheafToSheaf J D 
 
 /-- `plusPlusFunctor` is isomorphic to `sheafification`. -/
 def plusPlusFunctorIsoSheafification : J.sheafification D ≅ sheafification J D :=
-  isoWhiskerRight (plusPlusSheafIsoPresheafToSheaf J D) (sheafToPresheaf J D)
+  Functor.isoWhiskerRight (plusPlusSheafIsoPresheafToSheaf J D) (sheafToPresheaf J D)
 
 /-- `plusPlus` is isomorphic to `sheafify`. -/
 def plusPlusIsoSheafify (P : Cᵒᵖ ⥤ D) : J.sheafify P ≅ sheafify J P :=

--- a/Mathlib/CategoryTheory/Sites/Limits.lean
+++ b/Mathlib/CategoryTheory/Sites/Limits.lean
@@ -188,7 +188,7 @@ In `isColimitSheafifyCocone`, we show that this is a colimit cocone when `E` is 
 noncomputable def sheafifyCocone {F : K ⥤ Sheaf J D}
     (E : Cocone (F ⋙ sheafToPresheaf J D)) : Cocone F :=
   (Cocones.precompose
-    (isoWhiskerLeft F (asIso (sheafificationAdjunction J D).counit).symm).hom).obj
+    (Functor.isoWhiskerLeft F (asIso (sheafificationAdjunction J D).counit).symm).hom).obj
     ((presheafToSheaf J D).mapCocone E)
 
 /-- If `E` is a colimit cocone of presheaves, over a diagram factoring through sheaves,

--- a/Mathlib/CategoryTheory/Sites/LocallyInjective.lean
+++ b/Mathlib/CategoryTheory/Sites/LocallyInjective.lean
@@ -90,15 +90,15 @@ instance [IsIso φ] : IsLocallyInjective J φ :=
 
 attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 instance isLocallyInjective_forget [IsLocallyInjective J φ] :
-    IsLocallyInjective J (whiskerRight φ (forget D)) where
+    IsLocallyInjective J (Functor.whiskerRight φ (forget D)) where
   equalizerSieve_mem x y h := equalizerSieve_mem J φ x y h
 
 attribute [local instance] Types.instFunLike Types.instConcreteCategory in
 lemma isLocallyInjective_forget_iff :
-    IsLocallyInjective J (whiskerRight φ (forget D)) ↔ IsLocallyInjective J φ := by
+    IsLocallyInjective J (Functor.whiskerRight φ (forget D)) ↔ IsLocallyInjective J φ := by
   constructor
   · intro
-    exact ⟨fun x y h => equalizerSieve_mem J (whiskerRight φ (forget D)) x y h⟩
+    exact ⟨fun x y h => equalizerSieve_mem J (Functor.whiskerRight φ (forget D)) x y h⟩
   · intro
     infer_instance
 

--- a/Mathlib/CategoryTheory/Sites/LocallySurjective.lean
+++ b/Mathlib/CategoryTheory/Sites/LocallySurjective.lean
@@ -27,7 +27,7 @@ import Mathlib.CategoryTheory.Sites.LocallyInjective
 
 universe v u w v' u' w'
 
-open Opposite CategoryTheory CategoryTheory.GrothendieckTopology
+open Opposite CategoryTheory CategoryTheory.GrothendieckTopology CategoryTheory.Functor
 
 namespace CategoryTheory
 

--- a/Mathlib/CategoryTheory/Sites/MayerVietorisSquare.lean
+++ b/Mathlib/CategoryTheory/Sites/MayerVietorisSquare.lean
@@ -147,7 +147,7 @@ noncomputable def mk_of_isPullback (sq : Square C) [Mono sq.f₂₄] [Mono sq.f�
 variable (S : J.MayerVietorisSquare)
 
 lemma isPushoutAddCommGrpFreeSheaf [HasWeakSheafify J AddCommGrp.{v}] :
-    (S.map (yoneda ⋙ (whiskeringRight _ _ _).obj AddCommGrp.free ⋙
+    (S.map (yoneda ⋙ (Functor.whiskeringRight _ _ _).obj AddCommGrp.free ⋙
       presheafToSheaf J _)).IsPushout :=
   (S.isPushout.map (Sheaf.composeAndSheafify J AddCommGrp.free)).of_iso
     ((Square.mapFunctor.mapIso
@@ -234,13 +234,13 @@ noncomputable def shortComplex :
   X₃ := (presheafToSheaf J _).obj (yoneda.obj S.X₄ ⋙ AddCommGrp.free)
   f :=
     biprod.lift
-      ((presheafToSheaf J _).map (whiskerRight (yoneda.map S.f₁₂) _))
-      (-(presheafToSheaf J _).map (whiskerRight (yoneda.map S.f₁₃) _))
+      ((presheafToSheaf J _).map (Functor.whiskerRight (yoneda.map S.f₁₂) _))
+      (-(presheafToSheaf J _).map (Functor.whiskerRight (yoneda.map S.f₁₃) _))
   g :=
     biprod.desc
-      ((presheafToSheaf J _).map (whiskerRight (yoneda.map S.f₂₄) _))
-      ((presheafToSheaf J _).map (whiskerRight (yoneda.map S.f₃₄) _))
-  zero := (S.map (yoneda ⋙ (whiskeringRight _ _ _).obj AddCommGrp.free ⋙
+      ((presheafToSheaf J _).map (Functor.whiskerRight (yoneda.map S.f₂₄) _))
+      ((presheafToSheaf J _).map (Functor.whiskerRight (yoneda.map S.f₃₄) _))
+  zero := (S.map (yoneda ⋙ (Functor.whiskeringRight _ _ _).obj AddCommGrp.free ⋙
       presheafToSheaf J _)).cokernelCofork.condition
 
 instance : Mono S.shortComplex.f := by

--- a/Mathlib/CategoryTheory/Sites/PreservesSheafification.lean
+++ b/Mathlib/CategoryTheory/Sites/PreservesSheafification.lean
@@ -43,7 +43,7 @@ universe v u
 
 namespace CategoryTheory
 
-open Category Limits
+open Category Limits Functor
 
 variable {C : Type u} [Category.{v} C] (J : GrothendieckTopology C)
   {A B : Type*} [Category A] [Category B] (F : A ⥤ B)

--- a/Mathlib/CategoryTheory/Sites/Sheaf.lean
+++ b/Mathlib/CategoryTheory/Sites/Sheaf.lean
@@ -279,8 +279,8 @@ end
 
 theorem isSheaf_of_iso_iff {P P' : Cᵒᵖ ⥤ A} (e : P ≅ P') : IsSheaf J P ↔ IsSheaf J P' :=
   forall_congr' fun _ =>
-    ⟨Presieve.isSheaf_iso J (isoWhiskerRight e _),
-      Presieve.isSheaf_iso J (isoWhiskerRight e.symm _)⟩
+    ⟨Presieve.isSheaf_iso J (Functor.isoWhiskerRight e _),
+      Presieve.isSheaf_iso J (Functor.isoWhiskerRight e.symm _)⟩
 
 variable (J)
 
@@ -379,7 +379,7 @@ theorem isSheaf_iff_isSheaf_of_type (P : Cᵒᵖ ⥤ Type w) :
   constructor
   · intro hP
     refine Presieve.isSheaf_iso J ?_ (hP PUnit)
-    exact isoWhiskerLeft _ Coyoneda.punitIso ≪≫ P.rightUnitor
+    exact Functor.isoWhiskerLeft _ Coyoneda.punitIso ≪≫ P.rightUnitor
   · intro hP X Y S hS z hz
     refine ⟨fun x => (hP S hS).amalgamate (fun Z f hf => z f hf x) ?_, ?_, ?_⟩
     · intro Y₁ Y₂ Z g₁ g₂ f₁ f₂ hf₁ hf₂ h

--- a/Mathlib/CategoryTheory/Sites/SheafCohomology/Basic.lean
+++ b/Mathlib/CategoryTheory/Sites/SheafCohomology/Basic.lean
@@ -69,7 +69,7 @@ presheaf of sets `yoneda.obj U` to `F`. -/
 noncomputable def cohomologyPresheafFunctor (n : ℕ) :
     Sheaf J AddCommGrp.{v} ⥤ Cᵒᵖ ⥤ AddCommGrp.{w'} :=
   Functor.flip
-    (Functor.op (yoneda ⋙ (whiskeringRight _ _ _).obj
+    (Functor.op (yoneda ⋙ (Functor.whiskeringRight _ _ _).obj
       AddCommGrp.free ⋙ presheafToSheaf _ _) ⋙ extFunctor n)
 
 /-- Given an abelian sheaf `F`, this is the presheaf which sends `U`

--- a/Mathlib/CategoryTheory/Sites/SheafHom.lean
+++ b/Mathlib/CategoryTheory/Sites/SheafHom.lean
@@ -42,7 +42,7 @@ to the type of morphisms between the "restrictions" of `F` and `G` to the catego
 @[simps! obj]
 def presheafHom : Cᵒᵖ ⥤ Type _ where
   obj X := (Over.forget X.unop).op ⋙ F ⟶ (Over.forget X.unop).op ⋙ G
-  map f := whiskerLeft (Over.map f.unop).op
+  map f := Functor.whiskerLeft (Over.map f.unop).op
   map_id := by
     rintro ⟨X⟩
     ext φ ⟨Y⟩
@@ -84,7 +84,7 @@ def presheafHomSectionsEquiv : (presheafHom F G).sections ≃ (F ⟶ G) where
           (Over.homMk f : Over.mk f ⟶ Over.mk (𝟙 X₁)).op)
         rw [← s.2 f.op, presheafHom_map_app_op_mk_id]
         rfl }
-  invFun f := ⟨fun _ => whiskerLeft _ f, fun _ => rfl⟩
+  invFun f := ⟨fun _ => Functor.whiskerLeft _ f, fun _ => rfl⟩
   left_inv s := by
     dsimp
     ext ⟨X⟩ ⟨Y : Over X⟩

--- a/Mathlib/CategoryTheory/Sites/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Sites/Whiskering.lean
@@ -23,7 +23,7 @@ Given a natural transformation `η : F ⟶ G`, we obtain a natural transformatio
 
 namespace CategoryTheory
 
-open CategoryTheory.Limits
+open CategoryTheory.Limits Functor
 
 universe v₁ v₂ v₃ u₁ u₂ u₃
 

--- a/Mathlib/CategoryTheory/SmallObject/IsCardinalForSmallObjectArgument.lean
+++ b/Mathlib/CategoryTheory/SmallObject/IsCardinalForSmallObjectArgument.lean
@@ -420,7 +420,7 @@ lemma πObj_naturality {f g : Arrow C} (φ : f ⟶ g) :
   change _ ≫ _ ≫ e₂.inv = (_ ≫ e₁.inv) ≫ _
   have h₁ := ((iteration I κ).map φ).w =≫ e₂.inv
   have h₂ : φ.right ≫ e₂.hom = e₁.hom ≫ ((iteration I κ).map φ).right :=
-    ((whiskerRight (ιIteration I κ) Arrow.rightFunc).naturality φ)
+    ((Functor.whiskerRight (ιIteration I κ) Arrow.rightFunc).naturality φ)
   dsimp at h₁
   rw [assoc] at h₁
   apply h₁.trans

--- a/Mathlib/CategoryTheory/SmallObject/Iteration/Basic.lean
+++ b/Mathlib/CategoryTheory/SmallObject/Iteration/Basic.lean
@@ -132,7 +132,7 @@ induces a successor structure on `C ⥤ C`. -/
 @[simps]
 def ofNatTrans {F : C ⥤ C} (ε : 𝟭 C ⟶ F) : SuccStruct (C ⥤ C) where
   succ G := G ⋙ F
-  toSucc G := whiskerLeft G ε
+  toSucc G := Functor.whiskerLeft G ε
   X₀ := 𝟭 C
 
 variable (Φ : SuccStruct C)

--- a/Mathlib/CategoryTheory/Subobject/Lattice.lean
+++ b/Mathlib/CategoryTheory/Subobject/Lattice.lean
@@ -162,7 +162,7 @@ variable [HasImages C] [HasBinaryCoproducts C]
 which is functorial in both arguments,
 and which on `Subobject A` will induce a `SemilatticeSup`. -/
 def sup {A : C} : MonoOver A ⥤ MonoOver A ⥤ MonoOver A :=
-  curryObj ((forget A).prod (forget A) ⋙ uncurry.obj Over.coprod ⋙ image)
+  Functor.curryObj ((forget A).prod (forget A) ⋙ Functor.uncurry.obj Over.coprod ⋙ image)
 
 /-- A morphism version of `le_sup_left`. -/
 def leSupLeft {A : C} (f g : MonoOver A) : f ⟶ (sup.obj f).obj g := by

--- a/Mathlib/CategoryTheory/Subobject/MonoOver.lean
+++ b/Mathlib/CategoryTheory/Subobject/MonoOver.lean
@@ -42,7 +42,7 @@ noncomputable section
 
 namespace CategoryTheory
 
-open CategoryTheory CategoryTheory.Category CategoryTheory.Limits
+open CategoryTheory CategoryTheory.Category CategoryTheory.Limits CategoryTheory.Functor
 
 variable {C : Type u₁} [Category.{v₁} C] {X Y Z : C}
 variable {D : Type u₂} [Category.{v₂} D]

--- a/Mathlib/CategoryTheory/Sums/Associator.lean
+++ b/Mathlib/CategoryTheory/Sums/Associator.lean
@@ -16,7 +16,7 @@ universe v₁ v₂ v₃ u₁ u₂ u₃
 
 open CategoryTheory
 
-open Sum
+open Sum Functor
 
 namespace CategoryTheory.sum
 

--- a/Mathlib/CategoryTheory/Sums/Products.lean
+++ b/Mathlib/CategoryTheory/Sums/Products.lean
@@ -18,6 +18,8 @@ the product side.
 
 namespace CategoryTheory
 
+open Functor
+
 universe v u
 
 variable (A : Type*) [Category A] (A' : Type*) [Category A']

--- a/Mathlib/CategoryTheory/Triangulated/Opposite/Basic.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Opposite/Basic.lean
@@ -128,8 +128,8 @@ noncomputable def opShiftFunctorEquivalence (n : ℤ) : Cᵒᵖ ≌ Cᵒᵖ wher
   functor := shiftFunctor Cᵒᵖ n
   inverse := (shiftFunctor C n).op
   unitIso := NatIso.op (shiftFunctorCompIsoId C (-n) n n.add_left_neg) ≪≫
-    isoWhiskerRight (shiftFunctorOpIso C n (-n) n.add_right_neg).symm (shiftFunctor C n).op
-  counitIso := isoWhiskerLeft _ (shiftFunctorOpIso C n (-n) n.add_right_neg) ≪≫
+    Functor.isoWhiskerRight (shiftFunctorOpIso C n (-n) n.add_right_neg).symm (shiftFunctor C n).op
+  counitIso := Functor.isoWhiskerLeft _ (shiftFunctorOpIso C n (-n) n.add_right_neg) ≪≫
     NatIso.op (shiftFunctorCompIsoId C n (-n) n.add_right_neg).symm
   functor_unitIso_comp X := Quiver.Hom.unop_inj (by
     dsimp [shiftFunctorOpIso]

--- a/Mathlib/CategoryTheory/Triangulated/TriangleShift.lean
+++ b/Mathlib/CategoryTheory/Triangulated/TriangleShift.lean
@@ -133,16 +133,16 @@ noncomputable def invRotateIsoRotateRotateShiftFunctorNegOne :
   calc
     invRotate C ≅ invRotate C ⋙ 𝟭 _ := (Functor.rightUnitor _).symm
     _ ≅ invRotate C ⋙ Triangle.shiftFunctor C 0 :=
-          isoWhiskerLeft _ (Triangle.shiftFunctorZero C).symm
+          Functor.isoWhiskerLeft _ (Triangle.shiftFunctorZero C).symm
     _ ≅ invRotate C ⋙ Triangle.shiftFunctor C 1 ⋙ Triangle.shiftFunctor C (-1) :=
-          isoWhiskerLeft _ (Triangle.shiftFunctorAdd' C 1 (-1) 0 (add_neg_cancel 1))
+          Functor.isoWhiskerLeft _ (Triangle.shiftFunctorAdd' C 1 (-1) 0 (add_neg_cancel 1))
     _ ≅ invRotate C ⋙ (rotate C ⋙ rotate C ⋙ rotate C) ⋙ Triangle.shiftFunctor C (-1) :=
-          isoWhiskerLeft _ (isoWhiskerRight (rotateRotateRotateIso C).symm _)
+          Functor.isoWhiskerLeft _ (Functor.isoWhiskerRight (rotateRotateRotateIso C).symm _)
     _ ≅ (invRotate C ⋙ rotate C) ⋙ rotate C ⋙ rotate C ⋙ Triangle.shiftFunctor C (-1) :=
-          isoWhiskerLeft _ (Functor.associator _ _ _ ≪≫
-            isoWhiskerLeft _ (Functor.associator _ _ _)) ≪≫ (Functor.associator _ _ _).symm
+          Functor.isoWhiskerLeft _ (Functor.associator _ _ _ ≪≫
+            Functor.isoWhiskerLeft _ (Functor.associator _ _ _)) ≪≫ (Functor.associator _ _ _).symm
     _ ≅ 𝟭 _ ⋙ rotate C ⋙ rotate C ⋙ Triangle.shiftFunctor C (-1) :=
-          isoWhiskerRight (triangleRotation C).counitIso _
+          Functor.isoWhiskerRight (triangleRotation C).counitIso _
     _ ≅ _ := Functor.leftUnitor _
 
 namespace Triangle

--- a/Mathlib/CategoryTheory/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Whiskering.lean
@@ -28,6 +28,8 @@ identities.
 
 namespace CategoryTheory
 
+namespace Functor
+
 universe u₁ v₁ u₂ v₂ u₃ v₃ u₄ v₄
 
 section
@@ -45,7 +47,7 @@ def whiskerLeft (F : C ⥤ D) {G H : D ⥤ E} (α : G ⟶ H) :
   naturality X Y f := by rw [Functor.comp_map, Functor.comp_map, α.naturality]
 
 @[simp]
-lemma NatTrans.id_hcomp (F : C ⥤ D) {G H : D ⥤ E} (α : G ⟶ H) : 𝟙 F ◫ α = whiskerLeft F α := by
+lemma id_hcomp (F : C ⥤ D) {G H : D ⥤ E} (α : G ⟶ H) : 𝟙 F ◫ α = whiskerLeft F α := by
   ext
   simp
 
@@ -60,7 +62,7 @@ def whiskerRight {G H : C ⥤ D} (α : G ⟶ H) (F : D ⥤ E) :
     rw [Functor.comp_map, Functor.comp_map, ← F.map_comp, ← F.map_comp, α.naturality]
 
 @[simp]
-lemma NatTrans.hcomp_id {G H : C ⥤ D} (α : G ⟶ H) (F : D ⥤ E) : α ◫ 𝟙 F = whiskerRight α F := by
+lemma hcomp_id {G H : C ⥤ D} (α : G ⟶ H) (F : D ⥤ E) : α ◫ 𝟙 F = whiskerRight α F := by
   ext
   simp
 
@@ -109,7 +111,7 @@ instance faithful_whiskeringRight_obj {F : D ⥤ E} [F.Faithful] :
 /-- If `F : D ⥤ E` is fully faithful, then so is
 `(whiskeringRight C D E).obj F : (C ⥤ D) ⥤ C ⥤ E`. -/
 @[simps]
-def Functor.FullyFaithful.whiskeringRight {F : D ⥤ E} (hF : F.FullyFaithful)
+def FullyFaithful.whiskeringRight {F : D ⥤ E} (hF : F.FullyFaithful)
     (C : Type*) [Category C] :
     ((whiskeringRight C D E).obj F).FullyFaithful where
   preimage f :=
@@ -341,8 +343,6 @@ theorem isoWhiskerLeft_right (F : B ⥤ C) {G H : C ⥤ D} (α : G ≅ H) (K : D
 
 end
 
-namespace Functor
-
 universe u₅ v₅
 
 variable {A : Type u₁} [Category.{v₁} A] {B : Type u₂} [Category.{v₂} B]
@@ -368,8 +368,6 @@ theorem pentagon :
     whiskerRight (associator F G H).hom K ≫
         (associator F (G ⋙ H) K).hom ≫ whiskerLeft F (associator G H K).hom =
       (associator (F ⋙ G) H K).hom ≫ (associator F G (H ⋙ K)).hom := by aesop_cat
-
-end Functor
 
 variable {C₁ C₂ C₃ D₁ D₂ D₃ : Type*} [Category C₁] [Category C₂] [Category C₃]
   [Category D₁] [Category D₂] [Category D₃] (E : Type*) [Category E]
@@ -444,15 +442,17 @@ variable {E}
 /-- The "postcomposition" with a functor `E ⥤ E'` gives a functor
 `(E ⥤ E') ⥤ (C₁ ⥤ C₂ ⥤ E) ⥤ C₁ ⥤ C₂ ⥤ E'`. -/
 @[simps!]
-def Functor.postcompose₂ {E' : Type*} [Category E'] :
+def postcompose₂ {E' : Type*} [Category E'] :
     (E ⥤ E') ⥤ (C₁ ⥤ C₂ ⥤ E) ⥤ C₁ ⥤ C₂ ⥤ E' :=
   whiskeringRight C₂ _ _ ⋙ whiskeringRight C₁ _ _
 
 /-- The "postcomposition" with a functor `E ⥤ E'` gives a functor
 `(E ⥤ E') ⥤ (C₁ ⥤ C₂ ⥤ C₃ ⥤ E) ⥤ C₁ ⥤ C₂ ⥤ C₃ ⥤ E'`. -/
 @[simps!]
-def Functor.postcompose₃ {E' : Type*} [Category E'] :
+def postcompose₃ {E' : Type*} [Category E'] :
     (E ⥤ E') ⥤ (C₁ ⥤ C₂ ⥤ C₃ ⥤ E) ⥤ C₁ ⥤ C₂ ⥤ C₃ ⥤ E' :=
   whiskeringRight C₃ _ _ ⋙ whiskeringRight C₂ _ _ ⋙ whiskeringRight C₁ _ _
+
+end Functor
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/WithTerminal/Basic.lean
+++ b/Mathlib/CategoryTheory/WithTerminal/Basic.lean
@@ -386,7 +386,7 @@ objects. -/
 @[simps!]
 def mkCommaMorphism {F G : WithTerminal C ⥤ D} (η : F ⟶ G) : mkCommaObject F ⟶ mkCommaObject G where
   right := η.app .star
-  left := whiskerLeft incl η
+  left := Functor.whiskerLeft incl η
 
 /-- An element of the comma category `Comma (𝟭 (C ⥤ D)) (Functor.const C)` can be seen as a
 functor `WithTerminal C ⥤ D`. -/
@@ -768,7 +768,7 @@ objects. -/
 @[simps!]
 def mkCommaMorphism {F G : WithInitial C ⥤ D} (η : F ⟶ G) : mkCommaObject F ⟶ mkCommaObject G where
   left := η.app .star
-  right := whiskerLeft incl η
+  right := Functor.whiskerLeft incl η
 
 /-- An element of the comma category `Comma (Functor.const C) (𝟭 (C ⥤ D))` can be seen as a
 functor `WithInitial C ⥤ D`. -/

--- a/Mathlib/CategoryTheory/WithTerminal/Cone.lean
+++ b/Mathlib/CategoryTheory/WithTerminal/Cone.lean
@@ -39,7 +39,7 @@ def commaFromOver : (J ⥤ Over X) ⥤ Comma (𝟭 (J ⥤ C)) (Functor.const J) 
     hom.app a := (K.obj a).hom
   }
   map f := {
-    left := whiskerRight f (Over.forget X)
+    left := Functor.whiskerRight f (Over.forget X)
     right := 𝟙 X
   }
 
@@ -140,7 +140,7 @@ def commaFromUnder : (J ⥤ Under X) ⥤ Comma (Functor.const J) (𝟭 (J ⥤ C)
   }
   map f := {
     left := 𝟙 X
-    right := whiskerRight f (Under.forget X)
+    right := Functor.whiskerRight f (Under.forget X)
   }
 
 /-- For any functor `K : J ⥤ Under X`, there is a canonical extension

--- a/Mathlib/CategoryTheory/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Yoneda.lean
@@ -22,7 +22,7 @@ Also the Yoneda lemma, `yonedaLemma : (yoneda_pairing C) ≅ (yoneda_evaluation 
 
 namespace CategoryTheory
 
-open Opposite
+open Opposite Functor
 
 universe v v₁ v₂ u₁ u₂
 
@@ -899,8 +899,8 @@ def homNatIsoMaxRight {D : Type u₂} [Category.{max v₁ v₂} D] {F : C ⥤ D}
 @[simps!]
 def compYonedaCompWhiskeringLeft {D : Type u₂} [Category.{v₂} D] {F : C ⥤ D}
     (hF : F.FullyFaithful) : F ⋙ yoneda ⋙ (whiskeringLeft _ _ _).obj F.op ⋙
-      (CategoryTheory.whiskeringRight _ _ _).obj uliftFunctor.{v₁} ≅
-      yoneda ⋙ (CategoryTheory.whiskeringRight _ _ _).obj uliftFunctor.{v₂} :=
+      (Functor.whiskeringRight _ _ _).obj uliftFunctor.{v₁} ≅
+      yoneda ⋙ (Functor.whiskeringRight _ _ _).obj uliftFunctor.{v₂} :=
   NatIso.ofComponents (fun X => hF.homNatIso _)
     (fun f => by ext; exact Equiv.ulift.injective (hF.map_injective (by simp)))
 
@@ -908,7 +908,7 @@ def compYonedaCompWhiskeringLeft {D : Type u₂} [Category.{v₂} D] {F : C ⥤ 
 @[simps!]
 def compYonedaCompWhiskeringLeftMaxRight {D : Type u₂} [Category.{max v₁ v₂} D] {F : C ⥤ D}
     (hF : F.FullyFaithful) : F ⋙ yoneda ⋙ (whiskeringLeft _ _ _).obj F.op ≅
-      yoneda ⋙ (CategoryTheory.whiskeringRight _ _ _).obj uliftFunctor.{v₂} :=
+      yoneda ⋙ (Functor.whiskeringRight _ _ _).obj uliftFunctor.{v₂} :=
   NatIso.ofComponents (fun X => hF.homNatIsoMaxRight _)
     (fun f => by ext; exact Equiv.ulift.injective (hF.map_injective (by simp)))
 

--- a/Mathlib/Geometry/RingedSpace/OpenImmersion.lean
+++ b/Mathlib/Geometry/RingedSpace/OpenImmersion.lean
@@ -126,7 +126,7 @@ theorem isoRestrict_hom_ofRestrict : (isoRestrict f).hom ≫ Y.ofRestrict _ = f 
   -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11041): `ext` did not pick up `NatTrans.ext`
   refine PresheafedSpace.Hom.ext _ _ rfl <| NatTrans.ext <| funext fun x => ?_
   simp only [eqToHom_refl,
-    whiskerRight_id']
+    Functor.whiskerRight_id']
   erw [Category.comp_id, comp_c_app, f.c.naturality_assoc, ← X.presheaf.map_comp]
   trans f.c.app x ≫ X.presheaf.map (𝟙 _)
   · congr 1
@@ -328,7 +328,7 @@ theorem pullback_cone_of_left_condition : pullbackConeOfLeftFst f g ≫ f = Y.of
     -- Porting note: `NatTrans.comp_app` is not picked up by `dsimp`
     -- Perhaps see : https://github.com/leanprover-community/mathlib4/issues/5026
     rw [NatTrans.comp_app]
-    dsimp only [comp_c_app, unop_op, whiskerRight_app, pullbackConeOfLeftFst]
+    dsimp only [comp_c_app, unop_op, Functor.whiskerRight_app, pullbackConeOfLeftFst]
     -- simp only [ofRestrict_c_app, NatTrans.comp_app]
     simp only [app_invApp_assoc,
       eqToHom_app, Category.assoc, NatTrans.naturality_assoc]

--- a/Mathlib/Topology/Category/Compactum.lean
+++ b/Mathlib/Topology/Category/Compactum.lean
@@ -469,9 +469,9 @@ monadicity.
 noncomputable instance CompHaus.forgetCreatesLimits : CreatesLimits (forget CompHaus) := by
   let e : forget CompHaus ≅ compactumToCompHaus.inv ⋙ Compactum.forget :=
     (((forget CompHaus).leftUnitor.symm ≪≫
-    isoWhiskerRight compactumToCompHaus.asEquivalence.symm.unitIso (forget CompHaus)) ≪≫
+    Functor.isoWhiskerRight compactumToCompHaus.asEquivalence.symm.unitIso (forget CompHaus)) ≪≫
     compactumToCompHaus.inv.associator compactumToCompHaus (forget CompHaus)) ≪≫
-    isoWhiskerLeft _ compactumToCompHausCompForget
+    Functor.isoWhiskerLeft _ compactumToCompHausCompForget
   exact createsLimitsOfNatIso e.symm
 
 noncomputable instance Profinite.forgetCreatesLimits : CreatesLimits (forget Profinite) := by

--- a/Mathlib/Topology/Category/LightProfinite/Basic.lean
+++ b/Mathlib/Topology/Category/LightProfinite/Basic.lean
@@ -362,7 +362,7 @@ instance : LightDiagram'.toLightFunctor.{u}.Full where
 instance : LightDiagram'.toLightFunctor.{u}.EssSurj where
   mem_essImage Y :=
     ⟨⟨Y.diagram ⋙ Skeleton.equivalence.inverse⟩, ⟨lightDiagramToProfinite.preimageIso (
-      (Limits.lim.mapIso (isoWhiskerRight ((isoWhiskerLeft Y.diagram
+      (Limits.lim.mapIso (Functor.isoWhiskerRight ((Functor.isoWhiskerLeft Y.diagram
       Skeleton.equivalence.counitIso)) toProfinite)) ≪≫
       (limit.isLimit _).conePointUniqueUpToIso Y.isLimit)⟩⟩
 

--- a/Mathlib/Topology/Sheaves/Presheaf.lean
+++ b/Mathlib/Topology/Sheaves/Presheaf.lean
@@ -31,7 +31,7 @@ and provide their adjunction at
 
 universe w v u
 
-open CategoryTheory TopologicalSpace Opposite
+open CategoryTheory TopologicalSpace Opposite Functor
 
 variable (C : Type u) [Category.{v} C]
 

--- a/Mathlib/Topology/Sheaves/Skyscraper.lean
+++ b/Mathlib/Topology/Sheaves/Skyscraper.lean
@@ -339,7 +339,7 @@ def skyscraperPresheafStalkAdjunction [HasColimits C] :
     dsimp [Presheaf.stalkFunctor, toSkyscraperPresheaf]
     ext
     simp only [Functor.comp_obj, Functor.op_obj, ι_colimMap_assoc, skyscraperPresheaf_obj,
-      whiskerLeft_app, Category.comp_id]
+      Functor.whiskerLeft_app, Category.comp_id]
     split_ifs with h
     · simp [skyscraperPresheafStalkOfSpecializes]
       rfl

--- a/Mathlib/Topology/Sheaves/Stalks.lean
+++ b/Mathlib/Topology/Sheaves/Stalks.lean
@@ -49,7 +49,7 @@ open CategoryTheory
 
 open TopCat
 
-open CategoryTheory.Limits
+open CategoryTheory.Limits CategoryTheory.Functor
 
 open TopologicalSpace Topology
 


### PR DESCRIPTION
In Mathlib, we have many `MonoidalCategory.whiskerLeft_comp` in simp or rw arguments even when we are in the `MonoidalCategory` namespace. This is because we have `whiskerLeft` and related lemmas directly in the `CategoryTheory` namespace. This PR renames these names to `Functor.*` so that we can access `MonoidalCategory.whiskerLeft_comp` just by `whiskerLeft_comp` in the `MonoidalCategory` namespace.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
