### PR TITLE
[Merged by Bors] - chore(Geometry/RingedSpace): remove use of `erw` in `stalkSpecializes_stalkMap`

### DIFF
--- a/Mathlib/Geometry/RingedSpace/Stalks.lean
+++ b/Mathlib/Geometry/RingedSpace/Stalks.lean
@@ -197,8 +197,7 @@ theorem stalkSpecializes_stalkMap {X Y : PresheafedSpace.{_, _, v} C}
     whiskerRight_app, NatTrans.id_app, colimit.ι_pre, assoc,
     colimit.pre_desc, colimit.map_desc, colimit.ι_desc, Cocones.precompose_obj_ι,
     Cocone.whisker_ι, NatTrans.comp_app]
-  erw [X.presheaf.map_id, id_comp]
-  rfl
+  tauto
 
 end stalkMap
 


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>stalkSpecializes_stalkMap</code></summary>

### Trace profiling of `stalkSpecializes_stalkMap` before PR 27656
```diff
diff --git a/Mathlib/Geometry/RingedSpace/Stalks.lean b/Mathlib/Geometry/RingedSpace/Stalks.lean
index 1440d9f1af..5d9287d34f 100644
--- a/Mathlib/Geometry/RingedSpace/Stalks.lean
+++ b/Mathlib/Geometry/RingedSpace/Stalks.lean
@@ -183,2 +183,3 @@ def stalkIso {X Y : PresheafedSpace.{_, _, v} C} (α : X ≅ Y) (x : X) :
 
+set_option trace.profiler true in
 @[reassoc (attr := simp), elementwise (attr := simp)]
```
```
ℹ [1147/1147] Built Mathlib.Geometry.RingedSpace.Stalks
info: Mathlib/Geometry/RingedSpace/Stalks.lean:185:0: [Elab.command] [0.676808] @[reassoc (attr := simp), elementwise (attr := simp)]
    theorem stalkSpecializes_stalkMap {X Y : PresheafedSpace.{_, _, v} C} (f : X ⟶ Y) {x y : X} (h : x ⤳ y) :
        Y.presheaf.stalkSpecializes (f.base.hom.map_specializes h) ≫ f.stalkMap x =
          f.stalkMap y ≫ X.presheaf.stalkSpecializes h :=
      by
      -- Porting note: the original one liner `dsimp [stalkMap]; simp [stalkMap]` doesn't work,
        -- I had to uglify this
      
      dsimp [stalkSpecializes, Hom.stalkMap, stalkFunctor, stalkPushforward]
        -- We can't use `ext` here due to https://github.com/leanprover/std4/pull/159
        
      refine colimit.hom_ext fun j => ?_
      induction j with
      | op j => ?_
      dsimp
      simp only [colimit.ι_desc_assoc, ι_colimMap_assoc, whiskerLeft_app, whiskerRight_app, NatTrans.id_app,
        colimit.ι_pre, assoc, colimit.pre_desc, colimit.map_desc, colimit.ι_desc, Cocones.precompose_obj_ι,
        Cocone.whisker_ι, NatTrans.comp_app]
      erw [X.presheaf.map_id, id_comp]
      rfl
  [Elab.attribute] [0.642492] applying [reassoc (attr := simp)]
  [Elab.attribute] [0.024500] applying [elementwise (attr := simp)]
info: Mathlib/Geometry/RingedSpace/Stalks.lean:185:0: [Elab.async] [0.628340] elaborating proof of AlgebraicGeometry.PresheafedSpace.stalkMap.stalkSpecializes_stalkMap
  [Elab.definition.value] [0.623816] AlgebraicGeometry.PresheafedSpace.stalkMap.stalkSpecializes_stalkMap
    [Elab.step] [0.620855] 
          dsimp [stalkSpecializes, Hom.stalkMap, stalkFunctor, stalkPushforward]
            -- We can't use `ext` here due to https://github.com/leanprover/std4/pull/159
            
          refine colimit.hom_ext fun j => ?_
          induction j with
          | op j => ?_
          dsimp
          simp only [colimit.ι_desc_assoc, ι_colimMap_assoc, whiskerLeft_app, whiskerRight_app, NatTrans.id_app,
            colimit.ι_pre, assoc, colimit.pre_desc, colimit.map_desc, colimit.ι_desc, Cocones.precompose_obj_ι,
            Cocone.whisker_ι, NatTrans.comp_app]
          erw [X.presheaf.map_id, id_comp]
          rfl
      [Elab.step] [0.620840] 
            dsimp [stalkSpecializes, Hom.stalkMap, stalkFunctor, stalkPushforward]
              -- We can't use `ext` here due to https://github.com/leanprover/std4/pull/159
              
            refine colimit.hom_ext fun j => ?_
            induction j with
            | op j => ?_
            dsimp
            simp only [colimit.ι_desc_assoc, ι_colimMap_assoc, whiskerLeft_app, whiskerRight_app, NatTrans.id_app,
              colimit.ι_pre, assoc, colimit.pre_desc, colimit.map_desc, colimit.ι_desc, Cocones.precompose_obj_ι,
              Cocone.whisker_ι, NatTrans.comp_app]
            erw [X.presheaf.map_id, id_comp]
            rfl
        [Elab.step] [0.059790] dsimp [stalkSpecializes, Hom.stalkMap, stalkFunctor, stalkPushforward]
        [Elab.step] [0.164574] refine colimit.hom_ext fun j => ?_
          [Elab.step] [0.164094] expected type: colimit.desc
                    ((OpenNhds.inclusion ((TopCat.Hom.hom f.base) y)).op ⋙ Y.presheaf)
                    { pt := colimit ((OpenNhds.inclusion ((TopCat.Hom.hom f.base) x)).op ⋙ Y.presheaf),
                      ι :=
                        {
                          app := fun U ↦
                            colimit.ι ((OpenNhds.inclusion ((TopCat.Hom.hom f.base) x)).op ⋙ Y.presheaf)
                              (op { obj := (unop U).obj, property := ⋯ }),
                          naturality := ⋯ } } ≫
                  colimMap ((OpenNhds.inclusion ((ConcreteCategory.hom f.base) x)).op.whiskerLeft f.c) ≫
                    colimMap (whiskerRight (𝟙 (OpenNhds.map f.base x ⋙ OpenNhds.inclusion x).op) X.presheaf) ≫
                      colimit.pre ((OpenNhds.inclusion x).op ⋙ X.presheaf) (OpenNhds.map f.base x).op =
                (colimMap ((OpenNhds.inclusion ((ConcreteCategory.hom f.base) y)).op.whiskerLeft f.c) ≫
                    colimMap (whiskerRight (𝟙 (OpenNhds.map f.base y ⋙ OpenNhds.inclusion y).op) X.presheaf) ≫
                      colimit.pre ((OpenNhds.inclusion y).op ⋙ X.presheaf) (OpenNhds.map f.base y).op) ≫
                  colimit.desc ((OpenNhds.inclusion y).op ⋙ X.presheaf)
                    { pt := colimit ((OpenNhds.inclusion x).op ⋙ X.presheaf),
                      ι :=
                        {
                          app := fun U ↦
                            colimit.ι ((OpenNhds.inclusion x).op ⋙ X.presheaf)
                              (op { obj := (unop U).obj, property := ⋯ }),
                          naturality := ⋯ } }, term
              colimit.hom_ext fun j => ?_
            [Meta.synthInstance] [0.155453] ✅️ HasColimit
                  (((whiskeringLeft (OpenNhds ((TopCat.Hom.hom f.base) y))ᵒᵖ (Opens ↑↑Y)ᵒᵖ C).obj
                        (OpenNhds.inclusion ((TopCat.Hom.hom f.base) y)).op).obj
                    Y.presheaf)
        [Elab.step] [0.015593] dsimp
        [Elab.step] [0.271306] simp only [colimit.ι_desc_assoc, ι_colimMap_assoc, whiskerLeft_app, whiskerRight_app,
              NatTrans.id_app, colimit.ι_pre, assoc, colimit.pre_desc, colimit.map_desc, colimit.ι_desc,
              Cocones.precompose_obj_ι, Cocone.whisker_ι, NatTrans.comp_app]
          [Meta.isDefEq] [0.011490] ✅️ colimit.ι ?F ?j ≫
                colimit.desc ?F ?c ≫
                  ?h =?= colimit.ι ((OpenNhds.inclusion ((TopCat.Hom.hom f.base) y)).op ⋙ Y.presheaf) (op j) ≫
                colimit.desc ((OpenNhds.inclusion ((TopCat.Hom.hom f.base) y)).op ⋙ Y.presheaf)
                    { pt := colimit ((OpenNhds.inclusion ((TopCat.Hom.hom f.base) x)).op ⋙ Y.presheaf),
                      ι :=
                        {
                          app := fun U ↦
                            colimit.ι ((OpenNhds.inclusion ((TopCat.Hom.hom f.base) x)).op ⋙ Y.presheaf)
                              (op { obj := (unop U).obj, property := ⋯ }),
                          naturality := ⋯ } } ≫
                  colimMap ((OpenNhds.inclusion ((ConcreteCategory.hom f.base) x)).op.whiskerLeft f.c) ≫
                    colimMap (whiskerRight (𝟙 (OpenNhds.map f.base x ⋙ OpenNhds.inclusion x).op) X.presheaf) ≫
                      colimit.pre ((OpenNhds.inclusion x).op ⋙ X.presheaf) (OpenNhds.map f.base x).op
            [Meta.isDefEq] [0.010484] ✅️ colimit.desc ((OpenNhds.inclusion ((TopCat.Hom.hom f.base) y)).op ⋙ Y.presheaf)
                    ?c ≫
                  ?h =?= colimit.desc ((OpenNhds.inclusion ((TopCat.Hom.hom f.base) y)).op ⋙ Y.presheaf)
                    { pt := colimit ((OpenNhds.inclusion ((TopCat.Hom.hom f.base) x)).op ⋙ Y.presheaf),
                      ι :=
                        {
                          app := fun U ↦
                            colimit.ι ((OpenNhds.inclusion ((TopCat.Hom.hom f.base) x)).op ⋙ Y.presheaf)
                              (op { obj := (unop U).obj, property := ⋯ }),
                          naturality := ⋯ } } ≫
                  colimMap ((OpenNhds.inclusion ((ConcreteCategory.hom f.base) x)).op.whiskerLeft f.c) ≫
                    colimMap (whiskerRight (𝟙 (OpenNhds.map f.base x ⋙ OpenNhds.inclusion x).op) X.presheaf) ≫
                      colimit.pre ((OpenNhds.inclusion x).op ⋙ X.presheaf) (OpenNhds.map f.base x).op
          [Meta.isDefEq] [0.010218] ✅️ (whiskerRight ?α ?F).app
                ?X =?= (whiskerRight (𝟙 (OpenNhds.map f.base x ⋙ OpenNhds.inclusion x).op) X.presheaf).app
                (op { obj := j.obj, property := ⋯ })
            [Meta.isDefEq.delta] [0.010185] ✅️ (whiskerRight ?α ?F).app
                  ?X =?= (whiskerRight (𝟙 (OpenNhds.map f.base x ⋙ OpenNhds.inclusion x).op) X.presheaf).app
                  (op { obj := j.obj, property := ⋯ })
          [Meta.isDefEq] [0.010523] ✅️ colimMap ?α ≫
                colimit.desc ?G
                  ?c =?= colimMap (whiskerRight (𝟙 (OpenNhds.map f.base y ⋙ OpenNhds.inclusion y).op) X.presheaf) ≫
                colimit.desc ((OpenNhds.map f.base y).op ⋙ (OpenNhds.inclusion y).op ⋙ X.presheaf)
                  (Cocone.whisker (OpenNhds.map f.base y).op
                    { pt := colimit ((OpenNhds.inclusion x).op ⋙ X.presheaf),
                      ι :=
                        {
                          app := fun U ↦
                            colimit.ι ((OpenNhds.inclusion x).op ⋙ X.presheaf)
                              (op { obj := (unop U).obj, property := ⋯ }),
                          naturality := ⋯ } })
          [Meta.synthInstance] [0.138911] ✅️ HasColimitsOfShape (OpenNhds ((ConcreteCategory.hom f.base) y))ᵒᵖ C
            [Meta.synthInstance] [0.011998] ❌️ apply @BooleanAlgebra.toBoundedOrder to BoundedOrder
                  (OpenNhds ((ConcreteCategory.hom f.base) y))
              [Meta.synthInstance.tryResolve] [0.011965] ❌️ BoundedOrder
                    (OpenNhds ((ConcreteCategory.hom f.base) y)) ≟ BoundedOrder ?m.61603
                [Meta.isDefEq] [0.011920] ❌️ BoundedOrder
                      (OpenNhds ((ConcreteCategory.hom f.base) y)) =?= BoundedOrder ?m.61603
                  [Meta.isDefEq] [0.011809] ❌️ (OpenNhds.instLattice
                          ((ConcreteCategory.hom f.base)
                            y)).toLE =?= BooleanAlgebra.toDistribLattice.toSemilatticeInf.toLE
            [Meta.synthInstance] [0.015582] ❌️ apply @CoheytingAlgebra.toBoundedOrder to BoundedOrder
                  (OpenNhds ((ConcreteCategory.hom f.base) y))
              [Meta.synthInstance.tryResolve] [0.015536] ❌️ BoundedOrder
                    (OpenNhds ((ConcreteCategory.hom f.base) y)) ≟ BoundedOrder ?m.61642
                [Meta.isDefEq] [0.015487] ❌️ BoundedOrder
                      (OpenNhds ((ConcreteCategory.hom f.base) y)) =?= BoundedOrder ?m.61642
                  [Meta.isDefEq] [0.015310] ❌️ (OpenNhds.instLattice
                          ((ConcreteCategory.hom f.base)
                            y)).toLE =?= CoheytingAlgebra.toGeneralizedCoheytingAlgebra.toSemilatticeInf.toLE
                    [Meta.isDefEq.delta] [0.013448] ❌️ (OpenNhds.instLattice
                            ((ConcreteCategory.hom f.base)
                              y)).toLE =?= CoheytingAlgebra.toGeneralizedCoheytingAlgebra.toSemilatticeInf.toLE
                      [Meta.isDefEq] [0.013425] ❌️ (OpenNhds.instLattice
                              ((ConcreteCategory.hom f.base)
                                y)).toPreorder =?= CoheytingAlgebra.toGeneralizedCoheytingAlgebra.toSemilatticeInf.toPreorder
                        [Meta.isDefEq.delta] [0.010253] ❌️ (OpenNhds.instLattice
                                ((ConcreteCategory.hom f.base)
                                  y)).toPreorder =?= CoheytingAlgebra.toGeneralizedCoheytingAlgebra.toSemilatticeInf.toPreorder
                          [Meta.isDefEq] [0.010240] ❌️ (OpenNhds.instLattice
                                  ((ConcreteCategory.hom f.base)
                                    y)).toPartialOrder =?= CoheytingAlgebra.toGeneralizedCoheytingAlgebra.toSemilatticeInf.toPartialOrder
                            [Meta.isDefEq] [0.010149] ❌️ (OpenNhds.instLattice
                                    ((ConcreteCategory.hom f.base)
                                      y)).toPartialOrder =?= CoheytingAlgebra.toGeneralizedCoheytingAlgebra.toPartialOrder
            [Meta.synthInstance] [0.013427] ❌️ apply @HeytingAlgebra.toOrderBot to OrderBot
                  (OpenNhds ((ConcreteCategory.hom f.base) y))
              [Meta.synthInstance.tryResolve] [0.013405] ❌️ OrderBot
                    (OpenNhds ((ConcreteCategory.hom f.base) y)) ≟ OrderBot ?m.62409
                [Meta.isDefEq] [0.013394] ❌️ OrderBot (OpenNhds ((ConcreteCategory.hom f.base) y)) =?= OrderBot ?m.62409
                  [Meta.isDefEq] [0.013335] ❌️ (OpenNhds.partialOrder
                          ((ConcreteCategory.hom f.base) y)).toLE =?= HeytingAlgebra.toGeneralizedHeytingAlgebra.toLE
                    [Meta.isDefEq.delta] [0.011364] ❌️ (OpenNhds.partialOrder
                            ((ConcreteCategory.hom f.base) y)).toLE =?= HeytingAlgebra.toGeneralizedHeytingAlgebra.toLE
                      [Meta.isDefEq] [0.011348] ❌️ (OpenNhds.partialOrder
                              ((ConcreteCategory.hom f.base)
                                y)).toPreorder =?= HeytingAlgebra.toGeneralizedHeytingAlgebra.toPreorder
                        [Meta.isDefEq.delta] [0.010235] ❌️ (OpenNhds.partialOrder
                                ((ConcreteCategory.hom f.base)
                                  y)).toPreorder =?= HeytingAlgebra.toGeneralizedHeytingAlgebra.toPreorder
                          [Meta.isDefEq] [0.010220] ❌️ OpenNhds.partialOrder
                                ((ConcreteCategory.hom f.base)
                                  y) =?= HeytingAlgebra.toGeneralizedHeytingAlgebra.toPartialOrder
                            [Meta.isDefEq] [0.010176] ❌️ { le := fun U V ↦ U.obj ≤ V.obj, le_refl := ⋯, le_trans := ⋯,
                                  lt_iff_le_not_ge := ⋯,
                                  le_antisymm := ⋯ } =?= HeytingAlgebra.toGeneralizedHeytingAlgebra.toPartialOrder
                              [Meta.isDefEq] [0.010164] ❌️ { le := fun U V ↦ U.obj ≤ V.obj, le_refl := ⋯, le_trans := ⋯,
                                    lt_iff_le_not_ge := ⋯,
                                    le_antisymm := ⋯ } =?= HeytingAlgebra.toGeneralizedHeytingAlgebra.toSemilatticeSup.1
                                [Meta.isDefEq] [0.010046] ❌️ HeytingAlgebra.toGeneralizedHeytingAlgebra.toSemilatticeSup.1.toPreorder =?= {
                                      le := fun U V ↦ U.obj ≤ V.obj, le_refl := ⋯, le_trans := ⋯,
                                      lt_iff_le_not_ge := ⋯ }
                                  [Meta.isDefEq] [0.010033] ❌️ HeytingAlgebra.toGeneralizedHeytingAlgebra.toSemilatticeSup.1.1 =?= {
                                        le := fun U V ↦ U.obj ≤ V.obj, le_refl := ⋯, le_trans := ⋯,
                                        lt_iff_le_not_ge := ⋯ }
        [Elab.step] [0.104614] erw [X.presheaf.map_id, id_comp]
          [Elab.step] [0.102932] rw (transparency✝ := .default✝) [X.presheaf.map_id, id_comp]
            [Elab.step] [0.102923] (rewrite (transparency✝ := .default✝) [X.presheaf.map_id, id_comp];
                  with_annotate_state"]" (try (with_reducible rfl)))
              [Elab.step] [0.102916] rewrite (transparency✝ := .default✝) [X.presheaf.map_id, id_comp];
                    with_annotate_state"]" (try (with_reducible rfl))
                [Elab.step] [0.102910] rewrite (transparency✝ := .default✝) [X.presheaf.map_id, id_comp];
                      with_annotate_state"]" (try (with_reducible rfl))
                  [Elab.step] [0.101366] rewrite (transparency✝ := .default✝) [X.presheaf.map_id, id_comp]
                    [Meta.check] [0.037638] ✅️ fun _a ↦
                          f.c.app
                                ((OpenNhds.inclusion ((ConcreteCategory.hom f.base) x)).op.obj
                                  (op { obj := j.obj, property := ⋯ })) ≫
                              _a ≫
                                colimit.ι ((OpenNhds.inclusion x).op ⋙ X.presheaf)
                                  ((OpenNhds.map f.base x).op.obj (op { obj := j.obj, property := ⋯ })) =
                            f.c.app ((OpenNhds.inclusion ((ConcreteCategory.hom f.base) y)).op.obj (op j)) ≫
                              _a ≫
                                colimit.ι ((OpenNhds.inclusion x).op ⋙ X.presheaf)
                                  (op { obj := (unop ((OpenNhds.map f.base y).op.obj (op j))).obj, property := ⋯ })
                    [Meta.check] [0.027742] ✅️ fun _a ↦
                          f.c.app
                                ((OpenNhds.inclusion ((ConcreteCategory.hom f.base) x)).op.obj
                                  (op { obj := j.obj, property := ⋯ })) ≫
                              _a =
                            f.c.app ((OpenNhds.inclusion ((ConcreteCategory.hom f.base) y)).op.obj (op j)) ≫ _a
info: Mathlib/Geometry/RingedSpace/Stalks.lean:186:8: [Elab.async] [0.046946] Lean.addDecl
  [Kernel] [0.046926] typechecking declarations [AlgebraicGeometry.PresheafedSpace.stalkMap.stalkSpecializes_stalkMap]
info: Mathlib/Geometry/RingedSpace/Stalks.lean:185:2: [Elab.async] [0.050374] Lean.addDecl
  [Kernel] [0.050355] typechecking declarations [AlgebraicGeometry.PresheafedSpace.stalkMap.stalkSpecializes_stalkMap_assoc]
info: Mathlib/Geometry/RingedSpace/Stalks.lean:185:26: [Elab.async] [0.076721] Lean.addDecl
  [Kernel] [0.076693] typechecking declarations [AlgebraicGeometry.PresheafedSpace.stalkMap.stalkSpecializes_stalkMap_apply]
Build completed successfully.
```

