### PR TITLE
[Merged by Bors] - refactor(Order/Concept): rename `intentClosure` → `lowerPolar`

### DIFF
--- a/Mathlib/Order/Concept.lean
+++ b/Mathlib/Order/Concept.lean
@@ -28,6 +28,7 @@ Prove the fundamental theorem of concept lattices.
 ## References
 
 * [Davey, Priestley *Introduction to Lattices and Order*][davey_priestley]
+* [Birkhoff, Garrett *Lattice Theory*][birkhoff1940]
 
 ## Tags
 

--- a/Mathlib/Order/Concept.lean
+++ b/Mathlib/Order/Concept.lean
@@ -168,7 +168,7 @@ theorem upperPolar_lowerPolar_upperPolar (s : Set α) :
   (gc_upperPolar_lowerPolar r).l_u_l_eq_l _
 
 @[deprecated (since := "2025-07-10")]
-alias intentClosure_extentClosure_intentClosure := upperPolar_swap
+alias intentClosure_extentClosure_intentClosure := upperPolar_lowerPolar_upperPolar
 
 @[simp]
 theorem lowerPolar_upperPolar_lowerPolar (t : Set β) :

--- a/Mathlib/Order/Concept.lean
+++ b/Mathlib/Order/Concept.lean
@@ -203,9 +203,9 @@ structure Concept where
   extent : Set α
   /-- The intent of a concept. -/
   intent : Set β
-  /-- The axiom of a `Concept` stating that the upper polar of the first set is the second set. -/
+  /-- The intent consists of all elements related to all elements of the extent. -/
   upperPolar_extent : upperPolar r extent = intent
-  /-- The axiom of a `Concept` stating that the lower polar of the second set is the first set. -/
+  /-- The extent consists of all elements related to all elements of the intent. -/
   lowerPolar_intent : lowerPolar r intent = extent
 
 namespace Concept

