### PR TITLE
[Merged by Bors] - feat(Logic/Relation): add Trans instances for Relation.ReflTransGen

### DIFF
--- a/Mathlib/Logic/Relation.lean
+++ b/Mathlib/Logic/Relation.lean
@@ -513,9 +513,6 @@ section ReflTransGen
 
 open ReflTransGen
 
-instance : IsTrans α (ReflTransGen r) :=
-  ⟨@trans α r⟩
-
 instance : Trans r (ReflTransGen r) (ReflTransGen r) :=
   ⟨head⟩
 
@@ -559,6 +556,9 @@ theorem transitive_reflTransGen : Transitive (ReflTransGen r) := fun _ _ _ ↦ t
 
 instance : IsRefl α (ReflTransGen r) :=
   ⟨@ReflTransGen.refl α r⟩
+
+instance : IsTrans α (ReflTransGen r) :=
+  ⟨@ReflTransGen.trans α r⟩
 
 theorem reflTransGen_idem : ReflTransGen (ReflTransGen r) = ReflTransGen r :=
   reflTransGen_eq_self reflexive_reflTransGen transitive_reflTransGen

--- a/Mathlib/Logic/Relation.lean
+++ b/Mathlib/Logic/Relation.lean
@@ -445,6 +445,21 @@ end reflGen
 
 section TransGen
 
+instance : IsTrans α (TransGen r) :=
+  ⟨@TransGen.trans α r⟩
+
+instance : Trans (TransGen r) r (TransGen r) :=
+  ⟨TransGen.tail⟩
+
+instance : Trans r (TransGen r) (TransGen r) :=
+  ⟨TransGen.head⟩
+
+instance : Trans (TransGen r) (ReflTransGen r) (TransGen r) :=
+  ⟨TransGen.trans_left⟩
+
+instance : Trans (ReflTransGen r) (TransGen r) (TransGen r) :=
+  ⟨TransGen.trans_right⟩
+
 theorem transGen_eq_self (trans : Transitive r) : TransGen r = r :=
   funext fun a ↦ funext fun b ↦ propext <|
     ⟨fun h ↦ by
@@ -497,6 +512,15 @@ end TransGen
 section ReflTransGen
 
 open ReflTransGen
+
+instance : IsTrans α (ReflTransGen r) :=
+  ⟨@trans α r⟩
+
+instance : Trans r (ReflTransGen r) (ReflTransGen r) :=
+  ⟨head⟩
+
+instance : Trans (ReflTransGen r) r (ReflTransGen r) :=
+  ⟨tail⟩
 
 theorem reflTransGen_iff_eq (h : ∀ b, ¬r a b) : ReflTransGen r a b ↔ b = a := by
   rw [cases_head_iff]; simp [h, eq_comm]
@@ -719,38 +743,3 @@ theorem Equivalence.eqvGen_eq (h : Equivalence r) : EqvGen r = r :=
   funext fun _ ↦ funext fun _ ↦ propext <| h.eqvGen_iff
 
 end EqvGen
-
-section Trans
-
-open Relation
-
-variable {r : α → α → Prop}
-
-instance : Trans r (ReflTransGen r) (ReflTransGen r) :=
-  ⟨ReflTransGen.head⟩
-
-instance : Trans (ReflTransGen r) r (ReflTransGen r) :=
-  ⟨ReflTransGen.tail⟩
-
-instance : Trans (TransGen r) (ReflTransGen r) (TransGen r) :=
-  ⟨TransGen.trans_left⟩
-
-instance : Trans (TransGen r) (TransGen r) (TransGen r) :=
-  ⟨TransGen.trans⟩
-
-instance : Trans (TransGen r) r (TransGen r) :=
-  ⟨TransGen.tail⟩
-
-instance : Trans r (TransGen r) (TransGen r) :=
-  ⟨TransGen.head⟩
-
-instance : Trans (ReflTransGen r) (TransGen r) (TransGen r) :=
-  ⟨TransGen.trans_right⟩
-
-instance : IsTrans α (TransGen r) :=
-  ⟨@TransGen.trans α r⟩
-
-instance : IsTrans α (ReflTransGen r) :=
-  ⟨@ReflTransGen.trans α r⟩
-
-end Trans

--- a/Mathlib/Logic/Relation.lean
+++ b/Mathlib/Logic/Relation.lean
@@ -399,7 +399,7 @@ theorem tail' (hab : ReflTransGen r a b) (hbc : r b c) : TransGen r a c := by
 theorem head (hab : r a b) (hbc : TransGen r b c) : TransGen r a c :=
   head' hab hbc.to_reflTransGen
 
