### PR TITLE
feat(workflows): automatically assign reviewers

### DIFF
--- a/.github/workflows/auto_assign_reviewers.yaml
+++ b/.github/workflows/auto_assign_reviewers.yaml
@@ -14,6 +14,7 @@ jobs:
         run: |
           curl --output assignments.json --silent https://leanprover-community.github.io/queueboard/automatic_assignments.json
 
+      # Perhaps this is necessary, perhaps not.
       # The Hoskinson runners may not have jq installed, so do that now.
       - name: 'Setup jq'
         uses: dcarbone/install-jq-action@f0e10f46ff84f4d32178b4b76e1ef180b16f82c3 # v3.1.1
@@ -22,7 +23,9 @@ jobs:
       - name: parse assignments file and assign reviewers
         run: |
           echo "TODO: parsing the assignments file is not implemented yet!"
-          # placeholder logic: assign PR 18754 to grunweg
+          # the above files has entries of the form number: "user".
+          # for each pair (number, user) in the file, I want to run the following
+          # placeholder values: as an example, assign PR 18754 to grunweg
           number=18754
           user=grunweg
           printf 'about to assign PR "%s" to "%s"' "${number}" "${user}"

--- a/.github/workflows/auto_assign_reviewers.yaml
+++ b/.github/workflows/auto_assign_reviewers.yaml
@@ -23,7 +23,7 @@ jobs:
           # The assignments file has entries of the form "2234": "user_handle".
           # Use grep to select only the PR numbers, and sed to the trailing comma, as well as
           # any whitespace (both at the line start and after the colon).
-          lines=$(jq "." assignments.json | grep '"' | sed 's/,*$//' | sed 's/ *//')
+          lines=$(jq "." assignments.json | grep '"' | sed 's/,*$//' | sed 's/ *//' | sed 's/ //')
           for line in $lines; do
             # |line| has the form _"234":"user_handle"_ (without the underscores).
             # Use cut to extract the parts around the colon, and sed to remove the quotes.

--- a/.github/workflows/auto_assign_reviewers.yaml
+++ b/.github/workflows/auto_assign_reviewers.yaml
@@ -19,21 +19,34 @@ jobs:
       - name: 'Setup jq'
         uses: dcarbone/install-jq-action@f0e10f46ff84f4d32178b4b76e1ef180b16f82c3 # v3.1.1
 
-      # Parse the json file: TODO, that step is missing.
+      # Parse the json file: TODO complete this step
       - name: parse assignments file and assign reviewers
         run: |
-          echo "TODO: parsing the assignments file is not implemented yet!"
-          # the above files has entries of the form number: "user".
-          # for each pair (number, user) in the file, I want to run the following
-          # placeholder values: as an example, assign PR 18754 to grunweg
-          number=18754
-          user=grunweg
-          printf 'about to assign PR "%s" to "%s"\n' "${number}" "${user}"
-          # This keeps any existing assignee on the PR.
-          curl --location \
-            --request POST \
-            --header "Accept: application/vnd.github+json" \
-            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            --header "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/leanprover-community/mathlib4/issues/$number/assignees \
-            --data '{"assignees":["$user"]}'
+          # Extract the list of PR names in the assignments.
+          # jq's output is of the form
+          # [
+          #   "123",
+          #   "345"
+          # ]
+          # Grepping by the quote filters out all PR numbers only, then cut removes the
+          # initial whitespace and sed any trailing comma.
+          PRs=$(jq 'keys' assignments.json | grep '"' | cut -c 3- | sed 's/,*$//')
+          echo "trace: parsed PR numbers are $PRs"
+
+          # For each PR number, extract the corresponding assigned user from assignments.json
+          for pr_number in $PRs ; do
+            # FIXME: is this sufficient quoting? I want literal quotes around the PR number...
+            user=$(jq '.["$pr_number"]' assignments.json)
+            echo "trace: tried to extract the user for PR $pr_number, found $user"
+            # # as an example, assign PR 18754 to grunweg
+            # user=grunweg
+            # printf 'about to assign PR "%s" to "%s"\n' "${pr_number}" "${user}"
+            # # This keeps any existing assignee on the PR.
+            # curl --location \
+            #   --request POST \
+            #   --header "Accept: application/vnd.github+json" \
+            #   --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            #   --header "X-GitHub-Api-Version: 2022-11-28" \
+            #   https://api.github.com/repos/leanprover-community/mathlib4/issues/$pr_number/assignees \
+            #   --data '{"assignees":["$user"]}'
+          done

