### PR TITLE
[Merged by Bors] - feat(Algebra/Order): `LinearEquiv` version of `toLex`/`ofLex`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -819,6 +819,7 @@ import Mathlib.Algebra.Order.Group.Cyclic
 import Mathlib.Algebra.Order.Group.Defs
 import Mathlib.Algebra.Order.Group.DenselyOrdered
 import Mathlib.Algebra.Order.Group.End
+import Mathlib.Algebra.Order.Group.Equiv
 import Mathlib.Algebra.Order.Group.Finset
 import Mathlib.Algebra.Order.Group.Indicator
 import Mathlib.Algebra.Order.Group.InjSurj
@@ -874,6 +875,7 @@ import Mathlib.Algebra.Order.Kleene
 import Mathlib.Algebra.Order.Module.Algebra
 import Mathlib.Algebra.Order.Module.Basic
 import Mathlib.Algebra.Order.Module.Defs
+import Mathlib.Algebra.Order.Module.Equiv
 import Mathlib.Algebra.Order.Module.Field
 import Mathlib.Algebra.Order.Module.OrderedSMul
 import Mathlib.Algebra.Order.Module.Pointwise

--- a/Mathlib/Algebra/Order/Group/Equiv.lean
+++ b/Mathlib/Algebra/Order/Group/Equiv.lean
@@ -35,3 +35,13 @@ theorem coe_ofLexMulEquiv [Mul α] : ⇑(ofLexMulEquiv α) = ofLex := rfl
 
 @[to_additive (attr := simp)]
 theorem coe_symm_ofLexMulEquiv [Mul α] : ⇑(ofLexMulEquiv α).symm = toLex := rfl
+
+@[simp]
+lemma toEquiv_toLexMulEquiv (G H : Type*) [MulOneClass G] [MulOneClass H] :
+    ⇑(toLexMulEquiv (G × H) : G × H ≃ G ×ₗ H) = toLex :=
+  rfl
+
+@[simp]
+lemma toEquiv_symm_toLexMulEquiv (G H : Type*) [MulOneClass G] [MulOneClass H] :
+    ⇑((toLexMulEquiv (G × H)).symm : G ×ₗ H ≃ G × H) = ofLex :=
+  rfl

--- a/Mathlib/Algebra/Order/Group/Equiv.lean
+++ b/Mathlib/Algebra/Order/Group/Equiv.lean
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2025 Weiyi Wang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Weiyi Wang
+-/
+import Mathlib.Algebra.Group.Equiv.Defs
+import Mathlib.Algebra.Order.Group.Synonym
+
+/-!
+# Add/Mul equivalence for order type synonyms
+-/
+
+variable (α : Type*)
+
+/-- `toLex` as a `MulEquiv`. -/
+@[to_additive "`toLex` as a `AddEquiv`."]
+def toLexMulEquiv [Mul α] : α ≃* Lex α where
+  __ := toLex
+  map_mul' _ _ := by simp
+
+@[to_additive (attr := simp)]
+theorem coe_toLexMulEquiv [Mul α] : ⇑(toLexMulEquiv α) = toLex := rfl
+
+@[to_additive (attr := simp)]
+theorem coe_symm_toLexMulEquiv [Mul α] : ⇑(toLexMulEquiv α).symm = ofLex := rfl
+
+/-- `ofLex` as a `MulEquiv`. -/
+@[to_additive "`ofLex` as a `AddEquiv`."]
+def ofLexMulEquiv [Mul α] : Lex α ≃* α where
+  __ := ofLex
+  map_mul' _ _ := by simp
+
+@[to_additive (attr := simp)]
+theorem coe_ofLexMulEquiv [Mul α] : ⇑(ofLexMulEquiv α) = ofLex := rfl
+
+@[to_additive (attr := simp)]
+theorem coe_symm_ofLexMulEquiv [Mul α] : ⇑(ofLexMulEquiv α).symm = toLex := rfl

