### PR TITLE
[Merged by Bors] - chore(Algebra/Equiv/TransferInstance): delete duplicated `Shrink` material

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -19,6 +19,7 @@ import Mathlib.Algebra.Algebra.Pi
 import Mathlib.Algebra.Algebra.Prod
 import Mathlib.Algebra.Algebra.Rat
 import Mathlib.Algebra.Algebra.RestrictScalars
+import Mathlib.Algebra.Algebra.Shrink
 import Mathlib.Algebra.Algebra.Spectrum.Basic
 import Mathlib.Algebra.Algebra.Spectrum.Pi
 import Mathlib.Algebra.Algebra.Spectrum.Quasispectrum
@@ -275,6 +276,7 @@ import Mathlib.Algebra.Field.Opposite
 import Mathlib.Algebra.Field.Periodic
 import Mathlib.Algebra.Field.Power
 import Mathlib.Algebra.Field.Rat
+import Mathlib.Algebra.Field.Shrink
 import Mathlib.Algebra.Field.Subfield.Basic
 import Mathlib.Algebra.Field.Subfield.Defs
 import Mathlib.Algebra.Field.ULift
@@ -477,6 +479,7 @@ import Mathlib.Algebra.GroupWithZero.ProdHom
 import Mathlib.Algebra.GroupWithZero.Range
 import Mathlib.Algebra.GroupWithZero.Regular
 import Mathlib.Algebra.GroupWithZero.Semiconj
+import Mathlib.Algebra.GroupWithZero.Shrink
 import Mathlib.Algebra.GroupWithZero.Subgroup
 import Mathlib.Algebra.GroupWithZero.Submonoid.Pointwise
 import Mathlib.Algebra.GroupWithZero.Submonoid.Primal

--- a/Mathlib/Algebra/Algebra/Shrink.lean
+++ b/Mathlib/Algebra/Algebra/Shrink.lean
@@ -10,9 +10,7 @@ import Mathlib.Algebra.Ring.Shrink
 # Transfer module and algebra structures from `α` to `Shrink α`
 -/
 
--- FIXME: `to_additive` is incompatible with `noncomputable section`.
--- See https://github.com/leanprover-community/mathlib4/issues/1074.
-suppress_compilation
+noncomputable section
 
 universe v
 variable {R α : Type*} [Small.{v} α] [CommSemiring R]

--- a/Mathlib/Algebra/Algebra/Shrink.lean
+++ b/Mathlib/Algebra/Algebra/Shrink.lean
@@ -1,0 +1,28 @@
+/-
+Copyright (c) 2021 Kim Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+import Mathlib.Algebra.Equiv.TransferInstance
+import Mathlib.Algebra.Ring.Shrink
+
+/-!
+# Transfer module and algebra structures from `α` to `Shrink α`
+-/
+
+suppress_compilation
+
+universe v
+variable {R α : Type*} [Small.{v} α] [CommSemiring R]
+
+namespace Shrink
+
+instance [Semiring α] [Algebra R α] : Algebra R (Shrink.{v} α) := (equivShrink α).symm.algebra _
+
+variable (R α) in
+/-- Shrink `α` to a smaller universe preserves algebra structure. -/
+@[simps!]
+def _root_.Shrink.algEquiv [Small.{v} α] [Semiring α] [Algebra R α] : Shrink.{v} α ≃ₐ[R] α :=
+  (equivShrink α).symm.algEquiv _
+
+end Shrink

--- a/Mathlib/Algebra/Algebra/Shrink.lean
+++ b/Mathlib/Algebra/Algebra/Shrink.lean
@@ -10,6 +10,8 @@ import Mathlib.Algebra.Ring.Shrink
 # Transfer module and algebra structures from `α` to `Shrink α`
 -/
 
+-- FIXME: `to_additive` is incompatible with `noncomputable section`.
+-- See https://github.com/leanprover-community/mathlib4/issues/1074.
 suppress_compilation
 
 universe v

--- a/Mathlib/Algebra/Algebra/Shrink.lean
+++ b/Mathlib/Algebra/Algebra/Shrink.lean
@@ -22,7 +22,13 @@ instance [Semiring α] [Algebra R α] : Algebra R (Shrink.{v} α) := (equivShrin
 variable (R α) in
 /-- Shrink `α` to a smaller universe preserves algebra structure. -/
 @[simps!]
-def _root_.Shrink.algEquiv [Small.{v} α] [Semiring α] [Algebra R α] : Shrink.{v} α ≃ₐ[R] α :=
+def algEquiv [Small.{v} α] [Semiring α] [Algebra R α] : Shrink.{v} α ≃ₐ[R] α :=
   (equivShrink α).symm.algEquiv _
 
 end Shrink
+
+/-- A small algebra is algebra equivalent to its small model. -/
+@[deprecated Shrink.algEquiv (since := "2025-07-11")]
+def algEquivShrink (α β) [CommSemiring α] [Semiring β] [Algebra α β] [Small β] :
+    β ≃ₐ[α] Shrink β :=
+  ((equivShrink β).symm.algEquiv α).symm

--- a/Mathlib/Algebra/Category/AlgCat/Limits.lean
+++ b/Mathlib/Algebra/Category/AlgCat/Limits.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 import Mathlib.Algebra.Algebra.Pi
+import Mathlib.Algebra.Algebra.Shrink
 import Mathlib.Algebra.Category.AlgCat.Basic
 import Mathlib.Algebra.Category.ModuleCat.Basic
 import Mathlib.Algebra.Category.ModuleCat.Limits
@@ -73,7 +74,7 @@ def limitπAlgHom (j) :
       (F ⋙ forget₂ (AlgCat R) RingCat.{w} ⋙ forget₂ RingCat SemiRingCat.{w}) j with
     toFun := (Types.Small.limitCone (F ⋙ forget (AlgCat.{w} R))).π.app j
     commutes' := fun x => by
-      simp only [Types.Small.limitCone_π_app, ← Shrink.algEquiv_apply _ R,
+      simp only [Types.Small.limitCone_π_app, ← Shrink.algEquiv_apply R,
         Types.Small.limitCone_pt, AlgEquiv.commutes]
       rfl
     }

--- a/Mathlib/Algebra/Category/Grp/CartesianMonoidal.lean
+++ b/Mathlib/Algebra/Category/Grp/CartesianMonoidal.lean
@@ -5,6 +5,7 @@ Authors: Markus Himmel
 -/
 import Mathlib.Algebra.Category.Grp.Biproducts
 import Mathlib.Algebra.Category.Grp.Zero
+import Mathlib.Algebra.Ring.PUnit
 import Mathlib.CategoryTheory.Monoidal.Types.Basic
 
 /-!

--- a/Mathlib/Algebra/Category/Grp/Colimits.lean
+++ b/Mathlib/Algebra/Category/Grp/Colimits.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison, Sophie Morel
 -/
 import Mathlib.Algebra.Category.Grp.Preadditive
-import Mathlib.Algebra.Equiv.TransferInstance
+import Mathlib.Algebra.Group.Shrink
 import Mathlib.CategoryTheory.ConcreteCategory.Elementwise
 import Mathlib.Data.DFinsupp.BigOperators
 import Mathlib.Data.DFinsupp.Small

--- a/Mathlib/Algebra/Category/Grp/Limits.lean
+++ b/Mathlib/Algebra/Category/Grp/Limits.lean
@@ -8,6 +8,7 @@ import Mathlib.Algebra.Category.MonCat.ForgetCorepresentable
 import Mathlib.Algebra.Category.Grp.ForgetCorepresentable
 import Mathlib.Algebra.Category.Grp.Preadditive
 import Mathlib.Algebra.Category.MonCat.Limits
+import Mathlib.Algebra.Group.Subgroup.Ker
 import Mathlib.CategoryTheory.ConcreteCategory.ReflectsIso
 import Mathlib.CategoryTheory.Limits.ConcreteCategory.Basic
 

--- a/Mathlib/Algebra/Category/ModuleCat/AB.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/AB.lean
@@ -38,9 +38,9 @@ lemma ModuleCat.isSeparator [Small.{v} R] : IsSeparator (ModuleCat.of.{v} R (Shr
     fun X Y f g h ↦ by
   simp only [Set.mem_singleton_iff, forall_eq, ModuleCat.hom_ext_iff, LinearMap.ext_iff] at h
   ext x
-  simpa [linearEquivShrink, Equiv.linearEquiv] using
+  simpa [Shrink.linearEquiv, Equiv.linearEquiv] using
     h (ModuleCat.ofHom ((LinearMap.toSpanSingleton R X x).comp
-      ((linearEquivShrink R R).symm : Shrink R →ₗ[R] R))) 1
+      (Shrink.linearEquiv R R : Shrink R →ₗ[R] R))) 1
 
 instance [Small.{v} R] : HasSeparator (ModuleCat.{v} R) where
   hasSeparator := ⟨ModuleCat.of R (Shrink.{v} R), ModuleCat.isSeparator R⟩

--- a/Mathlib/Algebra/Category/ModuleCat/EnoughInjectives.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/EnoughInjectives.lean
@@ -5,6 +5,7 @@ Authors: Jujian Zhang
 -/
 import Mathlib.Algebra.Category.Grp.EnoughInjectives
 import Mathlib.Algebra.Category.ModuleCat.ChangeOfRings
+import Mathlib.Algebra.Ring.Shrink
 
 /-!
 # Category of $R$-modules has enough injectives

--- a/Mathlib/Algebra/Category/ModuleCat/Limits.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Limits.lean
@@ -6,6 +6,7 @@ Authors: Kim Morrison
 import Mathlib.Algebra.Category.ModuleCat.Basic
 import Mathlib.Algebra.Category.Grp.Limits
 import Mathlib.Algebra.Colimit.Module
+import Mathlib.Algebra.Module.Shrink
 
 /-!
 # The category of R-modules has all limits
@@ -81,7 +82,7 @@ def limitπLinearMap (j) :
   toFun := (Types.Small.limitCone (F ⋙ forget (ModuleCat R))).π.app j
   map_smul' _ _ := by
     simp only [Types.Small.limitCone_π_app,
-      ← Shrink.linearEquiv_apply (F ⋙ forget (ModuleCat R)).sections R, map_smul]
+      ← Shrink.linearEquiv_apply R (F ⋙ forget (ModuleCat R)).sections, map_smul]
     simp only [Shrink.linearEquiv_apply]
     rfl
   map_add' _ _ := by

