### PR TITLE
[Merged by Bors] - fix(scripts/create-adaption-pr.sh): fetch `master` if necessary

### DIFF
--- a/scripts/create-adaptation-pr.sh
+++ b/scripts/create-adaptation-pr.sh
@@ -126,6 +126,7 @@ usr_branch=$(git branch --show-current)
 echo
 echo "### [auto] checkout master and pull the latest changes"
 
+git fetch $MAIN_REMOTE master
 git checkout master
 git pull $MAIN_REMOTE master
 


### PR DESCRIPTION
Makes sure that `master` is available, in particular when the remote has been automatically added.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
