### PR TITLE
[Merged by Bors] - feat(MeasureTheory/SimpleFunc): add instances of algebraic structures

### DIFF
--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -553,6 +553,12 @@ instance instModule [Semiring K] [AddCommMonoid β] [Module K β] : Module K (α
 theorem smul_eq_map [SMul K β] (k : K) (f : α →ₛ β) : k • f = f.map (k • ·) :=
   rfl
 
+lemma smul_const [SMul K β] (k : K) (b : β) :
+    (k • const α b : α →ₛ β) = const α (k • b) := ext fun _ ↦ rfl
+
+@[simp]
+lemma one_eq_const_one [One β] : (1 : α →ₛ β) = const α 1 := rfl
+
 instance [NonUnitalNonAssocSemiring β] : NonUnitalNonAssocSemiring (α →ₛ β) where
   left_distrib _ _ _ := ext fun _ ↦ left_distrib ..
   right_distrib _ _ _ := ext fun _ ↦ right_distrib ..
@@ -599,6 +605,10 @@ instance [CommSemiring K] [Semiring β] [Algebra K β] : Algebra K (α →ₛ β
 @[simp]
 lemma algebraMap_apply [CommSemiring K] [Semiring β] [Algebra K β] (k : K) :
     algebraMap K (α →ₛ β) k = const α (algebraMap K β k) := rfl
+
+@[simp]
+lemma algebraMap_apply_apply [CommSemiring K] [Semiring β] [Algebra K β] (k : K) (x : α) :
+    algebraMap K (α →ₛ β) k x = algebraMap K β k := rfl
 
 lemma algebraMap_eq_smul_one [CommSemiring K] [Semiring β] [Algebra K β] (k : K) :
     algebraMap K (α →ₛ β) k = k • 1 := Algebra.algebraMap_eq_smul_one k

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -596,6 +596,10 @@ instance [CommSemiring K] [Semiring β] [Algebra K β] : Algebra K (α →ₛ β
   commutes' _ _ := ext fun _ ↦ Algebra.commutes ..
   smul_def' _ _ := ext fun _ ↦ Algebra.smul_def ..
 
+@[simp]
+lemma algebraMap_apply [CommSemiring K] [Semiring β] [Algebra K β] (k : K) :
+    algebraMap K (α →ₛ β) k = const α (algebraMap K β k) := rfl
+
 lemma algebraMap_eq_smul_one [CommSemiring K] [Semiring β] [Algebra K β] (k : K) :
     algebraMap K (α →ₛ β) k = k • 1 := Algebra.algebraMap_eq_smul_one k
 section Star

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -553,6 +553,50 @@ instance instModule [Semiring K] [AddCommMonoid β] [Module K β] : Module K (α
 theorem smul_eq_map [SMul K β] (k : K) (f : α →ₛ β) : k • f = f.map (k • ·) :=
   rfl
 
+instance [NonUnitalNonAssocSemiring β] : NonUnitalNonAssocSemiring (α →ₛ β) where
+  left_distrib _ _ _ := ext fun _ ↦ left_distrib ..
+  right_distrib _ _ _ := ext fun _ ↦ right_distrib ..
+  zero_mul _ := ext fun _ ↦ zero_mul ..
+  mul_zero _ := ext fun _ ↦ mul_zero ..
+
+instance [Semiring β] : Semiring (α →ₛ β) where
+
+noncomputable def simpleFuncAlgebraMap [CommSemiring K] [Semiring β] [Algebra K β] : K →+* α →ₛ β :=
+  { toFun k := const _ <| algebraMap _ β k
+    map_one' := ext fun _ ↦ algebraMap K β |>.map_one ▸ rfl
+    map_mul' _ _ := ext fun _ ↦ algebraMap K β |>.map_mul ..
+    map_zero' := ext fun _ ↦ algebraMap K β |>.map_zero ▸ rfl
+    map_add' _ _ := ext fun _ ↦ algebraMap K β |>.map_add ..}
+
+lemma algebraMap_const_mul_comm [CommSemiring K] [Semiring β] [Algebra K β] :
+     ∀ (c : K), ∀ (f : α →ₛ β), simpleFuncAlgebraMap c * f = f * simpleFuncAlgebraMap c :=
+  fun _ _ => ext fun _ => Algebra.commutes ..
+
+noncomputable instance [CommSemiring K] [Semiring β] [Algebra K β] : Algebra K (α →ₛ β) :=
+  simpleFuncAlgebraMap.toAlgebra' algebraMap_const_mul_comm
+
+section Star
+
+instance [Star β] : Star (α →ₛ β) where
+  star f := f.map Star.star
+
+@[simp]
+lemma star_apply [Star β] {f : α →ₛ β} {x : α} : star f x = star (f x) := rfl
+
+instance [InvolutiveStar β] : InvolutiveStar (α →ₛ β) where
+  star_involutive _ := ext fun _ ↦ star_star _
+
+instance [AddMonoid β] [StarAddMonoid β] : StarAddMonoid (α →ₛ β) where
+  star_add _ _ := ext fun _ ↦ star_add ..
+
+instance [Mul β] [StarMul β] : StarMul (α →ₛ β) where
+  star_mul _ _ := ext fun _ ↦ star_mul ..
+
+instance [NonUnitalNonAssocSemiring β] [StarRing β] : StarRing (α →ₛ β) where
+  star_add _ _ := ext fun _ ↦ star_add ..
+
+end Star
+
 section Preorder
 variable [Preorder β] {s : Set α} {f f₁ f₂ g g₁ g₂ : α →ₛ β} {hs : MeasurableSet s}
 
@@ -1024,35 +1068,6 @@ theorem lintegral_map' {β} [MeasurableSpace β] {μ' : Measure β} (f : α →�
 theorem lintegral_map {β} [MeasurableSpace β] (g : β →ₛ ℝ≥0∞) {f : α → β} (hf : Measurable f) :
     g.lintegral (Measure.map f μ) = (g.comp f hf).lintegral μ :=
   Eq.symm <| lintegral_map' _ _ f (fun _ => rfl) fun _s hs => Measure.map_apply hf hs
-
-section Star
-
-variable {R : Type*}
-
-instance [Star R] : Star (α →ₛ R) where
-  star f := f.map Star.star
-
-lemma star_apply [Star R] (f : α →ₛ R) (x : α) : (star f) x = star (f x) := rfl
-
-instance [InvolutiveStar R] : InvolutiveStar (α →ₛ R) where
-  star_involutive := fun _ => by ext; simp [star_apply]
-
-instance [AddMonoid R] [StarAddMonoid R] : StarAddMonoid (α →ₛ R) where
-  star_add := fun _ _ => by ext; simp [star_apply]
-
-instance [Mul R] [StarMul R] : StarMul (α →ₛ R) where
-  star_mul := fun _ _ => by ext; simp [star_apply]
-
-instance [NonUnitalNonAssocSemiring R] : NonUnitalNonAssocSemiring (α →ₛ R) where
-  left_distrib := fun _ _ _ => by ext; simp [left_distrib]
-  right_distrib := fun _ _ _ => by ext; simp [right_distrib]
-  zero_mul := fun _ => by ext; simp
-  mul_zero := fun _ => by ext; simp
-
-instance [NonUnitalNonAssocSemiring R] [StarRing R] : StarRing (α →ₛ R) where
-  star_add := fun _ _ => by ext; simp
-
-end Star
 
 end Measure
 

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -567,12 +567,12 @@ instance [Monoid K] [Semiring β] [MulAction K β] : MulAction K (α →ₛ β) 
 
 noncomputable instance [CommSemiring K] [Semiring β] [Algebra K β] : Algebra K (α →ₛ β) :=
   RingHom.toAlgebra'
-    { toFun _ := const α (algebraMap K β _)
-      map_one' := SimpleFunc.ext fun _ => (algebraMap K β).map_one ▸ rfl
-      map_mul' _ _:= ext fun _ => (algebraMap K β).map_mul _ _
-      map_zero' := SimpleFunc.ext fun _ => (algebraMap K β).map_zero ▸ rfl
-      map_add' _ _ := ext fun _ => (algebraMap K β).map_add _ _ }
-    fun c f => ext fun _ => Algebra.commutes c (f _)
+    { toFun _ := const α <| algebraMap K β _
+      map_one' := SimpleFunc.ext fun _ => algebraMap K β |>.map_one ▸ rfl
+      map_mul' _ _:= ext fun _ => algebraMap K β |>.map_mul _ _
+      map_zero' := SimpleFunc.ext fun _ => algebraMap K β |>.map_zero ▸ rfl
+      map_add' _ _ := ext fun _ => algebraMap K β |>.map_add _ _ }
+    fun c f => ext fun _ => Algebra.commutes c <| f _
 
 section Star
 

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -579,6 +579,21 @@ instance [NonAssocSemiring β] : NonAssocSemiring (α →ₛ β) :=
   fast_instance% Function.Injective.nonAssocSemiring (fun f : α →ₛ β ↦ ⇑f) SimpleFunc.coe_injective
       rfl rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ ↦ rfl)
 
+instance [NonAssocRing β] : NonAssocRing (α →ₛ β) where
+
+instance [NonUnitalCommSemiring β] : NonUnitalCommSemiring (α →ₛ β) :=
+  fast_instance% Function.Injective.nonUnitalCommSemiring (fun f : α →ₛ β ↦ ⇑f)
+    SimpleFunc.coe_injective rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+
+instance [CommSemiring β] : CommSemiring (α →ₛ β) where
+
+instance [NonUnitalCommRing β] : NonUnitalCommRing (α →ₛ β) :=
+  fast_instance% Function.Injective.nonUnitalCommRing (fun f : α →ₛ β ↦ ⇑f)
+    SimpleFunc.coe_injective rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ _ ↦ rfl)
+      (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+
+instance [CommRing β] : CommRing (α →ₛ β) where
+
 instance [Semiring β] : Semiring (α →ₛ β) where
 
 instance [NonUnitalRing β] : NonUnitalRing (α →ₛ β) where

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -1027,23 +1027,32 @@ theorem lintegral_map {β} [MeasurableSpace β] (g : β →ₛ ℝ≥0∞) {f : 
 
 section Star
 
-variable {R : Type*} [Star R]
+variable {R : Type*}
 
-instance : Star (α →ₛ R) where
+instance [Star R] : Star (α →ₛ R) where
   star f := f.map Star.star
 
-lemma star_apply (f : α →ₛ R) (x : α) : (star f) x = star (f x) := rfl
+lemma star_apply [Star R] (f : α →ₛ R) (x : α) : (star f) x = star (f x) := rfl
 
-end Star
-
-section InvolutiveStar
-
-variable {R : Type*} [TopologicalSpace R] [InvolutiveStar R] [ContinuousStar R]
-
-instance : InvolutiveStar (α →ₛ R) where
+instance [InvolutiveStar R] : InvolutiveStar (α →ₛ R) where
   star_involutive := fun _ => by ext; simp [star_apply]
 
-end InvolutiveStar
+instance [AddMonoid R] [StarAddMonoid R] : StarAddMonoid (α →ₛ R) where
+  star_add := fun _ _ => by ext; simp [star_apply]
+
+instance [Mul R] [StarMul R] : StarMul (α →ₛ R) where
+  star_mul := fun _ _ => by ext; simp [star_apply]
+
+instance [NonUnitalNonAssocSemiring R] : NonUnitalNonAssocSemiring (α →ₛ R) where
+  left_distrib := fun _ _ _ => by ext; simp [left_distrib]
+  right_distrib := fun _ _ _ => by ext; simp [right_distrib]
+  zero_mul := fun _ => by ext; simp
+  mul_zero := fun _ => by ext; simp
+
+instance [NonUnitalNonAssocSemiring R] [StarRing R] : StarRing (α →ₛ R) where
+  star_add := fun _ _ => by ext; simp
+
+end Star
 
 end Measure
 

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -565,17 +565,28 @@ instance [Monoid K] [MulAction K β] : MulAction K (α →ₛ β) where
   one_smul _ := ext fun _ ↦ one_smul ..
   mul_smul _ _ _ := ext fun _ ↦ mul_smul ..
 
-instance [CommSemiring K] [Semiring β] [Algebra K β] : IsScalarTower K (α →ₛ β) (α →ₛ β) where
-  smul_assoc _ _ _ := ext fun _ ↦ Algebra.smul_mul_assoc ..
+/-- Induced pointwise SMul. -/
+instance [SMul β β] : SMul (α →ₛ β) (α →ₛ β) :=
+  ⟨fun f g => (f.map (· • ·)).seq g⟩
 
-instance [CommSemiring K] [Semiring β] [Algebra K β] : SMulCommClass K (α →ₛ β) (α →ₛ β) where
-  smul_comm _ _ _ := ext fun _ => Algebra.mul_smul_comm .. |>.symm
+instance [SMul K β] [SMul β β] [IsScalarTower K β β] : IsScalarTower K (α →ₛ β) (α →ₛ β) where
+  smul_assoc _ _ _ := ext fun _ ↦ smul_assoc ..
 
-instance [CommSemiring K] [Semiring β] [Algebra K β] : Algebra K (α →ₛ β) :=
-   Algebra.ofModule' smul_one_mul mul_smul_one
+instance [SMul K β] [SMul β β] [SMulCommClass K β β] : SMulCommClass K (α →ₛ β) (α →ₛ β) where
+  smul_comm _ _ _ := ext fun _ ↦  smul_comm ..
 
-lemma algebraMap_apply [CommSemiring K] [Semiring β] [Algebra K β] (k : K) :
-    algebraMap K (α →ₛ β) k = k • 1 := rfl
+instance [CommSemiring K] [Semiring β] [Algebra K β] : Algebra K (α →ₛ β) where
+  algebraMap :={
+    toFun r := const α <| algebraMap K β r
+    map_one' := ext fun _ ↦ algebraMap K β |>.map_one ▸ rfl
+    map_mul' _ _ := ext fun _ ↦ algebraMap K β |>.map_mul ..
+    map_zero' := ext fun _ ↦ algebraMap K β |>.map_zero ▸ rfl
+    map_add' _ _ := ext fun _ ↦ algebraMap K β |>.map_add ..}
+  commutes' _ _ := ext fun _ ↦ Algebra.commutes ..
+  smul_def' _ _ := ext fun _ ↦ Algebra.smul_def ..
+
+lemma algebraMap_eq_smul_one [CommSemiring K] [Semiring β] [Algebra K β] (k : K) :
+    algebraMap K (α →ₛ β) k = k • 1 := Algebra.algebraMap_eq_smul_one k
 section Star
 
 instance [Star β] : Star (α →ₛ β) where

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -566,20 +566,16 @@ instance [Monoid K] [MulAction K β] : MulAction K (α →ₛ β) where
   mul_smul _ _ _ := ext fun _ ↦ mul_smul ..
 
 instance [CommSemiring K] [Semiring β] [Algebra K β] : IsScalarTower K (α →ₛ β) (α →ₛ β) where
-  smul_assoc x f g := by
-    ext x
-    simp only [smul_eq_mul, coe_mul, coe_smul, Pi.mul_apply, Pi.smul_apply, Algebra.smul_mul_assoc,
-      smul_apply]
+  smul_assoc _ _ _ := ext fun _ ↦ Algebra.smul_mul_assoc ..
 
 instance [CommSemiring K] [Semiring β] [Algebra K β] : SMulCommClass K (α →ₛ β) (α →ₛ β) where
-  smul_comm _ _ _ := by
-    ext x
-    simp only [smul_eq_mul, smul_apply, coe_mul, Pi.mul_apply, coe_smul, Pi.smul_apply,
-      Algebra.mul_smul_comm]
+  smul_comm _ _ _ := ext fun _ ↦ by simp
 
 instance [CommSemiring K] [Semiring β] [Algebra K β] : Algebra K (α →ₛ β) :=
-  Algebra.ofModule' (fun r x ↦ smul_one_mul r x) (fun r x ↦ mul_smul_one r x)
+   Algebra.ofModule' smul_one_mul mul_smul_one
 
+lemma algebraMap_apply [CommSemiring K] [Semiring β] [Algebra K β] (k : K) :
+    algebraMap K (α →ₛ β) k = k • (1 : α →ₛ β) := rfl
 section Star
 
 instance [Star β] : Star (α →ₛ β) where

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -511,47 +511,49 @@ theorem zpow_apply [DivInvMonoid β] (z : ℤ) (f : α →ₛ β) (a : α) : (f 
 section Additive
 
 instance instAddMonoid [AddMonoid β] : AddMonoid (α →ₛ β) :=
-  Function.Injective.addMonoid (fun f => show α → β from f) coe_injective coe_zero coe_add
-    fun _ _ => coe_smul _ _
+  fast_instance% Function.Injective.addMonoid (fun f => show α → β from f) coe_injective coe_zero
+    coe_add fun _ _ => coe_smul _ _
 
 instance instAddCommMonoid [AddCommMonoid β] : AddCommMonoid (α →ₛ β) :=
-  Function.Injective.addCommMonoid (fun f => show α → β from f) coe_injective coe_zero coe_add
-    fun _ _ => coe_smul _ _
+  fast_instance% Function.Injective.addCommMonoid (fun f => show α → β from f)
+    coe_injective coe_zero coe_add fun _ _ => coe_smul _ _
 
 instance instAddGroup [AddGroup β] : AddGroup (α →ₛ β) :=
   Function.Injective.addGroup (fun f => show α → β from f) coe_injective coe_zero coe_add coe_neg
     coe_sub (fun _ _ => coe_smul _ _) fun _ _ => coe_smul _ _
 
 instance instAddCommGroup [AddCommGroup β] : AddCommGroup (α →ₛ β) :=
-  Function.Injective.addCommGroup (fun f => show α → β from f) coe_injective coe_zero coe_add
-    coe_neg coe_sub (fun _ _ => coe_smul _ _) fun _ _ => coe_smul _ _
+  fast_instance% Function.Injective.addCommGroup (fun f => show α → β from f) coe_injective
+    coe_zero coe_add coe_neg coe_sub (fun _ _ => coe_smul _ _) fun _ _ => coe_smul _ _
 
 end Additive
 
 @[to_additive existing]
 instance instMonoid [Monoid β] : Monoid (α →ₛ β) :=
-  Function.Injective.monoid (fun f => show α → β from f) coe_injective coe_one coe_mul coe_pow
+  fast_instance% Function.Injective.monoid (fun f => show α → β from f) coe_injective coe_one
+    coe_mul coe_pow
 
 @[to_additive existing]
 instance instCommMonoid [CommMonoid β] : CommMonoid (α →ₛ β) :=
-  Function.Injective.commMonoid (fun f => show α → β from f) coe_injective coe_one coe_mul coe_pow
+  fast_instance% Function.Injective.commMonoid (fun f => show α → β from f) coe_injective coe_one
+    coe_mul coe_pow
 
 @[to_additive existing]
 instance instGroup [Group β] : Group (α →ₛ β) :=
-  Function.Injective.group (fun f => show α → β from f) coe_injective coe_one coe_mul coe_inv
-    coe_div coe_pow coe_zpow
+  fast_instance% Function.Injective.group (fun f => show α → β from f) coe_injective coe_one
+    coe_mul coe_inv coe_div coe_pow coe_zpow
 
 @[to_additive existing]
 instance instCommGroup [CommGroup β] : CommGroup (α →ₛ β) :=
-  Function.Injective.commGroup (fun f => show α → β from f) coe_injective coe_one coe_mul coe_inv
-    coe_div coe_pow coe_zpow
+  fast_instance% Function.Injective.commGroup (fun f => show α → β from f) coe_injective coe_one
+    coe_mul coe_inv coe_div coe_pow coe_zpow
 
 instance [Monoid K] [MulAction K β] : MulAction K (α →ₛ β) where
   one_smul _ := ext fun _ ↦ one_smul ..
   mul_smul _ _ _ := ext fun _ ↦ mul_smul ..
 
 instance instModule [Semiring K] [AddCommMonoid β] [Module K β] : Module K (α →ₛ β) :=
-  Function.Injective.module K ⟨⟨fun f => show α → β from f, coe_zero⟩, coe_add⟩
+  fast_instance% Function.Injective.module K ⟨⟨fun f => show α → β from f, coe_zero⟩, coe_add⟩
     coe_injective coe_smul
 
 theorem smul_eq_map [SMul K β] (k : K) (f : α →ₛ β) : k • f = f.map (k • ·) :=
@@ -563,18 +565,18 @@ lemma smul_const [SMul K β] (k : K) (b : β) :
 lemma one_eq_const_one [One β] : (1 : α →ₛ β) = const α 1 := rfl
 
 instance [NonUnitalNonAssocSemiring β] : NonUnitalNonAssocSemiring (α →ₛ β) :=
-  Function.Injective.nonUnitalNonAssocSemiring (fun f : α →ₛ β ↦ ⇑f) SimpleFunc.coe_injective
-      rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+  fast_instance% Function.Injective.nonUnitalNonAssocSemiring (fun f : α →ₛ β ↦ ⇑f)
+    SimpleFunc.coe_injective rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
 
 instance [NonUnitalSemiring β] : NonUnitalSemiring (α →ₛ β) :=
-  Function.Injective.nonUnitalSemiring (fun f : α →ₛ β ↦ ⇑f) SimpleFunc.coe_injective
+  fast_instance% Function.Injective.nonUnitalSemiring (fun f : α →ₛ β ↦ ⇑f) SimpleFunc.coe_injective
       rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
 
 instance [NatCast β] : NatCast (α →ₛ β) where
   natCast n := const _ (NatCast.natCast n)
 
 instance [NonAssocSemiring β] : NonAssocSemiring (α →ₛ β) :=
-  Function.Injective.nonAssocSemiring (fun f : α →ₛ β ↦ ⇑f) SimpleFunc.coe_injective
+  fast_instance% Function.Injective.nonAssocSemiring (fun f : α →ₛ β ↦ ⇑f) SimpleFunc.coe_injective
       rfl rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ ↦ rfl)
 
 instance [Semiring β] : Semiring (α →ₛ β) where

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -556,7 +556,6 @@ theorem smul_eq_map [SMul K β] (k : K) (f : α →ₛ β) : k • f = f.map (k 
 lemma smul_const [SMul K β] (k : K) (b : β) :
     (k • const α b : α →ₛ β) = const α (k • b) := ext fun _ ↦ rfl
 
-@[simp]
 lemma one_eq_const_one [One β] : (1 : α →ₛ β) = const α 1 := rfl
 
 instance [NonUnitalNonAssocSemiring β] : NonUnitalNonAssocSemiring (α →ₛ β) where
@@ -582,14 +581,10 @@ instance [Monoid K] [MulAction K β] : MulAction K (α →ₛ β) where
   one_smul _ := ext fun _ ↦ one_smul ..
   mul_smul _ _ _ := ext fun _ ↦ mul_smul ..
 
-/-- Induced pointwise SMul. -/
-instance [SMul β β] : SMul (α →ₛ β) (α →ₛ β) :=
-  ⟨fun f g => (f.map (· • ·)).seq g⟩
-
-instance [SMul K β] [SMul β β] [IsScalarTower K β β] : IsScalarTower K (α →ₛ β) (α →ₛ β) where
+instance [SMul K γ] [SMul γ β] [SMul K β] [IsScalarTower K γ β] : IsScalarTower K γ (α →ₛ β) where
   smul_assoc _ _ _ := ext fun _ ↦ smul_assoc ..
 
-instance [SMul K β] [SMul β β] [SMulCommClass K β β] : SMulCommClass K (α →ₛ β) (α →ₛ β) where
+instance [SMul K γ] [SMul γ β] [SMul K β] [SMulCommClass K γ β] : SMulCommClass K γ (α →ₛ β) where
   smul_comm _ _ _ := ext fun _ ↦  smul_comm ..
 
 instance [CommSemiring K] [Semiring β] [Algebra K β] : Algebra K (α →ₛ β) where
@@ -602,16 +597,12 @@ instance [CommSemiring K] [Semiring β] [Algebra K β] : Algebra K (α →ₛ β
   commutes' _ _ := ext fun _ ↦ Algebra.commutes ..
   smul_def' _ _ := ext fun _ ↦ Algebra.smul_def ..
 
-@[simp]
 lemma algebraMap_apply [CommSemiring K] [Semiring β] [Algebra K β] (k : K) :
     algebraMap K (α →ₛ β) k = const α (algebraMap K β k) := rfl
 
 @[simp]
 lemma algebraMap_apply_apply [CommSemiring K] [Semiring β] [Algebra K β] (k : K) (x : α) :
     algebraMap K (α →ₛ β) k x = algebraMap K β k := rfl
-
-lemma algebraMap_eq_smul_one [CommSemiring K] [Semiring β] [Algebra K β] (k : K) :
-    algebraMap K (α →ₛ β) k = k • 1 := Algebra.algebraMap_eq_smul_one k
 section Star
 
 instance [Star β] : Star (α →ₛ β) where

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -584,7 +584,7 @@ instance [Monoid K] [MulAction K β] : MulAction K (α →ₛ β) where
 instance [SMul K γ] [SMul γ β] [SMul K β] [IsScalarTower K γ β] : IsScalarTower K γ (α →ₛ β) where
   smul_assoc _ _ _ := ext fun _ ↦ smul_assoc ..
 
-instance [SMul K γ] [SMul γ β] [SMul K β] [SMulCommClass K γ β] : SMulCommClass K γ (α →ₛ β) where
+instance [SMul γ β] [SMul K β] [SMulCommClass K γ β] : SMulCommClass K γ (α →ₛ β) where
   smul_comm _ _ _ := ext fun _ ↦  smul_comm ..
 
 instance [CommSemiring K] [Semiring β] [Algebra K β] : Algebra K (α →ₛ β) where

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -561,6 +561,7 @@ instance [NonUnitalNonAssocSemiring β] : NonUnitalNonAssocSemiring (α →ₛ �
 
 instance [Semiring β] : Semiring (α →ₛ β) where
 
+/-- Convenience constructor providing `toFun` for `Algebra K (α →ₛ β)` instance. -/
 noncomputable def simpleFuncAlgebraMap [CommSemiring K] [Semiring β] [Algebra K β] : K →+* α →ₛ β :=
   { toFun k := const _ <| algebraMap _ β k
     map_one' := ext fun _ ↦ algebraMap K β |>.map_one ▸ rfl
@@ -568,6 +569,7 @@ noncomputable def simpleFuncAlgebraMap [CommSemiring K] [Semiring β] [Algebra K
     map_zero' := ext fun _ ↦ algebraMap K β |>.map_zero ▸ rfl
     map_add' _ _ := ext fun _ ↦ algebraMap K β |>.map_add ..}
 
+/-- Convenience constructor providing `commutes` for `Algebra K (α →ₛ β)` instance. -/
 lemma algebraMap_const_mul_comm [CommSemiring K] [Semiring β] [Algebra K β] :
      ∀ (c : K), ∀ (f : α →ₛ β), simpleFuncAlgebraMap c * f = f * simpleFuncAlgebraMap c :=
   fun _ _ => ext fun _ => Algebra.commutes ..

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -569,13 +569,13 @@ instance [CommSemiring K] [Semiring β] [Algebra K β] : IsScalarTower K (α →
   smul_assoc _ _ _ := ext fun _ ↦ Algebra.smul_mul_assoc ..
 
 instance [CommSemiring K] [Semiring β] [Algebra K β] : SMulCommClass K (α →ₛ β) (α →ₛ β) where
-  smul_comm _ _ _ := ext fun _ ↦ by simp
+  smul_comm _ _ _ := ext fun _ => (Algebra.mul_smul_comm ..).symm
 
 instance [CommSemiring K] [Semiring β] [Algebra K β] : Algebra K (α →ₛ β) :=
    Algebra.ofModule' smul_one_mul mul_smul_one
 
 lemma algebraMap_apply [CommSemiring K] [Semiring β] [Algebra K β] (k : K) :
-    algebraMap K (α →ₛ β) k = k • (1 : α →ₛ β) := rfl
+    algebraMap K (α →ₛ β) k = k • 1 := rfl
 section Star
 
 instance [Star β] : Star (α →ₛ β) where

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -569,7 +569,7 @@ instance [CommSemiring K] [Semiring β] [Algebra K β] : IsScalarTower K (α →
   smul_assoc _ _ _ := ext fun _ ↦ Algebra.smul_mul_assoc ..
 
 instance [CommSemiring K] [Semiring β] [Algebra K β] : SMulCommClass K (α →ₛ β) (α →ₛ β) where
-  smul_comm _ _ _ := ext fun _ => (Algebra.mul_smul_comm ..).symm
+  smul_comm _ _ _ := ext fun _ => Algebra.mul_smul_comm .. |>.symm
 
 instance [CommSemiring K] [Semiring β] [Algebra K β] : Algebra K (α →ₛ β) :=
    Algebra.ofModule' smul_one_mul mul_smul_one

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -565,14 +565,20 @@ instance [Monoid K] [MulAction K β] : MulAction K (α →ₛ β) where
   one_smul _ := ext fun _ ↦ one_smul ..
   mul_smul _ _ _ := ext fun _ ↦ mul_smul ..
 
+instance [CommSemiring K] [Semiring β] [Algebra K β] : IsScalarTower K (α →ₛ β) (α →ₛ β) where
+  smul_assoc x f g := by
+    ext x
+    simp only [smul_eq_mul, coe_mul, coe_smul, Pi.mul_apply, Pi.smul_apply, Algebra.smul_mul_assoc,
+      smul_apply]
+
+instance [CommSemiring K] [Semiring β] [Algebra K β] : SMulCommClass K (α →ₛ β) (α →ₛ β) where
+  smul_comm _ _ _ := by
+    ext x
+    simp only [smul_eq_mul, smul_apply, coe_mul, Pi.mul_apply, coe_smul, Pi.smul_apply,
+      Algebra.mul_smul_comm]
+
 instance [CommSemiring K] [Semiring β] [Algebra K β] : Algebra K (α →ₛ β) :=
-  RingHom.toAlgebra'
-    { toFun _ := const α <| algebraMap K β _
-      map_one' := SimpleFunc.ext fun _ => algebraMap K β |>.map_one ▸ rfl
-      map_mul' _ _:= ext fun _ => algebraMap K β |>.map_mul _ _
-      map_zero' := SimpleFunc.ext fun _ => algebraMap K β |>.map_zero ▸ rfl
-      map_add' _ _ := ext fun _ => algebraMap K β |>.map_add _ _ }
-    fun c f => ext fun _ => Algebra.commutes c <| f _
+  Algebra.ofModule' (fun r x ↦ smul_one_mul r x) (fun r x ↦ mul_smul_one r x)
 
 section Star
 

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -548,9 +548,8 @@ instance instCommGroup [CommGroup β] : CommGroup (α →ₛ β) :=
   fast_instance% Function.Injective.commGroup (fun f => show α → β from f) coe_injective coe_one
     coe_mul coe_inv coe_div coe_pow coe_zpow
 
-instance [Monoid K] [MulAction K β] : MulAction K (α →ₛ β) where
-  one_smul _ := ext fun _ ↦ one_smul ..
-  mul_smul _ _ _ := ext fun _ ↦ mul_smul ..
+instance [Monoid K] [MulAction K β] : MulAction K (α →ₛ β) :=
+  fast_instance% Function.Injective.mulAction (fun f => show α → β from f) coe_injective coe_smul
 
 instance instModule [Semiring K] [AddCommMonoid β] [Module K β] : Module K (α →ₛ β) :=
   fast_instance% Function.Injective.module K ⟨⟨fun f => show α → β from f, coe_zero⟩, coe_add⟩
@@ -565,12 +564,12 @@ lemma smul_const [SMul K β] (k : K) (b : β) :
 lemma one_eq_const_one [One β] : (1 : α →ₛ β) = const α 1 := rfl
 
 instance [NonUnitalNonAssocSemiring β] : NonUnitalNonAssocSemiring (α →ₛ β) :=
-  fast_instance% Function.Injective.nonUnitalNonAssocSemiring (fun f : α →ₛ β ↦ ⇑f)
+  fast_instance% Function.Injective.nonUnitalNonAssocSemiring (fun f => show α → β from f)
     coe_injective coe_zero coe_add coe_mul coe_smul
 
 instance [NonUnitalSemiring β] : NonUnitalSemiring (α →ₛ β) :=
-  fast_instance% Function.Injective.nonUnitalSemiring (fun f : α →ₛ β ↦ ⇑f) SimpleFunc.coe_injective
-      coe_zero coe_add coe_mul coe_smul
+  fast_instance% Function.Injective.nonUnitalSemiring (fun f => show α → β from f)
+    SimpleFunc.coe_injective coe_zero coe_add coe_mul coe_smul
 
 instance [NatCast β] : NatCast (α →ₛ β) where
   natCast n := const _ (NatCast.natCast n)
@@ -580,19 +579,19 @@ lemma coe_natCast [NatCast β] (n : ℕ) :
     ⇑(↑n : α →ₛ β) = fun _ ↦ ↑n := rfl
 
 instance [NonAssocSemiring β] : NonAssocSemiring (α →ₛ β) :=
-  fast_instance% Function.Injective.nonAssocSemiring (fun f : α →ₛ β ↦ ⇑f) SimpleFunc.coe_injective
-      coe_zero coe_one coe_add coe_mul coe_smul coe_natCast
+  fast_instance% Function.Injective.nonAssocSemiring (fun f => show α → β from f)
+    SimpleFunc.coe_injective coe_zero coe_one coe_add coe_mul coe_smul coe_natCast
 
 instance [NonAssocRing β] : NonAssocRing (α →ₛ β) where
 
 instance [NonUnitalCommSemiring β] : NonUnitalCommSemiring (α →ₛ β) :=
-  fast_instance% Function.Injective.nonUnitalCommSemiring (fun f : α →ₛ β ↦ ⇑f)
+  fast_instance% Function.Injective.nonUnitalCommSemiring (fun f => show α → β from f)
     coe_injective coe_zero coe_add coe_mul coe_smul
 
 instance [CommSemiring β] : CommSemiring (α →ₛ β) where
 
 instance [NonUnitalCommRing β] : NonUnitalCommRing (α →ₛ β) :=
-  fast_instance% Function.Injective.nonUnitalCommRing (fun f : α →ₛ β ↦ ⇑f)
+  fast_instance% Function.Injective.nonUnitalCommRing (fun f => show α → β from f)
     coe_injective coe_zero coe_add coe_mul coe_neg coe_sub
       coe_smul coe_smul
 

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -592,13 +592,13 @@ instance [NonAssocRing β] : NonAssocRing (α →ₛ β) :=
   fast_instance% Function.Injective.nonAssocRing (fun f => show α → β from f) coe_injective
     coe_zero coe_one coe_add coe_mul coe_neg coe_sub coe_smul coe_smul coe_natCast coe_intCast
 
-instance [NonAssocRing β] : NonAssocRing (α →ₛ β) where
-
 instance [NonUnitalCommSemiring β] : NonUnitalCommSemiring (α →ₛ β) :=
   fast_instance% Function.Injective.nonUnitalCommSemiring (fun f => show α → β from f)
     coe_injective coe_zero coe_add coe_mul coe_smul
 
-instance [CommSemiring β] : CommSemiring (α →ₛ β) where
+instance [CommSemiring β] : CommSemiring (α →ₛ β) :=
+  fast_instance% Function.Injective.commSemiring (fun f => show α → β from f)
+    coe_injective coe_zero coe_one coe_add coe_mul coe_smul coe_pow coe_natCast
 
 instance [NonUnitalCommRing β] : NonUnitalCommRing (α →ₛ β) :=
   fast_instance% Function.Injective.nonUnitalCommRing (fun f => show α → β from f)
@@ -609,15 +609,15 @@ instance [CommRing β] : CommRing (α →ₛ β) :=
     coe_one coe_add coe_mul coe_neg coe_sub coe_smul coe_smul coe_pow coe_natCast coe_intCast
 
 instance [Semiring β] : Semiring (α →ₛ β) :=
-  fast_instance% Function.Injective.semiring (fun (f : α →ₛ β) ↦ ⇑f) coe_injective coe_zero coe_one
-    coe_add coe_mul coe_smul coe_pow coe_natCast
+  fast_instance% Function.Injective.semiring (fun f => show α → β from f) coe_injective coe_zero
+    coe_one coe_add coe_mul coe_smul coe_pow coe_natCast
 
 instance [NonUnitalRing β] : NonUnitalRing (α →ₛ β) :=
-  fast_instance% Function.Injective.nonUnitalRing (fun (f : α →ₛ β) ↦ ⇑f) coe_injective coe_zero
-   coe_add coe_mul coe_neg coe_sub coe_smul coe_smul
+  fast_instance% Function.Injective.nonUnitalRing (fun f => show α → β from f) coe_injective
+   coe_zero coe_add coe_mul coe_neg coe_sub coe_smul coe_smul
 
 instance [Ring β] : Ring (α →ₛ β) :=
-  fast_instance% Function.Injective.ring (fun (f : α →ₛ β) ↦ ⇑f) coe_injective coe_zero
+  fast_instance% Function.Injective.ring (fun f => show α → β from f) coe_injective coe_zero
    coe_one coe_add coe_mul coe_neg coe_sub coe_smul coe_smul coe_pow coe_natCast coe_intCast
 
 instance [SMul K γ] [SMul γ β] [SMul K β] [IsScalarTower K γ β] : IsScalarTower K γ (α →ₛ β) where

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -561,11 +561,11 @@ instance [NonUnitalNonAssocSemiring β] : NonUnitalNonAssocSemiring (α →ₛ �
 
 instance [Semiring β] : Semiring (α →ₛ β) where
 
-instance [Monoid K] [Semiring β] [MulAction K β] : MulAction K (α →ₛ β) where
+instance [Monoid K] [MulAction K β] : MulAction K (α →ₛ β) where
   one_smul _ := ext fun _ ↦ one_smul ..
   mul_smul _ _ _ := ext fun _ ↦ mul_smul ..
 
-noncomputable instance [CommSemiring K] [Semiring β] [Algebra K β] : Algebra K (α →ₛ β) :=
+instance [CommSemiring K] [Semiring β] [Algebra K β] : Algebra K (α →ₛ β) :=
   RingHom.toAlgebra'
     { toFun _ := const α <| algebraMap K β _
       map_one' := SimpleFunc.ext fun _ => algebraMap K β |>.map_one ▸ rfl

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -592,8 +592,7 @@ instance [CommSemiring β] : CommSemiring (α →ₛ β) where
 
 instance [NonUnitalCommRing β] : NonUnitalCommRing (α →ₛ β) :=
   fast_instance% Function.Injective.nonUnitalCommRing (fun f => show α → β from f)
-    coe_injective coe_zero coe_add coe_mul coe_neg coe_sub
-      coe_smul coe_smul
+    coe_injective coe_zero coe_add coe_mul coe_neg coe_sub coe_smul coe_smul
 
 instance [CommRing β] : CommRing (α →ₛ β) where
 

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -561,8 +561,12 @@ instance [NonUnitalNonAssocSemiring β] : NonUnitalNonAssocSemiring (α →ₛ �
 
 instance [Semiring β] : Semiring (α →ₛ β) where
 
+instance [Monoid K] [Semiring β] [MulAction K β] : MulAction K (α →ₛ β) where
+  one_smul _ := ext fun _ ↦ one_smul ..
+  mul_smul _ _ _ := ext fun _ ↦ mul_smul ..
+
 /-- Convenience constructor providing `toFun` for `Algebra K (α →ₛ β)` instance. -/
-noncomputable def simpleFuncAlgebraMap [CommSemiring K] [Semiring β] [Algebra K β] : K →+* α →ₛ β :=
+def simpleFuncAlgebraMap [CommSemiring K] [Semiring β] [Algebra K β] : K →+* α →ₛ β :=
   { toFun k := const _ <| algebraMap _ β k
     map_one' := ext fun _ ↦ algebraMap K β |>.map_one ▸ rfl
     map_mul' _ _ := ext fun _ ↦ algebraMap K β |>.map_mul ..
@@ -574,7 +578,7 @@ lemma algebraMap_const_mul_comm [CommSemiring K] [Semiring β] [Algebra K β] :
      ∀ (c : K), ∀ (f : α →ₛ β), simpleFuncAlgebraMap c * f = f * simpleFuncAlgebraMap c :=
   fun _ _ => ext fun _ => Algebra.commutes ..
 
-noncomputable instance [CommSemiring K] [Semiring β] [Algebra K β] : Algebra K (α →ₛ β) :=
+instance [CommSemiring K] [Semiring β] [Algebra K β] : Algebra K (α →ₛ β) :=
   simpleFuncAlgebraMap.toAlgebra' algebraMap_const_mul_comm
 
 section Star

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -1025,6 +1025,26 @@ theorem lintegral_map {β} [MeasurableSpace β] (g : β →ₛ ℝ≥0∞) {f : 
     g.lintegral (Measure.map f μ) = (g.comp f hf).lintegral μ :=
   Eq.symm <| lintegral_map' _ _ f (fun _ => rfl) fun _s hs => Measure.map_apply hf hs
 
+section Star
+
+variable {R : Type*} [Star R]
+
+instance : Star (α →ₛ R) where
+  star f := f.map Star.star
+
+lemma star_apply (f : α →ₛ R) (x : α) : (star f) x = star (f x) := rfl
+
+end Star
+
+section InvolutiveStar
+
+variable {R : Type*} [TopologicalSpace R] [InvolutiveStar R] [ContinuousStar R]
+
+instance : InvolutiveStar (α →ₛ R) where
+  star_involutive := fun _ => by ext; simp [star_apply]
+
+end InvolutiveStar
+
 end Measure
 
 section FinMeasSupp

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -562,17 +562,20 @@ lemma smul_const [SMul K β] (k : K) (b : β) :
 
 lemma one_eq_const_one [One β] : (1 : α →ₛ β) = const α 1 := rfl
 
-open Function in
 instance [NonUnitalNonAssocSemiring β] : NonUnitalNonAssocSemiring (α →ₛ β) :=
-  Injective.nonUnitalNonAssocSemiring (fun f : α →ₛ β ↦ ⇑f) SimpleFunc.coe_injective
+  Function.Injective.nonUnitalNonAssocSemiring (fun f : α →ₛ β ↦ ⇑f) SimpleFunc.coe_injective
       rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
 
-instance [NonAssocSemiring β] : NonAssocSemiring (α →ₛ β) where
-  one_mul _ := ext fun _ ↦ one_mul ..
-  mul_one _ := ext fun _ ↦ mul_one ..
+instance [NonUnitalSemiring β] : NonUnitalSemiring (α →ₛ β) :=
+  Function.Injective.nonUnitalSemiring (fun f : α →ₛ β ↦ ⇑f) SimpleFunc.coe_injective
+      rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
 
-instance [NonUnitalSemiring β] : NonUnitalSemiring (α →ₛ β) where
-  mul_assoc _ _ _ := ext fun _ ↦ mul_assoc ..
+instance [NatCast β] : NatCast (α →ₛ β) where
+  natCast n := const _ (NatCast.natCast n)
+
+instance [NonAssocSemiring β] : NonAssocSemiring (α →ₛ β) :=
+  Function.Injective.nonAssocSemiring (fun f : α →ₛ β ↦ ⇑f) SimpleFunc.coe_injective
+      rfl rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ ↦ rfl)
 
 instance [Semiring β] : Semiring (α →ₛ β) where
 

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -572,7 +572,7 @@ noncomputable instance [CommSemiring K] [Semiring β] [Algebra K β] : Algebra K
       map_mul' _ _:= ext fun _ => (algebraMap K β).map_mul _ _
       map_zero' := SimpleFunc.ext fun _ => (algebraMap K β).map_zero ▸ rfl
       map_add' _ _ := ext fun _ => (algebraMap K β).map_add _ _ }
-    (fun c f => ext fun x => Algebra.commutes c (f x))
+    fun c f => ext fun _ => Algebra.commutes c (f _)
 
 section Star
 

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Johannes Hölzl
 -/
 import Mathlib.Algebra.Order.Pi
+import Mathlib.Algebra.Algebra.Pi
 import Mathlib.MeasureTheory.Constructions.BorelSpace.Order
 
 /-!
@@ -561,8 +562,6 @@ theorem smul_eq_map [SMul K β] (k : K) (f : α →ₛ β) : k • f = f.map (k 
 lemma smul_const [SMul K β] (k : K) (b : β) :
     (k • const α b : α →ₛ β) = const α (k • b) := ext fun _ ↦ rfl
 
-lemma one_eq_const_one [One β] : (1 : α →ₛ β) = const α 1 := rfl
-
 instance [NonUnitalNonAssocSemiring β] : NonUnitalNonAssocSemiring (α →ₛ β) :=
   fast_instance% Function.Injective.nonUnitalNonAssocSemiring (fun f => show α → β from f)
     coe_injective coe_zero coe_add coe_mul coe_smul
@@ -637,12 +636,13 @@ instance [CommSemiring K] [Semiring β] [Algebra K β] : Algebra K (α →ₛ β
   commutes' _ _ := ext fun _ ↦ Algebra.commutes ..
   smul_def' _ _ := ext fun _ ↦ Algebra.smul_def ..
 
-lemma algebraMap_apply [CommSemiring K] [Semiring β] [Algebra K β] (k : K) :
-    algebraMap K (α →ₛ β) k = const α (algebraMap K β k) := rfl
+@[simp]
+lemma const_algebraMap [CommSemiring K] [Semiring β] [Algebra K β] (k : K) :
+    const α (algebraMap K β k) = algebraMap K (α →ₛ β) k := rfl
 
 @[simp]
-lemma algebraMap_apply_apply [CommSemiring K] [Semiring β] [Algebra K β] (k : K) (x : α) :
-    algebraMap K (α →ₛ β) k x = algebraMap K β k := rfl
+lemma coe_algebraMap [CommSemiring K] [Semiring β] [Algebra K β] (k : K) (x : α) :
+    ⇑(algebraMap K (α →ₛ β)) k x = algebraMap K (α → β) k x := rfl
 
 section Star
 
@@ -650,7 +650,7 @@ instance [Star β] : Star (α →ₛ β) where
   star f := f.map Star.star
 
 @[simp]
-lemma star_apply [Star β] {f : α →ₛ β} {x : α} : star f x = star (f x) := rfl
+lemma coe_star [Star β] {f : α →ₛ β} : ⇑(star f) = star ⇑f := rfl
 
 instance [InvolutiveStar β] : InvolutiveStar (α →ₛ β) where
   star_involutive _ := ext fun _ ↦ star_star _

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -580,7 +580,18 @@ lemma coe_natCast [NatCast β] (n : ℕ) :
 
 instance [NonAssocSemiring β] : NonAssocSemiring (α →ₛ β) :=
   fast_instance% Function.Injective.nonAssocSemiring (fun f => show α → β from f)
-    SimpleFunc.coe_injective coe_zero coe_one coe_add coe_mul coe_smul coe_natCast
+    coe_injective coe_zero coe_one coe_add coe_mul coe_smul coe_natCast
+
+instance [IntCast β] : IntCast (α →ₛ β) where
+  intCast n := const _ (IntCast.intCast n)
+
+@[simp, norm_cast]
+lemma coe_intCast [IntCast β] (n : ℤ) :
+    ⇑(↑n : α →ₛ β) = fun _ ↦ ↑n := rfl
+
+instance [NonAssocRing β] : NonAssocRing (α →ₛ β) :=
+  fast_instance% Function.Injective.nonAssocRing (fun f => show α → β from f) coe_injective
+    coe_zero coe_one coe_add coe_mul coe_neg coe_sub coe_smul coe_smul coe_natCast coe_intCast
 
 instance [NonAssocRing β] : NonAssocRing (α →ₛ β) where
 
@@ -594,13 +605,21 @@ instance [NonUnitalCommRing β] : NonUnitalCommRing (α →ₛ β) :=
   fast_instance% Function.Injective.nonUnitalCommRing (fun f => show α → β from f)
     coe_injective coe_zero coe_add coe_mul coe_neg coe_sub coe_smul coe_smul
 
-instance [CommRing β] : CommRing (α →ₛ β) where
+instance [CommRing β] : CommRing (α →ₛ β) :=
+  fast_instance% Function.Injective.commRing (fun f => show α → β from f) coe_injective coe_zero
+    coe_one coe_add coe_mul coe_neg coe_sub coe_smul coe_smul coe_pow coe_natCast coe_intCast
 
-instance [Semiring β] : Semiring (α →ₛ β) where
+instance [Semiring β] : Semiring (α →ₛ β) :=
+  fast_instance% Function.Injective.semiring (fun (f : α →ₛ β) ↦ ⇑f) coe_injective coe_zero coe_one
+    coe_add coe_mul coe_smul coe_pow coe_natCast
 
-instance [NonUnitalRing β] : NonUnitalRing (α →ₛ β) where
+instance [NonUnitalRing β] : NonUnitalRing (α →ₛ β) :=
+  fast_instance% Function.Injective.nonUnitalRing (fun (f : α →ₛ β) ↦ ⇑f) coe_injective coe_zero
+   coe_add coe_mul coe_neg coe_sub coe_smul coe_smul
 
-instance [Ring β] : Ring (α →ₛ β) where
+instance [Ring β] : Ring (α →ₛ β) :=
+  fast_instance% Function.Injective.ring (fun (f : α →ₛ β) ↦ ⇑f) coe_injective coe_zero
+   coe_one coe_add coe_mul coe_neg coe_sub coe_smul coe_smul coe_pow coe_natCast coe_intCast
 
 instance [SMul K γ] [SMul γ β] [SMul K β] [IsScalarTower K γ β] : IsScalarTower K γ (α →ₛ β) where
   smul_assoc _ _ _ := ext fun _ ↦ smul_assoc ..
@@ -624,6 +643,7 @@ lemma algebraMap_apply [CommSemiring K] [Semiring β] [Algebra K β] (k : K) :
 @[simp]
 lemma algebraMap_apply_apply [CommSemiring K] [Semiring β] [Algebra K β] (k : K) (x : α) :
     algebraMap K (α →ₛ β) k x = algebraMap K β k := rfl
+
 section Star
 
 instance [Star β] : Star (α →ₛ β) where

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -565,21 +565,14 @@ instance [Monoid K] [Semiring β] [MulAction K β] : MulAction K (α →ₛ β) 
   one_smul _ := ext fun _ ↦ one_smul ..
   mul_smul _ _ _ := ext fun _ ↦ mul_smul ..
 
-/-- Convenience constructor providing `toFun` for `Algebra K (α →ₛ β)` instance. -/
-def simpleFuncAlgebraMap [CommSemiring K] [Semiring β] [Algebra K β] : K →+* α →ₛ β :=
-  { toFun k := const _ <| algebraMap _ β k
-    map_one' := ext fun _ ↦ algebraMap K β |>.map_one ▸ rfl
-    map_mul' _ _ := ext fun _ ↦ algebraMap K β |>.map_mul ..
-    map_zero' := ext fun _ ↦ algebraMap K β |>.map_zero ▸ rfl
-    map_add' _ _ := ext fun _ ↦ algebraMap K β |>.map_add ..}
-
-/-- Convenience constructor providing `commutes` for `Algebra K (α →ₛ β)` instance. -/
-lemma algebraMap_const_mul_comm [CommSemiring K] [Semiring β] [Algebra K β] :
-     ∀ (c : K), ∀ (f : α →ₛ β), simpleFuncAlgebraMap c * f = f * simpleFuncAlgebraMap c :=
-  fun _ _ => ext fun _ => Algebra.commutes ..
-
-instance [CommSemiring K] [Semiring β] [Algebra K β] : Algebra K (α →ₛ β) :=
-  simpleFuncAlgebraMap.toAlgebra' algebraMap_const_mul_comm
+noncomputable instance [CommSemiring K] [Semiring β] [Algebra K β] : Algebra K (α →ₛ β) :=
+  RingHom.toAlgebra'
+    { toFun _ := const α (algebraMap K β _)
+      map_one' := SimpleFunc.ext fun _ => (algebraMap K β).map_one ▸ rfl
+      map_mul' _ _:= ext fun _ => (algebraMap K β).map_mul _ _
+      map_zero' := SimpleFunc.ext fun _ => (algebraMap K β).map_zero ▸ rfl
+      map_add' _ _ := ext fun _ => (algebraMap K β).map_add _ _ }
+    (fun c f => ext fun x => Algebra.commutes c (f x))
 
 section Star
 

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -546,6 +546,10 @@ instance instCommGroup [CommGroup β] : CommGroup (α →ₛ β) :=
   Function.Injective.commGroup (fun f => show α → β from f) coe_injective coe_one coe_mul coe_inv
     coe_div coe_pow coe_zpow
 
+instance [Monoid K] [MulAction K β] : MulAction K (α →ₛ β) where
+  one_smul _ := ext fun _ ↦ one_smul ..
+  mul_smul _ _ _ := ext fun _ ↦ mul_smul ..
+
 instance instModule [Semiring K] [AddCommMonoid β] [Module K β] : Module K (α →ₛ β) :=
   Function.Injective.module K ⟨⟨fun f => show α → β from f, coe_zero⟩, coe_add⟩
     coe_injective coe_smul
@@ -558,11 +562,10 @@ lemma smul_const [SMul K β] (k : K) (b : β) :
 
 lemma one_eq_const_one [One β] : (1 : α →ₛ β) = const α 1 := rfl
 
-instance [NonUnitalNonAssocSemiring β] : NonUnitalNonAssocSemiring (α →ₛ β) where
-  left_distrib _ _ _ := ext fun _ ↦ left_distrib ..
-  right_distrib _ _ _ := ext fun _ ↦ right_distrib ..
-  zero_mul _ := ext fun _ ↦ zero_mul ..
-  mul_zero _ := ext fun _ ↦ mul_zero ..
+open Function in
+instance [NonUnitalNonAssocSemiring β] : NonUnitalNonAssocSemiring (α →ₛ β) :=
+  Injective.nonUnitalNonAssocSemiring (fun f : α →ₛ β ↦ ⇑f) SimpleFunc.coe_injective
+      rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
 
 instance [NonAssocSemiring β] : NonAssocSemiring (α →ₛ β) where
   one_mul _ := ext fun _ ↦ one_mul ..
@@ -576,10 +579,6 @@ instance [Semiring β] : Semiring (α →ₛ β) where
 instance [NonUnitalRing β] : NonUnitalRing (α →ₛ β) where
 
 instance [Ring β] : Ring (α →ₛ β) where
-
-instance [Monoid K] [MulAction K β] : MulAction K (α →ₛ β) where
-  one_smul _ := ext fun _ ↦ one_smul ..
-  mul_smul _ _ _ := ext fun _ ↦ mul_smul ..
 
 instance [SMul K γ] [SMul γ β] [SMul K β] [IsScalarTower K γ β] : IsScalarTower K γ (α →ₛ β) where
   smul_assoc _ _ _ := ext fun _ ↦ smul_assoc ..

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -566,31 +566,35 @@ lemma one_eq_const_one [One β] : (1 : α →ₛ β) = const α 1 := rfl
 
 instance [NonUnitalNonAssocSemiring β] : NonUnitalNonAssocSemiring (α →ₛ β) :=
   fast_instance% Function.Injective.nonUnitalNonAssocSemiring (fun f : α →ₛ β ↦ ⇑f)
-    SimpleFunc.coe_injective rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+    coe_injective coe_zero coe_add coe_mul coe_smul
 
 instance [NonUnitalSemiring β] : NonUnitalSemiring (α →ₛ β) :=
   fast_instance% Function.Injective.nonUnitalSemiring (fun f : α →ₛ β ↦ ⇑f) SimpleFunc.coe_injective
-      rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+      coe_zero coe_add coe_mul coe_smul
 
 instance [NatCast β] : NatCast (α →ₛ β) where
   natCast n := const _ (NatCast.natCast n)
 
+@[simp, norm_cast]
+lemma coe_natCast [NatCast β] (n : ℕ) :
+    ⇑(↑n : α →ₛ β) = fun _ ↦ ↑n := rfl
+
 instance [NonAssocSemiring β] : NonAssocSemiring (α →ₛ β) :=
   fast_instance% Function.Injective.nonAssocSemiring (fun f : α →ₛ β ↦ ⇑f) SimpleFunc.coe_injective
-      rfl rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ ↦ rfl)
+      coe_zero coe_one coe_add coe_mul coe_smul coe_natCast
 
 instance [NonAssocRing β] : NonAssocRing (α →ₛ β) where
 
 instance [NonUnitalCommSemiring β] : NonUnitalCommSemiring (α →ₛ β) :=
   fast_instance% Function.Injective.nonUnitalCommSemiring (fun f : α →ₛ β ↦ ⇑f)
-    SimpleFunc.coe_injective rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+    coe_injective coe_zero coe_add coe_mul coe_smul
 
 instance [CommSemiring β] : CommSemiring (α →ₛ β) where
 
 instance [NonUnitalCommRing β] : NonUnitalCommRing (α →ₛ β) :=
   fast_instance% Function.Injective.nonUnitalCommRing (fun f : α →ₛ β ↦ ⇑f)
-    SimpleFunc.coe_injective rfl (fun _ _ ↦ rfl) (fun _ _ ↦ rfl) (fun _ ↦ rfl) (fun _ _ ↦ rfl)
-      (fun _ _ ↦ rfl) (fun _ _ ↦ rfl)
+    coe_injective coe_zero coe_add coe_mul coe_neg coe_sub
+      coe_smul coe_smul
 
 instance [CommRing β] : CommRing (α →ₛ β) where
 

--- a/Mathlib/MeasureTheory/Function/SimpleFunc.lean
+++ b/Mathlib/MeasureTheory/Function/SimpleFunc.lean
@@ -559,7 +559,18 @@ instance [NonUnitalNonAssocSemiring β] : NonUnitalNonAssocSemiring (α →ₛ �
   zero_mul _ := ext fun _ ↦ zero_mul ..
   mul_zero _ := ext fun _ ↦ mul_zero ..
 
+instance [NonAssocSemiring β] : NonAssocSemiring (α →ₛ β) where
+  one_mul _ := ext fun _ ↦ one_mul ..
+  mul_one _ := ext fun _ ↦ mul_one ..
+
+instance [NonUnitalSemiring β] : NonUnitalSemiring (α →ₛ β) where
+  mul_assoc _ _ _ := ext fun _ ↦ mul_assoc ..
+
 instance [Semiring β] : Semiring (α →ₛ β) where
+
+instance [NonUnitalRing β] : NonUnitalRing (α →ₛ β) where
+
+instance [Ring β] : Ring (α →ₛ β) where
 
 instance [Monoid K] [MulAction K β] : MulAction K (α →ₛ β) where
   one_smul _ := ext fun _ ↦ one_smul ..


### PR DESCRIPTION
This adds a `Star` instance on simple functions into a type with a star structure, the associated `coe_star` lemma, and the relevant algebraic compatibility instances (e.g., `StarMul`) when the codomain is equipped with these.

We also add several missing instances (mostly `Ring`-like and `Algebra`-like).

This PR is the first in a series of small PRs aimed at providing a `CStarAlgebra` instance for L^∞ functions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
