### PR TITLE
[Merged by Bors] - feat(Tactic/Algebraize): add warning message when unable to find constant with provided name

### DIFF
--- a/Mathlib/Tactic/Algebraize.lean
+++ b/Mathlib/Tactic/Algebraize.lean
@@ -177,9 +177,9 @@ def addProperties (t : Array Expr) : TacticM Unit := withMainContext do
     -- lemma/constructor.
     | some p =>
       let cinfo ← try getConstInfo p catch _ =>
-        logWarning m!"Hypothesis {decl.toExpr} has type {decl.type}.\n\
+        logWarning m!"Hypothesis {decl.toExpr} has type{indentD decl.type}.\n\
           Its head symbol {.ofConstName nm} is (effectively) tagged with `@[algebraize {p}]`, \
-          but no constant {p} has been found.\n\
+          but no constant{indentD p}\nhas been found.\n\
           Check for missing imports, missing namespaces or typos."
         return
       let p' ← mkConstWithFreshMVarLevels p

--- a/Mathlib/Tactic/Algebraize.lean
+++ b/Mathlib/Tactic/Algebraize.lean
@@ -178,7 +178,7 @@ def addProperties (t : Array Expr) : TacticM Unit := withMainContext do
     | some p =>
       let cinfo ← try getConstInfo p catch _ =>
         logWarning m!"Hypothesis {decl.toExpr} has type {decl.type}.\n\
-          Its head symbol {nm} is (effectively) tagged with `@[algebraize {p}]`, \
+          Its head symbol {.ofConstName nm} is (effectively) tagged with `@[algebraize {p}]`, \
           but no constant {p} has been found.\n\
           Check for missing imports, missing namespaces or typos."
         return

--- a/Mathlib/Tactic/Algebraize.lean
+++ b/Mathlib/Tactic/Algebraize.lean
@@ -176,7 +176,12 @@ def addProperties (t : Array Expr) : TacticM Unit := withMainContext do
     -- If it has, `p` will either be the name of the corresponding `Algebra` property, or a
     -- lemma/constructor.
     | some p =>
-      let cinfo ← try getConstInfo p catch _ => return
+      let cinfo ← try getConstInfo p catch _ =>
+        logWarning m!"Hypothesis {decl.toExpr} has type {decl.type}.\n\
+          Its head symbol {nm} is (effectively) tagged with `@[algebraize {p}]`, \
+          but no constant {p} has been found.\n\
+          Check for missing imports, missing namespaces or typos."
+        return
       let p' ← mkConstWithFreshMVarLevels p
       let (pargs,_,_) ← forallMetaTelescope (← inferType p')
       let tp' := mkAppN p' pargs

--- a/MathlibTest/algebraize.lean
+++ b/MathlibTest/algebraize.lean
@@ -54,8 +54,11 @@ def RingHom.TestProperty4 (n : ℕ) {A B : Type*} [CommRing A] [CommRing B] (_ :
   ∀ m, n = m
 
 /--
-warning: Hypothesis hf has type RingHom.TestProperty4 n f.
-Its head symbol RingHom.TestProperty4 is (effectively) tagged with `@[algebraize RingHom.TestProperty4.toAlgebra]`, but no constant RingHom.TestProperty4.toAlgebra has been found.
+warning: Hypothesis hf has type
+  RingHom.TestProperty4 n f.
+Its head symbol RingHom.TestProperty4 is (effectively) tagged with `@[algebraize RingHom.TestProperty4.toAlgebra]`, but no constant
+  RingHom.TestProperty4.toAlgebra
+has been found.
 Check for missing imports, missing namespaces or typos.
 -/
 #guard_msgs (warning) in

--- a/MathlibTest/algebraize.lean
+++ b/MathlibTest/algebraize.lean
@@ -53,6 +53,17 @@ and hence needs to be created through a lemma. See e.g.
 def RingHom.TestProperty4 (n : ℕ) {A B : Type*} [CommRing A] [CommRing B] (_ : A →+* B) : Prop :=
   ∀ m, n = m
 
+/--
+warning: Hypothesis hf has type RingHom.TestProperty4 n f.
+Its head symbol RingHom.TestProperty4 is (effectively) tagged with `@[algebraize RingHom.TestProperty4.toAlgebra]`, but no constant RingHom.TestProperty4.toAlgebra has been found.
+Check for missing imports, missing namespaces or typos.
+-/
+#guard_msgs (warning) in
+example (n : ℕ) {A B : Type*} [CommRing A] [CommRing B] (f : A →+* B) (hf : f.TestProperty4 n) :
+    True := by
+  algebraize [f]
+  trivial
+
 lemma RingHom.TestProperty4.toAlgebra (n : ℕ) {A B : Type*} [CommRing A] [CommRing B] (f : A →+* B)
     (hf : f.TestProperty4 n) :
     letI : Algebra A B := f.toAlgebra


### PR DESCRIPTION
As evidenced by the discussion on #26635 and the follow-up #26657, it is easy to overlook a typo when names cannot be elaborated at the point of writing them, and there is no error or warning message when the elaboration *is* attempted later.
This PR remedies the second part of that issue as it pertains to the `algebraize` tactic and attribute, by logging a warning when the `algebraize` tactic is unable to find a constant associated to a name it is provided in its tags (or, when lacking such, that it generates).

See the new test for an example of the warning it produces.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
