### PR TITLE
[Merged by Bors] - refactor(Algebra/Module): rename `AddCommGroup.toNatModule` to `AddCommMonoid.toNatModule`

### DIFF
--- a/Mathlib/Algebra/Module/NatInt.lean
+++ b/Mathlib/Algebra/Module/NatInt.lean
@@ -13,8 +13,7 @@ This file concerns modules where the scalars are the natural numbers or the inte
 
 ## Main definitions
 
-* `AddCommGroup.toNatModule`: any `AddCommMonoid` is (uniquely) a module over the naturals.
-  TODO: this name is not right!
+* `AddCommMonoid.toNatModule`: any `AddCommMonoid` is (uniquely) a module over the naturals.
 * `AddCommGroup.toIntModule`: any `AddCommGroup` is a module over the integers.
 
 ## Main results
@@ -38,7 +37,7 @@ section AddCommMonoid
 
 variable [Semiring R] [AddCommMonoid M] [Module R M] (r s : R) (x : M)
 
-instance AddCommGroup.toNatModule : Module ℕ M where
+instance AddCommMonoid.toNatModule : Module ℕ M where
   one_smul := one_nsmul
   mul_smul m n a := mul_nsmul' a m n
   smul_add n a b := nsmul_add a b n

--- a/Mathlib/Tactic/Module.lean
+++ b/Mathlib/Tactic/Module.lean
@@ -461,11 +461,11 @@ partial def parse (iM : Q(AddCommMonoid $M)) (x : Q($M)) :
     pure ⟨u, R, iR, iRM, l.onScalar q(HMul.hMul $s), (q(NF.smul_eq_eval $pf₀ $pf_l $pf_r):)⟩
   /- parse a `(0:M)` -/
   | ~q(0) =>
-    pure ⟨0, q(Nat), q(Nat.instSemiring), q(AddCommGroup.toNatModule), [], q(NF.zero_eq_eval $M)⟩
+    pure ⟨0, q(Nat), q(Nat.instSemiring), q(AddCommMonoid.toNatModule), [], q(NF.zero_eq_eval $M)⟩
   /- anything else should be treated as an atom -/
   | _ =>
     let (k, ⟨x', _⟩) ← AtomM.addAtomQ x
-    pure ⟨0, q(Nat), q(Nat.instSemiring), q(AddCommGroup.toNatModule), [((q(1), x'), k)],
+    pure ⟨0, q(Nat), q(Nat.instSemiring), q(AddCommMonoid.toNatModule), [((q(1), x'), k)],
       q(NF.atom_eq_eval $x')⟩
 
 /-- Given expressions `R` and `M` representing types such that `M`'s is a module over `R`'s, and

--- a/MathlibTest/instance_diamonds/FieldTheory/IsAlgClosed/AlgebraicClosure.lean
+++ b/MathlibTest/instance_diamonds/FieldTheory/IsAlgClosed/AlgebraicClosure.lean
@@ -3,7 +3,7 @@ import Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure
 
 variable {k : Type*} [Field k]
 
-example : (AddCommGroup.toNatModule : Module ℕ (AlgebraicClosure k)) =
+example : (AddCommMonoid.toNatModule : Module ℕ (AlgebraicClosure k)) =
       @Algebra.toModule _ _ _ _ (AlgebraicClosure.instAlgebra k) := by
   with_reducible_and_instances rfl
 

--- a/MathlibTest/instance_diamonds/FieldTheory/SplittingField/Construction.lean
+++ b/MathlibTest/instance_diamonds/FieldTheory/SplittingField/Construction.lean
@@ -14,7 +14,7 @@ variable (f : K[X])
 -- The algebra instance deriving from `K` should be definitionally equal to that
 -- deriving from the field structure on `SplittingField f`.
 example :
-    (AddCommGroup.toNatModule : Module ℕ (SplittingField f)) =
+    (AddCommMonoid.toNatModule : Module ℕ (SplittingField f)) =
       @Algebra.toModule _ _ _ _ (SplittingField.algebra' f) := by
   with_reducible_and_instances rfl
 


### PR DESCRIPTION
It was named under `AddCommGroup` namespace but takes a `AddCommMonoid`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
