### PR TITLE
[Merged by Bors] - chore: rename doset to doubleCoset

### DIFF
--- a/Mathlib/GroupTheory/DoubleCoset.lean
+++ b/Mathlib/GroupTheory/DoubleCoset.lean
@@ -16,7 +16,7 @@ this is the usual left or right quotient of a group by a subgroup.
 
 ## Main definitions
 
-* `rel`: The double coset relation defined by two subgroups `H K` of `G`.
+* `setoid`: The double coset relation defined by two subgroups `H K` of `G`.
 * `DoubleCoset.quotient`: The quotient of `G` by the double coset relation, i.e, `H \ G / K`.
 -/
 
@@ -33,16 +33,24 @@ namespace DoubleCoset
 def doubleCoset (a : α) (s t : Set α) : Set α :=
   s * {a} * t
 
+@[deprecated (since := "2025-07-12")] alias doset := doubleCoset
+
 lemma doubleCoset_eq_image2 (a : α) (s t : Set α) :
     doubleCoset a s t = Set.image2 (· * a * ·) s t := by
   simp_rw [doubleCoset, Set.mul_singleton, ← Set.image2_mul, Set.image2_image_left]
+
+@[deprecated (since := "2025-07-12")] alias doset_eq_image2 := doubleCoset_eq_image2
 
 theorem mem_doubleCoset {s t : Set α} {a b : α} :
     b ∈ doubleCoset a s t ↔ ∃ x ∈ s, ∃ y ∈ t, b = x * a * y := by
   simp only [doubleCoset_eq_image2, Set.mem_image2, eq_comm]
 
+@[deprecated (since := "2025-07-12")] alias mem_doset := mem_doubleCoset
+
 theorem mem_doubleCoset_self (H K : Subgroup G) (a : G) : a ∈ doubleCoset a H K :=
   mem_doubleCoset.mpr ⟨1, H.one_mem, 1, K.one_mem, (one_mul a).symm.trans (mul_one (1 * a)).symm⟩
+
+@[deprecated (since := "2025-07-12")] alias mem_doset_self := mem_doubleCoset_self
 
 theorem doubleCoset_eq_of_mem {H K : Subgroup G} {a b : G} (hb : b ∈ doubleCoset a H K) :
     doubleCoset b H K = doubleCoset a H K := by
@@ -51,6 +59,8 @@ theorem doubleCoset_eq_of_mem {H K : Subgroup G} {a b : G} (hb : b ∈ doubleCos
     mul_assoc, mul_assoc, Subgroup.singleton_mul_subgroup hk, ← mul_assoc, ← mul_assoc,
     Subgroup.subgroup_mul_singleton hh]
 
+@[deprecated (since := "2025-07-12")] alias doset_eq_of_mem := doubleCoset_eq_of_mem
+
 theorem mem_doubleCoset_of_not_disjoint {H K : Subgroup G} {a b : G}
     (h : ¬Disjoint (doubleCoset a H K) (doubleCoset b H K)) : b ∈ doubleCoset a H K := by
   rw [Set.not_disjoint_iff] at h
@@ -58,6 +68,9 @@ theorem mem_doubleCoset_of_not_disjoint {H K : Subgroup G} {a b : G}
   obtain ⟨x, ⟨l, hl, r, hr, hrx⟩, y, hy, ⟨r', hr', rfl⟩⟩ := h
   refine ⟨y⁻¹ * l, H.mul_mem (H.inv_mem hy) hl, r * r'⁻¹, K.mul_mem hr (K.inv_mem hr'), ?_⟩
   rwa [mul_assoc, mul_assoc, eq_inv_mul_iff_mul_eq, ← mul_assoc, ← mul_assoc, eq_mul_inv_iff_mul_eq]
+
+@[deprecated (since := "2025-07-12")]
+alias mem_doset_of_not_disjoint := mem_doubleCoset_of_not_disjoint
 
 theorem eq_of_not_disjoint {H K : Subgroup G} {a b : G}
     (h : ¬Disjoint (doubleCoset a H K) (doubleCoset b H K)) :
@@ -104,6 +117,8 @@ theorem rel_bot_eq_right_group_rel (H : Subgroup G) :
 def quotToDoubleCoset (H K : Subgroup G) (q : Quotient (H : Set G) K) : Set G :=
   doubleCoset q.out H K
 
+@[deprecated (since := "2025-07-12")] alias quotToDoset := quotToDoubleCoset
+
 /-- Map from `G` to `H \ G / K` -/
 abbrev mk (H K : Subgroup G) (a : G) : Quotient (H : Set G) K :=
   Quotient.mk'' a
