### PR TITLE
[Merged by Bors] - chore(List/TakeWhile): golf and move `dropWhile_eq_self_iff`

### DIFF
--- a/Mathlib/Data/List/DropRight.lean
+++ b/Mathlib/Data/List/DropRight.lean
@@ -120,26 +120,6 @@ variable {p} {l}
 @[simp]
 theorem rdropWhile_eq_nil_iff : rdropWhile p l = [] ↔ ∀ x ∈ l, p x := by simp [rdropWhile]
 
--- it is in this file because it requires `List.Infix`
-@[simp]
-theorem dropWhile_eq_self_iff : dropWhile p l = l ↔ ∀ hl : 0 < l.length, ¬p (l.get ⟨0, hl⟩) := by
-  rcases l with - | ⟨hd, tl⟩
-  · simp only [dropWhile, true_iff]
-    intro h
-    by_contra
-    rwa [length_nil, lt_self_iff_false] at h
-  · rw [dropWhile]
-    refine ⟨fun h => ?_, fun h => ?_⟩
-    · intro _ H
-      rw [get] at H
-      refine (cons_ne_self hd tl) (Sublist.antisymm ?_ (sublist_cons_self _ _))
-      rw [← h]
-      simp only [H]
-      exact List.IsSuffix.sublist (dropWhile_suffix p)
-    · have := h (by simp only [length, Nat.succ_pos])
-      rw [get] at this
-      simp_rw [this]
-
 @[simp]
 theorem rdropWhile_eq_self_iff : rdropWhile p l = l ↔ ∀ hl : l ≠ [], ¬p (l.getLast hl) := by
   simp [rdropWhile, reverse_eq_iff, getLast_eq_getElem, Nat.pos_iff_ne_zero]

--- a/Mathlib/Data/List/TakeWhile.lean
+++ b/Mathlib/Data/List/TakeWhile.lean
@@ -25,6 +25,16 @@ theorem dropWhile_get_zero_not (l : List α) (hl : 0 < (l.dropWhile p).length) :
       simp_all only [dropWhile_cons_of_pos]
     · simp [hp]
 
+theorem length_dropWhile_le (l : List α) : (dropWhile p l).length ≤ l.length := by
+  induction l with
+  | nil => simp
+  | cons head tail ih =>
+    simp only [dropWhile, length_cons]
+    by_cases h_p_head : p head
+    · simp only [h_p_head]
+      omega
+    · simp [h_p_head]
+
 variable {p} {l : List α}
 
 @[simp]
@@ -32,6 +42,21 @@ theorem dropWhile_eq_nil_iff : dropWhile p l = [] ↔ ∀ x ∈ l, p x := by
   induction l with
   | nil => simp [dropWhile]
   | cons x xs IH => by_cases hp : p x <;> simp [hp, IH]
+
+@[simp]
+theorem dropWhile_eq_self_iff : dropWhile p l = l ↔ ∀ hl : 0 < l.length, ¬p (l.get ⟨0, hl⟩) := by
+  rcases l with - | ⟨hd, tl⟩
+  · simp
+  · rw [dropWhile]
+    by_cases h_p_hd : p hd
+    · simp only [h_p_hd, length_cons, Nat.zero_lt_succ, Fin.zero_eta, get_eq_getElem, Fin.val_zero,
+      getElem_cons_zero, not_true_eq_false, imp_false, iff_false]
+      intro h
+      replace h := congrArg length h
+      have := length_dropWhile_le p tl
+      simp at h
+      omega
+    · simp [h_p_hd]
 
 @[simp]
 theorem takeWhile_eq_self_iff : takeWhile p l = l ↔ ∀ x ∈ l, p x := by

--- a/Mathlib/Data/List/TakeWhile.lean
+++ b/Mathlib/Data/List/TakeWhile.lean
@@ -30,10 +30,9 @@ theorem length_dropWhile_le (l : List α) : (dropWhile p l).length ≤ l.length 
   | nil => simp
   | cons head tail ih =>
     simp only [dropWhile, length_cons]
-    by_cases h_p_head : p head
-    · simp only [h_p_head]
-      omega
-    · simp [h_p_head]
+    split
+    · omega
+    · simp
 
 variable {p} {l : List α}
 

--- a/Mathlib/Data/List/TakeWhile.lean
+++ b/Mathlib/Data/List/TakeWhile.lean
@@ -44,13 +44,13 @@ theorem dropWhile_eq_nil_iff : dropWhile p l = [] ↔ ∀ x ∈ l, p x := by
   | cons x xs IH => by_cases hp : p x <;> simp [hp, IH]
 
 @[simp]
-theorem dropWhile_eq_self_iff : dropWhile p l = l ↔ ∀ hl : 0 < l.length, ¬p (l.get ⟨0, hl⟩) := by
+theorem dropWhile_eq_self_iff : dropWhile p l = l ↔ ∀ hl : 0 < l.length, ¬p (l[0]'hl) := by
   rcases l with - | ⟨hd, tl⟩
   · simp
   · rw [dropWhile]
     by_cases h_p_hd : p hd
-    · simp only [h_p_hd, length_cons, Nat.zero_lt_succ, Fin.zero_eta, get_eq_getElem, Fin.val_zero,
-      getElem_cons_zero, not_true_eq_false, imp_false, iff_false]
+    · simp only [h_p_hd, length_cons, Nat.zero_lt_succ, getElem_cons_zero, not_true_eq_false,
+        imp_false, iff_false]
       intro h
       replace h := congrArg length h
       have := length_dropWhile_le p tl


### PR DESCRIPTION
Adds a lemma about dropWhile length, allowing `dropWhile_eq_self_iff` to be reproved and moved to a more appropriate file.

This lemma was found while doing work for [Project Numina](https://projectnumina.ai/).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
