### PR TITLE
[Merged by Bors] - feat: add version of fderiv_const_smul without differentiability hypotheses

### DIFF
--- a/Mathlib/Analysis/Calculus/FDeriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Add.lean
@@ -127,6 +127,37 @@ theorem fderivWithin_const_smul (hxs : UniqueDiffWithinAt 𝕜 s x)
     fderivWithin 𝕜 (c • f) s x = c • fderivWithin 𝕜 f s x :=
   fderivWithin_fun_const_smul hxs h c
 
+/-- If `c` is invertible, `c • f` is differentiable at `x` within `s` if and only if `f` is. -/
+lemma differentiableWithinAt_smul_iff (c : R) [Invertible c] :
+    DifferentiableWithinAt 𝕜 (c • f) s x ↔ DifferentiableWithinAt 𝕜 f s x := by
+  refine ⟨fun h ↦ ?_, fun h ↦ h.const_smul c⟩
+  apply (h.const_smul ⅟ c).congr_of_eventuallyEq ?_ (by simp)
+  filter_upwards with x using by simp
+
+/-- A version of `fderivWithin_const_smul` without differentiability hypothesis:
+in return, the constant `c` must be invertible, i.e. if `R` is a field. -/
+theorem fderivWithin_const_smul_of_invertible (c : R) [Invertible c]
+    (hs : UniqueDiffWithinAt 𝕜 s x) :
+    fderivWithin 𝕜 (c • f) s x = c • fderivWithin 𝕜 f s x := by
+  by_cases h : DifferentiableWithinAt 𝕜 f s x
+  · exact (h.hasFDerivWithinAt.const_smul c).fderivWithin hs
+  · obtain (rfl | hc) := eq_or_ne c 0
+    · simp
+    have : ¬DifferentiableWithinAt 𝕜 (c • f) s x := by
+      contrapose! h
+      exact (differentiableWithinAt_smul_iff c).mp h
+    simp [fderivWithin_zero_of_not_differentiableWithinAt h,
+      fderivWithin_zero_of_not_differentiableWithinAt this]
+
+/-- Special case of `fderivWithin_const_smul_of_invertible` over a field: any constant is allowed -/
+lemma fderivWithin_const_smul_of_field (c : 𝕜) (hs : UniqueDiffWithinAt 𝕜 s x) :
+    fderivWithin 𝕜 (c • f) s x = c • fderivWithin 𝕜 f s x := by
+  obtain (rfl | ha) := eq_or_ne c 0
+  · simp
+  · have : Invertible c := invertibleOfNonzero ha
+    ext x
+    simp [fderivWithin_const_smul_of_invertible c (f := f) hs]
+
 @[deprecated (since := "2025-06-14")] alias fderivWithin_const_smul' := fderivWithin_const_smul
 
 theorem fderiv_fun_const_smul (h : DifferentiableAt 𝕜 f x) (c : R) :
@@ -140,30 +171,19 @@ theorem fderiv_const_smul (h : DifferentiableAt 𝕜 f x) (c : R) :
 /-- If `c` is invertible, `c • f` is differentiable at `x` if and only if `f` is. -/
 lemma differentiableAt_smul_iff (c : R) [Invertible c] :
     DifferentiableAt 𝕜 (c • f) x ↔ DifferentiableAt 𝕜 f x := by
-  refine ⟨fun h ↦ ?_, fun h ↦ h.const_smul c⟩
-  apply (h.const_smul ⅟ c).congr_of_eventuallyEq
-  filter_upwards with x using by simp
+  rw [← differentiableWithinAt_univ, differentiableWithinAt_smul_iff, differentiableWithinAt_univ]
 
 /-- A version of `fderiv_const_smul` without differentiability hypothesis: in return, the constant
 `c` must be invertible, i.e. if `R` is a field. -/
 theorem fderiv_const_smul_of_invertible (c : R) [Invertible c] :
     fderiv 𝕜 (c • f) x = c • fderiv 𝕜 f x := by
