### PR TITLE
[Merged by Bors] - feat(Algebra): annihilator of fg module over PID is ann of some element

### DIFF
--- a/Mathlib/Algebra/Module/PID.lean
+++ b/Mathlib/Algebra/Module/PID.lean
@@ -269,4 +269,22 @@ theorem equiv_free_prod_directSum [h' : Module.Finite R M] :
           (h.prodCongr g).trans <| LinearEquiv.prodComm.{u, u} R _ (Fin n →₀ R) ⟩⟩
   rw [range_subtype, ker_mkQ]
 
+open LinearMap in
+theorem exists_ker_toSpanSingleton_eq_annihilator [Module.Finite R M] :
+    ∃ x : M, ker (toSpanSingleton R _ x) = annihilator R M := by
+  have ⟨m, ι, _, p, irr, n, ⟨e⟩⟩ := equiv_free_prod_directSum (R := R) (M := M)
+  refine ⟨e.symm (Finsupp.equivFunOnFinite.symm fun _ ↦ 1, DFinsupp.equivFunOnFintype.symm
+    fun _ ↦ Submodule.mkQ _ 1), le_antisymm (fun x h ↦ ?_) fun x h ↦ mem_annihilator.mp h _⟩
+  simp_rw [mem_ker, toSpanSingleton_apply, ← map_smul] at h
+  rw [e.symm.map_eq_zero_iff, Prod.ext_iff, Finsupp.ext_iff, DFinsupp.ext_iff] at h
+  obtain _ | m := m
+  · simp_rw [e.annihilator_eq, annihilator_prod, annihilator_eq_top_iff.mpr inferInstance,
+      DirectSum, annihilator_dfinsupp, top_inf_eq, Ideal.mem_iInf, mem_annihilator]
+    intro i r
+    obtain ⟨r, rfl⟩ := Submodule.mkQ_surjective _ r
+    rw [← mul_one r, ← smul_eq_mul, map_smul, ← mul_smul, mul_comm, mul_smul]
+    exact congr(r • $(h.2 i)).trans (smul_zero _)
+  · rw [show x = 0 by simpa using h.1 0]
+    exact zero_mem _
+
 end Module

--- a/Mathlib/Algebra/Module/PID.lean
+++ b/Mathlib/Algebra/Module/PID.lean
@@ -274,16 +274,14 @@ theorem exists_ker_toSpanSingleton_eq_annihilator [Module.Finite R M] :
     ∃ x : M, ker (toSpanSingleton R _ x) = annihilator R M := by
   have ⟨m, ι, _, p, irr, n, ⟨e⟩⟩ := equiv_free_prod_directSum (R := R) (M := M)
   refine ⟨e.symm (Finsupp.equivFunOnFinite.symm fun _ ↦ 1, DFinsupp.equivFunOnFintype.symm
-    fun _ ↦ Submodule.mkQ _ 1), le_antisymm (fun x h ↦ ?_) fun x h ↦ mem_annihilator.mp h _⟩
-  simp_rw [mem_ker, toSpanSingleton_apply, ← map_smul] at h
-  rw [e.symm.map_eq_zero_iff, Prod.ext_iff, Finsupp.ext_iff, DFinsupp.ext_iff] at h
+    fun _ ↦ mkQ _ 1), le_antisymm (fun x h ↦ ?_) fun x h ↦ mem_annihilator.mp h _⟩
+  rw [mem_ker, toSpanSingleton_apply, ← map_smul,
+    e.symm.map_eq_zero_iff, Prod.ext_iff, Finsupp.ext_iff, DFinsupp.ext_iff] at h
   obtain _ | m := m
