### PR TITLE
feat: a typeclass for `sSup`/`sInf` to be lawful

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4968,7 +4968,7 @@ import Mathlib.Order.KonigLemma
 import Mathlib.Order.KrullDimension
 import Mathlib.Order.Lattice
 import Mathlib.Order.LatticeIntervals
-import Mathlib.Order.LawfulPreorder
+import Mathlib.Order.LawfulSupInf
 import Mathlib.Order.LiminfLimsup
 import Mathlib.Order.Max
 import Mathlib.Order.MinMax

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4968,6 +4968,7 @@ import Mathlib.Order.KonigLemma
 import Mathlib.Order.KrullDimension
 import Mathlib.Order.Lattice
 import Mathlib.Order.LatticeIntervals
+import Mathlib.Order.LawfulPreorder
 import Mathlib.Order.LiminfLimsup
 import Mathlib.Order.Max
 import Mathlib.Order.MinMax

--- a/Mathlib/Order/CompleteLattice/Defs.lean
+++ b/Mathlib/Order/CompleteLattice/Defs.lean
@@ -3,8 +3,7 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
-import Mathlib.Order.Bounds.Basic
-import Mathlib.Order.SetNotation
+import Mathlib.Order.LawfulSupInf
 
 /-!
 # Definition of complete lattices
