### PR TITLE
[Merged by Bors] - chore(Analysis): remove a few unneccessary assignments in instance declarations

### DIFF
--- a/Mathlib/Analysis/CStarAlgebra/CStarMatrix.lean
+++ b/Mathlib/Analysis/CStarAlgebra/CStarMatrix.lean
@@ -767,13 +767,11 @@ instance instCStarRing : CStarRing (CStarMatrix n n A) :=
     rw [← Real.sqrt_le_sqrt_iff (by positivity)]
     simp [hmain]
 
-#adaptation_note /-- 2025-03-29 for lean4#7717 had to add `norm_mul_self_le` field. -/
 /-- Matrices with entries in a non-unital C⋆-algebra form a non-unital C⋆-algebra. -/
 noncomputable instance instNonUnitalCStarAlgebra :
     NonUnitalCStarAlgebra (CStarMatrix n n A) where
   smul_assoc x y z := by simp
   smul_comm m a b := (Matrix.mul_smul _ _ _).symm
-  norm_mul_self_le := CStarRing.norm_mul_self_le
 
 noncomputable instance instPartialOrder :
     PartialOrder (CStarMatrix n n A) := CStarAlgebra.spectralOrder _
@@ -795,10 +793,8 @@ noncomputable instance instNormedRing : NormedRing (CStarMatrix n n A) where
 noncomputable instance instNormedAlgebra : NormedAlgebra ℂ (CStarMatrix n n A) where
   norm_smul_le r M := by simpa only [norm_def, map_smul] using (toCLM M).opNorm_smul_le r
 
-#adaptation_note /-- 2025-03-29 for lean4#7717 had to add `norm_mul_self_le` field. -/
 /-- Matrices with entries in a unital C⋆-algebra form a unital C⋆-algebra. -/
 noncomputable instance instCStarAlgebra [DecidableEq n] : CStarAlgebra (CStarMatrix n n A) where
-  norm_mul_self_le := CStarRing.norm_mul_self_le
 
 end unital
 

--- a/Mathlib/Analysis/CStarAlgebra/Classes.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Classes.lean
@@ -35,10 +35,8 @@ class CStarAlgebra (A : Type*) extends NormedRing A, StarRing A, CompleteSpace A
 /-- The class of unital commutative (complex) C⋆-algebras. -/
 class CommCStarAlgebra (A : Type*) extends NormedCommRing A, CStarAlgebra A
 
-#adaptation_note /-- 2025-03-29 for lean4#7717 had to add `norm_mul_self_le` field. -/
 instance (priority := 100) CStarAlgebra.toNonUnitalCStarAlgebra (A : Type*) [CStarAlgebra A] :
     NonUnitalCStarAlgebra A where
-  norm_mul_self_le := CStarRing.norm_mul_self_le
 
 instance (priority := 100) CommCStarAlgebra.toNonUnitalCommCStarAlgebra (A : Type*)
     [CommCStarAlgebra A] : NonUnitalCommCStarAlgebra A where
