### PR TITLE
[Merged by Bors] - feat: coin problem with two coins and prime ideals in ℕ 

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5303,6 +5303,7 @@ import Mathlib.RingTheory.Ideal.Maps
 import Mathlib.RingTheory.Ideal.Maximal
 import Mathlib.RingTheory.Ideal.MinimalPrime.Basic
 import Mathlib.RingTheory.Ideal.MinimalPrime.Localization
+import Mathlib.RingTheory.Ideal.NatInt
 import Mathlib.RingTheory.Ideal.Nonunits
 import Mathlib.RingTheory.Ideal.Norm.AbsNorm
 import Mathlib.RingTheory.Ideal.Norm.RelNorm

--- a/Mathlib/Algebra/Order/Ring/Int.lean
+++ b/Mathlib/Algebra/Order/Ring/Int.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jeremy Avigad
+Authors: Jeremy Avigad, Emirhan Duysak, Adem Alp Gök, Junyan Xu
 -/
 import Mathlib.Algebra.Order.Group.Int
 import Mathlib.Algebra.Order.Group.Unbundled.Int

--- a/Mathlib/Algebra/Order/Ring/Int.lean
+++ b/Mathlib/Algebra/Order/Ring/Int.lean
@@ -7,6 +7,8 @@ import Mathlib.Algebra.Order.Group.Int
 import Mathlib.Algebra.Order.Group.Unbundled.Int
 import Mathlib.Algebra.Order.Ring.Defs
 import Mathlib.Algebra.Ring.Int.Parity
+import Mathlib.Data.Int.GCD
+import Mathlib.Data.Nat.Cast.Order.Basic
 import Mathlib.Order.BooleanAlgebra.Set
 
 /-!
@@ -51,3 +53,39 @@ lemma add_two_le_iff_lt_of_even_sub {m n : ℤ} (even : Even (n - m)) : m + 2 �
   rw [add_comm]; exact le_add_iff_lt_of_dvd_sub (by decide) even.two_dvd
 
 end Int
