### PR TITLE
[Merged by Bors] - chore: remove unnecessary `noncomputable` attribute

### DIFF
--- a/Mathlib/Algebra/Group/Action/Pointwise/Finset.lean
+++ b/Mathlib/Algebra/Group/Action/Pointwise/Finset.lean
@@ -73,18 +73,12 @@ instance isCentralScalar [SMul α β] [SMul αᵐᵒᵖ β] [IsCentralScalar α 
     IsCentralScalar α (Finset β) :=
   ⟨fun a s => coe_injective <| by simp only [coe_smul_finset, op_smul_eq_smul]⟩
 
-#adaptation_note /-- nightly-2025-04-07
-This now needs to be marked as noncomputable because of its dependence on `Set.monoid`.
-We should either find a way to rewrite this definition to avoid this,
-or request via @kim-em and @zwarich that changes in https://github.com/leanprover/lean4/pull/7824
-be revisited to avoid needing as many `noncomputable`s.
--/
 /-- A multiplicative action of a monoid `α` on a type `β` gives a multiplicative action of
 `Finset α` on `Finset β`. -/
 @[to_additive
       "An additive action of an additive monoid `α` on a type `β` gives an additive action
       of `Finset α` on `Finset β`"]
-protected noncomputable def mulAction [DecidableEq α] [Monoid α] [MulAction α β] :
+protected def mulAction [DecidableEq α] [Monoid α] [MulAction α β] :
     MulAction (Finset α) (Finset β) where
   mul_smul _ _ _ := image₂_assoc mul_smul
   one_smul s := image₂_singleton_left.trans <| by simp_rw [one_smul, image_id']


### PR DESCRIPTION
This is no longer necessary after updating to 4.22 with the new compiler. The other remaining `noncomputable` from the same adaptation note on Finset.addMonoid is still required, because that definition applies Injective.addMonoid to the noncomputable Set.addMonoid.