@@ -69,28 +67,19 @@ noncomputable instance NonUnitalStarSubalgebra.nonUnitalCommCStarAlgebra {S A : 
   norm_mul_self_le x := CStarRing.norm_star_mul_self (x := (x : A)) |>.symm.le
   mul_comm _ _ := Subtype.ext <| mul_comm _ _
 
-#adaptation_note /-- 2025-03-29 for lean4#7717 had to add `norm_mul_self_le` field. -/
 noncomputable instance : CommCStarAlgebra ℂ where
-  mul_comm := mul_comm
-  norm_mul_self_le := CStarRing.norm_mul_self_le
 
 section Pi
 
 variable {ι : Type*} {A : ι → Type*} [Fintype ι]
 
-#adaptation_note /-- 2025-03-29 for lean4#7717 had to add `norm_mul_self_le` field. -/
 instance [(i : ι) → NonUnitalCStarAlgebra (A i)] : NonUnitalCStarAlgebra (Π i, A i) where
-  norm_mul_self_le := CStarRing.norm_mul_self_le
 
 instance [(i : ι) → NonUnitalCommCStarAlgebra (A i)] : NonUnitalCommCStarAlgebra (Π i, A i) where
-  mul_comm := mul_comm
 
-#adaptation_note /-- 2025-03-29 for lean4#7717 had to add `norm_mul_self_le` field. -/
 noncomputable instance [(i : ι) → CStarAlgebra (A i)] : CStarAlgebra (Π i, A i) where
-  norm_mul_self_le := CStarRing.norm_mul_self_le
 
 noncomputable instance [(i : ι) → CommCStarAlgebra (A i)] : CommCStarAlgebra (Π i, A i) where
-  mul_comm := mul_comm
 
 end Pi
 
@@ -98,20 +87,14 @@ section Prod
 
 variable {A B : Type*}
 
-#adaptation_note /-- 2025-03-29 for lean4#7717 had to add `norm_mul_self_le` field. -/
 instance [NonUnitalCStarAlgebra A] [NonUnitalCStarAlgebra B] : NonUnitalCStarAlgebra (A × B) where
-  norm_mul_self_le := CStarRing.norm_mul_self_le
 
 instance [NonUnitalCommCStarAlgebra A] [NonUnitalCommCStarAlgebra B] :
     NonUnitalCommCStarAlgebra (A × B) where
-  mul_comm := mul_comm
 
-#adaptation_note /-- 2025-03-29 for lean4#7717 had to add `norm_mul_self_le` field. -/
 noncomputable instance [CStarAlgebra A] [CStarAlgebra B] : CStarAlgebra (A × B) where
-  norm_mul_self_le := CStarRing.norm_mul_self_le
 
 noncomputable instance [CommCStarAlgebra A] [CommCStarAlgebra B] : CommCStarAlgebra (A × B) where
-  mul_comm := mul_comm
 
 end Prod
 
@@ -119,15 +102,11 @@ namespace MulOpposite
 
 variable {A : Type*}
 
-#adaptation_note /-- 2025-03-29 for lean4#7717 had to add `norm_mul_self_le` field. -/
 instance [NonUnitalCStarAlgebra A] : NonUnitalCStarAlgebra Aᵐᵒᵖ where
-  norm_mul_self_le := CStarRing.norm_mul_self_le
 
 instance [NonUnitalCommCStarAlgebra A] : NonUnitalCommCStarAlgebra Aᵐᵒᵖ where
 
-#adaptation_note /-- 2025-03-29 for lean4#7717 had to add `norm_mul_self_le` field. -/
 noncomputable instance [CStarAlgebra A] : CStarAlgebra Aᵐᵒᵖ where
-  norm_mul_self_le := CStarRing.norm_mul_self_le
 
 noncomputable instance [CommCStarAlgebra A] : CommCStarAlgebra Aᵐᵒᵖ where
 

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Basic.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Basic.lean
@@ -64,10 +64,7 @@ instance {R A : Type*} [CommRing R] [StarRing R] [NormedRing A] [Algebra R A] [S
   { SubringClass.toNormedRing (elemental R a) with
     mul_comm := mul_comm }
 
-#adaptation_note /-- 2025-03-29 for lean4#7717 had to add `norm_mul_self_le` field. -/
 noncomputable instance (a : A) [IsStarNormal a] : CommCStarAlgebra (elemental ℂ a) where
-  mul_comm := mul_comm
-  norm_mul_self_le := CStarRing.norm_mul_self_le
 
 variable (a : A) [IsStarNormal a]
 

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousLinearMap.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousLinearMap.lean
@@ -12,8 +12,6 @@ We place this here because, for reasons related to the import hierarchy, it shou
 in earlier files.
 -/
 
-#adaptation_note /-- 2025-03-29 for lean4#7717 had to add `norm_mul_self_le` field. -/
 noncomputable
 instance {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E] [CompleteSpace E] :
     CStarAlgebra (E →L[ℂ] E) where
-  norm_mul_self_le := CStarRing.norm_mul_self_le

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousMap.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousMap.lean
@@ -20,19 +20,13 @@ namespace BoundedContinuousFunction
 
 variable [TopologicalSpace α]
 
-#adaptation_note /-- 2025-03-29 for lean4#7717 had to add `norm_mul_self_le` field. -/
 instance [NonUnitalCStarAlgebra A] : NonUnitalCStarAlgebra (α →ᵇ A) where
-  norm_mul_self_le := CStarRing.norm_mul_self_le
 
 instance [NonUnitalCommCStarAlgebra A] : NonUnitalCommCStarAlgebra (α →ᵇ A) where
-  mul_comm := mul_comm
 
-#adaptation_note /-- 2025-03-29 for lean4#7717 had to add `norm_mul_self_le` field. -/
 instance [CStarAlgebra A] : CStarAlgebra (α →ᵇ A) where
-  norm_mul_self_le := CStarRing.norm_mul_self_le
 
 instance [CommCStarAlgebra A] : CommCStarAlgebra (α →ᵇ A) where
-  mul_comm := mul_comm
 
 end BoundedContinuousFunction
 
@@ -40,19 +34,13 @@ namespace ContinuousMap
 
 variable [TopologicalSpace α] [CompactSpace α]
 
-#adaptation_note /-- 2025-03-29 for lean4#7717 had to add `norm_mul_self_le` field. -/
 instance [NonUnitalCStarAlgebra A] : NonUnitalCStarAlgebra C(α, A) where
-  norm_mul_self_le := CStarRing.norm_mul_self_le
 
 instance [NonUnitalCommCStarAlgebra A] : NonUnitalCommCStarAlgebra C(α, A) where
-  mul_comm := mul_comm
 
-#adaptation_note /-- 2025-03-29 for lean4#7717 had to add `norm_mul_self_le` field. -/
 instance [CStarAlgebra A] : CStarAlgebra C(α, A) where
-  norm_mul_self_le := CStarRing.norm_mul_self_le
 
 instance [CommCStarAlgebra A] : CommCStarAlgebra C(α, A) where
-  mul_comm := mul_comm
 
 end ContinuousMap
 
@@ -60,12 +48,9 @@ namespace ZeroAtInftyContinuousMap
 
 open ZeroAtInfty
 
-#adaptation_note /-- 2025-03-29 for lean4#7717 had to add `norm_mul_self_le` field. -/
 instance [TopologicalSpace α] [NonUnitalCStarAlgebra A] : NonUnitalCStarAlgebra C₀(α, A) where
-  norm_mul_self_le := CStarRing.norm_mul_self_le
 
 instance [TopologicalSpace α] [NonUnitalCommCStarAlgebra A] :
     NonUnitalCommCStarAlgebra C₀(α, A) where
-  mul_comm := mul_comm
 
 end ZeroAtInftyContinuousMap

--- a/Mathlib/Analysis/CStarAlgebra/Multiplier.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Multiplier.lean
@@ -640,8 +640,6 @@ instance instCStarRing : CStarRing 𝓜(𝕜, A) where
 
 end DenselyNormed
 
-#adaptation_note /-- 2025-03-29 for lean4#7717 had to add `norm_mul_self_le` field. -/
 noncomputable instance {A : Type*} [NonUnitalCStarAlgebra A] : CStarAlgebra 𝓜(ℂ, A) where
-  norm_mul_self_le := CStarRing.norm_mul_self_le
 
 end DoubleCentralizer

--- a/Mathlib/Analysis/CStarAlgebra/Unitization.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Unitization.lean
@@ -174,13 +174,10 @@ instance Unitization.instCStarRing : CStarRing (Unitization 𝕜 E) where
 unital, `A⁺¹ ≃⋆ₐ[ℂ] (ℂ × A)`. -/
 scoped[CStarAlgebra] postfix:max "⁺¹" => Unitization ℂ
 
-#adaptation_note /-- 2025-03-29 for lean4#7717 had to add `norm_mul_self_le` field. -/
 noncomputable instance Unitization.instCStarAlgebra {A : Type*} [NonUnitalCStarAlgebra A] :
     CStarAlgebra (Unitization ℂ A) where
-  norm_mul_self_le := CStarRing.norm_mul_self_le
 
 noncomputable instance Unitization.instCommCStarAlgebra {A : Type*} [NonUnitalCommCStarAlgebra A] :
     CommCStarAlgebra (Unitization ℂ A) where
-  mul_comm := mul_comm
 
 end CStarProperty

--- a/Mathlib/Analysis/CStarAlgebra/lpSpace.lean
+++ b/Mathlib/Analysis/CStarAlgebra/lpSpace.lean
@@ -17,12 +17,9 @@ noncomputable section
 
 variable {I : Type*} {A : I → Type*}
 
-#adaptation_note /-- 2025-03-29 for lean4#7717 had to add `norm_mul_self_le` field. -/
 instance [∀ i, NonUnitalCStarAlgebra (A i)] : NonUnitalCStarAlgebra (lp A ∞) where
-  norm_mul_self_le := CStarRing.norm_mul_self_le
 
 instance [∀ i, NonUnitalCommCStarAlgebra (A i)] : NonUnitalCommCStarAlgebra (lp A ∞) where
-  mul_comm := mul_comm
 
 -- it's slightly weird that we need the `Nontrivial` instance here
 -- it's because we have no way to say that `‖(1 : A i)‖` is uniformly bounded as a type class
@@ -31,9 +28,6 @@ instance [∀ i, Nontrivial (A i)] [∀ i, CStarAlgebra (A i)] : NormedRing (lp 
   dist_eq := dist_eq_norm
   norm_mul_le := norm_mul_le
 
-#adaptation_note /-- 2025-03-29 for lean4#7717 had to add `norm_mul_self_le` field. -/
 instance [∀ i, Nontrivial (A i)] [∀ i, CommCStarAlgebra (A i)] : CommCStarAlgebra (lp A ∞) where
-  mul_comm := mul_comm
-  norm_mul_self_le := CStarRing.norm_mul_self_le
 
 end

--- a/Mathlib/Analysis/LocallyConvex/WeakOperatorTopology.lean
+++ b/Mathlib/Analysis/LocallyConvex/WeakOperatorTopology.lean
@@ -226,11 +226,10 @@ instance instContinuousAdd : ContinuousAdd (E →WOT[𝕜] F) := .induced (induc
 instance instContinuousNeg : ContinuousNeg (E →WOT[𝕜] F) := .induced (inducingFn 𝕜 E F)
 instance instContinuousSMul : ContinuousSMul 𝕜 (E →WOT[𝕜] F) := .induced (inducingFn 𝕜 E F)
 
-#adaptation_note /-- 2025-03-29 lean4#7717 Needed to add these instances explicitly to avoid a
+#adaptation_note /-- 2025-03-29 lean4#7717 Needed to add this instance explicitly to avoid a
 limitation with parent instance inference. TODO(kmill): fix this. -/
 instance instIsTopologicalAddGroup : IsTopologicalAddGroup (E →WOT[𝕜] F) where
   toContinuousAdd := inferInstance
-  toContinuousNeg := inferInstance
 
 instance instUniformSpace : UniformSpace (E →WOT[𝕜] F) := .comap (inducingFn 𝕜 E F) inferInstance
 


### PR DESCRIPTION
These were introduced mostly as an adaptation for lean4#7717, but they seem to be unnecessary anymore. Since the changes were applied long ago, I can't see the build errors in the logs to figure out the exact issue. (I assume that they simply were not getting inferred.)

In addition to the now-unnecessary `norm_mul_self_le` field for `CStarAlgebra` introduced in those adaptation notes, we can also get rid of quite a few unnecessary `mul_comm` fields.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
