### PR TITLE
[Merged by Bors] - style: replace `HEq x y` with `x ≍ y`

### DIFF
--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/InducedMaps.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/InducedMaps.lean
@@ -88,7 +88,7 @@ include hfg
 /-- If `f(p(t) = g(q(t))` for two paths `p` and `q`, then the induced path homotopy classes
 `f(p)` and `g(p)` are the same as well, despite having a priori different types -/
 theorem heq_path_of_eq_image :
-    HEq ((πₘ (TopCat.ofHom f)).map ⟦p⟧) ((πₘ (TopCat.ofHom g)).map ⟦q⟧) := by
+    (πₘ (TopCat.ofHom f)).map ⟦p⟧ ≍ (πₘ (TopCat.ofHom g)).map ⟦q⟧ := by
   simp only [map_eq, ← Path.Homotopic.map_lift]; apply Path.Homotopic.hpath_hext; exact hfg
 
 private theorem start_path : f x₀ = g x₂ := by convert hfg 0 <;> simp only [Path.source]

--- a/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialSet/NerveAdjunction.lean
@@ -440,15 +440,15 @@ instance nerveFunctor₂.full : nerveFunctor₂.{u, u}.Full where
       rw [eq0] at lem0
       rw [eq1] at lem1
       rw [eq2] at lem2
