### PR TITLE
[Merged by Bors] - feat: two lemmas about Lp functions and product spaces

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4316,6 +4316,7 @@ import Mathlib.MeasureTheory.Function.LpSeminorm.Basic
 import Mathlib.MeasureTheory.Function.LpSeminorm.ChebyshevMarkov
 import Mathlib.MeasureTheory.Function.LpSeminorm.CompareExp
 import Mathlib.MeasureTheory.Function.LpSeminorm.Defs
+import Mathlib.MeasureTheory.Function.LpSeminorm.Prod
 import Mathlib.MeasureTheory.Function.LpSeminorm.TriangleInequality
 import Mathlib.MeasureTheory.Function.LpSeminorm.Trim
 import Mathlib.MeasureTheory.Function.LpSpace.Basic

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Prod.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Prod.lean
@@ -1,0 +1,40 @@
+/-
+Copyright (c) 2025 Rémy Degenne. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Rémy Degenne
+-/
+
+import Mathlib.MeasureTheory.Function.LpSeminorm.Basic
+import Mathlib.MeasureTheory.Measure.Prod
+
+/-!
+# ℒp spaces and products
+
+-/
+
+open scoped ENNReal
+
+namespace MeasureTheory
+
+variable {α β ε : Type*} {mα : MeasurableSpace α} {mβ : MeasurableSpace β}
+  [TopologicalSpace ε] [ContinuousENorm ε]
+  {μ : Measure α} {ν : Measure β} {p : ℝ≥0∞}
+
+lemma MemLp.comp_fst {f : α → ε} (hf : MemLp f p μ) (ν : Measure β) [IsFiniteMeasure ν] :
+    MemLp (fun x ↦ f x.1) p (μ.prod ν) := by
+  have hf' : MemLp f p (ν .univ • μ) := hf.smul_measure (by simp)
+  change MemLp (f ∘ Prod.fst) p (μ.prod ν)
+  rw [← memLp_map_measure_iff ?_ (by fun_prop)]
+  · simpa using hf'
+  · simpa using hf'.1
+
+lemma MemLp.comp_snd {f : β → ε} (hf : MemLp f p ν) (μ : Measure α) [IsFiniteMeasure μ]
+    [SFinite ν] :
+    MemLp (fun x ↦ f x.2) p (μ.prod ν) := by
+  have hf' : MemLp f p (μ .univ • ν) := hf.smul_measure (by simp)
+  change MemLp (f ∘ Prod.snd) p (μ.prod ν)
+  rw [← memLp_map_measure_iff ?_ (by fun_prop)]
+  · simpa using hf'
+  · simpa using hf'.1
+
+end MeasureTheory


### PR DESCRIPTION
If `MemLp f p μ` and `ν` is a finite measure on another space, then `MemLp (fun x ↦ f x.1) p (μ.prod ν)`.
Same lemma for `snd` instead of `fst`. That second lemma requires an additional `SFinite` hypothesis, which reflects the difference in hypotheses between `Measure.map_fst_prod` and `Measure.map_snd_prod`.

The lemmas are in a new file because other files in the folder don't import product measures.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
