### PR TITLE
[Merged by Bors] - feat(Algebra/Order/Monoid): StrictMono.isOrdered(Cancel)Monoid

### DIFF
--- a/Mathlib/Algebra/Order/Monoid/Basic.lean
+++ b/Mathlib/Algebra/Order/Monoid/Basic.lean
@@ -35,7 +35,7 @@ lemma Function.Injective.isOrderedMonoid [IsOrderedMonoid α] [One β] [Mul β]
 
 /-- Pullback an `IsOrderedMonoid` under a strictly monotone map. -/
 @[to_additive "Pullback an `IsOrderedAddMonoid` under a strictly monotone map."]
-lemma StrictMono.isOrderedMonoid' [IsOrderedMonoid α] [CommMonoid β] [LinearOrder β]
+lemma StrictMono.isOrderedMonoid [IsOrderedMonoid α] [CommMonoid β] [LinearOrder β]
     (f : β → α) (hf : StrictMono f) (mul : ∀ x y, f (x * y) = f x * f y) :
     IsOrderedMonoid β where
   mul_le_mul_left _ _ h _ := by
@@ -59,10 +59,10 @@ lemma Function.Injective.isOrderedCancelMonoid [IsOrderedCancelMonoid α] [One �
 
 /-- Pullback an `IsOrderedCancelMonoid` under a strictly monotone map. -/
 @[to_additive "Pullback an `IsOrderedAddCancelMonoid` under a strictly monotone map."]
-lemma StrictMono.isOrderedCancelMonoid' [IsOrderedCancelMonoid α] [CommMonoid β] [LinearOrder β]
+lemma StrictMono.isOrderedCancelMonoid [IsOrderedCancelMonoid α] [CommMonoid β] [LinearOrder β]
     (f : β → α) (hf : StrictMono f) (mul : ∀ x y, f (x * y) = f x * f y) :
     IsOrderedCancelMonoid β where
-  __ := hf.isOrderedMonoid' f mul
+  __ := hf.isOrderedMonoid f mul
   le_of_mul_le_mul_left a b c h := by simpa [← hf.le_iff_le, mul] using h
 
 @[deprecated (since := "2025-04-10")]

--- a/Mathlib/Algebra/Order/Monoid/Basic.lean
+++ b/Mathlib/Algebra/Order/Monoid/Basic.lean
@@ -33,6 +33,15 @@ lemma Function.Injective.isOrderedMonoid [IsOrderedMonoid α] [One β] [Mul β]
   { mul_le_mul_left a b ab c := show f (c * a) ≤ f (c * b) by
       rw [mul, mul]; apply mul_le_mul_left'; exact ab }
 
+/-- Pullback an `IsOrderedMonoid` under a strictly monotone map. -/
+@[to_additive "Pullback an `IsOrderedAddMonoid` under a strictly monotone map."]
+lemma StrictMono.isOrderedMonoid' [IsOrderedMonoid α] [CommMonoid β] [LinearOrder β]
+    (f : β → α) (hf : StrictMono f) (mul : ∀ x y, f (x * y) = f x * f y) :
+    IsOrderedMonoid β where
+  mul_le_mul_left _ _ h _ := by
+    simp_rw [← hf.le_iff_le, mul] at h ⊢
+    simpa using mul_le_mul_left' h _
+
 /-- Pullback an `IsOrderedCancelMonoid` under an injective map. -/
 @[to_additive Function.Injective.isOrderedCancelAddMonoid
     "Pullback an `IsOrderedCancelAddMonoid` under an injective map."]
@@ -47,6 +56,14 @@ lemma Function.Injective.isOrderedCancelMonoid [IsOrderedCancelMonoid α] [One �
   { __ := hf.isOrderedMonoid f one mul npow
     le_of_mul_le_mul_left a b c (bc : f (a * b) ≤ f (a * c)) :=
       (mul_le_mul_iff_left (f a)).1 (by rwa [← mul, ← mul]) }
+
+/-- Pullback an `IsOrderedCancelMonoid` under a strictly monotone map. -/
+@[to_additive "Pullback an `IsOrderedAddCancelMonoid` under a strictly monotone map."]
+lemma StrictMono.isOrderedCancelMonoid' [IsOrderedCancelMonoid α] [CommMonoid β] [LinearOrder β]
+    (f : β → α) (hf : StrictMono f) (mul : ∀ x y, f (x * y) = f x * f y) :
+    IsOrderedCancelMonoid β where
+  __ := hf.isOrderedMonoid' f mul
+  le_of_mul_le_mul_left a b c h := by simpa [← hf.le_iff_le, mul] using h
 
 @[deprecated (since := "2025-04-10")]
 alias Function.Injective.orderedCommMonoid := Function.Injective.isOrderedMonoid

--- a/Mathlib/Algebra/Order/Monoid/WithTop.lean
+++ b/Mathlib/Algebra/Order/Monoid/WithTop.lean
@@ -60,11 +60,3 @@ protected theorem le_add_self [AddCommMagma α] [LE α] [CanonicallyOrderedAdd �
     exact le_add_self
 
 end WithBot
-
-lemma IsOrderedMonoid.comap {G H F : Type*} [CommMonoid G] [CommMonoid H] [LinearOrder G]
-    [PartialOrder H] [IsOrderedMonoid H] [FunLike F G H] [MonoidHomClass F G H]
-    {f : F} (hf : StrictMono f) :
-    IsOrderedMonoid G where
-  mul_le_mul_left _ _ h _ := by
-    simp_rw [← hf.le_iff_le, map_mul] at h ⊢
-    simpa using mul_le_mul_left' h _

--- a/Mathlib/Algebra/Order/Monoid/WithTop.lean
+++ b/Mathlib/Algebra/Order/Monoid/WithTop.lean
@@ -60,3 +60,11 @@ protected theorem le_add_self [AddCommMagma α] [LE α] [CanonicallyOrderedAdd �
     exact le_add_self
 
 end WithBot
+
+lemma IsOrderedMonoid.comap {G H F : Type*} [CommMonoid G] [CommMonoid H] [LinearOrder G]
+    [PartialOrder H] [IsOrderedMonoid H] [FunLike F G H] [MonoidHomClass F G H]
+    {f : F} (hf : StrictMono f) :
+    IsOrderedMonoid G where
+  mul_le_mul_left _ _ h _ := by
+    simp_rw [← hf.le_iff_le, map_mul] at h ⊢
+    simpa using mul_le_mul_left' h _


### PR DESCRIPTION
pullback of `IsOrderedMonoid`

we have `Function.Injective.isOrderedMonoid` but that assumes that the monoid structure and order structure on the domain is also induced by the pullback

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
