### PR TITLE
[Merged by Bors] - feat(Data/Sum/Order): `Equiv.sumCongr` as an order isomorphism

### DIFF
--- a/Mathlib/Data/Sum/Order.lean
+++ b/Mathlib/Data/Sum/Order.lean
@@ -485,6 +485,29 @@ open OrderDual Sum
 namespace OrderIso
 
 variable [LE α] [LE β] [LE γ] (a : α) (b : β) (c : γ)
+  {α₁ α₂ β₁ β₂ γ₁ γ₂ : Type*} [LE α₁] [LE α₂] [LE β₁] [LE β₂] [LE γ₁] [LE γ₂]
+
+/-- `Equiv.sumCongr` promoted to an order isomorphism. -/
+@[simps! apply]
+def sumCongr {α₁ α₂ β₁ β₂ : Type*} [LE α₁] [LE α₂] [LE β₁] [LE β₂]
+    (ea : α₁ ≃o α₂) (eb : β₁ ≃o β₂) : α₁ ⊕ β₁ ≃o α₂ ⊕ β₂ where
+  toEquiv := .sumCongr ea eb
+  map_rel_iff' := by rintro (a | a) (b | b) <;> simp
+
+@[simp]
+theorem sumCongr_trans {α₁ α₂ β₁ β₂ γ₁ γ₂ : Type*} [LE α₁] [LE α₂] [LE β₁] [LE β₂] [LE γ₁] [LE γ₂]
+    (e₁ : α₁ ≃o β₁) (e₂ : α₂ ≃o β₂) (f₁ : β₁ ≃o γ₁) (f₂ : β₂ ≃o γ₂) :
+      (e₁.sumCongr e₂).trans (f₁.sumCongr f₂) = (e₁.trans f₁).sumCongr (e₂.trans f₂) := by
+  ext; simp
+
+@[simp]
+theorem sumCongr_symm {α₁ α₂ β₁ β₂ : Type*} [LE α₁] [LE α₂] [LE β₁] [LE β₂]
+    (ea : α₁ ≃o α₂) (eb : β₁ ≃o β₂) : (ea.sumCongr eb).symm = ea.symm.sumCongr eb.symm :=
+  rfl
+
+@[simp]
+theorem sumCongr_refl : sumCongr (OrderIso.refl α) (OrderIso.refl β) = OrderIso.refl _ := by
+  ext; simp
 
 /-- `Equiv.sumComm` promoted to an order isomorphism. -/
 @[simps! apply]
@@ -555,7 +578,27 @@ theorem sumDualDistrib_symm_inl : (sumDualDistrib α β).symm (inl (toDual a)) =
 theorem sumDualDistrib_symm_inr : (sumDualDistrib α β).symm (inr (toDual b)) = toDual (inr b) :=
   rfl
 
