### PR TITLE
chore(Data/Set/Image): move `BooleanAlgebra` material to `Order`

### DIFF
--- a/Mathlib/Algebra/Notation/Support.lean
+++ b/Mathlib/Algebra/Notation/Support.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Algebra.Notation.Pi.Basic
 public import Mathlib.Algebra.Notation.Prod
-public import Mathlib.Data.Set.Image
+public import Mathlib.Order.BooleanAlgebra.Set
 
 /-!
 # Support of a function

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -8,9 +8,8 @@ module
 public import Batteries.Tactic.Congr
 public import Mathlib.Data.Option.Basic
 public import Mathlib.Data.Prod.Basic
-public import Mathlib.Data.Set.Subsingleton
-public import Mathlib.Data.Set.SymmDiff
 public import Mathlib.Data.Set.Inclusion
+public import Mathlib.Data.Set.Subsingleton
 
 /-!
 # Images and preimages of sets
@@ -36,7 +35,7 @@ set, sets, image, preimage, pre-image, range
 
 @[expose] public section
 
-assert_not_exists WithTop OrderIso
+assert_not_exists HeytingAlgebra WithTop OrderIso
 
 universe u v
 
@@ -77,24 +76,6 @@ theorem preimage_inter {s t : Set β} : f ⁻¹' (s ∩ t) = f ⁻¹' s ∩ f �
 
 @[simp]
 theorem preimage_union {s t : Set β} : f ⁻¹' (s ∪ t) = f ⁻¹' s ∪ f ⁻¹' t :=
-  rfl
-
-@[simp]
-theorem preimage_compl {s : Set β} : f ⁻¹' sᶜ = (f ⁻¹' s)ᶜ :=
-  rfl
-
-@[simp]
-theorem preimage_diff (f : α → β) (s t : Set β) : f ⁻¹' (s \ t) = f ⁻¹' s \ f ⁻¹' t :=
-  rfl
-
-open scoped symmDiff in
-@[simp]
-lemma preimage_symmDiff {f : α → β} (s t : Set β) : f ⁻¹' (s ∆ t) = (f ⁻¹' s) ∆ (f ⁻¹' t) :=
-  rfl
-
-@[simp]
-theorem preimage_ite (f : α → β) (s t₁ t₂ : Set β) :
-    f ⁻¹' s.ite t₁ t₂ = (f ⁻¹' s).ite (f ⁻¹' t₁) (f ⁻¹' t₂) :=
   rfl
 
 @[simp]
@@ -274,16 +255,6 @@ theorem image_eq_empty {α β} {f : α → β} {s : Set α} : f '' s = ∅ ↔ s
   simp only [eq_empty_iff_forall_notMem]
   exact ⟨fun H a ha => H _ ⟨_, ha, rfl⟩, fun H b ⟨_, ha, _⟩ => H _ ha⟩
 
-theorem preimage_compl_eq_image_compl [BooleanAlgebra α] (s : Set α) :
-    Compl.compl ⁻¹' s = Compl.compl '' s :=
-  Set.ext fun x =>
-    ⟨fun h => ⟨xᶜ, h, compl_compl x⟩, fun h =>
-      Exists.elim h fun _ hy => (compl_eq_comm.mp hy.2).symm.subst hy.1⟩
-
-theorem mem_compl_image [BooleanAlgebra α] (t : α) (s : Set α) :
-    t ∈ Compl.compl '' s ↔ tᶜ ∈ s := by
-  simp [← preimage_compl_eq_image_compl]
-
 @[simp]
 theorem image_id_eq : image (id : α → α) = id := by ext; simp
 
@@ -299,10 +270,6 @@ lemma image_iterate_eq {f : α → α} {n : ℕ} : image (f^[n]) = (image f)^[n]
   induction n with
   | zero => simp
   | succ n ih => rw [iterate_succ', iterate_succ', ← ih, image_comp_eq]
-
-theorem compl_compl_image [BooleanAlgebra α] (s : Set α) :
-    Compl.compl '' (Compl.compl '' s) = s := by
-  rw [← image_comp, compl_comp_compl, image_id]
 
 theorem image_insert_eq {f : α → β} {a : α} {s : Set α} :
     f '' insert a s = insert (f a) (f '' s) := by grind
