### PR TITLE
[Merged by Bors] - fix: make `compile_inductive%` work correctly with new compiler

### DIFF
--- a/Mathlib/Util/CompileInductive.lean
+++ b/Mathlib/Util/CompileInductive.lean
@@ -206,8 +206,9 @@ partial def compileSizeOf (iv : InductiveVal) (rv : RecursorVal) : MetaM Unit :=
         for i in deps do
           -- We only want to recompile inductives defined in external modules, because attempting
           -- to recompile `sizeOf` functions defined in the current module multiple times will lead
-          -- to errors. We assume that any inductives defined in the current module can be marked
-          -- with `compile_inductive%` themselves.
+          -- to errors. An entire mutual block of inductives is compiled when compiling any
+          -- inductive within it, so every inductive within the same module can be explicitly
+          -- compiled using `compile_inductive%` if necessary.
           if ((← getEnv).getModuleIdxFor? i).isSome then
             if let some (.inductInfo iv) := (← getEnv).find? i then
                compileInductive iv (warn := false)


### PR DESCRIPTION
The implementation of `compile_inductive%` made assumptions about the implementation of the old compiler that are no longer true. In particular, it looked for compiler IR decls in the kernel env, but these now exist in a private environment extension.

The main use of this check is to avoid recompiling a `sizeOf` definition multiple times within its originating module, so to fix this we just disable the recursive recompilation of inductives within the module of their definition. This means that they will require explicit `compile_inductive%` directives themselves, which were already being supplied anyways.

Fixes #27017.