### PR TITLE
[Merged by Bors] - feat(WithZero): more lemmas about `exp` and `log`

### DIFF
--- a/Mathlib/Algebra/GroupWithZero/WithZero.lean
+++ b/Mathlib/Algebra/GroupWithZero/WithZero.lean
@@ -336,6 +336,8 @@ section AddMonoid
 /-- The exponential map as a function `M → Mᵐ⁰`. -/
 def exp (a : M) : Mᵐ⁰ := coe <| .ofAdd a
 
+@[simp] lemma exp_ne_zero {a : M} : exp a ≠ 0 := by simp [exp]
+
 variable [AddMonoid M]
 
 /-- The logarithm as a function `Mᵐ⁰ → M` with junk value `log 0 = 0`. -/

--- a/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
@@ -454,6 +454,6 @@ lemma lt_mul_exp_iff_le {x y : ℤᵐ⁰} (hy : y ≠ 0) : x < y * exp 1 ↔ x �
   obtain rfl | hx := eq_or_ne x 0
   · simp
   lift x to Multiplicative ℤ using hx
-  rw [← log_le_log, ← log_lt_log] <;>simp [log_mul, Int.lt_add_one_iff]
+  rw [← log_le_log, ← log_lt_log] <;> simp [log_mul, Int.lt_add_one_iff]
 
 end WithZero

--- a/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
@@ -6,6 +6,7 @@ Authors: Kenny Lau, Johan Commelin, Patrick Massot
 import Mathlib.Algebra.GroupWithZero.InjSurj
 import Mathlib.Algebra.GroupWithZero.WithZero
 import Mathlib.Algebra.Order.AddGroupWithTop
+import Mathlib.Algebra.Order.Group.Int
 import Mathlib.Algebra.Order.GroupWithZero.Unbundled.OrderIso
 import Mathlib.Algebra.Order.Monoid.Units
 import Mathlib.Algebra.Order.Monoid.Basic
