### PR TITLE
chore: make the arguments of fiberInclusion explicit

### DIFF
--- a/Mathlib/CategoryTheory/FiberedCategory/Fiber.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/Fiber.lean
@@ -43,31 +43,32 @@ instance fiberCategory : Category (Fiber p S) where
   id a := ⟨𝟙 a.1, IsHomLift.id a.2⟩
   comp φ ψ := ⟨φ.val ≫ ψ.val, by have := φ.2; have := ψ.2; infer_instance⟩
 
+variable (p S) in
 /-- The functor including `Fiber p S` into `𝒳`. -/
 def fiberInclusion : Fiber p S ⥤ 𝒳 where
   obj a := a.1
   map φ := φ.1
 
-instance {a b : Fiber p S} (φ : a ⟶ b) : IsHomLift p (𝟙 S) (fiberInclusion.map φ) := φ.2
+instance {a b : Fiber p S} (φ : a ⟶ b) : IsHomLift p (𝟙 S) ((fiberInclusion p S).map φ) := φ.2
 
 @[ext]
 lemma hom_ext {a b : Fiber p S} {φ ψ : a ⟶ b}
-    (h : fiberInclusion.map φ = fiberInclusion.map ψ) : φ = ψ :=
+    (h : (fiberInclusion p S).map φ = (fiberInclusion p S).map ψ) : φ = ψ :=
   Subtype.ext h
 
-instance : (fiberInclusion : Fiber p S ⥤ _).Faithful where
+instance : (fiberInclusion p S).Faithful where
 
-lemma fiberInclusion_obj_inj : (fiberInclusion : Fiber p S ⥤ _).obj.Injective :=
+lemma fiberInclusion_obj_inj : (fiberInclusion p S).obj.Injective :=
   fun _ _ f ↦ Subtype.val_inj.1 f
 
 /-- For fixed `S : 𝒮` this is the natural isomorphism between `fiberInclusion ⋙ p` and the constant
 function valued at `S`. -/
 @[simps!]
-def fiberInclusionCompIsoConst : fiberInclusion ⋙ p ≅ (const (Fiber p S)).obj S :=
+def fiberInclusionCompIsoConst : fiberInclusion p S ⋙ p ≅ (const (Fiber p S)).obj S :=
   NatIso.ofComponents (fun X ↦ eqToIso X.2)
