### PR TITLE
feat: the Dedekind-MacNeille completion

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4796,6 +4796,7 @@ import Mathlib.Order.ConditionallyCompleteLattice.Indexed
 import Mathlib.Order.Copy
 import Mathlib.Order.CountableDenseLinearOrder
 import Mathlib.Order.Cover
+import Mathlib.Order.Dedekind
 import Mathlib.Order.Defs.LinearOrder
 import Mathlib.Order.Defs.PartialOrder
 import Mathlib.Order.Defs.Unbundled

--- a/Mathlib/Order/Dedekind.lean
+++ b/Mathlib/Order/Dedekind.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 Wrenna Robson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Wrenna Robson, Violeta Hernández Palacios
 -/
+import Mathlib.Data.Set.Lattice
 import Mathlib.Order.CompleteLattice.Defs
 
 /-!
@@ -154,9 +155,12 @@ theorem lowerCut_ssubset_iff_ssubset_upperCut :
 theorem lowerCut_eq_iff_upperCut_eq : A.lowerCut = B.lowerCut ↔ A.upperCut = B.upperCut := by
   simp [subset_antisymm_iff, lowerCut_subset_iff_subset_upperCut, and_comm]
 
-@[ext]
+@[ext (iff := false)]
 theorem ext_lowerCut (h : A.lowerCut = B.lowerCut) : A = B := by
   cases A; cases B; simpa
+
+theorem ext_lowerCut_iff : A = B ↔ A.lowerCut = B.lowerCut :=
+  ⟨congrArg _, ext_lowerCut⟩
 
 theorem ext_upperCut (h : A.upperCut = B.upperCut) : A = B :=
   ext_lowerCut (lowerCut_eq_iff_upperCut_eq.mpr h)
@@ -212,7 +216,34 @@ theorem upperCut_sup (A B : DedekindCut α) : (A ⊔ B).upperCut = A.upperCut �
   upperCut_of_upperCuts ..
 
 theorem lowerCut_bot : (⊥ : DedekindCut α).lowerCut = ⋂₀ (lowerCut '' univ) := rfl
-theorem lowerCut_top : (⊤ : DedekindCut α).upperCut = ⋂₀ (upperCut '' univ) :=
+theorem upperCut_top : (⊤ : DedekindCut α).upperCut = ⋂₀ (upperCut '' univ) :=
   upperCut_of_upperCuts ..
+
+instance : CompleteLattice (DedekindCut α) where
+  sup := max
+  inf := min
+  le_refl _ := .rfl
+  le_trans _ _ _ := subset_trans
+  le_antisymm _ _:= by simp_all [ext_lowerCut_iff, subset_antisymm_iff, le_iff_lowerCut_subset]
+  le_inf A B C := le_inf (a := A.lowerCut)
+  inf_le_left A B := inf_le_left (a := A.lowerCut)
+  inf_le_right A B := inf_le_right (a := A.lowerCut)
+  sup_le A B C := by simp_rw [le_iff_upperCut_subset, upperCut_sup]; exact le_inf
+  le_sup_left A B := by rw [le_iff_upperCut_subset, upperCut_sup]; exact inf_le_left
+  le_sup_right A B := by rw [le_iff_upperCut_subset, upperCut_sup]; exact inf_le_right
+  sInf_le X A hA := sInter_subset_of_mem (mem_image_of_mem _ hA)
+  le_sInf X A H := by rintro B hB _ ⟨C, hC, rfl⟩; exact H _ hC hB
+  le_sSup X A hA := by
+    rw [le_iff_upperCut_subset, upperCut_sSup]
+    exact sInter_subset_of_mem (mem_image_of_mem _ hA)
+  sSup_le X A H := by
+    rw [le_iff_upperCut_subset, upperCut_sSup]
+    simp_rw [le_iff_upperCut_subset] at H
+    rintro B hB _ ⟨C, hC, rfl⟩
+    exact H _ hC hB
+  bot_le A := sInter_subset_of_mem (mem_image_of_mem _ ⟨⟩)
+  le_top A := by
+    rw [le_iff_upperCut_subset, upperCut_top]
+    exact sInter_subset_of_mem (mem_image_of_mem _ ⟨⟩)
 
 end DedekindCut

--- a/Mathlib/Order/Dedekind.lean
+++ b/Mathlib/Order/Dedekind.lean
@@ -42,9 +42,6 @@ theorem sInter_mem_lowerCuts {S : Set (Set α)} (hS : S ⊆ lowerCuts α) : ⋂�
   rw [← mem_lowerCuts_iff_eq.mp (hS ht)]
   exact fun _ hb ↦ ha fun _ hc ↦ hb (hc _ ht)
 
