### PR TITLE
[Merged by Bors] - chore: use `edist` instead of `dist` in `TendstoInMeasure`

### DIFF
--- a/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
+++ b/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
@@ -11,7 +11,7 @@ import Mathlib.MeasureTheory.Function.LpSpace.Complete
 
 We define convergence in measure which is one of the many notions of convergence in probability.
 A sequence of functions `f` is said to converge in measure to some function `g`
-if for all `ε > 0`, the measure of the set `{x | ε ≤ dist (f i x) (g x)}` tends to 0 as `i`
+if for all `ε > 0`, the measure of the set `{x | ε ≤ edist (f i x) (g x)}` tends to 0 as `i`
 converges along some given filter `l`.
 
 Convergence in measure is most notably used in the formulation of the weak law of large numbers
@@ -50,54 +50,68 @@ variable {α ι κ E : Type*} {m : MeasurableSpace α} {μ : Measure α}
 /-- A sequence of functions `f` is said to converge in measure to some function `g` if for all
 `ε > 0`, the measure of the set `{x | ε ≤ dist (f i x) (g x)}` tends to 0 as `i` converges along
 some given filter `l`. -/
-def TendstoInMeasure [Dist E] {_ : MeasurableSpace α} (μ : Measure α) (f : ι → α → E) (l : Filter ι)
-    (g : α → E) : Prop :=
-  ∀ ε, 0 < ε → Tendsto (fun i => μ { x | ε ≤ dist (f i x) (g x) }) l (𝓝 0)
+def TendstoInMeasure [EDist E] {_ : MeasurableSpace α} (μ : Measure α) (f : ι → α → E)
+    (l : Filter ι) (g : α → E) : Prop :=
+  ∀ ε, 0 < ε → Tendsto (fun i => μ { x | ε ≤ edist (f i x) (g x) }) l (𝓝 0)
+
+theorem tendstoInMeasure_iff_enorm [SeminormedAddCommGroup E] {l : Filter ι} {f : ι → α → E}
+    {g : α → E} :
+    TendstoInMeasure μ f l g ↔
+      ∀ ε, 0 < ε → Tendsto (fun i => μ { x | ε ≤ ‖f i x - g x‖ₑ }) l (𝓝 0) := by
+  simp_rw [TendstoInMeasure, edist_dist, dist_eq_norm, ofReal_norm]
 
 theorem tendstoInMeasure_iff_norm [SeminormedAddCommGroup E] {l : Filter ι} {f : ι → α → E}
     {g : α → E} :
     TendstoInMeasure μ f l g ↔
       ∀ ε, 0 < ε → Tendsto (fun i => μ { x | ε ≤ ‖f i x - g x‖ }) l (𝓝 0) := by
-  simp_rw [TendstoInMeasure, dist_eq_norm]
+  rw [tendstoInMeasure_iff_enorm]
+  refine ⟨fun h ε hε ↦ ?_, fun h ε hε ↦ ?_⟩
+  · convert h (ENNReal.ofReal ε) (ENNReal.ofReal_pos.mpr hε)
+    rw [← ofReal_norm, ENNReal.ofReal_le_ofReal_iff (by positivity)]
+  · by_cases hε_top : ε = ∞
+    · simp only [hε_top, top_le_iff, enorm_ne_top, Set.setOf_false, measure_empty]
+      exact tendsto_const_nhds
+    · lift ε to ℝ≥0 using hε_top
+      exact mod_cast h ε (mod_cast hε)
 
-theorem tendstoInMeasure_iff_tendsto_toNNReal [Dist E] [IsFiniteMeasure μ]
+theorem tendstoInMeasure_iff_tendsto_toNNReal [EDist E] [IsFiniteMeasure μ]
     {f : ι → α → E} {l : Filter ι} {g : α → E} :
     TendstoInMeasure μ f l g ↔
-      ∀ ε, 0 < ε → Tendsto (fun i => (μ { x | ε ≤ dist (f i x) (g x) }).toNNReal) l (𝓝 0) := by
-  have hfin ε i : μ { x | ε ≤ dist (f i x) (g x) } ≠ ⊤ :=
-    measure_ne_top μ {x | ε ≤ dist (f i x) (g x)}
+      ∀ ε, 0 < ε → Tendsto (fun i => (μ { x | ε ≤ edist (f i x) (g x) }).toNNReal) l (𝓝 0) := by
+  have hfin ε i : μ { x | ε ≤ edist (f i x) (g x) } ≠ ⊤ :=
+    measure_ne_top μ {x | ε ≤ edist (f i x) (g x)}
   refine ⟨fun h ε hε ↦ ?_, fun h ε hε ↦ ?_⟩
