### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/Span/Defs): replace Submodule.exists_add_eq_of_codisjoint with an iff

### DIFF
--- a/Mathlib/LinearAlgebra/BilinearForm/Orthogonal.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Orthogonal.lean
@@ -288,7 +288,7 @@ lemma ker_restrict_eq_of_codisjoint {p q : Submodule R M} (hpq : Codisjoint p q)
   simp only [LinearMap.mem_ker, Submodule.mem_comap, Submodule.coe_subtype]
   refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
   · ext w
-    obtain ⟨x, hx, y, hy, rfl⟩ := Submodule.exists_add_eq_of_codisjoint hpq w
+    obtain ⟨x, y, hx, hy, rfl⟩ := Submodule.codisjoint_iff_exists_add_eq.mp hpq w
     simpa [hB z hz y hy] using LinearMap.congr_fun h ⟨x, hx⟩
   · ext ⟨x, hx⟩
     simpa using LinearMap.congr_fun h x

--- a/Mathlib/LinearAlgebra/PerfectPairing/Restrict.lean
+++ b/Mathlib/LinearAlgebra/PerfectPairing/Restrict.lean
@@ -54,8 +54,8 @@ private lemma restrict_aux : Bijective (p.toLinearMap.compl₁₂ i j) := by
   · set F : Module.Dual R N := f ∘ₗ j.linearProjOfIsCompl _ hj hij.isCompl_right with hF
     have hF (n : N') : F (j n) = f n := by simp [hF]
     set m : M := p.toDualLeft.symm F with hm
-    obtain ⟨-, ⟨m₀, rfl⟩, y, hy, hm'⟩ :=
-      Submodule.exists_add_eq_of_codisjoint hij.isCompl_left.codisjoint m
+    obtain ⟨-, y, ⟨m₀, rfl⟩, hy, hm'⟩ :=
+      Submodule.codisjoint_iff_exists_add_eq.mp hij.isCompl_left.codisjoint m
     refine ⟨m₀, LinearMap.ext fun n ↦ ?_⟩
     replace hy : (p y) (j n) = 0 := by
       simp only [Submodule.mem_map, Submodule.mem_dualAnnihilator] at hy

--- a/Mathlib/LinearAlgebra/Span/Defs.lean
+++ b/Mathlib/LinearAlgebra/Span/Defs.lean
@@ -349,6 +349,12 @@ theorem mem_sup : x ∈ p ⊔ p' ↔ ∃ y ∈ p, ∃ z ∈ p', y + z = x :=
 theorem mem_sup' : x ∈ p ⊔ p' ↔ ∃ (y : p) (z : p'), (y : M) + z = x :=
   mem_sup.trans <| by simp only [Subtype.exists, exists_prop]
 
+theorem codisjoint_iff_exists_add_eq :
+    Codisjoint p p' ↔ ∀ z, ∃ x y, x ∈ p ∧ y ∈ p' ∧ x + y = z := by
+  rw [codisjoint_iff, eq_top_iff']
+  exact forall_congr' (fun z => mem_sup.trans <| by simp)
+
+@[deprecated codisjoint_iff_exists_add_eq (since := "2025-07-05")]
 lemma exists_add_eq_of_codisjoint (h : Codisjoint p p') (x : M) :
     ∃ y ∈ p, ∃ z ∈ p', y + z = x := by
   suffices x ∈ p ⊔ p' by exact Submodule.mem_sup.mp this

--- a/Mathlib/LinearAlgebra/Span/Defs.lean
+++ b/Mathlib/LinearAlgebra/Span/Defs.lean
@@ -355,7 +355,6 @@ theorem codisjoint_iff_exists_add_eq :
   exact forall_congr' (fun z => mem_sup.trans <| by simp)
 
 @[deprecated (since := "2025-07-05")] alias ⟨exists_add_eq_of_codisjoint, _⟩ := codisjoint_iff_exists_add_eq
-  simpa only [h.eq_top] using Submodule.mem_top
 
 variable (p p')
 

--- a/Mathlib/LinearAlgebra/Span/Defs.lean
+++ b/Mathlib/LinearAlgebra/Span/Defs.lean
@@ -354,7 +354,8 @@ theorem codisjoint_iff_exists_add_eq :
   rw [codisjoint_iff, eq_top_iff']
   exact forall_congr' (fun z => mem_sup.trans <| by simp)
 
-@[deprecated (since := "2025-07-05")] alias ⟨exists_add_eq_of_codisjoint, _⟩ := codisjoint_iff_exists_add_eq
+@[deprecated (since := "2025-07-05")]
+alias ⟨exists_add_eq_of_codisjoint, _⟩ := codisjoint_iff_exists_add_eq
 
 variable (p p')
 

--- a/Mathlib/LinearAlgebra/Span/Defs.lean
+++ b/Mathlib/LinearAlgebra/Span/Defs.lean
@@ -354,7 +354,7 @@ theorem codisjoint_iff_exists_add_eq :
   rw [codisjoint_iff, eq_top_iff']
   exact forall_congr' (fun z => mem_sup.trans <| by simp)
 
-@[deprecated codisjoint_iff_exists_add_eq (since := "2025-07-05")]
+@[deprecated (since := "2025-07-05")] alias ⟨exists_add_eq_of_codisjoint, _⟩ := codisjoint_iff_exists_add_eq
   simpa only [h.eq_top] using Submodule.mem_top
 
 variable (p p')

--- a/Mathlib/LinearAlgebra/Span/Defs.lean
+++ b/Mathlib/LinearAlgebra/Span/Defs.lean
@@ -355,9 +355,6 @@ theorem codisjoint_iff_exists_add_eq :
   exact forall_congr' (fun z => mem_sup.trans <| by simp)
 
 @[deprecated codisjoint_iff_exists_add_eq (since := "2025-07-05")]
-lemma exists_add_eq_of_codisjoint (h : Codisjoint p p') (x : M) :
-    ∃ y ∈ p, ∃ z ∈ p', y + z = x := by
-  suffices x ∈ p ⊔ p' by exact Submodule.mem_sup.mp this
   simpa only [h.eq_top] using Submodule.mem_top
 
 variable (p p')


### PR DESCRIPTION
Instead of introducing another theorem to go the other way, I have upgraded this one to an iff. The changed order of terms is preferable in my application (and probably others) because to prove the existential it is enough to provide the two witnesses first and leave everything else to simp.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
