### PR TITLE
[Merged by Bors] - feat(Data/Fin/Tuple): lemmas on appending finite sequences

### DIFF
--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -304,14 +304,14 @@ theorem append_right (u : Fin m → α) (v : Fin n → α) (i : Fin n) :
 
 /-- Appending two sequences v and w, and then extracting the initial part
 (i.e., the less than part), gives back the original first sequence v. -/
-theorem append_apply_lt (v : Fin m → α) (w : Fin n → α) (i : Fin (m + n)) (h : ↑i < m) :
+theorem append_apply_of_lt (v : Fin m → α) (w : Fin n → α) (i : Fin (m + n)) (h : ↑i < m) :
     append v w i = v ⟨↑i, h⟩ := by
   rw [← append_left v w]
   rfl
 
 /-- Appending two sequences v and w, and then extracting final part
 (i.e., the greater than or equal part), gives back the original second sequence w. -/
-theorem append_apply_ge (v : Fin m → α) (w : Fin n → α) (i : Fin (m + n)) (h : m ≤ ↑i) :
+theorem append_apply_of_ge (v : Fin m → α) (w : Fin n → α) (i : Fin (m + n)) (h : m ≤ ↑i) :
     append v w i = w ⟨↑i - m, Nat.sub_lt_left_of_lt_add h i.isLt⟩ := by
   rw [← append_right v w]
   congr!
@@ -403,7 +403,7 @@ theorem append_castAdd_natAdd {f : Fin (m + n) → α} :
 
 /-- Splitting a dependent finite sequence v into an initial part and a final part,
 and then concatenating these components, produces an identical sequence. -/
-theorem addCases_apply_pi {γ : Fin (m + n) → Sort*} (v : (i : Fin (m + n)) → γ i) :
+theorem addCases_castAdd_natAdd {γ : Fin (m + n) → Sort*} (v : ∀ i, γ i) :
     addCases (fun i ↦ v (castAdd n i)) (fun j ↦ v (natAdd m j)) = v := by
   ext i
   cases i using addCases <;> simp
@@ -811,7 +811,7 @@ theorem forall_fin_add {m n} (P : Fin (m + n) → Prop) :
 
 /-- A property holds for all dependent finite sequence of length m + n iff
 it holds for the concatenation of all pairs of length m sequences and length n sequences. -/
-theorem forall_fin_add_pi {γ : Fin (m + n) → Sort*} {P : ((i : Fin (m + n)) → γ i) → Prop} :
+theorem forall_fin_add_pi {γ : Fin (m + n) → Sort*} {P : (∀ i, γ i) → Prop} :
     (∀ v, P v) ↔ (∀ (vₘ : (i : Fin m) → γ (castAdd n i))
       (vₙ : (j : Fin n) → γ (natAdd m j)), P (addCases vₘ vₙ)) := by
   constructor
