### PR TITLE
[Merged by Bors] - feat: HasCompactSupport.sub lemma (multiplicative & additive version)

### DIFF
--- a/Mathlib/Topology/Algebra/Support.lean
+++ b/Mathlib/Topology/Algebra/Support.lean
@@ -339,7 +339,6 @@ theorem HasCompactSupport.div {α β : Type*} [TopologicalSpace α] [DivisionMon
     HasCompactMulSupport (f / f') :=
   div_eq_mul_inv f f' ▸ hf.mul hf'.inv'
 
-
 end DivisionMonoid
 
 section SMulZeroClass

--- a/Mathlib/Topology/Algebra/Support.lean
+++ b/Mathlib/Topology/Algebra/Support.lean
@@ -333,6 +333,13 @@ protected lemma HasCompactMulSupport.inv' {α β : Type*} [TopologicalSpace α] 
     HasCompactMulSupport (f⁻¹) := by
   simpa only [HasCompactMulSupport, mulTSupport, mulSupport_inv'] using hf
 
+@[to_additive]
+theorem HasCompactSupport.div {α β : Type*} [TopologicalSpace α] [DivisionMonoid β]
+    {f f' : α → β} (hf : HasCompactMulSupport f) (hf' : HasCompactMulSupport f') :
+    HasCompactMulSupport (f / f') :=
+  div_eq_mul_inv f f' ▸ hf.mul hf'.inv'
+
+
 end DivisionMonoid
 
 section SMulZeroClass


### PR DESCRIPTION
Filled missing API, easy consequence from lemma for negation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
