### PR TITLE
[Merged by Bors] - chore: optimize code

### DIFF
--- a/Mathlib/Analysis/Complex/Conformal.lean
+++ b/Mathlib/Analysis/Complex/Conformal.lean
@@ -21,12 +21,13 @@ to be conformal.
 ## Main results
 
 * `isConformalMap_complex_linear`: a nonzero complex linear map into an arbitrary complex normed
-                                   space is conformal.
+  space is conformal.
+
 * `isConformalMap_complex_linear_conj`: the composition of a nonzero complex linear map with `conj`
-                                        is complex linear.
+  is complex linear.
+
 * `isConformalMap_iff_is_complex_or_conj_linear`: a real linear map between the complex plane is
-                                                  conformal iff it's complex linear or the
-                                                  composition of some complex linear map and `conj`.
+  conformal iff it's complex linear or the composition of some complex linear map and `conj`.
 
 * `DifferentiableAt.conformalAt` states that a real-differentiable function with a nonvanishing
   differential from the complex plane into an arbitrary complex-normed space is conformal at a point
@@ -198,26 +199,23 @@ lemma real_linearMap_map_smul_complex {ℓ : ℂ →ₗ[ℝ] E} (h : ℓ I = I �
 Construct a complex-linear map from a real-linear map `ℓ` that maps `I` to `I • ℓ 1`.
 -/
 def LinearMap.complexOfReal (ℓ : ℂ →ₗ[ℝ] E) (h : ℓ I = I • ℓ 1) : ℂ →ₗ[ℂ] E where
-  toFun := ℓ
-  map_add' := ℓ.map_add
+  __ := ℓ
   map_smul' := real_linearMap_map_smul_complex h
 
 @[simp]
-lemma LinearMap.coe_complexOfReal {ℓ : ℂ →ₗ[ℝ] E} (h : ℓ I = I • ℓ 1) :
-    ℓ.complexOfReal h = (ℓ : ℂ → E) := rfl
+lemma LinearMap.coe_complexOfReal {ℓ : ℂ →ₗ[ℝ] E} (h) : ℓ.complexOfReal h = (ℓ : ℂ → E) := rfl
 
 /--
 Construct a continuous complex-linear map from a continuous real-linear map `ℓ` that maps `I` to
 `I • ℓ 1`.
 -/
 def ContinuousLinearMap.complexOfReal (ℓ : ℂ →L[ℝ] E) (h : ℓ I = I • ℓ 1) : ℂ →L[ℂ] E where
-  toFun := ℓ
-  map_add' := ℓ.map_add
+  __ := ℓ
   map_smul' := real_linearMap_map_smul_complex h
 
 @[simp]
-lemma ContinuousLinearMap.coe_complexOfReal {ℓ : ℂ →L[ℝ] E} (h : ℓ I = I • ℓ 1) :
-    ℓ.complexOfReal h = (ℓ : ℂ → E) := rfl
+lemma ContinuousLinearMap.coe_complexOfReal {ℓ : ℂ →L[ℝ] E} (h) : ℓ.complexOfReal h = (ℓ : ℂ → E) :=
+  rfl
 
 /--
 The **Cauchy-Riemann Equation**: A real-differentiable function `f` on `ℂ` is complex-differentiable
@@ -240,10 +238,10 @@ theorem differentiableWithinAt_complex_iff_differentiableWithinAt_real
 In cases where the **Cauchy-Riemann Equation** guarantees complex differentiability at `x`, the
 complex derivative equals `ContinuousLinearMap.complexOfReal` of the real derivative.
 -/
-protected theorem HasFDerivWithinAt.complexOfReal_hasFDerivWithinAt {f' : ℂ →L[ℝ] E}
-    (h₁ : HasFDerivWithinAt f f' s x) (h₂ : f' I = I • f' 1) :
+protected theorem HasFDerivWithinAt.complexOfReal {f' : ℂ →L[ℝ] E} (h₁ : HasFDerivWithinAt f f' s x)
+    (h₂ : f' I = I • f' 1) :
     HasFDerivWithinAt f (f'.complexOfReal h₂) s x :=
-  HasFDerivWithinAt.of_restrictScalars ℝ h₁ rfl
+  .of_restrictScalars ℝ h₁ rfl
 
 /--
 In cases where the **Cauchy-Riemann Equation** guarantees complex differentiability at `x`, the
@@ -264,7 +262,7 @@ theorem complexOfReal_hasDerivWithinAt (h₁ : DifferentiableWithinAt ℝ f s x)
     (h₂ : fderivWithin ℝ f s x I = I • fderivWithin ℝ f s x 1) :
     HasDerivWithinAt f ((fderivWithin ℝ f s x).complexOfReal h₂ 1) s x := by
   rw [hasDerivWithinAt_iff_hasFDerivWithinAt, smulRight_one_one]
-  exact (h₁.hasFDerivWithinAt).complexOfReal_hasFDerivWithinAt h₂
+  exact h₁.hasFDerivWithinAt.complexOfReal h₂
 
 /--
 In cases where the **Cauchy-Riemann Equation** guarantees complex differentiability at `x`, the


### PR DESCRIPTION
Following suggestions of @YaelDillies, optimize the code in `Analysis/Complex/Conformal.lean`. The optimizations were suggested during the review of #26839 but came in after Bors had already merged the PR.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