-instance : Trans (TransGen r) r (TransGen r) := 
+instance : Trans (TransGen r) r (TransGen r) :=
   ⟨tail⟩
 
 instance : Trans r (TransGen r) (TransGen r) :=

--- a/Mathlib/Logic/Relation.lean
+++ b/Mathlib/Logic/Relation.lean
@@ -310,12 +310,6 @@ theorem head (hab : r a b) (hbc : ReflTransGen r b c) : ReflTransGen r a c := by
   | refl => exact refl.tail hab
   | tail _ hcd hac => exact hac.tail hcd
 
-instance : Trans r (ReflTransGen r) (ReflTransGen r) :=
-  ⟨head⟩
-
-instance : Trans (ReflTransGen r) r (ReflTransGen r) :=
-  ⟨tail⟩
-
 theorem symmetric (h : Symmetric r) : Symmetric (ReflTransGen r) := by
   intro x y h
   induction h with
@@ -380,13 +374,7 @@ theorem trans_left (hab : TransGen r a b) (hbc : ReflTransGen r b c) : TransGen 
   | refl => assumption
   | tail _ hcd hac => exact hac.tail hcd
 
-instance : Trans (TransGen r) (ReflTransGen r) (TransGen r) :=
-  ⟨trans_left⟩
-
 attribute [trans] trans
-
-instance : Trans (TransGen r) (TransGen r) (TransGen r) :=
-  ⟨trans⟩
 
 theorem head' (hab : r a b) (hbc : ReflTransGen r b c) : TransGen r a c :=
   trans_left (single hab) hbc
@@ -398,12 +386,6 @@ theorem tail' (hab : ReflTransGen r a b) (hbc : r b c) : TransGen r a c := by
 
 theorem head (hab : r a b) (hbc : TransGen r b c) : TransGen r a c :=
   head' hab hbc.to_reflTransGen
-
-instance : Trans (TransGen r) r (TransGen r) :=
-  ⟨tail⟩
-
-instance : Trans r (TransGen r) (TransGen r) :=
-  ⟨head⟩
 
 @[elab_as_elim]
 theorem head_induction_on {P : ∀ a : α, TransGen r a b → Prop} {a : α} (h : TransGen r a b)
@@ -429,9 +411,6 @@ theorem trans_right (hab : ReflTransGen r a b) (hbc : TransGen r b c) : TransGen
   induction hbc with
   | single hbc => exact tail' hab hbc
   | tail _ hcd hac => exact hac.tail hcd
-
-instance : Trans (ReflTransGen r) (TransGen r) (TransGen r) :=
-  ⟨trans_right⟩
 
 theorem tail'_iff : TransGen r a c ↔ ∃ b, ReflTransGen r a b ∧ r b c := by
   refine ⟨fun h ↦ ?_, fun ⟨b, hab, hbc⟩ ↦ tail' hab hbc⟩
@@ -474,9 +453,6 @@ theorem transGen_eq_self (trans : Transitive r) : TransGen r = r :=
       | tail _ hcd hac => exact trans hac hcd, TransGen.single⟩
 
 theorem transitive_transGen : Transitive (TransGen r) := fun _ _ _ ↦ TransGen.trans
-
-instance : IsTrans α (TransGen r) :=
-  ⟨@TransGen.trans α r⟩
 
 theorem transGen_idem : TransGen (TransGen r) = TransGen r :=
   transGen_eq_self transitive_transGen
@@ -559,9 +535,6 @@ theorem transitive_reflTransGen : Transitive (ReflTransGen r) := fun _ _ _ ↦ t
 
 instance : IsRefl α (ReflTransGen r) :=
   ⟨@ReflTransGen.refl α r⟩
-
-instance : IsTrans α (ReflTransGen r) :=
-  ⟨@ReflTransGen.trans α r⟩
 
 theorem reflTransGen_idem : ReflTransGen (ReflTransGen r) = ReflTransGen r :=
   reflTransGen_eq_self reflexive_reflTransGen transitive_reflTransGen
@@ -746,3 +719,38 @@ theorem Equivalence.eqvGen_eq (h : Equivalence r) : EqvGen r = r :=
   funext fun _ ↦ funext fun _ ↦ propext <| h.eqvGen_iff
 
 end EqvGen
