### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Adjunction): the right partial adjoint

### DIFF
--- a/Mathlib/CategoryTheory/Adjunction/PartialAdjoint.lean
+++ b/Mathlib/CategoryTheory/Adjunction/PartialAdjoint.lean
@@ -41,6 +41,8 @@ namespace Functor
 
 open Category Opposite Limits
 
+section partialLeftAdjoint
+
 variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D] (F : D ⥤ C)
 
 /-- Given a functor `F : D ⥤ C`, this is a predicate on objects `X : C` corresponding
@@ -179,6 +181,173 @@ lemma leftAdjointObjIsDefined_colimit {J : Type*} [Category J] (R : J ⥤ C)
     (h : ∀ (j : J), F.leftAdjointObjIsDefined (R.obj j)) :
     F.leftAdjointObjIsDefined (colimit R) :=
   leftAdjointObjIsDefined_of_isColimit (colimit.isColimit R) h
+
+end partialLeftAdjoint
+
+section partialRightAdjoint
+
+variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D] (F : C ⥤ D)
+
+/-- Given a functor `F : C ⥤ D`, this is a predicate on objects `X : C` corresponding
+to the domain of definition of the (partial) left adjoint of `F`. -/
+def rightAdjointObjIsDefined : ObjectProperty D :=
+  fun Y ↦ IsRepresentable (F.op ⋙ yoneda.obj Y)
+
+lemma rightAdjointObjIsDefined_iff (Y : D) :
+    F.rightAdjointObjIsDefined Y ↔ IsRepresentable (F.op ⋙ yoneda.obj Y) := by rfl
+
+variable {F} in
+lemma rightAdjointObjIsDefined_of_adjunction {G : D ⥤ C} (adj : F ⊣ G) (Y : D) :
+    F.rightAdjointObjIsDefined Y :=
+  (adj.representableBy Y).isRepresentable
+
+/-- The full subcategory where `F.partialRightAdjoint` shall be defined. -/
+abbrev PartialRightAdjointSource := F.rightAdjointObjIsDefined.FullSubcategory
+
+instance (Y : F.PartialRightAdjointSource) :
+    IsRepresentable (F.op ⋙ yoneda.obj Y.obj) := Y.property
+
+/-- Given `F : D ⥤ C`, this is `F.partialRightAdjoint` on objects: it sends
+`X : C` such that `F.rightAdjointObjIsDefined X` holds to an object of `D`
+which represents the functor `F ⋙ coyoneda.obj (op X.obj)`. -/
+noncomputable def partialRightAdjointObj (Y : F.PartialRightAdjointSource) : C :=
+  (F.op ⋙ yoneda.obj Y.obj).reprX
+
+/-- Given `F : D ⥤ C`, this is the canonical bijection
+`(F.partialRightAdjointObj X ⟶ Y) ≃ (X.obj ⟶ F.obj Y)`
+for all `X : F.PartialRightAdjointSource` and `Y : D`. -/
+noncomputable def partialRightAdjointHomEquiv {X : C} {Y : F.PartialRightAdjointSource} :
+    (X ⟶ F.partialRightAdjointObj Y) ≃ (F.obj X ⟶ Y.obj) :=
+  (F.op ⋙ yoneda.obj Y.obj).representableBy.homEquiv
+
+lemma partialRightAdjointHomEquiv_comp {X X' : C} {Y : F.PartialRightAdjointSource}
+    (f : X' ⟶ F.partialRightAdjointObj Y) (g : X ⟶ X') :
+    F.partialRightAdjointHomEquiv (g ≫ f) =
+      F.map g ≫ F.partialRightAdjointHomEquiv f :=
+  RepresentableBy.homEquiv_comp ..
+
+/-- Given `F : D ⥤ C`, this is `F.partialRightAdjoint` on morphisms. -/
+noncomputable def partialRightAdjointMap {X Y : F.PartialRightAdjointSource}
+    (f : X ⟶ Y) : F.partialRightAdjointObj X ⟶ F.partialRightAdjointObj Y :=
+    F.partialRightAdjointHomEquiv.symm (F.partialRightAdjointHomEquiv (𝟙 _) ≫ f)
+
+@[simp]
+lemma partialRightAdjointHomEquiv_map {X Y : F.PartialRightAdjointSource}
+    (f : X ⟶ Y) :
+    F.partialRightAdjointHomEquiv (F.partialRightAdjointMap f) =
+      F.partialRightAdjointHomEquiv (𝟙 _) ≫ f := by
+  simp [partialRightAdjointMap]
+
+lemma partialRightAdjointHomEquiv_map_comp {X : C} {Y Y' : F.PartialRightAdjointSource}
+    (f : X ⟶ F.partialRightAdjointObj Y) (g : Y ⟶ Y') :
+    -- _ ⟶ F.partialRightAdjointObj _
+    F.partialRightAdjointHomEquiv (f ≫ F.partialRightAdjointMap g) =
+      F.partialRightAdjointHomEquiv f ≫ g := by
+  rw [partialRightAdjointHomEquiv_comp, partialRightAdjointHomEquiv_map,
+    ← assoc, ← partialRightAdjointHomEquiv_comp, comp_id]
+
+/-- Given `F : C ⥤ D`, this is the partial adjoint functor `F.PartialLeftAdjointSource ⥤ C`. -/
+@[simps]
+noncomputable def partialRightAdjoint : F.PartialRightAdjointSource ⥤ C where
+  obj := F.partialRightAdjointObj
+  map := F.partialRightAdjointMap
+  map_id X := by
+    apply F.partialRightAdjointHomEquiv.injective
+    dsimp
+    rw [partialRightAdjointHomEquiv_map]
+    erw [comp_id]
+  map_comp {X Y Z} f g := by
+    apply F.partialRightAdjointHomEquiv.injective
+    dsimp
+    rw [partialRightAdjointHomEquiv_map, partialRightAdjointHomEquiv_comp,
+      partialRightAdjointHomEquiv_map, ← assoc]
+    erw [← assoc]
+    rw [← F.partialRightAdjointHomEquiv_comp, comp_id,
+      partialRightAdjointHomEquiv_map]
+
+variable {F}
+
+lemma isLeftAdjoint_of_rightAdjointObjIsDefined_eq_top
+    (h : F.rightAdjointObjIsDefined = ⊤) : F.IsLeftAdjoint := by
+  replace h : ∀ X, IsRepresentable (F.op ⋙ yoneda.obj X) := fun X ↦ by
+    simp only [← rightAdjointObjIsDefined_iff, h, Pi.top_apply, Prop.top_eq_true]
+  exact (Adjunction.adjunctionOfEquivRight
+    -- FX ⟶ Y ≃ X ⟶ GY
+    (fun X Y ↦ (F.op ⋙ yoneda.obj Y).representableBy.homEquiv.symm)
+    (fun X Y Y' g f ↦ (RepresentableBy.comp_homEquiv_symm ..).symm)).isLeftAdjoint
+
+variable (F) in
+lemma isLeftAdjoint_iff_rightAdjointObjIsDefined_eq_top :
+    F.IsLeftAdjoint ↔ F.rightAdjointObjIsDefined = ⊤ := by
+  refine ⟨fun h ↦ ?_, isLeftAdjoint_of_rightAdjointObjIsDefined_eq_top⟩
+  ext X
+  simpa only [Pi.top_apply, Prop.top_eq_true, iff_true]
+    using rightAdjointObjIsDefined_of_adjunction (Adjunction.ofIsLeftAdjoint F) X
+
+noncomputable def asdf {J : Type*} [Category J]
+    {R : J ⥤ F.PartialRightAdjointSource}
+    {c : Cone (R ⋙ ObjectProperty.ι _)} (hc : IsLimit c)
+    {c' : Cone (R ⋙ F.partialRightAdjoint)} (hc' : IsLimit c') :
+    (F.op ⋙ yoneda.obj c.pt).RepresentableBy c'.pt := by
+  use ?_, ?_
+  · intro X
+    use ?_, ?_, ?_, ?_
+    · intro f
+      simp
+      -- need cone with F.obj X as "tip"
+      let ff : F.obj c'.pt ⟶ c.pt := hc.lift (Cone.mk _
+        { app := fun j ↦ F.partialRightAdjointHomEquiv (c'.π.app j)
+          naturality := fun j j' φ ↦ by
+            dsimp
+            rw [id_comp, ← c'.w φ, ← partialRightAdjointHomEquiv_map_comp]
+            dsimp })
+      exact F.map f ≫ ff
+
+#check Cocone.ι
+#check Cone
+/-- Auxiliary definition for `leftAdjointObjIsDefined_of_isColimit`. -/
+noncomputable def representableByCompYonedaObjOfIsLimit {J : Type*} [Category J]
+    {R : J ⥤ F.PartialRightAdjointSource}
+    {c : Cone (R ⋙ ObjectProperty.ι _)} (hc : IsLimit c)
+    {c' : Cone (R ⋙ F.partialRightAdjoint)} (hc' : IsLimit c') :
+    (F.op ⋙ yoneda.obj c.pt).RepresentableBy c'.pt where
+  homEquiv {Y} :=
+    -- paran: Cocone (R ⋙ F.leftAdjointObjIsDefined.ι)
+    { toFun := fun f ↦ hc.lift (Cone.mk _
+        { app := fun j ↦ F.partialRightAdjointHomEquiv (f ≫ c'.π.app j)
+          naturality := fun j j' φ ↦ by
+            dsimp
+            rw [id_comp, ← c'.w φ, ← partialRightAdjointHomEquiv_map_comp,
+              ← assoc]
+            dsimp })
+      invFun := fun g ↦ hc'.lift (Cone.mk _
+        { app := fun j ↦ F.partialRightAdjointHomEquiv.symm (g ≫ c.π.app j)
+          naturality := fun j j' φ ↦ by
+            apply F.partialRightAdjointHomEquiv.injective
+            have := c.w φ
+            dsimp at this ⊢
+            rw [id_comp, Equiv.apply_symm_apply, partialRightAdjointHomEquiv_map_comp,
+              Equiv.apply_symm_apply, assoc, this] })
+      left_inv := fun f ↦ hc'.hom_ext (fun j ↦ by simp)
+      right_inv := fun g ↦ hc.hom_ext (fun j ↦ by simp) }
+  homEquiv_comp {Y Y'} g f := hc.hom_ext (fun j ↦ by
+    dsimp
+    simp only [IsLimit.fac, partialRightAdjointHomEquiv_comp, assoc] )
+
+lemma rightAdjointObjIsDefined_of_isLimit {J : Type*} [Category J] {R : J ⥤ D} {c : Cone R}
+    (hc : IsLimit c) [HasLimitsOfShape J C]
+    (h : ∀ (j : J), F.rightAdjointObjIsDefined (R.obj j)) :
+    F.rightAdjointObjIsDefined c.pt :=
+  (representableByCompYonedaObjOfIsLimit
+    (R := ObjectProperty.lift _ R h) hc (limit.isLimit _)).isRepresentable
+
+lemma rightAdjointObjIsDefined_limit {J : Type*} [Category J] (R : J ⥤ D)
+    [HasLimit R] [HasLimitsOfShape J C]
+    (h : ∀ (j : J), F.rightAdjointObjIsDefined (R.obj j)) :
+    F.rightAdjointObjIsDefined (limit R) :=
+  rightAdjointObjIsDefined_of_isLimit (limit.isLimit R) h
+
+end partialRightAdjoint
 
 end Functor
 

--- a/Mathlib/CategoryTheory/Adjunction/PartialAdjoint.lean
+++ b/Mathlib/CategoryTheory/Adjunction/PartialAdjoint.lean
@@ -188,8 +188,8 @@ section partialRightAdjoint
 
 variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D] (F : C ⥤ D)
 
-/-- Given a functor `F : C ⥤ D`, this is a predicate on objects `X : C` corresponding
-to the domain of definition of the (partial) left adjoint of `F`. -/
+/-- Given a functor `F : C ⥤ D`, this is a predicate on objects `X : D` corresponding
+to the domain of definition of the (partial) right adjoint of `F`. -/
 def rightAdjointObjIsDefined : ObjectProperty D :=
   fun Y ↦ IsRepresentable (F.op ⋙ yoneda.obj Y)
 
@@ -207,15 +207,15 @@ abbrev PartialRightAdjointSource := F.rightAdjointObjIsDefined.FullSubcategory
 instance (Y : F.PartialRightAdjointSource) :
     IsRepresentable (F.op ⋙ yoneda.obj Y.obj) := Y.property
 
-/-- Given `F : D ⥤ C`, this is `F.partialRightAdjoint` on objects: it sends
-`X : C` such that `F.rightAdjointObjIsDefined X` holds to an object of `D`
+/-- Given `F : C ⥤ D`, this is `F.partialRightAdjoint` on objects: it sends
+`X : D` such that `F.rightAdjointObjIsDefined X` holds to an object of `C`
 which represents the functor `F ⋙ coyoneda.obj (op X.obj)`. -/
 noncomputable def partialRightAdjointObj (Y : F.PartialRightAdjointSource) : C :=
   (F.op ⋙ yoneda.obj Y.obj).reprX
 
-/-- Given `F : D ⥤ C`, this is the canonical bijection
-`(F.partialRightAdjointObj X ⟶ Y) ≃ (X.obj ⟶ F.obj Y)`
-for all `X : F.PartialRightAdjointSource` and `Y : D`. -/
+/-- Given `F : C ⥤ D`, this is the canonical bijection
+`(X ⟶ F.partialRightAdjointObj Y) ≃ (F.obj X ⟶ Y.obj)`
+for all `X : C` and `Y : F.PartialRightAdjointSource`. -/
 noncomputable def partialRightAdjointHomEquiv {X : C} {Y : F.PartialRightAdjointSource} :
     (X ⟶ F.partialRightAdjointObj Y) ≃ (F.obj X ⟶ Y.obj) :=
   (F.op ⋙ yoneda.obj Y.obj).representableBy.homEquiv
@@ -226,7 +226,7 @@ lemma partialRightAdjointHomEquiv_comp {X X' : C} {Y : F.PartialRightAdjointSour
       F.map g ≫ F.partialRightAdjointHomEquiv f :=
   RepresentableBy.homEquiv_comp ..
 
-/-- Given `F : D ⥤ C`, this is `F.partialRightAdjoint` on morphisms. -/
+/-- Given `F : C ⥤ D`, this is `F.partialRightAdjoint` on morphisms. -/
 noncomputable def partialRightAdjointMap {X Y : F.PartialRightAdjointSource}
     (f : X ⟶ Y) : F.partialRightAdjointObj X ⟶ F.partialRightAdjointObj Y :=
     F.partialRightAdjointHomEquiv.symm (F.partialRightAdjointHomEquiv (𝟙 _) ≫ f)
@@ -284,35 +284,13 @@ lemma isLeftAdjoint_iff_rightAdjointObjIsDefined_eq_top :
   simpa only [Pi.top_apply, Prop.top_eq_true, iff_true]
     using rightAdjointObjIsDefined_of_adjunction (Adjunction.ofIsLeftAdjoint F) X
 
-noncomputable def asdf {J : Type*} [Category J]
-    {R : J ⥤ F.PartialRightAdjointSource}
-    {c : Cone (R ⋙ ObjectProperty.ι _)} (hc : IsLimit c)
-    {c' : Cone (R ⋙ F.partialRightAdjoint)} (hc' : IsLimit c') :
-    (F.op ⋙ yoneda.obj c.pt).RepresentableBy c'.pt := by
-  use ?_, ?_
-  · intro X
-    use ?_, ?_, ?_, ?_
-    · intro f
-      simp
-      -- need cone with F.obj X as "tip"
-      let ff : F.obj c'.pt ⟶ c.pt := hc.lift (Cone.mk _
-        { app := fun j ↦ F.partialRightAdjointHomEquiv (c'.π.app j)
-          naturality := fun j j' φ ↦ by
-            dsimp
-            rw [id_comp, ← c'.w φ, ← partialRightAdjointHomEquiv_map_comp]
-            dsimp })
-      exact F.map f ≫ ff
-
-#check Cocone.ι
-#check Cone
-/-- Auxiliary definition for `leftAdjointObjIsDefined_of_isColimit`. -/
+/-- Auxiliary definition for `rightAdjointObjIsDefined_of_isLimit`. -/
 noncomputable def representableByCompYonedaObjOfIsLimit {J : Type*} [Category J]
     {R : J ⥤ F.PartialRightAdjointSource}
     {c : Cone (R ⋙ ObjectProperty.ι _)} (hc : IsLimit c)
     {c' : Cone (R ⋙ F.partialRightAdjoint)} (hc' : IsLimit c') :
     (F.op ⋙ yoneda.obj c.pt).RepresentableBy c'.pt where
   homEquiv {Y} :=
-    -- paran: Cocone (R ⋙ F.leftAdjointObjIsDefined.ι)
     { toFun := fun f ↦ hc.lift (Cone.mk _
         { app := fun j ↦ F.partialRightAdjointHomEquiv (f ≫ c'.π.app j)
           naturality := fun j j' φ ↦ by

--- a/Mathlib/CategoryTheory/Adjunction/PartialAdjoint.lean
+++ b/Mathlib/CategoryTheory/Adjunction/PartialAdjoint.lean
@@ -240,7 +240,6 @@ lemma partialRightAdjointHomEquiv_map {X Y : F.PartialRightAdjointSource}
 
 lemma partialRightAdjointHomEquiv_map_comp {X : C} {Y Y' : F.PartialRightAdjointSource}
     (f : X ⟶ F.partialRightAdjointObj Y) (g : Y ⟶ Y') :
-    -- _ ⟶ F.partialRightAdjointObj _
     F.partialRightAdjointHomEquiv (f ≫ F.partialRightAdjointMap g) =
       F.partialRightAdjointHomEquiv f ≫ g := by
   rw [partialRightAdjointHomEquiv_comp, partialRightAdjointHomEquiv_map,
@@ -272,7 +271,6 @@ lemma isLeftAdjoint_of_rightAdjointObjIsDefined_eq_top
   replace h : ∀ X, IsRepresentable (F.op ⋙ yoneda.obj X) := fun X ↦ by
     simp only [← rightAdjointObjIsDefined_iff, h, Pi.top_apply, Prop.top_eq_true]
   exact (Adjunction.adjunctionOfEquivRight
-    -- FX ⟶ Y ≃ X ⟶ GY
     (fun X Y ↦ (F.op ⋙ yoneda.obj Y).representableBy.homEquiv.symm)
     (fun X Y Y' g f ↦ (RepresentableBy.comp_homEquiv_symm ..).symm)).isLeftAdjoint
 


### PR DESCRIPTION
Given a functor `F : C ⥤ D`, we define a functor `F.partialLeftAdjoint : F.PartialLeftAdjointSource ⥤ C` which is defined on a certain full subcategory of `D`. It satisfies similar properties to the right adjoint of `F` (if this existed). We show that the domain of definition of this partial right adjoint is stable under certain limits.

This dualises #17388, I came across this while formalising Proposition 4.3.4 of Emily Riehl's Category Theory in Context. I will also work on formalising Proposition 4.3.6, which is the bifunctor version of this.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
