### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Limits/Shapes/End): (iso)ext for (co)wedges

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Shapes/End.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/End.lean
@@ -74,6 +74,8 @@ abbrev Wedge := Multifork (multicospanIndexEnd F)
 
 namespace Wedge
 
+variable {F}
+
 /-- A variant of `CategoryTheory.Limits.Cones.ext` specialized to produce
 isomorphisms of wedges. -/
 @[simps!]
@@ -83,8 +85,6 @@ def ext {W₁ W₂ : Wedge F} (e : W₁.pt ≅ W₂.pt)
     match j with
     | .left _ => he _
     | .right f => by simpa using (he f.left) =≫ _)
-
-variable {F}
 
 section Constructor
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/End.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/End.lean
@@ -74,6 +74,16 @@ abbrev Wedge := Multifork (multicospanIndexEnd F)
 
 namespace Wedge
 
+/-- A variant of `CategoryTheory.Limits.Cones.ext` specialized to produce
+isomorphisms of wedges. -/
+@[simps!]
+def ext {W₁ W₂ : Wedge F} (e : W₁.pt ≅ W₂.pt)
+    (he : ∀ j : J, W₁.ι j = e.hom ≫ W₂.ι j := by aesop_cat) : W₁ ≅ W₂ :=
+  Cones.ext e (fun j =>
+    match j with
+    | .left _ => he _
+    | .right f => by simpa using (he f.left) =≫ _)
+
 variable {F}
 
 section Constructor
@@ -129,6 +139,16 @@ abbrev Cowedge := Multicofork (multispanIndexCoend F)
 namespace Cowedge
 
 variable {F}
+
+/-- A variant of `CategoryTheory.Limits.Cocones.ext` specialized to produce
+isomorphisms of cowedges. -/
+@[simps!]
+def ext {W₁ W₂ : Cowedge F} (e : W₁.pt ≅ W₂.pt)
+    (he : ∀ j : J, W₁.π j ≫ e.hom  = W₂.π j := by aesop_cat) : W₁ ≅ W₂ :=
+  Cocones.ext e (fun j =>
+    match j with
+    | .right _ => he _
+    | .left f => by simpa using _ ≫= (he f.left))
 
 section Constructor
 


### PR DESCRIPTION
We provide a thin wrapper around `Cones.ext` in the case of (co)wedges that hides away their nature as multicospans in order to ease work with them.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