--- a/Mathlib/Algebra/Order/Group/Equiv.lean
+++ b/Mathlib/Algebra/Order/Group/Equiv.lean
@@ -5,6 +5,8 @@ Authors: Weiyi Wang
 -/
 import Mathlib.Algebra.Group.Equiv.Defs
 import Mathlib.Algebra.Order.Group.Synonym
+import Mathlib.Algebra.Order.Monoid.Lex
+import Mathlib.Data.Prod.Lex
 
 /-!
 # Add/Mul equivalence for order type synonyms

--- a/Mathlib/Algebra/Order/Group/Equiv.lean
+++ b/Mathlib/Algebra/Order/Group/Equiv.lean
@@ -4,9 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Weiyi Wang
 -/
 import Mathlib.Algebra.Group.Equiv.Defs
-import Mathlib.Algebra.Order.Group.Synonym
 import Mathlib.Algebra.Order.Monoid.Lex
-import Mathlib.Data.Prod.Lex
 
 /-!
 # Add/Mul equivalence for order type synonyms
@@ -39,11 +37,11 @@ theorem coe_ofLexMulEquiv [Mul α] : ⇑(ofLexMulEquiv α) = ofLex := rfl
 theorem coe_symm_ofLexMulEquiv [Mul α] : ⇑(ofLexMulEquiv α).symm = toLex := rfl
 
 @[simp]
-lemma toEquiv_toLexMulEquiv (G H : Type*) [MulOneClass G] [MulOneClass H] :
-    ⇑(toLexMulEquiv (G × H) : G × H ≃ G ×ₗ H) = toLex :=
+lemma toEquiv_toLexMulEquiv [Mul α] :
+    ⇑(toLexMulEquiv α : α ≃ Lex α) = toLex :=
   rfl
 
 @[simp]
-lemma toEquiv_symm_toLexMulEquiv (G H : Type*) [MulOneClass G] [MulOneClass H] :
-    ⇑((toLexMulEquiv (G × H)).symm : G ×ₗ H ≃ G × H) = ofLex :=
+lemma toEquiv_symm_toLexMulEquiv [Mul α] :
+    ⇑((toLexMulEquiv α).symm : Lex α ≃ α) = ofLex :=
   rfl

--- a/Mathlib/Algebra/Order/Group/Equiv.lean
+++ b/Mathlib/Algebra/Order/Group/Equiv.lean
@@ -13,7 +13,7 @@ import Mathlib.Algebra.Order.Group.Synonym
 variable (α : Type*)
 
 /-- `toLex` as a `MulEquiv`. -/
-@[to_additive "`toLex` as a `AddEquiv`."]
+@[to_additive (attr := simps toEquiv) "`toLex` as a `AddEquiv`."]
 def toLexMulEquiv [Mul α] : α ≃* Lex α where
   toEquiv := toLex
   map_mul' _ _ := by simp
@@ -25,7 +25,7 @@ theorem coe_toLexMulEquiv [Mul α] : ⇑(toLexMulEquiv α) = toLex := rfl
 theorem coe_symm_toLexMulEquiv [Mul α] : ⇑(toLexMulEquiv α).symm = ofLex := rfl
 
 /-- `ofLex` as a `MulEquiv`. -/
-@[to_additive "`ofLex` as a `AddEquiv`."]
+@[to_additive (attr := simps toEquiv) "`ofLex` as a `AddEquiv`."]
 def ofLexMulEquiv [Mul α] : Lex α ≃* α where
   toEquiv := ofLex
   map_mul' _ _ := by simp
@@ -35,11 +35,6 @@ theorem coe_ofLexMulEquiv [Mul α] : ⇑(ofLexMulEquiv α) = ofLex := rfl
 
 @[to_additive (attr := simp)]
 theorem coe_symm_ofLexMulEquiv [Mul α] : ⇑(ofLexMulEquiv α).symm = toLex := rfl
-
-@[to_additive (attr := simp)]
-lemma toEquiv_toLexMulEquiv [Mul α] :
-    (toLexMulEquiv α : α ≃ Lex α) = toLex :=
-  rfl
 
 @[to_additive (attr := simp)]
 lemma symm_toLexMulEquiv [Mul α] :

