### PR TITLE
[Merged by Bors] - feat(Combinatorics/Additive): trivial bounds on doubling constant

### DIFF
--- a/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
@@ -550,8 +550,10 @@ theorem div_mem_div : a ∈ s → b ∈ t → a / b ∈ s / t :=
   mem_image₂_of_mem
 
 @[to_additive]
-theorem div_card_le : #(s / t) ≤ #s * #t :=
+theorem card_div_le : #(s / t) ≤ #s * #t :=
   card_image₂_le _ _ _
+
+@[deprecated (since := "2025-07-02")] alias div_card_le := card_div_le
 
 @[to_additive (attr := simp)]
 theorem empty_div (s : Finset α) : ∅ / s = ∅ :=

--- a/Mathlib/Combinatorics/Additive/DoublingConst.lean
+++ b/Mathlib/Combinatorics/Additive/DoublingConst.lean
@@ -103,6 +103,37 @@ lemma mulConst_inv_right (A B : Finset G) : σₘ[A, B⁻¹] = δₘ[A, B] := by
 lemma divConst_inv_right (A B : Finset G) : δₘ[A, B⁻¹] = σₘ[A, B] := by
   rw [mulConst, divConst, div_inv_eq_mul]
 
+@[to_additive]
+lemma one_le_mulConst (hA : A.Nonempty) (hB : B.Nonempty) : 1 ≤ σₘ[A, B] := by
+  rw [mulConst, one_le_div₀]
+  · exact mod_cast card_le_card_mul_right hB
+  · simpa
+
+@[to_additive]
+lemma one_le_mulConst_self (hA : A.Nonempty) : 1 ≤ σₘ[A] := one_le_mulConst hA hA
+
+@[to_additive]
+lemma one_le_divConst (hA : A.Nonempty) (hB : B.Nonempty) : 1 ≤ δₘ[A, B] := by
+  rw [← mulConst_inv_right]
+  apply one_le_mulConst hA (by simpa)
+
+@[to_additive]
+lemma one_le_divConst_self (hA : A.Nonempty) : 1 ≤ δₘ[A] := one_le_divConst hA hA
+
+@[to_additive]
+lemma mulConst_le_card : σₘ[A, B] ≤ #B := by
+  obtain rfl | hA' := A.eq_empty_or_nonempty
+  · simp
+  rw [mulConst, div_le_iff₀' (by positivity)]
+  exact mod_cast card_mul_le
+
+@[to_additive]
+lemma divConst_le_card : δₘ[A, B] ≤ #B := by
+  obtain rfl | hA' := A.eq_empty_or_nonempty
+  · simp
+  rw [divConst, div_le_iff₀' (by positivity)]
+  exact mod_cast card_div_le
+
 section Fintype
 variable [Fintype G]
 


### PR DESCRIPTION
Add trivial upper and lower bounds on the doubling and difference constants.

Renames:
- `div_card_le` -> `card_div_le`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
