### PR TITLE
[Merged by Bors] - feat(NumberTheory/Padics/Complex.lean): add the padic complex numbers

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4666,6 +4666,7 @@ import Mathlib.NumberTheory.NumberField.Units.DirichletTheorem
 import Mathlib.NumberTheory.NumberField.Units.Regulator
 import Mathlib.NumberTheory.Ostrowski
 import Mathlib.NumberTheory.Padics.AddChar
+import Mathlib.NumberTheory.Padics.Complex
 import Mathlib.NumberTheory.Padics.Hensel
 import Mathlib.NumberTheory.Padics.MahlerBasis
 import Mathlib.NumberTheory.Padics.PadicIntegers

--- a/Mathlib/NumberTheory/Padics/Complex.lean
+++ b/Mathlib/NumberTheory/Padics/Complex.lean
@@ -15,13 +15,13 @@ In this file we define the field `ℂ_[p]` of `p`-adic complex numbers and we gi
 field and a valued field structure, induced by the unique extension of the `p`-adic norm to `ℂ_[p]`.
 
 ## Main Definitions
-* `PadicAlg p` : the algebraic closure of `ℚ_[p]`.
+* `PadicAlgCl p` : the algebraic closure of `ℚ_[p]`.
 * `PadicComplex p` : the type of `p`-adic complex numbers.
-* `PadicComplex_integers` : the ring of integers of `ℂ_[p]`.
+* `PadicComplexInt` : the ring of integers of `ℂ_[p]`.
 
 ## Main Results
 
-* `PadicComplex.norm_extends` : the norm on `ℂ_[p]` extends the norm on `PadicAlg p`, and hence
+* `PadicComplex.norm_extends` : the norm on `ℂ_[p]` extends the norm on `PadicAlgCl p`, and hence
   the norm on `ℚ_[p]`.
 * `PadicComplex.isNonarchimedean` : The norm on `ℂ_[p]` is nonarchimedean.
 
@@ -43,115 +43,113 @@ open scoped NNReal
 
 variable (p : ℕ) [hp : Fact (Nat.Prime p)]
 
-/-- `PadicAlg p` is the algebraic closure of `ℚ_[p]`. -/
-abbrev PadicAlg := AlgebraicClosure ℚ_[p]
+/-- `PadicAlgCl p` is the algebraic closure of `ℚ_[p]`. -/
+abbrev PadicAlgCl := AlgebraicClosure ℚ_[p]
 
-namespace PadicAlg
+namespace PadicAlgCl
 
-/-- `PadicAlg p` is an algebraic extension of `ℚ_[p]`. -/
-theorem isAlgebraic : Algebra.IsAlgebraic ℚ_[p] (PadicAlg p) := AlgebraicClosure.isAlgebraic _
+/-- `PadicAlgCl p` is an algebraic extension of `ℚ_[p]`. -/
+theorem isAlgebraic : Algebra.IsAlgebraic ℚ_[p] (PadicAlgCl p) := AlgebraicClosure.isAlgebraic _
 
-instance : Coe ℚ_[p] (PadicAlg p) := ⟨algebraMap ℚ_[p] (PadicAlg p)⟩
+instance : Coe ℚ_[p] (PadicAlgCl p) := ⟨algebraMap ℚ_[p] (PadicAlgCl p)⟩
 
-theorem coe_eq : (Coe.coe : ℚ_[p] → PadicAlg p) = algebraMap ℚ_[p] (PadicAlg p) := rfl
+theorem coe_eq : (Coe.coe : ℚ_[p] → PadicAlgCl p) = algebraMap ℚ_[p] (PadicAlgCl p) := rfl
 
-/-- `PadicAlg p` is a normed field, where the norm is the `p`-adic norm, that is, the spectral norm
-induced by the `p`-adic norm on `ℚ_[p]`. -/
-instance normedField : NormedField (PadicAlg p) := spectralNorm.normedField ℚ_[p] (PadicAlg p)
+/-- `PadicAlgCl p` is a normed field, where the norm is the `p`-adic norm, that is, the
+spectral norm induced by the `p`-adic norm on `ℚ_[p]`. -/
+instance normedField : NormedField (PadicAlgCl p) := spectralNorm.normedField ℚ_[p] (PadicAlgCl p)
 
