### PR TITLE
feat: prove that each (total) preorder is an extension of a (linear) partial order

### DIFF
--- a/Mathlib/Order/Interval/Finset/Defs.lean
+++ b/Mathlib/Order/Interval/Finset/Defs.lean
@@ -5,6 +5,7 @@ Authors: Yaël Dillies
 -/
 import Mathlib.Data.Finset.Preimage
 import Mathlib.Data.Finset.Prod
+import Mathlib.Data.Set.Finite.Lattice
 import Mathlib.Order.Hom.WithTopBot
 import Mathlib.Order.Interval.Set.UnorderedInterval
 
@@ -1279,6 +1280,26 @@ instance [Preorder α] [LocallyFiniteOrderTop α] : Finite { x : α // y ≤ x }
 
 instance [Preorder α] [LocallyFiniteOrderTop α] : Finite { x : α // y < x } := by
   simpa only [coe_Ioi] using (Finset.Ioi y).finite_toSet
+
+/-- A nonempty `LocallyFiniteOrderBot` with a directed order has a bottom element.
+  This is not an instance because the chosen `⊥` has bad definitional properties. -/
+noncomputable def LocallyFiniteOrderBot.orderBot (α : Type*) [Nonempty α] [Preorder α]
+    [LocallyFiniteOrderBot α] [IsDirected α (· ≥ ·)] : OrderBot α where
+  bot := Classical.choose (Set.finite_Iic (Classical.arbitrary α)).bddBelow
+  bot_le a := by
+    obtain (hb : ∀ _, _) := Classical.choose_spec (Set.finite_Iic (Classical.arbitrary α)).bddBelow
+    obtain ⟨c, hc, hca⟩ := exists_le_le (Classical.arbitrary α) a
+    exact (hb _ hc).trans hca
+
+/-- A nonempty `LocallyFiniteOrderTop` with a directed order has a top element.
+  This is not an instance because the chosen `⊤` has bad definitional properties. -/
+noncomputable def LocallyFiniteOrderTop.orderTop (α : Type*) [Nonempty α] [Preorder α]
+    [LocallyFiniteOrderTop α] [IsDirected α (· ≤ ·)] : OrderTop α where
+  top := Classical.choose (Set.finite_Ici (Classical.arbitrary α)).bddAbove
+  le_top a := by
+    obtain (hb : ∀ _, _) := Classical.choose_spec (Set.finite_Ici (Classical.arbitrary α)).bddAbove
+    obtain ⟨c, hc, hca⟩ := exists_ge_ge (Classical.arbitrary α) a
+    exact hca.trans <| hb _ hc
 
 namespace Set
 variable {α : Type*} [Preorder α]

--- a/Mathlib/Order/RelClasses.lean
+++ b/Mathlib/Order/RelClasses.lean
@@ -53,6 +53,11 @@ theorem IsStrictOrder.swap (r) [IsStrictOrder α r] : IsStrictOrder α (swap r) 
 theorem IsPartialOrder.swap (r) [IsPartialOrder α r] : IsPartialOrder α (swap r) :=
   { @IsPreorder.swap α r _, @IsAntisymm.swap α r _ with }
 
+instance isPartialOrder.eq (α : Type*) : IsPartialOrder α Eq where
+  refl _ := rfl
+  trans _ _ _ := Eq.trans
+  antisymm _ _ _ := Eq.symm
+
 theorem eq_empty_relation (r) [IsIrrefl α r] [Subsingleton α] : r = EmptyRelation :=
   funext₂ <| by simpa using not_rel_of_subsingleton r
 


### PR DESCRIPTION
Co-authored-by: Peter Nelson <apn.uni@gmail.com> (original author)

---
This is a part of PR #27217, which continues the work in PR #12773.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
