### PR TITLE
[Merged by Bors] - feat: in a Baire space, every nonempty open set is of second category

### DIFF
--- a/Mathlib/Topology/Baire/Lemmas.lean
+++ b/Mathlib/Topology/Baire/Lemmas.lean
@@ -88,10 +88,11 @@ theorem dense_of_mem_residual {s : Set X} (hs : s ∈ residual X) : Dense s :=
 In a Baire space, every nonempty open set is non‐meagre,
 that is, it cannot be written as a countable union of nowhere‐dense sets.
 -/
-theorem nonempty_open_nonmeagre {s : Set X} (hs : IsOpen s) (hne : s.Nonempty) :
-    ¬ IsMeagre s := fun h ↦ by
-  rcases (dense_of_mem_residual (by rwa [IsMeagre] at h)).inter_open_nonempty s hs hne
-    with ⟨x, hx, hxc⟩
+theorem not_isMeagre_of_isOpen {s : Set X} (hs : IsOpen s) (hne : s.Nonempty) :
+    ¬ IsMeagre s := by
+  intro h
+  obtain ⟨x, hx, hxc⟩ :=
+    (dense_of_mem_residual (by rwa [IsMeagre] at h)).inter_open_nonempty s hs hne
   exact hxc hx
 
 /-- Baire theorem: a countable intersection of dense Gδ sets is dense. Formulated here with ⋂₀. -/

--- a/Mathlib/Topology/Baire/Lemmas.lean
+++ b/Mathlib/Topology/Baire/Lemmas.lean
@@ -89,11 +89,9 @@ In a Baire space, every nonempty open set is non‐meagre,
 that is, it cannot be written as a countable union of nowhere‐dense sets.
 -/
 theorem nonempty_open_nonmeagre {s : Set X} (hs : IsOpen s) (hne : s.Nonempty) :
-    ¬ IsMeagre s := by
-  intro h
-  rw [IsMeagre] at h
-  have : Dense sᶜ := dense_of_mem_residual h
-  obtain ⟨x, hx, hxc⟩ := this.inter_open_nonempty s hs hne
+    ¬ IsMeagre s := fun h ↦ by
+  rcases (dense_of_mem_residual (by rwa [IsMeagre] at h)).inter_open_nonempty s hs hne
+    with ⟨x, hx, hxc⟩
   exact hxc hx
 
 /-- Baire theorem: a countable intersection of dense Gδ sets is dense. Formulated here with ⋂₀. -/

--- a/Mathlib/Topology/Baire/Lemmas.lean
+++ b/Mathlib/Topology/Baire/Lemmas.lean
@@ -88,8 +88,7 @@ theorem dense_of_mem_residual {s : Set X} (hs : s ∈ residual X) : Dense s :=
 In a Baire space, every nonempty open set is non‐meagre,
 that is, it cannot be written as a countable union of nowhere‐dense sets.
 -/
-theorem not_isMeagre_of_isOpen {s : Set X} (hs : IsOpen s) (hne : s.Nonempty) :
-    ¬ IsMeagre s := by
+theorem not_isMeagre_of_isOpen {s : Set X} (hs : IsOpen s) (hne : s.Nonempty) : ¬ IsMeagre s := by
   intro h
   obtain ⟨x, hx, hxc⟩ :=
     (dense_of_mem_residual (by rwa [IsMeagre] at h)).inter_open_nonempty s hs hne

--- a/Mathlib/Topology/Baire/Lemmas.lean
+++ b/Mathlib/Topology/Baire/Lemmas.lean
@@ -84,6 +84,18 @@ theorem dense_of_mem_residual {s : Set X} (hs : s ∈ residual X) : Dense s :=
   let ⟨_, hts, _, hd⟩ := mem_residual.1 hs
   hd.mono hts
 
+/--
+In a Baire space, every nonempty open set is non‐meagre,
+that is, it cannot be written as a countable union of nowhere‐dense sets.
+-/
+theorem nonempty_open_nonmeagre {s : Set X} (hs : IsOpen s) (hne : s.Nonempty) :
+    ¬ IsMeagre s := by
+  intro h
+  rw [IsMeagre] at h
+  have : Dense sᶜ := dense_of_mem_residual h
+  obtain ⟨x, hx, hxc⟩ := this.inter_open_nonempty s hs hne
+  exact hxc hx
+
 /-- Baire theorem: a countable intersection of dense Gδ sets is dense. Formulated here with ⋂₀. -/
 theorem dense_sInter_of_Gδ {S : Set (Set X)} (ho : ∀ s ∈ S, IsGδ s) (hS : S.Countable)
     (hd : ∀ s ∈ S, Dense s) : Dense (⋂₀ S) :=


### PR DESCRIPTION
In a Baire space, every nonempty open set is non‑meagre (of second category).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
