### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Preadditive/Injective/Basic, CategoryTheory/Preadditive/Projective/Basic): injectivity/projectivity criterion

### DIFF
--- a/Mathlib/CategoryTheory/Preadditive/Injective/Basic.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Injective/Basic.lean
@@ -300,7 +300,7 @@ namespace Functor
 
 variable {D : Type*} [Category D] (F : C ⥤ D)
 
-theorem injective_of_map_injective_fully_faithful_and_preserves_mono [F.Full] [F.Faithful]
+theorem injective_of_map_injective [F.Full] [F.Faithful]
     [F.PreservesMonomorphisms] (I : C) (hI : Injective (F.obj I)) : Injective I where
   factors g f _ := by
     obtain ⟨h, fac⟩ := hI.factors (F.map g) (F.map f)

--- a/Mathlib/CategoryTheory/Preadditive/Injective/Basic.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Injective/Basic.lean
@@ -301,7 +301,7 @@ namespace Functor
 variable {D : Type*} [Category D] (F : C ⥤ D)
 
 theorem injective_of_map_injective [F.Full] [F.Faithful]
-    [F.PreservesMonomorphisms] (I : C) (hI : Injective (F.obj I)) : Injective I where
+    [F.PreservesMonomorphisms] {I : C} (hI : Injective (F.obj I)) : Injective I where
   factors g f _ := by
     obtain ⟨h, fac⟩ := hI.factors (F.map g) (F.map f)
     exact ⟨F.preimage h, F.map_injective (by simp [fac])⟩

--- a/Mathlib/CategoryTheory/Preadditive/Injective/Basic.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Injective/Basic.lean
@@ -296,6 +296,18 @@ def injectivePresentationOfMap (adj : F ⊣ G)
 
 end Adjunction
 
+namespace Functor
+
+variable {D : Type*} [Category D] (F : C ⥤ D)
+
+theorem injective_of_map_injective_fully_faithful_and_preserves_mono [F.Full] [F.Faithful]
+    [F.PreservesMonomorphisms] (I : C) (hI : Injective (F.obj I)) : Injective I where
+  factors g f _ := by
+    obtain ⟨h, fac⟩ := hI.factors (F.map g) (F.map f)
+    exact ⟨F.preimage h,F.map_injective (by simp [fac])⟩
+
+end Functor
+
 /--
 [Lemma 3.8](https://ncatlab.org/nlab/show/injective+object#preservation_of_injective_objects)
 -/

--- a/Mathlib/CategoryTheory/Preadditive/Injective/Basic.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Injective/Basic.lean
@@ -304,7 +304,7 @@ theorem injective_of_map_injective_fully_faithful_and_preserves_mono [F.Full] [F
     [F.PreservesMonomorphisms] (I : C) (hI : Injective (F.obj I)) : Injective I where
   factors g f _ := by
     obtain ⟨h, fac⟩ := hI.factors (F.map g) (F.map f)
-    exact ⟨F.preimage h,F.map_injective (by simp [fac])⟩
+    exact ⟨F.preimage h, F.map_injective (by simp [fac])⟩
 
 end Functor
 

--- a/Mathlib/CategoryTheory/Preadditive/Projective/Basic.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Projective/Basic.lean
@@ -216,6 +216,18 @@ def mapProjectivePresentation (adj : F ⊣ G) [G.PreservesEpimorphisms] (X : C)
 
 end Adjunction
 
+namespace Functor
+
+variable {D : Type*} [Category D] (F : C ⥤ D)
+
+theorem projective_of_map_projective_fully_faithful_and_preserves_epi [F.Full] [F.Faithful]
+    [F.PreservesEpimorphisms] (P : C) (hP : Projective (F.obj P)) : Projective P where
+  factors g f _ := by
+    obtain ⟨h, fac⟩ := hP.factors (F.map g) (F.map f)
+    exact ⟨F.preimage h,F.map_injective (by simp [fac])⟩
+
+end Functor
+
 namespace Equivalence
 
 variable {D : Type u'} [Category.{v'} D] (F : C ≌ D)

--- a/Mathlib/CategoryTheory/Preadditive/Projective/Basic.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Projective/Basic.lean
@@ -220,7 +220,7 @@ namespace Functor
 
 variable {D : Type*} [Category D] (F : C ⥤ D)
 
-theorem projective_of_map_projective_fully_faithful_and_preserves_epi [F.Full] [F.Faithful]
+theorem projective_of_map_projective [F.Full] [F.Faithful]
     [F.PreservesEpimorphisms] (P : C) (hP : Projective (F.obj P)) : Projective P where
   factors g f _ := by
     obtain ⟨h, fac⟩ := hP.factors (F.map g) (F.map f)

--- a/Mathlib/CategoryTheory/Preadditive/Projective/Basic.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Projective/Basic.lean
@@ -224,7 +224,7 @@ theorem projective_of_map_projective_fully_faithful_and_preserves_epi [F.Full] [
     [F.PreservesEpimorphisms] (P : C) (hP : Projective (F.obj P)) : Projective P where
   factors g f _ := by
     obtain ⟨h, fac⟩ := hP.factors (F.map g) (F.map f)
-    exact ⟨F.preimage h,F.map_injective (by simp [fac])⟩
+    exact ⟨F.preimage h, F.map_injective (by simp [fac])⟩
 
 end Functor
 

--- a/Mathlib/CategoryTheory/Preadditive/Projective/Basic.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Projective/Basic.lean
@@ -221,7 +221,7 @@ namespace Functor
 variable {D : Type*} [Category D] (F : C ⥤ D)
 
 theorem projective_of_map_projective [F.Full] [F.Faithful]
-    [F.PreservesEpimorphisms] (P : C) (hP : Projective (F.obj P)) : Projective P where
+    [F.PreservesEpimorphisms] {P : C} (hP : Projective (F.obj P)) : Projective P where
   factors g f _ := by
     obtain ⟨h, fac⟩ := hP.factors (F.map g) (F.map f)
     exact ⟨F.preimage h, F.map_injective (by simp [fac])⟩


### PR DESCRIPTION
Prove that, if `F : C ⥤ D` is a fully faithful functor that preserves monomorphisms (resp. epimorphisms), and if the image by `F` of a map `f` of `C` is injective (resp. projective), then so is `f`.

This will be used when `F` is the inclusion of a full abelian subcategory to show that we only need to check injectivity/projectivity of a map in the big category.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
