### PR TITLE
[Merged by Bors] - chore: generalise `FreeGroup.ext_hom` to monoids

### DIFF
--- a/Mathlib/GroupTheory/FreeGroup/Basic.lean
+++ b/Mathlib/GroupTheory/FreeGroup/Basic.lean
@@ -569,6 +569,20 @@ protected lemma induction_on {C : FreeGroup α → Prop} (z : FreeGroup α) (C1 
   Quot.inductionOn z fun L ↦ L.recOn C1 fun ⟨x, b⟩ _tl ih ↦
     b.recOn (mul _ _ (inv_of _ <| of x) ih) (mul _ _ (of x) ih)
 
+/-- Two homomorphisms out of a free group are equal if they are equal on generators.
+
+See note [partially-applied ext lemmas]. -/
+@[to_additive (attr := ext) "Two homomorphisms out of a free additive group are equal if they are
+  equal on generators. See note [partially-applied ext lemmas]."]
+lemma ext_hom {M : Type*} [Monoid M] (f g : FreeGroup α →* M) (h : ∀ a, f (of a) = g (of a)) :
+    f = g := by
+  ext x
+  have this (x) : f (of x)⁻¹ = g (of x)⁻¹ := by
+    trans f (of x)⁻¹ * f (of x) * g (of x)⁻¹
+    · simp_rw [mul_assoc, h, ← _root_.map_mul, mul_inv_cancel, _root_.map_one, mul_one]
+    · simp_rw [← _root_.map_mul, inv_mul_cancel, _root_.map_one, one_mul]
+  induction x <;> simp [*]
+
 @[to_additive]
 theorem Red.exact : mk L₁ = mk L₂ ↔ Join Red L₁ L₂ :=
   calc
@@ -606,17 +620,7 @@ def lift : (α → β) ≃ (FreeGroup α →* β) where
       rintro ⟨L₁⟩ ⟨L₂⟩; simp [Lift.aux]
   invFun g := g ∘ of
   left_inv f := List.prod_singleton
-  right_inv g :=
-    MonoidHom.ext <| by
-      rintro ⟨L⟩
-      exact List.recOn L
-        (g.map_one.symm)
-        (by
-        rintro ⟨x, _ | _⟩ t (ih : _ = g (mk t))
-        · change _ = g ((of x)⁻¹ * mk t)
-          simpa [Lift.aux] using ih
-        · change _ = g (of x * mk t)
-          simpa [Lift.aux] using ih)
+  right_inv g := by ext; simp [of, Lift.aux]
 
 variable {f}
 
@@ -632,20 +636,6 @@ theorem lift.of {x} : lift f (of x) = f x :=
 theorem lift.unique (g : FreeGroup α →* β) (hg : ∀ x, g (FreeGroup.of x) = f x) {x} :
     g x = FreeGroup.lift f x :=
   DFunLike.congr_fun (lift.symm_apply_eq.mp (funext hg : g ∘ FreeGroup.of = f)) x
-
-/-- Two homomorphisms out of a free group are equal if they are equal on generators.
-
-See note [partially-applied ext lemmas]. -/
-@[to_additive (attr := ext) "Two homomorphisms out of a free additive group are equal if they are
-  equal on generators. See note [partially-applied ext lemmas]."]
-theorem ext_hom {M : Type*} [Monoid M] (f g : FreeGroup α →* M) (h : ∀ a, f (of a) = g (of a)) :
-    f = g := by
-  ext x
-  have this (x) : f (of x)⁻¹ = g (of x)⁻¹ := by
-    trans f (of x)⁻¹ * f (of x) * g (of x)⁻¹
-    · simp_rw [mul_assoc, h, ← _root_.map_mul, mul_inv_cancel, _root_.map_one, mul_one]
-    · simp_rw [← _root_.map_mul, inv_mul_cancel, _root_.map_one, one_mul]
-  induction x <;> simp [*]
 
 @[to_additive]
 theorem lift_of_eq_id (α) : lift of = MonoidHom.id (FreeGroup α) :=


### PR DESCRIPTION
Also spell `FreeGroup.induction_on` using `of` rather than `pure`. This lets me move it before `ext_hom`, so that I can use it in the proof.

From Toric

Co-authored-by: Andrew Yang <the.erd.one@gmail.com>


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
