### PR TITLE
[Merged by Bors] - chore(*): fix some scattered adaptation notes

### DIFF
--- a/Mathlib/AlgebraicGeometry/Morphisms/QuasiCompact.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/QuasiCompact.lean
@@ -254,14 +254,7 @@ theorem exists_pow_mul_eq_zero_of_res_basicOpen_eq_zero_of_isAffineOpen (X : Sch
     (H : x |_ (X.basicOpen f) = 0) :
     ∃ n : ℕ, f ^ n * x = 0 := by
   rw [← map_zero (X.presheaf.map (homOfLE <| X.basicOpen_le f : X.basicOpen f ⟶ U).op).hom] at H
-  #adaptation_note /-- nightly-2024-09-29
-  we could use dot notation here:
-  `(hU.isLocalization_basicOpen f).exists_of_eq H`
-  This is no longer possible;
-  likely changing the signature of `IsLocalization.Away.exists_of_eq` is in order.
--/
-  obtain ⟨n, e⟩ :=
-    @IsLocalization.Away.exists_of_eq _ _ _ _ _ _ (hU.isLocalization_basicOpen f) _ _ H
+  obtain ⟨n, e⟩ := (hU.isLocalization_basicOpen f).exists_of_eq _ H
   exact ⟨n, by simpa [mul_comm x] using e⟩
 
 /-- If `x : Γ(X, U)` is zero on `D(f)` for some `f : Γ(X, U)`, and `U` is quasi-compact, then

--- a/Mathlib/Analysis/Complex/TaylorSeries.lean
+++ b/Mathlib/Analysis/Complex/TaylorSeries.lean
@@ -24,23 +24,16 @@ see `Complex.hasSum_taylorSeries_of_entire`, `Complex.taylorSeries_eq_of_entire`
 `Complex.taylorSeries_eq_of_entire'`.
 -/
 
-#adaptation_note /-- https://github.com/leanprover/lean4/issues/5126
-we've had to change all
-the `⦃⦄` stricit implicit variable statements in this file to normal `{}` implicit variables.
-
-Once this issue is fixed, we should change them back. For now it doesn't break anything downstream.
--/
-
 namespace Complex
 
 open Nat
 
-variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E] [CompleteSpace E] {f : ℂ → E}
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E] [CompleteSpace E] ⦃f : ℂ → E⦄
 
 section ball
 
-variable {c : ℂ} {r : ℝ} (hf : DifferentiableOn ℂ f (Metric.ball c r))
-variable {z : ℂ} (hz : z ∈ Metric.ball c r)
+variable ⦃c : ℂ⦄ ⦃r : ℝ⦄ (hf : DifferentiableOn ℂ f (Metric.ball c r))
+variable ⦃z : ℂ⦄ (hz : z ∈ Metric.ball c r)
 
 include hf hz in
 /-- A function that is complex differentiable on the open ball of radius `r` around `c`
@@ -81,8 +74,8 @@ end ball
 
 section emetric
 
-variable {c : ℂ} {r : ENNReal} (hf : DifferentiableOn ℂ f (EMetric.ball c r))
-variable {z : ℂ} (hz : z ∈ EMetric.ball c r)
+variable ⦃c : ℂ⦄ ⦃r : ENNReal⦄ (hf : DifferentiableOn ℂ f (EMetric.ball c r))
+variable ⦃z : ℂ⦄ (hz : z ∈ EMetric.ball c r)
 
 include hf hz in
 /-- A function that is complex differentiable on the open ball of radius `r ≤ ∞` around `c`
@@ -115,7 +108,7 @@ end emetric
 
 section entire
 
-variable {f : ℂ → E} (hf : Differentiable ℂ f) (c z : ℂ)
+variable ⦃f : ℂ → E⦄ (hf : Differentiable ℂ f) (c z : ℂ)
 
 include hf in
 /-- A function that is complex differentiable on the complex plane is given by evaluating

