### PR TITLE
[Merged by Bors] - feat(RepresentationTheory/Homological): (co)(res/inf) natural transformations on group (co)homology

### DIFF
--- a/Mathlib/RepresentationTheory/Coinvariants.lean
+++ b/Mathlib/RepresentationTheory/Coinvariants.lean
@@ -422,7 +422,7 @@ instance (A : Rep k G) : ((coinvariantsTensor k G).obj A).Linear k where
 
 section
 
-variable {k G : Type u} [CommRing k] [Group G] (A : Rep k G)
+variable (k : Type u) {G : Type u} [CommRing k] [Group G]
 
 /-- Given a normal subgroup `S ≤ G`, this is the functor sending a `G`-representation `A` to the
 `G ⧸ S`-representation it induces on `A_S`. -/
@@ -437,7 +437,7 @@ noncomputable def quotientToCoinvariantsFunctor (S : Subgroup G) [S.Normal] :
 
 section Finsupp
 
-variable (α : Type u) [DecidableEq α]
+variable {k} (A : Rep k G) (α : Type u) [DecidableEq α]
 
 open MonoidalCategory Finsupp ModuleCat.MonoidalCategory
 

--- a/Mathlib/RepresentationTheory/Coinvariants.lean
+++ b/Mathlib/RepresentationTheory/Coinvariants.lean
@@ -163,9 +163,13 @@ noncomputable abbrev toCoinvariantsKer :
 
 /-- Given a normal subgroup `S ≤ G`, a `G`-representation `ρ` induces a `G`-representation on the
 coinvariants of `ρ|_S`. -/
-noncomputable abbrev toCoinvariants :
+noncomputable def toCoinvariants :
     Representation k G (Coinvariants <| ρ.comp S.subtype) :=
   quotient ρ (ker <| ρ.comp S.subtype) fun g => le_comap_ker ρ S g
+
+@[simp]
+lemma toCoinvariants_mk (g : G) (x : V) :
+    toCoinvariants ρ S g (Coinvariants.mk _ x) = Coinvariants.mk _ (ρ g x) := rfl
 
 instance : IsTrivial ((toCoinvariants ρ S).comp S.subtype) where
   out g := by
@@ -416,9 +420,24 @@ lemma coinvariantsTensor_hom_ext {M : ModuleCat k}
 instance (A : Rep k G) : ((coinvariantsTensor k G).obj A).Additive where
 instance (A : Rep k G) : ((coinvariantsTensor k G).obj A).Linear k where
 
+section
+
+variable {k G : Type u} [CommRing k] [Group G] (A : Rep k G)
+
+/-- Given a normal subgroup `S ≤ G`, this is the functor sending a `G`-representation `A` to the
+`G ⧸ S`-representation it induces on `A_S`. -/
+@[simps obj_V map_hom]
+noncomputable def quotientToCoinvariantsFunctor (S : Subgroup G) [S.Normal] :
+    Rep k G ⥤ Rep k (G ⧸ S) where
+  obj X := X.quotientToCoinvariants S
+  map {X Y} f := {
+    hom := (coinvariantsFunctor k S).map ((Action.res _ S.subtype).map f)
+    comm g := QuotientGroup.induction_on g fun g => by
+      ext; simp [ModuleCat.endRingEquiv, hom_comm_apply] }
+
 section Finsupp
 
-variable {k G : Type u} [CommRing k] [Group G] (A : Rep k G) (α : Type u) [DecidableEq α]
+variable (α : Type u) [DecidableEq α]
 
 open MonoidalCategory Finsupp ModuleCat.MonoidalCategory
 
@@ -485,4 +504,7 @@ lemma coinvariantsTensorFreeLEquiv_apply (x : (A ⊗ free k G α).ρ.Coinvariant
   rfl
 
 end Finsupp
+
+end
+
 end Rep

--- a/Mathlib/RepresentationTheory/Homological/GroupCohomology/Functoriality.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupCohomology/Functoriality.lean
@@ -627,19 +627,6 @@ noncomputable def resNatTrans (n : ℕ) :
     cochainsMap, congr (MonoidHom.comp_id _) cochainsMap, Category.id_comp
     (X := (Action.res _ _).obj _)]
 