--- a/.github/workflows/auto_assign_reviewers.yaml
+++ b/.github/workflows/auto_assign_reviewers.yaml
@@ -10,20 +10,17 @@ jobs:
     name: assign automatically proposed reviewers
     runs-on: ubuntu-latest
     steps:
-      - name: download auto-assignments
+      - name: download the list of proposed assignments
         run: |
           curl --output assignments.json https://leanprover-community.github.io/queueboard/automatic_assignments.json
 
-      # The Hoskinson runners may not have jq installed, so do that now.
-      - name: 'Setup jq'
-        uses: dcarbone/install-jq-action@f0e10f46ff84f4d32178b4b76e1ef180b16f82c3 # v3.1.1
-
-      # Parse the json file
       - name: parse assignments file and assign reviewers
         run: |
-          python3 write_assignments.py
-          echo "Wrote assignment file 'assign_users.sh'"
+          # We use a slightly roundabout way (shelling out to Python to parse the file and write
+          # the shell script we execute), as this is the easiest way to get around variable
+          # quotient issues.
+          # Rewriting this (or deciding that Python is nicer than shell and keeping it) is welcome.
+          python3 scripts/write_assignments.py
           chmod u+x assign_users.sh
-          echo 'File contents are:'
           cat assign_users.sh
           ./assign_users.sh

--- a/.github/workflows/auto_assign_reviewers.yaml
+++ b/.github/workflows/auto_assign_reviewers.yaml
@@ -35,7 +35,7 @@ jobs:
             curl --location \
               --request POST \
               --header "Accept: application/vnd.github+json" \
-              --header 'authorization: Bearer ${{ secrets.UPDATE_NOLINTS_TOKEN }}' \
+              --header 'authorization: Bearer ${{ secrets.ASSIGN_REVIEWERS }}' \
               --header "X-GitHub-Api-Version: 2022-11-28" \
               https://api.github.com/repos/leanprover-community/mathlib4/issues/$pr_number/assignees \
               --data '{"assignees":["$handle"]}'

--- a/.github/workflows/auto_assign_reviewers.yaml
+++ b/.github/workflows/auto_assign_reviewers.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: download auto-assignments
         run: |
-          curl --output assignments.json --silent https://leanprover-community.github.io/queueboard/automatic_assignments.json
+          curl --output assignments.json https://leanprover-community.github.io/queueboard/automatic_assignments.json
 
       # Perhaps this is necessary, perhaps not.
       # The Hoskinson runners may not have jq installed, so do that now.
@@ -28,7 +28,7 @@ jobs:
           # placeholder values: as an example, assign PR 18754 to grunweg
           number=18754
           user=grunweg
-          printf 'about to assign PR "%s" to "%s"' "${number}" "${user}"
+          printf 'about to assign PR "%s" to "%s"\n' "${number}" "${user}"
           # This keeps any existing assignee on the PR.
           curl --location \
             --request POST \

--- a/.github/workflows/auto_assign_reviewers.yaml
+++ b/.github/workflows/auto_assign_reviewers.yaml
@@ -21,9 +21,9 @@ jobs:
       - name: parse assignments file and assign reviewers
         run: |
           # The assignments file has entries of the form "2234": "user_handle".
