### PR TITLE
[Merged by Bors] - feat: implement the Cauchy-Riemann Equation

### DIFF
--- a/Mathlib/Analysis/Complex/Conformal.lean
+++ b/Mathlib/Analysis/Complex/Conformal.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Yourong Zang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Yourong Zang
+Authors: Yourong Zang, Stefan Kebekus
 -/
 import Mathlib.Analysis.Calculus.Conformal.NormedSpace
 import Mathlib.Analysis.Calculus.Deriv.Basic
@@ -240,13 +240,32 @@ theorem differentiableWithinAt_complex_iff_differentiableWithinAt_real
 In cases where the Cauchy-Riemann Equation guarantees complex differentiability, the complex
 derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
 -/
-theorem fDerivWithin_complex_eq_toComplexOfMapI_fderivWithin_real
+theorem complexOfReal_hasFDerivWithinAt (h₁ : DifferentiableWithinAt ℝ f s x)
+    (h₂ : fderivWithin ℝ f s x I = I • fderivWithin ℝ f s x 1) :
+    HasFDerivWithinAt f ((fderivWithin ℝ f s x).complexOfReal h₂) s x :=
+  HasFDerivWithinAt.of_restrictScalars ℝ h₁.hasFDerivWithinAt rfl
+
+/--
+In cases where the Cauchy-Riemann Equation guarantees complex differentiability, the complex
+derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
+-/
+theorem complexOfReal_fderivWithin
     (h₁ : DifferentiableWithinAt ℝ f s x)
     (h₂ : fderivWithin ℝ f s x I = I • fderivWithin ℝ f s x 1) (hs : UniqueDiffWithinAt ℝ s x) :
     fderivWithin ℂ f s x = (fderivWithin ℝ f s x).complexOfReal h₂ := by
   have := ((differentiableWithinAt_complex_iff_differentiableWithinAt_real hs).2
       ⟨h₁, h₂⟩).restrictScalars_fderivWithin ℝ hs
   simpa [DFunLike.ext_iff]
+
+/--
+In cases where the Cauchy-Riemann Equation guarantees complex differentiability, the complex
+derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
+-/
+theorem complexOfReal_hasDerivWithinAt (h₁ : DifferentiableWithinAt ℝ f s x)
+    (h₂ : fderivWithin ℝ f s x I = I • fderivWithin ℝ f s x 1) :
+    HasDerivWithinAt f ((fderivWithin ℝ f s x).complexOfReal h₂ 1) s x := by
+  rw [hasDerivWithinAt_iff_hasFDerivWithinAt, smulRight_one_one]
+  exact complexOfReal_hasFDerivWithinAt h₁ h₂
 
 /--
 The Cauchy-Riemann Equation: A real-differentiable function `f` on `ℂ` is complex-differentiable if
@@ -258,6 +277,25 @@ theorem differentiableAt_complex_iff_differentiableAt_real :
   ⟨fun h ↦ by simp [h.restrictScalars ℝ, h.fderiv_restrictScalars ℝ],
     fun ⟨h₁, h₂⟩ => (differentiableAt_iff_restrictScalars ℝ h₁).2
     ⟨(fderiv ℝ f x).complexOfReal h₂, rfl⟩⟩
+
+/--
+In cases where the Cauchy-Riemann Equation guarantees complex differentiability, the complex
+derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
+-/
+theorem complexOfReal_hasFDerivAt (h₁ : DifferentiableAt ℝ f x)
+    (h₂ : fderiv ℝ f x I = I • fderiv ℝ f x 1) :
+    HasFDerivAt f ((fderiv ℝ f x).complexOfReal h₂) x :=
+  hasFDerivAt_of_restrictScalars ℝ h₁.hasFDerivAt rfl
+
+/--
+In cases where the Cauchy-Riemann Equation guarantees complex differentiability, the complex
+derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
+-/
+theorem complexOfReal_hasDerivAt (h₁ : DifferentiableAt ℝ f x)
+    (h₂ : fderiv ℝ f x I = I • fderiv ℝ f x 1) :
+    HasDerivAt f ((fderiv ℝ f x).complexOfReal h₂ 1) x := by
+  rw [hasDerivAt_iff_hasFDerivAt, smulRight_one_one]
+  exact hasFDerivAt_of_restrictScalars ℝ h₁.hasFDerivAt rfl
 
 /--
 In cases where the Cauchy-Riemann Equation guarantees complex differentiability, the complex

--- a/Mathlib/Analysis/Complex/Conformal.lean
+++ b/Mathlib/Analysis/Complex/Conformal.lean
@@ -240,17 +240,16 @@ theorem differentiableWithinAt_complex_iff_differentiableWithinAt_real
 In cases where the Cauchy-Riemann Equation guarantees complex differentiability, the complex
 derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
 -/
