### PR TITLE
[Merged by Bors] - feat: sum of a locally finite collection of C^n sections is C^n

### DIFF
--- a/Mathlib/Geometry/Manifold/VectorBundle/SmoothSection.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/SmoothSection.lean
@@ -182,7 +182,9 @@ lemma ContMDiff.const_smul_section
     ContMDiff I (I.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (a • s x)) :=
   fun x₀ ↦ (hs x₀).const_smul_section
 
-lemma ContMDiffWithinAt.sum_section {ι : Type*} {s : Finset ι} {t : ι → (x : M) → V x}
+variable {ι : Type*} {t : ι → (x : M) → V x}
+
+lemma ContMDiffWithinAt.sum_section {s : Finset ι}
     (hs : ∀ i ∈ s,
       ContMDiffWithinAt I (I.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (t i x)) u x₀) :
     ContMDiffWithinAt I (I.prod 𝓘(𝕜, F)) n
@@ -196,18 +198,18 @@ lemma ContMDiffWithinAt.sum_section {ι : Type*} {s : Finset ι} {t : ι → (x 
     apply (hs _ (s.mem_insert_self i)).add_section
     exact h fun i a ↦ hs _ (s.mem_insert_of_mem a)
 
-lemma ContMDiffAt.sum_section {ι : Type*} {s : Finset ι} {t : ι → (x : M) → V x} {x₀ : M}
+lemma ContMDiffAt.sum_section {s : Finset ι} {x₀ : M}
     (hs : ∀ i ∈ s, ContMDiffAt I (I.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (t i x)) x₀) :
     ContMDiffAt I (I.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (∑ i ∈ s, (t i x))) x₀ := by
   simp_rw [← contMDiffWithinAt_univ] at hs ⊢
   exact .sum_section hs
 
-lemma ContMDiffOn.sum_section {ι : Type*} {s : Finset ι} {t : ι → (x : M) → V x}
+lemma ContMDiffOn.sum_section {s : Finset ι}
     (hs : ∀ i ∈ s, ContMDiffOn I (I.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (t i x)) u) :
     ContMDiffOn I (I.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (∑ i ∈ s, (t i x))) u :=
   fun x₀ hx₀ ↦ .sum_section fun i hi ↦ hs i hi x₀ hx₀
 
-lemma ContMDiff.sum_section {ι : Type*} {s : Finset ι} {t : ι → (x : M) → V x}
+lemma ContMDiff.sum_section {s : Finset ι}
     (hs : ∀ i ∈ s, ContMDiff I (I.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (t i x))) :
     ContMDiff I (I.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (∑ i ∈ s, (t i x))) :=
   fun x₀ ↦ .sum_section fun i hi ↦ (hs i hi) x₀
@@ -229,7 +231,7 @@ lemma ContMDiffOn.smul_section_of_tsupport {s : Π (x : M), V x} {ψ : M → �
 
 /-- The sum of a locally finite collection of sections is `C^k` iff each section is.
 Version at a point within a set. -/
-lemma ContMDiffWithinAt.sum_section_of_locallyFinite {ι : Type*} {t : ι → (x : M) → V x}
+lemma ContMDiffWithinAt.sum_section_of_locallyFinite
     (ht : LocallyFinite fun i ↦ {x : M | t i x ≠ 0})
     (ht' : ∀ i, ContMDiffWithinAt I (I.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (t i x)) u x₀) :
     ContMDiffWithinAt I (I.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (∑' i, (t i x))) u x₀ := by
@@ -263,23 +265,21 @@ lemma ContMDiffWithinAt.sum_section_of_locallyFinite {ι : Type*} {t : ι → (x
   exact hi this
 
 /-- The sum of a locally finite collection of sections is `C^k` at `x` iff each section is. -/
-lemma ContMDiffAt.sum_section_of_locallyFinite {ι : Type*} {t : ι → (x : M) → V x}
-    (ht : LocallyFinite fun i ↦ {x : M | t i x ≠ 0})
+lemma ContMDiffAt.sum_section_of_locallyFinite (ht : LocallyFinite fun i ↦ {x : M | t i x ≠ 0})
     (ht' : ∀ i, ContMDiffAt I (I.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (t i x)) x₀) :
     ContMDiffAt I (I.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (∑' i, (t i x))) x₀ := by
   simp_rw [← contMDiffWithinAt_univ] at ht' ⊢
   exact .sum_section_of_locallyFinite ht ht'
 
 /-- The sum of a locally finite collection of sections is `C^k` on a set `u` iff each section is. -/
-lemma ContMDiffOn.sum_section_of_locallyFinite {ι : Type*} {t : ι → (x : M) → V x} {u : Set M}
+lemma ContMDiffOn.sum_section_of_locallyFinite {u : Set M}
     (ht : LocallyFinite fun i ↦ {x : M | t i x ≠ 0})
     (ht' : ∀ i, ContMDiffOn I (I.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (t i x)) u) :
     ContMDiffOn I (I.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (∑' i, (t i x))) u :=
   fun x hx ↦ .sum_section_of_locallyFinite ht (ht' · x hx)
 
 /-- The sum of a locally finite collection of sections is `C^k` iff each section is. -/
-lemma ContMDiff.sum_section_of_locallyFinite {ι : Type*} {t : ι → (x : M) → V x}
-    (ht : LocallyFinite fun i ↦ {x : M | t i x ≠ 0})
+lemma ContMDiff.sum_section_of_locallyFinite (ht : LocallyFinite fun i ↦ {x : M | t i x ≠ 0})
     (ht' : ∀ i, ContMDiff I (I.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (t i x))) :
     ContMDiff I (I.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (∑' i, (t i x))) :=
   fun x ↦ .sum_section_of_locallyFinite ht fun i ↦ ht' i x

--- a/Mathlib/Geometry/Manifold/VectorBundle/SmoothSection.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/SmoothSection.lean
@@ -227,6 +227,63 @@ lemma ContMDiffOn.smul_section_of_tsupport {s : Π (x : M), V x} {ψ : M → �
     simp [image_eq_zero_of_notMem_tsupport hy, zeroSection]
   · exact Set.compl_subset_iff_union.mp <| Set.compl_subset_compl.mpr ht'
 
+/-- The sum of a locally finite collection of sections is `C^k` iff each section is.
+Version at a point within a set. -/
+lemma ContMDiffWithinAt.sum_section_of_locallyFinite {ι : Type*} {t : ι → (x : M) → V x}
+    (ht : LocallyFinite fun i ↦ {x : M | t i x ≠ 0})
+    (ht' : ∀ i, ContMDiffWithinAt I (I.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (t i x)) u x₀) :
+    ContMDiffWithinAt I (I.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (∑' i, (t i x))) u x₀ := by
+  obtain ⟨u', hu', hfin⟩ := ht x₀
+  -- All sections `t i` but a finite set `s` vanish near `x₀`: choose a neighbourhood `u` of `x₀`
+  -- and a finite set `s` of sections which don't vanish.
+  let s := {i | ((fun i ↦ {x | t i x ≠ 0}) i ∩ u').Nonempty}
+  have := hfin.fintype
+  have : ContMDiffWithinAt I (I.prod 𝓘(𝕜, F)) n
+      (fun x ↦ TotalSpace.mk' F x (∑ i ∈ s, (t i x))) (u ∩ u') x₀ :=
+    ContMDiffWithinAt.sum_section fun i hi ↦ ((ht' i).mono Set.inter_subset_left)
+  apply (contMDiffWithinAt_inter hu').mp
+  apply this.congr fun y hy ↦ ?_
+  · rw [TotalSpace.mk_inj, tsum_eq_sum']
+    refine support_subset_iff'.mpr fun i hi ↦ ?_
+    by_contra! h
+    have : i ∈ s.toFinset := by
+      refine Set.mem_toFinset.mpr ?_
+      simp only [s, ne_eq, Set.mem_setOf_eq]
+      use x₀
+      simpa using ⟨h, mem_of_mem_nhds hu'⟩
+    exact hi this
+  rw [TotalSpace.mk_inj, tsum_eq_sum']
+  refine support_subset_iff'.mpr fun i hi ↦ ?_
+  by_contra! h
+  have : i ∈ s.toFinset := by
+    refine Set.mem_toFinset.mpr ?_
+    simp only [s, ne_eq, Set.mem_setOf_eq]
+    use y
+    simpa using ⟨h, Set.mem_of_mem_inter_right hy⟩
+  exact hi this
+
+/-- The sum of a locally finite collection of sections is `C^k` at `x` iff each section is. -/
+lemma ContMDiffAt.sum_section_of_locallyFinite {ι : Type*} {t : ι → (x : M) → V x}
+    (ht : LocallyFinite fun i ↦ {x : M | t i x ≠ 0})
+    (ht' : ∀ i, ContMDiffAt I (I.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (t i x)) x₀) :
+    ContMDiffAt I (I.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (∑' i, (t i x))) x₀ := by
+  simp_rw [← contMDiffWithinAt_univ] at ht' ⊢
+  exact .sum_section_of_locallyFinite ht ht'
+
+/-- The sum of a locally finite collection of sections is `C^k` on a set `u` iff each section is. -/
+lemma ContMDiffOn.sum_section_of_locallyFinite {ι : Type*} {t : ι → (x : M) → V x} {u : Set M}
+    (ht : LocallyFinite fun i ↦ {x : M | t i x ≠ 0})
+    (ht' : ∀ i, ContMDiffOn I (I.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (t i x)) u) :
+    ContMDiffOn I (I.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (∑' i, (t i x))) u :=
+  fun x hx ↦ .sum_section_of_locallyFinite ht (ht' · x hx)
+
+/-- The sum of a locally finite collection of sections is `C^k` iff each section is. -/
+lemma ContMDiff.sum_section_of_locallyFinite {ι : Type*} {t : ι → (x : M) → V x}
+    (ht : LocallyFinite fun i ↦ {x : M | t i x ≠ 0})
+    (ht' : ∀ i, ContMDiff I (I.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (t i x))) :
+    ContMDiff I (I.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (∑' i, (t i x))) :=
+  fun x ↦ .sum_section_of_locallyFinite ht fun i ↦ ht' i x
+
 end operations
 
 /-- Bundled `n` times continuously differentiable sections of a vector bundle.

--- a/Mathlib/Geometry/Manifold/VectorBundle/SmoothSection.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/SmoothSection.lean
@@ -218,7 +218,7 @@ lemma ContMDiff.sum_section {s : Finset ι}
 bundle `V → M` is `C^k` once `s` is `C^k` on an open set containing `tsupport ψ` .
 
 This is a vector bundle analogue of `contMDiff_of_tsupport`. -/
-lemma ContMDiffOn.smul_section_of_tsupport {s : Π (x : M), V x} {ψ : M → 𝕜} {u : Set M}
+lemma ContMDiffOn.smul_section_of_tsupport {s : Π (x : M), V x} {ψ : M → 𝕜}
     (hψ : ContMDiffOn I 𝓘(𝕜) n ψ u) (ht : IsOpen u) (ht' : tsupport ψ ⊆ u)
     (hs : ContMDiffOn I (I.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (s x)) u) :
     ContMDiff I (I.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (ψ x • s x)) := by
@@ -272,8 +272,7 @@ lemma ContMDiffAt.sum_section_of_locallyFinite (ht : LocallyFinite fun i ↦ {x 
   exact .sum_section_of_locallyFinite ht ht'
 
 /-- The sum of a locally finite collection of sections is `C^k` on a set `u` iff each section is. -/
-lemma ContMDiffOn.sum_section_of_locallyFinite {u : Set M}
-    (ht : LocallyFinite fun i ↦ {x : M | t i x ≠ 0})
+lemma ContMDiffOn.sum_section_of_locallyFinite (ht : LocallyFinite fun i ↦ {x : M | t i x ≠ 0})
     (ht' : ∀ i, ContMDiffOn I (I.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (t i x)) u) :
     ContMDiffOn I (I.prod 𝓘(𝕜, F)) n (fun x ↦ TotalSpace.mk' F x (∑' i, (t i x))) u :=
   fun x hx ↦ .sum_section_of_locallyFinite ht (ht' · x hx)


### PR DESCRIPTION
This can be used to golf #26875 (and is nice API anyway).
As such, it is necessary to prove the existence of a Riemannian metric (hence of a Levi-Civita connection).
One could say it's on the path towards the Levi-Civita connection.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