--- a/Mathlib/Order/Concept.lean
+++ b/Mathlib/Order/Concept.lean
@@ -42,153 +42,153 @@ variable {ι : Sort*} {α β : Type*} {κ : ι → Sort*} (r : α → β → Pro
 /-! ### Lower and upper polars -/
 
 
-/-- The lower polar of `s : Set α` along a relation `r : α → β → Prop` is the set of all elements
+/-- The upper polar of `s : Set α` along a relation `r : α → β → Prop` is the set of all elements
 which `r` relates to all elements of `s`. -/
-def lowerPolar (s : Set α) : Set β :=
+def upperPolar (s : Set α) : Set β :=
   { b | ∀ ⦃a⦄, a ∈ s → r a b }
 
 @[deprecated (since := "2025-07-10")]
-alias intentClosure := lowerPolar
+alias intentClosure := upperPolar
 
-/-- The upper polar of `t : Set β` along a relation `r : α → β → Prop` is the set of all elements
+/-- The lower polar of `t : Set β` along a relation `r : α → β → Prop` is the set of all elements
 which `r` relates to all elements of `t`. -/
-def upperPolar (t : Set β) : Set α :=
+def lowerPolar (t : Set β) : Set α :=
   { a | ∀ ⦃b⦄, b ∈ t → r a b }
 
 @[deprecated (since := "2025-07-10")]
-alias extentClosure := upperPolar
+alias extentClosure := lowerPolar
 
 variable {r}
 
-theorem subset_lowerPolar_iff_subset_upperPolar :
-    t ⊆ lowerPolar r s ↔ s ⊆ upperPolar r t :=
+theorem subset_upperPolar_iff_subset_lowerPolar :
+    t ⊆ upperPolar r s ↔ s ⊆ lowerPolar r t :=
   ⟨fun h _ ha _ hb => h hb ha, fun h _ hb _ ha => h ha hb⟩
 
 @[deprecated (since := "2025-07-10")]
-alias subset_intentClosure_iff_subset_extentClosure := subset_lowerPolar_iff_subset_upperPolar
+alias subset_intentClosure_iff_subset_extentClosure := subset_upperPolar_iff_subset_lowerPolar
 
 variable (r)
 
-theorem gc_lowerPolar_upperPolar :
-    GaloisConnection (toDual ∘ lowerPolar r) (upperPolar r ∘ ofDual) := fun _ _ =>
-  subset_lowerPolar_iff_subset_upperPolar
+theorem gc_upperPolar_lowerPolar :
+    GaloisConnection (toDual ∘ upperPolar r) (lowerPolar r ∘ ofDual) := fun _ _ =>
+  subset_upperPolar_iff_subset_lowerPolar
 
 @[deprecated (since := "2025-07-10")]
-alias gc_intentClosure_extentClosure := gc_lowerPolar_upperPolar
+alias gc_intentClosure_extentClosure := gc_upperPolar_lowerPolar
 
-theorem lowerPolar_swap (t : Set β) : lowerPolar (swap r) t = upperPolar r t :=
+theorem upperPolar_swap (t : Set β) : upperPolar (swap r) t = lowerPolar r t :=
   rfl
 
 @[deprecated (since := "2025-07-10")]
-alias intentClosure_swap := lowerPolar_swap
+alias intentClosure_swap := upperPolar_swap
 
-theorem upperPolar_swap (s : Set α) : upperPolar (swap r) s = lowerPolar r s :=
+theorem lowerPolar_swap (s : Set α) : lowerPolar (swap r) s = upperPolar r s :=
   rfl
 
 @[deprecated (since := "2025-07-10")]
-alias extentClosure_swap := upperPolar_swap
-
-@[simp]
-theorem lowerPolar_empty : lowerPolar r ∅ = univ :=
-  eq_univ_of_forall fun _ _ => False.elim
-
-@[deprecated (since := "2025-07-10")]
-alias intentClosure_empty := lowerPolar_empty
+alias extentClosure_swap := lowerPolar_swap
 
 @[simp]
 theorem upperPolar_empty : upperPolar r ∅ = univ :=
-  lowerPolar_empty _
+  eq_univ_of_forall fun _ _ => False.elim
 
 @[deprecated (since := "2025-07-10")]
-alias extentClosure_empty := upperPolar_empty
+alias intentClosure_empty := upperPolar_empty
 
 @[simp]
-theorem lowerPolar_union (s₁ s₂ : Set α) :
-    lowerPolar r (s₁ ∪ s₂) = lowerPolar r s₁ ∩ lowerPolar r s₂ :=
+theorem lowerPolar_empty : lowerPolar r ∅ = univ :=
+  upperPolar_empty _
+
+@[deprecated (since := "2025-07-10")]
+alias extentClosure_empty := lowerPolar_empty
+
+@[simp]
+theorem upperPolar_union (s₁ s₂ : Set α) :
+    upperPolar r (s₁ ∪ s₂) = upperPolar r s₁ ∩ upperPolar r s₂ :=
   ext fun _ => forall₂_or_left
 
 @[deprecated (since := "2025-07-10")]
-alias intentClosure_union := lowerPolar_union
+alias intentClosure_union := upperPolar_union
 
 @[simp]
-theorem upperPolar_union (t₁ t₂ : Set β) :
-    upperPolar r (t₁ ∪ t₂) = upperPolar r t₁ ∩ upperPolar r t₂ :=
-  lowerPolar_union ..
+theorem lowerPolar_union (t₁ t₂ : Set β) :
+    lowerPolar r (t₁ ∪ t₂) = lowerPolar r t₁ ∩ lowerPolar r t₂ :=
+  upperPolar_union ..
 
 @[deprecated (since := "2025-07-10")]
-alias extentClosure_union := upperPolar_union
+alias extentClosure_union := lowerPolar_union
 
 @[simp]
-theorem lowerPolar_iUnion (f : ι → Set α) :
-    lowerPolar r (⋃ i, f i) = ⋂ i, lowerPolar r (f i) :=
-  (gc_lowerPolar_upperPolar r).l_iSup
-
-@[deprecated (since := "2025-07-10")]
-alias intentClosure_iUnion := lowerPolar_iUnion
-
-@[simp]
-theorem upperPolar_iUnion (f : ι → Set β) :
+theorem upperPolar_iUnion (f : ι → Set α) :
     upperPolar r (⋃ i, f i) = ⋂ i, upperPolar r (f i) :=
-  lowerPolar_iUnion ..
+  (gc_upperPolar_lowerPolar r).l_iSup
 
 @[deprecated (since := "2025-07-10")]
-alias extentClosure_iUnion := upperPolar_iUnion
+alias intentClosure_iUnion := upperPolar_iUnion
 
-theorem lowerPolar_iUnion₂ (f : ∀ i, κ i → Set α) :
-    lowerPolar r (⋃ (i) (j), f i j) = ⋂ (i) (j), lowerPolar r (f i j) :=
-  (gc_lowerPolar_upperPolar r).l_iSup₂
+@[simp]
+theorem lowerPolar_iUnion (f : ι → Set β) :
+    lowerPolar r (⋃ i, f i) = ⋂ i, lowerPolar r (f i) :=
+  upperPolar_iUnion ..
 
 @[deprecated (since := "2025-07-10")]
-alias intentClosure_iUnion₂ := lowerPolar_iUnion₂
+alias extentClosure_iUnion := lowerPolar_iUnion
 
-theorem upperPolar_iUnion₂ (f : ∀ i, κ i → Set β) :
+theorem upperPolar_iUnion₂ (f : ∀ i, κ i → Set α) :
     upperPolar r (⋃ (i) (j), f i j) = ⋂ (i) (j), upperPolar r (f i j) :=
-  lowerPolar_iUnion₂ ..
+  (gc_upperPolar_lowerPolar r).l_iSup₂
 
 @[deprecated (since := "2025-07-10")]
-alias extentClosure_iUnion₂ := upperPolar_iUnion₂
+alias intentClosure_iUnion₂ := upperPolar_iUnion₂
 
-theorem subset_upperPolar_lowerPolar (s : Set α) :
-    s ⊆ upperPolar r (lowerPolar r s) :=
-  (gc_lowerPolar_upperPolar r).le_u_l _
-
-@[deprecated (since := "2025-07-10")]
-alias subset_extentClosure_intentClosure := subset_upperPolar_lowerPolar
-
-theorem subset_lowerPolar_upperPolar (t : Set β) :
-    t ⊆ lowerPolar r (upperPolar r t) :=
-  subset_upperPolar_lowerPolar _ t
+theorem lowerPolar_iUnion₂ (f : ∀ i, κ i → Set β) :
+    lowerPolar r (⋃ (i) (j), f i j) = ⋂ (i) (j), lowerPolar r (f i j) :=
+  upperPolar_iUnion₂ ..
 
 @[deprecated (since := "2025-07-10")]
-alias subset_intentClosure_extentClosure := subset_lowerPolar_upperPolar
+alias extentClosure_iUnion₂ := lowerPolar_iUnion₂
+
+theorem subset_lowerPolar_upperPolar (s : Set α) :
+    s ⊆ lowerPolar r (upperPolar r s) :=
+  (gc_upperPolar_lowerPolar r).le_u_l _
+
+@[deprecated (since := "2025-07-10")]
+alias subset_extentClosure_intentClosure := subset_lowerPolar_upperPolar
+
+theorem subset_upperPolar_lowerPolar (t : Set β) :
+    t ⊆ upperPolar r (lowerPolar r t) :=
+  subset_lowerPolar_upperPolar _ t
+
+@[deprecated (since := "2025-07-10")]
+alias subset_intentClosure_extentClosure := subset_upperPolar_lowerPolar
 
 @[simp]
-theorem lowerPolar_upperPolar_lowerPolar (s : Set α) :
-    lowerPolar r (upperPolar r <| lowerPolar r s) = lowerPolar r s :=
-  (gc_lowerPolar_upperPolar r).l_u_l_eq_l _
+theorem upperPolar_lowerPolar_upperPolar (s : Set α) :
+    upperPolar r (lowerPolar r <| upperPolar r s) = upperPolar r s :=
+  (gc_upperPolar_lowerPolar r).l_u_l_eq_l _
 
 @[deprecated (since := "2025-07-10")]
-alias intentClosure_extentClosure_intentClosure := lowerPolar_swap
+alias intentClosure_extentClosure_intentClosure := upperPolar_swap
 
 @[simp]
-theorem upperPolar_lowerPolar_upperPolar (t : Set β) :
-    upperPolar r (lowerPolar r <| upperPolar r t) = upperPolar r t :=
-  lowerPolar_upperPolar_lowerPolar _ t
+theorem lowerPolar_upperPolar_lowerPolar (t : Set β) :
+    lowerPolar r (upperPolar r <| lowerPolar r t) = lowerPolar r t :=
+  upperPolar_lowerPolar_upperPolar _ t
 
 @[deprecated (since := "2025-07-10")]
-alias extentClosure_intentClosure_extentClosure := upperPolar_lowerPolar_upperPolar
-
-theorem lowerPolar_anti : Antitone (lowerPolar r) :=
-  (gc_lowerPolar_upperPolar r).monotone_l
-
-@[deprecated (since := "2025-07-10")]
-alias intentClosure_anti := lowerPolar_anti
+alias extentClosure_intentClosure_extentClosure := lowerPolar_upperPolar_lowerPolar
 
 theorem upperPolar_anti : Antitone (upperPolar r) :=
-  lowerPolar_anti _
+  (gc_upperPolar_lowerPolar r).monotone_l
 
 @[deprecated (since := "2025-07-10")]
-alias extentClosure_anti := upperPolar_anti
+alias intentClosure_anti := upperPolar_anti
+
+theorem lowerPolar_anti : Antitone (lowerPolar r) :=
+  upperPolar_anti _
+
+@[deprecated (since := "2025-07-10")]
+alias extentClosure_anti := lowerPolar_anti
 
 /-! ### Concepts -/
 
@@ -203,10 +203,10 @@ structure Concept where
   extent : Set α
   /-- The intent of a concept. -/
   intent : Set β
-  /-- The axiom of a `Concept` stating that the lower polar of the first set is the second set. -/
-  lowerPolar_extent : lowerPolar r extent = intent
-  /-- The axiom of a `Concept` stating that the upper polar of the second set is the first set. -/
-  upperPolar_intent : upperPolar r intent = extent
+  /-- The axiom of a `Concept` stating that the upper polar of the first set is the second set. -/
+  upperPolar_extent : upperPolar r extent = intent
+  /-- The axiom of a `Concept` stating that the lower polar of the second set is the first set. -/
+  lowerPolar_intent : lowerPolar r intent = extent
 
 namespace Concept
 
@@ -217,15 +217,15 @@ alias fst := extent
 alias snd := intent
 
 @[deprecated (since := "2025-07-10")]
-alias closure_fst := lowerPolar_extent
+alias closure_fst := upperPolar_extent
 
 @[deprecated (since := "2025-07-10")]
-alias closure_snd := upperPolar_intent
+alias closure_snd := lowerPolar_intent
 
 variable {r α β}
 variable {c d : Concept α β r}
 
-attribute [simp] lowerPolar_extent upperPolar_intent
+attribute [simp] upperPolar_extent lowerPolar_intent
 
 @[ext]
 theorem ext (h : c.extent = d.extent) : c = d := by
@@ -254,21 +254,21 @@ alias snd_injective := intent_injective
 
 instance instSupConcept : Max (Concept α β r) :=
   ⟨fun c d =>
-    { extent := upperPolar r (c.intent ∩ d.intent)
+    { extent := lowerPolar r (c.intent ∩ d.intent)
       intent := c.intent ∩ d.intent
-      lowerPolar_extent := by
-        rw [← c.lowerPolar_extent, ← d.lowerPolar_extent, ← lowerPolar_union,
-          lowerPolar_upperPolar_lowerPolar]
-      upperPolar_intent := rfl }⟩
+      upperPolar_extent := by
+        rw [← c.upperPolar_extent, ← d.upperPolar_extent, ← upperPolar_union,
+          upperPolar_lowerPolar_upperPolar]
+      lowerPolar_intent := rfl }⟩
 
 instance instInfConcept : Min (Concept α β r) :=
   ⟨fun c d =>
     { extent := c.extent ∩ d.extent
-      intent := lowerPolar r (c.extent ∩ d.extent)
-      lowerPolar_extent := rfl
-      upperPolar_intent := by
-        rw [← c.upperPolar_intent, ← d.upperPolar_intent, ← upperPolar_union,
-          upperPolar_lowerPolar_upperPolar] }⟩
+      intent := upperPolar r (c.extent ∩ d.extent)
+      upperPolar_extent := rfl
+      lowerPolar_intent := by
+        rw [← c.lowerPolar_intent, ← d.lowerPolar_intent, ← lowerPolar_union,
+          lowerPolar_upperPolar_lowerPolar] }⟩
 
 instance instSemilatticeInfConcept : SemilatticeInf (Concept α β r) :=
   (extent_injective.semilatticeInf _) fun _ _ => rfl
