### PR TITLE
[Merged by Bors] - chore(Algebra/GroupWithZero/Action/Hom): extract from other files

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -450,6 +450,7 @@ import Mathlib.Algebra.GroupWithZero.Action.ConjAct
 import Mathlib.Algebra.GroupWithZero.Action.Defs
 import Mathlib.Algebra.GroupWithZero.Action.End
 import Mathlib.Algebra.GroupWithZero.Action.Faithful
+import Mathlib.Algebra.GroupWithZero.Action.Hom
 import Mathlib.Algebra.GroupWithZero.Action.Opposite
 import Mathlib.Algebra.GroupWithZero.Action.Pi
 import Mathlib.Algebra.GroupWithZero.Action.Pointwise.Finset

--- a/Mathlib/Algebra/GroupWithZero/Action/Hom.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Hom.lean
@@ -28,8 +28,7 @@ instance [DistribSMul M B] : SMulZeroClass M (A →+ B) where
 @[simp] theorem smul_apply [DistribSMul M B] (m : M) (f : A →+ B) (a : A) : (m • f) a = m • f a :=
   rfl
 
-theorem smul_comp [DistribSMul M B] [DistribSMul M C]
-    (m : M) (g : B →+ C) (f : A →+ B) :
+theorem smul_comp [DistribSMul M C] (m : M) (g : B →+ C) (f : A →+ B) :
     (m • g).comp f = m • g.comp f := rfl
 
 instance [DistribSMul M B] [DistribSMul N B] [SMulCommClass M N B] :