@@ -132,6 +147,8 @@ theorem mk_eq_of_doubleCoset_eq {H K : Subgroup G} {a b : G}
   rw [eq]
   exact mem_doubleCoset.mp (h.symm ▸ mem_doubleCoset_self H K b)
 
+@[deprecated (since := "2025-07-12")] alias mk_eq_of_doset_eq := mk_eq_of_doubleCoset_eq
+
 theorem disjoint_out {H K : Subgroup G} {a b : Quotient H K} :
     a ≠ b → Disjoint (doubleCoset a.out H K) (doubleCoset b.out (H : Set G) K) := by
   contrapose!
@@ -147,6 +164,8 @@ theorem union_quotToDoubleCoset (H K : Subgroup G) : ⋃ q, quotToDoubleCoset H 
   refine ⟨h⁻¹, H.inv_mem h3, k⁻¹, K.inv_mem h4, ?_⟩
   simp only [h5, ← mul_assoc, one_mul, inv_mul_cancel, mul_inv_cancel_right]
 
+@[deprecated (since := "2025-07-12")] alias union_quotToDoset := union_quotToDoubleCoset
+
 theorem doubleCoset_union_rightCoset (H K : Subgroup G) (a : G) :
     ⋃ k : K, op (a * k) • ↑H = doubleCoset a H K := by
   ext x
@@ -160,6 +179,8 @@ theorem doubleCoset_union_rightCoset (H K : Subgroup G) (a : G) :
     refine ⟨⟨y, hy⟩, ?_⟩
     simp only [hxy, ← mul_assoc, hx, mul_inv_cancel_right]
 
+@[deprecated (since := "2025-07-12")] alias doset_union_rightCoset := doubleCoset_union_rightCoset
+
 theorem doubleCoset_union_leftCoset (H K : Subgroup G) (a : G) :
     ⋃ h : H, (h * a : G) • ↑K = doubleCoset a H K := by
   ext x
@@ -171,6 +192,8 @@ theorem doubleCoset_union_leftCoset (H K : Subgroup G) (a : G) :
   · rintro ⟨x, hx, y, hy, hxy⟩
     refine ⟨⟨x, hx⟩, ?_⟩
     simp only [hxy, ← mul_assoc, hy, one_mul, inv_mul_cancel, inv_mul_cancel_right]
+
+@[deprecated (since := "2025-07-12")] alias doset_union_leftCoset := doubleCoset_union_leftCoset
 
 theorem left_bot_eq_left_quot (H : Subgroup G) :
     Quotient (⊥ : Subgroup G) (H : Set G) = (G ⧸ H) := by

--- a/Mathlib/GroupTheory/DoubleCoset.lean
+++ b/Mathlib/GroupTheory/DoubleCoset.lean
@@ -17,7 +17,7 @@ this is the usual left or right quotient of a group by a subgroup.
 ## Main definitions
 
 * `rel`: The double coset relation defined by two subgroups `H K` of `G`.
-* `Doset.quotient`: The quotient of `G` by the double coset relation, i.e, `H \ G / K`.
+* `DoubleCoset.quotient`: The quotient of `G` by the double coset relation, i.e, `H \ G / K`.
 -/
 
 assert_not_exists MonoidWithZero
@@ -27,45 +27,45 @@ variable {G : Type*} [Group G] {α : Type*} [Mul α]
 open MulOpposite
 open scoped Pointwise
 
-namespace Doset
+namespace DoubleCoset
 
 /-- The double coset as an element of `Set α` corresponding to `s a t` -/
-def doset (a : α) (s t : Set α) : Set α :=
+def doubleCoset (a : α) (s t : Set α) : Set α :=
   s * {a} * t
 
-lemma doset_eq_image2 (a : α) (s t : Set α) : doset a s t = Set.image2 (· * a * ·) s t := by
-  simp_rw [doset, Set.mul_singleton, ← Set.image2_mul, Set.image2_image_left]
+lemma doubleCoset_eq_image2 (a : α) (s t : Set α) : doubleCoset a s t = Set.image2 (· * a * ·) s t := by
+  simp_rw [doubleCoset, Set.mul_singleton, ← Set.image2_mul, Set.image2_image_left]
 
-theorem mem_doset {s t : Set α} {a b : α} : b ∈ doset a s t ↔ ∃ x ∈ s, ∃ y ∈ t, b = x * a * y := by
-  simp only [doset_eq_image2, Set.mem_image2, eq_comm]
+theorem mem_doubleCoset {s t : Set α} {a b : α} : b ∈ doubleCoset a s t ↔ ∃ x ∈ s, ∃ y ∈ t, b = x * a * y := by
+  simp only [doubleCoset_eq_image2, Set.mem_image2, eq_comm]
 
