### PR TITLE
[Merged by Bors] - chore(Tactic/CancelDenoms): golf entire `cancel_factors_eq` using `grind`

### DIFF
--- a/Mathlib/Tactic/CancelDenoms/Core.lean
+++ b/Mathlib/Tactic/CancelDenoms/Core.lean
@@ -84,17 +84,7 @@ theorem cancel_factors_le {α} [Field α] [LinearOrder α] [IsStrictOrderedRing 
 theorem cancel_factors_eq {α} [Field α] {a b ad bd a' b' gcd : α} (ha : ad * a = a')
     (hb : bd * b = b') (had : ad ≠ 0) (hbd : bd ≠ 0) (hgcd : gcd ≠ 0) :
     (a = b) = (1 / gcd * (bd * a') = 1 / gcd * (ad * b')) := by
-  rw [← ha, ← hb, ← mul_assoc bd, ← mul_assoc ad, mul_comm bd]
-  ext; constructor
-  · rintro rfl
-    rfl
-  · intro h
-    simp only [← mul_assoc] at h
-    refine mul_left_cancel₀ (mul_ne_zero ?_ ?_) h
-    on_goal 1 => apply mul_ne_zero
-    on_goal 1 => apply div_ne_zero
-    · exact one_ne_zero
-    all_goals assumption
+  grind
 
 theorem cancel_factors_ne {α} [Field α] {a b ad bd a' b' gcd : α} (ha : ad * a = a')
     (hb : bd * b = b') (had : ad ≠ 0) (hbd : bd ≠ 0) (hgcd : gcd ≠ 0) :


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>cancel_factors_eq</code>: 120 ms before, 46 ms after  🎉</summary>

### Trace profiling of `cancel_factors_eq` before PR 27370
```diff
diff --git a/Mathlib/Tactic/CancelDenoms/Core.lean b/Mathlib/Tactic/CancelDenoms/Core.lean
index c4b62d3e29..3ec2128994 100644
--- a/Mathlib/Tactic/CancelDenoms/Core.lean
+++ b/Mathlib/Tactic/CancelDenoms/Core.lean
@@ -80,6 +80,7 @@ theorem cancel_factors_le {α} [Field α] [LinearOrder α] [IsStrictOrderedRing
   · exact mul_pos had hbd
   · exact one_div_pos.2 hgcd
 
+set_option trace.profiler true in
 theorem cancel_factors_eq {α} [Field α] {a b ad bd a' b' gcd : α} (ha : ad * a = a')
     (hb : bd * b = b') (had : ad ≠ 0) (hbd : bd ≠ 0) (hgcd : gcd ≠ 0) :
     (a = b) = (1 / gcd * (bd * a') = 1 / gcd * (ad * b')) := by
```
```
ℹ [436/436] Built Mathlib.Tactic.CancelDenoms.Core (2.8s)
info: Mathlib/Tactic/CancelDenoms/Core.lean:84:0: [Elab.command] [0.015258] theorem cancel_factors_eq {α} [Field α] {a b ad bd a' b' gcd : α} (ha : ad * a = a')
        (hb : bd * b = b') (had : ad ≠ 0) (hbd : bd ≠ 0) (hgcd : gcd ≠ 0) :
        (a = b) = (1 / gcd * (bd * a') = 1 / gcd * (ad * b')) :=
      by
      rw [← ha, ← hb, ← mul_assoc bd, ← mul_assoc ad, mul_comm bd]
      ext; constructor
      · rintro rfl
        rfl
      · intro h
        simp only [← mul_assoc] at h
        refine mul_left_cancel₀ (mul_ne_zero ?_ ?_) h
        on_goal 1 => apply mul_ne_zero
        on_goal 1 => apply div_ne_zero
        · exact one_ne_zero
        all_goals assumption
  [Elab.definition.header] [0.014988] CancelDenoms.cancel_factors_eq
info: Mathlib/Tactic/CancelDenoms/Core.lean:84:0: [Elab.async] [0.122474] elaborating proof of CancelDenoms.cancel_factors_eq
  [Elab.definition.value] [0.119890] CancelDenoms.cancel_factors_eq
    [Elab.step] [0.118614] 
          rw [← ha, ← hb, ← mul_assoc bd, ← mul_assoc ad, mul_comm bd]
          ext; constructor
          · rintro rfl
            rfl
          · intro h
            simp only [← mul_assoc] at h
            refine mul_left_cancel₀ (mul_ne_zero ?_ ?_) h
            on_goal 1 => apply mul_ne_zero
            on_goal 1 => apply div_ne_zero
            · exact one_ne_zero
            all_goals assumption
      [Elab.step] [0.118601] 
            rw [← ha, ← hb, ← mul_assoc bd, ← mul_assoc ad, mul_comm bd]
            ext; constructor
            · rintro rfl
              rfl
            · intro h
              simp only [← mul_assoc] at h
              refine mul_left_cancel₀ (mul_ne_zero ?_ ?_) h
              on_goal 1 => apply mul_ne_zero
              on_goal 1 => apply div_ne_zero
              · exact one_ne_zero
              all_goals assumption
        [Elab.step] [0.010324] rw [← ha, ← hb, ← mul_assoc bd, ← mul_assoc ad, mul_comm bd]
          [Elab.step] [0.010312] (rewrite [← ha, ← hb, ← mul_assoc bd, ← mul_assoc ad, mul_comm bd];
                with_annotate_state"]" (try (with_reducible rfl)))
            [Elab.step] [0.010299] rewrite [← ha, ← hb, ← mul_assoc bd, ← mul_assoc ad, mul_comm bd];
                  with_annotate_state"]" (try (with_reducible rfl))
              [Elab.step] [0.010291] rewrite [← ha, ← hb, ← mul_assoc bd, ← mul_assoc ad, mul_comm bd];
                    with_annotate_state"]" (try (with_reducible rfl))
        [Elab.step] [0.105805] ·
              intro h
              simp only [← mul_assoc] at h
              refine mul_left_cancel₀ (mul_ne_zero ?_ ?_) h
              on_goal 1 => apply mul_ne_zero
              on_goal 1 => apply div_ne_zero
              · exact one_ne_zero
              all_goals assumption
          [Elab.step] [0.105661] 
                intro h
                simp only [← mul_assoc] at h
                refine mul_left_cancel₀ (mul_ne_zero ?_ ?_) h
                on_goal 1 => apply mul_ne_zero
                on_goal 1 => apply div_ne_zero
                · exact one_ne_zero
                all_goals assumption
            [Elab.step] [0.105650] 
                  intro h
                  simp only [← mul_assoc] at h
                  refine mul_left_cancel₀ (mul_ne_zero ?_ ?_) h
                  on_goal 1 => apply mul_ne_zero
                  on_goal 1 => apply div_ne_zero
                  · exact one_ne_zero
                  all_goals assumption
              [Elab.step] [0.043946] refine mul_left_cancel₀ (mul_ne_zero ?_ ?_) h
                [Elab.step] [0.043859] expected type: a = b, term
                    mul_left_cancel₀ (mul_ne_zero ?_ ?_) h
                  [Elab.step] [0.025447] expected type: ?m.103 * ?m.104 ≠ 0, term
                      (mul_ne_zero ?_ ?_)
                    [Elab.step] [0.025432] expected type: ?m.103 * ?m.104 ≠ 0, term
                        mul_ne_zero ?_ ?_
                      [Meta.synthInstance] [0.019262] ✅️ NoZeroDivisors α
              [Elab.step] [0.021441] on_goal 1 => apply mul_ne_zero
                [Elab.step] [0.019543] apply mul_ne_zero
                  [Elab.step] [0.019530] apply mul_ne_zero
                    [Elab.step] [0.019514] apply mul_ne_zero
                      [Meta.synthInstance] [0.013986] ✅️ NoZeroDivisors α
              [Elab.step] [0.018650] · exact one_ne_zero
                [Elab.step] [0.018355] exact one_ne_zero
                  [Elab.step] [0.018309] exact one_ne_zero
                    [Elab.step] [0.018269] exact one_ne_zero
                      [Elab.step] [0.017827] expected type: 1 ≠ 0, term
                          one_ne_zero
                        [Meta.synthInstance] [0.012295] ✅️ NeZero 1
Build completed successfully (436 jobs).
```

### Trace profiling of `cancel_factors_eq` after PR 27370
```diff
diff --git a/Mathlib/Tactic/CancelDenoms/Core.lean b/Mathlib/Tactic/CancelDenoms/Core.lean
index c4b62d3e29..066f915189 100644
--- a/Mathlib/Tactic/CancelDenoms/Core.lean
+++ b/Mathlib/Tactic/CancelDenoms/Core.lean
@@ -80,20 +80,11 @@ theorem cancel_factors_le {α} [Field α] [LinearOrder α] [IsStrictOrderedRing
   · exact mul_pos had hbd
   · exact one_div_pos.2 hgcd
 
+set_option trace.profiler true in
 theorem cancel_factors_eq {α} [Field α] {a b ad bd a' b' gcd : α} (ha : ad * a = a')
     (hb : bd * b = b') (had : ad ≠ 0) (hbd : bd ≠ 0) (hgcd : gcd ≠ 0) :
     (a = b) = (1 / gcd * (bd * a') = 1 / gcd * (ad * b')) := by
-  rw [← ha, ← hb, ← mul_assoc bd, ← mul_assoc ad, mul_comm bd]
-  ext; constructor
-  · rintro rfl
-    rfl
-  · intro h
-    simp only [← mul_assoc] at h
-    refine mul_left_cancel₀ (mul_ne_zero ?_ ?_) h
-    on_goal 1 => apply mul_ne_zero
-    on_goal 1 => apply div_ne_zero
-    · exact one_ne_zero
-    all_goals assumption
+  grind
 
 theorem cancel_factors_ne {α} [Field α] {a b ad bd a' b' gcd : α} (ha : ad * a = a')
     (hb : bd * b = b') (had : ad ≠ 0) (hbd : bd ≠ 0) (hgcd : gcd ≠ 0) :
```
```
ℹ [436/436] Built Mathlib.Tactic.CancelDenoms.Core (3.1s)
info: Mathlib/Tactic/CancelDenoms/Core.lean:84:0: [Elab.command] [0.034809] theorem cancel_factors_eq {α} [Field α] {a b ad bd a' b' gcd : α} (ha : ad * a = a')
        (hb : bd * b = b') (had : ad ≠ 0) (hbd : bd ≠ 0) (hgcd : gcd ≠ 0) :
        (a = b) = (1 / gcd * (bd * a') = 1 / gcd * (ad * b')) := by grind
  [Elab.definition.header] [0.014091] CancelDenoms.cancel_factors_eq
info: Mathlib/Tactic/CancelDenoms/Core.lean:84:0: [Elab.async] [0.046425] elaborating proof of CancelDenoms.cancel_factors_eq
  [Elab.definition.value] [0.045869] CancelDenoms.cancel_factors_eq
    [Elab.step] [0.045340] grind
      [Elab.step] [0.045327] grind
        [Elab.step] [0.045311] grind
info: Mathlib/Tactic/CancelDenoms/Core.lean:87:2: [Elab.async] [0.027621] Lean.addDecl
  [Kernel] [0.027585] ✅️ typechecking declarations [CancelDenoms.cancel_factors_eq._proof_1_1]
Build completed successfully (436 jobs).
```
</details>

