### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Functor/KanExtension) : Kan extension along equivalences of categories

### DIFF
--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -693,16 +693,12 @@ section
 variable {L : C ≌ D} {F₀ : C ⥤ H} {F₁ : D ⥤ H}
 
 variable (F₀) in
-instance isLeftKanExtensionId : F₀.IsLeftKanExtension (F₀.leftUnitor.inv) := by
-  constructor
-  refine ⟨?_⟩
-  exact StructuredArrow.mkIdInitial
+instance isLeftKanExtensionId : F₀.IsLeftKanExtension F₀.leftUnitor.inv where
+  nonempty_isUniversal := ⟨StructuredArrow.mkIdInitial⟩
 
 variable (F₀) in
-instance isRightKanExtensionId : F₀.IsRightKanExtension (F₀.leftUnitor.hom) := by
-  constructor
-  refine ⟨?_⟩
-  exact CostructuredArrow.mkIdTerminal
+instance isRightKanExtensionId : F₀.IsRightKanExtension F₀.leftUnitor.hom where
+  nonempty_isUniversal := ⟨CostructuredArrow.mkIdTerminal⟩
 
 instance isLeftKanExtensionAlongEquivalence (α : F₀ ≅ L.functor ⋙ F₁) :
     F₁.IsLeftKanExtension α.hom := by

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -688,6 +688,58 @@ lemma limitIsoOfIsRightKanExtension_hom_π (i : C) :
 
 end Limit
 
+section
+
+variable {L : C ≌ D} {F₀ : C ⥤ H} {F₁ : D ⥤ H}
+
+variable (F₀) in
+instance isLeftKanExtensionId : F₀.IsLeftKanExtension (F₀.leftUnitor.inv) := by
+  constructor
+  refine ⟨?_⟩
+  exact StructuredArrow.mkIdInitial
+
+variable (F₀) in
+instance isRightKanExtensionId : F₀.IsRightKanExtension (F₀.leftUnitor.hom) := by
+  constructor
+  refine ⟨?_⟩
+  exact CostructuredArrow.mkIdTerminal
+
+instance isLeftKanExtensionAlongEquivalence (α : F₀ ≅ L.functor ⋙ F₁) :
+    F₁.IsLeftKanExtension α.hom := by
+  refine ⟨⟨?_⟩⟩
+  apply LeftExtension.isUniversalPostcomp₁Equiv
+    (G := L.functor) L.functor.leftUnitor F₀ _|>.invFun
+  refine IsInitial.ofUniqueHom
+    (fun y ↦ StructuredArrow.homMk <| α.inv ≫ y.hom ≫ y.right.leftUnitor.hom) ?_
+  intro y m
+  ext x
+  simpa using α.inv.app x ≫= congr_app m.w.symm x
+
+instance isLeftKanExtensionAlongEquivalence' (L : C ⥤ D) (α : F₀ ⟶ L ⋙ F₁)
+    [IsEquivalence L] [IsIso α] :
+    F₁.IsLeftKanExtension α :=
+  inferInstanceAs <|
+    F₁.IsLeftKanExtension (asIso α : F₀ ≅ (asEquivalence L).functor ⋙ F₁).hom
+
+instance isRightKanExtensionAlongEquivalence (α : L.functor ⋙ F₁ ≅ F₀) :
+    F₁.IsRightKanExtension α.hom := by
+  refine ⟨⟨?_⟩⟩
+  apply RightExtension.isUniversalPostcomp₁Equiv
+    (G := L.functor) L.functor.leftUnitor F₀ _|>.invFun
+  refine IsTerminal.ofUniqueHom
+    (fun y ↦ CostructuredArrow.homMk <| y.left.leftUnitor.inv ≫ y.hom ≫ α.inv) ?_
+  intro y m
+  ext x
+  simpa using congr_app m.w x =≫ α.inv.app x
+
+instance isRightKanExtensionAlongEquivalence' (L : C ⥤ D) (α : L ⋙ F₁ ⟶ F₀)
+    [IsEquivalence L] [IsIso α] :
+    F₁.IsRightKanExtension α :=
+  inferInstanceAs <|
+    F₁.IsRightKanExtension (asIso α : (asEquivalence L).functor ⋙ F₁ ≅ F₀).hom
+
+end
+
 end Functor
 
 end CategoryTheory


### PR DESCRIPTION
In this PR, we record as instances the somewhat trivial fact that if `L : C ≌ D` is an equivalence of categories and `F₀ ≅ L.functor ⋙ F₁` any natural isomorphism where `F₀` is a functor out of `C` and `F₁` a functor out of `D`, then the corresponding extension is a left Kan extension. The dual fact for right Kan extensions is recorded.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