-theorem sInter_lowerCuts_mem_lowerCuts : ⋂₀ lowerCuts α ∈ lowerCuts α :=
-  sInter_mem_lowerCuts (le_refl _)
-
 theorem Iic_mem_lowerCuts (a : α) : Iic a ∈ lowerCuts α := fun _ hb ↦ hb fun _ ↦ id
 
 /-- The set of lower cuts in a preorder is the set of sets with
@@ -64,9 +61,6 @@ theorem inter_mem_upperCuts (hs : s ∈ upperCuts α) (ht : t ∈ upperCuts α) 
 theorem sInter_mem_upperCuts {S : Set (Set α)} (hS : S ⊆ upperCuts α) : ⋂₀ S ∈ upperCuts α :=
   sInter_mem_lowerCuts (α := αᵒᵈ) hS
 
-theorem sInter_upperCuts_mem_upperCuts : ⋂₀ upperCuts α ∈ upperCuts α :=
-  sInter_mem_upperCuts (le_refl _)
-
 theorem Ici_mem_lowerCuts (a : α) : Iic a ∈ lowerCuts α := fun _ hb ↦ hb fun _ ↦ id
 
 theorem upperBounds_mem_upperCuts_of_mem_lowerCuts (H : s ∈ lowerCuts α) :
@@ -81,7 +75,7 @@ theorem lowerBounds_mem_lowerCuts_of_mem_upperCuts (H : s ∈ upperCuts α) :
 
 /-- A Dedekind cut (in the Dedekind-MacNeille completion) is a defined as a member of `lowerCuts α`.
 
-Use `Dedekind.of_lowerCuts` to define a member of this structure. For the dual definition through
+Use `DedekindCut.of_lowerCuts` to define a member of this structure. For the dual definition through
 `upperCuts`, use `DedekindCut.of_upperCuts`. -/
 structure DedekindCut (α : Type*) [Preorder α] where
   carrier : Set α
@@ -169,5 +163,56 @@ theorem ext_upperCut (h : A.upperCut = B.upperCut) : A = B :=
 
 theorem ext_upperCut_iff : A = B ↔ A.upperCut = B.upperCut :=
   ⟨congrArg _, ext_upperCut⟩
+
+/- ### Order instances -/
+
+instance : LE (DedekindCut α) where
+  le A B := A.lowerCut ⊆ B.lowerCut
+
+instance : InfSet (DedekindCut α) where
+  sInf X := .of_lowerCuts (⋂₀ (lowerCut '' X)) (by
+    apply sInter_mem_lowerCuts
+    rintro A ⟨B, hB, rfl⟩
+    exact lowerCut_mem_lowerCuts B
+  )
+
+instance : Min (DedekindCut α) where
+  min A B := .of_lowerCuts (A.lowerCut ∩ B.lowerCut) (by
+    apply inter_mem_lowerCuts <;> exact lowerCut_mem_lowerCuts _
+  )
+
+instance : SupSet (DedekindCut α) where
+  sSup X := .of_upperCuts (⋂₀ (upperCut '' X)) (by
+    apply sInter_mem_upperCuts
+    rintro A ⟨B, hB, rfl⟩
+    exact upperCut_mem_upperCuts B
+  )
+
+instance : Max (DedekindCut α) where
+  max A B := .of_upperCuts (A.upperCut ∩ B.upperCut) (by
+    apply inter_mem_upperCuts <;> exact upperCut_mem_upperCuts _
+  )
+
+instance : Bot (DedekindCut α) where
+  bot := sInf univ
+
+instance : Top (DedekindCut α) where
+  top := sSup univ
+
+theorem le_iff_lowerCut_subset : A ≤ B ↔ A.lowerCut ⊆ B.lowerCut := .rfl
+theorem le_iff_upperCut_subset : A ≤ B ↔ B.upperCut ⊆ A.upperCut := by
+  rw [le_iff_lowerCut_subset, lowerCut_subset_iff_subset_upperCut]
+
+theorem lowerCut_sInf (X : Set (DedekindCut α)) : (sInf X).lowerCut = ⋂₀ (lowerCut '' X) := rfl
+theorem upperCut_sSup (X : Set (DedekindCut α)) : (sSup X).upperCut = ⋂₀ (upperCut '' X) :=
+  upperCut_of_upperCuts ..
+
+theorem lowerCut_inf (A B : DedekindCut α) : (A ⊓ B).lowerCut = A.lowerCut ∩ B.lowerCut := rfl
+theorem upperCut_sup (A B : DedekindCut α) : (A ⊔ B).upperCut = A.upperCut ∩ B.upperCut :=
+  upperCut_of_upperCuts ..
+
+theorem lowerCut_bot : (⊥ : DedekindCut α).lowerCut = ⋂₀ (lowerCut '' univ) := rfl
+theorem lowerCut_top : (⊤ : DedekindCut α).upperCut = ⋂₀ (upperCut '' univ) :=
+  upperCut_of_upperCuts ..
 
 end DedekindCut

