### PR TITLE
[Merged by Bors] - chore(Data/Set/Disjoint): move `BooleanAlgebra` material to `Order`

### DIFF
--- a/Mathlib/Data/Set/Disjoint.lean
+++ b/Mathlib/Data/Set/Disjoint.lean
@@ -3,13 +3,13 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura
 -/
-import Mathlib.Order.BooleanAlgebra.Set
+import Mathlib.Data.Set.Basic
 
 /-!
 # Theorems about the `Disjoint` relation on `Set`.
 -/
 
-assert_not_exists RelIso
+assert_not_exists HeytingAlgebra RelIso
 
 /-! ### Set coercion to a type -/
 
@@ -80,50 +80,6 @@ lemma disjoint_union_right : Disjoint s (t ∪ u) ↔ Disjoint s t ∧ Disjoint 
 
 @[simp] lemma univ_disjoint : Disjoint univ s ↔ s = ∅ := top_disjoint
 @[simp] lemma disjoint_univ : Disjoint s univ ↔ s = ∅ := disjoint_top
-
-lemma disjoint_sdiff_left : Disjoint (t \ s) s := disjoint_sdiff_self_left
-
-lemma disjoint_sdiff_right : Disjoint s (t \ s) := disjoint_sdiff_self_right
-
--- TODO: prove this in terms of a lattice lemma
-theorem disjoint_sdiff_inter : Disjoint (s \ t) (s ∩ t) :=
-  disjoint_of_subset_right inter_subset_right disjoint_sdiff_left
-
-lemma subset_diff : s ⊆ t \ u ↔ s ⊆ t ∧ Disjoint s u := le_iff_subset.symm.trans le_sdiff
-
-theorem disjoint_of_subset_iff_left_eq_empty (h : s ⊆ t) :
-    Disjoint s t ↔ s = ∅ :=
-  disjoint_of_le_iff_left_eq_bot h
-
-/-! ### Lemmas about complement -/
-
-theorem subset_compl_iff_disjoint_left : s ⊆ tᶜ ↔ Disjoint t s :=
-  @le_compl_iff_disjoint_left (Set α) _ _ _
-
-theorem subset_compl_iff_disjoint_right : s ⊆ tᶜ ↔ Disjoint s t :=
-  @le_compl_iff_disjoint_right (Set α) _ _ _
-
-theorem disjoint_compl_left_iff_subset : Disjoint sᶜ t ↔ t ⊆ s :=
-  disjoint_compl_left_iff
-
-theorem disjoint_compl_right_iff_subset : Disjoint s tᶜ ↔ s ⊆ t :=
-  disjoint_compl_right_iff
-
-alias ⟨_, _root_.Disjoint.subset_compl_right⟩ := subset_compl_iff_disjoint_right
-
-alias ⟨_, _root_.Disjoint.subset_compl_left⟩ := subset_compl_iff_disjoint_left
-
-alias ⟨_, _root_.HasSubset.Subset.disjoint_compl_left⟩ := disjoint_compl_left_iff_subset
-
-alias ⟨_, _root_.HasSubset.Subset.disjoint_compl_right⟩ := disjoint_compl_right_iff_subset
-
-@[simp]
-theorem diff_ssubset_left_iff : s \ t ⊂ s ↔ (s ∩ t).Nonempty :=
-  sdiff_lt_left.trans <| by rw [not_disjoint_iff_nonempty_inter, inter_comm]
-
-theorem _root_.HasSubset.Subset.diff_ssubset_of_nonempty (hst : s ⊆ t) (hs : s.Nonempty) :
-    t \ s ⊂ t := by
-  simpa [inter_eq_self_of_subset_right hst]
 
 theorem disjoint_range_iff {β γ : Sort*} {x : β → α} {y : γ → α} :
     Disjoint (range x) (range y) ↔ ∀ i j, x i ≠ y j := by

--- a/Mathlib/Order/BooleanAlgebra/Set.lean
+++ b/Mathlib/Order/BooleanAlgebra/Set.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura
 -/
 import Mathlib.Data.Set.Disjoint
-import Mathlib.Order.SymmDiff
+import Mathlib.Order.BooleanAlgebra.Basic
 
 /-!
 # Boolean algebra of sets

