### PR TITLE
[Merged by Bors] - fix(RepresentationTheory/Homological/GroupHomology/*): remove unused `DecidableEq` arguments 

### DIFF
--- a/Mathlib/RepresentationTheory/Homological/GroupHomology/Basic.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupHomology/Basic.lean
@@ -157,8 +157,6 @@ theorem d_eq [DecidableEq G] :
 
 end inhomogeneousChains
 
-variable [DecidableEq G]
-
 /-- Given a `k`-linear `G`-representation `A`, this is the complex of inhomogeneous chains
 $$\dots \to \bigoplus_{G^1} A \to \bigoplus_{G^0} A \to 0$$
 which calculates the group homology of `A`. -/
@@ -166,6 +164,7 @@ noncomputable abbrev inhomogeneousChains :
     ChainComplex (ModuleCat k) ℕ :=
   ChainComplex.of (fun n => ModuleCat.of k ((Fin n → G) →₀ A))
     (fun n => inhomogeneousChains.d A n) fun n => by
+    classical
     simp only [inhomogeneousChains.d_eq]
     slice_lhs 3 4 => { rw [Iso.hom_inv_id] }
     slice_lhs 2 4 => { rw [Category.id_comp, ((barComplex k G).coinvariantsTensorObj A).d_comp_d] }
@@ -189,7 +188,7 @@ theorem inhomogeneousChains.d_comp_d :
 
 /-- Given a `k`-linear `G`-representation `A`, the complex of inhomogeneous chains is isomorphic
 to `(A ⊗[k] P)_G`, where `P` is the bar resolution of `k` as a trivial `G`-representation. -/
-def inhomogeneousChainsIso :
+def inhomogeneousChainsIso [DecidableEq G] :
     inhomogeneousChains A ≅ (barComplex k G).coinvariantsTensorObj A := by
   refine HomologicalComplex.Hom.isoOfComponents ?_ ?_
   · intro i
@@ -216,7 +215,7 @@ end groupHomology
 
 open groupHomology Rep
 
-variable {k G : Type u} [CommRing k] [Group G] [DecidableEq G] (A : Rep k G)
+variable {k G : Type u} [CommRing k] [Group G] (A : Rep k G)
 
 /-- The group homology of a `k`-linear `G`-representation `A`, as the homology of its complex
 of inhomogeneous chains. -/
@@ -239,7 +238,7 @@ theorem groupHomology_induction_on {n : ℕ}
 
 /-- The `n`th group homology of a `k`-linear `G`-representation `A` is isomorphic to
 `Torₙ(A, k)` (taken in `Rep k G`), where `k` is a trivial `k`-linear `G`-representation. -/
-def groupHomologyIsoTor (n : ℕ) :
+def groupHomologyIsoTor [DecidableEq G] (n : ℕ) :
     groupHomology A n ≅ ((Tor k G n).obj A).obj (Rep.trivial k G k) :=
   isoOfQuasiIsoAt (HomotopyEquiv.ofIso (inhomogeneousChainsIso A)).hom n ≪≫
     (torIso A (barResolution k G) n).symm
@@ -247,7 +246,7 @@ def groupHomologyIsoTor (n : ℕ) :
 /-- The `n`th group homology of a `k`-linear `G`-representation `A` is isomorphic to
 `Hₙ((A ⊗ P)_G)`, where `P` is any projective resolution of `k` as a trivial `k`-linear
 `G`-representation. -/
-def groupHomologyIso [Group G] [DecidableEq G] (A : Rep k G) (n : ℕ)
+def groupHomologyIso [DecidableEq G] (A : Rep k G) (n : ℕ)
     (P : ProjectiveResolution (Rep.trivial k G k)) :
     groupHomology A n ≅ (P.complex.coinvariantsTensorObj A).homology n :=
   groupHomologyIsoTor A n ≪≫ torIso A P n

--- a/Mathlib/RepresentationTheory/Homological/GroupHomology/Functoriality.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupHomology/Functoriality.lean
@@ -32,7 +32,6 @@ open CategoryTheory Rep Finsupp Representation
 
 variable {k G H : Type u} [CommRing k] [Group G] [Group H]
   {A : Rep k G} {B : Rep k H} (f : G →* H) (φ : A ⟶ (Action.res _ f).obj B) (n : ℕ)
-  [DecidableEq G] [DecidableEq H]
 
 /-- Given a group homomorphism `f : G →* H` and a representation morphism `φ : A ⟶ Res(f)(B)`,
 this is the chain map sending `∑ aᵢ·gᵢ : Gⁿ →₀ A` to `∑ φ(aᵢ)·(f ∘ gᵢ) : Hⁿ →₀ B`. -/
@@ -70,7 +69,7 @@ lemma chainsMap_id_f_hom_eq_mapRange {A B : Rep k G} (i : ℕ) (φ : A ⟶ B) :
   simp [chainsMap_f, MonoidHom.coe_id]
 
 lemma chainsMap_comp {G H K : Type u} [Group G] [Group H] [Group K]
-    [DecidableEq G] [DecidableEq H] [DecidableEq K] {A : Rep k G} {B : Rep k H} {C : Rep k K}
+    {A : Rep k G} {B : Rep k H} {C : Rep k K}
     (f : G →* H) (g : H →* K) (φ : A ⟶ (Action.res _ f).obj B) (ψ : B ⟶ (Action.res _ g).obj C) :
     chainsMap (g.comp f) (φ ≫ (Action.res _ f).map ψ) = chainsMap f φ ≫ chainsMap g ψ := by
   ext
@@ -117,8 +116,8 @@ lemma cyclesMap_id : cyclesMap (MonoidHom.id G) (𝟙 A) n = 𝟙 _ := by
   simp [cyclesMap]
 
 @[reassoc]
-lemma cyclesMap_comp {G H K : Type u} [Group G] [DecidableEq G] [Group H] [DecidableEq H]
-    [Group K] [DecidableEq K] {A : Rep k G} {B : Rep k H} {C : Rep k K} (f : G →* H) (g : H →* K)
+lemma cyclesMap_comp {G H K : Type u} [Group G] [Group H] [Group K]
+    {A : Rep k G} {B : Rep k H} {C : Rep k K} (f : G →* H) (g : H →* K)
     (φ : A ⟶ (Action.res _ f).obj B) (ψ : B ⟶ (Action.res _ g).obj C) (n : ℕ) :
     cyclesMap (g.comp f) (φ ≫ (Action.res _ f).map ψ) n = cyclesMap f φ n ≫ cyclesMap g ψ n := by
   simp [cyclesMap, ← HomologicalComplex.cyclesMap_comp, ← chainsMap_comp]
@@ -145,8 +144,8 @@ lemma map_id : map (MonoidHom.id G) (𝟙 A) n = 𝟙 _ := by
   simp [map, groupHomology]
 
 @[reassoc]
-lemma map_comp {G H K : Type u} [Group G] [DecidableEq G] [Group H] [DecidableEq H]
-    [Group K] [DecidableEq K] {A : Rep k G} {B : Rep k H} {C : Rep k K} (f : G →* H) (g : H →* K)
+lemma map_comp {G H K : Type u} [Group G] [Group H] [Group K]
+    {A : Rep k G} {B : Rep k H} {C : Rep k K} (f : G →* H) (g : H →* K)
     (φ : A ⟶ (Action.res _ f).obj B) (ψ : B ⟶ (Action.res _ g).obj C) (n : ℕ) :
     map (g.comp f) (φ ≫ (Action.res _ f).map ψ) n = map f φ n ≫ map g ψ n := by
   simp [map, ← HomologicalComplex.homologyMap_comp, ← chainsMap_comp]
@@ -269,7 +268,6 @@ theorem mapShortComplexH1_id : mapShortComplexH1 (MonoidHom.id G) (𝟙 A) = �
   ext <;> simp
 
 theorem mapShortComplexH1_comp {G H K : Type u} [Group G] [Group H] [Group K]
-    [DecidableEq G] [DecidableEq H] [DecidableEq K]
     {A : Rep k G} {B : Rep k H} {C : Rep k K} (f : G →* H) (g : H →* K)
     (φ : A ⟶ (Action.res _ f).obj B) (ψ : B ⟶ (Action.res _ g).obj C) :
     mapShortComplexH1 (g.comp f) (φ ≫ (Action.res _ f).map ψ) =
@@ -356,7 +354,6 @@ theorem mapShortComplexH2_id : mapShortComplexH2 (MonoidHom.id _) (𝟙 A) = �
     simp }
 
 theorem mapShortComplexH2_comp {G H K : Type u} [Group G] [Group H] [Group K]
-    [DecidableEq G] [DecidableEq H] [DecidableEq K]
     {A : Rep k G} {B : Rep k H} {C : Rep k K} (f : G →* H) (g : H →* K)
     (φ : A ⟶ (Action.res _ f).obj B) (ψ : B ⟶ (Action.res _ g).obj C) :
     mapShortComplexH2 (g.comp f) (φ ≫ (Action.res _ f).map ψ) =
@@ -405,7 +402,7 @@ end H2
 variable (k G) in
 /-- The functor sending a representation to its complex of inhomogeneous chains. -/
 @[simps]
-noncomputable def chainsFunctor [DecidableEq G] :
+noncomputable def chainsFunctor :
     Rep k G ⥤ ChainComplex (ModuleCat k) ℕ where
   obj A := inhomogeneousChains A
   map f := chainsMap (MonoidHom.id _) f

--- a/Mathlib/RepresentationTheory/Homological/GroupHomology/LowDegree.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupHomology/LowDegree.lean
@@ -53,7 +53,6 @@ variable {k G : Type u} [CommRing k] [Group G] (A : Rep k G)
 namespace groupHomology
 
 section Chains
-variable [DecidableEq G]
 
 /-- The 0th object in the complex of inhomogeneous chains of `A : Rep k G` is isomorphic
 to `A` as a `k`-module. -/
@@ -202,7 +201,7 @@ lemma d₃₂_single_one_thd (g h : G) (a : A) :
     d₃₂ A (single (g, h, 1) a) = single (h, 1) (A.ρ g⁻¹ a) - single (g * h, 1) a := by
   simp [d₃₂]
 
-variable (A) [DecidableEq G]
+variable (A)
 
 /-- Let `C(G, A)` denote the complex of inhomogeneous chains of `A : Rep k G`. This lemma
 says `d₁₀` gives a simpler expression for the 0th differential: that is, the following
@@ -334,7 +333,7 @@ theorem single_mem_cycles₁_of_mem_invariants (g : G) (a : A) (ha : a ∈ A.ρ.
     single g a ∈ cycles₁ A :=
   (single_mem_cycles₁_iff g a).2 (ha g)
 
-theorem d₂₁_apply_mem_cycles₁ [DecidableEq G] (x : G × G →₀ A) :
+theorem d₂₁_apply_mem_cycles₁ (x : G × G →₀ A) :
     d₂₁ A x ∈ cycles₁ A :=
   congr($(d₂₁_comp_d₁₀ A) x)
 
@@ -373,7 +372,7 @@ theorem single_mem_cycles₂_iff (g : G × G) (a : A) :
   rw [← (mapRange_injective (α := G) _ (map_zero _) (A.ρ.apply_bijective g.1⁻¹).1).eq_iff]
   simp [mem_cycles₂_iff, mapRange_add, eq_comm]
 
-theorem d₃₂_apply_mem_cycles₂ [DecidableEq G] (x : G × G × G →₀ A) :
+theorem d₃₂_apply_mem_cycles₂ (x : G × G × G →₀ A) :
     d₃₂ A x ∈ cycles₂ A :=
   congr($(d₃₂_comp_d₂₁ A) x)
 
@@ -395,8 +394,6 @@ def boundaries₂ : Submodule k (G × G →₀ A) :=
 variable {A}
 
 section
-
-variable [DecidableEq G]
 
 lemma mem_cycles₁_of_mem_boundaries₁ (f : G →₀ A) (h : f ∈ boundaries₁ A) :
     f ∈ cycles₁ A := by
@@ -435,8 +432,6 @@ theorem single_inv_ρ_self_add_single_mem_boundaries₁ (g : G) (a : A) :
 
 section
 
-variable [DecidableEq G]
-
 lemma mem_cycles₂_of_mem_boundaries₂ (x : G × G →₀ A) (h : x ∈ boundaries₂ A) :
     x ∈ cycles₂ A := by
   rcases h with ⟨x, rfl⟩
@@ -448,7 +443,7 @@ lemma boundaries₂_le_cycles₂ : boundaries₂ A ≤ cycles₂ A :=
 
 variable (A) in
 /-- The natural inclusion `B₂(G, A) →ₗ[k] Z₂(G, A)`. -/
-abbrev boundariesToCycles₂ [DecidableEq G] : boundaries₂ A →ₗ[k] cycles₂ A :=
+abbrev boundariesToCycles₂ : boundaries₂ A →ₗ[k] cycles₂ A :=
   Submodule.inclusion (boundaries₂_le_cycles₂ A)
 
 @[simp]
@@ -611,7 +606,7 @@ def coinvariantsKerOfIsBoundary₀ (x : A) (hx : IsBoundary₀ G x) :
     rcases (isBoundary₀_iff G x).1 hx with ⟨y, rfl⟩
     exact Submodule.finsuppSum_mem _ _ _ _ fun g _ => Coinvariants.mem_ker_of_eq g (y g) _ rfl⟩
 
-theorem isBoundary₀_of_mem_coinvariantsKer [DecidableEq G]
+theorem isBoundary₀_of_mem_coinvariantsKer
     (x : A) (hx : x ∈ Coinvariants.ker (Representation.ofDistribMulAction k G A)) :
     IsBoundary₀ G x :=
   Submodule.span_induction (fun _ ⟨g, hg⟩ => ⟨single g.1⁻¹ g.2, by simp_all⟩) ⟨0, by simp⟩
@@ -684,8 +679,6 @@ lemma shortComplexH0_exact : (shortComplexH0 A).Exact := by
   use x
   rfl
 
-variable [DecidableEq G]
-
 /-- The 0-cycles of the complex of inhomogeneous chains of `A` are isomorphic to `A`. -/
 def cyclesIso₀ : cycles A 0 ≅ A.V :=
   (inhomogeneousChains A).iCyclesIso _ 0 (by aesop) (by aesop) ≪≫ chainsIso₀ A
@@ -725,8 +718,6 @@ end cyclesIso₀
 
 section isoCycles₁
 
-variable [DecidableEq G]
-
 /-- The short complex `(G² →₀ A) --d₂₁--> (G →₀ A) --d₁₀--> A` is isomorphic to the 1st
 short complex associated to the complex of inhomogeneous chains of `A`. -/
 @[simps! hom inv]
@@ -763,8 +754,6 @@ end isoCycles₁
 
 section isoCycles₂
 
-variable [DecidableEq G]
-
 /-- The short complex `(G³ →₀ A) --d₃₂--> (G² →₀ A) --d₂₁--> (G →₀ A)` is isomorphic to the 2nd
 short complex associated to the complex of inhomogeneous chains of `A`. -/
 @[simps! hom inv]
@@ -800,8 +789,6 @@ lemma toCycles_comp_isoCycles₂_hom :
 end isoCycles₂
 
 section Homology
-
-variable [DecidableEq G]
 
 section H0
 

--- a/Mathlib/RepresentationTheory/Homological/GroupHomology/LowDegree.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupHomology/LowDegree.lean
@@ -283,7 +283,7 @@ theorem eq_d₃₂_comp_inv :
 @[reassoc (attr := simp), elementwise (attr := simp)]
 theorem d₂₁_comp_d₁₀ : d₂₁ A ≫ d₁₀ A = 0 := by
   ext x g
-  simp [d₁₀, d₂₁, sum_add_index, sum_sub_index, sub_sub_sub_comm, add_sub_add_comm]
+  simp [d₁₀, d₂₁, sum_add_index', sum_sub_index, sub_sub_sub_comm, add_sub_add_comm]
 
 @[reassoc (attr := simp), elementwise (attr := simp)]
 theorem d₃₂_comp_d₂₁ : d₃₂ A ≫ d₂₁ A = 0 := by
@@ -610,7 +610,7 @@ theorem isBoundary₀_of_mem_coinvariantsKer
     (x : A) (hx : x ∈ Coinvariants.ker (Representation.ofDistribMulAction k G A)) :
     IsBoundary₀ G x :=
   Submodule.span_induction (fun _ ⟨g, hg⟩ => ⟨single g.1⁻¹ g.2, by simp_all⟩) ⟨0, by simp⟩
-    (fun _ _ _ _ ⟨X, hX⟩ ⟨Y, hY⟩ => ⟨X + Y, by simp_all [sum_add_index, add_sub_add_comm]⟩)
+    (fun _ _ _ _ ⟨X, hX⟩ ⟨Y, hY⟩ => ⟨X + Y, by simp_all [sum_add_index', add_sub_add_comm]⟩)
     (fun r _ _ ⟨X, hX⟩ => ⟨r • X, by simp [← hX, sum_smul_index', smul_comm, smul_sub, smul_sum]⟩)
     hx
 
@@ -938,7 +938,7 @@ def H1ToTensorOfIsTrivial : H1 A →ₗ[ℤ] (Additive <| Abelianization G) ⊗[
   ((QuotientAddGroup.lift _ ((Finsupp.liftAddHom fun g => AddMonoidHomClass.toAddMonoidHom
     (TensorProduct.mk ℤ _ _ (Additive.ofMul (Abelianization.of g)))).comp
       (cycles₁ A).toAddSubgroup.subtype) fun ⟨y, hy⟩ ⟨z, hz⟩ => AddMonoidHom.mem_ker.2 <| by
-      simp [← hz, d₂₁, sum_sum_index, sum_add_index, tmul_add, sum_sub_index, tmul_sub,
+      simp [← hz, d₂₁, sum_sum_index, sum_add_index', tmul_add, sum_sub_index, tmul_sub,
         shortComplexH1]).comp <| AddMonoidHomClass.toAddMonoidHom (H1Iso A).hom.hom).toIntLinearMap
 
 variable {A} in


### PR DESCRIPTION
Mirrors #26352. A proof in `groupHomology.inhomogeneousChains` should use `classical` rather than a `DecidableEq` assumption, and this allows us to remove other `DecidableEq`s too. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
