### PR TITLE
[Merged by Bors] - feat: ContDiffOn.iUnion

### DIFF
--- a/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
@@ -565,6 +565,52 @@ alias ContDiff.prod := ContDiff.prodMk
 
 end prod
 
+/-! ### Being `C^k` on a union of sets can be tested on each set -/
+section contDiffOn_union
+
+/-- If a function is `C^k` on two open sets, it is also `C^n` on their union. -/
+lemma ContDiffOn.union_of_isOpen (hf : ContDiffOn 𝕜 n f s) (hf' : ContDiffOn 𝕜 n f t)
+    (hs : IsOpen s) (ht : IsOpen t) :
+    ContDiffOn 𝕜 n f (s ∪ t) := by
+  intro x hx
+  obtain (hx | hx) := hx
+  · exact (hf x hx).contDiffAt (hs.mem_nhds hx) |>.contDiffWithinAt
+  · exact (hf' x hx).contDiffAt (ht.mem_nhds hx) |>.contDiffWithinAt
+
+/-- A function is `C^k` on two open sets iff it is `C^k` on their union. -/
+lemma contDiffOn_union_iff_of_isOpen (hs : IsOpen s) (ht : IsOpen t) :
+    ContDiffOn 𝕜 n f (s ∪ t) ↔ ContDiffOn 𝕜 n f s ∧ ContDiffOn 𝕜 n f t :=
+  ⟨fun h ↦ ⟨h.mono subset_union_left, h.mono subset_union_right⟩,
+   fun ⟨hfs, hft⟩ ↦ ContDiffOn.union_of_isOpen hfs hft hs ht⟩
+
+lemma contDiff_of_contDiffOn_union_of_isOpen (hf : ContDiffOn 𝕜 n f s)
+    (hf' : ContDiffOn 𝕜 n f t) (hst : s ∪ t = univ) (hs : IsOpen s) (ht : IsOpen t) :
+    ContDiff 𝕜 n f := by
+  rw [← contDiffOn_univ, ← hst]
+  exact hf.union_of_isOpen hf' hs ht
+
+/-- If a function is `C^k` on open sets `s i`, it is `C^k` on their union -/
+lemma ContDiffOn.iUnion_of_isOpen {ι : Type*} {s : ι → Set E}
+    (hf : ∀ i : ι, ContDiffOn 𝕜 n f (s i)) (hs : ∀ i, IsOpen (s i)) :
+    ContDiffOn 𝕜 n f (⋃ i, s i) := by
+  rintro x ⟨si, ⟨i, rfl⟩, hxsi⟩
+  exact (hf i).contDiffAt ((hs i).mem_nhds hxsi) |>.contDiffWithinAt
+
+/-- A function is `C^k` on a union of open sets `s i` iff it is `C^k` on each `s i`. -/
+lemma contDiffOn_iUnion_iff_of_isOpen  {ι : Type*} {s : ι → Set E}
+    (hs : ∀ i, IsOpen (s i)) :
+    ContDiffOn 𝕜 n f (⋃ i, s i) ↔ ∀ i : ι, ContDiffOn 𝕜 n f (s i) :=
+  ⟨fun h i ↦ h.mono <| subset_iUnion_of_subset i fun _ a ↦ a,
+   fun h ↦ ContDiffOn.iUnion_of_isOpen h hs⟩
+
+lemma contDiff_of_contMDiffOn_iUnion_of_isOpen {ι : Type*} {s : ι → Set E}
+    (hf : ∀ i : ι, ContDiffOn 𝕜 n f (s i)) (hs : ∀ i, IsOpen (s i)) (hs' : ⋃ i, s i = univ) :
+    ContDiff 𝕜 n f := by
+  rw [← contDiffOn_univ, ← hs']
+  exact ContDiffOn.iUnion_of_isOpen hf hs
+
+end contDiffOn_union
+
 section comp
 
 /-!
@@ -1463,3 +1509,5 @@ theorem ContDiff.iterate_deriv' (n : ℕ) :
   | k + 1, _, hf => ContDiff.iterate_deriv' _ k (contDiff_succ_iff_deriv.mp hf).2.2
 
 end deriv
+
+set_option linter.style.longFile 1700

--- a/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
@@ -572,8 +572,7 @@ section contDiffOn_union
 lemma ContDiffOn.union_of_isOpen (hf : ContDiffOn 𝕜 n f s) (hf' : ContDiffOn 𝕜 n f t)
     (hs : IsOpen s) (ht : IsOpen t) :
     ContDiffOn 𝕜 n f (s ∪ t) := by
-  intro x hx
-  obtain (hx | hx) := hx
+  rintro x (hx | hx)
   · exact (hf x hx).contDiffAt (hs.mem_nhds hx) |>.contDiffWithinAt
   · exact (hf' x hx).contDiffAt (ht.mem_nhds hx) |>.contDiffWithinAt
 

--- a/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
@@ -565,7 +565,7 @@ alias ContDiff.prod := ContDiff.prodMk
 
 end prod
 
-/-! ### Being `C^k` on a union of sets can be tested on each set -/
+/-! ### Being `C^k` on a union of open sets can be tested on each set -/
 section contDiffOn_union
 
 /-- If a function is `C^k` on two open sets, it is also `C^n` on their union. -/
@@ -597,13 +597,13 @@ lemma ContDiffOn.iUnion_of_isOpen {ι : Type*} {s : ι → Set E}
   exact (hf i).contDiffAt ((hs i).mem_nhds hxsi) |>.contDiffWithinAt
 
 /-- A function is `C^k` on a union of open sets `s i` iff it is `C^k` on each `s i`. -/
-lemma contDiffOn_iUnion_iff_of_isOpen  {ι : Type*} {s : ι → Set E}
+lemma contDiffOn_iUnion_iff_of_isOpen {ι : Type*} {s : ι → Set E}
     (hs : ∀ i, IsOpen (s i)) :
     ContDiffOn 𝕜 n f (⋃ i, s i) ↔ ∀ i : ι, ContDiffOn 𝕜 n f (s i) :=
   ⟨fun h i ↦ h.mono <| subset_iUnion_of_subset i fun _ a ↦ a,
    fun h ↦ ContDiffOn.iUnion_of_isOpen h hs⟩
 
-lemma contDiff_of_contMDiffOn_iUnion_of_isOpen {ι : Type*} {s : ι → Set E}
+lemma contDiff_of_contDiffOn_iUnion_of_isOpen {ι : Type*} {s : ι → Set E}
     (hf : ∀ i : ι, ContDiffOn 𝕜 n f (s i)) (hs : ∀ i, IsOpen (s i)) (hs' : ⋃ i, s i = univ) :
     ContDiff 𝕜 n f := by
   rw [← contDiffOn_univ, ← hs']


### PR DESCRIPTION
Analogue of #26673 for `ContDifferentiableOn`.

Transitive mathlib clean-up from the path towards geodesics and the Levi-Civita connection.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
