### PR TITLE
[Merged by Bors] - chore: use `simp` or `simp_all` instead of `aesop` in Algebra/

### DIFF
--- a/Mathlib/Algebra/BigOperators/Finprod.lean
+++ b/Mathlib/Algebra/BigOperators/Finprod.lean
@@ -951,7 +951,7 @@ lemma finprod_option {f : Option α → M} (hf : (mulSupport (f ∘ some)).Finit
   replace hf : (mulSupport f).Finite := by simpa [finite_option]
   convert finprod_mem_insert' f (show none ∉ Set.range Option.some by aesop)
     (hf.subset inter_subset_right)
-  · aesop
+  · simp
   · rw [finprod_mem_range]
     exact Option.some_injective _
 

--- a/Mathlib/Algebra/BigOperators/Group/List/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Group/List/Basic.lean
@@ -64,7 +64,7 @@ theorem rel_prod {R : M → N → Prop} (h : R 1 1) (hf : (R ⇒ R ⇒ R) (· * 
 @[to_additive]
 theorem prod_hom_nonempty {l : List M} {F : Type*} [FunLike F M N] [MulHomClass F M N] (f : F)
     (hl : l ≠ []) : (l.map f).prod = f l.prod :=
-  match l, hl with | x :: xs, hl => by induction xs generalizing x <;> aesop
+  match l, hl with | x :: xs, hl => by induction xs generalizing x <;> simp_all
 
 @[to_additive]
 theorem prod_hom (l : List M) {F : Type*} [FunLike F M N] [MonoidHomClass F M N] (f : F) :
@@ -76,7 +76,7 @@ theorem prod_hom (l : List M) {F : Type*} [FunLike F M N] [MonoidHomClass F M N]
 theorem prod_hom₂_nonempty {l : List ι} (f : M → N → P)
     (hf : ∀ a b c d, f (a * b) (c * d) = f a c * f b d) (f₁ : ι → M) (f₂ : ι → N) (hl : l ≠ []) :
     (l.map fun i => f (f₁ i) (f₂ i)).prod = f (l.map f₁).prod (l.map f₂).prod := by
-  match l, hl with | x :: xs, hl => induction xs generalizing x <;> aesop
+  match l, hl with | x :: xs, hl => induction xs generalizing x <;> simp_all
 
 @[to_additive]
 theorem prod_hom₂ (l : List ι) (f : M → N → P) (hf : ∀ a b c d, f (a * b) (c * d) = f a c * f b d)

--- a/Mathlib/Algebra/DirectSum/Internal.lean
+++ b/Mathlib/Algebra/DirectSum/Internal.lean
@@ -459,7 +459,7 @@ theorem mul_apply_eq_zero {r r' : ⨁ i, A i} {m n : ι}
   obtain (hx | hx) : x.1 < m ∨ x.2 < n := by
     by_contra! h
     obtain ⟨hm, hn⟩ := h
-    obtain rfl : x.1 + x.2 = k := by aesop
+    obtain rfl : x.1 + x.2 = k := by simp_all
     apply lt_irrefl (m + n) <| lt_of_le_of_lt (by gcongr) hk
   all_goals simp [hr, hr', hx]
 

--- a/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
+++ b/Mathlib/Algebra/Group/Pointwise/Finset/Basic.lean
@@ -991,7 +991,7 @@ lemma univ_div_univ [Fintype α] : (univ / univ : Finset α) = univ := by simp [
   rw [div_eq_mul_inv]; exact subset_mul_right _ hs
 
 @[to_additive (attr := simp) zsmul_empty]
-lemma empty_zpow (hn : n ≠ 0) : (∅ : Finset α) ^ n = ∅ := by cases n <;> aesop
+lemma empty_zpow (hn : n ≠ 0) : (∅ : Finset α) ^ n = ∅ := by cases n <;> simp_all
 
 @[to_additive]
 lemma Nonempty.zpow (hs : s.Nonempty) : ∀ {n : ℤ}, (s ^ n).Nonempty

--- a/Mathlib/Algebra/GroupWithZero/Associated.lean
+++ b/Mathlib/Algebra/GroupWithZero/Associated.lean
@@ -236,7 +236,7 @@ theorem prime_mul_iff [CancelCommMonoidWithZero M] {x y : M} :
 lemma prime_pow_iff [CancelCommMonoidWithZero M] {p : M} {n : ℕ} :
     Prime (p ^ n) ↔ Prime p ∧ n = 1 := by
   refine ⟨fun hp ↦ ?_, fun ⟨hp, hn⟩ ↦ by simpa [hn]⟩
-  suffices n = 1 by aesop
+  suffices n = 1 by simp_all
   rcases n with - | n
   · simp at hp
   · rw [Nat.succ.injEq]

--- a/Mathlib/Algebra/Lie/TraceForm.lean
+++ b/Mathlib/Algebra/Lie/TraceForm.lean
@@ -176,7 +176,7 @@ lemma eq_zero_of_mem_genWeightSpace_mem_posFitting [LieRing.IsNilpotent L]
       ← (φ x).comp_apply, ← Module.End.mul_eq_comp, ← pow_succ', ← smul_assoc, this]
   suffices ∀ (x : L) m, m ∈ posFittingCompOf R M x → B m₀ m = 0 by
     refine LieSubmodule.iSup_induction (motive := fun m ↦ (B m₀) m = 0) _ hm₁ this (map_zero _) ?_
-    aesop
+    simp_all
   clear hm₁ m₁; intro x m₁ hm₁
   simp only [mem_genWeightSpace, Pi.zero_apply, zero_smul, sub_zero] at hm₀
   obtain ⟨k, hk⟩ := hm₀ x

--- a/Mathlib/Algebra/Module/CharacterModule.lean
+++ b/Mathlib/Algebra/Module/CharacterModule.lean
@@ -46,7 +46,7 @@ namespace CharacterModule
 
 instance : FunLike (CharacterModule A) A (AddCircle (1 : ℚ)) where
   coe c := c.toFun
-  coe_injective' _ _ _ := by aesop
+  coe_injective' _ _ _ := by simp_all
 
 instance : LinearMapClass (CharacterModule A) ℤ A (AddCircle (1 : ℚ)) where
   map_add _ _ _ := by rw [AddMonoidHom.map_add]

--- a/Mathlib/Algebra/Module/Submodule/Range.lean
+++ b/Mathlib/Algebra/Module/Submodule/Range.lean
@@ -299,7 +299,7 @@ theorem submoduleOf_sup_of_le {N₁ N₂ N : Submodule R M} (h₁ : N₁ ≤ N) 
     (N₁ ⊔ N₂).submoduleOf N = N₁.submoduleOf N ⊔ N₂.submoduleOf N := by
   apply Submodule.map_injective_of_injective N.subtype_injective
   simp only [submoduleOf, map_comap_eq]
-  aesop
+  simp_all
 
 @[simp]
 lemma comap_subtype_le_iff {p q r : Submodule R M} :

--- a/Mathlib/Algebra/MvPolynomial/Basic.lean
+++ b/Mathlib/Algebra/MvPolynomial/Basic.lean
@@ -860,7 +860,7 @@ lemma coeffs_add [DecidableEq R] {p q : MvPolynomial σ R} (h : Disjoint p.suppo
   have hr (n : σ →₀ ℕ) (hne : q.coeff n ≠ 0) : p.coeff n = 0 :=
     notMem_support_iff.mp <| h.notMem_of_mem_right_finset (mem_support_iff.mpr hne)
   have hor (n) (h : ¬coeff n p + coeff n q = 0) : coeff n p ≠ 0 ∨ coeff n q ≠ 0 := by
-    by_cases hp : coeff n p = 0 <;> aesop
+    by_cases hp : coeff n p = 0 <;> simp_all
   refine ⟨fun ⟨n, hn1, hn2⟩ ↦ ?_, ?_⟩
   · obtain (h | h) := hor n hn1
     · exact Or.inl ⟨n, by simp [h, hn2, hl n h]⟩

--- a/Mathlib/Algebra/Order/Antidiag/Nat.lean
+++ b/Mathlib/Algebra/Order/Antidiag/Nat.lean
@@ -37,7 +37,7 @@ This is `Nat.divisorsAntidiagonal` without a special case for `n = 0`. -/
     x ∈ divisorsAntidiagonal n ↔ x.1 * x.2 = n := by
     simp_rw [divisorsAntidiagonal, Finset.mem_map, Finset.mem_attach, Function.Embedding.coeFn_mk,
       Prod.ext_iff, true_and, ← coe_inj, Subtype.exists]
-    aesop
+    simp
   { antidiagonal := fun n ↦ divisorsAntidiagonal (Additive.toMul n) |>.map
       (.prodMap (Additive.ofMul.toEmbedding) (Additive.ofMul.toEmbedding))
     mem_antidiagonal := by simp [← ofMul_mul, mem_divisorsAntidiagonal] }

--- a/Mathlib/Algebra/Order/Antidiag/Pi.lean
+++ b/Mathlib/Algebra/Order/Antidiag/Pi.lean
@@ -116,7 +116,7 @@ def piAntidiag (s : Finset ι) (n : μ) : Finset (ι → μ) := by
     simp only [mem_map, mem_finAntidiagonal]
     refine Equiv.exists_congr ((e₁.symm.trans e₂).arrowCongr <| .refl _) fun g ↦ ?_
     have := Fintype.sum_equiv (e₂.symm.trans e₁) _ g fun _ ↦ rfl
-    aesop
+    simp_all
 
 variable {s : Finset ι} {n : μ} {f : ι → μ}
 

--- a/Mathlib/Algebra/Order/Ring/Star.lean
+++ b/Mathlib/Algebra/Order/Ring/Star.lean
@@ -44,7 +44,7 @@ private lemma mul_le_mul_of_nonneg_left {R : Type*} [NonUnitalCommSemiring R] [P
   | one => simp
   | mul x hx y hy =>
     simp only [← nonneg_iff, add_mul] at hx hy ⊢
-    apply add_le_add <;> aesop
+    apply add_le_add <;> simp_all
 
 /-- A commutative star-ordered semiring is an ordered semiring. -/
 instance toIsOrderedRing (R : Type*) [CommSemiring R] [PartialOrder R]

--- a/Mathlib/Algebra/Polynomial/Degree/Definitions.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Definitions.lean
@@ -304,7 +304,7 @@ def nextCoeff (p : R[X]) : R :=
 
 lemma nextCoeff_eq_zero :
     p.nextCoeff = 0 ↔ p.natDegree = 0 ∨ 0 < p.natDegree ∧ p.coeff (p.natDegree - 1) = 0 := by
-  simp [nextCoeff, or_iff_not_imp_left, pos_iff_ne_zero]; aesop
+  simp [nextCoeff, or_iff_not_imp_left, pos_iff_ne_zero]; simp_all
 
 lemma nextCoeff_ne_zero : p.nextCoeff ≠ 0 ↔ p.natDegree ≠ 0 ∧ p.coeff (p.natDegree - 1) ≠ 0 := by
   simp [nextCoeff]

--- a/Mathlib/Algebra/Polynomial/Degree/Lemmas.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Lemmas.lean
@@ -323,7 +323,7 @@ lemma nextCoeff_C_mul_X_add_C (ha : a ≠ 0) (c : R) : nextCoeff (C a * X + C c)
 lemma natDegree_eq_one : p.natDegree = 1 ↔ ∃ a ≠ 0, ∃ b, C a * X + C b = p := by
   refine ⟨fun hp ↦ ⟨p.coeff 1, fun h ↦ ?_, p.coeff 0, ?_⟩, ?_⟩
   · rw [← hp, coeff_natDegree, leadingCoeff_eq_zero] at h
-    aesop
+    simp_all
   · ext n
     obtain _ | _ | n := n
     · simp

--- a/Mathlib/Algebra/Polynomial/Degree/Monomial.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Monomial.lean
@@ -30,7 +30,7 @@ lemma natDegree_le_pred (hf : p.natDegree ≤ n) (hn : p.coeff n = 0) : p.natDeg
   · exact hf
   · refine (Nat.le_succ_iff_eq_or_le.1 hf).resolve_left fun h ↦ ?_
     rw [← Nat.succ_eq_add_one, ← h, coeff_natDegree, leadingCoeff_eq_zero] at hn
-    aesop
+    simp_all
 
 theorem monomial_natDegree_leadingCoeff_eq_self (h : #p.support ≤ 1) :
     monomial p.natDegree p.leadingCoeff = p := by

--- a/Mathlib/Algebra/Polynomial/SpecificDegree.lean
+++ b/Mathlib/Algebra/Polynomial/SpecificDegree.lean
@@ -59,7 +59,7 @@ lemma irreducible_of_degree_le_three_of_not_isRoot
   by_cases hdeg2 : 2 ≤ p.natDegree
   · rw [Polynomial.irreducible_iff_roots_eq_zero_of_degree_le_three hdeg2 hdeg.2]
     apply Multiset.eq_zero_of_forall_notMem
-    aesop
+    simp_all
   · apply Polynomial.irreducible_of_degree_eq_one
     rw [← Nat.cast_one, Polynomial.degree_eq_iff_natDegree_eq_of_pos (by norm_num)]
     exact le_antisymm (by rwa [not_le, Nat.lt_succ_iff] at hdeg2) hdeg.1


### PR DESCRIPTION
Motivation: reducing overhead and clarifying intent.