### PR TITLE
[Merged by Bors] - refactor: make `⇑e⁻¹ = ⇑e.symm` simp

### DIFF
--- a/Mathlib/Algebra/Algebra/Equiv.lean
+++ b/Mathlib/Algebra/Algebra/Equiv.lean
@@ -641,6 +641,8 @@ theorem mul_apply (e₁ e₂ : A₁ ≃ₐ[R] A₁) (x : A₁) : (e₁ * e₂) x
 
 lemma aut_inv (ϕ : A₁ ≃ₐ[R] A₁) : ϕ⁻¹ = ϕ.symm := rfl
 
+@[simp] lemma coe_inv (ϕ : A₁ ≃ₐ[R] A₁) : ⇑ϕ⁻¹ = ⇑ϕ.symm := rfl
+
 @[simp] theorem coe_pow (e : A₁ ≃ₐ[R] A₁) (n : ℕ) : ⇑(e ^ n) = e^[n] :=
   n.rec (by ext; simp) fun _ ih ↦ by ext; simp [pow_succ, ih]
 

--- a/Mathlib/Algebra/Group/End.lean
+++ b/Mathlib/Algebra/Group/End.lean
@@ -98,11 +98,11 @@ theorem mul_apply (f g : Perm α) (x) : (f * g) x = f (g x) :=
 theorem one_apply (x) : (1 : Perm α) x = x :=
   rfl
 
-@[simp]
+@[deprecated symm_apply_apply (since := "2025-08-16")]
 theorem inv_apply_self (f : Perm α) (x) : f⁻¹ (f x) = x :=
   f.symm_apply_apply x
 
-@[simp]
+@[deprecated apply_symm_apply (since := "2025-08-16")]
 theorem apply_inv_self (f : Perm α) (x) : f (f⁻¹ x) = x :=
   f.apply_symm_apply x
 
@@ -114,6 +114,8 @@ theorem mul_def (f g : Perm α) : f * g = g.trans f :=
 
 theorem inv_def (f : Perm α) : f⁻¹ = f.symm :=
   rfl
+
+@[simp] lemma coe_inv (f : Perm α) : ⇑f⁻¹ = ⇑f.symm := rfl
 
 @[simp, norm_cast] lemma coe_one : ⇑(1 : Perm α) = id := rfl
 
@@ -519,7 +521,7 @@ theorem swap_mul_self (i j : α) : swap i j * swap i j = 1 :=
 
 theorem swap_mul_eq_mul_swap (f : Perm α) (x y : α) : swap x y * f = f * swap (f⁻¹ x) (f⁻¹ y) :=
   Equiv.ext fun z => by
-    simp only [Perm.mul_apply, swap_apply_def]; split_ifs <;> simp_all [Perm.eq_inv_iff_eq]
+    simp only [Perm.mul_apply, swap_apply_def]; split_ifs <;> simp_all [eq_symm_apply]
 
 theorem mul_swap_eq_swap_mul (f : Perm α) (x y : α) : f * swap x y = swap (f x) (f y) * f := by
   simp [swap_mul_eq_mul_swap]

--- a/Mathlib/Algebra/Module/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Module/Equiv/Basic.lean
@@ -92,6 +92,8 @@ lemma mul_eq_trans (f g : M ≃ₗ[R] M) : f * g = g.trans f := rfl
 @[simp]
 lemma coe_one : ↑(1 : M ≃ₗ[R] M) = id := rfl
 
+@[simp] lemma coe_inv (f : M ≃ₗ[R] M) : ⇑f⁻¹ = ⇑f.symm := rfl
+
 @[simp]
 lemma coe_toLinearMap_one : (↑(1 : M ≃ₗ[R] M) : M →ₗ[R] M) = LinearMap.id := rfl
 

--- a/Mathlib/Algebra/Order/Rearrangement.lean
+++ b/Mathlib/Algebra/Order/Rearrangement.lean
@@ -87,15 +87,15 @@ theorem MonovaryOn.sum_smul_comp_perm_le_sum_smul (hfg : MonovaryOn f g s)
   grw [← hind]
   obtain hσa | hσa := eq_or_ne a (σ a)
   · rw [hτ, ← hσa, swap_self, trans_refl]
-  have h1s : σ⁻¹ a ∈ s := by
+  have h1s : σ.symm a ∈ s := by
     rw [Ne, ← inv_eq_iff_eq] at hσa
     refine mem_of_mem_insert_of_ne (hσ fun h ↦ hσa ?_) hσa
-    rwa [apply_inv_self, eq_comm] at h
+    rwa [apply_symm_apply, eq_comm] at h
   simp only [← s.sum_erase_add _ h1s, add_comm]
   rw [← add_assoc, ← add_assoc]
