### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/AffineSpace): lemmas for trivial spaces

### DIFF
--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
@@ -706,6 +706,13 @@ theorem eq_bot_or_nonempty (Q : AffineSubspace k P) : Q = ⊥ ∨ (Q : Set P).No
   rw [nonempty_iff_ne_bot]
   apply eq_or_ne
 
+lemma eq_bot_or_eq_top_of_subsingleton [Subsingleton P] (s : AffineSubspace k P) :
+    s = ⊥ ∨ s = ⊤ := by
+  rw [← coe_eq_bot_iff, ← coe_eq_univ_iff]
+  rcases (s : Set P).eq_empty_or_nonempty with h | h
+  · exact .inl h
+  · exact .inr h.eq_univ
+
 /-- A nonempty affine subspace is `⊤` if and only if its direction is `⊤`. -/
 @[simp]
 theorem direction_eq_top_iff_of_nonempty {s : AffineSubspace k P} (h : (s : Set P).Nonempty) :
@@ -857,6 +864,13 @@ theorem affineSpan_eq_bot : affineSpan k s = ⊥ ↔ s = ∅ := by
 theorem bot_lt_affineSpan : ⊥ < affineSpan k s ↔ s.Nonempty := by
   rw [bot_lt_iff_ne_bot, nonempty_iff_ne_empty]
   exact (affineSpan_eq_bot _).not
+
+lemma affineSpan_eq_top_iff_nonempty_of_subsingleton [Subsingleton P] :
+    affineSpan k s = ⊤ ↔ s.Nonempty := by
+  rw [← affineSpan_nonempty k, nonempty_iff_ne_bot]
+  rcases (affineSpan k s).eq_bot_or_eq_top_of_subsingleton with h | h
+  · simp [h]
+  · simp [h]
 
 end
 

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
@@ -3,6 +3,7 @@ Copyright (c) 2020 Joseph Myers. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Myers
 -/
+import Mathlib.Order.Atoms
 import Mathlib.Order.OmegaCompletePartialOrder
 import Mathlib.LinearAlgebra.Span.Defs
 import Mathlib.LinearAlgebra.AffineSpace.Defs
@@ -706,12 +707,12 @@ theorem eq_bot_or_nonempty (Q : AffineSubspace k P) : Q = ⊥ ∨ (Q : Set P).No
   rw [nonempty_iff_ne_bot]
   apply eq_or_ne
 
-lemma eq_bot_or_eq_top_of_subsingleton [Subsingleton P] (s : AffineSubspace k P) :
-    s = ⊥ ∨ s = ⊤ := by
-  rw [← coe_eq_bot_iff, ← coe_eq_univ_iff]
-  rcases (s : Set P).eq_empty_or_nonempty with h | h
-  · exact .inl h
-  · exact .inr h.eq_univ
+instance [Subsingleton P] : IsSimpleOrder (AffineSubspace k P) where
+  eq_bot_or_eq_top (s : AffineSubspace k P) := by
+    rw [← coe_eq_bot_iff, ← coe_eq_univ_iff]
+    rcases (s : Set P).eq_empty_or_nonempty with h | h
+    · exact .inl h
+    · exact .inr h.eq_univ
 
 /-- A nonempty affine subspace is `⊤` if and only if its direction is `⊤`. -/
 @[simp]
@@ -865,12 +866,11 @@ theorem bot_lt_affineSpan : ⊥ < affineSpan k s ↔ s.Nonempty := by
   rw [bot_lt_iff_ne_bot, nonempty_iff_ne_empty]
   exact (affineSpan_eq_bot _).not
 
+@[simp]
 lemma affineSpan_eq_top_iff_nonempty_of_subsingleton [Subsingleton P] :
     affineSpan k s = ⊤ ↔ s.Nonempty := by
-  rw [← affineSpan_nonempty k, nonempty_iff_ne_bot]
-  rcases (affineSpan k s).eq_bot_or_eq_top_of_subsingleton with h | h
-  · simp [h]
-  · simp [h]
+  rw [← bot_lt_affineSpan k]
+  exact ⟨fun h ↦ h ▸ bot_lt_top, IsSimpleOrder.eq_top_of_lt⟩
 
 end
 

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
@@ -869,8 +869,7 @@ theorem bot_lt_affineSpan : ⊥ < affineSpan k s ↔ s.Nonempty := by
 @[simp]
 lemma affineSpan_eq_top_iff_nonempty_of_subsingleton [Subsingleton P] :
     affineSpan k s = ⊤ ↔ s.Nonempty := by
-  rw [← bot_lt_affineSpan k]
-  exact ⟨fun h ↦ h ▸ bot_lt_top, IsSimpleOrder.eq_top_of_lt⟩
+  rw [← bot_lt_affineSpan k, IsSimpleOrder.bot_lt_iff_eq_top]
 
 end
 

