### PR TITLE
[Merged by Bors] - feat(Data/Nat/Digits): add `digits_length_le_iff`

### DIFF
--- a/Mathlib/Data/Nat/Digits/Lemmas.lean
+++ b/Mathlib/Data/Nat/Digits/Lemmas.lean
@@ -62,17 +62,8 @@ theorem digits_length_le_iff {b k : ℕ} (hb : 1 < b) (n : ℕ) :
   by_cases h : n = 0
   · simp [h]
     positivity
-  constructor
-  · intro hbn
-    rw [digits_len b n hb h] at hbn
-    rw [lt_pow_iff_log_lt hb h]
-    exact hbn
-  · intro hbn
-    by_cases h : n = 0
-    · simp [h]
-    rw [digits_len b n hb h]
-    rw [lt_pow_iff_log_lt hb h] at hbn
-    exact hbn
+  rw [digits_len b n hb h, lt_pow_iff_log_lt hb h]
+  exact add_one_le_iff
 
 theorem lt_digits_length_iff {b k : ℕ} (hb : 1 < b) (n : ℕ) :
     k < (b.digits n).length ↔ b ^ k ≤ n := by

--- a/Mathlib/Data/Nat/Digits/Lemmas.lean
+++ b/Mathlib/Data/Nat/Digits/Lemmas.lean
@@ -57,14 +57,6 @@ theorem digits_len (b n : ℕ) (hb : 1 < b) (hn : n ≠ 0) : (b.digits n).length
     contrapose! h
     exact div_eq_of_lt h
 
-theorem digits_length_le_of_lt {b k : ℕ} (hb : 1 < b) (n : ℕ) (hbn : n < b ^ k) :
-    (b.digits n).length ≤ k := by
-  by_cases h : n = 0
-  · simp [h]
-  rw [digits_len b n hb h]
-  rw [lt_pow_iff_log_lt hb h] at hbn
-  exact hbn
-
 theorem digits_length_le_iff {b k : ℕ} (hb : 1 < b) (n : ℕ) :
     (b.digits n).length ≤ k ↔ n < b ^ k  := by
   by_cases h : n = 0
@@ -75,8 +67,18 @@ theorem digits_length_le_iff {b k : ℕ} (hb : 1 < b) (n : ℕ) :
     rw [digits_len b n hb h] at hbn
     rw [lt_pow_iff_log_lt hb h]
     exact hbn
-  · intro h
-    exact digits_length_le_of_lt hb n h
+  · intro hbn
+    by_cases h : n = 0
+    · simp [h]
+    rw [digits_len b n hb h]
+    rw [lt_pow_iff_log_lt hb h] at hbn
+    exact hbn
+
+theorem lt_digits_length_iff {b k : ℕ} (hb : 1 < b) (n : ℕ) :
+    k < (b.digits n).length ↔ b ^ k ≤ n := by
+  rw [← not_iff_not]
+  push_neg
+  exact digits_length_le_iff hb n
 
 theorem getLast_digit_ne_zero (b : ℕ) {m : ℕ} (hm : m ≠ 0) :
     (digits b m).getLast (digits_ne_nil_iff_ne_zero.mpr hm) ≠ 0 := by

--- a/Mathlib/Data/Nat/Digits/Lemmas.lean
+++ b/Mathlib/Data/Nat/Digits/Lemmas.lean
@@ -57,6 +57,26 @@ theorem digits_len (b n : ℕ) (hb : 1 < b) (hn : n ≠ 0) : (b.digits n).length
     contrapose! h
     exact div_eq_of_lt h
 
+theorem digits_length_le_of_lt {b k : ℕ} (hb : 1 < b) (n : ℕ) (hn1 : n < b ^ k) :
+    (b.digits n).length ≤ k := by
+  by_cases h : n = 0
+  · simp [h]
+  rw [digits_len b n hb h]
+  exact (lt_pow_iff_log_lt hb h).mp hn1
+
+theorem digits_length_le_iff {b k : ℕ} (hb : 1 < b) (n : ℕ) :
+    (b.digits n).length ≤ k ↔ n < b ^ k  := by
+  by_cases h : n = 0
+  · simp [h]
+    positivity
+  constructor
+  · intro hbn
+    rw [digits_len b n hb h] at hbn
+    rw [lt_pow_iff_log_lt hb h]
+    exact hbn
+  · intro h
+    exact digits_length_le_of_lt hb n h
+
 theorem getLast_digit_ne_zero (b : ℕ) {m : ℕ} (hm : m ≠ 0) :
     (digits b m).getLast (digits_ne_nil_iff_ne_zero.mpr hm) ≠ 0 := by
   rcases b with (_ | _ | b)

--- a/Mathlib/Data/Nat/Digits/Lemmas.lean
+++ b/Mathlib/Data/Nat/Digits/Lemmas.lean
@@ -57,12 +57,13 @@ theorem digits_len (b n : ℕ) (hb : 1 < b) (hn : n ≠ 0) : (b.digits n).length
     contrapose! h
     exact div_eq_of_lt h
 
-theorem digits_length_le_of_lt {b k : ℕ} (hb : 1 < b) (n : ℕ) (hn1 : n < b ^ k) :
+theorem digits_length_le_of_lt {b k : ℕ} (hb : 1 < b) (n : ℕ) (hbn : n < b ^ k) :
     (b.digits n).length ≤ k := by
   by_cases h : n = 0
   · simp [h]
   rw [digits_len b n hb h]
-  exact (lt_pow_iff_log_lt hb h).mp hn1
+  rw [lt_pow_iff_log_lt hb h] at hbn
+  exact hbn
 
 theorem digits_length_le_iff {b k : ℕ} (hb : 1 < b) (n : ℕ) :
     (b.digits n).length ≤ k ↔ n < b ^ k  := by


### PR DESCRIPTION
Adds two lemmas related to the length of the list of digits of a number.

These lemmas were found while doing work for [Project Numina](https://projectnumina.ai/).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
