### PR TITLE
feat(MeasureTheory/PiSystem): add π-λ theorem and SetLike instance

### DIFF
--- a/Mathlib/MeasureTheory/PiSystem.lean
+++ b/Mathlib/MeasureTheory/PiSystem.lean
@@ -667,9 +667,9 @@ instance : SetLike (DynkinSystem α) (Set α) :=
   If `s ⊆ d`, then every set that is measurable with respect to the
   σ-algebra `generateFrom s` also belongs to `d`.
 -/
-lemma pi_lambda {s : Set (Set α)} (hs : IsPiSystem s) (hsD : s ⊆ d) :
+lemma pi_lambda {s : Set (Set α)} (hs : IsPiSystem s) (h_sub : s ⊆ d) :
     ∀ {t}, MeasurableSet[generateFrom s] t → t ∈ d :=
-  fun {t} ht => (generate_le d (fun u hu => hsD hu)) t (by simpa [generateFrom_eq hs] using ht)
+  fun {t} ht => (generate_le d (fun u hu => h_sub hu)) t (by simpa [generateFrom_eq hs] using ht)
 
 end DynkinSystem
 

--- a/Mathlib/MeasureTheory/PiSystem.lean
+++ b/Mathlib/MeasureTheory/PiSystem.lean
@@ -666,7 +666,7 @@ instance : SetLike (DynkinSystem α) (Set α) := ⟨Has, fun d' ↦ by aesop⟩
   If `s ⊆ d`, then every set that is measurable with respect to the
   σ-algebra `generateFrom s` also belongs to `d`.
 -/
-theorem pi_lambda
+theorem mem_of_isPiSystem_of_subset_of_measurableSet_generateFrom
     {s : Set (Set α)} (hs : IsPiSystem s) (h_sub : s ⊆ d)
     {t : Set α} (ht : MeasurableSet[generateFrom s] t) :
     t ∈ d :=

--- a/Mathlib/MeasureTheory/PiSystem.lean
+++ b/Mathlib/MeasureTheory/PiSystem.lean
@@ -663,14 +663,13 @@ instance : SetLike (DynkinSystem α) (Set α) :=
   ⟨ Has, fun _ _ h => ext (fun s => Iff.of_eq (congrFun h s)) ⟩
 
 /-- **Dynkin’s π-λ theorem** in its common form.
-Let `s : Set (Set α)` be a π-system and `d : DynkinSystem α` a Dynkin system.
-If `s ⊆ d`, then every set that is measurable with respect to the
-σ-algebra `generateFrom s` also belongs to `d`. -/
-lemma pi_lambda {s : Set (Set α)}
-    (hs  : IsPiSystem s)
-    (hsD : s ⊆ d) :
-    ∀ {t : Set α}, MeasurableSet[generateFrom s] t → t ∈ d := by
-  sorry
+  Let `s : Set (Set α)` be a π-system and `d : DynkinSystem α` a Dynkin system.
+  If `s ⊆ d`, then every set that is measurable with respect to the
+  σ-algebra `generateFrom s` also belongs to `d`.
+-/
+lemma pi_lambda {s : Set (Set α)} (hs : IsPiSystem s) (hsD : s ⊆ d) :
+    ∀ {t}, MeasurableSet[generateFrom s] t → t ∈ d :=
+  fun {t} ht => (generate_le d (fun u hu => hsD hu)) t (by simpa [generateFrom_eq hs] using ht)
 
 end DynkinSystem
 

--- a/Mathlib/MeasureTheory/PiSystem.lean
+++ b/Mathlib/MeasureTheory/PiSystem.lean
@@ -659,6 +659,19 @@ theorem generateFrom_eq {s : Set (Set α)} (hs : IsPiSystem s) :
       rw [ofMeasurableSpace_toMeasurableSpace]
       exact generate_le _ fun t ht => measurableSet_generateFrom ht)
 
+instance : SetLike (DynkinSystem α) (Set α) :=
+  ⟨ Has, fun _ _ h => ext (fun s => Iff.of_eq (congrFun h s)) ⟩
+
+/-- **Dynkin’s π-λ theorem** in its common form.
+Let `s : Set (Set α)` be a π-system and `d : DynkinSystem α` a Dynkin system.
+If `s ⊆ d`, then every set that is measurable with respect to the
+σ-algebra `generateFrom s` also belongs to `d`. -/
+lemma pi_lambda {s : Set (Set α)}
+    (hs  : IsPiSystem s)
+    (hsD : s ⊆ d) :
+    ∀ {t : Set α}, MeasurableSet[generateFrom s] t → t ∈ d := by
+  sorry
+
 end DynkinSystem
 
 /-- Induction principle for measurable sets.

--- a/Mathlib/MeasureTheory/PiSystem.lean
+++ b/Mathlib/MeasureTheory/PiSystem.lean
@@ -659,8 +659,7 @@ theorem generateFrom_eq {s : Set (Set α)} (hs : IsPiSystem s) :
       rw [ofMeasurableSpace_toMeasurableSpace]
       exact generate_le _ fun t ht => measurableSet_generateFrom ht)
 
-instance : SetLike (DynkinSystem α) (Set α) :=
-  ⟨ Has, fun _ _ h => ext (fun s => Iff.of_eq (congrFun h s)) ⟩
+instance : SetLike (DynkinSystem α) (Set α) := ⟨Has, fun d' ↦ by aesop⟩
 
 /-- **Dynkin’s π-λ theorem** in its common form.
   Let `s : Set (Set α)` be a π-system and `d : DynkinSystem α` a Dynkin system.

--- a/Mathlib/MeasureTheory/PiSystem.lean
+++ b/Mathlib/MeasureTheory/PiSystem.lean
@@ -666,9 +666,11 @@ instance : SetLike (DynkinSystem α) (Set α) := ⟨Has, fun d' ↦ by aesop⟩
   If `s ⊆ d`, then every set that is measurable with respect to the
   σ-algebra `generateFrom s` also belongs to `d`.
 -/
-lemma pi_lambda {s : Set (Set α)} (hs : IsPiSystem s) (h_sub : s ⊆ d) :
-    ∀ {t}, MeasurableSet[generateFrom s] t → t ∈ d :=
-  fun {t} ht => (generate_le d (fun u hu => h_sub hu)) t (by simpa [generateFrom_eq hs] using ht)
+theorem pi_lambda
+    {s : Set (Set α)} (hs : IsPiSystem s) (h_sub : s ⊆ d)
+    {t : Set α} (ht : MeasurableSet[generateFrom s] t) :
+    t ∈ d :=
+  (generate_le d (fun u hu => h_sub hu)) t (by simpa [generateFrom_eq hs] using ht)
 
 end DynkinSystem
 


### PR DESCRIPTION
Add two small features to `MeasureTheory/PiSystem`:

1. SetLike instance
`instance : SetLike (DynkinSystem α) (Set α)`
This lets us write `s ⊆ d` and `t ∈ d` for a DynkinSystem `d`, matching usual mathlib style.

2. `DynkinSystem.pi_lambda` lemma
Classical π‑λ theorem: if a π‑system `s` is contained in a Dynkin system `d`, every set measurable for `σ(s)` is also in `d`.

Currently, mathlib exposes this result only indirectly (e.g. via `generateFrom_eq`). Although logically equivalent, it is not obvious at first glance that those lemmas are the π‑λ theorem. The new lemma states the result in its familiar textbook form, so users can recognise and cite it immediately.

Both pieces are under 10 lines, term‑mode only, and do not modify existing APIs.

No breaking changes.

No dependencies.

