### PR TITLE
[Merged by Bors] - chore: add `Con.hom_ext` as alternative of `Con.lift_funext`

### DIFF
--- a/Mathlib/GroupTheory/Congruence/Hom.lean
+++ b/Mathlib/GroupTheory/Congruence/Hom.lean
@@ -236,22 +236,19 @@ theorem lift_apply_mk' (f : c.Quotient →* P) :
     (c.lift (f.comp c.mk') fun x y h => show f ↑x = f ↑y by rw [c.eq.2 h]) = f := by
   ext x; rcases x with ⟨⟩; rfl
 
-/-- Homomorphisms on the quotient of a monoid by a congruence relation are equal if they
-    are equal on elements that are coercions from the monoid. -/
-@[to_additive "Homomorphisms on the quotient of an `AddMonoid` by an additive congruence relation
-are equal if they are equal on elements that are coercions from the `AddMonoid`."]
-theorem lift_funext (f g : c.Quotient →* P) (h : ∀ a : M, f a = g a) : f = g := by
+/-- Extensionality for maps `f, g : M⧸~ →* N`: they are equal if their composition with
+`mk' : M → M⧸~` are equal. -/
+@[to_additive (attr := ext) "Extensionality for maps `f, g : M⧸~ →+ N`: they are equal if their
+composition with `mk' : M → M⧸~` are equal."]
+lemma hom_ext {f g : c.Quotient →* P} (h : f.comp (mk' c) = g.comp (mk' c)) : f = g := by
   rw [← lift_apply_mk' f, ← lift_apply_mk' g]
   congr 1
-  exact DFunLike.ext_iff.2 h
 
 /-- The uniqueness part of the universal property for quotients of monoids. -/
 @[to_additive "The uniqueness part of the universal property for quotients of `AddMonoid`s."]
 theorem lift_unique (H : c ≤ ker f) (g : c.Quotient →* P) (Hg : g.comp c.mk' = f) :
     g = c.lift f H :=
-  (lift_funext g (c.lift f H)) fun x => by
-    subst f
-    rfl
+  hom_ext <| by simpa
 
 /-- Surjective monoid homomorphisms constant on a congruence relation `c`'s equivalence classes
     induce a surjective homomorphism on `c`'s quotient. -/

--- a/Mathlib/GroupTheory/Congruence/Hom.lean
+++ b/Mathlib/GroupTheory/Congruence/Hom.lean
@@ -237,7 +237,7 @@ theorem lift_apply_mk' (f : c.Quotient →* P) :
   ext x; rcases x with ⟨⟩; rfl
 
 /-- Homomorphisms on the quotient of a monoid by a congruence relation `c` are equal if their
-    compositions with `c.mk'` are equal. -/
+compositions with `c.mk'` are equal. -/
 @[to_additive (attr := ext) "Homomorphisms on the quotient of an `AddMonoid` by an additive
 congruence relation `c` are equal if their compositions with `c.mk'` are equal."]
 lemma hom_ext {f g : c.Quotient →* P} (h : f.comp c.mk' = g.comp c.mk') : f = g := by

--- a/Mathlib/GroupTheory/Congruence/Hom.lean
+++ b/Mathlib/GroupTheory/Congruence/Hom.lean
@@ -236,11 +236,11 @@ theorem lift_apply_mk' (f : c.Quotient →* P) :
     (c.lift (f.comp c.mk') fun x y h => show f ↑x = f ↑y by rw [c.eq.2 h]) = f := by
   ext x; rcases x with ⟨⟩; rfl
 
-/-- Extensionality for maps `f, g : M⧸~ →* N`: they are equal if their composition with
-`mk' : M → M⧸~` are equal. -/
-@[to_additive (attr := ext) "Extensionality for maps `f, g : M⧸~ →+ N`: they are equal if their
-composition with `mk' : M → M⧸~` are equal."]
-lemma hom_ext {f g : c.Quotient →* P} (h : f.comp (mk' c) = g.comp (mk' c)) : f = g := by
+/-- Homomorphisms on the quotient of a monoid by a congruence relation `c` are equal if their
+    compositions with `c.mk'` are equal. -/
+@[to_additive "Homomorphisms on the quotient of an `AddMonoid` by an additive congruence relation
+`c` are equal if their compositions with `c.mk'` are equal."]
+lemma hom_ext {f g : c.Quotient →* P} (h : f.comp c.mk' = g.comp c.mk') : f = g := by
   rw [← lift_apply_mk' f, ← lift_apply_mk' g]
   congr 1
 

--- a/Mathlib/GroupTheory/Congruence/Hom.lean
+++ b/Mathlib/GroupTheory/Congruence/Hom.lean
@@ -238,8 +238,8 @@ theorem lift_apply_mk' (f : c.Quotient →* P) :
 
 /-- Homomorphisms on the quotient of a monoid by a congruence relation `c` are equal if their
     compositions with `c.mk'` are equal. -/
-@[to_additive "Homomorphisms on the quotient of an `AddMonoid` by an additive congruence relation
-`c` are equal if their compositions with `c.mk'` are equal."]
+@[to_additive (attr := ext) "Homomorphisms on the quotient of an `AddMonoid` by an additive
+congruence relation `c` are equal if their compositions with `c.mk'` are equal."]
 lemma hom_ext {f g : c.Quotient →* P} (h : f.comp c.mk' = g.comp c.mk') : f = g := by
   rw [← lift_apply_mk' f, ← lift_apply_mk' g]
   congr 1

--- a/Mathlib/GroupTheory/Congruence/Hom.lean
+++ b/Mathlib/GroupTheory/Congruence/Hom.lean
@@ -244,6 +244,13 @@ lemma hom_ext {f g : c.Quotient →* P} (h : f.comp (mk' c) = g.comp (mk' c)) : 
   rw [← lift_apply_mk' f, ← lift_apply_mk' g]
   congr 1
 
+/-- Homomorphisms on the quotient of a monoid by a congruence relation are equal if they
+    are equal on elements that are coercions from the monoid. -/
+@[to_additive "Homomorphisms on the quotient of an `AddMonoid` by an additive congruence relation
+are equal if they are equal on elements that are coercions from the `AddMonoid`."]
+theorem lift_funext (f g : c.Quotient →* P) (h : ∀ a : M, f a = g a) : f = g :=
+  hom_ext <| DFunLike.ext _ _ h
+
 /-- The uniqueness part of the universal property for quotients of monoids. -/
 @[to_additive "The uniqueness part of the universal property for quotients of `AddMonoid`s."]
 theorem lift_unique (H : c ≤ ker f) (g : c.Quotient →* P) (Hg : g.comp c.mk' = f) :

--- a/Mathlib/GroupTheory/Congruence/Hom.lean
+++ b/Mathlib/GroupTheory/Congruence/Hom.lean
@@ -255,7 +255,7 @@ theorem lift_funext (f g : c.Quotient →* P) (h : ∀ a : M, f a = g a) : f = g
 @[to_additive "The uniqueness part of the universal property for quotients of `AddMonoid`s."]
 theorem lift_unique (H : c ≤ ker f) (g : c.Quotient →* P) (Hg : g.comp c.mk' = f) :
     g = c.lift f H :=
-  hom_ext <| by simpa
+  hom_ext Hg
 
 /-- Surjective monoid homomorphisms constant on a congruence relation `c`'s equivalence classes
     induce a surjective homomorphism on `c`'s quotient. -/


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Zulip: [#mathlib4 > AddCon.hom_ext](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/AddCon.2Ehom_ext/with/527492513)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
