### PR TITLE
[Merged by Bors] - feat: limits of ENNReal exponentiation

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Log/ENNRealLogExp.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/ENNRealLogExp.lean
@@ -58,7 +58,7 @@ lemma exp_nmul (x : EReal) (n : ℕ) : exp (n * x) = (exp x) ^ n := by
 lemma exp_mul (x : EReal) (y : ℝ) : exp (x * y) = (exp x) ^ y := by
   rw [← log_eq_iff, log_rpow, log_exp, log_exp, mul_comm]
 
-lemma ENNReal.rpow_eq (x : ℝ≥0∞) (y : ℝ) : x ^ y = exp (y * log x) := by
+lemma ENNReal.rpow_eq_exp_mul_log (x : ℝ≥0∞) (y : ℝ) : x ^ y = exp (y * log x) := by
   rw [mul_comm, EReal.exp_mul, exp_log]
 
 end EReal
@@ -125,7 +125,7 @@ lemma _root_.EReal.tendsto_exp_nhds_bot_nhds_zero : Filter.Tendsto exp (𝓝 ⊥
 
 lemma tendsto_rpow_atTop_of_one_lt_base {b : ℝ≥0∞} (hb : 1 < b) :
     Filter.Tendsto (b ^ · : ℝ → ℝ≥0∞) Filter.atTop (𝓝 ⊤) := by
-  simp_rw [ENNReal.rpow_eq]
+  simp_rw [ENNReal.rpow_eq_exp_mul_log]
   refine EReal.tendsto_exp_nhds_top_nhds_top.comp ?_
   convert EReal.Tendsto.mul_const tendsto_coe_atTop _ _
   · rw [EReal.top_mul_of_pos (zero_lt_log_iff.2 hb)]
@@ -133,7 +133,7 @@ lemma tendsto_rpow_atTop_of_one_lt_base {b : ℝ≥0∞} (hb : 1 < b) :
 
 lemma tendsto_rpow_atTop_of_base_lt_one {b : ℝ≥0∞} (hb : b < 1) :
     Filter.Tendsto (b ^ · : ℝ → ℝ≥0∞) Filter.atTop (𝓝 0) := by
-  simp_rw [ENNReal.rpow_eq]
+  simp_rw [ENNReal.rpow_eq_exp_mul_log]
   refine EReal.tendsto_exp_nhds_bot_nhds_zero.comp ?_
   convert EReal.Tendsto.mul_const tendsto_coe_atTop _ _
   · rw [EReal.top_mul_of_neg (log_lt_zero_iff.2 hb)]
@@ -141,7 +141,7 @@ lemma tendsto_rpow_atTop_of_base_lt_one {b : ℝ≥0∞} (hb : b < 1) :
 
 lemma tendsto_rpow_atBot_of_one_lt_base {b : ℝ≥0∞} (hb : 1 < b) :
     Filter.Tendsto (b ^ · : ℝ → ℝ≥0∞) Filter.atBot (𝓝 0) := by
-  simp_rw [ENNReal.rpow_eq]
+  simp_rw [ENNReal.rpow_eq_exp_mul_log]
   refine EReal.tendsto_exp_nhds_bot_nhds_zero.comp ?_
   convert EReal.Tendsto.mul_const tendsto_coe_atBot _ _
   · rw [EReal.bot_mul_of_pos (zero_lt_log_iff.2 hb)]
@@ -149,7 +149,7 @@ lemma tendsto_rpow_atBot_of_one_lt_base {b : ℝ≥0∞} (hb : 1 < b) :
 
 lemma tendsto_rpow_atBot_of_base_lt_one {b : ℝ≥0∞} (hb : b < 1) :
     Filter.Tendsto (b ^ · : ℝ → ℝ≥0∞) Filter.atBot (𝓝 ⊤) := by
-  simp_rw [ENNReal.rpow_eq]
+  simp_rw [ENNReal.rpow_eq_exp_mul_log]
   refine EReal.tendsto_exp_nhds_top_nhds_top.comp ?_
   convert EReal.Tendsto.mul_const tendsto_coe_atBot _ _
   · rw [EReal.bot_mul_of_neg (log_lt_zero_iff.2 hb)]

--- a/Mathlib/Analysis/SpecialFunctions/Log/ENNRealLogExp.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Log/ENNRealLogExp.lean
@@ -58,6 +58,9 @@ lemma exp_nmul (x : EReal) (n : ℕ) : exp (n * x) = (exp x) ^ n := by
 lemma exp_mul (x : EReal) (y : ℝ) : exp (x * y) = (exp x) ^ y := by
   rw [← log_eq_iff, log_rpow, log_exp, log_exp, mul_comm]
 
+lemma ENNReal.rpow_eq (x : ℝ≥0∞) (y : ℝ) : x ^ y = exp (y * log x) := by
+  rw [mul_comm, EReal.exp_mul, exp_log]
+
 end EReal
 end Exp
 
@@ -109,6 +112,48 @@ lemma continuous_log : Continuous log := logOrderIso.continuous
 
 @[continuity, fun_prop]
 lemma continuous_exp : Continuous exp := expOrderIso.continuous
+
+lemma _root_.EReal.tendsto_exp_nhds_top_nhds_top : Filter.Tendsto exp (𝓝 ⊤) (𝓝 ⊤) :=
+  continuous_exp.tendsto ⊤
+
+lemma _root_.EReal.tendsto_exp_nhds_zero_nhds_one : Filter.Tendsto exp (𝓝 0) (𝓝 1) := by
+  convert continuous_exp.tendsto 0
+  simp
+
+lemma _root_.EReal.tendsto_exp_nhds_bot_nhds_zero : Filter.Tendsto exp (𝓝 ⊥) (𝓝 0) :=
+  continuous_exp.tendsto ⊥
+
+lemma tendsto_rpow_atTop_of_one_lt_base {b : ℝ≥0∞} (hb : 1 < b) :
+    Filter.Tendsto (b ^ · : ℝ → ℝ≥0∞) Filter.atTop (𝓝 ⊤) := by
+  simp_rw [ENNReal.rpow_eq]
+  refine EReal.tendsto_exp_nhds_top_nhds_top.comp ?_
+  convert EReal.Tendsto.mul_const tendsto_coe_atTop _ _
+  · rw [EReal.top_mul_of_pos (zero_lt_log_iff.2 hb)]
+  all_goals simp
+
+lemma tendsto_rpow_atTop_of_base_lt_one {b : ℝ≥0∞} (hb : b < 1) :
+    Filter.Tendsto (b ^ · : ℝ → ℝ≥0∞) Filter.atTop (𝓝 0) := by
+  simp_rw [ENNReal.rpow_eq]
+  refine EReal.tendsto_exp_nhds_bot_nhds_zero.comp ?_
+  convert EReal.Tendsto.mul_const tendsto_coe_atTop _ _
+  · rw [EReal.top_mul_of_neg (log_lt_zero_iff.2 hb)]
+  all_goals simp
+
+lemma tendsto_rpow_atBot_of_one_lt_base {b : ℝ≥0∞} (hb : 1 < b) :
+    Filter.Tendsto (b ^ · : ℝ → ℝ≥0∞) Filter.atBot (𝓝 0) := by
+  simp_rw [ENNReal.rpow_eq]
+  refine EReal.tendsto_exp_nhds_bot_nhds_zero.comp ?_
+  convert EReal.Tendsto.mul_const tendsto_coe_atBot _ _
+  · rw [EReal.bot_mul_of_pos (zero_lt_log_iff.2 hb)]
+  all_goals simp
+
+lemma tendsto_rpow_atBot_of_base_lt_one {b : ℝ≥0∞} (hb : b < 1) :
+    Filter.Tendsto (b ^ · : ℝ → ℝ≥0∞) Filter.atBot (𝓝 ⊤) := by
+  simp_rw [ENNReal.rpow_eq]
+  refine EReal.tendsto_exp_nhds_top_nhds_top.comp ?_
+  convert EReal.Tendsto.mul_const tendsto_coe_atBot _ _
+  · rw [EReal.bot_mul_of_neg (log_lt_zero_iff.2 hb)]
+  all_goals simp
 
 end Continuity
 

--- a/Mathlib/Topology/Instances/EReal/Lemmas.lean
+++ b/Mathlib/Topology/Instances/EReal/Lemmas.lean
@@ -168,21 +168,21 @@ lemma nhdsWithin_bot : 𝓝[≠] (⊥ : EReal) = (atBot).map Real.toEReal := by
 
 omit [TopologicalSpace α] in
 @[simp]
-lemma tendsto_coe_nhds_top {f : α → ℝ} {l : Filter α} :
+lemma tendsto_coe_nhds_top_iff {f : α → ℝ} {l : Filter α} :
     Tendsto (fun x ↦ Real.toEReal (f x)) l (𝓝 ⊤) ↔ Tendsto f l atTop := by
   rw [tendsto_nhds_top_iff_real, atTop_basis_Ioi.tendsto_right_iff]; simp
 
 lemma tendsto_coe_atTop : Tendsto Real.toEReal atTop (𝓝 ⊤) :=
-  tendsto_coe_nhds_top.2 tendsto_id
+  tendsto_coe_nhds_top_iff.2 tendsto_id
 
 omit [TopologicalSpace α] in
 @[simp]
-lemma tendsto_coe_nhds_bot {f : α → ℝ} {l : Filter α} :
+lemma tendsto_coe_nhds_bot_iff {f : α → ℝ} {l : Filter α} :
     Tendsto (fun x ↦ Real.toEReal (f x)) l (𝓝 ⊥) ↔ Tendsto f l atBot := by
   rw [tendsto_nhds_bot_iff_real, atBot_basis_Iio.tendsto_right_iff]; simp
 
 lemma tendsto_coe_atBot : Tendsto Real.toEReal atBot (𝓝 ⊥) :=
-  tendsto_coe_nhds_bot.2 tendsto_id
+  tendsto_coe_nhds_bot_iff.2 tendsto_id
 
 
 lemma tendsto_toReal_atTop : Tendsto EReal.toReal (𝓝[≠] ⊤) atTop := by

--- a/Mathlib/Topology/Instances/EReal/Lemmas.lean
+++ b/Mathlib/Topology/Instances/EReal/Lemmas.lean
@@ -166,6 +166,25 @@ lemma nhdsWithin_bot : 𝓝[≠] (⊥ : EReal) = (atBot).map Real.toEReal := by
     refine fun x ↦ ⟨x, ⟨EReal.bot_lt_coe x, fun x ⟨(h1 : x ≤ _), h2⟩ ↦ ?_⟩⟩
     simp [h1, Ne.bot_lt' fun a ↦ h2 a.symm]
 
+omit [TopologicalSpace α] in
+@[simp]
+lemma tendsto_coe_nhds_top {f : α → ℝ} {l : Filter α} :
+    Tendsto (fun x ↦ Real.toEReal (f x)) l (𝓝 ⊤) ↔ Tendsto f l atTop := by
+  rw [tendsto_nhds_top_iff_real, atTop_basis_Ioi.tendsto_right_iff]; simp
+
+lemma tendsto_coe_atTop : Tendsto Real.toEReal atTop (𝓝 ⊤) :=
+  tendsto_coe_nhds_top.2 tendsto_id
+
+omit [TopologicalSpace α] in
+@[simp]
+lemma tendsto_coe_nhds_bot {f : α → ℝ} {l : Filter α} :
+    Tendsto (fun x ↦ Real.toEReal (f x)) l (𝓝 ⊥) ↔ Tendsto f l atBot := by
+  rw [tendsto_nhds_bot_iff_real, atBot_basis_Iio.tendsto_right_iff]; simp
+
+lemma tendsto_coe_atBot : Tendsto Real.toEReal atBot (𝓝 ⊥) :=
+  tendsto_coe_nhds_bot.2 tendsto_id
+
+
 lemma tendsto_toReal_atTop : Tendsto EReal.toReal (𝓝[≠] ⊤) atTop := by
   rw [nhdsWithin_top, tendsto_map'_iff]
   exact tendsto_id
@@ -406,6 +425,14 @@ theorem continuousAt_add {p : EReal × EReal} (h : p.1 ≠ ⊤ ∨ p.2 ≠ ⊥) 
   · exact continuousAt_add_top_coe _
   · exact continuousAt_add_top_top
 
+lemma lowerSemicontinuous_add : LowerSemicontinuous fun p : EReal × EReal ↦ p.1 + p.2 := by
+  intro x y
+  by_cases hx₁ : x.1 = ⊥
+  · simp [hx₁]
+  by_cases hx₂ : x.2 = ⊥
+  · simp [hx₂]
+  · exact continuousAt_add (.inr hx₂) (.inl hx₁) |>.lowerSemicontinuousAt _
+
 /-! ### Continuity of multiplication -/
 
 /- Outside of indeterminacies `(0, ±∞)` and `(±∞, 0)`, the multiplication on `EReal` is continuous.
@@ -518,12 +545,28 @@ theorem continuousAt_mul {p : EReal × EReal} (h₁ : p.1 ≠ 0 ∨ p.2 ≠ ⊥)
     exact continuousAt_mul_top_ne_zero h₄
   · exact continuousAt_mul_top_top
 
-lemma lowerSemicontinuous_add : LowerSemicontinuous fun p : EReal × EReal ↦ p.1 + p.2 := by
-  intro x y
-  by_cases hx₁ : x.1 = ⊥
-  · simp [hx₁]
-  by_cases hx₂ : x.2 = ⊥
-  · simp [hx₂]
-  · exact continuousAt_add (.inr hx₂) (.inl hx₁) |>.lowerSemicontinuousAt _
+variable {a b : EReal}
+
+protected theorem tendsto_mul (h₁ : a ≠ 0 ∨ b ≠ ⊥) (h₂ : a ≠ 0 ∨ b ≠ ⊤) (h₃ : a ≠ ⊥ ∨ b ≠ 0)
+    (h₄ : a ≠ ⊤ ∨ b ≠ 0) :
+    Tendsto (fun p : EReal × EReal ↦ p.1 * p.2) (𝓝 (a, b)) (𝓝 (a * b)) :=
+  (continuousAt_mul h₁ h₂ h₃ h₄).tendsto
+
+protected theorem Tendsto.mul {f : Filter α} {ma : α → EReal} {mb : α → EReal} {a b : EReal}
+    (hma : Tendsto ma f (𝓝 a)) (hmb : Tendsto mb f (𝓝 b)) (h₁ : a ≠ 0 ∨ b ≠ ⊥)
+    (h₂ : a ≠ 0 ∨ b ≠ ⊤) (h₃ : a ≠ ⊥ ∨ b ≠ 0) (h₄ : a ≠ ⊤ ∨ b ≠ 0) :
+    Tendsto (fun x ↦ ma x * mb x) f (𝓝 (a * b)) :=
+  (EReal.tendsto_mul h₁ h₂ h₃ h₄).comp (hma.prodMk_nhds hmb)
+
+protected theorem Tendsto.const_mul {f : Filter α} {m : α → EReal} {a b : EReal}
+    (hm : Tendsto m f (𝓝 b)) (h₁ : a ≠ ⊥ ∨ b ≠ 0) (h₂ : a ≠ ⊤ ∨ b ≠ 0) :
+    Tendsto (fun b ↦ a * m b) f (𝓝 (a * b)) :=
+  by_cases (fun (this : a = 0) => by simp [this, tendsto_const_nhds])
+    fun ha : a ≠ 0 => EReal.Tendsto.mul tendsto_const_nhds hm (Or.inl ha) (Or.inl ha) h₁ h₂
+
+protected theorem Tendsto.mul_const {f : Filter α} {m : α → EReal} {a b : EReal}
+    (hm : Tendsto m f (𝓝 a)) (h₁ : a ≠ 0 ∨ b ≠ ⊥) (h₂ : a ≠ 0 ∨ b ≠ ⊤) :
+    Tendsto (fun x ↦ m x * b) f (𝓝 (a * b)) := by
+  simpa only [mul_comm] using EReal.Tendsto.const_mul hm h₁.symm h₂.symm
 
 end EReal


### PR DESCRIPTION
Prove lemmas about limits in `ENNReal` and use them to prove that `fun x => b ^ x` tends to +infinity when x goes to +infinity if `1 < b`, and similarly for ±infinity and according to whether `1 < b` or `b < 1`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
