### PR TITLE
[Merged by Bors] - feat(MvPolynomial/Funext): generalize

### DIFF
--- a/Mathlib/Algebra/MvPolynomial/Funext.lean
+++ b/Mathlib/Algebra/MvPolynomial/Funext.lean
@@ -44,12 +44,14 @@ private theorem funext_fin {n : ℕ} {p : MvPolynomial (Fin n) R}
     rw [eval_polynomial_eval_finSuccEquiv]
     exact h _ fun i _ ↦ i.cases (by simpa using hr) (by simpa using hx)
 
-variable {σ : Type*} {p q : MvPolynomial σ R}
+section
+
+variable {σ : Type*} {p q : MvPolynomial σ R} (s : σ → Set R) (hs : ∀ i, (s i).Infinite)
+include hs
 
 /-- Two multivariate polynomials over an integral domain are equal
 if they are equal when evaluated anywhere in a box with infinite sides. -/
-theorem funext_set (s : σ → Set R) (hs : ∀ i, (s i).Infinite)
-    (h : ∀ x ∈ Set.pi .univ s, (eval x) p = (eval x) q) :
+theorem funext_set (h : ∀ x ∈ Set.pi .univ s, (eval x) p = (eval x) q) :
     p = q := by
   suffices ∀ p, (∀ x ∈ Set.pi .univ s, eval x p = 0) → p = 0 by
     rw [← sub_eq_zero, this (p - q)]
@@ -65,6 +67,11 @@ theorem funext_set (s : σ → Set R) (hs : ∀ i, (s i).Infinite)
   obtain ⟨i, rfl⟩ | nex := em (∃ x, f x = i)
   · rw [hf.extend_apply]; exact hx _ ⟨⟩
   · simp_rw [Function.extend, dif_neg nex, hg]
+
+theorem funext_set_iff : (∀ x ∈ Set.pi .univ s, (eval x) p = (eval x) q) ↔ p = q :=
+  ⟨funext_set s hs, by rintro rfl _ _; rfl⟩
+
+end
 
 variable [Infinite R]
 

--- a/Mathlib/Algebra/MvPolynomial/Funext.lean
+++ b/Mathlib/Algebra/MvPolynomial/Funext.lean
@@ -46,6 +46,8 @@ private theorem funext_fin {n : ℕ} {p : MvPolynomial (Fin n) R}
 
 variable {σ : Type*} {p q : MvPolynomial σ R}
 
+/-- Two multivariate polynomials over an integral domain are equal
+if they are equal when evaluated anywhere in a box with infinite sides. -/
 theorem funext_set (s : σ → Set R) (hs : ∀ i, (s i).Infinite)
     (h : ∀ x ∈ Set.pi .univ s, (eval x) p = (eval x) q) :
     p = q := by

--- a/Mathlib/Algebra/MvPolynomial/Funext.lean
+++ b/Mathlib/Algebra/MvPolynomial/Funext.lean
@@ -68,8 +68,8 @@ theorem funext_set (h : ∀ x ∈ Set.pi .univ s, eval x p = eval x q) :
   · rw [hf.extend_apply]; exact hx _ ⟨⟩
   · simp_rw [Function.extend, dif_neg nex, hg]
 
-theorem funext_set_iff : (∀ x ∈ Set.pi .univ s, eval x p = eval x q) ↔ p = q :=
-  ⟨funext_set s hs, by rintro rfl _ _; rfl⟩
+theorem funext_set_iff : p = q ↔ (∀ x ∈ Set.pi .univ s, eval x p = eval x q) :=
+  ⟨by rintro rfl _ _; rfl, funext_set s hs⟩
 
 end
 

--- a/Mathlib/Algebra/MvPolynomial/Funext.lean
+++ b/Mathlib/Algebra/MvPolynomial/Funext.lean
@@ -51,7 +51,7 @@ include hs
 
 /-- Two multivariate polynomials over an integral domain are equal
 if they are equal when evaluated anywhere in a box with infinite sides. -/
-theorem funext_set (h : ∀ x ∈ Set.pi .univ s, (eval x) p = (eval x) q) :
+theorem funext_set (h : ∀ x ∈ Set.pi .univ s, eval x p = eval x q) :
     p = q := by
   suffices ∀ p, (∀ x ∈ Set.pi .univ s, eval x p = 0) → p = 0 by
     rw [← sub_eq_zero, this (p - q)]
@@ -68,7 +68,7 @@ theorem funext_set (h : ∀ x ∈ Set.pi .univ s, (eval x) p = (eval x) q) :
   · rw [hf.extend_apply]; exact hx _ ⟨⟩
   · simp_rw [Function.extend, dif_neg nex, hg]
 
