### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/Projectivization/Subspace): correspondence between linear and projective subspaces

### DIFF
--- a/Mathlib/LinearAlgebra/Projectivization/Subspace.lean
+++ b/Mathlib/LinearAlgebra/Projectivization/Subspace.lean
@@ -211,7 +211,7 @@ def submodule : Projectivization.Subspace K V ≃o Submodule K V where
       rcases eq_or_ne x 0 with rfl | hx₂
       · rwa [zero_add]
       rcases eq_or_ne y 0 with rfl | hy₂
-      · rw [add_zero]; exact hx₁
+      · rwa [add_zero]
       intro hxy
       exact s.mem_add _ _ hx₂ hy₂ hxy (hx₁ hx₂) (hy₁ hy₂)
     zero_mem' h := h.irrefl.elim
@@ -225,16 +225,14 @@ def submodule : Projectivization.Subspace K V ≃o Submodule K V where
       exact Iff.eq <| s.smul_mem_iff <| left_ne_zero_of_smul h
     mem_add' _ _ _ _ _ h₁ h₂ := s.add_mem h₁ h₂ }
   left_inv s := by
-    ext x
-    cases x with | _ x hx =>
+    ext ⟨x, hx⟩
     exact ⟨fun h => h hx, fun h _ => h⟩
   right_inv s := by
     ext x
-    change (x ≠ 0 → x ∈ s) ↔ x ∈ s
-    refine ⟨fun h => ?_, fun h _ => h⟩
-    rcases eq_or_ne x 0 with rfl | hx
-    · exact s.zero_mem
-    · exact h hx
+    suffices x = 0 → x ∈ s by
+      simpa [imp_iff_not_or]
+    rintro rfl
+    exact s.zero_mem
   map_rel_iff'.mp h₁ := Projectivization.ind fun _ hx h₂ => h₁ (fun _ => h₂) hx
   map_rel_iff'.mpr h₁ _ h₂ hx := h₁ <| h₂ hx
 

--- a/Mathlib/LinearAlgebra/Projectivization/Subspace.lean
+++ b/Mathlib/LinearAlgebra/Projectivization/Subspace.lean
@@ -204,43 +204,39 @@ theorem span_eq_span_iff {S T : Set (ℙ K V)} : span S = span T ↔ S ⊆ span 
 
 /-- The submodule corresponding to a projective subspace `s`, consisting of the representatives of
 points in `s` together with zero. This is the inverse of `Submodule.projectivization`. -/
-def submodule : Projectivization.Subspace K V ≃o Submodule K V :=
-  Equiv.toOrderIso {
-    toFun s := {
-      carrier := {x | (h : x ≠ 0) → Projectivization.mk K x h ∈ s.carrier}
-      add_mem' {x y} hx₁ hy₁ := by
-        rcases eq_or_ne x 0 with rfl | hx₂
-        · rw [zero_add]; exact hy₁
-        rcases eq_or_ne y 0 with rfl | hy₂
-        · rw [add_zero]; exact hx₁
-        intro hxy
-        exact s.mem_add _ _ hx₂ hy₂ hxy (hx₁ hx₂) (hy₁ hy₂)
-      zero_mem' h := h.irrefl.elim
-      smul_mem' c x h₁ h₂ := by
-        convert h₁ (right_ne_zero_of_smul h₂) using 1
-        rw [Projectivization.mk_eq_mk_iff']
-        exact ⟨c, rfl⟩
-    }
-    invFun s := {
-      carrier := setOf <| Projectivization.lift (↑· ∈ s) <| by
-        rintro ⟨-, h⟩ ⟨y, -⟩ c rfl
-        exact Iff.eq <| s.smul_mem_iff <| left_ne_zero_of_smul h
-      mem_add' _ _ _ _ _ h₁ h₂ := s.add_mem h₁ h₂
-    }
-    left_inv s := by
-      ext x
-      cases x with | _ x hx =>
-      exact ⟨fun h => h hx, fun h _ => h⟩
-    right_inv s := by
-      ext x
-      change (x ≠ 0 → x ∈ s) ↔ x ∈ s
-      refine ⟨fun h => ?_, fun h _ => h⟩
-      rcases eq_or_ne x 0 with rfl | hx
-      · exact s.zero_mem
-      · exact h hx
-  }
-  (fun _ _ h₁ _ h₂ _ => h₁ <| h₂ _)
-  (fun _ _ h₁ => Projectivization.ind fun _ _ h₂ => h₁ h₂)
+def submodule : Projectivization.Subspace K V ≃o Submodule K V where
+  toFun s :=
+  { carrier := {x | (h : x ≠ 0) → Projectivization.mk K x h ∈ s.carrier}
+    add_mem' {x y} hx₁ hy₁ := by
+      rcases eq_or_ne x 0 with rfl | hx₂
+      · rwa [zero_add]
+      rcases eq_or_ne y 0 with rfl | hy₂
+      · rw [add_zero]; exact hx₁
+      intro hxy
+      exact s.mem_add _ _ hx₂ hy₂ hxy (hx₁ hx₂) (hy₁ hy₂)
+    zero_mem' h := h.irrefl.elim
+    smul_mem' c x h₁ h₂ := by
+      convert h₁ (right_ne_zero_of_smul h₂) using 1
+      rw [Projectivization.mk_eq_mk_iff']
+      exact ⟨c, rfl⟩ }
+  invFun s :=
+  { carrier := setOf <| Projectivization.lift (↑· ∈ s) <| by
+      rintro ⟨-, h⟩ ⟨y, -⟩ c rfl
+      exact Iff.eq <| s.smul_mem_iff <| left_ne_zero_of_smul h
+    mem_add' _ _ _ _ _ h₁ h₂ := s.add_mem h₁ h₂ }
+  left_inv s := by
+    ext x
+    cases x with | _ x hx =>
+    exact ⟨fun h => h hx, fun h _ => h⟩
+  right_inv s := by
+    ext x
+    change (x ≠ 0 → x ∈ s) ↔ x ∈ s
+    refine ⟨fun h => ?_, fun h _ => h⟩
+    rcases eq_or_ne x 0 with rfl | hx
+    · exact s.zero_mem
+    · exact h hx
+  map_rel_iff'.mp h₁ := Projectivization.ind fun _ hx h₂ => h₁ (fun _ => h₂) hx
+  map_rel_iff'.mpr h₁ _ h₂ hx := h₁ <| h₂ hx
 
 @[simp]
 theorem mem_submodule_iff (s : Projectivization.Subspace K V) {v : V} (hv : v ≠ 0) :


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
