### PR TITLE
[Merged by Bors] - fix(KaehlerDifferential): avoid brackets around `Ω[S⁄R]` notation

### DIFF
--- a/Mathlib/Algebra/Module/Presentation/Differentials.lean
+++ b/Mathlib/Algebra/Module/Presentation/Differentials.lean
@@ -124,7 +124,7 @@ open differentials in
 equations `pres.differentialsRelations.Solution` when `pres` is a presentation
 of `S` as an `R`-algebra. -/
 noncomputable def differentialsSolution :
-    pres.differentialsRelations.Solution (Ω[S⁄R]) where
+    pres.differentialsRelations.Solution Ω[S⁄R] where
   var g := D _ _ (pres.val g)
   linearCombination_var_relation r := by
     simp only [differentialsRelations_G, LinearMap.coe_comp, LinearEquiv.coe_coe,
@@ -155,7 +155,7 @@ lemma differentialsSolution_isPresentation :
 
 /-- The presentation of the `S`-module `Ω[S⁄R]` deduced from a presentation
 of `S` as a `R`-algebra. -/
-noncomputable def differentials : Module.Presentation S (Ω[S⁄R]) where
+noncomputable def differentials : Module.Presentation S Ω[S⁄R] where
   G := ι
   R := σ
   relation := _

--- a/Mathlib/AlgebraicGeometry/Morphisms/FormallyUnramified.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/FormallyUnramified.lean
@@ -34,7 +34,7 @@ instance Algebra.FormallyUnramified.isOpenImmersion_SpecMap_lmul {R S : Type u} 
   rw [isOpenImmersion_SpecMap_iff_of_surjective _ (fun x ↦ ⟨1 ⊗ₜ x, by simp⟩)]
   apply (Ideal.isIdempotentElem_iff_of_fg _ (KaehlerDifferential.ideal_fg R S)).mp
   apply (Ideal.cotangent_subsingleton_iff _).mp
-  exact inferInstanceAs <| Subsingleton (Ω[S⁄R])
+  exact inferInstanceAs <| Subsingleton Ω[S⁄R]
 
 namespace AlgebraicGeometry
 

--- a/Mathlib/RingTheory/Extension/Cotangent/Basic.lean
+++ b/Mathlib/RingTheory/Extension/Cotangent/Basic.lean
@@ -436,7 +436,7 @@ end Generators
 -- TODO: generalize to essentially of finite presentation algebras
 open KaehlerDifferential in
 attribute [local instance] Module.finitePresentation_of_projective in
-instance [Algebra.FinitePresentation R S] : Module.FinitePresentation S (Ω[S⁄R]) := by
+instance [Algebra.FinitePresentation R S] : Module.FinitePresentation S Ω[S⁄R] := by
   let P := Algebra.Presentation.ofFinitePresentation R S
   have : Algebra.FiniteType R P.toExtension.Ring := .mvPolynomial _ _
   refine Module.finitePresentation_of_surjective _ P.toExtension.toKaehler_surjective ?_
@@ -501,7 +501,7 @@ abbrev Generators.equivH1Cotangent (P : Generators R S ι) :
   Generators.H1Cotangent.equiv _ _
 
 attribute [local instance] Module.finitePresentation_of_projective in
-instance [FinitePresentation R S] [Module.Projective S (Ω[S⁄R])] :
+instance [FinitePresentation R S] [Module.Projective S Ω[S⁄R]] :
     Module.Finite S (H1Cotangent R S) := by
   let P := Algebra.Presentation.ofFinitePresentation R S
   have : Algebra.FiniteType R P.toExtension.Ring := FiniteType.mvPolynomial R _

--- a/Mathlib/RingTheory/Kaehler/Basic.lean
+++ b/Mathlib/RingTheory/Kaehler/Basic.lean
@@ -155,25 +155,25 @@ instance KaehlerDifferential.module : Module (S ⊗[R] S) (KaehlerDifferential R
   Ideal.Cotangent.moduleOfTower _
 
 @[inherit_doc KaehlerDifferential]
-notation:100 "Ω[" S "⁄" R "]" => KaehlerDifferential R S
+notation "Ω[" S "⁄" R "]" => KaehlerDifferential R S
 
-instance : Nonempty (Ω[S⁄R]) := ⟨0⟩
+instance : Nonempty Ω[S⁄R] := ⟨0⟩
 
 instance KaehlerDifferential.module' {R' : Type*} [CommRing R'] [Algebra R' S]
     [SMulCommClass R R' S] :
-    Module R' (Ω[S⁄R]) :=
+    Module R' Ω[S⁄R] :=
   Submodule.Quotient.module' _
 
-instance : IsScalarTower S (S ⊗[R] S) (Ω[S⁄R]) :=
+instance : IsScalarTower S (S ⊗[R] S) Ω[S⁄R] :=
   Ideal.Cotangent.isScalarTower _
 
 instance KaehlerDifferential.isScalarTower_of_tower {R₁ R₂ : Type*} [CommRing R₁] [CommRing R₂]
     [Algebra R₁ S] [Algebra R₂ S] [SMul R₁ R₂]
     [SMulCommClass R R₁ S] [SMulCommClass R R₂ S] [IsScalarTower R₁ R₂ S] :
-    IsScalarTower R₁ R₂ (Ω[S⁄R]) :=
+    IsScalarTower R₁ R₂ Ω[S⁄R] :=
   Submodule.Quotient.isScalarTower _ _
 
-instance KaehlerDifferential.isScalarTower' : IsScalarTower R (S ⊗[R] S) (Ω[S⁄R]) :=
+instance KaehlerDifferential.isScalarTower' : IsScalarTower R (S ⊗[R] S) Ω[S⁄R] :=
   Submodule.Quotient.isScalarTower _ _
 
 /-- The quotient map `I → Ω[S⁄R]` with `I` being the kernel of `S ⊗[R] S → S`. -/
@@ -195,14 +195,14 @@ theorem KaehlerDifferential.DLinearMap_apply (s : S) :
         ⟨1 ⊗ₜ s - s ⊗ₜ 1, KaehlerDifferential.one_smul_sub_smul_one_mem_ideal R s⟩ := rfl
 
 /-- The universal derivation into `Ω[S⁄R]`. -/
-def KaehlerDifferential.D : Derivation R S (Ω[S⁄R]) :=
+def KaehlerDifferential.D : Derivation R S Ω[S⁄R] :=
   { toLinearMap := KaehlerDifferential.DLinearMap R S
     map_one_eq_zero' := by
       dsimp [KaehlerDifferential.DLinearMap_apply, Ideal.toCotangent_apply]
       congr
       rw [sub_self]
     leibniz' := fun a b => by
-      have : LinearMap.CompatibleSMul { x // x ∈ ideal R S } (Ω[S⁄R]) S (S ⊗[R] S) := inferInstance
+      have : LinearMap.CompatibleSMul { x // x ∈ ideal R S } Ω[S⁄R] S (S ⊗[R] S) := inferInstance
       dsimp [KaehlerDifferential.DLinearMap_apply]
       rw [← LinearMap.map_smul_of_tower (ideal R S).toCotangent,
         ← LinearMap.map_smul_of_tower (ideal R S).toCotangent,
@@ -243,8 +243,8 @@ theorem KaehlerDifferential.span_range_derivation :
 /-- `Ω[S⁄R]` is trivial if `R → S` is surjective.
 Also see `Algebra.FormallyUnramified.iff_subsingleton_kaehlerDifferential`. -/
 lemma KaehlerDifferential.subsingleton_of_surjective (h : Function.Surjective (algebraMap R S)) :
-    Subsingleton (Ω[S⁄R]) := by
-  suffices (⊤ : Submodule S (Ω[S⁄R])) ≤ ⊥ from
+    Subsingleton Ω[S⁄R] := by
+  suffices (⊤ : Submodule S Ω[S⁄R]) ≤ ⊥ from
     (subsingleton_iff_forall_eq 0).mpr fun y ↦ this trivial
   rw [← KaehlerDifferential.span_range_derivation, Submodule.span_le]
   rintro _ ⟨x, rfl⟩; obtain ⟨x, rfl⟩ := h x; simp
@@ -409,7 +409,7 @@ local instance instSS : Module (S ⊗[R] S) (KaehlerDifferential.ideal R S).cota
 /-- Derivations into `Ω[S⁄R]` is equivalent to derivations
 into `(KaehlerDifferential.ideal R S).cotangentIdeal`. -/
 noncomputable def KaehlerDifferential.endEquivDerivation' :
-    Derivation R S (Ω[S⁄R]) ≃ₗ[R] Derivation R S (ideal R S).cotangentIdeal :=
+    Derivation R S Ω[S⁄R] ≃ₗ[R] Derivation R S (ideal R S).cotangentIdeal :=
   LinearEquiv.compDer ((KaehlerDifferential.ideal R S).cotangentEquivIdeal.restrictScalars S)
 
 /-- (Implementation) An `Equiv` version of `KaehlerDifferential.End_equiv_aux`.
@@ -426,7 +426,7 @@ The endomorphisms of `Ω[S⁄R]` corresponds to sections of the surjection `S �
 with `J` being the kernel of the multiplication map `S ⊗[R] S →ₐ[R] S`.
 -/
 noncomputable def KaehlerDifferential.endEquiv :
-    Module.End S (Ω[S⁄R]) ≃
+    Module.End S Ω[S⁄R] ≃
       { f // (TensorProduct.lmul' R : S ⊗[R] S →ₐ[R] S).kerSquareLift.comp f = AlgHom.id R S } :=
   (KaehlerDifferential.linearMapEquivDerivation R S).toEquiv.trans <|
     (KaehlerDifferential.endEquivDerivation' R S).toEquiv.trans <|
@@ -462,7 +462,7 @@ theorem KaehlerDifferential.ideal_fg [EssFiniteType R S] :
     simpa [Ideal.Quotient.mk_eq_mk_iff_sub_mem] using AlgHom.congr_fun this x
 
 instance KaehlerDifferential.finite [EssFiniteType R S] :
-    Module.Finite S (Ω[S⁄R]) := by
+    Module.Finite S Ω[S⁄R] := by
   classical
   let s := (EssFiniteType.finset R S).image (fun s ↦ D R S s)
   refine ⟨⟨s, top_le_iff.mp ?_⟩⟩
@@ -751,7 +751,7 @@ theorem KaehlerDifferential.map_surjective :
 /-- The lift of the map `Ω[A⁄R] →ₗ[A] Ω[B⁄R]` to the base change along `A → B`.
 This is the first map in the exact sequence `B ⊗[A] Ω[A⁄R] → Ω[B⁄R] → Ω[B⁄A] → 0`. -/
 noncomputable def KaehlerDifferential.mapBaseChange : B ⊗[A] Ω[A⁄R] →ₗ[B] Ω[B⁄R] :=
-  (TensorProduct.isBaseChange A (Ω[A⁄R]) B).lift (KaehlerDifferential.map R R A B)
+  (TensorProduct.isBaseChange A Ω[A⁄R] B).lift (KaehlerDifferential.map R R A B)
 
 @[simp]
 theorem KaehlerDifferential.mapBaseChange_tmul (x : B) (y : Ω[A⁄R]) :
@@ -835,7 +835,7 @@ theorem KaehlerDifferential.range_kerCotangentToTensor
     simp only [kerCotangentToTensor_toCotangent, Submodule.restrictScalars_mem, LinearMap.mem_ker,
       mapBaseChange_tmul, map_D, RingHom.mem_ker.mp x.2, map_zero, smul_zero]
   · intro hx
-    obtain ⟨x, rfl⟩ := LinearMap.rTensor_surjective (Ω[A⁄R]) (g := Algebra.linearMap A B) h x
+    obtain ⟨x, rfl⟩ := LinearMap.rTensor_surjective Ω[A⁄R] (g := Algebra.linearMap A B) h x
     obtain ⟨x, rfl⟩ := (TensorProduct.lid _ _).symm.surjective x
     replace hx : x ∈ LinearMap.ker (KaehlerDifferential.map R R A B) := by simpa using hx
     rw [KaehlerDifferential.ker_map_of_surjective R A B h] at hx

--- a/Mathlib/RingTheory/Kaehler/Polynomial.lean
+++ b/Mathlib/RingTheory/Kaehler/Polynomial.lean
@@ -54,7 +54,7 @@ def KaehlerDifferential.mvPolynomialEquiv (σ : Type*) :
 /-- `{ dx | x ∈ σ }` forms a basis of the relative differential module
 of a polynomial algebra `R[σ]`. -/
 def KaehlerDifferential.mvPolynomialBasis (σ) :
-    Basis σ (MvPolynomial σ R) (Ω[MvPolynomial σ R⁄R]) :=
+    Basis σ (MvPolynomial σ R) Ω[MvPolynomial σ R⁄R] :=
   ⟨mvPolynomialEquiv R σ⟩
 
 lemma KaehlerDifferential.mvPolynomialBasis_repr_comp_D (σ) :
@@ -92,7 +92,7 @@ lemma KaehlerDifferential.mvPolynomialBasis_apply (σ) (i) :
     mvPolynomialBasis R σ i = D R (MvPolynomial σ R) (.X i) :=
   (mvPolynomialBasis_repr_symm_single R σ i 1).trans (one_smul _ _)
 
-instance (σ) : Module.Free (MvPolynomial σ R) (Ω[MvPolynomial σ R⁄R]) :=
+instance (σ) : Module.Free (MvPolynomial σ R) Ω[MvPolynomial σ R⁄R] :=
   .of_basis (KaehlerDifferential.mvPolynomialBasis R σ)
 
 end MvPolynomial

--- a/Mathlib/RingTheory/Kaehler/TensorProduct.lean
+++ b/Mathlib/RingTheory/Kaehler/TensorProduct.lean
@@ -29,7 +29,7 @@ namespace KaehlerDifferential
 /-- (Implementation). `A`-action on `S ⊗[R] Ω[A⁄R]`. -/
 noncomputable
 abbrev mulActionBaseChange : MulAction A (S ⊗[R] Ω[A⁄R]) :=
-  (TensorProduct.comm R S (Ω[A⁄R])).toEquiv.mulAction A
+  (TensorProduct.comm R S Ω[A⁄R]).toEquiv.mulAction A
 
 attribute [local instance] mulActionBaseChange
 
@@ -45,7 +45,7 @@ lemma mulActionBaseChange_smul_zero (a : A) :
 @[local simp]
 lemma mulActionBaseChange_smul_add (a : A) (x y : S ⊗[R] Ω[A⁄R]) :
     a • (x + y) = a • x + a • y := by
-  change (TensorProduct.comm R S (Ω[A⁄R])).symm (a • (TensorProduct.comm R S (Ω[A⁄R])) (x + y)) = _
+  change (TensorProduct.comm R S Ω[A⁄R]).symm (a • (TensorProduct.comm R S Ω[A⁄R]) (x + y)) = _
   rw [map_add, smul_add, map_add]
   rfl
 
@@ -53,7 +53,7 @@ lemma mulActionBaseChange_smul_add (a : A) (x y : S ⊗[R] Ω[A⁄R]) :
 noncomputable
 abbrev moduleBaseChange :
     Module A (S ⊗[R] Ω[A⁄R]) where
-  __ := (TensorProduct.comm R S (Ω[A⁄R])).toEquiv.mulAction A
+  __ := (TensorProduct.comm R S Ω[A⁄R]).toEquiv.mulAction A
   add_smul r s x := by induction x <;> simp [add_smul, tmul_add, *, add_add_add_comm]
   zero_smul x := by induction x <;> simp [*]
   smul_zero := by simp
@@ -124,7 +124,7 @@ The `S`-derivation `B = S ⊗[R] A` to `S ⊗[R] Ω[A⁄R]` sending `a ⊗ b` to
 noncomputable
 def derivationTensorProduct [h : Algebra.IsPushout R S A B] :
     Derivation S B (S ⊗[R] Ω[A⁄R]) where
-  __ := h.out.lift ((TensorProduct.mk R S (Ω[A⁄R]) 1).comp (D R A).toLinearMap)
+  __ := h.out.lift ((TensorProduct.mk R S Ω[A⁄R] 1).comp (D R A).toLinearMap)
   map_one_eq_zero' := by
     rw [← (algebraMap A B).map_one]
     refine (h.out.lift_eq _ _).trans ?_
@@ -212,7 +212,7 @@ then `Ω[B⁄S]` is the base change of `Ω[A⁄R]` along `R → S`.
 -/
 lemma isBaseChange [h : Algebra.IsPushout R S A B] :
     IsBaseChange S ((map R S A B).restrictScalars R) := by
-  convert (TensorProduct.isBaseChange R (Ω[A⁄R]) S).comp
+  convert (TensorProduct.isBaseChange R Ω[A⁄R] S).comp
     (IsBaseChange.ofEquiv (tensorKaehlerEquiv R S A B))
   refine LinearMap.ext fun x ↦ ?_
   simp only [LinearMap.coe_restrictScalars, LinearMap.coe_comp, LinearEquiv.coe_coe,

--- a/Mathlib/RingTheory/Smooth/Kaehler.lean
+++ b/Mathlib/RingTheory/Smooth/Kaehler.lean
@@ -438,7 +438,7 @@ private theorem Algebra.FormallySmooth.iff_injective_and_projective' :
     letI : Algebra (MvPolynomial S R) S := (MvPolynomial.aeval _root_.id).toAlgebra
     Algebra.FormallySmooth R S ↔
         Function.Injective (kerCotangentToTensor R (MvPolynomial S R) S) ∧
-        Module.Projective S (Ω[S⁄R]) := by
+        Module.Projective S Ω[S⁄R] := by
   letI : Algebra (MvPolynomial S R) S := (MvPolynomial.aeval _root_.id).toAlgebra
   have : Function.Surjective (algebraMap (MvPolynomial S R) S) :=
     fun x ↦ ⟨.X x, MvPolynomial.aeval_X _ _⟩
@@ -446,7 +446,7 @@ private theorem Algebra.FormallySmooth.iff_injective_and_projective' :
     ← Module.Projective.iff_split_of_projective]
   exact KaehlerDifferential.mapBaseChange_surjective _ _ _ this
 
-instance : Module.Projective P (Ω[P⁄R]) :=
+instance : Module.Projective P Ω[P⁄R] :=
   (Algebra.FormallySmooth.iff_injective_and_projective'.mp ‹_›).2
 
 include hf in
@@ -457,7 +457,7 @@ then `S` is formally smooth iff `I/I² → S ⊗[P] Ω[P⁄R]` is injective and 
 -/
 theorem Algebra.FormallySmooth.iff_injective_and_projective :
     Algebra.FormallySmooth R S ↔
-        Function.Injective (kerCotangentToTensor R P S) ∧ Module.Projective S (Ω[S⁄R]) := by
+        Function.Injective (kerCotangentToTensor R P S) ∧ Module.Projective S Ω[S⁄R] := by
   rw [Algebra.FormallySmooth.iff_injective_and_split hf,
     ← Module.Projective.iff_split_of_projective]
   exact KaehlerDifferential.mapBaseChange_surjective _ _ _ hf
@@ -468,7 +468,7 @@ An algebra is formally smooth if and only if `H¹(L_{R/S}) = 0` and `Ω_{S/R}` i
 @[stacks 031J]
 theorem Algebra.FormallySmooth.iff_subsingleton_and_projective :
     Algebra.FormallySmooth R S ↔
-        Subsingleton (Algebra.H1Cotangent R S) ∧ Module.Projective S (Ω[S⁄R]) := by
+        Subsingleton (Algebra.H1Cotangent R S) ∧ Module.Projective S Ω[S⁄R] := by
   refine (Algebra.FormallySmooth.iff_injective_and_projective
     (Generators.self R S).algebraMap_surjective).trans (and_congr ?_ Iff.rfl)
   change Function.Injective (Generators.self R S).toExtension.cotangentComplex ↔ _

--- a/Mathlib/RingTheory/Smooth/Local.lean
+++ b/Mathlib/RingTheory/Smooth/Local.lean
@@ -25,7 +25,7 @@ where `k` is the residue field of `S`.
 theorem Algebra.FormallySmooth.iff_injective_lTensor_residueField {R S} [CommRing R]
     [CommRing S] [IsLocalRing S] [Algebra R S] (P : Algebra.Extension R S)
     [FormallySmooth R P.Ring]
-    [Module.Free P.Ring (Ω[P.Ring⁄R])] [Module.Finite P.Ring (Ω[P.Ring⁄R])]
+    [Module.Free P.Ring Ω[P.Ring⁄R]] [Module.Finite P.Ring Ω[P.Ring⁄R]]
     (h' : P.ker.FG) :
     Algebra.FormallySmooth R S ↔
       Function.Injective (P.cotangentComplex.lTensor (ResidueField S)) := by

--- a/Mathlib/RingTheory/Smooth/Locus.lean
+++ b/Mathlib/RingTheory/Smooth/Locus.lean
@@ -50,7 +50,7 @@ variable {R A}
 
 attribute [local instance] Module.finitePresentation_of_projective in
 lemma smoothLocus_eq_compl_support_inter [EssFiniteType R A] :
-    smoothLocus R A = (Module.support A (H1Cotangent R A))ᶜ ∩ Module.freeLocus A (Ω[A⁄R]) := by
+    smoothLocus R A = (Module.support A (H1Cotangent R A))ᶜ ∩ Module.freeLocus A Ω[A⁄R] := by
   ext p
   simp only [Set.mem_inter_iff, Set.mem_compl_iff, Module.notMem_support_iff,
     Module.mem_freeLocus]
@@ -59,7 +59,7 @@ lemma smoothLocus_eq_compl_support_inter [EssFiniteType R A] :
   · have := IsLocalizedModule.iso p.asIdeal.primeCompl
       (H1Cotangent.map R R A (Localization.AtPrime p.asIdeal))
     exact this.subsingleton_congr.symm
-  · trans Module.Free (Localization.AtPrime p.asIdeal) (Ω[Localization.AtPrime p.asIdeal⁄R])
+  · trans Module.Free (Localization.AtPrime p.asIdeal) Ω[Localization.AtPrime p.asIdeal⁄R]
     · have : EssFiniteType A (Localization.AtPrime p.asIdeal) :=
         .of_isLocalization _ p.asIdeal.primeCompl
       have : EssFiniteType R (Localization.AtPrime p.asIdeal) := .comp _ A _

--- a/Mathlib/RingTheory/Smooth/StandardSmoothCotangent.lean
+++ b/Mathlib/RingTheory/Smooth/StandardSmoothCotangent.lean
@@ -200,7 +200,7 @@ See `SubmersivePresentation.basisKaehler` for the special case `κ = (Set.range 
 -/
 noncomputable def basisKaehlerOfIsCompl {κ : Type*} {f : κ → ι}
     (hf : Function.Injective f) (hcompl : IsCompl (Set.range f) (Set.range P.map)) :
-    Basis κ S (Ω[S⁄R]) := by
+    Basis κ S Ω[S⁄R] := by
   apply P.cotangentSpaceBasis.ofSplitExact (sectionCotangent_comp P)
     Extension.exact_cotangentComplex_toKaehler Extension.toKaehler_surjective hf (b := P.map)
   · intro i
@@ -220,7 +220,7 @@ noncomputable def basisKaehlerOfIsCompl {κ : Type*} {f : κ → ι}
 for `i` in the complement of `σ` in `ι` form a basis of `Ω[S⁄R]`. -/
 @[stacks 00T7 "(2)"]
 noncomputable def basisKaehler :
-    Basis ((Set.range P.map)ᶜ : Set _) S (Ω[S⁄R]) :=
+    Basis ((Set.range P.map)ᶜ : Set _) S Ω[S⁄R] :=
   P.basisKaehlerOfIsCompl Subtype.val_injective <| by
     rw [Subtype.range_coe_subtype]
     exact IsCompl.symm isCompl_compl
@@ -228,7 +228,7 @@ noncomputable def basisKaehler :
 /-- If `P` is a submersive presentation of `S` as an `R`-algebra, `Ω[S⁄R]` is free. -/
 @[stacks 00T7 "(2)"]
 theorem free_kaehlerDifferential (P : SubmersivePresentation R S ι σ) :
-    Module.Free S (Ω[S⁄R]) :=
+    Module.Free S Ω[S⁄R] :=
   Module.Free.of_basis P.basisKaehler
 
 attribute [local instance] Fintype.ofFinite in
@@ -236,7 +236,7 @@ attribute [local instance] Fintype.ofFinite in
 `Ω[S⁄R]` is free of rank the dimension of `P`, i.e. the number of generators minus the number
 of relations. -/
 theorem rank_kaehlerDifferential [Nontrivial S] [Finite ι]
-    (P : SubmersivePresentation R S ι σ) : Module.rank S (Ω[S⁄R]) = P.dimension := by
+    (P : SubmersivePresentation R S ι σ) : Module.rank S Ω[S⁄R] = P.dimension := by
   simp only [rank_eq_card_basis P.basisKaehler, Fintype.card_compl_set,
     Presentation.dimension, Nat.card_eq_fintype_card, Set.card_range_of_injective P.map_inj]
 
@@ -244,7 +244,7 @@ end SubmersivePresentation
 
 /-- If `S` is `R`-standard smooth, `Ω[S⁄R]` is a free `S`-module. -/
 instance IsStandardSmooth.free_kaehlerDifferential [IsStandardSmooth R S] :
-    Module.Free S (Ω[S⁄R]) := by
+    Module.Free S Ω[S⁄R] := by
   obtain ⟨_, _, _, _, ⟨P⟩⟩ := ‹IsStandardSmooth R S›
   exact P.free_kaehlerDifferential
 
@@ -257,12 +257,12 @@ instance IsStandardSmooth.subsingleton_h1Cotangent [IsStandardSmooth R S] :
 `S`-module of rank `n`. -/
 theorem IsStandardSmoothOfRelativeDimension.rank_kaehlerDifferential [Nontrivial S] (n : ℕ)
     [IsStandardSmoothOfRelativeDimension n R S] :
-    Module.rank S (Ω[S⁄R]) = n := by
+    Module.rank S Ω[S⁄R] = n := by
   obtain ⟨_, _, _, _, ⟨P, hP⟩⟩ := ‹IsStandardSmoothOfRelativeDimension n R S›
   rw [P.rank_kaehlerDifferential, hP]
 
 instance IsStandardSmoothOfRelationDimension.subsingleton_kaehlerDifferential
-    [IsStandardSmoothOfRelativeDimension 0 R S] : Subsingleton (Ω[S⁄R]) := by
+    [IsStandardSmoothOfRelativeDimension 0 R S] : Subsingleton Ω[S⁄R] := by
   cases subsingleton_or_nontrivial S
   · exact Module.subsingleton S _
   haveI : IsStandardSmooth R S := IsStandardSmoothOfRelativeDimension.isStandardSmooth 0

--- a/Mathlib/RingTheory/Unramified/Basic.lean
+++ b/Mathlib/RingTheory/Unramified/Basic.lean
@@ -49,7 +49,7 @@ This is equivalent to "for every `R`-algebra, every square-zero ideal
 See `Algebra.FormallyUnramified.iff_comp_injective`. -/
 @[mk_iff, stacks 00UM]
 class FormallyUnramified : Prop where
-  subsingleton_kaehlerDifferential : Subsingleton (Ω[A⁄R])
+  subsingleton_kaehlerDifferential : Subsingleton Ω[A⁄R]
 
 attribute [instance] FormallyUnramified.subsingleton_kaehlerDifferential
 

--- a/Mathlib/RingTheory/Unramified/Locus.lean
+++ b/Mathlib/RingTheory/Unramified/Locus.lean
@@ -63,7 +63,7 @@ section
 variable {R A : Type u} [CommRing R] [CommRing A] [Algebra R A]
 
 lemma unramifiedLocus_eq_compl_support :
-    unramifiedLocus R A = (Module.support A (Ω[A⁄R]))ᶜ := by
+    unramifiedLocus R A = (Module.support A Ω[A⁄R])ᶜ := by
   ext p
   simp only [Set.mem_compl_iff, Module.notMem_support_iff]
   have := IsLocalizedModule.iso p.asIdeal.primeCompl


### PR DESCRIPTION
There is no reason to need the brackets around `Ω[S⁄R]`. This PR fixes the notation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
