### PR TITLE
[Merged by Bors] - chore(CategoryTheory/MonoidalCategory): clean up names in simp and rw

### DIFF
--- a/Mathlib/Algebra/Homology/Monoidal.lean
+++ b/Mathlib/Algebra/Homology/Monoidal.lean
@@ -230,7 +230,7 @@ lemma rightUnitor'_inv (i : I) :
   rw [GradedObject.Monoidal.rightUnitor_inv_apply, assoc, assoc, Iso.cancel_iso_inv_left,
     GradedObject.Monoidal.ι_tensorHom]
   dsimp
-  rw [id_tensorHom, ← MonoidalCategory.whiskerLeft_comp_assoc]
+  rw [id_tensorHom, ← whiskerLeft_comp_assoc]
   congr 2
   rw [← cancel_epi (GradedObject.Monoidal.tensorUnit₀ (I := I)).hom, Iso.hom_inv_id_assoc]
   dsimp [tensorUnitIso]
@@ -246,8 +246,7 @@ lemma rightUnitor'_inv_comm (i j : I) :
       tensor_unit_d₂, comp_zero, add_zero]
     rw [mapBifunctor.d₁_eq _ _ _ _ hij _ _ (by simp)]
     dsimp
-    simp only [one_smul, whisker_exchange_assoc,
-      MonoidalCategory.whiskerRight_id, assoc, Iso.inv_hom_id_assoc]
+    simp only [one_smul, whisker_exchange_assoc, whiskerRight_id, assoc, Iso.inv_hom_id_assoc]
   · simp only [shape _ _ _ hij, comp_zero, zero_comp]
 
 /-- The right unitor for the tensor product of homological complexes. -/

--- a/Mathlib/CategoryTheory/Bicategory/Coherence.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Coherence.lean
@@ -156,7 +156,7 @@ theorem normalize_naturality {a b c : B} (p : Path a b) {f g : Hom b c} (η : f 
   induction η' with
   | id => simp
   | vcomp η θ ihf ihg =>
-    simp only [mk_vcomp, Bicategory.whiskerLeft_comp]
+    simp only [mk_vcomp, whiskerLeft_comp]
     slice_lhs 2 3 => rw [ihg]
     slice_lhs 1 2 => rw [ihf]
     simp

--- a/Mathlib/CategoryTheory/Bicategory/Functor/Oplax.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/Oplax.lean
@@ -153,7 +153,7 @@ def comp (F : OplaxFunctor B C) (G : OplaxFunctor C D) : OplaxFunctor B D where
   map₂_associator := fun f g h => by
     dsimp
     simp only [map₂_associator, ← PrelaxFunctor.map₂_comp_assoc, ← mapComp_naturality_right_assoc,
-      Bicategory.whiskerLeft_comp, assoc]
+      whiskerLeft_comp, assoc]
     simp only [map₂_associator, PrelaxFunctor.map₂_comp, mapComp_naturality_left_assoc,
       comp_whiskerRight, assoc]
   map₂_leftUnitor := fun f => by
@@ -163,7 +163,7 @@ def comp (F : OplaxFunctor B C) (G : OplaxFunctor C D) : OplaxFunctor B D where
   map₂_rightUnitor := fun f => by
     dsimp
     simp only [map₂_rightUnitor, PrelaxFunctor.map₂_comp, mapComp_naturality_right_assoc,
-      Bicategory.whiskerLeft_comp, assoc]
+      whiskerLeft_comp, assoc]
 
 /-- A structure on an oplax functor that promotes an oplax functor to a pseudofunctor.
 

--- a/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Oplax.lean
+++ b/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Oplax.lean
@@ -95,7 +95,7 @@ variable {a b c : B} {a' : C}
 theorem whiskerLeft_naturality_naturality (f : a' ⟶ G.obj a) {g h : a ⟶ b} (β : g ⟶ h) :
     f ◁ G.map₂ β ▷ θ.app b ≫ f ◁ θ.naturality h =
       f ◁ θ.naturality g ≫ f ◁ θ.app a ◁ H.map₂ β := by
-  simp_rw [← Bicategory.whiskerLeft_comp, naturality_naturality]
+  simp_rw [← whiskerLeft_comp, naturality_naturality]
 
 @[reassoc (attr := simp)]
 theorem whiskerRight_naturality_naturality {f g : a ⟶ b} (β : f ⟶ g) (h : G.obj b ⟶ a') :
@@ -110,7 +110,7 @@ theorem whiskerLeft_naturality_comp (f : a' ⟶ G.obj a) (g : a ⟶ b) (h : b �
         f ◁ (α_ _ _ _).hom ≫
           f ◁ G.map g ◁ θ.naturality h ≫
             f ◁ (α_ _ _ _).inv ≫ f ◁ θ.naturality g ▷ H.map h ≫ f ◁ (α_ _ _ _).hom := by
-  simp_rw [← Bicategory.whiskerLeft_comp, naturality_comp]
+  simp_rw [← whiskerLeft_comp, naturality_comp]
 
 @[reassoc (attr := simp)]
 theorem whiskerRight_naturality_comp (f : a ⟶ b) (g : b ⟶ c) (h : G.obj c ⟶ a') :
@@ -128,7 +128,7 @@ theorem whiskerRight_naturality_comp (f : a ⟶ b) (g : b ⟶ c) (h : G.obj c �
 theorem whiskerLeft_naturality_id (f : a' ⟶ G.obj a) :
     f ◁ θ.naturality (𝟙 a) ≫ f ◁ θ.app a ◁ H.mapId a =
       f ◁ G.mapId a ▷ θ.app a ≫ f ◁ (λ_ (θ.app a)).hom ≫ f ◁ (ρ_ (θ.app a)).inv := by
-  simp_rw [← Bicategory.whiskerLeft_comp, naturality_id]
+  simp_rw [← whiskerLeft_comp, naturality_id]
 
 @[reassoc (attr := simp)]
 theorem whiskerRight_naturality_id (f : G.obj a ⟶ a') :

--- a/Mathlib/CategoryTheory/Closed/Ideal.lean
+++ b/Mathlib/CategoryTheory/Closed/Ideal.lean
@@ -176,8 +176,7 @@ instance (priority := 10) exponentialIdeal_of_preservesBinaryProducts
     dsimp
     rw [← curry_natural_left, curry_eq_iff, uncurry_id_eq_ev, ← ir.homEquiv_naturality_left,
       ir.homEquiv_apply_eq, assoc, assoc, prodComparison_natural_whiskerLeft_assoc,
-      ← MonoidalCategory.whiskerLeft_comp_assoc,
-      ir.left_triangle_components, MonoidalCategory.whiskerLeft_id, id_comp]
+      ← whiskerLeft_comp_assoc, ir.left_triangle_components, whiskerLeft_id, id_comp]
     apply IsIso.hom_inv_id_assoc
   haveI : IsSplitMono (η.app (A ⟹ i.obj B)) := IsSplitMono.mk' ⟨_, this⟩
   apply mem_essImage_of_unit_isSplitMono

--- a/Mathlib/CategoryTheory/GradedObject/Monoidal.lean
+++ b/Mathlib/CategoryTheory/GradedObject/Monoidal.lean
@@ -97,7 +97,7 @@ lemma ι_tensorHom {X₁ X₂ Y₁ Y₂ : GradedObject I C} (f : X₁ ⟶ X₂) 
     [HasTensor X₁ Y₁] [HasTensor X₂ Y₂] (i₁ i₂ i₁₂ : I) (h : i₁ + i₂ = i₁₂) :
     ιTensorObj X₁ Y₁ i₁ i₂ i₁₂ h ≫ tensorHom f g i₁₂ =
       (f i₁ ⊗ₘ g i₂) ≫ ιTensorObj X₂ Y₂ i₁ i₂ i₁₂ h := by
-  rw [MonoidalCategory.tensorHom_def, assoc]
+  rw [tensorHom_def, assoc]
   apply ι_mapBifunctorMapMap
 
 /-- The morphism `tensorObj X Y₁ ⟶ tensorObj X Y₂` induced by a morphism of graded objects

--- a/Mathlib/CategoryTheory/Monoidal/Bimod.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Bimod.lean
@@ -150,12 +150,12 @@ def isoOfIso {X Y : Mon_ C} {P Q : Bimod X Y} (f : P.X ≅ Q.X)
     { hom := f.inv
       left_act_hom := by
         rw [← cancel_mono f.hom, Category.assoc, Category.assoc, Iso.inv_hom_id, Category.comp_id,
-          f_left_act_hom, ← Category.assoc, ← MonoidalCategory.whiskerLeft_comp, Iso.inv_hom_id,
-          MonoidalCategory.whiskerLeft_id, Category.id_comp]
+          f_left_act_hom, ← Category.assoc, ← whiskerLeft_comp, Iso.inv_hom_id,
+          whiskerLeft_id, Category.id_comp]
       right_act_hom := by
         rw [← cancel_mono f.hom, Category.assoc, Category.assoc, Iso.inv_hom_id, Category.comp_id,
           f_right_act_hom, ← Category.assoc, ← comp_whiskerRight, Iso.inv_hom_id,
-          MonoidalCategory.id_whiskerRight, Category.id_comp] }
+          id_whiskerRight, Category.id_comp] }
   hom_inv_id := by ext; dsimp; rw [Iso.hom_inv_id]
   inv_hom_id := by ext; dsimp; rw [Iso.inv_hom_id]
 
@@ -207,7 +207,7 @@ noncomputable def actLeft : R.X ⊗ X P Q ⟶ X P Q :=
           monoidal)
         (by
           dsimp
-          slice_lhs 1 1 => rw [MonoidalCategory.whiskerLeft_comp]
+          slice_lhs 1 1 => rw [whiskerLeft_comp]
           slice_lhs 2 3 => rw [associator_inv_naturality_right]
           slice_lhs 3 4 => rw [whisker_exchange]
           monoidal))
@@ -239,8 +239,8 @@ theorem left_assoc' :
   slice_lhs 2 3 => rw [← comp_whiskerRight, left_assoc, comp_whiskerRight, comp_whiskerRight]
   slice_rhs 1 2 => rw [associator_naturality_right]
   slice_rhs 2 3 =>
-    rw [← MonoidalCategory.whiskerLeft_comp, whiskerLeft_π_actLeft,
-      MonoidalCategory.whiskerLeft_comp, MonoidalCategory.whiskerLeft_comp]
+    rw [← whiskerLeft_comp, whiskerLeft_π_actLeft,
+      whiskerLeft_comp, whiskerLeft_comp]
   slice_rhs 4 5 => rw [whiskerLeft_π_actLeft]
   slice_rhs 3 4 => rw [associator_inv_naturality_middle]
   monoidal
@@ -267,8 +267,7 @@ noncomputable def actRight : X P Q ⊗ T.X ⟶ X P Q :=
           dsimp
           simp only [comp_whiskerRight, whisker_assoc, Category.assoc, Iso.inv_hom_id_assoc]
           slice_lhs 3 4 =>
-            rw [← MonoidalCategory.whiskerLeft_comp, middle_assoc,
-              MonoidalCategory.whiskerLeft_comp]
+            rw [← whiskerLeft_comp, middle_assoc, whiskerLeft_comp]
           simp))
 
 theorem π_tensor_id_actRight :
