### PR TITLE
[Merged by Bors] - feat: add root system induction principle equivalent to connectedness of Dynkin diagram

### DIFF
--- a/Mathlib/LinearAlgebra/RootSystem/Base.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Base.lean
@@ -33,7 +33,10 @@ is too strong.
 ## Main definitions / results:
 * `RootSystem.Base`: a base of a root pairing.
 * `RootSystem.Base.IsPos`: the predicate that a (co)root is positive relative to a base.
-* `RootSystem.Base.IsPos.IsPos.induction_on`: an induction principle for positive roots.
+* `RootSystem.Base.induction_add`: an induction principle for predicates on (co)roots which
+  respect addition of a simple root.
+* `RootSystem.Base.induction_reflect`: an induction principle for predicates on (co)roots which
+  respect reflection in a simple root.
 
 ## TODO
 
@@ -46,6 +49,7 @@ noncomputable section
 
 open Function Set Submodule
 open FaithfulSMul (algebraMap_injective)
+open Module.End (invtSubmodule mem_invtSubmodule)
 
 variable {ι R M N : Type*} [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
 
@@ -139,7 +143,6 @@ lemma eq_one_or_neg_one_of_mem_support_of_smul_mem_aux [Finite ι]
     (i : ι) (h : i ∈ b.support) (t : R) (ht : t • P.root i ∈ range P.root) :
     ∃ z : ℤ, z * t = 1 := by
   classical
-  have : Fintype ι := Fintype.ofFinite ι
   obtain ⟨j, hj⟩ := ht
   obtain ⟨f, hf⟩ : ∃ f : b.support → ℤ, P.coroot i = ∑ i, (t * f i) • P.coroot i := by
     have : P.coroot j ∈ span ℤ (P.coroot '' b.support) := b.coroot_mem_span_int j
@@ -160,7 +163,9 @@ lemma eq_one_or_neg_one_of_mem_support_of_smul_mem_aux [Finite ι]
   have : Injective (linearCombination R fun k : b.support ↦ P.coroot k) := b.linearIndepOn_coroot
   simpa [g, linearEquivFunOnFinite, mul_comm t] using (DFunLike.congr_fun (this hf) ⟨i, h⟩).symm
 
-lemma eq_one_or_neg_one_of_mem_support_of_smul_mem [Finite ι] [CharZero R]
+variable [CharZero R]
+
+lemma eq_one_or_neg_one_of_mem_support_of_smul_mem [Finite ι]
     [NoZeroSMulDivisors ℤ M] [NoZeroSMulDivisors ℤ N]
     (i : ι) (h : i ∈ b.support) (t : R) (ht : t • P.root i ∈ range P.root) :
     t = 1 ∨ t = - 1 := by
@@ -180,93 +185,92 @@ lemma eq_one_or_neg_one_of_mem_support_of_smul_mem [Finite ι] [CharZero R]
   rw [Int.mul_eq_one_iff_eq_one_or_neg_one] at this
   tauto
 
-lemma pos_or_neg_of_sum_smul_root_mem [CharZero R] [Fintype ι] (f : ι → ℤ)
-    (hf : ∑ j, f j • P.root j ∈ range P.root) (hf₀ : f.support ⊆ b.support) :
-    0 ≤ f ∨ f ≤ 0 := by
+lemma pos_or_neg_of_sum_smul_root_mem (f : ι → ℤ)
+    (hf : ∑ j ∈ b.support, f j • P.root j ∈ range P.root) (hf₀ : f.support ⊆ b.support) :
+    0 < f ∨ f < 0 := by
   suffices ∀ (f : ι → ℤ)
-      (hf : ∑ j, f j • P.root j ∈ AddSubmonoid.closure (P.root '' b.support))
-      (hf₀ : f.support ⊆ b.support), 0 ≤ f by
+      (hf : ∑ j ∈ b.support, f j • P.root j ∈ AddSubmonoid.closure (P.root '' b.support))
+      (hf₀ : f.support ⊆ b.support) (hf' : f ≠ 0), 0 < f by
     obtain ⟨k, hk⟩ := hf
+    have hf' : f ≠ 0 := by rintro rfl; exact P.ne_zero k <| by simp [hk]
     rcases b.root_mem_or_neg_mem k with hk' | hk' <;> rw [hk] at hk'
-    · left; exact this f hk' hf₀
-    · right; simpa using this (-f) (by convert hk'; simp) (by simpa only [support_neg'])
-  intro f hf hf₀
+    · left; exact this f hk' hf₀ hf'
+    · right; simpa using this (-f) (by convert hk'; simp) (by simpa only [support_neg']) (by simpa)
+  intro f hf hf₀ hf'
   let f' : b.support → ℤ := fun i ↦ f i
   replace hf : ∑ j, f' j • P.root j ∈ AddSubmonoid.closure (P.root '' b.support) := by
