### PR TITLE
[Merged by Bors] - feat(GroupTheory/Subgroup/Center): added lemma `center_is_normal`

### DIFF
--- a/Mathlib/GroupTheory/Subgroup/Center.lean
+++ b/Mathlib/GroupTheory/Subgroup/Center.lean
@@ -91,6 +91,10 @@ variable {H : Subgroup G}
 section Normalizer
 
 @[to_additive]
+theorem center_is_normal : (center G).Normal :=
+  ⟨fun a ha b ↦ by simp [mul_assoc, mem_center_iff.mp ha b, ha]⟩
+
+@[to_additive]
 theorem center_le_normalizer : center G ≤ H.normalizer := fun x hx y => by
   simp [← mem_center_iff.mp hx y, mul_assoc]
 

--- a/Mathlib/GroupTheory/Subgroup/Center.lean
+++ b/Mathlib/GroupTheory/Subgroup/Center.lean
@@ -91,7 +91,7 @@ variable {H : Subgroup G}
 section Normalizer
 
 @[to_additive]
-theorem center_is_normal : (center G).Normal :=
+instance center_is_normal : (center G).Normal :=
   ⟨fun a ha b ↦ by simp [mul_assoc, mem_center_iff.mp ha b, ha]⟩
 
 @[to_additive]

--- a/Mathlib/GroupTheory/Subgroup/Center.lean
+++ b/Mathlib/GroupTheory/Subgroup/Center.lean
@@ -91,7 +91,7 @@ variable {H : Subgroup G}
 section Normalizer
 
 @[to_additive]
-instance center_is_normal : (center G).Normal :=
+instance instNormalCenter : (center G).Normal :=
   ⟨fun a ha b ↦ by simp [mul_assoc, mem_center_iff.mp ha b, ha]⟩
 
 @[to_additive]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

```lean
@[to_additive]
instance center_is_normal : (center G).Normal
```

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
