### PR TITLE
feat(NumberTheory/Padics/PadicVal/Basic): `padicValNat p m = m.primeFactorsList.count p`

### DIFF
--- a/Mathlib/NumberTheory/Padics/PadicVal/Basic.lean
+++ b/Mathlib/NumberTheory/Padics/PadicVal/Basic.lean
@@ -108,7 +108,7 @@ theorem padicValNat_eq_maxPowDiv : @padicValNat = @maxPowDiv := by
     · intro h
       simp [h]
 
-lemma _root_.padicValNat_eq_primeFactorsList [hp : Fact p.Prime] {m : ℕ} :
+lemma _root_.padicValNat_eq_primeFactorsList_count [hp : Fact p.Prime] {m : ℕ} :
     padicValNat p m = (primeFactorsList m).count p := by
   induction m <;>
   simp [primeFactorsList_count_eq, padicValNat_def, multiplicity_eq_factorization hp.out]

--- a/Mathlib/NumberTheory/Padics/PadicVal/Basic.lean
+++ b/Mathlib/NumberTheory/Padics/PadicVal/Basic.lean
@@ -109,7 +109,7 @@ theorem padicValNat_eq_maxPowDiv : @padicValNat = @maxPowDiv := by
       simp [h]
 
 lemma _root_.padicValNat_eq_primeFactorsList_count [hp : Fact p.Prime] {m : ℕ} :
-    padicValNat p m = (primeFactorsList m).count p := by
+    padicValNat p m = m.primeFactorsList.count p := by
   induction m <;>
   simp [primeFactorsList_count_eq, padicValNat_def, multiplicity_eq_factorization hp.out]
 

--- a/Mathlib/NumberTheory/Padics/PadicVal/Basic.lean
+++ b/Mathlib/NumberTheory/Padics/PadicVal/Basic.lean
@@ -8,6 +8,7 @@ import Mathlib.NumberTheory.Padics.PadicVal.Defs
 import Mathlib.Data.Nat.MaxPowDiv
 import Mathlib.Data.Nat.Multiplicity
 import Mathlib.Data.Nat.Prime.Int
+import Mathlib.Data.Nat.Factorization.Defs
 
 /-!
 # `p`-adic Valuation
@@ -106,6 +107,11 @@ theorem padicValNat_eq_maxPowDiv : @padicValNat = @maxPowDiv := by
         rw [go, if_neg]; simp
     · intro h
       simp [h]
+
+lemma _root_.padicValNat_eq_primeFactorsList [hp : Fact p.Prime] {m : ℕ} :
+    padicValNat p m = (primeFactorsList m).count p := by
+  induction m <;>
+  simp [primeFactorsList_count_eq, padicValNat_def, multiplicity_eq_factorization hp.out]
 
 end padicValNat
 


### PR DESCRIPTION
With this we can do things like:
```lean
example : padicValNat 2 4 = 2 := by simp [padicValNat_eq_primeFactorsList_count]
```
(note that for the above to work, you should import `Mathlib.Tactic.Simproc.Factors`)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