@@ -342,35 +309,6 @@ theorem _root_.Function.Involutive.image_eq_preimage_symm {f : α → α} (hf : 
 theorem mem_image_iff_of_inverse {f : α → β} {g : β → α} {b : β} {s : Set α} (h₁ : LeftInverse g f)
     (h₂ : RightInverse g f) : b ∈ f '' s ↔ g b ∈ s := by
   rw [image_eq_preimage_of_inverse h₁ h₂]; rfl
-
-theorem image_compl_subset {f : α → β} {s : Set α} (H : Injective f) : f '' sᶜ ⊆ (f '' s)ᶜ :=
-  Disjoint.subset_compl_left <| by simp [disjoint_iff_inf_le, ← image_inter H]
-
-theorem subset_image_compl {f : α → β} {s : Set α} (H : Surjective f) : (f '' s)ᶜ ⊆ f '' sᶜ :=
-  compl_subset_iff_union.2 <| by
-    rw [← image_union]
-    simp [image_univ_of_surjective H]
-
-theorem image_compl_eq {f : α → β} {s : Set α} (H : Bijective f) : f '' sᶜ = (f '' s)ᶜ :=
-  Subset.antisymm (image_compl_subset H.1) (subset_image_compl H.2)
-
-theorem subset_image_diff (f : α → β) (s t : Set α) : f '' s \ f '' t ⊆ f '' (s \ t) := by
-  rw [diff_subset_iff, ← image_union, union_diff_self]
-  exact image_mono subset_union_right
-
-open scoped symmDiff in
-theorem subset_image_symmDiff : (f '' s) ∆ (f '' t) ⊆ f '' s ∆ t :=
-  (union_subset_union (subset_image_diff _ _ _) <| subset_image_diff _ _ _).trans
-    (superset_of_eq (image_union _ _ _))
-
-theorem image_diff {f : α → β} (hf : Injective f) (s t : Set α) : f '' (s \ t) = f '' s \ f '' t :=
-  Subset.antisymm
-    (Subset.trans (image_inter_subset _ _ _) <| inter_subset_inter_right _ <| image_compl_subset hf)
-    (subset_image_diff f s t)
-
-open scoped symmDiff in
-theorem image_symmDiff (hf : Injective f) (s t : Set α) : f '' s ∆ t = (f '' s) ∆ (f '' t) := by
-  simp_rw [Set.symmDiff_def, image_union, image_diff hf]
 
 theorem Nonempty.image (f : α → β) {s : Set α} : s.Nonempty → (f '' s).Nonempty
   | ⟨x, hx⟩ => ⟨f x, mem_image_of_mem f hx⟩
@@ -452,15 +390,6 @@ theorem disjoint_image_left {f : α → β} {s : Set α} {t : Set β} :
 theorem disjoint_image_right {f : α → β} {s : Set α} {t : Set β} :
     Disjoint t (f '' s) ↔ Disjoint (f ⁻¹' t) s := by
   rw [disjoint_comm, disjoint_comm (b := s), disjoint_image_left]
-
-theorem image_diff_preimage {f : α → β} {s : Set α} {t : Set β} :
-    f '' (s \ f ⁻¹' t) = f '' s \ t := by simp_rw [diff_eq, ← preimage_compl, image_inter_preimage]
-
-theorem compl_image : image (compl : Set α → Set α) = preimage compl :=
-  image_eq_preimage_of_inverse compl_compl compl_compl
-
-theorem compl_image_set_of {p : Set α → Prop} : compl '' { s | p s } = { s | p sᶜ } :=
-  congr_fun compl_image p
 
 theorem inter_preimage_subset (s : Set α) (t : Set β) (f : α → β) :
     s ∩ f ⁻¹' t ⊆ f ⁻¹' (f '' s ∩ t) := fun _ h => ⟨mem_image_of_mem _ h.left, h.right⟩
@@ -547,7 +476,8 @@ theorem powerset_insert (s : Set α) (a : α) : 𝒫 insert a s = 𝒫 s ∪ ins
     by_cases hs : a ∈ t
     · right
       refine ⟨t \ {a}, by grind⟩
-    · grind
+    · left
+      grind
   · grind
 
 theorem disjoint_powerset_insert {s : Set α} {a : α} (h : a ∉ s) :
@@ -586,13 +516,6 @@ theorem subset_range_of_surjective {f : α → β} (h : Surjective f) (s : Set �
 
 @[simp]
 theorem image_univ {f : α → β} : f '' univ = range f := by grind
-
-lemma image_compl_eq_range_diff_image {f : α → β} (hf : Injective f) (s : Set α) :
-    f '' sᶜ = range f \ f '' s := by rw [← image_univ, ← image_diff hf, compl_eq_univ_diff]
-
-/-- Alias of `Set.image_compl_eq_range_sdiff_image`. -/
-lemma range_diff_image {f : α → β} (hf : Injective f) (s : Set α) : range f \ f '' s = f '' sᶜ := by
-  rw [image_compl_eq_range_diff_image hf]
 
 @[simp]
 theorem preimage_eq_univ_iff {f : α → β} {s} : f ⁻¹' s = univ ↔ range f ⊆ s := by
@@ -658,12 +581,6 @@ theorem range_eq_singleton [Nonempty ι] {y} (hy : ∀ (x : ι), f x = y) :
 
 instance instNonemptyRange [Nonempty ι] (f : ι → α) : Nonempty (range f) :=
   (range_nonempty f).to_subtype
-
-@[simp]
-theorem image_union_image_compl_eq_range (f : α → β) : f '' s ∪ f '' sᶜ = range f := by grind
-
-theorem insert_image_compl_eq_range (f : α → β) (x : α) : insert (f x) (f '' {x}ᶜ) = range f := by
-  grind
 
 theorem image_preimage_eq_range_inter {f : α → β} {t : Set β} : f '' (f ⁻¹' t) = range f ∩ t := by
   grind
@@ -786,14 +703,6 @@ theorem preimage_inl_range_inr : Sum.inl ⁻¹' range (Sum.inr : β → α ⊕ �
 theorem preimage_inr_range_inl : Sum.inr ⁻¹' range (Sum.inl : α → α ⊕ β) = ∅ := by
   rw [← image_univ, preimage_inr_image_inl]
 
-@[simp]
-theorem compl_range_inl : (range (Sum.inl : α → α ⊕ β))ᶜ = range (Sum.inr : β → α ⊕ β) :=
-  IsCompl.compl_eq isCompl_range_inl_range_inr
-
-@[simp]
-theorem compl_range_inr : (range (Sum.inr : β → α ⊕ β))ᶜ = range (Sum.inl : α → α ⊕ β) :=
-  IsCompl.compl_eq isCompl_range_inl_range_inr.symm
-
 theorem preimage_sumElim (s : Set γ) (f : α → γ) (g : β → γ) :
     Sum.elim f g ⁻¹' s = Sum.inl '' (f ⁻¹' s) ∪ Sum.inr '' (g ⁻¹' s) := by
   ext (_ | _) <;> simp
@@ -864,9 +773,6 @@ theorem preimage_singleton_eq_empty {f : α → β} {y : β} : f ⁻¹' {y} = �
 
 theorem range_subset_singleton {f : ι → α} {x : α} : range f ⊆ {x} ↔ f = const ι x := by
   simp [funext_iff]
-
-theorem image_compl_preimage {f : α → β} {s : Set β} : f '' (f ⁻¹' s)ᶜ = range f \ s := by
-  rw [compl_eq_univ_diff, image_diff_preimage, image_univ]
 
 theorem rangeFactorization_eq {f : ι → β} : Subtype.val ∘ rangeFactorization f = f :=
   funext fun _ => rfl
@@ -948,10 +854,6 @@ theorem preimage_rangeSplitting {f : α → β} (hf : Injective f) :
 theorem isCompl_range_some_none (α : Type*) : IsCompl (range (some : α → Option α)) {none} :=
   IsCompl.of_le (fun _ ⟨⟨_, ha⟩, (hn : _ = none)⟩ => Option.some_ne_none _ (ha.trans hn))
     fun x _ => Option.casesOn x (Or.inr rfl) fun _ => Or.inl <| mem_range_self _
-
-@[simp]
-theorem compl_range_some (α : Type*) : (range (some : α → Option α))ᶜ = {none} :=
-  (isCompl_range_some_none α).compl_eq
 
 @[simp]
 theorem range_some_inter_none (α : Type*) : range (some : α → Option α) ∩ {none} = ∅ :=
@@ -1219,15 +1121,6 @@ theorem preimage_coe_nonempty {s t : Set α} :
 
 theorem preimage_coe_eq_empty {s t : Set α} : ((↑) : s → α) ⁻¹' t = ∅ ↔ s ∩ t = ∅ := by
   simp [← not_nonempty_iff_eq_empty, preimage_coe_nonempty]
-
--- Not `@[simp]` since `simp` can prove this.
-theorem preimage_coe_compl (s : Set α) : ((↑) : s → α) ⁻¹' sᶜ = ∅ :=
-  preimage_coe_eq_empty.2 (inter_compl_self s)
-
-@[simp]
-theorem preimage_coe_compl' (s : Set α) :
-    (fun x : (sᶜ : Set α) => (x : α)) ⁻¹' s = ∅ :=
-  preimage_coe_eq_empty.2 (compl_inter_self s)
 
 end Subtype
 

--- a/Mathlib/Data/Set/Prod.lean
+++ b/Mathlib/Data/Set/Prod.lean
@@ -8,6 +8,8 @@ module
 public import Mathlib.Data.Set.Image
 public import Mathlib.Data.SProd
 public import Mathlib.Data.Sum.Basic
+public import Mathlib.Logic.Equiv.Basic
+public import Mathlib.Order.BooleanAlgebra.Set
 
 /-!
 # Sets in product and pi types

--- a/Mathlib/Data/Set/Restrict.lean
+++ b/Mathlib/Data/Set/Restrict.lean
@@ -18,6 +18,8 @@ public import Mathlib.Data.Set.Image
 
 @[expose] public section
 
+assert_not_exists HeytingAlgebra
+
 variable {α β γ δ : Type*} {ι : Sort*} {π : α → Type*}
 
 open Equiv Equiv.Perm Function

--- a/Mathlib/Data/Set/SymmDiff.lean
+++ b/Mathlib/Data/Set/SymmDiff.lean
@@ -14,10 +14,10 @@ public section
 
 assert_not_exists RelIso
 
-namespace Set
+open Function
 
-universe u
-variable {α : Type u} {a : α} {s t u : Set α}
+namespace Set
+variable {α β : Type*} {a : α} {s t u : Set α} {f : α → β}
 
 open scoped symmDiff
 
@@ -49,5 +49,15 @@ theorem subset_symmDiff_union_symmDiff_left (h : Disjoint s t) : u ⊆ s ∆ u �
 
 theorem subset_symmDiff_union_symmDiff_right (h : Disjoint t u) : s ⊆ s ∆ t ∪ s ∆ u :=
   h.le_symmDiff_sup_symmDiff_right
+
+lemma image_symmDiff (hf : Injective f) (s t : Set α) : f '' s ∆ t = (f '' s) ∆ (f '' t) := by
+  simp_rw [Set.symmDiff_def, image_union, image_diff hf]
+
+lemma subset_image_symmDiff : (f '' s) ∆ (f '' t) ⊆ f '' s ∆ t :=
+  (union_subset_union (subset_image_diff _ _ _) <| subset_image_diff _ _ _).trans
+    (image_union _ _ _).superset
+
+@[simp]
+lemma preimage_symmDiff {f : α → β} (s t : Set β) : f ⁻¹' (s ∆ t) = (f ⁻¹' s) ∆ (f ⁻¹' t) := rfl
 
 end Set

--- a/Mathlib/Logic/Equiv/Embedding.lean
+++ b/Mathlib/Logic/Equiv/Embedding.lean
@@ -6,6 +6,7 @@ Authors: Eric Rodriguez
 module
 
 public import Mathlib.Logic.Embedding.Set
+public import Mathlib.Order.BooleanAlgebra.Set
 
 /-!
 # Equivalences on embeddings

--- a/Mathlib/Order/CompleteBooleanAlgebra.lean
+++ b/Mathlib/Order/CompleteBooleanAlgebra.lean
@@ -5,11 +5,10 @@ Authors: Johannes Hölzl, Yaël Dillies
 -/
 module
 
-public import Mathlib.Logic.Equiv.Set
 public import Mathlib.Logic.Pairwise
 public import Mathlib.Order.CompleteLattice.Lemmas
-public import Mathlib.Order.Directed
 public import Mathlib.Order.GaloisConnection.Basic
+public import Mathlib.Order.SymmDiff
 
 /-!
 # Frames, completely distributive lattices and complete Boolean algebras


### PR DESCRIPTION
Eventually, all order properties should move out, but this is a good fourth step that will, among others, unblock #23177.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
