### PR TITLE
[Merged by Bors] - feat(RingTheory/NonUnitalSubsemiring): add Aesop rules for `-(x * y)` subsemiring membership

### DIFF
--- a/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
+++ b/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
@@ -85,6 +85,15 @@ instance toNonUnitalCommSemiring {R} [NonUnitalCommSemiring R] [SetLike S R]
 
 /-! Note: currently, there are no ordered versions of non-unital rings. -/
 
+variable {s} in
+@[aesop unsafe 80% (rule_sets := [SetLike])]
+theorem neg_mul_mem [HasDistribNeg R] {x y : R} (hx : -x ∈ s) (hy : y ∈ s) : -(x * y) ∈ s := by
+  simpa using mul_mem hx hy
+
+variable {s} in
+@[aesop unsafe 80% (rule_sets := [SetLike])]
+theorem mul_neg_mem [HasDistribNeg R] {x y : R} (hx : x ∈ s) (hy : -y ∈ s) : -(x * y) ∈ s := by
+  simpa using mul_mem hx hy
 
 end NonUnitalSubsemiringClass
 

--- a/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
+++ b/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
@@ -35,6 +35,7 @@ because `x * -y` simplifies to `-(x * y)`. -/
 theorem mul_neg_mem {x y : R} (hx : x ∈ s) (hy : -y ∈ s) : -(x * y) ∈ s := by
   simpa using mul_mem hx hy
 
+-- doesn't work without the above `aesop` lemmas
 example {x y z : R} (hx : x ∈ s) (hy : -y ∈ s) (hz : z ∈ s) :
     x * (-y) * z ∈ s := by aesop
 

--- a/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
+++ b/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
@@ -100,7 +100,7 @@ theorem mul_neg_mem [HasDistribNeg R] {x y : R} (hx : x ∈ s) (hy : -y ∈ s) :
   simpa using mul_mem hx hy
 
 example [HasDistribNeg R] {x y z : R} (hx : x ∈ s) (hy : -y ∈ s) (hz : z ∈ s) :
-    x * -y * z ∈ s := by aesop
+    x * (-y) * z ∈ s := by aesop
 
 end NonUnitalSubsemiringClass
 

--- a/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
+++ b/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
@@ -87,11 +87,13 @@ instance toNonUnitalCommSemiring {R} [NonUnitalCommSemiring R] [SetLike S R]
 
 variable {s} in
 @[aesop unsafe 80% (rule_sets := [SetLike])]
+/- The Aesop rule `mul_mem` doesn't work in the absense of `neg_mem` because `-x * y` simplifies to `-(x * y)`. -/
 theorem neg_mul_mem [HasDistribNeg R] {x y : R} (hx : -x ∈ s) (hy : y ∈ s) : -(x * y) ∈ s := by
   simpa using mul_mem hx hy
 
 variable {s} in
 @[aesop unsafe 80% (rule_sets := [SetLike])]
+/- The Aesop rule `mul_mem` doesn't work in the absense of `neg_mem` because `x * -y` simplifies to `-(x * y)`. -/
 theorem mul_neg_mem [HasDistribNeg R] {x y : R} (hx : x ∈ s) (hy : -y ∈ s) : -(x * y) ∈ s := by
   simpa using mul_mem hx hy
 

--- a/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
+++ b/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
@@ -19,6 +19,27 @@ assert_not_exists RelIso
 
 universe u v w
 
+section neg_mul
+
+variable {R S : Type*} [Mul R] [HasDistribNeg R] [SetLike S R] [MulMemClass S R] {s : S}
+
+@[aesop unsafe 80% (rule_sets := [SetLike])]
+/- The Aesop rule `mul_mem` doesn't work in the absense of `neg_mem`
+because `-x * y` simplifies to `-(x * y)`. -/
+theorem neg_mul_mem {x y : R} (hx : -x ∈ s) (hy : y ∈ s) : -(x * y) ∈ s := by
+  simpa using mul_mem hx hy
+
+@[aesop unsafe 80% (rule_sets := [SetLike])]
+/- The Aesop rule `mul_mem` doesn't work in the absense of `neg_mem`
+because `x * -y` simplifies to `-(x * y)`. -/
+theorem mul_neg_mem {x y : R} (hx : x ∈ s) (hy : -y ∈ s) : -(x * y) ∈ s := by
+  simpa using mul_mem hx hy
+
+example {x y z : R} (hx : x ∈ s) (hy : -y ∈ s) (hz : z ∈ s) :
+    x * (-y) * z ∈ s := by aesop
+
+end neg_mul
+
 variable {R : Type u} {S : Type v} {T : Type w} [NonUnitalNonAssocSemiring R]
 
 /-- `NonUnitalSubsemiringClass S R` states that `S` is a type of subsets `s ⊆ R` that
