### PR TITLE
[Merged by Bors] - feat(ENNReal/Lemmas): limsup/liminf of `f + g` when either `f` or `g` tends to zero

### DIFF
--- a/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
+++ b/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
@@ -1427,53 +1427,35 @@ lemma ofNNReal_liminf {u : ι → ℝ≥0} (hf : f.IsCoboundedUnder (· ≥ ·) 
   rw [coe_le_coe, le_liminf_iff, le_liminf_iff]
   simp [forall_ennreal]
 
-theorem liminf_add_of_right_tendsto_zero (u : Filter ι)
-  (f : ι → ℝ≥0∞) {g : ι → ℝ≥0∞} (hg : u.Tendsto g (𝓝 0)) :
-    u.liminf (f + g) = u.liminf f := by
-  have h_eps {ε} (hε : ε > 0) : ∃ v ∈ u, ∀ n ∈ v, g n < ε := by
-    simpa [eventually_iff_exists_mem] using hg.eventually (gt_mem_nhds hε)
-  apply le_antisymm
-  · refine le_of_forall_gt_imp_ge_of_dense fun x hx ↦ ?_
-    rw [liminf_eq] at hx ⊢
-    apply sSup_le
-    intro y a
-    simp only [eventually_iff_exists_mem, mem_setOf_eq] at *
-    obtain ⟨w, hw₁, hw₂⟩ := a
-    contrapose! hx
-    apply le_sSup
-    simp only [mem_setOf_eq]
-    obtain ⟨N, hN₁, hN₂⟩ := h_eps (tsub_pos_of_lt hx)
-    refine ⟨_, u.inter_sets hw₁ hN₁, fun v hv ↦ ?_⟩
-    specialize hN₂ v (mem_of_mem_inter_right hv)
-    specialize hw₂ v (mem_of_mem_inter_left hv)
-    rw [← ENNReal.add_le_add_iff_right hN₂.ne_top]
-    trans y
-    · exact add_le_of_le_tsub_left_of_le hx.le hN₂.le
-    · assumption
-  · refine liminf_le_liminf (Eventually.of_forall ?_)
-    simp
+theorem liminf_add_of_right_tendsto_zero {u : Filter ι} {g : ι → ℝ≥0∞} (hg : u.Tendsto g (𝓝 0))
+    (f : ι → ℝ≥0∞) : u.liminf (f + g) = u.liminf f := by
+  refine le_antisymm ?_ <| liminf_le_liminf <| .of_forall <| by simp
+  refine liminf_le_of_le (by isBoundedDefault) fun b hb ↦ ?_
+  rw [Filter.le_liminf_iff']
+  rintro a hab
+  filter_upwards [hb, ENNReal.tendsto_nhds_zero.1 hg _ <| lt_min (tsub_pos_of_lt hab) one_pos]
+    with i hfg hg
+  exact ENNReal.le_of_add_le_add_right (hg.trans_lt <| by bound).ne <|
+    (add_le_of_le_tsub_left_of_le hab.le <| hg.trans <| min_le_left ..).trans hfg
 
-theorem limsup_add_of_right_tendsto_zero (u : Filter ι)
-  (f : ι → ℝ≥0∞) {g : ι → ℝ≥0∞} (hg : u.Tendsto g (𝓝 0)) :
-    u.limsup (f + g) = u.limsup f := by
-  have h_eps {ε} (hε : ε > 0) : ∃ v ∈ u, ∀ n ∈ v, g n < ε := by
-    simpa [eventually_iff_exists_mem] using hg.eventually (gt_mem_nhds hε)
-  apply le_antisymm
-  · refine le_of_forall_gt_imp_ge_of_dense fun y hx ↦ ?_
-    rw [limsup_eq] at hx ⊢
-    apply sInf_le
-    rw [sInf_lt_iff] at hx
-    simp only [eventually_iff_exists_mem, mem_setOf_eq, Pi.add_apply] at hx ⊢
-    obtain ⟨x, ⟨w, hw₁, hw₂⟩, hx⟩ := hx
-    obtain ⟨N, hN₁, hN₂⟩ := h_eps (tsub_pos_of_lt hx)
-    refine ⟨_, u.inter_sets hw₁ hN₁, fun v hv ↦ ?_⟩
-    specialize hN₂ v (mem_of_mem_inter_right hv)
-    specialize hw₂ v (mem_of_mem_inter_left hv)
-    trans x + g v
-    · gcongr
-    · exact add_le_of_le_tsub_left_of_le hx.le hN₂.le
-  · refine limsup_le_limsup (Eventually.of_forall ?_)
-    simp
+theorem liminf_add_of_left_tendsto_zero {u : Filter ι} {f : ι → ℝ≥0∞} (hf : u.Tendsto f (𝓝 0))
+    (g : ι → ℝ≥0∞) : u.liminf (f + g) = u.liminf g := by
+  rw [add_comm, liminf_add_of_right_tendsto_zero hf]
+
+theorem limsup_add_of_right_tendsto_zero {u : Filter ι} {g : ι → ℝ≥0∞} (hg : u.Tendsto g (𝓝 0))
+    (f : ι → ℝ≥0∞) : u.limsup (f + g) = u.limsup f := by
+  refine le_antisymm ?_ <| limsup_le_limsup <| .of_forall <| by simp
+  refine le_limsup_of_le (by isBoundedDefault) fun b hb ↦ ?_
+  rw [Filter.limsup_le_iff']
+  rintro a hba
+  filter_upwards [hb, ENNReal.tendsto_nhds_zero.1 hg _ <| tsub_pos_of_lt hba] with i hf hg
+  calc  f i + g i
+    _ ≤ b + g i := by gcongr
+    _ ≤ a := add_le_of_le_tsub_left_of_le hba.le hg
+
+theorem limsup_add_of_left_tendsto_zero {u : Filter ι} {f : ι → ℝ≥0∞} (hf : u.Tendsto f (𝓝 0))
+    (g : ι → ℝ≥0∞) : u.limsup (f + g) = u.limsup g := by
+  rw [add_comm, limsup_add_of_right_tendsto_zero hf]
 
 end LimsupLiminf
 

--- a/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
+++ b/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
@@ -6,6 +6,7 @@ Authors: Johannes Hölzl
 import Mathlib.Algebra.BigOperators.Intervals
 import Mathlib.Data.ENNReal.BigOperators
 import Mathlib.Tactic.Bound
+import Mathlib.Tactic.Peel
 import Mathlib.Topology.Order.LiminfLimsup
 import Mathlib.Topology.EMetricSpace.Lipschitz
 import Mathlib.Topology.Instances.NNReal.Lemmas
@@ -1427,107 +1428,67 @@ lemma ofNNReal_liminf {u : ι → ℝ≥0} (hf : f.IsCoboundedUnder (· ≥ ·) 
   rw [coe_le_coe, le_liminf_iff, le_liminf_iff]
   simp [forall_ennreal]
 
-theorem Filter.liminf_add_tendsTo_zero {T : Type*} [Preorder T] [IsDirected T fun x1 x2 => x1 ≤ x2] [Nonempty T]
-  (f g : T → ENNReal) (hg : Filter.atTop.Tendsto g (𝓝 0)) :
-    Filter.atTop.liminf (f + g) = Filter.atTop.liminf f := by
-  -- Since $g$ tends to $0$, for any $\epsilon > 0$, there exists $N$ such that for all $n \geq N$, $g(n) < \epsilon$.
-  have h_eps : ∀ ε > 0, ∃ N, ∀ n ≥ N, g n < ε := by
-    intro ε hε;
-    simpa using ( hg.eventually ( gt_mem_nhds hε ) );
-  refine' le_antisymm _ _;
-  -- Case 1
-  · refine' le_of_forall_gt_imp_ge_of_dense fun b hb => _;
-    simp only [ Filter.liminf_eq ] at *;
-    refine' csSup_le _ _;
-    -- Case 1
-    · -- Since $f$ and $g$ are non-negative, $0 \leq f n + g n$ for all $n$. Therefore, $0$ is in the set.
-      use 0
-      simp;
-    -- Case 2
-    · intro b_1 a
-      simp_all only [gt_iff_lt, ge_iff_le, eventually_atTop, Pi.add_apply, Set.mem_setOf_eq]
-      obtain ⟨w, h⟩ := a
-      contrapose! hb;
-      -- Since $b < b_1$, we can choose $\epsilon = b_1 - b$.
-      obtain ⟨N, hN⟩ : ∃ N, ∀ n ≥ N, g n < b_1 - b := by
-        exact h_eps _ ( tsub_pos_iff_lt.mpr hb );
-      refine' le_csSup _ _;
-      -- Case 1
-      · norm_num +zetaDelta at *;
-      -- Case 2
-      · dsimp
-        obtain ⟨w_max, hw⟩ := directed_of (· ≤ ·) N w
-        use w_max
-        intro n hn;
-        specialize h n ( hw.2.trans hn );
-        specialize hN n ( hw.1.trans hn ) ;
-        contrapose! hN;
-        exact tsub_le_iff_left.mpr ( by simpa only [ add_comm ] using le_trans h ( add_le_add_right hN.le _ ) );
-  -- Case 2
-  · refine' ( csSup_le _ _ );
-    -- Case 1
-    · norm_num;
-      exact ⟨ 0, ⟨ Classical.choice ‹_›, fun _ _ => zero_le _ ⟩ ⟩;
-    -- Case 2
-    · -- Given that $b$ is a lower bound for $f$, we need to show that $b$ is also a lower bound for $f + g$.
-      intros b hb
-      have h_lower_bound : ∀ᶠ n in Filter.atTop, b ≤ f n + g n := by
-        simp_all only [gt_iff_lt, ge_iff_le, eventually_map, eventually_atTop, Set.mem_setOf_eq]
-        obtain ⟨w, h⟩ := hb
-        exact ⟨ w, fun n hn => le_add_right ( h n hn ) ⟩;
-      refine' le_csSup _ _;
-      -- Case 1
-      · simp;
-      -- Case 2
-      · bound
+theorem liminf_add_tendsTo_zero [Preorder ι] [IsDirected ι (· ≤ ·)] [Nonempty ι]
+  (f g : ι → ℝ≥0∞) (hg : atTop.Tendsto g (𝓝 0)) :
+    atTop.liminf (f + g) = atTop.liminf f := by
+  have h_eps {ε} (hε : ε > 0) : ∃ N, ∀ n ≥ N, g n < ε := by
+    simpa using hg.eventually (gt_mem_nhds hε)
+  apply le_antisymm
+  · refine le_of_forall_gt_imp_ge_of_dense fun x hx ↦ ?_
+    rw [liminf_eq] at hx ⊢
+    apply csSup_le ⟨⊥, by simp⟩
+    intro y a
+    simp only [gt_iff_lt, ge_iff_le, eventually_atTop, mem_setOf_eq] at *
+    obtain ⟨w, h⟩ := a
+    contrapose! hx
+    obtain ⟨N, hN⟩ := h_eps (tsub_pos_iff_lt.mpr hx)
+    apply le_csSup (OrderTop.bddAbove _)
+    obtain ⟨w_max, hw⟩ := directed_of (· ≤ ·) N w
+    use w_max
+    intro n hn
+    specialize hN n (hw.1.trans hn)
+    contrapose! hN
+    rw [tsub_le_iff_left]
+    exact (h n (hw.2.trans hn)).trans (add_le_add_right hN.le _)
+  · apply csSup_le ⟨⊥, by simp⟩
+    intros x hx
+    apply le_csSup (OrderTop.bddAbove _)
+    simp only [eventually_map, eventually_atTop, mem_setOf_eq] at *
+    peel hx with h
+    exact le_add_right h
 
-theorem Filter.limsup_add_tendsTo_zero {T : Type*} [Preorder T] [IsDirected T fun x1 x2 => x1 ≤ x2] [Nonempty T]
-  (f g : T → ENNReal) (hg : Filter.atTop.Tendsto g (𝓝 0)) :
-    Filter.atTop.limsup (f + g) = Filter.atTop.limsup f := by
-  -- Since $g$ tends to $0$, for any $\epsilon > 0$, there exists an $N$ such that for all $n \geq N$, $g(n) < \epsilon$.
-  have h_eps : ∀ ε > 0, ∃ N, ∀ n ≥ N, g n < ε := by
-    intro ε hε;
-    simpa using ( hg.eventually ( gt_mem_nhds hε ) );
-  rw [ Filter.limsup_eq, Filter.limsup_eq ];
-  -- To prove the equality of the infimums, it suffices to show that for any $a$ in the set where $f n$ is eventually $\leq a$, there exists an $a'$ in the set where $f + g n$ is eventually $\leq a'$, and vice versa.
-  apply le_antisymm;
-  -- Case 1
-  · -- For any $a$ in the set where $f$ is eventually $\leq a$, we can find an $a' = a + \epsilon$ in the set where $f + g$ is eventually $\leq a'$.
-    have h_forall_a : ∀ a ∈ {a : ENNReal | ∀ᶠ n in Filter.atTop, f n ≤ a}, ∀ ε > 0, ∃ a' ∈ {a : ENNReal | ∀ᶠ n in Filter.atTop, (f + g) n ≤ a}, a' ≤ a + ε := by
-      simp +zetaDelta at *;
+theorem limsup_add_tendsTo_zero [Preorder ι] [IsDirected ι (· ≤ ·)] [Nonempty ι]
+  (f g : ι → ℝ≥0∞) (hg : atTop.Tendsto g (𝓝 0)) :
+    atTop.limsup (f + g) = atTop.limsup f := by
+  have h_eps {ε} (hε : ε > 0) : ∃ N, ∀ n ≥ N, g n < ε := by
+    simpa using hg.eventually (gt_mem_nhds hε)
+  rw [limsup_eq, limsup_eq]
+  apply le_antisymm
+  · have h_forall_a : ∀ a ∈ {a : ℝ≥0∞ | ∀ᶠ n in atTop, f n ≤ a},
+        ∀ ε > 0, ∃ a' ∈ {a : ℝ≥0∞ | ∀ᶠ n in atTop, (f + g) n ≤ a}, a' ≤ a + ε := by
+      simp only [eventually_atTop, mem_setOf_eq, forall_exists_index] at *
       intro a x hx ε ε_pos;
-      rcases h_eps ε ε_pos with ⟨ N, hN ⟩ ;
-      refine ⟨ a + ε, ?_, le_rfl ⟩;
-      obtain ⟨ w_max , hw ⟩ := directed_of (· ≤ ·) x N
+      rcases h_eps ε_pos with ⟨N, hN⟩
+      refine ⟨a + ε, ?_, le_rfl⟩
+      obtain ⟨w_max , hw⟩ := directed_of (· ≤ ·) x N
       use w_max
       intro n hn
-      exact add_le_add ( hx n ( hw.1.trans hn ) ) ( le_of_lt ( hN n ( hw.2.trans hn ) ) )
-    apply le_of_forall_le;
+      exact add_le_add (hx n (hw.1.trans hn)) (hN n (hw.2.trans hn)).le
+    apply le_of_forall_le
     intro c a
-    simp_all only [gt_iff_lt, ge_iff_le, eventually_atTop, Set.mem_setOf_eq, Pi.add_apply, forall_exists_index,
-      le_sInf_iff]
+    simp only [eventually_atTop, mem_setOf_eq, forall_exists_index, le_sInf_iff] at *
     intro b x h
-    contrapose! a;
-    rcases ENNReal.lt_iff_exists_add_pos_lt.1 a with ⟨ ε, ε_pos, hε ⟩;
-    rcases h_forall_a b x h ε ( by simpa using ε_pos ) with ⟨ a', ⟨ x', hx' ⟩, ha' ⟩ ; exact ⟨ a', x', hx', lt_of_le_of_lt ha' hε ⟩;
-  -- Case 2
-  · refine' le_csInf _ _;
-    -- Case 1
-    · simp_all only [gt_iff_lt, ge_iff_le, Pi.add_apply, eventually_atTop]
-      rcases h_eps 1 zero_lt_one with ⟨ N, hN ⟩;
-      -- Since $g(n) < 1$ for all $n \geq N$, we have $f(n) + g(n) \leq f(n) + 1$ for all $n \geq N$.
-      have h_le : ∀ n ≥ N, f n + g n ≤ f n + 1 := by
-        exact fun n hn => add_le_add_left ( le_of_lt ( hN n hn ) ) _;
-      exact ⟨ ⊤, ⟨ N, fun n hn => le_trans ( h_le n hn ) ( by norm_num ) ⟩ ⟩;
-    -- Case 2
-    · intro b a
-      simp_all only [gt_iff_lt, ge_iff_le, Pi.add_apply, eventually_atTop, Set.mem_setOf_eq]
-      refine' csInf_le _ _;
-      -- Case 1
-      · exact ⟨ 0, by rintro x ⟨ N, hN ⟩ ; exact zero_le _ ⟩;
-      -- Case 2
-      · obtain ⟨w, h⟩ := a
-        exact ⟨ w, fun n hn => le_trans ( le_add_right le_rfl ) ( h n hn ) ⟩
+    contrapose! a
+    simp only [exists_and_right]
+    rcases ENNReal.lt_iff_exists_add_pos_lt.1 a with ⟨ε, ε_pos, hε⟩
+    peel h_forall_a b x h ε (mod_cast ε_pos) with ha'
+    apply lt_of_le_of_lt ha' hε
+  · apply le_csInf ⟨⊤, by simp⟩
+    intro x hx
+    apply csInf_le (OrderBot.bddBelow _)
+    simp only [eventually_atTop, mem_setOf_eq] at hx ⊢
+    peel hx with h
+    exact (le_add_right le_rfl).trans h
 
 end LimsupLiminf
 

--- a/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
+++ b/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
@@ -1428,67 +1428,51 @@ lemma ofNNReal_liminf {u : ι → ℝ≥0} (hf : f.IsCoboundedUnder (· ≥ ·) 
   rw [coe_le_coe, le_liminf_iff, le_liminf_iff]
   simp [forall_ennreal]
 
-theorem liminf_add_tendsTo_zero [Preorder ι] [IsDirected ι (· ≤ ·)] [Nonempty ι]
-  (f g : ι → ℝ≥0∞) (hg : atTop.Tendsto g (𝓝 0)) :
-    atTop.liminf (f + g) = atTop.liminf f := by
-  have h_eps {ε} (hε : ε > 0) : ∃ N, ∀ n ≥ N, g n < ε := by
-    simpa using hg.eventually (gt_mem_nhds hε)
+theorem liminf_add_of_right_tendsto_zero (u : Filter ι) (f : ι → ℝ≥0∞) {g : ι → ℝ≥0∞} (hg : u.Tendsto g (𝓝 0)) :
+    u.liminf (f + g) = u.liminf f := by
+  have h_eps {ε} (hε : ε > 0) : ∃ v ∈ u, ∀ n ∈ v, g n < ε := by
+    simpa [eventually_iff_exists_mem] using hg.eventually (gt_mem_nhds hε)
   apply le_antisymm
   · refine le_of_forall_gt_imp_ge_of_dense fun x hx ↦ ?_
     rw [liminf_eq] at hx ⊢
-    apply csSup_le ⟨⊥, by simp⟩
+    apply sSup_le
     intro y a
-    simp only [gt_iff_lt, ge_iff_le, eventually_atTop, mem_setOf_eq] at *
-    obtain ⟨w, h⟩ := a
+    simp only [eventually_iff_exists_mem, mem_setOf_eq] at *
+    obtain ⟨w, hw₁, hw₂⟩ := a
     contrapose! hx
-    obtain ⟨N, hN⟩ := h_eps (tsub_pos_iff_lt.mpr hx)
-    apply le_csSup (OrderTop.bddAbove _)
-    obtain ⟨w_max, hw⟩ := directed_of (· ≤ ·) N w
-    use w_max
-    intro n hn
-    specialize hN n (hw.1.trans hn)
-    contrapose! hN
-    rw [tsub_le_iff_left]
-    exact (h n (hw.2.trans hn)).trans (add_le_add_right hN.le _)
-  · apply csSup_le ⟨⊥, by simp⟩
-    intros x hx
-    apply le_csSup (OrderTop.bddAbove _)
-    simp only [eventually_map, eventually_atTop, mem_setOf_eq] at *
-    peel hx with h
-    exact le_add_right h
+    apply le_sSup
+    simp only [mem_setOf_eq]
+    obtain ⟨N, hN₁, hN₂⟩ := h_eps (tsub_pos_of_lt hx)
+    refine ⟨_, u.inter_sets hw₁ hN₁, fun v hv ↦ ?_⟩
+    specialize hN₂ v (mem_of_mem_inter_right hv)
+    specialize hw₂ v (mem_of_mem_inter_left hv)
+    rw [← ENNReal.add_le_add_iff_right hN₂.ne_top]
+    trans y
+    · exact add_le_of_le_tsub_left_of_le hx.le hN₂.le
+    · assumption
+  · refine liminf_le_liminf (Eventually.of_forall ?_)
+    simp
 
-theorem limsup_add_tendsTo_zero [Preorder ι] [IsDirected ι (· ≤ ·)] [Nonempty ι]
-  (f g : ι → ℝ≥0∞) (hg : atTop.Tendsto g (𝓝 0)) :
-    atTop.limsup (f + g) = atTop.limsup f := by
-  have h_eps {ε} (hε : ε > 0) : ∃ N, ∀ n ≥ N, g n < ε := by
-    simpa using hg.eventually (gt_mem_nhds hε)
-  rw [limsup_eq, limsup_eq]
+theorem limsup_add_of_right_tendsto_zero (u : Filter ι) (f : ι → ℝ≥0∞) {g : ι → ℝ≥0∞} (hg : u.Tendsto g (𝓝 0)) :
+    u.limsup (f + g) = u.limsup f := by
+  have h_eps {ε} (hε : ε > 0) : ∃ v ∈ u, ∀ n ∈ v, g n < ε := by
+    simpa [eventually_iff_exists_mem] using hg.eventually (gt_mem_nhds hε)
   apply le_antisymm
-  · have h_forall_a : ∀ a ∈ {a : ℝ≥0∞ | ∀ᶠ n in atTop, f n ≤ a},
-        ∀ ε > 0, ∃ a' ∈ {a : ℝ≥0∞ | ∀ᶠ n in atTop, (f + g) n ≤ a}, a' ≤ a + ε := by
-      simp only [eventually_atTop, mem_setOf_eq, forall_exists_index] at *
-      intro a x hx ε ε_pos;
-      rcases h_eps ε_pos with ⟨N, hN⟩
-      refine ⟨a + ε, ?_, le_rfl⟩
-      obtain ⟨w_max , hw⟩ := directed_of (· ≤ ·) x N
-      use w_max
-      intro n hn
-      exact add_le_add (hx n (hw.1.trans hn)) (hN n (hw.2.trans hn)).le
-    apply le_of_forall_le
-    intro c a
-    simp only [eventually_atTop, mem_setOf_eq, forall_exists_index, le_sInf_iff] at *
-    intro b x h
-    contrapose! a
-    simp only [exists_and_right]
-    rcases ENNReal.lt_iff_exists_add_pos_lt.1 a with ⟨ε, ε_pos, hε⟩
-    peel h_forall_a b x h ε (mod_cast ε_pos) with ha'
-    apply lt_of_le_of_lt ha' hε
-  · apply le_csInf ⟨⊤, by simp⟩
-    intro x hx
-    apply csInf_le (OrderBot.bddBelow _)
-    simp only [eventually_atTop, mem_setOf_eq] at hx ⊢
-    peel hx with h
-    exact (le_add_right le_rfl).trans h
+  · refine le_of_forall_gt_imp_ge_of_dense fun y hx ↦ ?_
+    rw [limsup_eq] at hx ⊢
+    apply sInf_le
+    rw [sInf_lt_iff] at hx
+    simp only [eventually_iff_exists_mem, mem_setOf_eq, Pi.add_apply] at hx ⊢
+    obtain ⟨x, ⟨w, hw₁, hw₂⟩, hx⟩ := hx
+    obtain ⟨N, hN₁, hN₂⟩ := h_eps (tsub_pos_of_lt hx)
+    refine ⟨_, u.inter_sets hw₁ hN₁, fun v hv ↦ ?_⟩
+    specialize hN₂ v (mem_of_mem_inter_right hv)
+    specialize hw₂ v (mem_of_mem_inter_left hv)
+    trans x + g v
+    · gcongr
+    · exact add_le_of_le_tsub_left_of_le hx.le hN₂.le
+  · refine limsup_le_limsup (Eventually.of_forall ?_)
+    simp
 
 end LimsupLiminf
 

--- a/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
+++ b/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
@@ -6,7 +6,6 @@ Authors: Johannes Hölzl
 import Mathlib.Algebra.BigOperators.Intervals
 import Mathlib.Data.ENNReal.BigOperators
 import Mathlib.Tactic.Bound
-import Mathlib.Tactic.Peel
 import Mathlib.Topology.Order.LiminfLimsup
 import Mathlib.Topology.EMetricSpace.Lipschitz
 import Mathlib.Topology.Instances.NNReal.Lemmas

--- a/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
+++ b/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
@@ -1428,7 +1428,8 @@ lemma ofNNReal_liminf {u : ι → ℝ≥0} (hf : f.IsCoboundedUnder (· ≥ ·) 
   rw [coe_le_coe, le_liminf_iff, le_liminf_iff]
   simp [forall_ennreal]
 
-theorem liminf_add_of_right_tendsto_zero (u : Filter ι) (f : ι → ℝ≥0∞) {g : ι → ℝ≥0∞} (hg : u.Tendsto g (𝓝 0)) :
+theorem liminf_add_of_right_tendsto_zero (u : Filter ι)
+  (f : ι → ℝ≥0∞) {g : ι → ℝ≥0∞} (hg : u.Tendsto g (𝓝 0)) :
     u.liminf (f + g) = u.liminf f := by
   have h_eps {ε} (hε : ε > 0) : ∃ v ∈ u, ∀ n ∈ v, g n < ε := by
     simpa [eventually_iff_exists_mem] using hg.eventually (gt_mem_nhds hε)
@@ -1453,7 +1454,8 @@ theorem liminf_add_of_right_tendsto_zero (u : Filter ι) (f : ι → ℝ≥0∞)
   · refine liminf_le_liminf (Eventually.of_forall ?_)
     simp
 
-theorem limsup_add_of_right_tendsto_zero (u : Filter ι) (f : ι → ℝ≥0∞) {g : ι → ℝ≥0∞} (hg : u.Tendsto g (𝓝 0)) :
+theorem limsup_add_of_right_tendsto_zero (u : Filter ι)
+  (f : ι → ℝ≥0∞) {g : ι → ℝ≥0∞} (hg : u.Tendsto g (𝓝 0)) :
     u.limsup (f + g) = u.limsup f := by
   have h_eps {ε} (hε : ε > 0) : ∃ v ∈ u, ∀ n ∈ v, g n < ε := by
     simpa [eventually_iff_exists_mem] using hg.eventually (gt_mem_nhds hε)

--- a/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
+++ b/Mathlib/Topology/Instances/ENNReal/Lemmas.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl
 -/
 import Mathlib.Algebra.BigOperators.Intervals
 import Mathlib.Data.ENNReal.BigOperators
+import Mathlib.Tactic.Bound
 import Mathlib.Topology.Order.LiminfLimsup
 import Mathlib.Topology.EMetricSpace.Lipschitz
 import Mathlib.Topology.Instances.NNReal.Lemmas
@@ -1425,6 +1426,108 @@ lemma ofNNReal_liminf {u : ι → ℝ≥0} (hf : f.IsCoboundedUnder (· ≥ ·) 
   refine eq_of_forall_nnreal_iff fun r ↦ ?_
   rw [coe_le_coe, le_liminf_iff, le_liminf_iff]
   simp [forall_ennreal]
+
+theorem Filter.liminf_add_tendsTo_zero {T : Type*} [Preorder T] [IsDirected T fun x1 x2 => x1 ≤ x2] [Nonempty T]
+  (f g : T → ENNReal) (hg : Filter.atTop.Tendsto g (𝓝 0)) :
+    Filter.atTop.liminf (f + g) = Filter.atTop.liminf f := by
+  -- Since $g$ tends to $0$, for any $\epsilon > 0$, there exists $N$ such that for all $n \geq N$, $g(n) < \epsilon$.
+  have h_eps : ∀ ε > 0, ∃ N, ∀ n ≥ N, g n < ε := by
+    intro ε hε;
+    simpa using ( hg.eventually ( gt_mem_nhds hε ) );
+  refine' le_antisymm _ _;
+  -- Case 1
+  · refine' le_of_forall_gt_imp_ge_of_dense fun b hb => _;
+    simp only [ Filter.liminf_eq ] at *;
+    refine' csSup_le _ _;
+    -- Case 1
+    · -- Since $f$ and $g$ are non-negative, $0 \leq f n + g n$ for all $n$. Therefore, $0$ is in the set.
+      use 0
+      simp;
+    -- Case 2
+    · intro b_1 a
+      simp_all only [gt_iff_lt, ge_iff_le, eventually_atTop, Pi.add_apply, Set.mem_setOf_eq]
+      obtain ⟨w, h⟩ := a
+      contrapose! hb;
+      -- Since $b < b_1$, we can choose $\epsilon = b_1 - b$.
+      obtain ⟨N, hN⟩ : ∃ N, ∀ n ≥ N, g n < b_1 - b := by
+        exact h_eps _ ( tsub_pos_iff_lt.mpr hb );
+      refine' le_csSup _ _;
+      -- Case 1
+      · norm_num +zetaDelta at *;
+      -- Case 2
+      · dsimp
+        obtain ⟨w_max, hw⟩ := directed_of (· ≤ ·) N w
+        use w_max
+        intro n hn;
+        specialize h n ( hw.2.trans hn );
+        specialize hN n ( hw.1.trans hn ) ;
+        contrapose! hN;
+        exact tsub_le_iff_left.mpr ( by simpa only [ add_comm ] using le_trans h ( add_le_add_right hN.le _ ) );
+  -- Case 2
+  · refine' ( csSup_le _ _ );
+    -- Case 1
+    · norm_num;
+      exact ⟨ 0, ⟨ Classical.choice ‹_›, fun _ _ => zero_le _ ⟩ ⟩;
+    -- Case 2
+    · -- Given that $b$ is a lower bound for $f$, we need to show that $b$ is also a lower bound for $f + g$.
+      intros b hb
+      have h_lower_bound : ∀ᶠ n in Filter.atTop, b ≤ f n + g n := by
+        simp_all only [gt_iff_lt, ge_iff_le, eventually_map, eventually_atTop, Set.mem_setOf_eq]
+        obtain ⟨w, h⟩ := hb
+        exact ⟨ w, fun n hn => le_add_right ( h n hn ) ⟩;
+      refine' le_csSup _ _;
+      -- Case 1
+      · simp;
+      -- Case 2
+      · bound
+
+theorem Filter.limsup_add_tendsTo_zero {T : Type*} [Preorder T] [IsDirected T fun x1 x2 => x1 ≤ x2] [Nonempty T]
+  (f g : T → ENNReal) (hg : Filter.atTop.Tendsto g (𝓝 0)) :
+    Filter.atTop.limsup (f + g) = Filter.atTop.limsup f := by
+  -- Since $g$ tends to $0$, for any $\epsilon > 0$, there exists an $N$ such that for all $n \geq N$, $g(n) < \epsilon$.
+  have h_eps : ∀ ε > 0, ∃ N, ∀ n ≥ N, g n < ε := by
+    intro ε hε;
+    simpa using ( hg.eventually ( gt_mem_nhds hε ) );
+  rw [ Filter.limsup_eq, Filter.limsup_eq ];
+  -- To prove the equality of the infimums, it suffices to show that for any $a$ in the set where $f n$ is eventually $\leq a$, there exists an $a'$ in the set where $f + g n$ is eventually $\leq a'$, and vice versa.
+  apply le_antisymm;
+  -- Case 1
+  · -- For any $a$ in the set where $f$ is eventually $\leq a$, we can find an $a' = a + \epsilon$ in the set where $f + g$ is eventually $\leq a'$.
+    have h_forall_a : ∀ a ∈ {a : ENNReal | ∀ᶠ n in Filter.atTop, f n ≤ a}, ∀ ε > 0, ∃ a' ∈ {a : ENNReal | ∀ᶠ n in Filter.atTop, (f + g) n ≤ a}, a' ≤ a + ε := by
+      simp +zetaDelta at *;
+      intro a x hx ε ε_pos;
+      rcases h_eps ε ε_pos with ⟨ N, hN ⟩ ;
+      refine ⟨ a + ε, ?_, le_rfl ⟩;
+      obtain ⟨ w_max , hw ⟩ := directed_of (· ≤ ·) x N
+      use w_max
+      intro n hn
+      exact add_le_add ( hx n ( hw.1.trans hn ) ) ( le_of_lt ( hN n ( hw.2.trans hn ) ) )
+    apply le_of_forall_le;
+    intro c a
+    simp_all only [gt_iff_lt, ge_iff_le, eventually_atTop, Set.mem_setOf_eq, Pi.add_apply, forall_exists_index,
+      le_sInf_iff]
+    intro b x h
+    contrapose! a;
+    rcases ENNReal.lt_iff_exists_add_pos_lt.1 a with ⟨ ε, ε_pos, hε ⟩;
+    rcases h_forall_a b x h ε ( by simpa using ε_pos ) with ⟨ a', ⟨ x', hx' ⟩, ha' ⟩ ; exact ⟨ a', x', hx', lt_of_le_of_lt ha' hε ⟩;
+  -- Case 2
+  · refine' le_csInf _ _;
+    -- Case 1
+    · simp_all only [gt_iff_lt, ge_iff_le, Pi.add_apply, eventually_atTop]
+      rcases h_eps 1 zero_lt_one with ⟨ N, hN ⟩;
+      -- Since $g(n) < 1$ for all $n \geq N$, we have $f(n) + g(n) \leq f(n) + 1$ for all $n \geq N$.
+      have h_le : ∀ n ≥ N, f n + g n ≤ f n + 1 := by
+        exact fun n hn => add_le_add_left ( le_of_lt ( hN n hn ) ) _;
+      exact ⟨ ⊤, ⟨ N, fun n hn => le_trans ( h_le n hn ) ( by norm_num ) ⟩ ⟩;
+    -- Case 2
+    · intro b a
+      simp_all only [gt_iff_lt, ge_iff_le, Pi.add_apply, eventually_atTop, Set.mem_setOf_eq]
+      refine' csInf_le _ _;
+      -- Case 1
+      · exact ⟨ 0, by rintro x ⟨ N, hN ⟩ ; exact zero_le _ ⟩;
+      -- Case 2
+      · obtain ⟨w, h⟩ := a
+        exact ⟨ w, fun n hn => le_trans ( le_add_right le_rfl ) ( h n hn ) ⟩
 
 end LimsupLiminf
 

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -208,6 +208,7 @@
   ["Mathlib.Topology.Connected.TotallyDisconnected"],
   "Mathlib.Topology.Order.LeftRightNhds":
   ["Mathlib.Algebra.Ring.Pointwise.Set"],
+  "Mathlib.Topology.Instances.ENNReal.Lemmas": ["Mathlib.Tactic.Bound"],
   "Mathlib.Topology.Germ": ["Mathlib.Analysis.Normed.Module.Basic"],
   "Mathlib.Topology.DiscreteSubset": ["Mathlib.Tactic.TautoSet"],
   "Mathlib.Topology.Defs.Basic": ["Mathlib.Tactic.FunProp"],


### PR DESCRIPTION
Co-authored-by: @Aristotle-Harmonic

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
