### PR TITLE
fix(scripts/create-adaptation-pr): use nightly remote for bump branch + remove ineffective workarounds

### DIFF
--- a/scripts/create-adaptation-pr.sh
+++ b/scripts/create-adaptation-pr.sh
@@ -124,23 +124,15 @@ echo "### [auto] save the current branch name"
 usr_branch=$(git branch --show-current)
 
 echo
-echo "### [auto] checkout master and pull the latest changes"
+echo "### [auto] fetch the latest changes from '$MAIN_REMOTE/master'"
 
 git fetch $MAIN_REMOTE master
-
-# Ensure local master branch exists and tracks $MAIN_REMOTE/master
-if git show-ref --verify --quiet refs/heads/master; then
-  git checkout master
-  git pull $MAIN_REMOTE master
-else
-  git checkout -b master $MAIN_REMOTE/master
-fi
 
 echo
 echo "### [auto] checkout 'bump/$BUMPVERSION' and merge the latest changes from '$MAIN_REMOTE/master'"
 
 git checkout "bump/$BUMPVERSION"
-git pull --no-rebase $MAIN_REMOTE "bump/$BUMPVERSION"
+git pull $NIGHTLY_REMOTE "bump/$BUMPVERSION"
 git merge --no-edit $MAIN_REMOTE/master || true # ignore error if there are conflicts
 
 # Check if there are merge conflicts
@@ -281,7 +273,7 @@ echo
 echo "### [auto] checkout the 'nightly-testing' branch and merge the new branch into it"
 
 git checkout nightly-testing
-git pull --no-rebase $NIGHTLY_REMOTE nightly-testing
+git pull $NIGHTLY_REMOTE nightly-testing
 git merge --no-edit "bump/nightly-$NIGHTLYDATE" || true # ignore error if there are conflicts
 
 # Check if there are merge conflicts


### PR DESCRIPTION
This *should* make it work now...

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
