### PR TITLE
[Merged by Bors] - feat(Data/{Sum,Sigma}/Interval): Iic, Iio, Ici, and Ioi

### DIFF
--- a/Mathlib/Data/Sigma/Interval.lean
+++ b/Mathlib/Data/Sigma/Interval.lean
@@ -29,6 +29,7 @@ variable {ι : Type*} {α : ι → Type*}
 
 section Disjoint
 
+section LocallyFiniteOrder
 variable [DecidableEq ι] [∀ i, Preorder (α i)] [∀ i, LocallyFiniteOrder (α i)]
 
 instance instLocallyFiniteOrder : LocallyFiniteOrder (Σ i, α i) where
@@ -86,6 +87,52 @@ theorem Ioc_mk_mk : Ioc (⟨i, a⟩ : Sigma α) ⟨i, b⟩ = (Ioc a b).map (Embe
 @[simp]
 theorem Ioo_mk_mk : Ioo (⟨i, a⟩ : Sigma α) ⟨i, b⟩ = (Ioo a b).map (Embedding.sigmaMk i) :=
   dif_pos rfl
+
+end LocallyFiniteOrder
+
+section LocallyFiniteOrderBot
+variable [DecidableEq ι] [∀ i, Preorder (α i)] [∀ i, LocallyFiniteOrderBot (α i)]
+
+instance instLocallyFiniteOrderBot : LocallyFiniteOrderBot (Σ i, α i) where
+  finsetIic := Sigma.rec fun i a => (Iic a).map (Embedding.sigmaMk i)
+  finsetIio := Sigma.rec fun i a => (Iio a).map (Embedding.sigmaMk i)
+  finset_mem_Iic := fun ⟨i, a⟩ ⟨j, b⟩ => by
+    obtain rfl | hij := Decidable.eq_or_ne i j
+    · simp
+    · simp [hij, le_def, hij.symm]
+  finset_mem_Iio := fun ⟨i, a⟩ ⟨j, b⟩ => by
+    obtain rfl | hij := Decidable.eq_or_ne i j
+    · simp
+    · simp [hij, lt_def, hij.symm]
+
+variable (i : ι) (a : α i)
+
+@[simp] theorem Iic_mk : Iic (⟨i, a⟩ : Sigma α) = (Iic a).map (Embedding.sigmaMk i) := rfl
+@[simp] theorem Iio_mk : Iio (⟨i, a⟩ : Sigma α) = (Iio a).map (Embedding.sigmaMk i) := rfl
+
+end LocallyFiniteOrderBot
+
+section LocallyFiniteOrderTop
+variable [DecidableEq ι] [∀ i, Preorder (α i)] [∀ i, LocallyFiniteOrderTop (α i)]
+
+instance instLocallyFiniteOrderTop : LocallyFiniteOrderTop (Σ i, α i) where
+  finsetIci := Sigma.rec fun i a => (Ici a).map (Embedding.sigmaMk i)
+  finsetIoi := Sigma.rec fun i a => (Ioi a).map (Embedding.sigmaMk i)
+  finset_mem_Ici := fun ⟨i, a⟩ ⟨j, b⟩ => by
+    obtain rfl | hij := Decidable.eq_or_ne i j
+    · simp
+    · simp [hij, le_def]
+  finset_mem_Ioi := fun ⟨i, a⟩ ⟨j, b⟩ => by
+    obtain rfl | hij := Decidable.eq_or_ne i j
+    · simp
+    · simp [hij, lt_def]
+
+variable (i : ι) (a : α i)
+
+@[simp] theorem Ici_mk : Ici (⟨i, a⟩ : Sigma α) = (Ici a).map (Embedding.sigmaMk i) := rfl
+@[simp] theorem Ioi_mk : Ioi (⟨i, a⟩ : Sigma α) = (Ioi a).map (Embedding.sigmaMk i) := rfl
+
+end LocallyFiniteOrderTop
 
 end Disjoint
 

--- a/Mathlib/Data/Sigma/Interval.lean
+++ b/Mathlib/Data/Sigma/Interval.lean
@@ -91,17 +91,17 @@ theorem Ioo_mk_mk : Ioo (⟨i, a⟩ : Sigma α) ⟨i, b⟩ = (Ioo a b).map (Embe
 end LocallyFiniteOrder
 
 section LocallyFiniteOrderBot
-variable [DecidableEq ι] [∀ i, Preorder (α i)] [∀ i, LocallyFiniteOrderBot (α i)]
+variable [∀ i, Preorder (α i)] [∀ i, LocallyFiniteOrderBot (α i)]
 
 instance instLocallyFiniteOrderBot : LocallyFiniteOrderBot (Σ i, α i) where
   finsetIic := Sigma.rec fun i a => (Iic a).map (Embedding.sigmaMk i)
   finsetIio := Sigma.rec fun i a => (Iio a).map (Embedding.sigmaMk i)
   finset_mem_Iic := fun ⟨i, a⟩ ⟨j, b⟩ => by
-    obtain rfl | hij := Decidable.eq_or_ne i j
+    obtain rfl | hij := eq_or_ne i j
     · simp
     · simp [hij, le_def, hij.symm]
   finset_mem_Iio := fun ⟨i, a⟩ ⟨j, b⟩ => by
-    obtain rfl | hij := Decidable.eq_or_ne i j
+    obtain rfl | hij := eq_or_ne i j
     · simp
     · simp [hij, lt_def, hij.symm]
 
@@ -113,17 +113,17 @@ variable (i : ι) (a : α i)
 end LocallyFiniteOrderBot
 
 section LocallyFiniteOrderTop
-variable [DecidableEq ι] [∀ i, Preorder (α i)] [∀ i, LocallyFiniteOrderTop (α i)]
+variable [∀ i, Preorder (α i)] [∀ i, LocallyFiniteOrderTop (α i)]
 
 instance instLocallyFiniteOrderTop : LocallyFiniteOrderTop (Σ i, α i) where
   finsetIci := Sigma.rec fun i a => (Ici a).map (Embedding.sigmaMk i)
   finsetIoi := Sigma.rec fun i a => (Ioi a).map (Embedding.sigmaMk i)
   finset_mem_Ici := fun ⟨i, a⟩ ⟨j, b⟩ => by
-    obtain rfl | hij := Decidable.eq_or_ne i j
+    obtain rfl | hij := eq_or_ne i j
     · simp
     · simp [hij, le_def]
   finset_mem_Ioi := fun ⟨i, a⟩ ⟨j, b⟩ => by
-    obtain rfl | hij := Decidable.eq_or_ne i j
+    obtain rfl | hij := eq_or_ne i j
     · simp
     · simp [hij, lt_def]
 

--- a/Mathlib/Data/Sigma/Interval.lean
+++ b/Mathlib/Data/Sigma/Interval.lean
@@ -94,8 +94,8 @@ section LocallyFiniteOrderBot
 variable [∀ i, Preorder (α i)] [∀ i, LocallyFiniteOrderBot (α i)]
 
 instance instLocallyFiniteOrderBot : LocallyFiniteOrderBot (Σ i, α i) where
-  finsetIic := Sigma.rec fun i a => (Iic a).map (Embedding.sigmaMk i)
-  finsetIio := Sigma.rec fun i a => (Iio a).map (Embedding.sigmaMk i)
+  finsetIic | ⟨i, a⟩ => (Iic a).map (Embedding.sigmaMk i)
+  finsetIio | ⟨i, a⟩ => (Iio a).map (Embedding.sigmaMk i)
   finset_mem_Iic := fun ⟨i, a⟩ ⟨j, b⟩ => by
     obtain rfl | hij := eq_or_ne i j
     · simp
@@ -116,8 +116,8 @@ section LocallyFiniteOrderTop
 variable [∀ i, Preorder (α i)] [∀ i, LocallyFiniteOrderTop (α i)]
 
 instance instLocallyFiniteOrderTop : LocallyFiniteOrderTop (Σ i, α i) where
-  finsetIci := Sigma.rec fun i a => (Ici a).map (Embedding.sigmaMk i)
-  finsetIoi := Sigma.rec fun i a => (Ioi a).map (Embedding.sigmaMk i)
+  finsetIci | ⟨i, a⟩ => (Ici a).map (Embedding.sigmaMk i)
+  finsetIoi | ⟨i, a⟩ => (Ioi a).map (Embedding.sigmaMk i)
   finset_mem_Ici := fun ⟨i, a⟩ ⟨j, b⟩ => by
     obtain rfl | hij := eq_or_ne i j
     · simp

--- a/Mathlib/Data/Sum/Interval.lean
+++ b/Mathlib/Data/Sum/Interval.lean
@@ -429,7 +429,8 @@ lemma Iio_inr : Iio (inrₗ b : α ⊕ₗ β) = (Finset.univ.disjSum (Iio b)).ma
 
 end LocallyFiniteOrderBot
 
--- TODO: there is a diamond here
+/-- TODO: `LocallyFiniteOrder.toLocallyFiniteOrderBot` is probably a bad instance, as it forms
+a diamond with this instance, and constructs data from data. We should consider removing it. -/
 example [Fintype α] [Preorder α] [Preorder β] [OrderBot α] [OrderBot β] [OrderTop α]
     [LocallyFiniteOrder α] [LocallyFiniteOrder β] :
     LocallyFiniteOrder.toLocallyFiniteOrderBot = instLocallyFiniteOrderBot (α := α) (β := β) := by

--- a/Mathlib/Data/Sum/Interval.lean
+++ b/Mathlib/Data/Sum/Interval.lean
@@ -321,8 +321,10 @@ end Disjoint
 /-! ### Lexicographical sum of orders -/
 
 namespace Lex
-variable [Preorder α] [Preorder β] [OrderTop α] [OrderBot β] [LocallyFiniteOrder α]
-  [LocallyFiniteOrder β]
+
+section LocallyFiniteOrder
+variable [Preorder α] [Preorder β] [LocallyFiniteOrder α] [LocallyFiniteOrder β]
+variable [LocallyFiniteOrderTop α] [LocallyFiniteOrderBot β]
 
 /-- Throwaway tactic. -/
 local elab "simp_lex" : tactic => do
@@ -401,6 +403,54 @@ lemma Ioc_inr_inr :
 lemma Ioo_inr_inr :
     Ioo (inrₗ b₁ : α ⊕ₗ β) (inrₗ b₂) = (Ioo b₁ b₂).map (Embedding.inr.trans toLex.toEmbedding) := by
   rw [← Finset.map_map]; rfl
+
+end LocallyFiniteOrder
+
+section LocallyFiniteOrderBot
+variable [Preorder α] [Preorder β] [Fintype α] [LocallyFiniteOrderBot α] [LocallyFiniteOrderBot β]
+
+instance locallyFiniteOrderBot : LocallyFiniteOrderBot (α ⊕ₗ β) where
+  finsetIic := Sum.elim
+    (Iic · |>.map (.trans .inl toLex.toEmbedding))
+    (fun x => Finset.univ.disjSum (Iic x) |>.map toLex.toEmbedding) ∘ ofLex
+  finsetIio := Sum.elim
+    (Iio · |>.map (.trans .inl toLex.toEmbedding))
+    (fun x => Finset.univ.disjSum (Iio x) |>.map toLex.toEmbedding) ∘ ofLex
+  finset_mem_Iic := by simp
+  finset_mem_Iio := by simp
+
+variable (a : α) (b : β)
+
+lemma Iic_inl : Iic (inlₗ a : α ⊕ₗ β) = (Iic a).map (Embedding.inl.trans toLex.toEmbedding) := rfl
+lemma Iic_inr : Iic (inrₗ b : α ⊕ₗ β) = (Finset.univ.disjSum (Iic b)).map toLex.toEmbedding := rfl
+
+lemma Iio_inl : Iio (inlₗ a : α ⊕ₗ β) = (Iio a).map (Embedding.inl.trans toLex.toEmbedding) := rfl
+lemma Iio_inr : Iio (inrₗ b : α ⊕ₗ β) = (Finset.univ.disjSum (Iio b)).map toLex.toEmbedding := rfl
+
+end LocallyFiniteOrderBot
+
+section LocallyFiniteOrderTop
+variable [Preorder α] [Preorder β] [LocallyFiniteOrderTop α] [Fintype β] [LocallyFiniteOrderTop β]
+
+instance locallyFiniteOrderTop : LocallyFiniteOrderTop (α ⊕ₗ β) where
+  finsetIci := Sum.elim
+    (fun x => (Ici x).disjSum Finset.univ |>.map toLex.toEmbedding)
+    (Ici · |>.map (.trans .inr toLex.toEmbedding)) ∘ ofLex
+  finsetIoi := Sum.elim
+    (fun x => (Ioi x).disjSum Finset.univ |>.map toLex.toEmbedding)
+    (Ioi · |>.map (.trans .inr toLex.toEmbedding)) ∘ ofLex
+  finset_mem_Ici := by simp
+  finset_mem_Ioi := by simp
+
+variable (a : α) (b : β)
+
+lemma Ici_inl : Ici (inlₗ a : α ⊕ₗ β) = ((Ici a).disjSum Finset.univ).map toLex.toEmbedding := rfl
+lemma Ici_inr : Ici (inrₗ b : α ⊕ₗ β) = (Ici b).map (Embedding.inr.trans toLex.toEmbedding) := rfl
+
+lemma Ioi_inl : Ioi (inlₗ a : α ⊕ₗ β) = ((Ioi a).disjSum Finset.univ).map toLex.toEmbedding := rfl
+lemma Ioi_inr : Ioi (inrₗ b : α ⊕ₗ β) = (Ioi b).map (Embedding.inr.trans toLex.toEmbedding) := rfl
+
+end LocallyFiniteOrderTop
 
 end Lex
 end Sum

--- a/Mathlib/Data/Sum/Interval.lean
+++ b/Mathlib/Data/Sum/Interval.lean
@@ -207,6 +207,7 @@ variable {α β : Type*}
 
 section Disjoint
 
+section LocallyFiniteOrder
 variable [Preorder α] [Preorder β] [LocallyFiniteOrder α] [LocallyFiniteOrder β]
 
 instance instLocallyFiniteOrder : LocallyFiniteOrder (α ⊕ β) where
@@ -276,6 +277,44 @@ theorem Ioc_inr_inr : Ioc (inr b₁ : α ⊕ β) (inr b₂) = (Ioc b₁ b₂).ma
 
 theorem Ioo_inr_inr : Ioo (inr b₁ : α ⊕ β) (inr b₂) = (Ioo b₁ b₂).map Embedding.inr :=
   rfl
+
+end LocallyFiniteOrder
+
+section LocallyFiniteOrderBot
+variable [Preorder α] [Preorder β] [LocallyFiniteOrderBot α] [LocallyFiniteOrderBot β]
+
+instance : LocallyFiniteOrderBot (α ⊕ β) where
+  finsetIic := Sum.elim (Iic · |>.map .inl) (Iic · |>.map .inr)
+  finsetIio := Sum.elim (Iio · |>.map .inl) (Iio · |>.map .inr)
+  finset_mem_Iic := by simp
+  finset_mem_Iio := by simp
+
+variable (a : α) (b : β)
+
+theorem Iic_inl : Iic (inl a : α ⊕ β) = (Iic a).map Embedding.inl := rfl
+theorem Iic_inr : Iic (inr b : α ⊕ β) = (Iic b).map Embedding.inr := rfl
+theorem Iio_inl : Iio (inl a : α ⊕ β) = (Iio a).map Embedding.inl := rfl
+theorem Iio_inr : Iio (inr b : α ⊕ β) = (Iio b).map Embedding.inr := rfl
+
+end LocallyFiniteOrderBot
+
+section LocallyFiniteOrderTop
+variable [Preorder α] [Preorder β] [LocallyFiniteOrderTop α] [LocallyFiniteOrderTop β]
+
+instance : LocallyFiniteOrderTop (α ⊕ β) where
+  finsetIci := Sum.elim (Ici · |>.map .inl) (Ici · |>.map .inr)
+  finsetIoi := Sum.elim (Ioi · |>.map .inl) (Ioi · |>.map .inr)
+  finset_mem_Ici := by simp
+  finset_mem_Ioi := by simp
+
+variable (a : α) (b : β)
+
+theorem Ici_inl : Ici (inl a : α ⊕ β) = (Ici a).map Embedding.inl := rfl
+theorem Ici_inr : Ici (inr b : α ⊕ β) = (Ici b).map Embedding.inr := rfl
+theorem Ioi_inl : Ioi (inl a : α ⊕ β) = (Ioi a).map Embedding.inl := rfl
+theorem Ioi_inr : Ioi (inr b : α ⊕ β) = (Ioi b).map Embedding.inr := rfl
+
+end LocallyFiniteOrderTop
 
 end Disjoint
 

--- a/Mathlib/Data/Sum/Interval.lean
+++ b/Mathlib/Data/Sum/Interval.lean
@@ -409,7 +409,7 @@ end LocallyFiniteOrder
 section LocallyFiniteOrderBot
 variable [Preorder α] [Preorder β] [Fintype α] [LocallyFiniteOrderBot α] [LocallyFiniteOrderBot β]
 
-instance locallyFiniteOrderBot : LocallyFiniteOrderBot (α ⊕ₗ β) where
+instance instLocallyFiniteOrderBot : LocallyFiniteOrderBot (α ⊕ₗ β) where
   finsetIic := Sum.elim
     (Iic · |>.map (.trans .inl toLex.toEmbedding))
     (fun x => Finset.univ.disjSum (Iic x) |>.map toLex.toEmbedding) ∘ ofLex
@@ -429,10 +429,18 @@ lemma Iio_inr : Iio (inrₗ b : α ⊕ₗ β) = (Finset.univ.disjSum (Iio b)).ma
 
 end LocallyFiniteOrderBot
 
+-- TODO: there is a diamond here
+example [Fintype α] [Preorder α] [Preorder β] [OrderBot α] [OrderBot β] [OrderTop α]
+    [LocallyFiniteOrder α] [LocallyFiniteOrder β] :
+    LocallyFiniteOrder.toLocallyFiniteOrderBot = instLocallyFiniteOrderBot (α := α) (β := β) := by
+  try with_reducible_and_instances rfl -- fails
+  try rfl -- fails
+  exact Subsingleton.elim _ _
+
 section LocallyFiniteOrderTop
 variable [Preorder α] [Preorder β] [LocallyFiniteOrderTop α] [Fintype β] [LocallyFiniteOrderTop β]
 
-instance locallyFiniteOrderTop : LocallyFiniteOrderTop (α ⊕ₗ β) where
+instance instLocallyFiniteOrderTop : LocallyFiniteOrderTop (α ⊕ₗ β) where
   finsetIci := Sum.elim
     (fun x => (Ici x).disjSum Finset.univ |>.map toLex.toEmbedding)
     (Ici · |>.map (.trans .inr toLex.toEmbedding)) ∘ ofLex


### PR DESCRIPTION
This adds some missing `LocallyFiniteOrderBot` and `LocallyFiniteOrderTop` instances.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