--- a/Mathlib/Algebra/Order/Group/Equiv.lean
+++ b/Mathlib/Algebra/Order/Group/Equiv.lean
@@ -10,34 +10,34 @@ import Mathlib.Algebra.Order.Group.Synonym
 # Add/Mul equivalence for order type synonyms
 -/
 
-variable (α : Type*)
+variable (α : Type*) [Mul α]
 
 /-- `toLex` as a `MulEquiv`. -/
 @[to_additive "`toLex` as a `AddEquiv`."]
-def toLexMulEquiv [Mul α] : α ≃* Lex α where
+def toLexMulEquiv : α ≃* Lex α where
   toEquiv := toLex
   map_mul' _ _ := by simp
 
 /-- `ofLex` as a `MulEquiv`. -/
 @[to_additive "`ofLex` as a `AddEquiv`."]
-def ofLexMulEquiv [Mul α] : Lex α ≃* α where
+def ofLexMulEquiv : Lex α ≃* α where
   toEquiv := ofLex
   map_mul' _ _ := by simp
 
 @[to_additive (attr := simp)]
-theorem coe_toLexMulEquiv [Mul α] : ⇑(toLexMulEquiv α) = toLex := rfl
+theorem coe_toLexMulEquiv : ⇑(toLexMulEquiv α) = toLex := rfl
 
 @[to_additive (attr := simp)]
-theorem coe_ofLexMulEquiv [Mul α] : ⇑(ofLexMulEquiv α) = ofLex := rfl
+theorem coe_ofLexMulEquiv : ⇑(ofLexMulEquiv α) = ofLex := rfl
 
 @[to_additive (attr := simp)]
-lemma symm_toLexMulEquiv [Mul α] : (toLexMulEquiv α).symm = ofLexMulEquiv α := rfl
+lemma symm_toLexMulEquiv : (toLexMulEquiv α).symm = ofLexMulEquiv α := rfl
 
 @[to_additive (attr := simp)]
-lemma symm_ofLexMulEquiv [Mul α] :  (ofLexMulEquiv α).symm = toLexMulEquiv α := rfl
+lemma symm_ofLexMulEquiv :  (ofLexMulEquiv α).symm = toLexMulEquiv α := rfl
 
 @[to_additive (attr := simp)]
-lemma toEquiv_toLexMulEquiv [Mul α] : (toLexMulEquiv α : α ≃ Lex α) = toLex := rfl
+lemma toEquiv_toLexMulEquiv : (toLexMulEquiv α : α ≃ Lex α) = toLex := rfl
 
 @[to_additive (attr := simp)]
-lemma toEquiv_ofLexMulEquiv [Mul α] : (ofLexMulEquiv α : Lex α ≃ α) = ofLex := rfl
+lemma toEquiv_ofLexMulEquiv : (ofLexMulEquiv α : Lex α ≃ α) = ofLex := rfl

--- a/Mathlib/Algebra/Order/Group/Equiv.lean
+++ b/Mathlib/Algebra/Order/Group/Equiv.lean
@@ -34,7 +34,7 @@ theorem coe_ofLexMulEquiv : ⇑(ofLexMulEquiv α) = ofLex := rfl
 lemma symm_toLexMulEquiv : (toLexMulEquiv α).symm = ofLexMulEquiv α := rfl
 
 @[to_additive (attr := simp)]
-lemma symm_ofLexMulEquiv :  (ofLexMulEquiv α).symm = toLexMulEquiv α := rfl
+lemma symm_ofLexMulEquiv : (ofLexMulEquiv α).symm = toLexMulEquiv α := rfl
 
 @[to_additive (attr := simp)]
 lemma toEquiv_toLexMulEquiv : (toLexMulEquiv α : α ≃ Lex α) = toLex := rfl

--- a/Mathlib/Algebra/Order/Group/Equiv.lean
+++ b/Mathlib/Algebra/Order/Group/Equiv.lean
@@ -13,7 +13,7 @@ import Mathlib.Algebra.Order.Group.Synonym
 variable (α : Type*)
 
 /-- `toLex` as a `MulEquiv`. -/
