### PR TITLE
[Merged by Bors] - chore(Combinatorics/Additive): generalise the doubling difference inequality

### DIFF
--- a/Mathlib/Combinatorics/Additive/DoublingConst.lean
+++ b/Mathlib/Combinatorics/Additive/DoublingConst.lean
@@ -159,6 +159,22 @@ lemma card_mul_cast_mulConst (A B : Finset G) : (#A * σₘ[A, B] : 𝕜) = #(A 
 lemma card_mul_cast_divConst (A B : Finset G) : (#A * δₘ[A, B] : 𝕜) = #(A / B) := by
   norm_cast; exact card_mul_divConst _ _
 
+/-- If `A` has small doubling, then it has small difference, with the constant squared.
+
+This is a consequence of the Ruzsa triangle inequality. -/
+@[to_additive
+"If `A` has small doubling, then it has small difference, with the constant squared.
+
+This is a consequence of the Ruzsa triangle inequality."]
+lemma divConst_le_mulConst_sq : δₘ[A] ≤ σₘ[A] ^ 2 := by
+  obtain rfl | hA' := A.eq_empty_or_nonempty
+  · simp
+  refine le_of_mul_le_mul_right ?_ (by positivity : (0 : ℚ≥0) < #A * #A)
+  calc
+    _ = #(A / A) * (#A : ℚ≥0) := by rw [← mul_assoc, divConst_mul_card]
+    _ ≤ #(A * A) * #(A * A) := by norm_cast; exact ruzsa_triangle_inequality_div_mul_mul ..
+    _ = _ := by rw [← mulConst_mul_card]; ring
+
 end Group
 
 open scoped Combinatorics.Additive
@@ -189,22 +205,6 @@ lemma mulConst_le_divConst_sq : σₘ[A] ≤ δₘ[A] ^ 2 := by
     _ = #(A * A) * (#A : ℚ≥0) := by rw [← mul_assoc, mulConst_mul_card]
     _ ≤ #(A / A) * #(A / A) := by norm_cast; exact ruzsa_triangle_inequality_mul_div_div ..
     _ = _ := by rw [← divConst_mul_card]; ring
-
-/-- If `A` has small doubling, then it has small difference, with the constant squared.
-
-This is a consequence of the Ruzsa triangle inequality. -/
-@[to_additive
-"If `A` has small doubling, then it has small difference, with the constant squared.
-
-This is a consequence of the Ruzsa triangle inequality."]
-lemma divConst_le_mulConst_sq : δₘ[A] ≤ σₘ[A] ^ 2 := by
-  obtain rfl | hA' := A.eq_empty_or_nonempty
-  · simp
-  refine le_of_mul_le_mul_right ?_ (by positivity : (0 : ℚ≥0) < #A * #A)
-  calc
-    _ = #(A / A) * (#A : ℚ≥0) := by rw [← mul_assoc, divConst_mul_card]
-    _ ≤ #(A * A) * #(A * A) := by norm_cast; exact ruzsa_triangle_inequality_div_mul_mul ..
-    _ = _ := by rw [← mulConst_mul_card]; ring
 
 end CommGroup
 end Finset


### PR DESCRIPTION
The proof now works for non-abelian groups too, so we just move the entire lemma into the non-abelian section of the file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