-/-- `Equiv.SumAssoc` promoted to an order isomorphism. -/
+/-- `Equiv.sumCongr` promoted to an order isomorphism. -/
+@[simps! apply]
+def sumLexCongr (ea : α₁ ≃o α₂) (eb : β₁ ≃o β₂) : α₁ ⊕ₗ β₁ ≃o α₂ ⊕ₗ β₂ where
+  toEquiv := ofLex.trans ((Equiv.sumCongr ea eb).trans toLex)
+  map_rel_iff' := by simp_rw [Lex.forall]; rintro (a | a) (b | b) <;> simp
+
+@[simp]
+theorem sumLexCongr_trans (e₁ : α₁ ≃o β₁) (e₂ : α₂ ≃o β₂) (f₁ : β₁ ≃o γ₁) (f₂ : β₂ ≃o γ₂) :
+    (e₁.sumLexCongr e₂).trans (f₁.sumLexCongr f₂) = (e₁.trans f₁).sumLexCongr (e₂.trans f₂) := by
+  ext; simp
+
+@[simp]
+theorem sumLexCongr_symm (ea : α₁ ≃o α₂) (eb : β₁ ≃o β₂) :
+    (ea.sumLexCongr eb).symm = ea.symm.sumLexCongr eb.symm :=
+  rfl
+
+@[simp]
+theorem sumLexCongr_refl : (OrderIso.refl α).sumLexCongr (OrderIso.refl β) = OrderIso.refl _ := by
+  ext; simp
+
+/-- `Equiv.sumAssoc` promoted to an order isomorphism. -/
 def sumLexAssoc (α β γ : Type*) [LE α] [LE β] [LE γ] : (α ⊕ₗ β) ⊕ₗ γ ≃o α ⊕ₗ β ⊕ₗ γ :=
   { Equiv.sumAssoc α β γ with
     map_rel_iff' := fun {a b} =>
@@ -661,8 +704,6 @@ def orderIsoPUnitSumLex : WithBot α ≃o PUnit ⊕ₗ α :=
       exact not_coe_le_bot _
     · simp only [elim_inl, lex_inr_inr, coe_le_coe]
   ⟩
-
-
 
 @[simp]
 theorem orderIsoPUnitSumLex_bot : @orderIsoPUnitSumLex α _ ⊥ = toLex (inl PUnit.unit) :=

--- a/Mathlib/Data/Sum/Order.lean
+++ b/Mathlib/Data/Sum/Order.lean
@@ -491,7 +491,7 @@ variable [LE α] [LE β] [LE γ] (a : α) (b : β) (c : γ)
 @[simps! apply]
 def sumCongr (ea : α₁ ≃o α₂) (eb : β₁ ≃o β₂) : α₁ ⊕ β₁ ≃o α₂ ⊕ β₂ where
   toEquiv := .sumCongr ea eb
-  map_rel_iff' := by rintro (a | a) (b | b) <;> simp
+  map_rel_iff' := by aesop
 
 @[simp]
 theorem sumCongr_trans (e₁ : α₁ ≃o β₁) (e₂ : α₂ ≃o β₂) (f₁ : β₁ ≃o γ₁) (f₂ : β₂ ≃o γ₂) :

--- a/Mathlib/Data/Sum/Order.lean
+++ b/Mathlib/Data/Sum/Order.lean
@@ -484,8 +484,8 @@ open OrderDual Sum
 
 namespace OrderIso
 
-variable [LE α] [LE β] [LE γ] (a : α) (b : β) (c : γ)
-  {α₁ α₂ β₁ β₂ γ₁ γ₂ : Type*} [LE α₁] [LE α₂] [LE β₁] [LE β₂] [LE γ₁] [LE γ₂]
+variable {α₁ α₂ β₁ β₂ γ₁ γ₂ : Type*} [LE α] [LE β] [LE γ]
+  [LE α₁] [LE α₂] [LE β₁] [LE β₂] [LE γ₁] [LE γ₂] (a : α) (b : β) (c : γ)
 
 /-- `Equiv.sumCongr` promoted to an order isomorphism. -/
 @[simps! apply]
@@ -517,7 +517,7 @@ theorem sumComm_symm (α β : Type*) [LE α] [LE β] :
     (OrderIso.sumComm α β).symm = OrderIso.sumComm β α :=
   rfl
 
-/-- `Equiv.sumAssoc` promoted to an order isomorphism. -/
+/-- `Equiv.sumAssoc` promoted to an order isomorphism between disjoint sums. -/
 def sumAssoc (α β γ : Type*) [LE α] [LE β] [LE γ] : (α ⊕ β) ⊕ γ ≃o α ⊕ (β ⊕ γ) :=
   { Equiv.sumAssoc α β γ with
     map_rel_iff' := fun {a b} => by
@@ -576,7 +576,7 @@ theorem sumDualDistrib_symm_inl : (sumDualDistrib α β).symm (inl (toDual a)) =
 theorem sumDualDistrib_symm_inr : (sumDualDistrib α β).symm (inr (toDual b)) = toDual (inr b) :=
   rfl
 
-/-- `Equiv.sumCongr` promoted to an order isomorphism. -/
+/-- `Equiv.sumCongr` promoted to an order isomorphism between lexicographic sums. -/
 @[simps! apply]
 def sumLexCongr (ea : α₁ ≃o α₂) (eb : β₁ ≃o β₂) : α₁ ⊕ₗ β₁ ≃o α₂ ⊕ₗ β₂ where
   toEquiv := ofLex.trans ((Equiv.sumCongr ea eb).trans toLex)

--- a/Mathlib/Data/Sum/Order.lean
+++ b/Mathlib/Data/Sum/Order.lean
@@ -517,7 +517,7 @@ theorem sumComm_symm (α β : Type*) [LE α] [LE β] :
     (OrderIso.sumComm α β).symm = OrderIso.sumComm β α :=
   rfl
 
-/-- `Equiv.sumAssoc` promoted to an order isomorphism between disjoint sums. -/
+/-- `Equiv.sumAssoc` promoted to an order isomorphism. -/
 def sumAssoc (α β γ : Type*) [LE α] [LE β] [LE γ] : (α ⊕ β) ⊕ γ ≃o α ⊕ (β ⊕ γ) :=
   { Equiv.sumAssoc α β γ with
     map_rel_iff' := fun {a b} => by

--- a/Mathlib/Data/Sum/Order.lean
+++ b/Mathlib/Data/Sum/Order.lean
@@ -504,7 +504,7 @@ theorem sumCongr_symm (ea : α₁ ≃o α₂) (eb : β₁ ≃o β₂) :
   rfl
 
 @[simp]
-theorem sumCongr_refl : sumCongr (OrderIso.refl α) (OrderIso.refl β) = OrderIso.refl _ := by
+theorem sumCongr_refl : sumCongr (.refl α) (.refl β) = .refl _ := by
   ext; simp
 
 /-- `Equiv.sumComm` promoted to an order isomorphism. -/

--- a/Mathlib/Data/Sum/Order.lean
+++ b/Mathlib/Data/Sum/Order.lean
@@ -593,7 +593,7 @@ theorem sumLexCongr_symm (ea : α₁ ≃o α₂) (eb : β₁ ≃o β₂) :
   rfl
 
 @[simp]
-theorem sumLexCongr_refl : (OrderIso.refl α).sumLexCongr (OrderIso.refl β) = OrderIso.refl _ := by
+theorem sumLexCongr_refl : sumLexCongr (.refl α) (.refl β) = .refl _ := by
   ext; simp
 
 /-- `Equiv.sumAssoc` promoted to an order isomorphism. -/

--- a/Mathlib/Data/Sum/Order.lean
+++ b/Mathlib/Data/Sum/Order.lean
@@ -489,20 +489,18 @@ variable [LE α] [LE β] [LE γ] (a : α) (b : β) (c : γ)
 
 /-- `Equiv.sumCongr` promoted to an order isomorphism. -/
 @[simps! apply]
-def sumCongr {α₁ α₂ β₁ β₂ : Type*} [LE α₁] [LE α₂] [LE β₁] [LE β₂]
-    (ea : α₁ ≃o α₂) (eb : β₁ ≃o β₂) : α₁ ⊕ β₁ ≃o α₂ ⊕ β₂ where
+def sumCongr (ea : α₁ ≃o α₂) (eb : β₁ ≃o β₂) : α₁ ⊕ β₁ ≃o α₂ ⊕ β₂ where
   toEquiv := .sumCongr ea eb
   map_rel_iff' := by rintro (a | a) (b | b) <;> simp
 
 @[simp]
-theorem sumCongr_trans {α₁ α₂ β₁ β₂ γ₁ γ₂ : Type*} [LE α₁] [LE α₂] [LE β₁] [LE β₂] [LE γ₁] [LE γ₂]
-    (e₁ : α₁ ≃o β₁) (e₂ : α₂ ≃o β₂) (f₁ : β₁ ≃o γ₁) (f₂ : β₂ ≃o γ₂) :
-      (e₁.sumCongr e₂).trans (f₁.sumCongr f₂) = (e₁.trans f₁).sumCongr (e₂.trans f₂) := by
+theorem sumCongr_trans (e₁ : α₁ ≃o β₁) (e₂ : α₂ ≃o β₂) (f₁ : β₁ ≃o γ₁) (f₂ : β₂ ≃o γ₂) :
+    (e₁.sumCongr e₂).trans (f₁.sumCongr f₂) = (e₁.trans f₁).sumCongr (e₂.trans f₂) := by
   ext; simp
 
 @[simp]
-theorem sumCongr_symm {α₁ α₂ β₁ β₂ : Type*} [LE α₁] [LE α₂] [LE β₁] [LE β₂]
-    (ea : α₁ ≃o α₂) (eb : β₁ ≃o β₂) : (ea.sumCongr eb).symm = ea.symm.sumCongr eb.symm :=
+theorem sumCongr_symm (ea : α₁ ≃o α₂) (eb : β₁ ≃o β₂) :
+    (ea.sumCongr eb).symm = ea.symm.sumCongr eb.symm :=
   rfl
 
 @[simp]


### PR DESCRIPTION
We give two versions: one for the disjoint sum, and another for the lexicographic sum.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