-@[to_additive (attr := simps toEquiv) "`toLex` as a `AddEquiv`."]
+@[to_additive "`toLex` as a `AddEquiv`."]
 def toLexMulEquiv [Mul α] : α ≃* Lex α where
   toEquiv := toLex
   map_mul' _ _ := by simp
@@ -25,7 +25,7 @@ theorem coe_toLexMulEquiv [Mul α] : ⇑(toLexMulEquiv α) = toLex := rfl
 theorem coe_symm_toLexMulEquiv [Mul α] : ⇑(toLexMulEquiv α).symm = ofLex := rfl
 
 /-- `ofLex` as a `MulEquiv`. -/
-@[to_additive (attr := simps toEquiv) "`ofLex` as a `AddEquiv`."]
+@[to_additive "`ofLex` as a `AddEquiv`."]
 def ofLexMulEquiv [Mul α] : Lex α ≃* α where
   toEquiv := ofLex
   map_mul' _ _ := by simp
@@ -35,6 +35,11 @@ theorem coe_ofLexMulEquiv [Mul α] : ⇑(ofLexMulEquiv α) = ofLex := rfl
 
 @[to_additive (attr := simp)]
 theorem coe_symm_ofLexMulEquiv [Mul α] : ⇑(ofLexMulEquiv α).symm = toLex := rfl
+
+@[to_additive (attr := simp)]
+lemma toEquiv_toLexMulEquiv [Mul α] :
+    (toLexMulEquiv α : α ≃ Lex α) = toLex :=
+  rfl
 
 @[to_additive (attr := simp)]
 lemma symm_toLexMulEquiv [Mul α] :

--- a/Mathlib/Algebra/Order/Group/Equiv.lean
+++ b/Mathlib/Algebra/Order/Group/Equiv.lean
@@ -38,10 +38,10 @@ theorem coe_symm_ofLexMulEquiv [Mul α] : ⇑(ofLexMulEquiv α).symm = toLex := 
 
 @[to_additive (attr := simp)]
 lemma toEquiv_toLexMulEquiv [Mul α] :
-    ⇑(toLexMulEquiv α : α ≃ Lex α) = toLex :=
+    (toLexMulEquiv α : α ≃ Lex α) = toLex :=
   rfl
 
 @[to_additive (attr := simp)]
 lemma toEquiv_symm_toLexMulEquiv [Mul α] :
-    ⇑((toLexMulEquiv α).symm : Lex α ≃ α) = ofLex :=
+    ((toLexMulEquiv α).symm : Lex α ≃ α) = ofLex :=
   rfl

--- a/Mathlib/Algebra/Order/Group/Equiv.lean
+++ b/Mathlib/Algebra/Order/Group/Equiv.lean
@@ -18,12 +18,6 @@ def toLexMulEquiv [Mul α] : α ≃* Lex α where
   toEquiv := toLex
   map_mul' _ _ := by simp
 
-@[to_additive (attr := simp)]
-theorem coe_toLexMulEquiv [Mul α] : ⇑(toLexMulEquiv α) = toLex := rfl
-
-@[to_additive (attr := simp)]
-theorem coe_symm_toLexMulEquiv [Mul α] : ⇑(toLexMulEquiv α).symm = ofLex := rfl
-
 /-- `ofLex` as a `MulEquiv`. -/
 @[to_additive "`ofLex` as a `AddEquiv`."]
 def ofLexMulEquiv [Mul α] : Lex α ≃* α where
@@ -31,17 +25,19 @@ def ofLexMulEquiv [Mul α] : Lex α ≃* α where
   map_mul' _ _ := by simp
 
 @[to_additive (attr := simp)]
+theorem coe_toLexMulEquiv [Mul α] : ⇑(toLexMulEquiv α) = toLex := rfl
+
+@[to_additive (attr := simp)]
 theorem coe_ofLexMulEquiv [Mul α] : ⇑(ofLexMulEquiv α) = ofLex := rfl
 
 @[to_additive (attr := simp)]
