### PR TITLE
chore: replace `omega` with `grind` in `Algebra/` theorems/lemmas where applicable

### DIFF
--- a/Mathlib/Algebra/AddConstMap/Basic.lean
+++ b/Mathlib/Algebra/AddConstMap/Basic.lean
@@ -257,7 +257,7 @@ protected theorem rel_map_of_Icc [AddCommGroup G] [LinearOrder G] [IsOrderedAddM
       calc
         y ≤ l + a + n • a := sub_le_iff_le_add.1 hny.2
         _ = l + (n + 1) • a := by rw [add_comm n, add_smul, one_smul, add_assoc]
-        _ ≤ l + 0 • a := add_le_add_left (zsmul_le_zsmul_left ha.le (by omega)) _
+        _ ≤ l + 0 • a := add_le_add_left (zsmul_le_zsmul_left ha.le (by grind)) _
         _ ≤ x := by simpa using hx.1
     · -- If `n = 0`, then `l < y ≤ l + a`, hence we can apply the assumption
       exact hf x (Ico_subset_Icc_self hx) y (by simpa using Ioc_subset_Icc_self hny) hxy

--- a/Mathlib/Algebra/BigOperators/Fin.lean
+++ b/Mathlib/Algebra/BigOperators/Fin.lean
@@ -476,15 +476,15 @@ lemma partialProd_contractNth {G : Type*} [Monoid G] {n : ℕ}
     · rw [succAbove_of_castSucc_lt, contractNth_apply_of_lt _ _ _ _ h,
         succAbove_of_castSucc_lt] <;>
       simp only [lt_def, coe_castSucc, val_succ] <;>
-      omega
+      grind
     · rw [succAbove_of_castSucc_lt, contractNth_apply_of_eq _ _ _ _ h,
         succAbove_of_le_castSucc, castSucc_fin_succ, partialProd_succ, mul_assoc] <;>
       simp only [castSucc_lt_succ_iff, le_def, coe_castSucc] <;>
-      omega
+      grind
     · rw [succAbove_of_le_castSucc, succAbove_of_le_castSucc, contractNth_apply_of_gt _ _ _ _ h,
         castSucc_fin_succ] <;>
       simp only [le_def, val_succ, coe_castSucc] <;>
-      omega
+      grind
 
 /-- Let `(g₀, g₁, ..., gₙ)` be a tuple of elements in `Gⁿ⁺¹`.
 Then if `k < j`, this says `(g₀g₁...gₖ₋₁)⁻¹ * g₀g₁...gₖ = gₖ`.

--- a/Mathlib/Algebra/ContinuedFractions/Computation/Approximations.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Computation/Approximations.lean
@@ -211,7 +211,7 @@ theorem fib_le_of_contsAux_b :
       · simp [contsAux] -- case n = 0
       · simp [contsAux] -- case n = 1
       · let g := of v -- case 2 ≤ n
-        have : ¬n + 2 ≤ 1 := by omega
+        have : ¬n + 2 ≤ 1 := by grind
         have not_terminatedAt_n : ¬g.TerminatedAt n := Or.resolve_left hyp this
         obtain ⟨gp, s_ppred_nth_eq⟩ : ∃ gp, g.s.get? n = some gp :=
           Option.ne_none_iff_exists'.mp not_terminatedAt_n

--- a/Mathlib/Algebra/ContinuedFractions/Computation/TerminatesIffRat.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Computation/TerminatesIffRat.lean
@@ -298,7 +298,7 @@ theorem exists_nth_stream_eq_none_of_rat (q : ℚ) : ∃ n : ℕ, IntFractPair.s
         sub_add_eq_sub_sub_swap, sub_right_comm, sub_self, zero_sub]
     have : 0 ≤ ifp.fr := (nth_stream_fr_nonneg_lt_one stream_nth_eq).left
     have : 0 ≤ ifp.fr.num := Rat.num_nonneg.mpr this
-    omega
+    grind
 
 end IntFractPair
 

--- a/Mathlib/Algebra/CubicDiscriminant.lean
+++ b/Mathlib/Algebra/CubicDiscriminant.lean
@@ -88,7 +88,7 @@ private theorem coeffs : (∀ n > 3, P.toPoly.coeff n = 0) ∧ P.toPoly.coeff 3 
   norm_num
   intro n hn
   repeat' rw [if_neg]
-  any_goals omega
+  any_goals grind
   repeat' rw [zero_add]
 
 @[simp]

--- a/Mathlib/Algebra/GCDMonoid/Nat.lean
+++ b/Mathlib/Algebra/GCDMonoid/Nat.lean
@@ -84,7 +84,7 @@ theorem nonneg_of_normalize_eq_self {z : ℤ} (hz : normalize z = z) : 0 ≤ z :
   by_cases h : 0 ≤ z
   · exact h
   · rw [normalize_of_nonpos (le_of_not_ge h)] at hz
-    omega
+    grind
 
 theorem nonneg_iff_normalize_eq_self (z : ℤ) : normalize z = z ↔ 0 ≤ z :=
   ⟨nonneg_of_normalize_eq_self, normalize_of_nonneg⟩

--- a/Mathlib/Algebra/GeomSum.lean
+++ b/Mathlib/Algebra/GeomSum.lean
@@ -172,7 +172,7 @@ theorem geom_sum₂_mul_of_le [CommSemiring R] [PartialOrder R] [AddLeftReflectL
   simp_all only [Finset.mem_range]
   rw [mul_comm]
   congr
-  omega
+  grind
 
 theorem Commute.sub_dvd_pow_sub_pow [Ring R] {x y : R} (h : Commute x y) (n : ℕ) :
     x - y ∣ x ^ n - y ^ n :=
@@ -315,7 +315,7 @@ protected theorem Commute.mul_geom_sum₂_Ico [Ring R] {x y : R} (h : Commute x 
     rw [← pow_add]
     congr
     rw [mem_range] at j_in
-    omega
+    grind
   rw [this]
   simp_rw [pow_mul_comm y (n - m) _]
   simp_rw [← mul_assoc]
@@ -330,7 +330,7 @@ protected theorem Commute.geom_sum₂_succ_eq [Ring R] {x y : R} (h : Commute x 
   refine sum_congr rfl fun i hi => ?_
   suffices n - 1 - i + 1 = n - i by rw [this]
   rw [Finset.mem_range] at hi
-  omega
+  grind
 
 theorem geom_sum₂_succ_eq [CommRing R] (x y : R) {n : ℕ} :
     ∑ i ∈ range (n + 1), x ^ i * y ^ (n - i) =

--- a/Mathlib/Algebra/Group/Defs.lean
+++ b/Mathlib/Algebra/Group/Defs.lean
@@ -517,15 +517,15 @@ theorem npowBinRec.go_spec {M : Type*} [Semigroup M] [One M] (k : ℕ) (m n : M)
     npowBinRec.go (k + 1) m n = m * npowRec' (k + 1) n := by
   unfold go
   generalize hk : k + 1 = k'
-  replace hk : k' ≠ 0 := by omega
+  replace hk : k' ≠ 0 := by grind
   induction k' using Nat.binaryRecFromOne generalizing n m with
   | z₀ => simp at hk
   | z₁ => simp [npowRec']
   | f b k' k'0 ih =>
     rw [Nat.binaryRec_eq _ _ (Or.inl rfl), ih _ _ k'0]
     cases b <;> simp only [Nat.bit, cond_false, cond_true, npowRec'_two_mul]
-    rw [npowRec'_succ (by omega), npowRec'_two_mul, ← npowRec'_two_mul,
-      ← npowRec'_mul_comm (by omega), mul_assoc]
+    rw [npowRec'_succ (by grind), npowRec'_two_mul, ← npowRec'_two_mul,
+      ← npowRec'_mul_comm (by grind), mul_assoc]
 
 /--
 An abbreviation for `npowRec` with an additional typeclass assumption on associativity

--- a/Mathlib/Algebra/Group/Int/Even.lean
+++ b/Mathlib/Algebra/Group/Int/Even.lean
@@ -85,7 +85,7 @@ theorem isSquare_sign_iff {z : ℤ} : IsSquare z.sign ↔ 0 ≤ z := by
   | zero => simpa using ⟨0, by simp⟩
   | succ => norm_cast; simp
   | pred =>
-    rw [sign_eq_neg_one_of_neg (by omega), ← neg_add', Int.neg_nonneg]
+    rw [sign_eq_neg_one_of_neg (by grind), ← neg_add', Int.neg_nonneg]
     norm_cast
     simp only [reduceNeg, le_zero_eq, Nat.add_eq_zero, succ_ne_self, and_false, iff_false]
     rintro ⟨a | a, ⟨⟩⟩

--- a/Mathlib/Algebra/Group/Nat/Range.lean
+++ b/Mathlib/Algebra/Group/Nat/Range.lean
@@ -20,7 +20,7 @@ theorem disjoint_range_addLeftEmbedding (a : ℕ) (s : Finset ℕ) :
     Disjoint (range a) (map (addLeftEmbedding a) s) := by
   simp_rw [disjoint_left, mem_map, mem_range, addLeftEmbedding_apply]
   rintro _ h ⟨l, -, rfl⟩
-  omega
+  grind
 
 theorem disjoint_range_addRightEmbedding (a : ℕ) (s : Finset ℕ) :
     Disjoint (range a) (map (addRightEmbedding a) s) := by

--- a/Mathlib/Algebra/GroupWithZero/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Basic.lean
@@ -162,7 +162,7 @@ lemma zero_pow_eq_zero [Nontrivial M₀] : (0 : M₀) ^ n = 0 ↔ n ≠ 0 :=
 
 lemma pow_mul_eq_zero_of_le {a b : M₀} {m n : ℕ} (hmn : m ≤ n)
     (h : a ^ m * b = 0) : a ^ n * b = 0 := by
-  rw [show n = n - m + m by omega, pow_add, mul_assoc, h]
+  rw [show n = n - m + m by grind, pow_add, mul_assoc, h]
   simp
 
 variable [NoZeroDivisors M₀]

--- a/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
@@ -337,7 +337,7 @@ lemma pow_sub₀ (a : G₀) (ha : a ≠ 0) (h : n ≤ m) : a ^ (m - n) = a ^ m *
 
 lemma pow_sub_of_lt (a : G₀) (h : n < m) : a ^ (m - n) = a ^ m * (a ^ n)⁻¹ := by
   obtain rfl | ha := eq_or_ne a 0
-  · rw [zero_pow (Nat.ne_of_gt <| Nat.sub_pos_of_lt h), zero_pow (by omega), zero_mul]
+  · rw [zero_pow (Nat.ne_of_gt <| Nat.sub_pos_of_lt h), zero_pow (by grind), zero_mul]
   · exact pow_sub₀ _ ha <| Nat.le_of_lt h
 
 lemma inv_pow_sub₀ (ha : a ≠ 0) (h : n ≤ m) : a⁻¹ ^ (m - n) = (a ^ m)⁻¹ * a ^ n := by

--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/Basic.lean
@@ -75,11 +75,11 @@ lemma hasExt_iff [HasDerivedCategory.{w'} C] :
       rw [← cancel_mono ((Q.commShiftIso b).inv.app _),
         ← cancel_epi ((Q.commShiftIso a).hom.app _)]
       have : (((CochainComplex.singleFunctor C 0).obj X)⟦a⟧).IsStrictlyLE (-a) :=
-        CochainComplex.isStrictlyLE_shift _ 0 _ _ (by omega)
+        CochainComplex.isStrictlyLE_shift _ 0 _ _ (by grind)
       have : (((CochainComplex.singleFunctor C 0).obj Y)⟦b⟧).IsStrictlyGE (-b) :=
-        CochainComplex.isStrictlyGE_shift _ 0 _ _ (by omega)
+        CochainComplex.isStrictlyGE_shift _ 0 _ _ (by grind)
       apply (subsingleton_hom_of_isStrictlyLE_of_isStrictlyGE _ _ (-a) (-b) (by
-        omega)).elim
+        grind)).elim
 
 lemma hasExt_of_hasDerivedCategory [HasDerivedCategory.{w} C] : HasExt.{w} C := by
   rw [hasExt_iff.{w}]
@@ -112,9 +112,9 @@ noncomputable def comp {a b : ℕ} (α : Ext X Y a) (β : Ext Y Z b) {c : ℕ} (
 
 lemma comp_assoc {a₁ a₂ a₃ a₁₂ a₂₃ a : ℕ} (α : Ext X Y a₁) (β : Ext Y Z a₂) (γ : Ext Z T a₃)
     (h₁₂ : a₁ + a₂ = a₁₂) (h₂₃ : a₂ + a₃ = a₂₃) (h : a₁ + a₂ + a₃ = a) :
-    (α.comp β h₁₂).comp γ (show a₁₂ + a₃ = a by omega) =
-      α.comp (β.comp γ h₂₃) (by omega) :=
-  SmallShiftedHom.comp_assoc _ _ _ _ _ _ (by omega)
+    (α.comp β h₁₂).comp γ (show a₁₂ + a₃ = a by grind) =
+      α.comp (β.comp γ h₂₃) (by grind) :=
+  SmallShiftedHom.comp_assoc _ _ _ _ _ _ (by grind)
 
 @[simp]
 lemma comp_assoc_of_second_deg_zero
@@ -122,7 +122,7 @@ lemma comp_assoc_of_second_deg_zero
     (h₁₃ : a₁ + a₃ = a₁₃) :
     (α.comp β (add_zero _)).comp γ h₁₃ = α.comp (β.comp γ (zero_add _)) h₁₃ := by
   apply comp_assoc
-  omega
+  grind
 
 @[simp]
 lemma comp_assoc_of_third_deg_zero
@@ -130,7 +130,7 @@ lemma comp_assoc_of_third_deg_zero
     (h₁₂ : a₁ + a₂ = a₁₂) :
     (α.comp β h₁₂).comp γ (add_zero _) = α.comp (β.comp γ (add_zero _)) h₁₂ := by
   apply comp_assoc
-  omega
+  grind
 
 section
 
@@ -150,7 +150,7 @@ noncomputable abbrev hom {a : ℕ} (α : Ext X Y a) :
 
 @[simp]
 lemma comp_hom {a b : ℕ} (α : Ext X Y a) (β : Ext Y Z b) {c : ℕ} (h : a + b = c) :
-    (α.comp β h).hom = α.hom.comp β.hom (by omega) := by
+    (α.comp β h).hom = α.hom.comp β.hom (by grind) := by
   apply SmallShiftedHom.equiv_comp
 
 @[ext]
@@ -178,7 +178,7 @@ lemma mk₀_comp_mk₀_assoc (f : X ⟶ Y) (g : Y ⟶ Z) {n : ℕ} (α : Ext Z T
     (mk₀ f).comp ((mk₀ g).comp α (zero_add n)) (zero_add n) =
       (mk₀ (f ≫ g)).comp α (zero_add n) := by
   rw [← mk₀_comp_mk₀, comp_assoc]
-  omega
+  grind
 
 
 variable (X Y) in

--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/EnoughInjectives.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/EnoughInjectives.lean
@@ -93,12 +93,12 @@ open DerivedCategory
 lemma eq_zero_of_injective [HasExt.{w} C] {X I : C} {n : ℕ} [Injective I]
     (e : Ext X I (n + 1)) : e = 0 := by
   let K := (CochainComplex.singleFunctor C 0).obj X
-  have := K.isStrictlyGE_of_ge (-n) 0 (by omega)
+  have := K.isStrictlyGE_of_ge (-n) 0 (by grind)
   letI := HasDerivedCategory.standard C
   apply homEquiv.injective
   simp only [← cancel_mono (((singleFunctors C).shiftIso (n + 1) (-(n + 1)) 0
-    (by omega)).hom.app _), zero_hom, Limits.zero_comp]
-  exact to_singleFunctor_obj_eq_zero_of_injective (K := K) (n := -n) _ (by omega)
+    (by grind)).hom.app _), zero_hom, Limits.zero_comp]
+  exact to_singleFunctor_obj_eq_zero_of_injective (K := K) (n := -n) _ (by grind)
 
 end Abelian.Ext
 

--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/EnoughProjectives.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/EnoughProjectives.lean
@@ -95,9 +95,9 @@ lemma eq_zero_of_projective [HasExt.{w} C] {P Y : C} {n : ℕ} [Projective P]
   letI := HasDerivedCategory.standard C
   apply homEquiv.injective
   simp only [← cancel_mono (((singleFunctors C).shiftIso (n + 1) (- (n + 1)) 0
-    (by omega)).hom.app _), zero_hom, Limits.zero_comp]
+    (by grind)).hom.app _), zero_hom, Limits.zero_comp]
   apply from_singleFunctor_obj_eq_zero_of_projective
-    (L := (CochainComplex.singleFunctor C (-(n + 1))).obj Y) (n := - (n + 1)) _ (by omega)
+    (L := (CochainComplex.singleFunctor C (-(n + 1))).obj Y) (n := - (n + 1)) _ (by grind)
 
 end Abelian.Ext
 
@@ -127,7 +127,7 @@ lemma hasExt_of_enoughProjectives [LocallySmall.{w} C] [EnoughProjectives C] : H
       { exact := ShortComplex.exact_of_f_is_kernel _ (kernelIsKernel S.g) }
     have : Function.Surjective (Ext.precomp hS.extClass Y (add_comm 1 n)) := fun x₃ ↦
       Ext.contravariant_sequence_exact₃ hS Y x₃
-        (Ext.eq_zero_of_projective _) (by omega)
+        (Ext.eq_zero_of_projective _) (by grind)
     exact small_of_surjective.{w} this
 
 end CategoryTheory

--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/ExactSequences.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/ExactSequences.lean
@@ -45,7 +45,7 @@ lemma preadditiveCoyoneda_homologySequenceδ_singleTriangle_apply
     [HasDerivedCategory.{w'} C] {X : C} {n₀ : ℕ} (x : Ext X S.X₃ n₀)
     {n₁ : ℕ} (h : n₀ + 1 = n₁) :
     (preadditiveCoyoneda.obj (op ((singleFunctor C 0).obj X))).homologySequenceδ
-      hS.singleTriangle n₀ n₁ (by omega) x.hom =
+      hS.singleTriangle n₀ n₁ (by grind) x.hom =
         (x.comp hS.extClass h).hom := by
   rw [Pretriangulated.preadditiveCoyoneda_homologySequenceδ_apply,
     comp_hom, hS.extClass_hom, ShiftedHom.comp]
@@ -84,7 +84,7 @@ lemma covariant_sequence_exact₃' :
           comp_zero])).Exact := by
   letI := HasDerivedCategory.standard C
   have := (preadditiveCoyoneda.obj (op ((singleFunctor C 0).obj X))).homologySequence_exact₃ _
-    (hS.singleTriangle_distinguished) n₀ n₁ (by omega)
+    (hS.singleTriangle_distinguished) n₀ n₁ (by grind)
   rw [ShortComplex.ab_exact_iff_function_exact] at this ⊢
   apply Function.Exact.of_ladder_addEquiv_of_exact' (e₁ := Ext.homAddEquiv)
     (e₂ := Ext.homAddEquiv) (e₃ := Ext.homAddEquiv) (H := this)
@@ -103,7 +103,7 @@ lemma covariant_sequence_exact₁' :
           comp_zero])).Exact := by
   letI := HasDerivedCategory.standard C
   have := (preadditiveCoyoneda.obj (op ((singleFunctor C 0).obj X))).homologySequence_exact₁ _
-    (hS.singleTriangle_distinguished) n₀ n₁ (by omega)
+    (hS.singleTriangle_distinguished) n₀ n₁ (by grind)
   rw [ShortComplex.ab_exact_iff_function_exact] at this ⊢
   apply Function.Exact.of_ladder_addEquiv_of_exact' (e₁ := Ext.homAddEquiv)
     (e₂ := Ext.homAddEquiv) (e₃ := Ext.homAddEquiv) (H := this)
@@ -171,7 +171,7 @@ lemma preadditiveYoneda_homologySequenceδ_singleTriangle_apply
     [HasDerivedCategory.{w'} C] {Y : C} {n₀ : ℕ} (x : Ext S.X₁ Y n₀)
     {n₁ : ℕ} (h : 1 + n₀ = n₁) :
     (preadditiveYoneda.obj ((singleFunctor C 0).obj Y)).homologySequenceδ
-      ((triangleOpEquivalence _).functor.obj (op hS.singleTriangle)) n₀ n₁ (by omega) x.hom =
+      ((triangleOpEquivalence _).functor.obj (op hS.singleTriangle)) n₀ n₁ (by grind) x.hom =
       (hS.extClass.comp x h).hom := by
   rw [preadditiveYoneda_homologySequenceδ_apply,
     comp_hom, hS.extClass_hom, ShiftedHom.comp]
@@ -206,7 +206,7 @@ lemma contravariant_sequence_exact₁' :
         simp only [ShortComplex.ShortExact.extClass_comp_assoc])).Exact := by
   letI := HasDerivedCategory.standard C
   have := (preadditiveYoneda.obj ((singleFunctor C 0).obj Y)).homologySequence_exact₃ _
-    (op_distinguished _ hS.singleTriangle_distinguished) n₀ n₁ (by omega)
+    (op_distinguished _ hS.singleTriangle_distinguished) n₀ n₁ (by grind)
   rw [ShortComplex.ab_exact_iff_function_exact] at this ⊢
   apply Function.Exact.of_ladder_addEquiv_of_exact' (e₁ := Ext.homAddEquiv)
     (e₂ := Ext.homAddEquiv) (e₃ := Ext.homAddEquiv) (H := this)
@@ -222,7 +222,7 @@ lemma contravariant_sequence_exact₃' :
         simp only [ShortComplex.ShortExact.comp_extClass_assoc])).Exact := by
   letI := HasDerivedCategory.standard C
   have := (preadditiveYoneda.obj ((singleFunctor C 0).obj Y)).homologySequence_exact₁ _
