### PR TITLE
[Merged by Bors] - chore(Order/WithZero): `OrderIso.withZeroUnits`

### DIFF
--- a/Mathlib/Algebra/Order/GroupWithZero/WithZero.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/WithZero.lean
@@ -78,3 +78,24 @@ instance {α : Type*} [Mul α] [Preorder α] [MulRightMono α] :
         dsimp only at h ⊢
         norm_cast at h ⊢
         exact mul_le_mul_right' h x
+
+section Units
+
+variable {α : Type*} [LinearOrderedCommGroupWithZero α]
+
+open WithZero
+
+lemma WithZero.withZeroUnitsEquiv_strictMono :
+    StrictMono (withZeroUnitsEquiv (G := α)) := by
+  intro a b
+  cases a <;> cases b <;>
+  simp
+
+/-- Given any linearly ordered commutative group with zero `α`, this is the order isomorphism
+between `WithZero αˣ` with `α`. -/
+@[simps!]
+def OrderIso.withZeroUnits : WithZero αˣ ≃o α where
+  __ := withZeroUnitsEquiv
+  map_rel_iff' := WithZero.withZeroUnitsEquiv_strictMono.le_iff_le
+
+end Units

--- a/Mathlib/Algebra/Order/Hom/Monoid.lean
+++ b/Mathlib/Algebra/Order/Hom/Monoid.lean
@@ -971,3 +971,13 @@ def OrderMonoidIso.withZero {G H : Type*}
   invFun e := ⟨MulEquiv.withZero.symm e, fun {a b} ↦ by simp⟩
   left_inv _ := by ext; simp
   right_inv _ := by ext x; cases x <;> simp
+
+/-- Any linearly ordered group with zero is isomorphic to adjoining `0` to the units of itself. -/
+@[simps!]
+def OrderMonoidIso.withZeroUnits {α : Type*} [LinearOrderedCommGroupWithZero α]
+    [DecidablePred (fun a : α ↦ a = 0)] :
+    WithZero αˣ ≃*o α where
+  toMulEquiv := WithZero.withZeroUnitsEquiv
+  map_le_map_iff' {a b} := by
+    cases a <;> cases b <;>
+    simp

--- a/Mathlib/GroupTheory/ArchimedeanDensely.lean
+++ b/Mathlib/GroupTheory/ArchimedeanDensely.lean
@@ -390,16 +390,6 @@ lemma denselyOrdered_units_iff {G₀ : Type*} [LinearOrderedCommGroupWithZero G�
     refine ⟨Units.mk0 z hz'.ne', ?_⟩
     simp [← Units.val_lt_val, hz]
 
-/-- Any linearly ordered group with zero is isomorphic to adjoining `0` to the units of itself. -/
-@[simps!]
-def OrderMonoidIso.withZeroUnits {α : Type*} [LinearOrderedCommGroupWithZero α]
-    [DecidablePred (fun a : α ↦ a = 0)] :
-    WithZero αˣ ≃*o α where
-  toMulEquiv := WithZero.withZeroUnitsEquiv
-  map_le_map_iff' {a b} := by
-    cases a <;> cases b <;>
-    simp
-
 /-- Any nontrivial (has other than 0 and 1) linearly ordered mul-archimedean group with zero is
 either isomorphic (and order-isomorphic) to `ℤᵐ⁰`, or is densely ordered. -/
 lemma LinearOrderedCommGroupWithZero.discrete_or_denselyOrdered (G : Type*)


### PR DESCRIPTION
not bundled because `Algebra/Order/GroupWithZero/WithZero.lean` doesn't import OrderMonoidIso and move `OrderMonoidIso.withZeroUnits` earlier


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
