### PR TITLE
[Merged by Bors] - feat(ModelTheory): the language of Presburger Arithmetic

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4530,6 +4530,7 @@ import Mathlib.ModelTheory.Algebra.Field.IsAlgClosed
 import Mathlib.ModelTheory.Algebra.Ring.Basic
 import Mathlib.ModelTheory.Algebra.Ring.Definability
 import Mathlib.ModelTheory.Algebra.Ring.FreeCommRing
+import Mathlib.ModelTheory.Arithmetic.Presburger.Basic
 import Mathlib.ModelTheory.Basic
 import Mathlib.ModelTheory.Bundled
 import Mathlib.ModelTheory.Complexity

--- a/Mathlib/ModelTheory/Arithmetic/Presburger/Basic.lean
+++ b/Mathlib/ModelTheory/Arithmetic/Presburger/Basic.lean
@@ -27,14 +27,14 @@ variable {α : Type*}
 
 namespace FirstOrder
 
-/-- The type of Presburger arithmetic functions, defined as (0,1,+) -/
+/-- The type of Presburger arithmetic functions, defined as (0, 1, +). -/
 inductive presburgerFunc : ℕ → Type
   | zero : presburgerFunc 0
   | one : presburgerFunc 0
   | add : presburgerFunc 2
   deriving DecidableEq
 
-/-- The language of Presburger arithmetic, defined as (0,1,+). -/
+/-- The language of Presburger arithmetic, defined as (0, 1, +). -/
 def Language.presburger : Language :=
   { Functions := presburgerFunc
     Relations := fun _ => Empty }

--- a/Mathlib/ModelTheory/Arithmetic/Presburger/Basic.lean
+++ b/Mathlib/ModelTheory/Arithmetic/Presburger/Basic.lean
@@ -16,7 +16,8 @@ This file defines the first-order language of Presburger arithmetic as (0,S,+).
 
 ## TODO
 
-- Generalize `presburger.finsum` for a class like `FirstOrder.Language.IsOrdered`.
+- Generalize `presburger.finsum` (maybe also `presburger.natCast` and `presburger.nsmul`) for
+  classes like `FirstOrder.Language.IsOrdered`.
 - Define the theory of Presburger arithmetic and prove its properties (quantifier elimination,
   completeness, etc).
 
@@ -26,6 +27,7 @@ variable {α : Type*}
 
 namespace FirstOrder
 
+/-- The type of Presburger arithmetic functions, defined as (0,S,+) -/
 inductive presburgerFunc : ℕ → Type
   | zero : presburgerFunc 0
   | succ : presburgerFunc 1
@@ -45,6 +47,7 @@ variable {t t₁ t₂ : presburger.Term α}
 instance : Zero (presburger.Term α) where
   zero := Constants.term .zero
 
+/-- `presburger.succ t` is the successor of `t`, applying `presburgerFunc.succ` on `t`. -/
 def succ (t : presburger.Term α) := Functions.apply₁ presburgerFunc.succ t
 
 instance : Add (presburger.Term α) where

--- a/Mathlib/ModelTheory/Arithmetic/Presburger/Basic.lean
+++ b/Mathlib/ModelTheory/Arithmetic/Presburger/Basic.lean
@@ -67,9 +67,6 @@ instance : SMul ℕ (presburger.Term α) where
 
 @[simp] theorem succ_nsmul {n : ℕ} : (n + 1) • t = n • t + t := rfl
 
-/-- `presburger.succ t` is `t + 1`, the successor of `t`. -/
-def succ (t : presburger.Term α) := t + 1
-
 /-- Summation over a finite set of terms in Presburger arithmetic.
 
   It is defined via choice, so the result only makes sense when the structure satisfies
@@ -101,8 +98,6 @@ instance : presburger.Structure M where
 @[simp] theorem realize_zero : Term.realize v (0 : presburger.Term α) = 0 := rfl
 
 @[simp] theorem realize_one : Term.realize v (1 : presburger.Term α) = 1 := rfl
