### PR TITLE
[Merged by Bors] - docs: Inherit `Equivalence` docstring on notation

### DIFF
--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -87,7 +87,7 @@ structure Equivalence (C : Type u₁) (D : Type u₂) [Category.{v₁} C] [Categ
     ∀ X : C, functor.map (unitIso.hom.app X) ≫ counitIso.hom.app (functor.obj X) =
       𝟙 (functor.obj X) := by aesop_cat
 
-/-- We infix the usual notation for an equivalence -/
+@[inherit_doc Equivalence]
 infixr:10 " ≌ " => Equivalence
 
 variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]

--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -62,13 +62,15 @@ open CategoryTheory.Functor NatIso Category
 -- declare the `v`'s first; see `CategoryTheory.Category` for an explanation
 universe v₁ v₂ v₃ u₁ u₂ u₃
 
-/-- An equivalence of categories. We define an equivalence as a half-adjoint equivalence: a pair
-of functors `F : C ⥤ D` and `G : D ⥤ C` with a unit `η : 𝟭 C ≅ F ⋙ G` and counit
-`ε : G ⋙ F ≅ 𝟭 D`. `η` and `ε` are natural isomorphisms that satisfy the triangle law for `F`:
-`Fη ≫ εF = 𝟙 F`. Or, in other words, the composite `F ⟶ FGF ⟶ F` is the identity.
+/-- An equivalence of categories.
+
+We define an equivalence between `C` and `D` as a half-adjoint equivalence: a pair of functors
+`F : C ⥤ D` and `G : D ⥤ C` with a unit `η : 𝟭 C ≅ F ⋙ G` and counit `ε : G ⋙ F ≅ 𝟭 D` such that
+the natural isomorphisms `η` and `ε` satisfy the triangle law for `F`: namely, `Fη ≫ εF = 𝟙 F`. Or,
+in other words, the composite `F ⟶ FGF ⟶ F` is the identity.
 
 In `unit_inverse_comp`, we show that this is sufficient to establish a full adjoint
-equivalence—i.e., that the composite `G ⟶ GFG ⟶ G` must also be the identity.
+equivalence. I.e., the composite `G ⟶ GFG ⟶ G` is also the identity.
 
 The triangle equation `functor_unitIso_comp` is written as a family of equalities between
 morphisms. It is more complicated if we write it as an equality of natural transformations, because

--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -62,7 +62,8 @@ open CategoryTheory.Functor NatIso Category
 -- declare the `v`'s first; see `CategoryTheory.Category` for an explanation
 universe v₁ v₂ v₃ u₁ u₂ u₃
 
-/-- An equivalence of categories.
+/--
+An equivalence of categories.
 
 We define an equivalence between `C` and `D` as a half-adjoint equivalence: a pair of functors
 `F : C ⥤ D` and `G : D ⥤ C` with a unit `η : 𝟭 C ≅ F ⋙ G` and counit `ε : G ⋙ F ≅ 𝟭 D`, such that
@@ -74,7 +75,8 @@ equivalence. I.e., the composite `G ⟶ GFG ⟶ G` is also the identity.
 
 The triangle equation `functor_unitIso_comp` is written as a family of equalities between
 morphisms. It is more complicated if we write it as an equality of natural transformations, because
-then we would either have to insert natural transformations like `F ⟶ F𝟭` or abuse defeq. -/
+then we would either have to insert natural transformations like `F ⟶ F𝟭` or abuse defeq.
+-/
 @[ext, stacks 001J]
 structure Equivalence (C : Type u₁) (D : Type u₂) [Category.{v₁} C] [Category.{v₂} D] where mk' ::
   /-- The forwards direction of an equivalence. -/