-theorem mem_doset_self (H K : Subgroup G) (a : G) : a ∈ doset a H K :=
-  mem_doset.mpr ⟨1, H.one_mem, 1, K.one_mem, (one_mul a).symm.trans (mul_one (1 * a)).symm⟩
+theorem mem_doubleCoset_self (H K : Subgroup G) (a : G) : a ∈ doubleCoset a H K :=
+  mem_doubleCoset.mpr ⟨1, H.one_mem, 1, K.one_mem, (one_mul a).symm.trans (mul_one (1 * a)).symm⟩
 
-theorem doset_eq_of_mem {H K : Subgroup G} {a b : G} (hb : b ∈ doset a H K) :
-    doset b H K = doset a H K := by
-  obtain ⟨h, hh, k, hk, rfl⟩ := mem_doset.1 hb
-  rw [doset, doset, ← Set.singleton_mul_singleton, ← Set.singleton_mul_singleton, mul_assoc,
+theorem doubleCoset_eq_of_mem {H K : Subgroup G} {a b : G} (hb : b ∈ doubleCoset a H K) :
+    doubleCoset b H K = doubleCoset a H K := by
+  obtain ⟨h, hh, k, hk, rfl⟩ := mem_doubleCoset.1 hb
+  rw [doubleCoset, doubleCoset, ← Set.singleton_mul_singleton, ← Set.singleton_mul_singleton, mul_assoc,
     mul_assoc, Subgroup.singleton_mul_subgroup hk, ← mul_assoc, ← mul_assoc,
     Subgroup.subgroup_mul_singleton hh]
 
-theorem mem_doset_of_not_disjoint {H K : Subgroup G} {a b : G}
-    (h : ¬Disjoint (doset a H K) (doset b H K)) : b ∈ doset a H K := by
+theorem mem_doubleCoset_of_not_disjoint {H K : Subgroup G} {a b : G}
+    (h : ¬Disjoint (doubleCoset a H K) (doubleCoset b H K)) : b ∈ doubleCoset a H K := by
   rw [Set.not_disjoint_iff] at h
-  simp only [mem_doset] at *
+  simp only [mem_doubleCoset] at *
   obtain ⟨x, ⟨l, hl, r, hr, hrx⟩, y, hy, ⟨r', hr', rfl⟩⟩ := h
   refine ⟨y⁻¹ * l, H.mul_mem (H.inv_mem hy) hl, r * r'⁻¹, K.mul_mem hr (K.inv_mem hr'), ?_⟩
   rwa [mul_assoc, mul_assoc, eq_inv_mul_iff_mul_eq, ← mul_assoc, ← mul_assoc, eq_mul_inv_iff_mul_eq]
 
 theorem eq_of_not_disjoint {H K : Subgroup G} {a b : G}
-    (h : ¬Disjoint (doset a H K) (doset b H K)) : doset a H K = doset b H K := by
+    (h : ¬Disjoint (doubleCoset a H K) (doubleCoset b H K)) : doubleCoset a H K = doubleCoset b H K := by
   rw [disjoint_comm] at h
-  have ha : a ∈ doset b H K := mem_doset_of_not_disjoint h
-  apply doset_eq_of_mem ha
+  have ha : a ∈ doubleCoset b H K := mem_doubleCoset_of_not_disjoint h
+  apply doubleCoset_eq_of_mem ha
 
 /-- The setoid defined by the double_coset relation -/
 def setoid (H K : Set G) : Setoid G :=
-  Setoid.ker fun x => doset x H K
+  Setoid.ker fun x => doubleCoset x H K
 
 /-- Quotient of `G` by the double coset relation, i.e. `H \ G / K` -/
 def Quotient (H K : Set G) : Type _ :=
@@ -74,8 +74,8 @@ def Quotient (H K : Set G) : Type _ :=
 theorem rel_iff {H K : Subgroup G} {x y : G} :
     setoid ↑H ↑K x y ↔ ∃ a ∈ H, ∃ b ∈ K, y = a * x * b :=
   Iff.trans
-    ⟨fun (hxy : doset x H K = doset y H K) => hxy ▸ mem_doset_self H K y,
-      fun hxy => (doset_eq_of_mem hxy).symm⟩ mem_doset
+    ⟨fun (hxy : doubleCoset x H K = doubleCoset y H K) => hxy ▸ mem_doubleCoset_self H K y,
+      fun hxy => (doubleCoset_eq_of_mem hxy).symm⟩ mem_doubleCoset
 
 theorem bot_rel_eq_leftRel (H : Subgroup G) :
     ⇑(setoid ↑(⊥ : Subgroup G) ↑H) = ⇑(QuotientGroup.leftRel H) := by
