### PR TITLE
[Merged by Bors] - fix(Tactic/Algebraize): tactic is unable to see through assigned metavariables

### DIFF
--- a/Mathlib/Tactic/Algebraize.lean
+++ b/Mathlib/Tactic/Algebraize.lean
@@ -170,7 +170,7 @@ def addProperties (t : Array Expr) : TacticM Unit := withMainContext do
   let ctx ← getLCtx
   ctx.forM fun decl => do
     if decl.isImplementationDetail then return
-    let (nm, args) := decl.type.getAppFnArgs
+    let (nm, args) := (← instantiateMVars decl.type).getAppFnArgs
     -- Check if the type of the current hypothesis has been tagged with the `algebraize` attribute
     match Attr.algebraizeAttr.getParam? (← getEnv) nm with
     -- If it has, `p` will either be the name of the corresponding `Algebra` property, or a

--- a/MathlibTest/algebraize.lean
+++ b/MathlibTest/algebraize.lean
@@ -123,6 +123,14 @@ example (A B : Type*) [CommRing A] [CommRing B] (f g : A →+* B) (hf : f.TestPr
     guard_hyp algebraizeInst_1
   trivial
 
+/- make sure the tactic is able to see through assigned metavariables -/
+example (A B : Type*) [CommRing A] [CommRing B] (f : A →+* B) : f.TestProperty3 → True := by
+  refine @id (?P → True) ?h
+  intro hf -- the type of this variable is `?P := f.TestProperty3`, rather than just `f.TestProperty3`
+  algebraize [f]
+  guard_hyp algebraizeInst : @Algebra.TestProperty3 A B _ _ f.toAlgebra
+  trivial
+
 example (n m : ℕ) (A B : Type*) [CommRing A] [CommRing B] (f g : A →+* B) (hf : f.TestProperty4 n)
     (hg : g.TestProperty4 m) : True := by
   algebraize [f]

--- a/MathlibTest/algebraize.lean
+++ b/MathlibTest/algebraize.lean
@@ -131,6 +131,15 @@ example (A B : Type*) [CommRing A] [CommRing B] (f : A →+* B) : f.TestProperty
   guard_hyp algebraizeInst : @Algebra.TestProperty3 A B _ _ f.toAlgebra
   trivial
 
+/- make sure the tactic is able to see through assigned metavariables -/
+example (A B : Type*) [CommRing A] [CommRing B] (f : A →+* B) : f.TestProperty3 ↔ (@Algebra.TestProperty3 A B _ _ f.toAlgebra) := by
+  constructor
+  · intro hf -- the type of this variable is `?P := f.TestProperty3`, rather than just `f.TestProperty3`
+    algebraize [f]
+    guard_hyp algebraizeInst : @Algebra.TestProperty3 A B _ _ f.toAlgebra
+    exact algebraizeInst
+  · exact fun x => x.out
+
 example (n m : ℕ) (A B : Type*) [CommRing A] [CommRing B] (f g : A →+* B) (hf : f.TestProperty4 n)
     (hg : g.TestProperty4 m) : True := by
   algebraize [f]


### PR DESCRIPTION
The `algebraize` tactic had a bug which made it unable to find tagged properties when the type of a local hypothesis is (under the hood) an assigned metavariable. (bug found by @chrisflav and @erdOne) For example:
```lean-4
import Mathlib

lemma smooth_def {R S : Type u} [CommRing R] [CommRing S] {f :R →+* S} :
    f.Smooth ↔ f.FormallySmooth ∧ f.FinitePresentation := by
  constructor
  · intro hf
    algebraize [f]
    sorry -- no hypothesis `Algebra.Smooth ...`, despite `hf : f.Smooth` being in context.
  sorry
```
This PR fixes the bug by calling `instantiateMVars` on the type before figuring out the head symbol.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
