### PR TITLE
[Merged by Bors] - feat(RingTheory/PowerSeries/Binomial): add basic lemmas, golf

### DIFF
--- a/Mathlib/RingTheory/PowerSeries/Binomial.lean
+++ b/Mathlib/RingTheory/PowerSeries/Binomial.lean
@@ -61,35 +61,16 @@ lemma binomialSeries_add [Ring A] [Algebra R A] (r s : R) :
   rw [mul_comm, mul_smul]
 
 @[simp]
-lemma binomialSeries_nat [CommRing A] [Algebra R A] (d : ℕ) :
+lemma binomialSeries_nat [Ring A] [Algebra R A] (d : ℕ) :
     binomialSeries A (d : R) = (1 + X) ^ d := by
   ext n
-  by_cases h : d < n
-  · have hleft : (coeff A n) (binomialSeries A (d : R)) = 0 := by
-      simp [Ring.choose_natCast, Nat.choose_eq_zero_of_lt h]
-    have hright : (1 + X) ^ d = (((1 : Polynomial A) + (Polynomial.X)) ^ d).toPowerSeries := by
-      simp
-    rw [hleft, hright, Polynomial.coeff_coe]
-    refine (Polynomial.coeff_eq_zero_of_degree_lt ?_).symm
-    cases subsingleton_or_nontrivial A
-    · rw [Polynomial.degree_of_subsingleton]
-      exact WithBot.bot_lt_coe n
-    · rw [add_comm, ← Polynomial.C_1, Polynomial.degree_pow', Polynomial.degree_X_add_C,
-        Nat.smul_one_eq_cast, Nat.cast_lt]
-      · exact h
-      · rw [Polynomial.leadingCoeff_X_add_C, one_pow]
-        exact one_ne_zero
-  · rw [binomialSeries_coeff, add_comm, add_pow]
-    simp only [mul_one, one_pow, map_sum]
-    rw [sum_eq_single_of_mem n (by simp only [mem_range]; omega) ?_, coeff_X_pow_mul',
-      Ring.choose_eq_nat_choose]
-    · simp [Nat.cast_smul_eq_nsmul]
-    · intro k hk hkn
-      rw [mul_comm, ← map_natCast (C A), coeff_C_mul_X_pow]
-      exact if_neg (Ne.symm hkn)
+  have hright : (1 + X) ^ d = (((1 : Polynomial A) + (Polynomial.X)) ^ d).toPowerSeries := by
+    simp
+  rw [hright, Polynomial.coeff_coe, binomialSeries_coeff, Polynomial.coeff_one_add_X_pow]
+  simp [Ring.choose_eq_nat_choose, Nat.cast_smul_eq_nsmul]
 
 @[simp]
-lemma binomialSeries_zero [CommRing A] [Algebra R A] :
+lemma binomialSeries_zero [Ring A] [Algebra R A] :
     binomialSeries A (0 : R) = (1 : A⟦X⟧) := by
   simpa using binomialSeries_nat 0
 

--- a/Mathlib/RingTheory/PowerSeries/Binomial.lean
+++ b/Mathlib/RingTheory/PowerSeries/Binomial.lean
@@ -47,7 +47,12 @@ lemma binomialSeries_coeff [Semiring A] [SMul R A] (r : R) (n : ℕ) :
   coeff_mk n fun n ↦ Ring.choose r n • 1
 
 @[simp]
-lemma binomialSeries_add [Semiring A] [Algebra R A] (r s : R) :
+lemma binomialSeries_constantCoeff [Ring A] [Algebra R A] (r : R) :
+    (constantCoeff A) (binomialSeries A r) = 1 := by
+  simp [← coeff_zero_eq_constantCoeff_apply]
+
+@[simp]
+lemma binomialSeries_add [Ring A] [Algebra R A] (r s : R) :
     binomialSeries A (r + s) = binomialSeries A r * binomialSeries A s := by
   ext n
   simp only [binomialSeries_coeff, Ring.add_choose_eq n (Commute.all r s), coeff_mul,
@@ -56,25 +61,37 @@ lemma binomialSeries_add [Semiring A] [Algebra R A] (r s : R) :
   rw [mul_comm, mul_smul]
 
 @[simp]
-lemma binomialSeries_nat [CommRing A] (d : ℕ) :
-    binomialSeries A (d : ℤ) = (1 + X) ^ d := by
+lemma binomialSeries_nat [CommRing A] [Algebra R A] (d : ℕ) :
+    binomialSeries A (d : R) = (1 + X) ^ d := by
   ext n
   by_cases h : d < n
-  · rw [binomialSeries_coeff, add_comm, add_pow, map_sum, Ring.choose_natCast, natCast_zsmul,
-      Nat.choose_eq_zero_of_lt h, zero_nsmul, sum_eq_zero]
-    intro k hk
-    rw [one_pow, mul_one, coeff_X_pow_mul']
-    have hkd : k ≤ d := mem_range_succ_iff.mp hk
-    simp only [hkd.trans (le_of_lt h), ↓reduceIte]
-    rw [← map_natCast (C A), coeff_ne_zero_C (by omega)]
+  · have hleft : (coeff A n) (binomialSeries A (d : R)) = 0 := by
+      simp [Ring.choose_natCast, Nat.choose_eq_zero_of_lt h]
+    have hright : (1 + X) ^ d = (((1 : Polynomial A) + (Polynomial.X)) ^ d).toPowerSeries := by
+      simp
+    rw [hleft, hright, Polynomial.coeff_coe]
+    refine (Polynomial.coeff_eq_zero_of_degree_lt ?_).symm
+    cases subsingleton_or_nontrivial A
+    · rw [Polynomial.degree_of_subsingleton]
+      exact WithBot.bot_lt_coe n
+    · rw [add_comm, ← Polynomial.C_1, Polynomial.degree_pow', Polynomial.degree_X_add_C,
+        Nat.smul_one_eq_cast, Nat.cast_lt]
+      · exact h
+      · rw [Polynomial.leadingCoeff_X_add_C, one_pow]
+        exact one_ne_zero
   · rw [binomialSeries_coeff, add_comm, add_pow]
-    simp only [zsmul_eq_mul, mul_one, one_pow, map_sum]
+    simp only [mul_one, one_pow, map_sum]
     rw [sum_eq_single_of_mem n (by simp only [mem_range]; omega) ?_, coeff_X_pow_mul',
       Ring.choose_eq_nat_choose]
-    · simp
+    · simp [Nat.cast_smul_eq_nsmul]
     · intro k hk hkn
       rw [mul_comm, ← map_natCast (C A), coeff_C_mul_X_pow]
       exact if_neg (Ne.symm hkn)
+
+@[simp]
+lemma binomialSeries_zero [CommRing A] [Algebra R A] :
+    binomialSeries A (0 : R) = (1 : A⟦X⟧) := by
+  simpa using binomialSeries_nat 0
 
 lemma rescale_neg_one_invOneSubPow [CommRing A] (d : ℕ) :
     rescale (-1 : A) (invOneSubPow A d) = binomialSeries A (-d : ℤ) := by


### PR DESCRIPTION
This PR adds two simp lemmas for binomial power series, and generalizes the hypotheses of `binomialSeries_nat`.

---


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
