### PR TITLE
[Merged by Bors] - feat: a `MeasurableEmbedding` has a measurable left inverse

### DIFF
--- a/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
@@ -743,6 +743,35 @@ noncomputable def schroederBernstein {f : α → β} {g : β → α} (hf : Measu
   apply hx
   exact ⟨y, h, rfl⟩
 
+lemma equivRange_apply (hf : MeasurableEmbedding f) (x : α) :
+    hf.equivRange x = ⟨f x, mem_range_self x⟩ := by
+  suffices f x = (hf.equivRange x).1 by simp [this]
+  simp [MeasurableEmbedding.equivRange, MeasurableEquiv.cast, MeasurableEquiv.Set.univ,
+    MeasurableEmbedding.equivImage]
+
+lemma equivRange_symm_apply_mk (hf : MeasurableEmbedding f) (x : α) :
+    hf.equivRange.symm ⟨f x, mem_range_self x⟩ = x := by
+  have : x = hf.equivRange.symm (hf.equivRange x) := EquivLike.inv_apply_eq.mp rfl
+  conv_rhs => rw [this, hf.equivRange_apply]
+
+/-- The left-inverse of a MeasurableEmbedding -/
+protected noncomputable
+def invFun [Nonempty α] (hf : MeasurableEmbedding f) [∀ x, Decidable (x ∈ range f)] (x : β) : α :=
+  if hx : x ∈ range f then hf.equivRange.symm ⟨x, hx⟩ else (Nonempty.some inferInstance)
+
+@[fun_prop]
+lemma measurable_invFun [Nonempty α] [∀ x, Decidable (x ∈ range f)]
+    (hf : MeasurableEmbedding f) :
+    Measurable (hf.invFun : β → α) :=
+  Measurable.dite (by fun_prop) measurable_const hf.measurableSet_range
+
+lemma leftInverse_invFun [Nonempty α] [∀ x, Decidable (x ∈ range f)]
+    (hf : MeasurableEmbedding f) :
+    Function.LeftInverse hf.invFun f := by
+  intro x
+  simp only [MeasurableEmbedding.invFun, mem_range, exists_apply_eq_apply, ↓reduceDIte]
+  exact hf.equivRange_symm_apply_mk x
+
 end MeasurableEmbedding
 
 theorem MeasurableSpace.comap_compl {m' : MeasurableSpace β} [BooleanAlgebra β]

--- a/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
@@ -764,8 +764,7 @@ lemma measurable_invFun [Nonempty α] [∀ x, Decidable (x ∈ range f)] (hf : M
     Measurable (hf.invFun : β → α) :=
   Measurable.dite (by fun_prop) measurable_const hf.measurableSet_range
 
-lemma leftInverse_invFun [Nonempty α] [∀ x, Decidable (x ∈ range f)]
-    (hf : MeasurableEmbedding f) :
+lemma leftInverse_invFun [Nonempty α] [∀ x, Decidable (x ∈ range f)] (hf : MeasurableEmbedding f) :
     Function.LeftInverse hf.invFun f := by
   intro x
   simp only [MeasurableEmbedding.invFun, mem_range, exists_apply_eq_apply, ↓reduceDIte]

--- a/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
@@ -760,8 +760,7 @@ def invFun [Nonempty α] (hf : MeasurableEmbedding f) [∀ x, Decidable (x ∈ r
   if hx : x ∈ range f then hf.equivRange.symm ⟨x, hx⟩ else (Nonempty.some inferInstance)
 
 @[fun_prop, measurability]
-lemma measurable_invFun [Nonempty α] [∀ x, Decidable (x ∈ range f)]
-    (hf : MeasurableEmbedding f) :
+lemma measurable_invFun [Nonempty α] [∀ x, Decidable (x ∈ range f)] (hf : MeasurableEmbedding f) :
     Measurable (hf.invFun : β → α) :=
   Measurable.dite (by fun_prop) measurable_const hf.measurableSet_range
 

--- a/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
@@ -759,7 +759,7 @@ protected noncomputable
 def invFun [Nonempty α] (hf : MeasurableEmbedding f) [∀ x, Decidable (x ∈ range f)] (x : β) : α :=
   if hx : x ∈ range f then hf.equivRange.symm ⟨x, hx⟩ else (Nonempty.some inferInstance)
 
-@[fun_prop]
+@[fun_prop, measurability]
 lemma measurable_invFun [Nonempty α] [∀ x, Decidable (x ∈ range f)]
     (hf : MeasurableEmbedding f) :
     Measurable (hf.invFun : β → α) :=

--- a/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
@@ -765,7 +765,7 @@ def invFun [Nonempty α] (hf : MeasurableEmbedding f) (x : β) : α :=
 @[fun_prop, measurability]
 lemma measurable_invFun [Nonempty α] (hf : MeasurableEmbedding f) :
     Measurable (hf.invFun : β → α) :=
-   open Classical in
+  open Classical in
   Measurable.dite (by fun_prop) measurable_const hf.measurableSet_range
 
 lemma leftInverse_invFun [Nonempty α] (hf : MeasurableEmbedding f) : hf.invFun.LeftInverse f := by

--- a/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
@@ -769,8 +769,7 @@ lemma measurable_invFun [Nonempty α] [∀ x, Decidable (x ∈ range f)] (hf : M
 lemma leftInverse_invFun [Nonempty α] [∀ x, Decidable (x ∈ range f)] (hf : MeasurableEmbedding f) :
     hf.invFun.LeftInverse f := by
   intro x
-  simp only [MeasurableEmbedding.invFun, mem_range, exists_apply_eq_apply, ↓reduceDIte,
-    equivRange_symm_apply_mk]
+  simp [MeasurableEmbedding.invFun]
 
 end MeasurableEmbedding
 

--- a/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
@@ -769,8 +769,8 @@ lemma measurable_invFun [Nonempty α] [∀ x, Decidable (x ∈ range f)] (hf : M
 lemma leftInverse_invFun [Nonempty α] [∀ x, Decidable (x ∈ range f)] (hf : MeasurableEmbedding f) :
     hf.invFun.LeftInverse f := by
   intro x
-  simp only [MeasurableEmbedding.invFun, mem_range, exists_apply_eq_apply, ↓reduceDIte]
-  exact hf.equivRange_symm_apply_mk x
+  simp only [MeasurableEmbedding.invFun, mem_range, exists_apply_eq_apply, ↓reduceDIte,
+    equivRange_symm_apply_mk]
 
 end MeasurableEmbedding
 

--- a/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
@@ -754,7 +754,7 @@ lemma equivRange_symm_apply_mk (hf : MeasurableEmbedding f) (x : α) :
   nth_rw 3 [← hf.equivRange.symm_apply_apply x]
   rw [hf.equivRange_apply]
 
-/-- The left-inverse of a MeasurableEmbedding -/
+/-- The left-inverse of a `MeasurableEmbedding` -/
 protected noncomputable
 def invFun [Nonempty α] (hf : MeasurableEmbedding f) [∀ x, Decidable (x ∈ range f)] (x : β) : α :=
   if hx : x ∈ range f then hf.equivRange.symm ⟨x, hx⟩ else (Nonempty.some inferInstance)

--- a/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
@@ -751,8 +751,8 @@ lemma equivRange_apply (hf : MeasurableEmbedding f) (x : α) :
 
 lemma equivRange_symm_apply_mk (hf : MeasurableEmbedding f) (x : α) :
     hf.equivRange.symm ⟨f x, mem_range_self x⟩ = x := by
-  have : x = hf.equivRange.symm (hf.equivRange x) := EquivLike.inv_apply_eq.mp rfl
-  conv_rhs => rw [this, hf.equivRange_apply]
+  nth_rw 3 [← hf.equivRange.symm_apply_apply x]
+  rw [hf.equivRange_apply]
 
 /-- The left-inverse of a MeasurableEmbedding -/
 protected noncomputable

--- a/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
@@ -756,16 +756,16 @@ lemma equivRange_symm_apply_mk (hf : MeasurableEmbedding f) (x : α) :
   nth_rw 3 [← hf.equivRange.symm_apply_apply x]
   rw [hf.equivRange_apply]
 
-open Classical in
 /-- The left-inverse of a `MeasurableEmbedding` -/
 protected noncomputable
 def invFun [Nonempty α] (hf : MeasurableEmbedding f) (x : β) : α :=
+  open Classical in
   if hx : x ∈ range f then hf.equivRange.symm ⟨x, hx⟩ else (Nonempty.some inferInstance)
 
-open Classical in
 @[fun_prop, measurability]
 lemma measurable_invFun [Nonempty α] (hf : MeasurableEmbedding f) :
     Measurable (hf.invFun : β → α) :=
+   open Classical in
   Measurable.dite (by fun_prop) measurable_const hf.measurableSet_range
 
 lemma leftInverse_invFun [Nonempty α] (hf : MeasurableEmbedding f) : hf.invFun.LeftInverse f := by

--- a/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
@@ -756,18 +756,19 @@ lemma equivRange_symm_apply_mk (hf : MeasurableEmbedding f) (x : α) :
   nth_rw 3 [← hf.equivRange.symm_apply_apply x]
   rw [hf.equivRange_apply]
 
+open Classical in
 /-- The left-inverse of a `MeasurableEmbedding` -/
 protected noncomputable
-def invFun [Nonempty α] (hf : MeasurableEmbedding f) [∀ x, Decidable (x ∈ range f)] (x : β) : α :=
+def invFun [Nonempty α] (hf : MeasurableEmbedding f) (x : β) : α :=
   if hx : x ∈ range f then hf.equivRange.symm ⟨x, hx⟩ else (Nonempty.some inferInstance)
 
+open Classical in
 @[fun_prop, measurability]
-lemma measurable_invFun [Nonempty α] [∀ x, Decidable (x ∈ range f)] (hf : MeasurableEmbedding f) :
+lemma measurable_invFun [Nonempty α] (hf : MeasurableEmbedding f) :
     Measurable (hf.invFun : β → α) :=
   Measurable.dite (by fun_prop) measurable_const hf.measurableSet_range
 
-lemma leftInverse_invFun [Nonempty α] [∀ x, Decidable (x ∈ range f)] (hf : MeasurableEmbedding f) :
-    hf.invFun.LeftInverse f := by
+lemma leftInverse_invFun [Nonempty α] (hf : MeasurableEmbedding f) : hf.invFun.LeftInverse f := by
   intro x
   simp [MeasurableEmbedding.invFun]
 

--- a/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
@@ -743,12 +743,14 @@ noncomputable def schroederBernstein {f : α → β} {g : β → α} (hf : Measu
   apply hx
   exact ⟨y, h, rfl⟩
 
+@[simp]
 lemma equivRange_apply (hf : MeasurableEmbedding f) (x : α) :
     hf.equivRange x = ⟨f x, mem_range_self x⟩ := by
   suffices f x = (hf.equivRange x).1 by simp [this]
   simp [MeasurableEmbedding.equivRange, MeasurableEquiv.cast, MeasurableEquiv.Set.univ,
     MeasurableEmbedding.equivImage]
 
+@[simp]
 lemma equivRange_symm_apply_mk (hf : MeasurableEmbedding f) (x : α) :
     hf.equivRange.symm ⟨f x, mem_range_self x⟩ = x := by
   nth_rw 3 [← hf.equivRange.symm_apply_apply x]

--- a/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
@@ -765,7 +765,7 @@ lemma measurable_invFun [Nonempty α] [∀ x, Decidable (x ∈ range f)] (hf : M
   Measurable.dite (by fun_prop) measurable_const hf.measurableSet_range
 
 lemma leftInverse_invFun [Nonempty α] [∀ x, Decidable (x ∈ range f)] (hf : MeasurableEmbedding f) :
-    Function.LeftInverse hf.invFun f := by
+    hf.invFun.LeftInverse f := by
   intro x
   simp only [MeasurableEmbedding.invFun, mem_range, exists_apply_eq_apply, ↓reduceDIte]
   exact hf.equivRange_symm_apply_mk x


### PR DESCRIPTION
Definition of the measurable left inverse of a `MeasurableEmbedding`.

Co-authored-by: Rémy Degenne <remy.degenne@inria.fr>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
