### PR TITLE
[Merged by Bors] - feat(SimpleGraph): sub-walks of minimal length are also minimal

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Metric.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
@@ -278,6 +278,20 @@ lemma dist_top_of_ne (h : u ≠ v) : (⊤ : SimpleGraph V).dist u v = 1 := by
 lemma dist_top [DecidableEq V] : (⊤ : SimpleGraph V).dist u v = (if u = v then 0 else 1) := by
   by_cases h : u = v <;> simp [h]
 
+lemma length_eq_dist_of_subwalk {u' v' : V} {p₁ : G.Walk u v} {p₂ : G.Walk u' v'}
+    (h₁ : p₁.length = G.dist u v) (h₂ : p₂.IsSubwalk p₁) : p₂.length = G.dist u' v' := by
+  by_contra hh
+  rcases show p₂.length < G.dist u' v'  ∨ p₂.length > G.dist u' v' by omega
+  · have := SimpleGraph.dist_le p₂
+    omega
+  · obtain ⟨ru, rv, h⟩ := h₂
+    obtain ⟨s, _⟩ := p₂.reachable.exists_path_of_dist
+    let r := ru.append s |>.append rv
+    have : p₁.length = ru.length + p₂.length + rv.length := by simp [h]
+    have : r.length = ru.length + s.length + rv.length := by simp [r]
+    have := SimpleGraph.dist_le r
+    omega
+
 /-- Supergraphs have smaller or equal distances to their subgraphs. -/
 @[gcongr]
 protected theorem Reachable.dist_anti {G' : SimpleGraph V} (h : G ≤ G') (hr : G.Reachable u v) :

--- a/Mathlib/Combinatorics/SimpleGraph/Metric.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
@@ -281,7 +281,7 @@ lemma dist_top [DecidableEq V] : (⊤ : SimpleGraph V).dist u v = (if u = v then
 lemma length_eq_dist_of_subwalk {u' v' : V} {p₁ : G.Walk u v} {p₂ : G.Walk u' v'}
     (h₁ : p₁.length = G.dist u v) (h₂ : p₂.IsSubwalk p₁) : p₂.length = G.dist u' v' := by
   by_contra hh
-  rcases show p₂.length < G.dist u' v'  ∨ p₂.length > G.dist u' v' by omega
+  rcases show p₂.length < G.dist u' v' ∨ p₂.length > G.dist u' v' by omega
   · have := SimpleGraph.dist_le p₂
     omega
   · obtain ⟨ru, rv, h⟩ := h₂

--- a/Mathlib/Combinatorics/SimpleGraph/Metric.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
@@ -280,7 +280,7 @@ lemma dist_top [DecidableEq V] : (⊤ : SimpleGraph V).dist u v = (if u = v then
 
 lemma length_eq_dist_of_subwalk {u' v' : V} {p₁ : G.Walk u v} {p₂ : G.Walk u' v'}
     (h₁ : p₁.length = G.dist u v) (h₂ : p₂.IsSubwalk p₁) : p₂.length = G.dist u' v' := by
-  by_contra hh
+  by_contra! hh
   rcases show p₂.length < G.dist u' v' ∨ p₂.length > G.dist u' v' by omega
   · have := SimpleGraph.dist_le p₂
     omega

--- a/Mathlib/Combinatorics/SimpleGraph/Metric.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
@@ -281,7 +281,7 @@ lemma dist_top [DecidableEq V] : (⊤ : SimpleGraph V).dist u v = (if u = v then
 lemma length_eq_dist_of_subwalk {u' v' : V} {p₁ : G.Walk u v} {p₂ : G.Walk u' v'}
     (h₁ : p₁.length = G.dist u v) (h₂ : p₂.IsSubwalk p₁) : p₂.length = G.dist u' v' := by
   by_contra! hh
-  rcases show p₂.length < G.dist u' v' ∨ p₂.length > G.dist u' v' by omega
+  cases hh.lt_or_gt
   · have := SimpleGraph.dist_le p₂
     omega
   · obtain ⟨ru, rv, h⟩ := h₂

--- a/Mathlib/Combinatorics/SimpleGraph/Metric.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
@@ -280,17 +280,14 @@ lemma dist_top [DecidableEq V] : (⊤ : SimpleGraph V).dist u v = (if u = v then
 
 lemma length_eq_dist_of_subwalk {u' v' : V} {p₁ : G.Walk u v} {p₂ : G.Walk u' v'}
     (h₁ : p₁.length = G.dist u v) (h₂ : p₂.IsSubwalk p₁) : p₂.length = G.dist u' v' := by
-  by_contra! hh
-  cases hh.lt_or_gt
-  · have := SimpleGraph.dist_le p₂
-    omega
-  · obtain ⟨ru, rv, h⟩ := h₂
-    obtain ⟨s, _⟩ := p₂.reachable.exists_path_of_dist
-    let r := ru.append s |>.append rv
-    have : p₁.length = ru.length + p₂.length + rv.length := by simp [h]
-    have : r.length = ru.length + s.length + rv.length := by simp [r]
-    have := SimpleGraph.dist_le r
-    omega
+  refine (dist_le _).eq_of_not_lt' fun hh ↦ ?_
+  obtain ⟨ru, rv, h⟩ := h₂
+  obtain ⟨s, _⟩ := p₂.reachable.exists_path_of_dist
+  let r := ru.append s |>.append rv
+  have : p₁.length = ru.length + p₂.length + rv.length := by simp [h]
+  have : r.length = ru.length + s.length + rv.length := by simp [r]
+  have := dist_le r
+  omega
 
 /-- Supergraphs have smaller or equal distances to their subgraphs. -/
 @[gcongr]


### PR DESCRIPTION
Helper lemma to show that sub-walks of minimal length walks are also of minimal length.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [x] depends on: #26655 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
