### PR TITLE
[Merged by Bors] - chore(Cache): comment out broken code for getting the branch from PR info

### DIFF
--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -150,47 +150,50 @@ def getRemoteRepo (mathlibDepPath : FilePath) : IO RepoInfo := do
       return {repo := repo, useFirst := true}
 
     -- Only search for PR refs if we're not on a regular branch like master, bump/*, or nightly-testing*
-    let isSpecialBranch := branchName == "master" || branchName.startsWith "bump/" ||
-                          branchName.startsWith "nightly-testing"
+    -- let isSpecialBranch := branchName == "master" || branchName.startsWith "bump/" ||
+    --                       branchName.startsWith "nightly-testing"
 
+    -- TODO: this code is currently broken in two ways: 1. you need to write `%(refname)` in quotes and
+    -- 2. it is looking in the wrong place when in detached HEAD state.
+    -- We comment it out for now, but we should fix it later.
     -- Check if the current commit coincides with any PR ref
-    if !isSpecialBranch then
-      let mathlibRemoteName ← findMathlibRemote mathlibDepPath
-      let currentCommit ← IO.Process.output
-        {cmd := "git", args := #["rev-parse", "HEAD"], cwd := mathlibDepPath}
-
-      if currentCommit.exitCode == 0 then
-        let commit := currentCommit.stdout.trim
-        -- Get all PR refs that contain this commit
-        let prRefPattern := s!"refs/remotes/{mathlibRemoteName}/pr/*"
-        let refsInfo ← IO.Process.output
-          {cmd := "git", args := #["for-each-ref", "--contains", commit, prRefPattern, "--format=%(refname)"], cwd := mathlibDepPath}
-        -- The code below is for debugging purposes currently
-        IO.println s!"`git for-each-ref --contains {commit} {prRefPattern} --format=%(refname)` returned:
-        {refsInfo.stdout.trim} with exit code {refsInfo.exitCode} and stderr: {refsInfo.stderr.trim}."
-        let refsInfo' ← IO.Process.output
-          {cmd := "git", args := #["for-each-ref", "--contains", commit, prRefPattern, "--format=\"%(refname)\""], cwd := mathlibDepPath}
-        IO.println s!"`git for-each-ref --contains {commit} {prRefPattern} --format=\"%(refname)\"` returned:
-        {refsInfo'.stdout.trim} with exit code {refsInfo'.exitCode} and stderr: {refsInfo'.stderr.trim}."
-
-        if refsInfo.exitCode == 0 && !refsInfo.stdout.trim.isEmpty then
-          let prRefs := refsInfo.stdout.trim.split (· == '\n')
-          -- Extract PR numbers from refs like "refs/remotes/upstream/pr/1234"
-          for prRef in prRefs do
-            if let some prNumber := extractPRNumber prRef then
-              -- Get PR details using gh
-              let prInfo ← IO.Process.output
-                {cmd := "gh", args := #["pr", "view", toString prNumber, "--json", "headRefName,headRepositoryOwner,number"], cwd := mathlibDepPath}
-              if prInfo.exitCode == 0 then
-                if let .ok json := Lean.Json.parse prInfo.stdout.trim then
-                  if let .ok owner := json.getObjValAs? Lean.Json "headRepositoryOwner" then
-                    if let .ok login := owner.getObjValAs? String "login" then
-                      if let .ok repoName := json.getObjValAs? String "headRefName" then
-                        if let .ok prNum := json.getObjValAs? Nat "number" then
-                          let repo := s!"{login}/mathlib4"
-                          IO.println s!"Using cache from PR #{prNum} source: {login}/{repoName} (commit {commit.take 8} found in PR ref)"
-                          let useFirst := if login != "leanprover-community" then true else false
-                          return {repo := repo, useFirst := useFirst}
+    -- if !isSpecialBranch then
+    --   let mathlibRemoteName ← findMathlibRemote mathlibDepPath
+    --   let currentCommit ← IO.Process.output
+    --     {cmd := "git", args := #["rev-parse", "HEAD"], cwd := mathlibDepPath}
+    --
+    --   if currentCommit.exitCode == 0 then
+    --     let commit := currentCommit.stdout.trim
+    --     -- Get all PR refs that contain this commit
+    --     let prRefPattern := s!"refs/remotes/{mathlibRemoteName}/pr/*"
+    --     let refsInfo ← IO.Process.output
+    --       {cmd := "git", args := #["for-each-ref", "--contains", commit, prRefPattern, "--format=%(refname)"], cwd := mathlibDepPath}
+    --     -- The code below is for debugging purposes currently
+    --     IO.println s!"`git for-each-ref --contains {commit} {prRefPattern} --format=%(refname)` returned:
+    --     {refsInfo.stdout.trim} with exit code {refsInfo.exitCode} and stderr: {refsInfo.stderr.trim}."
+    --     let refsInfo' ← IO.Process.output
+    --       {cmd := "git", args := #["for-each-ref", "--contains", commit, prRefPattern, "--format=\"%(refname)\""], cwd := mathlibDepPath}
+    --     IO.println s!"`git for-each-ref --contains {commit} {prRefPattern} --format=\"%(refname)\"` returned:
+    --     {refsInfo'.stdout.trim} with exit code {refsInfo'.exitCode} and stderr: {refsInfo'.stderr.trim}."
+    --
+    --     if refsInfo.exitCode == 0 && !refsInfo.stdout.trim.isEmpty then
+    --       let prRefs := refsInfo.stdout.trim.split (· == '\n')
+    --       -- Extract PR numbers from refs like "refs/remotes/upstream/pr/1234"
+    --       for prRef in prRefs do
+    --         if let some prNumber := extractPRNumber prRef then
+    --           -- Get PR details using gh
+    --           let prInfo ← IO.Process.output
+    --             {cmd := "gh", args := #["pr", "view", toString prNumber, "--json", "headRefName,headRepositoryOwner,number"], cwd := mathlibDepPath}
+    --           if prInfo.exitCode == 0 then
+    --             if let .ok json := Lean.Json.parse prInfo.stdout.trim then
+    --               if let .ok owner := json.getObjValAs? Lean.Json "headRepositoryOwner" then
+    --                 if let .ok login := owner.getObjValAs? String "login" then
+    --                   if let .ok repoName := json.getObjValAs? String "headRefName" then
+    --                     if let .ok prNum := json.getObjValAs? Nat "number" then
+    --                       let repo := s!"{login}/mathlib4"
+    --                       IO.println s!"Using cache from PR #{prNum} source: {login}/{repoName} (commit {commit.take 8} found in PR ref)"
+    --                       let useFirst := if login != "leanprover-community" then true else false
+    --                       return {repo := repo, useFirst := useFirst}
 
   -- Fall back to using the remote that the current branch is tracking
   let trackingRemote ← IO.Process.output


### PR DESCRIPTION
Currently the syntax supplied to `for-each-ref` is not valid -- the interpolater needs quotes. So it should never been reached in any circumstance. We comment it out and leave a TODO because there is still some need to for better logic here.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
