### PR TITLE
[Merged by Bors] - feat: mark `HasFiniteIntegral` with `fun_prop`

### DIFF
--- a/Mathlib/MeasureTheory/Function/L1Space/HasFiniteIntegral.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space/HasFiniteIntegral.lean
@@ -79,6 +79,7 @@ theorem lintegral_enorm_neg {f : α → β} : ∫⁻ a, ‖(-f) a‖ₑ ∂μ = 
 
 /-- `HasFiniteIntegral f μ` means that the integral `∫⁻ a, ‖f a‖ ∂μ` is finite.
   `HasFiniteIntegral f` means `HasFiniteIntegral f volume`. -/
+@[fun_prop]
 def HasFiniteIntegral {_ : MeasurableSpace α} (f : α → ε)
     (μ : Measure α := by volume_tac) : Prop :=
   ∫⁻ a, ‖f a‖ₑ ∂μ < ∞
@@ -170,10 +171,12 @@ lemma hasFiniteIntegral_const_iff_isFiniteMeasure {c : β} (hc : c ≠ 0) :
     HasFiniteIntegral (fun _ ↦ c) μ ↔ IsFiniteMeasure μ :=
   hasFiniteIntegral_const_iff_isFiniteMeasure_enorm (enorm_ne_zero.mpr hc) enorm_ne_top
 
+@[fun_prop]
 theorem hasFiniteIntegral_const_enorm [IsFiniteMeasure μ] {c : ε} (hc : ‖c‖ₑ ≠ ∞) :
     HasFiniteIntegral (fun _ : α ↦ c) μ :=
   (hasFiniteIntegral_const_iff_enorm hc).2 <| .inr ‹_›
 
+@[fun_prop]
 theorem hasFiniteIntegral_const [IsFiniteMeasure μ] (c : β) :
     HasFiniteIntegral (fun _ : α => c) μ :=
   hasFiniteIntegral_const_iff.2 <| .inr ‹_›
