### PR TITLE
[Merged by Bors] - chore(IntegrableOn): generalise one more section to enorms

### DIFF
--- a/Mathlib/Analysis/MellinTransform.lean
+++ b/Mathlib/Analysis/MellinTransform.lean
@@ -230,7 +230,7 @@ theorem mellin_convergent_zero_of_isBigO {b : ℝ} {f : ℝ → ℝ}
   obtain ⟨d, _, hd'⟩ := hf.exists_pos
   simp_rw [IsBigOWith, eventually_nhdsWithin_iff, Metric.eventually_nhds_iff, gt_iff_lt] at hd'
   obtain ⟨ε, hε, hε'⟩ := hd'
-  refine ⟨ε, hε, integrableOn_Ioc_iff_integrableOn_Ioo.mpr ⟨?_, ?_⟩⟩
+  refine ⟨ε, hε, integrableOn_Ioc_iff_integrableOn_Ioo (by finiteness) |>.mpr ⟨?_, ?_⟩⟩
   · refine AEStronglyMeasurable.mul ?_ (hfc.mono_set Ioo_subset_Ioi_self)
     refine (continuousOn_of_forall_continuousAt fun t ht => ?_).aestronglyMeasurable
       measurableSet_Ioo
@@ -266,7 +266,7 @@ theorem mellin_convergent_of_isBigO_scalar {a b : ℝ} {f : ℝ → ℝ} {s : �
     rw [union_assoc, Ioc_union_Ioi (le_max_right _ _),
       Ioc_union_Ioi ((min_le_left _ _).trans (le_max_right _ _)), min_eq_left (lt_min hc2 hc1).le]
   rw [this, integrableOn_union, integrableOn_union]
-  refine ⟨⟨hc2', integrableOn_Icc_iff_integrableOn_Ioc.mp ?_⟩, hc1'⟩
+  refine ⟨⟨hc2', integrableOn_Icc_iff_integrableOn_Ioc (by finiteness) |>.mp ?_⟩, hc1'⟩
   refine
     (hfc.continuousOn_mul ?_ isOpen_Ioi.isLocallyClosed).integrableOn_compact_subset
       (fun t ht => (hc2.trans_le ht.1 : 0 < t)) isCompact_Icc

--- a/Mathlib/Analysis/MellinTransform.lean
+++ b/Mathlib/Analysis/MellinTransform.lean
@@ -230,7 +230,7 @@ theorem mellin_convergent_zero_of_isBigO {b : ℝ} {f : ℝ → ℝ}
   obtain ⟨d, _, hd'⟩ := hf.exists_pos
   simp_rw [IsBigOWith, eventually_nhdsWithin_iff, Metric.eventually_nhds_iff, gt_iff_lt] at hd'
   obtain ⟨ε, hε, hε'⟩ := hd'
-  refine ⟨ε, hε, integrableOn_Ioc_iff_integrableOn_Ioo (by finiteness) |>.mpr ⟨?_, ?_⟩⟩
+  refine ⟨ε, hε, Iff.mpr integrableOn_Ioc_iff_integrableOn_Ioo ⟨?_, ?_⟩⟩
   · refine AEStronglyMeasurable.mul ?_ (hfc.mono_set Ioo_subset_Ioi_self)
     refine (continuousOn_of_forall_continuousAt fun t ht => ?_).aestronglyMeasurable
       measurableSet_Ioo

--- a/Mathlib/Analysis/MellinTransform.lean
+++ b/Mathlib/Analysis/MellinTransform.lean
@@ -266,7 +266,7 @@ theorem mellin_convergent_of_isBigO_scalar {a b : ℝ} {f : ℝ → ℝ} {s : �
     rw [union_assoc, Ioc_union_Ioi (le_max_right _ _),
       Ioc_union_Ioi ((min_le_left _ _).trans (le_max_right _ _)), min_eq_left (lt_min hc2 hc1).le]
   rw [this, integrableOn_union, integrableOn_union]
-  refine ⟨⟨hc2', integrableOn_Icc_iff_integrableOn_Ioc (by finiteness) |>.mp ?_⟩, hc1'⟩
+  refine ⟨⟨hc2', Iff.mp integrableOn_Icc_iff_integrableOn_Ioc ?_⟩, hc1'⟩
   refine
     (hfc.continuousOn_mul ?_ isOpen_Ioi.isLocallyClosed).integrableOn_compact_subset
       (fun t ht => (hc2.trans_le ht.1 : 0 < t)) isCompact_Icc

--- a/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
@@ -39,7 +39,8 @@ theorem integrableOn_exp_Iic (c : ℝ) : IntegrableOn exp (Iic c) := by
   exact (exp_pos _).le
 
 theorem integrableOn_exp_neg_Ioi (c : ℝ) : IntegrableOn (fun (x : ℝ) => exp (-x)) (Ioi c) :=
-  integrableOn_Ici_iff_integrableOn_Ioi.mp (integrableOn_exp_Iic (-c)).comp_neg_Ici
+  integrableOn_Ici_iff_integrableOn_Ioi (by finiteness) |>.mp
+    (integrableOn_exp_Iic (-c)).comp_neg_Ici
 
 theorem integral_exp_Iic (c : ℝ) : ∫ x : ℝ in Iic c, exp x = exp c := by
   refine
@@ -68,7 +69,7 @@ theorem integrableOn_exp_mul_complex_Ioi {a : ℂ} (ha : a.re < 0) (c : ℝ) :
 
 theorem integrableOn_exp_mul_complex_Iic {a : ℂ} (ha : 0 < a.re) (c : ℝ) :
     IntegrableOn (fun x : ℝ => Complex.exp (a * x)) (Iic c) := by
-  simpa using integrableOn_Iic_iff_integrableOn_Iio.mpr
+  simpa using integrableOn_Iic_iff_integrableOn_Iio (by finiteness) |>.mpr
     (integrableOn_exp_mul_complex_Ioi (a := -a) (by simpa) (-c)).comp_neg_Iio
 
 theorem integrableOn_exp_mul_Ioi {a : ℝ} (ha : a < 0) (c : ℝ) :

--- a/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
@@ -39,8 +39,7 @@ theorem integrableOn_exp_Iic (c : ℝ) : IntegrableOn exp (Iic c) := by
   exact (exp_pos _).le
 
 theorem integrableOn_exp_neg_Ioi (c : ℝ) : IntegrableOn (fun (x : ℝ) => exp (-x)) (Ioi c) :=
-  integrableOn_Ici_iff_integrableOn_Ioi (by finiteness) |>.mp
-    (integrableOn_exp_Iic (-c)).comp_neg_Ici
+  Iff.mp integrableOn_Ici_iff_integrableOn_Ioi (integrableOn_exp_Iic (-c)).comp_neg_Ici
 
 theorem integral_exp_Iic (c : ℝ) : ∫ x : ℝ in Iic c, exp x = exp c := by
   refine
@@ -69,7 +68,7 @@ theorem integrableOn_exp_mul_complex_Ioi {a : ℂ} (ha : a.re < 0) (c : ℝ) :
 
 theorem integrableOn_exp_mul_complex_Iic {a : ℂ} (ha : 0 < a.re) (c : ℝ) :
     IntegrableOn (fun x : ℝ => Complex.exp (a * x)) (Iic c) := by
-  simpa using integrableOn_Iic_iff_integrableOn_Iio (by finiteness) |>.mpr
+  simpa using Iff.mpr integrableOn_Iic_iff_integrableOn_Iio
     (integrableOn_exp_mul_complex_Ioi (a := -a) (by simpa) (-c)).comp_neg_Iio
 
 theorem integrableOn_exp_mul_Ioi {a : ℝ} (ha : a < 0) (c : ℝ) :

--- a/Mathlib/Analysis/SpecialFunctions/Integrability/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrability/Basic.lean
@@ -64,8 +64,10 @@ theorem intervalIntegrable_rpow' {r : ℝ} (h : -1 < r) :
 /-- The power function `x ↦ x^s` is integrable on `(0, t)` iff `-1 < s`. -/
 lemma integrableOn_Ioo_rpow_iff {s t : ℝ} (ht : 0 < t) :
     IntegrableOn (fun x ↦ x ^ s) (Ioo (0 : ℝ) t) ↔ -1 < s := by
-  refine ⟨fun h ↦ ?_, fun h ↦ by simpa [intervalIntegrable_iff_integrableOn_Ioo_of_le ht.le]
-    using intervalIntegrable_rpow' h (a := 0) (b := t)⟩
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  swap
+  · rw [← intervalIntegrable_iff_integrableOn_Ioo_of_le ht.le]
+    apply intervalIntegrable_rpow' h (a := 0) (b := t)
   contrapose! h
   intro H
   have I : 0 < min 1 t := lt_min zero_lt_one ht
@@ -163,8 +165,10 @@ theorem intervalIntegrable_cpow' {r : ℂ} (h : -1 < r.re) :
 /-- The complex power function `x ↦ x^s` is integrable on `(0, t)` iff `-1 < s.re`. -/
 theorem integrableOn_Ioo_cpow_iff {s : ℂ} {t : ℝ} (ht : 0 < t) :
     IntegrableOn (fun x : ℝ ↦ (x : ℂ) ^ s) (Ioo (0 : ℝ) t) ↔ -1 < s.re := by
-  refine ⟨fun h ↦ ?_, fun h ↦ by simpa [intervalIntegrable_iff_integrableOn_Ioo_of_le ht.le]
-    using intervalIntegrable_cpow' h (a := 0) (b := t)⟩
+  refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+  swap
+  · rw [← intervalIntegrable_iff_integrableOn_Ioo_of_le ht.le]
+    exact intervalIntegrable_cpow' h (a := 0) (b := t)
   have B : IntegrableOn (fun a ↦ a ^ s.re) (Ioo 0 t) := by
     apply (integrableOn_congr_fun _ measurableSet_Ioo).1 h.norm
     intro a ha

--- a/Mathlib/Analysis/SpecialFunctions/Integrals/LogTrigonometric.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals/LogTrigonometric.lean
@@ -54,9 +54,9 @@ theorem integral_log_sin_zero_pi_div_two : ∫ x in (0)..(π / 2), log (sin x) =
         intervalIntegral.integral_sub _ intervalIntegrable_const,
         intervalIntegral.integral_const]
       · simp
-      · simpa using (intervalIntegrable_log_sin (a := 0) (b := π)).comp_mul_left 2
+      · simpa using (intervalIntegrable_log_sin (a := 0) (b := π)).comp_mul_left
       · apply IntervalIntegrable.sub _ intervalIntegrable_const
-        simpa using (intervalIntegrable_log_sin (a := 0) (b := π)).comp_mul_left 2
+        simpa using (intervalIntegrable_log_sin (a := 0) (b := π)).comp_mul_left
       · exact intervalIntegrable_log_cos
     _ = (∫ x in (0)..(π / 2), log (sin (2 * x)))
         - π / 2 * log 2 - ∫ x in (0)..(π / 2), log (sin x) := by

--- a/Mathlib/Analysis/SumIntegralComparisons.lean
+++ b/Mathlib/Analysis/SumIntegralComparisons.lean
@@ -50,7 +50,7 @@ lemma sum_Ico_le_integral_of_le
     (hg : IntegrableOn g (Set.Ico a b)) :
     ∑ i ∈ Finset.Ico a b, f i ≤ ∫ x in a..b, g x := by
   have A i (hi : i ∈ Finset.Ico a b) : IntervalIntegrable g volume i (i + 1 : ℕ) := by
-    rw [intervalIntegrable_iff_integrableOn_Ico_of_le (by simp) (by finiteness) (by finiteness)]
+    rw [intervalIntegrable_iff_integrableOn_Ico_of_le (by simp)]
     apply hg.mono _ le_rfl
     rintro x ⟨hx, h'x⟩
     simp only [Finset.mem_Ico, mem_Ico] at hi ⊢

--- a/Mathlib/Analysis/SumIntegralComparisons.lean
+++ b/Mathlib/Analysis/SumIntegralComparisons.lean
@@ -50,7 +50,7 @@ lemma sum_Ico_le_integral_of_le
     (hg : IntegrableOn g (Set.Ico a b)) :
     ∑ i ∈ Finset.Ico a b, f i ≤ ∫ x in a..b, g x := by
   have A i (hi : i ∈ Finset.Ico a b) : IntervalIntegrable g volume i (i + 1 : ℕ) := by
-    rw [intervalIntegrable_iff_integrableOn_Ico_of_le (by simp)]
+    rw [intervalIntegrable_iff_integrableOn_Ico_of_le (by simp) (by finiteness) (by finiteness)]
     apply hg.mono _ le_rfl
     rintro x ⟨hx, h'x⟩
     simp only [Finset.mem_Ico, mem_Ico] at hi ⊢

--- a/Mathlib/MeasureTheory/Integral/ExpDecay.lean
+++ b/Mathlib/MeasureTheory/Integral/ExpDecay.lean
@@ -38,6 +38,6 @@ theorem exp_neg_integrableOn_Ioi (a : ℝ) {b : ℝ} (h : 0 < b) :
 theorem integrable_of_isBigO_exp_neg {f : ℝ → ℝ} {a b : ℝ} (h0 : 0 < b)
     (hf : ContinuousOn f (Ici a)) (ho : f =O[atTop] fun x => exp (-b * x)) :
     IntegrableOn f (Ioi a) :=
-  integrableOn_Ici_iff_integrableOn_Ioi.mp <|
+  integrableOn_Ici_iff_integrableOn_Ioi (by finiteness) |>.mp <|
     (hf.locallyIntegrableOn measurableSet_Ici).integrableOn_of_isBigO_atTop
     ho ⟨Ioi b, Ioi_mem_atTop b, exp_neg_integrableOn_Ioi b h0⟩

--- a/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
@@ -714,77 +714,80 @@ the unprimed ones use `[NoAtoms μ]`.
 
 section PartialOrder
 
-variable [PartialOrder α] [MeasurableSingletonClass α] {f : α → E} {μ : Measure α} {a b : α}
+variable [PartialOrder α] [MeasurableSingletonClass α]
+  [TopologicalSpace ε'] [ENormedAddMonoid ε'] [PseudoMetrizableSpace ε']
+  {f : α → ε'} {μ : Measure α} {a b : α}
 
-theorem integrableOn_Icc_iff_integrableOn_Ioc' (ha : μ {a} ≠ ∞) :
+theorem integrableOn_Icc_iff_integrableOn_Ioc' (ha : μ {a} ≠ ∞) (ha' : ‖f a‖ₑ ≠ ∞) :
     IntegrableOn f (Icc a b) μ ↔ IntegrableOn f (Ioc a b) μ := by
   by_cases hab : a ≤ b
-  · rw [← Ioc_union_left hab, integrableOn_union, eq_true integrableOn_singleton, and_true]
+  · rw [← Ioc_union_left hab, integrableOn_union, eq_true (integrableOn_singleton ha'), and_true]
   · rw [Icc_eq_empty hab, Ioc_eq_empty]
     contrapose! hab
     exact hab.le
 
-theorem integrableOn_Icc_iff_integrableOn_Ico' (hb : μ {b} ≠ ∞) :
+theorem integrableOn_Icc_iff_integrableOn_Ico' (hb : μ {b} ≠ ∞) (hb' : ‖f b‖ₑ ≠ ∞) :
     IntegrableOn f (Icc a b) μ ↔ IntegrableOn f (Ico a b) μ := by
   by_cases hab : a ≤ b
-  · rw [← Ico_union_right hab, integrableOn_union, eq_true integrableOn_singleton, and_true]
+  · rw [← Ico_union_right hab, integrableOn_union, eq_true (integrableOn_singleton hb'), and_true]
   · rw [Icc_eq_empty hab, Ico_eq_empty]
     contrapose! hab
     exact hab.le
 
-theorem integrableOn_Ico_iff_integrableOn_Ioo' (ha : μ {a} ≠ ∞) :
+theorem integrableOn_Ico_iff_integrableOn_Ioo' (ha : μ {a} ≠ ∞) (ha' : ‖f a‖ₑ ≠ ∞) :
     IntegrableOn f (Ico a b) μ ↔ IntegrableOn f (Ioo a b) μ := by
   by_cases hab : a < b
   · rw [← Ioo_union_left hab, integrableOn_union,
-      eq_true integrableOn_singleton, and_true]
+      eq_true (integrableOn_singleton ha'), and_true]
   · rw [Ioo_eq_empty hab, Ico_eq_empty hab]
 
-theorem integrableOn_Ioc_iff_integrableOn_Ioo' (hb : μ {b} ≠ ∞) :
+theorem integrableOn_Ioc_iff_integrableOn_Ioo' (hb : μ {b} ≠ ∞) (hb' : ‖f b‖ₑ ≠ ∞) :
     IntegrableOn f (Ioc a b) μ ↔ IntegrableOn f (Ioo a b) μ := by
   by_cases hab : a < b
-  · rw [← Ioo_union_right hab, integrableOn_union, eq_true integrableOn_singleton, and_true]
+  · rw [← Ioo_union_right hab, integrableOn_union, eq_true (integrableOn_singleton hb'), and_true]
   · rw [Ioo_eq_empty hab, Ioc_eq_empty hab]
 
-theorem integrableOn_Icc_iff_integrableOn_Ioo' (ha : μ {a} ≠ ∞) (hb : μ {b} ≠ ∞) :
+theorem integrableOn_Icc_iff_integrableOn_Ioo'
+    (ha : μ {a} ≠ ∞) (ha' : ‖f a‖ₑ ≠ ∞) (hb : μ {b} ≠ ∞) (hb' : ‖f b‖ₑ ≠ ∞) :
     IntegrableOn f (Icc a b) μ ↔ IntegrableOn f (Ioo a b) μ := by
-  rw [integrableOn_Icc_iff_integrableOn_Ioc' ha, integrableOn_Ioc_iff_integrableOn_Ioo' hb]
+  rw [integrableOn_Icc_iff_integrableOn_Ioc' ha ha', integrableOn_Ioc_iff_integrableOn_Ioo' hb hb']
 
-theorem integrableOn_Ici_iff_integrableOn_Ioi' (hb : μ {b} ≠ ∞) :
+theorem integrableOn_Ici_iff_integrableOn_Ioi' (hb : μ {b} ≠ ∞) (hb' : ‖f b‖ₑ ≠ ∞) :
     IntegrableOn f (Ici b) μ ↔ IntegrableOn f (Ioi b) μ := by
-  rw [← Ioi_union_left, integrableOn_union, eq_true integrableOn_singleton, and_true]
+  rw [← Ioi_union_left, integrableOn_union, eq_true (integrableOn_singleton hb'), and_true]
 
-theorem integrableOn_Iic_iff_integrableOn_Iio' (hb : μ {b} ≠ ∞) :
+theorem integrableOn_Iic_iff_integrableOn_Iio' (hb : μ {b} ≠ ∞) (hb' : ‖f b‖ₑ ≠ ∞) :
     IntegrableOn f (Iic b) μ ↔ IntegrableOn f (Iio b) μ := by
-  rw [← Iio_union_right, integrableOn_union, eq_true integrableOn_singleton, and_true]
+  rw [← Iio_union_right, integrableOn_union, eq_true (integrableOn_singleton hb'), and_true]
 
 variable [NoAtoms μ]
 
-theorem integrableOn_Icc_iff_integrableOn_Ioc :
+theorem integrableOn_Icc_iff_integrableOn_Ioc (ha : ‖f a‖ₑ ≠ ∞) :
     IntegrableOn f (Icc a b) μ ↔ IntegrableOn f (Ioc a b) μ :=
-  integrableOn_Icc_iff_integrableOn_Ioc' (by rw [measure_singleton]; exact ENNReal.zero_ne_top)
+  integrableOn_Icc_iff_integrableOn_Ioc' (by rw [measure_singleton]; exact ENNReal.zero_ne_top) ha
 
-theorem integrableOn_Icc_iff_integrableOn_Ico :
+theorem integrableOn_Icc_iff_integrableOn_Ico (hb : ‖f b‖ₑ ≠ ∞) :
     IntegrableOn f (Icc a b) μ ↔ IntegrableOn f (Ico a b) μ :=
-  integrableOn_Icc_iff_integrableOn_Ico' (by rw [measure_singleton]; exact ENNReal.zero_ne_top)
+  integrableOn_Icc_iff_integrableOn_Ico' (by rw [measure_singleton]; exact ENNReal.zero_ne_top) hb
 
-theorem integrableOn_Ico_iff_integrableOn_Ioo :
+theorem integrableOn_Ico_iff_integrableOn_Ioo (ha : ‖f a‖ₑ ≠ ∞) :
     IntegrableOn f (Ico a b) μ ↔ IntegrableOn f (Ioo a b) μ :=
-  integrableOn_Ico_iff_integrableOn_Ioo' (by rw [measure_singleton]; exact ENNReal.zero_ne_top)
+  integrableOn_Ico_iff_integrableOn_Ioo' (by rw [measure_singleton]; exact ENNReal.zero_ne_top) ha
 
-theorem integrableOn_Ioc_iff_integrableOn_Ioo :
+theorem integrableOn_Ioc_iff_integrableOn_Ioo (hb : ‖f b‖ₑ ≠ ∞) :
     IntegrableOn f (Ioc a b) μ ↔ IntegrableOn f (Ioo a b) μ :=
-  integrableOn_Ioc_iff_integrableOn_Ioo' (by rw [measure_singleton]; exact ENNReal.zero_ne_top)
+  integrableOn_Ioc_iff_integrableOn_Ioo' (by rw [measure_singleton]; exact ENNReal.zero_ne_top) hb
 
-theorem integrableOn_Icc_iff_integrableOn_Ioo :
+theorem integrableOn_Icc_iff_integrableOn_Ioo (ha : ‖f a‖ₑ ≠ ∞) (hb : ‖f b‖ₑ ≠ ∞) :
     IntegrableOn f (Icc a b) μ ↔ IntegrableOn f (Ioo a b) μ := by
-  rw [integrableOn_Icc_iff_integrableOn_Ioc, integrableOn_Ioc_iff_integrableOn_Ioo]
+  rw [integrableOn_Icc_iff_integrableOn_Ioc ha, integrableOn_Ioc_iff_integrableOn_Ioo hb]
 
-theorem integrableOn_Ici_iff_integrableOn_Ioi :
+theorem integrableOn_Ici_iff_integrableOn_Ioi (hb : ‖f b‖ₑ ≠ ∞) :
     IntegrableOn f (Ici b) μ ↔ IntegrableOn f (Ioi b) μ :=
-  integrableOn_Ici_iff_integrableOn_Ioi' (by rw [measure_singleton]; exact ENNReal.zero_ne_top)
+  integrableOn_Ici_iff_integrableOn_Ioi' (by rw [measure_singleton]; exact ENNReal.zero_ne_top) hb
 
-theorem integrableOn_Iic_iff_integrableOn_Iio :
+theorem integrableOn_Iic_iff_integrableOn_Iio (hb : ‖f b‖ₑ ≠ ∞) :
     IntegrableOn f (Iic b) μ ↔ IntegrableOn f (Iio b) μ :=
-  integrableOn_Iic_iff_integrableOn_Iio' (by rw [measure_singleton]; exact ENNReal.zero_ne_top)
+  integrableOn_Iic_iff_integrableOn_Iio' (by rw [measure_singleton]; exact ENNReal.zero_ne_top) hb
 
 end PartialOrder

--- a/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
@@ -718,7 +718,8 @@ variable [PartialOrder α] [MeasurableSingletonClass α]
   [TopologicalSpace ε'] [ENormedAddMonoid ε'] [PseudoMetrizableSpace ε']
   {f : α → ε'} {μ : Measure α} {a b : α}
 
-theorem integrableOn_Icc_iff_integrableOn_Ioc' (ha : μ {a} ≠ ∞) (ha' : ‖f a‖ₑ ≠ ∞) :
+theorem integrableOn_Icc_iff_integrableOn_Ioc'
+    (ha : μ {a} ≠ ∞) (ha' : ‖f a‖ₑ ≠ ∞ := by finiteness) :
     IntegrableOn f (Icc a b) μ ↔ IntegrableOn f (Ioc a b) μ := by
   by_cases hab : a ≤ b
   · rw [← Ioc_union_left hab, integrableOn_union, eq_true (integrableOn_singleton ha'), and_true]
@@ -726,7 +727,8 @@ theorem integrableOn_Icc_iff_integrableOn_Ioc' (ha : μ {a} ≠ ∞) (ha' : ‖f
     contrapose! hab
     exact hab.le
 
-theorem integrableOn_Icc_iff_integrableOn_Ico' (hb : μ {b} ≠ ∞) (hb' : ‖f b‖ₑ ≠ ∞) :
+theorem integrableOn_Icc_iff_integrableOn_Ico'
+    (hb : μ {b} ≠ ∞) (hb' : ‖f b‖ₑ ≠ ∞ := by finiteness) :
     IntegrableOn f (Icc a b) μ ↔ IntegrableOn f (Ico a b) μ := by
   by_cases hab : a ≤ b
   · rw [← Ico_union_right hab, integrableOn_union, eq_true (integrableOn_singleton hb'), and_true]
@@ -734,59 +736,64 @@ theorem integrableOn_Icc_iff_integrableOn_Ico' (hb : μ {b} ≠ ∞) (hb' : ‖f
     contrapose! hab
     exact hab.le
 
-theorem integrableOn_Ico_iff_integrableOn_Ioo' (ha : μ {a} ≠ ∞) (ha' : ‖f a‖ₑ ≠ ∞) :
+theorem integrableOn_Ico_iff_integrableOn_Ioo'
+    (ha : μ {a} ≠ ∞) (ha' : ‖f a‖ₑ ≠ ∞ := by finiteness) :
     IntegrableOn f (Ico a b) μ ↔ IntegrableOn f (Ioo a b) μ := by
   by_cases hab : a < b
   · rw [← Ioo_union_left hab, integrableOn_union,
       eq_true (integrableOn_singleton ha'), and_true]
   · rw [Ioo_eq_empty hab, Ico_eq_empty hab]
 
-theorem integrableOn_Ioc_iff_integrableOn_Ioo' (hb : μ {b} ≠ ∞) (hb' : ‖f b‖ₑ ≠ ∞) :
+theorem integrableOn_Ioc_iff_integrableOn_Ioo'
+    (hb : μ {b} ≠ ∞) (hb' : ‖f b‖ₑ ≠ ∞ := by finiteness) :
     IntegrableOn f (Ioc a b) μ ↔ IntegrableOn f (Ioo a b) μ := by
   by_cases hab : a < b
   · rw [← Ioo_union_right hab, integrableOn_union, eq_true (integrableOn_singleton hb'), and_true]
   · rw [Ioo_eq_empty hab, Ioc_eq_empty hab]
 
-theorem integrableOn_Icc_iff_integrableOn_Ioo'
-    (ha : μ {a} ≠ ∞) (ha' : ‖f a‖ₑ ≠ ∞) (hb : μ {b} ≠ ∞) (hb' : ‖f b‖ₑ ≠ ∞) :
+theorem integrableOn_Icc_iff_integrableOn_Ioo' (ha : μ {a} ≠ ∞)
+    (ha' : ‖f a‖ₑ ≠ ∞ := by finiteness) (hb : μ {b} ≠ ∞) (hb' : ‖f b‖ₑ ≠ ∞ := by finiteness) :
     IntegrableOn f (Icc a b) μ ↔ IntegrableOn f (Ioo a b) μ := by
   rw [integrableOn_Icc_iff_integrableOn_Ioc' ha ha', integrableOn_Ioc_iff_integrableOn_Ioo' hb hb']
 
-theorem integrableOn_Ici_iff_integrableOn_Ioi' (hb : μ {b} ≠ ∞) (hb' : ‖f b‖ₑ ≠ ∞) :
+theorem integrableOn_Ici_iff_integrableOn_Ioi'
+    (hb : μ {b} ≠ ∞ := by finiteness) (hb' : ‖f b‖ₑ ≠ ∞ := by finiteness) :
     IntegrableOn f (Ici b) μ ↔ IntegrableOn f (Ioi b) μ := by
   rw [← Ioi_union_left, integrableOn_union, eq_true (integrableOn_singleton hb'), and_true]
 
-theorem integrableOn_Iic_iff_integrableOn_Iio' (hb : μ {b} ≠ ∞) (hb' : ‖f b‖ₑ ≠ ∞) :
+theorem integrableOn_Iic_iff_integrableOn_Iio'
+    (hb : μ {b} ≠ ∞ := by finiteness) (hb' : ‖f b‖ₑ ≠ ∞ := by finiteness) :
     IntegrableOn f (Iic b) μ ↔ IntegrableOn f (Iio b) μ := by
   rw [← Iio_union_right, integrableOn_union, eq_true (integrableOn_singleton hb'), and_true]
 
 variable [NoAtoms μ]
 
-theorem integrableOn_Icc_iff_integrableOn_Ioc (ha : ‖f a‖ₑ ≠ ∞) :
+theorem integrableOn_Icc_iff_integrableOn_Ioc (ha : ‖f a‖ₑ ≠ ∞ := by finiteness) :
     IntegrableOn f (Icc a b) μ ↔ IntegrableOn f (Ioc a b) μ :=
   integrableOn_Icc_iff_integrableOn_Ioc' (by rw [measure_singleton]; exact ENNReal.zero_ne_top) ha
 
-theorem integrableOn_Icc_iff_integrableOn_Ico (hb : ‖f b‖ₑ ≠ ∞) :
+theorem integrableOn_Icc_iff_integrableOn_Ico (hb : ‖f b‖ₑ ≠ ∞ := by finiteness) :
     IntegrableOn f (Icc a b) μ ↔ IntegrableOn f (Ico a b) μ :=
   integrableOn_Icc_iff_integrableOn_Ico' (by rw [measure_singleton]; exact ENNReal.zero_ne_top) hb
 
-theorem integrableOn_Ico_iff_integrableOn_Ioo (ha : ‖f a‖ₑ ≠ ∞) :
+theorem integrableOn_Ico_iff_integrableOn_Ioo (ha : ‖f a‖ₑ ≠ ∞ := by finiteness) :
     IntegrableOn f (Ico a b) μ ↔ IntegrableOn f (Ioo a b) μ :=
   integrableOn_Ico_iff_integrableOn_Ioo' (by rw [measure_singleton]; exact ENNReal.zero_ne_top) ha
 
-theorem integrableOn_Ioc_iff_integrableOn_Ioo (hb : ‖f b‖ₑ ≠ ∞) :
+theorem integrableOn_Ioc_iff_integrableOn_Ioo (hb : ‖f b‖ₑ ≠ ∞ := by finiteness) :
     IntegrableOn f (Ioc a b) μ ↔ IntegrableOn f (Ioo a b) μ :=
   integrableOn_Ioc_iff_integrableOn_Ioo' (by rw [measure_singleton]; exact ENNReal.zero_ne_top) hb
 
-theorem integrableOn_Icc_iff_integrableOn_Ioo (ha : ‖f a‖ₑ ≠ ∞) (hb : ‖f b‖ₑ ≠ ∞) :
+theorem integrableOn_Icc_iff_integrableOn_Ioo
+    (ha : ‖f a‖ₑ ≠ ∞ := by finiteness) (hb : ‖f b‖ₑ ≠ ∞ := by finiteness) :
     IntegrableOn f (Icc a b) μ ↔ IntegrableOn f (Ioo a b) μ := by
   rw [integrableOn_Icc_iff_integrableOn_Ioc ha, integrableOn_Ioc_iff_integrableOn_Ioo hb]
 
-theorem integrableOn_Ici_iff_integrableOn_Ioi (hb : ‖f b‖ₑ ≠ ∞) :
+theorem integrableOn_Ici_iff_integrableOn_Ioi (hb : ‖f b‖ₑ ≠ ∞ := by finiteness) :
     IntegrableOn f (Ici b) μ ↔ IntegrableOn f (Ioi b) μ :=
   integrableOn_Ici_iff_integrableOn_Ioi' (by rw [measure_singleton]; exact ENNReal.zero_ne_top) hb
 
-theorem integrableOn_Iic_iff_integrableOn_Iio (hb : ‖f b‖ₑ ≠ ∞) :
+theorem integrableOn_Iic_iff_integrableOn_Iio (hb : ‖f b‖ₑ ≠ ∞ := by finiteness) :
     IntegrableOn f (Iic b) μ ↔ IntegrableOn f (Iio b) μ :=
   integrableOn_Iic_iff_integrableOn_Iio' (by rw [measure_singleton]; exact ENNReal.zero_ne_top) hb
 

--- a/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
@@ -719,7 +719,7 @@ variable [PartialOrder α] [MeasurableSingletonClass α]
   {f : α → ε'} {μ : Measure α} {a b : α}
 
 theorem integrableOn_Icc_iff_integrableOn_Ioc'
-    (ha : μ {a} ≠ ∞) (ha' : ‖f a‖ₑ ≠ ∞ := by finiteness) :
+    (ha : μ {a} ≠ ∞ := by finiteness) (ha' : ‖f a‖ₑ ≠ ∞ := by finiteness) :
     IntegrableOn f (Icc a b) μ ↔ IntegrableOn f (Ioc a b) μ := by
   by_cases hab : a ≤ b
   · rw [← Ioc_union_left hab, integrableOn_union, eq_true (integrableOn_singleton ha'), and_true]

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean
@@ -339,14 +339,13 @@ theorem comp_mul_left (hf : IntervalIntegrable f volume a b) {c : ℝ}
   · ext; simp only [comp_apply]; congr 1; field_simp
   · rw [preimage_mul_const_uIcc (inv_ne_zero hc)]; field_simp [hc]
 
-theorem comp_mul_left_iff {c : ℝ} (hc : c ≠ 0)
-    -- can h' be deduced?
-    (h : ‖f (min a b)‖ₑ ≠ ∞) (h' : ‖f (c * min (a / c) (b / c))‖ₑ ≠ ∞) :
+-- Note that `h'` is **not** implied by `h` if `c` is negative.
+theorem comp_mul_left_iff {c : ℝ} (hc : c ≠ 0) (h : ‖f (min a b)‖ₑ ≠ ∞)
+    (h' : ‖f (c * min (a / c) (b / c))‖ₑ ≠ ∞) :
     IntervalIntegrable (fun x ↦ f (c * x)) volume (a / c) (b / c) ↔
       IntervalIntegrable f volume a b := by
-  refine ⟨fun h ↦ ?_/-simpa [hc] using h.comp_mul_left c⁻¹-/, (comp_mul_left · h h')⟩
-  have aux : ‖f (c * (c⁻¹ * min (a / c / c⁻¹) (b / c / c⁻¹)))‖ₑ ≠ ⊤ := sorry
-  simpa [hc] using h.comp_mul_left (c := c⁻¹) h' aux
+  exact ⟨fun h ↦ by simpa [hc] using h.comp_mul_left (c := c⁻¹) h' (by simp),
+    (comp_mul_left · h h')⟩
 
 theorem comp_mul_right (hf : IntervalIntegrable f volume a b) {c : ℝ}
     (h : ‖f (min a b)‖ₑ ≠ ∞) (h' : ‖f (c * min (a / c) (b / c))‖ₑ ≠ ∞) :
@@ -384,7 +383,7 @@ theorem iff_comp_neg (h : ‖f (min a b)‖ₑ ≠ ∞) :
 
 theorem comp_sub_left (hf : IntervalIntegrable f volume a b) (c : ℝ) (h : ‖f (min a b)‖ₑ ≠ ∞) :
     IntervalIntegrable (fun x ↦ f (c - x)) volume (c - a) (c - b) := by
-  sorry -- simpa only [neg_sub, ← sub_eq_add_neg] using (iff_comp_neg h).mp (hf.comp_add_left 0 h)
+  simpa only [neg_sub, ← sub_eq_add_neg] using (iff_comp_neg (by simp)).mp (hf.comp_add_left c h)
 
 theorem comp_sub_left_iff (c : ℝ) (h : ‖f (min a b)‖ₑ ≠ ∞) :
     IntervalIntegrable (fun x => f (c - x)) volume (c - a) (c - b) ↔

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean
@@ -106,21 +106,25 @@ theorem intervalIntegrable_iff_integrableOn_Ioc_of_le (hab : a ≤ b) :
     IntervalIntegrable f μ a b ↔ IntegrableOn f (Ioc a b) μ := by
   rw [intervalIntegrable_iff, uIoc_of_le hab]
 
-theorem intervalIntegrable_iff' [NoAtoms μ] :
+theorem intervalIntegrable_iff' [NoAtoms μ] (h : ‖f (min a b)‖ₑ ≠ ∞) :
     IntervalIntegrable f μ a b ↔ IntegrableOn f (uIcc a b) μ := by
-  rw [intervalIntegrable_iff, ← Icc_min_max, uIoc, integrableOn_Icc_iff_integrableOn_Ioc]
+  rw [intervalIntegrable_iff, ← Icc_min_max, uIoc, integrableOn_Icc_iff_integrableOn_Ioc h]
 
-theorem intervalIntegrable_iff_integrableOn_Icc_of_le {f : ℝ → E} {a b : ℝ} (hab : a ≤ b)
+theorem intervalIntegrable_iff_integrableOn_Icc_of_le (hab : a ≤ b) (ha : ‖f a‖ₑ ≠ ∞)
     {μ : Measure ℝ} [NoAtoms μ] : IntervalIntegrable f μ a b ↔ IntegrableOn f (Icc a b) μ := by
-  rw [intervalIntegrable_iff_integrableOn_Ioc_of_le hab, integrableOn_Icc_iff_integrableOn_Ioc]
+  rw [intervalIntegrable_iff_integrableOn_Ioc_of_le hab, integrableOn_Icc_iff_integrableOn_Ioc ha]
 
-theorem intervalIntegrable_iff_integrableOn_Ico_of_le [NoAtoms μ] (hab : a ≤ b) :
+theorem intervalIntegrable_iff_integrableOn_Ico_of_le [NoAtoms μ]
+    (hab : a ≤ b) (ha : ‖f a‖ₑ ≠ ∞) (hb : ‖f b‖ₑ ≠ ∞) :
     IntervalIntegrable f μ a b ↔ IntegrableOn f (Ico a b) μ := by
-  rw [intervalIntegrable_iff_integrableOn_Icc_of_le hab, integrableOn_Icc_iff_integrableOn_Ico]
+  rw [intervalIntegrable_iff_integrableOn_Icc_of_le hab ha,
+    integrableOn_Icc_iff_integrableOn_Ico hb]
 
-theorem intervalIntegrable_iff_integrableOn_Ioo_of_le [NoAtoms μ] (hab : a ≤ b) :
+theorem intervalIntegrable_iff_integrableOn_Ioo_of_le [NoAtoms μ]
+    (hab : a ≤ b) (ha : ‖f a‖ₑ ≠ ∞) (hb : ‖f b‖ₑ ≠ ∞) :
     IntervalIntegrable f μ a b ↔ IntegrableOn f (Ioo a b) μ := by
-  rw [intervalIntegrable_iff_integrableOn_Icc_of_le hab, integrableOn_Icc_iff_integrableOn_Ioo]
+  rw [intervalIntegrable_iff_integrableOn_Icc_of_le hab ha,
+    integrableOn_Icc_iff_integrableOn_Ioo ha hb]
 
 /-- If a function is integrable with respect to a given measure `μ` then it is interval integrable
   with respect to `μ` on `uIcc a b`. -/
@@ -320,10 +324,12 @@ theorem div_const {𝕜 : Type*} {f : ℝ → 𝕜} [NormedDivisionRing 𝕜] (h
     (c : 𝕜) : IntervalIntegrable (fun x => f x / c) μ a b := by
   simpa only [div_eq_mul_inv] using mul_const h c⁻¹
 
-theorem comp_mul_left (hf : IntervalIntegrable f volume a b) (c : ℝ) :
+theorem comp_mul_left (hf : IntervalIntegrable f volume a b) {c : ℝ}
+    (h : ‖f (min a b)‖ₑ ≠ ∞) (h' : ‖f (c * min (a / c) (b / c))‖ₑ ≠ ∞) :
     IntervalIntegrable (fun x => f (c * x)) volume (a / c) (b / c) := by
   rcases eq_or_ne c 0 with (hc | hc); · rw [hc]; simp
-  rw [intervalIntegrable_iff'] at hf ⊢
+  rw [intervalIntegrable_iff' h] at hf
+  rw [intervalIntegrable_iff' h'] at ⊢
   have A : MeasurableEmbedding fun x => x * c⁻¹ :=
     (Homeomorph.mulRight₀ _ (inv_ne_zero hc)).isClosedEmbedding.measurableEmbedding
   rw [← Real.smul_map_volume_mul_right (inv_ne_zero hc), IntegrableOn, Measure.restrict_smul,
@@ -333,46 +339,54 @@ theorem comp_mul_left (hf : IntervalIntegrable f volume a b) (c : ℝ) :
   · ext; simp only [comp_apply]; congr 1; field_simp
   · rw [preimage_mul_const_uIcc (inv_ne_zero hc)]; field_simp [hc]
 
-theorem comp_mul_left_iff {c : ℝ} (hc : c ≠ 0) :
+theorem comp_mul_left_iff {c : ℝ} (hc : c ≠ 0)
+    (h : ‖f (min a b)‖ₑ ≠ ∞) (h' : ‖f (c * min (a / c) (b / c))‖ₑ ≠ ∞) :
     IntervalIntegrable (fun x ↦ f (c * x)) volume (a / c) (b / c) ↔
       IntervalIntegrable f volume a b :=
-  ⟨fun h ↦ by simpa [hc] using h.comp_mul_left c⁻¹, (comp_mul_left · c)⟩
+  ⟨fun h ↦ by /-simp [hc];-/ sorry /- using h.comp_mul_left c⁻¹-/, (comp_mul_left · h h')⟩
 
-theorem comp_mul_right (hf : IntervalIntegrable f volume a b) (c : ℝ) :
+theorem comp_mul_right (hf : IntervalIntegrable f volume a b) {c : ℝ}
+    (h : ‖f (min a b)‖ₑ ≠ ∞) (h' : ‖f (c * min (a / c) (b / c))‖ₑ ≠ ∞) :
     IntervalIntegrable (fun x => f (x * c)) volume (a / c) (b / c) := by
-  simpa only [mul_comm] using comp_mul_left hf c
+  simpa only [mul_comm] using comp_mul_left hf h h'
 
-theorem comp_add_right (hf : IntervalIntegrable f volume a b) (c : ℝ) :
-    IntervalIntegrable (fun x => f (x + c)) volume (a - c) (b - c) := by
-  wlog h : a ≤ b generalizing a b
-  · exact IntervalIntegrable.symm (this hf.symm (le_of_not_ge h))
-  rw [intervalIntegrable_iff'] at hf ⊢
+theorem comp_add_right (hf : IntervalIntegrable f volume a b) (c : ℝ) (h : ‖f (min a b)‖ₑ ≠ ∞) :
+    IntervalIntegrable (fun x ↦ f (x + c)) volume (a - c) (b - c) := by
+  have h' : ‖f (min (a - c) (b - c) + c)‖ₑ ≠ ⊤ := by
+    rw [min_sub_sub_right, sub_add, sub_self, sub_zero]
+    exact h
+  wlog hab : a ≤ b generalizing a b
+  · apply IntervalIntegrable.symm (this hf.symm ?_ ?_ (le_of_not_ge hab))
+    · rw [min_comm]; exact h
+    · rw [min_comm]; exact h'
+  rw [intervalIntegrable_iff' h] at hf
+  rw [intervalIntegrable_iff' h'] at ⊢
   have A : MeasurableEmbedding fun x => x + c :=
     (Homeomorph.addRight c).isClosedEmbedding.measurableEmbedding
   rw [← map_add_right_eq_self volume c] at hf
   convert (MeasurableEmbedding.integrableOn_map_iff A).mp hf using 1
   rw [preimage_add_const_uIcc]
 
-theorem comp_add_left (hf : IntervalIntegrable f volume a b) (c : ℝ) :
-    IntervalIntegrable (fun x => f (c + x)) volume (a - c) (b - c) := by
-  simpa only [add_comm] using IntervalIntegrable.comp_add_right hf c
+theorem comp_add_left (hf : IntervalIntegrable f volume a b) (c : ℝ) (h : ‖f (min a b)‖ₑ ≠ ∞) :
+    IntervalIntegrable (fun x ↦ f (c + x)) volume (a - c) (b - c) := by
+  simpa [add_comm] using IntervalIntegrable.comp_add_right hf c h
 
-theorem comp_sub_right (hf : IntervalIntegrable f volume a b) (c : ℝ) :
-    IntervalIntegrable (fun x => f (x - c)) volume (a + c) (b + c) := by
-  simpa only [sub_neg_eq_add] using IntervalIntegrable.comp_add_right hf (-c)
+theorem comp_sub_right (hf : IntervalIntegrable f volume a b) (c : ℝ) (h : ‖f (min a b)‖ₑ ≠ ∞) :
+    IntervalIntegrable (fun x ↦ f (x - c)) volume (a + c) (b + c) := by
+  simpa only [sub_neg_eq_add] using IntervalIntegrable.comp_add_right hf (-c) h
 
-theorem iff_comp_neg :
-    IntervalIntegrable f volume a b ↔ IntervalIntegrable (fun x => f (-x)) volume (-a) (-b) := by
-  rw [← comp_mul_left_iff (neg_ne_zero.2 one_ne_zero)]; simp [div_neg]
+theorem iff_comp_neg (h : ‖f (min a b)‖ₑ ≠ ∞) :
+    IntervalIntegrable f volume a b ↔ IntervalIntegrable (fun x ↦ f (-x)) volume (-a) (-b) := by
+  rw [← comp_mul_left_iff (neg_ne_zero.2 one_ne_zero) h (by simp)]; simp [div_neg]
 
-theorem comp_sub_left (hf : IntervalIntegrable f volume a b) (c : ℝ) :
-    IntervalIntegrable (fun x => f (c - x)) volume (c - a) (c - b) := by
-  simpa only [neg_sub, ← sub_eq_add_neg] using iff_comp_neg.mp (hf.comp_add_left c)
+theorem comp_sub_left (hf : IntervalIntegrable f volume a b) (c : ℝ) (h : ‖f (min a b)‖ₑ ≠ ∞) :
+    IntervalIntegrable (fun x ↦ f (c - x)) volume (c - a) (c - b) := by
+  sorry -- simpa only [neg_sub, ← sub_eq_add_neg] using (iff_comp_neg h).mp (hf.comp_add_left 0 h)
 
-theorem comp_sub_left_iff (c : ℝ) :
+theorem comp_sub_left_iff (c : ℝ) (h : ‖f (min a b)‖ₑ ≠ ∞) :
     IntervalIntegrable (fun x => f (c - x)) volume (c - a) (c - b) ↔
       IntervalIntegrable f volume a b :=
-  ⟨fun h ↦ by simpa using h.comp_sub_left c, (.comp_sub_left · c)⟩
+  ⟨fun h ↦ by simpa using h.comp_sub_left c, (.comp_sub_left · c h)⟩
 
 end IntervalIntegrable
 
@@ -439,10 +453,10 @@ interval of the form `0..x`, for positive `x`.
 
 See `intervalIntegrable_of_even` for a stronger result. -/
 lemma intervalIntegrable_of_even₀ (h₁f : ∀ x, f x = f (-x))
-    (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x) (t : ℝ) :
+    (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x) {t : ℝ} (ht : ‖f (min 0 t)‖ₑ ≠ ∞) :
     IntervalIntegrable f volume 0 t := by
   rcases lt_trichotomy t 0 with h | h | h
-  · rw [IntervalIntegrable.iff_comp_neg]
+  · rw [IntervalIntegrable.iff_comp_neg ht]
     conv => arg 1; intro t; rw [← h₁f]
     simp [h₂f (-t) (by norm_num [h])]
   · rw [h]
@@ -452,22 +466,23 @@ lemma intervalIntegrable_of_even₀ (h₁f : ∀ x, f x = f (-x))
 if it is interval integrable (with respect to the volume measure) on every interval of the form
 `0..x`, for positive `x`. -/
 theorem intervalIntegrable_of_even
-    (h₁f : ∀ x, f x = f (-x)) (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x) (a b : ℝ) :
+    (h₁f : ∀ x, f x = f (-x)) (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x) {a b : ℝ}
+    (ha : ‖f (min 0 a)‖ₑ ≠ ∞) (hb : ‖f (min 0 b)‖ₑ ≠ ∞) :
     IntervalIntegrable f volume a b :=
   -- Split integral and apply lemma
-  (intervalIntegrable_of_even₀ h₁f h₂f a).symm.trans (b := 0)
-    (intervalIntegrable_of_even₀ h₁f h₂f b)
+  (intervalIntegrable_of_even₀ h₁f h₂f ha).symm.trans (b := 0)
+    (intervalIntegrable_of_even₀ h₁f h₂f hb)
 
 /-- An odd function is interval integrable (with respect to the volume measure) on every interval
 of the form `0..x` if it is interval integrable (with respect to the volume measure) on every
 interval of the form `0..x`, for positive `x`.
 
 See `intervalIntegrable_of_odd` for a stronger result. -/
-lemma intervalIntegrable_of_odd₀
-    (h₁f : ∀ x, -f x = f (-x)) (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x) (t : ℝ) :
+lemma intervalIntegrable_of_odd₀ (h₁f : ∀ x, -f x = f (-x))
+    (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x) {t : ℝ} (ht : ‖f (min 0 t)‖ₑ ≠ ∞) :
     IntervalIntegrable f volume 0 t := by
   rcases lt_trichotomy t 0 with h | h | h
-  · rw [IntervalIntegrable.iff_comp_neg]
+  · rw [IntervalIntegrable.iff_comp_neg ht]
     conv => arg 1; intro t; rw [← h₁f]
     apply IntervalIntegrable.neg
     simp [h₂f (-t) (by norm_num [h])]
@@ -478,10 +493,11 @@ lemma intervalIntegrable_of_odd₀
 iff it is interval integrable (with respect to the volume measure) on every interval of the form
 `0..x`, for positive `x`. -/
 theorem intervalIntegrable_of_odd
-    (h₁f : ∀ x, -f x = f (-x)) (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x) (a b : ℝ) :
+    (h₁f : ∀ x, -f x = f (-x)) (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x) {a b : ℝ}
+    (ha : ‖f (min 0 a)‖ₑ ≠ ∞) (hb : ‖f (min 0 b)‖ₑ ≠ ∞) :
     IntervalIntegrable f volume a b :=
   -- Split integral and apply lemma
-  (intervalIntegrable_of_odd₀ h₁f h₂f a).symm.trans (b := 0) (intervalIntegrable_of_odd₀ h₁f h₂f b)
+  (intervalIntegrable_of_odd₀ h₁f h₂f ha).symm.trans (intervalIntegrable_of_odd₀ h₁f h₂f hb)
 
 end
 

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean
@@ -340,10 +340,13 @@ theorem comp_mul_left (hf : IntervalIntegrable f volume a b) {c : ℝ}
   · rw [preimage_mul_const_uIcc (inv_ne_zero hc)]; field_simp [hc]
 
 theorem comp_mul_left_iff {c : ℝ} (hc : c ≠ 0)
+    -- can h' be deduced?
     (h : ‖f (min a b)‖ₑ ≠ ∞) (h' : ‖f (c * min (a / c) (b / c))‖ₑ ≠ ∞) :
     IntervalIntegrable (fun x ↦ f (c * x)) volume (a / c) (b / c) ↔
-      IntervalIntegrable f volume a b :=
-  ⟨fun h ↦ by /-simp [hc];-/ sorry /- using h.comp_mul_left c⁻¹-/, (comp_mul_left · h h')⟩
+      IntervalIntegrable f volume a b := by
+  refine ⟨fun h ↦ ?_/-simpa [hc] using h.comp_mul_left c⁻¹-/, (comp_mul_left · h h')⟩
+  have aux : ‖f (c * (c⁻¹ * min (a / c / c⁻¹) (b / c / c⁻¹)))‖ₑ ≠ ⊤ := sorry
+  simpa [hc] using h.comp_mul_left (c := c⁻¹) h' aux
 
 theorem comp_mul_right (hf : IntervalIntegrable f volume a b) {c : ℝ}
     (h : ‖f (min a b)‖ₑ ≠ ∞) (h' : ‖f (c * min (a / c) (b / c))‖ₑ ≠ ∞) :

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean
@@ -106,22 +106,23 @@ theorem intervalIntegrable_iff_integrableOn_Ioc_of_le (hab : a ≤ b) :
     IntervalIntegrable f μ a b ↔ IntegrableOn f (Ioc a b) μ := by
   rw [intervalIntegrable_iff, uIoc_of_le hab]
 
-theorem intervalIntegrable_iff' [NoAtoms μ] (h : ‖f (min a b)‖ₑ ≠ ∞) :
+theorem intervalIntegrable_iff' [NoAtoms μ] (h : ‖f (min a b)‖ₑ ≠ ∞ := by finiteness) :
     IntervalIntegrable f μ a b ↔ IntegrableOn f (uIcc a b) μ := by
   rw [intervalIntegrable_iff, ← Icc_min_max, uIoc, integrableOn_Icc_iff_integrableOn_Ioc h]
 
-theorem intervalIntegrable_iff_integrableOn_Icc_of_le (hab : a ≤ b) (ha : ‖f a‖ₑ ≠ ∞)
-    {μ : Measure ℝ} [NoAtoms μ] : IntervalIntegrable f μ a b ↔ IntegrableOn f (Icc a b) μ := by
+theorem intervalIntegrable_iff_integrableOn_Icc_of_le [NoAtoms μ]
+    (hab : a ≤ b) (ha : ‖f a‖ₑ ≠ ∞ := by finiteness) :
+    IntervalIntegrable f μ a b ↔ IntegrableOn f (Icc a b) μ := by
   rw [intervalIntegrable_iff_integrableOn_Ioc_of_le hab, integrableOn_Icc_iff_integrableOn_Ioc ha]
 
 theorem intervalIntegrable_iff_integrableOn_Ico_of_le [NoAtoms μ]
-    (hab : a ≤ b) (ha : ‖f a‖ₑ ≠ ∞) (hb : ‖f b‖ₑ ≠ ∞) :
+    (hab : a ≤ b) (ha : ‖f a‖ₑ ≠ ∞ := by finiteness) (hb : ‖f b‖ₑ ≠ ∞ := by finiteness) :
     IntervalIntegrable f μ a b ↔ IntegrableOn f (Ico a b) μ := by
   rw [intervalIntegrable_iff_integrableOn_Icc_of_le hab ha,
     integrableOn_Icc_iff_integrableOn_Ico hb]
 
 theorem intervalIntegrable_iff_integrableOn_Ioo_of_le [NoAtoms μ]
-    (hab : a ≤ b) (ha : ‖f a‖ₑ ≠ ∞) (hb : ‖f b‖ₑ ≠ ∞) :
+    (hab : a ≤ b) (ha : ‖f a‖ₑ ≠ ∞ := by finiteness) (hb : ‖f b‖ₑ ≠ ∞ := by finiteness) :
     IntervalIntegrable f μ a b ↔ IntegrableOn f (Ioo a b) μ := by
   rw [intervalIntegrable_iff_integrableOn_Icc_of_le hab ha,
     integrableOn_Icc_iff_integrableOn_Ioo ha hb]
@@ -325,7 +326,8 @@ theorem div_const {𝕜 : Type*} {f : ℝ → 𝕜} [NormedDivisionRing 𝕜] (h
   simpa only [div_eq_mul_inv] using mul_const h c⁻¹
 
 theorem comp_mul_left (hf : IntervalIntegrable f volume a b) {c : ℝ}
-    (h : ‖f (min a b)‖ₑ ≠ ∞) (h' : ‖f (c * min (a / c) (b / c))‖ₑ ≠ ∞) :
+    (h : ‖f (min a b)‖ₑ ≠ ∞ := by finiteness)
+    (h' : ‖f (c * min (a / c) (b / c))‖ₑ ≠ ∞ := by finiteness) :
     IntervalIntegrable (fun x => f (c * x)) volume (a / c) (b / c) := by
   rcases eq_or_ne c 0 with (hc | hc); · rw [hc]; simp
   rw [intervalIntegrable_iff' h] at hf
@@ -340,19 +342,21 @@ theorem comp_mul_left (hf : IntervalIntegrable f volume a b) {c : ℝ}
   · rw [preimage_mul_const_uIcc (inv_ne_zero hc)]; field_simp [hc]
 
 -- Note that `h'` is **not** implied by `h` if `c` is negative.
-theorem comp_mul_left_iff {c : ℝ} (hc : c ≠ 0) (h : ‖f (min a b)‖ₑ ≠ ∞)
-    (h' : ‖f (c * min (a / c) (b / c))‖ₑ ≠ ∞) :
+theorem comp_mul_left_iff {c : ℝ} (hc : c ≠ 0) (h : ‖f (min a b)‖ₑ ≠ ∞ := by finiteness)
+    (h' : ‖f (c * min (a / c) (b / c))‖ₑ ≠ ∞ := by finiteness) :
     IntervalIntegrable (fun x ↦ f (c * x)) volume (a / c) (b / c) ↔
       IntervalIntegrable f volume a b := by
   exact ⟨fun h ↦ by simpa [hc] using h.comp_mul_left (c := c⁻¹) h' (by simp),
     (comp_mul_left · h h')⟩
 
 theorem comp_mul_right (hf : IntervalIntegrable f volume a b) {c : ℝ}
-    (h : ‖f (min a b)‖ₑ ≠ ∞) (h' : ‖f (c * min (a / c) (b / c))‖ₑ ≠ ∞) :
+    (h : ‖f (min a b)‖ₑ ≠ ∞ := by finiteness)
+    (h' : ‖f (c * min (a / c) (b / c))‖ₑ ≠ ∞ := by finiteness) :
     IntervalIntegrable (fun x => f (x * c)) volume (a / c) (b / c) := by
   simpa only [mul_comm] using comp_mul_left hf h h'
 
-theorem comp_add_right (hf : IntervalIntegrable f volume a b) (c : ℝ) (h : ‖f (min a b)‖ₑ ≠ ∞) :
+theorem comp_add_right (hf : IntervalIntegrable f volume a b) (c : ℝ)
+    (h : ‖f (min a b)‖ₑ ≠ ∞ := by finiteness) :
     IntervalIntegrable (fun x ↦ f (x + c)) volume (a - c) (b - c) := by
   have h' : ‖f (min (a - c) (b - c) + c)‖ₑ ≠ ⊤ := by
     rw [min_sub_sub_right, sub_add, sub_self, sub_zero]
@@ -369,23 +373,26 @@ theorem comp_add_right (hf : IntervalIntegrable f volume a b) (c : ℝ) (h : ‖
   convert (MeasurableEmbedding.integrableOn_map_iff A).mp hf using 1
   rw [preimage_add_const_uIcc]
 
-theorem comp_add_left (hf : IntervalIntegrable f volume a b) (c : ℝ) (h : ‖f (min a b)‖ₑ ≠ ∞) :
+theorem comp_add_left (hf : IntervalIntegrable f volume a b) (c : ℝ)
+    (h : ‖f (min a b)‖ₑ ≠ ∞ := by finiteness) :
     IntervalIntegrable (fun x ↦ f (c + x)) volume (a - c) (b - c) := by
   simpa [add_comm] using IntervalIntegrable.comp_add_right hf c h
 
-theorem comp_sub_right (hf : IntervalIntegrable f volume a b) (c : ℝ) (h : ‖f (min a b)‖ₑ ≠ ∞) :
+theorem comp_sub_right (hf : IntervalIntegrable f volume a b) (c : ℝ)
+    (h : ‖f (min a b)‖ₑ ≠ ∞ := by finiteness) :
     IntervalIntegrable (fun x ↦ f (x - c)) volume (a + c) (b + c) := by
   simpa only [sub_neg_eq_add] using IntervalIntegrable.comp_add_right hf (-c) h
 
-theorem iff_comp_neg (h : ‖f (min a b)‖ₑ ≠ ∞) :
+theorem iff_comp_neg (h : ‖f (min a b)‖ₑ ≠ ∞ := by finiteness) :
     IntervalIntegrable f volume a b ↔ IntervalIntegrable (fun x ↦ f (-x)) volume (-a) (-b) := by
   rw [← comp_mul_left_iff (neg_ne_zero.2 one_ne_zero) h (by simp)]; simp [div_neg]
 
-theorem comp_sub_left (hf : IntervalIntegrable f volume a b) (c : ℝ) (h : ‖f (min a b)‖ₑ ≠ ∞) :
+theorem comp_sub_left (hf : IntervalIntegrable f volume a b) (c : ℝ)
+    (h : ‖f (min a b)‖ₑ ≠ ∞ := by finiteness) :
     IntervalIntegrable (fun x ↦ f (c - x)) volume (c - a) (c - b) := by
   simpa only [neg_sub, ← sub_eq_add_neg] using (iff_comp_neg (by simp)).mp (hf.comp_add_left c h)
 
-theorem comp_sub_left_iff (c : ℝ) (h : ‖f (min a b)‖ₑ ≠ ∞) :
+theorem comp_sub_left_iff (c : ℝ) (h : ‖f (min a b)‖ₑ ≠ ∞ := by finiteness) :
     IntervalIntegrable (fun x => f (c - x)) volume (c - a) (c - b) ↔
       IntervalIntegrable f volume a b :=
   ⟨fun h ↦ by simpa using h.comp_sub_left c, (.comp_sub_left · c h)⟩
@@ -455,7 +462,8 @@ interval of the form `0..x`, for positive `x`.
 
 See `intervalIntegrable_of_even` for a stronger result. -/
 lemma intervalIntegrable_of_even₀ (h₁f : ∀ x, f x = f (-x))
-    (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x) {t : ℝ} (ht : ‖f (min 0 t)‖ₑ ≠ ∞) :
+    (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x)
+    {t : ℝ} (ht : ‖f (min 0 t)‖ₑ ≠ ∞ := by finiteness) :
     IntervalIntegrable f volume 0 t := by
   rcases lt_trichotomy t 0 with h | h | h
   · rw [IntervalIntegrable.iff_comp_neg ht]
@@ -469,7 +477,7 @@ if it is interval integrable (with respect to the volume measure) on every inter
 `0..x`, for positive `x`. -/
 theorem intervalIntegrable_of_even
     (h₁f : ∀ x, f x = f (-x)) (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x) {a b : ℝ}
-    (ha : ‖f (min 0 a)‖ₑ ≠ ∞) (hb : ‖f (min 0 b)‖ₑ ≠ ∞) :
+    (ha : ‖f (min 0 a)‖ₑ ≠ ∞ := by finiteness) (hb : ‖f (min 0 b)‖ₑ ≠ ∞ := by finiteness) :
     IntervalIntegrable f volume a b :=
   -- Split integral and apply lemma
   (intervalIntegrable_of_even₀ h₁f h₂f ha).symm.trans (b := 0)
@@ -481,7 +489,8 @@ interval of the form `0..x`, for positive `x`.
 
 See `intervalIntegrable_of_odd` for a stronger result. -/
 lemma intervalIntegrable_of_odd₀ (h₁f : ∀ x, -f x = f (-x))
-    (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x) {t : ℝ} (ht : ‖f (min 0 t)‖ₑ ≠ ∞) :
+    (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x) {t : ℝ}
+    (ht : ‖f (min 0 t)‖ₑ ≠ ∞ := by finiteness) :
     IntervalIntegrable f volume 0 t := by
   rcases lt_trichotomy t 0 with h | h | h
   · rw [IntervalIntegrable.iff_comp_neg ht]
@@ -496,7 +505,7 @@ iff it is interval integrable (with respect to the volume measure) on every inte
 `0..x`, for positive `x`. -/
 theorem intervalIntegrable_of_odd
     (h₁f : ∀ x, -f x = f (-x)) (h₂f : ∀ x, 0 < x → IntervalIntegrable f volume 0 x) {a b : ℝ}
-    (ha : ‖f (min 0 a)‖ₑ ≠ ∞) (hb : ‖f (min 0 b)‖ₑ ≠ ∞) :
+    (ha : ‖f (min 0 a)‖ₑ ≠ ∞ := by finiteness) (hb : ‖f (min 0 b)‖ₑ ≠ ∞ := by finiteness) :
     IntervalIntegrable f volume a b :=
   -- Split integral and apply lemma
   (intervalIntegrable_of_odd₀ h₁f h₂f ha).symm.trans (intervalIntegrable_of_odd₀ h₁f h₂f hb)

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean
@@ -493,7 +493,7 @@ lemma intervalIntegrable_of_odd₀ (h₁f : ∀ x, -f x = f (-x))
     (ht : ‖f (min 0 t)‖ₑ ≠ ∞ := by finiteness) :
     IntervalIntegrable f volume 0 t := by
   rcases lt_trichotomy t 0 with h | h | h
-  · rw [IntervalIntegrable.iff_comp_neg ht]
+  · rw [IntervalIntegrable.iff_comp_neg]
     conv => arg 1; intro t; rw [← h₁f]
     apply IntervalIntegrable.neg
     simp [h₂f (-t) (by norm_num [h])]

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/FundThmCalculus.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/FundThmCalculus.lean
@@ -1230,7 +1230,7 @@ theorem integrableOn_deriv_right_of_nonneg (hcont : ContinuousOn g (Icc a b))
   have B : (∫ x : ℝ in Ioo a b, F x) ≤ g b - g a := by
     rw [← integral_Ioc_eq_integral_Ioo, ← intervalIntegral.integral_of_le hab.le]
     refine integral_le_sub_of_hasDeriv_right_of_le hab.le hcont hderiv ?_ fun x hx => ?_
-    · rwa [integrableOn_Icc_iff_integrableOn_Ioo (by finiteness) (by finiteness)]
+    · rwa [integrableOn_Icc_iff_integrableOn_Ioo]
     · convert NNReal.coe_le_coe.2 (fle x)
       simp only [Real.norm_of_nonneg (g'pos x hx), coe_nnnorm]
   exact lt_irrefl _ (hf.trans_le (ENNReal.ofReal_le_ofReal B))

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/FundThmCalculus.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/FundThmCalculus.lean
@@ -1207,7 +1207,7 @@ theorem integrableOn_deriv_right_of_nonneg (hcont : ContinuousOn g (Icc a b))
     (g'pos : ∀ x ∈ Ioo a b, 0 ≤ g' x) : IntegrableOn g' (Ioc a b) := by
   by_cases hab : a < b; swap
   · simp [Ioc_eq_empty hab]
-  rw [integrableOn_Ioc_iff_integrableOn_Ioo (by finiteness)]
+  rw [integrableOn_Ioc_iff_integrableOn_Ioo]
   have meas_g' : AEMeasurable g' (volume.restrict (Ioo a b)) := by
     apply (aemeasurable_derivWithin_Ioi g _).congr
     refine (ae_restrict_mem measurableSet_Ioo).mono fun x hx => ?_

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/FundThmCalculus.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/FundThmCalculus.lean
@@ -1116,7 +1116,7 @@ theorem integral_eq_sub_of_hasDeriv_right_of_le (hab : a ≤ b) (hcont : Continu
   rw [← g.intervalIntegral_comp_comm f'int, g.map_sub]
   exact integral_eq_sub_of_hasDeriv_right_of_le_real hab (g.continuous.comp_continuousOn hcont)
     (fun x hx => g.hasFDerivAt.comp_hasDerivWithinAt x (hderiv x hx))
-    (g.integrable_comp ((intervalIntegrable_iff_integrableOn_Icc_of_le hab).1 f'int))
+    (g.integrable_comp ((intervalIntegrable_iff_integrableOn_Icc_of_le hab (enorm_ne_top)).1 f'int))
 
 /-- Fundamental theorem of calculus-2: If `f : ℝ → E` is continuous on `[a, b]` and
   has a right derivative at `f' x` for all `x` in `[a, b)`, and `f'` is integrable on `[a, b]` then
@@ -1207,7 +1207,7 @@ theorem integrableOn_deriv_right_of_nonneg (hcont : ContinuousOn g (Icc a b))
     (g'pos : ∀ x ∈ Ioo a b, 0 ≤ g' x) : IntegrableOn g' (Ioc a b) := by
   by_cases hab : a < b; swap
   · simp [Ioc_eq_empty hab]
-  rw [integrableOn_Ioc_iff_integrableOn_Ioo]
+  rw [integrableOn_Ioc_iff_integrableOn_Ioo (by finiteness)]
   have meas_g' : AEMeasurable g' (volume.restrict (Ioo a b)) := by
     apply (aemeasurable_derivWithin_Ioi g _).congr
     refine (ae_restrict_mem measurableSet_Ioo).mono fun x hx => ?_
@@ -1230,7 +1230,7 @@ theorem integrableOn_deriv_right_of_nonneg (hcont : ContinuousOn g (Icc a b))
   have B : (∫ x : ℝ in Ioo a b, F x) ≤ g b - g a := by
     rw [← integral_Ioc_eq_integral_Ioo, ← intervalIntegral.integral_of_le hab.le]
     refine integral_le_sub_of_hasDeriv_right_of_le hab.le hcont hderiv ?_ fun x hx => ?_
-    · rwa [integrableOn_Icc_iff_integrableOn_Ioo]
+    · rwa [integrableOn_Icc_iff_integrableOn_Ioo (by finiteness) (by finiteness)]
     · convert NNReal.coe_le_coe.2 (fle x)
       simp only [Real.norm_of_nonneg (g'pos x hx), coe_nnnorm]
   exact lt_irrefl _ (hf.trans_le (ENNReal.ofReal_le_ofReal B))

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/FundThmCalculus.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/FundThmCalculus.lean
@@ -1116,7 +1116,7 @@ theorem integral_eq_sub_of_hasDeriv_right_of_le (hab : a ≤ b) (hcont : Continu
   rw [← g.intervalIntegral_comp_comm f'int, g.map_sub]
   exact integral_eq_sub_of_hasDeriv_right_of_le_real hab (g.continuous.comp_continuousOn hcont)
     (fun x hx => g.hasFDerivAt.comp_hasDerivWithinAt x (hderiv x hx))
-    (g.integrable_comp ((intervalIntegrable_iff_integrableOn_Icc_of_le hab (enorm_ne_top)).1 f'int))
+    (g.integrable_comp ((intervalIntegrable_iff_integrableOn_Icc_of_le hab enorm_ne_top).1 f'int))
 
 /-- Fundamental theorem of calculus-2: If `f : ℝ → E` is continuous on `[a, b]` and
   has a right derivative at `f' x` for all `x` in `[a, b)`, and `f'` is integrable on `[a, b]` then

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/Periodic.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/Periodic.lean
@@ -239,7 +239,8 @@ variable {f : ℝ → E} {T : ℝ}
 
 /-- A periodic function is interval integrable over every interval if it is interval integrable
 over one period. -/
-theorem intervalIntegrable {t : ℝ} (h₁f : Function.Periodic f T) (hT : 0 < T)
+theorem intervalIntegrable {t : ℝ} (h₁f : Function.Periodic f T)
+    (hT : 0 < T) (hT' : ‖f (min t (t + T))‖ₑ ≠ ∞)
     (h₂f : IntervalIntegrable f MeasureTheory.volume t (t + T)) (a₁ a₂ : ℝ) :
     IntervalIntegrable f MeasureTheory.volume a₁ a₂ := by
   -- Replace [a₁, a₂] by [t - n₁ * T, t + n₂ * T], where n₁ and n₂ are natural numbers
@@ -261,7 +262,7 @@ theorem intervalIntegrable {t : ℝ} (h₁f : Function.Periodic f T) (hT : 0 < T
   apply IntervalIntegrable.trans_iterate
   -- Show integrability over a shifted period
   intro k hk
-  convert (IntervalIntegrable.comp_sub_right h₂f ((k - n₁) * T)) using 1
+  convert (IntervalIntegrable.comp_sub_right h₂f ((k - n₁) * T) hT') using 1
   · funext x
     simpa using (h₁f.sub_int_mul_eq (k - n₁)).symm
   · simp [a, Nat.cast_add]
@@ -272,7 +273,7 @@ over every interval if it is interval integrable over the period starting from z
 theorem intervalIntegrable₀ (h₁f : Function.Periodic f T) (hT : 0 < T)
     (h₂f : IntervalIntegrable f MeasureTheory.volume 0 T) (a₁ a₂ : ℝ) :
     IntervalIntegrable f MeasureTheory.volume a₁ a₂ := by
-  apply h₁f.intervalIntegrable hT (t := 0)
+  apply h₁f.intervalIntegrable hT (t := 0) (by simp)
   simpa
 
 /-!

--- a/Mathlib/MeasureTheory/Integral/IntervalIntegral/Periodic.lean
+++ b/Mathlib/MeasureTheory/Integral/IntervalIntegral/Periodic.lean
@@ -240,7 +240,7 @@ variable {f : ℝ → E} {T : ℝ}
 /-- A periodic function is interval integrable over every interval if it is interval integrable
 over one period. -/
 theorem intervalIntegrable {t : ℝ} (h₁f : Function.Periodic f T)
-    (hT : 0 < T) (hT' : ‖f (min t (t + T))‖ₑ ≠ ∞)
+    (hT : 0 < T) (hT' : ‖f (min t (t + T))‖ₑ ≠ ∞ := by finiteness)
     (h₂f : IntervalIntegrable f MeasureTheory.volume t (t + T)) (a₁ a₂ : ℝ) :
     IntervalIntegrable f MeasureTheory.volume a₁ a₂ := by
   -- Replace [a₁, a₂] by [t - n₁ * T, t + n₂ * T], where n₁ and n₂ are natural numbers
@@ -273,7 +273,7 @@ over every interval if it is interval integrable over the period starting from z
 theorem intervalIntegrable₀ (h₁f : Function.Periodic f T) (hT : 0 < T)
     (h₂f : IntervalIntegrable f MeasureTheory.volume 0 T) (a₁ a₂ : ℝ) :
     IntervalIntegrable f MeasureTheory.volume a₁ a₂ := by
-  apply h₁f.intervalIntegrable hT (t := 0) (by simp)
+  apply h₁f.intervalIntegrable hT (t := 0)
   simpa
 
 /-!

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/Integral.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/Integral.lean
@@ -103,7 +103,7 @@ theorem integral_comp_abs {f : ℝ → ℝ} :
       let m : MeasurableEmbedding fun x : ℝ => -x := (Homeomorph.neg ℝ).measurableEmbedding
       rw [m.integrableOn_map_iff]
       simp_rw [Function.comp_def, abs_neg, neg_preimage, neg_Iic, neg_zero]
-      exact integrableOn_Ici_iff_integrableOn_Ioi.mpr hf
+      exact integrableOn_Ici_iff_integrableOn_Ioi (by finiteness)|>.mpr hf
     calc
       _ = (∫ x in Iic 0, f |x|) + ∫ x in Ioi 0, f |x| := by
         rw [← setIntegral_union (Iic_disjoint_Ioi le_rfl) measurableSet_Ioi int_Iic hf,

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/Integral.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/Integral.lean
@@ -103,7 +103,7 @@ theorem integral_comp_abs {f : ℝ → ℝ} :
       let m : MeasurableEmbedding fun x : ℝ => -x := (Homeomorph.neg ℝ).measurableEmbedding
       rw [m.integrableOn_map_iff]
       simp_rw [Function.comp_def, abs_neg, neg_preimage, neg_Iic, neg_zero]
-      exact integrableOn_Ici_iff_integrableOn_Ioi (by finiteness)|>.mpr hf
+      exact integrableOn_Ici_iff_integrableOn_Ioi (by finiteness) |>.mpr hf
     calc
       _ = (∫ x in Iic 0, f |x|) + ∫ x in Ioi 0, f |x| := by
         rw [← setIntegral_union (Iic_disjoint_Ioi le_rfl) measurableSet_Ioi int_Iic hf,

--- a/Mathlib/MeasureTheory/Measure/Lebesgue/Integral.lean
+++ b/Mathlib/MeasureTheory/Measure/Lebesgue/Integral.lean
@@ -103,7 +103,7 @@ theorem integral_comp_abs {f : ℝ → ℝ} :
       let m : MeasurableEmbedding fun x : ℝ => -x := (Homeomorph.neg ℝ).measurableEmbedding
       rw [m.integrableOn_map_iff]
       simp_rw [Function.comp_def, abs_neg, neg_preimage, neg_Iic, neg_zero]
-      exact integrableOn_Ici_iff_integrableOn_Ioi (by finiteness) |>.mpr hf
+      exact Iff.mpr integrableOn_Ici_iff_integrableOn_Ioi hf
     calc
       _ = (∫ x in Iic 0, f |x|) + ∫ x in Ioi 0, f |x| := by
         rw [← setIntegral_union (Iic_disjoint_Ioi le_rfl) measurableSet_Ioi int_Iic hf,

--- a/Mathlib/NumberTheory/AbelSummation.lean
+++ b/Mathlib/NumberTheory/AbelSummation.lean
@@ -262,7 +262,7 @@ theorem tendsto_sum_mul_atTop_nhds_one_sub_integral
       atTop (𝓝 (∫ t in Set.Ioi 0, deriv f t * ∑ k ∈ Icc 0 ⌊t⌋₊, c k)) := by
     refine Tendsto.congr (fun _ ↦ by rw [← integral_of_le (Nat.cast_nonneg _)]) ?_
     refine intervalIntegral_tendsto_integral_Ioi _ ?_ tendsto_natCast_atTop_atTop
-    exact integrableOn_Ici_iff_integrableOn_Ioi.mp
+    exact integrableOn_Ici_iff_integrableOn_Ioi (by finiteness) |>.mp
       <| (locallyIntegrableOn_mul_sum_Icc c le_rfl hf_int).integrableOn_of_isBigO_atTop
         hg_dom hg_int
   refine (h_lim.sub h_lim').congr (fun _ ↦ ?_)
@@ -284,7 +284,7 @@ theorem tendsto_sum_mul_atTop_nhds_one_sub_integral₀ (hc : c 0 = 0)
   have h_lim' : Tendsto (fun n : ℕ ↦ ∫ t in Set.Ioc (1 : ℝ) n, deriv f t * ∑ k ∈ Icc 0 ⌊t⌋₊, c k)
       atTop (𝓝 (∫ t in Set.Ioi 1, deriv f t * ∑ k ∈ Icc 0 ⌊t⌋₊, c k)) := by
     refine Tendsto.congr' h (intervalIntegral_tendsto_integral_Ioi _ ?_ tendsto_natCast_atTop_atTop)
-    exact integrableOn_Ici_iff_integrableOn_Ioi.mp
+    exact integrableOn_Ici_iff_integrableOn_Ioi (by finiteness) |>.mp
       <| (locallyIntegrableOn_mul_sum_Icc c zero_le_one hf_int).integrableOn_of_isBigO_atTop
         hg_dom hg_int
   refine (h_lim.sub h_lim').congr (fun _ ↦ ?_)
@@ -331,7 +331,7 @@ private theorem summable_mul_of_bigO_atTop_aux (m : ℕ)
       · exact add_le_add_left
           (le_trans (neg_le_abs _) (Real.norm_eq_abs _ ▸ norm_integral_le_integral_norm _)) _
       · refine add_le_add_left (setIntegral_mono_set ?_ ?_ Set.Ioc_subset_Ioi_self.eventuallyLE) C₁
-        · exact integrableOn_Ici_iff_integrableOn_Ioi.mp <|
+        · exact integrableOn_Ici_iff_integrableOn_Ioi (by finiteness) |>.mp <|
             (integrable_norm_iff h_mes.aestronglyMeasurable).mpr <|
               (locallyIntegrableOn_mul_sum_Icc _ m.cast_nonneg hf_int).integrableOn_of_isBigO_atTop
                 hg₁ hg₂

--- a/Mathlib/NumberTheory/AbelSummation.lean
+++ b/Mathlib/NumberTheory/AbelSummation.lean
@@ -262,7 +262,7 @@ theorem tendsto_sum_mul_atTop_nhds_one_sub_integral
       atTop (𝓝 (∫ t in Set.Ioi 0, deriv f t * ∑ k ∈ Icc 0 ⌊t⌋₊, c k)) := by
     refine Tendsto.congr (fun _ ↦ by rw [← integral_of_le (Nat.cast_nonneg _)]) ?_
     refine intervalIntegral_tendsto_integral_Ioi _ ?_ tendsto_natCast_atTop_atTop
-    exact integrableOn_Ici_iff_integrableOn_Ioi (by finiteness) |>.mp
+    exact Iff.mp integrableOn_Ici_iff_integrableOn_Ioi
       <| (locallyIntegrableOn_mul_sum_Icc c le_rfl hf_int).integrableOn_of_isBigO_atTop
         hg_dom hg_int
   refine (h_lim.sub h_lim').congr (fun _ ↦ ?_)
@@ -284,7 +284,7 @@ theorem tendsto_sum_mul_atTop_nhds_one_sub_integral₀ (hc : c 0 = 0)
   have h_lim' : Tendsto (fun n : ℕ ↦ ∫ t in Set.Ioc (1 : ℝ) n, deriv f t * ∑ k ∈ Icc 0 ⌊t⌋₊, c k)
       atTop (𝓝 (∫ t in Set.Ioi 1, deriv f t * ∑ k ∈ Icc 0 ⌊t⌋₊, c k)) := by
     refine Tendsto.congr' h (intervalIntegral_tendsto_integral_Ioi _ ?_ tendsto_natCast_atTop_atTop)
-    exact integrableOn_Ici_iff_integrableOn_Ioi (by finiteness) |>.mp
+    exact Iff.mp integrableOn_Ici_iff_integrableOn_Ioi
       <| (locallyIntegrableOn_mul_sum_Icc c zero_le_one hf_int).integrableOn_of_isBigO_atTop
         hg_dom hg_int
   refine (h_lim.sub h_lim').congr (fun _ ↦ ?_)
@@ -331,7 +331,7 @@ private theorem summable_mul_of_bigO_atTop_aux (m : ℕ)
       · exact add_le_add_left
           (le_trans (neg_le_abs _) (Real.norm_eq_abs _ ▸ norm_integral_le_integral_norm _)) _
       · refine add_le_add_left (setIntegral_mono_set ?_ ?_ Set.Ioc_subset_Ioi_self.eventuallyLE) C₁
-        · exact integrableOn_Ici_iff_integrableOn_Ioi (by finiteness) |>.mp <|
+        · exact Iff.mp integrableOn_Ici_iff_integrableOn_Ioi <|
             (integrable_norm_iff h_mes.aestronglyMeasurable).mpr <|
               (locallyIntegrableOn_mul_sum_Icc _ m.cast_nonneg hf_int).integrableOn_of_isBigO_atTop
                 hg₁ hg₂

--- a/Mathlib/NumberTheory/LSeries/SumCoeff.lean
+++ b/Mathlib/NumberTheory/LSeries/SumCoeff.lean
@@ -56,7 +56,7 @@ private theorem LSeriesSummable_of_sum_norm_bigO_aux (hf : f 0 = 0)
   simp_rw [LSeriesSummable, funext (LSeries.term_def₀ hf s), mul_comm (f _)]
   refine summable_mul_of_bigO_atTop' (f := fun t ↦ (t : ℂ) ^ (-s))
     (g := fun t ↦ t ^ (-(s.re + 1) + r)) _ h₃ ?_ ?_ ?_ ?_
-  · refine (integrableOn_Ici_iff_integrableOn_Ioi.mpr
+  · refine (integrableOn_Ici_iff_integrableOn_Ioi (by finiteness) |>.mpr
       (integrableOn_Ioi_deriv_norm_ofReal_cpow zero_lt_one ?_)).locallyIntegrableOn
     exact neg_re _ ▸ neg_nonpos.mpr <| hr.trans hs.le
   · refine (IsBigO.mul_atTop_rpow_natCast_of_isBigO_rpow _ _ _ ?_ hO h₂).congr_right (by simp)
@@ -113,7 +113,7 @@ private theorem LSeries_eq_mul_integral_aux {f : ℕ → ℂ} (hf : f 0 = 0) {r 
     rw [deriv_ofReal_cpow_const (zero_lt_one.trans ht).ne', h₄]
     · ring_nf
     · exact neg_ne_zero.mpr <| ne_zero_of_re_pos (hr.trans_lt hs)
-  · refine (integrableOn_Ici_iff_integrableOn_Ioi.mpr <|
+  · refine (integrableOn_Ici_iff_integrableOn_Ioi (by finiteness) |>.mpr <|
       integrableOn_Ioi_deriv_ofReal_cpow zero_lt_one
         (by simpa using hr.trans_lt hs)).locallyIntegrableOn
   · have hlim : Tendsto (fun n : ℕ ↦ (n : ℝ) ^ (-(s.re - r))) atTop (𝓝 0) :=

--- a/Mathlib/NumberTheory/LSeries/SumCoeff.lean
+++ b/Mathlib/NumberTheory/LSeries/SumCoeff.lean
@@ -56,7 +56,7 @@ private theorem LSeriesSummable_of_sum_norm_bigO_aux (hf : f 0 = 0)
   simp_rw [LSeriesSummable, funext (LSeries.term_def₀ hf s), mul_comm (f _)]
   refine summable_mul_of_bigO_atTop' (f := fun t ↦ (t : ℂ) ^ (-s))
     (g := fun t ↦ t ^ (-(s.re + 1) + r)) _ h₃ ?_ ?_ ?_ ?_
-  · refine (integrableOn_Ici_iff_integrableOn_Ioi (by finiteness) |>.mpr
+  · refine (Iff.mpr integrableOn_Ici_iff_integrableOn_Ioi
       (integrableOn_Ioi_deriv_norm_ofReal_cpow zero_lt_one ?_)).locallyIntegrableOn
     exact neg_re _ ▸ neg_nonpos.mpr <| hr.trans hs.le
   · refine (IsBigO.mul_atTop_rpow_natCast_of_isBigO_rpow _ _ _ ?_ hO h₂).congr_right (by simp)
@@ -113,7 +113,7 @@ private theorem LSeries_eq_mul_integral_aux {f : ℕ → ℂ} (hf : f 0 = 0) {r 
     rw [deriv_ofReal_cpow_const (zero_lt_one.trans ht).ne', h₄]
     · ring_nf
     · exact neg_ne_zero.mpr <| ne_zero_of_re_pos (hr.trans_lt hs)
-  · refine (integrableOn_Ici_iff_integrableOn_Ioi (by finiteness) |>.mpr <|
+  · refine (Iff.mpr integrableOn_Ici_iff_integrableOn_Ioi <|
       integrableOn_Ioi_deriv_ofReal_cpow zero_lt_one
         (by simpa using hr.trans_lt hs)).locallyIntegrableOn
   · have hlim : Tendsto (fun n : ℕ ↦ (n : ℝ) ^ (-(s.re - r))) atTop (𝓝 0) :=


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
