### PR TITLE
[Merged by Bors] - refactor: remove `suppress_compilation` from TensorProduct

### DIFF
--- a/Mathlib/Algebra/Algebra/Bilinear.lean
+++ b/Mathlib/Algebra/Algebra/Bilinear.lean
@@ -89,7 +89,7 @@ def mul : A →ₗ[R] A →ₗ[R] A :=
 
 /-- The multiplication map on a non-unital algebra, as an `R`-linear map from `A ⊗[R] A` to `A`. -/
 -- TODO: upgrade to A-linear map if A is a semiring.
-noncomputable def mul' : A ⊗[R] A →ₗ[R] A :=
+def mul' : A ⊗[R] A →ₗ[R] A :=
   TensorProduct.lift (mul R A)
 
 variable {A}

--- a/Mathlib/Algebra/Azumaya/Basic.lean
+++ b/Mathlib/Algebra/Azumaya/Basic.lean
@@ -39,7 +39,7 @@ lemma AlgHom.mulLeftRight_bij [h : IsAzumaya R A] :
 
 /-- The "canonical" isomorphism between `R ⊗ Rᵒᵖ` and `End R R` which is equal
   to `AlgHom.mulLeftRight R R`. -/
-noncomputable abbrev tensorEquivEnd : R ⊗[R] Rᵐᵒᵖ ≃ₐ[R] Module.End R R :=
+abbrev tensorEquivEnd : R ⊗[R] Rᵐᵒᵖ ≃ₐ[R] Module.End R R :=
   Algebra.TensorProduct.lid R Rᵐᵒᵖ|>.trans <| .moduleEndSelf R
 
 lemma coe_tensorEquivEnd : tensorEquivEnd R = AlgHom.mulLeftRight R R := by

--- a/Mathlib/Algebra/Azumaya/Defs.lean
+++ b/Mathlib/Algebra/Azumaya/Defs.lean
@@ -32,12 +32,12 @@ variable (R A : Type*) [CommSemiring R] [Semiring A] [Algebra R A]
 open TensorProduct MulOpposite
 
 /-- `A` as a `A ⊗[R] Aᵐᵒᵖ`-module (or equivalently, an `A`-`A` bimodule). -/
-noncomputable abbrev instModuleTensorProductMop :
+abbrev instModuleTensorProductMop :
   Module (A ⊗[R] Aᵐᵒᵖ) A := TensorProduct.Algebra.module
 
 /-- The canonical map from `A ⊗[R] Aᵐᵒᵖ` to `Module.End R A` where
   `a ⊗ b` maps to `f : x ↦ a * x * b`. -/
