### PR TITLE
[Merged by Bors] - chore(*): turn `set_option simprocs false` into `simp [-...]`

### DIFF
--- a/Counterexamples/CharPZeroNeCharZero.lean
+++ b/Counterexamples/CharPZeroNeCharZero.lean
@@ -30,6 +30,6 @@ theorem withZero_unit_charP_zero : CharP (WithZero Unit) 0 :=
   ⟨fun x => by cases x <;> simp⟩
 
 theorem withZero_unit_not_charZero : ¬CharZero (WithZero Unit) := fun ⟨h⟩ =>
-  h.ne (by simp : 1 + 1 ≠ 0 + 1) (by set_option simprocs false in simp)
+  h.ne (by simp : 1 + 1 ≠ 0 + 1) (by simp [-Nat.reduceAdd])
 
 end Counterexample

--- a/Mathlib/Algebra/Homology/ExactSequence.lean
+++ b/Mathlib/Algebra/Homology/ExactSequence.lean
@@ -207,15 +207,10 @@ lemma isComplex₂_mk (S : ComposableArrows C 2) (w : S.map' 0 1 ≫ S.map' 1 2 
     S.IsComplex :=
   S.isComplex₂_iff.2 w
 
-#adaptation_note /-- nightly-2024-03-11
-We turn off simprocs here.
-Ideally someone will investigate whether `simp` lemmas can be rearranged
-so that this works without the `set_option`,
-*or* come up with a proposal regarding finer control of disabling simprocs. -/
-set_option simprocs false in
 lemma _root_.CategoryTheory.ShortComplex.isComplex_toComposableArrows (S : ShortComplex C) :
     S.toComposableArrows.IsComplex :=
-  isComplex₂_mk _ (by simp)
+  -- Disable `Fin.reduceFinMk` because otherwise `Precompose.map_one_succ` does not apply.
+  isComplex₂_mk _ (by simp [-Fin.reduceFinMk])
 
 lemma exact₂_iff (S : ComposableArrows C 2) (hS : S.IsComplex) :
     S.Exact ↔ (S.sc' hS 0 1 2).Exact := by

--- a/Mathlib/Algebra/Homology/ExactSequence.lean
+++ b/Mathlib/Algebra/Homology/ExactSequence.lean
@@ -209,7 +209,7 @@ lemma isComplex₂_mk (S : ComposableArrows C 2) (w : S.map' 0 1 ≫ S.map' 1 2 
 
 lemma _root_.CategoryTheory.ShortComplex.isComplex_toComposableArrows (S : ShortComplex C) :
     S.toComposableArrows.IsComplex :=
-  -- Disable `Fin.reduceFinMk` because otherwise `Precompose.map_one_succ` does not apply.
+  -- Disable `Fin.reduceFinMk` because otherwise `Precompose.map_one_succ` does not apply. (#27382)
   isComplex₂_mk _ (by simp [-Fin.reduceFinMk])
 
 lemma exact₂_iff (S : ComposableArrows C 2) (hS : S.IsComplex) :

--- a/Mathlib/Algebra/Homology/HomologySequence.lean
+++ b/Mathlib/Algebra/Homology/HomologySequence.lean
@@ -110,15 +110,10 @@ instance [K.HasHomology i] [K.HasHomology j] :
   dsimp
   infer_instance
 
-#adaptation_note /-- nightly-2024-03-11
-We turn off simprocs here.
-Ideally someone will investigate whether `simp` lemmas can be rearranged
-so that this works without the `set_option`,
-*or* come up with a proposal regarding finer control of disabling simprocs. -/
-set_option simprocs false in
 instance [K.HasHomology i] [K.HasHomology j] :
     Epi ((composableArrows₃ K i j).map' 2 3) := by
-  dsimp
+  -- Disable `Fin.reduceFinMk`, otherwise `Precomp.obj_succ` does not fire.
+  dsimp [-Fin.reduceFinMk]
   infer_instance
 
 include hij in
@@ -152,20 +147,13 @@ variable (C)
 
 attribute [local simp] homologyMap_comp cyclesMap_comp opcyclesMap_comp
 
-#adaptation_note /-- nightly-2024-03-11
-We turn off simprocs here.
-Ideally someone will investigate whether `simp` lemmas can be rearranged
-so that this works without the `set_option`,
-*or* come up with a proposal regarding finer control of disabling simprocs. -/
-set_option simprocs false in
-/-- The functor `HomologicalComplex C c ⥤ ComposableArrows C 3` that maps `K` to the
-diagram `K.homology i ⟶ K.opcycles i ⟶ K.cycles j ⟶ K.homology j`. -/
 @[simps]
 noncomputable def composableArrows₃Functor [CategoryWithHomology C] :
     HomologicalComplex C c ⥤ ComposableArrows C 3 where
   obj K := composableArrows₃ K i j
   map {K L} φ := ComposableArrows.homMk₃ (homologyMap φ i) (opcyclesMap φ i) (cyclesMap φ j)
-    (homologyMap φ j) (by simp) (by simp) (by simp)
+    -- Disable `Fin.reduceFinMk`, otherwise `Precomp.obj_succ` does not fire.
+    (homologyMap φ j) (by simp) (by simp [-Fin.reduceFinMk]) (by simp [-Fin.reduceFinMk])
 
 end HomologySequence
 

--- a/Mathlib/Algebra/Homology/HomologySequence.lean
+++ b/Mathlib/Algebra/Homology/HomologySequence.lean
@@ -147,6 +147,8 @@ variable (C)
 
 attribute [local simp] homologyMap_comp cyclesMap_comp opcyclesMap_comp
 
+/-- The functor `HomologicalComplex C c ⥤ ComposableArrows C 3` that maps `K` to the
+diagram `K.homology i ⟶ K.opcycles i ⟶ K.cycles j ⟶ K.homology j`. -/
 @[simps]
 noncomputable def composableArrows₃Functor [CategoryWithHomology C] :
     HomologicalComplex C c ⥤ ComposableArrows C 3 where

--- a/Mathlib/Algebra/Homology/HomologySequence.lean
+++ b/Mathlib/Algebra/Homology/HomologySequence.lean
@@ -112,7 +112,7 @@ instance [K.HasHomology i] [K.HasHomology j] :
 
 instance [K.HasHomology i] [K.HasHomology j] :
     Epi ((composableArrows₃ K i j).map' 2 3) := by
-  -- Disable `Fin.reduceFinMk`, otherwise `Precomp.obj_succ` does not fire.
+  -- Disable `Fin.reduceFinMk`, otherwise `Precomp.obj_succ` does not fire. (#27382)
   dsimp [-Fin.reduceFinMk]
   infer_instance
 
@@ -154,7 +154,7 @@ noncomputable def composableArrows₃Functor [CategoryWithHomology C] :
     HomologicalComplex C c ⥤ ComposableArrows C 3 where
   obj K := composableArrows₃ K i j
   map {K L} φ := ComposableArrows.homMk₃ (homologyMap φ i) (opcyclesMap φ i) (cyclesMap φ j)
-    -- Disable `Fin.reduceFinMk`, otherwise `Precomp.obj_succ` does not fire.
+    -- Disable `Fin.reduceFinMk`, otherwise `Precomp.obj_succ` does not fire. (#27382)
     (homologyMap φ j) (by simp) (by simp [-Fin.reduceFinMk]) (by simp [-Fin.reduceFinMk])
 
 end HomologySequence

--- a/Mathlib/Algebra/Homology/HomotopyCategory/ShortExact.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/ShortExact.lean
@@ -125,11 +125,11 @@ lemma quasiIso_descShortComplex : QuasiIso (descShortComplex S) where
         ((homologyFunctorFactors C (up ℤ) _).hom.naturality S.f)
         (by
           erw [(homologyFunctorFactors C (up ℤ) n).hom.naturality_assoc]
-          -- Disable `Fin.reduceFinMk`, otherwise `Precomp.obj_succ` does not fire.
+          -- Disable `Fin.reduceFinMk`, otherwise `Precomp.obj_succ` does not fire. (#27382)
           dsimp [-Fin.reduceFinMk]
           rw [← HomologicalComplex.homologyMap_comp, inr_descShortComplex])
         (by
-          -- Disable `Fin.reduceFinMk`, otherwise `Precomp.obj_succ` does not fire.
+          -- Disable `Fin.reduceFinMk`, otherwise `Precomp.obj_succ` does not fire. (#27382)
           dsimp [-Fin.reduceFinMk]
           erw [homologySequenceδ_triangleh hS]
           simp only [Functor.comp_obj, HomologicalComplex.homologyFunctor_obj, assoc,

--- a/Mathlib/Algebra/Homology/HomotopyCategory/ShortExact.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/ShortExact.lean
@@ -110,8 +110,6 @@ lemma homologySequenceδ_triangleh (n₀ : ℤ) (n₁ : ℤ) (h : n₀ + 1 = n�
 
 open ComposableArrows
 
-set_option simprocs false
-
 include hS in
 lemma quasiIso_descShortComplex : QuasiIso (descShortComplex S) where
   quasiIsoAt n := by
@@ -127,10 +125,12 @@ lemma quasiIso_descShortComplex : QuasiIso (descShortComplex S) where
         ((homologyFunctorFactors C (up ℤ) _).hom.naturality S.f)
         (by
           erw [(homologyFunctorFactors C (up ℤ) n).hom.naturality_assoc]
-          dsimp
+          -- Disable `Fin.reduceFinMk`, otherwise `Precomp.obj_succ` does not fire.
+          dsimp [-Fin.reduceFinMk]
           rw [← HomologicalComplex.homologyMap_comp, inr_descShortComplex])
         (by
-          dsimp
+          -- Disable `Fin.reduceFinMk`, otherwise `Precomp.obj_succ` does not fire.
+          dsimp [-Fin.reduceFinMk]
           erw [homologySequenceδ_triangleh hS]
           simp only [Functor.comp_obj, HomologicalComplex.homologyFunctor_obj, assoc,
             Iso.inv_hom_id_app, comp_id])

--- a/Mathlib/CategoryTheory/ComposableArrows.lean
+++ b/Mathlib/CategoryTheory/ComposableArrows.lean
@@ -48,6 +48,8 @@ For now, we just turn off the offending simprocs in this file.
 
 *However*, hopefully it is possible to refactor the material here so that no disabling of
 simprocs is needed.
+
+See issue #27382.
 -/
 attribute [-simp] Fin.reduceFinMk
 

--- a/Mathlib/CategoryTheory/ComposableArrows.lean
+++ b/Mathlib/CategoryTheory/ComposableArrows.lean
@@ -44,13 +44,12 @@ New `simprocs` that run even in `dsimp` have caused breakages in this file.
 
 (e.g. `dsimp` can now simplify `2 + 3` to `5`)
 
-For now, we just turn off simprocs in this file.
-We'll soon provide finer grained options here, e.g. to turn off simprocs only in `dsimp`, etc.
+For now, we just turn off the offending simprocs in this file.
 
-*However*, hopefully it is possible to refactor the material here so that no backwards compatibility
-`set_option`s are required at all
+*However*, hopefully it is possible to refactor the material here so that no disabling of
+simprocs is needed.
 -/
-set_option simprocs false
+attribute [-simp] Fin.reduceFinMk
 
 namespace CategoryTheory
 
@@ -353,7 +352,6 @@ lemma map_comp {i j k : Fin (n + 1 + 1)} (hij : i ≤ j) (hjk : j ≤ k) :
     · obtain _ | _ | k := k
       · simp [Fin.ext_iff] at hjk
       · simp [Fin.le_def] at hjk
-        omega
       · dsimp
         rw [assoc, ← F.map_comp, homOfLE_comp]
   · obtain _ | j := j

--- a/Mathlib/Data/Nat/Choose/Sum.lean
+++ b/Mathlib/Data/Nat/Choose/Sum.lean
@@ -118,7 +118,7 @@ theorem four_pow_le_two_mul_add_one_mul_central_binom (n : ℕ) :
     4 ^ n ≤ (2 * n + 1) * (2 * n).choose n :=
   calc
     4 ^ n = (1 + 1) ^ (2 * n) := by norm_num [pow_mul]
-    _ = ∑ m ∈ range (2 * n + 1), (2 * n).choose m := by set_option simprocs false in simp [add_pow]
+    _ = ∑ m ∈ range (2 * n + 1), (2 * n).choose m := by simp [-Nat.reduceAdd, add_pow]
     _ ≤ ∑ _ ∈ range (2 * n + 1), (2 * n).choose (2 * n / 2) := by gcongr; apply choose_le_middle
     _ = (2 * n + 1) * choose (2 * n) n := by simp
 

--- a/Mathlib/Data/Num/Prime.lean
+++ b/Mathlib/Data/Num/Prime.lean
@@ -69,8 +69,7 @@ theorem minFac_to_nat (n : PosNum) : (minFac n : ℕ) = Nat.minFac n := by
     calc
       (n : ℕ) + (n : ℕ) + 1 ≤ (n : ℕ) + (n : ℕ) + (n : ℕ) := by simp
       _ = (n : ℕ) * (1 + 1 + 1) := by simp only [mul_add, mul_one]
-      _ < _ := by
-        set_option simprocs false in simp [mul_lt_mul]
+      _ < _ := by simp [mul_lt_mul]
   · rw [minFac, Nat.minFac_eq, if_pos]
     · rfl
     simp [← two_mul]

--- a/Mathlib/Geometry/Euclidean/Circumcenter.lean
+++ b/Mathlib/Geometry/Euclidean/Circumcenter.lean
@@ -563,7 +563,7 @@ theorem sum_reflectionCircumcenterWeightsWithCircumcenter {n : ℕ} {i₁ i₂ :
   simp_rw [sum_pointsWithCircumcenter, reflectionCircumcenterWeightsWithCircumcenter, sum_ite,
     sum_const, filter_or, filter_eq']
   rw [card_union_of_disjoint]
-  · set_option simprocs false in simp
+  · norm_num
   · simpa only [if_true, mem_univ, disjoint_singleton] using h
 
 /-- The reflection of the circumcenter of a simplex in an edge, in


### PR DESCRIPTION
Based on adaptation notes for `nightly-2024-03-11` but applies more generally. Looks like `ComposableArrows.Precomp.obj_succ` and `Fin.reduceFinMk` are the main source of these disabled simprocs (#27382), otherwise they all seem reasonable or have easy fixes.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