-
-@[simp] theorem realize_succ : Term.realize v (succ t) = Term.realize v t + 1 := rfl
 
 @[simp] theorem realize_add :
     Term.realize v (t₁ + t₂) = Term.realize v t₁ + Term.realize v t₂ := rfl

--- a/Mathlib/ModelTheory/Arithmetic/Presburger/Basic.lean
+++ b/Mathlib/ModelTheory/Arithmetic/Presburger/Basic.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 Dexin Zhang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Dexin Zhang
 -/
+import Mathlib.Algebra.Group.Basic
 import Mathlib.ModelTheory.Semantics
 
 /-!
@@ -53,9 +54,9 @@ def succ (t : presburger.Term α) := Functions.apply₁ presburgerFunc.succ t
 instance : Add (presburger.Term α) where
   add := Functions.apply₂ .add
 
-private def natCast : ℕ → presburger.Term α
+protected def natCast : ℕ → presburger.Term α
 | 0 => 0
-| n + 1 => succ (natCast n)
+| n + 1 => succ (presburger.natCast n)
 
 instance : NatCast (presburger.Term α) where
   natCast := presburger.natCast
@@ -64,9 +65,9 @@ instance : NatCast (presburger.Term α) where
 
 @[simp] theorem natCast_succ {n : ℕ} : NatCast.natCast (n + 1) = succ (n : presburger.Term α) := rfl
 
-private def nsmul : ℕ → presburger.Term α → presburger.Term α
+protected def nsmul : ℕ → presburger.Term α → presburger.Term α
 | 0, _ => 0
-| n + 1, t => nsmul n t + t
+| n + 1, t => presburger.nsmul n t + t
 
 instance : SMul ℕ (presburger.Term α) where
   smul := presburger.nsmul
@@ -131,9 +132,7 @@ end
   induction l with
   | nil => rfl
   | cons =>
-    haveI : Std.Associative (· + · : M → M → M) := ⟨add_assoc⟩
-    haveI : Std.Commutative (· + · : M → M → M) := ⟨add_comm⟩
     rw [List.nodup_cons, ←List.mem_toFinset] at hnodup
-    simp [*, Finset.fold_insert (op := (· + ·)) hnodup.1]
+    simp [*, Finset.fold_insert (β := M) (op := (· + ·)) hnodup.1]
 
 end FirstOrder.Language.presburger