-noncomputable def AlgHom.mulLeftRight : (A ⊗[R] Aᵐᵒᵖ) →ₐ[R] Module.End R A :=
+def AlgHom.mulLeftRight : (A ⊗[R] Aᵐᵒᵖ) →ₐ[R] Module.End R A :=
   letI : Module (A ⊗[R] Aᵐᵒᵖ) A := TensorProduct.Algebra.module
   letI : IsScalarTower R (A ⊗[R] Aᵐᵒᵖ) A := {
     smul_assoc := fun r ab a ↦ by

--- a/Mathlib/Algebra/Lie/BaseChange.lean
+++ b/Mathlib/Algebra/Lie/BaseChange.lean
@@ -23,8 +23,6 @@ scalars.
 lie ring, lie algebra, extension of scalars, restriction of scalars, base change
 -/
 
-suppress_compilation
-
 open scoped TensorProduct
 
 variable (R A L M : Type*)

--- a/Mathlib/Algebra/Lie/TensorProduct.lean
+++ b/Mathlib/Algebra/Lie/TensorProduct.lean
@@ -16,8 +16,6 @@ Tensor products of Lie modules carry natural Lie module structures.
 lie module, tensor product, universal property
 -/
 
-suppress_compilation
-
 universe u v w w₁ w₂ w₃
 
 variable {R : Type u} [CommRing R]

--- a/Mathlib/Algebra/Lie/Weights/Cartan.lean
+++ b/Mathlib/Algebra/Lie/Weights/Cartan.lean
@@ -26,8 +26,6 @@ Basic definitions and properties of the above ideas are provided in this file.
 
 -/
 
-suppress_compilation
-
 open Set
 
 variable {R L : Type*} [CommRing R] [LieRing L] [LieAlgebra R L]

--- a/Mathlib/Algebra/Module/Bimodule.lean
+++ b/Mathlib/Algebra/Module/Bimodule.lean
@@ -75,7 +75,7 @@ individually, rather than jointly via their tensor product.
 Note that `R` plays no role but it is convenient to make this generalisation to support the cases
 `R = ℕ` and `R = ℤ` which both show up naturally. See also `Subbimodule.baseChange`. -/
 @[simps]
-noncomputable def mk (p : AddSubmonoid M) (hA : ∀ (a : A) {m : M}, m ∈ p → a • m ∈ p)
+def mk (p : AddSubmonoid M) (hA : ∀ (a : A) {m : M}, m ∈ p → a • m ∈ p)
     (hB : ∀ (b : B) {m : M}, m ∈ p → b • m ∈ p) : Submodule (A ⊗[R] B) M :=
   { p with
     carrier := p
@@ -95,7 +95,7 @@ theorem smul_mem' (p : Submodule (A ⊗[R] B) M) (b : B) {m : M} (hm : m ∈ p) 
 /-- If `A` and `B` are also `Algebra`s over yet another set of scalars `S` then we may "base change"
 from `R` to `S`. -/
 @[simps!]
-noncomputable def baseChange (S : Type*) [CommSemiring S] [Module S M] [Algebra S A] [Algebra S B]
+def baseChange (S : Type*) [CommSemiring S] [Module S M] [Algebra S A] [Algebra S B]
     [IsScalarTower S A M] [IsScalarTower S B M] (p : Submodule (A ⊗[R] B) M) :
     Submodule (A ⊗[S] B) M :=
   mk p.toAddSubmonoid (smul_mem p) (smul_mem' p)

--- a/Mathlib/Algebra/Module/Bimodule.lean
+++ b/Mathlib/Algebra/Module/Bimodule.lean
@@ -124,13 +124,13 @@ variable [AddCommGroup M] [Module R M] [Module S M] [SMulCommClass R S M]
 /-- A `Submodule` over `R ⊗[ℕ] S` is naturally also a `Submodule` over the canonically-isomorphic
 ring `R ⊗[ℤ] S`. -/
 @[simps!]
-noncomputable def toSubbimoduleInt (p : Submodule (R ⊗[ℕ] S) M) : Submodule (R ⊗[ℤ] S) M :=
+def toSubbimoduleInt (p : Submodule (R ⊗[ℕ] S) M) : Submodule (R ⊗[ℤ] S) M :=
   baseChange ℤ p
 
 /-- A `Submodule` over `R ⊗[ℤ] S` is naturally also a `Submodule` over the canonically-isomorphic
 ring `R ⊗[ℕ] S`. -/
 @[simps!]
-noncomputable def toSubbimoduleNat (p : Submodule (R ⊗[ℤ] S) M) : Submodule (R ⊗[ℕ] S) M :=
+def toSubbimoduleNat (p : Submodule (R ⊗[ℤ] S) M) : Submodule (R ⊗[ℕ] S) M :=
   baseChange ℕ p
 
 end Ring

--- a/Mathlib/Data/Matrix/Kronecker.lean
+++ b/Mathlib/Data/Matrix/Kronecker.lean
@@ -411,8 +411,6 @@ open Matrix TensorProduct
 
 section Module
 
-suppress_compilation
-
 variable [CommSemiring R]
 variable [AddCommMonoid α] [AddCommMonoid β] [AddCommMonoid γ]
 variable [Module R α] [Module R β] [Module R γ]

--- a/Mathlib/LinearAlgebra/Alternating/DomCoprod.lean
+++ b/Mathlib/LinearAlgebra/Alternating/DomCoprod.lean
@@ -17,8 +17,6 @@ to be the exterior product of two alternating maps,
 taking values in the tensor product of the codomains of the original maps.
 -/
 
-suppress_compilation
-
 open TensorProduct
 
 variable {ιa ιb : Type*} [Fintype ιa] [Fintype ιb]

--- a/Mathlib/LinearAlgebra/BilinearForm/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/TensorProduct.lean
@@ -20,8 +20,6 @@ import Mathlib.RingTheory.TensorProduct.Finite
 
 -/
 
-suppress_compilation
-
 universe u v w uR uA uM₁ uM₂ uN₁ uN₂
 
 variable {R : Type uR} {A : Type uA} {M₁ : Type uM₁} {M₂ : Type uM₂} {N₁ : Type uN₁} {N₂ : Type uN₂}

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Prod.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Prod.lean
@@ -24,6 +24,8 @@ graded algebra equivalence.
 
 -/
 
+suppress_compilation
+
 variable {R M₁ M₂ N : Type*}
 variable [CommRing R] [AddCommGroup M₁] [AddCommGroup M₂] [AddCommGroup N]
 variable [Module R M₁] [Module R M₂] [Module R N]

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Prod.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Prod.lean
@@ -24,8 +24,6 @@ graded algebra equivalence.
 
 -/
 
-suppress_compilation
-
 variable {R M₁ M₂ N : Type*}
 variable [CommRing R] [AddCommGroup M₁] [AddCommGroup M₂] [AddCommGroup N]
 variable [Module R M₁] [Module R M₂] [Module R N]

--- a/Mathlib/LinearAlgebra/Contraction.lean
+++ b/Mathlib/LinearAlgebra/Contraction.lean
@@ -18,8 +18,6 @@ some basic properties of these maps.
 contraction, dual module, tensor product
 -/
 
-suppress_compilation
-
 variable {ι : Type*} (R M N P Q : Type*)
 
 -- Porting note: we need high priority for this to fire first; not the case in ML3

--- a/Mathlib/LinearAlgebra/DirectSum/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/DirectSum/TensorProduct.lean
@@ -17,8 +17,6 @@ This file shows that taking `TensorProduct`s commutes with taking `DirectSum`s i
 * `TensorProduct.directSumRight`
 -/
 
-suppress_compilation
-
 universe u v₁ v₂ w₁ w₁' w₂ w₂'
 
 section Ring

--- a/Mathlib/LinearAlgebra/Multilinear/TensorProduct.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/TensorProduct.lean
@@ -10,8 +10,6 @@ import Mathlib.LinearAlgebra.Multilinear.Basic
 # Constructions relating multilinear maps and tensor products.
 -/
 
-suppress_compilation
-
 namespace MultilinearMap
 
 section DomCoprod

--- a/Mathlib/LinearAlgebra/PiTensorProduct.lean
+++ b/Mathlib/LinearAlgebra/PiTensorProduct.lean
@@ -60,8 +60,6 @@ binary tensor product in `LinearAlgebra/TensorProduct.lean`.
 multilinear, tensor, tensor product
 -/
 
-suppress_compilation
-
 open Function
 
 section Semiring
@@ -103,7 +101,6 @@ def PiTensorProduct : Type _ :=
 
 variable {R}
 
-unsuppress_compilation in
 /-- This enables the notation `⨂[R] i : ι, s i` for the pi tensor product `PiTensorProduct`,
 given an indexed family of types `s : ι → Type*`. -/
 scoped[TensorProduct] notation3:100"⨂["R"] "(...)", "r:(scoped f => PiTensorProduct R f) => r
@@ -281,7 +278,6 @@ def tprod : MultilinearMap R s (⨂[R] i, s i) where
   map_update_smul' {_ f} i r x := by
     rw [smul_tprodCoeff', ← smul_tprodCoeff (1 : R) _ i, update_idem, update_self]
 
-unsuppress_compilation in
 @[inherit_doc tprod]
 notation3:100 "⨂ₜ["R"] "(...)", "r:(scoped f => tprod R f) => r
 

--- a/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct/Isometries.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/TensorProduct/Isometries.lean
@@ -20,8 +20,6 @@ These results are separate from the definition of `QuadraticForm.tmul` as that f
 * `QuadraticForm.tensorLId`: `TensorProduct.lid` as a `QuadraticForm.IsometryEquiv`
 -/
 
-suppress_compilation
-
 universe uR uM₁ uM₂ uM₃ uM₄
 variable {R : Type uR} {M₁ : Type uM₁} {M₂ : Type uM₂} {M₃ : Type uM₃} {M₄ : Type uM₄}
 

--- a/Mathlib/LinearAlgebra/TensorAlgebra/Grading.lean
+++ b/Mathlib/LinearAlgebra/TensorAlgebra/Grading.lean
@@ -13,8 +13,6 @@ The main result is `TensorAlgebra.gradedAlgebra`, which says that the tensor alg
 ℕ-graded algebra.
 -/
 
-suppress_compilation
-
 namespace TensorAlgebra
 
 variable {R M : Type*} [CommSemiring R] [AddCommMonoid M] [Module R M]

--- a/Mathlib/LinearAlgebra/TensorAlgebra/ToTensorPower.lean
+++ b/Mathlib/LinearAlgebra/TensorAlgebra/ToTensorPower.lean
@@ -13,8 +13,6 @@ In this file we show that `TensorAlgebra R M` is isomorphic to a direct sum of t
 `TensorAlgebra.equivDirectSum`.
 -/
 
-suppress_compilation
-
 open scoped DirectSum TensorProduct
 
 variable {R M : Type*} [CommSemiring R] [AddCommMonoid M] [Module R M]

--- a/Mathlib/LinearAlgebra/TensorPower/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorPower/Basic.lean
@@ -27,8 +27,6 @@ In this file we use `ₜ1` and `ₜ*` as local notation for the graded multiplic
 tensor powers. Elsewhere, using `1` and `*` on `GradedMonoid` should be preferred.
 -/
 
-suppress_compilation
-
 open scoped TensorProduct
 
 /-- Homogeneous tensor powers $M^{\otimes n}$. `⨂[R]^n M` is a shorthand for

--- a/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
@@ -11,8 +11,6 @@ import Mathlib.LinearAlgebra.TensorProduct.Basic
 
 -/
 
-suppress_compilation
-
 variable {R : Type*} [CommSemiring R]
 variable {R' : Type*} [Monoid R']
 variable {R'' : Type*} [Semiring R'']

--- a/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basic.lean
@@ -38,8 +38,6 @@ map `TensorProduct.mk` is the given bilinear map `f`.  Uniqueness is shown in th
 bilinear, tensor, tensor product
 -/
 
-suppress_compilation
-
 section Semiring
 
 variable {R : Type*} [CommSemiring R]

--- a/Mathlib/LinearAlgebra/TensorProduct/Graded/External.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Graded/External.lean
@@ -43,8 +43,6 @@ multiplication follows trivially from this after some point-free nonsense.
 
 -/
 
-suppress_compilation
-
 open scoped TensorProduct DirectSum
 
 variable {R ι : Type*}
@@ -175,7 +173,7 @@ variable [DirectSum.GAlgebra R 𝒜] [DirectSum.GAlgebra R ℬ]
 
 open TensorProduct (assoc map) in
 /-- The multiplication operation for tensor products of externally `ι`-graded algebras. -/
-noncomputable irreducible_def gradedMul :
+irreducible_def gradedMul :
     letI AB := DirectSum _ 𝒜 ⊗[R] DirectSum _ ℬ
     letI : Module R AB := TensorProduct.leftModule
     AB →ₗ[R] AB →ₗ[R] AB := by

--- a/Mathlib/LinearAlgebra/TensorProduct/Graded/External.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Graded/External.lean
@@ -173,7 +173,7 @@ variable [DirectSum.GAlgebra R 𝒜] [DirectSum.GAlgebra R ℬ]
 
 open TensorProduct (assoc map) in
 /-- The multiplication operation for tensor products of externally `ι`-graded algebras. -/
-irreducible_def gradedMul :
+noncomputable irreducible_def gradedMul :
     letI AB := DirectSum _ 𝒜 ⊗[R] DirectSum _ ℬ
     letI : Module R AB := TensorProduct.leftModule
     AB →ₗ[R] AB →ₗ[R] AB := by

--- a/Mathlib/LinearAlgebra/TensorProduct/Graded/Internal.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Graded/Internal.lean
@@ -47,6 +47,8 @@ type.
 * Determine if replacing the synonym with a single-field structure improves performance.
 -/
 
+suppress_compilation
+
 open scoped TensorProduct
 
 variable {R ι A B : Type*}
@@ -117,7 +119,7 @@ notation:100 x " ᵍ⊗ₜ[" R "] " y:100 => tmul R x y
 variable (R) in
 /-- An auxiliary construction to move between the graded tensor product of internally-graded objects
 and the tensor product of direct sums. -/
-def auxEquiv : (𝒜 ᵍ⊗[R] ℬ) ≃ₗ[R] (⨁ i, 𝒜 i) ⊗[R] (⨁ i, ℬ i) :=
+noncomputable def auxEquiv : (𝒜 ᵍ⊗[R] ℬ) ≃ₗ[R] (⨁ i, 𝒜 i) ⊗[R] (⨁ i, ℬ i) :=
   let fA := (decomposeAlgEquiv 𝒜).toLinearEquiv
   let fB := (decomposeAlgEquiv ℬ).toLinearEquiv
   (of R 𝒜 ℬ).symm.trans (TensorProduct.congr fA fB)
@@ -136,7 +138,7 @@ variable [Module ι (Additive ℤˣ)]
 
 /-- Auxiliary construction used to build the `Mul` instance and get distributivity of `+` and
 `\smul`. -/
-def mulHom : (𝒜 ᵍ⊗[R] ℬ) →ₗ[R] (𝒜 ᵍ⊗[R] ℬ) →ₗ[R] (𝒜 ᵍ⊗[R] ℬ) := by
+noncomputable def mulHom : (𝒜 ᵍ⊗[R] ℬ) →ₗ[R] (𝒜 ᵍ⊗[R] ℬ) →ₗ[R] (𝒜 ᵍ⊗[R] ℬ) := by
   letI fAB1 := auxEquiv R 𝒜 ℬ
   have := ((gradedMul R (𝒜 ·) (ℬ ·)).compl₁₂ fAB1.toLinearMap fAB1.toLinearMap).compr₂
     fAB1.symm.toLinearMap

--- a/Mathlib/LinearAlgebra/TensorProduct/Graded/Internal.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Graded/Internal.lean
@@ -47,8 +47,6 @@ type.
 * Determine if replacing the synonym with a single-field structure improves performance.
 -/
 
-suppress_compilation
-
 open scoped TensorProduct
 
 variable {R ι A B : Type*}
@@ -119,7 +117,7 @@ notation:100 x " ᵍ⊗ₜ[" R "] " y:100 => tmul R x y
 variable (R) in
 /-- An auxiliary construction to move between the graded tensor product of internally-graded objects
 and the tensor product of direct sums. -/
-noncomputable def auxEquiv : (𝒜 ᵍ⊗[R] ℬ) ≃ₗ[R] (⨁ i, 𝒜 i) ⊗[R] (⨁ i, ℬ i) :=
+def auxEquiv : (𝒜 ᵍ⊗[R] ℬ) ≃ₗ[R] (⨁ i, 𝒜 i) ⊗[R] (⨁ i, ℬ i) :=
   let fA := (decomposeAlgEquiv 𝒜).toLinearEquiv
   let fB := (decomposeAlgEquiv ℬ).toLinearEquiv
   (of R 𝒜 ℬ).symm.trans (TensorProduct.congr fA fB)
@@ -138,7 +136,7 @@ variable [Module ι (Additive ℤˣ)]
 
 /-- Auxiliary construction used to build the `Mul` instance and get distributivity of `+` and
 `\smul`. -/
-noncomputable def mulHom : (𝒜 ᵍ⊗[R] ℬ) →ₗ[R] (𝒜 ᵍ⊗[R] ℬ) →ₗ[R] (𝒜 ᵍ⊗[R] ℬ) := by
+def mulHom : (𝒜 ᵍ⊗[R] ℬ) →ₗ[R] (𝒜 ᵍ⊗[R] ℬ) →ₗ[R] (𝒜 ᵍ⊗[R] ℬ) := by
   letI fAB1 := auxEquiv R 𝒜 ℬ
   have := ((gradedMul R (𝒜 ·) (ℬ ·)).compl₁₂ fAB1.toLinearMap fAB1.toLinearMap).compr₂
     fAB1.symm.toLinearMap

--- a/Mathlib/LinearAlgebra/TensorProduct/Opposite.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Opposite.lean
@@ -13,8 +13,6 @@ The main result in this file is:
 * `Algebra.TensorProduct.opAlgEquiv R S A B : Aᵐᵒᵖ ⊗[R] Bᵐᵒᵖ ≃ₐ[S] (A ⊗[R] B)ᵐᵒᵖ`
 -/
 
-suppress_compilation
-
 open scoped TensorProduct
 
 variable (R S A B : Type*)

--- a/Mathlib/LinearAlgebra/TensorProduct/Pi.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Pi.lean
@@ -39,7 +39,7 @@ section
 
 variable {ι} (M : ι → Type*) [∀ i, AddCommMonoid (M i)] [∀ i, Module R (M i)]
 
-private noncomputable def piRightHomBil : N →ₗ[S] (∀ i, M i) →ₗ[R] ∀ i, N ⊗[R] M i where
+private def piRightHomBil : N →ₗ[S] (∀ i, M i) →ₗ[R] ∀ i, N ⊗[R] M i where
   toFun n := LinearMap.pi (fun i ↦ mk R N (M i) n ∘ₗ LinearMap.proj i)
   map_add' _ _ := by
     ext
@@ -48,7 +48,7 @@ private noncomputable def piRightHomBil : N →ₗ[S] (∀ i, M i) →ₗ[R] ∀
 
 /-- For any `R`-module `N`, index type `ι` and family of `R`-modules `Mᵢ`, there is a natural
 linear map `N ⊗[R] (∀ i, M i) →ₗ ∀ i, N ⊗[R] M i`. This map is an isomorphism if `ι` is finite. -/
-noncomputable def piRightHom : N ⊗[R] (∀ i, M i) →ₗ[S] ∀ i, N ⊗[R] M i :=
+def piRightHom : N ⊗[R] (∀ i, M i) →ₗ[S] ∀ i, N ⊗[R] M i :=
   AlgebraTensorModule.lift <| piRightHomBil R S N M
 
 @[simp]
@@ -83,7 +83,7 @@ private lemma piRightInv_single (x : N) (i : ι) (m : M i) :
   simp
 
 /-- Tensor product commutes with finite products on the right. -/
-noncomputable def piRight : N ⊗[R] (∀ i, M i) ≃ₗ[S] ∀ i, N ⊗[R] M i :=
+def piRight : N ⊗[R] (∀ i, M i) ≃ₗ[S] ∀ i, N ⊗[R] M i :=
   LinearEquiv.ofLinear
     (piRightHom R S N M)
     (piRightInv R S N M)
@@ -121,7 +121,7 @@ private def piScalarRightHomBil : N →ₗ[S] (ι → R) →ₗ[R] (ι → N) wh
 
 /-- For any `R`-module `N` and index type `ι`, there is a natural
 linear map `N ⊗[R] (ι → R) →ₗ (ι → N)`. This map is an isomorphism if `ι` is finite. -/
-noncomputable def piScalarRightHom : N ⊗[R] (ι → R) →ₗ[S] (ι → N) :=
+def piScalarRightHom : N ⊗[R] (ι → R) →ₗ[S] (ι → N) :=
   AlgebraTensorModule.lift <| piScalarRightHomBil R S N ι
 
 @[simp]
@@ -147,7 +147,7 @@ private lemma piScalarRightInv_single (x : N) (i : ι) :
 
 /-- For any `R`-module `N` and finite index type `ι`, `N ⊗[R] (ι → R)` is canonically
 isomorphic to `ι → N`. -/
-noncomputable def piScalarRight : N ⊗[R] (ι → R) ≃ₗ[S] (ι → N) :=
+def piScalarRight : N ⊗[R] (ι → R) ≃ₗ[S] (ι → N) :=
   LinearEquiv.ofLinear
     (piScalarRightHom R S N ι)
     (piScalarRightInv R S N ι)

--- a/Mathlib/LinearAlgebra/TensorProduct/Pi.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Pi.lean
@@ -58,7 +58,7 @@ lemma piRightHom_tmul (x : N) (f : ∀ i, M i) :
 
 variable [Fintype ι] [DecidableEq ι]
 
-private noncomputable
+private
 def piRightInv : (∀ i, N ⊗[R] M i) →ₗ[S] N ⊗[R] ∀ i, M i :=
   LinearMap.lsum S (fun i ↦ N ⊗[R] M i) S <| fun i ↦
     AlgebraTensorModule.map LinearMap.id (single R M i)
@@ -132,7 +132,7 @@ lemma piScalarRightHom_tmul (x : N) (f : ι → R) :
 
 variable [Fintype ι] [DecidableEq ι]
 
-private noncomputable
+private
 def piScalarRightInv : (ι → N) →ₗ[S] N ⊗[R] (ι → R) :=
   LinearMap.lsum S (fun _ ↦ N) S <| fun i ↦ {
     toFun := fun n ↦ n ⊗ₜ Pi.single i 1

--- a/Mathlib/LinearAlgebra/TensorProduct/Prod.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Prod.lean
@@ -24,8 +24,6 @@ See `Mathlib/LinearAlgebra/TensorProduct/Pi.lean` for arbitrary products.
 
 variable (R S M₁ M₂ M₃ : Type*)
 
-suppress_compilation
-
 namespace TensorProduct
 
 variable [CommSemiring R] [Semiring S] [AddCommMonoid M₁] [AddCommMonoid M₂] [AddCommMonoid M₃]

--- a/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Tower.lean
@@ -44,8 +44,6 @@ probably should still implement the less general ones as abbreviations to the mo
 fewer type arguments.
 -/
 
-suppress_compilation
-
 namespace TensorProduct
 
 namespace AlgebraTensorModule

--- a/Mathlib/RingTheory/Bialgebra/Basic.lean
+++ b/Mathlib/RingTheory/Bialgebra/Basic.lean
@@ -43,8 +43,6 @@ that satisfy the coalgebra axioms to define a bialgebra structure on `A`.
 bialgebra
 -/
 
-suppress_compilation
-
 universe u v w
 
 open Function
@@ -156,7 +154,6 @@ variable (R : Type u) [CommSemiring R]
 open Bialgebra
 
 /-- Every commutative (semi)ring is a bialgebra over itself -/
-noncomputable
 instance toBialgebra : Bialgebra R R where
   mul_compr₂_counit := by ext; simp
   counit_one := rfl
@@ -173,7 +170,6 @@ variable {R A : Type*} [CommSemiring R] [Semiring A] [Algebra R A]
 then `Bialgebra.ofAlgHom` consumes the counit and comultiplication
 as algebra homomorphisms that satisfy the coalgebra axioms to define
 a bialgebra structure on `A`. -/
-noncomputable
 abbrev ofAlgHom (comul : A →ₐ[R] (A ⊗[R] A)) (counit : A →ₐ[R] R)
     (h_coassoc : (Algebra.TensorProduct.assoc R R A A A).toAlgHom.comp
       ((Algebra.TensorProduct.map comul (.id R A)).comp comul)

--- a/Mathlib/RingTheory/Bialgebra/MonoidAlgebra.lean
+++ b/Mathlib/RingTheory/Bialgebra/MonoidAlgebra.lean
@@ -22,7 +22,7 @@ coalgebra structure.
   `A[T;T⁻¹]` when `A` is an `R`-bialgebra.
 -/
 
-suppress_compilation
+noncomputable section
 
 open Bialgebra
 

--- a/Mathlib/RingTheory/Coalgebra/Basic.lean
+++ b/Mathlib/RingTheory/Coalgebra/Basic.lean
@@ -20,8 +20,6 @@ In this file we define `Coalgebra`, and provide instances for:
 * <https://en.wikipedia.org/wiki/Coalgebra>
 -/
 
-suppress_compilation
-
 universe u v w
 
 open scoped TensorProduct
@@ -54,7 +52,7 @@ structure Coalgebra.Repr (R : Type u) {A : Type v}
   (eq : ∑ i ∈ index, left i ⊗ₜ[R] right i = CoalgebraStruct.comul a)
 
 /-- An arbitrarily chosen representation. -/
-def Coalgebra.Repr.arbitrary (R : Type u) {A : Type v}
+noncomputable def Coalgebra.Repr.arbitrary (R : Type u) {A : Type v}
     [CommSemiring R] [AddCommMonoid A] [Module R A] [CoalgebraStruct R A] (a : A) :
     Coalgebra.Repr R a where
   left := Prod.fst
@@ -354,7 +352,7 @@ variable [CommSemiring R] [AddCommMonoid A] [Module R A] [Coalgebra R A]
 
 open LinearMap
 
-instance instCoalgebraStruct : CoalgebraStruct R (ι →₀ A) where
+noncomputable instance instCoalgebraStruct : CoalgebraStruct R (ι →₀ A) where
   comul := Finsupp.lsum R fun i =>
     TensorProduct.map (Finsupp.lsingle i) (Finsupp.lsingle i) ∘ₗ comul
   counit := Finsupp.lsum R fun _ => counit
@@ -389,7 +387,7 @@ theorem comul_comp_lapply (i : ι) :
 elements of `ι` has a coalgebra structure. The coproduct `Δ` is given by `Δ(fᵢ a) = fᵢ a₁ ⊗ fᵢ a₂`
 where `Δ(a) = a₁ ⊗ a₂` and the counit `ε` by `ε(fᵢ a) = ε(a)`, where `fᵢ a` is the function sending
 `i` to `a` and all other elements of `ι` to zero. -/
-instance instCoalgebra : Coalgebra R (ι →₀ A) where
+noncomputable instance instCoalgebra : Coalgebra R (ι →₀ A) where
   rTensor_counit_comp_comul := by
     ext : 1
     rw [comp_assoc, comul_comp_lsingle, ← comp_assoc, rTensor_comp_map, counit_comp_lsingle,

--- a/Mathlib/RingTheory/Coalgebra/MonoidAlgebra.lean
+++ b/Mathlib/RingTheory/Coalgebra/MonoidAlgebra.lean
@@ -21,7 +21,7 @@ corresponding structure on its coefficients, defined in `Mathlib/RingTheory/Coal
   `A[T;T⁻¹]` when `A` is an `R`-coalgebra.
 -/
 
-suppress_compilation
+noncomputable section
 
 open Coalgebra
 

--- a/Mathlib/RingTheory/HopfAlgebra/Basic.lean
+++ b/Mathlib/RingTheory/HopfAlgebra/Basic.lean
@@ -40,8 +40,6 @@ so we could deduce the facts here from an equivalence `HopfAlgCat R ≌ Hopf_ (M
 
 -/
 
-suppress_compilation
-
 universe u v w
 
 /-- Isolates the antipode of a Hopf algebra, to allow API to be constructed before proving the

--- a/Mathlib/RingTheory/HopfAlgebra/MonoidAlgebra.lean
+++ b/Mathlib/RingTheory/HopfAlgebra/MonoidAlgebra.lean
@@ -22,7 +22,7 @@ results about the `R`-Hopf algebra instance on `A[G]`, building upon results in
   is a group scheme.
 -/
 
-suppress_compilation
+noncomputable section
 
 open HopfAlgebra
 

--- a/Mathlib/RingTheory/MatrixAlgebra.lean
+++ b/Mathlib/RingTheory/MatrixAlgebra.lean
@@ -20,8 +20,6 @@ import Mathlib.RingTheory.TensorProduct.Basic
   where the forward map is the (tensor-ified) Kronecker product.
 -/
 
-suppress_compilation
-
 open TensorProduct Algebra.TensorProduct Matrix
 
 variable {l m n p : Type*} {R S A B M N : Type*}

--- a/Mathlib/RingTheory/TensorProduct/Basic.lean
+++ b/Mathlib/RingTheory/TensorProduct/Basic.lean
@@ -35,8 +35,6 @@ multiplication is characterized by `(a₁ ⊗ₜ b₁) * (a₂ ⊗ₜ b₂) = (a
 
 assert_not_exists Equiv.Perm.cycleType
 
-suppress_compilation
-
 open scoped TensorProduct
 
 open TensorProduct

--- a/Mathlib/RingTheory/TensorProduct/Basic.lean
+++ b/Mathlib/RingTheory/TensorProduct/Basic.lean
@@ -103,12 +103,12 @@ variable (R M N : Type*)
 
 /-- The map `LinearMap.lTensorHom` which sends `f ↦ 1 ⊗ f` as a morphism of algebras. -/
 @[simps!]
-noncomputable def lTensorAlgHom : Module.End R M →ₐ[R] Module.End R (N ⊗[R] M) :=
+def lTensorAlgHom : Module.End R M →ₐ[R] Module.End R (N ⊗[R] M) :=
   .ofLinearMap (lTensorHom (M := N)) (lTensor_id N M) (lTensor_mul N)
 
 /-- The map `LinearMap.rTensorHom` which sends `f ↦ f ⊗ 1` as a morphism of algebras. -/
 @[simps!]
-noncomputable def rTensorAlgHom : Module.End R M →ₐ[R] Module.End R (M ⊗[R] N) :=
+def rTensorAlgHom : Module.End R M →ₐ[R] Module.End R (M ⊗[R] N) :=
   .ofLinearMap (rTensorHom (M := N)) (rTensor_id N M) (rTensor_mul N)
 
 end Module.End
@@ -859,7 +859,7 @@ variable (T A B : Type*) [CommSemiring T] [CommSemiring A] [CommSemiring B]
   [IsScalarTower R S A] [Algebra S T] [IsScalarTower S T A]
 
 /-- The natural isomorphism `A ⊗[S] (S ⊗[R] B) ≃ₐ[T] A ⊗[R] B`. -/
-noncomputable def cancelBaseChange : A ⊗[S] (S ⊗[R] B) ≃ₐ[T] A ⊗[R] B :=
+def cancelBaseChange : A ⊗[S] (S ⊗[R] B) ≃ₐ[T] A ⊗[R] B :=
   AlgEquiv.symm <| AlgEquiv.ofLinearEquiv
     (TensorProduct.AlgebraTensorModule.cancelBaseChange R S T A B).symm
     (by simp [Algebra.TensorProduct.one_def]) <|

--- a/Mathlib/RingTheory/TensorProduct/Free.lean
+++ b/Mathlib/RingTheory/TensorProduct/Free.lean
@@ -24,8 +24,6 @@ and deduce that `Module.Free` is stable under base change.
 
 assert_not_exists Cardinal
 
-suppress_compilation
-
 open scoped TensorProduct
 
 namespace Algebra

--- a/Mathlib/RingTheory/TensorProduct/Pi.lean
+++ b/Mathlib/RingTheory/TensorProduct/Pi.lean
@@ -42,13 +42,13 @@ lemma piRightHom_mul (x y : A ⊗[R] ∀ i, B i) :
 
 /-- The canonical map `A ⊗[R] (∀ i, B i) →ₐ[S] ∀ i, A ⊗[R] B i`. This is an isomorphism
 if `ι` is finite (see `Algebra.TensorProduct.piRight`). -/
-noncomputable def piRightHom : A ⊗[R] (∀ i, B i) →ₐ[S] ∀ i, A ⊗[R] B i :=
+def piRightHom : A ⊗[R] (∀ i, B i) →ₐ[S] ∀ i, A ⊗[R] B i :=
   AlgHom.ofLinearMap (_root_.TensorProduct.piRightHom R S A B) (by simp) (by simp)
 
 variable [Fintype ι] [DecidableEq ι]
 
 /-- Tensor product of rings commutes with finite products on the right. -/
-noncomputable def piRight : A ⊗[R] (∀ i, B i) ≃ₐ[S] ∀ i, A ⊗[R] B i :=
+def piRight : A ⊗[R] (∀ i, B i) ≃ₐ[S] ∀ i, A ⊗[R] B i :=
   AlgEquiv.ofLinearEquiv (_root_.TensorProduct.piRight R S A B) (by simp) (by simp)
 
 @[simp]
@@ -57,7 +57,7 @@ lemma piRight_tmul (x : A) (f : ∀ i, B i) :
 
 variable (ι) in
 /-- Variant of `Algebra.TensorProduct.piRight` with constant factors. -/
-noncomputable def piScalarRight : A ⊗[R] (ι → R) ≃ₐ[S] ι → A :=
+def piScalarRight : A ⊗[R] (ι → R) ≃ₐ[S] ι → A :=
   (piRight R S A (fun _ : ι ↦ R)).trans <|
     AlgEquiv.piCongrRight (fun _ ↦ Algebra.TensorProduct.rid R S A)
 
@@ -75,7 +75,7 @@ section
 variable (B C : Type*) [Semiring B] [Semiring C] [Algebra R B] [Algebra R C]
 
 /-- Tensor product of rings commutes with binary products on the right. -/
-noncomputable nonrec def prodRight : A ⊗[R] (B × C) ≃ₐ[S] A ⊗[R] B × A ⊗[R] C :=
+nonrec def prodRight : A ⊗[R] (B × C) ≃ₐ[S] A ⊗[R] B × A ⊗[R] C :=
   AlgEquiv.ofLinearEquiv (TensorProduct.prodRight R S A B C)
     (by simp [Algebra.TensorProduct.one_def])
     (LinearMap.map_mul_of_map_mul_tmul (fun _ _ _ _ ↦ by simp))


### PR DESCRIPTION
This was a workaround introduced in #7281 for extreme performance issues in the old compiler, which is no more!

This isn't an exhaustive removal of `suppress_compilation`, but is almost all of the ones related to `TensorProduct`.
A handful of `noncomputable`s downstream can now be removed too.

Benchmark results seem mostly neutral.

Zulip thread: [#mathlib4 > Why is tensor product noncomputable? @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Why.20is.20tensor.20product.20noncomputable.3F/near/526882931)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