@@ -85,13 +87,11 @@ structure Equivalence (C : Type u₁) (D : Type u₂) [Category.{v₁} C] [Categ
   unitIso : 𝟭 C ≅ functor ⋙ inverse
   /-- The composition `inverse ⋙ functor` is isomorphic to the identity. -/
   counitIso : inverse ⋙ functor ≅ 𝟭 D
-  /--
-  The triangle law for the forwards direction of an equivalence: the unit and counit compose
+  /-- The triangle law for the forwards direction of an equivalence: the unit and counit compose
   to the identity when whiskered along the forwards direction.
 
   We state this as a family of equalities among morphisms instead of an equality of natural
-  transformations to avoid abusing defeq or inserting natural transformations like `F ⟶ F𝟭`.
-  -/
+  transformations to avoid abusing defeq or inserting natural transformations like `F ⟶ F𝟭`. -/
   functor_unitIso_comp :
     ∀ X : C, functor.map (unitIso.hom.app X) ≫ counitIso.hom.app (functor.obj X) =
       𝟙 (functor.obj X) := by aesop_cat

--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -74,12 +74,12 @@ equivalence. I.e., the composite `G ⟶ GFG ⟶ G` is also the identity.
 
 The triangle equation `functor_unitIso_comp` is written as a family of equalities between
 morphisms. It is more complicated if we write it as an equality of natural transformations, because
-then we would have to insert natural transformations like `F ⟶ F𝟭`. -/
+then we would either have to insert natural transformations like `F ⟶ F𝟭` or abuse defeq. -/
 @[ext, stacks 001J]
 structure Equivalence (C : Type u₁) (D : Type u₂) [Category.{v₁} C] [Category.{v₂} D] where mk' ::
-  /-- The forwards direction of `C ≌ D`. -/
+  /-- The forwards direction of the equivalence. -/
   functor : C ⥤ D
-  /-- The backwards direction of `C ≌ D`. -/
+  /-- The backwards direction of the equivalence. -/
   inverse : D ⥤ C
   /-- The composition `functor ⋙ inverse` is isomorphic to the identity. -/
   unitIso : 𝟭 C ≅ functor ⋙ inverse
@@ -90,7 +90,7 @@ structure Equivalence (C : Type u₁) (D : Type u₂) [Category.{v₁} C] [Categ
   to the identity when whiskered along the forwards direction.
 
   We state this as a family of equalities among morphisms instead of an equality of natural
-  transformations to avoid inserting natural transformations like `F ⟶ F𝟭`.
+  transformations to avoid abusing defeq or inserting natural transformations like `F ⟶ F𝟭`.
   -/
   functor_unitIso_comp :
     ∀ X : C, functor.map (unitIso.hom.app X) ≫ counitIso.hom.app (functor.obj X) =

--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -62,12 +62,13 @@ open CategoryTheory.Functor NatIso Category
 -- declare the `v`'s first; see `CategoryTheory.Category` for an explanation
 universe v₁ v₂ v₃ u₁ u₂ u₃
 
-/-- An equivalence of categories. We define an equivalence as a (half)-adjoint equivalence: a pair
-of functors with a unit and counit which are natural isomorphisms that satisfy the triangle law
-`Fη ≫ εF = 𝟙 F`. Or, in other words, the composite `F ⟶ FGF ⟶ F` is the identity.
+/-- An equivalence of categories. We define an equivalence as a half-adjoint equivalence: a pair
+of functors `F : C ⥤ D` and `G : D ⥤ C` with a unit `η : 𝟭 C ≅ F ⋙ G` and counit
+`ε : G ⋙ F ≅ 𝟭 D`. `η` and `ε` are natural isomorphisms that satisfy the triangle law for `F`:
+`Fη ≫ εF = 𝟙 F`. Or in other words, the composite `F ⟶ FGF ⟶ F` is the identity.
 
-In `unit_inverse_comp`, we show that this is sufficient to establish an adjoint
-equivalence—i.e., that the composite `G ⟶ GFG ⟶ G` is also the identity.
+In `unit_inverse_comp`, we show that this is sufficient to establish a full adjoint
+equivalence—i.e., that the composite `G ⟶ GFG ⟶ G` must also be the identity.
 
 The triangle equation `functor_unitIso_comp` is written as a family of equalities between
 morphisms. It is more complicated if we write it as an equality of natural transformations, because

--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -65,7 +65,7 @@ universe v₁ v₂ v₃ u₁ u₂ u₃
 /-- An equivalence of categories.
 
 We define an equivalence between `C` and `D` as a half-adjoint equivalence: a pair of functors
-`F : C ⥤ D` and `G : D ⥤ C` with a unit `η : 𝟭 C ≅ F ⋙ G` and counit `ε : G ⋙ F ≅ 𝟭 D` such that
+`F : C ⥤ D` and `G : D ⥤ C` with a unit `η : 𝟭 C ≅ F ⋙ G` and counit `ε : G ⋙ F ≅ 𝟭 D`, such that
 the natural isomorphisms `η` and `ε` satisfy the triangle law for `F`: namely, `Fη ≫ εF = 𝟙 F`. Or,
 in other words, the composite `F ⟶ FGF ⟶ F` is the identity.
 

--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -65,7 +65,7 @@ universe v₁ v₂ v₃ u₁ u₂ u₃
 /-- An equivalence of categories. We define an equivalence as a half-adjoint equivalence: a pair
 of functors `F : C ⥤ D` and `G : D ⥤ C` with a unit `η : 𝟭 C ≅ F ⋙ G` and counit
 `ε : G ⋙ F ≅ 𝟭 D`. `η` and `ε` are natural isomorphisms that satisfy the triangle law for `F`:
-`Fη ≫ εF = 𝟙 F`. Or in other words, the composite `F ⟶ FGF ⟶ F` is the identity.
+`Fη ≫ εF = 𝟙 F`. Or, in other words, the composite `F ⟶ FGF ⟶ F` is the identity.
 
 In `unit_inverse_comp`, we show that this is sufficient to establish a full adjoint
 equivalence—i.e., that the composite `G ⟶ GFG ⟶ G` must also be the identity.

--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -82,7 +82,13 @@ structure Equivalence (C : Type u₁) (D : Type u₂) [Category.{v₁} C] [Categ
   unitIso : 𝟭 C ≅ functor ⋙ inverse
   /-- The composition `inverse ⋙ functor` is isomorphic to the identity. -/
   counitIso : inverse ⋙ functor ≅ 𝟭 D
-  /-- The unit and counit of an equivalence compose to the identity under the forwards direction. -/
+  /--
+  The triangle law for the forwards direction of an equivalence: the unit and counit compose
+  to the identity when whiskered along the forwards direction.
+
+  We state this as a family of equalities among morphisms instead of an equality of natural
+  transformations to avoid inserting natural transformations like `F ⟶ F𝟭`.
+  -/
   functor_unitIso_comp :
     ∀ X : C, functor.map (unitIso.hom.app X) ≫ counitIso.hom.app (functor.obj X) =
       𝟙 (functor.obj X) := by aesop_cat

--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -77,9 +77,9 @@ morphisms. It is more complicated if we write it as an equality of natural trans
 then we would either have to insert natural transformations like `F ⟶ F𝟭` or abuse defeq. -/
 @[ext, stacks 001J]
 structure Equivalence (C : Type u₁) (D : Type u₂) [Category.{v₁} C] [Category.{v₂} D] where mk' ::
-  /-- The forwards direction of the equivalence. -/
+  /-- The forwards direction of an equivalence. -/
   functor : C ⥤ D
-  /-- The backwards direction of the equivalence. -/
+  /-- The backwards direction of an equivalence. -/
   inverse : D ⥤ C
   /-- The composition `functor ⋙ inverse` is isomorphic to the identity. -/
   unitIso : 𝟭 C ≅ functor ⋙ inverse

--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -62,27 +62,27 @@ open CategoryTheory.Functor NatIso Category
 -- declare the `v`'s first; see `CategoryTheory.Category` for an explanation
 universe v₁ v₂ v₃ u₁ u₂ u₃
 
-/-- We define an equivalence as a (half)-adjoint equivalence, a pair of functors with
-  a unit and counit which are natural isomorphisms and the triangle law `Fη ≫ εF = 1`, or in other
-  words the composite `F ⟶ FGF ⟶ F` is the identity.
+/-- An equivalence of categories. We define an equivalence as a (half)-adjoint equivalence: a pair
+of functors with a unit and counit which are natural isomorphisms that satisfy the triangle law
+`Fη ≫ εF = 𝟙 F`. Or, in other words, the composite `F ⟶ FGF ⟶ F` is the identity.
 
-  In `unit_inverse_comp`, we show that this is actually an adjoint equivalence, i.e., that the
-  composite `G ⟶ GFG ⟶ G` is also the identity.
+In `unit_inverse_comp`, we show that this is sufficient to establish an adjoint
+equivalence—i.e., that the composite `G ⟶ GFG ⟶ G` is also the identity.
 
-  The triangle equation is written as a family of equalities between morphisms, it is more
-  complicated if we write it as an equality of natural transformations, because then we would have
-  to insert natural transformations like `F ⟶ F1`. -/
+The triangle equation `functor_unitIso_comp` is written as a family of equalities between
+morphisms. It is more complicated if we write it as an equality of natural transformations, because
+then we would have to insert natural transformations like `F ⟶ F𝟭`. -/
 @[ext, stacks 001J]
 structure Equivalence (C : Type u₁) (D : Type u₂) [Category.{v₁} C] [Category.{v₂} D] where mk' ::
-  /-- A functor in one direction -/
+  /-- The forwards direction of `C ≌ D`. -/
   functor : C ⥤ D
-  /-- A functor in the other direction -/
+  /-- The backwards direction of `C ≌ D`. -/
   inverse : D ⥤ C
-  /-- The composition `functor ⋙ inverse` is isomorphic to the identity -/
+  /-- The composition `functor ⋙ inverse` is isomorphic to the identity. -/
   unitIso : 𝟭 C ≅ functor ⋙ inverse
-  /-- The composition `inverse ⋙ functor` is also isomorphic to the identity -/
+  /-- The composition `inverse ⋙ functor` is isomorphic to the identity. -/
   counitIso : inverse ⋙ functor ≅ 𝟭 D
-  /-- The natural isomorphisms compose to the identity. -/
+  /-- The unit and counit of an equivalence compose to the identity under the forwards direction. -/
   functor_unitIso_comp :
     ∀ X : C, functor.map (unitIso.hom.app X) ≫ counitIso.hom.app (functor.obj X) =
       𝟙 (functor.obj X) := by aesop_cat

--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -67,10 +67,11 @@ universe v₁ v₂ v₃ u₁ u₂ u₃
 We define an equivalence between `C` and `D`, with notation `C ≌ D`, as a half-adjoint equivalence:
 a pair of functors `F : C ⥤ D` and `G : D ⥤ C` with a unit `η : 𝟭 C ≅ F ⋙ G` and counit
 `ε : G ⋙ F ≅ 𝟭 D`, such that the natural isomorphisms `η` and `ε` satisfy the triangle law for
-`F`: namely, `Fη ≫ εF = 𝟙 F`. Or, more informally, the composite `F ⟶ FGF ⟶ F` is the identity.
+`F`: namely, `Fη ≫ εF = 𝟙 F`. Or, in other words, the composite `F` ⟶ `F ⋙ G ⋙ F` ⟶ `F` is the
+identity.
 
 In `unit_inverse_comp`, we show that this is sufficient to establish a full adjoint
-equivalence. I.e., the composite `G ⟶ GFG ⟶ G` is also the identity.
+equivalence. I.e., the composite `G` ⟶ `G ⋙ F ⋙ G` ⟶ `G` is also the identity.
 
 The triangle equation `functor_unitIso_comp` is written as a family of equalities between
 morphisms. It is more complicated if we write it as an equality of natural transformations, because

--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -64,10 +64,10 @@ universe v₁ v₂ v₃ u₁ u₂ u₃
 
 /-- An equivalence of categories.
 
-We define an equivalence between `C` and `D` as a half-adjoint equivalence: a pair of functors
-`F : C ⥤ D` and `G : D ⥤ C` with a unit `η : 𝟭 C ≅ F ⋙ G` and counit `ε : G ⋙ F ≅ 𝟭 D`, such that
-the natural isomorphisms `η` and `ε` satisfy the triangle law for `F`: namely, `Fη ≫ εF = 𝟙 F`. Or,
-in other words, the composite `F ⟶ FGF ⟶ F` is the identity.
+We define an equivalence between `C` and `D`, with notation `C ≌ D`, as a half-adjoint equivalence:
+a pair of functors `F : C ⥤ D` and `G : D ⥤ C` with a unit `η : 𝟭 C ≅ F ⋙ G` and counit
+`ε : G ⋙ F ≅ 𝟭 D`, such that the natural isomorphisms `η` and `ε` satisfy the triangle law for
+`F`: namely, `Fη ≫ εF = 𝟙 F`. Or, more informally, the composite `F ⟶ FGF ⟶ F` is the identity.
 
 In `unit_inverse_comp`, we show that this is sufficient to establish a full adjoint
 equivalence. I.e., the composite `G ⟶ GFG ⟶ G` is also the identity.

--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -62,8 +62,7 @@ open CategoryTheory.Functor NatIso Category
 -- declare the `v`'s first; see `CategoryTheory.Category` for an explanation
 universe v₁ v₂ v₃ u₁ u₂ u₃
 
-/--
-An equivalence of categories.
+/-- An equivalence of categories.
 
 We define an equivalence between `C` and `D` as a half-adjoint equivalence: a pair of functors
 `F : C ⥤ D` and `G : D ⥤ C` with a unit `η : 𝟭 C ≅ F ⋙ G` and counit `ε : G ⋙ F ≅ 𝟭 D`, such that
@@ -75,8 +74,7 @@ equivalence. I.e., the composite `G ⟶ GFG ⟶ G` is also the identity.
 
 The triangle equation `functor_unitIso_comp` is written as a family of equalities between
 morphisms. It is more complicated if we write it as an equality of natural transformations, because
-then we would either have to insert natural transformations like `F ⟶ F𝟭` or abuse defeq.
--/
+then we would either have to insert natural transformations like `F ⟶ F𝟭` or abuse defeq. -/
 @[ext, stacks 001J]
 structure Equivalence (C : Type u₁) (D : Type u₂) [Category.{v₁} C] [Category.{v₂} D] where mk' ::
   /-- The forwards direction of an equivalence. -/


### PR DESCRIPTION
The prior docstring for the notation `≌` for `Equivalence` read only

> We infix the usual notation for an equivalence

This PR instead attaches `@[inherit_doc Equivalence]` to the notation, so that information for `Equivalence` is displayed when hovering over `≌`.

We also clean up the formatting and grammar of the docstrings for `Equivalence` and its fields, and make them less "context-specific" (and therefore more appropriate for hovers) without changing their content radically.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