+
+/-- If the gcd of two natural numbers `p` and `q` divides a third natural number `n`,
+and if `n` is at least `(p - 1) * (q - 1)`, then `n` can be represented as an `ℕ`-linear
+combination of `p` and `q`.
+
+TODO: show that if `p.gcd q = 1` and `0 ≤ n ≤ (p - 1) * (q - 1) - 1 = N`, then `n` is
+representable iff `N - n` is not. In particular `N` is not representable, solving the
+coin problem for two coins: https://en.wikipedia.org/wiki/Coin_problem#n_=_2. -/
+theorem Nat.exists_add_mul_eq_of_gcd_dvd_of_mul_pred_le (p q n : ℕ) (dvd : p.gcd q ∣ n)
+    (le : p.pred * q.pred ≤ n) : ∃ a b : ℕ, a * p + b * q = n := by
+  obtain _ | p := p
+  · have ⟨b, eq⟩ := q.gcd_zero_left ▸ dvd
+    exact ⟨0, b, by simpa [mul_comm, eq_comm] using eq⟩
+  obtain _ | q := q
+  · have ⟨a, eq⟩ := p.gcd_zero_right ▸ dvd
+    exact ⟨a, 0, by simpa [mul_comm, eq_comm] using eq⟩
+  rw [← Int.gcd_natCast_natCast, Int.gcd_dvd_iff] at dvd
+  have ⟨a_n, b_n, eq⟩ := dvd
+  let a := a_n % q.succ
+  let b := b_n + a_n / q.succ * p.succ
+  refine ⟨a.toNat, b.toNat, Nat.cast_injective (R := ℤ) ?_⟩
+  have : a * p.succ + b * q.succ = n := by rw [add_mul, ← add_assoc,
+    add_right_comm, mul_right_comm, ← add_mul, Int.emod_add_ediv', eq, mul_comm, mul_comm b_n]
+  rw [Nat.cast_add, Nat.cast_mul, Nat.cast_mul, Int.natCast_toNat_eq_self.mpr
+    (Int.emod_nonneg _ <| by omega), Int.natCast_toNat_eq_self.mpr, this]
+  -- show b ≥ 0 by contradiction
+  by_contra hb
+  replace hb : b ≤ -1 := by omega
+  apply lt_irrefl (n : ℤ)
+  have ha := Int.emod_lt a_n (by omega : (q.succ : ℤ) ≠ 0)
+  rw [p.pred_succ, q.pred_succ] at le
+  calc n = a * p.succ + b * q.succ := this.symm
+       _ ≤ q * p.succ + -1 * q.succ := by gcongr <;> omega
+       _ = p * q - 1 := by simp_rw [Nat.cast_succ, mul_add, mul_comm]; omega
+       _ ≤ n - 1 := by rwa [sub_le_sub_iff_right, ← Nat.cast_mul, Nat.cast_le]
+       _ < n := by omega

--- a/Mathlib/Data/Nat/Prime/Basic.lean
+++ b/Mathlib/Data/Nat/Prime/Basic.lean
@@ -85,6 +85,10 @@ theorem not_prime_iff_exists_dvd_ne {n : ℕ} (h : 2 ≤ n) : (¬Prime n) ↔ �
 theorem not_prime_iff_exists_dvd_lt {n : ℕ} (h : 2 ≤ n) : (¬Prime n) ↔ ∃ m, m ∣ n ∧ 2 ≤ m ∧ m < n :=
   ⟨exists_dvd_of_not_prime2 h, fun ⟨_, h1, h2, h3⟩ => not_prime_of_dvd_of_lt h1 h2 h3⟩
 
+theorem not_prime_iff_exists_mul_eq {n : ℕ} (h : 2 ≤ n) :
+    (¬Prime n) ↔ ∃ a b, a < n ∧ b < n ∧ a * b = n := by
+  rw [prime_iff_not_exists_mul_eq, and_iff_right h, Classical.not_not]
+
 theorem dvd_of_forall_prime_mul_dvd {a b : ℕ}
     (hdvd : ∀ p : ℕ, p.Prime → p ∣ a → p * a ∣ b) : a ∣ b := by
   obtain rfl | ha := eq_or_ne a 1

--- a/Mathlib/Data/Nat/Prime/Defs.lean
+++ b/Mathlib/Data/Nat/Prime/Defs.lean
@@ -137,6 +137,17 @@ theorem prime_def_le_sqrt {p : ℕ} : Prime p ↔ 2 ≤ p ∧ ∀ m, 2 ≤ m →
           refine this km (Nat.lt_of_mul_lt_mul_right (a := m) ?_) e
           rwa [one_mul, ← e]⟩
 
+theorem prime_iff_not_exists_mul_eq {p : ℕ} :
+    p.Prime ↔ 2 ≤ p ∧ ¬ ∃ m n, m < p ∧ n < p ∧ m * n = p := by
+  push_neg
+  simp_rw [prime_def_lt, dvd_def, exists_imp]
+  refine and_congr_right fun hp ↦ forall_congr' fun m ↦ (forall_congr' fun h ↦ ?_).trans forall_comm
+  simp_rw [Ne, forall_comm (β := _ = _), eq_comm, imp_false, not_lt]
+  refine forall₂_congr fun n hp ↦ ⟨by aesop, fun hpn ↦ ?_⟩
+  have := mul_ne_zero_iff.mp (hp ▸ show p ≠ 0 by omega)
+  exact (Nat.mul_eq_right (by omega)).mp
+    (hp.symm.trans (hpn.antisymm (hp ▸ Nat.le_mul_of_pos_left _ (by omega))))
+
 theorem prime_of_coprime (n : ℕ) (h1 : 1 < n) (h : ∀ m < n, m ≠ 0 → n.Coprime m) : Prime n := by
   refine prime_def_lt.mpr ⟨h1, fun m mlt mdvd => ?_⟩
   have hm : m ≠ 0 := by

