### PR TITLE
[Merged by Bors] - feat: iteratedDerivWithin version of zpow lemmas

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1437,6 +1437,7 @@ import Mathlib.Analysis.Calculus.InverseFunctionTheorem.FiniteDimensional
 import Mathlib.Analysis.Calculus.IteratedDeriv.Defs
 import Mathlib.Analysis.Calculus.IteratedDeriv.FaaDiBruno
 import Mathlib.Analysis.Calculus.IteratedDeriv.Lemmas
+import Mathlib.Analysis.Calculus.IteratedDeriv.WithinZpow
 import Mathlib.Analysis.Calculus.LHopital
 import Mathlib.Analysis.Calculus.LagrangeMultipliers
 import Mathlib.Analysis.Calculus.LineDeriv.Basic

--- a/Mathlib/Analysis/Calculus/Deriv/ZPow.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/ZPow.lean
@@ -5,6 +5,7 @@ Authors: Sébastien Gouëzel, Yury Kudryashov
 -/
 import Mathlib.Analysis.Calculus.Deriv.Pow
 import Mathlib.Analysis.Calculus.Deriv.Inv
+import Mathlib.Analysis.Calculus.Deriv.Shift
 
 /-!
 # Derivatives of `x ^ m`, `m : ℤ`
@@ -132,6 +133,33 @@ theorem iter_deriv_inv (k : ℕ) (x : 𝕜) :
 theorem iter_deriv_inv' (k : ℕ) :
     deriv^[k] Inv.inv = fun x : 𝕜 => (-1) ^ k * k ! * x ^ (-1 - k : ℤ) :=
   funext (iter_deriv_inv k)
+
+open Function in
+theorem iter_deriv_inv_linear (k : ℕ) (c d : 𝕜) :
+    deriv^[k] (fun x ↦ (c * x + d)⁻¹) =
+    (fun x : 𝕜 ↦ (-1) ^ k * k ! * c ^ k * (c * x + d)^ (-1 - k : ℤ)) := by
+  induction' k with k ihk
+  · simp
+  · rw [Nat.factorial_succ, show  k + 1 = 1 + k by ring, iterate_add_apply, ihk]
+    ext z
+    simp only [Int.reduceNeg, iterate_one, deriv_const_mul_field',
+      Nat.cast_add, Nat.cast_one]
+    by_cases hd : c = 0
+    · simp [hd]
+    · have := deriv_comp_add_const (fun x ↦ (c * x) ^ (-1 - k : ℤ)) (d / c) z
+      have h0 : (fun x ↦ (c * (x + d / c)) ^ (-1 - (k : ℤ))) =
+        (fun x ↦ (c * x + d) ^ (-1 - (k : ℤ))) := by
+        ext y
+        field_simp
+        ring_nf
+      rw [h0, deriv_comp_mul_left c (fun x ↦ (x) ^ (-1 - k : ℤ)) (z + d / c)] at this
+      field_simp [this]
+      ring_nf
+
+theorem iter_deriv_inv_linear_sub (k : ℕ) (c d : 𝕜) :
+    deriv^[k] (fun x ↦ (c * x - d)⁻¹) =
+    (fun x : 𝕜 ↦ (-1) ^ k * k ! * c ^ k * (c * x - d)^ (-1 - k : ℤ)) := by
+  simpa [sub_eq_add_neg] using iter_deriv_inv_linear k c (-d)
 
 variable {f : E → 𝕜} {t : Set E} {a : E}
 

--- a/Mathlib/Analysis/Calculus/Deriv/ZPow.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/ZPow.lean
@@ -134,16 +134,15 @@ theorem iter_deriv_inv' (k : ℕ) :
     deriv^[k] Inv.inv = fun x : 𝕜 => (-1) ^ k * k ! * x ^ (-1 - k : ℤ) :=
   funext (iter_deriv_inv k)
 
-open Function in
+open Nat Function in
 theorem iter_deriv_inv_linear (k : ℕ) (c d : 𝕜) :
     deriv^[k] (fun x ↦ (c * x + d)⁻¹) =
-    (fun x : 𝕜 ↦ (-1) ^ k * k ! * c ^ k * (c * x + d)^ (-1 - k : ℤ)) := by
+    (fun x : 𝕜 ↦ (-1) ^ k * k ! * c ^ k * (c * x + d) ^ (-1 - k : ℤ)) := by
   induction' k with k ihk
   · simp
-  · rw [Nat.factorial_succ, show  k + 1 = 1 + k by ring, iterate_add_apply, ihk]
+  · rw [factorial_succ, add_comm k 1, iterate_add_apply, ihk]
     ext z