+
+section Trans
+
+open Relation
+
+variable {r : α → α → Prop}
+
+instance : Trans r (ReflTransGen r) (ReflTransGen r) :=
+  ⟨ReflTransGen.head⟩
+
+instance : Trans (ReflTransGen r) r (ReflTransGen r) :=
+  ⟨ReflTransGen.tail⟩
+
+instance : Trans (TransGen r) (ReflTransGen r) (TransGen r) :=
+  ⟨TransGen.trans_left⟩
+
+instance : Trans (TransGen r) (TransGen r) (TransGen r) :=
+  ⟨TransGen.trans⟩
+
+instance : Trans (TransGen r) r (TransGen r) :=
+  ⟨TransGen.tail⟩
+
+instance : Trans r (TransGen r) (TransGen r) :=
+  ⟨TransGen.head⟩
+
+instance : Trans (ReflTransGen r) (TransGen r) (TransGen r) :=
+  ⟨TransGen.trans_right⟩
+
+instance : IsTrans α (TransGen r) :=
+  ⟨@TransGen.trans α r⟩
+
+instance : IsTrans α (ReflTransGen r) :=
+  ⟨@ReflTransGen.trans α r⟩
+
+end Trans

--- a/Mathlib/Logic/Relation.lean
+++ b/Mathlib/Logic/Relation.lean
@@ -399,6 +399,12 @@ theorem tail' (hab : ReflTransGen r a b) (hbc : r b c) : TransGen r a c := by
 theorem head (hab : r a b) (hbc : TransGen r b c) : TransGen r a c :=
   head' hab hbc.to_reflTransGen
 
+instance : Trans (TransGen r) r (TransGen r) := 
+  ⟨tail⟩
+
+instance : Trans r (TransGen r) (TransGen r) :=
+  ⟨head⟩
+
 @[elab_as_elim]
 theorem head_induction_on {P : ∀ a : α, TransGen r a b → Prop} {a : α} (h : TransGen r a b)
     (base : ∀ {a} (h : r a b), P a (single h))

--- a/Mathlib/Logic/Relation.lean
+++ b/Mathlib/Logic/Relation.lean
@@ -513,12 +513,6 @@ section ReflTransGen
 
 open ReflTransGen
 
-instance : Trans r (ReflTransGen r) (ReflTransGen r) :=
-  ⟨head⟩
-
-instance : Trans (ReflTransGen r) r (ReflTransGen r) :=
-  ⟨tail⟩
-
 theorem reflTransGen_iff_eq (h : ∀ b, ¬r a b) : ReflTransGen r a b ↔ b = a := by
   rw [cases_head_iff]; simp [h, eq_comm]
 
@@ -553,6 +547,12 @@ lemma reflTransGen_minimal {r' : α → α → Prop} (hr₁ : Reflexive r') (hr�
 theorem reflexive_reflTransGen : Reflexive (ReflTransGen r) := fun _ ↦ refl
 
 theorem transitive_reflTransGen : Transitive (ReflTransGen r) := fun _ _ _ ↦ trans
+
+instance : Trans r (ReflTransGen r) (ReflTransGen r) :=
+  ⟨head⟩
+
+instance : Trans (ReflTransGen r) r (ReflTransGen r) :=
+  ⟨tail⟩
 
 instance : IsRefl α (ReflTransGen r) :=
   ⟨@ReflTransGen.refl α r⟩

--- a/Mathlib/Logic/Relation.lean
+++ b/Mathlib/Logic/Relation.lean
@@ -310,6 +310,15 @@ theorem head (hab : r a b) (hbc : ReflTransGen r b c) : ReflTransGen r a c := by
   | refl => exact refl.tail hab
   | tail _ hcd hac => exact hac.tail hcd
 
+instance : Trans r r (ReflTransGen r) where
+  trans hab hbc := head hab (single hbc)
+
+instance : Trans r (ReflTransGen r) (ReflTransGen r) :=
+  ⟨head⟩
+
+instance : Trans (ReflTransGen r) r (ReflTransGen r) :=
+  ⟨tail⟩
+
 theorem symmetric (h : Symmetric r) : Symmetric (ReflTransGen r) := by
   intro x y h
   induction h with

--- a/Mathlib/Logic/Relation.lean
+++ b/Mathlib/Logic/Relation.lean
@@ -310,9 +310,6 @@ theorem head (hab : r a b) (hbc : ReflTransGen r b c) : ReflTransGen r a c := by
   | refl => exact refl.tail hab
   | tail _ hcd hac => exact hac.tail hcd
 
-instance : Trans r r (ReflTransGen r) where
-  trans hab hbc := head hab (single hbc)
-
 instance : Trans r (ReflTransGen r) (ReflTransGen r) :=
   ⟨head⟩
 


### PR DESCRIPTION
This PR adds `Trans` instances for `Relation.ReflTransGen`, with the benefit of allowing switching back and forth between single and multiple applications a relation in a `calc` block.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