-/-- The norm on `PadicAlg p` is nonarchimedean. -/
-theorem isNonarchimedean : IsNonarchimedean (norm : PadicAlg p → ℝ) :=
-  isNonarchimedean_spectralNorm (K := ℚ_[p]) (L := PadicAlg p)
+/-- The norm on `PadicAlgCl p` is nonarchimedean. -/
+theorem isNonarchimedean : IsNonarchimedean (norm : PadicAlgCl p → ℝ) :=
+  isNonarchimedean_spectralNorm (K := ℚ_[p]) (L := PadicAlgCl p)
 
-/-- The norm on `PadicAlg p` is the spectral norm induced by the `p`-adic norm on `ℚ_[p]`. -/
-theorem norm_def (x : PadicAlg p) : ‖x‖ = spectralNorm ℚ_[p] (PadicAlg p) x := rfl
+/-- The norm on `PadicAlgCl p` is the spectral norm induced by the `p`-adic norm on `ℚ_[p]`. -/
+@[simp]
+theorem spectralNorm_eq (x : PadicAlgCl p) : spectralNorm ℚ_[p] (PadicAlgCl p) x = ‖x‖ := rfl
 
-/-- The norm on `PadicAlg p` extends the `p`-adic norm on `ℚ_[p]`. -/
-theorem norm_extends (x : ℚ_[p]) : ‖(x : PadicAlg p)‖ = ‖x‖ :=
-  spectralAlgNorm_extends (K := ℚ_[p]) (L := PadicAlg p) _
+/-- The norm on `PadicAlgCl p` extends the `p`-adic norm on `ℚ_[p]`. -/
+@[simp] theorem norm_extends (x : ℚ_[p]) : ‖(x : PadicAlgCl p)‖ = ‖x‖ :=
+  spectralAlgNorm_extends (K := ℚ_[p]) (L := PadicAlgCl p) _
 
-instance : IsUltrametricDist (PadicAlg p) :=
-  IsUltrametricDist.isUltrametricDist_of_forall_norm_add_le_max_norm (PadicAlg.isNonarchimedean p)
+instance : IsUltrametricDist (PadicAlgCl p) :=
+  IsUltrametricDist.isUltrametricDist_of_forall_norm_add_le_max_norm (PadicAlgCl.isNonarchimedean p)
 
-/-- `PadicAlg p` is a valued field, with the valuation corresponding to the `p`-adic norm. -/
-instance valued : Valued (PadicAlg p) ℝ≥0 := NormedField.toValued
+/-- `PadicAlgCl p` is a valued field, with the valuation corresponding to the `p`-adic norm. -/
+instance valued : Valued (PadicAlgCl p) ℝ≥0 := NormedField.toValued
 
-/-- The valuation of `x : PadicAlg p` agrees with its `ℝ≥0`-valued norm. -/
-theorem valuation_def (x : PadicAlg p) : Valued.v x = ‖x‖₊ := rfl
+/-- The valuation of `x : PadicAlgCl p` agrees with its `ℝ≥0`-valued norm. -/
+theorem valuation_def (x : PadicAlgCl p) : Valued.v x = ‖x‖₊ := rfl
 
-/-- The coercion of the valuation of `x : PadicAlg p` to `ℝ` agrees with its norm. -/
-theorem valuation_coe (x : PadicAlg p) :
-  ((Valued.v x : ℝ≥0) : ℝ) = spectralNorm ℚ_[p] (PadicAlg p) x := rfl
+/-- The coercion of the valuation of `x : PadicAlgCl p` to `ℝ` agrees with its norm. -/
+@[simp] theorem valuation_coe (x : PadicAlgCl p) : ((Valued.v x : ℝ≥0) : ℝ) = ‖x‖ := rfl
 
-/-- The valuation of `p : PadicAlg p` is `1/p`. -/
-theorem valuation_p (p : ℕ) [Fact p.Prime] : Valued.v (p : PadicAlg p) = 1 / (p : ℝ≥0) := by
-  rw [← map_natCast (algebraMap ℚ_[p] (PadicAlg p))]
+/-- The valuation of `p : PadicAlgCl p` is `1/p`. -/
+theorem valuation_p (p : ℕ) [Fact p.Prime] : Valued.v (p : PadicAlgCl p) = 1 / (p : ℝ≥0) := by
+  rw [← map_natCast (algebraMap ℚ_[p] (PadicAlgCl p))]
   ext