@@ -97,9 +97,9 @@ theorem rel_bot_eq_right_group_rel (H : Subgroup G) :
   · rintro (h : b * a⁻¹ ∈ H)
     exact ⟨b * a⁻¹, h, 1, rfl, by rw [mul_one, inv_mul_cancel_right]⟩
 
-/-- Create a doset out of an element of `H \ G / K` -/
-def quotToDoset (H K : Subgroup G) (q : Quotient (H : Set G) K) : Set G :=
-  doset q.out H K
+/-- Create a double coset out of an element of `H \ G / K` -/
+def quotToDoubleCoset (H K : Subgroup G) (q : Quotient (H : Set G) K) : Set G :=
+  doubleCoset q.out H K
 
 /-- Map from `G` to `H \ G / K` -/
 abbrev mk (H K : Subgroup G) (a : G) : Quotient (H : Set G) K :=
@@ -124,30 +124,30 @@ theorem mk_out_eq_mul (H K : Subgroup G) (g : G) :
   refine ⟨h⁻¹, k⁻¹, H.inv_mem h_h, K.inv_mem hk, eq_mul_inv_of_mul_eq (eq_inv_mul_of_mul_eq ?_)⟩
   rw [← mul_assoc, ← T]
 
-theorem mk_eq_of_doset_eq {H K : Subgroup G} {a b : G} (h : doset a H K = doset b H K) :
+theorem mk_eq_of_doubleCoset_eq {H K : Subgroup G} {a b : G} (h : doubleCoset a H K = doubleCoset b H K) :
     mk H K a = mk H K b := by
   rw [eq]
-  exact mem_doset.mp (h.symm ▸ mem_doset_self H K b)
+  exact mem_doubleCoset.mp (h.symm ▸ mem_doubleCoset_self H K b)
 
 theorem disjoint_out {H K : Subgroup G} {a b : Quotient H K} :
-    a ≠ b → Disjoint (doset a.out H K) (doset b.out (H : Set G) K) := by
+    a ≠ b → Disjoint (doubleCoset a.out H K) (doubleCoset b.out (H : Set G) K) := by
   contrapose!
   intro h