--- a/Mathlib/Order/BooleanAlgebra/Set.lean
+++ b/Mathlib/Order/BooleanAlgebra/Set.lean
@@ -3,8 +3,8 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura
 -/
-import Mathlib.Data.Set.Basic
-import Mathlib.Order.BooleanAlgebra.Basic
+import Mathlib.Data.Set.Disjoint
+import Mathlib.Order.SymmDiff
 
 /-!
 # Boolean algebra of sets
@@ -159,6 +159,16 @@ theorem inter_subset (a b c : Set α) : a ∩ b ⊆ c ↔ a ⊆ bᶜ ∪ c :=
 
 theorem inter_compl_nonempty_iff {s t : Set α} : (s ∩ tᶜ).Nonempty ↔ ¬s ⊆ t :=
   (not_subset.trans <| exists_congr fun x => by simp).symm
+
+lemma subset_compl_iff_disjoint_left : s ⊆ tᶜ ↔ Disjoint t s := le_compl_iff_disjoint_left
+lemma subset_compl_iff_disjoint_right : s ⊆ tᶜ ↔ Disjoint s t := le_compl_iff_disjoint_right
+lemma disjoint_compl_left_iff_subset : Disjoint sᶜ t ↔ t ⊆ s := disjoint_compl_left_iff
+lemma disjoint_compl_right_iff_subset : Disjoint s tᶜ ↔ s ⊆ t := disjoint_compl_right_iff
+
+alias ⟨_, _root_.Disjoint.subset_compl_right⟩ := subset_compl_iff_disjoint_right
+alias ⟨_, _root_.Disjoint.subset_compl_left⟩ := subset_compl_iff_disjoint_left
+alias ⟨_, _root_.HasSubset.Subset.disjoint_compl_left⟩ := disjoint_compl_left_iff_subset
+alias ⟨_, _root_.HasSubset.Subset.disjoint_compl_right⟩ := disjoint_compl_right_iff_subset
 
 /-! ### Lemmas about set difference -/
 
@@ -333,6 +343,27 @@ theorem union_eq_diff_union_diff_union_inter (s t : Set α) : s ∪ t = s \ t �
 @[simp] lemma sdiff_sep_self (s : Set α) (p : α → Prop) : s \ {a ∈ s | p a} = {a ∈ s | ¬ p a} :=
   diff_self_inter
 
+lemma disjoint_sdiff_left : Disjoint (t \ s) s := disjoint_sdiff_self_left
+
+lemma disjoint_sdiff_right : Disjoint s (t \ s) := disjoint_sdiff_self_right
+
+-- TODO: prove this in terms of a boolean algebra lemma
+lemma disjoint_sdiff_inter : Disjoint (s \ t) (s ∩ t) :=
+  disjoint_of_subset_right inter_subset_right disjoint_sdiff_left
+
+lemma subset_diff : s ⊆ t \ u ↔ s ⊆ t ∧ Disjoint s u := le_iff_subset.symm.trans le_sdiff
+
+lemma disjoint_of_subset_iff_left_eq_empty (h : s ⊆ t) : Disjoint s t ↔ s = ∅ :=
+  disjoint_of_le_iff_left_eq_bot h
+
+@[simp]
+lemma diff_ssubset_left_iff : s \ t ⊂ s ↔ (s ∩ t).Nonempty :=
+  sdiff_lt_left.trans <| by rw [not_disjoint_iff_nonempty_inter, inter_comm]
+
+lemma _root_.HasSubset.Subset.diff_ssubset_of_nonempty (hst : s ⊆ t) (hs : s.Nonempty) :
+    t \ s ⊂ t := by
+  simpa [inter_eq_self_of_subset_right hst]
+
 /-! ### If-then-else for sets -/
 
 /-- `ite` for sets: `Set.ite t s s' ∩ t = s ∩ t`, `Set.ite t s s' ∩ tᶜ = s' ∩ tᶜ`.
@@ -416,4 +447,3 @@ theorem ite_eq_of_subset_right (t : Set α) {s₁ s₂ : Set α} (h : s₂ ⊆ s
   by_cases hx : x ∈ t <;> simp [*, Set.ite, or_iff_left_of_imp (@h x)]
 
 end Set
-


### PR DESCRIPTION
Eventually, all order properties should move out, but this is a good second step that will, among others, unblock #23177.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
