### PR TITLE
[Merged by Bors] - feat(Topology/Baire/Lemmas): In a nonempty Baire space, any dense GDelta set is not meagre

### DIFF
--- a/Mathlib/Topology/Baire/Lemmas.lean
+++ b/Mathlib/Topology/Baire/Lemmas.lean
@@ -167,4 +167,11 @@ theorem nonempty_interior_of_iUnion_of_closed [Nonempty X] [Countable ι] {f : �
     (hc : ∀ i, IsClosed (f i)) (hU : ⋃ i, f i = univ) : ∃ i, (interior <| f i).Nonempty := by
   simpa using (dense_iUnion_interior_of_closed hc hU).nonempty
 
+/-- In a nonempty Baire space, any dense `Gδ` set is not meagre. -/
+theorem IsGδ_dense_not_meagre [Nonempty X] {s : Set X} (hs : IsGδ s) (hd : Dense s) :
+    ¬ IsMeagre s := fun h ↦ by
+  rcases (mem_residual).1 h with ⟨t, hts, htG, hd'⟩
+  rcases (hd.inter_of_Gδ hs htG hd').nonempty with ⟨x, hx₁, hx₂⟩
+  exact (hts hx₂) hx₁
+
 end BaireTheorem

--- a/Mathlib/Topology/Baire/Lemmas.lean
+++ b/Mathlib/Topology/Baire/Lemmas.lean
@@ -168,7 +168,7 @@ theorem nonempty_interior_of_iUnion_of_closed [Nonempty X] [Countable ι] {f : �
   simpa using (dense_iUnion_interior_of_closed hc hU).nonempty
 
 /-- In a nonempty Baire space, any dense `Gδ` set is not meagre. -/
-theorem IsGδ_dense_not_meagre [Nonempty X] {s : Set X} (hs : IsGδ s) (hd : Dense s) :
+theorem not_isMeagre_of_isGδ_of_dense [Nonempty X] {s : Set X} (hs : IsGδ s) (hd : Dense s) :
     ¬ IsMeagre s := fun h ↦ by
   rcases (mem_residual).1 h with ⟨t, hts, htG, hd'⟩
   rcases (hd.inter_of_Gδ hs htG hd').nonempty with ⟨x, hx₁, hx₂⟩

--- a/Mathlib/Topology/Baire/Lemmas.lean
+++ b/Mathlib/Topology/Baire/Lemmas.lean
@@ -169,9 +169,10 @@ theorem nonempty_interior_of_iUnion_of_closed [Nonempty X] [Countable ι] {f : �
 
 /-- In a nonempty Baire space, any dense `Gδ` set is not meagre. -/
 theorem not_isMeagre_of_isGδ_of_dense [Nonempty X] {s : Set X} (hs : IsGδ s) (hd : Dense s) :
-    ¬ IsMeagre s := fun h ↦ by
+    ¬ IsMeagre s := by
+  intro h
   rcases (mem_residual).1 h with ⟨t, hts, htG, hd'⟩
   rcases (hd.inter_of_Gδ hs htG hd').nonempty with ⟨x, hx₁, hx₂⟩
-  exact (hts hx₂) hx₁
+  exact hts hx₂ hx₁
 
 end BaireTheorem


### PR DESCRIPTION
Proves that in a nonempty Baire space any dense Gδ set is not meagre

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
