### PR TITLE
feat: group declarations in PR summary by file

### DIFF
--- a/.github/workflows/PR_summary.yml
+++ b/.github/workflows/PR_summary.yml
@@ -202,7 +202,7 @@ jobs:
         fi
 
         echo "Compute Declarations' diff comment"
-        declDiff=$(../master-branch/scripts/declarations_diff.sh)
+        declDiff=$(../master-branch/scripts/declarations_diff.sh by-file ${{ github.event.pull_request.html_url }})
         if [ "$(printf '%s' "${declDiff}" | wc -l)" -gt 15 ]
         then
           declDiff="$(printf '<details><summary>\n\n%s\n\n</summary>\n\n%s\n\n</details>\n' "#### Declarations diff" "${declDiff}")"

--- a/scripts/declarations_diff.sh
+++ b/scripts/declarations_diff.sh
@@ -58,6 +58,7 @@ elif [ "${mode}" == "by-file" ]
 then
   short=1
   byfile=1
+  ## in "by-file" mode, we take an additional argument which is the html_url of the PR
   prUrl="${2:-}"
   shift
 else

--- a/scripts/declarations_diff.sh
+++ b/scripts/declarations_diff.sh
@@ -206,7 +206,7 @@ then
           close(hashCmd)
           diffUrl = prUrl "/files#diff-" hash
 
-          printf("<details>\n  <summary>[%s](%s)%s</summary>\n\n", file, diffUrl, summary)
+          printf("<details>\n  <summary><a href=\"%s\">%s</a> %s</summary>\n\n", diffUrl, file, summary)
 
           # Sort declarations alphabetically
           printf("%s", fileContent[file]) | "sort"


### PR DESCRIPTION
While reviewing a PR with many changed files, but only a few changed declarations, I wished there was a way to jump to the files with changed declarations in the diff view. After a little bit of hacking with help from Claude, the declaration diff in the PR summary will now group declaration changes by file and also link to each file in the diff view.

---

(still needs testing)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
