### PR TITLE
[Merged by Bors] - feat: the category of commutative bialgebras

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -98,6 +98,7 @@ import Mathlib.Algebra.Category.CoalgCat.Monoidal
 import Mathlib.Algebra.Category.CommAlgCat.Basic
 import Mathlib.Algebra.Category.CommAlgCat.FiniteType
 import Mathlib.Algebra.Category.CommAlgCat.Monoidal
+import Mathlib.Algebra.Category.CommBialgCat
 import Mathlib.Algebra.Category.ContinuousCohomology.Basic
 import Mathlib.Algebra.Category.FGModuleCat.Basic
 import Mathlib.Algebra.Category.FGModuleCat.EssentiallySmall

--- a/Mathlib/Algebra/Category/CommAlgCat/Basic.lean
+++ b/Mathlib/Algebra/Category/CommAlgCat/Basic.lean
@@ -146,17 +146,19 @@ def isoMk {X Y : Type v} {_ : CommRing X} {_ : CommRing Y} {_ : Algebra R X} {_ 
 
 /-- Build an `AlgEquiv` from an isomorphism in the category `CommAlgCat R`. -/
 @[simps]
-def ofIso (i : A ≅ B) : A ≃ₐ[R] B where
+def algEquivOfIso (i : A ≅ B) : A ≃ₐ[R] B where
   __ := i.hom.hom
   toFun := i.hom
   invFun := i.inv
   left_inv x := by simp
   right_inv x := by simp
 
+@[deprecated (since := "2025-08-22")] alias ofIso := algEquivOfIso
+
 /-- Algebra equivalences between `Algebra`s are the same as isomorphisms in `CommAlgCat`. -/
 @[simps]
 def isoEquivAlgEquiv : (of R X ≅ of R Y) ≃ (X ≃ₐ[R] Y) where
-  toFun := ofIso
+  toFun := algEquivOfIso
   invFun := isoMk
 
 instance reflectsIsomorphisms_forget : (forget (CommAlgCat.{u} R)).ReflectsIsomorphisms where

--- a/Mathlib/Algebra/Category/CommBialgCat.lean
+++ b/Mathlib/Algebra/Category/CommBialgCat.lean
@@ -147,7 +147,7 @@ def isoMk {X Y : Type v} {_ : CommRing X} {_ : CommRing Y} {_ : Bialgebra R X}
 
 /-- Build a `BialgEquiv` from an isomorphism in the category `CommBialgCat R`. -/
 @[simps apply, simps -isSimp symm_apply]
-def ofIso (i : A ≅ B) : A ≃ₐc[R] B where
+def bialgEquivOfIso (i : A ≅ B) : A ≃ₐc[R] B where
   __ := i.hom.hom
   toFun := i.hom
   invFun := i.inv
@@ -157,7 +157,7 @@ def ofIso (i : A ≅ B) : A ≃ₐc[R] B where
 /-- Bialgebra equivalences between `Bialgebra`s are the same as isomorphisms in `CommBialgCat`. -/
 @[simps]
 def isoEquivBialgEquiv : (of R X ≅ of R Y) ≃ (X ≃ₐc[R] Y) where
-  toFun := ofIso
+  toFun := bialgEquivOfIso
   invFun := isoMk
   left_inv _ := rfl
   right_inv _ := rfl

--- a/Mathlib/Algebra/Category/CommBialgCat.lean
+++ b/Mathlib/Algebra/Category/CommBialgCat.lean
@@ -69,7 +69,7 @@ instance : ConcreteCategory (CommBialgCat.{v} R) (· →ₐc[R] ·) where
   ofHom := Hom.mk
 
 /-- Turn a morphism in `CommBialgCat` back into a `BialgHom`. -/
-abbrev Hom.hom (f : Hom A B) := ConcreteCategory.hom (C := CommBialgCat R) f
+abbrev Hom.hom (f : Hom A B) : A →ₐc[R] B := ConcreteCategory.hom (C := CommBialgCat R) f
 
 /-- Typecheck a `BialgHom` as a morphism in `CommBialgCat R`. -/
 abbrev ofHom {X Y : Type v} {_ : CommRing X} {_ : CommRing Y} {_ : Bialgebra R X}
@@ -86,13 +86,9 @@ The results below duplicate the `ConcreteCategory` simp lemmas, but we can keep 
 -/
 
 @[simp] lemma hom_id : (𝟙 A : A ⟶ A).hom = AlgHom.id R A := rfl
-
-/- Provided for rewriting. -/
-lemma id_apply (A : CommBialgCat.{v} R) (a : A) : (𝟙 A : A ⟶ A) a = a := by simp
-
 @[simp] lemma hom_comp (f : A ⟶ B) (g : B ⟶ C) : (f ≫ g).hom = g.hom.comp f.hom := rfl
 
-/- Provided for rewriting. -/
+lemma id_apply (A : CommBialgCat.{v} R) (a : A) : (𝟙 A : A ⟶ A) a = a := by simp
 lemma comp_apply (f : A ⟶ B) (g : B ⟶ C) (a : A) : (f ≫ g) a = g (f a) := by simp
 
 @[ext] lemma hom_ext {f g : A ⟶ B} (hf : f.hom = g.hom) : f = g := Hom.ext hf
@@ -230,5 +226,5 @@ lemma commBialgCatEquivComonCommAlgCat_inverse_map_unop_hom
     f.unop.hom.unop.hom := rfl
 
 instance {A : CommBialgCat.{u} R} [IsCocomm R A] :
-    IsCommMon ((commBialgCatEquivComonCommAlgCat R).functor.obj A).unop.X := by
-  dsimp; infer_instance
+    IsCommMon ((commBialgCatEquivComonCommAlgCat R).functor.obj A).unop.X :=
+  inferInstanceAs <| IsCommMon <| op <| CommAlgCat.of R A

--- a/Mathlib/Algebra/Category/CommBialgCat.lean
+++ b/Mathlib/Algebra/Category/CommBialgCat.lean
@@ -1,0 +1,234 @@
+/-
+Copyright (c) 2025 Yaël Dillies, Michał Mrugała, Andrew Yang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies, Michał Mrugała, Andrew Yang
+-/
+import Mathlib.Algebra.Category.CommAlgCat.Monoidal
+import Mathlib.CategoryTheory.Monoidal.Mon_
+import Mathlib.RingTheory.Bialgebra.Equiv
+
+/-!
+# The category of commutative bialgebras over a commutative ring
+
+This file defines the bundled category `CommBialgCat R` of commutative bialgebras over a fixed
+commutative ring `R` along with the forgetful functor to `CommAlgCat`.
+-/
+
+noncomputable section
+
+open Bialgebra Coalgebra Opposite CategoryTheory Limits Mon_Class
+open scoped MonoidalCategory
+
+universe v u
+variable {R : Type u} [CommRing R]
+
+variable (R) in
+/-- The category of commutative `R`-bialgebras and their morphisms. -/
+structure CommBialgCat where
+  private mk ::
+  /-- The underlying type. -/
+  carrier : Type v
+  [commRing : CommRing carrier]
+  [bialgebra : Bialgebra R carrier]
+
+namespace CommBialgCat
+variable {A B C : CommBialgCat.{v} R} {X Y Z : Type v} [CommRing X] [Bialgebra R X]
+  [CommRing Y] [Bialgebra R Y] [CommRing Z] [Bialgebra R Z]
+
+attribute [instance] commRing bialgebra
+
+initialize_simps_projections CommBialgCat (-commRing, -bialgebra)
+
+instance : CoeSort (CommBialgCat R) (Type v) := ⟨carrier⟩
+
+attribute [coe] CommBialgCat.carrier
+
+variable (R) in
+/-- Turn an unbundled `R`-bialgebra into the corresponding object in the category of `R`-bialgebras.
+
+This is the preferred way to construct a term of `CommBialgCat R`. -/
+abbrev of (X : Type v) [CommRing X] [Bialgebra R X] : CommBialgCat.{v} R := ⟨X⟩
+
+variable (R) in
+lemma coe_of (X : Type v) [CommRing X] [Bialgebra R X] : (of R X : Type v) = X := rfl
+
+/-- The type of morphisms in `CommBialgCat R`. -/
+@[ext]
+structure Hom (A B : CommBialgCat.{v} R) where
+  private mk ::
+  /-- The underlying bialgebra map. -/
+  hom' : A →ₐc[R] B
+
+instance : Category (CommBialgCat.{v} R) where
+  Hom A B := Hom A B
+  id A := ⟨.id R A⟩
+  comp f g := ⟨g.hom'.comp f.hom'⟩
+
+instance : ConcreteCategory (CommBialgCat.{v} R) (· →ₐc[R] ·) where
+  hom := Hom.hom'
+  ofHom := Hom.mk
+
+/-- Turn a morphism in `CommBialgCat` back into a `BialgHom`. -/
+abbrev Hom.hom (f : Hom A B) := ConcreteCategory.hom (C := CommBialgCat R) f
+
+/-- Typecheck a `BialgHom` as a morphism in `CommBialgCat R`. -/
+abbrev ofHom {X Y : Type v} {_ : CommRing X} {_ : CommRing Y} {_ : Bialgebra R X}
+    {_ : Bialgebra R Y} (f : X →ₐc[R] Y) : of R X ⟶ of R Y :=
+  ConcreteCategory.ofHom (C := CommBialgCat R) f
+
+/-- Use the `ConcreteCategory.hom` projection for `@[simps]` lemmas. -/
+def Hom.Simps.hom (A B : CommBialgCat.{v} R) (f : Hom A B) := f.hom
+
+initialize_simps_projections Hom (hom' → hom)
+
+/-!
+The results below duplicate the `ConcreteCategory` simp lemmas, but we can keep them for `dsimp`.
+-/
+
+@[simp] lemma hom_id : (𝟙 A : A ⟶ A).hom = AlgHom.id R A := rfl
+
+/- Provided for rewriting. -/
+lemma id_apply (A : CommBialgCat.{v} R) (a : A) : (𝟙 A : A ⟶ A) a = a := by simp
+
+@[simp] lemma hom_comp (f : A ⟶ B) (g : B ⟶ C) : (f ≫ g).hom = g.hom.comp f.hom := rfl
+
+/- Provided for rewriting. -/
+lemma comp_apply (f : A ⟶ B) (g : B ⟶ C) (a : A) : (f ≫ g) a = g (f a) := by simp
+
+@[ext] lemma hom_ext {f g : A ⟶ B} (hf : f.hom = g.hom) : f = g := Hom.ext hf
+
+@[simp] lemma hom_ofHom (f : X →ₐc[R] Y) : (ofHom f).hom = f := rfl
+@[simp] lemma ofHom_hom (f : A ⟶ B) : ofHom f.hom = f := rfl
+
+@[simp] lemma ofHom_id : ofHom (.id R X) = 𝟙 (of R X) := rfl
+
+@[simp]
+lemma ofHom_comp (f : X →ₐc[R] Y) (g : Y →ₐc[R] Z) : ofHom (g.comp f) = ofHom f ≫ ofHom g := rfl
+
+lemma ofHom_apply (f : X →ₐc[R] Y) (x : X) : ofHom f x = f x := rfl
+
+lemma inv_hom_apply (e : A ≅ B) (x : A) : e.inv (e.hom x) = x := by simp
+lemma hom_inv_apply (e : A ≅ B) (x : B) : e.hom (e.inv x) = x := by simp
+
+instance : Inhabited (CommBialgCat R) := ⟨of R R⟩
+
+lemma forget_obj (A : CommBialgCat.{v} R) : (forget (CommBialgCat.{v} R)).obj A = A := rfl
+
+lemma forget_map (f : A ⟶ B) : (forget (CommBialgCat.{v} R)).map f = f := rfl
+
+instance : CommRing ((forget (CommBialgCat R)).obj A) := inferInstanceAs <| CommRing A
+
+instance : Bialgebra R ((forget (CommBialgCat R)).obj A) := inferInstanceAs <| Bialgebra R A
+
+instance hasForgetToCommAlgCat : HasForget₂ (CommBialgCat.{v} R) (CommAlgCat.{v} R) where
+  forget₂.obj M := .of R M
+  forget₂.map f := CommAlgCat.ofHom f.hom
+
+@[simp] lemma forget₂_commAlgCat_obj (A : CommBialgCat.{v} R) :
+    (forget₂ (CommBialgCat.{v} R) (CommAlgCat.{v} R)).obj A = .of R A := rfl
+
+@[simp] lemma forget₂_commAlgCat_map (f : A ⟶ B) :
+    (forget₂ (CommBialgCat.{v} R) (CommAlgCat.{v} R)).map f = CommAlgCat.ofHom f.hom := rfl
+
+/-- Forgetting to the underlying type and then building the bundled object returns the original
+bialgebra. -/
+@[simps]
+def ofSelfIso (M : CommBialgCat.{v} R) : of R M ≅ M where
+  hom := 𝟙 M
+  inv := 𝟙 M
+
+/-- Build an isomorphism in the category `CommBialgCat R` from a `BialgEquiv` between
+`Bialgebra`s. -/
+@[simps]
+def isoMk {X Y : Type v} {_ : CommRing X} {_ : CommRing Y} {_ : Bialgebra R X}
+    {_ : Bialgebra R Y} (e : X ≃ₐc[R] Y) : of R X ≅ of R Y where
+  hom := ofHom (e : X →ₐc[R] Y)
+  inv := ofHom (e.symm : Y →ₐc[R] X)
+
+/-- Build a `BialgEquiv` from an isomorphism in the category `CommBialgCat R`. -/
+@[simps apply, simps -isSimp symm_apply]
+def ofIso (i : A ≅ B) : A ≃ₐc[R] B where
+  __ := i.hom.hom
+  toFun := i.hom
+  invFun := i.inv
+  left_inv x := by simp
+  right_inv x := by simp
+
+/-- Bialgebra equivalences between `Bialgebra`s are the same as isomorphisms in `CommBialgCat`. -/
+@[simps]
+def isoEquivBialgEquiv : (of R X ≅ of R Y) ≃ (X ≃ₐc[R] Y) where
+  toFun := ofIso
+  invFun := isoMk
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+instance reflectsIsomorphisms_forget : (forget (CommBialgCat.{u} R)).ReflectsIsomorphisms where
+  reflects {X Y} f _ := by
+    let i := asIso ((forget (CommBialgCat.{u} R)).map f)
+    let e : X ≃ₐc[R] Y := { f.hom, i.toEquiv with }
+    exact (isoMk e).isIso_hom
+
+end CommBialgCat
+
+attribute [local ext] Quiver.Hom.unop_inj
+
+instance CommAlgCat.mon_ClassOpOf {A : Type u} [CommRing A] [Bialgebra R A] :
+    Mon_Class (op <| CommAlgCat.of R A) where
+  one := (CommAlgCat.ofHom <| counitAlgHom R A).op
+  mul := (CommAlgCat.ofHom <| comulAlgHom R A).op
+  one_mul := by ext; exact Coalgebra.rTensor_counit_comul _
+  mul_one := by ext; exact Coalgebra.lTensor_counit_comul _
+  mul_assoc := by ext; exact (Coalgebra.coassoc_symm_apply _).symm
+
+@[simp]
+lemma CommAlgCat.one_op_of_unop_hom {A : Type u} [CommRing A] [Bialgebra R A] :
+    η[op <| CommAlgCat.of R A].unop.hom = counitAlgHom R A := rfl
+
+@[simp]
+lemma CommAlgCat.mul_op_of_unop_hom {A : Type u} [CommRing A] [Bialgebra R A] :
+    μ[op <| CommAlgCat.of R A].unop.hom = comulAlgHom R A := rfl
+
+instance {A : Type u} [CommRing A] [Bialgebra R A] [IsCocomm R A] :
+    IsCommMon (Opposite.op <| CommAlgCat.of R A) where
+  mul_comm := by ext; exact comm_comul R _
+
+instance {A B : Type u} [CommRing A] [Bialgebra R A] [CommRing B] [Bialgebra R B]
+    (f : A →ₐc[R] B) : IsMon_Hom (CommAlgCat.ofHom (f : A →ₐ[R] B)).op where
+
+instance (A : (CommAlgCat R)ᵒᵖ) [Mon_Class A] : Bialgebra R A.unop :=
+  .ofAlgHom μ[A].unop.hom η[A].unop.hom
+    congr(($((Mon_Class.mul_assoc_flip A).symm)).unop.hom)
+    congr(($(Mon_Class.one_mul A)).unop.hom)
+    congr(($(Mon_Class.mul_one A)).unop.hom)
+
+variable (R) in
+/-- Commutative bialgebras over a commutative ring `R` are the same thing as comonoid
+`R`-algebras. -/
+@[simps! functor_obj_unop_X inverse_obj unitIso_hom_app
+  unitIso_inv_app counitIso_hom_app counitIso_inv_app]
+def commBialgCatEquivComonCommAlgCat : CommBialgCat R ≌ (Mon_ (CommAlgCat R)ᵒᵖ)ᵒᵖ where
+  functor.obj A := .op <| .mk <| .op <| .of R A
+  functor.map {A B} f := .op <| .mk' <| .op <| CommAlgCat.ofHom f.hom
+  inverse.obj A := .of R A.unop.X.unop
+  inverse.map {A B} f := CommBialgCat.ofHom <| .ofAlgHom f.unop.hom.unop.hom
+    congr(($(IsMon_Hom.one_hom (f := f.unop.hom))).unop.hom.toLinearMap)
+    congr(($((IsMon_Hom.mul_hom (f := f.unop.hom)).symm)).unop.hom.toLinearMap)
+  unitIso.hom := 𝟙 _
+  unitIso.inv := 𝟙 _
+  counitIso.hom := 𝟙 _
+  counitIso.inv := 𝟙 _
+
+@[simp]
+lemma commBialgCatEquivComonCommAlgCat_functor_map_unop_hom {A B : CommBialgCat R} (f : A ⟶ B) :
+  ((commBialgCatEquivComonCommAlgCat R).functor.map f).unop.hom =
+    (CommAlgCat.ofHom (AlgHomClass.toAlgHom f.hom)).op := rfl
+
+@[simp]
+lemma commBialgCatEquivComonCommAlgCat_inverse_map_unop_hom
+    {A B : (Mon_ (CommAlgCat R)ᵒᵖ)ᵒᵖ} (f : A ⟶ B) :
+  AlgHomClass.toAlgHom ((commBialgCatEquivComonCommAlgCat R).inverse.map f).hom =
+    f.unop.hom.unop.hom := rfl
+
+instance {A : CommBialgCat.{u} R} [IsCocomm R A] :
+    IsCommMon ((commBialgCatEquivComonCommAlgCat R).functor.obj A).unop.X := by
+  dsimp; infer_instance

--- a/Mathlib/Algebra/Category/CommBialgCat.lean
+++ b/Mathlib/Algebra/Category/CommBialgCat.lean
@@ -211,8 +211,8 @@ def commBialgCatEquivComonCommAlgCat : CommBialgCat R ≌ (Mon_ (CommAlgCat R)�
   functor.map {A B} f := .op <| .mk' <| .op <| CommAlgCat.ofHom f.hom
   inverse.obj A := .of R A.unop.X.unop
   inverse.map {A B} f := CommBialgCat.ofHom <| .ofAlgHom f.unop.hom.unop.hom
-    congr(($(IsMon_Hom.one_hom (f := f.unop.hom))).unop.hom.toLinearMap)
-    congr(($((IsMon_Hom.mul_hom (f := f.unop.hom)).symm)).unop.hom.toLinearMap)
+    congr(($(IsMon_Hom.one_hom (f := f.unop.hom))).unop.hom)
+    congr(($((IsMon_Hom.mul_hom (f := f.unop.hom)).symm)).unop.hom)
   unitIso.hom := 𝟙 _
   unitIso.inv := 𝟙 _
   counitIso.hom := 𝟙 _


### PR DESCRIPTION
Define the bundled category `CommBialgCat R` of commutative bialgebras over a fixed commutative ring `R` along with the forgetful functor to `CommAlgCat`.

From Toric

Co-authored-by: Andrew Yang <the.erd.one@gmail.com>
Co-authored-by: Michał Mrugała <kiolterino@gmail.com>


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
