### PR TITLE
[Merged by Bors] - chore(Algebra/Algebra/Defs): modified `RingHom.toAlgebra'` and `RingHom.toAlgebra` docstrings to reflect the risk of diamonds

### DIFF
--- a/Mathlib/Algebra/Algebra/Defs.lean
+++ b/Mathlib/Algebra/Algebra/Defs.lean
@@ -162,7 +162,9 @@ end CommRingRing
 end algebraMap
 
 /-- Creating an algebra from a morphism to the center of a semiring.
-See note [reducible non-instances]. -/
+See note [reducible non-instances]. *Warning:* Should not use if `S` already has a `SMul R S`
+instance, since this result creates another `SMul R S` instance from the supplied `RingHom` and
+this will likely create a diamond. -/
 abbrev RingHom.toAlgebra' {R S} [CommSemiring R] [Semiring S] (i : R →+* S)
     (h : ∀ c x, i c * x = x * i c) : Algebra R S where
   smul c x := i c * x
@@ -184,7 +186,9 @@ theorem RingHom.algebraMap_toAlgebra' {R S} [CommSemiring R] [Semiring S] (i : R
   rfl
 
 /-- Creating an algebra from a morphism to a commutative semiring.
-See note [reducible non-instances]. -/
+See note [reducible non-instances]. *Warning:* Should not use if `S` already has a `SMul R S`
+instance, since this result creates another `SMul R S` instance via the `RingHom.toAlgebra'` call
+and this will likely create a diamond. -/
 abbrev RingHom.toAlgebra {R S} [CommSemiring R] [CommSemiring S] (i : R →+* S) : Algebra R S :=
   i.toAlgebra' fun _ => mul_comm _
 

--- a/Mathlib/Algebra/Algebra/Defs.lean
+++ b/Mathlib/Algebra/Algebra/Defs.lean
@@ -188,9 +188,11 @@ theorem RingHom.algebraMap_toAlgebra' {R S} [CommSemiring R] [Semiring S] (i : R
   rfl
 
 /-- Creating an algebra from a morphism to a commutative semiring.
-See note [reducible non-instances]. *Warning:* Should not use if `S` already has a `SMul R S`
-instance, since this result creates another `SMul R S` instance via the `RingHom.toAlgebra'` call
-and this will likely create a diamond. -/
+See note [reducible non-instances].
+
+*Warning:* In general this should not be used if `S` already has a `SMul R S`
+instance, since this creates another `SMul R S` instance from the supplied `RingHom` and
+this will likely create a diamond. -/
 abbrev RingHom.toAlgebra {R S} [CommSemiring R] [CommSemiring S] (i : R →+* S) : Algebra R S :=
   i.toAlgebra' fun _ => mul_comm _
 

--- a/Mathlib/Algebra/Algebra/Defs.lean
+++ b/Mathlib/Algebra/Algebra/Defs.lean
@@ -162,8 +162,10 @@ end CommRingRing
 end algebraMap
 
 /-- Creating an algebra from a morphism to the center of a semiring.
-See note [reducible non-instances]. *Warning:* Should not use if `S` already has a `SMul R S`
-instance, since this result creates another `SMul R S` instance from the supplied `RingHom` and
+See note [reducible non-instances].
+
+*Warning:* In general this should not be used if `S` already has a `SMul R S`
+instance, since this creates another `SMul R S` instance from the supplied `RingHom` and
 this will likely create a diamond. -/
 abbrev RingHom.toAlgebra' {R S} [CommSemiring R] [Semiring S] (i : R →+* S)
     (h : ∀ c x, i c * x = x * i c) : Algebra R S where


### PR DESCRIPTION
Modified the docstring of `RingHom.toAlgebra'` to include a warning that if `S` already has a `SMul R S` 
instance, then using this result creates another `SMul R S` instance from the supplied `RingHom` and 
this will likely create a diamond. Also modified `RingHom.toAlgebra` similarly (a bit shorter, since this result calls the primed version, so the warning here says that the call to the primed version may create a diamond.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