-  by_cases h : DifferentiableAt 𝕜 f x
-  · exact (h.hasFDerivAt.const_smul c).fderiv
-  · obtain (rfl | hc) := eq_or_ne c 0
-    · simp [fderiv_zero]
-    have : ¬DifferentiableAt 𝕜 (c • f) x := by
-      contrapose! h
-      exact (differentiableAt_smul_iff c).mp h
-    simp [fderiv_zero_of_not_differentiableAt h, fderiv_zero_of_not_differentiableAt this]
+  simp [← fderivWithin_univ, fderivWithin_const_smul_of_invertible c uniqueDiffWithinAt_univ]
 
 /-- Special case of `fderiv_const_smul_of_invertible` over a field: any constant is allowed -/
 lemma fderiv_const_smul_of_field (c : 𝕜) : fderiv 𝕜 (c • f) = c • fderiv 𝕜 f := by
-  obtain (rfl | ha) := eq_or_ne c 0
-  · simp
-  · have : Invertible c := invertibleOfNonzero ha
-    ext x x'
-    simp [fderiv_const_smul_of_invertible c (f := f)]
+  simp_rw [← fderivWithin_univ]
+  ext x
+  simp [fderivWithin_const_smul_of_field c uniqueDiffWithinAt_univ]
 
 @[deprecated (since := "2025-06-14")] alias fderiv_const_smul' := fderiv_const_smul
 

--- a/Mathlib/Analysis/Calculus/FDeriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Add.lean
@@ -137,29 +137,33 @@ theorem fderiv_const_smul (h : DifferentiableAt 𝕜 f x) (c : R) :
     fderiv 𝕜 (c • f) x = c • fderiv 𝕜 f x :=
   (h.hasFDerivAt.const_smul c).fderiv
 
+/-- If `c` is invertible, `c • f` is differentiable at `x` if and only if `f` is. -/
+lemma differentiableAt_smul_iff (c : R) [Invertible c] :
+    DifferentiableAt 𝕜 (c • f) x ↔ DifferentiableAt 𝕜 f x := by
+  refine ⟨fun h ↦ ?_, fun h ↦ h.const_smul c⟩
+  apply (h.const_smul ⅟ c).congr_of_eventuallyEq
+  filter_upwards with x using by simp
+
 /-- A version of `fderiv_const_smul` without differentiability hypothesis: in return, the constant
 `c` must be invertible, i.e. if `R` is a field. -/
-theorem fderiv_const_smul'' (c : R) [Invertible c] :
+theorem fderiv_const_smul_of_invertible (c : R) [Invertible c] :
     fderiv 𝕜 (c • f) x = c • fderiv 𝕜 f x := by
   by_cases h : DifferentiableAt 𝕜 f x
   · exact (h.hasFDerivAt.const_smul c).fderiv
   · obtain (rfl | hc) := eq_or_ne c 0
     · simp [fderiv_zero]
-    -- make a separate lemma: f is differentiable at x iff c • f is?
     have : ¬DifferentiableAt 𝕜 (c • f) x := by
       contrapose! h
-      apply (h.const_smul ⅟ c).congr_of_eventuallyEq
-      filter_upwards with x
-      simp
+      exact (differentiableAt_smul_iff c).mp h
     simp [fderiv_zero_of_not_differentiableAt h, fderiv_zero_of_not_differentiableAt this]
 
