### PR TITLE
[Merged by Bors] - feat: `OrderEmbedding` is a topological embedding

### DIFF
--- a/Mathlib/Topology/Order/Basic.lean
+++ b/Mathlib/Topology/Order/Basic.lean
@@ -243,6 +243,13 @@ theorem StrictMono.isEmbedding_of_ordConnected {α β : Type*} [LinearOrder α] 
 @[deprecated (since := "2024-10-26")]
 alias StrictMono.embedding_of_ordConnected := StrictMono.isEmbedding_of_ordConnected
 
+/-- An `OrderEmbedding` is a topological embedding provided that the range of `f` is
+order-connected -/
+lemma OrderEmbedding.IsEmbedding {α β : Type*} [LinearOrder α] [LinearOrder β]
+    [TopologicalSpace α] [OrderTopology α] [TopologicalSpace β] [OrderTopology β]
+    (f : α ↪o β) (hc : OrdConnected (range f)) : Topology.IsEmbedding f :=
+  f.strictMono.isEmbedding_of_ordConnected hc
+
 /-- On a `Set.OrdConnected` subset of a linear order, the order topology for the restriction of the
 order is the same as the restriction to the subset of the order topology. -/
 instance orderTopology_of_ordConnected {α : Type u} [TopologicalSpace α] [LinearOrder α]

--- a/Mathlib/Topology/Order/Basic.lean
+++ b/Mathlib/Topology/Order/Basic.lean
@@ -245,7 +245,7 @@ alias StrictMono.embedding_of_ordConnected := StrictMono.isEmbedding_of_ordConne
 
 /-- An `OrderEmbedding` is a topological embedding provided that the range of `f` is
 order-connected -/
-lemma OrderEmbedding.IsEmbedding {α β : Type*} [LinearOrder α] [LinearOrder β]
+lemma OrderEmbedding.isEmbedding_of_ordConnected {α β : Type*} [LinearOrder α] [LinearOrder β]
     [TopologicalSpace α] [OrderTopology α] [TopologicalSpace β] [OrderTopology β]
     (f : α ↪o β) (hc : OrdConnected (range f)) : Topology.IsEmbedding f :=
   f.strictMono.isEmbedding_of_ordConnected hc


### PR DESCRIPTION
`OrderEmbedding` is a topological embedding provided that the range of `f` is order-connected.

Co-authored-by: Rémy Degenne <remy.degenne@inria.fr>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
