### PR TITLE
[Merged by Bors] - feat: `@[gcongr]` for `insert`/`erase`

### DIFF
--- a/Archive/Imo/Imo2019Q2.lean
+++ b/Archive/Imo/Imo2019Q2.lean
@@ -349,7 +349,8 @@ theorem A₂_ne_C : cfg.A₂ ≠ cfg.C := by
   have hc : Collinear ℝ ({cfg.A, cfg.B, cfg.C, cfg.A₁} : Set Pt) :=
     collinear_insert_insert_of_mem_affineSpan_pair h₁.left_mem_affineSpan
       cfg.sbtw_B_A₁_C.left_mem_affineSpan
-  refine hc.subset (Set.insert_subset_insert (Set.insert_subset_insert ?_))
+  refine hc.subset ?_
+  gcongr
   rw [Set.singleton_subset_iff]
   exact Set.mem_insert _ _
 
@@ -483,11 +484,11 @@ theorem symm_ω : cfg.symm.ω = cfg.ω := by
   · simp only [trianglePQB₂, Matrix.range_cons, Matrix.range_empty, Set.singleton_union,
       insert_empty_eq]
     rw [Set.insert_comm]
-    refine Set.insert_subset_insert (Set.insert_subset_insert ?_)
+    gcongr
     simp
   · simp only [triangleQPA₂, Matrix.range_cons, Matrix.range_empty, Set.singleton_union,
       insert_empty_eq]
-    refine Set.insert_subset_insert (Set.insert_subset_insert ?_)
+    gcongr
     simp
 
 /-! ### The second angle chase in the solution -/

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -181,8 +181,8 @@ theorem ssubset_iff_exists_subset_erase {s t : Finset α} : s ⊂ t ↔ ∃ a �
   exact ⟨a, ht, subset_erase.2 ⟨h.1, hs⟩⟩
 
 theorem erase_ssubset_insert (s : Finset α) (a : α) : s.erase a ⊂ insert a s :=
-  ssubset_iff_exists_subset_erase.2
-    ⟨a, mem_insert_self _ _, erase_subset_erase _ <| subset_insert _ _⟩
+  ssubset_iff_exists_subset_erase.2 <| by
+    exact ⟨a, mem_insert_self _ _, by grw [← subset_insert]⟩
 
 theorem erase_cons {s : Finset α} {a : α} (h : a ∉ s) : (s.cons a h).erase a = s := by
   rw [cons_eq_insert, erase_insert_eq_erase, erase_eq_of_notMem h]

--- a/Mathlib/Data/Finset/Erase.lean
+++ b/Mathlib/Data/Finset/Erase.lean
@@ -86,6 +86,7 @@ theorem erase_eq_self : s.erase a = s ↔ a ∉ s :=
 theorem erase_ne_self : s.erase a ≠ s ↔ a ∈ s :=
   erase_eq_self.not_left
 
+@[gcongr]
 theorem erase_subset_erase (a : α) {s t : Finset α} (h : s ⊆ t) : erase s a ⊆ erase t a :=
   val_le_iff.1 <| erase_le_erase _ <| val_le_iff.2 h
 

--- a/Mathlib/Data/Matroid/Circuit.lean
+++ b/Mathlib/Data/Matroid/Circuit.lean
@@ -278,14 +278,13 @@ lemma IsCircuit.eq_fundCircuit_of_subset (hC : M.IsCircuit C) (hI : M.Indep I)
 lemma fundCircuit_restrict {R : Set α} (hIR : I ⊆ R) (heR : e ∈ R) (hR : R ⊆ M.E) :
     (M ↾ R).fundCircuit e I = M.fundCircuit e I := by
   simp_rw [fundCircuit, M.restrict_closure_eq (R := R) (X := {e}) (by simpa)]
