### PR TITLE
[Merged by Bors] - chore: mark argument explicit in `LinearOrder.toBiheytingAlgebra`

### DIFF
--- a/Mathlib/Data/Fintype/Order.lean
+++ b/Mathlib/Data/Fintype/Order.lean
@@ -120,7 +120,7 @@ If the `α` is already a `BiheytingAlgebra`, then prefer to construct this insta
 `LinearOrder.toBiheytingAlgebra`. -/
 noncomputable abbrev toCompleteLinearOrder
     [LinearOrder α] [BoundedOrder α] : CompleteLinearOrder α :=
-  { toCompleteLattice α, ‹LinearOrder α›, LinearOrder.toBiheytingAlgebra with }
+  { toCompleteLattice α, ‹LinearOrder α›, LinearOrder.toBiheytingAlgebra _ with }
 
 -- See note [reducible non-instances]
 /-- A finite boolean algebra is complete. -/
@@ -144,15 +144,14 @@ variable (α) [Nonempty α]
 /-- A nonempty finite lattice is complete. If the lattice is already a `BoundedOrder`, then use
 `Fintype.toCompleteLattice` instead, as this gives definitional equality for `⊥` and `⊤`. -/
 noncomputable abbrev toCompleteLatticeOfNonempty [Lattice α] : CompleteLattice α :=
-  @toCompleteLattice _ _ _ <| @toBoundedOrder α _ ⟨Classical.arbitrary α⟩ _
+  @toCompleteLattice _ _ _ <| toBoundedOrder α
 
 -- See note [reducible non-instances]
 /-- A nonempty finite linear order is complete. If the linear order is already a `BoundedOrder`,
 then use `Fintype.toCompleteLinearOrder` instead, as this gives definitional equality for `⊥` and
 `⊤`. -/
-noncomputable abbrev toCompleteLinearOrderOfNonempty [LinearOrder α] : CompleteLinearOrder α := by
-  let _ := toBoundedOrder α
-  exact { toCompleteLatticeOfNonempty α, ‹LinearOrder α›, LinearOrder.toBiheytingAlgebra with }
+noncomputable abbrev toCompleteLinearOrderOfNonempty [LinearOrder α] : CompleteLinearOrder α :=
+  @toCompleteLinearOrder _ _ _ <| toBoundedOrder α
 
 end Nonempty
 

--- a/Mathlib/Data/Nat/PartENat.lean
+++ b/Mathlib/Data/Nat/PartENat.lean
@@ -739,6 +739,6 @@ noncomputable instance : LinearOrderedAddCommMonoidWithTop PartENat :=
 
 noncomputable instance : CompleteLinearOrder PartENat :=
   { lattice, withTopOrderIso.symm.toGaloisInsertion.liftCompleteLattice,
-    linearOrder, LinearOrder.toBiheytingAlgebra with }
+    linearOrder, linearOrder.toBiheytingAlgebra with }
 
 end PartENat

--- a/Mathlib/Order/CompleteLatticeIntervals.lean
+++ b/Mathlib/Order/CompleteLatticeIntervals.lean
@@ -209,7 +209,7 @@ noncomputable instance Set.Icc.completeLattice [ConditionallyCompleteLattice α]
 /-- Complete linear order structure on `Set.Icc` -/
 noncomputable instance [ConditionallyCompleteLinearOrder α] {a b : α} [Fact (a ≤ b)] :
     CompleteLinearOrder (Set.Icc a b) :=
-  { Set.Icc.completeLattice, Subtype.instLinearOrder _, LinearOrder.toBiheytingAlgebra with }
+  { Set.Icc.completeLattice, Subtype.instLinearOrder _, LinearOrder.toBiheytingAlgebra _ with }
 
 lemma Set.Icc.coe_sSup [ConditionallyCompleteLattice α] {a b : α} (h : a ≤ b)
     {S : Set (Set.Icc a b)} (hS : S.Nonempty) : have : Fact (a ≤ b) := ⟨h⟩

--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -736,7 +736,7 @@ theorem isGLB_sInf (s : Set (WithTop α)) : IsGLB s (sInf s) := by
 
 noncomputable instance : CompleteLinearOrder (WithTop α) where
   __ := linearOrder
