### PR TITLE
[Merged by Bors] - feat: `norm_num` extensions for Ordinals

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5945,6 +5945,7 @@ import Mathlib.Tactic.NormNum.NatFib
 import Mathlib.Tactic.NormNum.NatLog
 import Mathlib.Tactic.NormNum.NatSqrt
 import Mathlib.Tactic.NormNum.OfScientific
+import Mathlib.Tactic.NormNum.Ordinal
 import Mathlib.Tactic.NormNum.Pow
 import Mathlib.Tactic.NormNum.PowMod
 import Mathlib.Tactic.NormNum.Prime

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -197,6 +197,7 @@ import Mathlib.Tactic.NormNum.NatFib
 import Mathlib.Tactic.NormNum.NatLog
 import Mathlib.Tactic.NormNum.NatSqrt
 import Mathlib.Tactic.NormNum.OfScientific
+import Mathlib.Tactic.NormNum.Ordinal
 import Mathlib.Tactic.NormNum.Pow
 import Mathlib.Tactic.NormNum.PowMod
 import Mathlib.Tactic.NormNum.Prime

--- a/Mathlib/Tactic/NormNum/Ordinal.lean
+++ b/Mathlib/Tactic/NormNum/Ordinal.lean
@@ -19,8 +19,8 @@ We also define extensions for subtraction, multiplication, modulo, and power in 
 namespace Mathlib.Meta.NormNum
 open Lean Lean.Meta Qq Ordinal
 
-/- The `guard_msgs` in this file are for checking whether the current default extensions have been updated and
-the extensions in this file are no longer needed. -/
+/- The `guard_msgs` in this file are for checking whether the current default extensions have been
+updated and the extensions in this file are no longer needed. -/
 
 /-- info: 12 * 5 -/
 #guard_msgs in

--- a/Mathlib/Tactic/NormNum/Ordinal.lean
+++ b/Mathlib/Tactic/NormNum/Ordinal.lean
@@ -19,7 +19,7 @@ We also define extensions for subtraction, multiplication, modulo, and power in 
 namespace Mathlib.Meta.NormNum
 open Lean Lean.Meta Qq Ordinal
 
-/- These `guard_msgs` are for checking whether the current default extensions have been updated and
+/- The `guard_msgs` in this file are for checking whether the current default extensions have been updated and
 the extensions in this file are no longer needed. -/
 
 /-- info: 12 * 5 -/

