### PR TITLE
[Merged by Bors] - feat: `(vecMulVec _ _).rank ≤ 1`

### DIFF
--- a/Mathlib/Analysis/Normed/Module/FiniteDimension.lean
+++ b/Mathlib/Analysis/Normed/Module/FiniteDimension.lean
@@ -14,6 +14,7 @@ import Mathlib.Logic.Encodable.Pi
 import Mathlib.Topology.Algebra.Module.FiniteDimension
 import Mathlib.Topology.Algebra.InfiniteSum.Module
 import Mathlib.Topology.Instances.Matrix
+import Mathlib.LinearAlgebra.Dimension.LinearMap
 
 /-!
 # Finite dimensional normed spaces over complete fields

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -41,6 +41,10 @@ variable [Semiring R]
 /-- The rank of a matrix, defined as the dimension of its column space, as a cardinal. -/
 noncomputable def cRank (A : Matrix m n R) : Cardinal := Module.rank R <| span R <| range Aᵀ
 
+@[simp]
+theorem cRank_subsingleton [Subsingleton R] (A : Matrix m n R) : A.cRank = 1 :=
+  rank_subsingleton _ _
+
 lemma cRank_toNat_eq_finrank (A : Matrix m n R) :
     A.cRank.toNat = Module.finrank R (span R (range A.col)) := rfl
 
@@ -73,6 +77,10 @@ lemma cRank_le_card_width [StrongRankCondition R] [Fintype n] (A : Matrix m n R)
 
 /-- The rank of a matrix, defined as the dimension of its column space, as a term in `ℕ∞`. -/
 noncomputable def eRank (A : Matrix m n R) : ℕ∞ := A.cRank.toENat
+
+@[simp]
+theorem eRank_subsingleton [Subsingleton R] (A : Matrix m n R) : A.eRank = 1 := by
+  simp [eRank]
 
 lemma eRank_toNat_eq_finrank (A : Matrix m n R) :
     A.eRank.toNat = Module.finrank R (span R (range A.col)) :=
@@ -110,20 +118,23 @@ noncomputable def rank (A : Matrix m n R) : ℕ :=
   finrank R <| LinearMap.range A.mulVecLin
 
 @[simp]
-theorem cRank_one [StrongRankCondition R] [DecidableEq m] :
+theorem rank_subsingleton [Subsingleton R] (A : Matrix m n R) : A.rank = 1 :=
+  finrank_subsingleton
+
+@[simp]
+theorem cRank_one [Nontrivial R] [DecidableEq m] :
     (cRank (1 : Matrix m m R)) = lift.{uR} #m := by
