### PR TITLE
[Merged by Bors] - feat: `Finset.mem_filter_univ`

### DIFF
--- a/Archive/Imo/Imo1998Q2.lean
+++ b/Archive/Imo/Imo1998Q2.lean
@@ -106,10 +106,7 @@ theorem A_fibre_over_contestant (c : C) :
     (Finset.univ.filter fun p : JudgePair J => p.Agree r c ∧ p.Distinct) =
       ((A r).filter fun a : AgreedTriple C J => a.contestant = c).image Prod.snd := by
   ext p
-  simp only [A, Finset.mem_univ, Finset.mem_filter, Finset.mem_image]
-  constructor
-  · rintro ⟨_, h₂⟩; refine ⟨(c, p), ?_⟩; tauto
-  · intro h; aesop
+  simp [A]
 
 open scoped Classical in
 theorem A_fibre_over_contestant_card (c : C) :

--- a/Archive/Imo/Imo2001Q3.lean
+++ b/Archive/Imo/Imo2001Q3.lean
@@ -78,7 +78,7 @@ lemma card_not_easy_le_210 (hG : ∀ i, #(G i) ≤ 6) (hB : ∀ i j, ¬Disjoint 
       simp_rw [card_filter, ← univ_product_univ, sum_product]
     _ = ∑ i, #({p ∈ G i | ¬Easy B p}.biUnion fun p ↦ {j | p ∈ B j}) := by
       congr!; ext
-      simp_rw [mem_biUnion, mem_inter, mem_filter, mem_univ, true_and]
+      simp_rw [mem_biUnion, mem_inter, mem_filter]
       congr! 2; tauto
     _ ≤ ∑ i, ∑ p ∈ G i with ¬Easy B p, #{j | p ∈ B j} := sum_le_sum fun _ _ ↦ card_biUnion_le
     _ ≤ ∑ i, ∑ p ∈ G i with ¬Easy B p, 2 := by
@@ -101,7 +101,7 @@ theorem result (h : Condition G B) : ∃ p, Easy G p ∧ Easy B p := by
   have key := (card_union_le _ _).trans (add_le_add cB cG) |>.trans_lt
     (show _ < #(@univ (Fin 21 × Fin 21) _) by simp)
   obtain ⟨⟨i, j⟩, -, hij⟩ := exists_mem_notMem_of_card_lt_card key
-  simp_rw [mem_union, mem_map, mem_filter, mem_univ, Function.Embedding.coeFn_mk, Prod.exists,
+  simp_rw [mem_union, mem_map, mem_filter_univ, Function.Embedding.coeFn_mk, Prod.exists,
     Prod.swap_prod_mk, Prod.mk.injEq, existsAndEq, true_and, and_true, not_or, not_exists,
     not_and', not_not, mem_inter, and_imp] at hij
   obtain ⟨p, pG, pB⟩ := not_disjoint_iff.mp (G_inter_B i j)

--- a/Archive/Wiedijk100Theorems/Partition.lean
+++ b/Archive/Wiedijk100Theorems/Partition.lean
@@ -184,7 +184,7 @@ theorem partialGF_prop (α : Type*) [CommSemiring α] (n : ℕ) (s : Finset ℕ)
     simp only [φ, mem_filter]
     rw [mem_finsuppAntidiag]
     dsimp only [ne_eq, smul_eq_mul, id_eq, eq_mpr_eq_cast, le_eq_subset, Finsupp.coe_mk]
-    simp only [mem_univ, mem_filter, true_and] at ha
+    rw [mem_filter_univ] at ha
     refine ⟨⟨?_, fun i ↦ ?_⟩, fun i _ ↦ ⟨a.parts.count i, ha.1 i, rfl⟩⟩
     · conv_rhs => simp [← a.parts_sum]
       rw [sum_multiset_count_of_subset _ s]
@@ -197,7 +197,7 @@ theorem partialGF_prop (α : Type*) [CommSemiring α] (n : ℕ) (s : Finset ℕ)
   · dsimp only
     intro p₁ hp₁ p₂ hp₂ h
     apply Nat.Partition.ext
-    simp only [true_and, mem_univ, mem_filter] at hp₁ hp₂
+    rw [mem_filter_univ] at hp₁ hp₂
     ext i
     simp only [φ, ne_eq, smul_eq_mul, Finsupp.mk.injEq] at h
     by_cases hi : i = 0
@@ -209,7 +209,7 @@ theorem partialGF_prop (α : Type*) [CommSemiring α] (n : ℕ) (s : Finset ℕ)
     · rw [← mul_left_inj' hi]
       rw [funext_iff] at h
       exact h.2 i
-  · simp only [φ, mem_filter, mem_finsuppAntidiag, mem_univ, exists_prop, true_and, and_assoc]
+  · simp_rw [φ, mem_filter_univ, mem_filter, mem_finsuppAntidiag, exists_prop, and_assoc]
     rintro f ⟨hf, hf₃, hf₄⟩
     have hf' : f ∈ finsuppAntidiag s n := mem_finsuppAntidiag.mpr ⟨hf, hf₃⟩
     simp only [mem_finsuppAntidiag] at hf'

--- a/Mathlib/Algebra/Lie/Weights/RootSystem.lean
+++ b/Mathlib/Algebra/Lie/Weights/RootSystem.lean
@@ -456,12 +456,10 @@ lemma eq_top_of_invtSubmodule_ne_bot
     by_contra h
     have i_non_zero : i.1.IsNonZero := by
       obtain ⟨val, hval⟩ := i
-      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hval
-      exact hval
+      rwa [Finset.mem_filter_univ] at hval
     have j_non_zero : j.1.IsNonZero := by
       obtain ⟨val, hval⟩ := j
-      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hval
-      exact hval
+      rwa [Finset.mem_filter_univ] at hval
     let r := Weight.mk (R := K) (L := H) (M := L) (i.1.1 + j.1.1) h
     have r₁ : r ≠ 0 := by
       intro a

--- a/Mathlib/AlgebraicTopology/AlternatingFaceMapComplex.lean
+++ b/Mathlib/AlgebraicTopology/AlternatingFaceMapComplex.lean
@@ -83,8 +83,8 @@ theorem d_squared (n : ℕ) : objD X (n + 1) ≫ objD X n = 0 := by
   apply Finset.sum_bij φ
   · -- φ(S) is contained in Sᶜ
     intro ij hij
-    simp only [S, φ, Finset.mem_univ, Finset.compl_filter, Finset.mem_filter, true_and,
-      Fin.val_succ, Fin.coe_castLT] at hij ⊢
+    simp_rw [S, φ, Finset.compl_filter, Finset.mem_filter_univ, Fin.val_succ,
+      Fin.coe_castLT] at hij ⊢
     omega
   · -- φ : S → Sᶜ is injective
     rintro ⟨i, j⟩ hij ⟨i', j'⟩ hij' h
@@ -93,12 +93,11 @@ theorem d_squared (n : ℕ) : objD X (n + 1) ≫ objD X n = 0 := by
       by simpa [φ, Fin.castSucc_castLT] using congr_arg Fin.castSucc (congr_arg Prod.fst h)⟩
   · -- φ : S → Sᶜ is surjective
     rintro ⟨i', j'⟩ hij'
-    simp only [S, Finset.mem_univ, Finset.compl_filter, not_le, Finset.mem_filter, true_and] at hij'
+    simp_rw [S, Finset.compl_filter, Finset.mem_filter_univ, not_le] at hij'
     refine ⟨(j'.pred <| ?_, Fin.castSucc i'), ?_, ?_⟩
     · rintro rfl
       simp only [Fin.val_zero, not_lt_zero'] at hij'
-    · simpa only [S, Finset.mem_univ, forall_true_left, Prod.forall, Finset.mem_filter,
-        Fin.coe_castSucc, Fin.coe_pred, true_and] using Nat.le_sub_one_of_lt hij'
+    · simpa [S] using Nat.le_sub_one_of_lt hij'
     · simp only [φ, Fin.castLT_castSucc, Fin.succ_pred]
   · -- identification of corresponding terms in both sums
     rintro ⟨i, j⟩ hij

--- a/Mathlib/AlgebraicTopology/DoldKan/Decomposition.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Decomposition.lean
@@ -71,9 +71,8 @@ theorem decomposition_Q (n q : ℕ) :
         simp only [(HigherFacesVanish.of_P q n).comp_Hσ_eq hnaq', q'.rev_eq hnaq', neg_neg]
         rfl
       · ext ⟨i, hi⟩
-        simp only [q', Nat.lt_succ_iff_lt_or_eq, Finset.mem_univ, Finset.mem_filter,
-          Finset.mem_erase, ne_eq, Fin.mk.injEq, true_and]
-        aesop
+        simp_rw [Finset.mem_erase, Finset.mem_filter_univ, q', ne_eq, Fin.mk.injEq]
+        omega
 
 variable (X)
 

--- a/Mathlib/AlgebraicTopology/DoldKan/Decomposition.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Decomposition.lean
@@ -58,7 +58,7 @@ theorem decomposition_Q (n q : ℕ) :
     · rw [Q_is_eventually_constant (show n + 1 ≤ q by omega), hq]
       congr 1
       ext ⟨x, hx⟩
-      simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+      simp_rw [Finset.mem_filter_univ]
       omega
     · obtain ⟨a, ha⟩ := Nat.le.dest (Nat.succ_le_succ_iff.mp hqn)
       rw [Q_succ, HomologicalComplex.sub_f_apply, HomologicalComplex.comp_f, hq]

--- a/Mathlib/Analysis/Convex/Birkhoff.lean
+++ b/Mathlib/Analysis/Convex/Birkhoff.lean
@@ -120,7 +120,7 @@ private lemma doublyStochastic_sum_perm_aux (M : Matrix n n R)
     rw [← hd]
     refine card_lt_card ?_
     rw [ssubset_iff_of_subset (monotone_filter_right _ _)]
-    · simp only [ne_eq, mem_filter, mem_univ, true_and, Decidable.not_not, Prod.exists]
+    · simp_rw [mem_filter_univ, not_not, Prod.exists]
       refine ⟨i, σ i, hMi'.ne', ?_⟩
       simp [N, Equiv.toPEquiv_apply]
     · rintro ⟨i', j'⟩ hN' hM'

--- a/Mathlib/Combinatorics/Enumerative/Composition.lean
+++ b/Mathlib/Combinatorics/Enumerative/Composition.lean
@@ -848,10 +848,9 @@ def compositionAsSetEquiv (n : ℕ) : CompositionAsSet n ≃ Finset (Fin (n - 1)
       convert add_lt_add_right i.is_lt 1
       apply (Nat.succ_pred_eq_of_pos _).symm
       exact Nat.lt_of_lt_pred (Fin.pos i)
-    simp only [add_comm, Fin.ext_iff, Fin.val_zero, Fin.val_last, exists_prop, Set.toFinset_setOf,
-      Finset.mem_univ, Finset.mem_filter, add_eq_zero, and_false,
-      add_left_inj, false_or, true_and, reduceCtorEq]
-    simp_rw [this, false_or, ← Fin.ext_iff, exists_eq_right']
+    simp_rw [add_comm, Fin.ext_iff, Fin.val_zero, Fin.val_last, exists_prop, Set.toFinset_setOf,
+      Finset.mem_filter_univ, reduceCtorEq, this, false_or, add_left_inj, ← Fin.ext_iff,
+      exists_eq_right']
 
 instance compositionAsSetFintype (n : ℕ) : Fintype (CompositionAsSet n) :=
   Fintype.ofEquiv _ (compositionAsSetEquiv n).symm

--- a/Mathlib/Combinatorics/SimpleGraph/Copy.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Copy.lean
@@ -449,8 +449,7 @@ lemma copyCount_le_labelledCopyCount [Fintype W] : G.copyCount H ≤ G.labelledC
       Adj := ⊥
       adj_sub := False.elim
       edge_vert := False.elim }
-  simp only [eq_singleton_iff_unique_mem, mem_filter, mem_univ, true_and,
-    Nonempty.forall]
+  simp only [eq_singleton_iff_unique_mem, mem_filter_univ, Nonempty.forall]
   refine ⟨⟨⟨(Equiv.Set.univ _).symm, by simp⟩⟩, fun H' e ↦
     Subgraph.ext ((set_fintype_card_eq_univ_iff _).1 <| Fintype.card_congr e.toEquiv.symm) ?_⟩
   ext a b

--- a/Mathlib/Combinatorics/SimpleGraph/DegreeSum.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/DegreeSum.lean
@@ -131,9 +131,8 @@ theorem even_card_odd_degree_vertices [Fintype V] [DecidableRel G.Adj] :
       convert h
       exact ZMod.ne_zero_iff_odd.symm
     · intro v
-      simp only [true_and, mem_filter, mem_univ, Ne]
-      rw [ZMod.eq_zero_iff_even, ZMod.eq_one_iff_odd, ← Nat.not_even_iff_odd, imp_self]
-      trivial
+      rw [mem_filter_univ, Ne, ZMod.eq_zero_iff_even, ZMod.eq_one_iff_odd, ← Nat.not_even_iff_odd]
+      tauto
 
 theorem odd_card_odd_degree_vertices_ne [Fintype V] [DecidableEq V] [DecidableRel G.Adj] (v : V)
     (h : Odd (G.degree v)) : Odd #{w | w ≠ v ∧ Odd (G.degree w)} := by
@@ -141,7 +140,7 @@ theorem odd_card_odd_degree_vertices_ne [Fintype V] [DecidableEq V] [DecidableRe
   have hk : 0 < k := by
     have hh : Finset.Nonempty {v : V | Odd (G.degree v)} := by
       use v
-      simp only [true_and, mem_filter, mem_univ]
+      rw [mem_filter_univ]
       exact h
     rwa [← card_pos, hg, ← two_mul, mul_pos_iff_of_pos_left] at hh
     exact zero_lt_two
@@ -154,7 +153,7 @@ theorem odd_card_odd_degree_vertices_ne [Fintype V] [DecidableEq V] [DecidableRe
     rw [add_assoc, one_add_one_eq_two, ← Nat.mul_succ, ← two_mul]
     congr
     omega
-  · simpa only [true_and, mem_filter, mem_univ]
+  · rwa [mem_filter_univ]
 
 theorem exists_ne_odd_degree_of_exists_odd_degree [Fintype V] [DecidableRel G.Adj] (v : V)
     (h : Odd (G.degree v)) : ∃ w : V, w ≠ v ∧ Odd (G.degree w) := by
@@ -164,7 +163,7 @@ theorem exists_ne_odd_degree_of_exists_odd_degree [Fintype V] [DecidableRel G.Ad
     rw [hg]
     apply Nat.succ_pos
   rcases card_pos.mp hg' with ⟨w, hw⟩
-  simp only [true_and, mem_filter, mem_univ, Ne] at hw
+  rw [mem_filter_univ] at hw
   exact ⟨w, hw⟩
 
 end SimpleGraph

--- a/Mathlib/Combinatorics/SimpleGraph/Extremal/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Extremal/Basic.lean
@@ -107,7 +107,7 @@ at most `x` edges. -/
 theorem extremalNumber_le_iff (H : SimpleGraph W) (m : ℕ) :
     extremalNumber (card V) H ≤ m ↔
       ∀ ⦃G : SimpleGraph V⦄ [DecidableRel G.Adj], H.Free G → #G.edgeFinset ≤ m := by
-  simp_rw [extremalNumber_of_fintypeCard_eq rfl, Finset.sup_le_iff, mem_filter, mem_univ, true_and]
+  simp_rw [extremalNumber_of_fintypeCard_eq rfl, Finset.sup_le_iff, mem_filter_univ]
   exact ⟨fun h _ _ h' ↦ by convert h _ h', fun h _ h' ↦ by convert h h'⟩
 
 /-- `extremalNumber (card V) H` is greater than `x` if and only if there exists a `H`-free simple
@@ -115,7 +115,7 @@ graph `G` with more than `x` edges. -/
 theorem lt_extremalNumber_iff (H : SimpleGraph W) (m : ℕ) :
     m < extremalNumber (card V) H ↔
       ∃ G : SimpleGraph V, ∃ _ : DecidableRel G.Adj, H.Free G ∧ m < #G.edgeFinset := by
-  simp_rw [extremalNumber_of_fintypeCard_eq rfl, Finset.lt_sup_iff, mem_filter, mem_univ, true_and]
+  simp_rw [extremalNumber_of_fintypeCard_eq rfl, Finset.lt_sup_iff, mem_filter_univ]
   exact ⟨fun ⟨_, h, h'⟩ ↦ ⟨_, _, h, h'⟩, fun ⟨_, _, h, h'⟩ ↦ ⟨_, h, by convert h'⟩⟩
 
 variable {R : Type*} [Semiring R] [LinearOrder R] [FloorSemiring R]

--- a/Mathlib/Combinatorics/SimpleGraph/IncMatrix.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/IncMatrix.lean
@@ -122,7 +122,7 @@ theorem sum_incMatrix_apply_of_mem_edgeSet [Fintype α] :
   simp only [incMatrix_apply', sum_boole, mk'_mem_incidenceSet_iff, h]
   congr 2
   ext e
-  simp only [mem_filter, mem_univ, true_and, mem_insert, mem_singleton]
+  simp
 
 theorem sum_incMatrix_apply_of_notMem_edgeSet [Fintype α] (h : e ∉ G.edgeSet) :
     ∑ a, G.incMatrix R a e = 0 :=

--- a/Mathlib/Combinatorics/SimpleGraph/Turan.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Turan.lean
@@ -109,7 +109,7 @@ lemma exists_isTuranMaximal (hr : 0 < r) :
   classical
   let c := {H : SimpleGraph V | H.CliqueFree (r + 1)}
   have cn : c.toFinset.Nonempty := ⟨⊥, by
-    simp only [Set.toFinset_setOf, mem_filter, mem_univ, true_and, c]
+    rw [Set.toFinset_setOf, mem_filter_univ]
     exact cliqueFree_bot (by omega)⟩
   obtain ⟨S, Sm, Sl⟩ := exists_max_image c.toFinset (#·.edgeFinset) cn
   use S, inferInstance

--- a/Mathlib/Data/Fin/Tuple/Sort.lean
+++ b/Mathlib/Data/Fin/Tuple/Sort.lean
@@ -125,10 +125,8 @@ theorem lt_card_le_iff_apply_le_of_monotone [Preorder α] [DecidableLE α]
   contrapose! h
   rw [← Fin.card_Iio, Fintype.card_subtype]
   refine Finset.card_mono (fun i => Function.mtr ?_)
-  simp_rw [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_Iio]
-  intro hij hia
-  apply h
-  exact (h_sorted (le_of_not_gt hij)).trans hia
+  rw [Finset.mem_filter_univ, Finset.mem_Iio]
+  exact fun hij hia ↦ h ((h_sorted (le_of_not_gt hij)).trans hia)
 
 theorem lt_card_ge_iff_apply_ge_of_antitone [Preorder α] [DecidableLE α]
     {m : ℕ} (f : Fin m → α) (a : α) (h_sorted : Antitone f) (j : Fin m) :

--- a/Mathlib/Data/Fintype/Card.lean
+++ b/Mathlib/Data/Fintype/Card.lean
@@ -287,8 +287,8 @@ theorem existsUnique_iff_card_one {α} [Fintype α] (p : α → Prop) [Decidable
     (∃! a : α, p a) ↔ #{x | p x} = 1 := by
   rw [Finset.card_eq_one]
   refine exists_congr fun x => ?_
-  simp only [Subset.antisymm_iff, subset_singleton_iff', singleton_subset_iff,
-      true_and, and_comm, mem_univ, mem_filter]
+  simp only [Subset.antisymm_iff, subset_singleton_iff', singleton_subset_iff, and_comm,
+    mem_filter_univ]
 
 @[deprecated (since := "2024-12-17")] alias exists_unique_iff_card_one := existsUnique_iff_card_one
 
@@ -422,8 +422,8 @@ theorem wellFounded_of_trans_of_irrefl (r : α → α → Prop) [IsTrans α r] [
   cases nonempty_fintype α
   have (x y) (hxy : r x y) : #{z | r z x} < #{z | r z y} :=
     Finset.card_lt_card <| by
-      simp only [Finset.lt_iff_ssubset.symm, lt_iff_le_not_ge, Finset.le_iff_subset,
-          Finset.subset_iff, mem_filter, true_and, mem_univ]
+      simp_rw [Finset.lt_iff_ssubset.symm, lt_iff_le_not_ge, Finset.le_iff_subset,
+        Finset.subset_iff, mem_filter_univ]
       exact
         ⟨fun z hzx => _root_.trans hzx hxy,
           not_forall_of_exists_not ⟨x, Classical.not_imp.2 ⟨hxy, irrefl x⟩⟩⟩

--- a/Mathlib/Data/Fintype/Defs.lean
+++ b/Mathlib/Data/Fintype/Defs.lean
@@ -107,6 +107,8 @@ theorem coe_eq_univ : (s : Set α) = Set.univ ↔ s = univ := by rw [← coe_uni
 @[simp]
 theorem subset_univ (s : Finset α) : s ⊆ univ := fun a _ => mem_univ a
 
+theorem mem_filter_univ {p : α → Prop} [DecidablePred p] : ∀ x, x ∈ univ.filter p ↔ p x := by simp
+
 end Finset
 
 namespace Mathlib.Meta

--- a/Mathlib/Data/Fintype/Sets.lean
+++ b/Mathlib/Data/Fintype/Sets.lean
@@ -205,8 +205,7 @@ theorem toFinset_insert [DecidableEq α] {a : α} {s : Set α} [Fintype (insert 
 theorem filter_mem_univ_eq_toFinset [Fintype α] (s : Set α) [Fintype s] [DecidablePred (· ∈ s)] :
     Finset.univ.filter (· ∈ s) = s.toFinset := by
   ext
-  simp only [Finset.mem_univ, mem_filter,
-    true_and, mem_toFinset]
+  rw [mem_filter_univ, mem_toFinset]
 
 end Set
 

--- a/Mathlib/Geometry/Euclidean/Incenter.lean
+++ b/Mathlib/Geometry/Euclidean/Incenter.lean
@@ -198,7 +198,7 @@ lemma sum_excenterWeightsUnnorm_singleton_pos (hn : 1 < n) (i : Fin (n + 1)) :
   convert s.inv_height_lt_sum_inv_height hn i using 2 with j h
   · ext j
     simp
-  · simp only [ne_eq, Finset.mem_filter, Finset.mem_univ, true_and] at h
+  · rw [Finset.mem_filter_univ] at h
     simp [excenterWeightsUnnorm, h]
 
 /-- The existence of the excenter opposite a vertex (in two or more dimensions), expressed in
@@ -458,7 +458,7 @@ lemma exists_forall_dist_eq_iff_exists_excenterExists_and_eq_excenter {p : P}
     intro i
     split_ifs with hi
     · simpa using hi
-    · simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hi
+    · rw [Finset.mem_filter_univ] at hi
       simpa [hi] using h' i
   · rintro ⟨signs, h⟩
     replace h := (s.exists_forall_signedInfDist_eq_iff_excenterExists_and_eq_excenter hp).2 h

--- a/Mathlib/GroupTheory/SpecificGroups/Alternating/Centralizer.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Alternating/Centralizer.lean
@@ -67,16 +67,15 @@ theorem map_subtype_of_cycleType (m : Multiset ℕ) :
       if Even (m.sum + m.card) then ({g | g.cycleType = m} : Finset (Perm α)) else ∅ := by
   split_ifs with hm
   · ext g
-    simp only [Finset.mem_map, Finset.mem_filter, Finset.mem_univ, true_and,
-      Embedding.coe_subtype, Subtype.exists, mem_alternatingGroup, exists_and_left,
-      exists_prop, exists_eq_right_right, and_iff_left_iff_imp]
+    simp_rw [Finset.mem_map, Finset.mem_filter_univ, Embedding.coe_subtype, Subtype.exists,
+      mem_alternatingGroup, exists_and_left, exists_prop, exists_eq_right_right,
+      and_iff_left_iff_imp]
     intro hg
     rw [sign_of_cycleType, hg, Even.neg_one_pow hm]
   · rw [Finset.eq_empty_iff_forall_notMem]
     intro g hg
-    simp only [Finset.mem_map, Finset.mem_filter, Finset.mem_univ, true_and,
-      Embedding.coe_subtype, Subtype.exists, mem_alternatingGroup, exists_and_left,
-      exists_prop, exists_eq_right_right] at hg
+    simp_rw [Finset.mem_map, Finset.mem_filter_univ, Embedding.coe_subtype, Subtype.exists,
+      mem_alternatingGroup, exists_and_left, exists_prop, exists_eq_right_right] at hg
     rcases hg with ⟨hg, hs⟩
     rw [g.sign_of_cycleType, hg, neg_one_pow_eq_one_iff_even (by simp)] at hs
     contradiction

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -482,8 +482,8 @@ private theorem card_orderOf_eq_totient_aux₁ {d : ℕ} (hd : d ∣ Fintype.car
     refine Finset.sum_congr rfl fun m hm => ?_
     simp only [mem_properDivisors] at hm
     refine IH m hm.2 (hm.1.trans hd) (Finset.card_pos.2 ⟨a ^ (d / m), ?_⟩)
-    simp only [mem_filter, mem_univ, orderOf_pow a, ha, true_and,
-      Nat.gcd_eq_right (div_dvd_of_dvd hm.1), Nat.div_div_self hm.1 hd0]
+    rw [mem_filter_univ, orderOf_pow a, ha, Nat.gcd_eq_right (div_dvd_of_dvd hm.1),
+      Nat.div_div_self hm.1 hd0]
   have h2 :
     (∑ m ∈ d.divisors, #{a : α | orderOf a = m}) =
       ∑ m ∈ d.divisors, φ m := by

--- a/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
@@ -138,7 +138,7 @@ theorem det_mul (M N : Matrix n n R) : det (M * N) = det M * det N :=
       rw [Finset.sum_comm]
     _ = ∑ p : n → n with Bijective p, ∑ σ : Perm n, ε σ * ∏ i, M (σ i) (p i) * N (p i) i := by
       refine (sum_subset (filter_subset _ _) fun f _ hbij ↦ det_mul_aux ?_).symm
-      simpa only [true_and, mem_filter, mem_univ] using hbij
+      simpa only [mem_filter_univ] using hbij
     _ = ∑ τ : Perm n, ∑ σ : Perm n, ε σ * ∏ i, M (σ i) (τ i) * N (τ i) i :=
       sum_bij (fun p h ↦ Equiv.ofBijective p (mem_filter.1 h).2) (fun _ _ ↦ mem_univ _)
         (fun _ _ _ _ h ↦ by injection h)

--- a/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/Basic.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/QuadraticChar/Basic.lean
@@ -221,8 +221,8 @@ theorem quadraticChar_card_sqrts (hF : ringChar F ≠ 2) (a : F) :
       have h₁ : s = [b, -b].toFinset := by
         ext1
         rw [← pow_two] at h
-        simp only [Set.toFinset_setOf, h, mem_filter, mem_univ, true_and, List.toFinset_cons,
-          List.toFinset_nil, insert_empty_eq, mem_insert, mem_singleton, s]
+        simp_rw [s, Set.toFinset_setOf, mem_filter_univ, h, List.toFinset_cons, List.toFinset_nil,
+          insert_empty_eq, mem_insert, mem_singleton]
         exact sq_eq_sq_iff_eq_or_eq_neg
       norm_cast
       rw [h₁, List.toFinset_cons, List.toFinset_cons, List.toFinset_nil]

--- a/Mathlib/NumberTheory/MulChar/Basic.lean
+++ b/Mathlib/NumberTheory/MulChar/Basic.lean
@@ -567,8 +567,7 @@ theorem sum_one_eq_card_units [DecidableEq R] :
     · exact map_nonunit _ h
   · congr
     ext a
-    simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_map,
-      Function.Embedding.coeFn_mk, IsUnit]
+    simp [IsUnit]
 
 end sum
 

--- a/Mathlib/NumberTheory/NumberField/InfinitePlace/Ramification.lean
+++ b/Mathlib/NumberTheory/NumberField/InfinitePlace/Ramification.lean
@@ -407,11 +407,11 @@ lemma card_isUnramified [NumberField k] [IsGalois k K] :
     (t := {w : InfinitePlace k | w.IsUnramifiedIn K}), ← smul_eq_mul, ← sum_const]
   · refine sum_congr rfl (fun w hw ↦ ?_)
     obtain ⟨w, rfl⟩ := comap_surjective (K := K) w
-    simp only [mem_univ, mem_filter, true_and] at hw
+    rw [mem_filter_univ] at hw
     trans #(MulAction.orbit (K ≃ₐ[k] K) w).toFinset
     · congr; ext w'
-      simp only [mem_univ, mem_filter, true_and,
-        Set.mem_toFinset, mem_orbit_iff, @eq_comm _ (comap w' _), and_iff_right_iff_imp]
+      rw [mem_filter, mem_filter_univ, Set.mem_toFinset, mem_orbit_iff, @eq_comm _ (comap w' _),
+        and_iff_right_iff_imp]
       intro e; rwa [← isUnramifiedIn_comap, ← e]
     · rw [← MulAction.card_orbit_mul_card_stabilizer_eq_card_group _ w,
         ← Nat.card_eq_fintype_card (α := Stab w), card_stabilizer, if_pos,
@@ -430,11 +430,11 @@ lemma card_isUnramified_compl [NumberField k] [IsGalois k K] :
     (t := ({w : InfinitePlace k | w.IsUnramifiedIn K}: Finset _)ᶜ), ← smul_eq_mul, ← sum_const]
   · refine sum_congr rfl (fun w hw ↦ ?_)
     obtain ⟨w, rfl⟩ := comap_surjective (K := K) w
-    simp only [mem_univ, compl_filter, mem_filter, true_and] at hw
+    rw [compl_filter, mem_filter_univ] at hw
     trans Finset.card (MulAction.orbit (K ≃ₐ[k] K) w).toFinset
     · congr; ext w'
-      simp only [compl_filter, mem_filter, mem_univ, true_and,
-        @eq_comm _ (comap w' _), Set.mem_toFinset, mem_orbit_iff, and_iff_right_iff_imp]
+      rw [mem_filter, compl_filter, mem_filter_univ, @eq_comm _ (comap w' _), Set.mem_toFinset,
+        mem_orbit_iff, and_iff_right_iff_imp]
       intro e; rwa [← isUnramifiedIn_comap, ← e]
     · rw [← MulAction.card_orbit_mul_card_stabilizer_eq_card_group _ w,
         ← Nat.card_eq_fintype_card (α := Stab w), InfinitePlace.card_stabilizer, if_neg,

--- a/Mathlib/RingTheory/MvPolynomial/Symmetric/FundamentalTheorem.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Symmetric/FundamentalTheorem.lean
@@ -74,7 +74,7 @@ lemma accumulate_rec {i n m : ℕ} (hin : i < n) (him : i + 1 < m) (t : Fin n �
   convert (add_sum_erase _ _ _).symm
   · ext
     rw [mem_erase]
-    simp_rw [mem_filter, mem_univ, true_and, i.succ_le_iff, lt_iff_le_and_ne]
+    simp_rw [mem_filter_univ, i.succ_le_iff, lt_iff_le_and_ne]
     rw [and_comm, ne_comm, ← Fin.val_ne_iff]
   · exact mem_filter.2 ⟨mem_univ _, le_rfl⟩
 
@@ -85,7 +85,7 @@ lemma accumulate_last {i n m : ℕ} (hin : i < n) (hmi : m = i + 1) (t : Fin n �
   apply sum_eq_single_of_mem
   · rw [mem_filter]; exact ⟨mem_univ _, le_rfl⟩
   refine fun j hij hji ↦ ht j ?_
-  simp_rw [mem_filter, mem_univ, true_and] at hij
+  rw [mem_filter_univ] at hij
   exact hmi.trans_le (hij.lt_of_ne (Fin.val_ne_iff.2 hji).symm).nat_succ_le
 
 lemma accumulate_injective {n m} (hnm : n ≤ m) : Function.Injective (accumulate n m) := by
@@ -198,7 +198,7 @@ lemma supDegree_esymm [Nontrivial R] (him : i < m) :
   rw [(supDegree_monic_esymm him).1, ofLex_toLex]
   ext j
   simp_rw [Finsupp.indicator_apply, dite_eq_ite, mem_Iic, accumulate_apply, Finsupp.single_apply,
-    sum_ite_eq, mem_filter, mem_univ, true_and, Fin.le_def]
+    sum_ite_eq, mem_filter_univ, Fin.le_def]
 
 lemma monic_esymm {i : ℕ} (him : i ≤ m) : Monic toLex (esymm (Fin m) R i) := by
   cases i with


### PR DESCRIPTION
This lemma, or rather the sequence `simp_rw [mem_filter, mem_univ, true_and]` equivalent to it, is used quite a lot in Carleson, and it is tiring to repeat the sequence which cannot be replaced with plain `rw`.

It turns out that the new lemma can golf theorems here too!