### PR TITLE
[Merged by Bors] - feat: add mdifferentiable version of hom bundle smoothness lemmas

### DIFF
--- a/Mathlib/Geometry/Manifold/VectorBundle/Hom.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Hom.lean
@@ -327,7 +327,8 @@ lemma MDifferentiableWithinAt.clm_bundle_apply
     (hϕ : MDifferentiableWithinAt IM (IB.prod 𝓘(𝕜, F₁ →L[𝕜] F₂))
       (fun m ↦ TotalSpace.mk' (F₁ →L[𝕜] F₂) (E := fun (x : B) ↦ (E₁ x →L[𝕜] E₂ x)) (b m) (ϕ m))
       s x)
-    (hv : MDifferentiableWithinAt IM (IB.prod 𝓘(𝕜, F₁)) (fun m ↦ TotalSpace.mk' F₁ (b m) (v m)) s x) :
+    (hv : MDifferentiableWithinAt IM (IB.prod 𝓘(𝕜, F₁))
+      (fun m ↦ TotalSpace.mk' F₁ (b m) (v m)) s x) :
     MDifferentiableWithinAt IM (IB.prod 𝓘(𝕜, F₂))
       (fun m ↦ TotalSpace.mk' F₂ (b m) (ϕ m (v m))) s x := by
   simp only [mdifferentiableWithinAt_hom_bundle] at hϕ

--- a/Mathlib/Geometry/Manifold/VectorBundle/Hom.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Hom.lean
@@ -5,6 +5,7 @@ Authors: Floris van Doorn
 -/
 import Mathlib.Geometry.Manifold.VectorBundle.Basic
 import Mathlib.Topology.VectorBundle.Hom
+import Mathlib.Geometry.Manifold.VectorBundle.MDifferentiable
 
 /-! # Homs of `C^n` vector bundles over the same base space
 
@@ -42,6 +43,8 @@ variable {𝕜 B F₁ F₂ M : Type*} {n : WithTop ℕ∞}
 
 local notation "LE₁E₂" => TotalSpace (F₁ →L[𝕜] F₂) (fun (b : B) ↦ E₁ b →L[𝕜] E₂ b)
 
+section
+
 -- Porting note (https://github.com/leanprover-community/mathlib4/issues/11083):
 -- moved slow parts to separate lemmas
 theorem contMDiffOn_continuousLinearMapCoordChange
@@ -78,7 +81,41 @@ theorem contMDiffAt_hom_bundle (f : M → LE₁E₂) {x₀ : M} :
           (fun x ↦ inCoordinates F₁ E₁ F₂ E₂ (f x₀).1 (f x).1 (f x₀).1 (f x).1 (f x).2) x₀ :=
   contMDiffAt_totalSpace
 
-variable [ContMDiffVectorBundle n F₁ E₁ IB] [ContMDiffVectorBundle n F₂ E₂ IB]
+end
+
+section
+
+theorem mdifferentiableOn_continuousLinearMapCoordChange
+    [ContMDiffVectorBundle 1 F₁ E₁ IB] [ContMDiffVectorBundle 1 F₂ E₂ IB]
+    [MemTrivializationAtlas e₁] [MemTrivializationAtlas e₁']
+    [MemTrivializationAtlas e₂] [MemTrivializationAtlas e₂'] :
+    MDifferentiableOn IB 𝓘(𝕜, (F₁ →L[𝕜] F₂) →L[𝕜] F₁ →L[𝕜] F₂)
+      (continuousLinearMapCoordChange (RingHom.id 𝕜) e₁ e₁' e₂ e₂')
+      (e₁.baseSet ∩ e₂.baseSet ∩ (e₁'.baseSet ∩ e₂'.baseSet)) := by
+  have h₁ := contMDiffOn_coordChangeL (IB := IB) e₁' e₁ (n := 1) |>.mdifferentiableOn le_rfl
+  have h₂ := contMDiffOn_coordChangeL (IB := IB) e₂ e₂' (n := 1) |>.mdifferentiableOn le_rfl
+  refine (h₁.mono ?_).cle_arrowCongr (h₂.mono ?_) <;> mfld_set_tac
+
+variable [∀ x, IsTopologicalAddGroup (E₂ x)] [∀ x, ContinuousSMul 𝕜 (E₂ x)]
+
+theorem mdifferentiableWithinAt_hom_bundle (f : M → LE₁E₂) {s : Set M} {x₀ : M} :
+    MDifferentiableWithinAt IM (IB.prod 𝓘(𝕜, F₁ →L[𝕜] F₂)) f s x₀ ↔
+      MDifferentiableWithinAt IM IB (fun x ↦ (f x).1) s x₀ ∧
+        MDifferentiableWithinAt IM 𝓘(𝕜, F₁ →L[𝕜] F₂)
+          (fun x ↦ inCoordinates F₁ E₁ F₂ E₂ (f x₀).1 (f x).1 (f x₀).1 (f x).1 (f x).2) s x₀ :=
+  mdifferentiableWithinAt_totalSpace IB ..
+
+theorem mdifferentiableAt_hom_bundle (f : M → LE₁E₂) {x₀ : M} :
+    MDifferentiableAt IM (IB.prod 𝓘(𝕜, F₁ →L[𝕜] F₂)) f x₀ ↔
+      MDifferentiableAt IM IB (fun x ↦ (f x).1) x₀ ∧
+        MDifferentiableAt IM 𝓘(𝕜, F₁ →L[𝕜] F₂)
+          (fun x ↦ inCoordinates F₁ E₁ F₂ E₂ (f x₀).1 (f x).1 (f x₀).1 (f x).1 (f x).2) x₀ :=
+  mdifferentiableAt_totalSpace ..
+
+end
+
+variable [∀ x, IsTopologicalAddGroup (E₂ x)] [∀ x, ContinuousSMul 𝕜 (E₂ x)]
+  [ContMDiffVectorBundle n F₁ E₁ IB] [ContMDiffVectorBundle n F₂ E₂ IB]
 
 instance Bundle.ContinuousLinearMap.vectorPrebundle.isContMDiff :
     (Bundle.ContinuousLinearMap.vectorPrebundle (RingHom.id 𝕜) F₁ E₁ F₂ E₂).IsContMDiff IB n where
@@ -276,6 +313,62 @@ lemma ContMDiff.clm_bundle_apply
 
 end OneVariable
 
+section OneVariable'
+
+variable [∀ x, IsTopologicalAddGroup (E₂ x)] [∀ x, ContinuousSMul 𝕜 (E₂ x)]
+  {ϕ : ∀ x, (E₁ (b x) →L[𝕜] E₂ (b x))}
+
+/-- Consider a differentiable map `v : M → E₁` to a vector bundle, over a base map `b : M → B`, and
+linear maps `ϕ m : E₁ (b m) → E₂ (b m)` depending smoothly on `m`.
+One can apply `ϕ m` to `v m`, and the resulting map is differentiable.
+
+We give here a version of this statement within a set at a point. -/
+lemma MDifferentiableWithinAt.clm_bundle_apply
+    (hϕ : MDifferentiableWithinAt IM (IB.prod 𝓘(𝕜, F₁ →L[𝕜] F₂))
+      (fun m ↦ TotalSpace.mk' (F₁ →L[𝕜] F₂) (E := fun (x : B) ↦ (E₁ x →L[𝕜] E₂ x)) (b m) (ϕ m))
+      s x)
+    (hv : MDifferentiableWithinAt IM (IB.prod 𝓘(𝕜, F₁)) (fun m ↦ TotalSpace.mk' F₁ (b m) (v m)) s x) :
+    MDifferentiableWithinAt IM (IB.prod 𝓘(𝕜, F₂))
+      (fun m ↦ TotalSpace.mk' F₂ (b m) (ϕ m (v m))) s x := by
+  simp only [mdifferentiableWithinAt_hom_bundle] at hϕ
+  exact hϕ.2.clm_apply_of_inCoordinates hv hϕ.1
+
+/-- Consider a differentiable map `v : M → E₁` to a vector bundle, over a base map `b : M → B`, and
+linear maps `ϕ m : E₁ (b m) → E₂ (b m)` depending smoothly on `m`.
+One can apply `ϕ m` to `v m`, and the resulting map is differentiable.
+
+We give here a version of this statement at a point. -/
+lemma MDifferentiableAt.clm_bundle_apply
+    (hϕ : MDifferentiableAt IM (IB.prod 𝓘(𝕜, F₁ →L[𝕜] F₂))
+      (fun m ↦ TotalSpace.mk' (F₁ →L[𝕜] F₂) (E := fun (x : B) ↦ (E₁ x →L[𝕜] E₂ x)) (b m) (ϕ m)) x)
+    (hv : MDifferentiableAt IM (IB.prod 𝓘(𝕜, F₁)) (fun m ↦ TotalSpace.mk' F₁ (b m) (v m)) x) :
+    MDifferentiableAt IM (IB.prod 𝓘(𝕜, F₂)) (fun m ↦ TotalSpace.mk' F₂ (b m) (ϕ m (v m))) x :=
+  MDifferentiableWithinAt.clm_bundle_apply hϕ hv
+
+/-- Consider a differentiable map `v : M → E₁` to a vector bundle, over a base map `b : M → B`, and
+linear maps `ϕ m : E₁ (b m) → E₂ (b m)` depending smoothly on `m`.
+One can apply `ϕ m` to `v m`, and the resulting map is differentiable.
+
+We give here a version of this statement on a set. -/
+lemma MDifferentiableOn.clm_bundle_apply
+    (hϕ : MDifferentiableOn IM (IB.prod 𝓘(𝕜, F₁ →L[𝕜] F₂))
+      (fun m ↦ TotalSpace.mk' (F₁ →L[𝕜] F₂) (E := fun (x : B) ↦ (E₁ x →L[𝕜] E₂ x)) (b m) (ϕ m)) s)
+    (hv : MDifferentiableOn IM (IB.prod 𝓘(𝕜, F₁)) (fun m ↦ TotalSpace.mk' F₁ (b m) (v m)) s) :
+    MDifferentiableOn IM (IB.prod 𝓘(𝕜, F₂)) (fun m ↦ TotalSpace.mk' F₂ (b m) (ϕ m (v m))) s :=
+  fun x hx ↦ (hϕ x hx).clm_bundle_apply (hv x hx)
+
+/-- Consider a differentiable map `v : M → E₁` to a vector bundle, over a base map `b : M → B`, and
+linear maps `ϕ m : E₁ (b m) → E₂ (b m)` depending smoothly on `m`.
+One can apply `ϕ m` to `v m`, and the resulting map is differentiable. -/
+lemma MDifferentiable.clm_bundle_apply
+    (hϕ : MDifferentiable IM (IB.prod 𝓘(𝕜, F₁ →L[𝕜] F₂))
+      (fun m ↦ TotalSpace.mk' (F₁ →L[𝕜] F₂) (E := fun (x : B) ↦ (E₁ x →L[𝕜] E₂ x)) (b m) (ϕ m)))
+    (hv : MDifferentiable IM (IB.prod 𝓘(𝕜, F₁)) (fun m ↦ TotalSpace.mk' F₁ (b m) (v m))) :
+    MDifferentiable IM (IB.prod 𝓘(𝕜, F₂)) (fun m ↦ TotalSpace.mk' F₂ (b m) (ϕ m (v m))) :=
+  fun x ↦ (hϕ x).clm_bundle_apply (hv x)
+
+end OneVariable'
+
 section TwoVariables
 
 variable [∀ x, IsTopologicalAddGroup (E₃ x)] [∀ x, ContinuousSMul 𝕜 (E₃ x)]
@@ -340,5 +433,72 @@ lemma ContMDiff.clm_bundle_apply₂
   fun x ↦ (hψ x).clm_bundle_apply₂ (hv x) (hw x)
 
 end TwoVariables
+
+section TwoVariables'
+
+variable [∀ x, IsTopologicalAddGroup (E₃ x)] [∀ x, ContinuousSMul 𝕜 (E₃ x)]
+  {ψ : ∀ x, (E₁ (b x) →L[𝕜] E₂ (b x) →L[𝕜] E₃ (b x))} {w : ∀ x, E₂ (b x)}
+
+/-- Consider differentiable maps `v : M → E₁` and `v : M → E₂` to vector bundles, over a base map
+`b : M → B`, and bilinear maps `ψ m : E₁ (b m) → E₂ (b m) → E₃ (b m)` depending smoothly on `m`.
+One can apply `ψ  m` to `v m` and `w m`, and the resulting map is differentiable.
+
+We give here a version of this statement within a set at a point. -/
+lemma MDifferentiableWithinAt.clm_bundle_apply₂
+    (hψ : MDifferentiableWithinAt IM (IB.prod 𝓘(𝕜, F₁ →L[𝕜] F₂ →L[𝕜] F₃))
+      (fun m ↦ TotalSpace.mk' (F₁ →L[𝕜] F₂ →L[𝕜] F₃)
+      (E := fun (x : B) ↦ (E₁ x →L[𝕜] E₂ x →L[𝕜] E₃ x)) (b m) (ψ m)) s x)
+    (hv : MDifferentiableWithinAt IM (IB.prod 𝓘(𝕜, F₁))
+      (fun m ↦ TotalSpace.mk' F₁ (b m) (v m)) s x)
+    (hw : MDifferentiableWithinAt IM (IB.prod 𝓘(𝕜, F₂))
+      (fun m ↦ TotalSpace.mk' F₂ (b m) (w m)) s x) :
+    MDifferentiableWithinAt IM (IB.prod 𝓘(𝕜, F₃))
+      (fun m ↦ TotalSpace.mk' F₃ (b m) (ψ m (v m) (w m))) s x :=
+  hψ.clm_bundle_apply hv |>.clm_bundle_apply hw
+
+/-- Consider differentiable maps `v : M → E₁` and `v : M → E₂` to vector bundles, over a base map
+`b : M → B`, and bilinear maps `ψ m : E₁ (b m) → E₂ (b m) → E₃ (b m)` depending smoothly on `m`.
+One can apply `ψ  m` to `v m` and `w m`, and the resulting map is differentiable.
+
+We give here a version of this statement at a point. -/
+lemma MDifferentiableAt.clm_bundle_apply₂
+    (hψ : MDifferentiableAt IM (IB.prod 𝓘(𝕜, F₁ →L[𝕜] F₂ →L[𝕜] F₃))
+      (fun m ↦ TotalSpace.mk' (F₁ →L[𝕜] F₂ →L[𝕜] F₃)
+      (E := fun (x : B) ↦ (E₁ x →L[𝕜] E₂ x →L[𝕜] E₃ x)) (b m) (ψ m)) x)
+    (hv : MDifferentiableAt IM (IB.prod 𝓘(𝕜, F₁)) (fun m ↦ TotalSpace.mk' F₁ (b m) (v m)) x)
+    (hw : MDifferentiableAt IM (IB.prod 𝓘(𝕜, F₂)) (fun m ↦ TotalSpace.mk' F₂ (b m) (w m)) x) :
+    MDifferentiableAt IM (IB.prod 𝓘(𝕜, F₃))
+      (fun m ↦ TotalSpace.mk' F₃ (b m) (ψ m (v m) (w m))) x :=
+  MDifferentiableWithinAt.clm_bundle_apply₂ hψ hv hw
+
+/-- Consider differentiable maps `v : M → E₁` and `v : M → E₂` to vector bundles, over a base map
+`b : M → B`, and bilinear maps `ψ m : E₁ (b m) → E₂ (b m) → E₃ (b m)` depending smoothly on `m`.
+One can apply `ψ  m` to `v m` and `w m`, and the resulting map is differentiable.
+
+We give here a version of this statement on a set. -/
+lemma MDifferentiableOn.clm_bundle_apply₂
+    (hψ : MDifferentiableOn IM (IB.prod 𝓘(𝕜, F₁ →L[𝕜] F₂ →L[𝕜] F₃))
+      (fun m ↦ TotalSpace.mk' (F₁ →L[𝕜] F₂ →L[𝕜] F₃)
+      (E := fun (x : B) ↦ (E₁ x →L[𝕜] E₂ x →L[𝕜] E₃ x)) (b m) (ψ m)) s)
+    (hv : MDifferentiableOn IM (IB.prod 𝓘(𝕜, F₁)) (fun m ↦ TotalSpace.mk' F₁ (b m) (v m)) s)
+    (hw : MDifferentiableOn IM (IB.prod 𝓘(𝕜, F₂)) (fun m ↦ TotalSpace.mk' F₂ (b m) (w m)) s) :
+    MDifferentiableOn IM (IB.prod 𝓘(𝕜, F₃))
+      (fun m ↦ TotalSpace.mk' F₃ (b m) (ψ m (v m) (w m))) s :=
+  fun x hx ↦ (hψ x hx).clm_bundle_apply₂ (hv x hx) (hw x hx)
+
+/-- Consider differentiable maps `v : M → E₁` and `v : M → E₂` to vector bundles, over a base map
+`b : M → B`, and bilinear maps `ψ m : E₁ (b m) → E₂ (b m) → E₃ (b m)` depending smoothly on `m`.
+One can apply `ψ  m` to `v m` and `w m`, and the resulting map is differentiable. -/
+lemma MDifferentiable.clm_bundle_apply₂
+    (hψ : MDifferentiable IM (IB.prod 𝓘(𝕜, F₁ →L[𝕜] F₂ →L[𝕜] F₃))
+      (fun m ↦ TotalSpace.mk' (F₁ →L[𝕜] F₂ →L[𝕜] F₃)
+      (E := fun (x : B) ↦ (E₁ x →L[𝕜] E₂ x →L[𝕜] E₃ x)) (b m) (ψ m)))
+    (hv : MDifferentiable IM (IB.prod 𝓘(𝕜, F₁)) (fun m ↦ TotalSpace.mk' F₁ (b m) (v m)))
+    (hw : MDifferentiable IM (IB.prod 𝓘(𝕜, F₂)) (fun m ↦ TotalSpace.mk' F₂ (b m) (w m))) :
+    MDifferentiable IM (IB.prod 𝓘(𝕜, F₃))
+      (fun m ↦ TotalSpace.mk' F₃ (b m) (ψ m (v m) (w m))) :=
+  fun x ↦ (hψ x).clm_bundle_apply₂ (hv x) (hw x)
+
+end TwoVariables'
 
 end


### PR DESCRIPTION
These are necessary to prove that the pairing of bundle sections induced by a smooth Riemannian metric preserves differentiability.

From the path towards geodesics and the Levi-Civita connection.

Co-authored-by: Patrick Massot <patrickmassot@free.fr>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