-    (fun φ ↦ by simp [IsHomLift.fac' p (𝟙 S) (fiberInclusion.map φ)])
+    (fun φ ↦ by simp [IsHomLift.fac' p (𝟙 S) ((fiberInclusion p S).map φ)])
 
-lemma fiberInclusion_comp_eq_const : fiberInclusion ⋙ p = (const (Fiber p S)).obj S :=
+lemma fiberInclusion_comp_eq_const : fiberInclusion p S ⋙ p = (const (Fiber p S)).obj S :=
   Functor.ext_of_iso fiberInclusionCompIsoConst (fun x ↦ x.2)
 
 /-- The object of the fiber over `S` corresponding to a `a : 𝒳` such that `p(a) = S`. -/
@@ -75,7 +76,7 @@ def mk {p : 𝒳 ⥤ 𝒮} {S : 𝒮} {a : 𝒳} (ha : p.obj a = S) : Fiber p S 
 
 @[simp]
 lemma fiberInclusion_mk {p : 𝒳 ⥤ 𝒮} {S : 𝒮} {a : 𝒳} (ha : p.obj a = S) :
-    fiberInclusion.obj (mk ha) = a :=
+    (fiberInclusion p S).obj (mk ha) = a :=
   rfl
 
 /-- The morphism in the fiber over `S` corresponding to a morphism in `𝒳` lifting `𝟙 S`. -/
@@ -85,7 +86,7 @@ def homMk (p : 𝒳 ⥤ 𝒮) (S : 𝒮) {a b : 𝒳} (φ : a ⟶ b) [IsHomLift 
 
 @[simp]
 lemma fiberInclusion_homMk (p : 𝒳 ⥤ 𝒮) (S : 𝒮) {a b : 𝒳} (φ : a ⟶ b) [IsHomLift p (𝟙 S) φ] :
-    fiberInclusion.map (homMk p S φ) = φ :=
+    (fiberInclusion p S).map (homMk p S φ) = φ :=
   rfl
 
 @[simp]
@@ -113,17 +114,17 @@ def inducedFunctor : C ⥤ Fiber p S where
 /-- Given a functor `F : C ⥤ 𝒳` such that `F ⋙ p` is constant at some `S : 𝒮`, then
 we get a natural isomorphism between `inducedFunctor _ ⋙ fiberInclusion` and `F`. -/
 @[simps!]
-def inducedFunctorCompIsoSelf : (inducedFunctor hF) ⋙ fiberInclusion ≅ F := .refl _
+def inducedFunctorCompIsoSelf : (inducedFunctor hF) ⋙ fiberInclusion p S ≅ F := .refl _
 
-lemma inducedFunctor_comp : (inducedFunctor hF) ⋙ fiberInclusion = F := rfl
+lemma inducedFunctor_comp : (inducedFunctor hF) ⋙ fiberInclusion p S = F := rfl
 
 @[simp]
 lemma inducedFunctor_comp_obj (X : C) :
-    fiberInclusion.obj ((inducedFunctor hF).obj X) = F.obj X := rfl
+    (fiberInclusion p S).obj ((inducedFunctor hF).obj X) = F.obj X := rfl
 
 @[simp]
 lemma inducedFunctor_comp_map {X Y : C} (f : X ⟶ Y) :
-    fiberInclusion.map ((inducedFunctor hF).map f) = F.map f := rfl
+    (fiberInclusion p S).map ((inducedFunctor hF).map f) = F.map f := rfl
 
 end
 

--- a/Mathlib/CategoryTheory/FiberedCategory/HasFibers.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/HasFibers.lean
@@ -76,7 +76,7 @@ namespace HasFibers
 /-- The `HasFibers` on `p : 𝒳 ⥤ 𝒮` given by the fibers of `p` -/
 def canonical (p : 𝒳 ⥤ 𝒮) : HasFibers p where
   Fib := Fiber p
-  ι S := fiberInclusion
+  ι S := fiberInclusion p S
   comp_const S := fiberInclusion_comp_eq_const
   equiv S := by exact isEquivalence_of_iso (F := 𝟭 (Fiber p S)) (Iso.refl _)
 
@@ -92,10 +92,10 @@ def inducedFunctor : Fib p S ⥤ Fiber p S :=
   Fiber.inducedFunctor (comp_const S)
 
 /-- The natural transformation `ι S ≅ (inducedFunctor p S) ⋙ (fiberInclusion p S)` -/
-def inducedFunctor.natIso : ι S ≅ (inducedFunctor p S) ⋙ fiberInclusion :=
+def inducedFunctor.natIso : ι S ≅ (inducedFunctor p S) ⋙ fiberInclusion p S :=
   Fiber.inducedFunctorCompIsoSelf (comp_const S)
 
-lemma inducedFunctor_comp : ι S = (inducedFunctor p S) ⋙ fiberInclusion :=
+lemma inducedFunctor_comp : ι S = (inducedFunctor p S) ⋙ fiberInclusion p S :=
   Fiber.inducedFunctor_comp (comp_const S)
 
 instance : Functor.IsEquivalence (inducedFunctor p S) := equiv S
@@ -156,7 +156,7 @@ noncomputable def Fib.mk {S : 𝒮} {a : 𝒳} (ha : p.obj a = S) : Fib p S :=
 /-- Applying `ι S` to the preimage of `a : 𝒳` in `Fib p S` yields an object isomorphic to `a`. -/
 noncomputable def Fib.mkIsoSelf {S : 𝒮} {a : 𝒳} (ha : p.obj a = S) :
     (ι S).obj (Fib.mk ha) ≅ a :=
-  fiberInclusion.mapIso (Functor.objObjPreimageIso (inducedFunctor p S) (Fiber.mk ha))
+  (fiberInclusion p S).mapIso (Functor.objObjPreimageIso (inducedFunctor p S) (Fiber.mk ha))
 
 instance Fib.mkIsoSelfIsHomLift {S : 𝒮} {a : 𝒳} (ha : p.obj a = S) :
     IsHomLift p (𝟙 S) (Fib.mkIsoSelf ha).hom :=


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
