### PR TITLE
[Merged by Bors] - feat(LocallyIntegrable): generalise the first half of the file to enorms

### DIFF
--- a/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
@@ -406,7 +406,6 @@ theorem integrable_iff_integrableAtFilter_atBot_atTop
   constructor
   · exact fun hf ↦ ⟨⟨hf.integrableAtFilter _, hf.integrableAtFilter _⟩, hf.locallyIntegrable⟩
   · refine fun h ↦ integrable_iff_integrableAtFilter_cocompact.mpr ⟨?_, h.2⟩
-    have aux := (IntegrableAtFilter.sup_iff.mpr h.1)
     exact (IntegrableAtFilter.sup_iff.mpr h.1).filter_mono cocompact_le_atBot_atTop
 
 theorem integrable_iff_integrableAtFilter_atBot [LinearOrder X] [OrderTop X] [CompactIccSpace X] :

--- a/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
@@ -26,9 +26,11 @@ open MeasureTheory MeasureTheory.Measure Set Function TopologicalSpace Bornology
 
 open scoped Topology Interval ENNReal
 
-variable {X Y E F R : Type*} [MeasurableSpace X] [TopologicalSpace X]
+variable {X Y ε ε' ε'' E F R : Type*} [MeasurableSpace X] [TopologicalSpace X]
 variable [MeasurableSpace Y] [TopologicalSpace Y]
-variable [NormedAddCommGroup E] [NormedAddCommGroup F] {f g : X → E} {μ : Measure X} {s : Set X}
+variable [TopologicalSpace ε] [ContinuousENorm ε] [TopologicalSpace ε'] [ContinuousENorm ε']
+  [TopologicalSpace ε''] [ENormedAddMonoid ε'']
+  [NormedAddCommGroup E] [NormedAddCommGroup F] {f g : X → ε} {μ : Measure X} {s : Set X}
 
 namespace MeasureTheory
 
@@ -37,19 +39,31 @@ section LocallyIntegrableOn
 /-- A function `f : X → E` is *locally integrable on s*, for `s ⊆ X`, if for every `x ∈ s` there is
 a neighbourhood of `x` within `s` on which `f` is integrable. (Note this is, in general, strictly
 weaker than local integrability with respect to `μ.restrict s`.) -/
-def LocallyIntegrableOn (f : X → E) (s : Set X) (μ : Measure X := by volume_tac) : Prop :=
+def LocallyIntegrableOn (f : X → ε) (s : Set X) (μ : Measure X := by volume_tac) : Prop :=
   ∀ x : X, x ∈ s → IntegrableAtFilter f (𝓝[s] x) μ
 
 theorem LocallyIntegrableOn.mono_set (hf : LocallyIntegrableOn f s μ) {t : Set X}
     (hst : t ⊆ s) : LocallyIntegrableOn f t μ := fun x hx =>
   (hf x <| hst hx).filter_mono (nhdsWithin_mono x hst)
 
-theorem LocallyIntegrableOn.norm (hf : LocallyIntegrableOn f s μ) :
-    LocallyIntegrableOn (fun x => ‖f x‖) s μ := fun t ht =>
-  let ⟨U, hU_nhds, hU_int⟩ := hf t ht
-  ⟨U, hU_nhds, hU_int.norm⟩
+theorem LocallyIntegrableOn.enorm (hf : LocallyIntegrableOn f s μ) :
+    LocallyIntegrableOn (‖f ·‖ₑ) s μ := fun t ht ↦
+  let ⟨U, hU_nhd, hU_int⟩ := hf t ht
+  ⟨U, hU_nhd, hU_int.enorm⟩
 
-theorem LocallyIntegrableOn.mono (hf : LocallyIntegrableOn f s μ) {g : X → F}
+theorem LocallyIntegrableOn.norm {f : X → E} (hf : LocallyIntegrableOn f s μ) :
+    LocallyIntegrableOn (fun x => ‖f x‖) s μ := fun t ht =>
+  let ⟨U, hU_nhd, hU_int⟩ := hf t ht
+  ⟨U, hU_nhd, hU_int.norm⟩
+
+theorem LocallyIntegrableOn.mono_enorm (hf : LocallyIntegrableOn f s μ) {g : X → ε'}
+    (hg : AEStronglyMeasurable g μ) (h : ∀ᵐ x ∂μ, ‖g x‖ₑ ≤ ‖f x‖ₑ) :
+    LocallyIntegrableOn g s μ := by
+  intro x hx
+  rcases hf x hx with ⟨t, t_mem, ht⟩
+  exact ⟨t, t_mem, ht.mono_enorm hg.restrict (ae_restrict_of_ae h)⟩
+
+theorem LocallyIntegrableOn.mono {f : X → E} (hf : LocallyIntegrableOn f s μ) {g : X → F}
     (hg : AEStronglyMeasurable g μ) (h : ∀ᵐ x ∂μ, ‖g x‖ ≤ ‖f x‖) :
     LocallyIntegrableOn g s μ := by
   intro x hx
@@ -60,13 +74,14 @@ theorem IntegrableOn.locallyIntegrableOn (hf : IntegrableOn f s μ) : LocallyInt
   fun _ _ => ⟨s, self_mem_nhdsWithin, hf⟩
 
 /-- If a function is locally integrable on a compact set, then it is integrable on that set. -/
-theorem LocallyIntegrableOn.integrableOn_isCompact (hf : LocallyIntegrableOn f s μ)
-    (hs : IsCompact s) : IntegrableOn f s μ :=
+theorem LocallyIntegrableOn.integrableOn_isCompact [PseudoMetrizableSpace ε]
+    (hf : LocallyIntegrableOn f s μ) (hs : IsCompact s) : IntegrableOn f s μ :=
   IsCompact.induction_on hs integrableOn_empty (fun _u _v huv hv => hv.mono_set huv)
     (fun _u _v hu hv => integrableOn_union.mpr ⟨hu, hv⟩) hf
 
-theorem LocallyIntegrableOn.integrableOn_compact_subset (hf : LocallyIntegrableOn f s μ) {t : Set X}
-    (hst : t ⊆ s) (ht : IsCompact t) : IntegrableOn f t μ :=
+theorem LocallyIntegrableOn.integrableOn_compact_subset [PseudoMetrizableSpace ε]
+    (hf : LocallyIntegrableOn f s μ) {t : Set X} (hst : t ⊆ s) (ht : IsCompact t) :
+    IntegrableOn f t μ :=
   (hf.mono_set hst).integrableOn_isCompact ht
 
 /-- If a function `f` is locally integrable on a set `s` in a second countable topological space,
@@ -120,8 +135,9 @@ theorem LocallyIntegrableOn.exists_nat_integrableOn [SecondCountableTopology X]
     · simp only [h, empty_inter, integrableOn_empty]
     · exact hT _ h
 
-theorem LocallyIntegrableOn.aestronglyMeasurable [SecondCountableTopology X]
-    (hf : LocallyIntegrableOn f s μ) : AEStronglyMeasurable f (μ.restrict s) := by
+theorem LocallyIntegrableOn.aestronglyMeasurable [PseudoMetrizableSpace ε]
+    [SecondCountableTopology X] (hf : LocallyIntegrableOn f s μ) :
+    AEStronglyMeasurable f (μ.restrict s) := by
   rcases hf.exists_nat_integrableOn with ⟨u, -, su, hu⟩
   have : s = ⋃ n, u n ∩ s := by rw [← iUnion_inter]; exact (inter_eq_right.mpr su).symm
   rw [this, aestronglyMeasurable_iUnion_iff]
@@ -129,7 +145,8 @@ theorem LocallyIntegrableOn.aestronglyMeasurable [SecondCountableTopology X]
 
 /-- If `s` is locally closed (e.g. open or closed), then `f` is locally integrable on `s` iff it is
 integrable on every compact subset contained in `s`. -/
-theorem locallyIntegrableOn_iff [LocallyCompactSpace X] (hs : IsLocallyClosed s) :
+theorem locallyIntegrableOn_iff [PseudoMetrizableSpace ε]
+    [LocallyCompactSpace X] (hs : IsLocallyClosed s) :
     LocallyIntegrableOn f s μ ↔ ∀ (k : Set X), k ⊆ s → IsCompact k → IntegrableOn f k μ := by
   refine ⟨fun hf k hk ↦ hf.integrableOn_compact_subset hk, fun hf x hx ↦ ?_⟩
   rcases hs with ⟨U, Z, hU, hZ, rfl⟩
@@ -138,15 +155,16 @@ theorem locallyIntegrableOn_iff [LocallyCompactSpace X] (hs : IsLocallyClosed s)
   refine ⟨Z ∩ K, inter_mem_nhdsWithin _ (mem_interior_iff_mem_nhds.1 hxK), ?_⟩
   exact hf (Z ∩ K) (fun y hy ↦ ⟨hKU hy.2, hy.1⟩) (.inter_left hK hZ)
 
-protected theorem LocallyIntegrableOn.add
+protected theorem LocallyIntegrableOn.add [ContinuousAdd ε''] {f g : X → ε''}
     (hf : LocallyIntegrableOn f s μ) (hg : LocallyIntegrableOn g s μ) :
     LocallyIntegrableOn (f + g) s μ := fun x hx ↦ (hf x hx).add (hg x hx)
 
+-- TODO: once mathlib has a ENormedAddCommSubMonoid, generalise this lemma also
 protected theorem LocallyIntegrableOn.sub
-    (hf : LocallyIntegrableOn f s μ) (hg : LocallyIntegrableOn g s μ) :
+    {f g : X → E} (hf : LocallyIntegrableOn f s μ) (hg : LocallyIntegrableOn g s μ) :
     LocallyIntegrableOn (f - g) s μ := fun x hx ↦ (hf x hx).sub (hg x hx)
 
-protected theorem LocallyIntegrableOn.neg (hf : LocallyIntegrableOn f s μ) :
+protected theorem LocallyIntegrableOn.neg {f : X → E} (hf : LocallyIntegrableOn f s μ) :
     LocallyIntegrableOn (-f) s μ := fun x hx ↦ (hf x hx).neg
 
 end LocallyIntegrableOn
@@ -154,7 +172,7 @@ end LocallyIntegrableOn
 /-- A function `f : X → E` is *locally integrable* if it is integrable on a neighborhood of every
 point. In particular, it is integrable on all compact sets,
 see `LocallyIntegrable.integrableOn_isCompact`. -/
-def LocallyIntegrable (f : X → E) (μ : Measure X := by volume_tac) : Prop :=
+def LocallyIntegrable (f : X → ε) (μ : Measure X := by volume_tac) : Prop :=
   ∀ x : X, IntegrableAtFilter f (𝓝 x) μ
 
 theorem locallyIntegrable_comap (hs : MeasurableSet s) :
@@ -171,7 +189,13 @@ theorem LocallyIntegrable.locallyIntegrableOn (hf : LocallyIntegrable f μ) (s :
 theorem Integrable.locallyIntegrable (hf : Integrable f μ) : LocallyIntegrable f μ := fun _ =>
   hf.integrableAtFilter _
 
-theorem LocallyIntegrable.mono (hf : LocallyIntegrable f μ) {g : X → F}
+theorem LocallyIntegrable.mono_enorm (hf : LocallyIntegrable f μ) {g : X → ε'}
+    (hg : AEStronglyMeasurable g μ) (h : ∀ᵐ x ∂μ, ‖g x‖ₑ ≤ ‖f x‖ₑ) :
+    LocallyIntegrable g μ := by
+  rw [← locallyIntegrableOn_univ] at hf ⊢
+  exact hf.mono_enorm hg h
+
+theorem LocallyIntegrable.mono {f : X → E} (hf : LocallyIntegrable f μ) {g : X → F}
     (hg : AEStronglyMeasurable g μ) (h : ∀ᵐ x ∂μ, ‖g x‖ ≤ ‖f x‖) :
     LocallyIntegrable g μ := by
   rw [← locallyIntegrableOn_univ] at hf ⊢
@@ -207,14 +231,15 @@ theorem locallyIntegrableOn_iff_locallyIntegrable_restrict [OpensMeasurableSpace
     exacts [integrableOn_empty, hs.measurableSet]
 
 /-- If a function is locally integrable, then it is integrable on any compact set. -/
-theorem LocallyIntegrable.integrableOn_isCompact {k : Set X} (hf : LocallyIntegrable f μ)
-    (hk : IsCompact k) : IntegrableOn f k μ :=
+theorem LocallyIntegrable.integrableOn_isCompact [PseudoMetrizableSpace ε]
+    {k : Set X} (hf : LocallyIntegrable f μ) (hk : IsCompact k) : IntegrableOn f k μ :=
   (hf.locallyIntegrableOn k).integrableOn_isCompact hk
 
 /-- If a function is locally integrable, then it is integrable on an open neighborhood of any
 compact set. -/
-theorem LocallyIntegrable.integrableOn_nhds_isCompact (hf : LocallyIntegrable f μ) {k : Set X}
-    (hk : IsCompact k) : ∃ u, IsOpen u ∧ k ⊆ u ∧ IntegrableOn f u μ := by
+theorem LocallyIntegrable.integrableOn_nhds_isCompact [PseudoMetrizableSpace ε]
+    (hf : LocallyIntegrable f μ) {k : Set X} (hk : IsCompact k) :
+    ∃ u, IsOpen u ∧ k ⊆ u ∧ IntegrableOn f u μ := by
   refine IsCompact.induction_on hk ?_ ?_ ?_ ?_
   · refine ⟨∅, isOpen_empty, Subset.rfl, integrableOn_empty⟩
   · rintro s t hst ⟨u, u_open, tu, hu⟩
@@ -226,13 +251,13 @@ theorem LocallyIntegrable.integrableOn_nhds_isCompact (hf : LocallyIntegrable f 
     rcases mem_nhds_iff.1 ux with ⟨v, vu, v_open, xv⟩
     exact ⟨v, nhdsWithin_le_nhds (v_open.mem_nhds xv), v, v_open, Subset.rfl, hu.mono_set vu⟩
 
-theorem locallyIntegrable_iff [LocallyCompactSpace X] :
+theorem locallyIntegrable_iff [PseudoMetrizableSpace ε] [LocallyCompactSpace X] :
     LocallyIntegrable f μ ↔ ∀ k : Set X, IsCompact k → IntegrableOn f k μ :=
   ⟨fun hf _k hk => hf.integrableOn_isCompact hk, fun hf x =>
     let ⟨K, hK, h2K⟩ := exists_compact_mem_nhds x
     ⟨K, h2K, hf K hK⟩⟩
 
-theorem LocallyIntegrable.aestronglyMeasurable [SecondCountableTopology X]
+theorem LocallyIntegrable.aestronglyMeasurable [PseudoMetrizableSpace ε] [SecondCountableTopology X]
     (hf : LocallyIntegrable f μ) : AEStronglyMeasurable f μ := by
   simpa only [restrict_univ] using (locallyIntegrableOn_univ.mpr hf).aestronglyMeasurable
 
@@ -245,7 +270,7 @@ theorem LocallyIntegrable.exists_nat_integrableOn [SecondCountableTopology X]
   refine ⟨u, u_open, eq_univ_of_univ_subset u_union, fun n ↦ ?_⟩
   simpa only [inter_univ] using hu n
 
-theorem MemLp.locallyIntegrable [IsLocallyFiniteMeasure μ] {f : X → E} {p : ℝ≥0∞}
+theorem MemLp.locallyIntegrable [IsLocallyFiniteMeasure μ] {p : ℝ≥0∞}
     (hf : MemLp f p μ) (hp : 1 ≤ p) : LocallyIntegrable f μ := by
   intro x
   rcases μ.finiteAt_nhds x with ⟨U, hU, h'U⟩
@@ -257,21 +282,29 @@ theorem MemLp.locallyIntegrable [IsLocallyFiniteMeasure μ] {f : X → E} {p : �
 @[deprecated (since := "2025-02-21")]
 alias Memℒp.locallyIntegrable := MemLp.locallyIntegrable
 
+theorem locallyIntegrable_const_enorm [IsLocallyFiniteMeasure μ] {c : ε} (hc : ‖c‖ₑ ≠ ∞) :
+    LocallyIntegrable (fun _ => c) μ :=
+  (memLp_top_const_enorm hc).locallyIntegrable le_top
+
 theorem locallyIntegrable_const [IsLocallyFiniteMeasure μ] (c : E) :
     LocallyIntegrable (fun _ => c) μ :=
-  (memLp_top_const c).locallyIntegrable le_top
+  locallyIntegrable_const_enorm enorm_ne_top
+
+theorem locallyIntegrableOn_const_enorm [IsLocallyFiniteMeasure μ] {c : ε} (hc : ‖c‖ₑ ≠ ∞) :
+    LocallyIntegrableOn (fun _ => c) s μ :=
+  (locallyIntegrable_const_enorm hc).locallyIntegrableOn s
 
 theorem locallyIntegrableOn_const [IsLocallyFiniteMeasure μ] (c : E) :
     LocallyIntegrableOn (fun _ => c) s μ :=
-  (locallyIntegrable_const c).locallyIntegrableOn s
+  locallyIntegrableOn_const_enorm enorm_ne_top
 
-theorem locallyIntegrable_zero : LocallyIntegrable (fun _ ↦ (0 : E)) μ :=
-  (integrable_zero X E μ).locallyIntegrable
+theorem locallyIntegrable_zero : LocallyIntegrable (fun _ ↦ (0 : ε'')) μ :=
+  (integrable_zero X ε'' μ).locallyIntegrable
 
-theorem locallyIntegrableOn_zero : LocallyIntegrableOn (fun _ ↦ (0 : E)) s μ :=
+theorem locallyIntegrableOn_zero : LocallyIntegrableOn (fun _ ↦ (0 : ε'')) s μ :=
   locallyIntegrable_zero.locallyIntegrableOn s
 
-theorem LocallyIntegrable.indicator (hf : LocallyIntegrable f μ) {s : Set X}
+theorem LocallyIntegrable.indicator {f : X → ε''} (hf : LocallyIntegrable f μ) {s : Set X}
     (hs : MeasurableSet s) : LocallyIntegrable (s.indicator f) μ := by
   intro x
   rcases hf x with ⟨U, hU, h'U⟩
@@ -291,32 +324,36 @@ theorem locallyIntegrable_map_homeomorph [BorelSpace X] [BorelSpace Y] (e : X �
     ext x
     simp only [mem_preimage, Homeomorph.symm_apply_apply]
 
-protected theorem LocallyIntegrable.add (hf : LocallyIntegrable f μ) (hg : LocallyIntegrable g μ) :
-    LocallyIntegrable (f + g) μ := fun x ↦ (hf x).add (hg x)
+protected theorem LocallyIntegrable.add [ContinuousAdd ε''] {f g : X → ε''}
+    (hf : LocallyIntegrable f μ) (hg : LocallyIntegrable g μ) : LocallyIntegrable (f + g) μ :=
+  fun x ↦ (hf x).add (hg x)
 
-protected theorem LocallyIntegrable.sub (hf : LocallyIntegrable f μ) (hg : LocallyIntegrable g μ) :
-    LocallyIntegrable (f - g) μ := fun x ↦ (hf x).sub (hg x)
+protected theorem LocallyIntegrable.sub {f g : X → E}
+    (hf : LocallyIntegrable f μ) (hg : LocallyIntegrable g μ) : LocallyIntegrable (f - g) μ :=
+  fun x ↦ (hf x).sub (hg x)
 
-protected theorem LocallyIntegrable.neg (hf : LocallyIntegrable f μ) :
+protected theorem LocallyIntegrable.neg {f : X → E} (hf : LocallyIntegrable f μ) :
     LocallyIntegrable (-f) μ := fun x ↦ (hf x).neg
 
-protected theorem LocallyIntegrable.smul {𝕜 : Type*} [NormedAddCommGroup 𝕜] [SMulZeroClass 𝕜 E]
-    [IsBoundedSMul 𝕜 E] (hf : LocallyIntegrable f μ) (c : 𝕜) :
+protected theorem LocallyIntegrable.smul {f : X → E} {𝕜 : Type*} [NormedAddCommGroup 𝕜]
+    [SMulZeroClass 𝕜 E] [IsBoundedSMul 𝕜 E] (hf : LocallyIntegrable f μ) (c : 𝕜) :
     LocallyIntegrable (c • f) μ := fun x ↦ (hf x).smul c
 
-theorem locallyIntegrable_finset_sum' {ι} (s : Finset ι) {f : ι → X → E}
+variable {ε''' : Type*} [TopologicalSpace ε'''] [ENormedAddCommMonoid ε'''] [ContinuousAdd ε'''] in
+theorem locallyIntegrable_finset_sum' {ι} (s : Finset ι) {f : ι → X → ε'''}
     (hf : ∀ i ∈ s, LocallyIntegrable (f i) μ) : LocallyIntegrable (∑ i ∈ s, f i) μ :=
   Finset.sum_induction f (fun g => LocallyIntegrable g μ) (fun _ _ => LocallyIntegrable.add)
     locallyIntegrable_zero hf
 
-theorem locallyIntegrable_finset_sum {ι} (s : Finset ι) {f : ι → X → E}
+variable {ε''' : Type*} [TopologicalSpace ε'''] [ENormedAddCommMonoid ε'''] [ContinuousAdd ε'''] in
+theorem locallyIntegrable_finset_sum {ι} (s : Finset ι) {f : ι → X → ε'''}
     (hf : ∀ i ∈ s, LocallyIntegrable (f i) μ) : LocallyIntegrable (fun a ↦ ∑ i ∈ s, f i a) μ := by
   simpa only [← Finset.sum_apply] using locallyIntegrable_finset_sum' s hf
 
 /-- If `f` is locally integrable and `g` is continuous with compact support,
 then `g • f` is integrable. -/
 theorem LocallyIntegrable.integrable_smul_left_of_hasCompactSupport
-    [NormedSpace ℝ E] [OpensMeasurableSpace X] [T2Space X]
+    [NormedSpace ℝ E] [OpensMeasurableSpace X] [T2Space X] {f : X → E}
     (hf : LocallyIntegrable f μ) {g : X → ℝ} (hg : Continuous g) (h'g : HasCompactSupport g) :
     Integrable (fun x ↦ g x • f x) μ := by
   let K := tsupport g
@@ -353,35 +390,40 @@ theorem LocallyIntegrable.integrable_smul_right_of_hasCompactSupport
 
 open Filter
 
-theorem integrable_iff_integrableAtFilter_cocompact :
+theorem integrable_iff_integrableAtFilter_cocompact [PseudoMetrizableSpace ε] :
     Integrable f μ ↔ (IntegrableAtFilter f (cocompact X) μ ∧ LocallyIntegrable f μ) := by
   refine ⟨fun hf ↦ ⟨hf.integrableAtFilter _, hf.locallyIntegrable⟩, fun ⟨⟨s, hsc, hs⟩, hloc⟩ ↦ ?_⟩
   obtain ⟨t, htc, ht⟩ := mem_cocompact'.mp hsc
   rewrite [← integrableOn_univ, ← compl_union_self s, integrableOn_union]
   exact ⟨(hloc.integrableOn_isCompact htc).mono ht le_rfl, hs⟩
 
-theorem integrable_iff_integrableAtFilter_atBot_atTop [LinearOrder X] [CompactIccSpace X] :
+theorem integrable_iff_integrableAtFilter_atBot_atTop
+    [PseudoMetrizableSpace ε''] {f : X → ε''} [LinearOrder X] [CompactIccSpace X] :
     Integrable f μ ↔
     (IntegrableAtFilter f atBot μ ∧ IntegrableAtFilter f atTop μ) ∧ LocallyIntegrable f μ := by
   constructor
   · exact fun hf ↦ ⟨⟨hf.integrableAtFilter _, hf.integrableAtFilter _⟩, hf.locallyIntegrable⟩
   · refine fun h ↦ integrable_iff_integrableAtFilter_cocompact.mpr ⟨?_, h.2⟩
+    have aux := (IntegrableAtFilter.sup_iff.mpr h.1)
     exact (IntegrableAtFilter.sup_iff.mpr h.1).filter_mono cocompact_le_atBot_atTop
 
-theorem integrable_iff_integrableAtFilter_atBot [LinearOrder X] [OrderTop X] [CompactIccSpace X] :
+theorem integrable_iff_integrableAtFilter_atBot
+    [PseudoMetrizableSpace ε] [LinearOrder X] [OrderTop X] [CompactIccSpace X] :
     Integrable f μ ↔ IntegrableAtFilter f atBot μ ∧ LocallyIntegrable f μ := by
   constructor
   · exact fun hf ↦ ⟨hf.integrableAtFilter _, hf.locallyIntegrable⟩
   · refine fun h ↦ integrable_iff_integrableAtFilter_cocompact.mpr ⟨?_, h.2⟩
     exact h.1.filter_mono cocompact_le_atBot
 
-theorem integrable_iff_integrableAtFilter_atTop [LinearOrder X] [OrderBot X] [CompactIccSpace X] :
+theorem integrable_iff_integrableAtFilter_atTop
+    [PseudoMetrizableSpace ε] [LinearOrder X] [OrderBot X] [CompactIccSpace X] :
     Integrable f μ ↔ IntegrableAtFilter f atTop μ ∧ LocallyIntegrable f μ :=
   integrable_iff_integrableAtFilter_atBot (X := Xᵒᵈ)
 
 variable {a : X}
 
-theorem integrableOn_Iic_iff_integrableAtFilter_atBot [LinearOrder X] [CompactIccSpace X] :
+theorem integrableOn_Iic_iff_integrableAtFilter_atBot
+    [PseudoMetrizableSpace ε] [LinearOrder X] [CompactIccSpace X] :
     IntegrableOn f (Iic a) μ ↔ IntegrableAtFilter f atBot μ ∧ LocallyIntegrableOn f (Iic a) μ := by
   refine ⟨fun h ↦ ⟨⟨Iic a, Iic_mem_atBot a, h⟩, h.locallyIntegrableOn⟩, fun ⟨⟨s, hsl, hs⟩, h⟩ ↦ ?_⟩
   haveI : Nonempty X := Nonempty.intro a
@@ -389,12 +431,13 @@ theorem integrableOn_Iic_iff_integrableAtFilter_atBot [LinearOrder X] [CompactIc
   refine (integrableOn_union.mpr ⟨hs.mono ha' le_rfl, ?_⟩).mono Iic_subset_Iic_union_Icc le_rfl
   exact h.integrableOn_compact_subset Icc_subset_Iic_self isCompact_Icc
 
-theorem integrableOn_Ici_iff_integrableAtFilter_atTop [LinearOrder X] [CompactIccSpace X] :
+theorem integrableOn_Ici_iff_integrableAtFilter_atTop
+    [PseudoMetrizableSpace ε] [LinearOrder X] [CompactIccSpace X] :
     IntegrableOn f (Ici a) μ ↔ IntegrableAtFilter f atTop μ ∧ LocallyIntegrableOn f (Ici a) μ :=
   integrableOn_Iic_iff_integrableAtFilter_atBot (X := Xᵒᵈ)
 
 theorem integrableOn_Iio_iff_integrableAtFilter_atBot_nhdsWithin
-    [LinearOrder X] [CompactIccSpace X] [NoMinOrder X] [OrderTopology X] :
+    [PseudoMetrizableSpace ε] [LinearOrder X] [CompactIccSpace X] [NoMinOrder X] [OrderTopology X] :
     IntegrableOn f (Iio a) μ ↔ IntegrableAtFilter f atBot μ ∧
     IntegrableAtFilter f (𝓝[<] a) μ ∧ LocallyIntegrableOn f (Iio a) μ := by
   constructor
@@ -407,7 +450,7 @@ theorem integrableOn_Iio_iff_integrableAtFilter_atBot_nhdsWithin
       ⟨hbot, hlocal.mono_set (Iic_subset_Iio.mpr hs'_mono)⟩
 
 theorem integrableOn_Ioi_iff_integrableAtFilter_atTop_nhdsWithin
-    [LinearOrder X] [CompactIccSpace X] [NoMaxOrder X] [OrderTopology X] :
+    [PseudoMetrizableSpace ε] [LinearOrder X] [CompactIccSpace X] [NoMaxOrder X] [OrderTopology X] :
     IntegrableOn f (Ioi a) μ ↔ IntegrableAtFilter f atTop μ ∧
     IntegrableAtFilter f (𝓝[>] a) μ ∧ LocallyIntegrableOn f (Ioi a) μ :=
   integrableOn_Iio_iff_integrableAtFilter_atBot_nhdsWithin (X := Xᵒᵈ)
@@ -419,7 +462,7 @@ open MeasureTheory
 section borel
 
 variable [OpensMeasurableSpace X]
-variable {K : Set X} {a b : X}
+variable {K : Set X} {f : X → E} {a b : X}
 
 /-- A continuous function `f` is locally integrable with respect to any locally finite measure. -/
 theorem Continuous.locallyIntegrable [IsLocallyFiniteMeasure μ] [SecondCountableTopologyEither X E]
@@ -490,6 +533,7 @@ section Monotone
 
 variable [BorelSpace X] [ConditionallyCompleteLinearOrder X] [ConditionallyCompleteLinearOrder E]
   [OrderTopology X] [OrderTopology E] [SecondCountableTopology E] {p : ℝ≥0∞}
+  {f : X → E}
 
 theorem MonotoneOn.memLp_top (hmono : MonotoneOn f s) {a b : X}
     (ha : IsLeast s a) (hb : IsGreatest s b) (h's : MeasurableSet s) :

--- a/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
+++ b/Mathlib/MeasureTheory/Function/LocallyIntegrable.lean
@@ -169,7 +169,7 @@ protected theorem LocallyIntegrableOn.neg {f : X → E} (hf : LocallyIntegrableO
 
 end LocallyIntegrableOn
 
-/-- A function `f : X → E` is *locally integrable* if it is integrable on a neighborhood of every
+/-- A function `f : X → ε` is *locally integrable* if it is integrable on a neighborhood of every
 point. In particular, it is integrable on all compact sets,
 see `LocallyIntegrable.integrableOn_isCompact`. -/
 def LocallyIntegrable (f : X → ε) (μ : Measure X := by volume_tac) : Prop :=
@@ -310,7 +310,7 @@ theorem LocallyIntegrable.indicator {f : X → ε''} (hf : LocallyIntegrable f �
   rcases hf x with ⟨U, hU, h'U⟩
   exact ⟨U, hU, h'U.indicator hs⟩
 
-theorem locallyIntegrable_map_homeomorph [BorelSpace X] [BorelSpace Y] (e : X ≃ₜ Y) {f : Y → E}
+theorem locallyIntegrable_map_homeomorph [BorelSpace X] [BorelSpace Y] (e : X ≃ₜ Y) {f : Y → ε''}
     {μ : Measure X} : LocallyIntegrable f (Measure.map e μ) ↔ LocallyIntegrable (f ∘ e) μ := by
   refine ⟨fun h x => ?_, fun h x => ?_⟩
   · rcases h (e x) with ⟨U, hU, h'U⟩
@@ -390,7 +390,9 @@ theorem LocallyIntegrable.integrable_smul_right_of_hasCompactSupport
 
 open Filter
 
-theorem integrable_iff_integrableAtFilter_cocompact [PseudoMetrizableSpace ε] :
+variable [PseudoMetrizableSpace ε]
+
+theorem integrable_iff_integrableAtFilter_cocompact :
     Integrable f μ ↔ (IntegrableAtFilter f (cocompact X) μ ∧ LocallyIntegrable f μ) := by
   refine ⟨fun hf ↦ ⟨hf.integrableAtFilter _, hf.locallyIntegrable⟩, fun ⟨⟨s, hsc, hs⟩, hloc⟩ ↦ ?_⟩
   obtain ⟨t, htc, ht⟩ := mem_cocompact'.mp hsc
@@ -407,23 +409,20 @@ theorem integrable_iff_integrableAtFilter_atBot_atTop
     have aux := (IntegrableAtFilter.sup_iff.mpr h.1)
     exact (IntegrableAtFilter.sup_iff.mpr h.1).filter_mono cocompact_le_atBot_atTop
 
-theorem integrable_iff_integrableAtFilter_atBot
-    [PseudoMetrizableSpace ε] [LinearOrder X] [OrderTop X] [CompactIccSpace X] :
+theorem integrable_iff_integrableAtFilter_atBot [LinearOrder X] [OrderTop X] [CompactIccSpace X] :
     Integrable f μ ↔ IntegrableAtFilter f atBot μ ∧ LocallyIntegrable f μ := by
   constructor
   · exact fun hf ↦ ⟨hf.integrableAtFilter _, hf.locallyIntegrable⟩
   · refine fun h ↦ integrable_iff_integrableAtFilter_cocompact.mpr ⟨?_, h.2⟩
     exact h.1.filter_mono cocompact_le_atBot
 
-theorem integrable_iff_integrableAtFilter_atTop
-    [PseudoMetrizableSpace ε] [LinearOrder X] [OrderBot X] [CompactIccSpace X] :
+theorem integrable_iff_integrableAtFilter_atTop [LinearOrder X] [OrderBot X] [CompactIccSpace X] :
     Integrable f μ ↔ IntegrableAtFilter f atTop μ ∧ LocallyIntegrable f μ :=
   integrable_iff_integrableAtFilter_atBot (X := Xᵒᵈ)
 
 variable {a : X}
 
-theorem integrableOn_Iic_iff_integrableAtFilter_atBot
-    [PseudoMetrizableSpace ε] [LinearOrder X] [CompactIccSpace X] :
+theorem integrableOn_Iic_iff_integrableAtFilter_atBot [LinearOrder X] [CompactIccSpace X] :
     IntegrableOn f (Iic a) μ ↔ IntegrableAtFilter f atBot μ ∧ LocallyIntegrableOn f (Iic a) μ := by
   refine ⟨fun h ↦ ⟨⟨Iic a, Iic_mem_atBot a, h⟩, h.locallyIntegrableOn⟩, fun ⟨⟨s, hsl, hs⟩, h⟩ ↦ ?_⟩
   haveI : Nonempty X := Nonempty.intro a
@@ -431,13 +430,12 @@ theorem integrableOn_Iic_iff_integrableAtFilter_atBot
   refine (integrableOn_union.mpr ⟨hs.mono ha' le_rfl, ?_⟩).mono Iic_subset_Iic_union_Icc le_rfl
   exact h.integrableOn_compact_subset Icc_subset_Iic_self isCompact_Icc
 
-theorem integrableOn_Ici_iff_integrableAtFilter_atTop
-    [PseudoMetrizableSpace ε] [LinearOrder X] [CompactIccSpace X] :
+theorem integrableOn_Ici_iff_integrableAtFilter_atTop [LinearOrder X] [CompactIccSpace X] :
     IntegrableOn f (Ici a) μ ↔ IntegrableAtFilter f atTop μ ∧ LocallyIntegrableOn f (Ici a) μ :=
   integrableOn_Iic_iff_integrableAtFilter_atBot (X := Xᵒᵈ)
 
 theorem integrableOn_Iio_iff_integrableAtFilter_atBot_nhdsWithin
-    [PseudoMetrizableSpace ε] [LinearOrder X] [CompactIccSpace X] [NoMinOrder X] [OrderTopology X] :
+    [LinearOrder X] [CompactIccSpace X] [NoMinOrder X] [OrderTopology X] :
     IntegrableOn f (Iio a) μ ↔ IntegrableAtFilter f atBot μ ∧
     IntegrableAtFilter f (𝓝[<] a) μ ∧ LocallyIntegrableOn f (Iio a) μ := by
   constructor
@@ -450,7 +448,7 @@ theorem integrableOn_Iio_iff_integrableAtFilter_atBot_nhdsWithin
       ⟨hbot, hlocal.mono_set (Iic_subset_Iio.mpr hs'_mono)⟩
 
 theorem integrableOn_Ioi_iff_integrableAtFilter_atTop_nhdsWithin
-    [PseudoMetrizableSpace ε] [LinearOrder X] [CompactIccSpace X] [NoMaxOrder X] [OrderTopology X] :
+    [LinearOrder X] [CompactIccSpace X] [NoMaxOrder X] [OrderTopology X] :
     IntegrableOn f (Ioi a) μ ↔ IntegrableAtFilter f atTop μ ∧
     IntegrableAtFilter f (𝓝[>] a) μ ∧ LocallyIntegrableOn f (Ioi a) μ :=
   integrableOn_Iio_iff_integrableAtFilter_atBot_nhdsWithin (X := Xᵒᵈ)

--- a/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
+++ b/Mathlib/MeasureTheory/Integral/IntegrableOn.lean
@@ -513,12 +513,13 @@ theorem IntegrableAtFilter.inf_ae_iff {l : Filter α} :
 alias ⟨IntegrableAtFilter.of_inf_ae, _⟩ := IntegrableAtFilter.inf_ae_iff
 
 @[simp]
-theorem integrableAtFilter_top {f : α → E} : IntegrableAtFilter f ⊤ μ ↔ Integrable f μ := by
+theorem integrableAtFilter_top [PseudoMetrizableSpace ε'] {f : α → ε'} :
+    IntegrableAtFilter f ⊤ μ ↔ Integrable f μ := by
   refine ⟨fun h ↦ ?_, fun h ↦ h.integrableAtFilter ⊤⟩
   obtain ⟨s, hsf, hs⟩ := h
   exact (integrableOn_iff_integrable_of_support_subset fun _ _ ↦ hsf _).mp hs
 
-theorem IntegrableAtFilter.sup_iff {f : α → E} {l l' : Filter α} :
+theorem IntegrableAtFilter.sup_iff [PseudoMetrizableSpace ε'] {f : α → ε'} {l l' : Filter α} :
     IntegrableAtFilter f (l ⊔ l') μ ↔ IntegrableAtFilter f l μ ∧ IntegrableAtFilter f l' μ := by
   constructor
   · exact fun h => ⟨h.filter_mono le_sup_left, h.filter_mono le_sup_right⟩


### PR DESCRIPTION
---

This is not exhaustive; all `smul` lemmas can also be generalised (assuming suitable typeclasses).
That will happen in a separate PR.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