-theorem coe_symm_ofLexMulEquiv [Mul α] : ⇑(ofLexMulEquiv α).symm = toLex := rfl
+lemma symm_toLexMulEquiv [Mul α] : (toLexMulEquiv α).symm = ofLexMulEquiv α := rfl
 
 @[to_additive (attr := simp)]
-lemma toEquiv_toLexMulEquiv [Mul α] :
-    (toLexMulEquiv α : α ≃ Lex α) = toLex :=
-  rfl
+lemma symm_ofLexMulEquiv [Mul α] :  (ofLexMulEquiv α).symm = toLexMulEquiv α := rfl
 
 @[to_additive (attr := simp)]
-lemma symm_toLexMulEquiv [Mul α] :
-    (toLexMulEquiv α).symm = ofLexMulEquiv α :=
-  rfl
+lemma toEquiv_toLexMulEquiv [Mul α] : (toLexMulEquiv α : α ≃ Lex α) = toLex := rfl
+
+@[to_additive (attr := simp)]
+lemma toEquiv_ofLexMulEquiv [Mul α] : (ofLexMulEquiv α : Lex α ≃ α) = ofLex := rfl

--- a/Mathlib/Algebra/Order/Group/Equiv.lean
+++ b/Mathlib/Algebra/Order/Group/Equiv.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Weiyi Wang
 -/
 import Mathlib.Algebra.Group.Equiv.Defs
-import Mathlib.Algebra.Order.Monoid.Lex
+import Mathlib.Algebra.Order.Group.Synonym
 
 /-!
 # Add/Mul equivalence for order type synonyms

--- a/Mathlib/Algebra/Order/Group/Equiv.lean
+++ b/Mathlib/Algebra/Order/Group/Equiv.lean
@@ -15,7 +15,7 @@ variable (α : Type*)
 /-- `toLex` as a `MulEquiv`. -/
 @[to_additive "`toLex` as a `AddEquiv`."]
 def toLexMulEquiv [Mul α] : α ≃* Lex α where
-  __ := toLex
+  toEquiv := toLex
   map_mul' _ _ := by simp
 
 @[to_additive (attr := simp)]
@@ -27,7 +27,7 @@ theorem coe_symm_toLexMulEquiv [Mul α] : ⇑(toLexMulEquiv α).symm = ofLex := 
 /-- `ofLex` as a `MulEquiv`. -/
 @[to_additive "`ofLex` as a `AddEquiv`."]
 def ofLexMulEquiv [Mul α] : Lex α ≃* α where
-  __ := ofLex
+  toEquiv := ofLex
   map_mul' _ _ := by simp
 
 @[to_additive (attr := simp)]
@@ -42,6 +42,6 @@ lemma toEquiv_toLexMulEquiv [Mul α] :
   rfl
 
 @[to_additive (attr := simp)]
-lemma toEquiv_symm_toLexMulEquiv [Mul α] :
-    ((toLexMulEquiv α).symm : Lex α ≃ α) = ofLex :=
+lemma symm_toLexMulEquiv [Mul α] :
+    (toLexMulEquiv α).symm = ofLexMulEquiv α :=
   rfl

--- a/Mathlib/Algebra/Order/Group/Equiv.lean
+++ b/Mathlib/Algebra/Order/Group/Equiv.lean
@@ -36,12 +36,12 @@ theorem coe_ofLexMulEquiv [Mul α] : ⇑(ofLexMulEquiv α) = ofLex := rfl
 @[to_additive (attr := simp)]
 theorem coe_symm_ofLexMulEquiv [Mul α] : ⇑(ofLexMulEquiv α).symm = toLex := rfl
 
-@[simp]
+@[to_additive (attr := simp)]
 lemma toEquiv_toLexMulEquiv [Mul α] :
     ⇑(toLexMulEquiv α : α ≃ Lex α) = toLex :=
   rfl
 
-@[simp]
+@[to_additive (attr := simp)]
 lemma toEquiv_symm_toLexMulEquiv [Mul α] :
     ⇑((toLexMulEquiv α).symm : Lex α ≃ α) = ofLex :=
   rfl

