### PR TITLE
[Merged by Bors] - feat(CategoryTheory): localization of quotient categories

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2365,6 +2365,7 @@ import Mathlib.CategoryTheory.Localization.Pi
 import Mathlib.CategoryTheory.Localization.Preadditive
 import Mathlib.CategoryTheory.Localization.Predicate
 import Mathlib.CategoryTheory.Localization.Prod
+import Mathlib.CategoryTheory.Localization.Quotient
 import Mathlib.CategoryTheory.Localization.Resolution
 import Mathlib.CategoryTheory.Localization.SmallHom
 import Mathlib.CategoryTheory.Localization.SmallShiftedHom

--- a/Mathlib/CategoryTheory/Localization/LocalizerMorphism.lean
+++ b/Mathlib/CategoryTheory/Localization/LocalizerMorphism.lean
@@ -44,6 +44,15 @@ structure LocalizerMorphism where
 
 namespace LocalizerMorphism
 
+variable {W₁ W₂} in
+/-- Constructor for localizer morphisms given by a functor `F : C₁ ⥤ C₂`
+under the stronger assumption that the classes of morphisms `W₁` and `W₂`
+satisfy `W₁ = W₂.inverseImage F`. -/
+@[simps]
+def ofEq {F : C₁ ⥤ C₂} (hW : W₁ = W₂.inverseImage F) : LocalizerMorphism W₁ W₂ where
+  functor := F
+  map := by rw [hW]
+
 /-- The identity functor as a morphism of localizers. -/
 @[simps]
 def id : LocalizerMorphism W₁ W₁ where

