### PR TITLE
[Merged by Bors] - chore: deprecate `Scott` in favour of `WithScott`

### DIFF
--- a/Mathlib/Topology/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Topology/OmegaCompletePartialOrder.lean
@@ -18,17 +18,21 @@ of continuity is equivalent to continuity in ωCPOs.
 
 -/
 
-open Set OmegaCompletePartialOrder
+open Set OmegaCompletePartialOrder Topology
 
 universe u
 
 open Topology.IsScott in
-@[simp] lemma Topology.IsScott.ωscottContinuous_iff_continuous {α : Type*}
+@[simp] lemma Topology.IsScott.ωScottContinuous_iff_continuous {α : Type*}
     [OmegaCompletePartialOrder α] [TopologicalSpace α]
     [Topology.IsScott α (Set.range fun c : Chain α => Set.range c)] {f : α → Prop} :
     ωScottContinuous f ↔ Continuous f := by
-  rw [ωScottContinuous, scottContinuous_iff_continuous (fun a b hab => by
+  rw [ωScottContinuous, scottContinuousOn_iff_continuous (fun a b hab => by
     use Chain.pair a b hab; exact OmegaCompletePartialOrder.Chain.range_pair a b hab)]
+
+@[deprecated (since := "2025-07-02")]
+alias Topology.IsScott.ωscottContinuous_iff_continuous :=
+  Topology.IsScott.ωScottContinuous_iff_continuous
 
 -- "Scott", "ωSup"
 namespace Scott
@@ -65,18 +69,28 @@ end Scott
 /-- A Scott topological space is defined on preorders
 such that their open sets, seen as a function `α → Prop`,
 preserves the joins of ω-chains. -/
+@[deprecated WithScott (since := "2025-07-02")]
 abbrev Scott (α : Type u) := α
 
-instance Scott.topologicalSpace (α : Type u) [OmegaCompletePartialOrder α] :
+set_option linter.deprecated false in
+/-- Deprecated, use `WithScott`. -/
+@[deprecated Topology.WithScott.instTopologicalSpace (since := "2025-07-02")]
+abbrev Scott.topologicalSpace (α : Type u) [OmegaCompletePartialOrder α] :
     TopologicalSpace (Scott α) where
   IsOpen := Scott.IsOpen α
   isOpen_univ := Scott.isOpen_univ α
   isOpen_inter := Scott.IsOpen.inter α
   isOpen_sUnion := Scott.isOpen_sUnion α
 
+attribute [local instance] Scott.topologicalSpace
+
+set_option linter.deprecated false in
+@[deprecated isOpen_iff_continuous_mem (since := "2025-07-02")]
 lemma isOpen_iff_ωScottContinuous_mem {α} [OmegaCompletePartialOrder α] {s : Set (Scott α)} :
     IsOpen s ↔ ωScottContinuous fun x ↦ x ∈ s := by rfl
 
+set_option linter.deprecated false in
+@[deprecated "Use `WithScott` API" (since := "2025-07-02")]
 lemma scott_eq_Scott {α} [OmegaCompletePartialOrder α] :
     Topology.scott α (Set.range fun c : Chain α => Set.range c) = Scott.topologicalSpace α := by
   ext U
@@ -87,14 +101,17 @@ lemma scott_eq_Scott {α} [OmegaCompletePartialOrder α] :
 
 section notBelow
 
-variable {α : Type*} [OmegaCompletePartialOrder α] (y : Scott α)
+variable {α : Type*} [OmegaCompletePartialOrder α]
 
+set_option linter.deprecated false in
 /-- `notBelow` is an open set in `Scott α` used
 to prove the monotonicity of continuous functions -/
-def notBelow :=
+def notBelow (y : Scott α) :=
   { x | ¬x ≤ y }
 
-theorem notBelow_isOpen : IsOpen (notBelow y) := by
+set_option linter.deprecated false in
+@[deprecated isClosed_Iic (since := "2025-07-02")]
+theorem notBelow_isOpen (y : Scott α) : IsOpen (notBelow y) := by
   have h : Monotone (notBelow y) := fun x z hle ↦ mt hle.trans
   dsimp only [IsOpen, TopologicalSpace.IsOpen, Scott.IsOpen]
   rw [ωScottContinuous_iff_monotone_map_ωSup]
@@ -111,6 +128,8 @@ theorem isωSup_ωSup {α} [OmegaCompletePartialOrder α] (c : Chain α) : IsωS
   · apply le_ωSup
   · apply ωSup_le
 
+set_option linter.deprecated false in
+@[deprecated Topology.IsScott.ωscottContinuous_iff_continuous (since := "2025-07-02")]
 theorem scottContinuous_of_continuous {α β} [OmegaCompletePartialOrder α]
     [OmegaCompletePartialOrder β] (f : Scott α → Scott β) (hf : _root_.Continuous f) :
     OmegaCompletePartialOrder.ωScottContinuous f := by
@@ -128,6 +147,8 @@ theorem scottContinuous_of_continuous {α β} [OmegaCompletePartialOrder α]
     eq_iff_iff, not_forall, OrderHom.coe_mk]
   tauto
 
+set_option linter.deprecated false in
+@[deprecated Topology.IsScott.ωscottContinuous_iff_continuous (since := "2025-07-02")]
 theorem continuous_of_scottContinuous {α β} [OmegaCompletePartialOrder α]
     [OmegaCompletePartialOrder β] (f : Scott α → Scott β) (hf : ωScottContinuous f) :
     Continuous f := by

--- a/Mathlib/Topology/Order/LawsonTopology.lean
+++ b/Mathlib/Topology/Order/LawsonTopology.lean
@@ -227,7 +227,7 @@ instance (priority := 90) toT1Space : T1Space α where
     rw [lowerClosure_singleton, LowerSet.coe_Iic, ← WithLawson.isClosed_preimage_ofLawson]
     exact lawsonClosed_of_scottClosed _ isClosed_Iic
 
-@[deprecated (since := "2025-07-02")] protected alias isClosed_singleton := isClosed_singleton
+@[deprecated (since := "2025-07-02")] protected alias singleton_isClosed := isClosed_singleton
 
 end IsLawson
 

--- a/Mathlib/Topology/Order/LawsonTopology.lean
+++ b/Mathlib/Topology/Order/LawsonTopology.lean
@@ -213,29 +213,19 @@ lemma lawsonClosed_iff_dirSupClosed_of_isLowerSet (s : Set α) (h : IsLowerSet s
 end Preorder
 
 namespace IsLawson
-
-section PartialOrder
-
 variable [PartialOrder α] [TopologicalSpace α] [IsLawson α]
 
-lemma singleton_isClosed (a : α) : IsClosed ({a} : Set α) := by
-  simp only [IsLawson.topology_eq_lawson]
-  rw [← (Set.OrdConnected.upperClosure_inter_lowerClosure ordConnected_singleton),
-    ← WithLawson.isClosed_preimage_ofLawson]
-  apply IsClosed.inter
-    (lawsonClosed_of_lowerClosed _ (IsLower.isClosed_upperClosure (finite_singleton a)))
-  rw [lowerClosure_singleton, LowerSet.coe_Iic, ← WithLawson.isClosed_preimage_ofLawson]
-  apply lawsonClosed_of_scottClosed
-  exact IsScott.isClosed_Iic
-
+/-- The Lawson topology on a partial order is T₁. -/
 -- see Note [lower instance priority]
-/-- The Lawson topology on a partial order is T₀. -/
-instance (priority := 90) t0Space : T0Space α :=
-  (t0Space_iff_inseparable α).2 fun a b h => by
-    simpa only [inseparable_iff_closure_eq, closure_eq_iff_isClosed.mpr (singleton_isClosed a),
-      closure_eq_iff_isClosed.mpr (singleton_isClosed b), singleton_eq_singleton_iff] using h
-
-end PartialOrder
+instance (priority := 90) toT1Space : T1Space α where
+  t1 a := by
+    simp only [IsLawson.topology_eq_lawson]
+    rw [← (Set.OrdConnected.upperClosure_inter_lowerClosure ordConnected_singleton),
+      ← WithLawson.isClosed_preimage_ofLawson]
+    apply IsClosed.inter
+      (lawsonClosed_of_lowerClosed _ (IsLower.isClosed_upperClosure (finite_singleton a)))
+    rw [lowerClosure_singleton, LowerSet.coe_Iic, ← WithLawson.isClosed_preimage_ofLawson]
+    exact lawsonClosed_of_scottClosed _ isClosed_Iic
 
 end IsLawson
 

--- a/Mathlib/Topology/Order/LawsonTopology.lean
+++ b/Mathlib/Topology/Order/LawsonTopology.lean
@@ -227,6 +227,8 @@ instance (priority := 90) toT1Space : T1Space α where
     rw [lowerClosure_singleton, LowerSet.coe_Iic, ← WithLawson.isClosed_preimage_ofLawson]
     exact lawsonClosed_of_scottClosed _ isClosed_Iic
 
+@[deprecated (since := "2025-07-02")] protected alias isClosed_singleton := isClosed_singleton
+
 end IsLawson
 
 end Topology

--- a/Mathlib/Topology/Order/ScottTopology.lean
+++ b/Mathlib/Topology/Order/ScottTopology.lean
@@ -27,7 +27,7 @@ This file introduces the Scott topology on a preorder.
 - `Topology.IsScott.isLowerSet_of_isClosed`: Scott closed sets are lower.
 - `Topology.IsScott.monotone_of_continuous`: Functions continuous wrt the Scott topology are
   monotone.
-- `Topology.IsScott.scottContinuous_iff_continuous` - a function is Scott continuous (preserves
+- `Topology.IsScott.scottContinuousOn_iff_continuous` - a function is Scott continuous (preserves
   least upper bounds of directed sets) if and only if it is continuous wrt the Scott topology.
 - `Topology.IsScott.instT0Space` - the Scott topology on a partial order is T₀.
 
@@ -273,8 +273,11 @@ lemma lowerClosure_subset_closure [IsScott α univ] : ↑(lowerClosure s) ⊆ cl
     infer_instance
   · exact topology_eq α univ
 
-lemma isClosed_Iic [IsScott α univ] : IsClosed (Iic a) :=
-  isClosed_iff_isLowerSet_and_dirSupClosed.2 ⟨isLowerSet_Iic _, dirSupClosed_Iic _⟩
+instance [IsScott α univ] : ClosedIicTopology α where
+  isClosed_Iic _ :=
+    isClosed_iff_isLowerSet_and_dirSupClosed.2 ⟨isLowerSet_Iic _, dirSupClosed_Iic _⟩
+
+@[deprecated (since := "2025-07-02")] protected alias isClosed_Iic := isClosed_Iic
 
 /--
 The closure of a singleton `{a}` in the Scott topology is the right-closed left-infinite interval
@@ -292,7 +295,7 @@ lemma monotone_of_continuous [IsScott α D] (hf : Continuous f) : Monotone f := 
   simpa only [mem_compl_iff, mem_preimage, mem_Iic, le_refl, not_true]
     using isUpperSet_of_isOpen (D := D) ((isOpen_compl_iff.2 isClosed_Iic).preimage hf) hab h
 
-@[simp] lemma scottContinuous_iff_continuous {D : Set (Set α)} [Topology.IsScott α D]
+@[simp] lemma scottContinuousOn_iff_continuous {D : Set (Set α)} [Topology.IsScott α D]
     (hD : ∀ a b : α, a ≤ b → {a, b} ∈ D) : ScottContinuousOn D f ↔ Continuous f := by
   refine ⟨fun h ↦ continuous_def.2 fun u hu ↦ ?_, ?_⟩
   · rw [isOpen_iff_isUpperSet_and_dirSupInaccOn (D := D)]
@@ -305,12 +308,15 @@ lemma monotone_of_continuous [IsScott α D] (hf : Continuous f) : Monotone f := 
       fun b hb ↦ ?_⟩
     by_contra h
     let u := (Iic b)ᶜ
-    have hu : IsOpen (f ⁻¹' u) := (isOpen_compl_iff.2 Topology.IsScott.isClosed_Iic).preimage hf
+    have hu : IsOpen (f ⁻¹' u) := isClosed_Iic.isOpen_compl.preimage hf
     rw [isOpen_iff_isUpperSet_and_dirSupInaccOn (D := D)] at hu
     obtain ⟨c, hcd, hfcb⟩ := hu.2 h₀ d₁ d₂ d₃ h
     simp only [upperBounds, mem_image, forall_exists_index, and_imp, forall_apply_eq_imp_iff₂,
       mem_setOf] at hb
     exact hfcb <| hb _ hcd
+
+@[deprecated (since := "2025-07-02")]
+alias scottContinuous_iff_continuous := scottContinuousOn_iff_continuous
 
 end Preorder
 
@@ -367,7 +373,7 @@ end CompleteLinearOrder
 
 lemma isOpen_iff_scottContinuous_mem [Preorder α] {s : Set α} [TopologicalSpace α]
     [IsScott α univ] : IsOpen s ↔ ScottContinuous fun x ↦ x ∈ s := by
-  rw [← scottContinuousOn_univ, scottContinuous_iff_continuous (fun _ _ _ ↦ by trivial)]
+  rw [← scottContinuousOn_univ, scottContinuousOn_iff_continuous (fun _ _ _ ↦ by trivial)]
   exact isOpen_iff_continuous_mem
 
 end IsScott


### PR DESCRIPTION
This type synonym is a duplicate and badly implemented (it is an `abbrev`). Also fix a few misnamed lemmas about the Scott topology.

Closes #26494.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
