### PR TITLE
[Merged by Bors] -  feat: lemmas on the volume on `I` applied to intervals 

### DIFF
--- a/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
+++ b/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
@@ -35,11 +35,11 @@ lemma measurableEmbedding_coe : MeasurableEmbedding ((↑) : I → ℝ) where
   measurable := measurable_subtype_coe
   measurableSet_image' _ := measurableSet_Icc.subtype_image
 
-lemma volume_eq {s : Set I} : volume s = volume (Subtype.val '' s) :=
+lemma volume_apply {s : Set I} : volume s = volume (Subtype.val '' s) :=
   measurableEmbedding_coe.comap_apply ..
 
 instance : NoAtoms (volume : Measure I) where
-  measure_singleton x := by simp only [volume_eq, Set.image_singleton, measure_singleton]
+  measure_singleton x := by simp only [volume_apply, Set.image_singleton, measure_singleton]
 
 @[measurability]
 theorem measurable_symm : Measurable symm := continuous_symm.measurable
@@ -50,7 +50,7 @@ variable (x : I)
 
 @[simp]
 lemma volume_Iic : volume (Iic x) = .ofReal x := by
-  simp only [volume_eq, image_subtype_val_Icc_Iic, Real.volume_Icc, sub_zero]
+  simp only [volume_apply, image_subtype_val_Icc_Iic, Real.volume_Icc, sub_zero]
 
 @[simp]
 lemma volume_Iio : volume (Iio x) = .ofReal x := by
@@ -59,44 +59,44 @@ lemma volume_Iio : volume (Iio x) = .ofReal x := by
 
 @[simp]
 lemma volume_Ici : volume (Ici x) = .ofReal (1 - x) := by
-  simp only [volume_eq, image_subtype_val_Icc_Ici, Real.volume_Icc]
+  simp only [volume_apply, image_subtype_val_Icc_Ici, Real.volume_Icc]
 
 @[simp]
 lemma volume_Ioi : volume (Ioi x) = .ofReal (1 - x) := by
-  simp only [volume_eq, image_subtype_val_Icc_Ioi, Real.volume_Ioc]
+  simp only [volume_apply, image_subtype_val_Icc_Ioi, Real.volume_Ioc]
 
 variable (y : I)
 
 @[simp]
 lemma volume_Icc : volume (Icc x y) = .ofReal (y - x) := by
-  simp only [volume_eq, image_subtype_val_Icc, Real.volume_Icc]
+  simp only [volume_apply, image_subtype_val_Icc, Real.volume_Icc]
 
 @[simp]
 lemma volume_uIcc : volume (uIcc x y) = edist y x := by
