### PR TITLE
[Merged by Bors] - feat: API for `Minpoly.toAdjoin` and friends

### DIFF
--- a/Mathlib/FieldTheory/Minpoly/IsIntegrallyClosed.lean
+++ b/Mathlib/FieldTheory/Minpoly/IsIntegrallyClosed.lean
@@ -141,14 +141,21 @@ variable {x : S}
 theorem ToAdjoin.injective (hx : IsIntegral R x) : Function.Injective (Minpoly.toAdjoin R x) := by
   refine (injective_iff_map_eq_zero _).2 fun P₁ hP₁ => ?_
   obtain ⟨P, rfl⟩ := mk_surjective P₁
-  rwa [Minpoly.toAdjoin_apply', liftHom_mk, ← Subalgebra.coe_eq_zero, aeval_subalgebra_coe,
+  rwa [Minpoly.toAdjoin_apply, liftHom_mk, ← Subalgebra.coe_eq_zero, aeval_subalgebra_coe,
     isIntegrallyClosed_dvd_iff hx, ← AdjoinRoot.mk_eq_zero] at hP₁
 
 /-- The algebra isomorphism `AdjoinRoot (minpoly R x) ≃ₐ[R] adjoin R x` -/
-@[simps!]
 def equivAdjoin (hx : IsIntegral R x) : AdjoinRoot (minpoly R x) ≃ₐ[R] adjoin R ({x} : Set S) :=
   AlgEquiv.ofBijective (Minpoly.toAdjoin R x)
     ⟨minpoly.ToAdjoin.injective hx, Minpoly.toAdjoin.surjective R x⟩
+
+@[simp]
+theorem equivAdjoin_toAlgHom (hx : IsIntegral R x) :
+  equivAdjoin hx = Minpoly.toAdjoin R x := rfl
+
+@[simp]
+theorem equivAdjoin_apply (hx : IsIntegral R x) (a) :
+  equivAdjoin hx a = Minpoly.toAdjoin R x a := rfl
 
 /-- The `PowerBasis` of `adjoin R {x}` given by `x`. See `Algebra.adjoin.powerBasis` for a version
 over a field. -/

--- a/Mathlib/FieldTheory/Minpoly/IsIntegrallyClosed.lean
+++ b/Mathlib/FieldTheory/Minpoly/IsIntegrallyClosed.lean
@@ -154,6 +154,8 @@ theorem equivAdjoin_toAlgHom (hx : IsIntegral R x) : equivAdjoin hx = Minpoly.to
 @[simp]
 theorem coe_equivAdjoin (hx : IsIntegral R x) : ⇑(equivAdjoin hx) = Minpoly.toAdjoin R x := rfl
 
+@[deprecated (since := "21-07-2025")] alias equivAdjoin_apply := coe_equivAdjoin
+
 /-- The `PowerBasis` of `adjoin R {x}` given by `x`. See `Algebra.adjoin.powerBasis` for a version
 over a field. -/
 def _root_.Algebra.adjoin.powerBasis' (hx : IsIntegral R x) :

--- a/Mathlib/FieldTheory/Minpoly/IsIntegrallyClosed.lean
+++ b/Mathlib/FieldTheory/Minpoly/IsIntegrallyClosed.lean
@@ -154,7 +154,7 @@ theorem equivAdjoin_toAlgHom (hx : IsIntegral R x) : equivAdjoin hx = Minpoly.to
 @[simp]
 theorem coe_equivAdjoin (hx : IsIntegral R x) : ⇑(equivAdjoin hx) = Minpoly.toAdjoin R x := rfl
 
-@[deprecated (since := "21-07-2025")] alias equivAdjoin_apply := coe_equivAdjoin
+@[deprecated (since := "2025-07-21")] alias equivAdjoin_apply := coe_equivAdjoin
 
 /-- The `PowerBasis` of `adjoin R {x}` given by `x`. See `Algebra.adjoin.powerBasis` for a version
 over a field. -/

--- a/Mathlib/FieldTheory/Minpoly/IsIntegrallyClosed.lean
+++ b/Mathlib/FieldTheory/Minpoly/IsIntegrallyClosed.lean
@@ -141,8 +141,7 @@ variable {x : S}
 theorem ToAdjoin.injective (hx : IsIntegral R x) : Function.Injective (Minpoly.toAdjoin R x) := by
   refine (injective_iff_map_eq_zero _).2 fun P₁ hP₁ => ?_
   obtain ⟨P, rfl⟩ := mk_surjective P₁
-  rwa [Minpoly.toAdjoin_apply, liftHom_mk, ← Subalgebra.coe_eq_zero, aeval_subalgebra_coe,
-    isIntegrallyClosed_dvd_iff hx, ← AdjoinRoot.mk_eq_zero] at hP₁
+  simp_all [← Subalgebra.coe_eq_zero, isIntegrallyClosed_dvd_iff hx]
 
 /-- The algebra isomorphism `AdjoinRoot (minpoly R x) ≃ₐ[R] adjoin R x` -/
 def equivAdjoin (hx : IsIntegral R x) : AdjoinRoot (minpoly R x) ≃ₐ[R] adjoin R ({x} : Set S) :=
@@ -150,12 +149,10 @@ def equivAdjoin (hx : IsIntegral R x) : AdjoinRoot (minpoly R x) ≃ₐ[R] adjoi
     ⟨minpoly.ToAdjoin.injective hx, Minpoly.toAdjoin.surjective R x⟩
 
 @[simp]
-theorem equivAdjoin_toAlgHom (hx : IsIntegral R x) :
-  equivAdjoin hx = Minpoly.toAdjoin R x := rfl
+theorem equivAdjoin_toAlgHom (hx : IsIntegral R x) : equivAdjoin hx = Minpoly.toAdjoin R x := rfl
 
 @[simp]
-theorem equivAdjoin_apply (hx : IsIntegral R x) (a) :
-  equivAdjoin hx a = Minpoly.toAdjoin R x a := rfl
+theorem coe_equivAdjoin (hx : IsIntegral R x) : ⇑(equivAdjoin hx) = Minpoly.toAdjoin R x := rfl
 
 /-- The `PowerBasis` of `adjoin R {x}` given by `x`. See `Algebra.adjoin.powerBasis` for a version
 over a field. -/

--- a/Mathlib/RingTheory/Adjoin/Field.lean
+++ b/Mathlib/RingTheory/Adjoin/Field.lean
@@ -36,7 +36,17 @@ def AlgEquiv.adjoinSingletonEquivAdjoinRootMinpoly {R : Type*} [CommRing R] [Alg
     refine ⟨(injective_iff_map_eq_zero _).2 fun P₁ hP₁ ↦ ?_, Minpoly.toAdjoin.surjective F x⟩
     obtain ⟨P, rfl⟩ := mk_surjective P₁
     refine AdjoinRoot.mk_eq_zero.mpr (minpoly.dvd F x ?_)
-    rwa [Minpoly.toAdjoin_apply', liftHom_mk, ← Subalgebra.coe_eq_zero, aeval_subalgebra_coe] at hP₁
+    simp_all [← Subalgebra.coe_eq_zero]
+
+@[simp]
+theorem AlgEquiv.adjoinSingletonEquivAdjoinRootMinpoly_symm_toAlgHom {R : Type*} [CommRing R]
+    [Algebra F R] (x : R) :
+    (adjoinSingletonEquivAdjoinRootMinpoly F x).symm = AdjoinRoot.Minpoly.toAdjoin F x := rfl
+
+@[simp]
+theorem AlgEquiv.adjoinSingletonEquivAdjoinRootMinpoly_symm_apply {R : Type*} [CommRing R]
+    [Algebra F R] (x : R) (a) :
+    (adjoinSingletonEquivAdjoinRootMinpoly F x).symm a = AdjoinRoot.Minpoly.toAdjoin F x a := rfl
 
 /-- Produce an algebra homomorphism `Adjoin R {x} →ₐ[R] T` sending `x` to
 a root of `x`'s minimal polynomial in `T`. -/

--- a/Mathlib/RingTheory/Adjoin/Field.lean
+++ b/Mathlib/RingTheory/Adjoin/Field.lean
@@ -44,9 +44,9 @@ theorem AlgEquiv.adjoinSingletonEquivAdjoinRootMinpoly_symm_toAlgHom {R : Type*}
     (adjoinSingletonEquivAdjoinRootMinpoly F x).symm = AdjoinRoot.Minpoly.toAdjoin F x := rfl
 
 @[simp]
-theorem AlgEquiv.adjoinSingletonEquivAdjoinRootMinpoly_symm_apply {R : Type*} [CommRing R]
-    [Algebra F R] (x : R) (a) :
-    (adjoinSingletonEquivAdjoinRootMinpoly F x).symm a = AdjoinRoot.Minpoly.toAdjoin F x a := rfl
+theorem AlgEquiv.coe_adjoinSingletonEquivAdjoinRootMinpoly_symm {R : Type*} [CommRing R]
+    [Algebra F R] (x : R) :
+    ⇑(adjoinSingletonEquivAdjoinRootMinpoly F x).symm = AdjoinRoot.Minpoly.toAdjoin F x := rfl
 
 /-- Produce an algebra homomorphism `Adjoin R {x} →ₐ[R] T` sending `x` to
 a root of `x`'s minimal polynomial in `T`. -/

--- a/Mathlib/RingTheory/AdjoinRoot.lean
+++ b/Mathlib/RingTheory/AdjoinRoot.lean
@@ -558,22 +558,18 @@ open Algebra Polynomial
 /-- The surjective algebra morphism `R[X]/(minpoly R x) → R[x]`.
 If `R` is a integrally closed domain and `x` is integral, this is an isomorphism,
 see `minpoly.equivAdjoin`. -/
-@[simps!]
 def Minpoly.toAdjoin : AdjoinRoot (minpoly R x) →ₐ[R] adjoin R ({x} : Set S) :=
   liftHom _ ⟨x, self_mem_adjoin_singleton R x⟩
     (by simp [← Subalgebra.coe_eq_zero, aeval_subalgebra_coe])
 
 variable {R x}
 
-theorem Minpoly.toAdjoin_apply' (a : AdjoinRoot (minpoly R x)) :
-    Minpoly.toAdjoin R x a =
-      liftHom (minpoly R x) (⟨x, self_mem_adjoin_singleton R x⟩ : adjoin R ({x} : Set S))
-        (by simp [← Subalgebra.coe_eq_zero, aeval_subalgebra_coe]) a :=
-  rfl
+@[simp]
+theorem Minpoly.toAdjoin_apply (a : AdjoinRoot (minpoly R x)) :
+    Minpoly.toAdjoin R x a = liftHom (minpoly R x) ⟨x, self_mem_adjoin_singleton R x⟩
+      (by simp [← Subalgebra.coe_eq_zero, aeval_subalgebra_coe]) a := rfl
 
-theorem Minpoly.toAdjoin.apply_X :
-    Minpoly.toAdjoin R x (mk (minpoly R x) X) = ⟨x, self_mem_adjoin_singleton R x⟩ := by
-  simp [toAdjoin]
+theorem Minpoly.toAdjoin.apply_X : Minpoly.toAdjoin R x (mk (minpoly R x) X) = x := by simp
 
 variable (R x)
 

--- a/Mathlib/RingTheory/AdjoinRoot.lean
+++ b/Mathlib/RingTheory/AdjoinRoot.lean
@@ -565,17 +565,17 @@ def Minpoly.toAdjoin : AdjoinRoot (minpoly R x) →ₐ[R] adjoin R ({x} : Set S)
 variable {R x}
 
 @[simp]
-theorem Minpoly.toAdjoin_apply (a : AdjoinRoot (minpoly R x)) :
-    Minpoly.toAdjoin R x a = liftHom (minpoly R x) ⟨x, self_mem_adjoin_singleton R x⟩
-      (by simp [← Subalgebra.coe_eq_zero, aeval_subalgebra_coe]) a := rfl
+theorem Minpoly.coe_toAdjoin :
+    ⇑(Minpoly.toAdjoin R x) = liftHom (minpoly R x) ⟨x, self_mem_adjoin_singleton R x⟩
+      (by simp [← Subalgebra.coe_eq_zero, aeval_subalgebra_coe]) := rfl
 
-theorem Minpoly.toAdjoin.apply_X : Minpoly.toAdjoin R x (mk (minpoly R x) X) = x := by simp
+theorem Minpoly.coe_toAdjoin_mk_X : Minpoly.toAdjoin R x (mk (minpoly R x) X) = x := by simp
 
 variable (R x)
 
 theorem Minpoly.toAdjoin.surjective : Function.Surjective (Minpoly.toAdjoin R x) := by
   rw [← AlgHom.range_eq_top, _root_.eq_top_iff, ← adjoin_adjoin_coe_preimage]
-  exact adjoin_le fun ⟨y₁, y₂⟩ h ↦ ⟨mk (minpoly R x) X, by simpa [toAdjoin] using h.symm⟩
+  exact adjoin_le fun ⟨y₁, y₂⟩ h ↦ ⟨mk (minpoly R x) X, by simpa using h.symm⟩
 
 end minpoly
 

--- a/Mathlib/RingTheory/AdjoinRoot.lean
+++ b/Mathlib/RingTheory/AdjoinRoot.lean
@@ -569,12 +569,12 @@ theorem Minpoly.coe_toAdjoin :
     ⇑(Minpoly.toAdjoin R x) = liftHom (minpoly R x) ⟨x, self_mem_adjoin_singleton R x⟩
       (by simp [← Subalgebra.coe_eq_zero, aeval_subalgebra_coe]) := rfl
 
-@[deprecated (since := "21-07-2025")] alias Minpoly.toAdjoin_apply := Minpoly.coe_toAdjoin
-@[deprecated (since := "21-07-2025")] alias Minpoly.toAdjoin_apply' := Minpoly.coe_toAdjoin
+@[deprecated (since := "2025-07-21")] alias Minpoly.toAdjoin_apply := Minpoly.coe_toAdjoin
+@[deprecated (since := "2025-07-21")] alias Minpoly.toAdjoin_apply' := Minpoly.coe_toAdjoin
 
 theorem Minpoly.coe_toAdjoin_mk_X : Minpoly.toAdjoin R x (mk (minpoly R x) X) = x := by simp
 
-@[deprecated (since := "21-07-2025")] alias Minpoly.toAdjoin.apply_X := Minpoly.coe_toAdjoin_mk_X
+@[deprecated (since := "2025-07-21")] alias Minpoly.toAdjoin.apply_X := Minpoly.coe_toAdjoin_mk_X
 
 variable (R x)
 

--- a/Mathlib/RingTheory/AdjoinRoot.lean
+++ b/Mathlib/RingTheory/AdjoinRoot.lean
@@ -569,7 +569,12 @@ theorem Minpoly.coe_toAdjoin :
     ⇑(Minpoly.toAdjoin R x) = liftHom (minpoly R x) ⟨x, self_mem_adjoin_singleton R x⟩
       (by simp [← Subalgebra.coe_eq_zero, aeval_subalgebra_coe]) := rfl
 
+@[deprecated (since := "21-07-2025")] alias Minpoly.toAdjoin_apply := Minpoly.coe_toAdjoin
+@[deprecated (since := "21-07-2025")] alias Minpoly.toAdjoin_apply' := Minpoly.coe_toAdjoin
+
 theorem Minpoly.coe_toAdjoin_mk_X : Minpoly.toAdjoin R x (mk (minpoly R x) X) = x := by simp
+
+@[deprecated (since := "21-07-2025")] alias Minpoly.toAdjoin.apply_X := Minpoly.coe_toAdjoin_mk_X
 
 variable (R x)
 


### PR DESCRIPTION
* Replace `simps!` invocations on `AdjoinRoot.Minpoly.toAdjoin` and `minpoly.equivAdjoin` with principled API
* Create API for `AlgEquiv.adjoinSingletonEquivAdjoinRootMinpoly`

The auto-generated `simps!` lemmas unfolded the expressions too far for `simp` to be able to continue simplifying them. A good example of the difference is the proof of `Minpoly.toAdjoin.apply_X`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
