### PR TITLE
[Merged by Bors] - feat(MeasureTheory/Measure/Hausdorff): characterise dimH as infimum of vanishing measures

### DIFF
--- a/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
+++ b/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
@@ -146,7 +146,8 @@ This gives an equivalent definition of the Hausdorff dimension. -/
 theorem dimH_eq_iInf (s : Set X) : dimH s = ⨅ (d : ℝ≥0) (_ : μH[d] s = 0), (d : ℝ≥0∞) := by
   borelize X
   apply le_antisymm
-  · rw [dimH_def]; simp only [le_iInf_iff, iSup_le_iff, ENNReal.coe_le_coe]
+  · rw [dimH_def]
+    simp only [le_iInf_iff, iSup_le_iff, ENNReal.coe_le_coe]
     intro i hi j hj
     by_contra! hij
     simpa [hi, hj] using hausdorffMeasure_mono (le_of_lt hij) s

--- a/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
+++ b/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
@@ -144,7 +144,6 @@ theorem dimH_of_hausdorffMeasure_ne_zero_ne_top {d : ℝ≥0} {s : Set X} (h : �
 `d`-dimensional Hausdorff measure of `s` is zero. This infimum is taken in `ℝ≥0∞`.
 This gives an equivalent definition of the Hausdorff dimension. -/
 theorem dimH_eq_iInf (s : Set X) : dimH s = ⨅ (d : ℝ≥0) (_ : μH[d] s = 0), (d : ℝ≥0∞) := by
-  borelize X
   apply le_antisymm
   · rw [dimH_def]
     simp only [le_iInf_iff, iSup_le_iff, ENNReal.coe_le_coe]

--- a/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
+++ b/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
@@ -142,7 +142,7 @@ theorem dimH_of_hausdorffMeasure_ne_zero_ne_top {d : ℝ≥0} {s : Set X} (h : �
 
 /-- The Hausdorff dimension of a set `s` is the infimum of all `d : ℝ≥0` such that the
 `d`-dimensional Hausdorff measure of `s` is zero. This infimum is taken in `ℝ≥0∞`.
-This is an equivalent formulation of `dimH_def`. -/
+This gives an equivalent definition of the Hausdorff dimension. -/
 theorem dimH_eq_iInf (s : Set X) : dimH s = ⨅ (d : ℝ≥0) (_ : μH[d] s = 0), (d : ℝ≥0∞) := by
   borelize X
   apply le_antisymm

--- a/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
+++ b/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
@@ -154,9 +154,7 @@ theorem dimH_eq_iInf (s : Set X) : dimH s = ⨅ (d : ℝ≥0) (_ : μH[d] s = 0)
   · by_contra! h
     rcases ENNReal.lt_iff_exists_nnreal_btwn.1 h with ⟨d', hdim_lt, hlt⟩
     have h0 : μH[d'] s = 0 := by apply hausdorffMeasure_of_dimH_lt; exact hdim_lt
-    have hle : (⨅ (d'' : ℝ≥0) (_ : μH[d''] s = 0), (d'' : ℝ≥0∞)) ≤ (d' : ℝ≥0∞) := by
-      exact iInf₂_le d' h0
-    exact lt_irrefl _ (hlt.trans_le hle)
+    exact hlt.not_ge (iInf₂_le d' h0)
 
 end Measurable
 

--- a/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
+++ b/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
@@ -153,7 +153,7 @@ theorem dimH_eq_iInf (s : Set X) : dimH s = ⨅ (d : ℝ≥0) (_ : μH[d] s = 0)
     simpa [hi, hj] using hausdorffMeasure_mono hij.le s
   · by_contra! h
     rcases ENNReal.lt_iff_exists_nnreal_btwn.1 h with ⟨d', hdim_lt, hlt⟩
-    have h0 : μH[d'] s = 0 := by apply hausdorffMeasure_of_dimH_lt; exact hdim_lt
+    have h0 : μH[d'] s = 0 := hausdorffMeasure_of_dimH_lt hdim_lt
     exact hlt.not_ge (iInf₂_le d' h0)
 
 end Measurable

--- a/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
+++ b/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
@@ -140,6 +140,27 @@ theorem dimH_of_hausdorffMeasure_ne_zero_ne_top {d : ℝ≥0} {s : Set X} (h : �
     (h' : μH[d] s ≠ ∞) : dimH s = d :=
   le_antisymm (dimH_le_of_hausdorffMeasure_ne_top h') (le_dimH_of_hausdorffMeasure_ne_zero h)
 
+/-- The Hausdorff dimension of a set `s` is the infimum of all `d : ℝ≥0` such that the
+`d`-dimensional Hausdorff measure of `s` is zero. This infimum is taken in `ℝ≥0∞`.
+This is an equivalent formulation of `dimH_def`. -/
+theorem dimH_eq_iInf (s : Set X) : dimH s = ⨅ (d : ℝ≥0) (_ : μH[d] s = 0), (d : ℝ≥0∞) := by
+  borelize X
+  rw [dimH_def]
+  apply le_antisymm
+  · simp only [le_iInf_iff, iSup_le_iff, ENNReal.coe_le_coe]
+    intro i hi j hj
+    by_contra! hij
+    simpa [hi, hj] using hausdorffMeasure_mono (le_of_lt hij) s
+  · by_contra! h
+    rcases ENNReal.lt_iff_exists_nnreal_btwn.1 h with ⟨d', hdim_lt, hlt⟩
+    have h0 : μH[d'] s = 0 := by
+      apply hausdorffMeasure_of_dimH_lt
+      rw [dimH_def]
+      exact hdim_lt
+    have hle : (⨅ (d'' : ℝ≥0) (_ : μH[d''] s = 0), (d'' : ℝ≥0∞)) ≤ (d' : ℝ≥0∞) := by
+      exact iInf₂_le d' h0
+    exact lt_irrefl _ (hlt.trans_le hle)
+
 end Measurable
 
 @[mono]

--- a/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
+++ b/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
@@ -145,18 +145,14 @@ theorem dimH_of_hausdorffMeasure_ne_zero_ne_top {d : ℝ≥0} {s : Set X} (h : �
 This is an equivalent formulation of `dimH_def`. -/
 theorem dimH_eq_iInf (s : Set X) : dimH s = ⨅ (d : ℝ≥0) (_ : μH[d] s = 0), (d : ℝ≥0∞) := by
   borelize X
-  rw [dimH_def]
   apply le_antisymm
-  · simp only [le_iInf_iff, iSup_le_iff, ENNReal.coe_le_coe]
+  · rw [dimH_def]; simp only [le_iInf_iff, iSup_le_iff, ENNReal.coe_le_coe]
     intro i hi j hj
     by_contra! hij
     simpa [hi, hj] using hausdorffMeasure_mono (le_of_lt hij) s
   · by_contra! h
     rcases ENNReal.lt_iff_exists_nnreal_btwn.1 h with ⟨d', hdim_lt, hlt⟩
-    have h0 : μH[d'] s = 0 := by
-      apply hausdorffMeasure_of_dimH_lt
-      rw [dimH_def]
-      exact hdim_lt
+    have h0 : μH[d'] s = 0 := by apply hausdorffMeasure_of_dimH_lt; exact hdim_lt
     have hle : (⨅ (d'' : ℝ≥0) (_ : μH[d''] s = 0), (d'' : ℝ≥0∞)) ≤ (d' : ℝ≥0∞) := by
       exact iInf₂_le d' h0
     exact lt_irrefl _ (hlt.trans_le hle)

--- a/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
+++ b/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
@@ -150,7 +150,7 @@ theorem dimH_eq_iInf (s : Set X) : dimH s = ⨅ (d : ℝ≥0) (_ : μH[d] s = 0)
     simp only [le_iInf_iff, iSup_le_iff, ENNReal.coe_le_coe]
     intro i hi j hj
     by_contra! hij
-    simpa [hi, hj] using hausdorffMeasure_mono (le_of_lt hij) s
+    simpa [hi, hj] using hausdorffMeasure_mono hij.le s
   · by_contra! h
     rcases ENNReal.lt_iff_exists_nnreal_btwn.1 h with ⟨d', hdim_lt, hlt⟩
     have h0 : μH[d'] s = 0 := by apply hausdorffMeasure_of_dimH_lt; exact hdim_lt


### PR DESCRIPTION
Adds a characterisation of the Hausdorff dimension dimH s of a set s in a metric space as the infimum over all d : ℝ≥0 such that the d-dimensional Hausdorff measure of s is zero.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
