### PR TITLE
[Merged by Bors] - fix(Order): fix simp lemma for with{Top/Bot}{Map/Congr}

### DIFF
--- a/Mathlib/Order/Hom/WithTopBot.lean
+++ b/Mathlib/Order/Hom/WithTopBot.lean
@@ -166,6 +166,10 @@ def withTopCongr (e : α ≃o β) : WithTop α ≃o WithTop β :=
     toEquiv := e.toEquiv.optionCongr }
 
 @[simp]
+theorem withTopCongr_apply (e : α ≃o β) (a : WithTop α) :
+    withTopCongr e a = WithTop.map e a := rfl
+
+@[simp]
 theorem withTopCongr_refl : (OrderIso.refl α).withTopCongr = OrderIso.refl _ :=
   RelIso.toEquiv_injective Equiv.optionCongr_refl
 
@@ -178,13 +182,13 @@ theorem withTopCongr_trans (e₁ : α ≃o β) (e₂ : β ≃o γ) :
     (e₁.trans e₂).withTopCongr = e₁.withTopCongr.trans e₂.withTopCongr :=
   RelIso.toEquiv_injective <| e₁.toEquiv.optionCongr_trans e₂.toEquiv
 
-@[simp]
-theorem withTopCongr_apply_coe (e : α ≃o β) (a : α) :
-    withTopCongr e (a : WithTop α) = (e a : WithTop β) := rfl
-
 /-- A version of `Equiv.optionCongr` for `WithBot`. -/
 def withBotCongr (e : α ≃o β) : WithBot α ≃o WithBot β :=
   { e.toOrderEmbedding.withBotMap with toEquiv := e.toEquiv.optionCongr }
+
+@[simp]
+theorem withBotCongr_apply (e : α ≃o β) (a : WithBot α) :
+    withBotCongr e a = WithBot.map e a := rfl
 
 @[simp]
 theorem withBotCongr_refl : (OrderIso.refl α).withBotCongr = OrderIso.refl _ :=
@@ -198,10 +202,6 @@ theorem withBotCongr_symm (e : α ≃o β) : e.symm.withBotCongr = e.withBotCong
 theorem withBotCongr_trans (e₁ : α ≃o β) (e₂ : β ≃o γ) :
     (e₁.trans e₂).withBotCongr = e₁.withBotCongr.trans e₂.withBotCongr :=
   RelIso.toEquiv_injective <| e₁.toEquiv.optionCongr_trans e₂.toEquiv
-
-@[simp]
-theorem withBotCongr_apply_coe (e : α ≃o β) (a : α) :
-    withBotCongr e (a : WithBot α) = (e a : WithBot β) := rfl
 
 end OrderIso
 

--- a/Mathlib/Order/Hom/WithTopBot.lean
+++ b/Mathlib/Order/Hom/WithTopBot.lean
@@ -161,7 +161,6 @@ namespace OrderIso
 variable [PartialOrder α] [PartialOrder β] [PartialOrder γ]
 
 /-- A version of `Equiv.optionCongr` for `WithTop`. -/
-@[simps! apply]
 def withTopCongr (e : α ≃o β) : WithTop α ≃o WithTop β :=
   { e.toOrderEmbedding.withTopMap with
     toEquiv := e.toEquiv.optionCongr }
@@ -179,11 +178,11 @@ theorem withTopCongr_trans (e₁ : α ≃o β) (e₂ : β ≃o γ) :
     (e₁.trans e₂).withTopCongr = e₁.withTopCongr.trans e₂.withTopCongr :=
   RelIso.toEquiv_injective <| e₁.toEquiv.optionCongr_trans e₂.toEquiv
 
+@[simp]
 theorem withTopCongr_apply_coe (e : α ≃o β) (a : α) :
     withTopCongr e (a : WithTop α) = (e a : WithTop β) := rfl
 
 /-- A version of `Equiv.optionCongr` for `WithBot`. -/
-@[simps! apply]
 def withBotCongr (e : α ≃o β) : WithBot α ≃o WithBot β :=
   { e.toOrderEmbedding.withBotMap with toEquiv := e.toEquiv.optionCongr }
 
@@ -200,6 +199,7 @@ theorem withBotCongr_trans (e₁ : α ≃o β) (e₂ : β ≃o γ) :
     (e₁.trans e₂).withBotCongr = e₁.withBotCongr.trans e₂.withBotCongr :=
   RelIso.toEquiv_injective <| e₁.toEquiv.optionCongr_trans e₂.toEquiv
 
+@[simp]
 theorem withBotCongr_apply_coe (e : α ≃o β) (a : α) :
     withBotCongr e (a : WithBot α) = (e a : WithBot β) := rfl
 

--- a/Mathlib/Order/Hom/WithTopBot.lean
+++ b/Mathlib/Order/Hom/WithTopBot.lean
@@ -132,9 +132,10 @@ namespace OrderEmbedding
 variable [Preorder α] [Preorder β]
 
 /-- A version of `WithBot.map` for order embeddings. -/
-@[simps! -fullyApplied]
+@[simps -fullyApplied]
 protected def withBotMap (f : α ↪o β) : WithBot α ↪o WithBot β where
-  __ := f.toEmbedding.optionMap
+  toFun := WithBot.map f
+  inj' := Option.map_injective f.injective
   map_rel_iff' := WithBot.map_le_iff f f.map_rel_iff
 
 /-- A version of `WithTop.map` for order embeddings. -/
@@ -161,13 +162,11 @@ namespace OrderIso
 variable [PartialOrder α] [PartialOrder β] [PartialOrder γ]
 
 /-- A version of `Equiv.optionCongr` for `WithTop`. -/