--- a/Mathlib/Algebra/Category/MonCat/Limits.lean
+++ b/Mathlib/Algebra/Category/MonCat/Limits.lean
@@ -5,6 +5,7 @@ Authors: Kim Morrison
 -/
 import Mathlib.Algebra.Category.MonCat.Basic
 import Mathlib.Algebra.Group.Shrink
+import Mathlib.Algebra.Group.Submonoid.Defs
 import Mathlib.CategoryTheory.Limits.Creates
 import Mathlib.CategoryTheory.Limits.Types.Limits
 

--- a/Mathlib/Algebra/Category/Ring/Limits.lean
+++ b/Mathlib/Algebra/Category/Ring/Limits.lean
@@ -3,10 +3,9 @@ Copyright (c) 2019 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
-import Mathlib.Algebra.Ring.Pi
-import Mathlib.Algebra.Category.Ring.Basic
 import Mathlib.Algebra.Category.Grp.Limits
-import Mathlib.Algebra.Ring.Subring.Basic
+import Mathlib.Algebra.Category.Ring.Basic
+import Mathlib.Algebra.Ring.Shrink
 
 /-!
 # The category of (commutative) rings has all limits

--- a/Mathlib/Algebra/Equiv/TransferInstance.lean
+++ b/Mathlib/Algebra/Equiv/TransferInstance.lean
@@ -6,8 +6,6 @@ Authors: Johannes Hölzl
 import Mathlib.Algebra.Algebra.Equiv
 import Mathlib.Algebra.Field.Basic
 import Mathlib.Algebra.Group.TransferInstance
-import Mathlib.Logic.Equiv.Defs
-import Mathlib.Logic.Small.Defs
 import Mathlib.Algebra.Ring.Hom.InjSurj
 
 /-!
@@ -26,33 +24,6 @@ namespace Equiv
 section Instances
 
 variable (e : α ≃ β)
-
-@[to_additive]
-noncomputable instance [Small.{v} α] [One α] : One (Shrink.{v} α) :=
-  (equivShrink α).symm.one
-
-@[to_additive]
-noncomputable instance [Small.{v} α] [Mul α] : Mul (Shrink.{v} α) :=
-  (equivShrink α).symm.mul
-
-@[to_additive]
-noncomputable instance [Small.{v} α] [Div α] : Div (Shrink.{v} α) :=
-  (equivShrink α).symm.div
-
-@[to_additive]
-noncomputable instance [Small.{v} α] [Inv α] : Inv (Shrink.{v} α) :=
-  (equivShrink α).symm.Inv
-
-noncomputable instance [Small.{v} α] (R : Type*) [SMul R α] : SMul R (Shrink.{v} α) :=
-  (equivShrink α).symm.smul R
-
-noncomputable instance [Small.{v} α] (N : Type*) [Pow α N] : Pow (Shrink.{v} α) N :=
-  (equivShrink α).symm.pow N
-
-/-- Shrink `α` to a smaller universe preserves multiplication. -/
-@[to_additive "Shrink `α` to a smaller universe preserves addition."]
-noncomputable def _root_.Shrink.mulEquiv [Small.{v} α] [Mul α] : Shrink.{v} α ≃* α :=
-  (equivShrink α).symm.mulEquiv
 
 /-- An equivalence `e : α ≃ β` gives a ring equivalence `α ≃+* β`
 where the ring structure on `α` is
@@ -81,27 +52,11 @@ theorem ringEquiv_symm_apply (e : α ≃ β) [Add β] [Mul β] (b : β) : by
     letI := Equiv.mul e
     exact (ringEquiv e).symm b = e.symm b := rfl
 
-variable (α) in
-/-- Shrink `α` to a smaller universe preserves ring structure. -/
-noncomputable def _root_.Shrink.ringEquiv [Small.{v} α] [Add α] [Mul α] : Shrink.{v} α ≃+* α :=
-  (equivShrink α).symm.ringEquiv
-
-@[to_additive]
-noncomputable instance [Small.{v} α] [Semigroup α] : Semigroup (Shrink.{v} α) :=
-  (equivShrink α).symm.semigroup
-
 /-- Transfer `SemigroupWithZero` across an `Equiv` -/
 protected abbrev semigroupWithZero [SemigroupWithZero β] : SemigroupWithZero α := by
   let mul := e.mul
   let zero := e.zero
   apply e.injective.semigroupWithZero _ <;> intros <;> exact e.apply_symm_apply _
-
-noncomputable instance [Small.{v} α] [SemigroupWithZero α] : SemigroupWithZero (Shrink.{v} α) :=
-  (equivShrink α).symm.semigroupWithZero
-
-@[to_additive]
-noncomputable instance [Small.{v} α] [CommSemigroup α] : CommSemigroup (Shrink.{v} α) :=
-  (equivShrink α).symm.commSemigroup
 
 /-- Transfer `MulZeroClass` across an `Equiv` -/
 protected abbrev mulZeroClass [MulZeroClass β] : MulZeroClass α := by
@@ -109,38 +64,12 @@ protected abbrev mulZeroClass [MulZeroClass β] : MulZeroClass α := by
   let mul := e.mul
   apply e.injective.mulZeroClass _ <;> intros <;> exact e.apply_symm_apply _
 
-noncomputable instance [Small.{v} α] [MulZeroClass α] : MulZeroClass (Shrink.{v} α) :=
-  (equivShrink α).symm.mulZeroClass
-
-@[to_additive]
-noncomputable instance [Small.{v} α] [MulOneClass α] : MulOneClass (Shrink.{v} α) :=
-  (equivShrink α).symm.mulOneClass
-
 /-- Transfer `MulZeroOneClass` across an `Equiv` -/
 protected abbrev mulZeroOneClass [MulZeroOneClass β] : MulZeroOneClass α := by
   let zero := e.zero
   let one := e.one
   let mul := e.mul
   apply e.injective.mulZeroOneClass _ <;> intros <;> exact e.apply_symm_apply _
