### PR TITLE
[Merged by Bors] - fix(Data/NNReal): type-correct `GroupWithZero` instance on `NNReal`

### DIFF
--- a/Mathlib/Analysis/FunctionalSpaces/SobolevInequality.lean
+++ b/Mathlib/Analysis/FunctionalSpaces/SobolevInequality.lean
@@ -661,10 +661,7 @@ theorem eLpNorm_le_eLpNorm_fderiv_of_le [FiniteDimensional ℝ F]
   have hp' : p'⁻¹ = p⁻¹ - (finrank ℝ E : ℝ)⁻¹ := by
     rw [inv_inv, NNReal.coe_sub]
     · simp
-    · #adaptation_note /-- nightly-2024-11-20
-      This should just be `gcongr`, but this is not working as of nightly-2024-11-20.
-      Possibly related to #19262 (since this proof fails at `with_reducible_and_instances`). -/
-      exact inv_anti₀ (by positivity) h2p.le
+    · gcongr
   have : (q : ℝ≥0∞) ≤ p' := by
     have H : (p' : ℝ)⁻¹ ≤ (↑q)⁻¹ := trans hp' hpq
     norm_cast at H ⊢
@@ -672,10 +669,7 @@ theorem eLpNorm_le_eLpNorm_fderiv_of_le [FiniteDimensional ℝ F]
     · dsimp
       have : 0 < p⁻¹ - (finrank ℝ E : ℝ≥0)⁻¹ := by
         simp only [tsub_pos_iff_lt]
-        #adaptation_note /-- nightly-2024-11-20
-        This should just be `gcongr`, but this is not working as of nightly-2024-11-20.
-        Possibly related to #19262 (since this proof fails at `with_reducible_and_instances`). -/
-        exact inv_strictAnti₀ (by positivity) h2p
+        gcongr
       positivity
     · positivity
   set t := (μ s).toNNReal ^ (1 / q - 1 / p' : ℝ)

--- a/Mathlib/Data/NNReal/Defs.lean
+++ b/Mathlib/Data/NNReal/Defs.lean
@@ -86,8 +86,21 @@ instance : IsOrderedRing ℝ≥0 :=
 instance : IsStrictOrderedRing ℝ≥0 :=
   Nonneg.isStrictOrderedRing
 
-noncomputable instance : LinearOrderedCommGroupWithZero ℝ≥0 :=
-  Nonneg.linearOrderedCommGroupWithZero
+noncomputable instance : LinearOrderedCommGroupWithZero ℝ≥0 where
+  /- Both `LinearOrderedCommGroupWithZero` and `Semifield` inherit from `CommGroupWithZero`.
+  However, if we project both of them into a `GroupWithZero` and try to unify them
+  at `reducible_and_instances` transparency, then we unfold `instSemifield` into `Nonneg.semifield`
+  which also causes an unfolding of `NNReal` to `{x // 0 ≤ x}`. Those two are (intentionally!)
+  not defeq at `reducible_and_instances`, even though the instances on them are.
+
+  So we either need to copy all the `Nonneg` instances and redefine them specifically for `NNReal`,
+  or we need to avoid the unfold in the unification. The latter has a smaller impact.
+  -/
+  __ := instSemifield.toCommGroupWithZero.toGroupWithZero
+  __ := Nonneg.linearOrderedCommGroupWithZero
+
+example {p q : ℝ≥0} (h1p : 0 < p) (h2p : p ≤ q) : q⁻¹ ≤ p⁻¹ := by
+  with_reducible_and_instances exact inv_anti₀ h1p h2p
 
 /-- Coercion `ℝ≥0 → ℝ`. -/
 @[coe] def toReal : ℝ≥0 → ℝ := Subtype.val


### PR DESCRIPTION
We can get a `GroupWithZero` instance on `NNReal` via the `Semifield` instance or via the `LinearOrderedCommGroupWithZero` instance. Under reducible-with-instances these are defeq, but in the process we non-reducibly-with-instances unfold `NNReal` to `{x // 0 ≤ x}`. To correct this mismatch, we either need to redefine the instances on `NNReal` to respect this non-reducibility, or we can make sure the unification succeeds without unfolding `NNReal`. The latter seems to give fewer headaches.

(In the long run, are we going to unbundle `LinearOrderedCommGroupWithZero` like we did for the other ordered algebra objects?)

This issue was spotted because `gcongr` didn't work reliably on `NNReal` anymore; see the fixed adaptation notes.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
