### PR TITLE
[Merged by Bors] - chore: add defeq test for grind rings

### DIFF
--- a/MathlibTest/grind/ring.lean
+++ b/MathlibTest/grind/ring.lean
@@ -15,6 +15,10 @@ notation "ℝ" => Real
 @[instance] axiom Real.linearOrder : LinearOrder ℝ
 @[instance] axiom Real.isStrictOrderedRing : IsStrictOrderedRing ℝ
 
+example (R : Type) [I : Ring R] :
+  @AddCommGroup.toGrindIntModule R (@Ring.toAddCommGroup R I) =
+    @Lean.Grind.Ring.toIntModule R (@Ring.toGrindRing R I) := rfl
+
 example {α} [CommRing α] (x y : α) : x + y + y - x = 2 * y := by grind
 example (x y : ℝ) : (x + y) ^ 3 = x ^ 3 + y ^ 3 + 3 * (x * y ^ 2 + x ^ 2 * y) := by grind
 example {α} [CommRing α] (x : α) : x ^ 2 = x * x := by grind


### PR DESCRIPTION
This PR adds a defeq test for multiple paths that convert rings in Mathlib's algebraic hierarchy to abelian groups in grind's hierarchy.
This defeq test used to fail before `leanprover/lean4:v4.22.0-rc3`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
