### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Monoidal/DayConvolution): Internal homs for Day convolution

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2408,6 +2408,7 @@ import Mathlib.CategoryTheory.Monoidal.CommMon_
 import Mathlib.CategoryTheory.Monoidal.Comon_
 import Mathlib.CategoryTheory.Monoidal.Conv
 import Mathlib.CategoryTheory.Monoidal.DayConvolution
+import Mathlib.CategoryTheory.Monoidal.DayConvolution.Closed
 import Mathlib.CategoryTheory.Monoidal.Discrete
 import Mathlib.CategoryTheory.Monoidal.End
 import Mathlib.CategoryTheory.Monoidal.ExternalProduct

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution.lean
@@ -26,7 +26,6 @@ a map `𝟙_ V ⟶ U.obj (𝟙_ C)` that exhibits `U` as a pointwise left Kan ex
 
 ## TODOs (@robin-carlier)
 - Braided/symmetric case.
-- Case where `V` is closed.
 - Define a typeclass `DayConvolutionMonoidalCategory` extending `MonoidalCategory`
 - Characterization of lax monoidal functors out of a day convolution monoidal category.
 - Case `V = Type u` and its universal property.

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
@@ -245,7 +245,7 @@ lemma coev_naturality_app {G' H' : C ⥤ V} [DayConvolution F G'] (η : G ⟶ G'
 
 end coev
 
-theorem left_triangle_component (G : C ⥤ V) [DayConvolution F G]
+theorem left_triangle_components (G : C ⥤ V) [DayConvolution F G]
     (ℌ : DayConvolutionInternalHom F (F ⊛ G) H) [DayConvolution F H] :
     DayConvolution.map (𝟙 F) ℌ.coev_app ≫ ℌ.ev_app = 𝟙 (F ⊛ G) := by
   apply DayConvolution.corepresentableBy F G|>.homEquiv.injective
@@ -254,7 +254,7 @@ theorem left_triangle_component (G : C ⥤ V) [DayConvolution F G]
   apply MonoidalClosed.curry_injective
   simp [MonoidalClosed.curry_natural_left]
 
-theorem right_triangle_component (G : C ⥤ V) [DayConvolution F H]
+theorem right_triangle_components (G : C ⥤ V) [DayConvolution F H]
     (ℌ : DayConvolutionInternalHom F G H) {H' : C ⥤ V}
     (ℌ' : DayConvolutionInternalHom F (F ⊛ H) H') :
     ℌ'.coev_app ≫ ℌ'.map ℌ.ev_app ℌ = 𝟙 H := by

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
@@ -55,11 +55,11 @@ def internalHomDiagramFunctor (F : C ⥤ V) : (C ⥤ V) ⥤ C ⥤ Cᵒᵖ ⥤ C 
         simpa [-NatTrans.naturality] using congr_arg (ihom (F.obj (unop j))).map
           (η.naturality <| k ◁ f) }
 
-/-- `DayConvolutionInternalHom F H` asserts that `H` is an
-internal hom functor of `F` for the Day convolution monoidal structure.
+/-- `DayConvolutionInternalHom F G H` asserts that `H` is the value at `G` of
+an internal hom functor of `F` for the Day convolution monoidal structure.
 This is phrased as the data of a limit `CategoryTheory.Limits.Wedge`
-(i.e an end) on `internalHomDiagramFunctor F|>.obj G|>.obj c` for every `G` and
-`c`, with tip `(H.obj G).obj c` and two compatibility conditions asserting that
+(i.e an end) on `internalHomDiagramFunctor F|>.obj G|>.obj c` and
+`c`, with tip `(H.obj G).obj c` and a compatibility condition asserting that
 the functoriality of `H` identifies to the functoriality of ends. -/
 structure DayConvolutionInternalHom (F : C ⥤ V) (G : C ⥤ V) (H : C ⥤ V) where
   /-- The canonical projections maps -/
@@ -80,13 +80,6 @@ structure DayConvolutionInternalHom (F : C ⥤ V) (G : C ⥤ V) (H : C ⥤ V) wh
   obj_map_comp_π {c c' : C} (f : c ⟶ c') (j : C) :
     H.map f ≫ π c' j =
     π c j ≫ (ihom (F.obj j)).map (G.map (j ◁ f))
-  -- /-- The functoriality of `H` in its first variable identifies (through
-  -- `Limits.Wedge.IsLimit.hom_ext`) with the functoriality on ends
-  -- induced by functoriality of `internalHomDiagramFunctor F`. -/
-  -- map_app_comp_π {G G' : C ⥤ V} (η : G ⟶ G') (c j : C) :
-  --   (H.map η).app c ≫ π G' c j =
-  --   π G c j ≫ (ihom (F.obj j)).map (η.app (j ⊗ c))
-
 
 namespace DayConvolutionInternalHom
 
@@ -99,8 +92,8 @@ variable {F : C ⥤ V} {G : C ⥤ V} {H : C ⥤ V}
 /-- If we have a map `G ⟶ G'` and a `DayConvolutionInternalHom F G' H'`, then
 there is a unique map `H ⟶ H'` induced by functoriality of ends and functoriality
 of `internalHomDiagramFunctor F`. -/
-def map (ℌ : DayConvolutionInternalHom F G H) {G' : C ⥤ V} {H' : C ⥤ V} (f : G ⟶ G')
-    (ℌ' : DayConvolutionInternalHom F G' H') :
+def map (ℌ : DayConvolutionInternalHom F G H) {G' : C ⥤ V} {H' : C ⥤ V}
+    (f : G ⟶ G') (ℌ' : DayConvolutionInternalHom F G' H') :
     H ⟶ H' where
   app c := Limits.Wedge.IsLimit.lift (ℌ'.isLimitWedge c)
     (fun j ↦ (ℌ.π c j) ≫

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
@@ -204,7 +204,7 @@ def coev_app : G ⟶ H where
           simp [MonoidalClosed.curry_eq])
   naturality {c c'} f := by
     dsimp
-    apply Limits.Wedge.IsLimit.hom_ext (ℌ.isLimitWedge c')
+    apply Limits.Wedge.IsLimit.hom_ext <| ℌ.isLimitWedge c'
     intro (j : C)
     simp [Limits.multicospanIndexEnd_left,
       Limits.Multifork.ofι_pt, Limits.Wedge.mk_ι, Category.assoc]
@@ -236,7 +236,7 @@ lemma coev_naturality_app {G' : C ⥤ V} [DayConvolution F G'] (η : G ⟶ G')
     ℌ.coev_app ≫ ℌ.map (DayConvolution.map (𝟙 _) η) ℌ'' := by
   ext c
   dsimp
-  apply Limits.Wedge.IsLimit.hom_ext (ℌ''.isLimitWedge c)
+  apply Limits.Wedge.IsLimit.hom_ext <| ℌ''.isLimitWedge c
   intro j
   apply MonoidalClosed.uncurry_injective
   dsimp
@@ -264,7 +264,7 @@ theorem right_triangle_component (G : C ⥤ V) [DayConvolution F H]
     (ℌ' : DayConvolutionInternalHom F (F ⊛ H) H') :
     ℌ'.coev_app ≫ ℌ'.map ℌ.ev_app ℌ = 𝟙 H := by
   ext c
-  apply Limits.Wedge.IsLimit.hom_ext (ℌ.isLimitWedge c)
+  apply Limits.Wedge.IsLimit.hom_ext <| ℌ.isLimitWedge c
   intro j
   apply MonoidalClosed.uncurry_injective
   simp [MonoidalClosed.uncurry_natural_right]

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
@@ -26,7 +26,7 @@ universe v₁ v₂ u₁ u₂
 
 namespace CategoryTheory.MonoidalCategory
 open scoped ExternalProduct
-open Opposite
+open Opposite Limits
 
 noncomputable section
 
@@ -58,7 +58,7 @@ def dayConvolutionInternalHomDiagramFunctor (F : C ⥤ V) :
 
 /-- `DayConvolutionInternalHom F G H` asserts that `H` is the value at `G` of
 an internal hom functor of `F` for the Day convolution monoidal structure.
-This is phrased as the data of a limit `CategoryTheory.Limits.Wedge`
+This is phrased as the data of a limit `CategoryTheory.Wedge`
 (i.e an end) on `internalHomDiagramFunctor F|>.obj G|>.obj c` and
 `c`, with tip `(H.obj G).obj c` and a compatibility condition asserting that
 the functoriality of `H` identifies to the functoriality of ends. -/
@@ -72,16 +72,14 @@ structure DayConvolutionInternalHom (F : C ⥤ V) (G : C ⥤ V) (H : C ⥤ V) wh
   /-- The wedge defined by `π` and `hπ` is a limit wedge, i.e `H.obj c` is
   an end of `internalHomDiagramFunctor F G|>.obj c`. -/
   isLimitWedge c :
-    Limits.IsLimit <|
-      Limits.Wedge.mk
-        (F := dayConvolutionInternalHomDiagramFunctor F|>.obj G|>.obj c)
-        (H.obj c) (π c) (hπ c)
+    IsLimit <| Wedge.mk
+      (F := dayConvolutionInternalHomDiagramFunctor F|>.obj G|>.obj c)
+      (H.obj c) (π c) (hπ c)
   /-- The functoriality of `H.obj G` identifies (through
-  `Limits.Wedge.IsLimit.hom_ext`) with the functoriality on ends induced by
+  `Wedge.IsLimit.hom_ext`) with the functoriality on ends induced by
   functoriality of `internalHomDiagramFunctor F|>.obj G`. -/
   map_comp_π {c c' : C} (f : c ⟶ c') (j : C) :
-    H.map f ≫ π c' j =
-    π c j ≫ (ihom <| F.obj j).map (G.map <| j ◁ f)
+    H.map f ≫ π c' j = π c j ≫ (ihom <| F.obj j).map (G.map <| j ◁ f)
 
 namespace DayConvolutionInternalHom
 
@@ -98,32 +96,31 @@ of `internalHomDiagramFunctor F`. -/
 def map (ℌ : DayConvolutionInternalHom F G H) {G' : C ⥤ V} {H' : C ⥤ V}
     (f : G ⟶ G') (ℌ' : DayConvolutionInternalHom F G' H') :
     H ⟶ H' where
-  app c := Limits.Wedge.IsLimit.lift (ℌ'.isLimitWedge c)
+  app c := Wedge.IsLimit.lift (ℌ'.isLimitWedge c)
     (fun j ↦ (ℌ.π c j) ≫
       (dayConvolutionInternalHomDiagramFunctor
         F|>.map f|>.app c|>.app (op j)|>.app j))
     (fun ⦃j j'⦄ φ ↦ by
-      haveI := congrArg (fun t ↦ t.app j') <|
+      have := congrArg (fun t ↦ t.app j') <|
         dayConvolutionInternalHomDiagramFunctor
           F|>.map f|>.app c|>.naturality φ.op
-      dsimp at this
-      dsimp
+      dsimp at this ⊢
       rw [Category.assoc, ← (ihom (F.obj j)).map_comp, ← f.naturality,
         Functor.map_comp, reassoc_of% ℌ.hπ]
       simp)
   naturality {c c'} f := by
-    apply Limits.Wedge.IsLimit.hom_ext (ℌ'.isLimitWedge c')
+    apply Wedge.IsLimit.hom_ext (ℌ'.isLimitWedge c')
     intro j
     dsimp
     simp only [Category.assoc, map_comp_π]
-    rw [← Limits.Wedge.mk_ι
+    rw [← Wedge.mk_ι
         (F := dayConvolutionInternalHomDiagramFunctor F|>.obj _|>.obj c')
         (H'.obj c') (ℌ'.π c') (ℌ'.hπ c'),
-      ← Limits.Wedge.mk_ι
+      ← Wedge.mk_ι
         (F := dayConvolutionInternalHomDiagramFunctor F|>.obj _|>.obj c)
         (H'.obj c) (ℌ'.π c) (ℌ'.hπ c),
-      Limits.Wedge.IsLimit.lift_ι (ℌ'.isLimitWedge c'),
-      Limits.Wedge.IsLimit.lift_ι_assoc (ℌ'.isLimitWedge c) ]
+      Wedge.IsLimit.lift_ι (ℌ'.isLimitWedge c'),
+      Wedge.IsLimit.lift_ι_assoc (ℌ'.isLimitWedge c) ]
     simp [← Functor.map_comp]
 
 @[reassoc (attr := simp)]
@@ -133,10 +130,10 @@ lemma map_app_comp_π (ℌ : DayConvolutionInternalHom F G H)
     (ℌ.map f ℌ').app c ≫ ℌ'.π c j =
     ℌ.π c j ≫ (ihom <| F.obj j).map (f.app <| j ⊗ c) := by
   dsimp [map]
-  rw [← Limits.Wedge.mk_ι
+  rw [← Wedge.mk_ι
       (F := dayConvolutionInternalHomDiagramFunctor F|>.obj _|>.obj c)
       (H'.obj c) (ℌ'.π c) (ℌ'.hπ c),
-    Limits.Wedge.IsLimit.lift_ι (ℌ'.isLimitWedge c)]
+    Wedge.IsLimit.lift_ι (ℌ'.isLimitWedge c)]
 
 section ev
 
@@ -150,12 +147,14 @@ def ev_app : F ⊛ H ⟶ G :=
   DayConvolution.corepresentableBy F H|>.homEquiv.symm <|
     { app := fun x => MonoidalClosed.uncurry <| ℌ.π x.2 x.1
       naturality {x y} f := by
-        haveI := congrArg (fun t ↦ F.obj x.1 ◁ t) <| ℌ.hπ x.2 f.1
+        have := congrArg (fun t ↦ F.obj x.1 ◁ t) <| ℌ.hπ x.2 f.1
         dsimp at this ⊢
         simp only [whiskerLeft_comp] at this
-        simp only [Category.assoc, MonoidalClosed.uncurry_eq, Functor.id_obj]
-        rw [← whiskerLeft_comp_assoc, map_comp_π]
-        simp [← whisker_exchange_assoc, tensorHom_def,
+        simp only [Category.assoc, MonoidalClosed.uncurry_eq, Functor.id_obj,
+          ← whiskerLeft_comp_assoc, map_comp_π]
+        simp only [whiskerLeft_comp, Category.assoc, ihom.ev_naturality,
+          Functor.comp_obj, curriedTensor_obj_obj, Functor.id_obj,
+          ← whisker_exchange_assoc, tensorHom_def, Functor.map_comp,
           ← ihom.ev_naturality_assoc]
         rw [reassoc_of% this]
         simp }
@@ -164,11 +163,10 @@ def ev_app : F ⊛ H ⟶ G :=
 lemma unit_app_ev_app_app (x y : C) :
     ((DayConvolution.unit F H).app (x, y) ≫ (ℌ.ev_app).app (x ⊗ y)) =
     MonoidalClosed.uncurry (ℌ.π y x) := by
-  simp [ev_app]
-  haveI := Functor.descOfIsLeftKanExtension_fac_app (F ⊛ H)
+  have := Functor.descOfIsLeftKanExtension_fac_app (F ⊛ H)
     (DayConvolution.unit F H) G
   dsimp at this
-  rw [this]
+  simp [this, ev_app]
 
 lemma ev_naturality_app {G' H' : C ⥤ V} (ℌ' : DayConvolutionInternalHom F G' H')
     [DayConvolution F H'] (η : G ⟶ G') :
@@ -176,13 +174,7 @@ lemma ev_naturality_app {G' H' : C ⥤ V} (ℌ' : DayConvolutionInternalHom F G'
   apply DayConvolution.corepresentableBy F H|>.homEquiv.injective
   dsimp
   ext ⟨x, y⟩
-  dsimp
-  simp only [DayConvolution.unit_app_map_app_assoc,
-    externalProductBifunctor_obj_obj, NatTrans.id_app, id_tensorHom,
-    unit_app_ev_app_app, MonoidalClosed.uncurry_eq,
-    Functor.id_obj, unit_app_ev_app_app_assoc, Category.assoc]
-  rw [← whiskerLeft_comp_assoc, map_app_comp_π]
-  simp
+  simp [MonoidalClosed.uncurry_eq, ← whiskerLeft_comp_assoc]
 
 end ev
 
@@ -197,11 +189,11 @@ corresponding to the component at `G` of the "coevaluation" natural morphism
 `𝟭 ⟶ [F, F ⊛ _]`. -/
 def coev_app : G ⟶ H where
   app c :=
-    Limits.Wedge.IsLimit.lift (ℌ.isLimitWedge c)
+    Wedge.IsLimit.lift (ℌ.isLimitWedge c)
       (fun c' => MonoidalClosed.curry <|
         (DayConvolution.unit F G).app (c', c))
         (fun {c' c''} f => by
-          haveI := DayConvolution.unit_naturality F G f (𝟙 c)
+          have := DayConvolution.unit_naturality F G f (𝟙 c)
           simp only [Functor.map_id, tensorHom_id] at this
           replace this := congrArg MonoidalClosed.curry this
           simp only [MonoidalClosed.curry_natural_right] at this
@@ -210,18 +202,19 @@ def coev_app : G ⟶ H where
           simp [MonoidalClosed.curry_eq])
   naturality {c c'} f := by
     dsimp
-    apply Limits.Wedge.IsLimit.hom_ext <| ℌ.isLimitWedge c'
+    apply Wedge.IsLimit.hom_ext <| ℌ.isLimitWedge c'
     intro (j : C)
-    simp [Limits.multicospanIndexEnd_left,
-      Limits.Multifork.ofι_pt, Limits.Wedge.mk_ι, Category.assoc]
-    rw [← Limits.Wedge.mk_ι
+    simp only [multicospanIndexEnd_left,
+      dayConvolutionInternalHomDiagramFunctor_obj_obj_obj_obj, Multifork.ofι_pt,
+      Wedge.mk_ι, Category.assoc, map_comp_π]
+    rw [← Wedge.mk_ι
         (F := dayConvolutionInternalHomDiagramFunctor F|>.obj _|>.obj c)
         (H.obj c) (ℌ.π c) (ℌ.hπ c),
-      ← Limits.Wedge.mk_ι
+      ← Wedge.mk_ι
         (F := dayConvolutionInternalHomDiagramFunctor F|>.obj _|>.obj c')
         (H.obj c') (ℌ.π c') (ℌ.hπ c'),
-      Limits.Wedge.IsLimit.lift_ι_assoc, Limits.Wedge.IsLimit.lift_ι]
-    haveI := DayConvolution.unit_naturality F G (𝟙 j) f
+      Wedge.IsLimit.lift_ι_assoc, Wedge.IsLimit.lift_ι]
+    have := DayConvolution.unit_naturality F G (𝟙 j) f
     simp only [Functor.map_id, id_tensorHom] at this
     replace this := congrArg MonoidalClosed.curry this
     simp only [MonoidalClosed.curry_natural_right] at this
@@ -233,10 +226,10 @@ lemma coev_app_π (c j : C) :
     ℌ.coev_app.app c ≫ ℌ.π c j =
     MonoidalClosed.curry ((DayConvolution.unit F G).app (j, c)) := by
   dsimp [coev_app]
-  rw [← Limits.Wedge.mk_ι
+  rw [← Wedge.mk_ι
       (F := dayConvolutionInternalHomDiagramFunctor F|>.obj _|>.obj c)
       (H.obj c) (ℌ.π c) (ℌ.hπ c),
-    Limits.Wedge.IsLimit.lift_ι]
+    Wedge.IsLimit.lift_ι]
 
 lemma coev_naturality_app {G' H' : C ⥤ V} [DayConvolution F G'] (η : G ⟶ G')
     (ℌ' : DayConvolutionInternalHom F (F ⊛ G') H') :
@@ -244,7 +237,7 @@ lemma coev_naturality_app {G' H' : C ⥤ V} [DayConvolution F G'] (η : G ⟶ G'
     ℌ.coev_app ≫ ℌ.map (DayConvolution.map (𝟙 _) η) ℌ' := by
   ext c
   dsimp
-  apply Limits.Wedge.IsLimit.hom_ext <| ℌ'.isLimitWedge c
+  apply Wedge.IsLimit.hom_ext <| ℌ'.isLimitWedge c
   intro j
   apply MonoidalClosed.uncurry_injective
   dsimp
@@ -270,7 +263,7 @@ theorem right_triangle_components (G : C ⥤ V) [DayConvolution F H]
     (ℌ' : DayConvolutionInternalHom F (F ⊛ H) H') :
     ℌ'.coev_app ≫ ℌ'.map ℌ.ev_app ℌ = 𝟙 H := by
   ext c
-  apply Limits.Wedge.IsLimit.hom_ext <| ℌ.isLimitWedge c
+  apply Wedge.IsLimit.hom_ext <| ℌ.isLimitWedge c
   intro j
   apply MonoidalClosed.uncurry_injective
   simp [MonoidalClosed.uncurry_natural_right]

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
@@ -145,7 +145,7 @@ corresponding to the component at `G` of the "evaluation" natural morphism
 `F ⊛ [F, _] ⟶ 𝟭`. -/
 def ev_app : F ⊛ H ⟶ G :=
   DayConvolution.corepresentableBy F H|>.homEquiv.symm <|
-    { app := fun x => MonoidalClosed.uncurry <| ℌ.π x.2 x.1
+    { app x := MonoidalClosed.uncurry <| ℌ.π x.2 x.1
       naturality {x y} f := by
         have := congrArg (fun t ↦ F.obj x.1 ◁ t) <| ℌ.hπ x.2 f.1
         dsimp at this ⊢

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
@@ -163,7 +163,7 @@ lemma curry_unit_app_comp_ev_app_app (x y : C) :
   dsimp at this
   rw [this]
 
-lemma ev_naturality_app {G' H' : C ⥤ V} (ℌ' : DayConvolutionInternalHom F G' H)
+lemma ev_naturality_app {G' H' : C ⥤ V} (ℌ' : DayConvolutionInternalHom F G' H')
     [DayConvolution F H'] (η : G ⟶ G') :
     DayConvolution.map (𝟙 F) (ℌ.map η ℌ') ≫ ℌ'.ev_app =
     ℌ.ev_app ≫ η := by

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
@@ -61,55 +61,95 @@ This is phrased as the data of a limit `CategoryTheory.Limits.Wedge`
 (i.e an end) on `internalHomDiagramFunctor F|>.obj G|>.obj c` for every `G` and
 `c`, with tip `(H.obj G).obj c` and two compatibility conditions asserting that
 the functoriality of `H` identifies to the functoriality of ends. -/
-structure DayConvolutionInternalHom (F : C ⥤ V) (H : (C ⥤ V) ⥤ C ⥤ V) where
+structure DayConvolutionInternalHom (F : C ⥤ V) (G : C ⥤ V) (H : C ⥤ V) where
   /-- The canonical projections maps -/
-  π (G : C ⥤ V) (c j : C) :
-    (H.obj G).obj c ⟶ (ihom (F.obj j)).obj (G.obj (j ⊗ c))
+  π (c j : C) : H.obj c ⟶ (ihom (F.obj j)).obj (G.obj (j ⊗ c))
   /-- The projections maps assemble into a wedge. -/
-  hπ (G : C ⥤ V) (c : C) ⦃i j : C⦄ (f : i ⟶ j) :
-    π G c i ≫ (ihom (F.obj i)).map (G.map (f ▷ c)) =
-    π G c j ≫ (MonoidalClosed.pre (F.map f)).app (G.obj (j ⊗ c))
+  hπ (c : C) ⦃i j : C⦄ (f : i ⟶ j) :
+    π c i ≫ (ihom (F.obj i)).map (G.map (f ▷ c)) =
+    π c j ≫ (MonoidalClosed.pre (F.map f)).app (G.obj (j ⊗ c))
   /-- The wedge defined by `π` and `hπ` is a limit wedge, i.e `H.obj c` is
   an end of `internalHomDiagramFunctor F G|>.obj c`. -/
-  isLimitWedge G c :
+  isLimitWedge c :
     Limits.IsLimit <|
       Limits.Wedge.mk (F := internalHomDiagramFunctor F|>.obj G|>.obj c)
-        (H.obj G|>.obj c) (π G c) (hπ G c)
+        (H.obj c) (π c) (hπ c)
   /-- The functoriality of `H.obj G` identifies (through
   `Limits.Wedge.IsLimit.hom_ext`) with the functoriality on ends induced by
   functoriality of `internalHomDiagramFunctor F|>.obj G`. -/
-  obj_map_comp_π (G : C ⥤ V) {c c' : C} (f : c ⟶ c') (j : C) :
-    (H.obj G).map f ≫ π G c' j =
-    π G c j ≫ (ihom (F.obj j)).map (G.map (j ◁ f))
-  /-- The functoriality of `H` in its first variable identifies (through
-  `Limits.Wedge.IsLimit.hom_ext`) with the functoriality on ends
-  induced by functoriality of `internalHomDiagramFunctor F`. -/
-  map_app_comp_π {G G' : C ⥤ V} (η : G ⟶ G') (c j : C) :
-    (H.map η).app c ≫ π G' c j =
-    π G c j ≫ (ihom (F.obj j)).map (η.app (j ⊗ c))
+  obj_map_comp_π {c c' : C} (f : c ⟶ c') (j : C) :
+    H.map f ≫ π c' j =
+    π c j ≫ (ihom (F.obj j)).map (G.map (j ◁ f))
+  -- /-- The functoriality of `H` in its first variable identifies (through
+  -- `Limits.Wedge.IsLimit.hom_ext`) with the functoriality on ends
+  -- induced by functoriality of `internalHomDiagramFunctor F`. -/
+  -- map_app_comp_π {G G' : C ⥤ V} (η : G ⟶ G') (c j : C) :
+  --   (H.map η).app c ≫ π G' c j =
+  --   π G c j ≫ (ihom (F.obj j)).map (η.app (j ⊗ c))
 
 
 namespace DayConvolutionInternalHom
+
 open scoped DayConvolution
 
-attribute [reassoc (attr := simp)] obj_map_comp_π map_app_comp_π hπ
+attribute [reassoc (attr := simp)] obj_map_comp_π hπ
 
-variable {F : C ⥤ V} {H : (C ⥤ V) ⥤ C ⥤ V}
-  (ℌ : DayConvolutionInternalHom F H)
+variable {F : C ⥤ V} {G : C ⥤ V} {H : C ⥤ V}
+
+/-- If we have a map `G ⟶ G'` and a `DayConvolutionInternalHom F G' H'`, then
+there is a unique map `H ⟶ H'` induced by functoriality of ends and functoriality
+of `internalHomDiagramFunctor F`. -/
+def map (ℌ : DayConvolutionInternalHom F G H) {G' : C ⥤ V} {H' : C ⥤ V} (f : G ⟶ G')
+    (ℌ' : DayConvolutionInternalHom F G' H') :
+    H ⟶ H' where
+  app c := Limits.Wedge.IsLimit.lift (ℌ'.isLimitWedge c)
+    (fun j ↦ (ℌ.π c j) ≫
+      (internalHomDiagramFunctor F|>.map f|>.app c|>.app (op j)|>.app j))
+    (fun ⦃j j'⦄ φ ↦ by
+      haveI := congrArg (fun t ↦ t.app j') <|
+        internalHomDiagramFunctor F|>.map f|>.app c|>.naturality φ.op
+      dsimp at this
+      dsimp
+      rw [Category.assoc, ← (ihom (F.obj j)).map_comp, ← f.naturality,
+        Functor.map_comp, reassoc_of% ℌ.hπ]
+      simp)
+  naturality {c c'} f := by
+    apply Limits.Wedge.IsLimit.hom_ext (ℌ'.isLimitWedge c')
+    intro j
+    dsimp
+    simp only [Category.assoc, obj_map_comp_π]
+    rw [← Limits.Wedge.mk_ι (F := internalHomDiagramFunctor F|>.obj _|>.obj c')
+        (H'.obj c') (ℌ'.π c') (ℌ'.hπ c'),
+      ← Limits.Wedge.mk_ι (F := internalHomDiagramFunctor F|>.obj _|>.obj c)
+        (H'.obj c) (ℌ'.π c) (ℌ'.hπ c),
+      Limits.Wedge.IsLimit.lift_ι (ℌ'.isLimitWedge c'),
+      Limits.Wedge.IsLimit.lift_ι_assoc (ℌ'.isLimitWedge c) ]
+    simp [← Functor.map_comp]
+
+@[reassoc (attr := simp)]
+lemma map_app_comp_π (ℌ : DayConvolutionInternalHom F G H)
+    {G' : C ⥤ V} {H' : C ⥤ V} (f : G ⟶ G')
+    (ℌ' : DayConvolutionInternalHom F G' H') (c : C) (j : C) :
+    (ℌ.map f ℌ').app c ≫ ℌ'.π c j =
+    ℌ.π c j ≫ (ihom (F.obj j)).map (f.app (j ⊗ c)) := by
+  dsimp [map]
+  rw [← Limits.Wedge.mk_ι (F := internalHomDiagramFunctor F|>.obj _|>.obj c)
+      (H'.obj c) (ℌ'.π c) (ℌ'.hπ c),
+    Limits.Wedge.IsLimit.lift_ι (ℌ'.isLimitWedge c)]
 
 section ev
 
-variable (G : C ⥤ V) [DayConvolution F (H.obj G)]
+variable [DayConvolution F H] (ℌ : DayConvolutionInternalHom F G H)
 
 /-- Given `ℌ : DayConvolutionInternalHom F H`, if we think of `H.obj G`
 as the internal hom `[F, G]`, then this is the transformation
 corresponding to the component at `G` of the "evaluation" natural morphism
 `F ⊛ [F, _] ⟶ 𝟭`. -/
-def ev_app : F ⊛ (H.obj G) ⟶ G :=
-  DayConvolution.corepresentableBy F (H.obj G)|>.homEquiv.symm <|
-    { app := fun x => MonoidalClosed.uncurry <| ℌ.π G x.2 x.1
+def ev_app : F ⊛ H ⟶ G :=
+  DayConvolution.corepresentableBy F H|>.homEquiv.symm <|
+    { app := fun x => MonoidalClosed.uncurry <| ℌ.π x.2 x.1
       naturality {x y} f := by
-        haveI := congrArg (fun t ↦ F.obj x.1 ◁ t) <| ℌ.hπ G x.2 f.1
+        haveI := congrArg (fun t ↦ F.obj x.1 ◁ t) <| ℌ.hπ x.2 f.1
         dsimp at this ⊢
         simp only [whiskerLeft_comp] at this
         simp only [Category.assoc, MonoidalClosed.uncurry_eq, Functor.id_obj]
@@ -121,20 +161,20 @@ def ev_app : F ⊛ (H.obj G) ⟶ G :=
 
 @[reassoc (attr := simp)]
 lemma curry_unit_app_comp_ev_app_app (x y : C) :
-    ((DayConvolution.unit F (H.obj G)).app (x, y) ≫
-      (ev_app ℌ G).app (x ⊗ y)) =
-    MonoidalClosed.uncurry (ℌ.π G y x) := by
+    ((DayConvolution.unit F H).app (x, y) ≫
+      (ℌ.ev_app).app (x ⊗ y)) =
+    MonoidalClosed.uncurry (ℌ.π y x) := by
   simp [ev_app]
-  haveI := Functor.descOfIsLeftKanExtension_fac_app
-    (F ⊛ H.obj G) (DayConvolution.unit F (H.obj G)) G
+  haveI := Functor.descOfIsLeftKanExtension_fac_app (F ⊛ H)
+    (DayConvolution.unit F H) G
   dsimp at this
   rw [this]
 
-variable {G} in
-lemma ev_naturality_app {G' : C ⥤ V} [DayConvolution F (H.obj G')] (η : G ⟶ G') :
-    DayConvolution.map (𝟙 F) (H.map η) ≫ (ev_app ℌ G') =
-    (ev_app ℌ G) ≫ η := by
-  apply DayConvolution.corepresentableBy F (H.obj G)|>.homEquiv.injective
+lemma ev_naturality_app {G' H' : C ⥤ V} (ℌ' : DayConvolutionInternalHom F G' H)
+    [DayConvolution F H'] (η : G ⟶ G') :
+    DayConvolution.map (𝟙 F) (ℌ.map η ℌ') ≫ ℌ'.ev_app =
+    ℌ.ev_app ≫ η := by
+  apply DayConvolution.corepresentableBy F H|>.homEquiv.injective
   dsimp
   ext ⟨x, y⟩
   dsimp
@@ -149,15 +189,16 @@ end ev
 
 section coev
 
-variable (G : C ⥤ V) [DayConvolution F G]
+variable {G : C ⥤ V} [DayConvolution F G]
+    (ℌ : DayConvolutionInternalHom F (F ⊛ G) H)
 
 /-- Given `ℌ : DayConvolutionInternalHom F H`, if we think of `H.obj G`
 as the internal hom `[F, G]`, then this is the transformation
 corresponding to the component at `G` of the "coevaluation" natural morphism
 `𝟭 ⟶ [F, F ⊛ _]`. -/
-def coev_app : G ⟶ H.obj (F ⊛ G) where
+def coev_app : G ⟶ H where
   app c :=
-    Limits.Wedge.IsLimit.lift (ℌ.isLimitWedge (F ⊛ G) c)
+    Limits.Wedge.IsLimit.lift (ℌ.isLimitWedge c)
       (fun c' => MonoidalClosed.curry <|
         (DayConvolution.unit F G).app (c', c))
         (fun {c' c''} f => by
@@ -170,14 +211,14 @@ def coev_app : G ⟶ H.obj (F ⊛ G) where
           simp [MonoidalClosed.curry_eq])
   naturality {c c'} f := by
     dsimp
-    apply Limits.Wedge.IsLimit.hom_ext (ℌ.isLimitWedge (F ⊛ G) c')
+    apply Limits.Wedge.IsLimit.hom_ext (ℌ.isLimitWedge c')
     intro (j : C)
     simp [Limits.multicospanIndexEnd_left,
       Limits.Multifork.ofι_pt, Limits.Wedge.mk_ι, Category.assoc]
     rw [← Limits.Wedge.mk_ι (F := internalHomDiagramFunctor F|>.obj _|>.obj c)
-        (H.obj (F ⊛ G)|>.obj c) (ℌ.π (F ⊛ G) c) (ℌ.hπ (F ⊛ G) c),
+        (H.obj c) (ℌ.π c) (ℌ.hπ c),
       ← Limits.Wedge.mk_ι (F := internalHomDiagramFunctor F|>.obj _|>.obj c')
-        (H.obj (F ⊛ G)|>.obj c') (ℌ.π (F ⊛ G) c') (ℌ.hπ (F ⊛ G) c'),
+        (H.obj c') (ℌ.π c') (ℌ.hπ c'),
       Limits.Wedge.IsLimit.lift_ι_assoc, Limits.Wedge.IsLimit.lift_ι]
     haveI := DayConvolution.unit_naturality F G (𝟙 j) f
     simp only [Functor.map_id, id_tensorHom] at this
@@ -188,20 +229,21 @@ def coev_app : G ⟶ H.obj (F ⊛ G) where
 
 @[reassoc (attr := simp)]
 lemma coev_app_comp_π (c j : C) :
-    (ℌ.coev_app G).app c ≫ ℌ.π (F ⊛ G) c j =
+    ℌ.coev_app.app c ≫ ℌ.π c j =
     MonoidalClosed.curry ((DayConvolution.unit F G).app (j, c)) := by
   dsimp [coev_app]
   rw [← Limits.Wedge.mk_ι (F := internalHomDiagramFunctor F|>.obj _|>.obj c)
-      (H.obj (F ⊛ G)|>.obj c) (ℌ.π (F ⊛ G) c) (ℌ.hπ (F ⊛ G) c),
+      (H.obj c) (ℌ.π c) (ℌ.hπ c),
     Limits.Wedge.IsLimit.lift_ι]
 
-variable {G} in
 @[simp]
-lemma coev_naturality_app {G' : C ⥤ V} [DayConvolution F G'] (η : G ⟶ G') :
-    η ≫ ℌ.coev_app G' = ℌ.coev_app G ≫ H.map (DayConvolution.map (𝟙 _) η) := by
+lemma coev_naturality_app {G' : C ⥤ V} [DayConvolution F G'] (η : G ⟶ G')
+    (ℌ'' : DayConvolutionInternalHom F (F ⊛ G') H) :
+    η ≫ ℌ''.coev_app =
+    ℌ.coev_app ≫ ℌ.map (DayConvolution.map (𝟙 _) η) ℌ'' := by
   ext c
   dsimp
-  apply Limits.Wedge.IsLimit.hom_ext (ℌ.isLimitWedge (F ⊛ G') c)
+  apply Limits.Wedge.IsLimit.hom_ext (ℌ''.isLimitWedge c)
   intro j
   apply MonoidalClosed.uncurry_injective
   dsimp
@@ -214,18 +256,22 @@ lemma coev_naturality_app {G' : C ⥤ V} [DayConvolution F G'] (η : G ⟶ G') :
 end coev
 
 theorem left_triangle_component (G : C ⥤ V) [DayConvolution F G]
-    [DayConvolution F (H.obj (F ⊛ G))] :
-    DayConvolution.map (𝟙 F) (ℌ.coev_app G) ≫ ℌ.ev_app (F ⊛ G) = 𝟙 (F ⊛ G) := by
+    (ℌ : DayConvolutionInternalHom F (F ⊛ G) H)
+    [DayConvolution F H] :
+    DayConvolution.map (𝟙 F) ℌ.coev_app ≫ ℌ.ev_app = 𝟙 (F ⊛ G) := by
   apply DayConvolution.corepresentableBy F G|>.homEquiv.injective
   dsimp
   ext ⟨x, y⟩
   apply MonoidalClosed.curry_injective
   simp [MonoidalClosed.curry_natural_left]
 
-theorem right_triangle_component (G : C ⥤ V) [DayConvolution F (H.obj G)] :
-    ℌ.coev_app (H.obj G) ≫ H.map (ℌ.ev_app G) = 𝟙 (H.obj G) := by
+theorem right_triangle_component (G : C ⥤ V) [DayConvolution F H]
+    (ℌ : DayConvolutionInternalHom F G H)
+    {H' : C ⥤ V}
+    (ℌ' : DayConvolutionInternalHom F (F ⊛ H) H') :
+    ℌ'.coev_app ≫ ℌ'.map ℌ.ev_app ℌ = 𝟙 H := by
   ext c
-  apply Limits.Wedge.IsLimit.hom_ext (ℌ.isLimitWedge _ c)
+  apply Limits.Wedge.IsLimit.hom_ext (ℌ.isLimitWedge c)
   intro j
   apply MonoidalClosed.uncurry_injective
   simp [MonoidalClosed.uncurry_natural_right]

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
@@ -71,7 +71,7 @@ structure DayConvolutionInternalHom (F : C ⥤ V) (G : C ⥤ V) (H : C ⥤ V) wh
     π c j ≫ (MonoidalClosed.pre <| F.map f).app (G.obj <| j ⊗ c)
   /-- The wedge defined by `π` and `hπ` is a limit wedge, i.e `H.obj c` is
   an end of `internalHomDiagramFunctor F G|>.obj c`. -/
-  isLimitWedge c :
+  isLimitWedge (c : C) :
     IsLimit <| Wedge.mk
       (F := dayConvolutionInternalHomDiagramFunctor F|>.obj G|>.obj c)
       (H.obj c) (π c) (hπ c)

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
@@ -87,7 +87,8 @@ namespace DayConvolutionInternalHom
 
 open scoped DayConvolution
 
-attribute [reassoc (attr := simp)] map_comp_π hπ
+attribute [reassoc (attr := simp)] map_comp_π
+attribute [reassoc] hπ
 
 variable {F : C ⥤ V} {G : C ⥤ V} {H : C ⥤ V}
 

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
@@ -227,8 +227,8 @@ lemma coev_app_comp_π (c j : C) :
       (H.obj c) (ℌ.π c) (ℌ.hπ c),
     Limits.Wedge.IsLimit.lift_ι]
 
-lemma coev_naturality_app {G' : C ⥤ V} [DayConvolution F G'] (η : G ⟶ G')
-    (ℌ' : DayConvolutionInternalHom F (F ⊛ G') H) :
+lemma coev_naturality_app {G' H' : C ⥤ V} [DayConvolution F G'] (η : G ⟶ G')
+    (ℌ' : DayConvolutionInternalHom F (F ⊛ G') H') :
     η ≫ ℌ'.coev_app =
     ℌ.coev_app ≫ ℌ.map (DayConvolution.map (𝟙 _) η) ℌ' := by
   ext c

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
@@ -22,7 +22,7 @@ the Day convolution monoidal structure.
 constructions here to produce actual `CategoryTheory.MonoidalClosed` instances.
 -/
 
-universe v₁ v₂ v₃ v₄ v₅ u₁ u₂ u₃ u₄ u₅
+universe v₁ v₂ u₁ u₂
 
 namespace CategoryTheory.MonoidalCategory
 open scoped ExternalProduct

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
@@ -52,7 +52,7 @@ def internalHomDiagramFunctor (F : C ⥤ V) : (C ⥤ V) ⥤ C ⥤ Cᵒᵖ ⥤ C 
       naturality {c c'} f := by
         ext j k
         dsimp
-        simpa [-NatTrans.naturality] using congr_arg (ihom (F.obj (unop j))).map
+        simpa [-NatTrans.naturality] using congr_arg (ihom <| F.obj <| unop j).map
           (η.naturality <| k ◁ f) }
 
 /-- `DayConvolutionInternalHom F G H` asserts that `H` is the value at `G` of
@@ -63,11 +63,11 @@ This is phrased as the data of a limit `CategoryTheory.Limits.Wedge`
 the functoriality of `H` identifies to the functoriality of ends. -/
 structure DayConvolutionInternalHom (F : C ⥤ V) (G : C ⥤ V) (H : C ⥤ V) where
   /-- The canonical projections maps -/
-  π (c j : C) : H.obj c ⟶ (ihom (F.obj j)).obj (G.obj (j ⊗ c))
+  π (c j : C) : H.obj c ⟶ (ihom <| F.obj j).obj (G.obj <| j ⊗ c)
   /-- The projections maps assemble into a wedge. -/
   hπ (c : C) ⦃i j : C⦄ (f : i ⟶ j) :
-    π c i ≫ (ihom (F.obj i)).map (G.map (f ▷ c)) =
-    π c j ≫ (MonoidalClosed.pre (F.map f)).app (G.obj (j ⊗ c))
+    π c i ≫ (ihom (F.obj i)).map (G.map <| f ▷ c) =
+    π c j ≫ (MonoidalClosed.pre <| F.map f).app (G.obj <| j ⊗ c)
   /-- The wedge defined by `π` and `hπ` is a limit wedge, i.e `H.obj c` is
   an end of `internalHomDiagramFunctor F G|>.obj c`. -/
   isLimitWedge c :
@@ -79,7 +79,7 @@ structure DayConvolutionInternalHom (F : C ⥤ V) (G : C ⥤ V) (H : C ⥤ V) wh
   functoriality of `internalHomDiagramFunctor F|>.obj G`. -/
   obj_map_comp_π {c c' : C} (f : c ⟶ c') (j : C) :
     H.map f ≫ π c' j =
-    π c j ≫ (ihom (F.obj j)).map (G.map (j ◁ f))
+    π c j ≫ (ihom <| F.obj j).map (G.map <| j ◁ f)
 
 namespace DayConvolutionInternalHom
 
@@ -124,7 +124,7 @@ lemma map_app_comp_π (ℌ : DayConvolutionInternalHom F G H)
     {G' : C ⥤ V} {H' : C ⥤ V} (f : G ⟶ G')
     (ℌ' : DayConvolutionInternalHom F G' H') (c : C) (j : C) :
     (ℌ.map f ℌ').app c ≫ ℌ'.π c j =
-    ℌ.π c j ≫ (ihom (F.obj j)).map (f.app (j ⊗ c)) := by
+    ℌ.π c j ≫ (ihom <| F.obj j).map (f.app <| j ⊗ c) := by
   dsimp [map]
   rw [← Limits.Wedge.mk_ι (F := internalHomDiagramFunctor F|>.obj _|>.obj c)
       (H'.obj c) (ℌ'.π c) (ℌ'.hπ c),
@@ -154,8 +154,7 @@ def ev_app : F ⊛ H ⟶ G :=
 
 @[reassoc (attr := simp)]
 lemma curry_unit_app_comp_ev_app_app (x y : C) :
-    ((DayConvolution.unit F H).app (x, y) ≫
-      (ℌ.ev_app).app (x ⊗ y)) =
+    ((DayConvolution.unit F H).app (x, y) ≫ (ℌ.ev_app).app (x ⊗ y)) =
     MonoidalClosed.uncurry (ℌ.π y x) := by
   simp [ev_app]
   haveI := Functor.descOfIsLeftKanExtension_fac_app (F ⊛ H)
@@ -165,8 +164,7 @@ lemma curry_unit_app_comp_ev_app_app (x y : C) :
 
 lemma ev_naturality_app {G' H' : C ⥤ V} (ℌ' : DayConvolutionInternalHom F G' H')
     [DayConvolution F H'] (η : G ⟶ G') :
-    DayConvolution.map (𝟙 F) (ℌ.map η ℌ') ≫ ℌ'.ev_app =
-    ℌ.ev_app ≫ η := by
+    DayConvolution.map (𝟙 F) (ℌ.map η ℌ') ≫ ℌ'.ev_app = ℌ.ev_app ≫ η := by
   apply DayConvolution.corepresentableBy F H|>.homEquiv.injective
   dsimp
   ext ⟨x, y⟩
@@ -249,8 +247,7 @@ lemma coev_naturality_app {G' : C ⥤ V} [DayConvolution F G'] (η : G ⟶ G')
 end coev
 
 theorem left_triangle_component (G : C ⥤ V) [DayConvolution F G]
-    (ℌ : DayConvolutionInternalHom F (F ⊛ G) H)
-    [DayConvolution F H] :
+    (ℌ : DayConvolutionInternalHom F (F ⊛ G) H) [DayConvolution F H] :
     DayConvolution.map (𝟙 F) ℌ.coev_app ≫ ℌ.ev_app = 𝟙 (F ⊛ G) := by
   apply DayConvolution.corepresentableBy F G|>.homEquiv.injective
   dsimp
@@ -259,8 +256,7 @@ theorem left_triangle_component (G : C ⥤ V) [DayConvolution F G]
   simp [MonoidalClosed.curry_natural_left]
 
 theorem right_triangle_component (G : C ⥤ V) [DayConvolution F H]
-    (ℌ : DayConvolutionInternalHom F G H)
-    {H' : C ⥤ V}
+    (ℌ : DayConvolutionInternalHom F G H) {H' : C ⥤ V}
     (ℌ' : DayConvolutionInternalHom F (F ⊛ H) H') :
     ℌ'.coev_app ≫ ℌ'.map ℌ.ev_app ℌ = 𝟙 H := by
   ext c

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
@@ -39,7 +39,8 @@ The internal hom functor for Day convolution `[F, -]` is naturally isomorphic
 to the functor `G ↦ c ↦ end_ (c₁ c₂ ↦ ihom (F c₁) (G.obj (c₂ ⊗ c)))`, hence
 this definition. -/
 @[simps!]
-def internalHomDiagramFunctor (F : C ⥤ V) : (C ⥤ V) ⥤ C ⥤ Cᵒᵖ ⥤ C ⥤ V where
+def dayConvolutionInternalHomDiagramFunctor (F : C ⥤ V) :
+    (C ⥤ V) ⥤ C ⥤ Cᵒᵖ ⥤ C ⥤ V where
   obj G :=
     { obj c := Functor.whiskeringLeft₂ _|>.obj F.op|>.obj
         (tensorRight c ⋙ G)|>.obj MonoidalClosed.internalHom
@@ -52,8 +53,8 @@ def internalHomDiagramFunctor (F : C ⥤ V) : (C ⥤ V) ⥤ C ⥤ Cᵒᵖ ⥤ C 
       naturality {c c'} f := by
         ext j k
         dsimp
-        simpa [-NatTrans.naturality] using congr_arg (ihom <| F.obj <| unop j).map
-          (η.naturality <| k ◁ f) }
+        simpa [-NatTrans.naturality] using
+          congr_arg (ihom <| F.obj <| unop j).map (η.naturality <| k ◁ f) }
 
 /-- `DayConvolutionInternalHom F G H` asserts that `H` is the value at `G` of
 an internal hom functor of `F` for the Day convolution monoidal structure.
@@ -72,7 +73,8 @@ structure DayConvolutionInternalHom (F : C ⥤ V) (G : C ⥤ V) (H : C ⥤ V) wh
   an end of `internalHomDiagramFunctor F G|>.obj c`. -/
   isLimitWedge c :
     Limits.IsLimit <|
-      Limits.Wedge.mk (F := internalHomDiagramFunctor F|>.obj G|>.obj c)
+      Limits.Wedge.mk
+        (F := dayConvolutionInternalHomDiagramFunctor F|>.obj G|>.obj c)
         (H.obj c) (π c) (hπ c)
   /-- The functoriality of `H.obj G` identifies (through
   `Limits.Wedge.IsLimit.hom_ext`) with the functoriality on ends induced by
@@ -97,10 +99,12 @@ def map (ℌ : DayConvolutionInternalHom F G H) {G' : C ⥤ V} {H' : C ⥤ V}
     H ⟶ H' where
   app c := Limits.Wedge.IsLimit.lift (ℌ'.isLimitWedge c)
     (fun j ↦ (ℌ.π c j) ≫
-      (internalHomDiagramFunctor F|>.map f|>.app c|>.app (op j)|>.app j))
+      (dayConvolutionInternalHomDiagramFunctor
+        F|>.map f|>.app c|>.app (op j)|>.app j))
     (fun ⦃j j'⦄ φ ↦ by
       haveI := congrArg (fun t ↦ t.app j') <|
-        internalHomDiagramFunctor F|>.map f|>.app c|>.naturality φ.op
+        dayConvolutionInternalHomDiagramFunctor
+          F|>.map f|>.app c|>.naturality φ.op
       dsimp at this
       dsimp
       rw [Category.assoc, ← (ihom (F.obj j)).map_comp, ← f.naturality,
@@ -111,9 +115,11 @@ def map (ℌ : DayConvolutionInternalHom F G H) {G' : C ⥤ V} {H' : C ⥤ V}
     intro j
     dsimp
     simp only [Category.assoc, obj_map_comp_π]
-    rw [← Limits.Wedge.mk_ι (F := internalHomDiagramFunctor F|>.obj _|>.obj c')
+    rw [← Limits.Wedge.mk_ι
+        (F := dayConvolutionInternalHomDiagramFunctor F|>.obj _|>.obj c')
         (H'.obj c') (ℌ'.π c') (ℌ'.hπ c'),
-      ← Limits.Wedge.mk_ι (F := internalHomDiagramFunctor F|>.obj _|>.obj c)
+      ← Limits.Wedge.mk_ι
+        (F := dayConvolutionInternalHomDiagramFunctor F|>.obj _|>.obj c)
         (H'.obj c) (ℌ'.π c) (ℌ'.hπ c),
       Limits.Wedge.IsLimit.lift_ι (ℌ'.isLimitWedge c'),
       Limits.Wedge.IsLimit.lift_ι_assoc (ℌ'.isLimitWedge c) ]
@@ -126,7 +132,8 @@ lemma map_app_comp_π (ℌ : DayConvolutionInternalHom F G H)
     (ℌ.map f ℌ').app c ≫ ℌ'.π c j =
     ℌ.π c j ≫ (ihom <| F.obj j).map (f.app <| j ⊗ c) := by
   dsimp [map]
-  rw [← Limits.Wedge.mk_ι (F := internalHomDiagramFunctor F|>.obj _|>.obj c)
+  rw [← Limits.Wedge.mk_ι
+      (F := dayConvolutionInternalHomDiagramFunctor F|>.obj _|>.obj c)
       (H'.obj c) (ℌ'.π c) (ℌ'.hπ c),
     Limits.Wedge.IsLimit.lift_ι (ℌ'.isLimitWedge c)]
 
@@ -206,9 +213,11 @@ def coev_app : G ⟶ H where
     intro (j : C)
     simp [Limits.multicospanIndexEnd_left,
       Limits.Multifork.ofι_pt, Limits.Wedge.mk_ι, Category.assoc]
-    rw [← Limits.Wedge.mk_ι (F := internalHomDiagramFunctor F|>.obj _|>.obj c)
+    rw [← Limits.Wedge.mk_ι
+        (F := dayConvolutionInternalHomDiagramFunctor F|>.obj _|>.obj c)
         (H.obj c) (ℌ.π c) (ℌ.hπ c),
-      ← Limits.Wedge.mk_ι (F := internalHomDiagramFunctor F|>.obj _|>.obj c')
+      ← Limits.Wedge.mk_ι
+        (F := dayConvolutionInternalHomDiagramFunctor F|>.obj _|>.obj c')
         (H.obj c') (ℌ.π c') (ℌ.hπ c'),
       Limits.Wedge.IsLimit.lift_ι_assoc, Limits.Wedge.IsLimit.lift_ι]
     haveI := DayConvolution.unit_naturality F G (𝟙 j) f
@@ -223,7 +232,8 @@ lemma coev_app_comp_π (c j : C) :
     ℌ.coev_app.app c ≫ ℌ.π c j =
     MonoidalClosed.curry ((DayConvolution.unit F G).app (j, c)) := by
   dsimp [coev_app]
-  rw [← Limits.Wedge.mk_ι (F := internalHomDiagramFunctor F|>.obj _|>.obj c)
+  rw [← Limits.Wedge.mk_ι
+      (F := dayConvolutionInternalHomDiagramFunctor F|>.obj _|>.obj c)
       (H.obj c) (ℌ.π c) (ℌ.hπ c),
     Limits.Wedge.IsLimit.lift_ι]
 

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
@@ -79,7 +79,7 @@ structure DayConvolutionInternalHom (F : C ⥤ V) (G : C ⥤ V) (H : C ⥤ V) wh
   /-- The functoriality of `H.obj G` identifies (through
   `Limits.Wedge.IsLimit.hom_ext`) with the functoriality on ends induced by
   functoriality of `internalHomDiagramFunctor F|>.obj G`. -/
-  obj_map_comp_π {c c' : C} (f : c ⟶ c') (j : C) :
+  map_comp_π {c c' : C} (f : c ⟶ c') (j : C) :
     H.map f ≫ π c' j =
     π c j ≫ (ihom <| F.obj j).map (G.map <| j ◁ f)
 
@@ -87,7 +87,7 @@ namespace DayConvolutionInternalHom
 
 open scoped DayConvolution
 
-attribute [reassoc (attr := simp)] obj_map_comp_π hπ
+attribute [reassoc (attr := simp)] map_comp_π hπ
 
 variable {F : C ⥤ V} {G : C ⥤ V} {H : C ⥤ V}
 
@@ -114,7 +114,7 @@ def map (ℌ : DayConvolutionInternalHom F G H) {G' : C ⥤ V} {H' : C ⥤ V}
     apply Limits.Wedge.IsLimit.hom_ext (ℌ'.isLimitWedge c')
     intro j
     dsimp
-    simp only [Category.assoc, obj_map_comp_π]
+    simp only [Category.assoc, map_comp_π]
     rw [← Limits.Wedge.mk_ι
         (F := dayConvolutionInternalHomDiagramFunctor F|>.obj _|>.obj c')
         (H'.obj c') (ℌ'.π c') (ℌ'.hπ c'),
@@ -153,7 +153,7 @@ def ev_app : F ⊛ H ⟶ G :=
         dsimp at this ⊢
         simp only [whiskerLeft_comp] at this
         simp only [Category.assoc, MonoidalClosed.uncurry_eq, Functor.id_obj]
-        rw [← whiskerLeft_comp_assoc, obj_map_comp_π]
+        rw [← whiskerLeft_comp_assoc, map_comp_π]
         simp [← whisker_exchange_assoc, tensorHom_def,
           ← ihom.ev_naturality_assoc]
         rw [reassoc_of% this]

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
@@ -227,14 +227,13 @@ lemma coev_app_comp_π (c j : C) :
       (H.obj c) (ℌ.π c) (ℌ.hπ c),
     Limits.Wedge.IsLimit.lift_ι]
 
-@[simp]
 lemma coev_naturality_app {G' : C ⥤ V} [DayConvolution F G'] (η : G ⟶ G')
-    (ℌ'' : DayConvolutionInternalHom F (F ⊛ G') H) :
-    η ≫ ℌ''.coev_app =
-    ℌ.coev_app ≫ ℌ.map (DayConvolution.map (𝟙 _) η) ℌ'' := by
+    (ℌ' : DayConvolutionInternalHom F (F ⊛ G') H) :
+    η ≫ ℌ'.coev_app =
+    ℌ.coev_app ≫ ℌ.map (DayConvolution.map (𝟙 _) η) ℌ' := by
   ext c
   dsimp
-  apply Limits.Wedge.IsLimit.hom_ext <| ℌ''.isLimitWedge c
+  apply Limits.Wedge.IsLimit.hom_ext <| ℌ'.isLimitWedge c
   intro j
   apply MonoidalClosed.uncurry_injective
   dsimp

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
@@ -161,7 +161,7 @@ def ev_app : F ⊛ H ⟶ G :=
         simp }
 
 @[reassoc (attr := simp)]
-lemma curry_unit_app_comp_ev_app_app (x y : C) :
+lemma unit_app_ev_app_app (x y : C) :
     ((DayConvolution.unit F H).app (x, y) ≫ (ℌ.ev_app).app (x ⊗ y)) =
     MonoidalClosed.uncurry (ℌ.π y x) := by
   simp [ev_app]
@@ -179,8 +179,8 @@ lemma ev_naturality_app {G' H' : C ⥤ V} (ℌ' : DayConvolutionInternalHom F G'
   dsimp
   simp only [DayConvolution.unit_app_map_app_assoc,
     externalProductBifunctor_obj_obj, NatTrans.id_app, id_tensorHom,
-    curry_unit_app_comp_ev_app_app, MonoidalClosed.uncurry_eq,
-    Functor.id_obj, curry_unit_app_comp_ev_app_app_assoc, Category.assoc]
+    unit_app_ev_app_app, MonoidalClosed.uncurry_eq,
+    Functor.id_obj, unit_app_ev_app_app_assoc, Category.assoc]
   rw [← whiskerLeft_comp_assoc, map_app_comp_π]
   simp
 
@@ -229,7 +229,7 @@ def coev_app : G ⟶ H where
     simp [MonoidalClosed.curry_eq]
 
 @[reassoc (attr := simp)]
-lemma coev_app_comp_π (c j : C) :
+lemma coev_app_π (c j : C) :
     ℌ.coev_app.app c ≫ ℌ.π c j =
     MonoidalClosed.curry ((DayConvolution.unit F G).app (j, c)) := by
   dsimp [coev_app]
@@ -248,8 +248,8 @@ lemma coev_naturality_app {G' H' : C ⥤ V} [DayConvolution F G'] (η : G ⟶ G'
   intro j
   apply MonoidalClosed.uncurry_injective
   dsimp
-  simp only [Category.assoc, coev_app_comp_π, Functor.comp_obj, tensor_obj,
-    map_app_comp_π, coev_app_comp_π_assoc, MonoidalClosed.uncurry_natural_right,
+  simp only [Category.assoc, coev_app_π, Functor.comp_obj, tensor_obj,
+    map_app_comp_π, coev_app_π_assoc, MonoidalClosed.uncurry_natural_right,
     MonoidalClosed.uncurry_curry, DayConvolution.unit_app_map_app,
     NatTrans.id_app, id_tensorHom]
   simp [MonoidalClosed.uncurry_natural_left]

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
@@ -222,8 +222,7 @@ theorem left_triangle_component (G : C ⥤ V) [DayConvolution F G]
   apply MonoidalClosed.curry_injective
   simp [MonoidalClosed.curry_natural_left]
 
-theorem right_triangle_component (G : C ⥤ V) [DayConvolution F G]
-    [DayConvolution F (H.obj G)] :
+theorem right_triangle_component (G : C ⥤ V) [DayConvolution F (H.obj G)] :
     ℌ.coev_app (H.obj G) ≫ H.map (ℌ.ev_app G) = 𝟙 (H.obj G) := by
   ext c
   apply Limits.Wedge.IsLimit.hom_ext (ℌ.isLimitWedge _ c)

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
@@ -55,7 +55,7 @@ def internalHomDiagramFunctor (F : C ⥤ V) : (C ⥤ V) ⥤ C ⥤ Cᵒᵖ ⥤ C 
         simpa [-NatTrans.naturality] using congr_arg (ihom (F.obj (unop j))).map
           (η.naturality <| k ◁ f) }
 
-/-- `DayConvolutionInternalHom F G H` asserts that `H` is an
+/-- `DayConvolutionInternalHom F H` asserts that `H` is an
 internal hom functor of `F` for the Day convolution monoidal structure.
 This is phrased as the data of a limit `CategoryTheory.Limits.Wedge`
 (i.e an end) on `internalHomDiagramFunctor F|>.obj G|>.obj c` for every `G` and
@@ -101,7 +101,7 @@ section ev
 
 variable (G : C ⥤ V) [DayConvolution F (H.obj G)]
 
-/-- Given `ℌ : DayConvolutionInternalHom F G H`, if we think of `H`
+/-- Given `ℌ : DayConvolutionInternalHom F H`, if we think of `H.obj G`
 as the internal hom `[F, G]`, then this is the transformation
 corresponding to the component at `G` of the "evaluation" natural morphism
 `F ⊛ [F, _] ⟶ 𝟭`. -/
@@ -151,7 +151,7 @@ section coev
 
 variable (G : C ⥤ V) [DayConvolution F G]
 
-/-- Given `ℌ : DayConvolutionInternalHom F (F ⊛ G) H`, if we think of `H`
+/-- Given `ℌ : DayConvolutionInternalHom F H`, if we think of `H.obj G`
 as the internal hom `[F, G]`, then this is the transformation
 corresponding to the component at `G` of the "coevaluation" natural morphism
 `𝟭 ⟶ [F, F ⊛ _]`. -/

--- a/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
+++ b/Mathlib/CategoryTheory/Monoidal/DayConvolution/Closed.lean
@@ -1,0 +1,238 @@
+/-
+Copyright (c) 2025 Robin Carlier. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robin Carlier
+-/
+import Mathlib.CategoryTheory.Monoidal.DayConvolution
+import Mathlib.CategoryTheory.Closed.Monoidal
+import Mathlib.CategoryTheory.Limits.Shapes.End
+
+/-! # Internal homs for day convolution
+
+Given a category `V` that is monoidal closed, a category `C` that
+is monoidal, a functor `C ⥤ V`, and given the data of suitable day convolutions
+and suitable ends of profunctors `c c₁ c₂ ↦ ihom (F c₁) (·.obj (c₂ ⊗ c))`,
+we prove that the data of the units of the left Kan extensions that define
+day convolutions and the data of the canonical morphisms to the aforementioned
+ends can be organised as data that exhibit `F` as monoidal closed in `C ⥤ V` for
+the Day convolution monoidal structure.
+
+## TODOs
+* When `LawfulDayConvolutionMonoidalStruct` (#26820) lands, transport the
+constructions here to produce actual `CategoryTheory.MonoidalClosed` instances.
+-/
+
+universe v₁ v₂ v₃ v₄ v₅ u₁ u₂ u₃ u₄ u₅
+
+namespace CategoryTheory.MonoidalCategory
+open scoped ExternalProduct
+open Opposite
+
+noncomputable section
+
+variable {C : Type u₁} [Category.{v₁} C] {V : Type u₂} [Category.{v₂} V]
+  [MonoidalCategory C] [MonoidalCategory V] [MonoidalClosed V]
+
+/-- Given `F : C ⥤ V`, this is the functor
+`G ↦ c c₁ c₂ ↦ ihom (F c₁) (G.obj (c₂ ⊗ c))`.
+The internal hom functor for Day convolution `[F, -]` is naturally isomorphic
+to the functor `G ↦ c ↦ end_ (c₁ c₂ ↦ ihom (F c₁) (G.obj (c₂ ⊗ c)))`, hence
+this definition. -/
+@[simps!]
+def internalHomDiagramFunctor (F : C ⥤ V) : (C ⥤ V) ⥤ C ⥤ Cᵒᵖ ⥤ C ⥤ V where
+  obj G :=
+    { obj c := Functor.whiskeringLeft₂ _|>.obj F.op|>.obj
+        (tensorRight c ⋙ G)|>.obj MonoidalClosed.internalHom
+      map {c c'} f := Functor.whiskeringLeft₂ _|>.obj F.op|>.map
+        (Functor.whiskerRight (curriedTensor C|>.flip.map f) G)|>.app
+          MonoidalClosed.internalHom }
+  map {G G'} η :=
+    { app c := Functor.whiskeringLeft₂ _|>.obj F.op|>.map
+        (Functor.whiskerLeft _ η) |>.app MonoidalClosed.internalHom
+      naturality {c c'} f := by
+        ext j k
+        dsimp
+        simpa [-NatTrans.naturality] using congr_arg (ihom (F.obj (unop j))).map
+          (η.naturality <| k ◁ f) }
+
+/-- `DayConvolutionInternalHom F G H` asserts that `H` is an
+internal hom functor of `F` for the Day convolution monoidal structure.
+This is phrased as the data of a limit `CategoryTheory.Limits.Wedge`
+(i.e an end) on `internalHomDiagramFunctor F|>.obj G|>.obj c` for every `G` and
+`c`, with tip `(H.obj G).obj c` and two compatibility conditions asserting that
+the functoriality of `H` identifies to the functoriality of ends. -/
+structure DayConvolutionInternalHom (F : C ⥤ V) (H : (C ⥤ V) ⥤ C ⥤ V) where
+  /-- The canonical projections maps -/
+  π (G : C ⥤ V) (c j : C) :
+    (H.obj G).obj c ⟶ (ihom (F.obj j)).obj (G.obj (j ⊗ c))
+  /-- The projections maps assemble into a wedge. -/
+  hπ (G : C ⥤ V) (c : C) ⦃i j : C⦄ (f : i ⟶ j) :
+    π G c i ≫ (ihom (F.obj i)).map (G.map (f ▷ c)) =
+    π G c j ≫ (MonoidalClosed.pre (F.map f)).app (G.obj (j ⊗ c))
+  /-- The wedge defined by `π` and `hπ` is a limit wedge, i.e `H.obj c` is
+  an end of `internalHomDiagramFunctor F G|>.obj c`. -/
+  isLimitWedge G c :
+    Limits.IsLimit <|
+      Limits.Wedge.mk (F := internalHomDiagramFunctor F|>.obj G|>.obj c)
+        (H.obj G|>.obj c) (π G c) (hπ G c)
+  /-- The functoriality of `H.obj G` identifies (through
+  `Limits.Wedge.IsLimit.hom_ext`) with the functoriality on ends induced by
+  functoriality of `internalHomDiagramFunctor F|>.obj G`. -/
+  obj_map_comp_π (G : C ⥤ V) {c c' : C} (f : c ⟶ c') (j : C) :
+    (H.obj G).map f ≫ π G c' j =
+    π G c j ≫ (ihom (F.obj j)).map (G.map (j ◁ f))
+  /-- The functoriality of `H` in its first variable identifies (through
+  `Limits.Wedge.IsLimit.hom_ext`) with the functoriality on ends
+  induced by functoriality of `internalHomDiagramFunctor F`. -/
+  map_app_comp_π {G G' : C ⥤ V} (η : G ⟶ G') (c j : C) :
+    (H.map η).app c ≫ π G' c j =
+    π G c j ≫ (ihom (F.obj j)).map (η.app (j ⊗ c))
+
+
+namespace DayConvolutionInternalHom
+open scoped DayConvolution
+
+attribute [reassoc (attr := simp)] obj_map_comp_π map_app_comp_π hπ
+
+variable {F : C ⥤ V} {H : (C ⥤ V) ⥤ C ⥤ V}
+  (ℌ : DayConvolutionInternalHom F H)
+
+section ev
+
+variable (G : C ⥤ V) [DayConvolution F (H.obj G)]
+
+/-- Given `ℌ : DayConvolutionInternalHom F G H`, if we think of `H`
+as the internal hom `[F, G]`, then this is the transformation
+corresponding to the component at `G` of the "evaluation" natural morphism
+`F ⊛ [F, _] ⟶ 𝟭`. -/
+def ev_app : F ⊛ (H.obj G) ⟶ G :=
+  DayConvolution.corepresentableBy F (H.obj G)|>.homEquiv.symm <|
+    { app := fun x => MonoidalClosed.uncurry <| ℌ.π G x.2 x.1
+      naturality {x y} f := by
+        haveI := congrArg (fun t ↦ F.obj x.1 ◁ t) <| ℌ.hπ G x.2 f.1
+        dsimp at this ⊢
+        simp only [whiskerLeft_comp] at this
+        simp only [Category.assoc, MonoidalClosed.uncurry_eq, Functor.id_obj]
+        rw [← whiskerLeft_comp_assoc, obj_map_comp_π]
+        simp [← whisker_exchange_assoc, tensorHom_def,
+          ← ihom.ev_naturality_assoc]
+        rw [reassoc_of% this]
+        simp }
+
+@[reassoc (attr := simp)]
+lemma curry_unit_app_comp_ev_app_app (x y : C) :
+    ((DayConvolution.unit F (H.obj G)).app (x, y) ≫
+      (ev_app ℌ G).app (x ⊗ y)) =
+    MonoidalClosed.uncurry (ℌ.π G y x) := by
+  simp [ev_app]
+  haveI := Functor.descOfIsLeftKanExtension_fac_app
+    (F ⊛ H.obj G) (DayConvolution.unit F (H.obj G)) G
+  dsimp at this
+  rw [this]
+
+variable {G} in
+lemma ev_naturality_app {G' : C ⥤ V} [DayConvolution F (H.obj G')] (η : G ⟶ G') :
+    DayConvolution.map (𝟙 F) (H.map η) ≫ (ev_app ℌ G') =
+    (ev_app ℌ G) ≫ η := by
+  apply DayConvolution.corepresentableBy F (H.obj G)|>.homEquiv.injective
+  dsimp
+  ext ⟨x, y⟩
+  dsimp
+  simp only [DayConvolution.unit_app_map_app_assoc,
+    externalProductBifunctor_obj_obj, NatTrans.id_app, id_tensorHom,
+    curry_unit_app_comp_ev_app_app, MonoidalClosed.uncurry_eq,
+    Functor.id_obj, curry_unit_app_comp_ev_app_app_assoc, Category.assoc]
+  rw [← whiskerLeft_comp_assoc, map_app_comp_π]
+  simp
+
+end ev
+
+section coev
+
+variable (G : C ⥤ V) [DayConvolution F G]
+
+/-- Given `ℌ : DayConvolutionInternalHom F (F ⊛ G) H`, if we think of `H`
+as the internal hom `[F, G]`, then this is the transformation
+corresponding to the component at `G` of the "coevaluation" natural morphism
+`𝟭 ⟶ [F, F ⊛ _]`. -/
+def coev_app : G ⟶ H.obj (F ⊛ G) where
+  app c :=
+    Limits.Wedge.IsLimit.lift (ℌ.isLimitWedge (F ⊛ G) c)
+      (fun c' => MonoidalClosed.curry <|
+        (DayConvolution.unit F G).app (c', c))
+        (fun {c' c''} f => by
+          haveI := DayConvolution.unit_naturality F G f (𝟙 c)
+          simp only [Functor.map_id, tensorHom_id] at this
+          replace this := congrArg MonoidalClosed.curry this
+          simp only [MonoidalClosed.curry_natural_right] at this
+          dsimp
+          rw [← this]
+          simp [MonoidalClosed.curry_eq])
+  naturality {c c'} f := by
+    dsimp
+    apply Limits.Wedge.IsLimit.hom_ext (ℌ.isLimitWedge (F ⊛ G) c')
+    intro (j : C)
+    simp [Limits.multicospanIndexEnd_left,
+      Limits.Multifork.ofι_pt, Limits.Wedge.mk_ι, Category.assoc]
+    rw [← Limits.Wedge.mk_ι (F := internalHomDiagramFunctor F|>.obj _|>.obj c)
+        (H.obj (F ⊛ G)|>.obj c) (ℌ.π (F ⊛ G) c) (ℌ.hπ (F ⊛ G) c),
+      ← Limits.Wedge.mk_ι (F := internalHomDiagramFunctor F|>.obj _|>.obj c')
+        (H.obj (F ⊛ G)|>.obj c') (ℌ.π (F ⊛ G) c') (ℌ.hπ (F ⊛ G) c'),
+      Limits.Wedge.IsLimit.lift_ι_assoc, Limits.Wedge.IsLimit.lift_ι]
+    haveI := DayConvolution.unit_naturality F G (𝟙 j) f
+    simp only [Functor.map_id, id_tensorHom] at this
+    replace this := congrArg MonoidalClosed.curry this
+    simp only [MonoidalClosed.curry_natural_right] at this
+    rw [← this]
+    simp [MonoidalClosed.curry_eq]
+
+@[reassoc (attr := simp)]
+lemma coev_app_comp_π (c j : C) :
+    (ℌ.coev_app G).app c ≫ ℌ.π (F ⊛ G) c j =
+    MonoidalClosed.curry ((DayConvolution.unit F G).app (j, c)) := by
+  dsimp [coev_app]
+  rw [← Limits.Wedge.mk_ι (F := internalHomDiagramFunctor F|>.obj _|>.obj c)
+      (H.obj (F ⊛ G)|>.obj c) (ℌ.π (F ⊛ G) c) (ℌ.hπ (F ⊛ G) c),
+    Limits.Wedge.IsLimit.lift_ι]
+
+variable {G} in
+@[simp]
+lemma coev_naturality_app {G' : C ⥤ V} [DayConvolution F G'] (η : G ⟶ G') :
+    η ≫ ℌ.coev_app G' = ℌ.coev_app G ≫ H.map (DayConvolution.map (𝟙 _) η) := by
+  ext c
+  dsimp
+  apply Limits.Wedge.IsLimit.hom_ext (ℌ.isLimitWedge (F ⊛ G') c)
+  intro j
+  apply MonoidalClosed.uncurry_injective
+  dsimp
+  simp only [Category.assoc, coev_app_comp_π, Functor.comp_obj, tensor_obj,
+    map_app_comp_π, coev_app_comp_π_assoc, MonoidalClosed.uncurry_natural_right,
+    MonoidalClosed.uncurry_curry, DayConvolution.unit_app_map_app,
+    NatTrans.id_app, id_tensorHom]
+  simp [MonoidalClosed.uncurry_natural_left]
+
+end coev
+
+theorem left_triangle_component (G : C ⥤ V) [DayConvolution F G]
+    [DayConvolution F (H.obj (F ⊛ G))] :
+    DayConvolution.map (𝟙 F) (ℌ.coev_app G) ≫ ℌ.ev_app (F ⊛ G) = 𝟙 (F ⊛ G) := by
+  apply DayConvolution.corepresentableBy F G|>.homEquiv.injective
+  dsimp
+  ext ⟨x, y⟩
+  apply MonoidalClosed.curry_injective
+  simp [MonoidalClosed.curry_natural_left]
+
+theorem right_triangle_component (G : C ⥤ V) [DayConvolution F G]
+    [DayConvolution F (H.obj G)] :
+    ℌ.coev_app (H.obj G) ≫ H.map (ℌ.ev_app G) = 𝟙 (H.obj G) := by
+  ext c
+  apply Limits.Wedge.IsLimit.hom_ext (ℌ.isLimitWedge _ c)
+  intro j
+  apply MonoidalClosed.uncurry_injective
+  simp [MonoidalClosed.uncurry_natural_right]
+
+end DayConvolutionInternalHom
+
+end
+
+end CategoryTheory.MonoidalCategory


### PR DESCRIPTION
In this PR, we introduce a structure `DayConvolutionInternalHom` on triples of functors `F G H: C ⥤ V` and that bundles data necessary to exhibit `H` as the value at `G` of an "internal hom functor for F" for the day convolution monoidal structure.

More precisely, under the assumption that `V` is monoidal closed, the required data is that of suitably functorial (in `c` and `G`) ends of the profunctors `c₁ c₂ ↦ ihom (F c₁) (G.obj (c₂ ⊗ c))`. With this data, we construct for every `G` (and for implicit data of relevant day convolutions) transformations `F ⊛ [F, G] ⟶ G` and `G ⟶ [F, (F ⊛ G)]` that one should think of as the components of "evaluations" and "coevaluations" transformations exhibiting `[F, -]` as a right adjoint to `F ⊛ -`. To give body to this claim, we prove that these transformations are natural in `G`, and prove that they satisfy the triangle identities.  

This will be used in conjuction with #26820 to show that Day convolution structure are closed whenever `V` is closed and has relevant limits.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
