### PR TITLE
feat: add an equality between sums and products of cartesian products 

### DIFF
--- a/Mathlib/Algebra/BigOperators/Fin.lean
+++ b/Mathlib/Algebra/BigOperators/Fin.lean
@@ -164,6 +164,15 @@ theorem prod_congr' {a b : ℕ} (f : Fin b → M) (h : a = b) :
   congr
 
 @[to_additive]
+theorem prod_mul_eq_prod_product {a b : ℕ} {f : ℕ → M} :
+  ∏ x : Fin (a * b), f x =
+  ∏ p : Fin a × Fin b,
+    f (b * p.fst + p.snd : ℕ) := by
+  have := @Equiv.prod_comp M _ _ _ (ι := Fin a × Fin b) (κ := Fin (a * b))
+    (e := finProdFinEquiv) (g := fun x => f x)
+  simp [<- this, add_comm]
+
+@[to_additive]
 theorem prod_univ_add {a b : ℕ} (f : Fin (a + b) → M) :
     (∏ i : Fin (a + b), f i) = (∏ i : Fin a, f (castAdd b i)) * ∏ i : Fin b, f (natAdd a i) := by
   rw [Fintype.prod_equiv finSumFinEquiv.symm f fun i => f (finSumFinEquiv.toFun i)]

--- a/Mathlib/Algebra/BigOperators/Fin.lean
+++ b/Mathlib/Algebra/BigOperators/Fin.lean
@@ -165,21 +165,15 @@ theorem prod_congr' {a b : ℕ} (f : Fin b → M) (h : a = b) :
 
 @[to_additive]
 theorem prod_mul_eq_prod_product {a b : ℕ} {f : ℕ → M} :
-  ∏ x : Fin (a * b), f x =
-  ∏ p : Fin a × Fin b,
-    f (b * p.fst + p.snd : ℕ) := by
+    ∏ x : Fin (a * b), f x = ∏ i : Fin a, ∏ j : Fin b, f (b * i + j) := by
   have := @Equiv.prod_comp M _ _ _ (ι := Fin a × Fin b) (κ := Fin (a * b))
     (e := finProdFinEquiv) (g := fun x => f x)
-  simp [<- this, add_comm]
+  simp [<- this, add_comm, <- Finset.prod_product']
 
 @[to_additive]
 theorem prod_range_mul_eq_prod_product {a b : ℕ} {f : ℕ → M} :
-  ∏ x ∈ Finset.range (a * b), f x =
-  ∏ p ∈ Finset.range a ×ˢ Finset.range b,
-    f (b * p.fst + p.snd) := by
-  simp [prod_mul_eq_prod_product, Finset.prod_range, Fintype.prod_prod_type,
-    Finset.prod_product
-  ]
+    ∏ x ∈ Finset.range (a * b), f x = ∏ i : Fin a, ∏ j : Fin b, f (b * i + j) := by
+  simp [prod_mul_eq_prod_product, Finset.prod_range]
 
 @[to_additive]
 theorem prod_univ_add {a b : ℕ} (f : Fin (a + b) → M) :

--- a/Mathlib/Algebra/BigOperators/Fin.lean
+++ b/Mathlib/Algebra/BigOperators/Fin.lean
@@ -173,6 +173,15 @@ theorem prod_mul_eq_prod_product {a b : ℕ} {f : ℕ → M} :
   simp [<- this, add_comm]
 
 @[to_additive]
+theorem prod_range_mul_eq_prod_product {a b : ℕ} {f : ℕ → M} :
+  ∏ x ∈ Finset.range (a * b), f x =
+  ∏ p ∈ Finset.range a ×ˢ Finset.range b,
+    f (b * p.fst + p.snd) := by
+  simp [prod_mul_eq_prod_product, Finset.prod_range, Fintype.prod_prod_type,
+    Finset.prod_product
+  ]
+
+@[to_additive]
 theorem prod_univ_add {a b : ℕ} (f : Fin (a + b) → M) :
     (∏ i : Fin (a + b), f i) = (∏ i : Fin a, f (castAdd b i)) * ∏ i : Fin b, f (natAdd a i) := by
   rw [Fintype.prod_equiv finSumFinEquiv.symm f fun i => f (finSumFinEquiv.toFun i)]


### PR DESCRIPTION
Adds `prod_mul_eq_prod_product` and a version for Finsets `prod_range_mul_eq_prod_product` with to show an equality between `Fin (i * j)` and `Fin a × Fin b`.

It is likely `prod_range_mul_eq_prod_product` belongs in a different file, in which case only the first commit should be considered.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
