### PR TITLE
[Merged by Bors] - fix(NonZeroDivisors): swap left and right

### DIFF
--- a/Mathlib/Algebra/Group/Basic.lean
+++ b/Mathlib/Algebra/Group/Basic.lean
@@ -254,7 +254,7 @@ end LeftCancelMonoid
 
 section RightCancelMonoid
 
-variable [RightCancelMonoid M] {a b : M}
+variable [Monoid M] [IsRightCancelMul M] {a b : M}
 
 @[to_additive (attr := simp)]
 theorem mul_eq_right : a * b = b ↔ a = 1 := calc

--- a/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
+++ b/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Devon Tuma, Oliver Nash
 -/
-
 import Mathlib.Algebra.Group.Submonoid.Membership
 import Mathlib.Algebra.GroupWithZero.Associated
 

--- a/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
+++ b/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
@@ -37,15 +37,15 @@ variable (M₀ : Type*) [MonoidWithZero M₀] {x : M₀}
 /-- The collection of elements of a `MonoidWithZero` that are not left zero divisors form a
 `Submonoid`. -/
 def nonZeroDivisorsLeft : Submonoid M₀ where
-  carrier := {x | ∀ y, y * x = 0 → y = 0}
+  carrier := {x | ∀ y, x * y = 0 → y = 0}
   one_mem' := by simp
-  mul_mem' {x} {y} hx hy := fun z hz ↦ hx _ <| hy _ (mul_assoc z x y ▸ hz)
+  mul_mem' {x y} hx hy := fun z hz ↦ hy _ <| hx _ (mul_assoc x y z ▸ hz)
 
 @[simp]
-lemma mem_nonZeroDivisorsLeft_iff : x ∈ nonZeroDivisorsLeft M₀ ↔ ∀ y, y * x = 0 → y = 0 := .rfl
+lemma mem_nonZeroDivisorsLeft_iff : x ∈ nonZeroDivisorsLeft M₀ ↔ ∀ y, x * y = 0 → y = 0 := .rfl
 
 lemma notMem_nonZeroDivisorsLeft_iff :
-    x ∉ nonZeroDivisorsLeft M₀ ↔ {y | y * x = 0 ∧ y ≠ 0}.Nonempty := by
+    x ∉ nonZeroDivisorsLeft M₀ ↔ {y | x * y = 0 ∧ y ≠ 0}.Nonempty := by
   simpa [mem_nonZeroDivisorsLeft_iff] using Set.nonempty_def.symm
 
 @[deprecated (since := "2025-05-24")]
@@ -54,15 +54,15 @@ alias nmem_nonZeroDivisorsLeft_iff := notMem_nonZeroDivisorsLeft_iff
 /-- The collection of elements of a `MonoidWithZero` that are not right zero divisors form a
 `Submonoid`. -/
 def nonZeroDivisorsRight : Submonoid M₀ where
-  carrier := {x | ∀ y, x * y = 0 → y = 0}
+  carrier := {x | ∀ y, y * x = 0 → y = 0}
   one_mem' := by simp
-  mul_mem' := fun {x} {y} hx hy z hz ↦ hy _ (hx _ ((mul_assoc x y z).symm ▸ hz))
+  mul_mem' := fun {x y} hx hy z hz ↦ hx _ (hy _ ((mul_assoc z x y).symm ▸ hz))
 
 @[simp]
-lemma mem_nonZeroDivisorsRight_iff : x ∈ nonZeroDivisorsRight M₀ ↔ ∀ y, x * y = 0 → y = 0 := .rfl
+lemma mem_nonZeroDivisorsRight_iff : x ∈ nonZeroDivisorsRight M₀ ↔ ∀ y, y * x = 0 → y = 0 := .rfl
 
 lemma notMem_nonZeroDivisorsRight_iff :
-    x ∉ nonZeroDivisorsRight M₀ ↔ {y | x * y = 0 ∧ y ≠ 0}.Nonempty := by
+    x ∉ nonZeroDivisorsRight M₀ ↔ {y | y * x = 0 ∧ y ≠ 0}.Nonempty := by
   simpa [mem_nonZeroDivisorsRight_iff] using Set.nonempty_def.symm
 
 @[deprecated (since := "2025-05-24")]
@@ -75,29 +75,25 @@ lemma nonZeroDivisorsLeft_eq_right (M₀ : Type*) [CommMonoidWithZero M₀] :
 @[simp] lemma coe_nonZeroDivisorsLeft_eq [NoZeroDivisors M₀] [Nontrivial M₀] :
     nonZeroDivisorsLeft M₀ = {x : M₀ | x ≠ 0} := by
   ext x
