### PR TITLE
[Merged by Bors] - feat: basic linear algebra lemmas about matrices

### DIFF
--- a/Mathlib/Analysis/Normed/Module/FiniteDimension.lean
+++ b/Mathlib/Analysis/Normed/Module/FiniteDimension.lean
@@ -278,7 +278,7 @@ theorem opNNNorm_le {ι : Type*} [Fintype ι] (v : Basis ι 𝕜 E) {u : E →L[
     set φ := v.equivFunL.toContinuousLinearMap
     calc
       ‖u e‖₊ = ‖u (∑ i, v.equivFun e i • v i)‖₊ := by rw [v.sum_equivFun]
-      _ = ‖∑ i, v.equivFun e i • (u <| v i)‖₊ := by simp [map_sum]
+      _ = ‖∑ i, v.equivFun e i • (u <| v i)‖₊ := by simp only [equivFun_apply, map_sum, map_smul]
       _ ≤ ∑ i, ‖v.equivFun e i • (u <| v i)‖₊ := nnnorm_sum_le _ _
       _ = ∑ i, ‖v.equivFun e i‖₊ * ‖u (v i)‖₊ := by simp only [nnnorm_smul]
       _ ≤ ∑ i, ‖v.equivFun e i‖₊ * M := by gcongr; apply hu

--- a/Mathlib/Data/Matrix/Block.lean
+++ b/Mathlib/Data/Matrix/Block.lean
@@ -216,6 +216,14 @@ theorem fromBlocks_multiply [Fintype l] [Fintype m] [NonUnitalNonAssocSemiring �
   rcases i with ⟨⟩ <;> rcases j with ⟨⟩ <;> simp only [fromBlocks, mul_apply, of_apply,
       Sum.elim_inr, Fintype.sum_sum_type, Sum.elim_inl, add_apply]
 
+theorem fromBlocks_pow [Semiring α] [Fintype n] [Fintype m] [DecidableEq n] [DecidableEq m]
+    (A : Matrix n n α) (D : Matrix m m α) (k : ℕ) :
+    (fromBlocks A 0 0 D) ^ k = fromBlocks (A ^ k) 0 0 (D ^ k) := by
+  induction k with
+  | zero => ext (i | i) (j | j) <;> simp [one_apply]
+  | succ n ih =>
+    simp [ih, pow_succ, fromBlocks_multiply]
+
 theorem fromBlocks_mulVec [Fintype l] [Fintype m] [NonUnitalNonAssocSemiring α] (A : Matrix n l α)
     (B : Matrix n m α) (C : Matrix o l α) (D : Matrix o m α) (x : l ⊕ m → α) :
     (fromBlocks A B C D) *ᵥ x =

--- a/Mathlib/Data/Matrix/Block.lean
+++ b/Mathlib/Data/Matrix/Block.lean
@@ -216,7 +216,7 @@ theorem fromBlocks_multiply [Fintype l] [Fintype m] [NonUnitalNonAssocSemiring �
   rcases i with ⟨⟩ <;> rcases j with ⟨⟩ <;> simp only [fromBlocks, mul_apply, of_apply,
       Sum.elim_inr, Fintype.sum_sum_type, Sum.elim_inl, add_apply]
 
-theorem fromBlocks_pow [Semiring α] [Fintype n] [Fintype m] [DecidableEq n] [DecidableEq m]
+theorem fromBlocks_diagonal_pow [Semiring α] [Fintype n] [Fintype m] [DecidableEq n] [DecidableEq m]
     (A : Matrix n n α) (D : Matrix m m α) (k : ℕ) :
     (fromBlocks A 0 0 D) ^ k = fromBlocks (A ^ k) 0 0 (D ^ k) := by
   induction k with

--- a/Mathlib/Data/Matrix/Diagonal.lean
+++ b/Mathlib/Data/Matrix/Diagonal.lean
@@ -194,6 +194,10 @@ instance one : One (Matrix n n α) :=
 theorem diagonal_one : (diagonal fun _ => 1 : Matrix n n α) = 1 :=
   rfl
 
+@[simp]
+theorem diagonal_one' : (diagonal 1 : Matrix n n α) = 1 :=
+  rfl
+
 theorem one_apply {i j} : (1 : Matrix n n α) i j = if i = j then 1 else 0 :=
   rfl
 

--- a/Mathlib/Data/Matrix/Mul.lean
+++ b/Mathlib/Data/Matrix/Mul.lean
@@ -411,6 +411,11 @@ theorem diagonal_mul_diagonal' [Fintype n] [DecidableEq n] (d₁ d₂ : n → α
     diagonal d₁ * diagonal d₂ = diagonal fun i => d₁ i * d₂ i :=
   diagonal_mul_diagonal _ _
 
+theorem commute_diagonal {α : Type*} [NonUnitalNonAssocCommRing α]
+    [Fintype n] [DecidableEq n] (d₁ d₂ : n → α) :
+    Commute (diagonal d₁) (diagonal d₂) := by
+  simp_rw [commute_iff_eq, diagonal_mul_diagonal, mul_comm]
+
 theorem smul_eq_diagonal_mul [Fintype m] [DecidableEq m] (M : Matrix m n α) (a : α) :
     a • M = (diagonal fun _ => a) * M := by
   ext

--- a/Mathlib/Data/Matrix/Mul.lean
+++ b/Mathlib/Data/Matrix/Mul.lean
@@ -411,7 +411,7 @@ theorem diagonal_mul_diagonal' [Fintype n] [DecidableEq n] (d₁ d₂ : n → α
     diagonal d₁ * diagonal d₂ = diagonal fun i => d₁ i * d₂ i :=
   diagonal_mul_diagonal _ _
 
-theorem commute_diagonal {α : Type*} [NonUnitalNonAssocCommRing α]
+theorem commute_diagonal {α : Type*} [NonUnitalNonAssocCommSemiring α]
     [Fintype n] [DecidableEq n] (d₁ d₂ : n → α) :
     Commute (diagonal d₁) (diagonal d₂) := by
   simp_rw [commute_iff_eq, diagonal_mul_diagonal, mul_comm]

--- a/Mathlib/LinearAlgebra/Basis/Basic.lean
+++ b/Mathlib/LinearAlgebra/Basis/Basic.lean
@@ -68,6 +68,12 @@ protected theorem mem_span (x : M) : x ∈ span R (range b) :=
 protected theorem span_eq : span R (range b) = ⊤ :=
   eq_top_iff.mpr fun x _ => b.mem_span x
 
+theorem _root_.Submodule.eq_top_iff_forall_basis_mem {p : Submodule R M} :
+    p = ⊤ ↔ ∀ i, b i ∈ p := by
+  refine ⟨fun h ↦ by simp [h], fun h ↦ ?_⟩
+  replace h : range b ⊆ p := by rintro - ⟨i, rfl⟩; exact h i
+  simpa using span_mono (R := R) h
+
 theorem index_nonempty (b : Basis ι R M) [Nontrivial M] : Nonempty ι := by
   obtain ⟨x, y, ne⟩ : ∃ x y : M, x ≠ y := Nontrivial.exists_pair_ne
   obtain ⟨i, _⟩ := not_forall.mp (mt b.ext_elem_iff.2 ne)

--- a/Mathlib/LinearAlgebra/Basis/Defs.lean
+++ b/Mathlib/LinearAlgebra/Basis/Defs.lean
@@ -257,6 +257,7 @@ theorem Basis.sum_equivFun [Fintype ι] (b : Basis ι R M) (u : M) :
     ∑ i, b.equivFun u i • b i = u := by
   rw [← b.equivFun_symm_apply, b.equivFun.symm_apply_apply]
 
+@[simp]
 theorem Basis.sum_repr [Fintype ι] (b : Basis ι R M) (u : M) : ∑ i, b.repr u i • b i = u :=
   b.sum_equivFun u
 

--- a/Mathlib/LinearAlgebra/Eigenspace/Basic.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Basic.lean
@@ -545,6 +545,10 @@ theorem eigenspace_le_genEigenspace {f : End R M} {μ : R} {k : ℕ} (hk : 0 < k
     f.eigenspace μ ≤ f.genEigenspace μ k :=
   (f.genEigenspace _).monotone <| by simpa using Nat.succ_le_of_lt hk
 
+theorem eigenspace_le_maxGenEigenspace {f : End R M} {μ : R} :
+    f.eigenspace μ ≤ f.maxGenEigenspace μ :=
+  (f.genEigenspace _).monotone <| OrderTop.le_top _
+
 /-- All eigenvalues are generalized eigenvalues. -/
 theorem hasGenEigenvalue_of_hasEigenvalue {f : End R M} {μ : R} {k : ℕ} (hk : 0 < k)
     (hμ : f.HasEigenvalue μ) : f.HasGenEigenvalue μ k :=

--- a/Mathlib/LinearAlgebra/Eigenspace/Matrix.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Matrix.lean
@@ -68,6 +68,7 @@ lemma hasEigenvalue_toLin'_diagonal_iff [NoZeroDivisors R] (d : n → R) {μ : R
   hasEigenvalue_toLin_diagonal_iff _ <| Pi.basisFun R n
 
 end NontrivialCommRing
+
 namespace Matrix
 
 variable [CommRing R] [AddCommGroup M] [Module R M] (d : n → R) {μ : R} (b : Basis n R M)

--- a/Mathlib/LinearAlgebra/Eigenspace/Matrix.lean
+++ b/Mathlib/LinearAlgebra/Eigenspace/Matrix.lean
@@ -67,18 +67,16 @@ lemma hasEigenvalue_toLin'_diagonal_iff [NoZeroDivisors R] (d : n → R) {μ : R
     HasEigenvalue (toLin' (diagonal d)) μ ↔ (∃ i, d i = μ) :=
   hasEigenvalue_toLin_diagonal_iff _ <| Pi.basisFun R n
 
+end NontrivialCommRing
 namespace Matrix
 
-variable (d : n → R) {μ : R} (b : Basis n R M)
-omit [Nontrivial R]
+variable [CommRing R] [AddCommGroup M] [Module R M] (d : n → R) {μ : R} (b : Basis n R M)
 
 @[simp]
 lemma iSup_eigenspace_toLin_diagonal_eq_top :
     ⨆ μ, eigenspace ((diagonal d).toLin b b) μ = ⊤ := by
-  rw [Submodule.eq_top_iff_forall_basis_mem b]
-  intro j
-  suffices b j ∈ eigenspace ((diagonal d).toLin b b) (d j) from Submodule.mem_iSup_of_mem (d j) this
-  simp [diagonal_apply]
+  refine (Submodule.eq_top_iff_forall_basis_mem b).mpr fun j ↦ ?_
+  exact Submodule.mem_iSup_of_mem (d j) <| by simp [diagonal_apply]
 
 @[simp]
 lemma iSup_eigenspace_toLin'_diagonal_eq_top :
@@ -109,8 +107,6 @@ lemma maxGenEigenspace_toLin'_diagonal_eq_eigenspace :
   maxGenEigenspace_toLin_diagonal_eq_eigenspace d <| Pi.basisFun R n
 
 end Matrix
-
-end NontrivialCommRing
 
 /-- The spectrum of the diagonal operator is the range of the diagonal viewed as a function. -/
 @[simp] lemma spectrum_diagonal [Field R] (d : n → R) :

--- a/Mathlib/LinearAlgebra/Matrix/BilinearForm.lean
+++ b/Mathlib/LinearAlgebra/Matrix/BilinearForm.lean
@@ -205,10 +205,10 @@ theorem BilinForm.dotProduct_toMatrix_mulVec (B : BilinForm R₁ M₁) (x y : n 
 lemma BilinForm.apply_eq_dotProduct_toMatrix_mulVec (B : BilinForm R₁ M₁) (x y : M₁) :
     B x y = (b.repr x) ⬝ᵥ (BilinForm.toMatrix b B) *ᵥ (b.repr y) := by
   nth_rw 1 [← b.sum_repr x, ← b.sum_repr y]
-  suffices ∑ j, ∑ i, (b.repr y) j * (b.repr x i * B (b i) (b j)) =
-           ∑ j, ∑ i, (b.repr x) j * (b.repr y i * B (b j) (b i)) by
-    simpa [dotProduct, Matrix.mulVec_eq_sum, Finset.mul_sum, -Basis.sum_repr]
-  simp_rw [mul_comm (b.repr y _), mul_assoc]
+  suffices ∑ j, ∑ i, b.repr y j * b.repr x i * B (b i) (b j) =
+           ∑ i, ∑ j, b.repr x i * b.repr y j * B (b i) (b j) by
+    simpa [dotProduct, Matrix.mulVec_eq_sum, Finset.mul_sum, -Basis.sum_repr, ← mul_assoc]
+  simp_rw [mul_comm (b.repr y _)]
   exact Finset.sum_comm
 
 @[simp]

--- a/Mathlib/LinearAlgebra/Matrix/BilinearForm.lean
+++ b/Mathlib/LinearAlgebra/Matrix/BilinearForm.lean
@@ -205,10 +205,11 @@ theorem BilinForm.dotProduct_toMatrix_mulVec (B : BilinForm R₁ M₁) (x y : n 
 lemma BilinForm.apply_eq_dotProduct_toMatrix_mulVec (B : BilinForm R₁ M₁) (x y : M₁) :
     B x y = (b.repr x) ⬝ᵥ (BilinForm.toMatrix b B) *ᵥ (b.repr y) := by
   nth_rw 1 [← b.sum_repr x, ← b.sum_repr y]
-  simp [dotProduct, Matrix.mulVec_eq_sum, Finset.mul_sum]
-  rw [Finset.sum_comm]
-  refine Finset.sum_congr rfl (fun i _ ↦ Finset.sum_congr rfl fun j _ ↦ ?_)
-  ring
+  suffices ∑ j, ∑ i, (b.repr y) j * (b.repr x i * B (b i) (b j)) =
+           ∑ j, ∑ i, (b.repr x) j * (b.repr y i * B (b j) (b i)) by
+    simpa [dotProduct, Matrix.mulVec_eq_sum, Finset.mul_sum, -Basis.sum_repr]
+  simp_rw [mul_comm (b.repr y _), mul_assoc]
+  exact Finset.sum_comm
 
 @[simp]
 theorem Matrix.toBilin_apply (M : Matrix n n R₁) (x y : M₁) :

--- a/Mathlib/LinearAlgebra/Matrix/ToLin.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLin.lean
@@ -641,6 +641,13 @@ theorem Matrix.toLin_self (M : Matrix m n R) (i : n) :
     have := Finset.mem_univ i
     contradiction
 
+theorem Matrix.toLin_apply_eq_zero_iff {R M₁ M₂ : Type*} [CommRing R]
+    [AddCommGroup M₁] [AddCommGroup M₂] [Module R M₁] [Module R M₂]
+    {v₁ : Basis n R M₁} {v₂ : Basis m R M₂} {A : Matrix m n R} {x : M₁} :
+    A.toLin v₁ v₂ x = 0 ↔ ∀ j, (A *ᵥ v₁.repr x) j = 0 := by
+  rw [toLin_apply]
+  exact ⟨Fintype.linearIndependent_iff.mp v₂.linearIndependent _, fun h ↦ by simp [h]⟩
+
 variable {M₃ : Type*} [AddCommMonoid M₃] [Module R M₃] (v₃ : Basis l R M₃)
 
 theorem LinearMap.toMatrix_comp [Finite l] [DecidableEq m] (f : M₂ →ₗ[R] M₃) (g : M₁ →ₗ[R] M₂) :
@@ -665,6 +672,13 @@ theorem Matrix.toLin_mul [Finite l] [DecidableEq m] (A : Matrix l m R) (B : Matr
   haveI : DecidableEq l := fun _ _ ↦ Classical.propDecidable _
   rw [LinearMap.toMatrix_comp v₁ v₂ v₃]
   repeat' rw [LinearMap.toMatrix_toLin]
+
+@[simp]
+theorem Matrix.toLin_pow (A : Matrix n n R) (k : ℕ) :
+    (A ^ k).toLin v₁ v₁ = (A.toLin v₁ v₁) ^ k := by
+  induction k with
+  | zero => simp only [pow_zero, toLin_one]; rfl
+  | succ n ih => rw [pow_succ, pow_succ, toLin_mul v₁ v₁, ih, Module.End.mul_eq_comp]
 
 /-- Shortcut lemma for `Matrix.toLin_mul` and `LinearMap.comp_apply`. -/
 theorem Matrix.toLin_mul_apply [Finite l] [DecidableEq m] (A : Matrix l m R) (B : Matrix m n R)

--- a/Mathlib/LinearAlgebra/Matrix/ToLin.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLin.lean
@@ -358,6 +358,13 @@ theorem Matrix.toLin'_mul [Fintype m] [DecidableEq m] (M : Matrix l m R) (N : Ma
   Matrix.mulVecLin_mul _ _
 
 @[simp]
+theorem Matrix.toLin'_pow (M : Matrix n n R) (k : ℕ) :
+    (M ^ k).toLin' = M.toLin' ^ k := by
+  induction k with
+  | zero => rw [pow_zero, toLin'_one]; exact rfl
+  | succ n ih => rw [pow_succ, pow_succ, toLin'_mul, ih, Module.End.mul_eq_comp]
+
+@[simp]
 theorem Matrix.toLin'_submatrix [Fintype l] [DecidableEq l] (f₁ : m → k) (e₂ : n ≃ l)
     (M : Matrix k l R) :
     Matrix.toLin' (M.submatrix f₁ e₂) =

--- a/Mathlib/LinearAlgebra/Pi.lean
+++ b/Mathlib/LinearAlgebra/Pi.lean
@@ -599,6 +599,22 @@ def finTwoArrow : (Fin 2 → M) ≃ₗ[R] M × M :=
 
 end LinearEquiv
 
+lemma Pi.mem_span_range_single_inl_iff
+    [DecidableEq ι] [DecidableEq ι'] [Fintype ι] [Semiring R] {x : ι ⊕ ι' → R} :
+    x ∈ span R (Set.range fun i ↦ single (Sum.inl i) 1) ↔ ∀ k, x (Sum.inr k) = 0 := by
+  refine ⟨fun hx k ↦ ?_, fun hx ↦ ?_⟩
+  · induction hx using span_induction with
+    | mem x h => obtain ⟨i, rfl⟩ := h; simp
+    | zero => simp
+    | add u v _ _ hu hv => simp [hu, hv]
+    | smul t u _ hu => simp [hu]
+  · suffices x = ∑ i : ι, x (Sum.inl i) • Pi.single (M := fun _ ↦ R) (Sum.inl i) (1 : R) by
+      rw [this]
+      exact sum_mem <| fun i _ ↦ SMulMemClass.smul_mem _ <| subset_span <| Set.mem_range_self i
+    ext (i | i)
+    · simp [single_apply]
+    · simp [hx i]
+
 section Extend
 
 variable (R) {η : Type x} [Semiring R] (s : ι → η)


### PR DESCRIPTION
These came up in the proof that the Geck Construction yields semisimple Lie algebras. I am splitting them into their own PR to simplify review.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
