### PR TITLE
[Merged by Bors] - chore: scope the instances giving a normed space structure from a Riemannian bundle instance

### DIFF
--- a/Mathlib/Analysis/NormedSpace/OperatorNorm/NormedSpace.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm/NormedSpace.lean
@@ -205,9 +205,7 @@ theorem opNorm_comp_linearIsometryEquiv (f : F →SL[σ₂₃] G) (g : F' ≃ₛ
     haveI := g.symm.surjective.nontrivial
     simp [g.symm.toLinearIsometry.norm_toContinuousLinearMap]
 
--- `SeminormedAddGroup (Fₗ →L[𝕜] E →L[𝕜] Fₗ)` is too slow to synthesize in the `simpNF` linter,
--- which fails on this lemma with a deterministic timeout
-@[simp, nolint simpNF]
+@[simp]
 theorem norm_smulRightL (c : E →L[𝕜] 𝕜) [Nontrivial Fₗ] : ‖smulRightL 𝕜 E Fₗ c‖ = ‖c‖ :=
   ContinuousLinearMap.homothety_norm _ c.norm_smulRight_apply
 

--- a/Mathlib/Geometry/Manifold/Riemannian/Basic.lean
+++ b/Mathlib/Geometry/Manifold/Riemannian/Basic.lean
@@ -28,6 +28,7 @@ By definition, it then satisfies the predicate `IsRiemannianManifold I M`.
 
 The following code block is the standard way to say "Let `M` be a `C^∞` Riemannian manifold".
 ```
+open scoped Bundle
 variable
   {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}

--- a/Mathlib/Geometry/Manifold/VectorBundle/Riemannian.lean
+++ b/Mathlib/Geometry/Manifold/VectorBundle/Riemannian.lean
@@ -18,8 +18,9 @@ the bundle is a smooth function.
 If the fibers of a bundle `E` have a preexisting topology (like the tangent bundle), one can not
 assume additionally `[∀ b, InnerProductSpace ℝ (E b)]` as this would create diamonds. Instead,
 use `[RiemannianBundle E]`, which endows the fibers with a scalar product while ensuring that
-there is no diamond. We provide a constructor for `[RiemannianBundle E]` from a smooth family
-of metrics, which registers automatically `[IsContMDiffRiemannianBundle IB n F E]`.
+there is no diamond (for this, the `Bundle` scope should be open). We provide a
+constructor for `[RiemannianBundle E]` from a smooth family of metrics, which registers
+automatically `[IsContMDiffRiemannianBundle IB n F E]`.
 
 The following code block is the standard way to say "Let `E` be a smooth vector bundle equipped with
 a `C^n` Riemannian structure over a `C^n` manifold `B`":

--- a/Mathlib/Topology/VectorBundle/Riemannian.lean
+++ b/Mathlib/Topology/VectorBundle/Riemannian.lean
@@ -426,7 +426,8 @@ a `NormedAddCommGroup` structure.
 
 The normal priority for an instance which always applies like this one should be 100.
 We use 80 as this is rather specialized, so we want other paths to be tried first typically.
-As this instance is costly and quite specific, we also scope it to the `Bundle` namespace. -/
+As this instance is quite specific and very costly because of higher order unification, we
+also scope it to the `Bundle` namespace. -/
 noncomputable scoped instance (priority := 80) [h : RiemannianBundle E] (b : B) :
     NormedAddCommGroup (E b) :=
   (h.g.toCore b).toNormedAddCommGroupOfTopology (h.g.continuousAt b) (h.g.isVonNBounded b)
@@ -436,7 +437,8 @@ an `InnerProductSpace ℝ` structure.
 
 The normal priority for an instance which always applies like this one should be 100.
 We use 80 as this is rather specialized, so we want other paths to be tried first typically.
-As this instance is costly and quite specific, we also scope it to the `Bundle` namespace. -/
+As this instance is quite specific and very costly because of higher order unification, we
+also scope it to the `Bundle` namespace. -/
 noncomputable scoped instance (priority := 80) [h : RiemannianBundle E] (b : B) :
     InnerProductSpace ℝ (E b) :=
   .ofCoreOfTopology (h.g.toCore b) (h.g.continuousAt b) (h.g.isVonNBounded b)

--- a/Mathlib/Topology/VectorBundle/Riemannian.lean
+++ b/Mathlib/Topology/VectorBundle/Riemannian.lean
@@ -421,16 +421,22 @@ class RiemannianBundle where
   /-- The family of inner products on the fibers -/
   g : RiemannianMetric E
 
-/- The normal priority for an instance which always applies like this one should be 100.
+/-- A fiber in a bundle satisfying the `[RiemannianBundle E]` typeclass inherits
+a `NormedAddCommGroup` structure.
+
+The normal priority for an instance which always applies like this one should be 100.
 We use 80 as this is rather specialized, so we want other paths to be tried first typically.
-As this instance is costly and quite specific, we scope it to the `Bundle` namespace. -/
+As this instance is costly and quite specific, we also scope it to the `Bundle` namespace. -/
 noncomputable scoped instance (priority := 80) [h : RiemannianBundle E] (b : B) :
     NormedAddCommGroup (E b) :=
   (h.g.toCore b).toNormedAddCommGroupOfTopology (h.g.continuousAt b) (h.g.isVonNBounded b)
 
-/- The normal priority for an instance which always applies like this one should be 100.
+/-- A fiber in a bundle satisfying the `[RiemannianBundle E]` typeclass inherits
+an `InnerProductSpace ℝ` structure.
+
+The normal priority for an instance which always applies like this one should be 100.
 We use 80 as this is rather specialized, so we want other paths to be tried first typically.
-As this instance is costly and quite specific, we scope it to the `Bundle` namespace. -/
+As this instance is costly and quite specific, we also scope it to the `Bundle` namespace. -/
 noncomputable scoped instance (priority := 80) [h : RiemannianBundle E] (b : B) :
     InnerProductSpace ℝ (E b) :=
   .ofCoreOfTopology (h.g.toCore b) (h.g.continuousAt b) (h.g.isVonNBounded b)

--- a/Mathlib/Topology/VectorBundle/Riemannian.lean
+++ b/Mathlib/Topology/VectorBundle/Riemannian.lean
@@ -29,6 +29,8 @@ depends continuously on the base point, we register automatically an instance of
 
 The general theory should be built assuming `[IsContinuousRiemannianBundle F E]`, while the
 `[RiemannianBundle E]` mechanism is only to build data in specific situations.
+As instances related to Riemannian bundles are both costly and quite specific, they are scoped
+to the `Bundle` namespace.
 
 ## Keywords
 Vector bundle, Riemannian metric
@@ -420,14 +422,16 @@ class RiemannianBundle where
   g : RiemannianMetric E
 
 /- The normal priority for an instance which always applies like this one should be 100.
-We use 80 as this is rather specialized, so we want other paths to be tried first typically. -/
-noncomputable instance (priority := 80) [h : RiemannianBundle E] (b : B) :
+We use 80 as this is rather specialized, so we want other paths to be tried first typically.
+As this instance is costly and quite specific, we scope it to the `Bundle` namespace. -/
+noncomputable scoped instance (priority := 80) [h : RiemannianBundle E] (b : B) :
     NormedAddCommGroup (E b) :=
   (h.g.toCore b).toNormedAddCommGroupOfTopology (h.g.continuousAt b) (h.g.isVonNBounded b)
 
 /- The normal priority for an instance which always applies like this one should be 100.
-We use 80 as this is rather specialized, so we want other paths to be tried first typically. -/
-noncomputable instance (priority := 80) [h : RiemannianBundle E] (b : B) :
+We use 80 as this is rather specialized, so we want other paths to be tried first typically.
+As this instance is costly and quite specific, we scope it to the `Bundle` namespace. -/
+noncomputable scoped instance (priority := 80) [h : RiemannianBundle E] (b : B) :
     InnerProductSpace ℝ (E b) :=
   .ofCoreOfTopology (h.g.toCore b) (h.g.continuousAt b) (h.g.isVonNBounded b)
 


### PR DESCRIPTION
These are costly and quite specific. See discussion at [#mathlib4 > type-class inference slow/timing out @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/type-class.20inference.20slow.2Ftiming.20out/near/530312318)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
