### PR TITLE
refactor(OrderDual): make a one-field structure and remove defeq abuse

### DIFF
--- a/Mathlib/Algebra/Field/Basic.lean
+++ b/Mathlib/Algebra/Field/Basic.lean
@@ -7,7 +7,8 @@ import Mathlib.Algebra.Field.Defs
 import Mathlib.Algebra.Ring.GrindInstances
 import Mathlib.Algebra.Ring.Commute
 import Mathlib.Algebra.Ring.Invertible
-import Mathlib.Order.Synonym
+import Mathlib.Algebra.Order.Group.Synonym
+import Mathlib.Data.Nat.Cast.Synonym
 
 /-!
 # Lemmas about division (semi)rings and (semi)fields
@@ -279,11 +280,35 @@ end Function.Injective
 
 namespace OrderDual
 
-instance instRatCast [RatCast K] : RatCast Kᵒᵈ := ‹_›
-instance instDivisionSemiring [DivisionSemiring K] : DivisionSemiring Kᵒᵈ := ‹_›
-instance instDivisionRing [DivisionRing K] : DivisionRing Kᵒᵈ := ‹_›
-instance instSemifield [Semifield K] : Semifield Kᵒᵈ := ‹_›
-instance instField [Field K] : Field Kᵒᵈ := ‹_›
+instance instRatCast [RatCast K] : RatCast Kᵒᵈ where
+  ratCast q := toDual q
+
+instance instDivisionSemiring [DivisionSemiring K] : DivisionSemiring Kᵒᵈ where
+  left_distrib _ _ _ := congrArg toDual (left_distrib _ _ _)
+  right_distrib _ _ _ := congrArg toDual (right_distrib _ _ _)
+  zero_mul _ := congrArg toDual (zero_mul _)
+  mul_zero _ := congrArg toDual (mul_zero _)
+  inv_zero := congrArg toDual (inv_zero)
+  mul_inv_cancel _ h := congrArg toDual <| mul_inv_cancel₀ (h ∘ congrArg toDual)
+  nnqsmul q k := toDual (q • k.ofDual)
+  nnqsmul_def _ _ := congrArg toDual (DivisionSemiring.nnqsmul_def _ _)
+  nnratCast q := toDual q
+  nnratCast_def _ := congrArg toDual (DivisionSemiring.nnratCast_def _)
+
+instance instDivisionRing [DivisionRing K] : DivisionRing Kᵒᵈ where
+  __ : AddCommGroup (Kᵒᵈ) := inferInstance
+  __ : DivisionSemiring (Kᵒᵈ) := inferInstance
+  intCast z := toDual z
+  intCast_ofNat _ := congrArg toDual (Ring.intCast_ofNat _)
+  intCast_negSucc _ := congrArg toDual (Ring.intCast_negSucc _)
+  ratCast q := toDual q
+  ratCast_def q := congrArg toDual (DivisionRing.ratCast_def q)
+  qsmul q k := toDual (q • k.ofDual)
+  qsmul_def _ _ := congrArg toDual (DivisionRing.qsmul_def _ _)
+
+instance instSemifield [Semifield K] : Semifield Kᵒᵈ where
+
+instance instField [Field K] : Field Kᵒᵈ where
 
 end OrderDual
 

--- a/Mathlib/Algebra/Order/Group/Action/Synonym.lean
+++ b/Mathlib/Algebra/Order/Group/Action/Synonym.lean
@@ -22,34 +22,43 @@ variable {M N α : Type*}
 namespace OrderDual
 
 @[to_additive]
-instance instMulAction [Monoid M] [MulAction M α] : MulAction Mᵒᵈ α := ‹MulAction M α›
+instance instMulAction [Monoid M] [MulAction M α] : MulAction Mᵒᵈ α where
+  one_smul := one_smul M
+  mul_smul := (mul_smul ·.ofDual ·.ofDual)
 
 @[to_additive]
-instance instMulAction' [Monoid M] [MulAction M α] : MulAction M αᵒᵈ := ‹MulAction M α›
+instance instMulAction' [Monoid M] [MulAction M α] : MulAction M αᵒᵈ where
+  one_smul _ := congrArg toDual (one_smul _ _)
+  mul_smul _ _ _ := congrArg toDual (mul_smul _ _ _)
 
 @[to_additive]
-instance instSMulCommClass [SMul M α] [SMul N α] [SMulCommClass M N α] : SMulCommClass Mᵒᵈ N α :=
-  ‹SMulCommClass M N α›
+instance instSMulCommClass [SMul M α] [SMul N α] [SMulCommClass M N α] : SMulCommClass Mᵒᵈ N α where
+  smul_comm a := smul_comm a.ofDual
 
 @[to_additive]
-instance instSMulCommClass' [SMul M α] [SMul N α] [SMulCommClass M N α] : SMulCommClass M Nᵒᵈ α :=
-  ‹SMulCommClass M N α›
+instance instSMulCommClass' [SMul M α] [SMul N α] [SMulCommClass M N α] :
+    SMulCommClass M Nᵒᵈ α where
+  smul_comm a b := smul_comm a b.ofDual
 
 @[to_additive]
-instance instSMulCommClass'' [SMul M α] [SMul N α] [SMulCommClass M N α] : SMulCommClass M N αᵒᵈ :=
-  ‹SMulCommClass M N α›
+instance instSMulCommClass'' [SMul M α] [SMul N α] [SMulCommClass M N α] :
+    SMulCommClass M N αᵒᵈ where
+  smul_comm _ _ _:= congrArg toDual (smul_comm _ _ _)
 
 @[to_additive]
 instance instIsScalarTower [SMul M N] [SMul M α] [SMul N α] [IsScalarTower M N α] :
-    IsScalarTower Mᵒᵈ N α := ‹IsScalarTower M N α›
+    IsScalarTower Mᵒᵈ N α where
+  smul_assoc a := smul_assoc a.ofDual
 
 @[to_additive]
 instance instIsScalarTower' [SMul M N] [SMul M α] [SMul N α] [IsScalarTower M N α] :
-    IsScalarTower M Nᵒᵈ α := ‹IsScalarTower M N α›
+    IsScalarTower M Nᵒᵈ α where
+  smul_assoc a b := smul_assoc a b.ofDual
 
 @[to_additive]
 instance instIsScalarTower'' [SMul M N] [SMul M α] [SMul N α] [IsScalarTower M N α] :
-    IsScalarTower M N αᵒᵈ := ‹IsScalarTower M N α›
+    IsScalarTower M N αᵒᵈ where
+  smul_assoc _ _ _ := congrArg toDual (smul_assoc _ _ _)
 
 end OrderDual
 

--- a/Mathlib/Algebra/Order/Group/Synonym.lean
+++ b/Mathlib/Algebra/Order/Group/Synonym.lean
@@ -104,6 +104,10 @@ instance [InvolutiveInv α] : InvolutiveInv αᵒᵈ where
 
 @[to_additive]
 instance [DivInvMonoid α] : DivInvMonoid αᵒᵈ where
+  zpow z a := toDual (a.ofDual ^ z)
+  zpow_zero' _ := congrArg toDual (zpow_zero _)
+  zpow_succ' _ _ := congrArg toDual (DivInvMonoid.zpow_succ' _ _)
+  zpow_neg' _ _ := congrArg toDual (DivInvMonoid.zpow_neg' _ _)
   div_eq_mul_inv _ _ := congrArg toDual (div_eq_mul_inv _ _)
 
 @[to_additive]

--- a/Mathlib/Algebra/Order/Group/Synonym.lean
+++ b/Mathlib/Algebra/Order/Group/Synonym.lean
@@ -50,11 +50,11 @@ instance OrderDual.instPow' [h : Pow α β] : Pow α βᵒᵈ :=
 
 @[to_additive]
 instance [Semigroup α] : Semigroup αᵒᵈ where
-  mul_assoc a b c := congrArg toDual <| mul_assoc a.ofDual b.ofDual c.ofDual
+  mul_assoc _ _ _ := congrArg toDual <| mul_assoc ..
 
 @[to_additive]
 instance [CommSemigroup α] : CommSemigroup αᵒᵈ where
-  mul_comm a b := congrArg toDual <| mul_comm a.ofDual b.ofDual
+  mul_comm _ _ := congrArg toDual <| mul_comm ..
 
 @[to_additive]
 instance [Mul α] [IsLeftCancelMul α] : IsLeftCancelMul αᵒᵈ where
@@ -77,8 +77,8 @@ instance [RightCancelSemigroup α] : RightCancelSemigroup αᵒᵈ where
 
 @[to_additive]
 instance [MulOneClass α] : MulOneClass αᵒᵈ where
-  one_mul a := congrArg toDual (one_mul a.ofDual)
-  mul_one a := congrArg toDual (mul_one a.ofDual)
+  one_mul _ := congrArg toDual (one_mul _)
+  mul_one _ := congrArg toDual (mul_one _)
 
 @[to_additive]
 instance [Monoid α] : Monoid αᵒᵈ where
@@ -100,15 +100,15 @@ instance OrderDual.instCancelCommMonoid [h : CancelCommMonoid α] : CancelCommMo
 
 @[to_additive]
 instance [InvolutiveInv α] : InvolutiveInv αᵒᵈ where
-  inv_inv a := congrArg toDual (inv_inv a.ofDual)
+  inv_inv _ := congrArg toDual (inv_inv _)
 
 @[to_additive]
 instance [DivInvMonoid α] : DivInvMonoid αᵒᵈ where
-  div_eq_mul_inv a b := congrArg toDual (div_eq_mul_inv a.ofDual b.ofDual)
+  div_eq_mul_inv _ _ := congrArg toDual (div_eq_mul_inv _ _)
 
 @[to_additive]
 instance [DivisionMonoid α] : DivisionMonoid αᵒᵈ where
-  mul_inv_rev a b := congrArg toDual (mul_inv_rev a.ofDual b.ofDual)
+  mul_inv_rev _ _ := congrArg toDual (mul_inv_rev _ _)
   inv_eq_of_mul _ _ h := congrArg toDual (DivisionMonoid.inv_eq_of_mul _ _ (congrArg ofDual h))
 
 @[to_additive]
@@ -116,7 +116,7 @@ instance [DivisionCommMonoid α] : DivisionCommMonoid αᵒᵈ where
 
 @[to_additive]
 instance OrderDual.instGroup [Group α] : Group αᵒᵈ where
-  inv_mul_cancel a := congrArg toDual (inv_mul_cancel a.ofDual)
+  inv_mul_cancel _ := congrArg toDual (inv_mul_cancel _)
 
 @[to_additive]
 instance [CommGroup α] : CommGroup αᵒᵈ where

--- a/Mathlib/Algebra/Order/Group/Synonym.lean
+++ b/Mathlib/Algebra/Order/Group/Synonym.lean
@@ -21,82 +21,105 @@ variable {α β : Type*}
 
 
 @[to_additive]
-instance [h : One α] : One αᵒᵈ := h
+instance [h : One α] : One αᵒᵈ := ⟨toDual 1⟩
 
 @[to_additive]
-instance [h : Mul α] : Mul αᵒᵈ := h
+instance [h : Mul α] : Mul αᵒᵈ := ⟨fun a b => toDual (a.ofDual * b.ofDual)⟩
 
 @[to_additive]
-instance [h : Inv α] : Inv αᵒᵈ := h
+instance [h : Inv α] : Inv αᵒᵈ := ⟨fun a => toDual a.ofDual⁻¹⟩
 
 @[to_additive]
