### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/LinearIndependent): `linearIndependent_iffₒₛ` etc for linearly and canonically ordered semiring

### DIFF
--- a/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
@@ -618,7 +618,14 @@ theorem LinearIndependent.maximal_iff {ι : Type w} {R : Type u} [Semiring R] [N
 
 end Maximal
 
-section CanonicallyOrderedAdd
+/-!
+### Properties which require `LinearOrder R`, `CanonicallyOrderedAdd R` and `OrderedSub R`
+
+If the semiring `R` is linearly and canonically ordered and admits ordered subtraction (e.g.
+`R = ℕ`), `LinearIndependent` can be proved from linear combination over two disjoint sets.
+-/
+
+section LinearlyCanonicallyOrdered
 
 variable [LinearOrder R] [CanonicallyOrderedAdd R] [AddLeftMono R] [Sub R] [OrderedSub R]
 variable [IsCancelAdd M]
@@ -722,7 +729,7 @@ lemma not_linearIndepOn_finset_iffₒ [DecidableEq ι] {s : Finset ι} :
   · refine ⟨s \ t, Finset.sdiff_subset, g, f, ?_, i, hi, pos_of_ne_zero hgi⟩
     simpa [Finset.sdiff_sdiff_eq_self hst] using heq.symm
 
-end CanonicallyOrderedAdd
+end LinearlyCanonicallyOrdered
 
 end Semiring
 

--- a/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
@@ -627,14 +627,15 @@ If the semiring `R` is linearly and canonically ordered and admits ordered subtr
 
 section LinearlyCanonicallyOrdered
 
-variable [LinearOrder R] [CanonicallyOrderedAdd R] [AddLeftMono R] [Sub R] [OrderedSub R]
-variable [IsCancelAdd M]
+variable [LinearOrder R] [CanonicallyOrderedAdd R] [AddRightReflectLE R] [IsCancelAdd M]
 
 theorem linearIndependent_iffₒ :
     LinearIndependent R v ↔
       ∀ (s t : Finset ι) (f g : ι → R), Disjoint s t →
         ∑ i ∈ s, f i • v i = ∑ i ∈ t, g i • v i → (∀ i ∈ s, f i = 0) ∧ ∀ i ∈ t, g i = 0 := by
   classical
+  letI : Sub R := CanonicallyOrderedAdd.toSub
+  haveI : OrderedSub R := CanonicallyOrderedAdd.toSub.orderedSub
   rw [linearIndependent_iff'ₛ]
   refine ⟨fun h s t f g hst heq => ?_, fun h s f g heq => ?_⟩
   · specialize h (s ∪ t) (fun i => if i ∈ s then f i else 0) (fun i => if i ∈ t then g i else 0) ?_

--- a/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
@@ -694,13 +694,13 @@ nonrec theorem Fintype.linearIndependent_iffₒ [DecidableEq ι] [Fintype ι] :
 
 theorem Fintype.not_linearIndependent_iffₒ [DecidableEq ι] [Fintype ι] :
     ¬ LinearIndependent R v ↔ ∃ t, ∃ (f : ι → R),
-      ∑ i ∈ t, f i • v i = ∑ i ∉ t, f i • v i ∧ ∃ i, 0 < f i := by
+      ∑ i ∈ t, f i • v i = ∑ i ∉ t, f i • v i ∧ ∃ i ∈ t, 0 < f i := by
   simp only [linearIndependent_iffₒ, not_forall]
-  refine ⟨fun ⟨t, f, heq, i, hfi⟩ => ?_, fun ⟨t, f, heq, i, hfi⟩ =>
+  refine ⟨fun ⟨t, f, heq, i, hfi⟩ => ?_, fun ⟨t, f, heq, i, hi, hfi⟩ =>
     ⟨t, f, heq, i, pos_iff_ne_zero.1 hfi⟩⟩
   by_cases hi' : i ∈ t
-  · exact ⟨t, f, heq, i, pos_of_ne_zero hfi⟩
-  · refine ⟨tᶜ, f, ?_, i, pos_of_ne_zero hfi⟩
+  · exact ⟨t, f, heq, i, hi', pos_of_ne_zero hfi⟩
+  · refine ⟨tᶜ, f, ?_, i, Finset.mem_compl.2 hi', pos_of_ne_zero hfi⟩
     simp [heq]
 
 lemma linearIndepOn_finset_iffₒ [DecidableEq ι] {s : Finset ι} :

--- a/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
@@ -732,8 +732,7 @@ lemma linearIndepOn_finset_iffₒₛ [DecidableEq ι] {s : Finset ι} :
 lemma not_linearIndepOn_finset_iffₒₛ [DecidableEq ι] {s : Finset ι} :
     ¬LinearIndepOn R v s ↔ ∃ t ⊆ s, ∃ (f : ι → R),
       ∑ i ∈ t, f i • v i = ∑ i ∈ s \ t, f i • v i ∧ ∃ i ∈ t, 0 < f i := by
-  rw [linearIndepOn_finset_iffₒₛ]
-  simp only [not_forall]
+  simp only [linearIndepOn_finset_iffₒₛ, not_forall]
   refine ⟨fun ⟨t, hst, f, heq, i, hi, hfi⟩ => ?_,
     fun ⟨t, hst, f, heq, i, hi, hfi⟩ => ⟨t, hst, f, heq, i, hst hi, pos_iff_ne_zero.1 hfi⟩⟩
   by_cases hi' : i ∈ t

--- a/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
@@ -619,10 +619,10 @@ theorem LinearIndependent.maximal_iff {ι : Type w} {R : Type u} [Semiring R] [N
 end Maximal
 
 /-!
-### Properties which require `LinearOrder R`, `CanonicallyOrderedAdd R` and `OrderedSub R`
+### Properties which require `LinearOrder R` and `CanonicallyOrderedAdd R`
 
-If the semiring `R` is linearly and canonically ordered and admits ordered subtraction (e.g.
-`R = ℕ`), `LinearIndependent` can be proved from linear combination over two disjoint sets.
+If the semiring `R` is linearly and canonically ordered (e.g. `R = ℕ`), `LinearIndependent` can be
+proved from linear combination over two disjoint sets.
 -/
 
 section LinearlyCanonicallyOrdered

--- a/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
@@ -644,13 +644,10 @@ theorem linearIndependent_iffₒ :
       conv => rhs; rw [add_left_comm, ← Finset.sum_add_distrib]
       convert heq
         <;> simp_rw [← Finset.sum_filter_add_sum_filter_not s (fun i => g i ≤ f i), not_le]
-        <;> congr 1
-      · refine Finset.sum_congr rfl fun i hi => ?_
-        simp only [Finset.mem_filter] at hi
-        simp [← add_smul, tsub_add_cancel_of_le hi.2]
-      · refine Finset.sum_congr rfl fun i hi => ?_
-        simp only [Finset.mem_filter] at hi
-        simp [← add_smul, tsub_add_cancel_of_le hi.2.le]
+        <;> congr 1 <;> refine Finset.sum_congr rfl fun i hi => ?_
+        <;> simp only [Finset.mem_filter] at hi
+      · simp [← add_smul, tsub_add_cancel_of_le hi.2]
+      · simp [← add_smul, tsub_add_cancel_of_le hi.2.le]
     · intro i hi
       by_cases hi' : g i ≤ f i
       · exact hi'.antisymm' (tsub_eq_zero_iff_le.1 (h.1 i (Finset.mem_filter.2 ⟨hi, hi'⟩)))
@@ -703,7 +700,7 @@ lemma linearIndepOn_finset_iffₒ [DecidableEq ι] {s : Finset ι} :
         rw [← s.subtype_map_of_mem (fun x hx => hx), Finset.subtype_eq_univ.2 (fun x hx => hx)]
       erw [← Finset.map_sdiff]
       simpa [Embedding.subtype, -Finset.univ_eq_attach,
-        (Finset.inter_eq_right (t := .univ \ t₁)).2
+        (Finset.inter_eq_right (t := Finset.univ \ t₁)).2
           (Finset.subset_sdiff.2 ⟨t₂.subset_univ, ht₁t₂.symm⟩)] using heq
     · simp only [Finset.coe_sort_coe, Embedding.subtype, Finset.mem_map, Embedding.coeFn_mk,
         Subtype.exists, exists_and_right, exists_eq_right, dite_eq_right_iff, forall_exists_index,

--- a/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
@@ -673,14 +673,14 @@ theorem linearIndependent_iffₒₛ :
 theorem not_linearIndependent_iffₒₛ :
     ¬ LinearIndependent R v ↔
       ∃ (s t : Finset ι) (f : ι → R),
-        ∑ i ∈ s, f i • v i = ∑ i ∈ t, f i • v i ∧ Disjoint s t ∧ ∃ i ∈ s, 0 < f i := by
+        Disjoint s t ∧ ∑ i ∈ s, f i • v i = ∑ i ∈ t, f i • v i ∧ ∃ i ∈ s, 0 < f i := by
   simp only [linearIndependent_iffₒₛ, pos_iff_ne_zero]
   set_option push_neg.use_distrib true in push_neg
   refine ⟨fun ⟨s, t, f, hst, heq, h⟩ => ?_,
-    fun ⟨s, t, f, heq, hst, hi⟩ => ⟨s, t, f, hst, heq, .inl hi⟩⟩
+    fun ⟨s, t, f, hst, heq, hi⟩ => ⟨s, t, f, hst, heq, .inl hi⟩⟩
   rcases h with ⟨i, hi, hfi⟩ | ⟨i, hi, hgi⟩
-  · exact ⟨s, t, f, heq, hst, i, hi, hfi⟩
-  · exact ⟨t, s, f, heq.symm, hst.symm, i, hi, hgi⟩
+  · exact ⟨s, t, f, hst, heq, i, hi, hfi⟩
+  · exact ⟨t, s, f, hst.symm, heq.symm, i, hi, hgi⟩
 
 nonrec theorem Fintype.linearIndependent_iffₒₛ [DecidableEq ι] [Fintype ι] :
     LinearIndependent R v ↔ ∀ t, ∀ (f : ι → R),

--- a/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
@@ -693,7 +693,7 @@ nonrec theorem Fintype.linearIndependent_iffₒₛ [DecidableEq ι] [Fintype ι]
     · exact h.2 i (Finset.mem_compl.2 hi)
   · specialize h t₁ (fun i => if i ∈ t₁ ∨ i ∈ t₂ then f i else 0) ?_
     · rw [← Finset.sum_subset (ht₁t₂.le_compl_left)]
-      · convert heq using 1 <;> refine Finset.sum_congr rfl fun i hi => ?_ <;> simp [hi]
+      · convert heq using 2 with i hi i hi <;> simp [hi]
       · intro i hi hi'
         simp [Finset.mem_compl.1 hi, hi']
     refine ⟨fun i hi => ?_, fun i hi => ?_⟩ <;> simpa [hi] using h i

--- a/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
@@ -635,7 +635,7 @@ theorem linearIndependent_iffₒ :
         ∑ i ∈ s, f i • v i = ∑ i ∈ t, f i • v i → (∀ i ∈ s, f i = 0) ∧ ∀ i ∈ t, f i = 0 := by
   classical
   letI : Sub R := CanonicallyOrderedAdd.toSub
-  haveI : OrderedSub R := CanonicallyOrderedAdd.toSub.orderedSub
+  haveI : OrderedSub R := CanonicallyOrderedAdd.toOrderedSub
   rw [linearIndependent_iff'ₛ]
   refine ⟨fun h s t f hst heq => ?_, fun h s f g heq => ?_⟩
   · specialize h (s ∪ t) (fun i => if i ∈ s then f i else 0) (fun i => if i ∈ t then f i else 0) ?_

--- a/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
@@ -649,11 +649,12 @@ theorem linearIndependent_iffₒ :
       exact fun i ⟨_, hi⟩ ⟨_, hi'⟩ => hi.not_gt hi'
     · rw [← add_right_cancel_iff
         (a := ∑ i ∈ s with g i ≤ f i, g i • v i + ∑ i ∈ s with f i < g i, f i • v i)]
-      conv => lhs; rw [← add_assoc, ← Finset.sum_add_distrib]
-      conv => rhs; rw [add_left_comm, ← Finset.sum_add_distrib]
+      conv_lhs => rw [← add_assoc, ← Finset.sum_add_distrib]
+      conv_rhs => rw [add_left_comm, ← Finset.sum_add_distrib]
       convert heq
         <;> simp_rw [← Finset.sum_filter_add_sum_filter_not s (fun i => g i ≤ f i), not_le]
-        <;> congr 1 <;> refine Finset.sum_congr rfl fun i hi => ?_
+        <;> congr 1
+        <;> refine Finset.sum_congr rfl fun i hi => ?_
         <;> simp only [Finset.mem_filter] at hi
       · simp [hi.2, ← add_smul, tsub_add_cancel_of_le hi.2]
       · simp [hi.2.not_ge, ← add_smul, tsub_add_cancel_of_le hi.2.le]

--- a/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
@@ -3,8 +3,8 @@ Copyright (c) 2020 Anne Baanen. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Alexander Bentkamp, Anne Baanen
 -/
-import Mathlib.LinearAlgebra.Finsupp.LinearCombination
 import Mathlib.Algebra.Order.Sub.Basic
+import Mathlib.LinearAlgebra.Finsupp.LinearCombination
 import Mathlib.Lean.Expr.ExtraRecognizers
 
 /-!

--- a/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
@@ -692,7 +692,7 @@ nonrec theorem Fintype.linearIndependent_iffₒₛ [DecidableEq ι] [Fintype ι]
     · exact h.1 i hi
     · exact h.2 i (Finset.mem_compl.2 hi)
   · specialize h t₁ (fun i => if i ∈ t₁ ∨ i ∈ t₂ then f i else 0) ?_
-    · rw [← Finset.sum_subset (ht₁t₂.le_compl_left)]
+    · rw [← Finset.sum_subset ht₁t₂.le_compl_left]
       · convert heq using 2 with i hi i hi <;> simp [hi]
       · intro i hi hi'
         simp [Finset.mem_compl.1 hi, hi']

--- a/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Defs.lean
@@ -638,18 +638,19 @@ theorem linearIndependent_iffₒ :
   · specialize h (s.filter fun i => g i ≤ f i) (s.filter fun i => f i < g i) (f - g) (g - f) ?_ ?_
     · simp_rw [Finset.disjoint_left, Finset.mem_filter]
       exact fun i ⟨_, hi⟩ ⟨_, hi'⟩ => hi.not_gt hi'
-    · rw [←add_right_cancel_iff
+    · rw [← add_right_cancel_iff
         (a := ∑ i ∈ s with g i ≤ f i, g i • v i + ∑ i ∈ s with f i < g i, f i • v i)]
-      conv => lhs; rw [←add_assoc, ←Finset.sum_add_distrib]
-      conv => rhs; rw [add_left_comm, ←Finset.sum_add_distrib]
-      convert heq <;> simp_rw [←Finset.sum_filter_add_sum_filter_not s (fun i => g i ≤ f i), not_le]
+      conv => lhs; rw [← add_assoc, ← Finset.sum_add_distrib]
+      conv => rhs; rw [add_left_comm, ← Finset.sum_add_distrib]
+      convert heq
+        <;> simp_rw [← Finset.sum_filter_add_sum_filter_not s (fun i => g i ≤ f i), not_le]
         <;> congr 1
       · refine Finset.sum_congr rfl fun i hi => ?_
         simp only [Finset.mem_filter] at hi
-        simp [←add_smul, tsub_add_cancel_of_le hi.2]
+        simp [← add_smul, tsub_add_cancel_of_le hi.2]
       · refine Finset.sum_congr rfl fun i hi => ?_
         simp only [Finset.mem_filter] at hi
-        simp [←add_smul, tsub_add_cancel_of_le hi.2.le]
+        simp [← add_smul, tsub_add_cancel_of_le hi.2.le]
     · intro i hi
       by_cases hi' : g i ≤ f i
       · exact hi'.antisymm' (tsub_eq_zero_iff_le.1 (h.1 i (Finset.mem_filter.2 ⟨hi, hi'⟩)))


### PR DESCRIPTION
If the semiring `R` is linearly and canonically ordered (e.g. `R = ℕ`), `LinearIndependent` can be proved from linear combination over two disjoint sets.

This result is stronger than `linearIndependent_iff'ₛ` and is particularly useful in #27342.


---

- [x] depends on: #27340
- [x] depends on: #27639

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
