### PR TITLE
[Merged by Bors] - feat(Algebra/Order/Sub): `Sub` structure for linearly canonically ordered monoid

### DIFF
--- a/Mathlib/Algebra/Order/Sub/Basic.lean
+++ b/Mathlib/Algebra/Order/Sub/Basic.lean
@@ -200,20 +200,21 @@ lemma Even.tsub [AddLeftReflectLE α] {m n : α} (hm : Even m) (hn : Even n) :
 
 end CanonicallyLinearOrderedAddCommMonoid
 
-/-! ### `Sub` instance in linearly canonically ordered monoid using choice. -/
+/-! ### `Sub` structure in linearly canonically ordered monoid using choice. -/
 
 namespace CanonicallyOrderedAdd
 
 variable [AddCommMonoid α] [LinearOrder α] [CanonicallyOrderedAdd α]
 
-/-- `Sub` instance in linearly canonically ordered monoid using choice. -/
-noncomputable def toSub : Sub α where
+-- See note [reducible non instances]
+/-- `Sub` structure in linearly canonically ordered monoid using choice. -/
+noncomputable abbrev toSub : Sub α where
   sub x y := if h : y ≤ x then (exists_add_of_le h).choose else 0
 
 attribute [local instance] toSub
 
-/-- The `Sub` instance using choice satisfies `OrderedSub`. -/
-theorem toSub.orderedSub [AddRightReflectLE α] : OrderedSub α where
+/-- The `Sub` structure using choice satisfies `OrderedSub`. -/
+theorem toOrderedSub [AddRightReflectLE α] : OrderedSub α where
   tsub_le_iff_right a b c := by
     change dite _ _ _ ≤ c ↔ _
     split_ifs with h

--- a/Mathlib/Algebra/Order/Sub/Basic.lean
+++ b/Mathlib/Algebra/Order/Sub/Basic.lean
@@ -199,3 +199,31 @@ lemma Even.tsub [AddLeftReflectLE α] {m n : α} (hm : Even m) (hn : Even n) :
   · exact (tsub_add_tsub_comm h h).symm
 
 end CanonicallyLinearOrderedAddCommMonoid
+
+/-! ### `Sub` instance in linearly canonically ordered monoid using choice. -/
+
+namespace CanonicallyOrderedAdd
+
+variable [AddCommMonoid α] [LinearOrder α] [CanonicallyOrderedAdd α]
+
+/-- `Sub` instance in linearly canonically ordered monoid using choice. -/
+noncomputable def toSub : Sub α where
+  sub x y := if h : y ≤ x then (exists_add_of_le h).choose else 0
+
+attribute [local instance] toSub
+
+/-- The `Sub` instance using choice satisfies `OrderedSub`. -/
+instance [AddRightReflectLE α] : OrderedSub α where
+  tsub_le_iff_right a b c := by
+    change dite _ _ _ ≤ c ↔ _
+    split_ifs with h
+    · have := (exists_add_of_le h).choose_spec
+      rw [this] at h
+      conv_rhs => rw [this, add_comm]
+      rw [add_le_add_iff_right]
+    · rw [not_le] at h
+      constructor <;> intro h'
+      · simpa using add_le_add h' h.le
+      · exact zero_le c
+
+end CanonicallyOrderedAdd

--- a/Mathlib/Algebra/Order/Sub/Basic.lean
+++ b/Mathlib/Algebra/Order/Sub/Basic.lean
@@ -213,7 +213,7 @@ noncomputable def toSub : Sub α where
 attribute [local instance] toSub
 
 /-- The `Sub` instance using choice satisfies `OrderedSub`. -/
-instance [AddRightReflectLE α] : OrderedSub α where
+theorem toSub.orderedSub [AddRightReflectLE α] : OrderedSub α where
   tsub_le_iff_right a b c := by
     change dite _ _ _ ≤ c ↔ _
     split_ifs with h


### PR DESCRIPTION
There is a `Sub` structure for linearly canonically ordered monoid using choice that satisfies `OrderedSub`.

Thanks eric-wieser for the suggestion in #27341!

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