--- a/Mathlib/Algebra/Order/GroupWithZero/Lex.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Lex.lean
@@ -26,16 +26,6 @@ Create the "LinOrdCommGrpWithZero" category.
 
 -/
 
-@[simp]
-lemma toEquiv_toLexMulEquiv (G H : Type*) [MulOneClass G] [MulOneClass H] :
-    ⇑(toLexMulEquiv (G × H) : G × H ≃ G ×ₗ H) = toLex :=
-  rfl
-
-@[simp]
-lemma toEquiv_symm_toLexMulEquiv (G H : Type*) [MulOneClass G] [MulOneClass H] :
-    ⇑((toLexMulEquiv (G × H)).symm : G ×ₗ H ≃ G × H) = ofLex :=
-  rfl
-
 namespace MonoidWithZeroHom
 
 variable {M₀ N₀ : Type*}

--- a/Mathlib/Algebra/Order/GroupWithZero/Lex.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Lex.lean
@@ -6,8 +6,6 @@ Authors: Yakov Pechersky
 import Mathlib.Algebra.GroupWithZero.ProdHom
 import Mathlib.Algebra.Order.Group.Equiv
 import Mathlib.Algebra.Order.Hom.MonoidWithZero
-import Mathlib.Algebra.Order.Monoid.Lex
-import Mathlib.Data.Prod.Lex
 
 /-!
 # Order homomorphisms for products of linearly ordered groups with zero

--- a/Mathlib/Algebra/Order/GroupWithZero/Lex.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Lex.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yakov Pechersky
 -/
 import Mathlib.Algebra.GroupWithZero.ProdHom
+import Mathlib.Algebra.Order.Group.Equiv
 import Mathlib.Algebra.Order.Hom.MonoidWithZero
 import Mathlib.Algebra.Order.Monoid.Lex
 import Mathlib.Data.Prod.Lex
@@ -25,33 +26,14 @@ Create the "LinOrdCommGrpWithZero" category.
 
 -/
 
--- TODO: find a better place
-/-- `toLex` as a monoid isomorphism. -/
-def toLexMulEquiv (G H : Type*) [MulOneClass G] [MulOneClass H] : G × H ≃* G ×ₗ H where
-  toFun := toLex
-  invFun := ofLex
-  left_inv := ofLex_toLex
-  right_inv := toLex_ofLex
-  map_mul' := toLex_mul
-
-@[simp]
-lemma coe_toLexMulEquiv (G H : Type*) [MulOneClass G] [MulOneClass H] :
-    ⇑(toLexMulEquiv G H) = toLex :=
-  rfl
-
-@[simp]
-lemma coe_symm_toLexMulEquiv (G H : Type*) [MulOneClass G] [MulOneClass H] :
-    ⇑(toLexMulEquiv G H).symm = ofLex :=
-  rfl
-
 @[simp]
 lemma toEquiv_toLexMulEquiv (G H : Type*) [MulOneClass G] [MulOneClass H] :
-    ⇑(toLexMulEquiv G H : G × H ≃ G ×ₗ H) = toLex :=
+    ⇑(toLexMulEquiv (G × H) : G × H ≃ G ×ₗ H) = toLex :=
   rfl
 
 @[simp]
 lemma toEquiv_symm_toLexMulEquiv (G H : Type*) [MulOneClass G] [MulOneClass H] :
-    ⇑((toLexMulEquiv G H).symm : G ×ₗ H ≃ G × H) = ofLex :=
+    ⇑((toLexMulEquiv (G × H)).symm : G ×ₗ H ≃ G × H) = ofLex :=
   rfl
 
 namespace MonoidWithZeroHom

--- a/Mathlib/Algebra/Order/GroupWithZero/Lex.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Lex.lean
@@ -5,7 +5,7 @@ Authors: Yakov Pechersky
 -/
 import Mathlib.Algebra.GroupWithZero.ProdHom
 import Mathlib.Algebra.Order.Group.Equiv
