### PR TITLE
[Merged by Bors] - chore(Algebra/Equiv/TransferInstance): split off group results

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -422,6 +422,7 @@ import Mathlib.Algebra.Group.Subsemigroup.Membership
 import Mathlib.Algebra.Group.Subsemigroup.Operations
 import Mathlib.Algebra.Group.Support
 import Mathlib.Algebra.Group.Torsion
+import Mathlib.Algebra.Group.TransferInstance
 import Mathlib.Algebra.Group.Translate
 import Mathlib.Algebra.Group.TypeTags.Basic
 import Mathlib.Algebra.Group.TypeTags.Finite

--- a/Mathlib/Algebra/Equiv/TransferInstance.lean
+++ b/Mathlib/Algebra/Equiv/TransferInstance.lean
@@ -13,21 +13,7 @@ import Mathlib.Algebra.Ring.Hom.InjSurj
 /-!
 # Transfer algebraic structures across `Equiv`s
 
-In this file we prove theorems of the following form: if `β` has a
-group structure and `α ≃ β` then `α` has a group structure, and
-similarly for monoids, semigroups, rings, integral domains, fields and
-so on.
-
-Note that most of these constructions can also be obtained using the `transport` tactic.
-
-### Implementation details
-
-When adding new definitions that transfer type-classes across an equivalence, please use
-`abbrev`. See note [reducible non-instances].
-
-## Tags
-
-equiv, group, ring, field, module, algebra
+This continues the pattern set in `Mathlib/Algebra/Group/TransferInstance.lean`.
 -/
 
 

--- a/Mathlib/Algebra/Equiv/TransferInstance.lean
+++ b/Mathlib/Algebra/Equiv/TransferInstance.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl
 -/
 import Mathlib.Algebra.Algebra.Equiv
 import Mathlib.Algebra.Field.Basic
+import Mathlib.Algebra.Group.TransferInstance
 import Mathlib.Logic.Equiv.Defs
 import Mathlib.Logic.Small.Defs
 import Mathlib.Algebra.Ring.Hom.InjSurj
@@ -40,118 +41,27 @@ section Instances
 
 variable (e : α ≃ β)
 
-/-- Transfer `One` across an `Equiv` -/
-@[to_additive "Transfer `Zero` across an `Equiv`"]
-protected abbrev one [One β] : One α :=
-  ⟨e.symm 1⟩
-
-@[to_additive]
-theorem one_def [One β] :
-    letI := e.one
-    1 = e.symm 1 :=
-  rfl
-
 @[to_additive]
 noncomputable instance [Small.{v} α] [One α] : One (Shrink.{v} α) :=
   (equivShrink α).symm.one
-
-/-- Transfer `Mul` across an `Equiv` -/
-@[to_additive "Transfer `Add` across an `Equiv`"]
-protected abbrev mul [Mul β] : Mul α :=
-  ⟨fun x y => e.symm (e x * e y)⟩
-
-@[to_additive]
-theorem mul_def [Mul β] (x y : α) :
-    letI := Equiv.mul e
-    x * y = e.symm (e x * e y) :=
-  rfl
 
 @[to_additive]
 noncomputable instance [Small.{v} α] [Mul α] : Mul (Shrink.{v} α) :=
   (equivShrink α).symm.mul
 
-/-- Transfer `Div` across an `Equiv` -/
-@[to_additive "Transfer `Sub` across an `Equiv`"]
-protected abbrev div [Div β] : Div α :=
-  ⟨fun x y => e.symm (e x / e y)⟩
-
-@[to_additive]
-theorem div_def [Div β] (x y : α) :
-    letI := Equiv.div e
-    x / y = e.symm (e x / e y) :=
-  rfl
-
 @[to_additive]
 noncomputable instance [Small.{v} α] [Div α] : Div (Shrink.{v} α) :=
   (equivShrink α).symm.div
