### PR TITLE
[Merged by Bors] - feat: DifferentiableOn.iUnion

### DIFF
--- a/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
@@ -607,6 +607,55 @@ nonrec theorem DifferentiableAt.isBigO_sub {f : E → F} {x₀ : E} (h : Differe
 
 end FDerivProperties
 
+/-! ### Being differentiable on a union of sets can be tested on each set -/
+section differentiableOn_union
+
+/-- If a function is differentiable on two open sets, it is also differentiable on their union. -/
+lemma DifferentiableOn.union_of_isOpen
+    (hf : DifferentiableOn 𝕜 f s) (hf' : DifferentiableOn 𝕜 f t)
+    (hs : IsOpen s) (ht : IsOpen t) :
+    DifferentiableOn 𝕜 f (s ∪ t) := by
+  intro x hx
+  obtain (hx | hx) := hx
+  · exact (hf x hx).differentiableAt (hs.mem_nhds hx) |>.differentiableWithinAt
+  · exact (hf' x hx).differentiableAt (ht.mem_nhds hx) |>.differentiableWithinAt
+
+/-- A function is differentiable on two open sets iff it is differentiable on their union. -/
+lemma differentiableOn_union_iff_of_isOpen (hs : IsOpen s) (ht : IsOpen t) :
+    DifferentiableOn 𝕜 f (s ∪ t) ↔ DifferentiableOn 𝕜 f s ∧ DifferentiableOn 𝕜 f t :=
+  ⟨fun h ↦ ⟨h.mono subset_union_left, h.mono subset_union_right⟩,
+    fun ⟨hfs, hft⟩ ↦ DifferentiableOn.union_of_isOpen hfs hft hs ht⟩
+
+lemma differentiable_of_mdifferentiableOn_union_of_isOpen (hf : DifferentiableOn 𝕜 f s)
+    (hf' : DifferentiableOn 𝕜 f t) (hst : s ∪ t = univ) (hs : IsOpen s) (ht : IsOpen t) :
+    Differentiable 𝕜 f := by
+  rw [← differentiableOn_univ, ← hst]
+  exact hf.union_of_isOpen hf' hs ht
+
+/-- If a function is differentiable on open sets `s i`, it is differentiable on their union. -/
+lemma DifferentiableOn.iUnion_of_isOpen {ι : Type*} {s : ι → Set E}
+    (hf : ∀ i : ι, DifferentiableOn 𝕜 f (s i)) (hs : ∀ i, IsOpen (s i)) :
+    DifferentiableOn 𝕜 f (⋃ i, s i) := by
+  rintro x ⟨si, ⟨i, rfl⟩, hxsi⟩
+  exact (hf i).differentiableAt ((hs i).mem_nhds hxsi) |>.differentiableWithinAt
+
+/-- A function is differentiable on a union of open sets `s i`
+iff it is differentiable on each `s i`. -/
+lemma differentiableOn_iUnion_iff_of_isOpen  {ι : Type*} {s : ι → Set E}
+    (hs : ∀ i, IsOpen (s i)) :
+    DifferentiableOn 𝕜 f (⋃ i, s i) ↔ ∀ i : ι, DifferentiableOn 𝕜 f (s i) :=
+  ⟨fun h i ↦ h.mono <| subset_iUnion_of_subset i fun _ a ↦ a,
+   fun h ↦ DifferentiableOn.iUnion_of_isOpen h hs⟩
+
+lemma differentiable_of_differentiableOn_iUnion_of_isOpen {ι : Type*} {s : ι → Set E}
+    (hf : ∀ i : ι, DifferentiableOn 𝕜 f (s i))
+    (hs : ∀ i, IsOpen (s i)) (hs' : ⋃ i, s i = univ) :
+    Differentiable 𝕜 f := by
+  rw [← differentiableOn_univ, ← hs']
+  exact DifferentiableOn.iUnion_of_isOpen hf hs
+
+end differentiableOn_union
+
 section Continuous
 
 /-! ### Deducing continuity from differentiability -/

--- a/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Basic.lean
@@ -607,7 +607,7 @@ nonrec theorem DifferentiableAt.isBigO_sub {f : E → F} {x₀ : E} (h : Differe
 
 end FDerivProperties
 
-/-! ### Being differentiable on a union of sets can be tested on each set -/
+/-! ### Being differentiable on a union of open sets can be tested on each set -/
 section differentiableOn_union
 
 /-- If a function is differentiable on two open sets, it is also differentiable on their union. -/
@@ -626,7 +626,7 @@ lemma differentiableOn_union_iff_of_isOpen (hs : IsOpen s) (ht : IsOpen t) :
   ⟨fun h ↦ ⟨h.mono subset_union_left, h.mono subset_union_right⟩,
     fun ⟨hfs, hft⟩ ↦ DifferentiableOn.union_of_isOpen hfs hft hs ht⟩
 
-lemma differentiable_of_mdifferentiableOn_union_of_isOpen (hf : DifferentiableOn 𝕜 f s)
+lemma differentiable_of_differentiableOn_union_of_isOpen (hf : DifferentiableOn 𝕜 f s)
     (hf' : DifferentiableOn 𝕜 f t) (hst : s ∪ t = univ) (hs : IsOpen s) (ht : IsOpen t) :
     Differentiable 𝕜 f := by
   rw [← differentiableOn_univ, ← hst]
@@ -641,7 +641,7 @@ lemma DifferentiableOn.iUnion_of_isOpen {ι : Type*} {s : ι → Set E}
 
 /-- A function is differentiable on a union of open sets `s i`
 iff it is differentiable on each `s i`. -/
-lemma differentiableOn_iUnion_iff_of_isOpen  {ι : Type*} {s : ι → Set E}
+lemma differentiableOn_iUnion_iff_of_isOpen {ι : Type*} {s : ι → Set E}
     (hs : ∀ i, IsOpen (s i)) :
     DifferentiableOn 𝕜 f (⋃ i, s i) ↔ ∀ i : ι, DifferentiableOn 𝕜 f (s i) :=
   ⟨fun h i ↦ h.mono <| subset_iUnion_of_subset i fun _ a ↦ a,


### PR DESCRIPTION
Analogue of #26673 for `DifferentiableOn`.

Transitive mathlib clean-up from the path towards geodesics and the Levi-Civita connection.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
