### PR TITLE
[Merged by Bors] - fix(scripts/create-adaptation-pr): improve find_remote

### DIFF
--- a/scripts/create-adaptation-pr.sh
+++ b/scripts/create-adaptation-pr.sh
@@ -67,7 +67,7 @@ find_remote() {
   local repo_pattern="$1"
   # Use || true to prevent script exit if any command in the pipeline fails
   # This handles cases where git remote fails or grep doesn't find matches
-  git remote -v | grep "$repo_pattern· | grep "(fetch)" | head -n1 | cut -f1 || true
+  git remote -v | grep -E "$repo_pattern(\.git)? \(fetch\)" | head -n1 | cut -f1 || true
 }
 
 # Parse arguments


### PR DESCRIPTION
The old one was a syntax error and would've found a `mathlib4-nightly-testing` remote as a `mathlib4` remote (due to substring); this one is a bit more strict and works at least on my machine :-)

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
