### PR TITLE
[Merged by Bors] - chore(Data/Set/Insert): move `BooleanAlgebra` material to `Order`

### DIFF
--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -658,7 +658,7 @@ theorem ncard_exchange {a b : α} (ha : a ∉ s) (hb : b ∈ s) : (insert a (s \
 theorem ncard_exchange' {a b : α} (ha : a ∉ s) (hb : b ∈ s) :
     (insert a s \ {b}).ncard = s.ncard := by
   rw [← ncard_exchange ha hb, ← singleton_union, ← singleton_union, union_diff_distrib,
-    @diff_singleton_eq_self _ b {a} fun h ↦ ha (by rwa [← mem_singleton_iff.mp h])]
+    diff_singleton_eq_self fun h ↦ ha (by rwa [← mem_singleton_iff.mp h])]
 
 lemma odd_card_insert_iff {a : α} (ha : a ∉ s) (hs : s.Finite := by toFinite_tac) :
     Odd (insert a s).ncard ↔ Even s.ncard := by

--- a/Mathlib/Data/Set/Insert.lean
+++ b/Mathlib/Data/Set/Insert.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura
 -/
 import Mathlib.Data.Set.Disjoint
-import Mathlib.Order.BooleanAlgebra.Set
 
 /-!
 # Lemmas about insertion, singleton, and pairs
@@ -16,6 +15,8 @@ This file provides extra lemmas about `insert`, `singleton`, and `pair`.
 insert, singleton
 
 -/
+
+assert_not_exists HeytingAlgebra
 
 /-! ### Set coercion to a type -/
 
@@ -346,9 +347,6 @@ lemma disjoint_singleton_right : Disjoint s {a} ↔ a ∉ s :=
 lemma disjoint_singleton : Disjoint ({a} : Set α) {b} ↔ a ≠ b := by
   simp
 
-lemma ssubset_iff_sdiff_singleton : s ⊂ t ↔ ∃ a ∈ t, s ⊆ t \ {a} := by
-  simp [ssubset_iff_insert, subset_diff, insert_subset_iff]; aesop
-
 @[simp]
 theorem disjoint_insert_left : Disjoint (insert a s) t ↔ a ∉ t ∧ Disjoint s t := by
   simp only [Set.disjoint_left, Set.mem_insert_iff, forall_eq_or_imp]
@@ -356,74 +354,6 @@ theorem disjoint_insert_left : Disjoint (insert a s) t ↔ a ∉ t ∧ Disjoint 
 @[simp]
 theorem disjoint_insert_right : Disjoint s (insert a t) ↔ a ∉ s ∧ Disjoint s t := by
   rw [disjoint_comm, disjoint_insert_left, disjoint_comm]
-
-/-! ### Lemmas about complement -/
-
-@[simp] lemma nonempty_compl_of_nontrivial [Nontrivial α] (x : α) : Set.Nonempty {x}ᶜ := by
-  obtain ⟨y, hy⟩ := exists_ne x
-  exact ⟨y, by simp [hy]⟩
-
-theorem mem_compl_singleton_iff {a x : α} : x ∈ ({a} : Set α)ᶜ ↔ x ≠ a :=
-  Iff.rfl
-
-theorem compl_singleton_eq (a : α) : ({a} : Set α)ᶜ = { x | x ≠ a } :=
-  rfl
-
-@[simp]
-theorem compl_ne_eq_singleton (a : α) : ({ x | x ≠ a } : Set α)ᶜ = {a} :=
-  compl_compl _
-
-@[simp]
-theorem subset_compl_singleton_iff {a : α} {s : Set α} : s ⊆ {a}ᶜ ↔ a ∉ s :=
-  subset_compl_comm.trans singleton_subset_iff
-
-/-! ### Lemmas about set difference -/
-
-@[simp]
-theorem diff_singleton_subset_iff {x : α} {s t : Set α} : s \ {x} ⊆ t ↔ s ⊆ insert x t := by
-  rw [← union_singleton, union_comm]
-  apply diff_subset_iff
-
-theorem subset_diff_singleton {x : α} {s t : Set α} (h : s ⊆ t) (hx : x ∉ s) : s ⊆ t \ {x} :=
-  subset_inter h <| subset_compl_comm.1 <| singleton_subset_iff.2 hx
-
-theorem subset_insert_diff_singleton (x : α) (s : Set α) : s ⊆ insert x (s \ {x}) := by
-  rw [← diff_singleton_subset_iff]
-
-theorem diff_insert_of_notMem {x : α} (h : x ∉ s) : s \ insert x t = s \ t := by
-  refine Subset.antisymm (diff_subset_diff (refl _) (subset_insert ..)) fun y hy ↦ ?_
-  simp only [mem_diff, mem_insert_iff, not_or] at hy ⊢
-  exact ⟨hy.1, fun hxy ↦ h <| hxy ▸ hy.1, hy.2⟩
-
-@[deprecated (since := "2025-05-23")] alias diff_insert_of_not_mem := diff_insert_of_notMem
-
-@[simp]
-theorem insert_diff_of_mem (s) (h : a ∈ t) : insert a s \ t = s \ t := by
-  ext
-  constructor <;> simp +contextual [or_imp, h]
-
-theorem insert_diff_of_notMem (s) (h : a ∉ t) : insert a s \ t = insert a (s \ t) := by
-  classical
-    ext x
-    by_cases h' : x ∈ t
-    · simp [h', ne_of_mem_of_not_mem h' h]
-    · simp [h']
-
-@[deprecated (since := "2025-05-23")] alias insert_diff_of_not_mem := insert_diff_of_notMem
-
-theorem insert_diff_self_of_notMem {a : α} {s : Set α} (h : a ∉ s) : insert a s \ {a} = s := by
-  ext x
-  simp [and_iff_left_of_imp (ne_of_mem_of_not_mem · h)]
-
-@[deprecated (since := "2025-05-23")]
-alias insert_diff_self_of_not_mem := insert_diff_self_of_notMem
-
-lemma insert_diff_self_of_mem (ha : a ∈ s) : insert a (s \ {a}) = s := by
-  ext; simp +contextual [or_and_left, em, ha]
-
-lemma insert_erase_invOn :
-    InvOn (insert a) (fun s ↦ s \ {a}) {s : Set α | a ∈ s} {s : Set α | a ∉ s} :=
-  ⟨fun _s ha ↦ insert_diff_self_of_mem ha, fun _s ↦ insert_diff_self_of_notMem⟩
 
 theorem insert_inj (ha : a ∉ s) : insert a s = insert b s ↔ a = b :=
   ⟨fun h => eq_of_mem_insert_of_notMem (h ▸ mem_insert a s) ha,
@@ -453,41 +383,6 @@ theorem insert_inter_of_notMem (h : a ∉ t) : insert a s ∩ t = s ∩ t :=
 
 @[deprecated (since := "2025-05-23")] alias insert_inter_of_not_mem := insert_inter_of_notMem
 
-@[simp]
-theorem diff_singleton_eq_self {a : α} {s : Set α} (h : a ∉ s) : s \ {a} = s :=
-  sdiff_eq_self_iff_disjoint.2 <| by simp [h]
-
-theorem diff_singleton_ssubset {s : Set α} {a : α} : s \ {a} ⊂ s ↔ a ∈ s := by
-  simp
-
-@[deprecated (since := "2025-03-20")] alias diff_singleton_sSubset := diff_singleton_ssubset
-
-@[simp]
-theorem insert_diff_singleton {a : α} {s : Set α} : insert a (s \ {a}) = insert a s := by
-  simp [insert_eq, union_diff_self, -union_singleton, -singleton_union]
-
-theorem insert_diff_singleton_comm (hab : a ≠ b) (s : Set α) :
-    insert a (s \ {b}) = insert a s \ {b} := by
-  simp_rw [← union_singleton, union_diff_distrib,
-    diff_singleton_eq_self (mem_singleton_iff.not.2 hab.symm)]
-
-@[simp]
-theorem insert_diff_insert : insert a (s \ insert a t) = insert a (s \ t) := by
-  rw [← union_singleton (s := t), ← diff_diff, insert_diff_singleton]
-
-theorem mem_diff_singleton {x y : α} {s : Set α} : x ∈ s \ {y} ↔ x ∈ s ∧ x ≠ y :=
-  Iff.rfl
-
-theorem mem_diff_singleton_empty {t : Set (Set α)} : s ∈ t \ {∅} ↔ s ∈ t ∧ s.Nonempty :=
-  mem_diff_singleton.trans <| and_congr_right' nonempty_iff_ne_empty.symm
-
-theorem subset_insert_iff {s t : Set α} {x : α} :
-    s ⊆ insert x t ↔ s ⊆ t ∨ (x ∈ s ∧ s \ {x} ⊆ t) := by
-  rw [← diff_singleton_subset_iff]
-  by_cases hx : x ∈ s
-  · rw [and_iff_right hx, or_iff_right_of_imp diff_subset.trans]
-  rw [diff_singleton_eq_self hx, or_iff_left_of_imp And.right]
-
 /-! ### Lemmas about pairs -/
 
 theorem pair_eq_singleton (a : α) : ({a, a} : Set α) = {a} :=
@@ -500,12 +395,6 @@ theorem pair_eq_pair_iff {x y z w : α} :
     ({x, y} : Set α) = {z, w} ↔ x = z ∧ y = w ∨ x = w ∧ y = z := by
   simp [subset_antisymm_iff, insert_subset_iff]; aesop
 
-theorem pair_diff_left (hne : a ≠ b) : ({a, b} : Set α) \ {a} = {b} := by
-  rw [insert_diff_of_mem _ (mem_singleton a), diff_singleton_eq_self (by simpa)]
-
-theorem pair_diff_right (hne : a ≠ b) : ({a, b} : Set α) \ {b} = {a} := by
-  rw [pair_comm, pair_diff_left hne.symm]
-
 theorem pair_subset_iff : {a, b} ⊆ s ↔ a ∈ s ∧ b ∈ s := by
   rw [insert_subset_iff, singleton_subset_iff]
 
@@ -515,12 +404,9 @@ theorem pair_subset (ha : a ∈ s) (hb : b ∈ s) : {a, b} ⊆ s :=
 theorem subset_pair_iff : s ⊆ {a, b} ↔ ∀ x ∈ s, x = a ∨ x = b := by
   simp [subset_def]
 
-theorem subset_pair_iff_eq {x y : α} : s ⊆ {x, y} ↔ s = ∅ ∨ s = {x} ∨ s = {y} ∨ s = {x, y} := by
-  refine ⟨?_, by rintro (rfl | rfl | rfl | rfl) <;> simp⟩
-  rw [subset_insert_iff, subset_singleton_iff_eq, subset_singleton_iff_eq,
-    ← subset_empty_iff (s := s \ {x}), diff_subset_iff, union_empty, subset_singleton_iff_eq]
-  have h : x ∈ s → {y} = s \ {x} → s = {x,y} := fun h₁ h₂ ↦ by simp [h₁, h₂]
-  tauto
+theorem subset_pair_iff_eq {x y : α} : s ⊆ {x, y} ↔ s = ∅ ∨ s = {x} ∨ s = {y} ∨ s = {x, y} where
+  mp := by simp [subset_def, Set.ext_iff]; grind
+  mpr := by simp +contextual [or_imp]
 
 theorem Nonempty.subset_pair_iff_eq (hs : s.Nonempty) :
     s ⊆ {a, b} ↔ s = {a} ∨ s = {b} ∨ s = {a, b} := by

--- a/Mathlib/Data/Set/Subsingleton.lean
+++ b/Mathlib/Data/Set/Subsingleton.lean
@@ -232,7 +232,7 @@ theorem nontrivial_univ_iff : (univ : Set α).Nontrivial ↔ Nontrivial α :=
 
 @[simp]
 theorem singleton_ne_univ [Nontrivial α] (a : α) : {a} ≠ univ :=
-  nonempty_compl.mp (nonempty_compl_of_nontrivial a)
+  fun h ↦ nontrivial_univ.not_subset_singleton h.superset
 
 @[simp]
 theorem singleton_ssubset_univ [Nontrivial α] (a : α) : {a} ⊂ univ :=

--- a/Mathlib/Data/Set/Subsingleton.lean
+++ b/Mathlib/Data/Set/Subsingleton.lean
@@ -16,7 +16,7 @@ elements.
 
 -/
 
-assert_not_exists RelIso
+assert_not_exists HeytingAlgebra RelIso
 
 open Function
 

--- a/Mathlib/Order/BooleanAlgebra/Set.lean
+++ b/Mathlib/Order/BooleanAlgebra/Set.lean
@@ -3,7 +3,7 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura
 -/
-import Mathlib.Data.Set.Disjoint
+import Mathlib.Data.Set.Insert
 import Mathlib.Order.BooleanAlgebra.Basic
 
 /-!
@@ -169,6 +169,18 @@ alias ⟨_, _root_.Disjoint.subset_compl_right⟩ := subset_compl_iff_disjoint_r
 alias ⟨_, _root_.Disjoint.subset_compl_left⟩ := subset_compl_iff_disjoint_left
 alias ⟨_, _root_.HasSubset.Subset.disjoint_compl_left⟩ := disjoint_compl_left_iff_subset
 alias ⟨_, _root_.HasSubset.Subset.disjoint_compl_right⟩ := disjoint_compl_right_iff_subset
+
+@[simp] lemma nonempty_compl_of_nontrivial [Nontrivial α] (x : α) : Set.Nonempty {x}ᶜ := exists_ne x
+
+lemma mem_compl_singleton_iff : a ∈ ({b} : Set α)ᶜ ↔ a ≠ b := .rfl
+
+lemma compl_singleton_eq (a : α) : {a}ᶜ = {x | x ≠ a} := rfl
+
+@[simp]
+lemma compl_ne_eq_singleton (a : α) : {x | x ≠ a}ᶜ = {a} := compl_compl _
+
+@[simp]
+lemma subset_compl_singleton_iff : s ⊆ {a}ᶜ ↔ a ∉ s := subset_compl_comm.trans singleton_subset_iff
 
 /-! ### Lemmas about set difference -/
 
@@ -363,6 +375,92 @@ lemma diff_ssubset_left_iff : s \ t ⊂ s ↔ (s ∩ t).Nonempty :=
 lemma _root_.HasSubset.Subset.diff_ssubset_of_nonempty (hst : s ⊆ t) (hs : s.Nonempty) :
     t \ s ⊂ t := by
   simpa [inter_eq_self_of_subset_right hst]
+
+lemma ssubset_iff_sdiff_singleton : s ⊂ t ↔ ∃ a ∈ t, s ⊆ t \ {a} := by
+  simp [ssubset_iff_insert, subset_diff, insert_subset_iff]; aesop
+
+@[simp]
+lemma diff_singleton_subset_iff : s \ {a} ⊆ t ↔ s ⊆ insert a t := by
+  rw [← union_singleton, union_comm]
+  apply diff_subset_iff
+
+lemma subset_diff_singleton (h : s ⊆ t) (ha : a ∉ s) : s ⊆ t \ {a} :=
+  subset_inter h <| subset_compl_comm.1 <| singleton_subset_iff.2 ha
+
+lemma subset_insert_diff_singleton (x : α) (s : Set α) : s ⊆ insert x (s \ {x}) := by
+  rw [← diff_singleton_subset_iff]
+
+lemma diff_insert_of_notMem (h : a ∉ s) : s \ insert a t = s \ t := by
+  refine Subset.antisymm (diff_subset_diff (refl _) (subset_insert ..)) fun y hy ↦ ?_
+  simp only [mem_diff, mem_insert_iff, not_or] at hy ⊢
+  exact ⟨hy.1, fun hxy ↦ h <| hxy ▸ hy.1, hy.2⟩
+
+@[deprecated (since := "2025-05-23")] alias diff_insert_of_not_mem := diff_insert_of_notMem
+
+@[simp]
+lemma insert_diff_of_mem (s) (h : a ∈ t) : insert a s \ t = s \ t := by
+  ext
+  constructor <;> simp +contextual [or_imp, h]
+
+lemma insert_diff_of_notMem (s) (h : a ∉ t) : insert a s \ t = insert a (s \ t) := by
+  classical
+  ext x
+  by_cases h' : x ∈ t
+  · simp [h', ne_of_mem_of_not_mem h' h]
+  · simp [h']
+
+@[deprecated (since := "2025-05-23")] alias insert_diff_of_not_mem := insert_diff_of_notMem
+
+lemma insert_diff_self_of_notMem (h : a ∉ s) : insert a s \ {a} = s := by
+  ext x; simp [and_iff_left_of_imp (ne_of_mem_of_not_mem · h)]
+
+@[deprecated (since := "2025-05-23")]
+alias insert_diff_self_of_not_mem := insert_diff_self_of_notMem
+
+lemma insert_diff_self_of_mem (ha : a ∈ s) : insert a (s \ {a}) = s := by
+  ext; simp +contextual [or_and_left, em, ha]
+
+lemma insert_erase_invOn :
+    InvOn (insert a) (fun s ↦ s \ {a}) {s : Set α | a ∈ s} {s : Set α | a ∉ s} :=
+  ⟨fun _s ha ↦ insert_diff_self_of_mem ha, fun _s ↦ insert_diff_self_of_notMem⟩
+
+@[simp]
+lemma diff_singleton_eq_self (h : a ∉ s) : s \ {a} = s :=
+  sdiff_eq_self_iff_disjoint.2 <| by simp [h]
+
+lemma diff_singleton_ssubset : s \ {a} ⊂ s ↔ a ∈ s := by simp
+
+@[deprecated (since := "2025-03-20")] alias diff_singleton_sSubset := diff_singleton_ssubset
+
+@[simp]
+lemma insert_diff_singleton : insert a (s \ {a}) = insert a s := by
+  simp [insert_eq, union_diff_self, -union_singleton, -singleton_union]
+
+lemma insert_diff_singleton_comm (hab : a ≠ b) (s : Set α) :
+    insert a (s \ {b}) = insert a s \ {b} := by
+  simp_rw [← union_singleton, union_diff_distrib,
+    diff_singleton_eq_self (mem_singleton_iff.not.2 hab.symm)]
+
+@[simp]
+lemma insert_diff_insert : insert a (s \ insert a t) = insert a (s \ t) := by
+  rw [← union_singleton (s := t), ← diff_diff, insert_diff_singleton]
+
+lemma mem_diff_singleton : a ∈ s \ {b} ↔ a ∈ s ∧ a ≠ b := .rfl
+
+lemma mem_diff_singleton_empty {t : Set (Set α)} : s ∈ t \ {∅} ↔ s ∈ t ∧ s.Nonempty :=
+  mem_diff_singleton.trans <| and_congr_right' nonempty_iff_ne_empty.symm
+
+lemma subset_insert_iff : s ⊆ insert a t ↔ s ⊆ t ∨ (a ∈ s ∧ s \ {a} ⊆ t) := by
+  rw [← diff_singleton_subset_iff]
+  by_cases hx : a ∈ s
+  · rw [and_iff_right hx, or_iff_right_of_imp diff_subset.trans]
+  rw [diff_singleton_eq_self hx, or_iff_left_of_imp And.right]
+
+lemma pair_diff_left (hab : a ≠ b) : ({a, b} : Set α) \ {a} = {b} := by
+  rw [insert_diff_of_mem _ (mem_singleton a), diff_singleton_eq_self (by simpa)]
+
+lemma pair_diff_right (hab : a ≠ b) : ({a, b} : Set α) \ {b} = {a} := by
+  rw [pair_comm, pair_diff_left hab.symm]
 
 /-! ### If-then-else for sets -/
 

--- a/Mathlib/Order/Filter/Defs.lean
+++ b/Mathlib/Order/Filter/Defs.lean
@@ -3,9 +3,10 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Jeremy Avigad
 -/
-import Mathlib.Order.SetNotation
-import Mathlib.Order.Bounds.Defs
 import Mathlib.Data.Set.Insert
+import Mathlib.Order.SetNotation
+import Mathlib.Order.BooleanAlgebra.Set
+import Mathlib.Order.Bounds.Defs
 
 /-!
 # Definitions about filters

--- a/Mathlib/Order/Interval/Set/Basic.lean
+++ b/Mathlib/Order/Interval/Set/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Patrick Massot, Yury Kudryashov, Rémy Degenne
 -/
 import Mathlib.Data.Set.Subsingleton
+import Mathlib.Order.BooleanAlgebra.Set
 import Mathlib.Order.Interval.Set.Defs
 
 /-!


### PR DESCRIPTION
Eventually, all order properties should move out, but this is a good third step that will, among others, unblock #23177.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
