### PR TITLE
[Merged by Bors] - feat(Analysis/Normed/Group/Quotient): isometric versions of isomorphisms

### DIFF
--- a/Mathlib/Analysis/Normed/Group/Quotient.lean
+++ b/Mathlib/Analysis/Normed/Group/Quotient.lean
@@ -5,6 +5,8 @@ Authors: Patrick Massot, Riccardo Brasca
 -/
 import Mathlib.Analysis.Normed.Module.Basic
 import Mathlib.Analysis.Normed.Group.Hom
+import Mathlib.Analysis.Normed.Operator.LinearIsometry
+import Mathlib.LinearAlgebra.Isomorphisms
 import Mathlib.RingTheory.Ideal.Quotient.Operations
 import Mathlib.Topology.MetricSpace.HausdorffDistance
 
@@ -96,7 +98,7 @@ noncomputable section
 open Metric Set Topology NNReal
 
 namespace QuotientGroup
-variable {M : Type*} [SeminormedCommGroup M] {S : Subgroup M} {x : M ⧸ S} {m : M} {r ε : ℝ}
+variable {M : Type*} [SeminormedCommGroup M] {S T : Subgroup M} {x : M ⧸ S} {m : M} {r ε : ℝ}
 
 @[to_additive add_norm_aux]
 private lemma norm_aux (x : M ⧸ S) : {m : M | (m : M ⧸ S) = x}.Nonempty := Quot.exists_rep x
@@ -222,6 +224,34 @@ example :
 
 example [IsClosed (S : Set M)] :
     (instSeminormedCommGroup S) = NormedCommGroup.toSeminormedCommGroup := rfl
