### PR TITLE
[Merged by Bors] - chore: fix indentation of subsequent declaration lines

### DIFF
--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -252,7 +252,8 @@ section induction_principles
 "An induction principle on free monoids, with cases for `0`, `FreeAddMonoid.of` and `+`."]
 protected theorem inductionOn {C : FreeMonoid α → Prop} (z : FreeMonoid α) (one : C 1)
     (of : ∀ (x : α), C (FreeMonoid.of x)) (mul : ∀ (x y : FreeMonoid α), C x → C y → C (x * y)) :
-  C z := List.rec one (fun _ _ ih => mul [_] _ (of _) ih) z
+    C z :=
+  List.rec one (fun _ _ ih => mul [_] _ (of _) ih) z
 
 /-- An induction principle for free monoids which mirrors induction on lists, with cases analogous
 to the empty list and cons -/

--- a/Mathlib/Algebra/Group/Hom/Basic.lean
+++ b/Mathlib/Algebra/Group/Hom/Basic.lean
@@ -144,8 +144,8 @@ def ofMapMulInv {H : Type*} [Group H] (f : G → H)
 
 @[to_additive (attr := simp)]
 theorem coe_of_map_mul_inv {H : Type*} [Group H] (f : G → H)
-    (map_div : ∀ a b : G, f (a * b⁻¹) = f a * (f b)⁻¹) :
-  ↑(ofMapMulInv f map_div) = f := rfl
+    (map_div : ∀ a b : G, f (a * b⁻¹) = f a * (f b)⁻¹) : ↑(ofMapMulInv f map_div) = f :=
+  rfl
 
 /-- Define a morphism of additive groups given a map which respects ratios. -/
 @[to_additive "Define a morphism of additive groups given a map which respects difference."]

--- a/Mathlib/Algebra/Group/Hom/Defs.lean
+++ b/Mathlib/Algebra/Group/Hom/Defs.lean
@@ -507,16 +507,16 @@ attribute [coe] AddMonoidHom.toZeroHom
 
 /-- `MonoidHom` down-cast to a `OneHom`, forgetting the multiplicative property. -/
 @[to_additive "`AddMonoidHom` down-cast to a `ZeroHom`, forgetting the additive property"]
-instance MonoidHom.coeToOneHom [MulOneClass M] [MulOneClass N] :
-  Coe (M →* N) (OneHom M N) := ⟨MonoidHom.toOneHom⟩
+instance MonoidHom.coeToOneHom [MulOneClass M] [MulOneClass N] : Coe (M →* N) (OneHom M N) :=
+  ⟨MonoidHom.toOneHom⟩
 
 attribute [coe] MonoidHom.toMulHom
 attribute [coe] AddMonoidHom.toAddHom
 
 /-- `MonoidHom` down-cast to a `MulHom`, forgetting the 1-preserving property. -/
 @[to_additive "`AddMonoidHom` down-cast to an `AddHom`, forgetting the 0-preserving property."]
-instance MonoidHom.coeToMulHom [MulOneClass M] [MulOneClass N] :
-  Coe (M →* N) (M →ₙ* N) := ⟨MonoidHom.toMulHom⟩
+instance MonoidHom.coeToMulHom [MulOneClass M] [MulOneClass N] : Coe (M →* N) (M →ₙ* N) :=
+  ⟨MonoidHom.toMulHom⟩
 
 -- these must come after the coe_toFun definitions
 initialize_simps_projections ZeroHom (toFun → apply)
