### PR TITLE
[Merged by Bors] - feat(Data/List/DropRight): add reverse and append lemmas 

### DIFF
--- a/Mathlib/Data/List/DropRight.lean
+++ b/Mathlib/Data/List/DropRight.lean
@@ -133,6 +133,9 @@ theorem dropWhile_idempotent : dropWhile p (dropWhile p l) = dropWhile p l := by
 theorem rdropWhile_idempotent : rdropWhile p (rdropWhile p l) = rdropWhile p l :=
   rdropWhile_eq_self_iff.mpr (rdropWhile_last_not _ _)
 
+theorem rdropWhile_reverse : l.reverse.rdropWhile p = (l.dropWhile p).reverse := by
+  simp_rw [rdropWhile, reverse_reverse]
+
 /-- Take elements from the tail end of a list that satisfy `p : α → Bool`.
 Implemented naively via `List.reverse` -/
 def rtakeWhile : List α :=
@@ -175,6 +178,14 @@ theorem mem_rtakeWhile_imp {x : α} (hx : x ∈ rtakeWhile p l) : p x := by
 theorem rtakeWhile_idempotent (p : α → Bool) (l : List α) :
     rtakeWhile p (rtakeWhile p l) = rtakeWhile p l :=
   rtakeWhile_eq_self_iff.mpr fun _ => mem_rtakeWhile_imp
+
+theorem rtakeWhile_reverse : l.reverse.rtakeWhile p = (l.takeWhile p).reverse := by
+  simp_rw [rtakeWhile, reverse_reverse]
+
+theorem rdropWhile_append_rtakeWhile :
+    l.rdropWhile p ++ l.rtakeWhile p = l := by
+  simp only [rdropWhile, rtakeWhile]
+  rw [← List.reverse_append, takeWhile_append_dropWhile, reverse_reverse]
 
 lemma rdrop_add (i j : ℕ) : (l.rdrop i).rdrop j = l.rdrop (i + j) := by
   simp_rw [rdrop_eq_reverse_drop_reverse, reverse_reverse, drop_drop]

--- a/Mathlib/Data/List/DropRight.lean
+++ b/Mathlib/Data/List/DropRight.lean
@@ -182,6 +182,7 @@ theorem rtakeWhile_idempotent (p : α → Bool) (l : List α) :
 theorem rtakeWhile_reverse : l.reverse.rtakeWhile p = (l.takeWhile p).reverse := by
   simp_rw [rtakeWhile, reverse_reverse]
 
+@[simp]
 theorem rdropWhile_append_rtakeWhile :
     l.rdropWhile p ++ l.rtakeWhile p = l := by
   simp only [rdropWhile, rtakeWhile]


### PR DESCRIPTION
Adds lemmas for rdropWhile and rtakeWhile.

These lemmas were identified while doing work for Project Numina.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
