### PR TITLE
[Merged by Bors] - chore(RingTheory): use `extend` instead of `abbrev` in `IsS(emis)impleModule`

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Simple.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Simple.lean
@@ -20,8 +20,9 @@ variable {R M : Type*} [Ring R] [AddCommGroup M] [Module R M]
 
 open CategoryTheory ModuleCat
 
-theorem simple_iff_isSimpleModule : Simple (of R M) ↔ IsSimpleModule R M :=
-  (simple_iff_subobject_isSimpleOrder _).trans (subobjectModule (of R M)).isSimpleOrder_iff
+theorem simple_iff_isSimpleModule : Simple (of R M) ↔ IsSimpleModule R M := by
+  rw [simple_iff_subobject_isSimpleOrder, (subobjectModule (of R M)).isSimpleOrder_iff,
+    isSimpleModule_iff]
 
 theorem simple_iff_isSimpleModule' (M : ModuleCat R) : Simple M ↔ IsSimpleModule R M :=
   simple_iff_isSimpleModule
@@ -41,4 +42,5 @@ attribute [local instance] moduleOfAlgebraModule isScalarTower_of_algebra_module
 /-- Any `k`-algebra module which is 1-dimensional over `k` is simple. -/
 theorem simple_of_finrank_eq_one {k : Type*} [Field k] [Algebra k R] {V : ModuleCat R}
     (h : finrank k V = 1) : Simple V :=
