### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/BilinearMap): semi-linearize

### DIFF
--- a/Mathlib/Algebra/Module/Equiv/Defs.lean
+++ b/Mathlib/Algebra/Module/Equiv/Defs.lean
@@ -352,11 +352,9 @@ theorem apply_symm_apply (c : M₂) : e (e.symm c) = c :=
 theorem symm_apply_apply (b : M) : e.symm (e b) = b :=
   e.left_inv b
 
-@[simp]
 theorem comp_symm : e.toLinearMap ∘ₛₗ e.symm.toLinearMap = LinearMap.id :=
   LinearMap.ext e.apply_symm_apply
 
-@[simp]
 theorem symm_comp : e.symm.toLinearMap ∘ₛₗ e.toLinearMap = LinearMap.id :=
   LinearMap.ext e.symm_apply_apply
 
@@ -393,6 +391,11 @@ theorem eq_symm_comp {α : Type*} (f : α → M₁) (g : α → M₂) : f = e₁
 
 theorem symm_comp_eq {α : Type*} (f : α → M₁) (g : α → M₂) : e₁₂.symm ∘ g = f ↔ g = e₁₂ ∘ f :=
   e₁₂.toEquiv.symm_comp_eq f g
+
+@[simp]
+theorem comp_coe (f : M₁ ≃ₛₗ[σ₁₂] M₂) (f' : M₂ ≃ₛₗ[σ₂₃] M₃) :
+    (f' : M₂ →ₛₗ[σ₂₃] M₃).comp (f : M₁ →ₛₗ[σ₁₂] M₂) = (f.trans f' : M₁ ≃ₛₗ[σ₁₃] M₃) :=
+  rfl
 
 lemma trans_assoc (e₁₂ : M₁ ≃ₛₗ[σ₁₂] M₂) (e₂₃ : M₂ ≃ₛₗ[σ₂₃] M₃) (e₃₄ : M₃ ≃ₛₗ[σ₃₄] M₄) :
     (e₁₂.trans e₂₃).trans e₃₄ = e₁₂.trans (e₂₃.trans e₃₄) := rfl
@@ -475,11 +478,6 @@ theorem symm_trans_self (f : M₁ ≃ₛₗ[σ₁₂] M₂) : f.symm.trans f = L
 
 @[simp]
 theorem refl_toLinearMap [Module R M] : (LinearEquiv.refl R M : M →ₗ[R] M) = LinearMap.id :=
-  rfl
-
-@[simp]
-theorem comp_coe [Module R M] [Module R M₂] [Module R M₃] (f : M ≃ₗ[R] M₂) (f' : M₂ ≃ₗ[R] M₃) :
-    (f' : M₂ →ₗ[R] M₃).comp (f : M →ₗ[R] M₂) = (f.trans f' : M ≃ₗ[R] M₃) :=
   rfl
 
 @[simp]

--- a/Mathlib/LinearAlgebra/BilinearMap.lean
+++ b/Mathlib/LinearAlgebra/BilinearMap.lean
@@ -413,8 +413,8 @@ theorem llcomp_apply (f : N →ₛₗ[σ₂₃] P) (g : M →ₛₗ[σ₁₂] N)
 theorem llcomp_apply' (f : N →ₛₗ[σ₂₃] P) (g : M →ₛₗ[σ₁₂] N) : llcomp _ M N P f g = f ∘ₛₗ g := rfl
 
 omit [Module R M] in
-/-- Composing a linear map `P → Q` and a bilinear map `M → N → P` to
-form a bilinear map `M → N → Q`. -/
+/-- Composing a linear map `P →ₛₗ[σ₃₄] Q` and a bilinear map `M →ₛₗ[σ₁₃] N →ₛₗ[σ₂₃] P` to
+form a bilinear map `M →ₛₗ[σ₁₄] N →ₛₗ[σ₂₄] Q`. -/
 def compr₂ₛₗ (f : M →ₛₗ[σ₁₃] N →ₛₗ[σ₂₃] P) (g : P →ₛₗ[σ₃₄] Q) : M →ₛₗ[σ₁₄] N →ₛₗ[σ₂₄] Q :=
   llcomp _ N P Q g ∘ₛₗ f
 

--- a/Mathlib/LinearAlgebra/BilinearMap.lean
+++ b/Mathlib/LinearAlgebra/BilinearMap.lean
@@ -322,7 +322,8 @@ theorem lcomp_apply' (f : M →ₗ[R] Nₗ) (g : Nₗ →ₗ[R] Pₗ) : lcomp A 
 variable (M N P)
 
 variable (R₃) in
-/-- Composing linear maps as a bilinear map from `(M →ₗ[σ₁₂] N) × (N →ₗ[σ₂₃] P)` to `M →ₗ[σ₁₃] P` -/
+/-- Composing linear maps as a bilinear map from `(M →ₛₗ[σ₁₂] N) × (N →ₛₗ[σ₂₃] P)`
+to `M →ₛₗ[σ₁₃] P`. -/
 def llcomp : (N →ₛₗ[σ₂₃] P) →ₗ[R₃] (M →ₛₗ[σ₁₂] N) →ₛₗ[σ₂₃] M →ₛₗ[σ₁₃] P :=
   flip
     { toFun := lcompₛₗ _ P σ₂₃

--- a/Mathlib/LinearAlgebra/BilinearMap.lean
+++ b/Mathlib/LinearAlgebra/BilinearMap.lean
@@ -382,8 +382,7 @@ theorem bijective_compr₂_of_equiv (f : M →ₗ[R] Nₗ →ₗ[R] Pₗ) (g : P
   surjective_compr₂_of_equiv f g hf.2⟩
 
 section CommSemiringSemilinear
-variable {R R₁ R₂ R₃ R₄ : Type*} [CommSemiring R] [Semiring R₁] [CommSemiring R₂]
-  [CommSemiring R₃] [CommSemiring R₄]
+variable {R₂ R₃ R₄ : Type*} [CommSemiring R₂] [CommSemiring R₃] [CommSemiring R₄]
 variable {M : Type*} {N : Type*} {P : Type*} {Q : Type*}
 variable [AddCommMonoid M] [AddCommMonoid N] [AddCommMonoid P] [AddCommMonoid Q]
 variable [Module R M] [Module R₂ N] [Module R₃ P] [Module R₄ Q]

--- a/Mathlib/LinearAlgebra/BilinearMap.lean
+++ b/Mathlib/LinearAlgebra/BilinearMap.lean
@@ -414,7 +414,8 @@ theorem llcomp_apply' (f : N →ₛₗ[σ₂₃] P) (g : M →ₛₗ[σ₁₂] N
 
 omit [Module R M] in
 /-- Composing a linear map `P →ₛₗ[σ₃₄] Q` and a bilinear map `M →ₛₗ[σ₁₃] N →ₛₗ[σ₂₃] P` to
-form a bilinear map `M →ₛₗ[σ₁₄] N →ₛₗ[σ₂₄] Q`. -/
+form a bilinear map `M →ₛₗ[σ₁₄] N →ₛₗ[σ₂₄] Q`.
+This is the semi-linear version of `LinearMap.compr₂`. -/
 def compr₂ₛₗ (f : M →ₛₗ[σ₁₃] N →ₛₗ[σ₂₃] P) (g : P →ₛₗ[σ₃₄] Q) : M →ₛₗ[σ₁₄] N →ₛₗ[σ₂₄] Q :=
   llcomp _ N P Q g ∘ₛₗ f
 

--- a/Mathlib/LinearAlgebra/BilinearMap.lean
+++ b/Mathlib/LinearAlgebra/BilinearMap.lean
@@ -387,10 +387,8 @@ variable {R₂ R₃ R₄ M N P Q : Type*}
 variable [CommSemiring R₂] [CommSemiring R₃] [CommSemiring R₄]
 variable [AddCommMonoid M] [AddCommMonoid N] [AddCommMonoid P] [AddCommMonoid Q]
 variable [Module R M] [Module R₂ N] [Module R₃ P] [Module R₄ Q]
-variable {σ₁₂ : R →+* R₂} {σ₁₃ : R →+* R₃} {σ₁₄ : R →+* R₄}
-variable {σ₂₃ : R₂ →+* R₃} {σ₂₄ : R₂ →+* R₄}
-variable {σ₃₄ : R₃ →+* R₄}
-variable {σ₄₂ : R₄ →+* R₂} {σ₄₃ : R₄ →+* R₃}
+variable {σ₁₂ : R →+* R₂} {σ₁₃ : R →+* R₃} {σ₁₄ : R →+* R₄} {σ₂₃ : R₂ →+* R₃}
+variable {σ₂₄ : R₂ →+* R₄} {σ₃₄ : R₃ →+* R₄} {σ₄₂ : R₄ →+* R₂} {σ₄₃ : R₄ →+* R₃}
 variable [RingHomCompTriple σ₁₂ σ₂₃ σ₁₃] [RingHomCompTriple σ₄₂ σ₂₃ σ₄₃]
 variable [RingHomCompTriple σ₂₃ σ₃₄ σ₂₄] [RingHomCompTriple σ₁₃ σ₃₄ σ₁₄]
 variable [RingHomCompTriple σ₂₄ σ₄₃ σ₂₃]

--- a/Mathlib/LinearAlgebra/BilinearMap.lean
+++ b/Mathlib/LinearAlgebra/BilinearMap.lean
@@ -268,25 +268,17 @@ end Semiring
 
 section CommSemiring
 
-variable {R R₁ R₂ R₃ R₄ : Type*} [CommSemiring R] [Semiring R₁] [CommSemiring R₂]
-  [CommSemiring R₃] [CommSemiring R₄]
+variable {R R₁ R₂ : Type*} [CommSemiring R] [Semiring R₁] [Semiring R₂]
 variable {A : Type*} [Semiring A] {B : Type*} [Semiring B]
 variable {M : Type*} {N : Type*} {P : Type*} {Q : Type*}
 variable {Mₗ : Type*} {Nₗ : Type*} {Pₗ : Type*} {Qₗ Qₗ' : Type*}
 variable [AddCommMonoid M] [AddCommMonoid N] [AddCommMonoid P] [AddCommMonoid Q]
 variable [AddCommMonoid Mₗ] [AddCommMonoid Nₗ] [AddCommMonoid Pₗ]
 variable [AddCommMonoid Qₗ] [AddCommMonoid Qₗ']
-variable [Module R M] [Module R₂ N] [Module R₃ P] [Module R₄ Q]
+variable [Module R M]
 variable [Module R Mₗ] [Module R Nₗ] [Module R Pₗ] [Module R Qₗ] [Module R Qₗ']
-variable [Module R₁ Mₗ] [Module R₁ Pₗ] [Module R₁ Qₗ]
+variable [Module R₁ Mₗ] [Module R₂ N] [Module R₁ Pₗ] [Module R₁ Qₗ]
 variable [Module R₂ Pₗ] [Module R₂ Qₗ']
-variable {σ₁₂ : R →+* R₂} {σ₁₃ : R →+* R₃} {σ₁₄ : R →+* R₄}
-variable {σ₂₃ : R₂ →+* R₃} {σ₂₄ : R₂ →+* R₄}
-variable {σ₃₄ : R₃ →+* R₄}
-variable {σ₄₂ : R₄ →+* R₂} {σ₄₃ : R₄ →+* R₃}
-variable [RingHomCompTriple σ₁₂ σ₂₃ σ₁₃] [RingHomCompTriple σ₄₂ σ₂₃ σ₄₃]
-variable [RingHomCompTriple σ₂₃ σ₃₄ σ₂₄] [RingHomCompTriple σ₁₃ σ₃₄ σ₁₄]
-variable [RingHomCompTriple σ₂₄ σ₄₃ σ₂₃]
 variable (R)
 
 /-- Create a bilinear map from a function that is linear in each component.
@@ -304,7 +296,6 @@ theorem mk₂_apply (f : M → Nₗ → Pₗ) {H1 H2 H3 H4} (m : M) (n : Nₗ) :
 
 variable {R}
 
-
 variable (A Pₗ)
 variable [Module A Pₗ] [SMulCommClass R A Pₗ]
 
@@ -318,31 +309,6 @@ variable {A Pₗ}
 theorem lcomp_apply (f : M →ₗ[R] Nₗ) (g : Nₗ →ₗ[R] Pₗ) (x : M) : lcomp A _ f g x = g (f x) := rfl
 
 theorem lcomp_apply' (f : M →ₗ[R] Nₗ) (g : Nₗ →ₗ[R] Pₗ) : lcomp A Pₗ f g = g ∘ₗ f := rfl
-
-variable (M N P)
-
-variable (R₃) in
-/-- Composing linear maps as a bilinear map from `(M →ₛₗ[σ₁₂] N) × (N →ₛₗ[σ₂₃] P)`
-to `M →ₛₗ[σ₁₃] P`. -/
-def llcomp : (N →ₛₗ[σ₂₃] P) →ₗ[R₃] (M →ₛₗ[σ₁₂] N) →ₛₗ[σ₂₃] M →ₛₗ[σ₁₃] P :=
-  flip
-    { toFun := lcompₛₗ _ P σ₂₃
-      map_add' := fun _f _f' => ext₂ fun g _x => g.map_add _ _
-      map_smul' := fun (_c : R₂) _f => ext₂ fun g _x => g.map_smulₛₗ _ _ }
-
-variable {M N P}
-
-@[simp]
-theorem llcomp_apply (f : N →ₛₗ[σ₂₃] P) (g : M →ₛₗ[σ₁₂] N) (x : M) :
-    llcomp _ M N P f g x = f (g x) := rfl
-
-theorem llcomp_apply' (f : N →ₛₗ[σ₂₃] P) (g : M →ₛₗ[σ₁₂] N) : llcomp _ M N P f g = f ∘ₛₗ g := rfl
-
-section
-
-omit [CommSemiring R₂]
-
-variable [Semiring R₂] [Module R₂ Pₗ] [Module R₂ N] [Module R₂ Qₗ']
 
 /-- Composing linear maps `Q → M` and `Q' → N` with a bilinear map `M → N → P` to
 form a bilinear map `Q → Q' → P`. -/
@@ -377,17 +343,6 @@ theorem compl₁₂_inj [SMulCommClass R₂ R₁ Pₗ]
   · -- B₁ = B₂ → B₁.comp l r = B₂.comp l r
     subst h; rfl
 
-end
-
-omit [Module R M] in
-/-- Composing a linear map `P → Q` and a bilinear map `M → N → P` to
-form a bilinear map `M → N → Q`. -/
-def compr₂ₛₗ (f : M →ₛₗ[σ₁₃] N →ₛₗ[σ₂₃] P) (g : P →ₛₗ[σ₃₄] Q) : M →ₛₗ[σ₁₄] N →ₛₗ[σ₂₄] Q :=
-  llcomp _ N P Q g ∘ₛₗ f
-
-@[simp]
-theorem compr₂ₛₗ_apply (f : M →ₛₗ[σ₁₃] N →ₛₗ[σ₂₃] P) (g : P →ₛₗ[σ₃₄] Q) (m : M) (n : N) :
-    f.compr₂ₛₗ g m n = g (f m n) := rfl
 
 omit [Module R M] in
 /-- Composing a linear map `P → Q` and a bilinear map `M → N → P` to
@@ -407,13 +362,80 @@ theorem compr₂_apply [Module R A] [Module A M] [Module A Qₗ]
     f.compr₂ g m n = g (f m n) := rfl
 
 /-- A version of `Function.Injective.comp` for composition of a bilinear map with a linear map. -/
-theorem injective_compr₂ₛₗ_of_injective (f : M →ₛₗ[σ₁₃] N →ₛₗ[σ₂₃] P) (g : P →ₛₗ[σ₃₄] Q)
-    (hf : Injective f) (hg : Injective g) : Injective (f.compr₂ₛₗ g) :=
-  hg.injective_linearMapComp_left.comp hf
-
-/-- A version of `Function.Injective.comp` for composition of a bilinear map with a linear map. -/
 theorem injective_compr₂_of_injective (f : M →ₗ[R] Nₗ →ₗ[R] Pₗ) (g : Pₗ →ₗ[R] Qₗ) (hf : Injective f)
     (hg : Injective g) : Injective (f.compr₂ g) :=
+  hg.injective_linearMapComp_left.comp hf
+
+/-- A version of `Function.Surjective.comp` for composition of a bilinear map with a linear map. -/
+theorem surjective_compr₂_of_exists_rightInverse (f : M →ₗ[R] Nₗ →ₗ[R] Pₗ) (g : Pₗ →ₗ[R] Qₗ)
+    (hf : Surjective f) (hg : ∃ g' : Qₗ →ₗ[R] Pₗ, g.comp g' = LinearMap.id) :
+    Surjective (f.compr₂ g) := (surjective_comp_left_of_exists_rightInverse hg).comp hf
+
+/-- A version of `Function.Surjective.comp` for composition of a bilinear map with a linear map. -/
+theorem surjective_compr₂_of_equiv (f : M →ₗ[R] Nₗ →ₗ[R] Pₗ) (g : Pₗ ≃ₗ[R] Qₗ) (hf : Surjective f) :
+    Surjective (f.compr₂ g.toLinearMap) :=
+  surjective_compr₂_of_exists_rightInverse f g.toLinearMap hf ⟨g.symm, by simp⟩
+
+/-- A version of `Function.Bijective.comp` for composition of a bilinear map with a linear map. -/
+theorem bijective_compr₂_of_equiv (f : M →ₗ[R] Nₗ →ₗ[R] Pₗ) (g : Pₗ ≃ₗ[R] Qₗ) (hf : Bijective f) :
+    Bijective (f.compr₂ g.toLinearMap) :=
+  ⟨injective_compr₂_of_injective f g.toLinearMap hf.1 g.bijective.1,
+  surjective_compr₂_of_equiv f g hf.2⟩
+
+section CommSemiringSemilinear
+variable {R R₁ R₂ R₃ R₄ : Type*} [CommSemiring R] [Semiring R₁] [CommSemiring R₂]
+  [CommSemiring R₃] [CommSemiring R₄]
+variable {A : Type*} [Semiring A] {B : Type*} [Semiring B]
+variable {M : Type*} {N : Type*} {P : Type*} {Q : Type*}
+variable {Mₗ : Type*} {Nₗ : Type*} {Pₗ : Type*} {Qₗ Qₗ' : Type*}
+variable [AddCommMonoid M] [AddCommMonoid N] [AddCommMonoid P] [AddCommMonoid Q]
+variable [AddCommMonoid Mₗ] [AddCommMonoid Nₗ] [AddCommMonoid Pₗ]
+variable [AddCommMonoid Qₗ] [AddCommMonoid Qₗ']
+variable [Module R M] [Module R₂ N] [Module R₃ P] [Module R₄ Q]
+variable [Module R Mₗ] [Module R Nₗ] [Module R Pₗ] [Module R Qₗ] [Module R Qₗ']
+variable [Module R₁ Mₗ] [Module R₁ Pₗ] [Module R₁ Qₗ]
+variable [Module R₂ Pₗ] [Module R₂ Qₗ']
+variable {σ₁₂ : R →+* R₂} {σ₁₃ : R →+* R₃} {σ₁₄ : R →+* R₄}
+variable {σ₂₃ : R₂ →+* R₃} {σ₂₄ : R₂ →+* R₄}
+variable {σ₃₄ : R₃ →+* R₄}
+variable {σ₄₂ : R₄ →+* R₂} {σ₄₃ : R₄ →+* R₃}
+variable [RingHomCompTriple σ₁₂ σ₂₃ σ₁₃] [RingHomCompTriple σ₄₂ σ₂₃ σ₄₃]
+variable [RingHomCompTriple σ₂₃ σ₃₄ σ₂₄] [RingHomCompTriple σ₁₃ σ₃₄ σ₁₄]
+variable [RingHomCompTriple σ₂₄ σ₄₃ σ₂₃]
+
+variable (M N P)
+variable [Module A Pₗ] [SMulCommClass R A Pₗ]
+
+variable (R₃) in
+/-- Composing linear maps as a bilinear map from `(M →ₛₗ[σ₁₂] N) × (N →ₛₗ[σ₂₃] P)`
+to `M →ₛₗ[σ₁₃] P`. -/
+def llcomp : (N →ₛₗ[σ₂₃] P) →ₗ[R₃] (M →ₛₗ[σ₁₂] N) →ₛₗ[σ₂₃] M →ₛₗ[σ₁₃] P :=
+  flip
+    { toFun := lcompₛₗ _ P σ₂₃
+      map_add' := fun _f _f' => ext₂ fun g _x => g.map_add _ _
+      map_smul' := fun (_c : R₂) _f => ext₂ fun g _x => g.map_smulₛₗ _ _ }
+
+variable {M N P}
+
+@[simp]
+theorem llcomp_apply (f : N →ₛₗ[σ₂₃] P) (g : M →ₛₗ[σ₁₂] N) (x : M) :
+    llcomp _ M N P f g x = f (g x) := rfl
+
+theorem llcomp_apply' (f : N →ₛₗ[σ₂₃] P) (g : M →ₛₗ[σ₁₂] N) : llcomp _ M N P f g = f ∘ₛₗ g := rfl
+
+omit [Module R M] in
+/-- Composing a linear map `P → Q` and a bilinear map `M → N → P` to
+form a bilinear map `M → N → Q`. -/
+def compr₂ₛₗ (f : M →ₛₗ[σ₁₃] N →ₛₗ[σ₂₃] P) (g : P →ₛₗ[σ₃₄] Q) : M →ₛₗ[σ₁₄] N →ₛₗ[σ₂₄] Q :=
+  llcomp _ N P Q g ∘ₛₗ f
+
+@[simp]
+theorem compr₂ₛₗ_apply (f : M →ₛₗ[σ₁₃] N →ₛₗ[σ₂₃] P) (g : P →ₛₗ[σ₃₄] Q) (m : M) (n : N) :
+    f.compr₂ₛₗ g m n = g (f m n) := rfl
+
+/-- A version of `Function.Injective.comp` for composition of a bilinear map with a linear map. -/
+theorem injective_compr₂ₛₗ_of_injective (f : M →ₛₗ[σ₁₃] N →ₛₗ[σ₂₃] P) (g : P →ₛₗ[σ₃₄] Q)
+    (hf : Injective f) (hg : Injective g) : Injective (f.compr₂ₛₗ g) :=
   hg.injective_linearMapComp_left.comp hf
 
 /-- A version of `Function.Surjective.comp` for composition of a bilinear map with a linear map. -/
@@ -423,20 +445,10 @@ theorem surjective_compr₂ₛₗ_of_exists_rightInverse [RingHomInvPair σ₃�
     Surjective (f.compr₂ₛₗ g) := (surjective_comp_left_of_exists_rightInverse hg).comp hf
 
 /-- A version of `Function.Surjective.comp` for composition of a bilinear map with a linear map. -/
-theorem surjective_compr₂_of_exists_rightInverse (f : M →ₗ[R] Nₗ →ₗ[R] Pₗ) (g : Pₗ →ₗ[R] Qₗ)
-    (hf : Surjective f) (hg : ∃ g' : Qₗ →ₗ[R] Pₗ, g.comp g' = LinearMap.id) :
-    Surjective (f.compr₂ g) := (surjective_comp_left_of_exists_rightInverse hg).comp hf
-
-/-- A version of `Function.Surjective.comp` for composition of a bilinear map with a linear map. -/
 theorem surjective_compr₂ₛₗ_of_equiv [RingHomInvPair σ₃₄ σ₄₃] [RingHomInvPair σ₄₃ σ₃₄]
     (f : M →ₛₗ[σ₁₃] N →ₛₗ[σ₂₃] P) (g : P ≃ₛₗ[σ₃₄] Q) (hf : Surjective f) :
     Surjective (f.compr₂ₛₗ g.toLinearMap) :=
   surjective_compr₂ₛₗ_of_exists_rightInverse f g.toLinearMap hf ⟨g.symm, by simp⟩
-
-/-- A version of `Function.Surjective.comp` for composition of a bilinear map with a linear map. -/
-theorem surjective_compr₂_of_equiv (f : M →ₗ[R] Nₗ →ₗ[R] Pₗ) (g : Pₗ ≃ₗ[R] Qₗ) (hf : Surjective f) :
-    Surjective (f.compr₂ g.toLinearMap) :=
-  surjective_compr₂_of_exists_rightInverse f g.toLinearMap hf ⟨g.symm, by simp⟩
 
 /-- A version of `Function.Bijective.comp` for composition of a bilinear map with a linear map. -/
 theorem bijective_compr₂ₛₗ_of_equiv [RingHomInvPair σ₃₄ σ₄₃] [RingHomInvPair σ₄₃ σ₃₄]
@@ -445,11 +457,7 @@ theorem bijective_compr₂ₛₗ_of_equiv [RingHomInvPair σ₃₄ σ₄₃] [Ri
   ⟨injective_compr₂ₛₗ_of_injective f g.toLinearMap hf.1 g.bijective.1,
   surjective_compr₂ₛₗ_of_equiv f g hf.2⟩
 
-/-- A version of `Function.Bijective.comp` for composition of a bilinear map with a linear map. -/
-theorem bijective_compr₂_of_equiv (f : M →ₗ[R] Nₗ →ₗ[R] Pₗ) (g : Pₗ ≃ₗ[R] Qₗ) (hf : Bijective f) :
-    Bijective (f.compr₂ g.toLinearMap) :=
-  ⟨injective_compr₂_of_injective f g.toLinearMap hf.1 g.bijective.1,
-  surjective_compr₂_of_equiv f g hf.2⟩
+end CommSemiringSemilinear
 
 variable (R M)
 

--- a/Mathlib/LinearAlgebra/BilinearMap.lean
+++ b/Mathlib/LinearAlgebra/BilinearMap.lean
@@ -343,7 +343,6 @@ theorem compl₁₂_inj [SMulCommClass R₂ R₁ Pₗ]
   · -- B₁ = B₂ → B₁.comp l r = B₂.comp l r
     subst h; rfl
 
-
 omit [Module R M] in
 /-- Composing a linear map `P → Q` and a bilinear map `M → N → P` to
 form a bilinear map `M → N → Q`. -/
@@ -385,16 +384,9 @@ theorem bijective_compr₂_of_equiv (f : M →ₗ[R] Nₗ →ₗ[R] Pₗ) (g : P
 section CommSemiringSemilinear
 variable {R R₁ R₂ R₃ R₄ : Type*} [CommSemiring R] [Semiring R₁] [CommSemiring R₂]
   [CommSemiring R₃] [CommSemiring R₄]
-variable {A : Type*} [Semiring A] {B : Type*} [Semiring B]
 variable {M : Type*} {N : Type*} {P : Type*} {Q : Type*}
-variable {Mₗ : Type*} {Nₗ : Type*} {Pₗ : Type*} {Qₗ Qₗ' : Type*}
 variable [AddCommMonoid M] [AddCommMonoid N] [AddCommMonoid P] [AddCommMonoid Q]
-variable [AddCommMonoid Mₗ] [AddCommMonoid Nₗ] [AddCommMonoid Pₗ]
-variable [AddCommMonoid Qₗ] [AddCommMonoid Qₗ']
 variable [Module R M] [Module R₂ N] [Module R₃ P] [Module R₄ Q]
-variable [Module R Mₗ] [Module R Nₗ] [Module R Pₗ] [Module R Qₗ] [Module R Qₗ']
-variable [Module R₁ Mₗ] [Module R₁ Pₗ] [Module R₁ Qₗ]
-variable [Module R₂ Pₗ] [Module R₂ Qₗ']
 variable {σ₁₂ : R →+* R₂} {σ₁₃ : R →+* R₃} {σ₁₄ : R →+* R₄}
 variable {σ₂₃ : R₂ →+* R₃} {σ₂₄ : R₂ →+* R₄}
 variable {σ₃₄ : R₃ →+* R₄}
@@ -404,7 +396,6 @@ variable [RingHomCompTriple σ₂₃ σ₃₄ σ₂₄] [RingHomCompTriple σ₁
 variable [RingHomCompTriple σ₂₄ σ₄₃ σ₂₃]
 
 variable (M N P)
-variable [Module A Pₗ] [SMulCommClass R A Pₗ]
 
 variable (R₃) in
 /-- Composing linear maps as a bilinear map from `(M →ₛₗ[σ₁₂] N) × (N →ₛₗ[σ₂₃] P)`

--- a/Mathlib/LinearAlgebra/BilinearMap.lean
+++ b/Mathlib/LinearAlgebra/BilinearMap.lean
@@ -345,7 +345,9 @@ theorem compl₁₂_inj [SMulCommClass R₂ R₁ Pₗ]
 
 omit [Module R M] in
 /-- Composing a linear map `P → Q` and a bilinear map `M → N → P` to
-form a bilinear map `M → N → Q`. -/
+form a bilinear map `M → N → Q`.
+
+See `LinearMap.compr₂ₛₗ` for a semi-linear version of this. -/
 def compr₂ [Module R A] [Module A M] [Module A Qₗ]
     [SMulCommClass R A Qₗ] [IsScalarTower R A Qₗ] [IsScalarTower R A Pₗ]
     (f : M →ₗ[A] Nₗ →ₗ[R] Pₗ) (g : Pₗ →ₗ[A] Qₗ) : M →ₗ[A] Nₗ →ₗ[R] Qₗ where
@@ -415,7 +417,9 @@ theorem llcomp_apply' (f : N →ₛₗ[σ₂₃] P) (g : M →ₛₗ[σ₁₂] N
 omit [Module R M] in
 /-- Composing a linear map `P →ₛₗ[σ₃₄] Q` and a bilinear map `M →ₛₗ[σ₁₃] N →ₛₗ[σ₂₃] P` to
 form a bilinear map `M →ₛₗ[σ₁₄] N →ₛₗ[σ₂₄] Q`.
-This is the semi-linear version of `LinearMap.compr₂`. -/
+
+See `LinearMap.compr₂` for the linear version, where it's composing a linear map `Pₗ →ₗ[A] Qₗ`
+and a bilinear map `M →ₗ[A] Nₗ →ₗ[R] Pₗ` to form a bilinear map `M →ₗ[A] Nₗ →ₗ[R] Qₗ`. -/
 def compr₂ₛₗ (f : M →ₛₗ[σ₁₃] N →ₛₗ[σ₂₃] P) (g : P →ₛₗ[σ₃₄] Q) : M →ₛₗ[σ₁₄] N →ₛₗ[σ₂₄] Q :=
   llcomp _ N P Q g ∘ₛₗ f
 

--- a/Mathlib/LinearAlgebra/BilinearMap.lean
+++ b/Mathlib/LinearAlgebra/BilinearMap.lean
@@ -382,8 +382,9 @@ theorem bijective_compr₂_of_equiv (f : M →ₗ[R] Nₗ →ₗ[R] Pₗ) (g : P
   surjective_compr₂_of_equiv f g hf.2⟩
 
 section CommSemiringSemilinear
-variable {R₂ R₃ R₄ : Type*} [CommSemiring R₂] [CommSemiring R₃] [CommSemiring R₄]
-variable {M : Type*} {N : Type*} {P : Type*} {Q : Type*}
+
+variable {R₂ R₃ R₄ M N P Q : Type*}
+variable [CommSemiring R₂] [CommSemiring R₃] [CommSemiring R₄]
 variable [AddCommMonoid M] [AddCommMonoid N] [AddCommMonoid P] [AddCommMonoid Q]
 variable [Module R M] [Module R₂ N] [Module R₃ P] [Module R₄ Q]
 variable {σ₁₂ : R →+* R₂} {σ₁₃ : R →+* R₃} {σ₁₄ : R →+* R₄}

--- a/Mathlib/LinearAlgebra/BilinearMap.lean
+++ b/Mathlib/LinearAlgebra/BilinearMap.lean
@@ -418,8 +418,8 @@ omit [Module R M] in
 /-- Composing a linear map `P →ₛₗ[σ₃₄] Q` and a bilinear map `M →ₛₗ[σ₁₃] N →ₛₗ[σ₂₃] P` to
 form a bilinear map `M →ₛₗ[σ₁₄] N →ₛₗ[σ₂₄] Q`.
 
-See `LinearMap.compr₂` for the linear version, where it's composing a linear map `Pₗ →ₗ[A] Qₗ`
-and a bilinear map `M →ₗ[A] Nₗ →ₗ[R] Pₗ` to form a bilinear map `M →ₗ[A] Nₗ →ₗ[R] Qₗ`. -/
+See `LinearMap.compr₂` for a version of this definition, which does not support semi-linear maps but
+which does support towers of scalars. -/
 def compr₂ₛₗ (f : M →ₛₗ[σ₁₃] N →ₛₗ[σ₂₃] P) (g : P →ₛₗ[σ₃₄] Q) : M →ₛₗ[σ₁₄] N →ₛₗ[σ₂₄] Q :=
   llcomp _ N P Q g ∘ₛₗ f
 

--- a/Mathlib/LinearAlgebra/BilinearMap.lean
+++ b/Mathlib/LinearAlgebra/BilinearMap.lean
@@ -347,7 +347,8 @@ omit [Module R M] in
 /-- Composing a linear map `P → Q` and a bilinear map `M → N → P` to
 form a bilinear map `M → N → Q`.
 
-See `LinearMap.compr₂ₛₗ` for a semi-linear version of this. -/
+See `LinearMap.compr₂ₛₗ` for a version of this which does not support towers of scalars but which
+does support semi-linear maps. -/
 def compr₂ [Module R A] [Module A M] [Module A Qₗ]
     [SMulCommClass R A Qₗ] [IsScalarTower R A Qₗ] [IsScalarTower R A Pₗ]
     (f : M →ₗ[A] Nₗ →ₗ[R] Pₗ) (g : Pₗ →ₗ[A] Qₗ) : M →ₗ[A] Nₗ →ₗ[R] Qₗ where


### PR DESCRIPTION
Semi-linearizes `llcomp` and creates a new definition `compr₂ₛₗ` for the semi-linear version of `compr₂`.

Original PRs: #27353 (#27310, #24208).

Co-authored-by: @ADedecker

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