-theorem funext_set_iff : (∀ x ∈ Set.pi .univ s, (eval x) p = (eval x) q) ↔ p = q :=
+theorem funext_set_iff : (∀ x ∈ Set.pi .univ s, eval x p = eval x q) ↔ p = q :=
   ⟨funext_set s hs, by rintro rfl _ _; rfl⟩
 
 end

--- a/Mathlib/Algebra/MvPolynomial/Funext.lean
+++ b/Mathlib/Algebra/MvPolynomial/Funext.lean
@@ -24,40 +24,54 @@ if they are equal upon evaluating them on an arbitrary assignment of the variabl
 
 namespace MvPolynomial
 
-variable {R : Type*} [CommRing R] [IsDomain R] [Infinite R]
+variable {R : Type*} [CommRing R] [IsDomain R]
 
 private theorem funext_fin {n : ℕ} {p : MvPolynomial (Fin n) R}
-    (h : ∀ x : Fin n → R, eval x p = 0) : p = 0 := by
+    (s : Fin n → Set R) (hs : ∀ i, (s i).Infinite)
+    (h : ∀ x ∈ Set.pi .univ s, eval x p = 0) : p = 0 := by
   induction n with
   | zero =>
     apply (MvPolynomial.isEmptyRingEquiv R (Fin 0)).injective
     rw [RingEquiv.map_zero]
-    convert h finZeroElim
+    convert h _ finZeroElim
   | succ n ih =>
     apply (finSuccEquiv R n).injective
-    simp only [map_zero]
-    refine Polynomial.funext fun q => ?_
-    rw [Polynomial.eval_zero]
-    apply ih fun x => ?_
-    calc _ = _ := eval_polynomial_eval_finSuccEquiv p _
-         _ = 0 := h _
+    rw [map_zero]
+    apply Polynomial.eq_zero_of_infinite_isRoot
+    apply ((hs 0).image (C_injective ..).injOn).mono
+    rintro _ ⟨r, hr, rfl⟩
+    refine ih (s ·.succ) (fun _ ↦ hs _) fun x hx ↦ ?_
+    rw [eval_polynomial_eval_finSuccEquiv]
+    exact h _ fun i _ ↦ i.cases (by simpa using hr) (by simpa using hx)
 
-/-- Two multivariate polynomials over an infinite integral domain are equal
-if they are equal upon evaluating them on an arbitrary assignment of the variables. -/
-theorem funext {σ : Type*} {p q : MvPolynomial σ R} (h : ∀ x : σ → R, eval x p = eval x q) :
+variable {σ : Type*} {p q : MvPolynomial σ R}
+
+theorem funext_set (s : σ → Set R) (hs : ∀ i, (s i).Infinite)
+    (h : ∀ x ∈ Set.pi .univ s, (eval x) p = (eval x) q) :
     p = q := by
-  suffices ∀ p, (∀ x : σ → R, eval x p = 0) → p = 0 by
+  suffices ∀ p, (∀ x ∈ Set.pi .univ s, eval x p = 0) → p = 0 by
     rw [← sub_eq_zero, this (p - q)]
-    simp only [h, RingHom.map_sub, forall_const, sub_self]
-  clear h p q
+    intro x hx
+    simp_rw [map_sub, h x hx, sub_self]
   intro p h
   obtain ⟨n, f, hf, p, rfl⟩ := exists_fin_rename p
   suffices p = 0 by rw [this, map_zero]
-  apply funext_fin
-  intro x
-  classical
-    convert h (Function.extend f x 0)
-    simp only [eval, eval₂Hom_rename, Function.extend_comp hf]
+  refine funext_fin (s ∘ f) (fun _ ↦ hs _) fun x hx ↦ ?_
+  choose g hg using fun i ↦ (hs i).nonempty
+  convert h (Function.extend f x g) fun i _ ↦ ?_
+  · simp only [eval, eval₂Hom_rename, Function.extend_comp hf]
+  obtain ⟨i, rfl⟩ | nex := em (∃ x, f x = i)
+  · rw [hf.extend_apply]; exact hx _ ⟨⟩
+  · simp_rw [Function.extend, dif_neg nex, hg]
+
+variable [Infinite R]
+
+/-- Two multivariate polynomials over an infinite integral domain are equal
+if they are equal upon evaluating them on an arbitrary assignment of the variables. -/
+theorem funext {σ : Type*} {p q : MvPolynomial σ R}
+    (h : ∀ x : σ → R, eval x p = eval x q) :
+    p = q :=
+  funext_set _ (fun _ ↦ Set.infinite_univ) fun _ _ ↦ h _
 
 theorem funext_iff {σ : Type*} {p q : MvPolynomial σ R} :
     p = q ↔ ∀ x : σ → R, eval x p = eval x q :=


### PR DESCRIPTION
Instead of requiring the polynomials agree everywhere, it suffices to require them agree on a box with infinite sides.

Live coding at Formalizing Class Field Theory, in preparation for the normal basis theorem, where the box consists of all points with coordinates in an infinite subring.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