--- a/Mathlib/CategoryTheory/Localization/Predicate.lean
+++ b/Mathlib/CategoryTheory/Localization/Predicate.lean
@@ -497,6 +497,11 @@ lemma map_eq (h : AreEqualizedByLocalization W f g) (L : C ⥤ D) [L.IsLocalizat
     L.map f = L.map g :=
   (areEqualizedByLocalization_iff L W f g).1 h
 
+lemma map_eq_of_isInvertedBy (h : AreEqualizedByLocalization W f g)
+    (F : C ⥤ D) (hF : W.IsInvertedBy F) :
+    F.map f = F.map g := by
+  simp [← NatIso.naturality_1 (Localization.fac F hF W.Q), h.map_eq W.Q]
+
 end AreEqualizedByLocalization
 
 end

--- a/Mathlib/CategoryTheory/Localization/Quotient.lean
+++ b/Mathlib/CategoryTheory/Localization/Quotient.lean
@@ -86,7 +86,7 @@ lemma isLocalizedEquivalence :
     Functor.IsLocalization.mk' _ _
       (h.strictUniversalPropertyFixedTarget' hW _)
       (h.strictUniversalPropertyFixedTarget' hW _)
-  LocalizerMorphism.IsLocalizedEquivalence.of_isLocalization_of_isLocalization _ (W'.Q)
+  LocalizerMorphism.IsLocalizedEquivalence.of_isLocalization_of_isLocalization _ W'.Q
 
 end FactorsThroughLocalization
 

--- a/Mathlib/CategoryTheory/Localization/Quotient.lean
+++ b/Mathlib/CategoryTheory/Localization/Quotient.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2025 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+import Mathlib.CategoryTheory.Localization.LocalizerMorphism
+import Mathlib.CategoryTheory.Quotient
+
+/-!
+# Localization of quotient categories
+
+Given a relation `homRel : HomRel C` on morphisms in a category `C`
+and `W : MorphismProperty C`, we introduce a property
+`homRel.FactorsThroughLocalization W` expressing that related
+morphisms are mapped to the same morphism in the localized
+category with respect to `W`. When `W` is compatible with `homRel`
+(i.e. there is a class of morphisms `W'` such that
+`hW : W = W'.inverseImage (Quotient.functor homRel)`),
+we show that `LocalizerMorphism.ofEq hW : LocalizerMorphism W W'`
+induces an equivalence on localized categories.
+
+-/
+
+namespace HomRel
+
+open CategoryTheory
+
+variable {C D : Type*} [Category C] [Category D] (homRel : HomRel C)
+
+/-- Given `homRel : HomRel C` and `W : MorphismProperty C`, this is the property
+that whenever `homRel f g`, then the morphisms `f` and `g` are sent to the
+same morphism in the localization category with respect to `W`. -/
+def FactorsThroughLocalization (W : MorphismProperty C) : Prop :=
+  ∀ ⦃X Y : C⦄ ⦃f g : X ⟶ Y⦄, homRel f g → AreEqualizedByLocalization W f g
+
+variable {homRel} {W : MorphismProperty C}
+  (h : homRel.FactorsThroughLocalization W)
+  {W' : MorphismProperty (Quotient homRel)}
+  (hW : W = W'.inverseImage (Quotient.functor homRel))
+
+namespace FactorsThroughLocalization
+
+open Localization
+
+section
+
+variable {E : Type*} [Category E]
+
+/-- If `L' : Quotient homRel ⥤ D` satisfies the strict universal property of the
+localization, then `Quotient.functor homRel ⋙ L'` also satisfies it. -/
+def strictUniversalPropertyFixedTarget (L' : Quotient homRel ⥤ D)
+    (univ : StrictUniversalPropertyFixedTarget L' W' E) :
+      StrictUniversalPropertyFixedTarget
+        (Quotient.functor homRel ⋙ L') W E where
+  inverts _ _ _ hf := univ.inverts _ (by rwa [hW] at hf)
+  lift F hF :=
+    univ.lift (CategoryTheory.Quotient.lift _ F
+        (fun _ _ f g hfg ↦ (h hfg).map_eq_of_isInvertedBy _ hF)) (by
+      rintro K L ⟨f⟩ hf
+      exact hF _ (by simpa [hW] using hf))
+  fac F hF := by rw [Functor.assoc, univ.fac, Quotient.lift_spec]
+  uniq F₁ F₂ h := univ.uniq _ _ (Quotient.lift_unique' _ _ _ h)
+
+variable (E) in
+/-- If `homRel : HomRel C` satisfies `homRel.FactorsThroughLocalization W` and
+that the class of morphisms `W` induces a class of morphism `W'` on the quotient category,
+then `Quotient.functor homRel ⋙ W'.Q` satisfies the universal property of the
+localization. This is used in `HomRel.FactorsThroughLocalization.isLocalizedEquivalence`
+in order to show that as a localizer morphism, the quotient functor induces an
+equivalence on localized categories. -/
+noncomputable def strictUniversalPropertyFixedTarget' :
+    StrictUniversalPropertyFixedTarget
+      (Quotient.functor homRel ⋙ W'.Q) W E :=
+  strictUniversalPropertyFixedTarget h hW _ (strictUniversalPropertyFixedTargetQ W' E)
+
+end
+
+include h in
+/-- If `homRel : HomRel C` satisfies `homRel.FactorsThroughLocalization W` and
+that the class of morphisms `W` induces a class of morphism `W'` on the quotient category,
+then the localizer morphism given by the functor `Quotient.functor HomRel : C ⥤ Quotient homRel`
+induces equivalences on localized categories. -/
+lemma isLocalizedEquivalence :
+    (LocalizerMorphism.ofEq hW).IsLocalizedEquivalence :=
+  have : ((LocalizerMorphism.ofEq hW).functor ⋙ W'.Q).IsLocalization W :=
+    Functor.IsLocalization.mk' _ _
+      (h.strictUniversalPropertyFixedTarget' hW _)
+      (h.strictUniversalPropertyFixedTarget' hW _)
+  LocalizerMorphism.IsLocalizedEquivalence.of_isLocalization_of_isLocalization _ (W'.Q)
+
+end FactorsThroughLocalization
+
+end HomRel


### PR DESCRIPTION
Under certain circumstances, we show that the localized category of a quotient category identifies to the localization of the original category.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
