### PR TITLE
[Merged by Bors] - refactor: move `AddGroupWithOne` instances to the `Ring` subfolder

### DIFF
--- a/Mathlib/Algebra/CharP/Basic.lean
+++ b/Mathlib/Algebra/CharP/Basic.lean
@@ -5,7 +5,8 @@ Authors: Kenny Lau, Joey van Langen, Casper Putz
 -/
 import Mathlib.Algebra.CharP.Defs
 import Mathlib.Algebra.Group.Fin.Basic
-import Mathlib.Algebra.Group.ULift
+import Mathlib.Algebra.Ring.ULift
+import Mathlib.Algebra.Ring.Opposite
 import Mathlib.Data.Int.ModEq
 import Mathlib.Data.Nat.Cast.Prod
 import Mathlib.Data.ULift

--- a/Mathlib/Algebra/CharP/Defs.lean
+++ b/Mathlib/Algebra/CharP/Defs.lean
@@ -6,6 +6,7 @@ Authors: Kenny Lau, Joey van Langen, Casper Putz
 import Mathlib.Data.Nat.Cast.Basic
 import Mathlib.Data.Nat.Find
 import Mathlib.Data.Nat.Prime.Defs
+import Mathlib.Data.Int.Cast.Basic
 import Mathlib.Order.Lattice
 
 /-!

--- a/Mathlib/Algebra/Group/InjSurj.lean
+++ b/Mathlib/Algebra/Group/InjSurj.lean
@@ -22,6 +22,10 @@ Then `H` satisfies the group axioms.
 The relevant definition in this case is `Function.Surjective.group`.
 Dually, there is also `Function.Injective.group`.
 And there are versions for (additive) (commutative) semigroups/monoids.
+
+Note that the `nsmul` and `zsmul` hypotheses in the declarations in this file are declared as
+`∀ x n, f (n • x) = n • f x`, with the binders in a slightly unnatural order, as they are
+`to_additive`ized from the versions for `^`.
 -/
 
 

--- a/Mathlib/Algebra/Group/InjSurj.lean
+++ b/Mathlib/Algebra/Group/InjSurj.lean
@@ -5,7 +5,6 @@ Authors: Johan Commelin
 -/
 import Mathlib.Algebra.Group.Defs
 import Mathlib.Logic.Function.Basic
-import Mathlib.Data.Int.Cast.Basic
 import Mathlib.Tactic.Spread
 
 /-!
@@ -23,16 +22,6 @@ Then `H` satisfies the group axioms.
 The relevant definition in this case is `Function.Surjective.group`.
 Dually, there is also `Function.Injective.group`.
 And there are versions for (additive) (commutative) semigroups/monoids.
-
-## Implementation note
-
-The `nsmul` and `zsmul` assumptions on any transfer definition for an algebraic structure involving
-both addition and multiplication (eg `AddMonoidWithOne`) is `∀ n x, f (n • x) = n • f x`, which is
-what we would expect.
-However, we cannot do the same for transfer definitions built using `to_additive` (eg `AddMonoid`)
-as we want the multiplicative versions to be `∀ x n, f (x ^ n) = f x ^ n`.
-As a result, we must use `Function.swap` when using additivised transfer definitions in
-non-additivised ones.
 -/
 
 
@@ -42,7 +31,7 @@ namespace Function
 ### Injective
 -/
 
-assert_not_exists MonoidWithZero DenselyOrdered
+assert_not_exists MonoidWithZero DenselyOrdered AddMonoidWithOne
 
 namespace Injective
 
@@ -122,18 +111,6 @@ protected abbrev monoid [Monoid M₂] (f : M₁ → M₂) (hf : Injective f) (on
     npow_zero := fun x => hf <| by rw [npow, one, pow_zero],
     npow_succ := fun n x => hf <| by rw [npow, pow_succ, mul, npow] }
 