-
--- Porting note: this should be called `inv`,
--- but we already have an `Equiv.inv` (which perhaps should move to `Perm.inv`?)
-/-- Transfer `Inv` across an `Equiv` -/
-@[to_additive "Transfer `Neg` across an `Equiv`"]
-protected abbrev Inv [Inv β] : Inv α :=
-  ⟨fun x => e.symm (e x)⁻¹⟩
-
-@[to_additive]
-theorem inv_def [Inv β] (x : α) :
-    letI := Equiv.Inv e
-    x⁻¹ = e.symm (e x)⁻¹ :=
-  rfl
 
 @[to_additive]
 noncomputable instance [Small.{v} α] [Inv α] : Inv (Shrink.{v} α) :=
   (equivShrink α).symm.Inv
 
-/-- Transfer `SMul` across an `Equiv` -/
-protected abbrev smul (R : Type*) [SMul R β] : SMul R α :=
-  ⟨fun r x => e.symm (r • e x)⟩
-
-theorem smul_def {R : Type*} [SMul R β] (r : R) (x : α) :
-    letI := e.smul R
-    r • x = e.symm (r • e x) :=
-  rfl
-
 noncomputable instance [Small.{v} α] (R : Type*) [SMul R α] : SMul R (Shrink.{v} α) :=
   (equivShrink α).symm.smul R
 
-/-- Transfer `Pow` across an `Equiv` -/
-@[reducible, to_additive existing smul]
-protected def pow (N : Type*) [Pow β N] : Pow α N :=
-  ⟨fun x n => e.symm (e x ^ n)⟩
-
-theorem pow_def {N : Type*} [Pow β N] (n : N) (x : α) :
-    letI := e.pow N
-    x ^ n = e.symm (e x ^ n) :=
-  rfl
-
 noncomputable instance [Small.{v} α] (N : Type*) [Pow α N] : Pow (Shrink.{v} α) N :=
   (equivShrink α).symm.pow N
