### PR TITLE
[Merged by Bors] - doc(Data/Nat/Modeq): fix a couple of doc comment issues

### DIFF
--- a/Mathlib/Data/Nat/ModEq.lean
+++ b/Mathlib/Data/Nat/ModEq.lean
@@ -17,7 +17,7 @@ and proves basic properties about it such as the Chinese Remainder Theorem
 
 ## Notations
 
-`a ≡ b [MOD n]` is notation for `nat.ModEq n a b`, which is defined to mean `a % n = b % n`.
+`a ≡ b [MOD n]` is notation for `Nat.ModEq n a b`, which is defined to mean `a % n = b % n`.
 
 ## Tags
 
@@ -28,7 +28,7 @@ assert_not_exists OrderedAddCommMonoid Function.support
 
 namespace Nat
 
-/-- Modular equality. `n.ModEq a b`, or `a ≡ b [MOD n]`, means that `a - b` is a multiple of `n`. -/
+/-- Modular equality. `n.ModEq a b`, or `a ≡ b [MOD n]`, means that `a % n = b % n`. -/
 def ModEq (n a b : ℕ) :=
   a % n = b % n
 


### PR DESCRIPTION
* `nat` is now spelled `Nat`.
* Defining `a ≡ b [MOD n]` to mean "`a - b` is a multiple of `n`" does not make sense for the Lean naturals, which have saturating subtraction. Consider (a,b,n) = (1, 2, 3). (This comment was added in https://github.com/leanprover-community/mathlib3/commit/1dddcf69ecd7edfa3c9ebc4faf0723df8ff128ca)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