-/-- A type endowed with `0`, `1` and `+` is an additive monoid with one,
-if it admits an injective map that preserves `0`, `1` and `+` to an additive monoid with one.
-See note [reducible non-instances]. -/
-protected abbrev addMonoidWithOne {M₁} [Zero M₁] [One M₁] [Add M₁] [SMul ℕ M₁] [NatCast M₁]
-    [AddMonoidWithOne M₂] (f : M₁ → M₂) (hf : Injective f) (zero : f 0 = 0) (one : f 1 = 1)
-    (add : ∀ x y, f (x + y) = f x + f y) (nsmul : ∀ (n : ℕ) (x), f (n • x) = n • f x)
-    (natCast : ∀ n : ℕ, f n = n) : AddMonoidWithOne M₁ :=
-  { hf.addMonoid f zero add (swap nsmul) with
-    natCast := Nat.cast,
-    natCast_zero := hf (by rw [natCast, Nat.cast_zero, zero]),
-    natCast_succ := fun n => hf (by rw [natCast, Nat.cast_succ, add, one, natCast]), one := 1 }
-
 /-- A type endowed with `1` and `*` is a left cancel monoid, if it admits an injective map that
 preserves `1` and `*` to a left cancel monoid. See note [reducible non-instances]. -/
 @[to_additive
@@ -173,16 +150,6 @@ protected abbrev commMonoid [CommMonoid M₂] (f : M₁ → M₂) (hf : Injectiv
     (mul : ∀ x y, f (x * y) = f x * f y) (npow : ∀ (x) (n : ℕ), f (x ^ n) = f x ^ n) :
     CommMonoid M₁ :=
   { hf.monoid f one mul npow, hf.commSemigroup f mul with }
-
-/-- A type endowed with `0`, `1` and `+` is an additive commutative monoid with one, if it admits an
-injective map that preserves `0`, `1` and `+` to an additive commutative monoid with one.
-See note [reducible non-instances]. -/
-protected abbrev addCommMonoidWithOne {M₁} [Zero M₁] [One M₁] [Add M₁] [SMul ℕ M₁] [NatCast M₁]
-    [AddCommMonoidWithOne M₂] (f : M₁ → M₂) (hf : Injective f) (zero : f 0 = 0) (one : f 1 = 1)
-    (add : ∀ x y, f (x + y) = f x + f y) (nsmul : ∀ (n : ℕ) (x), f (n • x) = n • f x)
-    (natCast : ∀ n : ℕ, f n = n) : AddCommMonoidWithOne M₁ where
-  __ := hf.addMonoidWithOne f zero one add nsmul natCast
-  __ := hf.addCommMonoid _ zero add (swap nsmul)
 
 /-- A type endowed with `1` and `*` is a cancel commutative monoid, if it admits an injective map
 that preserves `1` and `*` to a cancel commutative monoid.  See note [reducible non-instances]. -/
@@ -292,20 +259,6 @@ protected abbrev group [Group M₂] (f : M₁ → M₂) (hf : Injective f) (one 
   { hf.divInvMonoid f one mul inv div npow zpow with
     inv_mul_cancel := fun x => hf <| by rw [mul, inv, inv_mul_cancel, one] }
 
-/-- A type endowed with `0`, `1` and `+` is an additive group with one, if it admits an injective
-map that preserves `0`, `1` and `+` to an additive group with one.  See note
-[reducible non-instances]. -/
-protected abbrev addGroupWithOne {M₁} [Zero M₁] [One M₁] [Add M₁] [SMul ℕ M₁] [Neg M₁] [Sub M₁]
-    [SMul ℤ M₁] [NatCast M₁] [IntCast M₁] [AddGroupWithOne M₂] (f : M₁ → M₂) (hf : Injective f)
-    (zero : f 0 = 0) (one : f 1 = 1) (add : ∀ x y, f (x + y) = f x + f y) (neg : ∀ x, f (-x) = -f x)
-    (sub : ∀ x y, f (x - y) = f x - f y) (nsmul : ∀ (n : ℕ) (x), f (n • x) = n • f x)
-    (zsmul : ∀ (n : ℤ) (x), f (n • x) = n • f x) (natCast : ∀ n : ℕ, f n = n)
-    (intCast : ∀ n : ℤ, f n = n) : AddGroupWithOne M₁ :=
-  { hf.addGroup f zero add neg sub (swap nsmul) (swap zsmul),
-    hf.addMonoidWithOne f zero one add nsmul natCast with
-    intCast := Int.cast,
-    intCast_ofNat := fun n => hf (by rw [natCast, intCast, Int.cast_natCast]),
-    intCast_negSucc := fun n => hf (by rw [intCast, neg, natCast, Int.cast_negSucc] ) }
 
 /-- A type endowed with `1`, `*` and `⁻¹` is a commutative group, if it admits an injective map that
 preserves `1`, `*` and `⁻¹` to a commutative group. See note [reducible non-instances]. -/
@@ -317,18 +270,6 @@ protected abbrev commGroup [CommGroup M₂] (f : M₁ → M₂) (hf : Injective 
     (div : ∀ x y, f (x / y) = f x / f y) (npow : ∀ (x) (n : ℕ), f (x ^ n) = f x ^ n)
     (zpow : ∀ (x) (n : ℤ), f (x ^ n) = f x ^ n) : CommGroup M₁ :=
   { hf.commMonoid f one mul npow, hf.group f one mul inv div npow zpow with }
-
-/-- A type endowed with `0`, `1` and `+` is an additive commutative group with one, if it admits an
-injective map that preserves `0`, `1` and `+` to an additive commutative group with one.
-See note [reducible non-instances]. -/
-protected abbrev addCommGroupWithOne {M₁} [Zero M₁] [One M₁] [Add M₁] [SMul ℕ M₁] [Neg M₁] [Sub M₁]
-    [SMul ℤ M₁] [NatCast M₁] [IntCast M₁] [AddCommGroupWithOne M₂] (f : M₁ → M₂) (hf : Injective f)
-    (zero : f 0 = 0) (one : f 1 = 1) (add : ∀ x y, f (x + y) = f x + f y) (neg : ∀ x, f (-x) = -f x)
-    (sub : ∀ x y, f (x - y) = f x - f y) (nsmul : ∀ (n : ℕ) (x), f (n • x) = n • f x)
-    (zsmul : ∀ (n : ℤ) (x), f (n • x) = n • f x) (natCast : ∀ n : ℕ, f n = n)
-    (intCast : ∀ n : ℤ, f n = n) : AddCommGroupWithOne M₁ :=
-  { hf.addGroupWithOne f zero one add neg sub nsmul zsmul natCast intCast,
-    hf.addCommMonoid _ zero add (swap nsmul) with }
 
 end Injective
 
@@ -398,18 +339,6 @@ protected abbrev monoid [Monoid M₁] (f : M₁ → M₂) (hf : Surjective f) (o
     npow_succ := fun n => hf.forall.2 fun x => by
       rw [← npow, pow_succ, ← npow, ← mul] }
 
-/-- A type endowed with `0`, `1` and `+` is an additive monoid with one, if it admits a surjective
-map that preserves `0`, `1` and `*` from an additive monoid with one. See note
-[reducible non-instances]. -/
-protected abbrev addMonoidWithOne {M₂} [Zero M₂] [One M₂] [Add M₂] [SMul ℕ M₂] [NatCast M₂]
-    [AddMonoidWithOne M₁] (f : M₁ → M₂) (hf : Surjective f) (zero : f 0 = 0) (one : f 1 = 1)
-    (add : ∀ x y, f (x + y) = f x + f y) (nsmul : ∀ (n : ℕ) (x), f (n • x) = n • f x)
-    (natCast : ∀ n : ℕ, f n = n) : AddMonoidWithOne M₂ :=
-  { hf.addMonoid f zero add (swap nsmul) with
-    natCast := Nat.cast,
-    natCast_zero := by rw [← natCast, Nat.cast_zero, zero]
-    natCast_succ := fun n => by rw [← natCast, Nat.cast_succ, add, one, natCast]
-    one := 1 }
 
 /-- A type endowed with `1` and `*` is a commutative monoid, if it admits a surjective map that
 preserves `1` and `*` from a commutative monoid. See note [reducible non-instances]. -/
@@ -420,16 +349,6 @@ protected abbrev commMonoid [CommMonoid M₁] (f : M₁ → M₂) (hf : Surjecti
     (mul : ∀ x y, f (x * y) = f x * f y) (npow : ∀ (x) (n : ℕ), f (x ^ n) = f x ^ n) :
     CommMonoid M₂ :=
   { hf.commSemigroup f mul, hf.monoid f one mul npow with }
-
-/-- A type endowed with `0`, `1` and `+` is an additive monoid with one,
-if it admits a surjective map that preserves `0`, `1` and `*` from an additive monoid with one.
-See note [reducible non-instances]. -/
-protected abbrev addCommMonoidWithOne {M₂} [Zero M₂] [One M₂] [Add M₂] [SMul ℕ M₂] [NatCast M₂]
-    [AddCommMonoidWithOne M₁] (f : M₁ → M₂) (hf : Surjective f) (zero : f 0 = 0) (one : f 1 = 1)
-    (add : ∀ x y, f (x + y) = f x + f y) (nsmul : ∀ (n : ℕ) (x), f (n • x) = n • f x)
-    (natCast : ∀ n : ℕ, f n = n) : AddCommMonoidWithOne M₂ where
-  __ := hf.addMonoidWithOne f zero one add nsmul natCast
-  __ := hf.addCommMonoid _ zero add (swap nsmul)
 
 /-- A type has an involutive inversion if it admits a surjective map that preserves `⁻¹` to a type
 which has an involutive inversion. See note [reducible non-instances] -/
@@ -474,22 +393,6 @@ protected abbrev group [Group M₁] (f : M₁ → M₂) (hf : Surjective f) (one
   { hf.divInvMonoid f one mul inv div npow zpow with
     inv_mul_cancel := hf.forall.2 fun x => by rw [← inv, ← mul, inv_mul_cancel, one] }
 
-/-- A type endowed with `0`, `1`, `+` is an additive group with one,
-if it admits a surjective map that preserves `0`, `1`, and `+` to an additive group with one.
-See note [reducible non-instances]. -/
-protected abbrev addGroupWithOne {M₂} [Zero M₂] [One M₂] [Add M₂] [Neg M₂] [Sub M₂] [SMul ℕ M₂]
-    [SMul ℤ M₂] [NatCast M₂] [IntCast M₂] [AddGroupWithOne M₁] (f : M₁ → M₂) (hf : Surjective f)
-    (zero : f 0 = 0) (one : f 1 = 1) (add : ∀ x y, f (x + y) = f x + f y) (neg : ∀ x, f (-x) = -f x)
-    (sub : ∀ x y, f (x - y) = f x - f y) (nsmul : ∀ (n : ℕ) (x), f (n • x) = n • f x)
-    (zsmul : ∀ (n : ℤ) (x), f (n • x) = n • f x) (natCast : ∀ n : ℕ, f n = n)
-    (intCast : ∀ n : ℤ, f n = n) : AddGroupWithOne M₂ :=
-  { hf.addMonoidWithOne f zero one add nsmul natCast,
-    hf.addGroup f zero add neg sub (swap nsmul) (swap zsmul) with
-    intCast := Int.cast,
-    intCast_ofNat := fun n => by rw [← intCast, Int.cast_natCast, natCast],
-    intCast_negSucc := fun n => by
-      rw [← intCast, Int.cast_negSucc, neg, natCast] }
-
 /-- A type endowed with `1`, `*`, `⁻¹`, and `/` is a commutative group, if it admits a surjective
 map that preserves `1`, `*`, `⁻¹`, and `/` from a commutative group. See note
 [reducible non-instances]. -/
@@ -501,18 +404,6 @@ protected abbrev commGroup [CommGroup M₁] (f : M₁ → M₂) (hf : Surjective
     (div : ∀ x y, f (x / y) = f x / f y) (npow : ∀ (x) (n : ℕ), f (x ^ n) = f x ^ n)
     (zpow : ∀ (x) (n : ℤ), f (x ^ n) = f x ^ n) : CommGroup M₂ :=
   { hf.commMonoid f one mul npow, hf.group f one mul inv div npow zpow with }
-
-/-- A type endowed with `0`, `1`, `+` is an additive commutative group with one, if it admits a
-surjective map that preserves `0`, `1`, and `+` to an additive commutative group with one.
-See note [reducible non-instances]. -/
-protected abbrev addCommGroupWithOne {M₂} [Zero M₂] [One M₂] [Add M₂] [Neg M₂] [Sub M₂] [SMul ℕ M₂]
-    [SMul ℤ M₂] [NatCast M₂] [IntCast M₂] [AddCommGroupWithOne M₁] (f : M₁ → M₂) (hf : Surjective f)
-    (zero : f 0 = 0) (one : f 1 = 1) (add : ∀ x y, f (x + y) = f x + f y) (neg : ∀ x, f (-x) = -f x)
-    (sub : ∀ x y, f (x - y) = f x - f y) (nsmul : ∀ (n : ℕ) (x), f (n • x) = n • f x)
-    (zsmul : ∀ (n : ℤ) (x), f (n • x) = n • f x) (natCast : ∀ n : ℕ, f n = n)
-    (intCast : ∀ n : ℤ, f n = n) : AddCommGroupWithOne M₂ :=
-  { hf.addGroupWithOne f zero one add neg sub nsmul zsmul natCast intCast,
-    hf.addCommMonoid _ zero add (swap nsmul) with }
 
 end Surjective
 

--- a/Mathlib/Algebra/Group/Opposite.lean
+++ b/Mathlib/Algebra/Group/Opposite.lean
@@ -22,9 +22,6 @@ namespace MulOpposite
 ### Additive structures on `αᵐᵒᵖ`
 -/
 
-@[to_additive] instance instNatCast [NatCast α] : NatCast αᵐᵒᵖ where natCast n := op n
-@[to_additive] instance instIntCast [IntCast α] : IntCast αᵐᵒᵖ where intCast n := op n
-
 instance instAddSemigroup [AddSemigroup α] : AddSemigroup αᵐᵒᵖ :=
   unop_injective.addSemigroup _ fun _ _ => rfl
 
@@ -49,17 +46,6 @@ instance instAddMonoid [AddMonoid α] : AddMonoid αᵐᵒᵖ :=
 instance instAddCommMonoid [AddCommMonoid α] : AddCommMonoid αᵐᵒᵖ :=
   unop_injective.addCommMonoid _ rfl (fun _ _ => rfl) fun _ _ => rfl
 
-instance instAddMonoidWithOne [AddMonoidWithOne α] : AddMonoidWithOne αᵐᵒᵖ where
-  toNatCast := instNatCast
-  toAddMonoid := instAddMonoid
-  toOne := instOne
-  natCast_zero := show op ((0 : ℕ) : α) = 0 by rw [Nat.cast_zero, op_zero]
-  natCast_succ := show ∀ n, op ((n + 1 : ℕ) : α) = op ↑(n : ℕ) + 1 by simp
-
-instance instAddCommMonoidWithOne [AddCommMonoidWithOne α] : AddCommMonoidWithOne αᵐᵒᵖ where
-  toAddMonoidWithOne := instAddMonoidWithOne
-  __ := instAddCommMonoid
-
 instance instSubNegMonoid [SubNegMonoid α] : SubNegMonoid αᵐᵒᵖ :=
   unop_injective.subNegMonoid _ (by exact rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ _ => rfl
@@ -71,17 +57,6 @@ instance instAddGroup [AddGroup α] : AddGroup αᵐᵒᵖ :=
 instance instAddCommGroup [AddCommGroup α] : AddCommGroup αᵐᵒᵖ :=
   unop_injective.addCommGroup _ rfl (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ _ => rfl
-
-instance instAddGroupWithOne [AddGroupWithOne α] : AddGroupWithOne αᵐᵒᵖ where
-  toAddMonoidWithOne := instAddMonoidWithOne
-  toIntCast := instIntCast
-  __ := instAddGroup
-  intCast_ofNat n := show op ((n : ℤ) : α) = op (n : α) by rw [Int.cast_natCast]
-  intCast_negSucc n := show op _ = op (-unop (op ((n + 1 : ℕ) : α))) by simp
-
-instance instAddCommGroupWithOne [AddCommGroupWithOne α] : AddCommGroupWithOne αᵐᵒᵖ where
-  toAddCommGroup := instAddCommGroup
-  __ := instAddGroupWithOne
 
 /-!
 ### Multiplicative structures on `αᵐᵒᵖ`
@@ -203,32 +178,6 @@ variable [DivInvMonoid α]
 
 end DivInvMonoid
 
-@[to_additive (attr := simp, norm_cast)]
-theorem op_natCast [NatCast α] (n : ℕ) : op (n : α) = n :=
-  rfl
-
-@[to_additive (attr := simp)]
-theorem op_ofNat [NatCast α] (n : ℕ) [n.AtLeastTwo] :
-    op (ofNat(n) : α) = ofNat(n) :=
-  rfl
-
-@[to_additive (attr := simp, norm_cast)]
-theorem op_intCast [IntCast α] (n : ℤ) : op (n : α) = n :=
-  rfl
-
-@[to_additive (attr := simp, norm_cast)]
-theorem unop_natCast [NatCast α] (n : ℕ) : unop (n : αᵐᵒᵖ) = n :=
-  rfl
-
-@[to_additive (attr := simp)]
-theorem unop_ofNat [NatCast α] (n : ℕ) [n.AtLeastTwo] :
-    unop (ofNat(n) : αᵐᵒᵖ) = ofNat(n) :=
-  rfl
-
-@[to_additive (attr := simp, norm_cast)]
-theorem unop_intCast [IntCast α] (n : ℤ) : unop (n : αᵐᵒᵖ) = n :=
-  rfl
-
 @[to_additive (attr := simp)]
 theorem unop_div [DivInvMonoid α] (x y : αᵐᵒᵖ) : unop (x / y) = (unop y)⁻¹ * unop x :=
   rfl
@@ -326,20 +275,5 @@ instance instGroup [Group α] : Group αᵃᵒᵖ :=
 instance instCommGroup [CommGroup α] : CommGroup αᵃᵒᵖ :=
   unop_injective.commGroup _ (by exact rfl) (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ _ => rfl
-
--- NOTE: `addMonoidWithOne α → addMonoidWithOne αᵃᵒᵖ` does not hold
-instance instAddCommMonoidWithOne [AddCommMonoidWithOne α] : AddCommMonoidWithOne αᵃᵒᵖ where
-  toNatCast := instNatCast
-  toOne := instOne
-  __ := instAddCommMonoid
-  natCast_zero := show op ((0 : ℕ) : α) = 0 by rw [Nat.cast_zero, op_zero]
-  natCast_succ := show ∀ n, op ((n + 1 : ℕ) : α) = op ↑(n : ℕ) + 1 by simp [add_comm]
-
-instance instAddCommGroupWithOne [AddCommGroupWithOne α] : AddCommGroupWithOne αᵃᵒᵖ where
-  toIntCast := instIntCast
-  toAddCommGroup := instAddCommGroup
-  __ := instAddCommMonoidWithOne
-  intCast_ofNat _ := congr_arg op <| Int.cast_natCast _
-  intCast_negSucc _ := congr_arg op <| Int.cast_negSucc _
 
 end AddOpposite

--- a/Mathlib/Algebra/Group/Prod.lean
+++ b/Mathlib/Algebra/Group/Prod.lean
@@ -36,9 +36,7 @@ We also prove trivial `simp` lemmas, and define the following operations on `Mon
 * `divMonoidHom`: Division bundled as a monoid homomorphism.
 -/
 
-assert_not_exists MonoidWithZero DenselyOrdered
--- TODO:
--- assert_not_exists AddMonoidWithOne
+assert_not_exists MonoidWithZero DenselyOrdered AddMonoidWithOne
 
 variable {G : Type*} {H : Type*} {M : Type*} {N : Type*} {P : Type*}
 

--- a/Mathlib/Algebra/Group/Subgroup/Defs.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Defs.lean
@@ -5,9 +5,9 @@ Authors: Kexing Ying
 -/
 import Mathlib.Algebra.Group.Submonoid.Defs
 import Mathlib.Data.Set.Inclusion
-import Mathlib.Data.Int.Cast.Basic
 import Mathlib.Tactic.Common
 import Mathlib.Tactic.FastInstance
+import Mathlib.Algebra.Group.Basic
 
 /-!
 # Subgroups

--- a/Mathlib/Algebra/Group/Subgroup/Defs.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Defs.lean
@@ -5,6 +5,7 @@ Authors: Kexing Ying
 -/
 import Mathlib.Algebra.Group.Submonoid.Defs
 import Mathlib.Data.Set.Inclusion
+import Mathlib.Data.Int.Cast.Basic
 import Mathlib.Tactic.Common
 import Mathlib.Tactic.FastInstance
 

--- a/Mathlib/Algebra/Group/Subgroup/Defs.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Defs.lean
@@ -3,11 +3,11 @@ Copyright (c) 2020 Kexing Ying. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kexing Ying
 -/
+import Mathlib.Algebra.Group.Basic
 import Mathlib.Algebra.Group.Submonoid.Defs
 import Mathlib.Data.Set.Inclusion
 import Mathlib.Tactic.Common
 import Mathlib.Tactic.FastInstance
-import Mathlib.Algebra.Group.Basic
 
 /-!
 # Subgroups

--- a/Mathlib/Algebra/Group/ULift.lean
+++ b/Mathlib/Algebra/Group/ULift.lean
@@ -99,44 +99,6 @@ instance monoid [Monoid α] : Monoid (ULift α) :=
 instance commMonoid [CommMonoid α] : CommMonoid (ULift α) :=
   Equiv.ulift.injective.commMonoid _ rfl (fun _ _ => rfl) fun _ _ => rfl
 
-instance instNatCast [NatCast α] : NatCast (ULift α) := ⟨(up ·)⟩
-instance instIntCast [IntCast α] : IntCast (ULift α) := ⟨(up ·)⟩
-
-@[simp, norm_cast]
-theorem up_natCast [NatCast α] (n : ℕ) : up (n : α) = n :=
-  rfl
-
-@[simp]
-theorem up_ofNat [NatCast α] (n : ℕ) [n.AtLeastTwo] :
-    up (ofNat(n) : α) = ofNat(n) :=
-  rfl
-
-@[simp, norm_cast]
-theorem up_intCast [IntCast α] (n : ℤ) : up (n : α) = n :=
-  rfl
-
-@[simp, norm_cast]
-theorem down_natCast [NatCast α] (n : ℕ) : down (n : ULift α) = n :=
-  rfl
-
-@[simp]
-theorem down_ofNat [NatCast α] (n : ℕ) [n.AtLeastTwo] :
-    down (ofNat(n) : ULift α) = ofNat(n) :=
-  rfl
-
-@[simp, norm_cast]
-theorem down_intCast [IntCast α] (n : ℤ) : down (n : ULift α) = n :=
-  rfl
-
-instance addMonoidWithOne [AddMonoidWithOne α] : AddMonoidWithOne (ULift α) :=
-  { ULift.one, ULift.addMonoid with
-      natCast := (⟨·⟩)
-      natCast_zero := congr_arg ULift.up Nat.cast_zero,
-      natCast_succ := fun _ => congr_arg ULift.up (Nat.cast_succ _) }
-
-instance addCommMonoidWithOne [AddCommMonoidWithOne α] : AddCommMonoidWithOne (ULift α) :=
-  { ULift.addMonoidWithOne, ULift.addCommMonoid with }
-
 @[to_additive]
 instance divInvMonoid [DivInvMonoid α] : DivInvMonoid (ULift α) :=
   Equiv.ulift.injective.divInvMonoid _ rfl (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
@@ -151,15 +113,6 @@ instance group [Group α] : Group (ULift α) :=
 instance commGroup [CommGroup α] : CommGroup (ULift α) :=
   Equiv.ulift.injective.commGroup _ rfl (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
     (fun _ _ => rfl) fun _ _ => rfl
-
-instance addGroupWithOne [AddGroupWithOne α] : AddGroupWithOne (ULift α) :=
-  { ULift.addMonoidWithOne, ULift.addGroup with
-      intCast := (⟨·⟩),
-      intCast_ofNat := fun _ => congr_arg ULift.up (Int.cast_natCast _),
-      intCast_negSucc := fun _ => congr_arg ULift.up (Int.cast_negSucc _) }
-
-instance addCommGroupWithOne [AddCommGroupWithOne α] : AddCommGroupWithOne (ULift α) :=
-  { ULift.addGroupWithOne, ULift.addCommGroup with }
 
 @[to_additive]
 instance leftCancelSemigroup [LeftCancelSemigroup α] : LeftCancelSemigroup (ULift α) :=

--- a/Mathlib/Algebra/NoZeroSMulDivisors/Defs.lean
+++ b/Mathlib/Algebra/NoZeroSMulDivisors/Defs.lean
@@ -5,6 +5,7 @@ Authors: Anne Baanen, Yury Kudryashov, Joseph Myers, Heather Macbeth, Kim Morris
 -/
 import Mathlib.Algebra.GroupWithZero.Action.Defs
 import Mathlib.Algebra.Group.Torsion
+import Mathlib.Tactic.Contrapose
 
 /-!
 # `NoZeroSMulDivisors`

--- a/Mathlib/Algebra/Order/Interval/Set/Group.lean
+++ b/Mathlib/Algebra/Order/Interval/Set/Group.lean
@@ -6,6 +6,7 @@ Authors: Johannes Hölzl, Mario Carneiro, Patrick Massot, Yury Kudryashov, Rémy
 import Mathlib.Algebra.Order.Group.Abs
 import Mathlib.Algebra.Order.Group.Basic
 import Mathlib.Algebra.Order.Ring.Defs
+import Mathlib.Data.Int.Cast.Basic
 import Mathlib.Order.Interval.Set.Basic
 import Mathlib.Logic.Pairwise
 

--- a/Mathlib/Algebra/README.md
+++ b/Mathlib/Algebra/README.md
@@ -9,7 +9,7 @@ previous:
 * `Algebra.Notation` for basic algebraic notation
 * `Algebra.Group` for semigroups, monoids, groups
 * `Algebra.GroupWithZero` for monoids with a zero adjoined, groups with a zero adjoined
-* `Algebra.Ring` for additive monoids with one, semirings, rings
+* `Algebra.Ring` for additive monoids and groups with one, semirings, rings
 * `Algebra.Field` for semifields, fields
 
 Files in earlier subfolders should not import files in later ones.

--- a/Mathlib/Algebra/README.md
+++ b/Mathlib/Algebra/README.md
@@ -9,7 +9,7 @@ previous:
 * `Algebra.Notation` for basic algebraic notation
 * `Algebra.Group` for semigroups, monoids, groups
 * `Algebra.GroupWithZero` for monoids with a zero adjoined, groups with a zero adjoined
-* `Algebra.Ring` for semirings, rings
+* `Algebra.Ring` for additive monoids with one, semirings, rings
 * `Algebra.Field` for semifields, fields
 
 Files in earlier subfolders should not import files in later ones.

--- a/Mathlib/Algebra/Ring/InjSurj.lean
+++ b/Mathlib/Algebra/Ring/InjSurj.lean
@@ -6,9 +6,20 @@ Authors: Jeremy Avigad, Leonardo de Moura, Floris van Doorn, Yury Kudryashov, Ne
 import Mathlib.Algebra.Ring.Defs
 import Mathlib.Algebra.Opposites
 import Mathlib.Algebra.GroupWithZero.InjSurj
+import Mathlib.Data.Int.Cast.Basic
 
 /-!
 # Pulling back rings along injective maps, and pushing them forward along surjective maps
+
+## Implementation note
+
+The `nsmul` and `zsmul` assumptions on any transfer definition for an algebraic structure involving
+both addition and multiplication (eg `AddMonoidWithOne`) is `∀ n x, f (n • x) = n • f x`, which is
+what we would expect.
+However, we cannot do the same for transfer definitions built using `to_additive` (eg `AddMonoid`)
+as we want the multiplicative versions to be `∀ x n, f (x ^ n) = f x ^ n`.
+As a result, we must use `Function.swap` when using additivised transfer definitions in
+non-additivised ones.
 -/
 
 variable {R S : Type*}
@@ -48,6 +59,55 @@ protected abbrev hasDistribNeg (f : S → R) (hf : Injective f) [Mul R] [HasDist
   { hf.involutiveNeg _ neg, ‹Mul S› with
     neg_mul := fun x y => hf <| by rw [neg, mul, neg, neg_mul, mul],
     mul_neg := fun x y => hf <| by rw [neg, mul, neg, mul_neg, mul] }
+
+/-- A type endowed with `0`, `1` and `+` is an additive monoid with one,
+if it admits an injective map that preserves `0`, `1` and `+` to an additive monoid with one.
+See note [reducible non-instances]. -/
+protected abbrev addMonoidWithOne [Zero S] [One S] [Add S] [SMul ℕ S] [NatCast S]
+    [AddMonoidWithOne R] (f : S → R) (hf : Injective f) (zero : f 0 = 0) (one : f 1 = 1)
+    (add : ∀ x y, f (x + y) = f x + f y) (nsmul : ∀ (n : ℕ) (x), f (n • x) = n • f x)
+    (natCast : ∀ n : ℕ, f n = n) : AddMonoidWithOne S :=
+  { hf.addMonoid f zero add (swap nsmul) with
+    natCast := Nat.cast,
+    natCast_zero := hf (by rw [natCast, Nat.cast_zero, zero]),
+    natCast_succ := fun n => hf (by rw [natCast, Nat.cast_succ, add, one, natCast]), one := 1 }
+
+/-- A type endowed with `0`, `1` and `+` is an additive commutative monoid with one, if it admits an
+injective map that preserves `0`, `1` and `+` to an additive commutative monoid with one.
+See note [reducible non-instances]. -/
+protected abbrev addCommMonoidWithOne {S} [Zero S] [One S] [Add S] [SMul ℕ S] [NatCast S]
+    [AddCommMonoidWithOne R] (f : S → R) (hf : Injective f) (zero : f 0 = 0) (one : f 1 = 1)
+    (add : ∀ x y, f (x + y) = f x + f y) (nsmul : ∀ (n : ℕ) (x), f (n • x) = n • f x)
+    (natCast : ∀ n : ℕ, f n = n) : AddCommMonoidWithOne S where
+  __ := hf.addMonoidWithOne f zero one add nsmul natCast
+  __ := hf.addCommMonoid _ zero add (swap nsmul)
+
+/-- A type endowed with `0`, `1` and `+` is an additive group with one, if it admits an injective
+map that preserves `0`, `1` and `+` to an additive group with one.  See note
+[reducible non-instances]. -/
+protected abbrev addGroupWithOne {S} [Zero S] [One S] [Add S] [SMul ℕ S] [Neg S] [Sub S]
+    [SMul ℤ S] [NatCast S] [IntCast S] [AddGroupWithOne R] (f : S → R) (hf : Injective f)
+    (zero : f 0 = 0) (one : f 1 = 1) (add : ∀ x y, f (x + y) = f x + f y) (neg : ∀ x, f (-x) = -f x)
+    (sub : ∀ x y, f (x - y) = f x - f y) (nsmul : ∀ (n : ℕ) (x), f (n • x) = n • f x)
+    (zsmul : ∀ (n : ℤ) (x), f (n • x) = n • f x) (natCast : ∀ n : ℕ, f n = n)
+    (intCast : ∀ n : ℤ, f n = n) : AddGroupWithOne S :=
+  { hf.addGroup f zero add neg sub (swap nsmul) (swap zsmul),
+    hf.addMonoidWithOne f zero one add nsmul natCast with
+    intCast := Int.cast,
+    intCast_ofNat := fun n => hf (by rw [natCast, intCast, Int.cast_natCast]),
+    intCast_negSucc := fun n => hf (by rw [intCast, neg, natCast, Int.cast_negSucc] ) }
+
+/-- A type endowed with `0`, `1` and `+` is an additive commutative group with one, if it admits an
+injective map that preserves `0`, `1` and `+` to an additive commutative group with one.
+See note [reducible non-instances]. -/
+protected abbrev addCommGroupWithOne {S} [Zero S] [One S] [Add S] [SMul ℕ S] [Neg S] [Sub S]
+    [SMul ℤ S] [NatCast S] [IntCast S] [AddCommGroupWithOne R] (f : S → R) (hf : Injective f)
+    (zero : f 0 = 0) (one : f 1 = 1) (add : ∀ x y, f (x + y) = f x + f y) (neg : ∀ x, f (-x) = -f x)
+    (sub : ∀ x y, f (x - y) = f x - f y) (nsmul : ∀ (n : ℕ) (x), f (n • x) = n • f x)
+    (zsmul : ∀ (n : ℤ) (x), f (n • x) = n • f x) (natCast : ∀ n : ℕ, f n = n)
+    (intCast : ∀ n : ℤ, f n = n) : AddCommGroupWithOne S :=
+  { hf.addGroupWithOne f zero one add neg sub nsmul zsmul natCast intCast,
+    hf.addCommMonoid _ zero add (swap nsmul) with }
 
 /-- Pullback a `NonUnitalNonAssocSemiring` instance along an injective function. -/
 -- See note [reducible non-instances]
@@ -228,6 +288,58 @@ protected abbrev hasDistribNeg [Mul R] [HasDistribNeg R]
   { hf.involutiveNeg _ neg, ‹Mul S› with
     neg_mul := hf.forall₂.2 fun x y => by rw [← neg, ← mul, neg_mul, neg, mul]
     mul_neg := hf.forall₂.2 fun x y => by rw [← neg, ← mul, mul_neg, neg, mul] }
+
+
+/-- A type endowed with `0`, `1` and `+` is an additive monoid with one, if it admits a surjective
+map that preserves `0`, `1` and `*` from an additive monoid with one. See note
+[reducible non-instances]. -/
+protected abbrev addMonoidWithOne {R} [Zero R] [One R] [Add R] [SMul ℕ R] [NatCast R]
+    [AddMonoidWithOne S] (f : S → R) (hf : Surjective f) (zero : f 0 = 0) (one : f 1 = 1)
+    (add : ∀ x y, f (x + y) = f x + f y) (nsmul : ∀ (n : ℕ) (x), f (n • x) = n • f x)
+    (natCast : ∀ n : ℕ, f n = n) : AddMonoidWithOne R :=
+  { hf.addMonoid f zero add (swap nsmul) with
+    natCast := Nat.cast,
+    natCast_zero := by rw [← natCast, Nat.cast_zero, zero]
+    natCast_succ := fun n => by rw [← natCast, Nat.cast_succ, add, one, natCast]
+    one := 1 }
+
+/-- A type endowed with `0`, `1` and `+` is an additive monoid with one,
+if it admits a surjective map that preserves `0`, `1` and `*` from an additive monoid with one.
+See note [reducible non-instances]. -/
+protected abbrev addCommMonoidWithOne {R} [Zero R] [One R] [Add R] [SMul ℕ R] [NatCast R]
+    [AddCommMonoidWithOne S] (f : S → R) (hf : Surjective f) (zero : f 0 = 0) (one : f 1 = 1)
+    (add : ∀ x y, f (x + y) = f x + f y) (nsmul : ∀ (n : ℕ) (x), f (n • x) = n • f x)
+    (natCast : ∀ n : ℕ, f n = n) : AddCommMonoidWithOne R where
+  __ := hf.addMonoidWithOne f zero one add nsmul natCast
+  __ := hf.addCommMonoid _ zero add (swap nsmul)
+
+/-- A type endowed with `0`, `1`, `+` is an additive group with one,
+if it admits a surjective map that preserves `0`, `1`, and `+` to an additive group with one.
+See note [reducible non-instances]. -/
+protected abbrev addGroupWithOne {R} [Zero R] [One R] [Add R] [Neg R] [Sub R] [SMul ℕ R]
+    [SMul ℤ R] [NatCast R] [IntCast R] [AddGroupWithOne S] (f : S → R) (hf : Surjective f)
+    (zero : f 0 = 0) (one : f 1 = 1) (add : ∀ x y, f (x + y) = f x + f y) (neg : ∀ x, f (-x) = -f x)
+    (sub : ∀ x y, f (x - y) = f x - f y) (nsmul : ∀ (n : ℕ) (x), f (n • x) = n • f x)
+    (zsmul : ∀ (n : ℤ) (x), f (n • x) = n • f x) (natCast : ∀ n : ℕ, f n = n)
+    (intCast : ∀ n : ℤ, f n = n) : AddGroupWithOne R :=
+  { hf.addMonoidWithOne f zero one add nsmul natCast,
+    hf.addGroup f zero add neg sub (swap nsmul) (swap zsmul) with
+    intCast := Int.cast,
+    intCast_ofNat := fun n => by rw [← intCast, Int.cast_natCast, natCast],
+    intCast_negSucc := fun n => by
+      rw [← intCast, Int.cast_negSucc, neg, natCast] }
+
+/-- A type endowed with `0`, `1`, `+` is an additive commutative group with one, if it admits a
+surjective map that preserves `0`, `1`, and `+` to an additive commutative group with one.
+See note [reducible non-instances]. -/
+protected abbrev addCommGroupWithOne {R} [Zero R] [One R] [Add R] [Neg R] [Sub R] [SMul ℕ R]
+    [SMul ℤ R] [NatCast R] [IntCast R] [AddCommGroupWithOne S] (f : S → R) (hf : Surjective f)
+    (zero : f 0 = 0) (one : f 1 = 1) (add : ∀ x y, f (x + y) = f x + f y) (neg : ∀ x, f (-x) = -f x)
+    (sub : ∀ x y, f (x - y) = f x - f y) (nsmul : ∀ (n : ℕ) (x), f (n • x) = n • f x)
+    (zsmul : ∀ (n : ℤ) (x), f (n • x) = n • f x) (natCast : ∀ n : ℕ, f n = n)
+    (intCast : ∀ n : ℤ, f n = n) : AddCommGroupWithOne R :=
+  { hf.addGroupWithOne f zero one add neg sub nsmul zsmul natCast intCast,
+    hf.addCommMonoid _ zero add (swap nsmul) with }
 
 /-- Pushforward a `NonUnitalNonAssocSemiring` instance along a surjective function.
 See note [reducible non-instances]. -/

--- a/Mathlib/Algebra/Ring/InjSurj.lean
+++ b/Mathlib/Algebra/Ring/InjSurj.lean
@@ -293,10 +293,9 @@ protected abbrev hasDistribNeg [Mul R] [HasDistribNeg R]
 /-- A type endowed with `0`, `1` and `+` is an additive monoid with one, if it admits a surjective
 map that preserves `0`, `1` and `*` from an additive monoid with one. See note
 [reducible non-instances]. -/
-protected abbrev addMonoidWithOne {R} [Zero R] [One R] [Add R] [SMul ℕ R] [NatCast R]
-    [AddMonoidWithOne S] (f : S → R) (hf : Surjective f) (zero : f 0 = 0) (one : f 1 = 1)
+protected abbrev addMonoidWithOne [AddMonoidWithOne R] (zero : f 0 = 0) (one : f 1 = 1)
     (add : ∀ x y, f (x + y) = f x + f y) (nsmul : ∀ (n : ℕ) (x), f (n • x) = n • f x)
-    (natCast : ∀ n : ℕ, f n = n) : AddMonoidWithOne R :=
+    (natCast : ∀ n : ℕ, f n = n) : AddMonoidWithOne S :=
   { hf.addMonoid f zero add (swap nsmul) with
     natCast := Nat.cast,
     natCast_zero := by rw [← natCast, Nat.cast_zero, zero]
@@ -306,22 +305,20 @@ protected abbrev addMonoidWithOne {R} [Zero R] [One R] [Add R] [SMul ℕ R] [Nat
 /-- A type endowed with `0`, `1` and `+` is an additive monoid with one,
 if it admits a surjective map that preserves `0`, `1` and `*` from an additive monoid with one.
 See note [reducible non-instances]. -/
-protected abbrev addCommMonoidWithOne {R} [Zero R] [One R] [Add R] [SMul ℕ R] [NatCast R]
-    [AddCommMonoidWithOne S] (f : S → R) (hf : Surjective f) (zero : f 0 = 0) (one : f 1 = 1)
+protected abbrev addCommMonoidWithOne [AddCommMonoidWithOne R] (zero : f 0 = 0) (one : f 1 = 1)
     (add : ∀ x y, f (x + y) = f x + f y) (nsmul : ∀ (n : ℕ) (x), f (n • x) = n • f x)
-    (natCast : ∀ n : ℕ, f n = n) : AddCommMonoidWithOne R where
+    (natCast : ∀ n : ℕ, f n = n) : AddCommMonoidWithOne S where
   __ := hf.addMonoidWithOne f zero one add nsmul natCast
   __ := hf.addCommMonoid _ zero add (swap nsmul)
 
 /-- A type endowed with `0`, `1`, `+` is an additive group with one,
 if it admits a surjective map that preserves `0`, `1`, and `+` to an additive group with one.
 See note [reducible non-instances]. -/
-protected abbrev addGroupWithOne {R} [Zero R] [One R] [Add R] [Neg R] [Sub R] [SMul ℕ R]
-    [SMul ℤ R] [NatCast R] [IntCast R] [AddGroupWithOne S] (f : S → R) (hf : Surjective f)
+protected abbrev addGroupWithOne [AddGroupWithOne R]
     (zero : f 0 = 0) (one : f 1 = 1) (add : ∀ x y, f (x + y) = f x + f y) (neg : ∀ x, f (-x) = -f x)
     (sub : ∀ x y, f (x - y) = f x - f y) (nsmul : ∀ (n : ℕ) (x), f (n • x) = n • f x)
     (zsmul : ∀ (n : ℤ) (x), f (n • x) = n • f x) (natCast : ∀ n : ℕ, f n = n)
-    (intCast : ∀ n : ℤ, f n = n) : AddGroupWithOne R :=
+    (intCast : ∀ n : ℤ, f n = n) : AddGroupWithOne S :=
   { hf.addMonoidWithOne f zero one add nsmul natCast,
     hf.addGroup f zero add neg sub (swap nsmul) (swap zsmul) with
     intCast := Int.cast,
@@ -332,12 +329,11 @@ protected abbrev addGroupWithOne {R} [Zero R] [One R] [Add R] [Neg R] [Sub R] [S
 /-- A type endowed with `0`, `1`, `+` is an additive commutative group with one, if it admits a
 surjective map that preserves `0`, `1`, and `+` to an additive commutative group with one.
 See note [reducible non-instances]. -/
-protected abbrev addCommGroupWithOne {R} [Zero R] [One R] [Add R] [Neg R] [Sub R] [SMul ℕ R]
-    [SMul ℤ R] [NatCast R] [IntCast R] [AddCommGroupWithOne S] (f : S → R) (hf : Surjective f)
+protected abbrev addCommGroupWithOne [AddCommGroupWithOne R]
     (zero : f 0 = 0) (one : f 1 = 1) (add : ∀ x y, f (x + y) = f x + f y) (neg : ∀ x, f (-x) = -f x)
     (sub : ∀ x y, f (x - y) = f x - f y) (nsmul : ∀ (n : ℕ) (x), f (n • x) = n • f x)
     (zsmul : ∀ (n : ℤ) (x), f (n • x) = n • f x) (natCast : ∀ n : ℕ, f n = n)
-    (intCast : ∀ n : ℤ, f n = n) : AddCommGroupWithOne R :=
+    (intCast : ∀ n : ℤ, f n = n) : AddCommGroupWithOne S :=
   { hf.addGroupWithOne f zero one add neg sub nsmul zsmul natCast intCast,
     hf.addCommMonoid _ zero add (swap nsmul) with }
 

--- a/Mathlib/Algebra/Ring/Opposite.lean
+++ b/Mathlib/Algebra/Ring/Opposite.lean
@@ -6,6 +6,7 @@ Authors: Kenny Lau
 import Mathlib.Algebra.Group.Equiv.Opposite
 import Mathlib.Algebra.GroupWithZero.Opposite
 import Mathlib.Algebra.Ring.Hom.Defs
+import Mathlib.Data.Int.Cast.Basic
 
 /-!
 # Ring structures on the multiplicative opposite
@@ -18,6 +19,57 @@ namespace MulOpposite
 instance instDistrib [Distrib R] : Distrib Rᵐᵒᵖ where
   left_distrib _ _ _ := unop_injective <| add_mul _ _ _
   right_distrib _ _ _ := unop_injective <| mul_add _ _ _
+
+@[to_additive] instance instNatCast [NatCast R] : NatCast Rᵐᵒᵖ where natCast n := op n
+@[to_additive] instance instIntCast [IntCast R] : IntCast Rᵐᵒᵖ where intCast n := op n
+
+@[to_additive (attr := simp, norm_cast)]
+theorem op_natCast [NatCast R] (n : ℕ) : op (n : R) = n :=
+  rfl
+
+@[to_additive (attr := simp)]
+theorem op_ofNat [NatCast R] (n : ℕ) [n.AtLeastTwo] :
+    op (ofNat(n) : R) = ofNat(n) :=
+  rfl
+
+@[to_additive (attr := simp, norm_cast)]
+theorem op_intCast [IntCast R] (n : ℤ) : op (n : R) = n :=
+  rfl
+
+@[to_additive (attr := simp, norm_cast)]
+theorem unop_natCast [NatCast R] (n : ℕ) : unop (n : Rᵐᵒᵖ) = n :=
+  rfl
+
+@[to_additive (attr := simp)]
+theorem unop_ofNat [NatCast R] (n : ℕ) [n.AtLeastTwo] :
+    unop (ofNat(n) : Rᵐᵒᵖ) = ofNat(n) :=
+  rfl
+
+@[to_additive (attr := simp, norm_cast)]
+theorem unop_intCast [IntCast R] (n : ℤ) : unop (n : Rᵐᵒᵖ) = n :=
+  rfl
+
+instance instAddMonoidWithOne [AddMonoidWithOne R] : AddMonoidWithOne Rᵐᵒᵖ where
+  toNatCast := instNatCast
+  toAddMonoid := instAddMonoid
+  toOne := instOne
+  natCast_zero := show op ((0 : ℕ) : R) = 0 by rw [Nat.cast_zero, op_zero]
+  natCast_succ := show ∀ n, op ((n + 1 : ℕ) : R) = op ↑(n : ℕ) + 1 by simp
+
+instance instAddCommMonoidWithOne [AddCommMonoidWithOne R] : AddCommMonoidWithOne Rᵐᵒᵖ where
+  toAddMonoidWithOne := instAddMonoidWithOne
+  __ := instAddCommMonoid
+
+instance instAddGroupWithOne [AddGroupWithOne R] : AddGroupWithOne Rᵐᵒᵖ where
+  toAddMonoidWithOne := instAddMonoidWithOne
+  toIntCast := instIntCast
+  __ := instAddGroup
+  intCast_ofNat n := show op ((n : ℤ) : R) = op (n : R) by rw [Int.cast_natCast]
+  intCast_negSucc n := show op _ = op (-unop (op ((n + 1 : ℕ) : R))) by simp
+
+instance instAddCommGroupWithOne [AddCommGroupWithOne R] : AddCommGroupWithOne Rᵐᵒᵖ where
+  toAddCommGroup := instAddCommGroup
+  __ := instAddGroupWithOne
 
 instance instNonUnitalNonAssocSemiring [NonUnitalNonAssocSemiring R] :
     NonUnitalNonAssocSemiring Rᵐᵒᵖ where
@@ -82,6 +134,21 @@ namespace AddOpposite
 instance instDistrib [Distrib R] : Distrib Rᵃᵒᵖ where
   left_distrib _ _ _ := unop_injective <| mul_add _ _ _
   right_distrib _ _ _ := unop_injective <| add_mul _ _ _
+
+-- NOTE: `addMonoidWithOne R → addMonoidWithOne Rᵃᵒᵖ` does not hold
+instance instAddCommMonoidWithOne [AddCommMonoidWithOne R] : AddCommMonoidWithOne Rᵃᵒᵖ where
+  toNatCast := instNatCast
+  toOne := instOne
+  __ := instAddCommMonoid
+  natCast_zero := show op ((0 : ℕ) : R) = 0 by rw [Nat.cast_zero, op_zero]
+  natCast_succ := show ∀ n, op ((n + 1 : ℕ) : R) = op ↑(n : ℕ) + 1 by simp [add_comm]
+
+instance instAddCommGroupWithOne [AddCommGroupWithOne R] : AddCommGroupWithOne Rᵃᵒᵖ where
+  toIntCast := instIntCast
+  toAddCommGroup := instAddCommGroup
+  __ := instAddCommMonoidWithOne
+  intCast_ofNat _ := congr_arg op <| Int.cast_natCast _
+  intCast_negSucc _ := congr_arg op <| Int.cast_negSucc _
 
 instance instNonUnitalNonAssocSemiring [NonUnitalNonAssocSemiring R] :
     NonUnitalNonAssocSemiring Rᵃᵒᵖ where

--- a/Mathlib/Algebra/Ring/ULift.lean
+++ b/Mathlib/Algebra/Ring/ULift.lean
@@ -31,6 +31,54 @@ instance distrib [Distrib R] : Distrib (ULift R) :=
     left_distrib := fun _ _ _ => (Equiv.ulift).injective (by simp [left_distrib]),
     right_distrib := fun _ _ _ => (Equiv.ulift).injective (by simp [right_distrib]) }
 
+
+instance instNatCast [NatCast R] : NatCast (ULift R) := ⟨(up ·)⟩
+instance instIntCast [IntCast R] : IntCast (ULift R) := ⟨(up ·)⟩
+
+@[simp, norm_cast]
+theorem up_natCast [NatCast R] (n : ℕ) : up (n : R) = n :=
+  rfl
+
+@[simp]
+theorem up_ofNat [NatCast R] (n : ℕ) [n.AtLeastTwo] :
+    up (ofNat(n) : R) = ofNat(n) :=
+  rfl
+
+@[simp, norm_cast]
+theorem up_intCast [IntCast R] (n : ℤ) : up (n : R) = n :=
+  rfl
+
+@[simp, norm_cast]
+theorem down_natCast [NatCast R] (n : ℕ) : down (n : ULift R) = n :=
+  rfl
+
+@[simp]
+theorem down_ofNat [NatCast R] (n : ℕ) [n.AtLeastTwo] :
+    down (ofNat(n) : ULift R) = ofNat(n) :=
+  rfl
+
+@[simp, norm_cast]
+theorem down_intCast [IntCast R] (n : ℤ) : down (n : ULift R) = n :=
+  rfl
+
+instance addMonoidWithOne [AddMonoidWithOne R] : AddMonoidWithOne (ULift R) :=
+  { ULift.one, ULift.addMonoid with
+      natCast := (⟨·⟩)
+      natCast_zero := congr_arg ULift.up Nat.cast_zero,
+      natCast_succ := fun _ => congr_arg ULift.up (Nat.cast_succ _) }
+
+instance addCommMonoidWithOne [AddCommMonoidWithOne R] : AddCommMonoidWithOne (ULift R) :=
+  { ULift.addMonoidWithOne, ULift.addCommMonoid with }
+
+instance addGroupWithOne [AddGroupWithOne α] : AddGroupWithOne (ULift α) :=
+  { ULift.addMonoidWithOne, ULift.addGroup with
+      intCast := (⟨·⟩),
+      intCast_ofNat := fun _ => congr_arg ULift.up (Int.cast_natCast _),
+      intCast_negSucc := fun _ => congr_arg ULift.up (Int.cast_negSucc _) }
+
+instance addCommGroupWithOne [AddCommGroupWithOne α] : AddCommGroupWithOne (ULift α) :=
+  { ULift.addGroupWithOne, ULift.addCommGroup with }
+
 instance nonUnitalNonAssocSemiring [NonUnitalNonAssocSemiring R] :
     NonUnitalNonAssocSemiring (ULift R) :=
   { zero := (0 : ULift R), add := (· + ·), mul := (· * ·), nsmul := AddMonoid.nsmul,

--- a/Mathlib/Algebra/Ring/ULift.lean
+++ b/Mathlib/Algebra/Ring/ULift.lean
@@ -5,6 +5,7 @@ Authors: Kim Morrison
 -/
 import Mathlib.Algebra.Group.ULift
 import Mathlib.Algebra.Ring.Equiv
+import Mathlib.Data.Int.Cast.Basic
 
 /-!
 # `ULift` instances for ring
@@ -70,13 +71,13 @@ instance addMonoidWithOne [AddMonoidWithOne R] : AddMonoidWithOne (ULift R) :=
 instance addCommMonoidWithOne [AddCommMonoidWithOne R] : AddCommMonoidWithOne (ULift R) :=
   { ULift.addMonoidWithOne, ULift.addCommMonoid with }
 
-instance addGroupWithOne [AddGroupWithOne α] : AddGroupWithOne (ULift α) :=
+instance addGroupWithOne [AddGroupWithOne R] : AddGroupWithOne (ULift R) :=
   { ULift.addMonoidWithOne, ULift.addGroup with
       intCast := (⟨·⟩),
       intCast_ofNat := fun _ => congr_arg ULift.up (Int.cast_natCast _),
       intCast_negSucc := fun _ => congr_arg ULift.up (Int.cast_negSucc _) }
 
-instance addCommGroupWithOne [AddCommGroupWithOne α] : AddCommGroupWithOne (ULift α) :=
+instance addCommGroupWithOne [AddCommGroupWithOne R] : AddCommGroupWithOne (ULift R) :=
   { ULift.addGroupWithOne, ULift.addCommGroup with }
 
 instance nonUnitalNonAssocSemiring [NonUnitalNonAssocSemiring R] :

--- a/Mathlib/Algebra/Ring/ULift.lean
+++ b/Mathlib/Algebra/Ring/ULift.lean
@@ -32,7 +32,6 @@ instance distrib [Distrib R] : Distrib (ULift R) :=
     left_distrib := fun _ _ _ => (Equiv.ulift).injective (by simp [left_distrib]),
     right_distrib := fun _ _ _ => (Equiv.ulift).injective (by simp [right_distrib]) }
 
-
 instance instNatCast [NatCast R] : NatCast (ULift R) := ⟨(up ·)⟩
 instance instIntCast [IntCast R] : IntCast (ULift R) := ⟨(up ·)⟩
 

--- a/Mathlib/Combinatorics/SimpleGraph/DeleteEdges.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/DeleteEdges.lean
@@ -6,6 +6,7 @@ Authors: Aaron Anderson, Jalex Stark, Kyle Miller, Alena Gusakov, Hunter Monroe
 import Mathlib.Algebra.Ring.Defs
 import Mathlib.Combinatorics.SimpleGraph.Finite
 import Mathlib.Combinatorics.SimpleGraph.Maps
+import Mathlib.Data.Int.Cast.Basic
 
 /-!
 # Edge deletion

--- a/Mathlib/Data/DFinsupp/Defs.lean
+++ b/Mathlib/Data/DFinsupp/Defs.lean
@@ -8,6 +8,7 @@ import Mathlib.Algebra.Group.InjSurj
 import Mathlib.Algebra.Group.Equiv.Defs
 import Mathlib.Algebra.Group.Pi.Basic
 import Mathlib.Algebra.Notation.Prod
+import Mathlib.Data.Int.Cast.Basic
 
 /-!
 # Dependent functions with finite support

--- a/Mathlib/Data/DFinsupp/Defs.lean
+++ b/Mathlib/Data/DFinsupp/Defs.lean
@@ -8,7 +8,7 @@ import Mathlib.Algebra.Group.InjSurj
 import Mathlib.Algebra.Group.Equiv.Defs
 import Mathlib.Algebra.Group.Pi.Basic
 import Mathlib.Algebra.Notation.Prod
-import Mathlib.Data.Int.Cast.Basic
+import Mathlib.Algebra.Group.Basic
 
 /-!
 # Dependent functions with finite support

--- a/Mathlib/Data/Int/Cast/Prod.lean
+++ b/Mathlib/Data/Int/Cast/Prod.lean
@@ -3,8 +3,8 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import Mathlib.Data.Nat.Cast.Prod
 import Mathlib.Data.Int.Cast.Basic
+import Mathlib.Data.Nat.Cast.Prod
 
 /-!
 # The product of two `AddGroupWithOne`s.

--- a/Mathlib/Data/Int/Cast/Prod.lean
+++ b/Mathlib/Data/Int/Cast/Prod.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Mathlib.Data.Nat.Cast.Prod
+import Mathlib.Data.Int.Cast.Basic
 
 /-!
 # The product of two `AddGroupWithOne`s.

--- a/Mathlib/Data/Matrix/Diagonal.lean
+++ b/Mathlib/Data/Matrix/Diagonal.lean
@@ -3,10 +3,10 @@ Copyright (c) 2018 Ellen Arlt. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Ellen Arlt, Blair Shi, Sean Leather, Mario Carneiro, Johan Commelin, Lu-Ming Zhang
 -/
+import Mathlib.Data.Int.Cast.Basic
 import Mathlib.Data.Int.Cast.Pi
 import Mathlib.Data.Matrix.Defs
 import Mathlib.Data.Nat.Cast.Basic
-import Mathlib.Data.Int.Cast.Basic
 
 /-!
 # Diagonal matrices

--- a/Mathlib/Data/Matrix/Diagonal.lean
+++ b/Mathlib/Data/Matrix/Diagonal.lean
@@ -6,6 +6,7 @@ Authors: Ellen Arlt, Blair Shi, Sean Leather, Mario Carneiro, Johan Commelin, Lu
 import Mathlib.Data.Int.Cast.Pi
 import Mathlib.Data.Matrix.Defs
 import Mathlib.Data.Nat.Cast.Basic
+import Mathlib.Data.Int.Cast.Basic
 
 /-!
 # Diagonal matrices

--- a/Mathlib/Data/Nat/Cast/Prod.lean
+++ b/Mathlib/Data/Nat/Cast/Prod.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Mathlib.Algebra.Group.Prod
+import Mathlib.Data.Nat.Cast.Defs
 
 /-!
 # The product of two `AddMonoidWithOne`s.

--- a/Mathlib/GroupTheory/Congruence/Defs.lean
+++ b/Mathlib/GroupTheory/Congruence/Defs.lean
@@ -594,7 +594,7 @@ theorem map_of_mul_left_rel_one [Monoid M] (c : Con M)
   have hf' : ∀ x : M, (x : c.Quotient) * f x = 1 := fun x ↦
     calc
       (x : c.Quotient) * f x = f (f x) * f x * (x * f x) := by simp [hf]
-      _ = f (f x) * (f x * x) * f x := by ac_rfl
+      _ = f (f x) * (f x * x) * f x := by simp_rw [mul_assoc]
       _ = 1 := by simp [hf]
   have : (⟨_, _, hf' x, hf x⟩ : c.Quotientˣ) = ⟨_, _, hf' y, hf y⟩ := Units.ext h
   exact congr_arg Units.inv this

--- a/Mathlib/GroupTheory/OreLocalization/Basic.lean
+++ b/Mathlib/GroupTheory/OreLocalization/Basic.lean
@@ -7,6 +7,7 @@ import Mathlib.GroupTheory.OreLocalization.OreSet
 import Mathlib.Tactic.Common
 import Mathlib.Algebra.Group.Submonoid.MulAction
 import Mathlib.Algebra.Group.Units.Defs
+import Mathlib.Data.Int.Cast.Basic
 
 /-!
 

--- a/Mathlib/GroupTheory/OreLocalization/Basic.lean
+++ b/Mathlib/GroupTheory/OreLocalization/Basic.lean
@@ -7,7 +7,7 @@ import Mathlib.GroupTheory.OreLocalization.OreSet
 import Mathlib.Tactic.Common
 import Mathlib.Algebra.Group.Submonoid.MulAction
 import Mathlib.Algebra.Group.Units.Defs
-import Mathlib.Data.Int.Cast.Basic
+import Mathlib.Algebra.Group.Basic
 
 /-!
 

--- a/Mathlib/Order/Filter/Germ/Basic.lean
+++ b/Mathlib/Order/Filter/Germ/Basic.lean
@@ -6,6 +6,7 @@ Authors: Yury Kudryashov, Abhimanyu Pallavi Sudhir
 import Mathlib.Algebra.Module.Pi
 import Mathlib.Algebra.Order.Monoid.Unbundled.ExistsOfLE
 import Mathlib.Data.Int.Cast.Pi
+import Mathlib.Data.Int.Cast.Basic
 import Mathlib.Data.Nat.Cast.Basic
 import Mathlib.Order.Filter.Tendsto
 

--- a/Mathlib/Order/Filter/Germ/Basic.lean
+++ b/Mathlib/Order/Filter/Germ/Basic.lean
@@ -5,8 +5,8 @@ Authors: Yury Kudryashov, Abhimanyu Pallavi Sudhir
 -/
 import Mathlib.Algebra.Module.Pi
 import Mathlib.Algebra.Order.Monoid.Unbundled.ExistsOfLE
-import Mathlib.Data.Int.Cast.Pi
 import Mathlib.Data.Int.Cast.Basic
+import Mathlib.Data.Int.Cast.Pi
 import Mathlib.Data.Nat.Cast.Basic
 import Mathlib.Order.Filter.Tendsto
 

--- a/Mathlib/SetTheory/PGame/Algebra.lean
+++ b/Mathlib/SetTheory/PGame/Algebra.lean
@@ -5,6 +5,7 @@ Authors: Reid Barton, Mario Carneiro, Isabel Longbottom, Kim Morrison, Yuyang Zh
 -/
 import Mathlib.Algebra.Order.ZeroLEOne
 import Mathlib.SetTheory.PGame.Order
+import Mathlib.Data.Nat.Cast.Defs
 
 /-!
 # Algebraic structure on pregames


### PR DESCRIPTION
There seems to be a convention here that the `Algebra/Group` folder should not contain things about `AddMonoidWithOne`, `AddCommMonoidWithOne`, `AddGroupWithOne`, and `AddCommGroupWithOne`, as these is more `Ring`-like, and cannot be additivized.

I renamed the variables to `R` and `S` to match the destination files, but everything else is copied directly.

Without this change, we're inconsistent and random `assert_not_exists` tests fail when trying to move content around within `Algebra/Group`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
