### PR TITLE
feat: slightly reduce the verbosity of `lake cache exe get`

### DIFF
--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -372,8 +372,6 @@ def unpackCache (hashMap : ModuleHashMap) (force : Bool) : CacheM Unit := do
   let hashMap ← hashMap.filterExists true
   let size := hashMap.size
   if size > 0 then
-    let now ← IO.monoMsNow
-    IO.println s!"Decompressing {size} file(s)"
     let args := (if force then #["-f"] else #[]) ++ #["-x", "--delete-corrupted", "-j", "-"]
     let child ← IO.Process.spawn { cmd := ← getLeanTar, args, stdin := .piped }
     let (stdin, child) ← child.takeStdin
@@ -404,8 +402,6 @@ def unpackCache (hashMap : ModuleHashMap) (force : Bool) : CacheM Unit := do
     stdin.putStr <| Lean.Json.compress <| .arr config
     let exitCode ← child.wait
     if exitCode != 0 then throw <| IO.userError s!"leantar failed with error code {exitCode}"
-    IO.println s!"Unpacked in {(← IO.monoMsNow) - now} ms"
-    IO.println "Completed successfully!"
   else IO.println "No cache files to decompress"
 
 instance : Ord FilePath where

--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -372,8 +372,7 @@ def unpackCache (hashMap : ModuleHashMap) (force : Bool) : CacheM Unit := do
   let hashMap ← hashMap.filterExists true
   let size := hashMap.size
   if size > 0 then
-    let decompressionMsg := s!"Decompressing {size} file(s) …"
-    IO.eprint decompressionMsg
+    IO.println s!"Decompressing {size} file(s)"
     let args := (if force then #["-f"] else #[]) ++ #["-x", "--delete-corrupted", "-j", "-"]
     let child ← IO.Process.spawn { cmd := ← getLeanTar, args, stdin := .piped }
     let (stdin, child) ← child.takeStdin
@@ -403,7 +402,6 @@ def unpackCache (hashMap : ModuleHashMap) (force : Bool) : CacheM Unit := do
         config.push <| .mkObj [("file", pathStr), ("base", mathlibDepPath)]
     stdin.putStr <| Lean.Json.compress <| .arr config
     let exitCode ← child.wait
-    IO.eprint ("\r" ++ (String.mk (List.replicate decompressionMsg.length ' ')) ++ "\r")
     if exitCode != 0 then throw <| IO.userError s!"leantar failed with error code {exitCode}"
   else IO.println "No cache files to decompress"
 

--- a/Cache/IO.lean
+++ b/Cache/IO.lean
@@ -372,6 +372,8 @@ def unpackCache (hashMap : ModuleHashMap) (force : Bool) : CacheM Unit := do
   let hashMap ← hashMap.filterExists true
   let size := hashMap.size
   if size > 0 then
+    let decompressionMsg := s!"Decompressing {size} file(s) …"
+    IO.eprint decompressionMsg
     let args := (if force then #["-f"] else #[]) ++ #["-x", "--delete-corrupted", "-j", "-"]
     let child ← IO.Process.spawn { cmd := ← getLeanTar, args, stdin := .piped }
     let (stdin, child) ← child.takeStdin
@@ -401,6 +403,7 @@ def unpackCache (hashMap : ModuleHashMap) (force : Bool) : CacheM Unit := do
         config.push <| .mkObj [("file", pathStr), ("base", mathlibDepPath)]
     stdin.putStr <| Lean.Json.compress <| .arr config
     let exitCode ← child.wait
+    IO.eprint ("\r" ++ (String.mk (List.replicate decompressionMsg.length ' ')) ++ "\r")
     if exitCode != 0 then throw <| IO.userError s!"leantar failed with error code {exitCode}"
   else IO.println "No cache files to decompress"
 

--- a/Cache/Requests.lean
+++ b/Cache/Requests.lean
@@ -345,7 +345,6 @@ def downloadFiles
     if failed > 0 then
       IO.println s!"{failed} download(s) failed"
       IO.Process.exit 1
-  else IO.println "No files to download"
 
 /-- Check if the project's `lean-toolchain` file matches mathlib's.
 Print and error and exit the process with error code 1 otherwise. -/


### PR DESCRIPTION
Along with reducing distracting verbosity, this change also addresses the confusing, seemingly contradictory output pair:

```
Downloaded: 6951 file(s) [attempted 6951/6951 = 100%] (100% success)
No files to download
```

Pre:

```
% lake exe cache get
Current branch: master
Using cache from origin: github-username/mathlib4
Attempting to download 6951 file(s) from leanprover-community/mathlib4 cache
Downloaded: 6951 file(s) [attempted 6951/6951 = 100%] (100% success)
No files to download
Decompressing 6951 file(s)
Unpacked in 546 ms
Completed successfully!
% lake exe cache get
Current branch: master
Using cache from origin: github-username/mathlib4
No files to download
No files to download
Decompressing 6951 file(s)
Unpacked in 320 ms
Completed successfully!
%
```

Post:

```
% lake exe cache get
Current branch: master
Using cache from origin: github-username/mathlib4
Attempting to download 6951 file(s) from leanprover-community/mathlib4 cache
Downloaded: 6951 file(s) [attempted 6951/6951 = 100%] (100% success)
Decompressing 6951 file(s)
% lake exe cache get
Current branch: master
Using cache from origin: github-username/mathlib4
Decompressing 6951 file(s)
%
```

Fixes #27038. Note that the download progress output is kept unchanged.