### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/AffineSpace/AffineSubspace): basic properties of `sInf` and `iInf`

### DIFF
--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
@@ -465,7 +465,7 @@ end affineSpan
 namespace AffineSubspace
 
 variable {k : Type*} {V : Type*} {P : Type*} [Ring k] [AddCommGroup V] [Module k V]
-  [S : AffineSpace V P]
+  [S : AffineSpace V P] {ι : Type*}
 
 instance : CompleteLattice (AffineSubspace k P) :=
   {
@@ -751,6 +751,55 @@ their directions. -/
 theorem direction_inf_of_mem_inf {s₁ s₂ : AffineSubspace k P} {p : P} (h : p ∈ s₁ ⊓ s₂) :
     (s₁ ⊓ s₂).direction = s₁.direction ⊓ s₂.direction :=
   direction_inf_of_mem ((mem_inf_iff p s₁ s₂).1 h).1 ((mem_inf_iff p s₁ s₂).1 h).2
+
+@[simp]
+theorem sInf_coe (t : Set (AffineSubspace k P)) :
+    ((sInf t : AffineSubspace k P) : Set P) = ⋂ s ∈ t, s :=
+  rfl
+
+theorem mem_sInf_iff (p : P) (t : Set (AffineSubspace k P)) : p ∈ sInf t ↔ ∀ s ∈ t, p ∈ s :=
+  Set.mem_iInter₂
+
+theorem direction_sInf (t : Set (AffineSubspace k P)) :
+    direction (sInf t) ≤ ⨅ s ∈ t, s.direction := by
+  simp only [direction_eq_vectorSpan, vectorSpan_def]
+  exact le_iInf₂ fun s hs => Submodule.span_mono <| vsub_self_mono <| biInter_subset_of_mem hs
+
+theorem direction_sInf_of_mem (t : Set (AffineSubspace k P)) (p : P) (h : ∀ s ∈ t, p ∈ s) :
+    direction (sInf t) = ⨅ s ∈ t, s.direction := by
+  apply (direction_sInf t).antisymm
+  intro v hv
+  rw [← vadd_mem_iff_mem_direction v ((mem_sInf_iff p t).mpr h), mem_sInf_iff]
+  intro s hs
+  rw [vadd_mem_iff_mem_direction v (h s hs)]
+  simp only [Submodule.mem_iInf] at hv
+  exact hv s hs
+
+theorem direction_sInf_of_mem_sInf (t : Set (AffineSubspace k P)) (p : P) (h : p ∈ sInf t) :
+    direction (sInf t) = ⨅ s ∈ t, s.direction :=
+  direction_sInf_of_mem t p <| (mem_sInf_iff p t).mp h
+
+@[simp]
+theorem iInf_coe (s : ι → AffineSubspace k P) :
+    ((iInf s : AffineSubspace k P) : Set P) = ⋂ i, s i := by
+  rw [iInf, sInf_coe, Set.biInter_range]
+
+theorem mem_iInf_iff (s : ι → AffineSubspace k P) (p : P) : p ∈ iInf s ↔ ∀ i, p ∈ s i := by
+  rw [iInf, mem_sInf_iff, Set.forall_mem_range]
+
+theorem direction_iInf (s : ι → AffineSubspace k P) :
+    (iInf s).direction ≤ ⨅ i, (s i).direction := by
+  apply (direction_sInf _).trans_eq
+  rw [iInf_range]
+
+theorem direction_iInf_of_mem (s : ι → AffineSubspace k P) (p : P) (h : ∀ i, p ∈ s i) :
+    (iInf s).direction = ⨅ i, (s i).direction := by
+  rw [iInf, direction_sInf_of_mem _ p ?_, iInf_range]
+  rwa [Set.forall_mem_range]
+
+theorem direction_iInf_of_mem_iInf (s : ι → AffineSubspace k P) (p : P) (h : p ∈ iInf s) :
+    (iInf s).direction = ⨅ i, (s i).direction := by
+  rw [iInf, direction_sInf_of_mem_sInf _ p h, iInf_range]
 
 /-- If one affine subspace is less than or equal to another, the same applies to their
 directions. -/

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
@@ -465,7 +465,7 @@ end affineSpan
 namespace AffineSubspace
 
 variable {k : Type*} {V : Type*} {P : Type*} [Ring k] [AddCommGroup V] [Module k V]
-  [S : AffineSpace V P] {ι : Type*}
+  [S : AffineSpace V P] {ι : Sort*}
 
 instance : CompleteLattice (AffineSubspace k P) :=
   {

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
@@ -753,7 +753,7 @@ theorem direction_inf_of_mem_inf {s₁ s₂ : AffineSubspace k P} {p : P} (h : p
   direction_inf_of_mem ((mem_inf_iff p s₁ s₂).1 h).1 ((mem_inf_iff p s₁ s₂).1 h).2
 
 @[simp]
-theorem sInf_coe (t : Set (AffineSubspace k P)) :
+theorem coe_sInf (t : Set (AffineSubspace k P)) :
     ((sInf t : AffineSubspace k P) : Set P) = ⋂ s ∈ t, s :=
   rfl
 
@@ -780,9 +780,9 @@ theorem direction_sInf_of_mem_sInf (t : Set (AffineSubspace k P)) (p : P) (h : p
   direction_sInf_of_mem t p <| (mem_sInf_iff p t).mp h
 
 @[simp]
-theorem iInf_coe (s : ι → AffineSubspace k P) :
+theorem coe_iInf (s : ι → AffineSubspace k P) :
     ((iInf s : AffineSubspace k P) : Set P) = ⋂ i, s i := by
-  rw [iInf, sInf_coe, Set.biInter_range]
+  rw [iInf, coe_sInf, Set.biInter_range]
 
 theorem mem_iInf_iff (s : ι → AffineSubspace k P) (p : P) : p ∈ iInf s ↔ ∀ i, p ∈ s i := by
   rw [iInf, mem_sInf_iff, Set.forall_mem_range]

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
@@ -752,7 +752,7 @@ theorem direction_inf_of_mem_inf {s₁ s₂ : AffineSubspace k P} {p : P} (h : p
     (s₁ ⊓ s₂).direction = s₁.direction ⊓ s₂.direction :=
   direction_inf_of_mem ((mem_inf_iff p s₁ s₂).1 h).1 ((mem_inf_iff p s₁ s₂).1 h).2
 
-@[simp]
+@[simp, norm_cast]
 theorem coe_sInf (t : Set (AffineSubspace k P)) :
     ((sInf t : AffineSubspace k P) : Set P) = ⋂ s ∈ t, s :=
   rfl
@@ -779,7 +779,7 @@ theorem direction_sInf_of_mem_sInf (t : Set (AffineSubspace k P)) (p : P) (h : p
     direction (sInf t) = ⨅ s ∈ t, s.direction :=
   direction_sInf_of_mem t p <| (mem_sInf_iff p t).mp h
 
-@[simp]
+@[simp, norm_cast]
 theorem coe_iInf (s : ι → AffineSubspace k P) :
     ((iInf s : AffineSubspace k P) : Set P) = ⋂ i, s i := by
   rw [iInf, coe_sInf, Set.biInter_range]


### PR DESCRIPTION
These properties are analogous to the existing ones for the binary infimum.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