-  · have hf : (fun i => (μ { x | ε ≤ dist (f i x) (g x) }).toNNReal) =
-        ENNReal.toNNReal ∘ (fun i => (μ { x | ε ≤ dist (f i x) (g x) })) := rfl
+  · have hf : (fun i => (μ { x | ε ≤ edist (f i x) (g x) }).toNNReal) =
+        ENNReal.toNNReal ∘ (fun i ↦ (μ { x | ε ≤ edist (f i x) (g x) })) := rfl
     rw [hf, ENNReal.tendsto_toNNReal_iff' (hfin ε)]
     exact h ε hε
   · rw [← ENNReal.tendsto_toNNReal_iff ENNReal.zero_ne_top (hfin ε)]
     exact h ε hε
 
-lemma TendstoInMeasure.mono [Dist E] {f : ι → α → E} {g : α → E} {u v : Filter ι} (huv : v ≤ u)
+lemma TendstoInMeasure.mono [EDist E] {f : ι → α → E} {g : α → E} {u v : Filter ι} (huv : v ≤ u)
     (hg : TendstoInMeasure μ f u g) : TendstoInMeasure μ f v g :=
   fun ε hε => (hg ε hε).mono_left huv
 
-lemma TendstoInMeasure.comp [Dist E] {f : ι → α → E} {g : α → E} {u : Filter ι}
+lemma TendstoInMeasure.comp [EDist E] {f : ι → α → E} {g : α → E} {u : Filter ι}
     {v : Filter κ} {ns : κ → ι} (hg : TendstoInMeasure μ f u g) (hns : Tendsto ns v u) :
     TendstoInMeasure μ (f ∘ ns) v g := fun ε hε ↦ (hg ε hε).comp hns
 
 namespace TendstoInMeasure
 
-variable [Dist E] {l : Filter ι} {f f' : ι → α → E} {g g' : α → E}
+variable [EDist E] {l : Filter ι} {f f' : ι → α → E} {g g' : α → E}
 
 protected theorem congr' (h_left : ∀ᶠ i in l, f i =ᵐ[μ] f' i) (h_right : g =ᵐ[μ] g')
     (h_tendsto : TendstoInMeasure μ f l g) : TendstoInMeasure μ f' l g' := by
   intro ε hε
   suffices
-    (fun i => μ { x | ε ≤ dist (f' i x) (g' x) }) =ᶠ[l] fun i => μ { x | ε ≤ dist (f i x) (g x) } by
+    (fun i ↦ μ { x | ε ≤ edist (f' i x) (g' x) }) =ᶠ[l] fun i ↦ μ { x | ε ≤ edist (f i x) (g x) } by
     rw [tendsto_congr' this]
     exact h_tendsto ε hε
   filter_upwards [h_left] with i h_ae_eq
   refine measure_congr ?_
   filter_upwards [h_ae_eq, h_right] with x hxf hxg
   rw [eq_iff_iff]
-  change ε ≤ dist (f' i x) (g' x) ↔ ε ≤ dist (f i x) (g x)
+  change ε ≤ edist (f' i x) (g' x) ↔ ε ≤ edist (f i x) (g x)
   rw [hxg, hxf]
 
 protected theorem congr (h_left : ∀ i, f i =ᵐ[μ] f' i) (h_right : g =ᵐ[μ] g')
@@ -116,7 +130,7 @@ end TendstoInMeasure
 
 section ExistsSeqTendstoAe
 
-variable [MetricSpace E]
+variable [EMetricSpace E]
 variable {f : ℕ → α → E} {g : α → E}
 
 /-- Auxiliary lemma for `tendstoInMeasure_of_tendsto_ae`. -/
@@ -130,13 +144,13 @@ theorem tendstoInMeasure_of_tendsto_ae_of_stronglyMeasurable [IsFiniteMeasure μ
   rw [gt_iff_lt, ENNReal.coe_pos, ← NNReal.coe_pos] at hδ
   obtain ⟨t, _, ht, hunif⟩ := tendstoUniformlyOn_of_ae_tendsto' hf hg hfg hδ
   rw [ENNReal.ofReal_coe_nnreal] at ht
-  rw [Metric.tendstoUniformlyOn_iff] at hunif
+  rw [EMetric.tendstoUniformlyOn_iff] at hunif
   obtain ⟨N, hN⟩ := eventually_atTop.1 (hunif ε hε)
   refine ⟨N, fun n hn => ?_⟩
-  suffices { x : α | ε ≤ dist (f n x) (g x) } ⊆ t from (measure_mono this).trans ht
+  suffices { x : α | ε ≤ edist (f n x) (g x) } ⊆ t from (measure_mono this).trans ht
   rw [← Set.compl_subset_compl]
   intro x hx
-  rw [Set.mem_compl_iff, Set.notMem_setOf_iff, dist_comm, not_le]
+  rw [Set.mem_compl_iff, Set.notMem_setOf_iff, edist_comm, not_le]
   exact hN n hn x hx
 
 /-- Convergence a.e. implies convergence in measure in a finite measure space. -/
@@ -155,8 +169,8 @@ theorem tendstoInMeasure_of_tendsto_ae [IsFiniteMeasure μ] (hf : ∀ n, AEStron
 namespace ExistsSeqTendstoAe
 
 theorem exists_nat_measure_lt_two_inv (hfg : TendstoInMeasure μ f atTop g) (n : ℕ) :
-    ∃ N, ∀ m ≥ N, μ { x | (2 : ℝ)⁻¹ ^ n ≤ dist (f m x) (g x) } ≤ (2⁻¹ : ℝ≥0∞) ^ n := by
-  specialize hfg ((2⁻¹ : ℝ) ^ n) (by simp only [inv_pos, zero_lt_two, pow_pos])
+    ∃ N, ∀ m ≥ N, μ { x | (2 : ℝ≥0∞)⁻¹ ^ n ≤ edist (f m x) (g x) } ≤ (2⁻¹ : ℝ≥0∞) ^ n := by
+  specialize hfg ((2⁻¹ : ℝ≥0∞) ^ n) (ENNReal.pow_pos (by simp) _)
   rw [ENNReal.tendsto_atTop_zero] at hfg
   exact hfg ((2 : ℝ≥0∞)⁻¹ ^ n) (pos_iff_ne_zero.mpr fun h_zero => by simpa using pow_eq_zero h_zero)
 
@@ -178,7 +192,7 @@ theorem seqTendstoAeSeq_succ (hfg : TendstoInMeasure μ f atTop g) {n : ℕ} :
 
 theorem seqTendstoAeSeq_spec (hfg : TendstoInMeasure μ f atTop g) (n k : ℕ)
     (hn : seqTendstoAeSeq hfg n ≤ k) :
-    μ { x | (2 : ℝ)⁻¹ ^ n ≤ dist (f k x) (g x) } ≤ (2 : ℝ≥0∞)⁻¹ ^ n := by
+    μ { x | (2 : ℝ≥0∞)⁻¹ ^ n ≤ edist (f k x) (g x) } ≤ (2 : ℝ≥0∞)⁻¹ ^ n := by
   cases n
   · exact Classical.choose_spec (exists_nat_measure_lt_two_inv hfg 0) k hn
   · exact Classical.choose_spec
@@ -203,14 +217,16 @@ theorem TendstoInMeasure.exists_seq_tendsto_ae (hfg : TendstoInMeasure μ f atTo
 
     On the other hand, as `s` is precisely the set for which `f (ns k)`
     doesn't converge to `g`, `f (ns k)` converges almost everywhere to `g` as required. -/
-  have h_lt_ε_real : ∀ (ε : ℝ) (_ : 0 < ε), ∃ k : ℕ, 2 * (2 : ℝ)⁻¹ ^ k < ε := by
+  have h_lt_ε_real : ∀ (ε : ℝ≥0∞) (_ : 0 < ε), ∃ k : ℕ, 2 * (2 : ℝ≥0∞)⁻¹ ^ k < ε := by
     intro ε hε
-    obtain ⟨k, h_k⟩ : ∃ k : ℕ, (2 : ℝ)⁻¹ ^ k < ε := exists_pow_lt_of_lt_one hε (by norm_num)
+    obtain ⟨k, h_k⟩ : ∃ k : ℕ, (2 : ℝ≥0∞)⁻¹ ^ k < ε := ENNReal.exists_inv_two_pow_lt hε.ne'
     refine ⟨k + 1, (le_of_eq ?_).trans_lt h_k⟩
-    rw [pow_add]; ring
+    rw [pow_add, pow_one, mul_comm, mul_assoc, ENNReal.inv_mul_cancel, mul_one]
+    · positivity
+    · simp
   set ns := ExistsSeqTendstoAe.seqTendstoAeSeq hfg
   use ns
-  let S := fun k => { x | (2 : ℝ)⁻¹ ^ k ≤ dist (f (ns k) x) (g x) }
+  let S := fun k => { x | (2 : ℝ≥0∞)⁻¹ ^ k ≤ edist (f (ns k) x) (g x) }
   have hμS_le : ∀ k, μ (S k) ≤ (2 : ℝ≥0∞)⁻¹ ^ k :=
     fun k => ExistsSeqTendstoAe.seqTendstoAeSeq_spec hfg k (ns k) le_rfl
   set s := Filter.atTop.limsup S with hs
@@ -218,7 +234,7 @@ theorem TendstoInMeasure.exists_seq_tendsto_ae (hfg : TendstoInMeasure μ f atTo
     refine measure_limsup_atTop_eq_zero (ne_top_of_le_ne_top ?_ (ENNReal.tsum_le_tsum hμS_le))
     simpa only [ENNReal.tsum_geometric, ENNReal.one_sub_inv_two, inv_inv] using ENNReal.ofNat_ne_top
   have h_tendsto : ∀ x ∈ sᶜ, Tendsto (fun i => f (ns i) x) atTop (𝓝 (g x)) := by
-    refine fun x hx => Metric.tendsto_atTop.mpr fun ε hε => ?_
+    refine fun x hx => EMetric.tendsto_atTop.mpr fun ε hε => ?_
     rw [hs, limsup_eq_iInf_iSup_of_nat] at hx
     simp only [S, Set.iSup_eq_iUnion, Set.iInf_eq_iInter, Set.compl_iInter, Set.compl_iUnion,
       Set.mem_iUnion, Set.mem_iInter, Set.mem_compl_iff, Set.mem_setOf_eq, not_le] at hx
@@ -226,16 +242,14 @@ theorem TendstoInMeasure.exists_seq_tendsto_ae (hfg : TendstoInMeasure μ f atTo
     obtain ⟨k, hk_lt_ε⟩ := h_lt_ε_real ε hε
     refine ⟨max N (k - 1), fun n hn_ge => lt_of_le_of_lt ?_ hk_lt_ε⟩
     specialize hNx n ((le_max_left _ _).trans hn_ge)
-    have h_inv_n_le_k : (2 : ℝ)⁻¹ ^ n ≤ 2 * (2 : ℝ)⁻¹ ^ k := by
-      rw [mul_comm, ← inv_mul_le_iff₀' (zero_lt_two' ℝ)]
-      conv_lhs =>
-        congr
-        rw [← pow_one (2 : ℝ)⁻¹]
-      rw [← pow_add, add_comm]
-      exact pow_le_pow_of_le_one (one_div (2 : ℝ) ▸ one_half_pos.le)
-        (inv_le_one_of_one_le₀ one_le_two)
-        ((le_tsub_add.trans (add_le_add_right (le_max_right _ _) 1)).trans
-          (add_le_add_right hn_ge 1))
+    have h_inv_n_le_k : (2 : ℝ≥0∞)⁻¹ ^ n ≤ 2 * (2 : ℝ≥0∞)⁻¹ ^ k := by
+      nth_rw 2 [← pow_one (2 : ℝ≥0∞)]
+      rw [mul_comm, ← ENNReal.inv_pow, ← ENNReal.inv_pow, ENNReal.inv_le_iff_le_mul, ← mul_assoc,
+        mul_comm (_ ^ n), mul_assoc, ← ENNReal.inv_le_iff_le_mul, inv_inv, ← pow_add]
+      · gcongr
+        · norm_num
+        · omega
+      all_goals simp
     exact le_trans hNx.le h_inv_n_le_k
   rw [ae_iff]
   refine ⟨ExistsSeqTendstoAe.seqTendstoAeSeq_strictMono hfg, measure_mono_null (fun x => ?_) hμs⟩
@@ -268,7 +282,7 @@ theorem exists_seq_tendstoInMeasure_atTop_iff [IsFiniteMeasure μ]
   push_neg at *
   obtain ⟨ε, hε, h2⟩ := h1
   obtain ⟨δ, ns, hδ, hns, h3⟩ : ∃ (δ : ℝ≥0) (ns : ℕ → ℕ), 0 < δ ∧ StrictMono ns ∧
-      ∀ n, δ ≤ (μ {x | ε ≤ dist (f (ns n) x) (g x)}).toNNReal := by
+      ∀ n, δ ≤ (μ {x | ε ≤ edist (f (ns n) x) (g x)}).toNNReal := by
     obtain ⟨s, hs, h4⟩ := not_tendsto_iff_exists_frequently_notMem.1 h2
     obtain ⟨δ, hδ, h5⟩ := NNReal.nhds_zero_basis.mem_iff.1 hs
     obtain ⟨ns, hns, h6⟩ := extraction_of_frequently_atTop h4
@@ -318,23 +332,23 @@ theorem tendstoInMeasure_of_tendsto_eLpNorm_of_stronglyMeasurable (hp_ne_zero : 
     {l : Filter ι} (hfg : Tendsto (fun n => eLpNorm (f n - g) p μ) l (𝓝 0)) :
     TendstoInMeasure μ f l g := by
   intro ε hε
-  replace hfg := ENNReal.Tendsto.const_mul
-    (Tendsto.ennrpow_const p.toReal hfg) (Or.inr <| @ENNReal.ofReal_ne_top (1 / ε ^ p.toReal))
+  by_cases hε_top : ε = ∞
+  · simp only [hε_top, top_le_iff, edist_ne_top, Set.setOf_false, measure_empty]
+    exact tendsto_const_nhds
+  replace hfg := ENNReal.Tendsto.const_mul (a := 1 / ε ^ p.toReal)
+    (Tendsto.ennrpow_const p.toReal hfg) (Or.inr <| by simp [hε.ne'])
   simp only [mul_zero,
     ENNReal.zero_rpow_of_pos (ENNReal.toReal_pos hp_ne_zero hp_ne_top)] at hfg
   rw [ENNReal.tendsto_nhds_zero] at hfg ⊢
   intro δ hδ
   refine (hfg δ hδ).mono fun n hn => ?_
   refine le_trans ?_ hn
-  rw [ENNReal.ofReal_div_of_pos (Real.rpow_pos_of_pos hε _), ENNReal.ofReal_one, mul_comm,
-    mul_one_div, ENNReal.le_div_iff_mul_le _ (Or.inl ENNReal.ofReal_ne_top), mul_comm]
-  · rw [← ENNReal.ofReal_rpow_of_pos hε]
-    convert mul_meas_ge_le_pow_eLpNorm' μ hp_ne_zero hp_ne_top ((hf n).sub hg).aestronglyMeasurable
-        (ENNReal.ofReal ε)
-    rw [dist_eq_norm, ← ENNReal.ofReal_le_ofReal_iff (norm_nonneg _), ofReal_norm_eq_enorm]
-    exact Iff.rfl
-  · rw [Ne, ENNReal.ofReal_eq_zero, not_le]
-    exact Or.inl (Real.rpow_pos_of_pos hε _)
+  rw [one_div, ← ENNReal.inv_mul_le_iff, inv_inv]
+  · convert mul_meas_ge_le_pow_eLpNorm' μ hp_ne_zero hp_ne_top
+      ((hf n).sub hg).aestronglyMeasurable ε using 6
+    simp [edist_dist, dist_eq_norm, ← ofReal_norm]
+  · simp [hε_top]
+  · simp [hε.ne']
 
 /-- This lemma is superseded by `MeasureTheory.tendstoInMeasure_of_tendsto_eLpNorm` where we
 allow `p = ∞`. -/
@@ -355,22 +369,20 @@ theorem tendstoInMeasure_of_tendsto_eLpNorm_top {E} [NormedAddCommGroup E] {f : 
     {g : α → E} {l : Filter ι} (hfg : Tendsto (fun n => eLpNorm (f n - g) ∞ μ) l (𝓝 0)) :
     TendstoInMeasure μ f l g := by
   intro δ hδ
+  by_cases hδ_top : δ = ∞
+  · simp only [hδ_top, top_le_iff, edist_ne_top, Set.setOf_false, measure_empty]
+    exact tendsto_const_nhds
   simp only [eLpNorm_exponent_top, eLpNormEssSup] at hfg
   rw [ENNReal.tendsto_nhds_zero] at hfg ⊢
   intro ε hε
-  specialize hfg (ENNReal.ofReal δ / 2)
-      (ENNReal.div_pos_iff.2 ⟨(ENNReal.ofReal_pos.2 hδ).ne.symm, ENNReal.ofNat_ne_top⟩)
+  specialize hfg (δ / 2) (ENNReal.div_pos_iff.2 ⟨hδ.ne', ENNReal.ofNat_ne_top⟩)
   refine hfg.mono fun n hn => ?_
-  simp only [gt_iff_lt,
-    Pi.sub_apply] at *
-  have : essSup (fun x : α => (‖f n x - g x‖₊ : ℝ≥0∞)) μ < ENNReal.ofReal δ :=
-    lt_of_le_of_lt hn
-      (ENNReal.half_lt_self (ENNReal.ofReal_pos.2 hδ).ne.symm ENNReal.ofReal_lt_top.ne)
+  simp only [Pi.sub_apply] at *
+  have : essSup (fun x : α => ‖f n x - g x‖ₑ) μ < δ :=
+    hn.trans_lt (ENNReal.half_lt_self hδ.ne' hδ_top)
   refine ((le_of_eq ?_).trans (ae_lt_of_essSup_lt this).le).trans hε.le
   congr with x
-  simp only [ENNReal.ofReal_le_iff_le_toReal ENNReal.coe_lt_top.ne, ENNReal.coe_toReal, not_lt,
-    coe_nnnorm, Set.mem_setOf_eq, Set.mem_compl_iff]
-  rw [← dist_eq_norm (f n x) (g x)]
+  simp [edist_dist, dist_eq_norm, ofReal_norm]
 
 /-- Convergence in Lp implies convergence in measure. -/
 theorem tendstoInMeasure_of_tendsto_eLpNorm {l : Filter ι} (hp_ne_zero : p ≠ 0)

--- a/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
+++ b/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
@@ -54,25 +54,33 @@ def TendstoInMeasure [EDist E] {_ : MeasurableSpace α} (μ : Measure α) (f : �
     (l : Filter ι) (g : α → E) : Prop :=
   ∀ ε, 0 < ε → Tendsto (fun i => μ { x | ε ≤ edist (f i x) (g x) }) l (𝓝 0)
 
+lemma tendstoInMeasure_of_ne_top [PseudoMetricSpace E] {_ : MeasurableSpace α} {μ : Measure α}
+    {f : ι → α → E} {l : Filter ι} {g : α → E}
+    (h : ∀ ε, 0 < ε → ε ≠ ∞ → Tendsto (fun i => μ { x | ε ≤ edist (f i x) (g x) }) l (𝓝 0)) :
+    TendstoInMeasure μ f l g := by
+  intro ε hε
+  by_cases hε_top : ε = ∞
+  · simp only [hε_top, top_le_iff, edist_ne_top, Set.setOf_false, measure_empty]
+    exact tendsto_const_nhds
+  · exact h ε hε hε_top
+
 theorem tendstoInMeasure_iff_enorm [SeminormedAddCommGroup E] {l : Filter ι} {f : ι → α → E}
     {g : α → E} :
     TendstoInMeasure μ f l g ↔
-      ∀ ε, 0 < ε → Tendsto (fun i => μ { x | ε ≤ ‖f i x - g x‖ₑ }) l (𝓝 0) := by
-  simp_rw [TendstoInMeasure, edist_eq_enorm_sub]
+      ∀ ε, 0 < ε → ε ≠ ∞ → Tendsto (fun i => μ { x | ε ≤ ‖f i x - g x‖ₑ }) l (𝓝 0) := by
+  simp_rw [← edist_eq_enorm_sub]
+  exact ⟨fun h ε hε hε_top ↦ h ε hε, tendstoInMeasure_of_ne_top⟩
 
 theorem tendstoInMeasure_iff_norm [SeminormedAddCommGroup E] {l : Filter ι} {f : ι → α → E}
     {g : α → E} :
     TendstoInMeasure μ f l g ↔
       ∀ ε, 0 < ε → Tendsto (fun i => μ { x | ε ≤ ‖f i x - g x‖ }) l (𝓝 0) := by
   rw [tendstoInMeasure_iff_enorm]
-  refine ⟨fun h ε hε ↦ ?_, fun h ε hε ↦ ?_⟩
-  · convert h (ENNReal.ofReal ε) (ENNReal.ofReal_pos.mpr hε)
+  refine ⟨fun h ε hε ↦ ?_, fun h ε hε hε_top ↦ ?_⟩
+  · convert h (ENNReal.ofReal ε) (ENNReal.ofReal_pos.mpr hε) (by finiteness)
     rw [← ofReal_norm, ENNReal.ofReal_le_ofReal_iff (by positivity)]
-  · by_cases hε_top : ε = ∞
-    · simp only [hε_top, top_le_iff, enorm_ne_top, Set.setOf_false, measure_empty]
-      exact tendsto_const_nhds
-    · lift ε to ℝ≥0 using hε_top
-      exact mod_cast h ε (mod_cast hε)
+  · lift ε to ℝ≥0 using hε_top
+    exact mod_cast h ε (mod_cast hε)
 
 theorem tendstoInMeasure_iff_tendsto_toNNReal [EDist E] [IsFiniteMeasure μ]
     {f : ι → α → E} {l : Filter ι} {g : α → E} :
@@ -298,7 +306,7 @@ end ExistsSeqTendstoAe
 section TendstoInMeasureUnique
 
 /-- The limit in measure is ae unique. -/
-theorem tendstoInMeasure_ae_unique [MetricSpace E] {g h : α → E} {f : ι → α → E} {u : Filter ι}
+theorem tendstoInMeasure_ae_unique [EMetricSpace E] {g h : α → E} {f : ι → α → E} {u : Filter ι}
     [NeBot u] [IsCountablyGenerated u] (hg : TendstoInMeasure μ f u g)
     (hh : TendstoInMeasure μ f u h) : g =ᵐ[μ] h := by
   obtain ⟨ns, h1, h1'⟩ := hg.exists_seq_tendsto_ae'
@@ -331,10 +339,7 @@ theorem tendstoInMeasure_of_tendsto_eLpNorm_of_stronglyMeasurable (hp_ne_zero : 
     (hp_ne_top : p ≠ ∞) (hf : ∀ n, StronglyMeasurable (f n)) (hg : StronglyMeasurable g)
     {l : Filter ι} (hfg : Tendsto (fun n => eLpNorm (f n - g) p μ) l (𝓝 0)) :
     TendstoInMeasure μ f l g := by
-  intro ε hε
-  by_cases hε_top : ε = ∞
-  · simp only [hε_top, top_le_iff, edist_ne_top, Set.setOf_false, measure_empty]
-    exact tendsto_const_nhds
+  refine tendstoInMeasure_of_ne_top fun ε hε hε_top ↦ ?_
   replace hfg := ENNReal.Tendsto.const_mul (a := 1 / ε ^ p.toReal)
     (Tendsto.ennrpow_const p.toReal hfg) (Or.inr <| by simp [hε.ne'])
   simp only [mul_zero,
@@ -368,10 +373,7 @@ Lp-convergence for all `p ≠ 0`. -/
 theorem tendstoInMeasure_of_tendsto_eLpNorm_top {E} [NormedAddCommGroup E] {f : ι → α → E}
     {g : α → E} {l : Filter ι} (hfg : Tendsto (fun n => eLpNorm (f n - g) ∞ μ) l (𝓝 0)) :
     TendstoInMeasure μ f l g := by
-  intro δ hδ
-  by_cases hδ_top : δ = ∞
-  · simp only [hδ_top, top_le_iff, edist_ne_top, Set.setOf_false, measure_empty]
-    exact tendsto_const_nhds
+  refine tendstoInMeasure_of_ne_top fun δ hδ hδ_top ↦ ?_
   simp only [eLpNorm_exponent_top, eLpNormEssSup] at hfg
   rw [ENNReal.tendsto_nhds_zero] at hfg ⊢
   intro ε hε

--- a/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
+++ b/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
@@ -58,7 +58,7 @@ theorem tendstoInMeasure_iff_enorm [SeminormedAddCommGroup E] {l : Filter ι} {f
     {g : α → E} :
     TendstoInMeasure μ f l g ↔
       ∀ ε, 0 < ε → Tendsto (fun i => μ { x | ε ≤ ‖f i x - g x‖ₑ }) l (𝓝 0) := by
-  simp_rw [TendstoInMeasure, edist_dist, dist_eq_norm, ofReal_norm]
+  simp_rw [TendstoInMeasure, edist_eq_enorm_sub]
 
 theorem tendstoInMeasure_iff_norm [SeminormedAddCommGroup E] {l : Filter ι} {f : ι → α → E}
     {g : α → E} :
@@ -346,7 +346,7 @@ theorem tendstoInMeasure_of_tendsto_eLpNorm_of_stronglyMeasurable (hp_ne_zero : 
   rw [one_div, ← ENNReal.inv_mul_le_iff, inv_inv]
   · convert mul_meas_ge_le_pow_eLpNorm' μ hp_ne_zero hp_ne_top
       ((hf n).sub hg).aestronglyMeasurable ε using 6
-    simp [edist_dist, dist_eq_norm, ← ofReal_norm]
+    simp [edist_eq_enorm_sub]
   · simp [hε_top]
   · simp [hε.ne']
 
@@ -382,7 +382,7 @@ theorem tendstoInMeasure_of_tendsto_eLpNorm_top {E} [NormedAddCommGroup E] {f : 
     hn.trans_lt (ENNReal.half_lt_self hδ.ne' hδ_top)
   refine ((le_of_eq ?_).trans (ae_lt_of_essSup_lt this).le).trans hε.le
   congr with x
-  simp [edist_dist, dist_eq_norm, ofReal_norm]
+  simp [edist_eq_enorm_sub]
 
 /-- Convergence in Lp implies convergence in measure. -/
 theorem tendstoInMeasure_of_tendsto_eLpNorm {l : Filter ι} (hp_ne_zero : p ≠ 0)

--- a/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
+++ b/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
@@ -54,8 +54,7 @@ def TendstoInMeasure [EDist E] {_ : MeasurableSpace α} (μ : Measure α) (f : �
     (l : Filter ι) (g : α → E) : Prop :=
   ∀ ε, 0 < ε → Tendsto (fun i => μ { x | ε ≤ edist (f i x) (g x) }) l (𝓝 0)
 
-lemma tendstoInMeasure_of_ne_top [PseudoMetricSpace E] {_ : MeasurableSpace α} {μ : Measure α}
-    {f : ι → α → E} {l : Filter ι} {g : α → E}
+lemma tendstoInMeasure_of_ne_top [PseudoMetricSpace E] {f : ι → α → E} {l : Filter ι} {g : α → E}
     (h : ∀ ε, 0 < ε → ε ≠ ∞ → Tendsto (fun i => μ { x | ε ≤ edist (f i x) (g x) }) l (𝓝 0)) :
     TendstoInMeasure μ f l g := by
   intro ε hε
@@ -71,16 +70,21 @@ theorem tendstoInMeasure_iff_enorm [SeminormedAddCommGroup E] {l : Filter ι} {f
   simp_rw [← edist_eq_enorm_sub]
   exact ⟨fun h ε hε hε_top ↦ h ε hε, tendstoInMeasure_of_ne_top⟩
 
+lemma tendstoInMeasure_iff_dist [PseudoMetricSpace E] {f : ι → α → E} {l : Filter ι} {g : α → E} :
+    TendstoInMeasure μ f l g
+      ↔ ∀ ε, 0 < ε → Tendsto (fun i => μ { x | ε ≤ dist (f i x) (g x) }) l (𝓝 0) := by
+  refine ⟨fun h ε hε ↦ ?_, fun h ↦ ?_⟩
+  · convert h (ENNReal.ofReal ε) (ENNReal.ofReal_pos.mpr hε) with i a
+    rw [edist_dist, ENNReal.ofReal_le_ofReal_iff (by positivity)]
+  · refine tendstoInMeasure_of_ne_top fun ε hε hε_top ↦ ?_
+    convert h ε.toReal (ENNReal.toReal_pos hε.ne' hε_top) with i a
+    rw [edist_dist, ENNReal.le_ofReal_iff_toReal_le hε_top (by positivity)]
+
 theorem tendstoInMeasure_iff_norm [SeminormedAddCommGroup E] {l : Filter ι} {f : ι → α → E}
     {g : α → E} :
     TendstoInMeasure μ f l g ↔
       ∀ ε, 0 < ε → Tendsto (fun i => μ { x | ε ≤ ‖f i x - g x‖ }) l (𝓝 0) := by
-  rw [tendstoInMeasure_iff_enorm]
-  refine ⟨fun h ε hε ↦ ?_, fun h ε hε hε_top ↦ ?_⟩
-  · convert h (ENNReal.ofReal ε) (ENNReal.ofReal_pos.mpr hε) (by finiteness)
-    rw [← ofReal_norm, ENNReal.ofReal_le_ofReal_iff (by positivity)]
-  · lift ε to ℝ≥0 using hε_top
-    exact mod_cast h ε (mod_cast hε)
+  simp_rw [tendstoInMeasure_iff_dist, dist_eq_norm_sub]
 
 theorem tendstoInMeasure_iff_tendsto_toNNReal [EDist E] [IsFiniteMeasure μ]
     {f : ι → α → E} {l : Filter ι} {g : α → E} :


### PR DESCRIPTION
With this change, we can use `TendstoInMeasure` in an extended metric space.

Useful for the Brownian motion project.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
