### PR TITLE
[Merged by Bors] - chore(CategoryTheory): insert associators and unitors

### DIFF
--- a/Mathlib/AlgebraicTopology/DoldKan/Compatibility.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Compatibility.lean
@@ -72,9 +72,11 @@ def equivalence₁CounitIso : (e'.inverse ⋙ eA.inverse) ⋙ F ≅ 𝟭 B' :=
   calc
     (e'.inverse ⋙ eA.inverse) ⋙ F ≅ (e'.inverse ⋙ eA.inverse) ⋙ eA.functor ⋙ e'.functor :=
       isoWhiskerLeft _ hF.symm
-    _ ≅ e'.inverse ⋙ (eA.inverse ⋙ eA.functor) ⋙ e'.functor := Iso.refl _
+    _ ≅ e'.inverse ⋙ (eA.inverse ⋙ eA.functor ⋙ e'.functor) := associator _ _ _
+    _ ≅ e'.inverse ⋙ (eA.inverse ⋙ eA.functor) ⋙ e'.functor :=
+      isoWhiskerLeft _ (associator _ _ _).symm
     _ ≅ e'.inverse ⋙ 𝟭 _ ⋙ e'.functor := isoWhiskerLeft _ (isoWhiskerRight eA.counitIso _)
-    _ ≅ e'.inverse ⋙ e'.functor := Iso.refl _
+    _ ≅ e'.inverse ⋙ e'.functor := isoWhiskerLeft _ (leftUnitor _)
     _ ≅ 𝟭 B' := e'.counitIso
 
 theorem equivalence₁CounitIso_eq : (equivalence₁ hF).counitIso = equivalence₁CounitIso hF := by
@@ -86,10 +88,12 @@ theorem equivalence₁CounitIso_eq : (equivalence₁ hF).counitIso = equivalence
 def equivalence₁UnitIso : 𝟭 A ≅ F ⋙ e'.inverse ⋙ eA.inverse :=
   calc
     𝟭 A ≅ eA.functor ⋙ eA.inverse := eA.unitIso