@@ -284,7 +283,7 @@ theorem actRight_one' : (_ ◁ η) ≫ actRight P Q = (ρ_ _).hom := by
   slice_lhs 1 2 =>erw [← whisker_exchange]
   slice_lhs 2 3 => rw [π_tensor_id_actRight]
   slice_lhs 1 2 => rw [associator_naturality_right]
-  slice_lhs 2 3 => rw [← MonoidalCategory.whiskerLeft_comp, actRight_one]
+  slice_lhs 2 3 => rw [← whiskerLeft_comp, actRight_one]
   simp
 
 theorem right_assoc' :
@@ -296,8 +295,8 @@ theorem right_assoc' :
   slice_lhs 1 2 => rw [← whisker_exchange]
   slice_lhs 2 3 => rw [π_tensor_id_actRight]
   slice_lhs 1 2 => rw [associator_naturality_right]
-  slice_lhs 2 3 => rw [← MonoidalCategory.whiskerLeft_comp, right_assoc,
-    MonoidalCategory.whiskerLeft_comp, MonoidalCategory.whiskerLeft_comp]
+  slice_lhs 2 3 => rw [← whiskerLeft_comp, right_assoc,
+    whiskerLeft_comp, whiskerLeft_comp]
   slice_rhs 1 2 => rw [associator_inv_naturality_left]
   slice_rhs 2 3 => rw [← comp_whiskerRight, π_tensor_id_actRight, comp_whiskerRight,
     comp_whiskerRight]
@@ -322,8 +321,8 @@ theorem middle_assoc' :
   slice_lhs 2 3 => rw [associator_naturality_left]
   -- Porting note: had to replace `rw` by `erw`
   slice_rhs 1 2 => rw [associator_naturality_middle]
-  slice_rhs 2 3 => rw [← MonoidalCategory.whiskerLeft_comp, π_tensor_id_actRight,
-    MonoidalCategory.whiskerLeft_comp, MonoidalCategory.whiskerLeft_comp]
+  slice_rhs 2 3 => rw [← whiskerLeft_comp, π_tensor_id_actRight,
+    whiskerLeft_comp, whiskerLeft_comp]
   slice_rhs 4 5 => rw [whiskerLeft_π_actLeft]
   slice_rhs 3 4 => rw [associator_inv_naturality_right]
   slice_rhs 4 5 => rw [whisker_exchange]
@@ -361,15 +360,15 @@ noncomputable def whiskerLeft {X Y Z : Mon_ C} (M : Bimod X Y) {N₁ N₂ : Bimo
         (by
           simp only [Category.assoc, tensor_whiskerLeft, Iso.inv_hom_id_assoc,
             Iso.cancel_iso_hom_left]
-          slice_lhs 1 2 => rw [← MonoidalCategory.whiskerLeft_comp, Hom.left_act_hom]
+          slice_lhs 1 2 => rw [← whiskerLeft_comp, Hom.left_act_hom]
           simp))
   left_act_hom := by
     refine (cancel_epi ((tensorLeft _).map (coequalizer.π _ _))).1 ?_
     dsimp
     slice_lhs 1 2 => rw [TensorBimod.whiskerLeft_π_actLeft]
     slice_lhs 3 4 => rw [ι_colimMap, parallelPairHom_app_one]
-    slice_rhs 1 2 => rw [← MonoidalCategory.whiskerLeft_comp, ι_colimMap, parallelPairHom_app_one,
-      MonoidalCategory.whiskerLeft_comp]
+    slice_rhs 1 2 => rw [← whiskerLeft_comp, ι_colimMap, parallelPairHom_app_one,
+      whiskerLeft_comp]
     slice_rhs 2 3 => rw [TensorBimod.whiskerLeft_π_actLeft]
     slice_rhs 1 2 => rw [associator_inv_naturality_right]
     slice_rhs 2 3 => rw [whisker_exchange]
