### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/Matrix/Ideal): deprecate `matricesOver`

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/Ideal.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Ideal.lean
@@ -18,9 +18,9 @@ We also characterize Jacobson radicals of ideals in such rings.
 
 ## Main results
 
-* `TwoSidedIdeal.equivMatricesOver` and `TwoSidedIdeal.orderIsoMatricesOver`
+* `TwoSidedIdeal.equivMatrix` and `TwoSidedIdeal.orderIsoMatrix`
   establish an order isomorphism between two-sided ideals in $R$ and those in $Mₙ(R)$.
-* `TwoSidedIdeal.jacobson_matricesOver` shows that $J(Mₙ(I)) = Mₙ(J(I))$
+* `TwoSidedIdeal.jacobson_matrix` shows that $J(Mₙ(I)) = Mₙ(J(I))$
   for any two-sided ideal $I ≤ R$.
 -/
 
@@ -33,7 +33,7 @@ variable {R : Type*} [Semiring R]
          (n : Type*) [Fintype n] [DecidableEq n]
 
 /-- The left ideal of matrices with entries in `I ≤ R`. -/
-def matricesOver (I : Ideal R) : Ideal (Matrix n n R) where
+def matrix (I : Ideal R) : Ideal (Matrix n n R) where
   __ := I.toAddSubmonoid.matrix
   smul_mem' M N hN := by
     intro i j
@@ -42,31 +42,44 @@ def matricesOver (I : Ideal R) : Ideal (Matrix n n R) where
     intro k _
     apply I.mul_mem_left _ (hN k j)
 
-@[simp]
-theorem mem_matricesOver (I : Ideal R) (M : Matrix n n R) :
-    M ∈ I.matricesOver n ↔ ∀ i j, M i j ∈ I := by rfl
+@[deprecated (since := "2025-07-28")] alias matricesOver := matrix
 
-theorem matricesOver_monotone : Monotone (matricesOver (R := R) n) :=
+@[simp]
+theorem mem_matrix (I : Ideal R) (M : Matrix n n R) :
+    M ∈ I.matrix n ↔ ∀ i j, M i j ∈ I := by rfl
+
+@[deprecated (since := "2025-07-28")] alias mem_matricesOver := mem_matrix
+
+theorem matrix_monotone : Monotone (matrix (R := R) n) :=
   fun _ _ IJ _ MI i j => IJ (MI i j)
 
-theorem matricesOver_strictMono_of_nonempty [Nonempty n] :
-    StrictMono (matricesOver (R := R) n) :=
-  matricesOver_monotone n |>.strictMono_of_injective <| fun I J eq => by
+@[deprecated (since := "2025-07-28")] alias matricesOver_monotone := matrix_monotone
+
+theorem matrix_strictMono_of_nonempty [Nonempty n] :
+    StrictMono (matrix (R := R) n) :=
+  matrix_monotone n |>.strictMono_of_injective <| fun I J eq => by
     ext x
     have : (∀ _ _, x ∈ I) ↔ (∀ _ _, x ∈ J) := congr((Matrix.of fun _ _ => x) ∈ $eq)
     simpa only [forall_const] using this
 
+@[deprecated (since := "2025-07-28")] alias matricesOver_strictMono_of_nonempty :=
+matrix_strictMono_of_nonempty
+
 @[simp]
-theorem matricesOver_bot : (⊥ : Ideal R).matricesOver n = ⊥ := by
+theorem matrix_bot : (⊥ : Ideal R).matrix n = ⊥ := by
   ext M
-  simp only [mem_matricesOver, mem_bot]
+  simp only [mem_matrix, mem_bot]
   constructor
   · intro H; ext; apply H
   · intro H; simp [H]
 
+@[deprecated (since := "2025-07-28")] alias matricesOver_bot := matrix_bot
+
 @[simp]
-theorem matricesOver_top : (⊤ : Ideal R).matricesOver n = ⊤ := by
+theorem matrix_top : (⊤ : Ideal R).matrix n = ⊤ := by
   ext; simp
+
+@[deprecated (since := "2025-07-28")] alias matricesOver_top := matrix_top
 
 end Ideal
 
@@ -79,8 +92,8 @@ variable {R : Type*} [Ring R] {n : Type*} [Fintype n] [DecidableEq n]
 
 /-- A standard basis matrix is in $J(Mₙ(I))$
 as long as its one possibly non-zero entry is in $J(I)$. -/
