### PR TITLE
[Merged by Bors] - feat(VectorBundle/MDifferentiable): add some basic API

### DIFF
--- a/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
@@ -61,6 +61,53 @@ theorem mdifferentiableAt_totalSpace (f : M → TotalSpace F E) {x₀ : M} :
         (fun x ↦ (trivializationAt F E (f x₀).proj (f x)).2) x₀ := by
   simpa [← mdifferentiableWithinAt_univ] using mdifferentiableWithinAt_totalSpace _ f
 
+namespace Bundle
+
+variable (E) {IB}
+
+theorem mdifferentiable_proj : MDifferentiable (IB.prod 𝓘(𝕜, F)) IB (π F E) := fun x ↦ by
+  have : MDifferentiableAt (IB.prod 𝓘(𝕜, F)) (IB.prod 𝓘(𝕜, F)) id x := mdifferentiableAt_id
+  rw [mdifferentiableAt_totalSpace] at this
+  exact this.1
+
+theorem mdifferentiableOn_proj {s : Set (TotalSpace F E)} :
+    MDifferentiableOn (IB.prod 𝓘(𝕜, F)) IB (π F E) s :=
+  (mdifferentiable_proj E).mdifferentiableOn
+
+theorem mdifferentiableAt_proj {p : TotalSpace F E} :
+    MDifferentiableAt (IB.prod 𝓘(𝕜, F)) IB (π F E) p :=
+  (mdifferentiable_proj E).mdifferentiableAt
+
+theorem mdifferentiableWithinAt_proj {s : Set (TotalSpace F E)} {p : TotalSpace F E} :
+    MDifferentiableWithinAt (IB.prod 𝓘(𝕜, F)) IB (π F E) s p :=
+  (mdifferentiableAt_proj E).mdifferentiableWithinAt
+
+variable (𝕜) [∀ x, AddCommMonoid (E x)]
+variable [∀ x, Module 𝕜 (E x)] [VectorBundle 𝕜 F E]
+
+theorem mdifferentiable_zeroSection : MDifferentiable IB (IB.prod 𝓘(𝕜, F)) (zeroSection F E) := by
+  intro x
+  unfold zeroSection
+  rw [mdifferentiableAt_section]
+  apply (mdifferentiableAt_const (c := 0)).congr_of_eventuallyEq
+  filter_upwards [(trivializationAt F E x).open_baseSet.mem_nhds
+    (mem_baseSet_trivializationAt F E x)] with y hy
+    using congr_arg Prod.snd <| (trivializationAt F E x).zeroSection 𝕜 hy
+
+theorem mdifferentiableOn_zeroSection {t : Set B} :
+    MDifferentiableOn IB (IB.prod 𝓘(𝕜, F)) (zeroSection F E) t :=
+  (mdifferentiable_zeroSection _ _).mdifferentiableOn
+
+theorem mdifferentiableAt_zeroSection {x : B} :
+    MDifferentiableAt IB (IB.prod 𝓘(𝕜, F)) (zeroSection F E) x :=
+  (mdifferentiable_zeroSection _ _).mdifferentiableAt
+
+theorem mdifferentiableWithinAt_zeroSection {t : Set B} {x : B} :
+    MDifferentiableWithinAt IB (IB.prod 𝓘(𝕜, F)) (zeroSection F E) t x :=
+  (mdifferentiable_zeroSection _ _ x).mdifferentiableWithinAt
+
+end Bundle
+
 end
 
 section

--- a/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/MDifferentiable.lean
@@ -61,6 +61,22 @@ theorem mdifferentiableAt_totalSpace (f : M → TotalSpace F E) {x₀ : M} :
         (fun x ↦ (trivializationAt F E (f x₀).proj (f x)).2) x₀ := by
   simpa [← mdifferentiableWithinAt_univ] using mdifferentiableWithinAt_totalSpace _ f
 
+/-- Characterization of differentiable sections of a vector bundle at a point within a set
+in terms of the preferred trivialization at that point. -/
+theorem mdifferentiableWithinAt_section (s : Π b, E b) {u : Set B} {b₀ : B} :
+    MDifferentiableWithinAt IB (IB.prod 𝓘(𝕜, F)) (fun b ↦ TotalSpace.mk' F b (s b)) u b₀ ↔
+      MDifferentiableWithinAt IB 𝓘(𝕜, F) (fun b ↦ (trivializationAt F E b₀ (s b)).2) u b₀ := by
+  rw [mdifferentiableWithinAt_totalSpace]
+  change MDifferentiableWithinAt _ _ id _ _ ∧ _ ↔ _
+  simp [mdifferentiableWithinAt_id]
+
+/-- Characterization of differentiable sections of a vector bundle at a point within a set
+in terms of the preferred trivialization at that point. -/
+theorem mdifferentiableAt_section (s : Π b, E b) {b₀ : B} :
+    MDifferentiableAt IB (IB.prod 𝓘(𝕜, F)) (fun b ↦ TotalSpace.mk' F b (s b)) b₀ ↔
+      MDifferentiableAt IB 𝓘(𝕜, F) (fun b ↦ (trivializationAt F E b₀ (s b)).2) b₀ := by
+  simpa [← mdifferentiableWithinAt_univ] using mdifferentiableWithinAt_section _ _
+
 namespace Bundle
 
 variable (E) {IB}


### PR DESCRIPTION
mirroring the development in VectorBundle/Basic.

From the path towards geodesics and the Levi-Civita connection.

Co-authored-by: Patrick Massot <patrickmassot@free.fr>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