--- a/Mathlib/Order/Dedekind.lean
+++ b/Mathlib/Order/Dedekind.lean
@@ -1,0 +1,79 @@
+/-
+Copyright (c) 2025 Wrenna Robson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Wrenna Robson, Violeta Hernández Palacios
+-/
+import Mathlib.Order.CompleteLattice.Defs
+
+/-!
+# Dedekind-MacNeille completion
+
+The Dedekind-MacNeille completion of a partial order is the smallest complete lattice into which it
+embeds.
+
+We provide an explicit construction, as the set of "lower cuts" of the order, meaning sets with
+`lowerBounds (upperBounds s) = s`. The dual construction as upper cuts, or sets with
+`upperBounds (lowerBounds s) = s` would also work; keeping this in mind, we keep the API symmetric.
+-/
+
+open Set
+
+variable {α : Type*} {s t : Set α} [Preorder α]
+
+/-! ### Lower cuts and upper cuts -/
+
+/-- The set of lower cuts in a preorder is the set of sets with
+`lowerBounds (upperBounds s) ⊆ s`.
+
+The theorem `mem_lowerCuts_iff_eq` shows the equivalence to the condition
+`lowerBounds (upperBounds s) = s` -/
+def lowerCuts (α : Type*) [Preorder α] : Set (Set α) :=
+  {s | lowerBounds (upperBounds s) ⊆ s}
+
+theorem mem_lowerCuts_iff_eq : s ∈ lowerCuts α ↔ lowerBounds (upperBounds s) = s := by
+  rw [lowerCuts, subset_antisymm_iff]
+  simp [subset_lowerBounds_upperBounds]
+
+theorem inter_mem_lowerCuts (hs : s ∈ lowerCuts α) (ht : t ∈ lowerCuts α) : s ∩ t ∈ lowerCuts α :=
+  fun _ ha ↦ ⟨hs fun _ hb ↦ ha fun _ ⟨hc, _⟩ ↦ hb hc, ht fun _ hb ↦ ha fun _ ⟨_, hc⟩ ↦ hb hc⟩
+
+theorem sInter_mem_lowerCuts {S : Set (Set α)} (hS : S ⊆ lowerCuts α) : ⋂₀ S ∈ lowerCuts α := by
+  intro a ha t ht
+  rw [← mem_lowerCuts_iff_eq.mp (hS ht)]
+  exact fun _ hb ↦ ha fun _ hc ↦ hb (hc _ ht)
+
+theorem sInter_lowerCuts_mem_lowerCuts : ⋂₀ lowerCuts α ∈ lowerCuts α :=
+  sInter_mem_lowerCuts (le_refl _)
+
+theorem Iic_mem_lowerCuts (a : α) : Iic a ∈ lowerCuts α := fun _ hb ↦ hb fun _ ↦ id
+
+/-- The set of lower cuts in a preorder is the set of sets with
+`upperBounds (lowerBounds s) ⊆ s`.
+
+The theorem `mem_upperCuts_iff_eq` shows the equivalence to the condition
+`upperBounds (lowerBounds s) = s` -/
+def upperCuts (α : Type*) [Preorder α] : Set (Set α) :=
+  {s | upperBounds (lowerBounds s) ⊆ s}
+
+theorem mem_upperCuts_iff_eq : s ∈ upperCuts α ↔ upperBounds (lowerBounds s) = s :=
+  mem_lowerCuts_iff_eq (α := αᵒᵈ)
+
+theorem inter_mem_upperCuts (hs : s ∈ upperCuts α) (ht : t ∈ upperCuts α) :
+    s ∩ t ∈ upperCuts α :=
+  inter_mem_lowerCuts (α := αᵒᵈ) hs ht
+
+theorem sInter_mem_upperCuts {S : Set (Set α)} (hS : S ⊆ upperCuts α) : ⋂₀ S ∈ upperCuts α :=
+  sInter_mem_lowerCuts (α := αᵒᵈ) hS
+
+theorem sInter_upperCuts_mem_upperCuts : ⋂₀ upperCuts α ∈ upperCuts α :=
+  sInter_mem_upperCuts (le_refl _)
+
+theorem Ici_mem_lowerCuts (a : α) : Iic a ∈ lowerCuts α := fun _ hb ↦ hb fun _ ↦ id
+
+theorem upperBounds_mem_upperCuts_of_mem_lowerCuts (H : s ∈ lowerCuts α) :
+    upperBounds s ∈ upperCuts α := by
+  simp_all [mem_upperCuts_iff_eq, mem_lowerCuts_iff_eq]
+
+theorem lowerBounds_mem_lowerCuts_of_mem_upperCuts (H : s ∈ upperCuts α) :
+    lowerBounds s ∈ lowerCuts α := by
+  simp_all [mem_upperCuts_iff_eq, mem_lowerCuts_iff_eq]

