### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/Contraction): generalize to Commsemiring

### DIFF
--- a/Mathlib/LinearAlgebra/Contraction.lean
+++ b/Mathlib/LinearAlgebra/Contraction.lean
@@ -117,16 +117,6 @@ theorem toMatrix_dualTensorHom {m : Type*} {n : Type*} [Fintype m] [Finite n] [D
   rw [and_iff_not_or_not, Classical.not_not] at hij
   rcases hij with hij | hij <;> simp [hij]
 
-end CommSemiring
-
-section CommRing
-
-variable [CommRing R]
-variable [AddCommGroup M] [AddCommGroup N] [AddCommGroup P] [AddCommGroup Q]
-variable [Module R M] [Module R N] [Module R P] [Module R Q]
-variable [DecidableEq ι] [Fintype ι] (b : Basis ι R M)
-variable {R M N P Q}
-
 /-- If `M` is free, the natural linear map $M^* ⊗ N → Hom(M, N)$ is an equivalence. This function
 provides this equivalence in return for a basis of `M`. -/
 -- We manually create simp-lemmas because `@[simps]` generates a malformed lemma
@@ -174,7 +164,7 @@ equivalence. -/
 noncomputable def dualTensorHomEquiv : Module.Dual R M ⊗[R] N ≃ₗ[R] M →ₗ[R] N :=
   dualTensorHomEquivOfBasis (Module.Free.chooseBasis R M)
 
-end CommRing
+end CommSemiring
 
 end Contraction
 
@@ -184,10 +174,9 @@ open TensorProduct
 
 open Module TensorProduct LinearMap
 
-section CommRing
-
-variable [CommRing R]
-variable [AddCommGroup M] [AddCommGroup N] [AddCommGroup P] [AddCommGroup Q]
+section CommSemiring
+variable [CommSemiring R]
+variable [AddCommMonoid M] [AddCommMonoid N] [AddCommMonoid P] [AddCommMonoid Q]
 variable [Module R M] [Module R N] [Module R P] [Module R Q]
 variable [Free R M] [Module.Finite R M] [Free R N] [Module.Finite R N]
 
@@ -273,6 +262,6 @@ theorem homTensorHomEquiv_apply (x : (M →ₗ[R] P) ⊗[R] (N →ₗ[R] Q)) :
     homTensorHomEquiv R M N P Q x = homTensorHomMap R M N P Q x := by
   rw [← LinearEquiv.coe_toLinearMap, homTensorHomEquiv_toLinearMap]
 
-end CommRing
+end CommSemiring
 
 end HomTensorHom


### PR DESCRIPTION
No changes to the proofs are needed.

Co-authored-by: Junyan Xu <junyanxu.math@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Split from #25284