-/-- Given a normal subgroup S ≤ G, this is the functor sending a `G`-representation `A` to the
-`G ⧸ S`-representation it induces on `A^S`. -/
-@[simps obj_V map_hom]
-noncomputable def quotientToInvariantsFunctor (S : Subgroup G) [S.Normal] :
-    Rep k G ⥤ Rep k (G ⧸ S) where
-  obj X := X.quotientToInvariants S
-  map {X Y} f := {
-    hom := (invariantsFunctor k S).map ((Action.res _ S.subtype).map f)
-    comm g := QuotientGroup.induction_on g fun g => by
-      ext x
-      simp [ModuleCat.endRingEquiv, Representation.quotientToInvariants,
-        Representation.toInvariants, invariants, hom_comm_apply] }
-
 /-- Given a normal subgroup `S ≤ G`, this is a natural transformation between the functors
 sending `A : Rep k G` to `Hⁿ(G ⧸ S, A^S)` and to `Hⁿ(G, A)`. -/
 @[simps]

--- a/Mathlib/RepresentationTheory/Homological/GroupCohomology/Functoriality.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupCohomology/Functoriality.lean
@@ -588,8 +588,8 @@ alias H2π_comp_H2Map := H2π_comp_map
 
 end H2
 
+variable (k G)
 
-variable (k G) in
 /-- The functor sending a representation to its complex of inhomogeneous cochains. -/
 @[simps]
 noncomputable def cochainsFunctor : Rep k G ⥤ CochainComplex (ModuleCat k) ℕ where
@@ -601,7 +601,6 @@ noncomputable def cochainsFunctor : Rep k G ⥤ CochainComplex (ModuleCat k) ℕ
 instance : (cochainsFunctor k G).PreservesZeroMorphisms where
 instance : (cochainsFunctor k G).Additive where
 
-variable (k G) in
 /-- The functor sending a `G`-representation `A` to `Hⁿ(G, A)`. -/
 @[simps]
 noncomputable def functor (n : ℕ) : Rep k G ⥤ ModuleCat k where
@@ -614,5 +613,43 @@ noncomputable def functor (n : ℕ) : Rep k G ⥤ ModuleCat k where
 
 instance (n : ℕ) : (functor k G n).PreservesZeroMorphisms where
   map_zero _ _ := by simp [map]
