### PR TITLE
[Merged by Bors] - feat(IntervalIntegral): integration by parts for scalar multiplication

### DIFF
--- a/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
@@ -635,23 +635,44 @@ section SMul
 
 variable {𝕜 : Type*} [NormedRing 𝕜] [Module 𝕜 E] [NormSMulClass 𝕜 E]
 
+theorem IntegrableOn.continuousOn_smul_of_subset [SecondCountableTopologyEither X 𝕜] {f : X → 𝕜}
+    (hf : ContinuousOn f K) {g : X → E} (hg : IntegrableOn g A μ)
+    (hK : IsCompact K) (hA : MeasurableSet A) (hAK : A ⊆ K) :
+    IntegrableOn (fun x => f x • g x) A μ := by
+  rcases IsCompact.exists_bound_of_continuousOn hK hf with ⟨C, hC⟩
+  rw [IntegrableOn, ← memLp_one_iff_integrable] at hg ⊢
+  have : ∀ᵐ x ∂μ.restrict A, ‖f x • g x‖ ≤ C * ‖g x‖ := by
+    filter_upwards [ae_restrict_mem hA] with x hx
+    refine (norm_smul_le _ _).trans ?_
+    gcongr
+    exact hC x (hAK hx)
+  exact
+    MemLp.of_le_mul hg (((hf.mono hAK).aestronglyMeasurable hA).smul hg.aestronglyMeasurable) this
+
 theorem IntegrableOn.continuousOn_smul [T2Space X] [SecondCountableTopologyEither X 𝕜] {g : X → E}
     (hg : IntegrableOn g K μ) {f : X → 𝕜} (hf : ContinuousOn f K) (hK : IsCompact K) :
-    IntegrableOn (fun x => f x • g x) K μ := by
-  rw [IntegrableOn, ← integrable_norm_iff]
-  · simp_rw [norm_smul]
-    refine IntegrableOn.continuousOn_mul ?_ hg.norm hK
-    exact continuous_norm.comp_continuousOn hf
-  · exact (hf.aestronglyMeasurable hK.measurableSet).smul hg.1
+    IntegrableOn (fun x => f x • g x) K μ :=
+  hg.continuousOn_smul_of_subset hf hK hK.measurableSet Subset.rfl
+
+theorem IntegrableOn.smul_continuousOn_of_subset [SecondCountableTopologyEither X E] {f : X → 𝕜}
+  (hf : IntegrableOn f A μ) {g : X → E} (hg : ContinuousOn g K)
+    (hA : MeasurableSet A) (hK : IsCompact K) (hAK : A ⊆ K) :
+    IntegrableOn (fun x => f x • g x) A μ := by
+  rcases IsCompact.exists_bound_of_continuousOn hK hg with ⟨C, hC⟩
+  rw [IntegrableOn, ← memLp_one_iff_integrable] at hf ⊢
+  have : ∀ᵐ x ∂μ.restrict A, ‖f x • g x‖ ≤ C * ‖f x‖ := by
+    filter_upwards [ae_restrict_mem hA] with x hx
+    refine (norm_smul_le _ _).trans ?_
+    rw [mul_comm]
+    gcongr
+    exact hC x (hAK hx)
+  exact
+    MemLp.of_le_mul hf (hf.aestronglyMeasurable.smul <| (hg.mono hAK).aestronglyMeasurable hA) this
 
 theorem IntegrableOn.smul_continuousOn [T2Space X] [SecondCountableTopologyEither X E] {f : X → 𝕜}
     (hf : IntegrableOn f K μ) {g : X → E} (hg : ContinuousOn g K) (hK : IsCompact K) :
-    IntegrableOn (fun x => f x • g x) K μ := by
-  rw [IntegrableOn, ← integrable_norm_iff]
-  · simp_rw [norm_smul]
-    refine IntegrableOn.mul_continuousOn hf.norm ?_ hK
-    exact continuous_norm.comp_continuousOn hg
-  · exact hf.1.smul (hg.aestronglyMeasurable hK.measurableSet)
+    IntegrableOn (fun x => f x • g x) K μ :=
+  hf.smul_continuousOn_of_subset hg hK.measurableSet hK (Subset.refl _)
 
 end SMul
 

