### PR TITLE
[Merged by Bors] - feat(Data/Matrix): add `Matrix.vecCons_inj`

### DIFF
--- a/Mathlib/Data/Fin/VecNotation.lean
+++ b/Mathlib/Data/Fin/VecNotation.lean
@@ -252,6 +252,10 @@ theorem cons_val_fin_one (x : α) (u : Fin 0 → α) : ∀ (i : Fin 1), vecCons 
 theorem cons_fin_one (x : α) (u : Fin 0 → α) : vecCons x u = fun _ => x :=
   funext (cons_val_fin_one x u)
 
+@[simp]
+theorem vecCons_inj (x y : α) (u v : Fin n → α) : vecCons x u = vecCons y v ↔ x = y ∧ u = v :=
+  Fin.cons_inj
+
 open Lean Qq in
 /-- `mkVecLiteralQ ![x, y, z]` produces the term `q(![$x, $y, $z])`. -/
 def _root_.PiFin.mkLiteralQ {u : Level} {α : Q(Type u)} {n : ℕ} (elems : Fin n → Q($α)) :

--- a/Mathlib/Data/Fin/VecNotation.lean
+++ b/Mathlib/Data/Fin/VecNotation.lean
@@ -253,7 +253,7 @@ theorem cons_fin_one (x : α) (u : Fin 0 → α) : vecCons x u = fun _ => x :=
   funext (cons_val_fin_one x u)
 
 @[simp]
-theorem vecCons_inj (x y : α) (u v : Fin n → α) : vecCons x u = vecCons y v ↔ x = y ∧ u = v :=
+theorem vecCons_inj {x y : α} {u v : Fin n → α} : vecCons x u = vecCons y v ↔ x = y ∧ u = v :=
   Fin.cons_inj
 
 open Lean Qq in

--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -406,7 +406,7 @@ alias submatrix_updateColumn_succAbove := submatrix_updateCol_succAbove
 
 end Submatrix
 
-section Vec
+section Vec2AndVec3
 
 section One
 
@@ -479,9 +479,6 @@ theorem mul_fin_three [AddCommMonoid α] [Mul α]
   fin_cases i <;> fin_cases j
     <;> simp [Matrix.mul_apply, Fin.sum_univ_succ, ← add_assoc]
 
-theorem vec1_eq {a b : α} (h : a = b) : ![a] = ![b] := by
-  simp [h]
-
 theorem vec2_eq {a₀ a₁ b₀ b₁ : α} (h₀ : a₀ = b₀) (h₁ : a₁ = b₁) : ![a₀, a₁] = ![b₀, b₁] := by
   simp [h₀, h₁]
 
