### PR TITLE
feat(Analysis/Complex/CauchyIntegral): A formula for `deriv (conj ∘ f ∘ conj)`

### DIFF
--- a/Mathlib/Analysis/Complex/CauchyIntegral.lean
+++ b/Mathlib/Analysis/Complex/CauchyIntegral.lean
@@ -674,6 +674,12 @@ theorem hasDerivAt_conj_comp_comp_conj' {f : ℂ → ℂ} {z f' : ℂ} (hf : Has
     HasDerivAt (conj ∘ f ∘ conj) (conj f') z :=
   conj_conj z ▸ hasDerivAt_conj_comp_comp_conj hf
 
+
+theorem differentiableAt_conj_comp_comp_conj_iff {f : ℂ → ℂ} {z : ℂ} :
+    DifferentiableAt ℂ (conj ∘ f ∘ conj) (conj z) ↔ DifferentiableAt ℂ f z :=
+  ⟨fun h ↦ (hasDerivAt_conj_comp_comp_conj_iff'.1 h.hasDerivAt).differentiableAt,
+  fun h ↦ h.hasDerivAt.conj_comp_comp_conj.differentiableAt⟩
+  
 /--
 Let $f : \mathbb{C} \to \mathbb{C}$ be a function. Then the derivative of the function
 $g(z) = \overline{f(\overline{z})}$ at $\overline{z}$ is $\overline{f'(z)}$.

--- a/Mathlib/Analysis/Complex/CauchyIntegral.lean
+++ b/Mathlib/Analysis/Complex/CauchyIntegral.lean
@@ -660,6 +660,11 @@ theorem hasDerivAt_conj_comp_comp_conj {f : ℂ → ℂ} {z f' : ℂ} (hf : HasD
   convert hf.comp (conj_conj z ▸ continuous_conj.tendsto (conj z)) using 2 with w
   rw [← norm_conj, ← norm_conj (_ - _)]; simp
 
+theorem hasDerivAt_conj_comp_comp_conj_iff {f : ℂ → ℂ} {z f' : ℂ} :
+    HasDerivAt (conj ∘ f ∘ conj) (conj f') (conj z) ↔ HasDerivAt f f' z :=
+  ⟨fun hf ↦ by convert hf.conj_comp_comp_conj <;> simp [Function.comp_def],
+  fun hf ↦ hf.conj_comp_comp_conj⟩
+ 
 /--
 Let $f : \mathbb{C} \to \mathbb{C}$ be a complex differentiable function at $z \in \mathbb{C}$ with
 derivative $f'(z)$. Then the function $g(w) = \overline{f(\overline{w})}$ is complex differentiable

--- a/Mathlib/Analysis/Complex/CauchyIntegral.lean
+++ b/Mathlib/Analysis/Complex/CauchyIntegral.lean
@@ -703,9 +703,7 @@ If $f$ is not differentiable at $\overline{w}$, then both sides have the junk va
 -/
 @[simp]
 theorem deriv_conj_comp_comp_conj' (f : ℂ → ℂ) :
-    deriv (conj ∘ f ∘ conj) = conj ∘ (deriv f) ∘ conj := by
-  ext z
-  nth_rw 1 [← conj_conj z]
-  exact deriv_conj_comp_comp_conj ..
+    deriv (conj ∘ f ∘ conj) = conj ∘ (deriv f) ∘ conj :=
+  funext fun z ↦ by simp [← deriv_conj_comp_comp_conj]
 
 end Complex

--- a/Mathlib/Analysis/Complex/CauchyIntegral.lean
+++ b/Mathlib/Analysis/Complex/CauchyIntegral.lean
@@ -668,6 +668,7 @@ at $\overline{z}$ with derivative $\overline{f'(\overline{z})}$.
 theorem hasDerivAt_conj_comp_comp_conj' {f : ℂ → ℂ} {z f' : ℂ} (hf : HasDerivAt f f' (conj z)) :
     HasDerivAt (conj ∘ f ∘ conj) (conj f') z :=
   conj_conj z ▸ hasDerivAt_conj_comp_comp_conj hf
+
 /--
 Let $f : \mathbb{C} \to \mathbb{C}$ be a function. Then the derivative of the function
 $g(z) = \overline{f(\overline{z})}$ at $\overline{z}$ is $\overline{f'(z)}$.

--- a/Mathlib/Analysis/Complex/CauchyIntegral.lean
+++ b/Mathlib/Analysis/Complex/CauchyIntegral.lean
@@ -667,7 +667,7 @@ at $\overline{z}$ with derivative $\overline{f'(\overline{z})}$.
 -/
 theorem hasDerivAt_conj_comp_comp_conj' {f : ℂ → ℂ} {z f' : ℂ} (hf : HasDerivAt f f' (conj z)) :
     HasDerivAt (conj ∘ f ∘ conj) (conj f') z :=
-  (conj_conj z) ▸ hasDerivAt_conj_comp_comp_conj hf
+  conj_conj z ▸ hasDerivAt_conj_comp_comp_conj hf
 /--
 Let $f : \mathbb{C} \to \mathbb{C}$ be a function. Then the derivative of the function
 $g(z) = \overline{f(\overline{z})}$ at $\overline{z}$ is $\overline{f'(z)}$.

--- a/Mathlib/Analysis/Complex/CauchyIntegral.lean
+++ b/Mathlib/Analysis/Complex/CauchyIntegral.lean
@@ -647,4 +647,68 @@ theorem analyticAt_iff_eventually_differentiableAt {f : ℂ → E} {c : ℂ} :
       exact (d z m).differentiableWithinAt
     exact h _ m
 
+open ComplexConjugate
+
+/--
+Let $f : \mathbb{C} \to \mathbb{C}$ be a complex differentiable function at $z \in \mathbb{C}$ with
+derivative $f'(z)$. Then the function $g(w) = \overline{f(\overline{w})}$ is complex differentiable
+at $\overline{z}$ with derivative $\overline{f'(\overline{z})}$.
+-/
+theorem hasDerivAt_conj_comp_comp_conj {f : ℂ → ℂ} {z f' : ℂ} (hf : HasDerivAt f f' z) :
+    HasDerivAt (conj ∘ f ∘ conj) (conj f') (conj z) := by
+  rw [hasDerivAt_iff_tendsto] at hf ⊢
+  have := continuous_conj.tendsto (conj z)
+  rw [conj_conj] at this
+  have := Filter.Tendsto.comp hf this
+  convert this with w
+  simp only [conj_conj, smul_eq_mul, Function.comp_apply]
+  congr 1
+  · congr 1
+    rw[← norm_conj]
+    simp
+  · rw[← norm_conj]
+    simp
+
+/--
+Let $f : \mathbb{C} \to \mathbb{C}$ be a complex differentiable function at $z \in \mathbb{C}$ with
+derivative $f'(z)$. Then the function $g(w) = \overline{f(\overline{w})}$ is complex differentiable
+at $\overline{z}$ with derivative $\overline{f'(\overline{z})}$.
+-/
+theorem hasDerivAt_conj_comp_comp_conj' {f : ℂ → ℂ} {z f' : ℂ} (hf : HasDerivAt f f' (conj z)) :
+    HasDerivAt (conj ∘ f ∘ conj) (conj f') z :=
+  (conj_conj z) ▸ hasDerivAt_conj_comp_comp_conj hf
+/--
+Let $f : \mathbb{C} \to \mathbb{C}$ be a function. Then the derivative of the function
+$g(z) = \overline{f(\overline{z})}$ at $\overline{z}$ is $\overline{f'(z)}$.
+If $f$ is not differentiable at $\overline{z}$, then both sides have the junk value $0$.
+-/
+theorem deriv_conj_comp_comp_conj (f : ℂ → ℂ) (z : ℂ) :
+    deriv (conj ∘ f ∘ conj) (conj z) = conj (deriv f z) := by
+  -- Case analysis on whether f is differentiable at p
+  set g := conj ∘ f ∘ conj
+  by_cases hf : DifferentiableAt ℂ f z
+  · exact (hasDerivAt_conj_comp_comp_conj hf.hasDerivAt).deriv
+  · by_cases hg : DifferentiableAt ℂ g (conj z)
+    · -- If g were differentiable, then f would be differentiable
+      have : DifferentiableAt ℂ f z := by
+        convert (hasDerivAt_conj_comp_comp_conj hg.hasDerivAt).differentiableAt using 2
+        · ext w
+          simp[g]
+        · simp
+      contradiction
+    · -- Both derivatives are zero when the functions are not differentiable
+      rw [deriv_zero_of_not_differentiableAt hg, deriv_zero_of_not_differentiableAt hf, map_zero]
+
+/--
+Let $f : \mathbb{C} \to \mathbb{C}$ be a function. Then the derivative of the function
+$g(w) = \overline{f(\overline{w})}$ at $w$ is $\overline{f'(\overline{w})}$.
+If $f$ is not differentiable at $\overline{w}$, then both sides have the junk value $0$.
+-/
+@[simp]
+theorem deriv_conj_comp_comp_conj' (f : ℂ → ℂ) :
+    deriv (conj ∘ f ∘ conj) = conj ∘ (deriv f) ∘ conj := by
+  ext z
+  nth_rw 1 [← conj_conj z]
+  exact deriv_conj_comp_comp_conj ..
+
 end Complex

--- a/Mathlib/Analysis/Complex/CauchyIntegral.lean
+++ b/Mathlib/Analysis/Complex/CauchyIntegral.lean
@@ -657,17 +657,8 @@ at $\overline{z}$ with derivative $\overline{f'(\overline{z})}$.
 theorem hasDerivAt_conj_comp_comp_conj {f : ℂ → ℂ} {z f' : ℂ} (hf : HasDerivAt f f' z) :
     HasDerivAt (conj ∘ f ∘ conj) (conj f') (conj z) := by
   rw [hasDerivAt_iff_tendsto] at hf ⊢
-  have := continuous_conj.tendsto (conj z)
-  rw [conj_conj] at this
-  have := Filter.Tendsto.comp hf this
-  convert this with w
-  simp only [conj_conj, smul_eq_mul, Function.comp_apply]
-  congr 1
-  · congr 1
-    rw[← norm_conj]
-    simp
-  · rw[← norm_conj]
-    simp
+  convert hf.comp (conj_conj z ▸ continuous_conj.tendsto (conj z)) using 2 with w
+  rw [← norm_conj, ← norm_conj (_ - _)]; simp
 
 /--
 Let $f : \mathbb{C} \to \mathbb{C}$ be a complex differentiable function at $z \in \mathbb{C}$ with

--- a/Mathlib/Analysis/Complex/CauchyIntegral.lean
+++ b/Mathlib/Analysis/Complex/CauchyIntegral.lean
@@ -687,20 +687,9 @@ If $f$ is not differentiable at $\overline{z}$, then both sides have the junk va
 -/
 theorem deriv_conj_comp_comp_conj (f : ℂ → ℂ) (z : ℂ) :
     deriv (conj ∘ f ∘ conj) (conj z) = conj (deriv f z) := by
-  -- Case analysis on whether f is differentiable at p
-  set g := conj ∘ f ∘ conj
   by_cases hf : DifferentiableAt ℂ f z
-  · exact (hasDerivAt_conj_comp_comp_conj hf.hasDerivAt).deriv
-  · by_cases hg : DifferentiableAt ℂ g (conj z)
-    · -- If g were differentiable, then f would be differentiable
-      have : DifferentiableAt ℂ f z := by
-        convert (hasDerivAt_conj_comp_comp_conj hg.hasDerivAt).differentiableAt using 2
-        · ext w
-          simp[g]
-        · simp
-      contradiction
-    · -- Both derivatives are zero when the functions are not differentiable
-      rw [deriv_zero_of_not_differentiableAt hg, deriv_zero_of_not_differentiableAt hf, map_zero]
+  · exact hf.hasDerivAt.conj_comp_comp_conj.deriv
+  · simp [deriv_zero_of_not_differentiableAt, hf, differentiableAt_conj_comp_comp_conj_iff]
 
 /--
 Let $f : \mathbb{C} \to \mathbb{C}$ be a function. Then the derivative of the function


### PR DESCRIPTION
We prove that if a holomorphic function at a point is composed before and after with complex conjugation, it remains holomorphic, and we prove the corresponding formula for the derivative. This is useful for various tasks (e.g. proving that the composition of two anti-holomorphic functions is holomorphic).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