-          # Use grep to select only the PR numbers, cut to remove initial whitespace
-          # and sed to remove any trailing comma and the middle space.
-          lines=$(jq "." assignments.json | grep '"' | cut -c 3- | sed 's/,*$//' | sed 's/ //')
+          # Use grep to select only the PR numbers, and sed to the trailing comma, as well as
+          # any whitespace (both at the line start and after the colon).
+          lines=$(jq "." assignments.json | grep '"' | sed 's/,*$//' | sed 's/ *//')
           for line in $lines; do
             # |line| has the form _"234":"user_handle"_ (without the underscores).
             # Use cut to extract the parts around the colon, and sed to remove the quotes.

--- a/.github/workflows/auto_assign_reviewers.yaml
+++ b/.github/workflows/auto_assign_reviewers.yaml
@@ -21,22 +21,9 @@ jobs:
       # Parse the json file
       - name: parse assignments file and assign reviewers
         run: |
-          # The assignments file has entries of the form "2234": "user_handle".
-          # Use grep to select only the PR numbers, and sed to the trailing comma, as well as
-          # any whitespace (both at the line start and after the colon).
-          lines=$(jq "." assignments.json | grep '"' | sed 's/,*$//' | sed 's/ *//' | sed 's/ //')
-          for line in $lines; do
-            # |line| has the form _"234":"user_handle"_ (without the underscores).
-            # Use cut to extract the parts around the colon, and sed to remove the quotes.
-            pr_number=$(echo $line | cut -d ":" -f1 | sed 's/"//' | sed 's/"//')
-            handle=$(echo $line | cut -d ":" -f2 | sed 's/"//' | sed 's/"//')
-            printf 'about to assign PR "%s" to "%s"\n' "${pr_number}" "${handle}"
-            # This keeps any existing assignee on the PR.
-            curl --location \
-              --request POST \
-              --header "Accept: application/vnd.github+json" \
-              --header 'authorization: Bearer ${{ secrets.ASSIGN_REVIEWERS }}' \
-              --header "X-GitHub-Api-Version: 2022-11-28" \
-              https://api.github.com/repos/leanprover-community/mathlib4/issues/$pr_number/assignees \
-              --data '{"assignees":["$handle"]}'
-          done
+          python3 write_assignments.py
+          echo "Wrote assignment file 'assign_users.sh'"
+          chmod u+x assign_users.sh
+          echo 'File contents are:'
+          cat assign_users.sh
+          ./assign_users.sh

--- a/.github/workflows/auto_assign_reviewers.yaml
+++ b/.github/workflows/auto_assign_reviewers.yaml
@@ -3,6 +3,7 @@ name: automatically assign reviewers
 on:
   schedule:
     - cron: "37 0 * * *" # At 00:37 UTC every day
+  push:
 
 jobs:
   autoassign-reviewers:

--- a/.github/workflows/auto_assign_reviewers.yaml
+++ b/.github/workflows/auto_assign_reviewers.yaml
@@ -1,0 +1,36 @@
+name: automatically assign reviewers
+
+on:
+  schedule:
+    - cron: "37 0 * * *" # At 00:37 UTC every day
+  workflow_dispatch:
+
+jobs:
+  autoassign-reviewers:
+    name: assign automatically proposed reviewers
+    runs-on: ubuntu-latest
+    steps:
+      - name: download auto-assignments
+        run: |
+          curl --output assignments.json --silent https://leanprover-community.github.io/queueboard/automatic_assignments.json
+
+      # The Hoskinson runners may not have jq installed, so do that now.
+      - name: 'Setup jq'
+        uses: dcarbone/install-jq-action@f0e10f46ff84f4d32178b4b76e1ef180b16f82c3 # v3.1.1
+
+      # Parse the json file: TODO, that step is missing.
+      - name: parse assignments file and assign reviewers
+        run: |
+          echo "TODO: parsing the assignments file is not implemented yet!"
+          # placeholder logic: assign PR 18754 to grunweg
+          number=18754
+          user=grunweg
+          printf 'about to assign PR "%s" to "%s"' "${number}" "${user}"
+          # This keeps any existing assignee on the PR.
+          curl --location \
+            --request POST \
+            --header "Accept: application/vnd.github+json" \
+            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/leanprover-community/mathlib4/issues/$number/assignees \
+            --data '{"assignees":["$user"]}'

