### PR TITLE
feat: Finite.linearOrder, choosing *some* linear order on a finite type

### DIFF
--- a/Mathlib/Data/Fintype/EquivFin.lean
+++ b/Mathlib/Data/Fintype/EquivFin.lean
@@ -393,13 +393,14 @@ theorem card_lt_of_surjective_not_injective [Fintype α] [Fintype β] (f : α �
     have w : Function.Bijective (Function.surjInv h) := ⟨Function.injective_surjInv h, hg⟩
     h' <| h.injective_of_fintype (Equiv.ofBijective _ w).symm
 
+end Fintype
+
 /-- Choose an arbitrary linear order on a `Fintype`: this is not an instance because in most
 situations, choosing a linear order extending a given preorder, or a particular linear order
 is preferred over choosing *any* linear order. -/
-protected noncomputable def linearOrder {α : Type*} [Fintype α] : LinearOrder α :=
+protected noncomputable def Finite.linearOrder {α : Type*} [Finite α] : LinearOrder α :=
+  haveI := Fintype.ofFinite α
   LinearOrder.lift' _ (Fintype.equivFin α).injective
-
-end Fintype
 
 protected theorem Fintype.false [Infinite α] (_h : Fintype α) : False :=
   not_finite α

--- a/Mathlib/Data/Fintype/EquivFin.lean
+++ b/Mathlib/Data/Fintype/EquivFin.lean
@@ -393,6 +393,12 @@ theorem card_lt_of_surjective_not_injective [Fintype α] [Fintype β] (f : α �
     have w : Function.Bijective (Function.surjInv h) := ⟨Function.injective_surjInv h, hg⟩
     h' <| h.injective_of_fintype (Equiv.ofBijective _ w).symm
 
+/-- Choose an arbitrary linear order on a `Fintype`: this is not an instance because in most
+situations, choosing a linear order extending a given preorder, or a particular linear order
+is preferred over choosing *any* linear order. -/
+protected noncomputable def linearOrder {α : Type*} [Fintype α] : LinearOrder α :=
+  LinearOrder.lift' _ (Fintype.equivFin α).injective
+
 end Fintype
 
 protected theorem Fintype.false [Infinite α] (_h : Fintype α) : False :=


### PR DESCRIPTION
This is useful if you want *just some* linear order (but will give wrong results if you expect anything particular about this order). [Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/LocallyFiniteOrderBot.20instance.20for.20Fintype/with/528420842)

---

This PR was mostly inspired by help of Aaron, Yael and Eric - thank you!

Part of the path towards geodesics and the Levi-Civita connection.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
