### PR TITLE
refactor(Polynomial/Bivariate): swap `X` and `Y` for improved notation

### DIFF
--- a/Mathlib/Algebra/Polynomial/Bivariate.lean
+++ b/Mathlib/Algebra/Polynomial/Bivariate.lean
@@ -17,7 +17,7 @@ the abbreviation `CC` to view a constant in the base ring `R` as a bivariate pol
 -/
 
 /-- The notation `Y` for `X` in the `Polynomial` scope. -/
-scoped[Polynomial.Bivariate] notation3:max "Y" => Polynomial.X (R := Polynomial _)
+scoped[Polynomial.Bivariate] notation3:max "Y" => Polynomial.C Polynomial.X
 
 /-- The notation `R[X][Y]` for `R[X][X]` in the `Polynomial` scope. -/
 scoped[Polynomial.Bivariate] notation3:max R "[X][Y]" => Polynomial (Polynomial R)
@@ -184,7 +184,7 @@ lemma eval₂_eval₂RingHom_apply (f : R →+* S) (x y : S) (p : R[X][Y]) :
   congr($(eval₂RingHom_eval₂RingHom f x y) p)
 
 lemma eval_C_X_comp_eval₂_map_C_X :
-    (evalRingHom (C X : R[X][Y])).comp (eval₂RingHom (mapRingHom <| algebraMap R R[X][Y]) (C Y)) =
+    (evalRingHom (Y : R[X][Y])).comp (eval₂RingHom (mapRingHom <| algebraMap R R[X][Y]) (C X)) =
       .id _ := by
   ext <;> simp
 
@@ -192,7 +192,7 @@ lemma eval_C_X_comp_eval₂_map_C_X :
 `Y : R[X,Y,X']` (substitution of `Y'` by `Y`), obtaining another polynomial in `R[X,Y,X']`.
 When this polynomial is then evaluated at `X' = X`, the original polynomial `p` is recovered. -/
 lemma eval_C_X_eval₂_map_C_X {p : R[X][Y]} :
-    eval (C X) (eval₂ (mapRingHom <| algebraMap R R[X][Y]) (C Y) p) = p :=
+    eval Y (eval₂ (mapRingHom <| algebraMap R R[X][Y]) (C X) p) = p :=
   congr($eval_C_X_comp_eval₂_map_C_X p)
 
 end


### PR DESCRIPTION
This way, `X` keeps on being `X`.

From Toric


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