+
+variable {G}
+
+/-- Given a group homomorphism `f : G →* H`, this is a natural transformation between the functors
+sending `A : Rep k H` to `Hⁿ(H, A)` and to `Hⁿ(G, Res(f)(A))`. -/
+@[simps]
+noncomputable def resNatTrans (n : ℕ) :
+    functor k H n ⟶ Action.res (ModuleCat k) f ⋙ functor k G n where
+  app X := map f (𝟙 _) n
+  naturality {X Y} φ := by simp [← cancel_epi (groupCohomology.π _ n),
+    ← HomologicalComplex.cyclesMap_comp_assoc, ← cochainsMap_comp, congr (MonoidHom.id_comp _)
+    cochainsMap, congr (MonoidHom.comp_id _) cochainsMap, Category.id_comp
+    (X := (Action.res _ _).obj _)]
+
+/-- Given a normal subgroup S ≤ G, this is the functor sending a `G`-representation `A` to the
+`G ⧸ S`-representation it induces on `A^S`. -/
+@[simps obj_V map_hom]
+noncomputable def quotientToInvariantsFunctor (S : Subgroup G) [S.Normal] :
+    Rep k G ⥤ Rep k (G ⧸ S) where
+  obj X := X.quotientToInvariants S
+  map {X Y} f := {
+    hom := (invariantsFunctor k S).map ((Action.res _ S.subtype).map f)
+    comm g := QuotientGroup.induction_on g fun g => by
+      ext x
+      simp [ModuleCat.endRingEquiv, Representation.quotientToInvariants,
+        Representation.toInvariants, invariants, hom_comm_apply] }
+
+/-- Given a normal subgroup `S ≤ G`, this is a natural transformation between the functors
+sending `A : Rep k G` to `Hⁿ(G ⧸ S, A^S)` and to `Hⁿ(G, A)`. -/
+@[simps]
+noncomputable def infNatTrans (S : Subgroup G) [S.Normal] (n : ℕ) :
+    quotientToInvariantsFunctor k S ⋙ functor k (G ⧸ S) n ⟶ functor k G n where
+  app A := map (QuotientGroup.mk' S) (subtype _ _ <| le_comap_invariants A.ρ S) n
+  naturality {X Y} φ := by
+    simp only [Functor.comp_map, functor_map, ← cancel_epi (groupCohomology.π _ n),
+      HomologicalComplex.homologyπ_naturality_assoc, HomologicalComplex.homologyπ_naturality,
+      ← HomologicalComplex.cyclesMap_comp_assoc, ← cochainsMap_comp]
+    congr 1
 
 end groupCohomology

--- a/Mathlib/RepresentationTheory/Homological/GroupHomology/Functoriality.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupHomology/Functoriality.lean
@@ -33,6 +33,12 @@ open CategoryTheory Rep Finsupp Representation
 variable {k G H : Type u} [CommRing k] [Group G] [Group H]
   {A : Rep k G} {B : Rep k H} (f : G →* H) (φ : A ⟶ (Action.res _ f).obj B) (n : ℕ)
 
+theorem congr {f₁ f₂ : G →* H} (h : f₁ = f₂) {φ : A ⟶ (Action.res _ f₁).obj B} {T : Type*}
+    (F : (f : G →* H) → (φ : A ⟶ (Action.res _ f).obj B) → T) :
+    F f₁ φ = F f₂ (h ▸ φ) := by
+  subst h
+  rfl
+
 /-- Given a group homomorphism `f : G →* H` and a representation morphism `φ : A ⟶ Res(f)(B)`,
 this is the chain map sending `∑ aᵢ·gᵢ : Gⁿ →₀ A` to `∑ φ(aᵢ)·(f ∘ gᵢ) : Hⁿ →₀ B`. -/
 @[simps! -isSimp f f_hom]
@@ -399,7 +405,8 @@ lemma H2π_comp_map :
 
 end H2
 
-variable (k G) in
+variable (k G)
+
 /-- The functor sending a representation to its complex of inhomogeneous chains. -/
 @[simps]
 noncomputable def chainsFunctor :
@@ -411,7 +418,6 @@ noncomputable def chainsFunctor :
 
 instance : (chainsFunctor k G).PreservesZeroMorphisms where
 
-variable (k G) in
 /-- The functor sending a `G`-representation `A` to `Hₙ(G, A)`. -/
 @[simps]
 noncomputable def functor (n : ℕ) : Rep k G ⥤ ModuleCat k where
@@ -424,5 +430,30 @@ noncomputable def functor (n : ℕ) : Rep k G ⥤ ModuleCat k where
 
 instance (n : ℕ) : (functor k G n).PreservesZeroMorphisms where
   map_zero _ _ := by simp [map]
+
+variable {G}
+
+/-- Given a group homomorphism `f : G →* H`, this is a natural transformation between the functors
+sending `A : Rep k H` to `Hₙ(G, Res(f)(A)) ⟶ Hₙ(H, A)`. -/
+@[simps]
+noncomputable def coresNatTrans (n : ℕ) :
+    Action.res (ModuleCat k) f ⋙ functor k G n ⟶ functor k H n where
+  app X := map f (𝟙 _) n
+  naturality {X Y} φ := by simp [← cancel_epi (groupHomology.π _ n),
+    ← HomologicalComplex.cyclesMap_comp_assoc, ← chainsMap_comp, congr (MonoidHom.id_comp _)
+    chainsMap, congr (MonoidHom.comp_id _) chainsMap, Category.id_comp
+    (X := (Action.res _ _).obj _)]
+
+/-- Given a normal subgroup `S ≤ G`, this is a natural transformation between the functors
+sending `A : Rep k G` to `Hₙ(G, A)` and to `Hₙ(G ⧸ S, A_S)`. -/
+@[simps]
+noncomputable def coinfNatTrans (S : Subgroup G) [S.Normal] (n : ℕ) :
+    functor k G n ⟶ quotientToCoinvariantsFunctor k S ⋙ functor k (G ⧸ S) n where
+  app A := map (QuotientGroup.mk' S) (mkQ _ _ <| Coinvariants.le_comap_ker A.ρ S) n
+  naturality {X Y} φ := by
+    simp only [Functor.comp_map, functor_map, ← cancel_epi (groupHomology.π _ n),
+      HomologicalComplex.homologyπ_naturality_assoc, HomologicalComplex.homologyπ_naturality,
+      ← HomologicalComplex.cyclesMap_comp_assoc, ← chainsMap_comp]
+    congr 1
 
 end groupHomology

--- a/Mathlib/RepresentationTheory/Homological/GroupHomology/Functoriality.lean
+++ b/Mathlib/RepresentationTheory/Homological/GroupHomology/Functoriality.lean
@@ -434,7 +434,7 @@ instance (n : ℕ) : (functor k G n).PreservesZeroMorphisms where
 variable {G}
 
 /-- Given a group homomorphism `f : G →* H`, this is a natural transformation between the functors
-sending `A : Rep k H` to `Hₙ(G, Res(f)(A)) ⟶ Hₙ(H, A)`. -/
+sending `A : Rep k H` to `Hₙ(G, Res(f)(A))` and to `Hₙ(H, A)`. -/
 @[simps]
 noncomputable def coresNatTrans (n : ℕ) :
     Action.res (ModuleCat k) f ⋙ functor k G n ⟶ functor k H n where

--- a/Mathlib/RepresentationTheory/Invariants.lean
+++ b/Mathlib/RepresentationTheory/Invariants.lean
@@ -219,6 +219,7 @@ instance : (invariantsFunctor k G).PreservesZeroMorphisms where
 instance : (invariantsFunctor k G).Additive where
 instance : (invariantsFunctor k G).Linear k where
 
+variable {G} in
 /-- Given a normal subgroup S ≤ G, this is the functor sending a `G`-representation `A` to the
 `G ⧸ S`-representation it induces on `A^S`. -/
 @[simps obj_V map_hom]

--- a/Mathlib/RepresentationTheory/Invariants.lean
+++ b/Mathlib/RepresentationTheory/Invariants.lean
@@ -219,6 +219,19 @@ instance : (invariantsFunctor k G).PreservesZeroMorphisms where
 instance : (invariantsFunctor k G).Additive where
 instance : (invariantsFunctor k G).Linear k where
 
+/-- Given a normal subgroup S ≤ G, this is the functor sending a `G`-representation `A` to the
+`G ⧸ S`-representation it induces on `A^S`. -/
+@[simps obj_V map_hom]
+noncomputable def quotientToInvariantsFunctor (S : Subgroup G) [S.Normal] :
+    Rep k G ⥤ Rep k (G ⧸ S) where
+  obj X := X.quotientToInvariants S
+  map {X Y} f := {
+    hom := (invariantsFunctor k S).map ((Action.res _ S.subtype).map f)
+    comm g := QuotientGroup.induction_on g fun g => by
+      ext x
+      simp [ModuleCat.endRingEquiv, Representation.quotientToInvariants,
+        Representation.toInvariants, invariants, hom_comm_apply] }
+
 /-- The adjunction between the functor equipping a module with the trivial representation, and
 the functor sending a representation to its submodule of invariants. -/
 @[simps]

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -208,7 +208,11 @@ open MonoidalCategory in
 theorem tensor_ρ {A B : Rep k G} : (A ⊗ B).ρ = A.ρ.tprod B.ρ := rfl
 
 @[simp]
-lemma res_obj_ρ {H : Type u} [Monoid H] (f : G →* H) (A : Rep k H) (g : G) :
+lemma res_obj_ρ {H : Type u} [Monoid H] (f : G →* H) (A : Rep k H) :
+    ρ ((Action.res _ f).obj A) = A.ρ.comp f := rfl
+
+@[simp]
+lemma coe_res_obj_ρ {H : Type u} [Monoid H] (f : G →* H) (A : Rep k H) (g : G) :
     DFunLike.coe (F := G →* (A →ₗ[k] A)) (ρ ((Action.res _ f).obj A)) g = A.ρ (f g) := rfl
 
 section Linearization


### PR DESCRIPTION
Given a group homomorphism `f : G →* H`, we define
- `groupCohomology.resNatTrans k f`: restriction natural transformation between the functors sending `A : Rep k H` to `Hⁿ(H, A)` and to `Hⁿ(G, Res(f)(A))`.
- `groupHomology.coresNatTrans k f`: corestriction natural transformation between the functors sending `A : Rep k H` to `Hₙ(G, Res(f)(A))` and to `Hₙ(H, A)`. 

Given a normal subgroup `S ≤ G`, we define 
- `groupCohomology.infNatTrans k S`: inflation natural transformation between the functors sending `A : Rep k G` to `Hⁿ(G ⧸ S, A^S)` and to `Hⁿ(G, A)`.
- `groupHomology.coinfNatTrans k S`: coinflation natural transformation between the functors sending sending `A : Rep k G` to `Hₙ(G, A)` and to `Hₙ(G ⧸ S, A_S)`. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