-  simp only [hτ, swap_apply_left, Function.comp_apply, Equiv.coe_trans, apply_inv_self]
+  simp only [hτ, swap_apply_left, Function.comp_apply, Equiv.coe_trans, apply_symm_apply]
   refine add_le_add (smul_add_smul_le_smul_add_smul' ?_ ?_) (sum_congr rfl fun x hx ↦ ?_).le
-  · specialize hamax (σ⁻¹ a) h1s
+  · specialize hamax (σ.symm a) h1s
     rw [Prod.Lex.toLex_le_toLex] at hamax
     rcases hamax with hamax | hamax
     · exact hfg (mem_insert_of_mem h1s) (mem_insert_self _ _) hamax
@@ -105,7 +105,7 @@ theorem MonovaryOn.sum_smul_comp_perm_le_sum_smul (hfg : MonovaryOn f g s)
     rcases hamax with hamax | hamax
     · exact hamax.le
     · exact hamax.1.le
-  · rw [mem_erase, Ne, eq_inv_iff_eq] at hx
+  · rw [mem_erase, Ne, eq_symm_apply] at hx
     rw [swap_apply_of_ne_of_ne hx.1 (σ.injective.ne _)]
     rintro rfl
     exact has hx.2
@@ -121,7 +121,7 @@ theorem AntivaryOn.sum_smul_le_sum_smul_comp_perm (hfg : AntivaryOn f g s)
 theorem MonovaryOn.sum_comp_perm_smul_le_sum_smul (hfg : MonovaryOn f g s)
     (hσ : {x | σ x ≠ x} ⊆ s) : ∑ i ∈ s, f (σ i) • g i ≤ ∑ i ∈ s, f i • g i := by
   convert hfg.sum_smul_comp_perm_le_sum_smul
-    (show { x | σ⁻¹ x ≠ x } ⊆ s by simp only [set_support_inv_eq, hσ]) using 1
+    (show { x | σ⁻¹ x ≠ x } ⊆ s by simp [set_support_symm_eq, hσ]) using 1
   exact σ.sum_comp' s (fun i j ↦ f i • g j) hσ
 
 /-- **Rearrangement Inequality**: Pointwise scalar multiplication of `f` and `g` is minimized when
@@ -171,7 +171,7 @@ theorem MonovaryOn.sum_smul_comp_perm_eq_sum_smul_iff (hfg : MonovaryOn f g s)
     ∑ i ∈ s, f i • g (σ i) = ∑ i ∈ s, f i • g i ↔ MonovaryOn f (g ∘ σ) s := by
   classical
   refine ⟨not_imp_not.1 fun h ↦ ?_, fun h ↦ (hfg.sum_smul_comp_perm_le_sum_smul hσ).antisymm <| by
-    simpa using h.sum_smul_comp_perm_le_sum_smul ((set_support_inv_eq _).subset.trans hσ)⟩
+    simpa using h.sum_smul_comp_perm_le_sum_smul ((set_support_symm_eq _).subset.trans hσ)⟩
   rw [MonovaryOn] at h
   push_neg at h
   obtain ⟨x, hx, y, hy, hgxy, hfxy⟩ := h
@@ -204,7 +204,7 @@ monovary together on `s`. Stated by permuting the entries of `f`. -/
 theorem MonovaryOn.sum_comp_perm_smul_eq_sum_smul_iff (hfg : MonovaryOn f g s)
     (hσ : {x | σ x ≠ x} ⊆ s) :
     ∑ i ∈ s, f (σ i) • g i = ∑ i ∈ s, f i • g i ↔ MonovaryOn (f ∘ σ) g s := by
-  have hσinv : { x | σ⁻¹ x ≠ x } ⊆ s := (set_support_inv_eq _).subset.trans hσ
+  have hσinv : { x | σ⁻¹ x ≠ x } ⊆ s := (set_support_symm_eq _).subset.trans hσ
   refine (Iff.trans ?_ <| hfg.sum_smul_comp_perm_eq_sum_smul_iff hσinv).trans
     ⟨fun h ↦ ?_, fun h ↦ ?_⟩
   · apply eq_iff_eq_cancel_right.2

--- a/Mathlib/Data/Fintype/Perm.lean
+++ b/Mathlib/Data/Fintype/Perm.lean
@@ -113,8 +113,8 @@ theorem nodup_permsOfList : ∀ {l : List α}, l.Nodup → (permsOfList l).Nodup
     · intro f hf₁ hf₂
       let ⟨x, hx, hx'⟩ := List.mem_flatMap.1 hf₂
       let ⟨g, hg⟩ := List.mem_map.1 hx'
-      obtain rfl : g⁻¹ x = a := f.injective <| by rw [hmeml hf₁, ← hg.2]; simp
-      have hxa : x ≠ g⁻¹ x := fun h => (List.nodup_cons.1 hl).1 (h ▸ hx)
+      obtain rfl : g.symm x = a := f.injective <| by rw [hmeml hf₁, ← hg.2]; simp
+      have hxa : x ≠ g.symm x := fun h => (List.nodup_cons.1 hl).1 (h ▸ hx)
       exact (List.nodup_cons.1 hl).1 <| mem_of_mem_permsOfList hg.1 (by simpa using hxa)
 
 /-- Given a finset, produce the finset of all permutations of its elements. -/

--- a/Mathlib/FieldTheory/KrullTopology.lean
+++ b/Mathlib/FieldTheory/KrullTopology.lean
@@ -116,7 +116,7 @@ def galGroupBasis (K L : Type*) [Field K] [Field L] [Algebra K L] :
     rw [IntermediateField.mem_fixingSubgroup_iff]
     intro x hx
     change σ (g (σ⁻¹ x)) = x
-    have h_in_F : σ⁻¹ x ∈ F := ⟨x, hx, by dsimp; rw [← AlgEquiv.invFun_eq_symm]; rfl⟩
+    have h_in_F : σ⁻¹ x ∈ F := ⟨x, hx, by dsimp⟩
     have h_g_fix : g (σ⁻¹ x) = σ⁻¹ x := by
       rw [Subgroup.mem_carrier, IntermediateField.mem_fixingSubgroup_iff F g] at hg
       exact hg (σ⁻¹ x) h_in_F

--- a/Mathlib/GroupTheory/Perm/Basic.lean
+++ b/Mathlib/GroupTheory/Perm/Basic.lean
@@ -31,9 +31,11 @@ variable {α : Type u} {β : Type v}
 
 namespace Perm
 
-@[simp] lemma image_inv (f : Perm α) (s : Set α) : ↑f⁻¹ '' s = f ⁻¹' s := f.image_symm_eq_preimage _
+@[deprecated Equiv.image_symm_eq_preimage (since := "2025-08-16")]
+lemma image_inv (f : Perm α) (s : Set α) : ↑f⁻¹ '' s = f ⁻¹' s := f.image_symm_eq_preimage _
 
-@[simp] lemma preimage_inv (f : Perm α) (s : Set α) : ↑f⁻¹ ⁻¹' s = f '' s :=
+@[deprecated Equiv.image_eq_preimage_symm (since := "2025-08-16")]
+lemma preimage_inv (f : Perm α) (s : Set α) : ↑f⁻¹ ⁻¹' s = f '' s :=
   (f.image_eq_preimage_symm _).symm
 
 end Perm

--- a/Mathlib/GroupTheory/Perm/Cycle/Basic.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Basic.lean
@@ -385,16 +385,15 @@ theorem isCycle_swap_mul_aux₂ {α : Type*} [DecidableEq α] :
       ∃ i : ℤ, ((swap x (f x) * f) ^ i) (f x) = b
   | (n : ℕ), _, _, _, hb, h => isCycle_swap_mul_aux₁ n hb h
   | .negSucc n, b, x, f, hb, h => by
-    obtain rfl | hfxb := eq_or_ne (f x) b
-    · exact ⟨0, rfl⟩
+    obtain hfxb | hfxb := eq_or_ne (f x) b
+    · exact ⟨0, hfxb⟩
     obtain ⟨hfb, hbx⟩ : f b ≠ b ∧ b ≠ x := ne_and_ne_of_swap_mul_apply_ne_self hb
     replace hb : (swap x (f.symm x) * f⁻¹) (f.symm b) ≠ f.symm b := by
       rw [mul_apply, swap_apply_def]
       split_ifs <;> simp [symm_apply_eq, eq_symm_apply] at * <;> tauto
     obtain ⟨i, hi⟩ := isCycle_swap_mul_aux₁ n hb <| by
       rw [← mul_apply, ← pow_succ]; simpa [pow_succ', eq_symm_apply] using h
-    refine ⟨-i, ?_⟩
-    rw [← EmbeddingLike.apply_eq_iff_eq (swap x (f⁻¹ x) * f⁻¹)]
+    refine ⟨-i, (swap x (f⁻¹ x) * f⁻¹).injective ?_⟩
     convert hi using 1
     · rw [zpow_neg, ← inv_zpow, ← mul_apply, mul_inv_rev, swap_inv, mul_swap_eq_swap_mul]
       simp [swap_comm _ x, ← mul_apply, -coe_mul, ← inv_def, -coe_inv, ← inv_def, mul_assoc _ f⁻¹,

--- a/Mathlib/GroupTheory/Perm/Cycle/Basic.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Basic.lean
@@ -119,9 +119,13 @@ theorem sameCycle_apply_right : SameCycle f x (f y) ↔ SameCycle f x y := by
 theorem sameCycle_symm_apply_left : SameCycle f (f.symm x) y ↔ SameCycle f x y := by
   rw [← sameCycle_apply_left, apply_symm_apply]
 
+@[deprecated (since := "2025-11-17")] alias sameCycle_inv_apply_left := sameCycle_symm_apply_left
+
 @[simp]
 theorem sameCycle_symm_apply_right : SameCycle f x (f.symm y) ↔ SameCycle f x y := by
   rw [← sameCycle_apply_right, apply_symm_apply]
+
+@[deprecated (since := "2025-11-17")] alias sameCycle_inv_apply_right := sameCycle_symm_apply_right
 
 @[simp]
 theorem sameCycle_zpow_left {n : ℤ} : SameCycle f ((f ^ n) x) y ↔ SameCycle f x y :=

--- a/Mathlib/GroupTheory/Perm/Cycle/Basic.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Basic.lean
@@ -90,7 +90,7 @@ alias ⟨SameCycle.of_inv, SameCycle.inv⟩ := sameCycle_inv
 
 @[simp]
 theorem sameCycle_conj : SameCycle (g * f * g⁻¹) x y ↔ SameCycle f (g⁻¹ x) (g⁻¹ y) :=
-  exists_congr fun i => by simp [conj_zpow, eq_inv_iff_eq]
+  exists_congr fun i => by simp [conj_zpow, eq_symm_apply]
 
 theorem SameCycle.conj : SameCycle f x y → SameCycle (g * f * g⁻¹) (g x) (g y) := by
   simp [sameCycle_conj]
@@ -116,12 +116,12 @@ theorem sameCycle_apply_right : SameCycle f x (f y) ↔ SameCycle f x y := by
   rw [sameCycle_comm, sameCycle_apply_left, sameCycle_comm]
 
 @[simp]
-theorem sameCycle_inv_apply_left : SameCycle f (f⁻¹ x) y ↔ SameCycle f x y := by
-  rw [← sameCycle_apply_left, apply_inv_self]
+theorem sameCycle_symm_apply_left : SameCycle f (f.symm x) y ↔ SameCycle f x y := by
+  rw [← sameCycle_apply_left, apply_symm_apply]
 
 @[simp]
-theorem sameCycle_inv_apply_right : SameCycle f x (f⁻¹ y) ↔ SameCycle f x y := by
-  rw [← sameCycle_apply_right, apply_inv_self]
+theorem sameCycle_symm_apply_right : SameCycle f x (f.symm y) ↔ SameCycle f x y := by
+  rw [← sameCycle_apply_right, apply_symm_apply]
 
 @[simp]
 theorem sameCycle_zpow_left {n : ℤ} : SameCycle f ((f ^ n) x) y ↔ SameCycle f x y :=
@@ -143,9 +143,9 @@ alias ⟨SameCycle.of_apply_left, SameCycle.apply_left⟩ := sameCycle_apply_lef
 
 alias ⟨SameCycle.of_apply_right, SameCycle.apply_right⟩ := sameCycle_apply_right
 
-alias ⟨SameCycle.of_inv_apply_left, SameCycle.inv_apply_left⟩ := sameCycle_inv_apply_left
+alias ⟨SameCycle.of_symm_apply_left, SameCycle.symm_apply_left⟩ := sameCycle_symm_apply_left
 
-alias ⟨SameCycle.of_inv_apply_right, SameCycle.inv_apply_right⟩ := sameCycle_inv_apply_right
+alias ⟨SameCycle.of_symm_apply_right, SameCycle.symm_apply_right⟩ := sameCycle_symm_apply_right
 
 alias ⟨SameCycle.of_pow_left, SameCycle.pow_left⟩ := sameCycle_pow_left
 
@@ -369,7 +369,8 @@ theorem isCycle_swap_mul_aux₁ {α : Type*} [DecidableEq α] :
     · exact ⟨0, hfbx⟩
     have : f b ≠ b ∧ b ≠ x := ne_and_ne_of_swap_mul_apply_ne_self hb
     have hb' : (swap x (f x) * f) (f.symm b) ≠ f.symm b := by
-      simpa [swap_apply_of_ne_of_ne this.2 hfbx.symm, eq_symm_apply] using this.1
+      simpa [swap_apply_of_ne_of_ne this.2 hfbx.symm, eq_symm_apply, f.injective.eq_iff]
+        using this.1
     obtain ⟨i, hi⟩ := hn hb' <| f.injective <| by simpa [pow_succ'] using h
     refine ⟨i + 1, ?_⟩
     rw [add_comm, zpow_add, mul_apply, hi, zpow_one, mul_apply, apply_symm_apply,
@@ -380,23 +381,23 @@ theorem isCycle_swap_mul_aux₂ {α : Type*} [DecidableEq α] :
       ∃ i : ℤ, ((swap x (f x) * f) ^ i) (f x) = b
   | (n : ℕ), _, _, _, hb, h => isCycle_swap_mul_aux₁ n hb h
   | .negSucc n, b, x, f, hb, h => by
-    obtain hfxb | hfxb := eq_or_ne (f x) b
-    · exact ⟨0, hfxb⟩
+    obtain rfl | hfxb := eq_or_ne (f x) b
+    · exact ⟨0, rfl⟩
     obtain ⟨hfb, hbx⟩ : f b ≠ b ∧ b ≠ x := ne_and_ne_of_swap_mul_apply_ne_self hb
     replace hb : (swap x (f.symm x) * f⁻¹) (f.symm b) ≠ f.symm b := by
       rw [mul_apply, swap_apply_def]
       split_ifs <;> simp [symm_apply_eq, eq_symm_apply] at * <;> tauto
     obtain ⟨i, hi⟩ := isCycle_swap_mul_aux₁ n hb <| by
       rw [← mul_apply, ← pow_succ]; simpa [pow_succ', eq_symm_apply] using h
-    refine ⟨-i, (swap x (f⁻¹ x) * f⁻¹).injective ?_⟩
+    refine ⟨-i, ?_⟩
+    rw [← EmbeddingLike.apply_eq_iff_eq (swap x (f⁻¹ x) * f⁻¹)]
     convert hi using 1
     · rw [zpow_neg, ← inv_zpow, ← mul_apply, mul_inv_rev, swap_inv, mul_swap_eq_swap_mul]
-      simp [swap_comm _ x, ← mul_apply, -coe_mul, ← inv_def, ← inv_def, mul_assoc _ f⁻¹,
+      simp [swap_comm _ x, ← mul_apply, -coe_mul, ← inv_def, -coe_inv, ← inv_def, mul_assoc _ f⁻¹,
         ← mul_zpow_mul, mul_assoc _ _ f]
       simp
-    · refine swap_apply_of_ne_of_ne ?_ ?_
-      · simpa [eq_comm, Perm.eq_inv_iff_eq, Perm.inv_eq_iff_eq] using hfxb
-      · simpa [eq_comm, eq_symm_apply, symm_apply_eq]
+    · exact swap_apply_of_ne_of_ne (by simpa [eq_comm, eq_symm_apply, symm_apply_eq] using hfxb)
+        (by simpa [eq_comm, eq_symm_apply, symm_apply_eq])
 
 theorem IsCycle.eq_swap_of_apply_apply_eq_self {α : Type*} [DecidableEq α] {f : Perm α}
     (hf : IsCycle f) {x : α} (hfx : f x ≠ x) (hffx : f (f x) = x) : f = swap x (f x) :=
@@ -765,12 +766,12 @@ theorem IsCycleOn.zpow_apply_eq {s : Finset α} (hf : f.IsCycleOn s) (ha : a ∈
 theorem IsCycleOn.pow_apply_eq_pow_apply {s : Finset α} (hf : f.IsCycleOn s) (ha : a ∈ s)
     {m n : ℕ} : (f ^ m) a = (f ^ n) a ↔ m ≡ n [MOD #s] := by
   rw [Nat.modEq_iff_dvd, ← hf.zpow_apply_eq ha]
-  simp [sub_eq_neg_add, zpow_add, eq_inv_iff_eq, eq_comm]
+  simp [sub_eq_neg_add, zpow_add, eq_symm_apply, eq_comm]
 
 theorem IsCycleOn.zpow_apply_eq_zpow_apply {s : Finset α} (hf : f.IsCycleOn s) (ha : a ∈ s)
     {m n : ℤ} : (f ^ m) a = (f ^ n) a ↔ m ≡ n [ZMOD #s] := by
   rw [Int.modEq_iff_dvd, ← hf.zpow_apply_eq ha]
-  simp [sub_eq_neg_add, zpow_add, eq_inv_iff_eq, eq_comm]
+  simp [sub_eq_neg_add, zpow_add, eq_symm_apply, eq_comm]
 
 theorem IsCycleOn.pow_card_apply {s : Finset α} (hf : f.IsCycleOn s) (ha : a ∈ s) :
     (f ^ #s) a = a :=

--- a/Mathlib/GroupTheory/Perm/Cycle/Factors.lean
+++ b/Mathlib/GroupTheory/Perm/Cycle/Factors.lean
@@ -51,7 +51,7 @@ theorem cycleOf_inv (f : Perm α) [DecidableRel f.SameCycle] (x : α) :
     (cycleOf f x)⁻¹ = cycleOf f⁻¹ x :=
   Equiv.ext fun y => by
     rw [inv_eq_iff_eq, cycleOf_apply, cycleOf_apply]
-    split_ifs <;> simp_all [sameCycle_inv, sameCycle_inv_apply_right]
+    split_ifs <;> simp_all [sameCycle_inv, sameCycle_symm_apply_right]
 
 @[simp]
 theorem cycleOf_pow_apply_self (f : Perm α) [DecidableRel f.SameCycle] (x : α) :
@@ -385,7 +385,7 @@ where
           (by
             rw [hfg hx]
             intro y hy
-            simp [inv_eq_iff_eq, cycleOf_apply, eq_comm (a := g y)] at hy
+            simp [symm_apply_eq, cycleOf_apply, eq_comm (a := g y)] at hy
             rw [hfg (Ne.symm hy.right), ← mul_inv_eq_one (a := g.cycleOf y), cycleOf_inv]
             simp_rw [mul_inv_rev]
             rw [inv_inv, cycleOf_mul_of_apply_right_eq_self, ← cycleOf_inv, mul_inv_eq_one]
@@ -410,7 +410,7 @@ where
         refine hg'y <| (disjoint_prod_right _ this y).resolve_right ?_
         have hsc : SameCycle g⁻¹ x (g y) := by rwa [sameCycle_inv, sameCycle_apply_right]
         rw [disjoint_prod_perm hm₃ hg'm.symm, List.prod_cons, ← eq_inv_mul_iff_mul_eq] at hm₁
-        simpa [hm₁, cycleOf_inv, hsc.cycleOf_apply, Perm.eq_inv_iff_eq, eq_comm] using hg'y⟩
+        simpa [hm₁, cycleOf_inv, hsc.cycleOf_apply, eq_symm_apply, eq_comm] using hg'y⟩
 
 theorem mem_list_cycles_iff {α : Type*} [Finite α] {l : List (Perm α)}
     (h1 : ∀ σ : Perm α, σ ∈ l → σ.IsCycle) (h2 : l.Pairwise Disjoint) {σ : Perm α} :
@@ -681,7 +681,8 @@ theorem disjoint_mul_inv_of_mem_cycleFactorsFinset {f g : Perm α} (h : f ∈ cy
   intro x
   by_cases hx : f x = x
   · exact Or.inr hx
-  rw [mul_apply, ← h.right _ (by simpa [Perm.eq_inv_iff_eq])]
+  left
+  rw [mul_apply, ← h.right _ (by simpa [eq_symm_apply])]
   simp
 
 /-- If c is a cycle, a ∈ c.support and c is a cycle of f, then `c = f.cycleOf a` -/
@@ -738,7 +739,7 @@ theorem mem_cycleFactorsFinset_conj (g k c : Perm α) :
   intro hc a ha
   simp only [coe_mul, Function.comp_apply, EmbeddingLike.apply_eq_iff_eq]
   apply hc
-  simpa [inv_def, eq_symm_apply] using ha
+  simp_all
 
 /-- If a permutation commutes with every cycle of `g`, then it commutes with `g`
 

--- a/Mathlib/GroupTheory/Perm/Finite.lean
+++ b/Mathlib/GroupTheory/Perm/Finite.lean
@@ -49,39 +49,39 @@ theorem isConj_of_support_equiv
 
 end Conjugation
 
-theorem perm_inv_on_of_perm_on_finset {s : Finset α} {f : Perm α} (h : ∀ x ∈ s, f x ∈ s) {y : α}
-    (hy : y ∈ s) : f⁻¹ y ∈ s := by
+theorem perm_symm_on_of_perm_on_finset {s : Finset α} {f : Perm α} (h : ∀ x ∈ s, f x ∈ s) {y : α}
+    (hy : y ∈ s) : f.symm y ∈ s := by
   have h0 : ∀ y ∈ s, ∃ (x : _) (hx : x ∈ s), y = (fun i (_ : i ∈ s) => f i) x hx :=
     Finset.surj_on_of_inj_on_of_card_le (fun x hx => (fun i _ => f i) x hx) (fun a ha => h a ha)
       (fun a₁ a₂ ha₁ ha₂ heq => (Equiv.apply_eq_iff_eq f).mp heq) rfl.ge
   obtain ⟨y2, hy2, rfl⟩ := h0 y hy
   simpa using hy2
 
-theorem perm_inv_mapsTo_of_mapsTo (f : Perm α) {s : Set α} [Finite s] (h : Set.MapsTo f s s) :
-    Set.MapsTo (f⁻¹ :) s s := by
+theorem perm_symm_mapsTo_of_mapsTo (f : Perm α) {s : Set α} [Finite s] (h : Set.MapsTo f s s) :
+    Set.MapsTo f.symm s s := by
   cases nonempty_fintype s
   exact fun x hx =>
     Set.mem_toFinset.mp <|
-      perm_inv_on_of_perm_on_finset
+      perm_symm_on_of_perm_on_finset
         (fun a ha => Set.mem_toFinset.mpr (h (Set.mem_toFinset.mp ha)))
         (Set.mem_toFinset.mpr hx)
 
 @[simp]
-theorem perm_inv_mapsTo_iff_mapsTo {f : Perm α} {s : Set α} [Finite s] :
-    Set.MapsTo (f⁻¹ :) s s ↔ Set.MapsTo f s s :=
-  ⟨perm_inv_mapsTo_of_mapsTo f⁻¹, perm_inv_mapsTo_of_mapsTo f⟩
+theorem perm_symm_mapsTo_iff_mapsTo {f : Perm α} {s : Set α} [Finite s] :
+    Set.MapsTo f.symm s s ↔ Set.MapsTo f s s :=
+  ⟨perm_symm_mapsTo_of_mapsTo f⁻¹, perm_symm_mapsTo_of_mapsTo f⟩
 
-theorem perm_inv_on_of_perm_on_finite {f : Perm α} {p : α → Prop} [Finite { x // p x }]
-    (h : ∀ x, p x → p (f x)) {x : α} (hx : p x) : p (f⁻¹ x) := by
+theorem perm_symm_on_of_perm_on_finite {f : Perm α} {p : α → Prop} [Finite { x // p x }]
+    (h : ∀ x, p x → p (f x)) {x : α} (hx : p x) : p (f.symm x) := by
   have : Finite { x | p x } := by simpa
-  simpa using perm_inv_mapsTo_of_mapsTo (s := {x | p x}) f h hx
+  simpa using perm_symm_mapsTo_of_mapsTo (s := {x | p x}) f h hx
 
 /-- If the permutation `f` maps `{x // p x}` into itself, then this returns the permutation
   on `{x // p x}` induced by `f`. Note that the `h` hypothesis is weaker than for
   `Equiv.Perm.subtypePerm`. -/
 abbrev subtypePermOfFintype (f : Perm α) {p : α → Prop} [Finite { x // p x }]
     (h : ∀ x, p x → p (f x)) : Perm { x // p x } :=
-  f.subtypePerm fun x => ⟨fun h₂ => f.inv_apply_self x ▸ perm_inv_on_of_perm_on_finite h h₂, h x⟩
+  f.subtypePerm fun x => ⟨fun h₂ => f.symm_apply_apply x ▸ perm_symm_on_of_perm_on_finite h h₂, h x⟩
 
 @[simp]
 theorem subtypePermOfFintype_apply (f : Perm α) {p : α → Prop} [Finite { x // p x }]
@@ -98,19 +98,17 @@ theorem perm_mapsTo_inl_iff_mapsTo_inr {m n : Type*} [Finite m] [Finite n] (σ :
   constructor <;>
     ( intro h
       classical
-        rw [← perm_inv_mapsTo_iff_mapsTo] at h
+        rw [← perm_symm_mapsTo_iff_mapsTo] at h
         intro x
         rcases hx : σ x with l | r)
   · rintro ⟨a, rfl⟩
     obtain ⟨y, hy⟩ := h ⟨l, rfl⟩
-    rw [← hx, σ.inv_apply_self] at hy
-    exact absurd hy Sum.inl_ne_inr
+    grind
   · rintro _; exact ⟨r, rfl⟩
   · rintro _; exact ⟨l, rfl⟩
   · rintro ⟨a, rfl⟩
     obtain ⟨y, hy⟩ := h ⟨r, rfl⟩
-    rw [← hx, σ.inv_apply_self] at hy
-    exact absurd hy Sum.inr_ne_inl
+    grind
 
 theorem mem_sumCongrHom_range_of_perm_mapsTo_inl {m n : Type*} [Finite m] [Finite n]
     {σ : Perm (m ⊕ n)} (h : Set.MapsTo σ (Set.range Sum.inl) (Set.range Sum.inl)) :
@@ -182,11 +180,11 @@ theorem Disjoint.isConj_mul [Finite α] {σ τ π ρ : Perm α} (hc1 : IsConj σ
   · rw [mem_coe, mem_support] at hxσ
     rw [Set.union_apply_left, Set.union_apply_left]
     · simp only [subtypeEquiv_apply, Perm.coe_mul, Sum.map_inl, comp_apply,
-        Set.union_symm_apply_left, Subtype.coe_mk, apply_eq_iff_eq]
+        Set.union_symm_apply_left, Subtype.coe_mk, apply_eq_iff_eq, coe_inv]
       have h := (hd2 (f x)).resolve_left ?_
-      · rw [mul_apply, mul_apply] at h
-        rw [h, inv_apply_self, (hd1 x).resolve_left hxσ]
-      · rwa [mul_apply, mul_apply, inv_apply_self, apply_eq_iff_eq]
+      · rw [mul_apply, mul_apply, coe_inv] at h
+        rw [h, symm_apply_apply, (hd1 x).resolve_left hxσ]
+      · rwa [mul_apply, mul_apply, coe_inv, symm_apply_apply, apply_eq_iff_eq]
     · rwa [Subtype.coe_mk, mem_coe, mem_support]
     · rwa [Subtype.coe_mk, Perm.mul_apply, (hd1 x).resolve_left hxσ, mem_coe,
         apply_mem_support, mem_support]
@@ -195,9 +193,9 @@ theorem Disjoint.isConj_mul [Finite α] {σ τ π ρ : Perm α} (hc1 : IsConj σ
     · simp only [subtypeEquiv_apply, Perm.coe_mul, Sum.map_inr, comp_apply,
         Set.union_symm_apply_right, Subtype.coe_mk]
       have h := (hd2 (g (τ x))).resolve_right ?_
-      · rw [mul_apply, mul_apply] at h
-        rw [inv_apply_self, h, (hd1 (τ x)).resolve_right hxτ]
-      · rwa [mul_apply, mul_apply, inv_apply_self, apply_eq_iff_eq]
+      · rw [mul_apply, mul_apply, coe_inv] at h
+        rw [coe_inv, coe_inv, symm_apply_apply, h, (hd1 (τ x)).resolve_right hxτ]
+      · rwa [mul_apply, mul_apply, coe_inv, symm_apply_apply, apply_eq_iff_eq]
     · rwa [Subtype.coe_mk, mem_coe, ← apply_mem_support, mem_support]
     · rwa [Subtype.coe_mk, Perm.mul_apply, (hd1 (τ x)).resolve_right hxτ,
         mem_coe, mem_support]

--- a/Mathlib/GroupTheory/Perm/Finite.lean
+++ b/Mathlib/GroupTheory/Perm/Finite.lean
@@ -57,6 +57,9 @@ theorem perm_symm_on_of_perm_on_finset {s : Finset α} {f : Perm α} (h : ∀ x 
   obtain ⟨y2, hy2, rfl⟩ := h0 y hy
   simpa using hy2
 
+@[deprecated (since := "2025-11-17")]
+alias perm_inv_on_of_perm_on_finset := perm_symm_on_of_perm_on_finset
+
 theorem perm_symm_mapsTo_of_mapsTo (f : Perm α) {s : Set α} [Finite s] (h : Set.MapsTo f s s) :
     Set.MapsTo f.symm s s := by
   cases nonempty_fintype s
@@ -66,15 +69,23 @@ theorem perm_symm_mapsTo_of_mapsTo (f : Perm α) {s : Set α} [Finite s] (h : Se
         (fun a ha => Set.mem_toFinset.mpr (h (Set.mem_toFinset.mp ha)))
         (Set.mem_toFinset.mpr hx)
 
+@[deprecated (since := "2025-11-17")] alias perm_inv_mapsTo_of_mapsTo := perm_symm_mapsTo_of_mapsTo
+
 @[simp]
 theorem perm_symm_mapsTo_iff_mapsTo {f : Perm α} {s : Set α} [Finite s] :
     Set.MapsTo f.symm s s ↔ Set.MapsTo f s s :=
   ⟨perm_symm_mapsTo_of_mapsTo f⁻¹, perm_symm_mapsTo_of_mapsTo f⟩
 
+@[deprecated (since := "2025-11-17")]
+alias perm_inv_mapsTo_iff_mapsTo := perm_symm_mapsTo_iff_mapsTo
+
 theorem perm_symm_on_of_perm_on_finite {f : Perm α} {p : α → Prop} [Finite { x // p x }]
     (h : ∀ x, p x → p (f x)) {x : α} (hx : p x) : p (f.symm x) := by
   have : Finite { x | p x } := by simpa
   simpa using perm_symm_mapsTo_of_mapsTo (s := {x | p x}) f h hx
+
+@[deprecated (since := "2025-11-17")]
+alias perm_inv_on_of_perm_on_finite := perm_symm_on_of_perm_on_finite
 
 /-- If the permutation `f` maps `{x // p x}` into itself, then this returns the permutation
   on `{x // p x}` induced by `f`. Note that the `h` hypothesis is weaker than for

--- a/Mathlib/GroupTheory/Perm/Sign.lean
+++ b/Mathlib/GroupTheory/Perm/Sign.lean
@@ -215,10 +215,11 @@ theorem signBijAux_mem {n : ℕ} {f : Perm (Fin n)} :
 
 @[simp]
 theorem signAux_inv {n : ℕ} (f : Perm (Fin n)) : signAux f⁻¹ = signAux f :=
-  prod_nbij (signBijAux f⁻¹) signBijAux_mem signBijAux_injOn signBijAux_surj fun ⟨a, b⟩ hab ↦ by
-    by_cases h : f⁻¹ b < f⁻¹ a
-    · simp_all [signBijAux, (mem_finPairsLT.1 hab).not_ge]
-    · simp_all [signBijAux, dif_neg h, (mem_finPairsLT.1 hab).le]
+  prod_nbij (signBijAux f⁻¹) signBijAux_mem signBijAux_injOn signBijAux_surj fun ⟨a, b⟩ hab ↦
+    if h : f.symm b < f.symm a then by
+      simp_all [signBijAux, (mem_finPairsLT.1 hab).not_ge]
+    else by
+      simp_all [signBijAux, dif_neg h, (mem_finPairsLT.1 hab).le]
 
 theorem signAux_mul {n : ℕ} (f g : Perm (Fin n)) : signAux (f * g) = signAux f * signAux g := by
   rw [← signAux_inv g]

--- a/Mathlib/GroupTheory/Perm/Sign.lean
+++ b/Mathlib/GroupTheory/Perm/Sign.lean
@@ -215,11 +215,10 @@ theorem signBijAux_mem {n : ℕ} {f : Perm (Fin n)} :
 
 @[simp]
 theorem signAux_inv {n : ℕ} (f : Perm (Fin n)) : signAux f⁻¹ = signAux f :=
-  prod_nbij (signBijAux f⁻¹) signBijAux_mem signBijAux_injOn signBijAux_surj fun ⟨a, b⟩ hab ↦
-    if h : f.symm b < f.symm a then by
-      simp_all [signBijAux, (mem_finPairsLT.1 hab).not_ge]
-    else by
-      simp_all [signBijAux, dif_neg h, (mem_finPairsLT.1 hab).le]
+  prod_nbij (signBijAux f⁻¹) signBijAux_mem signBijAux_injOn signBijAux_surj fun ⟨a, b⟩ hab ↦ by
+    by_cases h : f.symm b < f.symm a
+    · simp_all [signBijAux, (mem_finPairsLT.1 hab).not_ge]
+    · simp_all [signBijAux, dif_neg h, (mem_finPairsLT.1 hab).le]
 
 theorem signAux_mul {n : ℕ} (f g : Perm (Fin n)) : signAux (f * g) = signAux f * signAux g := by
   rw [← signAux_inv g]

--- a/Mathlib/GroupTheory/Perm/Support.lean
+++ b/Mathlib/GroupTheory/Perm/Support.lean
@@ -231,6 +231,8 @@ variable (p q : Perm α)
 lemma set_support_symm_eq : {x | p.symm x ≠ x} = {x | p x ≠ x} := by
   ext; simp [eq_symm_apply, eq_comm]
 
+@[deprecated (since := "2025-11-17")] alias set_support_inv_eq := set_support_symm_eq
+
 theorem set_support_apply_mem {p : Perm α} {a : α} :
     p a ∈ { x | p x ≠ x } ↔ a ∈ { x | p x ≠ x } := by simp
 

--- a/Mathlib/GroupTheory/Perm/Support.lean
+++ b/Mathlib/GroupTheory/Perm/Support.lean
@@ -228,8 +228,8 @@ section Set
 
 variable (p q : Perm α)
 
-theorem set_support_inv_eq : {x | p⁻¹ x ≠ x} = {x | p x ≠ x} := by
-  ext; simp [inv_def, eq_symm_apply, eq_comm]
+lemma set_support_symm_eq : {x | p.symm x ≠ x} = {x | p x ≠ x} := by
+  ext; simp [eq_symm_apply, eq_comm]
 
 theorem set_support_apply_mem {p : Perm α} {a : α} :
     p a ∈ { x | p x ≠ x } ↔ a ∈ { x | p x ≠ x } := by simp

--- a/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Determinant/Basic.lean
@@ -629,14 +629,14 @@ theorem det_blockDiagonal {o : Type*} [Fintype o] [DecidableEq o] (M : o → Mat
       exact (this k x).1
     · intro σ hσ
       rw [mem_preserving_snd] at hσ
-      have hσ' x : (σ⁻¹ x).snd = x.snd := by simpa [eq_comm] using hσ (σ⁻¹ x)
+      have hσ' x : (σ.symm x).snd = x.snd := by simpa [eq_comm] using hσ (σ.symm x)
       have mk_apply_eq : ∀ k x, ((σ (x, k)).fst, k) = σ (x, k) := by
         intro k x
         ext
         · simp only
         · simp only [hσ]
-      have mk_inv_apply_eq : ∀ k x, ((σ⁻¹ (x, k)).fst, k) = σ⁻¹ (x, k) := by grind
-      refine ⟨fun k _ => ⟨fun x => (σ (x, k)).fst, fun x => (σ⁻¹ (x, k)).fst, ?_, ?_⟩, ?_, ?_⟩
+      have mk_inv_apply_eq : ∀ k x, ((σ.symm (x, k)).fst, k) = σ.symm (x, k) := by grind
+      refine ⟨fun k _ => ⟨fun x => (σ (x, k)).fst, fun x => (σ.symm (x, k)).fst, ?_, ?_⟩, ?_, ?_⟩
       · intro x
         simp [mk_apply_eq]
       · intro x


### PR DESCRIPTION
The motivation here is that the spelling `⇑e⁻¹` is only available when `e` is an automorphism, while the `⇑e.symm` one is available for all isomorphisms. However we do not want to simplify `e⁻¹ = e.symm` (without the coercions to function) since `e⁻¹` is an algebraic expression and `e.symm` is not. We consider that applying the coercion to functions gets us out of algebra land, and therefore it is okay to "dealgebraise" the expression further.

From BrauerGroup and ClassFieldTheory

---
- [x] depends on: #31129
- [x] depends on: #31130
- [x] depends on: #31389

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