-
-/-- An equivalence `e : α ≃ β` gives a multiplicative equivalence `α ≃* β` where
-the multiplicative structure on `α` is the one obtained by transporting a multiplicative structure
-on `β` back along `e`. -/
-@[to_additive "An equivalence `e : α ≃ β` gives an additive equivalence `α ≃+ β` where
-the additive structure on `α` is the one obtained by transporting an additive structure
-on `β` back along `e`."]
-def mulEquiv (e : α ≃ β) [Mul β] :
-    let _ := Equiv.mul e
-    α ≃* β := by
-  intros
-  exact
-    { e with
-      map_mul' := fun x y => by
-        apply e.symm.injective
-        simp [mul_def] }
-
-@[to_additive (attr := simp)]
-theorem mulEquiv_apply (e : α ≃ β) [Mul β] (a : α) : (mulEquiv e) a = e a :=
-  rfl
-
-@[to_additive]
-theorem mulEquiv_symm_apply (e : α ≃ β) [Mul β] (b : β) :
-    letI := Equiv.mul e
-    (mulEquiv e).symm b = e.symm b :=
-  rfl
 
 /-- Shrink `α` to a smaller universe preserves multiplication. -/
 @[to_additive "Shrink `α` to a smaller universe preserves addition."]
@@ -190,12 +100,6 @@ variable (α) in
 noncomputable def _root_.Shrink.ringEquiv [Small.{v} α] [Add α] [Mul α] : Shrink.{v} α ≃+* α :=
   (equivShrink α).symm.ringEquiv
 
-/-- Transfer `Semigroup` across an `Equiv` -/
-@[to_additive "Transfer `add_semigroup` across an `Equiv`"]
-protected abbrev semigroup [Semigroup β] : Semigroup α := by
-  let mul := e.mul
-  apply e.injective.semigroup _; intros; exact e.apply_symm_apply _
-
 @[to_additive]
 noncomputable instance [Small.{v} α] [Semigroup α] : Semigroup (Shrink.{v} α) :=
   (equivShrink α).symm.semigroup
@@ -209,12 +113,6 @@ protected abbrev semigroupWithZero [SemigroupWithZero β] : SemigroupWithZero α
 noncomputable instance [Small.{v} α] [SemigroupWithZero α] : SemigroupWithZero (Shrink.{v} α) :=
   (equivShrink α).symm.semigroupWithZero
 
-/-- Transfer `CommSemigroup` across an `Equiv` -/
-@[to_additive "Transfer `AddCommSemigroup` across an `Equiv`"]
-protected abbrev commSemigroup [CommSemigroup β] : CommSemigroup α := by
-  let mul := e.mul
-  apply e.injective.commSemigroup _; intros; exact e.apply_symm_apply _
-
 @[to_additive]
 noncomputable instance [Small.{v} α] [CommSemigroup α] : CommSemigroup (Shrink.{v} α) :=
   (equivShrink α).symm.commSemigroup
@@ -227,13 +125,6 @@ protected abbrev mulZeroClass [MulZeroClass β] : MulZeroClass α := by
 
 noncomputable instance [Small.{v} α] [MulZeroClass α] : MulZeroClass (Shrink.{v} α) :=
   (equivShrink α).symm.mulZeroClass
-
-/-- Transfer `MulOneClass` across an `Equiv` -/
-@[to_additive "Transfer `AddZeroClass` across an `Equiv`"]
-protected abbrev mulOneClass [MulOneClass β] : MulOneClass α := by
-  let one := e.one
-  let mul := e.mul
-  apply e.injective.mulOneClass _ <;> intros <;> exact e.apply_symm_apply _
 
 @[to_additive]
 noncomputable instance [Small.{v} α] [MulOneClass α] : MulOneClass (Shrink.{v} α) :=
@@ -249,55 +140,17 @@ protected abbrev mulZeroOneClass [MulZeroOneClass β] : MulZeroOneClass α := by
 noncomputable instance [Small.{v} α] [MulZeroOneClass α] : MulZeroOneClass (Shrink.{v} α) :=
   (equivShrink α).symm.mulZeroOneClass
 
-/-- Transfer `Monoid` across an `Equiv` -/
-@[to_additive "Transfer `AddMonoid` across an `Equiv`"]
-protected abbrev monoid [Monoid β] : Monoid α := by
-  let one := e.one
-  let mul := e.mul
-  let pow := e.pow ℕ
-  apply e.injective.monoid _ <;> intros <;> exact e.apply_symm_apply _
-
 @[to_additive]
 noncomputable instance [Small.{v} α] [Monoid α] : Monoid (Shrink.{v} α) :=
   (equivShrink α).symm.monoid
-
-/-- Transfer `CommMonoid` across an `Equiv` -/
-@[to_additive "Transfer `AddCommMonoid` across an `Equiv`"]
-protected abbrev commMonoid [CommMonoid β] : CommMonoid α := by
-  let one := e.one
-  let mul := e.mul
-  let pow := e.pow ℕ
-  apply e.injective.commMonoid _ <;> intros <;> exact e.apply_symm_apply _
 
 @[to_additive]
 noncomputable instance [Small.{v} α] [CommMonoid α] : CommMonoid (Shrink.{v} α) :=
   (equivShrink α).symm.commMonoid
 
-/-- Transfer `Group` across an `Equiv` -/
-@[to_additive "Transfer `AddGroup` across an `Equiv`"]
-protected abbrev group [Group β] : Group α := by
-  let one := e.one
-  let mul := e.mul
-  let inv := e.Inv
-  let div := e.div
-  let npow := e.pow ℕ
-  let zpow := e.pow ℤ
-  apply e.injective.group _ <;> intros <;> exact e.apply_symm_apply _
-
 @[to_additive]
 noncomputable instance [Small.{v} α] [Group α] : Group (Shrink.{v} α) :=
   (equivShrink α).symm.group
-
-/-- Transfer `CommGroup` across an `Equiv` -/
-@[to_additive "Transfer `AddCommGroup` across an `Equiv`"]
-protected abbrev commGroup [CommGroup β] : CommGroup α := by
-  let one := e.one
-  let mul := e.mul
-  let inv := e.Inv
-  let div := e.div
-  let npow := e.pow ℕ
-  let zpow := e.pow ℤ
-  apply e.injective.commGroup _ <;> intros <;> exact e.apply_symm_apply _
 
 @[to_additive]
 noncomputable instance [Small.{v} α] [CommGroup α] : CommGroup (Shrink.{v} α) :=
@@ -527,12 +380,6 @@ section
 
 variable [Monoid R]
 
-/-- Transfer `MulAction` across an `Equiv` -/
-protected abbrev mulAction (e : α ≃ β) [MulAction R β] : MulAction R α :=
-  { e.smul R with
-    one_smul := by simp [smul_def]
-    mul_smul := by simp [smul_def, mul_smul] }
-
 noncomputable instance [Small.{v} α] [MulAction R α] : MulAction R (Shrink.{v} α) :=
   (equivShrink α).symm.mulAction R
 
@@ -666,21 +513,6 @@ end R
 end Instances
 
 end Equiv
-
-namespace Finite
-
-attribute [-instance] Fin.instMul
-
-/-- Any finite group in universe `u` is equivalent to some finite group in universe `v`. -/
-lemma exists_type_univ_nonempty_mulEquiv (G : Type u) [Group G] [Finite G] :
-    ∃ (G' : Type v) (_ : Group G') (_ : Fintype G'), Nonempty (G ≃* G') := by
-  obtain ⟨n, ⟨e⟩⟩ := Finite.exists_equiv_fin G
-  let f : Fin n ≃ ULift (Fin n) := Equiv.ulift.symm
-  let e : G ≃ ULift (Fin n) := e.trans f
-  letI groupH : Group (ULift (Fin n)) := e.symm.group
-  exact ⟨ULift (Fin n), groupH, inferInstance, ⟨MulEquiv.symm <| e.symm.mulEquiv⟩⟩
-
-end Finite
 
 section
 

--- a/Mathlib/Algebra/Group/AddChar.lean
+++ b/Mathlib/Algebra/Group/AddChar.lean
@@ -3,10 +3,12 @@ Copyright (c) 2022 Michael Stoll. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Stoll
 -/
-import Mathlib.Algebra.Ring.Regular
-import Mathlib.Algebra.Equiv.TransferInstance
 import Mathlib.Algebra.BigOperators.Pi
 import Mathlib.Algebra.BigOperators.Ring.Finset
+import Mathlib.Algebra.Group.Subgroup.Ker
+import Mathlib.Algebra.Group.TransferInstance
+import Mathlib.Algebra.Group.Units.Equiv
+import Mathlib.Algebra.Ring.Regular
 
 /-!
 # Characters from additive to multiplicative monoids

--- a/Mathlib/Algebra/Group/TransferInstance.lean
+++ b/Mathlib/Algebra/Group/TransferInstance.lean
@@ -11,10 +11,8 @@ import Mathlib.Data.Fintype.Basic
 /-!
 # Transfer algebraic structures across `Equiv`s
 
-In this file we prove lemmas of the following form: if `β` has a
-group structure and `α ≃ β` then `α` has a group structure, and
-similarly for monoids, semigroups, rings, integral domains, fields and
-so on.
+In this file we prove lemmas of the following form: if `β` has a group structure and `α ≃ β`
+then `α` has a group structure, and similarly for monoids, semigroups and so on.
 
 ### Implementation details
 
@@ -69,7 +67,7 @@ lemma inv_def [Inv β] (x : α) :
 variable (M) in
 /-- Transfer `SMul` across an `Equiv` -/
 @[to_additive "Transfer `VAdd` across an `Equiv`"]
-protected abbrev smul [SMul M β] : SMul M α := ⟨fun r x => e.symm (r • e x)⟩
+protected abbrev smul [SMul M β] : SMul M α where smul r x := e.symm (r • e x)
 
 @[to_additive]
 lemma smul_def [SMul M β] (r : M) (x : α) :

--- a/Mathlib/Algebra/Group/TransferInstance.lean
+++ b/Mathlib/Algebra/Group/TransferInstance.lean
@@ -1,0 +1,193 @@
+/-
+Copyright (c) 2018 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl
+-/
+import Mathlib.Algebra.Group.Action.Defs
+import Mathlib.Algebra.Group.Equiv.Defs
+import Mathlib.Algebra.Group.InjSurj
+import Mathlib.Data.Fintype.Basic
+
+/-!
+# Transfer algebraic structures across `Equiv`s
+
+In this file we prove lemmas of the following form: if `β` has a
+group structure and `α ≃ β` then `α` has a group structure, and
+similarly for monoids, semigroups, rings, integral domains, fields and
+so on.
+
+### Implementation details
+
+When adding new definitions that transfer type-classes across an equivalence, please use
+`abbrev`. See note [reducible non-instances].
+-/
+
+assert_not_exists MonoidWithZero
+
+namespace Equiv
+variable {M α β : Type*} (e : α ≃ β)
+
+/-- Transfer `One` across an `Equiv` -/
+@[to_additive "Transfer `Zero` across an `Equiv`"]
+protected abbrev one [One β] : One α where one := e.symm 1
+
+@[to_additive]
+lemma one_def [One β] :
+    letI := e.one
+    1 = e.symm 1 := rfl
+
+/-- Transfer `Mul` across an `Equiv` -/
+@[to_additive "Transfer `Add` across an `Equiv`"]
+protected abbrev mul [Mul β] : Mul α where mul x y := e.symm (e x * e y)
+
+@[to_additive]
+lemma mul_def [Mul β] (x y : α) :
+    letI := Equiv.mul e
+    x * y = e.symm (e x * e y) := rfl
+
+/-- Transfer `Div` across an `Equiv` -/
+@[to_additive "Transfer `Sub` across an `Equiv`"]
+protected abbrev div [Div β] : Div α :=
+  ⟨fun x y => e.symm (e x / e y)⟩
+
+@[to_additive]
+lemma div_def [Div β] (x y : α) :
+    letI := Equiv.div e
+    x / y = e.symm (e x / e y) := rfl
+
+-- Porting note: this should be called `inv`,
+-- but we already have an `Equiv.inv` (which perhaps should move to `Perm.inv`?)
+/-- Transfer `Inv` across an `Equiv` -/
+@[to_additive "Transfer `Neg` across an `Equiv`"]
+protected abbrev Inv [Inv β] : Inv α where inv x := e.symm (e x)⁻¹
+
+@[to_additive]
+lemma inv_def [Inv β] (x : α) :
+    letI := e.Inv
+    x⁻¹ = e.symm (e x)⁻¹ := rfl
+
+variable (M) in
+/-- Transfer `SMul` across an `Equiv` -/
+@[to_additive "Transfer `VAdd` across an `Equiv`"]
+protected abbrev smul [SMul M β] : SMul M α := ⟨fun r x => e.symm (r • e x)⟩
+
+@[to_additive]
+lemma smul_def [SMul M β] (r : M) (x : α) :
+    letI := e.smul M
+    r • x = e.symm (r • e x) := rfl
+
+variable (M) in
+/-- Transfer `Pow` across an `Equiv` -/
+@[to_additive existing smul]
+protected abbrev pow [Pow β M] : Pow α M where pow x n := e.symm (e x ^ n)
+
+@[to_additive existing smul_def]
+lemma pow_def [Pow β M] (n : M) (x : α) :
+    letI := e.pow M
+    x ^ n = e.symm (e x ^ n) := rfl
+
+/-- An equivalence `e : α ≃ β` gives a multiplicative equivalence `α ≃* β` where
+the multiplicative structure on `α` is the one obtained by transporting a multiplicative structure
+on `β` back along `e`. -/
+@[to_additive "An equivalence `e : α ≃ β` gives an additive equivalence `α ≃+ β` where
+the additive structure on `α` is the one obtained by transporting an additive structure
+on `β` back along `e`."]
+def mulEquiv (e : α ≃ β) [Mul β] :
+    let _ := Equiv.mul e
+    α ≃* β := by
+  intros
+  exact
+    { e with
+      map_mul' := fun x y => by
+        apply e.symm.injective
+        simp [mul_def] }
+
+@[to_additive (attr := simp)]
+lemma mulEquiv_apply (e : α ≃ β) [Mul β] (a : α) : (mulEquiv e) a = e a := rfl
+
+@[to_additive]
+lemma mulEquiv_symm_apply (e : α ≃ β) [Mul β] (b : β) :
+    letI := Equiv.mul e
+    (mulEquiv e).symm b = e.symm b := rfl
+
+/-- Transfer `Semigroup` across an `Equiv` -/
+@[to_additive "Transfer `add_semigroup` across an `Equiv`"]
+protected abbrev semigroup [Semigroup β] : Semigroup α := by
+  let mul := e.mul
+  apply e.injective.semigroup _; intros; exact e.apply_symm_apply _
+
+/-- Transfer `CommSemigroup` across an `Equiv` -/
+@[to_additive "Transfer `AddCommSemigroup` across an `Equiv`"]
+protected abbrev commSemigroup [CommSemigroup β] : CommSemigroup α := by
+  let mul := e.mul
+  apply e.injective.commSemigroup _; intros; exact e.apply_symm_apply _
+
+/-- Transfer `MulOneClass` across an `Equiv` -/
+@[to_additive "Transfer `AddZeroClass` across an `Equiv`"]
+protected abbrev mulOneClass [MulOneClass β] : MulOneClass α := by
+  let one := e.one
+  let mul := e.mul
+  apply e.injective.mulOneClass _ <;> intros <;> exact e.apply_symm_apply _
+
+/-- Transfer `Monoid` across an `Equiv` -/
+@[to_additive "Transfer `AddMonoid` across an `Equiv`"]
+protected abbrev monoid [Monoid β] : Monoid α := by
+  let one := e.one
+  let mul := e.mul
+  let pow := e.pow ℕ
+  apply e.injective.monoid _ <;> intros <;> exact e.apply_symm_apply _
+
+/-- Transfer `CommMonoid` across an `Equiv` -/
+@[to_additive "Transfer `AddCommMonoid` across an `Equiv`"]
+protected abbrev commMonoid [CommMonoid β] : CommMonoid α := by
+  let one := e.one
+  let mul := e.mul
+  let pow := e.pow ℕ
+  apply e.injective.commMonoid _ <;> intros <;> exact e.apply_symm_apply _
+
+/-- Transfer `Group` across an `Equiv` -/
+@[to_additive "Transfer `AddGroup` across an `Equiv`"]
+protected abbrev group [Group β] : Group α := by
+  let one := e.one
+  let mul := e.mul
+  let inv := e.Inv
+  let div := e.div
+  let npow := e.pow ℕ
+  let zpow := e.pow ℤ
+  apply e.injective.group _ <;> intros <;> exact e.apply_symm_apply _
+
+/-- Transfer `CommGroup` across an `Equiv` -/
+@[to_additive "Transfer `AddCommGroup` across an `Equiv`"]
+protected abbrev commGroup [CommGroup β] : CommGroup α := by
+  let one := e.one
+  let mul := e.mul
+  let inv := e.Inv
+  let div := e.div
+  let npow := e.pow ℕ
+  let zpow := e.pow ℤ
+  apply e.injective.commGroup _ <;> intros <;> exact e.apply_symm_apply _
+
+variable (M) [Monoid M] in
+/-- Transfer `MulAction` across an `Equiv` -/
+@[to_additive]
+protected abbrev mulAction (e : α ≃ β) [MulAction M β] : MulAction M α where
+  __ := e.smul M
+  one_smul := by simp [smul_def]
+  mul_smul := by simp [smul_def, mul_smul]
+
+end Equiv
+
+namespace Finite
+
+/-- Any finite group in universe `u` is equivalent to some finite group in universe `v`. -/
+@[to_additive
+"Any finite group in universe `u` is equivalent to some finite group in universe `v`."]
+lemma exists_type_univ_nonempty_mulEquiv.{u, v} (G : Type u) [Group G] [Finite G] :
+    ∃ (G' : Type v) (_ : Group G') (_ : Fintype G'), Nonempty (G ≃* G') := by
+  obtain ⟨n, ⟨e⟩⟩ := Finite.exists_equiv_fin G
+  let f : Fin n ≃ ULift (Fin n) := Equiv.ulift.symm
+  let e : G ≃ ULift (Fin n) := e.trans f
+  letI groupH : Group (ULift (Fin n)) := e.symm.group
+  exact ⟨ULift (Fin n), groupH, inferInstance, ⟨MulEquiv.symm <| e.symm.mulEquiv⟩⟩
+
+end Finite

--- a/Mathlib/Algebra/Group/TransferInstance.lean
+++ b/Mathlib/Algebra/Group/TransferInstance.lean
@@ -169,7 +169,7 @@ protected abbrev commGroup [CommGroup β] : CommGroup α := by
 
 variable (M) [Monoid M] in
 /-- Transfer `MulAction` across an `Equiv` -/
-@[to_additive]
+@[to_additive "Transfer `AddAction` across an `Equiv`"]
 protected abbrev mulAction (e : α ≃ β) [MulAction M β] : MulAction M α where
   __ := e.smul M
   one_smul := by simp [smul_def]

--- a/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
@@ -3,11 +3,12 @@ Copyright (c) 2023 Joël Riou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
-import Mathlib.Algebra.Homology.Homotopy
-import Mathlib.Algebra.Ring.NegOnePow
 import Mathlib.Algebra.Category.Grp.Preadditive
-import Mathlib.Tactic.Linarith
+import Mathlib.Algebra.Homology.Homotopy
+import Mathlib.Algebra.Module.Pi
+import Mathlib.Algebra.Ring.NegOnePow
 import Mathlib.CategoryTheory.Linear.LinearFunctor
+import Mathlib.Tactic.Linarith
 
 /-! The cochain complex of homomorphisms between cochain complexes
 

--- a/Mathlib/Algebra/Homology/HomotopyCategory/HomComplexShift.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/HomComplexShift.lean
@@ -5,6 +5,7 @@ Authors: Joël Riou
 -/
 import Mathlib.Algebra.Homology.HomotopyCategory.HomComplex
 import Mathlib.Algebra.Homology.HomotopyCategory.Shift
+import Mathlib.Algebra.Module.Equiv.Basic
 
 /-! Shifting cochains
 

--- a/Mathlib/CategoryTheory/Galois/Basic.lean
+++ b/Mathlib/CategoryTheory/Galois/Basic.lean
@@ -3,6 +3,7 @@ Copyright (c) 2024 Christian Merten. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Christian Merten
 -/
+import Mathlib.Algebra.Group.TransferInstance
 import Mathlib.CategoryTheory.Limits.Constructions.LimitsOfProductsAndEqualizers
 import Mathlib.CategoryTheory.Limits.FintypeCat
 import Mathlib.CategoryTheory.Limits.MonoCoprod
@@ -10,7 +11,6 @@ import Mathlib.CategoryTheory.Limits.Shapes.ConcreteCategory
 import Mathlib.CategoryTheory.Limits.Shapes.Diagonal
 import Mathlib.CategoryTheory.SingleObj
 import Mathlib.Data.Finite.Card
-import Mathlib.Algebra.Equiv.TransferInstance
 
 /-!
 # Definition and basic properties of Galois categories

--- a/Mathlib/CategoryTheory/Galois/GaloisObjects.lean
+++ b/Mathlib/CategoryTheory/Galois/GaloisObjects.lean
@@ -8,7 +8,6 @@ import Mathlib.CategoryTheory.Limits.FintypeCat
 import Mathlib.CategoryTheory.Limits.Preserves.Limits
 import Mathlib.CategoryTheory.Limits.Shapes.SingleObj
 import Mathlib.GroupTheory.GroupAction.Basic
-import Mathlib.Algebra.Equiv.TransferInstance
 
 /-!
 # Galois objects in Galois categories

--- a/Mathlib/CategoryTheory/Localization/CalculusOfFractions/Preadditive.lean
+++ b/Mathlib/CategoryTheory/Localization/CalculusOfFractions/Preadditive.lean
@@ -3,10 +3,10 @@ Copyright (c) 2024 Joël Riou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou
 -/
+import Mathlib.Algebra.Group.TransferInstance
 import Mathlib.CategoryTheory.Localization.CalculusOfFractions.Fractions
 import Mathlib.CategoryTheory.Localization.HasLocalization
 import Mathlib.CategoryTheory.Preadditive.AdditiveFunctor
-import Mathlib.Algebra.Equiv.TransferInstance
 
 /-!
 # The preadditive category structure on the localized category

--- a/Mathlib/CategoryTheory/Preadditive/Opposite.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Opposite.lean
@@ -3,8 +3,10 @@ Copyright (c) 2021 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison, Adam Topaz, Johan Commelin, Joël Riou
 -/
+import Mathlib.Algebra.Group.TransferInstance
+import Mathlib.Algebra.Module.Equiv.Defs
+import Mathlib.Algebra.Module.Opposite
 import Mathlib.CategoryTheory.Preadditive.AdditiveFunctor
-import Mathlib.Algebra.Equiv.TransferInstance
 
 /-!
 # If `C` is preadditive, `Cᵒᵖ` has a natural preadditive structure.

--- a/Mathlib/CategoryTheory/Preadditive/Transfer.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Transfer.lean
@@ -3,8 +3,8 @@ Copyright (c) 2025 Jakob von Raumer. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jakob von Raumer
 -/
+import Mathlib.Algebra.Group.TransferInstance
 import Mathlib.CategoryTheory.Preadditive.AdditiveFunctor
-import Mathlib.Algebra.Equiv.TransferInstance
 
 /-!
 # Pulling back a preadditive structure along a fully faithful functor

--- a/Mathlib/Data/Finsupp/MonomialOrder/DegLex.lean
+++ b/Mathlib/Data/Finsupp/MonomialOrder/DegLex.lean
@@ -4,9 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Antoine Chambert-Loir
 -/
 
+import Mathlib.Algebra.Group.TransferInstance
 import Mathlib.Data.Finsupp.MonomialOrder
 import Mathlib.Data.Finsupp.Weight
-import Mathlib.Algebra.Equiv.TransferInstance
 
 /-! Homogeneous lexicographic monomial ordering
 

--- a/Mathlib/Topology/Homotopy/HomotopyGroup.lean
+++ b/Mathlib/Topology/Homotopy/HomotopyGroup.lean
@@ -3,10 +3,10 @@ Copyright (c) 2021 Roberto Alvarez. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Roberto Alvarez
 -/
+import Mathlib.Algebra.Group.Ext
+import Mathlib.Algebra.Group.TransferInstance
 import Mathlib.AlgebraicTopology.FundamentalGroupoid.FundamentalGroup
 import Mathlib.GroupTheory.EckmannHilton
-import Mathlib.Algebra.Equiv.TransferInstance
-import Mathlib.Algebra.Group.Ext
 
 /-!
 # `n`th homotopy group


### PR DESCRIPTION
Move group results from `Algebra.Equiv.TransferInstance` to a new file `Algebra.Group.TransferInstance`. Additivise a few declarations along the way.

This is the first part of #26732, split off for Eric's convenience.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
