### PR TITLE
[Merged by Bors] - chore(Order/IsNormal): change default constructor

### DIFF
--- a/Mathlib/Order/IsNormal.lean
+++ b/Mathlib/Order/IsNormal.lean
@@ -31,6 +31,7 @@ namespace Order
 @[mk_iff isNormal_iff']
 structure IsNormal [LinearOrder α] [LinearOrder β] (f : α → β) : Prop where
   strictMono : StrictMono f
+  /-- This condition is the RHS of the `IsLUB (f '' Iio a) (f a)` predicate. -/
   mem_lowerBounds_upperBounds_of_isSuccLimit {a : α} (ha : IsSuccLimit a) :
     f a ∈ lowerBounds (upperBounds (f '' Iio a))
 

--- a/Mathlib/Order/IsNormal.lean
+++ b/Mathlib/Order/IsNormal.lean
@@ -28,26 +28,36 @@ variable {α β γ : Type*} {a b : α} {f : α → β} {g : β → γ}
 namespace Order
 
 /-- A normal function between well-orders is a strictly monotonic continuous function. -/
+@[mk_iff isNormal_iff']
 structure IsNormal [LinearOrder α] [LinearOrder β] (f : α → β) : Prop where
   strictMono : StrictMono f
-  isLUB_image_Iio_of_isSuccLimit {a : α} (ha : IsSuccLimit a) : IsLUB (f '' Iio a) (f a)
+  mem_lowerBounds_upperBounds_of_isSuccLimit {a : α} (ha : IsSuccLimit a) :
+    f a ∈ lowerBounds (upperBounds (f '' Iio a))
+
+theorem isNormal_iff [LinearOrder α] [LinearOrder β] {f : α → β} :
+    IsNormal f ↔ StrictMono f ∧ ∀ o, IsSuccLimit o → ∀ a, (∀ b < o, f b ≤ a) → f o ≤ a := by
+  simp [isNormal_iff', mem_lowerBounds, mem_upperBounds]
 
 namespace IsNormal
 
 section LinearOrder
 variable [LinearOrder α] [LinearOrder β] [LinearOrder γ]
 
-/-- This condition is the RHS of the `IsLUB (f '' Iio a) (f a)` predicate. -/
-theorem of_mem_lowerBounds_upperBounds {f : α → β} (hf : StrictMono f)
-    (hl : ∀ {a}, IsSuccLimit a → f a ∈ lowerBounds (upperBounds (f '' Iio a))) : IsNormal f := by
-  refine ⟨hf, fun {a} ha ↦ ⟨?_, hl ha⟩⟩
+theorem isLUB_image_Iio_of_isSuccLimit {f : α → β} (hf : IsNormal f) {a : α} (ha : IsSuccLimit a) :
+    IsLUB (f '' Iio a) (f a) := by
+  refine ⟨?_, hf.2 ha⟩
   rintro - ⟨b, hb, rfl⟩
-  exact (hf hb).le
+  exact (hf.1 hb).le
+
+@[deprecated "use the default constructor of `IsNormal` directly" (since := "2025-07-08")]
+theorem of_mem_lowerBounds_upperBounds {f : α → β} (hf : StrictMono f)
+    (hl : ∀ {a}, IsSuccLimit a → f a ∈ lowerBounds (upperBounds (f '' Iio a))) : IsNormal f :=
+  ⟨hf, hl⟩
 
 theorem of_succ_lt [SuccOrder α] [WellFoundedLT α]
     (hs : ∀ a, f a < f (succ a)) (hl : ∀ {a}, IsSuccLimit a → IsLUB (f '' Iio a) (f a)) :
     IsNormal f := by
-  refine ⟨fun a b ↦ ?_, hl⟩
+  refine ⟨fun a b ↦ ?_, fun ha ↦ (hl ha).2⟩
   induction b using SuccOrder.limitRecOn with
   | isMin b hb => exact hb.not_lt.elim
   | succ b hb IH =>
@@ -81,11 +91,9 @@ theorem map_isSuccLimit (hf : IsNormal f) (ha : IsSuccLimit a) : IsSuccLimit (f 
 theorem map_isLUB (hf : IsNormal f) {s : Set α} (hs : IsLUB s a) (hs' : s.Nonempty) :
     IsLUB (f '' s) (f a) := by
   refine ⟨?_, fun b hb ↦ ?_⟩
-  · simp_rw [mem_upperBounds, forall_mem_image, hf.strictMono.le_iff_le]
-    exact hs.1
+  · simpa [mem_upperBounds, hf.strictMono.le_iff_le] using hs.1
   · by_cases ha : a ∈ s
-    · simp_rw [mem_upperBounds, forall_mem_image] at hb
-      exact hb ha
+    · simp_all [mem_upperBounds]
     · have ha' := hs.isSuccLimit_of_notMem hs' ha
       rw [le_iff_forall_le hf ha']
       intro c hc
@@ -95,9 +103,9 @@ theorem map_isLUB (hf : IsNormal f) {s : Set α} (hs : IsLUB s a) (hs' : s.Nonem
 
 theorem _root_.InitialSeg.isNormal (f : α ≤i β) : IsNormal f where
   strictMono := f.strictMono
-  isLUB_image_Iio_of_isSuccLimit ha := by
+  mem_lowerBounds_upperBounds_of_isSuccLimit ha := by
     rw [f.image_Iio]
-    exact (f.map_isSuccLimit ha).isLUB_Iio
+    exact (f.map_isSuccLimit ha).isLUB_Iio.2
 
 theorem _root_.PrincipalSeg.isNormal (f : α <i β) : IsNormal f :=
   (f : α ≤i β).isNormal
@@ -109,7 +117,7 @@ protected theorem id : IsNormal (@id α) :=
   (OrderIso.refl _).isNormal
 
 theorem comp (hg : IsNormal g) (hf : IsNormal f) : IsNormal (g ∘ f) := by
-  refine .of_mem_lowerBounds_upperBounds (hg.strictMono.comp hf.strictMono) fun ha b hb ↦ ?_
+  refine ⟨hg.strictMono.comp hf.strictMono, fun ha b hb ↦ ?_⟩
   simp_rw [Function.comp_apply, mem_upperBounds, forall_mem_image] at hb
   simpa [hg.le_iff_forall_le (hf.map_isSuccLimit ha), hf.lt_iff_exists_lt ha] using
     fun c d hd hc ↦ (hg.strictMono hc).le.trans (hb hd)

--- a/Mathlib/Order/IsNormal.lean
+++ b/Mathlib/Order/IsNormal.lean
@@ -31,7 +31,8 @@ namespace Order
 @[mk_iff isNormal_iff']
 structure IsNormal [LinearOrder α] [LinearOrder β] (f : α → β) : Prop where
   strictMono : StrictMono f
-  /-- This condition is the RHS of the `IsLUB (f '' Iio a) (f a)` predicate. -/
+  /-- This condition is the RHS of the `IsLUB (f '' Iio a) (f a)` predicate, which is sufficient
+  since the LHS is implied by monotonicity. -/
   mem_lowerBounds_upperBounds_of_isSuccLimit {a : α} (ha : IsSuccLimit a) :
     f a ∈ lowerBounds (upperBounds (f '' Iio a))
 


### PR DESCRIPTION
The default constructor of `Order.IsNormal` currently contains a redundant hypothesis. The idea was that it might often be easier to reason in terms of `IsLUB` rather than unfolding everything down to inequalities. My work on #26900 suggests however that's not the case.

I've also added the theorem `isNormal_iff`, which takes care of unfolding the definition. (Note that it matches that given by `Ordinal.isNormal_iff_strictMono_limit`!)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