-
-noncomputable instance [Small.{v} α] [MulZeroOneClass α] : MulZeroOneClass (Shrink.{v} α) :=
-  (equivShrink α).symm.mulZeroOneClass
-
-@[to_additive]
-noncomputable instance [Small.{v} α] [Monoid α] : Monoid (Shrink.{v} α) :=
-  (equivShrink α).symm.monoid
-
-@[to_additive]
-noncomputable instance [Small.{v} α] [CommMonoid α] : CommMonoid (Shrink.{v} α) :=
-  (equivShrink α).symm.commMonoid
-
-@[to_additive]
-noncomputable instance [Small.{v} α] [Group α] : Group (Shrink.{v} α) :=
-  (equivShrink α).symm.group
-
-@[to_additive]
-noncomputable instance [Small.{v} α] [CommGroup α] : CommGroup (Shrink.{v} α) :=
-  (equivShrink α).symm.commGroup
 
 /-- Transfer `NonUnitalNonAssocSemiring` across an `Equiv` -/
 protected abbrev nonUnitalNonAssocSemiring [NonUnitalNonAssocSemiring β] :
@@ -151,10 +80,6 @@ protected abbrev nonUnitalNonAssocSemiring [NonUnitalNonAssocSemiring β] :
   let nsmul := e.smul ℕ
   apply e.injective.nonUnitalNonAssocSemiring _ <;> intros <;> exact e.apply_symm_apply _
 
-noncomputable instance [Small.{v} α] [NonUnitalNonAssocSemiring α] :
-    NonUnitalNonAssocSemiring (Shrink.{v} α) :=
-  (equivShrink α).symm.nonUnitalNonAssocSemiring
-
 /-- Transfer `NonUnitalSemiring` across an `Equiv` -/
 protected abbrev nonUnitalSemiring [NonUnitalSemiring β] : NonUnitalSemiring α := by
   let zero := e.zero
@@ -163,18 +88,12 @@ protected abbrev nonUnitalSemiring [NonUnitalSemiring β] : NonUnitalSemiring α
   let nsmul := e.smul ℕ
   apply e.injective.nonUnitalSemiring _ <;> intros <;> exact e.apply_symm_apply _
 
-noncomputable instance [Small.{v} α] [NonUnitalSemiring α] : NonUnitalSemiring (Shrink.{v} α) :=
-  (equivShrink α).symm.nonUnitalSemiring
-
 /-- Transfer `AddMonoidWithOne` across an `Equiv` -/
 protected abbrev addMonoidWithOne [AddMonoidWithOne β] : AddMonoidWithOne α :=
   { e.addMonoid, e.one with
     natCast := fun n => e.symm n
     natCast_zero := e.injective (by simp [zero_def])
     natCast_succ := fun n => e.injective (by simp [add_def, one_def]) }
-
-noncomputable instance [Small.{v} α] [AddMonoidWithOne α] : AddMonoidWithOne (Shrink.{v} α) :=
-  (equivShrink α).symm.addMonoidWithOne
 
 /-- Transfer `AddGroupWithOne` across an `Equiv` -/
 protected abbrev addGroupWithOne [AddGroupWithOne β] : AddGroupWithOne α :=
@@ -185,17 +104,11 @@ protected abbrev addGroupWithOne [AddGroupWithOne β] : AddGroupWithOne α :=
     intCast_negSucc := fun _ =>
       congr_arg e.symm <| (Int.cast_negSucc _).trans <| congr_arg _ (e.apply_symm_apply _).symm }
 
-noncomputable instance [Small.{v} α] [AddGroupWithOne α] : AddGroupWithOne (Shrink.{v} α) :=
-  (equivShrink α).symm.addGroupWithOne
-
 /-- Transfer `NonAssocSemiring` across an `Equiv` -/
 protected abbrev nonAssocSemiring [NonAssocSemiring β] : NonAssocSemiring α := by
   let mul := e.mul
   let add_monoid_with_one := e.addMonoidWithOne
   apply e.injective.nonAssocSemiring _ <;> intros <;> exact e.apply_symm_apply _
-
-noncomputable instance [Small.{v} α] [NonAssocSemiring α] : NonAssocSemiring (Shrink.{v} α) :=
-  (equivShrink α).symm.nonAssocSemiring
 
 /-- Transfer `Semiring` across an `Equiv` -/
 protected abbrev semiring [Semiring β] : Semiring α := by
@@ -203,9 +116,6 @@ protected abbrev semiring [Semiring β] : Semiring α := by
   let add_monoid_with_one := e.addMonoidWithOne
   let npow := e.pow ℕ
   apply e.injective.semiring _ <;> intros <;> exact e.apply_symm_apply _
-
-noncomputable instance [Small.{v} α] [Semiring α] : Semiring (Shrink.{v} α) :=
-  (equivShrink α).symm.semiring
 
 /-- Transfer `NonUnitalCommSemiring` across an `Equiv` -/
 protected abbrev nonUnitalCommSemiring [NonUnitalCommSemiring β] : NonUnitalCommSemiring α := by
@@ -215,19 +125,12 @@ protected abbrev nonUnitalCommSemiring [NonUnitalCommSemiring β] : NonUnitalCom
   let nsmul := e.smul ℕ
   apply e.injective.nonUnitalCommSemiring _ <;> intros <;> exact e.apply_symm_apply _
 
-noncomputable instance [Small.{v} α] [NonUnitalCommSemiring α] :
-    NonUnitalCommSemiring (Shrink.{v} α) :=
-  (equivShrink α).symm.nonUnitalCommSemiring
-
 /-- Transfer `CommSemiring` across an `Equiv` -/
 protected abbrev commSemiring [CommSemiring β] : CommSemiring α := by
   let mul := e.mul
   let add_monoid_with_one := e.addMonoidWithOne
   let npow := e.pow ℕ
   apply e.injective.commSemiring _ <;> intros <;> exact e.apply_symm_apply _
-
-noncomputable instance [Small.{v} α] [CommSemiring α] : CommSemiring (Shrink.{v} α) :=
-  (equivShrink α).symm.commSemiring
 
 /-- Transfer `NonUnitalNonAssocRing` across an `Equiv` -/
 protected abbrev nonUnitalNonAssocRing [NonUnitalNonAssocRing β] : NonUnitalNonAssocRing α := by
@@ -240,10 +143,6 @@ protected abbrev nonUnitalNonAssocRing [NonUnitalNonAssocRing β] : NonUnitalNon
   let zsmul := e.smul ℤ
   apply e.injective.nonUnitalNonAssocRing _ <;> intros <;> exact e.apply_symm_apply _
 
-noncomputable instance [Small.{v} α] [NonUnitalNonAssocRing α] :
-    NonUnitalNonAssocRing (Shrink.{v} α) :=
-  (equivShrink α).symm.nonUnitalNonAssocRing
-
 /-- Transfer `NonUnitalRing` across an `Equiv` -/
 protected abbrev nonUnitalRing [NonUnitalRing β] : NonUnitalRing α := by
   let zero := e.zero
@@ -255,17 +154,11 @@ protected abbrev nonUnitalRing [NonUnitalRing β] : NonUnitalRing α := by
   let zsmul := e.smul ℤ
   apply e.injective.nonUnitalRing _ <;> intros <;> exact e.apply_symm_apply _
 
-noncomputable instance [Small.{v} α] [NonUnitalRing α] : NonUnitalRing (Shrink.{v} α) :=
-  (equivShrink α).symm.nonUnitalRing
-
 /-- Transfer `NonAssocRing` across an `Equiv` -/
 protected abbrev nonAssocRing [NonAssocRing β] : NonAssocRing α := by
   let add_group_with_one := e.addGroupWithOne
   let mul := e.mul
   apply e.injective.nonAssocRing _ <;> intros <;> exact e.apply_symm_apply _
-
-noncomputable instance [Small.{v} α] [NonAssocRing α] : NonAssocRing (Shrink.{v} α) :=
-  (equivShrink α).symm.nonAssocRing
 
 /-- Transfer `Ring` across an `Equiv` -/
 protected abbrev ring [Ring β] : Ring α := by
@@ -273,9 +166,6 @@ protected abbrev ring [Ring β] : Ring α := by
   let add_group_with_one := e.addGroupWithOne
   let npow := e.pow ℕ
   apply e.injective.ring _ <;> intros <;> exact e.apply_symm_apply _
-
-noncomputable instance [Small.{v} α] [Ring α] : Ring (Shrink.{v} α) :=
-  (equivShrink α).symm.ring
 
 /-- Transfer `NonUnitalCommRing` across an `Equiv` -/
 protected abbrev nonUnitalCommRing [NonUnitalCommRing β] : NonUnitalCommRing α := by
@@ -288,9 +178,6 @@ protected abbrev nonUnitalCommRing [NonUnitalCommRing β] : NonUnitalCommRing α
   let zsmul := e.smul ℤ
   apply e.injective.nonUnitalCommRing _ <;> intros <;> exact e.apply_symm_apply _
 