@@ -84,23 +105,6 @@ instance toNonUnitalCommSemiring {R} [NonUnitalCommSemiring R] [SetLike S R]
     fun _ _ => rfl
 
 /-! Note: currently, there are no ordered versions of non-unital rings. -/
-
-variable {s} in
-@[aesop unsafe 80% (rule_sets := [SetLike])]
-/- The Aesop rule `mul_mem` doesn't work in the absense of `neg_mem`
-because `-x * y` simplifies to `-(x * y)`. -/
-theorem neg_mul_mem [HasDistribNeg R] {x y : R} (hx : -x ∈ s) (hy : y ∈ s) : -(x * y) ∈ s := by
-  simpa using mul_mem hx hy
-
-variable {s} in
-@[aesop unsafe 80% (rule_sets := [SetLike])]
-/- The Aesop rule `mul_mem` doesn't work in the absense of `neg_mem`
-because `x * -y` simplifies to `-(x * y)`. -/
-theorem mul_neg_mem [HasDistribNeg R] {x y : R} (hx : x ∈ s) (hy : -y ∈ s) : -(x * y) ∈ s := by
-  simpa using mul_mem hx hy
-
-example [HasDistribNeg R] {x y z : R} (hx : x ∈ s) (hy : -y ∈ s) (hz : z ∈ s) :
-    x * (-y) * z ∈ s := by aesop
 
 end NonUnitalSubsemiringClass
 

--- a/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
+++ b/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
@@ -87,15 +87,20 @@ instance toNonUnitalCommSemiring {R} [NonUnitalCommSemiring R] [SetLike S R]
 
 variable {s} in
 @[aesop unsafe 80% (rule_sets := [SetLike])]
-/- The Aesop rule `mul_mem` doesn't work in the absense of `neg_mem` because `-x * y` simplifies to `-(x * y)`. -/
+/- The Aesop rule `mul_mem` doesn't work in the absense of `neg_mem`
+because `-x * y` simplifies to `-(x * y)`. -/
 theorem neg_mul_mem [HasDistribNeg R] {x y : R} (hx : -x ∈ s) (hy : y ∈ s) : -(x * y) ∈ s := by
   simpa using mul_mem hx hy
 
 variable {s} in
 @[aesop unsafe 80% (rule_sets := [SetLike])]
-/- The Aesop rule `mul_mem` doesn't work in the absense of `neg_mem` because `x * -y` simplifies to `-(x * y)`. -/
+/- The Aesop rule `mul_mem` doesn't work in the absense of `neg_mem`
+because `x * -y` simplifies to `-(x * y)`. -/
 theorem mul_neg_mem [HasDistribNeg R] {x y : R} (hx : x ∈ s) (hy : -y ∈ s) : -(x * y) ∈ s := by
   simpa using mul_mem hx hy
+
+example [HasDistribNeg R] {x y z : R} (hx : x ∈ s) (hy : -y ∈ s) (hz : z ∈ s) :
+    x * -y * z ∈ s := by aesop
 
 end NonUnitalSubsemiringClass
 

--- a/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
+++ b/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
@@ -24,7 +24,7 @@ section neg_mul
 variable {R S : Type*} [Mul R] [HasDistribNeg R] [SetLike S R] [MulMemClass S R] {s : S}
 
 @[aesop unsafe 80% (rule_sets := [SetLike])]
