### PR TITLE
[Merged by Bors] - feat(CategoryTheory): add dinatural transformations (continuedx2)

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2043,6 +2043,7 @@ import Mathlib.CategoryTheory.Countable
 import Mathlib.CategoryTheory.Dialectica.Basic
 import Mathlib.CategoryTheory.Dialectica.Monoidal
 import Mathlib.CategoryTheory.DifferentialObject
+import Mathlib.CategoryTheory.DinatTrans
 import Mathlib.CategoryTheory.Discrete.Basic
 import Mathlib.CategoryTheory.Discrete.SumsProducts
 import Mathlib.CategoryTheory.Distributive.Cartesian

--- a/Mathlib/CategoryTheory/DinatTrans.lean
+++ b/Mathlib/CategoryTheory/DinatTrans.lean
@@ -45,8 +45,6 @@ namespace DinatTrans
 /-- Notation for dinatural transformations. -/
 scoped infixr:50 " ⤞ " => DinatTrans
 
-variable {E : Type u₃} [Category.{v₃} E] {F : Type u₄} [Category.{v₄} F]
-
 variable {F G H : Cᵒᵖ ⥤ C ⥤ D}
 
 /-- Post-composition with a natural transformation. -/

--- a/Mathlib/CategoryTheory/DinatTrans.lean
+++ b/Mathlib/CategoryTheory/DinatTrans.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2023 Andrea Laretto. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrea Laretto
+-/
+import Mathlib.CategoryTheory.Opposites
+
+/-!
+# Dinatural transformations
+Dinatural transformations are special kinds of transformations between
+functors `F G : Cᵒᵖ ⥤ C ⥤ D` which depend both covariantly and contravariantly
+on the same category (also known as difunctors).
+
+A dinatural transformation is a family of morphisms given only on *the diagonal* of the two
+functors, and is such that a certain naturality hexagon commutes.
+Note that dinatural transformations cannot be composed with each other (since the outer
+hexagon does not commute in general), but can still be "pre/post-composed" with
+ordinary natural transformations.
+
+## References
+* <https://ncatlab.org/nlab/show/dinatural+transformation>
+-/
+
+namespace CategoryTheory
+
+universe v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
+
+variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
+
+open Opposite
+
+/-- Dinatural transformations between two difunctors. -/
+structure DinatTrans (F G : Cᵒᵖ ⥤ C ⥤ D) : Type max u₁ v₂ where
+  /-- The component of a natural transformation. -/
+  app (X : C) : (F.obj (op X)).obj X ⟶ (G.obj (op X)).obj X
+  /-- The commutativity square for a given morphism. -/
+  dinaturality {X Y : C} (f : X ⟶ Y) :
+    (F.map f.op).app X ≫ app X ≫ (G.obj (op X)).map f =
+    (F.obj (op Y)).map f ≫ app Y ≫ (G.map f.op).app Y := by
+      aesop_cat
+
+attribute [reassoc (attr := simp)] DinatTrans.dinaturality
+
+namespace DinatTrans
+
+/-- Notation for dinatural transformations. -/
+scoped infixr:50 " ⤞ " => DinatTrans
+
+variable {E : Type u₃} [Category.{v₃} E] {F : Type u₄} [Category.{v₄} F]
+
+variable {F G H : Cᵒᵖ ⥤ C ⥤ D}
+
+/-- Post-composition with a natural transformation. -/
+@[simps]
+def compNatTrans (δ : F ⤞ G) (α : G ⟶ H) : F ⤞ H where
+  app X := δ.app X ≫ (α.app (op X)).app X
+  dinaturality f := by
+    rw [Category.assoc, Category.assoc, ← NatTrans.naturality_app,
+      ← δ.dinaturality_assoc f, NatTrans.naturality]
+
+/-- Pre-composition with a natural transformation. -/
+@[simps]
+def precompNatTrans (δ : G ⤞ H) (α : F ⟶ G) : F ⤞ H where
+  app X := (α.app (op X)).app X ≫ δ.app X
+
+end DinatTrans
+end CategoryTheory

--- a/Mathlib/CategoryTheory/DinatTrans.lean
+++ b/Mathlib/CategoryTheory/DinatTrans.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2023 Andrea Laretto. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Andrea Laretto
+Authors: Andrea Laretto, Fernando Chu
 -/
 import Mathlib.CategoryTheory.Opposites
 
@@ -36,8 +36,7 @@ structure DinatTrans (F G : Cᵒᵖ ⥤ C ⥤ D) : Type max u₁ v₂ where
   /-- The commutativity square for a given morphism. -/
   dinaturality {X Y : C} (f : X ⟶ Y) :
     (F.map f.op).app X ≫ app X ≫ (G.obj (op X)).map f =
-    (F.obj (op Y)).map f ≫ app Y ≫ (G.map f.op).app Y := by
-      aesop_cat
+    (F.obj (op Y)).map f ≫ app Y ≫ (G.map f.op).app Y := by aesop_cat
 
 attribute [reassoc (attr := simp)] DinatTrans.dinaturality
 

--- a/Mathlib/CategoryTheory/Functor/Category.lean
+++ b/Mathlib/CategoryTheory/Functor/Category.lean
@@ -78,7 +78,7 @@ theorem app_naturality {F G : C ⥤ D ⥤ E} (T : F ⟶ G) (X : C) {Y Z : D} (f 
     (F.obj X).map f ≫ (T.app X).app Z = (T.app X).app Y ≫ (G.obj X).map f :=
   (T.app X).naturality f
 
-@[reassoc]
+@[reassoc (attr := simp)]
 theorem naturality_app {F G : C ⥤ D ⥤ E} (T : F ⟶ G) (Z : D) {X Y : C} (f : X ⟶ Y) :
     (F.map f).app Z ≫ (T.app Y).app Z = (T.app X).app Z ≫ (G.map f).app Z :=
   congr_fun (congr_arg app (T.naturality f)) Z


### PR DESCRIPTION
This is a refactor of https://github.com/leanprover-community/mathlib4/pull/26577, which itself was a refactor of https://github.com/leanprover-community/mathlib4/pull/8118, with permission by @iwilare. It contains the definition of a dinatural transformation. There is no current future plans for these but maybe I or @iwilare will use these in the future.

I did very little, credits go to the other two authors.

Co-authored-by: [Andrea Laretto](https://github.com/iwilare) [iwilare@gmail.com](mailto:iwilare@gmail.com)
Co-authored-by:  [Brendan Seamas Murphy](https://github.com/Shamrock-Frost) [bsmurphy@math.utah.edu](mailto:bsmurphy@math.utah.edu)