### PR TITLE
[Merged by Bors] - feat(LinearAlgebra/TensorProduct/Associator): `lTensor rTensor ∘ assoc = assoc ∘ rTensor lTensor`

### DIFF
--- a/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
@@ -300,13 +300,13 @@ lemma rid_comp_lTensor (f : M →ₗ[R] R) :
     (rid R N).comp (lTensor N f) = lift ((lsmul R N).flip.compl₂ f) := ext' fun _ _ ↦ rfl
 
 lemma lTensor_rTensor_comp_assoc (x : M →ₗ[R] N) :
-    (lTensor P (rTensor Q x)) ∘ₗ (TensorProduct.assoc R P M Q)
-    = (TensorProduct.assoc R P N Q) ∘ₗ (rTensor Q (lTensor P x)) := by
+    lTensor P (rTensor Q x) ∘ₗ TensorProduct.assoc R P M Q
+    = TensorProduct.assoc R P N Q ∘ₗ rTensor Q (lTensor P x) := by
   simp_rw [rTensor, lTensor, map_map_comp_assoc_eq]
 
 lemma rTensor_lTensor_comp_assoc_symm (x : M →ₗ[R] N) :
-    (rTensor Q (lTensor P x)) ∘ₗ (TensorProduct.assoc R P M Q).symm
-    = (TensorProduct.assoc R P N Q).symm ∘ₗ (lTensor P (rTensor Q x)) := by
+    rTensor Q (lTensor P x) ∘ₗ (TensorProduct.assoc R P M Q).symm
+    = (TensorProduct.assoc R P N Q).symm ∘ₗ lTensor P (rTensor Q x) := by
   simp_rw [rTensor, lTensor, map_map_comp_assoc_symm_eq]
 
 end LinearMap

--- a/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
@@ -299,4 +299,14 @@ theorem lid_comp_rTensor (f : N →ₗ[R] R) :
 lemma rid_comp_lTensor (f : M →ₗ[R] R) :
     (rid R N).comp (lTensor N f) = lift ((lsmul R N).flip.compl₂ f) := ext' fun _ _ ↦ rfl
 
+lemma lTensor_rTensor_comp_assoc (x : M →ₗ[R] N) :
+    (lTensor _ (rTensor _ x)) ∘ₗ (TensorProduct.assoc R _ _ _).toLinearMap
+    = (TensorProduct.assoc R P N Q).toLinearMap ∘ₗ (rTensor _ (lTensor _ x)) := by
+  simp_rw [rTensor, lTensor, map_map_comp_assoc_eq]
+
+lemma rTensor_lTensor_comp_assoc_symm (x : M →ₗ[R] N) :
+    (rTensor _ (lTensor _ x)) ∘ₗ (TensorProduct.assoc R _ _ _).symm.toLinearMap
+    = (TensorProduct.assoc R P N Q).symm.toLinearMap ∘ₗ (lTensor _ (rTensor _ x)) := by
+  simp_rw [rTensor, lTensor, map_map_comp_assoc_symm_eq]
+
 end LinearMap

--- a/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Associator.lean
@@ -300,13 +300,13 @@ lemma rid_comp_lTensor (f : M →ₗ[R] R) :
     (rid R N).comp (lTensor N f) = lift ((lsmul R N).flip.compl₂ f) := ext' fun _ _ ↦ rfl
 
 lemma lTensor_rTensor_comp_assoc (x : M →ₗ[R] N) :
-    (lTensor _ (rTensor _ x)) ∘ₗ (TensorProduct.assoc R _ _ _).toLinearMap
-    = (TensorProduct.assoc R P N Q).toLinearMap ∘ₗ (rTensor _ (lTensor _ x)) := by
+    (lTensor P (rTensor Q x)) ∘ₗ (TensorProduct.assoc R P M Q)
+    = (TensorProduct.assoc R P N Q) ∘ₗ (rTensor Q (lTensor P x)) := by
   simp_rw [rTensor, lTensor, map_map_comp_assoc_eq]
 
 lemma rTensor_lTensor_comp_assoc_symm (x : M →ₗ[R] N) :
-    (rTensor _ (lTensor _ x)) ∘ₗ (TensorProduct.assoc R _ _ _).symm.toLinearMap
-    = (TensorProduct.assoc R P N Q).symm.toLinearMap ∘ₗ (lTensor _ (rTensor _ x)) := by
+    (rTensor Q (lTensor P x)) ∘ₗ (TensorProduct.assoc R P M Q).symm
+    = (TensorProduct.assoc R P N Q).symm ∘ₗ (lTensor P (rTensor Q x)) := by
   simp_rw [rTensor, lTensor, map_map_comp_assoc_symm_eq]
 
 end LinearMap


### PR DESCRIPTION
This adds `LinearMap.lTensor_rTensor_comp_assoc` and `LinearMap.rTensor_lTensor_comp_assoc_symm`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
