### PR TITLE
[Merged by Bors] - fix: do not remove reactions if the corresponding label is still present on the PR

### DIFF
--- a/.github/workflows/zulip_emoji_labelling.yaml
+++ b/.github/workflows/zulip_emoji_labelling.yaml
@@ -40,6 +40,7 @@ jobs:
         PR_NUMBER: ${{ github.event.number}}
         LABEL_STATUS: ${{ github.event.action }}
         LABEL_NAME: ${{ github.event.label.name }}
+        PR_LABELS: ${{ github.event.pull_request.labels.*.name }}
       run: |
-        printf $'Running the python script with pr "%s"\n' "$PR_NUMBER" "$LABEL_STATUS" "$LABEL"
-        python scripts/zulip_emoji_reactions.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "$LABEL_STATUS" "$LABEL_NAME" "$PR_NUMBER"
+        printf $'Running the python script with pr "%s"\n' "$PR_NUMBER" "$LABEL_STATUS" "$LABEL" "$PR_LABELS"
+        python scripts/zulip_emoji_reactions.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "$LABEL_STATUS" "$LABEL_NAME" "$PR_NUMBER" "$PR_LABELS"

--- a/.github/workflows/zulip_emoji_labelling.yaml
+++ b/.github/workflows/zulip_emoji_labelling.yaml
@@ -40,7 +40,7 @@ jobs:
         PR_NUMBER: ${{ github.event.number}}
         LABEL_STATUS: ${{ github.event.action }}
         LABEL_NAME: ${{ github.event.label.name }}
-        PR_LABELS: ${{ github.event.pull_request.labels.*.name }}
+        PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
       run: |
         printf $'Running the python script with pr "%s"\n' "$PR_NUMBER" "$LABEL_STATUS" "$LABEL" "$PR_LABELS"
         python scripts/zulip_emoji_reactions.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "$LABEL_STATUS" "$LABEL_NAME" "$PR_NUMBER" "$PR_LABELS"

--- a/.github/workflows/zulip_emoji_labelling.yaml
+++ b/.github/workflows/zulip_emoji_labelling.yaml
@@ -42,5 +42,5 @@ jobs:
         LABEL_NAME: ${{ github.event.label.name }}
         PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
       run: |
-        printf $'Running the python script with pr "%s"\n' "$PR_NUMBER" "$LABEL_STATUS" "$LABEL" "$PR_LABELS"
+        printf $'Running the python script with:\nPR number: "%s"\nlabel status: "%s"\nlabel: "%s"\nPR labels: "%s"\n' "$PR_NUMBER" "$LABEL_STATUS" "$LABEL" "$PR_LABELS"
         python scripts/zulip_emoji_reactions.py "$ZULIP_API_KEY" "$ZULIP_EMAIL" "$ZULIP_SITE" "$LABEL_STATUS" "$LABEL_NAME" "$PR_NUMBER" "$PR_LABELS"

--- a/scripts/zulip_emoji_reactions.py
+++ b/scripts/zulip_emoji_reactions.py
@@ -115,8 +115,8 @@ for message in messages:
 
         def remove_reaction(name: str, emoji_name: str, label_name: str, **kwargs) -> None:
             # We do not remove an emoji if the corresponding label is still present.
-            print(f'Removing {name}')
             if label_name not in PR_LABELS:
+                print(f'Removing {name}')
                 result = client.remove_reaction({
                     "message_id": message['id'],
                     "emoji_name": emoji_name,
@@ -143,7 +143,11 @@ for message in messages:
 
         # We should never remove any "this PR was migrated from a fork" reaction.
 
-        # Otherwise, remove all previous mutually exclusive emoji reactions.
+        # Otherwise, remove all previous mutually exclusive emoji reactions (unless
+        # PR_LABELS contains the corresponding label).
+        # Note that the 'merge' and 'closed-pr' reactions do not have a corresponding label,
+        # so we pass the empty string (which should never be in PR_LABELS) so that they are
+        # always removed.
         # If the emoji is a custom emoji, add the fields `emoji_code` and `reaction_type` as well.
         print("Removing previous reactions, if present.")
         if has_peace_sign:

--- a/scripts/zulip_emoji_reactions.py
+++ b/scripts/zulip_emoji_reactions.py
@@ -41,8 +41,9 @@ try:
     PR_LABELS = json.loads(PR_LABELS)
     assert isinstance(PR_LABELS, list)
 except:
-    print(f"parsing PR_LABELS failed; setting to None")
-    PR_LABELS = None
+    print(f"parsing PR_LABELS failed; setting to empty list")
+    # an empty list is a good default since we remove reactions if the label is `not in PR_LABELS`
+    PR_LABELS = []
 print(f"PR_LABELS: '{PR_LABELS}'")
 
 # Initialize Zulip client
@@ -114,7 +115,7 @@ for message in messages:
         print(f"matched: '{message}'")
 
         def remove_reaction(name: str, emoji_name: str, label_name: str, **kwargs) -> None:
-            # We do not remove an emoji if the corresponding label is still present.
+            # We only remove the emoji if the corresponding label is not present.
             if label_name not in PR_LABELS:
                 print(f'Removing {name}')
                 result = client.remove_reaction({
@@ -138,7 +139,7 @@ for message in messages:
             if ACTION == "labeled":
                 add_reaction('maintainer-merge', 'hammer')
             elif ACTION == "unlabeled":
-                remove_reaction('maintainer-merge', 'hammer')
+                remove_reaction('maintainer-merge', 'hammer', 'maintainer-merge')
             continue
 
         # We should never remove any "this PR was migrated from a fork" reaction.


### PR DESCRIPTION
Recently the reaction bot on Zulip has been observed to add a reaction and then remove it shortly afterwards (mainly the reactions corresponding to the `ready-to-merge` and `delegated` labels). The mechanism seems to be the following:
- a maintainer writes a comment like "bors merge" (or "bors d+") on a PR that has been `maintainer-merge`'d
- `zulip_emoji_merge_delegate.yaml` and `zulip_emoji_merge_delegate_wf.yaml` react to this comment and:
  - simultaneously adds the "ready-to-merge" and removes the `maintainer-merge` label
  - adds the "merge" emoji reaction on Zulip
- the `zulip_emoji_labelling.yaml` workflow reacts to the `maintainer-merge` label being removed, and clears the "merge" emoji as well. See [this log](https://github.com/leanprover-community/mathlib4/actions/runs/16270158496/job/45935446666#step:5:30) (which removes the "delegated" emoji).

We change the `zulip_emoji_labelling.yaml` workflow so that it passes the current list of labels on the PR to the `zulip_emoji_reactions.py` script, and also change the script so that it only removes a reaction if the corresponding label is NOT present.

cf. https://leanprover.zulipchat.com/#narrow/channel/345428-mathlib-reviewers/topic/merge.2Fdelegate.20emojis.20bot/near/528289834

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