+
+/-- An isometric version of `Subgroup.quotientEquivOfEq`. -/
+@[to_additive "An isometric version of `AddSubgroup.quotientEquivOfEq`."]
+def _root_.Subgroup.quotientIsometryEquivOfEq (h : S = T) : M ⧸ S ≃ᵢ M ⧸ T where
+  __ := Subgroup.quotientEquivOfEq h
+  isometry_toFun := by subst h; rintro ⟨_⟩ ⟨_⟩; rfl
+
+/-- An isometric version of `QuotientGroup.quotientBot`. -/
+@[to_additive "An isometric version of `QuotientAddGroup.quotientBot`."]
+def quotientBotIsometryEquiv : M ⧸ (⊥ : Subgroup M) ≃ᵢ M where
+  __ := quotientBot
+  isometry_toFun : Isometry quotientBot := by
+    rw [MonoidHomClass.isometry_iff_norm]
+    rintro ⟨x⟩
+    change ‖x‖ = ‖QuotientGroup.mk x‖
+    simp [norm_mk]
+
+/-- An isometric version of `QuotientGroup.quotientQuotientEquivQuotient`. -/
+@[to_additive "An isometric version of `QuotientAddGroup.quotientQuotientEquivQuotient`."]
+def quotientQuotientIsometryEquivQuotient (h : S ≤ T) : (M ⧸ S) ⧸ T.map (mk' S) ≃ᵢ M ⧸ T where
+  __ := quotientQuotientEquivQuotient S T h
+  isometry_toFun : Isometry (quotientQuotientEquivQuotient S T h) := by
+    rw [MonoidHomClass.isometry_iff_norm]
+    refine fun x => eq_of_forall_le_iff fun r => ?_
+    simp only [le_norm_iff]
+    exact ⟨
+      fun h₁ y h₂ z h₃ => h₁ z <| by subst_vars; rfl,
+      fun h₁ y h₂ => h₁ y ((quotientQuotientEquivQuotient S T h).injective h₂) y rfl⟩
 
 end QuotientGroup
 
@@ -387,7 +417,7 @@ have quotients of rings by two-sided ideals, hence the commutativity hypotheses 
 
 section Submodule
 
-variable {R : Type*} [Ring R] [Module R M] (S : Submodule R M)
+variable {R : Type*} [Ring R] [Module R M] (S T : Submodule R M)
 
 instance Submodule.Quotient.seminormedAddCommGroup : SeminormedAddCommGroup (M ⧸ S) :=
   QuotientAddGroup.instSeminormedAddCommGroup S.toAddSubgroup
@@ -428,6 +458,23 @@ instance Submodule.Quotient.instIsBoundedSMul (𝕜 : Type*)
 instance Submodule.Quotient.normedSpace (𝕜 : Type*) [NormedField 𝕜] [NormedSpace 𝕜 M] [SMul 𝕜 R]
     [IsScalarTower 𝕜 R M] : NormedSpace 𝕜 (M ⧸ S) where
   norm_smul_le := norm_smul_le
+
+/-- An isometric version of `Submodule.quotEquivOfEq`. -/
+def Submodule.quotLIEOfEq (h : S = T) : M ⧸ S ≃ₗᵢ[R] M ⧸ T where
+  __ := Submodule.quotEquivOfEq S T h
+  norm_map' := by subst h; rintro ⟨_⟩; rfl
+
+/-- An isometric version of `Submodule.quotientQuotientEquivQuotient`. -/
+def Submodule.quotientQuotientLIEQuotient (h : S ≤ T) : (M ⧸ S) ⧸ map S.mkQ T ≃ₗᵢ[R] M ⧸ T where
+  __ := Submodule.quotientQuotientEquivQuotient S T h
+  norm_map' :=
+    (AddMonoidHomClass.isometry_iff_norm _).mp
+      (QuotientAddGroup.quotientQuotientIsometryEquivQuotient
+        ((Submodule.toAddSubgroup_le S T).mpr h)).isometry
+
+/-- An isometric version of `Submodule.quotientQuotientEquivQuotientSup`. -/
+def Submodule.quotientQuotientLIEQuotientSup : (M ⧸ S) ⧸ map S.mkQ T ≃ₗᵢ[R] M ⧸ (S ⊔ T) :=
+  (quotLIEOfEq _ _ (by simp)).trans (quotientQuotientLIEQuotient _ _ le_sup_left)
 
 end Submodule
 

--- a/Mathlib/Analysis/Normed/Group/Quotient.lean
+++ b/Mathlib/Analysis/Normed/Group/Quotient.lean
@@ -226,13 +226,13 @@ example [IsClosed (S : Set M)] :
     (instSeminormedCommGroup S) = NormedCommGroup.toSeminormedCommGroup := rfl
 
 /-- An isometric version of `Subgroup.quotientEquivOfEq`. -/
-@[to_additive "An isometric version of `AddSubgroup.quotientEquivOfEq`."]
+@[to_additive /-- An isometric version of `AddSubgroup.quotientEquivOfEq`. -/]
 def _root_.Subgroup.quotientIsometryEquivOfEq (h : S = T) : M ⧸ S ≃ᵢ M ⧸ T where
   __ := Subgroup.quotientEquivOfEq h
   isometry_toFun := by subst h; rintro ⟨_⟩ ⟨_⟩; rfl
 
 /-- An isometric version of `QuotientGroup.quotientBot`. -/
-@[to_additive "An isometric version of `QuotientAddGroup.quotientBot`."]
+@[to_additive /-- An isometric version of `QuotientAddGroup.quotientBot`. -/]
 def quotientBotIsometryEquiv : M ⧸ (⊥ : Subgroup M) ≃ᵢ M where
   __ := quotientBot
   isometry_toFun : Isometry quotientBot := by
@@ -242,7 +242,7 @@ def quotientBotIsometryEquiv : M ⧸ (⊥ : Subgroup M) ≃ᵢ M where
     simp [norm_mk]
 
 /-- An isometric version of `QuotientGroup.quotientQuotientEquivQuotient`. -/
-@[to_additive "An isometric version of `QuotientAddGroup.quotientQuotientEquivQuotient`."]
+@[to_additive /-- An isometric version of `QuotientAddGroup.quotientQuotientEquivQuotient`. -/]
 def quotientQuotientIsometryEquivQuotient (h : S ≤ T) : (M ⧸ S) ⧸ T.map (mk' S) ≃ᵢ M ⧸ T where
   __ := quotientQuotientEquivQuotient S T h
   isometry_toFun : Isometry (quotientQuotientEquivQuotient S T h) := by


### PR DESCRIPTION
This PR adds an isometric version of the third isomorphism theorem for groups and modules.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
