### PR TITLE
refactor(LinearAlgebra/Projection): generalize results to use `Semiring` instead of `Ring`

### DIFF
--- a/Mathlib/LinearAlgebra/Projection.lean
+++ b/Mathlib/LinearAlgebra/Projection.lean
@@ -61,10 +61,9 @@ theorem isCompl_of_proj [Module S E] {p : Submodule S E}
     rw [codisjoint_iff_le_sup]
     intro x _
     rw [mem_sup']
-    refine ⟨⟨f' x, ?_⟩, ⟨x - f' x, ?_⟩, ?_⟩
+    refine ⟨⟨f' x, ?_⟩, ⟨x - f' x, ?_⟩, add_sub_cancel _ _⟩
     · simp only [mem_range, exists_apply_eq_apply]
     · simp [mem_ker, map_sub, f', hf]
-    · simp only [add_sub_cancel]
 
 end LinearMap
 

--- a/Mathlib/LinearAlgebra/Projection.lean
+++ b/Mathlib/LinearAlgebra/Projection.lean
@@ -63,8 +63,7 @@ theorem isCompl_of_proj [Module S E] {p : Submodule S E}
     rw [mem_sup']
     refine ⟨⟨f' x, ?_⟩, ⟨x - f' x, ?_⟩, ?_⟩
     · simp only [mem_range, exists_apply_eq_apply]
-    · rw [mem_ker, map_sub]
-      simp [f', hf]
+    · simp [mem_ker, map_sub, f', hf]
     · simp only [add_sub_cancel]
 
 end LinearMap

--- a/Mathlib/LinearAlgebra/Projection.lean
+++ b/Mathlib/LinearAlgebra/Projection.lean
@@ -50,37 +50,28 @@ theorem range_eq_of_proj {f : E' →ₗ[S] p'} (hf : ∀ x : p', f x = x) : rang
 theorem isCompl_of_proj {f : E' →ₗ[S] p'} (hf : ∀ x : p', f x = x) : IsCompl p' (ker f) := by
   let f' := p'.subtype ∘ₗ f
   have hf' : ∀ x : p', f' x = x := fun x => by simp [f', hf]
-  have : range f' = p' := by
-    rw [range_comp, range_eq_of_proj hf]
-    simp
-  simp_rw [← this]
-  have : ker f = ker f' := by
-    rw [ker_comp]
-    simp
-  simp_rw [this]
-  have hf' : IsIdempotentElem f' := by
-    rw [IsIdempotentElem, Module.End.mul_eq_comp]
-    ext x
-    simp [f', hf]
-  symm
   constructor
-  · rw [disjoint_iff]
-    ext x
-    simp only [mem_bot, mem_inf, mem_ker, mem_range]
-    constructor <;> intro h'
-    · rcases h'.2 with ⟨y, rfl⟩
-      rw [← hf'.eq, Module.End.mul_apply]
-      exact h'.1
-    · rw [h', map_zero, eq_self_iff_true, true_and]
-      use x
-      simp only [h', map_zero]
-  · suffices ∀ x : E', ∃ v : ker f', ∃ w : range f', x = v + w by
-      rw [codisjoint_iff]
+  · rw [disjoint_iff_inf_le]
+    rintro x ⟨hpx, hfx⟩
+    rw [SetLike.mem_coe, mem_ker, hf ⟨x, hpx⟩, mk_eq_zero] at hfx
+    simp only [hfx, zero_mem]
+  · symm
+    rw [codisjoint_iff_le_sup]
+    have : ker f = ker f' := by
+      rw [ker_comp]
+      simp
+    have hf' : IsIdempotentElem f' := by
+      rw [IsIdempotentElem, Module.End.mul_eq_comp]
       ext x
-      rcases this x with ⟨v, w, rfl⟩
-      simp only [mem_top, iff_true]
-      exact add_mem_sup (SetLike.coe_mem v) (SetLike.coe_mem w)
-    refine fun x => ⟨⟨x - f' x, ?_⟩, ⟨f' x, ?_⟩, ?_⟩
+      simp [f', hf]
+    simp_rw [this]
+    have : range f' = p' := by
+      rw [range_comp, range_eq_of_proj hf]
+      simp
+    simp_rw [← this]
+    intro x _
+    rw [mem_sup']
+    refine ⟨⟨x - f' x, ?_⟩, ⟨f' x, ?_⟩, ?_⟩
     · rw [mem_ker, map_sub, ← Module.End.mul_apply, hf'.eq, sub_self]
     · simp only [mem_range, exists_apply_eq_apply]
     · simp only [sub_add_cancel]

--- a/Mathlib/LinearAlgebra/Projection.lean
+++ b/Mathlib/LinearAlgebra/Projection.lean
@@ -30,26 +30,27 @@ variable {R : Type*} [Ring R] {E : Type*} [AddCommGroup E] [Module R E]
 variable {F : Type*} [AddCommGroup F] [Module R F] {G : Type*} [AddCommGroup G] [Module R G]
 variable (p q : Submodule R E)
 variable {S : Type*} [Semiring S] {M : Type*} [AddCommMonoid M] [Module S M] (m : Submodule S M)
-variable {E' : Type*} [AddCommGroup E'] [Module S E'] {p' : Submodule S E'}
-
 namespace LinearMap
 
 variable {p}
 
 open Submodule
 
-theorem ker_id_sub_eq_of_proj {f : E' →ₗ[S] p'} (hf : ∀ x : p', f x = x) :
-    ker (id - p'.subtype.comp f) = p' := by
+theorem ker_id_sub_eq_of_proj [Module S E] {p : Submodule S E}
+    {f : E →ₗ[S] p} (hf : ∀ x : p, f x = x) :
+    ker (id - p.subtype.comp f) = p := by
   ext x
   simp only [comp_apply, mem_ker, subtype_apply, sub_apply, id_apply, sub_eq_zero]
   exact ⟨fun h => h.symm ▸ Submodule.coe_mem _, fun hx => by rw [hf ⟨x, hx⟩, Subtype.coe_mk]⟩
 
-theorem range_eq_of_proj {f : E' →ₗ[S] p'} (hf : ∀ x : p', f x = x) : range f = ⊤ :=
+theorem range_eq_of_proj [Module S E] {p : Submodule S E}
+    {f : E →ₗ[S] p} (hf : ∀ x : p, f x = x) : range f = ⊤ :=
   range_eq_top.2 fun x => ⟨x, hf x⟩
 
-theorem isCompl_of_proj {f : E' →ₗ[S] p'} (hf : ∀ x : p', f x = x) : IsCompl p' (ker f) := by
-  let f' := p'.subtype ∘ₗ f
-  have hf' : ∀ x : p', f' x = x := fun x => by simp [f', hf]
+theorem isCompl_of_proj [Module S E] {p : Submodule S E}
+    {f : E →ₗ[S] p} (hf : ∀ x : p, f x = x) : IsCompl p (ker f) := by
+  let f' := p.subtype ∘ₗ f
+  have hf' : ∀ x : p, f' x = x := fun x => by simp [f', hf]
   constructor
   · rw [disjoint_iff_inf_le]
     rintro x ⟨hpx, hfx⟩
@@ -65,7 +66,7 @@ theorem isCompl_of_proj {f : E' →ₗ[S] p'} (hf : ∀ x : p', f x = x) : IsCom
       ext x
       simp [f', hf]
     simp_rw [this]
-    have : range f' = p' := by
+    have : range f' = p := by
       rw [range_comp, range_eq_of_proj hf]
       simp
     simp_rw [← this]
@@ -435,7 +436,8 @@ theorem codRestrict_apply_cod {f : M →ₗ[S] M} (h : IsProj m f) (x : m) : h.c
 theorem codRestrict_ker {f : M →ₗ[S] M} (h : IsProj m f) : ker h.codRestrict = ker f :=
   f.ker_codRestrict m _
 
-theorem isCompl {f : E' →ₗ[S] E'} (h : IsProj p' f) : IsCompl p' (ker f) := by
+theorem isCompl [Module S E] {p : Submodule S E} {f : E →ₗ[S] E}
+    (h : IsProj p f) : IsCompl p (ker f) := by
   rw [← codRestrict_ker]
   exact isCompl_of_proj h.codRestrict_apply_cod
 
@@ -502,7 +504,7 @@ theorem IsIdempotentElem.comp_eq_right_iff {q : M →ₗ[S] M} (hq : IsIdempoten
 
 open LinearMap in
 /-- Idempotent operators are equal iff their range and kernels are. -/
-lemma IsIdempotentElem.ext_iff {p q : E' →ₗ[S] E'}
+lemma IsIdempotentElem.ext_iff [Module S E] {p q : E →ₗ[S] E}
     (hp : IsIdempotentElem p) (hq : IsIdempotentElem q) :
     p = q ↔ range p = range q ∧ ker p = ker q := by
   refine ⟨fun h => ⟨congrArg range h, congrArg ker h⟩, fun ⟨hr, hk⟩ => ?_⟩

--- a/Mathlib/LinearAlgebra/Projection.lean
+++ b/Mathlib/LinearAlgebra/Projection.lean
@@ -50,33 +50,22 @@ theorem range_eq_of_proj [Module S E] {p : Submodule S E}
 
 theorem isCompl_of_proj [Module S E] {p : Submodule S E}
     {f : E →ₗ[S] p} (hf : ∀ x : p, f x = x) : IsCompl p (ker f) := by
-  let f' := p.subtype ∘ₗ f
-  have hf' : ∀ x : p, f' x = x := fun x => by simp [f', hf]
   constructor
   · rw [disjoint_iff_inf_le]
     rintro x ⟨hpx, hfx⟩
     rw [SetLike.mem_coe, mem_ker, hf ⟨x, hpx⟩, mk_eq_zero] at hfx
     simp only [hfx, zero_mem]
-  · symm
+  · let f' := p.subtype ∘ₗ f
+    suffices Codisjoint (range f') (ker f') by
+      simpa [f', ker_comp, range_comp, range_eq_of_proj hf] using this
     rw [codisjoint_iff_le_sup]
-    have : ker f = ker f' := by
-      rw [ker_comp]
-      simp
-    have hf' : IsIdempotentElem f' := by
-      rw [IsIdempotentElem, Module.End.mul_eq_comp]
-      ext x
-      simp [f', hf]
-    simp_rw [this]
-    have : range f' = p := by
-      rw [range_comp, range_eq_of_proj hf]
-      simp
-    simp_rw [← this]
     intro x _
     rw [mem_sup']
-    refine ⟨⟨x - f' x, ?_⟩, ⟨f' x, ?_⟩, ?_⟩
-    · rw [mem_ker, map_sub, ← Module.End.mul_apply, hf'.eq, sub_self]
+    refine ⟨⟨f' x, ?_⟩, ⟨x - f' x, ?_⟩, ?_⟩
     · simp only [mem_range, exists_apply_eq_apply]
-    · simp only [sub_add_cancel]
+    · rw [mem_ker, map_sub]
+      simp [f', hf]
+    · simp only [add_sub_cancel]
 
 end LinearMap
 

--- a/Mathlib/LinearAlgebra/Projection.lean
+++ b/Mathlib/LinearAlgebra/Projection.lean
@@ -30,6 +30,7 @@ variable {R : Type*} [Ring R] {E : Type*} [AddCommGroup E] [Module R E]
 variable {F : Type*} [AddCommGroup F] [Module R F] {G : Type*} [AddCommGroup G] [Module R G]
 variable (p q : Submodule R E)
 variable {S : Type*} [Semiring S] {M : Type*} [AddCommMonoid M] [Module S M] (m : Submodule S M)
+variable {E' : Type*} [AddCommGroup E'] [Module S E'] {p' : Submodule S E'}
 
 namespace LinearMap
 
@@ -37,26 +38,52 @@ variable {p}
 
 open Submodule
 
-theorem ker_id_sub_eq_of_proj {f : E →ₗ[R] p} (hf : ∀ x : p, f x = x) :
-    ker (id - p.subtype.comp f) = p := by
+theorem ker_id_sub_eq_of_proj {f : E' →ₗ[S] p'} (hf : ∀ x : p', f x = x) :
+    ker (id - p'.subtype.comp f) = p' := by
   ext x
   simp only [comp_apply, mem_ker, subtype_apply, sub_apply, id_apply, sub_eq_zero]
   exact ⟨fun h => h.symm ▸ Submodule.coe_mem _, fun hx => by rw [hf ⟨x, hx⟩, Subtype.coe_mk]⟩
 
-theorem range_eq_of_proj {f : E →ₗ[R] p} (hf : ∀ x : p, f x = x) : range f = ⊤ :=
+theorem range_eq_of_proj {f : E' →ₗ[S] p'} (hf : ∀ x : p', f x = x) : range f = ⊤ :=
   range_eq_top.2 fun x => ⟨x, hf x⟩
 
-theorem isCompl_of_proj {f : E →ₗ[R] p} (hf : ∀ x : p, f x = x) : IsCompl p (ker f) := by
+theorem isCompl_of_proj {f : E' →ₗ[S] p'} (hf : ∀ x : p', f x = x) : IsCompl p' (ker f) := by
+  let f' := p'.subtype ∘ₗ f
+  have hf' : ∀ x : p', f' x = x := fun x => by simp [f', hf]
+  have : range f' = p' := by
+    rw [range_comp, range_eq_of_proj hf]
+    simp
+  simp_rw [← this]
+  have : ker f = ker f' := by
+    rw [ker_comp]
+    simp
+  simp_rw [this]
+  have hf' : IsIdempotentElem f' := by
+    rw [IsIdempotentElem, Module.End.mul_eq_comp]
+    ext x
+    simp [f', hf]
+  symm
   constructor
-  · rw [disjoint_iff_inf_le]
-    rintro x ⟨hpx, hfx⟩
-    rw [SetLike.mem_coe, mem_ker, hf ⟨x, hpx⟩, mk_eq_zero] at hfx
-    simp only [hfx, zero_mem]
-  · rw [codisjoint_iff_le_sup]
-    intro x _
-    rw [mem_sup']
-    refine ⟨f x, ⟨x - f x, ?_⟩, add_sub_cancel _ _⟩
-    rw [mem_ker, LinearMap.map_sub, hf, sub_self]
+  · rw [disjoint_iff]
+    ext x
+    simp only [mem_bot, mem_inf, mem_ker, mem_range]
+    constructor <;> intro h'
+    · rcases h'.2 with ⟨y, rfl⟩
+      rw [← hf'.eq, Module.End.mul_apply]
+      exact h'.1
+    · rw [h', map_zero, eq_self_iff_true, true_and]
+      use x
+      simp only [h', map_zero]
+  · suffices ∀ x : E', ∃ v : ker f', ∃ w : range f', x = v + w by
+      rw [codisjoint_iff]
+      ext x
+      rcases this x with ⟨v, w, rfl⟩
+      simp only [mem_top, iff_true]
+      exact add_mem_sup (SetLike.coe_mem v) (SetLike.coe_mem w)
+    refine fun x => ⟨⟨x - f' x, ?_⟩, ⟨f' x, ?_⟩, ?_⟩
+    · rw [mem_ker, map_sub, ← Module.End.mul_apply, hf'.eq, sub_self]
+    · simp only [mem_range, exists_apply_eq_apply]
+    · simp only [sub_add_cancel]
 
 end LinearMap
 
@@ -417,7 +444,7 @@ theorem codRestrict_apply_cod {f : M →ₗ[S] M} (h : IsProj m f) (x : m) : h.c
 theorem codRestrict_ker {f : M →ₗ[S] M} (h : IsProj m f) : ker h.codRestrict = ker f :=
   f.ker_codRestrict m _
 
-theorem isCompl {f : E →ₗ[R] E} (h : IsProj p f) : IsCompl p (ker f) := by
+theorem isCompl {f : E' →ₗ[S] E'} (h : IsProj p' f) : IsCompl p' (ker f) := by
   rw [← codRestrict_ker]
   exact isCompl_of_proj h.codRestrict_apply_cod
 
@@ -484,13 +511,13 @@ theorem IsIdempotentElem.comp_eq_right_iff {q : M →ₗ[S] M} (hq : IsIdempoten
 
 open LinearMap in
 /-- Idempotent operators are equal iff their range and kernels are. -/
-lemma IsIdempotentElem.ext_iff {p q : E →ₗ[R] E}
+lemma IsIdempotentElem.ext_iff {p q : E' →ₗ[S] E'}
     (hp : IsIdempotentElem p) (hq : IsIdempotentElem q) :
     p = q ↔ range p = range q ∧ ker p = ker q := by
   refine ⟨fun h => ⟨congrArg range h, congrArg ker h⟩, fun ⟨hr, hk⟩ => ?_⟩
   ext x
-  obtain ⟨⟨v, hv⟩, ⟨w, hw⟩, rfl, _⟩ :=
-    (ker p).existsUnique_add_of_isCompl hp.isProj_range.isCompl.symm x
+  obtain ⟨v, w, hv, hw, rfl⟩ :=
+    codisjoint_iff_exists_add_eq.mp (hp.isProj_range.isCompl.symm).codisjoint x
   simp [mem_ker.mp, hv, (hk ▸ hv), (mem_range_iff hp).mp, hw, (mem_range_iff hq).mp, (hr ▸ hw)]
 
 alias ⟨_, IsIdempotentElem.ext⟩ := IsIdempotentElem.ext_iff

--- a/Mathlib/LinearAlgebra/Projection.lean
+++ b/Mathlib/LinearAlgebra/Projection.lean
@@ -30,6 +30,7 @@ variable {R : Type*} [Ring R] {E : Type*} [AddCommGroup E] [Module R E]
 variable {F : Type*} [AddCommGroup F] [Module R F] {G : Type*} [AddCommGroup G] [Module R G]
 variable (p q : Submodule R E)
 variable {S : Type*} [Semiring S] {M : Type*} [AddCommMonoid M] [Module S M] (m : Submodule S M)
+
 namespace LinearMap
 
 variable {p}

--- a/Mathlib/Topology/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearMap.lean
@@ -1141,11 +1141,10 @@ theorem ContinuousLinearMap.closedComplemented_ker_of_rightInverse {R : Type*} [
 namespace ContinuousLinearMap
 variable {R M : Type*} [Ring R] [TopologicalSpace M]
   [AddCommGroup M] [Module R M] [IsTopologicalAddGroup M]
-  {S : Type*} [Semiring S] [Module S M]
 
 omit [IsTopologicalAddGroup M] in
 /-- Idempotent operators are equal iff their range and kernels are. -/
-lemma IsIdempotentElem.ext_iff {p q : M →L[S] M}
+lemma IsIdempotentElem.ext_iff {S : Type*} [Semiring S] [Module S M] {p q : M →L[S] M}
     (hp : IsIdempotentElem p) (hq : IsIdempotentElem q) :
     p = q ↔ range p = range q ∧ ker p = ker q := by
   simpa using LinearMap.IsIdempotentElem.ext_iff

--- a/Mathlib/Topology/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearMap.lean
@@ -1141,10 +1141,11 @@ theorem ContinuousLinearMap.closedComplemented_ker_of_rightInverse {R : Type*} [
 namespace ContinuousLinearMap
 variable {R M : Type*} [Ring R] [TopologicalSpace M]
   [AddCommGroup M] [Module R M] [IsTopologicalAddGroup M]
+  {S : Type*} [Semiring S] [Module S M]
 
 omit [IsTopologicalAddGroup M] in
 /-- Idempotent operators are equal iff their range and kernels are. -/
-lemma IsIdempotentElem.ext_iff {p q : M →L[R] M}
+lemma IsIdempotentElem.ext_iff {p q : M →L[S] M}
     (hp : IsIdempotentElem p) (hq : IsIdempotentElem q) :
     p = q ↔ range p = range q ∧ ker p = ker q := by
   simpa using LinearMap.IsIdempotentElem.ext_iff


### PR DESCRIPTION


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