@@ -290,10 +290,10 @@ alias fst_ssubset_fst_iff := extent_ssubset_extent_iff
 @[simp]
 theorem intent_subset_intent_iff : c.intent ⊆ d.intent ↔ d ≤ c := by
   refine ⟨fun h => ?_, fun h => ?_⟩
-  · rw [← extent_subset_extent_iff, ← c.upperPolar_intent, ← d.upperPolar_intent]
-    exact upperPolar_anti _ h
-  · rw [← c.lowerPolar_extent, ← d.lowerPolar_extent]
+  · rw [← extent_subset_extent_iff, ← c.lowerPolar_intent, ← d.lowerPolar_intent]
     exact lowerPolar_anti _ h
+  · rw [← c.upperPolar_extent, ← d.upperPolar_extent]
+    exact upperPolar_anti _ h
 
 @[deprecated (since := "2025-07-10")]
 alias snd_subset_snd_iff := intent_subset_intent_iff
@@ -328,26 +328,26 @@ instance instLatticeConcept : Lattice (Concept α β r) :=
       exact subset_inter }
 
 instance instBoundedOrderConcept : BoundedOrder (Concept α β r) where
-  top := ⟨univ, lowerPolar r univ, rfl, eq_univ_of_forall fun _ _ hb => hb trivial⟩
+  top := ⟨univ, upperPolar r univ, rfl, eq_univ_of_forall fun _ _ hb => hb trivial⟩
   le_top _ := subset_univ _
