### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Limits/Shapes/End): functoriality of (co)ends

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Shapes/End.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/End.lean
@@ -242,6 +242,8 @@ lemma end_.map_id : end_.map (𝟙 F) = 𝟙 _ := by aesop_cat
 end
 
 variable (J C) in
+/-- If all bifunctors `Jᵒᵖ ⥤ J ⥤ C` have an end, then the construction
+`F ↦ end_ F` defines a functor `(Jᵒᵖ ⥤ J ⥤ C) ⥤ C`. -/
 @[simps]
 noncomputable def endFunctor [∀ (F : Jᵒᵖ ⥤ J ⥤ C), HasEnd F] :
     (Jᵒᵖ ⥤ J ⥤ C) ⥤ C where
@@ -313,6 +315,8 @@ lemma coend.map_id : coend.map (𝟙 F) = 𝟙 _ := by aesop_cat
 end
 
 variable (J C) in
+/-- If all bifunctors `Jᵒᵖ ⥤ J ⥤ C` have a coend, then the construction
+`F ↦ coend F` defines a functor `(Jᵒᵖ ⥤ J ⥤ C) ⥤ C`. -/
 @[simps]
 noncomputable def coendFunctor [∀ (F : Jᵒᵖ ⥤ J ⥤ C), HasCoend F] :
     (Jᵒᵖ ⥤ J ⥤ C) ⥤ C where

--- a/Mathlib/CategoryTheory/Limits/Shapes/End.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/End.lean
@@ -216,13 +216,42 @@ noncomputable def end_.lift : X ⟶ end_ F :=
 lemma end_.lift_π (j : J) : lift f hf ≫ π F j = f j := by
   apply IsLimit.fac
 
+variable {F' : Jᵒᵖ ⥤ J ⥤ C} [HasEnd F'] (f : F ⟶ F')
+
+/-- A natural transformation of functors F ⟶ F' induces a map end_ F ⟶ end_ F'. -/
+noncomputable def end_.map : end_ F ⟶ end_ F' :=
+  end_.lift (fun x ↦ end_.π _ _ ≫ (f.app (op x)).app x) (fun j j' φ ↦ by
+    have e := (f.app (op j)).naturality φ
+    simp only [Category.assoc]
+    rw [← e, reassoc_of% end_.condition F φ]
+    simp)
+
+@[reassoc (attr := simp)]
+lemma end_.map_π (j : J) :
+    end_.map f ≫ end_.π F' j = end_.π _ _ ≫ (f.app (op j)).app j := by
+  simp [end_.map]
+
+@[reassoc (attr := simp)]
+lemma end_.map_comp {F'' : Jᵒᵖ ⥤ J ⥤ C} [HasEnd F''] (g : F' ⟶ F'') :
+    end_.map f ≫ end_.map g = end_.map (f ≫ g) := by
+  aesop_cat
+
+@[simp]
+lemma end_.map_id : end_.map (𝟙 F) = 𝟙 _ := by aesop_cat
+
 end
+
+@[simps]
+noncomputable def endFunctor [∀ (F : Jᵒᵖ ⥤ J ⥤ C), HasEnd F] :
+    (Jᵒᵖ ⥤ J ⥤ C) ⥤ C where
+  obj F := end_ F
+  map f := end_.map f
 
 end End
 
 section Coend
 
-/-- Given `F : Jᵒᵖ ⥤ J ⥤ C`, this property asserts the existence of the end of `F`. -/
+/-- Given `F : Jᵒᵖ ⥤ J ⥤ C`, this property asserts the existence of the coend of `F`. -/
 abbrev HasCoend := HasMulticoequalizer (multispanIndexCoend F)
 
 variable [HasCoend F]
@@ -252,7 +281,7 @@ section
 variable {X : C} (f : ∀ j, (F.obj (op j)).obj j ⟶ X)
   (hf : ∀ ⦃i j : J⦄ (g : i ⟶ j), (F.map g.op).app i ≫ f i = (F.obj (op j)).map g ≫ f j)
 
-/-- Constructor for morphisms to the end of a functor. -/
+/-- Constructor for morphisms to the coend of a functor. -/
 noncomputable def coend.desc : coend F ⟶ X :=
   Cowedge.IsColimit.desc (colimit.isColimit _) f hf
 
@@ -260,7 +289,33 @@ noncomputable def coend.desc : coend F ⟶ X :=
 lemma coend.ι_desc (j : J) : ι F j ≫ desc f hf = f j := by
   apply IsColimit.fac
 
+variable {F' : Jᵒᵖ ⥤ J ⥤ C} [HasCoend F'] (f : F ⟶ F')
+
+/-- A natural transformation of functors F ⟶ F' induces a map coend F ⟶ coend F'. -/
+noncomputable def coend.map : coend F ⟶ coend F' :=
+  coend.desc (fun x ↦ (f.app (op x)).app x ≫ coend.ι _ _ ) (fun j j' φ ↦ by
+    simp [coend.condition])
+
+@[reassoc (attr := simp)]
+lemma coend.ι_map (j : J) :
+    coend.ι _ _ ≫ coend.map f = (f.app (op j)).app j ≫ coend.ι _ _ := by
+  simp [coend.map]
+
+@[reassoc (attr := simp)]
+lemma coend.map_comp {F'' : Jᵒᵖ ⥤ J ⥤ C} [HasCoend F''] (g : F' ⟶ F'') :
+    coend.map f ≫ coend.map g = coend.map (f ≫ g) := by
+  aesop_cat
+
+@[simp]
+lemma coend.map_id : coend.map (𝟙 F) = 𝟙 _ := by aesop_cat
+
 end
+
+@[simps]
+noncomputable def coendFunctor [∀ (F : Jᵒᵖ ⥤ J ⥤ C), HasCoend F] :
+    (Jᵒᵖ ⥤ J ⥤ C) ⥤ C where
+  obj F := coend F
+  map f := coend.map f
 
 end Coend
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/End.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/End.lean
@@ -241,6 +241,7 @@ lemma end_.map_id : end_.map (𝟙 F) = 𝟙 _ := by aesop_cat
 
 end
 
+variable (J C) in
 @[simps]
 noncomputable def endFunctor [∀ (F : Jᵒᵖ ⥤ J ⥤ C), HasEnd F] :
     (Jᵒᵖ ⥤ J ⥤ C) ⥤ C where
@@ -311,6 +312,7 @@ lemma coend.map_id : coend.map (𝟙 F) = 𝟙 _ := by aesop_cat
 
 end
 
+variable (J C) in
 @[simps]
 noncomputable def coendFunctor [∀ (F : Jᵒᵖ ⥤ J ⥤ C), HasCoend F] :
     (Jᵒᵖ ⥤ J ⥤ C) ⥤ C where


### PR DESCRIPTION
We define basic functoriality properties of the construction `F ↦ end_ F`, and bundle it as a functor whenever all ends exist.

The same is done for coends.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