-  __ := LinearOrder.toBiheytingAlgebra
+  __ := LinearOrder.toBiheytingAlgebra (WithTop α)
   le_sSup s := (isLUB_sSup s).1
   sSup_le s := (isLUB_sSup s).2
   le_sInf s := (isGLB_sInf s).2
@@ -964,9 +964,10 @@ noncomputable instance WithTop.WithBot.completeLattice {α : Type*}
     le_sInf := fun _ a haS => (WithTop.isGLB_sInf' ⟨a, haS⟩).2 haS }
 
 noncomputable instance WithTop.WithBot.completeLinearOrder {α : Type*}
-    [ConditionallyCompleteLinearOrder α] : CompleteLinearOrder (WithTop (WithBot α)) :=
-  -- FIXME: Spread notation doesn't work
-  { completeLattice, linearOrder, LinearOrder.toBiheytingAlgebra with }
+    [ConditionallyCompleteLinearOrder α] : CompleteLinearOrder (WithTop (WithBot α)) where
+  __ := completeLattice
+  __ := linearOrder
+  __ := linearOrder.toBiheytingAlgebra
 
 noncomputable instance WithBot.WithTop.completeLattice {α : Type*}
     [ConditionallyCompleteLattice α] : CompleteLattice (WithBot (WithTop α)) :=
@@ -977,7 +978,9 @@ noncomputable instance WithBot.WithTop.completeLattice {α : Type*}
     le_sInf := (WithTop.WithBot.completeLattice (α := αᵒᵈ)).sSup_le }
 
 noncomputable instance WithBot.WithTop.completeLinearOrder {α : Type*}
-    [ConditionallyCompleteLinearOrder α] : CompleteLinearOrder (WithBot (WithTop α)) :=
-  { completeLattice, linearOrder, LinearOrder.toBiheytingAlgebra with }
+    [ConditionallyCompleteLinearOrder α] : CompleteLinearOrder (WithBot (WithTop α)) where
+  __ := completeLattice
+  __ := linearOrder
+  __ := linearOrder.toBiheytingAlgebra
 
 end WithTopBot

--- a/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Basic.lean
@@ -736,7 +736,7 @@ theorem isGLB_sInf (s : Set (WithTop α)) : IsGLB s (sInf s) := by
 
 noncomputable instance : CompleteLinearOrder (WithTop α) where
   __ := linearOrder
-  __ := LinearOrder.toBiheytingAlgebra (WithTop α)
+  __ := linearOrder.toBiheytingAlgebra
   le_sSup s := (isLUB_sSup s).1
   sSup_le s := (isLUB_sSup s).2
   le_sInf s := (isGLB_sInf s).2

--- a/Mathlib/Order/Fin/Basic.lean
+++ b/Mathlib/Order/Fin/Basic.lean
@@ -54,7 +54,7 @@ instance instBoundedOrder [NeZero n] : BoundedOrder (Fin n) where
   bot_le := Fin.zero_le
 
 instance instBiheytingAlgebra [NeZero n] : BiheytingAlgebra (Fin n) :=
-  LinearOrder.toBiheytingAlgebra
+  LinearOrder.toBiheytingAlgebra (Fin n)
 
 @[simp, norm_cast]
 theorem coe_max (a b : Fin n) : ↑(max a b) = (max a b : ℕ) := rfl

--- a/Mathlib/Order/Heyting/Basic.lean
+++ b/Mathlib/Order/Heyting/Basic.lean
@@ -946,6 +946,7 @@ theorem himp_iff_imp (p q : Prop) : p ⇨ q ↔ p → q :=
 theorem compl_iff_not (p : Prop) : pᶜ ↔ ¬p :=
   Iff.rfl
 
+variable (α) in
 -- See note [reducible non-instances]
 /-- A bounded linear order is a bi-Heyting algebra by setting
 * `a ⇨ b = ⊤` if `a ≤ b` and `a ⇨ b = b` otherwise.


### PR DESCRIPTION
Mark `α : Type*` explicit in `LinearOrder.toBiheytingAlgebra`. This matches better with what other similar reducible non-instances have.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