-noncomputable instance [Small.{v} α] [NonUnitalCommRing α] : NonUnitalCommRing (Shrink.{v} α) :=
-  (equivShrink α).symm.nonUnitalCommRing
-
 /-- Transfer `CommRing` across an `Equiv` -/
 protected abbrev commRing [CommRing β] : CommRing α := by
   let mul := e.mul
@@ -298,30 +185,15 @@ protected abbrev commRing [CommRing β] : CommRing α := by
   let npow := e.pow ℕ
   apply e.injective.commRing _ <;> intros <;> exact e.apply_symm_apply _
 
-noncomputable instance [Small.{v} α] [CommRing α] : CommRing (Shrink.{v} α) :=
-  (equivShrink α).symm.commRing
-
-noncomputable instance [Small.{v} α] [Nontrivial α] : Nontrivial (Shrink.{v} α) :=
-  (equivShrink α).symm.nontrivial
-
 /-- Transfer `IsDomain` across an `Equiv` -/
 protected theorem isDomain [Semiring α] [Semiring β] [IsDomain β] (e : α ≃+* β) : IsDomain α :=
   Function.Injective.isDomain e.toRingHom e.injective
-
-noncomputable instance [Small.{v} α] [Semiring α] [IsDomain α] : IsDomain (Shrink.{v} α) :=
-  Equiv.isDomain (Shrink.ringEquiv α)
 
 /-- Transfer `NNRatCast` across an `Equiv` -/
 protected abbrev nnratCast [NNRatCast β] : NNRatCast α where nnratCast q := e.symm q
 
 /-- Transfer `RatCast` across an `Equiv` -/
 protected abbrev ratCast [RatCast β] : RatCast α where ratCast n := e.symm n
-
-noncomputable instance _root_.Shrink.instNNRatCast [Small.{v} α] [NNRatCast α] :
-    NNRatCast (Shrink.{v} α) := (equivShrink α).symm.nnratCast
-
-noncomputable instance _root_.Shrink.instRatCast [Small.{v} α] [RatCast α] :
-    RatCast (Shrink.{v} α) := (equivShrink α).symm.ratCast
 
 /-- Transfer `DivisionRing` across an `Equiv` -/
 protected abbrev divisionRing [DivisionRing β] : DivisionRing α := by
@@ -336,9 +208,6 @@ protected abbrev divisionRing [DivisionRing β] : DivisionRing α := by
   let nnqsmul := e.smul ℚ≥0
   let qsmul := e.smul ℚ
   apply e.injective.divisionRing _ <;> intros <;> exact e.apply_symm_apply _
-
-noncomputable instance [Small.{v} α] [DivisionRing α] : DivisionRing (Shrink.{v} α) :=
-  (equivShrink α).symm.divisionRing
 
 /-- Transfer `Field` across an `Equiv` -/
 protected abbrev field [Field β] : Field α := by
@@ -355,9 +224,6 @@ protected abbrev field [Field β] : Field α := by
   let qsmul := e.smul ℚ
   apply e.injective.field _ <;> intros <;> exact e.apply_symm_apply _
 
-noncomputable instance [Small.{v} α] [Field α] : Field (Shrink.{v} α) :=
-  (equivShrink α).symm.field
-
 section R
 
 variable (R : Type*)
@@ -365,9 +231,6 @@ variable (R : Type*)
 section
 
 variable [Monoid R]
-
-noncomputable instance [Small.{v} α] [MulAction R α] : MulAction R (Shrink.{v} α) :=
-  (equivShrink α).symm.mulAction R
 
 /-- Transfer `DistribMulAction` across an `Equiv` -/
 protected abbrev distribMulAction (e : α ≃ β) [AddCommMonoid β] :
@@ -380,10 +243,6 @@ protected abbrev distribMulAction (e : α ≃ β) [AddCommMonoid β] :
         smul_zero := by simp [zero_def, smul_def]
         smul_add := by simp [add_def, smul_def, smul_add] } :
       DistribMulAction R α)
-
-noncomputable instance [Small.{v} α] [AddCommMonoid α] [DistribMulAction R α] :
-    DistribMulAction R (Shrink.{v} α) :=
-  (equivShrink α).symm.distribMulAction R
 
 end
 
@@ -402,9 +261,6 @@ protected abbrev module (e : α ≃ β) [AddCommMonoid β] :
         add_smul := by simp [add_def, smul_def, add_smul] } :
       Module R α)
 
-noncomputable instance [Small.{v} α] [AddCommMonoid α] [Module R α] : Module R (Shrink.{v} α) :=
-  (equivShrink α).symm.module R
-
 /-- An equivalence `e : α ≃ β` gives a linear equivalence `α ≃ₗ[R] β`
 where the `R`-module structure on `α` is
 the one obtained by transporting an `R`-module structure on `β` back along `e`.
@@ -420,13 +276,6 @@ def linearEquiv (e : α ≃ β) [AddCommMonoid β] [Module R β] : by
         apply e.symm.injective
         simp only [toFun_as_coe, RingHom.id_apply, EmbeddingLike.apply_eq_iff_eq]
         exact Iff.mpr (apply_eq_iff_eq_symm_apply _) rfl }
-
-variable (α) in
-/-- Shrink `α` to a smaller universe preserves module structure. -/
-@[simps!]
-noncomputable def _root_.Shrink.linearEquiv [Small.{v} α] [AddCommMonoid α] [Module R α] :
-    Shrink.{v} α ≃ₗ[R] α :=
-  Equiv.linearEquiv _ (equivShrink α).symm
 
 end
 
@@ -456,10 +305,6 @@ lemma algebraMap_def (e : α ≃ β) [Semiring β] [Algebra R β] (r : R) :
   change e.symm (r • e 1) = e.symm (r • 1)
   simp only [Equiv.one_def, apply_symm_apply]
 
-noncomputable instance [Small.{v} α] [Semiring α] [Algebra R α] :
-    Algebra R (Shrink.{v} α) :=
-  (equivShrink α).symm.algebra _
-
 /-- An equivalence `e : α ≃ β` gives an algebra equivalence `α ≃ₐ[R] β`
 where the `R`-algebra structure on `α` is
 the one obtained by transporting an `R`-algebra structure on `β` back along `e`.
