### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Monoidal/Cartesian): the tensor product of representable functors is representable

### DIFF
--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Basic.lean
@@ -384,6 +384,15 @@ lemma lift_rightUnitor_hom {X Y : C} (f : X ⟶ Y) (g : X ⟶ 𝟙_ C) :
   rw [← Iso.eq_comp_inv]
   aesop_cat
 
+/-- Universal property of the cartesian product: Maps to `X ⊗ Y` correspond to pairs of maps to `X`
+and to `Y`. -/
+@[simps]
+def homToProd {X Y Z : C} : (Z ⟶ X ⊗ Y) ≃ (Z ⟶ X) × (Z ⟶ Y) where
+  toFun f := ⟨f ≫ fst _ _, f ≫ snd _ _⟩
+  invFun f := lift f.1 f.2
+  left_inv _ := by simp
+  right_inv _ := by simp
+
 section BraidedCategory
 
 variable [BraidedCategory C]

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Basic.lean
@@ -387,7 +387,7 @@ lemma lift_rightUnitor_hom {X Y : C} (f : X ⟶ Y) (g : X ⟶ 𝟙_ C) :
 /-- Universal property of the cartesian product: Maps to `X ⊗ Y` correspond to pairs of maps to `X`
 and to `Y`. -/
 @[simps]
-def homToProd {X Y Z : C} : (Z ⟶ X ⊗ Y) ≃ (Z ⟶ X) × (Z ⟶ Y) where
+def homEquivToProd {X Y Z : C} : (Z ⟶ X ⊗ Y) ≃ (Z ⟶ X) × (Z ⟶ Y) where
   toFun f := ⟨f ≫ fst _ _, f ≫ snd _ _⟩
   invFun f := lift f.1 f.2
   left_inv _ := by simp

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/FunctorCategory.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/FunctorCategory.lean
@@ -180,7 +180,7 @@ noncomputable def tensorObjComp (F G : D ⥤ C) (H : C ⥤ E) [PreservesFinitePr
 @[simps]
 protected def RepresentableBy.tensorObj {F : Cᵒᵖ ⥤ Type v} {G : Cᵒᵖ ⥤ Type v} {X Y : C}
     (h₁ : F.RepresentableBy X) (h₂ : G.RepresentableBy Y) : (F ⊗ G).RepresentableBy (X ⊗ Y) where
-  homEquiv {I} := homToProd.trans (h₁.homEquiv.prodCongr h₂.homEquiv)
+  homEquiv {I} := homEquivToProd.trans (h₁.homEquiv.prodCongr h₂.homEquiv)
   homEquiv_comp {I W} f g := by
     refine Prod.ext ?_ ?_
     · change h₁.homEquiv ((f ≫ g) ≫ fst X Y) = F.map f.op (h₁.homEquiv (g ≫ fst X Y))

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/FunctorCategory.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/FunctorCategory.lean
@@ -19,14 +19,16 @@ namespace CategoryTheory
 open Limits MonoidalCategory Category CartesianMonoidalCategory
 
 universe v
-variable (J C D E : Type*) [Category J] [Category C] [Category D] [Category E]
+variable {J C D E : Type*} [Category J] [Category C] [Category D] [Category E]
   [CartesianMonoidalCategory C] [CartesianMonoidalCategory E]
 
 namespace Functor
 
+variable (J C) in
 /-- The chosen terminal object in `J ⥤ C`. -/
 abbrev chosenTerminal : J ⥤ C := (Functor.const J).obj (𝟙_ C)
 
+variable (J C) in
 /-- The chosen terminal object in `J ⥤ C` is terminal. -/
 def chosenTerminalIsTerminal : IsTerminal (chosenTerminal J C) :=
   evaluationJointlyReflectsLimits _
@@ -34,7 +36,6 @@ def chosenTerminalIsTerminal : IsTerminal (chosenTerminal J C) :=
 
 section
 
-variable {J C D E}
 variable (F₁ F₂ : J ⥤ C)
 
 /-- The chosen binary product on `J ⥤ C`. -/
@@ -72,8 +73,6 @@ instance cartesianMonoidalCategory : CartesianMonoidalCategory (J ⥤ C) :=
 namespace Monoidal
 
 open CartesianMonoidalCategory
-
-variable {J C}
 
 @[simp]
 lemma tensorObj_obj (F₁ F₂ : J ⥤ C) (j : J) : (F₁ ⊗ F₂).obj j = (F₁.obj j) ⊗ (F₂.obj j) := rfl
@@ -171,26 +170,22 @@ instance {K : Type*} [Category K] [HasColimitsOfShape K C]
   exact preservesColimitsOfShape_of_natIso this.symm
 
 /-- A finite-products-preserving functor distributes over the tensor product of functors. -/
+@[simps!]
 noncomputable def tensorObjComp (F G : D ⥤ C) (H : C ⥤ E) [PreservesFiniteProducts H] :
     (F ⊗ G) ⋙ H ≅ (F ⋙ H) ⊗ (G ⋙ H) :=
   NatIso.ofComponents (fun X ↦ prodComparisonIso H (F.obj X) (G.obj X)) fun {X Y} f ↦ by
     dsimp; ext <;> simp [← Functor.map_comp]
 
 /-- A tensor product of representable functors is representable. -/
+@[simps]
 protected def RepresentableBy.tensorObj {F : Cᵒᵖ ⥤ Type v} {G : Cᵒᵖ ⥤ Type v} {X Y : C}
     (h₁ : F.RepresentableBy X) (h₂ : G.RepresentableBy Y) : (F ⊗ G).RepresentableBy (X ⊗ Y) where
   homEquiv {I} := homToProd.trans (h₁.homEquiv.prodCongr h₂.homEquiv)
   homEquiv_comp {I W} f g := by
     refine Prod.ext ?_ ?_
-    · refine (h₁.homEquiv_comp _ _).trans ?_
-      simp
-      change
-        F.map f.op (F.map g.op (h₁.homEquiv (fst X Y))) = F.map f.op (h₁.homEquiv (g ≫ fst X Y))
+    · change h₁.homEquiv ((f ≫ g) ≫ fst X Y) = F.map f.op (h₁.homEquiv (g ≫ fst X Y))
       simp [h₁.homEquiv_comp]
-    · refine (h₂.homEquiv_comp _ _).trans ?_
-      simp
-      change
-        G.map f.op (G.map g.op (h₂.homEquiv (snd X Y))) = G.map f.op (h₂.homEquiv (g ≫ snd X Y))
+    · change h₂.homEquiv ((f ≫ g) ≫ snd X Y) = G.map f.op (h₂.homEquiv (g ≫ snd X Y))
       simp [h₂.homEquiv_comp]
 
 end Monoidal


### PR DESCRIPTION
From Toric


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
