### PR TITLE
[Merged by Bors] - chore: generalise syntactically `Over.tensorHom_left_fst`

### DIFF
--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Over.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Over.lean
@@ -162,13 +162,15 @@ lemma tensorHom_left {R S T U : Over X} (f : R ⟶ S) (g : T ⟶ U) :
     (f ⊗ₘ g).left = pullback.map _ _ _ _ f.left g.left (𝟙 _) (by simp) (by simp) := rfl
 
 @[reassoc (attr := simp)]
-lemma tensorHom_left_fst {R S T U : Over X} (f : R ⟶ S) (g : T ⟶ U) :
-    (f ⊗ₘ g).left ≫ pullback.fst _ _ = pullback.fst _ _ ≫ f.left :=
+lemma tensorHom_left_fst {S U : C} {R T : Over X} (fS : S ⟶ X) (fU : U ⟶ X)
+    (f : R ⟶ mk fS) (g : T ⟶ mk fU) :
+    (f ⊗ₘ g).left ≫ pullback.fst fS fU = pullback.fst R.hom T.hom ≫ f.left :=
   limit.lift_π _ _
 
 @[reassoc (attr := simp)]
-lemma tensorHom_left_snd {R S T U : Over X} (f : R ⟶ S) (g : T ⟶ U) :
-    (f ⊗ₘ g).left ≫ pullback.snd _ _ = pullback.snd _ _ ≫ g.left :=
+lemma tensorHom_left_snd {S U : C} {R T : Over X} (fS : S ⟶ X) (fU : U ⟶ X)
+    (f : R ⟶ mk fS) (g : T ⟶ mk fU) :
+    (f ⊗ₘ g).left ≫ pullback.snd fS fU = pullback.snd R.hom T.hom ≫ g.left :=
   limit.lift_π _ _
 
 @[simp]


### PR DESCRIPTION
Previously, the LHS was `(f ⊗ₘ g).left ≫ pullback.fst S.hom U.hom`. Now it is `f ⊗ₘ g).left ≫ pullback.fst fS fU`, which is syntactically more general.

From Toric


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