### Trace profiling of `stalkSpecializes_stalkMap` after PR 27656
```diff
diff --git a/Mathlib/Geometry/RingedSpace/Stalks.lean b/Mathlib/Geometry/RingedSpace/Stalks.lean
index 1440d9f1af..115caed2ad 100644
--- a/Mathlib/Geometry/RingedSpace/Stalks.lean
+++ b/Mathlib/Geometry/RingedSpace/Stalks.lean
@@ -183,2 +183,3 @@ def stalkIso {X Y : PresheafedSpace.{_, _, v} C} (α : X ≅ Y) (x : X) :
 
+set_option trace.profiler true in
 @[reassoc (attr := simp), elementwise (attr := simp)]
@@ -199,4 +200,3 @@ theorem stalkSpecializes_stalkMap {X Y : PresheafedSpace.{_, _, v} C}
     Cocone.whisker_ι, NatTrans.comp_app]
-  erw [X.presheaf.map_id, id_comp]
-  rfl
+  tauto
 
```
```
ℹ [1147/1147] Built Mathlib.Geometry.RingedSpace.Stalks
info: Mathlib/Geometry/RingedSpace/Stalks.lean:185:0: [Elab.command] [0.574442] @[reassoc (attr := simp), elementwise (attr := simp)]
    theorem stalkSpecializes_stalkMap {X Y : PresheafedSpace.{_, _, v} C} (f : X ⟶ Y) {x y : X} (h : x ⤳ y) :
        Y.presheaf.stalkSpecializes (f.base.hom.map_specializes h) ≫ f.stalkMap x =
          f.stalkMap y ≫ X.presheaf.stalkSpecializes h :=
      by
      -- Porting note: the original one liner `dsimp [stalkMap]; simp [stalkMap]` doesn't work,
        -- I had to uglify this
      
      dsimp [stalkSpecializes, Hom.stalkMap, stalkFunctor, stalkPushforward]
        -- We can't use `ext` here due to https://github.com/leanprover/std4/pull/159
        
      refine colimit.hom_ext fun j => ?_
      induction j with
      | op j => ?_
      dsimp
      simp only [colimit.ι_desc_assoc, ι_colimMap_assoc, whiskerLeft_app, whiskerRight_app, NatTrans.id_app,
        colimit.ι_pre, assoc, colimit.pre_desc, colimit.map_desc, colimit.ι_desc, Cocones.precompose_obj_ι,
        Cocone.whisker_ι, NatTrans.comp_app]
      tauto
  [Elab.attribute] [0.534843] applying [reassoc (attr := simp)]
  [Elab.attribute] [0.029518] applying [elementwise (attr := simp)]
info: Mathlib/Geometry/RingedSpace/Stalks.lean:185:0: [Elab.async] [0.518954] elaborating proof of AlgebraicGeometry.PresheafedSpace.stalkMap.stalkSpecializes_stalkMap
  [Elab.definition.value] [0.515007] AlgebraicGeometry.PresheafedSpace.stalkMap.stalkSpecializes_stalkMap
    [Elab.step] [0.513351] 
          dsimp [stalkSpecializes, Hom.stalkMap, stalkFunctor, stalkPushforward]
            -- We can't use `ext` here due to https://github.com/leanprover/std4/pull/159
            
          refine colimit.hom_ext fun j => ?_
          induction j with
          | op j => ?_
          dsimp
          simp only [colimit.ι_desc_assoc, ι_colimMap_assoc, whiskerLeft_app, whiskerRight_app, NatTrans.id_app,
            colimit.ι_pre, assoc, colimit.pre_desc, colimit.map_desc, colimit.ι_desc, Cocones.precompose_obj_ι,
            Cocone.whisker_ι, NatTrans.comp_app]
          tauto
      [Elab.step] [0.513336] 
            dsimp [stalkSpecializes, Hom.stalkMap, stalkFunctor, stalkPushforward]
              -- We can't use `ext` here due to https://github.com/leanprover/std4/pull/159
              
            refine colimit.hom_ext fun j => ?_
            induction j with
            | op j => ?_
            dsimp
            simp only [colimit.ι_desc_assoc, ι_colimMap_assoc, whiskerLeft_app, whiskerRight_app, NatTrans.id_app,
              colimit.ι_pre, assoc, colimit.pre_desc, colimit.map_desc, colimit.ι_desc, Cocones.precompose_obj_ι,
              Cocone.whisker_ι, NatTrans.comp_app]
            tauto
        [Elab.step] [0.064070] dsimp [stalkSpecializes, Hom.stalkMap, stalkFunctor, stalkPushforward]
          [Meta.isDefEq] [0.011951] ✅️ colim.map
                ?α =?= colim.map (whiskerRight (𝟙 (OpenNhds.map f.base x ⋙ OpenNhds.inclusion x).op) X.presheaf)
            [Meta.isDefEq.delta] [0.011888] ✅️ colim.map
                  ?α =?= colim.map (whiskerRight (𝟙 (OpenNhds.map f.base x ⋙ OpenNhds.inclusion x).op) X.presheaf)
              [Meta.isDefEq] [0.011036] ✅️ ?α =?= whiskerRight (𝟙 (OpenNhds.map f.base x ⋙ OpenNhds.inclusion x).op)
                    X.presheaf
                [Meta.isDefEq.assign] [0.011033] ✅️ ?α := whiskerRight
                      (𝟙 (OpenNhds.map f.base x ⋙ OpenNhds.inclusion x).op) X.presheaf
                  [Meta.isDefEq.assign.checkTypes] [0.011000] ✅️ (?α : (OpenNhds.inclusion
                              ((ConcreteCategory.hom f.base) x)).op ⋙
                          (pushforward C f.base).obj X.presheaf ⟶
                        (OpenNhds.map f.base x).op ⋙
                          (OpenNhds.inclusion x).op ⋙
                            X.presheaf) := (whiskerRight (𝟙 (OpenNhds.map f.base x ⋙ OpenNhds.inclusion x).op)
                        X.presheaf : (OpenNhds.inclusion ((ConcreteCategory.hom f.base) x) ⋙ Opens.map f.base).op ⋙
                          X.presheaf ⟶
                        (OpenNhds.map f.base x ⋙ OpenNhds.inclusion x).op ⋙ X.presheaf)
                    [Meta.isDefEq] [0.010995] ✅️ (OpenNhds.inclusion ((ConcreteCategory.hom f.base) x)).op ⋙
                            (pushforward C f.base).obj X.presheaf ⟶
                          (OpenNhds.map f.base x).op ⋙
                            (OpenNhds.inclusion x).op ⋙
                              X.presheaf =?= (OpenNhds.inclusion ((ConcreteCategory.hom f.base) x) ⋙
                                Opens.map f.base).op ⋙
                            X.presheaf ⟶
                          (OpenNhds.map f.base x ⋙ OpenNhds.inclusion x).op ⋙ X.presheaf
                      [Meta.isDefEq] [0.010958] ✅️ category.toQuiver.1
                            ((OpenNhds.inclusion ((ConcreteCategory.hom f.base) x)).op ⋙
                              (pushforward C f.base).obj X.presheaf)
                            ((OpenNhds.map f.base x).op ⋙
                              (OpenNhds.inclusion x).op ⋙
                                X.presheaf) =?= category.toQuiver.1
                            ((OpenNhds.inclusion ((ConcreteCategory.hom f.base) x) ⋙ Opens.map f.base).op ⋙ X.presheaf)
                            ((OpenNhds.map f.base x ⋙ OpenNhds.inclusion x).op ⋙ X.presheaf)
                        [Meta.isDefEq] [0.010828] ✅️ NatTrans
                              ((OpenNhds.inclusion ((ConcreteCategory.hom f.base) x)).op ⋙
                                (pushforward C f.base).obj X.presheaf)
                              ((OpenNhds.map f.base x).op ⋙
                                (OpenNhds.inclusion x).op ⋙
                                  X.presheaf) =?= NatTrans
                              ((OpenNhds.inclusion ((ConcreteCategory.hom f.base) x) ⋙ Opens.map f.base).op ⋙
                                X.presheaf)
                              ((OpenNhds.map f.base x ⋙ OpenNhds.inclusion x).op ⋙ X.presheaf)
        [Elab.step] [0.164481] refine colimit.hom_ext fun j => ?_
          [Elab.step] [0.164004] expected type: colimit.desc
                    ((OpenNhds.inclusion ((TopCat.Hom.hom f.base) y)).op ⋙ Y.presheaf)
                    { pt := colimit ((OpenNhds.inclusion ((TopCat.Hom.hom f.base) x)).op ⋙ Y.presheaf),
                      ι :=
                        {
                          app := fun U ↦
                            colimit.ι ((OpenNhds.inclusion ((TopCat.Hom.hom f.base) x)).op ⋙ Y.presheaf)
                              (op { obj := (unop U).obj, property := ⋯ }),
                          naturality := ⋯ } } ≫
                  colimMap ((OpenNhds.inclusion ((ConcreteCategory.hom f.base) x)).op.whiskerLeft f.c) ≫
                    colimMap (whiskerRight (𝟙 (OpenNhds.map f.base x ⋙ OpenNhds.inclusion x).op) X.presheaf) ≫
                      colimit.pre ((OpenNhds.inclusion x).op ⋙ X.presheaf) (OpenNhds.map f.base x).op =
                (colimMap ((OpenNhds.inclusion ((ConcreteCategory.hom f.base) y)).op.whiskerLeft f.c) ≫
                    colimMap (whiskerRight (𝟙 (OpenNhds.map f.base y ⋙ OpenNhds.inclusion y).op) X.presheaf) ≫
                      colimit.pre ((OpenNhds.inclusion y).op ⋙ X.presheaf) (OpenNhds.map f.base y).op) ≫
                  colimit.desc ((OpenNhds.inclusion y).op ⋙ X.presheaf)
                    { pt := colimit ((OpenNhds.inclusion x).op ⋙ X.presheaf),
                      ι :=
                        {
                          app := fun U ↦
                            colimit.ι ((OpenNhds.inclusion x).op ⋙ X.presheaf)
                              (op { obj := (unop U).obj, property := ⋯ }),
                          naturality := ⋯ } }, term
              colimit.hom_ext fun j => ?_
            [Meta.synthInstance] [0.159686] ✅️ HasColimit
                  (((whiskeringLeft (OpenNhds ((TopCat.Hom.hom f.base) y))ᵒᵖ (Opens ↑↑Y)ᵒᵖ C).obj
                        (OpenNhds.inclusion ((TopCat.Hom.hom f.base) y)).op).obj
                    Y.presheaf)
              [Meta.synthInstance] [0.013890] ❌️ apply @GeneralizedBooleanAlgebra.toOrderBot to OrderBot
                    (OpenNhds ((TopCat.Hom.hom f.base) y))
                [Meta.synthInstance.tryResolve] [0.013857] ❌️ OrderBot
                      (OpenNhds ((TopCat.Hom.hom f.base) y)) ≟ OrderBot ?m.57320
                  [Meta.isDefEq] [0.013814] ❌️ OrderBot (OpenNhds ((TopCat.Hom.hom f.base) y)) =?= OrderBot ?m.57320
                    [Meta.isDefEq] [0.013706] ❌️ (OpenNhds.instLattice
                            ((TopCat.Hom.hom f.base)
                              y)).toLE =?= GeneralizedBooleanAlgebra.toDistribLattice.toSemilatticeInf.toLE
                      [Meta.isDefEq.delta] [0.012023] ❌️ (OpenNhds.instLattice
                              ((TopCat.Hom.hom f.base)
                                y)).toLE =?= GeneralizedBooleanAlgebra.toDistribLattice.toSemilatticeInf.toLE
                        [Meta.isDefEq] [0.012012] ❌️ (OpenNhds.instLattice
                                ((TopCat.Hom.hom f.base)
                                  y)).toPreorder =?= GeneralizedBooleanAlgebra.toDistribLattice.toSemilatticeInf.toPreorder
              [Meta.synthInstance] [0.010702] ❌️ apply @GeneralizedCoheytingAlgebra.toOrderBot to OrderBot
                    (OpenNhds ((TopCat.Hom.hom f.base) y))
                [Meta.synthInstance.tryResolve] [0.010659] ❌️ OrderBot
                      (OpenNhds ((TopCat.Hom.hom f.base) y)) ≟ OrderBot ?m.57359
                  [Meta.isDefEq] [0.010608] ❌️ OrderBot (OpenNhds ((TopCat.Hom.hom f.base) y)) =?= OrderBot ?m.57359
        [Elab.step] [0.257030] simp only [colimit.ι_desc_assoc, ι_colimMap_assoc, whiskerLeft_app, whiskerRight_app,
              NatTrans.id_app, colimit.ι_pre, assoc, colimit.pre_desc, colimit.map_desc, colimit.ι_desc,
              Cocones.precompose_obj_ι, Cocone.whisker_ι, NatTrans.comp_app]
          [Meta.isDefEq] [0.017085] ✅️ colimMap ?α ≫
                colimit.desc ?G
                  ?c =?= colimMap (whiskerRight (𝟙 (OpenNhds.map f.base y ⋙ OpenNhds.inclusion y).op) X.presheaf) ≫
                colimit.desc ((OpenNhds.map f.base y).op ⋙ (OpenNhds.inclusion y).op ⋙ X.presheaf)
                  (Cocone.whisker (OpenNhds.map f.base y).op
                    { pt := colimit ((OpenNhds.inclusion x).op ⋙ X.presheaf),
                      ι :=
                        {
                          app := fun U ↦
                            colimit.ι ((OpenNhds.inclusion x).op ⋙ X.presheaf)
                              (op { obj := (unop U).obj, property := ⋯ }),
                          naturality := ⋯ } })
            [Meta.isDefEq] [0.011374] ✅️ colimMap
                  ?α =?= colimMap (whiskerRight (𝟙 (OpenNhds.map f.base y ⋙ OpenNhds.inclusion y).op) X.presheaf)
              [Meta.isDefEq] [0.010653] ✅️ ?α =?= whiskerRight (𝟙 (OpenNhds.map f.base y ⋙ OpenNhds.inclusion y).op)
                    X.presheaf
                [Meta.isDefEq.assign] [0.010649] ✅️ ?α := whiskerRight
                      (𝟙 (OpenNhds.map f.base y ⋙ OpenNhds.inclusion y).op) X.presheaf
                  [Meta.isDefEq.assign.checkTypes] [0.010618] ✅️ (?α : (OpenNhds.inclusion
                              ((ConcreteCategory.hom f.base) y)).op ⋙
                          (pushforward C f.base).obj X.presheaf ⟶
                        (OpenNhds.map f.base y).op ⋙
                          (OpenNhds.inclusion y).op ⋙
                            X.presheaf) := (whiskerRight (𝟙 (OpenNhds.map f.base y ⋙ OpenNhds.inclusion y).op)
                        X.presheaf : (OpenNhds.inclusion ((ConcreteCategory.hom f.base) y) ⋙ Opens.map f.base).op ⋙
                          X.presheaf ⟶
                        (OpenNhds.map f.base y ⋙ OpenNhds.inclusion y).op ⋙ X.presheaf)
                    [Meta.isDefEq] [0.010613] ✅️ (OpenNhds.inclusion ((ConcreteCategory.hom f.base) y)).op ⋙
                            (pushforward C f.base).obj X.presheaf ⟶
                          (OpenNhds.map f.base y).op ⋙
                            (OpenNhds.inclusion y).op ⋙
                              X.presheaf =?= (OpenNhds.inclusion ((ConcreteCategory.hom f.base) y) ⋙
                                Opens.map f.base).op ⋙
                            X.presheaf ⟶
                          (OpenNhds.map f.base y ⋙ OpenNhds.inclusion y).op ⋙ X.presheaf
                      [Meta.isDefEq] [0.010570] ✅️ category.toQuiver.1
                            ((OpenNhds.inclusion ((ConcreteCategory.hom f.base) y)).op ⋙
                              (pushforward C f.base).obj X.presheaf)
                            ((OpenNhds.map f.base y).op ⋙
                              (OpenNhds.inclusion y).op ⋙
                                X.presheaf) =?= category.toQuiver.1
                            ((OpenNhds.inclusion ((ConcreteCategory.hom f.base) y) ⋙ Opens.map f.base).op ⋙ X.presheaf)
                            ((OpenNhds.map f.base y ⋙ OpenNhds.inclusion y).op ⋙ X.presheaf)
                        [Meta.isDefEq] [0.010418] ✅️ NatTrans
                              ((OpenNhds.inclusion ((ConcreteCategory.hom f.base) y)).op ⋙
                                (pushforward C f.base).obj X.presheaf)
                              ((OpenNhds.map f.base y).op ⋙
                                (OpenNhds.inclusion y).op ⋙
                                  X.presheaf) =?= NatTrans
                              ((OpenNhds.inclusion ((ConcreteCategory.hom f.base) y) ⋙ Opens.map f.base).op ⋙
                                X.presheaf)
                              ((OpenNhds.map f.base y ⋙ OpenNhds.inclusion y).op ⋙ X.presheaf)
          [Meta.synthInstance] [0.120468] ✅️ HasColimitsOfShape (OpenNhds ((ConcreteCategory.hom f.base) y))ᵒᵖ C
            [Meta.synthInstance] [0.011075] ❌️ apply @CompleteLattice.toBoundedOrder to BoundedOrder
                  (OpenNhds ((ConcreteCategory.hom f.base) y))
              [Meta.synthInstance.tryResolve] [0.011054] ❌️ BoundedOrder
                    (OpenNhds ((ConcreteCategory.hom f.base) y)) ≟ BoundedOrder ?m.61530
                [Meta.isDefEq] [0.011031] ❌️ BoundedOrder
                      (OpenNhds ((ConcreteCategory.hom f.base) y)) =?= BoundedOrder ?m.61530
            [Meta.synthInstance] [0.016436] ❌️ apply @CompleteLattice.hasColimits_of_completeLattice to HasColimits
                  (OpenNhds ((ConcreteCategory.hom f.base) y))
              [Meta.synthInstance.tryResolve] [0.016392] ❌️ HasColimits
                    (OpenNhds
                      ((ConcreteCategory.hom f.base)
                        y)) ≟ HasColimitsOfSize.{?u.61885, ?u.61886, ?u.61887, ?u.61887} ?m.61890
                [Meta.isDefEq] [0.016370] ❌️ HasColimits
                      (OpenNhds
                        ((ConcreteCategory.hom f.base)
                          y)) =?= HasColimitsOfSize.{?u.61885, ?u.61886, ?u.61887, ?u.61887} ?m.61890
                  [Meta.isDefEq] [0.016339] ❌️ HasColimitsOfSize.{v, v, v, v}
                        (OpenNhds
                          ((ConcreteCategory.hom f.base)
                            y)) =?= HasColimitsOfSize.{?u.61885, ?u.61886, ?u.61887, ?u.61887} ?m.61890
                    [Meta.isDefEq] [0.016255] ❌️ OpenNhds.openNhdsCategory
                          ((ConcreteCategory.hom f.base)
                            y) =?= Preorder.smallCategory (OpenNhds ((ConcreteCategory.hom f.base) y))
                      [Meta.isDefEq] [0.016204] ❌️ inferInstance =?= { Hom := fun U V ↦ ULift.{v, 0} (PLift (U ≤ V)),
                            id := fun X_1 ↦ { down := { down := ⋯ } },
                            comp := fun {X_1 Y_1 Z} f_1 g ↦ { down := { down := ⋯ } }, id_comp := ⋯, comp_id := ⋯,
                            assoc := ⋯ }
                        [Meta.isDefEq] [0.016154] ❌️ Preorder.smallCategory
                              (OpenNhds
                                ((ConcreteCategory.hom f.base)
                                  y)) =?= { Hom := fun U V ↦ ULift.{v, 0} (PLift (U ≤ V)),
                              id := fun X_1 ↦ { down := { down := ⋯ } },
                              comp := fun {X_1 Y_1 Z} f_1 g ↦ { down := { down := ⋯ } }, id_comp := ⋯, comp_id := ⋯,
                              assoc := ⋯ }
                          [Meta.isDefEq] [0.014700] ❌️ { Hom := fun U V ↦ ULift.{v, 0} (PLift (U ≤ V)),
                                id := fun X_1 ↦ { down := { down := ⋯ } },
                                comp := fun {X_1 Y_1 Z} f_1 g ↦ { down := { down := ⋯ } }, id_comp := ⋯, comp_id := ⋯,
                                assoc :=
                                  ⋯ } =?= { Hom := fun U V ↦ ULift.{v, 0} (PLift (U ≤ V)),
                                id := fun X_1 ↦ { down := { down := ⋯ } },
                                comp := fun {X_1 Y_1 Z} f_1 g ↦ { down := { down := ⋯ } }, id_comp := ⋯, comp_id := ⋯,
                                assoc := ⋯ }
                            [Meta.isDefEq] [0.014647] ❌️ { Hom := fun U V ↦ ULift.{v, 0} (PLift (U ≤ V)),
                                  id := fun X_1 ↦ { down := { down := ⋯ } },
                                  comp := fun {X_1 Y_1 Z} f_1 g ↦
                                    {
                                      down :=
                                        {
                                          down :=
                                            ⋯ } } } =?= { Hom := fun U V ↦ ULift.{v, 0} (PLift (U ≤ V)),
                                  id := fun X_1 ↦ { down := { down := ⋯ } },
                                  comp := fun {X_1 Y_1 Z} f_1 g ↦ { down := { down := ⋯ } } }
                              [Meta.isDefEq] [0.014605] ❌️ fun X_1 ↦
                                    { down := { down := ⋯ } } =?= fun X_1 ↦ { down := { down := ⋯ } }
                                [Meta.isDefEq] [0.014589] ❌️ { down := { down := ⋯ } } =?= { down := { down := ⋯ } }
                                  [Meta.isDefEq] [0.014519] ❌️ { down := ⋯ } =?= { down := ⋯ }
                                    [Meta.isDefEq] [0.014425] ❌️ X ≤ X =?= X ≤ X
        [Elab.step] [0.018070] tauto
info: Mathlib/Geometry/RingedSpace/Stalks.lean:186:8: [Elab.async] [0.054797] Lean.addDecl
  [Kernel] [0.054774] typechecking declarations [AlgebraicGeometry.PresheafedSpace.stalkMap.stalkSpecializes_stalkMap]
info: Mathlib/Geometry/RingedSpace/Stalks.lean:185:2: [Elab.async] [0.044230] Lean.addDecl
  [Kernel] [0.044215] typechecking declarations [AlgebraicGeometry.PresheafedSpace.stalkMap.stalkSpecializes_stalkMap_assoc]
info: Mathlib/Geometry/RingedSpace/Stalks.lean:185:26: [Elab.async] [0.060723] Lean.addDecl
  [Kernel] [0.060702] typechecking declarations [AlgebraicGeometry.PresheafedSpace.stalkMap.stalkSpecializes_stalkMap_apply]
Build completed successfully.
```
</details>