-    (op_distinguished _ hS.singleTriangle_distinguished) n₀ n₁ (by omega)
+    (op_distinguished _ hS.singleTriangle_distinguished) n₀ n₁ (by grind)
   rw [ShortComplex.ab_exact_iff_function_exact] at this ⊢
   apply Function.Exact.of_ladder_addEquiv_of_exact' (e₁ := Ext.homAddEquiv)
     (e₂ := Ext.homAddEquiv) (e₃ := Ext.homAddEquiv) (H := this)

--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/ExactSequences.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/ExactSequences.lean
@@ -45,7 +45,7 @@ lemma preadditiveCoyoneda_homologySequenceδ_singleTriangle_apply
     [HasDerivedCategory.{w'} C] {X : C} {n₀ : ℕ} (x : Ext X S.X₃ n₀)
     {n₁ : ℕ} (h : n₀ + 1 = n₁) :
     (preadditiveCoyoneda.obj (op ((singleFunctor C 0).obj X))).homologySequenceδ
-      hS.singleTriangle n₀ n₁ (by grind) x.hom =
+      hS.singleTriangle n₀ n₁ (by omega) x.hom =
         (x.comp hS.extClass h).hom := by
   rw [Pretriangulated.preadditiveCoyoneda_homologySequenceδ_apply,
     comp_hom, hS.extClass_hom, ShiftedHom.comp]
@@ -84,7 +84,7 @@ lemma covariant_sequence_exact₃' :
           comp_zero])).Exact := by
   letI := HasDerivedCategory.standard C
   have := (preadditiveCoyoneda.obj (op ((singleFunctor C 0).obj X))).homologySequence_exact₃ _
-    (hS.singleTriangle_distinguished) n₀ n₁ (by grind)
+    (hS.singleTriangle_distinguished) n₀ n₁ (by omega)
   rw [ShortComplex.ab_exact_iff_function_exact] at this ⊢
   apply Function.Exact.of_ladder_addEquiv_of_exact' (e₁ := Ext.homAddEquiv)
     (e₂ := Ext.homAddEquiv) (e₃ := Ext.homAddEquiv) (H := this)
@@ -103,7 +103,7 @@ lemma covariant_sequence_exact₁' :
           comp_zero])).Exact := by
   letI := HasDerivedCategory.standard C
   have := (preadditiveCoyoneda.obj (op ((singleFunctor C 0).obj X))).homologySequence_exact₁ _
-    (hS.singleTriangle_distinguished) n₀ n₁ (by grind)
+    (hS.singleTriangle_distinguished) n₀ n₁ (by omega)
   rw [ShortComplex.ab_exact_iff_function_exact] at this ⊢
   apply Function.Exact.of_ladder_addEquiv_of_exact' (e₁ := Ext.homAddEquiv)
     (e₂ := Ext.homAddEquiv) (e₃ := Ext.homAddEquiv) (H := this)
@@ -171,7 +171,7 @@ lemma preadditiveYoneda_homologySequenceδ_singleTriangle_apply
     [HasDerivedCategory.{w'} C] {Y : C} {n₀ : ℕ} (x : Ext S.X₁ Y n₀)
     {n₁ : ℕ} (h : 1 + n₀ = n₁) :
     (preadditiveYoneda.obj ((singleFunctor C 0).obj Y)).homologySequenceδ
-      ((triangleOpEquivalence _).functor.obj (op hS.singleTriangle)) n₀ n₁ (by grind) x.hom =
+      ((triangleOpEquivalence _).functor.obj (op hS.singleTriangle)) n₀ n₁ (by omega) x.hom =
       (hS.extClass.comp x h).hom := by
   rw [preadditiveYoneda_homologySequenceδ_apply,
     comp_hom, hS.extClass_hom, ShiftedHom.comp]
@@ -206,7 +206,7 @@ lemma contravariant_sequence_exact₁' :
         simp only [ShortComplex.ShortExact.extClass_comp_assoc])).Exact := by
   letI := HasDerivedCategory.standard C
   have := (preadditiveYoneda.obj ((singleFunctor C 0).obj Y)).homologySequence_exact₃ _
-    (op_distinguished _ hS.singleTriangle_distinguished) n₀ n₁ (by grind)
+    (op_distinguished _ hS.singleTriangle_distinguished) n₀ n₁ (by omega)
   rw [ShortComplex.ab_exact_iff_function_exact] at this ⊢
   apply Function.Exact.of_ladder_addEquiv_of_exact' (e₁ := Ext.homAddEquiv)
     (e₂ := Ext.homAddEquiv) (e₃ := Ext.homAddEquiv) (H := this)
@@ -222,7 +222,7 @@ lemma contravariant_sequence_exact₃' :
         simp only [ShortComplex.ShortExact.comp_extClass_assoc])).Exact := by
   letI := HasDerivedCategory.standard C
   have := (preadditiveYoneda.obj ((singleFunctor C 0).obj Y)).homologySequence_exact₁ _
-    (op_distinguished _ hS.singleTriangle_distinguished) n₀ n₁ (by grind)
+    (op_distinguished _ hS.singleTriangle_distinguished) n₀ n₁ (by omega)
   rw [ShortComplex.ab_exact_iff_function_exact] at this ⊢
   apply Function.Exact.of_ladder_addEquiv_of_exact' (e₁ := Ext.homAddEquiv)
     (e₂ := Ext.homAddEquiv) (e₃ := Ext.homAddEquiv) (H := this)