-protected theorem HasFDerivWithinAt.complexOfReal_hasFDerivWithinAt (h₁ : HasFDerivWithinAt f g s x)
-    (h₂ : g x I = I • g x 1) :
-    HasFDerivWithinAt f ((g x).complexOfReal h₂) s x :=
-  HasFDerivWithinAt.of_restrictScalars ℝ h₁.hasFDerivWithinAt rfl
+protected theorem HasFDerivWithinAt.complexOfReal_hasFDerivWithinAt {f' : ℂ →L[ℝ] E}
+    (h₁ : HasFDerivWithinAt f f' s x) (h₂ : f' I = I • f' 1) :
+    HasFDerivWithinAt f (f'.complexOfReal h₂) s x :=
+  HasFDerivWithinAt.of_restrictScalars ℝ h₁ rfl
 
 /--
 In cases where the Cauchy-Riemann Equation guarantees complex differentiability, the complex
 derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
 -/
-theorem complexOfReal_fderivWithin
-    (h₁ : DifferentiableWithinAt ℝ f s x)
+theorem complexOfReal_fderivWithin (h₁ : DifferentiableWithinAt ℝ f s x)
     (h₂ : fderivWithin ℝ f s x I = I • fderivWithin ℝ f s x 1) (hs : UniqueDiffWithinAt ℝ s x) :
     fderivWithin ℂ f s x = (fderivWithin ℝ f s x).complexOfReal h₂ := by
   have := ((differentiableWithinAt_complex_iff_differentiableWithinAt_real hs).2
@@ -265,7 +264,7 @@ theorem complexOfReal_hasDerivWithinAt (h₁ : DifferentiableWithinAt ℝ f s x)
     (h₂ : fderivWithin ℝ f s x I = I • fderivWithin ℝ f s x 1) :
     HasDerivWithinAt f ((fderivWithin ℝ f s x).complexOfReal h₂ 1) s x := by
   rw [hasDerivWithinAt_iff_hasFDerivWithinAt, smulRight_one_one]
-  exact complexOfReal_hasFDerivWithinAt h₁ h₂
+  exact HasFDerivWithinAt.complexOfReal_hasFDerivWithinAt h₁.hasFDerivWithinAt h₂
 
 /--
 The Cauchy-Riemann Equation: A real-differentiable function `f` on `ℂ` is complex-differentiable if
@@ -282,10 +281,10 @@ theorem differentiableAt_complex_iff_differentiableAt_real :
 In cases where the Cauchy-Riemann Equation guarantees complex differentiability, the complex
 derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
 -/
-theorem complexOfReal_hasFDerivAt (h₁ : DifferentiableAt ℝ f x)
-    (h₂ : fderiv ℝ f x I = I • fderiv ℝ f x 1) :
-    HasFDerivAt f ((fderiv ℝ f x).complexOfReal h₂) x :=
-  hasFDerivAt_of_restrictScalars ℝ h₁.hasFDerivAt rfl
+protected theorem HasFDerivAt.complexOfReal_hasFDerivAt {f' : ℂ →L[ℝ] E}
+    (h₁ : HasFDerivAt f f' x) (h₂ : f' I = I • f' 1) :
+    HasFDerivAt f (f'.complexOfReal h₂) x :=
+  hasFDerivAt_of_restrictScalars ℝ h₁ rfl
 
 /--
 In cases where the Cauchy-Riemann Equation guarantees complex differentiability, the complex

--- a/Mathlib/Analysis/Complex/Conformal.lean
+++ b/Mathlib/Analysis/Complex/Conformal.lean
@@ -173,8 +173,8 @@ variable
   {f : ℂ → E} {x : ℂ} {s : Set ℂ}
 
 /--
-Helper lemma for `differentiableAt_complex_iff_differentiableAt_real`: A real linear map `ℓ : ℂ
-→ₗ[ℝ] E` respects complex scalar multiplication if it maps `I` to `I • ℓ 1`.
+A real linear map `ℓ : ℂ →ₗ[ℝ] E` respects complex scalar multiplication if it maps `I` to
+`I • ℓ 1`.
 -/
 lemma real_linearMap_map_smul_complex {ℓ : ℂ →ₗ[ℝ] E} (h : ℓ I = I • ℓ 1) (a b : ℂ) :
     ℓ (a • b) = a • ℓ b := by
@@ -192,8 +192,8 @@ lemma real_linearMap_map_smul_complex {ℓ : ℂ →ₗ[ℝ] E} (h : ℓ I = I �
   ring
 
 /--
-Using the helper lemma `differentiableAt_complex_iff_differentiableAt_real`, construct a complex-
-linear map from a real-linear map `ℓ` that maps `I` to `I • ℓ 1`.
+Using `differentiableAt_complex_iff_differentiableAt_real`, construct a complex-linear map from a
+real-linear map `ℓ` that maps `I` to `I • ℓ 1`.
 -/
 def LinearMap.complexOfReal (ℓ : ℂ →ₗ[ℝ] E) (h : ℓ I = I • ℓ 1) : ℂ →ₗ[ℂ] E where
   toFun := ℓ
@@ -205,8 +205,8 @@ lemma LinearMap.coe_complexOfReal (ℓ : ℂ →ₗ[ℝ] E) (h : ℓ I = I • �
     ℓ.complexOfReal h = (ℓ : ℂ → E) := rfl
 
 /--
-Using the helper lemma `differentiableAt_complex_iff_differentiableAt_real`, construct a continuous
-complex- linear map from a continueous real-linear map `ℓ` that maps `I` to `I • ℓ 1`.
+Using `differentiableAt_complex_iff_differentiableAt_real`, construct a continuous complex- linear
+map from a continueous real-linear map `ℓ` that maps `I` to `I • ℓ 1`.
 -/
 def ContinuousLinearMap.complexOfReal (ℓ : ℂ →L[ℝ] E) (h : ℓ I = I • ℓ 1) : ℂ →L[ℂ] E where
   toFun := ℓ
@@ -263,7 +263,8 @@ theorem differentiableAt_complex_iff_differentiableAt_real :
 In cases where the Cauchy-Riemann Equation guarantees complex differentiability, the complex
 derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
 -/
-theorem complexOfReal_fderiv (h₁ : DifferentiableAt ℝ f x) h₂ : fderiv ℝ f x I = I • fderiv ℝ f x 1) :
+theorem complexOfReal_fderiv (h₁ : DifferentiableAt ℝ f x)
+    (h₂ : fderiv ℝ f x I = I • fderiv ℝ f x 1) :
     (fderiv ℝ f x).complexOfReal h₂ = fderiv ℂ f x := by
   have := (differentiableAt_complex_iff_differentiableAt_real.2 ⟨h₁, h₂⟩).fderiv_restrictScalars ℝ
   apply DFunLike.ext'

--- a/Mathlib/Analysis/Complex/Conformal.lean
+++ b/Mathlib/Analysis/Complex/Conformal.lean
@@ -240,9 +240,9 @@ theorem differentiableWithinAt_complex_iff_differentiableWithinAt_real
 In cases where the Cauchy-Riemann Equation guarantees complex differentiability, the complex
 derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
 -/
-theorem complexOfReal_hasFDerivWithinAt (h₁ : DifferentiableWithinAt ℝ f s x)
-    (h₂ : fderivWithin ℝ f s x I = I • fderivWithin ℝ f s x 1) :
-    HasFDerivWithinAt f ((fderivWithin ℝ f s x).complexOfReal h₂) s x :=
+protected theorem HasFDerivWithinAt.complexOfReal_hasFDerivWithinAt (h₁ : HasFDerivWithinAt f g s x)
+    (h₂ : g x I = I • g x 1) :
+    HasFDerivWithinAt f ((g x).complexOfReal h₂) s x :=
   HasFDerivWithinAt.of_restrictScalars ℝ h₁.hasFDerivWithinAt rfl
 
 /--

--- a/Mathlib/Analysis/Complex/Conformal.lean
+++ b/Mathlib/Analysis/Complex/Conformal.lean
@@ -201,7 +201,7 @@ def LinearMap.complexOfReal (ℓ : ℂ →ₗ[ℝ] E) (h : ℓ I = I • ℓ 1) 
   map_smul' := real_linearMap_map_smul_complex h
 
 @[simp]
-lemma LinearMap.coe_complexOfReal (ℓ : ℂ →ₗ[ℝ] E) (h : ℓ I = I • ℓ 1) :
+lemma LinearMap.coe_complexOfReal {ℓ : ℂ →ₗ[ℝ] E} (h : ℓ I = I • ℓ 1) :
     ℓ.complexOfReal h = (ℓ : ℂ → E) := rfl
 
 /--
@@ -214,7 +214,7 @@ def ContinuousLinearMap.complexOfReal (ℓ : ℂ →L[ℝ] E) (h : ℓ I = I •
   map_smul' := real_linearMap_map_smul_complex h
 
 @[simp]
-lemma ContinuousLinearMap.coe_complexOfReal (ℓ : ℂ →L[ℝ] E) (h : ℓ I = I • ℓ 1) :
+lemma ContinuousLinearMap.coe_complexOfReal {ℓ : ℂ →L[ℝ] E} (h : ℓ I = I • ℓ 1) :
     ℓ.complexOfReal h = (ℓ : ℂ → E) := rfl
 
 /--

--- a/Mathlib/Analysis/Complex/Conformal.lean
+++ b/Mathlib/Analysis/Complex/Conformal.lean
@@ -299,9 +299,7 @@ derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
 -/
 theorem complexOfReal_fderiv (h₁ : DifferentiableAt ℝ f x)
     (h₂ : fderiv ℝ f x I = I • fderiv ℝ f x 1) :
-    (fderiv ℝ f x).complexOfReal h₂ = fderiv ℂ f x := by
-  have := (differentiableAt_complex_iff_differentiableAt_real.2 ⟨h₁, h₂⟩).fderiv_restrictScalars ℝ
-  apply DFunLike.ext'
-  simp_all
+    (fderiv ℝ f x).complexOfReal h₂ = fderiv ℂ f x :=
+  (h₁.hasFDerivAt.complexOfReal_hasFDerivAt h₂).fderiv.symm
 
 end CauchyRiemann

--- a/Mathlib/Analysis/Complex/Conformal.lean
+++ b/Mathlib/Analysis/Complex/Conformal.lean
@@ -205,7 +205,7 @@ lemma LinearMap.coe_complexOfReal {ℓ : ℂ →ₗ[ℝ] E} (h : ℓ I = I • �
     ℓ.complexOfReal h = (ℓ : ℂ → E) := rfl
 
 /--
-Using `differentiableAt_complex_iff_differentiableAt_real`, construct a continuous complex- linear
+Using `differentiableAt_complex_iff_differentiableAt_real`, construct a continuous complex-linear
 map from a continueous real-linear map `ℓ` that maps `I` to `I • ℓ 1`.
 -/
 def ContinuousLinearMap.complexOfReal (ℓ : ℂ →L[ℝ] E) (h : ℓ I = I • ℓ 1) : ℂ →L[ℂ] E where
@@ -219,7 +219,8 @@ lemma ContinuousLinearMap.coe_complexOfReal {ℓ : ℂ →L[ℝ] E} (h : ℓ I =
 
 /--
 The **Cauchy-Riemann Equation**: A real-differentiable function `f` on `ℂ` is complex-differentiable
-within `s` iff the derivative `fderivWithin ℝ f s x` maps `I` to `I • (fderivWithin ℝ f s x) 1`.
+at `x` within `s` iff the derivative `fderivWithin ℝ f s x` maps `I` to
+`I • (fderivWithin ℝ f s x) 1`.
 -/
 theorem differentiableWithinAt_complex_iff_differentiableWithinAt_real
     (hs : UniqueDiffWithinAt ℝ s x) :
@@ -234,8 +235,8 @@ theorem differentiableWithinAt_complex_iff_differentiableWithinAt_real
     rfl
 
 /--
-In cases where the Cauchy-Riemann Equation guarantees complex differentiability, the complex
-derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
+In cases where the **Cauchy-Riemann Equation** guarantees complex differentiability at `x`, the
+complex derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
 -/
 protected theorem HasFDerivWithinAt.complexOfReal_hasFDerivWithinAt {f' : ℂ →L[ℝ] E}
     (h₁ : HasFDerivWithinAt f f' s x) (h₂ : f' I = I • f' 1) :
@@ -243,8 +244,8 @@ protected theorem HasFDerivWithinAt.complexOfReal_hasFDerivWithinAt {f' : ℂ �
   HasFDerivWithinAt.of_restrictScalars ℝ h₁ rfl
 
 /--
-In cases where the Cauchy-Riemann Equation guarantees complex differentiability, the complex
-derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
+In cases where the **Cauchy-Riemann Equation** guarantees complex differentiability at `x`, the
+complex derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
 -/
 theorem complexOfReal_fderivWithin (h₁ : DifferentiableWithinAt ℝ f s x)
     (h₂ : fderivWithin ℝ f s x I = I • fderivWithin ℝ f s x 1) (hs : UniqueDiffWithinAt ℝ s x) :
@@ -254,8 +255,8 @@ theorem complexOfReal_fderivWithin (h₁ : DifferentiableWithinAt ℝ f s x)
   simpa [DFunLike.ext_iff]
 
 /--
-In cases where the Cauchy-Riemann Equation guarantees complex differentiability, the complex
-derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
+In cases where the **Cauchy-Riemann Equation** guarantees complex differentiability at `x`, the
+complex derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
 -/
 theorem complexOfReal_hasDerivWithinAt (h₁ : DifferentiableWithinAt ℝ f s x)
     (h₂ : fderivWithin ℝ f s x I = I • fderivWithin ℝ f s x 1) :
@@ -264,8 +265,8 @@ theorem complexOfReal_hasDerivWithinAt (h₁ : DifferentiableWithinAt ℝ f s x)
   exact (h₁.hasFDerivWithinAt).complexOfReal_hasFDerivWithinAt h₂
 
 /--
-The Cauchy-Riemann Equation: A real-differentiable function `f` on `ℂ` is complex-differentiable if
-and only if the derivative `fderiv ℝ f x` maps `I` to `I • (fderiv ℝ f x) 1`.
+The **Cauchy-Riemann Equation**: A real-differentiable function `f` on `ℂ` is complex-differentiable
+at `x` if and only if the derivative `fderiv ℝ f x` maps `I` to `I • (fderiv ℝ f x) 1`.
 -/
 theorem differentiableAt_complex_iff_differentiableAt_real :
     DifferentiableAt ℂ f x ↔ DifferentiableAt ℝ f x ∧
@@ -275,8 +276,8 @@ theorem differentiableAt_complex_iff_differentiableAt_real :
     ⟨(fderiv ℝ f x).complexOfReal h₂, rfl⟩⟩
 
 /--
-In cases where the Cauchy-Riemann Equation guarantees complex differentiability, the complex
-derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
+In cases where the **Cauchy-Riemann Equation** guarantees complex differentiability at `x`, the
+complex derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
 -/
 protected theorem HasFDerivAt.complexOfReal_hasFDerivAt {f' : ℂ →L[ℝ] E}
     (h₁ : HasFDerivAt f f' x) (h₂ : f' I = I • f' 1) :
@@ -284,8 +285,8 @@ protected theorem HasFDerivAt.complexOfReal_hasFDerivAt {f' : ℂ →L[ℝ] E}
   hasFDerivAt_of_restrictScalars ℝ h₁ rfl
 
 /--
-In cases where the Cauchy-Riemann Equation guarantees complex differentiability, the complex
-derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
+In cases where the **Cauchy-Riemann Equation** guarantees complex differentiability at `x`, the
+complex derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
 -/
 theorem complexOfReal_hasDerivAt (h₁ : DifferentiableAt ℝ f x)
     (h₂ : fderiv ℝ f x I = I • fderiv ℝ f x 1) :
@@ -294,8 +295,8 @@ theorem complexOfReal_hasDerivAt (h₁ : DifferentiableAt ℝ f x)
   exact hasFDerivAt_of_restrictScalars ℝ h₁.hasFDerivAt rfl
 
 /--
-In cases where the Cauchy-Riemann Equation guarantees complex differentiability, the complex
-derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
+In cases where the **Cauchy-Riemann Equation** guarantees complex differentiability at `x`, the
+complex derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
 -/
 theorem complexOfReal_fderiv (h₁ : DifferentiableAt ℝ f x)
     (h₂ : fderiv ℝ f x I = I • fderiv ℝ f x 1) :

--- a/Mathlib/Analysis/Complex/Conformal.lean
+++ b/Mathlib/Analysis/Complex/Conformal.lean
@@ -267,6 +267,15 @@ theorem complexOfReal_hasDerivWithinAt (h₁ : DifferentiableWithinAt ℝ f s x)
   exact (h₁.hasFDerivWithinAt).complexOfReal_hasFDerivWithinAt h₂
 
 /--
+In cases where the **Cauchy-Riemann Equation** guarantees complex differentiability at `x`, the
+complex derivative equals `ContinuousLinearMap.complexOfReal` of the real derivative.
+-/
+theorem complexOfReal_derivWithin (h₁ : DifferentiableWithinAt ℝ f s x)
+    (h₂ : fderivWithin ℝ f s x I = I • fderivWithin ℝ f s x 1) (hs : UniqueDiffWithinAt ℂ s x) :
+    derivWithin f s x = fderivWithin ℝ f s x 1 :=
+  HasDerivWithinAt.derivWithin (complexOfReal_hasDerivWithinAt h₁ h₂) hs
+
+/--
 The **Cauchy-Riemann Equation**: A real-differentiable function `f` on `ℂ` is complex-differentiable
 at `x` if and only if the derivative `fderiv ℝ f x` maps `I` to `I • (fderiv ℝ f x) 1`.
 -/
@@ -295,6 +304,15 @@ theorem complexOfReal_hasDerivAt (h₁ : DifferentiableAt ℝ f x)
     HasDerivAt f ((fderiv ℝ f x).complexOfReal h₂ 1) x := by
   rw [hasDerivAt_iff_hasFDerivAt, smulRight_one_one]
   exact hasFDerivAt_of_restrictScalars ℝ h₁.hasFDerivAt rfl
+
+/--
+In cases where the **Cauchy-Riemann Equation** guarantees complex differentiability at `x`, the
+complex derivative equals `ContinuousLinearMap.complexOfReal` of the real derivative.
+-/
+theorem complexOfReal_deriv (h₁ : DifferentiableAt ℝ f x)
+    (h₂ : fderiv ℝ f x I = I • fderiv ℝ f x 1) :
+    deriv f x = fderiv ℝ f x 1 :=
+  HasDerivAt.deriv (complexOfReal_hasDerivAt h₁ h₂)
 
 /--
 In cases where the **Cauchy-Riemann Equation** guarantees complex differentiability at `x`, the

--- a/Mathlib/Analysis/Complex/Conformal.lean
+++ b/Mathlib/Analysis/Complex/Conformal.lean
@@ -225,14 +225,11 @@ theorem differentiableWithinAt_complex_iff_differentiableWithinAt_real
     (hs : UniqueDiffWithinAt ℝ s x) :
     (DifferentiableWithinAt ℂ f s x) ↔ (DifferentiableWithinAt ℝ f s x) ∧
       (fderivWithin ℝ f s x I = I • fderivWithin ℝ f s x 1) := by
-  constructor
-  · intro h
-    refine ⟨h.restrictScalars ℝ, ?_⟩
-    simp only [← h.restrictScalars_fderivWithin ℝ hs, ContinuousLinearMap.coe_restrictScalars']
+  refine ⟨fun h ↦ ⟨h.restrictScalars ℝ, ?_⟩, fun ⟨h₁, h₂⟩ ↦ ?_⟩
+  · simp only [← h.restrictScalars_fderivWithin ℝ hs, ContinuousLinearMap.coe_restrictScalars']
     rw [(by simp : I = I • 1), (fderivWithin ℂ f s x).map_smul]
     simp
-  · intro ⟨h₁, h₂⟩
-    apply (differentiableWithinAt_iff_restrictScalars ℝ h₁ hs).2
+  · apply (differentiableWithinAt_iff_restrictScalars ℝ h₁ hs).2
     use (fderivWithin ℝ f s x).complexOfReal h₂
     rfl
 

--- a/Mathlib/Analysis/Complex/Conformal.lean
+++ b/Mathlib/Analysis/Complex/Conformal.lean
@@ -261,7 +261,7 @@ theorem complexOfReal_hasDerivWithinAt (h₁ : DifferentiableWithinAt ℝ f s x)
     (h₂ : fderivWithin ℝ f s x I = I • fderivWithin ℝ f s x 1) :
     HasDerivWithinAt f ((fderivWithin ℝ f s x).complexOfReal h₂ 1) s x := by
   rw [hasDerivWithinAt_iff_hasFDerivWithinAt, smulRight_one_one]
-  exact HasFDerivWithinAt.complexOfReal_hasFDerivWithinAt h₁.hasFDerivWithinAt h₂
+  exact (h₁.hasFDerivWithinAt).complexOfReal_hasFDerivWithinAt h₂
 
 /--
 The Cauchy-Riemann Equation: A real-differentiable function `f` on `ℂ` is complex-differentiable if
@@ -271,7 +271,7 @@ theorem differentiableAt_complex_iff_differentiableAt_real :
     DifferentiableAt ℂ f x ↔ DifferentiableAt ℝ f x ∧
       fderiv ℝ f x I = I • fderiv ℝ f x 1 :=
   ⟨fun h ↦ by simp [h.restrictScalars ℝ, h.fderiv_restrictScalars ℝ],
-    fun ⟨h₁, h₂⟩ => (differentiableAt_iff_restrictScalars ℝ h₁).2
+    fun ⟨h₁, h₂⟩ ↦ (differentiableAt_iff_restrictScalars ℝ h₁).2
     ⟨(fderiv ℝ f x).complexOfReal h₂, rfl⟩⟩
 
 /--

--- a/Mathlib/Analysis/Complex/Conformal.lean
+++ b/Mathlib/Analysis/Complex/Conformal.lean
@@ -208,28 +208,22 @@ def LinearMap.complexOfReal (ℓ : ℂ →ₗ[ℝ] E) (h : ℓ I = I • ℓ 1) 
   map_add' := ℓ.map_add
   map_smul' := real_linearMap_map_smul_complex h
 
-/--
-The function underlying `ℓ.toComplexOfMapI` is the function unerlying `ℓ`.
--/
 @[simp]
-lemma LinearMap.coe_toComplexOfMapI (ℓ : ℂ →ₗ[ℝ] E) (h : ℓ I = I • ℓ 1) :
-    ℓ.toComplexOfMapI h = (ℓ : ℂ → E) := by rfl
+lemma LinearMap.coe_complexOfReal (ℓ : ℂ →ₗ[ℝ] E) (h : ℓ I = I • ℓ 1) :
+    ℓ.complexOfReal h = (ℓ : ℂ → E) := by rfl
 
 /--
 Using the helper lemma `differentiableAt_complex_iff_differentiableAt_real`, construct a continueous
 complex- linear map from a continueous real-linear map `ℓ` that maps `I` to `I • ℓ 1`.
 -/
-def ContinuousLinearMap.toComplexOfMapI (ℓ : ℂ →L[ℝ] E) (h : ℓ I = I • ℓ 1) : ℂ →L[ℂ] E where
+def ContinuousLinearMap.complexOfReal (ℓ : ℂ →L[ℝ] E) (h : ℓ I = I • ℓ 1) : ℂ →L[ℂ] E where
   toFun := ℓ
   map_add' := ℓ.map_add
   map_smul' := real_linearMap_map_smul_complex h
 
-/--
-The function underlying `ℓ.toComplexOfMapI` is the function unerlying `ℓ`.
--/
 @[simp]
-lemma ContinuousLinearMap.coe_toComplexOfMapI (ℓ : ℂ →L[ℝ] E) (h : ℓ I = I • ℓ 1) :
-    ℓ.toComplexOfMapI h = (ℓ : ℂ → E) := by rfl
+lemma ContinuousLinearMap.coe_complexOfReal (ℓ : ℂ →L[ℝ] E) (h : ℓ I = I • ℓ 1) :
+    ℓ.complexOfReal h = (ℓ : ℂ → E) := by rfl
 
 /--
 The **Cauchy-Riemann Equation**: A real-differentiable function `f` on `ℂ` is complex-differentiable
@@ -247,7 +241,7 @@ theorem differentiableWithinAt_complex_iff_differentiableWithinAt_real
     simp
   · intro ⟨h₁, h₂⟩
     apply (differentiableWithinAt_iff_restrictScalars ℝ h₁ hs).2
-    use (fderivWithin ℝ f s x).toComplexOfMapI h₂
+    use (fderivWithin ℝ f s x).complexOfReal h₂
     rfl
 
 /--
@@ -257,7 +251,7 @@ derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
 theorem fDerivWithin_complex_eq_toComplexOfMapI_fderivWithin_real
     (h₁ : DifferentiableWithinAt ℝ f s x)
     (h₂ : fderivWithin ℝ f s x I = I • fderivWithin ℝ f s x 1) (hs : UniqueDiffWithinAt ℝ s x) :
-    fderivWithin ℂ f s x = (fderivWithin ℝ f s x).toComplexOfMapI h₂ := by
+    fderivWithin ℂ f s x = (fderivWithin ℝ f s x).complexOfReal h₂ := by
   have := ((differentiableWithinAt_complex_iff_differentiableWithinAt_real hs).2
       ⟨h₁, h₂⟩).restrictScalars_fderivWithin ℝ hs
   have := coe_restrictScalars' (fderivWithin ℂ f s x) (R := ℝ)
@@ -274,7 +268,7 @@ theorem differentiableAt_complex_iff_differentiableAt_real :
   refine ⟨fun h ↦ by simp [h.restrictScalars ℝ, h.fderiv_restrictScalars ℝ], ?_⟩
   intro ⟨h₁, h₂⟩
   apply (differentiableAt_iff_restrictScalars ℝ h₁).2
-  use (fderiv ℝ f x).toComplexOfMapI h₂
+  use (fderiv ℝ f x).complexOfReal h₂
   rfl
 
 /--
@@ -283,7 +277,7 @@ derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
 -/
 theorem fderiv_complex_eq_toComplexOfMapI_fderiv_real (h₁ : DifferentiableAt ℝ f x)
     (h₂ : fderiv ℝ f x I = I • fderiv ℝ f x 1) :
-    fderiv ℂ f x = (fderiv ℝ f x).toComplexOfMapI h₂ := by
+    fderiv ℂ f x = (fderiv ℝ f x).complexOfReal h₂ := by
   have := (differentiableAt_complex_iff_differentiableAt_real.2 ⟨h₁, h₂⟩).fderiv_restrictScalars ℝ
   apply DFunLike.ext'
   simp_all

--- a/Mathlib/Analysis/Complex/Conformal.lean
+++ b/Mathlib/Analysis/Complex/Conformal.lean
@@ -192,8 +192,7 @@ lemma real_linearMap_map_smul_complex {ℓ : ℂ →ₗ[ℝ] E} (h : ℓ I = I �
   ring
 
 /--
-Using `differentiableAt_complex_iff_differentiableAt_real`, construct a complex-linear map from a
-real-linear map `ℓ` that maps `I` to `I • ℓ 1`.
+Construct a complex-linear map from a real-linear map `ℓ` that maps `I` to `I • ℓ 1`.
 -/
 def LinearMap.complexOfReal (ℓ : ℂ →ₗ[ℝ] E) (h : ℓ I = I • ℓ 1) : ℂ →ₗ[ℂ] E where
   toFun := ℓ
@@ -205,8 +204,8 @@ lemma LinearMap.coe_complexOfReal {ℓ : ℂ →ₗ[ℝ] E} (h : ℓ I = I • �
     ℓ.complexOfReal h = (ℓ : ℂ → E) := rfl
 
 /--
-Using `differentiableAt_complex_iff_differentiableAt_real`, construct a continuous complex-linear
-map from a continueous real-linear map `ℓ` that maps `I` to `I • ℓ 1`.
+Construct a continuous complex-linear map from a continueous real-linear map `ℓ` that maps `I` to
+`I • ℓ 1`.
 -/
 def ContinuousLinearMap.complexOfReal (ℓ : ℂ →L[ℝ] E) (h : ℓ I = I • ℓ 1) : ℂ →L[ℂ] E where
   toFun := ℓ

--- a/Mathlib/Analysis/Complex/Conformal.lean
+++ b/Mathlib/Analysis/Complex/Conformal.lean
@@ -20,14 +20,13 @@ to be conformal.
 
 ## Main results
 
-* `isConformalMap_complex_linear`: a nonzero complex linear map into an arbitrary complex
-                                   normed space is conformal.
-* `isConformalMap_complex_linear_conj`: the composition of a nonzero complex linear map with
-                                        `conj` is complex linear.
-* `isConformalMap_iff_is_complex_or_conj_linear`: a real linear map between the complex
-                                                  plane is conformal iff it's complex
-                                                  linear or the composition of
-                                                  some complex linear map and `conj`.
+* `isConformalMap_complex_linear`: a nonzero complex linear map into an arbitrary complex normed
+                                   space is conformal.
+* `isConformalMap_complex_linear_conj`: the composition of a nonzero complex linear map with `conj`
+                                        is complex linear.
+* `isConformalMap_iff_is_complex_or_conj_linear`: a real linear map between the complex plane is
+                                                  conformal iff it's complex linear or the
+                                                  composition of some complex linear map and `conj`.
 
 * `DifferentiableAt.conformalAt` states that a real-differentiable function with a nonvanishing
   differential from the complex plane into an arbitrary complex-normed space is conformal at a point
@@ -36,6 +35,10 @@ to be conformal.
 * `conformalAt_iff_differentiableAt_or_differentiableAt_comp_conj` proves that a real-differential
   function with a nonvanishing differential between the complex plane is conformal at a point if and
   only if it's holomorphic or antiholomorphic at that point.
+
+* `differentiableWithinAt_complex_iff_differentiableWithinAt_real` and
+  `differentiableAt_complex_iff_differentiableAt_real` characterize complex differentiability in
+  terms of the classic Cauchy-Riemann equation.
 
 ## Warning
 
@@ -204,7 +207,7 @@ lemma LinearMap.coe_complexOfReal {ℓ : ℂ →ₗ[ℝ] E} (h : ℓ I = I • �
     ℓ.complexOfReal h = (ℓ : ℂ → E) := rfl
 
 /--
-Construct a continuous complex-linear map from a continueous real-linear map `ℓ` that maps `I` to
+Construct a continuous complex-linear map from a continuous real-linear map `ℓ` that maps `I` to
 `I • ℓ 1`.
 -/
 def ContinuousLinearMap.complexOfReal (ℓ : ℂ →L[ℝ] E) (h : ℓ I = I • ℓ 1) : ℂ →L[ℂ] E where
@@ -235,7 +238,7 @@ theorem differentiableWithinAt_complex_iff_differentiableWithinAt_real
 
 /--
 In cases where the **Cauchy-Riemann Equation** guarantees complex differentiability at `x`, the
-complex derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
+complex derivative equals `ContinuousLinearMap.complexOfReal` of the real derivative.
 -/
 protected theorem HasFDerivWithinAt.complexOfReal_hasFDerivWithinAt {f' : ℂ →L[ℝ] E}
     (h₁ : HasFDerivWithinAt f f' s x) (h₂ : f' I = I • f' 1) :
@@ -244,7 +247,7 @@ protected theorem HasFDerivWithinAt.complexOfReal_hasFDerivWithinAt {f' : ℂ �
 
 /--
 In cases where the **Cauchy-Riemann Equation** guarantees complex differentiability at `x`, the
-complex derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
+complex derivative equals `ContinuousLinearMap.complexOfReal` of the real derivative.
 -/
 theorem complexOfReal_fderivWithin (h₁ : DifferentiableWithinAt ℝ f s x)
     (h₂ : fderivWithin ℝ f s x I = I • fderivWithin ℝ f s x 1) (hs : UniqueDiffWithinAt ℝ s x) :
@@ -255,7 +258,7 @@ theorem complexOfReal_fderivWithin (h₁ : DifferentiableWithinAt ℝ f s x)
 
 /--
 In cases where the **Cauchy-Riemann Equation** guarantees complex differentiability at `x`, the
-complex derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
+complex derivative equals `ContinuousLinearMap.complexOfReal` of the real derivative.
 -/
 theorem complexOfReal_hasDerivWithinAt (h₁ : DifferentiableWithinAt ℝ f s x)
     (h₂ : fderivWithin ℝ f s x I = I • fderivWithin ℝ f s x 1) :
@@ -276,7 +279,7 @@ theorem differentiableAt_complex_iff_differentiableAt_real :
 
 /--
 In cases where the **Cauchy-Riemann Equation** guarantees complex differentiability at `x`, the
-complex derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
+complex derivative equals `ContinuousLinearMap.complexOfReal` of the real derivative.
 -/
 protected theorem HasFDerivAt.complexOfReal_hasFDerivAt {f' : ℂ →L[ℝ] E}
     (h₁ : HasFDerivAt f f' x) (h₂ : f' I = I • f' 1) :
@@ -285,7 +288,7 @@ protected theorem HasFDerivAt.complexOfReal_hasFDerivAt {f' : ℂ →L[ℝ] E}
 
 /--
 In cases where the **Cauchy-Riemann Equation** guarantees complex differentiability at `x`, the
-complex derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
+complex derivative equals `ContinuousLinearMap.complexOfReal` of the real derivative.
 -/
 theorem complexOfReal_hasDerivAt (h₁ : DifferentiableAt ℝ f x)
     (h₂ : fderiv ℝ f x I = I • fderiv ℝ f x 1) :
@@ -295,7 +298,7 @@ theorem complexOfReal_hasDerivAt (h₁ : DifferentiableAt ℝ f x)
 
 /--
 In cases where the **Cauchy-Riemann Equation** guarantees complex differentiability at `x`, the
-complex derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
+complex derivative equals `ContinuousLinearMap.complexOfReal` of the real derivative.
 -/
 theorem complexOfReal_fderiv (h₁ : DifferentiableAt ℝ f x)
     (h₂ : fderiv ℝ f x I = I • fderiv ℝ f x 1) :

--- a/Mathlib/Analysis/Complex/Conformal.lean
+++ b/Mathlib/Analysis/Complex/Conformal.lean
@@ -223,7 +223,7 @@ within `s` iff the derivative `fderivWithin ℝ f s x` maps `I` to `I • (fderi
 -/
 theorem differentiableWithinAt_complex_iff_differentiableWithinAt_real
     (hs : UniqueDiffWithinAt ℝ s x) :
-    (DifferentiableWithinAt ℂ f s x) ↔ (DifferentiableWithinAt ℝ f s x) ∧
+    DifferentiableWithinAt ℂ f s x ↔ DifferentiableWithinAt ℝ f s x ∧
       (fderivWithin ℝ f s x I = I • fderivWithin ℝ f s x 1) := by
   refine ⟨fun h ↦ ⟨h.restrictScalars ℝ, ?_⟩, fun ⟨h₁, h₂⟩ ↦ ?_⟩
   · simp only [← h.restrictScalars_fderivWithin ℝ hs, ContinuousLinearMap.coe_restrictScalars']

--- a/Mathlib/Analysis/Complex/Conformal.lean
+++ b/Mathlib/Analysis/Complex/Conformal.lean
@@ -268,7 +268,7 @@ theorem complexOfReal_hasDerivWithinAt (h₁ : DifferentiableWithinAt ℝ f s x)
 
 /--
 In cases where the **Cauchy-Riemann Equation** guarantees complex differentiability at `x`, the
-complex derivative equals `ContinuousLinearMap.complexOfReal` of the real derivative.
+complex derivative equals the real derivative.
 -/
 theorem complexOfReal_derivWithin (h₁ : DifferentiableWithinAt ℝ f s x)
     (h₂ : fderivWithin ℝ f s x I = I • fderivWithin ℝ f s x 1) (hs : UniqueDiffWithinAt ℂ s x) :
@@ -307,7 +307,7 @@ theorem complexOfReal_hasDerivAt (h₁ : DifferentiableAt ℝ f x)
 
 /--
 In cases where the **Cauchy-Riemann Equation** guarantees complex differentiability at `x`, the
-complex derivative equals `ContinuousLinearMap.complexOfReal` of the real derivative.
+complex derivative equals the real derivative.
 -/
 theorem complexOfReal_deriv (h₁ : DifferentiableAt ℝ f x)
     (h₂ : fderiv ℝ f x I = I • fderiv ℝ f x 1) :

--- a/Mathlib/Analysis/Complex/Conformal.lean
+++ b/Mathlib/Analysis/Complex/Conformal.lean
@@ -178,25 +178,17 @@ Helper lemma for `differentiableAt_complex_iff_differentiableAt_real`: A real li
 -/
 lemma real_linearMap_map_smul_complex {ℓ : ℂ →ₗ[ℝ] E} (h : ℓ I = I • ℓ 1) (a b : ℂ) :
     ℓ (a • b) = a • ℓ b := by
-  rw [(by simp  : a = (a.re : ℂ) + (a.im : ℂ) • I), (by simp : b = (b.re : ℂ) + (b.im : ℂ) • I)]
+  rw [← re_add_im a, ← re_add_im b, ← smul_eq_mul _ I, ← smul_eq_mul _ I]
   have t₀ : ((a.im : ℂ) • I) • (b.re : ℂ) = (↑(a.im * b.re) : ℂ) • I := by
-    simp only [smul_eq_mul, ofReal_mul]
-    ring
+    simp only [smul_eq_mul, ofReal_mul, ← mul_assoc, mul_comm _ I]
   have t₁ : ((a.im : ℂ) • I) • (b.im : ℂ) • I = (↑(- a.im * b.im) : ℂ) • (1 : ℂ) := by
-    simp only [smul_eq_mul, neg_mul, ofReal_neg, ofReal_mul, mul_one]
-    ring_nf
-    simp
+    simp [mul_mul_mul_comm _ I]
   simp only [add_smul, smul_add, ℓ.map_add, t₀, t₁]
   repeat rw [Complex.coe_smul, ℓ.map_smul]
-  have t₂ {r : ℝ}  : ℓ (r : ℂ) = r • ℓ (1 : ℂ) := by
-    rw [← ℓ.map_smul]
-    congr
-    simp
+  have t₂ {r : ℝ}  : ℓ (r : ℂ) = r • ℓ (1 : ℂ) := by simp [← ℓ.map_smul]
   simp only [t₂, h]
   match_scalars
-  simp only [coe_algebraMap, mul_one, neg_mul, smul_eq_mul]
-  ring_nf
-  simp
+  simp [mul_mul_mul_comm _ I]
   ring
 
 /--
@@ -210,10 +202,10 @@ def LinearMap.complexOfReal (ℓ : ℂ →ₗ[ℝ] E) (h : ℓ I = I • ℓ 1) 
 
 @[simp]
 lemma LinearMap.coe_complexOfReal (ℓ : ℂ →ₗ[ℝ] E) (h : ℓ I = I • ℓ 1) :
-    ℓ.complexOfReal h = (ℓ : ℂ → E) := by rfl
+    ℓ.complexOfReal h = (ℓ : ℂ → E) := rfl
 
 /--
-Using the helper lemma `differentiableAt_complex_iff_differentiableAt_real`, construct a continueous
+Using the helper lemma `differentiableAt_complex_iff_differentiableAt_real`, construct a continuous
 complex- linear map from a continueous real-linear map `ℓ` that maps `I` to `I • ℓ 1`.
 -/
 def ContinuousLinearMap.complexOfReal (ℓ : ℂ →L[ℝ] E) (h : ℓ I = I • ℓ 1) : ℂ →L[ℂ] E where
@@ -223,11 +215,11 @@ def ContinuousLinearMap.complexOfReal (ℓ : ℂ →L[ℝ] E) (h : ℓ I = I •
 
 @[simp]
 lemma ContinuousLinearMap.coe_complexOfReal (ℓ : ℂ →L[ℝ] E) (h : ℓ I = I • ℓ 1) :
-    ℓ.complexOfReal h = (ℓ : ℂ → E) := by rfl
+    ℓ.complexOfReal h = (ℓ : ℂ → E) := rfl
 
 /--
 The **Cauchy-Riemann Equation**: A real-differentiable function `f` on `ℂ` is complex-differentiable
-within `s` if the derivative `fderivWithin ℝ f s x` maps `I` to I • (fderivWithin ℝ f s x) 1`.
+within `s` iff the derivative `fderivWithin ℝ f s x` maps `I` to `I • (fderivWithin ℝ f s x) 1`.
 -/
 theorem differentiableWithinAt_complex_iff_differentiableWithinAt_real
     (hs : UniqueDiffWithinAt ℝ s x) :
@@ -254,30 +246,25 @@ theorem fDerivWithin_complex_eq_toComplexOfMapI_fderivWithin_real
     fderivWithin ℂ f s x = (fderivWithin ℝ f s x).complexOfReal h₂ := by
   have := ((differentiableWithinAt_complex_iff_differentiableWithinAt_real hs).2
       ⟨h₁, h₂⟩).restrictScalars_fderivWithin ℝ hs
-  have := coe_restrictScalars' (fderivWithin ℂ f s x) (R := ℝ)
-  apply DFunLike.ext'
-  simp_all
+  simpa [DFunLike.ext_iff]
 
 /--
 The Cauchy-Riemann Equation: A real-differentiable function `f` on `ℂ` is complex-differentiable if
-the derivative `fderiv ℝ f x` maps `I` to I • (fderiv ℝ f x) 1`.
+and only if the derivative `fderiv ℝ f x` maps `I` to `I • (fderiv ℝ f x) 1`.
 -/
 theorem differentiableAt_complex_iff_differentiableAt_real :
     DifferentiableAt ℂ f x ↔ DifferentiableAt ℝ f x ∧
-      fderiv ℝ f x I = I • fderiv ℝ f x 1 := by
-  refine ⟨fun h ↦ by simp [h.restrictScalars ℝ, h.fderiv_restrictScalars ℝ], ?_⟩
-  intro ⟨h₁, h₂⟩
-  apply (differentiableAt_iff_restrictScalars ℝ h₁).2
-  use (fderiv ℝ f x).complexOfReal h₂
-  rfl
+      fderiv ℝ f x I = I • fderiv ℝ f x 1 :=
+  ⟨fun h ↦ by simp [h.restrictScalars ℝ, h.fderiv_restrictScalars ℝ],
+    fun ⟨h₁, h₂⟩ => (differentiableAt_iff_restrictScalars ℝ h₁).2
+    ⟨(fderiv ℝ f x).complexOfReal h₂, rfl⟩⟩
 
 /--
 In cases where the Cauchy-Riemann Equation guarantees complex differentiability, the complex
 derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
 -/
-theorem fderiv_complex_eq_toComplexOfMapI_fderiv_real (h₁ : DifferentiableAt ℝ f x)
-    (h₂ : fderiv ℝ f x I = I • fderiv ℝ f x 1) :
-    fderiv ℂ f x = (fderiv ℝ f x).complexOfReal h₂ := by
+theorem complexOfReal_fderiv (h₁ : DifferentiableAt ℝ f x) h₂ : fderiv ℝ f x I = I • fderiv ℝ f x 1) :
+    (fderiv ℝ f x).complexOfReal h₂ = fderiv ℂ f x := by
   have := (differentiableAt_complex_iff_differentiableAt_real.2 ⟨h₁, h₂⟩).fderiv_restrictScalars ℝ
   apply DFunLike.ext'
   simp_all

--- a/Mathlib/Analysis/Complex/Conformal.lean
+++ b/Mathlib/Analysis/Complex/Conformal.lean
@@ -203,7 +203,7 @@ lemma real_linearMap_map_smul_complex {ℓ : ℂ →ₗ[ℝ] E} (h : ℓ I = I �
 Using the helper lemma `differentiableAt_complex_iff_differentiableAt_real`, construct a complex-
 linear map from a real-linear map `ℓ` that maps `I` to `I • ℓ 1`.
 -/
-def LinearMap.toComplexOfMapI (ℓ : ℂ →ₗ[ℝ] E) (h : ℓ I = I • ℓ 1) : ℂ →ₗ[ℂ] E where
+def LinearMap.complexOfReal (ℓ : ℂ →ₗ[ℝ] E) (h : ℓ I = I • ℓ 1) : ℂ →ₗ[ℂ] E where
   toFun := ℓ
   map_add' := ℓ.map_add
   map_smul' := real_linearMap_map_smul_complex h
@@ -232,7 +232,7 @@ lemma ContinuousLinearMap.coe_toComplexOfMapI (ℓ : ℂ →L[ℝ] E) (h : ℓ I
     ℓ.toComplexOfMapI h = (ℓ : ℂ → E) := by rfl
 
 /--
-The Cauchy-Riemann Equation: A real-differentiable function `f` on `ℂ` is complex-differentiable
+The **Cauchy-Riemann Equation**: A real-differentiable function `f` on `ℂ` is complex-differentiable
 within `s` if the derivative `fderivWithin ℝ f s x` maps `I` to I • (fderivWithin ℝ f s x) 1`.
 -/
 theorem differentiableWithinAt_complex_iff_differentiableWithinAt_real
@@ -269,8 +269,8 @@ The Cauchy-Riemann Equation: A real-differentiable function `f` on `ℂ` is comp
 the derivative `fderiv ℝ f x` maps `I` to I • (fderiv ℝ f x) 1`.
 -/
 theorem differentiableAt_complex_iff_differentiableAt_real :
-    (DifferentiableAt ℂ f x) ↔ (DifferentiableAt ℝ f x) ∧
-      (fderiv ℝ f x I = I • fderiv ℝ f x 1) := by
+    DifferentiableAt ℂ f x ↔ DifferentiableAt ℝ f x ∧
+      fderiv ℝ f x I = I • fderiv ℝ f x 1 := by
   refine ⟨fun h ↦ by simp [h.restrictScalars ℝ, h.fderiv_restrictScalars ℝ], ?_⟩
   intro ⟨h₁, h₂⟩
   apply (differentiableAt_iff_restrictScalars ℝ h₁).2
@@ -281,7 +281,7 @@ theorem differentiableAt_complex_iff_differentiableAt_real :
 In cases where the Cauchy-Riemann Equation guarantees complex differentiability, the complex
 derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
 -/
-theorem fDeriv_complex_eq_toComplexOfMapI_fderiv_real (h₁ : DifferentiableAt ℝ f x)
+theorem fderiv_complex_eq_toComplexOfMapI_fderiv_real (h₁ : DifferentiableAt ℝ f x)
     (h₂ : fderiv ℝ f x I = I • fderiv ℝ f x 1) :
     fderiv ℂ f x = (fderiv ℝ f x).toComplexOfMapI h₂ := by
   have := (differentiableAt_complex_iff_differentiableAt_real.2 ⟨h₁, h₂⟩).fderiv_restrictScalars ℝ

--- a/Mathlib/Analysis/Complex/Conformal.lean
+++ b/Mathlib/Analysis/Complex/Conformal.lean
@@ -174,7 +174,7 @@ variable
 
 /--
 Helper lemma for `differentiableAt_complex_iff_differentiableAt_real`: A real linear map `ℓ : ℂ
-→ₗ[ℝ] ℂ` respects complex scalar multiplication if it maps `I` to `I • ℓ 1`.
+→ₗ[ℝ] E` respects complex scalar multiplication if it maps `I` to `I • ℓ 1`.
 -/
 lemma real_linearMap_map_smul_complex {ℓ : ℂ →ₗ[ℝ] E} (h : ℓ I = I • ℓ 1) :
     ∀ (a b : ℂ), ℓ (a • b) = a • ℓ b := by
@@ -220,11 +220,10 @@ theorem differentiableWithinAt_complex_iff_differentiableWithinAt_real
     simp
   · intro ⟨h₁, h₂⟩
     apply (differentiableWithinAt_iff_restrictScalars ℝ h₁ hs).2
-    use {
-      toFun := fderivWithin ℝ f s x
-      map_add' := (fderivWithin ℝ f s x).map_add'
-      map_smul' := real_linearMap_map_smul_complex h₂
-    }
+    use { toFun := fderivWithin ℝ f s x
+          map_add' := (fderivWithin ℝ f s x).map_add'
+          map_smul' := real_linearMap_map_smul_complex h₂ }
+    rfl
     rfl
 
 /--

--- a/Mathlib/Analysis/Complex/Conformal.lean
+++ b/Mathlib/Analysis/Complex/Conformal.lean
@@ -176,13 +176,9 @@ variable
 Helper lemma for `differentiableAt_complex_iff_differentiableAt_real`: A real linear map `ℓ : ℂ
 →ₗ[ℝ] E` respects complex scalar multiplication if it maps `I` to `I • ℓ 1`.
 -/
-lemma real_linearMap_map_smul_complex {ℓ : ℂ →ₗ[ℝ] E} (h : ℓ I = I • ℓ 1) :
-    ∀ (a b : ℂ), ℓ (a • b) = a • ℓ b := by
-  intro a b
+lemma real_linearMap_map_smul_complex {ℓ : ℂ →ₗ[ℝ] E} (h : ℓ I = I • ℓ 1) (a b : ℂ) :
+    ℓ (a • b) = a • ℓ b := by
   rw [(by simp  : a = (a.re : ℂ) + (a.im : ℂ) • I), (by simp : b = (b.re : ℂ) + (b.im : ℂ) • I)]
-  repeat rw [add_smul]
-  repeat rw [smul_add]
-  repeat rw [ℓ.map_add]
   have t₀ : ((a.im : ℂ) • I) • (b.re : ℂ) = (↑(a.im * b.re) : ℂ) • I := by
     simp only [smul_eq_mul, ofReal_mul]
     ring
@@ -190,19 +186,50 @@ lemma real_linearMap_map_smul_complex {ℓ : ℂ →ₗ[ℝ] E} (h : ℓ I = I �
     simp only [smul_eq_mul, neg_mul, ofReal_neg, ofReal_mul, mul_one]
     ring_nf
     simp
-  rw [t₀, t₁]
+  simp only [add_smul, smul_add, ℓ.map_add, t₀, t₁]
   repeat rw [Complex.coe_smul, ℓ.map_smul]
   have t₂ {r : ℝ}  : ℓ (r : ℂ) = r • ℓ (1 : ℂ) := by
     rw [← ℓ.map_smul]
     congr
     simp
-  repeat rw [t₂]
-  repeat rw [h]
+  simp only [t₂, h]
   match_scalars
   simp only [coe_algebraMap, mul_one, neg_mul, smul_eq_mul]
   ring_nf
   simp
   ring
+
+/--
+Using the helper lemma `differentiableAt_complex_iff_differentiableAt_real`, construct a complex-
+linear map from a real-linear map `ℓ` that maps `I` to `I • ℓ 1`.
+-/
+def LinearMap.toComplexOfMapI (ℓ : ℂ →ₗ[ℝ] E) (h : ℓ I = I • ℓ 1) : ℂ →ₗ[ℂ] E where
+  toFun := ℓ
+  map_add' := ℓ.map_add
+  map_smul' := real_linearMap_map_smul_complex h
+
+/--
+The function underlying `ℓ.toComplexOfMapI` is the function unerlying `ℓ`.
+-/
+@[simp]
+lemma LinearMap.coe_toComplexOfMapI (ℓ : ℂ →ₗ[ℝ] E) (h : ℓ I = I • ℓ 1) :
+    ℓ.toComplexOfMapI h = (ℓ : ℂ → E) := by rfl
+
+/--
+Using the helper lemma `differentiableAt_complex_iff_differentiableAt_real`, construct a continueous
+complex- linear map from a continueous real-linear map `ℓ` that maps `I` to `I • ℓ 1`.
+-/
+def ContinuousLinearMap.toComplexOfMapI (ℓ : ℂ →L[ℝ] E) (h : ℓ I = I • ℓ 1) : ℂ →L[ℂ] E where
+  toFun := ℓ
+  map_add' := ℓ.map_add
+  map_smul' := real_linearMap_map_smul_complex h
+
+/--
+The function underlying `ℓ.toComplexOfMapI` is the function unerlying `ℓ`.
+-/
+@[simp]
+lemma ContinuousLinearMap.coe_toComplexOfMapI (ℓ : ℂ →L[ℝ] E) (h : ℓ I = I • ℓ 1) :
+    ℓ.toComplexOfMapI h = (ℓ : ℂ → E) := by rfl
 
 /--
 The Cauchy-Riemann Equation: A real-differentiable function `f` on `ℂ` is complex-differentiable
@@ -220,11 +247,22 @@ theorem differentiableWithinAt_complex_iff_differentiableWithinAt_real
     simp
   · intro ⟨h₁, h₂⟩
     apply (differentiableWithinAt_iff_restrictScalars ℝ h₁ hs).2
-    use { toFun := fderivWithin ℝ f s x
-          map_add' := (fderivWithin ℝ f s x).map_add'
-          map_smul' := real_linearMap_map_smul_complex h₂ }
+    use (fderivWithin ℝ f s x).toComplexOfMapI h₂
     rfl
-    rfl
+
+/--
+In cases where the Cauchy-Riemann Equation guarantees complex differentiability, the complex
+derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
+-/
+theorem fDerivWithin_complex_eq_toComplexOfMapI_fderivWithin_real
+    (h₁ : DifferentiableWithinAt ℝ f s x)
+    (h₂ : fderivWithin ℝ f s x I = I • fderivWithin ℝ f s x 1) (hs : UniqueDiffWithinAt ℝ s x) :
+    fderivWithin ℂ f s x = (fderivWithin ℝ f s x).toComplexOfMapI h₂ := by
+  have := ((differentiableWithinAt_complex_iff_differentiableWithinAt_real hs).2
+      ⟨h₁, h₂⟩).restrictScalars_fderivWithin ℝ hs
+  have := coe_restrictScalars' (fderivWithin ℂ f s x) (R := ℝ)
+  apply DFunLike.ext'
+  simp_all
 
 /--
 The Cauchy-Riemann Equation: A real-differentiable function `f` on `ℂ` is complex-differentiable if
@@ -236,11 +274,18 @@ theorem differentiableAt_complex_iff_differentiableAt_real :
   refine ⟨fun h ↦ by simp [h.restrictScalars ℝ, h.fderiv_restrictScalars ℝ], ?_⟩
   intro ⟨h₁, h₂⟩
   apply (differentiableAt_iff_restrictScalars ℝ h₁).2
-  use {
-    toFun := fderiv ℝ f x
-    map_add' := (fderiv ℝ f x).map_add'
-    map_smul' := real_linearMap_map_smul_complex h₂
-  }
+  use (fderiv ℝ f x).toComplexOfMapI h₂
   rfl
+
+/--
+In cases where the Cauchy-Riemann Equation guarantees complex differentiability, the complex
+derivative equals `ContinuousLinearMap.toComplexOfMapI` of the real derivative.
+-/
+theorem fDeriv_complex_eq_toComplexOfMapI_fderiv_real (h₁ : DifferentiableAt ℝ f x)
+    (h₂ : fderiv ℝ f x I = I • fderiv ℝ f x 1) :
+    fderiv ℂ f x = (fderiv ℝ f x).toComplexOfMapI h₂ := by
+  have := (differentiableAt_complex_iff_differentiableAt_real.2 ⟨h₁, h₂⟩).fderiv_restrictScalars ℝ
+  apply DFunLike.ext'
+  simp_all
 
 end CauchyRiemann

--- a/Mathlib/Analysis/Complex/Conformal.lean
+++ b/Mathlib/Analysis/Complex/Conformal.lean
@@ -164,46 +164,84 @@ end Conformality
 ### The Cauchy-Riemann Equation for Complex-Differentiable Functions
 -/
 
+section CauchyRiemann
+
+open Complex
+
+variable
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
+  {f : ℂ → E} {x : ℂ} {s : Set ℂ}
+
 /--
-Helper lemma for `differentiableAt_complex_iff_differentiableAt_real`: A real linear map
-`ℓ : ℂ →ₗ[ℝ] ℂ` respects complex scalar multiplication if it maps `I` to `I • ℓ 1`.
+Helper lemma for `differentiableAt_complex_iff_differentiableAt_real`: A real linear map `ℓ : ℂ
+→ₗ[ℝ] ℂ` respects complex scalar multiplication if it maps `I` to `I • ℓ 1`.
 -/
-theorem real_linearMap_map_smul_complex {ℓ : ℂ →ₗ[ℝ] ℂ} (h : ℓ I = I • ℓ 1) :
+lemma real_linearMap_map_smul_complex {ℓ : ℂ →ₗ[ℝ] E} (h : ℓ I = I • ℓ 1) :
     ∀ (a b : ℂ), ℓ (a • b) = a • ℓ b := by
   intro a b
-  rw [(by simp only [real_smul, re_add_im] : a = a.re + a.im • I), (by simp : b = b.re + b.im • I)]
+  rw [(by simp  : a = (a.re : ℂ) + (a.im : ℂ) • I), (by simp : b = (b.re : ℂ) + (b.im : ℂ) • I)]
   repeat rw [add_smul]
   repeat rw [smul_add]
   repeat rw [ℓ.map_add]
-  have t₀ : (a.im • I) • ↑b.re = (a.im * b.re) • I := by
-    simp
+  have t₀ : ((a.im : ℂ) • I) • (b.re : ℂ) = (↑(a.im * b.re) : ℂ) • I := by
+    simp only [smul_eq_mul, ofReal_mul]
     ring
-  have t₁ : (a.im • I) • b.im • I = -(a.im * b.im) • (1 : ℂ) := by
-    simp [(by ring : ↑a.im * I * (↑b.im * I) = (↑a.im * ↑b.im) * (I * I))]
-  rw [t₀, t₁, (by simp : b.re = b.re • (1 : ℂ))]
-  repeat rw [Complex.coe_smul]
-  repeat rw [ℓ.map_smul]
-  repeat rw [← Complex.coe_smul]
+  have t₁ : ((a.im : ℂ) • I) • (b.im : ℂ) • I = (↑(- a.im * b.im) : ℂ) • (1 : ℂ) := by
+    simp only [smul_eq_mul, neg_mul, ofReal_neg, ofReal_mul, mul_one]
+    ring_nf
+    simp
+  rw [t₀, t₁]
+  repeat rw [Complex.coe_smul, ℓ.map_smul]
+  have t₂ {r : ℝ}  : ℓ (r : ℂ) = r • ℓ (1 : ℂ) := by
+    rw [← ℓ.map_smul]
+    congr
+    simp
+  repeat rw [t₂]
   repeat rw [h]
-  simp only [smul_eq_mul, ofReal_mul, ofReal_neg, neg_mul]
+  match_scalars
+  simp only [coe_algebraMap, mul_one, neg_mul, smul_eq_mul]
   ring_nf
-  rw [I_sq]
+  simp
   ring
 
 /--
-The Cauchy-Riemann Equation: A real-differentiable function `f : ℂ → ℂ` is complex differentiable if
-the derivative `fderiv ℝ f x` maps `I` to I • (fderiv ℝ f x) 1`.
+The Cauchy-Riemann Equation: A real-differentiable function `f` on `ℂ` is complex-differentiable
+within `s` if the derivative `fderivWithin ℝ f s x` maps `I` to I • (fderivWithin ℝ f s x) 1`.
 -/
-theorem differentiableAt_complex_iff_differentiableAt_real {f : ℂ → ℂ} {x : ℂ} :
-    (DifferentiableAt ℂ f x) ↔ (DifferentiableAt ℝ f x) ∧
-      (fderiv ℝ f x I = I • fderiv ℝ f x 1) := by
+theorem differentiableWithinAt_complex_iff_differentiableWithinAt_real
+    (hs : UniqueDiffWithinAt ℝ s x) :
+    (DifferentiableWithinAt ℂ f s x) ↔ (DifferentiableWithinAt ℝ f s x) ∧
+      (fderivWithin ℝ f s x I = I • fderivWithin ℝ f s x 1) := by
   constructor
-  · exact fun h ↦ by simp [h.restrictScalars ℝ, h.fderiv_restrictScalars ℝ]
+  · intro h
+    refine ⟨h.restrictScalars ℝ, ?_⟩
+    simp only [← h.restrictScalars_fderivWithin ℝ hs, ContinuousLinearMap.coe_restrictScalars']
+    rw [(by simp : I = I • 1), (fderivWithin ℂ f s x).map_smul]
+    simp
   · intro ⟨h₁, h₂⟩
-    apply (differentiableAt_iff_restrictScalars ℝ h₁).2
+    apply (differentiableWithinAt_iff_restrictScalars ℝ h₁ hs).2
     use {
-      toFun := fderiv ℝ f x
-      map_add' := (fderiv ℝ f x).map_add'
+      toFun := fderivWithin ℝ f s x
+      map_add' := (fderivWithin ℝ f s x).map_add'
       map_smul' := real_linearMap_map_smul_complex h₂
     }
     rfl
+
+/--
+The Cauchy-Riemann Equation: A real-differentiable function `f` on `ℂ` is complex-differentiable if
+the derivative `fderiv ℝ f x` maps `I` to I • (fderiv ℝ f x) 1`.
+-/
+theorem differentiableAt_complex_iff_differentiableAt_real :
+    (DifferentiableAt ℂ f x) ↔ (DifferentiableAt ℝ f x) ∧
+      (fderiv ℝ f x I = I • fderiv ℝ f x 1) := by
+  refine ⟨fun h ↦ by simp [h.restrictScalars ℝ, h.fderiv_restrictScalars ℝ], ?_⟩
+  intro ⟨h₁, h₂⟩
+  apply (differentiableAt_iff_restrictScalars ℝ h₁).2
+  use {
+    toFun := fderiv ℝ f x
+    map_add' := (fderiv ℝ f x).map_add'
+    map_smul' := real_linearMap_map_smul_complex h₂
+  }
+  rfl
+
+end CauchyRiemann


### PR DESCRIPTION
Describe complex differentiability for functions `f : ℂ → ℂ` using the Cauchy-Riemann equation.

This material closes a long-standing open TODO. It is used in [Project VD](https://github.com/kebekus/ProjectVD), which aims to formalize Value Distribution Theory for meromorphic functions on the complex plane. It is one of the ingredients in the proof of Jensen's Formula in complex analysis.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
