### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Limits/Shapes/Pullback/Categorical): remove useless [local simp]

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Categorical/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Categorical/Basic.lean
@@ -58,8 +58,6 @@ universe v₁ v₂ v₃ v₄ u₁ u₂ u₃ u₄
 
 namespace CategoryTheory.Limits
 
-attribute [local simp] CatCommSq.iso_hom_naturality  CatCommSq.iso_inv_naturality
-
 section
 
 variable {A : Type u₁} {B : Type u₂} {C : Type u₃}


### PR DESCRIPTION
`CatCommSq.iso_hom_naturality` and `CatCommSq.iso_inv_naturality` were made global simp during review of #26366 but an artifact of the original code remained.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