--- a/Mathlib/Order/Dedekind.lean
+++ b/Mathlib/Order/Dedekind.lean
@@ -58,8 +58,7 @@ def upperCuts (α : Type*) [Preorder α] : Set (Set α) :=
 theorem mem_upperCuts_iff_eq : s ∈ upperCuts α ↔ upperBounds (lowerBounds s) = s :=
   mem_lowerCuts_iff_eq (α := αᵒᵈ)
 
-theorem inter_mem_upperCuts (hs : s ∈ upperCuts α) (ht : t ∈ upperCuts α) :
-    s ∩ t ∈ upperCuts α :=
+theorem inter_mem_upperCuts (hs : s ∈ upperCuts α) (ht : t ∈ upperCuts α) : s ∩ t ∈ upperCuts α :=
   inter_mem_lowerCuts (α := αᵒᵈ) hs ht
 
 theorem sInter_mem_upperCuts {S : Set (Set α)} (hS : S ⊆ upperCuts α) : ⋂₀ S ∈ upperCuts α :=
@@ -77,3 +76,98 @@ theorem upperBounds_mem_upperCuts_of_mem_lowerCuts (H : s ∈ lowerCuts α) :
 theorem lowerBounds_mem_lowerCuts_of_mem_upperCuts (H : s ∈ upperCuts α) :
     lowerBounds s ∈ lowerCuts α := by
   simp_all [mem_upperCuts_iff_eq, mem_lowerCuts_iff_eq]
