### PR TITLE
[Merged by Bors] - feat(Algebra): MulOpposite lemmas

### DIFF
--- a/Mathlib/Algebra/Group/Opposite.lean
+++ b/Mathlib/Algebra/Group/Opposite.lean
@@ -34,6 +34,9 @@ instance instAddLeftCancelSemigroup [AddLeftCancelSemigroup α] : AddLeftCancelS
 instance instAddRightCancelSemigroup [AddRightCancelSemigroup α] : AddRightCancelSemigroup αᵐᵒᵖ :=
   unop_injective.addRightCancelSemigroup _ fun _ _ => rfl
 
+instance instAddCommMagma [AddCommMagma α] : AddCommMagma αᵐᵒᵖ :=
+  unop_injective.addCommMagma _ fun _ _ => rfl
+
 instance instAddCommSemigroup [AddCommSemigroup α] : AddCommSemigroup αᵐᵒᵖ :=
   unop_injective.addCommSemigroup _ fun _ _ => rfl
 

--- a/Mathlib/Algebra/Group/UniqueProds/Basic.lean
+++ b/Mathlib/Algebra/Group/UniqueProds/Basic.lean
@@ -67,6 +67,10 @@ namespace UniqueMul
 
 variable {G H : Type*} [Mul G] [Mul H] {A B : Finset G} {a0 b0 : G}
 
+@[to_additive]
+theorem mono {A' B' : Finset G} (hA : A ⊆ A') (hB : B ⊆ B') (h : UniqueMul A' B' a0 b0) :
+    UniqueMul A B a0 b0 := fun _ _ ha hb he ↦ h (hA ha) (hB hb) he
+
 @[to_additive (attr := nontriviality, simp)]
 theorem of_subsingleton [Subsingleton G] : UniqueMul A B a0 b0 := by
   simp [UniqueMul, eq_iff_true_of_subsingleton]

--- a/Mathlib/Algebra/GroupWithZero/Opposite.lean
+++ b/Mathlib/Algebra/GroupWithZero/Opposite.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
 import Mathlib.Algebra.Group.Opposite
+import Mathlib.Algebra.GroupWithZero.InjSurj
 import Mathlib.Algebra.GroupWithZero.NeZero
 
 /-!
@@ -43,6 +44,31 @@ instance instNoZeroDivisors [Zero α] [Mul α] [NoZeroDivisors α] : NoZeroDivis
   eq_zero_or_eq_zero_of_mul_eq_zero (H : op (_ * _) = op (0 : α)) :=
       Or.casesOn (eq_zero_or_eq_zero_of_mul_eq_zero <| op_injective H)
         (fun hy => Or.inr <| unop_injective <| hy) fun hx => Or.inl <| unop_injective <| hx
+
+instance [Mul α] [Zero α] [IsLeftCancelMulZero α] : IsRightCancelMulZero αᵐᵒᵖ where
+  mul_right_cancel_of_ne_zero h eq := unop_injective <|
+    mul_left_cancel₀ (unop_injective.ne_iff.mpr h) (congr_arg unop eq)
+
+instance [Mul α] [Zero α] [IsRightCancelMulZero α] : IsLeftCancelMulZero αᵐᵒᵖ where
+  mul_left_cancel_of_ne_zero h eq := unop_injective <|
+    mul_right_cancel₀ (unop_injective.ne_iff.mpr h) (congr_arg unop eq)
+
+instance [Mul α] [Zero α] [IsCancelMulZero α] : IsCancelMulZero αᵐᵒᵖ where
+
+@[simp] theorem isLeftCancelMulZero_iff [Mul α] [Zero α] :
+    IsLeftCancelMulZero αᵐᵒᵖ ↔ IsRightCancelMulZero α where
+  mp _ := (op_injective.comp op_injective).isRightCancelMulZero _ rfl fun _ _ ↦ rfl
+  mpr _ := inferInstance
+
+@[simp] theorem isRightCancelMulZero_iff [Mul α] [Zero α] :
+    IsRightCancelMulZero αᵐᵒᵖ ↔ IsLeftCancelMulZero α where
+  mp _ := (op_injective.comp op_injective).isLeftCancelMulZero _ rfl fun _ _ ↦ rfl
+  mpr _ := inferInstance
+
+@[simp] theorem isCancelMulZero_iff [Mul α] [Zero α] :
+    IsCancelMulZero αᵐᵒᵖ ↔ IsCancelMulZero α where
+  mp _ := (op_injective.comp op_injective).isCancelMulZero _ rfl fun _ _ ↦ rfl
+  mpr _ := inferInstance
 
 end MulOpposite
 

--- a/Mathlib/Algebra/MonoidAlgebra/Defs.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Defs.lean
@@ -736,7 +736,7 @@ variable [Semiring k]
 /-- The opposite of a `MonoidAlgebra R I` equivalent as a ring to
 the `MonoidAlgebra Rᵐᵒᵖ Iᵐᵒᵖ` over the opposite ring, taking elements to their opposite. -/
 @[simps! +simpRhs apply symm_apply]
