### PR TITLE
[Merged by Bors] - feat(Algebra/GroupWithZero/Range): MonoidWithZeroHom.(m)range_nontrivial

### DIFF
--- a/Mathlib/Algebra/GroupWithZero/Range.lean
+++ b/Mathlib/Algebra/GroupWithZero/Range.lean
@@ -52,7 +52,7 @@ open Set Subgroup Submonoid
 lemma mrange_nontrivial {G H : Type*} [MulZeroOneClass G] [MulZeroOneClass H] [Nontrivial H]
     (f : G →*₀ H) :
     Nontrivial (MonoidHom.mrange f) :=
-  ⟨⟨1, 1, by simp⟩, ⟨0, 0, by simp⟩, by simp⟩
+  ⟨1, ⟨0, 0, by simp⟩, by simp [Subtype.ext_iff]⟩
 
 lemma range_nontrivial {G H : Type*} [MulZeroOneClass G] [MulZeroOneClass H] [Nontrivial H]
     (f : G →*₀ H) :

--- a/Mathlib/Algebra/GroupWithZero/Range.lean
+++ b/Mathlib/Algebra/GroupWithZero/Range.lean
@@ -49,6 +49,16 @@ namespace MonoidWithZeroHom
 
 open Set Subgroup Submonoid
 
+lemma mrange_nontrivial {G H : Type*} [MulZeroOneClass G] [MulZeroOneClass H] [Nontrivial H]
+    (f : G →*₀ H) :
+    Nontrivial (MonoidHom.mrange f) :=
+  ⟨⟨1, 1, by simp⟩, ⟨0, 0, by simp⟩, by simp⟩
+
+lemma range_nontrivial {G H : Type*} [MulZeroOneClass G] [MulZeroOneClass H] [Nontrivial H]
+    (f : G →*₀ H) :
+    (Set.range f).Nontrivial :=
+  Set.nontrivial_coe_sort.mp f.mrange_nontrivial
+
 variable {A B F : Type*} [FunLike F A B] (f : F)
 
 section MonoidWithZero


### PR DESCRIPTION
for proving that it is not densely ordered
for PIR -> DVR for valuations

Since this is a nontrivial set, then it can't be densely ordered when the codomain is Zm0, as shown in #27112. Together, it is used in #27117 to show that a Zm0-valued valuation's subring is a DVR. 


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
