### PR TITLE
wip(commandStart): check the indentation of declaration keywords also

### DIFF
--- a/MathlibTest/CommandStart.lean
+++ b/MathlibTest/CommandStart.lean
@@ -327,9 +327,35 @@ Note: This linter can be disabled with `set_option linter.style.commandStart fal
  example : True := trivial
 
 -- TODO: the `lemma` in a declaration is not linted, only the doc-string
+/--
+warning: Keyword syntax '/-- Doc-string -/
+lemma qux : True :=
+  trivial' starts on column 7675, need to filter for false positives still
+
+Note: This linter can be disabled with `set_option linter.style.commandStart false`
+---
+info: go here
+real group? (group
+ "lemma"
+ (Command.declId `qux [])
+ (Command.declSig [] (Term.typeSpec ":" `True))
+ (Command.declValSimple ":=" `trivial (Termination.suffix [] []) []))
+-/
 #guard_msgs in
 /-- Doc-string -/
  lemma qux : True := trivial
+
+-- TODO: no false positive!
+/--
+info: go here
+real group? (group
+ "lemma"
+ (Command.declId `hoge [])
+ (Command.declSig [] (Term.typeSpec ":" `True))
+ (Command.declValSimple ":=" `trivial (Termination.suffix [] []) []))
+-/
+#guard_msgs in
+@[simp] lemma hoge : True := trivial
 
 /--
 warning: 'example : True :=

--- a/MathlibTest/CommandStart.lean
+++ b/MathlibTest/CommandStart.lean
@@ -318,6 +318,30 @@ Note: This linter can be disabled with `set_option linter.style.commandStart fal
  section
 
 /--
+warning: 'example : True :=
+  trivial' starts on column 1, but all commands should start at the beginning of the line.
+
+Note: This linter can be disabled with `set_option linter.style.commandStart false`
+-/
+#guard_msgs in
+ example : True := trivial
+
+-- TODO: the `lemma` in a declaration is not linted, only the doc-string
+#guard_msgs in
+/-- Doc-string -/
+ lemma qux : True := trivial
+
+/--
+warning: 'example : True :=
+  trivial' starts on column 1, but all commands should start at the beginning of the line.
+
+Note: This linter can be disabled with `set_option linter.style.commandStart false`
+-/
+#guard_msgs in
+-- normal comments are different syntax, hence the linter still applies after them
+ example : True := trivial
+
+/--
 warning: extra space in the source
 
 This part of the code


### PR DESCRIPTION
Check that e.g. a `lemma` keyword always starts on column 1 (unless preceded by an attribute).

---

TODO:
- make this work for other declarations also
- the position reported for the lemma column is not helpful (it might be the absolute column in the file, but that's missing line information)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
