### PR TITLE
chore: fix create-adaptation-pr.sh script

### DIFF
--- a/scripts/create-adaptation-pr.sh
+++ b/scripts/create-adaptation-pr.sh
@@ -228,7 +228,7 @@ if git diff --name-only bump/$BUMPVERSION bump/nightly-$NIGHTLYDATE | grep -q .;
 
   echo
   echo "### [auto] create a PR for the new branch"
-  echo "Creating a pull request. Setting the base of the PR to 'bump/$BUMPVERSION' on upstream, and the head to the nightly-testing fork."
+  echo "Creating a pull request. Setting the base of the PR to 'bump/$BUMPVERSION' on upstream."
 
   pr_title="chore: adaptations for nightly-$NIGHTLYDATE"
   gh_command="gh pr create -t \"$pr_title\" -b '' -B bump/$BUMPVERSION --repo leanprover-community/mathlib4"

--- a/scripts/create-adaptation-pr.sh
+++ b/scripts/create-adaptation-pr.sh
@@ -228,9 +228,11 @@ if git diff --name-only bump/$BUMPVERSION bump/nightly-$NIGHTLYDATE | grep -q .;
 
   echo
   echo "### [auto] create a PR for the new branch"
-  echo "Creating a pull request. Setting the base of the PR to 'bump/$BUMPVERSION'"
+  echo "Creating a pull request. Setting the base of the PR to 'bump/$BUMPVERSION' on upstream, and the head to the nightly-testing fork."
+
+  pr_title="chore: adaptations for nightly-$NIGHTLYDATE"
+  gh_command="gh pr create -t \"$pr_title\" -b '' -B bump/$BUMPVERSION --repo leanprover-community/mathlib4"
   echo "Running the following 'gh' command to do this:"
-  gh_command="gh pr create -t \"$pr_title\" -b '' -B bump/$BUMPVERSION --repo leanprover-community/mathlib4-nightly-testing"
   echo "> $gh_command"
   gh_output=$(eval $gh_command)
   # Extract the PR number from the output

--- a/scripts/create-adaptation-pr.sh
+++ b/scripts/create-adaptation-pr.sh
@@ -230,7 +230,6 @@ if git diff --name-only bump/$BUMPVERSION bump/nightly-$NIGHTLYDATE | grep -q .;
   echo "### [auto] create a PR for the new branch"
   echo "Creating a pull request. Setting the base of the PR to 'bump/$BUMPVERSION' on upstream."
 
-  pr_title="chore: adaptations for nightly-$NIGHTLYDATE"
   gh_command="gh pr create -t \"$pr_title\" -b '' -B bump/$BUMPVERSION --repo leanprover-community/mathlib4"
   echo "Running the following 'gh' command to do this:"
   echo "> $gh_command"


### PR DESCRIPTION
Ugh. It was making this PRs to `bump.v4.X` on the nightly-testing fork, but I think these are meant to live on the main fork.