### PR TITLE
feat(Data/Sym/Sym2): lift commutative operations to sym2

### DIFF
--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -785,11 +785,28 @@ lemma lift_smul_lift {α R N} [SMul R N] (f : { f : α → α → R // ∀ a₁ 
   simp_all only [Pi.smul_apply', lift_mk]
 
 /--
-Multiplication as a function from `Sym2`.
+Lift a commutative operation on `α` to one on `Sym2 α`, taking commutativity from the typeclass
+system. See also `Sym2.lift`, which takes the commutativity argument explicitly, and `Sym2.fromRel`,
+which takes a symmetric relation instead.
 -/
-def mul {M} [CommMagma M] : Sym2 M → M := lift ⟨(· * ·), mul_comm⟩
+def liftComm (op : α → α → β) [IsSymmOp op] : Sym2 α → β :=
+  lift ⟨op, IsSymmOp.symm_op⟩
 
 @[simp]
+lemma liftComm_mk {op : α → α → β} [IsSymmOp op] (xy : α × α) :
+    liftComm op (Sym2.mk xy) = op xy.1 xy.2 := rfl
+
+lemma liftComm_eq_fromRel (r : α → α → Prop) [hr : IsSymmOp r] :
+    liftComm r = fromRel (fun x y ↦ (hr.symm_op x y).mp) := rfl
+
+/--
+Multiplication as a function from `Sym2`.
+-/
+@[deprecated liftComm (since := "2025-07-03")]
+def mul {M} [CommMagma M] : Sym2 M → M := liftComm (· * ·)
+
+set_option linter.deprecated false in
+@[deprecated liftComm_mk (since := "2025-07-03"), simp]
 lemma mul_mk {M} [CommMagma M] (xy : M × M) :
     mul (.mk xy) = xy.1 * xy.2 := rfl
 

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -797,7 +797,7 @@ lemma liftComm_mk {op : α → α → β} [IsSymmOp op] (xy : α × α) :
     liftComm op (Sym2.mk xy) = op xy.1 xy.2 := rfl
 
 lemma liftComm_eq_fromRel (r : α → α → Prop) [hr : IsSymmOp r] :
-    liftComm r = fromRel (fun x y ↦ (hr.symm_op x y).mp) := rfl
+    liftComm r = setOf (fromRel (fun x y ↦ (hr.symm_op x y).mp)) := rfl
 
 /--
 Multiplication as a function from `Sym2`.

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -175,29 +175,30 @@ theorem mk_eq_mk_iff {p q : α × α} : Sym2.mk p = Sym2.mk q ↔ p = q ∨ p = 
   cases q
   simp only [eq_iff, Prod.mk_inj, Prod.swap_prod_mk]
 
+def lift (f : α → α → β) [hf : IsSymmOp f] : Sym2 α → β :=
+  Quot.lift (uncurry f) <| by rintro _ _ ⟨⟩; exacts [rfl, IsSymmOp.symm_op _ _]
+
 /-- The universal property of `Sym2`; symmetric functions of two arguments are equivalent to
 functions from `Sym2`. Note that when `β` is `Prop`, it can sometimes be more convenient to use
 `Sym2.fromRel` instead. -/
-def lift : { f : α → α → β // ∀ a₁ a₂, f a₁ a₂ = f a₂ a₁ } ≃ (Sym2 α → β) where
-  toFun f :=
-    Quot.lift (uncurry ↑f) <| by
-      rintro _ _ ⟨⟩
-      exacts [rfl, f.prop _ _]
+@[simps]
+def liftEquiv : { f : α → α → β // ∀ a₁ a₂, f a₁ a₂ = f a₂ a₁ } ≃ (Sym2 α → β) where
+  toFun f := lift f (hf := ⟨f.2⟩)
   invFun F := ⟨curry (F ∘ Sym2.mk), fun _ _ => congr_arg F eq_swap⟩
   right_inv _ := funext <| Sym2.ind fun _ _ => rfl
 
 @[simp]
-theorem lift_mk (f : { f : α → α → β // ∀ a₁ a₂, f a₁ a₂ = f a₂ a₁ }) (a₁ a₂ : α) :
-    lift f s(a₁, a₂) = (f : α → α → β) a₁ a₂ :=
+theorem liftEquiv_mk (f : { f : α → α → β // ∀ a₁ a₂, f a₁ a₂ = f a₂ a₁ }) (a₁ a₂ : α) :
+    liftEquiv f s(a₁, a₂) = (f : α → α → β) a₁ a₂ :=
   rfl
 
 @[simp]
-theorem coe_lift_symm_apply (F : Sym2 α → β) (a₁ a₂ : α) :
-    (lift.symm F : α → α → β) a₁ a₂ = F s(a₁, a₂) :=
+theorem coe_liftEquiv_symm_apply (F : Sym2 α → β) (a₁ a₂ : α) :
+    (liftEquiv.symm F : α → α → β) a₁ a₂ = F s(a₁, a₂) :=
   rfl
 
-/-- A two-argument version of `Sym2.lift`. -/
-def lift₂ :
+/-- A two-argument version of `Sym2.liftEquiv`. -/
+def liftEquiv₂ :
     { f : α → α → β → β → γ //
         ∀ a₁ a₂ b₁ b₂, f a₁ a₂ b₁ b₂ = f a₂ a₁ b₁ b₂ ∧ f a₁ a₂ b₁ b₂ = f a₁ a₂ b₂ b₁ } ≃
       (Sym2 α → Sym2 β → γ) where
@@ -214,16 +215,17 @@ def lift₂ :
   right_inv _ := funext₂ fun a b => Sym2.inductionOn₂ a b fun _ _ _ _ => rfl
 
 @[simp]
-theorem lift₂_mk
+theorem liftEquiv₂_mk
     (f :
     { f : α → α → β → β → γ //
       ∀ a₁ a₂ b₁ b₂, f a₁ a₂ b₁ b₂ = f a₂ a₁ b₁ b₂ ∧ f a₁ a₂ b₁ b₂ = f a₁ a₂ b₂ b₁ })
-    (a₁ a₂ : α) (b₁ b₂ : β) : lift₂ f s(a₁, a₂) s(b₁, b₂) = (f : α → α → β → β → γ) a₁ a₂ b₁ b₂ :=
+    (a₁ a₂ : α) (b₁ b₂ : β) :
+    liftEquiv₂ f s(a₁, a₂) s(b₁, b₂) = (f : α → α → β → β → γ) a₁ a₂ b₁ b₂ :=
   rfl
 
 @[simp]
-theorem coe_lift₂_symm_apply (F : Sym2 α → Sym2 β → γ) (a₁ a₂ : α) (b₁ b₂ : β) :
-    (lift₂.symm F : α → α → β → β → γ) a₁ a₂ b₁ b₂ = F s(a₁, a₂) s(b₁, b₂) :=
+theorem coe_liftEquiv₂_symm_apply (F : Sym2 α → Sym2 β → γ) (a₁ a₂ : α) (b₁ b₂ : β) :
+    (liftEquiv₂.symm F : α → α → β → β → γ) a₁ a₂ b₁ b₂ = F s(a₁, a₂) s(b₁, b₂) :=
   rfl
 
 /-- The functor `Sym2` is functorial, and this function constructs the induced maps.
@@ -268,11 +270,12 @@ def _root_.Function.Embedding.sym2Map (f : α ↪ β) : Sym2 α ↪ Sym2 β wher
   inj' := map.injective f.injective
 
 lemma lift_comp_map {g : γ → α} (f : {f : α → α → β // ∀ a₁ a₂, f a₁ a₂ = f a₂ a₁}) :
-    lift f ∘ map g = lift ⟨fun (c₁ c₂ : γ) => f.val (g c₁) (g c₂), fun _ _ => f.prop _ _⟩ :=
-  lift.symm_apply_eq.mp rfl
+    liftEquiv f ∘ map g =
+      liftEquiv ⟨fun (c₁ c₂ : γ) => f.val (g c₁) (g c₂), fun _ _ => f.prop _ _⟩ :=
+  liftEquiv.symm_apply_eq.mp rfl
 
 lemma lift_map_apply {g : γ → α} (f : {f : α → α → β // ∀ a₁ a₂, f a₁ a₂ = f a₂ a₁}) (p : Sym2 γ) :
-    lift f (map g p) = lift ⟨fun (c₁ c₂ : γ) => f.val (g c₁) (g c₂), fun _ _ => f.prop _ _⟩ p := by
+    liftEquiv f (map g p) = liftEquiv ⟨fun (c₁ c₂ : γ) => f.val (g c₁) (g c₂), fun _ _ => f.prop _ _⟩ p := by
   conv_rhs => rw [← lift_comp_map, comp_apply]
 
 section Membership

--- a/Mathlib/Data/Sym/Sym2.lean
+++ b/Mathlib/Data/Sym/Sym2.lean
@@ -796,8 +796,8 @@ def liftComm (op : α → α → β) [IsSymmOp op] : Sym2 α → β :=
 lemma liftComm_mk {op : α → α → β} [IsSymmOp op] (xy : α × α) :
     liftComm op (Sym2.mk xy) = op xy.1 xy.2 := rfl
 
-lemma liftComm_eq_fromRel (r : α → α → Prop) [hr : IsSymmOp r] :
-    liftComm r = setOf (fromRel (fun x y ↦ (hr.symm_op x y).mp)) := rfl
+lemma setOf_liftComm_eq_fromRel (r : α → α → Prop) [hr : IsSymmOp r] :
+    setOf (liftComm r) = fromRel (fun x y ↦ (hr.symm_op x y).mp) := rfl
 
 /--
 Multiplication as a function from `Sym2`.

--- a/Mathlib/Data/Sym/Sym2/Finsupp.lean
+++ b/Mathlib/Data/Sym/Sym2/Finsupp.lean
@@ -20,21 +20,21 @@ variable {α M₀ : Type*} [CommMonoidWithZero M₀] {f : α →₀ M₀}
 namespace Finsupp
 
 lemma sym2_support_eq_preimage_support_mul [NoZeroDivisors M₀] (f : α →₀ M₀) :
-    f.support.sym2 = map f ⁻¹' mul.support := by ext ⟨a, b⟩; simp
+    f.support.sym2 = map f ⁻¹' (liftComm (· * ·)).support := by ext ⟨a, b⟩; simp
 
-lemma mem_sym2_support_of_mul_ne_zero (p : Sym2 α) (hp : mul (p.map f) ≠ 0) :
+lemma mem_sym2_support_of_mul_ne_zero (p : Sym2 α) (hp : liftComm (· * ·) (p.map f) ≠ 0) :
     p ∈ f.support.sym2 := by
   obtain ⟨a, b⟩ := p
-  simp only [map_pair_eq, mul_mk, ne_eq] at hp
+  simp only [map_pair_eq, liftComm_mk, ne_eq] at hp
   simpa using .intro (left_ne_zero_of_mul hp) (right_ne_zero_of_mul hp)
 
 /-- The composition of a `Finsupp` with `Sym2.mul` as a `Finsupp`. -/
 noncomputable def sym2Mul (f : α →₀ M₀) : Sym2 α →₀ M₀ :=
-  .onFinset f.support.sym2 (fun p ↦ mul (p.map f)) mem_sym2_support_of_mul_ne_zero
+  .onFinset f.support.sym2 (fun p ↦ liftComm (· * ·) (p.map f)) mem_sym2_support_of_mul_ne_zero
 
 lemma support_sym2Mul_subset : f.sym2Mul.support ⊆ f.support.sym2 := support_onFinset_subset
 
-@[simp, norm_cast] lemma coe_sym2Mul (f : α →₀ M₀) : f.sym2Mul = mul ∘ map f := rfl
+@[simp, norm_cast] lemma coe_sym2Mul (f : α →₀ M₀) : f.sym2Mul = liftComm (· * ·) ∘ map f := rfl
 
 lemma sym2Mul_apply_mk (p : α × α) : f.sym2Mul (.mk p) = f p.1 * f p.2 := rfl
 

--- a/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
@@ -303,7 +303,7 @@ def polarBilin : BilinMap R M N :=
   (polar_smul_right Q)
 
 lemma polarSym2_map_smul {ι} (Q : QuadraticMap R M N) (g : ι → M) (l : ι → R) (p : Sym2 ι) :
-    polarSym2 Q (p.map (l • g)) = (p.map l).mul • polarSym2 Q (p.map g) := by
+    polarSym2 Q (p.map (l • g)) = (p.map l).liftComm (· * ·) • polarSym2 Q (p.map g) := by
   obtain ⟨_, _⟩ := p; simp [← smul_assoc, mul_comm]
 
 variable [CommSemiring S] [Algebra S R] [Module S M] [IsScalarTower S R M] [Module S N]

--- a/Mathlib/LinearAlgebra/QuadraticForm/Basis.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Basis.lean
@@ -55,7 +55,7 @@ theorem map_finsuppSum (Q : QuadraticMap R M N) (f : ι →₀ R) (g : ι → R 
 /-- The quadratic version of `Finsupp.apply_linearCombination`. -/
 theorem apply_linearCombination (Q : QuadraticMap R M N) {g : ι → M} (l : ι →₀ R) :
     Q (linearCombination R g l) = linearCombination R (Q ∘ g) (l * l) +
-      ∑ p ∈ l.support.sym2 with ¬ p.IsDiag, (p.map l).mul • polarSym2 Q (p.map g) := by
+      ∑ p ∈ l.support.sym2 with ¬ p.IsDiag, (p.map l).liftComm (· * ·) • polarSym2 Q (p.map g) := by
   simp_rw [linearCombination_apply, map_finsuppSum, Q.map_smul, mul_smul]
   rw [(l * l).sum_of_support_subset support_mul_subset_left _ <| by simp]
   simp [Finsupp.sum, ← polarSym2_map_smul, mul_smul]
@@ -64,7 +64,7 @@ theorem apply_linearCombination (Q : QuadraticMap R M N) {g : ι → M} (l : ι 
 theorem sum_repr_sq_add_sum_repr_mul_polar (Q : QuadraticMap R M N) (bm : Basis ι R M) (x : M) :
     linearCombination R (Q ∘ bm) (bm.repr x * bm.repr x) +
       ∑ p ∈ (bm.repr x).support.sym2 with ¬ p.IsDiag,
-        Sym2.mul (p.map (bm.repr x)) • polarSym2 Q (p.map bm) = Q x := by
+        Sym2.liftComm (· * ·) (p.map (bm.repr x)) • polarSym2 Q (p.map bm) = Q x := by
   rw [← apply_linearCombination, Basis.linearCombination_repr]
 
 end Finsupp


### PR DESCRIPTION
While we have `Sym2.lift`, it's often useful to lift operations which are known to be commutative to the typeclass system. Indeed, the existing `Sym2.mul` witnesses this already. Thus, this PR can also be seen as generalising `Sym2.mul`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
