### PR TITLE
[Merged by Bors] - chore(Analytic/Linear): replace a ContinuousLinearMap with a ContinuousLinearEquiv

### DIFF
--- a/Mathlib/Analysis/Analytic/Linear.lean
+++ b/Mathlib/Analysis/Analytic/Linear.lean
@@ -203,10 +203,10 @@ protected theorem analyticAt : AnalyticAt 𝕜 f x :=
 protected theorem analyticOnNhd : AnalyticOnNhd 𝕜 f s :=
   fun x _ ↦ f.analyticAt x
 
-protected theorem analyticWithinAt (f : E →L[𝕜] F) (s : Set E) (x : E) : AnalyticWithinAt 𝕜 f s x :=
+protected theorem analyticWithinAt : AnalyticWithinAt 𝕜 f s x :=
   (f.analyticAt x).analyticWithinAt
 
-protected theorem analyticOn (f : E →L[𝕜] F) (s : Set E) : AnalyticOn 𝕜 f s :=
+protected theorem analyticOn : AnalyticOn 𝕜 f s :=
   fun x _ ↦ f.analyticWithinAt _ x
 
 end ContinuousLinearEquiv

--- a/Mathlib/Analysis/Analytic/Linear.lean
+++ b/Mathlib/Analysis/Analytic/Linear.lean
@@ -221,10 +221,10 @@ protected theorem analyticAt : AnalyticAt 𝕜 f x :=
 protected theorem analyticOnNhd : AnalyticOnNhd 𝕜 f s :=
   fun x _ ↦ f.analyticAt x
 
-protected theorem analyticWithinAt (f : E →L[𝕜] F) (s : Set E) (x : E) : AnalyticWithinAt 𝕜 f s x :=
+protected theorem analyticWithinAt : AnalyticWithinAt 𝕜 f s x :=
   (f.analyticAt x).analyticWithinAt
 
-protected theorem analyticOn (f : E →L[𝕜] F) (s : Set E) : AnalyticOn 𝕜 f s :=
+protected theorem analyticOn : AnalyticOn 𝕜 f s :=
   fun x _ ↦ f.analyticWithinAt _ x
 
 end LinearIsometryEquiv

--- a/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/Basic.lean
@@ -385,7 +385,7 @@ theorem ContDiffWithinAt.comp_continuousLinearMap {x : G} (g : G →L[𝕜] E)
       change AnalyticOn 𝕜 (fun x ↦
         ContinuousMultilinearMap.compContinuousLinearMapL (fun _ ↦ g) (p (g x) i)) (⇑g ⁻¹' u)
       apply AnalyticOn.comp _ _ (Set.mapsTo_univ _ _)
-      · exact ContinuousLinearEquiv.analyticOn _ _
+      · exact ContinuousLinearMap.analyticOn _ _
       · exact (h'p i).comp (g.analyticOn _) (mapsTo_preimage _ _)
   | (n : ℕ∞) =>
     intro m hm


### PR DESCRIPTION
`ContinuousLinearEquiv.analyticWithinAt` and `ContinuousLinearEquiv.analyticOn` took a `ContinuousLinearMap` argument. This PR fixes that.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
