### PR TITLE
[Merged by Bors] - chore(SetTheory/Ordinal/Exponential): address porting notes

### DIFF
--- a/Mathlib/SetTheory/Ordinal/Exponential.lean
+++ b/Mathlib/SetTheory/Ordinal/Exponential.lean
@@ -138,28 +138,19 @@ theorem isLimit_opow_left {a b : Ordinal} (l : IsLimit a) (hb : b ≠ 0) : IsLim
   · exact isLimit_opow l.one_lt l'
 
 theorem opow_le_opow_right {a b c : Ordinal} (h₁ : 0 < a) (h₂ : b ≤ c) : a ^ b ≤ a ^ c := by
-  rcases lt_or_eq_of_le (one_le_iff_pos.2 h₁) with h₁ | h₁
+  rcases (one_le_iff_pos.2 h₁).eq_or_gt with h₁ | h₁
+  · simp_all
   · exact (opow_le_opow_iff_right h₁).2 h₂
-  · subst a
-    -- Porting note: `le_refl` is required.
-    simp only [one_opow, le_refl]
 
 theorem opow_le_opow_left {a b : Ordinal} (c : Ordinal) (ab : a ≤ b) : a ^ c ≤ b ^ c := by
-  by_cases a0 : a = 0
-  -- Porting note: `le_refl` is required.
-  · subst a
-    by_cases c0 : c = 0
-    · subst c
-      simp only [opow_zero, le_refl]
-    · simp only [zero_opow c0, Ordinal.zero_le]
+  obtain rfl | ha := eq_or_ne a 0
+  · obtain rfl | ha := eq_or_ne c 0 <;> simp_all
   · induction c using limitRecOn with
-    | zero => simp only [opow_zero, le_refl]
-    | succ c IH =>
-      simpa only [opow_succ] using mul_le_mul' IH ab
+    | zero => simp
+    | succ c IH => simpa using mul_le_mul' IH ab
     | isLimit c l IH =>
-      exact
-        (opow_le_of_limit a0 l).2 fun b' h =>
-          (IH _ h).trans (opow_le_opow_right ((Ordinal.pos_iff_ne_zero.2 a0).trans_le ab) h.le)
+      exact (opow_le_of_limit ha l).2 fun b' h ↦
+        (IH _ h).trans (opow_le_opow_right ((Ordinal.pos_iff_ne_zero.2 ha).trans_le ab) h.le)
 
 theorem opow_le_opow {a b c d : Ordinal} (hac : a ≤ c) (hbd : b ≤ d) (hc : 0 < c) : a ^ b ≤ c ^ d :=
   (opow_le_opow_left b hac).trans (opow_le_opow_right hc hbd)

--- a/Mathlib/SetTheory/Ordinal/Exponential.lean
+++ b/Mathlib/SetTheory/Ordinal/Exponential.lean
@@ -143,8 +143,8 @@ theorem opow_le_opow_right {a b c : Ordinal} (h₁ : 0 < a) (h₂ : b ≤ c) : a
   · exact (opow_le_opow_iff_right h₁).2 h₂
 
 theorem opow_le_opow_left {a b : Ordinal} (c : Ordinal) (ab : a ≤ b) : a ^ c ≤ b ^ c := by
-  obtain rfl | ha := eq_or_ne a 0
-  · obtain rfl | ha := eq_or_ne c 0 <;> simp_all
+  by_cases ha : a = 0
+  · by_cases c = 0 <;> simp_all
   · induction c using limitRecOn with
     | zero => simp
     | succ c IH => simpa using mul_le_mul' IH ab

--- a/Mathlib/SetTheory/Ordinal/Exponential.lean
+++ b/Mathlib/SetTheory/Ordinal/Exponential.lean
@@ -101,11 +101,7 @@ theorem opow_ne_zero {a : Ordinal} (b : Ordinal) (a0 : a ≠ 0) : a ^ b ≠ 0 :=
 
 @[simp]
 theorem opow_eq_zero {a b : Ordinal} : a ^ b = 0 ↔ a = 0 ∧ b ≠ 0 := by
-  obtain rfl | ha := eq_or_ne a 0
-  · obtain rfl | hb := eq_or_ne b 0
-    · simp
-    · simp [hb]
-  · simp [opow_ne_zero b ha, ha]
+  by_cases a = 0 <;> by_cases b = 0 <;> simp_all [opow_ne_zero]
 
 @[simp, norm_cast]
 theorem opow_natCast (a : Ordinal) (n : ℕ) : a ^ (n : Ordinal) = a ^ n := by


### PR DESCRIPTION
...by golfing the proofs so that they're no longer relevant!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