-      replace lem0 : HEq (uF'.map k) (Fhk.map' 1 2) := by
+      replace lem0 : uF'.map k ≍ Fhk.map' 1 2 := by
         refine HEq.trans (b := Fk.map' 0 1) ?_ lem0
         simp [uF', nerveFunctor₂, SSet.truncation,
           ReflQuiv.comp_eq_comp, OneTruncation₂.nerveHomEquiv, Fk, uF]
-      replace lem2 : HEq (uF'.map h) (Fhk.map' 0 1) := by
+      replace lem2 : uF'.map h ≍ Fhk.map' 0 1 := by
         refine HEq.trans (b := Fh.map' 0 1) ?_ lem2
         simp [uF', nerveFunctor₂, SSet.truncation,
           ReflQuiv.comp_eq_comp, OneTruncation₂.nerveHomEquiv, uF, ComposableArrows.hom, Fh]
-      replace lem1 : HEq (uF'.map (h ≫ k)) (Fhk.map' 0 2) := by
+      replace lem1 : uF'.map (h ≫ k) ≍ Fhk.map' 0 2 := by
         refine HEq.trans (b := Fhk'.map' 0 1) ?_ lem1
         simp only [Nat.reduceAdd,
           Fin.zero_eta, Fin.isValue, Fin.mk_one,

--- a/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
@@ -209,7 +209,7 @@ def HasForget₂.mk' {C : Type u} {D : Type u'} [Category.{v} C] [HasForget.{w} 
     [Category.{v'} D] [HasForget.{w} D]
     (obj : C → D) (h_obj : ∀ X, (forget D).obj (obj X) = (forget C).obj X)
     (map : ∀ {X Y}, (X ⟶ Y) → (obj X ⟶ obj Y))
-    (h_map : ∀ {X Y} {f : X ⟶ Y}, HEq ((forget D).map (map f)) ((forget C).map f)) :
+    (h_map : ∀ {X Y} {f : X ⟶ Y}, (forget D).map (map f) ≍ (forget C).map f) :
     HasForget₂ C D where
   forget₂ := Functor.Faithful.div _ _ _ @h_obj _ @h_map
   forget_comp := by apply Functor.Faithful.div_comp

--- a/Mathlib/CategoryTheory/EqToHom.lean
+++ b/Mathlib/CategoryTheory/EqToHom.lean
@@ -52,24 +52,24 @@ theorem eqToHom_trans {X Y Z : C} (p : X = Y) (q : Y = Z) :
   simp
 
 /-- `eqToHom h` is heterogeneously equal to the identity of its domain. -/
-lemma eqToHom_heq_id_dom (X Y : C) (h : X = Y) : HEq (eqToHom h) (𝟙 X) := by
+lemma eqToHom_heq_id_dom (X Y : C) (h : X = Y) : eqToHom h ≍ 𝟙 X := by
   subst h; rfl
 
 /-- `eqToHom h` is heterogeneously equal to the identity of its codomain. -/
-lemma eqToHom_heq_id_cod (X Y : C) (h : X = Y) : HEq (eqToHom h) (𝟙 Y) := by
+lemma eqToHom_heq_id_cod (X Y : C) (h : X = Y) : eqToHom h ≍ 𝟙 Y := by
   subst h; rfl
 
 /-- Two morphisms are conjugate via eqToHom if and only if they are heterogeneously equal.
 Note this used to be in the Functor namespace, where it doesn't belong. -/
 theorem conj_eqToHom_iff_heq {W X Y Z : C} (f : W ⟶ X) (g : Y ⟶ Z) (h : W = Y) (h' : X = Z) :
-    f = eqToHom h ≫ g ≫ eqToHom h'.symm ↔ HEq f g := by
+    f = eqToHom h ≫ g ≫ eqToHom h'.symm ↔ f ≍ g := by
   cases h
   cases h'
   simp
 
 theorem conj_eqToHom_iff_heq' {C} [Category C] {W X Y Z : C}
     (f : W ⟶ X) (g : Y ⟶ Z) (h : W = Y) (h' : Z = X) :
-    f = eqToHom h ≫ g ≫ eqToHom h' ↔ HEq f g := conj_eqToHom_iff_heq _ _ _ h'.symm
+    f = eqToHom h ≫ g ≫ eqToHom h' ↔ f ≍ g := conj_eqToHom_iff_heq _ _ _ h'.symm
 
 theorem comp_eqToHom_iff {X Y Y' : C} (p : Y = Y') (f : X ⟶ Y) (g : X ⟶ Y') :
     f ≫ eqToHom p = g ↔ f = g ≫ eqToHom p.symm :=
@@ -82,38 +82,38 @@ theorem eqToHom_comp_iff {X X' Y : C} (p : X = X') (f : X ⟶ Y) (g : X' ⟶ Y) 
     mpr := fun h => h ▸ by simp }
 
 theorem eqToHom_comp_heq {C} [Category C] {W X Y : C}
-    (f : Y ⟶ X) (h : W = Y) : HEq (eqToHom h ≫ f) f := by
+    (f : Y ⟶ X) (h : W = Y) : eqToHom h ≫ f ≍ f := by
   rw [← conj_eqToHom_iff_heq _ _ h rfl, eqToHom_refl, Category.comp_id]
 
 @[simp] theorem eqToHom_comp_heq_iff {C} [Category C] {W X Y Z Z' : C}
     (f : Y ⟶ X) (g : Z ⟶ Z') (h : W = Y) :
-    HEq (eqToHom h ≫ f) g ↔ HEq f g :=
+    eqToHom h ≫ f ≍ g ↔ f ≍ g :=
   ⟨(eqToHom_comp_heq ..).symm.trans, (eqToHom_comp_heq ..).trans⟩
 
 @[simp] theorem heq_eqToHom_comp_iff {C} [Category C] {W X Y Z Z' : C}
     (f : Y ⟶ X) (g : Z ⟶ Z') (h : W = Y) :
-    HEq g (eqToHom h ≫ f) ↔ HEq g f :=
+    g ≍ eqToHom h ≫ f ↔ g ≍ f :=
   ⟨(·.trans (eqToHom_comp_heq ..)), (·.trans (eqToHom_comp_heq ..).symm)⟩
 
 theorem comp_eqToHom_heq {C} [Category C] {X Y Z : C}
-    (f : X ⟶ Y) (h : Y = Z) : HEq (f ≫ eqToHom h) f := by
+    (f : X ⟶ Y) (h : Y = Z) : f ≫ eqToHom h ≍ f := by
   rw [← conj_eqToHom_iff_heq' _ _ rfl h, eqToHom_refl, Category.id_comp]
 
 @[simp] theorem comp_eqToHom_heq_iff {C} [Category C] {W X Y Z Z' : C}
     (f : X ⟶ Y) (g : Z ⟶ Z') (h : Y = W) :
-    HEq (f ≫ eqToHom h) g ↔ HEq f g :=
+    f ≫ eqToHom h ≍ g ↔ f ≍ g :=
   ⟨(comp_eqToHom_heq ..).symm.trans, (comp_eqToHom_heq ..).trans⟩
 
 @[simp] theorem heq_comp_eqToHom_iff {C} [Category C] {W X Y Z Z' : C}
     (f : X ⟶ Y) (g : Z ⟶ Z') (h : Y = W) :
-    HEq g (f ≫ eqToHom h) ↔ HEq g f :=
+    g ≍ f ≫ eqToHom h ↔ g ≍ f :=
   ⟨(·.trans (comp_eqToHom_heq ..)), (·.trans (comp_eqToHom_heq ..).symm)⟩
 
 theorem heq_comp {C} [Category C] {X Y Z X' Y' Z' : C}
     {f : X ⟶ Y} {g : Y ⟶ Z} {f' : X' ⟶ Y'} {g' : Y' ⟶ Z'}
     (eq1 : X = X') (eq2 : Y = Y') (eq3 : Z = Z')
-    (H1 : HEq f f') (H2 : HEq g g') :
-    HEq (f ≫ g) (f' ≫ g') := by
+    (H1 : f ≍ f') (H2 : g ≍ g') :
+    f ≫ g ≍ f' ≫ g' := by
   cases eq1; cases eq2; cases eq3; cases H1; cases H2; rfl
 
 variable {β : Sort*}
@@ -248,7 +248,7 @@ lemma ext_of_iso {F G : C ⥤ D} (e : F ≅ G) (hobj : ∀ X, F.obj X = G.obj X)
 
 /-- Proving equality between functors using heterogeneous equality. -/
 theorem hext {F G : C ⥤ D} (h_obj : ∀ X, F.obj X = G.obj X)
-    (h_map : ∀ (X Y) (f : X ⟶ Y), HEq (F.map f) (G.map f)) : F = G :=
+    (h_map : ∀ (X Y) (f : X ⟶ Y), F.map f ≍ G.map f) : F = G :=
   Functor.ext h_obj fun _ _ f => (conj_eqToHom_iff_heq _ _ (h_obj _) (h_obj _)).2 <| h_map _ _ f
 
 -- Using equalities between functors.
@@ -272,30 +272,30 @@ section HEq
 variable {E : Type u₃} [Category.{v₃} E] {F G : C ⥤ D} {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z}
 
 theorem map_comp_heq (hx : F.obj X = G.obj X) (hy : F.obj Y = G.obj Y) (hz : F.obj Z = G.obj Z)
-    (hf : HEq (F.map f) (G.map f)) (hg : HEq (F.map g) (G.map g)) :
-    HEq (F.map (f ≫ g)) (G.map (f ≫ g)) := by
+    (hf : F.map f ≍ G.map f) (hg : F.map g ≍ G.map g) :
+    F.map (f ≫ g) ≍ G.map (f ≫ g) := by
   rw [F.map_comp, G.map_comp]
   congr
 
 theorem map_comp_heq' (hobj : ∀ X : C, F.obj X = G.obj X)
-    (hmap : ∀ {X Y} (f : X ⟶ Y), HEq (F.map f) (G.map f)) :
-    HEq (F.map (f ≫ g)) (G.map (f ≫ g)) := by
+    (hmap : ∀ {X Y} (f : X ⟶ Y), F.map f ≍ G.map f) :
+    F.map (f ≫ g) ≍ G.map (f ≫ g) := by
   rw [Functor.hext hobj fun _ _ => hmap]
 
-theorem precomp_map_heq (H : E ⥤ C) (hmap : ∀ {X Y} (f : X ⟶ Y), HEq (F.map f) (G.map f)) {X Y : E}
-    (f : X ⟶ Y) : HEq ((H ⋙ F).map f) ((H ⋙ G).map f) :=
+theorem precomp_map_heq (H : E ⥤ C) (hmap : ∀ {X Y} (f : X ⟶ Y), F.map f ≍ G.map f) {X Y : E}
+    (f : X ⟶ Y) : (H ⋙ F).map f ≍ (H ⋙ G).map f :=
   hmap _
 
 theorem postcomp_map_heq (H : D ⥤ E) (hx : F.obj X = G.obj X) (hy : F.obj Y = G.obj Y)
-    (hmap : HEq (F.map f) (G.map f)) : HEq ((F ⋙ H).map f) ((G ⋙ H).map f) := by
+    (hmap : F.map f ≍ G.map f) : (F ⋙ H).map f ≍ (G ⋙ H).map f := by
   dsimp
   congr
 
 theorem postcomp_map_heq' (H : D ⥤ E) (hobj : ∀ X : C, F.obj X = G.obj X)
-    (hmap : ∀ {X Y} (f : X ⟶ Y), HEq (F.map f) (G.map f)) :
-    HEq ((F ⋙ H).map f) ((G ⋙ H).map f) := by rw [Functor.hext hobj fun _ _ => hmap]
+    (hmap : ∀ {X Y} (f : X ⟶ Y), F.map f ≍ G.map f) :
+    (F ⋙ H).map f ≍ (G ⋙ H).map f := by rw [Functor.hext hobj fun _ _ => hmap]
 
-theorem hcongr_hom {F G : C ⥤ D} (h : F = G) {X Y} (f : X ⟶ Y) : HEq (F.map f) (G.map f) := by
+theorem hcongr_hom {F G : C ⥤ D} (h : F = G) {X Y} (f : X ⟶ Y) : F.map f ≍ G.map f := by
   rw [h]
 
 end HEq

--- a/Mathlib/CategoryTheory/Functor/FullyFaithful.lean
+++ b/Mathlib/CategoryTheory/Functor/FullyFaithful.lean
@@ -296,7 +296,7 @@ variable (F G)
 /-- “Divide” a functor by a faithful functor. -/
 protected def Faithful.div (F : C ⥤ E) (G : D ⥤ E) [G.Faithful] (obj : C → D)
     (h_obj : ∀ X, G.obj (obj X) = F.obj X) (map : ∀ {X Y}, (X ⟶ Y) → (obj X ⟶ obj Y))
-    (h_map : ∀ {X Y} {f : X ⟶ Y}, HEq (G.map (map f)) (F.map f)) : C ⥤ D :=
+    (h_map : ∀ {X Y} {f : X ⟶ Y}, G.map (map f) ≍ F.map f) : C ⥤ D :=
   { obj, map := @map,
     map_id := by
       intros X
@@ -318,7 +318,7 @@ protected def Faithful.div (F : C ⥤ E) (G : D ⥤ E) [G.Faithful] (obj : C →
 -- CategoryTheory.Equivalence → CategoryTheory.FullyFaithful
 theorem Faithful.div_comp (F : C ⥤ E) [F.Faithful] (G : D ⥤ E) [G.Faithful] (obj : C → D)
     (h_obj : ∀ X, G.obj (obj X) = F.obj X) (map : ∀ {X Y}, (X ⟶ Y) → (obj X ⟶ obj Y))
-    (h_map : ∀ {X Y} {f : X ⟶ Y}, HEq (G.map (map f)) (F.map f)) :
+    (h_map : ∀ {X Y} {f : X ⟶ Y}, G.map (map f) ≍ F.map f) :
     Faithful.div F G obj @h_obj @map @h_map ⋙ G = F := by
   obtain ⟨⟨F_obj, _⟩, _, _⟩ := F; obtain ⟨⟨G_obj, _⟩, _, _⟩ := G
   unfold Faithful.div Functor.comp
@@ -331,7 +331,7 @@ theorem Faithful.div_comp (F : C ⥤ E) [F.Faithful] (G : D ⥤ E) [G.Faithful] 
 
 theorem Faithful.div_faithful (F : C ⥤ E) [F.Faithful] (G : D ⥤ E) [G.Faithful] (obj : C → D)
     (h_obj : ∀ X, G.obj (obj X) = F.obj X) (map : ∀ {X Y}, (X ⟶ Y) → (obj X ⟶ obj Y))
-    (h_map : ∀ {X Y} {f : X ⟶ Y}, HEq (G.map (map f)) (F.map f)) :
+    (h_map : ∀ {X Y} {f : X ⟶ Y}, G.map (map f) ≍ F.map f) :
     Functor.Faithful (Faithful.div F G obj @h_obj @map @h_map) :=
   (Faithful.div_comp F G _ h_obj _ @h_map).faithful_of_comp
 

--- a/Mathlib/CategoryTheory/GlueData.lean
+++ b/Mathlib/CategoryTheory/GlueData.lean
@@ -402,7 +402,7 @@ instance (D : GlueData' C) (i j k : D.J) :
     simp only [GlueData'.f', dif_pos hik]
     infer_instance
   else
-    have {X Y Z : C} (f : X ⟶ Y) (e : Z = X) : HEq (eqToHom e ≫ f) f := by subst e; simp
+    have {X Y Z : C} (f : X ⟶ Y) (e : Z = X) : eqToHom e ≫ f ≍ f := by subst e; simp
     convert D.f_hasPullback i j k hij hik <;> simp [GlueData'.f', hij, hik, this]
 
 open scoped Classical in

--- a/Mathlib/Combinatorics/Enumerative/Composition.lean
+++ b/Mathlib/Combinatorics/Enumerative/Composition.lean
@@ -583,7 +583,7 @@ protected def cast (c : Composition m) (hmn : m = n) : Composition n where
 @[simp]
 theorem cast_rfl (c : Composition n) : c.cast rfl = c := rfl
 
-theorem cast_heq (c : Composition m) (hmn : m = n) : HEq (c.cast hmn) c := by subst m; rfl
+theorem cast_heq (c : Composition m) (hmn : m = n) : c.cast hmn ≍ c := by subst m; rfl
 
 theorem cast_eq_cast (c : Composition m) (hmn : m = n) :
     c.cast hmn = cast (hmn ▸ rfl) c := by

--- a/Mathlib/Combinatorics/Quiver/Arborescence.lean
+++ b/Mathlib/Combinatorics/Quiver/Arborescence.lean
@@ -55,7 +55,7 @@ instance {V : Type u} [Quiver V] [Arborescence V] (b : V) : Unique (Path (root V
   - show that every vertex other than `r` has an arrow to it. -/
 noncomputable def arborescenceMk {V : Type u} [Quiver V] (r : V) (height : V → ℕ)
     (height_lt : ∀ ⦃a b⦄, (a ⟶ b) → height a < height b)
-    (unique_arrow : ∀ ⦃a b c : V⦄ (e : a ⟶ c) (f : b ⟶ c), a = b ∧ HEq e f)
+    (unique_arrow : ∀ ⦃a b c : V⦄ (e : a ⟶ c) (f : b ⟶ c), a = b ∧ e ≍ f)
     (root_or_arrow : ∀ b, b = r ∨ ∃ a, Nonempty (a ⟶ b)) :
     Arborescence V where
   root := r

--- a/Mathlib/Combinatorics/Quiver/Basic.lean
+++ b/Mathlib/Combinatorics/Quiver/Basic.lean
@@ -104,7 +104,7 @@ lemma homOfEq_injective {X X' Y Y' : V} (hX : X = X') (hY : Y = Y')
 lemma homOfEq_rfl {X Y : V} (f : X ⟶ Y) : Quiver.homOfEq f rfl rfl = f := rfl
 
 lemma heq_of_homOfEq_ext {X Y X' Y' : V} (hX : X = X') (hY : Y = Y') {f : X ⟶ Y} {f' : X' ⟶ Y'}
-    (e : Quiver.homOfEq f hX hY = f') : HEq f f' := by
+    (e : Quiver.homOfEq f hX hY = f') : f ≍ f' := by
   subst hX hY
   rw [Quiver.homOfEq_rfl] at e
   rw [e]
@@ -120,17 +120,17 @@ lemma eq_homOfEq_iff {X X' Y Y' : V} (f : X ⟶ Y) (g : X' ⟶ Y')
   subst hX hY; simp
 
 lemma homOfEq_heq {X Y X' Y' : V} (hX : X = X') (hY : Y = Y') (f : X ⟶ Y) :
-    HEq (homOfEq f hX hY) f := by
+    homOfEq f hX hY ≍ f := by
   cases hX; cases hY; rfl
 
 lemma homOfEq_heq_left_iff {X Y X' Y' : V} (f : X ⟶ Y) (g : X' ⟶ Y')
     (hX : X = X') (hY : Y = Y') :
-    HEq (homOfEq f hX hY) g ↔ HEq f g := by
+    homOfEq f hX hY ≍ g ↔ f ≍ g := by
   cases hX; cases hY; rfl
 
 lemma homOfEq_heq_right_iff {X Y X' Y' : V} (f : X ⟶ Y) (g : X' ⟶ Y')
     (hX : X' = X) (hY : Y' = Y) :
-    HEq f (homOfEq g hX hY) ↔ HEq f g := by
+    f ≍ homOfEq g hX hY ↔ f ≍ g := by
   cases hX; cases hY; rfl
 
 

--- a/Mathlib/Combinatorics/Quiver/Cast.lean
+++ b/Mathlib/Combinatorics/Quiver/Cast.lean
@@ -49,17 +49,17 @@ theorem Hom.cast_cast {u v u' v' u'' v'' : U} (e : u ⟶ v) (hu : u = u') (hv : 
   rfl
 
 theorem Hom.cast_heq {u v u' v' : U} (hu : u = u') (hv : v = v') (e : u ⟶ v) :
-    HEq (e.cast hu hv) e := by
+    e.cast hu hv ≍ e := by
   subst_vars
   rfl
 
 theorem Hom.cast_eq_iff_heq {u v u' v' : U} (hu : u = u') (hv : v = v') (e : u ⟶ v) (e' : u' ⟶ v') :
-    e.cast hu hv = e' ↔ HEq e e' := by
+    e.cast hu hv = e' ↔ e ≍ e' := by
   rw [Hom.cast_eq_cast]
   exact _root_.cast_eq_iff_heq
 
 theorem Hom.eq_cast_iff_heq {u v u' v' : U} (hu : u = u') (hv : v = v') (e : u ⟶ v) (e' : u' ⟶ v') :
-    e' = e.cast hu hv ↔ HEq e' e := by
+    e' = e.cast hu hv ↔ e' ≍ e := by
   rw [eq_comm, Hom.cast_eq_iff_heq]
   exact ⟨HEq.symm, HEq.symm⟩
 
@@ -96,17 +96,17 @@ theorem Path.cast_nil {u u' : U} (hu : u = u') : (Path.nil : Path u u).cast hu h
   rfl
 
 theorem Path.cast_heq {u v u' v' : U} (hu : u = u') (hv : v = v') (p : Path u v) :
-    HEq (p.cast hu hv) p := by
+    p.cast hu hv ≍ p := by
   rw [Path.cast_eq_cast]
   exact _root_.cast_heq _ _
 
 theorem Path.cast_eq_iff_heq {u v u' v' : U} (hu : u = u') (hv : v = v') (p : Path u v)
-    (p' : Path u' v') : p.cast hu hv = p' ↔ HEq p p' := by
+    (p' : Path u' v') : p.cast hu hv = p' ↔ p ≍ p' := by
   rw [Path.cast_eq_cast]
   exact _root_.cast_eq_iff_heq
 
 theorem Path.eq_cast_iff_heq {u v u' v' : U} (hu : u = u') (hv : v = v') (p : Path u v)
-    (p' : Path u' v') : p' = p.cast hu hv ↔ HEq p' p :=
+    (p' : Path u' v') : p' = p.cast hu hv ↔ p' ≍ p :=
   ⟨fun h => ((p.cast_eq_iff_heq hu hv p').1 h.symm).symm, fun h =>
     ((p.cast_eq_iff_heq hu hv p').2 h.symm).symm⟩
 

--- a/Mathlib/Combinatorics/Quiver/Path.lean
+++ b/Mathlib/Combinatorics/Quiver/Path.lean
@@ -46,10 +46,10 @@ lemma obj_eq_of_cons_eq_cons {p : Path a b} {p' : Path a c}
     {e : b ⟶ d} {e' : c ⟶ d} (h : p.cons e = p'.cons e') : b = c := by injection h
 
 lemma heq_of_cons_eq_cons {p : Path a b} {p' : Path a c}
-    {e : b ⟶ d} {e' : c ⟶ d} (h : p.cons e = p'.cons e') : HEq p p' := by injection h
+    {e : b ⟶ d} {e' : c ⟶ d} (h : p.cons e = p'.cons e') : p ≍ p' := by injection h
 
 lemma hom_heq_of_cons_eq_cons {p : Path a b} {p' : Path a c}
-    {e : b ⟶ d} {e' : c ⟶ d} (h : p.cons e = p'.cons e') : HEq e e' := by injection h
+    {e : b ⟶ d} {e' : c ⟶ d} (h : p.cons e = p'.cons e') : e ≍ e' := by injection h
 
 /-- The length of a path is the number of arrows it uses. -/
 def length {a : V} : ∀ {b : V}, Path a b → ℕ

--- a/Mathlib/Combinatorics/Quiver/Push.lean
+++ b/Mathlib/Combinatorics/Quiver/Push.lean
@@ -74,7 +74,7 @@ theorem lift_comp : (of σ ⋙q lift σ φ τ h) = φ := by
     iterate 2 apply (cast_heq _ _).trans
     apply HEq.symm
     apply (eqRec_heq _ _).trans
-    have : ∀ {α γ} {β : α → γ → Sort _} {a a'} (p : a = a') g (b : β a g), HEq (p ▸ b) b := by
+    have : ∀ {α γ} {β : α → γ → Sort _} {a a'} (p : a = a') g (b : β a g), p ▸ b ≍ b := by
       intros
       subst_vars
       rfl

--- a/Mathlib/Data/DFinsupp/Defs.lean
+++ b/Mathlib/Data/DFinsupp/Defs.lean
@@ -476,7 +476,7 @@ theorem single_injective {i} : Function.Injective (single i : β i → Π₀ i, 
 
 /-- Like `Finsupp.single_eq_single_iff`, but with a `HEq` due to dependent types -/
 theorem single_eq_single_iff (i j : ι) (xi : β i) (xj : β j) :
-    DFinsupp.single i xi = DFinsupp.single j xj ↔ i = j ∧ HEq xi xj ∨ xi = 0 ∧ xj = 0 := by
+    DFinsupp.single i xi = DFinsupp.single j xj ↔ i = j ∧ xi ≍ xj ∨ xi = 0 ∧ xj = 0 := by
   constructor
   · intro h
     by_cases hij : i = j

--- a/Mathlib/Data/EReal/Operations.lean
+++ b/Mathlib/Data/EReal/Operations.lean
@@ -334,7 +334,7 @@ def recENNReal {motive : EReal → Sort*} (coe : ∀ x : ℝ≥0∞, motive x)
 @[simp]
 theorem recENNReal_coe_ennreal {motive : EReal → Sort*} (coe : ∀ x : ℝ≥0∞, motive x)
     (neg_coe : ∀ x : ℝ≥0∞, 0 < x → motive (-x)) (x : ℝ≥0∞) : recENNReal coe neg_coe x = coe x := by
-  suffices ∀ y : EReal, x = y → HEq (recENNReal coe neg_coe y : motive y) (coe x) from
+  suffices ∀ y : EReal, x = y → (recENNReal coe neg_coe y : motive y) ≍ coe x from
     heq_iff_eq.mp (this x rfl)
   intro y hy
   have H₁ : 0 ≤ y := hy ▸ coe_ennreal_nonneg x

--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -116,7 +116,7 @@ theorem mk_eq_mk {a h a' h'} : @mk n a h = @mk n a' h' ↔ a = a' :=
 /-- Assume `k = l`. If two functions defined on `Fin k` and `Fin l` are equal on each element,
 then they coincide (in the heq sense). -/
 protected theorem heq_fun_iff {α : Sort*} {k l : ℕ} (h : k = l) {f : Fin k → α} {g : Fin l → α} :
-    HEq f g ↔ ∀ i : Fin k, f i = g ⟨(i : ℕ), h ▸ i.2⟩ := by
+    f ≍ g ↔ ∀ i : Fin k, f i = g ⟨(i : ℕ), h ▸ i.2⟩ := by
   subst h
   simp [funext_iff]
 
@@ -125,7 +125,7 @@ If two functions `Fin k → Fin k' → α` and `Fin l → Fin l' → α` are equ
 then they coincide (in the heq sense). -/
 protected theorem heq_fun₂_iff {α : Sort*} {k l k' l' : ℕ} (h : k = l) (h' : k' = l')
     {f : Fin k → Fin k' → α} {g : Fin l → Fin l' → α} :
-    HEq f g ↔ ∀ (i : Fin k) (j : Fin k'), f i j = g ⟨(i : ℕ), h ▸ i.2⟩ ⟨(j : ℕ), h' ▸ j.2⟩ := by
+    f ≍ g ↔ ∀ (i : Fin k) (j : Fin k'), f i j = g ⟨(i : ℕ), h ▸ i.2⟩ ⟨(j : ℕ), h' ▸ j.2⟩ := by
   subst h
   subst h'
   simp [funext_iff]
@@ -133,7 +133,7 @@ protected theorem heq_fun₂_iff {α : Sort*} {k l k' l' : ℕ} (h : k = l) (h' 
 /-- Two elements of `Fin k` and `Fin l` are heq iff their values in `ℕ` coincide. This requires
 `k = l`. For the left implication without this assumption, see `val_eq_val_of_heq`. -/
 protected theorem heq_ext_iff {k l : ℕ} (h : k = l) {i : Fin k} {j : Fin l} :
-    HEq i j ↔ (i : ℕ) = (j : ℕ) := by
+    i ≍ j ↔ (i : ℕ) = (j : ℕ) := by
   subst h
   simp [val_eq_val]
 

--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -1026,8 +1026,8 @@ not a definitional equality. -/
 /-- A `HEq` version of `Fin.removeNth_removeNth_eq_swap`. -/
 theorem removeNth_removeNth_heq_swap {α : Fin (n + 2) → Sort*} (m : ∀ i, α i)
     (i : Fin (n + 1)) (j : Fin (n + 2)) :
-    HEq (i.removeNth (j.removeNth m))
-      ((i.predAbove j).removeNth ((j.succAbove i).removeNth m)) := by
+    i.removeNth (j.removeNth m) ≍
+      (i.predAbove j).removeNth ((j.succAbove i).removeNth m) := by
   apply Function.hfunext rfl
   simp only [heq_iff_eq]
   rintro k _ rfl

--- a/Mathlib/Data/Finset/Image.lean
+++ b/Mathlib/Data/Finset/Image.lean
@@ -118,7 +118,7 @@ theorem map_refl : s.map (Embedding.refl _) = s :=
 
 @[simp]
 theorem map_cast_heq {α β} (h : α = β) (s : Finset α) :
-    HEq (s.map (Equiv.cast h).toEmbedding) s := by
+    s.map (Equiv.cast h).toEmbedding ≍ s := by
   subst h
   simp
 

--- a/Mathlib/Data/Fintype/Card.lean
+++ b/Mathlib/Data/Fintype/Card.lean
@@ -498,7 +498,7 @@ equality of types, using it should be avoided if possible. -/
 theorem fin_injective : Function.Injective Fin := fun m n h =>
   (Fintype.card_fin m).symm.trans <| (Fintype.card_congr <| Equiv.cast h).trans (Fintype.card_fin n)
 
-theorem Fin.val_eq_val_of_heq {k l : ℕ} {i : Fin k} {j : Fin l} (h : HEq i j) :
+theorem Fin.val_eq_val_of_heq {k l : ℕ} {i : Fin k} {j : Fin l} (h : i ≍ j) :
     (i : ℕ) = (j : ℕ) :=
   (Fin.heq_ext_iff (fin_injective (type_eq_of_heq h))).1 h
 

--- a/Mathlib/Data/Fintype/Quotient.lean
+++ b/Mathlib/Data/Fintype/Quotient.lean
@@ -153,7 +153,7 @@ def finChoiceEquiv :
 def finHRecOn {C : (∀ i, Quotient (S i)) → Sort*}
     (q : ∀ i, Quotient (S i))
     (f : ∀ a : ∀ i, α i, C (⟦a ·⟧))
-    (h : ∀ (a b : ∀ i, α i), (∀ i, a i ≈ b i) → HEq (f a) (f b)) :
+    (h : ∀ (a b : ∀ i, α i), (∀ i, a i ≈ b i) → f a ≍ f b) :
     C q :=
   eval_finChoice q ▸ (finChoice q).hrecOn f h
 

--- a/Mathlib/Data/Holor.lean
+++ b/Mathlib/Data/Holor.lean
@@ -144,7 +144,7 @@ theorem mul_assoc0 [Semigroup α] (x : Holor α ds₁) (y : Holor α ds₂) (z :
     rw [append_assoc]
 
 theorem mul_assoc [Semigroup α] (x : Holor α ds₁) (y : Holor α ds₂) (z : Holor α ds₃) :
-    HEq (mul (mul x y) z) (mul x (mul y z)) := by simp [cast_heq, mul_assoc0, assocLeft]
+    mul (mul x y) z ≍ mul x (mul y z) := by simp [cast_heq, mul_assoc0, assocLeft]
 
 theorem mul_left_distrib [Distrib α] (x : Holor α ds₁) (y : Holor α ds₂) (z : Holor α ds₂) :
     x ⊗ (y + z) = x ⊗ y + x ⊗ z := funext fun t => left_distrib (x t.take) (y t.drop) (z t.drop)

--- a/Mathlib/Data/List/AList.lean
+++ b/Mathlib/Data/List/AList.lean
@@ -347,8 +347,8 @@ theorem insertRec_insert {C : AList β → Sort*} (H0 : C ∅)
     {l : AList β} (h : c.1 ∉ l) :
     @insertRec α β _ C H0 IH (l.insert c.1 c.2) = IH c.1 c.2 l h (@insertRec α β _ C H0 IH l) := by
   obtain ⟨l, hl⟩ := l
-  suffices HEq (@insertRec α β _ C H0 IH ⟨c :: l, nodupKeys_cons.2 ⟨h, hl⟩⟩)
-      (IH c.1 c.2 ⟨l, hl⟩ h (@insertRec α β _ C H0 IH ⟨l, hl⟩)) by
+  suffices @insertRec α β _ C H0 IH ⟨c :: l, nodupKeys_cons.2 ⟨h, hl⟩⟩ ≍
+      IH c.1 c.2 ⟨l, hl⟩ h (@insertRec α β _ C H0 IH ⟨l, hl⟩) by
     cases c
     apply eq_of_heq
     convert this <;> rw [insert_of_notMem h]

--- a/Mathlib/Data/Multiset/Bind.lean
+++ b/Mathlib/Data/Multiset/Bind.lean
@@ -141,7 +141,7 @@ theorem bind_congr {f g : α → Multiset β} {m : Multiset α} :
     (∀ a ∈ m, f a = g a) → bind m f = bind m g := by simp +contextual [bind]
 
 theorem bind_hcongr {β' : Type v} {m : Multiset α} {f : α → Multiset β} {f' : α → Multiset β'}
-    (h : β = β') (hf : ∀ a ∈ m, HEq (f a) (f' a)) : HEq (bind m f) (bind m f') := by
+    (h : β = β') (hf : ∀ a ∈ m, f a ≍ f' a) : bind m f ≍ bind m f' := by
   subst h
   simp only [heq_eq_eq] at hf
   simp [bind_congr hf]

--- a/Mathlib/Data/Multiset/MapFold.lean
+++ b/Mathlib/Data/Multiset/MapFold.lean
@@ -51,7 +51,7 @@ theorem map_congr {f g : α → β} {s t : Multiset α} :
   exact congr_arg _ (List.map_congr_left h)
 
 theorem map_hcongr {β' : Type v} {m : Multiset α} {f : α → β} {f' : α → β'} (h : β = β')
-    (hf : ∀ a ∈ m, HEq (f a) (f' a)) : HEq (map f m) (map f' m) := by
+    (hf : ∀ a ∈ m, f a ≍ f' a) : map f m ≍ map f' m := by
   subst h; simp at hf
   simp [map_congr rfl hf]
 

--- a/Mathlib/Data/Multiset/Pi.lean
+++ b/Mathlib/Data/Multiset/Pi.lean
@@ -47,8 +47,8 @@ theorem cons_ne {a a' : α} {b : δ a} {f : ∀ a ∈ m, δ a} (h' : a' ∈ a ::
   dif_neg h
 
 theorem cons_swap {a a' : α} {b : δ a} {b' : δ a'} {m : Multiset α} {f : ∀ a ∈ m, δ a}
-    (h : a ≠ a') : HEq (Pi.cons (a' ::ₘ m) a b (Pi.cons m a' b' f))
-      (Pi.cons (a ::ₘ m) a' b' (Pi.cons m a b f)) := by
+    (h : a ≠ a') : Pi.cons (a' ::ₘ m) a b (Pi.cons m a' b' f) ≍
+      Pi.cons (a ::ₘ m) a' b' (Pi.cons m a b f) := by
   apply hfunext rfl
   simp only [heq_iff_eq]
   rintro a'' _ rfl

--- a/Mathlib/Data/Multiset/ZeroCons.lean
+++ b/Mathlib/Data/Multiset/ZeroCons.lean
@@ -132,7 +132,7 @@ overflow in `whnf`.
 protected
 def rec (C_0 : C 0) (C_cons : ∀ a m, C m → C (a ::ₘ m))
     (C_cons_heq :
-      ∀ a a' m b, HEq (C_cons a (a' ::ₘ m) (C_cons a' m b)) (C_cons a' (a ::ₘ m) (C_cons a m b)))
+      ∀ a a' m b, C_cons a (a' ::ₘ m) (C_cons a' m b) ≍ C_cons a' (a ::ₘ m) (C_cons a m b))
     (m : Multiset α) : C m :=
   Quotient.hrecOn m (@List.rec α (fun l => C ⟦l⟧) C_0 fun a l b => C_cons a ⟦l⟧ b) fun _ _ h =>
     h.rec_heq
@@ -144,13 +144,13 @@ def rec (C_0 : C 0) (C_cons : ∀ a m, C m → C (a ::ₘ m))
 protected
 def recOn (m : Multiset α) (C_0 : C 0) (C_cons : ∀ a m, C m → C (a ::ₘ m))
     (C_cons_heq :
-      ∀ a a' m b, HEq (C_cons a (a' ::ₘ m) (C_cons a' m b)) (C_cons a' (a ::ₘ m) (C_cons a m b))) :
+      ∀ a a' m b, C_cons a (a' ::ₘ m) (C_cons a' m b) ≍ C_cons a' (a ::ₘ m) (C_cons a m b)) :
     C m :=
   Multiset.rec C_0 C_cons C_cons_heq m
 
 variable {C_0 : C 0} {C_cons : ∀ a m, C m → C (a ::ₘ m)}
   {C_cons_heq :
-    ∀ a a' m b, HEq (C_cons a (a' ::ₘ m) (C_cons a' m b)) (C_cons a' (a ::ₘ m) (C_cons a m b))}
+    ∀ a a' m b, C_cons a (a' ::ₘ m) (C_cons a' m b) ≍ C_cons a' (a ::ₘ m) (C_cons a m b)}
 
 @[simp]
 theorem recOn_0 : @Multiset.recOn α C (0 : Multiset α) C_0 C_cons C_cons_heq = C_0 :=

--- a/Mathlib/Data/PFunctor/Univariate/M.lean
+++ b/Mathlib/Data/PFunctor/Univariate/M.lean
@@ -75,7 +75,7 @@ theorem agree_trivial {x : CofixA F 0} {y : CofixA F 1} : Agree x y := by constr
 @[deprecated (since := "2024-12-25")] alias agree_trival := agree_trivial
 
 theorem agree_children {n : ℕ} (x : CofixA F (succ n)) (y : CofixA F (succ n + 1)) {i j}
-    (h₀ : HEq i j) (h₁ : Agree x y) : Agree (children' x i) (children' y j) := by
+    (h₀ : i ≍ j) (h₁ : Agree x y) : Agree (children' x i) (children' y j) := by
   obtain - | ⟨_, _, hagree⟩ := h₁; cases h₀
   apply hagree
 

--- a/Mathlib/Data/Quot.lean
+++ b/Mathlib/Data/Quot.lean
@@ -61,16 +61,16 @@ instance [Unique α] : Unique (Quot ra) := Unique.mk' _
 
 /-- Recursion on two `Quotient` arguments `a` and `b`, result type depends on `⟦a⟧` and `⟦b⟧`. -/
 protected def hrecOn₂ (qa : Quot ra) (qb : Quot rb) (f : ∀ a b, φ ⟦a⟧ ⟦b⟧)
-    (ca : ∀ {b a₁ a₂}, ra a₁ a₂ → HEq (f a₁ b) (f a₂ b))
-    (cb : ∀ {a b₁ b₂}, rb b₁ b₂ → HEq (f a b₁) (f a b₂)) :
+    (ca : ∀ {b a₁ a₂}, ra a₁ a₂ → f a₁ b ≍ f a₂ b)
+    (cb : ∀ {a b₁ b₂}, rb b₁ b₂ → f a b₁ ≍ f a b₂) :
     φ qa qb :=
   Quot.hrecOn (motive := fun qa ↦ φ qa qb) qa
     (fun a ↦ Quot.hrecOn qb (f a) (fun _ _ pb ↦ cb pb))
     fun a₁ a₂ pa ↦
       Quot.induction_on qb fun b ↦
-        have h₁ : HEq (@Quot.hrecOn _ _ (φ _) ⟦b⟧ (f a₁) (@cb _)) (f a₁ b) := by
+        have h₁ : @Quot.hrecOn _ _ (φ _) ⟦b⟧ (f a₁) (@cb _) ≍ f a₁ b := by
           simp
-        have h₂ : HEq (f a₂ b) (@Quot.hrecOn _ _ (φ _) ⟦b⟧ (f a₂) (@cb _)) := by
+        have h₂ : f a₂ b ≍ @Quot.hrecOn _ _ (φ _) ⟦b⟧ (f a₂) (@cb _) := by
           simp
         (h₁.trans (ca pa)).trans h₂
 
@@ -218,7 +218,7 @@ instance {α : Type*} [Setoid α] : IsEquiv α (· ≈ ·) where
 
 /-- Induction on two `Quotient` arguments `a` and `b`, result type depends on `⟦a⟧` and `⟦b⟧`. -/
 protected def hrecOn₂ (qa : Quotient sa) (qb : Quotient sb) (f : ∀ a b, φ ⟦a⟧ ⟦b⟧)
-    (c : ∀ a₁ b₁ a₂ b₂, a₁ ≈ a₂ → b₁ ≈ b₂ → HEq (f a₁ b₁) (f a₂ b₂)) : φ qa qb :=
+    (c : ∀ a₁ b₁ a₂ b₂, a₁ ≈ a₂ → b₁ ≈ b₂ → f a₁ b₁ ≍ f a₂ b₂) : φ qa qb :=
   Quot.hrecOn₂ qa qb f (fun p ↦ c _ _ _ _ p (Setoid.refl _)) fun p ↦ c _ _ _ _ (Setoid.refl _) p
 
 /-- Map a function `f : α → β` that sends equivalent elements to equivalent elements
@@ -654,26 +654,26 @@ protected def recOnSubsingleton₂' {φ : Quotient s₁ → Quotient s₂ → So
 
 /-- Recursion on a `Quotient` argument `a`, result type depends on `⟦a⟧`. -/
 protected def hrecOn' {φ : Quotient s₁ → Sort*} (qa : Quotient s₁) (f : ∀ a, φ (Quotient.mk'' a))
-    (c : ∀ a₁ a₂, a₁ ≈ a₂ → HEq (f a₁) (f a₂)) : φ qa :=
+    (c : ∀ a₁ a₂, a₁ ≈ a₂ → f a₁ ≍ f a₂) : φ qa :=
   Quot.hrecOn qa f c
 
 @[simp]
 theorem hrecOn'_mk'' {φ : Quotient s₁ → Sort*} (f : ∀ a, φ (Quotient.mk'' a))
-    (c : ∀ a₁ a₂, a₁ ≈ a₂ → HEq (f a₁) (f a₂))
+    (c : ∀ a₁ a₂, a₁ ≈ a₂ → f a₁ ≍ f a₂)
     (x : α) : (Quotient.mk'' x).hrecOn' f c = f x :=
   rfl
 
 /-- Recursion on two `Quotient` arguments `a` and `b`, result type depends on `⟦a⟧` and `⟦b⟧`. -/
 protected def hrecOn₂' {φ : Quotient s₁ → Quotient s₂ → Sort*} (qa : Quotient s₁)
     (qb : Quotient s₂) (f : ∀ a b, φ (Quotient.mk'' a) (Quotient.mk'' b))
-    (c : ∀ a₁ b₁ a₂ b₂, a₁ ≈ a₂ → b₁ ≈ b₂ → HEq (f a₁ b₁) (f a₂ b₂)) :
+    (c : ∀ a₁ b₁ a₂ b₂, a₁ ≈ a₂ → b₁ ≈ b₂ → f a₁ b₁ ≍ f a₂ b₂) :
     φ qa qb :=
   Quotient.hrecOn₂ qa qb f c
 
 @[simp]
 theorem hrecOn₂'_mk'' {φ : Quotient s₁ → Quotient s₂ → Sort*}
     (f : ∀ a b, φ (Quotient.mk'' a) (Quotient.mk'' b))
-    (c : ∀ a₁ b₁ a₂ b₂, a₁ ≈ a₂ → b₁ ≈ b₂ → HEq (f a₁ b₁) (f a₂ b₂)) (x : α) (qb : Quotient s₂) :
+    (c : ∀ a₁ b₁ a₂ b₂, a₁ ≈ a₂ → b₁ ≈ b₂ → f a₁ b₁ ≍ f a₂ b₂) (x : α) (qb : Quotient s₂) :
     (Quotient.mk'' x).hrecOn₂' qb f c = qb.hrecOn' (f x) fun _ _ ↦ c _ _ _ _ (Setoid.refl _) :=
   rfl
 

--- a/Mathlib/Data/Sigma/Basic.lean
+++ b/Mathlib/Data/Sigma/Basic.lean
@@ -51,7 +51,7 @@ instance instDecidableEqSigma [h₁ : DecidableEq α] [h₂ : ∀ a, DecidableEq
     | _, _, _, _, isFalse n => isFalse fun h ↦ Sigma.noConfusion h fun e₁ _ ↦ n e₁
 
 theorem mk.inj_iff {a₁ a₂ : α} {b₁ : β a₁} {b₂ : β a₂} :
-    Sigma.mk a₁ b₁ = ⟨a₂, b₂⟩ ↔ a₁ = a₂ ∧ HEq b₁ b₂ := by simp
+    Sigma.mk a₁ b₁ = ⟨a₂, b₂⟩ ↔ a₁ = a₂ ∧ b₁ ≍ b₂ := by simp
 
 @[simp]
 theorem eta : ∀ x : Σa, β a, Sigma.mk x.1 x.2 = x
@@ -64,7 +64,7 @@ protected theorem eq {α : Type*} {β : α → Type*} : ∀ {p₁ p₂ : Σ a, �
 /-- A version of `Iff.mp Sigma.ext_iff` for functions from a nonempty type to a sigma type. -/
 theorem _root_.Function.eq_of_sigmaMk_comp {γ : Type*} [Nonempty γ]
     {a b : α} {f : γ → β a} {g : γ → β b} (h : Sigma.mk a ∘ f = Sigma.mk b ∘ g) :
-    a = b ∧ HEq f g := by
+    a = b ∧ f ≍ g := by
   rcases ‹Nonempty γ› with ⟨i⟩
   obtain rfl : a = b := congr_arg Sigma.fst (congr_fun h i)
   simpa [funext_iff] using h
@@ -220,7 +220,7 @@ instance decidableEq [h₁ : DecidableEq α] [h₂ : ∀ a, DecidableEq (β a)] 
     | _, _, _, _, isFalse n => isFalse fun h ↦ PSigma.noConfusion h fun e₁ _ ↦ n e₁
 
 theorem mk.inj_iff {a₁ a₂ : α} {b₁ : β a₁} {b₂ : β a₂} :
-    @PSigma.mk α β a₁ b₁ = @PSigma.mk α β a₂ b₂ ↔ a₁ = a₂ ∧ HEq b₁ b₂ :=
+    @PSigma.mk α β a₁ b₁ = @PSigma.mk α β a₂ b₂ ↔ a₁ = a₂ ∧ b₁ ≍ b₂ :=
   (Iff.intro PSigma.mk.inj) fun ⟨h₁, h₂⟩ ↦
     match a₁, a₂, b₁, b₂, h₁, h₂ with
     | _, _, _, _, Eq.refl _, HEq.refl _ => rfl

--- a/Mathlib/Data/Subtype.lean
+++ b/Mathlib/Data/Subtype.lean
@@ -49,13 +49,13 @@ protected theorem exists' {q : ∀ x, p x → Prop} : (∃ x h, q x h) ↔ ∃ x
   (@Subtype.exists _ _ fun x ↦ q x.1 x.2).symm
 
 theorem heq_iff_coe_eq (h : ∀ x, p x ↔ q x) {a1 : { x // p x }} {a2 : { x // q x }} :
-    HEq a1 a2 ↔ (a1 : α) = (a2 : α) :=
+    a1 ≍ a2 ↔ (a1 : α) = (a2 : α) :=
   Eq.rec
-    (motive := fun (pp : (α → Prop)) _ ↦ ∀ a2' : {x // pp x}, HEq a1 a2' ↔ (a1 : α) = (a2' : α))
+    (motive := fun (pp : (α → Prop)) _ ↦ ∀ a2' : {x // pp x}, a1 ≍ a2' ↔ (a1 : α) = (a2' : α))
     (fun _ ↦ heq_iff_eq.trans Subtype.ext_iff) (funext <| fun x ↦ propext (h x)) a2
 
 lemma heq_iff_coe_heq {α β : Sort _} {p : α → Prop} {q : β → Prop} {a : {x // p x}}
-    {b : {y // q y}} (h : α = β) (h' : HEq p q) : HEq a b ↔ HEq (a : α) (b : β) := by
+    {b : {y // q y}} (h : α = β) (h' : p ≍ q) : a ≍ b ↔ (a : α) ≍ (b : β) := by
   subst h
   subst h'
   rw [heq_iff_eq, heq_iff_eq, Subtype.ext_iff]

--- a/Mathlib/Geometry/RingedSpace/Basic.lean
+++ b/Mathlib/Geometry/RingedSpace/Basic.lean
@@ -75,7 +75,7 @@ theorem isUnit_res_of_isUnit_germ (U : Opens X) (f : X.presheaf.obj (op U)) (x :
   obtain ⟨V, hxV, g, rfl⟩ := X.presheaf.germ_exist x g'
   let W := U ⊓ V
   have hxW : x ∈ W := ⟨hx, hxV⟩
-  -- Porting note: `erw` can't write into `HEq`, so this is replaced with another `HEq` in the
+  -- Porting note: `erw` can't write into `heq`, so this is replaced with another `heq` in the
   -- desired form
   replace heq : (X.presheaf.germ _ x hxW) ((X.presheaf.map (U.infLELeft V).op) f *
       (X.presheaf.map (U.infLERight V).op) g) = (X.presheaf.germ _ x hxW) 1 := by

--- a/Mathlib/Geometry/RingedSpace/PresheafedSpace.lean
+++ b/Mathlib/Geometry/RingedSpace/PresheafedSpace.lean
@@ -90,7 +90,7 @@ theorem Hom.ext {X Y : PresheafedSpace C} (α β : Hom X Y) (w : α.base = β.ba
   rfl
 
 -- TODO including `injections` would make tidy work earlier.
-theorem hext {X Y : PresheafedSpace C} (α β : Hom X Y) (w : α.base = β.base) (h : HEq α.c β.c) :
+theorem hext {X Y : PresheafedSpace C} (α β : Hom X Y) (w : α.base = β.base) (h : α.c ≍ β.c) :
     α = β := by
   cases α
   cases β

--- a/Mathlib/GroupTheory/Congruence/Defs.lean
+++ b/Mathlib/GroupTheory/Congruence/Defs.lean
@@ -234,13 +234,13 @@ protected def liftOn₂ {β} {c : Con M} (q r : c.Quotient) (f : M → M → β)
 @[to_additive "A version of `Quotient.hrecOn₂'` for quotients by `AddCon`."]
 protected def hrecOn₂ {cM : Con M} {cN : Con N} {φ : cM.Quotient → cN.Quotient → Sort*}
     (a : cM.Quotient) (b : cN.Quotient) (f : ∀ (x : M) (y : N), φ x y)
-    (h : ∀ x y x' y', cM x x' → cN y y' → HEq (f x y) (f x' y')) : φ a b :=
+    (h : ∀ x y x' y', cM x x' → cN y y' → f x y ≍ f x' y') : φ a b :=
   Quotient.hrecOn₂' a b f h
 
 @[to_additive (attr := simp)]
 theorem hrec_on₂_coe {cM : Con M} {cN : Con N} {φ : cM.Quotient → cN.Quotient → Sort*} (a : M)
     (b : N) (f : ∀ (x : M) (y : N), φ x y)
-    (h : ∀ x y x' y', cM x x' → cN y y' → HEq (f x y) (f x' y')) :
+    (h : ∀ x y x' y', cM x x' → cN y y' → f x y ≍ f x' y') :
     Con.hrecOn₂ (↑a) (↑b) f h = f a b :=
   rfl
 

--- a/Mathlib/Lean/Meta/CongrTheorems.lean
+++ b/Mathlib/Lean/Meta/CongrTheorems.lean
@@ -106,7 +106,7 @@ protected theorem FastSubsingleton.elim {α : Sort u} [h : FastSubsingleton α] 
   h.inst.allEq
 
 protected theorem FastSubsingleton.helim {α β : Sort u} [FastSubsingleton α]
-    (h₂ : α = β) (a : α) (b : β) : HEq a b := by
+    (h₂ : α = β) (a : α) (b : β) : a ≍ b := by
   have : Subsingleton α := FastSubsingleton.inst
   exact Subsingleton.helim h₂ a b
 
@@ -202,11 +202,11 @@ Otherwise it might be an `Eq` if the equality is homogeneous.
 This is the interpretation of the `CongrArgKind`s in the generated congruence theorem:
 * `.eq` corresponds to having three arguments `(x : α) (x' : α) (h : x = x')`.
   Note that `h` might have additional hypotheses.
-* `.heq` corresponds to having three arguments `(x : α) (x' : α') (h : HEq x x')`
+* `.heq` corresponds to having three arguments `(x : α) (x' : α') (h : x ≍ x')`
   Note that `h` might have additional hypotheses.
 * `.fixed` corresponds to having a single argument `(x : α)` that is fixed between the LHS and RHS
 * `.subsingletonInst` corresponds to having two arguments `(x : α) (x' : α')` for which the
-  congruence generator was able to prove that `HEq x x'` already. This is a slight abuse of
+  congruence generator was able to prove that `x ≍ x'` already. This is a slight abuse of
   this `CongrArgKind` since this is used even for types that are not subsingleton typeclasses.
 
 Note that the first entry in this array is for the function itself.

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -44,11 +44,11 @@ instance [Subsingleton α] (p : α → Prop) : Subsingleton (Subtype p) :=
   ⟨fun ⟨x, _⟩ ⟨y, _⟩ ↦ by cases Subsingleton.elim x y; rfl⟩
 
 theorem congr_heq {α β γ : Sort _} {f : α → γ} {g : β → γ} {x : α} {y : β}
-    (h₁ : HEq f g) (h₂ : HEq x y) : f x = g y := by
+    (h₁ : f ≍ g) (h₂ : x ≍ y) : f x = g y := by
   cases h₂; cases h₁; rfl
 
 theorem congr_arg_heq {β : α → Sort*} (f : ∀ a, β a) :
-    ∀ {a₁ a₂ : α}, a₁ = a₂ → HEq (f a₁) (f a₂)
+    ∀ {a₁ a₂ : α}, a₁ = a₂ → f a₁ ≍ f a₂
   | _, _, rfl => HEq.rfl
 
 @[simp] theorem eq_iff_eq_cancel_left {b c : α} : (∀ {a}, a = b ↔ a = c) ↔ b = c :=
@@ -431,32 +431,32 @@ theorem Eq.rec_eq_cast {α : Sort _} {P : α → Sort _} {x y : α} (h : x = y) 
 
 theorem eqRec_heq' {α : Sort*} {a' : α} {motive : (a : α) → a' = a → Sort*}
     (p : motive a' (rfl : a' = a')) {a : α} (t : a' = a) :
-    HEq (@Eq.rec α a' motive p a t) p := by
+    @Eq.rec α a' motive p a t ≍ p := by
   subst t; rfl
 
 theorem rec_heq_of_heq {α β : Sort _} {a b : α} {C : α → Sort*} {x : C a} {y : β}
-    (e : a = b) (h : HEq x y) : HEq (e ▸ x) y := by subst e; exact h
+    (e : a = b) (h : x ≍ y) : e ▸ x ≍ y := by subst e; exact h
 
 theorem rec_heq_iff_heq {α β : Sort _} {a b : α} {C : α → Sort*} {x : C a} {y : β} {e : a = b} :
-    HEq (e ▸ x) y ↔ HEq x y := by subst e; rfl
+    e ▸ x ≍ y ↔ x ≍ y := by subst e; rfl
 
 theorem heq_rec_iff_heq {α β : Sort _} {a b : α} {C : α → Sort*} {x : β} {y : C a} {e : a = b} :
-    HEq x (e ▸ y) ↔ HEq x y := by subst e; rfl
+    x ≍ e ▸ y ↔ x ≍ y := by subst e; rfl
 
 @[simp]
 theorem cast_heq_iff_heq {α β γ : Sort _} (e : α = β) (a : α) (c : γ) :
-    HEq (cast e a) c ↔ HEq a c := by subst e; rfl
+    cast e a ≍ c ↔ a ≍ c := by subst e; rfl
 
 @[simp]
 theorem heq_cast_iff_heq {α β γ : Sort _} (e : β = γ) (a : α) (b : β) :
-    HEq a (cast e b) ↔ HEq a b := by subst e; rfl
+    a ≍ cast e b ↔ a ≍ b := by subst e; rfl
 
 universe u
 variable {α β : Sort u} {e : β = α} {a : α} {b : β}
 
-lemma heq_of_eq_cast (e : β = α) : a = cast e b → HEq a b := by rintro rfl; simp
+lemma heq_of_eq_cast (e : β = α) : a = cast e b → a ≍ b := by rintro rfl; simp
 
-lemma eq_cast_iff_heq : a = cast e b ↔ HEq a b := ⟨heq_of_eq_cast _, fun h ↦ by cases h; rfl⟩
+lemma eq_cast_iff_heq : a = cast e b ↔ a ≍ b := ⟨heq_of_eq_cast _, fun h ↦ by cases h; rfl⟩
 
 end Equality
 

--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -282,7 +282,7 @@ theorem apply_eq_iff_eq_symm_apply {x : α} {y : β} (f : α ≃ β) : f x = y �
     (Equiv.cast h).trans (Equiv.cast h2) = Equiv.cast (h.trans h2) :=
   ext fun x => by substs h h2; rfl
 
-theorem cast_eq_iff_heq {α β} (h : α = β) {a : α} {b : β} : Equiv.cast h a = b ↔ HEq a b := by
+theorem cast_eq_iff_heq {α β} (h : α = β) {a : α} {b : β} : Equiv.cast h a = b ↔ a ≍ b := by
   subst h; simp
 
 theorem symm_apply_eq {α β} (e : α ≃ β) {x y} : e.symm x = y ↔ x = e y :=

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -47,9 +47,9 @@ theorem onFun_apply (f : β → β → γ) (g : α → β) (a b : α) : onFun f 
   rfl
 
 lemma hfunext {α α' : Sort u} {β : α → Sort v} {β' : α' → Sort v} {f : ∀ a, β a} {f' : ∀ a, β' a}
-    (hα : α = α') (h : ∀ a a', HEq a a' → HEq (f a) (f' a')) : HEq f f' := by
+    (hα : α = α') (h : ∀ a a', a ≍ a' → f a ≍ f' a') : f ≍ f' := by
   subst hα
-  have : ∀a, HEq (f a) (f' a) := fun a ↦ h a a (HEq.refl a)
+  have : ∀a, f a ≍ f' a := fun a ↦ h a a (HEq.refl a)
   have : β = β' := by funext a; exact type_eq_of_heq (this a)
   subst this
   apply heq_of_eq

--- a/Mathlib/Logic/Unique.lean
+++ b/Mathlib/Logic/Unique.lean
@@ -178,7 +178,7 @@ theorem eq_const_of_unique {β : Sort*} [Unique α] (f : α → β) : f = Functi
   eq_const_of_subsingleton ..
 
 theorem heq_const_of_unique [Unique α] {β : α → Sort v} (f : ∀ a, β a) :
-    HEq f (Function.const α (f default)) :=
+    f ≍ Function.const α (f default) :=
   (Function.hfunext rfl) fun i _ _ ↦ by rw [Subsingleton.elim i default]; rfl
 
 namespace Function

--- a/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
@@ -332,7 +332,7 @@ protected theorem measurableEmbedding (e : α ≃ᵐ β) : MeasurableEmbedding e
 
 /-- Equal measurable spaces are equivalent. -/
 protected def cast {α β} [i₁ : MeasurableSpace α] [i₂ : MeasurableSpace β] (h : α = β)
-    (hi : HEq i₁ i₂) : α ≃ᵐ β where
+    (hi : i₁ ≍ i₂) : α ≃ᵐ β where
   toEquiv := Equiv.cast h
   measurable_toFun := by
     subst h

--- a/Mathlib/Order/RelIso/Basic.lean
+++ b/Mathlib/Order/RelIso/Basic.lean
@@ -655,7 +655,7 @@ lemma trans_assoc {δ : Type*} {u : δ → δ → Prop} (ab : r ≃r s) (bc : s 
 /-- A relation isomorphism between equal relations on equal types. -/
 @[simps! toEquiv apply]
 protected def cast {α β : Type u} {r : α → α → Prop} {s : β → β → Prop} (h₁ : α = β)
-    (h₂ : HEq r s) : r ≃r s :=
+    (h₂ : r ≍ s) : r ≃r s :=
   ⟨Equiv.cast h₁, @fun a b => by
     subst h₁
     rw [eq_of_heq h₂]
@@ -663,17 +663,17 @@ protected def cast {α β : Type u} {r : α → α → Prop} {s : β → β → 
 
 @[simp]
 protected theorem cast_symm {α β : Type u} {r : α → α → Prop} {s : β → β → Prop} (h₁ : α = β)
-    (h₂ : HEq r s) : (RelIso.cast h₁ h₂).symm = RelIso.cast h₁.symm h₂.symm :=
+    (h₂ : r ≍ s) : (RelIso.cast h₁ h₂).symm = RelIso.cast h₁.symm h₂.symm :=
   rfl
 
 @[simp]
 protected theorem cast_refl {α : Type u} {r : α → α → Prop} (h₁ : α = α := rfl)
-    (h₂ : HEq r r := HEq.rfl) : RelIso.cast h₁ h₂ = RelIso.refl r :=
+    (h₂ : r ≍ r := HEq.rfl) : RelIso.cast h₁ h₂ = RelIso.refl r :=
   rfl
 
 @[simp]
 protected theorem cast_trans {α β γ : Type u} {r : α → α → Prop} {s : β → β → Prop}
-    {t : γ → γ → Prop} (h₁ : α = β) (h₁' : β = γ) (h₂ : HEq r s) (h₂' : HEq s t) :
+    {t : γ → γ → Prop} (h₁ : α = β) (h₁' : β = γ) (h₂ : r ≍ s) (h₂' : s ≍ t) :
     (RelIso.cast h₁ h₂).trans (RelIso.cast h₁' h₂') = RelIso.cast (h₁.trans h₁') (h₂.trans h₂') :=
   ext fun x => by subst h₁; rfl
 

--- a/Mathlib/Probability/Kernel/IonescuTulcea/Traj.lean
+++ b/Mathlib/Probability/Kernel/IonescuTulcea/Traj.lean
@@ -95,8 +95,8 @@ private lemma measure_cast {a b : ℕ} (h : a = b) (μ : (n : ℕ) → Measure (
   exact Measure.map_id
 
 private lemma heq_measurableSpace_Iic_pi {a b : ℕ} (h : a = b) :
-    HEq (inferInstance : MeasurableSpace (Π i : Iic a, X i))
-    (inferInstance : MeasurableSpace (Π i : Iic b, X i)) := by cases h; rfl
+    (inferInstance : MeasurableSpace (Π i : Iic a, X i)) ≍
+      (inferInstance : MeasurableSpace (Π i : Iic b, X i)) := by cases h; rfl
 
 end castLemmas
 

--- a/Mathlib/SetTheory/Game/Nim.lean
+++ b/Mathlib/SetTheory/Game/Nim.lean
@@ -59,11 +59,15 @@ theorem nim_def (o : Ordinal) : nim o =
 theorem leftMoves_nim (o : Ordinal) : (nim o).LeftMoves = o.toType := by rw [nim]; rfl
 theorem rightMoves_nim (o : Ordinal) : (nim o).RightMoves = o.toType := by rw [nim]; rfl
 
-theorem moveLeft_nim_hEq (o : Ordinal) :
-    HEq (nim o).moveLeft fun i : o.toType => nim ((enumIsoToType o).symm i) := by rw [nim]; rfl
+theorem moveLeft_nim_heq (o : Ordinal) :
+    (nim o).moveLeft ≍ fun i : o.toType => nim ((enumIsoToType o).symm i) := by rw [nim]; rfl
 
-theorem moveRight_nim_hEq (o : Ordinal) :
-    HEq (nim o).moveRight fun i : o.toType => nim ((enumIsoToType o).symm i) := by rw [nim]; rfl
+@[deprecated (since := "2025-07-05")] alias moveLeft_nim_hEq := moveLeft_nim_heq
+
+theorem moveRight_nim_heq (o : Ordinal) :
+    (nim o).moveRight ≍ fun i : o.toType => nim ((enumIsoToType o).symm i) := by rw [nim]; rfl
+
+@[deprecated (since := "2025-07-05")] alias moveRight_nim_hEq := moveRight_nim_heq
 
 /-- Turns an ordinal less than `o` into a left move for `nim o` and vice versa. -/
 noncomputable def toLeftMovesNim {o : Ordinal} : Set.Iio o ≃ (nim o).LeftMoves :=
@@ -85,7 +89,7 @@ theorem toRightMovesNim_symm_lt {o : Ordinal} (i : (nim o).RightMoves) :
 
 @[simp]
 theorem moveLeft_nim {o : Ordinal} (i) : (nim o).moveLeft i = nim (toLeftMovesNim.symm i).val :=
-  (congr_heq (moveLeft_nim_hEq o).symm (cast_heq _ i)).symm
+  (congr_heq (moveLeft_nim_heq o).symm (cast_heq _ i)).symm
 
 @[deprecated moveLeft_nim (since := "2024-10-30")]
 alias moveLeft_nim' := moveLeft_nim
@@ -96,7 +100,7 @@ theorem moveLeft_toLeftMovesNim {o : Ordinal} (i) :
 
 @[simp]
 theorem moveRight_nim {o : Ordinal} (i) : (nim o).moveRight i = nim (toRightMovesNim.symm i).val :=
-  (congr_heq (moveRight_nim_hEq o).symm (cast_heq _ i)).symm
+  (congr_heq (moveRight_nim_heq o).symm (cast_heq _ i)).symm
 
 @[deprecated moveRight_nim (since := "2024-10-30")]
 alias moveRight_nim' := moveRight_nim

--- a/Mathlib/SetTheory/Game/Ordinal.lean
+++ b/Mathlib/SetTheory/Game/Ordinal.lean
@@ -61,7 +61,7 @@ theorem toLeftMovesToPGame_symm_lt {o : Ordinal} (i : o.toPGame.LeftMoves) :
 
 @[nolint unusedHavesSuffices]
 theorem toPGame_moveLeft_hEq {o : Ordinal} :
-    HEq o.toPGame.moveLeft fun x : o.toType => ((enumIsoToType o).symm x).val.toPGame := by
+    o.toPGame.moveLeft ≍ fun x : o.toType => ((enumIsoToType o).symm x).val.toPGame := by
   rw [toPGame]
   rfl
 

--- a/Mathlib/SetTheory/PGame/Algebra.lean
+++ b/Mathlib/SetTheory/PGame/Algebra.lean
@@ -67,7 +67,7 @@ theorem neg_ofLists (L R : List PGame) :
     · simp
     · rintro ⟨⟨a, ha⟩⟩ ⟨⟨b, hb⟩⟩ h
       have :
-        ∀ {m n} (_ : m = n) {b : ULift (Fin m)} {c : ULift (Fin n)} (_ : HEq b c),
+        ∀ {m n} (_ : m = n) {b : ULift (Fin m)} {c : ULift (Fin n)} (_ : b ≍ c),
           (b.down : ℕ) = ↑c.down := by
         rintro m n rfl b c
         simp only [heq_eq_eq]

--- a/Mathlib/SetTheory/PGame/Basic.lean
+++ b/Mathlib/SetTheory/PGame/Basic.lean
@@ -117,8 +117,8 @@ theorem moveRight_mk {xl xr xL xR} : (⟨xl, xr, xL, xR⟩ : PGame).moveRight = 
   rfl
 
 lemma ext {x y : PGame} (hl : x.LeftMoves = y.LeftMoves) (hr : x.RightMoves = y.RightMoves)
-    (hL : ∀ i j, HEq i j → x.moveLeft i = y.moveLeft j)
-    (hR : ∀ i j, HEq i j → x.moveRight i = y.moveRight j) :
+    (hL : ∀ i j, i ≍ j → x.moveLeft i = y.moveLeft j)
+    (hR : ∀ i j, i ≍ j → x.moveRight i = y.moveRight j) :
     x = y := by
   cases x
   cases y

--- a/Mathlib/Tactic/CC/MkProof.lean
+++ b/Mathlib/Tactic/CC/MkProof.lean
@@ -91,7 +91,7 @@ partial def isCongruent (e₁ e₂ : Expr) : CCM Bool := do
       return false
     else if ← pureIsDefEq (← inferType f) (← inferType g) then
       /- Case 1: `f` and `g` have the same type, then we can create a congruence proof for
-         `HEq (f a) (g b)` -/
+         `f a ≍ g b` -/
       return true
     else if f.isApp && g.isApp then
       -- Case 2: `f` and `g` are congruent
@@ -100,7 +100,7 @@ partial def isCongruent (e₁ e₂ : Expr) : CCM Bool := do
       /-
       f and g are not congruent nor they have the same type.
       We can't generate a congruence proof in this case because the following lemma
-        `hcongr : HEq f₁ f₂ → HEq a₁ a₂ → HEq (f₁ a₁) (f₂ a₂)`
+        `hcongr : f₁ ≍ f₂ → a₁ ≍ a₂ → f₁ a₁ ≍ f₂ a₂`
       is not provable.
       Remark: it is also not provable in MLTT, Coq and Agda (even if we assume UIP).
       -/
@@ -415,7 +415,7 @@ partial def mkProof (lhs rhs : Expr) (H : EntryExpr) (heqProofs : Bool) : CCM Ex
   | .ofDExpr H => mkDelayedProof H
 
 /--
-If `asHEq` is `true`, then build a proof for `HEq e₁ e₂`.
+If `asHEq` is `true`, then build a proof for `e₁ ≍ e₂`.
 Otherwise, build a proof for `e₁ = e₂`.
 The result is `none` if `e₁` and `e₂` are not in the same equivalence class. -/
 partial def getEqProofCore (e₁ e₂ : Expr) (asHEq : Bool) : CCM (Option Expr) := do
@@ -493,7 +493,7 @@ The result is `none` if `e₁` and `e₂` are not in the same equivalence class.
 partial def getEqProof (e₁ e₂ : Expr) : CCM (Option Expr) :=
   getEqProofCore e₁ e₂ false
 
-/-- Build a proof for `HEq e₁ e₂`.
+/-- Build a proof for `e₁ ≍ e₂`.
 The result is `none` if `e₁` and `e₂` are not in the same equivalence class. -/
 @[inline]
 partial def getHEqProof (e₁ e₂ : Expr) : CCM (Option Expr) :=

--- a/Mathlib/Tactic/CongrExclamation.lean
+++ b/Mathlib/Tactic/CongrExclamation.lean
@@ -494,8 +494,8 @@ def CongrMetaM.nextPattern : CongrMetaM (Option (TSyntax `rcasesPat)) := do
     else
       (none, s)
 
-private theorem heq_imp_of_eq_imp {α : Sort*} {x y : α} {p : HEq x y → Prop}
-    (h : (he : x = y) → p (heq_of_eq he)) (he : HEq x y) : p he := by
+private theorem heq_imp_of_eq_imp {α : Sort*} {x y : α} {p : x ≍ y → Prop}
+    (h : (he : x = y) → p (heq_of_eq he)) (he : x ≍ y) : p he := by
   cases he
   exact h rfl
 
@@ -510,9 +510,9 @@ that is trivial. If there are any patterns in the current `CongrMetaM` state the
 of `Lean.MVarId.intros` it does `Lean.Elab..Tactic.RCases.rintro`.
 
 Cleaning up includes:
-- deleting hypotheses of the form `HEq x x`, `x = x`, and `x ↔ x`.
+- deleting hypotheses of the form `x ≍ x`, `x = x`, and `x ↔ x`.
 - deleting Prop hypotheses that are already in the local context.
-- converting `HEq x y` to `x = y` if possible.
+- converting `x ≍ y` to `x = y` if possible.
 - converting `x = y` to `x ↔ y` if possible.
 -/
 partial

--- a/Mathlib/Tactic/CongrM.lean
+++ b/Mathlib/Tactic/CongrM.lean
@@ -21,7 +21,7 @@ open Lean Parser Tactic Elab Tactic Meta
 initialize registerTraceClass `Tactic.congrm
 
 /--
-`congrm e` is a tactic for proving goals of the form `lhs = rhs`, `lhs ↔ rhs`, `HEq lhs rhs`,
+`congrm e` is a tactic for proving goals of the form `lhs = rhs`, `lhs ↔ rhs`, `lhs ≍ rhs`,
 or `R lhs rhs` when `R` is a reflexive relation.
 The expression `e` is a pattern containing placeholders `?_`,
 and this pattern is matched against `lhs` and `rhs` simultaneously.

--- a/Mathlib/Tactic/Subsingleton.lean
+++ b/Mathlib/Tactic/Subsingleton.lean
@@ -103,7 +103,7 @@ def Lean.MVarId.subsingleton (g : MVarId) (insts : Array (Term × AbstractMVarsR
 namespace Mathlib.Tactic
 
 /--
-The `subsingleton` tactic tries to prove a goal of the form `x = y` or `HEq x y`
+The `subsingleton` tactic tries to prove a goal of the form `x = y` or `x ≍ y`
 using the fact that the types involved are *subsingletons*
 (a type with exactly zero or one terms).
 To a first approximation, it does `apply Subsingleton.elim`.

--- a/Mathlib/Tactic/TermCongr.lean
+++ b/Mathlib/Tactic/TermCongr.lean
@@ -288,7 +288,7 @@ def CongrResult.eq (res : CongrResult) : MetaM Expr := do
   | some pf => pf .eq
   | none => mkEqRefl res.lhs
 
-/-- Returns the proof that `HEq lhs rhs`. Fails if the `CongrResult` is inapplicable.
+/-- Returns the proof that `lhs ≍ rhs`. Fails if the `CongrResult` is inapplicable.
 If `pf? = none`, this returns the `rfl` proof. -/
 def CongrResult.heq (res : CongrResult) : MetaM Expr := do
   match res.pf? with

--- a/Mathlib/Topology/ContinuousMap/Sigma.lean
+++ b/Mathlib/Topology/ContinuousMap/Sigma.lean
@@ -48,7 +48,7 @@ theorem isEmbedding_sigmaMk_comp [Nonempty X] :
       ⟨_, (isOpen_sigma_fst_preimage {i}).preimage (continuous_eval_const x), fun _ ↦ Iff.rfl⟩⟩
   injective := by
     rintro ⟨i, g⟩ ⟨i', g'⟩ h
-    obtain ⟨rfl, hg⟩ : i = i' ∧ HEq (⇑g) (⇑g') :=
+    obtain ⟨rfl, hg⟩ : i = i' ∧ ⇑g ≍ ⇑g' :=
       Function.eq_of_sigmaMk_comp <| congr_arg DFunLike.coe h
     simpa using hg
 

--- a/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorff.lean
@@ -710,7 +710,7 @@ instance : SecondCountableTopology GHSpace := by
       -- use the equality between `F p` and `F q` to deduce that the distances have equal
       -- integer parts
       have : (F p).2 ⟨i, hip⟩ ⟨j, hjp⟩ = (F q).2 ⟨i, hiq⟩ ⟨j, hjq⟩ := by
-        have hpq' : HEq (F p).snd (F q).snd := (Sigma.mk.inj_iff.1 hpq).2
+        have hpq' : (F p).snd ≍ (F q).snd := (Sigma.mk.inj_iff.1 hpq).2
         rw [Fin.heq_fun₂_iff Npq Npq] at hpq'
         rw [← hpq']
       rw [Ap, Aq] at this
@@ -863,7 +863,7 @@ theorem totallyBounded {t : Set GHSpace} {C : ℝ} {u : ℕ → ℝ} {K : ℕ �
       -- use the equality between `F p` and `F q` to deduce that the distances have equal
       -- integer parts
       have : ((F p).2 ⟨i, hip⟩ ⟨j, hjp⟩).1 = ((F q).2 ⟨i, hiq⟩ ⟨j, hjq⟩).1 := by
-        have hpq' : HEq (F p).snd (F q).snd := (Sigma.mk.inj_iff.1 hpq).2
+        have hpq' : (F p).snd ≍ (F q).snd := (Sigma.mk.inj_iff.1 hpq).2
         rw [Fin.heq_fun₂_iff Npq Npq] at hpq'
         rw [← hpq']
       have : ⌊ε⁻¹ * dist x y⌋ = ⌊ε⁻¹ * dist (Ψ x) (Ψ y)⌋ := by

--- a/MathlibTest/MkIffOfInductive.lean
+++ b/MathlibTest/MkIffOfInductive.lean
@@ -35,7 +35,7 @@ mk_iff_of_inductive_prop Eq       test.eq_iff
 example (α : Sort u) (a b : α) : a = b ↔ b = a := test.eq_iff a b
 
 mk_iff_of_inductive_prop HEq      test.heq_iff
-example {α : Sort u} (a : α) {β : Sort u} (b : β) : HEq a b ↔ β = α ∧ HEq b a := test.heq_iff a b
+example {α : Sort u} (a : α) {β : Sort u} (b : β) : a ≍ b ↔ β = α ∧ b ≍ a := test.heq_iff a b
 
 mk_iff_of_inductive_prop List.Perm test.perm_iff
 open scoped List in

--- a/MathlibTest/Subsingleton.lean
+++ b/MathlibTest/Subsingleton.lean
@@ -20,7 +20,7 @@ example (p : Prop) (h h' : p) : h = h' := by subsingleton
 /-!
 HEq proof irrelevance
 -/
-example (p q : Prop) (h : p) (h' : q) : HEq h h' := by subsingleton
+example (p q : Prop) (h : p) (h' : q) : h ≍ h' := by subsingleton
 
 /-!
 Does intros.
@@ -30,7 +30,7 @@ example : ∀ {α : Type} [Subsingleton α] (x y : α), x = y := by subsingleton
 /-!
 Does intros, and turns HEq into Eq if possible.
 -/
-example : ∀ {α : Type} [Subsingleton α] (x y : α), HEq x y := by subsingleton
+example : ∀ {α : Type} [Subsingleton α] (x y : α), x ≍ y := by subsingleton
 
 section AvoidSurprise
 

--- a/MathlibTest/TermCongr.lean
+++ b/MathlibTest/TermCongr.lean
@@ -145,7 +145,7 @@ to be definitionally equal to
 -/
 #guard_msgs in
 example {s t : α → Prop} (h : s = t) :
-    HEq (fun (n : Subtype s) => true) (fun (n : Subtype t) => true) :=
+    (fun (n : Subtype s) => true) ≍ (fun (n : Subtype t) => true) :=
   congr(fun (n : Subtype $h) => true)
 
 /--

--- a/MathlibTest/cc.lean
+++ b/MathlibTest/cc.lean
@@ -67,31 +67,31 @@ example (a b c : Nat) (f : Nat → Nat → Nat) :
 example (a b c : Nat) (f : Nat → Nat → Nat) : a = b → c = b → f (f a b) a = f (f c c) c := by
   cc
 
-example (a b c d : Nat) : HEq a b → b = c → HEq c d → HEq a d := by
+example (a b c d : Nat) : a ≍ b → b = c → c ≍ d → a ≍ d := by
   cc
 
-example (a b c d : Nat) : a = b → b = c → HEq c d → HEq a d := by
+example (a b c d : Nat) : a = b → b = c → c ≍ d → a ≍ d := by
   cc
 
-example (a b c d : Nat) : a = b → HEq b c → HEq c d → HEq a d := by
+example (a b c d : Nat) : a = b → b ≍ c → c ≍ d → a ≍ d := by
   cc
 
-example (a b c d : Nat) : HEq a b → HEq b c → c = d → HEq a d := by
+example (a b c d : Nat) : a ≍ b → b ≍ c → c = d → a ≍ d := by
   cc
 
-example (a b c d : Nat) : HEq a b → b = c → c = d → HEq a d := by
+example (a b c d : Nat) : a ≍ b → b = c → c = d → a ≍ d := by
   cc
 
-example (a b c d : Nat) : a = b → b = c → c = d → HEq a d := by
+example (a b c d : Nat) : a = b → b = c → c = d → a ≍ d := by
   cc
 
-example (a b c d : Nat) : a = b → HEq b c → c = d → HEq a d := by
+example (a b c d : Nat) : a = b → b ≍ c → c = d → a ≍ d := by
   cc
 
 axiom f₁ : {α : Type} → α → α → α
 axiom g₁ : Nat → Nat
 
-example (a b c : Nat) : a = b → HEq (g₁ a) (g₁ b) := by
+example (a b c : Nat) : a = b → g₁ a ≍ g₁ b := by
   cc
 
 example (a b c : Nat) : a = b → c = b → f₁ (f₁ a b) (g₁ c) = f₁ (f₁ c a) (g₁ b) := by
@@ -149,7 +149,7 @@ example (a b : Nat) : (a = b ↔ a = b) := by
 example (a b : Nat) : (a = b) = (b = a) := by
   cc
 
-example (a b : Nat) : HEq (a = b) (b = a) := by
+example (a b : Nat) : (a = b) ≍ (b = a) := by
   cc
 
 example (p : Nat → Nat → Prop) (f : Nat → Nat) (a b c d : Nat) :
@@ -176,40 +176,40 @@ example (a b c : Nat) : a = b → R a b → R a a := by
 example (a b c : Prop) : a = b → b = c → (a ↔ c) := by
   cc
 
-example (a b c : Prop) : a = b → HEq b c → (a ↔ c) := by
+example (a b c : Prop) : a = b → b ≍ c → (a ↔ c) := by
   cc
 
-example (a b c : Nat) : HEq a b → b = c → HEq a c := by
+example (a b c : Nat) : a ≍ b → b = c → a ≍ c := by
   cc
 
-example (a b c : Nat) : HEq a b → b = c → a = c := by
+example (a b c : Nat) : a ≍ b → b = c → a = c := by
   cc
 
-example (a b c d : Nat) : HEq a b → HEq b c → HEq c d → a = d := by
+example (a b c d : Nat) : a ≍ b → b ≍ c → c ≍ d → a = d := by
   cc
 
-example (a b c d : Nat) : HEq a b → b = c → HEq c d → a = d := by
+example (a b c d : Nat) : a ≍ b → b = c → c ≍ d → a = d := by
   cc
 
 example (a b c : Prop) : a = b → b = c → (a ↔ c) := by
   cc
 
-example (a b c : Prop) : HEq a b → b = c → (a ↔ c) := by
+example (a b c : Prop) : a ≍ b → b = c → (a ↔ c) := by
   cc
 
-example (a b c d : Prop) : HEq a b → HEq b c → HEq c d → (a ↔ d) := by
+example (a b c d : Prop) : a ≍ b → b ≍ c → c ≍ d → (a ↔ d) := by
   cc
 
-def foo (a b c d : Prop) : HEq a b → b = c → HEq c d → (a ↔ d) := by
+def foo (a b c d : Prop) : a ≍ b → b = c → c ≍ d → (a ↔ d) := by
   cc
 
-example (a b c : Nat) (f : Nat → Nat) : HEq a b → b = c → HEq (f a) (f c) := by
+example (a b c : Nat) (f : Nat → Nat) : a ≍ b → b = c → f a ≍ f c := by
   cc
 
-example (a b c : Nat) (f : Nat → Nat) : HEq a b → b = c → f a = f c := by
+example (a b c : Nat) (f : Nat → Nat) : a ≍ b → b = c → f a = f c := by
   cc
 
-example (a b c d : Nat) (f : Nat → Nat) : HEq a b → b = c → HEq c (f d) → f a = f (f d) := by
+example (a b c d : Nat) (f : Nat → Nat) : a ≍ b → b = c → c ≍ f d → f a = f (f d) := by
   cc
 
 end CC3
@@ -225,17 +225,17 @@ axiom app : {α : Type u} → {n m : Nat} →
 
 example (n1 n2 n3 : Nat)
     (v1 w1 : List.Vector Nat n1) (w1' : List.Vector Nat n3) (v2 w2 : List.Vector Nat n2) :
-    n1 = n3 → v1 = w1 → HEq w1 w1' → v2 = w2 → HEq (app v1 v2) (app w1' w2) := by
+    n1 = n3 → v1 = w1 → w1 ≍ w1' → v2 = w2 → app v1 v2 ≍ app w1' w2 := by
   cc
 
 example (n1 n2 n3 : Nat)
     (v1 w1 : List.Vector Nat n1) (w1' : List.Vector Nat n3) (v2 w2 : List.Vector Nat n2) :
-    HEq n1 n3 → v1 = w1 → HEq w1 w1' → HEq v2 w2 → HEq (app v1 v2) (app w1' w2) := by
+    n1 ≍ n3 → v1 = w1 → w1 ≍ w1' → v2 ≍ w2 → app v1 v2 ≍ app w1' w2 := by
   cc
 
 example (n1 n2 n3 : Nat)
     (v1 w1 v : List.Vector Nat n1) (w1' : List.Vector Nat n3) (v2 w2 w : List.Vector Nat n2) :
-    HEq n1 n3 → v1 = w1 → HEq w1 w1' → HEq v2 w2 → HEq (app w1' w2) (app v w) →
+    n1 ≍ n3 → v1 = w1 → w1 ≍ w1' → v2 ≍ w2 → app w1' w2 ≍ app v w →
       app v1 v2 = app v w := by
   cc
 
@@ -270,53 +270,53 @@ axiom h : {a : A} → {ba : B a} → {cba : C a ba} → {dcba : D a ba cba} →
 
 attribute [instance] C_ss
 
-example : ∀ (a a' : A), HEq a a' → HEq (mk_B1 a) (mk_B1 a') := by
+example : ∀ (a a' : A), a ≍ a' → mk_B1 a ≍ mk_B1 a' := by
   cc
 
-example : ∀ (a a' : A), HEq a a' → HEq (mk_B2 a) (mk_B2 a') := by
+example : ∀ (a a' : A), a ≍ a' → mk_B2 a ≍ mk_B2 a' := by
   cc
 
-example : ∀ (a a' : A) (h : a = a') (b : B a), HEq (h ▸ b) b := by
+example : ∀ (a a' : A) (h : a = a') (b : B a), h ▸ b ≍ b := by
   cc
 
-example : HEq a1 (y a2) → HEq (mk_B1 a1) (mk_B1 (y a2)) := by
+example : a1 ≍ y a2 → mk_B1 a1 ≍ mk_B1 (y a2) := by
   cc
 
-example : HEq a1 (x a2) → HEq a2 (y a1) → HEq (mk_B1 (x (y a1))) (mk_B1 (x (y (x a2)))) := by
+example : a1 ≍ x a2 → a2 ≍ y a1 → mk_B1 (x (y a1)) ≍ mk_B1 (x (y (x a2))) := by
   cc
 
-example : HEq a1 (y a2) → HEq (mk_B1 a1) (mk_B2 (y a2)) →
-    HEq (f (mk_C1 (mk_B2 a1))) (f (mk_C2 (mk_B1 (y a2)))) := by
+example : a1 ≍ y a2 → mk_B1 a1 ≍ mk_B2 (y a2) →
+    f (mk_C1 (mk_B2 a1)) ≍ f (mk_C2 (mk_B1 (y a2))) := by
   cc
 
-example : HEq a1 (y a2) → HEq (tr_B (mk_B1 a1)) (mk_B2 (y a2)) →
-    HEq (f (mk_C1 (mk_B2 a1))) (f (mk_C2 (tr_B (mk_B1 (y a2))))) := by
+example : a1 ≍ y a2 → tr_B (mk_B1 a1) ≍ mk_B2 (y a2) →
+    f (mk_C1 (mk_B2 a1)) ≍ f (mk_C2 (tr_B (mk_B1 (y a2)))) := by
   cc
 
-example : HEq a1 (y a2) → HEq (mk_B1 a1) (mk_B2 (y a2)) →
-    HEq (g (f (mk_C1 (mk_B2 a1)))) (g (f (mk_C2 (mk_B1 (y a2))))) := by
+example : a1 ≍ y a2 → mk_B1 a1 ≍ (mk_B2 (y a2)) →
+    g (f (mk_C1 (mk_B2 a1))) ≍ g (f (mk_C2 (mk_B1 (y a2)))) := by
   cc
 
-example : HEq a1 (y a2) → HEq (tr_B (mk_B1 a1)) (mk_B2 (y a2)) →
-    HEq (g (f (mk_C1 (mk_B2 a1)))) (g (f (mk_C2 (tr_B (mk_B1 (y a2)))))) := by
+example : a1 ≍ y a2 → tr_B (mk_B1 a1) ≍ mk_B2 (y a2) →
+    g (f (mk_C1 (mk_B2 a1))) ≍ g (f (mk_C2 (tr_B (mk_B1 (y a2))))) := by
   cc
 
-example : HEq a1 (y a2) → HEq a2 (z a3) → HEq a3 (x a1) → HEq (mk_B1 a1) (mk_B2 (y (z (x a1)))) →
-          HEq (f (mk_C1 (mk_B2 (y (z (x a1)))))) (f' (mk_C2 (mk_B1 a1))) →
-          HEq (g (f (mk_C1 (mk_B2 (y (z (x a1))))))) (g (f' (mk_C2 (mk_B1 a1)))) := by
+example : a1 ≍ y a2 → a2 ≍ z a3 → a3 ≍ x a1 → mk_B1 a1 ≍ mk_B2 (y (z (x a1))) →
+          f (mk_C1 (mk_B2 (y (z (x a1))))) ≍ f' (mk_C2 (mk_B1 a1)) →
+          g (f (mk_C1 (mk_B2 (y (z (x a1)))))) ≍ g (f' (mk_C2 (mk_B1 a1))) := by
   cc
 
-example : HEq a1 (y a2) → HEq a2 (z a3) → HEq a3 (x a1) → HEq (mk_B1 a1) (mk_B2 (y (z (x a1)))) →
-          HEq (f (mk_C1 (mk_B2 (y (z (x a1)))))) (f' (mk_C2 (mk_B1 a1))) →
-          HEq (f' (mk_C1 (mk_B1 a1))) (f (mk_C2 (mk_B2 (y (z (x a1)))))) →
-          HEq (g (f (mk_C1 (mk_B1 (y (z (x a1))))))) (g (f' (mk_C2 (mk_B2 a1)))) := by
+example : a1 ≍ y a2 → a2 ≍ z a3 → a3 ≍ x a1 → mk_B1 a1 ≍ mk_B2 (y (z (x a1))) →
+          f (mk_C1 (mk_B2 (y (z (x a1))))) ≍ f' (mk_C2 (mk_B1 a1)) →
+          f' (mk_C1 (mk_B1 a1)) ≍ f (mk_C2 (mk_B2 (y (z (x a1))))) →
+          g (f (mk_C1 (mk_B1 (y (z (x a1)))))) ≍ g (f' (mk_C2 (mk_B2 a1))) := by
   cc
 
-example : HEq a1 (y a2) → HEq a2 (z a3) → HEq a3 (x a1) →
-          HEq (tr_B (mk_B1 a1)) (mk_B2 (y (z (x a1)))) →
-          HEq (f (mk_C1 (mk_B2 (y (z (x a1)))))) (f' (mk_C2 (tr_B (mk_B1 a1)))) →
-          HEq (f' (mk_C1 (tr_B (mk_B1 a1)))) (f (mk_C2 (mk_B2 (y (z (x a1)))))) →
-          HEq (g (f (mk_C1 (tr_B (mk_B1 (y (z (x a1)))))))) (g (f' (mk_C2 (mk_B2 a1)))) := by
+example : a1 ≍ y a2 → a2 ≍ z a3 → a3 ≍ x a1 →
+          tr_B (mk_B1 a1) ≍ mk_B2 (y (z (x a1))) →
+          f (mk_C1 (mk_B2 (y (z (x a1))))) ≍ f' (mk_C2 (tr_B (mk_B1 a1))) →
+          f' (mk_C1 (tr_B (mk_B1 a1))) ≍ f (mk_C2 (mk_B2 (y (z (x a1))))) →
+          g (f (mk_C1 (tr_B (mk_B1 (y (z (x a1))))))) ≍ g (f' (mk_C2 (mk_B2 a1))) := by
   cc
 
 end LocalAxioms
@@ -330,7 +330,7 @@ example (a b c a' b' c' : Nat) : a = a' → b = b' → c = c' → a + b + c + a 
 example (a b : Unit) : a = b := by
   cc
 
-example (a b : Nat) (h₁ : a = 0) (h₂ : b = 0) : a = b → HEq h₁ h₂ := by
+example (a b : Nat) (h₁ : a = 0) (h₂ : b = 0) : a = b → h₁ ≍ h₂ := by
   cc
 
 axiom inv' : (a : Nat) → a ≠ 0 → Nat
@@ -339,7 +339,7 @@ example (a b : Nat) (h₁ : a ≠ 0) (h₂ : b ≠ 0) : a = b → inv' a h₁ = 
   cc
 
 example (C : Nat → Type) (f : (n : _) → C n → C n) (n m : Nat) (c : C n) (d : C m) :
-    HEq (f n) (f m) → HEq c d → HEq n m → HEq (f n c) (f m d) := by
+    f n ≍ f m → c ≍ d → n ≍ m → f n c ≍ f m d := by
   cc
 
 end CC6
@@ -352,7 +352,7 @@ example (f g : {α : Type} → α → α → α) (h : Nat → Nat) (a b : Nat) :
 
 example (f g : {α : Type} → (a b : α) → {x : α // x ≠ b})
     (h : (b : Nat) → {x : Nat // x ≠ b}) (a b₁ b₂ : Nat) :
-    h = f a → b₁ = b₂ → HEq (h b₁) (f a b₂) := by
+    h = f a → b₁ = b₂ → h b₁ ≍ f a b₂ := by
   cc
 
 example (f : Nat → Nat → Nat) (a b c d : Nat) :
@@ -360,7 +360,7 @@ example (f : Nat → Nat → Nat) (a b c d : Nat) :
   cc
 
 example (f : Nat → Nat → Nat) (a b c d : Nat) :
-        HEq c d → HEq (f a) (f b) → HEq (f a c) (f b d) := by
+        c ≍ d → f a ≍ f b → f a c ≍ f b d := by
   cc
 
 end CC7

--- a/MathlibTest/congr.lean
+++ b/MathlibTest/congr.lean
@@ -36,7 +36,7 @@ theorem ex6 : ((a : Nat) × Fin (a + 1)) = ((a : Nat) × Fin (1 + a)) := by
 theorem ex7 (p : Prop) (h1 h2 : p) : h1 = h2 := by
   congr!
 
-theorem ex8 (p q : Prop) (h1 : p) (h2 : q) : HEq h1 h2 := by
+theorem ex8 (p q : Prop) (h1 : p) (h2 : q) : h1 ≍ h2 := by
   congr!
 
 theorem ex9 (a b : Nat) (h : a = b) : a + 1 ≤ b + 1 := by
@@ -54,13 +54,13 @@ theorem ex12 (p q : Prop) (h : p ↔ q) : p = q := by
 theorem ex13 (x y : α) (h : x = y) (f : α → Nat) : f x = f y := by
   congr!
 
-theorem ex14 {α : Type} (f : Nat → Nat) (h : ∀ x, f x = 0) (z : α) (hz : HEq z 0) :
-    HEq f (fun (_ : α) => z) := by
+theorem ex14 {α : Type} (f : Nat → Nat) (h : ∀ x, f x = 0) (z : α) (hz : z ≍ 0) :
+    f ≍ fun (_ : α) => z := by
   congr!
   · guard_target = Nat = α
     exact type_eq_of_heq hz.symm
   next n x _ =>
-    guard_target = HEq (f n) z
+    guard_target = f n ≍ z
     rw [h]
     exact hz.symm
 
@@ -85,7 +85,7 @@ example (s t : Set α) (f : Subtype s → α) (g : Subtype t → α) :
   congr!
   · guard_target = s = t
     exact test_sorry
-  · guard_target = HEq f g
+  · guard_target = f ≍ g
     exact test_sorry
 
 set_option linter.unusedTactic false in
@@ -101,7 +101,7 @@ example {ι κ : Type u} (f : ι → α) (g : κ → α) :
   congr! +typeEqs
   · guard_target = ι = κ
     exact test_sorry
-  · guard_target = HEq f g
+  · guard_target = f ≍ g
     exact test_sorry
 
 /- Generating type equalities is not OK if they're not likely to be the same type. -/
@@ -111,11 +111,11 @@ example (s : Set α) (t : Set β) : (ℕ × Subtype s) = (ℕ × Subtype t) := b
   exact test_sorry
 
 /- Congruence here is OK since `Fin m = Fin n` is plausible to prove. -/
-example (m n : Nat) (h : m = n) (x : Fin m) (y : Fin n) : HEq (x + x) (y + y) := by
+example (m n : Nat) (h : m = n) (x : Fin m) (y : Fin n) : x + x ≍ y + y := by
   congr!
-  guard_target = HEq x y
+  guard_target = x ≍ y
   exact test_sorry
-  guard_target = HEq x y
+  guard_target = x ≍ y
   exact test_sorry
 
 /- Props are types, but prop equalities are totally plausible. -/
@@ -126,16 +126,16 @@ example (p q r : Prop) : p ∧ q ↔ p ∧ r := by
 
 set_option linter.unusedTactic false in
 /- Congruence here is not OK by default since `α = β` is not generally plausible. -/
-example (α β) [inst1 : Add α] [inst2 : Add β] (x : α) (y : β) : HEq (x + x) (y + y) := by
+example (α β) [inst1 : Add α] [inst2 : Add β] (x : α) (y : β) : x + x ≍ y + y := by
   congr!
-  guard_target = HEq (x + x) (y + y)
+  guard_target = x + x ≍ y + y
   -- But with typeEqs we can get it to generate the congruence anyway:
   have : α = β := test_sorry
-  have : HEq inst1 inst2 := test_sorry
+  have : inst1 ≍ inst2 := test_sorry
   congr! +typeEqs
-  guard_target = HEq x y
+  guard_target = x ≍ y
   exact test_sorry
-  guard_target = HEq x y
+  guard_target = x ≍ y
   exact test_sorry
 
 example (prime : Nat → Prop) (n : Nat) :
@@ -180,19 +180,19 @@ def walk.map (f : α → β) (w : walk α x y) : walk β (f x) (f y) :=
   match x, y, w with
   | _, _, .nil n => .nil (f n)
 
-example (w : walk α x y) (w' : walk α x' y') (f : α → β) : HEq (w.map f) (w'.map f) := by
+example (w : walk α x y) (w' : walk α x' y') (f : α → β) : w.map f ≍ w'.map f := by
   congr!
   guard_target = x = x'
   exact test_sorry
   guard_target = y = y'
   exact test_sorry
-  -- get x = y and y = y' in context for `HEq w w'` goal.
+  -- get x = y and y = y' in context for `w ≍ w'` goal.
   have : x = x' := by assumption
   have : y = y' := by assumption
-  guard_target = HEq w w'
+  guard_target = w ≍ w'
   exact test_sorry
 
-example (w : walk α x y) (w' : walk α x' y') (f : α → β) : HEq (w.map f) (w'.map f) := by
+example (w : walk α x y) (w' : walk α x' y') (f : α → β) : w.map f ≍ w'.map f := by
   congr! with rfl rfl
   guard_target = x = x'
   exact test_sorry
@@ -266,17 +266,17 @@ example (x y z : Nat) (h : x = z) (hy : y = 2) : 1 + x + y = g z + 2 := by
 
 set_option linter.unusedTactic false in
 example (Fintype : Type → Type)
-    (α β : Type) (inst : Fintype α) (inst' : Fintype β) : HEq inst inst' := by
+    (α β : Type) (inst : Fintype α) (inst' : Fintype β) : inst ≍ inst' := by
   congr!
-  guard_target = HEq inst inst'
+  guard_target = inst ≍ inst'
   exact test_sorry
 
 /- Here, `Fintype` is a subsingleton class so the `HEq` reduces to `Fintype α = Fintype β`.
 Since these are explicit type arguments with no forward dependencies, this reduces to `α = β`.
 Generating a type equality seems like the right thing to do in this context.
-Usually `HEq inst inst'` wouldn't be generated as a subgoal with the default `typeEqs := false`. -/
+Usually `inst ≍ inst'` wouldn't be generated as a subgoal with the default `typeEqs := false`. -/
 example (Fintype : Type → Type) [∀ γ, Subsingleton (Fintype γ)]
-    (α β : Type) (inst : Fintype α) (inst' : Fintype β) : HEq inst inst' := by
+    (α β : Type) (inst : Fintype α) (inst' : Fintype β) : inst ≍ inst' := by
   congr!
   guard_target = α = β
   exact test_sorry

--- a/MathlibTest/congrm.lean
+++ b/MathlibTest/congrm.lean
@@ -111,7 +111,7 @@ example (f : α → Prop) (h : ∀ a, f a ↔ True) : (∀ a : α, f a) ↔ (∀
   congrm ∀ _, ?_
   exact h _
 
-example (α : Nat → Type) (f : (x : Nat) → α x) (h : i = j) : HEq (f i) (f j) := by
+example (α : Nat → Type) (f : (x : Nat) → α x) (h : i = j) : f i ≍ f j := by
   congrm f ?_
   exact h
 

--- a/MathlibTest/convert.lean
+++ b/MathlibTest/convert.lean
@@ -118,7 +118,7 @@ example {α β : Type u} [Fintype α] [Fintype β] : Fintype.card α = Fintype.c
   · guard_target = α = β
     exact test_sorry
   · rename_i inst1 inst2 h
-    guard_target = HEq inst1 inst2
+    guard_target = inst1 ≍ inst2
     have : Subsingleton (Fintype α) := test_sorry
     congr!
 


### PR DESCRIPTION
The notation `≍` for `HEq` was introduced in leanprover/lean4#8503 and all instances of `HEq x y` in core and Batteries are replaced with `x ≍ y` in leanprover/lean4#8872 and leanprover-community/batteries#1298.
This PR applies the same replacement in Mathlib.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
