### PR TITLE
[Merged by Bors] - chore(Algebra/Group/WithOne): injectivity of `coe` and `map`

### DIFF
--- a/Mathlib/Algebra/Group/WithOne/Basic.lean
+++ b/Mathlib/Algebra/Group/WithOne/Basic.lean
@@ -93,6 +93,19 @@ theorem map_id : map (MulHom.id α) = MonoidHom.id (WithOne α) := by
   induction x <;> rfl
 
 @[to_additive]
+theorem map_injective {f : α →ₙ* β} (hf : Function.Injective f) : Function.Injective (map f)
+  | none, none, _ => rfl
+  | (a₁ : α), (a₂ : α), H => by simpa [hf.eq_iff] using H
+
+@[to_additive]
+theorem map_injective' : Function.Injective (WithOne.map (α := α) (β := β)) := fun f g h ↦
+  MulHom.ext fun x ↦ coe_injective <| by simp only [← map_coe, h]
+
+@[to_additive (attr := simp)]
+theorem map_inj {f g : α →ₙ* β} : map f = map g ↔ f = g :=
+  map_injective'.eq_iff
+
+@[to_additive]
 theorem map_map (f : α →ₙ* β) (g : β →ₙ* γ) (x) : map g (map f x) = map (g.comp f) x := by
   induction x <;> rfl
 

--- a/Mathlib/Algebra/Group/WithOne/Defs.lean
+++ b/Mathlib/Algebra/Group/WithOne/Defs.lean
@@ -152,6 +152,10 @@ instance instCanLift : CanLift (WithOne α) α (↑) fun a => a ≠ 1 where
 theorem coe_inj {a b : α} : (a : WithOne α) = b ↔ a = b :=
   Option.some_inj
 
+@[to_additive]
+lemma coe_injective : Function.Injective (coe : α → WithOne α) :=
+  fun _ _ ↦ coe_inj.mp
+
 @[to_additive (attr := elab_as_elim)]
 protected theorem cases_on {P : WithOne α → Prop} : ∀ x : WithOne α, P 1 → (∀ a : α, P a) → P x :=
   Option.casesOn

--- a/Mathlib/Algebra/Group/WithOne/Defs.lean
+++ b/Mathlib/Algebra/Group/WithOne/Defs.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Johan Commelin
 -/
 import Mathlib.Algebra.Group.Defs
+import Mathlib.Data.Option.Basic
 import Mathlib.Logic.Nontrivial.Basic
 import Mathlib.Tactic.Common
 

--- a/Mathlib/Algebra/Group/WithOne/Defs.lean
+++ b/Mathlib/Algebra/Group/WithOne/Defs.lean
@@ -154,7 +154,7 @@ theorem coe_inj {a b : α} : (a : WithOne α) = b ↔ a = b :=
 
 @[to_additive]
 lemma coe_injective : Function.Injective (coe : α → WithOne α) :=
-  fun _ _ ↦ coe_inj.mp
+  Option.some_injective
 
 @[to_additive (attr := elab_as_elim)]
 protected theorem cases_on {P : WithOne α → Prop} : ∀ x : WithOne α, P 1 → (∀ a : α, P a) → P x :=

--- a/Mathlib/Algebra/Group/WithOne/Defs.lean
+++ b/Mathlib/Algebra/Group/WithOne/Defs.lean
@@ -155,7 +155,7 @@ theorem coe_inj {a b : α} : (a : WithOne α) = b ↔ a = b :=
 
 @[to_additive]
 lemma coe_injective : Function.Injective (coe : α → WithOne α) :=
-  Option.some_injective
+  Option.some_injective _
 
 @[to_additive (attr := elab_as_elim)]
 protected theorem cases_on {P : WithOne α → Prop} : ∀ x : WithOne α, P 1 → (∀ a : α, P a) → P x :=

--- a/Mathlib/Algebra/GroupWithZero/WithZero.lean
+++ b/Mathlib/Algebra/GroupWithZero/WithZero.lean
@@ -360,6 +360,9 @@ def exp (a : M) : Mᵐ⁰ := coe <| .ofAdd a
 
 @[simp] lemma exp_ne_zero {a : M} : exp a ≠ 0 := by simp [exp]
 
+lemma exp_injective : Injective (exp : M → Mᵐ⁰) :=
+  Multiplicative.ofAdd.injective.comp WithZero.coe_injective
+
 variable [AddMonoid M]
 
 /-- The logarithm as a function `Mᵐ⁰ → M` with junk value `log 0 = 0`. -/

--- a/Mathlib/Algebra/GroupWithZero/WithZero.lean
+++ b/Mathlib/Algebra/GroupWithZero/WithZero.lean
@@ -360,9 +360,6 @@ def exp (a : M) : Mᵐ⁰ := coe <| .ofAdd a
 
 @[simp] lemma exp_ne_zero {a : M} : exp a ≠ 0 := by simp [exp]
 
-lemma exp_injective : Injective (exp : M → Mᵐ⁰) :=
-  Multiplicative.ofAdd.injective.comp WithZero.coe_injective
-
 variable [AddMonoid M]
 
 /-- The logarithm as a function `Mᵐ⁰ → M` with junk value `log 0 = 0`. -/


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