-instance [h : Div α] : Div αᵒᵈ := h
-
-@[to_additive (attr := to_additive) (reorder := 1 2) OrderDual.instSMul]
-instance OrderDual.instPow [h : Pow α β] : Pow αᵒᵈ β := h
-
-@[to_additive (attr := to_additive) (reorder := 1 2) OrderDual.instSMul']
-instance OrderDual.instPow' [h : Pow α β] : Pow α βᵒᵈ := h
+instance [h : Div α] : Div αᵒᵈ := ⟨fun a b => toDual (a.ofDual / b.ofDual)⟩
 
 @[to_additive]
-instance [h : Semigroup α] : Semigroup αᵒᵈ := h
+instance OrderDual.instSMul [SMul α β] : SMul α βᵒᵈ :=
+  ⟨fun a b => toDual (a • b.ofDual)⟩
+
+@[to_additive existing (reorder := 1 2) OrderDual.instSMul]
+instance OrderDual.instPow [Pow α β] : Pow αᵒᵈ β :=
+  ⟨fun a b => toDual (a.ofDual ^ b)⟩
 
 @[to_additive]
-instance [h : CommSemigroup α] : CommSemigroup αᵒᵈ := h
+instance OrderDual.instSMul' [SMul α β] : SMul αᵒᵈ β :=
+  ⟨fun a b => (a.ofDual' • b)⟩
+
+@[to_additive existing (reorder := 1 2) OrderDual.instSMul']
+instance OrderDual.instPow' [h : Pow α β] : Pow α βᵒᵈ :=
+  ⟨fun a b => (a ^ b.ofDual)⟩
 
 @[to_additive]
-instance [Mul α] [h : IsLeftCancelMul α] : IsLeftCancelMul αᵒᵈ := h
+instance [Semigroup α] : Semigroup αᵒᵈ where
+  mul_assoc a b c := congrArg toDual <| mul_assoc a.ofDual b.ofDual c.ofDual
 
 @[to_additive]
-instance [Mul α] [h : IsRightCancelMul α] : IsRightCancelMul αᵒᵈ := h
+instance [CommSemigroup α] : CommSemigroup αᵒᵈ where
+  mul_comm a b := congrArg toDual <| mul_comm a.ofDual b.ofDual
 
 @[to_additive]
-instance [Mul α] [h : IsCancelMul α] : IsCancelMul αᵒᵈ := h
+instance [Mul α] [IsLeftCancelMul α] : IsLeftCancelMul αᵒᵈ where
+  mul_left_cancel _ _ _ h := (congrArg toDual <| mul_left_cancel <| congrArg ofDual h)
 
 @[to_additive]
-instance [h : LeftCancelSemigroup α] : LeftCancelSemigroup αᵒᵈ := h
+instance [Mul α] [IsRightCancelMul α] : IsRightCancelMul αᵒᵈ where
+  mul_right_cancel _ _ _ h := (congrArg toDual <| mul_right_cancel <| congrArg ofDual h)
 
 @[to_additive]
-instance [h : RightCancelSemigroup α] : RightCancelSemigroup αᵒᵈ := h
+instance [Mul α] [IsCancelMul α] : IsCancelMul αᵒᵈ where
 
 @[to_additive]
-instance [h : MulOneClass α] : MulOneClass αᵒᵈ := h
+instance [LeftCancelSemigroup α] : LeftCancelSemigroup αᵒᵈ where
+  __ := inferInstanceAs (IsLeftCancelMul αᵒᵈ)
 
 @[to_additive]
-instance [h : Monoid α] : Monoid αᵒᵈ := h
+instance [RightCancelSemigroup α] : RightCancelSemigroup αᵒᵈ where
+  __ := inferInstanceAs (IsRightCancelMul αᵒᵈ)
 
 @[to_additive]
-instance OrderDual.instCommMonoid [h : CommMonoid α] : CommMonoid αᵒᵈ := h
+instance [MulOneClass α] : MulOneClass αᵒᵈ where
+  one_mul a := congrArg toDual (one_mul a.ofDual)
+  mul_one a := congrArg toDual (mul_one a.ofDual)
 
 @[to_additive]
-instance [h : LeftCancelMonoid α] : LeftCancelMonoid αᵒᵈ := h
+instance [Monoid α] : Monoid αᵒᵈ where
 
 @[to_additive]
-instance [h : RightCancelMonoid α] : RightCancelMonoid αᵒᵈ := h
+instance OrderDual.instCommMonoid [CommMonoid α] : CommMonoid αᵒᵈ where
 
 @[to_additive]
-instance [h : CancelMonoid α] : CancelMonoid αᵒᵈ := h
+instance [LeftCancelMonoid α] : LeftCancelMonoid αᵒᵈ where
 
 @[to_additive]
-instance OrderDual.instCancelCommMonoid [h : CancelCommMonoid α] : CancelCommMonoid αᵒᵈ := h
+instance [RightCancelMonoid α] : RightCancelMonoid αᵒᵈ where
 
 @[to_additive]
-instance [h : InvolutiveInv α] : InvolutiveInv αᵒᵈ := h
+instance [CancelMonoid α] : CancelMonoid αᵒᵈ where
 
 @[to_additive]
-instance [h : DivInvMonoid α] : DivInvMonoid αᵒᵈ := h
+instance OrderDual.instCancelCommMonoid [h : CancelCommMonoid α] : CancelCommMonoid αᵒᵈ where
 
 @[to_additive]
-instance [h : DivisionMonoid α] : DivisionMonoid αᵒᵈ := h
+instance [InvolutiveInv α] : InvolutiveInv αᵒᵈ where
+  inv_inv a := congrArg toDual (inv_inv a.ofDual)
 
 @[to_additive]
-instance [h : DivisionCommMonoid α] : DivisionCommMonoid αᵒᵈ := h
+instance [DivInvMonoid α] : DivInvMonoid αᵒᵈ where
+  div_eq_mul_inv a b := congrArg toDual (div_eq_mul_inv a.ofDual b.ofDual)
 
 @[to_additive]
-instance OrderDual.instGroup [h : Group α] : Group αᵒᵈ := h
+instance [DivisionMonoid α] : DivisionMonoid αᵒᵈ where
+  mul_inv_rev a b := congrArg toDual (mul_inv_rev a.ofDual b.ofDual)
+  inv_eq_of_mul _ _ h := congrArg toDual (DivisionMonoid.inv_eq_of_mul _ _ (congrArg ofDual h))
 
 @[to_additive]
-instance [h : CommGroup α] : CommGroup αᵒᵈ := h
+instance [DivisionCommMonoid α] : DivisionCommMonoid αᵒᵈ where
+
+@[to_additive]
+instance OrderDual.instGroup [Group α] : Group αᵒᵈ where
+  inv_mul_cancel a := congrArg toDual (inv_mul_cancel a.ofDual)
+
+@[to_additive]
+instance [CommGroup α] : CommGroup αᵒᵈ where
 
 @[to_additive (attr := simp)]
 theorem toDual_one [One α] : toDual (1 : α) = 1 := rfl

--- a/Mathlib/Algebra/Order/GroupWithZero/Action/Synonym.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Action/Synonym.lean
@@ -23,29 +23,46 @@ variable {G₀ M₀ : Type*}
 
 namespace OrderDual
 
-instance instSMulWithZero [Zero G₀] [Zero M₀] [SMulWithZero G₀ M₀] : SMulWithZero G₀ᵒᵈ M₀ :=
-  ‹SMulWithZero G₀ M₀›
+instance instSMulWithZero [Zero G₀] [Zero M₀] [SMulWithZero G₀ M₀] : SMulWithZero G₀ᵒᵈ M₀ where
+  smul_zero _ := smul_zero (M := G₀) _
+  zero_smul := zero_smul (M₀ := G₀)
 
-instance instSMulWithZero' [Zero G₀] [Zero M₀] [SMulWithZero G₀ M₀] : SMulWithZero G₀ M₀ᵒᵈ :=
-  ‹SMulWithZero G₀ M₀›
+instance instSMulWithZero' [Zero G₀] [Zero M₀] [SMulWithZero G₀ M₀] : SMulWithZero G₀ M₀ᵒᵈ where
+  smul_zero _ := congrArg toDual (smul_zero _)
+  zero_smul _ := congrArg toDual (zero_smul _ _)
 
-instance instDistribSMul [AddZeroClass M₀] [DistribSMul G₀ M₀] : DistribSMul G₀ᵒᵈ M₀ :=
-  ‹DistribSMul G₀ M₀›
+instance instDistribSMul [AddZeroClass M₀] [DistribSMul G₀ M₀] : DistribSMul G₀ᵒᵈ M₀ where
+  smul_zero _ := smul_zero (M := G₀) _
+  smul_add a := smul_add a.ofDual
 
-instance instDistribSMul' [AddZeroClass M₀] [DistribSMul G₀ M₀] : DistribSMul G₀ M₀ᵒᵈ :=
-  ‹DistribSMul G₀ M₀›
+instance instDistribSMul' [AddZeroClass M₀] [DistribSMul G₀ M₀] : DistribSMul G₀ M₀ᵒᵈ where
+  smul_zero _ := congrArg toDual (smul_zero _)
+  smul_add _ _ _ := congrArg toDual (smul_add _ _ _)
 
 instance instDistribMulAction [Monoid G₀] [AddMonoid M₀] [DistribMulAction G₀ M₀] :
-    DistribMulAction G₀ᵒᵈ M₀ := ‹DistribMulAction G₀ M₀›
+    DistribMulAction G₀ᵒᵈ M₀ where
+  __ : DistribSMul G₀ᵒᵈ M₀ := inferInstance
+  one_smul := one_smul (M := G₀)
+  mul_smul _ _ := mul_smul (α := G₀) _ _
+
 
 instance instDistribMulAction' [Monoid G₀] [AddMonoid M₀] [DistribMulAction G₀ M₀] :
-    DistribMulAction G₀ M₀ᵒᵈ := ‹DistribMulAction G₀ M₀›
+    DistribMulAction G₀ M₀ᵒᵈ where
+  __ : DistribSMul G₀ M₀ᵒᵈ := inferInstance
+  one_smul _ := congrArg toDual (one_smul _ _)
+  mul_smul _ _ _ := congrArg toDual (mul_smul _ _ _)
 
 instance instMulActionWithZero [MonoidWithZero G₀] [AddMonoid M₀] [MulActionWithZero G₀ M₀] :
-    MulActionWithZero G₀ᵒᵈ M₀ := ‹MulActionWithZero G₀ M₀›
+    MulActionWithZero G₀ᵒᵈ M₀ where
+  __ : SMulWithZero G₀ᵒᵈ M₀ := inferInstance
+  one_smul := one_smul (M := G₀)
+  mul_smul _ _ := mul_smul (α := G₀) _ _
 
 instance instMulActionWithZero' [MonoidWithZero G₀] [AddMonoid M₀] [MulActionWithZero G₀ M₀] :
-    MulActionWithZero G₀ M₀ᵒᵈ := ‹MulActionWithZero G₀ M₀›
+    MulActionWithZero G₀ M₀ᵒᵈ where
+  __ : SMulWithZero G₀ M₀ᵒᵈ := inferInstance
+  one_smul _ := congrArg toDual (one_smul _ _)
+  mul_smul _ _ _ := congrArg toDual (mul_smul _ _ _)
 
 end OrderDual
 

--- a/Mathlib/Algebra/Order/GroupWithZero/Synonym.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Synonym.lean
@@ -23,25 +23,37 @@ variable {α : Type*}
 
 open OrderDual
 
-instance [h : MulZeroClass α] : MulZeroClass αᵒᵈ := h
+instance [MulZeroClass α] : MulZeroClass αᵒᵈ where
+  mul_zero _ := congrArg toDual (mul_zero _)
+  zero_mul _ := congrArg toDual (zero_mul _)
 
-instance [h : MulZeroOneClass α] : MulZeroOneClass αᵒᵈ := h
+instance [MulZeroOneClass α] : MulZeroOneClass αᵒᵈ where
+  one_mul _ := congrArg toDual (one_mul _)
+  mul_one _ := congrArg toDual (mul_one _)
 
-instance [Mul α] [Zero α] [h : NoZeroDivisors α] : NoZeroDivisors αᵒᵈ := h
+instance [Mul α] [Zero α] [NoZeroDivisors α] : NoZeroDivisors αᵒᵈ where
+  eq_zero_or_eq_zero_of_mul_eq_zero h :=
+    (eq_zero_or_eq_zero_of_mul_eq_zero (congrArg ofDual h)).imp (congrArg toDual) (congrArg toDual)
 
-instance [h : SemigroupWithZero α] : SemigroupWithZero αᵒᵈ := h
+instance [SemigroupWithZero α] : SemigroupWithZero αᵒᵈ where
 
-instance [h : MonoidWithZero α] : MonoidWithZero αᵒᵈ := h
+instance [MonoidWithZero α] : MonoidWithZero αᵒᵈ where
 
-instance [h : CancelMonoidWithZero α] : CancelMonoidWithZero αᵒᵈ := h
+instance [CancelMonoidWithZero α] : CancelMonoidWithZero αᵒᵈ where
+  mul_left_cancel_of_ne_zero hzero h :=
+    congrArg toDual (mul_left_cancel₀ (hzero ∘ congrArg toDual) (congrArg ofDual h))
+  mul_right_cancel_of_ne_zero hzero h :=
+    congrArg toDual (mul_right_cancel₀ (hzero ∘ congrArg toDual) (congrArg ofDual h))
 
-instance [h : CommMonoidWithZero α] : CommMonoidWithZero αᵒᵈ := h
+instance [CommMonoidWithZero α] : CommMonoidWithZero αᵒᵈ where
 
-instance [h : CancelCommMonoidWithZero α] : CancelCommMonoidWithZero αᵒᵈ := h
+instance [CancelCommMonoidWithZero α] : CancelCommMonoidWithZero αᵒᵈ where
 
-instance [h : GroupWithZero α] : GroupWithZero αᵒᵈ := h
+instance [GroupWithZero α] : GroupWithZero αᵒᵈ where
+  inv_zero := congrArg toDual (inv_zero)
+  mul_inv_cancel _ h := congrArg toDual (mul_inv_cancel₀ (h ∘ congrArg toDual))
 
-instance [h : CommGroupWithZero α] : CommGroupWithZero αᵒᵈ := h
+instance [CommGroupWithZero α] : CommGroupWithZero αᵒᵈ where
 
 /-! ### Lexicographic order -/
 

--- a/Mathlib/Algebra/Order/Module/Synonym.lean
+++ b/Mathlib/Algebra/Order/Module/Synonym.lean
@@ -25,11 +25,11 @@ variable {α β : Type*}
 namespace OrderDual
 
 instance instModule [Semiring α] [AddCommMonoid β] [Module α β] : Module αᵒᵈ β where
-  add_smul := add_smul (R := α)
+  add_smul _ _ := add_smul (R := α) _ _
   zero_smul := zero_smul _
 
 instance instModule' [Semiring α] [AddCommMonoid β] [Module α β] : Module α βᵒᵈ where
-  add_smul := add_smul (M := β)
+  add_smul _ _ _ := congrArg toDual (add_smul _ _ _)
   zero_smul := zero_smul _
 
 end OrderDual

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/OrderDual.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/OrderDual.lean
@@ -18,34 +18,34 @@ namespace OrderDual
 
 @[to_additive]
 instance mulLeftReflectLE [LE α] [Mul α] [c : MulLeftReflectLE α] : MulLeftReflectLE αᵒᵈ :=
-  ⟨c.1.flip⟩
+  ⟨fun a => c.elim a.ofDual⟩
 
 @[to_additive]
 instance mulLeftMono [LE α] [Mul α] [c : MulLeftMono α] : MulLeftMono αᵒᵈ :=
-  ⟨c.1.flip⟩
+  ⟨fun a => c.elim a.ofDual⟩
 
 @[to_additive]
 instance mulRightReflectLE [LE α] [Mul α] [c : MulRightReflectLE α] : MulRightReflectLE αᵒᵈ :=
-  ⟨c.1.flip⟩
+  ⟨fun a => c.elim a.ofDual⟩
 
 @[to_additive]
 instance mulRightMono [LE α] [Mul α] [c : MulRightMono α] : MulRightMono αᵒᵈ :=
-  ⟨c.1.flip⟩
+  ⟨fun a => c.elim a.ofDual⟩
 
 @[to_additive]
 instance mulLeftReflectLT [LT α] [Mul α] [c : MulLeftReflectLT α] : MulLeftReflectLT αᵒᵈ :=
-  ⟨c.1.flip⟩
+  ⟨fun a => c.elim a.ofDual⟩
 
 @[to_additive]
 instance mulLeftStrictMono [LT α] [Mul α] [c : MulLeftStrictMono α] : MulLeftStrictMono αᵒᵈ :=
-  ⟨c.1.flip⟩
+  ⟨fun a => c.elim a.ofDual⟩
 
 @[to_additive]
 instance mulRightReflectLT [LT α] [Mul α] [c : MulRightReflectLT α] : MulRightReflectLT αᵒᵈ :=
-  ⟨c.1.flip⟩
+  ⟨fun a => c.elim a.ofDual⟩
 
 @[to_additive]
 instance mulRightStrictMono [LT α] [Mul α] [c : MulRightStrictMono α] : MulRightStrictMono αᵒᵈ :=
-  ⟨c.1.flip⟩
+  ⟨fun a => c.elim a.ofDual⟩
 
 end OrderDual

--- a/Mathlib/Algebra/Order/Ring/Synonym.lean
+++ b/Mathlib/Algebra/Order/Ring/Synonym.lean
@@ -18,39 +18,61 @@ variable {R : Type*}
 /-! ### Order dual -/
 
 
-instance [h : Distrib R] : Distrib Rᵒᵈ := h
+instance [Distrib R] : Distrib Rᵒᵈ where
+  left_distrib _ _ _ := congrArg OrderDual.toDual (left_distrib _ _ _)
+  right_distrib _ _ _ := congrArg OrderDual.toDual (right_distrib _ _ _)
 
-instance [Mul R] [Add R] [h : LeftDistribClass R] : LeftDistribClass Rᵒᵈ := h
+instance [Mul R] [Add R] [LeftDistribClass R] : LeftDistribClass Rᵒᵈ where
+  left_distrib _ _ _ := congrArg OrderDual.toDual (left_distrib _ _ _)
 
-instance [Mul R] [Add R] [h : RightDistribClass R] : RightDistribClass Rᵒᵈ := h
+instance [Mul R] [Add R] [RightDistribClass R] : RightDistribClass Rᵒᵈ where
+  right_distrib _ _ _ := congrArg OrderDual.toDual (right_distrib _ _ _)
 
-instance [h : NonUnitalNonAssocSemiring R] : NonUnitalNonAssocSemiring Rᵒᵈ := h
+instance [NonUnitalNonAssocSemiring R] : NonUnitalNonAssocSemiring Rᵒᵈ where
+  zero_add _ := congrArg OrderDual.toDual (zero_add _)
+  add_zero _ := congrArg OrderDual.toDual (add_zero _)
+  nsmul n r := .toDual (n • r.ofDual)
+  nsmul_zero _ := congrArg OrderDual.toDual (zero_nsmul _)
+  nsmul_succ _ _ := congrArg OrderDual.toDual (AddMonoid.nsmul_succ _ _)
+  zero_mul _ := congrArg OrderDual.toDual (zero_mul _)
+  mul_zero _ := congrArg OrderDual.toDual (mul_zero _)
 
-instance [h : NonUnitalSemiring R] : NonUnitalSemiring Rᵒᵈ := h
+instance [NonUnitalSemiring R] : NonUnitalSemiring Rᵒᵈ where
 
-instance [h : NonAssocSemiring R] : NonAssocSemiring Rᵒᵈ := h
+instance [NonAssocSemiring R] : NonAssocSemiring Rᵒᵈ where
 
-instance [h : Semiring R] : Semiring Rᵒᵈ := h
+instance [Semiring R] : Semiring Rᵒᵈ where
 
-instance [h : NonUnitalCommSemiring R] : NonUnitalCommSemiring Rᵒᵈ := h
+instance [NonUnitalCommSemiring R] : NonUnitalCommSemiring Rᵒᵈ where
 
-instance [h : CommSemiring R] : CommSemiring Rᵒᵈ := h
+instance [CommSemiring R] : CommSemiring Rᵒᵈ where
 
-instance [Mul R] [h : HasDistribNeg R] : HasDistribNeg Rᵒᵈ := h
+instance [Mul R] [HasDistribNeg R] : HasDistribNeg Rᵒᵈ where
+  neg_mul _ _ := congrArg OrderDual.toDual (neg_mul _ _)
+  mul_neg _ _ := congrArg OrderDual.toDual (mul_neg _ _)
 
-instance [h : NonUnitalNonAssocRing R] : NonUnitalNonAssocRing Rᵒᵈ := h
+instance [NonUnitalNonAssocRing R] : NonUnitalNonAssocRing Rᵒᵈ where
 
-instance [h : NonUnitalRing R] : NonUnitalRing Rᵒᵈ := h
+instance [NonUnitalRing R] : NonUnitalRing Rᵒᵈ where
 
-instance [h : NonAssocRing R] : NonAssocRing Rᵒᵈ := h
+instance [NonAssocRing R] : NonAssocRing Rᵒᵈ where
 
-instance [h : Ring R] : Ring Rᵒᵈ := h
+instance [Ring R] : Ring Rᵒᵈ where
+  __ : Semiring (Rᵒᵈ) := inferInstance
+  __ : AddGroup (Rᵒᵈ) := inferInstance
 
-instance [h : NonUnitalCommRing R] : NonUnitalCommRing Rᵒᵈ := h
+instance [NonUnitalCommRing R] : NonUnitalCommRing Rᵒᵈ where
 
-instance [h : CommRing R] : CommRing Rᵒᵈ := h
+instance [CommRing R] : CommRing Rᵒᵈ where
 
-instance [Ring R] [h : IsDomain R] : IsDomain Rᵒᵈ := h
+instance [Ring R] [IsDomain R] : IsDomain Rᵒᵈ where
+  mul_left_cancel_of_ne_zero hzero h :=
+    congrArg OrderDual.toDual (mul_left_cancel₀ (hzero ∘ congrArg OrderDual.toDual)
+      (congrArg OrderDual.ofDual h))
+  mul_right_cancel_of_ne_zero hzero h :=
+    congrArg OrderDual.toDual (mul_right_cancel₀ (hzero ∘ congrArg OrderDual.toDual)
+      (congrArg OrderDual.ofDual h))
+
 
 /-! ### Lexicographical order -/
 

--- a/Mathlib/Data/Nat/Cast/Synonym.lean
+++ b/Mathlib/Data/Nat/Cast/Synonym.lean
@@ -20,14 +20,27 @@ variable {α : Type*}
 
 open OrderDual
 
-instance [h : NatCast α] : NatCast αᵒᵈ :=
-  h
+instance [NatCast α] : NatCast αᵒᵈ where
+  natCast n := toDual n
 
-instance [h : AddMonoidWithOne α] : AddMonoidWithOne αᵒᵈ :=
-  h
+-- maybe these algebra instances should be found by importing the
+-- Algebra.Order.Group.Synonym file? there, a bunch of to-additive things exist
+-- which allows us to not repeat these definitions
+instance [AddMonoidWithOne α] : AddMonoidWithOne αᵒᵈ where
+  add a b := toDual (a.ofDual + b.ofDual)
+  add_assoc _ _ _ := congrArg toDual (add_assoc _ _ _)
+  zero := toDual 0
+  zero_add _ := congrArg toDual (zero_add _)
+  add_zero _ := congrArg toDual (add_zero _)
+  nsmul n a := toDual (n • a.ofDual)
+  nsmul_zero _ := congrArg toDual (zero_nsmul _)
+  nsmul_succ _ _ := congrArg toDual (succ_nsmul _ _)
+  one := toDual 1
+  natCast_zero := congrArg toDual AddMonoidWithOne.natCast_zero
+  natCast_succ _ := congrArg toDual (AddMonoidWithOne.natCast_succ _)
 
-instance [h : AddCommMonoidWithOne α] : AddCommMonoidWithOne αᵒᵈ :=
-  h
+instance [AddCommMonoidWithOne α] : AddCommMonoidWithOne αᵒᵈ where
+  add_comm _ _ := congrArg toDual (add_comm _ _)
 
 @[simp]
 theorem toDual_natCast [NatCast α] (n : ℕ) : toDual (n : α) = n :=

--- a/Mathlib/Logic/Function/Iterate.lean
+++ b/Mathlib/Logic/Function/Iterate.lean
@@ -92,6 +92,14 @@ theorem iterate_invariant {g : α → β} (h : g ∘ f = g) (n : ℕ) : g ∘ f^
   | 0 => rfl
   | m + 1 => by rwa [show  g ∘ f^[m + 1] = (g ∘ f^[m]) ∘ f  by rfl, iterate_invariant h m]
 
+theorem comp_iterate_comp {f : α → β} {g : β → α} (n : ℕ) : (f ∘ g)^[n] ∘ f = f ∘ (g ∘ f)^[n] := by
+  induction n with
+  | zero => rfl
+  | succ n ih => rw [iterate_succ,iterate_succ,← comp_assoc _ f g,ih]; rfl
+
+theorem iterate_comp {f : α → β} {g : β → α} (n : ℕ) : (f ∘ g)^[n + 1] = f ∘ (g ∘ f)^[n] ∘ g := by
+  rw [← comp_assoc,← comp_iterate_comp,comp_assoc,iterate_succ]
+
 theorem Injective.iterate (Hinj : Injective f) (n : ℕ) : Injective f^[n] :=
   Nat.recOn n injective_id fun _ ihn ↦ ihn.comp Hinj
 

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -723,7 +723,7 @@ lemma LinearOrder.ext_lt {A B : LinearOrder α} (H : ∀ x y : α, (haveI := A; 
 /-- Type synonym to equip a type with the dual order: `≤` means `≥` and `<` means `>`. `αᵒᵈ` is
 notation for `OrderDual α`. -/
 structure OrderDual (α : Type*) where
-  toDual :: (ofDual : α)
+  toDual' :: (ofDual' : α)
 
 @[inherit_doc]
 notation:max α "ᵒᵈ" => OrderDual α
@@ -731,25 +731,25 @@ notation:max α "ᵒᵈ" => OrderDual α
 namespace OrderDual
 
 instance (α : Type*) [h : Nonempty α] : Nonempty αᵒᵈ :=
-  h.map toDual
+  h.map toDual'
 
 instance (α : Type*) [h : Subsingleton α] : Subsingleton αᵒᵈ where
   allEq := fun ⟨a⟩ ⟨b⟩ => by rw [h.allEq a b]
 
 instance (α : Type*) [LE α] : LE αᵒᵈ :=
-  ⟨fun x y ↦ y.ofDual ≤ x.ofDual⟩
+  ⟨fun x y ↦ y.ofDual' ≤ x.ofDual'⟩
 
 instance (α : Type*) [LT α] : LT αᵒᵈ :=
-  ⟨fun x y ↦ y.ofDual < x.ofDual⟩
+  ⟨fun x y ↦ y.ofDual' < x.ofDual'⟩
 
 instance instOrd (α : Type*) [Ord α] : Ord αᵒᵈ where
-  compare := fun a b ↦ compare b.ofDual a.ofDual
+  compare := fun a b ↦ compare b.ofDual' a.ofDual'
 
 instance instSup (α : Type*) [Min α] : Max αᵒᵈ :=
-  ⟨(toDual <| ·.ofDual ⊓ ·.ofDual)⟩
+  ⟨(toDual' <| ·.ofDual' ⊓ ·.ofDual')⟩
 
 instance instInf (α : Type*) [Max α] : Min αᵒᵈ :=
-  ⟨(toDual <| ·.ofDual ⊔ ·.ofDual)⟩
+  ⟨(toDual' <| ·.ofDual' ⊔ ·.ofDual')⟩
 
 instance instPreorder (α : Type*) [Preorder α] : Preorder αᵒᵈ where
   le_refl := fun _ ↦ le_refl _
@@ -758,23 +758,24 @@ instance instPreorder (α : Type*) [Preorder α] : Preorder αᵒᵈ where
 
 instance instPartialOrder (α : Type*) [PartialOrder α] : PartialOrder αᵒᵈ where
   __ := inferInstanceAs (Preorder αᵒᵈ)
-  le_antisymm := fun a b hab hba ↦ congrArg toDual (@le_antisymm α _ a.ofDual b.ofDual hba hab)
+  le_antisymm := fun a b hab hba ↦ congrArg toDual' (@le_antisymm α _ a.ofDual' b.ofDual' hba hab)
 
 instance instLinearOrder (α : Type*) [LinearOrder α] : LinearOrder αᵒᵈ where
   __ := inferInstanceAs (PartialOrder αᵒᵈ)
   __ := inferInstanceAs (Ord αᵒᵈ)
   le_total := fun ⟨a⟩ ⟨b⟩ ↦ le_total b a
   min_def :=
-    fun ⟨a⟩ ⟨b⟩ ↦ show toDual (max a b) = _ by rw [max_comm, max_def, apply_ite toDual]; rfl
+    fun ⟨a⟩ ⟨b⟩ ↦ show toDual' (max a b) = _ by rw [max_comm, max_def, apply_ite toDual']; rfl
   max_def :=
-    fun ⟨a⟩ ⟨b⟩ ↦ show toDual (min a b) = _ by rw [min_comm, min_def,apply_ite toDual]; rfl
-  toDecidableLE a b := inferInstanceAs (Decidable (b.ofDual ≤ a.ofDual))
-  toDecidableLT a b := inferInstanceAs (Decidable (b.ofDual < a.ofDual))
-  toDecidableEq a b := decidable_of_iff (a.ofDual = b.ofDual) (⟨congrArg toDual,congrArg ofDual⟩)
+    fun ⟨a⟩ ⟨b⟩ ↦ show toDual' (min a b) = _ by rw [min_comm, min_def,apply_ite toDual']; rfl
+  toDecidableLE a b := inferInstanceAs (Decidable (b.ofDual' ≤ a.ofDual'))
+  toDecidableLT a b := inferInstanceAs (Decidable (b.ofDual' < a.ofDual'))
+  toDecidableEq a b := decidable_of_iff (a.ofDual' = b.ofDual')
+    (⟨congrArg toDual',congrArg ofDual'⟩)
   compare_eq_compareOfLessAndEq a b := by
     simp only [compare, LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq, eq_comm]
     convert rfl
-    exact ⟨congrArg ofDual,congrArg toDual⟩
+    exact ⟨congrArg ofDual',congrArg toDual'⟩
 
 -- #check LinearOrder
 /-- The opposite linear order to a given linear order -/
@@ -799,7 +800,7 @@ def _root_.LinearOrder.swap (α : Type*) (_ : LinearOrder α) : LinearOrder α w
   -- inferInstanceAs <| LinearOrder (OrderDual α)
 
 instance [Inhabited α] : Inhabited αᵒᵈ where
-  default := .toDual default
+  default := toDual' default
 
 -- theorem Ord.dual_dual (α : Type*) [H : Ord α] : OrderDual.instOrd αᵒᵈ = H :=
 --   rfl
@@ -1269,11 +1270,11 @@ theorem exists_between [LT α] [DenselyOrdered α] : ∀ {a₁ a₂ : α}, a₁ 
 
 instance OrderDual.denselyOrdered (α : Type*) [LT α] [h : DenselyOrdered α] :
     DenselyOrdered αᵒᵈ :=
-  ⟨fun _ _ ha ↦ (@exists_between α _ h _ _ ha).elim fun a h ↦ ⟨toDual a, h.symm⟩⟩
+  ⟨fun _ _ ha ↦ (@exists_between α _ h _ _ ha).elim fun a h ↦ ⟨toDual' a, h.symm⟩⟩
 
 @[simp]
 theorem denselyOrdered_orderDual [LT α] : DenselyOrdered αᵒᵈ ↔ DenselyOrdered α :=
-  ⟨fun h => ⟨fun _ _ ha ↦ (@exists_between αᵒᵈ _ h _ _ ha).elim fun a h ↦ ⟨a.ofDual, h.symm⟩⟩,
+  ⟨fun h => ⟨fun _ _ ha ↦ (@exists_between αᵒᵈ _ h _ _ ha).elim fun a h ↦ ⟨a.ofDual', h.symm⟩⟩,
     @OrderDual.denselyOrdered α _⟩
 
 /-- Any ordered subsingleton is densely ordered. Not an instance to avoid a heavy subsingleton

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -777,7 +777,6 @@ instance instLinearOrder (α : Type*) [LinearOrder α] : LinearOrder αᵒᵈ wh
     convert rfl
     exact ⟨congrArg ofDual',congrArg toDual'⟩
 
--- #check LinearOrder
 /-- The opposite linear order to a given linear order -/
 def _root_.LinearOrder.swap (α : Type*) (_ : LinearOrder α) : LinearOrder α where
   le a b := b ≤ a
@@ -797,24 +796,9 @@ def _root_.LinearOrder.swap (α : Type*) (_ : LinearOrder α) : LinearOrder α w
   compare_eq_compareOfLessAndEq a b := by
     simp only [LinearOrder.compare_eq_compareOfLessAndEq, compareOfLessAndEq, eq_comm]
     convert rfl
-  -- inferInstanceAs <| LinearOrder (OrderDual α)
 
 instance [Inhabited α] : Inhabited αᵒᵈ where
   default := toDual' default
-
--- theorem Ord.dual_dual (α : Type*) [H : Ord α] : OrderDual.instOrd αᵒᵈ = H :=
---   rfl
-
--- theorem Preorder.dual_dual (α : Type*) [H : Preorder α] : OrderDual.instPreorder αᵒᵈ = H :=
---   rfl
-
--- theorem instPartialOrder.dual_dual (α : Type*) [H : PartialOrder α] :
---     OrderDual.instPartialOrder αᵒᵈ = H :=
---   rfl
-
--- theorem instLinearOrder.dual_dual (α : Type*) [H : LinearOrder α] :
---     OrderDual.instLinearOrder αᵒᵈ = H :=
---   rfl
 
 end OrderDual
 

--- a/Mathlib/Order/BoundedOrder/Basic.lean
+++ b/Mathlib/Order/BoundedOrder/Basic.lean
@@ -218,18 +218,18 @@ namespace OrderDual
 variable (α)
 
 instance instTop [Bot α] : Top αᵒᵈ :=
-  ⟨(⊥ : α)⟩
+  ⟨toDual ⊥⟩
 
 instance instBot [Top α] : Bot αᵒᵈ :=
-  ⟨(⊤ : α)⟩
+  ⟨toDual ⊤⟩
 
 instance instOrderTop [LE α] [OrderBot α] : OrderTop αᵒᵈ where
   __ := inferInstanceAs (Top αᵒᵈ)
-  le_top := @bot_le α _ _
+  le_top a := bot_le (a := a.ofDual)
 
 instance instOrderBot [LE α] [OrderTop α] : OrderBot αᵒᵈ where
   __ := inferInstanceAs (Bot αᵒᵈ)
-  bot_le := @le_top α _ _
+  bot_le a := le_top (a := a.ofDual)
 
 @[simp]
 theorem ofDual_bot [Top α] : ofDual ⊥ = (⊤ : α) :=
@@ -328,15 +328,16 @@ theorem Ne.bot_lt' (h : ⊥ ≠ a) : ⊥ < a :=
 theorem ne_bot_of_le_ne_bot (hb : b ≠ ⊥) (hab : b ≤ a) : a ≠ ⊥ :=
   (hb.bot_lt.trans_le hab).ne'
 
+-- this would be a lot easier if we imported Data.Set.Operations
 lemma bot_notMem_iff {s : Set α} : ⊥ ∉ s ↔ ∀ x ∈ s, ⊥ < x :=
-  top_notMem_iff (α := αᵒᵈ)
+  (top_notMem_iff (s := s ∘ ofDual)).trans ⟨fun h a => h (toDual a),fun h a => h (a.ofDual)⟩
 
 @[deprecated (since := "2025-05-23")] alias bot_not_mem_iff := bot_notMem_iff
 
 variable [Nontrivial α]
 
 theorem not_isMax_bot : ¬IsMax (⊥ : α) :=
-  @not_isMin_top αᵒᵈ _ _ _
+  fun h => @not_isMin_top αᵒᵈ _ _ _ (h.toDual)
 
 end OrderBot
 

--- a/Mathlib/Order/BoundedOrder/Lattice.lean
+++ b/Mathlib/Order/BoundedOrder/Lattice.lean
@@ -67,7 +67,8 @@ lemma inf_top_eq (a : α) : a ⊓ ⊤ = a := inf_of_le_left le_top
 
 @[simp]
 theorem inf_eq_top_iff : a ⊓ b = ⊤ ↔ a = ⊤ ∧ b = ⊤ :=
-  @sup_eq_bot_iff αᵒᵈ _ _ _ _
+  toDual.apply_eq_iff_eq.symm.trans <| (@sup_eq_bot_iff αᵒᵈ _ _ _ _).trans
+    <| (and_congr toDual.apply_eq_iff_eq toDual.apply_eq_iff_eq)
 
 end SemilatticeInfTop
 
@@ -108,7 +109,8 @@ variable [SemilatticeInf α]
 
 theorem exists_le_and_iff_exists {P : α → Prop} {x₀ : α} (hP : Antitone P) :
     (∃ x, x ≤ x₀ ∧ P x) ↔ ∃ x, P x :=
-  exists_ge_and_iff_exists <| hP.dual_left
+  (OrderDual.toDual.exists_congr_left).trans <|
+    (exists_ge_and_iff_exists <| hP.dual_left).trans (OrderDual.ofDual.exists_congr_left)
 
 lemma exists_and_iff_of_antitone {P Q : α → Prop} (hP : Antitone P) (hQ : Antitone Q) :
     ((∃ x, P x) ∧ ∃ x, Q x) ↔ (∃ x, P x ∧ Q x) :=
@@ -152,7 +154,8 @@ theorem min_eq_bot [OrderBot α] {a b : α} : min a b = ⊥ ↔ a = ⊥ ∨ b = 
 
 @[simp]
 theorem max_eq_top [OrderTop α] {a b : α} : max a b = ⊤ ↔ a = ⊤ ∨ b = ⊤ :=
-  @min_eq_bot αᵒᵈ _ _ a b
+  ofDual.apply_eq_iff_eq.trans <| (@min_eq_bot αᵒᵈ _ _ (toDual a) (toDual b)).trans <|
+    or_congr toDual.apply_eq_iff_eq toDual.apply_eq_iff_eq
 
 @[aesop (rule_sets := [finiteness]) safe apply]
 lemma max_ne_top [OrderTop α] {a b : α} (ha : a ≠ ⊤) (hb : b ≠ ⊤) : max a b ≠ ⊤ := by

--- a/Mathlib/Order/BoundedOrder/Monotone.lean
+++ b/Mathlib/Order/BoundedOrder/Monotone.lean
@@ -45,11 +45,13 @@ section OrderBot
 
 variable [PartialOrder α] [OrderBot α] [Preorder β] {f : α → β} {a b : α}
 
-theorem StrictMono.apply_eq_bot_iff (hf : StrictMono f) : f a = f ⊥ ↔ a = ⊥ :=
-  hf.dual.apply_eq_top_iff
+theorem StrictMono.apply_eq_bot_iff (hf : StrictMono f) : f a = f ⊥ ↔ a = ⊥ := by
+  convert (hf.dual.apply_eq_top_iff (a := toDual a))
+  all_goals exact ⟨congrArg toDual,congrArg ofDual⟩
 
-theorem StrictAnti.apply_eq_bot_iff (hf : StrictAnti f) : f a = f ⊥ ↔ a = ⊥ :=
-  hf.dual.apply_eq_top_iff
+theorem StrictAnti.apply_eq_bot_iff (hf : StrictAnti f) : f a = f ⊥ ↔ a = ⊥ := by
+  convert hf.dual.apply_eq_top_iff
+  all_goals exact ⟨congrArg toDual,congrArg ofDual⟩
 
 end OrderBot
 

--- a/Mathlib/Order/Circular.lean
+++ b/Mathlib/Order/Circular.lean
@@ -416,10 +416,10 @@ abbrev LinearOrder.toCircularOrder (α : Type*) [LinearOrder α] : CircularOrder
 namespace OrderDual
 
 instance btw (α : Type*) [Btw α] : Btw αᵒᵈ :=
-  ⟨fun a b c : α => Btw.btw c b a⟩
+  ⟨fun a b c => Btw.btw c.ofDual b.ofDual a.ofDual⟩
 
 instance sbtw (α : Type*) [SBtw α] : SBtw αᵒᵈ :=
-  ⟨fun a b c : α => SBtw.sbtw c b a⟩
+  ⟨fun a b c => SBtw.sbtw c.ofDual b.ofDual a.ofDual⟩
 
 instance circularPreorder (α : Type*) [CircularPreorder α] : CircularPreorder αᵒᵈ :=
   { OrderDual.btw α,
@@ -427,14 +427,15 @@ instance circularPreorder (α : Type*) [CircularPreorder α] : CircularPreorder 
     btw_refl := fun _ => @btw_refl α _ _
     btw_cyclic_left := fun {_ _ _} => @btw_cyclic_right α _ _ _ _
     sbtw_trans_left := fun {_ _ _ _} habc hbdc => hbdc.trans_right habc
-    sbtw_iff_btw_not_btw := fun {a b c} => @sbtw_iff_btw_not_btw α _ c b a }
+    sbtw_iff_btw_not_btw := fun {a b c} => @sbtw_iff_btw_not_btw α _ c.ofDual b.ofDual a.ofDual }
 
 instance circularPartialOrder (α : Type*) [CircularPartialOrder α] : CircularPartialOrder αᵒᵈ :=
   { OrderDual.circularPreorder α with
-    btw_antisymm := fun {_ _ _} habc hcba => @btw_antisymm α _ _ _ _ hcba habc }
+    btw_antisymm := fun {_ _ _} habc hcba => (@btw_antisymm α _ _ _ _ hcba habc).imp
+      (congrArg toDual) (·.imp (congrArg toDual) (congrArg toDual)) }
 
 instance (α : Type*) [CircularOrder α] : CircularOrder αᵒᵈ :=
   { OrderDual.circularPartialOrder α with
-    btw_total := fun {a b c} => @btw_total α _ c b a }
+    btw_total := fun {a b c} => @btw_total α _ c.ofDual b.ofDual a.ofDual }
 
 end OrderDual

--- a/Mathlib/Order/Compare.lean
+++ b/Mathlib/Order/Compare.lean
@@ -107,13 +107,13 @@ open Ordering OrderDual
 theorem toDual_compares_toDual [LT α] {a b : α} {o : Ordering} :
     Compares o (toDual a) (toDual b) ↔ Compares o b a := by
   cases o
-  exacts [Iff.rfl, eq_comm, Iff.rfl]
+  exacts [Iff.rfl, eq_comm.trans (EmbeddingLike.apply_eq_iff_eq toDual), Iff.rfl]
 
 @[simp]
 theorem ofDual_compares_ofDual [LT α] {a b : αᵒᵈ} {o : Ordering} :
     Compares o (ofDual a) (ofDual b) ↔ Compares o b a := by
   cases o
-  exacts [Iff.rfl, eq_comm, Iff.rfl]
+  exacts [Iff.rfl, eq_comm.trans (EmbeddingLike.apply_eq_iff_eq ofDual), Iff.rfl]
 
 theorem cmp_compares [LinearOrder α] (a b : α) : (cmp a b).Compares a b := by
   obtain h | h | h := lt_trichotomy a b <;> simp [cmp, cmpUsing, h, h.not_gt]

--- a/Mathlib/Order/Disjoint.lean
+++ b/Mathlib/Order/Disjoint.lean
@@ -205,6 +205,35 @@ arguments. -/
 def Codisjoint (a b : α) : Prop :=
   ∀ ⦃x⦄, a ≤ x → b ≤ x → ⊤ ≤ x
 
+section OrderDual
+open OrderDual
+
+@[simp]
+lemma disjoint_toDual_iff : Disjoint (toDual a) (toDual b) ↔ Codisjoint a b :=
+  OrderDual.ofDual.forall_congr_left
+
+@[simp]
+lemma codisjoint_ofDual_iff {a b : αᵒᵈ} : Codisjoint (ofDual a) (ofDual b) ↔ Disjoint a b :=
+  OrderDual.toDual.forall_congr_left
+
+omit [OrderTop α]
+
+@[simp]
+theorem disjoint_ofDual_iff [OrderBot α] {a b : αᵒᵈ} :
+    Disjoint (ofDual a) (ofDual b) ↔ Codisjoint a b :=
+  OrderDual.toDual.forall_congr_left
+@[simp]
+lemma codisjoint_toDual_iff [OrderBot α] :
+    Codisjoint (OrderDual.toDual a) (.toDual b) ↔ Disjoint a b :=
+  OrderDual.ofDual.forall_congr_left
+
+alias ⟨Codisjoint.of_dual,Codisjoint.dual⟩ := disjoint_toDual_iff
+alias ⟨Codisjoint.of_dual',Codisjoint.dual'⟩ := disjoint_ofDual_iff
+alias ⟨Disjoint.of_dual,Disjoint.dual⟩ := codisjoint_toDual_iff
+alias ⟨Disjoint.of_dual',Disjoint.dual'⟩ := codisjoint_ofDual_iff
+
+end OrderDual
+
 theorem codisjoint_comm : Codisjoint a b ↔ Codisjoint b a :=
   forall_congr' fun _ ↦ forall_swap
 
@@ -280,25 +309,28 @@ section SemilatticeSupTop
 variable [SemilatticeSup α] [OrderTop α] {a b c : α}
 
 theorem codisjoint_iff_le_sup : Codisjoint a b ↔ ⊤ ≤ a ⊔ b :=
-  @disjoint_iff_inf_le αᵒᵈ _ _ _ _
+  disjoint_toDual_iff.symm.trans <| @disjoint_iff_inf_le αᵒᵈ _ _ _ _
 
-theorem codisjoint_iff : Codisjoint a b ↔ a ⊔ b = ⊤ :=
-  @disjoint_iff αᵒᵈ _ _ _ _
+theorem codisjoint_iff : Codisjoint a b ↔ a ⊔ b = ⊤ := by
+  convert @disjoint_iff αᵒᵈ _ _ (.toDual a) (.toDual b)
+  · exact disjoint_toDual_iff.symm
+  · exact OrderDual.toDual.apply_eq_iff_eq.symm
 
-theorem Codisjoint.top_le : Codisjoint a b → ⊤ ≤ a ⊔ b :=
-  @Disjoint.le_bot αᵒᵈ _ _ _ _
+alias ⟨Codisjoint.top_le,_⟩ := codisjoint_iff_le_sup
 
-theorem Codisjoint.eq_top : Codisjoint a b → a ⊔ b = ⊤ :=
-  @Disjoint.eq_bot αᵒᵈ _ _ _ _
+alias ⟨Codisjoint.eq_top,_⟩ := codisjoint_iff
 
-theorem codisjoint_assoc : Codisjoint (a ⊔ b) c ↔ Codisjoint a (b ⊔ c) :=
-  @disjoint_assoc αᵒᵈ _ _ _ _ _
+theorem codisjoint_assoc : Codisjoint (a ⊔ b) c ↔ Codisjoint a (b ⊔ c) := by
+  convert @disjoint_assoc αᵒᵈ ..
+  all_goals exact disjoint_toDual_iff.symm
 
-theorem codisjoint_left_comm : Codisjoint a (b ⊔ c) ↔ Codisjoint b (a ⊔ c) :=
-  @disjoint_left_comm αᵒᵈ _ _ _ _ _
+theorem codisjoint_left_comm : Codisjoint a (b ⊔ c) ↔ Codisjoint b (a ⊔ c) := by
+  convert @disjoint_left_comm αᵒᵈ ..
+  all_goals exact disjoint_toDual_iff.symm
 
-theorem codisjoint_right_comm : Codisjoint (a ⊔ b) c ↔ Codisjoint (a ⊔ c) b :=
-  @disjoint_right_comm αᵒᵈ _ _ _ _ _
+theorem codisjoint_right_comm : Codisjoint (a ⊔ b) c ↔ Codisjoint (a ⊔ c) b := by
+  convert @disjoint_right_comm αᵒᵈ ..
+  all_goals exact disjoint_toDual_iff.symm
 
 variable (c)
 
@@ -318,11 +350,11 @@ variable {c}
 
 theorem Codisjoint.of_codisjoint_sup_of_le (h : Codisjoint (a ⊔ b) c) (hle : c ≤ a) :
     Codisjoint a b :=
-  @Disjoint.of_disjoint_inf_of_le αᵒᵈ _ _ _ _ _ h hle
+  .of_dual <| Disjoint.of_disjoint_inf_of_le (h.dual) hle
 
 theorem Codisjoint.of_codisjoint_sup_of_le' (h : Codisjoint (a ⊔ b) c) (hle : c ≤ b) :
     Codisjoint a b :=
-  @Disjoint.of_disjoint_inf_of_le' αᵒᵈ _ _ _ _ _ h hle
+  .of_dual <| Disjoint.of_disjoint_inf_of_le' h.dual hle
 
 end SemilatticeSupTop
 
@@ -345,7 +377,7 @@ theorem Codisjoint.inf_right (hb : Codisjoint a b) (hc : Codisjoint a c) : Codis
   codisjoint_inf_right.2 ⟨hb, hc⟩
 
 theorem Codisjoint.left_le_of_le_inf_right (h : a ⊓ b ≤ c) (hd : Codisjoint b c) : a ≤ c :=
-  @Disjoint.left_le_of_le_sup_right αᵒᵈ _ _ _ _ _ h hd.symm
+  @Disjoint.left_le_of_le_sup_right αᵒᵈ _ _ _ _ _ h hd.symm.dual
 
 theorem Codisjoint.left_le_of_le_inf_left (h : b ⊓ a ≤ c) (hd : Codisjoint b c) : a ≤ c :=
   hd.left_le_of_le_inf_right <| by rwa [inf_comm]
@@ -355,34 +387,6 @@ end DistribLatticeTop
 end Codisjoint
 
 open OrderDual
-
-theorem Disjoint.dual [PartialOrder α] [OrderBot α] {a b : α} :
-    Disjoint a b → Codisjoint (toDual a) (toDual b) :=
-  id
-
-theorem Codisjoint.dual [PartialOrder α] [OrderTop α] {a b : α} :
-    Codisjoint a b → Disjoint (toDual a) (toDual b) :=
-  id
-
-@[simp]
-theorem disjoint_toDual_iff [PartialOrder α] [OrderTop α] {a b : α} :
-    Disjoint (toDual a) (toDual b) ↔ Codisjoint a b :=
-  Iff.rfl
-
-@[simp]
-theorem disjoint_ofDual_iff [PartialOrder α] [OrderBot α] {a b : αᵒᵈ} :
-    Disjoint (ofDual a) (ofDual b) ↔ Codisjoint a b :=
-  Iff.rfl
-
-@[simp]
-theorem codisjoint_toDual_iff [PartialOrder α] [OrderBot α] {a b : α} :
-    Codisjoint (toDual a) (toDual b) ↔ Disjoint a b :=
-  Iff.rfl
-
-@[simp]
-theorem codisjoint_ofDual_iff [PartialOrder α] [OrderTop α] {a b : αᵒᵈ} :
-    Codisjoint (ofDual a) (ofDual b) ↔ Disjoint a b :=
-  Iff.rfl
 
 section DistribLattice
 
@@ -420,10 +424,10 @@ protected theorem symm (h : IsCompl x y) : IsCompl y x :=
 lemma _root_.isCompl_comm : IsCompl x y ↔ IsCompl y x := ⟨IsCompl.symm, IsCompl.symm⟩
 
 theorem dual (h : IsCompl x y) : IsCompl (toDual x) (toDual y) :=
-  ⟨h.2, h.1⟩
+  ⟨h.2.dual, h.1.dual⟩
 
 theorem ofDual {a b : αᵒᵈ} (h : IsCompl a b) : IsCompl (ofDual a) (ofDual b) :=
-  ⟨h.2, h.1⟩
+  ⟨.of_dual h.2, .of_dual h.1⟩
 
 end BoundedPartialOrder
 
@@ -477,7 +481,7 @@ theorem le_right_iff (h : IsCompl x y) : z ≤ y ↔ Disjoint z x :=
   h.symm.le_left_iff
 
 theorem left_le_iff (h : IsCompl x y) : x ≤ z ↔ Codisjoint z y :=
-  h.dual.le_left_iff
+  h.dual.le_left_iff.trans (disjoint_toDual_iff)
 
 theorem right_le_iff (h : IsCompl x y) : y ≤ z ↔ Codisjoint z x :=
   h.symm.left_le_iff
@@ -518,8 +522,12 @@ protected theorem disjoint_iff [OrderBot α] [OrderBot β] {x y : α × β} :
     exact ⟨ha hza.1 hzb.1, hb hza.2 hzb.2⟩
 
 protected theorem codisjoint_iff [OrderTop α] [OrderTop β] {x y : α × β} :
-    Codisjoint x y ↔ Codisjoint x.1 y.1 ∧ Codisjoint x.2 y.2 :=
-  @Prod.disjoint_iff αᵒᵈ βᵒᵈ _ _ _ _ _ _
+    Codisjoint x y ↔ Codisjoint x.1 y.1 ∧ Codisjoint x.2 y.2 := by
+  convert @Prod.disjoint_iff αᵒᵈ βᵒᵈ _ _ _ _ (x.map toDual toDual) (y.map toDual toDual)
+  · exact Equiv.forall_congr_left ⟨Prod.map toDual toDual, Prod.map ofDual ofDual,
+      fun _ => rfl, fun _ => rfl⟩
+  · exact disjoint_toDual_iff.symm
+  · exact disjoint_toDual_iff.symm
 
 protected theorem isCompl_iff [BoundedOrder α] [BoundedOrder β] {x y : α × β} :
     IsCompl x y ↔ IsCompl x.1 y.1 ∧ IsCompl x.2 y.2 := by
@@ -551,10 +559,10 @@ theorem eq_top_of_bot_isCompl (h : IsCompl ⊥ x) : x = ⊤ :=
   eq_top_of_isCompl_bot h.symm
 
 theorem eq_bot_of_isCompl_top (h : IsCompl x ⊤) : x = ⊥ :=
-  eq_top_of_isCompl_bot h.dual
+  congrArg ofDual <| eq_top_of_isCompl_bot h.dual
 
 theorem eq_bot_of_top_isCompl (h : IsCompl ⊤ x) : x = ⊥ :=
-  eq_top_of_bot_isCompl h.dual
+  congrArg ofDual <| eq_top_of_bot_isCompl h.dual
 
 end
 
@@ -610,8 +618,8 @@ variable [Lattice α] [BoundedOrder α] [ComplementedLattice α]
 
 instance : ComplementedLattice αᵒᵈ :=
   ⟨fun a ↦
-    let ⟨b, hb⟩ := exists_isCompl (show α from a)
-    ⟨b, hb.dual⟩⟩
+    let ⟨b, hb⟩ := exists_isCompl a.ofDual
+    ⟨toDual b, hb.dual⟩⟩
 
 end ComplementedLattice
 

--- a/Mathlib/Order/Iterate.lean
+++ b/Mathlib/Order/Iterate.lean
@@ -60,7 +60,7 @@ theorem seq_pos_lt_seq_of_lt_of_le (hf : Monotone f) {n : ℕ} (hn : 0 < n) (h�
 
 theorem seq_pos_lt_seq_of_le_of_lt (hf : Monotone f) {n : ℕ} (hn : 0 < n) (h₀ : x 0 ≤ y 0)
     (hx : ∀ k < n, x (k + 1) ≤ f (x k)) (hy : ∀ k < n, f (y k) < y (k + 1)) : x n < y n :=
-  hf.dual.seq_pos_lt_seq_of_lt_of_le hn h₀ hy hx
+  hf.dual.seq_pos_lt_seq_of_lt_of_le (y := (OrderDual.toDual <| x ·)) hn h₀ hy hx
 
 theorem seq_lt_seq_of_lt_of_le (hf : Monotone f) (n : ℕ) (h₀ : x 0 < y 0)
     (hx : ∀ k < n, x (k + 1) < f (x k)) (hy : ∀ k < n, f (y k) ≤ y (k + 1)) : x n < y n := by
@@ -69,7 +69,7 @@ theorem seq_lt_seq_of_lt_of_le (hf : Monotone f) (n : ℕ) (h₀ : x 0 < y 0)
 
 theorem seq_lt_seq_of_le_of_lt (hf : Monotone f) (n : ℕ) (h₀ : x 0 < y 0)
     (hx : ∀ k < n, x (k + 1) ≤ f (x k)) (hy : ∀ k < n, f (y k) < y (k + 1)) : x n < y n :=
-  hf.dual.seq_lt_seq_of_lt_of_le n h₀ hy hx
+  hf.dual.seq_lt_seq_of_lt_of_le (y := OrderDual.toDual ∘ x) n h₀ hy hx
 
 /-!
 ### Iterates of two functions
@@ -93,16 +93,21 @@ theorem le_iterate_comp_of_le (hf : Monotone f) (H : h ∘ g ≤ f ∘ h) (n : �
   case hx => exact H _
 
 theorem iterate_comp_le_of_le (hf : Monotone f) (H : f ∘ h ≤ h ∘ g) (n : ℕ) :
-    f^[n] ∘ h ≤ h ∘ g^[n] :=
-  hf.dual.le_iterate_comp_of_le H n
+    f^[n] ∘ h ≤ h ∘ g^[n] := by
+  have := show _ ≤ _^[n] ∘ OrderDual.toDual ∘ _ from hf.dual.le_iterate_comp_of_le H n
+  rwa [← comp_assoc,comp_iterate_comp] at this
 
 /-- If `f ≤ g` and `f` is monotone, then `f^[n] ≤ g^[n]`. -/
 theorem iterate_le_of_le {g : α → α} (hf : Monotone f) (h : f ≤ g) (n : ℕ) : f^[n] ≤ g^[n] :=
   hf.iterate_comp_le_of_le h n
 
 /-- If `f ≤ g` and `g` is monotone, then `f^[n] ≤ g^[n]`. -/
-theorem le_iterate_of_le {g : α → α} (hg : Monotone g) (h : f ≤ g) (n : ℕ) : f^[n] ≤ g^[n] :=
-  hg.dual.iterate_le_of_le h n
+theorem le_iterate_of_le {g : α → α} (hg : Monotone g) (h : f ≤ g) (n : ℕ) : f^[n] ≤ g^[n] := by
+  have := show OrderDual.ofDual ∘ (⇑OrderDual.toDual ∘ f ∘ ⇑OrderDual.ofDual)^[n] ≤
+      OrderDual.ofDual ∘ (⇑OrderDual.toDual ∘ g ∘ ⇑OrderDual.ofDual)^[n] from
+    hg.dual.iterate_le_of_le (h ·.ofDual) n
+  simp_rw [← Function.comp_assoc,← comp_iterate_comp] at this
+  exact (this <| OrderDual.toDual ·)
 
 end Monotone
 
@@ -125,16 +130,21 @@ variable {α : Type*} [Preorder α] {f : α → α}
 theorem id_le_iterate_of_id_le (h : id ≤ f) (n : ℕ) : id ≤ f^[n] := by
   simpa only [iterate_id] using monotone_id.iterate_le_of_le h n
 
-theorem iterate_le_id_of_le_id (h : f ≤ id) (n : ℕ) : f^[n] ≤ id :=
-  @id_le_iterate_of_id_le αᵒᵈ _ f h n
+theorem iterate_le_id_of_le_id (h : f ≤ id) (n : ℕ) : f^[n] ≤ id := by
+  have := show OrderDual.ofDual ∘ (OrderDual.toDual ∘ f ∘ OrderDual.ofDual)^[n] ≤
+        OrderDual.ofDual ∘ id from id_le_iterate_of_id_le (h <|OrderDual.ofDual ·) n
+  rw [← Function.comp_assoc OrderDual.toDual f OrderDual.ofDual,← comp_iterate_comp] at this
+  exact (this <| OrderDual.toDual ·)
 
 theorem monotone_iterate_of_id_le (h : id ≤ f) : Monotone fun m => f^[m] :=
   monotone_nat_of_le_succ fun n x => by
     rw [iterate_succ_apply']
     exact h _
 
-theorem antitone_iterate_of_le_id (h : f ≤ id) : Antitone fun m => f^[m] := fun m n hmn =>
-  @monotone_iterate_of_id_le αᵒᵈ _ f h m n hmn
+theorem antitone_iterate_of_le_id (h : f ≤ id) : Antitone fun m => f^[m] :=
+  .of_dual_right <| monotone_nat_of_le_succ fun n x => by
+    simp_rw [comp_apply, iterate_succ']
+    exact h _
 
 end Preorder
 
@@ -168,8 +178,14 @@ theorem iterate_pos_lt_of_map_lt (h : Commute f g) (hf : Monotone f) (hg : Stric
   · intros; simp [h.iterate_right _ _, hg.iterate _ hx]
 
 theorem iterate_pos_lt_of_map_lt' (h : Commute f g) (hf : StrictMono f) (hg : Monotone g) {x}
-    (hx : f x < g x) {n} (hn : 0 < n) : f^[n] x < g^[n] x :=
-  @iterate_pos_lt_of_map_lt αᵒᵈ _ g f h.symm hg.dual hf.dual x hx n hn
+    (hx : f x < g x) {n} (hn : 0 < n) : f^[n] x < g^[n] x := by
+  have : (OrderDual.toDual ∘ f ∘ OrderDual.ofDual).Commute
+      (OrderDual.toDual ∘ g ∘ OrderDual.ofDual) :=
+    (congrArg OrderDual.toDual <| h.eq <| OrderDual.ofDual ·)
+  have :=
+    show (_ ∘ _) x < (_ ∘ _) x from
+    @iterate_pos_lt_of_map_lt αᵒᵈ _ _ _ this.symm hg.dual hf.dual (.toDual x) hx n hn
+  rwa [comp_iterate_comp,comp_iterate_comp] at this
 
 end Preorder
 
@@ -183,8 +199,14 @@ theorem iterate_pos_lt_iff_map_lt (h : Commute f g) (hf : Monotone f) (hg : Stri
   · simp only [lt_asymm H, lt_asymm (h.symm.iterate_pos_lt_of_map_lt' hg hf H hn)]
 
 theorem iterate_pos_lt_iff_map_lt' (h : Commute f g) (hf : StrictMono f) (hg : Monotone g) {x n}
-    (hn : 0 < n) : f^[n] x < g^[n] x ↔ f x < g x :=
-  @iterate_pos_lt_iff_map_lt αᵒᵈ _ _ _ h.symm hg.dual hf.dual x n hn
+    (hn : 0 < n) : f^[n] x < g^[n] x ↔ f x < g x := by
+  have : (OrderDual.toDual ∘ f ∘ OrderDual.ofDual).Commute
+      (OrderDual.toDual ∘ g ∘ OrderDual.ofDual) :=
+    (congrArg OrderDual.toDual <| h.eq <| OrderDual.ofDual ·)
+  have :=
+    show (_ ∘ _) _ < (_ ∘ _) _ ↔ _ from
+    @iterate_pos_lt_iff_map_lt αᵒᵈ _ _ _ this.symm hg.dual hf.dual (.toDual x) n hn
+  rwa [comp_iterate_comp,comp_iterate_comp] at this
 
 theorem iterate_pos_le_iff_map_le (h : Commute f g) (hf : Monotone f) (hg : StrictMono g) {x n}
     (hn : 0 < n) : f^[n] x ≤ g^[n] x ↔ f x ≤ g x := by
@@ -217,7 +239,9 @@ theorem monotone_iterate_of_le_map (hf : Monotone f) (hx : x ≤ f x) : Monotone
 /-- If `f` is a monotone map and `f x ≤ x` at some point `x`, then the iterates `f^[n] x` form
 an antitone sequence. -/
 theorem antitone_iterate_of_map_le (hf : Monotone f) (hx : f x ≤ x) : Antitone fun n => f^[n] x :=
-  hf.dual.monotone_iterate_of_le_map hx
+  .of_dual_right <| monotone_nat_of_le_succ fun n => by
+    simp only [comp_apply, iterate_succ_apply, OrderDual.toDual_le_toDual]
+    exact hf.iterate n hx
 
 end Monotone
 
@@ -237,6 +261,8 @@ theorem strictMono_iterate_of_lt_map (hf : StrictMono f) (hx : x < f x) :
 form a strictly antitone sequence. -/
 theorem strictAnti_iterate_of_map_lt (hf : StrictMono f) (hx : f x < x) :
     StrictAnti fun n => f^[n] x :=
-  hf.dual.strictMono_iterate_of_lt_map hx
+  .of_dual_right <| strictMono_nat_of_lt_succ fun n => by
+    dsimp only [comp_apply, iterate_succ']
+    exact hf.iterate n hx
 
 end StrictMono

--- a/Mathlib/Order/Lattice.lean
+++ b/Mathlib/Order/Lattice.lean
@@ -273,20 +273,16 @@ class SemilatticeInf (α : Type u) extends PartialOrder α where
 instance SemilatticeInf.toMin [SemilatticeInf α] : Min α where min a b := SemilatticeInf.inf a b
 
 instance OrderDual.instSemilatticeSup (α) [SemilatticeInf α] : SemilatticeSup αᵒᵈ where
-  sup := @SemilatticeInf.inf α _
-  le_sup_left := @SemilatticeInf.inf_le_left α _
-  le_sup_right := @SemilatticeInf.inf_le_right α _
+  sup := (toDual <| @SemilatticeInf.inf α _ ·.ofDual ·.ofDual)
+  le_sup_left _ _ := @SemilatticeInf.inf_le_left α ..
+  le_sup_right _ _ := @SemilatticeInf.inf_le_right α ..
   sup_le := fun _ _ _ hca hcb => @SemilatticeInf.le_inf α _ _ _ _ hca hcb
 
 instance OrderDual.instSemilatticeInf (α) [SemilatticeSup α] : SemilatticeInf αᵒᵈ where
-  inf := @SemilatticeSup.sup α _
-  inf_le_left := @le_sup_left α _
-  inf_le_right := @le_sup_right α _
+  inf := (toDual <| ·.ofDual ⊔ ·.ofDual)
+  inf_le_left _ _ := @le_sup_left α ..
+  inf_le_right _ _ := @le_sup_right α ..
   le_inf := fun _ _ _ hca hcb => @sup_le α _ _ _ _ hca hcb
-
-theorem SemilatticeSup.dual_dual (α : Type*) [H : SemilatticeSup α] :
-    OrderDual.instSemilatticeSup αᵒᵈ = H :=
-  SemilatticeSup.ext fun _ _ => Iff.rfl
 
 section SemilatticeInf
 
@@ -343,14 +339,14 @@ attribute [simp] inf_of_le_left inf_of_le_right
 
 @[simp]
 theorem inf_lt_left : a ⊓ b < a ↔ ¬a ≤ b :=
-  @left_lt_sup αᵒᵈ _ _ _
+  @left_lt_sup αᵒᵈ ..
 
 @[simp]
 theorem inf_lt_right : a ⊓ b < b ↔ ¬b ≤ a :=
-  @right_lt_sup αᵒᵈ _ _ _
+  @right_lt_sup αᵒᵈ ..
 
 theorem inf_lt_left_or_right (h : a ≠ b) : a ⊓ b < a ∨ a ⊓ b < b :=
-  @left_or_right_lt_sup αᵒᵈ _ _ _ h
+  left_or_right_lt_sup (h ∘ congrArg OrderDual.ofDual)
 
 @[gcongr]
 theorem inf_le_inf (h₁ : a ≤ b) (h₂ : c ≤ d) : a ⊓ c ≤ b ⊓ d :=
@@ -368,50 +364,52 @@ theorem inf_idem (a : α) : a ⊓ a = a := by simp
 
 instance : Std.IdempotentOp (α := α) (· ⊓ ·) := ⟨inf_idem⟩
 
-theorem inf_comm (a b : α) : a ⊓ b = b ⊓ a := @sup_comm αᵒᵈ _ _ _
+theorem inf_comm (a b : α) : a ⊓ b = b ⊓ a := congrArg OrderDual.ofDual <| sup_comm ..
 
 instance : Std.Commutative (α := α) (· ⊓ ·) := ⟨inf_comm⟩
 
-theorem inf_assoc (a b c : α) : a ⊓ b ⊓ c = a ⊓ (b ⊓ c) := @sup_assoc αᵒᵈ _ _ _ _
+theorem inf_assoc (a b c : α) : a ⊓ b ⊓ c = a ⊓ (b ⊓ c) :=
+  congrArg OrderDual.ofDual <| sup_assoc ..
 
 instance : Std.Associative (α := α) (· ⊓ ·) := ⟨inf_assoc⟩
 
 theorem inf_left_right_swap (a b c : α) : a ⊓ b ⊓ c = c ⊓ b ⊓ a :=
-  @sup_left_right_swap αᵒᵈ _ _ _ _
+  congrArg OrderDual.ofDual <| sup_left_right_swap ..
 
 theorem inf_left_idem (a b : α) : a ⊓ (a ⊓ b) = a ⊓ b := by simp
 
 theorem inf_right_idem (a b : α) : a ⊓ b ⊓ b = a ⊓ b := by simp
 
 theorem inf_left_comm (a b c : α) : a ⊓ (b ⊓ c) = b ⊓ (a ⊓ c) :=
-  @sup_left_comm αᵒᵈ _ a b c
+  congrArg OrderDual.ofDual <| sup_left_comm ..
 
 theorem inf_right_comm (a b c : α) : a ⊓ b ⊓ c = a ⊓ c ⊓ b :=
-  @sup_right_comm αᵒᵈ _ a b c
+  congrArg OrderDual.ofDual <| sup_right_comm ..
 
 theorem inf_inf_inf_comm (a b c d : α) : a ⊓ b ⊓ (c ⊓ d) = a ⊓ c ⊓ (b ⊓ d) :=
-  @sup_sup_sup_comm αᵒᵈ _ _ _ _ _
+  congrArg OrderDual.ofDual <| sup_sup_sup_comm ..
 
 theorem inf_inf_distrib_left (a b c : α) : a ⊓ (b ⊓ c) = a ⊓ b ⊓ (a ⊓ c) :=
-  @sup_sup_distrib_left αᵒᵈ _ _ _ _
+  congrArg OrderDual.ofDual <| sup_sup_distrib_left ..
 
 theorem inf_inf_distrib_right (a b c : α) : a ⊓ b ⊓ c = a ⊓ c ⊓ (b ⊓ c) :=
-  @sup_sup_distrib_right αᵒᵈ _ _ _ _
+  congrArg OrderDual.ofDual <| sup_sup_distrib_right ..
 
 theorem inf_congr_left (hb : a ⊓ c ≤ b) (hc : a ⊓ b ≤ c) : a ⊓ b = a ⊓ c :=
-  @sup_congr_left αᵒᵈ _ _ _ _ hb hc
+  congrArg OrderDual.ofDual <| sup_congr_left hb hc
 
 theorem inf_congr_right (h1 : b ⊓ c ≤ a) (h2 : a ⊓ c ≤ b) : a ⊓ c = b ⊓ c :=
-  @sup_congr_right αᵒᵈ _ _ _ _ h1 h2
+  congrArg OrderDual.ofDual <| sup_congr_right h1 h2
 
 theorem inf_eq_inf_iff_left : a ⊓ b = a ⊓ c ↔ a ⊓ c ≤ b ∧ a ⊓ b ≤ c :=
-  @sup_eq_sup_iff_left αᵒᵈ _ _ _ _
+  OrderDual.ofDual.injective.eq_iff.trans <| sup_eq_sup_iff_left ..
+
 
 theorem inf_eq_inf_iff_right : a ⊓ c = b ⊓ c ↔ b ⊓ c ≤ a ∧ a ⊓ c ≤ b :=
-  @sup_eq_sup_iff_right αᵒᵈ _ _ _ _
+  OrderDual.ofDual.injective.eq_iff.trans <| sup_eq_sup_iff_right ..
 
 theorem Ne.inf_lt_or_inf_lt : a ≠ b → a ⊓ b < a ∨ a ⊓ b < b :=
-  @Ne.lt_sup_or_lt_sup αᵒᵈ _ _ _
+  @Ne.lt_sup_or_lt_sup αᵒᵈ _ _ _ ∘ (· ∘ congrArg OrderDual.ofDual)
 
 theorem SemilatticeInf.ext_inf {α} {A B : SemilatticeInf α}
     (H : ∀ x y : α, (haveI := A; x ≤ y) ↔ x ≤ y)
@@ -428,12 +426,9 @@ theorem SemilatticeInf.ext {α} {A B : SemilatticeInf α}
   congr
   ext; apply SemilatticeInf.ext_inf H
 
-theorem SemilatticeInf.dual_dual (α : Type*) [H : SemilatticeInf α] :
-    OrderDual.instSemilatticeInf αᵒᵈ = H :=
-  SemilatticeInf.ext fun _ _ => Iff.rfl
-
 theorem inf_le_ite (s s' : α) (P : Prop) [Decidable P] : s ⊓ s' ≤ ite P s s' :=
-  @ite_le_sup αᵒᵈ _ _ _ _ _
+  OrderDual.toDual_le_toDual.mp <| apply_ite OrderDual.toDual P .. ▸
+    ite_le_sup (α := αᵒᵈ) (.toDual s) (.toDual s') P
 
 end SemilatticeInf
 
@@ -445,10 +440,15 @@ The partial order is defined so that `a ≤ b` unfolds to `b ⊓ a = a`; cf. `in
 -/
 def SemilatticeInf.mk' {α : Type*} [Min α] (inf_comm : ∀ a b : α, a ⊓ b = b ⊓ a)
     (inf_assoc : ∀ a b c : α, a ⊓ b ⊓ c = a ⊓ (b ⊓ c)) (inf_idem : ∀ a : α, a ⊓ a = a) :
-    SemilatticeInf α := by
-  haveI : SemilatticeSup αᵒᵈ := SemilatticeSup.mk' inf_comm inf_assoc inf_idem
-  haveI i := OrderDual.instSemilatticeInf αᵒᵈ
-  exact i
+    SemilatticeInf α where
+  inf := (· ⊓ ·)
+  le a b := b ⊓ a = a
+  le_refl := inf_idem
+  le_trans a b c hab hbc := by rw [← hab, ← inf_assoc, hbc]
+  le_antisymm a b hab hba := by rwa [← hab, ← inf_comm]
+  inf_le_left a b := by rw [← inf_assoc, inf_idem]
+  inf_le_right a b := by rw [inf_comm, inf_assoc, inf_idem]
+  le_inf a b c hba hca := by rwa [inf_comm b,inf_assoc, hba]
 
 /-!
 ### Lattices
@@ -623,8 +623,9 @@ end DistribLattice
 /-- Prove distributivity of an existing lattice from the dual distributive law. -/
 abbrev DistribLattice.ofInfSupLe
     [Lattice α] (inf_sup_le : ∀ a b c : α, a ⊓ (b ⊔ c) ≤ a ⊓ b ⊔ a ⊓ c) : DistribLattice α where
-  le_sup_inf := (@OrderDual.instDistribLattice αᵒᵈ {inferInstanceAs (Lattice αᵒᵈ) with
-      le_sup_inf := inf_sup_le}).le_sup_inf
+  le_sup_inf a b c := (@OrderDual.instDistribLattice αᵒᵈ {inferInstanceAs (Lattice αᵒᵈ) with
+      le_sup_inf _ _ _ := inf_sup_le _ _ _}).le_sup_inf (.toDual (.toDual a))
+        (.toDual (.toDual b)) (.toDual (.toDual c))
 
 /-!
 ### Lattices derived from linear orders
@@ -675,7 +676,7 @@ theorem sup_lt_iff : b ⊔ c < a ↔ b < a ∧ c < a :=
    fun h => sup_ind (p := (· < a)) b c h.1 h.2⟩
 
 theorem inf_ind (a b : α) {p : α → Prop} : p a → p b → p (a ⊓ b) :=
-  @sup_ind αᵒᵈ _ _ _ _
+  @sup_ind αᵒᵈ _ (.toDual a) (.toDual b) (p ·.ofDual)
 
 @[simp]
 theorem inf_le_iff : b ⊓ c ≤ a ↔ b ≤ a ∨ c ≤ a :=
@@ -892,15 +893,15 @@ theorem of_map_inf [SemilatticeInf α] [SemilatticeInf β] {f : α → β}
 
 theorem of_left_le_map_sup [SemilatticeSup α] [Preorder β] {f : α → β}
     (h : ∀ x y, f x ≤ f (x ⊔ y)) : Monotone f :=
-  monotone_dual_iff.1 <| of_map_inf_le_left h
+  monotone_dual_iff.1 <| of_map_inf_le_left (h ·.ofDual ·.ofDual)
 
 theorem of_le_map_sup [SemilatticeSup α] [SemilatticeSup β] {f : α → β}
     (h : ∀ x y, f x ⊔ f y ≤ f (x ⊔ y)) : Monotone f :=
-  monotone_dual_iff.mp <| of_map_inf_le h
+  .of_dual <| of_map_inf_le (h ·.ofDual ·.ofDual)
 
 theorem of_map_sup [SemilatticeSup α] [SemilatticeSup β] {f : α → β}
     (h : ∀ x y, f (x ⊔ y) = f x ⊔ f y) : Monotone f :=
-  (@of_map_inf (OrderDual α) (OrderDual β) _ _ _ h).dual
+  .of_dual (of_map_inf (congrArg toDual <| h ·.ofDual ·.ofDual))
 
 variable [LinearOrder α]
 
@@ -911,7 +912,7 @@ theorem map_sup [SemilatticeSup β] {f : α → β} (hf : Monotone f) (x y : α)
 
 theorem map_inf [SemilatticeInf β] {f : α → β} (hf : Monotone f) (x y : α) :
     f (x ⊓ y) = f x ⊓ f y :=
-  hf.dual.map_sup _ _
+  congrArg ofDual (hf.dual.map_sup _ _)
 
 end Monotone
 
@@ -926,7 +927,7 @@ protected theorem sup [Preorder α] [SemilatticeSup β] {f g : α → β} {s : S
 /-- Pointwise infimum of two monotone functions is a monotone function. -/
 protected theorem inf [Preorder α] [SemilatticeInf β] {f g : α → β} {s : Set α}
     (hf : MonotoneOn f s) (hg : MonotoneOn g s) : MonotoneOn (f ⊓ g) s :=
-  (hf.dual.sup hg.dual).dual
+  .of_dual' ((hf.dual).sup (hg.dual))
 
 /-- Pointwise maximum of two monotone functions is a monotone function. -/
 protected theorem max [Preorder α] [LinearOrder β] {f g : α → β} {s : Set α} (hf : MonotoneOn f s)
@@ -944,7 +945,7 @@ theorem of_map_inf [SemilatticeInf α] [SemilatticeInf β]
 
 theorem of_map_sup [SemilatticeSup α] [SemilatticeSup β]
     (h : ∀ x ∈ s, ∀ y ∈ s, f (x ⊔ y) = f x ⊔ f y) : MonotoneOn f s :=
-  (@of_map_inf αᵒᵈ βᵒᵈ _ _ _ _ h).dual
+  .of_dual (.of_map_inf (f := toDual ∘ f ∘ ofDual) (congrArg toDual <| h ·.ofDual · ·.ofDual ·))
 
 variable [LinearOrder α]
 
@@ -957,7 +958,7 @@ theorem map_sup [SemilatticeSup β] (hf : MonotoneOn f s) (hx : x ∈ s) (hy : y
 
 theorem map_inf [SemilatticeInf β] (hf : MonotoneOn f s) (hx : x ∈ s) (hy : y ∈ s) :
     f (x ⊓ y) = f x ⊓ f y :=
-  hf.dual.map_sup hx hy
+  congrArg ofDual <| (hf.dual).map_sup hx hy
 
 end MonotoneOn
 
@@ -997,11 +998,11 @@ variable [LinearOrder α]
 
 theorem map_sup [SemilatticeInf β] {f : α → β} (hf : Antitone f) (x y : α) :
     f (x ⊔ y) = f x ⊓ f y :=
-  hf.dual_right.map_sup x y
+  congrArg ofDual <| hf.dual_right.map_sup x y
 
 theorem map_inf [SemilatticeSup β] {f : α → β} (hf : Antitone f) (x y : α) :
     f (x ⊓ y) = f x ⊔ f y :=
-  hf.dual_right.map_inf x y
+  congrArg ofDual <| hf.dual_right.map_inf x y
 
 end Antitone
 
@@ -1016,7 +1017,7 @@ protected theorem sup [Preorder α] [SemilatticeSup β] {f g : α → β} {s : S
 /-- Pointwise infimum of two antitone functions is an antitone function. -/
 protected theorem inf [Preorder α] [SemilatticeInf β] {f g : α → β} {s : Set α}
     (hf : AntitoneOn f s) (hg : AntitoneOn g s) : AntitoneOn (f ⊓ g) s :=
-  (hf.dual.sup hg.dual).dual
+  .of_dual' <| hf.dual.sup hg.dual
 
 /-- Pointwise maximum of two antitone functions is an antitone function. -/
 protected theorem max [Preorder α] [LinearOrder β] {f g : α → β} {s : Set α} (hf : AntitoneOn f s)
@@ -1034,7 +1035,7 @@ theorem of_map_inf [SemilatticeInf α] [SemilatticeSup β]
 
 theorem of_map_sup [SemilatticeSup α] [SemilatticeInf β]
     (h : ∀ x ∈ s, ∀ y ∈ s, f (x ⊔ y) = f x ⊓ f y) : AntitoneOn f s :=
-  (@of_map_inf αᵒᵈ βᵒᵈ _ _ _ _ h).dual
+  .of_dual (of_map_inf (f := toDual ∘ f ∘ ofDual) (congrArg toDual <| h ·.ofDual · ·.ofDual ·))
 
 variable [LinearOrder α]
 
@@ -1047,7 +1048,7 @@ theorem map_sup [SemilatticeInf β] (hf : AntitoneOn f s) (hx : x ∈ s) (hy : y
 
 theorem map_inf [SemilatticeSup β] (hf : AntitoneOn f s) (hx : x ∈ s) (hy : y ∈ s) :
     f (x ⊓ y) = f x ⊔ f y :=
-  hf.dual.map_sup hx hy
+  congrArg ofDual <| (hf.dual).map_sup hx hy
 
 end AntitoneOn
 

--- a/Mathlib/Order/Max.lean
+++ b/Mathlib/Order/Max.lean
@@ -73,16 +73,16 @@ instance IsEmpty.toNoMaxOrder [LT α] [IsEmpty α] : NoMaxOrder α := ⟨isEmpty
 instance IsEmpty.toNoMinOrder [LT α] [IsEmpty α] : NoMinOrder α := ⟨isEmptyElim⟩
 
 instance OrderDual.noBotOrder [LE α] [NoTopOrder α] : NoBotOrder αᵒᵈ :=
-  ⟨fun a => exists_not_le (α := α) a⟩
+  ⟨fun a => exists_not_le (α := α) a.ofDual |>.elim (⟨toDual ·, ·⟩)⟩
 
 instance OrderDual.noTopOrder [LE α] [NoBotOrder α] : NoTopOrder αᵒᵈ :=
-  ⟨fun a => exists_not_ge (α := α) a⟩
+  ⟨fun a => exists_not_ge (α := α) a.ofDual |>.elim (⟨toDual ·, ·⟩)⟩
 
 instance OrderDual.noMinOrder [LT α] [NoMaxOrder α] : NoMinOrder αᵒᵈ :=
-  ⟨fun a => exists_gt (α := α) a⟩
+  ⟨fun a => exists_gt (α := α) a.ofDual |>.elim (⟨toDual ·, ·⟩)⟩
 
 instance OrderDual.noMaxOrder [LT α] [NoMinOrder α] : NoMaxOrder αᵒᵈ :=
-  ⟨fun a => exists_lt (α := α) a⟩
+  ⟨fun a => exists_lt (α := α) a.ofDual |>.elim (⟨toDual ·, ·⟩)⟩
 
 -- See note [lower instance priority]
 instance (priority := 100) [Preorder α] [NoMinOrder α] : NoBotOrder α :=
@@ -198,35 +198,35 @@ theorem IsBot.isMin_iff {α} [PartialOrder α] {i j : α} (h : IsBot i) : IsMin 
 
 @[simp]
 theorem isBot_toDual_iff : IsBot (toDual a) ↔ IsTop a :=
-  Iff.rfl
+  ⟨(· <| toDual ·),(· <| ofDual ·)⟩
 
 @[simp]
 theorem isTop_toDual_iff : IsTop (toDual a) ↔ IsBot a :=
-  Iff.rfl
+  ⟨(· <| toDual ·),(· <| ofDual ·)⟩
 
 @[simp]
 theorem isMin_toDual_iff : IsMin (toDual a) ↔ IsMax a :=
-  Iff.rfl
+  ⟨(@· <| toDual ·),(@· <| ofDual ·)⟩
 
 @[simp]
 theorem isMax_toDual_iff : IsMax (toDual a) ↔ IsMin a :=
-  Iff.rfl
+  ⟨(@· <| toDual ·),(@· <| ofDual ·)⟩
 
 @[simp]
 theorem isBot_ofDual_iff {a : αᵒᵈ} : IsBot (ofDual a) ↔ IsTop a :=
-  Iff.rfl
+  ⟨(· <| ofDual ·),(· <| toDual ·)⟩
 
 @[simp]
 theorem isTop_ofDual_iff {a : αᵒᵈ} : IsTop (ofDual a) ↔ IsBot a :=
-  Iff.rfl
+  ⟨(· <| ofDual ·),(· <| toDual ·)⟩
 
 @[simp]
 theorem isMin_ofDual_iff {a : αᵒᵈ} : IsMin (ofDual a) ↔ IsMax a :=
-  Iff.rfl
+  ⟨(@· <| ofDual ·),(@· <| toDual ·)⟩
 
 @[simp]
 theorem isMax_ofDual_iff {a : αᵒᵈ} : IsMax (ofDual a) ↔ IsMin a :=
-  Iff.rfl
+  ⟨(@· <| ofDual ·),(@· <| toDual ·)⟩
 
 alias ⟨_, IsTop.toDual⟩ := isBot_toDual_iff
 
@@ -338,13 +338,13 @@ protected theorem IsBot.not_isMax [Nontrivial α] (ha : IsBot a) : ¬ IsMax a :=
   exact hb <| ha'.eq_of_ge (ha.lt_of_ne hb.symm).le
 
 protected theorem IsTop.not_isMin [Nontrivial α] (ha : IsTop a) : ¬ IsMin a :=
-  ha.toDual.not_isMax
+  (ha.toDual.not_isMax ·.toDual)
 
 protected theorem IsBot.not_isTop [Nontrivial α] (ha : IsBot a) : ¬ IsTop a :=
   mt IsTop.isMax ha.not_isMax
 
 protected theorem IsTop.not_isBot [Nontrivial α] (ha : IsTop a) : ¬ IsBot a :=
-  ha.toDual.not_isTop
+  (ha.toDual.not_isTop ·.toDual)
 
 end PartialOrder
 

--- a/Mathlib/Order/MinMax.lean
+++ b/Mathlib/Order/MinMax.lean
@@ -128,8 +128,9 @@ theorem min_cases (a b : α) : min a b = a ∧ a ≤ b ∨ min a b = b ∧ b < a
 /-- For elements `a` and `b` of a linear order, either `max a b = a` and `b ≤ a`,
     or `max a b = b` and `a < b`.
     Use cases on this lemma to automate linarith in inequalities -/
-theorem max_cases (a b : α) : max a b = a ∧ b ≤ a ∨ max a b = b ∧ a < b :=
-  @min_cases αᵒᵈ _ a b
+theorem max_cases (a b : α) : max a b = a ∧ b ≤ a ∨ max a b = b ∧ a < b := by
+  convert (@min_cases αᵒᵈ _ (.toDual a) (.toDual b))
+  all_goals exact OrderDual.ofDual.apply_eq_iff_eq
 
 theorem min_eq_iff : min a b = c ↔ a = c ∧ a ≤ b ∨ b = c ∧ b ≤ a := by
   constructor
@@ -137,8 +138,10 @@ theorem min_eq_iff : min a b = c ↔ a = c ∧ a ≤ b ∨ b = c ∧ b ≤ a := 
     refine Or.imp (fun h' => ?_) (fun h' => ?_) (le_total a b) <;> exact ⟨by simpa [h'] using h, h'⟩
   · rintro (⟨rfl, h⟩ | ⟨rfl, h⟩) <;> simp [h]
 
-theorem max_eq_iff : max a b = c ↔ a = c ∧ b ≤ a ∨ b = c ∧ a ≤ b :=
-  @min_eq_iff αᵒᵈ _ a b c
+theorem max_eq_iff : max a b = c ↔ a = c ∧ b ≤ a ∨ b = c ∧ a ≤ b := by
+  convert @min_eq_iff αᵒᵈ _ (.toDual a) (.toDual b) (.toDual c)
+  all_goals exact OrderDual.ofDual.apply_eq_iff_eq
+
 
 theorem min_lt_min_left_iff : min a c < min b c ↔ a < b ∧ a < c := by
   simp_rw [lt_min_iff, min_lt_iff, or_iff_left (lt_irrefl _)]
@@ -187,30 +190,31 @@ theorem MonotoneOn.map_max (hf : MonotoneOn f s) (ha : a ∈ s) (hb : b ∈ s) :
     simp only [max_eq_right, max_eq_left, hf ha hb, hf hb ha, h]
 
 theorem MonotoneOn.map_min (hf : MonotoneOn f s) (ha : a ∈ s) (hb : b ∈ s) : f (min a b) =
-    min (f a) (f b) := hf.dual.map_max ha hb
+    min (f a) (f b) := congrArg OrderDual.ofDual <| hf.dual.map_max ha hb
 
 theorem AntitoneOn.map_max (hf : AntitoneOn f s) (ha : a ∈ s) (hb : b ∈ s) : f (max a b) =
-    min (f a) (f b) := hf.dual_right.map_max ha hb
+    min (f a) (f b) := congrArg OrderDual.ofDual <| hf.dual_right.map_max ha hb
 
 theorem AntitoneOn.map_min (hf : AntitoneOn f s) (ha : a ∈ s) (hb : b ∈ s) : f (min a b) =
-    max (f a) (f b) := hf.dual.map_max ha hb
+    max (f a) (f b) := congrArg OrderDual.ofDual <| hf.dual.map_max ha hb
 
 theorem Monotone.map_max (hf : Monotone f) : f (max a b) = max (f a) (f b) := by
   rcases le_total a b with h | h <;> simp [h, hf h]
 
 theorem Monotone.map_min (hf : Monotone f) : f (min a b) = min (f a) (f b) :=
-  hf.dual.map_max
+  congrArg OrderDual.ofDual <| hf.dual.map_max
 
 theorem Antitone.map_max (hf : Antitone f) : f (max a b) = min (f a) (f b) := by
   rcases le_total a b with h | h <;> simp [h, hf h]
 
 theorem Antitone.map_min (hf : Antitone f) : f (min a b) = max (f a) (f b) :=
-  hf.dual.map_max
+  congrArg OrderDual.ofDual <| hf.dual.map_max
 
 theorem min_choice (a b : α) : min a b = a ∨ min a b = b := by cases le_total a b <;> simp [*]
 
-theorem max_choice (a b : α) : max a b = a ∨ max a b = b :=
-  @min_choice αᵒᵈ _ a b
+theorem max_choice (a b : α) : max a b = a ∨ max a b = b := by
+  convert @min_choice αᵒᵈ _ (.toDual a) (.toDual b)
+  all_goals exact OrderDual.ofDual.apply_eq_iff_eq
 
 theorem le_of_max_le_left {a b c : α} (h : max a b ≤ c) : a ≤ c :=
   le_trans (le_max_left _ _) h

--- a/Mathlib/Order/Monotone/Basic.lean
+++ b/Mathlib/Order/Monotone/Basic.lean
@@ -95,145 +95,188 @@ variable [Preorder α] [Preorder β] {f : α → β} {s : Set α}
 
 @[simp]
 theorem monotone_comp_ofDual_iff : Monotone (f ∘ ofDual) ↔ Antitone f :=
-  forall_swap
+  ⟨fun h a b => @h (toDual b) (toDual a),fun h a b => @h b.ofDual a.ofDual⟩
 
 @[simp]
 theorem antitone_comp_ofDual_iff : Antitone (f ∘ ofDual) ↔ Monotone f :=
-  forall_swap
+  ⟨fun h a b => @h (toDual b) (toDual a),fun h a b => @h b.ofDual a.ofDual⟩
 
--- Porting note:
--- Here (and below) without the type ascription, Lean is seeing through the
--- defeq `βᵒᵈ = β` and picking up the wrong `Preorder` instance.
--- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/logic.2Eequiv.2Ebasic.20mathlib4.23631/near/311744939
 @[simp]
-theorem monotone_toDual_comp_iff : Monotone (toDual ∘ f : α → βᵒᵈ) ↔ Antitone f :=
+theorem monotone_toDual_comp_iff : Monotone (toDual ∘ f) ↔ Antitone f :=
   Iff.rfl
 
 @[simp]
-theorem antitone_toDual_comp_iff : Antitone (toDual ∘ f : α → βᵒᵈ) ↔ Monotone f :=
+theorem antitone_toDual_comp_iff : Antitone (toDual ∘ f) ↔ Monotone f :=
   Iff.rfl
 
 @[simp]
-theorem monotoneOn_comp_ofDual_iff : MonotoneOn (f ∘ ofDual) s ↔ AntitoneOn f s :=
-  forall₂_swap
+theorem monotoneOn_comp_ofDual_iff {s : Set αᵒᵈ} :
+    MonotoneOn (f ∘ ofDual) s ↔ AntitoneOn f (toDual ⁻¹' s) :=
+  ⟨fun h a ha b hb => @h (toDual b) hb (toDual a) ha,
+    fun h a ha b hb => @h (b.ofDual) hb (a.ofDual) ha⟩
+
+theorem monotoneOn_comp_ofDual_iff' :
+    MonotoneOn (f ∘ ofDual) (ofDual ⁻¹' s) ↔ AntitoneOn f s :=
+  monotoneOn_comp_ofDual_iff
+
 
 @[simp]
-theorem antitoneOn_comp_ofDual_iff : AntitoneOn (f ∘ ofDual) s ↔ MonotoneOn f s :=
-  forall₂_swap
+theorem antitoneOn_comp_ofDual_iff {s : Set αᵒᵈ} :
+    AntitoneOn (f ∘ ofDual) s ↔ MonotoneOn f (toDual ⁻¹' s) :=
+  ⟨fun h a ha b hb => @h (toDual b) hb (toDual a) ha,
+    fun h a ha b hb => @h (b.ofDual) hb (a.ofDual) ha⟩
+
+theorem antitoneOn_comp_ofDual_iff' {s : Set α} :
+    AntitoneOn (f ∘ ofDual) (ofDual ⁻¹' s) ↔ MonotoneOn f s :=
+  antitoneOn_comp_ofDual_iff
 
 @[simp]
-theorem monotoneOn_toDual_comp_iff : MonotoneOn (toDual ∘ f : α → βᵒᵈ) s ↔ AntitoneOn f s :=
+theorem monotoneOn_toDual_comp_iff : MonotoneOn (toDual ∘ f) s ↔ AntitoneOn f s :=
   Iff.rfl
 
 @[simp]
-theorem antitoneOn_toDual_comp_iff : AntitoneOn (toDual ∘ f : α → βᵒᵈ) s ↔ MonotoneOn f s :=
+theorem antitoneOn_toDual_comp_iff : AntitoneOn (toDual ∘ f) s ↔ MonotoneOn f s :=
   Iff.rfl
 
 @[simp]
 theorem strictMono_comp_ofDual_iff : StrictMono (f ∘ ofDual) ↔ StrictAnti f :=
-  forall_swap
+  ⟨fun h a b => @h (toDual b) (toDual a), fun h a b => @h b.ofDual a.ofDual⟩
 
 @[simp]
 theorem strictAnti_comp_ofDual_iff : StrictAnti (f ∘ ofDual) ↔ StrictMono f :=
-  forall_swap
+  ⟨fun h a b => @h (toDual b) (toDual a), fun h a b => @h b.ofDual a.ofDual⟩
 
 @[simp]
-theorem strictMono_toDual_comp_iff : StrictMono (toDual ∘ f : α → βᵒᵈ) ↔ StrictAnti f :=
+theorem strictMono_toDual_comp_iff : StrictMono (toDual ∘ f) ↔ StrictAnti f :=
   Iff.rfl
 
 @[simp]
-theorem strictAnti_toDual_comp_iff : StrictAnti (toDual ∘ f : α → βᵒᵈ) ↔ StrictMono f :=
+theorem strictAnti_toDual_comp_iff : StrictAnti (toDual ∘ f) ↔ StrictMono f :=
   Iff.rfl
 
 @[simp]
-theorem strictMonoOn_comp_ofDual_iff : StrictMonoOn (f ∘ ofDual) s ↔ StrictAntiOn f s :=
-  forall₂_swap
+theorem strictMonoOn_comp_ofDual_iff {s : Set αᵒᵈ} :
+    StrictMonoOn (f ∘ ofDual) s ↔ StrictAntiOn f (toDual ⁻¹' s) :=
+  ⟨fun h a ha b hb => @h (toDual b) hb (toDual a) ha,
+    fun h a ha b hb => @h (b.ofDual) hb (a.ofDual) ha⟩
+
+theorem strictMonoOn_comp_ofDual_iff' :
+    StrictMonoOn (f ∘ ofDual) (ofDual ⁻¹' s) ↔ StrictAntiOn f s :=
+  strictMonoOn_comp_ofDual_iff
+
 
 @[simp]
-theorem strictAntiOn_comp_ofDual_iff : StrictAntiOn (f ∘ ofDual) s ↔ StrictMonoOn f s :=
-  forall₂_swap
+theorem strictAntiOn_comp_ofDual_iff {s : Set αᵒᵈ} :
+    StrictAntiOn (f ∘ ofDual) s ↔ StrictMonoOn f (toDual ⁻¹' s) :=
+  ⟨fun h a ha b hb => @h (toDual b) hb (toDual a) ha,
+    fun h a ha b hb => @h (b.ofDual) hb (a.ofDual) ha⟩
+
+theorem strictAntiOn_comp_ofDual_iff' :
+    StrictAntiOn (f ∘ ofDual) (ofDual ⁻¹' s) ↔ StrictMonoOn f s :=
+  strictAntiOn_comp_ofDual_iff
 
 @[simp]
-theorem strictMonoOn_toDual_comp_iff : StrictMonoOn (toDual ∘ f : α → βᵒᵈ) s ↔ StrictAntiOn f s :=
+theorem strictMonoOn_toDual_comp_iff : StrictMonoOn (toDual ∘ f) s ↔ StrictAntiOn f s :=
   Iff.rfl
 
 @[simp]
-theorem strictAntiOn_toDual_comp_iff : StrictAntiOn (toDual ∘ f : α → βᵒᵈ) s ↔ StrictMonoOn f s :=
+theorem strictAntiOn_toDual_comp_iff : StrictAntiOn (toDual ∘ f) s ↔ StrictMonoOn f s :=
   Iff.rfl
 
-theorem monotone_dual_iff : Monotone (toDual ∘ f ∘ ofDual : αᵒᵈ → βᵒᵈ) ↔ Monotone f := by
+theorem monotone_dual_iff : Monotone (toDual ∘ f ∘ ofDual) ↔ Monotone f := by
   rw [monotone_toDual_comp_iff, antitone_comp_ofDual_iff]
 
-theorem antitone_dual_iff : Antitone (toDual ∘ f ∘ ofDual : αᵒᵈ → βᵒᵈ) ↔ Antitone f := by
+theorem antitone_dual_iff : Antitone (toDual ∘ f ∘ ofDual) ↔ Antitone f := by
   rw [antitone_toDual_comp_iff, monotone_comp_ofDual_iff]
 
-theorem monotoneOn_dual_iff : MonotoneOn (toDual ∘ f ∘ ofDual : αᵒᵈ → βᵒᵈ) s ↔ MonotoneOn f s := by
+theorem monotoneOn_dual_iff {s : Set αᵒᵈ} :
+    MonotoneOn (toDual ∘ f ∘ ofDual) s ↔ MonotoneOn f (toDual ⁻¹' s) := by
   rw [monotoneOn_toDual_comp_iff, antitoneOn_comp_ofDual_iff]
+theorem monotoneOn_dual_iff' :
+    MonotoneOn (toDual ∘ f ∘ ofDual) (ofDual ⁻¹' s) ↔ MonotoneOn f s :=
+  monotoneOn_dual_iff
 
-theorem antitoneOn_dual_iff : AntitoneOn (toDual ∘ f ∘ ofDual : αᵒᵈ → βᵒᵈ) s ↔ AntitoneOn f s := by
+theorem antitoneOn_dual_iff {s : Set αᵒᵈ} :
+    AntitoneOn (toDual ∘ f ∘ ofDual) s ↔ AntitoneOn f (toDual ⁻¹' s) := by
   rw [antitoneOn_toDual_comp_iff, monotoneOn_comp_ofDual_iff]
+theorem antitoneOn_dual_iff' :
+    AntitoneOn (toDual ∘ f ∘ ofDual) (ofDual ⁻¹' s) ↔ AntitoneOn f s :=
+  antitoneOn_dual_iff
 
-theorem strictMono_dual_iff : StrictMono (toDual ∘ f ∘ ofDual : αᵒᵈ → βᵒᵈ) ↔ StrictMono f := by
+theorem strictMono_dual_iff : StrictMono (toDual ∘ f ∘ ofDual) ↔ StrictMono f := by
   rw [strictMono_toDual_comp_iff, strictAnti_comp_ofDual_iff]
 
-theorem strictAnti_dual_iff : StrictAnti (toDual ∘ f ∘ ofDual : αᵒᵈ → βᵒᵈ) ↔ StrictAnti f := by
+theorem strictAnti_dual_iff : StrictAnti (toDual ∘ f ∘ ofDual) ↔ StrictAnti f := by
   rw [strictAnti_toDual_comp_iff, strictMono_comp_ofDual_iff]
 
-theorem strictMonoOn_dual_iff :
-    StrictMonoOn (toDual ∘ f ∘ ofDual : αᵒᵈ → βᵒᵈ) s ↔ StrictMonoOn f s := by
+theorem strictMonoOn_dual_iff {s : Set αᵒᵈ} :
+    StrictMonoOn (toDual ∘ f ∘ ofDual) s ↔ StrictMonoOn f (toDual ⁻¹' s) := by
   rw [strictMonoOn_toDual_comp_iff, strictAntiOn_comp_ofDual_iff]
+theorem strictMonoOn_dual_iff' :
+    StrictMonoOn (toDual ∘ f ∘ ofDual) (ofDual ⁻¹' s) ↔ StrictMonoOn f s :=
+  strictMonoOn_dual_iff
 
-theorem strictAntiOn_dual_iff :
-    StrictAntiOn (toDual ∘ f ∘ ofDual : αᵒᵈ → βᵒᵈ) s ↔ StrictAntiOn f s := by
+theorem strictAntiOn_dual_iff {s : Set αᵒᵈ} :
+    StrictAntiOn (toDual ∘ f ∘ ofDual) s ↔ StrictAntiOn f (toDual ⁻¹' s) := by
   rw [strictAntiOn_toDual_comp_iff, strictMonoOn_comp_ofDual_iff]
+theorem strictAntiOn_dual_iff' :
+    StrictAntiOn (toDual ∘ f ∘ ofDual) (ofDual ⁻¹' s) ↔ StrictAntiOn f s :=
+  strictAntiOn_dual_iff
 
-alias ⟨_, Monotone.dual_left⟩ := antitone_comp_ofDual_iff
+alias ⟨Monotone.of_dual_left, Monotone.dual_left⟩ := antitone_comp_ofDual_iff
 
-alias ⟨_, Antitone.dual_left⟩ := monotone_comp_ofDual_iff
+alias ⟨Antitone.of_dual_left, Antitone.dual_left⟩ := monotone_comp_ofDual_iff
 
-alias ⟨_, Monotone.dual_right⟩ := antitone_toDual_comp_iff
+alias ⟨Monotone.of_dual_right, Monotone.dual_right⟩ := antitone_toDual_comp_iff
 
-alias ⟨_, Antitone.dual_right⟩ := monotone_toDual_comp_iff
+alias ⟨Antitone.of_dual_right, Antitone.dual_right⟩ := monotone_toDual_comp_iff
 
-alias ⟨_, MonotoneOn.dual_left⟩ := antitoneOn_comp_ofDual_iff
+alias ⟨MonotoneOn.of_dual_left, MonotoneOn.dual_left'⟩ := antitoneOn_comp_ofDual_iff
+alias ⟨MonotoneOn.of_dual_left', MonotoneOn.dual_left⟩ := antitoneOn_comp_ofDual_iff'
 
-alias ⟨_, AntitoneOn.dual_left⟩ := monotoneOn_comp_ofDual_iff
+alias ⟨AntitoneOn.of_dual_left, AntitoneOn.dual_left'⟩ := monotoneOn_comp_ofDual_iff
+alias ⟨AntitoneOn.of_dual_left', AntitoneOn.dual_left⟩ := monotoneOn_comp_ofDual_iff'
 
-alias ⟨_, MonotoneOn.dual_right⟩ := antitoneOn_toDual_comp_iff
+alias ⟨MonotoneOn.of_dual_right, MonotoneOn.dual_right⟩ := antitoneOn_toDual_comp_iff
 
-alias ⟨_, AntitoneOn.dual_right⟩ := monotoneOn_toDual_comp_iff
+alias ⟨AntitoneOn.of_dual_right, AntitoneOn.dual_right⟩ := monotoneOn_toDual_comp_iff
 
-alias ⟨_, StrictMono.dual_left⟩ := strictAnti_comp_ofDual_iff
+alias ⟨StrictMono.of_dual_left, StrictMono.dual_left⟩ := strictAnti_comp_ofDual_iff
 
-alias ⟨_, StrictAnti.dual_left⟩ := strictMono_comp_ofDual_iff
+alias ⟨StrictAnti.of_dual_left, StrictAnti.dual_left⟩ := strictMono_comp_ofDual_iff
 
-alias ⟨_, StrictMono.dual_right⟩ := strictAnti_toDual_comp_iff
+alias ⟨StrictMono.of_dual_right, StrictMono.dual_right⟩ := strictAnti_toDual_comp_iff
 
-alias ⟨_, StrictAnti.dual_right⟩ := strictMono_toDual_comp_iff
+alias ⟨StrictAnti.of_dual_right, StrictAnti.dual_right⟩ := strictMono_toDual_comp_iff
 
-alias ⟨_, StrictMonoOn.dual_left⟩ := strictAntiOn_comp_ofDual_iff
+alias ⟨StrictMonoOn.of_dual_left, StrictMonoOn.dual_left⟩ := strictAntiOn_comp_ofDual_iff
 
-alias ⟨_, StrictAntiOn.dual_left⟩ := strictMonoOn_comp_ofDual_iff
+alias ⟨StrictAntiOn.of_dual_left, StrictAntiOn.dual_left'⟩ := strictMonoOn_comp_ofDual_iff
+alias ⟨StrictAntiOn.of_dual_left', StrictAntiOn.dual_left⟩ := strictMonoOn_comp_ofDual_iff'
 
-alias ⟨_, StrictMonoOn.dual_right⟩ := strictAntiOn_toDual_comp_iff
+alias ⟨StrictMonoOn.of_dual_right, StrictMonoOn.dual_right⟩ := strictAntiOn_toDual_comp_iff
 
-alias ⟨_, StrictAntiOn.dual_right⟩ := strictMonoOn_toDual_comp_iff
+alias ⟨StrictAntiOn.of_dual_right, StrictAntiOn.dual_right⟩ := strictMonoOn_toDual_comp_iff
 
-alias ⟨_, Monotone.dual⟩ := monotone_dual_iff
+alias ⟨Monotone.of_dual, Monotone.dual⟩ := monotone_dual_iff
 
-alias ⟨_, Antitone.dual⟩ := antitone_dual_iff
+alias ⟨Antitone.of_dual, Antitone.dual⟩ := antitone_dual_iff
 
-alias ⟨_, MonotoneOn.dual⟩ := monotoneOn_dual_iff
+alias ⟨MonotoneOn.of_dual, MonotoneOn.dual'⟩ := monotoneOn_dual_iff
+alias ⟨MonotoneOn.of_dual', MonotoneOn.dual⟩ := monotoneOn_dual_iff'
 
-alias ⟨_, AntitoneOn.dual⟩ := antitoneOn_dual_iff
+alias ⟨AntitoneOn.of_dual, AntitoneOn.dual'⟩ := antitoneOn_dual_iff
+alias ⟨AntitoneOn.of_dual', AntitoneOn.dual⟩ := antitoneOn_dual_iff'
 
-alias ⟨_, StrictMono.dual⟩ := strictMono_dual_iff
+alias ⟨StrictMono.of_dual, StrictMono.dual⟩ := strictMono_dual_iff
 
-alias ⟨_, StrictAnti.dual⟩ := strictAnti_dual_iff
+alias ⟨StrictAnti.of_dual, StrictAnti.dual⟩ := strictAnti_dual_iff
 
-alias ⟨_, StrictMonoOn.dual⟩ := strictMonoOn_dual_iff
+alias ⟨StrictMonoOn.of_dual, StrictMonoOn.dual'⟩ := strictMonoOn_dual_iff
+alias ⟨StrictMonoOn.of_dual', StrictMonoOn.dual⟩ := strictMonoOn_dual_iff'
 
-alias ⟨_, StrictAntiOn.dual⟩ := strictAntiOn_dual_iff
+alias ⟨StrictAntiOn.of_dual, StrictAntiOn.dual'⟩ := strictAntiOn_dual_iff
+alias ⟨StrictAntiOn.of_dual', StrictAntiOn.dual⟩ := strictAntiOn_dual_iff'
 
 end OrderDual
 
@@ -247,11 +290,11 @@ theorem StrictMono.wellFoundedLT [WellFoundedLT β] (hf : StrictMono f) : WellFo
 theorem StrictAnti.wellFoundedLT [WellFoundedGT β] (hf : StrictAnti f) : WellFoundedLT α :=
   StrictMono.wellFoundedLT (β := βᵒᵈ) hf
 
-theorem StrictMono.wellFoundedGT [WellFoundedGT β] (hf : StrictMono f) : WellFoundedGT α :=
-  StrictMono.wellFoundedLT (α := αᵒᵈ) (β := βᵒᵈ) (fun _ _ h ↦ hf h)
+theorem StrictMono.wellFoundedGT [WellFoundedGT β] (hf : StrictMono f) : WellFoundedGT α where
+  wf := InvImage.wf toDual <| (StrictMono.wellFoundedLT (α := αᵒᵈ) (β := βᵒᵈ) (fun _ _ h ↦ hf h)).wf
 
-theorem StrictAnti.wellFoundedGT [WellFoundedLT β] (hf : StrictAnti f) : WellFoundedGT α :=
-  StrictMono.wellFoundedLT (α := αᵒᵈ) (fun _ _ h ↦ hf h)
+theorem StrictAnti.wellFoundedGT [WellFoundedLT β] (hf : StrictAnti f) : WellFoundedGT α where
+  wf := InvImage.wf toDual <| (StrictMono.wellFoundedLT (α := αᵒᵈ) (fun _ _ h ↦ hf h)).wf
 
 end WellFounded
 
@@ -309,8 +352,10 @@ protected theorem StrictMono.ite (hf : StrictMono f) (hg : StrictMono g) {p : α
 protected theorem StrictAnti.ite' (hf : StrictAnti f) (hg : StrictAnti g) {p : α → Prop}
     [DecidablePred p]
     (hp : ∀ ⦃x y⦄, x < y → p y → p x) (hfg : ∀ ⦃x y⦄, p x → ¬p y → x < y → g y < f x) :
-    StrictAnti fun x ↦ if p x then f x else g x :=
-  StrictMono.ite' hf.dual_right hg.dual_right hp hfg
+    StrictAnti fun x ↦ if p x then f x else g x := by
+  apply of_dual_right
+  convert (StrictMono.ite' hf.dual_right hg.dual_right hp hfg) with x
+  simp [apply_ite toDual (p x)]
 
 protected theorem StrictAnti.ite (hf : StrictAnti f) (hg : StrictAnti g) {p : α → Prop}
     [DecidablePred p] (hp : ∀ ⦃x y⦄, x < y → p y → p x) (hfg : ∀ x, g x ≤ f x) :
@@ -370,8 +415,9 @@ theorem StrictMonoOn.eq_iff_eq (hf : StrictMonoOn f s) {a b : α} (ha : a ∈ s)
     rfl⟩
 
 theorem StrictAntiOn.eq_iff_eq (hf : StrictAntiOn f s) {a b : α} (ha : a ∈ s) (hb : b ∈ s) :
-    f a = f b ↔ b = a :=
-  (hf.dual_right.eq_iff_eq ha hb).trans eq_comm
+    f a = f b ↔ b = a := by
+  convert (hf.dual_right.eq_iff_eq ha hb).trans eq_comm
+  simp
 
 theorem StrictMonoOn.lt_iff_lt (hf : StrictMonoOn f s) {a b : α} (ha : a ∈ s) (hb : b ∈ s) :
     f a < f b ↔ a < b := by
@@ -402,7 +448,8 @@ protected theorem StrictMonoOn.compares (hf : StrictMonoOn f s) {a b : α} (ha :
 
 protected theorem StrictAntiOn.compares (hf : StrictAntiOn f s) {a b : α} (ha : a ∈ s)
     (hb : b ∈ s) {o : Ordering} : o.Compares (f a) (f b) ↔ o.Compares b a :=
-  toDual_compares_toDual.trans <| hf.dual_right.compares hb ha
+  toDual_compares_toDual.symm.trans <| hf.dual_right.compares hb ha
+
 
 protected theorem StrictMono.compares (hf : StrictMono f) {a b : α} {o : Ordering} :
     o.Compares (f a) (f b) ↔ o.Compares a b :=
@@ -421,7 +468,8 @@ theorem StrictAnti.injective (hf : StrictAnti f) : Injective f :=
 lemma StrictMonoOn.injOn (hf : StrictMonoOn f s) : s.InjOn f := fun x hx y hy hxy ↦
   show Ordering.eq.Compares x y from (hf.compares hx hy).1 hxy
 
-lemma StrictAntiOn.injOn (hf : StrictAntiOn f s) : s.InjOn f := hf.dual_left.injOn
+lemma StrictAntiOn.injOn (hf : StrictAntiOn f s) : s.InjOn f := fun x hx y hy he => by
+  exact congrArg ofDual <| hf.dual_left.injOn hx hy he
 
 theorem StrictMono.maximal_of_maximal_image (hf : StrictMono f) {a} (hmax : ∀ p, p ≤ f a) (x : α) :
     x ≤ a :=
@@ -567,7 +615,7 @@ theorem strictMono_nat_of_lt_succ {f : ℕ → α} (hf : ∀ n, f n < f (n + 1))
   Nat.rel_of_forall_rel_succ_of_lt (· < ·) hf
 
 theorem strictAnti_nat_of_succ_lt {f : ℕ → α} (hf : ∀ n, f (n + 1) < f n) : StrictAnti f :=
-  @strictMono_nat_of_lt_succ αᵒᵈ _ f hf
+  @strictMono_nat_of_lt_succ αᵒᵈ _ (toDual ∘ f) hf
 
 namespace Nat
 
@@ -580,7 +628,9 @@ theorem exists_strictMono' [NoMaxOrder α] (a : α) : ∃ f : ℕ → α, Strict
 /-- If `α` is a preorder with no maximal elements, then there exists a strictly antitone function
 `ℕ → α` with any prescribed value of `f 0`. -/
 theorem exists_strictAnti' [NoMinOrder α] (a : α) : ∃ f : ℕ → α, StrictAnti f ∧ f 0 = a :=
-  exists_strictMono' (OrderDual.toDual a)
+  (exists_strictMono' (OrderDual.toDual a)).elim
+    (⟨ofDual ∘ ·, ·.imp (StrictMono.dual_right) (congrArg ofDual)⟩)
+
 
 theorem exists_strictMono_subsequence {P : ℕ → Prop} (h : ∀ N, ∃ n > N, P n) :
     ∃ φ : ℕ → ℕ, StrictMono φ ∧ ∀ n, P (φ n) := by
@@ -601,7 +651,7 @@ theorem exists_strictMono [Nonempty α] [NoMaxOrder α] : ∃ f : ℕ → α, St
 /-- If `α` is a nonempty preorder with no minimal elements, then there exists a strictly antitone
 function `ℕ → α`. -/
 theorem exists_strictAnti [Nonempty α] [NoMinOrder α] : ∃ f : ℕ → α, StrictAnti f :=
-  exists_strictMono αᵒᵈ
+  (exists_strictMono αᵒᵈ).elim (⟨ofDual ∘ ·,·⟩)
 
 lemma pow_self_mono : Monotone fun n : ℕ ↦ n ^ n := by
   refine monotone_nat_of_le_succ fun n ↦ ?_
@@ -663,7 +713,7 @@ theorem exists_strictMono : ∃ f : ℤ → α, StrictMono f := by
 /-- If `α` is a nonempty preorder with no minimal or maximal elements, then there exists a strictly
 antitone function `f : ℤ → α`. -/
 theorem exists_strictAnti : ∃ f : ℤ → α, StrictAnti f :=
-  exists_strictMono αᵒᵈ
+  (exists_strictMono αᵒᵈ).elim (⟨ofDual ∘ ·,·⟩)
 
 end Int
 

--- a/Mathlib/Order/RelClasses.lean
+++ b/Mathlib/Order/RelClasses.lean
@@ -239,18 +239,18 @@ lemma wellFounded_lt [LT α] [WellFoundedLT α] : @WellFounded α (· < ·) := I
 lemma wellFounded_gt [LT α] [WellFoundedGT α] : @WellFounded α (· > ·) := IsWellFounded.wf
 
 -- See note [lower instance priority]
-instance (priority := 100) (α : Type*) [LT α] [h : WellFoundedLT α] : WellFoundedGT αᵒᵈ :=
-  h
+instance (priority := 100) (α : Type*) [LT α] [h : WellFoundedLT α] : WellFoundedGT αᵒᵈ where
+  wf := InvImage.wf OrderDual.ofDual' h.wf
 
 -- See note [lower instance priority]
-instance (priority := 100) (α : Type*) [LT α] [h : WellFoundedGT α] : WellFoundedLT αᵒᵈ :=
-  h
+instance (priority := 100) (α : Type*) [LT α] [h : WellFoundedGT α] : WellFoundedLT αᵒᵈ where
+  wf := InvImage.wf OrderDual.ofDual' h.wf
 
 theorem wellFoundedGT_dual_iff (α : Type*) [LT α] : WellFoundedGT αᵒᵈ ↔ WellFoundedLT α :=
-  ⟨fun h => ⟨h.wf⟩, fun h => ⟨h.wf⟩⟩
+  ⟨fun h => ⟨InvImage.wf OrderDual.toDual' h.wf⟩, fun h => ⟨InvImage.wf OrderDual.ofDual' h.wf⟩⟩
 
 theorem wellFoundedLT_dual_iff (α : Type*) [LT α] : WellFoundedLT αᵒᵈ ↔ WellFoundedGT α :=
-  ⟨fun h => ⟨h.wf⟩, fun h => ⟨h.wf⟩⟩
+  ⟨fun h => ⟨InvImage.wf OrderDual.toDual' h.wf⟩, fun h => ⟨InvImage.wf OrderDual.ofDual' h.wf⟩⟩
 
 /-- A well order is a well-founded linear order. -/
 class IsWellOrder (α : Type u) (r : α → α → Prop) : Prop
@@ -396,8 +396,9 @@ theorem Prod.wellFoundedLT' [PartialOrder α] [WellFoundedLT α] [Preorder β] [
 
 /-- See `Prod.wellFoundedGT` for a version that only requires `Preorder α`. -/
 theorem Prod.wellFoundedGT' [PartialOrder α] [WellFoundedGT α] [Preorder β] [WellFoundedGT β] :
-    WellFoundedGT (α × β) :=
-  @Prod.wellFoundedLT' αᵒᵈ βᵒᵈ _ _ _ _
+    WellFoundedGT (α × β) where
+  wf := InvImage.wf (Prod.map OrderDual.toDual' OrderDual.toDual')
+    (@Prod.wellFoundedLT' αᵒᵈ βᵒᵈ _ _ _ _).wf
 
 namespace Set
 
@@ -772,8 +773,8 @@ theorem transitive_ge [Preorder α] : Transitive (@GE.ge α _) :=
 theorem transitive_gt [Preorder α] : Transitive (@GT.gt α _) :=
   transitive_of_trans _
 
-instance OrderDual.isTotal_le [LE α] [h : IsTotal α (· ≤ ·)] : IsTotal αᵒᵈ (· ≤ ·) :=
-  @IsTotal.swap α _ h
+instance OrderDual.isTotal_le [LE α] [h : IsTotal α (· ≤ ·)] : IsTotal αᵒᵈ (· ≤ ·) where
+  total a b := IsTotal.total (self := h) b.ofDual' a.ofDual'
 
 instance : WellFoundedLT ℕ :=
   ⟨Nat.lt_wfRel.wf⟩

--- a/Mathlib/Order/Synonym.lean
+++ b/Mathlib/Order/Synonym.lean
@@ -41,16 +41,21 @@ variable {α : Type*}
 
 namespace OrderDual
 
-instance [h : Nontrivial α] : Nontrivial αᵒᵈ :=
-  h
+instance [h : Nontrivial α] : Nontrivial αᵒᵈ where
+  exists_pair_ne := h.exists_pair_ne.elim
+    (fun a ⟨b,hb⟩ => ⟨toDual' a, ⟨toDual' b,hb ∘ congrArg ofDual'⟩⟩)
 
 /-- `toDual` is the identity function to the `OrderDual` of a linear order. -/
-def toDual : α ≃ αᵒᵈ :=
-  Equiv.refl _
+def toDual : α ≃ αᵒᵈ := ⟨toDual',ofDual',fun _ => rfl, fun _ => rfl⟩
 
 /-- `ofDual` is the identity function from the `OrderDual` of a linear order. -/
-def ofDual : αᵒᵈ ≃ α :=
-  Equiv.refl _
+def ofDual : αᵒᵈ ≃ α := toDual.symm
+
+@[simp]
+theorem toDual'_eq : (@toDual' α) = ⇑(@toDual α) := rfl
+
+@[simp]
+theorem ofDual'_eq : (@ofDual' α) = ⇑(@ofDual α) := rfl
 
 @[simp]
 theorem toDual_symm_eq : (@toDual α).symm = ofDual := rfl
@@ -98,18 +103,18 @@ theorem toDual_le [LE α] {a : α} {b : αᵒᵈ} : toDual a ≤ b ↔ ofDual b 
 theorem toDual_lt [LT α] {a : α} {b : αᵒᵈ} : toDual a < b ↔ ofDual b < a :=
   Iff.rfl
 
-/-- Recursor for `αᵒᵈ`. -/
-@[elab_as_elim]
-protected def rec {C : αᵒᵈ → Sort*} (h₂ : ∀ a : α, C (toDual a)) : ∀ a : αᵒᵈ, C a :=
-  h₂
+/-- Recursor for `αᵒᵈ` using `OrderDual.toDual`. -/
+@[elab_as_elim, induction_eliminator, cases_eliminator]
+protected def rec' {C : αᵒᵈ → Sort*} (h₂ : ∀ a : α, C (toDual a)) : ∀ a : αᵒᵈ, C a :=
+  fun a => h₂ (ofDual a)
 
 @[simp]
 protected theorem «forall» {p : αᵒᵈ → Prop} : (∀ a, p a) ↔ ∀ a, p (toDual a) :=
-  Iff.rfl
+  ⟨(· <| toDual ·),(· <| ofDual ·)⟩
 
 @[simp]
 protected theorem «exists» {p : αᵒᵈ → Prop} : (∃ a, p a) ↔ ∃ a, p (toDual a) :=
-  Iff.rfl
+  ⟨(·.rec (⟨ofDual ·, ·⟩)),(·.rec (⟨toDual ·, ·⟩))⟩
 
 alias ⟨_, _root_.LE.le.dual⟩ := toDual_le_toDual
 

--- a/Mathlib/Order/WithBot.lean
+++ b/Mathlib/Order/WithBot.lean
@@ -504,25 +504,27 @@ theorem coe_ne_top : (a : WithTop α) ≠ ⊤ :=
 See `WithTop.toDualBotEquiv` for the related order-iso.
 -/
 protected def toDual : WithTop α ≃ WithBot αᵒᵈ :=
-  Equiv.refl _
+  ⟨Option.map OrderDual.toDual,Option.map OrderDual.ofDual,
+    fun | .some _ => rfl | .none => rfl, fun | .some _ => rfl | .none => rfl⟩
 
 /-- `WithTop.ofDual` is the equivalence sending `⊤` to `⊥` and any `a : αᵒᵈ` to `ofDual a : α`.
 See `WithTop.toDualBotEquiv` for the related order-iso.
 -/
 protected def ofDual : WithTop αᵒᵈ ≃ WithBot α :=
-  Equiv.refl _
+  ⟨Option.map OrderDual.ofDual,Option.map OrderDual.toDual,
+    fun | .some _ => rfl | .none => rfl, fun | .some _ => rfl | .none => rfl⟩
 
 /-- `WithBot.toDual` is the equivalence sending `⊥` to `⊤` and any `a : α` to `toDual a : αᵒᵈ`.
 See `WithBot.toDual_top_equiv` for the related order-iso.
 -/
 protected def _root_.WithBot.toDual : WithBot α ≃ WithTop αᵒᵈ :=
-  Equiv.refl _
+  WithTop.ofDual.symm
 
 /-- `WithBot.ofDual` is the equivalence sending `⊥` to `⊤` and any `a : αᵒᵈ` to `ofDual a : α`.
 See `WithBot.ofDual_top_equiv` for the related order-iso.
 -/
 protected def _root_.WithBot.ofDual : WithBot αᵒᵈ ≃ WithTop α :=
-  Equiv.refl _
+  _root_.WithTop.toDual.symm
 
 @[simp]
 theorem toDual_symm_apply (a : WithBot αᵒᵈ) : WithTop.toDual.symm a = WithBot.ofDual a :=
@@ -537,7 +539,7 @@ theorem toDual_apply_top : WithTop.toDual (⊤ : WithTop α) = ⊥ :=
   rfl
 
 @[simp]
-theorem ofDual_apply_top : WithTop.ofDual (⊤ : WithTop α) = ⊥ :=
+theorem ofDual_apply_top : WithTop.ofDual (⊤ : WithTop αᵒᵈ) = ⊥ :=
   rfl
 
 open OrderDual
@@ -640,15 +642,15 @@ lemma map₂_coe_coe (f : α → β → γ) (a : α) (b : β) : map₂ f a b = f
     map₂ f a b = ⊤ ↔ a = ⊤ ∨ b = ⊤ := Option.map₂_eq_none_iff
 
 theorem map_toDual (f : αᵒᵈ → βᵒᵈ) (a : WithBot α) :
-    map f (WithBot.toDual a) = a.map (toDual ∘ f) :=
-  rfl
+    map f (WithBot.toDual a) = map (f ∘ toDual) a :=
+  congrFun (Option.map_comp_map _ _) a
 
-theorem map_ofDual (f : α → β) (a : WithBot αᵒᵈ) : map f (WithBot.ofDual a) = a.map (ofDual ∘ f) :=
-  rfl
+theorem map_ofDual (f : α → β) (a : WithBot αᵒᵈ) : map f (WithBot.ofDual a) = a.map (f ∘ ofDual) :=
+  congrFun (Option.map_comp_map _ _) a
 
 theorem toDual_map (f : α → β) (a : WithTop α) :
     WithTop.toDual (map f a) = WithBot.map (toDual ∘ f ∘ ofDual) (WithTop.toDual a) :=
-  rfl
+  congrFun (Option.map_comp_map _ _) a
 
 theorem ofDual_map (f : αᵒᵈ → βᵒᵈ) (a : WithTop αᵒᵈ) :
     WithTop.ofDual (map f a) = WithBot.map (ofDual ∘ f ∘ toDual) (WithTop.ofDual a) :=


### PR DESCRIPTION


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
