### PR TITLE
[Merged by Bors] - chore: further whitespace fixes

### DIFF
--- a/Mathlib/Algebra/BigOperators/Finsupp/Fin.lean
+++ b/Mathlib/Algebra/BigOperators/Finsupp/Fin.lean
@@ -23,7 +23,7 @@ lemma sum_cons [AddCommMonoid M] (n : ℕ) (σ : Fin n →₀ M) (i : M) :
   exact Fin.sum_cons i σ
 
 lemma sum_cons' [Zero M] [AddCommMonoid N] (n : ℕ) (σ : Fin n →₀ M) (i : M)
-    (f : Fin (n+1) → M → N) (h : ∀ x, f x 0 = 0) :
+    (f : Fin (n + 1) → M → N) (h : ∀ x, f x 0 = 0) :
     (sum (Finsupp.cons i σ) f) = f 0 i + sum σ (Fin.tail f) := by
   rw [sum_fintype _ _ (fun _ => by apply h), sum_fintype _ _ (fun _ => by apply h)]
   simp_rw [Fin.sum_univ_succ, cons_zero, cons_succ]

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
@@ -212,7 +212,7 @@ variable {s : Finset ι} {t : Finset κ} {f : ι → M} {g : κ → M}
 
 @[to_additive]
 lemma prod_of_injOn (e : ι → κ) (he : Set.InjOn e s) (hest : Set.MapsTo e s t)
