### PR TITLE
[Merged by Bors] - feat(SimpleGraph): lemmas relating edges and darts to the support

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -830,7 +830,7 @@ theorem edges_eq_zipWith_support {u v : V} {p : G.Walk u v} :
   | nil => simp
   | cons _ p' ih => cases p' <;> simp [edges_cons, ih]
 
-theorem darts_eq_getVert {u v : V} {p : G.Walk u v} (n : ℕ) (h : n < p.darts.length) :
+theorem darts_getElem_eq_getVert {u v : V} {p : G.Walk u v} (n : ℕ) (h : n < p.darts.length) :
     p.darts[n] = ⟨⟨p.getVert n, p.getVert (n + 1)⟩, p.adj_getVert_succ (p.length_darts ▸ h)⟩ := by
   rw [p.length_darts] at h
   ext
@@ -1122,11 +1122,12 @@ lemma edge_lastDart (p : G.Walk v w) (hp : ¬ p.Nil) :
 
 theorem firstDart_eq {p : G.Walk v w} (h₁ : ¬ p.Nil) (h₂ : 0 < p.darts.length) :
     p.firstDart h₁ = p.darts[0] := by
-  simp [Dart.ext_iff, firstDart_toProd, darts_eq_getVert]
+  simp [Dart.ext_iff, firstDart_toProd, darts_getElem_eq_getVert]
 
 theorem lastDart_eq {p : G.Walk v w} (h₁ : ¬ p.Nil) (h₂ : 0 < p.darts.length) :
     p.lastDart h₁ = p.darts[p.darts.length - 1] := by
-  simp (disch := grind) [Dart.ext_iff, lastDart_toProd, darts_eq_getVert, p.getVert_of_length_le]
+  simp (disch := grind) [Dart.ext_iff, lastDart_toProd, darts_getElem_eq_getVert,
+    p.getVert_of_length_le]
 
 lemma cons_tail_eq (p : G.Walk u v) (hp : ¬ p.Nil) :
     cons (p.adj_snd hp) p.tail = p := by

--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -824,22 +824,22 @@ theorem nodup_tail_support_reverse {u : V} {p : G.Walk u u} :
     ← getVert_eq_support_getElem? _ (by rw [Walk.length_support]; cutsat)]
   aesop
 
-theorem edges_eq_support {u v : V} {p : G.Walk u v} :
-    p.edges = (p.support.zip p.support.tail).map (fun x ↦ s(x.1, x.2)) := by
+theorem edges_eq_zipWith_support {u v : V} {p : G.Walk u v} :
+    p.edges = List.zipWith (s(·, ·)) p.support p.support.tail := by
   induction p with
   | nil => simp
   | cons _ p' ih => cases p' <;> simp [edges_cons, ih]
 
-theorem darts_toProd_eq {u v : V} {p : G.Walk u v} (n : ℕ) (h : n < p.darts.length) :
-    p.darts[n].toProd = (p.getVert n, p.getVert (n + 1)) := by
+theorem darts_eq_getVert {u v : V} {p : G.Walk u v} (n : ℕ) (h : n < p.darts.length) :
+    p.darts[n] = ⟨⟨p.getVert n, p.getVert (n + 1)⟩, p.adj_getVert_succ (p.length_darts ▸ h)⟩ := by
   rw [p.length_darts] at h
-  repeat rw [p.getVert_eq_support_getElem (by omega)]
   ext