-  refine subset_antisymm (insert_subset_insert (inter_subset_inter_right _ ?_))
-    (insert_subset_insert (inter_subset_inter_right _ ?_))
-  · refine subset_sInter fun J ⟨hJI, heJ⟩ ↦ sInter_subset_of_mem ⟨hJI, ?_⟩
+  apply subset_antisymm
+  · gcongr 5 with J hJI; intro heJ
     simp only [restrict_closure_eq']
     refine (inter_subset_inter_left _ ?_).trans subset_union_left
     rwa [inter_eq_self_of_subset_left (hJI.trans hIR)]
-  refine subset_sInter fun J ⟨hJI, heJ⟩ ↦ sInter_subset_of_mem
-    ⟨hJI, M.closure_subset_closure_of_subset_closure ?_⟩
+  gcongr 5 with J hJI; intro heJ
+  refine closure_subset_closure_of_subset_closure ?_
   rw [restrict_closure_eq _ (hJI.trans hIR) hR] at heJ
   simp only [subset_inter_iff, inter_subset_right, and_true] at heJ
   exact subset_trans (by simpa [M.mem_closure_of_mem' (mem_singleton e) (hR heR)]) heJ

--- a/Mathlib/Data/Set/Insert.lean
+++ b/Mathlib/Data/Set/Insert.lean
@@ -84,6 +84,7 @@ theorem insert_subset_iff : insert a s ⊆ t ↔ a ∈ t ∧ s ⊆ t := by
 theorem insert_subset (ha : a ∈ t) (hs : s ⊆ t) : insert a s ⊆ t :=
   insert_subset_iff.mpr ⟨ha, hs⟩
 
+@[gcongr]
 theorem insert_subset_insert (h : s ⊆ t) : insert a s ⊆ insert a t := fun _ => Or.imp_right (@h _)
 
 @[simp] theorem insert_subset_insert_iff (ha : a ∉ s) : insert a s ⊆ insert a t ↔ s ⊆ t := by

--- a/Mathlib/FieldTheory/IntermediateField/Adjoin/Defs.lean
+++ b/Mathlib/FieldTheory/IntermediateField/Adjoin/Defs.lean
@@ -316,7 +316,7 @@ theorem subset_adjoin : S ⊆ adjoin F S := fun _ hx => Subfield.subset_closure 
 
 instance adjoin.setCoe : CoeTC S (adjoin F S) where coe x := ⟨x, subset_adjoin F S (Subtype.mem x)⟩
 
-@[mono]
+@[mono, gcongr]
 theorem adjoin.mono (T : Set E) (h : S ⊆ T) : adjoin F S ≤ adjoin F T :=
   GaloisConnection.monotone_l gc h
 
@@ -373,7 +373,7 @@ theorem adjoin_insert_adjoin (x : E) :
       (Set.insert_subset_iff.mpr
         ⟨subset_adjoin _ _ (Set.mem_insert _ _),
           adjoin_le_iff.mpr (subset_adjoin_of_subset_right _ _ (Set.subset_insert _ _))⟩))
-    (adjoin.mono _ _ _ (Set.insert_subset_insert (subset_adjoin _ _)))
+    (by grw [← subset_adjoin])
 
 /-- `F[S][T] = F[T][S]` -/
 theorem adjoin_adjoin_comm (T : Set E) :

--- a/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/FiniteDimensional.lean
@@ -598,15 +598,14 @@ theorem collinear_insert_insert_insert_left_of_mem_affineSpan_pair {p₁ p₂ p�
     (h₁ : p₁ ∈ line[k, p₄, p₅]) (h₂ : p₂ ∈ line[k, p₄, p₅]) (h₃ : p₃ ∈ line[k, p₄, p₅]) :
     Collinear k ({p₁, p₂, p₃, p₄} : Set P) := by
   refine (collinear_insert_insert_insert_of_mem_affineSpan_pair h₁ h₂ h₃).subset ?_
-  repeat apply Set.insert_subset_insert
-  simp
+  gcongr; simp
 
 /-- If three points lie in the affine span of two points, the first three points are collinear. -/
 theorem collinear_triple_of_mem_affineSpan_pair {p₁ p₂ p₃ p₄ p₅ : P} (h₁ : p₁ ∈ line[k, p₄, p₅])
     (h₂ : p₂ ∈ line[k, p₄, p₅]) (h₃ : p₃ ∈ line[k, p₄, p₅]) :
     Collinear k ({p₁, p₂, p₃} : Set P) := by
   refine (collinear_insert_insert_insert_left_of_mem_affineSpan_pair h₁ h₂ h₃).subset ?_
-  simp [Set.insert_subset_insert]
+  gcongr; simp
 
 variable (k) in
 /-- A set of points is coplanar if their `vectorSpan` has dimension at most `2`. -/

--- a/Mathlib/Topology/Algebra/Support.lean
+++ b/Mathlib/Topology/Algebra/Support.lean
@@ -69,8 +69,7 @@ alias image_eq_one_of_nmem_mulTSupport := image_eq_one_of_notMem_mulTSupport
 @[to_additive]
 theorem range_subset_insert_image_mulTSupport (f : X → α) :
     range f ⊆ insert 1 (f '' mulTSupport f) :=
-  (range_subset_insert_image_mulSupport f).trans <|
-    insert_subset_insert <| image_subset _ subset_closure
+  (range_subset_insert_image_mulSupport f).trans <| by gcongr
 
 @[to_additive]
 theorem range_eq_image_mulTSupport_or (f : X → α) :

--- a/Mathlib/Topology/Algebra/Support.lean
+++ b/Mathlib/Topology/Algebra/Support.lean
@@ -68,8 +68,8 @@ alias image_eq_one_of_nmem_mulTSupport := image_eq_one_of_notMem_mulTSupport
 
 @[to_additive]
 theorem range_subset_insert_image_mulTSupport (f : X → α) :
-    range f ⊆ insert 1 (f '' mulTSupport f) :=
-  (range_subset_insert_image_mulSupport f).trans <| by gcongr
+    range f ⊆ insert 1 (f '' mulTSupport f) := by
+  grw [← subset_mulTSupport f]; exact range_subset_insert_image_mulSupport f
 
 @[to_additive]
 theorem range_eq_image_mulTSupport_or (f : X → α) :


### PR DESCRIPTION
Also golf some proofs using these new tags. This also required tagging `adjoin.mono`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