--- a/Mathlib/RingTheory/Ideal/Maximal.lean
+++ b/Mathlib/RingTheory/Ideal/Maximal.lean
@@ -216,6 +216,27 @@ theorem exists_le_prime_notMem_of_isIdempotentElem (a : α) (ha : IsIdempotentEl
 @[deprecated (since := "2025-05-24")]
 alias exists_le_prime_nmem_of_isIdempotentElem := exists_le_prime_notMem_of_isIdempotentElem
 
+section IsPrincipalIdealRing
+
+variable [IsPrincipalIdealRing α]
+
+theorem isPrime_iff_of_isPrincipalIdealRing {P : Ideal α} (hP : P ≠ ⊥) :
+    P.IsPrime ↔ ∃ p, Prime p ∧ P = span {p} where
+  mp h := by
+    obtain ⟨p, rfl⟩ := Submodule.IsPrincipal.principal P
+    exact ⟨p, (span_singleton_prime (by simp [·] at hP)).mp h, rfl⟩
+  mpr := by
+    rintro ⟨p, hp, rfl⟩
+    rwa [span_singleton_prime (by simp [hp.ne_zero])]
+
+theorem isPrime_iff_of_isPrincipalIdealRing_of_noZeroDivisors [NoZeroDivisors α] [Nontrivial α]
+    {P : Ideal α} : P.IsPrime ↔ P = ⊥ ∨ ∃ p, Prime p ∧ P = span {p} := by
+  rw [or_iff_not_imp_left, ← forall_congr' isPrime_iff_of_isPrincipalIdealRing,
+    ← or_iff_not_imp_left, or_iff_right_of_imp]
+  rintro rfl; exact bot_prime
+
+end IsPrincipalIdealRing
+
 end Ideal
 
 end CommSemiring

--- a/Mathlib/RingTheory/Ideal/NatInt.lean
+++ b/Mathlib/RingTheory/Ideal/NatInt.lean
@@ -1,0 +1,84 @@
+/-
+Copyright (c) 2025 Junyan Xu. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Junyan Xu
+-/
+import Mathlib.Algebra.Order.Ring.Int
+import Mathlib.Data.Nat.Prime.Int
+import Mathlib.RingTheory.LocalRing.MaximalIdeal.Basic
+
+/-!
+# Prime ideals in ℕ and ℤ
+
+## Main results
+
+* `Ideal.isPrime_nat_iff`: the prime ideals in ℕ are ⟨0⟩, ⟨p⟩ (for prime `p`), and ⟨2, 3⟩ = {1}ᶜ.
+  The proof follows https://math.stackexchange.com/a/4224486.
+
+* `Ideal.isPrime_int_iff` : the prime ideals in ℤ are ⟨0⟩ and ⟨p⟩ (for prime `p`).
+-/
+
+/-- The natural numbers form a local semiring. -/
+instance : IsLocalRing ℕ where
+  isUnit_or_isUnit_of_add_one {a b} hab := by
+    have h : a = 1 ∨ b = 1 := by omega
+    apply h.imp <;> simp +contextual
+
+open IsLocalRing Ideal
+
+theorem Nat.mem_maximalIdeal_iff {n : ℕ} : n ∈ maximalIdeal ℕ ↔ n ≠ 1 := by simp
+
+theorem Nat.coe_maximalIdeal : (maximalIdeal ℕ : Set ℕ) = {1}ᶜ := by ext; simp
+
+theorem Nat.maximalIdeal_eq_span_two_three : maximalIdeal ℕ = .span {2, 3} := by
+  refine le_antisymm (fun n h ↦ ?_) (span_le.mpr <| Set.pair_subset (by simp) (by simp))
+  obtain lt | lt := (mem_maximalIdeal_iff.mp h).lt_or_gt
+  · obtain rfl := lt_one_iff.mp lt; exact zero_mem _
+  exact mem_span_pair.mpr <|
+    exists_add_mul_eq_of_gcd_dvd_of_mul_pred_le 2 3 n (by simp) (show 2 ≤ n by omega)
+
+theorem Ideal.isPrime_nat_iff {P : Ideal ℕ} :
+    P.IsPrime ↔ P = ⊥ ∨ P = maximalIdeal ℕ ∨ ∃ p : ℕ, p.Prime ∧ P = span {p} := by
+  refine .symm ⟨?_, fun h ↦ or_iff_not_imp_left.mpr fun h0 ↦ or_iff_not_imp_right.mpr fun hsp ↦
+    (le_maximalIdeal h.ne_top).antisymm fun n hn ↦ ?_⟩
+  · rintro (rfl | rfl | ⟨p, hp, rfl⟩)
+    · exact bot_prime
+    · exact (maximalIdeal.isMaximal ℕ).isPrime
+    · rwa [span_singleton_prime (by simp [hp.ne_zero]), ← Nat.prime_iff]
+  rw [← le_bot_iff, SetLike.not_le_iff_exists] at h0
+  classical
+  let p := Nat.find h0
+  have ⟨(hp : p ∈ P), (hp0 : p ≠ 0)⟩ := Nat.find_spec h0
+  have : p ≠ 1 := ne_of_mem_of_not_mem hp P.one_notMem
+  have prime : p.Prime := Nat.prime_iff_not_exists_mul_eq.mpr <| .intro (by omega)
+    fun ⟨m, n, hm, hn, eq⟩ ↦ have := mul_ne_zero_iff.mp (eq ▸ hp0)
+    (h.mem_or_mem (eq ▸ hp)).elim (Nat.find_min h0 hm ⟨·, this.1⟩) (Nat.find_min h0 hn ⟨·, this.2⟩)
+  push_neg at hsp
+  have ⟨q, hq, hqp⟩ := SetLike.exists_of_lt
+    ((P.span_singleton_le_iff_mem.mpr hp).lt_of_ne (hsp p prime).symm)
+  obtain rfl | hn1 := eq_or_ne n 0
+  · exact Ideal.zero_mem _
+  have : n ≠ 1 := Nat.mem_maximalIdeal_iff.mp hn
+  have ⟨a, b, eq⟩ := Nat.exists_add_mul_eq_of_gcd_dvd_of_mul_pred_le p q _
+    (by simp [prime.coprime_iff_not_dvd.mpr (Ideal.mem_span_singleton.not.mp hqp)])
+    (Nat.lt_pow_self (show 1 < n by omega)).le
+  exact h.mem_of_pow_mem _ (eq ▸ add_mem (P.mul_mem_left _ hp) (P.mul_mem_left _ hq))
+
+theorem Ideal.map_comap_natCastRingHom_int {I : Ideal ℤ} :
+    (I.comap (Nat.castRingHom ℤ)).map (Nat.castRingHom ℤ) = I :=
+  map_comap_le.antisymm fun n hn ↦ n.sign_mul_natAbs ▸ mul_mem_left _ _ <| mem_map_of_mem _
+    (mem_comap.mpr <| show (n.natAbs : ℤ) ∈ I from n.sign_mul_self ▸ mul_mem_left _ _ hn)
+
+theorem Ideal.isPrime_int_iff {P : Ideal ℤ} :
+    P.IsPrime ↔ P = ⊥ ∨ ∃ p : ℕ, p.Prime ∧ P = span {(p : ℤ)} := by
+  refine .symm ⟨?_, fun h ↦ ?_⟩
+  · rintro (rfl | ⟨p, hp, rfl⟩)
+    · exact bot_prime
+    rwa [span_singleton_prime (by simp [hp.ne_zero]), ← Nat.prime_iff_prime_int]
+  rw [← P.map_comap_natCastRingHom_int]
+  obtain hP | hP := isPrime_nat_iff.mp (h.comap (Nat.castRingHom ℤ))
+  · exact .inl (by rw [hP, map_bot])
+  have ⟨p, hp, hP⟩ := hP.resolve_left fun hP ↦ by
+    rw [← P.map_comap_natCastRingHom_int, hP, Nat.maximalIdeal_eq_span_two_three, map_span] at h
+    exact h.one_notMem (Set.image_pair .. ▸ mem_span_pair.mpr ⟨-1, 1, rfl⟩)
+  exact .inr ⟨p, hp, by rw [hP, map_span, Set.image_singleton, Nat.coe_castRingHom]⟩

--- a/Mathlib/RingTheory/KrullDimension/Basic.lean
+++ b/Mathlib/RingTheory/KrullDimension/Basic.lean
@@ -5,11 +5,11 @@ Authors: Fangming Li, Jujian Zhang
 -/
 import Mathlib.Algebra.MvPolynomial.CommRing
 import Mathlib.Algebra.Polynomial.Basic
+import Mathlib.Order.KrullDimension
 import Mathlib.RingTheory.Ideal.Quotient.Defs
 import Mathlib.RingTheory.Ideal.MinimalPrime.Basic
 import Mathlib.RingTheory.Jacobson.Radical
 import Mathlib.RingTheory.Spectrum.Prime.Basic
-import Mathlib.Order.KrullDimension
 
 /-!
 # Krull dimensions of (commutative) rings


### PR DESCRIPTION
This is the outcome of a course project at Heidelberg University: https://matematiflo.github.io/CompAssistedMath2025/

+ If the gcd of two natural numbers `p` and `q` divides a third natural number `n`, and if `n` is at least `(p - 1) * (q - 1)`, then `n` can be represented as an `ℕ`-linear combination of `p` and `q`; in other words, one can pay the amount `n` using coins of value `p` and `q`.

+ As a consequence, the prime ideals in ℕ are 0, ⟨p⟩, and {1}ᶜ.

Co-authored-by: Adem Alp Gök @adem-goek
Co-authored-by: Emirhan Duysak @duysex
Co-authored-by: Johan Commelin @jcommelin (for `IsLocalRing ℕ`)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