--- a/.github/workflows/auto_assign_reviewers.yaml
+++ b/.github/workflows/auto_assign_reviewers.yaml
@@ -3,7 +3,6 @@ name: automatically assign reviewers
 on:
   schedule:
     - cron: "37 0 * * *" # At 00:37 UTC every day
-  workflow_dispatch:
 
 jobs:
   autoassign-reviewers:
@@ -14,39 +13,29 @@ jobs:
         run: |
           curl --output assignments.json https://leanprover-community.github.io/queueboard/automatic_assignments.json
 
-      # Perhaps this is necessary, perhaps not.
       # The Hoskinson runners may not have jq installed, so do that now.
       - name: 'Setup jq'
         uses: dcarbone/install-jq-action@f0e10f46ff84f4d32178b4b76e1ef180b16f82c3 # v3.1.1
 
-      # Parse the json file: TODO complete this step
+      # Parse the json file
       - name: parse assignments file and assign reviewers
         run: |
-          # Extract the list of PR names in the assignments.
-          # jq's output is of the form
-          # [
-          #   "123",
-          #   "345"
-          # ]
-          # Grepping by the quote filters out all PR numbers only, then cut removes the
-          # initial whitespace and sed any trailing comma.
-          PRs=$(jq 'keys' assignments.json | grep '"' | cut -c 3- | sed 's/,*$//')
-          echo "trace: parsed PR numbers are $PRs"
-
-          # For each PR number, extract the corresponding assigned user from assignments.json
-          for pr_number in $PRs ; do
-            # FIXME: is this sufficient quoting? I want literal quotes around the PR number...
-            user=$(jq '.["$pr_number"]' assignments.json)
-            echo "trace: tried to extract the user for PR $pr_number, found $user"
-            # # as an example, assign PR 18754 to grunweg
-            # user=grunweg
-            # printf 'about to assign PR "%s" to "%s"\n' "${pr_number}" "${user}"
-            # # This keeps any existing assignee on the PR.
-            # curl --location \
-            #   --request POST \
-            #   --header "Accept: application/vnd.github+json" \
-            #   --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            #   --header "X-GitHub-Api-Version: 2022-11-28" \
-            #   https://api.github.com/repos/leanprover-community/mathlib4/issues/$pr_number/assignees \
-            #   --data '{"assignees":["$user"]}'
+          # The assignments file has entries of the form "2234": "user_handle".
+          # Use grep to select only the PR numbers, cut to remove initial whitespace
+          # and sed to remove any trailing comma and the middle space.
+          lines=$(jq "." assignments.json | grep '"' | cut -c 3- | sed 's/,*$//' | sed 's/ //')
+          for line in $lines; do
+            # |line| has the form _"234":"user_handle"_ (without the underscores).
+            # Use cut to extract the parts around the colon, and sed to remove the quotes.
+            pr_number=$(echo $line | cut -d ":" -f1 | sed 's/"//' | sed 's/"//')
+            handle=$(echo $line | cut -d ":" -f2 | sed 's/"//' | sed 's/"//')
+            printf 'about to assign PR "%s" to "%s"\n' "${pr_number}" "${handle}"
+            # This keeps any existing assignee on the PR.
+            curl --location \
+              --request POST \
+              --header "Accept: application/vnd.github+json" \
+              --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/leanprover-community/mathlib4/issues/$pr_number/assignees \
+              --data '{"assignees":["$handle"]}'
           done

--- a/.github/workflows/auto_assign_reviewers.yaml
+++ b/.github/workflows/auto_assign_reviewers.yaml
@@ -35,7 +35,7 @@ jobs:
             curl --location \
               --request POST \
               --header "Accept: application/vnd.github+json" \
