### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/Finsupp/LinearCombination): add `Submodule.mem_span_finset'`

### DIFF
--- a/Mathlib/LinearAlgebra/Finsupp/LinearCombination.lean
+++ b/Mathlib/LinearAlgebra/Finsupp/LinearCombination.lean
@@ -445,6 +445,21 @@ lemma Submodule.mem_span_finset {s : Finset M} {x : M} :
     simp +contextual [Function.support_subset_iff'.1 hf]
   mpr := by rintro ⟨f, -, rfl⟩; exact sum_mem fun x hx ↦ smul_mem _ _ <| subset_span <| hx
 
+/-- An variant of `Submodule.mem_span_finset` using `s` as the index type. -/
+lemma Submodule.mem_span_finset' {s : Finset M} {x : M} :
+    x ∈ span R s ↔ ∃ f : s → R, ∑ a : s, f a • a.1 = x := by
+  rw [mem_span_finset]
+  constructor
+  · rintro ⟨f, _, rfl⟩
+    refine ⟨f ∘ Subtype.val, ?_⟩
+    erw [Finset.sum_coe_sort_eq_attach, Finset.sum_attach s (fun a => f a • a)]
+  · intro ⟨f, hx⟩
+    classical
+    refine ⟨fun a => if h : a ∈ s then f ⟨a, h⟩ else 0, ?_, ?_⟩
+    · simpa using fun x hx _ => hx
+    · rw [← Finset.sum_attach]
+      simpa [← Finset.sum_coe_sort_eq_attach]
+
 /-- An element `m ∈ M` is contained in the `R`-submodule spanned by a set `s ⊆ M`, if and only if
 `m` can be written as a finite `R`-linear combination of elements of `s`.
 The implementation uses `Finsupp.sum`. -/

--- a/Mathlib/LinearAlgebra/Finsupp/LinearCombination.lean
+++ b/Mathlib/LinearAlgebra/Finsupp/LinearCombination.lean
@@ -448,17 +448,8 @@ lemma Submodule.mem_span_finset {s : Finset M} {x : M} :
 /-- An variant of `Submodule.mem_span_finset` using `s` as the index type. -/
 lemma Submodule.mem_span_finset' {s : Finset M} {x : M} :
     x ∈ span R s ↔ ∃ f : s → R, ∑ a : s, f a • a.1 = x := by
-  rw [mem_span_finset]
-  constructor
-  · rintro ⟨f, _, rfl⟩
-    refine ⟨f ∘ Subtype.val, ?_⟩
-    erw [Finset.sum_coe_sort_eq_attach, Finset.sum_attach s (fun a => f a • a)]
-  · intro ⟨f, hx⟩
-    classical
-    refine ⟨fun a => if h : a ∈ s then f ⟨a, h⟩ else 0, ?_, ?_⟩
-    · simpa using fun x hx _ => hx
-    · rw [← Finset.sum_attach]
-      simpa [← Finset.sum_coe_sort_eq_attach]
+  rw [← Subtype.range_val (s := s.toSet), ← Fintype.range_linearCombination]
+  rfl
 
 /-- An element `m ∈ M` is contained in the `R`-submodule spanned by a set `s ⊆ M`, if and only if
 `m` can be written as a finite `R`-linear combination of elements of `s`.

--- a/Mathlib/LinearAlgebra/Finsupp/LinearCombination.lean
+++ b/Mathlib/LinearAlgebra/Finsupp/LinearCombination.lean
@@ -445,7 +445,7 @@ lemma Submodule.mem_span_finset {s : Finset M} {x : M} :
     simp +contextual [Function.support_subset_iff'.1 hf]
   mpr := by rintro ⟨f, -, rfl⟩; exact sum_mem fun x hx ↦ smul_mem _ _ <| subset_span <| hx
 
-/-- An variant of `Submodule.mem_span_finset` using `s` as the index type. -/
+/-- A variant of `Submodule.mem_span_finset` using `s` as the index type. -/
 lemma Submodule.mem_span_finset' {s : Finset M} {x : M} :
     x ∈ span R s ↔ ∃ f : s → R, ∑ a : s, f a • a.1 = x := by
   rw [← Subtype.range_val (s := s.toSet), ← Fintype.range_linearCombination]


### PR DESCRIPTION
which is an variant of `Submodule.mem_span_finset` using `s` as the index type.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