@@ -402,12 +403,16 @@ instance instLinearOrderedCommGroupWithZero [CommGroup α] [LinearOrder α] [IsO
 variable {G : Type*} [Preorder G] {a b : G}
 
 @[simp] lemma exp_le_exp : exp a ≤ exp b ↔ a ≤ b := by simp [exp]
+@[simp] lemma exp_lt_exp : exp a < exp b ↔ a < b := by simp [exp]
 
 @[simp] lemma exp_pos : 0 < exp a := by simp [exp]
 
 variable [AddGroup G] {x y : Gᵐ⁰}
 
 @[simp] lemma log_le_log (hx : x ≠ 0) (hy : y ≠ 0) : log x ≤ log y ↔ x ≤ y := by
+  lift x to Multiplicative G using hx; lift y to Multiplicative G using hy; simp [log]
+
+@[simp] lemma log_lt_log (hx : x ≠ 0) (hy : y ≠ 0) : log x < log y ↔ x < y := by
   lift x to Multiplicative G using hx; lift y to Multiplicative G using hy; simp [log]
 
 lemma log_le_iff_le_exp (hx : x ≠ 0) : log x ≤ a ↔ x ≤ exp a := by
@@ -425,6 +430,12 @@ lemma lt_log_iff_exp_lt (hx : x ≠ 0) : a < log x ↔ exp a < x := by
 lemma lt_exp_of_log_lt (hxa : log x < a) : x < exp a := by
   obtain rfl | hx := eq_or_ne x 0 <;> simp [← log_lt_iff_lt_exp, *]
 
+lemma le_log_of_exp_le (hax : exp a ≤ x) : a ≤ log x :=
+  (le_log_iff_exp_le (exp_pos.trans_le hax).ne').2 hax
+
+lemma lt_log_of_exp_lt (hax : exp a < x) : a < log x := 
+  (lt_log_iff_exp_lt (exp_pos.trans hax).ne').2 hax
+
 /-- The exponential map as an order isomorphism between `G` and `Gᵐ⁰ˣ`. -/
 @[simps!] def expOrderIso : G ≃o Gᵐ⁰ˣ where
   __ := expEquiv
@@ -434,5 +445,12 @@ lemma lt_exp_of_log_lt (hxa : log x < a) : x < exp a := by
 @[simps!] def logOrderIso : Gᵐ⁰ˣ ≃o G where
   __ := logEquiv
   map_rel_iff' := by simp
+
+lemma lt_mul_exp_iff_le {x y : ℤᵐ⁰} (hy : y ≠ 0) : x < y * exp 1 ↔ x ≤ y := by
+  lift y to Multiplicative ℤ using hy
+  obtain rfl | hx := eq_or_ne x 0
+  · simp
+  lift x to Multiplicative ℤ using hx
+  rw [← log_le_log, ← log_lt_log] <;>simp [log_mul, Int.lt_add_one_iff]
 
 end WithZero

--- a/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
@@ -427,6 +427,9 @@ lemma le_log_iff_exp_le (hx : x ≠ 0) : a ≤ log x ↔ exp a ≤ x := by
 lemma lt_log_iff_exp_lt (hx : x ≠ 0) : a < log x ↔ exp a < x := by
   lift x to Multiplicative G using hx; simpa [log, exp] using .rfl
 
+lemma le_exp_of_log_le (hxa : log x ≤ a) : x ≤ exp a := by
+  obtain rfl | hx := eq_or_ne x 0 <;> simp [← log_le_iff_le_exp, *]
+
 lemma lt_exp_of_log_lt (hxa : log x < a) : x < exp a := by
   obtain rfl | hx := eq_or_ne x 0 <;> simp [← log_lt_iff_lt_exp, *]
 

--- a/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
@@ -433,7 +433,7 @@ lemma lt_exp_of_log_lt (hxa : log x < a) : x < exp a := by
 lemma le_log_of_exp_le (hax : exp a ≤ x) : a ≤ log x :=
   (le_log_iff_exp_le (exp_pos.trans_le hax).ne').2 hax
 
-lemma lt_log_of_exp_lt (hax : exp a < x) : a < log x := 
+lemma lt_log_of_exp_lt (hax : exp a < x) : a < log x :=
   (lt_log_iff_exp_lt (exp_pos.trans hax).ne').2 hax
 
 /-- The exponential map as an order isomorphism between `G` and `Gᵐ⁰ˣ`. -/

--- a/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
@@ -403,22 +403,27 @@ variable {G : Type*} [Preorder G] {a b : G}
 
 @[simp] lemma exp_le_exp : exp a ≤ exp b ↔ a ≤ b := by simp [exp]
 
-variable [AddGroup G]
+@[simp] lemma exp_pos : 0 < exp a := by simp [exp]
 
-@[simp] lemma log_le_log {x y : Gᵐ⁰} (hx : x ≠ 0) (hy : y ≠ 0) : log x ≤ log y ↔ x ≤ y := by
+variable [AddGroup G] {x y : Gᵐ⁰}
+
+@[simp] lemma log_le_log (hx : x ≠ 0) (hy : y ≠ 0) : log x ≤ log y ↔ x ≤ y := by
   lift x to Multiplicative G using hx; lift y to Multiplicative G using hy; simp [log]
 
-lemma log_le_iff_le_exp {x : Gᵐ⁰} (hx : x ≠ 0) : log x ≤ a ↔ x ≤ exp a := by
+lemma log_le_iff_le_exp (hx : x ≠ 0) : log x ≤ a ↔ x ≤ exp a := by
   lift x to Multiplicative G using hx; simpa [log, exp] using .rfl
 
-lemma log_lt_iff_lt_exp {x : Gᵐ⁰} (hx : x ≠ 0) : log x < a ↔ x < exp a := by
+lemma log_lt_iff_lt_exp (hx : x ≠ 0) : log x < a ↔ x < exp a := by
   lift x to Multiplicative G using hx; simpa [log, exp] using .rfl
 
-lemma le_log_iff_exp_le {x : Gᵐ⁰} (hx : x ≠ 0) : a ≤ log x ↔ exp a ≤ x := by
+lemma le_log_iff_exp_le (hx : x ≠ 0) : a ≤ log x ↔ exp a ≤ x := by
   lift x to Multiplicative G using hx; simpa [log, exp] using .rfl
 
-lemma lt_log_iff_exp_lt {x : Gᵐ⁰} (hx : x ≠ 0) : a < log x ↔ exp a < x := by
+lemma lt_log_iff_exp_lt (hx : x ≠ 0) : a < log x ↔ exp a < x := by
   lift x to Multiplicative G using hx; simpa [log, exp] using .rfl
+
+lemma lt_exp_of_log_lt (hxa : log x < a) : x < exp a := by
+  obtain rfl | hx := eq_or_ne x 0 <;> simp [← log_lt_iff_lt_exp, *]
 
 /-- The exponential map as an order isomorphism between `G` and `Gᵐ⁰ˣ`. -/
 @[simps!] def expOrderIso : G ≃o Gᵐ⁰ˣ where


### PR DESCRIPTION
These turned out useful in two separate PRs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