+
+/-! ### Dedekind cuts -/
+
+/-- A Dedekind cut (in the Dedekind-MacNeille completion) is a defined as a member of `lowerCuts α`.
+
+Use `Dedekind.of_lowerCuts` to define a member of this structure. For the dual definition through
+`upperCuts`, use `DedekindCut.of_upperCuts`. -/
+structure DedekindCut (α : Type*) [Preorder α] where
+  carrier : Set α
+  carrier_mem_lowerCuts : carrier ∈ lowerCuts α
+
+namespace DedekindCut
+
+variable (A B : DedekindCut α)
+
+/- The lower set in a Dedekind cut. -/
+def lowerCut : Set α := A.carrier
+
+theorem lowerCut_mem_lowerCuts : A.lowerCut ∈ lowerCuts α :=
+  A.carrier_mem_lowerCuts
+
+@[simp]
+theorem lowerCut_eq : lowerBounds (upperBounds A.lowerCut) = A.lowerCut :=
+  mem_lowerCuts_iff_eq.mp A.lowerCut_mem_lowerCuts
+
+/- The upper set in a Dedekind cut. -/
+def upperCut : Set α := upperBounds A.lowerCut
+
+@[simp]
+theorem upperCut_eq : upperBounds (lowerBounds A.upperCut) = A.upperCut := by
+  rw [upperCut, lowerCut_eq]
+
+theorem upperCut_mem_upperCuts : A.upperCut ∈ upperCuts α :=
+  mem_upperCuts_iff_eq.mpr A.upperCut_eq
+
+@[simp]
+theorem upperBounds_lowerCut : upperBounds A.lowerCut = A.upperCut :=
+  rfl
+
+@[simp]
+theorem lowerBounds_upperCut : lowerBounds A.upperCut = A.lowerCut := by
+  rw [← upperBounds_lowerCut, lowerCut_eq]
+
+/-- Build a Dedekind cut from its lower set. -/
+def of_lowerCuts (s : Set α) (hs : s ∈ lowerCuts α) : DedekindCut α :=
+  ⟨s, hs⟩
+
+@[simp]
+theorem lowerCut_of_lowerCuts (hs : s ∈ lowerCuts α) : lowerCut (of_lowerCuts s hs) = s :=
+  rfl
+
+@[simp]
+theorem upperCut_of_lowerCuts (hs : s ∈ lowerCuts α) :
+    upperCut (of_lowerCuts s hs) = upperBounds s :=
+  rfl
+
+/-- Build a Dedekind cut from its upper set. -/
+def of_upperCuts (s : Set α) (hs : s ∈ upperCuts α) : DedekindCut α :=
+  ⟨_, lowerBounds_mem_lowerCuts_of_mem_upperCuts hs⟩
+
+@[simp]
+theorem lowerCut_of_upperCuts (hs : s ∈ upperCuts α) :
+    lowerCut (of_upperCuts s hs) = lowerBounds s :=
+  rfl
+
+@[simp]
+theorem upperCut_of_upperCuts (hs : s ∈ upperCuts α) :
+    upperCut (of_upperCuts s hs) = s :=
+  mem_upperCuts_iff_eq.mp hs
+
+variable {A B}
+
+theorem lowerCut_subset_iff_subset_upperCut :
+    A.lowerCut ⊆ B.lowerCut ↔ B.upperCut ⊆ A.upperCut where
+  mp  H := by simpa using fun a ha ↦ upperBounds_mono_set H ha
+  mpr H := by simpa using fun a ha ↦ lowerBounds_mono_set H ha
+
+theorem lowerCut_ssubset_iff_ssubset_upperCut :
+    A.lowerCut ⊂ B.lowerCut ↔ B.upperCut ⊂ A.upperCut := by
+  simp [ssubset_def, lowerCut_subset_iff_subset_upperCut]
+
+theorem lowerCut_eq_iff_upperCut_eq : A.lowerCut = B.lowerCut ↔ A.upperCut = B.upperCut := by
+  simp [subset_antisymm_iff, lowerCut_subset_iff_subset_upperCut, and_comm]
+
+@[ext]
+theorem ext_lowerCut (h : A.lowerCut = B.lowerCut) : A = B := by
+  cases A; cases B; simpa
+
+theorem ext_upperCut (h : A.upperCut = B.upperCut) : A = B :=
+  ext_lowerCut (lowerCut_eq_iff_upperCut_eq.mpr h)
+
+theorem ext_upperCut_iff : A = B ↔ A.upperCut = B.upperCut :=
+  ⟨congrArg _, ext_upperCut⟩
+
+end DedekindCut

--- a/Mathlib/Order/Dedekind.lean
+++ b/Mathlib/Order/Dedekind.lean
@@ -315,7 +315,11 @@ def ofElementEmbedding : β ↪o DedekindCut β where
 
 variable [CompleteLattice γ]
 
-/-- Any order embedding `β ↪o γ` into a complete lattice factors through `DedekindCut β`. -/
+/-- Any order embedding `β ↪o γ` into a complete lattice factors through `DedekindCut β`.
+
+This map is defined so that `factorEmbedding f A = sSup (f '' A.lowerCut)`. Although the
+construction `factorEmbedding f A = sInf (f '' A.upperCut)` would also work, these do **not** in
+general give equal embeddings. -/
 def factorEmbedding (f : β ↪o γ) : DedekindCut β ↪o γ :=
   .ofMapLEIff (fun A ↦ sSup (f '' A.lowerCut)) <| by
     refine fun A B ↦ ⟨fun h x hx ↦ ?_, fun h ↦ sSup_le_sSup (image_mono h)⟩
@@ -325,7 +329,6 @@ def factorEmbedding (f : β ↪o γ) : DedekindCut β ↪o γ :=
     rw [← f.le_iff_le]
     exact h _ (image_upperCut_subset_upperBounds _ f.monotone (mem_image_of_mem _ hy)) hx
 
-/-- Note that `factorEmbedding f A = sInf (f '' A.upperCut)` is not necessarily true! -/
 theorem factorEmbedding_apply (f : β ↪o γ) (A : DedekindCut β) :
     factorEmbedding f A = sSup (f '' A.lowerCut) :=
   rfl


### PR DESCRIPTION
We construct the type of Dedekind cuts of a preorder and define a complete lattice structure on it. We prove that for a partial order, this gives the "smallest" complete lattice containing it, in the sense that any embedding into a complete lattice factors through the Dedekind completion.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

This PR is based on [Lean 3 code](https://github.com/linesthatinterlace/verifying-cmce/blob/main/lean/src/shared/order_theory/dmnc.lean) by @linesthatinterlace.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