-  rw [valuation_coe, spectralNorm_extends, padicNormE.norm_p, one_div, NNReal.coe_inv,
+  rw [valuation_coe, norm_extends, padicNormE.norm_p, one_div, NNReal.coe_inv,
     NNReal.coe_natCast]
 
-/-- The valuation on `PadicAlg p` has rank one. -/
-instance : RankOne (PadicAlg.valued p).v where
+/-- The valuation on `PadicAlgCl p` has rank one. -/
+instance : RankOne (PadicAlgCl.valued p).v where
   hom         := MonoidWithZeroHom.id ℝ≥0
   strictMono' := strictMono_id
   nontrivial' := by
     use p
-    haveI hp : Nat.Prime p := hp.1
+    have hp : Nat.Prime p := hp.1
     simp only [valuation_p, one_div, ne_eq, inv_eq_zero, Nat.cast_eq_zero, inv_eq_one,
       Nat.cast_eq_one]
     exact ⟨hp.ne_zero, hp.ne_one⟩
 
-instance : UniformContinuousConstSMul ℚ_[p] (PadicAlg p) :=
-  uniformContinuousConstSMul_of_continuousConstSMul ℚ_[p] (PadicAlg p)
+instance : UniformContinuousConstSMul ℚ_[p] (PadicAlgCl p) :=
+  uniformContinuousConstSMul_of_continuousConstSMul ℚ_[p] (PadicAlgCl p)
 
-end PadicAlg
+end PadicAlgCl
 
-/-- `ℂ_[p]` is the field of `p`-adic complex numbers, that is, the completion of `PadicAlg p` with
+/-- `ℂ_[p]` is the field of `p`-adic complex numbers, that is, the completion of `PadicAlgCl p` with
 respect to the `p`-adic norm. -/
-abbrev PadicComplex := UniformSpace.Completion (PadicAlg p)
+abbrev PadicComplex := UniformSpace.Completion (PadicAlgCl p)
 
 /-- `ℂ_[p]` is the field of `p`-adic complex numbers. -/
 notation "ℂ_[" p "]" => PadicComplex p
 
 namespace PadicComplex
-/-- `ℂ_[p]` is a valued field, where the valuation is the one extending that on `PadicAlg p`. -/
+/-- `ℂ_[p]` is a valued field, where the valuation is the one extending that on `PadicAlgCl p`. -/
 instance valued : Valued ℂ_[p] ℝ≥0 := inferInstance
 
-/-- The valuation on `ℂ_[p]` extends the valuation on `PadicAlg p`. -/
-theorem valuation_extends (x : PadicAlg p) : Valued.v (x : ℂ_[p]) = Valued.v x :=
+/-- The valuation on `ℂ_[p]` extends the valuation on `PadicAlgCl p`. -/
+theorem valuation_extends (x : PadicAlgCl p) : Valued.v (x : ℂ_[p]) = Valued.v x :=
   Valued.extension_extends _
 
-theorem coe_eq (x : PadicAlg p) : (x : ℂ_[p]) = algebraMap (PadicAlg p) ℂ_[p] x := rfl
+theorem coe_eq (x : PadicAlgCl p) : (x : ℂ_[p]) = algebraMap (PadicAlgCl p) ℂ_[p] x := rfl
 
-theorem coe_zero : ((0 : PadicAlg p) : ℂ_[p]) = 0 := rfl
+@[simp] theorem coe_zero : ((0 : PadicAlgCl p) : ℂ_[p]) = 0 := rfl
 
 /-- `ℂ_[p]` is an algebra over `ℚ_[p]`. -/
 instance : Algebra ℚ_[p] ℂ_[p] where
-  smul := (UniformSpace.Completion.instSMul ℚ_[p] (PadicAlg p)).smul
-  algebraMap :=
-    RingHom.comp (UniformSpace.Completion.coeRingHom) (algebraMap ℚ_[p] (PadicAlg p))
+  smul := (UniformSpace.Completion.instSMul ℚ_[p] (PadicAlgCl p)).smul
+  algebraMap := (UniformSpace.Completion.coeRingHom).comp (algebraMap ℚ_[p] (PadicAlgCl p))
   commutes' r x := by rw [mul_comm]
   smul_def' r x := by
     apply UniformSpace.Completion.ext' (continuous_const_smul r) (continuous_mul_left _)
     intro a
-    have : UniformSpace.Completion.coeRingHom ((algebraMap ℚ_[p] (PadicAlg p)) r) * ↑a =
-       UniformSpace.Completion.coeRingHom ((algebraMap ℚ_[p] (PadicAlg p)) r) *
+    have : UniformSpace.Completion.coeRingHom ((algebraMap ℚ_[p] (PadicAlgCl p)) r) * ↑a =
+       UniformSpace.Completion.coeRingHom ((algebraMap ℚ_[p] (PadicAlgCl p)) r) *
        UniformSpace.Completion.coeRingHom a := rfl
     rw [← UniformSpace.Completion.coe_smul, RingHom.coe_comp, Function.comp_apply,
       this, ← map_mul, Algebra.smul_def]
     rfl
 
-instance : IsScalarTower ℚ_[p] (PadicAlg p) ℂ_[p] := IsScalarTower.of_algebraMap_eq (congrFun rfl)
+instance : IsScalarTower ℚ_[p] (PadicAlgCl p) ℂ_[p] := IsScalarTower.of_algebraMap_eq (congrFun rfl)
 
 @[simp, norm_cast]
-lemma coe_natCast (n : ℕ) : ((n : PadicAlg p) : ℂ_[p]) = (n : ℂ_[p])  := by
-  rw [← map_natCast (algebraMap (PadicAlg p) ℂ_[p]) n, coe_eq]
+lemma coe_natCast (n : ℕ) : ((n : PadicAlgCl p) : ℂ_[p]) = (n : ℂ_[p])  := by
+  rw [← map_natCast (algebraMap (PadicAlgCl p) ℂ_[p]) n, coe_eq]
 
 /-- The valuation of `p : ℂ_[p]` is `1/p`. -/
 theorem valuation_p : Valued.v (p : ℂ_[p]) = 1 / (p : ℝ≥0) := by
-  have := valuation_extends p (p : PadicAlg p)
-  rw [PadicAlg.valuation_p] at this
-  simpa only [← map_natCast (algebraMap (PadicAlg p) ℂ_[p]), ← coe_eq]
+  rw [← map_natCast (algebraMap (PadicAlgCl p) ℂ_[p]), ← coe_eq, valuation_extends,
+    PadicAlgCl.valuation_p]
 
 /-- The valuation on `ℂ_[p]` has rank one. -/
 instance : RankOne (PadicComplex.valued p).v where
@@ -159,13 +157,13 @@ instance : RankOne (PadicComplex.valued p).v where
   strictMono' := strictMono_id
   nontrivial' := by
     use p
-    haveI hp : Nat.Prime p := hp.1
+    have hp : Nat.Prime p := hp.1
     simp only [valuation_p, one_div, ne_eq, inv_eq_zero, Nat.cast_eq_zero, inv_eq_one,
       Nat.cast_eq_one]
     exact ⟨hp.ne_zero, hp.ne_one⟩
 
 lemma rankOne_hom_eq :
-    RankOne.hom (PadicComplex.valued p).v = RankOne.hom (PadicAlg.valued p).v := rfl
+    RankOne.hom (PadicComplex.valued p).v = RankOne.hom (PadicAlgCl.valued p).v := rfl
 
 /-- `ℂ_[p]` is a normed field, where the norm corresponds to the extension of the `p`-adic
   valuation. -/
@@ -173,32 +171,30 @@ instance : NormedField ℂ_[p] :=  Valued.toNormedField _ _
 
 theorem norm_def : (Norm.norm : ℂ_[p] → ℝ) = Valued.norm := rfl
 
-/-- The norm on `ℂ_[p]` extends the norm on `PadicAlg p`. -/
-theorem norm_extends (x : PadicAlg p) : ‖(x : ℂ_[p])‖ = ‖x‖ := by
+/-- The norm on `ℂ_[p]` extends the norm on `PadicAlgCl p`. -/
+theorem norm_extends (x : PadicAlgCl p) : ‖(x : ℂ_[p])‖ = ‖x‖ := by
   rw [norm_def, Valued.norm, ← coe_nnnorm, valuation_extends p x, coe_nnnorm]
   rfl
 
-/-- The `ℝ≥0`-valued norm on `ℂ_[p]` extends that on `PadicAlg p`. -/
-theorem nnnorm_extends (x : PadicAlg p) : ‖(x : ℂ_[p])‖₊ = ‖x‖₊ := by ext; exact norm_extends p x
+/-- The `ℝ≥0`-valued norm on `ℂ_[p]` extends that on `PadicAlgCl p`. -/
+theorem nnnorm_extends (x : PadicAlgCl p) : ‖(x : ℂ_[p])‖₊ = ‖x‖₊ := by ext; exact norm_extends p x
 
 /-- The norm on `ℂ_[p]` is nonarchimedean. -/
 theorem isNonarchimedean : IsNonarchimedean (Norm.norm : ℂ_[p] → ℝ) := fun x y ↦ by
   refine UniformSpace.Completion.induction_on₂ x y
-    (isClosed_le (Continuous.comp continuous_norm continuous_add)
-      (Continuous.max (Continuous.comp (@continuous_norm ℂ_[p] _) (Continuous.fst continuous_id))
-      (Continuous.comp (@continuous_norm ℂ_[p] _) (Continuous.snd continuous_id)))) (fun a b ↦ ?_)
-  · rw [← UniformSpace.Completion.coe_add, norm_extends, norm_extends, norm_extends]
-    exact PadicAlg.isNonarchimedean p a b
+    (isClosed_le (continuous_norm.comp continuous_add) (by continuity)) (fun a b ↦ ?_)
+  rw [← UniformSpace.Completion.coe_add, norm_extends, norm_extends, norm_extends]
+  exact PadicAlgCl.isNonarchimedean p a b
 
 end PadicComplex
 
 /-- We define `𝓞_ℂ_[p]` as the valuation subring of of `ℂ_[p]`, consisting of those elements with
   valuation `≤ 1`. -/
-def padicComplexIntegers : ValuationSubring ℂ_[p] := (PadicComplex.valued p).v.valuationSubring
+def PadicComplexInt : ValuationSubring ℂ_[p] := (PadicComplex.valued p).v.valuationSubring
 
 /-- We define `𝓞_ℂ_[p]` as the subring of elements of `ℂ_[p]` with valuation `≤ 1`. -/
-notation "𝓞_ℂ_[" p "]" => padicComplexIntegers p
+notation "𝓞_ℂ_[" p "]" => PadicComplexInt p
 
 /-- `𝓞_ℂ_[p]` is the ring of integers of `ℂ_[p]`. -/
-theorem PadicComplex.integers : Valuation.Integers (PadicComplex.valued p).v 𝓞_ℂ_[p] :=
+theorem PadicComplexInt.integers : Valuation.Integers (PadicComplex.valued p).v 𝓞_ℂ_[p] :=
   Valuation.integer.integers _

--- a/Mathlib/NumberTheory/Padics/Complex.lean
+++ b/Mathlib/NumberTheory/Padics/Complex.lean
@@ -44,7 +44,7 @@ open scoped NNReal
 
 variable (p : ℕ) [hp : Fact (Nat.Prime p)]
 
-/-- `PadicAlgCl p` is the algebraic closure of `ℚ_[p]`. -/
+/-- `PadicAlgCl p` is a fixed algebraic closure of `ℚ_[p]`. -/
 abbrev PadicAlgCl := AlgebraicClosure ℚ_[p]
 
 namespace PadicAlgCl

--- a/Mathlib/NumberTheory/Padics/Complex.lean
+++ b/Mathlib/NumberTheory/Padics/Complex.lean
@@ -9,15 +9,16 @@ import Mathlib.Topology.Algebra.Valued.NormedValued
 import Mathlib.Topology.Algebra.Valued.ValuedField
 
 /-!
-# The `p`-adic complex numbers.
+# The field `ℂ_[p]` of `p`-adic complex numbers.
 
-In this file we define the field `ℂ_[p]` of `p`-adic complex numbers and we give it both a normed
-field and a valued field structure, induced by the unique extension of the `p`-adic norm to `ℂ_[p]`.
+In this file we define the field `ℂ_[p]` of `p`-adic complex numbers as the `p`-adic completion of
+an algebraic closure of `ℚ_[p]`. We endow `ℂ_[p]` with both a normed field and a valued field
+structure, induced by the unique extension of the `p`-adic norm to `ℂ_[p]`.
 
 ## Main Definitions
 * `PadicAlgCl p` : the algebraic closure of `ℚ_[p]`.
-* `PadicComplex p` : the type of `p`-adic complex numbers.
-* `PadicComplexInt` : the ring of integers of `ℂ_[p]`.
+* `PadicComplex p` : the type of `p`-adic complex numbers, denoted by `ℂ_[p]`.
+* `PadicComplexInt p` : the ring of integers of `ℂ_[p]`.
 
 ## Main Results
 
@@ -37,7 +38,7 @@ p-adic, p adic, padic, norm, valuation, Cauchy, completion, p-adic completion
 
 noncomputable section
 
-open Valued Valuation
+open Valuation
 
 open scoped NNReal
 
@@ -133,11 +134,7 @@ instance : Algebra ℚ_[p] ℂ_[p] where
   smul_def' r x := by
     apply UniformSpace.Completion.ext' (continuous_const_smul r) (continuous_mul_left _)
     intro a
-    have : UniformSpace.Completion.coeRingHom ((algebraMap ℚ_[p] (PadicAlgCl p)) r) * ↑a =
-       UniformSpace.Completion.coeRingHom ((algebraMap ℚ_[p] (PadicAlgCl p)) r) *
-       UniformSpace.Completion.coeRingHom a := rfl
-    rw [← UniformSpace.Completion.coe_smul, RingHom.coe_comp, Function.comp_apply,
-      this, ← map_mul, Algebra.smul_def]
+    rw [RingHom.coe_comp, Function.comp_apply, Algebra.smul_def]
     rfl
 
 instance : IsScalarTower ℚ_[p] (PadicAlgCl p) ℂ_[p] := IsScalarTower.of_algebraMap_eq (congrFun rfl)

--- a/Mathlib/NumberTheory/Padics/Complex.lean
+++ b/Mathlib/NumberTheory/Padics/Complex.lean
@@ -1,0 +1,194 @@
+/-
+Copyright (c) 2025 María Inés de Frutos-Fernández. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: María Inés de Frutos-Fernández
+-/
+import Mathlib.Analysis.Normed.Unbundled.SpectralNorm
+import Mathlib.NumberTheory.Padics.PadicNumbers
+import Mathlib.Topology.Algebra.Valued.NormedValued
+import Mathlib.Topology.Algebra.Valued.ValuedField
+
+/-!
+# The `p`-adic complex numbers.
+
+In this file we define the field `ℂ_[p]` of `p`-adic complex numbers and we give it both a normed
+field and a valued field structure, induced by the unique extension of the `p`-adic norm to `ℂ_[p]`.
+
+## Main Definitions
+* `PadicAlg p` : the algebraic closure of `ℚ_[p]`.
+* `PadicComplex p` : the type of `p`-adic complex numbers.
+* `PadicComplex_integers` : the ring of integers of `ℂ_[p]`.
+
+## Main Results
+
+* `PadicComplex.norm_extends` : the norm on `ℂ_[p]` extends the norm on `PadicAlg p`, and hence
+  the norm on `ℚ_[p]`.
+* `PadicComplex.isNonarchimedean` : The norm on `ℂ_[p]` is nonarchimedean.
+
+## Notation
+
+We introduce the notation `ℂ_[p]` for the `p`-adic complex numbers, and `𝓞_ℂ_[p]` for its ring of
+integers.
+
+## Tags
+
+p-adic, p adic, padic, norm, valuation, Cauchy, completion, p-adic completion
+-/
+
+noncomputable section
+
+open Valued Valuation
+
+open scoped NNReal
+
+variable (p : ℕ) [hp : Fact (Nat.Prime p)]
+
+/-- `PadicAlg p` is the algebraic closure of `ℚ_[p]`. -/
+@[reducible] def PadicAlg := AlgebraicClosure ℚ_[p]
+
+namespace PadicAlg
+
+/-- `PadicAlg p` is an algebraic extension of `ℚ_[p]`. -/
+theorem isAlgebraic : Algebra.IsAlgebraic ℚ_[p] (PadicAlg p) := AlgebraicClosure.isAlgebraic _
+
+instance : Coe ℚ_[p] (PadicAlg p) := ⟨algebraMap ℚ_[p] (PadicAlg p)⟩
+
+theorem coe_eq : (Coe.coe : ℚ_[p] → PadicAlg p) = algebraMap ℚ_[p] (PadicAlg p) := rfl
+
+/-- `PadicAlg p` is a normed field, where the norm is the `p`-adic norm, that is, the spectral norm
+induced by the `p`-adic norm on `ℚ_[p]`. -/
+instance normedField : NormedField (PadicAlg p) := spectralNorm.normedField ℚ_[p] (PadicAlg p)
+
+/-- The norm on `PadicAlg p` is nonarchimedean. -/
+theorem isNonarchimedean : IsNonarchimedean (norm : PadicAlg p → ℝ) :=
+  isNonarchimedean_spectralNorm (K := ℚ_[p]) (L := PadicAlg p)
+
+/-- The norm on `PadicAlg p` is the spectral norm induced by the `p`-adic norm on `ℚ_[p]`. -/
+theorem norm_def (x : PadicAlg p) : ‖x‖ = spectralNorm ℚ_[p] (PadicAlg p) x := rfl
+
+/-- The norm on `PadicAlg p` extends the `p`-adic norm on `ℚ_[p]`. -/
+theorem norm_extends (x : ℚ_[p]) : ‖(x : PadicAlg p)‖ = ‖x‖ :=
+  spectralAlgNorm_extends (K := ℚ_[p]) (L := PadicAlg p) _
+
+instance : IsUltrametricDist (PadicAlg p) :=
+  IsUltrametricDist.isUltrametricDist_of_forall_norm_add_le_max_norm (PadicAlg.isNonarchimedean p)
+
+/-- `PadicAlg p` is a valued field, with the valuation corresponding to the `p`-adic norm. -/
+instance valuedField : Valued (PadicAlg p) ℝ≥0 := NormedField.toValued
+
+/-- The valuation of `x : PadicAlg p` agrees with its `ℝ≥0`-valued norm. -/
+theorem valuation_def (x : PadicAlg p) : Valued.v x = ‖x‖₊ := rfl
+
+/-- The coercion of the valuation of `x : PadicAlg p` to `ℝ` agrees with its norm. -/
+theorem valuation_coe (x : PadicAlg p) :
+  ((Valued.v x : ℝ≥0) : ℝ) = spectralNorm ℚ_[p] (PadicAlg p) x := rfl
+
+/-- The valuation of `p : PadicAlg p` is `1/p`. -/
+theorem valuation_p (p : ℕ) [Fact p.Prime] : Valued.v (p : PadicAlg p) = 1 / (p : ℝ≥0) := by
+  rw [← map_natCast (algebraMap ℚ_[p] (PadicAlg p))]
+  ext
+  rw [valuation_coe, spectralNorm_extends, padicNormE.norm_p, one_div, NNReal.coe_inv,
+    NNReal.coe_natCast]
+
+end PadicAlg
+
+/-- `ℂ_[p]` is the field of `p`-adic complex numbers, that is, the completion of `PadicAlg p` with
+respect to the `p`-adic norm. -/
+def PadicComplex := UniformSpace.Completion (PadicAlg p)
+
+/-- `ℂ_[p]` is the field of `p`-adic complex numbers. -/
+notation "ℂ_[" p "]" => PadicComplex p
+
+namespace PadicComplex
+
+/-- The `p`-adic complex numbers have a field structure. -/
+instance : Field ℂ_[p] := UniformSpace.Completion.instField
+
+/-- The `p`-adic complex numbers are inhabited. -/
+instance : Inhabited ℂ_[p] := ⟨0⟩
+
+/-- `ℂ_[p]` is a valued field, where the valuation is the one extending that on `PadicAlg p`. -/
+instance valued : Valued ℂ_[p] ℝ≥0 := Valued.valuedCompletion
+
+/-- `ℂ_[p]` is a complete space. -/
+instance completeSpace : CompleteSpace ℂ_[p] := UniformSpace.Completion.completeSpace _
+
+instance : Coe (PadicAlg p) ℂ_[p] := ⟨UniformSpace.Completion.coe'⟩
+
+/-- The valuation on `ℂ_[p]` extends the valuation on `PadicAlg p`. -/
+theorem valuation_extends (x : PadicAlg p) : Valued.v (x : ℂ_[p]) = Valued.v x :=
+  Valued.extension_extends _
+
+/-- `ℂ_[p]` is an algebra over `PadicAlg p`. -/
+instance : Algebra (PadicAlg p) ℂ_[p] := UniformSpace.Completion.algebra' _
+
+theorem coe_eq (x : PadicAlg p) : (x : ℂ_[p]) = algebraMap (PadicAlg p) ℂ_[p] x := rfl
+
+theorem coe_zero : ((0 : PadicAlg p) : ℂ_[p]) = 0 := rfl
+
+/-- `ℂ_[p]` is an algebra over `ℚ_[p]`. -/
+instance : Algebra ℚ_[p] ℂ_[p] :=
+  ((algebraMap (PadicAlg p) ℂ_[p]).comp (algebraMap ℚ_[p] (PadicAlg p))).toAlgebra
+
+instance : IsScalarTower ℚ_[p] (PadicAlg p) ℂ_[p] := IsScalarTower.of_algebraMap_eq (congrFun rfl)
+
+@[simp, norm_cast]
+lemma coe_natCast (n : ℕ) : ((n : PadicAlg p) : ℂ_[p]) = (n : ℂ_[p])  := by
+  rw [← map_natCast (algebraMap (PadicAlg p) ℂ_[p]) n, coe_eq]
+
+/-- The valuation of `p : ℂ_[p]` is `1/p`. -/
+theorem valuation_p : Valued.v (p : ℂ_[p]) = 1 / (p : ℝ≥0) := by
+  have := valuation_extends p (p : PadicAlg p)
+  rw [PadicAlg.valuation_p] at this
+  simpa only [← map_natCast (algebraMap (PadicAlg p) ℂ_[p]), ← coe_eq]
+
+/-- The valuation on `ℂ_[p]` has rank one. -/
+instance : RankOne (PadicComplex.valued p).v where
+  hom         := MonoidWithZeroHom.id ℝ≥0
+  strictMono' := strictMono_id
+  nontrivial' := by
+    use p
+    haveI hp : Nat.Prime p := hp.1
+    simp only [valuation_p, one_div, ne_eq, inv_eq_zero, Nat.cast_eq_zero, inv_eq_one,
+      Nat.cast_eq_one]
+    exact ⟨hp.ne_zero, hp.ne_one⟩
+
+/-- `ℂ_[p]` is a normed field, where the norm corresponds to the extension of the `p`-adic
+  valuation. -/
+instance C_p.NormedField : NormedField ℂ_[p] :=  Valued.toNormedField _ _
+
+instance : NormedField (UniformSpace.Completion (PadicAlg p)) := C_p.NormedField p
+
+theorem norm_def : (Norm.norm : ℂ_[p] → ℝ) = Valued.norm := rfl
+
+/-- The norm on `ℂ_[p]` extends the norm on `PadicAlg p`. -/
+theorem norm_extends (x : PadicAlg p) : ‖(x : ℂ_[p])‖ = ‖x‖ := by
+  by_cases hx : x = 0
+  · rw [hx, coe_zero, norm_zero, norm_zero]
+  · rw [norm_def, Valued.norm, ← coe_nnnorm, ← PadicAlg.valuation_def, ← valuation_extends p x]
+    rfl
+
+/-- The `ℝ≥0`-valued norm on `ℂ_[p]` extends that on `PadicAlg p`. -/
+theorem nnnorm_extends (x : PadicAlg p) : ‖(x : ℂ_[p])‖₊ = ‖x‖₊ := by ext; exact norm_extends p x
+
+/-- The norm on `ℂ_[p]` is nonarchimedean. -/
+theorem isNonarchimedean : IsNonarchimedean (Norm.norm : ℂ_[p] → ℝ) := fun x y ↦ by
+  refine UniformSpace.Completion.induction_on₂ x y
+    (isClosed_le (Continuous.comp continuous_norm continuous_add)
+      (Continuous.max (Continuous.comp (@continuous_norm ℂ_[p] _) (Continuous.fst continuous_id))
+      (Continuous.comp (@continuous_norm ℂ_[p] _) (Continuous.snd continuous_id)))) (fun a b ↦ ?_)
+  · rw [← UniformSpace.Completion.coe_add, norm_extends, norm_extends, norm_extends]
+    exact PadicAlg.isNonarchimedean p a b
+
+end PadicComplex
+
+/-- We define `𝓞_ℂ_[p]` as the valuation subring of of `ℂ_[p]`, consisting of those elements with
+  valuation `≤ 1`. -/
+def padicComplexIntegers : ValuationSubring ℂ_[p] := (PadicComplex.valued p).v.valuationSubring
+
+/-- We define `𝓞_ℂ_[p]` as the subring of elements of `ℂ_[p]` with valuation `≤ 1`. -/
+notation "𝓞_ℂ_[" p "]" => padicComplexIntegers p
+
+/-- `𝓞_ℂ_[p]` is the ring of integers of `ℂ_[p]`. -/
+theorem PadicComplex.integers : Valuation.Integers (PadicComplex.valued p).v 𝓞_ℂ_[p] :=
+  Valuation.integer.integers _


### PR DESCRIPTION
We define the field of p-adic complex numbers.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
