### PR TITLE
[Merged by Bors] - chore: deprecate cc tactic

### DIFF
--- a/Mathlib/Tactic/CC.lean
+++ b/Mathlib/Tactic/CC.lean
@@ -181,6 +181,12 @@ def foldEqcM {α} {m : Type → Type} [Monad m] (s : CCState) (e : Expr) (a : α
 
 end CCState
 
+/-- Option to control whether to show a deprecation warning for the `cc` tactic. -/
+register_option mathlib.tactic.cc.warning : Bool := {
+  defValue := true
+  descr := "Show a deprecation warning when using the `cc` tactic"
+}
+
 /--
 Applies congruence closure to solve the given metavariable.
 This procedure tries to solve the goal by chaining
@@ -204,6 +210,10 @@ derives `a = b` from `Nat.succ a = Nat.succ b`, and `Nat.succ a != Nat.zero` for
 (de Moura, Selsam IJCAR 2016).
 -/
 def _root_.Lean.MVarId.cc (m : MVarId) (cfg : CCConfig := {}) : MetaM Unit := do
+  -- Check if warning should be shown
+  if ← getBoolOption `mathlib.tactic.cc.warning true then
+    logWarning "The tactic `cc` is deprecated since 2025-07-31, please use `grind` instead."
+
   let (_, m) ← m.intros
   m.withContext do
     let s ← CCState.mkUsingHsCore cfg

--- a/Mathlib/Tactic/CC.lean
+++ b/Mathlib/Tactic/CC.lean
@@ -212,7 +212,12 @@ derives `a = b` from `Nat.succ a = Nat.succ b`, and `Nat.succ a != Nat.zero` for
 def _root_.Lean.MVarId.cc (m : MVarId) (cfg : CCConfig := {}) : MetaM Unit := do
   -- Check if warning should be shown
   if ← getBoolOption `mathlib.tactic.cc.warning true then
-    logWarning "The tactic `cc` is deprecated since 2025-07-31, please use `grind` instead."
+    logWarning "The tactic `cc` is deprecated since 2025-07-31, please use `grind` instead.\n\n\
+      Please report any regressions at https://github.com/leanprover/lean4/issues/.\n\
+      Note that `cc` supports some goals that `grind` doesn't,\n\
+      but these rely on higher-order unification and can result in unpredictable performance.\n\
+      If a downstream library is relying on this functionality,\n\
+      please report this in an issue and we'll help find a solution."
 
   let (_, m) ← m.intros
   m.withContext do

--- a/MathlibTest/cc.lean
+++ b/MathlibTest/cc.lean
@@ -6,7 +6,15 @@ import Mathlib.Tactic.CC
 
 set_option linter.unusedVariables false
 
-/-- warning: The tactic `cc` is deprecated since 2025-07-31, please use `grind` instead. -/
+/--
+warning: The tactic `cc` is deprecated since 2025-07-31, please use `grind` instead.
+
+Please report any regressions at https://github.com/leanprover/lean4/issues/.
+Note that `cc` supports some goals that `grind` doesn't,
+but these rely on higher-order unification and can result in unpredictable performance.
+If a downstream library is relying on this functionality,
+please report this in an issue and we'll help find a solution.
+-/
 #guard_msgs in
 example (a b : Nat) : a = b → a = b := by
   cc

--- a/MathlibTest/cc.lean
+++ b/MathlibTest/cc.lean
@@ -6,6 +6,14 @@ import Mathlib.Tactic.CC
 
 set_option linter.unusedVariables false
 
+/-- warning: The tactic `cc` is deprecated since 2025-07-31, please use `grind` instead. -/
+#guard_msgs in
+example (a b : Nat) : a = b → a = b := by
+  cc
+
+-- Turn off the warning for the rest of the file
+set_option mathlib.tactic.cc.warning false
+
 section CC1
 
 open List (Vector)


### PR DESCRIPTION
This PR deprecates Mathlib's `cc` tactic. (This is a port of Leo's implementation in Lean 3.)

While `cc` does support some goals which `grind` doesn't (some by design for performance reasons, others we should catch up soon anyway), Mathlib hasn't ever relied on this additional functionality, and we don't know of downstream libraries using it. If we discover such users, I'd like to first have a change to migrate them to `grind`, and then we can decide whether to cancel the deprecation, or spin out `cc` into a standalone library.