### PR TITLE
[Merged by Bors] - feat(GroupTheory/ArchimedeanDensely): finset.univ of Int AddEquiv is refl or neg

### DIFF
--- a/Mathlib/GroupTheory/ArchimedeanDensely.lean
+++ b/Mathlib/GroupTheory/ArchimedeanDensely.lean
@@ -85,7 +85,7 @@ lemma Int.univ_addEquiv :
     (Finset.univ : Finset (ℤ ≃+ ℤ)) = .cons (.neg ℤ) {.refl ℤ} (by simp [AddEquiv.ext_int_iff]) :=
   rfl
 
-@[simp] lemma Int.card_fintype_addEquiv : Fintype.card (ℤ ≃+ ℤ) = 2 := by simp [Fintype.card]
+@[simp] lemma Int.card_fintype_addEquiv : Fintype.card (ℤ ≃+ ℤ) = 2 := rfl
 
 instance : Unique (ℤ ≃+o ℤ) where
   uniq e := OrderAddMonoidIso.toAddEquiv_injective <|

--- a/Mathlib/GroupTheory/ArchimedeanDensely.lean
+++ b/Mathlib/GroupTheory/ArchimedeanDensely.lean
@@ -85,6 +85,8 @@ lemma Int.univ_addEquiv :
     (Finset.univ : Finset (ℤ ≃+ ℤ)) = .cons (.neg ℤ) {.refl ℤ} (by simp [AddEquiv.ext_int_iff]) :=
   rfl
 
+@[simp] lemma Int.card_fintype_addEquiv : Fintype.card (ℤ ≃+ ℤ) = 2 := by simp [Fintype.card]
+
 instance : Unique (ℤ ≃+o ℤ) where
   uniq e := OrderAddMonoidIso.toAddEquiv_injective <|
     Int.addEquiv_eq_refl_or_neg e |>.resolve_right fun H => by

--- a/Mathlib/GroupTheory/ArchimedeanDensely.lean
+++ b/Mathlib/GroupTheory/ArchimedeanDensely.lean
@@ -22,7 +22,8 @@ They are placed here in a separate file (rather than incorporated as a continuat
 `GroupTheory.Archimedean`) because they rely on some imports from pointwise lemmas.
 -/
 
-open Multiplicative Set
+open Set
+open scoped WithZero
 
 -- no earlier file imports the necessary requirements for the next two
 
@@ -40,7 +41,7 @@ lemma Subgroup.mem_closure_singleton_iff_existsUnique_zpow {G : Type*}
   · suffices Function.Injective (a ^ · : ℤ → G) by
       rintro ⟨m, rfl⟩
       exact ⟨m, rfl, fun k hk ↦ this hk⟩
-    rcases ha.lt_or_lt with ha | ha
+    rcases ha.lt_or_gt with ha | ha
     · exact (zpow_right_strictAnti ha).injective
     · exact (zpow_right_strictMono ha).injective
   · exact fun h ↦ h.exists
@@ -79,11 +80,6 @@ instance : Fintype (ℤ ≃+ ℤ) where
     obtain rfl | rfl := Int.addEquiv_eq_refl_or_neg x <;>
     simp
 
-@[simp]
-lemma Int.univ_addEquiv :
-    (Finset.univ : Finset (ℤ ≃+ ℤ)) = .cons (.neg ℤ) {.refl ℤ} (by simp [AddEquiv.ext_int_iff]) :=
-  rfl
-
 instance : Unique (ℤ ≃+o ℤ) where
   uniq e := OrderAddMonoidIso.toAddEquiv_injective <|
     Int.addEquiv_eq_refl_or_neg e |>.resolve_right fun H => by
@@ -92,6 +88,11 @@ instance : Unique (ℤ ≃+o ℤ) where
         rw [← map_zero e, map_lt_map_iff]
         simp
       simp [H] at h1
+
+@[simp]
+lemma Int.univ_addEquiv :
+    (Finset.univ : Finset (ℤ ≃+ ℤ)) = .cons (.neg ℤ) {.refl ℤ} (by simp [AddEquiv.ext_int_iff]) :=
+  rfl
 
 open OrderDual in
 instance : Unique (ℤ ≃+o ℤᵒᵈ) where
@@ -159,13 +160,12 @@ noncomputable def LinearOrderedCommGroup.closure_equiv_closure {G G' : Type*}
           ← zpow_right_inj xpos, (A ⟨_, D a⟩).choose_spec]
     · intro a b
       generalize_proofs A B C D E F
-      simp only [Submonoid.coe_mul, coe_toSubmonoid, Submonoid.mk_mul_mk, Subtype.mk.injEq,
-                 coe_mul, MulMemClass.mk_mul_mk, Subtype.ext_iff]
+      simp only [coe_mul, MulMemClass.mk_mul_mk, Subtype.ext_iff]
       rw [← zpow_add, zpow_right_inj ypos, ← zpow_right_inj xpos, zpow_add,
           (A a).choose_spec, (A b).choose_spec, (A (a * b)).choose_spec]
       simp
     · intro a b