-import Mathlib.Algebra.Order.Group.Synonym
+import Mathlib.Algebra.Order.Monoid.Lex
 import Mathlib.Algebra.Order.Hom.MonoidWithZero
 import Mathlib.Data.Prod.Lex
 

--- a/Mathlib/Algebra/Order/GroupWithZero/Lex.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Lex.lean
@@ -5,7 +5,9 @@ Authors: Yakov Pechersky
 -/
 import Mathlib.Algebra.GroupWithZero.ProdHom
 import Mathlib.Algebra.Order.Group.Equiv
+import Mathlib.Algebra.Order.Group.Synonym
 import Mathlib.Algebra.Order.Hom.MonoidWithZero
+import Mathlib.Data.Prod.Lex
 
 /-!
 # Order homomorphisms for products of linearly ordered groups with zero

--- a/Mathlib/Algebra/Order/Module/Equiv.lean
+++ b/Mathlib/Algebra/Order/Module/Equiv.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2025 Weiyi Wang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Weiyi Wang
+-/
+import Mathlib.Algebra.Module.Equiv.Basic
+import Mathlib.Algebra.Order.Group.Equiv
+import Mathlib.Algebra.Order.Module.Synonym
+
+/-!
+# Linear equivalence for order type synonyms
+-/
+
+variable (α β : Type*)
+variable [Semiring α] [AddCommMonoid β] [Module α β]
+
+/-- `toLex` as a linear equivalence -/
+def toLexLinearEquiv : β ≃ₗ[α] Lex β := (toLexAddEquiv β).toLinearEquiv toLex_smul
+
+@[simp]
+theorem coe_toLexLinearEquiv : ⇑(toLexLinearEquiv α β) = toLex := rfl
+
+@[simp]
+theorem coe_symm_toLexLinearEquiv : ⇑(toLexLinearEquiv α β).symm = ofLex := rfl
+
+/-- `ofLex` as a linear equivalence -/
+def ofLexLinearEquiv : Lex β ≃ₗ[α] β := (ofLexAddEquiv β).toLinearEquiv ofLex_smul
+
+@[simp]
+theorem coe_ofLexLinearEquiv : ⇑(ofLexLinearEquiv α β) = ofLex := rfl
+
+@[simp]
+theorem coe_symm_ofLexLinearEquiv : ⇑(ofLexLinearEquiv α β).symm = toLex := rfl

--- a/Mathlib/Algebra/Order/Module/Equiv.lean
+++ b/Mathlib/Algebra/Order/Module/Equiv.lean
@@ -17,17 +17,11 @@ variable [Semiring α] [AddCommMonoid β] [Module α β]
 /-- `toLex` as a linear equivalence -/
 def toLexLinearEquiv : β ≃ₗ[α] Lex β := (toLexAddEquiv β).toLinearEquiv toLex_smul
 
-@[simp]
-theorem coe_toLexLinearEquiv : ⇑(toLexLinearEquiv α β) = toLex := rfl
-
-@[simp]
-theorem coe_symm_toLexLinearEquiv : ⇑(toLexLinearEquiv α β).symm = ofLex := rfl
-
 /-- `ofLex` as a linear equivalence -/
 def ofLexLinearEquiv : Lex β ≃ₗ[α] β := (ofLexAddEquiv β).toLinearEquiv ofLex_smul
 
-@[simp]
-theorem coe_ofLexLinearEquiv : ⇑(ofLexLinearEquiv α β) = ofLex := rfl
+@[simp] lemma coe_toLexLinearEquiv : ⇑(toLexLinearEquiv α β) = toLex := rfl
+@[simp] lemma coe_ofLexLinearEquiv : ⇑(ofLexLinearEquiv α β) = ofLex := rfl
 
-@[simp]
-theorem coe_symm_ofLexLinearEquiv : ⇑(ofLexLinearEquiv α β).symm = toLex := rfl
+@[simp] lemma symm_toLexLinearEquiv : (toLexLinearEquiv α β).symm = ofLexLinearEquiv α β := rfl
+@[simp] lemma symm_ofLexLinearEquiv : (ofLexLinearEquiv α β).symm = toLexLinearEquiv α β := rfl


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