@@ -379,7 +378,7 @@ noncomputable def whiskerLeft {X Y Z : Mon_ C} (M : Bimod X Y) {N₁ N₂ : Bimo
     dsimp
     slice_lhs 1 2 => rw [TensorBimod.π_tensor_id_actRight]
     slice_lhs 3 4 => rw [ι_colimMap, parallelPairHom_app_one]
-    slice_lhs 2 3 => rw [← MonoidalCategory.whiskerLeft_comp, Hom.right_act_hom]
+    slice_lhs 2 3 => rw [← whiskerLeft_comp, Hom.right_act_hom]
     slice_rhs 1 2 =>
       rw [← comp_whiskerRight, ι_colimMap, parallelPairHom_app_one, comp_whiskerRight]
     slice_rhs 2 3 => rw [TensorBimod.π_tensor_id_actRight]
@@ -402,8 +401,7 @@ noncomputable def whiskerRight {X Y Z : Mon_ C} {M₁ M₂ : Bimod X Y} (f : M�
     slice_lhs 1 2 => rw [TensorBimod.whiskerLeft_π_actLeft]
     slice_lhs 3 4 => rw [ι_colimMap, parallelPairHom_app_one]
     slice_lhs 2 3 => rw [← comp_whiskerRight, Hom.left_act_hom]
-    slice_rhs 1 2 => rw [← MonoidalCategory.whiskerLeft_comp, ι_colimMap, parallelPairHom_app_one,
-      MonoidalCategory.whiskerLeft_comp]
+    slice_rhs 1 2 => rw [← whiskerLeft_comp, ι_colimMap, parallelPairHom_app_one, whiskerLeft_comp]
     slice_rhs 2 3 => rw [TensorBimod.whiskerLeft_π_actLeft]
     slice_rhs 1 2 => rw [associator_inv_naturality_middle]
     simp
@@ -438,8 +436,7 @@ noncomputable def homAux : (P.tensorBimod Q).X ⊗ L.X ⟶ (P.tensorBimod (Q.ten
         slice_lhs 3 4 => rw [coequalizer.condition]
         slice_lhs 2 3 => rw [associator_naturality_right]
         slice_lhs 3 4 =>
-          rw [← MonoidalCategory.whiskerLeft_comp,
-            TensorBimod.whiskerLeft_π_actLeft, MonoidalCategory.whiskerLeft_comp]
+          rw [← whiskerLeft_comp, TensorBimod.whiskerLeft_π_actLeft, whiskerLeft_comp]
         simp)
 
 /-- The underlying morphism of the forward component of the associator isomorphism. -/
@@ -455,8 +452,8 @@ noncomputable def hom :
       slice_lhs 3 5 => rw [π_tensor_id_preserves_coequalizer_inv_desc]
       slice_lhs 2 3 => rw [associator_naturality_middle]
       slice_lhs 3 4 =>
-        rw [← MonoidalCategory.whiskerLeft_comp, coequalizer.condition,
-          MonoidalCategory.whiskerLeft_comp, MonoidalCategory.whiskerLeft_comp]
+        rw [← whiskerLeft_comp, coequalizer.condition,
+          whiskerLeft_comp, whiskerLeft_comp]
       slice_rhs 1 2 => rw [associator_naturality_left]
       slice_rhs 2 3 => rw [← whisker_exchange]
       slice_rhs 3 5 => rw [π_tensor_id_preserves_coequalizer_inv_desc]
@@ -470,8 +467,7 @@ theorem hom_left_act_hom' :
   simp only [curriedTensor_obj_map]
   slice_lhs 1 2 => rw [TensorBimod.whiskerLeft_π_actLeft]
   slice_lhs 3 4 => rw [coequalizer.π_desc]
-  slice_rhs 1 2 => rw [← MonoidalCategory.whiskerLeft_comp, coequalizer.π_desc,
-    MonoidalCategory.whiskerLeft_comp]
+  slice_rhs 1 2 => rw [← whiskerLeft_comp, coequalizer.π_desc, whiskerLeft_comp]
   refine (cancel_epi ((tensorRight _ ⋙ tensorLeft _).map (coequalizer.π _ _))).1 ?_
   dsimp; dsimp [TensorBimod.X]
   slice_lhs 1 2 => rw [associator_inv_naturality_middle]
@@ -481,9 +477,8 @@ theorem hom_left_act_hom' :
   slice_lhs 4 6 => rw [π_tensor_id_preserves_coequalizer_inv_desc]
   slice_lhs 3 4 => rw [associator_naturality_left]
   slice_rhs 1 3 =>
-    rw [← MonoidalCategory.whiskerLeft_comp, ← MonoidalCategory.whiskerLeft_comp,
-      π_tensor_id_preserves_coequalizer_inv_desc, MonoidalCategory.whiskerLeft_comp,
-      MonoidalCategory.whiskerLeft_comp]
+    rw [← whiskerLeft_comp, ← whiskerLeft_comp, π_tensor_id_preserves_coequalizer_inv_desc,
+      whiskerLeft_comp, whiskerLeft_comp]
   slice_rhs 3 4 => erw [TensorBimod.whiskerLeft_π_actLeft P (Q.tensorBimod L)]
   slice_rhs 2 3 => erw [associator_inv_naturality_right]
   slice_rhs 3 4 => erw [whisker_exchange]
@@ -511,8 +506,7 @@ theorem hom_right_act_hom' :
   slice_rhs 2 3 => erw [associator_naturality_middle]
   dsimp
   slice_rhs 3 4 =>
-    rw [← MonoidalCategory.whiskerLeft_comp, TensorBimod.π_tensor_id_actRight,
-      MonoidalCategory.whiskerLeft_comp, MonoidalCategory.whiskerLeft_comp]
+    rw [← whiskerLeft_comp, TensorBimod.π_tensor_id_actRight, whiskerLeft_comp, whiskerLeft_comp]
   monoidal
 
 /-- An auxiliary morphism for the definition of the underlying morphism of the inverse component of
@@ -529,7 +523,7 @@ noncomputable def invAux : P.X ⊗ (Q.tensorBimod L).X ⟶ ((P.tensorBimod Q).te
             comp_whiskerRight]
         slice_lhs 4 5 => rw [coequalizer.condition]
         slice_lhs 3 4 => rw [associator_naturality_left]
-        slice_rhs 1 2 => rw [MonoidalCategory.whiskerLeft_comp]
+        slice_rhs 1 2 => rw [whiskerLeft_comp]
         slice_rhs 2 3 => rw [associator_inv_naturality_right]
         slice_rhs 3 4 => rw [whisker_exchange]
         monoidal)
@@ -549,8 +543,8 @@ noncomputable def inv :
         rw [← comp_whiskerRight, coequalizer.condition, comp_whiskerRight, comp_whiskerRight]
       slice_rhs 1 2 => rw [associator_naturality_right]
       slice_rhs 2 3 =>
-        rw [← MonoidalCategory.whiskerLeft_comp, TensorBimod.whiskerLeft_π_actLeft,
-          MonoidalCategory.whiskerLeft_comp, MonoidalCategory.whiskerLeft_comp]
+        rw [← whiskerLeft_comp, TensorBimod.whiskerLeft_π_actLeft,
+          whiskerLeft_comp, whiskerLeft_comp]
       slice_rhs 4 6 => rw [id_tensor_π_preserves_coequalizer_inv_desc]
       slice_rhs 3 4 => rw [associator_inv_naturality_middle]
       monoidal)
@@ -625,7 +619,7 @@ theorem hom_left_act_hom' :
   dsimp
   slice_lhs 1 4 => rw [id_tensor_π_preserves_coequalizer_inv_colimMap_desc]
   slice_lhs 2 3 => rw [left_assoc]
-  slice_rhs 1 2 => rw [← MonoidalCategory.whiskerLeft_comp, coequalizer.π_desc]
+  slice_rhs 1 2 => rw [← whiskerLeft_comp, coequalizer.π_desc]
   rw [Iso.inv_hom_id_assoc]
 
 theorem hom_right_act_hom' :
@@ -660,7 +654,7 @@ theorem hom_inv_id : hom P ≫ inv P = 𝟙 _ := by
   slice_lhs 2 3 => rw [← whisker_exchange]
   slice_lhs 3 4 => rw [coequalizer.condition]
   slice_lhs 2 3 => rw [associator_naturality_right]
-  slice_lhs 3 4 => rw [← MonoidalCategory.whiskerLeft_comp, Mon_Class.mul_one]
+  slice_lhs 3 4 => rw [← whiskerLeft_comp, Mon_Class.mul_one]
   slice_rhs 1 2 => rw [Category.comp_id]
   monoidal
 
@@ -679,7 +673,7 @@ theorem hom_left_act_hom' :
   dsimp
   slice_lhs 1 4 => rw [id_tensor_π_preserves_coequalizer_inv_colimMap_desc]
   slice_lhs 2 3 => rw [middle_assoc]
-  slice_rhs 1 2 => rw [← MonoidalCategory.whiskerLeft_comp, coequalizer.π_desc]
+  slice_rhs 1 2 => rw [← whiskerLeft_comp, coequalizer.π_desc]
   rw [Iso.inv_hom_id_assoc]
 
 theorem hom_right_act_hom' :
@@ -730,7 +724,7 @@ theorem whiskerLeft_id_bimod {X Y Z : Mon_ C} {M : Bimod X Y} {N : Bimod Y Z} :
   ext
   apply Limits.coequalizer.hom_ext
   dsimp only [tensorBimod_X, whiskerLeft_hom, id_hom']
-  simp only [MonoidalCategory.whiskerLeft_id, ι_colimMap, parallelPair_obj_one,
+  simp only [whiskerLeft_id, ι_colimMap, parallelPair_obj_one,
     parallelPairHom_app_one, Category.id_comp]
   erw [Category.comp_id]
 
@@ -739,7 +733,7 @@ theorem id_whiskerRight_bimod {X Y Z : Mon_ C} {M : Bimod X Y} {N : Bimod Y Z} :
   ext
   apply Limits.coequalizer.hom_ext
   dsimp only [tensorBimod_X, whiskerRight_hom, id_hom']
-  simp only [MonoidalCategory.id_whiskerRight, ι_colimMap, parallelPair_obj_one,
+  simp only [id_whiskerRight, ι_colimMap, parallelPair_obj_one,
     parallelPairHom_app_one, Category.id_comp]
   erw [Category.comp_id]
 
@@ -788,10 +782,10 @@ theorem comp_whiskerLeft_bimod {W X Y Z : Mon_ C} (M : Bimod W X) (N : Bimod X Y
   simp only [Functor.flip_obj_map, curriedTensor_map_app]
   slice_rhs 1 3 => rw [π_tensor_id_preserves_coequalizer_inv_desc]
   slice_rhs 3 4 => rw [ι_colimMap, parallelPairHom_app_one]
-  slice_rhs 2 3 => rw [← MonoidalCategory.whiskerLeft_comp, ι_colimMap, parallelPairHom_app_one]
+  slice_rhs 2 3 => rw [← whiskerLeft_comp, ι_colimMap, parallelPairHom_app_one]
   slice_rhs 3 4 => rw [coequalizer.π_desc]
   dsimp [AssociatorBimod.invAux]
-  slice_rhs 2 2 => rw [MonoidalCategory.whiskerLeft_comp]
+  slice_rhs 2 2 => rw [whiskerLeft_comp]
   slice_rhs 3 5 => rw [id_tensor_π_preserves_coequalizer_inv_desc]
   slice_rhs 2 3 => rw [associator_inv_naturality_right]
   slice_rhs 1 3 => rw [Iso.hom_inv_id_assoc]
@@ -819,7 +813,7 @@ theorem whiskerRight_id_bimod {X Y : Mon_ C} {M N : Bimod X Y} (f : M ⟶ N) :
   slice_rhs 3 4 => rw [← whisker_exchange]
   slice_rhs 4 5 => rw [coequalizer.condition]
   slice_rhs 3 4 => rw [associator_naturality_right]
-  slice_rhs 4 5 => rw [← MonoidalCategory.whiskerLeft_comp, Mon_Class.mul_one]
+  slice_rhs 4 5 => rw [← whiskerLeft_comp, Mon_Class.mul_one]
   simp
 
 theorem whiskerRight_comp_bimod {W X Y Z : Mon_ C} {M M' : Bimod W X} (f : M ⟶ M') (N : Bimod X Y)
@@ -867,11 +861,11 @@ theorem whisker_assoc_bimod {W X Y Z : Mon_ C} (M : Bimod W X) {N N' : Bimod X Y
   slice_lhs 1 2 => rw [← comp_whiskerRight, ι_colimMap, parallelPairHom_app_one]
   slice_rhs 1 3 => rw [π_tensor_id_preserves_coequalizer_inv_desc]
   slice_rhs 3 4 => rw [ι_colimMap, parallelPairHom_app_one]
-  slice_rhs 2 3 => rw [← MonoidalCategory.whiskerLeft_comp, ι_colimMap, parallelPairHom_app_one]
+  slice_rhs 2 3 => rw [← whiskerLeft_comp, ι_colimMap, parallelPairHom_app_one]
   dsimp [AssociatorBimod.inv]
   slice_rhs 3 4 => rw [coequalizer.π_desc]
   dsimp [AssociatorBimod.invAux]
-  slice_rhs 2 2 => rw [MonoidalCategory.whiskerLeft_comp]
+  slice_rhs 2 2 => rw [whiskerLeft_comp]
   slice_rhs 3 5 => rw [id_tensor_π_preserves_coequalizer_inv_desc]
   slice_rhs 2 3 => rw [associator_inv_naturality_middle]
   slice_rhs 1 3 => rw [Iso.hom_inv_id_assoc]
@@ -920,13 +914,12 @@ theorem pentagon_bimod {V W X Y Z : Mon_ C} (M : Bimod V W) (N : Bimod W X) (P :
   dsimp only [TensorBimod.X]
   slice_lhs 2 3 => rw [associator_naturality_middle]
   slice_lhs 5 6 => rw [ι_colimMap, parallelPairHom_app_one]
-  slice_lhs 4 5 => rw [← MonoidalCategory.whiskerLeft_comp, coequalizer.π_desc]
+  slice_lhs 4 5 => rw [← whiskerLeft_comp, coequalizer.π_desc]
   slice_lhs 3 4 =>
-    rw [← MonoidalCategory.whiskerLeft_comp, π_tensor_id_preserves_coequalizer_inv_desc,
-      MonoidalCategory.whiskerLeft_comp, MonoidalCategory.whiskerLeft_comp]
+    rw [← whiskerLeft_comp, π_tensor_id_preserves_coequalizer_inv_desc,
+      whiskerLeft_comp, whiskerLeft_comp]
   slice_rhs 1 2 => rw [associator_naturality_left]
-  slice_rhs 2 3 =>
-    rw [← whisker_exchange]
+  slice_rhs 2 3 => rw [← whisker_exchange]
   slice_rhs 3 5 => rw [π_tensor_id_preserves_coequalizer_inv_desc]
   slice_rhs 2 3 => rw [associator_naturality_right]
   monoidal
@@ -948,7 +941,7 @@ theorem triangle_bimod {X Y Z : Mon_ C} (M : Bimod X Y) (N : Bimod Y Z) :
   slice_lhs 1 3 => rw [π_tensor_id_preserves_coequalizer_inv_desc]
   slice_lhs 3 4 => rw [ι_colimMap, parallelPairHom_app_one]
   dsimp [LeftUnitorBimod.hom]
-  slice_lhs 2 3 => rw [← MonoidalCategory.whiskerLeft_comp, coequalizer.π_desc]
+  slice_lhs 2 3 => rw [← whiskerLeft_comp, coequalizer.π_desc]
   slice_rhs 1 2 => rw [← comp_whiskerRight, coequalizer.π_desc]
   slice_rhs 1 2 => rw [coequalizer.condition]
   simp only [Category.assoc]

--- a/Mathlib/CategoryTheory/Monoidal/Braided/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided/Basic.lean
@@ -230,7 +230,7 @@ def braidedCategoryOfFaithful {C D : Type*} [Category C] [Category D] [MonoidalC
       μ_natural_left_assoc, ← comp_whiskerRight_assoc, w,
       comp_whiskerRight_assoc, Functor.LaxMonoidal.associativity_assoc,
       Functor.LaxMonoidal.associativity_assoc, ← μ_natural_right, ←
-      MonoidalCategory.whiskerLeft_comp_assoc, w, MonoidalCategory.whiskerLeft_comp_assoc,
+      whiskerLeft_comp_assoc, w, whiskerLeft_comp_assoc,
       reassoc_of% w, braiding_naturality_right_assoc,
       Functor.LaxMonoidal.associativity, hexagon_forward_assoc]
   hexagon_reverse := by
@@ -239,8 +239,8 @@ def braidedCategoryOfFaithful {C D : Type*} [Category C] [Category D] [MonoidalC
     refine (cancel_epi (μ F _ _)).1 ?_
     refine (cancel_epi (_ ◁ μ F _ _)).1 ?_
     rw [Functor.map_comp, Functor.map_comp, Functor.map_comp, Functor.map_comp, ←
-      μ_natural_right_assoc, ← MonoidalCategory.whiskerLeft_comp_assoc, w,
-      MonoidalCategory.whiskerLeft_comp_assoc, Functor.LaxMonoidal.associativity_inv_assoc,
+      μ_natural_right_assoc, ← whiskerLeft_comp_assoc, w,
+      whiskerLeft_comp_assoc, Functor.LaxMonoidal.associativity_inv_assoc,
       Functor.LaxMonoidal.associativity_inv_assoc, ← μ_natural_left,
       ← comp_whiskerRight_assoc, w, comp_whiskerRight_assoc, reassoc_of% w,
       braiding_naturality_left_assoc, Functor.LaxMonoidal.associativity_inv, hexagon_reverse_assoc]
@@ -324,7 +324,7 @@ theorem braiding_rightUnitor_aux₂ (X : C) :
 
 @[reassoc]
 theorem braiding_rightUnitor (X : C) : (β_ (𝟙_ C) X).hom ≫ (ρ_ X).hom = (λ_ X).hom := by
-  rw [← whiskerLeft_iff, MonoidalCategory.whiskerLeft_comp, braiding_rightUnitor_aux₂]
+  rw [← whiskerLeft_iff, whiskerLeft_comp, braiding_rightUnitor_aux₂]
 
 @[reassoc, simp]
 theorem braiding_tensorUnit_left (X : C) : (β_ (𝟙_ C) X).hom = (λ_ X).hom ≫ (ρ_ X).inv := by
@@ -560,18 +560,16 @@ def tensorδ (X₁ X₂ Y₁ Y₂ : C) : (X₁ ⊗ Y₁) ⊗ X₂ ⊗ Y₂ ⟶ (
 @[reassoc (attr := simp)]
 lemma tensorμ_tensorδ (X₁ X₂ Y₁ Y₂ : C) :
     tensorμ X₁ X₂ Y₁ Y₂ ≫ tensorδ X₁ X₂ Y₁ Y₂ = 𝟙 _ := by
-  simp only [tensorμ, tensorδ, assoc, Iso.inv_hom_id_assoc,
-    ← MonoidalCategory.whiskerLeft_comp_assoc, Iso.hom_inv_id_assoc,
-    hom_inv_whiskerRight_assoc, Iso.hom_inv_id, Iso.inv_hom_id,
-    MonoidalCategory.whiskerLeft_id, id_comp]
+  simp only [tensorμ, ← whiskerLeft_comp_assoc, tensorδ, assoc, Iso.inv_hom_id_assoc,
+    Iso.hom_inv_id_assoc, hom_inv_whiskerRight_assoc, Iso.inv_hom_id, whiskerLeft_id, id_comp,
+    Iso.hom_inv_id]
 
 @[reassoc (attr := simp)]
 lemma tensorδ_tensorμ (X₁ X₂ Y₁ Y₂ : C) :
     tensorδ X₁ X₂ Y₁ Y₂ ≫ tensorμ X₁ X₂ Y₁ Y₂ = 𝟙 _ := by
-  simp only [tensorμ, tensorδ, assoc, Iso.inv_hom_id_assoc,
-    ← MonoidalCategory.whiskerLeft_comp_assoc, Iso.hom_inv_id_assoc,
-    inv_hom_whiskerRight_assoc, Iso.inv_hom_id, Iso.hom_inv_id,
-    MonoidalCategory.whiskerLeft_id, id_comp]
+  simp only [tensorδ, ← whiskerLeft_comp_assoc, tensorμ, assoc, Iso.inv_hom_id_assoc,
+    Iso.hom_inv_id_assoc, inv_hom_whiskerRight_assoc, Iso.inv_hom_id, whiskerLeft_id, id_comp,
+    Iso.hom_inv_id]
 
 @[reassoc]
 theorem tensorμ_natural {X₁ X₂ Y₁ Y₂ U₁ U₂ V₁ V₂ : C} (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (g₁ : U₁ ⟶ V₁)
@@ -615,7 +613,7 @@ theorem tensor_left_unitality (X₁ X₂ : C) :
     monoidal
   slice_rhs 1 3 => rw [this]
   clear this
-  slice_rhs 1 2 => rw [← MonoidalCategory.whiskerLeft_comp, ← comp_whiskerRight,
+  slice_rhs 1 2 => rw [← whiskerLeft_comp, ← comp_whiskerRight,
     leftUnitor_inv_braiding]
   simp [tensorHom_def]
 
@@ -632,7 +630,7 @@ theorem tensor_right_unitality (X₁ X₂ : C) :
     monoidal
   slice_rhs 1 3 => rw [this]
   clear this
-  slice_rhs 2 3 => rw [← MonoidalCategory.whiskerLeft_comp, ← comp_whiskerRight,
+  slice_rhs 2 3 => rw [← whiskerLeft_comp, ← comp_whiskerRight,
     rightUnitor_inv_braiding]
   simp [tensorHom_def]
 

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Basic.lean
@@ -258,7 +258,7 @@ lemma lift_comp_fst_snd {X Y Z : C} (f : X ⟶ Y ⊗ Z) :
 
 @[reassoc (attr := simp)]
 lemma whiskerLeft_fst (X : C) {Y Z : C} (f : Y ⟶ Z) : X ◁ f ≫ fst _ _ = fst _ _ := by
-  simp [fst_def, ← MonoidalCategory.whiskerLeft_comp_assoc]
+  simp [fst_def, ← whiskerLeft_comp_assoc]
 
 @[reassoc (attr := simp)]
 lemma whiskerLeft_snd (X : C) {Y Z : C} (f : Y ⟶ Z) : X ◁ f ≫ snd _ _ = snd _ _ ≫ f := by
@@ -270,7 +270,7 @@ lemma whiskerRight_fst {X Y : C} (f : X ⟶ Y) (Z : C) : f ▷ Z ≫ fst _ _ = f
 
 @[reassoc (attr := simp)]
 lemma whiskerRight_snd {X Y : C} (f : X ⟶ Y) (Z : C) : f ▷ Z ≫ snd _ _ = snd _ _ := by
-  simp [snd_def, ← MonoidalCategory.comp_whiskerRight_assoc]
+  simp [snd_def, ← comp_whiskerRight_assoc]
 
 @[reassoc (attr := simp)]
 lemma tensorHom_fst {X₁ X₂ Y₁ Y₂ : C} (f : X₁ ⟶ X₂) (g : Y₁ ⟶ Y₂) :
@@ -302,7 +302,7 @@ lemma lift_whiskerLeft {X Y Z W : C} (f : X ⟶ Y) (g : X ⟶ Z) (h : Z ⟶ W) :
 lemma associator_hom_fst (X Y Z : C) :
     (α_ X Y Z).hom ≫ fst _ _ = fst _ _ ≫ fst _ _ := by
   simp [fst_def, ← whiskerLeft_rightUnitor_assoc, -whiskerLeft_rightUnitor,
-    ← MonoidalCategory.whiskerLeft_comp_assoc]
+    ← whiskerLeft_comp_assoc]
 
 @[reassoc (attr := simp)]
 lemma associator_hom_snd_fst (X Y Z : C) :
@@ -313,13 +313,13 @@ lemma associator_hom_snd_fst (X Y Z : C) :
 lemma associator_hom_snd_snd (X Y Z : C) :
     (α_ X Y Z).hom ≫ snd _ _ ≫ snd _ _ = snd _ _ := by
   simp [snd_def, ← leftUnitor_whiskerRight_assoc, -leftUnitor_whiskerRight,
-    ← MonoidalCategory.comp_whiskerRight_assoc]
+    ← comp_whiskerRight_assoc]
 
 @[reassoc (attr := simp)]
 lemma associator_inv_fst_fst (X Y Z : C) :
     (α_ X Y Z).inv ≫ fst _ _ ≫ fst _ _ = fst _ _ := by
   simp [fst_def, ← whiskerLeft_rightUnitor_assoc, -whiskerLeft_rightUnitor,
-    ← MonoidalCategory.whiskerLeft_comp_assoc]
+    ← whiskerLeft_comp_assoc]
 
 @[deprecated (since := "2025-04-01")] alias associator_inv_fst := associator_inv_fst_fst
 @[deprecated (since := "2025-04-01")] alias associator_inv_fst_assoc := associator_inv_fst_fst_assoc
@@ -333,7 +333,7 @@ lemma associator_inv_fst_snd (X Y Z : C) :
 lemma associator_inv_snd (X Y Z : C) :
     (α_ X Y Z).inv ≫ snd _ _ = snd _ _ ≫ snd _ _ := by
   simp [snd_def, ← leftUnitor_whiskerRight_assoc, -leftUnitor_whiskerRight,
-    ← MonoidalCategory.comp_whiskerRight_assoc]
+    ← comp_whiskerRight_assoc]
 
 @[reassoc (attr := simp)]
 lemma lift_lift_associator_hom {X Y Z W : C} (f : X ⟶ Y) (g : X ⟶ Z) (h : X ⟶ W) :

--- a/Mathlib/CategoryTheory/Monoidal/Hopf_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Hopf_.lean
@@ -99,7 +99,7 @@ theorem hom_antipode {A B : C} [Hopf_Class A] [Hopf_Class B] (f : A ⟶ B) [IsBi
     slice_lhs 1 2 =>
       rw [IsComon_Hom.hom_counit]
   · rw [Conv.mul_eq, Conv.one_eq]
-    simp only [MonoidalCategory.whiskerLeft_comp, Category.assoc]
+    simp only [whiskerLeft_comp, Category.assoc]
     slice_lhs 2 3 =>
       rw [← whisker_exchange]
     slice_lhs 3 4 =>
@@ -197,61 +197,55 @@ theorem antipode_comul₂ (A : C) [Hopf_Class A] :
     ε[A] ≫ (λ_ (𝟙_ C)).inv ≫ (η[A] ⊗ₘ η[A]) := by
   -- We should write a version of `slice_lhs` that zooms through whiskerings.
   slice_lhs 6 6 =>
-    simp only [tensorHom_def', MonoidalCategory.whiskerLeft_comp]
+    simp only [tensorHom_def', whiskerLeft_comp]
   slice_lhs 7 8 =>
-    rw [← MonoidalCategory.whiskerLeft_comp, associator_inv_naturality_middle,
-      MonoidalCategory.whiskerLeft_comp]
+    rw [← whiskerLeft_comp, associator_inv_naturality_middle, whiskerLeft_comp]
   slice_lhs 8 9 =>
-    rw [← MonoidalCategory.whiskerLeft_comp, ← comp_whiskerRight,
-      BraidedCategory.braiding_naturality_right,
-      comp_whiskerRight, MonoidalCategory.whiskerLeft_comp]
+    rw [← whiskerLeft_comp, ← comp_whiskerRight, BraidedCategory.braiding_naturality_right,
+      comp_whiskerRight, whiskerLeft_comp]
   slice_lhs 9 10 =>
-    rw [← MonoidalCategory.whiskerLeft_comp,
-      associator_naturality_left,
-      MonoidalCategory.whiskerLeft_comp]
+    rw [← whiskerLeft_comp, associator_naturality_left, whiskerLeft_comp]
   slice_lhs 5 6 =>
-    rw [← MonoidalCategory.whiskerLeft_comp, ← MonoidalCategory.whiskerLeft_comp,
-      ← BraidedCategory.braiding_naturality_left,
-      MonoidalCategory.whiskerLeft_comp, MonoidalCategory.whiskerLeft_comp]
+    rw [← whiskerLeft_comp, ← whiskerLeft_comp, ← BraidedCategory.braiding_naturality_left,
+      whiskerLeft_comp, whiskerLeft_comp]
   slice_lhs 11 12 =>
     rw [tensorHom_def', ← Category.assoc, ← associator_inv_naturality_right]
   slice_lhs 10 11 =>
-    rw [← MonoidalCategory.whiskerLeft_comp, ← whisker_exchange,
-      MonoidalCategory.whiskerLeft_comp]
+    rw [← whiskerLeft_comp, ← whisker_exchange, whiskerLeft_comp]
   slice_lhs 6 10 =>
-    simp only [← MonoidalCategory.whiskerLeft_comp]
+    simp only [← whiskerLeft_comp]
     rw [← BraidedCategory.hexagon_reverse_assoc, Iso.inv_hom_id_assoc,
       ← BraidedCategory.braiding_naturality_left]
-    simp only [MonoidalCategory.whiskerLeft_comp]
+    simp only [whiskerLeft_comp]
   rw [Comon_Class.comul_assoc_flip_assoc, Iso.inv_hom_id_assoc]
   slice_lhs 2 3 =>
-    simp only [← MonoidalCategory.whiskerLeft_comp]
+    simp only [← whiskerLeft_comp]
     rw [Comon_Class.comul_assoc]
-    simp only [MonoidalCategory.whiskerLeft_comp]
+    simp only [whiskerLeft_comp]
   slice_lhs 3 7 =>
-    simp only [← MonoidalCategory.whiskerLeft_comp]
+    simp only [← whiskerLeft_comp]
     rw [← associator_naturality_middle_assoc, Iso.hom_inv_id_assoc]
     simp only [← comp_whiskerRight]
     rw [antipode_right]
     simp only [comp_whiskerRight]
-    simp only [MonoidalCategory.whiskerLeft_comp]
+    simp only [whiskerLeft_comp]
   slice_lhs 2 3 =>
-    simp only [← MonoidalCategory.whiskerLeft_comp]
+    simp only [← whiskerLeft_comp]
     rw [Comon_Class.counit_comul]
-    simp only [MonoidalCategory.whiskerLeft_comp]
+    simp only [whiskerLeft_comp]
   slice_lhs 3 4 =>
-    simp only [← MonoidalCategory.whiskerLeft_comp]
+    simp only [← whiskerLeft_comp]
     rw [BraidedCategory.braiding_naturality_left]
-    simp only [MonoidalCategory.whiskerLeft_comp]
+    simp only [whiskerLeft_comp]
   slice_lhs 4 5 =>
-    simp only [← MonoidalCategory.whiskerLeft_comp]
+    simp only [← whiskerLeft_comp]
     rw [whisker_exchange]
-    simp only [MonoidalCategory.whiskerLeft_comp]
+    simp only [whiskerLeft_comp]
   slice_lhs 5 7 =>
     rw [associator_inv_naturality_right_assoc, whisker_exchange]
   simp only [braiding_tensorUnit_left,
-    MonoidalCategory.whiskerLeft_comp, whiskerLeft_rightUnitor_inv,
-    MonoidalCategory.whiskerRight_id, whiskerLeft_rightUnitor, Category.assoc, Iso.hom_inv_id_assoc,
+    whiskerLeft_comp, whiskerLeft_rightUnitor_inv,
+    whiskerRight_id, whiskerLeft_rightUnitor, Category.assoc, Iso.hom_inv_id_assoc,
     Iso.inv_hom_id_assoc, whiskerLeft_inv_hom_assoc, antipode_right_assoc]
   rw [rightUnitor_inv_naturality_assoc, tensorHom_def]
   monoidal
@@ -269,8 +263,8 @@ theorem antipode_comul (A : C) [Hopf_Class A] :
     simp only [Category.assoc, Iso.inv_hom_id_assoc]
     exact antipode_comul₁ A
   · rw [Conv.mul_eq, Conv.one_eq]
-    simp only [MonoidalCategory.whiskerLeft_comp, tensor_whiskerLeft, Category.assoc,
-      Iso.inv_hom_id_assoc, Mon_Class.tensorObj.mul_def, Mon_Class.tensorObj.one_def]
+    simp only [whiskerLeft_comp, tensor_whiskerLeft, Category.assoc, Iso.inv_hom_id_assoc,
+      Mon_Class.tensorObj.mul_def, Mon_Class.tensorObj.one_def]
     simp only [tensorμ]
     simp only [Category.assoc, Iso.inv_hom_id_assoc]
     exact antipode_comul₂ A
@@ -361,51 +355,51 @@ theorem mul_antipode₂ (A : C) [Hopf_Class A] :
     rw [Iso.inv_hom_id]
   rw [Category.id_comp]
   slice_lhs 5 7 =>
-    simp only [← MonoidalCategory.whiskerLeft_comp]
+    simp only [← whiskerLeft_comp]
     rw [← BraidedCategory.hexagon_forward]
-    simp only [MonoidalCategory.whiskerLeft_comp]
+    simp only [whiskerLeft_comp]
   simp only [tensor_whiskerLeft, Category.assoc, Iso.inv_hom_id_assoc, pentagon_inv_inv_hom_inv_inv,
     whisker_assoc, Mon_Class.mul_assoc, whiskerLeft_inv_hom_assoc]
   slice_lhs 3 4 =>
-    simp only [← MonoidalCategory.whiskerLeft_comp]
+    simp only [← whiskerLeft_comp]
     rw [BraidedCategory.braiding_naturality_right]
-    simp only [MonoidalCategory.whiskerLeft_comp]
+    simp only [whiskerLeft_comp]
   rw [tensorHom_def']
-  simp only [MonoidalCategory.whiskerLeft_comp]
+  simp only [whiskerLeft_comp]
   slice_lhs 5 6 =>
-    simp only [← MonoidalCategory.whiskerLeft_comp]
+    simp only [← whiskerLeft_comp]
     rw [← associator_naturality_right]
-    simp only [MonoidalCategory.whiskerLeft_comp]
+    simp only [whiskerLeft_comp]
   slice_lhs 4 5 =>
-    simp only [← MonoidalCategory.whiskerLeft_comp]
+    simp only [← whiskerLeft_comp]
     rw [← whisker_exchange]
-    simp only [MonoidalCategory.whiskerLeft_comp]
+    simp only [whiskerLeft_comp]
   slice_lhs 5 9 =>
-    simp only [← MonoidalCategory.whiskerLeft_comp]
+    simp only [← whiskerLeft_comp]
     rw [associator_inv_naturality_middle_assoc, Iso.hom_inv_id_assoc]
     simp only [← comp_whiskerRight]
     rw [antipode_right]
     simp only [comp_whiskerRight]
-    simp only [MonoidalCategory.whiskerLeft_comp]
+    simp only [whiskerLeft_comp]
   slice_lhs 6 7 =>
-    simp only [← MonoidalCategory.whiskerLeft_comp]
+    simp only [← whiskerLeft_comp]
     rw [Mon_Class.one_mul]
-    simp only [MonoidalCategory.whiskerLeft_comp]
+    simp only [whiskerLeft_comp]
   slice_lhs 3 4 =>
-    simp only [← MonoidalCategory.whiskerLeft_comp]
+    simp only [← whiskerLeft_comp]
     rw [← BraidedCategory.braiding_naturality_left]
-    simp only [MonoidalCategory.whiskerLeft_comp]
+    simp only [whiskerLeft_comp]
   slice_lhs 4 5 =>
-    simp only [← MonoidalCategory.whiskerLeft_comp]
+    simp only [← whiskerLeft_comp]
     rw [← BraidedCategory.braiding_naturality_right]
-    simp only [MonoidalCategory.whiskerLeft_comp]
+    simp only [whiskerLeft_comp]
   rw [← associator_naturality_middle_assoc]
-  simp only [braiding_tensorUnit_right, MonoidalCategory.whiskerLeft_comp]
+  simp only [braiding_tensorUnit_right, whiskerLeft_comp]
   slice_lhs 6 7 =>
-    simp only [← MonoidalCategory.whiskerLeft_comp]
+    simp only [← whiskerLeft_comp]
     rw [Iso.inv_hom_id]
-    simp only [MonoidalCategory.whiskerLeft_comp]
-  simp only [MonoidalCategory.whiskerLeft_id, Category.id_comp]
+    simp only [whiskerLeft_comp]
+  simp only [whiskerLeft_id, Category.id_comp]
   slice_lhs 5 6 =>
     rw [whiskerLeft_rightUnitor, Category.assoc, ← rightUnitor_naturality]
   rw [associator_inv_naturality_right_assoc, Iso.hom_inv_id_assoc]
@@ -440,7 +434,7 @@ theorem mul_antipode (A : C) [Hopf_Class A] :
     exact mul_antipode₁ A
   · rw [Conv.mul_eq, Conv.one_eq]
     simp only [Comon_.tensorObj_comul, whiskerRight_tensor,
-      BraidedCategory.braiding_naturality_assoc, MonoidalCategory.whiskerLeft_comp, Category.assoc,
+      BraidedCategory.braiding_naturality_assoc, whiskerLeft_comp, Category.assoc,
       Comon_.tensorObj_counit]
     simp only [tensorμ]
     simp only [Category.assoc, pentagon_hom_inv_inv_inv_inv_assoc]

--- a/Mathlib/CategoryTheory/Monoidal/Limits.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Limits.lean
@@ -61,10 +61,10 @@ instance : (lim (J := J) (C := C)).LaxMonoidal :=
         ← associator_naturality_right, ← tensorHom_def_assoc]
       dsimp
       conv_rhs => rw [tensorHom_def, ← whisker_exchange,
-        ← MonoidalCategory.whiskerLeft_comp_assoc, limit.lift_π,
+        ← whiskerLeft_comp_assoc, limit.lift_π,
         whisker_exchange, ← associator_naturality_left_assoc]
       dsimp only
-      conv_rhs => rw [tensorHom_def, MonoidalCategory.whiskerLeft_comp,
+      conv_rhs => rw [tensorHom_def, whiskerLeft_comp,
         ← associator_naturality_middle_assoc,
         ← associator_naturality_right, ← comp_whiskerRight_assoc,
         ← tensorHom_def, ← tensorHom_def_assoc]))
@@ -80,11 +80,10 @@ instance : (lim (J := J) (C := C)).LaxMonoidal :=
       dsimp
       simp only [id_tensorHom, limit.lift_map, Category.assoc, limit.lift_π]
       dsimp
-      simp only [tensorHom_def, ← whisker_exchange,
-        MonoidalCategory.whiskerRight_id, Category.assoc, Iso.inv_hom_id,
-        Category.comp_id, ← MonoidalCategory.whiskerLeft_comp_assoc]
+      simp only [tensorHom_def, ← whisker_exchange, whiskerRight_id, Category.assoc, Iso.inv_hom_id,
+        Category.comp_id, ← whiskerLeft_comp_assoc]
       erw [limit.lift_π]
-      rw [MonoidalCategory.whiskerLeft_id, Category.id_comp]))
+      rw [whiskerLeft_id, Category.id_comp]))
 
 @[reassoc (attr := simp)]
 lemma lim_ε_π (j : J) : ε (lim (J := J) (C := C)) ≫ limit.π _ j = 𝟙 _ :=

--- a/Mathlib/CategoryTheory/Monoidal/Mod_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Mod_.lean
@@ -107,13 +107,13 @@ def comap {A B : Mon_ C} (f : A ⟶ B) : Mod_ B ⥤ Mod_ A where
       assoc := by
         -- oh, for homotopy.io in a widget!
         slice_rhs 2 3 => rw [whisker_exchange]
-        simp only [whiskerRight_tensor, MonoidalCategory.whiskerLeft_comp, Category.assoc,
+        simp only [whiskerRight_tensor, whiskerLeft_comp, Category.assoc,
           Iso.hom_inv_id_assoc]
         slice_rhs 4 5 => rw [Mod_.assoc_flip]
         slice_rhs 3 4 => rw [associator_inv_naturality_middle]
         slice_rhs 2 4 => rw [Iso.hom_inv_id_assoc]
-        slice_rhs 1 2 => rw [← MonoidalCategory.comp_whiskerRight, ← whisker_exchange]
-        slice_rhs 1 2 => rw [← MonoidalCategory.comp_whiskerRight, ← tensorHom_def',
+        slice_rhs 1 2 => rw [← comp_whiskerRight, ← whisker_exchange]
+        slice_rhs 1 2 => rw [← comp_whiskerRight, ← tensorHom_def',
           ← IsMon_Hom.mul_hom]
         rw [comp_whiskerRight, Category.assoc] }
   map g :=

--- a/Mathlib/CategoryTheory/Monoidal/Mon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Mon_.lean
@@ -566,7 +566,7 @@ theorem Mon_tensor_mul_one (M N : C) [Mon_Class M] [Mon_Class N] :
     (M ⊗ N) ◁ ((λ_ (𝟙_ C)).inv ≫ (η[M] ⊗ₘ η[N])) ≫
         tensorμ M N M N ≫ (μ[M] ⊗ₘ μ[N]) =
       (ρ_ (M ⊗ N)).hom := by
-  simp only [MonoidalCategory.whiskerLeft_comp_assoc]
+  simp only [whiskerLeft_comp_assoc]
   slice_lhs 2 3 => rw [tensorμ_natural_right]
   slice_lhs 3 4 => rw [← tensor_comp, mul_one, mul_one]
   symm
@@ -578,7 +578,7 @@ theorem Mon_tensor_mul_assoc (M N : C) [Mon_Class M] [Mon_Class N] :
       (α_ (M ⊗ N : C) (M ⊗ N) (M ⊗ N)).hom ≫
         ((M ⊗ N : C) ◁ (tensorμ M N M N ≫ (μ ⊗ₘ μ))) ≫
           tensorμ M N M N ≫ (μ ⊗ₘ μ) := by
-  simp only [comp_whiskerRight_assoc, MonoidalCategory.whiskerLeft_comp_assoc]
+  simp only [comp_whiskerRight_assoc, whiskerLeft_comp_assoc]
   slice_lhs 2 3 => rw [tensorμ_natural_left]
   slice_lhs 3 4 => rw [← tensor_comp, mul_assoc, mul_assoc, tensor_comp, tensor_comp]
   slice_lhs 1 3 => rw [tensor_associativity]
@@ -789,13 +789,13 @@ theorem mul_braiding (X Y : C) [Mon_Class X] [Mon_Class Y] :
   dsimp [tensorObj.mul_def]
   simp only [tensorμ, Category.assoc, BraidedCategory.braiding_naturality,
     BraidedCategory.braiding_tensor_right_hom, BraidedCategory.braiding_tensor_left_hom,
-    comp_whiskerRight, whisker_assoc, MonoidalCategory.whiskerLeft_comp, pentagon_assoc,
+    comp_whiskerRight, whisker_assoc, whiskerLeft_comp, pentagon_assoc,
     pentagon_inv_hom_hom_hom_inv_assoc, Iso.inv_hom_id_assoc, whiskerLeft_hom_inv_assoc]
   slice_lhs 3 4 =>
     -- We use symmetry here:
-    rw [← MonoidalCategory.whiskerLeft_comp, ← comp_whiskerRight, SymmetricCategory.symmetry]
-  simp only [id_whiskerRight, MonoidalCategory.whiskerLeft_id, Category.id_comp, Category.assoc,
-    pentagon_inv_assoc, Iso.hom_inv_id_assoc]
+    rw [← whiskerLeft_comp, ← comp_whiskerRight, SymmetricCategory.symmetry]
+  simp only [id_whiskerRight, whiskerLeft_id, Category.id_comp, Category.assoc, pentagon_inv_assoc,
+    Iso.hom_inv_id_assoc]
   slice_lhs 1 2 =>
     rw [← associator_inv_naturality_left]
   slice_lhs 2 3 =>

--- a/Mathlib/CategoryTheory/Monoidal/Preadditive.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Preadditive.lean
@@ -168,7 +168,7 @@ theorem biproduct_ι_comp_leftDistributor_hom {J : Type} [Finite J] (X : C) (f :
     (X ◁ biproduct.ι _ j) ≫ (leftDistributor X f).hom = biproduct.ι (fun j => X ⊗ f j) j := by
   classical
   cases nonempty_fintype J
-  simp [leftDistributor_hom, Preadditive.comp_sum, ← MonoidalCategory.whiskerLeft_comp_assoc,
+  simp [leftDistributor_hom, Preadditive.comp_sum, ← whiskerLeft_comp_assoc,
     biproduct.ι_π, whiskerLeft_dite, dite_comp]
 
 @[reassoc (attr := simp)]
@@ -176,7 +176,7 @@ theorem leftDistributor_inv_comp_biproduct_π {J : Type} [Finite J] (X : C) (f :
     (leftDistributor X f).inv ≫ (X ◁ biproduct.π _ j) = biproduct.π _ j := by
   classical
   cases nonempty_fintype J
-  simp [leftDistributor_inv, Preadditive.sum_comp, ← MonoidalCategory.whiskerLeft_comp,
+  simp [leftDistributor_inv, Preadditive.sum_comp, ← whiskerLeft_comp,
     biproduct.ι_π, whiskerLeft_dite, comp_dite]
 
 @[reassoc (attr := simp)]
@@ -243,7 +243,7 @@ theorem rightDistributor_inv_comp_biproduct_π {J : Type} [Finite J] (f : J → 
     (rightDistributor f X).inv ≫ (biproduct.π _ j ▷ X) = biproduct.π _ j := by
   classical
   cases nonempty_fintype J
-  simp [rightDistributor_inv, Preadditive.sum_comp, ← MonoidalCategory.comp_whiskerRight,
+  simp [rightDistributor_inv, Preadditive.sum_comp, ← comp_whiskerRight,
     biproduct.ι_π, dite_whiskerRight, comp_dite]
 
 @[reassoc (attr := simp)]

--- a/Mathlib/CategoryTheory/Monoidal/Transport.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Transport.lean
@@ -91,11 +91,11 @@ def induced [MonoidalCategoryStruct D] (F : D ⥤ C) [F.Faithful]
   pentagon W X Y Z := F.map_injective <| by
     simp only [Functor.map_comp, fData.whiskerRight_eq, fData.associator_eq, Iso.trans_assoc,
       Iso.trans_hom, Iso.symm_hom, tensorIso_hom, Iso.refl_hom, tensorHom_id, id_tensorHom,
-      comp_whiskerRight, whisker_assoc, assoc, fData.whiskerLeft_eq,
-      MonoidalCategory.whiskerLeft_comp, Iso.hom_inv_id_assoc, whiskerLeft_hom_inv_assoc,
-      hom_inv_whiskerRight_assoc, Iso.inv_hom_id_assoc, Iso.cancel_iso_inv_left]
+      comp_whiskerRight, whisker_assoc, assoc, fData.whiskerLeft_eq, whiskerLeft_comp,
+      Iso.hom_inv_id_assoc, whiskerLeft_hom_inv_assoc, hom_inv_whiskerRight_assoc,
+      Iso.inv_hom_id_assoc, Iso.cancel_iso_inv_left]
     slice_lhs 5 6 =>
-      rw [← MonoidalCategory.whiskerLeft_comp, hom_inv_whiskerRight]
+      rw [← whiskerLeft_comp, hom_inv_whiskerRight]
     rw [whisker_exchange_assoc]
     simp
   leftUnitor_naturality {X Y : D} f := F.map_injective <| by


### PR DESCRIPTION
This was made possible by PR #26611.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
