### PR TITLE
[Merged by Bors] - chore: remove unnecessary uses of `compile_def%`

### DIFF
--- a/Mathlib/Algebra/Star/Basic.lean
+++ b/Mathlib/Algebra/Star/Basic.lean
@@ -43,9 +43,6 @@ open MulOpposite
 class Star (R : Type u) where
   star : R → R
 
--- https://github.com/leanprover/lean4/issues/2096
-compile_def% Star.star
-
 variable {R : Type u}
 
 export Star (star)

--- a/Mathlib/Data/FunLike/Basic.lean
+++ b/Mathlib/Data/FunLike/Basic.lean
@@ -142,9 +142,6 @@ class DFunLike (F : Sort*) (α : outParam (Sort*)) (β : outParam <| α → Sort
   /-- The coercion to functions must be injective. -/
   coe_injective' : Function.Injective coe
 
--- https://github.com/leanprover/lean4/issues/2096
-compile_def% DFunLike.coe
-
 /-- The class `FunLike F α β` (`Fun`ction-`Like`) expresses that terms of type `F`
 have an injective coercion to functions from `α` to `β`.
 `FunLike` is the non-dependent version of `DFunLike`.

--- a/Mathlib/Data/Set/Operations.lean
+++ b/Mathlib/Data/Set/Operations.lean
@@ -8,7 +8,6 @@ import Mathlib.Data.Set.CoeSort
 import Mathlib.Data.SProd
 import Mathlib.Data.Subtype
 import Mathlib.Order.Notation
-import Mathlib.Util.CompileInductive
 
 /-!
 # Basic definitions about sets
@@ -57,15 +56,6 @@ More advanced theorems about these definitions are located in other files in `Ma
 
 set, image, preimage
 -/
-
--- https://github.com/leanprover/lean4/issues/2096
-compile_def% Union.union
-compile_def% Inter.inter
-compile_def% SDiff.sdiff
-compile_def% HasCompl.compl
-compile_def% EmptyCollection.emptyCollection
-compile_def% Insert.insert
-compile_def% Singleton.singleton
 
 attribute [ext] Set.ext
 


### PR DESCRIPTION
These were a workaround for bugs in the old compiler (https://github.com/leanprover/lean4/issues/2096) and are no longer necessary.