--- a/Mathlib/ModelTheory/Arithmetic/Presburger/Basic.lean
+++ b/Mathlib/ModelTheory/Arithmetic/Presburger/Basic.lean
@@ -1,0 +1,137 @@
+/-
+Copyright (c) 2025 Dexin Zhang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Dexin Zhang
+-/
+import Mathlib.ModelTheory.Semantics
+
+
+/-!
+# Presburger arithmetic
+
+This file defines the first-order language of Presburger arithmetic as (0,S,+).
+
+## Main Definitions
+
+- `FirstOrder.Language.presburger`: the language of Presburger arithmetic.
+
+## TODO
+
+- Generalize `presburger.finsum` for a class like `FirstOrder.Language.IsOrdered`.
+- Define the theory of Presburger arithmetic and prove its properties (quantifier elimination,
+  completeness, etc).
+
+-/
+
+variable {α : Type*}
+
+namespace FirstOrder
+
+inductive presburgerFunc : ℕ → Type
+  | zero : presburgerFunc 0
+  | succ : presburgerFunc 1
+  | add : presburgerFunc 2
+  deriving DecidableEq
+
+/-- The language of Presburger arithmetic, defined as (0,S,+). -/
+def Language.presburger : Language :=
+  { Functions := presburgerFunc
+    Relations := fun _ => Empty }
+  deriving IsAlgebraic
+
+namespace Language.presburger
+
+variable {t t₁ t₂ : presburger.Term α}
+
+instance : Zero (presburger.Term α) where
+  zero := Constants.term .zero
+
+def succ (t : presburger.Term α) := Functions.apply₁ presburgerFunc.succ t
+
+instance : Add (presburger.Term α) where
+  add := Functions.apply₂ .add
+
+private def natCast : ℕ → presburger.Term α
+| 0 => 0
+| n + 1 => succ (natCast n)
+
+instance : NatCast (presburger.Term α) where
+  natCast := presburger.natCast
+
+@[simp] theorem natCast_zero : NatCast.natCast 0 = (0 : presburger.Term α) := rfl
+
+@[simp] theorem natCast_succ {n : ℕ} : NatCast.natCast (n + 1) = succ (n : presburger.Term α) := rfl
+
+private def nsmul : ℕ → presburger.Term α → presburger.Term α
+| 0, _ => 0
+| n + 1, t => nsmul n t + t
+
+instance : SMul ℕ (presburger.Term α) where
+  smul := presburger.nsmul
+
+@[simp] theorem zero_nsmul : 0 • t = 0 := rfl
+
+@[simp] theorem succ_nsmul {n : ℕ} : (n + 1) • t = n • t + t := rfl
+
+/-- Summation over a finite set of terms in Presburger arithmetic.
+  
+  It is defined via choice, and therefore the result only makes sense when the structure satisfies
+  commutativity (see `realize_finsum`). -/
+noncomputable def finsum {β : Type*} [Fintype β] (f : β → presburger.Term α) : presburger.Term α :=
+  ((Finset.univ : Finset β).toList.map f).foldr (· + ·) 0
+
+variable {M : Type*} {v : α → M}
+
+section
+
+variable [Zero M] [One M] [Add M]
+
+instance : presburger.Structure M where
+  funMap
+  | .zero, _ => 0
+  | .succ, v => v 0 + 1
+  | .add, v => v 0 + v 1
+
+@[simp] theorem funMap_zero {v} :
+    @Structure.funMap presburger M _ _ presburgerFunc.zero v = 0 := rfl
+
+@[simp] theorem funMap_succ {v} :
+    @Structure.funMap presburger M _ _ presburgerFunc.succ v = v 0 + 1 := rfl
+
+@[simp] theorem funMap_add {v} :
+    @Structure.funMap presburger M _ _ presburgerFunc.add v = v 0 + v 1 := rfl
+
+@[simp] theorem realize_zero : Term.realize v (0 : presburger.Term α) = 0 := rfl
+
+@[simp] theorem realize_succ : Term.realize v (succ t) = Term.realize v t + 1 := rfl
+
+@[simp] theorem realize_add :
+    Term.realize v (t₁ + t₂) = Term.realize v t₁ + Term.realize v t₂ := rfl
+
+end
+
+@[simp] theorem realize_natCast [AddMonoidWithOne M] {n : ℕ} :
+    Term.realize v (n : presburger.Term α) = n := by
+  induction n with simp [*]
+
+@[simp] theorem realize_nsmul [AddMonoidWithOne M] {n : ℕ} :
+    Term.realize v (n • t) = n • Term.realize v t := by
+  induction n with simp [*, _root_.zero_nsmul, add_nsmul]
+
+@[simp] theorem realize_finsum [AddCommMonoidWithOne M]
+    {β : Type*} [Fintype β] {f : β → presburger.Term α} :
+    Term.realize v (finsum f) = ∑ i, Term.realize v (f i) := by
+  classical
+  simp only [finsum, Finset.sum_eq_fold]
+  conv => rhs; rw [←Finset.toList_toFinset Finset.univ]
+  have hnodup := Finset.nodup_toList (Finset.univ : Finset β)
+  generalize (Finset.univ : Finset β).toList = l at *
+  induction l with
+  | nil => rfl
+  | cons =>
+    haveI : Std.Associative (· + · : M → M → M) := ⟨add_assoc⟩
+    haveI : Std.Commutative (· + · : M → M → M) := ⟨add_comm⟩
+    rw [List.nodup_cons, ←List.mem_toFinset] at hnodup
+    simp [*, Finset.fold_insert (op := (· + ·)) hnodup.1]
+
+end FirstOrder.Language.presburger

--- a/Mathlib/ModelTheory/Arithmetic/Presburger/Basic.lean
+++ b/Mathlib/ModelTheory/Arithmetic/Presburger/Basic.lean
@@ -21,7 +21,6 @@ This file defines the first-order language of Presburger arithmetic as (0,1,+).
   `FirstOrder.Language.IsOrdered`.
 - Define the theory of Presburger arithmetic and prove its properties (quantifier elimination,
   completeness, etc).