@@ -489,17 +486,11 @@ theorem vec3_eq {a₀ a₁ a₂ b₀ b₁ b₂ : α} (h₀ : a₀ = b₀) (h₁ 
     ![a₀, a₁, a₂] = ![b₀, b₁, b₂] := by
   simp [h₀, h₁, h₂]
 
-theorem vec1_add [Add α] (a b : α) : ![a] + ![b] = ![a + b] := by
-  simp
-
 theorem vec2_add [Add α] (a₀ a₁ b₀ b₁ : α) : ![a₀, a₁] + ![b₀, b₁] = ![a₀ + b₀, a₁ + b₁] := by
   simp
 
 theorem vec3_add [Add α] (a₀ a₁ a₂ b₀ b₁ b₂ : α) :
     ![a₀, a₁, a₂] + ![b₀, b₁, b₂] = ![a₀ + b₀, a₁ + b₁, a₂ + b₂] := by
-  simp
-
-theorem smul_vec1 {R : Type*} [SMul R α] (x : R) (a : α) : x • ![a] = ![x • a] := by
   simp
 
 theorem smul_vec2 {R : Type*} [SMul R α] (x : R) (a₀ a₁ : α) :
@@ -511,13 +502,6 @@ theorem smul_vec3 {R : Type*} [SMul R α] (x : R) (a₀ a₁ a₂ : α) :
   simp
 
 variable [AddCommMonoid α] [Mul α]
-
-theorem vec1_dotProduct' {a b : α} : ![a] ⬝ᵥ ![b] = a * b := by
-  simp
-
-@[simp]
-theorem vec1_dotProduct (v w : Fin 1 → α) : v ⬝ᵥ w = v 0 * w 0 :=
-  vec1_dotProduct'
 
 theorem vec2_dotProduct' {a₀ a₁ b₀ b₁ : α} : ![a₀, a₁] ⬝ᵥ ![b₀, b₁] = a₀ * b₀ + a₁ * b₁ := by
   simp
@@ -535,7 +519,7 @@ theorem vec3_dotProduct' {a₀ a₁ a₂ b₀ b₁ b₂ : α} :
 theorem vec3_dotProduct (v w : Fin 3 → α) : v ⬝ᵥ w = v 0 * w 0 + v 1 * w 1 + v 2 * w 2 :=
   vec3_dotProduct'
 
-end Vec
+end Vec2AndVec3
 
 end Matrix
 

--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -406,7 +406,7 @@ alias submatrix_updateColumn_succAbove := submatrix_updateCol_succAbove
 
 end Submatrix
 
-section Vec2AndVec3
+section Vec
 
 section One
 
@@ -479,14 +479,31 @@ theorem mul_fin_three [AddCommMonoid α] [Mul α]
   fin_cases i <;> fin_cases j
     <;> simp [Matrix.mul_apply, Fin.sum_univ_succ, ← add_assoc]
 
-theorem vec2_eq {a₀ a₁ b₀ b₁ : α} (h₀ : a₀ = b₀) (h₁ : a₁ = b₁) : ![a₀, a₁] = ![b₀, b₁] := by
-  subst_vars
-  rfl
+@[simp]
+theorem vec1_eq_iff {a b : α} : ![a] = ![b] ↔ a = b := by
+  simp
+
+theorem vec1_eq {a b : α} (h : a = b) : ![a] = ![b] :=
+  vec1_eq_iff.2 h
+
+@[simp]
+theorem vec2_eq_iff {a₀ a₁ b₀ b₁ : α} : ![a₀, a₁] = ![b₀, b₁] ↔ a₀ = b₀ ∧ a₁ = b₁ := by
+  simp
+
+theorem vec2_eq {a₀ a₁ b₀ b₁ : α} (h₀ : a₀ = b₀) (h₁ : a₁ = b₁) : ![a₀, a₁] = ![b₀, b₁] :=
+  vec2_eq_iff.2 ⟨h₀, h₁⟩
+
+@[simp]
+theorem vec3_eq_iff {a₀ a₁ a₂ b₀ b₁ b₂ : α} :
+    ![a₀, a₁, a₂] = ![b₀, b₁, b₂] ↔ a₀ = b₀ ∧ a₁ = b₁ ∧ a₂ = b₂ := by
+  simp
 
 theorem vec3_eq {a₀ a₁ a₂ b₀ b₁ b₂ : α} (h₀ : a₀ = b₀) (h₁ : a₁ = b₁) (h₂ : a₂ = b₂) :
-    ![a₀, a₁, a₂] = ![b₀, b₁, b₂] := by
-  subst_vars
-  rfl
+    ![a₀, a₁, a₂] = ![b₀, b₁, b₂] :=
+  vec3_eq_iff.2 ⟨h₀, h₁, h₂⟩
+
+theorem vec1_add [Add α] (a b : α) : ![a] + ![b] = ![a + b] := by
+  rw [cons_add_cons, empty_add_empty]
 
 theorem vec2_add [Add α] (a₀ a₁ b₀ b₁ : α) : ![a₀, a₁] + ![b₀, b₁] = ![a₀ + b₀, a₁ + b₁] := by
   rw [cons_add_cons, cons_add_cons, empty_add_empty]
@@ -494,6 +511,9 @@ theorem vec2_add [Add α] (a₀ a₁ b₀ b₁ : α) : ![a₀, a₁] + ![b₀, b
 theorem vec3_add [Add α] (a₀ a₁ a₂ b₀ b₁ b₂ : α) :
     ![a₀, a₁, a₂] + ![b₀, b₁, b₂] = ![a₀ + b₀, a₁ + b₁, a₂ + b₂] := by
   rw [cons_add_cons, cons_add_cons, cons_add_cons, empty_add_empty]
+
+theorem smul_vec1 {R : Type*} [SMul R α] (x : R) (a : α) :
+    x • ![a] = ![x • a] := by rw [smul_cons, smul_empty]
 
 theorem smul_vec2 {R : Type*} [SMul R α] (x : R) (a₀ a₁ : α) :
     x • ![a₀, a₁] = ![x • a₀, x • a₁] := by rw [smul_cons, smul_cons, smul_empty]
@@ -504,8 +524,15 @@ theorem smul_vec3 {R : Type*} [SMul R α] (x : R) (a₀ a₁ a₂ : α) :
 
 variable [AddCommMonoid α] [Mul α]
 
+theorem vec1_dotProduct' {a b : α} : ![a] ⬝ᵥ ![b] = a * b := by
+  rw [cons_dotProduct_cons, dotProduct_empty, add_zero]
+
+@[simp]
+theorem vec1_dotProduct (v w : Fin 1 → α) : v ⬝ᵥ w = v 0 * w 0 :=
+  vec1_dotProduct'
+
 theorem vec2_dotProduct' {a₀ a₁ b₀ b₁ : α} : ![a₀, a₁] ⬝ᵥ ![b₀, b₁] = a₀ * b₀ + a₁ * b₁ := by
-  rw [cons_dotProduct_cons, cons_dotProduct_cons, dotProduct_empty, add_zero]
+  rw [cons_dotProduct_cons, vec1_dotProduct']
 
 @[simp]
 theorem vec2_dotProduct (v w : Fin 2 → α) : v ⬝ᵥ w = v 0 * w 0 + v 1 * w 1 :=
@@ -513,15 +540,14 @@ theorem vec2_dotProduct (v w : Fin 2 → α) : v ⬝ᵥ w = v 0 * w 0 + v 1 * w 
 
 theorem vec3_dotProduct' {a₀ a₁ a₂ b₀ b₁ b₂ : α} :
     ![a₀, a₁, a₂] ⬝ᵥ ![b₀, b₁, b₂] = a₀ * b₀ + a₁ * b₁ + a₂ * b₂ := by
-  rw [cons_dotProduct_cons, cons_dotProduct_cons, cons_dotProduct_cons, dotProduct_empty,
-    add_zero, add_assoc]
+  rw [cons_dotProduct_cons, vec2_dotProduct', add_assoc]
 
 -- This is not tagged `@[simp]` because it does not mesh well with simp lemmas for
 -- dot and cross products in dimension 3.
 theorem vec3_dotProduct (v w : Fin 3 → α) : v ⬝ᵥ w = v 0 * w 0 + v 1 * w 1 + v 2 * w 2 :=
   vec3_dotProduct'
 
-end Vec2AndVec3
+end Vec
 
 end Matrix
 

--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -479,57 +479,48 @@ theorem mul_fin_three [AddCommMonoid α] [Mul α]
   fin_cases i <;> fin_cases j
     <;> simp [Matrix.mul_apply, Fin.sum_univ_succ, ← add_assoc]
 
-theorem vec1_eq_iff {a b : α} : ![a] = ![b] ↔ a = b := by
-  simp
+theorem vec1_eq {a b : α} (h : a = b) : ![a] = ![b] := by
+  simp [h]
 
-theorem vec1_eq {a b : α} (h : a = b) : ![a] = ![b] :=
-  vec1_eq_iff.2 h
-
-theorem vec2_eq_iff {a₀ a₁ b₀ b₁ : α} : ![a₀, a₁] = ![b₀, b₁] ↔ a₀ = b₀ ∧ a₁ = b₁ := by
-  simp
-
-theorem vec2_eq {a₀ a₁ b₀ b₁ : α} (h₀ : a₀ = b₀) (h₁ : a₁ = b₁) : ![a₀, a₁] = ![b₀, b₁] :=
-  vec2_eq_iff.2 ⟨h₀, h₁⟩
-
-theorem vec3_eq_iff {a₀ a₁ a₂ b₀ b₁ b₂ : α} :
-    ![a₀, a₁, a₂] = ![b₀, b₁, b₂] ↔ a₀ = b₀ ∧ a₁ = b₁ ∧ a₂ = b₂ := by
-  simp
+theorem vec2_eq {a₀ a₁ b₀ b₁ : α} (h₀ : a₀ = b₀) (h₁ : a₁ = b₁) : ![a₀, a₁] = ![b₀, b₁] := by
+  simp [h₀, h₁]
 
 theorem vec3_eq {a₀ a₁ a₂ b₀ b₁ b₂ : α} (h₀ : a₀ = b₀) (h₁ : a₁ = b₁) (h₂ : a₂ = b₂) :
-    ![a₀, a₁, a₂] = ![b₀, b₁, b₂] :=
-  vec3_eq_iff.2 ⟨h₀, h₁, h₂⟩
+    ![a₀, a₁, a₂] = ![b₀, b₁, b₂] := by
+  simp [h₀, h₁, h₂]
 
 theorem vec1_add [Add α] (a b : α) : ![a] + ![b] = ![a + b] := by
-  rw [cons_add_cons, empty_add_empty]
+  simp
 
 theorem vec2_add [Add α] (a₀ a₁ b₀ b₁ : α) : ![a₀, a₁] + ![b₀, b₁] = ![a₀ + b₀, a₁ + b₁] := by
-  rw [cons_add_cons, cons_add_cons, empty_add_empty]
+  simp
 
 theorem vec3_add [Add α] (a₀ a₁ a₂ b₀ b₁ b₂ : α) :
     ![a₀, a₁, a₂] + ![b₀, b₁, b₂] = ![a₀ + b₀, a₁ + b₁, a₂ + b₂] := by
-  rw [cons_add_cons, cons_add_cons, cons_add_cons, empty_add_empty]
+  simp
 
-theorem smul_vec1 {R : Type*} [SMul R α] (x : R) (a : α) :
-    x • ![a] = ![x • a] := by rw [smul_cons, smul_empty]
+theorem smul_vec1 {R : Type*} [SMul R α] (x : R) (a : α) : x • ![a] = ![x • a] := by
+  simp
 
 theorem smul_vec2 {R : Type*} [SMul R α] (x : R) (a₀ a₁ : α) :
-    x • ![a₀, a₁] = ![x • a₀, x • a₁] := by rw [smul_cons, smul_cons, smul_empty]
+    x • ![a₀, a₁] = ![x • a₀, x • a₁] := by
+  simp
 
 theorem smul_vec3 {R : Type*} [SMul R α] (x : R) (a₀ a₁ a₂ : α) :
     x • ![a₀, a₁, a₂] = ![x • a₀, x • a₁, x • a₂] := by
-  rw [smul_cons, smul_cons, smul_cons, smul_empty]
+  simp
 
 variable [AddCommMonoid α] [Mul α]
 
 theorem vec1_dotProduct' {a b : α} : ![a] ⬝ᵥ ![b] = a * b := by
-  rw [cons_dotProduct_cons, dotProduct_empty, add_zero]
+  simp
 
 @[simp]
 theorem vec1_dotProduct (v w : Fin 1 → α) : v ⬝ᵥ w = v 0 * w 0 :=
   vec1_dotProduct'
 
 theorem vec2_dotProduct' {a₀ a₁ b₀ b₁ : α} : ![a₀, a₁] ⬝ᵥ ![b₀, b₁] = a₀ * b₀ + a₁ * b₁ := by
-  rw [cons_dotProduct_cons, vec1_dotProduct']
+  simp
 
 @[simp]
 theorem vec2_dotProduct (v w : Fin 2 → α) : v ⬝ᵥ w = v 0 * w 0 + v 1 * w 1 :=
@@ -537,7 +528,7 @@ theorem vec2_dotProduct (v w : Fin 2 → α) : v ⬝ᵥ w = v 0 * w 0 + v 1 * w 
 
 theorem vec3_dotProduct' {a₀ a₁ a₂ b₀ b₁ b₂ : α} :
     ![a₀, a₁, a₂] ⬝ᵥ ![b₀, b₁, b₂] = a₀ * b₀ + a₁ * b₁ + a₂ * b₂ := by
-  rw [cons_dotProduct_cons, vec2_dotProduct', add_assoc]
+  simp [add_assoc]
 
 -- This is not tagged `@[simp]` because it does not mesh well with simp lemmas for
 -- dot and cross products in dimension 3.

--- a/Mathlib/Data/Matrix/Notation.lean
+++ b/Mathlib/Data/Matrix/Notation.lean
@@ -479,21 +479,18 @@ theorem mul_fin_three [AddCommMonoid α] [Mul α]
   fin_cases i <;> fin_cases j
     <;> simp [Matrix.mul_apply, Fin.sum_univ_succ, ← add_assoc]
 
-@[simp]
 theorem vec1_eq_iff {a b : α} : ![a] = ![b] ↔ a = b := by
   simp
 
 theorem vec1_eq {a b : α} (h : a = b) : ![a] = ![b] :=
   vec1_eq_iff.2 h
 
-@[simp]
 theorem vec2_eq_iff {a₀ a₁ b₀ b₁ : α} : ![a₀, a₁] = ![b₀, b₁] ↔ a₀ = b₀ ∧ a₁ = b₁ := by
   simp
 
 theorem vec2_eq {a₀ a₁ b₀ b₁ : α} (h₀ : a₀ = b₀) (h₁ : a₁ = b₁) : ![a₀, a₁] = ![b₀, b₁] :=
   vec2_eq_iff.2 ⟨h₀, h₁⟩
 
-@[simp]
 theorem vec3_eq_iff {a₀ a₁ a₂ b₀ b₁ b₂ : α} :
     ![a₀, a₁, a₂] = ![b₀, b₁, b₂] ↔ a₀ = b₀ ∧ a₁ = b₁ ∧ a₂ = b₂ := by
   simp


### PR DESCRIPTION
`vecCons_inj` is the `vecCons` version of `Fin.cons_inj`. Also use it to simplify some proofs for `vec2` and `vec3`.

[Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/.60!.5Ba.5D.20.3D.20!.5Bb.5D.20.E2.86.94.20a.20.3D.20b.60/)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