--- a/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
@@ -655,7 +655,7 @@ theorem IntegrableOn.continuousOn_smul [T2Space X] [SecondCountableTopologyEithe
   hg.continuousOn_smul_of_subset hf hK hK.measurableSet Subset.rfl
 
 theorem IntegrableOn.smul_continuousOn_of_subset [SecondCountableTopologyEither X E] {f : X → 𝕜}
-  (hf : IntegrableOn f A μ) {g : X → E} (hg : ContinuousOn g K)
+    (hf : IntegrableOn f A μ) {g : X → E} (hg : ContinuousOn g K)
     (hA : MeasurableSet A) (hK : IsCompact K) (hAK : A ⊆ K) :
     IntegrableOn (fun x => f x • g x) A μ := by
   rcases IsCompact.exists_bound_of_continuousOn hK hg with ⟨C, hC⟩

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean
@@ -295,6 +295,33 @@ theorem mul_const {f : ℝ → A} (hf : IntervalIntegrable f μ a b) (c : A) :
     IntervalIntegrable (fun x => f x * c) μ a b :=
   hf.mul_continuousOn continuousOn_const
 
+section SMul
+
+variable {f : ℝ → 𝕜} {g : ℝ → E} [NormedRing 𝕜] [Module 𝕜 E] [NormSMulClass 𝕜 E]
+variable [NoAtoms μ]
+
+theorem smul_continuousOn (hf : IntervalIntegrable f μ a b)
+    (hg : ContinuousOn g [[a, b]]) : IntervalIntegrable (fun x => f x • g x) μ a b := by
+  rw [intervalIntegrable_iff'] at hf ⊢
+  apply hf.smul_continuousOn hg isCompact_uIcc
+
+theorem continuousOn_smul (hg : IntervalIntegrable g μ a b)
+    (hf : ContinuousOn f [[a, b]]) : IntervalIntegrable (fun x => f x • g x) μ a b := by
+  rw [intervalIntegrable_iff'] at hg ⊢
+  apply hg.continuousOn_smul hf isCompact_uIcc
+
+@[simp]
+theorem const_smul (hg : IntervalIntegrable g μ a b) (c : 𝕜) :
+    IntervalIntegrable (fun x => c • g x) μ a b :=
+  hg.continuousOn_smul continuousOn_const
+
+@[simp]
+theorem smul_const (hf : IntervalIntegrable f μ a b) (c : E) :
+    IntervalIntegrable (fun x => f x • c) μ a b :=
+  hf.smul_continuousOn continuousOn_const
+
+end SMul
+
 @[simp]
 theorem div_const {𝕜 : Type*} {f : ℝ → 𝕜} [NormedDivisionRing 𝕜] (h : IntervalIntegrable f μ a b)
     (c : 𝕜) : IntervalIntegrable (fun x => f x / c) μ a b := by

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean
@@ -275,6 +275,8 @@ protected theorem finsum {f : ι → ℝ → E} (h : ∀ i, IntervalIntegrable (
     apply intervalIntegrable_const_iff.2
     tauto
 
+section Mul
+
 theorem mul_continuousOn {f g : ℝ → A} (hf : IntervalIntegrable f μ a b)
     (hg : ContinuousOn g [[a, b]]) : IntervalIntegrable (fun x => f x * g x) μ a b := by
   rw [intervalIntegrable_iff] at hf ⊢
@@ -295,20 +297,21 @@ theorem mul_const {f : ℝ → A} (hf : IntervalIntegrable f μ a b) (c : A) :
     IntervalIntegrable (fun x => f x * c) μ a b :=
   hf.mul_continuousOn continuousOn_const
 
+end Mul
+
 section SMul
 
 variable {f : ℝ → 𝕜} {g : ℝ → E} [NormedRing 𝕜] [Module 𝕜 E] [NormSMulClass 𝕜 E]
-variable [NoAtoms μ]
 
 theorem smul_continuousOn (hf : IntervalIntegrable f μ a b)
     (hg : ContinuousOn g [[a, b]]) : IntervalIntegrable (fun x => f x • g x) μ a b := by
-  rw [intervalIntegrable_iff'] at hf ⊢
-  apply hf.smul_continuousOn hg isCompact_uIcc
+  rw [intervalIntegrable_iff] at hf ⊢
+  exact hf.smul_continuousOn_of_subset hg measurableSet_Ioc isCompact_uIcc Ioc_subset_Icc_self
 
 theorem continuousOn_smul (hg : IntervalIntegrable g μ a b)
     (hf : ContinuousOn f [[a, b]]) : IntervalIntegrable (fun x => f x • g x) μ a b := by
-  rw [intervalIntegrable_iff'] at hg ⊢
-  apply hg.continuousOn_smul hf isCompact_uIcc
+  rw [intervalIntegrable_iff] at hg ⊢
+  exact hg.continuousOn_smul_of_subset hf isCompact_uIcc measurableSet_Ioc Ioc_subset_Icc_self
 
 @[simp]
 theorem const_smul (hg : IntervalIntegrable g μ a b) (c : 𝕜) :

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean
@@ -313,16 +313,6 @@ theorem continuousOn_smul (hg : IntervalIntegrable g μ a b)
   rw [intervalIntegrable_iff] at hg ⊢
   exact hg.continuousOn_smul_of_subset hf isCompact_uIcc measurableSet_Ioc Ioc_subset_Icc_self
 
-@[simp]
-theorem const_smul (hg : IntervalIntegrable g μ a b) (c : 𝕜) :
-    IntervalIntegrable (fun x => c • g x) μ a b :=
-  hg.continuousOn_smul continuousOn_const
-
-@[simp]
-theorem smul_const (hf : IntervalIntegrable f μ a b) (c : E) :
-    IntervalIntegrable (fun x => f x • c) μ a b :=
-  hf.smul_continuousOn continuousOn_const
-
 end SMul
 
 @[simp]

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/IntegrationByParts.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/IntegrationByParts.lean
@@ -33,6 +33,8 @@ variable {a b : ℝ}
 
 section Parts
 
+section Mul
+
 variable {A : Type*} [NormedRing A] [NormedAlgebra ℝ A] [CompleteSpace A] {u v u' v' : ℝ → A}
 
 /-- The integral of the derivative of a product of two maps.
@@ -139,6 +141,80 @@ theorem integral_mul_deriv_eq_deriv_mul
     ∫ x in a..b, u x * v' x = u b * v b - u a * v a - ∫ x in a..b, u' x * v x :=
   integral_mul_deriv_eq_deriv_mul_of_hasDerivWithinAt
     (fun x hx ↦ (hu x hx).hasDerivWithinAt) (fun x hx ↦ (hv x hx).hasDerivWithinAt) hu' hv'
+
+end Mul
+
+section SMul
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] [NormedAlgebra ℝ 𝕜]
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] [NormedSpace ℝ E] [CompleteSpace E]
+variable [IsScalarTower ℝ 𝕜 E]
+
+variable {u u' : ℝ → 𝕜}
+variable {v v' : ℝ → E}
+
+/-- The integral of the derivative of a scalar multiplication. -/
+theorem integral_deriv_smul_eq_sub_of_hasDeriv_right (hu : ContinuousOn u [[a, b]])
+    (hv : ContinuousOn v [[a, b]])
+    (huu' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivWithinAt u (u' x) (Ioi x) x)
+    (hvv' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivWithinAt v (v' x) (Ioi x) x)
+    (hu' : IntervalIntegrable u' volume a b)
+    (hv' : IntervalIntegrable v' volume a b) :
+    ∫ x in a..b, u' x • v x + u x • v' x = u b • v b - u a • v a := by
+  simp_rw [add_comm]
+  apply integral_eq_sub_of_hasDeriv_right (hu.smul hv) fun x hx ↦ (huu' x hx).smul (hvv' x hx)
+  exact (hv'.continuousOn_smul hu).add (hu'.smul_continuousOn hv)
+
+/-- **Integration by parts** (vector-valued). -/
+theorem integral_smul_deriv_eq_deriv_smul_of_hasDeriv_right
+    (hu : ContinuousOn u [[a, b]]) (hv : ContinuousOn v [[a, b]])
+    (huu' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivWithinAt u (u' x) (Ioi x) x)
+    (hvv' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivWithinAt v (v' x) (Ioi x) x)
+    (hu' : IntervalIntegrable u' volume a b) (hv' : IntervalIntegrable v' volume a b) :
+    ∫ x in a..b, u x • v' x = u b • v b - u a • v a - ∫ x in a..b, u' x • v x := by
+  rw [← integral_deriv_smul_eq_sub_of_hasDeriv_right hu hv huu' hvv' hu' hv', ← integral_sub]
+  · simp_rw [add_sub_cancel_left]
+  · exact (hu'.smul_continuousOn hv).add (hv'.continuousOn_smul hu)
+  · exact hu'.smul_continuousOn hv
+
+/-- **Integration by parts** (vector-valued).
+Special case of `integral_smul_deriv_eq_deriv_smul_of_hasDeriv_right`
+where the functions have a two-sided derivative in the interior of the interval. -/
+theorem integral_smul_deriv_eq_deriv_smul_of_hasDerivAt
+    (hu : ContinuousOn u [[a, b]]) (hv : ContinuousOn v [[a, b]])
+    (huu' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivAt u (u' x) x)
+    (hvv' : ∀ x ∈ Ioo (min a b) (max a b), HasDerivAt v (v' x) x)
+    (hu' : IntervalIntegrable u' volume a b) (hv' : IntervalIntegrable v' volume a b) :
+    ∫ x in a..b, u x • v' x = u b • v b - u a • v a - ∫ x in a..b, u' x • v x :=
+  integral_smul_deriv_eq_deriv_smul_of_hasDeriv_right hu hv
+        (fun x hx ↦ (huu' x hx).hasDerivWithinAt) (fun x hx ↦ (hvv' x hx).hasDerivWithinAt) hu' hv'
+
+/-- **Integration by parts** (vector-valued). Special case of
+`intervalIntegrable.integral_smul_deriv_eq_deriv_smul_of_hasDeriv_right`
+where the functions have a one-sided derivative at the endpoints. -/
+theorem integral_smul_deriv_eq_deriv_smul_of_hasDerivWithinAt
+    (hu : ∀ x ∈ [[a, b]], HasDerivWithinAt u (u' x) [[a, b]] x)
+    (hv : ∀ x ∈ [[a, b]], HasDerivWithinAt v (v' x) [[a, b]] x)
+    (hu' : IntervalIntegrable u' volume a b) (hv' : IntervalIntegrable v' volume a b) :
+    ∫ x in a..b, u x • v' x = u b • v b - u a • v a - ∫ x in a..b, u' x • v x :=
+  integral_smul_deriv_eq_deriv_smul_of_hasDerivAt
+    (fun x hx ↦ (hu x hx).continuousWithinAt)
+    (fun x hx ↦ (hv x hx).continuousWithinAt)
+    (fun x hx ↦ hu x (mem_Icc_of_Ioo hx) |>.hasDerivAt (Icc_mem_nhds hx.1 hx.2))
+    (fun x hx ↦ hv x (mem_Icc_of_Ioo hx) |>.hasDerivAt (Icc_mem_nhds hx.1 hx.2))
+    hu' hv'
+
+/-- **Integration by parts** (vector-valued). Special case of
+`intervalIntegrable.integral_smul_deriv_eq_deriv_smul_of_hasDeriv_right`
+where the functions have a derivative also at the endpoints. -/
+theorem integral_smul_deriv_eq_deriv_smul
+    (hu : ∀ x ∈ [[a, b]], HasDerivAt u (u' x) x) (hv : ∀ x ∈ [[a, b]], HasDerivAt v (v' x) x)
+    (hu' : IntervalIntegrable u' volume a b) (hv' : IntervalIntegrable v' volume a b) :
+    ∫ x in a..b, u x • v' x = u b • v b - u a • v a - ∫ x in a..b, u' x • v x :=
+  integral_smul_deriv_eq_deriv_smul_of_hasDerivWithinAt
+    (fun x hx ↦ (hu x hx).hasDerivWithinAt) (fun x hx ↦ (hv x hx).hasDerivWithinAt) hu' hv'
+
+end SMul
 
 end Parts
 


### PR DESCRIPTION

---
This very straightforward PR adds a version of integration by parts for scalar multiplication and some prerequisite `smul` lemmas.
Needed for applying integration by parts to vector-valued functions, my use-case is a project on oscillatory integrals: https://github.com/roos-j/lean-oscillatory

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
