### PR TITLE
[Merged by Bors] - feat(Topology/ClusterPt): Swapped version of `ClusterPt.frequently`

### DIFF
--- a/Mathlib/Topology/ClusterPt.lean
+++ b/Mathlib/Topology/ClusterPt.lean
@@ -99,6 +99,11 @@ theorem ClusterPt.of_inf_right {f g : Filter X} (H : ClusterPt x <| f ⊓ g) :
     ClusterPt x g :=
   H.mono inf_le_right
 
+theorem ClusterPt.frequently' {F : Filter X} {p : X → Prop} (hx : ClusterPt x F)
+    (hp : ∀ᶠ y in F, p y) : ∃ᶠ y in nhds x, p y := by
+  rw [eventually_iff, ← le_principal_iff] at hp
+  exact clusterPt_principal_iff_frequently.mp (hx.mono hp)
+
 section MapClusterPt
 
 variable {F : Filter α} {u : α → X} {x : X}

--- a/Mathlib/Topology/ClusterPt.lean
+++ b/Mathlib/Topology/ClusterPt.lean
@@ -46,6 +46,18 @@ theorem ClusterPt.frequently {F : Filter X} {p : X → Prop} (hx : ClusterPt x F
     (hp : ∀ᶠ y in 𝓝 x, p y) : ∃ᶠ y in F, p y :=
   clusterPt_iff_frequently.mp hx {y | p y} hp
 
+theorem Filter.HasBasis.clusterPt_iff_frequently' {ι} {p : ι → Prop} {s : ι → Set X} {F : Filter X}
+    (hx : F.HasBasis p s) : ClusterPt x F ↔ ∀ i, p i → ∃ᶠ x in 𝓝 x, x ∈ s i := by
+  simp only [(𝓝 x).basis_sets.clusterPt_iff hx, Filter.frequently_iff]
+  exact ⟨fun h a b c d ↦ h d b, fun h a b c d ↦ h c d b⟩
+
+theorem clusterPt_iff_frequently' {F : Filter X} : ClusterPt x F ↔ ∀ s ∈ F, ∃ᶠ y in 𝓝 x, y ∈ s :=
+  F.basis_sets.clusterPt_iff_frequently'
+
+theorem ClusterPt.frequently' {F : Filter X} {p : X → Prop} (hx : ClusterPt x F)
+    (hp : ∀ᶠ y in F, p y) : ∃ᶠ y in 𝓝 x, p y :=
+  clusterPt_iff_frequently'.mp hx {y | p y} hp
+
 theorem clusterPt_iff_nonempty {F : Filter X} :
     ClusterPt x F ↔ ∀ ⦃U : Set X⦄, U ∈ 𝓝 x → ∀ ⦃V⦄, V ∈ F → (U ∩ V).Nonempty :=
   inf_neBot_iff
@@ -98,11 +110,6 @@ theorem ClusterPt.of_inf_left {f g : Filter X} (H : ClusterPt x <| f ⊓ g) : Cl
 theorem ClusterPt.of_inf_right {f g : Filter X} (H : ClusterPt x <| f ⊓ g) :
     ClusterPt x g :=
   H.mono inf_le_right
-
-theorem ClusterPt.frequently' {F : Filter X} {p : X → Prop} (hx : ClusterPt x F)
-    (hp : ∀ᶠ y in F, p y) : ∃ᶠ y in nhds x, p y := by
-  rw [eventually_iff, ← le_principal_iff] at hp
-  exact clusterPt_principal_iff_frequently.mp (hx.mono hp)
 
 section MapClusterPt
 


### PR DESCRIPTION
This PR adds the theorem
```
theorem ClusterPt.frequently' {F : Filter X} {p : X → Prop} (hx : ClusterPt x F)
    (hp : ∀ᶠ y in F, p y) : ∃ᶠ y in nhds x, p y := by
```
which is basically a swapped version of the existing theorem
```
theorem ClusterPt.frequently {F : Filter X} {p : X → Prop} (hx : ClusterPt x F)
    (hp : ∀ᶠ y in 𝓝 x, p y) : ∃ᶠ y in F, p y :=
```
I'm not sure if there's a common generalization.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
