### PR TITLE
[Merged by Bors] - feat(Geometry/Euclidean/MongePoint) add theorems about orthocenter and circumcenter

### DIFF
--- a/Mathlib/Geometry/Euclidean/MongePoint.lean
+++ b/Mathlib/Geometry/Euclidean/MongePoint.lean
@@ -82,6 +82,19 @@ theorem mongePoint_eq_smul_vsub_vadd_circumcenter {n : ℕ} (s : Simplex ℝ P n
         s.circumcenter :=
   rfl
 
+/-- **Sylvester's theorem**: The position of the Monge point relative to the circumcenter via the
+sum of vectors to the vertices. -/
+theorem smul_mongePoint_vsub_circumcenter_eq_sum_vsub {n : ℕ} (s : Simplex ℝ P (n + 2)) :
+    (n + 1) • (s.mongePoint -ᵥ s.circumcenter) = ∑ i , (s.points i -ᵥ s.circumcenter) := by
+  rw [mongePoint_eq_smul_vsub_vadd_circumcenter, vadd_vsub, ← smul_assoc]
+  field_simp
+  have h : Invertible (↑n + (2:ℝ) + 1) := by norm_cast; apply invertibleOfPos
+  rw [@smul_eq_iff_eq_invOf_smul _ _ _ _ (↑n + (2:ℝ) + 1)  _ _ h, smul_sum]
+  unfold Finset.centroid
+  rw [← Finset.sum_smul_vsub_const_eq_affineCombination_vsub _ _ _ _ (by simp)]
+  simp only [centroidWeights_apply, card_univ, Fintype.card_fin, Nat.cast_add, Nat.cast_ofNat,
+    Nat.cast_one, invOf_eq_inv]
+
 /-- The Monge point lies in the affine span. -/
 theorem mongePoint_mem_affineSpan {n : ℕ} (s : Simplex ℝ P n) :
     s.mongePoint ∈ affineSpan ℝ (Set.range s.points) :=
@@ -326,16 +339,11 @@ theorem orthocenter_eq_smul_vsub_vadd_circumcenter (t : Triangle ℝ P) :
   rw [orthocenter_eq_mongePoint, mongePoint_eq_smul_vsub_vadd_circumcenter]
   norm_num
 
-/-- **Sylvester's theorem** : The vector from the circumcenter to the orthocenter of a triangle
-is equal to the sum of the vectors from the circumcenter to each point. -/
+/-- **Sylvester's theorem**, specialized to triangles。 -/
 theorem orthocenter_vsub_circumcenter_eq_sum_vsub (t : Triangle ℝ P) :
-    t.orthocenter -ᵥ t.circumcenter = ∑ i ∈ Finset.univ, (t.points i -ᵥ t.circumcenter) := by
-  rw [orthocenter_eq_smul_vsub_vadd_circumcenter, vadd_vsub, smul_eq_iff_eq_invOf_smul, smul_sum,
-    ← Finset.weightedVSubOfPoint_apply (Finset.univ) (fun x: Fin 3 => (⅟ 3:ℝ)) t.points
-      t.circumcenter]
-  unfold Finset.centroid
-  rw [← Finset.sum_smul_vsub_const_eq_affineCombination_vsub _ _ _ _ (by simp)]
-  rfl
+    t.orthocenter -ᵥ t.circumcenter = ∑ i, (t.points i -ᵥ t.circumcenter) := by
+  rw [← t.smul_mongePoint_vsub_circumcenter_eq_sum_vsub, zero_add, one_smul,
+    orthocenter_eq_mongePoint]
 
 /-- The orthocenter lies in the affine span. -/
 theorem orthocenter_mem_affineSpan (t : Triangle ℝ P) :

--- a/Mathlib/Geometry/Euclidean/MongePoint.lean
+++ b/Mathlib/Geometry/Euclidean/MongePoint.lean
@@ -326,6 +326,17 @@ theorem orthocenter_eq_smul_vsub_vadd_circumcenter (t : Triangle ℝ P) :
   rw [orthocenter_eq_mongePoint, mongePoint_eq_smul_vsub_vadd_circumcenter]
   norm_num
 
+/-- **Sylvester's theorem** : The vector from the circumcenter to the orthocenter of a triangle
+is equal to the sum of the vectors from the circumcenter to each point. -/
+theorem orthocenter_vsub_circumcenter_eq_sum_vsub (t : Triangle ℝ P) :
+    t.orthocenter -ᵥ t.circumcenter = ∑ i ∈ Finset.univ, (t.points i -ᵥ t.circumcenter) := by
+  rw [orthocenter_eq_smul_vsub_vadd_circumcenter, vadd_vsub, smul_eq_iff_eq_invOf_smul, smul_sum,
+    ← Finset.weightedVSubOfPoint_apply (Finset.univ) (fun x: Fin 3 => (⅟ 3:ℝ)) t.points
+      t.circumcenter]
+  unfold Finset.centroid
+  rw [← Finset.sum_smul_vsub_const_eq_affineCombination_vsub _ _ _ _ (by simp)]
+  rfl
+
 /-- The orthocenter lies in the affine span. -/
 theorem orthocenter_mem_affineSpan (t : Triangle ℝ P) :
     t.orthocenter ∈ affineSpan ℝ (Set.range t.points) :=
@@ -399,6 +410,23 @@ theorem dist_orthocenter_reflection_circumcenter_finset (t : Triangle ℝ P) {i�
       t.circumradius := by
   simp only [coe_insert, coe_singleton]
   exact dist_orthocenter_reflection_circumcenter _ h
+
+/-- The distance from the circumcenter to the reflection of the orthocenter in a side equals the
+circumradius. -/
+theorem dist_circumcenter_reflection_orthocenter (t : Triangle ℝ P) {i₁ i₂ : Fin 3} (h : i₁ ≠ i₂) :
+    dist t.circumcenter (reflection (affineSpan ℝ (t.points '' {i₁, i₂})) t.orthocenter) =
+      t.circumradius := by
+  rw [EuclideanGeometry.dist_reflection, dist_comm, dist_orthocenter_reflection_circumcenter t h]
+
+/-- The distance from the circumcenter to the reflection of the orthocenter in a side equals the
+circumradius, variant using a `Finset`. -/
+theorem dist_circumcenter_reflection_orthocenter_finset (t : Triangle ℝ P) {i₁ i₂ : Fin 3}
+  (h : i₁ ≠ i₂) :
+    dist t.circumcenter
+      (reflection (affineSpan ℝ (t.points '' ↑({i₁, i₂} : Finset (Fin 3)))) t.orthocenter) =
+      t.circumradius := by
+  simp only [coe_insert, coe_singleton]
+  exact dist_circumcenter_reflection_orthocenter _ h
 
 /-- The affine span of the orthocenter and a vertex is contained in
 the altitude. -/

--- a/Mathlib/Geometry/Euclidean/MongePoint.lean
+++ b/Mathlib/Geometry/Euclidean/MongePoint.lean
@@ -85,7 +85,7 @@ theorem mongePoint_eq_smul_vsub_vadd_circumcenter {n : ℕ} (s : Simplex ℝ P n
 /-- **Sylvester's theorem**: The position of the Monge point relative to the circumcenter via the
 sum of vectors to the vertices. -/
 theorem smul_mongePoint_vsub_circumcenter_eq_sum_vsub {n : ℕ} (s : Simplex ℝ P (n + 2)) :
-    (n + 1) • (s.mongePoint -ᵥ s.circumcenter) = ∑ i , (s.points i -ᵥ s.circumcenter) := by
+    (n + 1) • (s.mongePoint -ᵥ s.circumcenter) = ∑ i, (s.points i -ᵥ s.circumcenter) := by
   rw [mongePoint_eq_smul_vsub_vadd_circumcenter, vadd_vsub, ← smul_assoc]
   field_simp
   have h : Invertible (↑n + (2:ℝ) + 1) := by norm_cast; apply invertibleOfPos
@@ -339,7 +339,7 @@ theorem orthocenter_eq_smul_vsub_vadd_circumcenter (t : Triangle ℝ P) :
   rw [orthocenter_eq_mongePoint, mongePoint_eq_smul_vsub_vadd_circumcenter]
   norm_num
 
-/-- **Sylvester's theorem**, specialized to triangles。 -/
+/-- **Sylvester's theorem**, specialized to triangles. -/
 theorem orthocenter_vsub_circumcenter_eq_sum_vsub (t : Triangle ℝ P) :
     t.orthocenter -ᵥ t.circumcenter = ∑ i, (t.points i -ᵥ t.circumcenter) := by
   rw [← t.smul_mongePoint_vsub_circumcenter_eq_sum_vsub, zero_add, one_smul,


### PR DESCRIPTION
---

I added some theorems about the relationship between the orthocenter and the circumcenter of a triangle.
These results are used in the proofs of the Nine-Point Circle theorems.

- **Sylvester's theorem** `orthocenter_vsub_circumcenter_eq_sum_vsub` : The vector from the circumcenter to the orthocenter of a triangle is equal to the sum of the vectors from the circumcenter to each vertex. [Wikipedia links](https://en.wikipedia.org/wiki/Sylvester%27s_triangle_problem)
- `dist_circumcenter_reflection_orthocenter` : A symmetry version of `dist_orthocenter_reflection_circumcenter`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
