### PR TITLE
[Merged by Bors] - feat(Topology/Semicontinuous): use weaker assumptions for some results

### DIFF
--- a/Mathlib/Topology/Semicontinuous.lean
+++ b/Mathlib/Topology/Semicontinuous.lean
@@ -276,26 +276,17 @@ end
 
 section
 
-variable {γ : Type*}
-
-private theorem order_aux [LinearOrder γ] {x y : γ} (h : x < y) :
-    ∃ x' y', x' < y ∧ x < y' ∧ ∀ z, x' < z → y' ≤ z := by
-  by_cases hz : ∃ z, x < z ∧ z < y
-  · have ⟨z, hxz, hzy⟩ := hz
-    exact ⟨z, z, hzy, hxz, fun _ => le_of_lt⟩
-  · push_neg at hz
-    exact ⟨x, y, h, h, hz⟩
-
-variable [CompleteLinearOrder γ]
+variable {γ : Type*} [CompleteLinearOrder γ]
 
 theorem lowerSemicontinuousWithinAt_iff_le_liminf {f : α → γ} :
     LowerSemicontinuousWithinAt f s x ↔ f x ≤ liminf f (𝓝[s] x) := by
   constructor
   · intro hf; unfold LowerSemicontinuousWithinAt at hf
     contrapose! hf
-    obtain ⟨y, z, ylt, h₁, h₂⟩ := order_aux hf; use y
-    exact ⟨ylt, fun h => h₁.not_ge
-      (le_liminf_of_le (by isBoundedDefault) (h.mono fun _ => h₂ _))⟩
+    obtain ⟨z, ltz, y, ylt, h₁⟩ := hf.exists_disjoint_Iio_Ioi; use y
+    exact ⟨ylt, fun h => ltz.not_ge
+      (le_liminf_of_le (by isBoundedDefault) (h.mono fun _ h₂ =>
+        le_of_not_gt fun h₃ => (h₁ _ h₃ _ h₂).false))⟩
   exact fun hf y ylt => eventually_lt_of_lt_liminf (ylt.trans_le hf)
 
 alias ⟨LowerSemicontinuousWithinAt.le_liminf, _⟩ := lowerSemicontinuousWithinAt_iff_le_liminf
@@ -332,9 +323,9 @@ theorem lowerSemicontinuousOn_iff_isClosed_epigraph {f : α → γ} {s : Set α}
   constructor
   · intro hf ⟨x, y⟩ h
     by_cases hx : x ∈ s
-    · have ⟨x', y', hx', hy', h₁⟩ := order_aux (h hx)
-      filter_upwards [(hf x hx x' hx').prodMk_nhds (eventually_lt_nhds hy')]
-        with _ ⟨h₂, h₃⟩ h₄ using h₃.trans_le <| h₁ _ <| h₂ h₄
+    · have ⟨y', hy', z, hz, h₁⟩ := (h hx).exists_disjoint_Iio_Ioi
+      filter_upwards [(hf x hx z hz).prodMk_nhds (eventually_lt_nhds hy')]
+        with _ ⟨h₂, h₃⟩ h₄ using h₁ _ h₃ _ <| h₂ h₄
     · filter_upwards [(continuous_fst.tendsto _).eventually (hs.isOpen_compl.eventually_mem hx)]
         with _ h₁ h₂ using (h₁ h₂).elim
   · intro hf x _ y hy


### PR DESCRIPTION
Previously, several results about semicontinuity assumed a dense ordering. In `lowerSemicontinuous_iff_isClosed_epigraph`, there was also a completeness requirement on the order, preventing its use with real-valued functions. This PR removes these superfluous assumptions.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
