### PR TITLE
[Merged by Bors] - feat(GroupTheory/FreeGroup): add cyclic reduction of words

### DIFF
--- a/Mathlib/GroupTheory/FreeGroup/CyclicallyReduced.lean
+++ b/Mathlib/GroupTheory/FreeGroup/CyclicallyReduced.lean
@@ -3,8 +3,7 @@ Copyright (c) 2025 Bernhard Reinke. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Amir Livne Bar-on, Bernhard Reinke
 -/
-import Mathlib.Data.List.Induction
-import Mathlib.GroupTheory.FreeGroup.Basic
+import Mathlib.GroupTheory.FreeGroup.Reduce
 
 /-!
 This file defines some extra lemmas for free groups, in particular about cyclically reduced words.
@@ -71,65 +70,60 @@ theorem flatten_replicate (n : ℕ) (h : IsCyclicallyReduced L) :
     rw [Option.mem_def, List.head?_flatten_replicate (h := by simp +arith)] at hb
     exact h.2 _ ha _ hb
 
-<<<<<<< HEAD
 end IsCyclicallyReduced
-=======
 variable [DecidableEq α]
 
 /-- This function produces a subword of a word `w` by cancelling the first and last letters of `w`
 as long as possible. If `w` is reduced, the resulting word will be cyclically reduced. -/