-  · simp_rw [e.annihilator_eq, annihilator_prod, annihilator_eq_top_iff.mpr inferInstance,
-      DirectSum, annihilator_dfinsupp, top_inf_eq, Ideal.mem_iInf, mem_annihilator]
-    intro i r
-    obtain ⟨r, rfl⟩ := Submodule.mkQ_surjective _ r
-    rw [← mul_one r, ← smul_eq_mul, map_smul, ← mul_smul, mul_comm, mul_smul]
-    exact congr(r • $(h.2 i)).trans (smul_zero _)
+  · rw [← mul_one x, ← smul_eq_mul, e.annihilator_eq, annihilator_prod]
+    simp_rw [annihilator_eq_top_iff.mpr inferInstance, DirectSum, annihilator_dfinsupp,
+      top_inf_eq, mem_iInf, Ideal.annihilator_quotient, ← Quotient.mk_eq_zero]
+    exact h.2
   · rw [show x = 0 by simpa using h.1 0]
     exact zero_mem _
 

--- a/Mathlib/RingTheory/Ideal/Maps.lean
+++ b/Mathlib/RingTheory/Ideal/Maps.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
+import Mathlib.Data.DFinsupp.Module
 import Mathlib.RingTheory.Ideal.Operations
 
 /-!
@@ -806,6 +807,39 @@ theorem Module.annihilator_eq_top_iff : annihilator R M = ⊤ ↔ Subsingleton M
       rw [← one_smul R m, ← one_smul R m']
       simp_rw [mem_annihilator.mp (h ▸ Submodule.mem_top)]⟩,
     fun _ ↦ top_le_iff.mp fun _ _ ↦ mem_annihilator.mpr fun _ ↦ Subsingleton.elim _ _⟩
+
+theorem Module.annihilator_prod : annihilator R (M × M') = annihilator R M ⊓ annihilator R M' := by
+  ext
+  simp_rw [Ideal.mem_inf, mem_annihilator,
+    Prod.forall, Prod.smul_mk, Prod.mk_eq_zero, forall_and_left, ← forall_and_right]
+
+theorem Module.annihilator_finsupp {ι : Type*} [Nonempty ι] :
+    annihilator R (ι →₀ M) = annihilator R M := by
+  ext r; simp_rw [mem_annihilator]
+  constructor <;> intro h
+  · let i := Classical.arbitrary ι
+    classical simpa using fun m ↦ DFunLike.congr_fun (h (Finsupp.single i m)) i
+  · intro m; ext i; exact h _
+
+section
+
+variable {ι : Type*} {M : ι → Type*} [∀ i, AddCommMonoid (M i)] [∀ i, Module R (M i)]
+
+theorem Module.annihilator_dfinsupp : annihilator R (Π₀ i, M i) = ⨅ i, annihilator R (M i) := by
+  ext r; simp only [mem_annihilator, Ideal.mem_iInf]
+  constructor <;> intro h
+  · intro i m
+    classical simpa using DFunLike.congr_fun (h (DFinsupp.single i m)) i
+  · intro m; ext i; exact h i _
+
+theorem Module.annihilator_pi : annihilator R (Π i, M i) = ⨅ i, annihilator R (M i) := by
+  ext r; simp only [mem_annihilator, Ideal.mem_iInf]
+  constructor <;> intro h
+  · intro i m
+    classical simpa using congr_fun (h (Pi.single i m)) i
+  · intro m; ext i; exact h i _
+
+end
 
 namespace Submodule
 

--- a/Mathlib/RingTheory/Ideal/Maps.lean
+++ b/Mathlib/RingTheory/Ideal/Maps.lean
@@ -817,8 +817,8 @@ theorem Module.annihilator_finsupp {ι : Type*} [Nonempty ι] :
     annihilator R (ι →₀ M) = annihilator R M := by
   ext r; simp_rw [mem_annihilator]
   constructor <;> intro h
-  · let i := Classical.arbitrary ι
-    classical simpa using fun m ↦ DFunLike.congr_fun (h (Finsupp.single i m)) i
+  · refine Nonempty.elim ‹_› fun i : ι ↦ ?_
+    simpa using fun m ↦ congr($(h (Finsupp.single i m)) i)
   · intro m; ext i; exact h _
 
 section


### PR DESCRIPTION
Live coding at *Formalizing Class Field Theory* for the finite case of the normal basis theorem

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