-protected noncomputable def opRingEquiv [Monoid G] :
+protected noncomputable def opRingEquiv [Mul G] :
     (MonoidAlgebra k G)ᵐᵒᵖ ≃+* MonoidAlgebra kᵐᵒᵖ Gᵐᵒᵖ :=
   { opAddEquiv.symm.trans <|
       (Finsupp.mapRange.addEquiv (opAddEquiv : k ≃+ kᵐᵒᵖ)).trans <| Finsupp.domCongr opEquiv with
@@ -757,10 +757,10 @@ protected noncomputable def opRingEquiv [Monoid G] :
       rw [MulOpposite.unop_mul (α := MonoidAlgebra k G), unop_op, unop_op, single_mul_single]
       simp }
 
-theorem opRingEquiv_single [Monoid G] (r : k) (x : G) :
+theorem opRingEquiv_single [Mul G] (r : k) (x : G) :
     MonoidAlgebra.opRingEquiv (op (single x r)) = single (op x) (op r) := by simp
 
-theorem opRingEquiv_symm_single [Monoid G] (r : kᵐᵒᵖ) (x : Gᵐᵒᵖ) :
+theorem opRingEquiv_symm_single [Mul G] (r : kᵐᵒᵖ) (x : Gᵐᵒᵖ) :
     MonoidAlgebra.opRingEquiv.symm (single x r) = op (single x.unop r.unop) := by simp
 
 end Opposite
@@ -1384,7 +1384,7 @@ variable [Semiring k]
 /-- The opposite of an `R[I]` is ring equivalent to
 the `AddMonoidAlgebra Rᵐᵒᵖ I` over the opposite ring, taking elements to their opposite. -/
 @[simps! +simpRhs apply symm_apply]
