### PR TITLE
[Merged by Bors] - docs(Simproc/Divisors): fix module docstring

### DIFF
--- a/Mathlib/Tactic/Simproc/Divisors.lean
+++ b/Mathlib/Tactic/Simproc/Divisors.lean
@@ -9,8 +9,8 @@ import Mathlib.Util.Qq
 /-! # Divisor Simprocs
 
 This file implements (d)simprocs to compute various objects related to divisors:
-- `Nat.divisorsEq`: computes `Nat.divisors n` for explicit values of `n`
-- `Nat.properDivisorsEq`: computes `Nat.properDivisors n` for explicit values of `n`
+- `Nat.divisors_ofNat`: computes `Nat.divisors n` for explicit values of `n`
+- `Nat.properDivisors_ofNat`: computes `Nat.properDivisors n` for explicit values of `n`
 
 -/
 

--- a/Mathlib/Tactic/Simproc/Divisors.lean
+++ b/Mathlib/Tactic/Simproc/Divisors.lean
@@ -16,15 +16,15 @@ This file implements (d)simprocs to compute various objects related to divisors:
 
 open Lean Meta Simp Qq
 
-/-- The `Nat.divisorsEq` computes the finset `Nat.divisors n` when `n` is a natural number
-literal. For instance, this simplifies `Nat.divisors 6` to `{1, 2, 3, 6}`. -/
+/-- The dsimproc `Nat.divisors_ofNat` computes the finset `Nat.divisors n` when `n` is a
+numeral. For instance, this simplifies `Nat.divisors 6` to `{1, 2, 3, 6}`. -/
 dsimproc_decl Nat.divisors_ofNat (Nat.divisors _) := fun e => do
   unless e.isAppOfArity `Nat.divisors 1 do return .continue
   let some n ← fromExpr? e.appArg! | return .continue
   return .done <| mkSetLiteralQ q(Finset ℕ) <| ((unsafe n.divisors.val.unquot).map mkNatLit)
 
-/-- Compute the finset `Nat.properDivisorsEq n` when `n` is a numeral.
-For instance, this simplifies `Nat.properDivisorsEq 12` to `{1, 2, 3, 4, 6}`. -/
+/-- The dsimproc `Nat.properDivisors_ofNat` computes the finset `Nat.properDivisors n` when
+`n` is a numeral. For instance, this simplifies `Nat.properDivisors 12` to `{1, 2, 3, 4, 6}`. -/
 dsimproc_decl Nat.properDivisors_ofNat (Nat.properDivisors _) := fun e => do
   unless e.isAppOfArity `Nat.properDivisors 1 do return .continue
   let some n ← fromExpr? e.appArg! | return .continue


### PR DESCRIPTION
Fix the module docstring to reflect the actual names of the dsimprocs

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