-theorem single_mem_jacobson_matricesOver (I : Ideal R) :
-    ∀ x ∈ I.jacobson, ∀ (i j : n), single i j x ∈ (I.matricesOver n).jacobson := by
+theorem single_mem_jacobson_matrix (I : Ideal R) :
+    ∀ x ∈ I.jacobson, ∀ (i j : n), single i j x ∈ (I.matrix n).jacobson := by
   -- Proof generalized from example 8 in
   -- https://ysharifi.wordpress.com/2022/08/16/the-jacobson-radical-basic-examples/
   simp_rw [Ideal.mem_jacobson_iff]
@@ -98,18 +111,23 @@ theorem single_mem_jacobson_matricesOver (I : Ideal R) :
   · simp [N, qj, sum_apply, mul_apply]
 
 @[deprecated (since := "2025-05-05")]
-alias stdBasisMatrix_mem_jacobson_matricesOver := single_mem_jacobson_matricesOver
+alias stdBasisMatrix_mem_jacobson_matricesOver := single_mem_jacobson_matrix
+
+@[deprecated (since := "2025-07-28")] alias single_mem_jacobson_matricesOver :=
+single_mem_jacobson_matrix
 
 /-- For any left ideal $I ≤ R$, we have $Mₙ(J(I)) ≤ J(Mₙ(I))$. -/
-theorem matricesOver_jacobson_le (I : Ideal R) :
-    I.jacobson.matricesOver n ≤ (I.matricesOver n).jacobson := by
+theorem matrix_jacobson_le (I : Ideal R) :
+    I.jacobson.matrix n ≤ (I.matrix n).jacobson := by
   intro M MI
   rw [matrix_eq_sum_single M]
   apply sum_mem
   intro i _
   apply sum_mem
   intro j _
-  apply single_mem_jacobson_matricesOver I _ (MI i j)
+  apply single_mem_jacobson_matrix I _ (MI i j)
+
+@[deprecated (since := "2025-07-28")] alias matricesOver_jacobson_le := matrix_jacobson_le
 
 end Ideal
 
@@ -249,28 +267,41 @@ variable [NonUnitalNonAssocRing R] [Fintype n]
 
 /-- The two-sided ideal of matrices with entries in `I ≤ R`. -/
 @[simps]
-def matricesOver (I : TwoSidedIdeal R) : TwoSidedIdeal (Matrix n n R) where
+def matrix (I : TwoSidedIdeal R) : TwoSidedIdeal (Matrix n n R) where
   ringCon := I.ringCon.matrix n
 
-@[simp]
-lemma mem_matricesOver (I : TwoSidedIdeal R) (M : Matrix n n R) :
-    M ∈ I.matricesOver n ↔ ∀ i j, M i j ∈ I := Iff.rfl
+@[deprecated (since := "2025-07-28")] alias matricesOver := matrix
 
-theorem matricesOver_monotone : Monotone (matricesOver (R := R) n) :=
+@[simp]
+lemma mem_matrix (I : TwoSidedIdeal R) (M : Matrix n n R) :
+    M ∈ I.matrix n ↔ ∀ i j, M i j ∈ I := Iff.rfl
+
+@[deprecated (since := "2025-07-28")] alias mem_matricesOver := mem_matrix
+
+theorem matrix_monotone : Monotone (matrix (R := R) n) :=
   fun _ _ IJ _ MI i j => IJ (MI i j)
 
-theorem matricesOver_strictMono_of_nonempty [h : Nonempty n] :
-    StrictMono (matricesOver (R := R) n) :=
-  matricesOver_monotone n |>.strictMono_of_injective <|
+@[deprecated (since := "2025-07-28")] alias matricesOver_monotone := matrix_monotone
+
+theorem matrix_strictMono_of_nonempty [h : Nonempty n] :
+    StrictMono (matrix (R := R) n) :=
+  matrix_monotone n |>.strictMono_of_injective <|
     .comp (fun _ _ => mk.inj) <| (RingCon.matrix_injective n).comp ringCon_injective
 
-@[simp]
-theorem matricesOver_bot : (⊥ : TwoSidedIdeal R).matricesOver n = ⊥ :=
-  ringCon_injective <| RingCon.matrix_bot _
+@[deprecated (since := "2025-07-28")] alias matricesOver_strictMono_of_nonempty :=
+matrix_strictMono_of_nonempty
 
 @[simp]
