### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Functor/KanExtension): transitivity of left Kan extensions

### DIFF
--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -612,24 +612,22 @@ def LeftExtension.isUniversalPrecomp₂
     (hα : (LeftExtension.mk F₁ α).IsUniversal)
     {b : L'.LeftExtension F₁} (hb : b.IsUniversal) :
     ((LeftExtension.precomp₂ L' α).obj b).IsUniversal := by
-  letI : (Y : (L ⋙ L').LeftExtension F₀) →
-      Unique ((precomp₂ L' α).obj b ⟶ Y) := by
-    intro y
+  letI (y : (L ⋙ L').LeftExtension F₀) :
+      Unique ((precomp₂ L' α).obj b ⟶ y) := by
     let u : L'.LeftExtension F₁ :=
       mk y.right <|
         hα.desc <| LeftExtension.mk _ <|
           y.hom ≫ (L.associator L' y.right).hom
-    let f := hb.desc <| u
     refine
-      ⟨⟨StructuredArrow.homMk f
+      ⟨⟨StructuredArrow.homMk (hb.desc <| u)
         (by
           ext x
           haveI hb_fac_app := congr_app (hb.fac u) (L.obj x)
           haveI hα_fac_app :=
             congr_app (hα.fac <| LeftExtension.mk _ <|
-              y.hom ≫ (L.associator L' y.right).hom) (x)
+              y.hom ≫ (L.associator L' y.right).hom) x
           dsimp at hα_fac_app hb_fac_app
-          simp [f, hb_fac_app, u, hα_fac_app])⟩, ?_⟩
+          simp [hb_fac_app, u, hα_fac_app])⟩, ?_⟩
     intro a
     dsimp
     ext1
@@ -648,7 +646,7 @@ def LeftExtension.isUniversalPrecomp₂
       comp_obj, StructuredArrow.left_eq_id, const_obj_map, id_comp,
       precomp₂_obj_right, whiskeringLeft_obj_map, NatTrans.comp_app,
       precomp₂_obj_hom_app, whiskerLeft_app, assoc] at a_w_t
-    simp [← a_w_t, f, hb_fac_app, u, hα_fac_app]
+    simp [← a_w_t, hb_fac_app, u, hα_fac_app]
   apply IsInitial.ofUnique
 
 /-- If the left extension defined by `α : F₀ ⟶ L ⋙ F₁` is universal,
@@ -661,9 +659,7 @@ def LeftExtension.isUniversalOfPrecomp₂
     {b : L'.LeftExtension F₁}
     (hb : ((LeftExtension.precomp₂ L' α).obj b).IsUniversal) :
     b.IsUniversal := by
-  letI : (Y : L'.LeftExtension F₁) →
-      Unique (b ⟶ Y) := by
-    intro y
+  letI (y : L'.LeftExtension F₁) : Unique (b ⟶ y) := by
     let u : (LeftExtension.precomp₂ L' α).obj b ⟶
       (LeftExtension.precomp₂ L' α).obj y := hb.to _
     haveI := u.w
@@ -715,7 +711,7 @@ theorem isLeftKanExtension_iff_postcompose [F₁.IsLeftKanExtension α]
     (γ : F₀ ⟶ L'' ⋙ F₂)
     (hγ :
       α ≫ whiskerLeft _ β ≫
-        (Functor.associator _ _ _).inv ≫ (whiskerRight e.hom F₂) =
+        (Functor.associator _ _ _).inv ≫ whiskerRight e.hom F₂ =
       γ := by aesop_cat) :
     F₂.IsLeftKanExtension β ↔ F₂.IsLeftKanExtension γ := by
   let Ψ := leftExtensionEquivalenceOfIso₁ e F₀

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -619,16 +619,14 @@ def LeftExtension.isUniversalPrecomp₂
         hα.desc <| LeftExtension.mk _ <|
           y.hom ≫ (L.associator L' y.right).hom
     refine
-      ⟨⟨StructuredArrow.homMk (hb.desc <| u)
-        (by
+      ⟨⟨StructuredArrow.homMk (hb.desc <| u) <| by
           ext x
           haveI hb_fac_app := congr_app (hb.fac u) (L.obj x)
           haveI hα_fac_app :=
             congr_app (hα.fac <| LeftExtension.mk _ <|
               y.hom ≫ (L.associator L' y.right).hom) x
           dsimp at hα_fac_app hb_fac_app
-          simp [hb_fac_app, u, hα_fac_app])⟩, ?_⟩
-    intro a
+          simp [hb_fac_app, u, hα_fac_app]⟩, fun a => ?_⟩
     dsimp
     ext1
     apply hb.hom_ext
@@ -667,9 +665,7 @@ def LeftExtension.isUniversalOfPrecomp₂
       whiskeringLeft_obj_obj, StructuredArrow.left_eq_id, const_obj_map, id_comp,
       whiskeringLeft_obj_map] at this
     refine
-      ⟨⟨StructuredArrow.homMk
-        u.right
-        (by
+      ⟨⟨StructuredArrow.homMk u.right <| by
           apply hα.hom_ext
           ext t
           have := congr_app u.w t
@@ -677,8 +673,7 @@ def LeftExtension.isUniversalOfPrecomp₂
             whiskeringLeft_obj_obj, comp_obj, StructuredArrow.left_eq_id,
             const_obj_map, id_comp, precomp₂_obj_hom_app, whiskeringLeft_obj_map,
             NatTrans.comp_app, whiskerLeft_app, assoc] at this
-          simp [this])⟩, ?_⟩
-    intro a
+          simp [this]⟩, fun a => ?_⟩
     dsimp
     ext1
     apply hb.hom_ext
@@ -702,8 +697,8 @@ def LeftExtension.isUniversalOfPrecomp₂Equiv
     b.IsUniversal ≃ ((LeftExtension.precomp₂ L' α).obj b).IsUniversal where
   toFun h := LeftExtension.isUniversalPrecomp₂ α hα h
   invFun h := LeftExtension.isUniversalOfPrecomp₂ α hα h
-  left_inv x :=  by subsingleton
-  right_inv x :=  by subsingleton
+  left_inv x := by subsingleton
+  right_inv x := by subsingleton
 
 
 theorem isLeftKanExtension_iff_postcompose [F₁.IsLeftKanExtension α]

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -691,7 +691,7 @@ def LeftExtension.isUniversalOfPrecomp₂
 then for every `L' : D ⥤ D'`, `F₁ : D ⥤ H`, an extension
 `b : L'.LeftExtension F₁` is universal if and only if
 `(LeftExtension.precomp₂ L' α).obj b` is universal. -/
-def LeftExtension.isUniversalOfPrecomp₂Equiv
+def LeftExtension.isUniversalPrecomp₂Equiv
     (hα : (LeftExtension.mk F₁ α).IsUniversal)
     (b : L'.LeftExtension F₁) :
     b.IsUniversal ≃ ((LeftExtension.precomp₂ L' α).obj b).IsUniversal where

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -619,7 +619,7 @@ def LeftExtension.isUniversalPrecomp₂
         hα.desc <| LeftExtension.mk _ <|
           y.hom ≫ (L.associator L' y.right).hom
     refine
-      ⟨⟨StructuredArrow.homMk (hb.desc <| u) <| by
+      ⟨⟨StructuredArrow.homMk (hb.desc u) <| by
           ext x
           haveI hb_fac_app := congr_app (hb.fac u) (L.obj x)
           haveI hα_fac_app :=

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -677,7 +677,10 @@ def LeftExtension.isUniversalOfPrecomp₂
           apply hα.hom_ext
           ext t
           have := congr_app u.w t
-          simp at this
+          simp only [precomp₂_obj_left, const_obj_obj, precomp₂_obj_right,
+            whiskeringLeft_obj_obj, comp_obj, StructuredArrow.left_eq_id,
+            const_obj_map, id_comp, precomp₂_obj_hom_app, whiskeringLeft_obj_map,
+            NatTrans.comp_app, whiskerLeft_app, assoc] at this
           simp [this])⟩, ?_⟩
     intro a
     dsimp
@@ -686,7 +689,10 @@ def LeftExtension.isUniversalOfPrecomp₂
     ext t
     have := congr_app u.w t
     have a_w := a.w
-    simp at this a_w
+    simp only [precomp₂_obj_left, const_obj_obj, precomp₂_obj_right,
+      whiskeringLeft_obj_obj, comp_obj, StructuredArrow.left_eq_id,
+      const_obj_map, id_comp, precomp₂_obj_hom_app, whiskeringLeft_obj_map,
+      NatTrans.comp_app, whiskerLeft_app, assoc] at this a_w
     simp [← this, a_w]
   apply IsInitial.ofUnique
 

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -597,7 +597,7 @@ section transitivity
 def LeftExtension.precomp₂
     {F₀ : C ⥤ H} {L : C ⥤ D} {F₁ : D ⥤ H} (L' : D ⥤ D') (α : F₀ ⟶ L ⋙ F₁) :
     L'.LeftExtension F₁ ⥤ (L ⋙ L').LeftExtension F₀ :=
-  (LeftExtension.precomp L' F₁ L) ⋙ (StructuredArrow.map α)
+  LeftExtension.precomp L' F₁ L ⋙ StructuredArrow.map α
 
 variable
     {L : C ⥤ D} {L' : D ⥤ D'}

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -507,6 +507,7 @@ lemma hasRightExtension_iff_of_iso₁ : HasRightKanExtension L F ↔ HasRightKan
 
 /-- The equivalence `LeftExtension L F ≌ LeftExtension L' F` induced by
 a natural isomorphism `L ≅ L'`. -/
+@[simps!]
 def leftExtensionEquivalenceOfIso₁ : LeftExtension L F ≌ LeftExtension L' F :=
   StructuredArrow.mapNatIso ((whiskeringLeft C D H).mapIso iso₁)
 
@@ -587,6 +588,152 @@ lemma isRightKanExtension_iff_of_iso₂ {F₁' F₂' : D ⥤ H} (α₁ : L ⋙ F
   · exact fun _ => ⟨⟨eq.2 (isUniversalOfIsRightKanExtension F₂' α₂)⟩⟩
 
 end
+
+section transitivity
+
+/-- A variant of `LeftExtension.precomp` where we precompose, and then
+"whisker" the diagram by a given natural transformation `(α : F₀ ⟶ L ⋙ F₁)` -/
+@[simps!]
+def LeftExtension.precomp₂
+    {F₀ : C ⥤ H} {L : C ⥤ D} {F₁ : D ⥤ H} (L' : D ⥤ D') (α : F₀ ⟶ L ⋙ F₁) :
+    L'.LeftExtension F₁ ⥤ (L ⋙ L').LeftExtension F₀ :=
+  (LeftExtension.precomp L' F₁ L) ⋙ (StructuredArrow.map α)
+
+variable
+    {L : C ⥤ D} {L' : D ⥤ D'}
+    {F₀ : C ⥤ H} {F₁ : D ⥤ H} {F₂ : D' ⥤ H}
+    (α : F₀ ⟶ L ⋙ F₁)
+
+/-- If the right extension defined by `α : F₀ ⟶ L ⋙ F₁` is universal,
+then for every `L' : D ⥤ D'`, `F₁ : D ⥤ H`, if an extension
+`b : L'.LeftExtension F₁` is universal, so is the "pasted" extension
+`(LeftExtension.precomp₂ L' α).obj b`. -/
+def LeftExtension.isUniversalPrecomp₂
+    (hα : (LeftExtension.mk F₁ α).IsUniversal)
+    {b : L'.LeftExtension F₁} (hb : b.IsUniversal) :
+    ((LeftExtension.precomp₂ L' α).obj b).IsUniversal := by
+  letI : (Y : (L ⋙ L').LeftExtension F₀) →
+      Unique ((precomp₂ L' α).obj b ⟶ Y) := by
+    intro y
+    let u : L'.LeftExtension F₁ :=
+      mk y.right <|
+        hα.desc <| LeftExtension.mk _ <|
+          y.hom ≫ (L.associator L' y.right).hom
+    let f := hb.desc <| u
+    refine
+      ⟨⟨StructuredArrow.homMk f
+        (by
+          ext x
+          haveI hb_fac_app := congr_app (hb.fac u) (L.obj x)
+          haveI hα_fac_app :=
+            congr_app (hα.fac <| LeftExtension.mk _ <|
+              y.hom ≫ (L.associator L' y.right).hom) (x)
+          dsimp at hα_fac_app hb_fac_app
+          simp [f, hb_fac_app, u, hα_fac_app])⟩, ?_⟩
+    intro a
+    dsimp
+    ext1
+    apply hb.hom_ext
+    apply hα.hom_ext
+    ext t
+    dsimp
+    have a_w_t := congr_app a.w t
+    have hb_fac_app := congr_app (hb.fac u) (L.obj t)
+    have hα_fac_app :=
+      congr_app
+        (hα.fac <| LeftExtension.mk _ <|
+          y.hom ≫ (L.associator L' y.right).hom) t
+    dsimp at hb_fac_app hα_fac_app
+    simp only [precomp₂_obj_left, const_obj_obj, whiskeringLeft_obj_obj,
+      comp_obj, StructuredArrow.left_eq_id, const_obj_map, id_comp,
+      precomp₂_obj_right, whiskeringLeft_obj_map, NatTrans.comp_app,
+      precomp₂_obj_hom_app, whiskerLeft_app, assoc] at a_w_t
+    simp [← a_w_t, f, hb_fac_app, u, hα_fac_app]
+  apply IsInitial.ofUnique
+
+/-- If the left extension defined by `α : F₀ ⟶ L ⋙ F₁` is universal,
+then for every `L' : D ⥤ D'`, `F₁ : D ⥤ H`, if an extension
+`b : L'.LeftExtension F₁` is such that the "pasted" extension
+`(LeftExtension.precomp₂ L' α).obj b` is universal, then `b` is itself
+universal. -/
+def LeftExtension.isUniversalOfPrecomp₂
+    (hα : (LeftExtension.mk F₁ α).IsUniversal)
+    {b : L'.LeftExtension F₁}
+    (hb : ((LeftExtension.precomp₂ L' α).obj b).IsUniversal) :
+    b.IsUniversal := by
+  letI : (Y : L'.LeftExtension F₁) →
+      Unique (b ⟶ Y) := by
+    intro y
+    let u : (LeftExtension.precomp₂ L' α).obj b ⟶
+      (LeftExtension.precomp₂ L' α).obj y := hb.to _
+    haveI := u.w
+    simp only [precomp₂_obj_left, const_obj_obj, precomp₂_obj_right,
+      whiskeringLeft_obj_obj, StructuredArrow.left_eq_id, const_obj_map, id_comp,
+      whiskeringLeft_obj_map] at this
+    refine
+      ⟨⟨StructuredArrow.homMk
+        u.right
+        (by
+          apply hα.hom_ext
+          ext t
+          have := congr_app u.w t
+          simp at this
+          simp [this])⟩, ?_⟩
+    intro a
+    dsimp
+    ext1
+    apply hb.hom_ext
+    ext t
+    have := congr_app u.w t
+    have a_w := a.w
+    simp at this a_w
+    simp [← this, a_w]
+  apply IsInitial.ofUnique
+
+/-- If the left extension defined by `α : F₀ ⟶ L ⋙ F₁` is universal,
+then for every `L' : D ⥤ D'`, `F₁ : D ⥤ H`, an extension
+`b : L'.LeftExtension F₁` is universal if and only if
+`(LeftExtension.precomp₂ L' α).obj b` is universal. -/
+def LeftExtension.isUniversalOfPrecomp₂Equiv
+    (hα : (LeftExtension.mk F₁ α).IsUniversal)
+    (b : L'.LeftExtension F₁) :
+    b.IsUniversal ≃ ((LeftExtension.precomp₂ L' α).obj b).IsUniversal where
+  toFun h := LeftExtension.isUniversalPrecomp₂ α hα h
+  invFun h := LeftExtension.isUniversalOfPrecomp₂ α hα h
+  left_inv x :=  by subsingleton
+  right_inv x :=  by subsingleton
+
+
+theorem isLeftKanExtension_iff_postcompose [F₁.IsLeftKanExtension α]
+    {F₂ : D' ⥤ H} (L'' : C ⥤ D') (e : L ⋙ L' ≅ L'') (β : F₁ ⟶ L' ⋙ F₂)
+    (γ : F₀ ⟶ L'' ⋙ F₂)
+    (hγ :
+      α ≫ whiskerLeft _ β ≫
+        (Functor.associator _ _ _).inv ≫ (whiskerRight e.hom F₂) =
+      γ := by aesop_cat) :
+    F₂.IsLeftKanExtension β ↔ F₂.IsLeftKanExtension γ := by
+  let Ψ := leftExtensionEquivalenceOfIso₁ e F₀
+  obtain ⟨⟨hα⟩⟩ := (inferInstance : F₁.IsLeftKanExtension α)
+  refine ⟨fun ⟨⟨h⟩⟩ => ⟨⟨?_⟩⟩, fun ⟨⟨h⟩⟩ => ⟨⟨?_⟩⟩⟩
+  · apply IsInitial.isInitialIffObj Ψ.inverse _|>.invFun
+    haveI := LeftExtension.isUniversalPrecomp₂ α hα h
+    let i :
+        (LeftExtension.precomp₂ L' α).obj (LeftExtension.mk F₂ β) ≅
+        Ψ.inverse.obj (LeftExtension.mk F₂ γ) :=
+      StructuredArrow.isoMk (NatIso.ofComponents fun _ ↦ .refl _) <| by
+        ext x
+        simp [Ψ, ← congr_app hγ x, ← Functor.map_comp]
+    exact IsInitial.ofIso this i
+  · apply LeftExtension.isUniversalOfPrecomp₂ α hα
+    apply IsInitial.isInitialIffObj Ψ.functor _|>.invFun
+    let i :
+        (LeftExtension.mk F₂ γ) ≅
+        Ψ.functor.obj <| (LeftExtension.precomp₂ L' α).obj <|
+          LeftExtension.mk F₂ β :=
+      StructuredArrow.isoMk (NatIso.ofComponents fun _ ↦ .refl _)
+    exact IsInitial.ofIso h i
+
+end transitivity
 
 section Colimit
 


### PR DESCRIPTION
In this PR, we show that left Kan extensions are "transitive" in the following sense : if `α : F₀ ⟶ L ⋙ F₁` exhibits `F₁` as a left Kan extension of `F₀` along `L : C ⥤ D`, then given a functor `L' : D ⥤ D'` an an extension `(β : F₁ ⟶ L' ⋙ F₂)`, the "pasted extension" formed by `α` and `β` exhibits `F₂` as a left Kan extension of `F₀` along `L ⋙ L'` if and only if `β` exhibits `F₂` as a left Kan extension of `F₁` along `L'`. This refines the current theorems in mathlib that only treat the case where we pre or post-compose by an equivalence.

The actual statement we prove is "fully weak" and lets us pick a functor isomorphic to `L ⋙ L'` and an extension isomorphic to the pasted one if needed. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I will PR the dual version of everything for right Kan extensions as soon as we settle on the final form of this one.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
