### PR TITLE
[Merged by Bors] - feat(Bivariate): aevalAeval and swap

### DIFF
--- a/Mathlib/Algebra/Polynomial/Bivariate.lean
+++ b/Mathlib/Algebra/Polynomial/Bivariate.lean
@@ -197,6 +197,51 @@ lemma eval_C_X_eval₂_map_C_X {p : R[X][Y]} :
 
 end
 
+section aevalAeval
+
+noncomputable section
+
+variable {R A : Type*} [CommRing R] [CommRing A] [Algebra R A]
+
+/-- `aevalAeval x y` is the `R`-algebra evaluation morphism sending a two-variable polynomial
+  `p : R[X][Y]` to `p(x,y)`. -/
+abbrev aevalAeval (x y : A) : R[X][Y] →ₐ[R] A :=
+  ((aeval x).restrictScalars R).comp
+    (letI := Polynomial.algebra; (aeval (R := R[X]) (C y)).restrictScalars R)
+
+theorem coe_aevalAeval_eq_evalEval (x y : A) : ⇑(aevalAeval x y) = evalEval x y := by
+  ext p; simp [aevalAeval, evalEval, aeval, eval, Algebra.ofId]
+
+/-- The R-algebra automorphism given by `X ↦ Y` and `Y ↦ X`. -/
+def Bivariate.swap : R[X][Y] ≃ₐ[R] R[X][Y] := by
+  apply AlgEquiv.ofAlgHom (aevalAeval (Y : R[X][Y]) (C X)) (aevalAeval (Y : R[X][Y]) (C X))
+    <;> (ext n m <;> simp)
+
+/-- Evaluating `swap p` at `x`, `y` is the same as evaluating `p` at `y` `x`. -/
+theorem Bivariate.aevalAeval_swap (x y : A) (p : R[X][Y]) :
+    aevalAeval x y (swap p) = aevalAeval y x p := by
+  unfold swap aevalAeval at *
+  induction p using Polynomial.induction_on' with
+  | add => aesop
+  | monomial n a =>
+    simp_all
+    induction a using Polynomial.induction_on' <;> aesop (add norm add_mul)
+
+attribute [local instance] Polynomial.algebra in
+theorem Bivariate.aveal_eq_map_swap (x : A) (p : R[X][Y]) :
+    aeval (C x) p = mapAlgHom (aeval x) (swap p) := by
+  simp only [swap, aevalAeval]
+  induction' p using Polynomial.induction_on' with p q hp hq
+  · aesop
+  · next n a =>
+      simp_all
+      induction a using Polynomial.induction_on'
+        <;> aesop (add norm [add_mul, C_mul_X_pow_eq_monomial])
+
+end
+
+end aevalAeval
+
 end Polynomial
 
 open Polynomial

--- a/Mathlib/Algebra/Polynomial/Bivariate.lean
+++ b/Mathlib/Algebra/Polynomial/Bivariate.lean
@@ -217,24 +217,33 @@ def Bivariate.swap : R[X][Y] ≃ₐ[R] R[X][Y] := by
   apply AlgEquiv.ofAlgHom (aevalAeval (Y : R[X][Y]) (C X)) (aevalAeval (Y : R[X][Y]) (C X))
     <;> (ext n m <;> simp)
 
+@[simp]
+theorem Bivariate.swap_apply (p : R[X][Y]) : swap p = p.aevalAeval (A := R[X][Y]) Y (C X) := rfl
+
+theorem Bivariate.swap_X : swap (R := R) (C X) = Y := by simp
+
+theorem Bivariate.swap_Y : swap (R := R) Y = (C X) := by simp
+
+theorem Bivariate.swap_monomial_monomial (n m : ℕ) (r : R) :
+    swap (monomial n (monomial m r)) = (monomial m (monomial n r)) := by
+  simp [← C_mul_X_pow_eq_monomial]; ac_rfl
+
 /-- Evaluating `swap p` at `x`, `y` is the same as evaluating `p` at `y` `x`. -/
 theorem Bivariate.aevalAeval_swap (x y : A) (p : R[X][Y]) :
     aevalAeval x y (swap p) = aevalAeval y x p := by
-  unfold swap aevalAeval at *
   induction p using Polynomial.induction_on' with
   | add => aesop
   | monomial n a =>
-    simp_all
+    simp
     induction a using Polynomial.induction_on' <;> aesop (add norm add_mul)
 
 attribute [local instance] Polynomial.algebra in
 theorem Bivariate.aveal_eq_map_swap (x : A) (p : R[X][Y]) :
     aeval (C x) p = mapAlgHom (aeval x) (swap p) := by
-  simp only [swap, aevalAeval]
-  induction' p using Polynomial.induction_on' with p q hp hq
-  · aesop
-  · next n a =>
-      simp_all
+  induction p using Polynomial.induction_on' with
+  | add =>  aesop
+  | monomial n a =>
+      simp
       induction a using Polynomial.induction_on'
         <;> aesop (add norm [add_mul, C_mul_X_pow_eq_monomial])
 


### PR DESCRIPTION
Add the `aeval` equivalent to `Bivariate.evalEval`.
This PR also introduces `Bivariate.swap`, the R-algebra automorphism given by `X ↦ Y` and `Y ↦ X`.

Co-authored-by: María Inés de Frutos Fernández <[mariaines.dff@gmail.com](mailto:mariaines.dff@gmail.com)>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