@@ -866,11 +866,9 @@ protected theorem MonoidHom.map_zpow' [DivInvMonoid M] [DivInvMonoid N] (f : M �
 
 /-- Makes a `OneHom` inverse from the bijective inverse of a `OneHom` -/
 @[to_additive (attr := simps)
-  "Make a `ZeroHom` inverse from the bijective inverse of a `ZeroHom`"]
-def OneHom.inverse [One M] [One N]
-    (f : OneHom M N) (g : N → M)
-    (h₁ : Function.LeftInverse g f) :
-  OneHom N M :=
+"Make a `ZeroHom` inverse from the bijective inverse of a `ZeroHom`"]
+def OneHom.inverse [One M] [One N] (f : OneHom M N) (g : N → M) (h₁ : Function.LeftInverse g f) :
+    OneHom N M :=
   { toFun := g,
     map_one' := by rw [← f.map_one, h₁] }
 

--- a/Mathlib/Algebra/GroupWithZero/Action/Defs.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Defs.lean
@@ -233,7 +233,7 @@ protected abbrev Function.Injective.mulActionWithZero (f : ZeroHom A' A) (hf : I
 /-- Pushforward a `MulActionWithZero` structure along a surjective zero-preserving homomorphism. -/
 -- See note [reducible non-instances]
 protected abbrev Function.Surjective.mulActionWithZero (f : ZeroHom A A') (hf : Surjective f)
-   (smul : ∀ (a : M₀) (b), f (a • b) = a • f b) : MulActionWithZero M₀ A' :=
+    (smul : ∀ (a : M₀) (b), f (a • b) = a • f b) : MulActionWithZero M₀ A' :=
   { hf.mulAction f smul, hf.smulWithZero f smul with }
 
 variable (A)

--- a/Mathlib/Algebra/GroupWithZero/Hom.lean
+++ b/Mathlib/Algebra/GroupWithZero/Hom.lean
@@ -117,8 +117,7 @@ instance coeToMonoidHom : Coe (α →*₀ β) (α →* β) :=
 attribute [coe] toZeroHom
 
 /-- `MonoidWithZeroHom` down-cast to a `ZeroHom`, forgetting the monoidal property. -/
-instance coeToZeroHom :
-  Coe (α →*₀ β) (ZeroHom α β) := ⟨toZeroHom⟩
+instance coeToZeroHom : Coe (α →*₀ β) (ZeroHom α β) := ⟨toZeroHom⟩
 
 -- This must come after the coe_toFun definitions
 initialize_simps_projections MonoidWithZeroHom (toFun → apply)

--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Defs.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Defs.lean
@@ -181,16 +181,16 @@ instance (priority := 100) MulRightStrictMono.toMulPosStrictMono [MulRightStrict
     MulPosStrictMono α where elim _ _ := ‹MulRightStrictMono α›.elim _
 
 instance (priority := 100) MulLeftMono.toPosMulReflectLT [MulLeftReflectLT α] :
-   PosMulReflectLT α where elim _ _ := ‹MulLeftReflectLT α›.elim _
+    PosMulReflectLT α where elim _ _ := ‹MulLeftReflectLT α›.elim _
 
 instance (priority := 100) MulRightMono.toMulPosReflectLT [MulRightReflectLT α] :
-   MulPosReflectLT α where elim _ _ := ‹MulRightReflectLT α›.elim _
+    MulPosReflectLT α where elim _ _ := ‹MulRightReflectLT α›.elim _
 
 instance (priority := 100) MulLeftStrictMono.toPosMulReflectLE [MulLeftReflectLE α] :
-   PosMulReflectLE α where elim _ _ := ‹MulLeftReflectLE α›.elim _
+    PosMulReflectLE α where elim _ _ := ‹MulLeftReflectLE α›.elim _
 
 instance (priority := 100) MulRightStrictMono.toMulPosReflectLE [MulRightReflectLE α] :
-   MulPosReflectLE α where elim _ _ := ‹MulRightReflectLE α›.elim _
+    MulPosReflectLE α where elim _ _ := ‹MulRightReflectLE α›.elim _
 
 @[gcongr]
 theorem mul_le_mul_of_nonneg_left [PosMulMono α] (h : b ≤ c) (a0 : 0 ≤ a) : a * b ≤ a * c :=

--- a/Mathlib/Control/Basic.lean
+++ b/Mathlib/Control/Basic.lean
@@ -207,7 +207,7 @@ open Functor
 
 theorem CommApplicative.commutative_map {m : Type u → Type v} [h : Applicative m]
     [CommApplicative m] {α β γ} (a : m α) (b : m β) {f : α → β → γ} :
-  f <$> a <*> b = flip f <$> b <*> a :=
+    f <$> a <*> b = flip f <$> b <*> a :=
   calc
     f <$> a <*> b = (fun p : α × β => f p.1 p.2) <$> (Prod.mk <$> a <*> b) := by
       simp only [map_seq, map_map, Function.comp_def]

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -1295,14 +1295,12 @@ end lookup
 section range'
 
 @[simp]
-lemma range'_0 (a b : ℕ) :
-   range' a b 0 = replicate b a := by
+lemma range'_0 (a b : ℕ) : range' a b 0 = replicate b a := by
   induction b with
   | zero => simp
   | succ b ih => simp [range'_succ, ih, replicate_succ]
 
-lemma left_le_of_mem_range' {a b s x : ℕ}
-    (hx : x ∈ List.range' a b s) : a ≤ x := by
+lemma left_le_of_mem_range' {a b s x : ℕ} (hx : x ∈ List.range' a b s) : a ≤ x := by
   obtain ⟨i, _, rfl⟩ := List.mem_range'.mp hx
   exact le_add_right a (s * i)
 

--- a/Mathlib/Data/List/TakeDrop.lean
+++ b/Mathlib/Data/List/TakeDrop.lean
@@ -59,7 +59,7 @@ theorem take_one_drop_eq_of_lt_length {l : List α} {n : ℕ} (h : n < l.length)
 
 /-- `take_concat_get` in simp normal form -/
 lemma take_concat_get' (l : List α) (i : ℕ) (h : i < l.length) :
-  l.take i ++ [l[i]] = l.take (i + 1) := by simp
+    l.take i ++ [l[i]] = l.take (i + 1) := by simp
 
 theorem cons_getElem_drop_succ {l : List α} {n : Nat} {h : n < l.length} :
     l[n] :: l.drop (n + 1) = l.drop n :=

--- a/Mathlib/Data/Nat/Cast/Defs.lean
+++ b/Mathlib/Data/Nat/Cast/Defs.lean
@@ -70,7 +70,7 @@ Some discussion is [on Zulip here](https://leanprover.zulipchat.com/#narrow/stre
 -/
 
 @[simp, norm_cast] theorem Nat.cast_ofNat {n : ℕ} [NatCast R] [Nat.AtLeastTwo n] :
-  (Nat.cast ofNat(n) : R) = ofNat(n) := rfl
+    (Nat.cast ofNat(n) : R) = ofNat(n) := rfl
 
 @[deprecated Nat.cast_ofNat (since := "2024-12-22")]
 theorem Nat.cast_eq_ofNat {n : ℕ} [NatCast R] [Nat.AtLeastTwo n] :

--- a/Mathlib/Data/Prod/Basic.lean
+++ b/Mathlib/Data/Prod/Basic.lean
@@ -167,7 +167,7 @@ theorem Lex.trans {r : α → α → Prop} {s : β → β → Prop} [IsTrans α 
   | (_, _), (_, _), (_, _), right _ hxy₂,   right _ hyz₂   => right _ (_root_.trans hxy₂ hyz₂)
 
 instance {r : α → α → Prop} {s : β → β → Prop} [IsTrans α r] [IsTrans β s] :
-  IsTrans (α × β) (Prod.Lex r s) :=
+    IsTrans (α × β) (Prod.Lex r s) :=
   ⟨fun _ _ _ ↦ Lex.trans⟩
 
 instance {r : α → α → Prop} {s : β → β → Prop} [IsStrictOrder α r] [IsAntisymm β s] :
@@ -192,7 +192,7 @@ instance isTotal_right {r : α → α → Prop} {s : β → β → Prop} [IsTric
     · exact Or.inr (.left _ _ hji) ⟩
 
 instance IsTrichotomous [IsTrichotomous α r] [IsTrichotomous β s] :
-  IsTrichotomous (α × β) (Prod.Lex r s) :=
+    IsTrichotomous (α × β) (Prod.Lex r s) :=
 ⟨fun ⟨i, a⟩ ⟨j, b⟩ ↦ by
   obtain hij | rfl | hji := trichotomous_of r i j
   { exact Or.inl (Lex.left _ _ hij) }

--- a/Mathlib/Data/Seq/Computation.lean
+++ b/Mathlib/Data/Seq/Computation.lean
@@ -1026,8 +1026,8 @@ def LiftRelAux (R : α → β → Prop) (C : Computation α → Computation β �
 
 variable {R : α → β → Prop} {C : Computation α → Computation β → Prop}
 
-@[simp] lemma liftRelAux_inl_inl {a : α} {b : β} :
-  LiftRelAux R C (Sum.inl a) (Sum.inl b) = R a b := rfl
+@[simp] lemma liftRelAux_inl_inl {a : α} {b : β} : LiftRelAux R C (Sum.inl a) (Sum.inl b) = R a b :=
+  rfl
 @[simp] lemma liftRelAux_inl_inr {a : α} {cb} :
     LiftRelAux R C (Sum.inl a) (Sum.inr cb) = ∃ b, b ∈ cb ∧ R a b :=
   rfl

--- a/Mathlib/Data/Stream/Init.lean
+++ b/Mathlib/Data/Stream/Init.lean
@@ -74,7 +74,7 @@ theorem get_succ_cons (n : ℕ) (s : Stream' α) (x : α) : get (x :: s) n.succ 
   rfl
 
 @[simp] lemma get_cons_append_zero {a : α} {x : List α} {s : Stream' α} :
-  (a :: x ++ₛ s).get 0 = a := rfl
+    (a :: x ++ₛ s).get 0 = a := rfl
 
 @[simp] lemma append_eq_cons {a : α} {as : Stream' α} : [a] ++ₛ as = a :: as := rfl
 

--- a/Mathlib/Logic/Function/Basic.lean
+++ b/Mathlib/Logic/Function/Basic.lean
@@ -1046,9 +1046,9 @@ theorem InvImage.equivalence {α : Sort u} {β : Sort v} (r : β → β → Prop
   ⟨fun _ ↦ h.1 _, h.symm, h.trans⟩
 
 instance {α β : Type*} {r : α → β → Prop} {x : α × β} [Decidable (r x.1 x.2)] :
-  Decidable (uncurry r x) :=
-‹Decidable _›
+    Decidable (uncurry r x) :=
+  ‹Decidable _›
 
 instance {α β : Type*} {r : α × β → Prop} {a : α} {b : β} [Decidable (r (a, b))] :
-  Decidable (curry r a b) :=
-‹Decidable _›
+    Decidable (curry r a b) :=
+  ‹Decidable _›

--- a/Mathlib/Order/ULift.lean
+++ b/Mathlib/Order/ULift.lean
@@ -38,8 +38,8 @@ instance [BEq α] : BEq (ULift.{v} α) where beq x y := x.down == y.down
 instance [Ord α] : Ord (ULift.{v} α) where compare x y := compare x.down y.down
 
 @[simp] theorem up_compare [Ord α] (a b : α) : compare (up a) (up b) = compare a b := rfl
-@[simp] theorem down_compare [Ord α] (a b : ULift α) :
-  compare (down a) (down b) = compare a b := rfl
+@[simp] theorem down_compare [Ord α] (a b : ULift α) : compare (down a) (down b) = compare a b :=
+  rfl
 
 instance [Max α] : Max (ULift.{v} α) where max x y := up <| x.down ⊔ y.down
 

--- a/Mathlib/Tactic/MkIffOfInductiveProp.lean
+++ b/Mathlib/Tactic/MkIffOfInductiveProp.lean
@@ -52,7 +52,7 @@ This relation is user-visible, so we compact it by removing each `b_j` where a `
 hence `a_i = b_j`. We need to take care when there are `p_i` and `p_j` with `p_i = p_j = b_k`.
 -/
 partial def compactRelation :
-  List Expr → List (Expr × Expr) → List (Option Expr) × List (Expr × Expr) × (Expr → Expr)
+    List Expr → List (Expr × Expr) → List (Option Expr) × List (Expr × Expr) × (Expr → Expr)
 | [],    as_ps => ([], as_ps, id)
 | b::bs, as_ps =>
   match as_ps.span (fun ⟨_, p⟩ ↦ p != b) with

--- a/Mathlib/Tactic/Sat/FromLRAT.lean
+++ b/Mathlib/Tactic/Sat/FromLRAT.lean
@@ -259,7 +259,7 @@ partial def buildConj (arr : Array (Array Int)) (start stop : Nat) : Expr :=
 /-- Constructs the proofs of `⊢ ctx.proof c` for each clause `c` in `ctx`.
 The proofs are stashed in a `HashMap` keyed on the clause ID. -/
 partial def buildClauses (arr : Array (Array Int)) (ctx : Expr) (start stop : Nat)
-  (f p : Expr) (accum : Nat × HashMap Nat Clause) : Nat × HashMap Nat Clause :=
+    (f p : Expr) (accum : Nat × HashMap Nat Clause) : Nat × HashMap Nat Clause :=
   match stop - start with
   | 0 => panic! "empty"
   | 1 =>
@@ -319,7 +319,7 @@ structure LClause where
      * If all clauses are falsified, then we are done: `hc v hv hx hy : False`.
 -/
 partial def buildProofStep (db : HashMap Nat Clause)
-  (ns pf : Array Int) (ctx clause : Expr) : Except String Expr := Id.run do
+    (ns pf : Array Int) (ctx clause : Expr) : Except String Expr := Id.run do
   let mut lams := #[]
   let mut args := #[]
   let mut gctx : HashMap Nat LClause := {}
@@ -394,7 +394,7 @@ inductive LRATStep
   * `steps`: The input LRAT proof trace
 -/
 partial def buildProof (arr : Array (Array Int)) (ctx ctx' : Expr)
-  (steps : Array LRATStep) : MetaM Expr := do
+    (steps : Array LRATStep) : MetaM Expr := do
   let p := mkApp (mkConst ``Sat.Fmla.subsumes_self) ctx
   let mut db := (buildClauses arr ctx 0 arr.size ctx' p default).2
   for step in steps do

--- a/Mathlib/Tactic/Simps/Basic.lean
+++ b/Mathlib/Tactic/Simps/Basic.lean
@@ -794,8 +794,8 @@ Optionally, this command accepts three optional arguments:
   `set_option trace.simps.verbose true` was set.
 -/
 def getRawProjections (stx : Syntax) (str : Name) (traceIfExists : Bool := false)
-  (rules : Array ProjectionRule := #[]) (trc := false) :
-  CoreM (List Name × Array ProjectionData) := do
+    (rules : Array ProjectionRule := #[]) (trc := false) :
+    CoreM (List Name × Array ProjectionData) := do
   withOptions (· |>.updateBool `trace.simps.verbose (trc || ·)) <| do
   let env ← getEnv
   if let some data := (structureExt.getState env).find? str then
@@ -1053,8 +1053,8 @@ was just used. In that case we need to apply these projections before we continu
 `simpLemmas`: names of the simp lemmas added so far.(simpLemmas : Array Name)
 -/
 partial def addProjections (nm : NameStruct) (type lhs rhs : Expr)
-  (args : Array Expr) (mustBeStr : Bool) (cfg : Config)
-  (todo : List (String × Syntax)) (toApply : List Nat) : MetaM (Array Name) := do
+    (args : Array Expr) (mustBeStr : Bool) (cfg : Config)
+    (todo : List (String × Syntax)) (toApply : List Nat) : MetaM (Array Name) := do
   -- we don't want to unfold non-reducible definitions (like `Set`) to apply more arguments
   trace[simps.debug] "Type of the Expression before normalizing: {type}"
   withTransparency cfg.typeMd <| forallTelescopeReducing type fun typeArgs tgt ↦ withDefault do


### PR DESCRIPTION
Found by the linter in #27473; not exhaustive.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
