### PR TITLE
[Merged by Bors] - feat: add lemmas for modular exponentiation with the totient function

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3312,6 +3312,7 @@ import Mathlib.Data.Nat.PSub
 import Mathlib.Data.Nat.Pairing
 import Mathlib.Data.Nat.PartENat
 import Mathlib.Data.Nat.Periodic
+import Mathlib.Data.Nat.PowModTotient
 import Mathlib.Data.Nat.Prime.Basic
 import Mathlib.Data.Nat.Prime.Defs
 import Mathlib.Data.Nat.Prime.Factorial

--- a/Mathlib/Data/Nat/PowModTotient.lean
+++ b/Mathlib/Data/Nat/PowModTotient.lean
@@ -9,8 +9,8 @@ import Mathlib.FieldTheory.Finite.Basic
 # Modular exponentiation with the totient function
 
 This file contains lemmas about modular exponentiation.
-In particular, it contains lemmas about an exponent can be reduced modulo the totient function
-when the base is coprime to the modulus.
+In particular, it contains lemmas showing that an exponent can be reduced modulo the totient
+function when the base is coprime to the modulus.
 
 ## Main Results
 

--- a/Mathlib/Data/Nat/PowModTotient.lean
+++ b/Mathlib/Data/Nat/PowModTotient.lean
@@ -14,7 +14,8 @@ when the base is coprime to the modulus.
 
 ## Main Results
 
-* `pow_totient_mod`: If `x` is coprime to `n`, then `x ^ φ n % n = 1`.
+* `pow_totient_mod`: If `x` is coprime to `n`, then the modular exponentiation
+  `x ^ k % n` can be reduced to `x ^ (k % φ n) % n`.
 
 ## TODOs
 

--- a/Mathlib/Data/Nat/PowModTotient.lean
+++ b/Mathlib/Data/Nat/PowModTotient.lean
@@ -1,0 +1,50 @@
+/-
+Copyright (c) 2025 Bolton Bailey. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Bolton Bailey
+-/
+import Mathlib.FieldTheory.Finite.Basic
+
+/-!
+# Modular exponentiation with the totient function
+
+This file contains lemmas about modular exponentiation.
+In particular, it contains lemmas about an exponent can be reduced modulo the totient function
+when the base is coprime to the modulus.
+
+## Main Results
+
+* `pow_totient_mod`: If `x` is coprime to `n`, then `x ^ n.totient % n = 1`.
+
+## TODOs
+
+- Extend to results in cases where the base is not coprime to the modulus.
+- Write a tactic or simproc that can automatically reduce exponents
+  or towers of exponents using these results.
+
+-/
+
+namespace Nat
+
+lemma pow_totient_mod_eq_one {x n : ℕ} (hn : 1 < n) (h : x.Coprime n) :
+    (x ^ n.totient) % n = 1 := by
+  exact mod_eq_of_modEq (ModEq.pow_totient h) hn
+
+lemma pow_add_totient_mod_eq {x k n : ℕ} (hn : 1 < n) (h : x.Coprime n) :
+    (x ^ (k + n.totient)) % n = (x ^ k) % n := by
+  rw [pow_add, mul_mod, pow_totient_mod_eq_one hn h]
+  simp only [mul_one, dvd_refl, mod_mod_of_dvd]
+
+lemma pow_add_mul_totient_mod_eq {x k l n : ℕ} (hn : 1 < n) (h : x.Coprime n) :
+    (x ^ (k + l * n.totient)) % n = (x ^ k) % n := by
+  induction l with
+  | zero => simp
+  | succ l ih =>
+    rw [add_mul, one_mul, ← add_assoc, pow_add_totient_mod_eq hn h, ih]
+
+lemma pow_totient_mod {x k n : ℕ} (hn : 1 < n) (h : x.Coprime n) :
+    x ^ k % n = x ^ (k % n.totient) % n := by
+  rw [← div_add_mod' k (φ n), add_comm, pow_add_mul_totient_mod_eq hn h, add_mul_mod_self_right,
+    mod_mod k (φ n)]
+
+end Nat

--- a/Mathlib/Data/Nat/PowModTotient.lean
+++ b/Mathlib/Data/Nat/PowModTotient.lean
@@ -14,7 +14,7 @@ when the base is coprime to the modulus.
 
 ## Main Results
 
-* `pow_totient_mod`: If `x` is coprime to `n`, then `x ^ n.totient % n = 1`.
+* `pow_totient_mod`: If `x` is coprime to `n`, then `x ^ φ n % n = 1`.
 
 ## TODOs
 
@@ -27,23 +27,23 @@ when the base is coprime to the modulus.
 namespace Nat
 
 lemma pow_totient_mod_eq_one {x n : ℕ} (hn : 1 < n) (h : x.Coprime n) :
-    (x ^ n.totient) % n = 1 := by
+    (x ^ φ n) % n = 1 := by
   exact mod_eq_of_modEq (ModEq.pow_totient h) hn
 
 lemma pow_add_totient_mod_eq {x k n : ℕ} (hn : 1 < n) (h : x.Coprime n) :
-    (x ^ (k + n.totient)) % n = (x ^ k) % n := by
+    (x ^ (k + φ n)) % n = (x ^ k) % n := by
   rw [pow_add, mul_mod, pow_totient_mod_eq_one hn h]
   simp only [mul_one, dvd_refl, mod_mod_of_dvd]
 
 lemma pow_add_mul_totient_mod_eq {x k l n : ℕ} (hn : 1 < n) (h : x.Coprime n) :
-    (x ^ (k + l * n.totient)) % n = (x ^ k) % n := by
+    (x ^ (k + l * φ n)) % n = (x ^ k) % n := by
   induction l with
   | zero => simp
   | succ l ih =>
     rw [add_mul, one_mul, ← add_assoc, pow_add_totient_mod_eq hn h, ih]
 
 lemma pow_totient_mod {x k n : ℕ} (hn : 1 < n) (h : x.Coprime n) :
-    x ^ k % n = x ^ (k % n.totient) % n := by
+    x ^ k % n = x ^ (k % φ n) % n := by
   rw [← div_add_mod' k (φ n), add_comm, pow_add_mul_totient_mod_eq hn h, add_mul_mod_self_right,
     mod_mod k (φ n)]
 


### PR DESCRIPTION
This PR adds lemmas around reducing the exponent of a modular exponentiation.

These lemmas were found while doing work for [Project Numina](https://projectnumina.ai/).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