@@ -821,7 +821,7 @@ theorem forall_fin_add_pi {γ : Fin (m + n) → Sort*} {P : ((i : Fin (m + n)) �
   · -- ∀ vₘ vₙ, P(addCases vₘ vₙ) → ∀ v, P(v)
     intro h v
     convert h (fun i => v (castAdd n i)) (fun j => v (natAdd m j))
-    exact (addCases_apply_pi v).symm
+    exact (addCases_castAdd_natAdd v).symm
 
 lemma exists_iff_castSucc {P : Fin (n + 1) → Prop} :
     (∃ i, P i) ↔ P (last n) ∨ ∃ i : Fin n, P i.castSucc where

--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -813,13 +813,11 @@ theorem forall_fin_add {m n} (P : Fin (m + n) → Prop) :
 it holds for the concatenation of all pairs of length m sequences and length n sequences. -/
 theorem forall_fin_add_pi {γ : Fin (m + n) → Sort*} {P : (∀ i, γ i) → Prop} :
     (∀ v, P v) ↔ (∀ (vₘ : (i : Fin m) → γ (castAdd n i))
-      (vₙ : (j : Fin n) → γ (natAdd m j)), P (addCases vₘ vₙ)) := by
-  constructor
-  · -- ∀ v, P(v) → ∀ vₘ vₙ, P(addCases vₘ vₙ)
-    intro hv hvm hvn
-    exact hv fun i ↦ addCases hvm hvn i
-  · -- ∀ vₘ vₙ, P(addCases vₘ vₙ) → ∀ v, P(v)
-    intro h v
+      (vₙ : (j : Fin n) → γ (natAdd m j)), P (addCases vₘ vₙ)) where
+  -- ∀ v, P(v) → ∀ vₘ vₙ, P(addCases vₘ vₙ)
+  mp hv vm vn := hv (addCases vm vn)
+  -- ∀ vₘ vₙ, P(addCases vₘ vₙ) → ∀ v, P(v)
+  mpr h v := by
     convert h (fun i => v (castAdd n i)) (fun j => v (natAdd m j))
     exact (addCases_castAdd_natAdd v).symm
 

--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -302,21 +302,6 @@ theorem append_right (u : Fin m → α) (v : Fin n → α) (i : Fin n) :
     append u v (natAdd m i) = v i :=
   addCases_right _
 
-/-- Appending two sequences v and w, and then extracting the initial part
-(i.e., the less than part), gives back the original first sequence v. -/
-theorem append_apply_of_lt (v : Fin m → α) (w : Fin n → α) (i : Fin (m + n)) (h : ↑i < m) :
-    append v w i = v ⟨↑i, h⟩ := by
-  rw [← append_left v w]
-  rfl
-
-/-- Appending two sequences v and w, and then extracting final part
-(i.e., the greater than or equal part), gives back the original second sequence w. -/
-theorem append_apply_of_ge (v : Fin m → α) (w : Fin n → α) (i : Fin (m + n)) (h : m ≤ ↑i) :
-    append v w i = w ⟨↑i - m, Nat.sub_lt_left_of_lt_add h i.isLt⟩ := by
-  rw [← append_right v w]
-  congr!
-  exact Fin.ext (Nat.add_sub_of_le h).symm
-
 theorem append_right_nil (u : Fin m → α) (v : Fin n → α) (hv : n = 0) :
     append u v = u ∘ Fin.cast (by rw [hv, Nat.add_zero]) := by
   refine funext (Fin.addCases (fun l => ?_) fun r => ?_)

--- a/Mathlib/Data/Fin/Tuple/Basic.lean
+++ b/Mathlib/Data/Fin/Tuple/Basic.lean
@@ -806,17 +806,15 @@ lemma forall_iff_castSucc {P : Fin (n + 1) → Prop} :
 /-- A finite sequence of properties P holds for {0 , ... , m + n - 1} iff
 it holds separately for both {0 , ... , m - 1} and {m, ..., m + n - 1}. -/
 theorem forall_fin_add {m n} (P : Fin (m + n) → Prop) :
-    (∀ i, P i) ↔ (∀ i, P (castAdd _ i)) ∧ (∀ i, P (natAdd _ i)) :=
+    (∀ i, P i) ↔ (∀ i, P (castAdd _ i)) ∧ (∀ j, P (natAdd _ j)) :=
   ⟨fun h => ⟨fun _ => h _, fun _ => h _⟩, fun ⟨hm, hn⟩ => Fin.addCases hm hn⟩
 
 /-- A property holds for all dependent finite sequence of length m + n iff
 it holds for the concatenation of all pairs of length m sequences and length n sequences. -/
 theorem forall_fin_add_pi {γ : Fin (m + n) → Sort*} {P : (∀ i, γ i) → Prop} :
-    (∀ v, P v) ↔ (∀ (vₘ : (i : Fin m) → γ (castAdd n i))
-      (vₙ : (j : Fin n) → γ (natAdd m j)), P (addCases vₘ vₙ)) where
-  -- ∀ v, P(v) → ∀ vₘ vₙ, P(addCases vₘ vₙ)
+    (∀ v, P v) ↔
+      (∀ (vₘ : ∀ i, γ (castAdd n i)) (vₙ : ∀ j, γ (natAdd m j)), P (addCases vₘ vₙ)) where
   mp hv vm vn := hv (addCases vm vn)
-  -- ∀ vₘ vₙ, P(addCases vₘ vₙ) → ∀ v, P(v)
   mpr h v := by
     convert h (fun i => v (castAdd n i)) (fun j => v (natAdd m j))
     exact (addCases_castAdd_natAdd v).symm


### PR DESCRIPTION
Prove simple results regarding appending and de-appending of finite sequences.
Used to define conical combinations and the conical hull (subsequent PR).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
