### PR TITLE
[Merged by Bors] - fix: reword instructions for adding co-authors in the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,10 +11,13 @@ In particular, note that most reviewers will only notice your PR
 if it passes the continuous integration checks.
 Please ask for help on https://leanprover.zulipchat.com if needed.
 
-To indicate co-authors, include lines at the bottom of the commit message
-(that is, before the `---`) using the following format:
+To indicate co-authors, include at least one commit authored by each
+co-author among the commits in the pull request. If necessary, you may 
+create empty commits to indicate co-authorship, using commands like so:
 
-Co-authored-by: Author Name <author@email.com>
+git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"
+
+When merging, all the commits will be squashed into a single commit listing all co-authors.
 
 If you are moving or deleting declarations, please include these lines at the bottom of the commit message
 (that is, before the `---`) using the following format:


### PR DESCRIPTION
This remedies the issue reported in the associated Zulip topic, namely, that the merge commit squashed by bors includes the co-authors who did not author commits in a way that is not recognized by GitHub.

https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/co-authored-by.20bors.20issue/with/531479378

---

Disclaimer: I cannot test these instructions without creating and merging a PR here. But the `bors-ng` source code and other past merged PRs indicate that it should work.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
