### PR TITLE
[Merged by Bors] - feat(MeasureTheory/Measure/AddContent): Add lemma `addContent_biUnion_eq`

### DIFF
--- a/Mathlib/MeasureTheory/Measure/AddContent.lean
+++ b/Mathlib/MeasureTheory/Measure/AddContent.lean
@@ -314,6 +314,22 @@ lemma addContent_biUnion_le {ι : Type*} (hC : IsSetRing C) {s : ι → Set α}
     refine (addContent_union_le hC hs.1 (hC.biUnion_mem S hs.2)).trans ?_
     exact add_le_add le_rfl (h hs.2)
 
+lemma addContent_biUnion_eq {ι : Type*} (hC : IsSetRing C) {s : ι → Set α}
+    {S : Finset ι} (hs : ∀ n ∈ S, s n ∈ C) (hS : (S : Set ι).PairwiseDisjoint s) :
+    m (⋃ i ∈ S, s i) = ∑ i ∈ S, m (s i) := by
+  classical
+  induction S using Finset.induction with
+  | empty => simp
+  | insert i S hiS h =>
+    rw [Finset.sum_insert hiS]
+    simp_rw [← Finset.mem_coe, Finset.coe_insert, Set.biUnion_insert]
+    simp only [Finset.mem_insert, forall_eq_or_imp] at hs
+    simp only [Finset.coe_insert, Set.pairwiseDisjoint_insert] at hS
+    rw [← h hs.2 hS.1]
+    refine addContent_union hC hs.1 (hC.biUnion_mem S hs.2) ?_
+    rw [disjoint_iUnion₂_right]
+    exact fun j hjS ↦ hS.2 j hjS (ne_of_mem_of_not_mem hjS hiS).symm
+
 lemma le_addContent_diff (m : AddContent C) (hC : IsSetRing C) (hs : s ∈ C) (ht : t ∈ C) :
     m s - m t ≤ m (s \ t) := by
   conv_lhs => rw [← inter_union_diff s t]


### PR DESCRIPTION
This PR adds a lemma `addContent_biUnion_eq` stating than an `AddContent` is additive on a finite pairwise disjoint union. We already have the inequality `addContent_biUnion_le` without the pairwise disjoint assumption.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
