### PR TITLE
[Merged by Bors] - fix(CI): branch on url remotes in `getRepoFromRemote` 

### DIFF
--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -1,5 +1,5 @@
 /-
-Copyrighe (c) 2023 Arthur Paulino. All rights reserved.
+Copyright (c) 2023 Arthur Paulino. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Arthur Paulino
 -/


### PR DESCRIPTION
We deploy the logic from #26600 to branch off whether the remote is URL, as can happen with `gh pr checkout`. We also clean up the logic some by factoring out a common function.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Inspection of the CI logs after #26600 indicates we should not have surprises. Additionally, since we explicitly use the `--repo` flag in CI, these changes to logic of determining the remote have far less of a chance of breaking CI currently. Tests with `gh pr checkout` show that the logic works as expected.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