@@ -484,13 +329,6 @@ theorem algEquiv_symm_apply (e : α ≃ β) [Semiring β] [Algebra R β] (b : β
     letI := Equiv.semiring e
     letI := Equiv.algebra R e
     exact (algEquiv R e).symm b = e.symm b := rfl
-
-variable (α) in
-/-- Shrink `α` to a smaller universe preserves algebra structure. -/
-@[simps!]
-noncomputable def _root_.Shrink.algEquiv [Small.{v} α] [Semiring α] [Algebra R α] :
-    Shrink.{v} α ≃ₐ[R] α :=
-  Equiv.algEquiv _ (equivShrink α).symm
 
 end
 

--- a/Mathlib/Algebra/Field/Shrink.lean
+++ b/Mathlib/Algebra/Field/Shrink.lean
@@ -11,6 +11,8 @@ import Mathlib.Tactic.SuppressCompilation
 # Transfer field structures from `α` to `Shrink α`
 -/
 
+-- FIXME: `to_additive` is incompatible with `noncomputable section`.
+-- See https://github.com/leanprover-community/mathlib4/issues/1074.
 suppress_compilation
 
 universe v

--- a/Mathlib/Algebra/Field/Shrink.lean
+++ b/Mathlib/Algebra/Field/Shrink.lean
@@ -1,0 +1,26 @@
+/-
+Copyright (c) 2021 Kim Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+import Mathlib.Algebra.Equiv.TransferInstance
+import Mathlib.Logic.Small.Defs
+import Mathlib.Tactic.SuppressCompilation
+
+/-!
+# Transfer field structures from `α` to `Shrink α`
+-/
+
+suppress_compilation
+
+universe v
+variable {α : Type*} [Small.{v} α]
+
+namespace Shrink
+
+instance [NNRatCast α] : NNRatCast (Shrink.{v} α) := (equivShrink α).symm.nnratCast
+instance [RatCast α] : RatCast (Shrink.{v} α) := (equivShrink α).symm.ratCast
+instance [DivisionRing α] : DivisionRing (Shrink.{v} α) := (equivShrink _).symm.divisionRing
+instance [Field α] : Field (Shrink.{v} α) := (equivShrink _).symm.field
+
+end Shrink

--- a/Mathlib/Algebra/Field/Shrink.lean
+++ b/Mathlib/Algebra/Field/Shrink.lean
@@ -11,9 +11,7 @@ import Mathlib.Tactic.SuppressCompilation
 # Transfer field structures from `α` to `Shrink α`
 -/
 
--- FIXME: `to_additive` is incompatible with `noncomputable section`.
--- See https://github.com/leanprover-community/mathlib4/issues/1074.
-suppress_compilation
+noncomputable section
 
 universe v
 variable {α : Type*} [Small.{v} α]

--- a/Mathlib/Algebra/Group/Shrink.lean
+++ b/Mathlib/Algebra/Group/Shrink.lean
@@ -24,34 +24,6 @@ namespace Shrink
 @[to_additive] instance [Inv α] : Inv (Shrink.{v} α) := (equivShrink α).symm.Inv
 @[to_additive] instance [Pow α M] : Pow (Shrink.{v} α) M := (equivShrink α).symm.pow M
 
-/-- Shrink `α` to a smaller universe preserves multiplication. -/
-@[to_additive "Shrink `α` to a smaller universe preserves addition."]
-def mulEquiv [Mul α] : Shrink.{v} α ≃* α := (equivShrink α).symm.mulEquiv
-
-@[to_additive]
-instance [Semigroup α] : Semigroup (Shrink.{v} α) := (equivShrink α).symm.semigroup
-
-@[to_additive]
-instance [CommSemigroup α] : CommSemigroup (Shrink.{v} α) := (equivShrink α).symm.commSemigroup
-
-@[to_additive]
-instance [MulOneClass α] : MulOneClass (Shrink.{v} α) := (equivShrink α).symm.mulOneClass
-
-@[to_additive]
-instance [Monoid α] : Monoid (Shrink.{v} α) := (equivShrink α).symm.monoid
-
-@[to_additive]
-instance [CommMonoid α] : CommMonoid (Shrink.{v} α) := (equivShrink α).symm.commMonoid
-
-@[to_additive]
-instance [Group α] : Group (Shrink.{v} α) := (equivShrink α).symm.group
-
-@[to_additive]
-instance [CommGroup α] : CommGroup (Shrink.{v} α) := (equivShrink α).symm.commGroup
-
-@[to_additive]
-instance [Monoid M] [MulAction M α] : MulAction M (Shrink.{v} α) := (equivShrink α).symm.mulAction M
-
 end Shrink
 
 @[to_additive (attr := simp)]
@@ -95,3 +67,35 @@ lemma equivShrink_symm_inv [Inv α] (x : Shrink α) :
 @[to_additive (attr := simp)]
 lemma equivShrink_inv [Inv α] (x : α) : equivShrink α x⁻¹ = (equivShrink α x)⁻¹ := by
   simp [Equiv.inv_def]
+
+namespace Shrink
+
+/-- Shrink `α` to a smaller universe preserves multiplication. -/
+@[to_additive "Shrink `α` to a smaller universe preserves addition."]
+def mulEquiv [Mul α] : Shrink.{v} α ≃* α := (equivShrink α).symm.mulEquiv
+
+@[to_additive]
+instance [Semigroup α] : Semigroup (Shrink.{v} α) := (equivShrink α).symm.semigroup
+
+@[to_additive]
+instance [CommSemigroup α] : CommSemigroup (Shrink.{v} α) := (equivShrink α).symm.commSemigroup
+
+@[to_additive]
+instance [MulOneClass α] : MulOneClass (Shrink.{v} α) := (equivShrink α).symm.mulOneClass
+
+@[to_additive]
+instance [Monoid α] : Monoid (Shrink.{v} α) := (equivShrink α).symm.monoid
+
+@[to_additive]
+instance [CommMonoid α] : CommMonoid (Shrink.{v} α) := (equivShrink α).symm.commMonoid
+
+@[to_additive]
+instance [Group α] : Group (Shrink.{v} α) := (equivShrink α).symm.group
+
+@[to_additive]
+instance [CommGroup α] : CommGroup (Shrink.{v} α) := (equivShrink α).symm.commGroup
+
+@[to_additive]
+instance [Monoid M] [MulAction M α] : MulAction M (Shrink.{v} α) := (equivShrink α).symm.mulAction M
+
+end Shrink

--- a/Mathlib/Algebra/Group/Shrink.lean
+++ b/Mathlib/Algebra/Group/Shrink.lean
@@ -11,6 +11,8 @@ import Mathlib.Tactic.SuppressCompilation
 # Transfer group structures from `α` to `Shrink α`.
 -/
 
+-- FIXME: `to_additive` is incompatible with `noncomputable section`.
+-- See https://github.com/leanprover-community/mathlib4/issues/1074.
 suppress_compilation
 
 universe v

--- a/Mathlib/Algebra/Group/Shrink.lean
+++ b/Mathlib/Algebra/Group/Shrink.lean
@@ -3,125 +3,95 @@ Copyright (c) 2021 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
+import Mathlib.Algebra.Group.TransferInstance
 import Mathlib.Logic.Small.Defs
-import Mathlib.Algebra.Equiv.TransferInstance
+import Mathlib.Tactic.SuppressCompilation
 
 /-!
 # Transfer group structures from `α` to `Shrink α`.
 -/
 
-noncomputable section
+suppress_compilation
 
-variable {α : Type*}
+universe v
+variable {M α : Type*} [Small.{v} α]
 
--- TODO: noncomputable has to be specified explicitly. https://github.com/leanprover-community/mathlib4/issues/1074 (item 8)
+namespace Shrink
+
+@[to_additive] instance [One α] : One (Shrink.{v} α) := (equivShrink α).symm.one
+@[to_additive] instance [Mul α] : Mul (Shrink.{v} α) := (equivShrink α).symm.mul
+@[to_additive] instance [Div α] : Div (Shrink.{v} α) := (equivShrink α).symm.div
+@[to_additive] instance [Inv α] : Inv (Shrink.{v} α) := (equivShrink α).symm.Inv
+@[to_additive] instance [Pow α M] : Pow (Shrink.{v} α) M := (equivShrink α).symm.pow M
+
+/-- Shrink `α` to a smaller universe preserves multiplication. -/
+@[to_additive "Shrink `α` to a smaller universe preserves addition."]
+def mulEquiv [Mul α] : Shrink.{v} α ≃* α := (equivShrink α).symm.mulEquiv
+
 @[to_additive]
-noncomputable instance [One α] [Small α] : One (Shrink α) := (equivShrink _).symm.one
+instance [Semigroup α] : Semigroup (Shrink.{v} α) := (equivShrink α).symm.semigroup
+
+@[to_additive]
+instance [CommSemigroup α] : CommSemigroup (Shrink.{v} α) := (equivShrink α).symm.commSemigroup
+
+@[to_additive]
+instance [MulOneClass α] : MulOneClass (Shrink.{v} α) := (equivShrink α).symm.mulOneClass
+
+@[to_additive]
+instance [Monoid α] : Monoid (Shrink.{v} α) := (equivShrink α).symm.monoid
+
+@[to_additive]
+instance [CommMonoid α] : CommMonoid (Shrink.{v} α) := (equivShrink α).symm.commMonoid
+
+@[to_additive]
+instance [Group α] : Group (Shrink.{v} α) := (equivShrink α).symm.group
+
+@[to_additive]
+instance [CommGroup α] : CommGroup (Shrink.{v} α) := (equivShrink α).symm.commGroup
+
+@[to_additive]
+instance [Monoid M] [MulAction M α] : MulAction M (Shrink.{v} α) := (equivShrink α).symm.mulAction M
+
+end Shrink
 
 @[to_additive (attr := simp)]
-lemma equivShrink_symm_one [One α] [Small α] : (equivShrink α).symm 1 = 1 :=
+lemma equivShrink_symm_one [One α] : (equivShrink α).symm 1 = 1 :=
   (equivShrink α).symm_apply_apply 1
 
--- TODO: noncomputable has to be specified explicitly. https://github.com/leanprover-community/mathlib4/issues/1074 (item 8)
-@[to_additive]
-noncomputable instance [Mul α] [Small α] : Mul (Shrink α) := (equivShrink _).symm.mul
-
 @[to_additive (attr := simp)]
-lemma equivShrink_symm_mul [Mul α] [Small α] (x y : Shrink α) :
+lemma equivShrink_symm_mul [Mul α] (x y : Shrink α) :
     (equivShrink α).symm (x * y) = (equivShrink α).symm x * (equivShrink α).symm y := by
-  rw [Equiv.mul_def]
-  simp
+  simp [Equiv.mul_def]
 
 @[to_additive (attr := simp)]
-lemma equivShrink_mul [Mul α] [Small α] (x y : α) :
+lemma equivShrink_mul [Mul α] (x y : α) :
     equivShrink α (x * y) = equivShrink α x * equivShrink α y := by
-  rw [Equiv.mul_def]
-  simp
+  simp [Equiv.mul_def]
 
 @[simp]
-lemma equivShrink_symm_smul {R : Type*} [SMul R α] [Small α] (r : R) (x : Shrink α) :
-    (equivShrink α).symm (r • x) = r • (equivShrink α).symm x := by
-  rw [Equiv.smul_def]
-  simp
+lemma equivShrink_symm_smul {M : Type*} [SMul M α] (m : M) (x : Shrink α) :
+    (equivShrink α).symm (m • x) = m • (equivShrink α).symm x := by
+  simp [Equiv.smul_def]
 
 @[simp]
-lemma equivShrink_smul {R : Type*} [SMul R α] [Small α] (r : R) (x : α) :
-    equivShrink α (r • x) = r • equivShrink α x := by
-  rw [Equiv.smul_def]
-  simp
-
--- TODO: noncomputable has to be specified explicitly. https://github.com/leanprover-community/mathlib4/issues/1074 (item 8)
-@[to_additive]
-noncomputable instance [Div α] [Small α] : Div (Shrink α) := (equivShrink _).symm.div
-
+lemma equivShrink_smul {M : Type*} [SMul M α] (m : M) (x : α) :
+    equivShrink α (m • x) = m • equivShrink α x := by
+  simp [Equiv.smul_def]
 @[to_additive (attr := simp)]
-lemma equivShrink_symm_div [Div α] [Small α] (x y : Shrink α) :
+lemma equivShrink_symm_div [Div α] (x y : Shrink α) :
     (equivShrink α).symm (x / y) = (equivShrink α).symm x / (equivShrink α).symm y := by
-  rw [Equiv.div_def]
-  simp
+  simp [Equiv.div_def]
 
 @[to_additive (attr := simp)]
-lemma equivShrink_div [Div α] [Small α] (x y : α) :
+lemma equivShrink_div [Div α] (x y : α) :
     equivShrink α (x / y) = equivShrink α x / equivShrink α y := by
-  rw [Equiv.div_def]
-  simp
-
--- TODO: noncomputable has to be specified explicitly. https://github.com/leanprover-community/mathlib4/issues/1074 (item 8)
-@[to_additive]
-noncomputable instance [Inv α] [Small α] : Inv (Shrink α) := (equivShrink _).symm.Inv
+  simp [Equiv.div_def]
 
 @[to_additive (attr := simp)]
-lemma equivShrink_symm_inv [Inv α] [Small α] (x : Shrink α) :
+lemma equivShrink_symm_inv [Inv α] (x : Shrink α) :
     (equivShrink α).symm x⁻¹ = ((equivShrink α).symm x)⁻¹ := by
-  rw [Equiv.inv_def]
-  simp
+  simp [Equiv.inv_def]
 
 @[to_additive (attr := simp)]
-lemma equivShrink_inv [Inv α] [Small α] (x : α) :
-    equivShrink α x⁻¹ = (equivShrink α x)⁻¹ := by
-  rw [Equiv.inv_def]
-  simp
-
--- TODO: noncomputable has to be specified explicitly. https://github.com/leanprover-community/mathlib4/issues/1074 (item 8)
-@[to_additive]
-noncomputable instance [Semigroup α] [Small α] : Semigroup (Shrink α) :=
-  (equivShrink _).symm.semigroup
-
-instance [SemigroupWithZero α] [Small α] : SemigroupWithZero (Shrink α) :=
-  (equivShrink _).symm.semigroupWithZero
-
--- TODO: noncomputable has to be specified explicitly. https://github.com/leanprover-community/mathlib4/issues/1074 (item 8)
-@[to_additive]
-noncomputable instance [CommSemigroup α] [Small α] : CommSemigroup (Shrink α) :=
-  (equivShrink _).symm.commSemigroup
-
-instance [MulZeroClass α] [Small α] : MulZeroClass (Shrink α) :=
-  (equivShrink _).symm.mulZeroClass
-
--- TODO: noncomputable has to be specified explicitly. https://github.com/leanprover-community/mathlib4/issues/1074 (item 8)
-@[to_additive]
-noncomputable instance [MulOneClass α] [Small α] : MulOneClass (Shrink α) :=
-  (equivShrink _).symm.mulOneClass
-
-instance [MulZeroOneClass α] [Small α] : MulZeroOneClass (Shrink α) :=
-  (equivShrink _).symm.mulZeroOneClass
-
--- TODO: noncomputable has to be specified explicitly. https://github.com/leanprover-community/mathlib4/issues/1074 (item 8)
-@[to_additive]
-noncomputable instance [Monoid α] [Small α] : Monoid (Shrink α) :=
-  (equivShrink _).symm.monoid
-
--- TODO: noncomputable has to be specified explicitly. https://github.com/leanprover-community/mathlib4/issues/1074 (item 8)
-@[to_additive]
-noncomputable instance [CommMonoid α] [Small α] : CommMonoid (Shrink α) :=
-  (equivShrink _).symm.commMonoid
-
--- TODO: noncomputable has to be specified explicitly. https://github.com/leanprover-community/mathlib4/issues/1074 (item 8)
-@[to_additive]
-noncomputable instance [Group α] [Small α] : Group (Shrink α) :=
-  (equivShrink _).symm.group
-
--- TODO: noncomputable has to be specified explicitly. https://github.com/leanprover-community/mathlib4/issues/1074 (item 8)
-@[to_additive]
-noncomputable instance [CommGroup α] [Small α] : CommGroup (Shrink α) :=
-  (equivShrink _).symm.commGroup
+lemma equivShrink_inv [Inv α] (x : α) : equivShrink α x⁻¹ = (equivShrink α x)⁻¹ := by
+  simp [Equiv.inv_def]

--- a/Mathlib/Algebra/GroupWithZero/Shrink.lean
+++ b/Mathlib/Algebra/GroupWithZero/Shrink.lean
@@ -10,6 +10,8 @@ import Mathlib.Algebra.Equiv.TransferInstance
 # Transfer group with zero structures from `α` to `Shrink α`
 -/
 
+-- FIXME: `to_additive` is incompatible with `noncomputable section`.
+-- See https://github.com/leanprover-community/mathlib4/issues/1074.
 suppress_compilation
 
 universe v

--- a/Mathlib/Algebra/GroupWithZero/Shrink.lean
+++ b/Mathlib/Algebra/GroupWithZero/Shrink.lean
@@ -1,0 +1,24 @@
+/-
+Copyright (c) 2021 Kim Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+import Mathlib.Algebra.Group.Shrink
+import Mathlib.Algebra.Equiv.TransferInstance
+
+/-!
+# Transfer group with zero structures from `α` to `Shrink α`
+-/
+
+suppress_compilation
+
+universe v
+variable {M α : Type*} [Small.{v} α]
+
+instance [SemigroupWithZero α] : SemigroupWithZero (Shrink α) :=
+  (equivShrink _).symm.semigroupWithZero
+instance [MulZeroClass α] : MulZeroClass (Shrink α) := (equivShrink _).symm.mulZeroClass
+instance [MulZeroOneClass α] : MulZeroOneClass (Shrink α) := (equivShrink _).symm.mulZeroOneClass
+
+instance [Monoid M] [AddCommMonoid α] [DistribMulAction M α] : DistribMulAction M (Shrink.{v} α) :=
+  (equivShrink α).symm.distribMulAction M

--- a/Mathlib/Algebra/GroupWithZero/Shrink.lean
+++ b/Mathlib/Algebra/GroupWithZero/Shrink.lean
@@ -10,9 +10,7 @@ import Mathlib.Algebra.Equiv.TransferInstance
 # Transfer group with zero structures from `α` to `Shrink α`
 -/
 
--- FIXME: `to_additive` is incompatible with `noncomputable section`.
--- See https://github.com/leanprover-community/mathlib4/issues/1074.
-suppress_compilation
+noncomputable section
 
 universe v
 variable {M α : Type*} [Small.{v} α]

--- a/Mathlib/Algebra/Module/FinitePresentation.lean
+++ b/Mathlib/Algebra/Module/FinitePresentation.lean
@@ -3,7 +3,6 @@ Copyright (c) 2024 Andrew Yang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andrew Yang
 -/
-import Mathlib.Algebra.Module.Shrink
 import Mathlib.LinearAlgebra.FreeModule.Finite.Basic
 import Mathlib.LinearAlgebra.Isomorphisms
 import Mathlib.LinearAlgebra.TensorProduct.RightExactness
@@ -94,9 +93,9 @@ theorem Module.FinitePresentation.equiv_quotient [Module.FinitePresentation R M]
     ∃ (L : Type v) (_ : AddCommGroup L) (_ : Module R L) (K : Submodule R L)
       (_ : M ≃ₗ[R] L ⧸ K), Module.Free R L ∧ Module.Finite R L ∧ K.FG :=
   have ⟨_n, _K, e, fg⟩ := Module.FinitePresentation.exists_fin R M
-  let es := linearEquivShrink
-  ⟨_, inferInstance, inferInstance, _, e ≪≫ₗ Submodule.Quotient.equiv _ _ (es ..) rfl,
-    .of_equiv (es ..), .equiv (es ..), fg.map (es ..).toLinearMap⟩
+  let es := Shrink.linearEquiv
+  ⟨_, inferInstance, inferInstance, _, e ≪≫ₗ Submodule.Quotient.equiv _ _ (es ..).symm rfl,
+    .of_equiv (es ..).symm, .equiv (es ..).symm, fg.map (es ..).symm.toLinearMap⟩
 
 end
 

--- a/Mathlib/Algebra/Module/Injective.lean
+++ b/Mathlib/Algebra/Module/Injective.lean
@@ -3,9 +3,8 @@ Copyright (c) 2022 Jujian Zhang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jujian Zhang
 -/
+import Mathlib.Algebra.Module.Shrink
 import Mathlib.LinearAlgebra.LinearPMap
-import Mathlib.Algebra.Equiv.TransferInstance
-import Mathlib.Logic.Small.Basic
 import Mathlib.RingTheory.Ideal.Defs
 
 /-!
@@ -380,7 +379,7 @@ protected theorem injective (h : Module.Baer R Q) : Module.Injective R Q where
 
 protected theorem of_injective [Small.{v} R] (inj : Module.Injective R Q) : Module.Baer R Q := by
   intro I g
-  let eI := Shrink.linearEquiv I R
+  let eI := Shrink.linearEquiv R I
   let eR := Shrink.linearEquiv R R
   obtain ⟨g', hg'⟩ := Module.Injective.out (eR.symm.toLinearMap ∘ₗ I.subtype ∘ₗ eI.toLinearMap)
     (eR.symm.injective.comp <| Subtype.val_injective.comp eI.injective) (g ∘ₗ eI.toLinearMap)

--- a/Mathlib/Algebra/Module/Injective.lean
+++ b/Mathlib/Algebra/Module/Injective.lean
@@ -5,6 +5,7 @@ Authors: Jujian Zhang
 -/
 import Mathlib.Algebra.Module.Shrink
 import Mathlib.LinearAlgebra.LinearPMap
+import Mathlib.Logic.Small.Basic
 import Mathlib.RingTheory.Ideal.Defs
 
 /-!

--- a/Mathlib/Algebra/Module/Projective.lean
+++ b/Mathlib/Algebra/Module/Projective.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Kevin Buzzard. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kevin Buzzard, Antoine Labelle
 -/
-import Mathlib.Algebra.Equiv.TransferInstance
+import Mathlib.Algebra.Module.Shrink
 import Mathlib.LinearAlgebra.TensorProduct.Basis
 import Mathlib.Logic.UnivLE
 

--- a/Mathlib/Algebra/Module/Shrink.lean
+++ b/Mathlib/Algebra/Module/Shrink.lean
@@ -27,3 +27,9 @@ variable (R α) in
 def linearEquiv : Shrink.{v} α ≃ₗ[R] α := (equivShrink α).symm.linearEquiv _
 
 end Shrink
+
+/-- A small module is linearly equivalent to its small model. -/
+@[deprecated Shrink.linearEquiv (since := "2025-07-11")]
+def linearEquivShrink (α β) [Semiring α] [AddCommMonoid β] [Module α β] [Small β] :
+    β ≃ₗ[α] Shrink β :=
+  ((equivShrink β).symm.linearEquiv α).symm

--- a/Mathlib/Algebra/Module/Shrink.lean
+++ b/Mathlib/Algebra/Module/Shrink.lean
@@ -10,6 +10,8 @@ import Mathlib.Algebra.Group.Shrink
 # Transfer module and algebra structures from `α` to `Shrink α`
 -/
 
+-- FIXME: `to_additive` is incompatible with `noncomputable section`.
+-- See https://github.com/leanprover-community/mathlib4/issues/1074.
 suppress_compilation
 
 universe v

--- a/Mathlib/Algebra/Module/Shrink.lean
+++ b/Mathlib/Algebra/Module/Shrink.lean
@@ -3,11 +3,11 @@ Copyright (c) 2021 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
-import Mathlib.Algebra.Group.Shrink
+import Mathlib.Algebra.Equiv.TransferInstance
 import Mathlib.Algebra.Ring.Shrink
 
 /-!
-# Transfer module and algebra structures from `α` to `Shrink α`.
+# Transfer module and algebra structures from `α` to `Shrink α`
 -/
 
 noncomputable section

--- a/Mathlib/Algebra/Module/Shrink.lean
+++ b/Mathlib/Algebra/Module/Shrink.lean
@@ -4,28 +4,24 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 import Mathlib.Algebra.Equiv.TransferInstance
-import Mathlib.Algebra.Ring.Shrink
+import Mathlib.Algebra.Group.Shrink
 
 /-!
 # Transfer module and algebra structures from `α` to `Shrink α`
 -/
 
-noncomputable section
+suppress_compilation
 
-variable {α β : Type*}
+universe v
+variable {R α : Type*} [Small.{v} α] [Semiring R] [AddCommMonoid α] [Module R α]
 
-instance [Semiring α] [AddCommMonoid β] [Module α β] [Small β] : Module α (Shrink β) :=
-  (equivShrink _).symm.module α
+namespace Shrink
 
-/-- A small module is linearly equivalent to its small model. -/
-def linearEquivShrink (α β) [Semiring α] [AddCommMonoid β] [Module α β] [Small β] :
-    β ≃ₗ[α] Shrink β :=
-  ((equivShrink β).symm.linearEquiv α).symm
+instance : Module R (Shrink.{v} α) := (equivShrink α).symm.module R
 
-instance [CommSemiring α] [Semiring β] [Algebra α β] [Small β] : Algebra α (Shrink β) :=
-  (equivShrink _).symm.algebra α
+variable (R α) in
+/-- Shrinking `α` to a smaller universe preserves module structure. -/
+@[simps!]
+def linearEquiv : Shrink.{v} α ≃ₗ[R] α := (equivShrink α).symm.linearEquiv _
 
-/-- A small algebra is algebra equivalent to its small model. -/
-def algEquivShrink (α β) [CommSemiring α] [Semiring β] [Algebra α β] [Small β] :
-    β ≃ₐ[α] Shrink β :=
-  ((equivShrink β).symm.algEquiv α).symm
+end Shrink

--- a/Mathlib/Algebra/Ring/Shrink.lean
+++ b/Mathlib/Algebra/Ring/Shrink.lean
@@ -10,6 +10,8 @@ import Mathlib.Algebra.Group.Shrink
 # Transfer ring structures from `α` to `Shrink α`
 -/
 
+-- FIXME: `to_additive` is incompatible with `noncomputable section`.
+-- See https://github.com/leanprover-community/mathlib4/issues/1074.
 suppress_compilation
 
 namespace Shrink

--- a/Mathlib/Algebra/Ring/Shrink.lean
+++ b/Mathlib/Algebra/Ring/Shrink.lean
@@ -10,9 +10,7 @@ import Mathlib.Algebra.Group.Shrink
 # Transfer ring structures from `α` to `Shrink α`
 -/
 
--- FIXME: `to_additive` is incompatible with `noncomputable section`.
--- See https://github.com/leanprover-community/mathlib4/issues/1074.
-suppress_compilation
+noncomputable section
 
 namespace Shrink
 universe v

--- a/Mathlib/Algebra/Ring/Shrink.lean
+++ b/Mathlib/Algebra/Ring/Shrink.lean
@@ -3,61 +3,56 @@ Copyright (c) 2021 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
-import Mathlib.Logic.Small.Defs
 import Mathlib.Algebra.Equiv.TransferInstance
+import Mathlib.Algebra.Group.Shrink
 
 /-!
-# Transfer ring structures from `α` to `Shrink α`.
+# Transfer ring structures from `α` to `Shrink α`
 -/
 
-noncomputable section
+suppress_compilation
 
-variable {α : Type*}
+namespace Shrink
+universe v
+variable {α : Type*} [Small.{v} α]
 
-instance [NonUnitalNonAssocSemiring α] [Small α] : NonUnitalNonAssocSemiring (Shrink α) :=
-  (equivShrink _).symm.nonUnitalNonAssocSemiring
+variable (α) in
+/-- Shrink `α` to a smaller universe preserves ring structure. -/
+def ringEquiv [Add α] [Mul α] : Shrink.{v} α ≃+* α := (equivShrink α).symm.ringEquiv
 
-instance [NonUnitalSemiring α] [Small α] : NonUnitalSemiring (Shrink α) :=
-  (equivShrink _).symm.nonUnitalSemiring
+instance [NonUnitalNonAssocSemiring α] : NonUnitalNonAssocSemiring (Shrink.{v} α) :=
+  (equivShrink α).symm.nonUnitalNonAssocSemiring
 
-instance [AddMonoidWithOne α] [Small α] : AddMonoidWithOne (Shrink α) :=
-  (equivShrink _).symm.addMonoidWithOne
+instance [NonUnitalSemiring α] : NonUnitalSemiring (Shrink.{v} α) :=
+  (equivShrink α).symm.nonUnitalSemiring
 
-instance [AddGroupWithOne α] [Small α] : AddGroupWithOne (Shrink α) :=
-  (equivShrink _).symm.addGroupWithOne
+instance [AddMonoidWithOne α] : AddMonoidWithOne (Shrink.{v} α) :=
+  (equivShrink α).symm.addMonoidWithOne
 
-instance [NonAssocSemiring α] [Small α] : NonAssocSemiring (Shrink α) :=
-  (equivShrink _).symm.nonAssocSemiring
+instance [AddGroupWithOne α] : AddGroupWithOne (Shrink.{v} α) :=
+  (equivShrink α).symm.addGroupWithOne
 
-instance [Semiring α] [Small α] : Semiring (Shrink α) :=
-  (equivShrink _).symm.semiring
+instance [NonAssocSemiring α] : NonAssocSemiring (Shrink.{v} α) :=
+  (equivShrink α).symm.nonAssocSemiring
 
-instance [NonUnitalCommSemiring α] [Small α] : NonUnitalCommSemiring (Shrink α) :=
-  (equivShrink _).symm.nonUnitalCommSemiring
+instance [Semiring α] : Semiring (Shrink.{v} α) := (equivShrink α).symm.semiring
 
-instance [CommSemiring α] [Small α] : CommSemiring (Shrink α) :=
-  (equivShrink _).symm.commSemiring
+instance [NonUnitalCommSemiring α] : NonUnitalCommSemiring (Shrink.{v} α) :=
+  (equivShrink α).symm.nonUnitalCommSemiring
 
-instance [NonUnitalNonAssocRing α] [Small α] : NonUnitalNonAssocRing (Shrink α) :=
-  (equivShrink _).symm.nonUnitalNonAssocRing
+instance [CommSemiring α] : CommSemiring (Shrink.{v} α) := (equivShrink α).symm.commSemiring
 
-instance [NonUnitalRing α] [Small α] : NonUnitalRing (Shrink α) :=
-  (equivShrink _).symm.nonUnitalRing
+instance [NonUnitalNonAssocRing α] : NonUnitalNonAssocRing (Shrink.{v} α) :=
+  (equivShrink α).symm.nonUnitalNonAssocRing
 
-instance [Ring α] [Small α] : Ring (Shrink α) :=
-  (equivShrink _).symm.ring
+instance [NonUnitalRing α] : NonUnitalRing (Shrink.{v} α) := (equivShrink α).symm.nonUnitalRing
+instance [NonAssocRing α] : NonAssocRing (Shrink.{v} α) := (equivShrink α).symm.nonAssocRing
+instance [Ring α] : Ring (Shrink.{v} α) := (equivShrink α).symm.ring
 
-instance [NonUnitalCommRing α] [Small α] : NonUnitalCommRing (Shrink α) :=
-  (equivShrink _).symm.nonUnitalCommRing
+instance [NonUnitalCommRing α] : NonUnitalCommRing (Shrink.{v} α) :=
+  (equivShrink α).symm.nonUnitalCommRing
 
-instance [CommRing α] [Small α] : CommRing (Shrink α) :=
-  (equivShrink _).symm.commRing
+instance [CommRing α] : CommRing (Shrink.{v} α) := (equivShrink α).symm.commRing
+instance [Semiring α] [IsDomain α] : IsDomain (Shrink.{v} α) := Equiv.isDomain (Shrink.ringEquiv α)
 
-instance [Nontrivial α] [Small α] : Nontrivial (Shrink α) :=
-  (equivShrink _).symm.nontrivial
-
-instance [DivisionRing α] [Small α] : DivisionRing (Shrink α) :=
-  (equivShrink _).symm.divisionRing
-
-instance [Field α] [Small α] : Field (Shrink α) :=
-  (equivShrink _).symm.field
+end Shrink

--- a/Mathlib/RingTheory/Flat/Basic.lean
+++ b/Mathlib/RingTheory/Flat/Basic.lean
@@ -120,7 +120,7 @@ theorem rTensor_preserves_injective_linearMap [Flat R M] (f : N →ₗ[R] P)
   refine rTensor_injective_of_fg fun N P Nfg Pfg le ↦ ?_
   rw [← Finite.iff_fg] at Nfg Pfg
   have := Finite.small R P
-  let se := (Shrink.linearEquiv.{_, u} P R).symm
+  let se := (Shrink.linearEquiv R P).symm
   have := Module.Finite.equiv se
   rw [rTensor_injective_iff_subtype (fun _ _ ↦ (Subtype.ext <| hf <| Subtype.ext_iff.mp ·)) se]
   exact (flat_iff R M).mp ‹_› _ (Finite.iff_fg.mp inferInstance)
@@ -137,7 +137,7 @@ lemma iff_rTensor_preserves_injective_linearMapₛ [Small.{v'} R] : Flat R M ↔
       (f : N →ₗ[R] N'), Function.Injective f → Function.Injective (f.rTensor M) :=
   ⟨by introv _; apply rTensor_preserves_injective_linearMap, fun h ↦ ⟨fun P _ _ _ _ _ ↦ by
     have := Finite.small.{v'} R P
-    rw [rTensor_injective_iff_subtype Subtype.val_injective (Shrink.linearEquiv.{_, v'} P R).symm]
+    rw [rTensor_injective_iff_subtype Subtype.val_injective (Shrink.linearEquiv R P).symm]
     exact h _ Subtype.val_injective⟩⟩
 
 /-- `M` is flat if and only if `𝟙 M ⊗ f` is injective whenever `f` is an injective linear map
@@ -192,11 +192,11 @@ lemma of_ulift [Flat R (ULift.{v'} M)] : Flat R M :=
   of_linearEquiv ULift.moduleEquiv.symm
 
 instance shrink [Small.{v'} M] [Flat R M] : Flat R (Shrink.{v'} M) :=
-  of_linearEquiv (Shrink.linearEquiv M R)
+  of_linearEquiv (Shrink.linearEquiv R M)
 
 -- Making this an instance causes an infinite sequence `M → Shrink M → Shrink (Shrink M) → ...`.
 lemma of_shrink [Small.{v'} M] [Flat R (Shrink.{v'} M)] : Flat R M :=
-  of_linearEquiv (Shrink.linearEquiv M R).symm
+  of_linearEquiv (Shrink.linearEquiv R M).symm
 
 section DirectSum
 


### PR DESCRIPTION
Split `Algebra.Small.Group` into
* `Algebra.Group.Shrink`
* `Algebra.GroupWithZero.Shrink`

Split `Algebra.Small.Ring` into
* `Algebra.Ring.Shrink`
* `Algebra.Field.Shrink`

Split `Algebra.Small.Module` into
* `Algebra.Module.Shrink`
* `Algebra.Algebra.Shrink`

Almost all of this duplicated the material in `Algebra.Equiv.TransferInstance`, which we therefore remove.

This is the second part of #26732, split off for Eric's convenience.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