--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/ExtClass.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/ExtClass.lean
@@ -98,7 +98,7 @@ lemma comp_extClass : (Ext.mk₀ S.g).comp hS.extClass (zero_add 1) = 0 := by
 @[simp]
 lemma comp_extClass_assoc {Y : C} {n : ℕ} (γ : Ext S.X₁ Y n) {n' : ℕ} (h : 1 + n = n') :
     (Ext.mk₀ S.g).comp (hS.extClass.comp γ h) (zero_add n') = 0 := by
-  rw [← Ext.comp_assoc (a₁₂ := 1) _ _ _ (by grind) (by grind) (by grind),
+  rw [← Ext.comp_assoc (a₁₂ := 1) _ _ _ (by omega) (by omega) (by omega),
     comp_extClass, Ext.zero_comp]
 
 @[simp]
@@ -112,7 +112,7 @@ lemma extClass_comp : hS.extClass.comp (Ext.mk₀ S.f) (add_zero 1) = 0 := by
 @[simp]
 lemma extClass_comp_assoc {Y : C} {n : ℕ} (γ : Ext S.X₂ Y n) {n' : ℕ} {h : 1 + n = n'} :
     hS.extClass.comp ((Ext.mk₀ S.f).comp γ (zero_add n)) h = 0 := by
-  rw [← Ext.comp_assoc (a₁₂ := 1) _ _ _ (by grind) (by grind) (by grind),
+  rw [← Ext.comp_assoc (a₁₂ := 1) _ _ _ (by omega) (by omega) (by omega),
     extClass_comp, Ext.zero_comp]
 
 end ShortExact

--- a/Mathlib/Algebra/Homology/DerivedCategory/Ext/ExtClass.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Ext/ExtClass.lean
@@ -98,7 +98,7 @@ lemma comp_extClass : (Ext.mk₀ S.g).comp hS.extClass (zero_add 1) = 0 := by
 @[simp]
 lemma comp_extClass_assoc {Y : C} {n : ℕ} (γ : Ext S.X₁ Y n) {n' : ℕ} (h : 1 + n = n') :
     (Ext.mk₀ S.g).comp (hS.extClass.comp γ h) (zero_add n') = 0 := by
-  rw [← Ext.comp_assoc (a₁₂ := 1) _ _ _ (by omega) (by omega) (by omega),
+  rw [← Ext.comp_assoc (a₁₂ := 1) _ _ _ (by grind) (by grind) (by grind),
     comp_extClass, Ext.zero_comp]
 
 @[simp]
@@ -112,7 +112,7 @@ lemma extClass_comp : hS.extClass.comp (Ext.mk₀ S.f) (add_zero 1) = 0 := by
 @[simp]
 lemma extClass_comp_assoc {Y : C} {n : ℕ} (γ : Ext S.X₂ Y n) {n' : ℕ} {h : 1 + n = n'} :
     hS.extClass.comp ((Ext.mk₀ S.f).comp γ (zero_add n)) h = 0 := by
-  rw [← Ext.comp_assoc (a₁₂ := 1) _ _ _ (by omega) (by omega) (by omega),
+  rw [← Ext.comp_assoc (a₁₂ := 1) _ _ _ (by grind) (by grind) (by grind),
     extClass_comp, Ext.zero_comp]
 
 end ShortExact

--- a/Mathlib/Algebra/Homology/DerivedCategory/Fractions.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/Fractions.lean
@@ -164,7 +164,7 @@ lemma subsingleton_hom_of_isStrictlyLE_of_isStrictlyGE (X Y : CochainComplex C �
     ext i
     by_cases hi : a < i
     · apply (X'.isZero_of_isStrictlyLE a i hi).eq_of_src
-    · apply (Y.isZero_of_isStrictlyGE b i (by omega)).eq_of_tgt
+    · apply (Y.isZero_of_isStrictlyGE b i (by grind)).eq_of_tgt
   rw [this, Q.map_zero, comp_zero]
 
 end DerivedCategory

--- a/Mathlib/Algebra/Homology/Embedding/Basic.lean
+++ b/Mathlib/Algebra/Homology/Embedding/Basic.lean
@@ -268,7 +268,7 @@ lemma notMem_range_embeddingUpIntGE_iff (n : ℤ) :
     exact h (n - p).natAbs (by simp; omega)
   · intros
     dsimp
-    omega
+    grind
 
 @[deprecated (since := "2025-05-23")]
 alias not_mem_range_embeddingUpIntGE_iff := notMem_range_embeddingUpIntGE_iff

--- a/Mathlib/Algebra/Homology/Embedding/Boundary.lean
+++ b/Mathlib/Algebra/Homology/Embedding/Boundary.lean
@@ -175,13 +175,13 @@ lemma boundaryGE_embeddingUpIntGE_iff (p : ℤ) (n : ℕ) :
     · rfl
     · have := h.2 n
       dsimp at this
-      omega
+      grind
   · rintro rfl
     constructor
     · simp
     · intro i hi
       dsimp at hi
-      omega
+      grind
 
 lemma boundaryLE_embeddingUpIntLE_iff (p : ℤ) (n : ℕ) :
     (embeddingUpIntLE p).BoundaryLE n ↔ n = 0 := by
@@ -191,12 +191,12 @@ lemma boundaryLE_embeddingUpIntLE_iff (p : ℤ) (n : ℕ) :
     · rfl
     · have := h.2 n
       dsimp at this
-      omega
+      grind
   · rintro rfl
     constructor
     · simp
     · intro i hi
       dsimp at hi
-      omega
+      grind
 
 end ComplexShape

--- a/Mathlib/Algebra/Homology/Embedding/CochainComplex.lean
+++ b/Mathlib/Algebra/Homology/Embedding/CochainComplex.lean
@@ -161,28 +161,28 @@ lemma isStrictlyLE_of_le (p q : ℤ) (hpq : p ≤ q) [K.IsStrictlyLE p] :
   rw [isStrictlyLE_iff]
   intro i hi
   apply K.isZero_of_isStrictlyLE p
-  omega
+  grind
 
 lemma isStrictlyGE_of_ge (p q : ℤ) (hpq : p ≤ q) [K.IsStrictlyGE q] :
     K.IsStrictlyGE p := by
   rw [isStrictlyGE_iff]
   intro i hi
   apply K.isZero_of_isStrictlyGE q
-  omega
+  grind
 
 lemma isLE_of_le (p q : ℤ) (hpq : p ≤ q) [K.IsLE p] :
     K.IsLE q := by
   rw [isLE_iff]
   intro i hi
   apply K.exactAt_of_isLE p
-  omega
+  grind
 
 lemma isGE_of_ge (p q : ℤ) (hpq : p ≤ q) [K.IsGE q] :
     K.IsGE p := by
   rw [isGE_iff]
   intro i hi
   apply K.exactAt_of_isGE q
-  omega
+  grind
 
 section
 
@@ -214,15 +214,15 @@ lemma exists_iso_single (n : ℤ) [K.IsStrictlyGE n] [K.IsStrictlyLE n] :
     ∃ (M : C), Nonempty (K ≅ (single _ _ n).obj M) :=
   ⟨K.X n, ⟨{
       hom := mkHomToSingle (𝟙 _) (fun i (hi : i + 1 = n) ↦
-        (K.isZero_of_isStrictlyGE n i (by omega)).eq_of_src _ _)
+        (K.isZero_of_isStrictlyGE n i (by grind)).eq_of_src _ _)
       inv := mkHomFromSingle (𝟙 _) (fun i (hi : n + 1 = i) ↦
-        (K.isZero_of_isStrictlyLE n i (by omega)).eq_of_tgt _ _)
+        (K.isZero_of_isStrictlyLE n i (by grind)).eq_of_tgt _ _)
       hom_inv_id := by
         ext i
         obtain hi | rfl | hi := lt_trichotomy i n
-        · apply (K.isZero_of_isStrictlyGE n i (by omega)).eq_of_src
+        · apply (K.isZero_of_isStrictlyGE n i (by grind)).eq_of_src
         · simp
-        · apply (K.isZero_of_isStrictlyLE n i (by omega)).eq_of_tgt
+        · apply (K.isZero_of_isStrictlyLE n i (by grind)).eq_of_tgt
       inv_hom_id := by aesop }⟩⟩
 
 instance (A : C) (n : ℤ) :
@@ -273,7 +273,7 @@ lemma quasiIso_truncGEMap_iff :
     obtain ⟨k, rfl⟩ := Int.le.dest hi
     exact h k _ rfl
   · rintro h i i' rfl
-    exact h _ (by dsimp; omega)
+    exact h _ (by dsimp; grind)
 
 lemma quasiIso_truncLEMap_iff :
     QuasiIso (truncLEMap φ n) ↔ ∀ (i : ℤ) (_ : i ≤ n), QuasiIsoAt φ i := by
@@ -281,9 +281,9 @@ lemma quasiIso_truncLEMap_iff :
   constructor
   · intro h i hi
     obtain ⟨k, rfl⟩ := Int.le.dest hi
-    exact h k _ (by dsimp; omega)
+    exact h k _ (by dsimp; grind)
   · rintro h i i' rfl
-    exact h _ (by dsimp; omega)
+    exact h _ (by dsimp; grind)
 
 end
 
@@ -305,13 +305,13 @@ lemma isStrictlyLE_shift (n : ℤ) [K.IsStrictlyLE n] (a n' : ℤ) (h : a + n' =
     (K⟦a⟧).IsStrictlyLE n' := by
   rw [isStrictlyLE_iff]
   intro i hi
-  exact IsZero.of_iso (K.isZero_of_isStrictlyLE n _ (by omega)) (K.shiftFunctorObjXIso a i _ rfl)
+  exact IsZero.of_iso (K.isZero_of_isStrictlyLE n _ (by grind)) (K.shiftFunctorObjXIso a i _ rfl)
 
 lemma isStrictlyGE_shift (n : ℤ) [K.IsStrictlyGE n] (a n' : ℤ) (h : a + n' = n) :
     (K⟦a⟧).IsStrictlyGE n' := by
   rw [isStrictlyGE_iff]
   intro i hi
-  exact IsZero.of_iso (K.isZero_of_isStrictlyGE n _ (by omega)) (K.shiftFunctorObjXIso a i _ rfl)
+  exact IsZero.of_iso (K.isZero_of_isStrictlyGE n _ (by grind)) (K.shiftFunctorObjXIso a i _ rfl)
 
 section
 
@@ -321,14 +321,14 @@ lemma isLE_shift (n : ℤ) [K.IsLE n] (a n' : ℤ) (h : a + n' = n) : (K⟦a⟧)
   rw [isLE_iff]
   intro i hi
   rw [exactAt_iff_isZero_homology]
-  exact IsZero.of_iso (K.isZero_of_isLE n (a + i) (by omega))
+  exact IsZero.of_iso (K.isZero_of_isLE n (a + i) (by grind))
     (((homologyFunctor C _ (0 : ℤ)).shiftIso a i _ rfl).app K)
 
 lemma isGE_shift (n : ℤ) [K.IsGE n] (a n' : ℤ) (h : a + n' = n) : (K⟦a⟧).IsGE n' := by
   rw [isGE_iff]
   intro i hi
   rw [exactAt_iff_isZero_homology]
-  exact IsZero.of_iso (K.isZero_of_isGE n (a + i) (by omega))
+  exact IsZero.of_iso (K.isZero_of_isGE n (a + i) (by grind))
     (((homologyFunctor C _ (0 : ℤ)).shiftIso a i _ rfl).app K)
 
 end

--- a/Mathlib/Algebra/Homology/Embedding/Connect.lean
+++ b/Mathlib/Algebra/Homology/Embedding/Connect.lean
@@ -110,16 +110,16 @@ lemma d_comp_d (n m p : ℤ) : h.d n m ≫ h.d m p = 0 := by
   · rw [h.shape m p hmp, comp_zero]
   obtain n | (_ | _ | n) := n
   · obtain rfl : m = .ofNat (n + 1) := by simp [← hnm]
-    obtain rfl : p = .ofNat (n + 2) := by simp [← hmp]; omega
+    obtain rfl : p = .ofNat (n + 2) := by simp [← hmp]; grind
     simp only [Int.ofNat_eq_coe, X_ofNat, d_ofNat, HomologicalComplex.d_comp_d]
-  · obtain rfl : m = 0 := by omega
-    obtain rfl : p = 1 := by omega
+  · obtain rfl : m = 0 := by grind
+    obtain rfl : p = 1 := by grind
     simp
-  · obtain rfl : m = -1 := by omega
-    obtain rfl : p = 0 := by omega
+  · obtain rfl : m = -1 := by grind
+    obtain rfl : p = 0 := by grind
     simp
-  · obtain rfl : m = .negSucc (n + 1) := by omega
-    obtain rfl : p = .negSucc n := by omega
+  · obtain rfl : m = .negSucc (n + 1) := by grind
+    obtain rfl : p = .negSucc n := by grind
     simp
 
 /-- Given `h : ConnectData K L` where `K : ChainComplex C ℕ` and `L : CochainComplex C ℕ`,

--- a/Mathlib/Algebra/Homology/ExactSequence.lean
+++ b/Mathlib/Algebra/Homology/ExactSequence.lean
@@ -80,8 +80,8 @@ attribute [reassoc] IsComplex.zero
 variable {S}
 
 @[reassoc]
-lemma IsComplex.zero' (hS : S.IsComplex) (i j k : ℕ) (hij : i + 1 = j := by omega)
-    (hjk : j + 1 = k := by omega) (hk : k ≤ n := by omega) :
+lemma IsComplex.zero' (hS : S.IsComplex) (i j k : ℕ) (hij : i + 1 = j := by grind)
+    (hjk : j + 1 = k := by grind) (hk : k ≤ n := by grind) :
     S.map' i j ≫ S.map' j k = 0 := by
   subst hij hjk
   exact hS.zero i hk
@@ -103,7 +103,7 @@ lemma isComplex₀ (S : ComposableArrows C 0) : S.IsComplex where
   zero i hi := by simp +decide at hi
 
 lemma isComplex₁ (S : ComposableArrows C 1) : S.IsComplex where
-  zero i hi := by omega
+  zero i hi := by grind
 
 variable (S)
 
@@ -127,8 +127,8 @@ structure Exact : Prop extends S.IsComplex where
 
 variable {S}
 
-lemma Exact.exact' (hS : S.Exact) (i j k : ℕ) (hij : i + 1 = j := by omega)
-    (hjk : j + 1 = k := by omega) (hk : k ≤ n := by omega) :
+lemma Exact.exact' (hS : S.Exact) (i j k : ℕ) (hij : i + 1 = j := by grind)
+    (hjk : j + 1 = k := by grind) (hk : k ≤ n := by grind) :
     (S.sc' hS.toIsComplex i j k).Exact := by
   subst hij hjk
   exact hS.exact i hk
@@ -191,16 +191,16 @@ lemma exact₀ (S : ComposableArrows C 0) : S.Exact where
 
 lemma exact₁ (S : ComposableArrows C 1) : S.Exact where
   toIsComplex := S.isComplex₁
-  exact i hi := by exfalso; omega
+  exact i hi := by exfalso; grind
 
 lemma isComplex₂_iff (S : ComposableArrows C 2) :
     S.IsComplex ↔ S.map' 0 1 ≫ S.map' 1 2 = 0 := by
   constructor
   · intro h
-    exact h.zero 0 (by omega)
+    exact h.zero 0 (by grind)
   · intro h
     refine IsComplex.mk (fun i hi => ?_)
-    obtain rfl : i = 0 := by omega
+    obtain rfl : i = 0 := by grind
     exact h
 
 lemma isComplex₂_mk (S : ComposableArrows C 2) (w : S.map' 0 1 ≫ S.map' 1 2 = 0) :
@@ -216,10 +216,10 @@ lemma exact₂_iff (S : ComposableArrows C 2) (hS : S.IsComplex) :
     S.Exact ↔ (S.sc' hS 0 1 2).Exact := by
   constructor
   · intro h
-    exact h.exact 0 (by omega)
+    exact h.exact 0 (by grind)
   · intro h
     refine Exact.mk hS (fun i hi => ?_)
-    obtain rfl : i = 0 := by omega
+    obtain rfl : i = 0 := by grind
     exact h
 
 lemma exact₂_mk (S : ComposableArrows C 2) (w : S.map' 0 1 ≫ S.map' 1 2 = 0)
@@ -244,7 +244,7 @@ lemma exact_iff_δ₀ (S : ComposableArrows C (n + 2)) :
     · rw [exact₂_iff]; swap
       · rw [isComplex₂_iff]
         exact h.toIsComplex.zero 0
-      exact h.exact 0 (by omega)
+      exact h.exact 0 (by grind)
     · exact Exact.mk (IsComplex.mk (fun i hi => h.toIsComplex.zero (i + 1)))
         (fun i hi => h.exact (i + 1))
   · rintro ⟨h, h₀⟩
@@ -280,7 +280,7 @@ lemma exact_iff_δlast {n : ℕ} (S : ComposableArrows C (n + 2)) :
     · rw [exact₂_iff]; swap
       · rw [isComplex₂_iff]
         exact h.toIsComplex.zero n
-      exact h.exact n (by omega)
+      exact h.exact n (by grind)
   · rintro ⟨h, h'⟩
     refine Exact.mk (IsComplex.mk (fun i hi => ?_)) (fun i hi => ?_)
     · simp only [Nat.add_le_add_iff_right] at hi

--- a/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
@@ -259,10 +259,10 @@ lemma comp_assoc {n₁ n₂ n₃ n₁₂ n₂₃ n₁₂₃ : ℤ}
       z₁.comp (z₂.comp z₃ h₂₃) (by rw [← h₂₃, ← h₁₂₃, add_assoc]) := by
   substs h₁₂ h₂₃ h₁₂₃
   ext p q hpq
-  rw [comp_v _ _ rfl p (p + n₁ + n₂) q (add_assoc _ _ _).symm (by omega),
-    comp_v z₁ z₂ rfl p (p + n₁) (p + n₁ + n₂) (by omega) (by omega),
-    comp_v z₁ (z₂.comp z₃ rfl) (add_assoc n₁ n₂ n₃).symm p (p + n₁) q (by omega) (by omega),
-    comp_v z₂ z₃ rfl (p + n₁) (p + n₁ + n₂) q (by omega) (by omega), assoc]
+  rw [comp_v _ _ rfl p (p + n₁ + n₂) q (add_assoc _ _ _).symm (by grind),
+    comp_v z₁ z₂ rfl p (p + n₁) (p + n₁ + n₂) (by grind) (by grind),
+    comp_v z₁ (z₂.comp z₃ rfl) (add_assoc n₁ n₂ n₃).symm p (p + n₁) q (by grind) (by grind),
+    comp_v z₂ z₃ rfl (p + n₁) (p + n₁ + n₂) q (by grind) (by grind), assoc]
 
 /-! The formulation of the associativity of the composition of cochains given by the
 lemma `comp_assoc` often requires a careful selection of degrees with good definitional
@@ -274,19 +274,19 @@ lemma comp_assoc_of_first_is_zero_cochain {n₂ n₃ n₂₃ : ℤ}
     (z₁ : Cochain F G 0) (z₂ : Cochain G K n₂) (z₃ : Cochain K L n₃)
     (h₂₃ : n₂ + n₃ = n₂₃) :
     (z₁.comp z₂ (zero_add n₂)).comp z₃ h₂₃ = z₁.comp (z₂.comp z₃ h₂₃) (zero_add n₂₃) :=
-  comp_assoc _ _ _ _ _ (by omega)
+  comp_assoc _ _ _ _ _ (by grind)
 
 @[simp]
 lemma comp_assoc_of_second_is_zero_cochain {n₁ n₃ n₁₃ : ℤ}
     (z₁ : Cochain F G n₁) (z₂ : Cochain G K 0) (z₃ : Cochain K L n₃) (h₁₃ : n₁ + n₃ = n₁₃) :
     (z₁.comp z₂ (add_zero n₁)).comp z₃ h₁₃ = z₁.comp (z₂.comp z₃ (zero_add n₃)) h₁₃ :=
-  comp_assoc _ _ _ _ _ (by omega)
+  comp_assoc _ _ _ _ _ (by grind)
 
 @[simp]
 lemma comp_assoc_of_third_is_zero_cochain {n₁ n₂ n₁₂ : ℤ}
     (z₁ : Cochain F G n₁) (z₂ : Cochain G K n₂) (z₃ : Cochain K L 0) (h₁₂ : n₁ + n₂ = n₁₂) :
     (z₁.comp z₂ h₁₂).comp z₃ (add_zero n₁₂) = z₁.comp (z₂.comp z₃ (add_zero n₂)) h₁₂ :=
-  comp_assoc _ _ _ _ _ (by omega)
+  comp_assoc _ _ _ _ _ (by grind)
 
 @[simp]
 lemma comp_assoc_of_second_degree_eq_neg_third_degree {n₁ n₂ n₁₂ : ℤ}
@@ -294,37 +294,37 @@ lemma comp_assoc_of_second_degree_eq_neg_third_degree {n₁ n₂ n₁₂ : ℤ}
     (z₁.comp z₂ h₁₂).comp z₃
       (show n₁₂ + n₂ = n₁ by rw [← h₁₂, add_assoc, neg_add_cancel, add_zero]) =
       z₁.comp (z₂.comp z₃ (neg_add_cancel n₂)) (add_zero n₁) :=
-  comp_assoc _ _ _ _ _ (by omega)
+  comp_assoc _ _ _ _ _ (by grind)
 
 @[simp]
 protected lemma zero_comp {n₁ n₂ n₁₂ : ℤ} (z₂ : Cochain G K n₂)
     (h : n₁ + n₂ = n₁₂) : (0 : Cochain F G n₁).comp z₂ h = 0 := by
   ext p q hpq
-  simp only [comp_v _ _ h p _ q rfl (by omega), zero_v, zero_comp]
+  simp only [comp_v _ _ h p _ q rfl (by grind), zero_v, zero_comp]
 
 @[simp]
 protected lemma add_comp {n₁ n₂ n₁₂ : ℤ} (z₁ z₁' : Cochain F G n₁) (z₂ : Cochain G K n₂)
     (h : n₁ + n₂ = n₁₂) : (z₁ + z₁').comp z₂ h = z₁.comp z₂ h + z₁'.comp z₂ h := by
   ext p q hpq
-  simp only [comp_v _ _ h p _ q rfl (by omega), add_v, add_comp]
+  simp only [comp_v _ _ h p _ q rfl (by grind), add_v, add_comp]
 
 @[simp]
 protected lemma sub_comp {n₁ n₂ n₁₂ : ℤ} (z₁ z₁' : Cochain F G n₁) (z₂ : Cochain G K n₂)
     (h : n₁ + n₂ = n₁₂) : (z₁ - z₁').comp z₂ h = z₁.comp z₂ h - z₁'.comp z₂ h := by
   ext p q hpq
-  simp only [comp_v _ _ h p _ q rfl (by omega), sub_v, sub_comp]
+  simp only [comp_v _ _ h p _ q rfl (by grind), sub_v, sub_comp]
 
 @[simp]
 protected lemma neg_comp {n₁ n₂ n₁₂ : ℤ} (z₁ : Cochain F G n₁) (z₂ : Cochain G K n₂)
     (h : n₁ + n₂ = n₁₂) : (-z₁).comp z₂ h = -z₁.comp z₂ h := by
   ext p q hpq
-  simp only [comp_v _ _ h p _ q rfl (by omega), neg_v, neg_comp]
+  simp only [comp_v _ _ h p _ q rfl (by grind), neg_v, neg_comp]
 
 @[simp]
 protected lemma smul_comp {n₁ n₂ n₁₂ : ℤ} (k : R) (z₁ : Cochain F G n₁) (z₂ : Cochain G K n₂)
     (h : n₁ + n₂ = n₁₂) : (k • z₁).comp z₂ h = k • (z₁.comp z₂ h) := by
   ext p q hpq
-  simp only [comp_v _ _ h p _ q rfl (by omega), smul_v, Linear.smul_comp]
+  simp only [comp_v _ _ h p _ q rfl (by grind), smul_v, Linear.smul_comp]
 
 @[simp]
 lemma units_smul_comp {n₁ n₂ n₁₂ : ℤ} (k : Rˣ) (z₁ : Cochain F G n₁) (z₂ : Cochain G K n₂)
@@ -341,31 +341,31 @@ protected lemma id_comp {n : ℤ} (z₂ : Cochain F G n) :
 protected lemma comp_zero {n₁ n₂ n₁₂ : ℤ} (z₁ : Cochain F G n₁)
     (h : n₁ + n₂ = n₁₂) : z₁.comp (0 : Cochain G K n₂) h = 0 := by
   ext p q hpq
-  simp only [comp_v _ _ h p _ q rfl (by omega), zero_v, comp_zero]
+  simp only [comp_v _ _ h p _ q rfl (by grind), zero_v, comp_zero]
 
 @[simp]
 protected lemma comp_add {n₁ n₂ n₁₂ : ℤ} (z₁ : Cochain F G n₁) (z₂ z₂' : Cochain G K n₂)
     (h : n₁ + n₂ = n₁₂) : z₁.comp (z₂ + z₂') h = z₁.comp z₂ h + z₁.comp z₂' h := by
   ext p q hpq
-  simp only [comp_v _ _ h p _ q rfl (by omega), add_v, comp_add]
+  simp only [comp_v _ _ h p _ q rfl (by grind), add_v, comp_add]
 
 @[simp]
 protected lemma comp_sub {n₁ n₂ n₁₂ : ℤ} (z₁ : Cochain F G n₁) (z₂ z₂' : Cochain G K n₂)
     (h : n₁ + n₂ = n₁₂) : z₁.comp (z₂ - z₂') h = z₁.comp z₂ h - z₁.comp z₂' h := by
   ext p q hpq
-  simp only [comp_v _ _ h p _ q rfl (by omega), sub_v, comp_sub]
+  simp only [comp_v _ _ h p _ q rfl (by grind), sub_v, comp_sub]
 
 @[simp]
 protected lemma comp_neg {n₁ n₂ n₁₂ : ℤ} (z₁ : Cochain F G n₁) (z₂ : Cochain G K n₂)
     (h : n₁ + n₂ = n₁₂) : z₁.comp (-z₂) h = -z₁.comp z₂ h := by
   ext p q hpq
-  simp only [comp_v _ _ h p _ q rfl (by omega), neg_v, comp_neg]
+  simp only [comp_v _ _ h p _ q rfl (by grind), neg_v, comp_neg]
 
 @[simp]
 protected lemma comp_smul {n₁ n₂ n₁₂ : ℤ} (z₁ : Cochain F G n₁) (k : R) (z₂ : Cochain G K n₂)
     (h : n₁ + n₂ = n₁₂) : z₁.comp (k • z₂) h = k • (z₁.comp z₂ h) := by
   ext p q hpq
-  simp only [comp_v _ _ h p _ q rfl (by omega), smul_v, Linear.comp_smul]
+  simp only [comp_v _ _ h p _ q rfl (by grind), smul_v, Linear.comp_smul]
 
 @[simp]
 lemma comp_units_smul {n₁ n₂ n₁₂ : ℤ} (z₁ : Cochain F G n₁) (k : Rˣ) (z₂ : Cochain G K n₂)
@@ -415,8 +415,8 @@ lemma δ_v (hnm : n + 1 = m) (z : Cochain F G n) (p q : ℤ) (hpq : p + m = q) (
     z.v p q₁ (by rw [hq₁, ← hpq, ← hnm, ← add_assoc, add_sub_cancel_right]) ≫ G.d q₁ q
       + m.negOnePow • F.d p q₂ ≫ z.v q₂ q
           (by rw [← hq₂, add_assoc, add_comm 1, hnm, hpq]) := by
-  obtain rfl : q₁ = p + n := by omega
-  obtain rfl : q₂ = p + m - n := by omega
+  obtain rfl : q₁ = p + n := by grind
+  obtain rfl : q₂ = p + m - n := by grind
   rfl
 
 lemma δ_shape (hnm : ¬ n + 1 = m) (z : Cochain F G n) : δ n m z = 0 := by
@@ -425,7 +425,7 @@ lemma δ_shape (hnm : ¬ n + 1 = m) (z : Cochain F G n) : δ n m z = 0 := by
   rw [Cochain.mk_v, Cochain.zero_v, F.shape, G.shape, comp_zero, zero_add, zero_comp, smul_zero]
   all_goals
     simp only [ComplexShape.up_Rel]
-    exact fun _ => hnm (by omega)
+    exact fun _ => hnm (by grind)
 
 variable (F G) (R)
 
@@ -475,8 +475,8 @@ lemma δ_δ (n₀ n₁ n₂ : ℤ) (z : Cochain F G n₀) : δ n₁ n₂ (δ n�
   ext p q hpq
   dsimp
   simp only [δ_v n₁ n₂ h₁₂ _ p q hpq _ _ rfl rfl,
-    δ_v n₀ n₁ h₀₁ z p (q-1) (by omega) (q-2) _ (by omega) rfl,
-    δ_v n₀ n₁ h₀₁ z (p+1) q (by omega) _ (p+2) rfl (by omega),
+    δ_v n₀ n₁ h₀₁ z p (q-1) (by grind) (q-2) _ (by grind) rfl,
+    δ_v n₀ n₁ h₀₁ z (p+1) q (by grind) _ (p+2) rfl (by grind),
     ← h₁₂, Int.negOnePow_succ, add_comp, assoc,
     HomologicalComplex.d_comp_d, comp_zero, zero_add, comp_add,
     HomologicalComplex.d_comp_d_assoc, zero_comp, smul_zero,
@@ -491,14 +491,14 @@ lemma δ_comp {n₁ n₂ n₁₂ : ℤ} (z₁ : Cochain F G n₁) (z₂ : Cochai
   subst h₁₂ h₁ h₂ h
   ext p q hpq
   dsimp
-  rw [z₁.comp_v _ (add_assoc n₁ n₂ 1).symm p _ q rfl (by omega),
-    Cochain.comp_v _ _ (show n₁ + 1 + n₂ = n₁ + n₂ + 1 by omega) p (p+n₁+1) q
-      (by omega) (by omega),
-    δ_v (n₁ + n₂) _ rfl (z₁.comp z₂ rfl) p q hpq (p + n₁ + n₂) _ (by omega) rfl,
+  rw [z₁.comp_v _ (add_assoc n₁ n₂ 1).symm p _ q rfl (by grind),
+    Cochain.comp_v _ _ (show n₁ + 1 + n₂ = n₁ + n₂ + 1 by grind) p (p+n₁+1) q
+      (by grind) (by grind),
+    δ_v (n₁ + n₂) _ rfl (z₁.comp z₂ rfl) p q hpq (p + n₁ + n₂) _ (by grind) rfl,
     z₁.comp_v z₂ rfl p _ _ rfl rfl,
-    z₁.comp_v z₂ rfl (p+1) (p+n₁+1) q (by omega) (by omega),
-    δ_v n₂ (n₂+1) rfl z₂ (p+n₁) q (by omega) (p+n₁+n₂) _ (by omega) rfl,
-    δ_v n₁ (n₁+1) rfl z₁ p (p+n₁+1) (by omega) (p+n₁) _ (by omega) rfl]
+    z₁.comp_v z₂ rfl (p+1) (p+n₁+1) q (by grind) (by grind),
+    δ_v n₂ (n₂+1) rfl z₂ (p+n₁) q (by grind) (p+n₁+n₂) _ (by grind) rfl,
+    δ_v n₁ (n₁+1) rfl z₁ p (p+n₁+1) (by grind) (p+n₁) _ (by grind) rfl]
   simp only [assoc, comp_add, add_comp, Int.negOnePow_succ, Int.negOnePow_add n₁ n₂,
     Units.neg_smul, comp_neg, neg_comp, smul_neg, smul_smul, Linear.units_smul_comp,
     mul_comm n₁.negOnePow n₂.negOnePow, Linear.comp_units_smul, smul_add]
@@ -521,7 +521,7 @@ lemma δ_comp_zero_cochain {n₁ : ℤ} (z₁ : Cochain F G n₁) (z₂ : Cochai
 @[simp]
 lemma δ_zero_cochain_v (z : Cochain F G 0) (p q : ℤ) (hpq : p + 1 = q) :
     (δ 0 1 z).v p q hpq = z.v p p (add_zero p) ≫ G.d p q - F.d p q ≫ z.v q q (add_zero q) := by
-  simp only [δ_v 0 1 (zero_add 1) z p q hpq p q (by omega) hpq, Int.negOnePow_one, Units.neg_smul,
+  simp only [δ_v 0 1 (zero_add 1) z p q hpq p q (by grind) hpq, Int.negOnePow_one, Units.neg_smul,
     one_smul, sub_eq_add_neg]
 
 @[simp]
@@ -531,7 +531,7 @@ lemma δ_ofHom {p : ℤ} (φ : F ⟶ G) : δ 0 p (Cochain.ofHom φ) = 0 := by
     ext
     simp
   · rw [δ_shape]
-    omega
+    grind
 
 @[simp]
 lemma δ_ofHomotopy {φ₁ φ₂ : F ⟶ G} (h : Homotopy φ₁ φ₂) :
@@ -810,7 +810,7 @@ lemma map_comp {n₁ n₂ n₁₂ : ℤ} (z₁ : Cochain F G n₁) (z₂ : Cocha
     (Cochain.comp z₁ z₂ h).map Φ = Cochain.comp (z₁.map Φ) (z₂.map Φ) h := by
   ext p q hpq
   dsimp
-  simp only [map_v, comp_v _ _ h p _ q rfl (by omega), Φ.map_comp]
+  simp only [map_v, comp_v _ _ h p _ q rfl (by grind), Φ.map_comp]
 
 @[simp]
 lemma map_ofHom :

--- a/Mathlib/Algebra/Homology/HomotopyCategory/HomComplexShift.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/HomComplexShift.lean
@@ -66,7 +66,7 @@ lemma leftShift_v (a n' : ℤ) (hn' : n + a = n') (p q : ℤ) (hpq : p + n' = q)
     (γ.leftShift a n' hn').v p q hpq = (a * n' + ((a * (a - 1))/2)).negOnePow •
       (K.shiftFunctorObjXIso a p p'
         (by rw [← add_left_inj n, hp', add_assoc, add_comm a, hn', hpq])).hom ≫ γ.v p' q hp' := by
-  obtain rfl : p' = p + a := by omega
+  obtain rfl : p' = p + a := by grind
   dsimp only [leftShift]
   simp only [mk_v]
 
@@ -93,8 +93,8 @@ def leftUnshift {n' a : ℤ} (γ : Cochain (K⟦a⟧) L n') (n : ℤ) (hn : n + 
 lemma leftUnshift_v {n' a : ℤ} (γ : Cochain (K⟦a⟧) L n') (n : ℤ) (hn : n + a = n')
     (p q : ℤ) (hpq : p + n = q) (p' : ℤ) (hp' : p' + n' = q) :
     (γ.leftUnshift n hn).v p q hpq = (a * n' + ((a * (a-1))/2)).negOnePow •
-      (K.shiftFunctorObjXIso a p' p (by omega)).inv ≫ γ.v p' q (by omega) := by
-  obtain rfl : p' = p - a := by omega
+      (K.shiftFunctorObjXIso a p' p (by grind)).inv ≫ γ.v p' q (by grind) := by
+  obtain rfl : p' = p - a := by grind
   rfl
 
 /-- The map `Cochain K L n → Cochain (K⟦a⟧) (L⟦a⟧) n`. -/
@@ -111,7 +111,7 @@ lemma shift_v (a : ℤ) (p q : ℤ) (hpq : p + n = q) (p' q' : ℤ)
   rfl
 
 lemma shift_v' (a : ℤ) (p q : ℤ) (hpq : p + n = q) :
-    (γ.shift a).v p q hpq = γ.v (p + a) (q + a) (by omega) := by
+    (γ.shift a).v p q hpq = γ.v (p + a) (q + a) (by grind) := by
   simp only [shift_v γ a p q hpq _ _ rfl rfl, shiftFunctor_obj_X, shiftFunctorObjXIso,
     HomologicalComplex.XIsoOfEq_rfl, Iso.refl_hom, Iso.refl_inv, comp_id, id_comp]
 
@@ -135,16 +135,16 @@ lemma rightShift_rightUnshift {a n' : ℤ} (γ : Cochain K (L⟦a⟧) n') (n : �
 lemma leftUnshift_leftShift (a n' : ℤ) (hn' : n + a = n') :
     (γ.leftShift a n' hn').leftUnshift n hn' = γ := by
   ext p q hpq
-  rw [(γ.leftShift a n' hn').leftUnshift_v n hn' p q hpq (q-n') (by omega),
-    γ.leftShift_v a n' hn' (q-n') q (by omega) p hpq, Linear.comp_units_smul,
+  rw [(γ.leftShift a n' hn').leftUnshift_v n hn' p q hpq (q-n') (by grind),
+    γ.leftShift_v a n' hn' (q-n') q (by grind) p hpq, Linear.comp_units_smul,
     Iso.inv_hom_id_assoc, smul_smul, Int.units_mul_self, one_smul]
 
 @[simp]
 lemma leftShift_leftUnshift {a n' : ℤ} (γ : Cochain (K⟦a⟧) L n') (n : ℤ) (hn' : n + a = n') :
     (γ.leftUnshift n hn').leftShift a n' hn' = γ := by
   ext p q hpq
-  rw [(γ.leftUnshift n hn').leftShift_v a n' hn' p q hpq (q-n) (by omega),
-    γ.leftUnshift_v n hn' (q-n) q (by omega) p hpq, Linear.comp_units_smul, smul_smul,
+  rw [(γ.leftUnshift n hn').leftShift_v a n' hn' p q hpq (q-n) (by grind),
+    γ.leftUnshift_v n hn' (q-n) q (by grind) p hpq, Linear.comp_units_smul, smul_smul,
     Iso.hom_inv_id_assoc, Int.units_mul_self, one_smul]
 
 @[simp]
@@ -159,7 +159,7 @@ lemma leftShift_add (a n' : ℤ) (hn' : n + a = n') :
     (γ₁ + γ₂).leftShift a n' hn' = γ₁.leftShift a n' hn' + γ₂.leftShift a n' hn' := by
   ext p q hpq
   dsimp
-  simp only [leftShift_v _ a n' hn' p q hpq (p + a) (by omega), add_v, comp_add, smul_add]
+  simp only [leftShift_v _ a n' hn' p q hpq (p + a) (by grind), add_v, comp_add, smul_add]
 
 @[simp]
 lemma shift_add (a : ℤ) :
@@ -283,7 +283,7 @@ lemma leftShift_smul (a n' : ℤ) (hn' : n + a = n') (x : R) :
     (x • γ).leftShift a n' hn' = x • γ.leftShift a n' hn' := by
   ext p q hpq
   dsimp
-  simp only [leftShift_v _ a n' hn' p q hpq (p + a) (by omega), smul_v, Linear.comp_smul,
+  simp only [leftShift_v _ a n' hn' p q hpq (p + a) (by grind), smul_v, Linear.comp_smul,
     smul_comm x]
 
 @[simp]
@@ -364,25 +364,25 @@ lemma leftUnshift_units_smul {n' a : ℤ} (γ : Cochain (K⟦a⟧) L n') (n : �
 lemma rightUnshift_comp {m : ℤ} {a : ℤ} (γ' : Cochain L (M⟦a⟧) m) {nm : ℤ} (hnm : n + m = nm)
     (nm' : ℤ) (hnm' : nm + a = nm') (m' : ℤ) (hm' : m + a = m') :
     (γ.comp γ' hnm).rightUnshift nm' hnm' =
-      γ.comp (γ'.rightUnshift m' hm') (by omega) := by
+      γ.comp (γ'.rightUnshift m' hm') (by grind) := by
   ext p q hpq
-  rw [(γ.comp γ' hnm).rightUnshift_v nm' hnm' p q hpq (p + n + m) (by omega),
+  rw [(γ.comp γ' hnm).rightUnshift_v nm' hnm' p q hpq (p + n + m) (by grind),
     γ.comp_v γ' hnm p (p + n) (p + n + m) rfl rfl,
-    comp_v _ _ (show n + m' = nm' by omega) p (p + n) q (by omega) (by omega),
-    γ'.rightUnshift_v m' hm' (p + n) q (by omega) (p + n + m) rfl, assoc]
+    comp_v _ _ (show n + m' = nm' by grind) p (p + n) q (by grind) (by grind),
+    γ'.rightUnshift_v m' hm' (p + n) q (by grind) (p + n + m) rfl, assoc]
 
 lemma leftShift_comp (a n' : ℤ) (hn' : n + a = n') {m t t' : ℤ} (γ' : Cochain L M m)
     (h : n + m = t) (ht' : t + a = t') :
     (γ.comp γ' h).leftShift a t' ht' = (a * m).negOnePow • (γ.leftShift a n' hn').comp γ'
       (by rw [← ht', ← h, ← hn', add_assoc, add_comm a, add_assoc]) := by
   ext p q hpq
-  have h' : n' + m = t' := by omega
+  have h' : n' + m = t' := by grind
   dsimp
-  simp only [Cochain.comp_v _ _ h' p (p + n') q rfl (by omega),
-    γ.leftShift_v a n' hn' p (p + n') rfl (p + a) (by omega),
-    (γ.comp γ' h).leftShift_v a t' (by omega) p q hpq (p + a) (by omega),
+  simp only [Cochain.comp_v _ _ h' p (p + n') q rfl (by grind),
+    γ.leftShift_v a n' hn' p (p + n') rfl (p + a) (by grind),
+    (γ.comp γ' h).leftShift_v a t' (by grind) p q hpq (p + a) (by grind),
     smul_smul, Linear.units_smul_comp, assoc, Int.negOnePow_add, ← mul_assoc, ← h',
-    comp_v _ _ h (p + a) (p + n') q (by omega) (by omega)]
+    comp_v _ _ h (p + a) (p + n') q (by grind) (by grind)]
   congr 2
   rw [add_comm n', mul_add, Int.negOnePow_add]
 
@@ -395,14 +395,14 @@ lemma leftShift_comp_zero_cochain (a n' : ℤ) (hn' : n + a = n') (γ' : Cochain
 lemma δ_rightShift (a n' m' : ℤ) (hn' : n' + a = n) (m : ℤ) (hm' : m' + a = m) :
     δ n' m' (γ.rightShift a n' hn') = a.negOnePow • (δ n m γ).rightShift a m' hm' := by
   by_cases hnm : n + 1 = m
-  · have hnm' : n' + 1 = m' := by omega
+  · have hnm' : n' + 1 = m' := by grind
     ext p q hpq
     dsimp
     rw [(δ n m γ).rightShift_v a m' hm' p q hpq _ rfl,
-      δ_v n m hnm _ p (p+m) rfl (p+n) (p+1) (by omega) rfl,
-      δ_v n' m' hnm' _ p q hpq (p+n') (p+1) (by omega) rfl,
+      δ_v n m hnm _ p (p+m) rfl (p+n) (p+1) (by grind) rfl,
+      δ_v n' m' hnm' _ p q hpq (p+n') (p+1) (by grind) rfl,
       γ.rightShift_v a n' hn' p (p+n') rfl (p+n) rfl,
-      γ.rightShift_v a n' hn' (p+1) q _ (p+m) (by omega)]
+      γ.rightShift_v a n' hn' (p+1) q _ (p+m) (by grind)]
     simp only [shiftFunctorObjXIso, shiftFunctor_obj_d',
       Linear.comp_units_smul, assoc, HomologicalComplex.XIsoOfEq_inv_comp_d,
       add_comp, HomologicalComplex.d_comp_XIsoOfEq_inv, Linear.units_smul_comp, smul_add,
@@ -410,7 +410,7 @@ lemma δ_rightShift (a n' m' : ℤ) (hn' : n' + a = n) (m : ℤ) (hm' : m' + a =
     congr 1
     simp only [← hm', add_comm m', Int.negOnePow_add, ← mul_assoc,
       Int.units_mul_self, one_mul]
-  · have hnm' : ¬ n' + 1 = m' := fun _ => hnm (by omega)
+  · have hnm' : ¬ n' + 1 = m' := fun _ => hnm (by grind)
     rw [δ_shape _ _ hnm', δ_shape _ _ hnm, rightShift_zero, smul_zero]
 
 lemma δ_rightUnshift {a n' : ℤ} (γ : Cochain K (L⟦a⟧) n') (n : ℤ) (hn : n' + a = n)
@@ -424,14 +424,14 @@ lemma δ_rightUnshift {a n' : ℤ} (γ : Cochain K (L⟦a⟧) n') (n : ℤ) (hn 
 lemma δ_leftShift (a n' m' : ℤ) (hn' : n + a = n') (m : ℤ) (hm' : m + a = m') :
     δ n' m' (γ.leftShift a n' hn') = a.negOnePow • (δ n m γ).leftShift a m' hm' := by
   by_cases hnm : n + 1 = m
-  · have hnm' : n' + 1 = m' := by omega
+  · have hnm' : n' + 1 = m' := by grind
     ext p q hpq
     dsimp
-    rw [(δ n m γ).leftShift_v a m' hm' p q hpq (p+a) (by omega),
-      δ_v n m hnm _ (p+a) q (by omega) (p+n') (p+1+a) (by omega) (by omega),
-      δ_v n' m' hnm' _ p q hpq (p+n') (p+1) (by omega) rfl,
-      γ.leftShift_v a n' hn' p (p+n') rfl (p+a) (by omega),
-      γ.leftShift_v a n' hn' (p+1) q (by omega) (p+1+a) (by omega)]
+    rw [(δ n m γ).leftShift_v a m' hm' p q hpq (p+a) (by grind),
+      δ_v n m hnm _ (p+a) q (by grind) (p+n') (p+1+a) (by grind) (by grind),
+      δ_v n' m' hnm' _ p q hpq (p+n') (p+1) (by grind) rfl,
+      γ.leftShift_v a n' hn' p (p+n') rfl (p+a) (by grind),
+      γ.leftShift_v a n' hn' (p+1) q (by grind) (p+1+a) (by grind)]
     simp only [shiftFunctor_obj_X, shiftFunctorObjXIso, HomologicalComplex.XIsoOfEq_rfl,
       Iso.refl_hom, id_comp, Linear.units_smul_comp, shiftFunctor_obj_d',
       Linear.comp_units_smul, smul_add, smul_smul]
@@ -441,7 +441,7 @@ lemma δ_leftShift (a n' m' : ℤ) (hn' : n + a = n') (m : ℤ) (hm' : m + a = m
     · simp only [← Int.negOnePow_add, ← hn', ← hm', ← hnm]
       congr 1
       linarith
-  · have hnm' : ¬ n' + 1 = m' := fun _ => hnm (by omega)
+  · have hnm' : ¬ n' + 1 = m' := fun _ => hnm (by grind)
     rw [δ_shape _ _ hnm', δ_shape _ _ hnm, leftShift_zero, smul_zero]
 
 lemma δ_leftUnshift {a n' : ℤ} (γ : Cochain (K⟦a⟧) L n') (n : ℤ) (hn : n + a = n')
@@ -460,8 +460,8 @@ lemma δ_shift (a m : ℤ) :
     dsimp
     simp only [shift_v', shiftFunctor_obj_d',
       δ_v n m hnm _ p q hpq (q - 1) (p + 1) rfl rfl,
-      δ_v n m hnm _ (p + a) (q + a) (by omega) (q - 1 + a) (p + 1 + a)
-        (by omega) (by omega),
+      δ_v n m hnm _ (p + a) (q + a) (by grind) (q - 1 + a) (p + 1 + a)
+        (by grind) (by grind),
       smul_add, Linear.units_smul_comp, Linear.comp_units_smul, add_right_inj]
     rw [smul_comm]
   · rw [δ_shape _ _ hnm, δ_shape _ _ hnm, shift_zero, smul_zero]
@@ -470,8 +470,8 @@ lemma leftShift_rightShift (a n' : ℤ) (hn' : n' + a = n) :
     (γ.rightShift a n' hn').leftShift a n hn' =
       (a * n + (a * (a - 1)) / 2).negOnePow • γ.shift a := by
   ext p q hpq
-  simp only [leftShift_v _ a n hn' p q hpq (p + a) (by omega),
-    rightShift_v _ a n' hn' (p + a) q (by omega) (q + a) (by omega), units_smul_v, shift_v']
+  simp only [leftShift_v _ a n hn' p q hpq (p + a) (by grind),
+    rightShift_v _ a n' hn' (p + a) q (by grind) (q + a) (by grind), units_smul_v, shift_v']
   dsimp
   rw [id_comp, comp_id]
 
@@ -479,8 +479,8 @@ lemma rightShift_leftShift (a n' : ℤ) (hn' : n + a = n') :
     (γ.leftShift a n' hn').rightShift a n hn' =
       (a * n' + (a * (a - 1)) / 2).negOnePow • γ.shift a := by
   ext p q hpq
-  simp only [rightShift_v _ a n hn' p q hpq (q + a) (by omega),
-    leftShift_v _ a n' hn' p (q + a) (by omega) (p + a) (by omega), units_smul_v, shift_v']
+  simp only [rightShift_v _ a n hn' p q hpq (q + a) (by grind),
+    leftShift_v _ a n' hn' p (q + a) (by grind) (p + a) (by grind), units_smul_v, shift_v']
   dsimp
   rw [id_comp, comp_id]
 

--- a/Mathlib/Algebra/Homology/HomotopyCategory/MappingCone.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/MappingCone.lean
@@ -95,7 +95,7 @@ lemma inr_f_snd_v (p : ℤ) :
 lemma inl_fst :
     (inl φ).comp (fst φ).1 (neg_add_cancel 1) = Cochain.ofHom (𝟙 F) := by
   ext p
-  simp [Cochain.comp_v _ _ (neg_add_cancel 1) p (p-1) p rfl (by omega)]
+  simp [Cochain.comp_v _ _ (neg_add_cancel 1) p (p-1) p rfl (by grind)]
 
 @[simp]
 lemma inl_snd :
@@ -123,27 +123,27 @@ it is also interesting to have `reassoc` variants of lemmas, like `inl_fst_assoc
 @[simp]
 lemma inl_fst_assoc {K : CochainComplex C ℤ} {d e : ℤ} (γ : Cochain F K d) (he : 1 + d = e) :
     (inl φ).comp ((fst φ).1.comp γ he) (by rw [← he, neg_add_cancel_left]) = γ := by
-  rw [← Cochain.comp_assoc _ _ _ (neg_add_cancel 1) (by omega) (by omega), inl_fst,
+  rw [← Cochain.comp_assoc _ _ _ (neg_add_cancel 1) (by grind) (by grind), inl_fst,
     Cochain.id_comp]
 
 @[simp]
 lemma inl_snd_assoc {K : CochainComplex C ℤ} {d e f : ℤ} (γ : Cochain G K d)
     (he : 0 + d = e) (hf : -1 + e = f) :
     (inl φ).comp ((snd φ).comp γ he) hf = 0 := by
-  obtain rfl : e = d := by omega
+  obtain rfl : e = d := by grind
   rw [← Cochain.comp_assoc_of_second_is_zero_cochain, inl_snd, Cochain.zero_comp]
 
 @[simp]
 lemma inr_fst_assoc {K : CochainComplex C ℤ} {d e f : ℤ} (γ : Cochain F K d)
     (he : 1 + d = e) (hf : 0 + e = f) :
     (Cochain.ofHom (inr φ)).comp ((fst φ).1.comp γ he) hf = 0 := by
-  obtain rfl : e = f := by omega
+  obtain rfl : e = f := by grind
   rw [← Cochain.comp_assoc_of_first_is_zero_cochain, inr_fst, Cochain.zero_comp]
 
 @[simp]
 lemma inr_snd_assoc {K : CochainComplex C ℤ} {d e : ℤ} (γ : Cochain G K d) (he : 0 + d = e) :
     (Cochain.ofHom (inr φ)).comp ((snd φ).comp γ he) (by simp only [← he, zero_add]) = γ := by
-  obtain rfl : d = e := by omega
+  obtain rfl : d = e := by grind
   rw [← Cochain.comp_assoc_of_first_is_zero_cochain, inr_snd, Cochain.id_comp]
 
 lemma ext_to (i j : ℤ) (hij : i + 1 = j) {A : C} {f g : A ⟶ (mappingCone φ).X i}
@@ -162,13 +162,13 @@ lemma ext_to_iff (i j : ℤ) (hij : i + 1 = j) {A : C} (f g : A ⟶ (mappingCone
     exact ext_to φ i j hij h₁ h₂
 
 lemma ext_from (i j : ℤ) (hij : j + 1 = i) {A : C} {f g : (mappingCone φ).X j ⟶ A}
-    (h₁ : (inl φ).v i j (by omega) ≫ f = (inl φ).v i j (by omega) ≫ g)
+    (h₁ : (inl φ).v i j (by grind) ≫ f = (inl φ).v i j (by grind) ≫ g)
     (h₂ : (inr φ).f j ≫ f = (inr φ).f j ≫ g) :
     f = g :=
   homotopyCofiber.ext_from_X φ i j hij h₁ h₂
 
 lemma ext_from_iff (i j : ℤ) (hij : j + 1 = i) {A : C} (f g : (mappingCone φ).X j ⟶ A) :
-    f = g ↔ (inl φ).v i j (by omega) ≫ f = (inl φ).v i j (by omega) ≫ g ∧
+    f = g ↔ (inl φ).v i j (by grind) ≫ f = (inl φ).v i j (by grind) ≫ g ∧
       (inr φ).f j ≫ f = (inr φ).f j ≫ g := by
   constructor
   · rintro rfl
@@ -177,14 +177,14 @@ lemma ext_from_iff (i j : ℤ) (hij : j + 1 = i) {A : C} (f g : (mappingCone φ)
     exact ext_from φ i j hij h₁ h₂
 
 lemma decomp_to {i : ℤ} {A : C} (f : A ⟶ (mappingCone φ).X i) (j : ℤ) (hij : i + 1 = j) :
-    ∃ (a : A ⟶ F.X j) (b : A ⟶ G.X i), f = a ≫ (inl φ).v j i (by omega) + b ≫ (inr φ).f i :=
+    ∃ (a : A ⟶ F.X j) (b : A ⟶ G.X i), f = a ≫ (inl φ).v j i (by grind) + b ≫ (inr φ).f i :=
   ⟨f ≫ (fst φ).1.v i j hij, f ≫ (snd φ).v i i (add_zero i),
     by apply ext_to φ i j hij <;> simp⟩
 
 lemma decomp_from {j : ℤ} {A : C} (f : (mappingCone φ).X j ⟶ A) (i : ℤ) (hij : j + 1 = i) :
     ∃ (a : F.X i ⟶ A) (b : G.X j ⟶ A),
       f = (fst φ).1.v j i hij ≫ a + (snd φ).v j j (add_zero j) ≫ b :=
-  ⟨(inl φ).v i j (by omega) ≫ f, (inr φ).f j ≫ f,
+  ⟨(inl φ).v i j (by grind) ≫ f, (inr φ).f j ≫ f,
     by apply ext_from φ i j hij <;> simp⟩
 
 lemma ext_cochain_to_iff (i j : ℤ) (hij : i + 1 = j)
@@ -197,7 +197,7 @@ lemma ext_cochain_to_iff (i j : ℤ) (hij : i + 1 = j)
   · rintro ⟨h₁, h₂⟩
     ext p q hpq
     rw [ext_to_iff φ q (q + 1) rfl]
-    replace h₁ := Cochain.congr_v h₁ p (q + 1) (by omega)
+    replace h₁ := Cochain.congr_v h₁ p (q + 1) (by grind)
     replace h₂ := Cochain.congr_v h₂ p q hpq
     simp only [Cochain.comp_v _ _ _ p q (q + 1) hpq rfl] at h₁
     simp only [Cochain.comp_zero_cochain_v] at h₂
@@ -206,7 +206,7 @@ lemma ext_cochain_to_iff (i j : ℤ) (hij : i + 1 = j)
 lemma ext_cochain_from_iff (i j : ℤ) (hij : i + 1 = j)
     {K : CochainComplex C ℤ} {γ₁ γ₂ : Cochain (mappingCone φ) K j} :
     γ₁ = γ₂ ↔
-      (inl φ).comp γ₁ (show _ = i by omega) = (inl φ).comp γ₂ (by omega) ∧
+      (inl φ).comp γ₁ (show _ = i by grind) = (inl φ).comp γ₂ (by grind) ∧
         (Cochain.ofHom (inr φ)).comp γ₁ (zero_add j) =
           (Cochain.ofHom (inr φ)).comp γ₂ (zero_add j) := by
   constructor
@@ -215,9 +215,9 @@ lemma ext_cochain_from_iff (i j : ℤ) (hij : i + 1 = j)
   · rintro ⟨h₁, h₂⟩
     ext p q hpq
     rw [ext_from_iff φ (p + 1) p rfl]
-    replace h₁ := Cochain.congr_v h₁ (p + 1) q (by omega)
-    replace h₂ := Cochain.congr_v h₂ p q (by omega)
-    simp only [Cochain.comp_v (inl φ) _ _ (p + 1) p q (by omega) hpq] at h₁
+    replace h₁ := Cochain.congr_v h₁ (p + 1) q (by grind)
+    replace h₂ := Cochain.congr_v h₂ p q (by grind)
+    simp only [Cochain.comp_v (inl φ) _ _ (p + 1) p q (by grind) hpq] at h₁
     simp only [Cochain.zero_cochain_comp_v, Cochain.ofHom_v] at h₂
     exact ⟨h₁, h₂⟩
 
@@ -227,10 +227,10 @@ lemma id :
   simp [ext_cochain_from_iff φ (-1) 0 (neg_add_cancel 1)]
 
 lemma id_X (p q : ℤ) (hpq : p + 1 = q) :
-    (fst φ).1.v p q hpq ≫ (inl φ).v q p (by omega) +
+    (fst φ).1.v p q hpq ≫ (inl φ).v q p (by grind) +
       (snd φ).v p p (add_zero p) ≫ (inr φ).f p = 𝟙 ((mappingCone φ).X p) := by
   simpa only [Cochain.add_v, Cochain.comp_zero_cochain_v, Cochain.ofHom_v, id_f,
-    Cochain.comp_v _ _ (add_neg_cancel 1) p q p hpq (by omega)]
+    Cochain.comp_v _ _ (add_neg_cancel 1) p q p hpq (by grind)]
     using Cochain.congr_v (id φ) p p (add_zero p)
 
 @[reassoc]
@@ -238,7 +238,7 @@ lemma inl_v_d (i j k : ℤ) (hij : i + (-1) = j) (hik : k + (-1) = i) :
     (inl φ).v i j hij ≫ (mappingCone φ).d j i =
       φ.f i ≫ (inr φ).f i - F.d i k ≫ (inl φ).v _ _ hik := by
   dsimp [mappingCone, inl, inr]
-  rw [homotopyCofiber.inlX_d φ j i k (by dsimp; omega) (by dsimp; omega)]
+  rw [homotopyCofiber.inlX_d φ j i k (by dsimp; grind) (by dsimp; grind)]
   abel
 
 @[reassoc]
@@ -255,8 +255,8 @@ lemma d_fst_v (i j k : ℤ) (hij : i + 1 = j) (hjk : j + 1 = k) :
 @[reassoc (attr := simp)]
 lemma d_fst_v' (i j : ℤ) (hij : i + 1 = j) :
     (mappingCone φ).d (i - 1) i ≫ (fst φ).1.v i j hij =
-      -(fst φ).1.v (i - 1) i (by omega) ≫ F.d i j :=
-  d_fst_v φ (i - 1) i j (by omega) hij
+      -(fst φ).1.v (i - 1) i (by grind) ≫ F.d i j :=
+  d_fst_v φ (i - 1) i j (by grind) hij
 
 @[reassoc]
 lemma d_snd_v (i j : ℤ) (hij : i + 1 = j) :
@@ -269,7 +269,7 @@ lemma d_snd_v (i j : ℤ) (hij : i + 1 = j) :
 @[reassoc (attr := simp)]
 lemma d_snd_v' (n : ℤ) :
     (mappingCone φ).d (n - 1) n ≫ (snd φ).v n n (add_zero n) =
-    (fst φ : Cochain (mappingCone φ) F 1).v (n - 1) n (by omega) ≫ φ.f n +
+    (fst φ : Cochain (mappingCone φ) F 1).v (n - 1) n (by grind) ≫ φ.f n +
       (snd φ).v (n - 1) (n - 1) (add_zero _) ≫ G.d (n - 1) n := by
   apply d_snd_v
 
@@ -278,7 +278,7 @@ lemma δ_inl :
     δ (-1) 0 (inl φ) = Cochain.ofHom (φ ≫ inr φ) := by
   ext p
   simp [δ_v (-1) 0 (neg_add_cancel 1) (inl φ) p p (add_zero p) _ _ rfl rfl,
-    inl_v_d φ p (p - 1) (p + 1) (by omega) (by omega)]
+    inl_v_d φ p (p - 1) (p + 1) (by grind) (by grind)]
 
 @[simp]
 lemma δ_snd :
@@ -300,7 +300,7 @@ variable (α : Cochain F K m) (β : Cochain G K n) (h : m + 1 = n)
 
 @[simp]
 lemma inl_descCochain :
-    (inl φ).comp (descCochain φ α β h) (by omega) = α := by
+    (inl φ).comp (descCochain φ α β h) (by grind) = α := by
   simp [descCochain]
 
 @[simp]
@@ -312,20 +312,20 @@ lemma inr_descCochain :
 lemma inl_v_descCochain_v (p₁ p₂ p₃ : ℤ) (h₁₂ : p₁ + (-1) = p₂) (h₂₃ : p₂ + n = p₃) :
     (inl φ).v p₁ p₂ h₁₂ ≫ (descCochain φ α β h).v p₂ p₃ h₂₃ =
         α.v p₁ p₃ (by rw [← h₂₃, ← h₁₂, ← h, add_comm m, add_assoc, neg_add_cancel_left]) := by
-  simpa only [Cochain.comp_v _ _ (show -1 + n = m by omega) p₁ p₂ p₃
-    (by omega) (by omega)] using
-      Cochain.congr_v (inl_descCochain φ α β h) p₁ p₃ (by omega)
+  simpa only [Cochain.comp_v _ _ (show -1 + n = m by grind) p₁ p₂ p₃
+    (by grind) (by grind)] using
+      Cochain.congr_v (inl_descCochain φ α β h) p₁ p₃ (by grind)
 
 @[reassoc (attr := simp)]
 lemma inr_f_descCochain_v (p₁ p₂ : ℤ) (h₁₂ : p₁ + n = p₂) :
     (inr φ).f p₁ ≫ (descCochain φ α β h).v p₁ p₂ h₁₂ = β.v p₁ p₂ h₁₂ := by
   simpa only [Cochain.comp_v _ _ (zero_add n) p₁ p₁ p₂ (add_zero p₁) h₁₂, Cochain.ofHom_v]
-    using Cochain.congr_v (inr_descCochain φ α β h) p₁ p₂ (by omega)
+    using Cochain.congr_v (inr_descCochain φ α β h) p₁ p₂ (by grind)
 
 lemma δ_descCochain (n' : ℤ) (hn' : n + 1 = n') :
     δ n n' (descCochain φ α β h) =
       (fst φ).1.comp (δ m n α +
-          n'.negOnePow • (Cochain.ofHom φ).comp β (zero_add n)) (by omega) +
+          n'.negOnePow • (Cochain.ofHom φ).comp β (zero_add n)) (by grind) +
       (snd φ).comp (δ n n' β) (zero_add n') := by
   dsimp only [descCochain]
   simp only [δ_add, Cochain.comp_add, δ_comp (fst φ).1 α _ 2 n n' hn' (by omega) (by omega),
@@ -384,7 +384,7 @@ lemma inr_f_desc_f (p : ℤ) :
 lemma inr_desc : inr φ ≫ desc φ α β eq = β := by aesop_cat
 
 lemma desc_f (p q : ℤ) (hpq : p + 1 = q) :
-    (desc φ α β eq).f p = (fst φ).1.v p q hpq ≫ α.v q p (by omega) +
+    (desc φ α β eq).f p = (fst φ).1.v p q hpq ≫ α.v q p (by grind) +
       (snd φ).v p p (add_zero p) ≫ β.f p := by
   simp [ext_from_iff _ _ _ hpq]
 
@@ -427,18 +427,18 @@ lemma liftCochain_snd :
 
 @[reassoc (attr := simp)]
 lemma liftCochain_v_fst_v (p₁ p₂ p₃ : ℤ) (h₁₂ : p₁ + n = p₂) (h₂₃ : p₂ + 1 = p₃) :
-    (liftCochain φ α β h).v p₁ p₂ h₁₂ ≫ (fst φ).1.v p₂ p₃ h₂₃ = α.v p₁ p₃ (by omega) := by
+    (liftCochain φ α β h).v p₁ p₂ h₁₂ ≫ (fst φ).1.v p₂ p₃ h₂₃ = α.v p₁ p₃ (by grind) := by
   simpa only [Cochain.comp_v _ _ h p₁ p₂ p₃ h₁₂ h₂₃]
-    using Cochain.congr_v (liftCochain_fst φ α β h) p₁ p₃ (by omega)
+    using Cochain.congr_v (liftCochain_fst φ α β h) p₁ p₃ (by grind)
 
 @[reassoc (attr := simp)]
 lemma liftCochain_v_snd_v (p₁ p₂ : ℤ) (h₁₂ : p₁ + n = p₂) :
     (liftCochain φ α β h).v p₁ p₂ h₁₂ ≫ (snd φ).v p₂ p₂ (add_zero p₂) = β.v p₁ p₂ h₁₂ := by
   simpa only [Cochain.comp_v _ _ (add_zero n) p₁ p₂ p₂ h₁₂ (add_zero p₂)]
-    using Cochain.congr_v (liftCochain_snd φ α β h) p₁ p₂ (by omega)
+    using Cochain.congr_v (liftCochain_snd φ α β h) p₁ p₂ (by grind)
 
 lemma δ_liftCochain (m' : ℤ) (hm' : m + 1 = m') :
-    δ n m (liftCochain φ α β h) = -(δ m m' α).comp (inl φ) (by omega) +
+    δ n m (liftCochain φ α β h) = -(δ m m' α).comp (inl φ) (by grind) +
       (δ n m β + α.comp (Cochain.ofHom φ) (add_zero m)).comp
         (Cochain.ofHom (inr φ)) (add_zero m) := by
   dsimp only [liftCochain]
@@ -491,7 +491,7 @@ lemma lift_fst :
 @[reassoc (attr := simp)]
 lemma lift_f_snd_v (p q : ℤ) (hpq : p + 0 = q) :
     (lift φ α β eq).f p ≫ (snd φ).v p q hpq = β.v p q hpq := by
-  obtain rfl : q = p := by omega
+  obtain rfl : q = p := by grind
   simp [lift]
 
 lemma lift_snd :
@@ -499,7 +499,7 @@ lemma lift_snd :
 
 lemma lift_f (p q : ℤ) (hpq : p + 1 = q) :
     (lift φ α β eq).f p = α.1.v p q hpq ≫
-      (inl φ).v q p (by omega) + β.v p p (add_zero p) ≫ (inr φ).f p := by
+      (inl φ).v q p (by grind) + β.v p p (add_zero p) ≫ (inr φ).f p := by
   simp [ext_to_iff _ _ _ hpq]
 
 end
@@ -525,17 +525,17 @@ variable {K L : CochainComplex C ℤ} {n m : ℤ}
 @[simp]
 lemma liftCochain_descCochain :
     (liftCochain φ α β h).comp (descCochain φ α' β' h') hp =
-      α.comp α' (by omega) + β.comp β' (by omega) := by
+      α.comp α' (by grind) + β.comp β' (by grind) := by
   simp [liftCochain, descCochain,
-    Cochain.comp_assoc α (inl φ) _ _ (show -1 + n' = m' by omega) (by linarith)]
+    Cochain.comp_assoc α (inl φ) _ _ (show -1 + n' = m' by grind) (by linarith)]
 
 lemma liftCochain_v_descCochain_v (p₁ p₂ p₃ : ℤ) (h₁₂ : p₁ + n = p₂) (h₂₃ : p₂ + n' = p₃)
     (q : ℤ) (hq : p₁ + m = q) :
     (liftCochain φ α β h).v p₁ p₂ h₁₂ ≫ (descCochain φ α' β' h').v p₂ p₃ h₂₃ =
-      α.v p₁ q hq ≫ α'.v q p₃ (by omega) + β.v p₁ p₂ h₁₂ ≫ β'.v p₂ p₃ h₂₃ := by
-  have eq := Cochain.congr_v (liftCochain_descCochain φ α β α' β' h h' p hp) p₁ p₃ (by omega)
+      α.v p₁ q hq ≫ α'.v q p₃ (by grind) + β.v p₁ p₂ h₁₂ ≫ β'.v p₂ p₃ h₂₃ := by
+  have eq := Cochain.congr_v (liftCochain_descCochain φ α β α' β' h h' p hp) p₁ p₃ (by grind)
   simpa only [Cochain.comp_v _ _ hp p₁ p₂ p₃ h₁₂ h₂₃, Cochain.add_v,
-    Cochain.comp_v _ _ _ _ _ _ hq (show q + m' = p₃ by omega)] using eq
+    Cochain.comp_v _ _ _ _ _ _ hq (show q + m' = p₃ by grind)] using eq
 
 end
 
@@ -544,7 +544,7 @@ lemma lift_desc_f {K L : CochainComplex C ℤ} (α : Cocycle K F 1) (β : Cochai
     (α' : Cochain F L (-1)) (β' : G ⟶ L)
     (eq' : δ (-1) 0 α' = Cochain.ofHom (φ ≫ β')) (n n' : ℤ) (hnn' : n + 1 = n') :
     (lift φ α β eq).f n ≫ (desc φ α' β' eq').f n =
-    α.1.v n n' hnn' ≫ α'.v n' n (by omega) + β.v n n (add_zero n) ≫ β'.f n := by
+    α.1.v n n' hnn' ≫ α'.v n' n (by grind) + β.v n n (add_zero n) ≫ β'.f n := by
   simp only [lift, desc, Cocycle.homOf_f, liftCocycle_coe, descCocycle_coe, Cocycle.ofHom_coe,
     liftCochain_v_descCochain_v φ α.1 β α' (Cochain.ofHom β') (zero_add 1) (neg_add_cancel 1) 0
     (add_zero 0) n n n (add_zero n) (add_zero n) n' hnn', Cochain.ofHom_v]

--- a/Mathlib/Algebra/Homology/HomotopyCategory/MappingCone.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/MappingCone.lean
@@ -95,7 +95,7 @@ lemma inr_f_snd_v (p : ℤ) :
 lemma inl_fst :
     (inl φ).comp (fst φ).1 (neg_add_cancel 1) = Cochain.ofHom (𝟙 F) := by
   ext p
-  simp [Cochain.comp_v _ _ (neg_add_cancel 1) p (p-1) p rfl (by grind)]
+  simp [Cochain.comp_v _ _ (neg_add_cancel 1) p (p-1) p rfl (by omega)]
 
 @[simp]
 lemma inl_snd :
@@ -123,27 +123,27 @@ it is also interesting to have `reassoc` variants of lemmas, like `inl_fst_assoc
 @[simp]
 lemma inl_fst_assoc {K : CochainComplex C ℤ} {d e : ℤ} (γ : Cochain F K d) (he : 1 + d = e) :
     (inl φ).comp ((fst φ).1.comp γ he) (by rw [← he, neg_add_cancel_left]) = γ := by
-  rw [← Cochain.comp_assoc _ _ _ (neg_add_cancel 1) (by grind) (by grind), inl_fst,
+  rw [← Cochain.comp_assoc _ _ _ (neg_add_cancel 1) (by omega) (by omega), inl_fst,
     Cochain.id_comp]
 
 @[simp]
 lemma inl_snd_assoc {K : CochainComplex C ℤ} {d e f : ℤ} (γ : Cochain G K d)
     (he : 0 + d = e) (hf : -1 + e = f) :
     (inl φ).comp ((snd φ).comp γ he) hf = 0 := by
-  obtain rfl : e = d := by grind
+  obtain rfl : e = d := by omega
   rw [← Cochain.comp_assoc_of_second_is_zero_cochain, inl_snd, Cochain.zero_comp]
 
 @[simp]
 lemma inr_fst_assoc {K : CochainComplex C ℤ} {d e f : ℤ} (γ : Cochain F K d)
     (he : 1 + d = e) (hf : 0 + e = f) :
     (Cochain.ofHom (inr φ)).comp ((fst φ).1.comp γ he) hf = 0 := by
-  obtain rfl : e = f := by grind
+  obtain rfl : e = f := by omega
   rw [← Cochain.comp_assoc_of_first_is_zero_cochain, inr_fst, Cochain.zero_comp]
 
 @[simp]
 lemma inr_snd_assoc {K : CochainComplex C ℤ} {d e : ℤ} (γ : Cochain G K d) (he : 0 + d = e) :
     (Cochain.ofHom (inr φ)).comp ((snd φ).comp γ he) (by simp only [← he, zero_add]) = γ := by
-  obtain rfl : d = e := by grind
+  obtain rfl : d = e := by omega
   rw [← Cochain.comp_assoc_of_first_is_zero_cochain, inr_snd, Cochain.id_comp]
 
 lemma ext_to (i j : ℤ) (hij : i + 1 = j) {A : C} {f g : A ⟶ (mappingCone φ).X i}
@@ -162,13 +162,13 @@ lemma ext_to_iff (i j : ℤ) (hij : i + 1 = j) {A : C} (f g : A ⟶ (mappingCone
     exact ext_to φ i j hij h₁ h₂
 
 lemma ext_from (i j : ℤ) (hij : j + 1 = i) {A : C} {f g : (mappingCone φ).X j ⟶ A}
-    (h₁ : (inl φ).v i j (by grind) ≫ f = (inl φ).v i j (by grind) ≫ g)
+    (h₁ : (inl φ).v i j (by omega) ≫ f = (inl φ).v i j (by omega) ≫ g)
     (h₂ : (inr φ).f j ≫ f = (inr φ).f j ≫ g) :
     f = g :=
   homotopyCofiber.ext_from_X φ i j hij h₁ h₂
 
 lemma ext_from_iff (i j : ℤ) (hij : j + 1 = i) {A : C} (f g : (mappingCone φ).X j ⟶ A) :
-    f = g ↔ (inl φ).v i j (by grind) ≫ f = (inl φ).v i j (by grind) ≫ g ∧
+    f = g ↔ (inl φ).v i j (by omega) ≫ f = (inl φ).v i j (by omega) ≫ g ∧
       (inr φ).f j ≫ f = (inr φ).f j ≫ g := by
   constructor
   · rintro rfl
@@ -177,14 +177,14 @@ lemma ext_from_iff (i j : ℤ) (hij : j + 1 = i) {A : C} (f g : (mappingCone φ)
     exact ext_from φ i j hij h₁ h₂
 
 lemma decomp_to {i : ℤ} {A : C} (f : A ⟶ (mappingCone φ).X i) (j : ℤ) (hij : i + 1 = j) :
-    ∃ (a : A ⟶ F.X j) (b : A ⟶ G.X i), f = a ≫ (inl φ).v j i (by grind) + b ≫ (inr φ).f i :=
+    ∃ (a : A ⟶ F.X j) (b : A ⟶ G.X i), f = a ≫ (inl φ).v j i (by omega) + b ≫ (inr φ).f i :=
   ⟨f ≫ (fst φ).1.v i j hij, f ≫ (snd φ).v i i (add_zero i),
     by apply ext_to φ i j hij <;> simp⟩
 
 lemma decomp_from {j : ℤ} {A : C} (f : (mappingCone φ).X j ⟶ A) (i : ℤ) (hij : j + 1 = i) :
     ∃ (a : F.X i ⟶ A) (b : G.X j ⟶ A),
       f = (fst φ).1.v j i hij ≫ a + (snd φ).v j j (add_zero j) ≫ b :=
-  ⟨(inl φ).v i j (by grind) ≫ f, (inr φ).f j ≫ f,
+  ⟨(inl φ).v i j (by omega) ≫ f, (inr φ).f j ≫ f,
     by apply ext_from φ i j hij <;> simp⟩
 
 lemma ext_cochain_to_iff (i j : ℤ) (hij : i + 1 = j)
@@ -197,7 +197,7 @@ lemma ext_cochain_to_iff (i j : ℤ) (hij : i + 1 = j)
   · rintro ⟨h₁, h₂⟩
     ext p q hpq
     rw [ext_to_iff φ q (q + 1) rfl]
-    replace h₁ := Cochain.congr_v h₁ p (q + 1) (by grind)
+    replace h₁ := Cochain.congr_v h₁ p (q + 1) (by omega)
     replace h₂ := Cochain.congr_v h₂ p q hpq
     simp only [Cochain.comp_v _ _ _ p q (q + 1) hpq rfl] at h₁
     simp only [Cochain.comp_zero_cochain_v] at h₂
@@ -206,7 +206,7 @@ lemma ext_cochain_to_iff (i j : ℤ) (hij : i + 1 = j)
 lemma ext_cochain_from_iff (i j : ℤ) (hij : i + 1 = j)
     {K : CochainComplex C ℤ} {γ₁ γ₂ : Cochain (mappingCone φ) K j} :
     γ₁ = γ₂ ↔
-      (inl φ).comp γ₁ (show _ = i by grind) = (inl φ).comp γ₂ (by grind) ∧
+      (inl φ).comp γ₁ (show _ = i by omega) = (inl φ).comp γ₂ (by omega) ∧
         (Cochain.ofHom (inr φ)).comp γ₁ (zero_add j) =
           (Cochain.ofHom (inr φ)).comp γ₂ (zero_add j) := by
   constructor
@@ -215,9 +215,9 @@ lemma ext_cochain_from_iff (i j : ℤ) (hij : i + 1 = j)
   · rintro ⟨h₁, h₂⟩
     ext p q hpq
     rw [ext_from_iff φ (p + 1) p rfl]
-    replace h₁ := Cochain.congr_v h₁ (p + 1) q (by grind)
-    replace h₂ := Cochain.congr_v h₂ p q (by grind)
-    simp only [Cochain.comp_v (inl φ) _ _ (p + 1) p q (by grind) hpq] at h₁
+    replace h₁ := Cochain.congr_v h₁ (p + 1) q (by omega)
+    replace h₂ := Cochain.congr_v h₂ p q (by omega)
+    simp only [Cochain.comp_v (inl φ) _ _ (p + 1) p q (by omega) hpq] at h₁
     simp only [Cochain.zero_cochain_comp_v, Cochain.ofHom_v] at h₂
     exact ⟨h₁, h₂⟩
 
@@ -227,10 +227,10 @@ lemma id :
   simp [ext_cochain_from_iff φ (-1) 0 (neg_add_cancel 1)]
 
 lemma id_X (p q : ℤ) (hpq : p + 1 = q) :
-    (fst φ).1.v p q hpq ≫ (inl φ).v q p (by grind) +
+    (fst φ).1.v p q hpq ≫ (inl φ).v q p (by omega) +
       (snd φ).v p p (add_zero p) ≫ (inr φ).f p = 𝟙 ((mappingCone φ).X p) := by
   simpa only [Cochain.add_v, Cochain.comp_zero_cochain_v, Cochain.ofHom_v, id_f,
-    Cochain.comp_v _ _ (add_neg_cancel 1) p q p hpq (by grind)]
+    Cochain.comp_v _ _ (add_neg_cancel 1) p q p hpq (by omega)]
     using Cochain.congr_v (id φ) p p (add_zero p)
 
 @[reassoc]
@@ -238,7 +238,7 @@ lemma inl_v_d (i j k : ℤ) (hij : i + (-1) = j) (hik : k + (-1) = i) :
     (inl φ).v i j hij ≫ (mappingCone φ).d j i =
       φ.f i ≫ (inr φ).f i - F.d i k ≫ (inl φ).v _ _ hik := by
   dsimp [mappingCone, inl, inr]
-  rw [homotopyCofiber.inlX_d φ j i k (by dsimp; grind) (by dsimp; grind)]
+  rw [homotopyCofiber.inlX_d φ j i k (by dsimp; omega) (by dsimp; omega)]
   abel
 
 @[reassoc]
@@ -255,8 +255,8 @@ lemma d_fst_v (i j k : ℤ) (hij : i + 1 = j) (hjk : j + 1 = k) :
 @[reassoc (attr := simp)]
 lemma d_fst_v' (i j : ℤ) (hij : i + 1 = j) :
     (mappingCone φ).d (i - 1) i ≫ (fst φ).1.v i j hij =
-      -(fst φ).1.v (i - 1) i (by grind) ≫ F.d i j :=
-  d_fst_v φ (i - 1) i j (by grind) hij
+      -(fst φ).1.v (i - 1) i (by omega) ≫ F.d i j :=
+  d_fst_v φ (i - 1) i j (by omega) hij
 
 @[reassoc]
 lemma d_snd_v (i j : ℤ) (hij : i + 1 = j) :
@@ -269,7 +269,7 @@ lemma d_snd_v (i j : ℤ) (hij : i + 1 = j) :
 @[reassoc (attr := simp)]
 lemma d_snd_v' (n : ℤ) :
     (mappingCone φ).d (n - 1) n ≫ (snd φ).v n n (add_zero n) =
-    (fst φ : Cochain (mappingCone φ) F 1).v (n - 1) n (by grind) ≫ φ.f n +
+    (fst φ : Cochain (mappingCone φ) F 1).v (n - 1) n (by omega) ≫ φ.f n +
       (snd φ).v (n - 1) (n - 1) (add_zero _) ≫ G.d (n - 1) n := by
   apply d_snd_v
 
@@ -278,7 +278,7 @@ lemma δ_inl :
     δ (-1) 0 (inl φ) = Cochain.ofHom (φ ≫ inr φ) := by
   ext p
   simp [δ_v (-1) 0 (neg_add_cancel 1) (inl φ) p p (add_zero p) _ _ rfl rfl,
-    inl_v_d φ p (p - 1) (p + 1) (by grind) (by grind)]
+    inl_v_d φ p (p - 1) (p + 1) (by omega) (by omega)]
 
 @[simp]
 lemma δ_snd :
@@ -300,7 +300,7 @@ variable (α : Cochain F K m) (β : Cochain G K n) (h : m + 1 = n)
 
 @[simp]
 lemma inl_descCochain :
-    (inl φ).comp (descCochain φ α β h) (by grind) = α := by
+    (inl φ).comp (descCochain φ α β h) (by omega) = α := by
   simp [descCochain]
 
 @[simp]
@@ -312,20 +312,20 @@ lemma inr_descCochain :
 lemma inl_v_descCochain_v (p₁ p₂ p₃ : ℤ) (h₁₂ : p₁ + (-1) = p₂) (h₂₃ : p₂ + n = p₃) :
     (inl φ).v p₁ p₂ h₁₂ ≫ (descCochain φ α β h).v p₂ p₃ h₂₃ =
         α.v p₁ p₃ (by rw [← h₂₃, ← h₁₂, ← h, add_comm m, add_assoc, neg_add_cancel_left]) := by
-  simpa only [Cochain.comp_v _ _ (show -1 + n = m by grind) p₁ p₂ p₃
-    (by grind) (by grind)] using
-      Cochain.congr_v (inl_descCochain φ α β h) p₁ p₃ (by grind)
+  simpa only [Cochain.comp_v _ _ (show -1 + n = m by omega) p₁ p₂ p₃
+    (by omega) (by omega)] using
+      Cochain.congr_v (inl_descCochain φ α β h) p₁ p₃ (by omega)
 
 @[reassoc (attr := simp)]
 lemma inr_f_descCochain_v (p₁ p₂ : ℤ) (h₁₂ : p₁ + n = p₂) :
     (inr φ).f p₁ ≫ (descCochain φ α β h).v p₁ p₂ h₁₂ = β.v p₁ p₂ h₁₂ := by
   simpa only [Cochain.comp_v _ _ (zero_add n) p₁ p₁ p₂ (add_zero p₁) h₁₂, Cochain.ofHom_v]
-    using Cochain.congr_v (inr_descCochain φ α β h) p₁ p₂ (by grind)
+    using Cochain.congr_v (inr_descCochain φ α β h) p₁ p₂ (by omega)
 
 lemma δ_descCochain (n' : ℤ) (hn' : n + 1 = n') :
     δ n n' (descCochain φ α β h) =
       (fst φ).1.comp (δ m n α +
-          n'.negOnePow • (Cochain.ofHom φ).comp β (zero_add n)) (by grind) +
+          n'.negOnePow • (Cochain.ofHom φ).comp β (zero_add n)) (by omega) +
       (snd φ).comp (δ n n' β) (zero_add n') := by
   dsimp only [descCochain]
   simp only [δ_add, Cochain.comp_add, δ_comp (fst φ).1 α _ 2 n n' hn' (by omega) (by omega),
@@ -384,7 +384,7 @@ lemma inr_f_desc_f (p : ℤ) :
 lemma inr_desc : inr φ ≫ desc φ α β eq = β := by aesop_cat
 
 lemma desc_f (p q : ℤ) (hpq : p + 1 = q) :
-    (desc φ α β eq).f p = (fst φ).1.v p q hpq ≫ α.v q p (by grind) +
+    (desc φ α β eq).f p = (fst φ).1.v p q hpq ≫ α.v q p (by omega) +
       (snd φ).v p p (add_zero p) ≫ β.f p := by
   simp [ext_from_iff _ _ _ hpq]
 
@@ -427,18 +427,18 @@ lemma liftCochain_snd :
 
 @[reassoc (attr := simp)]
 lemma liftCochain_v_fst_v (p₁ p₂ p₃ : ℤ) (h₁₂ : p₁ + n = p₂) (h₂₃ : p₂ + 1 = p₃) :
-    (liftCochain φ α β h).v p₁ p₂ h₁₂ ≫ (fst φ).1.v p₂ p₃ h₂₃ = α.v p₁ p₃ (by grind) := by
+    (liftCochain φ α β h).v p₁ p₂ h₁₂ ≫ (fst φ).1.v p₂ p₃ h₂₃ = α.v p₁ p₃ (by omega) := by
   simpa only [Cochain.comp_v _ _ h p₁ p₂ p₃ h₁₂ h₂₃]
-    using Cochain.congr_v (liftCochain_fst φ α β h) p₁ p₃ (by grind)
+    using Cochain.congr_v (liftCochain_fst φ α β h) p₁ p₃ (by omega)
 
 @[reassoc (attr := simp)]
 lemma liftCochain_v_snd_v (p₁ p₂ : ℤ) (h₁₂ : p₁ + n = p₂) :
     (liftCochain φ α β h).v p₁ p₂ h₁₂ ≫ (snd φ).v p₂ p₂ (add_zero p₂) = β.v p₁ p₂ h₁₂ := by
   simpa only [Cochain.comp_v _ _ (add_zero n) p₁ p₂ p₂ h₁₂ (add_zero p₂)]
-    using Cochain.congr_v (liftCochain_snd φ α β h) p₁ p₂ (by grind)
+    using Cochain.congr_v (liftCochain_snd φ α β h) p₁ p₂ (by omega)
 
 lemma δ_liftCochain (m' : ℤ) (hm' : m + 1 = m') :
-    δ n m (liftCochain φ α β h) = -(δ m m' α).comp (inl φ) (by grind) +
+    δ n m (liftCochain φ α β h) = -(δ m m' α).comp (inl φ) (by omega) +
       (δ n m β + α.comp (Cochain.ofHom φ) (add_zero m)).comp
         (Cochain.ofHom (inr φ)) (add_zero m) := by
   dsimp only [liftCochain]
@@ -491,7 +491,7 @@ lemma lift_fst :
 @[reassoc (attr := simp)]
 lemma lift_f_snd_v (p q : ℤ) (hpq : p + 0 = q) :
     (lift φ α β eq).f p ≫ (snd φ).v p q hpq = β.v p q hpq := by
-  obtain rfl : q = p := by grind
+  obtain rfl : q = p := by omega
   simp [lift]
 
 lemma lift_snd :
@@ -499,7 +499,7 @@ lemma lift_snd :
 
 lemma lift_f (p q : ℤ) (hpq : p + 1 = q) :
     (lift φ α β eq).f p = α.1.v p q hpq ≫
-      (inl φ).v q p (by grind) + β.v p p (add_zero p) ≫ (inr φ).f p := by
+      (inl φ).v q p (by omega) + β.v p p (add_zero p) ≫ (inr φ).f p := by
   simp [ext_to_iff _ _ _ hpq]
 
 end
@@ -525,17 +525,17 @@ variable {K L : CochainComplex C ℤ} {n m : ℤ}
 @[simp]
 lemma liftCochain_descCochain :
     (liftCochain φ α β h).comp (descCochain φ α' β' h') hp =
-      α.comp α' (by grind) + β.comp β' (by grind) := by
+      α.comp α' (by omega) + β.comp β' (by omega) := by
   simp [liftCochain, descCochain,
-    Cochain.comp_assoc α (inl φ) _ _ (show -1 + n' = m' by grind) (by linarith)]
+    Cochain.comp_assoc α (inl φ) _ _ (show -1 + n' = m' by omega) (by linarith)]
 
 lemma liftCochain_v_descCochain_v (p₁ p₂ p₃ : ℤ) (h₁₂ : p₁ + n = p₂) (h₂₃ : p₂ + n' = p₃)
     (q : ℤ) (hq : p₁ + m = q) :
     (liftCochain φ α β h).v p₁ p₂ h₁₂ ≫ (descCochain φ α' β' h').v p₂ p₃ h₂₃ =
-      α.v p₁ q hq ≫ α'.v q p₃ (by grind) + β.v p₁ p₂ h₁₂ ≫ β'.v p₂ p₃ h₂₃ := by
-  have eq := Cochain.congr_v (liftCochain_descCochain φ α β α' β' h h' p hp) p₁ p₃ (by grind)
+      α.v p₁ q hq ≫ α'.v q p₃ (by omega) + β.v p₁ p₂ h₁₂ ≫ β'.v p₂ p₃ h₂₃ := by
+  have eq := Cochain.congr_v (liftCochain_descCochain φ α β α' β' h h' p hp) p₁ p₃ (by omega)
   simpa only [Cochain.comp_v _ _ hp p₁ p₂ p₃ h₁₂ h₂₃, Cochain.add_v,
-    Cochain.comp_v _ _ _ _ _ _ hq (show q + m' = p₃ by grind)] using eq
+    Cochain.comp_v _ _ _ _ _ _ hq (show q + m' = p₃ by omega)] using eq
 
 end
 
@@ -544,7 +544,7 @@ lemma lift_desc_f {K L : CochainComplex C ℤ} (α : Cocycle K F 1) (β : Cochai
     (α' : Cochain F L (-1)) (β' : G ⟶ L)
     (eq' : δ (-1) 0 α' = Cochain.ofHom (φ ≫ β')) (n n' : ℤ) (hnn' : n + 1 = n') :
     (lift φ α β eq).f n ≫ (desc φ α' β' eq').f n =
-    α.1.v n n' hnn' ≫ α'.v n' n (by grind) + β.v n n (add_zero n) ≫ β'.f n := by
+    α.1.v n n' hnn' ≫ α'.v n' n (by omega) + β.v n n (add_zero n) ≫ β'.f n := by
   simp only [lift, desc, Cocycle.homOf_f, liftCocycle_coe, descCocycle_coe, Cocycle.ofHom_coe,
     liftCochain_v_descCochain_v φ α.1 β α' (Cochain.ofHom β') (zero_add 1) (neg_add_cancel 1) 0
     (add_zero 0) n n n (add_zero n) (add_zero n) n' hnn', Cochain.ofHom_v]

--- a/Mathlib/Algebra/Homology/HomotopyCategory/Pretriangulated.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/Pretriangulated.lean
@@ -58,7 +58,7 @@ lemma inl_v_triangle_mor₃_f (p q : ℤ) (hpq : p + (-1) = q) :
   -- the following list of lemmas was obtained by doing
   -- simp? [Cochain.rightShift_v _ 1 0 (zero_add 1) q q (add_zero q) p (by omega)]
   simp only [Int.reduceNeg, Cochain.rightShift_neg, Cochain.neg_v, shiftFunctor_obj_X',
-    Cochain.rightShift_v _ 1 0 (zero_add 1) q q (add_zero q) p (by omega), shiftFunctor_obj_X,
+    Cochain.rightShift_v _ 1 0 (zero_add 1) q q (add_zero q) p (by grind), shiftFunctor_obj_X,
     shiftFunctorObjXIso, Preadditive.comp_neg, inl_v_fst_v_assoc]
 
 @[reassoc (attr := simp)]
@@ -292,10 +292,10 @@ lemma rotateHomotopyEquiv_comm₃ :
   dsimp [rotateHomotopyEquiv]
   -- the following list of lemmas has been obtained by doing
   -- simp? [lift_f _ _ _ _ _ (p + 1) rfl,
-  --   (Cochain.ofHom φ).leftShift_v 1 1 (zero_add 1) p (p + 1) rfl (p + 1) (by omega)]
+  --   (Cochain.ofHom φ).leftShift_v 1 1 (zero_add 1) p (p + 1) rfl (p + 1) (by grind)]
   simp only [Int.reduceNeg, lift_f _ _ _ _ _ (p + 1) rfl, shiftFunctor_obj_X', Cocycle.coe_neg,
     Cocycle.leftShift_coe, Cocycle.ofHom_coe, Cochain.neg_v,
-    (Cochain.ofHom φ).leftShift_v 1 1 (zero_add 1) p (p + 1) rfl (p + 1) (by omega),
+    (Cochain.ofHom φ).leftShift_v 1 1 (zero_add 1) p (p + 1) rfl (p + 1) (by grind),
     shiftFunctor_obj_X, mul_one, sub_self, mul_zero, Int.zero_ediv, add_zero, Int.negOnePow_one,
     shiftFunctorObjXIso, HomologicalComplex.XIsoOfEq_rfl, Iso.refl_hom, Cochain.ofHom_v, id_comp,
     Units.neg_smul, one_smul, neg_neg, Preadditive.neg_comp, Preadditive.add_comp, assoc,
@@ -401,7 +401,7 @@ lemma map_δ :
     shiftFunctor_obj_X, shiftFunctorObjXIso, HomologicalComplex.XIsoOfEq_rfl, Iso.refl_inv,
     comp_neg, comp_id, inr_f_triangle_mor₃_f, comp_zero, add_zero]
   dsimp [triangle]
-  rw [Cochain.rightShift_v _ 1 0 (by omega) n n (by omega) (n + 1) (by omega)]
+  rw [Cochain.rightShift_v _ 1 0 (by grind) n n (by grind) (n + 1) (by grind)]
   simp only [shiftFunctor_obj_X, Cochain.neg_v, shiftFunctorObjXIso,
     HomologicalComplex.XIsoOfEq_rfl, Iso.refl_inv, comp_id, Functor.map_neg]
 

--- a/Mathlib/Algebra/Homology/HomotopyCategory/ShiftSequence.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/ShiftSequence.lean
@@ -137,7 +137,7 @@ lemma quasiIso_shift_iff {K L : CochainComplex C ℤ} (φ : K ⟶ L) (n : ℤ) :
   simp only [quasiIso_iff, fun i ↦ quasiIsoAt_shift_iff φ n i _ rfl]
   constructor
   · intro h j
-    obtain ⟨i, rfl⟩ : ∃ i, j = n + i := ⟨j - n, by omega⟩
+    obtain ⟨i, rfl⟩ : ∃ i, j = n + i := ⟨j - n, by grind⟩
     exact h i
   · intro h i
     exact h (n + i)
@@ -161,10 +161,10 @@ lemma liftCycles_shift_homologyπ
     (hj : (up ℤ).next i = j) (hf : f ≫ (K⟦n⟧).d i j = 0) (i' : ℤ) (hi' : n + i = i') (j' : ℤ)
     (hj' : (up ℤ).next i' = j') :
     (K⟦n⟧).liftCycles f j hj hf ≫ (K⟦n⟧).homologyπ i =
-      K.liftCycles (f ≫ (K.shiftFunctorObjXIso n i i' (by omega)).hom) j' hj' (by
+      K.liftCycles (f ≫ (K.shiftFunctorObjXIso n i i' (by grind)).hom) j' hj' (by
         simp only [next] at hj hj'
-        obtain rfl : i' = i + n := by omega
-        obtain rfl : j' = j + n := by omega
+        obtain rfl : i' = i + n := by grind
+        obtain rfl : j' = j + n := by grind
         dsimp at hf ⊢
         simp only [Linear.comp_units_smul] at hf
         apply (one_smul (M := ℤˣ) _).symm.trans _

--- a/Mathlib/Algebra/Homology/HomotopyCategory/ShortExact.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/ShortExact.lean
@@ -35,7 +35,7 @@ lemma homologySequenceδ_quotient_mapTriangle_obj
     (homologyFunctor C (up ℤ) 0).homologySequenceδ
         ((quotient C (up ℤ)).mapTriangle.obj T) n₀ n₁ h =
       (homologyFunctorFactors C (up ℤ) n₀).hom.app _ ≫
-        (HomologicalComplex.homologyFunctor C (up ℤ) 0).shiftMap T.mor₃ n₀ n₁ (by omega) ≫
+        (HomologicalComplex.homologyFunctor C (up ℤ) 0).shiftMap T.mor₃ n₀ n₁ (by grind) ≫
         (homologyFunctorFactors C (up ℤ) n₁).inv.app _ := by
   apply homologyFunctor_shiftMap
 
@@ -101,7 +101,7 @@ lemma homologySequenceδ_triangleh (n₀ : ℤ) (n₁ : ℤ) (h : n₀ + 1 = n�
   dsimp [Functor.shiftMap, homologyFunctor_shift]
   rw [HomologicalComplex.homologyπ_naturality_assoc,
     HomologicalComplex.liftCycles_comp_cyclesMap_assoc,
-    S.X₁.liftCycles_shift_homologyπ_assoc _ _ _ _ n₁ (by omega) (n₁ + 1) (by simp),
+    S.X₁.liftCycles_shift_homologyπ_assoc _ _ _ _ n₁ (by grind) (n₁ + 1) (by simp),
     Iso.inv_hom_id_app]
   dsimp [homologyFunctor_shift]
   simp only [hab, add_comp, assoc, inl_v_triangle_mor₃_f_assoc,

--- a/Mathlib/Algebra/Homology/TotalComplexShift.lean
+++ b/Mathlib/Algebra/Homology/TotalComplexShift.lean
@@ -144,8 +144,8 @@ lemma D₁_totalShift₁XIso_hom (n₀ n₁ n₀' n₁' : ℤ) (h₀ : n₀ + x 
     dsimp at h hpq
     dsimp [totalShift₁XIso]
     rw [ι_D₁_assoc, Linear.comp_units_smul, ι_totalDesc_assoc, ι_D₁,
-      ((shiftFunctor₁ C x).obj K).d₁_eq _ rfl _ _ (by dsimp; omega),
-      K.d₁_eq _ (show p + x + 1 = p + 1 + x by omega) _ _ (by dsimp; omega)]
+      ((shiftFunctor₁ C x).obj K).d₁_eq _ rfl _ _ (by dsimp; grind),
+      K.d₁_eq _ (show p + x + 1 = p + 1 + x by grind) _ _ (by dsimp; grind)]
     dsimp
     rw [one_smul, Category.assoc, ι_totalDesc, one_smul, Linear.units_smul_comp]
   · rw [D₁_shape _ _ _ _ h, zero_comp, D₁_shape, comp_zero, smul_zero]
@@ -161,8 +161,8 @@ lemma D₂_totalShift₁XIso_hom (n₀ n₁ n₀' n₁' : ℤ) (h₀ : n₀ + x 
     dsimp at h hpq
     dsimp [totalShift₁XIso]
     rw [ι_D₂_assoc, Linear.comp_units_smul, ι_totalDesc_assoc, ι_D₂,
-      ((shiftFunctor₁ C x).obj K).d₂_eq _ _ rfl _ (by dsimp; omega),
-      K.d₂_eq _ _ rfl _ (by dsimp; omega), smul_smul,
+      ((shiftFunctor₁ C x).obj K).d₂_eq _ _ rfl _ (by dsimp; grind),
+      K.d₂_eq _ _ rfl _ (by dsimp; grind), smul_smul,
       Linear.units_smul_comp, Category.assoc, ι_totalDesc]
     dsimp
     congr 1
@@ -198,10 +198,10 @@ lemma ι_totalShift₁Iso_inv_f (a b n : ℤ) (h : a + b = n) (a' n' : ℤ)
     K.ιTotal (up ℤ) a' b n' ha' ≫
       (CochainComplex.shiftFunctorObjXIso (K.total (up ℤ)) x n n' hn').inv ≫
         (K.totalShift₁Iso x).inv.f n =
-      (K.shiftFunctor₁XXIso a x a' (by omega) b).inv ≫
+      (K.shiftFunctor₁XXIso a x a' (by grind) b).inv ≫
         ((shiftFunctor₁ C x).obj K).ιTotal (up ℤ) a b n h := by
   subst hn'
-  obtain rfl : a = a' - x := by omega
+  obtain rfl : a = a' - x := by grind
   dsimp [totalShift₁Iso, totalShift₁XIso, shiftFunctor₁XXIso, XXIsoOfEq]
   simp only [id_comp, ι_totalDesc]
 
@@ -248,8 +248,8 @@ lemma D₁_totalShift₂XIso_hom (n₀ n₁ n₀' n₁' : ℤ) (h₀ : n₀ + y 
     dsimp at h hpq
     dsimp [totalShift₂XIso]
     rw [ι_D₁_assoc, Linear.comp_units_smul, ι_totalDesc_assoc, Linear.units_smul_comp,
-      ι_D₁, smul_smul, ((shiftFunctor₂ C y).obj K).d₁_eq _ rfl _ _ (by dsimp; omega),
-      K.d₁_eq _ rfl _ _ (by dsimp; omega)]
+      ι_D₁, smul_smul, ((shiftFunctor₂ C y).obj K).d₁_eq _ rfl _ _ (by dsimp; grind),
+      K.d₁_eq _ rfl _ _ (by dsimp; grind)]
     dsimp
     rw [one_smul, one_smul, Category.assoc, ι_totalDesc, Linear.comp_units_smul,
       ← Int.negOnePow_add]
@@ -268,15 +268,15 @@ lemma D₂_totalShift₂XIso_hom (n₀ n₁ n₀' n₁' : ℤ) (h₀ : n₀ + y 
     dsimp at h hpq
     dsimp [totalShift₂XIso]
     rw [ι_D₂_assoc, Linear.comp_units_smul, ι_totalDesc_assoc, Linear.units_smul_comp,
-      smul_smul, ι_D₂, ((shiftFunctor₂ C y).obj K).d₂_eq _ _ rfl _ (by dsimp; omega),
-      K.d₂_eq _ _ (show q + y + 1 = q + 1 + y by omega) _ (by dsimp; omega),
+      smul_smul, ι_D₂, ((shiftFunctor₂ C y).obj K).d₂_eq _ _ rfl _ (by dsimp; grind),
+      K.d₂_eq _ _ (show q + y + 1 = q + 1 + y by grind) _ (by dsimp; grind),
       Linear.units_smul_comp, Category.assoc, smul_smul, ι_totalDesc]
     dsimp
     rw [Linear.units_smul_comp, Linear.comp_units_smul, smul_smul, smul_smul,
       ← Int.negOnePow_add, ← Int.negOnePow_add, ← Int.negOnePow_add,
       ← Int.negOnePow_add]
     congr 2
-    omega
+    grind
   · rw [D₂_shape _ _ _ _ h, zero_comp, D₂_shape, comp_zero, smul_zero]
     simp_all only [up_Rel]
     grind
@@ -299,7 +299,7 @@ lemma ι_totalShift₂Iso_hom_f (a b n : ℤ) (h : a + b = n) (b' : ℤ) (hb' : 
     (n' : ℤ) (hn' : n' = n + y) :
     ((shiftFunctor₂ C y).obj K).ιTotal (up ℤ) a b n h ≫ (K.totalShift₂Iso y).hom.f n =
       (a * y).negOnePow • (K.shiftFunctor₂XXIso a b y b' hb').hom ≫
-        K.ιTotal (up ℤ) a b' n' (by dsimp; omega) ≫
+        K.ιTotal (up ℤ) a b' n' (by dsimp; grind) ≫
           (CochainComplex.shiftFunctorObjXIso (K.total (up ℤ)) y n n' hn').inv := by
   subst hb' hn'
   dsimp [totalShift₂Iso, totalShift₂XIso]
@@ -311,10 +311,10 @@ lemma ι_totalShift₂Iso_inv_f (a b n : ℤ) (h : a + b = n) (b' n' : ℤ)
     K.ιTotal (up ℤ) a b' n' hb' ≫
       (CochainComplex.shiftFunctorObjXIso (K.total (up ℤ)) y n n' hn').inv ≫
         (K.totalShift₂Iso y).inv.f n =
-      (a * y).negOnePow • (K.shiftFunctor₂XXIso a b y b' (by omega)).inv ≫
+      (a * y).negOnePow • (K.shiftFunctor₂XXIso a b y b' (by grind)).inv ≫
         ((shiftFunctor₂ C y).obj K).ιTotal (up ℤ) a b n h := by
   subst hn'
-  obtain rfl : b = b' - y := by omega
+  obtain rfl : b = b' - y := by grind
   dsimp [totalShift₂Iso, totalShift₂XIso, shiftFunctor₂XXIso, XXIsoOfEq]
   simp only [id_comp, ι_totalDesc]
 
@@ -354,11 +354,11 @@ lemma totalShift₁Iso_trans_totalShift₂Iso :
     Linear.units_smul_comp, Linear.comp_units_smul]
   dsimp [shiftFunctor₁₂CommIso]
   rw [id_comp, id_comp, id_comp, id_comp, comp_id,
-    ι_totalShift₂Iso_hom_f _ y (n₁ + x) n₂ (n + x) (by omega) _ rfl _ rfl, smul_smul,
+    ι_totalShift₂Iso_hom_f _ y (n₁ + x) n₂ (n + x) (by grind) _ rfl _ rfl, smul_smul,
     ← Int.negOnePow_add, add_mul, add_comm (x * y)]
   dsimp
   rw [id_comp, comp_id,
-    ι_totalShift₁Iso_hom_f_assoc _ x n₁ (n₂ + y) (n + y) (by omega) _ rfl (n + x + y) (by omega),
+    ι_totalShift₁Iso_hom_f_assoc _ x n₁ (n₂ + y) (n + y) (by grind) _ rfl (n + x + y) (by grind),
     CochainComplex.shiftFunctorComm_hom_app_f]
   dsimp
   rw [Iso.inv_hom_id, comp_id, id_comp]

--- a/Mathlib/Algebra/Lie/CartanExists.lean
+++ b/Mathlib/Algebra/Lie/CartanExists.lean
@@ -272,7 +272,7 @@ lemma engel_isBot_of_isMin (hLK : finrank K L ≤ #K) (U : LieSubalgebra K L)
     use s \ t
     refine ⟨?_, ?_⟩
     · refine le_trans ?_ (Finset.le_card_sdiff _ _)
-      omega
+      grind
     · intro α hα
       simp only [Finset.mem_sdiff, Multiset.mem_toFinset, mem_roots', IsRoot.def, not_and, t] at hα
       exact hα.2 hψ
@@ -283,7 +283,7 @@ lemma engel_isBot_of_isMin (hLK : finrank K L ≤ #K) (U : LieSubalgebra K L)
     -- Which follows from our assumptions `i < r` and `r ≤ s.card`
     -- and the fact that the degree of `coeff χ i` is less than or equal to `r - i`.
     apply lt_of_le_of_lt (lieCharpoly_coeff_natDegree _ _ _ _ i (r - i) _)
-    · omega
+    · grind
     · dsimp only [r] at hi ⊢
       rw [Nat.add_sub_cancel' hi.le]
   -- We need to show that for all `α ∈ s`, the polynomial `coeff χ i` evaluates to zero at `α`.
@@ -339,7 +339,7 @@ lemma engel_isBot_of_isMin (hLK : finrank K L ≤ #K) (U : LieSubalgebra K L)
   use (toEnd K U Q v ^ k) z'
   refine ⟨?_, ?_⟩
   · -- And `⁅v, _⁆ ^ k` applied to `z'` is non-zero by definition of `n`.
-    apply Nat.find_min hz'; omega
+    apply Nat.find_min hz'; grind
   · rw [← hn, hk, pow_succ', Module.End.mul_apply]
 
 variable (K L)

--- a/Mathlib/Algebra/Lie/CartanExists.lean
+++ b/Mathlib/Algebra/Lie/CartanExists.lean
@@ -272,7 +272,7 @@ lemma engel_isBot_of_isMin (hLK : finrank K L ≤ #K) (U : LieSubalgebra K L)
     use s \ t
     refine ⟨?_, ?_⟩
     · refine le_trans ?_ (Finset.le_card_sdiff _ _)
-      grind
+      omega
     · intro α hα
       simp only [Finset.mem_sdiff, Multiset.mem_toFinset, mem_roots', IsRoot.def, not_and, t] at hα
       exact hα.2 hψ
@@ -283,7 +283,7 @@ lemma engel_isBot_of_isMin (hLK : finrank K L ≤ #K) (U : LieSubalgebra K L)
     -- Which follows from our assumptions `i < r` and `r ≤ s.card`
     -- and the fact that the degree of `coeff χ i` is less than or equal to `r - i`.
     apply lt_of_le_of_lt (lieCharpoly_coeff_natDegree _ _ _ _ i (r - i) _)
-    · grind
+    · omega
     · dsimp only [r] at hi ⊢
       rw [Nat.add_sub_cancel' hi.le]
   -- We need to show that for all `α ∈ s`, the polynomial `coeff χ i` evaluates to zero at `α`.
@@ -339,7 +339,7 @@ lemma engel_isBot_of_isMin (hLK : finrank K L ≤ #K) (U : LieSubalgebra K L)
   use (toEnd K U Q v ^ k) z'
   refine ⟨?_, ?_⟩
   · -- And `⁅v, _⁆ ^ k` applied to `z'` is non-zero by definition of `n`.
-    apply Nat.find_min hz'; grind
+    apply Nat.find_min hz'; omega
   · rw [← hn, hk, pow_succ', Module.End.mul_apply]
 
 variable (K L)

--- a/Mathlib/Algebra/Lie/LieTheorem.lean
+++ b/Mathlib/Algebra/Lie/LieTheorem.lean
@@ -72,7 +72,7 @@ private lemma weightSpaceOfIsLieTower_aux (z : L) (v : V) (hv : v ∈ weightSpac
         LinearMap.smul_apply, Module.End.one_apply, forall_eq, pow_zero, hv w, sub_self, zero_mem]
     · next n hn =>
       intro m hm
-      obtain (hm | rfl) : m < n + 1 ∨ m = n + 1 := by omega
+      obtain (hm | rfl) : m < n + 1 ∨ m = n + 1 := by grind
       · exact U'.mono (Nat.le_succ n) (hn w m hm)
       have H : ∀ w, ⁅w, (π z ^ n) v⁆ = (T χ w) ((π z ^ n) v) + χ w • ((π z ^ n) v) := by simp
       rw [T, LinearMap.sub_apply, pow_succ', Module.End.mul_apply, LieModule.toEnd_apply_apply,

--- a/Mathlib/Algebra/Lie/Nilpotent.lean
+++ b/Mathlib/Algebra/Lie/Nilpotent.lean
@@ -337,7 +337,7 @@ theorem isNilpotent_toEnd_of_isNilpotent₂ [IsNilpotent L M] (x y : L) :
     _root_.IsNilpotent (toEnd R L M x ∘ₗ toEnd R L M y) := by
   obtain ⟨k, hM⟩ := IsNilpotent.nilpotent R L M
   replace hM : lowerCentralSeries R L M (2 * k) = ⊥ := by
-    rw [eq_bot_iff, ← hM]; exact antitone_lowerCentralSeries R L M (by omega)
+    rw [eq_bot_iff, ← hM]; exact antitone_lowerCentralSeries R L M (by grind)
   use k
   ext m
   rw [Module.End.pow_apply, LinearMap.zero_apply, ← LieSubmodule.mem_bot (R := R) (L := L), ← hM]

--- a/Mathlib/Algebra/Lie/Sl2.lean
+++ b/Mathlib/Algebra/Lie/Sl2.lean
@@ -219,7 +219,7 @@ lemma pow_toEnd_f_eq_zero_of_eq_nat
       lie_h := (P.lie_h_pow_toEnd_f _).trans (by simp [hn])
       lie_e := (P.lie_e_pow_succ_toEnd_f _).trans (by simp [hn]) }
   obtain ⟨m, hm⟩ := this.exists_nat
-  have : (n : ℤ) < m + 2 * (n + 1) := by omega
+  have : (n : ℤ) < m + 2 * (n + 1) := by grind
   exact this.ne (Int.cast_injective (α := R) <| by simpa [sub_eq_iff_eq_add] using hm)
 
 end HasPrimitiveVectorWith

--- a/Mathlib/Algebra/Lie/Weights/Chain.lean
+++ b/Mathlib/Algebra/Lie/Weights/Chain.lean
@@ -325,7 +325,7 @@ lemma genWeightSpace_zsmul_add_ne_bot {n : ℤ}
 
 lemma genWeightSpace_neg_zsmul_add_ne_bot {n : ℕ} (hn : n ≤ chainBotCoeff α β) :
     genWeightSpace M ((-n : ℤ) • α + β : L → R) ≠ ⊥ := by
-  apply genWeightSpace_zsmul_add_ne_bot α β <;> omega
+  apply genWeightSpace_zsmul_add_ne_bot α β <;> grind
 
 /-- The last weight in an `α`-chain through `β`. -/
 noncomputable

--- a/Mathlib/Algebra/Lie/Weights/Killing.lean
+++ b/Mathlib/Algebra/Lie/Weights/Killing.lean
@@ -590,7 +590,7 @@ lemma finrank_rootSpace_eq_one (α : Weight K H L) (hα : α.IsNonZero) :
     have h₀ : finrank K (rootSpace H α) ≠ 0 := by
       convert_to finrank K (rootSpace H α).toSubmodule ≠ 0
       simpa using α.genWeightSpace_ne_bot
-    omega
+    grind
   intro contra
   obtain ⟨h, e, f, ht, heα, hfα⟩ := exists_isSl2Triple_of_weight_isNonZero hα
   let F : rootSpace H α →ₗ[K] K := killingForm K L f ∘ₗ (rootSpace H α).subtype

--- a/Mathlib/Algebra/Lie/Weights/RootSystem.lean
+++ b/Mathlib/Algebra/Lie/Weights/RootSystem.lean
@@ -121,7 +121,7 @@ lemma rootSpace_neg_nsmul_add_chainTop_of_lt (hα : α.IsNonZero) {n : ℕ} (hn 
       apply_coroot_eq_cast' α β, Int.cast_sub, Int.cast_mul, Int.cast_ofNat, mul_comm (2 : K),
       add_sub_cancel, add_sub, Nat.cast_inj, eq_sub_iff_add_eq, ← Nat.cast_add, ← sub_eq_neg_add,
       sub_eq_iff_eq_add] at this
-    omega
+    grind
   have H₂ : ((1 + n + chainTopCoeff (-α) W) • α + chainTop (-α) W : H → K) =
       (chainTopCoeff α β + 1) • α + β := by
     simp only [Weight.coe_neg, ← Nat.cast_smul_eq_nsmul ℤ, Nat.cast_add, Nat.cast_one, coe_chainTop,
@@ -186,7 +186,7 @@ lemma chainLength_zero [Nontrivial L] : chainLength 0 β = 0 := by
   `β (coroot α) = q - r`. In particular, it is an integer. -/
 lemma apply_coroot_eq_cast :
     β (coroot α) = (chainBotCoeff α β - chainTopCoeff α β : ℤ) := by
-  rw [apply_coroot_eq_cast', ← chainTopCoeff_add_chainBotCoeff]; congr 1; omega
+  rw [apply_coroot_eq_cast', ← chainTopCoeff_add_chainBotCoeff]; congr 1; grind
 
 lemma le_chainBotCoeff_of_rootSpace_ne_top
     (hα : α.IsNonZero) (n : ℤ) (hn : rootSpace H (-n • α + β) ≠ ⊥) :
@@ -337,7 +337,7 @@ lemma eq_neg_one_or_eq_zero_or_eq_one_of_eq_smul
     swap
     · simp only [tsub_le_iff_right, le_add_iff_nonneg_right, Nat.cast_nonneg, neg_sub, true_and]
       rw [← Nat.cast_add, chainBotCoeff_add_chainTopCoeff, hn]
-      omega
+      grind
     rw [h, hk, ← Int.cast_smul_eq_zsmul K, ← add_smul] at this
     simp only [Int.cast_sub, Int.cast_natCast,
       sub_add_sub_cancel', add_sub_cancel_left, ne_eq] at this
@@ -361,7 +361,7 @@ def reflectRoot (α β : Weight K H L) : Weight K H L where
     · simpa [hα.eq] using β.genWeightSpace_ne_bot
     rw [sub_eq_neg_add, apply_coroot_eq_cast α β, ← neg_smul, ← Int.cast_neg,
       Int.cast_smul_eq_zsmul, rootSpace_zsmul_add_ne_bot_iff α β hα]
-    omega
+    grind
 
 lemma reflectRoot_isNonZero (α β : Weight K H L) (hβ : β.IsNonZero) :
     (reflectRoot α β).IsNonZero := by

--- a/Mathlib/Algebra/Module/LinearMap/End.lean
+++ b/Mathlib/Algebra/Module/LinearMap/End.lean
@@ -171,7 +171,7 @@ theorem iterate_bijective (h : Bijective f') : ∀ n : ℕ, Bijective (f' ^ n)
 
 theorem injective_of_iterate_injective {n : ℕ} (hn : n ≠ 0) (h : Injective (f' ^ n)) :
     Injective f' := by
-  rw [← Nat.succ_pred_eq_of_pos (show 0 < n by omega), iterate_succ, coe_comp] at h
+  rw [← Nat.succ_pred_eq_of_pos (show 0 < n by grind), iterate_succ, coe_comp] at h
   exact h.of_comp
 
 theorem surjective_of_iterate_surjective {n : ℕ} (hn : n ≠ 0) (h : Surjective (f' ^ n)) :

--- a/Mathlib/Algebra/MvPolynomial/Degrees.lean
+++ b/Mathlib/Algebra/MvPolynomial/Degrees.lean
@@ -474,8 +474,8 @@ lemma totalDegree_finsetSum_le {ι : Type*} {s : Finset ι} {f : ι → MvPolyno
   (totalDegree_finset_sum ..).trans <| Finset.sup_le hf
 
 lemma degreeOf_le_totalDegree (f : MvPolynomial σ R) (i : σ) : f.degreeOf i ≤ f.totalDegree :=
-  degreeOf_le_iff.mpr fun d hd ↦ (eq_or_ne (d i) 0).elim (by omega) fun h ↦
-    (Finset.single_le_sum (by omega) <| Finsupp.mem_support_iff.mpr h).trans
+  degreeOf_le_iff.mpr fun d hd ↦ (eq_or_ne (d i) 0).elim (by grind) fun h ↦
+    (Finset.single_le_sum (by grind) <| Finsupp.mem_support_iff.mpr h).trans
     (le_totalDegree hd)
 
 theorem exists_degree_lt [Fintype σ] (f : MvPolynomial σ R) (n : ℕ)

--- a/Mathlib/Algebra/Order/Antidiag/Nat.lean
+++ b/Mathlib/Algebra/Order/Antidiag/Nat.lean
@@ -132,7 +132,7 @@ lemma image_apply_finMulAntidiag {d n : ℕ} {i : Fin d} (hd : d ≠ 1) :
       rw [Fin.nontrivial_iff_two_le]
       obtain rfl | hd' := eq_or_ne d 0
       · exact i.elim0
-      omega
+      grind
     obtain ⟨i', hi_ne⟩ := exists_ne i
     use fun j => if j = i then k else if j = i' then r else 1
     simp only [ite_true, and_true]

--- a/Mathlib/Algebra/Order/Floor/Ring.lean
+++ b/Mathlib/Algebra/Order/Floor/Ring.lean
@@ -208,7 +208,7 @@ lemma mul_cast_floor_div_cancel_of_pos {n : ℤ} (hn : 0 < n) (a : k) : ⌊a * n
   rw [mul_comm, cast_mul_floor_div_cancel_of_pos hn]
 
 theorem natCast_mul_floor_div_cancel {n : ℕ} (hn : n ≠ 0) (a : k) : ⌊n * a⌋ / n = ⌊a⌋ := by
-  simpa using cast_mul_floor_div_cancel_of_pos (n := n) (by omega) a
+  simpa using cast_mul_floor_div_cancel_of_pos (n := n) (by grind) a
 
 theorem mul_natCast_floor_div_cancel {n : ℕ} (hn : n ≠ 0) {a : k} : ⌊a * n⌋ / n = ⌊a⌋ := by
   rw [mul_comm, natCast_mul_floor_div_cancel hn]

--- a/Mathlib/Algebra/Order/Group/Basic.lean
+++ b/Mathlib/Algebra/Order/Group/Basic.lean
@@ -127,7 +127,7 @@ theorem not_isCyclic_of_denselyOrdered [DenselyOrdered α] [Nontrivial α] : ¬I
   rcases lt_trichotomy a 1 with hlt | rfl | hlt
   · rcases exists_between hlt with ⟨b, hab, hb⟩
     rcases ha b with ⟨k, rfl⟩
-    suffices 0 < k ∧ k < 1 by omega
+    suffices 0 < k ∧ k < 1 by grind
     rw [← one_lt_inv'] at hlt
     simp_rw [← zpow_lt_zpow_iff_right hlt]
     simp_all
@@ -135,7 +135,7 @@ theorem not_isCyclic_of_denselyOrdered [DenselyOrdered α] [Nontrivial α] : ¬I
     simpa [hb.symm] using ha b
   · rcases exists_between hlt with ⟨b, hb, hba⟩
     rcases ha b with ⟨k, rfl⟩
-    suffices 0 < k ∧ k < 1 by omega
+    suffices 0 < k ∧ k < 1 by grind
     simp_rw [← zpow_lt_zpow_iff_right hlt]
     simp_all
 

--- a/Mathlib/Algebra/Order/Group/Int/Sum.lean
+++ b/Mathlib/Algebra/Order/Group/Int/Sum.lean
@@ -45,11 +45,11 @@ lemma sum_le_sum_range {s : Finset ℤ} {c : ℤ} (hs : ∀ x ∈ s, x ≤ c) :
     ∑ x ∈ s, x ≤ ∑ n ∈ range #s, (c - n) := by
   convert sum_le_sum_Ioc hs
   refine sum_nbij (c - ·) ?_ ?_ ?_ (fun _ _ ↦ rfl)
-  · intro x mx; rw [mem_Ioc]; dsimp only; rw [mem_range] at mx; omega
-  · intro x mx y my (h : c - x = c - y); omega
+  · intro x mx; rw [mem_Ioc]; dsimp only; rw [mem_range] at mx; grind
+  · intro x mx y my (h : c - x = c - y); grind
   · intro x mx; simp_rw [coe_range, Set.mem_image, Set.mem_Iio]
     rw [mem_coe, mem_Ioc] at mx
-    use (c - x).toNat; omega
+    use (c - x).toNat; grind
 
 /-- Sharp lower bound for the sum of a finset of integers that is bounded below, `Ico` version. -/
 lemma sum_Ico_le_sum {s : Finset ℤ} {c : ℤ} (hs : ∀ x ∈ s, c ≤ x) :
@@ -74,8 +74,8 @@ lemma sum_range_le_sum {s : Finset ℤ} {c : ℤ} (hs : ∀ x ∈ s, c ≤ x) :
     ∑ n ∈ range #s, (c + n) ≤ ∑ x ∈ s, x := by
   convert sum_Ico_le_sum hs
   refine sum_nbij (c + ·) ?_ ?_ ?_ (fun _ _ ↦ rfl)
-  · intro x mx; rw [mem_Ico]; dsimp only; rw [mem_range] at mx; omega
-  · intro x mx y my (h : c + x = c + y); omega
+  · intro x mx; rw [mem_Ico]; dsimp only; rw [mem_range] at mx; grind
+  · intro x mx y my (h : c + x = c + y); grind
   · intro x mx; simp_rw [coe_range, Set.mem_image, Set.mem_Iio]
     rw [mem_coe, mem_Ico] at mx
     use (x - c).toNat; omega

--- a/Mathlib/Algebra/Order/Group/Unbundled/Int.lean
+++ b/Mathlib/Algebra/Order/Group/Unbundled/Int.lean
@@ -78,7 +78,7 @@ theorem abs_le_one_iff {a : ℤ} : |a| ≤ 1 ↔ a = 0 ∨ a = 1 ∨ a = -1 := b
       simp only [negSucc_ne_zero, abs_eq_natAbs, natAbs_negSucc, succ_eq_add_one,
         Int.natCast_add, cast_ofNat_Int, add_eq_right, natCast_eq_zero, false_or, reduceNeg]
       rw [negSucc_eq]
-      omega
+      grind
 
 theorem one_le_abs {z : ℤ} (h₀ : z ≠ 0) : 1 ≤ |z| :=
   add_one_le_iff.mpr (abs_pos.mpr h₀)
@@ -87,10 +87,10 @@ lemma eq_zero_of_abs_lt_dvd {m x : ℤ} (h1 : m ∣ x) (h2 : |x| < m) : x = 0 :=
   by_contra h
   have := Int.natAbs_le_of_dvd_ne_zero h1 h
   rw [Int.abs_eq_natAbs] at h2
-  omega
+  grind
 
 lemma abs_sub_lt_of_lt_lt {m a b : ℕ} (ha : a < m) (hb : b < m) : |(b : ℤ) - a| < m := by
-  rw [abs_lt]; omega
+  rw [abs_lt]; grind
 
 /-! #### `/`  -/
 

--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Basic.lean
@@ -922,7 +922,7 @@ lemma zpow_pos (ha : 0 < a) : ∀ n : ℤ, 0 < a ^ n
 
 lemma zpow_left_strictMonoOn₀ [MulPosMono G₀] (hn : 0 < n) :
     StrictMonoOn (fun a : G₀ ↦ a ^ n) {a | 0 ≤ a} := by
-  lift n to ℕ using hn.le; simpa using pow_left_strictMonoOn₀ (by omega)
+  lift n to ℕ using hn.le; simpa using pow_left_strictMonoOn₀ (by grind)
 
 lemma zpow_right_mono₀ (ha : 1 ≤ a) : Monotone fun n : ℤ ↦ a ^ n := by
   refine monotone_int_of_le_succ fun n ↦ ?_

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Pow.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Pow.lean
@@ -120,7 +120,7 @@ lemma pow_le_pow_mul_of_sq_le_mul [MulLeftMono M] {a b : M} (hab : a ^ 2 ≤ b *
   | n + 2, _ => by
     calc
       a ^ (n + 2) = a ^ (n + 1) * a := by rw [pow_succ]
-      _ ≤ b ^ n * a * a := mul_le_mul_right' (pow_le_pow_mul_of_sq_le_mul hab (by omega)) _
+      _ ≤ b ^ n * a * a := mul_le_mul_right' (pow_le_pow_mul_of_sq_le_mul hab (by grind)) _
       _ = b ^ n * a ^ 2 := by rw [mul_assoc, sq]
       _ ≤ b ^ n * (b * a) := mul_le_mul_left' hab _
       _ = b ^ (n + 1) * a := by rw [← mul_assoc, ← pow_succ]

--- a/Mathlib/Algebra/Order/Ring/Int.lean
+++ b/Mathlib/Algebra/Order/Ring/Int.lean
@@ -78,15 +78,15 @@ theorem Nat.exists_add_mul_eq_of_gcd_dvd_of_mul_pred_le (p q n : ℕ) (dvd : p.g
   have : a * p.succ + b * q.succ = n := by rw [add_mul, ← add_assoc,
     add_right_comm, mul_right_comm, ← add_mul, Int.emod_add_ediv', eq, mul_comm, mul_comm b_n]
   rw [Nat.cast_add, Nat.cast_mul, Nat.cast_mul, Int.natCast_toNat_eq_self.mpr
-    (Int.emod_nonneg _ <| by omega), Int.natCast_toNat_eq_self.mpr, this]
+    (Int.emod_nonneg _ <| by grind), Int.natCast_toNat_eq_self.mpr, this]
   -- show b ≥ 0 by contradiction
   by_contra hb
-  replace hb : b ≤ -1 := by omega
+  replace hb : b ≤ -1 := by grind
   apply lt_irrefl (n : ℤ)
-  have ha := Int.emod_lt a_n (by omega : (q.succ : ℤ) ≠ 0)
+  have ha := Int.emod_lt a_n (by grind : (q.succ : ℤ) ≠ 0)
   rw [p.pred_succ, q.pred_succ] at le
   calc n = a * p.succ + b * q.succ := this.symm
        _ ≤ q * p.succ + -1 * q.succ := by gcongr <;> omega
-       _ = p * q - 1 := by simp_rw [Nat.cast_succ, mul_add, mul_comm]; omega
+       _ = p * q - 1 := by simp_rw [Nat.cast_succ, mul_add, mul_comm]; grind
        _ ≤ n - 1 := by rwa [sub_le_sub_iff_right, ← Nat.cast_mul, Nat.cast_le]
-       _ < n := by omega
+       _ < n := by grind

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Rat.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Rat.lean
@@ -98,11 +98,11 @@ protected theorem lt_iff (a b : ℚ) : a < b ↔ a.num * b.den < b.num * a.den :
       · constructor
         · refine (·.elim ?_ And.right)
           rintro ⟨hna, nb0⟩
-          apply (Int.mul_neg_of_neg_of_pos hna _).trans_le (Int.mul_nonneg nb0 _) <;> omega
+          apply (Int.mul_neg_of_neg_of_pos hna _).trans_le (Int.mul_nonneg nb0 _) <;> grind
         · intro h
           suffices na < 0 ∧ 0 ≤ nb ∨ na ≤ 0 ∨ 0 < nb by simpa [h]
           contrapose! h
-          apply (Int.mul_nonpos_of_nonpos_of_nonneg _ _).trans (Int.mul_nonneg _ _) <;> omega
+          apply (Int.mul_nonpos_of_nonpos_of_nonneg _ _).trans (Int.mul_nonneg _ _) <;> grind
 
 protected theorem le_iff (a b : ℚ) : a ≤ b ↔ a.num * b.den ≤ b.num * a.den := by
   simpa only [Rat.not_lt, not_lt] using (Rat.lt_iff b a).not

--- a/Mathlib/Algebra/Polynomial/AlgebraMap.lean
+++ b/Mathlib/Algebra/Polynomial/AlgebraMap.lean
@@ -694,9 +694,9 @@ theorem eq_zero_of_mul_eq_zero_of_smul (P : R[X]) (h : ∀ r : R, r • P = 0 �
   simp only [Finset.mem_antidiagonal, ne_eq, Prod.forall, Prod.mk.injEq, not_and]
   intro i j hij H
   obtain hi | rfl | hi := lt_trichotomy i l
-  · have hj : m < j := by omega
+  · have hj : m < j := by grind
     rw [coeff_eq_zero_of_natDegree_lt hj, mul_zero]
-  · omega
+  · grind
   · rw [← coeff_C_mul, ← smul_eq_C_mul, IH _ hi, coeff_zero]
 termination_by Q.natDegree
 

--- a/Mathlib/Algebra/Polynomial/CoeffList.lean
+++ b/Mathlib/Algebra/Polynomial/CoeffList.lean
@@ -103,7 +103,7 @@ theorem coeffList_monomial {x : R} (hx : x ≠ 0) (n : ℕ) :
     have : ((monomial n) x).natDegree.succ = n + 1 := by
       simp [Polynomial.natDegree_monomial_eq n hx]
     simpa [coeffList, withBotSucc_degree_eq_natDegree_add_one h]
-      using Polynomial.coeff_monomial_of_ne _ (by omega)
+      using Polynomial.coeff_monomial_of_ne _ (by grind)
 
 /- Coefficients of a polynomial `P` are always the leading coefficient, some number of zeros, and
 then `coeffList P.eraseLead`. -/
@@ -125,7 +125,7 @@ theorem coeffList_eraseLead (h : P ≠ 0) :
       d = P.natDegree - P.eraseLead.degree.succ := by
     use P.natDegree - P.eraseLead.natDegree -  1
     have := eraseLead_natDegree_le P
-    omega
+    grind
   rw [← hn2]; clear hn2
   apply List.ext_getElem?
   rintro (_ | k)
@@ -134,24 +134,24 @@ theorem coeffList_eraseLead (h : P ≠ 0) :
   simp only [coeffList, List.map_reverse]
   by_cases hkd : P.natDegree + 1 ≤ k + 1
   · rw [List.getElem?_eq_none]
-      <;> simpa [hep, h] using by omega
+      <;> simpa [hep, h] using by grind
   obtain ⟨dk, hdk⟩ := exists_add_of_le (Nat.le_of_lt_succ (Nat.lt_of_not_ge hkd))
   rw [List.getElem?_reverse (by simpa [withBotSucc_degree_eq_natDegree_add_one h] using hkd),
     List.getElem?_cons_succ, List.length_map, List.length_range, List.getElem?_map,
-    List.getElem?_range (by omega), Option.map_some]
+    List.getElem?_range (by grind), Option.map_some]
   conv_lhs => arg 1; equals P.eraseLead.coeff dk =>
-    rw [eraseLead_coeff_of_ne (f := P) dk (by omega)]
+    rw [eraseLead_coeff_of_ne (f := P) dk (by grind)]
     congr
-    omega
+    grind
   by_cases hkn : k < n
-  · simpa [List.getElem?_append, hkn] using coeff_eq_zero_of_natDegree_lt (by omega)
+  · simpa [List.getElem?_append, hkn] using coeff_eq_zero_of_natDegree_lt (by grind)
   · rw [List.getElem?_append_right (List.length_replicate ▸ Nat.le_of_not_gt hkn),
       List.length_replicate, List.getElem?_reverse, List.getElem?_map]
     · rw [List.length_map, List.length_range,
-        List.getElem?_range (by omega), Option.map_some]
+        List.getElem?_range (by grind), Option.map_some]
       congr 2
-      omega
-    · simpa using by omega
+      grind
+    · simpa using by grind
 
 end Semiring
 section Ring

--- a/Mathlib/Algebra/Polynomial/CoeffList.lean
+++ b/Mathlib/Algebra/Polynomial/CoeffList.lean
@@ -103,7 +103,7 @@ theorem coeffList_monomial {x : R} (hx : x ≠ 0) (n : ℕ) :
     have : ((monomial n) x).natDegree.succ = n + 1 := by
       simp [Polynomial.natDegree_monomial_eq n hx]
     simpa [coeffList, withBotSucc_degree_eq_natDegree_add_one h]
-      using Polynomial.coeff_monomial_of_ne _ (by grind)
+      using Polynomial.coeff_monomial_of_ne _ (by omega)
 
 /- Coefficients of a polynomial `P` are always the leading coefficient, some number of zeros, and
 then `coeffList P.eraseLead`. -/
@@ -125,7 +125,7 @@ theorem coeffList_eraseLead (h : P ≠ 0) :
       d = P.natDegree - P.eraseLead.degree.succ := by
     use P.natDegree - P.eraseLead.natDegree -  1
     have := eraseLead_natDegree_le P
-    grind
+    omega
   rw [← hn2]; clear hn2
   apply List.ext_getElem?
   rintro (_ | k)
@@ -134,24 +134,24 @@ theorem coeffList_eraseLead (h : P ≠ 0) :
   simp only [coeffList, List.map_reverse]
   by_cases hkd : P.natDegree + 1 ≤ k + 1
   · rw [List.getElem?_eq_none]
-      <;> simpa [hep, h] using by grind
+      <;> simpa [hep, h] using by omega
   obtain ⟨dk, hdk⟩ := exists_add_of_le (Nat.le_of_lt_succ (Nat.lt_of_not_ge hkd))
   rw [List.getElem?_reverse (by simpa [withBotSucc_degree_eq_natDegree_add_one h] using hkd),
     List.getElem?_cons_succ, List.length_map, List.length_range, List.getElem?_map,
-    List.getElem?_range (by grind), Option.map_some]
+    List.getElem?_range (by omega), Option.map_some]
   conv_lhs => arg 1; equals P.eraseLead.coeff dk =>
-    rw [eraseLead_coeff_of_ne (f := P) dk (by grind)]
+    rw [eraseLead_coeff_of_ne (f := P) dk (by omega)]
     congr
-    grind
+    omega
   by_cases hkn : k < n
-  · simpa [List.getElem?_append, hkn] using coeff_eq_zero_of_natDegree_lt (by grind)
+  · simpa [List.getElem?_append, hkn] using coeff_eq_zero_of_natDegree_lt (by omega)
   · rw [List.getElem?_append_right (List.length_replicate ▸ Nat.le_of_not_gt hkn),
       List.length_replicate, List.getElem?_reverse, List.getElem?_map]
     · rw [List.length_map, List.length_range,
-        List.getElem?_range (by grind), Option.map_some]
+        List.getElem?_range (by omega), Option.map_some]
       congr 2
-      grind
-    · simpa using by grind
+      omega
+    · simpa using by omega
 
 end Semiring
 section Ring

--- a/Mathlib/Algebra/Polynomial/Degree/IsMonicOfDegree.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/IsMonicOfDegree.lean
@@ -63,7 +63,7 @@ lemma IsMonicOfDegree.exists_natDegree_lt {p : R[X]} {n : ℕ} (hn : n ≠ 0)
     rw [add_comm, hp.natDegree_eq, hp.leadingCoeff_eq, map_one, one_mul]
   · refine p.eraseLead_natDegree_le.trans_lt ?_
     rw [hp.natDegree_eq]
-    omega
+    grind
 
 lemma IsMonicOfDegree.mul {p q : R[X]} {m n : ℕ} (hp : IsMonicOfDegree p m)
     (hq : IsMonicOfDegree q n) :
@@ -178,7 +178,7 @@ lemma isMonicOfDegree_one_iff {f : R[X]} : IsMonicOfDegree f 1 ↔ ∃ r : R, f 
   ext1 n
   rcases n.eq_zero_or_pos with rfl | hn
   · simp
-  · exact H.coeff_eq (isMonicOfDegree_X_add_one _) (by omega)
+  · exact H.coeff_eq (isMonicOfDegree_X_add_one _) (by grind)
 
 lemma isMonicOfDegree_add_add_two (a b : R) : IsMonicOfDegree (X ^ 2 + C a * X + C b) 2 := by
   rw [add_assoc]
@@ -196,7 +196,7 @@ lemma isMonicOfDegree_two_iff {f : R[X]} :
   · obtain rfl : n = 0 := Nat.lt_one_iff.mp hn
     simp
   · simp
-  · exact H.coeff_eq (isMonicOfDegree_add_add_two ..) (by omega)
+  · exact H.coeff_eq (isMonicOfDegree_add_add_two ..) (by grind)
 
 end Semiring
 
@@ -257,7 +257,7 @@ lemma IsMonicOfDegree.of_dvd_add {a b r : R[X]} {m n : ℕ} (hmn : n ≤ m) (ha 
     ∃ q : R[X], IsMonicOfDegree q (m - n) ∧ a = q * b - r := by
   obtain ⟨q, hq⟩ := exists_eq_mul_left_of_dvd  h
   refine ⟨q, hb.of_mul_right ?_, eq_sub_iff_add_eq.mpr hq⟩
-  rw [← hq, show m - n + n = m by omega]
+  rw [← hq, show m - n + n = m by grind]
   exact ha.add_right hr
 
 lemma IsMonicOfDegree.of_dvd_sub {a b r : R[X]} {m n : ℕ} (hmn : n ≤ m) (ha : IsMonicOfDegree a m)

--- a/Mathlib/Algebra/Polynomial/Derivative.lean
+++ b/Mathlib/Algebra/Polynomial/Derivative.lean
@@ -386,7 +386,7 @@ theorem iterate_derivative_mul {n} (p q : R[X]) :
       refine sum_congr rfl fun k hk => ?_
       rw [mem_range] at hk
       congr
-      omega
+      grind
     · rw [Nat.choose_zero_right, tsub_zero]
 
 /--

--- a/Mathlib/Algebra/Polynomial/FieldDivision.lean
+++ b/Mathlib/Algebra/Polynomial/FieldDivision.lean
@@ -131,7 +131,7 @@ theorem one_lt_rootMultiplicity_iff_isRoot
   rw [one_lt_rootMultiplicity_iff_isRoot_iterate_derivative h]
   refine ⟨fun h ↦ ⟨h 0 (by simp), h 1 (by simp)⟩, fun ⟨h0, h1⟩ m hm ↦ ?_⟩
   obtain (_ | _ | m) := m
-  exacts [h0, h1, by omega]
+  exacts [h0, h1, by grind]
 
 end CommRing
 
@@ -188,7 +188,7 @@ theorem isRoot_of_isRoot_of_dvd_derivative_mul [CharZero R] {f g : R[X]} (hf0 : 
   rw [rootMultiplicity_mul hdfg0, derivative_rootMultiplicity_of_root haf,
     rootMultiplicity_eq_zero hg, add_zero, rootMultiplicity_mul (hr ▸ hdfg0), add_comm,
     Nat.sub_eq_iff_eq_add (Nat.succ_le_iff.2 ((rootMultiplicity_pos hf0).2 haf))] at hr'
-  omega
+  grind
 
 section NormalizationMonoid
 

--- a/Mathlib/Algebra/Polynomial/Laurent.lean
+++ b/Mathlib/Algebra/Polynomial/Laurent.lean
@@ -307,7 +307,7 @@ theorem trunc_C_mul_T (n : ℤ) (r : R) : trunc (C r * T n) = ite (0 ≤ n) (mon
     apply comapDomain_single
   · rw [toFinsupp_inj]
     ext a
-    have : n ≠ a := by omega
+    have : n ≠ a := by grind
     simp only [coeff_ofFinsupp, comapDomain_apply, Int.ofNat_eq_coe, coeff_zero,
       single_eq_of_ne this]
 

--- a/Mathlib/Algebra/Polynomial/OfFn.lean
+++ b/Mathlib/Algebra/Polynomial/OfFn.lean
@@ -108,7 +108,7 @@ theorem ofFn_comp_toFn_eq_id_of_natDegree_lt {n : ℕ} {p : R[X]} (h_deg : p.nat
   ext i
   by_cases h : i < n
   · simp [h, toFn]
-  · have : p.coeff i = 0 := coeff_eq_zero_of_natDegree_lt <| by omega
+  · have : p.coeff i = 0 := coeff_eq_zero_of_natDegree_lt <| by grind
     simp_all
 
 end ofFn

--- a/Mathlib/Algebra/Polynomial/Sequence.lean
+++ b/Mathlib/Algebra/Polynomial/Sequence.lean
@@ -132,7 +132,7 @@ protected lemma span (hCoeff : ∀ i, IsUnit (S i).leadingCoeff) : span R (Set.r
           mul_one, C_eq_zero, leadingCoeff_eq_zero]
       · apply head.ne_zero_of_degree_gt
         rw [← head_degree_eq]
-        exact natDegree_pos_iff_degree_pos.mp (by omega)
+        exact natDegree_pos_iff_degree_pos.mp (by grind)
     -- and that they have matching leading coefficients
     have hPhead : P.leadingCoeff = head.leadingCoeff := by
       rw [degree_eq_natDegree, head_degree_eq_natDegree] at head_degree_eq

--- a/Mathlib/Algebra/Polynomial/UnitTrinomial.lean
+++ b/Mathlib/Algebra/Polynomial/UnitTrinomial.lean
@@ -244,7 +244,7 @@ theorem irreducible_aux2 {k m m' n : ℕ} (hkm : k < m) (hmn : m < n) (hkm' : k 
   · refine Or.inr ?_
     rw [← trinomial_mirror hkm' hmn' u.ne_zero u.ne_zero, eq_comm, mirror_eq_iff] at hp
     exact hq.trans hp
-  · obtain rfl : m = m' := by omega
+  · obtain rfl : m = m' := by grind
     exact Or.inl (hq.trans hp.symm)
 
 theorem irreducible_aux3 {k m m' n : ℕ} (hkm : k < m) (hmn : m < n) (hkm' : k < m') (hmn' : m' < n)

--- a/Mathlib/Algebra/Ring/Divisibility/Lemmas.lean
+++ b/Mathlib/Algebra/Ring/Divisibility/Lemmas.lean
@@ -46,7 +46,7 @@ lemma pow_dvd_add_pow_of_pow_eq_zero_right (hp : n + m ≤ p + 1) (h_comm : Comm
   apply dvd_nsmul_of_dvd
   rcases le_or_gt m i with (hi : m ≤ i) | (hi : i + 1 ≤ m)
   · exact dvd_mul_of_dvd_left (pow_dvd_pow x hi) _
-  · simp [pow_eq_zero_of_le (by omega : n ≤ j) hy]
+  · simp [pow_eq_zero_of_le (by grind : n ≤ j) hy]
 
 lemma pow_dvd_add_pow_of_pow_eq_zero_left (hp : n + m ≤ p + 1) (h_comm : Commute x y)
     (hx : x ^ n = 0) : y ^ m ∣ (x + y) ^ p :=

--- a/Mathlib/Algebra/Squarefree/Basic.lean
+++ b/Mathlib/Algebra/Squarefree/Basic.lean
@@ -81,7 +81,7 @@ theorem Squarefree.eq_zero_or_one_of_pow_of_not_isUnit [Monoid R] {x : R} {n : �
     (h : Squarefree (x ^ n)) (h' : ¬ IsUnit x) :
     n = 0 ∨ n = 1 := by
   contrapose! h'
-  replace h' : 2 ≤ n := by omega
+  replace h' : 2 ≤ n := by grind
   have : x * x ∣ x ^ n := by rw [← sq]; exact pow_dvd_pow x h'
   exact h.squarefree_of_dvd this x (refl _)
 

--- a/Mathlib/Algebra/Vertex/VertexOperator.lean
+++ b/Mathlib/Algebra/Vertex/VertexOperator.lean
@@ -72,7 +72,7 @@ theorem ncoeff_eq_zero_of_lt_order (A : VertexOperator R V) (n : ℤ) (x : V)
 theorem coeff_eq_zero_of_lt_order (A : VertexOperator R V) (n : ℤ) (x : V)
     (h : n < HahnSeries.order ((HahnModule.of R).symm (A x))) : coeff A n x = 0 := by
   rw [coeff_eq_ncoeff, ncoeff_eq_zero_of_lt_order A (-n - 1) x]
-  omega
+  grind
 
 /-- Given an endomorphism-valued function on integers satisfying a pointwise bounded-pole condition,
 we produce a vertex operator. -/


### PR DESCRIPTION
Motivation: `grind` subsumes `omega`, which is expected to be deprecated.