### PR TITLE
[Merged by Bors] - chore: remove unnecessary `noncomputable` attributes after 4.22.0 rc3

### DIFF
--- a/Mathlib/AlgebraicGeometry/IdealSheaf/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/IdealSheaf/Basic.lean
@@ -762,7 +762,7 @@ lemma Hom.support_ker (f : X.Hom Y) [QuasiCompact f] :
 
 /-- The functor taking a morphism into `Y` to its kernel as an ideal sheaf on `Y`. -/
 @[simps]
-noncomputable def kerFunctor (Y : Scheme.{u}) : (Over Y)ᵒᵖ ⥤ IdealSheafData Y where
+def kerFunctor (Y : Scheme.{u}) : (Over Y)ᵒᵖ ⥤ IdealSheafData Y where
   obj f := f.unop.hom.ker
   map {f g} hfg := homOfLE <| by simpa only [Functor.id_obj, Functor.const_obj_obj,
     OrderDual.toDual_le_toDual, ← Over.w hfg.unop] using hfg.unop.left.le_ker_comp f.unop.hom

--- a/Mathlib/AlgebraicGeometry/Morphisms/Etale.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Etale.lean
@@ -84,11 +84,11 @@ instance : Category X.Etale :=
   inferInstanceAs <| Category (MorphismProperty.Over @IsEtale ⊤ X)
 
 /-- The forgetful functor from schemes étale over `X` to schemes over `X`. -/
-noncomputable def Etale.forget : X.Etale ⥤ Over X :=
+def Etale.forget : X.Etale ⥤ Over X :=
   MorphismProperty.Over.forget @IsEtale ⊤ X
 
 /-- The forgetful functor from schemes étale over `X` to schemes over `X` is fully faithful. -/
-noncomputable def Etale.forgetFullyFaithful : (Etale.forget X).FullyFaithful :=
+def Etale.forgetFullyFaithful : (Etale.forget X).FullyFaithful :=
   MorphismProperty.Comma.forgetFullyFaithful _ _ _
 
 instance : (Etale.forget X).Full :=

--- a/Mathlib/NumberTheory/LSeries/Nonvanishing.lean
+++ b/Mathlib/NumberTheory/LSeries/Nonvanishing.lean
@@ -68,7 +68,7 @@ and takes nonnegative real values.
 
 /-- The complex-valued arithmetic function that is the convolution of the constant
 function `1` with `χ`. -/
-noncomputable def zetaMul (χ : DirichletCharacter ℂ N) : ArithmeticFunction ℂ :=
+def zetaMul (χ : DirichletCharacter ℂ N) : ArithmeticFunction ℂ :=
   .zeta * toArithmeticFunction (χ ·)
 
 /-- The arithmetic function `zetaMul χ` is multiplicative. -/

--- a/Mathlib/Probability/ProbabilityMassFunction/Binomial.lean
+++ b/Mathlib/Probability/ProbabilityMassFunction/Binomial.lean
@@ -22,7 +22,7 @@ namespace PMF
 open ENNReal NNReal
 /-- The binomial `PMF`: the probability of observing exactly `i` “heads” in a sequence of `n`
 independent coin tosses, each having probability `p` of coming up “heads”. -/
-noncomputable def binomial (p : ℝ≥0∞) (h : p ≤ 1) (n : ℕ) : PMF (Fin (n + 1)) :=
+def binomial (p : ℝ≥0∞) (h : p ≤ 1) (n : ℕ) : PMF (Fin (n + 1)) :=
   .ofFintype (fun i =>
       -- Using `toNNReal` here makes this computable
       ↑(p.toNNReal^(i : ℕ) * (1-p.toNNReal)^((Fin.last n - i) : ℕ) * (n.choose i : ℕ))) (by

--- a/Mathlib/Topology/ContinuousMap/Bounded/Basic.lean
+++ b/Mathlib/Topology/ContinuousMap/Bounded/Basic.lean
@@ -547,7 +547,7 @@ instance instMulOneClass [MulOneClass R] [BoundedMul R] [ContinuousMul R] : MulO
 @[to_additive (attr := simps)
 "Composition on the left by a (lipschitz-continuous) homomorphism of topological `AddMonoid`s, as a
 `AddMonoidHom`. Similar to `AddMonoidHom.compLeftContinuous`."]
-protected noncomputable def _root_.MonoidHom.compLeftContinuousBounded (α : Type*)
+protected def _root_.MonoidHom.compLeftContinuousBounded (α : Type*)
     [TopologicalSpace α] [PseudoMetricSpace β] [Monoid β] [BoundedMul β] [ContinuousMul β]
     [PseudoMetricSpace γ] [Monoid γ] [BoundedMul γ] [ContinuousMul γ]
     (g : β →* γ) {C : NNReal} (hg : LipschitzWith C g) :


### PR DESCRIPTION
These were likely all fixed due to leanprover/lean4#8691.