### PR TITLE
feat(Tactic/Linter): add TacticMs for natural subtraction and division

### DIFF
--- a/Mathlib/Tactic/Linter/TruncatedNat.lean
+++ b/Mathlib/Tactic/Linter/TruncatedNat.lean
@@ -1,0 +1,66 @@
+import Lean
+import Batteries
+import Qq
+
+section
+
+open Lean Meta Elab.Tactic Qq
+
+def containsNaturalSubtraction : Expr → Bool
+  | .app (.app (.const ``HSub.hSub _) (.const ``Nat _)) _ => true
+  | .app f a => containsNaturalSubtraction f || containsNaturalSubtraction a
+  | .lam _ _ b _ => containsNaturalSubtraction b
+  | .forallE _ _ b _ => containsNaturalSubtraction b
+  | .letE _ _ v b _ => containsNaturalSubtraction v || containsNaturalSubtraction b
+  | _ => false
+
+def checkIfNaturalSubtraction : TacticM Bool := do
+  withMainContext do
+    logInfo "Checking if the goal or local context contains natural subtraction"
+    let goal ← getMainGoal
+    logInfo m!"Checking goal: {goal}"
+    let type ← goal.getType
+    if containsNaturalSubtraction type then
+      logInfo m!"ALERT: Goal contains natural subtraction: {type}"
+      return true
+    let ctx ← getLCtx
+    for (decl : LocalDecl) in ctx do
+      if containsNaturalSubtraction decl.type then
+        logInfo m!"ALERT: Local declaration of type {decl.type} contains natural subtraction."
+        return true
+    logInfo "No natural subtraction found in goal or local context"
+    return false
+
+def containsNaturalDivision : Expr → Bool
+  | .app (.app (.const ``HDiv.hDiv _) (.const ``Nat _)) _ => true
+  | .app f a => containsNaturalDivision f || containsNaturalDivision a
+  | .lam _ _ b _ => containsNaturalDivision b
+  | .forallE _ _ b _ => containsNaturalDivision b
+  | .letE _ _ v b _ => containsNaturalDivision v || containsNaturalDivision b
+  | _ => false
+
+def checkIfNaturalDivision : TacticM Bool := do
+  withMainContext do
+    logInfo "Checking if the goal or local context contains natural division"
+    let goal ← getMainGoal
+    logInfo m!"Checking goal: {goal}"
+    let type ← goal.getType
+    if containsNaturalDivision type then
+      logInfo m!"ALERT: Goal contains natural division: {type}"
+      return true
+    let ctx ← getLCtx
+    for (decl : LocalDecl) in ctx do
+      if containsNaturalDivision decl.type then
+        logInfo m!"ALERT: Local declaration of type {decl.type} contains natural division."
+        return true
+    logInfo "No natural division found in goal or local context"
+    return false
+
+end
+
+-- example (a b : Nat) (h : a / b = 0) : 2 = 3 := by
+--   run_tac
+--     checkIfNaturalSubtraction
+--   run_tac
+--     checkIfNaturalDivision
+--   sorry


### PR DESCRIPTION
This is a (pair of) short tactic scripts I wrote for Project Numina while vetting formal formal statements (thanks to [this guide](https://github.com/mirefek/lean-tactic-programming-guide) for the primer). The scripts check for the presence of natural subtraction and natural division, which can often lead to mistakes.

Of course, Mathlib allows natural subtraction freely, so it's not obvious this could be made useful to Mathlib itself. Still, maybe it's of use to some other project, so I'll leave it here.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
