### PR TITLE
[Merged by Bors] - chore: whitespace before `:`

### DIFF
--- a/Mathlib/Algebra/Algebra/Subalgebra/Directed.lean
+++ b/Mathlib/Algebra/Algebra/Subalgebra/Directed.lean
@@ -44,7 +44,7 @@ variable (K)
 it on each subalgebra, and proving that it agrees on the intersection of subalgebras. -/
 noncomputable def iSupLift (dir : Directed (· ≤ ·) K) (f : ∀ i, K i →ₐ[R] B)
     (hf : ∀ (i j : ι) (h : K i ≤ K j), f i = (f j).comp (inclusion h))
-    (T : Subalgebra R A) (hT : T = iSup K): ↥T →ₐ[R] B :=
+    (T : Subalgebra R A) (hT : T = iSup K) : ↥T →ₐ[R] B :=
   { toFun := Set.iUnionLift (fun i => ↑(K i)) (fun i x => f i x)
         (fun i j x hxi hxj => by
           let ⟨k, hik, hjk⟩ := dir i j

--- a/Mathlib/Algebra/BrauerGroup/Defs.lean
+++ b/Mathlib/Algebra/BrauerGroup/Defs.lean
@@ -84,7 +84,7 @@ end IsBrauerEquivalent
 variable (K)
 
 /-- `CSA` equipped with Brauer Equivalence is indeed a setoid. -/
-def Brauer.CSA_Setoid: Setoid (CSA K) where
+def Brauer.CSA_Setoid : Setoid (CSA K) where
   r := IsBrauerEquivalent
   iseqv := IsBrauerEquivalent.is_eqv
 

--- a/Mathlib/Algebra/DirectSum/Idempotents.lean
+++ b/Mathlib/Algebra/DirectSum/Idempotents.lean
@@ -36,7 +36,7 @@ lemma isIdempotentElem_idempotent (i : I) : IsIdempotentElem (idempotent V i : R
 /-- If a semiring can be decomposed into direct sum of finite left ideals `Vᵢ`
   where `1 = e₁ + ... + eₙ` and `eᵢ ∈ Vᵢ`, then `eᵢ` is a family of complete
   orthogonal idempotents. -/
-theorem completeOrthogonalIdempotents_idempotent [Fintype I]:
+theorem completeOrthogonalIdempotents_idempotent [Fintype I] :
     CompleteOrthogonalIdempotents (idempotent V) where
   idem := isIdempotentElem_idempotent V
   ortho i j hij := by

--- a/Mathlib/Algebra/Group/Subgroup/Map.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Map.lean
@@ -117,7 +117,7 @@ theorem coe_map (f : G →* N) (K : Subgroup G) : (K.map f : Set N) = f '' K :=
   rfl
 
 @[to_additive (attr := simp)]
-theorem map_toSubmonoid (f : G →* G') (K : Subgroup G):
+theorem map_toSubmonoid (f : G →* G') (K : Subgroup G) :
   (Subgroup.map f K).toSubmonoid = Submonoid.map f K.toSubmonoid := rfl
 
 @[to_additive (attr := simp)]

--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
@@ -445,7 +445,7 @@ lemma Ext.mk₀_sum {X Y : C} {ι : Type*} [Fintype ι] (f : ι → (X ⟶ Y)) :
 
 /-- `Ext` commutes with biproducts in its first variable. -/
 noncomputable def Ext.biproductAddEquiv {J : Type*} [Fintype J] {X : J → C} {c : Bicone X}
-    (hc : c.IsBilimit) (Y : C) (n : ℕ): Ext c.pt Y n ≃+ Π i, Ext (X i) Y n where
+    (hc : c.IsBilimit) (Y : C) (n : ℕ) : Ext c.pt Y n ≃+ Π i, Ext (X i) Y n where
   toFun e i := (Ext.mk₀ (c.ι i)).comp e (zero_add n)
   invFun e := ∑ (i : J), (Ext.mk₀ (c.π i)).comp (e i) (zero_add n)
   left_inv x := by

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -149,7 +149,7 @@ theorem lowerCentralSeries_map_eq_lcs : (lowerCentralSeries R L N k).map N.incl 
   rw [lowerCentralSeries_eq_lcs_comap, LieSubmodule.map_comap_incl, inf_eq_right]
   apply lcs_le_self
 
-theorem lowerCentralSeries_eq_bot_iff_lcs_eq_bot:
+theorem lowerCentralSeries_eq_bot_iff_lcs_eq_bot :
     lowerCentralSeries R L N k = ⊥ ↔ lcs k N = ⊥ := by
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
   · rw [← N.lowerCentralSeries_map_eq_lcs, ← LieModuleHom.le_ker_iff_map]

--- a/Mathlib/Algebra/Module/Submodule/Ker.lean
+++ b/Mathlib/Algebra/Module/Submodule/Ker.lean
@@ -131,7 +131,7 @@ theorem ker_eq_top {f : M →ₛₗ[τ₁₂] M₂} : ker f = ⊤ ↔ f = 0 :=
   ⟨fun h => ext fun _ => mem_ker.1 <| h.symm ▸ trivial, fun h => h.symm ▸ ker_zero⟩
 
 theorem exists_ne_zero_of_sSup_eq_top {f : M →ₛₗ[τ₁₂] M₂} (h : f ≠ 0) (s : Set (Submodule R M))
-    (hs : sSup s = ⊤): ∃ m ∈ s, f ∘ₛₗ m.subtype ≠ 0 := by
+    (hs : sSup s = ⊤) : ∃ m ∈ s, f ∘ₛₗ m.subtype ≠ 0 := by
   contrapose! h
   simp_rw [← ker_eq_top, eq_top_iff, ← hs, sSup_le_iff, le_ker_iff_comp_subtype_eq_zero]
   exact h

--- a/Mathlib/Algebra/Module/ZLattice/Covolume.lean
+++ b/Mathlib/Algebra/Module/ZLattice/Covolume.lean
@@ -175,7 +175,7 @@ variable {ι : Type*} [Fintype ι] (b : Basis ι ℤ L)
 see the `Naming convention` section in the introduction. -/
 theorem tendsto_card_div_pow'' [FiniteDimensional ℝ E] [MeasurableSpace E] [BorelSpace E]
     {s : Set E} (hs₁ : IsBounded s) (hs₂ : MeasurableSet s)
-    (hs₃ : volume (frontier ((b.ofZLatticeBasis ℝ).equivFun '' s)) = 0):
+    (hs₃ : volume (frontier ((b.ofZLatticeBasis ℝ).equivFun '' s)) = 0) :
     Tendsto (fun n : ℕ ↦ (Nat.card (s ∩ (n : ℝ)⁻¹ • L : Set E) : ℝ) / n ^ card ι)
       atTop (𝓝 (volume.real ((b.ofZLatticeBasis ℝ).equivFun '' s))) := by
   refine Tendsto.congr' ?_

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -572,7 +572,7 @@ theorem mul_pos_iff [ExistsAddOfLE R] [PosMulStrictMono R] [MulPosStrictMono R]
     h.elim (and_imp.2 mul_pos) (and_imp.2 mul_pos_of_neg_of_neg)⟩
 
 theorem mul_nonneg_iff [ExistsAddOfLE R] [MulPosStrictMono R] [PosMulStrictMono R]
-    [AddLeftReflectLE R] [AddLeftMono R]:
+    [AddLeftReflectLE R] [AddLeftMono R] :
     0 ≤ a * b ↔ 0 ≤ a ∧ 0 ≤ b ∨ a ≤ 0 ∧ b ≤ 0 :=
   ⟨nonneg_and_nonneg_or_nonpos_and_nonpos_of_mul_nonneg, fun h =>
     h.elim (and_imp.2 mul_nonneg) (and_imp.2 mul_nonneg_of_nonpos_of_nonpos)⟩

--- a/Mathlib/Algebra/Ring/Semireal/Defs.lean
+++ b/Mathlib/Algebra/Ring/Semireal/Defs.lean
@@ -36,7 +36,7 @@ class IsSemireal [Add R] [Mul R] [One R] [Zero R] : Prop where
   one_add_ne_zero {s : R} (hs : IsSumSq s) : 1 + s ≠ 0
 
 /-- In a semireal ring, `-1` is not a sum of squares. -/
-theorem IsSemireal.not_isSumSq_neg_one [AddGroup R] [One R] [Mul R] [IsSemireal R]:
+theorem IsSemireal.not_isSumSq_neg_one [AddGroup R] [One R] [Mul R] [IsSemireal R] :
     ¬ IsSumSq (-1 : R) := (by simpa using one_add_ne_zero ·)
 
 /--

--- a/Mathlib/Algebra/SkewMonoidAlgebra/Basic.lean
+++ b/Mathlib/Algebra/SkewMonoidAlgebra/Basic.lean
@@ -350,7 +350,7 @@ theorem toFinsupp_sum' {k' G' : Type*} [AddCommMonoid k'] (f : SkewMonoidAlgebra
   _root_.map_sum toFinsuppAddEquiv (fun a ↦ g a (f.coeff a)) f.toFinsupp.support
 
 theorem ofFinsupp_sum {k' G' : Type*} [AddCommMonoid k'] (f : G →₀ k)
-    (g : G → k → G' →₀ k'):
+    (g : G → k → G' →₀ k') :
     (⟨Finsupp.sum f g⟩ : SkewMonoidAlgebra k' G') = sum ⟨f⟩ (⟨g · ·⟩) := by
   apply toFinsupp_injective; simp only [toFinsupp_sum']
 

--- a/Mathlib/AlgebraicGeometry/Modules/Tilde.lean
+++ b/Mathlib/AlgebraicGeometry/Modules/Tilde.lean
@@ -81,7 +81,7 @@ theorem isLocallyFraction_pred {U : Opens (PrimeSpectrum.Top R)}
   rfl
 
 /- M_x is an O_SpecR(U)-module when x is in U -/
-noncomputable instance (U : (Opens (PrimeSpectrum.Top R))ᵒᵖ) (x : U.unop):
+noncomputable instance (U : (Opens (PrimeSpectrum.Top R))ᵒᵖ) (x : U.unop) :
     Module ((Spec.structureSheaf R).val.obj U) (Localizations M x):=
   Module.compHom (R := (Localization.AtPrime x.1.asIdeal)) _
     ((StructureSheaf.openToLocalization R U.unop x x.2).hom)

--- a/Mathlib/Analysis/Calculus/ContDiff/Defs.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Defs.lean
@@ -242,7 +242,7 @@ theorem ContDiffWithinAt.congr_of_eventuallyEq_of_mem (h : ContDiffWithinAt 𝕜
     (h₁ : f₁ =ᶠ[𝓝[s] x] f) (hx : x ∈ s) : ContDiffWithinAt 𝕜 n f₁ s x :=
   h.congr_of_eventuallyEq h₁ <| h₁.self_of_nhdsWithin hx
 
-theorem Filter.EventuallyEq.congr_contDiffWithinAt_of_mem (h₁ : f₁ =ᶠ[𝓝[s] x] f) (hx : x ∈ s):
+theorem Filter.EventuallyEq.congr_contDiffWithinAt_of_mem (h₁ : f₁ =ᶠ[𝓝[s] x] f) (hx : x ∈ s) :
     ContDiffWithinAt 𝕜 n f₁ s x ↔ ContDiffWithinAt 𝕜 n f s x :=
   ⟨fun H ↦ H.congr_of_eventuallyEq_of_mem h₁.symm hx, fun H ↦ H.congr_of_eventuallyEq_of_mem h₁ hx⟩
 

--- a/Mathlib/Analysis/Calculus/LogDeriv.lean
+++ b/Mathlib/Analysis/Calculus/LogDeriv.lean
@@ -57,11 +57,11 @@ theorem logDeriv_div {f g : 𝕜 → 𝕜'} (x : 𝕜) (hf : f x ≠ 0) (hg : g 
   field_simp [mul_comm]
   ring
 
-theorem logDeriv_mul_const {f : 𝕜 → 𝕜'} (x : 𝕜) (a : 𝕜') (ha : a ≠ 0):
+theorem logDeriv_mul_const {f : 𝕜 → 𝕜'} (x : 𝕜) (a : 𝕜') (ha : a ≠ 0) :
     logDeriv (fun z => f z * a) x = logDeriv f x := by
   simp only [logDeriv_apply, deriv_mul_const_field, mul_div_mul_right _ _ ha]
 
-theorem logDeriv_const_mul {f : 𝕜 → 𝕜'} (x : 𝕜) (a : 𝕜') (ha : a ≠ 0):
+theorem logDeriv_const_mul {f : 𝕜 → 𝕜'} (x : 𝕜) (a : 𝕜') (ha : a ≠ 0) :
     logDeriv (fun z => a * f z) x = logDeriv f x := by
   simp only [logDeriv_apply, deriv_const_mul_field, mul_div_mul_left _ _ ha]
 

--- a/Mathlib/Analysis/Complex/Positivity.lean
+++ b/Mathlib/Analysis/Complex/Positivity.lean
@@ -25,7 +25,7 @@ namespace DifferentiableOn
 derivatives at `c` are all nonnegative real has nonnegative real values on `c + [0,r)`. -/
 theorem nonneg_of_iteratedDeriv_nonneg {f : ℂ → ℂ} {c : ℂ} {r : ℝ}
     (hf : DifferentiableOn ℂ f (Metric.ball c r)) (h : ∀ n, 0 ≤ iteratedDeriv n f c) ⦃z : ℂ⦄
-    (hz₁ : c ≤ z) (hz₂ : z ∈ Metric.ball c r):
+    (hz₁ : c ≤ z) (hz₂ : z ∈ Metric.ball c r) :
     0 ≤ f z := by
   have H := taylorSeries_eq_on_ball' hz₂ hf
   rw [← sub_nonneg] at hz₁

--- a/Mathlib/Analysis/InnerProductSpace/JointEigenspace.lean
+++ b/Mathlib/Analysis/InnerProductSpace/JointEigenspace.lean
@@ -116,7 +116,7 @@ open scoped Function -- required for scoped `on` notation
 /-- A commuting family of symmetric linear maps on a finite dimensional inner
 product space is simultaneously diagonalizable. -/
 theorem iSup_iInf_eq_top_of_commute {ι : Type*} {T : ι → E →ₗ[𝕜] E}
-    (hT : ∀ i, (T i).IsSymmetric) (h : Pairwise (Commute on T)):
+    (hT : ∀ i, (T i).IsSymmetric) (h : Pairwise (Commute on T)) :
     ⨆ χ : ι → 𝕜, ⨅ i, eigenspace (T i) (χ i) = ⊤ :=
   calc
   _ = ⨆ χ : ι → 𝕜, ⨅ i, maxGenEigenspace (T i) (χ i) :=

--- a/Mathlib/Analysis/Normed/Lp/WithLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/WithLp.lean
@@ -182,7 +182,7 @@ theorem equiv_neg [AddCommGroup V] (x : WithLp p V) : WithLp.equiv p V (-x) = -W
   rfl
 
 @[deprecated toLp_neg (since := "2025-06-08")]
-theorem equiv_symm_neg [AddCommGroup V] (x' : V):
+theorem equiv_symm_neg [AddCommGroup V] (x' : V) :
     (WithLp.equiv p V).symm (-x') = -(WithLp.equiv p V).symm x' :=
   rfl
 

--- a/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
+++ b/Mathlib/Analysis/NormedSpace/HahnBanach/Separation.lean
@@ -215,7 +215,7 @@ namespace RCLike
 variable [RCLike 𝕜] [Module 𝕜 E] [IsScalarTower ℝ 𝕜 E]
 
 /-- Real linear extension of continuous extension of `LinearMap.extendTo𝕜'` -/
-noncomputable def extendTo𝕜'ₗ [ContinuousConstSMul 𝕜 E]: (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[𝕜] 𝕜) :=
+noncomputable def extendTo𝕜'ₗ [ContinuousConstSMul 𝕜 E] : (E →L[ℝ] ℝ) →ₗ[ℝ] (E →L[𝕜] 𝕜) :=
   letI to𝕜 (fr : (E →L[ℝ] ℝ)) : (E →L[𝕜] 𝕜) :=
     { toLinearMap := LinearMap.extendTo𝕜' fr
       cont := show Continuous fun x ↦ (fr x : 𝕜) - (I : 𝕜) * (fr ((I : 𝕜) • x) : 𝕜) by fun_prop }

--- a/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
@@ -207,7 +207,7 @@ theorem integrableOn_Ioi_deriv_ofReal_cpow {s : ℂ} {t : ℝ} (ht : 0 < t) (hs 
   refine h.congr_fun (fun x hx ↦ ?_) measurableSet_Ioi
   rw [Complex.deriv_ofReal_cpow_const (ht.trans hx).ne' (fun h ↦ (Complex.zero_re ▸ h ▸ hs).false)]
 
-theorem integrableOn_Ioi_deriv_norm_ofReal_cpow {s : ℂ} {t : ℝ} (ht : 0 < t) (hs : s.re ≤ 0):
+theorem integrableOn_Ioi_deriv_norm_ofReal_cpow {s : ℂ} {t : ℝ} (ht : 0 < t) (hs : s.re ≤ 0) :
     IntegrableOn (deriv fun x : ℝ ↦ ‖(x : ℂ) ^ s‖) (Set.Ioi t) := by
   rw [integrableOn_congr_fun (fun x hx ↦ by
     rw [deriv_norm_ofReal_cpow _ (ht.trans hx)]) measurableSet_Ioi]

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/EnoughInjectives.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/EnoughInjectives.lean
@@ -350,7 +350,7 @@ instance : HasFunctorialFactorization (monomorphisms C) (monomorphisms C).rlp :=
 /-- A (functorial) factorization of any morphisms in a Grothendieck abelian category
 as a monomorphism followed by a morphism which has the right lifting property
 with respect to all monomorphisms. -/
-noncomputable abbrev monoMapFactorizationDataRlp {X Y : C} (f : X ⟶ Y):
+noncomputable abbrev monoMapFactorizationDataRlp {X Y : C} (f : X ⟶ Y) :
     MapFactorizationData (monomorphisms C) (monomorphisms C).rlp f :=
   (functorialFactorizationData _ _).factorizationData f
 

--- a/Mathlib/CategoryTheory/Join/Basic.lean
+++ b/Mathlib/CategoryTheory/Join/Basic.lean
@@ -166,20 +166,20 @@ lemma homInduction_edge {P : {x y : C ⋆ D} → (x ⟶ y) → Sort*}
 variable (C D)
 
 /-- The left inclusion is fully faithful. -/
-def inclLeftFullyFaithful: (inclLeft C D).FullyFaithful where
+def inclLeftFullyFaithful : (inclLeft C D).FullyFaithful where
   preimage f := f.down
 
 /-- The right inclusion is fully faithful. -/
-def inclRightFullyFaithful: (inclRight C D).FullyFaithful where
+def inclRightFullyFaithful : (inclRight C D).FullyFaithful where
   preimage f := f.down
 
-instance inclLeftFull: (inclLeft C D).Full := inclLeftFullyFaithful C D |>.full
+instance inclLeftFull : (inclLeft C D).Full := inclLeftFullyFaithful C D |>.full
 
-instance inclRightFull: (inclRight C D).Full := inclRightFullyFaithful C D |>.full
+instance inclRightFull : (inclRight C D).Full := inclRightFullyFaithful C D |>.full
 
-instance inclLeftFaithFull: (inclLeft C D).Faithful := inclLeftFullyFaithful C D |>.faithful
+instance inclLeftFaithFull : (inclLeft C D).Faithful := inclLeftFullyFaithful C D |>.faithful
 
-instance inclRightFaithfull: (inclRight C D).Faithful := inclRightFullyFaithful C D |>.faithful
+instance inclRightFaithfull : (inclRight C D).Faithful := inclRightFullyFaithful C D |>.faithful
 
 variable {C} in
 /-- A situational lemma to help putting identities in the form `(inclLeft _ _).map _` when using

--- a/Mathlib/CategoryTheory/Monoidal/End.lean
+++ b/Mathlib/CategoryTheory/Monoidal/End.lean
@@ -143,7 +143,7 @@ theorem ε_naturality {X Y : C} (f : X ⟶ Y) [F.LaxMonoidal] :
   ((ε F).naturality f).symm
 
 @[reassoc (attr := simp)]
-theorem η_naturality {X Y : C} (f : X ⟶ Y) [F.OplaxMonoidal]:
+theorem η_naturality {X Y : C} (f : X ⟶ Y) [F.OplaxMonoidal] :
     (η F).app X ≫ (𝟙_ (C ⥤ C)).map f = (η F).app X ≫ f := by
   simp
 
@@ -154,7 +154,7 @@ theorem μ_naturality {m n : M} {X Y : C} (f : X ⟶ Y) [F.LaxMonoidal] :
 
 -- This is a simp lemma in the reverse direction via `NatTrans.naturality`.
 @[reassoc]
-theorem δ_naturality {m n : M} {X Y : C} (f : X ⟶ Y) [F.OplaxMonoidal]:
+theorem δ_naturality {m n : M} {X Y : C} (f : X ⟶ Y) [F.OplaxMonoidal] :
     (δ F m n).app X ≫ (F.obj n).map ((F.obj m).map f) =
       (F.obj _).map f ≫ (δ F m n).app Y := by simp
 
@@ -168,7 +168,7 @@ theorem μ_naturality₂ {m n m' n' : M} (f : m ⟶ m') (g : n ⟶ n') (X : C) [
   simpa using this
 
 @[reassoc (attr := simp)]
-theorem μ_naturalityₗ {m n m' : M} (f : m ⟶ m') (X : C) [F.LaxMonoidal]:
+theorem μ_naturalityₗ {m n m' : M} (f : m ⟶ m') (X : C) [F.LaxMonoidal] :
     (F.obj n).map ((F.map f).app X) ≫ (μ F m' n).app X =
       (μ F m n).app X ≫ (F.map (f ▷ n)).app X := by
   rw [← tensorHom_id, ← μ_naturality₂ F f (𝟙 n) X]
@@ -188,18 +188,18 @@ theorem δ_naturalityₗ {m n m' : M} (f : m ⟶ m') (X : C) [F.OplaxMonoidal] :
   congr_app (δ_natural_left F f n) X
 
 @[reassoc (attr := simp)]
-theorem δ_naturalityᵣ {m n n' : M} (g : n ⟶ n') (X : C) [F.OplaxMonoidal]:
+theorem δ_naturalityᵣ {m n n' : M} (g : n ⟶ n') (X : C) [F.OplaxMonoidal] :
     (δ F m n).app X ≫ (F.map g).app ((F.obj m).obj X) =
       (F.map (m ◁ g)).app X ≫ (δ F m n').app X :=
   congr_app (δ_natural_right F m g) X
 
 @[reassoc]
-theorem left_unitality_app (n : M) (X : C) [F.LaxMonoidal]:
+theorem left_unitality_app (n : M) (X : C) [F.LaxMonoidal] :
     (F.obj n).map ((ε F).app X) ≫ (μ F (𝟙_ M) n).app X ≫ (F.map (λ_ n).hom).app X = 𝟙 _ :=
   congr_app (left_unitality F n).symm X
 
 @[simp, reassoc]
-theorem obj_ε_app (n : M) (X : C) [F.Monoidal]:
+theorem obj_ε_app (n : M) (X : C) [F.Monoidal] :
     (F.obj n).map ((ε F).app X) = (F.map (λ_ n).inv).app X ≫ (δ F (𝟙_ M) n).app X := by
   rw [map_leftUnitor_inv]
   dsimp
@@ -269,7 +269,7 @@ theorem obj_zero_map_μ_app {m : M} {X Y : C} (f : X ⟶ (F.obj m).obj Y) [F.Mon
   simp
 
 @[simp]
-theorem obj_μ_zero_app (m₁ m₂ : M) (X : C) [F.Monoidal]:
+theorem obj_μ_zero_app (m₁ m₂ : M) (X : C) [F.Monoidal] :
     (μ F (𝟙_ M) m₂).app ((F.obj m₁).obj X) ≫ (μ F m₁ (𝟙_ M ⊗ m₂)).app X ≫
     (F.map (α_ m₁ (𝟙_ M) m₂).inv).app X ≫ (δ F (m₁ ⊗ 𝟙_ M) m₂).app X =
     (μ F (𝟙_ M) m₂).app ((F.obj m₁).obj X) ≫

--- a/Mathlib/CategoryTheory/MorphismProperty/Descent.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Descent.lean
@@ -55,7 +55,7 @@ lemma pullback_snd_iff [P.IsStableUnderBaseChange] [P.DescendsAlong Q] [HasPullb
     (hg : Q g) : P (pullback.snd f g) ↔ P f :=
   iff_of_isPullback (IsPullback.of_hasPullback f g).flip hg
 
-instance DescendsAlong.top: (⊤ : MorphismProperty C).DescendsAlong Q where
+instance DescendsAlong.top : (⊤ : MorphismProperty C).DescendsAlong Q where
   of_isPullback _ _ _ := trivial
 
 instance DescendsAlong.inf [P.DescendsAlong Q] [W.DescendsAlong Q] : (P ⊓ W).DescendsAlong Q where

--- a/Mathlib/CategoryTheory/Sites/GlobalSections.lean
+++ b/Mathlib/CategoryTheory/Sites/GlobalSections.lean
@@ -213,7 +213,7 @@ noncomputable def Sheaf.ΓNatIsoSectionsFunctor :
 /-- Global sections of a sheaf of types `F` correspond to morphisms from a terminal sheaf to `F`.
 We use the constant sheaf on a singleton type as a specific choice of terminal sheaf here. -/
 noncomputable def Sheaf.ΓObjEquivHom [HasWeakSheafify J (Type w)]
-    [HasGlobalSectionsFunctor J (Type w)] (F : Sheaf J (Type w)) (X : Type w) [Unique X]:
+    [HasGlobalSectionsFunctor J (Type w)] (F : Sheaf J (Type w)) (X : Type w) [Unique X] :
       (Γ J (Type w)).obj F ≃ ((constantSheaf J (Type w)).obj X ⟶ F) :=
   (Equiv.funUnique X _).symm.trans ((constantSheafΓAdj J (Type w)).homEquiv _ _).symm
 

--- a/Mathlib/Data/Matrix/RowCol.lean
+++ b/Mathlib/Data/Matrix/RowCol.lean
@@ -483,7 +483,7 @@ theorem single_mul_eq_updateRow_zero
 @[simp]
 theorem updateRow_zero_mul_updateCol_zero
     [DecidableEq l] [DecidableEq n] [Fintype m] [NonUnitalNonAssocSemiring α]
-    (i : l) (r : m → α) (j : n) (c : m → α):
+    (i : l) (r : m → α) (j : n) (c : m → α) :
     (0 : Matrix l m α).updateRow i r * (0 : Matrix m n α).updateCol j c = single i j (r ⬝ᵥ c) := by
   rw [updateRow_mul, vecMul_updateCol, mul_updateCol, single_eq_of_single_single, Matrix.zero_mul,
     vecMul_zero, zero_mulVec, updateCol_zero_zero, updateRow, ← Pi.single, ← Pi.single]

--- a/Mathlib/Data/Quot.lean
+++ b/Mathlib/Data/Quot.lean
@@ -304,7 +304,7 @@ theorem Quotient.lift_surjective_iff {α β : Sort*} {s : Setoid α} (f : α →
   Quot.surjective_lift h
 
 theorem Quotient.lift_surjective {α β : Sort*} {s : Setoid α} (f : α → β)
-    (h : ∀ (a b : α), a ≈ b → f a = f b) (hf : Function.Surjective f):
+    (h : ∀ (a b : α), a ≈ b → f a = f b) (hf : Function.Surjective f) :
     Function.Surjective (Quotient.lift f h : Quotient s → β) :=
   (Quot.surjective_lift h).mpr hf
 

--- a/Mathlib/Data/Vector/MapLemmas.lean
+++ b/Mathlib/Data/Vector/MapLemmas.lean
@@ -51,12 +51,12 @@ theorem map_map (f₁ : β → γ) (f₂ : α → β) :
     map f₁ (map f₂ xs) = map (fun x => f₁ <| f₂ x) xs := by
   induction xs <;> simp_all
 
-theorem map_pmap {p : α → Prop} (f₁ : β → γ) (f₂ : (a : α) → p a → β) (H : ∀ x ∈ xs.toList, p x):
+theorem map_pmap {p : α → Prop} (f₁ : β → γ) (f₂ : (a : α) → p a → β) (H : ∀ x ∈ xs.toList, p x) :
     map f₁ (pmap f₂ xs H) = pmap (fun x hx => f₁ <| f₂ x hx) xs H := by
   induction xs <;> simp_all
 
 theorem pmap_map {p : β → Prop} (f₁ : (b : β) → p b → γ) (f₂ : α → β)
-    (H : ∀ x ∈ (xs.map f₂).toList, p x):
+    (H : ∀ x ∈ (xs.map f₂).toList, p x) :
     pmap f₁ (map f₂ xs) H = pmap (fun x hx => f₁ (f₂ x) hx) xs (by simpa using H) := by
   induction xs <;> simp_all
 

--- a/Mathlib/GroupTheory/FixedPointFree.lean
+++ b/Mathlib/GroupTheory/FixedPointFree.lean
@@ -67,7 +67,7 @@ theorem commute_all_of_involutive (hφ : FixedPointFree φ) (h2 : Function.Invol
   rwa [hφ.coe_eq_inv_of_involutive h2, inv_eq_iff_eq_inv, mul_inv_rev, inv_inv, inv_inv] at key
 
 /-- If a finite group admits a fixed-point-free involution, then it is commutative. -/
-def commGroupOfInvolutive (hφ : FixedPointFree φ) (h2 : Function.Involutive φ):
+def commGroupOfInvolutive (hφ : FixedPointFree φ) (h2 : Function.Involutive φ) :
     CommGroup G := .mk (hφ.commute_all_of_involutive h2)
 
 theorem orderOf_ne_two_of_involutive (hφ : FixedPointFree φ) (h2 : Function.Involutive φ) (g : G) :

--- a/Mathlib/GroupTheory/GroupAction/Basic.lean
+++ b/Mathlib/GroupTheory/GroupAction/Basic.lean
@@ -318,7 +318,7 @@ theorem stabilizerEquivStabilizer_symm_apply (hg : b = g +ᵥ b) (x : stabilizer
   simp [stabilizerEquivStabilizer]
 
 theorem stabilizerEquivStabilizer_trans
-    (hg : b = g +ᵥ a) (hh : c = h +ᵥ b) (hk : c = k +ᵥ a) (H : k = h + g):
+    (hg : b = g +ᵥ a) (hh : c = h +ᵥ b) (hk : c = k +ᵥ a) (H : k = h + g) :
     (stabilizerEquivStabilizer hg).trans (stabilizerEquivStabilizer hh)
       = stabilizerEquivStabilizer hk := by
   ext; simp [stabilizerEquivStabilizer_apply, H]

--- a/Mathlib/GroupTheory/OrderOfElement.lean
+++ b/Mathlib/GroupTheory/OrderOfElement.lean
@@ -409,7 +409,7 @@ theorem orderOf_mul_dvd_lcm (h : Commute x y) :
   exact Function.Commute.minimalPeriod_of_comp_dvd_lcm h.function_commute_mul_left
 
 @[to_additive]
-theorem orderOf_dvd_lcm_mul (h : Commute x y):
+theorem orderOf_dvd_lcm_mul (h : Commute x y) :
     orderOf y ∣ Nat.lcm (orderOf x) (orderOf (x * y)) := by
   by_cases h0 : orderOf x = 0
   · rw [h0, lcm_zero_left]
@@ -422,7 +422,7 @@ theorem orderOf_dvd_lcm_mul (h : Commute x y):
       (lcm_dvd_iff.2 ⟨(orderOf_pow_dvd _).trans (dvd_lcm_left _ _), dvd_lcm_right _ _⟩)
 
 @[to_additive addOrderOf_add_dvd_mul_addOrderOf]
-theorem orderOf_mul_dvd_mul_orderOf (h : Commute x y):
+theorem orderOf_mul_dvd_mul_orderOf (h : Commute x y) :
     orderOf (x * y) ∣ orderOf x * orderOf y :=
   dvd_trans h.orderOf_mul_dvd_lcm (lcm_dvd_mul _ _)
 

--- a/Mathlib/GroupTheory/Perm/DomMulAct.lean
+++ b/Mathlib/GroupTheory/Perm/DomMulAct.lean
@@ -115,7 +115,7 @@ variable [DecidableEq α] [DecidableEq ι]
 
 /-- The cardinality of the type of permutations preserving a function
   (without the finiteness assumption on target) -/
-theorem stabilizer_card':
+theorem stabilizer_card' :
     Fintype.card {g : Perm α // f ∘ g = f} =
       ∏ i ∈ Finset.univ.image f, (Fintype.card ({a // f a = i}))! := by
   set φ : α → Finset.univ.image f :=

--- a/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
@@ -738,7 +738,7 @@ theorem linearDepOn_iff : ¬LinearIndepOn R v s ↔
 
 @[deprecated (since := "2025-02-15")] alias linearDependent_comp_subtype := linearDepOn_iff
 
-theorem linearIndepOn_iff_disjoint: LinearIndepOn R v s ↔
+theorem linearIndepOn_iff_disjoint : LinearIndepOn R v s ↔
       Disjoint (Finsupp.supported R R s) (LinearMap.ker <| Finsupp.linearCombination R v) := by
   rw [linearIndepOn_iff, LinearMap.disjoint_ker]
 

--- a/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
@@ -592,7 +592,7 @@ theorem linearIndepOn_id_pair {x y : V} (hx : x ≠ 0) (hy : ∀ a : K, a • x 
 @[deprecated (since := "2025-02-15")] alias linearIndependent_pair := linearIndepOn_id_pair
 
 /-- `LinearIndepOn.pair_iff` is a version that works over arbitrary rings. -/
-theorem linearIndepOn_pair_iff {i j : ι} (v : ι → V) (hij : i ≠ j) (hi : v i ≠ 0):
+theorem linearIndepOn_pair_iff {i j : ι} (v : ι → V) (hij : i ≠ j) (hi : v i ≠ 0) :
     LinearIndepOn K v {i, j} ↔ ∀ (c : K), c • v i ≠ v j := by
   rw [pair_comm]
   convert linearIndepOn_insert (s := {i}) (a := j) hij.symm

--- a/Mathlib/LinearAlgebra/Multilinear/Basic.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Basic.lean
@@ -811,7 +811,7 @@ theorem comp_compMultilinearMap (g : M₃ →ₗ[R] M₄) (g' : M₂ →ₗ[R] M
 
 /-- The two types of composition are associative. -/
 theorem compMultilinearMap_compLinearMap
-    (g : M₂ →ₗ[R] M₃) (f : MultilinearMap R M₁ M₂) (f' : ∀ i, M₁' i →ₗ[R] M₁ i):
+    (g : M₂ →ₗ[R] M₃) (f : MultilinearMap R M₁ M₂) (f' : ∀ i, M₁' i →ₗ[R] M₁ i) :
     g.compMultilinearMap (f.compLinearMap f') = (g.compMultilinearMap f).compLinearMap f' := rfl
 
 @[simp]

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -1431,7 +1431,7 @@ theorem eLpNormEssSup_const_smul (c : 𝕜) (f : α → F) :
   simp_rw [eLpNormEssSup_eq_essSup_enorm, Pi.smul_apply, enorm_smul,
     ENNReal.essSup_const_mul]
 
-theorem eLpNorm_const_smul (c : 𝕜) (f : α → F) (p : ℝ≥0∞) (μ : Measure α):
+theorem eLpNorm_const_smul (c : 𝕜) (f : α → F) (p : ℝ≥0∞) (μ : Measure α) :
     eLpNorm (c • f) p μ = ‖c‖ₑ * eLpNorm f p μ := by
   obtain rfl | hc := eq_or_ne c 0
   · simp

--- a/Mathlib/MeasureTheory/Group/Convolution.lean
+++ b/Mathlib/MeasureTheory/Group/Convolution.lean
@@ -39,7 +39,7 @@ scoped[MeasureTheory] infixr:80 " ∗ " => MeasureTheory.Measure.conv
 
 @[to_additive]
 theorem lintegral_mconv_eq_lintegral_prod [MeasurableMul₂ M] {μ ν : Measure M}
-    {f : M → ℝ≥0∞} (hf : Measurable f):
+    {f : M → ℝ≥0∞} (hf : Measurable f) :
     ∫⁻ z, f z ∂(μ ∗ₘ ν) = ∫⁻ z, f (z.1 * z.2) ∂(μ.prod ν) := by
   rw [mconv, lintegral_map hf measurable_mul]
 

--- a/Mathlib/ModelTheory/ElementarySubstructures.lean
+++ b/Mathlib/ModelTheory/ElementarySubstructures.lean
@@ -74,7 +74,7 @@ def subtype (S : L.ElementarySubstructure M) : S ↪ₑ[L] M where
 theorem subtype_apply {S : L.ElementarySubstructure M} {x : S} : subtype S x = x :=
   rfl
 
-theorem subtype_injective (S : L.ElementarySubstructure M): Function.Injective (subtype S) :=
+theorem subtype_injective (S : L.ElementarySubstructure M) : Function.Injective (subtype S) :=
   Subtype.coe_injective
 
 @[simp]

--- a/Mathlib/ModelTheory/Substructures.lean
+++ b/Mathlib/ModelTheory/Substructures.lean
@@ -634,7 +634,7 @@ def subtype (S : L.Substructure M) : S ↪[L] M where
 theorem subtype_apply {S : L.Substructure M} {x : S} : subtype S x = x :=
   rfl
 
-theorem subtype_injective (S : L.Substructure M): Function.Injective (subtype S) :=
+theorem subtype_injective (S : L.Substructure M) : Function.Injective (subtype S) :=
   Subtype.coe_injective
 
 @[simp]

--- a/Mathlib/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/Mathlib/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -27,7 +27,7 @@ local notation "SLMOD(" N ")" =>
   @Matrix.SpecialLinearGroup.map (Fin 2) _ _ _ _ _ _ (Int.castRingHom (ZMod N))
 
 @[simp]
-theorem SL_reduction_mod_hom_val (γ : SL(2, ℤ)) (i j : Fin 2):
+theorem SL_reduction_mod_hom_val (γ : SL(2, ℤ)) (i j : Fin 2) :
     SLMOD(N) γ i j = (γ i j : ZMod N) :=
   rfl
 

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/FundamentalCone.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/FundamentalCone.lean
@@ -321,7 +321,7 @@ theorem torsion_unitSMul_mem_integerSet {x : mixedSpace K} {ζ : (𝓞 K)ˣ} (h�
 
 /-- The action of `torsion K` on `integerSet K`. -/
 @[simps]
-instance integerSetTorsionSMul: SMul (torsion K) (integerSet K) where
+instance integerSetTorsionSMul : SMul (torsion K) (integerSet K) where
   smul := fun ⟨ζ, hζ⟩ ⟨x, hx⟩ ↦ ⟨ζ • x, torsion_unitSMul_mem_integerSet hζ hx⟩
 
 instance : MulAction (torsion K) (integerSet K) where

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/NormLeOne.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/NormLeOne.lean
@@ -307,7 +307,7 @@ abbrev fderiv_expMap (x : realSpace K) : realSpace K →L[ℝ] realSpace K :=
   .pi fun w ↦ (ContinuousLinearMap.smulRight (1 : ℝ →L[ℝ] ℝ) (deriv_expMap_single w (x w))).comp
     (.proj w)
 
-theorem hasFDerivAt_expMap (x : realSpace K): HasFDerivAt expMap (fderiv_expMap x) x := by
+theorem hasFDerivAt_expMap (x : realSpace K) : HasFDerivAt expMap (fderiv_expMap x) x := by
   simpa [expMap, fderiv_expMap, hasFDerivAt_pi', PartialHomeomorph.pi_apply,
     ContinuousLinearMap.proj_pi] using
     fun w ↦ (hasDerivAt_expMap_single w _).hasFDerivAt.comp x (hasFDerivAt_apply w x)

--- a/Mathlib/NumberTheory/RamificationInertia/Galois.lean
+++ b/Mathlib/NumberTheory/RamificationInertia/Galois.lean
@@ -96,7 +96,7 @@ noncomputable instance : MulAction (L ≃ₐ[K] L) (primesOver p B) where
     rw [map_mul]
     exact (Q.1.map_map ((galRestrict A K L B) τ).toRingHom ((galRestrict A K L B) σ).toRingHom).symm
 
-theorem coe_smul_primesOver_eq_map_galRestrict (σ : L ≃ₐ[K] L) (P : primesOver p B):
+theorem coe_smul_primesOver_eq_map_galRestrict (σ : L ≃ₐ[K] L) (P : primesOver p B) :
     (σ • P).1 = map (galRestrict A K L B σ) P :=
   rfl
 

--- a/Mathlib/Order/Interval/Finset/Defs.lean
+++ b/Mathlib/Order/Interval/Finset/Defs.lean
@@ -1110,28 +1110,28 @@ theorem subtype_Ioc_eq : Ioc a b = (Ioc (a : α) b).subtype p :=
 theorem subtype_Ioo_eq : Ioo a b = (Ioo (a : α) b).subtype p :=
   rfl
 
-theorem map_subtype_embedding_Icc (hp : ∀ ⦃a b x⦄, a ≤ x → x ≤ b → p a → p b → p x):
+theorem map_subtype_embedding_Icc (hp : ∀ ⦃a b x⦄, a ≤ x → x ≤ b → p a → p b → p x) :
     (Icc a b).map (Embedding.subtype p) = (Icc a b : Finset α) := by
   rw [subtype_Icc_eq]
   refine Finset.subtype_map_of_mem fun x hx => ?_
   rw [mem_Icc] at hx
   exact hp hx.1 hx.2 a.prop b.prop
 
-theorem map_subtype_embedding_Ico (hp : ∀ ⦃a b x⦄, a ≤ x → x ≤ b → p a → p b → p x):
+theorem map_subtype_embedding_Ico (hp : ∀ ⦃a b x⦄, a ≤ x → x ≤ b → p a → p b → p x) :
     (Ico a b).map (Embedding.subtype p) = (Ico a b : Finset α) := by
   rw [subtype_Ico_eq]
   refine Finset.subtype_map_of_mem fun x hx => ?_
   rw [mem_Ico] at hx
   exact hp hx.1 hx.2.le a.prop b.prop
 
-theorem map_subtype_embedding_Ioc (hp : ∀ ⦃a b x⦄, a ≤ x → x ≤ b → p a → p b → p x):
+theorem map_subtype_embedding_Ioc (hp : ∀ ⦃a b x⦄, a ≤ x → x ≤ b → p a → p b → p x) :
     (Ioc a b).map (Embedding.subtype p) = (Ioc a b : Finset α) := by
   rw [subtype_Ioc_eq]
   refine Finset.subtype_map_of_mem fun x hx => ?_
   rw [mem_Ioc] at hx
   exact hp hx.1.le hx.2 a.prop b.prop
 
-theorem map_subtype_embedding_Ioo (hp : ∀ ⦃a b x⦄, a ≤ x → x ≤ b → p a → p b → p x):
+theorem map_subtype_embedding_Ioo (hp : ∀ ⦃a b x⦄, a ≤ x → x ≤ b → p a → p b → p x) :
     (Ioo a b).map (Embedding.subtype p) = (Ioo a b : Finset α) := by
   rw [subtype_Ioo_eq]
   refine Finset.subtype_map_of_mem fun x hx => ?_

--- a/Mathlib/Order/Interval/Set/Pi.lean
+++ b/Mathlib/Order/Interval/Set/Pi.lean
@@ -52,20 +52,20 @@ theorem piecewise_mem_Icc' {s : Set ι} [∀ j, Decidable (j ∈ s)] {f₁ f₂ 
 
 section Nonempty
 
-theorem pi_univ_Ioi_subset [Nonempty ι]: (pi univ fun i ↦ Ioi (x i)) ⊆ Ioi x := fun _ hz ↦
+theorem pi_univ_Ioi_subset [Nonempty ι] : (pi univ fun i ↦ Ioi (x i)) ⊆ Ioi x := fun _ hz ↦
   ⟨fun i ↦ le_of_lt <| hz i trivial, fun h ↦
     (‹Nonempty ι›.elim) fun i ↦ not_lt_of_ge (h i) (hz i trivial)⟩
 
-theorem pi_univ_Iio_subset [Nonempty ι]: (pi univ fun i ↦ Iio (x i)) ⊆ Iio x :=
+theorem pi_univ_Iio_subset [Nonempty ι] : (pi univ fun i ↦ Iio (x i)) ⊆ Iio x :=
   pi_univ_Ioi_subset (α := fun i ↦ (α i)ᵒᵈ) x
 
-theorem pi_univ_Ioo_subset [Nonempty ι]: (pi univ fun i ↦ Ioo (x i) (y i)) ⊆ Ioo x y := fun _ hx ↦
+theorem pi_univ_Ioo_subset [Nonempty ι] : (pi univ fun i ↦ Ioo (x i) (y i)) ⊆ Ioo x y := fun _ hx ↦
   ⟨(pi_univ_Ioi_subset _) fun i hi ↦ (hx i hi).1, (pi_univ_Iio_subset _) fun i hi ↦ (hx i hi).2⟩
 
-theorem pi_univ_Ioc_subset [Nonempty ι]: (pi univ fun i ↦ Ioc (x i) (y i)) ⊆ Ioc x y := fun _ hx ↦
+theorem pi_univ_Ioc_subset [Nonempty ι] : (pi univ fun i ↦ Ioc (x i) (y i)) ⊆ Ioc x y := fun _ hx ↦
   ⟨(pi_univ_Ioi_subset _) fun i hi ↦ (hx i hi).1, fun i ↦ (hx i trivial).2⟩
 
-theorem pi_univ_Ico_subset [Nonempty ι]: (pi univ fun i ↦ Ico (x i) (y i)) ⊆ Ico x y := fun _ hx ↦
+theorem pi_univ_Ico_subset [Nonempty ι] : (pi univ fun i ↦ Ico (x i) (y i)) ⊆ Ico x y := fun _ hx ↦
   ⟨fun i ↦ (hx i trivial).1, (pi_univ_Iio_subset _) fun i hi ↦ (hx i hi).2⟩
 
 end Nonempty

--- a/Mathlib/RepresentationTheory/Homological/GroupCohomology/LowDegree.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupCohomology/LowDegree.lean
@@ -1279,7 +1279,7 @@ def H1IsoOfIsTrivial :
 noncomputable alias H1LequivOfIsTrivial := H1IsoOfIsTrivial
 
 @[reassoc (attr := simp), elementwise (attr := simp)]
-theorem H1π_comp_H1IsoOfIsTrivial_hom:
+theorem H1π_comp_H1IsoOfIsTrivial_hom :
     H1π A ≫ (H1IsoOfIsTrivial A).hom = (cocycles₁IsoOfIsTrivial A).hom := by
   simp [H1IsoOfIsTrivial, H1π]
 

--- a/Mathlib/RingTheory/Polynomial/GaussNorm.lean
+++ b/Mathlib/RingTheory/Polynomial/GaussNorm.lean
@@ -134,7 +134,7 @@ theorem gaussNorm_C [ZeroHomClass F R ℝ] [NonnegHomClass F R ℝ] (hc : 0 ≤ 
   simp [← Polynomial.coe_C, hc]
 
 @[simp]
-theorem gaussNorm_monomial [ZeroHomClass F R ℝ] [NonnegHomClass F R ℝ] (hc : 0 ≤ c) (n : ℕ):
+theorem gaussNorm_monomial [ZeroHomClass F R ℝ] [NonnegHomClass F R ℝ] (hc : 0 ≤ c) (n : ℕ) :
     (monomial R n r).gaussNorm v c = v r * c ^ n := by
   simp [← Polynomial.coe_monomial, hc]
 

--- a/Mathlib/RingTheory/PowerSeries/Evaluation.lean
+++ b/Mathlib/RingTheory/PowerSeries/Evaluation.lean
@@ -96,7 +96,7 @@ theorem HasEval.map (hφ : Continuous φ) {a : R} (ha : HasEval a) :
   simp only [hasEval_iff] at ha ⊢
   exact ha.map hφ
 
-protected theorem HasEval.X:
+protected theorem HasEval.X :
     HasEval (X : R⟦X⟧) := by
   rw [hasEval_iff]
   exact MvPowerSeries.HasEval.X

--- a/Mathlib/RingTheory/Valuation/Minpoly.lean
+++ b/Mathlib/RingTheory/Valuation/Minpoly.lean
@@ -39,7 +39,7 @@ variable {L}
 /- For any unit `x : Lˣ`, we prove that a certain power of the valuation of zeroth coefficient of
 the minimal polynomial of `x` over `K` is nonzero. This lemma is helpful for defining the valuation
 on `L` inducing `v`. -/
-theorem pow_coeff_zero_ne_zero_of_unit [FiniteDimensional K L] (x : L) (hx : IsUnit x):
+theorem pow_coeff_zero_ne_zero_of_unit [FiniteDimensional K L] (x : L) (hx : IsUnit x) :
     v ((minpoly K x).coeff 0) ^ (finrank K L / (minpoly K x).natDegree) ≠ (0 : Γ₀) := by
   have h_alg : Algebra.IsAlgebraic K L := Algebra.IsAlgebraic.of_finite K L
   have hx₀ : IsIntegral K x := (Algebra.IsAlgebraic.isAlgebraic x).isIntegral

--- a/Mathlib/SetTheory/Ordinal/Family.lean
+++ b/Mathlib/SetTheory/Ordinal/Family.lean
@@ -297,7 +297,7 @@ theorem iSup_succ (o : Ordinal) : ⨆ a : Iio o, succ a.1 = o := by
   · exact fun a ha ↦ (lt_succ a).trans_le <| Ordinal.le_iSup (fun x : Iio _ ↦ _) ⟨a, ha⟩
 
 -- TODO: generalize to conditionally complete lattices
-theorem iSup_sum {α β} (f : α ⊕ β → Ordinal.{u}) [Small.{u} α] [Small.{u} β]:
+theorem iSup_sum {α β} (f : α ⊕ β → Ordinal.{u}) [Small.{u} α] [Small.{u} β] :
     iSup f = max (⨆ a, f (Sum.inl a)) (⨆ b, f (Sum.inr b)) := by
   apply (Ordinal.iSup_le _).antisymm (max_le _ _)
   · rintro (i | i)

--- a/Mathlib/Tactic/Widget/Conv.lean
+++ b/Mathlib/Tactic/Widget/Conv.lean
@@ -87,7 +87,7 @@ open Lean Syntax in
 /-- Return the link text and inserted text above and below of the conv widget. -/
 @[nolint unusedArguments]
 def insertEnter (locations : Array Lean.SubExpr.GoalsLocation) (goalType : Expr)
-    (params : SelectInsertParams): MetaM (String × String × Option (String.Pos × String.Pos)) := do
+    (params : SelectInsertParams) : MetaM (String × String × Option (String.Pos × String.Pos)) := do
   let some pos := locations[0]? | throwError "You must select something."
   let (fvar, subexprPos) ← match pos with
   | ⟨_, .target subexprPos⟩ => pure (none, subexprPos)

--- a/Mathlib/Topology/Algebra/Monoid.lean
+++ b/Mathlib/Topology/Algebra/Monoid.lean
@@ -437,7 +437,7 @@ Let `f : α → M` and `g : α → M` be functions. If `g` tends to zero on a fi
 and the image of `l` under `f` is disjoint from the cocompact filter on `M`, then
 `fun x : α ↦ f x * g x` also tends to zero on `l`. -/
 theorem Tendsto.tendsto_mul_zero_of_disjoint_cocompact_left {f g : α → M} {l : Filter α}
-    (hf : Disjoint (map f l) (cocompact M)) (hg : Tendsto g l (𝓝 0)):
+    (hf : Disjoint (map f l) (cocompact M)) (hg : Tendsto g l (𝓝 0)) :
     Tendsto (fun x ↦ f x * g x) l (𝓝 0) :=
   tendsto_mul_prod_nhds_zero_of_disjoint_cocompact hf |>.comp (tendsto_map.prodMk hg)
 

--- a/Mathlib/Topology/Algebra/Valued/NormedValued.lean
+++ b/Mathlib/Topology/Algebra/Valued/NormedValued.lean
@@ -202,7 +202,7 @@ end toNormedField
 /--
 The nontrivially normed field structure determined by a rank one valuation.
 -/
-def toNontriviallyNormedField: NontriviallyNormedField L := {
+def toNontriviallyNormedField : NontriviallyNormedField L := {
   val.toNormedField with
   non_trivial := by
     obtain ⟨x, hx⟩ := Valuation.RankOne.nontrivial val.v

--- a/Mathlib/Topology/Category/TopCat/Limits/Basic.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Basic.lean
@@ -133,7 +133,7 @@ end IsLimit
 
 variable (F : J ⥤ TopCat.{u})
 
-theorem limit_topology [HasLimit F]:
+theorem limit_topology [HasLimit F] :
     (limit F).str = ⨅ j, (F.obj j).str.induced (limit.π F j) :=
   induced_of_isLimit _ (limit.isLimit _)
 
@@ -253,7 +253,7 @@ end IsColimit
 
 variable (F)
 
-theorem colimit_topology (F : J ⥤ TopCat.{u}) [HasColimit F]:
+theorem colimit_topology (F : J ⥤ TopCat.{u}) [HasColimit F] :
     (colimit F).str = ⨆ j, (F.obj j).str.coinduced (colimit.ι F j) :=
   coinduced_of_isColimit _ (colimit.isColimit _)
 

--- a/Mathlib/Topology/ContinuousMap/ContinuousMapZero.lean
+++ b/Mathlib/Topology/ContinuousMap/ContinuousMapZero.lean
@@ -451,7 +451,7 @@ section Norm
 
 variable {α : Type*} {𝕜 : Type*} {R : Type*} [TopologicalSpace α] [CompactSpace α] [Zero α]
 
-noncomputable instance [MetricSpace R] [Zero R]: MetricSpace C(α, R)₀ :=
+noncomputable instance [MetricSpace R] [Zero R] : MetricSpace C(α, R)₀ :=
   ContinuousMapZero.isUniformEmbedding_toContinuousMap.comapMetricSpace _
 
 lemma isometry_toContinuousMap [MetricSpace R] [Zero R] :

--- a/Mathlib/Topology/ContinuousOn.lean
+++ b/Mathlib/Topology/ContinuousOn.lean
@@ -409,7 +409,7 @@ theorem dense_pi {ι : Type*} {α : ι → Type*} [∀ i, TopologicalSpace (α i
     pi_univ]
 
 theorem DenseRange.piMap {ι : Type*} {X Y : ι → Type*} [∀ i, TopologicalSpace (Y i)]
-    {f : (i : ι) → (X i) → (Y i)} (hf : ∀ i, DenseRange (f i)):
+    {f : (i : ι) → (X i) → (Y i)} (hf : ∀ i, DenseRange (f i)) :
     DenseRange (Pi.map f) := by
   rw [DenseRange, Set.range_piMap]
   exact dense_pi Set.univ (fun i _ => hf i)

--- a/Mathlib/Topology/LocallyFinsupp.lean
+++ b/Mathlib/Topology/LocallyFinsupp.lean
@@ -210,7 +210,7 @@ def mk_of_mem [AddCommGroup Y] (f : X → Y) (hf : f ∈ locallyFinsuppWithin.ad
 instance [AddCommGroup Y] : Zero (locallyFinsuppWithin U Y) where
   zero := mk_of_mem 0 <| zero_mem _
 
-instance [AddCommGroup Y]: Add (locallyFinsuppWithin U Y) where
+instance [AddCommGroup Y] : Add (locallyFinsuppWithin U Y) where
   add D₁ D₂ := mk_of_mem (D₁ + D₂) <| add_mem D₁.memAddSubgroup D₂.memAddSubgroup
 
 instance [AddCommGroup Y] : Neg (locallyFinsuppWithin U Y) where
@@ -324,7 +324,7 @@ instance [Lattice Y] [Zero Y] : Lattice (locallyFinsuppWithin U Y) where
 /--
 Functions with locally finite support within `U` form an ordered commutative group.
 -/
-instance [AddCommGroup Y] [LinearOrder Y] [IsOrderedAddMonoid Y]:
+instance [AddCommGroup Y] [LinearOrder Y] [IsOrderedAddMonoid Y] :
     IsOrderedAddMonoid (locallyFinsuppWithin U Y) where
   add_le_add_left := fun _ _ _ _ ↦ by simpa [le_def]
 

--- a/Mathlib/Topology/Order/IsLUB.lean
+++ b/Mathlib/Topology/Order/IsLUB.lean
@@ -248,7 +248,7 @@ theorem DenseRange.exists_seq_strictMono_tendsto_of_lt {β : Type*} [LinearOrder
 
 theorem DenseRange.exists_seq_strictMono_tendsto {β : Type*} [LinearOrder β] [DenselyOrdered α]
     [NoMinOrder α] [FirstCountableTopology α] {f : β → α} (hf : DenseRange f) (hmono : Monotone f)
-    (x : α):
+    (x : α) :
     ∃ u : ℕ → β, StrictMono u ∧ (∀ n, f (u n) ∈ Iio x) ∧ Tendsto (f ∘ u) atTop (𝓝 x) := by
   rcases Dense.exists_seq_strictMono_tendsto hf x with ⟨u, hu, huxf, hlim⟩
   have hux (n : ℕ) : u n ∈ Iio x := (huxf n).1
@@ -318,7 +318,7 @@ theorem DenseRange.exists_seq_strictAnti_tendsto_of_lt {β : Type*} [LinearOrder
 
 theorem DenseRange.exists_seq_strictAnti_tendsto {β : Type*} [LinearOrder β] [DenselyOrdered α]
     [NoMaxOrder α] [FirstCountableTopology α] {f : β → α} (hf : DenseRange f) (hmono : Monotone f)
-    (x : α):
+    (x : α) :
     ∃ u : ℕ → β, StrictAnti u ∧ (∀ n, f (u n) ∈ Ioi x) ∧ Tendsto (f ∘ u) atTop (𝓝 x) :=
   hf.exists_seq_strictMono_tendsto (α := αᵒᵈ) (β := βᵒᵈ) hmono.dual x
 


### PR DESCRIPTION
Found by #26718.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
