### PR TITLE
[Merged by Bors] - feat(Probability): `posterior_eq_withDensity_of_countable`

### DIFF
--- a/Mathlib/Probability/Kernel/Posterior.lean
+++ b/Mathlib/Probability/Kernel/Posterior.lean
@@ -286,6 +286,18 @@ lemma posterior_eq_withDensity (h_ac : ∀ᵐ ω ∂μ, κ ω ≪ κ ∘ₘ μ) 
     with ω h h_eq hωs
   rw [← h, h_eq, Kernel.const_apply]
 
+lemma posterior_eq_withDensity_of_countable {Ω : Type*} [Countable Ω] [MeasurableSpace Ω]
+    [Nonempty Ω] [StandardBorelSpace Ω] (κ : Kernel Ω 𝓧) [IsFiniteKernel κ]
+    (μ : Measure Ω) [IsFiniteMeasure μ] :
+    ∀ᵐ x ∂(κ ∘ₘ μ), (κ†μ) x = μ.withDensity (fun ω ↦ (κ ω).rnDeriv (κ ∘ₘ μ) x) := by
+  have h_rnDeriv ω := Kernel.rnDeriv_eq_rnDeriv_measure (κ := κ) (η := Kernel.const Ω (κ ∘ₘ μ))
+    (a := ω)
+  simp only [Filter.EventuallyEq, Kernel.const_apply] at h_rnDeriv
+  rw [← ae_all_iff] at h_rnDeriv
+  filter_upwards [posterior_eq_withDensity Measure.absolutelyContinuous_comp_of_countable,
+    h_rnDeriv] with x hx hx_all
+  simp_rw [hx, hx_all]
+
 end CountableOrCountablyGenerated
 
 end ProbabilityTheory


### PR DESCRIPTION
This PR adds a simpler version of `posterior_eq_withDensity` for the case of a countable space.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
