### PR TITLE
[Merged by Bors] - feat(Topology/Instances/Matrix): topology of `Set.matrix`

### DIFF
--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -630,8 +630,7 @@ variable {A : Type*} [AddMonoid A]
 /-- A version of `Set.matrix` for `AddSubmonoid`s.
 Given an `AddSubmonoid` `S`, `S.matrix` is the `AddSubmonoid` of matrices `m`
 all of whose entries `m i j` belong to `S`. -/
-def matrix (S : AddSubmonoid A) :
-    AddSubmonoid (Matrix m n A) where
+def matrix (S : AddSubmonoid A) : AddSubmonoid (Matrix m n A) where
   carrier := Set.matrix S
   add_mem' hm hn i j := add_mem (hm i j) (hn i j)
   zero_mem' _ _ := zero_mem _

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -656,22 +656,21 @@ end AddSubgroup
 
 namespace Subring
 
-variable {A : Type*} [Ring A]
+variable {R : Type*} [Ring R]
 variable {ι : Type*} [Fintype ι] [DecidableEq ι]
 
 /-- A version of `Set.matrix` for `Subring`s.
-Given an `Subring` `S`, `S.matrix` is the `Subring` of square matrices `m`
+Given a `Subring` `S`, `S.matrix` is the `Subring` of square matrices `m`
 all of whose entries `m i j` belong to `S`. -/
-def matrix (S : Subring A) :
-    Subring (Matrix ι ι A) where
+def matrix (S : Subring R) :
+    Subring (Matrix ι ι R) where
       __ := S.toAddSubgroup.matrix
       mul_mem' ha hb i j := Subring.sum_mem _ (fun k _ => Subring.mul_mem _ (ha i k) (hb k j))
       one_mem' i j := by
         rw[Matrix.one_apply]
-        if h : i = j then
-          rw[if_pos h]; apply Subring.one_mem
-        else
-          rw[if_neg h]; apply Subring.zero_mem
+        by_cases h : i = j
+        · rw[if_pos h]; apply Subring.one_mem
+        rw[if_neg h]; apply Subring.zero_mem
 
 end Subring
 

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -626,51 +626,64 @@ end AlgEquiv
 namespace AddSubmonoid
 
 variable {A : Type*} [AddMonoid A]
-variable {ι₁ ι₂ : Type*}
 
 /-- A version of `Set.matrix` for `AddSubmonoid`s.
 Given an `AddSubmonoid` `S`, `S.matrix` is the `AddSubmonoid` of matrices `m`
 all of whose entries `m i j` belong to `S`. -/
 def matrix (S : AddSubmonoid A) :
-    AddSubmonoid (Matrix ι₁ ι₂ A) where
-      carrier := Set.matrix S
-      add_mem' hm hn i j := add_mem (hm i j) (hn i j)
-      zero_mem' _ _ := zero_mem _
+    AddSubmonoid (Matrix m n A) where
+  carrier := Set.matrix S
+  add_mem' hm hn i j := add_mem (hm i j) (hn i j)
+  zero_mem' _ _ := zero_mem _
 
 end AddSubmonoid
 
 namespace AddSubgroup
 
 variable {A : Type*} [AddGroup A]
-variable {ι₁ ι₂ : Type*}
 
 /-- A version of `Set.matrix` for `AddSubgroup`s.
 Given an `AddSubgroup` `S`, `S.matrix` is the `AddSubgroup` of matrices `m`
 all of whose entries `m i j` belong to `S`. -/
 def matrix (S : AddSubgroup A) :
-    AddSubgroup (Matrix ι₁ ι₂ A) where
-      __ := S.toAddSubmonoid.matrix
-      neg_mem' hm i j := AddSubgroup.neg_mem _ (hm i j)
+    AddSubgroup (Matrix m n A) where
+  __ := S.toAddSubmonoid.matrix
+  neg_mem' hm i j := AddSubgroup.neg_mem _ (hm i j)
 
 end AddSubgroup
+
+namespace Subsemiring
+
+variable {R : Type*} [Semiring R]
+variable [Fintype n] [DecidableEq n]
+
+/-- A version of `Set.matrix` for `Subsemiring`s.
+Given a `Subsemiring` `S`, `S.matrix` is the `Subsemiring` of square matrices `m`
+all of whose entries `m i j` belong to `S`. -/
+def matrix (S : Subsemiring R) :
+    Subsemiring (Matrix n n R) where
+  __ := S.toAddSubmonoid.matrix
+  mul_mem' ha hb i j := Subsemiring.sum_mem _ (fun k _ => Subsemiring.mul_mem _ (ha i k) (hb k j))
+  one_mem' i j := by
+    rw[Matrix.one_apply]
+    by_cases h : i = j
+    · rw[if_pos h]; apply Subsemiring.one_mem
+    rw[if_neg h]; apply Subsemiring.zero_mem
+
+end Subsemiring
 
 namespace Subring
 
 variable {R : Type*} [Ring R]
-variable {ι : Type*} [Fintype ι] [DecidableEq ι]
+variable [Fintype n] [DecidableEq n]
 
 /-- A version of `Set.matrix` for `Subring`s.
 Given a `Subring` `S`, `S.matrix` is the `Subring` of square matrices `m`
 all of whose entries `m i j` belong to `S`. -/
 def matrix (S : Subring R) :
