### PR TITLE
[Merged by Bors] - feat: `Spec(R)` notation for `Spec (CommRingCat.of R)`

### DIFF
--- a/Mathlib/AlgebraicGeometry/AffineScheme.lean
+++ b/Mathlib/AlgebraicGeometry/AffineScheme.lean
@@ -543,7 +543,7 @@ theorem basicOpen :
 
 lemma Spec_basicOpen {R : CommRingCat} (f : R) :
     IsAffineOpen (X := Spec R) (PrimeSpectrum.basicOpen f) :=
-  basicOpen_eq_of_affine f ▸ (isAffineOpen_top (Spec (.of R))).basicOpen _
+  basicOpen_eq_of_affine f ▸ (isAffineOpen_top Spec(R)).basicOpen _
 
 instance [IsAffine X] (r : Γ(X, ⊤)) : IsAffine (X.basicOpen r) :=
   (isAffineOpen_top X).basicOpen _
@@ -850,7 +850,7 @@ def SpecMapRestrictBasicOpenIso {R S : CommRingCat} (f : R ⟶ S) (r : R) :
   letI e₂ : Localization.Away (f.hom r) ≃ₐ[S] Γ(Spec S, basicOpen (f.hom r)) :=
     IsLocalization.algEquiv (Submonoid.powers (f.hom r)) _ _
   refine Arrow.isoMk ?_ ?_ ?_
-  · exact (Spec (.of S)).isoOfEq (comap_basicOpen _ _) ≪≫
+  · exact Spec(S).isoOfEq (comap_basicOpen _ _) ≪≫
       (IsAffineOpen.Spec_basicOpen (f.hom r)).isoSpec ≪≫ Scheme.Spec.mapIso e₂.toCommRingCatIso.op
   · exact (IsAffineOpen.Spec_basicOpen r).isoSpec ≪≫ Scheme.Spec.mapIso e₁.toCommRingCatIso.op
   · have := AlgebraicGeometry.IsOpenImmersion.of_isLocalization
@@ -1092,7 +1092,7 @@ variable {X : Scheme.{u}} {A : CommRingCat}
 this is the lift to `X ⟶ Spec (A ⧸ I)`. -/
 def Scheme.Hom.liftQuotient (f : X.Hom (Spec A)) (I : Ideal A)
     (hI : I ≤ RingHom.ker ((Scheme.ΓSpecIso A).inv ≫ f.appTop).hom) :
-    X ⟶ Spec (.of (A ⧸ I)) :=
+    X ⟶ Spec(A ⧸ I) :=
   X.toSpecΓ ≫ Spec.map (CommRingCat.ofHom
     (Ideal.Quotient.lift _ ((Scheme.ΓSpecIso _).inv ≫ f.appTop).hom hI))
 

--- a/Mathlib/AlgebraicGeometry/AffineSpace.lean
+++ b/Mathlib/AlgebraicGeometry/AffineSpace.lean
@@ -174,7 +174,7 @@ Also see `AffineSpace.SpecIso`.
 -/
 @[simps -isSimp hom inv]
 def isoOfIsAffine [IsAffine S] :
-    𝔸(n; S) ≅ Spec (.of (MvPolynomial n Γ(S, ⊤))) where
+    𝔸(n; S) ≅ Spec(MvPolynomial n Γ(S, ⊤)) where
       hom := 𝔸(n; S).toSpecΓ ≫ Spec.map (CommRingCat.ofHom
         (eval₂Hom ((𝔸(n; S) ↘ S).appTop).hom (coord S)))
       inv := homOfVector (Spec.map (CommRingCat.ofHom C) ≫ S.isoSpec.inv)
@@ -237,7 +237,7 @@ instance [IsAffine S] : IsAffine 𝔸(n; S) := .of_isIso (isoOfIsAffine n S).hom
 variable (n) in
 /-- The affine space over an affine base is isomorphic to the spectrum of the polynomial ring. -/
 def SpecIso (R : CommRingCat.{max u v}) :
-    𝔸(n; Spec R) ≅ Spec (.of (MvPolynomial n R)) :=
+    𝔸(n; Spec R) ≅ Spec(MvPolynomial n R) :=
   isoOfIsAffine _ _ ≪≫ Scheme.Spec.mapIso (MvPolynomial.mapEquiv _
     (Scheme.ΓSpecIso R).symm.commRingCatIsoToRingEquiv).toCommRingCatIso.op
 

--- a/Mathlib/AlgebraicGeometry/Cover/Open.lean
+++ b/Mathlib/AlgebraicGeometry/Cover/Open.lean
@@ -253,7 +253,7 @@ section deprecated
 /-- The basic open sets form an affine open cover of `Spec R`. -/
 def affineBasisCoverOfAffine (R : CommRingCat.{u}) : OpenCover (Spec R) where
   J := R
-  obj r := Spec (CommRingCat.of <| Localization.Away r)
+  obj r := Spec(Localization.Away r)
   map r := Spec.map (CommRingCat.ofHom (algebraMap R (Localization.Away r)))
   f _ := 1
   covers r := by

--- a/Mathlib/AlgebraicGeometry/IdealSheaf/Subscheme.lean
+++ b/Mathlib/AlgebraicGeometry/IdealSheaf/Subscheme.lean
@@ -38,7 +38,7 @@ variable (I : IdealSheafData X)
 
 /-- `Spec (𝒪ₓ(U)/I(U))`, the object to be glued into the closed subscheme. -/
 def glueDataObj (U : X.affineOpens) : Scheme :=