-/- The Aesop rule `mul_mem` doesn't work in the absense of `neg_mem`
+/- The Aesop rule `mul_mem` doesn't work in the absence of `neg_mem`
 because `-x * y` simplifies to `-(x * y)`. -/
 theorem neg_mul_mem {x y : R} (hx : -x ∈ s) (hy : y ∈ s) : -(x * y) ∈ s := by
   simpa using mul_mem hx hy

--- a/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
+++ b/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
@@ -23,15 +23,15 @@ section neg_mul
 
 variable {R S : Type*} [Mul R] [HasDistribNeg R] [SetLike S R] [MulMemClass S R] {s : S}
 
-@[aesop unsafe 80% (rule_sets := [SetLike])]
 /-- This lemma exists for `aesop`, as `aesop` simplifies `-x * y` to `-(x * y)` before applying
 unsafe rules like `mul_mem`, leading to a dead end in cases where `neg_mem` does not hold. -/
+@[aesop unsafe 80% (rule_sets := [SetLike])]
 theorem neg_mul_mem {x y : R} (hx : -x ∈ s) (hy : y ∈ s) : -(x * y) ∈ s := by
   simpa using mul_mem hx hy
 
-@[aesop unsafe 80% (rule_sets := [SetLike])]
 /-- This lemma exists for `aesop`, as `aesop` simplifies `x * -y` to `-(x * y)` before applying
 unsafe rules like `mul_mem`, leading to a dead end in cases where `neg_mem` does not hold. -/
+@[aesop unsafe 80% (rule_sets := [SetLike])]
 theorem mul_neg_mem {x y : R} (hx : x ∈ s) (hy : -y ∈ s) : -(x * y) ∈ s := by
   simpa using mul_mem hx hy
 

--- a/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
+++ b/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
@@ -30,7 +30,7 @@ theorem neg_mul_mem {x y : R} (hx : -x ∈ s) (hy : y ∈ s) : -(x * y) ∈ s :=
   simpa using mul_mem hx hy
 
 @[aesop unsafe 80% (rule_sets := [SetLike])]
-/- The Aesop rule `mul_mem` doesn't work in the absense of `neg_mem`
+/- The Aesop rule `mul_mem` doesn't work in the absence of `neg_mem`
 because `x * -y` simplifies to `-(x * y)`. -/
 theorem mul_neg_mem {x y : R} (hx : x ∈ s) (hy : -y ∈ s) : -(x * y) ∈ s := by
   simpa using mul_mem hx hy

--- a/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
+++ b/Mathlib/RingTheory/NonUnitalSubsemiring/Defs.lean
@@ -24,14 +24,14 @@ section neg_mul
 variable {R S : Type*} [Mul R] [HasDistribNeg R] [SetLike S R] [MulMemClass S R] {s : S}
 
 @[aesop unsafe 80% (rule_sets := [SetLike])]
-/- The Aesop rule `mul_mem` doesn't work in the absence of `neg_mem`
-because `-x * y` simplifies to `-(x * y)`. -/
+/-- This lemma exists for `aesop`, as `aesop` simplifies `-x * y` to `-(x * y)` before applying
+unsafe rules like `mul_mem`, leading to a dead end in cases where `neg_mem` does not hold. -/
 theorem neg_mul_mem {x y : R} (hx : -x ∈ s) (hy : y ∈ s) : -(x * y) ∈ s := by
   simpa using mul_mem hx hy
 
 @[aesop unsafe 80% (rule_sets := [SetLike])]
-/- The Aesop rule `mul_mem` doesn't work in the absence of `neg_mem`
-because `x * -y` simplifies to `-(x * y)`. -/
+/-- This lemma exists for `aesop`, as `aesop` simplifies `x * -y` to `-(x * y)` before applying
+unsafe rules like `mul_mem`, leading to a dead end in cases where `neg_mem` does not hold. -/
 theorem mul_neg_mem {x y : R} (hx : x ∈ s) (hy : -y ∈ s) : -(x * y) ∈ s := by
   simpa using mul_mem hx hy
 


### PR DESCRIPTION
The Aesop rule `mul_mem` doesn't decompose goals of the form `-x * y ∈ s` or `x * -y ∈ s` in the absence of `neg_mem` because these expressions simplify to `-(x * y) ∈ s`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
