### PR TITLE
[Merged by Bors] - feat(Data/Sum/Order): `toLex` as a `RelIso`

### DIFF
--- a/Mathlib/Data/Sum/Order.lean
+++ b/Mathlib/Data/Sum/Order.lean
@@ -335,8 +335,10 @@ theorem not_inr_lt_inl [LT α] [LT β] {a : α} {b : β} : ¬toLex (inr b) < toL
 
 /-- `toLex` promoted to a `RelIso` between `<` relations. -/
 def toLexRelIsoLT [LT α] [LT β] :
-    Sum.Lex (· < · : α → α → Prop) (· < · : β → β → Prop) ≃r (· < · : α ⊕ₗ β → _ → _) :=
-  RelIso.refl _
+    Sum.Lex (· < · : α → α → Prop) (· < · : β → β → Prop) ≃r (· < · : α ⊕ₗ β → _ → _) where
+  toFun := toLex
+  invFun := ofLex
+  map_rel_iff' := .rfl
 
 @[simp]
 theorem toLexRelIsoLT_coe [LT α] [LT β] : ⇑(toLexRelIsoLT (α := α) (β := β)) = toLex :=
@@ -348,8 +350,10 @@ theorem toLexRelIsoLT_symm_coe [LT α] [LT β] : ⇑(toLexRelIsoLT (α := α) (�
 
 /-- `toLex` promoted to a `RelIso` between `≤` relations. -/
 def toLexRelIsoLE [LE α] [LE β] :
-    Sum.Lex (· ≤ · : α → α → Prop) (· ≤ · : β → β → Prop) ≃r (· ≤ · : α ⊕ₗ β → _ → _) :=
-  RelIso.refl _
+    Sum.Lex (· ≤ · : α → α → Prop) (· ≤ · : β → β → Prop) ≃r (· ≤ · : α ⊕ₗ β → _ → _) where
+  toFun := toLex
+  invFun := ofLex
+  map_rel_iff' := .rfl
 
 @[simp]
 theorem toLexRelIsoLE_coe [LE α] [LE β] : ⇑(toLexRelIsoLE (α := α) (β := β)) = toLex :=

--- a/Mathlib/Data/Sum/Order.lean
+++ b/Mathlib/Data/Sum/Order.lean
@@ -333,6 +333,32 @@ theorem not_inr_le_inl [LE α] [LE β] {a : α} {b : β} : ¬toLex (inr b) ≤ t
 theorem not_inr_lt_inl [LT α] [LT β] {a : α} {b : β} : ¬toLex (inr b) < toLex (inl a) :=
   lex_inr_inl
 
+/-- `toLex` promoted to a `RelIso` between `<` relations. -/
+def toLexRelIsoLT [LT α] [LT β] :
+    Sum.Lex (· < · : α → α → Prop) (· < · : β → β → Prop) ≃r (· < · : α ⊕ₗ β → _ → _) :=
+  RelIso.refl _
+
+@[simp]
+theorem toLexRelIsoLT_apply [LT α] [LT β] (x : α ⊕ β) : toLexRelIsoLT x = toLex x :=
+  rfl
+
+@[simp]
+theorem toLexRelIsoLT_symm_apply [LT α] [LT β] (x : α ⊕ₗ β) : toLexRelIsoLT.symm x = ofLex x :=
+  rfl
+
+/-- `toLex` promoted to a `RelIso` between `≤` relations. -/
+def toLexRelIsoLE [LE α] [LE β] :
+    Sum.Lex (· ≤ · : α → α → Prop) (· ≤ · : β → β → Prop) ≃r (· ≤ · : α ⊕ₗ β → _ → _) :=
+  RelIso.refl _
+
+@[simp]
+theorem toLexRelIsoLE_apply [LE α] [LE β] (x : α ⊕ β) : toLexRelIsoLE x = toLex x :=
+  rfl
+
+@[simp]
+theorem toLexRelIsoLE_symm_apply [LE α] [LE β] (x : α ⊕ₗ β) : toLexRelIsoLE.symm x = ofLex x :=
+  rfl
+
 section Preorder
 
 variable [Preorder α] [Preorder β]

--- a/Mathlib/Data/Sum/Order.lean
+++ b/Mathlib/Data/Sum/Order.lean
@@ -339,11 +339,11 @@ def toLexRelIsoLT [LT α] [LT β] :
   RelIso.refl _
 
 @[simp]
-theorem toLexRelIsoLT_apply [LT α] [LT β] (x : α ⊕ β) : toLexRelIsoLT x = toLex x :=
+theorem toLexRelIsoLT_coe [LT α] [LT β] : ⇑(toLexRelIsoLT (α := α) (β := β)) = toLex :=
   rfl
 
 @[simp]
-theorem toLexRelIsoLT_symm_apply [LT α] [LT β] (x : α ⊕ₗ β) : toLexRelIsoLT.symm x = ofLex x :=
+theorem toLexRelIsoLT_symm_coe [LT α] [LT β] : ⇑(toLexRelIsoLT (α := α) (β := β)).symm = ofLex :=
   rfl
 
 /-- `toLex` promoted to a `RelIso` between `≤` relations. -/
@@ -352,11 +352,11 @@ def toLexRelIsoLE [LE α] [LE β] :
   RelIso.refl _
 
 @[simp]
-theorem toLexRelIsoLE_apply [LE α] [LE β] (x : α ⊕ β) : toLexRelIsoLE x = toLex x :=
+theorem toLexRelIsoLE_coe [LE α] [LE β] : ⇑(toLexRelIsoLE (α := α) (β := β)) = toLex :=
   rfl
 
 @[simp]
-theorem toLexRelIsoLE_symm_apply [LE α] [LE β] (x : α ⊕ₗ β) : toLexRelIsoLE.symm x = ofLex x :=
+theorem toLexRelIsoLE_symm_coe [LE α] [LE β] : ⇑(toLexRelIsoLE (α := α) (β := β)).symm = ofLex :=
   rfl
 
 section Preorder


### PR DESCRIPTION
As [requested](https://github.com/leanprover-community/mathlib4/pull/20409#discussion_r1903319844) by @eric-wieser in #20409.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
