### PR TITLE
[Merged by Bors] - fix: add `whnfR` in the code for the string diagram widget

### DIFF
--- a/Mathlib/Tactic/Widget/StringDiagram.lean
+++ b/Mathlib/Tactic/Widget/StringDiagram.lean
@@ -366,7 +366,7 @@ def mkEqHtml (lhs rhs : Html) : Html :=
 /-- Given an equality between 2-morphisms, return a string diagram of the LHS and RHS.
 Otherwise `none`. -/
 def stringEqM? (e : Expr) : MetaM (Option Html) := do
-  let e ← instantiateMVars e
+  let e ← whnfR <| ← instantiateMVars e
   let some (_, lhs, rhs) := e.eq? | return none
   let some lhs ← stringM? lhs | return none
   let some rhs ← stringM? rhs | return none
@@ -375,7 +375,7 @@ def stringEqM? (e : Expr) : MetaM (Option Html) := do
 /-- Given an 2-morphism or equality between 2-morphisms, return a string diagram.
 Otherwise `none`. -/
 def stringMorOrEqM? (e : Expr) : MetaM (Option Html) := do
-  forallTelescopeReducing (← inferType e) fun xs a => do
+  forallTelescopeReducing (← whnfR <| ← inferType e) fun xs a => do
     if let some html ← stringM? (mkAppN e xs) then
       return some html
     else if let some html ← stringEqM? a then


### PR DESCRIPTION
Without this, the widget cannot see the expression after `have` line.

The following example is reported on [#Infinity-Cosmos > Bicategory of enriched categories @ 💬](https://leanprover.zulipchat.com/#narrow/channel/455414-Infinity-Cosmos/topic/Bicategory.20of.20enriched.20categories/near/527192362)
```
example {C : Type} [Category C] [MonoidalCategory C]
    {D : Type} [Category D] [MonoidalCategory D]
    (F G : C ⥤ D) (α : F ⟶ G)
    {X Y : C} {Z : D} (h : α.app X = α.app X) :
    α.app X ⊗ₘ 𝟙 Z = α.app X ⊗ₘ 𝟙 Z := by
  have h' := h
  with_panel_widgets [Mathlib.Tactic.Widget.StringDiagram]
  sorry  -- "No String Diagram."
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