-  Spec (.of (Γ(X, U) ⧸ I.ideal U))
+  Spec(Γ(X, U) ⧸ I.ideal U)
 
 /-- `Spec (𝒪ₓ(U)/I(U)) ⟶ Spec (𝒪ₓ(U)) = U`, the closed immersion into `U`. -/
 noncomputable

--- a/Mathlib/AlgebraicGeometry/Limits.lean
+++ b/Mathlib/AlgebraicGeometry/Limits.lean
@@ -36,12 +36,12 @@ attribute [local instance] Opposite.small
 namespace AlgebraicGeometry
 
 /-- `Spec ℤ` is the terminal object in the category of schemes. -/
-noncomputable def specZIsTerminal : IsTerminal (Spec (CommRingCat.of ℤ)) :=
+noncomputable def specZIsTerminal : IsTerminal Spec(ℤ) :=
   @IsTerminal.isTerminalObj _ _ _ _ Scheme.Spec _ inferInstance
     (terminalOpOfInitial CommRingCat.zIsInitial)
 
 /-- `Spec ℤ` is the terminal object in the category of schemes. -/
-noncomputable def specULiftZIsTerminal : IsTerminal (Spec (.of (ULift.{u} ℤ))) :=
+noncomputable def specULiftZIsTerminal : IsTerminal Spec(ULift.{u} ℤ) :=
   @IsTerminal.isTerminalObj _ _ _ _ Scheme.Spec _ inferInstance
     (terminalOpOfInitial CommRingCat.isInitial)
 
@@ -90,7 +90,7 @@ theorem emptyIsInitial_to : emptyIsInitial.to = Scheme.emptyTo :=
 instance : IsEmpty (∅ : Scheme.{u}) :=
   show IsEmpty PEmpty by infer_instance
 
-instance spec_punit_isEmpty : IsEmpty (Spec (CommRingCat.of PUnit.{u+1})) :=
+instance spec_punit_isEmpty : IsEmpty Spec(PUnit.{u+1}) :=
   inferInstanceAs <| IsEmpty (PrimeSpectrum PUnit)
 
 instance (priority := 100) isOpenImmersion_of_isEmpty {X Y : Scheme} (f : X ⟶ Y)
@@ -112,11 +112,11 @@ noncomputable def isInitialOfIsEmpty {X : Scheme} [IsEmpty X] : IsInitial X :=
   emptyIsInitial.ofIso (asIso <| emptyIsInitial.to _)
 
 /-- `Spec 0` is the initial object in the category of schemes. -/
-noncomputable def specPunitIsInitial : IsInitial (Spec (.of PUnit.{u+1})) :=
+noncomputable def specPunitIsInitial : IsInitial Spec(PUnit.{u+1}) :=
   emptyIsInitial.ofIso (asIso <| emptyIsInitial.to _)
 
 instance (priority := 100) isAffine_of_isEmpty {X : Scheme} [IsEmpty X] : IsAffine X :=
-  .of_isIso (inv (emptyIsInitial.to X) ≫ emptyIsInitial.to (Spec (.of PUnit)))
+  .of_isIso (inv (emptyIsInitial.to X) ≫ emptyIsInitial.to Spec(PUnit))
 
 instance : HasInitial Scheme.{u} :=
   hasInitial_of_unique ∅
@@ -367,7 +367,7 @@ variable (R S : Type u) [CommRing R] [CommRing S]
 /-- The map `Spec R ⨿ Spec S ⟶ Spec (R × S)`.
 This is an isomorphism as witnessed by an `IsIso` instance provided below. -/
 noncomputable
-def coprodSpec : Spec (.of R) ⨿ Spec (.of S) ⟶ Spec (.of (R × S)) :=
+def coprodSpec : Spec(R) ⨿ Spec(S) ⟶ Spec(R × S) :=
   coprod.desc (Spec.map (CommRingCat.ofHom <| RingHom.fst _ _))
     (Spec.map (CommRingCat.ofHom <| RingHom.snd _ _))
 
@@ -393,8 +393,8 @@ lemma coprodSpec_coprodMk (x) :
     ext; simp [Ideal.prod, CommRingCat.ofHom]
 
 lemma coprodSpec_apply (x) :
-    (coprodSpec R S).base x = (PrimeSpectrum.primeSpectrumProd R S).symm
-      ((coprodMk (Spec (.of R)) (Spec (.of S))).symm x) := by
+    (coprodSpec R S).base x =
+      (PrimeSpectrum.primeSpectrumProd R S).symm ((coprodMk Spec(R) Spec(S)).symm x) := by
   rw [← coprodSpec_coprodMk, Homeomorph.apply_symm_apply]
 
 lemma isIso_stalkMap_coprodSpec (x) :
@@ -420,8 +420,8 @@ lemma isIso_stalkMap_coprodSpec (x) :
 instance : IsIso (coprodSpec R S) := by
   rw [isIso_iff_stalk_iso]
   refine ⟨?_, isIso_stalkMap_coprodSpec R S⟩
-  convert_to IsIso (TopCat.isoOfHomeo (X := Spec (.of (R × S))) <|
-    PrimeSpectrum.primeSpectrumProdHomeo.trans (coprodMk (Spec (.of R)) (Spec (.of S)))).inv
+  convert_to IsIso (TopCat.isoOfHomeo (X := Spec(R × S)) <|
+    PrimeSpectrum.primeSpectrumProdHomeo.trans (coprodMk Spec(R) Spec(S))).inv
   · ext x; exact coprodSpec_apply R S x
   · infer_instance
 
