### PR TITLE
[Merged by Bors] - feat: Finset.max'_eq_iff

### DIFF
--- a/Mathlib/Data/Finset/Max.lean
+++ b/Mathlib/Data/Finset/Max.lean
@@ -245,21 +245,11 @@ theorem min'_eq_inf' : s.min' H = s.inf' H id := rfl
 @[simp]
 theorem max'_singleton (a : α) : ({a} : Finset α).max' (singleton_nonempty _) = a := by simp [max']
 
-lemma min'_eq_iff (a : α) :
-    s.min' H = a ↔ a ∈ s ∧ ∀ (b : α), b ∈ s → a ≤ b := by
-  constructor
-  · rintro rfl
-    exact ⟨min'_mem _ _, min'_le _⟩
-  · rintro ⟨h₁, h₂⟩
-    exact le_antisymm (min'_le _ _ h₁) (by rwa [le_min'_iff])
+lemma min'_eq_iff (a : α) : s.min' H = a ↔ a ∈ s ∧ ∀ (b : α), b ∈ s → a ≤ b :=
+  ⟨(· ▸ ⟨min'_mem _ _, min'_le _⟩), fun h ↦ le_antisymm (min'_le _ _ h.1) (le_min' _ _ _ h.2)⟩
 
-lemma max'_eq_iff (a : α) :
-    s.max' H = a ↔ a ∈ s ∧ ∀ (b : α), b ∈ s → b ≤ a := by
-  constructor
-  · rintro rfl
-    exact ⟨max'_mem _ _, le_max' _⟩
-  · rintro ⟨h₁, h₂⟩
-    exact le_antisymm (by rwa [max'_le_iff]) (le_max' _ _ h₁)
+lemma max'_eq_iff (a : α) : s.max' H = a ↔ a ∈ s ∧ ∀ (b : α), b ∈ s → b ≤ a :=
+  ⟨(· ▸ ⟨max'_mem _ _, le_max' _⟩), fun h ↦ le_antisymm (max'_le _ _ _ h.2) (le_max' _ _ h.1)⟩
 
 theorem min'_le_max' (hs : s.Nonempty) : s.min' hs ≤ s.max' hs := min'_le _ _ (max'_mem _ _)
 

--- a/Mathlib/Data/Finset/Max.lean
+++ b/Mathlib/Data/Finset/Max.lean
@@ -245,6 +245,22 @@ theorem min'_eq_inf' : s.min' H = s.inf' H id := rfl
 @[simp]
 theorem max'_singleton (a : α) : ({a} : Finset α).max' (singleton_nonempty _) = a := by simp [max']
 
+lemma min'_eq_iff (a : α) :
+    s.min' H = a ↔ a ∈ s ∧ ∀ (b : α), b ∈ s → a ≤ b := by
+  constructor
+  · rintro rfl
+    exact ⟨min'_mem _ _, min'_le _⟩
+  · rintro ⟨h₁, h₂⟩
+    exact le_antisymm (min'_le _ _ h₁) (by rwa [le_min'_iff])
+
+lemma max'_eq_iff (a : α) :
+    s.max' H = a ↔ a ∈ s ∧ ∀ (b : α), b ∈ s → b ≤ a := by
+  constructor
+  · rintro rfl
+    exact ⟨max'_mem _ _, le_max' _⟩
+  · rintro ⟨h₁, h₂⟩
+    exact le_antisymm (by rwa [max'_le_iff]) (le_max' _ _ h₁)
+
 theorem min'_le_max' (hs : s.Nonempty) : s.min' hs ≤ s.max' hs := min'_le _ _ (max'_mem _ _)
 
 theorem min'_lt_max' {i j} (H1 : i ∈ s) (H2 : j ∈ s) (H3 : i ≠ j) :


### PR DESCRIPTION
This PR add two lemmas which give characterizations of `Finset.max'/min'`. (This will be used in some future cosimplicial construction.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