-    _ ≅ eA.functor ⋙ 𝟭 A' ⋙ eA.inverse := Iso.refl _
+    _ ≅ eA.functor ⋙ 𝟭 A' ⋙ eA.inverse := isoWhiskerLeft _ (leftUnitor _).symm
     _ ≅ eA.functor ⋙ (e'.functor ⋙ e'.inverse) ⋙ eA.inverse :=
       isoWhiskerLeft _ (isoWhiskerRight e'.unitIso _)
-    _ ≅ (eA.functor ⋙ e'.functor) ⋙ e'.inverse ⋙ eA.inverse := Iso.refl _
+    _ ≅ eA.functor ⋙ (e'.functor ⋙ e'.inverse ⋙ eA.inverse) :=
+      isoWhiskerLeft _ (associator _ _ _)
+    _ ≅ (eA.functor ⋙ e'.functor) ⋙ e'.inverse ⋙ eA.inverse := (associator _ _ _).symm
     _ ≅ F ⋙ e'.inverse ⋙ eA.inverse := isoWhiskerRight hF _
 
 theorem equivalence₁UnitIso_eq : (equivalence₁ hF).unitIso = equivalence₁UnitIso hF := by
@@ -110,37 +114,39 @@ theorem equivalence₂_inverse :
 @[simps!]
 def equivalence₂CounitIso : (eB.functor ⋙ e'.inverse ⋙ eA.inverse) ⋙ F ⋙ eB.inverse ≅ 𝟭 B :=
   calc
-    (eB.functor ⋙ e'.inverse ⋙ eA.inverse) ⋙ F ⋙ eB.inverse ≅
-        eB.functor ⋙ (e'.inverse ⋙ eA.inverse ⋙ F) ⋙ eB.inverse :=
-      Iso.refl _
+    (eB.functor ⋙ e'.inverse ⋙ eA.inverse) ⋙ F ⋙ eB.inverse
+      ≅ eB.functor ⋙ (e'.inverse ⋙ eA.inverse) ⋙ F ⋙ eB.inverse := associator _ _ _
+    _ ≅ eB.functor ⋙ ((e'.inverse ⋙ eA.inverse) ⋙ F) ⋙ eB.inverse :=
+      isoWhiskerLeft _ (associator _ _ _).symm
     _ ≅ eB.functor ⋙ 𝟭 _ ⋙ eB.inverse :=
       isoWhiskerLeft _ (isoWhiskerRight (equivalence₁CounitIso hF) _)
-    _ ≅ eB.functor ⋙ eB.inverse := Iso.refl _
+    _ ≅ eB.functor ⋙ eB.inverse := isoWhiskerLeft _ (leftUnitor _)
     _ ≅ 𝟭 B := eB.unitIso.symm
 
 theorem equivalence₂CounitIso_eq :
     (equivalence₂ eB hF).counitIso = equivalence₂CounitIso eB hF := by
   ext Y'
-  dsimp [equivalence₂, Iso.refl]
-  simp only [equivalence₁CounitIso_eq, equivalence₁CounitIso_hom_app, comp_id, id_comp,
-    Functor.map_comp, assoc, equivalence₂CounitIso_hom_app]
+  simp [equivalence₂, equivalence₁CounitIso_eq]
 
 /-- The unit isomorphism of the equivalence `equivalence₂` between `A` and `B`. -/
 @[simps!]
 def equivalence₂UnitIso : 𝟭 A ≅ (F ⋙ eB.inverse) ⋙ eB.functor ⋙ e'.inverse ⋙ eA.inverse :=
   calc
     𝟭 A ≅ F ⋙ e'.inverse ⋙ eA.inverse := equivalence₁UnitIso hF
-    _ ≅ F ⋙ 𝟭 B' ⋙ e'.inverse ⋙ eA.inverse := Iso.refl _
+    _ ≅ F ⋙ 𝟭 B' ⋙ e'.inverse ⋙ eA.inverse :=
+      isoWhiskerLeft _ (leftUnitor _).symm
     _ ≅ F ⋙ (eB.inverse ⋙ eB.functor) ⋙ e'.inverse ⋙ eA.inverse :=
       isoWhiskerLeft _ (isoWhiskerRight eB.counitIso.symm _)
-    _ ≅ (F ⋙ eB.inverse) ⋙ eB.functor ⋙ e'.inverse ⋙ eA.inverse := Iso.refl _
+    _ ≅ (F ⋙ eB.inverse ⋙ eB.functor) ⋙ e'.inverse ⋙ eA.inverse :=
+      (associator _ _ _).symm
+    _ ≅ ((F ⋙ eB.inverse) ⋙ eB.functor) ⋙ e'.inverse ⋙ eA.inverse :=
+      isoWhiskerRight (associator _ _ _).symm _
+    _ ≅ (F ⋙ eB.inverse) ⋙ eB.functor ⋙ e'.inverse ⋙ eA.inverse :=
+      associator _ _ _
 
 theorem equivalence₂UnitIso_eq : (equivalence₂ eB hF).unitIso = equivalence₂UnitIso eB hF := by
   ext X
-  dsimp [equivalence₂]
-  simp only [equivalence₁UnitIso_eq, equivalence₁UnitIso_hom_app, comp_id, id_comp, assoc,
-    equivalence₂UnitIso_hom_app]
-  rfl
+  simp [equivalence₂, equivalence₁]
 
 variable {eB}
 
@@ -150,8 +156,9 @@ whose inverse is `G : B ≅ A`. -/
 def equivalence : A ≌ B :=
   ((equivalence₂ eB hF).changeInverse
     (calc eB.functor ⋙ e'.inverse ⋙ eA.inverse ≅
-        (eB.functor ⋙ e'.inverse) ⋙ eA.inverse := (Functor.associator _ _ _).symm
+        (eB.functor ⋙ e'.inverse) ⋙ eA.inverse := (associator _ _ _).symm
     _ ≅ (G ⋙ eA.functor) ⋙ eA.inverse := isoWhiskerRight hG _
+    _ ≅ G ⋙ eA.functor ⋙ eA.inverse := associator _ _ _
     _ ≅ G ⋙ 𝟭 A := isoWhiskerLeft _ eA.unitIso.symm
     _ ≅ G := G.rightUnitor))
 
@@ -174,9 +181,9 @@ an isomorphism `η : G ⋙ F ≅ eB.functor`. -/
 def τ₁ (η : G ⋙ F ≅ eB.functor) : eB.functor ⋙ e'.inverse ⋙ e'.functor ≅ eB.functor :=
   calc
     eB.functor ⋙ e'.inverse ⋙ e'.functor ≅ (eB.functor ⋙ e'.inverse) ⋙ e'.functor :=
-        Iso.refl _
+        (associator _ _ _).symm
     _ ≅ (G ⋙ eA.functor) ⋙ e'.functor := isoWhiskerRight hG _
-    _ ≅ G ⋙ eA.functor ⋙ e'.functor := by rfl
+    _ ≅ G ⋙ eA.functor ⋙ e'.functor := associator _ _ _
     _ ≅ G ⋙ F := isoWhiskerLeft _ hF
     _ ≅ eB.functor := η
 
@@ -186,7 +193,7 @@ variable (η : G ⋙ F ≅ eB.functor)
 @[simps!]
 def equivalenceCounitIso : G ⋙ F ⋙ eB.inverse ≅ 𝟭 B :=
   calc
-    G ⋙ F ⋙ eB.inverse ≅ (G ⋙ F) ⋙ eB.inverse := Iso.refl _
+    G ⋙ F ⋙ eB.inverse ≅ (G ⋙ F) ⋙ eB.inverse := (associator _ _ _).symm
     _ ≅ eB.functor ⋙ eB.inverse := isoWhiskerRight η _
     _ ≅ 𝟭 B := eB.unitIso.symm
 
@@ -198,15 +205,15 @@ theorem equivalenceCounitIso_eq (hη : τ₀ = τ₁ hF hG η) :
   dsimp [equivalence]
   simp only [comp_id, id_comp, Functor.map_comp, equivalence₂CounitIso_eq,
     equivalence₂CounitIso_hom_app, assoc, equivalenceCounitIso_hom_app]
-  simp only [← eB.inverse.map_comp_assoc, ← τ₀_hom_app, hη, τ₁_hom_app, equivalence₂_inverse,
-    Functor.comp_obj]
+  simp only [equivalence₂_inverse, comp_obj, ← τ₀_hom_app, hη, τ₁_hom_app, ←
+    eB.inverse.map_comp_assoc]
   rw [hF.inv.naturality_assoc, hF.inv.naturality_assoc]
-  dsimp
   congr 2
-  simp only [← e'.functor.map_comp_assoc, Equivalence.fun_inv_map, assoc,
-    Iso.inv_hom_id_app_assoc, hG.inv_hom_id_app]
-  dsimp
-  rw [comp_id, eA.functor_unitIso_comp, e'.functor.map_id, id_comp, hF.inv_hom_id_app_assoc]
+  simp only [← e'.functor.map_comp_assoc]
+  simp only [Functor.comp_map, Equivalence.fun_inv_map, comp_obj, id_obj, map_comp, assoc]
+  simp only [← e'.functor.map_comp_assoc]
+  simp only [Iso.inv_hom_id_app_assoc, Iso.inv_hom_id_app, comp_obj, comp_id,
+    Equivalence.functor_unit_comp, map_id, id_comp]
 
 variable (hF)
 
@@ -215,9 +222,9 @@ unit isomorphism of `e'` and the isomorphism `hF : eA.functor ⋙ e'.functor ≅
 @[simps!]
 def υ : eA.functor ≅ F ⋙ e'.inverse :=
   calc
-    eA.functor ≅ eA.functor ⋙ 𝟭 A' := (Functor.leftUnitor _).symm
+    eA.functor ≅ eA.functor ⋙ 𝟭 A' := (rightUnitor _).symm
     _ ≅ eA.functor ⋙ e'.functor ⋙ e'.inverse := isoWhiskerLeft _ e'.unitIso
-    _ ≅ (eA.functor ⋙ e'.functor) ⋙ e'.inverse := Iso.refl _
+    _ ≅ (eA.functor ⋙ e'.functor) ⋙ e'.inverse := (associator _ _ _).symm
     _ ≅ F ⋙ e'.inverse := isoWhiskerRight hF _
 
 variable (ε : eA.functor ≅ F ⋙ e'.inverse) (hG)
@@ -228,15 +235,24 @@ def equivalenceUnitIso : 𝟭 A ≅ (F ⋙ eB.inverse) ⋙ G :=
   calc
     𝟭 A ≅ eA.functor ⋙ eA.inverse := eA.unitIso
     _ ≅ (F ⋙ e'.inverse) ⋙ eA.inverse := isoWhiskerRight ε _
-    _ ≅ F ⋙ 𝟭 B' ⋙ e'.inverse ⋙ eA.inverse := Iso.refl _
+    _ ≅ F ⋙ e'.inverse ⋙ eA.inverse := associator _ _ _
+    _ ≅ F ⋙ 𝟭 B' ⋙ e'.inverse ⋙ eA.inverse := isoWhiskerLeft _ (leftUnitor _).symm
     _ ≅ F ⋙ (eB.inverse ⋙ eB.functor) ⋙ e'.inverse ⋙ eA.inverse :=
       isoWhiskerLeft _ (isoWhiskerRight eB.counitIso.symm _)
-    _ ≅ (F ⋙ eB.inverse) ⋙ (eB.functor ⋙ e'.inverse) ⋙ eA.inverse := Iso.refl _
+    _ ≅ (F ⋙ eB.inverse ⋙ eB.functor) ⋙ e'.inverse ⋙ eA.inverse := (associator _ _ _).symm
+    _ ≅ ((F ⋙ eB.inverse) ⋙ eB.functor) ⋙ e'.inverse ⋙ eA.inverse :=
+      isoWhiskerRight (associator _ _ _).symm _
+    _ ≅ (F ⋙ eB.inverse) ⋙ eB.functor ⋙ e'.inverse ⋙ eA.inverse := associator _ _ _
+    _ ≅ (F ⋙ eB.inverse) ⋙ (eB.functor ⋙ e'.inverse) ⋙ eA.inverse :=
+      isoWhiskerLeft _ (associator _ _ _).symm
     _ ≅ (F ⋙ eB.inverse) ⋙ (G ⋙ eA.functor) ⋙ eA.inverse :=
       isoWhiskerLeft _ (isoWhiskerRight hG _)
-    _ ≅ (F ⋙ eB.inverse ⋙ G) ⋙ eA.functor ⋙ eA.inverse := Iso.refl _
-    _ ≅ (F ⋙ eB.inverse ⋙ G) ⋙ 𝟭 A := isoWhiskerLeft _ eA.unitIso.symm
-    _ ≅ (F ⋙ eB.inverse) ⋙ G := Iso.refl _
+    _ ≅ ((F ⋙ eB.inverse) ⋙ G ⋙ eA.functor) ⋙ eA.inverse := (associator _ _ _).symm
+    _ ≅ (((F ⋙ eB.inverse) ⋙ G) ⋙ eA.functor) ⋙ eA.inverse :=
+      isoWhiskerRight (associator _ _ _).symm _
+    _ ≅ ((F ⋙ eB.inverse) ⋙ G) ⋙ eA.functor ⋙ eA.inverse := associator _ _ _
+    _ ≅ ((F ⋙ eB.inverse) ⋙ G) ⋙ 𝟭 A := isoWhiskerLeft _ eA.unitIso.symm
+    _ ≅ (F ⋙ eB.inverse) ⋙ G := rightUnitor _
 
 variable {ε hF hG}
 

--- a/Mathlib/CategoryTheory/Adjunction/Mates.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Mates.lean
@@ -79,7 +79,7 @@ Note that if one of the transformations is an iso, it does not imply the other i
 def mateEquiv : TwoSquare G L₁ L₂ H ≃ TwoSquare R₁ H G R₂ where
   toFun α := .mk _ _ _ _ <|
     (rightUnitor _).inv ≫
-    (whiskerLeft (R₁ ⋙ G) adj₂.unit) ≫
+    whiskerLeft (R₁ ⋙ G) adj₂.unit ≫
     (associator _ _ _).hom ≫ whiskerLeft _ (associator _ _ _).inv ≫
     whiskerLeft R₁ (whiskerRight α.natTrans R₂) ≫
     whiskerLeft _ (associator _ _ _).hom ≫ (associator _ _ _).inv ≫

--- a/Mathlib/CategoryTheory/Adjunction/Mates.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Mates.lean
@@ -78,25 +78,37 @@ Note that if one of the transformations is an iso, it does not imply the other i
 @[simps]
 def mateEquiv : TwoSquare G L₁ L₂ H ≃ TwoSquare R₁ H G R₂ where
   toFun α := .mk _ _ _ _ <|
-    whiskerLeft (R₁ ⋙ G) adj₂.unit ≫
-    whiskerRight (whiskerLeft R₁ α.natTrans) R₂ ≫
-    whiskerRight adj₁.counit (H ⋙ R₂)
+    (rightUnitor _).inv ≫
+    (whiskerLeft (R₁ ⋙ G) adj₂.unit) ≫
+    (associator _ _ _).hom ≫ whiskerLeft _ (associator _ _ _).inv ≫
+    whiskerLeft R₁ (whiskerRight α.natTrans R₂) ≫
+    whiskerLeft _ (associator _ _ _).hom ≫ (associator _ _ _).inv ≫
+    whiskerRight adj₁.counit (H ⋙ R₂) ≫
+    (leftUnitor _).hom
   invFun β := .mk _ _ _ _ <|
+    (leftUnitor _).inv ≫
     whiskerRight adj₁.unit (G ⋙ L₂) ≫
+    (associator _ _ _).inv ≫ whiskerRight (associator _ _ _).hom _ ≫
     whiskerRight (whiskerLeft L₁ β.natTrans) L₂ ≫
-    whiskerLeft (L₁ ⋙ H) adj₂.counit
+    whiskerRight (associator _ _ _).inv _ ≫ (associator _ _ _).hom ≫
+    whiskerLeft (L₁ ⋙ H) adj₂.counit ≫
+    (rightUnitor _).hom
   left_inv α := by
     ext
-    unfold whiskerRight whiskerLeft
-    simp only [comp_obj, id_obj, Functor.comp_map, comp_app, map_comp, assoc, counit_naturality,
-      counit_naturality_assoc, left_triangle_components_assoc]
+    simp only [comp_obj, whiskerLeft_comp, whiskerLeft_twice, assoc, Iso.hom_inv_id_assoc,
+      whiskerRight_comp, comp_app, id_obj, leftUnitor_inv_app, Functor.whiskerRight_app,
+      Functor.comp_map, associator_inv_app, associator_hom_app, map_id, Functor.whiskerLeft_app,
+      rightUnitor_inv_app, leftUnitor_hom_app, rightUnitor_hom_app, comp_id, id_comp,
+      counit_naturality, counit_naturality_assoc, left_triangle_components_assoc]
     rw [← assoc, ← Functor.comp_map, α.natTrans.naturality, Functor.comp_map, assoc, ← H.map_comp,
       left_triangle_components, map_id]
     simp only [comp_obj, comp_id]
   right_inv β := by
     ext
-    unfold whiskerLeft whiskerRight
-    simp only [comp_obj, id_obj, Functor.comp_map, comp_app, map_comp, assoc,
+    simp only [comp_obj, whiskerRight_comp, whiskerRight_twice, assoc, Iso.inv_hom_id_assoc,
+      whiskerLeft_comp, comp_app, id_obj, rightUnitor_inv_app, Functor.whiskerLeft_app,
+      associator_hom_app, associator_inv_app, Functor.whiskerRight_app, leftUnitor_inv_app, map_id,
+      Functor.comp_map, rightUnitor_hom_app, leftUnitor_hom_app, comp_id, id_comp,
       unit_naturality_assoc, right_triangle_components_assoc]
     rw [← assoc, ← Functor.comp_map, assoc, ← β.natTrans.naturality, ← assoc, Functor.comp_map,
       ← G.map_comp, right_triangle_components, map_id, id_comp]
@@ -117,7 +129,9 @@ theorem mateEquiv_counit_symm (α : TwoSquare R₁ H G R₂) (d : D) :
 theorem unit_mateEquiv (α : TwoSquare G L₁ L₂ H) (c : C) :
     G.map (adj₁.unit.app c) ≫ (mateEquiv adj₁ adj₂ α).app _ =
       adj₂.unit.app _ ≫ R₂.map (α.app _) := by
-  dsimp [mateEquiv]
+  simp only [id_obj, comp_obj, mateEquiv, Equiv.coe_fn_mk, comp_app, rightUnitor_inv_app,
+    Functor.whiskerLeft_app, associator_hom_app, associator_inv_app, Functor.whiskerRight_app,
+    Functor.comp_map, leftUnitor_hom_app, comp_id, id_comp]
   rw [← adj₂.unit_naturality_assoc]
   slice_lhs 2 3 =>
     rw [← R₂.map_comp, ← Functor.comp_map G L₂, α.naturality]
@@ -149,10 +163,10 @@ theorem mateEquiv_vcomp (α : TwoSquare G₁ L₁ L₂ H₁) (β : TwoSquare G�
     (mateEquiv adj₁ adj₃) (α ≫ₕ β) = (mateEquiv adj₁ adj₂ α) ≫ᵥ (mateEquiv adj₂ adj₃ β) := by
   unfold hComp vComp mateEquiv
   ext b
-  simp only [comp_obj, Equiv.coe_fn_mk, whiskerLeft_comp, whiskerLeft_twice, assoc,
-    whiskerRight_comp, comp_app, Functor.whiskerLeft_app, Functor.whiskerRight_app,
-    associator_hom_app, map_id, associator_inv_app, id_obj, Functor.comp_map, id_comp,
-    whiskerRight_twice, comp_id]
+  simp only [comp_obj, Equiv.coe_fn_mk, whiskerRight_comp, whiskerRight_twice, assoc,
+    whiskerLeft_comp, comp_app, id_obj, rightUnitor_inv_app, Functor.whiskerLeft_app,
+    associator_hom_app, associator_inv_app, Functor.whiskerRight_app, map_id, Functor.comp_map,
+    leftUnitor_hom_app, comp_id, id_comp, whiskerLeft_twice, Iso.hom_inv_id_assoc]
   slice_rhs 1 4 => rw [← assoc, ← assoc, ← unit_naturality (adj₃)]
   rw [L₃.map_comp, R₃.map_comp]
   slice_rhs 2 4 =>
@@ -188,8 +202,11 @@ theorem mateEquiv_hcomp (α : TwoSquare G L₁ L₂ H) (β : TwoSquare H L₃ L�
       (mateEquiv adj₃ adj₄ β) ≫ₕ (mateEquiv adj₁ adj₂ α) := by
   unfold vComp hComp mateEquiv Adjunction.comp
   ext c
-  dsimp
-  simp only [comp_id, map_comp, id_comp, assoc]
+  simp only [comp_obj, whiskerRight_comp, assoc, mk'_unit, whiskerLeft_comp, mk'_counit,
+    whiskerRight_twice, Iso.inv_hom_id_assoc, Equiv.coe_fn_mk, comp_app, id_obj,
+    rightUnitor_inv_app, Functor.whiskerLeft_app, Functor.whiskerRight_app, map_id,
+    associator_inv_app, associator_hom_app, Functor.comp_map, rightUnitor_hom_app,
+    leftUnitor_hom_app, comp_id, id_comp, whiskerLeft_twice, Iso.hom_inv_id_assoc]
   slice_rhs 2 4 =>
     rw [← R₂.map_comp, ← R₂.map_comp, ← assoc, ← unit_naturality (adj₄)]
   rw [R₂.map_comp, L₄.map_comp, R₄.map_comp, R₂.map_comp]
@@ -326,9 +343,10 @@ theorem conjugateEquiv_comp (α : L₂ ⟶ L₁) (β : L₃ ⟶ L₂) :
     (L₂.leftUnitor.hom ≫ α ≫ L₁.rightUnitor.inv)
     (L₃.leftUnitor.hom ≫ β ≫ L₂.rightUnitor.inv)
   have vcompd := congr_app vcomp d
-  dsimp [mateEquiv, vComp, vComp] at vcompd
-  simp only [hComp_app, id_obj, comp_app, comp_obj, leftUnitor_hom_app, rightUnitor_inv_app,
-    comp_id, id_comp, Functor.id_map, map_comp, assoc] at vcompd ⊢
+  simp only [comp_obj, id_obj, mateEquiv_apply, comp_app, rightUnitor_inv_app,
+    Functor.whiskerLeft_app, associator_hom_app, associator_inv_app, Functor.whiskerRight_app,
+    hComp_app, leftUnitor_hom_app, comp_id, id_comp, Functor.id_map, map_comp, Functor.comp_map,
+    assoc, whiskerRight_comp, whiskerLeft_comp, vComp_app, map_id] at vcompd ⊢
   rw [vcompd]
 
 @[simp]

--- a/Mathlib/CategoryTheory/Closed/Functor.lean
+++ b/Mathlib/CategoryTheory/Closed/Functor.lean
@@ -139,16 +139,16 @@ theorem frobeniusMorphism_mate (h : L ⊣ F) (A : C) :
   apply congr_arg
   ext B
   unfold mateEquiv
-  simp only [Functor.comp_obj, curriedTensor_obj_obj, Equiv.coe_fn_mk, Functor.whiskerLeft_comp,
-    Functor.whiskerLeft_twice, Functor.whiskerRight_comp, assoc, NatTrans.comp_app,
-    Functor.whiskerLeft_app, Functor.whiskerRight_app, prodComparisonNatTrans_app,
-    curriedTensor_map_app, Functor.id_obj, Functor.comp_map, curriedTensor_obj_map,
-    prodComparisonNatIso_inv, NatIso.isIso_inv_app]
+  simp only [Functor.comp_obj, curriedTensor_obj_obj, Equiv.coe_fn_mk, Functor.whiskerRight_comp,
+    Functor.whiskerLeft_comp, assoc, NatTrans.comp_app, Functor.id_obj, Functor.rightUnitor_inv_app,
+    Functor.whiskerLeft_app, Functor.associator_hom_app, Functor.associator_inv_app,
+    Functor.whiskerRight_app, prodComparisonNatTrans_app, curriedTensor_map_app, Functor.comp_map,
+    curriedTensor_obj_map, Functor.leftUnitor_hom_app, comp_id, id_comp, prodComparisonNatIso_inv,
+    NatIso.isIso_inv_app]
   rw [← F.map_comp, ← F.map_comp]
   simp only [Functor.map_comp]
   apply IsIso.eq_inv_of_inv_hom_id
-  simp only [assoc, Functor.associator_inv_app, Functor.associator_hom_app, Functor.comp_obj,
-    curriedTensor_obj_obj, curriedTensor_obj_obj, Functor.map_id, id_comp]
+  simp only [assoc]
   rw [prodComparison_natural_whiskerLeft, prodComparison_natural_whiskerRight_assoc]
   slice_lhs 2 3 => rw [← prodComparison_comp]
   simp only [assoc]

--- a/Mathlib/CategoryTheory/Functor/TwoSquare.lean
+++ b/Mathlib/CategoryTheory/Functor/TwoSquare.lean
@@ -132,8 +132,8 @@ scoped infixr:80 " ≫ₕ " => hComp -- type as \gg\_h
 @[simps!]
 def vComp (w : TwoSquare T L R B) (w' : TwoSquare B L' R'' B'') :
     TwoSquare T (L ⋙ L') (R ⋙ R'') B'' :=
-  .mk _ _ _ _ <| (associator _ _ _).hom ≫ (whiskerRight w.natTrans R'') ≫
-    (associator _ _ _).inv ≫ (whiskerLeft L w'.natTrans) ≫ (associator _ _ _).hom
+  .mk _ _ _ _ <| (associator _ _ _).inv ≫ whiskerRight w.natTrans R'' ≫
+    (associator _ _ _).hom ≫ whiskerLeft L w'.natTrans ≫ (associator _ _ _).inv
 
 /-- Notation for the vertical composition of 2-squares. -/
 scoped infixr:80 " ≫ᵥ " => vComp -- type as \gg\_v

--- a/Mathlib/CategoryTheory/Sums/Associator.lean
+++ b/Mathlib/CategoryTheory/Sums/Associator.lean
@@ -48,13 +48,13 @@ theorem associator_map_inl_inl {X Y : C} (f : X ⟶ Y) :
 @[simp]
 theorem associator_map_inl_inr {X Y : D} (f : X ⟶ Y) :
     (associator C D E).map ((inl_ _ _).map ((inr_ _ _).map f)) =
-    (inr_ _ _).map ((inl_ _ _).map f) :=
-  rfl
+    (inr_ _ _).map ((inl_ _ _).map f) := by
+  simp [associator]
 
 @[simp]
 theorem associator_map_inr {X Y : E} (f : X ⟶ Y) :
-    (associator C D E).map ((inr_ _ _).map f) = (inr_ _ _).map ((inr_ _ _).map f) :=
-  rfl
+    (associator C D E).map ((inr_ _ _).map f) = (inr_ _ _).map ((inr_ _ _).map f) := by
+  simp [associator]
 
 /-- Characterizing the composition of the associator and the left inclusion. -/
 @[simps!]
@@ -98,14 +98,14 @@ theorem inverseAssociator_obj_inr_inr (X) : (inverseAssociator C D E).obj (inr (
 
 @[simp]
 theorem inverseAssociator_map_inl {X Y : C} (f : X ⟶ Y) :
-    (inverseAssociator C D E).map ((inl_ _ _).map f) = (inl_ _ _).map ((inl_ _ _).map f) :=
-  rfl
+    (inverseAssociator C D E).map ((inl_ _ _).map f) = (inl_ _ _).map ((inl_ _ _).map f) := by
+  simp [inverseAssociator]
 
 @[simp]
 theorem inverseAssociator_map_inr_inl {X Y : D} (f : X ⟶ Y) :
     (inverseAssociator C D E).map ((inr_ _ _).map ((inl_ _ _).map f)) =
-    (inl_ _ _).map ((inr_ _ _).map f) :=
-  rfl
+    (inl_ _ _).map ((inr_ _ _).map f) := by
+  simp [inverseAssociator]
 
 @[simp]
 theorem inverseAssociator_map_inr_inr {X Y : E} (f : X ⟶ Y) :
@@ -149,9 +149,11 @@ def associativity : (C ⊕ D) ⊕ E ≌ C ⊕ (D ⊕ E) where
     (Functor.sumIsoExt
       ((Functor.associator _ _ _).symm ≪≫ Functor.rightUnitor _ ≪≫
         (isoWhiskerRight (inlCompInlCompAssociator C D E) (inverseAssociator C D E) ≪≫
-          inlCompInverseAssociator C D E).symm ≪≫ Functor.associator _ _ _)
+          inlCompInverseAssociator C D E).symm ≪≫ Functor.associator _ _ _ ≪≫
+          isoWhiskerLeft _ (Functor.associator _ _ _))
       ((Functor.associator _ _ _).symm ≪≫ Functor.rightUnitor _ ≪≫
         (isoWhiskerRight (inrCompInlCompAssociator C D E) (inverseAssociator C D E) ≪≫
+          Functor.associator _ _ _ ≪≫
           inlCompInrCompInverseAssociator C D E).symm ≪≫
         Functor.associator _ _ _ ≪≫ isoWhiskerLeft _ (Functor.associator _ _ _)))
     (Functor.rightUnitor _ ≪≫
@@ -166,7 +168,8 @@ def associativity : (C ⊕ D) ⊕ E ≌ C ⊕ (D ⊕ E) where
       ((Functor.associator _ _ _).symm ≪≫ (Functor.associator _ _ _).symm ≪≫
         isoWhiskerRight (Functor.associator _ _ _ ≪≫
           inlCompInrCompInverseAssociator C D E) (associator C D E) ≪≫
-        Functor.associator _ _ _ ≪≫ inrCompInlCompAssociator C D E ≪≫ (Functor.rightUnitor _).symm)
+        Functor.associator _ _ _ ≪≫ inrCompInlCompAssociator C D E ≪≫
+        (Functor.rightUnitor _).symm ≪≫ Functor.associator _ _ _)
       ((Functor.associator _ _ _).symm ≪≫ (Functor.associator _ _ _).symm ≪≫
         isoWhiskerRight (Functor.associator _ _ _ ≪≫
           inrCompInrCompInverseAssociator C D E) (associator C D E) ≪≫

--- a/Mathlib/CategoryTheory/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Whiskering.lean
@@ -331,14 +331,14 @@ theorem isoWhiskerRight_twice {H K : B ⥤ C} (F : C ⥤ D) (G : D ⥤ E) (α : 
 theorem isoWhiskerRight_left (F : B ⥤ C) {G H : C ⥤ D} (α : G ≅ H) (K : D ⥤ E) :
     isoWhiskerRight (isoWhiskerLeft F α) K =
     Functor.associator _ _ _ ≪≫ isoWhiskerLeft F (isoWhiskerRight α K) ≪≫
-      Functor.associator _ _ _ := by
+      (Functor.associator _ _ _).symm := by
   aesop_cat
 
 @[reassoc]
 theorem isoWhiskerLeft_right (F : B ⥤ C) {G H : C ⥤ D} (α : G ≅ H) (K : D ⥤ E) :
     isoWhiskerLeft F (isoWhiskerRight α K) =
     (Functor.associator _ _ _).symm ≪≫ isoWhiskerRight (isoWhiskerLeft F α) K ≪≫
-      (Functor.associator _ _ _).symm := by
+      Functor.associator _ _ _ := by
   aesop_cat
 
 end


### PR DESCRIPTION
Also fixed several wrong associator directions.

This PR is extracted from a WIP PR #26601, where the old expressions are type incorrect.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