-    simp only [Int.reduceNeg, iterate_one, deriv_const_mul_field',
-      Nat.cast_add, Nat.cast_one]
+    simp only [Int.reduceNeg, iterate_one, deriv_const_mul_field', cast_add, cast_one]
     by_cases hd : c = 0
     · simp [hd]
     · have := deriv_comp_add_const (fun x ↦ (c * x) ^ (-1 - k : ℤ)) (d / c) z
@@ -158,7 +157,7 @@ theorem iter_deriv_inv_linear (k : ℕ) (c d : 𝕜) :
 
 theorem iter_deriv_inv_linear_sub (k : ℕ) (c d : 𝕜) :
     deriv^[k] (fun x ↦ (c * x - d)⁻¹) =
-    (fun x : 𝕜 ↦ (-1) ^ k * k ! * c ^ k * (c * x - d)^ (-1 - k : ℤ)) := by
+    (fun x : 𝕜 ↦ (-1) ^ k * k ! * c ^ k * (c * x - d) ^ (-1 - k : ℤ)) := by
   simpa [sub_eq_add_neg] using iter_deriv_inv_linear k c (-d)
 
 variable {f : E → 𝕜} {t : Set E} {a : E}

--- a/Mathlib/Analysis/Calculus/Deriv/ZPow.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/ZPow.lean
@@ -138,9 +138,10 @@ open Nat Function in
 theorem iter_deriv_inv_linear (k : ℕ) (c d : 𝕜) :
     deriv^[k] (fun x ↦ (c * x + d)⁻¹) =
     (fun x : 𝕜 ↦ (-1) ^ k * k ! * c ^ k * (c * x + d) ^ (-1 - k : ℤ)) := by
-  induction' k with k ihk
-  · simp
-  · rw [factorial_succ, add_comm k 1, iterate_add_apply, ihk]
+  induction k with
+  | zero => simp
+  | succ k ihk =>
+    rw [factorial_succ, add_comm k 1, iterate_add_apply, ihk]
     ext z
     simp only [Int.reduceNeg, iterate_one, deriv_const_mul_field', cast_add, cast_one]
     by_cases hd : c = 0

--- a/Mathlib/Analysis/Calculus/IteratedDeriv/Defs.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/Defs.lean
@@ -298,6 +298,23 @@ theorem iteratedDeriv_eq_iterate : iteratedDeriv n f = deriv^[n] f := by
   convert iteratedDerivWithin_eq_iterate (F := F)
   simp [derivWithin_univ]
 
+theorem iteratedDerivWithin_of_isOpen (hs : IsOpen s) :
+    Set.EqOn (iteratedDerivWithin n f s) (iteratedDeriv n f) s := by
+  unfold iteratedDerivWithin iteratedDeriv
+  intro x hx
+  simp_rw [iteratedFDerivWithin_of_isOpen n hs hx]
+
+theorem iteratedDerivWithin_congr_of_isOpen (f : 𝕜 → F) (n : ℕ) {s t : Set 𝕜} (hs : IsOpen s)
+    (ht : IsOpen t) : (s ∩ t).EqOn (iteratedDerivWithin n f s) (iteratedDerivWithin n f t) := by
+  intro r hr
+  rw [iteratedDerivWithin_of_isOpen hs hr.1, iteratedDerivWithin_of_isOpen ht  hr.2]
+
+theorem iteratedDerivWithin_of_isOpen_eq_iterate (hs : IsOpen s) :
+    EqOn (iteratedDerivWithin n f s) (deriv^[n] f) s := by
+  apply Set.EqOn.trans (iteratedDerivWithin_of_isOpen hs)
+  rw [iteratedDeriv_eq_iterate]
+  exact fun ⦃x⦄ ↦ congrFun rfl
+
 /-- The `n+1`-th iterated derivative can be obtained by taking the `n`-th derivative of the
 derivative. -/
 theorem iteratedDeriv_succ' : iteratedDeriv (n + 1) f = iteratedDeriv n (deriv f) := by

--- a/Mathlib/Analysis/Calculus/IteratedDeriv/Defs.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/Defs.lean
@@ -300,9 +300,8 @@ theorem iteratedDeriv_eq_iterate : iteratedDeriv n f = deriv^[n] f := by
 
 theorem iteratedDerivWithin_of_isOpen (hs : IsOpen s) :
     Set.EqOn (iteratedDerivWithin n f s) (iteratedDeriv n f) s := by
-  unfold iteratedDerivWithin iteratedDeriv
   intro x hx
-  simp_rw [iteratedFDerivWithin_of_isOpen n hs hx]
+  simp_rw [iteratedDerivWithin, iteratedDeriv,iteratedFDerivWithin_of_isOpen n hs hx]
 
 theorem iteratedDerivWithin_congr_right_of_isOpen (f : 𝕜 → F) (n : ℕ) {s t : Set 𝕜} (hs : IsOpen s)
     (ht : IsOpen t) : (s ∩ t).EqOn (iteratedDerivWithin n f s) (iteratedDerivWithin n f t) := by

--- a/Mathlib/Analysis/Calculus/IteratedDeriv/Defs.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/Defs.lean
@@ -304,7 +304,7 @@ theorem iteratedDerivWithin_of_isOpen (hs : IsOpen s) :
   intro x hx
   simp_rw [iteratedFDerivWithin_of_isOpen n hs hx]
 
-theorem iteratedDerivWithin_congr_of_isOpen (f : 𝕜 → F) (n : ℕ) {s t : Set 𝕜} (hs : IsOpen s)
+theorem iteratedDerivWithin_congr_right_of_isOpen (f : 𝕜 → F) (n : ℕ) {s t : Set 𝕜} (hs : IsOpen s)
     (ht : IsOpen t) : (s ∩ t).EqOn (iteratedDerivWithin n f s) (iteratedDerivWithin n f t) := by
   intro r hr
   rw [iteratedDerivWithin_of_isOpen hs hr.1, iteratedDerivWithin_of_isOpen ht  hr.2]

--- a/Mathlib/Analysis/Calculus/IteratedDeriv/WithinZpow.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/WithinZpow.lean
@@ -32,4 +32,4 @@ theorem iteratedDerivWithin_one_div (k : ℕ) (hs : IsOpen s) :
     (fun y ↦ (-1) ^ k * (k !) * (y ^ (-1 - k : ℤ))) := by
   apply Set.EqOn.trans (iteratedDerivWithin_of_isOpen_eq_iterate hs)
   intro t ht
-  simp only [one_div, iter_deriv_inv', Int.reduceNeg]
+  simp

--- a/Mathlib/Analysis/Calculus/IteratedDeriv/WithinZpow.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/WithinZpow.lean
@@ -1,0 +1,34 @@
+/-
+Copyright (c) 2025 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+import Mathlib.Analysis.Calculus.IteratedDeriv.Defs
+import Mathlib.Analysis.Calculus.Deriv.ZPow
+
+/-!
+# Derivatives of `x ^ m`, `m : ℤ` within an open set
+
+In this file we prove theorems about iterated derivatives of `x ^ m`, `m : ℤ` within an open set.
+
+## Keywords
+
+iterated, derivative, power, open set
+-/
+
+open scoped Nat
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {s : Set 𝕜}
+
+theorem iteratedDerivWithin_zpow (m : ℤ) (k : ℕ) (hs : IsOpen s) :
+    s.EqOn (iteratedDerivWithin k (fun y ↦ y ^ m) s)
+    (fun y ↦ (∏ i ∈ Finset.range k, ((m : 𝕜) - i)) * y ^ (m - k)) := by
+  apply Set.EqOn.trans (iteratedDerivWithin_of_isOpen_eq_iterate hs)
+  simp
+
+theorem iteratedDerivWithin_one_div (k : ℕ) (hs : IsOpen s) :
+    s.EqOn (iteratedDerivWithin k (fun y ↦ 1 / y) s)
+    (fun y ↦ (-1) ^ k * (k !) * (y ^ (-1 - k : ℤ))) := by
+  apply Set.EqOn.trans (iteratedDerivWithin_of_isOpen_eq_iterate hs)
+  intro t ht
+  simp only [one_div, iter_deriv_inv', Int.reduceNeg]

--- a/Mathlib/Analysis/Calculus/IteratedDeriv/WithinZpow.lean
+++ b/Mathlib/Analysis/Calculus/IteratedDeriv/WithinZpow.lean
@@ -24,6 +24,7 @@ theorem iteratedDerivWithin_zpow (m : ℤ) (k : ℕ) (hs : IsOpen s) :
     s.EqOn (iteratedDerivWithin k (fun y ↦ y ^ m) s)
     (fun y ↦ (∏ i ∈ Finset.range k, ((m : 𝕜) - i)) * y ^ (m - k)) := by
   apply Set.EqOn.trans (iteratedDerivWithin_of_isOpen_eq_iterate hs)
+  intro t ht
   simp
 
 theorem iteratedDerivWithin_one_div (k : ℕ) (hs : IsOpen s) :


### PR DESCRIPTION
We add some more API for iteratedDerivWithin, specifically for zpow and linear functions. This will be used for q-expansion of Eisenstein series.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
