### PR TITLE
[Merged by Bors] - feat(CategoryTheory/Limits): removed possibly faulty simp theorem

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/PullbackCone.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/PullbackCone.lean
@@ -92,10 +92,8 @@ abbrev fst (t : PullbackCone f g) : t.pt ⟶ X :=
 abbrev snd (t : PullbackCone f g) : t.pt ⟶ Y :=
   t.π.app WalkingCospan.right
 
-@[simp]
 theorem π_app_left (c : PullbackCone f g) : c.π.app WalkingCospan.left = c.fst := rfl
 
-@[simp]
 theorem π_app_right (c : PullbackCone f g) : c.π.app WalkingCospan.right = c.snd := rfl
 
 @[simp]


### PR DESCRIPTION
As discussed [here](https://leanprover.zulipchat.com/#narrow/channel/113489-new-members/topic/.E2.9C.94.20Maximum.20recursion.20error.20at.20simp.20tactic/with/530502013), I got an infinite simp loop where it repeatedly tried to apply `PullbackCone.π_app_left`. This was the definition from mathlib:

```
/-- The first projection of a pullback cone. -/
abbrev fst (t : PullbackCone f g) : t.pt ⟶ X :=
  t.π.app WalkingCospan.left
...
@[simp]
theorem π_app_left (c : PullbackCone f g) : c.π.app WalkingCospan.left = c.fst := rfl
```

Seems like it unfolded the abbrev to immedeately apply the theorem again. So I removed the simp tags, let's see if the build runs through.

--- 
EDIT: Sorry, I used `π_app_left` in the branch name, hence the warning above "The head ref may contain hidden characters".

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