@@ -464,7 +464,7 @@ instance {J : Type*} [Finite J] : PreservesColimitsOfShape (Discrete J) Scheme.S
 /-- The canonical map `∐ Spec Rᵢ ⟶ Spec (Π Rᵢ)`.
 This is an isomorphism when the product is finite. -/
 noncomputable
-def sigmaSpec (R : ι → CommRingCat) : (∐ fun i ↦ Spec (R i)) ⟶ Spec (.of (Π i, R i)) :=
+def sigmaSpec (R : ι → CommRingCat) : (∐ fun i ↦ Spec (R i)) ⟶ Spec(Π i, R i) :=
   Sigma.desc (fun i ↦ Spec.map (CommRingCat.ofHom (Pi.evalRingHom _ i)))
 
 @[reassoc (attr := simp)]

--- a/Mathlib/AlgebraicGeometry/Modules/Tilde.lean
+++ b/Mathlib/AlgebraicGeometry/Modules/Tilde.lean
@@ -148,20 +148,20 @@ noncomputable instance (U : (Opens (PrimeSpectrum.Top R))ᵒᵖ) :
   inferInstanceAs <| AddCommGroup (Tilde.sectionsSubmodule M U)
 
 noncomputable instance (U : (Opens (PrimeSpectrum.Top R))ᵒᵖ) :
-    Module ((Spec (.of R)).ringCatSheaf.1.obj U) (M.tildeInType.1.obj U) :=
+    Module (Spec(R).ringCatSheaf.1.obj U) (M.tildeInType.1.obj U) :=
   inferInstanceAs <| Module _ (Tilde.sectionsSubmodule M U)
 
 /--
 `M^~` as a sheaf of `𝒪_{Spec R}`-modules
 -/