-  have := nontrivial_of_invariantBasisNumber R
   have h : LinearIndependent R (1 : Matrix m m R)ᵀ := by
     convert Pi.linearIndependent_single_one m R
     simp [funext_iff, Matrix.one_eq_pi_single]
   rw [cRank, rank_span h, ← lift_umax, ← Cardinal.mk_range_eq_of_injective h.injective, lift_id']
 
-@[simp] theorem eRank_one [StrongRankCondition R] [DecidableEq m] :
+@[simp] theorem eRank_one [Nontrivial R] [DecidableEq m] :
     (eRank (1 : Matrix m m R)) = ENat.card m := by
   rw [eRank, cRank_one, toENat_lift, ENat.card]
 
 @[simp]
-theorem rank_one [StrongRankCondition R] [DecidableEq n] :
+theorem rank_one [Nontrivial R] [DecidableEq n] :
     rank (1 : Matrix n n R) = Fintype.card n := by
   rw [rank, mulVecLin_one, LinearMap.range_id, finrank_top, finrank_pi]
 
@@ -141,38 +152,40 @@ theorem cRank_zero {m n : Type*} [Nontrivial R] : cRank (0 : Matrix m n R) = 0 :
 theorem eRank_zero {m n : Type*} [Nontrivial R] : eRank (0 : Matrix m n R) = 0 := by
   simp [eRank]
 
-theorem rank_le_card_width [StrongRankCondition R] (A : Matrix m n R) :
+theorem rank_le_card_width [Nontrivial R] (A : Matrix m n R) :
     A.rank ≤ Fintype.card n := by
   haveI : Module.Finite R (n → R) := Module.Finite.pi
   haveI : Module.Free R (n → R) := Module.Free.pi _ _
   exact A.mulVecLin.finrank_range_le.trans_eq (finrank_pi _)
 
-theorem rank_le_width [StrongRankCondition R] {m n : ℕ} (A : Matrix (Fin m) (Fin n) R) :
+theorem rank_le_width [Nontrivial R] {m n : ℕ} (A : Matrix (Fin m) (Fin n) R) :
     A.rank ≤ n :=
   A.rank_le_card_width.trans <| (Fintype.card_fin n).le
 
-theorem rank_mul_le_left [StrongRankCondition R] (A : Matrix m n R) (B : Matrix n o R) :
+theorem rank_mul_le_left (A : Matrix m n R) (B : Matrix n o R) :
     (A * B).rank ≤ A.rank := by
+  nontriviality R
   rw [rank, rank, mulVecLin_mul]
   exact Cardinal.toNat_le_toNat (LinearMap.rank_comp_le_left _ _) (rank_lt_aleph0 _ _)
 
-theorem rank_mul_le_right [StrongRankCondition R] (A : Matrix m n R) (B : Matrix n o R) :
+theorem rank_mul_le_right (A : Matrix m n R) (B : Matrix n o R) :
     (A * B).rank ≤ B.rank := by
+  nontriviality R
   rw [rank, rank, mulVecLin_mul]
   exact finrank_le_finrank_of_rank_le_rank (LinearMap.lift_rank_comp_le_right _ _)
     (rank_lt_aleph0 _ _)
 
-theorem rank_mul_le [StrongRankCondition R] (A : Matrix m n R) (B : Matrix n o R) :
+theorem rank_mul_le (A : Matrix m n R) (B : Matrix n o R) :
     (A * B).rank ≤ min A.rank B.rank :=
   le_min (rank_mul_le_left _ _) (rank_mul_le_right _ _)
 
-theorem rank_unit [StrongRankCondition R] [DecidableEq n] (A : (Matrix n n R)ˣ) :
+theorem rank_unit [Nontrivial R] [DecidableEq n] (A : (Matrix n n R)ˣ) :
     (A : Matrix n n R).rank = Fintype.card n := by
   apply le_antisymm (rank_le_card_width (A : Matrix n n R)) _
   have := rank_mul_le_left (A : Matrix n n R) (↑A⁻¹ : Matrix n n R)
   rwa [← Units.val_mul, mul_inv_cancel, Units.val_one, rank_one] at this
 
-theorem rank_of_isUnit [StrongRankCondition R] [DecidableEq n] (A : Matrix n n R) (h : IsUnit A) :
+theorem rank_of_isUnit [Nontrivial R] [DecidableEq n] (A : Matrix n n R) (h : IsUnit A) :
     A.rank = Fintype.card n := by
   obtain ⟨A, rfl⟩ := h
   exact rank_unit A
@@ -201,7 +214,7 @@ lemma rank_mul_eq_right_of_isUnit_det [Fintype m] [DecidableEq m]
 
 omit [Fintype n] in
 /-- Taking a subset of the rows and permuting the columns reduces the rank. -/
-theorem rank_submatrix_le [StrongRankCondition R] [Fintype m] [Fintype m₀] (f : n₀ → n) (e : m₀ ≃ m)
+theorem rank_submatrix_le [Nontrivial R] [Fintype m] [Fintype m₀] (f : n₀ → n) (e : m₀ ≃ m)
     (A : Matrix n m R) : rank (A.submatrix f e) ≤ rank A := by
   rw [rank, rank, mulVecLin_submatrix, LinearMap.range_comp, LinearMap.range_comp,
     show LinearMap.funLeft R R e.symm = LinearEquiv.funCongrLeft R R e.symm from rfl,
@@ -270,13 +283,13 @@ theorem rank_eq_finrank_range_toLin [Finite m] [DecidableEq n] {M₁ M₂ : Type
   simp only [e₁, e₂, LinearMap.comp_apply, LinearEquiv.coe_coe, Equiv.refl_apply,
     aux₁, aux₂, LinearMap.coe_single, toLin_self, map_sum, LinearEquiv.map_smul, Basis.equiv_apply]
 
-theorem rank_le_card_height [Fintype m] [StrongRankCondition R] (A : Matrix m n R) :
+theorem rank_le_card_height [Fintype m] [Nontrivial R] (A : Matrix m n R) :
     A.rank ≤ Fintype.card m := by
   haveI : Module.Finite R (m → R) := Module.Finite.pi
   haveI : Module.Free R (m → R) := Module.Free.pi _ _
   exact (Submodule.finrank_le _).trans (finrank_pi R).le
 
-theorem rank_le_height [StrongRankCondition R] {m n : ℕ} (A : Matrix (Fin m) (Fin n) R) :
+theorem rank_le_height [Nontrivial R] {m n : ℕ} (A : Matrix (Fin m) (Fin n) R) :
     A.rank ≤ m :=
   A.rank_le_card_height.trans <| (Fintype.card_fin m).le
 

--- a/Mathlib/Data/Matrix/Rank.lean
+++ b/Mathlib/Data/Matrix/Rank.lean
@@ -179,6 +179,12 @@ theorem rank_mul_le (A : Matrix m n R) (B : Matrix n o R) :
     (A * B).rank ≤ min A.rank B.rank :=
   le_min (rank_mul_le_left _ _) (rank_mul_le_right _ _)
 
+theorem rank_vecMulVec_le (w : m → R) (v : n → R) : (Matrix.vecMulVec w v).rank ≤ 1 := by
+  rw [Matrix.vecMulVec_eq Unit]
+  refine le_trans (rank_mul_le_left _ _) ?_
+  nontriviality R
+  exact rank_le_card_width _
+
 theorem rank_unit [Nontrivial R] [DecidableEq n] (A : (Matrix n n R)ˣ) :
     (A : Matrix n n R).rank = Fintype.card n := by
   apply le_antisymm (rank_le_card_width (A : Matrix n n R)) _
@@ -454,3 +460,12 @@ lemma rank_add_rank_le_card_of_mul_eq_zero [Field R] [Finite l] [Fintype m]
   rw [LinearMap.range_le_ker_iff, ← Matrix.toLin_mul, hAB, map_zero]
 
 end Matrix
+
+-- TODO: generalize to `cRank` then deprecate
+theorem Matrix.rank_vecMulVec.{u} {K m n : Type u} [CommRing K] [Fintype n]
+    [DecidableEq n] (w : m → K) (v : n → K) : (Matrix.vecMulVec w v).toLin'.rank ≤ 1 := by
+  nontriviality K
+  rw [Matrix.vecMulVec_eq (Fin 1), Matrix.toLin'_mul]
+  refine le_trans (LinearMap.rank_comp_le_left _ _) ?_
+  refine (LinearMap.rank_le_domain _).trans_eq ?_
+  rw [rank_fun', Fintype.card_ofSubsingleton, Nat.cast_one]

--- a/Mathlib/LinearAlgebra/Dimension/Finrank.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Finrank.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Anne Baanen
 -/
-import Mathlib.LinearAlgebra.Dimension.Basic
+import Mathlib.LinearAlgebra.Dimension.Subsingleton
 import Mathlib.SetTheory.Cardinal.ToNat
 
 /-!
@@ -57,6 +57,9 @@ Note that if `R` is not a field then there can exist modules `M` with `¬(Module
 `ℤ`-linearly independent subsets of `ℚ` are precisely the nonzero singletons. -/
 noncomputable def finrank (R M : Type*) [Semiring R] [AddCommMonoid M] [Module R M] : ℕ :=
   Cardinal.toNat (Module.rank R M)
+
+@[simp] theorem finrank_subsingleton [Subsingleton R] : finrank R M = 1 := by
+  rw [finrank, rank_subsingleton, map_one]
 
 theorem finrank_eq_of_rank_eq {n : ℕ} (h : Module.rank R M = ↑n) : finrank R M = n := by
   simp [finrank, h]

--- a/Mathlib/LinearAlgebra/FreeModule/Finite/Matrix.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Finite/Matrix.lean
@@ -3,9 +3,8 @@ Copyright (c) 2021 Riccardo Brasca. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Riccardo Brasca
 -/
-import Mathlib.LinearAlgebra.Dimension.LinearMap
 import Mathlib.LinearAlgebra.FreeModule.StrongRankCondition
-import Mathlib.LinearAlgebra.Matrix.ToLin
+import Mathlib.LinearAlgebra.Dimension.Finite
 
 /-!
 # Finite and free modules using matrices

--- a/Mathlib/LinearAlgebra/FreeModule/Finite/Matrix.lean
+++ b/Mathlib/LinearAlgebra/FreeModule/Finite/Matrix.lean
@@ -106,11 +106,3 @@ instance Module.Free.addMonoidHom [Module.Free ℤ N] : Module.Free ℤ (M →+ 
   Module.Free.of_equiv (addMonoidHomLequivInt ℤ).symm
 
 end Integer
-
-theorem Matrix.rank_vecMulVec {K m n : Type u} [CommRing K] [Fintype n]
-    [DecidableEq n] (w : m → K) (v : n → K) : (Matrix.vecMulVec w v).toLin'.rank ≤ 1 := by
-  nontriviality K
-  rw [Matrix.vecMulVec_eq (Fin 1), Matrix.toLin'_mul]
-  refine le_trans (LinearMap.rank_comp_le_left _ _) ?_
-  refine (LinearMap.rank_le_domain _).trans_eq ?_
-  rw [rank_fun', Fintype.card_ofSubsingleton, Nat.cast_one]

--- a/Mathlib/LinearAlgebra/Matrix/FiniteDimensional.lean
+++ b/Mathlib/LinearAlgebra/Matrix/FiniteDimensional.lean
@@ -6,7 +6,6 @@ Authors: Johannes Hölzl, Patrick Massot, Casper Putz, Anne Baanen
 import Mathlib.Data.Matrix.Basic
 import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 import Mathlib.LinearAlgebra.FreeModule.Finite.Matrix
-import Mathlib.LinearAlgebra.Matrix.ToLin
 
 /-!
 # The finite-dimensional space of matrices


### PR DESCRIPTION
We had a copy of this already for `.toLin'.rank`, but we leave deprecating this until we have a better replacement.

Discussed in [#new members > Is this a reasonable formalization? @ 💬](https://leanprover.zulipchat.com/#narrow/channel/113489-new-members/topic/Is.20this.20a.20reasonable.20formalization.3F/near/528413552)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->
- [x] depends on: #27074

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