-    suffices ∑ j, f' j • P.root j = ∑ j, f j • P.root j by rwa [this]
-    rw [← Fintype.sum_subset (s := b.support) (by aesop), ← b.support.sum_finset_coe]; rfl
+    suffices ∑ j, f' j • P.root j = ∑ j ∈ b.support, f j • P.root j by rwa [this]
+    rw [← b.support.sum_finset_coe]; rfl
   rw [← span_nat_eq_addSubmonoid_closure, mem_toAddSubmonoid,
     Fintype.mem_span_image_iff_exists_fun] at hf
   obtain ⟨c, hc⟩ := hf
   replace hc (i : b.support) : c i = f' i := Fintype.linearIndependent_iffₛ.mp
     (b.linearIndepOn_root.restrict_scalars' ℤ) (Int.ofNat ∘ c) f' (by simpa) i
-  intro i
-  by_cases hi : i ∈ b.support
-  · change 0 ≤ f' ⟨i, hi⟩
-    simp [← hc]
-  · replace hi : i ∉ f.support := by contrapose! hi; exact hf₀ hi
-    aesop
+  have aux : 0 ≤ f := by
+    intro i
+    by_cases hi : i ∈ b.support
+    · change 0 ≤ f' ⟨i, hi⟩
+      simp [← hc]
+    · replace hi : i ∉ f.support := by contrapose! hi; exact hf₀ hi
+      aesop
+  refine Pi.lt_def.mpr ⟨aux, ?_⟩
+  by_contra! contra
+  replace contra : f = 0 := le_antisymm contra aux
+  contradiction
 
-lemma sub_notMem_range_root [CharZero R] [Finite ι]
+lemma not_nonpos_iff_pos_of_sum_mem_range_root (f : ι → ℤ)
+    (hf : ∑ j ∈ b.support, f j • P.root j ∈ range P.root) (hf₀ : f.support ⊆ b.support) :
+    (¬ f ≤ 0) ↔ 0 < f := by
+  rw [Pi.lt_def]
+  refine ⟨fun h ↦ ⟨?_, ?_⟩, fun ⟨h, ⟨i, hi⟩⟩ contra ↦ by simp [le_antisymm contra h] at hi⟩
+  · rcases b.pos_or_neg_of_sum_smul_root_mem f hf hf₀ with h' | h'
+    · exact le_of_lt h'
+    · exfalso
+      exact h (le_of_lt h')
+  · contrapose! h; exact h
+
+lemma not_nonneg_iff_neg_of_sum_mem_range_root (f : ι → ℤ)
+    (hf : ∑ j ∈ b.support, f j • P.root j ∈ range P.root) (hf₀ : f.support ⊆ b.support) :
+    (¬ 0 ≤ f) ↔ f < 0 := by
+  replace hf : ∑ j ∈ b.support, (-f) j • P.root j ∈ range P.root := by
+    rw [← neg_mem_range_root_iff]; simpa
+  have := b.not_nonpos_iff_pos_of_sum_mem_range_root (-f) hf (by simpa)
+  aesop
+
+lemma sub_notMem_range_root
     {i j : ι} (hi : i ∈ b.support) (hj : j ∈ b.support) :
     P.root i - P.root j ∉ range P.root := by
   rcases eq_or_ne j i with rfl | hij
   · simpa only [sub_self, mem_range, not_exists] using fun k ↦ P.ne_zero k
   classical
-  have _i : Fintype ι := Fintype.ofFinite ι
   let f : ι → ℤ := fun k ↦ if k = i then 1 else if k = j then -1 else 0
-  have hf : ∑ k, f k • P.root k = P.root i - P.root j := by
-    rw [← Fintype.sum_subset (s := {i, j}) (by aesop), Finset.sum_insert (by aesop),
-      Finset.sum_singleton]
+  have hf : ∑ k ∈ b.support, f k • P.root k = P.root i - P.root j := by
+    have : {i, j} ⊆ b.support := by aesop (add simp Finset.insert_subset_iff)
+    rw [← Finset.sum_subset (s₁ := {i, j}) (s₂ := b.support) (by aesop) (by aesop),
+      Finset.sum_insert (by aesop), Finset.sum_singleton]
     simp [f, hij, sub_eq_add_neg]
   intro contra
   rcases b.pos_or_neg_of_sum_smul_root_mem f (by rwa [hf]) (by aesop) with pos | neg
-  · simpa [hij, f] using pos j
-  · simpa [hij, f] using neg i
+  · simpa [hij, f] using le_of_lt pos j
+  · simpa [hij, f] using le_of_lt neg i
 
 @[deprecated (since := "2025-05-24")] alias sub_nmem_range_root := sub_notMem_range_root
 
-lemma sub_notMem_range_coroot [CharZero R] [Finite ι]
+lemma sub_notMem_range_coroot
     {i j : ι} (hi : i ∈ b.support) (hj : j ∈ b.support) :
     P.coroot i - P.coroot j ∉ range P.coroot :=
   b.flip.sub_notMem_range_root hi hj
 
 @[deprecated (since := "2025-05-24")] alias sub_nmem_range_coroot := sub_notMem_range_coroot
 
-lemma pairingIn_le_zero_of_ne [CharZero R] [IsDomain R] [P.IsCrystallographic] [Finite ι]
+lemma pairingIn_le_zero_of_ne [IsDomain R] [P.IsCrystallographic] [Finite ι]
     {i j} (hij : i ≠ j) (hi : i ∈ b.support) (hj : j ∈ b.support) :
     P.pairingIn ℤ i j ≤ 0 := by
   by_contra! h
   exact b.sub_notMem_range_root hi hj <| P.root_sub_root_mem_of_pairingIn_pos h hij
 
-lemma pos_of_sum_smul_sub_mem_range_root
-    [Nontrivial M] [NoZeroSMulDivisors ℤ M] [Fintype ι] [P.IsReduced]
-    {i : ι} (hi : i ∈ b.support) {f : ι → ℕ}
-    (hf₀ : f.support ⊆ b.support)
-    (h₁ : ∑ j, f j • P.root j ∈ range P.root)
-    (h₂ : ∑ j, f j • P.root j - P.root i ∈ range P.root) :
-    0 < f i := by
-  have _i : CharZero R := CharZero.of_noZeroSMulDivisors R M
-  classical
-  let g (j : ι) : ℤ := f j -  if j = i then 1 else 0
-  suffices 0 ≤ g by simpa [g] using this i
-  have hg₀ : g.support ⊆ b.support := fun j hj ↦ by
-    rcases eq_or_ne j i with rfl | hij; · assumption
-    exact hf₀ <| by simpa [hij, g] using hj
-  have hg₁ : ∑ j, g j • P.root j = ∑ j, f j • P.root j - P.root i := by simp [g, sub_smul]
-  suffices ¬ g ≤ 0 by have := b.pos_or_neg_of_sum_smul_root_mem g (by rwa [hg₁]) hg₀; tauto
-  intro contra
-  replace contra (j : ι) (hj : j ≠ i) : f j = 0 := by simpa [g, hj] using contra j
-  replace contra : ∑ j, f j • P.root j = f i • P.root i :=
-    Finset.sum_eq_single_of_mem _ (by aesop) (by aesop)
-  suffices f i = 1 by simp [this ▸ contra, P.ne_zero] at h₂
-  by_contra hfi
-  rw [contra] at h₁
-  have aux : f i ≠ 0 := fun hi₀ ↦ by simp [hi₀, P.ne_zero] at h₁
-  replace hfi : (f i).AtLeastTwo := ⟨by omega⟩
-  exact P.nsmul_notMem_range_root h₁
 variable {b}
-variable [CharZero R] [IsDomain R] [P.IsCrystallographic] [Finite ι] {i j : b.support}
+variable [IsDomain R] [P.IsCrystallographic] [Finite ι] {i j : b.support}
 
 @[simp] lemma chainBotCoeff_eq_zero :
     P.chainBotCoeff i j = 0 :=
@@ -311,151 +315,266 @@ def toCoweightBasis :
     b.toCoweightBasis.repr (P.coroot i) = Finsupp.single i 1 := by
   simp [← LinearEquiv.eq_symm_apply]
 
+end RootSystem
+
+section RootPairing
+
+variable {P : RootPairing ι R M N} (b : P.Base)
+
 include b
-variable [Fintype ι]
 
 lemma exists_root_eq_sum_nat_or_neg (i : ι) :
-    ∃ f : ι → ℕ, P.root i = ∑ j, f j • P.root j ∨ P.root i = - ∑ j, f j • P.root j := by
+    ∃ f : ι → ℕ, f.support ⊆ b.support ∧
+      (P.root i =   ∑ j ∈ b.support, f j • P.root j ∨
+       P.root i = - ∑ j ∈ b.support, f j • P.root j) := by
   classical
   simp_rw [← neg_eq_iff_eq_neg]
-  suffices ∀ m ∈ AddSubmonoid.closure (P.root '' b.support), ∃ f : ι → ℕ, m = ∑ j, f j • P.root j by
+  suffices ∀ m ∈ AddSubmonoid.closure (P.root '' b.support),
+    ∃ f : ι → ℕ, f.support ⊆ b.support ∧ m = ∑ j ∈ b.support, f j • P.root j by
     rcases b.root_mem_or_neg_mem i with hi | hi
-    · obtain ⟨f, hf⟩ := this _ hi
-      exact ⟨f, Or.inl hf⟩
-    · obtain ⟨f, hf⟩ := this _ hi
-      exact ⟨f, Or.inr hf⟩
+    · obtain ⟨f, hf, hf'⟩ := this _ hi
+      exact ⟨f, hf, Or.inl hf'⟩
+    · obtain ⟨f, hf, hf'⟩ := this _ hi
+      exact ⟨f, hf, Or.inr hf'⟩
   intro m hm
   refine AddSubmonoid.closure_induction ?_ ⟨0, by simp⟩ ?_ hm
   · rintro - ⟨j, hj, rfl⟩
-    exact ⟨Pi.single j 1, by simp [Pi.single_apply]⟩
-  · intro _ _ _ _ ⟨f, hf⟩ ⟨g, hg⟩
-    exact ⟨f + g, by simp [hf, hg, add_smul, Finset.sum_add_distrib]⟩
+    exact ⟨Pi.single j 1, by simpa, by aesop (add simp Pi.single_apply)⟩
+  · intro _ _ _ _ ⟨f, hf, hf'⟩ ⟨g, hg, hg'⟩
+    refine ⟨f + g, ?_, by simp [hf', hg', add_smul, Finset.sum_add_distrib]⟩
+    exact (support_add f g).trans <| union_subset_iff.mpr ⟨hf, hg⟩
 
-lemma exists_root_eq_sum_int (i : ι) :
-    ∃ f : ι → ℤ, (0 ≤ f ∨ f ≤ 0) ∧ P.root i = ∑ j, f j • P.root j := by
-  obtain ⟨f, hf | hf⟩ := b.exists_root_eq_sum_nat_or_neg i
-  · exact ⟨  Nat.cast ∘ f, Or.inl fun _ ↦ by simp, by simp [hf]⟩
-  · exact ⟨- Nat.cast ∘ f, Or.inr fun _ ↦ by simp, by simp [hf]⟩
+-- TODO Upgrade to point of strict positivity / negativity belongs to `b.support`?
+lemma exists_root_eq_sum_int [CharZero R] (i : ι) :
+    ∃ f : ι → ℤ, f.support ⊆ b.support ∧ (0 < f ∨ f < 0) ∧
+      P.root i = ∑ j ∈ b.support, f j • P.root j := by
+  obtain ⟨f, hf, hf' | hf'⟩ := b.exists_root_eq_sum_nat_or_neg i
+  · refine ⟨Nat.cast ∘ f, by simpa, Or.inl <| Pi.lt_def.mpr ⟨fun _ ↦ by simp, ?_⟩, by simp [hf']⟩
+    by_contra! contra
+    replace contra : f = 0 := by ext i; simpa using contra i
+    exact P.ne_zero i <| by simp [hf', contra]
+  · refine ⟨-Nat.cast ∘ f, by simpa, Or.inr <| Pi.lt_def.mpr ⟨fun _ ↦ by simp, ?_⟩, by simp [hf']⟩
+    by_contra! contra
+    replace contra : f = 0 := by ext i; simpa using contra i
+    exact P.ne_zero i <| by simp [hf', contra]
 
-lemma exists_coroot_eq_sum_int (i : ι) :
-    ∃ f : ι → ℤ, (0 ≤ f ∨ f ≤ 0) ∧ P.coroot i = ∑ j, f j • P.coroot j :=
-  b.flip.exists_root_eq_sum_int i (P := P.flip)
-
-end RootSystem
+end RootPairing
 
 section PositiveRoots
 
-variable {P : RootPairing ι R M N} (b : P.Base) [Fintype ι]
+variable {P : RootPairing ι R M N} (b : P.Base) [CharZero R]
+
+/-- Given a base `α₁, α₂, …`, the height of a root `∑ zᵢαᵢ` relative to this base is `∑ zᵢ`. -/
+def height (i : ι) : ℤ :=
+  ∑ j ∈ b.support, (b.exists_root_eq_sum_int i).choose j
+
+variable {b} in
+lemma height_eq_sum {i : ι} {f : ι → ℤ} (heq : P.root i = ∑ j ∈ b.support, f j • P.root j) :
+    b.height i = ∑ j ∈ b.support, f j := by
+  suffices ∀ j ∈ b.support, (b.exists_root_eq_sum_int i).choose j = f j from
+    Finset.sum_congr rfl this
+  intro j hj
+  obtain ⟨-, -, h⟩ := (b.exists_root_eq_sum_int i).choose_spec
+  rw [h, b.support.sum_subtype (p := (· ∈ b.support)) (by simp) (F := inferInstance),
+    b.support.sum_subtype (p := (· ∈ b.support)) (by simp) (F := inferInstance)] at heq
+  have aux (j : b.support) := Fintype.linearIndependent_iffₛ.mp
+      (b.linearIndepOn_root.restrict_scalars' ℤ) ((b.exists_root_eq_sum_int i).choose ∘ (↑))
+      (f ∘ (↑)) (by simpa) j
+  simpa using aux ⟨j, hj⟩
+
+lemma height_ne_zero (i : ι) :
+    b.height i ≠ 0 := by
+  obtain ⟨f, hf₀, hf₁, hf₂⟩ := b.exists_root_eq_sum_int i
+  rw [height_eq_sum hf₂]
+  rcases hf₁ with pos | neg
+  · refine (Finset.sum_pos' (fun i _ ↦ pos.le i) ?_).ne'
+    by_contra! contra
+    replace contra (j : ι) : f j = 0 := by
+      by_cases hj : j ∈ f.support
+      · exact le_antisymm (contra j (hf₀ hj)) (pos.le j)
+      · simpa using hj
+    exact P.ne_zero i <| by simp [hf₂, contra]
+  · refine (Finset.sum_neg' (fun i _ ↦ neg.le i) ?_).ne
+    by_contra! contra
+    replace contra (j : ι) : f j = 0 := by
+      by_cases hj : j ∈ f.support
+      · exact le_antisymm (neg.le j) (contra j (hf₀ hj))
+      · simpa using hj
+    exact P.ne_zero i <| by simp [hf₂, contra]
+
+lemma height_reflectionPerm_self (i : ι) :
+    letI := P.indexNeg
+    b.height (-i) = -b.height i := by
+  letI := P.indexNeg
+  obtain ⟨f, hf₀, hf₁, hf₂⟩ := b.exists_root_eq_sum_int i
+  have hf₃ : P.root (-i) = ∑ j ∈ b.support, (-f) j • P.root j := by simpa
+  simp only [height_eq_sum hf₂, height_eq_sum hf₃, Pi.neg_apply, Finset.sum_neg_distrib]
+
+variable {b} in
+lemma height_one_of_mem_support {i : ι} (hi : i ∈ b.support) :
+    b.height i = 1 := by
+  classical
+  have : P.root i = ∑ j ∈ b.support, (Pi.single i 1 : ι → ℤ) j • P.root j := by
+    rw [Finset.sum_eq_single_of_mem i hi (by aesop)]; simp
+  simpa [height_eq_sum this]
+
+lemma height_add {i j k : ι} (hk : P.root k = P.root i + P.root j) :
+    b.height k = b.height i + b.height j := by
+  obtain ⟨f, -, -, hf⟩ := b.exists_root_eq_sum_int i
+  obtain ⟨g, -, -, hg⟩ := b.exists_root_eq_sum_int j
+  have hfg : P.root k = ∑ l ∈ b.support, (f + g) l • P.root l := by
+    simp_rw [Pi.add_apply, add_smul, Finset.sum_add_distrib, ← hf, ← hg, hk]
+  simp_rw [height_eq_sum hf, height_eq_sum hg, height_eq_sum hfg, ← Finset.sum_add_distrib,
+    Pi.add_apply]
+
+lemma height_sub {i j k : ι} (hk : P.root k = P.root i - P.root j) :
+    b.height k = b.height i - b.height j := by
+  letI := P.indexNeg
+  replace hk : P.root k = P.root i + P.root (-j) := by simpa [← sub_eq_add_neg]
+  rw [sub_eq_add_neg, ← b.height_reflectionPerm_self, b.height_add hk]
+
+lemma height_add_zsmul {i j k : ι} {z : ℤ} (hk : P.root k = P.root i + z • P.root j) :
+    b.height k = b.height i + z • b.height j := by
+  obtain ⟨f, -, -, hf⟩ := b.exists_root_eq_sum_int i
+  obtain ⟨g, -, -, hg⟩ := b.exists_root_eq_sum_int j
+  have hfg : P.root k = ∑ l ∈ b.support, (f + z • g) l • P.root l := by
+    simp_rw [Pi.add_apply, Pi.smul_apply, add_smul, smul_assoc, Finset.sum_add_distrib,
+      ← Finset.smul_sum, ← hf, ← hg, hk]
+  simp_rw [height_eq_sum hf, height_eq_sum hg, height_eq_sum hfg, Pi.add_apply, Pi.smul_apply,
+    Finset.sum_add_distrib, Finset.smul_sum]
 
 /-- The predicate that a (co)root is positive with respect to a base. -/
-def IsPos (i : ι) : Prop :=
-  ∃ f : ι → ℕ, f.support ⊆ b.support ∧ P.root i = ∑ j, f j • P.root j
+def IsPos (i : ι) : Prop := 0 < b.height i
+
+lemma isPos_iff {i : ι} : b.IsPos i ↔ 0 < b.height i := Iff.rfl
+
+lemma isPos_iff' {i : ι} : b.IsPos i ↔ 0 ≤ b.height i := by
+  rw [isPos_iff]
+  have := b.height_ne_zero i
+  omega
+
+lemma IsPos.or_neg (i : ι) :
+    letI := P.indexNeg
+    b.IsPos i ∨ b.IsPos (-i) := by
+  rw [isPos_iff, isPos_iff, height_reflectionPerm_self]
+  have := b.height_ne_zero i
+  omega
+
+lemma IsPos.neg_iff_not (i : ι) :
+    letI := P.indexNeg
+    b.IsPos (-i) ↔ ¬ b.IsPos i := by
+  rw [isPos_iff, isPos_iff, height_reflectionPerm_self]
+  have := b.height_ne_zero i
+  omega
 
 variable {b}
 
-lemma IsPos.add {i j k : ι}
-    (hi : b.IsPos i) (hj : j ∈ b.support) (hk : P.root k = P.root i + P.root j) :
-    b.IsPos k := by
-  classical
-  obtain ⟨f, hf, hf'⟩ := hi
-  refine ⟨f + Pi.single j 1, ?_, ?_⟩
-  · apply (Function.support_add (f := f) (g := Pi.single j 1)).trans
-    simp [insert_subset_iff, hj, hf]
-  · simp_rw [hk, Pi.add_apply, add_smul, Finset.sum_add_distrib, ← hf']
-    rw [Finset.sum_eq_single_of_mem j (Finset.mem_univ _) (fun x _ h ↦ by simp [h]),
-      Pi.single_eq_same, one_smul]
+lemma isPos_of_mem_support {i : ι} (h : i ∈ b.support) :
+    b.IsPos i := by
+  rw [isPos_iff, height_one_of_mem_support h]
+  exact Int.one_pos
 
-lemma IsPos.sub [P.IsReduced] [Nontrivial M] [NoZeroSMulDivisors ℤ M] {i j k : ι}
+lemma IsPos.add {i j k : ι}
+    (hi : b.IsPos i) (hj : b.IsPos j) (hk : P.root k = P.root i + P.root j) :
+    b.IsPos k := by
+  rw [isPos_iff] at hi hj ⊢
+  rw [b.height_add hk]
+  omega
+
+lemma IsPos.sub {i j k : ι}
     (hi : b.IsPos i) (hj : j ∈ b.support) (hk : P.root k = P.root i - P.root j) :
     b.IsPos k := by
-  classical
-  obtain ⟨f, hf, hf'⟩ := hi
-  let f' := f - Pi.single j 1
-  suffices f = f' + Pi.single j 1 by
-    refine ⟨f', fun l hl ↦ ?_, ?_⟩
-    · rcases eq_or_ne j l with rfl | hlj; · assumption
-      apply hf
-      simpa [f', hlj] using hl
-    · simp_rw [hk, hf', this, Pi.add_apply, add_smul, Finset.sum_add_distrib, add_sub_assoc,
-        add_eq_left]
-      rw [Finset.sum_eq_single_of_mem j (Finset.mem_univ _) (fun x _ h ↦ by simp [h]),
-        Pi.single_eq_same, one_smul, sub_self]
-  ext l
-  rcases eq_or_ne j l with rfl | hl
-  · suffices 0 < f j by simp only [Pi.add_apply, Pi.sub_apply, Pi.single_eq_same, f']; omega
-    apply b.pos_of_sum_smul_sub_mem_range_root hj hf (hf' ▸ mem_range_self i)
-    rw [← hf', ← hk]
-    exact mem_range_self k
-  · simp [hl, f']
+  rw [isPos_iff] at hi
+  rw [isPos_iff', b.height_sub hk, height_one_of_mem_support hj]
+  omega
 
-variable [P.IsCrystallographic]
-
-lemma IsPos.exists_mem_support_pos_pairingIn [CharZero R] {i : ι} (h₀ : b.IsPos i) :
-    ∃ j ∈ b.support, 0 < P.pairingIn ℤ i j := by
-  simp_rw [P.zero_lt_pairingIn_iff' (S := ℤ) (i := i)]
+lemma IsPos.exists_mem_support_pos_pairingIn [P.IsCrystallographic] {i : ι} (h₀ : b.IsPos i) :
+    ∃ j ∈ b.support, 0 < P.pairingIn ℤ j i := by
   by_contra! contra
   suffices P.pairingIn ℤ i i ≤ 0 by aesop
-  obtain ⟨f, hf, hf'⟩ := h₀
-  have : P.pairingIn ℤ i i = ∑ j, f j • P.pairingIn ℤ j i := algebraMap_injective ℤ R <| by
-    simp_rw [algebraMap_pairingIn, map_sum, ← root_coroot_eq_pairing, hf', map_sum, map_nsmul,
-      LinearMap.coeFn_sum, Finset.sum_apply, LinearMap.smul_apply, root_coroot_eq_pairing,
-      nsmul_eq_mul, algebraMap_pairingIn]
+  obtain ⟨f, hf₀, hf₁, hf₂⟩ := b.exists_root_eq_sum_int i
+  replace hf₁ : 0 < f := by
+    refine hf₁.resolve_right ?_
+    rw [isPos_iff, height_eq_sum hf₂] at h₀
+    contrapose! h₀
+    exact Finset.sum_nonpos fun i _ ↦ h₀.le i
+  have : P.pairingIn ℤ i i = ∑ j ∈ b.support, f j • P.pairingIn ℤ j i :=
+    algebraMap_injective ℤ R <| by
+      simp_rw [algebraMap_pairingIn, map_sum, ← root_coroot_eq_pairing, hf₂, map_sum, map_zsmul,
+        LinearMap.coeFn_sum, Finset.sum_apply, LinearMap.smul_apply, root_coroot_eq_pairing,
+        zsmul_eq_mul, algebraMap_pairingIn]
   rw [this]
   refine Finset.sum_nonpos fun j _ ↦ ?_
   by_cases hj : j ∈ Function.support f
-  · exact Left.nsmul_nonpos (contra j (hf hj)) (f j)
+  · exact smul_nonpos_of_nonneg_of_nonpos (hf₁.le j) (contra j (hf₀ hj))
   · aesop
 
-variable [P.IsReduced] [Nontrivial M] [NoZeroSMulDivisors ℤ M] [IsDomain R]
+variable [Finite ι] [IsDomain R] [P.IsCrystallographic] [P.IsReduced]
 
-lemma IsPos.induction_on
+lemma IsPos.add_zsmul {i j k : ι} {z : ℤ} (hij : i ≠ j)
+    (hi : b.IsPos i) (hj : j ∈ b.support) (hk : P.root k = P.root i + z • P.root j) :
+    b.IsPos k := by
+  replace hij : LinearIndependent R ![P.root j, P.root i] := by
+    refine IsReduced.linearIndependent P hij.symm fun contra ↦ ?_
+    letI := P.indexNeg
+    replace contra : i = -j := by rw [eq_comm, neg_eq_iff_eq_neg]; simpa using contra
+    rw [contra, isPos_iff, height_reflectionPerm_self, height_one_of_mem_support hj] at hi
+    omega
+  induction z generalizing i k with
+  | zero => aesop
+  | succ w hw =>
+    obtain ⟨l, hl⟩ : P.root i + (w : ℤ) • P.root j ∈ range P.root := by
+      replace hk : P.root i + (w + 1) • P.root j ∈ range P.root := ⟨k, by rw [hk]; module⟩
+      simp only [natCast_zsmul, root_add_nsmul_mem_range_iff_le_chainTopCoeff hij] at hk ⊢
+      omega
+    replace hk : P.root k = P.root l + P.root j := by rw [hk, hl]; module
+    exact (hw hi hl hij).add (b.isPos_of_mem_support hj) hk
+  | pred w hw =>
+    obtain ⟨l, hl⟩ : P.root i + (-w : ℤ) • P.root j ∈ range P.root := by
+      replace hk : P.root i - (w + 1) • P.root j ∈ range P.root := ⟨k, by rw [hk]; module⟩
+      rw [neg_smul, ← sub_eq_add_neg, natCast_zsmul]
+      simp only [root_sub_nsmul_mem_range_iff_le_chainBotCoeff hij] at hk ⊢
+      omega
+    replace hk : P.root k = P.root l - P.root j := by rw [hk, hl]; module
+    exact (hw hi hl hij).sub hj hk
+
+lemma IsPos.reflectionPerm {i j : ι} (hi : b.IsPos i) (hj : j ∈ b.support) (hij : i ≠ j) :
+    b.IsPos (P.reflectionPerm j i) := by
+  have : P.root (P.reflectionPerm j i) = P.root i + (-P.pairingIn ℤ i j) • P.root j := by
+    rw [root_reflectionPerm, neg_smul, reflection_apply_root' ℤ, sub_eq_add_neg]
+  exact hi.add_zsmul hij hj this
+
+omit [P.IsReduced] in
+lemma IsPos.induction_on_add
     {i : ι} (h₀ : b.IsPos i)
     {p : ι → Prop}
     (h₁ : ∀ i ∈ b.support, p i)
     (h₂ : ∀ i j k, P.root k = P.root i + P.root j → p i → j ∈ b.support → p k) :
     p i := by
-  classical
-  have _i : CharZero R := CharZero.of_noZeroSMulDivisors R M
-  obtain ⟨f, hf₀, hf⟩ := id h₀
-  generalize hN : ∑ j, f j = N
-  induction N using Nat.recOn generalizing f i with
-  | zero =>
-    exfalso
-    apply P.ne_zero i
-    replace hN : f = 0 := by ext; aesop
-    simpa [hN] using hf
+  generalize hN : b.height i = N
+  induction N using Int.induction_on generalizing i with
+  | zero => exact False.elim <| b.height_ne_zero i hN
   | succ n ih =>
     obtain ⟨j, hj, hj'⟩ := h₀.exists_mem_support_pos_pairingIn
+    rw [P.zero_lt_pairingIn_iff'] at hj'
     rcases eq_or_ne i j with rfl | hij; · exact h₁ i hj
     obtain ⟨k, hk⟩ := P.root_sub_root_mem_of_pairingIn_pos hj' hij
-    let f' := f - Pi.single j 1
-    have hf'₀ : Function.support f' ⊆ b.support := fun l hl ↦ by
-      rcases eq_or_ne j l with rfl | hjl; · assumption
-      exact hf₀ <| by simpa [hjl, f'] using hl
-    have hff' : f = f' + Pi.single j 1 := by
-      ext l
-      rcases ne_or_eq j l with hl | rfl; · simp [hl, f']
-      suffices 0 < f j by simp only [Pi.add_apply, Pi.sub_apply, Pi.single_eq_same, f']; omega
-      apply b.pos_of_sum_smul_sub_mem_range_root hj hf₀ (hf ▸ mem_range_self i)
-      rw [← hf, ← hk]
-      exact mem_range_self k
-    have hf' : ∑ k, f' k = n := by simpa [hff', Finset.sum_add_distrib, hj] using hN
-    have hfk : P.root k = ∑ j, f' j • P.root j := by
-      have aux : ∀ l ∈ Finset.univ, l ≠ j → Pi.single (M := fun _ ↦ M) j (P.root l) l = 0 :=
-        fun l _ hl ↦ by simp [hl]
-      simp_rw [hk, hf, hff', Pi.add_apply, add_smul, Finset.sum_add_distrib, Pi.single_apply_smul,
-        add_sub_assoc, add_eq_left, sub_eq_zero,
-        Finset.sum_eq_single_of_mem j (Finset.mem_univ j) aux, Pi.single_eq_same]
-    exact h₂ k j i (by simp [hk]) (ih (h₀.sub hj hk) f' hf'₀ hfk hf') hj
+    have hkn : b.height k = n := by rw [b.height_sub hk, height_one_of_mem_support hj]; omega
+    have hkpos : b.IsPos k := by rw [isPos_iff']; omega
+    exact h₂ k j i (by rw [hk]; module) (ih hkpos hkn) hj
+  | pred n ih =>
+    rw [isPos_iff] at h₀
+    omega
 
+omit [P.IsReduced] in
 /-- This lemma is included mostly for comparison with the informal literature. Usually
-`RootPairing.Base.induction_on_pos` will be more useful. -/
+`RootPairing.Base.IsPos.induction_on_add` will be more useful. -/
 lemma exists_eq_sum_and_forall_sum_mem_of_isPos {i : ι} (hi : b.IsPos i) :
     ∃ n, ∃ f : Fin n → ι,
       range f ⊆ b.support ∧
       P.root i = ∑ m, P.root (f m) ∧
       ∀ m, ∑ m' ≤ m, P.root (f m') ∈ range P.root := by
-  apply hi.induction_on (fun j hj ↦ ⟨1, ![j], by simpa⟩)
+  apply hi.induction_on_add (fun j hj ↦ ⟨1, ![j], by simpa⟩)
   intro j k l h₁ ⟨n, f, h₂, h₃, h₄⟩ h₅
   refine ⟨n + 1, Fin.snoc f k, ?_, ?_, fun m ↦ ?_⟩
   · simpa using insert_subset h₅ h₂
@@ -467,6 +586,67 @@ lemma exists_eq_sum_and_forall_sum_mem_of_isPos {i : ι} (hi : b.IsPos i) :
     · replace hm : m = n := by omega
       replace hm : Finset.Iic m = Finset.univ := by ext; simp [hm, Fin.le_def, Fin.is_le]
       simp [hm, Fin.sum_univ_castSucc, ← h₃, ← h₁]
+
+omit [P.IsReduced] in
+lemma induction_add (i : ι) {p : ι → Prop}
+    (h₀ : ∀ i, p i → p (P.reflectionPerm i i))
+    (h₁ : ∀ i ∈ b.support, p i)
+    (h₂ : ∀ i j k, P.root k = P.root i + P.root j → p i → j ∈ b.support → p k) :
+    p i := by
+  letI := P.indexNeg
+  rcases IsPos.or_neg b i with hi | hi
+  · exact hi.induction_on_add h₁ h₂
+  · suffices p (-i) by rw [← neg_neg i]; exact h₀ (-i) this
+    exact hi.induction_on_add h₁ h₂
+
+lemma IsPos.induction_on_reflect
+    {i : ι} (h₀ : b.IsPos i)
+    {p : ι → Prop}
+    (h₁ : ∀ i ∈ b.support, p i)
+    (h₂ : ∀ i j, p i → j ∈ b.support → p (P.reflectionPerm j i)) :
+    p i := by
+  generalize hN : (b.height i).natAbs = N
+  induction N using Nat.strongRecOn generalizing i with
+  | ind n ih =>
+    obtain ⟨j, hj, hj'⟩ := h₀.exists_mem_support_pos_pairingIn
+    rw [P.zero_lt_pairingIn_iff'] at hj'
+    rcases eq_or_ne i j with rfl | hij; · exact h₁ i hj
+    have hk := h₀.reflectionPerm hj hij
+    have : (b.height (P.reflectionPerm j i)).natAbs < n := by
+      suffices b.height (P.reflectionPerm j i) < b.height i by
+        have : (b.height (P.reflectionPerm j i)).natAbs = b.height (P.reflectionPerm j i) :=
+          Int.natAbs_of_nonneg <| (isPos_iff' _).mp hk
+        omega
+      have := P.reflection_apply_root' ℤ (i := j) (j := i)
+      rw [← root_reflectionPerm, sub_eq_add_neg, ← neg_smul] at this
+      rw [b.height_add_zsmul this]
+      replace hj : 0 < b.height j := (isPos_iff _).mp <| isPos_of_mem_support hj
+      aesop
+    simpa using h₂ (P.reflectionPerm j i) j
+      (ih (m := (b.height (P.reflectionPerm j i)).natAbs) this hk rfl) hj
+
+lemma induction_reflect (i : ι) {p : ι → Prop}
+    (h₀ : ∀ i, p i → p (P.reflectionPerm i i))
+    (h₁ : ∀ i ∈ b.support, p i)
+    (h₂ : ∀ i j, p i → j ∈ b.support → p (P.reflectionPerm j i)) :
+    p i := by
+  letI := P.indexNeg
+  rcases IsPos.or_neg b i with hi | hi
+  · exact hi.induction_on_reflect h₁ h₂
+  · suffices p (-i) by rw [← neg_neg i]; exact h₀ (-i) this
+    exact hi.induction_on_reflect h₁ h₂
+
+lemma forall_mem_support_invtSubmodule_iff (q : Submodule R M) :
+    (∀ i ∈ b.support, q ∈ invtSubmodule (P.reflection i)) ↔
+      (∀ i, q ∈ invtSubmodule (P.reflection i)) := by
+  refine ⟨fun hq i ↦ ?_, fun hq i _ ↦ hq i⟩
+  letI := P.indexNeg
+  have (j : ι) : P.reflection (-j) = P.reflection j := by ext x; simp [reflection_apply, two_smul]
+  refine b.induction_reflect i (by aesop) hq ?_
+  clear i
+  intro i j hi hj
+  rw [reflection_reflectionPerm]
+  exact Module.End.invtSubmodule.comp _ (Module.End.invtSubmodule.comp _ (hq j hj) hi) (hq j hj)
 
 end PositiveRoots
 

--- a/Mathlib/LinearAlgebra/RootSystem/Base.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Base.lean
@@ -344,7 +344,6 @@ lemma exists_root_eq_sum_nat_or_neg (i : ι) :
     refine ⟨f + g, ?_, by simp [hf', hg', add_smul, Finset.sum_add_distrib]⟩
     exact (support_add f g).trans <| union_subset_iff.mpr ⟨hf, hg⟩
 
--- TODO Upgrade to point of strict positivity / negativity belongs to `b.support`?
 lemma exists_root_eq_sum_int [CharZero R] (i : ι) :
     ∃ f : ι → ℤ, f.support ⊆ b.support ∧ (0 < f ∨ f < 0) ∧
       P.root i = ∑ j ∈ b.support, f j • P.root j := by

--- a/Mathlib/LinearAlgebra/RootSystem/CartanMatrix.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/CartanMatrix.lean
@@ -162,7 +162,7 @@ lemma cartanMatrix_nondegenerate
   cartanMatrixIn_nondegenerate ℤ b
 
 /-- A characterisation of the connectedness of the Dynkin diagram for irreducible root pairings. -/
-lemma induction_on_cartanMatrix [NoZeroSMulDivisors ℤ M] [P.IsReduced] [P.IsIrreducible]
+lemma induction_on_cartanMatrix [P.IsReduced] [P.IsIrreducible]
     (p : b.support → Prop) {i j : b.support} (hi : p i)
     (hp : ∀ i j, p i → b.cartanMatrix j i ≠ 0 → p j) :
     p j := by

--- a/Mathlib/LinearAlgebra/RootSystem/CartanMatrix.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/CartanMatrix.lean
@@ -17,12 +17,17 @@ This file contains definitions and basic results about Cartan matrices of root p
 * `RootPairing.Base.cartanMatrix`: the Cartan matrix of a crystallographic root pairing, with
   respect to a base `b`.
 * `RootPairing.Base.cartanMatrix_nondegenerate`: the Cartan matrix is non-degenerate.
+* `RootPairing.Base.induction_on_cartanMatrix`: an induction principle expressing the connectedness
+  of the Dynkin diagram of an irreducible root pairing.
 
 -/
 
 noncomputable section
 
+open FaithfulSMul (algebraMap_injective)
 open Function Set
+open Module.End (invtSubmodule mem_invtSubmodule)
+open Submodule (span subset_span)
 
 variable {ι R M N : Type*} [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
 
@@ -56,7 +61,7 @@ lemma cartanMatrixIn_apply_same [FaithfulSMul S R] (i : b.support) :
 `[P.IsValuedIn S]` then such a base would provide basis of `P.rootSpan S` and we could avoid
 using `Matrix.map` below. -/
 lemma cartanMatrixIn_mul_diagonal_eq {P : RootSystem ι R M N} [P.IsValuedIn S]
-    (B : P.InvariantForm) (b : P.Base) [DecidableEq ι] [Fintype b.support] :
+    (B : P.InvariantForm) (b : P.Base) [DecidableEq ι] :
     (b.cartanMatrixIn S).map (algebraMap S R) *
       (Matrix.diagonal fun i : b.support ↦ B.form (P.root i) (P.root i)) =
       (2 : R) • BilinForm.toMatrix b.toWeightBasis B.form := by
@@ -94,12 +99,26 @@ lemma cartanMatrix_apply_same (i : b.support) :
     b.cartanMatrix i i = 2 :=
   b.cartanMatrixIn_apply_same ℤ i
 
-lemma cartanMatrix_le_zero_of_ne [Finite ι] [IsDomain R]
+lemma cartanMatrix_apply_eq_zero_iff_pairing {i j : b.support} :
+    b.cartanMatrix i j = 0 ↔ P.pairing i j = 0 := by
+  rw [cartanMatrix, cartanMatrixIn_def, ← (algebraMap_injective ℤ R).eq_iff,
+    algebraMap_pairingIn, map_zero]
+
+variable [IsDomain R]
+
+lemma cartanMatrix_apply_eq_zero_iff_symm {i j : b.support} :
+    b.cartanMatrix i j = 0 ↔ b.cartanMatrix j i = 0 := by
+  have _i := P.reflexive_left
+  simp only [cartanMatrix_apply_eq_zero_iff_pairing, P.pairing_eq_zero_iff]
+
+variable [Finite ι]
+
+lemma cartanMatrix_le_zero_of_ne
     (i j : b.support) (h : i ≠ j) :
     b.cartanMatrix i j ≤ 0 :=
   b.pairingIn_le_zero_of_ne (by rwa [ne_eq, ← Subtype.ext_iff]) i.property j.property
 
-lemma cartanMatrix_mem_of_ne [Finite ι] [IsDomain R] {i j : b.support} (hij : i ≠ j) :
+lemma cartanMatrix_mem_of_ne {i j : b.support} (hij : i ≠ j) :
     b.cartanMatrix i j ∈ ({-3, -2, -1, 0} : Set ℤ) := by
   have := P.reflexive_left
   have := P.reflexive_right
@@ -114,33 +133,71 @@ lemma cartanMatrix_mem_of_ne [Finite ι] [IsDomain R] {i j : b.support} (hij : i
   refine ⟨⟨{i, j}, by simpa⟩, Finsupp.single i (1 : R) + Finsupp.single j (2 : R), ?_⟩
   simp [contra, hij, hij.symm]
 
-lemma cartanMatrix_eq_neg_chainTopCoeff [Finite ι] [IsDomain R] {i j : b.support} (hij : i ≠ j) :
+lemma cartanMatrix_eq_neg_chainTopCoeff {i j : b.support} (hij : i ≠ j) :
     b.cartanMatrix i j = - P.chainTopCoeff j i := by
   rw [cartanMatrix, cartanMatrixIn_def, ← neg_eq_iff_eq_neg, ← b.chainTopCoeff_eq_of_ne hij.symm]
 
-lemma cartanMatrix_apply_eq_zero_iff [Finite ι] [IsDomain R] {i j : b.support} (hij : i ≠ j) :
+lemma cartanMatrix_apply_eq_zero_iff {i j : b.support} (hij : i ≠ j) :
     b.cartanMatrix i j = 0 ↔ P.root i + P.root j ∉ range P.root := by
   rw [b.cartanMatrix_eq_neg_chainTopCoeff hij, neg_eq_zero, Int.natCast_eq_zero,
     P.chainTopCoeff_eq_zero_iff]
   replace hij := b.linearIndependent_pair_of_ne hij.symm
   tauto
 
-lemma abs_cartanMatrix_apply [Finite ι] [DecidableEq ι] [IsDomain R] {i j : b.support} :
+lemma abs_cartanMatrix_apply [DecidableEq ι] {i j : b.support} :
     |b.cartanMatrix i j| = (if i = j then 4 else 0) - b.cartanMatrix i j := by
   rcases eq_or_ne i j with rfl | h
   · simp
   · simpa [h] using b.cartanMatrix_le_zero_of_ne i j h
 
 @[simp]
-lemma cartanMatrix_map_abs [DecidableEq ι] [Finite ι] [IsDomain R] :
+lemma cartanMatrix_map_abs [DecidableEq ι] :
     b.cartanMatrix.map abs = 4 • 1 - b.cartanMatrix := by
   ext; simp [abs_cartanMatrix_apply, Matrix.ofNat_apply]
 
-lemma cartanMatrix_nondegenerate [Finite ι] [IsDomain R]
+lemma cartanMatrix_nondegenerate
     {P : RootSystem ι R M N} [P.IsCrystallographic] (b : P.Base) :
     b.cartanMatrix.Nondegenerate :=
   let _i : Fintype ι := Fintype.ofFinite ι
   cartanMatrixIn_nondegenerate ℤ b
+
+/-- A characterisation of the connectedness of the Dynkin diagram for irreducible root pairings. -/
+lemma induction_on_cartanMatrix [NoZeroSMulDivisors ℤ M] [P.IsReduced] [P.IsIrreducible]
+    (p : b.support → Prop) {i j : b.support} (hi : p i)
+    (hp : ∀ i j, p i → b.cartanMatrix j i ≠ 0 → p j) :
+    p j := by
+  have _i : Nontrivial M := ⟨P.root i, 0, P.ne_zero i⟩
+  let q : Submodule R M := span R (P.root ∘ (↑) '' {i | p i})
+  have hq₀ : q ≠ ⊥ := q.ne_bot_iff.mpr ⟨P.root i, subset_span <| by simpa, P.ne_zero i⟩
+  have hq_mem (k : b.support) : P.root k ∈ q ↔ p k := by
+    refine ⟨fun hk ↦ ?_, fun hk ↦ subset_span <| by simpa⟩
+    contrapose! hk
+    exact b.linearIndepOn_root.linearIndependent.notMem_span_image hk
+  have hq_notMem (k : b.support) (hk : P.root k ∉ q) : q ≤ LinearMap.ker (P.coroot' k) := by
+    refine fun x hx ↦ LinearMap.mem_ker.mpr ?_
+    contrapose! hk
+    rw [hq_mem]
+    induction hx using Submodule.span_induction with
+    | mem x hx =>
+      obtain ⟨l, hl, rfl⟩ : ∃ l : b.support, p l ∧ P.root l = x := by aesop
+      replace hk : b.cartanMatrix k l ≠ 0 := by
+        rwa [ne_eq, cartanMatrix_apply_eq_zero_iff_symm, cartanMatrix_apply_eq_zero_iff_pairing]
+      tauto
+    | zero => aesop
+    | add x y hx hy hx' hy' =>
+      replace hk : P.coroot' k x ≠ 0 ∨ P.coroot' k y ≠ 0 := by by_contra! contra; aesop
+      tauto
+    | smul a x hx hx' => aesop
+  have hq : ∀ k, q ∈ invtSubmodule (P.reflection k) := by
+    rw [← b.forall_mem_support_invtSubmodule_iff]
+    refine fun k hkb ↦ (mem_invtSubmodule _).mpr fun x hx ↦ ?_
+    rw [Submodule.mem_comap, LinearEquiv.coe_coe, reflection_apply]
+    apply q.sub_mem hx
+    by_cases hk : P.root k ∈ q
+    · exact q.smul_mem _ hk
+    · replace hk : P.coroot' k x = 0 := hq_notMem ⟨k, hkb⟩ hk hx
+      simp [hk]
+  simp [← hq_mem, IsIrreducible.eq_top_of_invtSubmodule_reflection q hq hq₀]
 
 end IsCrystallographic
 

--- a/Mathlib/LinearAlgebra/RootSystem/Defs.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Defs.lean
@@ -368,6 +368,14 @@ lemma coreflection_eq_flip_reflection :
     P.coreflection i = P.flip.reflection i :=
   rfl
 
+lemma reflection_reflectionPerm {i j : ι} :
+    P.reflection (P.reflectionPerm j i) = P.reflection j * P.reflection i * P.reflection j := by
+  ext x
+  simp only [reflection_apply, coreflection_apply, PerfectPairing.flip_apply_apply,
+    coroot_reflectionPerm, root_coroot_eq_pairing, map_sub, map_smul, smul_eq_mul,
+    root_reflectionPerm, LinearEquiv.mul_apply, pairing_same]
+  module
+
 lemma reflection_dualMap_eq_coreflection :
     (P.reflection i).dualMap ∘ₗ P.toLinearMap.flip = P.toLinearMap.flip ∘ₗ P.coreflection i := by
   ext n m

--- a/Mathlib/LinearAlgebra/RootSystem/IsValuedIn.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/IsValuedIn.lean
@@ -292,7 +292,7 @@ lemma pairingIn_eq_zero_iff {S : Type*} [CommRing S] [Algebra S R] [FaithfulSMul
     P.pairing_eq_zero_iff
 
 variable {P i j} in
-lemma reflection_apply_root' (S : Type*) [CommRing S] [Algebra S R] [FaithfulSMul S R]
+lemma reflection_apply_root' (S : Type*) [CommRing S] [Algebra S R]
     [Module S M] [IsScalarTower S R M] [P.IsValuedIn S] :
     P.reflection i (P.root j) = P.root j - (P.pairingIn S j i) • P.root i := by
   rw [reflection_apply_root, ← P.algebraMap_pairingIn S, algebraMap_smul]

--- a/Mathlib/LinearAlgebra/RootSystem/IsValuedIn.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/IsValuedIn.lean
@@ -291,6 +291,12 @@ lemma pairingIn_eq_zero_iff {S : Type*} [CommRing S] [Algebra S R] [FaithfulSMul
   simpa only [← FaithfulSMul.algebraMap_eq_zero_iff S R, algebraMap_pairingIn] using
     P.pairing_eq_zero_iff
 
+variable {P i j} in
+lemma reflection_apply_root' (S : Type*) [CommRing S] [Algebra S R] [FaithfulSMul S R]
+    [Module S M] [IsScalarTower S R M] [P.IsValuedIn S] :
+    P.reflection i (P.root j) = P.root j - (P.pairingIn S j i) • P.root i := by
+  rw [reflection_apply_root, ← P.algebraMap_pairingIn S, algebraMap_smul]
+
 /-- A variant of `RootPairing.coxeterWeight` for root pairings which are valued in a smaller set of
 coefficients.
 


### PR DESCRIPTION
The headline result is `RootPairing.Base.induction_on_cartanMatrix`. In order to prove this we add a second induction principle for root system bases `RootPairing.Base.induction_reflect`. This is essentially equivalent to the fact that the Weyl group is generated by simple reflections.

This is almost the first time `RootPairing.Base` has been used in a non-trivial way and as a result some further development of its API was necessary. In particular:

* We systematically change pattern `∑ j, f j • P.root j` to
  `∑ j ∈ b.support, f j • P.root j` (removing various issues assocated with `Fintype ι`).
* We introduce a new definition `RootPairing.Base.height` and use it to redefine
  `RootPairing.Base.IsPos`


---



<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
