### PR TITLE
[Merged by Bors] - chore(Order/Concept): golf ext(')

### DIFF
--- a/Mathlib/Order/Concept.lean
+++ b/Mathlib/Order/Concept.lean
@@ -230,17 +230,15 @@ attribute [simp] upperPolar_extent lowerPolar_intent
 
 @[ext]
 theorem ext (h : c.extent = d.extent) : c = d := by
-  obtain ⟨s₁, t₁, h₁, _⟩ := c
-  obtain ⟨s₂, t₂, h₂, _⟩ := d
-  dsimp at h₁ h₂ h
-  substs h h₁ h₂
+  obtain ⟨s₁, t₁, rfl, _⟩ := c
+  obtain ⟨s₂, t₂, rfl, _⟩ := d
+  substs h
   rfl
 
 theorem ext' (h : c.intent = d.intent) : c = d := by
-  obtain ⟨s₁, t₁, _, h₁⟩ := c
-  obtain ⟨s₂, t₂, _, h₂⟩ := d
-  dsimp at h₁ h₂ h
-  substs h h₁ h₂
+  obtain ⟨s₁, t₁, _, rfl⟩ := c
+  obtain ⟨s₂, t₂, _, rfl⟩ := d
+  substs h
   rfl
 
 theorem extent_injective : Injective (@extent α β r) := fun _ _ => ext


### PR DESCRIPTION
Light golfs on `ext` and `ext'` for Concept.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
