### PR TITLE
feat(FieldTheory): isomorphism with quotient of polynomial ring by minimal polynomial of primitive element

### DIFF
--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Algebra.lean
@@ -86,10 +86,16 @@ theorem adjoin_algebraic_toSubalgebra {S : Set E} (hS : ∀ x ∈ S, IsAlgebraic
     (Algebra.IsIntegral.adjoin fun x hx ↦ (hS x hx).isIntegral).inv_mem
 
 theorem adjoin_simple_toSubalgebra_of_integral (hα : IsIntegral F α) :
-    F⟮α⟯.toSubalgebra = Algebra.adjoin F {α} := by
-  apply adjoin_algebraic_toSubalgebra
-  rintro x (rfl : x = α)
-  rwa [isAlgebraic_iff_isIntegral]
+    F⟮α⟯.toSubalgebra = Algebra.adjoin F {α} :=
+  adjoin_algebraic_toSubalgebra <| by simpa [isAlgebraic_iff_isIntegral]
+
+lemma _root_.Algebra.adjoin_eq_top_of_intermediateField {S : Set E} (hS : ∀ x ∈ S, IsAlgebraic F x)
+    (hS₂ : IntermediateField.adjoin F S = ⊤) : Algebra.adjoin F S = ⊤ := by
+  simp [*, ← IntermediateField.adjoin_algebraic_toSubalgebra hS]
+
+lemma _root_.Algebra.adjoin_eq_top_of_primitive_element {α : E} (hα : IsIntegral F α)
+    (hα₂ : F⟮α⟯ = ⊤) : Algebra.adjoin F {α} = ⊤ :=
+  Algebra.adjoin_eq_top_of_intermediateField (by simpa [isAlgebraic_iff_isIntegral]) hα₂
 
 lemma finite_of_fg_of_isAlgebraic
     (h : IntermediateField.FG (⊤ : IntermediateField F E)) [Algebra.IsAlgebraic F E] :

--- a/Mathlib/FieldTheory/PrimitiveElement.lean
+++ b/Mathlib/FieldTheory/PrimitiveElement.lean
@@ -411,7 +411,7 @@ section algEquiv
 
 variable {F E : Type*} [Field F] [Field E] [Algebra F E]
 
-/-
+/--
 `F`-isomorphism between a field extension `E/F` and the quotient `F[X]⧸span {f}`, where `f` is
 the minimal polynomial over `F` of a primitive element in `E/F`.
 -/

--- a/Mathlib/FieldTheory/PrimitiveElement.lean
+++ b/Mathlib/FieldTheory/PrimitiveElement.lean
@@ -8,6 +8,7 @@ import Mathlib.FieldTheory.IsAlgClosed.Basic
 import Mathlib.FieldTheory.SplittingField.Construction
 import Mathlib.RingTheory.IntegralDomain
 import Mathlib.RingTheory.Polynomial.UniqueFactorization
+import Mathlib.FieldTheory.IntermediateField.Adjoin.Algebra
 
 /-!
 # Primitive Element Theorem
@@ -405,3 +406,20 @@ theorem primitive_element_iff_algHom_eq_of_eval (α : E)
 end Field
 
 end iff
+
+section algEquiv
+
+variable {F E : Type*} [Field F] [Field E] [Algebra F E]
+
+noncomputable def AlgEquiv.adjoinRootMinpolyPrimitiveElement {α : E}
+    (hα : IsIntegral F α) (hα₂ : F⟮α⟯ = ⊤) : AdjoinRoot (minpoly F α) ≃ₐ[F] E :=
+  (AlgEquiv.adjoinSingletonEquivAdjoinRootMinpoly F α).symm.trans <|
+  (Subalgebra.equivOfEq _ _ <| Algebra.adjoin_eq_top_of_primitive_element hα hα₂).trans
+  Subalgebra.topEquiv
+
+@[simp]
+theorem AlgEquiv.adjoinRootMinpolyPrimitiveElement_apply {α : E}
+    (hα : IsIntegral F α) (hα₂ : F⟮α⟯ = ⊤) (x) :
+    adjoinRootMinpolyPrimitiveElement hα hα₂ x = AdjoinRoot.Minpoly.toAdjoin F α x := rfl
+
+end algEquiv

--- a/Mathlib/FieldTheory/PrimitiveElement.lean
+++ b/Mathlib/FieldTheory/PrimitiveElement.lean
@@ -411,6 +411,10 @@ section algEquiv
 
 variable {F E : Type*} [Field F] [Field E] [Algebra F E]
 
+/-
+`F`-isomorphism between a field extension `E/F` and the quotient `F[X]⧸span {f}`, where `f` is
+the minimal polynomial over `F` of a primitive element in `E/F`.
+-/
 noncomputable def AlgEquiv.adjoinRootMinpolyPrimitiveElement {α : E}
     (hα : IsIntegral F α) (hα₂ : F⟮α⟯ = ⊤) : AdjoinRoot (minpoly F α) ≃ₐ[F] E :=
   (AlgEquiv.adjoinSingletonEquivAdjoinRootMinpoly F α).symm.trans <|


### PR DESCRIPTION
 Define the `F`-isomorphism between a field extension `E/F` and the quotient of `F[X]` by the ideal generated by the minimal polynomial of a primitive element in `E`

---

This PR is technically independent of #27278, but depends on that PR for the isomorphism defined here to have good `simp` properties.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