-    Subring (Matrix ι ι R) where
-      __ := S.toAddSubgroup.matrix
-      mul_mem' ha hb i j := Subring.sum_mem _ (fun k _ => Subring.mul_mem _ (ha i k) (hb k j))
-      one_mem' i j := by
-        rw[Matrix.one_apply]
-        by_cases h : i = j
-        · rw[if_pos h]; apply Subring.one_mem
-        rw[if_neg h]; apply Subring.zero_mem
+    Subring (Matrix n n R) where
+  __ := S.toSubsemiring.matrix
+  neg_mem' hm i j := Subring.neg_mem _ (hm i j)
 
 end Subring
 

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -67,70 +67,6 @@ theorem sum_apply [AddCommMonoid α] (i : m) (j : n) (s : Finset β) (g : β →
 
 end Matrix
 
-namespace AddSubmonoid
-
-variable {A : Type*} [AddMonoid A]
-
-/-- A version of `Set.matrix` for `AddSubmonoid`s.
-Given an `AddSubmonoid` `S`, `S.matrix` is the `AddSubmonoid` of matrices `m`
-all of whose entries `m i j` belong to `S`. -/
-def matrix (S : AddSubmonoid A) :
-    AddSubmonoid (Matrix m n A) where
-  carrier := Set.matrix S
-  add_mem' hm hn i j := add_mem (hm i j) (hn i j)
-  zero_mem' _ _ := zero_mem _
-
-end AddSubmonoid
-
-namespace AddSubgroup
-
-variable {A : Type*} [AddGroup A]
-
-/-- A version of `Set.matrix` for `AddSubgroup`s.
-Given an `AddSubgroup` `S`, `S.matrix` is the `AddSubgroup` of matrices `m`
-all of whose entries `m i j` belong to `S`. -/
-def matrix (S : AddSubgroup A) :
-    AddSubgroup (Matrix m n A) where
-  __ := S.toAddSubmonoid.matrix
-  neg_mem' hm i j := AddSubgroup.neg_mem _ (hm i j)
-
-end AddSubgroup
-
-namespace Subsemiring
-
-variable {R : Type*} [Semiring R]
-variable [Fintype n] [DecidableEq n]
-
-/-- A version of `Set.matrix` for `Subsemiring`s.
-Given a `Subsemiring` `S`, `S.matrix` is the `Subsemiring` of square matrices `m`
-all of whose entries `m i j` belong to `S`. -/
-def matrix (S : Subsemiring R) :
-    Subsemiring (Matrix n n R) where
-  __ := S.toAddSubmonoid.matrix
-  mul_mem' ha hb i j := Subsemiring.sum_mem _ (fun k _ => Subsemiring.mul_mem _ (ha i k) (hb k j))
-  one_mem' i j := by
-    rw[Matrix.one_apply]
-    by_cases h : i = j
-    · rw[if_pos h]; apply Subsemiring.one_mem
-    rw[if_neg h]; apply Subsemiring.zero_mem
-
-end Subsemiring
-
-namespace Subring
-
-variable {R : Type*} [Ring R]
-variable [Fintype n] [DecidableEq n]
-
-/-- A version of `Set.matrix` for `Subring`s.
-Given a `Subring` `S`, `S.matrix` is the `Subring` of square matrices `m`
-all of whose entries `m i j` belong to `S`. -/
-def matrix (S : Subring R) :
-    Subring (Matrix n n R) where
-  __ := S.toSubsemiring.matrix
-  neg_mem' hm i j := Subring.neg_mem _ (hm i j)
-
-end Subring
-
 open Matrix
 
 namespace Matrix
@@ -686,6 +622,66 @@ we can get rid of the `ᵒᵖ` in the left-hand side, see `Matrix.transposeAlgEq
     ext; simp [algebraMap_matrix_apply, eq_comm, apply_ite MulOpposite.unop]
 
 end AlgEquiv
+
+namespace AddSubmonoid
+
+variable {A : Type*} [AddMonoid A]
+
+/-- A version of `Set.matrix` for `AddSubmonoid`s.
+Given an `AddSubmonoid` `S`, `S.matrix` is the `AddSubmonoid` of matrices `m`
+all of whose entries `m i j` belong to `S`. -/
+def matrix (S : AddSubmonoid A) :
+    AddSubmonoid (Matrix m n A) where
+  carrier := Set.matrix S
+  add_mem' hm hn i j := add_mem (hm i j) (hn i j)
+  zero_mem' _ _ := zero_mem _
+
+end AddSubmonoid
+
+namespace AddSubgroup
+
+variable {A : Type*} [AddGroup A]
+
+/-- A version of `Set.matrix` for `AddSubgroup`s.
+Given an `AddSubgroup` `S`, `S.matrix` is the `AddSubgroup` of matrices `m`
+all of whose entries `m i j` belong to `S`. -/
+def matrix (S : AddSubgroup A) :
+    AddSubgroup (Matrix m n A) where
+  __ := S.toAddSubmonoid.matrix
+  neg_mem' hm i j := AddSubgroup.neg_mem _ (hm i j)
+
+end AddSubgroup
+
+namespace Subsemiring
+
+variable {R : Type*} [Semiring R]
+variable [Fintype n] [DecidableEq n]
+
+/-- A version of `Set.matrix` for `Subsemiring`s.
+Given a `Subsemiring` `S`, `S.matrix` is the `Subsemiring` of square matrices `m`
+all of whose entries `m i j` belong to `S`. -/
+def matrix (S : Subsemiring R) :
+    Subsemiring (Matrix n n R) where
+  __ := S.toAddSubmonoid.matrix
+  mul_mem' ha hb i j := Subsemiring.sum_mem _ (fun k _ => Subsemiring.mul_mem _ (ha i k) (hb k j))
+  one_mem' := (diagonal_mem_matrix (Subsemiring.zero_mem _)).mpr (fun _ => Subsemiring.one_mem _)
+
+end Subsemiring
+
+namespace Subring
+
+variable {R : Type*} [Ring R]
+variable [Fintype n] [DecidableEq n]
+
+/-- A version of `Set.matrix` for `Subring`s.
+Given a `Subring` `S`, `S.matrix` is the `Subring` of square matrices `m`
+all of whose entries `m i j` belong to `S`. -/
+def matrix (S : Subring R) :
+    Subring (Matrix n n R) where
+  __ := S.toSubsemiring.matrix
+  neg_mem' hm i j := Subring.neg_mem _ (hm i j)
+
+end Subring
 
 open Matrix
 

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -67,6 +67,70 @@ theorem sum_apply [AddCommMonoid α] (i : m) (j : n) (s : Finset β) (g : β →
 
 end Matrix
 
+namespace AddSubmonoid
+
+variable {A : Type*} [AddMonoid A]
+
+/-- A version of `Set.matrix` for `AddSubmonoid`s.
+Given an `AddSubmonoid` `S`, `S.matrix` is the `AddSubmonoid` of matrices `m`
+all of whose entries `m i j` belong to `S`. -/
+def matrix (S : AddSubmonoid A) :
+    AddSubmonoid (Matrix m n A) where
+  carrier := Set.matrix S
+  add_mem' hm hn i j := add_mem (hm i j) (hn i j)
+  zero_mem' _ _ := zero_mem _
+
+end AddSubmonoid
+
+namespace AddSubgroup
+
+variable {A : Type*} [AddGroup A]
+
+/-- A version of `Set.matrix` for `AddSubgroup`s.
+Given an `AddSubgroup` `S`, `S.matrix` is the `AddSubgroup` of matrices `m`
+all of whose entries `m i j` belong to `S`. -/
+def matrix (S : AddSubgroup A) :
+    AddSubgroup (Matrix m n A) where
+  __ := S.toAddSubmonoid.matrix
+  neg_mem' hm i j := AddSubgroup.neg_mem _ (hm i j)
+
+end AddSubgroup
+
+namespace Subsemiring
+
+variable {R : Type*} [Semiring R]
+variable [Fintype n] [DecidableEq n]
+
+/-- A version of `Set.matrix` for `Subsemiring`s.
+Given a `Subsemiring` `S`, `S.matrix` is the `Subsemiring` of square matrices `m`
+all of whose entries `m i j` belong to `S`. -/
+def matrix (S : Subsemiring R) :
+    Subsemiring (Matrix n n R) where
+  __ := S.toAddSubmonoid.matrix
+  mul_mem' ha hb i j := Subsemiring.sum_mem _ (fun k _ => Subsemiring.mul_mem _ (ha i k) (hb k j))
+  one_mem' i j := by
+    rw[Matrix.one_apply]
+    by_cases h : i = j
+    · rw[if_pos h]; apply Subsemiring.one_mem
+    rw[if_neg h]; apply Subsemiring.zero_mem
+
+end Subsemiring
+
+namespace Subring
+
+variable {R : Type*} [Ring R]
+variable [Fintype n] [DecidableEq n]
+
+/-- A version of `Set.matrix` for `Subring`s.
+Given a `Subring` `S`, `S.matrix` is the `Subring` of square matrices `m`
+all of whose entries `m i j` belong to `S`. -/
+def matrix (S : Subring R) :
+    Subring (Matrix n n R) where
+  __ := S.toSubsemiring.matrix
+  neg_mem' hm i j := Subring.neg_mem _ (hm i j)
+
+end Subring
+
 open Matrix
 
 namespace Matrix
@@ -622,70 +686,6 @@ we can get rid of the `ᵒᵖ` in the left-hand side, see `Matrix.transposeAlgEq
     ext; simp [algebraMap_matrix_apply, eq_comm, apply_ite MulOpposite.unop]
 
 end AlgEquiv
-
-namespace AddSubmonoid
-
-variable {A : Type*} [AddMonoid A]
-
-/-- A version of `Set.matrix` for `AddSubmonoid`s.
-Given an `AddSubmonoid` `S`, `S.matrix` is the `AddSubmonoid` of matrices `m`
-all of whose entries `m i j` belong to `S`. -/
-def matrix (S : AddSubmonoid A) :
-    AddSubmonoid (Matrix m n A) where
-  carrier := Set.matrix S
-  add_mem' hm hn i j := add_mem (hm i j) (hn i j)
-  zero_mem' _ _ := zero_mem _
-
-end AddSubmonoid
-
-namespace AddSubgroup
-
-variable {A : Type*} [AddGroup A]
-
-/-- A version of `Set.matrix` for `AddSubgroup`s.
-Given an `AddSubgroup` `S`, `S.matrix` is the `AddSubgroup` of matrices `m`
-all of whose entries `m i j` belong to `S`. -/
-def matrix (S : AddSubgroup A) :
-    AddSubgroup (Matrix m n A) where
-  __ := S.toAddSubmonoid.matrix
-  neg_mem' hm i j := AddSubgroup.neg_mem _ (hm i j)
-
-end AddSubgroup
-
-namespace Subsemiring
-
-variable {R : Type*} [Semiring R]
-variable [Fintype n] [DecidableEq n]
-
-/-- A version of `Set.matrix` for `Subsemiring`s.
-Given a `Subsemiring` `S`, `S.matrix` is the `Subsemiring` of square matrices `m`
-all of whose entries `m i j` belong to `S`. -/
-def matrix (S : Subsemiring R) :
-    Subsemiring (Matrix n n R) where
-  __ := S.toAddSubmonoid.matrix
-  mul_mem' ha hb i j := Subsemiring.sum_mem _ (fun k _ => Subsemiring.mul_mem _ (ha i k) (hb k j))
-  one_mem' i j := by
-    rw[Matrix.one_apply]
-    by_cases h : i = j
-    · rw[if_pos h]; apply Subsemiring.one_mem
-    rw[if_neg h]; apply Subsemiring.zero_mem
-
-end Subsemiring
-
-namespace Subring
-
-variable {R : Type*} [Ring R]
-variable [Fintype n] [DecidableEq n]
-
-/-- A version of `Set.matrix` for `Subring`s.
-Given a `Subring` `S`, `S.matrix` is the `Subring` of square matrices `m`
-all of whose entries `m i j` belong to `S`. -/
-def matrix (S : Subring R) :
-    Subring (Matrix n n R) where
-  __ := S.toSubsemiring.matrix
-  neg_mem' hm i j := Subring.neg_mem _ (hm i j)
-
-end Subring
 
 open Matrix
 

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -5,6 +5,7 @@ Authors: Ellen Arlt, Blair Shi, Sean Leather, Mario Carneiro, Johan Commelin, Lu
 -/
 import Mathlib.Algebra.Algebra.Opposite
 import Mathlib.Algebra.Algebra.Pi
+import Mathlib.Algebra.Algebra.Subalgebra.Basic
 import Mathlib.Algebra.BigOperators.RingEquiv
 import Mathlib.Data.Finite.Prod
 import Mathlib.Data.Matrix.Mul
@@ -682,6 +683,34 @@ def matrix (S : Subring R) : Subring (Matrix n n R) where
   neg_mem' hm i j := Subring.neg_mem _ (hm i j)
 
 end Subring
+
+namespace Submodule
+
+variable {R M : Type*} [Semiring R] [AddCommMonoid M] [Module R M]
+
+/-- A version of `Set.matrix` for `Submodule`s.
+Given a `Submodule` `S`, `S.matrix` is the `Submodule` of matrices `m`
+all of whose entries `m i j` belong to `S`. -/
+def matrix (S : Submodule R M) : Submodule R (Matrix m n M) where
+  __ := S.toAddSubmonoid.matrix
+  smul_mem' _ _ hm i j := Submodule.smul_mem _ _ (hm i j)
+
+end Submodule
+
+namespace Subalgebra
+
+variable {R A : Type*} [CommSemiring R] [Semiring A] [Algebra R A]
+variable [Fintype n] [DecidableEq n]
+
+/-- A version of `Set.matrix` for `Subalgebra`s.
+Given a `Subalgebra` `S`, `S.matrix` is the `Subalgebra` of square matrices `m`
+all of whose entries `m i j` belong to `S`. -/
+def matrix (S : Subalgebra R A) : Subalgebra R (Matrix n n A) where
+  __ := S.toSubsemiring.matrix
+  algebraMap_mem' _ :=
+    (diagonal_mem_matrix (Subalgebra.zero_mem _)).mpr (fun _ => Subalgebra.algebraMap_mem _ _)
+
+end Subalgebra
 
 open Matrix
 

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -5,7 +5,6 @@ Authors: Ellen Arlt, Blair Shi, Sean Leather, Mario Carneiro, Johan Commelin, Lu
 -/
 import Mathlib.Algebra.Algebra.Opposite
 import Mathlib.Algebra.Algebra.Pi
-import Mathlib.Algebra.Algebra.Subalgebra.Basic
 import Mathlib.Algebra.BigOperators.RingEquiv
 import Mathlib.Data.Finite.Prod
 import Mathlib.Data.Matrix.Mul
@@ -696,21 +695,6 @@ def matrix (S : Submodule R M) : Submodule R (Matrix m n M) where
   smul_mem' _ _ hm i j := Submodule.smul_mem _ _ (hm i j)
 
 end Submodule
-
-namespace Subalgebra
-
-variable {R A : Type*} [CommSemiring R] [Semiring A] [Algebra R A]
-variable [Fintype n] [DecidableEq n]
-
-/-- A version of `Set.matrix` for `Subalgebra`s.
-Given a `Subalgebra` `S`, `S.matrix` is the `Subalgebra` of square matrices `m`
-all of whose entries `m i j` belong to `S`. -/
-def matrix (S : Subalgebra R A) : Subalgebra R (Matrix n n A) where
-  __ := S.toSubsemiring.matrix
-  algebraMap_mem' _ :=
-    (diagonal_mem_matrix (Subalgebra.zero_mem _)).mpr (fun _ => Subalgebra.algebraMap_mem _ _)
-
-end Subalgebra
 
 open Matrix
 

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -626,76 +626,54 @@ end AlgEquiv
 namespace AddSubmonoid
 
 variable {A : Type*} [AddMonoid A]
+variable {ι₁ ι₂ : Type*}
 
 /-- A version of `Set.matrix` for `AddSubmonoid`s.
 Given an `AddSubmonoid` `S`, `S.matrix` is the `AddSubmonoid` of matrices `m`
 all of whose entries `m i j` belong to `S`. -/
-@[simps]
-def matrix (S : AddSubmonoid A) : AddSubmonoid (Matrix m n A) where
-  carrier := Set.matrix S
-  add_mem' hm hn i j := add_mem (hm i j) (hn i j)
-  zero_mem' _ _ := zero_mem _
+def matrix (S : AddSubmonoid A) :
+    AddSubmonoid (Matrix ι₁ ι₂ A) where
+      carrier := Set.matrix S
+      add_mem' hm hn i j := add_mem (hm i j) (hn i j)
+      zero_mem' _ _ := zero_mem _
 
 end AddSubmonoid
 
 namespace AddSubgroup
 
 variable {A : Type*} [AddGroup A]
+variable {ι₁ ι₂ : Type*}
 
 /-- A version of `Set.matrix` for `AddSubgroup`s.
 Given an `AddSubgroup` `S`, `S.matrix` is the `AddSubgroup` of matrices `m`
 all of whose entries `m i j` belong to `S`. -/
-@[simps!]
-def matrix (S : AddSubgroup A) : AddSubgroup (Matrix m n A) where
-  __ := S.toAddSubmonoid.matrix
-  neg_mem' hm i j := AddSubgroup.neg_mem _ (hm i j)
+def matrix (S : AddSubgroup A) :
+    AddSubgroup (Matrix ι₁ ι₂ A) where
+      __ := S.toAddSubmonoid.matrix
+      neg_mem' hm i j := AddSubgroup.neg_mem _ (hm i j)
 
 end AddSubgroup
 
-namespace Subsemiring
-
-variable {R : Type*} [NonAssocSemiring R]
-variable [Fintype n] [DecidableEq n]
-
-/-- A version of `Set.matrix` for `Subsemiring`s.
-Given a `Subsemiring` `S`, `S.matrix` is the `Subsemiring` of square matrices `m`
-all of whose entries `m i j` belong to `S`. -/
-@[simps!]
-def matrix (S : Subsemiring R) : Subsemiring (Matrix n n R) where
-  __ := S.toAddSubmonoid.matrix
-  mul_mem' ha hb i j := Subsemiring.sum_mem _ (fun k _ => Subsemiring.mul_mem _ (ha i k) (hb k j))
-  one_mem' := (diagonal_mem_matrix_iff (Subsemiring.zero_mem _)).mpr fun _ => Subsemiring.one_mem _
-
-end Subsemiring
-
 namespace Subring
 
-variable {R : Type*} [Ring R]
-variable [Fintype n] [DecidableEq n]
+variable {A : Type*} [Ring A]
+variable {ι : Type*} [Fintype ι] [DecidableEq ι]
 
 /-- A version of `Set.matrix` for `Subring`s.
-Given a `Subring` `S`, `S.matrix` is the `Subring` of square matrices `m`
+Given an `Subring` `S`, `S.matrix` is the `Subring` of square matrices `m`
 all of whose entries `m i j` belong to `S`. -/
-@[simps!]
-def matrix (S : Subring R) : Subring (Matrix n n R) where
-  __ := S.toSubsemiring.matrix
-  neg_mem' hm i j := Subring.neg_mem _ (hm i j)
+def matrix (S : Subring A) :
+    Subring (Matrix ι ι A) where
+      __ := S.toAddSubgroup.matrix
+      mul_mem' ha hb i j := Subring.sum_mem _ (fun k _ => Subring.mul_mem _ (ha i k) (hb k j))
+      one_mem' i j := by
+        rw[Matrix.one_apply]
+        if h : i = j then
+          rw[if_pos h]; apply Subring.one_mem
+        else
+          rw[if_neg h]; apply Subring.zero_mem
 
 end Subring
-
-namespace Submodule
-
-variable {R M : Type*} [Semiring R] [AddCommMonoid M] [Module R M]
-
-/-- A version of `Set.matrix` for `Submodule`s.
-Given a `Submodule` `S`, `S.matrix` is the `Submodule` of matrices `m`
-all of whose entries `m i j` belong to `S`. -/
-@[simps!]
-def matrix (S : Submodule R M) : Submodule R (Matrix m n M) where
-  __ := S.toAddSubmonoid.matrix
-  smul_mem' _ _ hm i j := Submodule.smul_mem _ _ (hm i j)
-
-end Submodule
 
 open Matrix
 

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -630,6 +630,7 @@ variable {A : Type*} [AddMonoid A]
 /-- A version of `Set.matrix` for `AddSubmonoid`s.
 Given an `AddSubmonoid` `S`, `S.matrix` is the `AddSubmonoid` of matrices `m`
 all of whose entries `m i j` belong to `S`. -/
+@[simps]
 def matrix (S : AddSubmonoid A) : AddSubmonoid (Matrix m n A) where
   carrier := Set.matrix S
   add_mem' hm hn i j := add_mem (hm i j) (hn i j)
@@ -644,6 +645,7 @@ variable {A : Type*} [AddGroup A]
 /-- A version of `Set.matrix` for `AddSubgroup`s.
 Given an `AddSubgroup` `S`, `S.matrix` is the `AddSubgroup` of matrices `m`
 all of whose entries `m i j` belong to `S`. -/
+@[simps!]
 def matrix (S : AddSubgroup A) : AddSubgroup (Matrix m n A) where
   __ := S.toAddSubmonoid.matrix
   neg_mem' hm i j := AddSubgroup.neg_mem _ (hm i j)
@@ -652,16 +654,17 @@ end AddSubgroup
 
 namespace Subsemiring
 
-variable {R : Type*} [Semiring R]
+variable {R : Type*} [NonAssocSemiring R]
 variable [Fintype n] [DecidableEq n]
 
 /-- A version of `Set.matrix` for `Subsemiring`s.
 Given a `Subsemiring` `S`, `S.matrix` is the `Subsemiring` of square matrices `m`
 all of whose entries `m i j` belong to `S`. -/
+@[simps!]
 def matrix (S : Subsemiring R) : Subsemiring (Matrix n n R) where
   __ := S.toAddSubmonoid.matrix
   mul_mem' ha hb i j := Subsemiring.sum_mem _ (fun k _ => Subsemiring.mul_mem _ (ha i k) (hb k j))
-  one_mem' := (diagonal_mem_matrix (Subsemiring.zero_mem _)).mpr (fun _ => Subsemiring.one_mem _)
+  one_mem' := (diagonal_mem_matrix_iff (Subsemiring.zero_mem _)).mpr fun _ => Subsemiring.one_mem _
 
 end Subsemiring
 
@@ -673,6 +676,7 @@ variable [Fintype n] [DecidableEq n]
 /-- A version of `Set.matrix` for `Subring`s.
 Given a `Subring` `S`, `S.matrix` is the `Subring` of square matrices `m`
 all of whose entries `m i j` belong to `S`. -/
+@[simps!]
 def matrix (S : Subring R) : Subring (Matrix n n R) where
   __ := S.toSubsemiring.matrix
   neg_mem' hm i j := Subring.neg_mem _ (hm i j)

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -644,8 +644,7 @@ variable {A : Type*} [AddGroup A]
 /-- A version of `Set.matrix` for `AddSubgroup`s.
 Given an `AddSubgroup` `S`, `S.matrix` is the `AddSubgroup` of matrices `m`
 all of whose entries `m i j` belong to `S`. -/
-def matrix (S : AddSubgroup A) :
-    AddSubgroup (Matrix m n A) where
+def matrix (S : AddSubgroup A) : AddSubgroup (Matrix m n A) where
   __ := S.toAddSubmonoid.matrix
   neg_mem' hm i j := AddSubgroup.neg_mem _ (hm i j)
 
@@ -659,8 +658,7 @@ variable [Fintype n] [DecidableEq n]
 /-- A version of `Set.matrix` for `Subsemiring`s.
 Given a `Subsemiring` `S`, `S.matrix` is the `Subsemiring` of square matrices `m`
 all of whose entries `m i j` belong to `S`. -/
-def matrix (S : Subsemiring R) :
-    Subsemiring (Matrix n n R) where
+def matrix (S : Subsemiring R) : Subsemiring (Matrix n n R) where
   __ := S.toAddSubmonoid.matrix
   mul_mem' ha hb i j := Subsemiring.sum_mem _ (fun k _ => Subsemiring.mul_mem _ (ha i k) (hb k j))
   one_mem' := (diagonal_mem_matrix (Subsemiring.zero_mem _)).mpr (fun _ => Subsemiring.one_mem _)
@@ -675,8 +673,7 @@ variable [Fintype n] [DecidableEq n]
 /-- A version of `Set.matrix` for `Subring`s.
 Given a `Subring` `S`, `S.matrix` is the `Subring` of square matrices `m`
 all of whose entries `m i j` belong to `S`. -/
-def matrix (S : Subring R) :
-    Subring (Matrix n n R) where
+def matrix (S : Subring R) : Subring (Matrix n n R) where
   __ := S.toSubsemiring.matrix
   neg_mem' hm i j := Subring.neg_mem _ (hm i j)
 

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -690,6 +690,7 @@ variable {R M : Type*} [Semiring R] [AddCommMonoid M] [Module R M]
 /-- A version of `Set.matrix` for `Submodule`s.
 Given a `Submodule` `S`, `S.matrix` is the `Submodule` of matrices `m`
 all of whose entries `m i j` belong to `S`. -/
+@[simps!]
 def matrix (S : Submodule R M) : Submodule R (Matrix m n M) where
   __ := S.toAddSubmonoid.matrix
   smul_mem' _ _ hm i j := Submodule.smul_mem _ _ (hm i j)

--- a/Mathlib/Data/Matrix/Defs.lean
+++ b/Mathlib/Data/Matrix/Defs.lean
@@ -588,6 +588,6 @@ theorem transpose_mem_matrix_iff {M : Matrix m n α} :
   simp only [Set.mem_matrix, transpose_apply]; exact forall_comm
 
 theorem submatrix_mem_matrix {M : Matrix m n α} (hM : M ∈ S.matrix) {r : l → m} {c : o → n} :
-    (M.submatrix r c) ∈ S.matrix := by simp_all [Set.mem_matrix]
+    M.submatrix r c ∈ S.matrix := by simp_all [Set.mem_matrix]
 
 end Matrix

--- a/Mathlib/Data/Matrix/Defs.lean
+++ b/Mathlib/Data/Matrix/Defs.lean
@@ -576,6 +576,11 @@ def matrix (S : Set α) : Set (Matrix m n α) := {M | ∀ i j, M i j ∈ S}
 theorem mem_matrix {S : Set α} {M : Matrix m n α} :
     M ∈ S.matrix ↔ ∀ i j, M i j ∈ S := .rfl
 
+theorem matrix_eq_pi {S : Set α} :
+    S.matrix = of.symm ⁻¹' Set.univ.pi fun (_ : m) ↦ Set.univ.pi fun (_ : n) ↦ S := by
+  ext
+  simp [Set.mem_matrix]
+
 end Set
 
 namespace Matrix

--- a/Mathlib/Data/Matrix/Defs.lean
+++ b/Mathlib/Data/Matrix/Defs.lean
@@ -569,13 +569,22 @@ end Matrix
 
 namespace Set
 
-variable {ι₁ ι₂ : Type*} {X : Type*}
+/-- Given a set `S`, `S.matrix` is the set of matrices `M`
+all of whose entries `M i j` belong to `S`. -/
+def matrix (S : Set α) : Set (Matrix m n α) := {M | ∀ i j, M i j ∈ S}
 
-/-- Given a set `S`, `S.matrix` is the set of matrices `m`
-all of whose entries `m i j` belong to `S`. -/
-def matrix (S : Set X) : Set (Matrix ι₁ ι₂ X) := {m | ∀ i j, m i j ∈ S}
-
-@[simp] theorem mem_matrix (S : Set X) {m : Matrix ι₁ ι₂ X} :
-  m ∈ S.matrix ↔ ∀ i j, m i j ∈ S := .rfl
+@[simp] theorem mem_matrix (S : Set α) {M : Matrix m n α} :
+    M ∈ S.matrix ↔ ∀ i j, M i j ∈ S := .rfl
 
 end Set
+
+namespace Matrix
+
+variable {S : Set α}
+
+theorem transpose_mem_matrix {M : Matrix m n α} (hM : M ∈ S.matrix) : Mᵀ ∈ S.matrix := by simp_all
+
+theorem submatrix_mem_matrix {M : Matrix m n α} (hM : M ∈ S.matrix) {r : l → m} {c : o → n} :
+    (M.submatrix r c) ∈ S.matrix := by simp_all
+
+end Matrix

--- a/Mathlib/Data/Matrix/Defs.lean
+++ b/Mathlib/Data/Matrix/Defs.lean
@@ -573,7 +573,7 @@ namespace Set
 all of whose entries `M i j` belong to `S`. -/
 def matrix (S : Set α) : Set (Matrix m n α) := {M | ∀ i j, M i j ∈ S}
 
-@[simp] theorem mem_matrix (S : Set α) {M : Matrix m n α} :
+@[simp] theorem mem_matrix {S : Set α} {M : Matrix m n α} :
     M ∈ S.matrix ↔ ∀ i j, M i j ∈ S := .rfl
 
 end Set

--- a/Mathlib/Data/Matrix/Defs.lean
+++ b/Mathlib/Data/Matrix/Defs.lean
@@ -589,13 +589,9 @@ theorem transpose_mem_matrix_iff {M : Matrix m n α} :
 theorem submatrix_mem_matrix {M : Matrix m n α} {r : l → m} {c : o → n} (hM : M ∈ S.matrix) :
     M.submatrix r c ∈ S.matrix := by simp_all [Set.mem_matrix]
 
-theorem submatrix_mem_matrix_iff_mem_matrix {M : Matrix m n α} {r : l → m} {c : o → n}
+theorem submatrix_mem_matrix_iff {M : Matrix m n α} {r : l → m} {c : o → n}
     (hr : Function.Surjective r) (hc : Function.Surjective c) :
     M.submatrix r c ∈ S.matrix ↔ M ∈ S.matrix :=
-  ⟨ fun h i j =>
-      let ⟨ a , ha ⟩ := hr i
-      let ⟨ b , hb ⟩ := hc j
-      ha ▸ hb ▸ h a b,
-    fun hM => submatrix_mem_matrix hM ⟩
+  ⟨(hr.forall.mpr fun _ => hc.forall.mpr fun _ => · _ _), submatrix_mem_matrix⟩
 
 end Matrix

--- a/Mathlib/Data/Matrix/Defs.lean
+++ b/Mathlib/Data/Matrix/Defs.lean
@@ -586,11 +586,16 @@ variable {S : Set α}
 theorem transpose_mem_matrix_iff {M : Matrix m n α} :
     Mᵀ ∈ S.matrix ↔ M ∈ S.matrix := forall_comm
 
-theorem submatrix_mem_matrix {M : Matrix m n α} (hM : M ∈ S.matrix) {r : l → m} {c : o → n} :
+theorem submatrix_mem_matrix {M : Matrix m n α} {r : l → m} {c : o → n} (hM : M ∈ S.matrix) :
     M.submatrix r c ∈ S.matrix := by simp_all [Set.mem_matrix]
 
-theorem mem_matrix_of_submatrix_mem_matrix [Nonempty l] [Nonempty o] {M : Matrix m n α} :
-    (∀ (r : l → m) (c : o → n), M.submatrix r c ∈ S.matrix) → M ∈ S.matrix :=
-  fun h _ _ => h (fun _ => _) (fun _ => _) Classical.ofNonempty Classical.ofNonempty
+theorem submatrix_mem_matrix_iff_mem_matrix {M : Matrix m n α} {r : l → m} {c : o → n}
+    (hr : Function.Surjective r) (hc : Function.Surjective c) :
+    M.submatrix r c ∈ S.matrix ↔ M ∈ S.matrix :=
+  ⟨ fun h i j =>
+      let ⟨ a , ha ⟩ := hr i
+      let ⟨ b , hb ⟩ := hc j
+      ha ▸ hb ▸ h a b,
+    fun hM => submatrix_mem_matrix hM ⟩
 
 end Matrix

--- a/Mathlib/Data/Matrix/Defs.lean
+++ b/Mathlib/Data/Matrix/Defs.lean
@@ -573,7 +573,7 @@ namespace Set
 all of whose entries `M i j` belong to `S`. -/
 def matrix (S : Set α) : Set (Matrix m n α) := {M | ∀ i j, M i j ∈ S}
 
-@[simp] theorem mem_matrix {S : Set α} {M : Matrix m n α} :
+theorem mem_matrix {S : Set α} {M : Matrix m n α} :
     M ∈ S.matrix ↔ ∀ i j, M i j ∈ S := .rfl
 
 end Set
@@ -588,6 +588,6 @@ theorem transpose_mem_matrix_iff {M : Matrix m n α} :
   simp only [Set.mem_matrix, transpose_apply]; exact forall_comm
 
 theorem submatrix_mem_matrix {M : Matrix m n α} (hM : M ∈ S.matrix) {r : l → m} {c : o → n} :
-    (M.submatrix r c) ∈ S.matrix := by simp_all
+    (M.submatrix r c) ∈ S.matrix := by simp_all [Set.mem_matrix]
 
 end Matrix

--- a/Mathlib/Data/Matrix/Defs.lean
+++ b/Mathlib/Data/Matrix/Defs.lean
@@ -582,6 +582,7 @@ namespace Matrix
 
 variable {S : Set α}
 
+@[simp]
 theorem transpose_mem_matrix_iff {M : Matrix m n α} :
     Mᵀ ∈ S.matrix ↔ M ∈ S.matrix := by
   simp only [Set.mem_matrix, transpose_apply]; exact forall_comm

--- a/Mathlib/Data/Matrix/Defs.lean
+++ b/Mathlib/Data/Matrix/Defs.lean
@@ -584,10 +584,13 @@ variable {S : Set α}
 
 @[simp]
 theorem transpose_mem_matrix_iff {M : Matrix m n α} :
-    Mᵀ ∈ S.matrix ↔ M ∈ S.matrix := by
-  simp only [Set.mem_matrix, transpose_apply]; exact forall_comm
+    Mᵀ ∈ S.matrix ↔ M ∈ S.matrix := forall_comm
 
 theorem submatrix_mem_matrix {M : Matrix m n α} (hM : M ∈ S.matrix) {r : l → m} {c : o → n} :
     M.submatrix r c ∈ S.matrix := by simp_all [Set.mem_matrix]
+
+theorem mem_matrix_of_submatrix_mem_matrix [Nonempty l] [Nonempty o] {M : Matrix m n α} :
+    (∀ (r : l → m) (c : o → n), M.submatrix r c ∈ S.matrix) → M ∈ S.matrix :=
+  fun h _ _ => h (fun _ => _) (fun _ => _) Classical.ofNonempty Classical.ofNonempty
 
 end Matrix

--- a/Mathlib/Data/Matrix/Defs.lean
+++ b/Mathlib/Data/Matrix/Defs.lean
@@ -582,7 +582,9 @@ namespace Matrix
 
 variable {S : Set α}
 
-theorem transpose_mem_matrix {M : Matrix m n α} (hM : M ∈ S.matrix) : Mᵀ ∈ S.matrix := by simp_all
+theorem transpose_mem_matrix_iff {M : Matrix m n α} :
+    Mᵀ ∈ S.matrix ↔ M ∈ S.matrix := by
+  simp only [Set.mem_matrix, transpose_apply]; exact forall_comm
 
 theorem submatrix_mem_matrix {M : Matrix m n α} (hM : M ∈ S.matrix) {r : l → m} {c : o → n} :
     (M.submatrix r c) ∈ S.matrix := by simp_all

--- a/Mathlib/Data/Matrix/Defs.lean
+++ b/Mathlib/Data/Matrix/Defs.lean
@@ -569,29 +569,13 @@ end Matrix
 
 namespace Set
 
-/-- Given a set `S`, `S.matrix` is the set of matrices `M`
-all of whose entries `M i j` belong to `S`. -/
-def matrix (S : Set α) : Set (Matrix m n α) := {M | ∀ i j, M i j ∈ S}
+variable {ι₁ ι₂ : Type*} {X : Type*}
 
-theorem mem_matrix {S : Set α} {M : Matrix m n α} :
-    M ∈ S.matrix ↔ ∀ i j, M i j ∈ S := .rfl
+/-- Given a set `S`, `S.matrix` is the set of matrices `m`
+all of whose entries `m i j` belong to `S`. -/
+def matrix (S : Set X) : Set (Matrix ι₁ ι₂ X) := {m | ∀ i j, m i j ∈ S}
+
+@[simp] theorem mem_matrix (S : Set X) {m : Matrix ι₁ ι₂ X} :
+  m ∈ S.matrix ↔ ∀ i j, m i j ∈ S := .rfl
 
 end Set
-
-namespace Matrix
-
-variable {S : Set α}
-
-@[simp]
-theorem transpose_mem_matrix_iff {M : Matrix m n α} :
-    Mᵀ ∈ S.matrix ↔ M ∈ S.matrix := forall_comm
-
-theorem submatrix_mem_matrix {M : Matrix m n α} {r : l → m} {c : o → n} (hM : M ∈ S.matrix) :
-    M.submatrix r c ∈ S.matrix := by simp_all [Set.mem_matrix]
-
-theorem submatrix_mem_matrix_iff {M : Matrix m n α} {r : l → m} {c : o → n}
-    (hr : Function.Surjective r) (hc : Function.Surjective c) :
-    M.submatrix r c ∈ S.matrix ↔ M ∈ S.matrix :=
-  ⟨(hr.forall.mpr fun _ => hc.forall.mpr fun _ => · _ _), submatrix_mem_matrix⟩
-
-end Matrix

--- a/Mathlib/Topology/Instances/Matrix.lean
+++ b/Mathlib/Topology/Instances/Matrix.lean
@@ -43,7 +43,7 @@ instance [TopologicalSpace R] : TopologicalSpace (Matrix m n R) :=
 instance [TopologicalSpace R] [T2Space R] : T2Space (Matrix m n R) :=
   Pi.t2Space
 
-theorem Set.matrix_isOpen [Fintype m] [Fintype n]
+theorem IsOpen.matrix [Fintype m] [Fintype n]
     [TopologicalSpace R] {S : Set R} (hS : IsOpen S) :
     IsOpen (S.matrix : Set (Matrix m n R)) := by
   rw [isOpen_pi_iff']

--- a/Mathlib/Topology/Instances/Matrix.lean
+++ b/Mathlib/Topology/Instances/Matrix.lean
@@ -22,9 +22,9 @@ This file is a place to collect topological results about matrices.
 
 * Sets of matrices:
   * `IsOpen.matrix`: the set of finite matrices with entries in an open set
-  is itself an open set.
+    is itself an open set.
   * `IsCompact.matrix`: the set of matrices with entries in a compact set
-  is itself a compact set.
+    is itself a compact set.
 * Continuity:
   * `Continuous.matrix_det`: the determinant is continuous over a topological ring.
   * `Continuous.matrix_adjugate`: the adjugate is continuous over a topological ring.

--- a/Mathlib/Topology/Instances/Matrix.lean
+++ b/Mathlib/Topology/Instances/Matrix.lean
@@ -20,8 +20,11 @@ This file is a place to collect topological results about matrices.
 
 ## Main results
 
-* `Set.matrix_isOpen`: the set of finite matrices with entries in an open set
+* Sets of matrices:
+  * `IsOpen.matrix`: the set of finite matrices with entries in an open set
   is itself an open set.
+  * `IsCompact.matrix`: the set of matrices with entries in a compact set
+  is itself a compact set.
 * Continuity:
   * `Continuous.matrix_det`: the determinant is continuous over a topological ring.
   * `Continuous.matrix_adjugate`: the adjugate is continuous over a topological ring.
@@ -43,6 +46,8 @@ instance [TopologicalSpace R] : TopologicalSpace (Matrix m n R) :=
 instance [TopologicalSpace R] [T2Space R] : T2Space (Matrix m n R) :=
   Pi.t2Space
 
+section Set
+
 theorem IsOpen.matrix [Fintype m] [Fintype n]
     [TopologicalSpace R] {S : Set R} (hS : IsOpen S) :
     IsOpen (S.matrix : Set (Matrix m n R)) := by
@@ -54,6 +59,12 @@ theorem IsOpen.matrix [Fintype m] [Fintype n]
   intro g hg
   use fun j ↦ S
   exact ⟨fun j ↦ ⟨hS, hg j⟩, fun g hg ↦ by simp_all⟩
+
+theorem IsCompact.matrix [TopologicalSpace R] {S : Set R} (hS : IsCompact S) :
+    IsCompact (S.matrix : Set (Matrix m n R)) :=
+  isCompact_pi_infinite (fun _ => (isCompact_pi_infinite (fun _ => hS)))
+
+end Set
 
 /-! ### Lemmas about continuity of operations -/
 

--- a/Mathlib/Topology/Instances/Matrix.lean
+++ b/Mathlib/Topology/Instances/Matrix.lean
@@ -62,7 +62,7 @@ theorem IsOpen.matrix [Fintype m] [Fintype n]
 
 theorem IsCompact.matrix [TopologicalSpace R] {S : Set R} (hS : IsCompact S) :
     IsCompact (S.matrix : Set (Matrix m n R)) :=
-  isCompact_pi_infinite (fun _ => (isCompact_pi_infinite (fun _ => hS)))
+  isCompact_pi_infinite fun _ => isCompact_pi_infinite fun _ => hS
 
 end Set
 

--- a/Mathlib/Topology/Instances/Matrix.lean
+++ b/Mathlib/Topology/Instances/Matrix.lean
@@ -20,6 +20,8 @@ This file is a place to collect topological results about matrices.
 
 ## Main results
 
+* `Set.matrix_isOpen`: the set of finite matrices with entries in an open set
+  is itself an open set.
 * Continuity:
   * `Continuous.matrix_det`: the determinant is continuous over a topological ring.
   * `Continuous.matrix_adjugate`: the adjugate is continuous over a topological ring.
@@ -40,6 +42,18 @@ instance [TopologicalSpace R] : TopologicalSpace (Matrix m n R) :=
 
 instance [TopologicalSpace R] [T2Space R] : T2Space (Matrix m n R) :=
   Pi.t2Space
+
+theorem Set.matrix_isOpen [Fintype m] [Fintype n]
+    [TopologicalSpace R] {S : Set R} (hS : IsOpen S) :
+    IsOpen (S.matrix : Set (Matrix m n R)) := by
+  rw [isOpen_pi_iff']
+  intro f hf
+  use fun i ↦ {g | ∀ j, g j ∈ S}
+  refine ⟨fun i ↦ ⟨?_, hf i⟩, fun f hf ↦ by simpa using hf⟩
+  rw [isOpen_pi_iff']
+  intro g hg
+  use fun j ↦ S
+  exact ⟨fun j ↦ ⟨hS, hg j⟩, fun g hg ↦ by simp_all⟩
 
 /-! ### Lemmas about continuity of operations -/
 

--- a/Mathlib/Topology/Instances/Matrix.lean
+++ b/Mathlib/Topology/Instances/Matrix.lean
@@ -50,15 +50,10 @@ section Set
 
 theorem IsOpen.matrix [Fintype m] [Fintype n]
     [TopologicalSpace R] {S : Set R} (hS : IsOpen S) :
-    IsOpen (S.matrix : Set (Matrix m n R)) := by
-  rw [isOpen_pi_iff']
-  intro f hf
-  use fun i ↦ {g | ∀ j, g j ∈ S}
-  refine ⟨fun i ↦ ⟨?_, hf i⟩, fun f hf ↦ by simpa using hf⟩
-  rw [isOpen_pi_iff']
-  intro g hg
-  use fun j ↦ S
-  exact ⟨fun j ↦ ⟨hS, hg j⟩, fun g hg ↦ by simp_all⟩
+    IsOpen (S.matrix : Set (Matrix m n R)) :=
+  Set.matrix_eq_pi ▸
+    (isOpen_set_pi Set.finite_univ fun _ _ =>
+    isOpen_set_pi Set.finite_univ fun _ _ => hS).preimage continuous_id
 
 theorem IsCompact.matrix [TopologicalSpace R] {S : Set R} (hS : IsCompact S) :
     IsCompact (S.matrix : Set (Matrix m n R)) :=


### PR DESCRIPTION
Prove topological results (`IsOpen`, `IsCompact`) about `Set.matrix`. 

- [x] depends on: #27190 

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Set.2Ematrix/near/527826651)

Co-authored-by: Kevin Buzzard <k.buzzard@imperial.ac.uk>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
