### PR TITLE
[Merged by Bors] - feat: Subtype.map_{eq,ne}

### DIFF
--- a/Mathlib/Data/Subtype.lean
+++ b/Mathlib/Data/Subtype.lean
@@ -181,11 +181,9 @@ theorem map_involutive {p : α → Prop} {f : α → α} (h : ∀ a, p a → p (
 
 theorem map_ne {p : α → Prop} {q : β → Prop} {f g : α → β}
     (h₁ : ∀ a : α, p a → q (f a)) (h₂ : ∀ a : α, p a → q (g a))
-    (h₃ : ∀ a₁ a₂ : α, p a₁ → p a₂ → f a₁ ≠ g a₂)
     (x y : Subtype p) :
-    map f h₁ x ≠ map g h₂ y := by
-  simp only [map_def, ne_eq, mk.injEq]
-  exact h₃ _ _ x.2 y.2
+    map f h₁ x ≠ map g h₂ y ↔ f x ≠ g y :=
+  .not ⟨congr_arg Subtype.val, (Subtype.ext ·)⟩
 
 instance [HasEquiv α] (p : α → Prop) : HasEquiv (Subtype p) :=
   ⟨fun s t ↦ (s : α) ≈ (t : α)⟩

--- a/Mathlib/Data/Subtype.lean
+++ b/Mathlib/Data/Subtype.lean
@@ -183,7 +183,7 @@ theorem map_eq {p : α → Prop} {q : β → Prop} {f g : α → β}
     (h₁ : ∀ a : α, p a → q (f a)) (h₂ : ∀ a : α, p a → q (g a))
     (x y : Subtype p) :
     map f h₁ x = map g h₂ y ↔ f x = g y :=
-  ⟨congr_arg Subtype.val, (Subtype.ext ·)⟩
+  Subtype.ext_iff
 
 theorem map_ne {p : α → Prop} {q : β → Prop} {f g : α → β}
     (h₁ : ∀ a : α, p a → q (f a)) (h₂ : ∀ a : α, p a → q (g a))

--- a/Mathlib/Data/Subtype.lean
+++ b/Mathlib/Data/Subtype.lean
@@ -179,11 +179,17 @@ theorem map_involutive {p : α → Prop} {f : α → α} (h : ∀ a, p a → p (
     (hf : Involutive f) : Involutive (map f h) :=
   fun x ↦ Subtype.ext (hf x)
 
+theorem map_eq {p : α → Prop} {q : β → Prop} {f g : α → β}
+    (h₁ : ∀ a : α, p a → q (f a)) (h₂ : ∀ a : α, p a → q (g a))
+    (x y : Subtype p) :
+    map f h₁ x = map g h₂ y ↔ f x = g y :=
+  ⟨congr_arg Subtype.val, (Subtype.ext ·)⟩
+
 theorem map_ne {p : α → Prop} {q : β → Prop} {f g : α → β}
     (h₁ : ∀ a : α, p a → q (f a)) (h₂ : ∀ a : α, p a → q (g a))
     (x y : Subtype p) :
     map f h₁ x ≠ map g h₂ y ↔ f x ≠ g y :=
-  .not ⟨congr_arg Subtype.val, (Subtype.ext ·)⟩
+  map_eq h₁ h₂ x y |>.not
 
 instance [HasEquiv α] (p : α → Prop) : HasEquiv (Subtype p) :=
   ⟨fun s t ↦ (s : α) ≈ (t : α)⟩

--- a/Mathlib/Data/Subtype.lean
+++ b/Mathlib/Data/Subtype.lean
@@ -189,7 +189,7 @@ theorem map_ne {p : α → Prop} {q : β → Prop} {f g : α → β}
     (h₁ : ∀ a : α, p a → q (f a)) (h₂ : ∀ a : α, p a → q (g a))
     {x y : Subtype p} :
     map f h₁ x ≠ map g h₂ y ↔ f x ≠ g y :=
-  map_eq h₁ h₂ x y |>.not
+  map_eq h₁ h₂ |>.not
 
 instance [HasEquiv α] (p : α → Prop) : HasEquiv (Subtype p) :=
   ⟨fun s t ↦ (s : α) ≈ (t : α)⟩

--- a/Mathlib/Data/Subtype.lean
+++ b/Mathlib/Data/Subtype.lean
@@ -181,7 +181,7 @@ theorem map_involutive {p : α → Prop} {f : α → α} (h : ∀ a, p a → p (
 
 theorem map_eq {p : α → Prop} {q : β → Prop} {f g : α → β}
     (h₁ : ∀ a : α, p a → q (f a)) (h₂ : ∀ a : α, p a → q (g a))
-    (x y : Subtype p) :
+    {x y : Subtype p} :
     map f h₁ x = map g h₂ y ↔ f x = g y :=
   Subtype.ext_iff
 

--- a/Mathlib/Data/Subtype.lean
+++ b/Mathlib/Data/Subtype.lean
@@ -187,7 +187,7 @@ theorem map_eq {p : α → Prop} {q : β → Prop} {f g : α → β}
 
 theorem map_ne {p : α → Prop} {q : β → Prop} {f g : α → β}
     (h₁ : ∀ a : α, p a → q (f a)) (h₂ : ∀ a : α, p a → q (g a))
-    (x y : Subtype p) :
+    {x y : Subtype p} :
     map f h₁ x ≠ map g h₂ y ↔ f x ≠ g y :=
   map_eq h₁ h₂ x y |>.not
 

--- a/Mathlib/Data/Subtype.lean
+++ b/Mathlib/Data/Subtype.lean
@@ -179,6 +179,14 @@ theorem map_involutive {p : α → Prop} {f : α → α} (h : ∀ a, p a → p (
     (hf : Involutive f) : Involutive (map f h) :=
   fun x ↦ Subtype.ext (hf x)
 
+theorem map_ne {p : α → Prop} {q : β → Prop} {f g : α → β}
+    (h₁ : ∀ a : α, p a → q (f a)) (h₂ : ∀ a : α, p a → q (g a))
+    (h₃ : ∀ a₁ a₂ : α, p a₁ → p a₂ → f a₁ ≠ g a₂)
+    (x y : Subtype p) :
+    map f h₁ x ≠ map g h₂ y := by
+  simp only [map_def, ne_eq, mk.injEq]
+  exact h₃ _ _ x.2 y.2
+
 instance [HasEquiv α] (p : α → Prop) : HasEquiv (Subtype p) :=
   ⟨fun s t ↦ (s : α) ≈ (t : α)⟩
 


### PR DESCRIPTION
Co-authored-by: Salvatore Mercuri <smercuri@ed.ac.uk>
Co-authored-by: Jireh Loreaux <loreaujy@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