@@ -43,12 +42,6 @@ In lemma names,
 open Function OrderDual Set
 
 variable {α β γ : Type*} {ι ι' : Sort*} {κ : ι → Sort*} {κ' : ι' → Sort*}
-
-instance OrderDual.supSet (α) [InfSet α] : SupSet αᵒᵈ :=
-  ⟨(sInf : Set α → α)⟩
-
-instance OrderDual.infSet (α) [SupSet α] : InfSet αᵒᵈ :=
-  ⟨(sSup : Set α → α)⟩
 
 /-- Note that we rarely use `CompleteSemilatticeSup`
 (in fact, any such object is always a `CompleteLattice`, so it's usually best to start there).
@@ -370,3 +363,4 @@ theorem biInf_lt_iff {s : Set β} {f : β → α} : ⨅ i ∈ s, f i < a ↔ ∃
 end CompleteLinearOrder
 
 end
+

--- a/Mathlib/Order/LawfulPreorder.lean
+++ b/Mathlib/Order/LawfulPreorder.lean
@@ -44,8 +44,9 @@ bounds rather than arbitrary elements when a least upper bound exists.
 class LawfulSupPreorder (α) extends Preorder α, SupSet α where
   isLUB_sSup_of_exists_isLUB (s : Set α) : (∃ x, IsLUB s x) → IsLUB s (sSup s)
 
+/-- Defines `sSup` so as to return an arbitrary LUB when it exists, and a default element otherwise. -/
 open Classical in
-noncomputable instance Preorder.toLawfulSupPreorder [Preorder α] [Inhabited α] :
+noncomputable def Preorder.toLawfulSupPreorder [Preorder α] [Inhabited α] :
     LawfulSupPreorder α where
   sSup s := if hs : ∃ x, IsLUB s x then Classical.choose hs else default
   isLUB_sSup_of_exists_isLUB s := by

--- a/Mathlib/Order/LawfulPreorder.lean
+++ b/Mathlib/Order/LawfulPreorder.lean
@@ -29,6 +29,10 @@ whenever they exist.
 - `Preorder.toLawfulInfPreorder`: Any preorder can be made into a lawful inf preorder by defining
   `sInf s` to be any GLB of `s` when one exists.
 - `Preorder.toLawfulPreorder`: Any preorder can therefore be made into a lawful preorder.
+
+## Todo
+
+Redefine the lattice classes `CompleteLattice`, `ConditionallyCompleteLattice`, and `OmegaCompleteLattice` so as to extend the `LawfulPreorder` typeclass.
 -/
 
 variable {α : Type*}

--- a/Mathlib/Order/LawfulPreorder.lean
+++ b/Mathlib/Order/LawfulPreorder.lean
@@ -32,7 +32,8 @@ whenever they exist.
 
 ## Todo
 
-Redefine the lattice classes `CompleteLattice`, `ConditionallyCompleteLattice`, and `OmegaCompleteLattice` so as to extend the `LawfulPreorder` typeclass.
+Redefine the lattice classes `CompleteLattice`, `ConditionallyCompleteLattice`, and
+`OmegaCompleteLattice` so as to extend the `LawfulPreorder` typeclass.
 -/
 
 variable {α : Type*}
@@ -47,7 +48,8 @@ bounds rather than arbitrary elements when a least upper bound exists.
 class LawfulSupPreorder (α) extends Preorder α, SupSet α where
   isLUB_sSup_of_exists_isLUB (s : Set α) : (∃ x, IsLUB s x) → IsLUB s (sSup s)
 
-/-- Defines `sSup` so as to return an arbitrary LUB when it exists, and a default element otherwise. -/
+/-- Defines `sSup` so as to return an arbitrary LUB when it exists, and a default element otherwise.
+-/
 open Classical in
 noncomputable def Preorder.toLawfulSupPreorder [Preorder α] [Inhabited α] :
     LawfulSupPreorder α where
@@ -67,8 +69,10 @@ bounds rather than arbitrary elements when a greatest lower bounds exists.
 class LawfulInfPreorder (α) extends Preorder α, InfSet α where
   isGLB_sInf_of_exists_isGLB (s : Set α) : (∃ x, IsGLB s x) → IsGLB s (sInf s)
 
+/-- Defines `sInf` so as to return an arbitrary GLB when it exists, and a default element otherwise.
+-/
 open Classical in
-noncomputable instance Preorder.toLawfulInfPreorder [Preorder α] [Inhabited α] :
+noncomputable def Preorder.toLawfulInfPreorder [Preorder α] [Inhabited α] :
     LawfulInfPreorder α where
   sInf s := if hs : ∃ x, IsGLB s x then Classical.choose hs else default
   isGLB_sInf_of_exists_isGLB s := by
@@ -81,6 +85,13 @@ A preorder with both lawful suprema and lawful infima.
 -/
 class LawfulPreorder (α) extends LawfulSupPreorder α, LawfulInfPreorder α
 
+/-- Defines `sSup` and `sInf` so as to return an arbitrary LUB and GLB when they exist, and a
+default element otherwise.
+-/
 open Classical in
-noncomputable instance Preorder.toLawfulPreorder [Preorder α] [Inhabited α] :
+noncomputable def Preorder.toLawfulPreorder [Preorder α] [Inhabited α] :
     LawfulPreorder α where
+  sInf := Preorder.toLawfulInfPreorder.sInf
+  sSup := Preorder.toLawfulSupPreorder.sSup
+  isGLB_sInf_of_exists_isGLB := Preorder.toLawfulInfPreorder.isGLB_sInf_of_exists_isGLB
+  isLUB_sSup_of_exists_isLUB := Preorder.toLawfulSupPreorder.isLUB_sSup_of_exists_isLUB

--- a/Mathlib/Order/LawfulPreorder.lean
+++ b/Mathlib/Order/LawfulPreorder.lean
@@ -10,9 +10,31 @@ import Mathlib.Order.Defs.PartialOrder
 variable {α β : Type*}
 
 class LawfulSupPreorder (α) extends Preorder α, SupSet α where
-  isLUB_sSup_of_exists_isLUB (s : Set α) : ∃ x, IsLUB s x → IsLUB s (sSup s)
+  isLUB_sSup_of_exists_isLUB (s : Set α) : (∃ x, IsLUB s x) → IsLUB s (sSup s)
+
+open Classical in
+noncomputable instance Preorder.toLawfulSupPreorder [Preorder α] [Inhabited α] :
+    LawfulSupPreorder α where
+  sSup s := if hs : ∃ x, IsLUB s x then Classical.choose hs else default
+  isLUB_sSup_of_exists_isLUB s := by
+    intro ⟨x, hs⟩
+    rw [dif_pos]
+    exact Classical.choose_spec ⟨x, hs⟩
 
 class LawfulInfPreorder (α) extends Preorder α, InfSet α where
-  isGLB_sInf_of_exists_isGLB (s : Set α) : ∃ x, IsGLB s x → IsGLB s (sInf s)
+  isGLB_sInf_of_exists_isGLB (s : Set α) : (∃ x, IsGLB s x) → IsGLB s (sInf s)
+
+open Classical in
+noncomputable instance Preorder.toLawfulInfPreorder [Preorder α] [Inhabited α] :
+    LawfulInfPreorder α where
+  sInf s := if hs : ∃ x, IsGLB s x then Classical.choose hs else default
+  isGLB_sInf_of_exists_isGLB s := by
+    intro ⟨x, hs⟩
+    rw [dif_pos]
+    exact Classical.choose_spec ⟨x, hs⟩
 
 class LawfulPreorder (α) extends LawfulSupPreorder α, LawfulInfPreorder α
+
+open Classical in
+noncomputable instance Preorder.toLawfulPreorder [Preorder α] [Inhabited α] :
+    LawfulPreorder α where

--- a/Mathlib/Order/LawfulPreorder.lean
+++ b/Mathlib/Order/LawfulPreorder.lean
@@ -7,8 +7,40 @@ import Mathlib.Order.SetNotation
 import Mathlib.Order.Bounds.Defs
 import Mathlib.Order.Defs.PartialOrder
 
-variable {α β : Type*}
+/-!
+# Lawful Suprema and Infima
 
+This file introduces type classes that enforce correctness properties for suprema and infima
+operations on preorders, ensuring they return actual least upper bounds and greatest lower bounds
+whenever they exist.
+
+## Main declarations
+
+
+- `LawfulSupPreorder`: Typeclass ensuring that whenever a set `s` has a least upper bound, `sSup s`
+  returns a least upper bound.
+- `LawfulInfPreorder`: Typeclass ensuring that whenever a set `s` has a greatest lower bound,
+  `sInf s` returns a greatest lower bound.
+- `LawfulPreorder`: Typeclass combining both lawful suprema and infima properties.
+
+## Main statements
+
+- `Preorder.toLawfulSupPreorder`: Any preorder can be made into a lawful sup preorder by defining
+  `sSup s` to be any LUB of `s` when one exists.
+- `Preorder.toLawfulInfPreorder`: Any preorder can be made into a lawful inf preorder by defining
+  `sInf s` to be any GLB of `s` when one exists.
+- `Preorder.toLawfulPreorder`: Any preorder can therefore be made into a lawful preorder.
+-/
+
+variable {α : Type*}
+
+/--
+A preorder with lawful suprema: whenever a set has a least upper bound, `sSup` returns a least upper
+bound for that set.
+
+This ensures that the supremum operation `sSup` behaves correctly by returning actual least upper
+bounds rather than arbitrary elements when a least upper bounds exists.
+-/
 class LawfulSupPreorder (α) extends Preorder α, SupSet α where
   isLUB_sSup_of_exists_isLUB (s : Set α) : (∃ x, IsLUB s x) → IsLUB s (sSup s)
 
@@ -21,6 +53,13 @@ noncomputable instance Preorder.toLawfulSupPreorder [Preorder α] [Inhabited α]
     rw [dif_pos]
     exact Classical.choose_spec ⟨x, hs⟩
 
+/--
+A preorder with lawful infima: whenever a set has a greatest lower bound, `sInf` returns a greastest
+lower bound for that set.
+
+This ensures that the infimum operation `sInf` behaves correctly by returning actual greatest lower
+bounds rather than arbitrary elements when a greatest lower bounds exists.
+-/
 class LawfulInfPreorder (α) extends Preorder α, InfSet α where
   isGLB_sInf_of_exists_isGLB (s : Set α) : (∃ x, IsGLB s x) → IsGLB s (sInf s)
 
@@ -33,6 +72,9 @@ noncomputable instance Preorder.toLawfulInfPreorder [Preorder α] [Inhabited α]
     rw [dif_pos]
     exact Classical.choose_spec ⟨x, hs⟩
 
+/--
+A preorder with both lawful suprema and lawful infima.
+-/
 class LawfulPreorder (α) extends LawfulSupPreorder α, LawfulInfPreorder α
 
 open Classical in

--- a/Mathlib/Order/LawfulPreorder.lean
+++ b/Mathlib/Order/LawfulPreorder.lean
@@ -1,0 +1,18 @@
+/-
+Copyright (c) 2017 Pierre Quinton. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Pierre Quinton
+-/
+import Mathlib.Order.SetNotation
+import Mathlib.Order.Bounds.Defs
+import Mathlib.Order.Defs.PartialOrder
+
+variable {α β : Type*}
+
+class LawfulSupPreorder (α) extends Preorder α, SupSet α where
+  isLUB_sSup_of_exists_isLUB (s : Set α) : ∃ x, IsLUB s x → IsLUB s (sSup s)
+
+class LawfulInfPreorder (α) extends Preorder α, InfSet α where
+  isGLB_sInf_of_exists_isGLB (s : Set α) : ∃ x, IsGLB s x → IsGLB s (sInf s)
+
+class LawfulPreorder (α) extends LawfulSupPreorder α, LawfulInfPreorder α

--- a/Mathlib/Order/LawfulPreorder.lean
+++ b/Mathlib/Order/LawfulPreorder.lean
@@ -16,7 +16,6 @@ whenever they exist.
 
 ## Main declarations
 
-
 - `LawfulSupPreorder`: Typeclass ensuring that whenever a set `s` has a least upper bound, `sSup s`
   returns a least upper bound.
 - `LawfulInfPreorder`: Typeclass ensuring that whenever a set `s` has a greatest lower bound,

--- a/Mathlib/Order/LawfulPreorder.lean
+++ b/Mathlib/Order/LawfulPreorder.lean
@@ -39,7 +39,7 @@ A preorder with lawful suprema: whenever a set has a least upper bound, `sSup` r
 bound for that set.
 
 This ensures that the supremum operation `sSup` behaves correctly by returning actual least upper
-bounds rather than arbitrary elements when a least upper bounds exists.
+bounds rather than arbitrary elements when a least upper bound exists.
 -/
 class LawfulSupPreorder (α) extends Preorder α, SupSet α where
   isLUB_sSup_of_exists_isLUB (s : Set α) : (∃ x, IsLUB s x) → IsLUB s (sSup s)

--- a/Mathlib/Order/LawfulSupInf.lean
+++ b/Mathlib/Order/LawfulSupInf.lean
@@ -3,9 +3,8 @@ Copyright (c) 2017 Pierre Quinton. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Pierre Quinton
 -/
+import Mathlib.Order.Bounds.Basic
 import Mathlib.Order.SetNotation
-import Mathlib.Order.Bounds.Defs
-import Mathlib.Order.Defs.PartialOrder
 
 /-!
 # Lawful Suprema and Infima
@@ -95,3 +94,25 @@ noncomputable def Preorder.toLawfulSupInf [Preorder α] [Inhabited α] :
   sSup := Preorder.toLawfulSup.sSup
   isGLB_sInf_of_exists_isGLB := Preorder.toLawfulInf.isGLB_sInf_of_exists_isGLB
   isLUB_sSup_of_exists_isLUB := Preorder.toLawfulSup.isLUB_sSup_of_exists_isLUB
+
+namespace OrderDual
+
+instance supSet (α) [InfSet α] : SupSet αᵒᵈ :=
+  ⟨(sInf : Set α → α)⟩
+
+instance infSet (α) [SupSet α] : InfSet αᵒᵈ :=
+  ⟨(sSup : Set α → α)⟩
+
+instance instLawfulInf (α) [LawfulSup α] : LawfulInf αᵒᵈ where
+  isGLB_sInf_of_exists_isGLB s := by
+    intro ⟨x, hx⟩
+    exact @LawfulSup.isLUB_sSup_of_exists_isLUB α _ s ⟨x, hx.dual⟩
+
+instance instLawfulSup (α) [LawfulInf α] : LawfulSup αᵒᵈ where
+  isLUB_sSup_of_exists_isLUB s := by
+    intro ⟨x, hx⟩
+    exact @LawfulInf.isGLB_sInf_of_exists_isGLB α _ s ⟨x, hx.dual⟩
+
+instance instLawfulSupInf (α) [LawfulSupInf α] : LawfulSupInf αᵒᵈ where
+
+end OrderDual

--- a/Mathlib/Order/LawfulSupInf.lean
+++ b/Mathlib/Order/LawfulSupInf.lean
@@ -48,9 +48,9 @@ bounds rather than arbitrary elements when a least upper bound exists.
 class LawfulSup (α) extends Preorder α, SupSet α where
   isLUB_sSup_of_exists_isLUB (s : Set α) : (∃ x, IsLUB s x) → IsLUB s (sSup s)
 
+open Classical in
 /-- Defines `sSup` so as to return an arbitrary LUB when it exists, and a default element otherwise.
 -/
-open Classical in
 noncomputable def Preorder.toLawfulSup [Preorder α] [Inhabited α] :
     LawfulSup α where
   sSup s := if hs : ∃ x, IsLUB s x then Classical.choose hs else default
@@ -69,9 +69,9 @@ bounds rather than arbitrary elements when a greatest lower bounds exists.
 class LawfulInf (α) extends Preorder α, InfSet α where
   isGLB_sInf_of_exists_isGLB (s : Set α) : (∃ x, IsGLB s x) → IsGLB s (sInf s)
 
+open Classical in
 /-- Defines `sInf` so as to return an arbitrary GLB when it exists, and a default element otherwise.
 -/
-open Classical in
 noncomputable def Preorder.toLawfulInf [Preorder α] [Inhabited α] :
     LawfulInf α where
   sInf s := if hs : ∃ x, IsGLB s x then Classical.choose hs else default
@@ -85,10 +85,10 @@ A preorder with both lawful suprema and lawful infima.
 -/
 class LawfulSupInf (α) extends LawfulSup α, LawfulInf α
 
+open Classical in
 /-- Defines `sSup` and `sInf` so as to return an arbitrary LUB and GLB when they exist, and a
 default element otherwise.
 -/
-open Classical in
 noncomputable def Preorder.toLawfulSupInf [Preorder α] [Inhabited α] :
     LawfulSupInf α where
   sInf := Preorder.toLawfulInf.sInf

--- a/Mathlib/Order/LawfulSupInf.lean
+++ b/Mathlib/Order/LawfulSupInf.lean
@@ -16,24 +16,24 @@ whenever they exist.
 
 ## Main declarations
 
-- `LawfulSupPreorder`: Typeclass ensuring that whenever a set `s` has a least upper bound, `sSup s`
+- `LawfulSup`: Typeclass ensuring that whenever a set `s` has a least upper bound, `sSup s`
   returns a least upper bound.
-- `LawfulInfPreorder`: Typeclass ensuring that whenever a set `s` has a greatest lower bound,
+- `LawfulInf`: Typeclass ensuring that whenever a set `s` has a greatest lower bound,
   `sInf s` returns a greatest lower bound.
-- `LawfulPreorder`: Typeclass combining both lawful suprema and infima properties.
+- `LawfulSupInf`: Typeclass combining both lawful suprema and infima properties.
 
 ## Main statements
 
-- `Preorder.toLawfulSupPreorder`: Any preorder can be made into a lawful sup preorder by defining
+- `Preorder.toLawfulSup`: Any preorder can be made into a lawful sup preorder by defining
   `sSup s` to be any LUB of `s` when one exists.
-- `Preorder.toLawfulInfPreorder`: Any preorder can be made into a lawful inf preorder by defining
+- `Preorder.toLawfulInf`: Any preorder can be made into a lawful inf preorder by defining
   `sInf s` to be any GLB of `s` when one exists.
-- `Preorder.toLawfulPreorder`: Any preorder can therefore be made into a lawful preorder.
+- `Preorder.toLawfulSupInf`: Any preorder can therefore be made into a lawful preorder.
 
 ## Todo
 
 Redefine the lattice classes `CompleteLattice`, `ConditionallyCompleteLattice`, and
-`OmegaCompleteLattice` so as to extend the `LawfulPreorder` typeclass.
+`OmegaCompleteLattice` so as to extend the `LawfulSupInf` typeclass.
 -/
 
 variable {α : Type*}
@@ -45,14 +45,14 @@ bound for that set.
 This ensures that the supremum operation `sSup` behaves correctly by returning actual least upper
 bounds rather than arbitrary elements when a least upper bound exists.
 -/
-class LawfulSupPreorder (α) extends Preorder α, SupSet α where
+class LawfulSup (α) extends Preorder α, SupSet α where
   isLUB_sSup_of_exists_isLUB (s : Set α) : (∃ x, IsLUB s x) → IsLUB s (sSup s)
 
 /-- Defines `sSup` so as to return an arbitrary LUB when it exists, and a default element otherwise.
 -/
 open Classical in
-noncomputable def Preorder.toLawfulSupPreorder [Preorder α] [Inhabited α] :
-    LawfulSupPreorder α where
+noncomputable def Preorder.toLawfulSup [Preorder α] [Inhabited α] :
+    LawfulSup α where
   sSup s := if hs : ∃ x, IsLUB s x then Classical.choose hs else default
   isLUB_sSup_of_exists_isLUB s := by
     intro ⟨x, hs⟩
@@ -66,14 +66,14 @@ lower bound for that set.
 This ensures that the infimum operation `sInf` behaves correctly by returning actual greatest lower
 bounds rather than arbitrary elements when a greatest lower bounds exists.
 -/
-class LawfulInfPreorder (α) extends Preorder α, InfSet α where
+class LawfulInf (α) extends Preorder α, InfSet α where
   isGLB_sInf_of_exists_isGLB (s : Set α) : (∃ x, IsGLB s x) → IsGLB s (sInf s)
 
 /-- Defines `sInf` so as to return an arbitrary GLB when it exists, and a default element otherwise.
 -/
 open Classical in
-noncomputable def Preorder.toLawfulInfPreorder [Preorder α] [Inhabited α] :
-    LawfulInfPreorder α where
+noncomputable def Preorder.toLawfulInf [Preorder α] [Inhabited α] :
+    LawfulInf α where
   sInf s := if hs : ∃ x, IsGLB s x then Classical.choose hs else default
   isGLB_sInf_of_exists_isGLB s := by
     intro ⟨x, hs⟩
@@ -83,15 +83,15 @@ noncomputable def Preorder.toLawfulInfPreorder [Preorder α] [Inhabited α] :
 /--
 A preorder with both lawful suprema and lawful infima.
 -/
-class LawfulPreorder (α) extends LawfulSupPreorder α, LawfulInfPreorder α
+class LawfulSupInf (α) extends LawfulSup α, LawfulInf α
 
 /-- Defines `sSup` and `sInf` so as to return an arbitrary LUB and GLB when they exist, and a
 default element otherwise.
 -/
 open Classical in
-noncomputable def Preorder.toLawfulPreorder [Preorder α] [Inhabited α] :
-    LawfulPreorder α where
-  sInf := Preorder.toLawfulInfPreorder.sInf
-  sSup := Preorder.toLawfulSupPreorder.sSup
-  isGLB_sInf_of_exists_isGLB := Preorder.toLawfulInfPreorder.isGLB_sInf_of_exists_isGLB
-  isLUB_sSup_of_exists_isLUB := Preorder.toLawfulSupPreorder.isLUB_sSup_of_exists_isLUB
+noncomputable def Preorder.toLawfulSupInf [Preorder α] [Inhabited α] :
+    LawfulSupInf α where
+  sInf := Preorder.toLawfulInf.sInf
+  sSup := Preorder.toLawfulSup.sSup
+  isGLB_sInf_of_exists_isGLB := Preorder.toLawfulInf.isGLB_sInf_of_exists_isGLB
+  isLUB_sSup_of_exists_isLUB := Preorder.toLawfulSup.isLUB_sSup_of_exists_isLUB


### PR DESCRIPTION
Adds lawful infima and suprema type classes.

A preorder with lawful suprema: whenever a set has a least upper bound, `sSup` returns a least upper bound for that set.
A preorder with lawful infima: whenever a set has a greatest lower bound, `sInf` returns a greastest lower bound for that set.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