-theorem matricesOver_top : (⊤ : TwoSidedIdeal R).matricesOver n = ⊤ :=
+theorem matrix_bot : (⊥ : TwoSidedIdeal R).matrix n = ⊥ :=
+  ringCon_injective <| RingCon.matrix_bot _
+
+@[deprecated (since := "2025-07-28")] alias matricesOver_bot := matrix_bot
+
+@[simp]
+theorem matrix_top : (⊤ : TwoSidedIdeal R).matrix n = ⊤ :=
   ringCon_injective <| RingCon.matrix_top _
+
+@[deprecated (since := "2025-07-28")] alias matricesOver_top := matrix_top
 
 end NonUnitalNonAssocRing
 
@@ -285,33 +316,38 @@ Given an ideal $I ≤ R$, we send it to $Mₙ(I)$.
 Given an ideal $J ≤ Mₙ(R)$, we send it to $\{Nᵢⱼ ∣ ∃ N ∈ J\}$.
 -/
 @[simps]
-def equivMatricesOver [Nonempty n] [DecidableEq n] :
+def equivMatrix [Nonempty n] [DecidableEq n] :
     TwoSidedIdeal R ≃ TwoSidedIdeal (Matrix n n R) where
-  toFun I := I.matricesOver n
+  toFun I := I.matrix n
   invFun J := { ringCon := J.ringCon.ofMatrix }
   right_inv _ := ringCon_injective <| RingCon.matrix_ofMatrix _
   left_inv _ := ringCon_injective <| RingCon.ofMatrix_matrix _
 
-theorem coe_equivMatricesOver_symm_apply (I : TwoSidedIdeal (Matrix n n R)) (i j : n) :
-    equivMatricesOver.symm I = {N i j | N ∈ I} := by
+@[deprecated (since := "2025-07-28")] alias equivMatricesOver := equivMatrix
+
+theorem coe_equivMatrix_symm_apply (I : TwoSidedIdeal (Matrix n n R)) (i j : n) :
+    equivMatrix.symm I = {N i j | N ∈ I} := by
   ext r
   constructor
   · intro h
     exact ⟨single i j r, by simpa using h i j, by simp⟩
   · rintro ⟨n, hn, rfl⟩