--- a/Mathlib/CategoryTheory/GradedObject/Monoidal.lean
+++ b/Mathlib/CategoryTheory/GradedObject/Monoidal.lean
@@ -314,12 +314,7 @@ lemma associator_naturality (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (f₃ 
     [HasGoodTensor₁₂Tensor Y₁ Y₂ Y₃] [HasGoodTensorTensor₂₃ Y₁ Y₂ Y₃] :
     tensorHom (tensorHom f₁ f₂) f₃ ≫ (associator Y₁ Y₂ Y₃).hom =
       (associator X₁ X₂ X₃).hom ≫ tensorHom f₁ (tensorHom f₂ f₃) := by
-        #adaptation_note /-- https://github.com/leanprover/lean4/pull/4154
-        this used to be aesop_cat -/
-        ext x i₁ i₂ i₃ h : 2
-        simp only [categoryOfGradedObjects_comp, ιTensorObj₃'_tensorHom_assoc,
-          associator_conjugation, ιTensorObj₃'_associator_hom, assoc, Iso.inv_hom_id_assoc,
-          ιTensorObj₃'_associator_hom_assoc, ιTensorObj₃_tensorHom]
+        aesop_cat
 
 end
 

--- a/Mathlib/Data/Bool/Basic.lean
+++ b/Mathlib/Data/Bool/Basic.lean
@@ -49,8 +49,7 @@ theorem or_eq_true_eq_eq_true_or_eq_true (a b : Bool) :
 
 theorem not_eq_true_eq_eq_false (a : Bool) : (not a = true) = (a = false) := by cases a <;> simp
 
-#adaptation_note /-- nightly-2024-03-05
-this is no longer a simp lemma, as the LHS simplifies. -/
+@[simp]
 theorem and_eq_false_eq_eq_false_or_eq_false (a b : Bool) :
     ((a && b) = false) = (a = false ∨ b = false) := by
   cases a <;> cases b <;> simp

--- a/Mathlib/Data/Bool/Basic.lean
+++ b/Mathlib/Data/Bool/Basic.lean
@@ -49,7 +49,8 @@ theorem or_eq_true_eq_eq_true_or_eq_true (a b : Bool) :
 
 theorem not_eq_true_eq_eq_false (a : Bool) : (not a = true) = (a = false) := by cases a <;> simp
 
-@[simp]
+#adaptation_note /-- nightly-2024-03-05
+this is no longer a simp lemma, as the LHS simplifies. -/
 theorem and_eq_false_eq_eq_false_or_eq_false (a b : Bool) :
     ((a && b) = false) = (a = false ∨ b = false) := by
   cases a <;> cases b <;> simp

--- a/Mathlib/Data/Nat/Hyperoperation.lean
+++ b/Mathlib/Data/Nat/Hyperoperation.lean
@@ -77,11 +77,7 @@ theorem hyperoperation_two_two_eq_four (n : ℕ) : hyperoperation (n + 1) 2 2 = 
 theorem hyperoperation_ge_three_one (n k : ℕ) : hyperoperation (n + 3) 1 k = 1 := by
   induction n generalizing k with
   | zero => grind
-  | succ n ih =>
-    cases k
-    · grind
-    · #adaptation_note /-- This will work by `grind` after nightly-2025-07-02. -/
-      rw [hyperoperation_recursion, ih]
+  | succ n ih => cases k <;> grind
 
 @[grind =]
 theorem hyperoperation_ge_four_zero (n k : ℕ) :

--- a/Mathlib/Data/Prod/PProd.lean
+++ b/Mathlib/Data/Prod/PProd.lean
@@ -14,9 +14,6 @@ open Function
 
 variable {α β γ δ : Sort*}
 
-#adaptation_note /-- this will not be needed after nightly-2025-07-01 -/
-attribute [grind cases eager] PProd
-
 namespace PProd
 
 def mk.injArrow {α : Type*} {β : Type*} {x₁ : α} {y₁ : β} {x₂ : α} {y₂ : β} :

--- a/Mathlib/LinearAlgebra/BilinearForm/Properties.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Properties.lean
@@ -268,11 +268,9 @@ noncomputable def dualBasis (B : BilinForm K V) (hB : B.Nondegenerate) (b : Basi
 theorem dualBasis_repr_apply
     (B : BilinForm K V) (hB : B.Nondegenerate) (b : Basis ι K V) (x i) :
     (B.dualBasis hB b).repr x i = B x (b i) := by
-  #adaptation_note /-- https://github.com/leanprover/lean4/pull/4814
-  we did not need the `@` in front of `toDual_def` in the `rw`.
-  I'm confused! -/
+  have := FiniteDimensional.of_fintype_basis b
   rw [dualBasis, Basis.map_repr, LinearEquiv.symm_symm, LinearEquiv.trans_apply,
-    Basis.dualBasis_repr, @toDual_def]
+    Basis.dualBasis_repr, toDual_def]
 
 theorem apply_dualBasis_left (B : BilinForm K V) (hB : B.Nondegenerate) (b : Basis ι K V) (i j) :
     B (B.dualBasis hB b i) (b j) = if j = i then 1 else 0 := by

--- a/Mathlib/LinearAlgebra/PiTensorProduct.lean
+++ b/Mathlib/LinearAlgebra/PiTensorProduct.lean
@@ -683,12 +683,7 @@ variable (s) in
 def reindex (e : ι ≃ ι₂) : (⨂[R] i : ι, s i) ≃ₗ[R] ⨂[R] i : ι₂, s (e.symm i) :=
   let f := domDomCongrLinearEquiv' R R s (⨂[R] (i : ι₂), s (e.symm i)) e
   let g := domDomCongrLinearEquiv' R R s (⨂[R] (i : ι), s i) e
-  #adaptation_note /-- v4.7.0-rc1
-  An alternative to the last two proofs would be `aesop (simp_config := {zetaDelta := true})`
-  or a wrapper macro to that effect. -/
-  LinearEquiv.ofLinear (lift <| f.symm <| tprod R) (lift <| g <| tprod R)
-    (by aesop (add norm simp [f, g]))
-    (by aesop (add norm simp [f, g]))
+  LinearEquiv.ofLinear (lift <| f.symm <| tprod R) (lift <| g <| tprod R) (by aesop) (by aesop)
 
 end
 

--- a/Mathlib/MeasureTheory/Covering/Vitali.lean
+++ b/Mathlib/MeasureTheory/Covering/Vitali.lean
@@ -167,12 +167,7 @@ theorem exists_disjoint_subfamily_covering_enlargement_closedBall
   · exact ⟨∅, Subset.refl _, pairwiseDisjoint_empty, by simp⟩
   by_cases ht : ∀ a ∈ t, r a < 0
   · exact ⟨t, Subset.rfl, fun a ha b _ _ => by
-      #adaptation_note /-- nightly-2024-03-16
-      Previously `Function.onFun` unfolded in the following `simp only`,
-      but now needs a separate `rw`.
-      This may be a bug: a no import minimization may be required. -/
-      rw [Function.onFun]
-      simp only [closedBall_eq_empty.2 (ht a ha), empty_disjoint],
+      simp only [closedBall_eq_empty.2 (ht a ha), empty_disjoint, Function.onFun],
       fun a ha => ⟨a, ha, by simp only [closedBall_eq_empty.2 (ht a ha), empty_subset]⟩⟩
   push_neg at ht
   let t' := { a ∈ t | 0 ≤ r a }

--- a/Mathlib/NumberTheory/ClassNumber/AdmissibleAbsoluteValue.lean
+++ b/Mathlib/NumberTheory/ClassNumber/AdmissibleAbsoluteValue.lean
@@ -92,20 +92,14 @@ theorem exists_approx_aux (n : ℕ) (h : abv.IsAdmissible) :
     obtain ⟨s, hs⟩ :=
       Fintype.exists_lt_card_fiber_of_mul_lt_card (f := t)
         (by simpa only [Fintype.card_fin, pow_succ'] using Nat.lt_succ_self (M ^ n.succ))
-    refine ⟨fun i ↦ (Finset.univ.filter fun x ↦ t x = s).toList.get <| i.castLE ?_, fun i j h ↦ ?_,
+    have : (M ^ n).succ ≤ (Finset.toList {x | t x = s}).length := by
+      rwa [Finset.length_toList]
+    refine ⟨fun i ↦ (Finset.toList {x | t x = s})[i.castLE this], fun i j h ↦ ?_,
       fun i₀ i₁ ↦ ht _ _ ?_⟩
-    · rwa [Finset.length_toList]
-    · ext
-      simpa [(Finset.nodup_toList _).getElem_inj_iff] using h
-    · #adaptation_note /-- https://github.com/leanprover/lean4/pull/4400
-      This proof was nicer before.
-      Please feel welcome to improve it, by avoiding use of `List.get` in favour of `GetElem`. -/
-      have : ∀ i h, t ((Finset.univ.filter fun x ↦ t x = s).toList.get ⟨i, h⟩) = s := fun i h ↦
-        (Finset.mem_filter.mp (Finset.mem_toList.mp (List.get_mem _ ⟨i, h⟩))).2
-      simp only [Nat.succ_eq_add_one, Finset.length_toList, List.get_eq_getElem] at this
-      simp only [Nat.succ_eq_add_one, List.get_eq_getElem, Fin.coe_castLE]
-      rw [this _ (Nat.lt_of_le_of_lt (Nat.le_of_lt_succ i₁.2) hs),
-        this _ (Nat.lt_of_le_of_lt (Nat.le_of_lt_succ i₀.2) hs)]
+    · simpa [(Finset.nodup_toList _).getElem_inj_iff, Fin.val_inj] using h
+    · have : ∀ (i : Fin (M^n).succ), t (Finset.toList {x | t x = s})[i.castLE this] = s := fun i ↦
+        (Finset.mem_filter.mp ((Finset.mem_toList (s := {x | t x = s})).mp (List.getElem_mem _))).2
+      simp_rw [this]
   -- Since `s` is large enough, there are two elements of `A ∘ s`
   -- where the second components lie close together.
   obtain ⟨k₀, k₁, hk, h⟩ := ih hε hb fun x ↦ Fin.tail (A (s x))

--- a/Mathlib/Probability/Kernel/Disintegration/Density.lean
+++ b/Mathlib/Probability/Kernel/Disintegration/Density.lean
@@ -246,12 +246,7 @@ lemma setIntegral_densityProcess (hκν : fst κ ≤ ν) [IsFiniteKernel ν]
   simp_rw [sUnion_eq_iUnion]
   have h_disj : Pairwise (Disjoint on fun i : S ↦ (i : Set γ)) := by
     intro u v huv
-    #adaptation_note /-- nightly-2024-03-16
-    Previously `Function.onFun` unfolded in the following `simp only`,
-    but now needs a `rw`.
-    This may be a bug: a no import minimization may be required.
-    simp only [Finset.coe_sort_coe, Function.onFun] -/
-    rw [Function.onFun]
+    simp only [Function.onFun]
     refine disjoint_countablePartition (hS_subset (by simp)) (hS_subset (by simp)) ?_
     rwa [ne_eq, ← Subtype.ext_iff]
   rw [integral_iUnion, iUnion_prod_const, measureReal_def, measure_iUnion,

--- a/Mathlib/Tactic/ModCases.lean
+++ b/Mathlib/Tactic/ModCases.lean
@@ -74,11 +74,9 @@ partial def proveOnModCases {u : Level} (n : Q(ℕ)) (a : Q(ℤ)) (b : Q(ℕ)) (
     let (pr, acc) ← proveOnModCases n a b1 p
     pure (q(onModCases_succ $b $g $pr), g.mvarId! :: acc)
 
-#adaptation_note /-- kmill 2025-06-28 Added `unusedHavesSuffices` since `p₁` is "unused". -/
 /--
 Int case of `mod_cases h : e % n`.
 -/
-@[nolint unusedHavesSuffices]
 def modCases (h : TSyntax `Lean.binderIdent) (e : Q(ℤ)) (n : ℕ) : TacticM Unit := do
   let ⟨u, p, g⟩ ← inferTypeQ (.mvar (← getMainGoal))
   have lit : Q(ℕ) := mkRawNatLit n


### PR DESCRIPTION
This PR deals with adaptation notes in Mathlib that have become irrelevant or easily fixable. The remainder are going to require actual thinking to fix.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
