### PR TITLE
[Merged by Bors] - chore: import `rw??` into `Mathlib.Tactic.Common`

### DIFF
--- a/Mathlib/Tactic/Common.lean
+++ b/Mathlib/Tactic/Common.lean
@@ -107,6 +107,7 @@ import Mathlib.Tactic.Variable
 import Mathlib.Tactic.Widget.Calc
 import Mathlib.Tactic.Widget.CongrM
 import Mathlib.Tactic.Widget.Conv
+import Mathlib.Tactic.Widget.LibraryRewrite
 import Mathlib.Tactic.WLOG
 import Mathlib.Util.AssertExists
 import Mathlib.Util.CountHeartbeats

--- a/Mathlib/Tactic/Widget/LibraryRewrite.lean
+++ b/Mathlib/Tactic/Widget/LibraryRewrite.lean
@@ -552,7 +552,7 @@ def SectionToMessageData (sec : Array (Rewrite × Name) × Bool) : MetaM (Option
   return some <| "Pattern " ++ head ++ "\n" ++ rewrites
 
 /-- `#rw?? e` gives all possible rewrites of `e`. It is a testing command for the `rw??` tactic -/
-syntax (name := rw??Command) "#rw??" ("all")? term : command
+syntax (name := rw??Command) "#rw??" (&"all")? term : command
 
 open Elab
 /-- Elaborate a `#rw??` command. -/


### PR DESCRIPTION
This PR makes `rw??` available to use in most places inside of mathlib.

This also caught the problem that "all" was turned into a token accidentally.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