-/-- Special case of `fderiv_const_smul''` over a field: any constant is allowed -/
-lemma fderiv_const_smul''' (c : 𝕜) : fderiv 𝕜 (c • f) = c • (fderiv 𝕜 f) := by
+/-- Special case of `fderiv_const_smul_of_invertible` over a field: any constant is allowed -/
+lemma fderiv_const_smul_of_field (c : 𝕜) : fderiv 𝕜 (c • f) = c • (fderiv 𝕜 f) := by
   obtain (rfl | ha) := eq_or_ne c 0
   · simp
   · have : Invertible c := invertibleOfNonzero ha
     ext x x'
-    simp [fderiv_const_smul'' c (f := f)]
+    simp [fderiv_const_smul_of_invertible c (f := f)]
 
 @[deprecated (since := "2025-06-14")] alias fderiv_const_smul' := fderiv_const_smul
 

--- a/Mathlib/Analysis/Calculus/FDeriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Add.lean
@@ -5,6 +5,7 @@ Authors: Jeremy Avigad, Sébastien Gouëzel, Yury Kudryashov
 -/
 import Mathlib.Analysis.Calculus.FDeriv.Linear
 import Mathlib.Analysis.Calculus.FDeriv.Comp
+import Mathlib.Analysis.Calculus.FDeriv.Const
 
 /-!
 # Additive operations on derivatives
@@ -135,6 +136,30 @@ theorem fderiv_fun_const_smul (h : DifferentiableAt 𝕜 f x) (c : R) :
 theorem fderiv_const_smul (h : DifferentiableAt 𝕜 f x) (c : R) :
     fderiv 𝕜 (c • f) x = c • fderiv 𝕜 f x :=
   (h.hasFDerivAt.const_smul c).fderiv
+
+/-- A version of `fderiv_const_smul` without differentiability hypothesis: in return, the constant
+`c` must be invertible, i.e. if `R` is a field. -/
+theorem fderiv_const_smul'' (c : R) [Invertible c] :
+    fderiv 𝕜 (c • f) x = c • fderiv 𝕜 f x := by
+  by_cases h : DifferentiableAt 𝕜 f x
+  · exact (h.hasFDerivAt.const_smul c).fderiv
+  · obtain (rfl | hc) := eq_or_ne c 0
+    · simp [fderiv_zero]
+    -- make a separate lemma: f is differentiable at x iff c • f is?
+    have : ¬DifferentiableAt 𝕜 (c • f) x := by
+      contrapose! h
+      apply (h.const_smul ⅟ c).congr_of_eventuallyEq
+      filter_upwards with x
+      simp
+    simp [fderiv_zero_of_not_differentiableAt h, fderiv_zero_of_not_differentiableAt this]
+
+/-- Special case of `fderiv_const_smul''` over a field: any constant is allowed -/
+lemma fderiv_const_smul''' (c : 𝕜) : fderiv 𝕜 (c • f) = c • (fderiv 𝕜 f) := by
+  obtain (rfl | ha) := eq_or_ne c 0
+  · simp
+  · have : Invertible c := invertibleOfNonzero ha
+    ext x x'
+    simp [fderiv_const_smul'' c (f := f)]
 
 @[deprecated (since := "2025-06-14")] alias fderiv_const_smul' := fderiv_const_smul
 

--- a/Mathlib/Analysis/Calculus/FDeriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Add.lean
@@ -158,7 +158,7 @@ theorem fderiv_const_smul_of_invertible (c : R) [Invertible c] :
     simp [fderiv_zero_of_not_differentiableAt h, fderiv_zero_of_not_differentiableAt this]
 
 /-- Special case of `fderiv_const_smul_of_invertible` over a field: any constant is allowed -/
-lemma fderiv_const_smul_of_field (c : 𝕜) : fderiv 𝕜 (c • f) = c • (fderiv 𝕜 f) := by
+lemma fderiv_const_smul_of_field (c : 𝕜) : fderiv 𝕜 (c • f) = c • fderiv 𝕜 f := by
   obtain (rfl | ha) := eq_or_ne c 0
   · simp
   · have : Invertible c := invertibleOfNonzero ha


### PR DESCRIPTION
In return, the scalar must be invertible, or any scalar in a field.

Part of the path towards geodesics and the Levi-Civita connection.
Co-authored by: @PatrickMassot

---

The analogous lemma for `mfderiv` does not make sense (as that always assumes a field).

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
