### PR TITLE
feat(LinearAlgebra/OnSup): extend linear maps to sums of modules

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4112,6 +4112,7 @@ import Mathlib.LinearAlgebra.Multilinear.DFinsupp
 import Mathlib.LinearAlgebra.Multilinear.FiniteDimensional
 import Mathlib.LinearAlgebra.Multilinear.Pi
 import Mathlib.LinearAlgebra.Multilinear.TensorProduct
+import Mathlib.LinearAlgebra.OnSup
 import Mathlib.LinearAlgebra.Orientation
 import Mathlib.LinearAlgebra.PID
 import Mathlib.LinearAlgebra.PerfectPairing.Basic

--- a/Mathlib/LinearAlgebra/OnSup.lean
+++ b/Mathlib/LinearAlgebra/OnSup.lean
@@ -42,8 +42,8 @@ variable {R M : Type*} [Ring R] [AddCommGroup M] [Module R M] {P Q : Submodule R
 /-- If `P` and `Q` are two `R`-submodules of `M`, then the quotient
   `(P × Q) / ker (fun ((p, q) : P × Q) ↦ p + q)` is isomorphic to `P ⊔ Q` as an `R`-module. -/
 noncomputable def Submodule.quotientCoprodAddEquiv :
-    ((P × Q) ⧸ (ker ((inclusion (le_sup_left (b := Q))).coprod
-      (inclusion (le_sup_right (a := P)))))) ≃ₗ[R] (P + Q) :=
+    ((P × Q) ⧸ ker ((inclusion le_sup_left).coprod (inclusion le_sup_right) : _ →ₗ[R] ↥(P ⊔ Q)))
+      ≃ₗ[R] (P + Q) :=
   quotKerEquivOfSurjective _ (by
     rw [← range_eq_top, eq_top_iff]
     rintro ⟨x, hx⟩ _

--- a/Mathlib/LinearAlgebra/OnSup.lean
+++ b/Mathlib/LinearAlgebra/OnSup.lean
@@ -4,30 +4,31 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Antoine Chambert-Loir, María Inés de Frutos-Fernández
 -/
 
+import Mathlib.Algebra.Module.Submodule.Lattice
 import Mathlib.Algebra.Module.Submodule.Pointwise
 import Mathlib.LinearAlgebra.BilinearMap
 import Mathlib.LinearAlgebra.Isomorphisms
 
 /-! # Extending linear maps to sums of modules
 
-Let `A` be a ring, `X, Y` be `A`-modules, and `M, N` be `A`-submodules of `X`.
+Let `R` be a ring, `M, N` be `A`-modules, and `P, Q` be `A`-submodules of `X`.
 
-Given two linear maps `f : M →ₗ[A] Y` and `g : N →ₗ[A] Y` that agree on `M ∩ N`, there is a unique
-linear map `M + N →ₗ[A] Y` that simultaneously extends `f` and `g`.
+Given two linear maps `f : P →ₗ[A] N` and `g : Q →ₗ[A] N` that agree on `P ⊓ Q`,
+there is a unique linear map `P ⊔ Q →ₗ[R] N` that simultaneously extends `f` and `g`.
 
 ## Main definitions
-* `Submodule.quotientCoprodAddEquiv`: if `M` and `N` are two `A`-submodules of `X`, then the
-  quotient `(M × N) / ker (fun ((m, n) : M × N) ↦ m + n)` is isomorphic to `M + N` as an `A`-module.
-* `LinearMap.onSup`: given two linear maps `f : M →ₗ[A] Y` and `g : N →ₗ[A] Y` that agree on
-  `M ∩ N`, this is the linear map `M + N →ₗ[A] Y` that simultaneously extends `f` and `g`.
-* `LinearMap.onSupEquiv`: the bijection between the set of linear maps `M + N →ₗ[A] Y` and the
-  set of pairs of linear maps `(M →ₗ[A] Y) × (N →ₗ[A] Y))` that agree on the intersection `M ⊓ N`.
-* `LinearMap.onSupLinearEquiv`: the `A`-linear equivalence between the module of linear maps
-  `M + N →ₗ[A] Y` and the module of pairs of linear maps `(M →ₗ[A] Y) × (N →ₗ[A] Y))` that agree
-  on the intersection `M ⊓ N`. This requires `A` to be commutative.
+* `Submodule.quotientCoprodAddEquiv`: if `P` and `Q` are two `R`-submodules of `M`, then the
+  quotient `(P × Q) / ker (fun ((p, q) : P × Q) ↦ p + q)` is isomorphic to `P ⊔ Q` as an `R`-module.
+* `LinearMap.onSup`: given two linear maps `f : P →ₗ[R] N` and `g : Q →ₗ[R] N` that agree on
+  `P ⊓ Q`, this is the linear map `P ⊔ Q →ₗ[R] N` that simultaneously extends `f` and `g`.
+* `LinearMap.onSupEquiv`: the bijection between the set of linear maps `P + Q →ₗ[R] N` and the
+  set of pairs of linear maps `(P →ₗ[R] N) × (Q →ₗ[R] N))` that agree on the intersection `P ⊓ Q`.
+* `LinearMap.onSupLinearEquiv`: the `R`-linear equivalence between the module of linear maps
+  `P ⊔ Q →ₗ[R] N` and the module of pairs of linear maps `(P →ₗ[R] N) × (Q →ₗ[R] N))` that agree
+  on the intersection `M ⊓ N`. This requires `R` to be commutative.
 
 ## Main results
-* `LinearMap.onSup_unique` : if `u : M + N →ₗ[A] Y` extends both `f` and `g`, then it agrees
+* `LinearMap.onSup_unique` : if `u : P ⊔ R →ₗ[R] N` extends both `f` and `g`, then it agrees
   with `LinearMap.onSup`.
 
 -/
@@ -36,13 +37,13 @@ section onSup
 
 open Function LinearEquiv LinearMap Submodule
 
-variable {A X : Type*} [Ring A] [AddCommGroup X] [Module A X] {M N : Submodule A X}
+variable {R M : Type*} [Ring R] [AddCommGroup M] [Module R M] {P Q : Submodule R M}
 
-/-- If `M` and `N` are two `A`-submodules of `X`, then the quotient
-  `(M × N) / ker (fun ((m, n) : M × N) ↦ m + n)` is isomorphic to `M + N` as an `A`-module. -/
+/-- If `P` and `Q` are two `R`-submodules of `M`, then the quotient
+  `(P × Q) / ker (fun ((p, q) : P × Q) ↦ p + q)` is isomorphic to `P ⊔ Q` as an `R`-module. -/
 noncomputable def Submodule.quotientCoprodAddEquiv :
-    ((M × N) ⧸ (ker ((inclusion (le_sup_left (b := N))).coprod
-      (inclusion (le_sup_right (a := M)))))) ≃ₗ[A] (M + N) :=
+    ((P × Q) ⧸ (ker ((inclusion (le_sup_left (b := Q))).coprod
+      (inclusion (le_sup_right (a := P)))))) ≃ₗ[R] (P + Q) :=
   quotKerEquivOfSurjective _ (by
     rw [← range_eq_top, eq_top_iff]
     rintro ⟨x, hx⟩ _
@@ -52,114 +53,117 @@ noncomputable def Submodule.quotientCoprodAddEquiv :
 
 namespace LinearMap
 
-variable {Y : Type*} [AddCommGroup Y] [Module A Y] {f : M →ₗ[A] Y} {g : N →ₗ[A] Y}
+variable {N : Type*} [AddCommGroup N] [Module R N] {f : P →ₗ[R] N} {g : Q →ₗ[R] N}
 
-/-- Given two linear maps `f : M →ₗ[A] Y` and `g : N →ₗ[A] Y` that agree on `M ∩ N`, this is
-the linear map `M + N →ₗ[A] Y` that simultaneously extends `f` and `g`. -/
-noncomputable def onSup (h : ∀ x (hM : x ∈ M) (hN : x ∈ N), f ⟨x, hM⟩ = g ⟨x, hN⟩) :
-    M + N →ₗ[A] Y := by
-  apply comp ?_ quotientCoprodAddEquiv.symm.toLinearMap
-  apply (ker _).liftQ (f.coprod g)
+/-- Given two linear maps `f : P →ₗ[R] N` and `g : Q →ₗ[R] N` that agree on `P ⊓ Q`, this is
+the linear map `P ⊔ Q →ₗ[R] N` that simultaneously extends `f` and `g`. -/
+noncomputable def onSup
+    -- (h : ∀ x (hP : x ∈ P) (hQ : x ∈ Q), f ⟨x, hP⟩ = g ⟨x, hQ⟩) :
+    (h : f ∘ₗ inclusion inf_le_left = g ∘ₗ inclusion inf_le_right) :
+    ↥(P ⊔ Q) →ₗ[R] N := by
+  apply comp ((ker _).liftQ (f.coprod g) ?_) quotientCoprodAddEquiv.symm.toLinearMap
   rintro ⟨⟨x, hx⟩, ⟨y, hy⟩⟩ hxy
   simp only [mem_ker, coprod_apply, add_eq_zero_iff_eq_neg, ← Subtype.coe_inj, coe_inclusion,
     NegMemClass.coe_neg] at hxy
   simp only [mem_ker, coprod_apply, add_eq_zero_iff_eq_neg, ← map_neg]
-  have hneg : - (⟨y, hy⟩ : N) = ⟨-y, N.neg_mem hy⟩ := by simp [← Subtype.coe_inj]
-  simp_rw [hneg, hxy]
-  exact h (-y) (hxy ▸ hx) (N.neg_mem hy)
+  have hx' : x ∈ P ⊓ Q := ⟨hx, by simp [hxy, hy]⟩
+  rw [show ⟨x, hx⟩ = inclusion inf_le_left ⟨x , hx'⟩ by simp [← Subtype.coe_inj]]
+  rw [show -⟨y, hy⟩ = inclusion inf_le_right ⟨x, hx'⟩ by simp [← Subtype.coe_inj, hxy]]
+  simp only [← LinearMap.comp_apply, h]
 
-theorem onSup_apply_left (h : ∀ x (hM : x ∈ M) (hN : x ∈ N), f ⟨x, hM⟩ = g ⟨x, hN⟩)
-    {x : X} (hx : x ∈ M) : onSup h ⟨x, le_sup_left (b := N) hx⟩ = f ⟨x, hx⟩ := by
-  have h : (quotientCoprodAddEquiv (M := M) (N := N)).symm ⟨x, le_sup_left (b := N) hx⟩ =
-      Submodule.Quotient.mk ⟨⟨x, hx⟩, (0 : N)⟩ := by
-    rw [symm_apply_eq]
-    simp only [add_eq_sup, quotientCoprodAddEquiv, quotKerEquivOfSurjective, trans_apply,
-      ofTop_apply, quotKerEquivRange_apply_mk, coprod_apply, map_zero, add_zero, inclusion_apply]
+theorem onSup_apply_left
+    (h : f ∘ₗ inclusion inf_le_left = g ∘ₗ inclusion inf_le_right)
+    {x : M} (hx : x ∈ P) : onSup h ⟨x, le_sup_left (b := Q) hx⟩ = f ⟨x, hx⟩ := by
+  have h : (quotientCoprodAddEquiv (P := P) (Q := Q)).symm ⟨x, le_sup_left (b := Q) hx⟩ =
+      Submodule.Quotient.mk ⟨⟨x, hx⟩, (0 : Q)⟩ := by
+    simp [symm_apply_eq, quotientCoprodAddEquiv, quotKerEquivOfSurjective, inclusion_apply]
   simp only [add_eq_sup, onSup, comp_apply] at h ⊢
   simp [h, liftQ_apply]
 
-theorem onSup_apply_right (h : ∀ x (hM : x ∈ M) (hN : x ∈ N), f ⟨x, hM⟩ = g ⟨x, hN⟩)
-    {x} (hx : x ∈ N) : onSup h ⟨x, le_sup_right (a := M) hx⟩ = g ⟨x, hx⟩ := by
-  have h : (quotientCoprodAddEquiv (M := M) (N := N)).symm ⟨x, le_sup_right (a := M) hx⟩ =
-      Submodule.Quotient.mk ⟨(0 : M), ⟨x, hx⟩⟩ := by
-    rw [symm_apply_eq]
-    simp only [add_eq_sup, quotientCoprodAddEquiv, quotKerEquivOfSurjective, trans_apply,
-      ofTop_apply, quotKerEquivRange_apply_mk, coprod_apply, map_zero, zero_add, inclusion_apply]
+theorem onSup_apply_right
+    (h : f ∘ₗ inclusion inf_le_left = g ∘ₗ inclusion inf_le_right)
+    {x} (hx : x ∈ Q) : onSup h ⟨x, le_sup_right (a := P) hx⟩ = g ⟨x, hx⟩ := by
+  have h : (quotientCoprodAddEquiv (P := P) (Q := Q)).symm ⟨x, le_sup_right (a := P) hx⟩ =
+      Submodule.Quotient.mk ⟨(0 : P), ⟨x, hx⟩⟩ := by
+    simp [symm_apply_eq, quotientCoprodAddEquiv, quotKerEquivOfSurjective, inclusion_apply]
   simp only [add_eq_sup, onSup, comp_apply] at h ⊢
   simp [h, liftQ_apply]
 
-theorem onSup_apply (h : ∀ x (hM : x ∈ M) (hN : x ∈ N), f ⟨x, hM⟩ = g ⟨x, hN⟩)
-    {x y} (hx : x ∈ M) (hy : y ∈ N) :
+theorem onSup_apply
+    (h : f ∘ₗ inclusion inf_le_left = g ∘ₗ inclusion inf_le_right)
+    {x y} (hx : x ∈ P) (hy : y ∈ Q) :
     onSup h ⟨x + y, add_mem_sup hx hy⟩ = f ⟨x, hx⟩ + g ⟨y, hy⟩ := by
-  rw [← onSup_apply_left h hx, ← onSup_apply_right h hy, ← map_add, AddMemClass.mk_add_mk]
+  simp [← onSup_apply_left h hx, ← onSup_apply_right h hy, ← map_add]
 
-theorem onSup_comp_left (h : ∀ x (hM : x ∈ M) (hN : x ∈ N), f ⟨x, hM⟩ = g ⟨x, hN⟩) :
+theorem onSup_comp_left (h : f ∘ₗ inclusion inf_le_left = g ∘ₗ inclusion inf_le_right) :
     (onSup h).comp (inclusion le_sup_left) = f := by
   ext ⟨x, hx⟩
-  rw [← onSup_apply_left h, comp_apply, inclusion_apply]
+  simp [← onSup_apply_left h, inclusion_apply]
 
-theorem onSup_comp_right (h : ∀ x (hM : x ∈ M) (hN : x ∈ N), f ⟨x, hM⟩ = g ⟨x, hN⟩) :
+theorem onSup_comp_right (h : f ∘ₗ inclusion inf_le_left = g ∘ₗ inclusion inf_le_right) :
     (onSup h).comp (inclusion le_sup_right) = g := by
   ext ⟨x, hx⟩
-  rw [← onSup_apply_right h, comp_apply, inclusion_apply]
+  simp [← onSup_apply_right h, inclusion_apply]
 
-theorem onSup_unique (h : ∀ x (hM : x ∈ M) (hN : x ∈ N), f ⟨x, hM⟩ = g ⟨x, hN⟩) {u : M + N →ₗ[A] Y}
-    (huf : u.comp (inclusion le_sup_left) = f) (hug : u.comp (inclusion le_sup_right) = g) :
-    u = onSup h := by
+@[ext]
+theorem sup_ext {f g : ↥(P ⊔ Q) →ₗ[R] N}
+    (left : f.comp (inclusion le_sup_left) = g.comp (inclusion le_sup_left))
+    (right : f.comp (inclusion le_sup_right) = g.comp (inclusion le_sup_right)) :
+    f = g := by
   ext ⟨x, hx⟩
-  obtain ⟨y, hy, z, hz, heq⟩ := mem_sup.mp hx
-  have heq : (⟨x, hx⟩ : M + N) = ⟨y, le_sup_left (b := N) hy⟩ + ⟨z, le_sup_right (a := M) hz⟩ := by
-    simp [heq]
-  rw [heq, map_add, map_add, onSup_apply_left h hy, onSup_apply_right h hz]
-  simp only [add_eq_sup, LinearMap.ext_iff, comp_apply, inclusion_apply,
-    Subtype.forall] at huf hug ⊢
-  rw [huf y hy, hug z hz]
+  obtain ⟨y, z, hx'⟩ := Submodule.mem_sup'.mp hx
+  suffices (⟨x, hx⟩ : ↥(P ⊔ Q)) = inclusion le_sup_left y + inclusion le_sup_right z by
+    simp only [this, map_add, ← LinearMap.comp_apply, left, right]
+  simp only [← Subtype.coe_inj, coe_add, coe_inclusion, hx']
 
+theorem onSup_unique
+    (h : f ∘ₗ inclusion inf_le_left = g ∘ₗ inclusion inf_le_right)
+    {u : ↥(P ⊔ Q) →ₗ[R] N}
+    (huf : u.comp (inclusion le_sup_left) = f) (hug : u.comp (inclusion le_sup_right) = g) :
+    onSup h = u := by
+  ext ⟨x, hx⟩ <;>
+    simp only [huf, hug, ← onSup_apply_left h, ← onSup_apply_right h,
+      coe_comp, Function.comp_apply] <;>
+    congr
 
 variable (M N Y)
 
-/-- The bijection between the set of maps `M + N →ₗ[A] Y` and the set of pairs of maps
-  `(M →ₗ[A] Y) × (N →ₗ[A] Y))` that agree on the intersection `M ⊓ N`. -/
-noncomputable def onSupEquiv : (M + N →ₗ[A] Y) ≃
-  {(fg : (M →ₗ[A] Y) × (N →ₗ[A] Y)) | fg.1.comp (inclusion inf_le_left) =
-    fg.2.comp (inclusion inf_le_right)} := by
-  apply Equiv.ofBijective (fun fg ↦ ⟨⟨fg.comp (inclusion (le_sup_left (a := M) (b := N))),
-      fg.comp (inclusion (le_sup_right (a := M) (b := N)))⟩, by ext; simp [inclusion_apply]⟩)
-  · constructor
-    · intros f g hfg
-      simp only [Set.coe_setOf, Set.mem_setOf_eq, add_eq_sup, Subtype.mk.injEq, Prod.mk.injEq,
-        LinearMap.ext_iff, coe_comp, Function.comp_apply, inclusion_apply] at hfg
-      ext ⟨mn, hmn⟩
-      simp only [add_eq_sup, sup_eq_range, mem_range] at hmn
-      obtain ⟨mn, rfl⟩ := hmn
-      have heq : (⟨(mn.1 : X) + (mn.2 : X), hmn⟩ : M + N) =
-        ⟨mn.1, le_sup_left (a := M) mn.1.2⟩ + ⟨mn.2, le_sup_right (a := M) mn.2.2⟩ := rfl
-      simp only [add_eq_sup, coprod_apply, subtype_apply]
-      rw [heq, map_add, map_add, hfg.1 mn.1, hfg.2 mn.2]
-    · rintro ⟨fg, hfg⟩
-      have h : ∀ x (hM : x ∈ M) (hN : x ∈ N), fg.1 ⟨x, hM⟩ = fg.2 ⟨x, hN⟩ := by
-        simp only [Set.mem_setOf_eq] at hfg
-        intro x hxM hxN
-        have hf1 : fg.1 (⟨x, hxM⟩ : M) = (fg.1 ∘ₗ (inclusion inf_le_left)) ⟨x, ⟨hxM, hxN⟩⟩ := rfl
-        rw [hf1, hfg]
-        rfl
-      use onSup h
-      simp only [Set.coe_setOf, Set.mem_setOf_eq, add_eq_sup, Subtype.mk.injEq]
-      rw [onSup_comp_left, onSup_comp_right]
+/-- The bijection between the set of maps `P ⊔ Q →ₗ[R] N` and the set of pairs of maps
+  `(P →ₗ[R] N) × (Q →ₗ[R] N))` that agree on the intersection `P ⊓ Q`. -/
+noncomputable def onSupEquiv : (↥(P ⊔ Q) →ₗ[R] N) ≃
+    {(fg : (P →ₗ[R] N) × (Q →ₗ[R] N)) | fg.1.comp (inclusion inf_le_left) =
+      fg.2.comp (inclusion inf_le_right)} where
+  toFun u := ⟨⟨u.comp (inclusion le_sup_left), u.comp (inclusion le_sup_right)⟩, rfl⟩
+  invFun h := onSup h.prop
+  left_inv u := by
+    simp only
+    apply onSup_unique h <;>
+      ext <;> rfl
+  right_inv h := by
+    ext ⟨x, hx⟩ <;> simp
+    · rw [← onSup_apply_left h.prop hx]; rfl
+    · rw [← onSup_apply_right h.prop hx]; rfl
 
 section Comm
 
-variable {A X Y : Type*} [CommRing A] [AddCommGroup X] [Module A X]
-  [AddCommGroup Y] [Module A Y] (M N : Submodule A X)
+variable {R M N : Type*} [CommRing R] [AddCommGroup M] [Module R M]
+  [AddCommGroup N] [Module R N] (P Q : Submodule R M)
 
-/-- The `A`-linear equivalence between the module of linear maps `M + N →ₗ[A] Y` and the module of
-  pairs of linear maps `(M →ₗ[A] Y) × (N →ₗ[A] Y))` that agree on the intersection `M ⊓ N`. -/
-noncomputable def onSupLinearEquiv : (M + N →ₗ[A] Y) ≃ₗ[A] eqLocus
-    ((lcomp A Y (inclusion (inf_le_left (a := M) (b := N)))).comp (fst A _ _))
-    ((lcomp A Y (inclusion (inf_le_right (a := M) (b := N)))).comp (snd A _ _)) :=
-  ofBijective (codRestrict _ ((lcomp A Y (inclusion le_sup_left)).prod
-      (lcomp A Y (inclusion le_sup_right))) (fun _ ↦ by ext; simp [inclusion_apply]))
-    (onSupEquiv M N Y).bijective
+noncomputable example : (P + Q →ₗ[R] N) ≃ₗ[R] eqLocus
+        ((lcomp R N (inclusion (inf_le_left (a := P) (b := Q)))).comp (fst R _ _))
+    ((lcomp R N (inclusion (inf_le_right (a := P) (b := Q)))).comp (snd R _ _)) :=
+  ofBijective (codRestrict _ ((lcomp R N (inclusion le_sup_left)).prod
+      (lcomp R N (inclusion le_sup_right))) (fun _ ↦ by ext; simp [inclusion_apply]))
+    (onSupEquiv M N).bijective
+
+/-- The `R`-linear equivalence between the module of linear maps `P ⊔ Q →ₗ[R] N` and the module of
+  pairs of linear maps `(P →ₗ[R] N) × (Q →ₗ[R] N))` that agree on the intersection `P ⊓ Q`. -/
+noncomputable def onSupLinearEquiv : (↥(P ⊔ Q) →ₗ[R] N) ≃ₗ[R] eqLocus
+    ((lcomp R N (inclusion (inf_le_left (a := P) (b := Q)))).comp (fst R _ _))
+    ((lcomp R N (inclusion (inf_le_right (a := P) (b := Q)))).comp (snd R _ _)) := {
+  onSupEquiv M N (P := P) (Q := Q) (R := R) with
+  map_add' u v := by ext <;> rfl
+  map_smul' r u := by ext <;> rfl }
 
 end Comm
 

--- a/Mathlib/LinearAlgebra/OnSup.lean
+++ b/Mathlib/LinearAlgebra/OnSup.lean
@@ -44,12 +44,10 @@ variable {R M : Type*} [Ring R] [AddCommGroup M] [Module R M] {P Q : Submodule R
 noncomputable def Submodule.quotientCoprodAddEquiv :
     ((P × Q) ⧸ ker ((inclusion le_sup_left).coprod (inclusion le_sup_right) : _ →ₗ[R] ↥(P ⊔ Q)))
       ≃ₗ[R] (P + Q) :=
-  quotKerEquivOfSurjective _ (by
-    rw [← range_eq_top, eq_top_iff]
-    rintro ⟨x, hx⟩ _
+  quotKerEquivOfSurjective _ <| by
+    rintro ⟨x, hx⟩
     obtain ⟨y, hy, z, hz, rfl⟩ := mem_sup.mp hx
-    use ⟨⟨y, hy⟩, ⟨z, hz⟩⟩
-    simp [coprod_apply, ← Subtype.coe_inj, coe_add, coe_inclusion])
+    exact ⟨⟨⟨y, hy⟩, ⟨z, hz⟩⟩, rfl⟩
 
 namespace LinearMap
 
@@ -57,9 +55,7 @@ variable {N : Type*} [AddCommGroup N] [Module R N] {f : P →ₗ[R] N} {g : Q �
 
 /-- Given two linear maps `f : P →ₗ[R] N` and `g : Q →ₗ[R] N` that agree on `P ⊓ Q`, this is
 the linear map `↥(P ⊔ Q) →ₗ[R] N` that simultaneously extends `f` and `g`. -/
-noncomputable def onSup
-    -- (h : ∀ x (hP : x ∈ P) (hQ : x ∈ Q), f ⟨x, hP⟩ = g ⟨x, hQ⟩) :
-    (h : f ∘ₗ inclusion inf_le_left = g ∘ₗ inclusion inf_le_right) :
+noncomputable def onSup (h : f ∘ₗ inclusion inf_le_left = g ∘ₗ inclusion inf_le_right) :
     ↥(P ⊔ Q) →ₗ[R] N := by
   apply comp ((ker _).liftQ (f.coprod g) ?_) quotientCoprodAddEquiv.symm.toLinearMap
   rintro ⟨⟨x, hx⟩, ⟨y, hy⟩⟩ hxy
@@ -71,8 +67,7 @@ noncomputable def onSup
   rw [show -⟨y, hy⟩ = inclusion inf_le_right ⟨x, hx'⟩ by simp [← Subtype.coe_inj, hxy]]
   simp only [← LinearMap.comp_apply, h]
 
-theorem onSup_apply_left
-    (h : f ∘ₗ inclusion inf_le_left = g ∘ₗ inclusion inf_le_right)
+theorem onSup_apply_left (h : f ∘ₗ inclusion inf_le_left = g ∘ₗ inclusion inf_le_right)
     {x : M} (hx : x ∈ P) : onSup h ⟨x, le_sup_left (b := Q) hx⟩ = f ⟨x, hx⟩ := by
   have h : (quotientCoprodAddEquiv (P := P) (Q := Q)).symm ⟨x, le_sup_left (b := Q) hx⟩ =
       Submodule.Quotient.mk ⟨⟨x, hx⟩, (0 : Q)⟩ := by
@@ -80,8 +75,7 @@ theorem onSup_apply_left
   simp only [add_eq_sup, onSup, comp_apply] at h ⊢
   simp [h, liftQ_apply]
 
-theorem onSup_apply_right
-    (h : f ∘ₗ inclusion inf_le_left = g ∘ₗ inclusion inf_le_right)
+theorem onSup_apply_right (h : f ∘ₗ inclusion inf_le_left = g ∘ₗ inclusion inf_le_right)
     {x} (hx : x ∈ Q) : onSup h ⟨x, le_sup_right (a := P) hx⟩ = g ⟨x, hx⟩ := by
   have h : (quotientCoprodAddEquiv (P := P) (Q := Q)).symm ⟨x, le_sup_right (a := P) hx⟩ =
       Submodule.Quotient.mk ⟨(0 : P), ⟨x, hx⟩⟩ := by
@@ -89,17 +83,18 @@ theorem onSup_apply_right
   simp only [add_eq_sup, onSup, comp_apply] at h ⊢
   simp [h, liftQ_apply]
 
-theorem onSup_apply
-    (h : f ∘ₗ inclusion inf_le_left = g ∘ₗ inclusion inf_le_right)
+theorem onSup_apply (h : f ∘ₗ inclusion inf_le_left = g ∘ₗ inclusion inf_le_right)
     {x y} (hx : x ∈ P) (hy : y ∈ Q) :
     onSup h ⟨x + y, add_mem_sup hx hy⟩ = f ⟨x, hx⟩ + g ⟨y, hy⟩ := by
   simp [← onSup_apply_left h hx, ← onSup_apply_right h hy, ← map_add]
 
+@[simp]
 theorem onSup_comp_left (h : f ∘ₗ inclusion inf_le_left = g ∘ₗ inclusion inf_le_right) :
     (onSup h).comp (inclusion le_sup_left) = f := by
   ext ⟨x, hx⟩
   simp [← onSup_apply_left h, inclusion_apply]
 
+@[simp]
 theorem onSup_comp_right (h : f ∘ₗ inclusion inf_le_left = g ∘ₗ inclusion inf_le_right) :
     (onSup h).comp (inclusion le_sup_right) = g := by
   ext ⟨x, hx⟩
@@ -116,12 +111,10 @@ theorem sup_ext {f g : ↥(P ⊔ Q) →ₗ[R] N}
     simp only [this, map_add, ← LinearMap.comp_apply, left, right]
   simp only [← Subtype.coe_inj, coe_add, coe_inclusion, hx']
 
-theorem onSup_unique
-    (h : f ∘ₗ inclusion inf_le_left = g ∘ₗ inclusion inf_le_right)
-    {u : ↥(P ⊔ Q) →ₗ[R] N}
-    (huf : u.comp (inclusion le_sup_left) = f) (hug : u.comp (inclusion le_sup_right) = g) :
-    onSup h = u := by
-  ext : 1 <;> simp [huf, hug, onSup_comp_left, onSup_comp_right]
+theorem onSup_unique (h : f ∘ₗ inclusion inf_le_left = g ∘ₗ inclusion inf_le_right)
+    {u : ↥(P ⊔ Q) →ₗ[R] N} (huf : u.comp (inclusion le_sup_left) = f)
+    (hug : u.comp (inclusion le_sup_right) = g) :
+    onSup h = u := by ext : 1 <;> simp [huf, hug]
 
 variable (M N Y)
 
@@ -134,24 +127,14 @@ noncomputable def onSupEquiv : (↥(P ⊔ Q) →ₗ[R] N) ≃
   invFun h := onSup h.prop
   left_inv u := by
     simp only
-    apply onSup_unique h <;>
+    apply onSup_unique <;>
       ext <;> rfl
-  right_inv h := by
-    ext ⟨x, hx⟩ <;> simp
-    · rw [← onSup_apply_left h.prop hx]; rfl
-    · rw [← onSup_apply_right h.prop hx]; rfl
+  right_inv h := by ext ⟨x, hx⟩ <;> simp
 
 section Comm
 
 variable {R M N : Type*} [CommRing R] [AddCommGroup M] [Module R M]
   [AddCommGroup N] [Module R N] (P Q : Submodule R M)
-
-noncomputable example : (P + Q →ₗ[R] N) ≃ₗ[R] eqLocus
-        ((lcomp R N (inclusion (inf_le_left (a := P) (b := Q)))).comp (fst R _ _))
-    ((lcomp R N (inclusion (inf_le_right (a := P) (b := Q)))).comp (snd R _ _)) :=
-  ofBijective (codRestrict _ ((lcomp R N (inclusion le_sup_left)).prod
-      (lcomp R N (inclusion le_sup_right))) (fun _ ↦ by ext; simp [inclusion_apply]))
-    (onSupEquiv M N).bijective
 
 /-- The `R`-linear equivalence between the module of linear maps `↥(P ⊔ Q) →ₗ[R] N` and the module
 of pairs of linear maps `(P →ₗ[R] N) × (Q →ₗ[R] N))` that agree on the intersection `P ⊓ Q`. -/

--- a/Mathlib/LinearAlgebra/OnSup.lean
+++ b/Mathlib/LinearAlgebra/OnSup.lean
@@ -153,8 +153,8 @@ noncomputable example : (P + Q →ₗ[R] N) ≃ₗ[R] eqLocus
       (lcomp R N (inclusion le_sup_right))) (fun _ ↦ by ext; simp [inclusion_apply]))
     (onSupEquiv M N).bijective
 
-/-- The `R`-linear equivalence between the module of linear maps `↥(P ⊔ Q) →ₗ[R] N` and the module of
-  pairs of linear maps `(P →ₗ[R] N) × (Q →ₗ[R] N))` that agree on the intersection `P ⊓ Q`. -/
+/-- The `R`-linear equivalence between the module of linear maps `↥(P ⊔ Q) →ₗ[R] N` and the module
+of pairs of linear maps `(P →ₗ[R] N) × (Q →ₗ[R] N))` that agree on the intersection `P ⊓ Q`. -/
 noncomputable def onSupLinearEquiv : (↥(P ⊔ Q) →ₗ[R] N) ≃ₗ[R] eqLocus
     ((lcomp R N (inclusion (inf_le_left (a := P) (b := Q)))).comp (fst R _ _))
     ((lcomp R N (inclusion (inf_le_right (a := P) (b := Q)))).comp (snd R _ _)) := {

--- a/Mathlib/LinearAlgebra/OnSup.lean
+++ b/Mathlib/LinearAlgebra/OnSup.lean
@@ -121,10 +121,7 @@ theorem onSup_unique
     {u : ↥(P ⊔ Q) →ₗ[R] N}
     (huf : u.comp (inclusion le_sup_left) = f) (hug : u.comp (inclusion le_sup_right) = g) :
     onSup h = u := by
-  ext ⟨x, hx⟩ <;>
-    simp only [huf, hug, ← onSup_apply_left h, ← onSup_apply_right h,
-      coe_comp, Function.comp_apply] <;>
-    congr
+  ext : 1 <;> simp [huf, hug, onSup_comp_left, onSup_comp_right]
 
 variable (M N Y)
 

--- a/Mathlib/LinearAlgebra/OnSup.lean
+++ b/Mathlib/LinearAlgebra/OnSup.lean
@@ -14,17 +14,17 @@ import Mathlib.LinearAlgebra.Isomorphisms
 Let `R` be a ring, `M, N` be `A`-modules, and `P, Q` be `A`-submodules of `X`.
 
 Given two linear maps `f : P →ₗ[A] N` and `g : Q →ₗ[A] N` that agree on `P ⊓ Q`,
-there is a unique linear map `P ⊔ Q →ₗ[R] N` that simultaneously extends `f` and `g`.
+there is a unique linear map `↥(P ⊔ Q) →ₗ[R] N` that simultaneously extends `f` and `g`.
 
 ## Main definitions
 * `Submodule.quotientCoprodAddEquiv`: if `P` and `Q` are two `R`-submodules of `M`, then the
   quotient `(P × Q) / ker (fun ((p, q) : P × Q) ↦ p + q)` is isomorphic to `P ⊔ Q` as an `R`-module.
 * `LinearMap.onSup`: given two linear maps `f : P →ₗ[R] N` and `g : Q →ₗ[R] N` that agree on
-  `P ⊓ Q`, this is the linear map `P ⊔ Q →ₗ[R] N` that simultaneously extends `f` and `g`.
+  `P ⊓ Q`, this is the linear map `↥(P ⊔ Q) →ₗ[R] N` that simultaneously extends `f` and `g`.
 * `LinearMap.onSupEquiv`: the bijection between the set of linear maps `P + Q →ₗ[R] N` and the
   set of pairs of linear maps `(P →ₗ[R] N) × (Q →ₗ[R] N))` that agree on the intersection `P ⊓ Q`.
 * `LinearMap.onSupLinearEquiv`: the `R`-linear equivalence between the module of linear maps
-  `P ⊔ Q →ₗ[R] N` and the module of pairs of linear maps `(P →ₗ[R] N) × (Q →ₗ[R] N))` that agree
+  `↥(P ⊔ Q) →ₗ[R] N` and the module of pairs of linear maps `(P →ₗ[R] N) × (Q →ₗ[R] N))` that agree
   on the intersection `M ⊓ N`. This requires `R` to be commutative.
 
 ## Main results
@@ -56,7 +56,7 @@ namespace LinearMap
 variable {N : Type*} [AddCommGroup N] [Module R N] {f : P →ₗ[R] N} {g : Q →ₗ[R] N}
 
 /-- Given two linear maps `f : P →ₗ[R] N` and `g : Q →ₗ[R] N` that agree on `P ⊓ Q`, this is
-the linear map `P ⊔ Q →ₗ[R] N` that simultaneously extends `f` and `g`. -/
+the linear map `↥(P ⊔ Q) →ₗ[R] N` that simultaneously extends `f` and `g`. -/
 noncomputable def onSup
     -- (h : ∀ x (hP : x ∈ P) (hQ : x ∈ Q), f ⟨x, hP⟩ = g ⟨x, hQ⟩) :
     (h : f ∘ₗ inclusion inf_le_left = g ∘ₗ inclusion inf_le_right) :
@@ -128,7 +128,7 @@ theorem onSup_unique
 
 variable (M N Y)
 
-/-- The bijection between the set of maps `P ⊔ Q →ₗ[R] N` and the set of pairs of maps
+/-- The bijection between the set of maps `↥(P ⊔ Q) →ₗ[R] N` and the set of pairs of maps
   `(P →ₗ[R] N) × (Q →ₗ[R] N))` that agree on the intersection `P ⊓ Q`. -/
 noncomputable def onSupEquiv : (↥(P ⊔ Q) →ₗ[R] N) ≃
     {(fg : (P →ₗ[R] N) × (Q →ₗ[R] N)) | fg.1.comp (inclusion inf_le_left) =
@@ -156,7 +156,7 @@ noncomputable example : (P + Q →ₗ[R] N) ≃ₗ[R] eqLocus
       (lcomp R N (inclusion le_sup_right))) (fun _ ↦ by ext; simp [inclusion_apply]))
     (onSupEquiv M N).bijective
 
-/-- The `R`-linear equivalence between the module of linear maps `P ⊔ Q →ₗ[R] N` and the module of
+/-- The `R`-linear equivalence between the module of linear maps `↥(P ⊔ Q) →ₗ[R] N` and the module of
   pairs of linear maps `(P →ₗ[R] N) × (Q →ₗ[R] N))` that agree on the intersection `P ⊓ Q`. -/
 noncomputable def onSupLinearEquiv : (↥(P ⊔ Q) →ₗ[R] N) ≃ₗ[R] eqLocus
     ((lcomp R N (inclusion (inf_le_left (a := P) (b := Q)))).comp (fst R _ _))

--- a/Mathlib/LinearAlgebra/OnSup.lean
+++ b/Mathlib/LinearAlgebra/OnSup.lean
@@ -1,0 +1,168 @@
+/-
+Copyright (c) 2025 Antoine Chambert-Loir, María Inés de Frutos-Fernández. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Antoine Chambert-Loir, María Inés de Frutos-Fernández
+-/
+
+import Mathlib.Algebra.Module.Submodule.Pointwise
+import Mathlib.LinearAlgebra.BilinearMap
+import Mathlib.LinearAlgebra.Isomorphisms
+
+/-! # Extending linear maps to sums of modules
+
+Let `A` be a ring, `X, Y` be `A`-modules, and `M, N` be `A`-submodules of `X`.
+
+Given two linear maps `f : M →ₗ[A] Y` and `g : N →ₗ[A] Y` that agree on `M ∩ N`, there is a unique
+linear map `M + N →ₗ[A] Y` that simultaneously extends `f` and `g`.
+
+## Main definitions
+* `Submodule.quotientCoprodAddEquiv`: if `M` and `N` are two `A`-submodules of `X`, then the
+  quotient `(M × N) / ker (fun ((m, n) : M × N) ↦ m + n)` is isomorphic to `M + N` as an `A`-module.
+* `LinearMap.onSup`: given two linear maps `f : M →ₗ[A] Y` and `g : N →ₗ[A] Y` that agree on
+  `M ∩ N`, this is the linear map `M + N →ₗ[A] Y` that simultaneously extends `f` and `g`.
+* `LinearMap.onSupEquiv`: the bijection between the set of linear maps `M + N →ₗ[A] Y` and the
+  set of pairs of linear maps `(M →ₗ[A] Y) × (N →ₗ[A] Y))` that agree on the intersection `M ⊓ N`.
+* `LinearMap.onSupLinearEquiv`: the `A`-linear equivalence between the module of linear maps
+  `M + N →ₗ[A] Y` and the module of pairs of linear maps `(M →ₗ[A] Y) × (N →ₗ[A] Y))` that agree
+  on the intersection `M ⊓ N`. This requires `A` to be commutative.
+
+## Main results
+* `LinearMap.onSup_unique` : if `u : M + N →ₗ[A] Y` extends both `f` and `g`, then it agrees
+  with `LinearMap.onSup`.
+
+-/
+
+section onSup
+
+open Function LinearEquiv LinearMap Submodule
+
+variable {A X : Type*} [Ring A] [AddCommGroup X] [Module A X] {M N : Submodule A X}
+
+/-- If `M` and `N` are two `A`-submodules of `X`, then the quotient
+  `(M × N) / ker (fun ((m, n) : M × N) ↦ m + n)` is isomorphic to `M + N` as an `A`-module. -/
+noncomputable def Submodule.quotientCoprodAddEquiv :
+    ((M × N) ⧸ (ker ((inclusion (le_sup_left (b := N))).coprod
+      (inclusion (le_sup_right (a := M)))))) ≃ₗ[A] (M + N) :=
+  quotKerEquivOfSurjective _ (by
+    rw [← range_eq_top, eq_top_iff]
+    rintro ⟨x, hx⟩ _
+    obtain ⟨y, hy, z, hz, rfl⟩ := mem_sup.mp hx
+    use ⟨⟨y, hy⟩, ⟨z, hz⟩⟩
+    simp [coprod_apply, ← Subtype.coe_inj, coe_add, coe_inclusion])
+
+namespace LinearMap
+
+variable {Y : Type*} [AddCommGroup Y] [Module A Y] {f : M →ₗ[A] Y} {g : N →ₗ[A] Y}
+
+/-- Given two linear maps `f : M →ₗ[A] Y` and `g : N →ₗ[A] Y` that agree on `M ∩ N`, this is
+the linear map `M + N →ₗ[A] Y` that simultaneously extends `f` and `g`. -/
+noncomputable def onSup (h : ∀ x (hM : x ∈ M) (hN : x ∈ N), f ⟨x, hM⟩ = g ⟨x, hN⟩) :
+    M + N →ₗ[A] Y := by
+  apply comp ?_ quotientCoprodAddEquiv.symm.toLinearMap
+  apply (ker _).liftQ (f.coprod g)
+  rintro ⟨⟨x, hx⟩, ⟨y, hy⟩⟩ hxy
+  simp only [mem_ker, coprod_apply, add_eq_zero_iff_eq_neg, ← Subtype.coe_inj, coe_inclusion,
+    NegMemClass.coe_neg] at hxy
+  simp only [mem_ker, coprod_apply, add_eq_zero_iff_eq_neg, ← map_neg]
+  have hneg : - (⟨y, hy⟩ : N) = ⟨-y, N.neg_mem hy⟩ := by simp [← Subtype.coe_inj]
+  simp_rw [hneg, hxy]
+  exact h (-y) (hxy ▸ hx) (N.neg_mem hy)
+
+theorem onSup_apply_left (h : ∀ x (hM : x ∈ M) (hN : x ∈ N), f ⟨x, hM⟩ = g ⟨x, hN⟩)
+    {x : X} (hx : x ∈ M) : onSup h ⟨x, le_sup_left (b := N) hx⟩ = f ⟨x, hx⟩ := by
+  have h : (quotientCoprodAddEquiv (M := M) (N := N)).symm ⟨x, le_sup_left (b := N) hx⟩ =
+      Submodule.Quotient.mk ⟨⟨x, hx⟩, (0 : N)⟩ := by
+    rw [symm_apply_eq]
+    simp only [add_eq_sup, quotientCoprodAddEquiv, quotKerEquivOfSurjective, trans_apply,
+      ofTop_apply, quotKerEquivRange_apply_mk, coprod_apply, map_zero, add_zero, inclusion_apply]
+  simp only [add_eq_sup, onSup, comp_apply] at h ⊢
+  simp [h, liftQ_apply]
+
+theorem onSup_apply_right (h : ∀ x (hM : x ∈ M) (hN : x ∈ N), f ⟨x, hM⟩ = g ⟨x, hN⟩)
+    {x} (hx : x ∈ N) : onSup h ⟨x, le_sup_right (a := M) hx⟩ = g ⟨x, hx⟩ := by
+  have h : (quotientCoprodAddEquiv (M := M) (N := N)).symm ⟨x, le_sup_right (a := M) hx⟩ =
+      Submodule.Quotient.mk ⟨(0 : M), ⟨x, hx⟩⟩ := by
+    rw [symm_apply_eq]
+    simp only [add_eq_sup, quotientCoprodAddEquiv, quotKerEquivOfSurjective, trans_apply,
+      ofTop_apply, quotKerEquivRange_apply_mk, coprod_apply, map_zero, zero_add, inclusion_apply]
+  simp only [add_eq_sup, onSup, comp_apply] at h ⊢
+  simp [h, liftQ_apply]
+
+theorem onSup_apply (h : ∀ x (hM : x ∈ M) (hN : x ∈ N), f ⟨x, hM⟩ = g ⟨x, hN⟩)
+    {x y} (hx : x ∈ M) (hy : y ∈ N) :
+    onSup h ⟨x + y, add_mem_sup hx hy⟩ = f ⟨x, hx⟩ + g ⟨y, hy⟩ := by
+  rw [← onSup_apply_left h hx, ← onSup_apply_right h hy, ← map_add, AddMemClass.mk_add_mk]
+
+theorem onSup_comp_left (h : ∀ x (hM : x ∈ M) (hN : x ∈ N), f ⟨x, hM⟩ = g ⟨x, hN⟩) :
+    (onSup h).comp (inclusion le_sup_left) = f := by
+  ext ⟨x, hx⟩
+  rw [← onSup_apply_left h, comp_apply, inclusion_apply]
+
+theorem onSup_comp_right (h : ∀ x (hM : x ∈ M) (hN : x ∈ N), f ⟨x, hM⟩ = g ⟨x, hN⟩) :
+    (onSup h).comp (inclusion le_sup_right) = g := by
+  ext ⟨x, hx⟩
+  rw [← onSup_apply_right h, comp_apply, inclusion_apply]
+
+theorem onSup_unique (h : ∀ x (hM : x ∈ M) (hN : x ∈ N), f ⟨x, hM⟩ = g ⟨x, hN⟩) {u : M + N →ₗ[A] Y}
+    (huf : u.comp (inclusion le_sup_left) = f) (hug : u.comp (inclusion le_sup_right) = g) :
+    u = onSup h := by
+  ext ⟨x, hx⟩
+  obtain ⟨y, hy, z, hz, heq⟩ := mem_sup.mp hx
+  have heq : (⟨x, hx⟩ : M + N) = ⟨y, le_sup_left (b := N) hy⟩ + ⟨z, le_sup_right (a := M) hz⟩ := by
+    simp [heq]
+  rw [heq, map_add, map_add, onSup_apply_left h hy, onSup_apply_right h hz]
+  simp only [add_eq_sup, LinearMap.ext_iff, comp_apply, inclusion_apply,
+    Subtype.forall] at huf hug ⊢
+  rw [huf y hy, hug z hz]
+
+
+variable (M N Y)
+
+/-- The bijection between the set of maps `M + N →ₗ[A] Y` and the set of pairs of maps
+  `(M →ₗ[A] Y) × (N →ₗ[A] Y))` that agree on the intersection `M ⊓ N`. -/
+noncomputable def onSupEquiv : (M + N →ₗ[A] Y) ≃
+  {(fg : (M →ₗ[A] Y) × (N →ₗ[A] Y)) | fg.1.comp (inclusion inf_le_left) =
+    fg.2.comp (inclusion inf_le_right)} := by
+  apply Equiv.ofBijective (fun fg ↦ ⟨⟨fg.comp (inclusion (le_sup_left (a := M) (b := N))),
+      fg.comp (inclusion (le_sup_right (a := M) (b := N)))⟩, by ext; simp [inclusion_apply]⟩)
+  · constructor
+    · intros f g hfg
+      simp only [Set.coe_setOf, Set.mem_setOf_eq, add_eq_sup, Subtype.mk.injEq, Prod.mk.injEq,
+        LinearMap.ext_iff, coe_comp, Function.comp_apply, inclusion_apply] at hfg
+      ext ⟨mn, hmn⟩
+      simp only [add_eq_sup, sup_eq_range, mem_range] at hmn
+      obtain ⟨mn, rfl⟩ := hmn
+      have heq : (⟨(mn.1 : X) + (mn.2 : X), hmn⟩ : M + N) =
+        ⟨mn.1, le_sup_left (a := M) mn.1.2⟩ + ⟨mn.2, le_sup_right (a := M) mn.2.2⟩ := rfl
+      simp only [add_eq_sup, coprod_apply, subtype_apply]
+      rw [heq, map_add, map_add, hfg.1 mn.1, hfg.2 mn.2]
+    · rintro ⟨fg, hfg⟩
+      have h : ∀ x (hM : x ∈ M) (hN : x ∈ N), fg.1 ⟨x, hM⟩ = fg.2 ⟨x, hN⟩ := by
+        simp only [Set.mem_setOf_eq] at hfg
+        intro x hxM hxN
+        have hf1 : fg.1 (⟨x, hxM⟩ : M) = (fg.1 ∘ₗ (inclusion inf_le_left)) ⟨x, ⟨hxM, hxN⟩⟩ := rfl
+        rw [hf1, hfg]
+        rfl
+      use onSup h
+      simp only [Set.coe_setOf, Set.mem_setOf_eq, add_eq_sup, Subtype.mk.injEq]
+      rw [onSup_comp_left, onSup_comp_right]
+
+section Comm
+
+variable {A X Y : Type*} [CommRing A] [AddCommGroup X] [Module A X]
+  [AddCommGroup Y] [Module A Y] (M N : Submodule A X)
+
+/-- The `A`-linear equivalence between the module of linear maps `M + N →ₗ[A] Y` and the module of
+  pairs of linear maps `(M →ₗ[A] Y) × (N →ₗ[A] Y))` that agree on the intersection `M ⊓ N`. -/
+noncomputable def onSupLinearEquiv : (M + N →ₗ[A] Y) ≃ₗ[A] eqLocus
+    ((lcomp A Y (inclusion (inf_le_left (a := M) (b := N)))).comp (fst A _ _))
+    ((lcomp A Y (inclusion (inf_le_right (a := M) (b := N)))).comp (snd A _ _)) :=
+  ofBijective (codRestrict _ ((lcomp A Y (inclusion le_sup_left)).prod
+      (lcomp A Y (inclusion le_sup_right))) (fun _ ↦ by ext; simp [inclusion_apply]))
+    (onSupEquiv M N Y).bijective
+
+end Comm
+
+end LinearMap
+
+end onSup


### PR DESCRIPTION
Let `A` be a ring, `X, Y` be `A`-modules, and `M, N` be `A`-submodules of `X`.

Given two linear maps `f : M →ₗ[A] Y` and `g : N →ₗ[A] Y` that agree on `M ∩ N`, there is a unique linear map `M + N →ₗ[A] Y` that simultaneously extends `f` and `g`.

Co-authored-by: @AntoineChambert-Loir 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
