### PR TITLE
[Merged by Bors] - fix(to_additive): don't consider extra attributes in `to_additive self`

### DIFF
--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -1211,8 +1211,8 @@ def elabToAdditive : Syntax → CoreM Config
       | `(toAdditiveNameHint| self) => (true, true)
       | _ => (false, false)
     if self && !attrs.isEmpty then
-      throwError "invalid `(attr := ..)` in combination with `self`, \
-        because there is only one declaration to put the attributes on. \
+      throwError "invalid `(attr := ...)` after `self`, \
+        as there is only one declaration for the attributes.\n\
         Instead, you can write the attributes in the usual way."
     trace[to_additive_detail] "attributes: {attrs}; reorder arguments: {reorder}"
     return {

--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -1210,6 +1210,8 @@ def elabToAdditive : Syntax → CoreM Config
       | `(toAdditiveNameHint| existing) => (true, false)
       | `(toAdditiveNameHint| self) => (true, true)
       | _ => (false, false)
+    if self && !attrs.isEmpty then
+      throwError "cannot use both `self` and `(attr := ..)`"
     trace[to_additive_detail] "attributes: {attrs}; reorder arguments: {reorder}"
     return {
       trace := trace.isSome
@@ -1222,35 +1224,34 @@ def elabToAdditive : Syntax → CoreM Config
 
 mutual
 /-- Apply attributes to the multiplicative and additive declarations. -/
-partial def applyAttributes (stx : Syntax) (rawAttrs : Array Syntax) (thisAttr src tgt : Name) :
-  TermElabM (Array Name) := do
+partial def applyAttributes (cfg : Config) (thisAttr src tgt : Name) : TermElabM (Array Name) := do
   -- we only copy the `instance` attribute, since `@[to_additive] instance` is nice to allow
   copyInstanceAttribute src tgt
   -- Warn users if the multiplicative version has an attribute
-  if linter.existingAttributeWarning.get (← getOptions) then
+  if !cfg.self && linter.existingAttributeWarning.get (← getOptions) then
     let appliedAttrs ← getAllSimpAttrs src
     if appliedAttrs.size > 0 then
       let appliedAttrs := ", ".intercalate (appliedAttrs.toList.map toString)
       -- Note: we're not bothering to print the correct attribute arguments.
-      Linter.logLintIf linter.existingAttributeWarning stx m!"\
+      Linter.logLintIf linter.existingAttributeWarning cfg.ref m!"\
         The source declaration {src} was given the simp-attribute(s) {appliedAttrs} before \
         calling @[{thisAttr}].\nThe preferred method is to use something like \
         `@[{thisAttr} (attr := {appliedAttrs})]`\nto apply the attribute to both \
         {src} and the target declaration {tgt}."
-    warnAttr stx Lean.Elab.Tactic.Ext.extExtension
+    warnAttr cfg.ref Lean.Elab.Tactic.Ext.extExtension
       (fun b n => (b.tree.values.any fun t => t.declName = n)) thisAttr `ext src tgt
-    warnAttr stx Lean.Meta.Rfl.reflExt (·.values.contains ·) thisAttr `refl src tgt
-    warnAttr stx Lean.Meta.Symm.symmExt (·.values.contains ·) thisAttr `symm src tgt
-    warnAttr stx Batteries.Tactic.transExt (·.values.contains ·) thisAttr `trans src tgt
-    warnAttr stx Lean.Meta.coeExt (·.contains ·) thisAttr `coe src tgt
-    warnParametricAttr stx Lean.Linter.deprecatedAttr thisAttr `deprecated src tgt
+    warnAttr cfg.ref Lean.Meta.Rfl.reflExt (·.values.contains ·) thisAttr `refl src tgt
+    warnAttr cfg.ref Lean.Meta.Symm.symmExt (·.values.contains ·) thisAttr `symm src tgt
+    warnAttr cfg.ref Batteries.Tactic.transExt (·.values.contains ·) thisAttr `trans src tgt
+    warnAttr cfg.ref Lean.Meta.coeExt (·.contains ·) thisAttr `coe src tgt
+    warnParametricAttr cfg.ref Lean.Linter.deprecatedAttr thisAttr `deprecated src tgt
     -- the next line also warns for `@[to_additive, simps]`, because of the application times
-    warnParametricAttr stx simpsAttr thisAttr `simps src tgt
-    warnExt stx Term.elabAsElim.ext (·.contains ·) thisAttr `elab_as_elim src tgt
+    warnParametricAttr cfg.ref simpsAttr thisAttr `simps src tgt
+    warnExt cfg.ref Term.elabAsElim.ext (·.contains ·) thisAttr `elab_as_elim src tgt
   -- add attributes
   -- the following is similar to `Term.ApplyAttributesCore`, but we hijack the implementation of
   -- `simps` and `to_additive`.
-  let attrs ← elabAttrs rawAttrs
+  let attrs ← elabAttrs cfg.attrs
   let (additiveAttrs, attrs) := attrs.partition (·.name == `to_additive)
   let nestedDecls ←
     match additiveAttrs.size with
@@ -1301,7 +1302,7 @@ partial def copyMetaData (cfg : Config) (src tgt : Name) : CoreM (Array Name) :=
     additivizeLemmas #[src, tgt] "equation lemmas" fun nm ↦
       (·.getD #[]) <$> MetaM.run' (getEqnsFor? nm)
   MetaM.run' <| Elab.Term.TermElabM.run' <|
-    applyAttributes cfg.ref cfg.attrs `to_additive src tgt
+    applyAttributes cfg `to_additive src tgt
 
 /--
 Make a new copy of a declaration, replacing fragments of the names of identifiers in the type and

--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -1211,7 +1211,9 @@ def elabToAdditive : Syntax → CoreM Config
       | `(toAdditiveNameHint| self) => (true, true)
       | _ => (false, false)
     if self && !attrs.isEmpty then
-      throwError "cannot use both `self` and `(attr := ..)`"
+      throwError "invalid `(attr := ..)` in combination with `self`, \
+        because there is only one declaration to put the attributes on. \
+        Instead, you can write the attributes in the usual way."
     trace[to_additive_detail] "attributes: {attrs}; reorder arguments: {reorder}"
     return {
       trace := trace.isSome

--- a/MathlibTest/toAdditive.lean
+++ b/MathlibTest/toAdditive.lean
@@ -521,3 +521,7 @@ fun {α} [i : Add α] a => i.1 a
 -/
 #guard_msgs in
 #print myAdd
+
+/-! Test that the `existingAttributeWarning` linter doesn't fire for `to_additive self`. -/
+@[simp, to_additive self]
+theorem to_additive_self : 5 = 5 := rfl

--- a/MathlibTest/toAdditive.lean
+++ b/MathlibTest/toAdditive.lean
@@ -524,4 +524,14 @@ fun {α} [i : Add α] a => i.1 a
 
 /-! Test that the `existingAttributeWarning` linter doesn't fire for `to_additive self`. -/
 @[simp, to_additive self]
-theorem to_additive_self : 5 = 5 := rfl
+theorem test1 : 5 = 5 := rfl
+
+/-! Test that we can't write `to_additive self (attr := ..)`. -/
+
+/--
+error: invalid `(attr := ...)` after `self`, as there is only one declaration for the attributes.
+Instead, you can write the attributes in the usual way.
+-/
+#guard_msgs in
+@[to_additive self (attr := simp)]
+theorem test2 : 5 = 5 := rfl


### PR DESCRIPTION
When using `to_additive self`, it doesn't make sense to use `(attr := ...)`. Additionally, the `existingAttributeWarning` linter should be disabled.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