-              --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+              --header 'authorization: Bearer ${{ secrets.UPDATE_NOLINTS_TOKEN }}' \
               --header "X-GitHub-Api-Version: 2022-11-28" \
               https://api.github.com/repos/leanprover-community/mathlib4/issues/$pr_number/assignees \
               --data '{"assignees":["$handle"]}'

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -46,6 +46,9 @@ to learn about it as well!
   `*-pr-testing-NNNN` branch.
 - `update_nolints_CI.sh`
   Update the `nolints.json` file to remove unneeded entries. Automatically run once a week.
+- `write_assignments.py` is used to automatically assign a reviewer to each stale github PR.
+  This script reads in a .json file with assignment and generates a shell script with the
+  corresponding github API calls (which is then executed).
 - `bench_summary.lean`
   Convert data retrieved from the speed center into a shorter, more accessible format,
   and post a comment with this summary on github.

--- a/scripts/write_assignments.py
+++ b/scripts/write_assignments.py
@@ -1,0 +1,25 @@
+"""
+Read a file |assignments.json| containing reviewer assignments for pull requests,
+parse its contents and generate a shell script making the github API calls to add these users
+as assignees.
+"""
+import json
+
+def call(number: int, handle: str) -> str:
+    # This keeps any existing assignee on the PR.
+    # Calling this with a non-existent user does nothing (in particular, keeps existing assignees).
+    raw = f'''curl --location --request POST --header "Accept: application/vnd.github+json" \\
+        --header "authorization: Bearer ${{ secrets.ASSIGN_REVIEWERS }}" \\
+        --header "X-GitHub-Api-Version: 2022-11-28" \\
+        https://api.github.com/repos/leanprover-community/mathlib4/issues/{number}/assignees \\
+        --data \'{{"assignees":["{handle}"]}}\''''
+    return raw.replace("        ", "  ")
+
+if __name__ == '__main__':
+    with open('assignments.json', 'r') as fi:
+        data = json.load(fi)
+    output = [call(number, user_handle) for (number, user_handle) in data.items()]
+    with open('assign_users.sh', 'w') as outfile:
+        for (number, user_handle) in data.items():
+            print(f"assigning PR {number} to {user_handle}")
+        outfile.write("\n".join(output) + '\n')

--- a/scripts/write_assignments.py
+++ b/scripts/write_assignments.py
@@ -5,9 +5,11 @@ as assignees.
 """
 import json
 
+# Create the github API call to assign mathlib PR |number| to user |handle|.
+# Any existing assignee is kept; specifying a non-existent user does nothing.
+# Github's assignment syntax is documented at
+# https://docs.github.com/en/rest/issues/assignees?apiVersion=2022-11-28#add-assignees-to-an-issue.
 def call(number: int, handle: str) -> str:
-    # This keeps any existing assignee on the PR.
-    # Calling this with a non-existent user does nothing (in particular, keeps existing assignees).
     raw = f'''curl --location --request POST --header "Accept: application/vnd.github+json" \\
         --header "authorization: Bearer ${{ secrets.ASSIGN_REVIEWERS }}" \\
         --header "X-GitHub-Api-Version: 2022-11-28" \\


### PR DESCRIPTION
Once per day, automatically assign all proposed reviewers from the automatic assignment algorithm.
These are initial suggestions; users are free to manually assign to somebody else (or to un-assign themselves; after a day, the algorithm will randomly choose a user again.)

To work around variable quoting issues, we follow a slightly roundabout approach: instead of parsing the json file using a shell script and calling the github API from bash in a loop, we use Python to parse the file, generate a shell script with the desired APIi calls, and execute that script instead.
(This has the advantage of making the output easily auditable; future rewrites are also welcome.)

---------

See [the github documentation](https://docs.github.com/en/rest/issues/assignees?apiVersion=2022-11-28#add-assignees-to-an-issue) for the assignment syntax used.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