-  simpa [out_eq'] using mk_eq_of_doset_eq (eq_of_not_disjoint h)
+  simpa [out_eq'] using mk_eq_of_doubleCoset_eq (eq_of_not_disjoint h)
 
-theorem union_quotToDoset (H K : Subgroup G) : ⋃ q, quotToDoset H K q = Set.univ := by
+theorem union_quotToDoubleCoset (H K : Subgroup G) : ⋃ q, quotToDoubleCoset H K q = Set.univ := by
   ext x
-  simp only [Set.mem_iUnion, quotToDoset, mem_doset, SetLike.mem_coe, Set.mem_univ,
+  simp only [Set.mem_iUnion, quotToDoubleCoset, mem_doubleCoset, SetLike.mem_coe, Set.mem_univ,
     iff_true]
   use mk H K x
   obtain ⟨h, k, h3, h4, h5⟩ := mk_out_eq_mul H K x
   refine ⟨h⁻¹, H.inv_mem h3, k⁻¹, K.inv_mem h4, ?_⟩
   simp only [h5, ← mul_assoc, one_mul, inv_mul_cancel, mul_inv_cancel_right]
 
-theorem doset_union_rightCoset (H K : Subgroup G) (a : G) :
-    ⋃ k : K, op (a * k) • ↑H = doset a H K := by
+theorem doubleCoset_union_rightCoset (H K : Subgroup G) (a : G) :
+    ⋃ k : K, op (a * k) • ↑H = doubleCoset a H K := by
   ext x
-  simp only [mem_rightCoset_iff, mul_inv_rev, Set.mem_iUnion, mem_doset,
+  simp only [mem_rightCoset_iff, mul_inv_rev, Set.mem_iUnion, mem_doubleCoset,
     SetLike.mem_coe]
   constructor
   · rintro ⟨y, h_h⟩
@@ -157,10 +157,10 @@ theorem doset_union_rightCoset (H K : Subgroup G) (a : G) :
     refine ⟨⟨y, hy⟩, ?_⟩
     simp only [hxy, ← mul_assoc, hx, mul_inv_cancel_right]
 
-theorem doset_union_leftCoset (H K : Subgroup G) (a : G) :
-    ⋃ h : H, (h * a : G) • ↑K = doset a H K := by
+theorem doubleCoset_union_leftCoset (H K : Subgroup G) (a : G) :
+    ⋃ h : H, (h * a : G) • ↑K = doubleCoset a H K := by
   ext x
-  simp only [mem_leftCoset_iff, mul_inv_rev, Set.mem_iUnion, mem_doset]
+  simp only [mem_leftCoset_iff, mul_inv_rev, Set.mem_iUnion, mem_doubleCoset]
   constructor
   · rintro ⟨y, h_h⟩
     refine ⟨y, y.2, a⁻¹ * y⁻¹ * x, h_h, ?_⟩
@@ -183,4 +183,4 @@ theorem right_bot_eq_right_quot (H : Subgroup G) :
   ext
   simp_rw [← rel_bot_eq_right_group_rel H]
 
-end Doset
+end DoubleCoset

--- a/Mathlib/GroupTheory/DoubleCoset.lean
+++ b/Mathlib/GroupTheory/DoubleCoset.lean
@@ -33,10 +33,12 @@ namespace DoubleCoset
 def doubleCoset (a : α) (s t : Set α) : Set α :=
   s * {a} * t
 
-lemma doubleCoset_eq_image2 (a : α) (s t : Set α) : doubleCoset a s t = Set.image2 (· * a * ·) s t := by
+lemma doubleCoset_eq_image2 (a : α) (s t : Set α) :
+    doubleCoset a s t = Set.image2 (· * a * ·) s t := by
   simp_rw [doubleCoset, Set.mul_singleton, ← Set.image2_mul, Set.image2_image_left]
 
-theorem mem_doubleCoset {s t : Set α} {a b : α} : b ∈ doubleCoset a s t ↔ ∃ x ∈ s, ∃ y ∈ t, b = x * a * y := by
+theorem mem_doubleCoset {s t : Set α} {a b : α} :
+    b ∈ doubleCoset a s t ↔ ∃ x ∈ s, ∃ y ∈ t, b = x * a * y := by
   simp only [doubleCoset_eq_image2, Set.mem_image2, eq_comm]
 
 theorem mem_doubleCoset_self (H K : Subgroup G) (a : G) : a ∈ doubleCoset a H K :=
@@ -45,8 +47,8 @@ theorem mem_doubleCoset_self (H K : Subgroup G) (a : G) : a ∈ doubleCoset a H 
 theorem doubleCoset_eq_of_mem {H K : Subgroup G} {a b : G} (hb : b ∈ doubleCoset a H K) :
     doubleCoset b H K = doubleCoset a H K := by
   obtain ⟨h, hh, k, hk, rfl⟩ := mem_doubleCoset.1 hb
-  rw [doubleCoset, doubleCoset, ← Set.singleton_mul_singleton, ← Set.singleton_mul_singleton, mul_assoc,
-    mul_assoc, Subgroup.singleton_mul_subgroup hk, ← mul_assoc, ← mul_assoc,
+  rw [doubleCoset, doubleCoset, ← Set.singleton_mul_singleton, ← Set.singleton_mul_singleton,
+    mul_assoc, mul_assoc, Subgroup.singleton_mul_subgroup hk, ← mul_assoc, ← mul_assoc,
     Subgroup.subgroup_mul_singleton hh]
 
 theorem mem_doubleCoset_of_not_disjoint {H K : Subgroup G} {a b : G}
@@ -58,7 +60,8 @@ theorem mem_doubleCoset_of_not_disjoint {H K : Subgroup G} {a b : G}
   rwa [mul_assoc, mul_assoc, eq_inv_mul_iff_mul_eq, ← mul_assoc, ← mul_assoc, eq_mul_inv_iff_mul_eq]
 
 theorem eq_of_not_disjoint {H K : Subgroup G} {a b : G}
-    (h : ¬Disjoint (doubleCoset a H K) (doubleCoset b H K)) : doubleCoset a H K = doubleCoset b H K := by
+    (h : ¬Disjoint (doubleCoset a H K) (doubleCoset b H K)) :
+    doubleCoset a H K = doubleCoset b H K := by
   rw [disjoint_comm] at h
   have ha : a ∈ doubleCoset b H K := mem_doubleCoset_of_not_disjoint h
   apply doubleCoset_eq_of_mem ha
@@ -124,8 +127,8 @@ theorem mk_out_eq_mul (H K : Subgroup G) (g : G) :
   refine ⟨h⁻¹, k⁻¹, H.inv_mem h_h, K.inv_mem hk, eq_mul_inv_of_mul_eq (eq_inv_mul_of_mul_eq ?_)⟩
   rw [← mul_assoc, ← T]
 
-theorem mk_eq_of_doubleCoset_eq {H K : Subgroup G} {a b : G} (h : doubleCoset a H K = doubleCoset b H K) :
-    mk H K a = mk H K b := by
+theorem mk_eq_of_doubleCoset_eq {H K : Subgroup G} {a b : G}
+    (h : doubleCoset a H K = doubleCoset b H K) : mk H K a = mk H K b := by
   rw [eq]
   exact mem_doubleCoset.mp (h.symm ▸ mem_doubleCoset_self H K b)
 

--- a/Mathlib/GroupTheory/DoubleCoset.lean
+++ b/Mathlib/GroupTheory/DoubleCoset.lean
@@ -33,24 +33,24 @@ namespace DoubleCoset
 def doubleCoset (a : α) (s t : Set α) : Set α :=
   s * {a} * t
 
-@[deprecated (since := "2025-07-12")] alias doset := doubleCoset
+@[deprecated (since := "2025-07-12")] alias _root_.Doset.doset := doubleCoset
 
 lemma doubleCoset_eq_image2 (a : α) (s t : Set α) :
     doubleCoset a s t = Set.image2 (· * a * ·) s t := by
   simp_rw [doubleCoset, Set.mul_singleton, ← Set.image2_mul, Set.image2_image_left]
 
-@[deprecated (since := "2025-07-12")] alias doset_eq_image2 := doubleCoset_eq_image2
+@[deprecated (since := "2025-07-12")] alias _root_.Doset.doset_eq_image2 := doubleCoset_eq_image2
 
 theorem mem_doubleCoset {s t : Set α} {a b : α} :
     b ∈ doubleCoset a s t ↔ ∃ x ∈ s, ∃ y ∈ t, b = x * a * y := by
   simp only [doubleCoset_eq_image2, Set.mem_image2, eq_comm]
 
-@[deprecated (since := "2025-07-12")] alias mem_doset := mem_doubleCoset
+@[deprecated (since := "2025-07-12")] alias _root_.Doset.mem_doset := mem_doubleCoset
 
 theorem mem_doubleCoset_self (H K : Subgroup G) (a : G) : a ∈ doubleCoset a H K :=
   mem_doubleCoset.mpr ⟨1, H.one_mem, 1, K.one_mem, (one_mul a).symm.trans (mul_one (1 * a)).symm⟩
 
-@[deprecated (since := "2025-07-12")] alias mem_doset_self := mem_doubleCoset_self
+@[deprecated (since := "2025-07-12")] alias _root_.Doset.mem_doset_self := mem_doubleCoset_self
 
 theorem doubleCoset_eq_of_mem {H K : Subgroup G} {a b : G} (hb : b ∈ doubleCoset a H K) :
     doubleCoset b H K = doubleCoset a H K := by
@@ -59,7 +59,7 @@ theorem doubleCoset_eq_of_mem {H K : Subgroup G} {a b : G} (hb : b ∈ doubleCos
     mul_assoc, mul_assoc, Subgroup.singleton_mul_subgroup hk, ← mul_assoc, ← mul_assoc,
     Subgroup.subgroup_mul_singleton hh]
 
-@[deprecated (since := "2025-07-12")] alias doset_eq_of_mem := doubleCoset_eq_of_mem
+@[deprecated (since := "2025-07-12")] alias _root_.Doset.doset_eq_of_mem := doubleCoset_eq_of_mem
 
 theorem mem_doubleCoset_of_not_disjoint {H K : Subgroup G} {a b : G}
     (h : ¬Disjoint (doubleCoset a H K) (doubleCoset b H K)) : b ∈ doubleCoset a H K := by
@@ -70,7 +70,7 @@ theorem mem_doubleCoset_of_not_disjoint {H K : Subgroup G} {a b : G}
   rwa [mul_assoc, mul_assoc, eq_inv_mul_iff_mul_eq, ← mul_assoc, ← mul_assoc, eq_mul_inv_iff_mul_eq]
 
 @[deprecated (since := "2025-07-12")]
-alias mem_doset_of_not_disjoint := mem_doubleCoset_of_not_disjoint
+alias _root_.Doset.mem_doset_of_not_disjoint := mem_doubleCoset_of_not_disjoint
 
 theorem eq_of_not_disjoint {H K : Subgroup G} {a b : G}
     (h : ¬Disjoint (doubleCoset a H K) (doubleCoset b H K)) :
@@ -79,19 +79,31 @@ theorem eq_of_not_disjoint {H K : Subgroup G} {a b : G}
   have ha : a ∈ doubleCoset b H K := mem_doubleCoset_of_not_disjoint h
   apply doubleCoset_eq_of_mem ha
 
+@[deprecated (since := "2025-07-12")]
+alias _root_.Doset.eq_of_not_disjoint := eq_of_not_disjoint
+
 /-- The setoid defined by the double_coset relation -/
 def setoid (H K : Set G) : Setoid G :=
   Setoid.ker fun x => doubleCoset x H K
 
+@[deprecated (since := "2025-07-12")]
+alias _root_.Doset.setoid := setoid
+
 /-- Quotient of `G` by the double coset relation, i.e. `H \ G / K` -/
 def Quotient (H K : Set G) : Type _ :=
   _root_.Quotient (setoid H K)
+
+@[deprecated (since := "2025-07-12")]
+alias _root_.Doset.Quotient := Quotient
 
 theorem rel_iff {H K : Subgroup G} {x y : G} :
     setoid ↑H ↑K x y ↔ ∃ a ∈ H, ∃ b ∈ K, y = a * x * b :=
   Iff.trans
     ⟨fun (hxy : doubleCoset x H K = doubleCoset y H K) => hxy ▸ mem_doubleCoset_self H K y,
       fun hxy => (doubleCoset_eq_of_mem hxy).symm⟩ mem_doubleCoset
+
+@[deprecated (since := "2025-07-12")]
+alias _root_.Doset.rel_iff := rel_iff
 
 theorem bot_rel_eq_leftRel (H : Subgroup G) :
     ⇑(setoid ↑(⊥ : Subgroup G) ↑H) = ⇑(QuotientGroup.leftRel H) := by
@@ -103,6 +115,9 @@ theorem bot_rel_eq_leftRel (H : Subgroup G) :
   · rintro (h : a⁻¹ * b ∈ H)
     exact ⟨1, rfl, a⁻¹ * b, h, by rw [one_mul, mul_inv_cancel_left]⟩
 
+@[deprecated (since := "2025-07-12")]
+alias _root_.Doset.bot_rel_eq_leftRel := bot_rel_eq_leftRel
+
 theorem rel_bot_eq_right_group_rel (H : Subgroup G) :
     ⇑(setoid ↑H ↑(⊥ : Subgroup G)) = ⇑(QuotientGroup.rightRel H) := by
   ext a b
@@ -113,15 +128,20 @@ theorem rel_bot_eq_right_group_rel (H : Subgroup G) :
   · rintro (h : b * a⁻¹ ∈ H)
     exact ⟨b * a⁻¹, h, 1, rfl, by rw [mul_one, inv_mul_cancel_right]⟩
 
+@[deprecated (since := "2025-07-12")]
+alias _root_.Doset.rel_bot_eq_right_group_rel := rel_bot_eq_right_group_rel
+
 /-- Create a double coset out of an element of `H \ G / K` -/
 def quotToDoubleCoset (H K : Subgroup G) (q : Quotient (H : Set G) K) : Set G :=
   doubleCoset q.out H K
 
-@[deprecated (since := "2025-07-12")] alias quotToDoset := quotToDoubleCoset
+@[deprecated (since := "2025-07-12")] alias _root_.Doset.quotToDoset := quotToDoubleCoset
 
 /-- Map from `G` to `H \ G / K` -/
 abbrev mk (H K : Subgroup G) (a : G) : Quotient (H : Set G) K :=
   Quotient.mk'' a
+
+@[deprecated (since := "2025-07-12")] alias _root_.Doset.mk := mk
 
 instance (H K : Subgroup G) : Inhabited (Quotient (H : Set G) K) :=
   ⟨mk H K (1 : G)⟩
@@ -131,8 +151,12 @@ theorem eq (H K : Subgroup G) (a b : G) :
   rw [Quotient.eq'']
   apply rel_iff
 
+@[deprecated (since := "2025-07-12")] alias _root_.Doset.eq := eq
+
 theorem out_eq' (H K : Subgroup G) (q : Quotient ↑H ↑K) : mk H K q.out = q :=
   Quotient.out_eq' q
+
+@[deprecated (since := "2025-07-12")] alias _root_.Doset.out_eq' := out_eq'
 
 theorem mk_out_eq_mul (H K : Subgroup G) (g : G) :
     ∃ h k : G, h ∈ H ∧ k ∈ K ∧ (mk H K g : Quotient ↑H ↑K).out = h * g * k := by
@@ -142,18 +166,23 @@ theorem mk_out_eq_mul (H K : Subgroup G) (g : G) :
   refine ⟨h⁻¹, k⁻¹, H.inv_mem h_h, K.inv_mem hk, eq_mul_inv_of_mul_eq (eq_inv_mul_of_mul_eq ?_)⟩
   rw [← mul_assoc, ← T]
 
+@[deprecated (since := "2025-07-12")] alias _root_.Doset.mk_out_eq_mul := mk_out_eq_mul
+
 theorem mk_eq_of_doubleCoset_eq {H K : Subgroup G} {a b : G}
     (h : doubleCoset a H K = doubleCoset b H K) : mk H K a = mk H K b := by
   rw [eq]
   exact mem_doubleCoset.mp (h.symm ▸ mem_doubleCoset_self H K b)
 
-@[deprecated (since := "2025-07-12")] alias mk_eq_of_doset_eq := mk_eq_of_doubleCoset_eq
+@[deprecated (since := "2025-07-12")]
+alias _root_.Doset.mk_eq_of_doset_eq := mk_eq_of_doubleCoset_eq
 
 theorem disjoint_out {H K : Subgroup G} {a b : Quotient H K} :
     a ≠ b → Disjoint (doubleCoset a.out H K) (doubleCoset b.out (H : Set G) K) := by
   contrapose!
   intro h
   simpa [out_eq'] using mk_eq_of_doubleCoset_eq (eq_of_not_disjoint h)
+
+@[deprecated (since := "2025-07-12")] alias _root_.Doset.disjoint_out := disjoint_out
 
 theorem union_quotToDoubleCoset (H K : Subgroup G) : ⋃ q, quotToDoubleCoset H K q = Set.univ := by
   ext x
@@ -164,7 +193,8 @@ theorem union_quotToDoubleCoset (H K : Subgroup G) : ⋃ q, quotToDoubleCoset H 
   refine ⟨h⁻¹, H.inv_mem h3, k⁻¹, K.inv_mem h4, ?_⟩
   simp only [h5, ← mul_assoc, one_mul, inv_mul_cancel, mul_inv_cancel_right]
 
-@[deprecated (since := "2025-07-12")] alias union_quotToDoset := union_quotToDoubleCoset
+@[deprecated (since := "2025-07-12")]
+alias _root_.Doset.union_quotToDoset := union_quotToDoubleCoset
 
 theorem doubleCoset_union_rightCoset (H K : Subgroup G) (a : G) :
     ⋃ k : K, op (a * k) • ↑H = doubleCoset a H K := by
@@ -179,7 +209,8 @@ theorem doubleCoset_union_rightCoset (H K : Subgroup G) (a : G) :
     refine ⟨⟨y, hy⟩, ?_⟩
     simp only [hxy, ← mul_assoc, hx, mul_inv_cancel_right]
 
-@[deprecated (since := "2025-07-12")] alias doset_union_rightCoset := doubleCoset_union_rightCoset
+@[deprecated (since := "2025-07-12")]
+alias _root_.Doset.doset_union_rightCoset := doubleCoset_union_rightCoset
 
 theorem doubleCoset_union_leftCoset (H K : Subgroup G) (a : G) :
     ⋃ h : H, (h * a : G) • ↑K = doubleCoset a H K := by
@@ -193,7 +224,8 @@ theorem doubleCoset_union_leftCoset (H K : Subgroup G) (a : G) :
     refine ⟨⟨x, hx⟩, ?_⟩
     simp only [hxy, ← mul_assoc, hy, one_mul, inv_mul_cancel, inv_mul_cancel_right]
 
-@[deprecated (since := "2025-07-12")] alias doset_union_leftCoset := doubleCoset_union_leftCoset
+@[deprecated (since := "2025-07-12")]
+alias _root_.Doset.doset_union_leftCoset := doubleCoset_union_leftCoset
 
 theorem left_bot_eq_left_quot (H : Subgroup G) :
     Quotient (⊥ : Subgroup G) (H : Set G) = (G ⧸ H) := by
@@ -202,11 +234,17 @@ theorem left_bot_eq_left_quot (H : Subgroup G) :
   ext
   simp_rw [← bot_rel_eq_leftRel H]
 
+@[deprecated (since := "2025-07-12")]
+alias _root_.Doset.left_bot_eq_left_quot := left_bot_eq_left_quot
+
 theorem right_bot_eq_right_quot (H : Subgroup G) :
     Quotient (H : Set G) (⊥ : Subgroup G) = _root_.Quotient (QuotientGroup.rightRel H) := by
   unfold Quotient
   congr
   ext
   simp_rw [← rel_bot_eq_right_group_rel H]
+
+@[deprecated (since := "2025-07-12")]
+alias _root_.Doset.right_bot_eq_right_quot := right_bot_eq_right_quot
 
 end DoubleCoset


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I was working with these in FLT and something snapped. It's *not a word*. 