--- a/Mathlib/Tactic/NormNum/Ordinal.lean
+++ b/Mathlib/Tactic/NormNum/Ordinal.lean
@@ -1,0 +1,205 @@
+/-
+Copyright (c) 2025 Miyahara Kō. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Miyahara Kō
+-/
+
+import Mathlib.SetTheory.Ordinal.Exponential
+import Mathlib.Tactic.NormNum.Basic
+
+/-!
+# `norm_num` extensions for Ordinals
+-/
+
+namespace Mathlib.Meta.NormNum
+open Lean Lean.Meta Qq Ordinal
+
+/-!
+The default `norm_num` extentions for multiplication & inequality requires to be semiring,
+so doesn't normalize ordinals that doesn't satisfy right distributive low.
+We require new extensions for them.
+-/
+
+/-- info: 12 * 5 -/
+#guard_msgs in
+#norm_num (12 : Ordinal.{0}) * (5 : Ordinal.{0})
+
+/-- info: 5 < 12 -/
+#guard_msgs in
+#norm_num (5 : Ordinal.{0}) < 12
+
+lemma isNat_ordinalMul.{u} : ∀ {a b : Ordinal.{u}} {an bn rn : ℕ},
+    IsNat a an → IsNat b bn → an * bn = rn → IsNat (a * b) rn
+  | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, rfl => ⟨Eq.symm <| natCast_mul ..⟩
+
+/-- The `norm_num` extension for multiplication on ordinals. -/
+@[norm_num (_ : Ordinal) * (_ : Ordinal)]
+def evalOrdinalMul : NormNumExt where
+  eval {u α} e := do
+    let some u' := u.dec | throwError "level is not succ"
+    haveI' : u =QL u' + 1 := ⟨⟩
+    match α, e with
+    | ~q(Ordinal.{u'}), ~q(($a : Ordinal) * ($b : Ordinal)) =>
+      let i : Q(AddMonoidWithOne Ordinal.{u'}) := q(inferInstance)
+      let ⟨an, pa⟩ ← deriveNat a i
+      let ⟨bn, pb⟩ ← deriveNat b i
+      have rn : Q(ℕ) := mkRawNatLit (an.natLit! * bn.natLit!)
+      have : ($an * $bn) =Q $rn := ⟨⟩
+      pure (.isNat i rn q(isNat_ordinalMul $pa $pb (.refl $rn)))
+    | _, _ => throwError "not multiplication on ordinals"
+
+lemma isNat_ordinalLE_true.{u} : ∀ {a b : Ordinal.{u}} {an bn : ℕ},
+    IsNat a an → IsNat b bn → decide (an ≤ bn) = true → a ≤ b
+  | _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, h => Nat.cast_le.mpr <| of_decide_eq_true h
+
+lemma isNat_ordinalLE_false.{u} : ∀ {a b : Ordinal.{u}} {an bn : ℕ},
+    IsNat a an → IsNat b bn → decide (an ≤ bn) = false → ¬a ≤ b
+  | _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, h => not_iff_not.mpr Nat.cast_le |>.mpr <| of_decide_eq_false h
+
+lemma isNat_ordinalLT_true.{u} : ∀ {a b : Ordinal.{u}} {an bn : ℕ},
+    IsNat a an → IsNat b bn → decide (an < bn) = true → a < b
+  | _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, h => Nat.cast_lt.mpr <| of_decide_eq_true h
+
+lemma isNat_ordinalLT_false.{u} : ∀ {a b : Ordinal.{u}} {an bn : ℕ},
+    IsNat a an → IsNat b bn → decide (an < bn) = false → ¬a < b
+  | _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, h => not_iff_not.mpr Nat.cast_lt |>.mpr <| of_decide_eq_false h
+
+/-- The `norm_num` extension for inequality on ordinals. -/
+@[norm_num (_ : Ordinal) ≤ (_ : Ordinal)]
+def evalOrdinalLE : NormNumExt where
+  eval {u α} e := do
+    unless u.isEquiv ql(0) do throwError "level is not zero"
+    haveI' : u =QL 0 := ⟨⟩
+    match α, e with
+    | ~q(Prop), ~q(($a : Ordinal) ≤ ($b : Ordinal)) =>
+      let i : Q(AddMonoidWithOne Ordinal.{u_1}) := q(inferInstance)
+      let ⟨an, pa⟩ ← deriveNat a i
+      let ⟨bn, pb⟩ ← deriveNat b i
+      if an.natLit! ≤ bn.natLit! then
+        have this : decide ($an ≤ $bn) =Q true := ⟨⟩
+        pure (.isTrue q(isNat_ordinalLE_true $pa $pb $this))
+      else
+        have this : decide ($an ≤ $bn) =Q false := ⟨⟩
+        pure (.isFalse q(isNat_ordinalLE_false $pa $pb $this))
+    | _, _ => throwError "not inequality on ordinals"
+
+/-- The `norm_num` extension for strict inequality on ordinals. -/
+@[norm_num (_ : Ordinal) < (_ : Ordinal)]
+def evalOrdinalLT : NormNumExt where
+  eval {u α} e := do
+    unless u.isEquiv ql(0) do throwError "level is not zero"
+    haveI' : u =QL 0 := ⟨⟩
+    match α, e with
+    | ~q(Prop), ~q(($a : Ordinal) < ($b : Ordinal)) =>
+      let i : Q(AddMonoidWithOne Ordinal.{u_1}) := q(inferInstance)
+      let ⟨an, pa⟩ ← deriveNat a i
+      let ⟨bn, pb⟩ ← deriveNat b i
+      if an.natLit! < bn.natLit! then
+        have this : decide ($an < $bn) =Q true := ⟨⟩
+        pure (.isTrue q(isNat_ordinalLT_true $pa $pb $this))
+      else
+        have this : decide ($an < $bn) =Q false := ⟨⟩
+        pure (.isFalse q(isNat_ordinalLT_false $pa $pb $this))
+    | _, _ => throwError "not strict inequality on ordinals"
+
+lemma isNat_ordinalSub.{u} : ∀ {a b : Ordinal.{u}} {an bn rn : ℕ},
+    IsNat a an → IsNat b bn → an - bn = rn → IsNat (a - b) rn
+  | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, rfl => ⟨Eq.symm <| natCast_sub ..⟩
+
+/-- The `norm_num` extension for subtration on ordinals. -/
+@[norm_num (_ : Ordinal) - (_ : Ordinal)]
+def evalOrdinalSub : NormNumExt where
+  eval {u α} e := do
+    let some u' := u.dec | throwError "level is not succ"
+    haveI' : u =QL u' + 1 := ⟨⟩
+    match α, e with
+    | ~q(Ordinal.{u'}), ~q(($a : Ordinal) - ($b : Ordinal)) =>
+      let i : Q(AddMonoidWithOne Ordinal.{u'}) := q(inferInstance)
+      let ⟨an, pa⟩ ← deriveNat a i
+      let ⟨bn, pb⟩ ← deriveNat b i
+      have rn : Q(ℕ) := mkRawNatLit (an.natLit! - bn.natLit!)
+      have : ($an - $bn) =Q $rn := ⟨⟩
+      pure (.isNat i rn q(isNat_ordinalSub $pa $pb (.refl $rn)))
+    | _, _ => throwError "not subtration on ordinals"
+
+lemma isNat_ordinalDiv.{u} : ∀ {a b : Ordinal.{u}} {an bn rn : ℕ},
+    IsNat a an → IsNat b bn → an / bn = rn → IsNat (a / b) rn
+  | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, rfl => ⟨Eq.symm <| natCast_div ..⟩
+
+/-- The `norm_num` extension for division on ordinals. -/
+@[norm_num (_ : Ordinal) / (_ : Ordinal)]
+def evalOrdinalDiv : NormNumExt where
+  eval {u α} e := do
+    let some u' := u.dec | throwError "level is not succ"
+    haveI' : u =QL u' + 1 := ⟨⟩
+    match α, e with
+    | ~q(Ordinal.{u'}), ~q(($a : Ordinal) / ($b : Ordinal)) =>
+      let i : Q(AddMonoidWithOne Ordinal.{u'}) := q(inferInstance)
+      let ⟨an, pa⟩ ← deriveNat a i
+      let ⟨bn, pb⟩ ← deriveNat b i
+      have rn : Q(ℕ) := mkRawNatLit (an.natLit! / bn.natLit!)
+      have : ($an / $bn) =Q $rn := ⟨⟩
+      pure (.isNat i rn q(isNat_ordinalDiv $pa $pb (.refl $rn)))
+    | _, _ => throwError "not division on ordinals"
+
+lemma isNat_ordinalMod.{u} : ∀ {a b : Ordinal.{u}} {an bn rn : ℕ},
+    IsNat a an → IsNat b bn → an % bn = rn → IsNat (a % b) rn
+  | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, rfl => ⟨Eq.symm <| natCast_mod ..⟩
+
+/-- The `norm_num` extension for modulo on ordinals. -/
+@[norm_num (_ : Ordinal) % (_ : Ordinal)]
+def evalOrdinalMod : NormNumExt where
+  eval {u α} e := do
+    let some u' := u.dec | throwError "level is not succ"
+    haveI' : u =QL u' + 1 := ⟨⟩
+    match α, e with
+    | ~q(Ordinal.{u'}), ~q(($a : Ordinal) % ($b : Ordinal)) =>
+      let i : Q(AddMonoidWithOne Ordinal.{u'}) := q(inferInstance)
+      let ⟨an, pa⟩ ← deriveNat a i
+      let ⟨bn, pb⟩ ← deriveNat b i
+      have rn : Q(ℕ) := mkRawNatLit (an.natLit! % bn.natLit!)
+      have : ($an % $bn) =Q $rn := ⟨⟩
+      pure (.isNat i rn q(isNat_ordinalMod $pa $pb (.refl $rn)))
+    | _, _ => throwError "not modulo on ordinals"
+
+lemma isNat_ordinalOPow.{u} : ∀ {a b : Ordinal.{u}} {an bn rn : ℕ},
+    IsNat a an → IsNat b bn → an ^ bn = rn → IsNat (a ^ b) rn
+  | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, rfl => ⟨Eq.symm <| natCast_opow ..⟩
+
+/-- The `norm_num` extension for homogenous power on ordinals. -/
+@[norm_num (_ : Ordinal) ^ (_ : Ordinal)]
+def evalOrdinalOPow : NormNumExt where
+  eval {u α} e := do
+    let some u' := u.dec | throwError "level is not succ"
+    haveI' : u =QL u' + 1 := ⟨⟩
+    match α, e with
+    | ~q(Ordinal.{u'}), ~q(($a : Ordinal) ^ ($b : Ordinal)) =>
+      let i : Q(AddMonoidWithOne Ordinal.{u'}) := q(inferInstance)
+      let ⟨an, pa⟩ ← deriveNat a i
+      let ⟨bn, pb⟩ ← deriveNat b i
+      have rn : Q(ℕ) := mkRawNatLit (an.natLit! ^ bn.natLit!)
+      have : ($an ^ $bn) =Q $rn := ⟨⟩
+      pure (.isNat i rn q(isNat_ordinalOPow $pa $pb (.refl $rn)))
+    | _, _ => throwError "not homogenous power on ordinals"
+
+lemma isNat_ordinalNPow.{u} : ∀ {a : Ordinal.{u}} {b an bn rn : ℕ},
+    IsNat a an → IsNat b bn → an ^ bn = rn → IsNat (a ^ b) rn
+  | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, rfl => ⟨Eq.symm <| natCast_opow .. |>.trans <| opow_natCast ..⟩
+
+/-- The `norm_num` extension for natural power on ordinals. -/
+@[norm_num (_ : Ordinal) ^ (_ : ℕ)]
+def evalOrdinalNPow : NormNumExt where
+  eval {u α} e := do
+    let some u' := u.dec | throwError "level is not succ"
+    haveI' : u =QL u' + 1 := ⟨⟩
+    match α, e with
+    | ~q(Ordinal.{u'}), ~q(($a : Ordinal) ^ ($b : ℕ)) =>
+      let i : Q(AddMonoidWithOne Ordinal.{u'}) := q(inferInstance)
+      let ⟨an, pa⟩ ← deriveNat a i
+      let ⟨bn, pb⟩ ← deriveNat b q(inferInstance)
+      have rn : Q(ℕ) := mkRawNatLit (an.natLit! ^ bn.natLit!)
+      have : ($an ^ $bn) =Q $rn := ⟨⟩
+      pure (.isNat i rn q(isNat_ordinalNPow $pa $pb (.refl $rn)))
+    | _, _ => throwError "not natural power on ordinals"
+
+end Mathlib.Meta.NormNum

--- a/Mathlib/Tactic/NormNum/Ordinal.lean
+++ b/Mathlib/Tactic/NormNum/Ordinal.lean
@@ -9,16 +9,18 @@ import Mathlib.Tactic.NormNum.Basic
 
 /-!
 # `norm_num` extensions for Ordinals
+
+The default `norm_num` extensions for multiplication & inequality requires to be semiring,
+so doesn't normalize ordinals that doesn't satisfy right distributive low.
+We require new extensions for them.
+We also define extensions for subtraction, multiplication, modulo, and power in this file.
 -/
 
 namespace Mathlib.Meta.NormNum
 open Lean Lean.Meta Qq Ordinal
 
-/-!
-The default `norm_num` extentions for multiplication & inequality requires to be semiring,
-so doesn't normalize ordinals that doesn't satisfy right distributive low.
-We require new extensions for them.
--/
+/- These `guard_msgs` are for checking whether the current default extensions have been updated and
+the extensions in this file are no longer needed. -/
 
 /-- info: 12 * 5 -/
 #guard_msgs in
@@ -68,8 +70,7 @@ lemma isNat_ordinalLT_false.{u} : ∀ {a b : Ordinal.{u}} {an bn : ℕ},
 @[norm_num (_ : Ordinal) ≤ (_ : Ordinal)]
 def evalOrdinalLE : NormNumExt where
   eval {u α} e := do
-    unless u.isEquiv ql(0) do throwError "level is not zero"
-    haveI' : u =QL 0 := ⟨⟩
+    let ⟨_⟩ ← assertLevelDefEqQ u ql(0)
     match α, e with
     | ~q(Prop), ~q(($a : Ordinal) ≤ ($b : Ordinal)) =>
       let i : Q(AddMonoidWithOne Ordinal.{u_1}) := q(inferInstance)
@@ -87,8 +88,7 @@ def evalOrdinalLE : NormNumExt where
 @[norm_num (_ : Ordinal) < (_ : Ordinal)]
 def evalOrdinalLT : NormNumExt where
   eval {u α} e := do
-    unless u.isEquiv ql(0) do throwError "level is not zero"
-    haveI' : u =QL 0 := ⟨⟩
+    let ⟨_⟩ ← assertLevelDefEqQ u ql(0)
     match α, e with
     | ~q(Prop), ~q(($a : Ordinal) < ($b : Ordinal)) =>
       let i : Q(AddMonoidWithOne Ordinal.{u_1}) := q(inferInstance)

--- a/Mathlib/Tactic/NormNum/Ordinal.lean
+++ b/Mathlib/Tactic/NormNum/Ordinal.lean
@@ -10,10 +10,10 @@ import Mathlib.Tactic.NormNum.Basic
 /-!
 # `norm_num` extensions for Ordinals
 
-The default `norm_num` extensions for multiplication & inequality requires to be semiring,
-so doesn't normalize ordinals that doesn't satisfy right distributive low.
-We require new extensions for them.
-We also define extensions for subtraction, multiplication, modulo, and power in this file.
+The default `norm_num` extensions for many operators requires a semiring,
+which without a right distributive law, ordinals do not have.
+
+We must therefore define new extensions for them.
 -/
 
 namespace Mathlib.Meta.NormNum

--- a/Mathlib/Tactic/NormNum/Ordinal.lean
+++ b/Mathlib/Tactic/NormNum/Ordinal.lean
@@ -26,10 +26,6 @@ the extensions in this file are no longer needed. -/
 #guard_msgs in
 #norm_num (12 : Ordinal.{0}) * (5 : Ordinal.{0})
 
-/-- info: 5 < 12 -/
-#guard_msgs in
-#norm_num (5 : Ordinal.{0}) < 12
-
 lemma isNat_ordinalMul.{u} : ∀ {a b : Ordinal.{u}} {an bn rn : ℕ},
     IsNat a an → IsNat b bn → an * bn = rn → IsNat (a * b) rn
   | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, rfl => ⟨Eq.symm <| natCast_mul ..⟩
@@ -49,6 +45,14 @@ def evalOrdinalMul : NormNumExt where
       have : ($an * $bn) =Q $rn := ⟨⟩
       pure (.isNat i rn q(isNat_ordinalMul $pa $pb (.refl $rn)))
     | _, _ => throwError "not multiplication on ordinals"
+
+/-- info: 5 ≤ 12 -/
+#guard_msgs in
+#norm_num (5 : Ordinal.{0}) ≤ 12
+
+/-- info: 5 < 12 -/
+#guard_msgs in
+#norm_num (5 : Ordinal.{0}) < 12
 
 lemma isNat_ordinalLE_true.{u} : ∀ {a b : Ordinal.{u}} {an bn : ℕ},
     IsNat a an → IsNat b bn → decide (an ≤ bn) = true → a ≤ b
@@ -102,6 +106,10 @@ def evalOrdinalLT : NormNumExt where
         pure (.isFalse q(isNat_ordinalLT_false $pa $pb $this))
     | _, _ => throwError "not strict inequality on ordinals"
 
+/-- info: 12 - 5 -/
+#guard_msgs in
+#norm_num (12 : Ordinal.{0}) - 5
+
 lemma isNat_ordinalSub.{u} : ∀ {a b : Ordinal.{u}} {an bn rn : ℕ},
     IsNat a an → IsNat b bn → an - bn = rn → IsNat (a - b) rn
   | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, rfl => ⟨Eq.symm <| natCast_sub ..⟩
@@ -122,6 +130,10 @@ def evalOrdinalSub : NormNumExt where
       pure (.isNat i rn q(isNat_ordinalSub $pa $pb (.refl $rn)))
     | _, _ => throwError "not subtration on ordinals"
 
+/-- info: 12 / 5 -/
+#guard_msgs in
+#norm_num (12 : Ordinal.{0}) / 5
+
 lemma isNat_ordinalDiv.{u} : ∀ {a b : Ordinal.{u}} {an bn rn : ℕ},
     IsNat a an → IsNat b bn → an / bn = rn → IsNat (a / b) rn
   | _, _, _, _, _, ⟨rfl⟩, ⟨rfl⟩, rfl => ⟨Eq.symm <| natCast_div ..⟩
@@ -141,6 +153,10 @@ def evalOrdinalDiv : NormNumExt where
       have : ($an / $bn) =Q $rn := ⟨⟩
       pure (.isNat i rn q(isNat_ordinalDiv $pa $pb (.refl $rn)))
     | _, _ => throwError "not division on ordinals"
+
+/-- info: 12 % 5 -/
+#guard_msgs in
+#norm_num (12 : Ordinal.{0}) % 5
 
 lemma isNat_ordinalMod.{u} : ∀ {a b : Ordinal.{u}} {an bn rn : ℕ},
     IsNat a an → IsNat b bn → an % bn = rn → IsNat (a % b) rn
@@ -181,6 +197,10 @@ def evalOrdinalOPow : NormNumExt where
       have : ($an ^ $bn) =Q $rn := ⟨⟩
       pure (.isNat i rn q(isNat_ordinalOPow $pa $pb (.refl $rn)))
     | _, _ => throwError "not homogenous power on ordinals"
+
+/-- info: 12 ^ 2 -/
+#guard_msgs in
+#norm_num (12 : Ordinal.{0}) ^ (2 : ℕ)
 
 lemma isNat_ordinalNPow.{u} : ∀ {a : Ordinal.{u}} {b an bn rn : ℕ},
     IsNat a an → IsNat b bn → an ^ bn = rn → IsNat (a ^ b) rn

--- a/MathlibTest/norm_num_ordinal.lean
+++ b/MathlibTest/norm_num_ordinal.lean
@@ -1,0 +1,10 @@
+import Mathlib.Tactic.NormNum.Ordinal
+
+universe u
+
+example : (2 : Ordinal.{0}) * 3 + 4 = 10 := by norm_num
+
+example : ¬(15 : Ordinal.{4}) / 4 % 34 < 3 := by norm_num
+
+example : (12 : Ordinal.{u}) ^ (2 : Ordinal.{u}) ^ (2 : ℕ) ≤
+    (12 : Ordinal.{u}) ^ (2 : Ordinal.{u}) ^ (2 : ℕ) := by norm_num


### PR DESCRIPTION
---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
