### PR TITLE
[Merged by Bors] - feat(Data/Finset): add `Finset.filter_notMem_eq_sdiff`, `Finset.map_sdiff`

### DIFF
--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -394,11 +394,15 @@ theorem filter_union (s₁ s₂ : Finset α) : (s₁ ∪ s₂).filter p = s₁.f
   ext fun _ => by simp only [mem_filter, mem_union, or_and_right]
 
 theorem filter_union_right (s : Finset α) : s.filter p ∪ s.filter q = s.filter fun x => p x ∨ q x :=
-  ext fun x => by simp [mem_filter, mem_union, ← and_or_left]
+  ext fun x => by simp only [mem_filter, mem_union, ← and_or_left]
 
-theorem filter_mem_eq_inter {s t : Finset α} [∀ i, Decidable (i ∈ t)] :
+theorem filter_mem_eq_inter {s t : Finset α} :
     (s.filter fun i => i ∈ t) = s ∩ t :=
-  ext fun i => by simp [mem_filter, mem_inter]
+  ext fun i => by simp only [mem_filter, mem_inter]
+
+theorem filter_notMem_eq_sdiff {s t : Finset α} :
+    (s.filter fun i => i ∉ t) = s \ t :=
+  ext fun i => by simp only [mem_filter, mem_sdiff]
 
 theorem filter_inter_distrib (s t : Finset α) : (s ∩ t).filter p = s.filter p ∩ t.filter p := by
   ext

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -394,19 +394,23 @@ theorem filter_union (s₁ s₂ : Finset α) : (s₁ ∪ s₂).filter p = s₁.f
   ext fun _ => by simp only [mem_filter, mem_union, or_and_right]
 
 theorem filter_union_right (s : Finset α) : s.filter p ∪ s.filter q = s.filter fun x => p x ∨ q x :=
-  ext fun _ => by simp [mem_filter, mem_union, ← and_or_left]
+  ext fun x => by simp [mem_filter, mem_union, ← and_or_left]
 
-theorem filter_mem_eq_inter {s t : Finset α} : (s.filter fun i => i ∈ t) = s ∩ t :=
-  ext fun _ => by simp [mem_filter, mem_inter]
+theorem filter_mem_eq_inter {s t : Finset α} [∀ i, Decidable (i ∈ t)] :
+    (s.filter fun i => i ∈ t) = s ∩ t :=
+  ext fun i => by simp [mem_filter, mem_inter]
 
-theorem filter_notMem_eq_sdiff {s t : Finset α} : (s.filter fun i => i ∉ t) = s \ t :=
+theorem filter_notMem_eq_sdiff {s t : Finset α} [∀ i, Decidable (i ∉ t)] :
+    (s.filter fun i => i ∉ t) = s \ t :=
   ext fun _ => by simp only [mem_filter, mem_sdiff]
 
-theorem filter_inter_distrib (s t : Finset α) : (s ∩ t).filter p = s.filter p ∩ t.filter p :=
-  ext fun _ => by simp [mem_filter, mem_inter, and_assoc]
+theorem filter_inter_distrib (s t : Finset α) : (s ∩ t).filter p = s.filter p ∩ t.filter p := by
+  ext
+  simp [mem_filter, mem_inter, and_assoc]
 
-theorem filter_inter (s t : Finset α) : filter p s ∩ t = filter p (s ∩ t) :=
-  ext fun _ => by simp only [mem_inter, mem_filter, and_right_comm]
+theorem filter_inter (s t : Finset α) : filter p s ∩ t = filter p (s ∩ t) := by
+  ext
+  simp only [mem_inter, mem_filter, and_right_comm]
 
 theorem inter_filter (s t : Finset α) : s ∩ filter p t = filter p (s ∩ t) := by
   rw [inter_comm, filter_inter, inter_comm]
@@ -416,8 +420,9 @@ theorem filter_insert (a : α) (s : Finset α) :
   ext x
   split_ifs with h <;> by_cases h' : x = a <;> simp [h, h']
 
-theorem filter_erase (a : α) (s : Finset α) : filter p (erase s a) = erase (filter p s) a :=
-  ext fun _ => by simp only [and_assoc, mem_filter, iff_self, mem_erase]
+theorem filter_erase (a : α) (s : Finset α) : filter p (erase s a) = erase (filter p s) a := by
+  ext x
+  simp only [and_assoc, mem_filter, iff_self, mem_erase]
 
 theorem filter_or (s : Finset α) : (s.filter fun a => p a ∨ q a) = s.filter p ∪ s.filter q :=
   ext fun _ => by simp [mem_filter, mem_union, and_or_left]

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -394,23 +394,19 @@ theorem filter_union (s₁ s₂ : Finset α) : (s₁ ∪ s₂).filter p = s₁.f
   ext fun _ => by simp only [mem_filter, mem_union, or_and_right]
 
 theorem filter_union_right (s : Finset α) : s.filter p ∪ s.filter q = s.filter fun x => p x ∨ q x :=
