### PR TITLE
[Merged by Bors] - fix(Tactic/Algebraize): adapt application filter to `RingHom.toModule`

### DIFF
--- a/Mathlib/Tactic/Algebraize.lean
+++ b/Mathlib/Tactic/Algebraize.lean
@@ -201,7 +201,7 @@ def addProperties (t : Array Expr) : TacticM Unit := withMainContext do
           let tp ← inferType val -- This should be the type `Algebra.Property A B`.
           return (val, tp)
       let .some (val,tp) ← getValType | return
-      /- Find all arguments to `Algebra.Property A B`(or `Module.Property A B`) which are
+      /- Find all arguments to `Algebra.Property A B` or `Module.Property A B` which are
         of the form `RingHom.toAlgebra f`, `RingHom.toModule f`
         or `Algebra.toModule (RingHom.toAlgebra f)`. -/
       let ringHom_args ← tp.getAppArgs.filterMapM <| fun x => liftMetaM do

--- a/Mathlib/Tactic/Algebraize.lean
+++ b/Mathlib/Tactic/Algebraize.lean
@@ -201,11 +201,13 @@ def addProperties (t : Array Expr) : TacticM Unit := withMainContext do
           let tp ← inferType val -- This should be the type `Algebra.Property A B`.
           return (val, tp)
       let .some (val,tp) ← getValType | return
-      /- Find all arguments to `Algebra.Property A B` which are of the form
-        `RingHom.toAlgebra x` or `Algebra.toModule (RingHom.toAlgebra x)`. -/
+      /- Find all arguments to `Algebra.Property A B`(or `Module.Property A B`) which are
+        of the form `RingHom.toAlgebra f`, `RingHom.toModule f`
+        or `Algebra.toModule (RingHom.toAlgebra f)`. -/
       let ringHom_args ← tp.getAppArgs.filterMapM <| fun x => liftMetaM do
         let y := (← whnfUntil x ``Algebra.toModule) >>= (·.getAppArgs.back?)
-        return (← whnfUntil (y.getD x) ``RingHom.toAlgebra) >>= (·.getAppArgs.back?)
+        return ((← whnfUntil (y.getD x) ``RingHom.toAlgebra) <|> (← whnfUntil x ``RingHom.toModule))
+          >>= (·.getAppArgs.back?)
       /- Check that we're not reproving a local hypothesis, and that all involved `RingHom`s are
         indeed arguments to the tactic. -/
       unless (← synthInstance? tp).isSome || !(← ringHom_args.allM (fun z => t.anyM

--- a/MathlibTest/algebraize.lean
+++ b/MathlibTest/algebraize.lean
@@ -61,12 +61,12 @@ lemma RingHom.TestProperty4.toAlgebra (n : ℕ) {A B : Type*} [CommRing A] [Comm
       { out := hf }
 
 /-- Test property for when the `RingHom` property corresponds to a `Module` property
-  using `RingHom.toModule`. (compare to property 2, which uses `RingHom.toAlgebra.toModule`) -/
+  using `RingHom.toModule`. (Compare to property 2, which uses `RingHom.toAlgebra.toModule`.) -/
 class Module.TestProperty5 (A M : Type*) [Semiring A] [AddCommMonoid M] [Module A M] : Prop where
   out : ∀ x : A, ∀ M : M, x • M = 0
 
 /-- Test property for when the `RingHom` property corresponds to a `Module` property
-  using `RingHom.toModule`. (compare to property 2, which uses `RingHom.toAlgebra.toModule`) -/
+  using `RingHom.toModule`. (Compare to property 2, which uses `RingHom.toAlgebra.toModule`.) -/
 @[algebraize Module.TestProperty5]
 def RingHom.TestProperty5 {A B : Type*} [CommRing A] [CommRing B] (f : A →+* B) : Prop :=
   @Module.TestProperty5 A B _ _ f.toModule

--- a/MathlibTest/algebraize.lean
+++ b/MathlibTest/algebraize.lean
@@ -60,6 +60,17 @@ lemma RingHom.TestProperty4.toAlgebra (n : ℕ) {A B : Type*} [CommRing A] [Comm
       letI : Algebra A B := f.toAlgebra
       { out := hf }
 
+/-- Test property for when the `RingHom` property corresponds to a `Module` property
+  using `RingHom.toModule`. (compare to property 2, which uses `RingHom.toAlgebra.toModule`) -/
+class Module.TestProperty5 (A M : Type*) [Semiring A] [AddCommMonoid M] [Module A M] : Prop where
+  out : ∀ x : A, ∀ M : M, x • M = 0
+
+/-- Test property for when the `RingHom` property corresponds to a `Module` property
+  using `RingHom.toModule`. (compare to property 2, which uses `RingHom.toAlgebra.toModule`) -/
+@[algebraize Module.TestProperty5]
+def RingHom.TestProperty5 {A B : Type*} [CommRing A] [CommRing B] (f : A →+* B) : Prop :=
+  @Module.TestProperty5 A B _ _ f.toModule
+
 end example_definitions
 
 set_option tactic.hygienic false
@@ -127,6 +138,14 @@ example (n m : ℕ) (A B : Type*) [CommRing A] [CommRing B] (f g : A →+* B) (h
     (hg : g.TestProperty4 m) : True := by
   algebraize [f]
   guard_hyp algebraizeInst : Algebra.TestProperty4 n A B
+  fail_if_success
+    guard_hyp algebraizeInst_1
+  trivial
+
+example (A B : Type*) [CommRing A] [CommRing B] (f g : A →+* B) (hf : f.TestProperty5)
+    (hg : g.TestProperty5) : True := by
+  algebraize [f]
+  guard_hyp algebraizeInst : @Module.TestProperty5 A B _ _ f.toModule
   fail_if_success
     guard_hyp algebraizeInst_1
   trivial


### PR DESCRIPTION
If the result of a lemma tagged with `algebraize` uses `RingHom.toModule`, the tactic didn't detect the relevant ringhom, and was unable to filter irrelevant hypotheses. For example:
```lean-4
import Mathlib.Tactic.Algebraize
set_option tactic.hygienic false

class Module.TestProperty5 (A M : Type*) [Semiring A] [AddCommMonoid M] [Module A M] : Prop where
  out : ∀ x : A, ∀ M : M, x • M = 0

@[algebraize Module.TestProperty5]
def RingHom.TestProperty5 {A B : Type*} [CommRing A] [CommRing B] (f : A →+* B) : Prop :=
  @Module.TestProperty5 A B _ _ f.toModule

example (A B : Type*) [CommRing A] [CommRing B] (f g : A →+* B) (hf : f.TestProperty5)
    (hg : g.TestProperty5) : True := by
  algebraize [f]
  guard_hyp algebraizeInst : @Module.TestProperty5 A B _ _ f.toModule
  fail_if_success
    guard_hyp algebraizeInst_1 : @Module.TestProperty5 A B _ _ g.toModule -- this is irrelevant to `f`, so should not be created.
  trivial
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