-  simp only [SetLike.mem_coe, mem_nonZeroDivisorsLeft_iff, mul_eq_zero, forall_eq_or_imp, true_and,
+  simp only [SetLike.mem_coe, mem_nonZeroDivisorsLeft_iff, mul_eq_zero, Set.mem_setOf_eq]
+  refine ⟨fun h ↦ ?_, fun hx y hx' ↦ by aesop⟩
+  contrapose! h
+  exact ⟨1, Or.inl h, one_ne_zero⟩
+
+@[simp] lemma coe_nonZeroDivisorsRight_eq [NoZeroDivisors M₀] [Nontrivial M₀] :
+    nonZeroDivisorsRight M₀ = {x : M₀ | x ≠ 0} := by
+  ext x
+  simp only [SetLike.mem_coe, mem_nonZeroDivisorsRight_iff, mul_eq_zero, forall_eq_or_imp, true_and,
     Set.mem_setOf_eq]
   refine ⟨fun h ↦ ?_, fun hx y hx' ↦ by contradiction⟩
   contrapose! h
   exact ⟨1, h, one_ne_zero⟩
 
-@[simp] lemma coe_nonZeroDivisorsRight_eq [NoZeroDivisors M₀] [Nontrivial M₀] :
-    nonZeroDivisorsRight M₀ = {x : M₀ | x ≠ 0} := by
-  ext x
-  simp only [SetLike.mem_coe, mem_nonZeroDivisorsRight_iff, mul_eq_zero, Set.mem_setOf_eq]
-  refine ⟨fun h ↦ ?_, fun hx y hx' ↦ by aesop⟩
-  contrapose! h
-  exact ⟨1, Or.inl h, one_ne_zero⟩
-
 end
 
 /-- The submonoid of non-zero-divisors of a `MonoidWithZero` `M₀`. -/
-def nonZeroDivisors (M₀ : Type*) [MonoidWithZero M₀] : Submonoid M₀ where
-  carrier := { x | ∀ z, z * x = 0 → z = 0 }
-  one_mem' _ hz := by rwa [mul_one] at hz
-  mul_mem' hx₁ hx₂ _ hz := by
-    rw [← mul_assoc] at hz
-    exact hx₁ _ (hx₂ _ hz)
+def nonZeroDivisors (M₀ : Type*) [MonoidWithZero M₀] : Submonoid M₀  :=
+  nonZeroDivisorsLeft M₀ ⊓ nonZeroDivisorsRight M₀
 
 /-- The notation for the submonoid of non-zero divisors. -/
 scoped[nonZeroDivisors] notation:9000 M₀ "⁰" => nonZeroDivisors M₀
@@ -120,32 +116,49 @@ open nonZeroDivisors
 section MonoidWithZero
 variable {F M₀ M₀' : Type*} [MonoidWithZero M₀] [MonoidWithZero M₀'] {r x y : M₀}
 
--- this lemma reflects symmetry-breaking in the definition of `nonZeroDivisors`
-lemma nonZeroDivisorsLeft_eq_nonZeroDivisors : nonZeroDivisorsLeft M₀ = nonZeroDivisors M₀ := rfl
+lemma nonZeroDivisorsLeft_eq_nonZeroSMulDivisors :
+    nonZeroDivisorsLeft M₀ = nonZeroSMulDivisors M₀ M₀ := rfl
 
-lemma nonZeroDivisorsRight_eq_nonZeroSMulDivisors :
-    nonZeroDivisorsRight M₀ = nonZeroSMulDivisors M₀ M₀ := rfl
+@[deprecated (since := "2025-07-16")]
+alias nonZeroDivisorsRight_eq_nonZeroSMulDivisors := nonZeroDivisorsLeft_eq_nonZeroSMulDivisors
 
-theorem mem_nonZeroDivisors_iff : r ∈ M₀⁰ ↔ ∀ x, x * r = 0 → x = 0 := Iff.rfl
+theorem mem_nonZeroDivisors_iff :
+    r ∈ M₀⁰ ↔ (∀ x, r * x = 0 → x = 0) ∧ ∀ x, x * r = 0 → x = 0 := Iff.rfl
 
-lemma notMem_nonZeroDivisors_iff : r ∉ M₀⁰ ↔ {s | s * r = 0 ∧ s ≠ 0}.Nonempty := by
-  simpa [mem_nonZeroDivisors_iff] using Set.nonempty_def.symm
+lemma notMem_nonZeroDivisors_iff :
+    r ∉ M₀⁰ ↔ {s | r * s = 0 ∧ s ≠ 0}.Nonempty ∨ {s | s * r = 0 ∧ s ≠ 0}.Nonempty := by
+  simp [-not_and, not_and_or, mem_nonZeroDivisors_iff, Set.nonempty_def]
 
 @[deprecated (since := "2025-05-24")] alias nmem_nonZeroDivisors_iff := notMem_nonZeroDivisors_iff
 
-theorem mul_right_mem_nonZeroDivisors_eq_zero_iff (hr : r ∈ M₀⁰) : x * r = 0 ↔ x = 0 :=
+theorem mul_left_mem_nonZeroDivisorsLeft_eq_zero_iff (hr : r ∈ nonZeroDivisorsLeft M₀) :
+    r * x = 0 ↔ x = 0 :=
   ⟨hr _, by simp +contextual⟩
+
+theorem mul_right_mem_nonZeroDivisorsRight_eq_zero_iff (hr : r ∈ nonZeroDivisorsRight M₀) :
+    x * r = 0 ↔ x = 0 :=
+  ⟨hr _, by simp +contextual⟩
+
+theorem mul_right_mem_nonZeroDivisors_eq_zero_iff (hr : r ∈ M₀⁰) : x * r = 0 ↔ x = 0 :=
+  mul_right_mem_nonZeroDivisorsRight_eq_zero_iff hr.2
 
 @[simp]
 theorem mul_right_coe_nonZeroDivisors_eq_zero_iff {c : M₀⁰} : x * c = 0 ↔ x = 0 :=
   mul_right_mem_nonZeroDivisors_eq_zero_iff c.prop
 
-lemma IsUnit.mem_nonZeroDivisors (hx : IsUnit x) : x ∈ M₀⁰ := fun _ ↦ hx.mul_left_eq_zero.mp
+lemma IsUnit.mem_nonZeroDivisors (hx : IsUnit x) : x ∈ M₀⁰ :=
+  ⟨fun _ ↦ hx.mul_right_eq_zero.mp, fun _ ↦ hx.mul_left_eq_zero.mp⟩
 
 section Nontrivial
 variable [Nontrivial M₀]
 
-theorem zero_notMem_nonZeroDivisors : 0 ∉ M₀⁰ := fun h ↦ one_ne_zero <| h 1 <| mul_zero _
+theorem zero_notMem_nonZeroDivisorsLeft : 0 ∉ nonZeroDivisorsLeft M₀ :=
+  fun h ↦ one_ne_zero <| h 1 <| zero_mul _
+
+theorem zero_notMem_nonZeroDivisorsRight : 0 ∉ nonZeroDivisorsRight M₀ :=
+  fun h ↦ one_ne_zero <| h 1 <| mul_zero _
+
+theorem zero_notMem_nonZeroDivisors : 0 ∉ M₀⁰ := fun h ↦ zero_notMem_nonZeroDivisorsLeft h.1
 
 @[deprecated (since := "2025-05-23")]
 alias zero_not_mem_nonZeroDivisors := zero_notMem_nonZeroDivisors
@@ -179,15 +192,16 @@ theorem eq_zero_of_ne_zero_of_mul_right_eq_zero (hx : x ≠ 0) (hxy : y * x = 0)
 theorem eq_zero_of_ne_zero_of_mul_left_eq_zero (hx : x ≠ 0) (hxy : x * y = 0) : y = 0 :=
   Or.resolve_left (eq_zero_or_eq_zero_of_mul_eq_zero hxy) hx
 
-theorem mem_nonZeroDivisors_of_ne_zero (hx : x ≠ 0) : x ∈ M₀⁰ := fun _ ↦
-  eq_zero_of_ne_zero_of_mul_right_eq_zero hx
+theorem mem_nonZeroDivisors_of_ne_zero (hx : x ≠ 0) : x ∈ M₀⁰ :=
+  ⟨fun _ ↦ eq_zero_of_ne_zero_of_mul_left_eq_zero hx,
+   fun _ ↦ eq_zero_of_ne_zero_of_mul_right_eq_zero hx⟩
 
 @[simp] lemma mem_nonZeroDivisors_iff_ne_zero [Nontrivial M₀] : x ∈ M₀⁰ ↔ x ≠ 0 :=
   ⟨nonZeroDivisors.ne_zero, mem_nonZeroDivisors_of_ne_zero⟩
 
 theorem le_nonZeroDivisors_of_noZeroDivisors {S : Submonoid M₀} (hS : (0 : M₀) ∉ S) :
-    S ≤ M₀⁰ := fun _ hx _ hy ↦
-  (eq_zero_or_eq_zero_of_mul_eq_zero hy).resolve_right (ne_of_mem_of_not_mem hx hS)
+    S ≤ M₀⁰ := fun _ hx ↦
+  mem_nonZeroDivisors_of_ne_zero <| by rintro rfl; exact hS hx
 
 theorem powers_le_nonZeroDivisors_of_noZeroDivisors (hx : x ≠ 0) : Submonoid.powers x ≤ M₀⁰ :=
   le_nonZeroDivisors_of_noZeroDivisors fun h ↦ hx (h.recOn fun _ ↦ pow_eq_zero)
@@ -196,13 +210,15 @@ end NoZeroDivisors
 
 variable [FunLike F M₀ M₀']
 
+-- TODO: nonZeroDivisorsLeft/Right also works
 theorem map_ne_zero_of_mem_nonZeroDivisors [Nontrivial M₀] [ZeroHomClass F M₀ M₀'] (g : F)
     (hg : Injective (g : M₀ → M₀')) {x : M₀} (h : x ∈ M₀⁰) : g x ≠ 0 := fun h0 ↦
-  one_ne_zero (h 1 ((one_mul x).symm ▸ hg (h0.trans (map_zero g).symm)))
+  one_ne_zero (h.2 1 ((one_mul x).symm ▸ hg (h0.trans (map_zero g).symm)))
 
 theorem map_mem_nonZeroDivisors [Nontrivial M₀] [NoZeroDivisors M₀'] [ZeroHomClass F M₀ M₀'] (g : F)
-    (hg : Injective g) {x : M₀} (h : x ∈ M₀⁰) : g x ∈ M₀'⁰ := fun _ hz ↦
-  eq_zero_of_ne_zero_of_mul_right_eq_zero (map_ne_zero_of_mem_nonZeroDivisors g hg h) hz
+    (hg : Injective g) {x : M₀} (h : x ∈ M₀⁰) : g x ∈ M₀'⁰ :=
+  ⟨fun _ ↦ eq_zero_of_ne_zero_of_mul_left_eq_zero (map_ne_zero_of_mem_nonZeroDivisors g hg h),
+    fun _ ↦ eq_zero_of_ne_zero_of_mul_right_eq_zero (map_ne_zero_of_mem_nonZeroDivisors g hg h)⟩
 
 theorem MulEquivClass.map_nonZeroDivisors {M₀ S F : Type*} [MonoidWithZero M₀] [MonoidWithZero S]
     [EquivLike F M₀ S] [MulEquivClass F M₀ S] (h : F) :
@@ -230,7 +246,8 @@ theorem nonZeroDivisors_le_comap_nonZeroDivisors_of_injective [NoZeroDivisors M�
 then it is a non-zero-divisor. -/
 theorem mem_nonZeroDivisors_of_injective [MonoidWithZeroHomClass F M₀ M₀'] {f : F}
     (hf : Injective f) (hx : f x ∈ M₀'⁰) : x ∈ M₀⁰ :=
-  fun y hy ↦ hf <| map_zero f ▸ hx (f y) (map_mul f y x ▸ map_zero f ▸ congrArg f hy)
+  ⟨fun y hy ↦ hf <| map_zero f ▸ hx.1 (f y) (map_mul f x y ▸ map_zero f ▸ congrArg f hy),
+    fun y hy ↦ hf <| map_zero f ▸ hx.2 (f y) (map_mul f y x ▸ map_zero f ▸ congrArg f hy)⟩
 
 @[deprecated (since := "2025-02-03")]
 alias mem_nonZeroDivisor_of_injective := mem_nonZeroDivisors_of_injective
@@ -247,6 +264,18 @@ end MonoidWithZero
 section CommMonoidWithZero
 variable {M₀ : Type*} [CommMonoidWithZero M₀] {a b r x : M₀}
 
+lemma nonZeroDivisorsLeft_eq_nonZeroDivisors : nonZeroDivisorsLeft M₀ = nonZeroDivisors M₀ := by
+  rw [nonZeroDivisors, nonZeroDivisorsLeft_eq_right, inf_idem]
+
+lemma nonZeroDivisorsRight_eq_nonZeroDivisors : nonZeroDivisorsRight M₀ = nonZeroDivisors M₀ := by
+  rw [← nonZeroDivisorsLeft_eq_right, nonZeroDivisorsLeft_eq_nonZeroDivisors]
+
+theorem mem_nonZeroDivisors_iff_right : r ∈ M₀⁰ ↔ ∀ x, x * r = 0 → x = 0 := by
+  rw [← nonZeroDivisorsRight_eq_nonZeroDivisors]; rfl
+
+lemma notMem_nonZeroDivisors_iff_right : r ∉ M₀⁰ ↔ {s | s * r = 0 ∧ s ≠ 0}.Nonempty := by
+  simp [mem_nonZeroDivisors_iff_right, Set.nonempty_def]
+
 lemma mul_left_mem_nonZeroDivisors_eq_zero_iff (hr : r ∈ M₀⁰) : r * x = 0 ↔ x = 0 := by
   rw [mul_comm, mul_right_mem_nonZeroDivisors_eq_zero_iff hr]
 
@@ -256,14 +285,11 @@ lemma mul_left_coe_nonZeroDivisors_eq_zero_iff {c : M₀⁰} : (c : M₀) * x = 
 
 lemma mul_mem_nonZeroDivisors : a * b ∈ M₀⁰ ↔ a ∈ M₀⁰ ∧ b ∈ M₀⁰ where
   mp h := by
-    constructor <;> intro x h' <;> apply h
+    rw [← nonZeroDivisorsRight_eq_nonZeroDivisors]
+    constructor <;> intro x h' <;> apply h.2
     · rw [← mul_assoc, h', zero_mul]
     · rw [mul_comm a b, ← mul_assoc, h', zero_mul]
-  mpr := by
-    rintro ⟨ha, hb⟩ x hx
-    apply ha
-    apply hb
-    rw [mul_assoc, hx]
+  mpr := fun h ↦ mul_mem h.1 h.2
 
 theorem nonZeroDivisors_dvd_iff_dvd_coe {a b : M₀⁰} :
     a ∣ b ↔ (a : M₀) ∣ (b : M₀) :=
@@ -297,17 +323,13 @@ variable {M₀ M : Type*} [MonoidWithZero M₀] [Zero M] [MulAction M₀ M] {x :
 
 lemma mem_nonZeroSMulDivisors_iff : x ∈ M₀⁰[M] ↔ ∀ (m : M), x • m = 0 → m = 0 := Iff.rfl
 
-variable (M₀)
+@[deprecated (since := "2025-07-16")]
+alias unop_nonZeroSMulDivisors_mulOpposite_eq_nonZeroDivisors :=
+  nonZeroDivisorsLeft_eq_nonZeroSMulDivisors
 
-@[simp]
-lemma unop_nonZeroSMulDivisors_mulOpposite_eq_nonZeroDivisors :
-    (M₀ᵐᵒᵖ ⁰[M₀]).unop = M₀⁰ := rfl
-
-/-- The non-zero `•`-divisors with `•` as right multiplication correspond with the non-zero
-divisors. Note that the `MulOpposite` is needed because we defined `nonZeroDivisors` with
-multiplication on the right. -/
-lemma nonZeroSMulDivisors_mulOpposite_eq_op_nonZeroDivisors :
-    M₀ᵐᵒᵖ ⁰[M₀] = M₀⁰.op := rfl
+@[deprecated (since := "2025-07-16")]
+alias nonZeroSMulDivisors_mulOpposite_eq_op_nonZeroDivisors :=
+  nonZeroDivisorsLeft_eq_nonZeroSMulDivisors
 
 end nonZeroSMulDivisors
 
@@ -334,7 +356,7 @@ section CommMonoidWithZero
 variable {M₀ : Type*} [CommMonoidWithZero M₀] {a : M₀}
 
 theorem mk_mem_nonZeroDivisors_associates : Associates.mk a ∈ (Associates M₀)⁰ ↔ a ∈ M₀⁰ := by
-  rw [mem_nonZeroDivisors_iff, mem_nonZeroDivisors_iff, ← not_iff_not]
+  rw [mem_nonZeroDivisors_iff_right, mem_nonZeroDivisors_iff_right, ← not_iff_not]
   push_neg
   constructor
   · rintro ⟨⟨x⟩, hx₁, hx₂⟩

--- a/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
+++ b/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
@@ -3,10 +3,9 @@ Copyright (c) 2020 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Devon Tuma, Oliver Nash
 -/
-import Mathlib.Algebra.Group.Action.Opposite
+
 import Mathlib.Algebra.Group.Submonoid.Membership
 import Mathlib.Algebra.GroupWithZero.Associated
-import Mathlib.Algebra.GroupWithZero.Opposite
 
 /-!
 # Non-zero divisors and smul-divisors

--- a/Mathlib/Algebra/Lie/Weights/Killing.lean
+++ b/Mathlib/Algebra/Lie/Weights/Killing.lean
@@ -204,7 +204,7 @@ lemma eq_zero_of_isNilpotent_ad_of_mem_isCartanSubalgebra {x : L} (hx : x ∈ H)
   have comm : Commute (toEnd K H L ⟨x, hx⟩) (toEnd K H L y) := by
     rw [commute_iff_lie_eq, ← LieHom.map_lie, trivial_lie_zero, LieHom.map_zero]
   rw [traceForm_apply_apply, ← Module.End.mul_eq_comp, LinearMap.zero_apply]
-  exact (LinearMap.isNilpotent_trace_of_isNilpotent (comm.isNilpotent_mul_left hx')).eq_zero
+  exact (LinearMap.isNilpotent_trace_of_isNilpotent (comm.isNilpotent_mul_right hx')).eq_zero
 
 @[simp]
 lemma corootSpace_zero_eq_bot :

--- a/Mathlib/Algebra/Polynomial/AlgebraMap.lean
+++ b/Mathlib/Algebra/Polynomial/AlgebraMap.lean
@@ -697,9 +697,9 @@ open nonZeroDivisors
 /-- *McCoy theorem*: a polynomial `P : R[X]` is a zerodivisor if and only if there is `a : R`
 such that `a ≠ 0` and `a • P = 0`. -/
 theorem notMem_nonZeroDivisors_iff {P : R[X]} : P ∉ R[X]⁰ ↔ ∃ a : R, a ≠ 0 ∧ a • P = 0 := by
-  refine ⟨fun hP ↦ ?_, fun ⟨a, ha, h⟩ h1 ↦ ha <| C_eq_zero.1 <| (h1 _) <| smul_eq_C_mul a ▸ h⟩
+  refine ⟨fun hP ↦ ?_, fun ⟨a, ha, h⟩ h1 ↦ ha <| C_eq_zero.1 <| (h1.2 _) <| smul_eq_C_mul a ▸ h⟩
   by_contra! h
-  obtain ⟨Q, hQ⟩ := _root_.notMem_nonZeroDivisors_iff.1 hP
+  obtain ⟨Q, hQ⟩ := notMem_nonZeroDivisors_iff_right.1 hP
   refine hQ.2 (eq_zero_of_mul_eq_zero_of_smul P (fun a ha ↦ ?_) Q (mul_comm P _ ▸ hQ.1))
   contrapose! ha
   exact h a ha
@@ -711,7 +711,7 @@ protected lemma mem_nonZeroDivisors_iff {P : R[X]} : P ∈ R[X]⁰ ↔ ∀ a : R
 
 lemma mem_nonzeroDivisors_of_coeff_mem {p : R[X]} (n : ℕ) (hp : p.coeff n ∈ R⁰) :
     p ∈ R[X]⁰ :=
-  Polynomial.mem_nonZeroDivisors_iff.mpr fun r hr ↦ hp _ (by simpa using congr(coeff $hr n))
+  Polynomial.mem_nonZeroDivisors_iff.mpr fun r hr ↦ hp.2 _ (by simpa using congr(coeff $hr n))
 
 lemma X_mem_nonzeroDivisors : X ∈ R[X]⁰ :=
   mem_nonzeroDivisors_of_coeff_mem 1 (by simp [one_mem])

--- a/Mathlib/Algebra/Polynomial/Module/FiniteDimensional.lean
+++ b/Mathlib/Algebra/Polynomial/Module/FiniteDimensional.lean
@@ -30,7 +30,8 @@ theorem isTorsion_of_aeval_eq_zero [CommSemiring R] [NoZeroDivisors R] [Semiring
     [AddCommMonoid M] [Module A M] [Module R M] [IsScalarTower R A M]
     {p : R[X]} (h : aeval a p = 0) (h' : p ≠ 0) :
     IsTorsion R[X] (AEval R M a) := by
-  have hp : p ∈ nonZeroDivisors R[X] := fun q hq ↦ Or.resolve_right (mul_eq_zero.mp hq) h'
+  have hp : p ∈ nonZeroDivisors R[X] := mem_nonZeroDivisors_iff_right.mpr
+    fun q hq ↦ Or.resolve_right (mul_eq_zero.mp hq) h'
   exact fun x ↦ ⟨⟨p, hp⟩, (of R M a).symm.injective <| by simp [h]⟩
 
 variable (K M a)

--- a/Mathlib/Algebra/Ring/NonZeroDivisors.lean
+++ b/Mathlib/Algebra/Ring/NonZeroDivisors.lean
@@ -15,41 +15,92 @@ assert_not_exists Field
 
 open scoped nonZeroDivisors
 
+section MonoidWithZero
+
+variable {R : Type*} [MonoidWithZero R] {r : R}
+
+theorem IsLeftRegular.mem_nonZeroDivisorsLeft (h : IsLeftRegular r) : r ∈ nonZeroDivisorsLeft R :=
+  fun x hrx ↦ h (by simpa)
+
+theorem IsRightRegular.mem_nonZeroDivisorsRight (h : IsRightRegular r) :
+    r ∈ nonZeroDivisorsRight R :=
+  fun x hrx ↦ h (by simpa)
+
+end MonoidWithZero
+
+section Monoid
+
+variable {R : Type*} [Monoid R] [Finite R] {r : R}
+
+theorem IsLeftRegular.isUnit_of_finite (h : IsLeftRegular r) : IsUnit r := by
+  rwa [IsUnit.isUnit_iff_mulLeft_bijective, ← Finite.injective_iff_bijective]
+
+theorem IsRightRegular.isUnit_of_finite (h : IsRightRegular r) : IsUnit r := by
+  rwa [IsUnit.isUnit_iff_mulRight_bijective, ← Finite.injective_iff_bijective]
+
+theorem isRegular_iff_isUnit_of_finite {r : R} : IsRegular r ↔ IsUnit r where
+  mp h := h.1.isUnit_of_finite
+  mpr h := h.isRegular
+
+end Monoid
+
 section Ring
+
 variable {R : Type*} [Ring R] {a x y r : R}
 
-lemma mul_cancel_right_mem_nonZeroDivisors (hr : r ∈ R⁰) : x * r = y * r ↔ x = y := by
+lemma mul_cancel_left_mem_nonZeroDivisorsLeft (hr : r ∈ nonZeroDivisorsLeft R) :
+    r * x = r * y ↔ x = y := by
+  refine ⟨fun h ↦ ?_, congrArg (r * ·)⟩
+  rw [← sub_eq_zero, ← mul_left_mem_nonZeroDivisorsLeft_eq_zero_iff hr, mul_sub, h, sub_self]
+
+lemma mul_cancel_right_mem_nonZeroDivisorsRight (hr : r ∈ nonZeroDivisorsRight R) :
+    x * r = y * r ↔ x = y := by
   refine ⟨fun h ↦ ?_, congrArg (· * r)⟩
-  rw [← sub_eq_zero, ← mul_right_mem_nonZeroDivisors_eq_zero_iff hr, sub_mul, h, sub_self]
+  rw [← sub_eq_zero, ← mul_right_mem_nonZeroDivisorsRight_eq_zero_iff hr, sub_mul, h, sub_self]
+
+lemma mul_cancel_right_mem_nonZeroDivisors (hr : r ∈ R⁰) : x * r = y * r ↔ x = y :=
+  mul_cancel_right_mem_nonZeroDivisorsRight hr.2
 
 lemma mul_cancel_right_coe_nonZeroDivisors {c : R⁰} : x * c = y * c ↔ x = y :=
   mul_cancel_right_mem_nonZeroDivisors c.prop
 
-lemma isLeftRegular_iff_mem_nonZeroDivisorsRight : IsLeftRegular r ↔ r ∈ nonZeroDivisorsRight R :=
+lemma isLeftRegular_iff_mem_nonZeroDivisorsLeft : IsLeftRegular r ↔ r ∈ nonZeroDivisorsLeft R :=
   ⟨fun h r' eq ↦ h (by simp_rw [eq, mul_zero]),
     fun h r₁ r₂ eq ↦ sub_eq_zero.mp <| h _ <| by simp_rw [mul_sub, eq, sub_self]⟩
 
-lemma isRightRegular_iff_mem_nonZeroDivisorsLeft : IsRightRegular r ↔ r ∈ nonZeroDivisorsLeft R :=
+lemma isRightRegular_iff_mem_nonZeroDivisorsRight : IsRightRegular r ↔ r ∈ nonZeroDivisorsRight R :=
   ⟨fun h r' eq ↦ h (by simp_rw [eq, zero_mul]),
     fun h r₁ r₂ eq ↦ sub_eq_zero.mp <| h _ <| by simp_rw [sub_mul, eq, sub_self]⟩
 
-lemma le_nonZeroDivisors_iff_isRightRegular {S : Submonoid R} :
-    S ≤ R⁰ ↔ ∀ s : S, IsRightRegular (s : R) := by
-  simp_rw [SetLike.le_def, isRightRegular_iff_mem_nonZeroDivisorsLeft, Subtype.forall,
-    nonZeroDivisorsLeft_eq_nonZeroDivisors]
+lemma isRegular_iff_mem_nonZeroDivisors : IsRegular r ↔ r ∈ R⁰ := by
+  rw [isRegular_iff, isLeftRegular_iff_mem_nonZeroDivisorsLeft,
+    isRightRegular_iff_mem_nonZeroDivisorsRight, nonZeroDivisors, Submonoid.mem_inf]
 
-lemma le_nonZeroDivisors_iff_isRegular {R} [CommRing R] {S : Submonoid R} :
+lemma le_nonZeroDivisorsLeft_iff_isLeftRegular {S : Submonoid R} :
+    S ≤ nonZeroDivisorsLeft R ↔ ∀ s : S, IsLeftRegular (s : R) := by
+  simp_rw [SetLike.le_def, isLeftRegular_iff_mem_nonZeroDivisorsLeft, Subtype.forall]
+
+lemma le_nonZeroDivisorsRight_iff_isRightRegular {S : Submonoid R} :
+    S ≤ nonZeroDivisorsRight R ↔ ∀ s : S, IsRightRegular (s : R) := by
+  simp_rw [SetLike.le_def, isRightRegular_iff_mem_nonZeroDivisorsRight, Subtype.forall]
+
+lemma le_nonZeroDivisors_iff_isRegular {S : Submonoid R} :
     S ≤ R⁰ ↔ ∀ s : S, IsRegular (s : R) := by
-  simp_rw [le_nonZeroDivisors_iff_isRightRegular,
-    Commute.isRightRegular_iff (Commute.all _), Commute.isRegular_iff (Commute.all _)]
+  simp_rw [nonZeroDivisors, le_inf_iff, le_nonZeroDivisorsLeft_iff_isLeftRegular,
+    le_nonZeroDivisorsRight_iff_isRightRegular, isRegular_iff, forall_and]
+
+@[deprecated (since := "2025-07-16")]
+alias isLeftRegular_iff_mem_nonZeroDivisorsRight := isLeftRegular_iff_mem_nonZeroDivisorsLeft
+
+@[deprecated (since := "2025-07-16")]
+alias isRightRegular_iff_mem_nonZeroDivisorsLeft := isRightRegular_iff_mem_nonZeroDivisorsRight
+
+@[deprecated (since := "2025-07-16")]
+alias le_nonZeroDivisors_iff_isRightRegular := le_nonZeroDivisorsRight_iff_isRightRegular
 
 /-- In a finite ring, an element is a unit iff it is a non-zero-divisor. -/
 lemma isUnit_iff_mem_nonZeroDivisors_of_finite [Finite R] : IsUnit a ↔ a ∈ nonZeroDivisors R := by
-  refine ⟨IsUnit.mem_nonZeroDivisors, fun ha ↦ ?_⟩
-  rw [IsUnit.isUnit_iff_mulRight_bijective, ← Finite.injective_iff_bijective]
-  intro b c hbc
-  rw [← sub_eq_zero, ← sub_mul] at hbc
-  exact sub_eq_zero.mp (ha _ hbc)
+  rw [← isRegular_iff_mem_nonZeroDivisors, isRegular_iff_isUnit_of_finite]
 
 end Ring
 

--- a/Mathlib/Dynamics/Newton.lean
+++ b/Mathlib/Dynamics/Newton.lean
@@ -64,7 +64,7 @@ theorem isNilpotent_iterate_newtonMap_sub_of_isNilpotent (h : IsNilpotent <| aev
   | zero => simp
   | succ n ih =>
     rw [iterate_succ', comp_apply, newtonMap_apply, sub_right_comm]
-    refine (Commute.all _ _).isNilpotent_sub ih <| (Commute.all _ _).isNilpotent_mul_right ?_
+    refine (Commute.all _ _).isNilpotent_sub ih <| (Commute.all _ _).isNilpotent_mul_left ?_
     simpa using Commute.isNilpotent_add (Commute.all _ _)
       (isNilpotent_aeval_sub_of_isNilpotent_sub P ih) h
 
@@ -123,7 +123,7 @@ theorem existsUnique_nilpotent_sub_and_aeval_eq_zero
       isUnit_aeval_of_isUnit_aeval_of_isNilpotent_sub h' hr₁
     rw [← sub_sub_sub_cancel_right r₂ r₁ x]
     refine IsNilpotent.isUnit_add_left_of_commute ?_ this (Commute.all _ _)
-    exact (Commute.all _ _).isNilpotent_mul_right <| (Commute.all _ _).isNilpotent_sub hr₂ hr₁
+    exact (Commute.all _ _).isNilpotent_mul_left <| (Commute.all _ _).isNilpotent_sub hr₂ hr₁
 
 @[deprecated (since := "2024-12-17")]
 alias exists_unique_nilpotent_sub_and_aeval_eq_zero := existsUnique_nilpotent_sub_and_aeval_eq_zero

--- a/Mathlib/FieldTheory/Laurent.lean
+++ b/Mathlib/FieldTheory/Laurent.lean
@@ -35,7 +35,7 @@ open scoped nonZeroDivisors
 variable {R : Type u} [CommRing R] (r s : R) (p q : R[X]) (f : RatFunc R)
 
 theorem taylor_mem_nonZeroDivisors (hp : p ∈ R[X]⁰) : taylor r p ∈ R[X]⁰ := by
-  rw [mem_nonZeroDivisors_iff]
+  rw [mem_nonZeroDivisors_iff_right]
   intro x hx
   have : x = taylor (r - r) x := by simp
   rwa [this, sub_eq_add_neg, ← taylor_taylor, ← taylor_mul,

--- a/Mathlib/LinearAlgebra/Dimension/Torsion/Basic.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Torsion/Basic.lean
@@ -28,4 +28,4 @@ theorem rank_quotient_eq_of_le_torsion {R M : Type*} [CommRing R] [AddCommGroup 
     intro t g hg i hi
     obtain ⟨r, hg⟩ := hN hg
     simp_rw [Finset.smul_sum, Submonoid.smul_def, smul_smul] at hg
-    exact r.prop _ (mul_comm (g i) r ▸ hs t _ hg i hi)
+    exact r.prop.2 _ (mul_comm (g i) r ▸ hs t _ hg i hi)

--- a/Mathlib/LinearAlgebra/Trace.lean
+++ b/Mathlib/LinearAlgebra/Trace.lean
@@ -308,7 +308,7 @@ lemma trace_comp_eq_mul_of_commute_of_isNilpotent [IsReduced R] {f g : Module.En
   set n := g - algebraMap R _ μ
   replace hg : trace R M (f ∘ₗ n) = 0 := by
     rw [← isNilpotent_iff_eq_zero, ← Module.End.mul_eq_comp]
-    refine isNilpotent_trace_of_isNilpotent (Commute.isNilpotent_mul_right ?_ hg)
+    refine isNilpotent_trace_of_isNilpotent (Commute.isNilpotent_mul_left ?_ hg)
     exact h_comm.sub_right (Algebra.commute_algebraMap_right μ f)
   have hμ : g = algebraMap R _ μ + n := eq_add_of_sub_eq' rfl
   have : f ∘ₗ algebraMap R _ μ = μ • f := by ext; simp -- TODO Surely exists?

--- a/Mathlib/NumberTheory/ClassNumber/Finite.lean
+++ b/Mathlib/NumberTheory/ClassNumber/Finite.lean
@@ -279,7 +279,7 @@ theorem exists_mk0_eq_mk0 [IsDedekindDomain S] [Algebra.IsAlgebraic R S] (I : (I
     · rw [mem_nonZeroDivisors_iff_ne_zero]
       rintro rfl
       rw [Ideal.zero_eq_bot, Ideal.mul_bot] at hJ
-      exact hM (Ideal.span_singleton_eq_bot.mp (I.2 _ hJ))
+      exact hM (Ideal.span_singleton_eq_bot.mp (I.2.2 _ hJ))
     · rw [ClassGroup.mk0_eq_mk0_iff]
       exact ⟨algebraMap _ _ M, b, hM, b_ne_zero, hJ⟩
     rw [← SetLike.mem_coe, ← Set.singleton_subset_iff, ← Ideal.span_le, ← Ideal.dvd_iff_le]

--- a/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
+++ b/Mathlib/NumberTheory/LegendreSymbol/AddCharacter.lean
@@ -85,7 +85,8 @@ theorem IsPrimitive.of_ne_one {F : Type u} [Field F] {ψ : AddChar F R'} (hψ : 
 lemma not_isPrimitive_mulShift [Finite R] (e : AddChar R R') {r : R}
     (hr : ¬ IsUnit r) : ¬ IsPrimitive (e.mulShift r) := by
   simp only [IsPrimitive, not_forall]
-  simp only [isUnit_iff_mem_nonZeroDivisors_of_finite, mem_nonZeroDivisors_iff, not_forall] at hr
+  simp only [isUnit_iff_mem_nonZeroDivisors_of_finite,
+    mem_nonZeroDivisors_iff_right, not_forall] at hr
   rcases hr with ⟨x, h, h'⟩
   exact ⟨x, h', by simp only [mulShift_mulShift, mul_comm r, h, mulShift_zero, not_ne_iff]⟩
 

--- a/Mathlib/RingTheory/Algebraic/Basic.lean
+++ b/Mathlib/RingTheory/Algebraic/Basic.lean
@@ -543,7 +543,7 @@ theorem IsAlgebraic.exists_nonzero_coeff_and_aeval_eq_zero
   obtain ⟨q, hpq, hq⟩ := exists_eq_pow_rootMultiplicity_mul_and_not_dvd p hp0 0
   simp only [C_0, sub_zero, X_pow_mul, X_dvd_iff] at hpq hq
   rw [hpq, map_mul, aeval_X_pow] at hp
-  exact ⟨q, hq, (nonZeroDivisors S).pow_mem hs (rootMultiplicity 0 p) (aeval s q) hp⟩
+  exact ⟨q, hq, (S⁰.pow_mem hs (rootMultiplicity 0 p)).2 (aeval s q) hp⟩
 
 theorem IsAlgebraic.exists_nonzero_eq_adjoin_mul {s : S} (hRs : IsAlgebraic R s) (hs : s ∈ S⁰) :
     ∃ᵉ (t ∈ Algebra.adjoin R {s}) (r ≠ (0 : R)), s * t = algebraMap R S r := by

--- a/Mathlib/RingTheory/ClassGroup.lean
+++ b/Mathlib/RingTheory/ClassGroup.lean
@@ -344,7 +344,7 @@ theorem ClassGroup.mk0_eq_mk0_inv_iff [IsDedekindDomain R] {I J : (Ideal R)⁰} 
   refine ⟨fun ⟨a, ha⟩ ↦ ⟨a, ?_, ha⟩, fun ⟨a, _, ha⟩ ↦ ⟨a, ha⟩⟩
   by_contra!
   rw [this, Submodule.span_zero_singleton] at ha
-  exact nonZeroDivisors.coe_ne_zero _ <| J.prop _ ha
+  exact nonZeroDivisors.coe_ne_zero _ <| J.prop.2 _ ha
 
 /-- The class group of principal ideal domain is finite (in fact a singleton).
 

--- a/Mathlib/RingTheory/Ideal/MinimalPrime/Localization.lean
+++ b/Mathlib/RingTheory/Ideal/MinimalPrime/Localization.lean
@@ -79,8 +79,8 @@ theorem Ideal.exists_mul_mem_of_mem_minimalPrimes
 /-- minimal primes are contained in zero divisors. -/
 lemma Ideal.disjoint_nonZeroDivisors_of_mem_minimalPrimes {p : Ideal R} (hp : p ∈ minimalPrimes R) :
     Disjoint (p : Set R) (nonZeroDivisors R) := by
-  simp_rw [Set.disjoint_left, SetLike.mem_coe, mem_nonZeroDivisors_iff, not_forall, exists_prop,
-    @and_comm (_ * _ = _), ← mul_comm]
+  simp_rw [Set.disjoint_left, SetLike.mem_coe, mem_nonZeroDivisors_iff_right, not_forall,
+    exists_prop, @and_comm (_ * _ = _), ← mul_comm]
   exact fun _ ↦ Ideal.exists_mul_mem_of_mem_minimalPrimes hp
 
 theorem Ideal.exists_comap_eq_of_mem_minimalPrimes {I : Ideal S} (f : R →+* S) (p)

--- a/Mathlib/RingTheory/Ideal/Operations.lean
+++ b/Mathlib/RingTheory/Ideal/Operations.lean
@@ -1242,7 +1242,8 @@ open scoped nonZeroDivisors in
 theorem Ideal.span_singleton_nonZeroDivisors {R : Type*} [CommSemiring R] [NoZeroDivisors R]
     {r : R} : span {r} ∈ (Ideal R)⁰ ↔ r ∈ R⁰ := by
   cases subsingleton_or_nontrivial R
-  · exact ⟨fun _ _ _ ↦ Subsingleton.eq_zero _, fun _ _ _ ↦ Subsingleton.eq_zero _⟩
+  · simp_rw [← nonZeroDivisorsRight_eq_nonZeroDivisors]
+    exact ⟨fun _ _ _ ↦ Subsingleton.eq_zero _, fun _ _ _ ↦ Subsingleton.eq_zero _⟩
   · rw [mem_nonZeroDivisors_iff_ne_zero, mem_nonZeroDivisors_iff_ne_zero, ne_eq, zero_eq_bot,
       span_singleton_eq_bot]
 

--- a/Mathlib/RingTheory/Localization/Cardinality.lean
+++ b/Mathlib/RingTheory/Localization/Cardinality.lean
@@ -58,11 +58,7 @@ namespace Localization
 
 theorem cardinalMk {S : Submonoid R} (hS : S ≤ R⁰) : #(Localization S) = #R := by
   apply OreLocalization.cardinalMk
-  convert hS using 1
-  ext x
-  rw [mem_nonZeroDivisorsRight_iff, mem_nonZeroDivisors_iff]
-  congr! 3
-  rw [mul_comm]
+  rwa [nonZeroDivisorsLeft_eq_nonZeroDivisors]
 
 end Localization
 

--- a/Mathlib/RingTheory/Localization/Defs.lean
+++ b/Mathlib/RingTheory/Localization/Defs.lean
@@ -774,6 +774,7 @@ variable (M)
 
 theorem nonZeroDivisors_le_comap [IsLocalization M S] :
     nonZeroDivisors R ≤ (nonZeroDivisors S).comap (algebraMap R S) := by
+  simp_rw [← nonZeroDivisorsRight_eq_nonZeroDivisors]
   rintro a ha b (e : b * algebraMap R S a = 0)
   obtain ⟨x, s, rfl⟩ := mk'_surjective M b
   rw [← @mk'_one R _ M, ← mk'_mul, ← (algebraMap R S).map_zero, ← @mk'_one R _ M,
@@ -909,7 +910,7 @@ theorem to_map_eq_zero_iff {x : R} (hM : M ≤ nonZeroDivisors R) : algebraMap R
   constructor <;> intro h
   · obtain ⟨c, hc⟩ := (eq_iff_exists M S).mp h
     rw [mul_zero, mul_comm] at hc
-    exact hM c.2 x hc
+    exact (hM c.2).2 x hc
   · rw [h]
 
 protected theorem injective (hM : M ≤ nonZeroDivisors R) : Injective (algebraMap R S) := by

--- a/Mathlib/RingTheory/Localization/LocalizationLocalization.lean
+++ b/Mathlib/RingTheory/Localization/LocalizationLocalization.lean
@@ -259,11 +259,11 @@ theorem isFractionRing_of_isLocalization (S T : Type*) [CommRing S] [CommRing T]
   have := isLocalization_of_submonoid_le S T M (nonZeroDivisors R) hM
   refine @isLocalization_of_is_exists_mul_mem _ _ _ _ _ _ _ this ?_ ?_
   · exact map_nonZeroDivisors_le M S
-  · rintro ⟨x, hx⟩
+  · rintro ⟨x, -, hx⟩
     obtain ⟨⟨y, s⟩, e⟩ := IsLocalization.surj M x
     use algebraMap R S s
     rw [mul_comm, Subtype.coe_mk, e]
-    refine Set.mem_image_of_mem (algebraMap R S) ?_
+    refine Set.mem_image_of_mem (algebraMap R S) (mem_nonZeroDivisors_iff_right.mpr ?_)
     intro z hz
     apply IsLocalization.injective S hM
     rw [map_zero]

--- a/Mathlib/RingTheory/MvPowerSeries/NoZeroDivisors.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/NoZeroDivisors.lean
@@ -88,7 +88,7 @@ theorem mem_nonZeroDivisorsLeft_of_constantCoeff {φ : MvPowerSeries σ R}
     · simp only [← mem_antidiagonal.mp huv, le_add_iff_nonneg_left, zero_le]
     · rintro rfl
       simp_all
-  · simp only [mem_antidiagonal, add_zero, not_true_eq_false, coeff_zero_eq_constantCoeff,
+  · simp only [mem_antidiagonal, zero_add, not_true_eq_false, coeff_zero_eq_constantCoeff,
       false_implies]
 
 /-- A multivariate power series is not a zero divisor
@@ -98,10 +98,21 @@ theorem mem_nonZeroDivisors_of_constantCoeff {φ : MvPowerSeries σ R}
     φ ∈ (MvPowerSeries σ R)⁰ :=
   ⟨mem_nonZeroDivisorsLeft_of_constantCoeff hφ.1, mem_nonZeroDivisorsRight_of_constantCoeff hφ.2⟩
 
--- TODO: left and right versions
-lemma monomial_mem_nonzeroDivisors {n : σ →₀ ℕ} {r} :
-    monomial R n r ∈ (MvPowerSeries σ R)⁰ ↔ r ∈ R⁰ := by
-  simp only [mem_nonZeroDivisors_iff]
+lemma monomial_mem_nonzeroDivisorsLeft {n : σ →₀ ℕ} {r} :
+    monomial R n r ∈ nonZeroDivisorsLeft (MvPowerSeries σ R) ↔ r ∈ nonZeroDivisorsLeft R := by
+  constructor
+  · intro H s hrs
+    have := H (C _ _ s) (by rw [← monomial_zero_eq_C, monomial_mul_monomial]; ext; simp [hrs])
+    simpa using congr(coeff _ 0 $(this))
+  · intro H p hrp
+    ext i
+    have := congr(coeff _ (i + n) $hrp)
+    rw [coeff_monomial_mul, if_pos le_add_self, add_tsub_cancel_right] at this
+    simpa using H _ this
+
+-- TODO: reduce duplication
+lemma monomial_mem_nonzeroDivisorsRight {n : σ →₀ ℕ} {r} :
+    monomial R n r ∈ nonZeroDivisorsRight (MvPowerSeries σ R) ↔ r ∈ nonZeroDivisorsRight R := by
   constructor
   · intro H s hrs
     have := H (C _ _ s) (by rw [← monomial_zero_eq_C, monomial_mul_monomial]; ext; simp [hrs])
@@ -111,6 +122,10 @@ lemma monomial_mem_nonzeroDivisors {n : σ →₀ ℕ} {r} :
     have := congr(coeff _ (i + n) $hrp)
     rw [coeff_mul_monomial, if_pos le_add_self, add_tsub_cancel_right] at this
     simpa using H _ this
+
+lemma monomial_mem_nonzeroDivisors {n : σ →₀ ℕ} {r} :
+    monomial R n r ∈ (MvPowerSeries σ R)⁰ ↔ r ∈ R⁰ :=
+  monomial_mem_nonzeroDivisorsLeft.and monomial_mem_nonzeroDivisorsRight
 
 lemma X_mem_nonzeroDivisors {i : σ} :
     X i ∈ (MvPowerSeries σ R)⁰ := by

--- a/Mathlib/RingTheory/MvPowerSeries/NoZeroDivisors.lean
+++ b/Mathlib/RingTheory/MvPowerSeries/NoZeroDivisors.lean
@@ -48,17 +48,16 @@ section Semiring
 
 variable [Semiring R]
 
-/-- A multivariate power series is not a zero divisor
-  when its constant coefficient is not a zero divisor -/
-theorem mem_nonZeroDivisors_of_constantCoeff {φ : MvPowerSeries σ R}
-    (hφ : constantCoeff σ R φ ∈ R⁰) :
-    φ ∈ (MvPowerSeries σ R)⁰ := by
+theorem mem_nonZeroDivisorsRight_of_constantCoeff {φ : MvPowerSeries σ R}
+    (hφ : constantCoeff σ R φ ∈ nonZeroDivisorsRight R) :
+    φ ∈ nonZeroDivisorsRight (MvPowerSeries σ R) := by
   classical
   intro x hx
   ext d
   apply WellFoundedLT.induction d
   intro e he
-  rw [map_zero, ← mul_right_mem_nonZeroDivisors_eq_zero_iff hφ, ← map_zero (f := coeff R e), ← hx]
+  rw [map_zero, ← mul_right_mem_nonZeroDivisorsRight_eq_zero_iff hφ,
+    ← map_zero (f := coeff R e), ← hx]
   convert (coeff_mul e x φ).symm
   rw [Finset.sum_eq_single (e, 0), coeff_zero_eq_constantCoeff]
   · rintro ⟨u, _⟩ huv _
@@ -70,6 +69,36 @@ theorem mem_nonZeroDivisors_of_constantCoeff {φ : MvPowerSeries σ R}
   · simp only [mem_antidiagonal, add_zero, not_true_eq_false, coeff_zero_eq_constantCoeff,
       false_implies]
 
+-- TODO: derive from `mem_nonZeroDivisorsRight_of_constantCoeff` using `MulOpposite`
+theorem mem_nonZeroDivisorsLeft_of_constantCoeff {φ : MvPowerSeries σ R}
+    (hφ : constantCoeff σ R φ ∈ nonZeroDivisorsLeft R) :
+    φ ∈ nonZeroDivisorsLeft (MvPowerSeries σ R) := by
+  classical
+  intro x hx
+  ext d
+  apply WellFoundedLT.induction d
+  intro e he
+  rw [map_zero, ← mul_left_mem_nonZeroDivisorsLeft_eq_zero_iff hφ,
+    ← map_zero (f := coeff R e), ← hx]
+  convert (coeff_mul e φ x).symm
+  rw [Finset.sum_eq_single (0, e), coeff_zero_eq_constantCoeff]
+  · rintro ⟨_, u⟩ huv _
+    suffices u < e by simp only [he u this, mul_zero, map_zero]
+    apply lt_of_le_of_ne
+    · simp only [← mem_antidiagonal.mp huv, le_add_iff_nonneg_left, zero_le]
+    · rintro rfl
+      simp_all
+  · simp only [mem_antidiagonal, add_zero, not_true_eq_false, coeff_zero_eq_constantCoeff,
+      false_implies]
+
+/-- A multivariate power series is not a zero divisor
+  when its constant coefficient is not a zero divisor -/
+theorem mem_nonZeroDivisors_of_constantCoeff {φ : MvPowerSeries σ R}
+    (hφ : constantCoeff σ R φ ∈ R⁰) :
+    φ ∈ (MvPowerSeries σ R)⁰ :=
+  ⟨mem_nonZeroDivisorsLeft_of_constantCoeff hφ.1, mem_nonZeroDivisorsRight_of_constantCoeff hφ.2⟩
+
+-- TODO: left and right versions
 lemma monomial_mem_nonzeroDivisors {n : σ →₀ ℕ} {r} :
     monomial R n r ∈ (MvPowerSeries σ R)⁰ ↔ r ∈ R⁰ := by
   simp only [mem_nonZeroDivisors_iff]

--- a/Mathlib/RingTheory/Nilpotent/Basic.lean
+++ b/Mathlib/RingTheory/Nilpotent/Basic.lean
@@ -172,19 +172,19 @@ theorem isNilpotent_finsum {ι : Type*} {f : ι → R}
     exact Commute.isNilpotent_sum (fun b _ ↦ hf b) (fun _ _ _ _ ↦ h_comm _ _)
   · simp only [finsum_def, dif_neg h, IsNilpotent.zero]
 
-protected lemma isNilpotent_mul_left_iff (h_comm : Commute x y) (hy : y ∈ nonZeroDivisorsLeft R) :
+protected lemma isNilpotent_mul_right_iff (h_comm : Commute x y) (hy : y ∈ nonZeroDivisorsRight R) :
     IsNilpotent (x * y) ↔ IsNilpotent x := by
-  refine ⟨?_, h_comm.isNilpotent_mul_left⟩
-  rintro ⟨k, hk⟩
-  rw [mul_pow h_comm] at hk
-  exact ⟨k, (nonZeroDivisorsLeft R).pow_mem hy k _ hk⟩
-
-protected lemma isNilpotent_mul_right_iff (h_comm : Commute x y) (hx : x ∈ nonZeroDivisorsRight R) :
-    IsNilpotent (x * y) ↔ IsNilpotent y := by
   refine ⟨?_, h_comm.isNilpotent_mul_right⟩
   rintro ⟨k, hk⟩
   rw [mul_pow h_comm] at hk
-  exact ⟨k, (nonZeroDivisorsRight R).pow_mem hx k _ hk⟩
+  exact ⟨k, (nonZeroDivisorsRight R).pow_mem hy k _ hk⟩
+
+protected lemma isNilpotent_mul_left_iff (h_comm : Commute x y) (hx : x ∈ nonZeroDivisorsLeft R) :
+    IsNilpotent (x * y) ↔ IsNilpotent y := by
+  refine ⟨?_, h_comm.isNilpotent_mul_left⟩
+  rintro ⟨k, hk⟩
+  rw [mul_pow h_comm] at hk
+  exact ⟨k, (nonZeroDivisorsLeft R).pow_mem hx k _ hk⟩
 
 end Semiring
 

--- a/Mathlib/RingTheory/Nilpotent/Defs.lean
+++ b/Mathlib/RingTheory/Nilpotent/Defs.lean
@@ -235,14 +235,14 @@ section Semiring
 
 variable [Semiring R]
 
-theorem isNilpotent_mul_left (h_comm : Commute x y) (h : IsNilpotent x) : IsNilpotent (x * y) := by
+theorem isNilpotent_mul_right (h_comm : Commute x y) (h : IsNilpotent x) : IsNilpotent (x * y) := by
   obtain ⟨n, hn⟩ := h
   use n
   rw [h_comm.mul_pow, hn, zero_mul]
 
-theorem isNilpotent_mul_right (h_comm : Commute x y) (h : IsNilpotent y) : IsNilpotent (x * y) := by
+theorem isNilpotent_mul_left (h_comm : Commute x y) (h : IsNilpotent y) : IsNilpotent (x * y) := by
   rw [h_comm.eq]
-  exact h_comm.symm.isNilpotent_mul_left h
+  exact h_comm.symm.isNilpotent_mul_right h
 
 end Semiring
 

--- a/Mathlib/RingTheory/Norm/Transitivity.lean
+++ b/Mathlib/RingTheory/Norm/Transitivity.lean
@@ -159,7 +159,7 @@ theorem Matrix.det_det [Fintype m] [Fintype n] (f : S →+* Matrix n n R) :
   let f' := f.polyToMatrix
   let M' := cornerAddX M k
   have : (f' M'.det).det = ((M'.map f').comp m m n n R[X]).det := by
-    refine sub_eq_zero.mp <| mem_nonZeroDivisors_iff.mp
+    refine sub_eq_zero.mp <| mem_nonZeroDivisors_iff_right.mp
       (pow_mem ?_ _) _ (det_det_aux k fun M ↦ ih _ _ <| by simp [← card])
     rw [polyToMatrix_cornerAddX, ← charpoly]
     exact (Matrix.charpoly_monic _).mem_nonZeroDivisors

--- a/Mathlib/RingTheory/OreLocalization/Cardinality.lean
+++ b/Mathlib/RingTheory/OreLocalization/Cardinality.lean
@@ -20,7 +20,7 @@ namespace OreLocalization
 
 variable {R : Type u} [Ring R] {S : Submonoid R} [OreLocalization.OreSet S]
 
-theorem cardinalMk (hS : S ≤ nonZeroDivisorsRight R) : #(OreLocalization S R) = #R :=
+theorem cardinalMk (hS : S ≤ nonZeroDivisorsLeft R) : #(OreLocalization S R) = #R :=
   le_antisymm (cardinalMk_le S) (mk_le_of_injective (numeratorHom_inj hS))
 
 end OreLocalization

--- a/Mathlib/RingTheory/OreLocalization/Ring.lean
+++ b/Mathlib/RingTheory/OreLocalization/Ring.lean
@@ -195,7 +195,7 @@ lemma zsmul_eq_zsmul (n : ℤ) (x : X[S⁻¹]) :
 
 open nonZeroDivisors
 
-theorem numeratorHom_inj (hS : S ≤ nonZeroDivisorsRight R) :
+theorem numeratorHom_inj (hS : S ≤ nonZeroDivisorsLeft R) :
     Function.Injective (numeratorHom : R → R[S⁻¹]) :=
   fun r₁ r₂ h => by
   rw [numeratorHom_apply, numeratorHom_apply, oreDiv_eq_iff] at h
@@ -214,9 +214,17 @@ theorem nontrivial_iff :
     Nontrivial R[S⁻¹] ↔ 0 ∉ S := by
   rw [← not_subsingleton_iff_nontrivial, subsingleton_iff]
 
-theorem nontrivial_of_nonZeroDivisors [Nontrivial R] (hS : S ≤ R⁰) :
+theorem nontrivial_of_nonZeroDivisorsLeft [Nontrivial R] (hS : S ≤ nonZeroDivisorsLeft R) :
+    Nontrivial R[S⁻¹] :=
+  nontrivial_iff.mpr (fun e ↦ one_ne_zero <| hS e 1 (zero_mul _))
+
+theorem nontrivial_of_nonZeroDivisorsRight [Nontrivial R] (hS : S ≤ nonZeroDivisorsRight R) :
     Nontrivial R[S⁻¹] :=
   nontrivial_iff.mpr (fun e ↦ one_ne_zero <| hS e 1 (mul_zero _))
+
+theorem nontrivial_of_nonZeroDivisors [Nontrivial R] (hS : S ≤ R⁰) :
+    Nontrivial R[S⁻¹] :=
+  nontrivial_of_nonZeroDivisorsLeft (hS.trans inf_le_left)
 
 end Ring
 
@@ -239,7 +247,7 @@ protected def inv : R[R⁰⁻¹] → R[R⁰⁻¹] :=
   liftExpand
     (fun r s =>
       if hr : r = (0 : R) then (0 : R[R⁰⁻¹])
-      else s /ₒ ⟨r, fun _ => eq_zero_of_ne_zero_of_mul_right_eq_zero hr⟩)
+      else s /ₒ ⟨r, mem_nonZeroDivisors_of_ne_zero hr⟩)
     (by
       intro r t s hst
       by_cases hr : r = 0
@@ -258,7 +266,7 @@ open Classical in
 protected theorem inv_def {r : R} {s : R⁰} :
     (r /ₒ s)⁻¹ =
       if hr : r = (0 : R) then (0 : R[R⁰⁻¹])
-      else s /ₒ ⟨r, fun _ => eq_zero_of_ne_zero_of_mul_right_eq_zero hr⟩ := by
+      else s /ₒ ⟨r, mem_nonZeroDivisors_of_ne_zero hr⟩ := by
   with_unfolding_all rfl
 
 protected theorem mul_inv_cancel (x : R[R⁰⁻¹]) (h : x ≠ 0) : x * x⁻¹ = 1 := by

--- a/Mathlib/RingTheory/Polynomial/Nilpotent.lean
+++ b/Mathlib/RingTheory/Polynomial/Nilpotent.lean
@@ -32,7 +32,7 @@ variable [Semiring R] {P : R[X]}
 
 lemma isNilpotent_C_mul_pow_X_of_isNilpotent (n : ℕ) (hnil : IsNilpotent r) :
     IsNilpotent ((C r) * X ^ n) := by
-  refine Commute.isNilpotent_mul_left (commute_X_pow _ _).symm ?_
+  refine Commute.isNilpotent_mul_right (commute_X_pow _ _).symm ?_
   obtain ⟨m, hm⟩ := hnil
   refine ⟨m, ?_⟩
   rw [← C_pow, hm, C_0]
@@ -53,7 +53,7 @@ lemma isNilpotent_pow_X_mul_C_of_isNilpotent (n : ℕ) (hnil : IsNilpotent r) :
 @[simp] lemma isNilpotent_X_mul_iff :
     IsNilpotent (X * P) ↔ IsNilpotent P := by
   refine ⟨fun h ↦ ?_, ?_⟩
-  · rwa [Commute.isNilpotent_mul_right_iff (commute_X P) (by simp)] at h
+  · rwa [Commute.isNilpotent_mul_left_iff (commute_X P) (by simp)] at h
   · rintro ⟨k, hk⟩
     exact ⟨k, by simp [(commute_X P).mul_pow, hk]⟩
 
@@ -195,7 +195,7 @@ lemma isNilpotent_aeval_sub_of_isNilpotent_sub (h : IsNilpotent (a - b)) :
     IsNilpotent (aeval a P - aeval b P) := by
   simp only [← eval_map_algebraMap]
   have ⟨c, hc⟩ := evalSubFactor (map (algebraMap R S) P) a b
-  exact hc ▸ (Commute.all _ _).isNilpotent_mul_right h
+  exact hc ▸ (Commute.all _ _).isNilpotent_mul_left h
 
 variable {P}
 

--- a/Mathlib/RingTheory/Polynomial/ScaleRoots.lean
+++ b/Mathlib/RingTheory/Polynomial/ScaleRoots.lean
@@ -60,7 +60,7 @@ theorem support_scaleRoots_eq (p : R[X]) {s : R} (hs : s ∈ nonZeroDivisors R) 
     (by intro i
         simp only [coeff_scaleRoots, Polynomial.mem_support_iff]
         intro p_ne_zero ps_zero
-        have := pow_mem hs (p.natDegree - i) _ ps_zero
+        have := (pow_mem hs (p.natDegree - i)).2 _ ps_zero
         contradiction)
 
 @[simp]

--- a/Mathlib/RingTheory/PowerSeries/Substitution.lean
+++ b/Mathlib/RingTheory/PowerSeries/Substitution.lean
@@ -108,12 +108,12 @@ theorem HasSubst.add (hf : HasSubst f) (hg : HasSubst g) :
 theorem HasSubst.mul_left (hf : HasSubst f) :
     HasSubst (f * g) := by
   simp only [HasSubst, map_mul]
-  exact (Commute.all _ _).isNilpotent_mul_left hf
+  exact (Commute.all _ _).isNilpotent_mul_right hf
 
 theorem HasSubst.mul_right (hf : HasSubst f) :
     HasSubst (g * f) := by
   simp only [HasSubst, map_mul]
-  exact (Commute.all _ _).isNilpotent_mul_right hf
+  exact (Commute.all _ _).isNilpotent_mul_left hf
 
 theorem HasSubst.smul (r : MvPowerSeries τ S) {a : MvPowerSeries τ S}
     (ha : HasSubst a) :

--- a/Mathlib/Topology/Sheaves/CommRingCat.lean
+++ b/Mathlib/Topology/Sheaves/CommRingCat.lean
@@ -174,11 +174,12 @@ instance (F : X.Sheaf CommRingCat.{w}) : Mono F.presheaf.toTotalQuotientPresheaf
   set m := _
   change Function.Injective (algebraMap _ (Localization m))
   refine IsLocalization.injective (M := m) (S := Localization m) ?_
+  rw [← nonZeroDivisorsRight_eq_nonZeroDivisors]
   intro s hs t e
   apply section_ext F (unop U)
   intro x hx
   rw [RingHom.map_zero]
-  apply Submonoid.mem_iInf.mp hs ⟨x, hx⟩
+  apply (Submonoid.mem_iInf.mp hs ⟨x, hx⟩).2
   rw [← map_mul, e, map_zero]
 
 end SubmonoidPresheaf


### PR DESCRIPTION
Towards #22997 (see also [zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Issue.3A.20nonZeroDivisors.2C.20regular.20elements.2C.20and.20localization)):

+ Swap the definitions of `nonZeroDivisorsLeft` and `nonZeroDivisorsRight`, so as to conform to the convention in the literature (see https://en.wikipedia.org/wiki/Zero_divisor) and connects to mathlib's `IsLeftRegular` and `IsRightRegular` respectively without the presence of commutativity hypotheses.

+ Redefine `nonZeroDivisors` to be the intersection of `nonZeroDivisorsLeft` and `nonZeroDivisorsRight`, in analogy with `IsRegular`.

+ Swap `Commute.isNilpotent_mul_left/right(_iff)` as the names were also contrary to convention. (If the statements are left unchanged then the proofs need to be changed.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
