### PR TITLE
[Merged by Bors] - fix(to_additive): expand projections more often

### DIFF
--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -651,9 +651,9 @@ def expand (e : Expr) : MetaM Expr := do
     | .proj n i s =>
       let some info := getStructureInfo? (← getEnv) n | return .continue -- e.g. if `n` is `Exists`
       let some projName := info.getProjFn? i | unreachable!
-      -- if `projName` requires reordering, replace `f` with the application `projName s`
-      -- and then visit `projName s args` again.
-      if (reorderFn projName).isEmpty then
+      -- if `projName` is explicitly tagged with `@[to_additive]`,
+      -- replace `f` with the application `projName s` and then visit `projName s args` again.
+      if findTranslation? env projName |>.isNone then
         return .continue
       return .visit <| (← whnfD (← inferType s)).withApp fun sf sargs ↦
         mkAppN (mkApp (mkAppN (.const projName sf.constLevels!) sargs) s) args

--- a/MathlibTest/toAdditive.lean
+++ b/MathlibTest/toAdditive.lean
@@ -517,7 +517,7 @@ fun {α} [i : Mul α] a => i.1 a
 #print myMul
 /--
 info: def myAdd : {α : Type} → [i : Add α] → α → α → α :=
-fun {α} [i : Add α] a => i.1 a
+fun {α} [Add α] a => Add.add a
 -/
 #guard_msgs in
 #print myAdd


### PR DESCRIPTION
This PR is a follow-up on #27405, since that PR didn't actually fix the original problem with the proof generated by `@[reassoc]`.

It turns out that we should always expand projections if they have been explicitly tagged with `@[to_additive]` or `@[to_dual]`. In this case, `CategoryTheory.NatTrans.naturality` is not dual to itself, but its dual is proven separately, and tagged with `@[to_dual existing]`. So, we really need to expand the projection.

There is no clear way to tell if a projection has been tagged explicitly,  or automatically when tagging the structure. So, projections are sometimes expanded unnecessarily.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
