### PR TITLE
[Merged by Bors] - feat(Probability): Prove Hoeffding's lemma corollary 

### DIFF
--- a/Mathlib/Probability/Moments/SubGaussian.lean
+++ b/Mathlib/Probability/Moments/SubGaussian.lean
@@ -72,7 +72,8 @@ as special cases of a notion of sub-Gaussianity with respect to a kernel and a m
 
 * `measure_sum_ge_le_of_iIndepFun`: Hoeffding's inequality for sums of independent sub-Gaussian
   random variables.
-* `hasSubgaussianMGF_of_centered_mem_Icc`: Hoeffding's lemma for centered bounded random variables.
+* `hasSubgaussianMGF_of_mem_Icc_of_integral_eq_zero`: Hoeffding's lemma for random variables with
+  expectation zero.
 * `measure_sum_ge_le_of_HasCondSubgaussianMGF`: the Azuma-Hoeffding inequality for sub-Gaussian
   random variables.
 
@@ -729,8 +730,8 @@ end HasSubgaussianMGF
 
 section HoeffdingLemma
 
-protected lemma mgf_le_of_centered_mem_Icc [IsProbabilityMeasure μ] {a b t : ℝ}
-    (hm : AEMeasurable X μ) (hc : μ[X] = 0) (hb : ∀ᵐ ω ∂μ, X ω ∈ Set.Icc a b) (ht : 0 < t) :
+protected lemma mgf_le_of_mem_Icc_of_integral_eq_zero [IsProbabilityMeasure μ] {a b t : ℝ}
+    (hm : AEMeasurable X μ) (hb : ∀ᵐ ω ∂μ, X ω ∈ Set.Icc a b) (hc : μ[X] = 0) (ht : 0 < t) :
     mgf X μ t ≤ exp ((‖b - a‖₊ / 2) ^ 2 * t ^ 2 / 2) := by
   have hi (u : ℝ) : Integrable (fun ω ↦ exp (u * X ω)) μ := integrable_exp_mul_of_mem_Icc hm hb
   have hs : Set.Icc 0 t ⊆ interior (integrableExpSet X μ) := by simp [hi, integrableExpSet]
@@ -749,20 +750,20 @@ protected lemma mgf_le_of_centered_mem_Icc [IsProbabilityMeasure μ] {a b t : �
 /-- **Hoeffding's lemma**: with respect to a probability measure `μ`, if `X` is a random variable
 that has expectation zero and is almost surely in `Set.Icc a b` for some `a ≤ b`, then `X` has a
 sub-Gaussian moment generating function with parameter `((b - a) / 2) ^ 2`. -/
-lemma hasSubgaussianMGF_of_centered_mem_Icc [IsProbabilityMeasure μ] {a b : ℝ}
-    (hm : AEMeasurable X μ) (hc : μ[X] = 0) (hb : ∀ᵐ ω ∂μ, X ω ∈ Set.Icc a b) :
+lemma hasSubgaussianMGF_of_mem_Icc_of_integral_eq_zero [IsProbabilityMeasure μ] {a b : ℝ}
+    (hm : AEMeasurable X μ) (hb : ∀ᵐ ω ∂μ, X ω ∈ Set.Icc a b) (hc : μ[X] = 0) :
     HasSubgaussianMGF X ((‖b - a‖₊ / 2) ^ 2) μ where
   integrable_exp_mul t := integrable_exp_mul_of_mem_Icc hm hb
   mgf_le t := by
     obtain ht | ht | ht := lt_trichotomy 0 t
-    · exact ProbabilityTheory.mgf_le_of_centered_mem_Icc hm hc hb ht
+    · exact ProbabilityTheory.mgf_le_of_mem_Icc_of_integral_eq_zero hm hb hc ht
     · simp [← ht]
     calc
     _ = mgf (-X) μ (-t) := by simp [mgf]
     _ ≤ exp ((‖-a - -b‖₊ / 2) ^ 2 * (-t) ^ 2 / 2) := by
-      apply ProbabilityTheory.mgf_le_of_centered_mem_Icc (hm.neg)
-      · rw [integral_neg, hc, neg_zero]
+      apply ProbabilityTheory.mgf_le_of_mem_Icc_of_integral_eq_zero (hm.neg)
       · filter_upwards [hb] with ω ⟨hl, hr⟩ using ⟨neg_le_neg_iff.2 hr, neg_le_neg_iff.2 hl⟩
+      · rw [integral_neg, hc, neg_zero]
       · rwa [Left.neg_pos_iff]
     _ = exp (((‖b - a‖₊ / 2) ^ 2) * t ^ 2 / 2) := by ring_nf
 
@@ -771,9 +772,9 @@ lemma hasSubgaussianMGF_of_mem_Icc [IsProbabilityMeasure μ] {a b : ℝ} (hm : A
     (hb : ∀ᵐ ω ∂μ, X ω ∈ Set.Icc a b) :
     HasSubgaussianMGF (fun ω ↦ X ω - μ[X]) ((‖b - a‖₊ / 2) ^ 2) μ := by
   rw [← sub_sub_sub_cancel_right b a μ[X]]
-  apply hasSubgaussianMGF_of_centered_mem_Icc (hm.sub_const _)
-  · simp [integral_sub (Integrable.of_mem_Icc a b hm hb) (integrable_const _)]
+  apply hasSubgaussianMGF_of_mem_Icc_of_integral_eq_zero (hm.sub_const _)
   · filter_upwards [hb] with ω hab using by simpa using hab
+  · simp [integral_sub (Integrable.of_mem_Icc a b hm hb) (integrable_const _)]
 
 end HoeffdingLemma
 

--- a/Mathlib/Probability/Moments/SubGaussian.lean
+++ b/Mathlib/Probability/Moments/SubGaussian.lean
@@ -770,11 +770,10 @@ lemma hasSubgaussianMGF_of_centered_mem_Icc [IsProbabilityMeasure μ] {a b : ℝ
 lemma hasSubgaussianMGF_of_mem_Icc [IsProbabilityMeasure μ] {a b : ℝ} (hm : AEMeasurable X μ)
     (hb : ∀ᵐ ω ∂μ, X ω ∈ Set.Icc a b) :
     HasSubgaussianMGF (fun ω ↦ X ω - μ[X]) ((‖b - a‖₊ / 2) ^ 2) μ := by
-  have : HasSubgaussianMGF (fun ω ↦ X ω - μ[X]) ((‖b - μ[X] - (a - μ[X])‖₊ / 2) ^ 2) μ := by
-    apply hasSubgaussianMGF_of_centered_mem_Icc (AEMeasurable.sub_const hm _)
-    · simp [integral_sub (Integrable.of_mem_Icc a b hm hb) (integrable_const _)]
-    · filter_upwards [hb] with ω hab using by simpa using hab
-  simpa using this
+  rw [← sub_sub_sub_cancel_right b a μ[X]]
+  apply hasSubgaussianMGF_of_centered_mem_Icc (hm.sub_const _)
+  · simp [integral_sub (Integrable.of_mem_Icc a b hm hb) (integrable_const _)]
+  · filter_upwards [hb] with ω hab using by simpa using hab
 
 end HoeffdingLemma
 


### PR DESCRIPTION
Prove a corollary of Hoeffding's lemma for random variables with non-zero expectation.

This simple corollary was suggested by a reviewer based on a recent contribution  (#26744).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