-      simp only [MulEquiv.coe_mk, Equiv.coe_fn_mk, Subtype.mk_le_mk]
+      simp only [Subtype.mk_le_mk]
       generalize_proofs A B C D
       simp [zpow_le_zpow_iff_right ypos, ← zpow_le_zpow_iff_right xpos, A.choose_spec,
         B.choose_spec]
@@ -182,7 +182,7 @@ lemma Subgroup.isLeast_of_closure_iff_eq_mabs {a b : G} :
     rw [mem_closure_singleton] at ha
     obtain ⟨n, rfl⟩ := ha
     have := h.left
-    simp only [mem_closure_singleton, mem_setOf_eq, ← mul_zsmul] at this
+    simp only [mem_closure_singleton, mem_setOf_eq] at this
     obtain ⟨m, hm⟩ := this.left
     have key : m * n = 1 := by
       rw [← zpow_right_inj this.right, zpow_mul', hm, zpow_one]
@@ -191,7 +191,7 @@ lemma Subgroup.isLeast_of_closure_iff_eq_mabs {a b : G} :
     rcases key with ⟨rfl, rfl⟩|⟨rfl, rfl⟩ <;>
     simp [this.right.le, this.right, mabs]
   · wlog ha : 1 ≤ a generalizing a
-    · convert @this (a⁻¹) ?_ (by simpa using le_of_not_le ha) using 4
+    · convert @this (a⁻¹) ?_ (by simpa using le_of_not_ge ha) using 4
       · simp
       · rwa [mabs_inv]
     rw [mabs, sup_eq_left.mpr ((inv_le_one'.mpr ha).trans ha)] at h
@@ -234,6 +234,80 @@ noncomputable def LinearOrderedCommGroup.multiplicative_int_orderMonoidIso_of_is
   have : IsLeast {y : Additive G | 0 < y} (.ofMul x) := h
   let f' := LinearOrderedAddCommGroup.int_orderAddMonoidIso_of_isLeast_pos (G := Additive G) this
   exact ⟨AddEquiv.toMultiplicative' f', by simp⟩
+
+section TypeTags
+
+/-- Reinterpret `G ≃*o H` as `Additive G ≃+o Additive H`. -/
+def OrderMonoidIso.toAdditive {G H : Type*}
+    [CommMonoid G] [PartialOrder G] [CommMonoid H] [PartialOrder H] :
+    (G ≃*o H) ≃ (Additive G ≃+o Additive H) where
+  toFun e := ⟨MulEquiv.toAdditive e, by simp⟩
+  invFun e := ⟨MulEquiv.toAdditive.symm e, by simp⟩
+  left_inv e := by ext; simp
+  right_inv e := by ext; simp
+
+/-- Reinterpret `G ≃+o H` as `Multiplicative G ≃*o Multiplicative H`. -/
+def OrderAddMonoidIso.toMultiplicative {G H : Type*}
+    [AddCommMonoid G] [PartialOrder G] [AddCommMonoid H] [PartialOrder H] :
+    (G ≃+o H) ≃ (Multiplicative G ≃*o Multiplicative H) where
+  toFun e := ⟨AddEquiv.toMultiplicative e, by simp⟩
+  invFun e := ⟨AddEquiv.toMultiplicative.symm e, by simp⟩
+  left_inv e := by ext; simp
+  right_inv e := by ext; simp
+
+/-- Reinterpret `Additive G ≃+o H` as `G ≃*o Multiplicative H`. -/
+def OrderAddMonoidIso.toMultiplicative' {G H : Type*}
+    [CommMonoid G] [PartialOrder G] [AddCommMonoid H] [PartialOrder H] :
+    (Additive G ≃+o H) ≃ (G ≃*o Multiplicative H) where
+  toFun e := ⟨AddEquiv.toMultiplicative' e, by simp⟩
+  invFun e := ⟨AddEquiv.toMultiplicative'.symm e, by simp⟩
+  left_inv e := by ext; simp
+  right_inv e := by ext; simp
+
+/-- Reinterpret `G ≃* Multiplicative H` as `Additive G ≃+ H`. -/
+abbrev OrderMonoidIso.toAdditive' {G H : Type*}
+    [CommMonoid G] [PartialOrder G] [AddCommMonoid H] [PartialOrder H] :
+    (G ≃*o Multiplicative H) ≃ (Additive G ≃+o H) :=
+  OrderAddMonoidIso.toMultiplicative'.symm
+
+/-- Reinterpret `G ≃+o Additive H` as `Multiplicative G ≃*o H`. -/
+def OrderAddMonoidIso.toMultiplicative'' {G H : Type*}
+    [AddCommMonoid G] [PartialOrder G] [CommMonoid H] [PartialOrder H] :
+    (G ≃+o Additive H) ≃ (Multiplicative G ≃*o H) where
+  toFun e := ⟨AddEquiv.toMultiplicative'' e, by simp⟩
+  invFun e := ⟨AddEquiv.toMultiplicative''.symm e, by simp⟩
+  left_inv e := by ext; simp
+  right_inv e := by ext; simp
+
+/-- Reinterpret `Multiplicative G ≃*o H` as `G ≃+o Additive H` as. -/
+abbrev OrderMonoidIso.toAdditive'' {G H : Type*}
+    [AddCommMonoid G] [PartialOrder G] [CommMonoid H] [PartialOrder H] :
+    (Multiplicative G ≃*o H) ≃ (G ≃+o Additive H) :=
+  OrderAddMonoidIso.toMultiplicative''.symm
+
+/-- The multiplicative version of an additivized ordered monoid is order-mul-equivalent to itself.
+-/
+def OrderMonoidIso.toMultiplicative_toAdditive {G : Type*} [CommMonoid G] [PartialOrder G] :
+    Multiplicative (Additive G) ≃*o G :=
+  OrderAddMonoidIso.toMultiplicative'' <| OrderMonoidIso.toAdditive (.refl _)
+
+/-- The additive version of an multiplicativized ordered additive monoid is
+order-add-equivalent to itself. -/
+def OrderAddMonoidIso.toAdditive_toMultiplicative {G : Type*} [AddCommMonoid G] [PartialOrder G] :
+    Additive (Multiplicative G) ≃+o G :=
+  OrderMonoidIso.toAdditive' <| OrderAddMonoidIso.toMultiplicative (.refl _)
+
+instance Additive.instUniqueOrderAddMonoidIso {G H : Type*}
+    [CommMonoid G] [PartialOrder G] [CommMonoid H] [PartialOrder H] [Unique (G ≃*o H)] :
+    Unique (Additive G ≃+o Additive H) :=
+  OrderMonoidIso.toAdditive.symm.unique
+
+instance Multiplicative.instUniqueOrderdMonoidIso {G H : Type*}
+    [AddCommMonoid G] [PartialOrder G] [AddCommMonoid H] [PartialOrder H] [Unique (G ≃+o H)] :
+    Unique (Multiplicative G ≃*o Multiplicative H) :=
+  OrderAddMonoidIso.toMultiplicative.symm.unique
+
+end TypeTags
 
 /-- Any linearly ordered archimedean additive group is either isomorphic (and order-isomorphic)
 to the integers, or is densely ordered. -/
@@ -314,39 +388,39 @@ lemma denselyOrdered_units_iff {G₀ : Type*} [LinearOrderedCommGroupWithZero G�
     refine ⟨Units.mk0 z hz'.ne', ?_⟩
     simp [← Units.val_lt_val, hz]
 
+/-- Any linearly ordered group with zero is isomorphic to adjoining `0` to the units of itself. -/
+@[simps!]
+def OrderMonoidIso.withZeroUnits {α : Type*} [LinearOrderedCommGroupWithZero α]
+    [DecidablePred (fun a : α ↦ a = 0)] :
+    WithZero αˣ ≃*o α where
+  toMulEquiv := WithZero.withZeroUnitsEquiv
+  map_le_map_iff' {a b} := by
+    cases a <;> cases b <;>
+    simp
+
 /-- Any nontrivial (has other than 0 and 1) linearly ordered mul-archimedean group with zero is
-either isomorphic (and order-isomorphic) to `ℤₘ₀`, or is densely ordered. -/
+either isomorphic (and order-isomorphic) to `ℤᵐ⁰`, or is densely ordered. -/
 lemma LinearOrderedCommGroupWithZero.discrete_or_denselyOrdered (G : Type*)
     [LinearOrderedCommGroupWithZero G] [Nontrivial Gˣ] [MulArchimedean G] :
-    Nonempty (G ≃*o ℤₘ₀) ∨ DenselyOrdered G := by
+    Nonempty (G ≃*o ℤᵐ⁰) ∨ DenselyOrdered G := by
   classical
   rw [← denselyOrdered_units_iff]
   refine (LinearOrderedCommGroup.discrete_or_denselyOrdered Gˣ).imp_left ?_
   intro ⟨f⟩
-  refine ⟨OrderMonoidIso.trans
-    ⟨WithZero.withZeroUnitsEquiv.symm, ?_⟩ ⟨f.withZero, ?_⟩⟩
-  · intro
-    simp only [WithZero.withZeroUnitsEquiv, MulEquiv.symm_mk,
-      MulEquiv.toEquiv_eq_coe, Equiv.toFun_as_coe, EquivLike.coe_coe, MulEquiv.coe_mk,
-      Equiv.coe_fn_symm_mk ]
-    split_ifs <;>
-    simp_all [← Units.val_le_val]
-  · intro a b
-    induction a <;> induction b <;>
-    simp [MulEquiv.withZero]
+  exact ⟨OrderMonoidIso.withZeroUnits.symm.trans f.withZero⟩
 
 open WithZero in
 /-- Any nontrivial (has other than 0 and 1) linearly ordered mul-archimedean group with zero is
-either isomorphic (and order-isomorphic) to `ℤₘ₀`, or is densely ordered, exclusively -/
+either isomorphic (and order-isomorphic) to `ℤᵐ⁰`, or is densely ordered, exclusively -/
 lemma LinearOrderedCommGroupWithZero.discrete_iff_not_denselyOrdered (G : Type*)
     [LinearOrderedCommGroupWithZero G] [Nontrivial Gˣ] [MulArchimedean G] :
-    Nonempty (G ≃*o ℤₘ₀) ↔ ¬ DenselyOrdered G := by
+    Nonempty (G ≃*o ℤᵐ⁰) ↔ ¬ DenselyOrdered G := by
   rw [← denselyOrdered_units_iff,
       ← LinearOrderedCommGroup.discrete_iff_not_denselyOrdered]
   refine Nonempty.congr ?_ ?_ <;> intro f
-  · refine ⟨MulEquiv.unzero (withZeroUnitsEquiv.trans f), ?_⟩
+  · refine ⟨MulEquiv.withZero.symm (withZeroUnitsEquiv.trans f), ?_⟩
     intros
-    simp only [MulEquiv.unzero, withZeroUnitsEquiv, MulEquiv.trans_apply,
+    simp only [MulEquiv.withZero, withZeroUnitsEquiv, MulEquiv.trans_apply,
       MulEquiv.coe_mk, Equiv.coe_fn_mk, recZeroCoe_coe, OrderMonoidIso.coe_mulEquiv,
       MulEquiv.symm_trans_apply, MulEquiv.symm_mk, Equiv.coe_fn_symm_mk, map_eq_zero, coe_ne_zero,
       ↓reduceDIte, unzero_coe, MulEquiv.toEquiv_eq_coe, Equiv.toFun_as_coe, EquivLike.coe_coe]
@@ -354,7 +428,7 @@ lemma LinearOrderedCommGroupWithZero.discrete_iff_not_denselyOrdered (G : Type*)
   · refine ⟨withZeroUnitsEquiv.symm.trans (MulEquiv.withZero f), ?_⟩
     intros
     simp only [withZeroUnitsEquiv, MulEquiv.symm_mk, MulEquiv.withZero,
-      MulEquiv.toMonoidHom_eq_coe, MulEquiv.toEquiv_eq_coe, Equiv.toFun_as_coe, EquivLike.coe_coe,
+      MulEquiv.toEquiv_eq_coe, Equiv.toFun_as_coe, EquivLike.coe_coe,
       MulEquiv.trans_apply, MulEquiv.coe_mk, Equiv.coe_fn_symm_mk, Equiv.coe_fn_mk]
     split_ifs <;>
     simp_all [← Units.val_le_val]
@@ -428,7 +502,7 @@ lemma LinearOrderedCommGroup.wellFoundedOn_setOf_ge_gt_iff_nonempty_discrete
 
 lemma LinearOrderedCommGroupWithZero.wellFoundedOn_setOf_le_lt_iff_nonempty_discrete_of_ne_zero
     {G₀ : Type*} [LinearOrderedCommGroupWithZero G₀] [Nontrivial G₀ˣ] {g : G₀} (hg : g ≠ 0) :
-    Set.WellFoundedOn {x : G₀ | g ≤ x} (· < ·) ↔ Nonempty (G₀ ≃*o ℤₘ₀) := by
+    Set.WellFoundedOn {x : G₀ | g ≤ x} (· < ·) ↔ Nonempty (G₀ ≃*o ℤᵐ⁰) := by
   suffices Set.WellFoundedOn {x : G₀ | g ≤ x} (· < ·) ↔
     Set.WellFoundedOn {x : G₀ˣ | Units.mk0 g hg ≤ x} (· < ·) by
     rw [this, LinearOrderedCommGroup.wellFoundedOn_setOf_le_lt_iff_nonempty_discrete]
@@ -436,14 +510,14 @@ lemma LinearOrderedCommGroupWithZero.wellFoundedOn_setOf_le_lt_iff_nonempty_disc
     · exact WithZero.withZeroUnitsEquiv.symm.trans f.withZero
     · intro a b
       rcases eq_or_ne a 0 with rfl|ha
-      · simp [WithZero.withZeroUnitsEquiv, MulEquiv.withZero]
+      · simp [WithZero.withZeroUnitsEquiv]
       rcases eq_or_ne b 0 with rfl|hb
-      · simp [WithZero.withZeroUnitsEquiv, MulEquiv.withZero]
-      simp [WithZero.withZeroUnitsEquiv, MulEquiv.withZero, ha, hb, ← Units.val_le_val]
-    · exact MulEquiv.unzero (WithZero.withZeroUnitsEquiv.trans f)
+      · simp [WithZero.withZeroUnitsEquiv]
+      simp [WithZero.withZeroUnitsEquiv, ha, hb, ← Units.val_le_val]
+    · exact MulEquiv.withZero.symm (WithZero.withZeroUnitsEquiv.trans f)
     · intros
       rw [← WithZero.coe_le_coe]
-      simp [WithZero.withZeroUnitsEquiv, MulEquiv.unzero]
+      simp
   rw [← Set.wellFoundedOn_sdiff_singleton (a := 0)]
   refine ⟨fun h ↦ (h.mapsTo Units.val ?_).mono' ?_,
     fun h ↦ (h.mapsTo ?_ ?_).mono' ?_⟩
@@ -458,7 +532,7 @@ lemma LinearOrderedCommGroupWithZero.wellFoundedOn_setOf_le_lt_iff_nonempty_disc
 
 lemma LinearOrderedCommGroupWithZero.wellFoundedOn_setOf_ge_gt_iff_nonempty_discrete_of_ne_zero
     {G₀ : Type*} [LinearOrderedCommGroupWithZero G₀] [Nontrivial G₀ˣ] {g : G₀} (hg : g ≠ 0) :
-    Set.WellFoundedOn {x : G₀ | x ≤ g} (· > ·) ↔ Nonempty (G₀ ≃*o ℤₘ₀) := by
+    Set.WellFoundedOn {x : G₀ | x ≤ g} (· > ·) ↔ Nonempty (G₀ ≃*o ℤᵐ⁰) := by
   have hg' : g⁻¹ ≠ 0 := by simp [hg]
   rw [← wellFoundedOn_setOf_le_lt_iff_nonempty_discrete_of_ne_zero hg',
     ← Set.wellFoundedOn_sdiff_singleton (a := 0)]

--- a/Mathlib/GroupTheory/ArchimedeanDensely.lean
+++ b/Mathlib/GroupTheory/ArchimedeanDensely.lean
@@ -80,6 +80,11 @@ instance : Fintype (ℤ ≃+ ℤ) where
     obtain rfl | rfl := Int.addEquiv_eq_refl_or_neg x <;>
     simp
 
+@[simp]
+lemma Int.univ_addEquiv :
+    (Finset.univ : Finset (ℤ ≃+ ℤ)) = .cons (.neg ℤ) {.refl ℤ} (by simp [AddEquiv.ext_int_iff]) :=
+  rfl
+
 instance : Unique (ℤ ≃+o ℤ) where
   uniq e := OrderAddMonoidIso.toAddEquiv_injective <|
     Int.addEquiv_eq_refl_or_neg e |>.resolve_right fun H => by
@@ -88,11 +93,6 @@ instance : Unique (ℤ ≃+o ℤ) where
         rw [← map_zero e, map_lt_map_iff]
         simp
       simp [H] at h1
-
-@[simp]
-lemma Int.univ_addEquiv :
-    (Finset.univ : Finset (ℤ ≃+ ℤ)) = .cons (.neg ℤ) {.refl ℤ} (by simp [AddEquiv.ext_int_iff]) :=
-  rfl
 
 open OrderDual in
 instance : Unique (ℤ ≃+o ℤᵒᵈ) where

--- a/Mathlib/GroupTheory/ArchimedeanDensely.lean
+++ b/Mathlib/GroupTheory/ArchimedeanDensely.lean
@@ -22,8 +22,7 @@ They are placed here in a separate file (rather than incorporated as a continuat
 `GroupTheory.Archimedean`) because they rely on some imports from pointwise lemmas.
 -/
 
-open Set
-open scoped WithZero
+open Multiplicative Set
 
 -- no earlier file imports the necessary requirements for the next two
 
@@ -41,7 +40,7 @@ lemma Subgroup.mem_closure_singleton_iff_existsUnique_zpow {G : Type*}
   · suffices Function.Injective (a ^ · : ℤ → G) by
       rintro ⟨m, rfl⟩
       exact ⟨m, rfl, fun k hk ↦ this hk⟩
-    rcases ha.lt_or_gt with ha | ha
+    rcases ha.lt_or_lt with ha | ha
     · exact (zpow_right_strictAnti ha).injective
     · exact (zpow_right_strictMono ha).injective
   · exact fun h ↦ h.exists
@@ -79,6 +78,11 @@ instance : Fintype (ℤ ≃+ ℤ) where
   complete x := by
     obtain rfl | rfl := Int.addEquiv_eq_refl_or_neg x <;>
     simp
+
+@[simp]
+lemma Int.univ_addEquiv :
+    (Finset.univ : Finset (ℤ ≃+ ℤ)) = .cons (.neg ℤ) {.refl ℤ} (by simp [AddEquiv.ext_int_iff]) :=
+  rfl
 
 instance : Unique (ℤ ≃+o ℤ) where
   uniq e := OrderAddMonoidIso.toAddEquiv_injective <|
@@ -155,12 +159,13 @@ noncomputable def LinearOrderedCommGroup.closure_equiv_closure {G G' : Type*}
           ← zpow_right_inj xpos, (A ⟨_, D a⟩).choose_spec]
     · intro a b
       generalize_proofs A B C D E F
-      simp only [coe_mul, MulMemClass.mk_mul_mk, Subtype.ext_iff]
+      simp only [Submonoid.coe_mul, coe_toSubmonoid, Submonoid.mk_mul_mk, Subtype.mk.injEq,
+                 coe_mul, MulMemClass.mk_mul_mk, Subtype.ext_iff]
       rw [← zpow_add, zpow_right_inj ypos, ← zpow_right_inj xpos, zpow_add,
           (A a).choose_spec, (A b).choose_spec, (A (a * b)).choose_spec]
       simp
     · intro a b
-      simp only [Subtype.mk_le_mk]
+      simp only [MulEquiv.coe_mk, Equiv.coe_fn_mk, Subtype.mk_le_mk]
       generalize_proofs A B C D
       simp [zpow_le_zpow_iff_right ypos, ← zpow_le_zpow_iff_right xpos, A.choose_spec,
         B.choose_spec]
@@ -177,7 +182,7 @@ lemma Subgroup.isLeast_of_closure_iff_eq_mabs {a b : G} :
     rw [mem_closure_singleton] at ha
     obtain ⟨n, rfl⟩ := ha
     have := h.left
-    simp only [mem_closure_singleton, mem_setOf_eq] at this
+    simp only [mem_closure_singleton, mem_setOf_eq, ← mul_zsmul] at this
     obtain ⟨m, hm⟩ := this.left
     have key : m * n = 1 := by
       rw [← zpow_right_inj this.right, zpow_mul', hm, zpow_one]
@@ -186,7 +191,7 @@ lemma Subgroup.isLeast_of_closure_iff_eq_mabs {a b : G} :
     rcases key with ⟨rfl, rfl⟩|⟨rfl, rfl⟩ <;>
     simp [this.right.le, this.right, mabs]
   · wlog ha : 1 ≤ a generalizing a
-    · convert @this (a⁻¹) ?_ (by simpa using le_of_not_ge ha) using 4
+    · convert @this (a⁻¹) ?_ (by simpa using le_of_not_le ha) using 4
       · simp
       · rwa [mabs_inv]
     rw [mabs, sup_eq_left.mpr ((inv_le_one'.mpr ha).trans ha)] at h
@@ -229,80 +234,6 @@ noncomputable def LinearOrderedCommGroup.multiplicative_int_orderMonoidIso_of_is
   have : IsLeast {y : Additive G | 0 < y} (.ofMul x) := h
   let f' := LinearOrderedAddCommGroup.int_orderAddMonoidIso_of_isLeast_pos (G := Additive G) this
   exact ⟨AddEquiv.toMultiplicative' f', by simp⟩
-
-section TypeTags
-
-/-- Reinterpret `G ≃*o H` as `Additive G ≃+o Additive H`. -/
-def OrderMonoidIso.toAdditive {G H : Type*}
-    [CommMonoid G] [PartialOrder G] [CommMonoid H] [PartialOrder H] :
-    (G ≃*o H) ≃ (Additive G ≃+o Additive H) where
-  toFun e := ⟨MulEquiv.toAdditive e, by simp⟩
-  invFun e := ⟨MulEquiv.toAdditive.symm e, by simp⟩
-  left_inv e := by ext; simp
-  right_inv e := by ext; simp
-
-/-- Reinterpret `G ≃+o H` as `Multiplicative G ≃*o Multiplicative H`. -/
-def OrderAddMonoidIso.toMultiplicative {G H : Type*}
-    [AddCommMonoid G] [PartialOrder G] [AddCommMonoid H] [PartialOrder H] :
-    (G ≃+o H) ≃ (Multiplicative G ≃*o Multiplicative H) where
-  toFun e := ⟨AddEquiv.toMultiplicative e, by simp⟩
-  invFun e := ⟨AddEquiv.toMultiplicative.symm e, by simp⟩
-  left_inv e := by ext; simp
-  right_inv e := by ext; simp
-
-/-- Reinterpret `Additive G ≃+o H` as `G ≃*o Multiplicative H`. -/
-def OrderAddMonoidIso.toMultiplicative' {G H : Type*}
-    [CommMonoid G] [PartialOrder G] [AddCommMonoid H] [PartialOrder H] :
-    (Additive G ≃+o H) ≃ (G ≃*o Multiplicative H) where
-  toFun e := ⟨AddEquiv.toMultiplicative' e, by simp⟩
-  invFun e := ⟨AddEquiv.toMultiplicative'.symm e, by simp⟩
-  left_inv e := by ext; simp
-  right_inv e := by ext; simp
-
-/-- Reinterpret `G ≃* Multiplicative H` as `Additive G ≃+ H`. -/
-abbrev OrderMonoidIso.toAdditive' {G H : Type*}
-    [CommMonoid G] [PartialOrder G] [AddCommMonoid H] [PartialOrder H] :
-    (G ≃*o Multiplicative H) ≃ (Additive G ≃+o H) :=
-  OrderAddMonoidIso.toMultiplicative'.symm
-
-/-- Reinterpret `G ≃+o Additive H` as `Multiplicative G ≃*o H`. -/
-def OrderAddMonoidIso.toMultiplicative'' {G H : Type*}
-    [AddCommMonoid G] [PartialOrder G] [CommMonoid H] [PartialOrder H] :
-    (G ≃+o Additive H) ≃ (Multiplicative G ≃*o H) where
-  toFun e := ⟨AddEquiv.toMultiplicative'' e, by simp⟩
-  invFun e := ⟨AddEquiv.toMultiplicative''.symm e, by simp⟩
-  left_inv e := by ext; simp
-  right_inv e := by ext; simp
-
-/-- Reinterpret `Multiplicative G ≃*o H` as `G ≃+o Additive H` as. -/
-abbrev OrderMonoidIso.toAdditive'' {G H : Type*}
-    [AddCommMonoid G] [PartialOrder G] [CommMonoid H] [PartialOrder H] :
-    (Multiplicative G ≃*o H) ≃ (G ≃+o Additive H) :=
-  OrderAddMonoidIso.toMultiplicative''.symm
-
-/-- The multiplicative version of an additivized ordered monoid is order-mul-equivalent to itself.
--/
-def OrderMonoidIso.toMultiplicative_toAdditive {G : Type*} [CommMonoid G] [PartialOrder G] :
-    Multiplicative (Additive G) ≃*o G :=
-  OrderAddMonoidIso.toMultiplicative'' <| OrderMonoidIso.toAdditive (.refl _)
-
-/-- The additive version of an multiplicativized ordered additive monoid is
-order-add-equivalent to itself. -/
-def OrderAddMonoidIso.toAdditive_toMultiplicative {G : Type*} [AddCommMonoid G] [PartialOrder G] :
-    Additive (Multiplicative G) ≃+o G :=
-  OrderMonoidIso.toAdditive' <| OrderAddMonoidIso.toMultiplicative (.refl _)
-
-instance Additive.instUniqueOrderAddMonoidIso {G H : Type*}
-    [CommMonoid G] [PartialOrder G] [CommMonoid H] [PartialOrder H] [Unique (G ≃*o H)] :
-    Unique (Additive G ≃+o Additive H) :=
-  OrderMonoidIso.toAdditive.symm.unique
-
-instance Multiplicative.instUniqueOrderdMonoidIso {G H : Type*}
-    [AddCommMonoid G] [PartialOrder G] [AddCommMonoid H] [PartialOrder H] [Unique (G ≃+o H)] :
-    Unique (Multiplicative G ≃*o Multiplicative H) :=
-  OrderAddMonoidIso.toMultiplicative.symm.unique
-
-end TypeTags
 
 /-- Any linearly ordered archimedean additive group is either isomorphic (and order-isomorphic)
 to the integers, or is densely ordered. -/
@@ -383,39 +314,39 @@ lemma denselyOrdered_units_iff {G₀ : Type*} [LinearOrderedCommGroupWithZero G�
     refine ⟨Units.mk0 z hz'.ne', ?_⟩
     simp [← Units.val_lt_val, hz]
 
-/-- Any linearly ordered group with zero is isomorphic to adjoining `0` to the units of itself. -/
-@[simps!]
-def OrderMonoidIso.withZeroUnits {α : Type*} [LinearOrderedCommGroupWithZero α]
-    [DecidablePred (fun a : α ↦ a = 0)] :
-    WithZero αˣ ≃*o α where
-  toMulEquiv := WithZero.withZeroUnitsEquiv
-  map_le_map_iff' {a b} := by
-    cases a <;> cases b <;>
-    simp
-
 /-- Any nontrivial (has other than 0 and 1) linearly ordered mul-archimedean group with zero is
-either isomorphic (and order-isomorphic) to `ℤᵐ⁰`, or is densely ordered. -/
+either isomorphic (and order-isomorphic) to `ℤₘ₀`, or is densely ordered. -/
 lemma LinearOrderedCommGroupWithZero.discrete_or_denselyOrdered (G : Type*)
     [LinearOrderedCommGroupWithZero G] [Nontrivial Gˣ] [MulArchimedean G] :
-    Nonempty (G ≃*o ℤᵐ⁰) ∨ DenselyOrdered G := by
+    Nonempty (G ≃*o ℤₘ₀) ∨ DenselyOrdered G := by
   classical
   rw [← denselyOrdered_units_iff]
   refine (LinearOrderedCommGroup.discrete_or_denselyOrdered Gˣ).imp_left ?_
   intro ⟨f⟩
-  exact ⟨OrderMonoidIso.withZeroUnits.symm.trans f.withZero⟩
+  refine ⟨OrderMonoidIso.trans
+    ⟨WithZero.withZeroUnitsEquiv.symm, ?_⟩ ⟨f.withZero, ?_⟩⟩
+  · intro
+    simp only [WithZero.withZeroUnitsEquiv, MulEquiv.symm_mk,
+      MulEquiv.toEquiv_eq_coe, Equiv.toFun_as_coe, EquivLike.coe_coe, MulEquiv.coe_mk,
+      Equiv.coe_fn_symm_mk ]
+    split_ifs <;>
+    simp_all [← Units.val_le_val]
+  · intro a b
+    induction a <;> induction b <;>
+    simp [MulEquiv.withZero]
 
 open WithZero in
 /-- Any nontrivial (has other than 0 and 1) linearly ordered mul-archimedean group with zero is
-either isomorphic (and order-isomorphic) to `ℤᵐ⁰`, or is densely ordered, exclusively -/
+either isomorphic (and order-isomorphic) to `ℤₘ₀`, or is densely ordered, exclusively -/
 lemma LinearOrderedCommGroupWithZero.discrete_iff_not_denselyOrdered (G : Type*)
     [LinearOrderedCommGroupWithZero G] [Nontrivial Gˣ] [MulArchimedean G] :
-    Nonempty (G ≃*o ℤᵐ⁰) ↔ ¬ DenselyOrdered G := by
+    Nonempty (G ≃*o ℤₘ₀) ↔ ¬ DenselyOrdered G := by
   rw [← denselyOrdered_units_iff,
       ← LinearOrderedCommGroup.discrete_iff_not_denselyOrdered]
   refine Nonempty.congr ?_ ?_ <;> intro f
-  · refine ⟨MulEquiv.withZero.symm (withZeroUnitsEquiv.trans f), ?_⟩
+  · refine ⟨MulEquiv.unzero (withZeroUnitsEquiv.trans f), ?_⟩
     intros
-    simp only [MulEquiv.withZero, withZeroUnitsEquiv, MulEquiv.trans_apply,
+    simp only [MulEquiv.unzero, withZeroUnitsEquiv, MulEquiv.trans_apply,
       MulEquiv.coe_mk, Equiv.coe_fn_mk, recZeroCoe_coe, OrderMonoidIso.coe_mulEquiv,
       MulEquiv.symm_trans_apply, MulEquiv.symm_mk, Equiv.coe_fn_symm_mk, map_eq_zero, coe_ne_zero,
       ↓reduceDIte, unzero_coe, MulEquiv.toEquiv_eq_coe, Equiv.toFun_as_coe, EquivLike.coe_coe]
@@ -423,7 +354,7 @@ lemma LinearOrderedCommGroupWithZero.discrete_iff_not_denselyOrdered (G : Type*)
   · refine ⟨withZeroUnitsEquiv.symm.trans (MulEquiv.withZero f), ?_⟩
     intros
     simp only [withZeroUnitsEquiv, MulEquiv.symm_mk, MulEquiv.withZero,
-      MulEquiv.toEquiv_eq_coe, Equiv.toFun_as_coe, EquivLike.coe_coe,
+      MulEquiv.toMonoidHom_eq_coe, MulEquiv.toEquiv_eq_coe, Equiv.toFun_as_coe, EquivLike.coe_coe,
       MulEquiv.trans_apply, MulEquiv.coe_mk, Equiv.coe_fn_symm_mk, Equiv.coe_fn_mk]
     split_ifs <;>
     simp_all [← Units.val_le_val]
@@ -497,7 +428,7 @@ lemma LinearOrderedCommGroup.wellFoundedOn_setOf_ge_gt_iff_nonempty_discrete
 
 lemma LinearOrderedCommGroupWithZero.wellFoundedOn_setOf_le_lt_iff_nonempty_discrete_of_ne_zero
     {G₀ : Type*} [LinearOrderedCommGroupWithZero G₀] [Nontrivial G₀ˣ] {g : G₀} (hg : g ≠ 0) :
-    Set.WellFoundedOn {x : G₀ | g ≤ x} (· < ·) ↔ Nonempty (G₀ ≃*o ℤᵐ⁰) := by
+    Set.WellFoundedOn {x : G₀ | g ≤ x} (· < ·) ↔ Nonempty (G₀ ≃*o ℤₘ₀) := by
   suffices Set.WellFoundedOn {x : G₀ | g ≤ x} (· < ·) ↔
     Set.WellFoundedOn {x : G₀ˣ | Units.mk0 g hg ≤ x} (· < ·) by
     rw [this, LinearOrderedCommGroup.wellFoundedOn_setOf_le_lt_iff_nonempty_discrete]
@@ -505,14 +436,14 @@ lemma LinearOrderedCommGroupWithZero.wellFoundedOn_setOf_le_lt_iff_nonempty_disc
     · exact WithZero.withZeroUnitsEquiv.symm.trans f.withZero
     · intro a b
       rcases eq_or_ne a 0 with rfl|ha
-      · simp [WithZero.withZeroUnitsEquiv]
+      · simp [WithZero.withZeroUnitsEquiv, MulEquiv.withZero]
       rcases eq_or_ne b 0 with rfl|hb
-      · simp [WithZero.withZeroUnitsEquiv]
-      simp [WithZero.withZeroUnitsEquiv, ha, hb, ← Units.val_le_val]
-    · exact MulEquiv.withZero.symm (WithZero.withZeroUnitsEquiv.trans f)
+      · simp [WithZero.withZeroUnitsEquiv, MulEquiv.withZero]
+      simp [WithZero.withZeroUnitsEquiv, MulEquiv.withZero, ha, hb, ← Units.val_le_val]
+    · exact MulEquiv.unzero (WithZero.withZeroUnitsEquiv.trans f)
     · intros
       rw [← WithZero.coe_le_coe]
-      simp
+      simp [WithZero.withZeroUnitsEquiv, MulEquiv.unzero]
   rw [← Set.wellFoundedOn_sdiff_singleton (a := 0)]
   refine ⟨fun h ↦ (h.mapsTo Units.val ?_).mono' ?_,
     fun h ↦ (h.mapsTo ?_ ?_).mono' ?_⟩
@@ -527,7 +458,7 @@ lemma LinearOrderedCommGroupWithZero.wellFoundedOn_setOf_le_lt_iff_nonempty_disc
 
 lemma LinearOrderedCommGroupWithZero.wellFoundedOn_setOf_ge_gt_iff_nonempty_discrete_of_ne_zero
     {G₀ : Type*} [LinearOrderedCommGroupWithZero G₀] [Nontrivial G₀ˣ] {g : G₀} (hg : g ≠ 0) :
-    Set.WellFoundedOn {x : G₀ | x ≤ g} (· > ·) ↔ Nonempty (G₀ ≃*o ℤᵐ⁰) := by
+    Set.WellFoundedOn {x : G₀ | x ≤ g} (· > ·) ↔ Nonempty (G₀ ≃*o ℤₘ₀) := by
   have hg' : g⁻¹ ≠ 0 := by simp [hg]
   rw [← wellFoundedOn_setOf_le_lt_iff_nonempty_discrete_of_ne_zero hg',
     ← Set.wellFoundedOn_sdiff_singleton (a := 0)]


### PR DESCRIPTION
Follow-up to #24582


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