-  ext fun x => by simp only [mem_filter, mem_union, ← and_or_left]
+  ext fun _ => by simp only [mem_filter, mem_union, ← and_or_left]
 
-theorem filter_mem_eq_inter {s t : Finset α} :
-    (s.filter fun i => i ∈ t) = s ∩ t :=
-  ext fun i => by simp only [mem_filter, mem_inter]
+theorem filter_mem_eq_inter {s t : Finset α} : (s.filter fun i => i ∈ t) = s ∩ t :=
+  ext fun _ => by simp only [mem_filter, mem_inter]
 
-theorem filter_notMem_eq_sdiff {s t : Finset α} :
-    (s.filter fun i => i ∉ t) = s \ t :=
-  ext fun i => by simp only [mem_filter, mem_sdiff]
+theorem filter_notMem_eq_sdiff {s t : Finset α} : (s.filter fun i => i ∉ t) = s \ t :=
+  ext fun _ => by simp only [mem_filter, mem_sdiff]
 
-theorem filter_inter_distrib (s t : Finset α) : (s ∩ t).filter p = s.filter p ∩ t.filter p := by
-  ext
-  simp [mem_filter, mem_inter, and_assoc]
+theorem filter_inter_distrib (s t : Finset α) : (s ∩ t).filter p = s.filter p ∩ t.filter p :=
+  ext fun _ => by simp [mem_filter, mem_inter, and_assoc]
 
-theorem filter_inter (s t : Finset α) : filter p s ∩ t = filter p (s ∩ t) := by
-  ext
-  simp only [mem_inter, mem_filter, and_right_comm]
+theorem filter_inter (s t : Finset α) : filter p s ∩ t = filter p (s ∩ t) :=
+  ext fun _ => by simp only [mem_inter, mem_filter, and_right_comm]
 
 theorem inter_filter (s t : Finset α) : s ∩ filter p t = filter p (s ∩ t) := by
   rw [inter_comm, filter_inter, inter_comm]
@@ -420,9 +416,8 @@ theorem filter_insert (a : α) (s : Finset α) :
   ext x
   split_ifs with h <;> by_cases h' : x = a <;> simp [h, h']
 
-theorem filter_erase (a : α) (s : Finset α) : filter p (erase s a) = erase (filter p s) a := by
-  ext x
-  simp only [and_assoc, mem_filter, iff_self, mem_erase]
+theorem filter_erase (a : α) (s : Finset α) : filter p (erase s a) = erase (filter p s) a :=
+  ext fun _ => by simp only [and_assoc, mem_filter, iff_self, mem_erase]
 
 theorem filter_or (s : Finset α) : (s.filter fun a => p a ∨ q a) = s.filter p ∪ s.filter q :=
   ext fun _ => by simp [mem_filter, mem_union, and_or_left]

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -394,10 +394,10 @@ theorem filter_union (s₁ s₂ : Finset α) : (s₁ ∪ s₂).filter p = s₁.f
   ext fun _ => by simp only [mem_filter, mem_union, or_and_right]
 
 theorem filter_union_right (s : Finset α) : s.filter p ∪ s.filter q = s.filter fun x => p x ∨ q x :=
-  ext fun _ => by simp only [mem_filter, mem_union, ← and_or_left]
+  ext fun _ => by simp [mem_filter, mem_union, ← and_or_left]
 
 theorem filter_mem_eq_inter {s t : Finset α} : (s.filter fun i => i ∈ t) = s ∩ t :=
-  ext fun _ => by simp only [mem_filter, mem_inter]
+  ext fun _ => by simp [mem_filter, mem_inter]
 
 theorem filter_notMem_eq_sdiff {s t : Finset α} : (s.filter fun i => i ∉ t) = s \ t :=
   ext fun _ => by simp only [mem_filter, mem_sdiff]

--- a/Mathlib/Data/Finset/Image.lean
+++ b/Mathlib/Data/Finset/Image.lean
@@ -223,6 +223,10 @@ theorem map_inter [DecidableEq α] [DecidableEq β] {f : α ↪ β} (s₁ s₂ :
     (s₁ ∩ s₂).map f = s₁.map f ∩ s₂.map f :=
   mod_cast Set.image_inter f.injective (s := s₁) (t := s₂)
 
+theorem map_sdiff [DecidableEq α] [DecidableEq β] {f : α ↪ β} (s₁ s₂ : Finset α) :
+    (s₁ \ s₂).map f = s₁.map f \ s₂.map f :=
+  mod_cast Set.image_diff f.injective (s := s₁) (t := s₂)
+
 @[simp]
 theorem map_singleton (f : α ↪ β) (a : α) : map f {a} = {f a} :=
   coe_injective <| by simp only [coe_map, coe_singleton, Set.image_singleton]


### PR DESCRIPTION
`Finset.filter_notMem_eq_sdiff` is the symmetric correspondence of `Finset.filter_mem_eq_inter`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