-protected noncomputable def opRingEquiv [AddCommMonoid G] :
+protected noncomputable def opRingEquiv [AddCommMagma G] :
     k[G]ᵐᵒᵖ ≃+* kᵐᵒᵖ[G] :=
   { opAddEquiv.symm.trans (mapRange.addEquiv (opAddEquiv : k ≃+ kᵐᵒᵖ)) with
     map_mul' := by
@@ -1406,10 +1406,10 @@ protected noncomputable def opRingEquiv [AddCommMonoid G] :
 -- @[simp] -- Porting note (https://github.com/leanprover-community/mathlib4/issues/10618): simp can prove this.
 -- More specifically, the LHS simplifies to `Finsupp.single`, which implies there's some
 -- defeq abuse going on.
-theorem opRingEquiv_single [AddCommMonoid G] (r : k) (x : G) :
+theorem opRingEquiv_single [AddCommMagma G] (r : k) (x : G) :
     AddMonoidAlgebra.opRingEquiv (op (single x r)) = single x (op r) := by simp
 
-theorem opRingEquiv_symm_single [AddCommMonoid G] (r : kᵐᵒᵖ) (x : Gᵐᵒᵖ) :
+theorem opRingEquiv_symm_single [AddCommMagma G] (r : kᵐᵒᵖ) (x : Gᵐᵒᵖ) :
     AddMonoidAlgebra.opRingEquiv.symm (single x r) = op (single x r.unop) := by simp
 
 end Opposite

--- a/Mathlib/Algebra/Opposites.lean
+++ b/Mathlib/Algebra/Opposites.lean
@@ -176,6 +176,14 @@ instance instInvolutiveNeg [InvolutiveNeg α] : InvolutiveNeg αᵐᵒᵖ where
 instance instInvolutiveInv [InvolutiveInv α] : InvolutiveInv αᵐᵒᵖ where
   inv_inv _ := unop_injective <| inv_inv _
 
+instance [Add α] [IsLeftCancelAdd α] : IsLeftCancelAdd αᵐᵒᵖ where
+  add_left_cancel _ _ _ eq := unop_injective <| add_left_cancel (congr_arg unop eq)
+
+instance [Add α] [IsRightCancelAdd α] : IsRightCancelAdd αᵐᵒᵖ where
+  add_right_cancel _ _ _ eq := unop_injective <| add_right_cancel (congr_arg unop eq)
+
+instance [Add α] [IsCancelAdd α] : IsCancelAdd αᵐᵒᵖ where
+
 @[to_additive] instance instSMul [SMul α β] : SMul α βᵐᵒᵖ where smul c x := op (c • unop x)
 
 @[simp] lemma op_zero [Zero α] : op (0 : α) = 0 := rfl

--- a/Mathlib/Algebra/Ring/Equiv.lean
+++ b/Mathlib/Algebra/Ring/Equiv.lean
@@ -925,21 +925,27 @@ theorem isDomain_iff {A B : Type*} [Semiring A] [Semiring B] (e : A ≃* B) :
   mp _ := e.symm.isDomain
   mpr _ := e.isDomain
 
-include e
+theorem isDomain_iff {A B : Type*} [Semiring A] [Semiring B] (e : A ≃* B) :
+    IsDomain A ↔ IsDomain B where
+  mp _ := e.symm.isDomain
+  mpr _ := e.isDomain
 
-theorem noZeroDivisors_iff : NoZeroDivisors A ↔ NoZeroDivisors B where
+variable {A B : Type*} [MulZeroClass A] [MulZeroClass B]
+
+theorem noZeroDivisors_iff (e : A ≃* B) : NoZeroDivisors A ↔ NoZeroDivisors B where
   mp _ := e.symm.noZeroDivisors
   mpr _ := e.noZeroDivisors
 
-theorem isLeftCancelMulZero_iff : IsLeftCancelMulZero A ↔ IsLeftCancelMulZero B where
+theorem isLeftCancelMulZero_iff (e : A ≃* B) : IsLeftCancelMulZero A ↔ IsLeftCancelMulZero B where
   mp _ := e.symm.injective.isLeftCancelMulZero _ (map_zero _) (map_mul _)
   mpr _ := e.injective.isLeftCancelMulZero _ (map_zero _) (map_mul _)
 
-theorem isRightCancelMulZero_iff : IsRightCancelMulZero A ↔ IsRightCancelMulZero B where
+theorem isRightCancelMulZero_iff (e : A ≃* B) :
+    IsRightCancelMulZero A ↔ IsRightCancelMulZero B where
   mp _ := e.symm.injective.isRightCancelMulZero _ (map_zero _) (map_mul _)
   mpr _ := e.injective.isRightCancelMulZero _ (map_zero _) (map_mul _)
 
-theorem isCancelMulZero_iff : IsCancelMulZero A ↔ IsCancelMulZero B where
+theorem isCancelMulZero_iff (e : A ≃* B) : IsCancelMulZero A ↔ IsCancelMulZero B where
   mp _ := e.symm.injective.isCancelMulZero _ (map_zero _) (map_mul _)
   mpr _ := e.injective.isCancelMulZero _ (map_zero _) (map_mul _)
 

--- a/Mathlib/Algebra/Ring/Equiv.lean
+++ b/Mathlib/Algebra/Ring/Equiv.lean
@@ -920,4 +920,27 @@ protected theorem isDomain {A : Type*} (B : Type*) [Semiring A] [Semiring B] [Is
     e.injective.isRightCancelMulZero e (map_zero e) (map_mul e) with
     exists_pair_ne := ⟨e.symm 0, e.symm 1, e.symm.injective.ne zero_ne_one⟩ }
 
+theorem isDomain_iff {A B : Type*} [Semiring A] [Semiring B] (e : A ≃* B) :
+    IsDomain A ↔ IsDomain B where
+  mp _ := e.symm.isDomain
+  mpr _ := e.isDomain
+
+include e
+
+theorem noZeroDivisors_iff : NoZeroDivisors A ↔ NoZeroDivisors B where
+  mp _ := e.symm.noZeroDivisors
+  mpr _ := e.noZeroDivisors
+
+theorem isLeftCancelMulZero_iff : IsLeftCancelMulZero A ↔ IsLeftCancelMulZero B where
+  mp _ := e.symm.injective.isLeftCancelMulZero _ (map_zero _) (map_mul _)
+  mpr _ := e.injective.isLeftCancelMulZero _ (map_zero _) (map_mul _)
+
+theorem isRightCancelMulZero_iff : IsRightCancelMulZero A ↔ IsRightCancelMulZero B where
+  mp _ := e.symm.injective.isRightCancelMulZero _ (map_zero _) (map_mul _)
+  mpr _ := e.injective.isRightCancelMulZero _ (map_zero _) (map_mul _)
+
+theorem isCancelMulZero_iff : IsCancelMulZero A ↔ IsCancelMulZero B where
+  mp _ := e.symm.injective.isCancelMulZero _ (map_zero _) (map_mul _)
+  mpr _ := e.injective.isCancelMulZero _ (map_zero _) (map_mul _)
+
 end MulEquiv

--- a/Mathlib/Algebra/Ring/Equiv.lean
+++ b/Mathlib/Algebra/Ring/Equiv.lean
@@ -925,11 +925,6 @@ theorem isDomain_iff {A B : Type*} [Semiring A] [Semiring B] (e : A ≃* B) :
   mp _ := e.symm.isDomain
   mpr _ := e.isDomain
 
-theorem isDomain_iff {A B : Type*} [Semiring A] [Semiring B] (e : A ≃* B) :
-    IsDomain A ↔ IsDomain B where
-  mp _ := e.symm.isDomain
-  mpr _ := e.isDomain
-
 variable {A B : Type*} [MulZeroClass A] [MulZeroClass B]
 
 theorem noZeroDivisors_iff (e : A ≃* B) : NoZeroDivisors A ↔ NoZeroDivisors B where


### PR DESCRIPTION
Also add more lemmas towards #27241:

+ generalize `(Add)MonoidAlgebra.opRingEquiv` to weaker typeclass assumptions.

+ add `UniqueMul/Add.mono`.

+ add stability of some typeclasses under `MulEquiv`s.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
