### PR TITLE
[Merged by Bors] - feat(Topology/MetricSpace/HausdorffDimension): Proves `dimH s < ⊤` in finite-dimensional normed spaces

### DIFF
--- a/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
+++ b/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
@@ -461,6 +461,14 @@ theorem dimH_univ_eq_finrank : dimH (univ : Set E) = finrank ℝ E :=
 theorem dimH_univ : dimH (univ : Set ℝ) = 1 := by
   rw [dimH_univ_eq_finrank ℝ, Module.finrank_self, Nat.cast_one]
 
+/-- The Hausdorff dimension of any set in a finite-dimensional real normed space is finite. -/
+theorem dimH_lt_top (s : Set E) : dimH s < ⊤ := by calc
+  dimH s ≤ dimH (univ : Set E) := dimH_mono (subset_univ s)
+  _ = finrank ℝ E := Real.dimH_univ_eq_finrank E
+  _ < ⊤ := by simp
+
+theorem dimH_ne_top (s : Set E) : dimH s ≠ ⊤ := (dimH_lt_top E s).ne
+
 variable {E}
 
 lemma hausdorffMeasure_of_finrank_lt [MeasurableSpace E] [BorelSpace E] {d : ℝ}

--- a/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
+++ b/Mathlib/Topology/MetricSpace/HausdorffDimension.lean
@@ -461,15 +461,15 @@ theorem dimH_univ_eq_finrank : dimH (univ : Set E) = finrank ℝ E :=
 theorem dimH_univ : dimH (univ : Set ℝ) = 1 := by
   rw [dimH_univ_eq_finrank ℝ, Module.finrank_self, Nat.cast_one]
 
+variable {E}
+
 /-- The Hausdorff dimension of any set in a finite-dimensional real normed space is finite. -/
 theorem dimH_lt_top (s : Set E) : dimH s < ⊤ := by calc
   dimH s ≤ dimH (univ : Set E) := dimH_mono (subset_univ s)
-  _ = finrank ℝ E := Real.dimH_univ_eq_finrank E
+  _ = finrank ℝ E := dimH_univ_eq_finrank E
   _ < ⊤ := by simp
 
-theorem dimH_ne_top (s : Set E) : dimH s ≠ ⊤ := (dimH_lt_top E s).ne
-
-variable {E}
+theorem dimH_ne_top (s : Set E) : dimH s ≠ ⊤ := (dimH_lt_top s).ne
 
 lemma hausdorffMeasure_of_finrank_lt [MeasurableSpace E] [BorelSpace E] {d : ℝ}
     (hd : finrank ℝ E < d) : (μH[d] : Measure E) = 0 := by

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -65,7 +65,7 @@
    "type": "git",
    "subDir": null,
    "scope": "leanprover-community",
-   "rev": "82fd0cf6aaa1e2580aa17b3b1e5b9140e6e6a5e5",
+   "rev": "3cabaef23886b82ba46f07018f2786d9496477d6",
    "name": "batteries",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -65,7 +65,7 @@
    "type": "git",
    "subDir": null,
    "scope": "leanprover-community",
-   "rev": "3cabaef23886b82ba46f07018f2786d9496477d6",
+   "rev": "82fd0cf6aaa1e2580aa17b3b1e5b9140e6e6a5e5",
    "name": "batteries",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",


### PR DESCRIPTION
Establish that the Hausdorff dimension of any set in a finite-dimensional real normed space is finite. 


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
