### PR TITLE
[Merged by Bors] - feat: `covarianceBilin` lemmas

### DIFF
--- a/Mathlib/Probability/Moments/CovarianceBilin.lean
+++ b/Mathlib/Probability/Moments/CovarianceBilin.lean
@@ -238,11 +238,13 @@ lemma covarianceBilin_of_not_memLp (h : ¬ MemLp id 2 μ) (L₁ L₂ : Dual ℝ 
 lemma covarianceBilin_zero : covarianceBilin (0 : Measure E) = 0 := by
   rw [covarianceBilin, Measure.map_zero, uncenteredCovarianceBilin_zero]
 
-lemma covarianceBilin_comm (h : MemLp id 2 μ) (L₁ L₂ : Dual ℝ E) :
+lemma covarianceBilin_comm (L₁ L₂ : Dual ℝ E) :
     covarianceBilin μ L₁ L₂ = covarianceBilin μ L₂ L₁ := by
-  have h' : MemLp id 2 (Measure.map (fun x ↦ x - ∫ (x : E), x ∂μ) μ) :=
-    (measurableEmbedding_subRight _).memLp_map_measure_iff.mpr <| h.sub (memLp_const _)
-  simp_rw [covarianceBilin, uncenteredCovarianceBilin_apply h', mul_comm (L₁ _)]
+  by_cases h : MemLp id 2 μ
+  · have h' : MemLp id 2 (Measure.map (fun x ↦ x - ∫ (x : E), x ∂μ) μ) :=
+      (measurableEmbedding_subRight _).memLp_map_measure_iff.mpr <| h.sub (memLp_const _)
+    simp_rw [covarianceBilin, uncenteredCovarianceBilin_apply h', mul_comm (L₁ _)]
+  · simp [h]
 
 variable [CompleteSpace E]
 
@@ -264,9 +266,12 @@ lemma covarianceBilin_eq_covariance (h : MemLp id 2 μ) (L₁ L₂ : Dual ℝ E)
     covarianceBilin μ L₁ L₂ = cov[L₁, L₂; μ] := by
   rw [covarianceBilin_apply h, covariance]
 
-lemma covarianceBilin_same_eq_variance (h : MemLp id 2 μ) (L : Dual ℝ E) :
+lemma covarianceBilin_self_eq_variance (h : MemLp id 2 μ) (L : Dual ℝ E) :
     covarianceBilin μ L L = Var[L; μ] := by
   rw [covarianceBilin_eq_covariance h, covariance_self (by fun_prop)]
+
+@[deprecated (since := "2025-07-16")] alias covarianceBilin_same_eq_variance :=
+  covarianceBilin_self_eq_variance
 
 end Covariance
 

--- a/Mathlib/Probability/Moments/CovarianceBilin.lean
+++ b/Mathlib/Probability/Moments/CovarianceBilin.lean
@@ -5,7 +5,7 @@ Authors: Rémy Degenne
 -/
 import Mathlib.Analysis.LocallyConvex.ContinuousOfBounded
 import Mathlib.MeasureTheory.Constructions.BorelSpace.ContinuousLinearMap
-import Mathlib.Probability.Moments.Variance
+import Mathlib.Probability.Moments.Covariance
 
 /-!
 # Covariance in Banach spaces
@@ -179,6 +179,11 @@ lemma uncenteredCovarianceBilin_of_not_memLp (h : ¬ MemLp id 2 μ) (L₁ L₂ :
     uncenteredCovarianceBilin μ L₁ L₂ = 0 := by
   simp [uncenteredCovarianceBilin, Dual.toLp_of_not_memLp h]
 
+lemma uncenteredCovarianceBilin_zero : uncenteredCovarianceBilin (0 : Measure E) = 0 := by
+  ext
+  have : Subsingleton (Lp ℝ 2 (0 : Measure E)) := ⟨fun x y ↦ Lp.ext_iff.2 rfl⟩
+  simp [uncenteredCovarianceBilin, Subsingleton.eq_zero (Dual.toLp 0 2)]
+
 lemma norm_uncenteredCovarianceBilin_le (L₁ L₂ : Dual ℝ E) :
     ‖uncenteredCovarianceBilin μ L₁ L₂‖ ≤ ‖L₁‖ * ‖L₂‖ * ∫ x, ‖x‖ ^ 2 ∂μ := by
   by_cases h : MemLp id 2 μ
@@ -229,6 +234,16 @@ lemma covarianceBilin_of_not_memLp (h : ¬ MemLp id 2 μ) (L₁ L₂ : Dual ℝ 
   rw [this]
   exact h_Lp.add (memLp_const _)
 
+@[simp]
+lemma covarianceBilin_zero : covarianceBilin (0 : Measure E) = 0 := by
+  rw [covarianceBilin, Measure.map_zero, uncenteredCovarianceBilin_zero]
+
+lemma covarianceBilin_comm (h : MemLp id 2 μ) (L₁ L₂ : Dual ℝ E) :
+    covarianceBilin μ L₁ L₂ = covarianceBilin μ L₂ L₁ := by
+  have h' : MemLp id 2 (Measure.map (fun x ↦ x - ∫ (x : E), x ∂μ) μ) :=
+    (measurableEmbedding_subRight _).memLp_map_measure_iff.mpr <| h.sub (memLp_const _)
+  simp_rw [covarianceBilin, uncenteredCovarianceBilin_apply h', mul_comm (L₁ _)]
+
 variable [CompleteSpace E]
 
 lemma covarianceBilin_apply (h : MemLp id 2 μ) (L₁ L₂ : Dual ℝ E) :
@@ -239,10 +254,19 @@ lemma covarianceBilin_apply (h : MemLp id 2 μ) (L₁ L₂ : Dual ℝ E) :
     simp [← hL]
   · exact (measurableEmbedding_subRight _).memLp_map_measure_iff.mpr <| h.sub (memLp_const _)
 
+lemma covarianceBilin_apply' (h : MemLp id 2 μ) (L₁ L₂ : Dual ℝ E) :
+    covarianceBilin μ L₁ L₂ = ∫ x, L₁ (x - μ[id]) * L₂ (x - μ[id]) ∂μ := by
+  rw [covarianceBilin_apply h]
+  have hL (L : Dual ℝ E) : μ[L] = L (∫ x, x ∂μ) := L.integral_comp_comm (h.integrable (by simp))
+  simp [← hL]
+
+lemma covarianceBilin_eq_covariance (h : MemLp id 2 μ) (L₁ L₂ : Dual ℝ E) :
+    covarianceBilin μ L₁ L₂ = cov[L₁, L₂; μ] := by
+  rw [covarianceBilin_apply h, covariance]
+
 lemma covarianceBilin_same_eq_variance (h : MemLp id 2 μ) (L : Dual ℝ E) :
     covarianceBilin μ L L = Var[L; μ] := by
-  rw [covarianceBilin_apply h, variance_eq_integral (by fun_prop)]
-  simp_rw [pow_two]
+  rw [covarianceBilin_eq_covariance h, covariance_self (by fun_prop)]
 
 end Covariance
 


### PR DESCRIPTION
Co-authored-by: Etienne Marion @EtienneC30

From the Brownian motion project.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
