### PR TITLE
[Merged by Bors] - feat(Geometry/Euclidean/Sphere/Basic): add theorems for angles subtended by diameters

### DIFF
--- a/Mathlib/Geometry/Euclidean/Angle/Sphere.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Sphere.lean
@@ -75,7 +75,7 @@ open Real InnerProductSpace
 
 /-- For a diameter of a sphere, the angle subtended by the diameter
 at any other point on the sphere is a right angle. -/
-theorem angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter (p₁ p₂ p₃ : P) (s : Sphere P)
+theorem angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter {p₁ p₂ p₃ : P} {s : Sphere P}
     (hd : s.IsDiameter p₁ p₃) :
     ∠ p₁ p₂ p₃ = π / 2 ↔ p₂ ∈ s := by
   constructor
@@ -125,15 +125,14 @@ theorem angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter (p₁ p₂ p₃ : P) (s
 /-- For three distinct points, the angle at the second point
 is a right angle if and only if the second point lies on the sphere having the first and third
 points as diameter endpoints. -/
-theorem angle_eq_pi_div_two_iff_mem_sphere_ofDiameter (p₁ p₂ p₃ : P) :
+theorem angle_eq_pi_div_two_iff_mem_sphere_ofDiameter {p₁ p₂ p₃ : P} :
     ∠ p₁ p₂ p₃ = π / 2 ↔ p₂ ∈ Sphere.ofDiameter p₁ p₃ :=
-  angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter p₁ p₂ p₃ (Sphere.ofDiameter p₁ p₃)
-    (Sphere.isDiameter_ofDiameter p₁ p₃)
+  angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter (Sphere.isDiameter_ofDiameter p₁ p₃)
 
 /-- **Thales' theorem**: The angle inscribed in a semicircle is a right angle. -/
-theorem thales_theorem (p₁ p₂ p₃ : P) (s : Sphere P) (hd : s.IsDiameter p₁ p₃) :
+theorem thales_theorem {p₁ p₂ p₃ : P} {s : Sphere P} (hd : s.IsDiameter p₁ p₃) :
     ∠ p₁ p₂ p₃ = π / 2 ↔ p₂ ∈ s :=
-  angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter p₁ p₂ p₃ s hd
+  angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter hd
 
 end Sphere
 

--- a/Mathlib/Geometry/Euclidean/Angle/Sphere.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Sphere.lean
@@ -92,7 +92,7 @@ theorem angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter {p₁ p₂ p₃ : P} {s
     mem_sphere.mp hd.right_mem]
   exact eq_comm
 
-/-- For three distinct points, the angle at the second point
+/-- **Thales' theorem**: For three distinct points, the angle at the second point
 is a right angle if and only if the second point lies on the sphere having the first and third
 points as diameter endpoints. -/
 theorem angle_eq_pi_div_two_iff_mem_sphere_ofDiameter {p₁ p₂ p₃ : P} :
@@ -102,10 +102,6 @@ theorem angle_eq_pi_div_two_iff_mem_sphere_ofDiameter {p₁ p₂ p₃ : P} :
 alias thales_theorem := angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter
 
 end Sphere
-
-end EuclideanGeometry
-
-namespace EuclideanGeometry
 
 variable {V : Type*} {P : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [MetricSpace P]
   [NormedAddTorsor V P] [hd2 : Fact (finrank ℝ V = 2)] [Module.Oriented ℝ V (Fin 2)]

--- a/Mathlib/Geometry/Euclidean/Angle/Sphere.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Sphere.lean
@@ -80,7 +80,7 @@ theorem angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter (p₁ p₂ p₃ : P) (s
     ∠ p₁ p₂ p₃ = π / 2 ↔ p₂ ∈ s := by
   constructor
   · intro h
-    have h_perp : ⟪p₁ -ᵥ p₂, p₃ -ᵥ p₂⟫_ℝ = 0 :=
+    have h_perp : ⟪p₁ -ᵥ p₂, p₃ -ᵥ p₂⟫ = 0 :=
       (InnerProductGeometry.inner_eq_zero_iff_angle_eq_pi_div_two (p₁ -ᵥ p₂) (p₃ -ᵥ p₂)).mpr h
     let o := midpoint ℝ p₁ p₃
     rw [← vsub_add_vsub_cancel p₁ o p₂, ← vsub_add_vsub_cancel p₃ o p₂,
@@ -92,7 +92,7 @@ theorem angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter (p₁ p₂ p₃ : P) (s
         real_inner_comm (p₃ -ᵥ o) (o -ᵥ p₂)] at h_perp
     ring_nf at h_perp
     have h_eq : dist p₂ o = dist p₃ o := by
-      have : ⟪p₂ -ᵥ o, p₂ -ᵥ o⟫_ℝ = ⟪p₃ -ᵥ o, p₃ -ᵥ o⟫_ℝ := by
+      have : ⟪p₂ -ᵥ o, p₂ -ᵥ o⟫ = ⟪p₃ -ᵥ o, p₃ -ᵥ o⟫ := by
         rw [← inner_neg_neg (p₂ -ᵥ o)]
         simp only [neg_vsub_eq_vsub_rev]
         linarith
@@ -108,7 +108,7 @@ theorem angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter (p₁ p₂ p₃ : P) (s
     have h_center : o = midpoint ℝ p₁ p₃ := hd.midpoint_eq_center.symm
     have h_mem1 : dist o p₂ = s.radius := mem_sphere'.mp h
     have h_mem2 : dist o p₃ = s.radius := mem_sphere'.mp hd.right_mem
-    have h_perp : ⟪p₁ -ᵥ p₂, p₃ -ᵥ p₂⟫_ℝ = 0 := by
+    have h_perp : ⟪p₁ -ᵥ p₂, p₃ -ᵥ p₂⟫ = 0 := by
       rw [← vsub_add_vsub_cancel p₁ o p₂, ← vsub_add_vsub_cancel p₃ o p₂,
           inner_add_left, inner_add_right, inner_add_right]
       have h_opp : p₁ -ᵥ o = -(p₃ -ᵥ o) := by
@@ -126,9 +126,9 @@ theorem angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter (p₁ p₂ p₃ : P) (s
 is a right angle if and only if the second point lies on the sphere having the first and third
 points as diameter endpoints. -/
 theorem angle_eq_pi_div_two_iff_mem_sphere_ofDiameter (p₁ p₂ p₃ : P) :
-    ∠ p₁ p₂ p₃ = π / 2 ↔ p₂ ∈ Sphere.ofDiameter p₁ p₃ := by
-  exact angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter p₁ p₂ p₃
-        (Sphere.ofDiameter p₁ p₃) (Sphere.isDiameter_ofDiameter p₁ p₃)
+    ∠ p₁ p₂ p₃ = π / 2 ↔ p₂ ∈ Sphere.ofDiameter p₁ p₃ :=
+  angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter p₁ p₂ p₃ (Sphere.ofDiameter p₁ p₃)
+    (Sphere.isDiameter_ofDiameter p₁ p₃)
 
 /-- **Thales' theorem**: The angle inscribed in a semicircle is a right angle. -/
 theorem thales_theorem (p₁ p₂ p₃ : P) (s : Sphere P) (hd : s.IsDiameter p₁ p₃) :

--- a/Mathlib/Geometry/Euclidean/Angle/Sphere.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Sphere.lean
@@ -67,6 +67,81 @@ end Orientation
 namespace EuclideanGeometry
 
 variable {V : Type*} {P : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [MetricSpace P]
+  [NormedAddTorsor V P]
+
+namespace Sphere
+
+open Real InnerProductSpace
+
+/-- For a diameter of a sphere, the angle subtended by the diameter
+at any other point on the sphere is a right angle. -/
+theorem angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter (p₁ p₂ p₃ : P) (s : Sphere P)
+    (hd : s.IsDiameter p₁ p₃) :
+    ∠ p₁ p₂ p₃ = π / 2 ↔ p₂ ∈ s := by
+  constructor
+  · intro h
+    have h_perp : ⟪p₁ -ᵥ p₂, p₃ -ᵥ p₂⟫_ℝ = 0 :=
+      (InnerProductGeometry.inner_eq_zero_iff_angle_eq_pi_div_two (p₁ -ᵥ p₂) (p₃ -ᵥ p₂)).mpr h
+    let o := midpoint ℝ p₁ p₃
+    rw [← vsub_add_vsub_cancel p₁ o p₂, ← vsub_add_vsub_cancel p₃ o p₂,
+        inner_add_left, inner_add_right, inner_add_right] at h_perp
+    have h_opp : p₁ -ᵥ o = -(p₃ -ᵥ o) := by
+      rw [left_vsub_midpoint, right_vsub_midpoint, ← smul_neg]
+      simp only [invOf_eq_inv, neg_vsub_eq_vsub_rev]
+    rw [h_opp, inner_neg_left, inner_neg_left,
+        real_inner_comm (p₃ -ᵥ o) (o -ᵥ p₂)] at h_perp
+    ring_nf at h_perp
+    have h_eq : dist p₂ o = dist p₃ o := by
+      have : ⟪p₂ -ᵥ o, p₂ -ᵥ o⟫_ℝ = ⟪p₃ -ᵥ o, p₃ -ᵥ o⟫_ℝ := by
+        rw [← inner_neg_neg (p₂ -ᵥ o)]
+        simp only [neg_vsub_eq_vsub_rev]
+        linarith
+      rw [real_inner_self_eq_norm_sq, real_inner_self_eq_norm_sq,
+          ← dist_eq_norm_vsub, ← dist_eq_norm_vsub] at this
+      rw [← Real.sqrt_sq dist_nonneg, ← Real.sqrt_sq dist_nonneg, this,
+          Real.sqrt_sq dist_nonneg, Real.sqrt_sq dist_nonneg]
+    rw [mem_sphere', dist_comm, ← hd.midpoint_eq_center, h_eq,
+        show o = midpoint ℝ p₁ p₃ from rfl, hd.midpoint_eq_center,
+        dist_comm, mem_sphere'.mp hd.right_mem]
+  · intro h
+    let o := s.center
+    have h_center : o = midpoint ℝ p₁ p₃ := hd.midpoint_eq_center.symm
+    have h_mem1 : dist o p₂ = s.radius := mem_sphere'.mp h
+    have h_mem2 : dist o p₃ = s.radius := mem_sphere'.mp hd.right_mem
+    have h_perp : ⟪p₁ -ᵥ p₂, p₃ -ᵥ p₂⟫_ℝ = 0 := by
+      rw [← vsub_add_vsub_cancel p₁ o p₂, ← vsub_add_vsub_cancel p₃ o p₂,
+          inner_add_left, inner_add_right, inner_add_right]
+      have h_opp : p₁ -ᵥ o = -(p₃ -ᵥ o) := by
+        rw [h_center, left_vsub_midpoint, right_vsub_midpoint, ← smul_neg]
+        simp only [invOf_eq_inv, neg_vsub_eq_vsub_rev]
+      rw [h_opp, inner_neg_left, inner_neg_left,
+          real_inner_self_eq_norm_sq, ← dist_eq_norm_vsub,
+          real_inner_self_eq_norm_sq, ← dist_eq_norm_vsub,
+          dist_comm, h_mem1, h_mem2, real_inner_comm (p₃ -ᵥ o) (o -ᵥ p₂)]
+      ring
+    exact (InnerProductGeometry.inner_eq_zero_iff_angle_eq_pi_div_two
+          (p₁ -ᵥ p₂) (p₃ -ᵥ p₂)).mp h_perp
+
+/-- For three distinct points, the angle at the second point
+is a right angle if and only if the second point lies on the sphere having the first and third
+points as diameter endpoints. -/
+theorem angle_eq_pi_div_two_iff_mem_sphere_ofDiameter (p₁ p₂ p₃ : P) :
+    ∠ p₁ p₂ p₃ = π / 2 ↔ p₂ ∈ Sphere.ofDiameter p₁ p₃ := by
+  exact angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter p₁ p₂ p₃
+        (Sphere.ofDiameter p₁ p₃) (Sphere.isDiameter_ofDiameter p₁ p₃)
+
+/-- **Thales' theorem**: The angle inscribed in a semicircle is a right angle. -/
+theorem thales_theorem (p₁ p₂ p₃ : P) (s : Sphere P) (hd : s.IsDiameter p₁ p₃) :
+    ∠ p₁ p₂ p₃ = π / 2 ↔ p₂ ∈ s :=
+  angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter p₁ p₂ p₃ s hd
+
+end Sphere
+
+end EuclideanGeometry
+
+namespace EuclideanGeometry
+
+variable {V : Type*} {P : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [MetricSpace P]
   [NormedAddTorsor V P] [hd2 : Fact (finrank ℝ V = 2)] [Module.Oriented ℝ V (Fin 2)]
 
 local notation "o" => Module.Oriented.positiveOrientation

--- a/Mathlib/Geometry/Euclidean/Angle/Sphere.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Sphere.lean
@@ -73,54 +73,24 @@ namespace Sphere
 
 open Real InnerProductSpace
 
-/-- For a diameter of a sphere, the angle subtended by the diameter
-at any other point on the sphere is a right angle. -/
+/-- **Thales' theorem**: The angle inscribed in a semicircle is a right angle. -/
 theorem angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter {p₁ p₂ p₃ : P} {s : Sphere P}
     (hd : s.IsDiameter p₁ p₃) :
     ∠ p₁ p₂ p₃ = π / 2 ↔ p₂ ∈ s := by
-  constructor
-  · intro h
-    have h_perp : ⟪p₁ -ᵥ p₂, p₃ -ᵥ p₂⟫ = 0 :=
-      (InnerProductGeometry.inner_eq_zero_iff_angle_eq_pi_div_two (p₁ -ᵥ p₂) (p₃ -ᵥ p₂)).mpr h
-    let o := midpoint ℝ p₁ p₃
-    rw [← vsub_add_vsub_cancel p₁ o p₂, ← vsub_add_vsub_cancel p₃ o p₂,
-        inner_add_left, inner_add_right, inner_add_right] at h_perp
-    have h_opp : p₁ -ᵥ o = -(p₃ -ᵥ o) := by
-      rw [left_vsub_midpoint, right_vsub_midpoint, ← smul_neg]
-      simp only [invOf_eq_inv, neg_vsub_eq_vsub_rev]
-    rw [h_opp, inner_neg_left, inner_neg_left,
-        real_inner_comm (p₃ -ᵥ o) (o -ᵥ p₂)] at h_perp
-    ring_nf at h_perp
-    have h_eq : dist p₂ o = dist p₃ o := by
-      have : ⟪p₂ -ᵥ o, p₂ -ᵥ o⟫ = ⟪p₃ -ᵥ o, p₃ -ᵥ o⟫ := by
-        rw [← inner_neg_neg (p₂ -ᵥ o)]
-        simp only [neg_vsub_eq_vsub_rev]
-        linarith
-      rw [real_inner_self_eq_norm_sq, real_inner_self_eq_norm_sq,
-          ← dist_eq_norm_vsub, ← dist_eq_norm_vsub] at this
-      rw [← Real.sqrt_sq dist_nonneg, ← Real.sqrt_sq dist_nonneg, this,
-          Real.sqrt_sq dist_nonneg, Real.sqrt_sq dist_nonneg]
-    rw [mem_sphere', dist_comm, ← hd.midpoint_eq_center, h_eq,
-        show o = midpoint ℝ p₁ p₃ from rfl, hd.midpoint_eq_center,
-        dist_comm, mem_sphere'.mp hd.right_mem]
-  · intro h
-    let o := s.center
-    have h_center : o = midpoint ℝ p₁ p₃ := hd.midpoint_eq_center.symm
-    have h_mem1 : dist o p₂ = s.radius := mem_sphere'.mp h
-    have h_mem2 : dist o p₃ = s.radius := mem_sphere'.mp hd.right_mem
-    have h_perp : ⟪p₁ -ᵥ p₂, p₃ -ᵥ p₂⟫ = 0 := by
-      rw [← vsub_add_vsub_cancel p₁ o p₂, ← vsub_add_vsub_cancel p₃ o p₂,
-          inner_add_left, inner_add_right, inner_add_right]
-      have h_opp : p₁ -ᵥ o = -(p₃ -ᵥ o) := by
-        rw [h_center, left_vsub_midpoint, right_vsub_midpoint, ← smul_neg]
-        simp only [invOf_eq_inv, neg_vsub_eq_vsub_rev]
-      rw [h_opp, inner_neg_left, inner_neg_left,
-          real_inner_self_eq_norm_sq, ← dist_eq_norm_vsub,
-          real_inner_self_eq_norm_sq, ← dist_eq_norm_vsub,
-          dist_comm, h_mem1, h_mem2, real_inner_comm (p₃ -ᵥ o) (o -ᵥ p₂)]
-      ring
-    exact (InnerProductGeometry.inner_eq_zero_iff_angle_eq_pi_div_two
-          (p₁ -ᵥ p₂) (p₃ -ᵥ p₂)).mp h_perp
+  rw [mem_sphere', EuclideanGeometry.angle,
+    ← InnerProductGeometry.inner_eq_zero_iff_angle_eq_pi_div_two]
+  let o := s.center
+  have h_center : o = midpoint ℝ p₁ p₃ := hd.midpoint_eq_center.symm
+  rw [← vsub_add_vsub_cancel p₁ o p₂, ← vsub_add_vsub_cancel p₃ o p₂,
+    inner_add_left, inner_add_right, inner_add_right]
+  have h_opp : p₁ -ᵥ o = -(p₃ -ᵥ o) := by
+    rw [h_center, left_vsub_midpoint, right_vsub_midpoint, ← smul_neg, neg_vsub_eq_vsub_rev]
+  rw [h_opp, inner_neg_left, inner_neg_left, real_inner_comm (p₃ -ᵥ o) (o -ᵥ p₂)]
+  ring_nf
+  rw [neg_add_eq_zero, real_inner_self_eq_norm_sq, ← dist_eq_norm_vsub,
+    real_inner_self_eq_norm_sq, ← dist_eq_norm_vsub, sq_eq_sq₀ dist_nonneg dist_nonneg,
+    mem_sphere.mp hd.right_mem]
+  exact eq_comm
 
 /-- For three distinct points, the angle at the second point
 is a right angle if and only if the second point lies on the sphere having the first and third
@@ -129,10 +99,7 @@ theorem angle_eq_pi_div_two_iff_mem_sphere_ofDiameter {p₁ p₂ p₃ : P} :
     ∠ p₁ p₂ p₃ = π / 2 ↔ p₂ ∈ Sphere.ofDiameter p₁ p₃ :=
   angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter (Sphere.isDiameter_ofDiameter p₁ p₃)
 
-/-- **Thales' theorem**: The angle inscribed in a semicircle is a right angle. -/
-theorem thales_theorem {p₁ p₂ p₃ : P} {s : Sphere P} (hd : s.IsDiameter p₁ p₃) :
-    ∠ p₁ p₂ p₃ = π / 2 ↔ p₂ ∈ s :=
-  angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter hd
+alias thales_theorem := angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter
 
 end Sphere
 

--- a/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
@@ -491,59 +491,60 @@ open Real InnerProductSpace
 
 /-- For a diameter of a sphere, the angle subtended by the diameter
 at any other point on the sphere is a right angle. -/
-theorem angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter (A B C : P) (s : Sphere P)
-    (hDiam : s.IsDiameter A C) (_ : B ≠ A) (_ : B ≠ C) :
-    ∠ A B C = π / 2 ↔ B ∈ s := by
+theorem angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter (p₁ p₂ p₃ : P) (s : Sphere P)
+    (hd : s.IsDiameter p₁ p₃) :
+    ∠ p₁ p₂ p₃ = π / 2 ↔ p₂ ∈ s := by
   constructor
-  · intro hAngle
-    have h_perp : ⟪A -ᵥ B, C -ᵥ B⟫_ℝ = 0 :=
-      (InnerProductGeometry.inner_eq_zero_iff_angle_eq_pi_div_two (A -ᵥ B) (C -ᵥ B)).mpr hAngle
-    let O := midpoint ℝ A C
-    rw [← vsub_add_vsub_cancel A O B, ← vsub_add_vsub_cancel C O B,
+  · intro h
+    have h_perp : ⟪p₁ -ᵥ p₂, p₃ -ᵥ p₂⟫_ℝ = 0 :=
+      (InnerProductGeometry.inner_eq_zero_iff_angle_eq_pi_div_two (p₁ -ᵥ p₂) (p₃ -ᵥ p₂)).mpr h
+    let o := midpoint ℝ p₁ p₃
+    rw [← vsub_add_vsub_cancel p₁ o p₂, ← vsub_add_vsub_cancel p₃ o p₂,
         inner_add_left, inner_add_right, inner_add_right] at h_perp
-    have hAC_opposite : A -ᵥ O = -(C -ᵥ O) := by
+    have h_opp : p₁ -ᵥ o = -(p₃ -ᵥ o) := by
       rw [left_vsub_midpoint, right_vsub_midpoint, ← smul_neg]
       simp only [invOf_eq_inv, neg_vsub_eq_vsub_rev]
-    rw [hAC_opposite, inner_neg_left, inner_neg_left,
-        real_inner_comm (C -ᵥ O) (O -ᵥ B)] at h_perp
+    rw [h_opp, inner_neg_left, inner_neg_left,
+        real_inner_comm (p₃ -ᵥ o) (o -ᵥ p₂)] at h_perp
     ring_nf at h_perp
-    have hBO_eq_CO : dist B O = dist C O := by
-      have : ⟪B -ᵥ O, B -ᵥ O⟫_ℝ = ⟪C -ᵥ O, C -ᵥ O⟫_ℝ := by
-        rw [← inner_neg_neg (B -ᵥ O)]
+    have h_eq : dist p₂ o = dist p₃ o := by
+      have : ⟪p₂ -ᵥ o, p₂ -ᵥ o⟫_ℝ = ⟪p₃ -ᵥ o, p₃ -ᵥ o⟫_ℝ := by
+        rw [← inner_neg_neg (p₂ -ᵥ o)]
         simp only [neg_vsub_eq_vsub_rev]
         linarith
       rw [real_inner_self_eq_norm_sq, real_inner_self_eq_norm_sq,
           ← dist_eq_norm_vsub, ← dist_eq_norm_vsub] at this
       rw [← Real.sqrt_sq dist_nonneg, ← Real.sqrt_sq dist_nonneg, this,
           Real.sqrt_sq dist_nonneg, Real.sqrt_sq dist_nonneg]
-    rw [mem_sphere', dist_comm, ← hDiam.midpoint_eq_center, hBO_eq_CO,
-        show O = midpoint ℝ A C from rfl, hDiam.midpoint_eq_center,
-        dist_comm, mem_sphere'.mp hDiam.right_mem]
-  · intro hB
-    let O := s.center
-    have hO : O = midpoint ℝ A C := hDiam.midpoint_eq_center.symm
-    have hOB : dist O B = s.radius := mem_sphere'.mp hB
-    have hOC : dist O C = s.radius := mem_sphere'.mp hDiam.right_mem
-    have h_perp : ⟪A -ᵥ B, C -ᵥ B⟫_ℝ = 0 := by
-      rw [← vsub_add_vsub_cancel A O B, ← vsub_add_vsub_cancel C O B,
+    rw [mem_sphere', dist_comm, ← hd.midpoint_eq_center, h_eq,
+        show o = midpoint ℝ p₁ p₃ from rfl, hd.midpoint_eq_center,
+        dist_comm, mem_sphere'.mp hd.right_mem]
+  · intro h
+    let o := s.center
+    have h_center : o = midpoint ℝ p₁ p₃ := hd.midpoint_eq_center.symm
+    have h_mem1 : dist o p₂ = s.radius := mem_sphere'.mp h
+    have h_mem2 : dist o p₃ = s.radius := mem_sphere'.mp hd.right_mem
+    have h_perp : ⟪p₁ -ᵥ p₂, p₃ -ᵥ p₂⟫_ℝ = 0 := by
+      rw [← vsub_add_vsub_cancel p₁ o p₂, ← vsub_add_vsub_cancel p₃ o p₂,
           inner_add_left, inner_add_right, inner_add_right]
-      have hAC_opposite : A -ᵥ O = -(C -ᵥ O) := by
-        rw [hO, left_vsub_midpoint, right_vsub_midpoint, ← smul_neg]
+      have h_opp : p₁ -ᵥ o = -(p₃ -ᵥ o) := by
+        rw [h_center, left_vsub_midpoint, right_vsub_midpoint, ← smul_neg]
         simp only [invOf_eq_inv, neg_vsub_eq_vsub_rev]
-      rw [hAC_opposite, inner_neg_left, inner_neg_left,
+      rw [h_opp, inner_neg_left, inner_neg_left,
           real_inner_self_eq_norm_sq, ← dist_eq_norm_vsub,
           real_inner_self_eq_norm_sq, ← dist_eq_norm_vsub,
-          dist_comm, hOB, hOC, real_inner_comm (C -ᵥ O) (O -ᵥ B)]
+          dist_comm, h_mem1, h_mem2, real_inner_comm (p₃ -ᵥ o) (o -ᵥ p₂)]
       ring
-    exact (InnerProductGeometry.inner_eq_zero_iff_angle_eq_pi_div_two (A -ᵥ B) (C -ᵥ B)).mp h_perp
+    exact (InnerProductGeometry.inner_eq_zero_iff_angle_eq_pi_div_two
+          (p₁ -ᵥ p₂) (p₃ -ᵥ p₂)).mp h_perp
 
 /-- For three distinct points, the angle at the second point
 is a right angle if and only if the second point lies on the sphere having the first and third
 points as diameter endpoints. -/
-theorem angle_eq_pi_div_two_iff_mem_sphere_ofDiameter (A B C : P) (hBA : B ≠ A) (hBC : B ≠ C) :
-    ∠ A B C = π / 2 ↔ B ∈ Sphere.ofDiameter A C := by
-  exact angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter A B C
-        (Sphere.ofDiameter A C) (Sphere.isDiameter_ofDiameter A C) hBA hBC
+theorem angle_eq_pi_div_two_iff_mem_sphere_ofDiameter (p₁ p₂ p₃ : P) :
+    ∠ p₁ p₂ p₃ = π / 2 ↔ p₂ ∈ Sphere.ofDiameter p₁ p₃ := by
+  exact angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter p₁ p₂ p₃
+        (Sphere.ofDiameter p₁ p₃) (Sphere.isDiameter_ofDiameter p₁ p₃)
 
 end Sphere
 

--- a/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
@@ -7,6 +7,7 @@ import Mathlib.Analysis.Convex.StrictConvexBetween
 import Mathlib.Analysis.InnerProductSpace.Convex
 import Mathlib.Analysis.Normed.Affine.Convex
 import Mathlib.Geometry.Euclidean.Basic
+import Mathlib.Geometry.Euclidean.Angle.Unoriented.Affine
 
 /-!
 # Spheres
@@ -485,6 +486,8 @@ lemma isDiameter_iff_mem_and_mem_and_wbtw :
   have hd := hr.dist_add_dist
   rw [mem_sphere.1 h₁, mem_sphere'.1 h₂, ← two_mul, eq_comm] at hd
   exact isDiameter_iff_mem_and_mem_and_dist.2 ⟨h₁, h₂, hd⟩
+
+open Real InnerProductSpace
 
 /-- For a diameter of a sphere, the angle subtended by the diameter
 at any other point on the sphere is a right angle. -/

--- a/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
@@ -486,6 +486,62 @@ lemma isDiameter_iff_mem_and_mem_and_wbtw :
   rw [mem_sphere.1 h₁, mem_sphere'.1 h₂, ← two_mul, eq_comm] at hd
   exact isDiameter_iff_mem_and_mem_and_dist.2 ⟨h₁, h₂, hd⟩
 
+/-- For a diameter of a sphere, the angle subtended by the diameter
+at any other point on the sphere is a right angle. -/
+theorem angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter (A B C : P) (s : Sphere P)
+    (hDiam : s.IsDiameter A C) (_ : B ≠ A) (_ : B ≠ C) :
+    ∠ A B C = π / 2 ↔ B ∈ s := by
+  constructor
+  · intro hAngle
+    have h_perp : ⟪A -ᵥ B, C -ᵥ B⟫_ℝ = 0 :=
+      (InnerProductGeometry.inner_eq_zero_iff_angle_eq_pi_div_two (A -ᵥ B) (C -ᵥ B)).mpr hAngle
+    let O := midpoint ℝ A C
+    rw [← vsub_add_vsub_cancel A O B, ← vsub_add_vsub_cancel C O B,
+        inner_add_left, inner_add_right, inner_add_right] at h_perp
+    have hAC_opposite : A -ᵥ O = -(C -ᵥ O) := by
+      rw [left_vsub_midpoint, right_vsub_midpoint, ← smul_neg]
+      simp only [invOf_eq_inv, neg_vsub_eq_vsub_rev]
+    rw [hAC_opposite, inner_neg_left, inner_neg_left,
+        real_inner_comm (C -ᵥ O) (O -ᵥ B)] at h_perp
+    ring_nf at h_perp
+    have hBO_eq_CO : dist B O = dist C O := by
+      have : ⟪B -ᵥ O, B -ᵥ O⟫_ℝ = ⟪C -ᵥ O, C -ᵥ O⟫_ℝ := by
+        rw [← inner_neg_neg (B -ᵥ O)]
+        simp only [neg_vsub_eq_vsub_rev]
+        linarith
+      rw [real_inner_self_eq_norm_sq, real_inner_self_eq_norm_sq,
+          ← dist_eq_norm_vsub, ← dist_eq_norm_vsub] at this
+      rw [← Real.sqrt_sq dist_nonneg, ← Real.sqrt_sq dist_nonneg, this,
+          Real.sqrt_sq dist_nonneg, Real.sqrt_sq dist_nonneg]
+    rw [mem_sphere', dist_comm, ← hDiam.midpoint_eq_center, hBO_eq_CO,
+        show O = midpoint ℝ A C from rfl, hDiam.midpoint_eq_center,
+        dist_comm, mem_sphere'.mp hDiam.right_mem]
+  · intro hB
+    let O := s.center
+    have hO : O = midpoint ℝ A C := hDiam.midpoint_eq_center.symm
+    have hOB : dist O B = s.radius := mem_sphere'.mp hB
+    have hOC : dist O C = s.radius := mem_sphere'.mp hDiam.right_mem
+    have h_perp : ⟪A -ᵥ B, C -ᵥ B⟫_ℝ = 0 := by
+      rw [← vsub_add_vsub_cancel A O B, ← vsub_add_vsub_cancel C O B,
+          inner_add_left, inner_add_right, inner_add_right]
+      have hAC_opposite : A -ᵥ O = -(C -ᵥ O) := by
+        rw [hO, left_vsub_midpoint, right_vsub_midpoint, ← smul_neg]
+        simp only [invOf_eq_inv, neg_vsub_eq_vsub_rev]
+      rw [hAC_opposite, inner_neg_left, inner_neg_left,
+          real_inner_self_eq_norm_sq, ← dist_eq_norm_vsub,
+          real_inner_self_eq_norm_sq, ← dist_eq_norm_vsub,
+          dist_comm, hOB, hOC, real_inner_comm (C -ᵥ O) (O -ᵥ B)]
+      ring
+    exact (InnerProductGeometry.inner_eq_zero_iff_angle_eq_pi_div_two (A -ᵥ B) (C -ᵥ B)).mp h_perp
+
+/-- For three distinct points, the angle at the second point
+is a right angle if and only if the second point lies on the sphere having the first and third
+points as diameter endpoints. -/
+theorem angle_eq_pi_div_two_iff_mem_sphere_ofDiameter (A B C : P) (hBA : B ≠ A) (hBC : B ≠ C) :
+    ∠ A B C = π / 2 ↔ B ∈ Sphere.ofDiameter A C := by
+  exact angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter A B C
+        (Sphere.ofDiameter A C) (Sphere.isDiameter_ofDiameter A C) hBA hBC
+
 end Sphere
 
 end EuclideanSpace

--- a/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Sphere/Basic.lean
@@ -7,7 +7,6 @@ import Mathlib.Analysis.Convex.StrictConvexBetween
 import Mathlib.Analysis.InnerProductSpace.Convex
 import Mathlib.Analysis.Normed.Affine.Convex
 import Mathlib.Geometry.Euclidean.Basic
-import Mathlib.Geometry.Euclidean.Angle.Unoriented.Affine
 
 /-!
 # Spheres
@@ -486,65 +485,6 @@ lemma isDiameter_iff_mem_and_mem_and_wbtw :
   have hd := hr.dist_add_dist
   rw [mem_sphere.1 h₁, mem_sphere'.1 h₂, ← two_mul, eq_comm] at hd
   exact isDiameter_iff_mem_and_mem_and_dist.2 ⟨h₁, h₂, hd⟩
-
-open Real InnerProductSpace
-
-/-- For a diameter of a sphere, the angle subtended by the diameter
-at any other point on the sphere is a right angle. -/
-theorem angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter (p₁ p₂ p₃ : P) (s : Sphere P)
-    (hd : s.IsDiameter p₁ p₃) :
-    ∠ p₁ p₂ p₃ = π / 2 ↔ p₂ ∈ s := by
-  constructor
-  · intro h
-    have h_perp : ⟪p₁ -ᵥ p₂, p₃ -ᵥ p₂⟫_ℝ = 0 :=
-      (InnerProductGeometry.inner_eq_zero_iff_angle_eq_pi_div_two (p₁ -ᵥ p₂) (p₃ -ᵥ p₂)).mpr h
-    let o := midpoint ℝ p₁ p₃
-    rw [← vsub_add_vsub_cancel p₁ o p₂, ← vsub_add_vsub_cancel p₃ o p₂,
-        inner_add_left, inner_add_right, inner_add_right] at h_perp
-    have h_opp : p₁ -ᵥ o = -(p₃ -ᵥ o) := by
-      rw [left_vsub_midpoint, right_vsub_midpoint, ← smul_neg]
-      simp only [invOf_eq_inv, neg_vsub_eq_vsub_rev]
-    rw [h_opp, inner_neg_left, inner_neg_left,
-        real_inner_comm (p₃ -ᵥ o) (o -ᵥ p₂)] at h_perp
-    ring_nf at h_perp
-    have h_eq : dist p₂ o = dist p₃ o := by
-      have : ⟪p₂ -ᵥ o, p₂ -ᵥ o⟫_ℝ = ⟪p₃ -ᵥ o, p₃ -ᵥ o⟫_ℝ := by
-        rw [← inner_neg_neg (p₂ -ᵥ o)]
-        simp only [neg_vsub_eq_vsub_rev]
-        linarith
-      rw [real_inner_self_eq_norm_sq, real_inner_self_eq_norm_sq,
-          ← dist_eq_norm_vsub, ← dist_eq_norm_vsub] at this
-      rw [← Real.sqrt_sq dist_nonneg, ← Real.sqrt_sq dist_nonneg, this,
-          Real.sqrt_sq dist_nonneg, Real.sqrt_sq dist_nonneg]
-    rw [mem_sphere', dist_comm, ← hd.midpoint_eq_center, h_eq,
-        show o = midpoint ℝ p₁ p₃ from rfl, hd.midpoint_eq_center,
-        dist_comm, mem_sphere'.mp hd.right_mem]
-  · intro h
-    let o := s.center
-    have h_center : o = midpoint ℝ p₁ p₃ := hd.midpoint_eq_center.symm
-    have h_mem1 : dist o p₂ = s.radius := mem_sphere'.mp h
-    have h_mem2 : dist o p₃ = s.radius := mem_sphere'.mp hd.right_mem
-    have h_perp : ⟪p₁ -ᵥ p₂, p₃ -ᵥ p₂⟫_ℝ = 0 := by
-      rw [← vsub_add_vsub_cancel p₁ o p₂, ← vsub_add_vsub_cancel p₃ o p₂,
-          inner_add_left, inner_add_right, inner_add_right]
-      have h_opp : p₁ -ᵥ o = -(p₃ -ᵥ o) := by
-        rw [h_center, left_vsub_midpoint, right_vsub_midpoint, ← smul_neg]
-        simp only [invOf_eq_inv, neg_vsub_eq_vsub_rev]
-      rw [h_opp, inner_neg_left, inner_neg_left,
-          real_inner_self_eq_norm_sq, ← dist_eq_norm_vsub,
-          real_inner_self_eq_norm_sq, ← dist_eq_norm_vsub,
-          dist_comm, h_mem1, h_mem2, real_inner_comm (p₃ -ᵥ o) (o -ᵥ p₂)]
-      ring
-    exact (InnerProductGeometry.inner_eq_zero_iff_angle_eq_pi_div_two
-          (p₁ -ᵥ p₂) (p₃ -ᵥ p₂)).mp h_perp
-
-/-- For three distinct points, the angle at the second point
-is a right angle if and only if the second point lies on the sphere having the first and third
-points as diameter endpoints. -/
-theorem angle_eq_pi_div_two_iff_mem_sphere_ofDiameter (p₁ p₂ p₃ : P) :
-    ∠ p₁ p₂ p₃ = π / 2 ↔ p₂ ∈ Sphere.ofDiameter p₁ p₃ := by
-  exact angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter p₁ p₂ p₃
-        (Sphere.ofDiameter p₁ p₃) (Sphere.isDiameter_ofDiameter p₁ p₃)
 
 end Sphere
 

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -318,6 +318,9 @@ Q284960:
 
 Q285719:
   title: Thales's theorem
+  decl: EuclideanGeometry.Sphere.thales_theorem
+  authors: Li Jiale
+  date: 2025
 
 Q287347:
   title: Gradient theorem


### PR DESCRIPTION
Add two formulations relating sphere diameters and right angles:

* `angle_eq_pi_div_two_iff_mem_sphere_of_isDiameter`: For a diameter of a sphere, 
  the angle subtended by the diameter at any other point on the sphere is a right 
  angle if and only if the point lies on the sphere.

* `angle_eq_pi_div_two_iff_mem_sphere_ofDiameter`: For three distinct points, 
  the angle at the second point is a right angle if and only if the second point 
  lies on the sphere having the first and third points as diameter endpoints.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
