### PR TITLE
[Merged by Bors] - feat(ZMod): add `to_additive_dont_translate`

### DIFF
--- a/Mathlib/Data/ZMod/Basic.lean
+++ b/Mathlib/Data/ZMod/Basic.lean
@@ -1234,35 +1234,17 @@ lemma ZModModule.add_add_add_cancel (x y z : G) : (x + y) + (y + z) = x + z := b
 end two
 end Module
 
-section AddGroup
-variable {α : Type*} [AddGroup α] {n : ℕ}
-
-@[simp]
-lemma nsmul_zmod_val_inv_nsmul (hn : (Nat.card α).gcd n = 1) (a : α) :
-    n • (n⁻¹ : ZMod (Nat.card α)).val • a = a := by
-  replace hn : (Nat.card α).Coprime n := hn
-  rw [← mul_nsmul', ← mod_natCard_nsmul, ← ZMod.val_natCast, Nat.cast_mul,
-    ZMod.mul_val_inv hn.symm, ZMod.val_one_eq_one_mod, mod_natCard_nsmul, one_nsmul]
-
-@[simp]
-lemma zmod_val_inv_nsmul_nsmul (hn : (Nat.card α).gcd n = 1) (a : α) :
-    (n⁻¹ : ZMod (Nat.card α)).val • n • a = a := by
-  rw [nsmul_left_comm, nsmul_zmod_val_inv_nsmul hn]
-
-end AddGroup
-
 section Group
 variable {α : Type*} [Group α] {n : ℕ}
 
--- TODO: we can't use `to_additive`, because it tries to translate `n⁻¹` into `-n`
-@[simp]
+@[to_additive (attr := simp) nsmul_zmod_val_inv_nsmul]
 lemma pow_zmod_val_inv_pow (hn : (Nat.card α).gcd n = 1) (a : α) :
     (a ^ (n⁻¹ : ZMod (Nat.card α)).val) ^ n = a := by
   replace hn : (Nat.card α).Coprime n := hn
   rw [← pow_mul', ← pow_mod_natCard, ← ZMod.val_natCast, Nat.cast_mul, ZMod.mul_val_inv hn.symm,
     ZMod.val_one_eq_one_mod, pow_mod_natCard, pow_one]
 
-@[simp]
+@[to_additive (attr := simp) zmod_val_inv_nsmul_nsmul]
 lemma pow_pow_zmod_val_inv (hn : (Nat.card α).gcd n = 1) (a : α) :
     (a ^ n) ^ (n⁻¹ : ZMod (Nat.card α)).val = a := by rw [pow_right_comm, pow_zmod_val_inv_pow hn]
 

--- a/Mathlib/Data/ZMod/Defs.lean
+++ b/Mathlib/Data/ZMod/Defs.lean
@@ -120,6 +120,7 @@ instance (n : ℕ) [NeZero n] : NeZero (1 : Fin (n + 1)) :=
 end Fin
 
 /-- The integers modulo `n : ℕ`. -/
+@[to_additive_dont_translate]
 def ZMod : ℕ → Type
   | 0 => ℤ
   | n + 1 => Fin (n + 1)


### PR DESCRIPTION
This PR adds the tag `@[to_additive_dont_translate]` to `ZMod`, so that it is treated the same as `ℕ` by `to_additive`. This allows us to use `to_additive` in 2 more places.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