-    (h' : ∀ i ∈ t, i ∉ e '' s → g i = 1) (h : ∀ i ∈ s, f i = g (e i))  :
+    (h' : ∀ i ∈ t, i ∉ e '' s → g i = 1) (h : ∀ i ∈ s, f i = g (e i)) :
     ∏ i ∈ s, f i = ∏ j ∈ t, g j := by
   classical
   exact (prod_nbij e (fun a ↦ mem_image_of_mem e) he (by simp [Set.surjOn_image]) h).trans <|

--- a/Mathlib/Algebra/Category/ModuleCat/ExteriorPower.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/ExteriorPower.lean
@@ -40,7 +40,7 @@ namespace AlternatingMap
 variable {M : ModuleCat.{v} R} {N : ModuleCat.{max u v} R} {n : ℕ}
 
 @[ext]
-lemma ext {φ φ' : M.AlternatingMap N n} (h : ∀ (x : Fin n → M), φ x = φ' x ) :
+lemma ext {φ φ' : M.AlternatingMap N n} (h : ∀ (x : Fin n → M), φ x = φ' x) :
     φ = φ' :=
   _root_.AlternatingMap.ext h
 

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf/Free.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf/Free.lean
@@ -85,7 +85,7 @@ noncomputable def freeHomEquiv : (freeObj F ⟶ G) ≃ (F ⟶ G.presheaf ⋙ for
 
 lemma free_hom_ext {ψ ψ' : freeObj F ⟶ G}
     (h : freeAdjunctionUnit R F ≫ Functor.whiskerRight ((toPresheaf _).map ψ) _ =
-      freeAdjunctionUnit R F ≫ Functor.whiskerRight ((toPresheaf _).map ψ') _ ) : ψ = ψ' :=
+      freeAdjunctionUnit R F ≫ Functor.whiskerRight ((toPresheaf _).map ψ') _) : ψ = ψ' :=
   freeHomEquiv.injective h
 
 variable (R) in

--- a/Mathlib/Algebra/Category/ModuleCat/Topology/Basic.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Topology/Basic.lean
@@ -85,7 +85,7 @@ abbrev ofHom {X Y : Type v}
     (f : X →L[R] Y) : of R X ⟶ of R Y :=
   ConcreteCategory.ofHom f
 
-@[simp] lemma hom_ofHom  {X Y : Type v}
+@[simp] lemma hom_ofHom {X Y : Type v}
     [AddCommGroup X] [Module R X] [TopologicalSpace X] [ContinuousAdd X] [ContinuousSMul R X]
     [AddCommGroup Y] [Module R Y] [TopologicalSpace Y] [ContinuousAdd Y] [ContinuousSMul R Y]
     (f : X →L[R] Y) :

--- a/Mathlib/Algebra/Group/Action/TypeTags.lean
+++ b/Mathlib/Algebra/Group/Action/TypeTags.lean
@@ -28,11 +28,12 @@ instance Additive.vadd [SMul α β] : VAdd (Additive α) β where vadd a := (a.t
 
 instance Multiplicative.smul [VAdd α β] : SMul (Multiplicative α) β where smul a := (a.toAdd +ᵥ ·)
 
-@[simp] lemma toMul_smul [SMul α β] (a:Additive α) (b : β) : (a.toMul : α) • b = a +ᵥ b := rfl
+@[simp] lemma toMul_smul [SMul α β] (a : Additive α) (b : β) : (a.toMul : α) • b = a +ᵥ b := rfl
 
 @[simp] lemma ofMul_vadd [SMul α β] (a : α) (b : β) : ofMul a +ᵥ b = a • b := rfl
 
-@[simp] lemma toAdd_vadd [VAdd α β] (a:Multiplicative α) (b : β) : (a.toAdd : α) +ᵥ b = a • b := rfl
+@[simp] lemma toAdd_vadd [VAdd α β] (a : Multiplicative α) (b : β) : (a.toAdd : α) +ᵥ b = a • b :=
+  rfl
 
 @[simp] lemma ofAdd_smul [VAdd α β] (a : α) (b : β) : ofAdd a • b = a +ᵥ b := rfl
 

--- a/Mathlib/Algebra/Group/Fin/Tuple.lean
+++ b/Mathlib/Algebra/Group/Fin/Tuple.lean
@@ -25,7 +25,7 @@ lemma insertNth_mul [∀ j, Mul (α j)] (i : Fin (n + 1)) (x y : α i) (p q : �
   insertNth_binop (fun _ ↦ (· * ·)) i x y p q
 
 @[to_additive (attr := simp)]
-lemma insertNth_div [∀ j, Div (α j)] (i : Fin (n + 1)) (x y : α i)(p q : ∀ j, α (i.succAbove j)) :
+lemma insertNth_div [∀ j, Div (α j)] (i : Fin (n + 1)) (x y : α i) (p q : ∀ j, α (i.succAbove j)) :
     i.insertNth (x / y) (p / q) = i.insertNth x p / i.insertNth y q :=
   insertNth_binop (fun _ ↦ (· / ·)) i x y p q
 

--- a/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Basic.lean
@@ -389,7 +389,7 @@ theorem image_op_mul : op '' (s * t) = op '' t * op '' s :=
   image_image2_antidistrib op_mul
 
 @[to_additive (attr := simp) prod_add_prod_comm]
-lemma prod_mul_prod_comm [Mul β] (s₁ s₂: Set α) (t₁ t₂ : Set β) :
+lemma prod_mul_prod_comm [Mul β] (s₁ s₂ : Set α) (t₁ t₂ : Set β) :
    (s₁ ×ˢ t₁) * (s₂ ×ˢ t₂) = (s₁ * s₂) ×ˢ (t₁ * t₂) := by ext; simp [mem_mul]; aesop
 
 @[deprecated (since := "2025-03-11")]

--- a/Mathlib/Algebra/Group/Pointwise/Set/Scalar.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Set/Scalar.lean
@@ -113,10 +113,10 @@ lemma smul_nonempty : (s • t).Nonempty ↔ s.Nonempty ∧ t.Nonempty := image2
 @[to_additive] lemma Nonempty.of_smul_left : (s • t).Nonempty → s.Nonempty := .of_image2_left
 @[to_additive] lemma Nonempty.of_smul_right : (s • t).Nonempty → t.Nonempty := .of_image2_right
 
-@[to_additive (attr := simp low+1)]
+@[to_additive (attr := simp low + 1)]
 lemma smul_singleton : s • ({b} : Set β) = (· • b) '' s := image2_singleton_right
 
-@[to_additive (attr := simp low+1)]
+@[to_additive (attr := simp low + 1)]
 lemma singleton_smul : ({a} : Set α) • t = a • t := image2_singleton_left
 
 @[to_additive (attr := simp high)]
@@ -255,10 +255,10 @@ lemma Nonempty.vsub : s.Nonempty → t.Nonempty → (s -ᵥ t : Set α).Nonempty
 lemma Nonempty.of_vsub_left : (s -ᵥ t : Set α).Nonempty → s.Nonempty := .of_image2_left
 lemma Nonempty.of_vsub_right : (s -ᵥ t : Set α).Nonempty → t.Nonempty := .of_image2_right
 
-@[simp low+1]
+@[simp low + 1]
 lemma vsub_singleton (s : Set β) (b : β) : s -ᵥ {b} = (· -ᵥ b) '' s := image2_singleton_right
 
-@[simp low+1]
+@[simp low + 1]
 lemma singleton_vsub (t : Set β) (b : β) : {b} -ᵥ t = (b -ᵥ ·) '' t := image2_singleton_left
 
 @[simp high] lemma singleton_vsub_singleton : ({b} : Set β) -ᵥ {c} = {b -ᵥ c} := image2_singleton

--- a/Mathlib/Algebra/GroupWithZero/WithZero.lean
+++ b/Mathlib/Algebra/GroupWithZero/WithZero.lean
@@ -132,7 +132,7 @@ lemma map'_zero (f : α →* β) : map' f 0 = 0 := rfl
 lemma map'_id : map' (MonoidHom.id β) = MonoidHom.id (WithZero β) := by
   ext x; induction x <;> rfl
 
-lemma map'_map'  (f : α →* β) (g : β →* γ) (x) : map' g (map' f x) = map' (g.comp f) x := by
+lemma map'_map' (f : α →* β) (g : β →* γ) (x) : map' g (map' f x) = map' (g.comp f) x := by
   induction x <;> rfl
 
 @[simp]

--- a/Mathlib/Algebra/Homology/BifunctorAssociator.lean
+++ b/Mathlib/Algebra/Homology/BifunctorAssociator.lean
@@ -311,7 +311,7 @@ lemma ι_D₂ [HasGoodTrifunctor₁₂Obj F₁₂ G K₁ K₂ K₃ c₁₂ c₄]
   simp [D₂]
 
 @[reassoc (attr := simp)]
-lemma ι_D₃  :
+lemma ι_D₃ :
     ι F₁₂ G K₁ K₂ K₃ c₁₂ c₄ i₁ i₂ i₃ j h ≫ D₃ F₁₂ G K₁ K₂ K₃ c₁₂ c₄ j j' =
       d₃ F₁₂ G K₁ K₂ K₃ c₁₂ c₄ i₁ i₂ i₃ j' := by
   simp only [ι_eq _ _ _ _ _ _ _ _ _ _ _ _ rfl h, D₃, assoc, mapBifunctor.ι_D₂]

--- a/Mathlib/Algebra/Homology/HasNoLoop.lean
+++ b/Mathlib/Algebra/Homology/HasNoLoop.lean
@@ -31,7 +31,7 @@ lemma not_rel_self : ¬ c.Rel j j :=
   HasNoLoop.not_rel_self j
 
 variable {j} in
-lemma not_rel_of_eq {j' : ι } (h : j = j') : ¬ c.Rel j j' := by
+lemma not_rel_of_eq {j' : ι} (h : j = j') : ¬ c.Rel j j' := by
   subst h
   exact c.not_rel_self j
 

--- a/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
@@ -363,13 +363,13 @@ protected lemma comp_neg {n₁ n₂ n₁₂ : ℤ} (z₁ : Cochain F G n₁) (z�
 
 @[simp]
 protected lemma comp_smul {n₁ n₂ n₁₂ : ℤ} (z₁ : Cochain F G n₁) (k : R) (z₂ : Cochain G K n₂)
-    (h : n₁ + n₂ = n₁₂ ) : z₁.comp (k • z₂) h = k • (z₁.comp z₂ h) := by
+    (h : n₁ + n₂ = n₁₂) : z₁.comp (k • z₂) h = k • (z₁.comp z₂ h) := by
   ext p q hpq
   simp only [comp_v _ _ h p _ q rfl (by omega), smul_v, Linear.comp_smul]
 
 @[simp]
 lemma comp_units_smul {n₁ n₂ n₁₂ : ℤ} (z₁ : Cochain F G n₁) (k : Rˣ) (z₂ : Cochain G K n₂)
-    (h : n₁ + n₂ = n₁₂ ) : z₁.comp (k • z₂) h = k • (z₁.comp z₂ h) := by
+    (h : n₁ + n₂ = n₁₂) : z₁.comp (k • z₂) h = k • (z₁.comp z₂ h) := by
   apply Cochain.comp_smul
 
 @[simp]

--- a/Mathlib/Algebra/Homology/HomotopyCofiber.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCofiber.lean
@@ -115,7 +115,7 @@ noncomputable def inlX (i j : ι) (hij : c.Rel j i) : F.X i ⟶ X φ j :=
   biprod.inl ≫ (XIsoBiprod φ j i hij).inv
 
 @[reassoc (attr := simp)]
-lemma inlX_fstX (i j : ι ) (hij : c.Rel j i) :
+lemma inlX_fstX (i j : ι) (hij : c.Rel j i) :
     inlX φ i j hij ≫ fstX φ j i hij = 𝟙 _ := by
   simp [inlX, fstX]
 

--- a/Mathlib/Algebra/Homology/HomotopyCofiber.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCofiber.lean
@@ -542,7 +542,7 @@ end cylinder
 
 /-- If a functor inverts homotopy equivalences, it sends homotopic maps to the same map. -/
 lemma _root_.Homotopy.map_eq_of_inverts_homotopyEquivalences
-    {φ₀ φ₁ : F ⟶ G} (h : Homotopy φ₀ φ₁)(hc : ∀ j, ∃ i, c.Rel i j)
+    {φ₀ φ₁ : F ⟶ G} (h : Homotopy φ₀ φ₁) (hc : ∀ j, ∃ i, c.Rel i j)
     [∀ i, HasBinaryBiproduct (F.X i) (F.X i)]
     [HasHomotopyCofiber (biprod.lift (𝟙 F) (-𝟙 F))]
     {D : Type*} [Category D] (H : HomologicalComplex C c ⥤ D)

--- a/Mathlib/Algebra/Homology/ShortComplex/ShortExact.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/ShortExact.lean
@@ -126,7 +126,7 @@ lemma ShortExact.isIso_f_iff {S : ShortComplex C} (hS : S.ShortExact) [Balanced 
     have : Epi S.f := (S.exact_iff_epi (hX₃.eq_of_tgt _ _)).1 hS.exact
     apply isIso_of_mono_of_epi
 
-lemma ShortExact.isIso_g_iff  {S : ShortComplex C} (hS : S.ShortExact) [Balanced C] :
+lemma ShortExact.isIso_g_iff {S : ShortComplex C} (hS : S.ShortExact) [Balanced C] :
     IsIso S.g ↔ IsZero S.X₁ := by
   have := hS.exact.hasZeroObject
   have := hS.mono_f

--- a/Mathlib/Algebra/Homology/SingleHomology.lean
+++ b/Mathlib/Algebra/Homology/SingleHomology.lean
@@ -87,7 +87,7 @@ lemma singleObjCyclesSelfIso_hom_singleObjOpcyclesSelfIso_hom :
   simp [singleObjCyclesSelfIso, singleObjOpcyclesSelfIso]
 
 @[reassoc (attr := simp)]
-lemma singleObjCyclesSelfIso_inv_homologyπ  :
+lemma singleObjCyclesSelfIso_inv_homologyπ :
     (singleObjCyclesSelfIso _ _ _).inv ≫ ((single C c j).obj A).homologyπ j =
       (singleObjHomologySelfIso _ _ _).inv := by
   simp [singleObjCyclesSelfIso, singleObjHomologySelfIso]

--- a/Mathlib/Algebra/Lie/TraceForm.lean
+++ b/Mathlib/Algebra/Lie/TraceForm.lean
@@ -161,7 +161,7 @@ lemma traceForm_apply_eq_zero_of_mem_lcs_of_mem_center {x y : L}
 invariant (in the sense that the action of `L` is skew-adjoint wrt `B`) then components of the
 Fitting decomposition of `M` are orthogonal wrt `B`. -/
 lemma eq_zero_of_mem_genWeightSpace_mem_posFitting [LieRing.IsNilpotent L]
-    {B : LinearMap.BilinForm R M} (hB : ∀ (x : L) (m n : M), B ⁅x, m⁆ n = - B m ⁅x, n⁆)
+    {B : LinearMap.BilinForm R M} (hB : ∀ (x : L) (m n : M), B ⁅x, m⁆ n = -B m ⁅x, n⁆)
     {m₀ m₁ : M} (hm₀ : m₀ ∈ genWeightSpace M (0 : L → R)) (hm₁ : m₁ ∈ posFittingComp R L M) :
     B m₀ m₁ = 0 := by
   replace hB : ∀ x (k : ℕ) m n, B m ((φ x ^ k) n) = (- 1 : R) ^ k • B ((φ x ^ k) m) n := by

--- a/Mathlib/Algebra/Lie/Weights/Killing.lean
+++ b/Mathlib/Algebra/Lie/Weights/Killing.lean
@@ -560,7 +560,7 @@ lemma exists_isSl2Triple_of_weight_isNonZero {α : Weight K H L} (hα : α.IsNon
     simp [← smul_assoc, f, hh, mul_comm _ (2 * (α h)⁻¹)]
 
 lemma _root_.IsSl2Triple.h_eq_coroot {α : Weight K H L} (hα : α.IsNonZero)
-    {h e f : L} (ht : IsSl2Triple h e f) (heα : e ∈ rootSpace H α) (hfα : f ∈ rootSpace H (- α)) :
+    {h e f : L} (ht : IsSl2Triple h e f) (heα : e ∈ rootSpace H α) (hfα : f ∈ rootSpace H (-α)) :
     h = coroot α := by
   have hef := lie_eq_killingForm_smul_of_mem_rootSpace_of_mem_rootSpace_neg heα hfα
   lift h to H using by simpa only [← ht.lie_e_f, hef] using H.smul_mem _ (Submodule.coe_mem _)
@@ -616,7 +616,7 @@ noncomputable def sl2SubalgebraOfRoot {α : Weight K H L} (hα : α.IsNonZero) :
   exact t.toLieSubalgebra K
 
 lemma mem_sl2SubalgebraOfRoot_iff {α : Weight K H L} (hα : α.IsNonZero) {h e f : L}
-    (t : IsSl2Triple h e f) (hte : e ∈ rootSpace H α) (htf : f ∈ rootSpace H (- α)) {x : L} :
+    (t : IsSl2Triple h e f) (hte : e ∈ rootSpace H α) (htf : f ∈ rootSpace H (-α)) {x : L} :
     x ∈ sl2SubalgebraOfRoot hα ↔ ∃ c₁ c₂ c₃ : K, x = c₁ • e + c₂ • f + c₃ • ⁅e, f⁆ := by
   simp only [sl2SubalgebraOfRoot, IsSl2Triple.mem_toLieSubalgebra_iff]
   generalize_proofs _ _ _ he hf

--- a/Mathlib/Algebra/Module/Submodule/Pointwise.lean
+++ b/Mathlib/Algebra/Module/Submodule/Pointwise.lean
@@ -394,7 +394,7 @@ lemma set_smul_inductionOn {motive : (x : M) → (_ : x ∈ s • N) → Prop}
     (hx : x ∈ s • N)
     (smul₀ : ∀ ⦃r : S⦄ ⦃n : M⦄ (mem₁ : r ∈ s) (mem₂ : n ∈ N),
       motive (r • n) (mem_set_smul_of_mem_mem mem₁ mem₂))
-    (smul₁ : ∀ (r : R) ⦃m : M⦄ (mem : m ∈ s • N) ,
+    (smul₁ : ∀ (r : R) ⦃m : M⦄ (mem : m ∈ s • N),
       motive m mem → motive (r • m) (Submodule.smul_mem _ r mem)) --
     (add : ∀ ⦃m₁ m₂ : M⦄ (mem₁ : m₁ ∈ s • N) (mem₂ : m₂ ∈ s • N),
       motive m₁ mem₁ → motive m₂ mem₂ → motive (m₁ + m₂) (Submodule.add_mem _ mem₁ mem₂))

--- a/Mathlib/Algebra/Module/Torsion.lean
+++ b/Mathlib/Algebra/Module/Torsion.lean
@@ -936,7 +936,7 @@ lemma torsionBy.nsmul_iff {x : A} :
     x ∈ A[n] ↔ n • x = 0 :=
   Nat.cast_smul_eq_nsmul ℤ n x ▸ Submodule.mem_torsionBy_iff ..
 
-lemma torsionBy.mod_self_nsmul (s : ℕ) (x : A[n])  :
+lemma torsionBy.mod_self_nsmul (s : ℕ) (x : A[n]) :
     s • x = (s % n) • x :=
   nsmul_eq_mod_nsmul s (torsionBy.nsmul x)
 

--- a/Mathlib/Algebra/Order/Disjointed.lean
+++ b/Mathlib/Algebra/Order/Disjointed.lean
@@ -34,7 +34,7 @@ protected lemma Monotone.disjointed_add_one_sup {f : ι → α} (hf : Monotone f
     disjointed f (i + 1) ⊔ f i = f (i + 1) := by
   simpa only [succ_eq_add_one i] using hf.disjointed_succ_sup i
 
-protected lemma Monotone.disjointed_add_one [NoMaxOrder ι]  {f : ι → α} (hf : Monotone f) (i : ι) :
+protected lemma Monotone.disjointed_add_one [NoMaxOrder ι] {f : ι → α} (hf : Monotone f) (i : ι) :
     disjointed f (i + 1) = f (i + 1) \ f i := by
   rw [← succ_eq_add_one, hf.disjointed_succ]
   exact not_isMax i

--- a/Mathlib/Algebra/Pointwise/Stabilizer.lean
+++ b/Mathlib/Algebra/Pointwise/Stabilizer.lean
@@ -97,7 +97,7 @@ lemma stabilizer_union_eq_left (hdisj : Disjoint s t) (hstab : stabilizer G s �
 
 @[to_additive]
 lemma stabilizer_union_eq_right (hdisj : Disjoint s t) (hstab : stabilizer G t ≤ stabilizer G s)
-    (hstab_union : stabilizer G (s ∪ t) ≤ stabilizer G s)  :
+    (hstab_union : stabilizer G (s ∪ t) ≤ stabilizer G s) :
     stabilizer G (s ∪ t) = stabilizer G t := by
   rw [union_comm, stabilizer_union_eq_left hdisj.symm hstab (union_comm .. ▸ hstab_union)]
 

--- a/Mathlib/Algebra/Polynomial/Degree/IsMonicOfDegree.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/IsMonicOfDegree.lean
@@ -112,7 +112,7 @@ lemma IsMonicOfDegree.of_mul_left {p q : R[X]} {m n : ℕ} (hp : IsMonicOfDegree
   rw [natDegree_mul' h, hp.natDegree_eq] at this
   exact (Nat.add_left_cancel this.symm).symm
 
-lemma IsMonicOfDegree.of_mul_right  {p q : R[X]} {m n : ℕ} (hq : IsMonicOfDegree q n)
+lemma IsMonicOfDegree.of_mul_right {p q : R[X]} {m n : ℕ} (hq : IsMonicOfDegree q n)
     (hpq : IsMonicOfDegree (p * q) (m + n)) :
     IsMonicOfDegree p m := by
   rcases subsingleton_or_nontrivial R with H | H
@@ -163,7 +163,7 @@ variable (R) in
 lemma isMonicOfDegree_X : IsMonicOfDegree (X : R[X]) 1 :=
   (isMonicOfDegree_iff ..).mpr ⟨natDegree_X_le, coeff_X_one⟩
 
-variable (R)  in
+variable (R) in
 lemma isMonicOfDegree_X_pow (n : ℕ) : IsMonicOfDegree ((X : R[X]) ^ n) n :=
   (isMonicOfDegree_iff ..).mpr ⟨natDegree_X_pow_le n, coeff_X_pow_self n⟩
 

--- a/Mathlib/Algebra/Polynomial/Sequence.lean
+++ b/Mathlib/Algebra/Polynomial/Sequence.lean
@@ -176,7 +176,7 @@ noncomputable def basis : Basis ℕ R R[X] :=
 
 /-- The `i`'th basis vector is the `i`'th polynomial in the sequence. -/
 @[simp]
-lemma basis_eq_self  (i : ℕ) : S.basis hCoeff i = S i := Basis.mk_apply _ _ _
+lemma basis_eq_self (i : ℕ) : S.basis hCoeff i = S i := Basis.mk_apply _ _ _
 
 /-- Basis elements have strictly monotone degree. -/
 lemma basis_degree_strictMono : StrictMono <| degree ∘ (S.basis hCoeff) := fun _ _  ↦ by simp

--- a/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
+++ b/Mathlib/AlgebraicGeometry/AffineTransitionLimit.lean
@@ -149,7 +149,7 @@ lemma exists_mem_of_isClosed_of_nonempty'
     (hZc : ∀ i hij, IsClosed (Z i hij))
     (hZne : ∀ i hij, (Z i hij).Nonempty)
     (hZcpt : ∀ i hij, IsCompact (Z i hij))
-    (hstab : ∀ (i i' : I) (hi'i : i' ⟶ i) (hij : i ⟶ j) ,
+    (hstab : ∀ (i i' : I) (hi'i : i' ⟶ i) (hij : i ⟶ j),
       Set.MapsTo (D.map hi'i).base (Z i' (hi'i ≫ hij)) (Z i hij)) :
     ∃ (s : c.pt), ∀ i hij, (c.π.app i).base s ∈ Z i hij := by
   have {i₁ i₂ : Over j} (f : i₁ ⟶ i₂) : IsAffineHom ((Over.forget j ⋙ D).map f) := by

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Basic.lean
@@ -207,7 +207,7 @@ variable {f}
 variable {m' : ℕ} {g : A} (g_deg : g ∈ 𝒜 m') (hm' : 0 < m') {x : A} (hx : x = f * g)
 
 @[reassoc]
-lemma awayMap_awayToSection  :
+lemma awayMap_awayToSection :
     CommRingCat.ofHom (awayMap 𝒜 g_deg hx) ≫ awayToSection 𝒜 x =
       awayToSection 𝒜 f ≫ (Proj 𝒜).presheaf.map (homOfLE (basicOpen_mono _ _ _ ⟨_, hx⟩)).op := by
   ext a

--- a/Mathlib/AlgebraicGeometry/Sites/Representability.lean
+++ b/Mathlib/AlgebraicGeometry/Sites/Representability.lean
@@ -111,7 +111,7 @@ lemma yoneda_toGlued_yonedaGluedToSheaf (i : ι) :
   apply GlueData.sheafValGluedMk_val
 
 @[simp]
-lemma yonedaGluedToSheaf_app_toGlued {i : ι}  :
+lemma yonedaGluedToSheaf_app_toGlued {i : ι} :
     (yonedaGluedToSheaf hf).val.app _ (toGlued hf i) = yonedaEquiv (f i) := by
   rw [← yoneda_toGlued_yonedaGluedToSheaf hf i, yonedaEquiv_comp,
     yonedaEquiv_yoneda_map]

--- a/Mathlib/AlgebraicTopology/ModelCategory/Basic.lean
+++ b/Mathlib/AlgebraicTopology/ModelCategory/Basic.lean
@@ -91,7 +91,7 @@ section mk'
 open MorphismProperty
 
 variable {C} in
-private lemma mk'.cm3a_aux [CategoryWithFibrations C]  [CategoryWithCofibrations C]
+private lemma mk'.cm3a_aux [CategoryWithFibrations C] [CategoryWithCofibrations C]
     [CategoryWithWeakEquivalences C]
     [(weakEquivalences C).HasTwoOutOfThreeProperty]
     [IsWeakFactorizationSystem (trivialCofibrations C) (fibrations C)]

--- a/Mathlib/AlgebraicTopology/Quasicategory/Basic.lean
+++ b/Mathlib/AlgebraicTopology/Quasicategory/Basic.lean
@@ -38,7 +38,7 @@ class Quasicategory (S : SSet) : Prop where
     (_h0 : 0 < i) (_hn : i < Fin.last (n+2)),
       ∃ σ : Δ[n+2] ⟶ S, σ₀ = Λ[n + 2, i].ι ≫ σ
 
-lemma Quasicategory.hornFilling {S : SSet} [Quasicategory S] ⦃n : ℕ⦄ ⦃i : Fin (n+1)⦄
+lemma Quasicategory.hornFilling {S : SSet} [Quasicategory S] ⦃n : ℕ⦄ ⦃i : Fin (n + 1)⦄
     (h0 : 0 < i) (hn : i < Fin.last n)
     (σ₀ : (Λ[n, i] : SSet) ⟶ S) : ∃ σ : Δ[n] ⟶ S, σ₀ = Λ[n, i].ι ≫ σ := by
   cases n using Nat.casesAuxOn with
@@ -56,9 +56,9 @@ instance (S : SSet) [KanComplex S] : Quasicategory S where
   hornFilling' _ _ σ₀ _ _ := KanComplex.hornFilling σ₀
 
 lemma quasicategory_of_filler (S : SSet)
-    (filler : ∀ ⦃n : ℕ⦄ ⦃i : Fin (n+3)⦄ (σ₀ : (Λ[n+2, i] : SSet) ⟶ S)
-      (_h0 : 0 < i) (_hn : i < Fin.last (n+2)),
-      ∃ σ : S _⦋n+2⦌, ∀ (j) (h : j ≠ i), S.δ j σ = σ₀.app _ (horn.face i j h)) :
+    (filler : ∀ ⦃n : ℕ⦄ ⦃i : Fin (n + 3)⦄ (σ₀ : (Λ[n + 2, i] : SSet) ⟶ S)
+      (_h0 : 0 < i) (_hn : i < Fin.last (n + 2)),
+      ∃ σ : S _⦋n + 2⦌, ∀ (j) (h : j ≠ i), S.δ j σ = σ₀.app _ (horn.face i j h)) :
     Quasicategory S where
   hornFilling' n i σ₀ h₀ hₙ := by
     obtain ⟨σ, h⟩ := filler σ₀ h₀ hₙ

--- a/Mathlib/AlgebraicTopology/SimplexCategory/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/Basic.lean
@@ -402,8 +402,8 @@ def factor_δ {m n : ℕ} (f : ⦋m⦌ ⟶ ⦋n + 1⦌) (j : Fin (n + 2)) : ⦋m
   f ≫ σ (Fin.predAbove 0 j)
 
 open Fin in
-lemma factor_δ_spec {m n : ℕ} (f : ⦋m⦌ ⟶ ⦋n+1⦌) (j : Fin (n+2))
-    (hj : ∀ (k : Fin (m+1)), f.toOrderHom k ≠ j) :
+lemma factor_δ_spec {m n : ℕ} (f : ⦋m⦌ ⟶ ⦋n + 1⦌) (j : Fin (n + 2))
+    (hj : ∀ (k : Fin (m + 1)), f.toOrderHom k ≠ j) :
     factor_δ f j ≫ δ j = f := by
   ext k : 3
   specialize hj k

--- a/Mathlib/AlgebraicTopology/SimplexCategory/GeneratorsRelations/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/GeneratorsRelations/Basic.lean
@@ -155,7 +155,7 @@ lemma hom_induction' (P : MorphismProperty SimplexCategoryGenRel)
     (δ_comp : ∀ {n m : ℕ} (u : mk (m + 1) ⟶ mk n)
       (i : Fin (m + 2)), P u → P (δ i ≫ u))
     (σ_comp : ∀ {n m : ℕ} (u : mk m ⟶ mk n)
-      (i : Fin (m + 1)), P u → P (σ i ≫ u )) {a b : SimplexCategoryGenRel} (f : a ⟶ b) :
+      (i : Fin (m + 1)), P u → P (σ i ≫ u)) {a b : SimplexCategoryGenRel} (f : a ⟶ b) :
     P f := by
   suffices generators.multiplicativeClosure' ≤ P by
     rw [← MorphismProperty.multiplicativeClosure_eq_multiplicativeClosure',

--- a/Mathlib/AlgebraicTopology/SimplicialSet/HomotopyCat.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/HomotopyCat.lean
@@ -195,7 +195,7 @@ end
 
 section
 
-private lemma map_map_of_eq.{w}  {C : Type u} [Category.{v} C] (V : Cᵒᵖ ⥤ Type w) {X Y Z : C}
+private lemma map_map_of_eq.{w} {C : Type u} [Category.{v} C] (V : Cᵒᵖ ⥤ Type w) {X Y Z : C}
     {α : X ⟶ Y} {β : Y ⟶ Z} {γ : X ⟶ Z} {φ} :
     α ≫ β = γ → V.map α.op (V.map β.op φ) = V.map γ.op φ := by
   rintro rfl

--- a/Mathlib/AlgebraicTopology/SimplicialSet/Horn.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/Horn.lean
@@ -191,7 +191,7 @@ def face {n : ℕ} (i j : Fin (n + 2)) (h : j ≠ i) : (Λ[n+1, i] : SSet.{u}) _
 
 /-- Two morphisms from a horn are equal if they are equal on all suitable faces. -/
 protected
-lemma hom_ext {n : ℕ} {i : Fin (n+2)} {S : SSet} (σ₁ σ₂ : (Λ[n+1, i] : SSet.{u}) ⟶ S)
+lemma hom_ext {n : ℕ} {i : Fin (n + 2)} {S : SSet} (σ₁ σ₂ : (Λ[n + 1, i] : SSet.{u}) ⟶ S)
     (h : ∀ (j) (h : j ≠ i), σ₁.app _ (face i j h) = σ₂.app _ (face i j h)) :
     σ₁ = σ₂ := by
   rw [← Subpresheaf.equalizer_eq_iff]

--- a/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplex.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/StdSimplex.lean
@@ -118,7 +118,7 @@ def const (n : ℕ) (k : Fin (n + 1)) (m : SimplexCategoryᵒᵖ) : Δ[n].obj m 
   objMk (OrderHom.const _ k )
 
 @[simp]
-lemma const_down_toOrderHom (n : ℕ) (k : Fin (n+1)) (m : SimplexCategoryᵒᵖ) :
+lemma const_down_toOrderHom (n : ℕ) (k : Fin (n + 1)) (m : SimplexCategoryᵒᵖ) :
     (const n k m).down.toOrderHom = OrderHom.const _ k :=
   rfl
 
@@ -136,7 +136,7 @@ def edge (n : ℕ) (a b : Fin (n + 1)) (hab : a ≤ b) : Δ[n] _⦋1⦌ := by
   simp only [unop_op, len_mk, Fin.forall_fin_one]
   apply Fin.mk_le_mk.mpr hab
 
-lemma coe_edge_down_toOrderHom (n : ℕ) (a b : Fin (n+1)) (hab : a ≤ b) :
+lemma coe_edge_down_toOrderHom (n : ℕ) (a b : Fin (n + 1)) (hab : a ≤ b) :
     ↑(edge n a b hab).down.toOrderHom = ![a, b] :=
   rfl
 
@@ -148,7 +148,7 @@ def triangle {n : ℕ} (a b c : Fin (n + 1)) (hab : a ≤ b) (hbc : b ≤ c) : �
   dsimp
   simp only [*, true_and]
 
-lemma coe_triangle_down_toOrderHom {n : ℕ} (a b c : Fin (n+1)) (hab : a ≤ b) (hbc : b ≤ c) :
+lemma coe_triangle_down_toOrderHom {n : ℕ} (a b c : Fin (n + 1)) (hab : a ≤ b) (hbc : b ≤ c) :
     ↑(triangle a b c hab hbc).down.toOrderHom = ![a, b, c] :=
   rfl
 

--- a/Mathlib/Analysis/Analytic/CPolynomial.lean
+++ b/Mathlib/Analysis/Analytic/CPolynomial.lean
@@ -113,7 +113,7 @@ protected theorem hasFiniteFPowerSeriesOnBall :
     · rw [toFormalMultilinearSeries, dif_pos rfl]; rfl
     · intro m _ ne; rw [toFormalMultilinearSeries, dif_neg ne.symm]; rfl
 
-lemma cpolynomialAt  : CPolynomialAt 𝕜 f x :=
+lemma cpolynomialAt : CPolynomialAt 𝕜 f x :=
   f.hasFiniteFPowerSeriesOnBall.cpolynomialAt_of_mem
     (by simp only [Metric.emetric_ball_top, Set.mem_univ])
 

--- a/Mathlib/Analysis/Analytic/Constructions.lean
+++ b/Mathlib/Analysis/Analytic/Constructions.lean
@@ -1016,7 +1016,7 @@ lemma AnalyticWithinAt.zpow {f : E → 𝕝} {z : E} {s : Set E} {n : ℤ}
 
 /-- ZPowers of analytic functions (into a normed field over `𝕜`) are analytic away from the zeros.
 -/
-lemma AnalyticAt.fun_zpow {f : E → 𝕝} {z : E} {n : ℤ}  (h₁f : AnalyticAt 𝕜 f z) (h₂f : f z ≠ 0) :
+lemma AnalyticAt.fun_zpow {f : E → 𝕝} {z : E} {n : ℤ} (h₁f : AnalyticAt 𝕜 f z) (h₂f : f z ≠ 0) :
     AnalyticAt 𝕜 (fun x ↦ f x ^ n) z := by
   by_cases hn : 0 ≤ n
   · exact zpow_nonneg h₁f hn
@@ -1039,7 +1039,7 @@ lemma AnalyticOn.fun_zpow {f : E → 𝕝} {s : Set E} {n : ℤ} (h₁f : Analyt
 
 /-- ZPowers of analytic functions (into a normed field over `𝕜`) are analytic away from the zeros.
 -/
-lemma AnalyticOn.zpow {f : E → 𝕝} {s : Set E} {n : ℤ}  (h₁f : AnalyticOn 𝕜 f s)
+lemma AnalyticOn.zpow {f : E → 𝕝} {s : Set E} {n : ℤ} (h₁f : AnalyticOn 𝕜 f s)
     (h₂f : ∀ z ∈ s, f z ≠ 0) :
     AnalyticOn 𝕜 (f ^ n) s := by
   exact fun_zpow h₁f h₂f

--- a/Mathlib/Analysis/Analytic/Inverse.lean
+++ b/Mathlib/Analysis/Analytic/Inverse.lean
@@ -609,7 +609,7 @@ lemma HasFPowerSeriesAt.tendsto_partialSum_prod_of_comp
   congr with i
   exact i.elim0
 
-lemma HasFPowerSeriesAt.eventually_hasSum_of_comp  {f : E → F} {g : F → G}
+lemma HasFPowerSeriesAt.eventually_hasSum_of_comp {f : E → F} {g : F → G}
     {q : FormalMultilinearSeries 𝕜 F G} {p : FormalMultilinearSeries 𝕜 E F} {x : E}
     (hgf : HasFPowerSeriesAt (g ∘ f) (q.comp p) x) (hf : HasFPowerSeriesAt f p x)
     (hq : 0 < q.radius) :

--- a/Mathlib/Analysis/CStarAlgebra/CStarMatrix.lean
+++ b/Mathlib/Analysis/CStarAlgebra/CStarMatrix.lean
@@ -525,7 +525,7 @@ lemma toCLM_apply_single [DecidableEq m] {M : CStarMatrix m n A} {i : m} (a : A)
   simp [toCLM_apply, equiv, Equiv.refl]
 
 open WithCStarModule in
-lemma toCLM_apply_single_apply [DecidableEq m] {M : CStarMatrix m n A}{i : m} {j : n} (a : A) :
+lemma toCLM_apply_single_apply [DecidableEq m] {M : CStarMatrix m n A} {i : m} {j : n} (a : A) :
     (toCLM M) (equiv _ _ |>.symm <| Pi.single i a) j = a * M i j := by simp
 
 open WithCStarModule in

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Instances.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Instances.lean
@@ -239,7 +239,7 @@ end SelfAdjointUnital
 section Nonneg
 
 lemma CFC.exists_sqrt_of_isSelfAdjoint_of_quasispectrumRestricts {A : Type*} [NonUnitalRing A]
-    [StarRing A] [TopologicalSpace A] [Module ℝ A] [IsScalarTower ℝ A A] [SMulCommClass ℝ A A ]
+    [StarRing A] [TopologicalSpace A] [Module ℝ A] [IsScalarTower ℝ A A] [SMulCommClass ℝ A A]
     [NonUnitalContinuousFunctionalCalculus ℝ A IsSelfAdjoint]
     {a : A} (ha₁ : IsSelfAdjoint a) (ha₂ : QuasispectrumRestricts a ContinuousMap.realToNNReal) :
     ∃ x : A, IsSelfAdjoint x ∧ QuasispectrumRestricts x ContinuousMap.realToNNReal ∧ x * x = a := by
@@ -336,7 +336,7 @@ lemma cfcHom_real_eq_restrict {a : A} (ha : IsSelfAdjoint a) :
   ha.spectrumRestricts.cfcHom_eq_restrict _ Complex.isometry_ofReal.isUniformEmbedding
     ha ha.isStarNormal
 
-lemma cfc_real_eq_complex {a : A} (f : ℝ → ℝ) (ha : IsSelfAdjoint a := by cfc_tac)  :
+lemma cfc_real_eq_complex {a : A} (f : ℝ → ℝ) (ha : IsSelfAdjoint a := by cfc_tac) :
     cfc f a = cfc (fun x ↦ f x.re : ℂ → ℂ) a := by
   replace ha : IsSelfAdjoint a := ha -- hack to avoid issues caused by autoParam
   exact ha.spectrumRestricts.cfc_eq_restrict (f := Complex.reCLM)
@@ -356,7 +356,7 @@ lemma cfcₙHom_real_eq_restrict {a : A} (ha : IsSelfAdjoint a) :
   ha.quasispectrumRestricts.2.cfcₙHom_eq_restrict _ Complex.isometry_ofReal.isUniformEmbedding
     ha ha.isStarNormal
 
-lemma cfcₙ_real_eq_complex {a : A} (f : ℝ → ℝ) (ha : IsSelfAdjoint a := by cfc_tac)  :
+lemma cfcₙ_real_eq_complex {a : A} (f : ℝ → ℝ) (ha : IsSelfAdjoint a := by cfc_tac) :
     cfcₙ f a = cfcₙ (fun x ↦ f x.re : ℂ → ℂ) a := by
   replace ha : IsSelfAdjoint a := ha -- hack to avoid issues caused by autoParam
   exact ha.quasispectrumRestricts.2.cfcₙ_eq_restrict (f := Complex.reCLM)
@@ -378,7 +378,7 @@ lemma cfcHom_nnreal_eq_restrict {a : A} (ha : 0 ≤ a) :
       (cfcHom (IsSelfAdjoint.of_nonneg ha)) := by
   apply (SpectrumRestricts.nnreal_of_nonneg ha).cfcHom_eq_restrict _ isUniformEmbedding_subtype_val
 
-lemma cfc_nnreal_eq_real {a : A} (f : ℝ≥0 → ℝ≥0) (ha : 0 ≤ a := by cfc_tac)  :
+lemma cfc_nnreal_eq_real {a : A} (f : ℝ≥0 → ℝ≥0) (ha : 0 ≤ a := by cfc_tac) :
     cfc f a = cfc (fun x ↦ f x.toNNReal : ℝ → ℝ) a := by
   replace ha : 0 ≤ a := ha -- hack to avoid issues caused by autoParam
   apply (SpectrumRestricts.nnreal_of_nonneg ha).cfc_eq_restrict _

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Instances.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Instances.lean
@@ -401,7 +401,7 @@ lemma cfcₙHom_nnreal_eq_restrict {a : A} (ha : 0 ≤ a) :
   apply (QuasispectrumRestricts.nnreal_of_nonneg ha).cfcₙHom_eq_restrict _
     isUniformEmbedding_subtype_val
 
-lemma cfcₙ_nnreal_eq_real {a : A} (f : ℝ≥0 → ℝ≥0) (ha : 0 ≤ a := by cfc_tac)  :
+lemma cfcₙ_nnreal_eq_real {a : A} (f : ℝ≥0 → ℝ≥0) (ha : 0 ≤ a := by cfc_tac) :
     cfcₙ f a = cfcₙ (fun x ↦ f x.toNNReal : ℝ → ℝ) a := by
   replace ha : 0 ≤ a := ha -- hack to avoid issues caused by autoParam
   apply (QuasispectrumRestricts.nnreal_of_nonneg ha).cfcₙ_eq_restrict _

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/NonUnital.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/NonUnital.lean
@@ -552,7 +552,7 @@ lemma cfcₙ_neg_id (ha : p a := by cfc_tac) :
 
 variable [UniqueHom R A]
 
-lemma cfcₙ_comp_neg (hf : ContinuousOn f ((- ·) '' (σₙ R a)) := by cfc_cont_tac)
+lemma cfcₙ_comp_neg (hf : ContinuousOn f ((-·) '' (σₙ R a)) := by cfc_cont_tac)
     (h0 : f 0 = 0 := by cfc_zero_tac) (ha : p a := by cfc_tac) :
     cfcₙ (f <| - ·) a = cfcₙ f (-a) := by
   rw [cfcₙ_comp' .., cfcₙ_neg_id _]

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Unital.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Unital.lean
@@ -813,7 +813,7 @@ lemma cfc_zpow (a : Aˣ) (n : ℤ) (ha : p a := by cfc_tac) :
 variable [UniqueHom R A]
 
 lemma cfc_comp_inv (f : R → R) (a : Aˣ)
-    (hf : ContinuousOn f ((· ⁻¹) '' (spectrum R (a : A))) := by cfc_cont_tac)
+    (hf : ContinuousOn f ((·⁻¹) '' (spectrum R (a : A))) := by cfc_cont_tac)
     (ha : p a := by cfc_tac) :
     cfc (fun x ↦ f x⁻¹) (a : A) = cfc f (↑a⁻¹ : A) := by
   rw [cfc_comp' .., cfc_inv_id _]
@@ -856,7 +856,7 @@ lemma cfc_neg_id (ha : p a := by cfc_tac) : cfc (- · : R → R) a = -a := by
 
 variable [UniqueHom R A]
 
-lemma cfc_comp_neg (hf : ContinuousOn f ((- ·) '' (spectrum R (a : A))) := by cfc_cont_tac)
+lemma cfc_comp_neg (hf : ContinuousOn f ((-·) '' (spectrum R (a : A))) := by cfc_cont_tac)
     (ha : p a := by cfc_tac) : cfc (f <| - ·) a = cfc f (-a) := by
   rw [cfc_comp' .., cfc_neg_id _]
 
@@ -964,7 +964,7 @@ variable {A : Type*} [TopologicalSpace A] [Ring A] [StarRing A] [PartialOrder A]
 lemma CFC.inv_nonneg_of_nonneg (a : Aˣ) (ha : (0 : A) ≤ a := by cfc_tac) : (0 : A) ≤ a⁻¹ :=
   cfc_inv_id (R := ℝ≥0) a ▸ cfc_predicate _ (a : A)
 
-lemma CFC.inv_nonneg (a : Aˣ)  : (0 : A) ≤ a⁻¹ ↔ (0 : A) ≤ a :=
+lemma CFC.inv_nonneg (a : Aˣ) : (0 : A) ≤ a⁻¹ ↔ (0 : A) ≤ a :=
   ⟨fun _ ↦ inv_inv a ▸ inv_nonneg_of_nonneg a⁻¹, fun _ ↦ inv_nonneg_of_nonneg a⟩
 
 end NNReal

--- a/Mathlib/Analysis/Calculus/FDeriv/Analytic.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Analytic.lean
@@ -635,7 +635,7 @@ theorem _root_.HasFDerivAt.multilinear_comp
 /-- Technical lemma used in the proof of `hasFTaylorSeriesUpTo_iteratedFDeriv`, to compare sums
 over embedding of `Fin k` and `Fin (k + 1)`. -/
 private lemma _root_.Equiv.succ_embeddingFinSucc_fst_symm_apply {ι : Type*} [DecidableEq ι]
-    {n : ℕ} (e : Fin (n+1) ↪ ι) {k : ι}
+    {n : ℕ} (e : Fin (n + 1) ↪ ι) {k : ι}
     (h'k : k ∈ Set.range (Equiv.embeddingFinSucc n ι e).1) (hk : k ∈ Set.range e) :
     Fin.succ ((Equiv.embeddingFinSucc n ι e).1.toEquivRange.symm ⟨k, h'k⟩)
       = e.toEquivRange.symm ⟨k, hk⟩ := by

--- a/Mathlib/Analysis/Calculus/FormalMultilinearSeries.lean
+++ b/Mathlib/Analysis/Calculus/FormalMultilinearSeries.lean
@@ -358,7 +358,7 @@ theorem constFormalMultilinearSeries_apply [NontriviallyNormedField 𝕜] [Norme
   Nat.casesOn n (fun hn => (hn rfl).elim) (fun _ _ => rfl) hn
 
 @[simp]
-lemma constFormalMultilinearSeries_zero [NontriviallyNormedField 𝕜] [NormedAddCommGroup E ]
+lemma constFormalMultilinearSeries_zero [NontriviallyNormedField 𝕜] [NormedAddCommGroup E]
     [NormedAddCommGroup F] [NormedSpace 𝕜 E] [NormedSpace 𝕜 F] :
     constFormalMultilinearSeries 𝕜 E (0 : F) = 0 := by
   ext n x

--- a/Mathlib/Analysis/Calculus/VectorField.lean
+++ b/Mathlib/Analysis/Calculus/VectorField.lean
@@ -123,7 +123,7 @@ lemma lieBracket_add_left (hV : DifferentiableAt 𝕜 V x) (hV₁ : Differentiab
   abel
 
 lemma lieBracketWithin_add_right (hW : DifferentiableWithinAt 𝕜 W s x)
-    (hW₁ : DifferentiableWithinAt 𝕜 W₁ s x) (hs :  UniqueDiffWithinAt 𝕜 s x) :
+    (hW₁ : DifferentiableWithinAt 𝕜 W₁ s x) (hs : UniqueDiffWithinAt 𝕜 s x) :
     lieBracketWithin 𝕜 V (W + W₁) s x =
       lieBracketWithin 𝕜 V W s x + lieBracketWithin 𝕜 V W₁ s x := by
   simp only [lieBracketWithin, Pi.add_apply, map_add]

--- a/Mathlib/Analysis/Complex/Hadamard.lean
+++ b/Mathlib/Analysis/Complex/Hadamard.lean
@@ -410,7 +410,7 @@ lemma sSupNormIm_scale_right (f : ℂ → E) {l u : ℝ} (hul : l < u) :
 
 /-- A technical lemma relating the bounds given by the three lines lemma on a general strip
 to the bounds for its scaled version on the strip ``re ⁻¹' [0, 1]`. -/
-lemma interpStrip_scale (f : ℂ → E) {l u : ℝ} (hul: l < u) (z : ℂ)  : interpStrip (scale f l u)
+lemma interpStrip_scale (f : ℂ → E) {l u : ℝ} (hul : l < u) (z : ℂ) : interpStrip (scale f l u)
     ((z - ↑l) / (↑u - ↑l)) = interpStrip' f l u z := by
   simp only [interpStrip, interpStrip']
   simp_rw [sSupNormIm_scale_left f hul, sSupNormIm_scale_right f hul]
@@ -611,7 +611,7 @@ closed strip `re ⁻¹' [l, u]` and differentiable on open strip `re ⁻¹' (l, 
 `re ⁻¹' [a,b]` the inequality
 `‖f(z)‖ ≤ M(0) ^ (1 - ((z.re - l) / (u - l))) * M(1) ^ ((z.re - l) / (u - l))`
 holds. -/
-lemma norm_le_interpStrip_of_mem_verticalClosedStrip {l u : ℝ} (hul: l < u)
+lemma norm_le_interpStrip_of_mem_verticalClosedStrip {l u : ℝ} (hul : l < u)
     {f : ℂ → E} {z : ℂ}
     (hz : z ∈ verticalClosedStrip l u) (hd : DiffContOnCl ℂ f (verticalStrip l u))
     (hB : BddAbove ((norm ∘ f) '' verticalClosedStrip l u)) :

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Topology.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Topology.lean
@@ -167,7 +167,7 @@ lemma comp_ofComplex (f : ℍ → ℂ) (z : ℍ) : (↑ₕ f) z = f z :=
 lemma comp_ofComplex_of_im_pos (f : ℍ → ℂ) (z : ℂ) (hz : 0 < z.im) : (↑ₕ f) z = f ⟨z, hz⟩ :=
   congrArg _ <| ofComplex_apply ⟨z, hz⟩
 
-lemma comp_ofComplex_of_im_le_zero (f : ℍ → ℂ) (z z' : ℂ) (hz : z.im ≤ 0) (hz' : z'.im ≤ 0)  :
+lemma comp_ofComplex_of_im_le_zero (f : ℍ → ℂ) (z z' : ℂ) (hz : z.im ≤ 0) (hz' : z'.im ≤ 0) :
     (↑ₕ f) z = (↑ₕ f) z' := by
   simp [ofComplex_apply_of_im_nonpos, hz, hz']
 

--- a/Mathlib/Analysis/Convex/Deriv.lean
+++ b/Mathlib/Analysis/Convex/Deriv.lean
@@ -791,7 +791,7 @@ section right
 /-- If `f : ℝ → ℝ` is strictly convex on `S` and differentiable at `y ∈ S`, then the slope of any
 secant line with right endpoint at `y` is strictly less than the left derivative at `y`. -/
 lemma slope_lt_of_hasDerivWithinAt_Iio (hfc : StrictConvexOn ℝ S f)
-    (hx : x ∈ S) (hy : y ∈ S) (hxy : x < y) (hf' : HasDerivWithinAt f f' (Iio y) y)  :
+    (hx : x ∈ S) (hy : y ∈ S) (hxy : x < y) (hf' : HasDerivWithinAt f f' (Iio y) y) :
     slope f x y < f' := by
   obtain ⟨u, hxu, huy⟩ := exists_between hxy
   have hu : u ∈ S := hfc.1.ordConnected.out hx hy ⟨hxu.le, huy.le⟩
@@ -800,7 +800,7 @@ lemma slope_lt_of_hasDerivWithinAt_Iio (hfc : StrictConvexOn ℝ S f)
   exact this.trans_le <| hfc.convexOn.slope_le_of_hasDerivWithinAt_Iio hu hy huy hf'
 
 lemma slope_lt_leftDeriv (hfc : StrictConvexOn ℝ S f) (hx : x ∈ S) (hy : y ∈ S) (hxy : x < y)
-    (hfd : DifferentiableWithinAt ℝ f (Iio y) y)  :
+    (hfd : DifferentiableWithinAt ℝ f (Iio y) y) :
     slope f x y < derivWithin f (Iio y) y :=
   hfc.slope_lt_of_hasDerivWithinAt_Iio hx hy hxy hfd.hasDerivWithinAt
 

--- a/Mathlib/Analysis/Fourier/FourierTransformDeriv.lean
+++ b/Mathlib/Analysis/Fourier/FourierTransformDeriv.lean
@@ -441,7 +441,7 @@ lemma integrable_fourierPowSMulRight {n : ℕ} (hf : Integrable (fun v ↦ ‖v�
   exact (norm_fourierPowSMulRight_le L f v n).trans (le_of_eq (by ring))
 
 lemma hasFTaylorSeriesUpTo_fourierIntegral {N : WithTop ℕ∞}
-    (hf : ∀ (n : ℕ), n ≤ N → Integrable (fun v ↦ ‖v‖^n * ‖f v‖) μ)
+    (hf : ∀ (n : ℕ), n ≤ N → Integrable (fun v ↦ ‖v‖ ^ n * ‖f v‖) μ)
     (h'f : AEStronglyMeasurable f μ) :
     HasFTaylorSeriesUpTo N (fourierIntegral 𝐞 μ L.toLinearMap₂ f)
       (fun w n ↦ fourierIntegral 𝐞 μ L.toLinearMap₂ (fun v ↦ fourierPowSMulRight L f v n) w) := by
@@ -493,7 +493,7 @@ lemma hasFTaylorSeriesUpTo_fourierIntegral {N : WithTop ℕ∞}
 to `ℕ∞` (and so are the inequalities in the assumption `hf`). Avoids normcasting in some
 applications. -/
 lemma hasFTaylorSeriesUpTo_fourierIntegral' {N : ℕ∞}
-    (hf : ∀ (n : ℕ), n ≤ N → Integrable (fun v ↦ ‖v‖^n * ‖f v‖) μ)
+    (hf : ∀ (n : ℕ), n ≤ N → Integrable (fun v ↦ ‖v‖ ^ n * ‖f v‖) μ)
     (h'f : AEStronglyMeasurable f μ) :
     HasFTaylorSeriesUpTo N (fourierIntegral 𝐞 μ L.toLinearMap₂ f)
       (fun w n ↦ fourierIntegral 𝐞 μ L.toLinearMap₂ (fun v ↦ fourierPowSMulRight L f v n) w) :=
@@ -513,7 +513,7 @@ theorem contDiff_fourierIntegral {N : ℕ∞}
 transform of `f` is the Fourier transform of `fourierPowSMulRight L f v n`,
 i.e., `(L v ⬝) ^ n • f v`. -/
 lemma iteratedFDeriv_fourierIntegral {N : ℕ∞}
-    (hf : ∀ (n : ℕ), n ≤ N → Integrable (fun v ↦ ‖v‖^n * ‖f v‖) μ)
+    (hf : ∀ (n : ℕ), n ≤ N → Integrable (fun v ↦ ‖v‖ ^ n * ‖f v‖) μ)
     (h'f : AEStronglyMeasurable f μ) {n : ℕ} (hn : n ≤ N) :
     iteratedFDeriv ℝ n (fourierIntegral 𝐞 μ L.toLinearMap₂ f) =
       fourierIntegral 𝐞 μ L.toLinearMap₂ (fun v ↦ fourierPowSMulRight L f v n) := by
@@ -631,7 +631,7 @@ in terms of integrals of iterated derivatives of `f` (of order up to `n`) multip
 (for `i ≤ k`). -/
 lemma pow_mul_norm_iteratedFDeriv_fourierIntegral_le [FiniteDimensional ℝ V]
     {μ : Measure V} [Measure.IsAddHaarMeasure μ] {K N : ℕ∞} (hf : ContDiff ℝ N f)
-    (h'f : ∀ (k n : ℕ), k ≤ K → n ≤ N → Integrable (fun v ↦ ‖v‖^k * ‖iteratedFDeriv ℝ n f v‖) μ)
+    (h'f : ∀ (k n : ℕ), k ≤ K → n ≤ N → Integrable (fun v ↦ ‖v‖ ^ k * ‖iteratedFDeriv ℝ n f v‖) μ)
     {k n : ℕ} (hk : k ≤ K) (hn : n ≤ N) (v : V) (w : W) :
     |L v w| ^ n * ‖(iteratedFDeriv ℝ k (fourierIntegral 𝐞 μ L.toLinearMap₂ f)) w‖ ≤
       ‖v‖ ^ n * (2 * π * ‖L‖) ^ k * (2 * k + 2) ^ n *
@@ -723,7 +723,7 @@ theorem fourierIntegral_iteratedFDeriv {N : ℕ∞} (hf : ContDiff ℝ N f)
 at most `n`) multiplied by powers of `v` (of order at most `k`). -/
 lemma pow_mul_norm_iteratedFDeriv_fourierIntegral_le
     {K N : ℕ∞} (hf : ContDiff ℝ N f)
-    (h'f : ∀ (k n : ℕ), k ≤ K → n ≤ N → Integrable (fun v ↦ ‖v‖^k * ‖iteratedFDeriv ℝ n f v‖))
+    (h'f : ∀ (k n : ℕ), k ≤ K → n ≤ N → Integrable (fun v ↦ ‖v‖ ^ k * ‖iteratedFDeriv ℝ n f v‖))
     {k n : ℕ} (hk : k ≤ K) (hn : n ≤ N) (w : V) :
     ‖w‖ ^ n * ‖iteratedFDeriv ℝ k (𝓕 f) w‖ ≤ (2 * π) ^ k * (2 * k + 2) ^ n *
       ∑ p ∈ Finset.range (k + 1) ×ˢ Finset.range (n + 1),

--- a/Mathlib/Analysis/NormedSpace/MultipliableUniformlyOn.lean
+++ b/Mathlib/Analysis/NormedSpace/MultipliableUniformlyOn.lean
@@ -146,7 +146,7 @@ lemma hasProdLocallyUniformlyOn_nat_one_add {f : ℕ → α → R} (hK : IsOpen 
     HasProdLocallyUniformlyOn (fun n x ↦ 1 + f n x) (fun x ↦ ∏' i, (1 + f i x)) K :=
   hasProdLocallyUniformlyOn_one_add hK hu (Nat.cofinite_eq_atTop ▸ h) hcts
 
-lemma multipliableLocallyUniformlyOn_nat_one_add  {f : ℕ → α → R} (hK : IsOpen K) {u : ℕ → ℝ}
+lemma multipliableLocallyUniformlyOn_nat_one_add {f : ℕ → α → R} (hK : IsOpen K) {u : ℕ → ℝ}
     (hu : Summable u) (h : ∀ᶠ n in atTop, ∀ x ∈ K, ‖f n x‖ ≤ u n)
     (hcts : ∀ n, ContinuousOn (f n) K) :
     MultipliableLocallyUniformlyOn (fun n x ↦ 1 + f n x) K :=

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm/Prod.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm/Prod.lean
@@ -154,7 +154,7 @@ variable (𝕜 E F)
 
 /-- The operator norm of the second projection `E × F → F` is exactly 1 if `F` is nontrivial. -/
 @[simp] lemma norm_snd [SeminormedAddCommGroup E] [NormedSpace 𝕜 E]
-    [NormedAddCommGroup F] [NormedSpace 𝕜 F] [Nontrivial F]  :
+    [NormedAddCommGroup F] [NormedSpace 𝕜 F] [Nontrivial F] :
     ‖snd 𝕜 E F‖ = 1 := by
   refine le_antisymm (norm_snd_le ..) ?_
   let ⟨f, hf⟩ := exists_ne (0 : F)

--- a/Mathlib/Analysis/SpecialFunctions/Complex/LogBounds.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/LogBounds.lean
@@ -200,7 +200,7 @@ lemma norm_log_one_add_le {z : ℂ} (hz : ‖z‖ < 1) :
   exact norm_add_le_of_le (Complex.norm_log_one_add_sub_self_le hz) le_rfl
 
 /-- For `‖z‖ ≤ 1/2`, the complex logarithm is bounded by `(3/2) * ‖z‖`. -/
-lemma norm_log_one_add_half_le_self {z : ℂ} (hz : ‖z‖ ≤ 1/2) : ‖log (1 + z)‖ ≤ (3/2) * ‖z‖ := by
+lemma norm_log_one_add_half_le_self {z : ℂ} (hz : ‖z‖ ≤ 1 / 2) : ‖log (1 + z)‖ ≤ (3/2) * ‖z‖ := by
   apply le_trans (norm_log_one_add_le (lt_of_le_of_lt hz one_half_lt_one))
   have hz3 : (1 - ‖z‖)⁻¹ ≤ 2 := by
     rw [inv_eq_one_div, div_le_iff₀]

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckAxioms/Basic.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckAxioms/Basic.lean
@@ -365,7 +365,7 @@ lemma hasExactColimitsOfShape_of_final [HasFiniteLimits C] {J J' : Type*} [Categ
 
 /-- `HasExactLimitsOfShape` can be "pushed forward" along initial functors -/
 lemma hasExactLimitsOfShape_of_initial [HasFiniteColimits C] {J J' : Type*} [Category J]
-    [Category J'] (F : J ⥤ J') [F.Initial]  [HasLimitsOfShape J' C] [HasLimitsOfShape J C]
+    [Category J'] (F : J ⥤ J') [F.Initial] [HasLimitsOfShape J' C] [HasLimitsOfShape J C]
     [HasExactLimitsOfShape J C] : HasExactLimitsOfShape J' C where
   preservesFiniteColimits :=
     letI : PreservesFiniteColimits ((whiskeringLeft J J' C).obj F) := ⟨fun _ ↦ inferInstance⟩

--- a/Mathlib/CategoryTheory/Adjunction/Lifting/Right.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Lifting/Right.lean
@@ -169,7 +169,7 @@ See https://ncatlab.org/nlab/show/adjoint+triangle+theorem
 -/
 lemma isLeftAdjoint_triangle_lift {U : A ⥤ B} {F : B ⥤ A} (L : C ⥤ B) (adj₁ : F ⊣ U)
     [∀ X, RegularMono (adj₁.unit.app X)] [HasCoreflexiveEqualizers C]
-    [(L ⋙ F).IsLeftAdjoint ] : L.IsLeftAdjoint where
+    [(L ⋙ F).IsLeftAdjoint] : L.IsLeftAdjoint where
   exists_rightAdjoint :=
     ⟨LiftRightAdjoint.constructRightAdjoint L _ adj₁ (Adjunction.ofIsLeftAdjoint _),
       ⟨Adjunction.adjunctionOfEquivRight _ _⟩⟩

--- a/Mathlib/CategoryTheory/ComposableArrows.lean
+++ b/Mathlib/CategoryTheory/ComposableArrows.lean
@@ -704,9 +704,9 @@ lemma hom_ext₄ {f g : ComposableArrows C 4} {φ φ' : f ⟶ g}
     φ = φ' :=
   hom_ext_succ h₀ (hom_ext₃ h₁ h₂ h₃ h₄)
 
-lemma map'_inv_eq_inv_map' {n m : ℕ} (h : n+1 ≤ m) {f g : ComposableArrows C m}
-    (app : f.obj' n ≅ g.obj' n) (app' : f.obj' (n+1) ≅ g.obj' (n+1))
-    (w : f.map' n (n+1) ≫ app'.hom = app.hom ≫ g.map' n (n+1)) :
+lemma map'_inv_eq_inv_map' {n m : ℕ} (h : n + 1 ≤ m) {f g : ComposableArrows C m}
+    (app : f.obj' n ≅ g.obj' n) (app' : f.obj' (n + 1) ≅ g.obj' (n + 1))
+    (w : f.map' n (n + 1) ≫ app'.hom = app.hom ≫ g.map' n (n + 1)) :
     map' g n (n+1) ≫ app'.inv = app.inv ≫ map' f n (n+1) := by
   rw [← cancel_epi app.hom, ← reassoc_of% w, app'.hom_inv_id, comp_id, app.hom_inv_id_assoc]
 

--- a/Mathlib/CategoryTheory/EffectiveEpi/Preserves.lean
+++ b/Mathlib/CategoryTheory/EffectiveEpi/Preserves.lean
@@ -172,7 +172,7 @@ class ReflectsEffectiveEpiFamilies (F : C ⥤ D) : Prop where
 
 lemma effectiveEpiFamily_of_map (F : C ⥤ D) [ReflectsEffectiveEpiFamilies.{u} F]
     {α : Type u} {B : C} (X : α → C) (π : (a : α) → (X a ⟶ B))
-    (h : EffectiveEpiFamily (fun a ↦ F.obj (X a)) (fun a  ↦ F.map (π a))) :
+    (h : EffectiveEpiFamily (fun a ↦ F.obj (X a)) (fun a ↦ F.map (π a))) :
     EffectiveEpiFamily X π :=
   ReflectsEffectiveEpiFamilies.reflects X π h
 
@@ -190,7 +190,7 @@ class ReflectsFiniteEffectiveEpiFamilies (F : C ⥤ D) : Prop where
 
 lemma finite_effectiveEpiFamily_of_map (F : C ⥤ D) [ReflectsFiniteEffectiveEpiFamilies F]
     {α : Type} [Finite α] {B : C} (X : α → C) (π : (a : α) → (X a ⟶ B))
-    (h : EffectiveEpiFamily (fun a ↦ F.obj (X a)) (fun a  ↦ F.map (π a))) :
+    (h : EffectiveEpiFamily (fun a ↦ F.obj (X a)) (fun a ↦ F.map (π a))) :
     EffectiveEpiFamily X π :=
   ReflectsFiniteEffectiveEpiFamilies.reflects X π h
 

--- a/Mathlib/CategoryTheory/Enriched/Ordinary/Basic.lean
+++ b/Mathlib/CategoryTheory/Enriched/Ordinary/Basic.lean
@@ -127,7 +127,7 @@ lemma eComp_eHomWhiskerLeft (X Y : C) {Z Z' : C} (g : Z ⟶ Z') :
 object `(X ⟶[V] Y₁) ⊗ (Y₁ ⟶[V] Z)` via the map defined by whiskering in the
 middle with `α.hom` and `α.inv`. -/
 @[reassoc]
-lemma eHom_whisker_cancel {X Y Y₁ Z : C} (α : Y  ≅ Y₁) :
+lemma eHom_whisker_cancel {X Y Y₁ Z : C} (α : Y ≅ Y₁) :
     eHomWhiskerLeft V X α.hom ▷ _ ≫ _ ◁ eHomWhiskerRight V α.inv Z ≫
       eComp V X Y₁ Z = eComp V X Y Z := by
   dsimp [eHomWhiskerLeft, eHomWhiskerRight]
@@ -138,7 +138,7 @@ lemma eHom_whisker_cancel {X Y Y₁ Z : C} (α : Y  ≅ Y₁) :
   simp [← eHomWhiskerLeft_comp]
 
 @[reassoc]
-lemma eHom_whisker_cancel_inv {X Y Y₁ Z : C} (α : Y  ≅ Y₁) :
+lemma eHom_whisker_cancel_inv {X Y Y₁ Z : C} (α : Y ≅ Y₁) :
     eHomWhiskerLeft V X α.inv ▷ _ ≫ _ ◁ eHomWhiskerRight V α.hom Z ≫
       eComp V X Y Z = eComp V X Y₁ Z := eHom_whisker_cancel V α.symm
 

--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -141,7 +141,7 @@ lemma asNatTrans_mkHom {e f : C ≌ D} (η : e ⟶ f) :
 lemma id_asNatTrans {e : C ≌ D} : asNatTrans (𝟙 e) = 𝟙 _ := rfl
 
 @[simp, reassoc]
-lemma comp_asNatTrans {e f g: C ≌ D} (α : e ⟶ f) (β : f ⟶ g) :
+lemma comp_asNatTrans {e f g : C ≌ D} (α : e ⟶ f) (β : f ⟶ g) :
     asNatTrans (α ≫ β) = asNatTrans α ≫ asNatTrans β :=
   rfl
 
@@ -149,7 +149,7 @@ lemma comp_asNatTrans {e f g: C ≌ D} (α : e ⟶ f) (β : f ⟶ g) :
 lemma mkHom_id_functor {e : C ≌ D} : mkHom (𝟙 e.functor) = 𝟙 e := rfl
 
 @[simp, reassoc]
-lemma mkHom_comp {e f g: C ≌ D} (α : e.functor ⟶ f.functor) (β : f.functor ⟶ g.functor) :
+lemma mkHom_comp {e f g : C ≌ D} (α : e.functor ⟶ f.functor) (β : f.functor ⟶ g.functor) :
     mkHom (α ≫ β) = mkHom α ≫ mkHom β :=
   rfl
 

--- a/Mathlib/CategoryTheory/Equivalence/Symmetry.lean
+++ b/Mathlib/CategoryTheory/Equivalence/Symmetry.lean
@@ -78,7 +78,7 @@ def inverseFunctorObjIso (e : C ≌ D) :
 /-- We can compare the way we obtain a natural isomorphism `e.inverse ≅ f.inverse` from
 an isomorphism `e ≌ f` via `inverseFunctor` with the way we get one through
 `Iso.isoInverseOfIsoFunctor`. -/
-lemma inverseFunctorMapIso_symm_eq_isoInverseOfIsoFunctor {e f: C ≌ D} (α : e ≅ f) :
+lemma inverseFunctorMapIso_symm_eq_isoInverseOfIsoFunctor {e f : C ≌ D} (α : e ≅ f) :
     Iso.unop ((inverseFunctor C D).mapIso α.symm) =
     Iso.isoInverseOfIsoFunctor ((functorFunctor _ _).mapIso α) := by
   aesop_cat

--- a/Mathlib/CategoryTheory/Filtered/Final.lean
+++ b/Mathlib/CategoryTheory/Filtered/Final.lean
@@ -463,7 +463,7 @@ end CategoryTheory
 open CategoryTheory
 
 lemma Monotone.final_functor_iff {J₁ J₂ : Type*} [Preorder J₁] [Preorder J₂]
-    [IsDirected J₁ (· ≤ · )] {f : J₁ → J₂} (hf : Monotone f) :
+    [IsDirected J₁ (· ≤ ·)] {f : J₁ → J₂} (hf : Monotone f) :
     hf.functor.Final ↔ ∀ (j₂ : J₂), ∃ (j₁ : J₁), j₂ ≤ f j₁ := by
   rw [Functor.final_iff_of_isFiltered]
   constructor

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Pointwise.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Pointwise.lean
@@ -546,7 +546,7 @@ def costructuredArrowMapCocone (G : D ⥤ H) (α : F ⟶ L ⋙ G) (Y : D) :
     naturality := by simp [← G.map_comp] }
 
 @[simp]
-lemma pointwiseLeftKanExtension_desc_app (G : D ⥤ H) (α :  F ⟶ L ⋙ G) (Y : D) :
+lemma pointwiseLeftKanExtension_desc_app (G : D ⥤ H) (α : F ⟶ L ⋙ G) (Y : D) :
     ((pointwiseLeftKanExtension L F).descOfIsLeftKanExtension (pointwiseLeftKanExtensionUnit L F)
       G α |>.app Y) = colimit.desc _ (costructuredArrowMapCocone L F G α Y) := by
   let β : L.pointwiseLeftKanExtension F ⟶ G :=

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Preserves.lean
@@ -41,7 +41,7 @@ class PreservesLeftKanExtension where
 for a similar constructor taking as input a single `LeftExtension`. -/
 lemma PreservesLeftKanExtension.mk'
     (preserves : ∀ {E : LeftExtension L F}, E.IsUniversal →
-      Nonempty (LeftExtension.postcompose₂ L F G|>.obj E).IsUniversal) :
+      Nonempty (LeftExtension.postcompose₂ L F G |>.obj E).IsUniversal) :
     G.PreservesLeftKanExtension F L where
   preserves _ _ h :=
     ⟨⟨Limits.IsInitial.equivOfIso
@@ -63,7 +63,7 @@ lemma PreservesLeftKanExtension.mk_of_preserves_isLeftKanExtension
 /-- Show that `G` preserves left Kan extensions if it maps some left Kan extension to a left
 Kan extension, phrased in terms of `IsUniversal`. -/
 lemma PreservesLeftKanExtension.mk_of_preserves_isUniversal (E : LeftExtension L F)
-    (hE : E.IsUniversal) (h : Nonempty (LeftExtension.postcompose₂ L F G|>.obj E).IsUniversal) :
+    (hE : E.IsUniversal) (h : Nonempty (LeftExtension.postcompose₂ L F G |>.obj E).IsUniversal) :
     G.PreservesLeftKanExtension F L :=
   .mk' G F L fun hE' ↦
     ⟨Limits.IsInitial.equivOfIso
@@ -113,7 +113,7 @@ def LeftExtension.coconeAtWhiskerRightIso (E : LeftExtension L F) (c : C) :
 all of them. -/
 lemma PreservesPointwiseLeftKanExtensionAt.mk' (c : C) {E : LeftExtension L F}
   (hE : E.IsPointwiseLeftKanExtensionAt c)
-  (hGE : (LeftExtension.postcompose₂ L F G|>.obj E).IsPointwiseLeftKanExtensionAt c) :
+  (hGE : (LeftExtension.postcompose₂ L F G |>.obj E).IsPointwiseLeftKanExtensionAt c) :
     G.PreservesPointwiseLeftKanExtensionAt F L c where
   preserves E' hE' :=
     ⟨Limits.IsColimit.ofIsoColimit hGE <|
@@ -293,7 +293,7 @@ class PreservesRightKanExtension where
 for a similar constructor taking as input a single `RightExtension`. -/
 lemma PreservesRightKanExtension.mk'
     (preserves : ∀ {E : RightExtension L F}, E.IsUniversal →
-      Nonempty (RightExtension.postcompose₂ L F G|>.obj E).IsUniversal) :
+      Nonempty (RightExtension.postcompose₂ L F G |>.obj E).IsUniversal) :
     G.PreservesRightKanExtension F L where
   preserves _ _ h :=
     ⟨⟨Limits.IsTerminal.equivOfIso
@@ -303,7 +303,7 @@ lemma PreservesRightKanExtension.mk'
 Kan extension. -/
 lemma PreservesRightKanExtension.mk_of_preserves_isRightKanExtension
     (F' : C ⥤ B) (α : L ⋙ F' ⟶ F) [IsRightKanExtension F' α]
-    (h : IsRightKanExtension (F' ⋙ G) <| (Functor.associator _ _ _).inv ≫ whiskerRight α G ) :
+    (h : IsRightKanExtension (F' ⋙ G) <| (Functor.associator _ _ _).inv ≫ whiskerRight α G) :
     G.PreservesRightKanExtension F L :=
   .mk fun F'' α' h ↦
     isRightKanExtension_of_iso
@@ -315,7 +315,7 @@ lemma PreservesRightKanExtension.mk_of_preserves_isRightKanExtension
 /-- Show that `G` preserves right Kan extensions if it maps some right Kan extension to a left
 Kan extension, phrased in terms of `IsUniversal`. -/
 lemma PreservesRightKanExtension.mk_of_preserves_isUniversal (E : RightExtension L F)
-    (hE : E.IsUniversal) (h : Nonempty (RightExtension.postcompose₂ L F G|>.obj E).IsUniversal) :
+    (hE : E.IsUniversal) (h : Nonempty (RightExtension.postcompose₂ L F G |>.obj E).IsUniversal) :
     G.PreservesRightKanExtension F L :=
   .mk' G F L fun hE' ↦
     ⟨Limits.IsTerminal.equivOfIso
@@ -364,7 +364,7 @@ def RightExtension.coneAtWhiskerRightIso (E : RightExtension L F) (c : C) :
 all of them. -/
 lemma PreservesPointwiseRightKanExtensionAt.mk' (c : C) {E : RightExtension L F}
   (hE : E.IsPointwiseRightKanExtensionAt c)
-  (hGE : (RightExtension.postcompose₂ L F G|>.obj E).IsPointwiseRightKanExtensionAt c) :
+  (hGE : (RightExtension.postcompose₂ L F G |>.obj E).IsPointwiseRightKanExtensionAt c) :
     G.PreservesPointwiseRightKanExtensionAt F L c where
   preserves E' hE' :=
     ⟨Limits.IsLimit.ofIsoLimit hGE <|

--- a/Mathlib/CategoryTheory/GradedObject.lean
+++ b/Mathlib/CategoryTheory/GradedObject.lean
@@ -302,7 +302,7 @@ for all `j : J`, the coproduct of all `X i` such `p i = j` exists. -/
 abbrev HasMap : Prop := ∀ (j : J), HasCoproduct (X.mapObjFun p j)
 
 variable {X Y} in
-lemma hasMap_of_iso (e : X ≅ Y) (p: I → J) [HasMap X p] : HasMap Y p := fun j => by
+lemma hasMap_of_iso (e : X ≅ Y) (p : I → J) [HasMap X p] : HasMap Y p := fun j => by
   have α : Discrete.functor (X.mapObjFun p j) ≅ Discrete.functor (Y.mapObjFun p j) :=
     Discrete.natIso (fun ⟨i, _⟩ => (GradedObject.eval i).mapIso e)
   exact hasColimit_of_iso α.symm

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -446,11 +446,11 @@ def preInv (G : D ≌ C) : Grothendieck F ⥤ Grothendieck (G.functor ⋙ F) :=
   map (whiskerRight G.counitInv F) ⋙ Grothendieck.pre (G.functor ⋙ F) G.inverse
 
 variable {F} in
-lemma pre_comp_map (G: D ⥤ C) {H : C ⥤ Cat} (α : F ⟶ H) :
+lemma pre_comp_map (G : D ⥤ C) {H : C ⥤ Cat} (α : F ⟶ H) :
     pre F G ⋙ map α = map (whiskerLeft G α) ⋙ pre H G := rfl
 
 variable {F} in
-lemma pre_comp_map_assoc (G: D ⥤ C) {H : C ⥤ Cat} (α : F ⟶ H) {E : Type*} [Category E]
+lemma pre_comp_map_assoc (G : D ⥤ C) {H : C ⥤ Cat} (α : F ⟶ H) {E : Type*} [Category E]
     (K : Grothendieck H ⥤ E) : pre F G ⋙ map α ⋙ K= map (whiskerLeft G α) ⋙ pre H G ⋙ K := rfl
 
 variable {E : Type*} [Category E] in

--- a/Mathlib/CategoryTheory/Join/Basic.lean
+++ b/Mathlib/CategoryTheory/Join/Basic.lean
@@ -505,7 +505,7 @@ lemma mapWhiskerLeft_comp {Fᵣ : D ⥤ E'} {Gᵣ : D ⥤ E'} {Hᵣ : D ⥤ E'}
   aesop_cat
 
 @[simp]
-lemma mapWhiskerLeft_id  (H : C ⥤ E) (Fᵣ : D ⥤ E') :
+lemma mapWhiskerLeft_id (H : C ⥤ E) (Fᵣ : D ⥤ E') :
     mapWhiskerLeft H (𝟙 Fᵣ) = 𝟙 _ := by
   aesop_cat
 

--- a/Mathlib/CategoryTheory/Join/Pseudofunctor.lean
+++ b/Mathlib/CategoryTheory/Join/Pseudofunctor.lean
@@ -58,7 +58,7 @@ lemma mapWhiskerRight_whiskerLeft (F : A ⥤ B) {G H : B ⥤ C} (η : G ⟶ H) :
 
 variable (A) in
 @[reassoc]
-lemma mapWhiskerLeft_whiskerRight {F G: B ⥤ C} (η : F ⟶ G) (H : C ⥤ D) :
+lemma mapWhiskerLeft_whiskerRight {F G : B ⥤ C} (η : F ⟶ G) (H : C ⥤ D) :
     mapWhiskerLeft _ (whiskerRight η H) =
     (mapCompRight A F H).hom ≫ whiskerRight (mapWhiskerLeft _ η) (mapPair (𝟭 A) H) ≫
       (mapCompRight A G H).inv := by
@@ -66,7 +66,7 @@ lemma mapWhiskerLeft_whiskerRight {F G: B ⥤ C} (η : F ⟶ G) (H : C ⥤ D) :
 
 variable (D) in
 @[reassoc]
-lemma mapWhiskerRight_whiskerRight {F G: A ⥤ B} (η : F ⟶ G) (H : B ⥤ C) :
+lemma mapWhiskerRight_whiskerRight {F G : A ⥤ B} (η : F ⟶ G) (H : B ⥤ C) :
     mapWhiskerRight (whiskerRight η H) _ =
     (mapCompLeft D F H).hom ≫ whiskerRight (mapWhiskerRight η _) (mapPair H (𝟭 D)) ≫
       (mapCompLeft D G H).inv := by

--- a/Mathlib/CategoryTheory/Limits/FunctorCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/FunctorCategory/Basic.lean
@@ -428,7 +428,7 @@ lemma preservesColimit_of_evaluation (F : D ⥤ K ⥤ C) (G : J ⥤ D)
     change IsColimit ((F ⋙ (evaluation K C).obj X).mapCocone c)
     exact isColimitOfPreserves _ hc⟩⟩
 
-@[deprecated "No deprecation message was provided."  (since := "2024-11-19")]
+@[deprecated "No deprecation message was provided." (since := "2024-11-19")]
 lemma preservesColimitOfEvaluation (F : D ⥤ K ⥤ C) (G : J ⥤ D)
     (H : ∀ k, PreservesColimit G (F ⋙ (evaluation K C).obj k)) : PreservesColimit G F :=
   preservesColimit_of_evaluation _ _ H

--- a/Mathlib/CategoryTheory/Localization/HomEquiv.lean
+++ b/Mathlib/CategoryTheory/Localization/HomEquiv.lean
@@ -57,7 +57,7 @@ lemma homMap_map (f : X ⟶ Y) :
 
 variable (X) in
 @[simp]
-lemma homMap_id  :
+lemma homMap_id :
     Φ.homMap L₁ L₂ (𝟙 (L₁.obj X)) = 𝟙 (L₂.obj (Φ.functor.obj X)) := by
   simpa using Φ.homMap_map L₁ L₂ (𝟙 X)
 

--- a/Mathlib/CategoryTheory/Localization/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Localization/Monoidal.lean
@@ -352,7 +352,7 @@ lemma triangle_aux₁ {X₁ X₂ X₃ Y₁ Y₂ Y₃ : LocalizedMonoidal L W ε}
   simp only [associator_naturality_assoc, ← tensor_comp, Iso.hom_inv_id, id_tensorHom,
     whiskerLeft_id, comp_id]
 
-lemma triangle_aux₂ {X Y  : LocalizedMonoidal L W ε} {X' Y' : C}
+lemma triangle_aux₂ {X Y : LocalizedMonoidal L W ε} {X' Y' : C}
     (e₁ : (L').obj X' ≅ X) (e₂ : (L').obj Y' ≅ Y) :
       e₁.hom ⊗ₘ (ε.hom ⊗ₘ e₂.hom) ≫ (λ_ Y).hom =
         (L').obj X' ◁ ((ε' L W ε).hom ▷ (L').obj Y' ≫
@@ -362,7 +362,7 @@ lemma triangle_aux₂ {X Y  : LocalizedMonoidal L W ε} {X' Y' : C}
   congr 3
   exact (comp_id _).symm
 
-lemma triangle_aux₃ {X Y  : LocalizedMonoidal L W ε} {X' Y' : C}
+lemma triangle_aux₃ {X Y : LocalizedMonoidal L W ε} {X' Y' : C}
     (e₁ : (L').obj X' ≅ X) (e₂ : (L').obj Y' ≅ Y) : (ρ_ X).hom ▷ _ =
       ((e₁.inv ⊗ₘ ε.inv) ⊗ₘ e₂.inv) ≫ _ ◁ e₂.hom ≫ ((μ L W ε X' (𝟙_ C)).hom ≫
         (L').map (ρ_ X').hom) ▷ Y ≫ e₁.hom ▷ Y := by

--- a/Mathlib/CategoryTheory/Localization/Opposite.lean
+++ b/Mathlib/CategoryTheory/Localization/Opposite.lean
@@ -77,7 +77,7 @@ end Functor
 
 namespace Localization
 
-lemma isoOfHom_unop  {X Y : Cᵒᵖ} (w : X ⟶ Y) (hw : W.op w) :
+lemma isoOfHom_unop {X Y : Cᵒᵖ} (w : X ⟶ Y) (hw : W.op w) :
     (isoOfHom L.op W.op w hw).unop = (isoOfHom L W w.unop hw) := by ext; rfl
 
 lemma isoOfHom_op_inv {X Y : Cᵒᵖ} (w : X ⟶ Y) (hw : W.op w) :

--- a/Mathlib/CategoryTheory/Localization/SmallHom.lean
+++ b/Mathlib/CategoryTheory/Localization/SmallHom.lean
@@ -72,12 +72,12 @@ lemma hasSmallLocalizedHom_iff_of_isos {X' Y' : C} (e : X ≅ X') (e' : Y ≅ Y'
   exact small_congr (Iso.homCongr (W.Q.mapIso e) (W.Q.mapIso e'))
 
 variable (X) in
-lemma hasSmallLocalizedHom_iff_target {Y Y' : C} (f : Y ⟶  Y') (hf : W f):
+lemma hasSmallLocalizedHom_iff_target {Y Y' : C} (f : Y ⟶ Y') (hf : W f):
     HasSmallLocalizedHom.{w} W X Y ↔ HasSmallLocalizedHom.{w} W X Y' := by
   simp only [hasSmallLocalizedHom_iff W W.Q]
   exact small_congr (Iso.homCongr (Iso.refl _) (Localization.isoOfHom W.Q W f hf))
 
-lemma hasSmallLocalizedHom_iff_source {X' : C} (f : X ⟶  X') (hf : W f) (Y : C) :
+lemma hasSmallLocalizedHom_iff_source {X' : C} (f : X ⟶ X') (hf : W f) (Y : C) :
     HasSmallLocalizedHom.{w} W X Y ↔ HasSmallLocalizedHom.{w} W X' Y := by
   simp only [hasSmallLocalizedHom_iff W W.Q]
   exact small_congr (Iso.homCongr (Localization.isoOfHom W.Q W f hf) (Iso.refl _))
@@ -167,7 +167,7 @@ lemma mk_comp_mk [HasSmallLocalizedHom.{w} W X Y] [HasSmallLocalizedHom.{w} W Y 
 
 @[simp]
 lemma comp_mk_id [HasSmallLocalizedHom.{w} W X Y] [HasSmallLocalizedHom.{w} W Y Y]
-    (α : SmallHom.{w} W X Y)  :
+    (α : SmallHom.{w} W X Y) :
     α.comp (mk W (𝟙 Y)) = α :=
   (equiv W W.Q).injective (by simp [equiv_comp])
 

--- a/Mathlib/CategoryTheory/Localization/SmallShiftedHom.lean
+++ b/Mathlib/CategoryTheory/Localization/SmallShiftedHom.lean
@@ -56,14 +56,14 @@ lemma hasSmallLocalizedShiftedHom_iff
 
 variable {Y} in
 lemma hasSmallLocalizedShiftedHom_iff_target [W.IsCompatibleWithShift M]
-    {Y' : C} (f : Y ⟶  Y') (hf : W f) :
+    {Y' : C} (f : Y ⟶ Y') (hf : W f) :
     HasSmallLocalizedShiftedHom.{w} W M X Y ↔ HasSmallLocalizedShiftedHom.{w} W M X Y' :=
   forall_congr' (fun a ↦ forall_congr' (fun b ↦
     hasSmallLocalizedHom_iff_target W (X⟦a⟧) (f⟦b⟧') (W.shift hf b)))
 
 variable {X} in
 lemma hasSmallLocalizedShiftedHom_iff_source [W.IsCompatibleWithShift M]
-    {X' : C} (f : X ⟶  X') (hf : W f) (Y : C) :
+    {X' : C} (f : X ⟶ X') (hf : W f) (Y : C) :
     HasSmallLocalizedShiftedHom.{w} W M X Y ↔ HasSmallLocalizedShiftedHom.{w} W M X' Y :=
   forall_congr' (fun a ↦ forall_congr' (fun b ↦
     hasSmallLocalizedHom_iff_source W (f⟦a⟧') (W.shift hf a) (Y⟦b⟧)))

--- a/Mathlib/CategoryTheory/Monoidal/Action/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Action/Basic.lean
@@ -505,7 +505,7 @@ lemma actionHom_id {d d' : D} (f : d ⟶ d') (c : C) :
   simp [actionHom_def]
 
 @[simp]
-lemma id_actionHom  (d : D) {c c' : C} (f : c ⟶ c') :
+lemma id_actionHom (d : D) {c c' : C} (f : c ⟶ c') :
     (𝟙 d) ⊙ᵣₘ f = d ⊴ᵣ f := by
   simp [actionHom_def]
 

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Basic.lean
@@ -681,7 +681,7 @@ instance isIso_prodComparison_of_preservesLimit_pair : IsIso (prodComparison F A
   rw [← prodComparisonIso_hom]
   infer_instance
 
-@[simp] lemma prodComparisonIso_id  : prodComparisonIso (𝟭 C) A B = .refl _ := by ext <;> simp
+@[simp] lemma prodComparisonIso_id : prodComparisonIso (𝟭 C) A B = .refl _ := by ext <;> simp
 
 @[simp]
 lemma prodComparisonIso_comp [PreservesLimit (pair A B) (F ⋙ G)]

--- a/Mathlib/CategoryTheory/Opposites.lean
+++ b/Mathlib/CategoryTheory/Opposites.lean
@@ -660,7 +660,7 @@ lemma op_rightUnitor :
       (Functor.opComp _ _).symm := by
   aesop_cat
 
-lemma op_associator {E E': Type*} [Category E] [Category E'] {F : C ⥤ D} {G : D ⥤ E} {H : E ⥤ E'} :
+lemma op_associator {E E' : Type*} [Category E] [Category E'] {F : C ⥤ D} {G : D ⥤ E} {H : E ⥤ E'} :
     NatIso.op (Functor.associator F G H) =
       Functor.opComp _ _ ≪≫ isoWhiskerLeft F.op (Functor.opComp _ _) ≪≫
         (Functor.associator F.op G.op H.op).symm ≪≫
@@ -681,7 +681,7 @@ lemma unop_rightUnitor {F : Cᵒᵖ ⥤ Dᵒᵖ} :
       (Functor.unopComp _ _).symm := by
   aesop_cat
 
-lemma unop_associator {E E': Type*} [Category E] [Category E']
+lemma unop_associator {E E' : Type*} [Category E] [Category E']
     {F : Cᵒᵖ ⥤ Dᵒᵖ} {G : Dᵒᵖ ⥤ Eᵒᵖ} {H : Eᵒᵖ ⥤ E'ᵒᵖ} :
     NatIso.unop (Functor.associator F G H) =
       Functor.unopComp _ _ ≪≫ isoWhiskerLeft F.unop (Functor.unopComp _ _) ≪≫

--- a/Mathlib/CategoryTheory/Sites/Coherent/RegularSheaves.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/RegularSheaves.lean
@@ -236,7 +236,7 @@ theorem isSheaf_of_projective (F : Cᵒᵖ ⥤ D) [Preregular C] [∀ (X : C), P
     isSheafFor_regular_of_projective _ _
 
 /-- Every Yoneda-presheaf is a sheaf for the regular topology. -/
-lemma isSheaf_yoneda_obj [Preregular C] (W : C)  :
+lemma isSheaf_yoneda_obj [Preregular C] (W : C) :
     Presieve.IsSheaf (regularTopology C) (yoneda.obj W) := by
   rw [regularTopology, isSheaf_coverage]
   intro X S ⟨_, hS⟩

--- a/Mathlib/CategoryTheory/Sites/Coherent/SequentialLimit.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/SequentialLimit.lean
@@ -90,7 +90,7 @@ variable (h : ∀ (G : ℕᵒᵖ ⥤ C),
   (∀ n, EffectiveEpi (G.map (homOfLE (Nat.le_succ n)).op)) → EffectiveEpi (limit.π G ⟨0⟩))
 
 include hF h hc in
-lemma isLocallySurjective_π_app_zero_of_isLocallySurjective_map  :
+lemma isLocallySurjective_π_app_zero_of_isLocallySurjective_map :
     Sheaf.IsLocallySurjective (c.π.app ⟨0⟩) := by
   rw [coherentTopology.isLocallySurjective_iff, regularTopology.isLocallySurjective_iff]
   intro X y

--- a/Mathlib/CategoryTheory/Sites/ConstantSheaf.lean
+++ b/Mathlib/CategoryTheory/Sites/ConstantSheaf.lean
@@ -114,7 +114,7 @@ lemma isConstant_iff_isIso_counit_app [(constantSheaf J D).Faithful] [(constantS
 A variant of `isConstant_iff_isIso_counit_app` for a general left adjoint to evaluation at a
 terminal object.
 -/
-lemma isConstant_iff_isIso_counit_app'  {L : D ⥤ Sheaf J D} {T : C} (hT : IsTerminal T)
+lemma isConstant_iff_isIso_counit_app' {L : D ⥤ Sheaf J D} {T : C} (hT : IsTerminal T)
     (adj : L ⊣ (sheafSections J D).obj ⟨T⟩)
     [L.Faithful] [L.Full] (F : Sheaf J D) : IsConstant J F ↔ IsIso (adj.counit.app F) :=
   (isConstant_iff_mem_essImage J hT adj F).trans (isIso_counit_app_iff_mem_essImage adj).symm

--- a/Mathlib/CategoryTheory/Sites/SheafHom.lean
+++ b/Mathlib/CategoryTheory/Sites/SheafHom.lean
@@ -161,7 +161,7 @@ variable (F G S)
 
 include hG in
 open PresheafHom.IsSheafFor in
-lemma presheafHom_isSheafFor  :
+lemma presheafHom_isSheafFor :
     Presieve.IsSheafFor (presheafHom F G) S.arrows := by
   intro x hx
   apply existsUnique_of_exists_of_unique

--- a/Mathlib/CategoryTheory/Triangulated/HomologicalFunctor.lean
+++ b/Mathlib/CategoryTheory/Triangulated/HomologicalFunctor.lean
@@ -197,7 +197,7 @@ lemma homologySequenceδ_comp :
   rw [← F.shiftMap_comp, comp_distTriang_mor_zero₃₁ _ hT, shiftMap_zero]
 
 @[reassoc]
-lemma homologySequence_comp  :
+lemma homologySequence_comp :
     (F.shift n₀).map T.mor₁ ≫ (F.shift n₀).map T.mor₂ = 0 := by
   rw [← Functor.map_comp, comp_distTriang_mor_zero₁₂ _ hT, Functor.map_zero]
 

--- a/Mathlib/Combinatorics/SetFamily/FourFunctions.lean
+++ b/Mathlib/Combinatorics/SetFamily/FourFunctions.lean
@@ -134,7 +134,7 @@ lemma collapse_nonneg (hf : 0 ≤ f) : 0 ≤ collapse 𝒜 a f := fun _s ↦ sum
 
 lemma collapse_modular [ExistsAddOfLE β]
     (hu : a ∉ u) (h₁ : 0 ≤ f₁) (h₂ : 0 ≤ f₂) (h₃ : 0 ≤ f₃) (h₄ : 0 ≤ f₄)
-    (h : ∀ ⦃s⦄, s ⊆ insert a u → ∀ ⦃t⦄, t ⊆ insert a u →  f₁ s * f₂ t ≤ f₃ (s ∩ t) * f₄ (s ∪ t))
+    (h : ∀ ⦃s⦄, s ⊆ insert a u → ∀ ⦃t⦄, t ⊆ insert a u → f₁ s * f₂ t ≤ f₃ (s ∩ t) * f₄ (s ∪ t))
     (𝒜 ℬ : Finset (Finset α)) :
     ∀ ⦃s⦄, s ⊆ u → ∀ ⦃t⦄, t ⊆ u → collapse 𝒜 a f₁ s * collapse ℬ a f₂ t ≤
       collapse (𝒜 ⊼ ℬ) a f₃ (s ∩ t) * collapse (𝒜 ⊻ ℬ) a f₄ (s ∪ t) := by

--- a/Mathlib/Combinatorics/SimpleGraph/Clique.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Clique.lean
@@ -169,7 +169,7 @@ lemma IsClique.sdiff_of_sup_edge {v w : α} {s : Set α} (hc : (G ⊔ edge v w).
   have := hc hx.1 hy.1 hxy
   simp_all [sup_adj, edge_adj]
 
-lemma isClique_sup_edge_of_ne_sdiff {v w : α} {s : Set α} (h : v ≠ w ) (hv : G.IsClique (s \ {v}))
+lemma isClique_sup_edge_of_ne_sdiff {v w : α} {s : Set α} (h : v ≠ w) (hv : G.IsClique (s \ {v}))
     (hw : G.IsClique (s \ {w})) : (G ⊔ edge v w).IsClique s := by
   intro x hx y hy hxy
   by_cases h' : x ∈ s \ {v} ∧ y ∈ s \ {v} ∨ x ∈ s \ {w} ∧ y ∈ s \ {w}

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
@@ -154,7 +154,7 @@ theorem Preconnected.map {G : SimpleGraph V} {H : SimpleGraph V'} (f : G →g H)
   hf.forall₂.2 fun _ _ => Nonempty.map (Walk.map _) <| hG _ _
 
 @[mono]
-protected lemma Preconnected.mono  {G G' : SimpleGraph V} (h : G ≤ G') (hG : G.Preconnected) :
+protected lemma Preconnected.mono {G G' : SimpleGraph V} (h : G ≤ G') (hG : G.Preconnected) :
     G'.Preconnected := fun u v => (hG u v).mono h
 
 lemma bot_preconnected_iff_subsingleton : (⊥ : SimpleGraph V).Preconnected ↔ Subsingleton V := by

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -87,7 +87,7 @@ lemma IsHamiltonianCycle.map {H : SimpleGraph β} (f : G →g H) (hf : Bijective
     rw [List.count_map_of_injective _ _ hf.injective, ← support_copy, ← tail_cons_eq]
     exact hp.isHamiltonian_tail _
 
-lemma isHamiltonianCycle_isCycle_and_isHamiltonian_tail  :
+lemma isHamiltonianCycle_isCycle_and_isHamiltonian_tail :
     p.IsHamiltonianCycle ↔ p.IsCycle ∧ p.tail.IsHamiltonian :=
   ⟨fun ⟨h, h'⟩ ↦ ⟨h, h'⟩, fun ⟨h, h'⟩ ↦ ⟨h, h'⟩⟩
 

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -547,7 +547,7 @@ def IsAlternating (G G' : SimpleGraph V) :=
 lemma IsAlternating.mono {G'' : SimpleGraph V} (halt : G.IsAlternating G') (h : G'' ≤ G) :
     G''.IsAlternating G' := fun _ _ _ hww' hvw hvw' ↦ halt hww' (h hvw) (h hvw')
 
-lemma IsAlternating.spanningCoe (halt : G.IsAlternating G') (H : Subgraph G)  :
+lemma IsAlternating.spanningCoe (halt : G.IsAlternating G') (H : Subgraph G) :
     H.spanningCoe.IsAlternating G' := by
   intro v w w' hww' hvw hvv'
   simp only [Subgraph.spanningCoe_adj] at hvw hvv'

--- a/Mathlib/Combinatorics/SimpleGraph/Triangle/Removal.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Triangle/Removal.lean
@@ -54,7 +54,7 @@ private lemma aux {n k : ℕ} (hk : 0 < k) (hn : k ≤ n) : n < 2 * k * (n / k) 
   apply (mod_lt n hk).trans_le
   simpa using Nat.mul_le_mul_left k ((Nat.one_le_div_iff hk).2 hn)
 
-private lemma card_bound (hP₁ : P.IsEquipartition) (hP₃ : #P.parts ≤ bound (ε / 8) ⌈4/ε⌉₊)
+private lemma card_bound (hP₁ : P.IsEquipartition) (hP₃ : #P.parts ≤ bound (ε / 8) ⌈4 / ε⌉₊)
     (hX : s ∈ P.parts) : card α / (2 * bound (ε / 8) ⌈4 / ε⌉₊ : ℝ) ≤ #s := by
   cases isEmpty_or_nonempty α
   · simp [Fintype.card_eq_zero]
@@ -66,8 +66,8 @@ private lemma card_bound (hP₁ : P.IsEquipartition) (hP₃ : #P.parts ≤ bound
     _ ≤ (#s : ℝ) := mod_cast hP₁.average_le_card_part hX
 
 private lemma triangle_removal_aux (hε : 0 < ε) (hP₁ : P.IsEquipartition)
-    (hP₃ : #P.parts ≤ bound (ε / 8) ⌈4/ε⌉₊)
-    (ht : t ∈ (G.regularityReduced P (ε/8) (ε/4)).cliqueFinset 3) :
+    (hP₃ : #P.parts ≤ bound (ε / 8) ⌈4 / ε⌉₊)
+    (ht : t ∈ (G.regularityReduced P (ε / 8) (ε / 4)).cliqueFinset 3) :
     triangleRemovalBound ε * card α ^ 3 ≤ #(G.cliqueFinset 3) := by
   rw [mem_cliqueFinset_iff, is3Clique_iff] at ht
   obtain ⟨x, y, z, ⟨-, s, hX, Y, hY, xX, yY, nXY, uXY, dXY⟩,
@@ -94,7 +94,7 @@ private lemma triangle_removal_aux (hε : 0 < ε) (hP₁ : P.IsEquipartition)
       triangle_counting G (by rwa [that]) uXY dXY (by rwa [that]) uXZ dXZ (by rwa [that]) uYZ dYZ
 
 lemma regularityReduced_edges_card_aux [Nonempty α] (hε : 0 < ε) (hP : P.IsEquipartition)
-    (hPε : P.IsUniform G (ε/8)) (hP' : 4 / ε ≤ #P.parts) :
+    (hPε : P.IsUniform G (ε / 8)) (hP' : 4 / ε ≤ #P.parts) :
     2 * (#G.edgeFinset - #(G.regularityReduced P (ε/8) (ε/4)).edgeFinset : ℝ)
       < 2 * ε * (card α ^ 2 : ℕ) := by
   let A := (P.nonUniforms G (ε/8)).biUnion fun (U, V) ↦ U ×ˢ V

--- a/Mathlib/Condensed/Discrete/Colimit.lean
+++ b/Mathlib/Condensed/Discrete/Colimit.lean
@@ -379,7 +379,7 @@ lemma lanPresheafExt_hom {F G : LightProfinite.{u}ᵒᵖ ⥤ Type u} (S : LightP
   aesop
 
 @[simp]
-lemma lanPresheafExt_inv  {F G : LightProfinite.{u}ᵒᵖ ⥤ Type u} (S : LightProfinite.{u}ᵒᵖ)
+lemma lanPresheafExt_inv {F G : LightProfinite.{u}ᵒᵖ ⥤ Type u} (S : LightProfinite.{u}ᵒᵖ)
     (i : toLightProfinite.op ⋙ F ≅ toLightProfinite.op ⋙ G) : (lanPresheafExt i).inv.app S =
       colimMap (whiskerLeft (CostructuredArrow.proj toLightProfinite.op S) i.inv) := by
   simp only [lanPresheaf, pointwiseLeftKanExtension_obj, lanPresheafExt,

--- a/Mathlib/Data/BitVec.lean
+++ b/Mathlib/Data/BitVec.lean
@@ -40,9 +40,9 @@ open Fin.NatCast
 
 instance : SMul ℕ (BitVec w) := ⟨fun x y => ofFin <| x • y.toFin⟩
 instance : SMul ℤ (BitVec w) := ⟨fun x y => ofFin <| x • y.toFin⟩
-lemma toFin_nsmul (n : ℕ) (x : BitVec w)  : toFin (n • x) = n • x.toFin := rfl
-lemma toFin_zsmul (z : ℤ) (x : BitVec w)  : toFin (z • x) = z • x.toFin := rfl
-lemma toFin_pow (x : BitVec w) (n : ℕ)    : toFin (x ^ n) = x.toFin ^ n := by
+lemma toFin_nsmul (n : ℕ) (x : BitVec w) : toFin (n • x) = n • x.toFin := rfl
+lemma toFin_zsmul (z : ℤ) (x : BitVec w) : toFin (z • x) = z • x.toFin := rfl
+lemma toFin_pow (x : BitVec w) (n : ℕ) : toFin (x ^ n) = x.toFin ^ n := by
   induction n with
   | zero => simp
   | succ n ih => simp [ih, BitVec.pow_succ, pow_succ]

--- a/Mathlib/Data/Fin/Rev.lean
+++ b/Mathlib/Data/Fin/Rev.lean
@@ -107,11 +107,11 @@ lemma predAbove_rev_right (p : Fin n) (i : Fin (n + 1)) :
 lemma rev_predAbove {n : ℕ} (p : Fin n) (i : Fin (n + 1)) :
     (predAbove p i).rev = predAbove p.rev i.rev := by rw [predAbove_rev_left, rev_rev]
 
-lemma add_rev_cast (j : Fin (n+1)) : j.1 + j.rev.1 = n := by
+lemma add_rev_cast (j : Fin (n + 1)) : j.1 + j.rev.1 = n := by
   obtain ⟨j, hj⟩ := j
   simp [Nat.add_sub_cancel' <| le_of_lt_succ hj]
 
-lemma rev_add_cast (j : Fin (n+1)) : j.rev.1 + j.1 = n := by
+lemma rev_add_cast (j : Fin (n + 1)) : j.rev.1 + j.1 = n := by
   rw [Nat.add_comm, j.add_rev_cast]
 
 end Fin

--- a/Mathlib/Data/Fin/SuccPred.lean
+++ b/Mathlib/Data/Fin/SuccPred.lean
@@ -36,7 +36,7 @@ lemma orderSucc_apply {n : ℕ} (i : Fin (n + 1)) :
     Order.succ i = Fin.lastCases (Fin.last n) Fin.succ i := rfl
 
 @[simp]
-lemma orderSucc_last (n : ℕ)  :
+lemma orderSucc_last (n : ℕ) :
     Order.succ (Fin.last n) = Fin.last n := by
   simp [orderSucc_apply]
 

--- a/Mathlib/Data/Int/Init.lean
+++ b/Mathlib/Data/Int/Init.lean
@@ -232,7 +232,7 @@ lemma div_le_div_iff_of_dvd_of_pos_of_neg (hb : 0 < b) (hd : d < 0) (hba : b ∣
     a / b ≤ c / d ↔ c * b ≤ d * a :=
   ediv_le_ediv_iff_of_dvd_of_pos_of_neg hb hd hba hdc
 
-lemma div_le_div_iff_of_dvd_of_neg_of_pos (hb : b < 0) (hd : 0 < d) (hba : b ∣ a)  (hdc : d ∣ c) :
+lemma div_le_div_iff_of_dvd_of_neg_of_pos (hb : b < 0) (hd : 0 < d) (hba : b ∣ a) (hdc : d ∣ c) :
     a / b ≤ c / d ↔ c * b ≤ d * a :=
   ediv_le_ediv_iff_of_dvd_of_neg_of_pos hb hd hba hdc
 

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -108,7 +108,7 @@ theorem exists_of_length_succ {n} : ∀ l : List α, l.length = n + 1 → ∃ h 
       · subsingleton
       · apply ih; simpa using hl
 
-@[simp default+1] -- Raise priority above `length_injective_iff`.
+@[simp default + 1] -- Raise priority above `length_injective_iff`.
 lemma length_injective [Subsingleton α] : Injective (length : List α → ℕ) :=
   length_injective_iff.mpr inferInstance
 

--- a/Mathlib/Data/Matroid/Closure.lean
+++ b/Mathlib/Data/Matroid/Closure.lean
@@ -889,7 +889,7 @@ lemma Restriction.isBase_iff_of_spanning {N : Matroid α} (hR : N ≤r M) (hN : 
   rw [Spanning.isBase_restrict_iff (show M.Spanning R from hN), restrict_ground_eq]
 
 lemma ext_spanning {M M' : Matroid α} (h : M.E = M'.E)
-    (hsp : ∀ S, S ⊆ M.E → (M.Spanning S ↔ M'.Spanning S )) : M = M' := by
+    (hsp : ∀ S, S ⊆ M.E → (M.Spanning S ↔ M'.Spanning S)) : M = M' := by
   have hsp' : M.Spanning = M'.Spanning := by
     ext S
     refine (em (S ⊆ M.E)).elim (fun hSE ↦ by rw [hsp _ hSE] )

--- a/Mathlib/Data/Nat/Init.lean
+++ b/Mathlib/Data/Nat/Init.lean
@@ -328,7 +328,7 @@ lemma decreasingInduction_trans {motive : (m : ℕ) → m ≤ k → Sort*} (hmn 
   | step hnk ih =>
       rw [decreasingInduction_succ _ _ (Nat.le_trans hmn hnk), ih, decreasingInduction_succ]
 
-lemma decreasingInduction_succ_left  {motive : (m : ℕ) → m ≤ n → Sort*} (of_succ self)
+lemma decreasingInduction_succ_left {motive : (m : ℕ) → m ≤ n → Sort*} (of_succ self)
     (smn : m + 1 ≤ n) (mn : m ≤ n) :
     decreasingInduction (motive := motive) of_succ self mn =
       of_succ m smn (decreasingInduction of_succ self smn) := by

--- a/Mathlib/Data/Set/Insert.lean
+++ b/Mathlib/Data/Set/Insert.lean
@@ -335,7 +335,7 @@ theorem Nonempty.eq_one [Subsingleton α] [One α] {s : Set α} (h : s.Nonempty)
 
 /-! ### Disjointness -/
 
-@[simp default+1]
+@[simp default + 1]
 lemma disjoint_singleton_left : Disjoint {a} s ↔ a ∉ s := by simp [Set.disjoint_iff, subset_def]
 
 @[simp]

--- a/Mathlib/Dynamics/TopologicalEntropy/Subset.lean
+++ b/Mathlib/Dynamics/TopologicalEntropy/Subset.lean
@@ -48,7 +48,7 @@ lemma IsDynCoverOf.monotone_subset {T : X → X} {F G : Set X} (F_G : F ⊆ G) {
     IsDynCoverOf T F U n s :=
   F_G.trans h
 
-lemma IsDynNetIn.monotone_subset {T : X → X} {F G : Set X} (F_G : F ⊆ G ) {U : Set (X × X)} {n : ℕ}
+lemma IsDynNetIn.monotone_subset {T : X → X} {F G : Set X} (F_G : F ⊆ G) {U : Set (X × X)} {n : ℕ}
     {s : Set X} (h : IsDynNetIn T F U n s) :
     IsDynNetIn T G U n s :=
   ⟨h.1.trans F_G, h.2⟩

--- a/Mathlib/FieldTheory/PurelyInseparable/Basic.lean
+++ b/Mathlib/FieldTheory/PurelyInseparable/Basic.lean
@@ -438,7 +438,7 @@ theorem isPurelyInseparable_iff_finSepDegree_eq_one :
   ⟨fun _ ↦ IsPurelyInseparable.finSepDegree_eq_one F E,
     fun h ↦ isPurelyInseparable_of_finSepDegree_eq_one h⟩
 
-lemma isSeparable_iff_finInsepDegree_eq_one  :
+lemma isSeparable_iff_finInsepDegree_eq_one :
     Algebra.IsSeparable F K ↔ finInsepDegree F K = 1 := by
   rw [← separableClosure.eq_top_iff, ← IntermediateField.finrank_eq_one_iff_eq_top, finInsepDegree]
 

--- a/Mathlib/Geometry/Manifold/ContMDiffMFDeriv.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiffMFDeriv.lean
@@ -426,7 +426,7 @@ variable [IsManifold I 1 M] [IsManifold I' 1 M']
 
 /-- The canonical equivalence between the tangent bundle of a product and the product of
 tangent bundles is smooth. -/
-lemma contMDiff_equivTangentBundleProd  :
+lemma contMDiff_equivTangentBundleProd :
     ContMDiff (I.prod I').tangent (I.tangent.prod I'.tangent) n
       (equivTangentBundleProd I M I' M') := by
   rw [equivTangentBundleProd_eq_tangentMap_prod_tangentMap]

--- a/Mathlib/GroupTheory/GroupAction/Defs.lean
+++ b/Mathlib/GroupTheory/GroupAction/Defs.lean
@@ -532,7 +532,7 @@ lemma stabilizer_smul_eq_right {α} [Group α] [MulAction α β] [SMulCommClass 
     rw [inv_smul_smul]
 
 @[to_additive (attr := simp)]
-lemma stabilizer_mul_eq_left [Group α] [IsScalarTower G α α] (a b : α)  :
+lemma stabilizer_mul_eq_left [Group α] [IsScalarTower G α α] (a b : α) :
     stabilizer G (a * b) = stabilizer G a := stabilizer_smul_eq_left a _ <| mul_left_injective _
 
 @[to_additive (attr := simp)]

--- a/Mathlib/GroupTheory/Index.lean
+++ b/Mathlib/GroupTheory/Index.lean
@@ -563,7 +563,7 @@ variable (H K) in
 @[to_additive] class IsFiniteRelIndex : Prop where
   protected relindex_ne_zero : H.relindex K ≠ 0
 
-@[to_additive] lemma relindex_ne_zero  [H.IsFiniteRelIndex K] : H.relindex K ≠ 0 :=
+@[to_additive] lemma relindex_ne_zero [H.IsFiniteRelIndex K] : H.relindex K ≠ 0 :=
   IsFiniteRelIndex.relindex_ne_zero
 
 @[to_additive]

--- a/Mathlib/LinearAlgebra/Matrix/FixedDetMatrices.lean
+++ b/Mathlib/LinearAlgebra/Matrix/FixedDetMatrices.lean
@@ -36,7 +36,7 @@ lemma ext' {m : R} {A B : FixedDetMatrix n R m} (h : A.1 = B.1) : A = B := by
   congr
 
 @[ext]
-lemma ext {m : R} {A B : FixedDetMatrix n R m} (h : ∀ i j , A.1 i j = B.1 i j) : A = B := by
+lemma ext {m : R} {A B : FixedDetMatrix n R m} (h : ∀ i j, A.1 i j = B.1 i j) : A = B := by
   apply ext'
   ext i j
   apply h

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
@@ -235,7 +235,7 @@ lemma mapGL_inj [FaithfulSMul R S] (g g' : SpecialLinearGroup n R) :
   apply SpecialLinearGroup.ext
   simpa [mapGL, toGL_inj, ext_iff, (FaithfulSMul.algebraMap_injective R S).eq_iff] using h
 
-lemma mapGL_injective [FaithfulSMul R S]  :
+lemma mapGL_injective [FaithfulSMul R S] :
     Function.Injective (mapGL (R := R) (n := n) S) :=
   fun a b ↦ by simp
 

--- a/Mathlib/LinearAlgebra/Matrix/Integer.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Integer.lean
@@ -40,7 +40,7 @@ lemma map_mul_natCast {α : Type*} [NonAssocSemiring α] (A B : Matrix n n ℕ) 
     map (A * B) ((↑) : ℕ → α) = map A (↑) * map B (↑) :=
   Matrix.map_mul (f := Nat.castRingHom α)
 
-lemma map_mul_intCast {α : Type*} [NonAssocRing α]  (A B : Matrix n n ℤ) :
+lemma map_mul_intCast {α : Type*} [NonAssocRing α] (A B : Matrix n n ℤ) :
     map (A * B) ((↑) : ℤ → α) = map A (↑) * map B (↑) :=
   Matrix.map_mul (f := Int.castRingHom α)
 

--- a/Mathlib/LinearAlgebra/Multilinear/Basic.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Basic.lean
@@ -1334,7 +1334,7 @@ theorem map_update_sub [DecidableEq ι] (m : ∀ i, M₁ i) (i : ι) (x y : M₁
 
 @[deprecated (since := "2024-11-03")] protected alias map_sub := MultilinearMap.map_update_sub
 
-lemma map_update [DecidableEq ι] (x : (i : ι) → M₁ i) (i : ι) (v : M₁ i)  :
+lemma map_update [DecidableEq ι] (x : (i : ι) → M₁ i) (i : ι) (v : M₁ i) :
     f (update x i v) = f x - f (update x i (x i - v)) := by
   rw [map_update_sub, update_eq_self, sub_sub_cancel]
 

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/G2.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/G2.lean
@@ -94,7 +94,7 @@ lemma not_isG2_iff_isNotG2 :
     aesop
 
 lemma IsG2.pairingIn_mem_zero_one_three [P.IsG2]
-    (i j : ι) (h : P.root i ≠ P.root j) (h' : P.root i ≠ - P.root j) :
+    (i j : ι) (h : P.root i ≠ P.root j) (h' : P.root i ≠ -P.root j) :
     P.pairingIn ℤ i j ∈ ({-3, -1, 0, 1, 3} : Set ℤ) := by
   suffices ¬ (∀ i j, P.pairingIn ℤ i j = P.pairingIn ℤ j i ∨
                      P.pairingIn ℤ i j = 2 * P.pairingIn ℤ j i ∨

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -111,7 +111,7 @@ lemma pairingIn_pairingIn_mem_set_of_isCrystal_of_isRed [P.IsReduced] :
   aesop -- #24551 (this should be faster)
 
 lemma pairingIn_pairingIn_mem_set_of_isCrystal_of_isRed' [P.IsReduced]
-    (hij : α i ≠ α j) (hij' : α i ≠ - α j) :
+    (hij : α i ≠ α j) (hij' : α i ≠ -α j) :
     (P.pairingIn ℤ i j, P.pairingIn ℤ j i) ∈
       ({(0, 0), (1, 1), (-1, -1), (1, 2), (2, 1), (-1, -2), (-2, -1), (1, 3), (3, 1), (-1, -3),
         (-3, -1)} : Set (ℤ × ℤ)) := by
@@ -136,7 +136,7 @@ lemma RootPositiveForm.rootLength_le_of_pairingIn_eq (B : P.RootPositiveForm ℤ
 variable {P} in
 lemma RootPositiveForm.rootLength_lt_of_pairingIn_notMem
     (B : P.RootPositiveForm ℤ) {i j : ι}
-    (hne : α i ≠ α j) (hne' : α i ≠ - α j)
+    (hne : α i ≠ α j) (hne' : α i ≠ -α j)
     (hij : P.pairingIn ℤ i j ∉ ({-1, 0, 1} : Set ℤ)) :
     B.rootLength j < B.rootLength i := by
   have hij' : P.pairingIn ℤ i j = -3 ∨ P.pairingIn ℤ i j = -2 ∨ P.pairingIn ℤ i j = 2 ∨
@@ -228,7 +228,7 @@ lemma root_sub_root_mem_of_pairingIn_pos (h : 0 < P.pairingIn ℤ i j) (h' : i �
 /-- If two roots make an obtuse angle then their sum is a root (provided it is not zero).
 
 See `RootPairing.pairingIn_le_zero_of_root_add_mem` for a partial converse. -/
-lemma root_add_root_mem_of_pairingIn_neg (h : P.pairingIn ℤ i j < 0) (h' : α i ≠ - α j) :
+lemma root_add_root_mem_of_pairingIn_neg (h : P.pairingIn ℤ i j < 0) (h' : α i ≠ -α j) :
     α i + α j ∈ Φ := by
   let _i := P.indexNeg
   replace h : 0 < P.pairingIn ℤ i (-j) := by simpa

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -449,7 +449,7 @@ lemma root_sub_root_mem_of_mem_of_mem (hk : α k + α i - α j ∈ Φ)
 
 /-- This is Lemma 2.5 (b) from [Geck](Geck2017). -/
 lemma root_add_root_mem_of_mem_of_mem (hk : α k + α i - α j ∈ Φ)
-    (hkj : α k ≠ - α i) (hk' : α k - α j ∈ Φ) :
+    (hkj : α k ≠ -α i) (hk' : α k - α j ∈ Φ) :
     α k + α i ∈ Φ := by
   let _i := P.indexNeg
   replace hk : α (-k) + α j - α i ∈ Φ := by

--- a/Mathlib/LinearAlgebra/RootSystem/Reduced.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Reduced.lean
@@ -53,7 +53,7 @@ lemma isReduced_iff' : P.IsReduced ↔ ∀ i j : ι, i ≠ j →
     · tauto
     · exact Or.inr (h i j h' hLin)
 
-lemma IsReduced.linearIndependent [P.IsReduced] (h : i ≠ j) (h' : P.root i ≠ - P.root j) :
+lemma IsReduced.linearIndependent [P.IsReduced] (h : i ≠ j) (h' : P.root i ≠ -P.root j) :
     LinearIndependent R ![P.root i, P.root j] := by
   have := IsReduced.eq_or_eq_neg (P := P) i j
   aesop
@@ -261,7 +261,7 @@ lemma coxeterWeightIn_eq_four_iff_not_linearIndependent :
     P.coxeterWeightIn S i j = 4 ↔ ¬ LinearIndependent R ![P.root i, P.root j] := by
   rw [P.linearIndependent_iff_coxeterWeightIn_ne_four S, not_not]
 
-lemma coxeterWeightIn_ne_four [P.IsReduced] (h : i ≠ j) (h' : P.root i ≠ - P.root j) :
+lemma coxeterWeightIn_ne_four [P.IsReduced] (h : i ≠ j) (h' : P.root i ≠ -P.root j) :
     P.coxeterWeightIn S i j ≠ 4 := by
   rw [ne_eq, coxeterWeightIn_eq_four_iff_not_linearIndependent, not_not]
   exact IsReduced.linearIndependent P h h'

--- a/Mathlib/LinearAlgebra/SesquilinearForm.lean
+++ b/Mathlib/LinearAlgebra/SesquilinearForm.lean
@@ -920,7 +920,7 @@ lemma apply_mul_apply_lt_iff_linearIndependent [NoZeroSMulDivisors R M]
 /-- Strict **Cauchy-Schwarz** is equivalent to linear independence for positive definite symmetric
 forms. -/
 lemma apply_sq_lt_iff_linearIndependent_of_symm [NoZeroSMulDivisors R M]
-    (hp : ∀ x, x ≠ 0 → 0 < B x x) (hB: B.IsSymm) (x y : M) :
+    (hp : ∀ x, x ≠ 0 → 0 < B x x) (hB : B.IsSymm) (x y : M) :
     (B x y) ^ 2 < (B x x) * (B y y) ↔ LinearIndependent R ![x, y] := by
   rw [show (B x y) ^ 2 = (B x y) * (B y x) by rw [sq, ← hB, RingHom.id_apply]]
   exact apply_mul_apply_lt_iff_linearIndependent B hp x y

--- a/Mathlib/Logic/Equiv/Basic.lean
+++ b/Mathlib/Logic/Equiv/Basic.lean
@@ -483,7 +483,7 @@ def sigmaSigmaSubtypeEq {α β : Type*} {γ : α → β → Type*} (a : α) (b :
 
 @[simp]
 lemma sigmaSigmaSubtypeEq_apply {α β : Type*} {γ : α → β → Type*} {a : α} {b : β}
-    (s: {s : (a : α) × (b : β) × γ a b // s.1 = a ∧ s.2.1 = b}) :
+    (s : {s : (a : α) × (b : β) × γ a b // s.1 = a ∧ s.2.1 = b}) :
     sigmaSigmaSubtypeEq a b s = cast (congrArg₂ γ s.2.1 s.2.2) s.1.2.2 := by
   simp [sigmaSigmaSubtypeEq]
 

--- a/Mathlib/Logic/Equiv/Fin/Basic.lean
+++ b/Mathlib/Logic/Equiv/Fin/Basic.lean
@@ -204,10 +204,10 @@ def Equiv.embeddingFinSucc (n : ℕ) (ι : Type*) :
   ((finSuccEquiv n).embeddingCongr (Equiv.refl ι)).trans
     (Function.Embedding.optionEmbeddingEquiv (Fin n) ι)
 
-@[simp] lemma Equiv.embeddingFinSucc_fst {n : ℕ} {ι : Type*} (e : Fin (n+1) ↪ ι) :
+@[simp] lemma Equiv.embeddingFinSucc_fst {n : ℕ} {ι : Type*} (e : Fin (n + 1) ↪ ι) :
     ((Equiv.embeddingFinSucc n ι e).1 : Fin n → ι) = e ∘ Fin.succ := rfl
 
-@[simp] lemma Equiv.embeddingFinSucc_snd {n : ℕ} {ι : Type*} (e : Fin (n+1) ↪ ι) :
+@[simp] lemma Equiv.embeddingFinSucc_snd {n : ℕ} {ι : Type*} (e : Fin (n + 1) ↪ ι) :
     ((Equiv.embeddingFinSucc n ι e).2 : ι) = e 0 := rfl
 
 @[simp] lemma Equiv.coe_embeddingFinSucc_symm {n : ℕ} {ι : Type*}

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -46,8 +46,8 @@ theorem const_inj [Nonempty α] {y₁ y₂ : β} : const α y₁ = const α y₂
 theorem onFun_apply (f : β → β → γ) (g : α → β) (a b : α) : onFun f g a b = f (g a) (g b) :=
   rfl
 
-lemma hfunext {α α' : Sort u} {β : α → Sort v} {β' : α' → Sort v} {f : ∀a, β a} {f' : ∀a, β' a}
-    (hα : α = α') (h : ∀a a', HEq a a' → HEq (f a) (f' a')) : HEq f f' := by
+lemma hfunext {α α' : Sort u} {β : α → Sort v} {β' : α' → Sort v} {f : ∀ a, β a} {f' : ∀ a, β' a}
+    (hα : α = α') (h : ∀ a a', HEq a a' → HEq (f a) (f' a')) : HEq f f' := by
   subst hα
   have : ∀a, HEq (f a) (f' a) := fun a ↦ h a a (HEq.refl a)
   have : β = β' := by funext a; exact type_eq_of_heq (this a)
@@ -513,7 +513,7 @@ theorem update_injective (f : ∀ a, β a) (a' : α) : Injective (update f a') :
   have := congr_fun h a'
   rwa [update_self, update_self] at this
 
-lemma forall_update_iff (f : ∀a, β a) {a : α} {b : β a} (p : ∀a, β a → Prop) :
+lemma forall_update_iff (f : ∀ a, β a) {a : α} {b : β a} (p : ∀ a, β a → Prop) :
     (∀ x, p x (update f a b x)) ↔ p a b ∧ ∀ x, x ≠ a → p x (f x) := by
   rw [← and_forall_ne a, update_self]
   simp +contextual

--- a/Mathlib/Logic/Function/FiberPartition.lean
+++ b/Mathlib/Logic/Function/FiberPartition.lean
@@ -32,7 +32,7 @@ as an arbitrary such `x`.
 -/
 noncomputable def image (f : Y → Z) (a : Fiber f) : Z := a.2.choose.1
 
-lemma eq_fiber_image  (f : Y → Z) (a : Fiber f) : a.1 = f ⁻¹' {a.image} := a.2.choose_spec.symm
+lemma eq_fiber_image (f : Y → Z) (a : Fiber f) : a.1 = f ⁻¹' {a.image} := a.2.choose_spec.symm
 
 /--
 Given `y : Y`, `Fiber.mk f y` is the fiber of `f` that `y` belongs to, as an element of `Fiber f`.

--- a/Mathlib/MeasureTheory/Function/Holder.lean
+++ b/Mathlib/MeasureTheory/Function/Holder.lean
@@ -188,7 +188,7 @@ protected lemma smul_add (f₁ f₂ : Lp 𝕜 p μ) (g : Lp E q μ) :
   filter_upwards [AEEqFun.coeFn_add f₁.val f₂.val] with x hx
   simp [hx, add_smul]
 
-protected lemma add_smul (f : Lp 𝕜 p μ) (g₁ g₂  : Lp E q μ) :
+protected lemma add_smul (f : Lp 𝕜 p μ) (g₁ g₂ : Lp E q μ) :
     f • (g₁ + g₂) = f • g₁ + f • g₂ := by
   simp only [smul_def, ← MemLp.toLp_add]
   apply MemLp.toLp_congr _ _ ?_

--- a/Mathlib/MeasureTheory/Function/L1Space/Integrable.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space/Integrable.lean
@@ -665,7 +665,7 @@ theorem Integrable.measure_norm_ge_lt_top {f : α → β} (hf : Integrable f μ)
 
 /-- A non-quantitative version of Markov inequality for integrable functions: the measure of points
 where `‖f x‖ₑ > ε` is finite for all positive `ε`. -/
-lemma Integrable.measure_norm_gt_lt_top_enorm  {E : Type*} [TopologicalSpace E] [ContinuousENorm E]
+lemma Integrable.measure_norm_gt_lt_top_enorm {E : Type*} [TopologicalSpace E] [ContinuousENorm E]
     {f : α → E} (hf : Integrable f μ) {ε : ℝ≥0∞} (hε : 0 < ε) : μ {x | ε < ‖f x‖ₑ} < ∞ := by
   by_cases hε' : ε = ∞
   · simp [hε']

--- a/Mathlib/MeasureTheory/OuterMeasure/AE.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/AE.lean
@@ -118,7 +118,7 @@ theorem ae_eq_symm {f g : α → β} (h : f =ᵐ[μ] g) : g =ᵐ[μ] f :=
 theorem ae_eq_trans {f g h : α → β} (h₁ : f =ᵐ[μ] g) (h₂ : g =ᵐ[μ] h) : f =ᵐ[μ] h :=
   h₁.trans h₂
 
-@[simp] lemma ae_eq_top  : ae μ = ⊤ ↔ ∀ a, μ {a} ≠ 0 := by
+@[simp] lemma ae_eq_top : ae μ = ⊤ ↔ ∀ a, μ {a} ≠ 0 := by
   simp only [Filter.ext_iff, mem_ae_iff, mem_top, ne_eq]
   refine ⟨fun h a ha ↦ by simpa [ha] using (h {a}ᶜ).1, fun h s ↦ ⟨fun hs ↦ ?_, ?_⟩⟩
   · rw [← compl_empty_iff, ← not_nonempty_iff_eq_empty]

--- a/Mathlib/NumberTheory/EulerProduct/ExpLog.lean
+++ b/Mathlib/NumberTheory/EulerProduct/ExpLog.lean
@@ -20,7 +20,7 @@ open Complex
 
 open Topology in
 /-- If `f : α → ℂ` is summable, then so is `n ↦ log (1 - f n)`. -/
-lemma Summable.clog_one_sub {α  : Type*} {f : α → ℂ} (hsum : Summable f) :
+lemma Summable.clog_one_sub {α : Type*} {f : α → ℂ} (hsum : Summable f) :
     Summable fun n ↦ log (1 - f n) := by
   have hg : DifferentiableAt ℂ (fun z ↦ log (1 - z)) 0 := by
     have : 1 - 0 ∈ slitPlane := (sub_zero (1 : ℂ)).symm ▸ one_mem_slitPlane

--- a/Mathlib/NumberTheory/ModularForms/EisensteinSeries/Summable.lean
+++ b/Mathlib/NumberTheory/ModularForms/EisensteinSeries/Summable.lean
@@ -193,7 +193,7 @@ lemma summable_one_div_norm_rpow {k : ℝ} (hk : 2 < k) :
 /-- If the inverse of a function `isBigO` to `(|(n : ℝ)| ^ a)⁻¹` for `1 < a`, then the function is
 Summable. -/
 lemma summable_inv_of_isBigO_rpow_inv {α : Type*} [NormedField α] [CompleteSpace α]
-    {f  : ℤ → α} {a : ℝ} (hab : 1 < a)
+    {f : ℤ → α} {a : ℝ} (hab : 1 < a)
     (hf : (fun n ↦ (f n)⁻¹) =O[cofinite] fun n ↦ (|(n : ℝ)| ^ a)⁻¹) :
     Summable fun n ↦ (f n)⁻¹ :=
   summable_of_isBigO

--- a/Mathlib/NumberTheory/RamificationInertia/Basic.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Basic.lean
@@ -302,7 +302,7 @@ section absNorm
 /-- The absolute norm of an ideal `P` above a rational prime `p` is
 `|p| ^ ((span {p}).inertiaDeg P)`. -/
 lemma absNorm_eq_pow_inertiaDeg [IsDedekindDomain R] [Module.Free ℤ R] [Module.Finite ℤ R] {p : ℤ}
-    (P : Ideal R) [P.LiesOver (span {p})] (hp: Prime p) :
+    (P : Ideal R) [P.LiesOver (span {p})] (hp : Prime p) :
     absNorm P = p.natAbs ^ ((span {p}).inertiaDeg P) := by
   have : (span {p}).IsMaximal :=
     (isPrime_of_prime (prime_span_singleton_iff.mpr hp)).isMaximal (by simp [hp.ne_zero])

--- a/Mathlib/NumberTheory/WellApproximable.lean
+++ b/Mathlib/NumberTheory/WellApproximable.lean
@@ -318,7 +318,7 @@ See also `AddCircle.exists_norm_nsmul_le`. -/
 lemma _root_.NormedAddCommGroup.exists_norm_nsmul_le {A : Type*}
     [NormedAddCommGroup A] [CompactSpace A] [PreconnectedSpace A]
     [MeasurableSpace A] [BorelSpace A] {μ : Measure A} [μ.IsAddHaarMeasure]
-    (ξ : A) {n : ℕ} (hn : 0 < n) (δ : ℝ) (hδ : μ univ ≤ (n + 1) • μ (closedBall (0 : A) (δ/2))) :
+    (ξ : A) {n : ℕ} (hn : 0 < n) (δ : ℝ) (hδ : μ univ ≤ (n + 1) • μ (closedBall (0 : A) (δ / 2))) :
     ∃ j ∈ Icc 1 n, ‖j • ξ‖ ≤ δ := by
   have : IsFiniteMeasure μ := CompactSpace.isFiniteMeasure
   let B : Icc 0 n → Set A := fun j ↦ closedBall ((j : ℕ) • ξ) (δ/2)

--- a/Mathlib/Order/BooleanSubalgebra.lean
+++ b/Mathlib/Order/BooleanSubalgebra.lean
@@ -55,7 +55,7 @@ lemma mem_carrier : a ∈ L.carrier ↔ a ∈ L := .rfl
 @[simp] lemma coe_mk (L : Sublattice α) (h_compl h_bot) : (mk L h_compl h_bot : Set α) = L := rfl
 @[simp] lemma mk_le_mk {L M : Sublattice α} (hL_compl hL_bot hM_compl hM_bot) :
     mk L hL_compl hL_bot ≤ mk M hM_compl hM_bot ↔ L ≤ M := .rfl
-@[simp] lemma mk_lt_mk{L M : Sublattice α} (hL_compl hL_bot hM_compl hM_bot) :
+@[simp] lemma mk_lt_mk {L M : Sublattice α} (hL_compl hL_bot hM_compl hM_bot) :
     mk L hL_compl hL_bot < mk M hM_compl hM_bot ↔ L < M := .rfl
 
 /-- Copy of a boolean subalgebra with a new `carrier` equal to the old one. Useful to fix

--- a/Mathlib/Order/Category/BddDistLat.lean
+++ b/Mathlib/Order/Category/BddDistLat.lean
@@ -116,7 +116,7 @@ lemma hom_ext {X Y : BddDistLat} {f g : X ⟶ Y} (hf : f.hom = g.hom) : f = g :=
 
 @[simp]
 lemma hom_ofHom {X Y : Type u} [DistribLattice X] [BoundedOrder X] [DistribLattice Y]
-    [BoundedOrder Y](f : BoundedLatticeHom X Y) :
+    [BoundedOrder Y] (f : BoundedLatticeHom X Y) :
   (ofHom f).hom = f := rfl
 
 @[simp]

--- a/Mathlib/Order/CountableDenseLinearOrder.lean
+++ b/Mathlib/Order/CountableDenseLinearOrder.lean
@@ -64,7 +64,7 @@ theorem exists_between_finsets [DenselyOrdered α] [NoMinOrder α]
         fun m ↦ ⟨m, fun x hx ↦ (nlo ⟨x, hx⟩).elim, fun y hy ↦ (nhi ⟨y, hy⟩).elim⟩
 
 lemma exists_orderEmbedding_insert [DenselyOrdered β] [NoMinOrder β] [NoMaxOrder β]
-    [nonem : Nonempty β]  (S : Finset α) (f : S ↪o β) (a : α) :
+    [nonem : Nonempty β] (S : Finset α) (f : S ↪o β) (a : α) :
     ∃ (g : (insert a S : Finset α) ↪o β),
       g ∘ (Set.inclusion ((S.subset_insert a) : ↑S ⊆ ↑(insert a S))) = f := by
   let Slt := {x ∈ S.attach | x.val < a}.image f

--- a/Mathlib/Order/Interval/Finset/Box.lean
+++ b/Mathlib/Order/Interval/Finset/Box.lean
@@ -54,7 +54,7 @@ lemma box_succ_disjUnion (n : ℕ) :
 
 @[simp] lemma zero_mem_box : (0 : α) ∈ box n ↔ n = 0 := by cases n <;> simp [box_succ_eq_sdiff]
 
-lemma eq_zero_iff_eq_zero_of_mem_box  {x : α} (hx : x ∈ box n) : x = 0 ↔ n = 0 :=
+lemma eq_zero_iff_eq_zero_of_mem_box {x : α} (hx : x ∈ box n) : x = 0 ↔ n = 0 :=
   ⟨zero_mem_box.mp ∘ (· ▸ hx), fun hn ↦ by rwa [hn, box_zero, mem_singleton] at hx⟩
 
 end Finset

--- a/Mathlib/Order/RelSeries.lean
+++ b/Mathlib/Order/RelSeries.lean
@@ -975,7 +975,7 @@ def range (n : ℕ) : LTSeries ℕ where
 
 @[simp] lemma length_range (n : ℕ) : (range n).length = n := rfl
 
-@[simp] lemma range_apply (n : ℕ) (i : Fin (n+1)) : (range n) i = i := rfl
+@[simp] lemma range_apply (n : ℕ) (i : Fin (n + 1)) : (range n) i = i := rfl
 
 @[simp] lemma head_range (n : ℕ) : (range n).head = 0 := rfl
 

--- a/Mathlib/Probability/CondVar.lean
+++ b/Mathlib/Probability/CondVar.lean
@@ -58,7 +58,7 @@ lemma condVar_of_sigmaFinite [SigmaFinite (μ.trim hm)] :
       else 0 := condExp_of_sigmaFinite _
 
 lemma condVar_of_stronglyMeasurable [SigmaFinite (μ.trim hm)]
-    (hX : StronglyMeasurable[m] X) (hXint : Integrable ((X - μ[X | m]) ^ 2) μ) :
+    (hX : StronglyMeasurable[m] X) (hXint : Integrable ((X - μ[X|m]) ^ 2) μ) :
     Var[X; μ | m] = fun ω ↦ (X ω - (μ[X | m]) ω) ^ 2 :=
   condExp_of_stronglyMeasurable _ ((hX.sub stronglyMeasurable_condExp).pow _) hXint
 
@@ -83,7 +83,7 @@ lemma condVar_congr_ae (h : X =ᵐ[μ] Y) : Var[X; μ | m] =ᵐ[μ] Var[Y; μ | 
   condExp_congr_ae <| by filter_upwards [h, condExp_congr_ae h] with ω hω hω'; dsimp; rw [hω, hω']
 
 lemma condVar_of_aestronglyMeasurable [hμm : SigmaFinite (μ.trim hm)]
-    (hX : AEStronglyMeasurable[m] X μ) (hXint : Integrable ((X - μ[X | m]) ^ 2) μ) :
+    (hX : AEStronglyMeasurable[m] X μ) (hXint : Integrable ((X - μ[X|m]) ^ 2) μ) :
     Var[X; μ | m] =ᵐ[μ] (X - μ[X | m]) ^ 2 :=
   condExp_of_aestronglyMeasurable' _ ((continuous_pow _).comp_aestronglyMeasurable
     (hX.sub stronglyMeasurable_condExp.aestronglyMeasurable)) hXint
@@ -92,7 +92,7 @@ lemma integrable_condVar : Integrable Var[X; μ | m] μ := integrable_condExp
 
 /-- The integral of the conditional variance `Var[X | m]` over an `m`-measurable set is equal to
 the integral of `(X - μ[X | m]) ^ 2` on that set. -/
-lemma setIntegral_condVar [SigmaFinite (μ.trim hm)] (hX : Integrable ((X - μ[X | m]) ^ 2) μ)
+lemma setIntegral_condVar [SigmaFinite (μ.trim hm)] (hX : Integrable ((X - μ[X|m]) ^ 2) μ)
     (hs : MeasurableSet[m] s) :
     ∫ ω in s, (Var[X; μ | m]) ω ∂μ = ∫ ω in s, (X ω - (μ[X | m]) ω) ^ 2 ∂μ :=
   setIntegral_condExp _ hX hs

--- a/Mathlib/Probability/CondVar.lean
+++ b/Mathlib/Probability/CondVar.lean
@@ -58,7 +58,7 @@ lemma condVar_of_sigmaFinite [SigmaFinite (μ.trim hm)] :
       else 0 := condExp_of_sigmaFinite _
 
 lemma condVar_of_stronglyMeasurable [SigmaFinite (μ.trim hm)]
-    (hX : StronglyMeasurable[m] X) (hXint : Integrable ((X - μ[X|m]) ^ 2) μ) :
+    (hX : StronglyMeasurable[m] X) (hXint : Integrable ((X - μ[X | m]) ^ 2) μ) :
     Var[X; μ | m] = fun ω ↦ (X ω - (μ[X | m]) ω) ^ 2 :=
   condExp_of_stronglyMeasurable _ ((hX.sub stronglyMeasurable_condExp).pow _) hXint
 
@@ -83,7 +83,7 @@ lemma condVar_congr_ae (h : X =ᵐ[μ] Y) : Var[X; μ | m] =ᵐ[μ] Var[Y; μ | 
   condExp_congr_ae <| by filter_upwards [h, condExp_congr_ae h] with ω hω hω'; dsimp; rw [hω, hω']
 
 lemma condVar_of_aestronglyMeasurable [hμm : SigmaFinite (μ.trim hm)]
-    (hX : AEStronglyMeasurable[m] X μ) (hXint : Integrable ((X - μ[X|m]) ^ 2) μ) :
+    (hX : AEStronglyMeasurable[m] X μ) (hXint : Integrable ((X - μ[X | m]) ^ 2) μ) :
     Var[X; μ | m] =ᵐ[μ] (X - μ[X | m]) ^ 2 :=
   condExp_of_aestronglyMeasurable' _ ((continuous_pow _).comp_aestronglyMeasurable
     (hX.sub stronglyMeasurable_condExp.aestronglyMeasurable)) hXint
@@ -92,7 +92,7 @@ lemma integrable_condVar : Integrable Var[X; μ | m] μ := integrable_condExp
 
 /-- The integral of the conditional variance `Var[X | m]` over an `m`-measurable set is equal to
 the integral of `(X - μ[X | m]) ^ 2` on that set. -/
-lemma setIntegral_condVar [SigmaFinite (μ.trim hm)] (hX : Integrable ((X - μ[X|m]) ^ 2) μ)
+lemma setIntegral_condVar [SigmaFinite (μ.trim hm)] (hX : Integrable ((X - μ[X | m]) ^ 2) μ)
     (hs : MeasurableSet[m] s) :
     ∫ ω in s, (Var[X; μ | m]) ω ∂μ = ∫ ω in s, (X ω - (μ[X | m]) ω) ^ 2 ∂μ :=
   setIntegral_condExp _ hX hs

--- a/Mathlib/Probability/Independence/Conditional.lean
+++ b/Mathlib/Probability/Independence/Conditional.lean
@@ -261,7 +261,7 @@ end
 section CondIndep
 
 lemma condIndep_iff_condIndepSets (m' m₁ m₂ : MeasurableSpace Ω) {mΩ : MeasurableSpace Ω}
-    [StandardBorelSpace Ω] (hm' : m' ≤ mΩ) (μ : Measure Ω ) [IsFiniteMeasure μ] :
+    [StandardBorelSpace Ω] (hm' : m' ≤ mΩ) (μ : Measure Ω) [IsFiniteMeasure μ] :
     CondIndep m' m₁ m₂ hm' μ
       ↔ CondIndepSets m' hm' {s | MeasurableSet[m₁] s} {s | MeasurableSet[m₂] s} μ := by
   simp only [CondIndep, CondIndepSets, Kernel.Indep]

--- a/Mathlib/Probability/Kernel/Composition/IntegralCompProd.lean
+++ b/Mathlib/Probability/Kernel/Composition/IntegralCompProd.lean
@@ -481,7 +481,7 @@ lemma integral_compProd [SFinite μ] [IsSFiniteKernel κ] {E : Type*}
 lemma setIntegral_compProd [SFinite μ] [IsSFiniteKernel κ] {E : Type*}
     [NormedAddCommGroup E] [NormedSpace ℝ E]
     {s : Set α} (hs : MeasurableSet s) {t : Set β} (ht : MeasurableSet t)
-    {f : α × β → E} (hf : IntegrableOn f (s ×ˢ t) (μ ⊗ₘ κ))  :
+    {f : α × β → E} (hf : IntegrableOn f (s ×ˢ t) (μ ⊗ₘ κ)) :
     ∫ x in s ×ˢ t, f x ∂(μ ⊗ₘ κ) = ∫ a in s, ∫ b in t, f (a, b) ∂(κ a) ∂μ := by
   rw [Measure.compProd, ProbabilityTheory.setIntegral_compProd hs ht hf]
   simp

--- a/Mathlib/Probability/Moments/ComplexMGF.lean
+++ b/Mathlib/Probability/Moments/ComplexMGF.lean
@@ -80,7 +80,7 @@ lemma complexMGF_id_map (hX : AEMeasurable X μ) : complexMGF id (μ.map X) = co
   · fun_prop
 
 lemma complexMGF_congr_identDistrib {Ω' : Type*} {mΩ' : MeasurableSpace Ω'} {μ' : Measure Ω'}
-    {Y : Ω' → ℝ}  (h : IdentDistrib X Y μ μ') :
+    {Y : Ω' → ℝ} (h : IdentDistrib X Y μ μ') :
     complexMGF X μ = complexMGF Y μ' := by
   rw [← complexMGF_id_map h.aemeasurable_fst, ← complexMGF_id_map h.aemeasurable_snd, h.map_eq]
 

--- a/Mathlib/Probability/Moments/IntegrableExpMul.lean
+++ b/Mathlib/Probability/Moments/IntegrableExpMul.lean
@@ -75,7 +75,7 @@ lemma integrable_exp_mul_of_le_of_le {a b : ℝ}
 /-- If `ω ↦ exp (u * X ω)` is integrable at `u` and `-u`, then it is integrable on `[-u, u]`. -/
 lemma integrable_exp_mul_of_abs_le
     (hu_int_pos : Integrable (fun ω ↦ exp (u * X ω)) μ)
-    (hu_int_neg : Integrable (fun ω ↦ exp (- u * X ω)) μ)
+    (hu_int_neg : Integrable (fun ω ↦ exp (-u * X ω)) μ)
     (htu : |t| ≤ |u|) :
     Integrable (fun ω ↦ exp (t * X ω)) μ := by
   refine integrable_exp_mul_of_le_of_le (a := -|u|) (b := |u|) ?_ ?_ ?_ ?_
@@ -169,7 +169,7 @@ lemma integrable_exp_mul_abs_add (ht_int_pos : Integrable (fun ω ↦ exp ((v + 
 /-- If `ω ↦ exp (t * X ω)` is integrable at `t` and `-t`, then `ω ↦ exp (t * |X ω|)` is
 integrable. -/
 lemma integrable_exp_mul_abs (ht_int_pos : Integrable (fun ω ↦ exp (t * X ω)) μ)
-    (ht_int_neg : Integrable (fun ω ↦ exp (- t * X ω)) μ) :
+    (ht_int_neg : Integrable (fun ω ↦ exp (-t * X ω)) μ) :
     Integrable (fun ω ↦ exp (t * |X ω|)) μ := by
   have h := integrable_exp_mul_abs_add (t := t) (μ := μ) (X := X) (v := 0) ?_ ?_
   · simpa using h
@@ -190,7 +190,7 @@ lemma integrable_exp_abs_mul_abs_add (ht_int_pos : Integrable (fun ω ↦ exp ((
 /-- If `ω ↦ exp (t * X ω)` is integrable at `t` and `-t`, then `ω ↦ exp (|t| * |X ω|)` is
 integrable. -/
 lemma integrable_exp_abs_mul_abs (ht_int_pos : Integrable (fun ω ↦ exp (t * X ω)) μ)
-    (ht_int_neg : Integrable (fun ω ↦ exp (- t * X ω)) μ) :
+    (ht_int_neg : Integrable (fun ω ↦ exp (-t * X ω)) μ) :
     Integrable (fun ω ↦ exp (|t| * |X ω|)) μ := by
   rcases le_total 0 t with ht_nonneg | ht_nonpos
   · simp_rw [abs_of_nonneg ht_nonneg]
@@ -362,7 +362,7 @@ lemma integrable_pow_mul_exp_of_integrable_exp_mul (ht : t ≠ 0)
 integrable for all nonnegative `p : ℝ`. -/
 lemma integrable_rpow_abs_of_integrable_exp_mul (ht : t ≠ 0)
     (ht_int_pos : Integrable (fun ω ↦ exp (t * X ω)) μ)
-    (ht_int_neg : Integrable (fun ω ↦ exp (- t * X ω)) μ) {p : ℝ} (hp : 0 ≤ p) :
+    (ht_int_neg : Integrable (fun ω ↦ exp (-t * X ω)) μ) {p : ℝ} (hp : 0 ≤ p) :
     Integrable (fun ω ↦ |X ω| ^ p) μ := by
   have h := integrable_rpow_abs_mul_exp_of_integrable_exp_mul (μ := μ) (X := X) ht (v := 0) ?_ ?_ hp
   · simpa using h
@@ -373,7 +373,7 @@ lemma integrable_rpow_abs_of_integrable_exp_mul (ht : t ≠ 0)
 integrable for all `n : ℕ`. That is, all moments of `X` are finite. -/
 lemma integrable_pow_abs_of_integrable_exp_mul (ht : t ≠ 0)
     (ht_int_pos : Integrable (fun ω ↦ exp (t * X ω)) μ)
-    (ht_int_neg : Integrable (fun ω ↦ exp (- t * X ω)) μ) (n : ℕ) :
+    (ht_int_neg : Integrable (fun ω ↦ exp (-t * X ω)) μ) (n : ℕ) :
     Integrable (fun ω ↦ |X ω| ^ n) μ := by
   convert integrable_rpow_abs_of_integrable_exp_mul ht ht_int_pos ht_int_neg
     (by positivity : 0 ≤ (n : ℝ)) with ω
@@ -383,7 +383,7 @@ lemma integrable_pow_abs_of_integrable_exp_mul (ht : t ≠ 0)
 integrable for all nonnegative `p : ℝ`. -/
 lemma integrable_rpow_of_integrable_exp_mul (ht : t ≠ 0)
     (ht_int_pos : Integrable (fun ω ↦ exp (t * X ω)) μ)
-    (ht_int_neg : Integrable (fun ω ↦ exp (- t * X ω)) μ) {p : ℝ} (hp : 0 ≤ p) :
+    (ht_int_neg : Integrable (fun ω ↦ exp (-t * X ω)) μ) {p : ℝ} (hp : 0 ≤ p) :
     Integrable (fun ω ↦ X ω ^ p) μ := by
   have h := integrable_rpow_mul_exp_of_integrable_exp_mul (μ := μ) (X := X) ht (v := 0) ?_ ?_ hp
   · simpa using h
@@ -394,7 +394,7 @@ lemma integrable_rpow_of_integrable_exp_mul (ht : t ≠ 0)
 integrable for all `n : ℕ`. -/
 lemma integrable_pow_of_integrable_exp_mul (ht : t ≠ 0)
     (ht_int_pos : Integrable (fun ω ↦ exp (t * X ω)) μ)
-    (ht_int_neg : Integrable (fun ω ↦ exp (- t * X ω)) μ) (n : ℕ) :
+    (ht_int_neg : Integrable (fun ω ↦ exp (-t * X ω)) μ) (n : ℕ) :
     Integrable (fun ω ↦ X ω ^ n) μ := by
   convert integrable_rpow_of_integrable_exp_mul ht ht_int_pos ht_int_neg
     (by positivity : 0 ≤ (n : ℝ)) with ω

--- a/Mathlib/RepresentationTheory/Homological/GroupCohomology/LowDegree.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupCohomology/LowDegree.lean
@@ -1161,7 +1161,7 @@ def H0Iso : H0 A ≅ ModuleCat.of k A.ρ.invariants :=
 noncomputable alias isoH0 := H0Iso
 
 @[reassoc (attr := simp), elementwise (attr := simp)]
-lemma π_comp_H0Iso_hom  :
+lemma π_comp_H0Iso_hom :
     π A 0 ≫ (H0Iso A).hom = (cocyclesIso₀ A).hom := by
   simp [H0Iso]
 
@@ -1254,7 +1254,7 @@ def H1Iso : H1 A ≅ (shortComplexH1 A).moduleCatLeftHomologyData.H :=
 noncomputable alias isoH1 := H1Iso
 
 @[reassoc (attr := simp), elementwise (attr := simp)]
-lemma π_comp_H1Iso_hom  :
+lemma π_comp_H1Iso_hom :
     π A 1 ≫ (H1Iso A).hom = (isoCocycles₁ A).hom ≫
       (shortComplexH1 A).moduleCatLeftHomologyData.π := by
   simp [H1Iso, isoCocycles₁, π, HomologicalComplex.homologyπ, leftHomologyπ]
@@ -1348,7 +1348,7 @@ def H2Iso : H2 A ≅ (shortComplexH2 A).moduleCatLeftHomologyData.H :=
 noncomputable alias isoH2 := H2Iso
 
 @[reassoc (attr := simp), elementwise (attr := simp)]
-lemma π_comp_H2Iso_hom  :
+lemma π_comp_H2Iso_hom :
     π A 2 ≫ (H2Iso A).hom = (isoCocycles₂ A).hom ≫
       (shortComplexH2 A).moduleCatLeftHomologyData.π := by
   simp [H2Iso, isoCocycles₂, π, HomologicalComplex.homologyπ, leftHomologyπ]

--- a/Mathlib/RingTheory/Flat/FaithfullyFlat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/FaithfullyFlat/Basic.lean
@@ -444,7 +444,7 @@ section arbitrary_universe
 /--
 If `M` is a faithfully flat module, then for all linear maps `f`, the map `id ⊗ f = 0`, if and only
 if `f = 0`. -/
-lemma zero_iff_lTensor_zero [h: FaithfullyFlat R M]
+lemma zero_iff_lTensor_zero [h : FaithfullyFlat R M]
     {N : Type*} [AddCommGroup N] [Module R N]
     {N' : Type*} [AddCommGroup N'] [Module R N'] (f : N →ₗ[R] N') :
     f = 0 ↔ LinearMap.lTensor M f = 0 :=

--- a/Mathlib/RingTheory/MvPolynomial/Homogeneous.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Homogeneous.lean
@@ -276,7 +276,7 @@ theorem rename_isHomogeneous_iff {f : σ → τ} (hf : f.Injective) :
     exact Finsupp.sum_mapDomain_index_inj (h := fun _ ↦ id) hf
   · rwa [coeff_rename_mapDomain f hf]
 
-lemma finSuccEquiv_coeff_isHomogeneous {N : ℕ} {φ : MvPolynomial (Fin (N+1)) R} {n : ℕ}
+lemma finSuccEquiv_coeff_isHomogeneous {N : ℕ} {φ : MvPolynomial (Fin (N + 1)) R} {n : ℕ}
     (hφ : φ.IsHomogeneous n) (i j : ℕ) (h : i + j = n) :
     ((finSuccEquiv _ _ φ).coeff i).IsHomogeneous j := by
   intro d hd

--- a/Mathlib/RingTheory/NoetherNormalization.lean
+++ b/Mathlib/RingTheory/NoetherNormalization.lean
@@ -118,7 +118,7 @@ private lemma degreeOf_t_neq_of_neq (hv : v ∈ f.support) (hw : w ∈ f.support
   refine sum_r_mul_neq f v w (fun i ↦ ?_) (fun i ↦ ?_) neq <;>
   exact lt_of_le_of_lt ((monomial_le_degreeOf i ‹_›).trans (degreeOf_le_totalDegree f i)) (by omega)
 
-private lemma leadingCoeff_finSuccEquiv_t  :
+private lemma leadingCoeff_finSuccEquiv_t :
     (finSuccEquiv k n ((T f) ((monomial v) (coeff v f)))).leadingCoeff =
     algebraMap k _ (coeff v f) := by
   rw [monomial_eq, Finsupp.prod_fintype]

--- a/Mathlib/RingTheory/Smooth/StandardSmooth.lean
+++ b/Mathlib/RingTheory/Smooth/StandardSmooth.lean
@@ -110,7 +110,7 @@ variable {R S ι σ}
 variable (P : PreSubmersivePresentation R S ι σ)
 
 include P in
-lemma card_relations_le_card_vars_of_isFinite [Finite ι]  :
+lemma card_relations_le_card_vars_of_isFinite [Finite ι] :
     Nat.card σ ≤ Nat.card ι :=
   Nat.card_le_card_of_injective P.map P.map_inj
 

--- a/Mathlib/RingTheory/TensorProduct/Finite.lean
+++ b/Mathlib/RingTheory/TensorProduct/Finite.lean
@@ -110,7 +110,7 @@ section NontrivialTensorProduct
 
 variable (R M : Type*) [CommRing R] [AddCommGroup M] [Module R M] [Module.Finite R M] [Nontrivial M]
 
-lemma Module.exists_isPrincipal_quotient_of_finite  :
+lemma Module.exists_isPrincipal_quotient_of_finite :
     ∃ N : Submodule R M, N ≠ ⊤ ∧ Submodule.IsPrincipal (⊤ : Submodule R (M ⧸ N)) := by
   obtain ⟨n, f, hf⟩ := @Module.Finite.exists_fin R M _ _ _ _
   let s := { m : ℕ | Submodule.span R (f '' (Fin.val ⁻¹' (Set.Iio m))) ≠ ⊤ }

--- a/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
+++ b/Mathlib/Topology/Algebra/ContinuousMonoidHom.lean
@@ -364,7 +364,7 @@ def mk' (f : M ≃ₜ N) (h : ∀ x y, f (x * y) = f x * f y) : M ≃ₜ* N :=
 
 set_option linter.docPrime false in -- This is about `ContinuousMulEquiv.mk'`
 @[simp]
-lemma coe_mk' (f : M ≃ₜ N) (h : ∀ x y, f (x * y) = f x * f y)  : ⇑(mk' f h) = f := rfl
+lemma coe_mk' (f : M ≃ₜ N) (h : ∀ x y, f (x * y) = f x * f y) : ⇑(mk' f h) = f := rfl
 
 end coe
 

--- a/Mathlib/Topology/Algebra/InfiniteSum/Module.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Module.lean
@@ -220,7 +220,7 @@ lemma MulAction.automorphize_smul_left [Group α] [MulAction α β] (f : β → 
 
 /-- Automorphization of a function into an `R`-`Module` distributes, that is, commutes with the
 `R`-scalar multiplication. -/
-lemma AddAction.automorphize_smul_left [AddGroup α] [AddAction α β]  (f : β → M)
+lemma AddAction.automorphize_smul_left [AddGroup α] [AddAction α β] (f : β → M)
     (g : Quotient (AddAction.orbitRel α β) → R) :
     AddAction.automorphize ((g ∘ (@Quotient.mk' _ (_))) • f)
       = g • (AddAction.automorphize f : Quotient (AddAction.orbitRel α β) → M) := by

--- a/Mathlib/Topology/Algebra/InfiniteSum/Real.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/Real.lean
@@ -68,7 +68,7 @@ theorem summable_sigma_of_nonneg {α} {β : α → Type*} {f : (Σ x, β x) → 
   lift f to (Σx, β x) → ℝ≥0 using hf
   simpa using mod_cast NNReal.summable_sigma
 
-lemma summable_partition {α β : Type*} {f : β → ℝ} (hf : 0 ≤ f) {s : α  → Set β}
+lemma summable_partition {α β : Type*} {f : β → ℝ} (hf : 0 ≤ f) {s : α → Set β}
     (hs : ∀ i, ∃! j, i ∈ s j) : Summable f ↔
       (∀ j, Summable fun i : s j ↦ f i) ∧ Summable fun j ↦ ∑' i : s j, f i := by
   simpa only [← (Set.sigmaEquiv s hs).summable_iff] using summable_sigma_of_nonneg (fun _ ↦ hf _)

--- a/Mathlib/Topology/Algebra/InfiniteSum/UniformOn.lean
+++ b/Mathlib/Topology/Algebra/InfiniteSum/UniformOn.lean
@@ -226,7 +226,7 @@ theorem HasProdLocallyUniformlyOn.tprod_eqOn [T2Space α]
 
 @[to_additive]
 lemma HasProdLocallyUniformlyOn.tendstoLocallyUniformlyOn_finsetRange
-    {f : ℕ → β → α} (h : HasProdLocallyUniformlyOn f g s)  :
+    {f : ℕ → β → α} (h : HasProdLocallyUniformlyOn f g s) :
     TendstoLocallyUniformlyOn (fun N b ↦ ∏ i ∈ Finset.range N, f i b) g atTop s := by
   rw [hasProdLocallyUniformlyOn_iff_tendstoLocallyUniformlyOn] at h
   intro v hv r hr

--- a/Mathlib/Topology/Algebra/Order/Field.lean
+++ b/Mathlib/Topology/Algebra/Order/Field.lean
@@ -191,11 +191,11 @@ theorem Filter.Tendsto.div_atBot {a : 𝕜} (h : Tendsto f l (𝓝 a)) (hg : Ten
   simp only [div_eq_mul_inv]
   exact mul_zero a ▸ h.mul (tendsto_inv_atBot_zero.comp hg)
 
-lemma Filter.Tendsto.const_div_atTop (hg : Tendsto g l atTop) (r : 𝕜)  :
+lemma Filter.Tendsto.const_div_atTop (hg : Tendsto g l atTop) (r : 𝕜) :
     Tendsto (fun n ↦ r / g n) l (𝓝 0) :=
   tendsto_const_nhds.div_atTop hg
 
-lemma Filter.Tendsto.const_div_atBot (hg : Tendsto g l atBot) (r : 𝕜)  :
+lemma Filter.Tendsto.const_div_atBot (hg : Tendsto g l atBot) (r : 𝕜) :
     Tendsto (fun n ↦ r / g n) l (𝓝 0) :=
   tendsto_const_nhds.div_atBot hg
 

--- a/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
+++ b/Mathlib/Topology/Algebra/RestrictedProduct/Basic.lean
@@ -96,7 +96,7 @@ instance : DFunLike (Πʳ i, [R i, A i]_[𝓕]) ι R where
   coe_injective' _ _ := Subtype.ext
 
 @[ext]
-lemma ext {x y :  Πʳ i, [R i, A i]_[𝓕]} (h : ∀ i, x i = y i) : x = y :=
+lemma ext {x y : Πʳ i, [R i, A i]_[𝓕]} (h : ∀ i, x i = y i) : x = y :=
   Subtype.ext <| funext h
 
 lemma range_coe :

--- a/Mathlib/Topology/CWComplex/Classical/Finite.lean
+++ b/Mathlib/Topology/CWComplex/Classical/Finite.lean
@@ -163,7 +163,7 @@ lemma CWComplex.finiteType_mkFiniteType.{u} {X : Type u} [TopologicalSpace X] (C
       MapsTo (map n i) (sphere 0 1) (⋃ (m < n) (j : cell m), map m j '' closedBall 0 1))
     (closed' : ∀ (A : Set X) (_ : A ⊆ C),
       (∀ n j, IsClosed (A ∩ map n j '' closedBall 0 1)) → IsClosed A)
-    (union' :  ⋃ (n : ℕ) (j : cell n), map n j '' closedBall 0 1 = C) :
+    (union' : ⋃ (n : ℕ) (j : cell n), map n j '' closedBall 0 1 = C) :
     letI := mkFiniteType C cell map finite_cell source_eq continuousOn continuousOn_symm
       pairwiseDisjoint' mapsTo closed' union'
     FiniteType C :=
@@ -225,7 +225,7 @@ def RelCWComplex.mkFinite.{u} {X : Type u} [TopologicalSpace X] (C : Set X)
 /-- A CW complex that was constructed using `RelCWComplex.mkFinite` is finite. -/
 lemma RelCWComplex.finite_mkFinite.{u} {X : Type u} [TopologicalSpace X] (C : Set X)
     (D : outParam (Set X)) (cell : (n : ℕ) → Type u)
-    (map : (n : ℕ)  → (i : cell n) → PartialEquiv (Fin n → ℝ) X)
+    (map : (n : ℕ) → (i : cell n) → PartialEquiv (Fin n → ℝ) X)
     (eventually_isEmpty_cell : ∀ᶠ n in Filter.atTop, IsEmpty (cell n))
     (finite_cell : ∀ (n : ℕ), _root_.Finite (cell n))
     (source_eq : ∀ (n : ℕ) (i : cell n), (map n i).source = ball 0 1)
@@ -276,7 +276,7 @@ def CWComplex.mkFinite.{u} {X : Type u} [TopologicalSpace X] (C : Set X)
 
 /-- A CW complex that was constructed using `CWComplex.mkFinite` is finite. -/
 lemma CWComplex.finite_mkFinite.{u} {X : Type u} [TopologicalSpace X] (C : Set X)
-    (cell : (n : ℕ) → Type u) (map : (n : ℕ)  → (i : cell n) → PartialEquiv (Fin n → ℝ) X)
+    (cell : (n : ℕ) → Type u) (map : (n : ℕ) → (i : cell n) → PartialEquiv (Fin n → ℝ) X)
     (eventually_isEmpty_cell : ∀ᶠ n in Filter.atTop, IsEmpty (cell n))
     (finite_cell : ∀ (n : ℕ), _root_.Finite (cell n))
     (source_eq : ∀ (n : ℕ) (i : cell n), (map n i).source = ball 0 1)

--- a/Mathlib/Topology/EMetricSpace/Lipschitz.lean
+++ b/Mathlib/Topology/EMetricSpace/Lipschitz.lean
@@ -364,7 +364,7 @@ protected theorem continuous {f : α → β} (hf : LocallyLipschitz f) : Continu
   exact (hK.continuousOn).continuousAt ht
 
 /-- The composition of locally Lipschitz functions is locally Lipschitz. -/
-protected lemma comp  {f : β → γ} {g : α → β}
+protected lemma comp {f : β → γ} {g : α → β}
     (hf : LocallyLipschitz f) (hg : LocallyLipschitz g) : LocallyLipschitz (f ∘ g) := by
   intro x
   -- g is Lipschitz on t ∋ x, f is Lipschitz on u ∋ g(x)

--- a/Mathlib/Topology/Homeomorph/Lemmas.lean
+++ b/Mathlib/Topology/Homeomorph/Lemmas.lean
@@ -520,7 +520,7 @@ lemma isHomeomorph_iff_isEmbedding_surjective : IsHomeomorph f ↔ IsEmbedding f
 alias isHomeomorph_iff_embedding_surjective := isHomeomorph_iff_isEmbedding_surjective
 
 /-- A map is a homeomorphism iff it is continuous, closed and bijective. -/
-lemma isHomeomorph_iff_continuous_isClosedMap_bijective  : IsHomeomorph f ↔
+lemma isHomeomorph_iff_continuous_isClosedMap_bijective : IsHomeomorph f ↔
     Continuous f ∧ IsClosedMap f ∧ Function.Bijective f :=
   ⟨fun hf => ⟨hf.continuous, hf.isClosedMap, hf.bijective⟩, fun ⟨hf, hf', hf''⟩ =>
     ⟨hf, fun _ hu => isClosed_compl_iff.1 (image_compl_eq hf'' ▸ hf' _ hu.isClosed_compl), hf''⟩⟩

--- a/Mathlib/Topology/Homotopy/Lifting.lean
+++ b/Mathlib/Topology/Homotopy/Lifting.lean
@@ -258,7 +258,7 @@ lemma eq_liftPath_iff {Γ : I → E} : Γ = cov.liftPath γ e γ_0 ↔ Continuou
     Γ_cont (cov.liftPath γ e γ_0).continuous (Γ_lifts ▸ lifts.symm) 0 (Γ_0 ▸ zero.symm)⟩
 
 /-- Unique characterization of the lifted path. -/
-lemma eq_liftPath_iff' {Γ : C(I,E)} : Γ = cov.liftPath γ e γ_0 ↔ p ∘ Γ = γ ∧ Γ 0 = e := by
+lemma eq_liftPath_iff' {Γ : C(I, E)} : Γ = cov.liftPath γ e γ_0 ↔ p ∘ Γ = γ ∧ Γ 0 = e := by
   simp_rw [← DFunLike.coe_fn_eq, eq_liftPath_iff, and_iff_right (ContinuousMap.continuous _)]
 
 end path_lifting

--- a/Mathlib/Topology/LocallyFinsupp.lean
+++ b/Mathlib/Topology/LocallyFinsupp.lean
@@ -196,7 +196,7 @@ protected def addSubgroup [AddCommGroup Y] : AddSubgroup (X → Y) where
   neg_mem' {f} hf := by
     simp_all
 
-protected lemma memAddSubgroup  [AddCommGroup Y] (D : locallyFinsuppWithin U Y) :
+protected lemma memAddSubgroup [AddCommGroup Y] (D : locallyFinsuppWithin U Y) :
     (D : X → Y) ∈ locallyFinsuppWithin.addSubgroup U :=
   ⟨D.supportWithinDomain, D.supportLocallyFiniteWithinDomain⟩
 

--- a/Mathlib/Topology/MetricSpace/Ultra/Basic.lean
+++ b/Mathlib/Topology/MetricSpace/Ultra/Basic.lean
@@ -96,14 +96,14 @@ lemma ball_eq_or_disjoint :
   have h₂ := ball_eq_of_mem <| Set.inter_subset_right h.some_mem
   exact h₁.trans h₂.symm
 
-lemma closedBall_eq_of_mem {x y: X} {r : ℝ} (h : y ∈ closedBall x r) :
+lemma closedBall_eq_of_mem {x y : X} {r : ℝ} (h : y ∈ closedBall x r) :
     closedBall x r = closedBall y r := by
   ext
   simp_rw [mem_closedBall] at h ⊢
   constructor <;> intro h' <;>
   exact (dist_triangle_max _ _ _).trans (max_le h' (dist_comm x _ ▸ h))
 
-lemma mem_closedBall_iff {x y: X} {r : ℝ} :
+lemma mem_closedBall_iff {x y : X} {r : ℝ} :
     y ∈ closedBall x r ↔ x ∈ closedBall y r := by
   cases le_or_gt 0 r with
   | inl hr =>

--- a/Mathlib/Topology/MetricSpace/UniformConvergence.lean
+++ b/Mathlib/Topology/MetricSpace/UniformConvergence.lean
@@ -263,7 +263,7 @@ lemma lipschitzWith_one_ofFun_toFun' [Finite 𝔗] (h : ⋃₀ 𝔖 ⊆ ⋃₀ �
     LipschitzWith 1 (ofFun 𝔖 ∘ toFun 𝔗 : (α →ᵤ[𝔗] β) → (α →ᵤ[𝔖] β)) :=
   lipschitzWith_iff.mpr fun _x hx ↦ lipschitzWith_eval (h hx)
 
-lemma lipschitzWith_restrict (s : Set α) (hs : s ∈ 𝔖)  :
+lemma lipschitzWith_restrict (s : Set α) (hs : s ∈ 𝔖) :
     LipschitzWith 1 (UniformFun.ofFun ∘ s.restrict ∘ toFun 𝔖 : (α →ᵤ[𝔖] β) → (s →ᵤ β)) :=
   UniformFun.lipschitzWith_iff.mpr fun x ↦ lipschitzWith_eval ⟨s, hs, x.2⟩
 

--- a/Mathlib/Topology/UniformSpace/LocallyUniformConvergence.lean
+++ b/Mathlib/Topology/UniformSpace/LocallyUniformConvergence.lean
@@ -210,7 +210,7 @@ theorem tendstoLocallyUniformlyOn_iff_forall_isCompact [LocallyCompactSpace α] 
     TendstoLocallyUniformlyOn F f p s ↔ ∀ K, K ⊆ s → IsCompact K → TendstoUniformlyOn F f p K :=
   (tendstoLocallyUniformlyOn_TFAE F f p hs).out 0 1
 
-lemma tendstoLocallyUniformly_iff_forall_isCompact [LocallyCompactSpace α]  :
+lemma tendstoLocallyUniformly_iff_forall_isCompact [LocallyCompactSpace α] :
     TendstoLocallyUniformly F f p ↔ ∀ K : Set α, IsCompact K → TendstoUniformlyOn F f p K := by
   simp only [← tendstoLocallyUniformlyOn_univ,
     tendstoLocallyUniformlyOn_iff_forall_isCompact isOpen_univ, Set.subset_univ, forall_true_left]

--- a/Mathlib/Topology/UnitInterval.lean
+++ b/Mathlib/Topology/UnitInterval.lean
@@ -265,7 +265,7 @@ lemma monotone_addNSMul (hδ : 0 ≤ δ) : Monotone (addNSMul h δ) :=
   fun _ _ hnm ↦ monotone_projIcc h <| (add_le_add_iff_left _).mpr (nsmul_le_nsmul_left hδ hnm)
 
 lemma abs_sub_addNSMul_le (hδ : 0 ≤ δ) {t : Icc a b} (n : ℕ)
-    (ht : t ∈ Icc (addNSMul h δ n) (addNSMul h δ (n+1))) :
+    (ht : t ∈ Icc (addNSMul h δ n) (addNSMul h δ (n + 1))) :
     (|t - addNSMul h δ n| : α) ≤ δ :=
   calc
     (|t - addNSMul h δ n| : α) = t - addNSMul h δ n            := abs_eq_self.2 <| sub_nonneg.2 ht.1


### PR DESCRIPTION
Found by #26706: likely not exhaustive, but a good first approximation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