-    rw [SetLike.mem_coe, mem_iff, equivMatricesOver_symm_apply_ringCon,
+    rw [SetLike.mem_coe, mem_iff, equivMatrix_symm_apply_ringCon,
       RingCon.coe_ofMatrix_eq_relationMap i j]
     exact ⟨n, 0, (I.mem_iff n).mp hn, rfl, rfl⟩
 
+@[deprecated (since := "2025-07-28")] alias coe_equivMatricesOver_symm_apply :=
+coe_equivMatrix_symm_apply
+
 /--
 Two-sided ideals in $R$ are order-isomorphic with those in $Mₙ(R)$.
-See also `equivMatricesOver`.
+See also `equivMatrix`.
 -/
 @[simps!]
-def orderIsoMatricesOver : TwoSidedIdeal R ≃o TwoSidedIdeal (Matrix n n R) where
-  __ := equivMatricesOver
+def orderIsoMatrix : TwoSidedIdeal R ≃o TwoSidedIdeal (Matrix n n R) where
+  __ := equivMatrix
   map_rel_iff' {I J} := by
-    simp only [equivMatricesOver_apply]
+    simp only [equivMatrix_apply]
     constructor
     · intro le x xI
       specialize @le (of fun _ _ => x) (by simp [xI])
@@ -319,14 +355,18 @@ def orderIsoMatricesOver : TwoSidedIdeal R ≃o TwoSidedIdeal (Matrix n n R) whe
     · intro IJ M MI i j
       exact IJ <| MI i j
 
+@[deprecated (since := "2025-07-28")] alias orderIsoMatricesOver := orderIsoMatrix
+
 end NonAssocRing
 
 section Ring
 variable [Ring R] [Fintype n]
 
-theorem asIdeal_matricesOver [DecidableEq n] (I : TwoSidedIdeal R) :
-    asIdeal (I.matricesOver n) = (asIdeal I).matricesOver n := by
+theorem asIdeal_matrix [DecidableEq n] (I : TwoSidedIdeal R) :
+    asIdeal (I.matrix n) = (asIdeal I).matrix n := by
   ext; simp
+
+@[deprecated (since := "2025-07-28")] alias asIdeal_matricesOver := asIdeal_matrix
 
 end Ring
 
@@ -339,8 +379,8 @@ open Matrix
 
 variable {R : Type*} [Ring R] {n : Type*} [Fintype n] [DecidableEq n]
 
-private lemma jacobson_matricesOver_le (I : TwoSidedIdeal R) :
-    (I.matricesOver n).jacobson ≤ I.jacobson.matricesOver n := by
+private lemma jacobson_matrix_le (I : TwoSidedIdeal R) :
+    (I.matrix n).jacobson ≤ I.jacobson.matrix n := by
   -- Proof generalized from example 8 in
   -- https://ysharifi.wordpress.com/2022/08/16/the-jacobson-radical-basic-examples/
   intro M Mmem p q
@@ -354,16 +394,22 @@ private lemma jacobson_matricesOver_le (I : TwoSidedIdeal R) :
   use N p p
   simpa [mul_apply, single, ite_and] using NxMI p p
 
-/-- For any two-sided ideal $I ≤ R$, we have $J(Mₙ(I)) = Mₙ(J(I))$. -/
-theorem jacobson_matricesOver (I : TwoSidedIdeal R) :
-    (I.matricesOver n).jacobson = I.jacobson.matricesOver n := by
-  apply le_antisymm
-  · apply jacobson_matricesOver_le
-  · change asIdeal (I.matricesOver n).jacobson ≥ asIdeal (I.jacobson.matricesOver n)
-    simp [asIdeal_jacobson, asIdeal_matricesOver, Ideal.matricesOver_jacobson_le]
+@[deprecated (since := "2025-07-28")] alias jacobson_matricesOver_le := jacobson_matrix_le
 
-theorem matricesOver_jacobson_bot :
-    (⊥ : TwoSidedIdeal R).jacobson.matricesOver n = (⊥ : TwoSidedIdeal (Matrix n n R)).jacobson :=
-  matricesOver_bot n (R := R) ▸ (jacobson_matricesOver _).symm
+/-- For any two-sided ideal $I ≤ R$, we have $J(Mₙ(I)) = Mₙ(J(I))$. -/
+theorem jacobson_matrix (I : TwoSidedIdeal R) :
+    (I.matrix n).jacobson = I.jacobson.matrix n := by
+  apply le_antisymm
+  · apply jacobson_matrix_le
+  · change asIdeal (I.matrix n).jacobson ≥ asIdeal (I.jacobson.matrix n)
+    simp [asIdeal_jacobson, asIdeal_matrix, Ideal.matrix_jacobson_le]
+
+@[deprecated (since := "2025-07-28")] alias jacobson_matricesOver := jacobson_matrix
+
+theorem matrix_jacobson_bot :
+    (⊥ : TwoSidedIdeal R).jacobson.matrix n = (⊥ : TwoSidedIdeal (Matrix n n R)).jacobson :=
+  matrix_bot n (R := R) ▸ (jacobson_matrix _).symm
+
+@[deprecated (since := "2025-07-28")] alias matricesOver_jacobson_bot := matrix_jacobson_bot
 
 end TwoSidedIdeal

--- a/Mathlib/RingTheory/SimpleRing/Matrix.lean
+++ b/Mathlib/RingTheory/SimpleRing/Matrix.lean
@@ -15,6 +15,6 @@ namespace IsSimpleRing
 variable (ι A : Type*) [Ring A] [Fintype ι] [Nonempty ι]
 
 instance matrix [IsSimpleRing A] : IsSimpleRing (Matrix ι ι A) where
-  simple := letI := Classical.decEq ι; TwoSidedIdeal.orderIsoMatricesOver |>.symm.isSimpleOrder
+  simple := letI := Classical.decEq ι; TwoSidedIdeal.orderIsoMatrix |>.symm.isSimpleOrder
 
 end IsSimpleRing


### PR DESCRIPTION
`Ideal.matricesOver` is not an ideal name - one should use `matrix` instead of `matricesOver`, see also #27190 where the analogous `Set.matrix`, `Subring.matrix`, etc are defined. 

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Set.2Ematrix/near/527826651)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
