### PR TITLE
[Merged by Bors] - chore: move some bot output to the 'nightly-testing' stream

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -116,7 +116,7 @@ jobs:
           api-key: ${{ secrets.ZULIP_API_KEY }}
           email: 'github-mathlib4-bot@leanprover.zulipchat.com'
           organization-url: 'https://leanprover.zulipchat.com'
-          to: 'mathlib reviewers'
+          to: 'nightly-testing'
           type: 'stream'
           topic: 'lean4checker'
           content: |
@@ -129,7 +129,7 @@ jobs:
           api-key: ${{ secrets.ZULIP_API_KEY }}
           email: 'github-mathlib4-bot@leanprover.zulipchat.com'
           organization-url: 'https://leanprover.zulipchat.com'
-          to: 'mathlib reviewers'
+          to: 'nightly-testing'
           type: 'stream'
           topic: 'mathlib test executable'
           content: |
@@ -142,7 +142,7 @@ jobs:
           api-key: ${{ secrets.ZULIP_API_KEY }}
           email: 'github-mathlib4-bot@leanprover.zulipchat.com'
           organization-url: 'https://leanprover.zulipchat.com'
-          to: 'mathlib reviewers'
+          to: 'nightly-testing'
           type: 'stream'
           topic: 'lean4checker failure'
           content: |
@@ -156,7 +156,7 @@ jobs:
           api-key: ${{ secrets.ZULIP_API_KEY }}
           email: 'github-mathlib4-bot@leanprover.zulipchat.com'
           organization-url: 'https://leanprover.zulipchat.com'
-          to: 'mathlib reviewers'
+          to: 'nightly-testing'
           type: 'stream'
           topic: 'mathlib test executable failure'
           content: |

--- a/.github/workflows/update_dependencies_zulip.yml
+++ b/.github/workflows/update_dependencies_zulip.yml
@@ -70,7 +70,7 @@ jobs:
           api-key: ${{ secrets.ZULIP_API_KEY }}
           email: 'github-mathlib4-bot@leanprover.zulipchat.com'
           organization-url: 'https://leanprover.zulipchat.com'
-          to: 'mathlib reviewers'
+          to: 'nightly-testing'
           type: 'stream'
           topic: 'Mathlib `lake update` failure'
           content: |
@@ -125,7 +125,7 @@ jobs:
           api-key: ${{ secrets.ZULIP_API_KEY }}
           email: 'github-mathlib4-bot@leanprover.zulipchat.com'
           organization-url: 'https://leanprover.zulipchat.com'
-          to: 'mathlib reviewers'
+          to: 'nightly-testing'
           type: 'stream'
           topic: 'Mathlib `lake update` success'
           content: |


### PR DESCRIPTION
This PR modifies some bots so they post in the public 'nightly-testing` Zulip channel, rather than the private 'mathlib reviewers channel.