### PR TITLE
[Merged by Bors] - feat: contMDiffOn_section_of_mem_baseSet

### DIFF
--- a/Mathlib/Geometry/Manifold/VectorBundle/Basic.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Basic.lean
@@ -486,8 +486,8 @@ theorem Trivialization.contMDiffOn_symm (e : Trivialization F (π F E)) [MemTriv
 
 /-- Smoothness of a `C^n` section at `x₀` within a set `a` can be determined
 using any trivialisation whose `baseSet` contains `x₀`. -/
-theorem Trivialization.contMDiffWithinAt_section (s : ∀ x, E x) (a : Set B) {x₀ : B}
-    (e : Trivialization F (Bundle.TotalSpace.proj : Bundle.TotalSpace F E → B))
+theorem Trivialization.contMDiffWithinAt_section {s : ∀ x, E x} (a : Set B) {x₀ : B}
+    {e : Trivialization F (Bundle.TotalSpace.proj : Bundle.TotalSpace F E → B)}
     [MemTrivializationAtlas e] (hx₀ : x₀ ∈ e.baseSet) :
     ContMDiffWithinAt IB (IB.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (s x)) a x₀ ↔
       ContMDiffWithinAt IB 𝓘(𝕜, F) n (fun x ↦ (e ⟨x, s x⟩).2) a x₀ := by
@@ -504,7 +504,7 @@ theorem contMDiffAt_section_of_mem_baseSet {s : ∀ x, E x} {x₀ : B}
     ContMDiffAt IB (IB.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (s x)) x₀ ↔
       ContMDiffAt IB 𝓘(𝕜, F) n (fun x ↦ (e ⟨x, s x⟩).2) x₀ := by
   simp_rw [← contMDiffWithinAt_univ]
-  exact e.contMDiffWithinAt_section  s univ hx₀
+  exact e.contMDiffWithinAt_section univ hx₀
 
 /-- Smoothness of a `C^n` section on `s` can be determined
 using any trivialisation whose `baseSet` contains `s`. -/
@@ -513,16 +513,10 @@ theorem contMDiffOn_section_of_mem_baseSet {s : ∀ x, E x} {a : Set B}
     [MemTrivializationAtlas e] (ha : IsOpen a) (ha' : a ⊆ e.baseSet) :
     ContMDiffOn IB (IB.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (s x)) a ↔
       ContMDiffOn IB 𝓘(𝕜, F) n (fun x ↦ (e ⟨x, s x⟩).2) a := by
-  -- golfing useful?
-  constructor
-  · intro h x hx
-    have : ContMDiffAt IB (IB.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (s x)) x :=
-      (h x hx).contMDiffAt <| ha.mem_nhds hx
-    exact ((contMDiffAt_section_of_mem_baseSet (ha' hx)).mp this).contMDiffWithinAt
-  · intro h x hx
-    have : ContMDiffAt IB 𝓘(𝕜, F) n (fun x ↦ (e { proj := x, snd := s x }).2) x :=
-      (h x hx).contMDiffAt <| ha.mem_nhds hx
-    exact ((contMDiffAt_section_of_mem_baseSet (ha' hx)).mpr this).contMDiffWithinAt
+  refine ⟨fun h x hx ↦ ?_, fun h x hx ↦ ?_⟩ <;>
+  have := (h x hx).contMDiffAt <| ha.mem_nhds hx
+  · exact ((contMDiffAt_section_of_mem_baseSet (ha' hx)).mp this).contMDiffWithinAt
+  · exact ((contMDiffAt_section_of_mem_baseSet (ha' hx)).mpr this).contMDiffWithinAt
 
 /-- For any trivialization `e`, the smoothness of a `C^n` section on `e.baseSet`
 can be determined using `e`. -/

--- a/Mathlib/Geometry/Manifold/VectorBundle/Basic.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Basic.lean
@@ -484,6 +484,55 @@ theorem Trivialization.contMDiffOn_symm (e : Trivialization F (π F E)) [MemTriv
     contMDiffOn_snd.congr fun x hx ↦ ?_⟩
   rw [e.apply_symm_apply hx]
 
+/-- Smoothness of a `C^n` section at `x₀` within a set `a` can be determined
+using any trivialisation whose `baseSet` contains `x₀`. -/
+theorem Trivialization.contMDiffWithinAt_section (s : ∀ x, E x) (a : Set B) {x₀ : B}
+    (e : Trivialization F (Bundle.TotalSpace.proj : Bundle.TotalSpace F E → B))
+    [MemTrivializationAtlas e] (hx₀ : x₀ ∈ e.baseSet) :
+    ContMDiffWithinAt IB (IB.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (s x)) a x₀ ↔
+      ContMDiffWithinAt IB 𝓘(𝕜, F) n (fun x ↦ (e ⟨x, s x⟩).2) a x₀ := by
+  rw [e.contMDiffWithinAt_iff]
+  · change ContMDiffWithinAt IB IB n id a x₀ ∧ _ ↔ _
+    simp [contMDiffWithinAt_id]
+  · rwa [mem_source]
+
+/-- Smoothness of a `C^n` section at `x₀` can be determined
+using any trivialisation whose `baseSet` contains `x₀`. -/
+theorem contMDiffAt_section_of_mem_baseSet {s : ∀ x, E x} {x₀ : B}
+    {e : Trivialization F (Bundle.TotalSpace.proj : Bundle.TotalSpace F E → B)}
+    [MemTrivializationAtlas e] (hx₀ : x₀ ∈ e.baseSet) :
+    ContMDiffAt IB (IB.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (s x)) x₀ ↔
+      ContMDiffAt IB 𝓘(𝕜, F) n (fun x ↦ (e ⟨x, s x⟩).2) x₀ := by
+  simp_rw [← contMDiffWithinAt_univ]
+  exact e.contMDiffWithinAt_section  s univ hx₀
+
+/-- Smoothness of a `C^n` section on `s` can be determined
+using any trivialisation whose `baseSet` contains `s`. -/
+theorem contMDiffOn_section_of_mem_baseSet {s : ∀ x, E x} {a : Set B}
+    {e : Trivialization F (Bundle.TotalSpace.proj : Bundle.TotalSpace F E → B)}
+    [MemTrivializationAtlas e] (ha : IsOpen a) (ha' : a ⊆ e.baseSet) :
+    ContMDiffOn IB (IB.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (s x)) a ↔
+      ContMDiffOn IB 𝓘(𝕜, F) n (fun x ↦ (e ⟨x, s x⟩).2) a := by
+  -- golfing useful?
+  constructor
+  · intro h x hx
+    have : ContMDiffAt IB (IB.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (s x)) x :=
+      (h x hx).contMDiffAt <| ha.mem_nhds hx
+    exact ((contMDiffAt_section_of_mem_baseSet (ha' hx)).mp this).contMDiffWithinAt
+  · intro h x hx
+    have : ContMDiffAt IB 𝓘(𝕜, F) n (fun x ↦ (e { proj := x, snd := s x }).2) x :=
+      (h x hx).contMDiffAt <| ha.mem_nhds hx
+    exact ((contMDiffAt_section_of_mem_baseSet (ha' hx)).mpr this).contMDiffWithinAt
+
+/-- For any trivialization `e`, the smoothness of a `C^n` section on `e.baseSet`
+can be determined using `e`. -/
+theorem contMDiffOn_section_of_mem_baseSet₀ {s : ∀ x, E x}
+    {e : Trivialization F (Bundle.TotalSpace.proj : Bundle.TotalSpace F E → B)}
+    [MemTrivializationAtlas e] :
+    ContMDiffOn IB (IB.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (s x)) e.baseSet ↔
+      ContMDiffOn IB 𝓘(𝕜, F) n (fun x ↦ (e ⟨x, s x⟩).2) e.baseSet :=
+  contMDiffOn_section_of_mem_baseSet e.open_baseSet (subset_refl _)
+
 end
 
 /-! ### Core construction for `C^n` vector bundles -/


### PR DESCRIPTION
Smoothness of a section can be determined using any trivialisation, not just the preferred trivialisation at a point.

Part of the path towards geodesics and the Levi-Civita connection.

Co-authored by: @PatrickMassot 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
