### PR TITLE
[Merged by Bors] - feat: simple lemmas on circle integrability

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Integrability/LogMeromorphic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrability/LogMeromorphic.lean
@@ -163,6 +163,14 @@ theorem circleIntegrable_log_norm_meromorphicOn_of_nonneg (hf : MeromorphicOn f 
   exact circleIntegrable_log_norm_meromorphicOn hf
 
 /--
+Variant of `circleIntegrable_log_norm_meromorphicOn` for factorized rational functions.
+-/
+theorem circleIntegrable_log_norm_factorizedRational {R : ℝ} {c : ℂ} (D : ℂ → ℤ) :
+    CircleIntegrable (∑ᶠ u, ((D u) * log ‖· - u‖)) c R :=
+  CircleIntegrable.finsum (fun _ ↦ (circleIntegrable_log_norm_meromorphicOn
+    (analyticOnNhd_id.sub analyticOnNhd_const).meromorphicOn).const_smul)
+
+/--
 If `f` is complex meromorphic on a circle in the complex plane, then `log⁺ ‖f ·‖` is circle
 integrable over that circle.
 -/
@@ -171,8 +179,7 @@ theorem circleIntegrable_posLog_norm_meromorphicOn (hf : MeromorphicOn f (sphere
   simp_rw [← half_mul_log_add_log_abs, mul_add]
   apply CircleIntegrable.add
   · apply (circleIntegrable_log_norm_meromorphicOn hf).const_mul
-  · apply IntervalIntegrable.const_mul
-    apply (circleIntegrable_log_norm_meromorphicOn hf).abs
+  · apply (circleIntegrable_log_norm_meromorphicOn hf).abs.const_mul
 
 /--
 Variant of `circleIntegrable_posLog_norm_meromorphicOn` for non-negative radii.

--- a/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
@@ -177,9 +177,7 @@ theorem circleIntegrable_const (a : E) (c : ℂ) (R : ℝ) : CircleIntegrable (f
 
 namespace CircleIntegrable
 
-variable
-  {f g : ℂ → E} {c : ℂ} {R : ℝ}
-  {A : Type*} [NormedRing A]
+variable {f g : ℂ → E} {c : ℂ} {R : ℝ} {A : Type*} [NormedRing A] {a : A}
 
 /--
 Analogue of `IntervalIntegrable.abs`: If a real-valued function `f` is circle integrable, then so is
@@ -212,17 +210,12 @@ protected theorem finsum {ι : Type*} {f : ι → ℂ → E} (h : ∀ i, CircleI
 nonrec theorem neg (hf : CircleIntegrable f c R) : CircleIntegrable (-f) c R :=
   hf.neg
 
-/--
-If `f` is circle integrable, then so are its scalar multiples.
--/
-theorem const_smul {a : A} {f : ℂ → A} (h : CircleIntegrable f c R) :
-    CircleIntegrable (a • f) c R := by
-  apply IntervalIntegrable.const_mul h
+/-- If `f` is circle integrable, then so are its scalar multiples. -/
+theorem const_smul {f : ℂ → A} (h : CircleIntegrable f c R) : CircleIntegrable (a • f) c R :=
+  IntervalIntegrable.const_mul h _
 
-/--
-If `f` is circle integrable, then so are its scalar multiples.
--/
-theorem const_smul_fun {a : A} {f : ℂ → A} (h : CircleIntegrable f c R) :
+/-- If `f` is circle integrable, then so are its scalar multiples. -/
+theorem const_fun_smul {f : ℂ → A} (h : CircleIntegrable f c R) :
     CircleIntegrable (fun z ↦ a • f z) c R := const_smul h
 
 /-- The function we actually integrate over `[0, 2π]` in the definition of `circleIntegral` is

--- a/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleIntegral.lean
@@ -177,7 +177,9 @@ theorem circleIntegrable_const (a : E) (c : ℂ) (R : ℝ) : CircleIntegrable (f
 
 namespace CircleIntegrable
 
-variable {f g : ℂ → E} {c : ℂ} {R : ℝ}
+variable
+  {f g : ℂ → E} {c : ℂ} {R : ℝ}
+  {A : Type*} [NormedRing A]
 
 /--
 Analogue of `IntervalIntegrable.abs`: If a real-valued function `f` is circle integrable, then so is
@@ -209,6 +211,19 @@ protected theorem finsum {ι : Type*} {f : ι → ℂ → E} (h : ∀ i, CircleI
 
 nonrec theorem neg (hf : CircleIntegrable f c R) : CircleIntegrable (-f) c R :=
   hf.neg
+
+/--
+If `f` is circle integrable, then so are its scalar multiples.
+-/
+theorem const_smul {a : A} {f : ℂ → A} (h : CircleIntegrable f c R) :
+    CircleIntegrable (a • f) c R := by
+  apply IntervalIntegrable.const_mul h
+
+/--
+If `f` is circle integrable, then so are its scalar multiples.
+-/
+theorem const_smul_fun {a : A} {f : ℂ → A} (h : CircleIntegrable f c R) :
+    CircleIntegrable (fun z ↦ a • f z) c R := const_smul h
 
 /-- The function we actually integrate over `[0, 2π]` in the definition of `circleIntegral` is
 integrable. -/


### PR DESCRIPTION
Add very simple but useful lemmas concerning circle integrability of functions on the complex plane.

This material is used in [Project VD](https://github.com/kebekus/ProjectVD), which aims to formalize Value Distribution Theory for meromorphic functions on the complex plane.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