-@[to_additive "This function produces a subword of a word `w` by cancelling the first and last
+@[to_additive /-- This function produces a subword of a word `w` by cancelling the first and last
 letters of `w` as long as possible. If `w` is reduced, the resulting word will be cyclically
-reduced."]
+reduced. -/]
 def reduceCyclically : List (α × Bool) → List (α × Bool) :=
   List.bidirectionalRec
     (nil := [])
     (singleton := fun x => [x])
     (cons_append := fun a l b rC => if b.1 = a.1 ∧ (!b.2) = a.2 then rC else a :: l ++ [b])
 
-/-- Partner function to `reduceCyclically`. See `reduceCyclically_conjugation`. -/
-@[to_additive "Partner function to `reduceCyclically`. See `reduceCyclically_conjugation`."]
-def reduceCyclicallyConjugator : List (α × Bool) → List (α × Bool) := List.bidirectionalRec
+namespace reduceCyclically
+
+/-- Partner function to `reduceCyclically`. See `reduceCyclically.conjugation`. -/
+@[to_additive /-- Partner function to `reduceCyclically`. See `reduceCyclically.conjugation`. -/]
+def conjugator : List (α × Bool) → List (α × Bool) := List.bidirectionalRec
   (nil := [])
   (singleton := fun _ => [])
   (cons_append := fun a _ b rCC => if b.1 = a.1 ∧ (!b.2) = a.2 then a :: rCC else [] )
 
 @[to_additive (attr := simp)]
-theorem reduceCyclically_nil : reduceCyclically ([] : List (α × Bool)) = [] :=
-  by simp [reduceCyclically]
+theorem nil : reduceCyclically ([] : List (α × Bool)) = [] := by simp [reduceCyclically]
 
 @[to_additive (attr := simp)]
-theorem reduceCyclically_singleton {a : α × Bool} : reduceCyclically [a] = [a] :=
-  by simp [reduceCyclically]
+theorem singleton {a : α × Bool} : reduceCyclically [a] = [a] := by simp [reduceCyclically]
 
 @[to_additive (attr := simp)]
-theorem reduceCyclicallyConjugator_nil : reduceCyclicallyConjugator ([] : List (α × Bool)) = [] :=
-  by simp [reduceCyclicallyConjugator]
+theorem conjugator.nil : conjugator ([] : List (α × Bool)) = [] := by simp [conjugator]
 
 @[to_additive (attr := simp)]
-theorem reduceCyclicallyConjugator_singleton {a : α × Bool} : reduceCyclicallyConjugator [a] = [] :=
-  by simp [reduceCyclicallyConjugator]
+theorem conjugator.singleton {a : α × Bool} : conjugator [a] = [] := by simp [conjugator]
 
 @[to_additive]
-theorem reduceCyclically_cons_append {a b : α × Bool} (l : List (α × Bool)) :
+theorem cons_append {a b : α × Bool} (l : List (α × Bool)) :
     reduceCyclically (a :: (l ++ [b])) =
     if b.1 = a.1 ∧ (!b.2) = a.2 then reduceCyclically l else a :: l ++ [b] := by
   simp [reduceCyclically]
 
 @[to_additive]
-theorem reduceCyclicallyConjugator_cons_append {a b : α × Bool} (l : List (α × Bool)) :
-    reduceCyclicallyConjugator (a :: (l ++ [b])) =
-    if b.1 = a.1 ∧ (!b.2) = a.2 then a :: reduceCyclicallyConjugator l else [] := by
-  simp [reduceCyclicallyConjugator]
+theorem conjugator.cons_append {a b : α × Bool} (l : List (α × Bool)) :
+    conjugator (a :: (l ++ [b])) = if b.1 = a.1 ∧ (!b.2) = a.2 then a :: conjugator l else [] := by
+  simp [conjugator]
 
 @[to_additive]
-theorem reduceCyclically_conjugation (w : List (α × Bool)) : w = reduceCyclicallyConjugator w ++
-    reduceCyclically w ++ invRev (reduceCyclicallyConjugator w) := by
+theorem conjugation (w : List (α × Bool)) :
+    w = conjugator w ++ reduceCyclically w ++ invRev (conjugator w) := by
   induction w using List.bidirectionalRec
   case nil => simp
   case singleton => simp
   case cons_append a l b eq =>
-    rw [reduceCyclically_cons_append, reduceCyclicallyConjugator_cons_append]
+    rw [cons_append, conjugator.cons_append]
     split
     case isTrue h =>
       nth_rw 1 [eq]
@@ -137,22 +131,24 @@ theorem reduceCyclically_conjugation (w : List (α × Bool)) : w = reduceCyclica
     case isFalse => simp
 
 @[to_additive]
-theorem reduceCyclically_sound (w : List (α × Bool)) :
-    IsReduced w → IsCyclicallyReduced (reduceCyclically w) := by
+theorem sound (w : List (α × Bool)) (h : IsReduced w) :
+    IsCyclicallyReduced (reduceCyclically w) := by
+  revert h
   induction w using List.bidirectionalRec
   case nil => simp
   case singleton => simp
   case cons_append a l b ih =>
     intro h
-    rw [reduceCyclically_cons_append]
+    rw [cons_append]
     split
     case isTrue =>
       apply ih
       apply h.infix
       exists [a], [b]
-    case isFalse h =>
+    case isFalse h' =>
       rw [isCyclicallyReduced_cons_append_iff]
-      simp_all
+      exact ⟨h, by simpa using h'⟩
 
->>>>>>> c961bb07ae (feat(GroupTheory/FreeGroup): add cyclical reduction)
+end reduceCyclically
+
 end FreeGroup

--- a/Mathlib/GroupTheory/FreeGroup/CyclicallyReduced.lean
+++ b/Mathlib/GroupTheory/FreeGroup/CyclicallyReduced.lean
@@ -3,7 +3,8 @@ Copyright (c) 2025 Bernhard Reinke. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Amir Livne Bar-on, Bernhard Reinke
 -/
-import Mathlib.GroupTheory.FreeGroup.Reduce
+import Mathlib.Data.List.Induction
+import Mathlib.GroupTheory.FreeGroup.Basic
 
 /-!
 This file defines some extra lemmas for free groups, in particular about cyclically reduced words.

--- a/Mathlib/GroupTheory/FreeGroup/CyclicallyReduced.lean
+++ b/Mathlib/GroupTheory/FreeGroup/CyclicallyReduced.lean
@@ -151,7 +151,7 @@ theorem reduceCyclically_sound (w : List (α × Bool)) :
       exists [a], [b]
     case isFalse h =>
       rw [isCyclicallyReduced_cons_append_iff]
-      trivial
+      simp_all
 
 >>>>>>> c961bb07ae (feat(GroupTheory/FreeGroup): add cyclical reduction)
 end FreeGroup

--- a/Mathlib/GroupTheory/FreeGroup/CyclicallyReduced.lean
+++ b/Mathlib/GroupTheory/FreeGroup/CyclicallyReduced.lean
@@ -142,14 +142,10 @@ theorem sound (w : List (α × Bool)) (h : IsReduced w) :
     intro h
     rw [cons_append]
     split
-    case isTrue =>
-      apply ih
-      apply h.infix
-      exists [a], [b]
+    case isTrue => exact ih (h.infix ⟨[a], [b], rfl⟩)
     case isFalse h' =>
       rw [isCyclicallyReduced_cons_append_iff]
       exact ⟨h, by simpa using h'⟩
 
 end reduceCyclically
-
 end FreeGroup

--- a/Mathlib/GroupTheory/FreeGroup/CyclicallyReduced.lean
+++ b/Mathlib/GroupTheory/FreeGroup/CyclicallyReduced.lean
@@ -3,7 +3,7 @@ Copyright (c) 2025 Bernhard Reinke. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Amir Livne Bar-on, Bernhard Reinke
 -/
-import Mathlib.GroupTheory.FreeGroup.Basic
+import Mathlib.GroupTheory.FreeGroup.Reduce
 
 /-!
 This file defines some extra lemmas for free groups, in particular about cyclically reduced words.
@@ -70,5 +70,88 @@ theorem flatten_replicate (n : ℕ) (h : IsCyclicallyReduced L) :
     rw [Option.mem_def, List.head?_flatten_replicate (h := by simp +arith)] at hb
     exact h.2 _ ha _ hb
 
+<<<<<<< HEAD
 end IsCyclicallyReduced
+=======
+variable [DecidableEq α]
+
+/-- This function produces a subword of a word `w` by cancelling the first and last letters of `w`
+as long as possible. If `w` is reduced, the resulting word will be cyclically reduced. -/
+@[to_additive "This function produces a subword of a word `w` by cancelling the first and last
+letters of `w` as long as possible. If `w` is reduced, the resulting word will be cyclically
+reduced."]
+def reduceCyclically : List (α × Bool) → List (α × Bool) :=
+  List.bidirectionalRec
+    (nil := [])
+    (singleton := fun x => [x])
+    (cons_append := fun a l b rC => if b.1 = a.1 ∧ (!b.2) = a.2 then rC else a :: l ++ [b])
+
+/-- Partner function to `reduceCyclically`. See `reduceCyclically_conjugation`. -/
+@[to_additive "Partner function to `reduceCyclically`. See `reduceCyclically_conjugation`."]
+def reduceCyclicallyConjugator : List (α × Bool) → List (α × Bool) := List.bidirectionalRec
+  (nil := [])
+  (singleton := fun _ => [])
+  (cons_append := fun a _ b rCC => if b.1 = a.1 ∧ (!b.2) = a.2 then a :: rCC else [] )
+
+@[to_additive (attr := simp)]
+theorem reduceCyclically_nil : reduceCyclically ([] : List (α × Bool)) = [] :=
+  by simp [reduceCyclically]
+
+@[to_additive (attr := simp)]
+theorem reduceCyclically_singleton {a : α × Bool} : reduceCyclically [a] = [a] :=
+  by simp [reduceCyclically]
+
+@[to_additive (attr := simp)]
+theorem reduceCyclicallyConjugator_nil : reduceCyclicallyConjugator ([] : List (α × Bool)) = [] :=
+  by simp [reduceCyclicallyConjugator]
+
+@[to_additive (attr := simp)]
+theorem reduceCyclicallyConjugator_singleton {a : α × Bool} : reduceCyclicallyConjugator [a] = [] :=
+  by simp [reduceCyclicallyConjugator]
+
+@[to_additive]
+theorem reduceCyclically_cons_append {a b : α × Bool} (l : List (α × Bool)) :
+    reduceCyclically (a :: (l ++ [b])) =
+    if b.1 = a.1 ∧ (!b.2) = a.2 then reduceCyclically l else a :: l ++ [b] := by
+  simp [reduceCyclically]
+
+@[to_additive]
+theorem reduceCyclicallyConjugator_cons_append {a b : α × Bool} (l : List (α × Bool)) :
+    reduceCyclicallyConjugator (a :: (l ++ [b])) =
+    if b.1 = a.1 ∧ (!b.2) = a.2 then a :: reduceCyclicallyConjugator l else [] := by
+  simp [reduceCyclicallyConjugator]
+
+@[to_additive]
+theorem reduceCyclically_conjugation (w : List (α × Bool)) : w = reduceCyclicallyConjugator w ++
+    reduceCyclically w ++ invRev (reduceCyclicallyConjugator w) := by
+  induction w using List.bidirectionalRec
+  case nil => simp
+  case singleton => simp
+  case cons_append a l b eq =>
+    rw [reduceCyclically_cons_append, reduceCyclicallyConjugator_cons_append]
+    split
+    case isTrue h =>
+      nth_rw 1 [eq]
+      simp [invRev, h.1.symm, h.2.symm]
+    case isFalse => simp
+
+@[to_additive]
+theorem reduceCyclically_sound (w : List (α × Bool)) :
+    IsReduced w → IsCyclicallyReduced (reduceCyclically w) := by
+  induction w using List.bidirectionalRec
+  case nil => simp
+  case singleton => simp
+  case cons_append a l b ih =>
+    intro h
+    rw [reduceCyclically_cons_append]
+    split
+    case isTrue =>
+      apply ih
+      apply h.infix
+      exists [a], [b]
+    case isFalse h =>
+      rw [isCyclicallyReduced_cons_append_iff]
+      trivial
+
+>>>>>>> c961bb07ae (feat(GroupTheory/FreeGroup): add cyclical reduction)
 end FreeGroup

--- a/Mathlib/GroupTheory/FreeGroup/CyclicallyReduced.lean
+++ b/Mathlib/GroupTheory/FreeGroup/CyclicallyReduced.lean
@@ -72,27 +72,28 @@ theorem flatten_replicate (n : ℕ) (h : IsCyclicallyReduced L) :
     exact h.2 _ ha _ hb
 
 end IsCyclicallyReduced
-variable [DecidableEq α]
 
 /-- This function produces a subword of a word `w` by cancelling the first and last letters of `w`
 as long as possible. If `w` is reduced, the resulting word will be cyclically reduced. -/
 @[to_additive /-- This function produces a subword of a word `w` by cancelling the first and last
 letters of `w` as long as possible. If `w` is reduced, the resulting word will be cyclically
 reduced. -/]
-def reduceCyclically : List (α × Bool) → List (α × Bool) :=
+def reduceCyclically [DecidableEq α] : List (α × Bool) → List (α × Bool) :=
   List.bidirectionalRec
     (nil := [])
     (singleton := fun x => [x])
     (cons_append := fun a l b rC => if b.1 = a.1 ∧ (!b.2) = a.2 then rC else a :: l ++ [b])
 
 namespace reduceCyclically
+variable [DecidableEq α]
 
 /-- Partner function to `reduceCyclically`. See `reduceCyclically.conjugation`. -/
 @[to_additive /-- Partner function to `reduceCyclically`. See `reduceCyclically.conjugation`. -/]
-def conjugator : List (α × Bool) → List (α × Bool) := List.bidirectionalRec
-  (nil := [])
-  (singleton := fun _ => [])
-  (cons_append := fun a _ b rCC => if b.1 = a.1 ∧ (!b.2) = a.2 then a :: rCC else [] )
+def conjugator : List (α × Bool) → List (α × Bool) :=
+  List.bidirectionalRec
+    (nil := [])
+    (singleton := fun _ => [])
+    (cons_append := fun a _ b rCC => if b.1 = a.1 ∧ (!b.2) = a.2 then a :: rCC else [] )
 
 @[to_additive (attr := simp)]
 theorem nil : reduceCyclically ([] : List (α × Bool)) = [] := by simp [reduceCyclically]
@@ -134,12 +135,10 @@ theorem conjugation (w : List (α × Bool)) :
 @[to_additive]
 theorem sound (w : List (α × Bool)) (h : IsReduced w) :
     IsCyclicallyReduced (reduceCyclically w) := by
-  revert h
   induction w using List.bidirectionalRec
   case nil => simp
   case singleton => simp
   case cons_append a l b ih =>
-    intro h
     rw [cons_append]
     split
     case isTrue => exact ih (h.infix ⟨[a], [b], rfl⟩)


### PR DESCRIPTION
This PR adds the definition of `reduceCyclically`. This function produces a subword of a word `w` by cancelling the first and last letters of `w` as long as possible. If `w` is reduced, the resulting word will be cyclically reduced.

It is a part of a series of PR on the theory of cyclically reduced words.

Upstreamed from the [EquationalTheories](https://github.com/teorth/equational_theories) project.

 - [x] depends on: #25966 
 - [x] depends on: #27672 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
