### PR TITLE
[Merged by Bors] - chore(GroupWithZero/WithZero): use `recZeroCoe` for `WithZero.lift'`

### DIFF
--- a/Mathlib/Algebra/GroupWithZero/WithZero.lean
+++ b/Mathlib/Algebra/GroupWithZero/WithZero.lean
@@ -110,11 +110,9 @@ theorem monoidWithZeroHom_ext ⦃f g : WithZero α →*₀ β⦄
 @[simps! symm_apply_apply]
 nonrec def lift' : (α →* β) ≃ (WithZero α →*₀ β) where
   toFun f :=
-    { toFun := fun
-        | 0 => 0
-        | (a : α) => f a
+    { toFun := recZeroCoe 0 f
       map_zero' := rfl
-      map_one' := map_one f
+      map_one' := by simp
       map_mul' := fun
         | 0, _ => (zero_mul _).symm
         | (_ : α), 0 => (mul_zero _).symm


### PR DESCRIPTION
gives better simps apply lemmas


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