-  bot := ⟨upperPolar r univ, univ, eq_univ_of_forall fun _ _ ha => ha trivial, rfl⟩
+  bot := ⟨lowerPolar r univ, univ, eq_univ_of_forall fun _ _ ha => ha trivial, rfl⟩
   bot_le _ := intent_subset_intent_iff.1 <| subset_univ _
 
 instance : SupSet (Concept α β r) :=
   ⟨fun S =>
-    { extent := upperPolar r (⋂ c ∈ S, intent c)
+    { extent := lowerPolar r (⋂ c ∈ S, intent c)
       intent := ⋂ c ∈ S, intent c
-      lowerPolar_extent := by
-        simp_rw [← lowerPolar_extent, ← lowerPolar_iUnion₂, lowerPolar_upperPolar_lowerPolar]
-      upperPolar_intent := rfl }⟩
+      upperPolar_extent := by
+        simp_rw [← upperPolar_extent, ← upperPolar_iUnion₂, upperPolar_lowerPolar_upperPolar]
+      lowerPolar_intent := rfl }⟩
 
 instance : InfSet (Concept α β r) :=
   ⟨fun S =>
     { extent := ⋂ c ∈ S, extent c
-      intent := lowerPolar r (⋂ c ∈ S, extent c)
-      lowerPolar_extent := rfl
-      upperPolar_intent := by
-        simp_rw [← upperPolar_intent, ← upperPolar_iUnion₂, upperPolar_lowerPolar_upperPolar] }⟩
+      intent := upperPolar r (⋂ c ∈ S, extent c)
+      upperPolar_extent := rfl
+      lowerPolar_intent := by
+        simp_rw [← lowerPolar_intent, ← lowerPolar_iUnion₂, lowerPolar_upperPolar_lowerPolar] }⟩
 
 instance : CompleteLattice (Concept α β r) :=
   { Concept.instLatticeConcept,
@@ -368,14 +368,14 @@ theorem extent_top : (⊤ : Concept α β r).extent = univ :=
 alias top_fst := extent_top
 
 @[simp]
-theorem intent_top : (⊤ : Concept α β r).intent = lowerPolar r univ :=
+theorem intent_top : (⊤ : Concept α β r).intent = upperPolar r univ :=
   rfl
 
 @[deprecated (since := "2025-07-10")]
 alias top_snd := intent_top
 
 @[simp]
-theorem extent_bot : (⊥ : Concept α β r).extent = upperPolar r univ :=
+theorem extent_bot : (⊥ : Concept α β r).extent = lowerPolar r univ :=
   rfl
 
 @[deprecated (since := "2025-07-10")]
@@ -389,7 +389,7 @@ theorem intent_bot : (⊥ : Concept α β r).intent = univ :=
 alias bot_snd := intent_bot
 
 @[simp]
-theorem extent_sup (c d : Concept α β r) : (c ⊔ d).extent = upperPolar r (c.intent ∩ d.intent) :=
+theorem extent_sup (c d : Concept α β r) : (c ⊔ d).extent = lowerPolar r (c.intent ∩ d.intent) :=
   rfl
 
 @[deprecated (since := "2025-07-10")]
@@ -410,7 +410,7 @@ theorem extent_inf (c d : Concept α β r) : (c ⊓ d).extent = c.extent ∩ d.e
 alias inf_fst := extent_inf
 
 @[simp]
-theorem intent_inf (c d : Concept α β r) : (c ⊓ d).intent = lowerPolar r (c.extent ∩ d.extent) :=
+theorem intent_inf (c d : Concept α β r) : (c ⊓ d).intent = upperPolar r (c.extent ∩ d.extent) :=
   rfl
 
 @[deprecated (since := "2025-07-10")]
@@ -418,7 +418,7 @@ alias inf_snd := intent_inf
 
 @[simp]
 theorem extent_sSup (S : Set (Concept α β r)) :
-    (sSup S).extent = upperPolar r (⋂ c ∈ S, intent c) :=
+    (sSup S).extent = lowerPolar r (⋂ c ∈ S, intent c) :=
   rfl
 
 @[deprecated (since := "2025-07-10")]
@@ -440,7 +440,7 @@ alias sInf_fst := extent_sInf
 
 @[simp]
 theorem intent_sInf (S : Set (Concept α β r)) :
-    (sInf S).intent = lowerPolar r (⋂ c ∈ S, extent c) :=
+    (sInf S).intent = upperPolar r (⋂ c ∈ S, extent c) :=
   rfl
 
 @[deprecated (since := "2025-07-10")]
@@ -452,7 +452,7 @@ instance : Inhabited (Concept α β r) :=
 /-- Swap the sets of a concept to make it a concept of the dual context. -/
 @[simps]
 def swap (c : Concept α β r) : Concept β α (swap r) :=
-  ⟨c.intent, c.extent, c.upperPolar_intent, c.lowerPolar_extent⟩
+  ⟨c.intent, c.extent, c.lowerPolar_intent, c.upperPolar_extent⟩
 
 @[simp]
 theorem swap_swap (c : Concept α β r) : c.swap.swap = c :=

--- a/Mathlib/Order/Concept.lean
+++ b/Mathlib/Order/Concept.lean
@@ -42,93 +42,153 @@ variable {ι : Sort*} {α β : Type*} {κ : ι → Sort*} (r : α → β → Pro
 /-! ### Intent and extent -/
 
 
-/-- The intent closure of `s : Set α` along a relation `r : α → β → Prop` is the set of all elements
+/-- The lower polar of `s : Set α` along a relation `r : α → β → Prop` is the set of all elements
 which `r` relates to all elements of `s`. -/
-def intentClosure (s : Set α) : Set β :=
+def lowerPolar (s : Set α) : Set β :=
   { b | ∀ ⦃a⦄, a ∈ s → r a b }
 
-/-- The extent closure of `t : Set β` along a relation `r : α → β → Prop` is the set of all elements
+@[deprecated (since := "2025-07-10")]
+alias intentClosure := lowerPolar
+
+/-- The upper polar of `t : Set β` along a relation `r : α → β → Prop` is the set of all elements
 which `r` relates to all elements of `t`. -/
-def extentClosure (t : Set β) : Set α :=
+def upperPolar (t : Set β) : Set α :=
   { a | ∀ ⦃b⦄, b ∈ t → r a b }
+
+@[deprecated (since := "2025-07-10")]
+alias extentClosure := upperPolar
 
 variable {r}
 
-theorem subset_intentClosure_iff_subset_extentClosure :
-    t ⊆ intentClosure r s ↔ s ⊆ extentClosure r t :=
+theorem subset_lowerPolar_iff_subset_upperPolar :
+    t ⊆ lowerPolar r s ↔ s ⊆ upperPolar r t :=
   ⟨fun h _ ha _ hb => h hb ha, fun h _ hb _ ha => h ha hb⟩
+
+@[deprecated (since := "2025-07-10")]
+alias subset_intentClosure_iff_subset_extentClosure := subset_lowerPolar_iff_subset_upperPolar
 
 variable (r)
 
-theorem gc_intentClosure_extentClosure :
-    GaloisConnection (toDual ∘ intentClosure r) (extentClosure r ∘ ofDual) := fun _ _ =>
-  subset_intentClosure_iff_subset_extentClosure
+theorem gc_lowerPolar_upperPolar :
+    GaloisConnection (toDual ∘ lowerPolar r) (upperPolar r ∘ ofDual) := fun _ _ =>
+  subset_lowerPolar_iff_subset_upperPolar
 
-theorem intentClosure_swap (t : Set β) : intentClosure (swap r) t = extentClosure r t :=
+@[deprecated (since := "2025-07-10")]
+alias gc_intentClosure_extentClosure := gc_lowerPolar_upperPolar
+
+theorem lowerPolar_swap (t : Set β) : lowerPolar (swap r) t = upperPolar r t :=
   rfl
 
-theorem extentClosure_swap (s : Set α) : extentClosure (swap r) s = intentClosure r s :=
+@[deprecated (since := "2025-07-10")]
+alias intentClosure_swap := lowerPolar_swap
+
+theorem upperPolar_swap (s : Set α) : upperPolar (swap r) s = lowerPolar r s :=
   rfl
+
+@[deprecated (since := "2025-07-10")]
+alias extentClosure_swap := upperPolar_swap
 
 @[simp]
-theorem intentClosure_empty : intentClosure r ∅ = univ :=
+theorem lowerPolar_empty : lowerPolar r ∅ = univ :=
   eq_univ_of_forall fun _ _ => False.elim
 
-@[simp]
-theorem extentClosure_empty : extentClosure r ∅ = univ :=
-  intentClosure_empty _
+@[deprecated (since := "2025-07-10")]
+alias intentClosure_empty := lowerPolar_empty
 
 @[simp]
-theorem intentClosure_union (s₁ s₂ : Set α) :
-    intentClosure r (s₁ ∪ s₂) = intentClosure r s₁ ∩ intentClosure r s₂ :=
-  Set.ext fun _ => forall₂_or_left
+theorem upperPolar_empty : upperPolar r ∅ = univ :=
+  lowerPolar_empty _
+
+@[deprecated (since := "2025-07-10")]
+alias extentClosure_empty := upperPolar_empty
 
 @[simp]
-theorem extentClosure_union (t₁ t₂ : Set β) :
-    extentClosure r (t₁ ∪ t₂) = extentClosure r t₁ ∩ extentClosure r t₂ :=
-  intentClosure_union _ _ _
+theorem lowerPolar_union (s₁ s₂ : Set α) :
+    lowerPolar r (s₁ ∪ s₂) = lowerPolar r s₁ ∩ lowerPolar r s₂ :=
+  ext fun _ => forall₂_or_left
+
+@[deprecated (since := "2025-07-10")]
+alias intentClosure_union := lowerPolar_union
 
 @[simp]
-theorem intentClosure_iUnion (f : ι → Set α) :
-    intentClosure r (⋃ i, f i) = ⋂ i, intentClosure r (f i) :=
-  (gc_intentClosure_extentClosure r).l_iSup
+theorem upperPolar_union (t₁ t₂ : Set β) :
+    upperPolar r (t₁ ∪ t₂) = upperPolar r t₁ ∩ upperPolar r t₂ :=
+  lowerPolar_union ..
+
+@[deprecated (since := "2025-07-10")]
+alias extentClosure_union := upperPolar_union
 
 @[simp]
-theorem extentClosure_iUnion (f : ι → Set β) :
-    extentClosure r (⋃ i, f i) = ⋂ i, extentClosure r (f i) :=
-  intentClosure_iUnion _ _
+theorem lowerPolar_iUnion (f : ι → Set α) :
+    lowerPolar r (⋃ i, f i) = ⋂ i, lowerPolar r (f i) :=
+  (gc_lowerPolar_upperPolar r).l_iSup
 
-theorem intentClosure_iUnion₂ (f : ∀ i, κ i → Set α) :
-    intentClosure r (⋃ (i) (j), f i j) = ⋂ (i) (j), intentClosure r (f i j) :=
-  (gc_intentClosure_extentClosure r).l_iSup₂
-
-theorem extentClosure_iUnion₂ (f : ∀ i, κ i → Set β) :
-    extentClosure r (⋃ (i) (j), f i j) = ⋂ (i) (j), extentClosure r (f i j) :=
-  intentClosure_iUnion₂ _ _
-
-theorem subset_extentClosure_intentClosure (s : Set α) :
-    s ⊆ extentClosure r (intentClosure r s) :=
-  (gc_intentClosure_extentClosure r).le_u_l _
-
-theorem subset_intentClosure_extentClosure (t : Set β) :
-    t ⊆ intentClosure r (extentClosure r t) :=
-  subset_extentClosure_intentClosure _ t
+@[deprecated (since := "2025-07-10")]
+alias intentClosure_iUnion := lowerPolar_iUnion
 
 @[simp]
-theorem intentClosure_extentClosure_intentClosure (s : Set α) :
-    intentClosure r (extentClosure r <| intentClosure r s) = intentClosure r s :=
-  (gc_intentClosure_extentClosure r).l_u_l_eq_l _
+theorem upperPolar_iUnion (f : ι → Set β) :
+    upperPolar r (⋃ i, f i) = ⋂ i, upperPolar r (f i) :=
+  lowerPolar_iUnion ..
+
+@[deprecated (since := "2025-07-10")]
+alias extentClosure_iUnion := upperPolar_iUnion
+
+theorem lowerPolar_iUnion₂ (f : ∀ i, κ i → Set α) :
+    lowerPolar r (⋃ (i) (j), f i j) = ⋂ (i) (j), lowerPolar r (f i j) :=
+  (gc_lowerPolar_upperPolar r).l_iSup₂
+
+@[deprecated (since := "2025-07-10")]
+alias intentClosure_iUnion₂ := lowerPolar_iUnion₂
+
+theorem upperPolar_iUnion₂ (f : ∀ i, κ i → Set β) :
+    upperPolar r (⋃ (i) (j), f i j) = ⋂ (i) (j), upperPolar r (f i j) :=
+  lowerPolar_iUnion₂ ..
+
+@[deprecated (since := "2025-07-10")]
+alias extentClosure_iUnion₂ := upperPolar_iUnion₂
+
+theorem subset_upperPolar_lowerPolar (s : Set α) :
+    s ⊆ upperPolar r (lowerPolar r s) :=
+  (gc_lowerPolar_upperPolar r).le_u_l _
+
+@[deprecated (since := "2025-07-10")]
+alias subset_extentClosure_intentClosure := subset_upperPolar_lowerPolar
+
+theorem subset_lowerPolar_upperPolar (t : Set β) :
+    t ⊆ lowerPolar r (upperPolar r t) :=
+  subset_upperPolar_lowerPolar _ t
+
+@[deprecated (since := "2025-07-10")]
+alias subset_intentClosure_extentClosure := subset_lowerPolar_upperPolar
 
 @[simp]
-theorem extentClosure_intentClosure_extentClosure (t : Set β) :
-    extentClosure r (intentClosure r <| extentClosure r t) = extentClosure r t :=
-  intentClosure_extentClosure_intentClosure _ t
+theorem lowerPolar_upperPolar_lowerPolar (s : Set α) :
+    lowerPolar r (upperPolar r <| lowerPolar r s) = lowerPolar r s :=
+  (gc_lowerPolar_upperPolar r).l_u_l_eq_l _
 
-theorem intentClosure_anti : Antitone (intentClosure r) :=
-  (gc_intentClosure_extentClosure r).monotone_l
+@[deprecated (since := "2025-07-10")]
+alias intentClosure_extentClosure_intentClosure := lowerPolar_swap
 
-theorem extentClosure_anti : Antitone (extentClosure r) :=
-  intentClosure_anti _
+@[simp]
+theorem upperPolar_lowerPolar_upperPolar (t : Set β) :
+    upperPolar r (lowerPolar r <| upperPolar r t) = upperPolar r t :=
+  lowerPolar_upperPolar_lowerPolar _ t
+
+@[deprecated (since := "2025-07-10")]
+alias extentClosure_intentClosure_extentClosure := upperPolar_lowerPolar_upperPolar
+
+theorem lowerPolar_anti : Antitone (lowerPolar r) :=
+  (gc_lowerPolar_upperPolar r).monotone_l
+
+@[deprecated (since := "2025-07-10")]
+alias intentClosure_anti := lowerPolar_anti
+
+theorem upperPolar_anti : Antitone (upperPolar r) :=
+  lowerPolar_anti _
+
+@[deprecated (since := "2025-07-10")]
+alias extentClosure_anti := upperPolar_anti
 
 /-! ### Concepts -/
 
@@ -139,19 +199,25 @@ variable (α β)
 such that `s` is the set of all elements that are `r`-related to all of `t` and `t` is the set of
 all elements that are `r`-related to all of `s`. -/
 structure Concept extends Set α × Set β where
-  /-- The axiom of a `Concept` stating that the closure of the first set is the second set. -/
-  closure_fst : intentClosure r fst = snd
-  /-- The axiom of a `Concept` stating that the closure of the second set is the first set. -/
-  closure_snd : extentClosure r snd = fst
+  /-- The axiom of a `Concept` stating that the lower polar of the first set is the second set. -/
+  lowerPolar_fst : lowerPolar r fst = snd
+  /-- The axiom of a `Concept` stating that the upper polar of the second set is the first set. -/
+  upperPolar_snd : upperPolar r snd = fst
 
 initialize_simps_projections Concept (+toProd, -fst, -snd)
 
 namespace Concept
 
+@[deprecated (since := "2025-07-10")]
+alias closure_fst := lowerPolar_fst
+
+@[deprecated (since := "2025-07-10")]
+alias closure_snd := upperPolar_snd
+
 variable {r α β}
 variable {c d : Concept α β r}
 
-attribute [simp] closure_fst closure_snd
+attribute [simp] lowerPolar_fst upperPolar_snd
 
 @[ext]
 theorem ext (h : c.fst = d.fst) : c = d := by
@@ -174,21 +240,21 @@ theorem snd_injective : Injective fun c : Concept α β r => c.snd := fun _ _ =>
 
 instance instSupConcept : Max (Concept α β r) :=
   ⟨fun c d =>
-    { fst := extentClosure r (c.snd ∩ d.snd)
+    { fst := upperPolar r (c.snd ∩ d.snd)
       snd := c.snd ∩ d.snd
-      closure_fst := by
-        rw [← c.closure_fst, ← d.closure_fst, ← intentClosure_union,
-          intentClosure_extentClosure_intentClosure]
-      closure_snd := rfl }⟩
+      lowerPolar_fst := by
+        rw [← c.lowerPolar_fst, ← d.lowerPolar_fst, ← lowerPolar_union,
+          lowerPolar_upperPolar_lowerPolar]
+      upperPolar_snd := rfl }⟩
 
 instance instInfConcept : Min (Concept α β r) :=
   ⟨fun c d =>
     { fst := c.fst ∩ d.fst
-      snd := intentClosure r (c.fst ∩ d.fst)
-      closure_fst := rfl
-      closure_snd := by
-        rw [← c.closure_snd, ← d.closure_snd, ← extentClosure_union,
-          extentClosure_intentClosure_extentClosure] }⟩
+      snd := lowerPolar r (c.fst ∩ d.fst)
+      lowerPolar_fst := rfl
+      upperPolar_snd := by
+        rw [← c.upperPolar_snd, ← d.upperPolar_snd, ← upperPolar_union,
+          upperPolar_lowerPolar_upperPolar] }⟩
 
 instance instSemilatticeInfConcept : SemilatticeInf (Concept α β r) :=
   (fst_injective.semilatticeInf _) fun _ _ => rfl
@@ -204,10 +270,10 @@ theorem fst_ssubset_fst_iff : c.fst ⊂ d.fst ↔ c < d :=
 @[simp]
 theorem snd_subset_snd_iff : c.snd ⊆ d.snd ↔ d ≤ c := by
   refine ⟨fun h => ?_, fun h => ?_⟩
-  · rw [← fst_subset_fst_iff, ← c.closure_snd, ← d.closure_snd]
-    exact extentClosure_anti _ h
-  · rw [← c.closure_fst, ← d.closure_fst]
-    exact intentClosure_anti _ h
+  · rw [← fst_subset_fst_iff, ← c.upperPolar_snd, ← d.upperPolar_snd]
+    exact upperPolar_anti _ h
+  · rw [← c.lowerPolar_fst, ← d.lowerPolar_fst]
+    exact lowerPolar_anti _ h
 
 @[simp]
 theorem snd_ssubset_snd_iff : c.snd ⊂ d.snd ↔ d < c := by
@@ -229,28 +295,26 @@ instance instLatticeConcept : Lattice (Concept α β r) :=
       exact subset_inter }
 
 instance instBoundedOrderConcept : BoundedOrder (Concept α β r) where