-def withTopCongr (e : α ≃o β) : WithTop α ≃o WithTop β :=
-  { e.toOrderEmbedding.withTopMap with
-    toEquiv := e.toEquiv.optionCongr }
-
-@[simp]
-theorem withTopCongr_apply (e : α ≃o β) (a : WithTop α) :
-    withTopCongr e a = WithTop.map e a := rfl
+@[simps -fullyApplied]
+def withTopCongr (e : α ≃o β) : WithTop α ≃o WithTop β where
+  toFun := WithTop.map e
+  __ := e.toOrderEmbedding.withTopMap
+  __ := e.toEquiv.optionCongr
 
 @[simp]
 theorem withTopCongr_refl : (OrderIso.refl α).withTopCongr = OrderIso.refl _ :=
@@ -183,12 +182,11 @@ theorem withTopCongr_trans (e₁ : α ≃o β) (e₂ : β ≃o γ) :
   RelIso.toEquiv_injective <| e₁.toEquiv.optionCongr_trans e₂.toEquiv
 
 /-- A version of `Equiv.optionCongr` for `WithBot`. -/
-def withBotCongr (e : α ≃o β) : WithBot α ≃o WithBot β :=
-  { e.toOrderEmbedding.withBotMap with toEquiv := e.toEquiv.optionCongr }
-
-@[simp]
-theorem withBotCongr_apply (e : α ≃o β) (a : WithBot α) :
-    withBotCongr e a = WithBot.map e a := rfl
+@[simps -fullyApplied]
+def withBotCongr (e : α ≃o β) : WithBot α ≃o WithBot β where
+  toFun := WithBot.map e
+  __ := e.toOrderEmbedding.withBotMap
+  __ := e.toEquiv.optionCongr
 
 @[simp]
 theorem withBotCongr_refl : (OrderIso.refl α).withBotCongr = OrderIso.refl _ :=

--- a/Mathlib/Order/Hom/WithTopBot.lean
+++ b/Mathlib/Order/Hom/WithTopBot.lean
@@ -179,6 +179,9 @@ theorem withTopCongr_trans (e₁ : α ≃o β) (e₂ : β ≃o γ) :
     (e₁.trans e₂).withTopCongr = e₁.withTopCongr.trans e₂.withTopCongr :=
   RelIso.toEquiv_injective <| e₁.toEquiv.optionCongr_trans e₂.toEquiv
 
+theorem withTopCongr_apply_coe (e : α ≃o β) (a : α) :
+    withTopCongr e (a : WithTop α) = (e a : WithTop β) := rfl
+
 /-- A version of `Equiv.optionCongr` for `WithBot`. -/
 @[simps! apply]
 def withBotCongr (e : α ≃o β) : WithBot α ≃o WithBot β :=
@@ -196,6 +199,9 @@ theorem withBotCongr_symm (e : α ≃o β) : e.symm.withBotCongr = e.withBotCong
 theorem withBotCongr_trans (e₁ : α ≃o β) (e₂ : β ≃o γ) :
     (e₁.trans e₂).withBotCongr = e₁.withBotCongr.trans e₂.withBotCongr :=
   RelIso.toEquiv_injective <| e₁.toEquiv.optionCongr_trans e₂.toEquiv
+
+theorem withBotCongr_apply_coe (e : α ≃o β) (a : α) :
+    withBotCongr e (a : WithBot α) = (e a : WithBot β) := rfl
 
 end OrderIso
 


### PR DESCRIPTION
This change includes the following in generated simp lemmas:
```diff
-@[simp] theorem OrderEmbedding.withBotMap_apply {α : Type u_1} {β : Type u_2} [Preorder α] [Preorder β] (f : α ↪o β) : 
-  ⇑f.withBotMap = Option.map ⇑f
+@[simp] theorem OrderEmbedding.withBotMap_apply {α : Type u_1} {β : Type u_2} [Preorder α] [Preorder β] (f : α ↪o β) :
+  ⇑f.withBotMap = WithBot.map ⇑f

@[simp] theorem OrderEmbedding.withTopMap_apply {α : Type u_1} {β : Type u_2} [Preorder α] [Preorder β] (f : α ↪o β) :
  ⇑f.withTopMap = WithTop.map ⇑f -- unchanged

-@[simp] theorem OrderIso.withBotCongr_apply {α : Type u_1} {β : Type u_2} [PartialOrder α] [PartialOrder β] (e : α ≃o β) (a✝ : Option α) : 
-  e.withBotCongr a✝ = Option.map (⇑e) a✝
+@[simp] theorem OrderIso.withBotCongr_apply {α : Type u_1} {β : Type u_2} [PartialOrder α] [PartialOrder β] (e : α ≃o β) :
+  ⇑e.withBotCongr = WithBot.map ⇑e

-@[simp] theorem OrderIso.withTopCongr_apply {α : Type u_1} {β : Type u_2} [PartialOrder α] [PartialOrder β] (e : α ≃o β) (a✝ : Option α) : 
-  e.withTopCongr a✝ = Option.map (⇑e) a✝
+@[simp] theorem OrderIso.withTopCongr_apply {α : Type u_1} {β : Type u_2} [PartialOrder α] [PartialOrder β] (e : α ≃o β) :
+  ⇑e.withTopCongr = WithTop.map ⇑e
```


---

~~The existing @[simps!] lemma on `withTopCongr` sends the expression to Equiv.optionCongr, which is hard to work with because it losts WithTop/WithBot tags and Option has fewer lemmas. Add these to preserve WithTop/WithBot tags.~~

~~I didn't tag these as `@[simp]` because it would conflict with existing `@[simps!]`. But to be honest I don't like the existing simps. Can I remove `@[simps! apply]` from `withTopCongr` and promote the new lemma as simp normal form?~~

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
