### PR TITLE
[Merged by Bors] - fix: fetch depth for master to nightly workflow

### DIFF
--- a/.github/workflows/nightly_merge_master.yml
+++ b/.github/workflows/nightly_merge_master.yml
@@ -19,6 +19,7 @@ jobs:
           ref: nightly-testing
           path: nightly-testing
           token: ${{ secrets.NIGHTLY_TESTING }}
+          fetch-depth: 0
 
       - name: Configure Lean
         uses: leanprover/lean-action@f807b338d95de7813c5c50d018f1c23c9b93b4ec # 2025-04-24


### PR DESCRIPTION
Fixes the fetch depth for the "Merge master to nightly" workflow; we need to have the entire commit history or else we'll have weird unwanted side effects.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
