### PR TITLE
[Merged by Bors] - chore(Algebra/Polynomial/IsMonicOfDegree): do not import compute_degree tactic

### DIFF
--- a/Mathlib/Algebra/Polynomial/Degree/IsMonicOfDegree.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/IsMonicOfDegree.lean
@@ -5,7 +5,6 @@ Authors: Michael Stoll
 -/
 import Mathlib.Algebra.Polynomial.AlgebraMap
 import Mathlib.Algebra.Polynomial.Monic
-import Mathlib.Tactic.ComputeDegree
 
 /-!
 # Monic polynomials of given degree
@@ -171,7 +170,7 @@ lemma isMonicOfDegree_monomial_one (n : ℕ) : IsMonicOfDegree (monomial n (1 : 
   simpa only [monomial_one_right_eq_X_pow] using isMonicOfDegree_X_pow R n
 
 lemma isMonicOfDegree_X_add_one (r : R) : IsMonicOfDegree (X + C r) 1 :=
-  (isMonicOfDegree_X R).add_right (by compute_degree!)
+  (isMonicOfDegree_X R).add_right (by rw [natDegree_C]; exact zero_lt_one)
 
 lemma isMonicOfDegree_one_iff {f : R[X]} : IsMonicOfDegree f 1 ↔ ∃ r : R, f = X + C r := by
   refine ⟨fun H ↦ ?_, fun ⟨r, H⟩ ↦ H ▸ isMonicOfDegree_X_add_one r⟩
@@ -183,7 +182,11 @@ lemma isMonicOfDegree_one_iff {f : R[X]} : IsMonicOfDegree f 1 ↔ ∃ r : R, f 
 
 lemma isMonicOfDegree_add_add_two (a b : R) : IsMonicOfDegree (X ^ 2 + C a * X + C b) 2 := by
   rw [add_assoc]
-  exact (isMonicOfDegree_X_pow R 2).add_right <| by compute_degree!
+  exact (isMonicOfDegree_X_pow R 2).add_right <|
+    calc
+    _ ≤ max (C a * X).natDegree (C b).natDegree := natDegree_add_le ..
+    _ = (C a * X).natDegree := by simp
+    _ < 2 := natDegree_C_mul_le .. |>.trans natDegree_X_le |>.trans_lt one_lt_two
 
 lemma isMonicOfDegree_two_iff {f : R[X]} :
     IsMonicOfDegree f 2 ↔ ∃ a b : R, f = X ^ 2 + C a * X + C b := by
@@ -213,9 +216,8 @@ lemma IsMonicOfDegree.natDegree_sub_lt {p q : R[X]} {n : ℕ} (hn : n ≠ 0) (hp
   rw [← sub_sub_sub_cancel_right p q (X ^ n)]
   replace hp := hp.natDegree_sub_X_pow hn
   replace hq := hq.natDegree_sub_X_pow hn
-  set p' := p - X ^ n -- do not confuse `compute_degree!`
-  set q' := q - X ^ n
-  compute_degree!
+  rw [← Nat.le_sub_one_iff_lt (Nat.zero_lt_of_ne_zero hn)] at hp hq ⊢
+  exact (natDegree_sub_le_iff_left hq).mpr hp
 
 lemma IsMonicOfDegree.sub {p q : R[X]} {n : ℕ} (hp : IsMonicOfDegree p n) (hq : q.natDegree < n) :
     IsMonicOfDegree (p - q) n := by
@@ -225,11 +227,16 @@ lemma IsMonicOfDegree.sub {p q : R[X]} {n : ℕ} (hp : IsMonicOfDegree p n) (hq 
 variable [Nontrivial R]
 
 lemma isMonicOfDegree_X_sub_one (r : R) : IsMonicOfDegree (X - C r) 1 :=
-  (isMonicOfDegree_X R).sub (by compute_degree!)
+  (isMonicOfDegree_X R).sub (by rw [natDegree_C]; exact zero_lt_one)
 
 lemma isMonicOfDegree_sub_add_two (a b : R) : IsMonicOfDegree (X ^ 2 - C a * X + C b) 2 := by
   rw [sub_add]
-  exact (isMonicOfDegree_X_pow R 2).add_right <| by compute_degree!
+  exact (isMonicOfDegree_X_pow R 2).add_right <| by
+    rw [natDegree_neg]
+    calc
+    _ ≤ max (C a * X).natDegree (C b).natDegree := natDegree_sub_le ..
+    _ = (C a * X).natDegree := by simp
+    _ < 2 := natDegree_C_mul_le .. |>.trans natDegree_X_le |>.trans_lt one_lt_two
 
 /-- A version of `Polynomial.isMonicOfDegree_two_iff` with negated middle coefficient. -/
 lemma isMonicOfDegree_two_iff' {f : R[X]} :


### PR DESCRIPTION
To prepare for an extension of the `monicity` tactic to also work for `IsMonicOfDegree`, avoid importing this and related tactics in the file that defines `IsMonicOfDegree`.

This means that some proof that used `compute_degree` or `compute_degree!` need to be spelled out in terms of the API for `Polynomial.natDegree`.

Zulip: [#mathlib4 > Gelfand-Mazur theorem @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Gelfand-Mazur.20theorem/near/526268507)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