-
 -/
 
 variable {α : Type*}

--- a/Mathlib/ModelTheory/Arithmetic/Presburger/Basic.lean
+++ b/Mathlib/ModelTheory/Arithmetic/Presburger/Basic.lean
@@ -77,7 +77,7 @@ instance : SMul ℕ (presburger.Term α) where
 @[simp] theorem succ_nsmul {n : ℕ} : (n + 1) • t = n • t + t := rfl
 
 /-- Summation over a finite set of terms in Presburger arithmetic.
-  
+
   It is defined via choice, and therefore the result only makes sense when the structure satisfies
   commutativity (see `realize_finsum`). -/
 noncomputable def finsum {β : Type*} [Fintype β] (f : β → presburger.Term α) : presburger.Term α :=

--- a/Mathlib/ModelTheory/Arithmetic/Presburger/Basic.lean
+++ b/Mathlib/ModelTheory/Arithmetic/Presburger/Basic.lean
@@ -69,8 +69,8 @@ instance : SMul ℕ (presburger.Term α) where
 
 /-- Summation over a finite set of terms in Presburger arithmetic.
 
-  It is defined via choice, so the result only makes sense when the structure satisfies
-  commutativity (see `realize_sum`). -/
+It is defined via choice, so the result only makes sense when the structure satisfies
+commutativity (see `realize_sum`). -/
 noncomputable def sum {β : Type*} (s : Finset β) (f : β → presburger.Term α) : presburger.Term α :=
   (s.toList.map f).sum
 

--- a/Mathlib/ModelTheory/Arithmetic/Presburger/Basic.lean
+++ b/Mathlib/ModelTheory/Arithmetic/Presburger/Basic.lean
@@ -9,7 +9,7 @@ import Mathlib.ModelTheory.Semantics
 /-!
 # Presburger arithmetic
 
-This file defines the first-order language of Presburger arithmetic as (0,S,+).
+This file defines the first-order language of Presburger arithmetic as (0,1,+).
 
 ## Main Definitions
 
@@ -17,8 +17,8 @@ This file defines the first-order language of Presburger arithmetic as (0,S,+).
 
 ## TODO
 
-- Generalize `presburger.finsum` (maybe also `presburger.natCast` and `presburger.nsmul`) for
-  classes like `FirstOrder.Language.IsOrdered`.
+- Generalize `presburger.finsum` (maybe also `NatCast` and `SMul`) for classes like
+  `FirstOrder.Language.IsOrdered`.
 - Define the theory of Presburger arithmetic and prove its properties (quantifier elimination,
   completeness, etc).
 
@@ -28,14 +28,14 @@ variable {α : Type*}
 
 namespace FirstOrder
 
-/-- The type of Presburger arithmetic functions, defined as (0,S,+) -/
+/-- The type of Presburger arithmetic functions, defined as (0,1,+) -/
 inductive presburgerFunc : ℕ → Type
   | zero : presburgerFunc 0
-  | succ : presburgerFunc 1
+  | one : presburgerFunc 0
   | add : presburgerFunc 2
   deriving DecidableEq
 
-/-- The language of Presburger arithmetic, defined as (0,S,+). -/
+/-- The language of Presburger arithmetic, defined as (0,1,+). -/
 def Language.presburger : Language :=
   { Functions := presburgerFunc
     Relations := fun _ => Empty }
@@ -48,37 +48,32 @@ variable {t t₁ t₂ : presburger.Term α}
 instance : Zero (presburger.Term α) where
   zero := Constants.term .zero
 
-/-- `presburger.succ t` is the successor of `t`, applying `presburgerFunc.succ` on `t`. -/
-def succ (t : presburger.Term α) := Functions.apply₁ presburgerFunc.succ t
+instance : One (presburger.Term α) where
+  one := Constants.term .one
 
 instance : Add (presburger.Term α) where
   add := Functions.apply₂ .add
 