-  simp only [uIcc, volume_eq, image_subtype_val_Icc, Icc.coe_inf, Icc.coe_sup, Real.volume_Icc,
+  simp only [uIcc, volume_apply, image_subtype_val_Icc, Icc.coe_inf, Icc.coe_sup, Real.volume_Icc,
     max_sub_min_eq_abs, edist_dist, Subtype.dist_eq, Real.dist_eq]
 
 @[simp]
 lemma volume_Ico : volume (Ico x y) = .ofReal (y - x) := by
-  simp only [volume_eq, image_subtype_val_Ico, Real.volume_Ico]
+  simp only [volume_apply, image_subtype_val_Ico, Real.volume_Ico]
 
 @[simp]
 lemma volume_Ioc : volume (Ioc x y) = .ofReal (y - x) := by
-  simp only [volume_eq, image_subtype_val_Ioc, Real.volume_Ioc]
+  simp only [volume_apply, image_subtype_val_Ioc, Real.volume_Ioc]
 
 @[simp]
 lemma volume_uIoc : volume (uIoc x y) = edist y x := by
-  simp only [uIoc, volume_eq, image_subtype_val_Ioc, Icc.coe_inf, Icc.coe_sup, Real.volume_Ioc,
+  simp only [uIoc, volume_apply, image_subtype_val_Ioc, Icc.coe_inf, Icc.coe_sup, Real.volume_Ioc,
     max_sub_min_eq_abs, edist_dist, Subtype.dist_eq, Real.dist_eq]
 
 
 @[simp]
 lemma volume_Ioo : volume (Ioo x y) = .ofReal (y - x) := by
-  simp only [volume_eq, image_subtype_val_Ioo, Real.volume_Ioo]
+  simp only [volume_apply, image_subtype_val_Ioo, Real.volume_Ioo]
 
 @[simp]
 lemma volume_uIoo : volume (uIoo x y) = edist y x := by
-  simp only [uIoo, volume_eq, image_subtype_val_Ioo, Icc.coe_inf, Icc.coe_sup, Real.volume_Ioo,
+  simp only [uIoo, volume_apply, image_subtype_val_Ioo, Icc.coe_inf, Icc.coe_sup, Real.volume_Ioo,
     max_sub_min_eq_abs, edist_dist, Subtype.dist_eq, Real.dist_eq]
 
 end unitInterval

--- a/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
+++ b/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
@@ -32,8 +32,7 @@ instance : NoAtoms (volume : Measure I) where
   measure_singleton x := by
     rw [volume_def, Measure.comap_apply _ Subtype.val_injective ?_ _ (measurableSet_singleton x)]
     · simp only [Set.image_singleton, measure_singleton]
-    · intro s hs
-      exact measurableSet_Icc.subtype_image hs
+    · exact fun _ hs ↦ measurableSet_Icc.subtype_image hs
 
 @[measurability]
 theorem measurable_symm : Measurable symm := continuous_symm.measurable
@@ -52,10 +51,17 @@ lemma volume_Iio : volume (Iio x) = .ofReal x := by
   simp only [← volume_image_subtype_coe measurableSet_Icc, image_subtype_val_Icc_Iio,
     Real.volume_Ico, sub_zero]
 
-variable (y : I)
+@[simp]
+lemma volume_Ici : volume (Ici x) = .ofReal (1 - x) := by
+  simp only [← volume_image_subtype_coe measurableSet_Icc, image_subtype_val_Icc_Ici,
+    Real.volume_Icc]
 
-example (a b : ℝ) : edist a b = .ofReal (|a - b|) := by
-  exact edist_dist a b
+@[simp]
+lemma volume_Ioi : volume (Ioi x) = .ofReal (1 - x) := by
+  simp only [← volume_image_subtype_coe measurableSet_Icc, image_subtype_val_Icc_Ioi,
+    Real.volume_Ioc]
+
+variable (y : I)
 
 @[simp]
 lemma volume_Icc : volume (Icc x y) = .ofReal (y - x) := by

--- a/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
+++ b/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
@@ -57,15 +57,27 @@ lemma volume_Iio : volume (Iio x) = .ofReal x := by
 
 variable (y : I)
 
+example (a b : ℝ) : edist a b = .ofReal (|a - b|) := by
+  exact edist_dist a b
+
 @[simp]
 lemma volume_Icc : volume (Icc x y) = .ofReal (y - x) := by
   simp only [← volume_image_subtype_coe measurableSet_Icc, image_subtype_val_Icc, Real.volume_Icc]
 
-lemma volume_uIcc (h : x ≤ y) : volume (uIcc x y) = .ofReal (y - x) := by
-  simp only [uIcc_of_le h, volume_Icc]
-
-lemma volume_uIcc' (h : y ≤ x) : volume (uIcc x y) = .ofReal (x - y) := by
-  simp only [uIcc_of_ge h, volume_Icc]
+@[simp]
+lemma volume_uIcc : volume (uIcc x y) = edist y x := by
+  by_cases h : x ≤ y
+  · simp only [uIcc_of_le h, volume_Icc]
+    suffices |y.1 - x| = y - x by
+      rw [←this]
+      exact (edist_dist y x).symm
+    exact abs_of_nonneg <| sub_nonneg_of_le h
+  · simp only [uIcc_of_gt (not_le.mp h), volume_Icc]
+    rw [edist_comm]
+    suffices |x - y.1| = x - y by
+      rw [←this]
+      exact (edist_dist x y).symm
+    exact abs_of_pos <| sub_pos.mpr (not_le.mp h)
 
 @[simp]
 lemma volume_Ico : volume (Ico x y) = .ofReal (y - x) := by
@@ -95,11 +107,20 @@ lemma volume_Ioc : volume (Ioc x y) = .ofReal (y - x) := by
     rw [ENNReal.ofReal_eq_zero]
     exact tsub_nonpos.mpr (not_lt.mp hx)
 
-lemma volume_uIoc (h : x ≤ y) : volume (uIoc x y) = .ofReal (y - x) := by
-  simp only [uIoc_of_le h, volume_Ioc]
-
-lemma volume_uIoc' (h : y ≤ x) : volume (uIoc x y) = .ofReal (x - y) := by
-  simp only [uIoc_of_ge h, volume_Ioc]
+@[simp]
+lemma volume_uIoc : volume (uIoc x y) = edist y x := by
+  by_cases h : x ≤ y
+  · simp only [uIoc_of_le h, volume_Ioc]
+    suffices |y.1 - x| = y - x by
+      rw [←this]
+      exact (edist_dist y x).symm
+    exact abs_of_nonneg <| sub_nonneg_of_le h
+  · simp only [uIoc_of_ge (not_le.mp h).le, volume_Ioc]
+    rw [edist_comm]
+    suffices |x - y.1| = x - y by
+      rw [←this]
+      exact (edist_dist x y).symm
+    exact abs_of_pos <| sub_pos.mpr (not_le.mp h)
 
 @[simp]
 lemma volume_Ioo : volume (Ioo x y) = .ofReal (y - x) := by
@@ -115,10 +136,19 @@ lemma volume_Ioo : volume (Ioo x y) = .ofReal (y - x) := by
     rw [ENNReal.ofReal_eq_zero]
     exact tsub_nonpos.mpr (not_lt.mp hx)
 
-lemma volume_uIoo (h : x ≤ y) : volume (uIoo x y) = .ofReal (y - x) := by
-  simp only [uIoo_of_le h, volume_Ioo]
-
-lemma volume_uIoo' (h : y ≤ x) : volume (uIoo x y) = .ofReal (x - y) := by
-  simp only [uIoo_of_ge h, volume_Ioo]
+@[simp]
+lemma volume_uIoo : volume (uIoo x y) = edist y x := by
+  by_cases h : x ≤ y
+  · simp only [uIoo_of_le h, volume_Ioo]
+    suffices |y.1 - x| = y - x by
+      rw [←this]
+      exact (edist_dist y x).symm
+    exact abs_of_nonneg <| sub_nonneg_of_le h
+  · simp only [uIoo_of_ge (not_le.mp h).le, volume_Ioo]
+    rw [edist_comm]
+    suffices |x - y.1| = x - y by
+      rw [←this]
+      exact (edist_dist x y).symm
+    exact abs_of_pos <| sub_pos.mpr (not_le.mp h)
 
 end unitInterval

--- a/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
+++ b/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
@@ -49,11 +49,8 @@ lemma volume_Iic : volume (Iic x) = .ofReal x := by
 
 @[simp]
 lemma volume_Iio : volume (Iio x) = .ofReal x := by
-  suffices volume (Iio x) = volume (Iic x) by
-    rw [this]
-    exact volume_Iic x
-  refine measure_eq_measure_of_null_diff (Iio_subset_Iic_self) ?_
-  rw [Iic_diff_Iio_same, measure_singleton x]
+  simp only [← volume_image_subtype_coe measurableSet_Icc, image_subtype_val_Icc_Iio,
+    Real.volume_Ico, sub_zero]
 
 variable (y : I)
 
@@ -67,88 +64,43 @@ lemma volume_Icc : volume (Icc x y) = .ofReal (y - x) := by
 @[simp]
 lemma volume_uIcc : volume (uIcc x y) = edist y x := by
   by_cases h : x ≤ y
-  · simp only [uIcc_of_le h, volume_Icc]
-    suffices |y.1 - x| = y - x by
-      rw [←this]
-      exact (edist_dist y x).symm
-    exact abs_of_nonneg <| sub_nonneg_of_le h
-  · simp only [uIcc_of_gt (not_le.mp h), volume_Icc]
-    rw [edist_comm]
-    suffices |x - y.1| = x - y by
-      rw [←this]
-      exact (edist_dist x y).symm
-    exact abs_of_pos <| sub_pos.mpr (not_le.mp h)
+  · rw [uIcc_of_le h, edist_dist y x, show dist y x = |y.1 - x| by rfl]
+    replace h : x.1 ≤ y.1 := h
+    simp only [volume_Icc, abs_of_nonneg <| sub_nonneg_of_le h]
+  · rw [uIcc_of_gt (not_le.mp h), edist_comm, edist_dist x y, show dist x y = |x.1 - y| by rfl]
+    replace h : y.1 < x.1 := not_le.mp h
+    simp only [volume_Icc, abs_of_pos <| sub_pos.mpr h]
 
 @[simp]
 lemma volume_Ico : volume (Ico x y) = .ofReal (y - x) := by
-  by_cases hx : x < y
-  · suffices volume (Ico x y) = volume (Icc x y) by
-      rw [this]
-      exact volume_Icc x y
-    refine measure_eq_measure_of_null_diff Ico_subset_Icc_self ?_
-    rw [Icc_diff_Ico_same hx.le]
-    exact measure_singleton y
-  · rw [Ico_eq_empty hx, measure_empty]
-    apply Eq.symm
-    rw [ENNReal.ofReal_eq_zero]
-    exact tsub_nonpos.mpr (not_lt.mp hx)
+  simp only [← volume_image_subtype_coe measurableSet_Icc, image_subtype_val_Ico, Real.volume_Ico]
 
 @[simp]
 lemma volume_Ioc : volume (Ioc x y) = .ofReal (y - x) := by
-  by_cases hx : x < y
-  · suffices volume (Ioc x y) = volume (Icc x y) by
-      rw [this]
-      exact volume_Icc x y
-    refine measure_eq_measure_of_null_diff Ioc_subset_Icc_self ?_
-    rw [Icc_diff_Ioc_same hx.le]
-    exact measure_singleton x
-  · rw [Ioc_eq_empty hx, measure_empty]
-    apply Eq.symm
-    rw [ENNReal.ofReal_eq_zero]
-    exact tsub_nonpos.mpr (not_lt.mp hx)
+  simp only [← volume_image_subtype_coe measurableSet_Icc, image_subtype_val_Ioc, Real.volume_Ioc]
 
 @[simp]
 lemma volume_uIoc : volume (uIoc x y) = edist y x := by
   by_cases h : x ≤ y
-  · simp only [uIoc_of_le h, volume_Ioc]
-    suffices |y.1 - x| = y - x by
-      rw [←this]
-      exact (edist_dist y x).symm
-    exact abs_of_nonneg <| sub_nonneg_of_le h
-  · simp only [uIoc_of_ge (not_le.mp h).le, volume_Ioc]
-    rw [edist_comm]
-    suffices |x - y.1| = x - y by
-      rw [←this]
-      exact (edist_dist x y).symm
-    exact abs_of_pos <| sub_pos.mpr (not_le.mp h)
+  · rw [uIoc_of_le h, edist_dist y x, show dist y x = |y.1 - x| by rfl]
+    replace h : x.1 ≤ y.1 := h
+    simp only [volume_Ioc, abs_of_nonneg <| sub_nonneg_of_le h]
+  · rw [uIoc_of_ge (not_le.mp h).le, edist_comm, edist_dist x y, show dist x y = |x.1 - y| by rfl]
+    replace h : y.1 < x.1 := not_le.mp h
+    simp only [volume_Ioc, abs_of_pos <| sub_pos.mpr h]
 
 @[simp]
 lemma volume_Ioo : volume (Ioo x y) = .ofReal (y - x) := by
-  by_cases hx : x < y
-  · suffices volume (Ioo x y) = volume (Ico x y) by
-      rw [this]
-      exact volume_Ico x y
-    refine measure_eq_measure_of_null_diff Ioo_subset_Ico_self ?_
-    rw [Ico_diff_Ioo_same hx]
-    exact measure_singleton x
-  · rw [Ioo_eq_empty hx, measure_empty]
-    apply Eq.symm
-    rw [ENNReal.ofReal_eq_zero]
-    exact tsub_nonpos.mpr (not_lt.mp hx)
+  simp only [← volume_image_subtype_coe measurableSet_Icc, image_subtype_val_Ioo, Real.volume_Ioo]
 
 @[simp]
 lemma volume_uIoo : volume (uIoo x y) = edist y x := by
   by_cases h : x ≤ y
-  · simp only [uIoo_of_le h, volume_Ioo]
-    suffices |y.1 - x| = y - x by
-      rw [←this]
-      exact (edist_dist y x).symm
-    exact abs_of_nonneg <| sub_nonneg_of_le h
-  · simp only [uIoo_of_ge (not_le.mp h).le, volume_Ioo]
-    rw [edist_comm]
-    suffices |x - y.1| = x - y by
-      rw [←this]
-      exact (edist_dist x y).symm
-    exact abs_of_pos <| sub_pos.mpr (not_le.mp h)
+  · rw [uIoo_of_le h, edist_dist y x, show dist y x = |y.1 - x| by rfl]
+    replace h : x.1 ≤ y.1 := h
+    simp only [volume_Ioo, abs_of_nonneg <| sub_nonneg_of_le h]
+  · rw [uIoo_of_ge (not_le.mp h).le, edist_comm, edist_dist x y, show dist x y = |x.1 - y| by rfl]
+    replace h : y.1 < x.1 := not_le.mp h
+    simp only [volume_Ioo, abs_of_pos <| sub_pos.mpr h]
 
 end unitInterval

--- a/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
+++ b/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
@@ -62,6 +62,14 @@ lemma volume_Icc : volume (Icc x y) = .ofReal (y - x) := by
   simp only [← volume_image_subtype_coe measurableSet_Icc, image_subtype_val_Icc, Real.volume_Icc]
 
 @[simp]
+lemma volume_uIcc (h : x ≤ y) : volume (uIcc x y) = .ofReal (y - x) := by
+  simp only [uIcc_of_le h, volume_Icc]
+
+@[simp]
+lemma volume_uIcc' (h : y ≤ x) : volume (uIcc x y) = .ofReal (x - y) := by
+  simp only [uIcc_of_ge h, volume_Icc]
+
+@[simp]
 lemma volume_Ico : volume (Ico x y) = .ofReal (y - x) := by
   by_cases hx : x < y
   · suffices volume (Ico x y) = volume (Icc x y) by
@@ -90,6 +98,14 @@ lemma volume_Ioc : volume (Ioc x y) = .ofReal (y - x) := by
     exact tsub_nonpos.mpr (not_lt.mp hx)
 
 @[simp]
+lemma volume_uIoc (h : x ≤ y) : volume (uIoc x y) = .ofReal (y - x) := by
+  simp only [uIoc_of_le h, volume_Ioc]
+
+@[simp]
+lemma volume_uIoc' (h : y ≤ x) : volume (uIoc x y) = .ofReal (x - y) := by
+  simp only [uIoc_of_ge h, volume_Ioc]
+
+@[simp]
 lemma volume_Ioo : volume (Ioo x y) = .ofReal (y - x) := by
   by_cases hx : x < y
   · suffices volume (Ioo x y) = volume (Ico x y) by
@@ -103,5 +119,12 @@ lemma volume_Ioo : volume (Ioo x y) = .ofReal (y - x) := by
     rw [ENNReal.ofReal_eq_zero]
     exact tsub_nonpos.mpr (not_lt.mp hx)
 
+@[simp]
+lemma volume_uIoo (h : x ≤ y) : volume (uIoo x y) = .ofReal (y - x) := by
+  simp only [uIoo_of_le h, volume_Ioo]
+
+@[simp]
+lemma volume_uIoo' (h : y ≤ x) : volume (uIoo x y) = .ofReal (x - y) := by
+  simp only [uIoo_of_ge h, volume_Ioo]
 
 end unitInterval

--- a/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
+++ b/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
@@ -41,20 +41,6 @@ theorem measurable_symm : Measurable symm := continuous_symm.measurable
 
 open Set
 
-lemma measure_preserving_symm : volume = volume.map symm := by
-  refine (volume : Measure I).ext_of_Ici ?_ ?_
-  intro a
-  rw [volume.map_apply measurable_symm measurableSet_Ici]
-  have : σ ⁻¹' Ici a = Iic ⟨1 - a, mem_iff_one_sub_mem.mp a.2⟩ := by
-    ext x
-    constructor
-    · intro (h : a.1 ≤ 1 - x)
-      exact le_sub_comm.mp h
-    · intro (h : x.1 ≤ 1 - a.1)
-      exact le_sub_comm.mp h
-  simp only [this, ← volume_image_subtype_coe measurableSet_Icc, image_subtype_val_Icc_Ici,
-  image_subtype_val_Icc_Iic, Real.volume_Icc, sub_zero]
-
 variable (x : I)
 
 @[simp]

--- a/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
+++ b/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
@@ -12,7 +12,9 @@ import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
 # The canonical measure on the unit interval
 
 This file provides a `MeasureTheory.MeasureSpace` instance on `unitInterval`,
-and shows it is a probability measure.
+and shows it is a probability measure with no atoms.
+
+It also contains some basic results on the volume of various interval sets.
 -/
 open scoped unitInterval
 open MeasureTheory

--- a/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
+++ b/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2024 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Eric Wieser
+Authors: Eric Wieser, Gaëtan Serré
 -/
 import Mathlib.Topology.UnitInterval
 import Mathlib.MeasureTheory.Constructions.BorelSpace.Basic
@@ -28,7 +28,64 @@ instance : IsProbabilityMeasure (volume : Measure I) where
     rw [Measure.Subtype.volume_univ nullMeasurableSet_Icc, Real.volume_Icc, sub_zero,
       ENNReal.ofReal_one]
 
+instance : NoAtoms (volume : Measure I) where
+  measure_singleton x := by
+    rw [volume_def, Measure.comap_apply _ Subtype.val_injective ?_ _ (measurableSet_singleton x)]
+    · simp only [Set.image_singleton, measure_singleton]
+    · intro s hs
+      exact measurableSet_Icc.subtype_image hs
+
 @[measurability]
 theorem measurable_symm : Measurable symm := continuous_symm.measurable
+
+open Set
+
+@[simp]
+lemma volume_Icc (x : I) : volume (Icc 0 x) = .ofReal x := by
+  simp [← volume_image_subtype_coe measurableSet_Icc, Real.volume_Icc, sub_zero]
+
+@[simp]
+lemma volume_Ico (x : I) : volume (Ico 0 x) = .ofReal x := by
+  suffices volume (Ico 0 x) = volume (Icc 0 x) by
+    rw [this]
+    exact volume_Icc x
+  refine measure_eq_measure_of_null_diff Ico_subset_Icc_self ?_
+  rw [Icc_diff_Ico_same nonneg']
+  exact measure_singleton x
+
+@[simp]
+lemma volume_Ioc (x : I) : volume (Ioc 0 x) = .ofReal x := by
+  suffices volume (Ioc 0 x) = volume (Icc 0 x) by
+    rw [this]
+    exact volume_Icc x
+  refine measure_eq_measure_of_null_diff Ioc_subset_Icc_self ?_
+  rw [Icc_diff_Ioc_same nonneg']
+  exact measure_singleton 0
+
+lemma volume_Ioo (x : I) : volume (Ioo 0 x) = .ofReal x := by
+  by_cases hx : 0 < x
+  · suffices volume (Ioo 0 x) = volume (Ico 0 x) by
+      rw [this]
+      exact volume_Ico x
+    refine measure_eq_measure_of_null_diff Ioo_subset_Ico_self ?_
+    rw [Ico_diff_Ioo_same hx]
+    exact measure_singleton 0
+  · rw [le_zero_iff.mp (not_lt.mp hx)]
+    simp only [lt_self_iff_false, not_false_eq_true, Ioo_eq_empty, measure_empty, Icc.coe_zero,
+      ENNReal.ofReal_zero]
+
+@[simp]
+lemma volume_Iic (x : I) : volume (Iic x) = .ofReal x := by
+  simp only [← volume_image_subtype_coe measurableSet_Icc, image_subtype_val_Icc_Iic,
+    Real.volume_Icc, sub_zero]
+
+@[simp]
+lemma volume_Iio (x : I) : volume (Iio x) = .ofReal x := by
+  suffices volume (Iio x) = volume (Iic x) by
+    rw [this]
+    exact volume_Iic x
+  refine measure_eq_measure_of_null_diff (Iio_subset_Iic_self) ?_
+  rw [Iic_diff_Iio_same, measure_singleton x]
+
 
 end unitInterval

--- a/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
+++ b/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
@@ -41,6 +41,20 @@ theorem measurable_symm : Measurable symm := continuous_symm.measurable
 
 open Set
 
+lemma measure_preserving_symm : volume = volume.map symm := by
+  refine (volume : Measure I).ext_of_Ici ?_ ?_
+  intro a
+  rw [volume.map_apply measurable_symm measurableSet_Ici]
+  have : σ ⁻¹' Ici a = Iic ⟨1 - a, mem_iff_one_sub_mem.mp a.2⟩ := by
+    ext x
+    constructor
+    · intro (h : a.1 ≤ 1 - x)
+      exact le_sub_comm.mp h
+    · intro (h : x.1 ≤ 1 - a.1)
+      exact le_sub_comm.mp h
+  simp only [this, ← volume_image_subtype_coe measurableSet_Icc, image_subtype_val_Icc_Ici,
+  image_subtype_val_Icc_Iic, Real.volume_Icc, sub_zero]
+
 variable (x : I)
 
 @[simp]

--- a/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
+++ b/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
@@ -40,52 +40,67 @@ theorem measurable_symm : Measurable symm := continuous_symm.measurable
 
 open Set
 
-@[simp]
-lemma volume_Icc (x : I) : volume (Icc 0 x) = .ofReal x := by
-  simp [← volume_image_subtype_coe measurableSet_Icc, Real.volume_Icc, sub_zero]
+variable (x : I)
 
 @[simp]
-lemma volume_Ico (x : I) : volume (Ico 0 x) = .ofReal x := by
-  suffices volume (Ico 0 x) = volume (Icc 0 x) by
-    rw [this]
-    exact volume_Icc x
-  refine measure_eq_measure_of_null_diff Ico_subset_Icc_self ?_
-  rw [Icc_diff_Ico_same nonneg']
-  exact measure_singleton x
-
-@[simp]
-lemma volume_Ioc (x : I) : volume (Ioc 0 x) = .ofReal x := by
-  suffices volume (Ioc 0 x) = volume (Icc 0 x) by
-    rw [this]
-    exact volume_Icc x
-  refine measure_eq_measure_of_null_diff Ioc_subset_Icc_self ?_
-  rw [Icc_diff_Ioc_same nonneg']
-  exact measure_singleton 0
-
-lemma volume_Ioo (x : I) : volume (Ioo 0 x) = .ofReal x := by
-  by_cases hx : 0 < x
-  · suffices volume (Ioo 0 x) = volume (Ico 0 x) by
-      rw [this]
-      exact volume_Ico x
-    refine measure_eq_measure_of_null_diff Ioo_subset_Ico_self ?_
-    rw [Ico_diff_Ioo_same hx]
-    exact measure_singleton 0
-  · rw [le_zero_iff.mp (not_lt.mp hx)]
-    simp only [lt_self_iff_false, not_false_eq_true, Ioo_eq_empty, measure_empty, Icc.coe_zero,
-      ENNReal.ofReal_zero]
-
-@[simp]
-lemma volume_Iic (x : I) : volume (Iic x) = .ofReal x := by
+lemma volume_Iic : volume (Iic x) = .ofReal x := by
   simp only [← volume_image_subtype_coe measurableSet_Icc, image_subtype_val_Icc_Iic,
     Real.volume_Icc, sub_zero]
 
 @[simp]
-lemma volume_Iio (x : I) : volume (Iio x) = .ofReal x := by
+lemma volume_Iio : volume (Iio x) = .ofReal x := by
   suffices volume (Iio x) = volume (Iic x) by
     rw [this]
     exact volume_Iic x
   refine measure_eq_measure_of_null_diff (Iio_subset_Iic_self) ?_
   rw [Iic_diff_Iio_same, measure_singleton x]
+
+variable (y : I)
+
+@[simp]
+lemma volume_Icc : volume (Icc x y) = .ofReal (y - x) := by
+  simp only [← volume_image_subtype_coe measurableSet_Icc, image_subtype_val_Icc, Real.volume_Icc]
+
+@[simp]
+lemma volume_Ico : volume (Ico x y) = .ofReal (y - x) := by
+  by_cases hx : x < y
+  · suffices volume (Ico x y) = volume (Icc x y) by
+      rw [this]
+      exact volume_Icc x y
+    refine measure_eq_measure_of_null_diff Ico_subset_Icc_self ?_
+    rw [Icc_diff_Ico_same hx.le]
+    exact measure_singleton y
+  · rw [Ico_eq_empty hx, measure_empty]
+    apply Eq.symm
+    rw [ENNReal.ofReal_eq_zero]
+    exact tsub_nonpos.mpr (not_lt.mp hx)
+
+@[simp]
+lemma volume_Ioc : volume (Ioc x y) = .ofReal (y - x) := by
+  by_cases hx : x < y
+  · suffices volume (Ioc x y) = volume (Icc x y) by
+      rw [this]
+      exact volume_Icc x y
+    refine measure_eq_measure_of_null_diff Ioc_subset_Icc_self ?_
+    rw [Icc_diff_Ioc_same hx.le]
+    exact measure_singleton x
+  · rw [Ioc_eq_empty hx, measure_empty]
+    apply Eq.symm
+    rw [ENNReal.ofReal_eq_zero]
+    exact tsub_nonpos.mpr (not_lt.mp hx)
+
+lemma volume_Ioo : volume (Ioo x y) = .ofReal (y - x) := by
+  by_cases hx : x < y
+  · suffices volume (Ioo x y) = volume (Ico x y) by
+      rw [this]
+      exact volume_Ico x y
+    refine measure_eq_measure_of_null_diff Ioo_subset_Ico_self ?_
+    rw [Ico_diff_Ioo_same hx]
+    exact measure_singleton x
+  · rw [Ioo_eq_empty hx, measure_empty]
+    apply Eq.symm
+    rw [ENNReal.ofReal_eq_zero]
+    exact tsub_nonpos.mpr (not_lt.mp hx)
 
 
 end unitInterval

--- a/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
+++ b/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
@@ -89,6 +89,7 @@ lemma volume_Ioc : volume (Ioc x y) = .ofReal (y - x) := by
     rw [ENNReal.ofReal_eq_zero]
     exact tsub_nonpos.mpr (not_lt.mp hx)
 
+@[simp]
 lemma volume_Ioo : volume (Ioo x y) = .ofReal (y - x) := by
   by_cases hx : x < y
   · suffices volume (Ioo x y) = volume (Ico x y) by

--- a/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
+++ b/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
@@ -61,11 +61,9 @@ variable (y : I)
 lemma volume_Icc : volume (Icc x y) = .ofReal (y - x) := by
   simp only [← volume_image_subtype_coe measurableSet_Icc, image_subtype_val_Icc, Real.volume_Icc]
 
-@[simp]
 lemma volume_uIcc (h : x ≤ y) : volume (uIcc x y) = .ofReal (y - x) := by
   simp only [uIcc_of_le h, volume_Icc]
 
-@[simp]
 lemma volume_uIcc' (h : y ≤ x) : volume (uIcc x y) = .ofReal (x - y) := by
   simp only [uIcc_of_ge h, volume_Icc]
 
@@ -97,11 +95,9 @@ lemma volume_Ioc : volume (Ioc x y) = .ofReal (y - x) := by
     rw [ENNReal.ofReal_eq_zero]
     exact tsub_nonpos.mpr (not_lt.mp hx)
 
-@[simp]
 lemma volume_uIoc (h : x ≤ y) : volume (uIoc x y) = .ofReal (y - x) := by
   simp only [uIoc_of_le h, volume_Ioc]
 
-@[simp]
 lemma volume_uIoc' (h : y ≤ x) : volume (uIoc x y) = .ofReal (x - y) := by
   simp only [uIoc_of_ge h, volume_Ioc]
 
@@ -119,11 +115,9 @@ lemma volume_Ioo : volume (Ioo x y) = .ofReal (y - x) := by
     rw [ENNReal.ofReal_eq_zero]
     exact tsub_nonpos.mpr (not_lt.mp hx)
 
-@[simp]
 lemma volume_uIoo (h : x ≤ y) : volume (uIoo x y) = .ofReal (y - x) := by
   simp only [uIoo_of_le h, volume_Ioo]
 
-@[simp]
 lemma volume_uIoo' (h : y ≤ x) : volume (uIoo x y) = .ofReal (x - y) := by
   simp only [uIoo_of_ge h, volume_Ioo]
 

--- a/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
+++ b/Mathlib/MeasureTheory/Constructions/UnitInterval.lean
@@ -30,11 +30,16 @@ instance : IsProbabilityMeasure (volume : Measure I) where
     rw [Measure.Subtype.volume_univ nullMeasurableSet_Icc, Real.volume_Icc, sub_zero,
       ENNReal.ofReal_one]
 
+lemma measurableEmbedding_coe : MeasurableEmbedding ((↑) : I → ℝ) where
+  injective := Subtype.val_injective
+  measurable := measurable_subtype_coe
+  measurableSet_image' _ := measurableSet_Icc.subtype_image
+
+lemma volume_eq {s : Set I} : volume s = volume (Subtype.val '' s) :=
+  measurableEmbedding_coe.comap_apply ..
+
 instance : NoAtoms (volume : Measure I) where
-  measure_singleton x := by
-    rw [volume_def, Measure.comap_apply _ Subtype.val_injective ?_ _ (measurableSet_singleton x)]
-    · simp only [Set.image_singleton, measure_singleton]
-    · exact fun _ hs ↦ measurableSet_Icc.subtype_image hs
+  measure_singleton x := by simp only [volume_eq, Set.image_singleton, measure_singleton]
 
 @[measurability]
 theorem measurable_symm : Measurable symm := continuous_symm.measurable
@@ -45,8 +50,7 @@ variable (x : I)
 
 @[simp]
 lemma volume_Iic : volume (Iic x) = .ofReal x := by
-  simp only [← volume_image_subtype_coe measurableSet_Icc, image_subtype_val_Icc_Iic,
-    Real.volume_Icc, sub_zero]
+  simp only [volume_eq, image_subtype_val_Icc_Iic, Real.volume_Icc, sub_zero]
 
 @[simp]
 lemma volume_Iio : volume (Iio x) = .ofReal x := by
@@ -55,60 +59,44 @@ lemma volume_Iio : volume (Iio x) = .ofReal x := by
 
 @[simp]
 lemma volume_Ici : volume (Ici x) = .ofReal (1 - x) := by
-  simp only [← volume_image_subtype_coe measurableSet_Icc, image_subtype_val_Icc_Ici,
-    Real.volume_Icc]
+  simp only [volume_eq, image_subtype_val_Icc_Ici, Real.volume_Icc]
 
 @[simp]
 lemma volume_Ioi : volume (Ioi x) = .ofReal (1 - x) := by
-  simp only [← volume_image_subtype_coe measurableSet_Icc, image_subtype_val_Icc_Ioi,
-    Real.volume_Ioc]
+  simp only [volume_eq, image_subtype_val_Icc_Ioi, Real.volume_Ioc]
 
 variable (y : I)
 
 @[simp]
 lemma volume_Icc : volume (Icc x y) = .ofReal (y - x) := by
-  simp only [← volume_image_subtype_coe measurableSet_Icc, image_subtype_val_Icc, Real.volume_Icc]
+  simp only [volume_eq, image_subtype_val_Icc, Real.volume_Icc]
 
 @[simp]
 lemma volume_uIcc : volume (uIcc x y) = edist y x := by
-  by_cases h : x ≤ y
-  · rw [uIcc_of_le h, edist_dist y x, show dist y x = |y.1 - x| by rfl]
-    replace h : x.1 ≤ y.1 := h
-    simp only [volume_Icc, abs_of_nonneg <| sub_nonneg_of_le h]
-  · rw [uIcc_of_gt (not_le.mp h), edist_comm, edist_dist x y, show dist x y = |x.1 - y| by rfl]
-    replace h : y.1 < x.1 := not_le.mp h
-    simp only [volume_Icc, abs_of_pos <| sub_pos.mpr h]
+  simp only [uIcc, volume_eq, image_subtype_val_Icc, Icc.coe_inf, Icc.coe_sup, Real.volume_Icc,
+    max_sub_min_eq_abs, edist_dist, Subtype.dist_eq, Real.dist_eq]
 
 @[simp]
 lemma volume_Ico : volume (Ico x y) = .ofReal (y - x) := by
-  simp only [← volume_image_subtype_coe measurableSet_Icc, image_subtype_val_Ico, Real.volume_Ico]
+  simp only [volume_eq, image_subtype_val_Ico, Real.volume_Ico]
 
 @[simp]
 lemma volume_Ioc : volume (Ioc x y) = .ofReal (y - x) := by
-  simp only [← volume_image_subtype_coe measurableSet_Icc, image_subtype_val_Ioc, Real.volume_Ioc]
+  simp only [volume_eq, image_subtype_val_Ioc, Real.volume_Ioc]
 
 @[simp]
 lemma volume_uIoc : volume (uIoc x y) = edist y x := by
-  by_cases h : x ≤ y
-  · rw [uIoc_of_le h, edist_dist y x, show dist y x = |y.1 - x| by rfl]
-    replace h : x.1 ≤ y.1 := h
-    simp only [volume_Ioc, abs_of_nonneg <| sub_nonneg_of_le h]
-  · rw [uIoc_of_ge (not_le.mp h).le, edist_comm, edist_dist x y, show dist x y = |x.1 - y| by rfl]
-    replace h : y.1 < x.1 := not_le.mp h
-    simp only [volume_Ioc, abs_of_pos <| sub_pos.mpr h]
+  simp only [uIoc, volume_eq, image_subtype_val_Ioc, Icc.coe_inf, Icc.coe_sup, Real.volume_Ioc,
+    max_sub_min_eq_abs, edist_dist, Subtype.dist_eq, Real.dist_eq]
+
 
 @[simp]
 lemma volume_Ioo : volume (Ioo x y) = .ofReal (y - x) := by
-  simp only [← volume_image_subtype_coe measurableSet_Icc, image_subtype_val_Ioo, Real.volume_Ioo]
+  simp only [volume_eq, image_subtype_val_Ioo, Real.volume_Ioo]
 
 @[simp]
 lemma volume_uIoo : volume (uIoo x y) = edist y x := by
-  by_cases h : x ≤ y
-  · rw [uIoo_of_le h, edist_dist y x, show dist y x = |y.1 - x| by rfl]
-    replace h : x.1 ≤ y.1 := h
-    simp only [volume_Ioo, abs_of_nonneg <| sub_nonneg_of_le h]
-  · rw [uIoo_of_ge (not_le.mp h).le, edist_comm, edist_dist x y, show dist x y = |x.1 - y| by rfl]
-    replace h : y.1 < x.1 := not_le.mp h
-    simp only [volume_Ioo, abs_of_pos <| sub_pos.mpr h]
+  simp only [uIoo, volume_eq, image_subtype_val_Ioo, Icc.coe_inf, Icc.coe_sup, Real.volume_Ioo,
+    max_sub_min_eq_abs, edist_dist, Subtype.dist_eq, Real.dist_eq]
 
 end unitInterval


### PR DESCRIPTION
- `instance : NoAtoms (volume : Measure I)`

- `(volume : Measure I) s = volume (Subtype.val '' s)`

- `(volume : Measure I) (Icc x y) = ENNReal.ofReal (y - x)`

- `(volume : Measure I) (Ico x y) = ENNReal.ofReal (y - x)`

- `(volume : Measure I) (Ioc x y) = ENNReal.ofReal (y - x)`

- `(volume : Measure I) (Ioo x y) = ENNReal.ofReal (y - x)`

- `(volume : Measure I) (Iic x) = ENNReal.ofReal x`

- `(volume : Measure I) (Ici x) = ENNReal.ofReal (1 - x)`

- `(volume : Measure I) (Iio x) = ENNReal.ofReal x`

- `(volume : Measure I) (Ioi x) = ENNReal.ofReal (1 - x)`

- `(volume : Measure I) (uIcc x y) = edist y x`

- `(volume : Measure I) (uIoc x y) = edist y x`

- `(volume : Measure I) (uIoo x y) = edist y x`

Co-authored-by: Rémy Degenne <remy.degenne@inria.fr>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
