### PR TITLE
[Merged by Bors] - chore(Algebra/Ring/Subsemiring/Order): add missing projection

### DIFF
--- a/Mathlib/Algebra/Ring/Subsemiring/Order.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/Order.lean
@@ -59,7 +59,7 @@ def nonneg : Subsemiring R where
   add_mem' := add_nonneg
   zero_mem' := le_rfl
 
-@[simp] lemma mem_nonneg {x : R} : x ∈ nonneg R ↔ x ∈ Set.Ici 0 := .rfl
+@[simp] lemma mem_nonneg {x : R} : x ∈ nonneg R ↔ 0 ≤ x := .rfl
 
 end nonneg
 

--- a/Mathlib/Algebra/Ring/Subsemiring/Order.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/Order.lean
@@ -45,13 +45,22 @@ instance toIsStrictOrderedRing [Semiring R] [PartialOrder R] [IsStrictOrderedRin
   Subtype.coe_injective.isStrictOrderedRing Subtype.val rfl rfl (fun _ _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) (fun _ _ => rfl) fun _ => rfl
 
+section nonneg
+
+variable {R : Type*} [Semiring R] [PartialOrder R] [IsOrderedRing R]
+
+variable (R) in
 /-- The set of nonnegative elements in an ordered semiring, as a subsemiring. -/
 @[simps]
-def nonneg (R : Type*) [Semiring R] [PartialOrder R] [IsOrderedRing R] : Subsemiring R where
+def nonneg : Subsemiring R where
   carrier := Set.Ici 0
   mul_mem' := mul_nonneg
   one_mem' := zero_le_one
   add_mem' := add_nonneg
   zero_mem' := le_rfl
+
+@[simp] lemma mem_nonneg {x : R} : x ∈ nonneg R ↔ x ∈ Set.Ici 0 := .rfl
+
+end nonneg
 
 end Subsemiring

--- a/Mathlib/Algebra/Ring/Subsemiring/Order.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/Order.lean
@@ -47,7 +47,7 @@ instance toIsStrictOrderedRing [Semiring R] [PartialOrder R] [IsStrictOrderedRin
 
 section nonneg
 
-variable {R : Type*} [Semiring R] [PartialOrder R] [IsOrderedRing R]
+variable [Semiring R] [PartialOrder R] [IsOrderedRing R]
 
 variable (R) in
 /-- The set of nonnegative elements in an ordered semiring, as a subsemiring. -/


### PR DESCRIPTION
Add standard `simp` projection `Subsemiring.mem_nonneg`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