-  top := ⟨⟨univ, intentClosure r univ⟩, rfl, eq_univ_of_forall fun _ _ hb => hb trivial⟩
+  top := ⟨⟨univ, lowerPolar r univ⟩, rfl, eq_univ_of_forall fun _ _ hb => hb trivial⟩
   le_top _ := subset_univ _
-  bot := ⟨⟨extentClosure r univ, univ⟩, eq_univ_of_forall fun _ _ ha => ha trivial, rfl⟩
+  bot := ⟨⟨upperPolar r univ, univ⟩, eq_univ_of_forall fun _ _ ha => ha trivial, rfl⟩
   bot_le _ := snd_subset_snd_iff.1 <| subset_univ _
 
 instance : SupSet (Concept α β r) :=
   ⟨fun S =>
-    { fst := extentClosure r (⋂ c ∈ S, (c : Concept _ _ _).snd)
+    { fst := upperPolar r (⋂ c ∈ S, (c : Concept _ _ _).snd)
       snd := ⋂ c ∈ S, (c : Concept _ _ _).snd
-      closure_fst := by
-        simp_rw [← closure_fst, ← intentClosure_iUnion₂,
-          intentClosure_extentClosure_intentClosure]
-      closure_snd := rfl }⟩
+      lowerPolar_fst := by
+        simp_rw [← lowerPolar_fst, ← lowerPolar_iUnion₂, lowerPolar_upperPolar_lowerPolar]
+      upperPolar_snd := rfl }⟩
 
 instance : InfSet (Concept α β r) :=
   ⟨fun S =>
     { fst := ⋂ c ∈ S, (c : Concept _ _ _).fst
-      snd := intentClosure r (⋂ c ∈ S, (c : Concept _ _ _).fst)
-      closure_fst := rfl
-      closure_snd := by
-        simp_rw [← closure_snd, ← extentClosure_iUnion₂,
-          extentClosure_intentClosure_extentClosure] }⟩
+      snd := lowerPolar r (⋂ c ∈ S, (c : Concept _ _ _).fst)
+      lowerPolar_fst := rfl
+      upperPolar_snd := by
+        simp_rw [← upperPolar_snd, ← upperPolar_iUnion₂, upperPolar_lowerPolar_upperPolar] }⟩
 
 instance : CompleteLattice (Concept α β r) :=
   { Concept.instLatticeConcept,
@@ -268,11 +332,11 @@ theorem top_fst : (⊤ : Concept α β r).fst = univ :=
   rfl
 
 @[simp]
-theorem top_snd : (⊤ : Concept α β r).snd = intentClosure r univ :=
+theorem top_snd : (⊤ : Concept α β r).snd = lowerPolar r univ :=
   rfl
 
 @[simp]
-theorem bot_fst : (⊥ : Concept α β r).fst = extentClosure r univ :=
+theorem bot_fst : (⊥ : Concept α β r).fst = upperPolar r univ :=
   rfl
 
 @[simp]
@@ -280,7 +344,7 @@ theorem bot_snd : (⊥ : Concept α β r).snd = univ :=
   rfl
 
 @[simp]
-theorem sup_fst (c d : Concept α β r) : (c ⊔ d).fst = extentClosure r (c.snd ∩ d.snd) :=
+theorem sup_fst (c d : Concept α β r) : (c ⊔ d).fst = upperPolar r (c.snd ∩ d.snd) :=
   rfl
 
 @[simp]
@@ -292,12 +356,12 @@ theorem inf_fst (c d : Concept α β r) : (c ⊓ d).fst = c.fst ∩ d.fst :=
   rfl
 
 @[simp]
-theorem inf_snd (c d : Concept α β r) : (c ⊓ d).snd = intentClosure r (c.fst ∩ d.fst) :=
+theorem inf_snd (c d : Concept α β r) : (c ⊓ d).snd = lowerPolar r (c.fst ∩ d.fst) :=
   rfl
 
 @[simp]
 theorem sSup_fst (S : Set (Concept α β r)) :
-    (sSup S).fst = extentClosure r (⋂ c ∈ S, (c : Concept _ _ _).snd) :=
+    (sSup S).fst = upperPolar r (⋂ c ∈ S, (c : Concept _ _ _).snd) :=
   rfl
 
 @[simp]
@@ -310,7 +374,7 @@ theorem sInf_fst (S : Set (Concept α β r)) : (sInf S).fst = ⋂ c ∈ S, (c : 
 
 @[simp]
 theorem sInf_snd (S : Set (Concept α β r)) :
-    (sInf S).snd = intentClosure r (⋂ c ∈ S, (c : Concept _ _ _).fst) :=
+    (sInf S).snd = lowerPolar r (⋂ c ∈ S, (c : Concept _ _ _).fst) :=
   rfl
 
 instance : Inhabited (Concept α β r) :=
@@ -319,7 +383,7 @@ instance : Inhabited (Concept α β r) :=
 /-- Swap the sets of a concept to make it a concept of the dual context. -/
 @[simps]
 def swap (c : Concept α β r) : Concept β α (swap r) :=
-  ⟨c.toProd.swap, c.closure_snd, c.closure_fst⟩
+  ⟨c.toProd.swap, c.upperPolar_snd, c.lowerPolar_fst⟩
 
 @[simp]
 theorem swap_swap (c : Concept α β r) : c.swap.swap = c :=

--- a/Mathlib/Order/Concept.lean
+++ b/Mathlib/Order/Concept.lean
@@ -199,7 +199,9 @@ variable (α β)
 such that `s` is the set of all elements that are `r`-related to all of `t` and `t` is the set of
 all elements that are `r`-related to all of `s`. -/
 structure Concept where
+  /-- The extent of a concept. -/
   extent : Set α
+  /-- The intent of a concept. -/
   intent : Set β
   /-- The axiom of a `Concept` stating that the lower polar of the first set is the second set. -/
   lowerPolar_extent : lowerPolar r extent = intent

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -452,6 +452,15 @@
   url           = {https://doi.org/10.1215/S0012-7094-37-00334-X}
 }
 
+@Book{            birkhoff1940,
+  author        = {Birkhoff, Garrett},
+  title         = {Lattice Theory},
+  edition       = {First},
+  publisher     = {American Mathematical Society},
+  year          = {1940},
+  volume        = {25}
+}
+
 @Article{         birkhoff1942,
   author        = {Birkhoff, Garrett},
   title         = {Lattice-Ordered groups},


### PR DESCRIPTION
The former name was being misused; the intent closure of a set `s` is actually `lowerPolar r (upperPolar r s)`.

The name "polar" can be found in the reference. Although the two types of polars don't have separate names, we choose lower and upper in analogy to `lowerBounds` and `upperBounds`; in fact, `lowerPolar (· ≤ ·) s` is def-eq to `lowerBounds s`, and likewise for `upperPolar`. 

While we're at it, we also get rid of the `Concept.toProd` projection, in favor of giving more informative names to its fields.

This PR contains no mathematics, it's just renaming.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

This rename was originally @linesthatinterlace's idea, but I second it!

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
