### PR TITLE
[Merged by Bors] - feat: add continuousOn_iUnion

### DIFF
--- a/Mathlib/Topology/ContinuousOn.lean
+++ b/Mathlib/Topology/ContinuousOn.lean
@@ -1388,6 +1388,26 @@ theorem continouousOn_union_iff_of_isOpen {f : α → β} (hs : IsOpen s) (ht : 
   ⟨fun h ↦ ⟨h.mono s.subset_union_left, h.mono s.subset_union_right⟩,
    fun h ↦ h.left.union_of_isOpen h.right hs ht⟩
 
+/-- If a function is continuous on open sets `s i`, it is continuous on their union -/
+lemma ContinuousOn.iUnion_of_isOpen {ι : Type*} {s : ι → Set α}
+    (hf : ∀ i : ι, ContinuousOn f (s i)) (hs : ∀ i, IsOpen (s i)) :
+    ContinuousOn f (⋃ i, s i) := by
+  rintro x ⟨si, ⟨i, rfl⟩, hxsi⟩
+  exact (hf i).continuousAt ((hs i).mem_nhds hxsi) |>.continuousWithinAt
+
+/-- A function is continuous on a union of open sets `s i` iff it is continuous on each `s i`. -/
+lemma continuousOn_iUnion_iff_of_isOpen  {ι : Type*} {s : ι → Set α}
+    (hs : ∀ i, IsOpen (s i)) :
+    ContinuousOn f (⋃ i, s i) ↔ ∀ i : ι, ContinuousOn f (s i) :=
+  ⟨fun h i ↦ h.mono <| subset_iUnion_of_subset i fun _ a ↦ a,
+   fun h ↦ ContinuousOn.iUnion_of_isOpen h hs⟩
+
+lemma continuous_of_continuousOn_iUnion_of_isOpen {ι : Type*} {s : ι → Set α}
+    (hf : ∀ i : ι, ContinuousOn f (s i)) (hs : ∀ i, IsOpen (s i)) (hs' : ⋃ i, s i = univ) :
+    Continuous f := by
+  rw [continuous_iff_continuousOn_univ, ← hs'] -- diffgeo would expect ← continuousOn_univ!
+  exact ContinuousOn.iUnion_of_isOpen hf hs
+
 /-- If `f` is continuous on some neighbourhood `s'` of `s` and `f` maps `s` to `t`,
 the preimage of a set neighbourhood of `t` is a set neighbourhood of `s`. -/
 -- See `Continuous.tendsto_nhdsSet` for a special case.

--- a/Mathlib/Topology/ContinuousOn.lean
+++ b/Mathlib/Topology/ContinuousOn.lean
@@ -1405,7 +1405,7 @@ lemma continuousOn_iUnion_iff_of_isOpen  {ι : Type*} {s : ι → Set α}
 lemma continuous_of_continuousOn_iUnion_of_isOpen {ι : Type*} {s : ι → Set α}
     (hf : ∀ i : ι, ContinuousOn f (s i)) (hs : ∀ i, IsOpen (s i)) (hs' : ⋃ i, s i = univ) :
     Continuous f := by
-  rw [continuous_iff_continuousOn_univ, ← hs'] -- diffgeo would expect ← continuousOn_univ!
+  rw [continuous_iff_continuousOn_univ, ← hs']
   exact ContinuousOn.iUnion_of_isOpen hf hs
 
 /-- If `f` is continuous on some neighbourhood `s'` of `s` and `f` maps `s` to `t`,


### PR DESCRIPTION
A function is continuous on a union of open sets iff it is continuous on each individual set.
This extends the results in #22684 to arbitrary unions; the `ContMDiffOn` analogue is proven in #26673.

---

This exposed the naming bikeshed [here](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Naming.20convention/near/527026580), which is however independent of this PR.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