-  · by_cases h' : n = 0
+  · simp only [p.getVert_eq_support_getElem (le_of_lt h)]
+    by_cases h' : n = 0
     · simp [h', List.getElem_zero]
     · have := p.isChain_dartAdj_darts.getElem (n - 1) (by grind)
       grind [DartAdj, =_ cons_map_snd_darts]
-  · simp [← p.cons_map_snd_darts]
+  · simp [p.getVert_eq_support_getElem h, ← p.cons_map_snd_darts]
 
 theorem edges_injective {u v : V} : Function.Injective (Walk.edges : G.Walk u v → List (Sym2 V))
   | .nil, .nil, _ => rfl
@@ -1120,13 +1120,13 @@ lemma edge_firstDart (p : G.Walk v w) (hp : ¬ p.Nil) :
 lemma edge_lastDart (p : G.Walk v w) (hp : ¬ p.Nil) :
     (p.lastDart hp).edge = s(p.penultimate, w) := rfl
 
-theorem firstDart_eq {p : G.Walk v w} (h₁ : ¬p.Nil) (h₂ : 0 < p.darts.length) :
+theorem firstDart_eq {p : G.Walk v w} (h₁ : ¬ p.Nil) (h₂ : 0 < p.darts.length) :
     p.firstDart h₁ = p.darts[0] := by
-  simp [Dart.ext_iff, firstDart_toProd, darts_toProd_eq]
+  simp [Dart.ext_iff, firstDart_toProd, darts_eq_getVert]
 
-theorem lastDart_eq {p : G.Walk v w} (h₁ : ¬p.Nil) (h₂ : 0 < p.darts.length) :
+theorem lastDart_eq {p : G.Walk v w} (h₁ : ¬ p.Nil) (h₂ : 0 < p.darts.length) :
     p.lastDart h₁ = p.darts[p.darts.length - 1] := by
-  simp (disch := omega) [Dart.ext_iff, lastDart_toProd, darts_toProd_eq, p.getVert_of_length_le]
+  simp (disch := grind) [Dart.ext_iff, lastDart_toProd, darts_eq_getVert, p.getVert_of_length_le]
 
 lemma cons_tail_eq (p : G.Walk u v) (hp : ¬ p.Nil) :
     cons (p.adj_snd hp) p.tail = p := by

--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -837,7 +837,7 @@ theorem darts_toProd_eq {u v : V} {p : G.Walk u v} (n : ℕ) (h : n < p.darts.le
   ext
   · by_cases h' : n = 0
     · simp [h', List.getElem_zero]
-    · have := List.chain'_getElem p.chain'_dartAdj_darts (n - 1) (by omega)
+    · have := p.chain'_dartAdj_darts.getElem (n - 1) (by grind)
       grind [DartAdj, =_ cons_map_snd_darts]
   · simp [← p.cons_map_snd_darts]
 
@@ -1581,3 +1581,5 @@ lemma isSubwalk_antisymm {u v} {p₁ p₂ : G.Walk u v} (h₁ : p₁.IsSubwalk p
 end Walk
 
 end SimpleGraph
+
+set_option linter.style.longFile 1700

--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -838,8 +838,7 @@ theorem darts_toProd_eq {u v : V} {p : G.Walk u v} (n : ℕ) (h : n < p.darts.le
   · by_cases h' : n = 0
     · simp [h', List.getElem_zero]
     · have := List.chain'_getElem p.chain'_dartAdj_darts (n - 1) (by omega)
-      simp only [DartAdj, show n - 1 + 1 = n by omega] at this
-      simp [← p.cons_map_snd_darts, List.getElem_cons, ← this, h']
+      grind [DartAdj, =_ cons_map_snd_darts]
   · simp [← p.cons_map_snd_darts]
 
 theorem edges_injective {u v : V} : Function.Injective (Walk.edges : G.Walk u v → List (Sym2 V))
@@ -1120,6 +1119,14 @@ lemma edge_firstDart (p : G.Walk v w) (hp : ¬ p.Nil) :
 
 lemma edge_lastDart (p : G.Walk v w) (hp : ¬ p.Nil) :
     (p.lastDart hp).edge = s(p.penultimate, w) := rfl
+
+theorem firstDart_eq {p : G.Walk v w} (h₁ : ¬p.Nil) (h₂ : 0 < p.darts.length) :
+    p.firstDart h₁ = p.darts[0] := by
+  simp [Dart.ext_iff, firstDart_toProd, darts_toProd_eq]
+
+theorem lastDart_eq {p : G.Walk v w} (h₁ : ¬p.Nil) (h₂ : 0 < p.darts.length) :
+    p.lastDart h₁ = p.darts[p.darts.length - 1] := by
+  simp (disch := omega) [Dart.ext_iff, lastDart_toProd, darts_toProd_eq, p.getVert_of_length_le]
 
 lemma cons_tail_eq (p : G.Walk u v) (hp : ¬ p.Nil) :
     cons (p.adj_snd hp) p.tail = p := by

--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -824,6 +824,24 @@ theorem nodup_tail_support_reverse {u : V} {p : G.Walk u u} :
     ← getVert_eq_support_getElem? _ (by rw [Walk.length_support]; cutsat)]
   aesop
 
+theorem edges_eq_support {u v : V} {p : G.Walk u v} :
+    p.edges = (p.support.zip p.support.tail).map (fun x ↦ s(x.1, x.2)) := by
+  induction p with
+  | nil => simp
+  | cons _ p' ih => cases p' <;> simp [edges_cons, ih]
+
+theorem darts_toProd_eq {u v : V} {p : G.Walk u v} (n : ℕ) (h : n < p.darts.length) :
+    p.darts[n].toProd = (p.getVert n, p.getVert (n + 1)) := by
+  rw [p.length_darts] at h
+  repeat rw [p.getVert_eq_support_getElem (by omega)]
+  ext
+  · by_cases h' : n = 0
+    · simp [h', List.getElem_zero]
+    · have := List.chain'_getElem p.chain'_dartAdj_darts (n - 1) (by omega)
+      simp only [DartAdj, show n - 1 + 1 = n by omega] at this
+      simp [← p.cons_map_snd_darts, List.getElem_cons, ← this, h']
+  · simp [← p.cons_map_snd_darts]
+
 theorem edges_injective {u v : V} : Function.Injective (Walk.edges : G.Walk u v → List (Sym2 V))
   | .nil, .nil, _ => rfl
   | .nil, .cons _ _, h => by simp at h

--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -837,7 +837,7 @@ theorem darts_toProd_eq {u v : V} {p : G.Walk u v} (n : ℕ) (h : n < p.darts.le
   ext
   · by_cases h' : n = 0
     · simp [h', List.getElem_zero]
-    · have := p.chain'_dartAdj_darts.getElem (n - 1) (by grind)
+    · have := p.isChain_dartAdj_darts.getElem (n - 1) (by grind)
       grind [DartAdj, =_ cons_map_snd_darts]
   · simp [← p.cons_map_snd_darts]
 


### PR DESCRIPTION
Useful lemmas to make it easier to pass between the support/edges/darts of a walk.

- [x] depends on: #25812

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
