### PR TITLE
[Merged by Bors] - feat(Data/Finset/Card): add eraseInduction

### DIFF
--- a/Mathlib/Combinatorics/Hindman.lean
+++ b/Mathlib/Combinatorics/Hindman.lean
@@ -237,14 +237,14 @@ theorem FP.mul_two {M} [Semigroup M] (a : Stream' M) (i j : ℕ) (ij : i < j) :
 theorem FP.finset_prod {M} [CommMonoid M] (a : Stream' M) (s : Finset ℕ) (hs : s.Nonempty) :
     (s.prod fun i => a.get i) ∈ FP a := by
   refine FP_drop_subset_FP _ (s.min' hs) ?_
-  induction s using Finset.strongInduction with | H s ih => _
+  induction s using Finset.eraseInduction with | H s ih => _
   rw [← Finset.mul_prod_erase _ _ (s.min'_mem hs), ← Stream'.head_drop]
   rcases (s.erase (s.min' hs)).eq_empty_or_nonempty with h | h
   · rw [h, Finset.prod_empty, mul_one]
     exact FP.head _
   · apply FP.cons
     rw [Stream'.tail_eq_drop, Stream'.drop_drop, add_comm]
-    refine Set.mem_of_subset_of_mem ?_ (ih _ (Finset.erase_ssubset <| s.min'_mem hs) h)
+    refine Set.mem_of_subset_of_mem ?_ (ih _ (s.min'_mem hs) h)
     have : s.min' hs + 1 ≤ (s.erase (s.min' hs)).min' h :=
       Nat.succ_le_of_lt (Finset.min'_lt_of_mem_erase_min' _ _ <| Finset.min'_mem _ _)
     obtain ⟨d, hd⟩ := Nat.exists_eq_add_of_le this

--- a/Mathlib/Data/Finset/Card.lean
+++ b/Mathlib/Data/Finset/Card.lean
@@ -23,6 +23,7 @@ This defines the cardinality of a `Finset` and provides induction principles for
 * `Finset.strongDownwardInductionOn`
 * `Finset.case_strong_induction_on`
 * `Finset.Nonempty.strong_induction`
+* `Finset.eraseInduction`
 -/
 
 assert_not_exists Monoid

--- a/Mathlib/Data/Finset/Card.lean
+++ b/Mathlib/Data/Finset/Card.lean
@@ -843,6 +843,6 @@ only requires removing single elements at a time.
 -/
 theorem eraseInduction [DecidableEq α] {p : Finset α → Prop}
     (H : (S : Finset α) → ((∀ s ∈ S, p (S.erase s)) → (p S))) (S : Finset α) : p S :=
-  strongInduction (fun S ih ↦ H S fun s hs ↦ ih (S.erase s) (erase_ssubset hs)) S
+  S.strongInduction fun S ih => H S fun _ hs => ih _ (erase_ssubset hs)
 
 end Finset

--- a/Mathlib/Data/Finset/Card.lean
+++ b/Mathlib/Data/Finset/Card.lean
@@ -842,7 +842,7 @@ But it can be more precise when the induction argument
 only requires removing single elements at a time.
 -/
 theorem eraseInduction [DecidableEq α] {p : Finset α → Prop}
-    (H : (S : Finset α) → ((∀ s ∈ S, p (S.erase s)) → (p S))) (S : Finset α) : p S :=
+    (H : (S : Finset α) → (∀ s ∈ S, p (S.erase s)) → p S) (S : Finset α) : p S :=
   S.strongInduction fun S ih => H S fun _ hs => ih _ (erase_ssubset hs)
 
 end Finset

--- a/Mathlib/Data/Finset/Card.lean
+++ b/Mathlib/Data/Finset/Card.lean
@@ -831,4 +831,17 @@ theorem lt_wf {α} : WellFounded (@LT.lt (Finset α) _) :=
     card_lt_card hxy
   Subrelation.wf H <| InvImage.wf _ <| (Nat.lt_wfRel).2
 
+/--
+To prove a proposition for an arbitrary `Finset α`,
+it suffices to prove that for any `S : Finset α`, the following is true:
+the property is true for S with any element `s` removed, then the property holds for `S`.
+
+This is a weaker version of `Finset.strongInduction`.
+But it can be more precise when the induction argument
+only requires removing single elements at a time.
+-/
+theorem eraseInduction [DecidableEq α] {p : Finset α → Prop}
+    (H : (S : Finset α) → ((∀ s ∈ S, p (S.erase s)) → (p S))) (S : Finset α) : p S :=
+  strongInduction (fun S ih ↦ H S fun s hs ↦ ih (S.erase s) (erase_ssubset hs)) S
+
 end Finset

--- a/Mathlib/Data/Finset/Max.lean
+++ b/Mathlib/Data/Finset/Max.lean
@@ -456,7 +456,7 @@ theorem induction_on_max [DecidableEq α] {p : Finset α → Prop} (s : Finset �
   · exact h0
   · have H : s.max' hne ∈ s := max'_mem s hne
     rw [← insert_erase H]
-    exact step _ _ (fun x ↦ lt_max'_of_mem_erase_max' s hne) (ih (s.max' hne) H)
+    exact step _ _ (fun x ↦ s.lt_max'_of_mem_erase_max' hne) (ih _ H)
 
 /-- Induction principle for `Finset`s in a linearly ordered type: a predicate is true on all
 `s : Finset α` provided that:
@@ -492,7 +492,7 @@ theorem induction_on_max_value [DecidableEq ι] (f : ι → α) {p : Finset ι �
     simp only [mem_image] at H
     rcases H with ⟨a, has, hfa⟩
     rw [← insert_erase has]
-    apply step _ _ (notMem_erase a s) (fun x hx => ?_) (ihs a has)
+    refine step _ _ (notMem_erase a s) (fun x hx => ?_) (ihs a has)
     rw [hfa]
     exact le_max' _ _ (mem_image_of_mem _ <| mem_of_mem_erase hx)
 

--- a/Mathlib/Data/Finset/Max.lean
+++ b/Mathlib/Data/Finset/Max.lean
@@ -451,12 +451,12 @@ theorem card_le_diff_of_interleaved {s t : Finset α}
 @[elab_as_elim]
 theorem induction_on_max [DecidableEq α] {p : Finset α → Prop} (s : Finset α) (h0 : p ∅)
     (step : ∀ a s, (∀ x ∈ s, x < a) → p s → p (insert a s)) : p s := by
-  induction' s using Finset.strongInductionOn with s ihs
+  induction' s using Finset.eraseInduction with s ih
   rcases s.eq_empty_or_nonempty with (rfl | hne)
   · exact h0
   · have H : s.max' hne ∈ s := max'_mem s hne
     rw [← insert_erase H]
-    exact step _ _ (fun x => s.lt_max'_of_mem_erase_max' hne) (ihs _ <| erase_ssubset H)
+    exact step _ _ (fun x ↦ lt_max'_of_mem_erase_max' s hne) (ih (s.max' hne) H)
 
 /-- Induction principle for `Finset`s in a linearly ordered type: a predicate is true on all
 `s : Finset α` provided that:
@@ -484,7 +484,7 @@ ordered type : a predicate is true on all `s : Finset α` provided that:
 @[elab_as_elim]
 theorem induction_on_max_value [DecidableEq ι] (f : ι → α) {p : Finset ι → Prop} (s : Finset ι)
     (h0 : p ∅) (step : ∀ a s, a ∉ s → (∀ x ∈ s, f x ≤ f a) → p s → p (insert a s)) : p s := by
-  induction' s using Finset.strongInductionOn with s ihs
+  induction' s using Finset.eraseInduction with s ihs
   rcases (s.image f).eq_empty_or_nonempty with (hne | hne)
   · simp only [image_eq_empty] at hne
     simp only [hne, h0]
@@ -492,7 +492,7 @@ theorem induction_on_max_value [DecidableEq ι] (f : ι → α) {p : Finset ι �
     simp only [mem_image] at H
     rcases H with ⟨a, has, hfa⟩
     rw [← insert_erase has]
-    refine step _ _ (notMem_erase a s) (fun x hx => ?_) (ihs _ <| erase_ssubset has)
+    apply step _ _ (notMem_erase a s) (fun x hx => ?_) (ihs a has)
     rw [hfa]
     exact le_max' _ _ (mem_image_of_mem _ <| mem_of_mem_erase hx)
 

--- a/Mathlib/LinearAlgebra/Matrix/Block.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Block.lean
@@ -244,7 +244,7 @@ protected theorem BlockTriangular.det [DecidableEq α] [LinearOrder α] (hM : Bl
   suffices ∀ hs : Finset α, univ.image b = hs → M.det = ∏ a ∈ hs, (M.toSquareBlock b a).det by
     exact this _ rfl
   intro s hs
-  induction s using Finset.strongInduction generalizing m with | H s ih =>
+  induction s using Finset.eraseInduction generalizing m with | H s ih =>
   subst hs
   cases isEmpty_or_nonempty m
   · simp
@@ -259,7 +259,7 @@ protected theorem BlockTriangular.det [DecidableEq α] [LinearOrder α] (hM : Bl
     have h' : BlockTriangular (M.toSquareBlockProp fun i => b i ≠ k) b' := hM.submatrix
     have hb' : image b' univ = (image b univ).erase k := by
       convert image_subtype_ne_univ_eq_image_erase k b
-    rw [ih _ (erase_ssubset <| max'_mem _ _) h' hb']
+    rw [ih _ (max'_mem _ _) h' hb']
     refine Finset.prod_congr rfl fun l hl => ?_
     let he : { a // b' a = l } ≃ { a // b a = l } :=
       haveI hc : ∀ i, b i = l → b i ≠ k := fun i hi => ne_of_eq_of_ne hi (ne_of_mem_erase hl)

--- a/Mathlib/RingTheory/Lasker.lean
+++ b/Mathlib/RingTheory/Lasker.lean
@@ -50,7 +50,7 @@ lemma decomposition_erase_inf [DecidableEq (Ideal R)] {I : Ideal R}
     · exact ⟨s, Finset.Subset.rfl, hs, H⟩
     push_neg at H
     obtain ⟨J, hJ, hJ'⟩ := H
-    refine (IH _ (hJ) ?_).imp
+    refine (IH _ hJ ?_).imp
       fun t ↦ And.imp_left (fun ht ↦ ht.trans (Finset.erase_subset _ _))
     rw [← Finset.insert_erase hJ] at hs
     simp [← hs, hJ']

--- a/Mathlib/RingTheory/Lasker.lean
+++ b/Mathlib/RingTheory/Lasker.lean
@@ -44,16 +44,16 @@ namespace Ideal
 lemma decomposition_erase_inf [DecidableEq (Ideal R)] {I : Ideal R}
     {s : Finset (Ideal R)} (hs : s.inf id = I) :
     ∃ t : Finset (Ideal R), t ⊆ s ∧ t.inf id = I ∧ (∀ ⦃J⦄, J ∈ t → ¬ (t.erase J).inf id ≤ J) := by
-  induction s using Finset.strongInductionOn
-  rename_i _ s IH
-  by_cases H : ∀ J ∈ s, ¬ (s.erase J).inf id ≤ J
-  · exact ⟨s, Finset.Subset.rfl, hs, H⟩
-  push_neg at H
-  obtain ⟨J, hJ, hJ'⟩ := H
-  refine (IH (s.erase J) (Finset.erase_ssubset hJ) ?_).imp
-    fun t ↦ And.imp_left (fun ht ↦ ht.trans (Finset.erase_subset _ _))
-  rw [← Finset.insert_erase hJ] at hs
-  simp [← hs, hJ']
+  induction s using Finset.eraseInduction with
+  | H s IH =>
+    by_cases H : ∀ J ∈ s, ¬ (s.erase J).inf id ≤ J
+    · exact ⟨s, Finset.Subset.rfl, hs, H⟩
+    push_neg at H
+    obtain ⟨J, hJ, hJ'⟩ := H
+    refine (IH _ (hJ) ?_).imp
+      fun t ↦ And.imp_left (fun ht ↦ ht.trans (Finset.erase_subset _ _))
+    rw [← Finset.insert_erase hJ] at hs
+    simp [← hs, hJ']
 
 open scoped Function -- required for scoped `on` notation
 


### PR DESCRIPTION
Adds an induction principle on `Finset` which is  weaker but more precise than `strongInduction`. This allows many (most?) applications of `Finset.strongInduction` to be golfed.

Zulip discussion here: [#Is there code for X? > Descending induction for Finset @ 💬](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/Descending.20induction.20for.20Finset/near/521576706)

This lemma was identified while doing work for Project Numina.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
