### PR TITLE
feat(Algebra/Category/ModuleCat/Sheaf/VectorBundle): define vector bundles

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -172,6 +172,7 @@ import Mathlib.Algebra.Category.ModuleCat.Sheaf.Limits
 import Mathlib.Algebra.Category.ModuleCat.Sheaf.PullbackContinuous
 import Mathlib.Algebra.Category.ModuleCat.Sheaf.PushforwardContinuous
 import Mathlib.Algebra.Category.ModuleCat.Sheaf.Quasicoherent
+import Mathlib.Algebra.Category.ModuleCat.Sheaf.VectorBundle
 import Mathlib.Algebra.Category.ModuleCat.Simple
 import Mathlib.Algebra.Category.ModuleCat.Subobject
 import Mathlib.Algebra.Category.ModuleCat.Tannaka

--- a/Mathlib/Algebra/Category/ModuleCat/Sheaf/VectorBundle.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Sheaf/VectorBundle.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2025 Paul Lezeau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Lezeau
+-/
+import Mathlib.Algebra.Category.ModuleCat.Sheaf.Free
+import Mathlib.Algebra.Category.ModuleCat.Sheaf.PushforwardContinuous
+import Mathlib.CategoryTheory.Sites.CoversTop
+
+/-! # Vector Bundles
+
+A sheaf of modules is a vector bundle if it is locally isomorphic to a free sheaf.
+
+-/
+
+universe u v
+
+namespace SheafOfModules
+
+open CategoryTheory Limits
+
+variable {C : Type u} [Category.{v, u} C]
+variable {J : GrothendieckTopology C}
+variable {R : Sheaf J RingCat} (M : SheafOfModules R)
+variable [∀ (X : C), (J.over X).HasSheafCompose (forget₂ RingCat AddCommGrp)]
+variable [∀ (X : C), HasWeakSheafify (J.over X) AddCommGrp]
+variable [∀ (X : C), (J.over X).WEqualsLocallyBijective AddCommGrp]
+
+/-- A vector bundle is a sheaf of modules that is locally isomorphic to
+a free sheaf. -/
+structure VectorBundleData (M : SheafOfModules.{v} R) where
+  /-- The index type for the open cover on which the vector bundle is free. -/
+  OpensIndex : Type u
+  /-- The indexed family of opens on which the vector bundle is free. -/
+  opens : OpensIndex → C
+  /-- The indexed family of types that index local bases for the vector bundle. -/
+  BasisIndex : OpensIndex → Type v
+  /-- The indexed family of opens covers the base. -/
+  coversTop : J.CoversTop opens
+  /-- The restriction of the vector bundle to one of the opens is free. -/
+  locallyFree : ∀ i, (M.over <| opens i) ≅ SheafOfModules.free (BasisIndex i)
+
+--TODO: construct a `QuasiCoherentData` from a `VectorBundle` data.
+
+/-- A class for vector bundles of constant finite rank. -/
+class IsVectorBundle (M : SheafOfModules R) where
+  /-- The predicate that a sheaf of modules is locally free. -/
+  exists_vector_bundle_data : Nonempty  M.VectorBundleData
+
+-- TODO: prove that vector bundles are quasicoherent
+
+end SheafOfModules


### PR DESCRIPTION
This PR defines vector bundles (upstreamed from [formal-conjectures](https://github.com/google-deepmind/formal-conjectures/pull/28/files)). I plan on adding some more API about the definition in this PR, but figured it would be nice to get some initial feedback about the definition before doing so!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