@@ -211,6 +214,7 @@ theorem HasFiniteIntegral.mono_measure {f : α → ε} (h : HasFiniteIntegral f 
     HasFiniteIntegral f μ :=
   lt_of_le_of_lt (lintegral_mono' hμ le_rfl) h
 
+@[fun_prop]
 theorem HasFiniteIntegral.add_measure {f : α → ε} (hμ : HasFiniteIntegral f μ)
     (hν : HasFiniteIntegral f ν) : HasFiniteIntegral f (μ + ν) := by
   simp only [HasFiniteIntegral, lintegral_add_measure] at *
@@ -234,17 +238,18 @@ theorem HasFiniteIntegral.smul_measure {f : α → ε} (h : HasFiniteIntegral f 
   simp only [HasFiniteIntegral, lintegral_smul_measure] at *
   exact mul_lt_top hc.lt_top h
 
-@[simp]
+@[fun_prop, simp]
 theorem hasFiniteIntegral_zero_measure {m : MeasurableSpace α} (f : α → ε) :
     HasFiniteIntegral f (0 : Measure α) := by
   simp only [HasFiniteIntegral, lintegral_zero_measure, zero_lt_top]
 
 variable (α μ) in
-@[simp]
+@[fun_prop, simp]
 theorem hasFiniteIntegral_zero {ε : Type*} [TopologicalSpace ε] [ENormedAddMonoid ε] :
     HasFiniteIntegral (fun _ : α => (0 : ε)) μ := by
   simp [hasFiniteIntegral_iff_enorm]
 
+@[fun_prop]
 theorem HasFiniteIntegral.neg {f : α → β} (hfi : HasFiniteIntegral f μ) :
     HasFiniteIntegral (-f) μ := by simpa [hasFiniteIntegral_iff_enorm] using hfi
 
@@ -252,9 +257,11 @@ theorem HasFiniteIntegral.neg {f : α → β} (hfi : HasFiniteIntegral f μ) :
 theorem hasFiniteIntegral_neg_iff {f : α → β} : HasFiniteIntegral (-f) μ ↔ HasFiniteIntegral f μ :=
   ⟨fun h => neg_neg f ▸ h.neg, HasFiniteIntegral.neg⟩
 
+@[fun_prop]
 theorem HasFiniteIntegral.enorm {f : α → ε} (hfi : HasFiniteIntegral f μ) :
     HasFiniteIntegral (‖f ·‖ₑ) μ := by simpa [hasFiniteIntegral_iff_enorm] using hfi
 
+@[fun_prop]
 theorem HasFiniteIntegral.norm {f : α → β} (hfi : HasFiniteIntegral f μ) :
     HasFiniteIntegral (fun a => ‖f a‖) μ := by simpa [hasFiniteIntegral_iff_enorm] using hfi
 
@@ -420,11 +427,12 @@ section PosPart
 
 /-! Lemmas used for defining the positive part of an `L¹` function -/
 
-
+@[fun_prop]
 theorem HasFiniteIntegral.max_zero {f : α → ℝ} (hf : HasFiniteIntegral f μ) :
     HasFiniteIntegral (fun a => max (f a) 0) μ :=
   hf.mono <| Eventually.of_forall fun x => by simp [abs_le, le_abs_self]
 
+@[fun_prop]
 theorem HasFiniteIntegral.min_zero {f : α → ℝ} (hf : HasFiniteIntegral f μ) :
     HasFiniteIntegral (fun a => min (f a) 0) μ :=
   hf.mono <| Eventually.of_forall fun x => by simpa [abs_le] using neg_abs_le _
@@ -435,6 +443,7 @@ section NormedSpace
 
 variable {𝕜 : Type*}
 
+@[fun_prop]
 theorem HasFiniteIntegral.smul [NormedAddCommGroup 𝕜] [SMulZeroClass 𝕜 β] [IsBoundedSMul 𝕜 β]
     (c : 𝕜) {f : α → β} :
     HasFiniteIntegral f μ → HasFiniteIntegral (c • f) μ := by
@@ -454,10 +463,12 @@ theorem hasFiniteIntegral_smul_iff [NormedRing 𝕜] [MulActionWithZero 𝕜 β]
     simpa only [smul_smul, Units.inv_mul, one_smul] using h.smul ((c⁻¹ : 𝕜ˣ) : 𝕜)
   exact HasFiniteIntegral.smul _
 
+@[fun_prop]
 theorem HasFiniteIntegral.const_mul [NormedRing 𝕜] {f : α → 𝕜} (h : HasFiniteIntegral f μ) (c : 𝕜) :
     HasFiniteIntegral (fun x => c * f x) μ :=
   h.smul c
 
+@[fun_prop]
 theorem HasFiniteIntegral.mul_const [NormedRing 𝕜] {f : α → 𝕜} (h : HasFiniteIntegral f μ) (c : 𝕜) :
     HasFiniteIntegral (fun x => f x * c) μ :=
   h.smul (MulOpposite.op c)
@@ -484,6 +495,7 @@ section restrict
 
 variable {E : Type*} [NormedAddCommGroup E] {f : α → ε}
 
+@[fun_prop]
 lemma HasFiniteIntegral.restrict (h : HasFiniteIntegral f μ) {s : Set α} :
     HasFiniteIntegral f (μ.restrict s) := by
   refine lt_of_le_of_lt ?_ h

--- a/Mathlib/MeasureTheory/Function/L1Space/Integrable.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space/Integrable.lean
@@ -248,9 +248,8 @@ theorem integrable_add_measure [PseudoMetrizableSpace ε] {f : α → ε} :
   ⟨fun h => ⟨h.left_of_add_measure, h.right_of_add_measure⟩, fun h => h.1.add_measure h.2⟩
 
 @[simp]
-theorem integrable_zero_measure {f : α → ε} :
-    Integrable f (0 : Measure α) :=
-  ⟨by fun_prop, by fun_prop⟩
+theorem integrable_zero_measure {f : α → ε} : Integrable f (0 : Measure α) := by
+  constructor <;> fun_prop
 
 /-- In a measurable space with measurable singletons, every function is integrable with respect to
 a Dirac measure.

--- a/Mathlib/MeasureTheory/Function/L1Space/Integrable.lean
+++ b/Mathlib/MeasureTheory/Function/L1Space/Integrable.lean
@@ -69,6 +69,7 @@ theorem Integrable.aemeasurable [MeasurableSpace ε] [BorelSpace ε] [PseudoMetr
     {f : α → ε} (hf : Integrable f μ) : AEMeasurable f μ :=
   hf.aestronglyMeasurable.aemeasurable
 
+@[fun_prop]
 theorem Integrable.hasFiniteIntegral {f : α → ε} (hf : Integrable f μ) : HasFiniteIntegral f μ :=
   hf.2
 
@@ -150,7 +151,7 @@ theorem integrable_const [IsFiniteMeasure μ] (c : β) : Integrable (fun _ : α 
   integrable_const_iff.2 <| .inr ‹_›
 
 -- TODO: an `ENorm`-version of this lemma requires `HasFiniteIntegral.of_finite`
-@[simp]
+@[fun_prop, simp]
 lemma Integrable.of_finite [Finite α] [MeasurableSingletonClass α] [IsFiniteMeasure μ] {f : α → β} :
     Integrable f μ := ⟨.of_discrete, .of_finite⟩
 
@@ -249,7 +250,7 @@ theorem integrable_add_measure [PseudoMetrizableSpace ε] {f : α → ε} :
 @[simp]
 theorem integrable_zero_measure {f : α → ε} :
     Integrable f (0 : Measure α) :=
-  ⟨aestronglyMeasurable_zero_measure f, hasFiniteIntegral_zero_measure f⟩
+  ⟨by fun_prop, by fun_prop⟩
 
 /-- In a measurable space with measurable singletons, every function is integrable with respect to
 a Dirac measure.
@@ -278,6 +279,7 @@ section
 
 variable {ε : Type*} [TopologicalSpace ε] [ENormedAddMonoid ε]
 
+@[fun_prop]
 theorem Integrable.smul_measure {f : α → ε} (h : Integrable f μ) {c : ℝ≥0∞} (hc : c ≠ ∞) :
     Integrable f (c • μ) := by
   rw [← memLp_one_iff_integrable] at h ⊢
@@ -417,7 +419,7 @@ end ENormedAddCommMonoid
 See `Integrable.neg'` for the same statement, but formulated with `x ↦ - f x` instead of `-f`. -/
 @[fun_prop]
 theorem Integrable.neg {f : α → β} (hf : Integrable f μ) : Integrable (-f) μ :=
-  ⟨hf.aestronglyMeasurable.neg, hf.hasFiniteIntegral.neg⟩
+  ⟨hf.aestronglyMeasurable.neg, by fun_prop⟩
 
 /-- If `f` is integrable, then so is `fun x ↦ - f x`.
 See `Integrable.neg` for the same statement, but formulated with `-f` instead of `fun x ↦ - f x`. -/
@@ -507,12 +509,12 @@ theorem Integrable.sub' {f g : α → β} (hf : Integrable f μ) (hg : Integrabl
     Integrable (fun a ↦ f a - g a) μ := by simpa only [sub_eq_add_neg] using hf.add hg.neg
 
 @[fun_prop]
-theorem Integrable.enorm {f : α → ε} (hf : Integrable f μ) : Integrable (‖f ·‖ₑ) μ :=
-  ⟨hf.aestronglyMeasurable.enorm.aestronglyMeasurable, hf.hasFiniteIntegral.enorm⟩
+theorem Integrable.enorm {f : α → ε} (hf : Integrable f μ) : Integrable (‖f ·‖ₑ) μ := by
+  constructor <;> fun_prop
 
 @[fun_prop]
-theorem Integrable.norm {f : α → β} (hf : Integrable f μ) : Integrable (fun a => ‖f a‖) μ :=
-  ⟨hf.aestronglyMeasurable.norm, hf.hasFiniteIntegral.norm⟩
+theorem Integrable.norm {f : α → β} (hf : Integrable f μ) : Integrable (fun a => ‖f a‖) μ := by
+  constructor <;> fun_prop
 
 @[fun_prop]
 theorem Integrable.inf {β}
@@ -937,9 +939,8 @@ section PosPart
 
 @[fun_prop]
 theorem Integrable.pos_part {f : α → ℝ} (hf : Integrable f μ) :
-    Integrable (fun a => max (f a) 0) μ :=
-  ⟨(hf.aestronglyMeasurable.aemeasurable.max aemeasurable_const).aestronglyMeasurable,
-    hf.hasFiniteIntegral.max_zero⟩
+    Integrable (fun a => max (f a) 0) μ := by
+  constructor <;> fun_prop
 
 @[fun_prop]
 theorem Integrable.neg_part {f : α → ℝ} (hf : Integrable f μ) :
@@ -954,8 +955,8 @@ variable {𝕜 : Type*}
 
 @[fun_prop]
 theorem Integrable.smul [NormedAddCommGroup 𝕜] [SMulZeroClass 𝕜 β] [IsBoundedSMul 𝕜 β] (c : 𝕜)
-    {f : α → β} (hf : Integrable f μ) : Integrable (c • f) μ :=
-  ⟨by fun_prop, hf.hasFiniteIntegral.smul c⟩
+    {f : α → β} (hf : Integrable f μ) : Integrable (c • f) μ := by
+  constructor <;> fun_prop
 
 @[fun_prop]
 theorem Integrable.fun_smul [NormedAddCommGroup 𝕜] [SMulZeroClass 𝕜 β] [IsBoundedSMul 𝕜 β] (c : 𝕜)


### PR DESCRIPTION
And use it to golf a few proofs.

---

HasFiniteIntegral.smul_enorm can also be golfed: I'll do that in a follow-up, depending on the order in which these two PRs are merged.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