--- a/Mathlib/Algebra/GroupWithZero/Action/Hom.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Hom.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2025 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+-/
+
+import Mathlib.Algebra.GroupWithZero.Action.Defs
+import Mathlib.Algebra.Group.Hom.Instances
+
+/-! # Zero-related `•` instances on group-like morphisms -/
+
+variable {M N A B C : Type*}
+
+namespace AddMonoidHom
+
+section
+variable [AddZeroClass A] [AddZeroClass B] [AddZeroClass C]
+
+instance [DistribSMul M B] : SMulZeroClass M (A →+ B) where
+  smul r f :=
+    { toFun a := r • f a
+      map_zero' := by simp only [map_zero, smul_zero]
+      map_add' _ _ := by simp only [map_add, smul_add] }
+  smul_zero _ := ext fun _ => smul_zero _
+
+@[norm_cast] theorem coe_smul [DistribSMul M B] (m : M) (f : A →+ B) : ⇑(m • f) = m • f := rfl
+
+@[simp] theorem smul_apply [DistribSMul M B] (m : M) (f : A →+ B) (a : A) : (m • f) a = m • f a :=
+  rfl
+
+theorem smul_comp [DistribSMul M B] [DistribSMul M C]
+    (m : M) (g : B →+ C) (f : A →+ B) :
+    (m • g).comp f = m • g.comp f := rfl
+
+instance [DistribSMul M B] [DistribSMul N B] [SMulCommClass M N B] :
+    SMulCommClass M N (A →+ B) where
+  smul_comm _ _ _ := ext fun _ => smul_comm _ _ _
+
+instance [SMul M N] [DistribSMul M B] [DistribSMul N B] [IsScalarTower M N B] :
+    IsScalarTower M N (A →+ B) where
+  smul_assoc _ _ _ := ext fun _ => smul_assoc _ _ _
+
+instance [DistribSMul M B] [DistribSMul Mᵐᵒᵖ B] [IsCentralScalar M B] :
+    IsCentralScalar M (A →+ B) where
+  op_smul_eq_smul _ _ := ext fun _ => op_smul_eq_smul _ _
+
+end
+
+variable [AddZeroClass A] [AddCommMonoid B]
+
+instance [DistribSMul M B] : DistribSMul M (A →+ B) where
+  smul_add _ _ _ := ext fun _ => smul_add _ _ _
+
+instance [Monoid M] [DistribMulAction M B] : DistribMulAction M (A →+ B) where
+  __ : DistribSMul _ _ := inferInstance
+  one_smul _ := ext fun _ => one_smul _ _
+  mul_smul _ _ _ :=  ext fun _ => mul_smul _ _ _
+
+end AddMonoidHom

--- a/Mathlib/Algebra/GroupWithZero/Action/Pi.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Pi.lean
@@ -6,6 +6,7 @@ Authors: Simon Hudon, Patrick Massot
 import Mathlib.Algebra.Group.Action.Pi
 import Mathlib.Algebra.GroupWithZero.Action.Defs
 import Mathlib.Algebra.GroupWithZero.Defs
+import Mathlib.Algebra.GroupWithZero.Pi
 import Mathlib.Tactic.Common
 
 /-!
@@ -32,21 +33,21 @@ variable {f : I → Type v}
 namespace Pi
 
 instance smulZeroClass (α) {n : ∀ i, Zero <| f i} [∀ i, SMulZeroClass α <| f i] :
-  @SMulZeroClass α (∀ i : I, f i) (@Pi.instZero I f n) where
+    @SMulZeroClass α (∀ i : I, f i) (@Pi.instZero I f n) where
   smul_zero _ := funext fun _ => smul_zero _
 
 instance smulZeroClass' {g : I → Type*} {n : ∀ i, Zero <| g i} [∀ i, SMulZeroClass (f i) (g i)] :
-  @SMulZeroClass (∀ i, f i) (∀ i : I, g i) (@Pi.instZero I g n) where
+    @SMulZeroClass (∀ i, f i) (∀ i : I, g i) (@Pi.instZero I g n) where
   smul_zero := by intros; ext x; exact smul_zero _
 
 instance distribSMul (α) {n : ∀ i, AddZeroClass <| f i} [∀ i, DistribSMul α <| f i] :
-  @DistribSMul α (∀ i : I, f i) (@Pi.addZeroClass I f n) where
+    @DistribSMul α (∀ i : I, f i) (@Pi.addZeroClass I f n) where
   smul_zero _ := funext fun _ => smul_zero _
   smul_add _ _ _ := funext fun _ => smul_add _ _ _
 
 instance distribSMul' {g : I → Type*} {n : ∀ i, AddZeroClass <| g i}
-  [∀ i, DistribSMul (f i) (g i)] :
-  @DistribSMul (∀ i, f i) (∀ i : I, g i) (@Pi.addZeroClass I g n) where
+    [∀ i, DistribSMul (f i) (g i)] :
+    @DistribSMul (∀ i, f i) (∀ i : I, g i) (@Pi.addZeroClass I g n) where
   smul_zero := by intros; ext x; exact smul_zero _
   smul_add := by intros; ext x; exact smul_add _ _ _
 
@@ -58,6 +59,26 @@ instance distribMulAction' {g : I → Type*} {m : ∀ i, Monoid (f i)} {n : ∀ 
     [∀ i, DistribMulAction (f i) (g i)] :
     @DistribMulAction (∀ i, f i) (∀ i : I, g i) (@Pi.monoid I f m) (@Pi.addMonoid I g n) :=
   { Pi.mulAction', Pi.distribSMul' with }
+
+instance smulWithZero (α) [Zero α] [∀ i, Zero (f i)] [∀ i, SMulWithZero α (f i)] :
+    SMulWithZero α (∀ i, f i) :=
+  { Pi.instSMul with
+    smul_zero := fun _ => funext fun _ => smul_zero _
+    zero_smul := fun _ => funext fun _ => zero_smul _ _ }
+
+instance smulWithZero' {g : I → Type*} [∀ i, Zero (g i)] [∀ i, Zero (f i)]
+    [∀ i, SMulWithZero (g i) (f i)] : SMulWithZero (∀ i, g i) (∀ i, f i) :=
+  { Pi.smul' with
+    smul_zero := fun _ => funext fun _ => smul_zero _
+    zero_smul := fun _ => funext fun _ => zero_smul _ _ }
+
+instance mulActionWithZero (α) [MonoidWithZero α] [∀ i, Zero (f i)]
+    [∀ i, MulActionWithZero α (f i)] : MulActionWithZero α (∀ i, f i) :=
+  { Pi.mulAction _, Pi.smulWithZero _ with }
+
+instance mulActionWithZero' {g : I → Type*} [∀ i, MonoidWithZero (g i)] [∀ i, Zero (f i)]
+    [∀ i, MulActionWithZero (g i) (f i)] : MulActionWithZero (∀ i, g i) (∀ i, f i) :=
+  { Pi.mulAction', Pi.smulWithZero' with }
 
 theorem single_smul {α} [Monoid α] [∀ i, AddMonoid <| f i] [∀ i, DistribMulAction α <| f i]
     [DecidableEq I] (i : I) (r : α) (x : f i) : single i (r • x) = r • single i x :=

--- a/Mathlib/Algebra/GroupWithZero/Action/Prod.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Prod.lean
@@ -52,6 +52,14 @@ instance mulDistribMulAction {R : Type*} [Monoid R] [Monoid M] [Monoid N]
   smul_mul _ _ _ := by ext <;> exact smul_mul' ..
   smul_one _ := by ext <;> exact smul_one _
 
+instance smulWithZero {R : Type*} [Zero R] [Zero M] [Zero N] [SMulWithZero R M] [SMulWithZero R N] :
+    SMulWithZero R (M × N) where
+  zero_smul _ := by ext <;> exact zero_smul ..
+
+instance mulActionWithZero {R : Type*} [MonoidWithZero R] [Zero M] [Zero N] [MulActionWithZero R M]
+    [MulActionWithZero R N] : MulActionWithZero R (M × N) :=
+  { Prod.mulAction, Prod.smulWithZero with }
+
 end Prod
 
 /-! ### Scalar multiplication as a homomorphism -/

--- a/Mathlib/Algebra/Module/Hom.lean
+++ b/Mathlib/Algebra/Module/Hom.lean
@@ -5,6 +5,7 @@ Authors: Eric Wieser
 -/
 import Mathlib.Algebra.Group.Hom.Instances
 import Mathlib.Algebra.GroupWithZero.Action.End
+import Mathlib.Algebra.GroupWithZero.Action.Hom
 import Mathlib.Algebra.Module.End
 import Mathlib.Algebra.Ring.Opposite
 import Mathlib.GroupTheory.GroupAction.DomAct.Basic
@@ -12,7 +13,7 @@ import Mathlib.GroupTheory.GroupAction.DomAct.Basic
 /-!
 # Bundled Hom instances for module and multiplicative actions
 
-This file defines instances for `Module`, `MulAction` and related structures on bundled `Hom` types.
+This file defines instances for `Module` on bundled `Hom` types.
 
 These are analogous to the instances in `Algebra.Module.Pi`, but for bundled instead of unbundled
 functions.
@@ -27,41 +28,10 @@ variable {R S M A B : Type*}
 
 namespace AddMonoidHom
 
-section
-
-instance instDistribSMul [AddZeroClass A] [AddCommMonoid B] [DistribSMul M B] :
-    DistribSMul M (A →+ B) where
-  smul_add _ _ _ := ext fun _ => smul_add _ _ _
-
-variable [Monoid R] [Monoid S] [AddMonoid A] [AddCommMonoid B]
-variable [DistribMulAction R B] [DistribMulAction S B]
-
-instance instDistribMulAction : DistribMulAction R (A →+ B) where
-  smul_zero := smul_zero
-  smul_add := smul_add
-  one_smul _ := ext fun _ => one_smul _ _
-  mul_smul _ _ _ := ext fun _ => mul_smul _ _ _
-
-@[simp] theorem coe_smul (r : R) (f : A →+ B) : ⇑(r • f) = r • ⇑f := rfl
-
-theorem smul_apply (r : R) (f : A →+ B) (x : A) : (r • f) x = r • f x :=
-  rfl
-
-instance smulCommClass [SMulCommClass R S B] : SMulCommClass R S (A →+ B) :=
-  ⟨fun _ _ _ => ext fun _ => smul_comm _ _ _⟩
-
-instance isScalarTower [SMul R S] [IsScalarTower R S B] : IsScalarTower R S (A →+ B) :=
-  ⟨fun _ _ _ => ext fun _ => smul_assoc _ _ _⟩
-
-instance isCentralScalar [DistribMulAction Rᵐᵒᵖ B] [IsCentralScalar R B] :
-    IsCentralScalar R (A →+ B) :=
-  ⟨fun _ _ => ext fun _ => op_smul_eq_smul _ _⟩
-
-end
-
-instance instModule [Semiring R] [AddMonoid A] [AddCommMonoid B] [Module R B] : Module R (A →+ B) :=
-  { add_smul := fun _ _ _=> ext fun _ => add_smul _ _ _
-    zero_smul := fun _ => ext fun _ => zero_smul _ _ }
+instance instModule [Semiring R] [AddMonoid A] [AddCommMonoid B] [Module R B] :
+    Module R (A →+ B) where
+  add_smul _ _ _ := ext fun _ => add_smul _ _ _
+  zero_smul _ := ext fun _ => zero_smul _ _
 
 instance instDomMulActModule
     {S M M₂ : Type*} [Semiring S] [AddCommMonoid M] [AddCommMonoid M₂] [Module S M] :

--- a/Mathlib/Algebra/Module/Hom.lean
+++ b/Mathlib/Algebra/Module/Hom.lean
@@ -71,14 +71,14 @@ theorem smul_apply (r : R) (f : AddMonoid.End A) (x : A) : (r • f) x = r • f
   rfl
 
 instance smulCommClass [SMulCommClass R S A] : SMulCommClass R S (AddMonoid.End A) :=
-  AddMonoidHom.smulCommClass
+  AddMonoidHom.instSMulCommClass
 
 instance isScalarTower [SMul R S] [IsScalarTower R S A] : IsScalarTower R S (AddMonoid.End A) :=
-  AddMonoidHom.isScalarTower
+  AddMonoidHom.instIsScalarTower
 
 instance isCentralScalar [DistribMulAction Rᵐᵒᵖ A] [IsCentralScalar R A] :
     IsCentralScalar R (AddMonoid.End A) :=
-  AddMonoidHom.isCentralScalar
+  AddMonoidHom.instIsCentralScalar
 
 end
 

--- a/Mathlib/Algebra/Module/Pi.lean
+++ b/Mathlib/Algebra/Module/Pi.lean
@@ -28,26 +28,6 @@ theorem _root_.IsSMulRegular.pi {α : Type*} [∀ i, SMul α <| f i] {k : α}
     (hk : ∀ i, IsSMulRegular (f i) k) : IsSMulRegular (∀ i, f i) k := fun _ _ h =>
   funext fun i => hk i (congr_fun h i :)
 
-instance smulWithZero (α) [Zero α] [∀ i, Zero (f i)] [∀ i, SMulWithZero α (f i)] :
-    SMulWithZero α (∀ i, f i) :=
-  { Pi.instSMul with
-    smul_zero := fun _ => funext fun _ => smul_zero _
-    zero_smul := fun _ => funext fun _ => zero_smul _ _ }
-
-instance smulWithZero' {g : I → Type*} [∀ i, Zero (g i)] [∀ i, Zero (f i)]
-    [∀ i, SMulWithZero (g i) (f i)] : SMulWithZero (∀ i, g i) (∀ i, f i) :=
-  { Pi.smul' with
-    smul_zero := fun _ => funext fun _ => smul_zero _
-    zero_smul := fun _ => funext fun _ => zero_smul _ _ }
-
-instance mulActionWithZero (α) [MonoidWithZero α] [∀ i, Zero (f i)]
-    [∀ i, MulActionWithZero α (f i)] : MulActionWithZero α (∀ i, f i) :=
-  { Pi.mulAction _, Pi.smulWithZero _ with }
-
-instance mulActionWithZero' {g : I → Type*} [∀ i, MonoidWithZero (g i)] [∀ i, Zero (f i)]
-    [∀ i, MulActionWithZero (g i) (f i)] : MulActionWithZero (∀ i, g i) (∀ i, f i) :=
-  { Pi.mulAction', Pi.smulWithZero' with }
-
 variable (I f)
 
 instance module (α) {r : Semiring α} {m : ∀ i, AddCommMonoid <| f i} [∀ i, Module α <| f i] :

--- a/Mathlib/Algebra/Module/Prod.lean
+++ b/Mathlib/Algebra/Module/Prod.lean
@@ -17,15 +17,6 @@ variable {R : Type*} {M : Type*} {N : Type*}
 
 namespace Prod
 
-instance smulWithZero [Zero R] [Zero M] [Zero N] [SMulWithZero R M] [SMulWithZero R N] :
-    SMulWithZero R (M × N) where
-  smul_zero _ := by ext <;> exact smul_zero ..
-  zero_smul _ := by ext <;> exact zero_smul ..
-
-instance mulActionWithZero [MonoidWithZero R] [Zero M] [Zero N] [MulActionWithZero R M]
-    [MulActionWithZero R N] : MulActionWithZero R (M × N) :=
-  { Prod.mulAction, Prod.smulWithZero with }
-
 instance instModule [Semiring R] [AddCommMonoid M] [AddCommMonoid N] [Module R M] [Module R N] :
     Module R (M × N) where
   add_smul _ _ _ := by ext <;> exact add_smul ..

--- a/Mathlib/Algebra/Order/Module/OrderedSMul.lean
+++ b/Mathlib/Algebra/Order/Module/OrderedSMul.lean
@@ -5,10 +5,11 @@ Authors: Frédéric Dupuis
 -/
 import Mathlib.Algebra.Field.Defs
 import Mathlib.Algebra.GroupWithZero.Invertible
-import Mathlib.Algebra.Module.Pi
-import Mathlib.Algebra.Module.Prod
 import Mathlib.Algebra.Order.Group.Unbundled.Abs
 import Mathlib.Algebra.Order.Module.Defs
+import Mathlib.Algebra.Group.Action.Basic
+import Mathlib.Algebra.GroupWithZero.Action.Pi
+import Mathlib.Algebra.GroupWithZero.Action.Prod
 
 /-!
 # Ordered scalar product


### PR DESCRIPTION
This matches the Pi and Prod files in the same folder, and moves non-modules instances upstream to the `GroupWithZero` folder.

The instances for AddMonoidHom have been generalized, the rest have been moved without changes.

This is some cleanup ahead of #27305, which makes it clearer where the new `ZeroHom` instances there should go.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
