### PR TITLE
[Merged by Bors] - feat(Algebra/Order/Sub): add `map_tsub_of_le`

### DIFF
--- a/Mathlib/Algebra/Order/Sub/Unbundled/Hom.lean
+++ b/Mathlib/Algebra/Order/Sub/Unbundled/Hom.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
 import Mathlib.Algebra.Group.Equiv.Defs
-import Mathlib.Algebra.Order.Sub.Defs
+import Mathlib.Algebra.Order.Sub.Unbundled.Basic
 import Mathlib.Algebra.Ring.Basic
 import Mathlib.Order.Hom.Basic
 /-!
@@ -32,6 +32,13 @@ theorem le_tsub_mul {R : Type*} [NonUnitalCommSemiring R] [Preorder R] [Sub R] [
   simpa only [mul_comm _ c] using le_mul_tsub
 
 end Add
+
+theorem map_tsub_of_le {F : Type*} [PartialOrder α] [AddCommSemigroup α] [ExistsAddOfLE α]
+    [AddLeftMono α] [Sub α] [OrderedSub α] [PartialOrder β] [AddCommSemigroup β] [Sub β]
+    [OrderedSub β] [AddLeftReflectLE β] [FunLike F α β] [AddHomClass F α β]
+    (f : F) (a b : α) (h : b ≤ a) : f a - f b = f (a - b) := by
+  conv => lhs; rw [← tsub_add_cancel_of_le h]
+  rw [map_add, add_tsub_cancel_right]
 
 /-- An order isomorphism between types with ordered subtraction preserves subtraction provided that
 it preserves addition. -/


### PR DESCRIPTION
An `AddHom` keeps ordered subtraction in canonically ordered monoids. This is a simple corollary of `tsub_add_cancel_of_le`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
