### PR TITLE
[Merged by Bors] - chore(RingTheory/Valuation/ValuativeRel): add unexpander for relation notation

### DIFF
--- a/Mathlib/RingTheory/Valuation/ValuativeRel.lean
+++ b/Mathlib/RingTheory/Valuation/ValuativeRel.lean
@@ -75,8 +75,9 @@ class ValuativeRel (R : Type*) [CommRing R] where
   rel_mul_cancel {x y z} : ¬ rel z 0 → rel (x * z) (y * z) → rel x y
   not_rel_one_zero : ¬ rel 1 0
 
-@[inherit_doc ValuativeRel.rel]
-notation:50 (name := valuativeRel) a:50 " ≤ᵥ " b:51 => binrel% ValuativeRel.rel a b
+@[inherit_doc] infix:50 " ≤ᵥ " => ValuativeRel.rel
+
+macro_rules | `($a ≤ᵥ $b) => `(binrel% ValuativeRel.rel $a $b)
 
 /-- Unexpander for the `a ≤ᵥ b` notation. -/
 @[app_unexpander ValuativeRel.rel]

--- a/Mathlib/RingTheory/Valuation/ValuativeRel.lean
+++ b/Mathlib/RingTheory/Valuation/ValuativeRel.lean
@@ -79,12 +79,6 @@ class ValuativeRel (R : Type*) [CommRing R] where
 
 macro_rules | `($a ≤ᵥ $b) => `(binrel% ValuativeRel.rel $a $b)
 
-/-- Unexpander for the `a ≤ᵥ b` notation. -/
-@[app_unexpander ValuativeRel.rel]
-def relUnexpander : Lean.PrettyPrinter.Unexpander
-  | `($_ $a $b) => `($a ≤ᵥ $b)
-  | _ => throw ()
-
 namespace Valuation
 
 variable {R Γ : Type*} [CommRing R] [LinearOrderedCommMonoidWithZero Γ]

--- a/Mathlib/RingTheory/Valuation/ValuativeRel.lean
+++ b/Mathlib/RingTheory/Valuation/ValuativeRel.lean
@@ -78,6 +78,12 @@ class ValuativeRel (R : Type*) [CommRing R] where
 @[inherit_doc ValuativeRel.rel]
 notation:50 (name := valuativeRel) a:50 " ≤ᵥ " b:51 => binrel% ValuativeRel.rel a b
 
+/-- Unexpander for the `a ≤ᵥ b` notation. -/
+@[app_unexpander ValuativeRel.rel]
+def relUnexpander : Lean.PrettyPrinter.Unexpander
+  | `($_ $a $b) => `($a ≤ᵥ $b)
+  | _ => throw ()
+
 namespace Valuation
 
 variable {R Γ : Type*} [CommRing R] [LinearOrderedCommMonoidWithZero Γ]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