--- a/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
@@ -946,7 +946,7 @@ theorem affineCombination_mem_affineSpan [Nontrivial k] {s : Finset ι} {w : ι 
     exact AffineSubspace.vadd_mem_of_mem_direction hv (mem_affineSpan k (Set.mem_range_self _))
 
 /-- An `affineCombination` with sum of weights 1 is in the
-`affineSpan` of an indexed family, if family is nonempty. -/
+`affineSpan` of an indexed family, if the family is nonempty. -/
 theorem affineCombination_mem_affineSpan_of_nonempty [Nonempty ι] {s : Finset ι} {w : ι → k}
     (h : ∑ i ∈ s, w i = 1) (p : ι → P) :
     s.affineCombination k p w ∈ affineSpan k (Set.range p) := by

--- a/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
@@ -945,6 +945,18 @@ theorem affineCombination_mem_affineSpan [Nontrivial k] {s : Finset ι} {w : ι 
     rw [← vsub_vadd (s.affineCombination k p w) (p i1)]
     exact AffineSubspace.vadd_mem_of_mem_direction hv (mem_affineSpan k (Set.mem_range_self _))
 
+/-- An `affineCombination` with sum of weights 1 is in the
+`affineSpan` of an indexed family, if family is nonempty. -/
+theorem affineCombination_mem_affineSpan_of_nonempty [Nonempty ι] {s : Finset ι} {w : ι → k}
+    (h : ∑ i ∈ s, w i = 1) (p : ι → P) :
+    s.affineCombination k p w ∈ affineSpan k (Set.range p) := by
+  rcases subsingleton_or_nontrivial k with hs | hn
+  · have hnv := Module.subsingleton k V
+    rw [AddTorsor.subsingleton_iff V P] at hnv
+    rw [(affineSpan_eq_top_iff_nonempty_of_subsingleton k).2 (Set.range_nonempty p)]
+    simp
+  · exact affineCombination_mem_affineSpan h p
+
 variable (k) in
 /-- A vector is in the `vectorSpan` of an indexed family if and only
 if it is a `weightedVSub` with sum of weights 0. -/

--- a/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
@@ -138,7 +138,7 @@ lemma isIrreducible_iff_invtRootSubmodule
     have := IsIrreducible.eq_top_of_invtSubmodule_reflection q hq
     tauto
   · let q' : P.invtRootSubmodule := ⟨q, P.mem_invtRootSubmodule_iff.mpr hq⟩
-    replace hq' : ⊥ < q' := by simpa [q', bot_lt_iff_ne_bot]
+    replace hq' : ⊥ < q' := by simpa [q', bot_lt_iff_ne_bot, -IsSimpleOrder.bot_lt_iff_eq_top]
     suffices q' = ⊤ by simpa [q'] using this
     exact IsSimpleOrder.eq_top_of_lt hq'
 

--- a/Mathlib/Order/Atoms.lean
+++ b/Mathlib/Order/Atoms.lean
@@ -850,6 +850,9 @@ instance (priority := 100) : IsCoatomistic α :=
 @[simp] lemma bot_lt_iff_eq_top {a : α} : ⊥ < a ↔ a = ⊤ :=
   ⟨eq_top_of_lt, fun h ↦ h ▸ bot_lt_top⟩
 
+@[simp] lemma lt_top_iff_eq_bot {a : α} : a < ⊤ ↔ a = ⊥ :=
+  ⟨eq_bot_of_lt, fun h ↦ h ▸ bot_lt_top⟩
+
 end IsSimpleOrder
 
 theorem isSimpleOrder_iff_isAtom_top [PartialOrder α] [BoundedOrder α] :

--- a/Mathlib/Order/Atoms.lean
+++ b/Mathlib/Order/Atoms.lean
@@ -847,6 +847,9 @@ instance (priority := 100) : IsAtomistic α where
 instance (priority := 100) : IsCoatomistic α :=
   isAtomistic_dual_iff_isCoatomistic.1 (by infer_instance)
 
+@[simp] lemma bot_lt_iff_eq_top {a : α} : ⊥ < a ↔ a = ⊤ :=
+  ⟨eq_top_of_lt, fun h ↦ h ▸ bot_lt_top⟩
+
 end IsSimpleOrder
 
 theorem isSimpleOrder_iff_isAtom_top [PartialOrder α] [BoundedOrder α] :


### PR DESCRIPTION
Add two lemmas about affine subspaces and affine spans in a subsingleton affine space.  Deduce a variant of
`affineCombination_mem_affineSpan` that uses a nonempty index type rather than a nontrivial ring (this allows `Nontrivial k` hypotheses to be avoided for users in cases where the index type of the combination is known to be nonempty, such as for combinations of vertices of a simplex).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