-  (simple_iff_isSimpleModule' V).mpr (is_simple_module_of_finrank_eq_one h)
+  (simple_iff_isSimpleModule' V).mpr <| (isSimpleModule_iff ..).mpr <|
+    is_simple_module_of_finrank_eq_one h

--- a/Mathlib/Algebra/Module/PID.lean
+++ b/Mathlib/Algebra/Module/PID.lean
@@ -64,7 +64,7 @@ theorem Submodule.isSemisimple_torsionBy_of_irreducible {a : R} (h : Irreducible
     IsSemisimpleModule R (torsionBy R M a) :=
   haveI := PrincipalIdealRing.isMaximal_of_irreducible h
   letI := Ideal.Quotient.field (R ∙ a)
-  (submodule_torsionBy_orderIso a).complementedLattice
+  (isSemisimpleModule_iff ..).mpr (submodule_torsionBy_orderIso a).complementedLattice
 
 variable [IsDomain R]
 

--- a/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Irreducible.lean
@@ -58,7 +58,7 @@ instance [Nontrivial M] : Nontrivial P.invtRootSubmodule where
 lemma isSimpleModule_weylGroupRootRep_iff [Nontrivial M] :
     IsSimpleModule (MonoidAlgebra R P.weylGroup) P.weylGroupRootRep.asModule ↔
     ∀ (q : Submodule R M), (∀ i, q ∈ invtSubmodule (P.reflection i)) → q ≠ ⊥ → q = ⊤ := by
-  rw [IsSimpleModule, ← P.weylGroupRootRep.mapSubmodule.isSimpleOrder_iff]
+  rw [isSimpleModule_iff, ← P.weylGroupRootRep.mapSubmodule.isSimpleOrder_iff]
   refine ⟨fun h q hq₁ hq₂ ↦ ?_, fun h ↦ ⟨fun q ↦ ?_⟩⟩
   · suffices ∀ g : P.weylGroup, q ∈ invtSubmodule (P.weylGroupRootRep g) by
       let q' : P.weylGroupRootRep.invtSubmodule :=

--- a/Mathlib/LinearAlgebra/Semisimple.lean
+++ b/Mathlib/LinearAlgebra/Semisimple.lean
@@ -67,7 +67,7 @@ variable {f}
 See also `Module.End.isSemisimple_iff`. -/
 lemma isSemisimple_iff' :
     f.IsSemisimple ↔ ∀ p : invtSubmodule f, ∃ q : invtSubmodule f, IsCompl p q := by
-  rw [IsSemisimple, IsSemisimpleModule, (AEval.mapSubmodule R M f).symm.complementedLattice_iff,
+  rw [IsSemisimple, isSemisimpleModule_iff, (AEval.mapSubmodule R M f).symm.complementedLattice_iff,
     complementedLattice_iff]
   rfl
 
@@ -81,7 +81,7 @@ lemma isSemisimple_restrict_iff (p) (hp : p ∈ invtSubmodule f) :
   let e : Submodule R[X] (AEval' (f.restrict hp)) ≃o Iic (AEval.mapSubmodule R M f ⟨p, hp⟩) :=
     (Submodule.orderIsoMapComap <| AEval.restrict_equiv_mapSubmodule f p hp).trans
       (Submodule.mapIic _)
-  simp_rw [IsSemisimple, IsSemisimpleModule, e.complementedLattice_iff, disjoint_iff,
+  simp_rw [IsSemisimple, isSemisimpleModule_iff, e.complementedLattice_iff, disjoint_iff,
     ← (OrderIso.Iic _ _).complementedLattice_iff, Iic.complementedLattice_iff, Subtype.forall,
     Subtype.exists, Subtype.mk_le_mk, Sublattice.mk_inf_mk, Sublattice.mk_sup_mk, Subtype.mk.injEq,
     exists_and_left, exists_and_right, invtSubmodule.mk_eq_bot_iff, exists_prop, and_assoc]

--- a/Mathlib/LinearAlgebra/Semisimple.lean
+++ b/Mathlib/LinearAlgebra/Semisimple.lean
@@ -120,7 +120,8 @@ protected lemma _root_.LinearEquiv.isSemisimple_iff {M₂ : Type*} [AddCommGroup
     f.IsSemisimple ↔ g.IsSemisimple := by
   let e : AEval' f ≃ₗ[R[X]] AEval' g := LinearEquiv.ofAEval _ (e.trans (AEval'.of g)) fun x ↦ by
     simpa [AEval'.X_smul_of] using LinearMap.congr_fun he x
-  exact (Submodule.orderIsoMapComap e).complementedLattice_iff
+  simp_rw [IsSemisimple, isSemisimpleModule_iff,
+    (Submodule.orderIsoMapComap e).complementedLattice_iff]
 
 lemma eq_zero_of_isNilpotent_isSemisimple (hn : IsNilpotent f) (hs : f.IsSemisimple) : f = 0 := by
   have ⟨n, h0⟩ := hn
@@ -166,7 +167,7 @@ lemma IsSemisimple.restrict {p : Submodule R M} (hp : p ∈ f.invtSubmodule) (hf
       Iic (AEval.mapSubmodule R M f ⟨p, hp⟩) :=
     (Submodule.orderIsoMapComap <| AEval.restrict_equiv_mapSubmodule f p hp).trans <|
       Submodule.mapIic _
-  exact e.complementedLattice_iff.mpr inferInstance
+  exact (isSemisimpleModule_iff ..).mpr (e.complementedLattice_iff.mpr inferInstance)
 
 lemma IsSemisimple.isFinitelySemisimple (hf : f.IsSemisimple) :
     f.IsFinitelySemisimple :=

--- a/Mathlib/RepresentationTheory/Maschke.lean
+++ b/Mathlib/RepresentationTheory/Maschke.lean
@@ -159,10 +159,10 @@ theorem exists_isCompl (p : Submodule (MonoidAlgebra k G) V) :
   rcases MonoidAlgebra.exists_leftInverse_of_injective p.subtype p.ker_subtype with ⟨f, hf⟩
   exact ⟨LinearMap.ker f, LinearMap.isCompl_of_proj <| DFunLike.congr_fun hf⟩
 
-/-- This also implies instances `IsSemisimpleModule (MonoidAlgebra k G) V` and
+/-- This also implies instances `ComplementedLattice (Submodule (MonoidAlgebra k G) V)` and
 `IsSemisimpleRing (MonoidAlgebra k G)`. -/
-instance complementedLattice : ComplementedLattice (Submodule (MonoidAlgebra k G) V) :=
-  ⟨exists_isCompl⟩
+instance : IsSemisimpleModule (MonoidAlgebra k G) V where
+  exists_isCompl := exists_isCompl
 
 instance [AddGroup G] : IsSemisimpleRing (AddMonoidAlgebra k G) :=
   haveI : NeZero (Fintype.card (Multiplicative G) : k) := by

--- a/Mathlib/RingTheory/Length.lean
+++ b/Mathlib/RingTheory/Length.lean
@@ -259,7 +259,7 @@ lemma Module.length_of_free_of_finite
 lemma Module.length_eq_one_iff :
     Module.length R M = 1 ↔ IsSimpleModule R M := by
   rw [← WithBot.coe_inj, Module.coe_length, WithBot.coe_one,
-    Order.krullDim_eq_one_iff_of_boundedOrder]
+    Order.krullDim_eq_one_iff_of_boundedOrder, isSimpleModule_iff]
 
 variable (R M) in
 @[simp]

--- a/Mathlib/RingTheory/SimpleModule/Basic.lean
+++ b/Mathlib/RingTheory/SimpleModule/Basic.lean
@@ -53,20 +53,22 @@ import Mathlib.RingTheory.Noetherian.Defs
 variable {ι : Type*} (R S : Type*) [Ring R] [Ring S] (M : Type*) [AddCommGroup M] [Module R M]
 
 /-- A module is simple when it has only two submodules, `⊥` and `⊤`. -/
-class IsSimpleModule extends
+@[mk_iff] class IsSimpleModule extends
   IsSimpleOrder (Submodule R M)
 
 /-- A module is semisimple when every submodule has a complement, or equivalently, the module
   is a direct sum of simple modules. -/
-class IsSemisimpleModule extends
+@[mk_iff] class IsSemisimpleModule extends
   ComplementedLattice (Submodule R M)
+
+instance [IsSimpleModule R M] : IsSemisimpleModule R M where
 
 /-- A ring is semisimple if it is semisimple as a module over itself. -/
 abbrev IsSemisimpleRing := IsSemisimpleModule R R
 
 variable {R S} in
-theorem RingEquiv.isSemisimpleRing (e : R ≃+* S) [IsSemisimpleRing R] : IsSemisimpleRing S :=
-  (Submodule.orderIsoMapComap e.toSemilinearEquiv).complementedLattice
+theorem RingEquiv.isSemisimpleRing (e : R ≃+* S) [IsSemisimpleRing R] : IsSemisimpleRing S where
+  __ := (Submodule.orderIsoMapComap e.toSemilinearEquiv).complementedLattice
 
 variable {R S} in
 theorem RingEquiv.isSemisimpleRing_iff (e : R ≃+* S) : IsSemisimpleRing R ↔ IsSemisimpleRing S :=
@@ -82,25 +84,24 @@ theorem IsSimpleModule.nontrivial [IsSimpleModule R M] : Nontrivial M :=
 variable {m : Submodule R M} {N : Type*} [AddCommGroup N] {R S M}
 
 theorem LinearMap.isSimpleModule_iff_of_bijective [Module S N] {σ : R →+* S} [RingHomSurjective σ]
-    (l : M →ₛₗ[σ] N) (hl : Function.Bijective l) : IsSimpleModule R M ↔ IsSimpleModule S N :=
-  (Submodule.orderIsoMapComapOfBijective l hl).isSimpleOrder_iff
+    (l : M →ₛₗ[σ] N) (hl : Function.Bijective l) : IsSimpleModule R M ↔ IsSimpleModule S N := by
+  simp_rw [isSimpleModule_iff, (Submodule.orderIsoMapComapOfBijective l hl).isSimpleOrder_iff]
 
 variable [Module R N]
 
-theorem IsSimpleModule.congr (e : M ≃ₗ[R] N) [IsSimpleModule R N] : IsSimpleModule R M :=
-  (Submodule.orderIsoMapComap e).isSimpleOrder
+theorem IsSimpleModule.congr (e : M ≃ₗ[R] N) [IsSimpleModule R N] : IsSimpleModule R M where
+  __ := (Submodule.orderIsoMapComap e).isSimpleOrder
 
 theorem LinearEquiv.isSimpleModule_iff (e : M ≃ₗ[R] N) : IsSimpleModule R M ↔ IsSimpleModule R N :=
   ⟨(·.congr e.symm), (·.congr e)⟩
 
 theorem isSimpleModule_iff_isAtom : IsSimpleModule R m ↔ IsAtom m := by
-  rw [← Set.isSimpleOrder_Iic_iff_isAtom]
+  rw [← Set.isSimpleOrder_Iic_iff_isAtom, isSimpleModule_iff]
   exact m.mapIic.isSimpleOrder_iff
 
 theorem isSimpleModule_iff_isCoatom : IsSimpleModule R (M ⧸ m) ↔ IsCoatom m := by
-  rw [← Set.isSimpleOrder_Ici_iff_isCoatom]
-  apply OrderIso.isSimpleOrder_iff
-  exact Submodule.comapMkQRelIso m
+  rw [← Set.isSimpleOrder_Ici_iff_isCoatom, isSimpleModule_iff]
+  exact (Submodule.comapMkQRelIso m).isSimpleOrder_iff
 
 theorem covBy_iff_quot_is_simple {A B : Submodule R M} (hAB : A ≤ B) :
     A ⋖ B ↔ IsSimpleModule R (B ⧸ Submodule.comap B.subtype A) := by
@@ -162,11 +163,12 @@ theorem IsSimpleModule.annihilator_isMaximal {R} [CommRing R] [Module R M]
   rwa [e.annihilator_eq, I.annihilator_quotient]
 
 theorem isSimpleModule_iff_toSpanSingleton_surjective : IsSimpleModule R M ↔
-    Nontrivial M ∧ ∀ x : M, x ≠ 0 → Function.Surjective (LinearMap.toSpanSingleton R M x) :=
-  ⟨fun h ↦ ⟨h.nontrivial, fun _ ↦ h.toSpanSingleton_surjective⟩, fun ⟨_, h⟩ ↦
+    Nontrivial M ∧ ∀ x : M, x ≠ 0 → Function.Surjective (LinearMap.toSpanSingleton R M x) where
+  mp h := ⟨h.nontrivial, fun _ ↦ h.toSpanSingleton_surjective⟩
+  mpr := fun ⟨_, h⟩ ↦ (isSimpleModule_iff R M).mpr
     ⟨fun m ↦ or_iff_not_imp_left.mpr fun ne_bot ↦
       have ⟨x, hxm, hx0⟩ := m.ne_bot_iff.mp ne_bot
-      top_unique <| fun z _ ↦ by obtain ⟨y, rfl⟩ := h x hx0 z; exact m.smul_mem _ hxm⟩⟩
+      top_unique <| fun z _ ↦ by obtain ⟨y, rfl⟩ := h x hx0 z; exact m.smul_mem _ hxm⟩
 
 /-- A ring is a simple module over itself iff it is a division ring. -/
 theorem isSimpleModule_self_iff_isUnit :
@@ -179,8 +181,8 @@ theorem isSimpleModule_self_iff_isUnit :
     exact ⟨⟨x, y, left_inv_eq_right_inv hzy hyx ▸ hzy, hyx⟩, rfl⟩
 
 theorem IsSemisimpleModule.of_sSup_simples_eq_top
-    (h : sSup { m : Submodule R M | IsSimpleModule R m } = ⊤) : IsSemisimpleModule R M :=
-  complementedLattice_of_sSup_atoms_eq_top (by simp_rw [← h, isSimpleModule_iff_isAtom])
+    (h : sSup { m : Submodule R M | IsSimpleModule R m } = ⊤) : IsSemisimpleModule R M where
+  __ := complementedLattice_of_sSup_atoms_eq_top (by simp_rw [← h, isSimpleModule_iff_isAtom])
 
 namespace IsSemisimpleModule
 
@@ -222,14 +224,14 @@ theorem annihilator_isRadical (R) [CommRing R] [Module R M] [IsSemisimpleModule 
   rw [← Submodule.annihilator_top, ← sSup_simples_eq_top, sSup_eq_iSup', Submodule.annihilator_iSup]
   exact Ideal.isRadical_iInf _ fun i ↦ (i.2.annihilator_isMaximal).isPrime.isRadical
 
-instance submodule {m : Submodule R M} : IsSemisimpleModule R m :=
-  m.mapIic.complementedLattice_iff.2 IsModularLattice.complementedLattice_Iic
+instance submodule {m : Submodule R M} : IsSemisimpleModule R m where
+  __ := m.mapIic.complementedLattice_iff.2 IsModularLattice.complementedLattice_Iic
 
 variable {R M}
 open LinearMap
 
-theorem congr (e : N ≃ₗ[R] M) : IsSemisimpleModule R N :=
-  (Submodule.orderIsoMapComap e.symm).complementedLattice
+theorem congr (e : N ≃ₗ[R] M) : IsSemisimpleModule R N where
+  __ := (Submodule.orderIsoMapComap e.symm).complementedLattice
 
 theorem of_injective (f : N →ₗ[R] M) (hf : Function.Injective f) : IsSemisimpleModule R N :=
   congr (Submodule.topEquiv.symm.trans <| Submodule.equivMapOfInjective f hf _)
@@ -256,8 +258,9 @@ variable {M' : Type*} [AddCommGroup M'] [Module R M'] {N'} [AddCommGroup N'] [Mo
 
 theorem _root_.LinearMap.isSemisimpleModule_iff_of_bijective
     [RingHomSurjective σ] (hl : Function.Bijective l) :
-    IsSemisimpleModule R M' ↔ IsSemisimpleModule S N' :=
-  (Submodule.orderIsoMapComapOfBijective l hl).complementedLattice_iff
+    IsSemisimpleModule R M' ↔ IsSemisimpleModule S N' := by
+  simp_rw [isSemisimpleModule_iff,
+    (Submodule.orderIsoMapComapOfBijective l hl).complementedLattice_iff]
 
 -- TODO: generalize Submodule.equivMapOfInjective from InvPair to RingHomSurjective
 proof_wanted _root_.LinearMap.isSemisimpleModule_of_injective (_ : Function.Injective l)
@@ -284,6 +287,7 @@ theorem sSup_simples_eq_top_iff_isSemisimpleModule :
 lemma isSemisimpleModule_of_isSemisimpleModule_submodule {s : Set ι} {p : ι → Submodule R M}
     (hp : ∀ i ∈ s, IsSemisimpleModule R (p i)) (hp' : ⨆ i ∈ s, p i = ⊤) :
     IsSemisimpleModule R M := by
+  simp_rw [isSemisimpleModule_iff] at hp ⊢
   refine complementedLattice_of_complementedLattice_Iic (fun i hi ↦ ?_) hp'
   simpa only [← (p i).mapIic.complementedLattice_iff] using hp i hi
 

--- a/Mathlib/RingTheory/SimpleModule/Basic.lean
+++ b/Mathlib/RingTheory/SimpleModule/Basic.lean
@@ -53,12 +53,12 @@ import Mathlib.RingTheory.Noetherian.Defs
 variable {ι : Type*} (R S : Type*) [Ring R] [Ring S] (M : Type*) [AddCommGroup M] [Module R M]
 
 /-- A module is simple when it has only two submodules, `⊥` and `⊤`. -/
-abbrev IsSimpleModule extends
+class IsSimpleModule extends
   IsSimpleOrder (Submodule R M)
 
 /-- A module is semisimple when every submodule has a complement, or equivalently, the module
   is a direct sum of simple modules. -/
-abbrev IsSemisimpleModule extends
+class IsSemisimpleModule extends
   ComplementedLattice (Submodule R M)
 
 /-- A ring is semisimple if it is semisimple as a module over itself. -/

--- a/Mathlib/RingTheory/SimpleModule/Basic.lean
+++ b/Mathlib/RingTheory/SimpleModule/Basic.lean
@@ -53,12 +53,12 @@ import Mathlib.RingTheory.Noetherian.Defs
 variable {ι : Type*} (R S : Type*) [Ring R] [Ring S] (M : Type*) [AddCommGroup M] [Module R M]
 
 /-- A module is simple when it has only two submodules, `⊥` and `⊤`. -/
-abbrev IsSimpleModule :=
+abbrev IsSimpleModule extends
   IsSimpleOrder (Submodule R M)
 
 /-- A module is semisimple when every submodule has a complement, or equivalently, the module
   is a direct sum of simple modules. -/
-abbrev IsSemisimpleModule :=
+abbrev IsSemisimpleModule extends
   ComplementedLattice (Submodule R M)
 
 /-- A ring is semisimple if it is semisimple as a module over itself. -/

--- a/Mathlib/RingTheory/SimpleModule/Basic.lean
+++ b/Mathlib/RingTheory/SimpleModule/Basic.lean
@@ -63,6 +63,8 @@ variable {ι : Type*} (R S : Type*) [Ring R] [Ring S] (M : Type*) [AddCommGroup 
 
 instance [IsSimpleModule R M] : IsSemisimpleModule R M where
 
+instance (R) [DivisionRing R] : IsSimpleModule R R where
+
 /-- A ring is semisimple if it is semisimple as a module over itself. -/
 abbrev IsSemisimpleRing := IsSemisimpleModule R R
 

--- a/Mathlib/RingTheory/SimpleModule/Rank.lean
+++ b/Mathlib/RingTheory/SimpleModule/Rank.lean
@@ -14,4 +14,4 @@ theorem isSimpleModule_iff_finrank_eq_one {R M} [DivisionRing R] [AddCommGroup M
     IsSimpleModule R M ↔ Module.finrank R M = 1 :=
   ⟨fun h ↦ have := h.nontrivial; have ⟨v, hv⟩ := exists_ne (0 : M)
     (finrank_eq_one_iff_of_nonzero' v hv).mpr (IsSimpleModule.toSpanSingleton_surjective R hv),
-  is_simple_module_of_finrank_eq_one⟩
+  (isSimpleModule_iff ..).mpr ∘ is_simple_module_of_finrank_eq_one⟩


### PR DESCRIPTION
Zulip: https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/type-class.20inference.20slow.2Ftiming.20out/near/530558662

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
