### PR TITLE
[Merged by Bors] - feat(Data/Rat): add lemma for multiplying num or den

### DIFF
--- a/Mathlib/Data/NNRat/Lemmas.lean
+++ b/Mathlib/Data/NNRat/Lemmas.lean
@@ -7,6 +7,8 @@ import Mathlib.Algebra.Field.Rat
 import Mathlib.Algebra.Group.Indicator
 import Mathlib.Algebra.GroupWithZero.Action.End
 import Mathlib.Algebra.Order.Field.Rat
+import Mathlib.Data.Rat.Lemmas
+import Mathlib.Tactic.Zify
 
 /-!
 # Field and action structures on the nonnegative rationals
@@ -65,5 +67,27 @@ variable {q : ℚ≥0}
 /-- A recursor for nonnegative rationals in terms of numerators and denominators. -/
 protected def rec {α : ℚ≥0 → Sort*} (h : ∀ m n : ℕ, α (m / n)) (q : ℚ≥0) : α q := by
   rw [← num_div_den q]; apply h
+
+theorem mul_num (q₁ q₂ : ℚ≥0) :
+    (q₁ * q₂).num = q₁.num * q₂.num / Nat.gcd (q₁.num * q₂.num) (q₁.den * q₂.den) := by
+  zify
+  convert Rat.mul_num q₁ q₂ <;> norm_cast
+
+theorem mul_den (q₁ q₂ : ℚ≥0) :
+    (q₁ * q₂).den = q₁.den * q₂.den / Nat.gcd (q₁.num * q₂.num) (q₁.den * q₂.den) := by
+  convert Rat.mul_den q₁ q₂
+  norm_cast
+
+/-- A version of `NNRat.mul_den` without division. -/
+theorem den_mul_den_eq_den_mul_gcd (q₁ q₂ : ℚ≥0) :
+    q₁.den * q₂.den = (q₁ * q₂).den * ((q₁.num * q₂.num).gcd (q₁.den * q₂.den)) := by
+  convert Rat.den_mul_den_eq_den_mul_gcd q₁ q₂
+  norm_cast
+
+/-- A version of `NNRat.mul_num` without division. -/
+theorem num_mul_num_eq_num_mul_gcd (q₁ q₂ : ℚ≥0) :
+    q₁.num * q₂.num = (q₁ * q₂).num * ((q₁.num * q₂.num).gcd (q₁.den * q₂.den)) := by
+  zify
+  convert Rat.num_mul_num_eq_num_mul_gcd q₁ q₂ <;> norm_cast
 
 end NNRat

--- a/Mathlib/Data/Rat/Lemmas.lean
+++ b/Mathlib/Data/Rat/Lemmas.lean
@@ -91,6 +91,20 @@ theorem mul_den (q₁ q₂ : ℚ) :
       q₁.den * q₂.den / Nat.gcd (q₁.num * q₂.num).natAbs (q₁.den * q₂.den) := by
   rw [mul_def, normalize_eq]
 
+/-- A version of `Rat.mul_den` without division. -/
+theorem den_mul_den_eq_den_mul_gcd (q₁ q₂ : ℚ) :
+    q₁.den * q₂.den = (q₁ * q₂).den * ((q₁.num * q₂.num).natAbs.gcd (q₁.den * q₂.den)) := by
+  rw [mul_den]
+  exact ((Nat.dvd_iff_div_mul_eq _ _).mp (Nat.gcd_dvd_right _ _)).symm
+
+/-- A version of `Rat.mul_num` without division. -/
+theorem num_mul_num_eq_num_mul_gcd (q₁ q₂ : ℚ) :
+    q₁.num * q₂.num = (q₁ * q₂).num * ((q₁.num * q₂.num).natAbs.gcd (q₁.den * q₂.den)) := by
+  rw [mul_num]
+  refine (Int.ediv_mul_cancel ?_).symm
+  rw [← Int.dvd_natAbs]
+  exact Int.ofNat_dvd.mpr (Nat.gcd_dvd_left _ _)
+
 theorem mul_self_num (q : ℚ) : (q * q).num = q.num * q.num := by
   rw [mul_num, Int.natAbs_mul, Nat.Coprime.gcd_eq_one, Int.ofNat_one, Int.ediv_one]
   exact (q.reduced.mul_right q.reduced).mul (q.reduced.mul_right q.reduced)


### PR DESCRIPTION
Small lemmas for Rat split off from #26059. These restates `mul_num` and `mul_den` so one doesn't need to deal with integer division.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