-noncomputable def tilde : (Spec (CommRingCat.of R)).Modules where
+noncomputable def tilde : Spec(R).Modules where
   val :=
     { obj := fun U ↦ ModuleCat.of _ (M.tildeInType.val.obj U)
       map := fun {U V} i ↦ ofHom
         -- TODO: after https://github.com/leanprover-community/mathlib4/pull/19511 we need to hint `(Y := ...)`
         -- This suggests `restrictScalars` needs to be redesigned.
-        (Y := (restrictScalars ((Spec (CommRingCat.of R)).ringCatSheaf.val.map i).hom).obj
-          (of ((Spec (CommRingCat.of R)).ringCatSheaf.val.obj V) (M.tildeInType.val.obj V)))
+        (Y := (restrictScalars (Spec(R).ringCatSheaf.val.map i).hom).obj
+          (of (Spec(R).ringCatSheaf.val.obj V) (M.tildeInType.val.obj V)))
         { toFun := M.tildeInType.val.map i
           map_smul' := by intros; rfl
           map_add' := by intros; rfl } }

--- a/Mathlib/AlgebraicGeometry/Morphisms/ClosedImmersion.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/ClosedImmersion.lean
@@ -305,7 +305,7 @@ theorem isAffine_surjective_of_isAffine [IsClosedImmersion f] :
     ((ConcreteCategory.bijective_of_isIso _).2.comp Ideal.Quotient.mk_surjective)
 
 lemma Spec_iff {R : CommRingCat} {f : X ⟶ Spec R} :
-    IsClosedImmersion f ↔ ∃ I : Ideal R, ∃ e : X ≅ Spec (.of <| R ⧸ I),
+    IsClosedImmersion f ↔ ∃ I : Ideal R, ∃ e : X ≅ Spec(R ⧸ I),
       f = e.hom ≫ Spec.map (CommRingCat.ofHom (Ideal.Quotient.mk I)) := by
   constructor
   · intro H

--- a/Mathlib/AlgebraicGeometry/Morphisms/FiniteType.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/FiniteType.lean
@@ -68,7 +68,7 @@ instance locallyOfFiniteType_isStableUnderBaseChange :
     MorphismProperty.IsStableUnderBaseChange @LocallyOfFiniteType :=
   HasRingHomProperty.isStableUnderBaseChange RingHom.finiteType_isStableUnderBaseChange
 
-instance {R} [CommRing R] [IsJacobsonRing R] : JacobsonSpace (Spec (.of R)) :=
+instance {R} [CommRing R] [IsJacobsonRing R] : JacobsonSpace Spec(R) :=
   inferInstanceAs (JacobsonSpace (PrimeSpectrum R))
 
 instance {R : CommRingCat} [IsJacobsonRing R] : JacobsonSpace (Spec R) :=

--- a/Mathlib/AlgebraicGeometry/Morphisms/Proper.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Proper.lean
@@ -119,7 +119,7 @@ theorem isIntegral_appTop_of_universallyClosed (f : X ⟶ Y) [UniversallyClosed 
 
 /-- If `X` is an integral scheme that is universally closed over `Spec K`,
 then `Γ(X, ⊤)` is a field. -/
-theorem isField_of_universallyClosed (f : X ⟶ Spec (.of K)) [IsIntegral X] [UniversallyClosed f] :
+theorem isField_of_universallyClosed (f : X ⟶ Spec(K)) [IsIntegral X] [UniversallyClosed f] :
     IsField Γ(X, ⊤) := by
   let F := (Scheme.ΓSpecIso _).inv ≫ f.appTop
   have : F.hom.IsIntegral := by
@@ -130,7 +130,7 @@ theorem isField_of_universallyClosed (f : X ⟶ Spec (.of K)) [IsIntegral X] [Un
 
 /-- If `X` is an integral scheme that is universally closed and of finite type over `Spec K`,
 then `Γ(X, ⊤)` is a finite field extension over `K`. -/
-theorem finite_appTop_of_universallyClosed (f : X ⟶ Spec (.of K))
+theorem finite_appTop_of_universallyClosed (f : X ⟶ Spec(K))
     [IsIntegral X] [UniversallyClosed f] [LocallyOfFiniteType f] :
     f.appTop.hom.Finite := by
   have x : X := Nonempty.some inferInstance

--- a/Mathlib/AlgebraicGeometry/Morphisms/UniversallyClosed.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/UniversallyClosed.lean
@@ -100,12 +100,12 @@ instance universallyClosed_isLocalAtTarget : IsLocalAtTarget @UniversallyClosed 
 open Scheme.Pullback _root_.PrimeSpectrum MvPolynomial in
 /-- If `X` is universally closed over a field, then `X` is quasi-compact. -/
 lemma compactSpace_of_universallyClosed
-    {K} [Field K] (f : X ⟶ Spec (.of K)) [UniversallyClosed f] : CompactSpace X := by
+    {K} [Field K] (f : X ⟶ Spec(K)) [UniversallyClosed f] : CompactSpace X := by
   classical
   let 𝒰 : X.OpenCover := X.affineCover
   let U (i : 𝒰.J) : X.Opens := (𝒰.map i).opensRange
-  let T : Scheme := Spec (.of <| MvPolynomial 𝒰.J K)
-  let q : T ⟶ Spec (.of K) := Spec.map (CommRingCat.ofHom MvPolynomial.C)
+  let T : Scheme := Spec(MvPolynomial 𝒰.J K)
+  let q : T ⟶ Spec(K) := Spec.map (CommRingCat.ofHom MvPolynomial.C)
   let Ti (i : 𝒰.J) : T.Opens := basicOpen (MvPolynomial.X i)
   let fT : pullback f q ⟶ T := pullback.snd f q
   let p : pullback f q ⟶ X := pullback.fst f q

--- a/Mathlib/AlgebraicGeometry/Noetherian.lean
+++ b/Mathlib/AlgebraicGeometry/Noetherian.lean
@@ -310,7 +310,7 @@ instance {R : CommRingCat} [IsNoetherianRing R] :
     IsNoetherian (Spec R) where
 
 instance {R} [CommRing R] [IsNoetherianRing R] :
-    IsNoetherian (Spec (.of R)) := by
+    IsNoetherian Spec(R) := by
   suffices IsNoetherianRing (CommRingCat.of R) by infer_instance
   assumption
 

--- a/Mathlib/AlgebraicGeometry/OpenImmersion.lean
+++ b/Mathlib/AlgebraicGeometry/OpenImmersion.lean
@@ -261,7 +261,7 @@ theorem exists_affine_mem_range_and_range_subset
     show ((e.hom ≫ e.inv).base ⟨x, hxV⟩).1 ∈ U from e.hom_inv_id ▸ hxU
   obtain ⟨_, ⟨_, ⟨r : R, rfl⟩, rfl⟩, hr, hr'⟩ :=
     PrimeSpectrum.isBasis_basic_opens.exists_subset_of_mem_open this (Opens.is_open' _)
-  let f : Spec (CommRingCat.of (Localization.Away r)) ⟶ X :=
+  let f : Spec(Localization.Away r) ⟶ X :=
     Spec.map (CommRingCat.ofHom (algebraMap R (Localization.Away r))) ≫ ⟨e.inv ≫ X.ofRestrict _⟩
   refine ⟨.of (Localization.Away r), f, inferInstance, ?_⟩
   rw [Scheme.comp_base, TopCat.coe_comp, Set.range_comp]

--- a/Mathlib/AlgebraicGeometry/PointsPi.lean
+++ b/Mathlib/AlgebraicGeometry/PointsPi.lean
@@ -35,9 +35,9 @@ lemma Ideal.span_eq_top_of_span_image_evalRingHom
   simpa [Finsupp.sum_fintype] using hf i
 
 lemma eq_top_of_sigmaSpec_subset_of_isCompact
-    (U : (Spec (.of (Π i, R i))).Opens) (V : Set (Spec (.of (Π i, R i))))
+    (U : Spec(Π i, R i).Opens) (V : Set Spec(Π i, R i))
     (hV : ↑(sigmaSpec R).opensRange ⊆ V)
-    (hV' : IsCompact (X := Spec (.of (Π i, R i))) V)
+    (hV' : IsCompact (X := Spec(Π i, R i)) V)
     (hVU : V ⊆ U) : U = ⊤ := by
   obtain ⟨s, hs⟩ := (PrimeSpectrum.isOpen_iff _).mp U.2
   obtain ⟨t, hts, ht, ht'⟩ : ∃ t ⊆ s, t.Finite ∧ V ⊆ ⋃ i ∈ t, (basicOpen i).1 := by
@@ -59,7 +59,7 @@ lemma eq_top_of_sigmaSpec_subset_of_isCompact
   simpa [← zeroLocus_span s, zeroLocus_empty_iff_eq_top.mpr this] using hs
 
 lemma eq_bot_of_comp_quotientMk_eq_sigmaSpec (I : Ideal (Π i, R i))
-    (f : (∐ fun i ↦ Spec (R i)) ⟶ Spec (.of ((Π i, R i) ⧸ I)))
+    (f : (∐ fun i ↦ Spec (R i)) ⟶ Spec((Π i, R i) ⧸ I))
     (hf : f ≫ Spec.map (CommRingCat.ofHom (Ideal.Quotient.mk I)) = sigmaSpec R) :
     I = ⊥ := by
   refine le_bot_iff.mp fun x hx ↦ ?_
@@ -70,7 +70,7 @@ lemma eq_bot_of_comp_quotientMk_eq_sigmaSpec (I : Ideal (Π i, R i))
 /-- If `V` is a locally closed subscheme of `Spec (Π Rᵢ)` containing `∐ Spec Rᵢ`, then
 `V = Spec (Π Rᵢ)`. -/
 lemma isIso_of_comp_eq_sigmaSpec {V : Scheme}
-    (f : (∐ fun i ↦ Spec (R i)) ⟶ V) (g : V ⟶ Spec (.of (Π i, R i)))
+    (f : (∐ fun i ↦ Spec (R i)) ⟶ V) (g : V ⟶ Spec(Π i, R i))
     [IsImmersion g] [CompactSpace V]
     (hU' : f ≫ g = sigmaSpec R) : IsIso g := by
   have : g.coborderRange = ⊤ := by
@@ -92,7 +92,7 @@ variable (X : Scheme)
 This is injective if `X` is quasi-separated, surjective if `X` is affine,
 or if `X` is compact and each `Rᵢ` is local. -/
 noncomputable
-def pointsPi : (Spec (.of (Π i, R i)) ⟶ X) → Π i, Spec (R i) ⟶ X :=
+def pointsPi : (Spec(Π i, R i) ⟶ X) → Π i, Spec (R i) ⟶ X :=
   fun f i ↦ Spec.map (CommRingCat.ofHom (Pi.evalRingHom (R ·) i)) ≫ f
 
 lemma pointsPi_injective [QuasiSeparatedSpace X] : Function.Injective (pointsPi R X) := by

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Basic.lean
@@ -133,7 +133,7 @@ def awayToSection : CommRingCat.of (Away 𝒜 f) ⟶ Γ(Proj 𝒜, basicOpen �
 /-- The canonical map `Proj A |_ D₊(f) ⟶ Spec (A_f)₀`.
 This is an isomorphism when `f` is homogeneous of positive degree. See `basicOpenIsoSpec` below. -/
 noncomputable
-def basicOpenToSpec : (basicOpen 𝒜 f).toScheme ⟶ Spec (.of (Away 𝒜 f)) :=
+def basicOpenToSpec : (basicOpen 𝒜 f).toScheme ⟶ Spec(Away 𝒜 f) :=
   (basicOpen 𝒜 f).toSpecΓ ≫ Spec.map (awayToSection 𝒜 f)
 
 lemma basicOpenToSpec_app_top :
@@ -147,7 +147,7 @@ lemma basicOpenToSpec_app_top :
 
 /-- The structure map `Proj A ⟶ Spec A₀`. -/
 noncomputable
-def toSpecZero : Proj 𝒜 ⟶ Spec (.of (𝒜 0)) :=
+def toSpecZero : Proj 𝒜 ⟶ Spec(𝒜 0) :=
   (Scheme.topIso _).inv ≫ (Scheme.isoOfEq _ (basicOpen_one _)).inv ≫
     basicOpenToSpec 𝒜 1 ≫ Spec.map (CommRingCat.ofHom (fromZeroRingHom 𝒜 _))
 
@@ -157,7 +157,7 @@ variable {m} (f_deg : f ∈ 𝒜 m) (hm : 0 < m)
 when `f` is homogeneous of positive degree. -/
 @[simps! -isSimp hom]
 noncomputable
-def basicOpenIsoSpec : (basicOpen 𝒜 f).toScheme ≅ Spec (.of (Away 𝒜 f)) :=
+def basicOpenIsoSpec : (basicOpen 𝒜 f).toScheme ≅ Spec(Away 𝒜 f) :=
   have : IsIso (basicOpenToSpec 𝒜 f) := by
     apply (isIso_iff_of_reflects_iso _ Scheme.forgetToLocallyRingedSpace).mp ?_
     convert ProjectiveSpectrum.Proj.isIso_toSpec 𝒜 f f_deg hm using 1
@@ -181,7 +181,7 @@ def basicOpenIsoAway : CommRingCat.of (Away 𝒜 f) ≅ Γ(Proj 𝒜, basicOpen 
 
 /-- The open immersion `Spec (A_f)₀ ⟶ Proj A`. -/
 noncomputable
-def awayι : Spec (.of (Away 𝒜 f)) ⟶ Proj 𝒜 :=
+def awayι : Spec(Away 𝒜 f) ⟶ Proj 𝒜 :=
   (basicOpenIsoSpec 𝒜 f f_deg hm).inv ≫ (Proj.basicOpen 𝒜 f).ι
 
 @[reassoc]
@@ -252,8 +252,7 @@ lemma SpecMap_awayMap_awayι :
 /-- The isomorphism `D₊(f) ×[Proj 𝒜] D₊(g) ≅ D₊(fg)`. -/
 noncomputable
 def pullbackAwayιIso :
-    Limits.pullback (awayι 𝒜 f f_deg hm) (awayι 𝒜 g g_deg hm') ≅
-      Spec (CommRingCat.of (Away 𝒜 x)) :=
+    Limits.pullback (awayι 𝒜 f f_deg hm) (awayι 𝒜 g g_deg hm') ≅ Spec(Away 𝒜 x) :=
     IsOpenImmersion.isoOfRangeEq (Limits.pullback.fst _ _ ≫ awayι 𝒜 f f_deg hm)
       (awayι 𝒜 x (hx ▸ SetLike.mul_mem_graded f_deg g_deg) (hm.trans_le (m.le_add_right m'))) <| by
   rw [IsOpenImmersion.range_pullback_to_base_of_left]

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Proper.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Proper.lean
@@ -82,12 +82,12 @@ instance isSeparated : IsSeparated (toSpecZero 𝒜) := by
     (f := (pullbackDiagonalMapIdIso ..).inv) _).mp ?_
   let e₁ : pullback ((affineOpenCover 𝒜).map i ≫ toSpecZero 𝒜)
         ((affineOpenCover 𝒜).map j ≫ toSpecZero 𝒜) ≅
-        Spec (.of <| TensorProduct (𝒜 0) (Away 𝒜 i.2) (Away 𝒜 j.2)) := by
+        Spec(TensorProduct (𝒜 0) (Away 𝒜 i.2) (Away 𝒜 j.2)) := by
     refine pullback.congrHom ?_ ?_ ≪≫ pullbackSpecIso (𝒜 0) (Away 𝒜 i.2) (Away 𝒜 j.2)
     · simp [affineOpenCover, openCoverOfISupEqTop, awayι_toSpecZero]; rfl
     · simp [affineOpenCover, openCoverOfISupEqTop, awayι_toSpecZero]; rfl
   let e₂ : pullback ((affineOpenCover 𝒜).map i) ((affineOpenCover 𝒜).map j) ≅
-        Spec (.of <| (Away 𝒜 (i.2 * j.2))) :=
+        Spec(Away 𝒜 (i.2 * j.2)) :=
     pullbackAwayιIso 𝒜 _ _ _ _ rfl
   rw [← MorphismProperty.cancel_right_of_respectsIso (P := @IsClosedImmersion) _ e₁.hom,
     ← MorphismProperty.cancel_left_of_respectsIso (P := @IsClosedImmersion) e₂.inv]
@@ -316,7 +316,7 @@ lemma valuativeCriterion_existence [Algebra.FiniteType (𝒜 0) A] :
     rintro _ ⟨x, rfl⟩
     obtain rfl := Subsingleton.elim x (IsLocalRing.closedPoint K)
     exact hi
-  let φ : Spec (.of K) ⟶ _ := IsOpenImmersion.lift _ _ this
+  let φ : Spec(K) ⟶ _ := IsOpenImmersion.lift _ _ this
   have H : Spec.preimage i₂ ≫ CommRingCat.ofHom (algebraMap O K) =
       CommRingCat.ofHom (fromZeroRingHom 𝒜 _) ≫ Spec.preimage φ := by
     apply Spec.map_injective

--- a/Mathlib/AlgebraicGeometry/Pullbacks.lean
+++ b/Mathlib/AlgebraicGeometry/Pullbacks.lean
@@ -624,7 +624,7 @@ over a scheme `Spec R` and the `Spec` of the tensor product `S ⊗[R] T`. -/
 noncomputable
 def pullbackSpecIso :
     pullback (Spec.map (CommRingCat.ofHom (algebraMap R S)))
-      (Spec.map (CommRingCat.ofHom (algebraMap R T))) ≅ Spec (.of <| S ⊗[R] T) :=
+      (Spec.map (CommRingCat.ofHom (algebraMap R T))) ≅ Spec(S ⊗[R] T) :=
   letI H := IsLimit.equivIsoLimit (PullbackCone.eta _)
     (PushoutCocone.isColimitEquivIsLimitOp _ (CommRingCat.pushoutCoconeIsColimit R S T))
   limit.isoLimitCone ⟨_, isLimitPullbackConeMapOfIsLimit Scheme.Spec _ H⟩

--- a/Mathlib/AlgebraicGeometry/ResidueField.lean
+++ b/Mathlib/AlgebraicGeometry/ResidueField.lean
@@ -44,8 +44,7 @@ def residueField (x : X) : CommRingCat :=
 instance (x : X) : Field (X.residueField x) :=
   inferInstanceAs <| Field (IsLocalRing.ResidueField (X.presheaf.stalk x))
 
-instance (x : X) : Unique (Spec (X.residueField x)) :=
-  inferInstanceAs (Unique (Spec (CommRingCat.of _)))
+instance (x : X) : Unique (Spec (X.residueField x)) := inferInstanceAs (Unique Spec(_))
 
 /-- The residue map from the stalk to the residue field. -/
 def residue (X : Scheme.{u}) (x) : X.presheaf.stalk x ⟶ X.residueField x :=
@@ -271,7 +270,7 @@ lemma descResidueField_fromSpecResidueField {K : Type*} [Field K] (X : Scheme) {
   simp [fromSpecResidueField, ← Spec.map_comp_assoc]
 
 lemma descResidueField_stalkClosedPointTo_fromSpecResidueField
-    (K : Type u) [Field K] (X : Scheme.{u}) (f : Spec (.of K) ⟶ X) :
+    (K : Type u) [Field K] (X : Scheme.{u}) (f : Spec(K) ⟶ X) :
     Spec.map (@descResidueField (CommRingCat.of K) _ X _ (Scheme.stalkClosedPointTo f)
         _) ≫
       X.fromSpecResidueField (f.base (closedPoint K)) = f := by
@@ -295,7 +294,7 @@ lemma SpecToEquivOfField_eq_iff {K : Type*} [Field K] {X : Scheme}
 /-- For a field `K` and a scheme `X`, the morphisms `Spec K ⟶ X` bijectively correspond
 to pairs of points `x` of `X` and embeddings `κ(x) ⟶ K`. -/
 def SpecToEquivOfField (K : Type u) [Field K] (X : Scheme.{u}) :
-    (Spec (.of K) ⟶ X) ≃ Σ x, X.residueField x ⟶ .of K where
+    (Spec(K) ⟶ X) ≃ Σ x, X.residueField x ⟶ .of K where
   toFun f :=
     ⟨_, X.descResidueField (Scheme.stalkClosedPointTo f)⟩
   invFun xf := Spec.map xf.2 ≫ X.fromSpecResidueField xf.1

--- a/Mathlib/AlgebraicGeometry/Restrict.lean
+++ b/Mathlib/AlgebraicGeometry/Restrict.lean
@@ -431,8 +431,7 @@ lemma Scheme.Opens.isoOfLE_inv_ι {X : Scheme.{u}} {U V : X.Opens}
 
 /-- For `f : R`, `D(f)` as an open subscheme of `Spec R` is isomorphic to `Spec R[1/f]`. -/
 def basicOpenIsoSpecAway {R : CommRingCat.{u}} (f : R) :
-    Scheme.Opens.toScheme (X := Spec R) (PrimeSpectrum.basicOpen f) ≅
-      Spec (CommRingCat.of (Localization.Away f)) :=
+    Scheme.Opens.toScheme (X := Spec R) (PrimeSpectrum.basicOpen f) ≅ Spec(Localization.Away f) :=
   IsOpenImmersion.isoOfRangeEq (Scheme.Opens.ι _) (Spec.map (CommRingCat.ofHom (algebraMap _ _)))
     (by
       simp only [Scheme.Opens.range_ι]

--- a/Mathlib/AlgebraicGeometry/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/Scheme.lean
@@ -16,6 +16,14 @@ and the structure sheaf of `Spec R`, for some commutative ring `R`.
 
 A morphism of schemes is just a morphism of the underlying locally ringed spaces.
 
+## Notation
+
+`Spec R` typechecks only for `R : CommRingCat`. It happens quite often that we want to take Spec of
+an unbundled ring, and this can be spelled `Spec (CommRingCat.of R)`, or `Spec (.of R)` using
+anonymous dot notation. This is such a common situation that we have dedicated notation: `Spec(R)`
+
+Note that one can write `Spec(R)` for `R : CommRingCat`, but one shouldn't: This is `Spec (.of ↑R)`
+under the hood, which simplifies to `Spec R`.
 -/
 
 -- Explicit universe annotations were used in this file to improve performance https://github.com/leanprover-community/mathlib4/issues/12737

--- a/Mathlib/AlgebraicGeometry/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/Scheme.lean
@@ -413,6 +413,12 @@ def Spec (R : CommRingCat) : Scheme where
   local_affine _ := ⟨⟨⊤, trivial⟩, R, ⟨(Spec.toLocallyRingedSpace.obj (op R)).restrictTopIso⟩⟩
   toLocallyRingedSpace := Spec.locallyRingedSpaceObj R
 
+/-- The spectrum of an unbundled ring as a scheme.
+
+WARNING: If `R` is already an element of `CommRingCat`, you should use `Spec R` instead of
+`Spec(R)`, which is secretly `Spec(↑R)`. -/
+scoped notation3 "Spec("R")" => Spec <| .of R
+
 theorem Spec_toLocallyRingedSpace (R : CommRingCat) :
     (Spec R).toLocallyRingedSpace = Spec.locallyRingedSpaceObj R :=
   rfl
@@ -555,11 +561,11 @@ lemma toOpen_eq (U) :
     (by exact StructureSheaf.toOpen R U) =
     (ΓSpecIso R).inv ≫ (Spec R).presheaf.map (homOfLE le_top).op := rfl
 
-instance {K} [Field K] : Unique (Spec (.of K)) :=
+instance {K} [Field K] : Unique Spec(K) :=
   inferInstanceAs <| Unique (PrimeSpectrum K)
 
 @[simp]
-lemma default_asIdeal {K} [Field K] : (default : Spec (.of K)).asIdeal = ⊥ := rfl
+lemma default_asIdeal {K} [Field K] : (default : Spec(K)).asIdeal = ⊥ := rfl
 
 section BasicOpen
 

--- a/Mathlib/AlgebraicGeometry/Stalk.lean
+++ b/Mathlib/AlgebraicGeometry/Stalk.lean
@@ -270,7 +270,7 @@ instance isLocalHom_stalkClosedPointTo :
 Useful for use in combination with `CommRingCat.of K` for a field `K`.
 -/
 instance isLocalHom_stalkClosedPointTo' {R : Type u} [CommRing R] [IsLocalRing R]
-    (f : Spec (.of R) ⟶ X) :
+    (f : Spec(R) ⟶ X) :
     IsLocalHom (stalkClosedPointTo f).hom :=
   isLocalHom_stalkClosedPointTo f
 

--- a/Mathlib/AlgebraicGeometry/ValuativeCriterion.lean
+++ b/Mathlib/AlgebraicGeometry/ValuativeCriterion.lean
@@ -58,9 +58,9 @@ structure ValuativeCommSq {X Y : Scheme.{u}} (f : X ⟶ Y) where
   [algebra : Algebra R K]
   [isFractionRing : IsFractionRing R K]
   /-- The top map in a valuative commutative map. -/
-  (i₁ : Spec (.of K) ⟶ X)
+  (i₁ : Spec(K) ⟶ X)
   /-- The bottom map in a valuative commutative map. -/
-  (i₂ : Spec (.of R) ⟶ Y)
+  (i₂ : Spec(R) ⟶ Y)
   (commSq : CommSq i₁ (Spec.map (CommRingCat.ofHom (algebraMap R K))) f i₂)
 
 namespace ValuativeCommSq
@@ -145,9 +145,9 @@ lemma of_specializingMap (H : (topologically @SpecializingMap).universally f) :
   replace H := H (pullback.snd i₂ f) i₂ (pullback.fst i₂ f) (.of_hasPullback i₂ f)
   let lft := pullback.lift (Spec.map (CommRingCat.ofHom (algebraMap R K))) i₁ w.symm
   obtain ⟨x, h₁, h₂⟩ := @H (lft.base (closedPoint _)) _ (specializes_closedPoint (R := R) _)
-  let e : CommRingCat.of R ≅ (Spec (.of R)).presheaf.stalk ((pullback.fst i₂ f).base x) :=
+  let e : CommRingCat.of R ≅ Spec(R).presheaf.stalk ((pullback.fst i₂ f).base x) :=
     (stalkClosedPointIso (.of R)).symm ≪≫
-      (Spec (.of R)).presheaf.stalkCongr (.of_eq h₂.symm)
+      Spec(R).presheaf.stalkCongr (.of_eq h₂.symm)
   let α := e.hom ≫ (pullback.fst i₂ f).stalkMap x
   have : IsLocalHom e.hom.hom := isLocalHom_of_isIso e.hom
   have : IsLocalHom α.hom := inferInstanceAs
@@ -156,7 +156,7 @@ lemma of_specializingMap (H : (topologically @SpecializingMap).universally f) :
   have hαβ : α ≫ β = CommRingCat.ofHom (algebraMap R K) := by
     simp only [CommRingCat.coe_of, Iso.trans_hom, Iso.symm_hom, TopCat.Presheaf.stalkCongr_hom,
       Category.assoc, α, e, β, stalkClosedPointIso_inv, StructureSheaf.toStalk]
-    change (Scheme.ΓSpecIso (.of R)).inv ≫ (Spec (.of R)).presheaf.germ _ _ _ ≫ _ = _
+    change (Scheme.ΓSpecIso (.of R)).inv ≫ Spec(R).presheaf.germ _ _ _ ≫ _ = _
     simp only [TopCat.Presheaf.germ_stalkSpecializes_assoc, Scheme.stalkMap_germ_assoc]
     -- `map_top` introduces defeq problems, according to `check_compositions`.
     -- This is probably the cause of the `erw` needed below.
@@ -276,7 +276,7 @@ lemma IsSeparated.valuativeCriterion [IsSeparated f] : ValuativeCriterion.Unique
   dsimp at *
   have h := hl₁'.trans hl₂'.symm
   let Z := pullback (pullback.diagonal f) (pullback.lift l₁ l₂ h)
-  let g : Z ⟶ Spec (.of S.R) := pullback.snd _ _
+  let g : Z ⟶ Spec(S.R) := pullback.snd _ _
   have : IsClosedImmersion g := MorphismProperty.pullback_snd _ _ inferInstance
   have hZ : IsAffine Z := by
     rw [@HasAffineProperty.iff_of_isAffine @IsClosedImmersion] at this
@@ -290,7 +290,7 @@ lemma IsSeparated.valuativeCriterion [IsSeparated f] : ValuativeCriterion.Unique
     refine (HasAffineProperty.iff_of_isAffine (P := MorphismProperty.isomorphisms Scheme)).mpr ?_
     exact ⟨hZ, (ConcreteCategory.isIso_iff_bijective _).mpr h⟩
   constructor
-  · let l : Spec (.of S.K) ⟶ Z :=
+  · let l : Spec(S.K) ⟶ Z :=
       pullback.lift S.i₁ (Spec.map (CommRingCat.ofHom (algebraMap S.R S.K))) (by
         apply IsPullback.hom_ext (IsPullback.of_hasPullback _ _)
         · simpa using hl₁.symm


### PR DESCRIPTION
This notation was instrumental in understanding the "industrial size" goals that showed up in Toric. Indeed, `Spec (.of R)` is reasonably short, but it currently pretty-prints as `Spec (CommRingCat.of R)`, which is unbearably long.

There is a slight potential for ambiguity with `Spec R`, which I have hopefully mitigated with a docstring. If ever someone nonetheless writes a lemma about `Spec(R)` where `R : CommRingCat`, all odds are that it will be innocuous since `.of ↑R = R` definitionally.

Alternatively, we could make the `Spec(R)` notation and delaborator automatically detect whether `R : CommRingCat` or not. I would rather postpone this extra complexity until strictly necessary.

From Toric


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