-protected def natCast : ℕ → presburger.Term α
-| 0 => 0
-| n + 1 => succ (presburger.natCast n)
-
 instance : NatCast (presburger.Term α) where
-  natCast := presburger.natCast
+  natCast := Nat.unaryCast
 
 @[simp] theorem natCast_zero : NatCast.natCast 0 = (0 : presburger.Term α) := rfl
 
-@[simp] theorem natCast_succ {n : ℕ} : NatCast.natCast (n + 1) = succ (n : presburger.Term α) := rfl
-
-protected def nsmul : ℕ → presburger.Term α → presburger.Term α
-| 0, _ => 0
-| n + 1, t => presburger.nsmul n t + t
+@[simp] theorem natCast_succ {n : ℕ} : NatCast.natCast (n + 1) = (n : presburger.Term α) + 1 := rfl
 
 instance : SMul ℕ (presburger.Term α) where
-  smul := presburger.nsmul
+  smul := nsmulRec
 
 @[simp] theorem zero_nsmul : 0 • t = 0 := rfl
 
 @[simp] theorem succ_nsmul {n : ℕ} : (n + 1) • t = n • t + t := rfl
 
+/-- `presburger.succ t` is `t + 1`, the successor of `t`. -/
+def succ (t : presburger.Term α) := t + 1
+
 /-- Summation over a finite set of terms in Presburger arithmetic.
 
-  It is defined via choice, and therefore the result only makes sense when the structure satisfies
+  It is defined via choice, so the result only makes sense when the structure satisfies
   commutativity (see `realize_finsum`). -/
 noncomputable def finsum {β : Type*} [Fintype β] (f : β → presburger.Term α) : presburger.Term α :=
   ((Finset.univ : Finset β).toList.map f).foldr (· + ·) 0
@@ -92,19 +87,21 @@ variable [Zero M] [One M] [Add M]
 instance : presburger.Structure M where
   funMap
   | .zero, _ => 0
-  | .succ, v => v 0 + 1
+  | .one, v => 1
   | .add, v => v 0 + v 1
 
 @[simp] theorem funMap_zero {v} :
     @Structure.funMap presburger M _ _ presburgerFunc.zero v = 0 := rfl
 
-@[simp] theorem funMap_succ {v} :
-    @Structure.funMap presburger M _ _ presburgerFunc.succ v = v 0 + 1 := rfl
+@[simp] theorem funMap_one {v} :
+    @Structure.funMap presburger M _ _ presburgerFunc.one v = 1 := rfl
 
 @[simp] theorem funMap_add {v} :
     @Structure.funMap presburger M _ _ presburgerFunc.add v = v 0 + v 1 := rfl
 
 @[simp] theorem realize_zero : Term.realize v (0 : presburger.Term α) = 0 := rfl
+
+@[simp] theorem realize_one : Term.realize v (1 : presburger.Term α) = 1 := rfl
 
 @[simp] theorem realize_succ : Term.realize v (succ t) = Term.realize v t + 1 := rfl
 
@@ -119,7 +116,7 @@ end
 
 @[simp] theorem realize_nsmul [AddMonoidWithOne M] {n : ℕ} :
     Term.realize v (n • t) = n • Term.realize v t := by
-  induction n with simp [*, _root_.zero_nsmul, add_nsmul]
+  induction n with simp [*, add_nsmul]
 
 @[simp] theorem realize_finsum [AddCommMonoidWithOne M]
     {β : Type*} [Fintype β] {f : β → presburger.Term α} :

--- a/Mathlib/ModelTheory/Arithmetic/Presburger/Basic.lean
+++ b/Mathlib/ModelTheory/Arithmetic/Presburger/Basic.lean
@@ -5,7 +5,6 @@ Authors: Dexin Zhang
 -/
 import Mathlib.ModelTheory.Semantics
 
-
 /-!
 # Presburger arithmetic
 


### PR DESCRIPTION
This PR introduces the first-order language of [Presburger Arithmetic](https://en.wikipedia.org/wiki/Presburger_arithmetic). It has not defined the theory of Presburger Arithmetic yet (left as TODO), but is enough to prove some definability results (#27100).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
