### PR TITLE
[Merged by Bors] - perf(Mathlib/Topology/Instances/Nat): Reduce imports

### DIFF
--- a/Mathlib/Topology/Instances/Nat.lean
+++ b/Mathlib/Topology/Instances/Nat.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
 import Mathlib.Topology.Instances.Int
-import Mathlib.Data.Nat.Lattice
 
 /-!
 # Topology on the natural numbers
@@ -59,6 +58,6 @@ instance : ProperSpace ℕ :=
     exact (Set.finite_Icc _ _).isCompact⟩
 
 instance : NoncompactSpace ℕ :=
-  noncompactSpace_of_neBot <| by simp [Filter.atTop_neBot]
+  noncompactSpace_of_neBot <| by simp only [Filter.cocompact_eq_cofinite, Filter.cofinite_neBot]
 
 end Nat


### PR DESCRIPTION
Reduces -0.08% cumulation.

### `lake exe pole` results:

#### Before
| file                                                                 | instructions | cumulative | parallelism |
| :------------------------------------------------------------------- | -----------: | ---------: | :---------: |
| Mathlib                                                              |        34672 |    6505900 |    26.65    |
| Mathlib.Analysis.CStarAlgebra.CompletelyPositiveMap                  |        35421 |    6471228 |    9.27     |
| Mathlib.Analysis.CStarAlgebra.CStarMatrix                            |       138959 |    6435806 |    9.30     |
| Mathlib.Analysis.CStarAlgebra.Module.Constructions                   |        66853 |    6296846 |    9.47     |
| Mathlib.Analysis.CStarAlgebra.Module.Defs                            |        60235 |    6229992 |    9.56     |
| Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Order     |       174252 |    6169756 |    9.64     |
| Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Basic     |       159421 |    5995504 |    9.85     |
| Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Isometric |       170884 |    5836082 |    10.00    |
| Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Instances |       162420 |    5665198 |    10.27    |
| Mathlib.Analysis.Normed.Algebra.Spectrum                             |       118536 |    5502777 |    10.32    |
| Mathlib.Analysis.Complex.Polynomial.Basic                            |        29016 |    5384241 |    10.48    |

#### After

| file                                                                 | instructions | cumulative | parallelism |
| :------------------------------------------------------------------- | -----------: | ---------: | :---------: |
| Mathlib                                                              |        34672 |    6511385 |    26.63    |
| Mathlib.Analysis.CStarAlgebra.CompletelyPositiveMap                  |        35402 |    6476713 |    9.26     |
| Mathlib.Analysis.CStarAlgebra.CStarMatrix                            |       138365 |    6441310 |    9.29     |
| Mathlib.Analysis.CStarAlgebra.Module.Constructions                   |        66850 |    6302945 |    9.46     |
| Mathlib.Analysis.CStarAlgebra.Module.Defs                            |        60228 |    6236094 |    9.55     |
| Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Order     |       174293 |    6175866 |    9.63     |
| Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Basic     |       159417 |    6001572 |    9.84     |
| Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Isometric |       170861 |    5842154 |    9.99     |
| Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Instances |       162438 |    5671293 |    10.26    |
| Mathlib.Analysis.Normed.Algebra.Spectrum                             |       118553 |    5508854 |    10.31    |
| Mathlib.Analysis.Complex.Polynomial.Basic                            |        29014 |    5390301 |    10.47    |

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
