### PR TITLE
[Merged by Bors] - chore: remove old 2024-04 deprecations

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/PiL2.lean
+++ b/Mathlib/Analysis/InnerProductSpace/PiL2.lean
@@ -194,11 +194,6 @@ theorem EuclideanSpace.inner_eq_star_dotProduct (x y : EuclideanSpace 𝕜 ι) :
 lemma EuclideanSpace.inner_toLp_toLp (x y : ι → 𝕜) :
     ⟪toLp 2 x, toLp 2 y⟫ = dotProduct y (star x) := rfl
 
-@[deprecated EuclideanSpace.inner_toLp_toLp (since := "2024-04-27")]
-theorem EuclideanSpace.inner_piLp_equiv_symm (x y : ι → 𝕜) :
-    ⟪(WithLp.equiv 2 _).symm x, (WithLp.equiv 2 _).symm y⟫ = y ⬝ᵥ star x :=
-  rfl
-
 /-- A finite, mutually orthogonal family of subspaces of `E`, which span `E`, induce an isometry
 from `E` to `PiLp 2` of the subspaces equipped with the `L2` inner product. -/
 def DirectSum.IsInternal.isometryL2OfOrthogonalFamily [DecidableEq ι] {V : ι → Submodule 𝕜 E}
@@ -258,18 +253,8 @@ def EuclideanSpace.single (i : ι) (a : 𝕜) : EuclideanSpace 𝕜 ι :=
 
 @[simp] lemma EuclideanSpace.ofLp_single (i : ι) (a : 𝕜) : ofLp (single i a) = Pi.single i a := rfl
 
-@[deprecated EuclideanSpace.ofLp_single (since := "2024-04-27")]
-theorem WithLp.equiv_single (i : ι) (a : 𝕜) :
-    WithLp.equiv _ _ (EuclideanSpace.single i a) = Pi.single i a :=
-  rfl
-
 @[simp]
 lemma EuclideanSpace.toLp_single (i : ι) (a : 𝕜) : toLp _ (Pi.single i a) = single i a := rfl
-
-@[deprecated EuclideanSpace.toLp_single (since := "2024-04-27")]
-theorem WithLp.equiv_symm_single (i : ι) (a : 𝕜) :
-    (WithLp.equiv _ _).symm (Pi.single i a) = EuclideanSpace.single i a :=
-  rfl
 
 @[simp]
 theorem EuclideanSpace.single_apply (i : ι) (a : 𝕜) (j : ι) :
@@ -1148,20 +1133,9 @@ def toEuclideanLin : Matrix m n 𝕜 ≃ₗ[𝕜] EuclideanSpace 𝕜 n →ₗ[�
 lemma toEuclideanLin_toLp (A : Matrix m n 𝕜) (x : n → 𝕜) :
     Matrix.toEuclideanLin A (toLp _ x) = toLp _ (Matrix.toLin' A x) := rfl
 
-@[deprecated toEuclideanLin_toLp (since := "2024-04-27")]
-theorem toEuclideanLin_piLp_equiv_symm (A : Matrix m n 𝕜) (x : n → 𝕜) :
-    Matrix.toEuclideanLin A ((WithLp.equiv _ _).symm x) =
-      (WithLp.equiv _ _).symm (A *ᵥ x) :=
-  rfl
-
 @[simp]
 theorem piLp_ofLp_toEuclideanLin (A : Matrix m n 𝕜) (x : EuclideanSpace 𝕜 n) :
     ofLp (Matrix.toEuclideanLin A x) = Matrix.toLin' A (ofLp x) :=
-  rfl
-
-@[deprecated piLp_ofLp_toEuclideanLin (since := "2024-04-27")]
-theorem piLp_equiv_toEuclideanLin (A : Matrix m n 𝕜) (x : EuclideanSpace 𝕜 n) :
-    WithLp.equiv _ _ (Matrix.toEuclideanLin A x) = A *ᵥ (WithLp.equiv _ _ x) :=
   rfl
 
 theorem toEuclideanLin_apply (M : Matrix m n 𝕜) (v : EuclideanSpace 𝕜 n) :
@@ -1172,19 +1146,9 @@ theorem ofLp_toEuclideanLin_apply (M : Matrix m n 𝕜) (v : EuclideanSpace 𝕜
     ofLp (toEuclideanLin M v) = M *ᵥ ofLp v :=
   rfl
 
-@[deprecated ofLp_toEuclideanLin_apply (since := "2024-04-27")]
-theorem piLp_equiv_toEuclideanLin_apply (M : Matrix m n 𝕜) (v : EuclideanSpace 𝕜 n) :
-    WithLp.equiv 2 (m → 𝕜) (toEuclideanLin M v) = M *ᵥ WithLp.equiv 2 (n → 𝕜) v :=
-  rfl
-
 @[simp]
 theorem toEuclideanLin_apply_piLp_toLp (M : Matrix m n 𝕜) (v : n → 𝕜) :
     toEuclideanLin M (toLp _ v) = toLp _ (M *ᵥ v) :=
-  rfl
-
-@[deprecated toEuclideanLin_apply_piLp_toLp (since := "2024-04-27")]
-theorem toEuclideanLin_apply_piLp_equiv_symm (M : Matrix m n 𝕜) (v : n → 𝕜) :
-    toEuclideanLin M ((WithLp.equiv 2 (n→ 𝕜)).symm v) = (WithLp.equiv 2 (m → 𝕜)).symm (M *ᵥ v) :=
   rfl
 
 -- `Matrix.toEuclideanLin` is the same as `Matrix.toLin` applied to `PiLp.basisFun`,

--- a/Mathlib/Analysis/Normed/Lp/MeasurableSpace.lean
+++ b/Mathlib/Analysis/Normed/Lp/MeasurableSpace.lean
@@ -25,14 +25,8 @@ instance measurableSpace : MeasurableSpace (WithLp p X) :=
 @[fun_prop, measurability]
 lemma measurable_ofLp : Measurable (@WithLp.ofLp p X) := fun _ h ↦ h
 
-@[deprecated measurable_ofLp (since := "2024-04-27")]
-lemma measurable_equiv : Measurable (WithLp.equiv p X) := fun _ h ↦ h
-
 @[fun_prop, measurability]
 lemma measurable_toLp : Measurable (@WithLp.toLp p X) := fun _ h ↦ h
-
-@[deprecated measurable_toLp (since := "2024-04-27")]
-lemma measurable_equiv_symm : Measurable (WithLp.equiv p X).symm := fun _ h ↦ h
 
 variable (Y : Type*) [MeasurableSpace Y] [TopologicalSpace X] [TopologicalSpace Y]
   [BorelSpace X] [BorelSpace Y] [SecondCountableTopologyEither X Y]

--- a/Mathlib/Analysis/Normed/Lp/PiLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/PiLp.lean
@@ -129,15 +129,6 @@ the use of the type synonym. -/
 @[simp] lemma ofLp_apply (x : PiLp p α) (i : ι) : ofLp x i = x i := rfl
 @[simp] lemma toLp_apply (x : ∀ i, α i) (i : ι) : toLp p x i = x i := rfl
 
-@[deprecated ofLp_apply (since := "2024-04-27")]
-theorem _root_.WithLp.equiv_pi_apply (x : PiLp p α) (i : ι) : WithLp.equiv p _ x i = x i :=
-  rfl
-
-@[deprecated toLp_apply (since := "2024-04-27")]
-theorem _root_.WithLp.equiv_symm_pi_apply (x : ∀ i, α i) (i : ι) :
-    (WithLp.equiv p _).symm x i = x i :=
-  rfl
-
 section DistNorm
 
 variable [Fintype ι]
@@ -444,18 +435,9 @@ instance topologicalSpace [∀ i, TopologicalSpace (β i)] : TopologicalSpace (P
 theorem continuous_ofLp [∀ i, TopologicalSpace (β i)] : Continuous (@ofLp p (∀ i, β i)) :=
   continuous_id
 
-@[deprecated continuous_ofLp (since := "2024-04-27")]
-theorem continuous_equiv [∀ i, TopologicalSpace (β i)] : Continuous (WithLp.equiv p (Π i, β i)) :=
-  continuous_ofLp _ _
-
 @[fun_prop, continuity]
 theorem continuous_toLp [∀ i, TopologicalSpace (β i)] : Continuous (@toLp p (∀ i, β i)) :=
   continuous_id
-
-@[deprecated continuous_toLp (since := "2024-04-27")]
-theorem continuous_equiv_symm [∀ i, TopologicalSpace (β i)] :
-    Continuous (WithLp.equiv p (Π i, β i)).symm :=
-  continuous_toLp _ _
 
 instance secondCountableTopology [Countable ι] [∀ i, TopologicalSpace (β i)]
     [∀ i, SecondCountableTopology (β i)] : SecondCountableTopology (PiLp p β) :=
@@ -468,19 +450,9 @@ lemma uniformContinuous_ofLp [∀ i, UniformSpace (β i)] :
     UniformContinuous (@ofLp p (∀ i, β i)) :=
   uniformContinuous_id
 
-@[deprecated uniformContinuous_ofLp (since := "2024-04-27")]
-theorem uniformContinuous_equiv [∀ i, UniformSpace (β i)] :
-    UniformContinuous (WithLp.equiv p (∀ i, β i)) :=
-  uniformContinuous_ofLp _ _
-
 lemma uniformContinuous_toLp [∀ i, UniformSpace (β i)] :
     UniformContinuous (@toLp p (∀ i, β i)) :=
   uniformContinuous_id
-
-@[deprecated uniformContinuous_toLp (since := "2024-04-27")]
-theorem uniformContinuous_equiv_symm [∀ i, UniformSpace (β i)] :
-    UniformContinuous (WithLp.equiv p (∀ i, β i)).symm :=
-  uniformContinuous_toLp _ _
 
 instance completeSpace [∀ i, UniformSpace (β i)] [∀ i, CompleteSpace (β i)] :
     CompleteSpace (PiLp p β) :=
@@ -549,19 +521,9 @@ lemma lipschitzWith_ofLp [∀ i, PseudoEMetricSpace (β i)] :
     LipschitzWith 1 (@ofLp p (∀ i, β i)) :=
   lipschitzWith_ofLp_aux p β
 
-@[deprecated lipschitzWith_ofLp (since := "2024-04-27")]
-theorem lipschitzWith_equiv [∀ i, PseudoEMetricSpace (β i)] :
-    LipschitzWith 1 (WithLp.equiv p (∀ i, β i)) :=
-  lipschitzWith_ofLp p β
-
 theorem antilipschitzWith_ofLp [∀ i, PseudoEMetricSpace (β i)] :
     AntilipschitzWith ((Fintype.card ι : ℝ≥0) ^ (1 / p).toReal) (@ofLp p (∀ i, β i)) :=
   antilipschitzWith_ofLp_aux p β
-
-@[deprecated antilipschitzWith_ofLp (since := "2024-04-27")]
-theorem antilipschitzWith_equiv [∀ i, PseudoEMetricSpace (β i)] :
-    AntilipschitzWith ((Fintype.card ι : ℝ≥0) ^ (1 / p).toReal) (WithLp.equiv p (∀ i, β i)) :=
-  antilipschitzWith_ofLp p β
 
 lemma isometry_ofLp_infty [∀ i, PseudoEMetricSpace (β i)] :
     Isometry (@ofLp ∞ (∀ i, β i)) :=
@@ -569,11 +531,6 @@ lemma isometry_ofLp_infty [∀ i, PseudoEMetricSpace (β i)] :
   le_antisymm (by simpa only [ENNReal.coe_one, one_mul] using lipschitzWith_ofLp ∞ β x y)
     (by simpa only [ENNReal.div_top, ENNReal.toReal_zero, NNReal.rpow_zero, ENNReal.coe_one,
       one_mul] using antilipschitzWith_ofLp ∞ β x y)
-
-@[deprecated isometry_ofLp_infty (since := "2024-04-27")]
-theorem infty_equiv_isometry [∀ i, PseudoEMetricSpace (β i)] :
-    Isometry (WithLp.equiv ∞ (∀ i, β i)) :=
-  isometry_ofLp_infty _
 
 /-- seminormed group instance on the product of finitely many normed groups, using the `L^p`
 norm. -/
@@ -630,21 +587,10 @@ theorem nnnorm_eq_ciSup (f : PiLp ∞ β) : ‖f‖₊ = ⨆ i, ‖f i‖₊ := 
   rw [nnnorm_eq_ciSup, Pi.nnnorm_def, Finset.sup_univ_eq_ciSup]
   dsimp only [ofLp_apply]
 
-@[deprecated nnnorm_ofLp (since := "2024-04-27")]
-theorem nnnorm_equiv (f : PiLp ∞ β) : ‖WithLp.equiv ⊤ _ f‖₊ = ‖f‖₊ := nnnorm_ofLp _
-
 @[simp] lemma nnnorm_toLp (f : ∀ i, β i) : ‖toLp ∞ f‖₊ = ‖f‖₊ := (nnnorm_ofLp _).symm
-
-@[deprecated nnnorm_toLp (since := "2024-04-27")]
-theorem nnnorm_equiv_symm (f : ∀ i, β i) : ‖(WithLp.equiv ⊤ _).symm f‖₊ = ‖f‖₊ := nnnorm_toLp _
 
 @[simp] lemma norm_ofLp (f : PiLp ∞ β) : ‖ofLp f‖ = ‖f‖ := congr_arg NNReal.toReal <| nnnorm_ofLp f
 @[simp] lemma norm_toLp (f : ∀ i, β i) : ‖toLp ∞ f‖ = ‖f‖ := (norm_ofLp _).symm
-
-@[deprecated norm_ofLp (since := "2024-04-27")]
-theorem norm_equiv (f : PiLp ∞ β) : ‖WithLp.equiv ⊤ _ f‖ = ‖f‖ := norm_ofLp _
-@[deprecated norm_toLp (since := "2024-04-27")]
-theorem norm_equiv_symm (f : ∀ i, β i) : ‖(WithLp.equiv ⊤ _).symm f‖ = ‖f‖ := norm_toLp _
 
 end Linfty
 
@@ -947,58 +893,24 @@ theorem nnnorm_toLp_single (i : ι) (b : β i) :
     intro j hij
     rw [toLp_apply, Pi.single_eq_of_ne hij, nnnorm_zero, NNReal.zero_rpow hp0]
 
-@[deprecated nnnorm_toLp_single (since := "2024-04-27")]
-theorem nnnorm_equiv_symm_single (i : ι) (b : β i) :
-    ‖(WithLp.equiv p (∀ i, β i)).symm (Pi.single i b)‖₊ = ‖b‖₊ :=
-  nnnorm_toLp_single _ _ _ _
-
 @[simp]
 lemma norm_toLp_single (i : ι) (b : β i) : ‖toLp p (Pi.single i b)‖ = ‖b‖ :=
   congr_arg ((↑) : ℝ≥0 → ℝ) <| nnnorm_toLp_single p β i b
-
-@[deprecated norm_toLp_single (since := "2024-04-27")]
-theorem norm_equiv_symm_single (i : ι) (b : β i) :
-    ‖(WithLp.equiv p (∀ i, β i)).symm (Pi.single i b)‖ = ‖b‖ :=
-  norm_toLp_single _ _ _ _
 
 @[simp]
 lemma nndist_toLp_single_same (i : ι) (b₁ b₂ : β i) :
     nndist (toLp p (Pi.single i b₁)) (toLp p (Pi.single i b₂)) = nndist b₁ b₂ := by
   rw [nndist_eq_nnnorm, nndist_eq_nnnorm, ← toLp_sub, ← Pi.single_sub, nnnorm_toLp_single]
 
-@[deprecated nndist_toLp_single_same (since := "2024-04-27")]
-theorem nndist_equiv_symm_single_same (i : ι) (b₁ b₂ : β i) :
-    nndist
-        ((WithLp.equiv p (∀ i, β i)).symm (Pi.single i b₁))
-        ((WithLp.equiv p (∀ i, β i)).symm (Pi.single i b₂)) =
-      nndist b₁ b₂ :=
-  nndist_toLp_single_same _ _ _ _ _
-
 @[simp]
 lemma dist_toLp_single_same (i : ι) (b₁ b₂ : β i) :
     dist (toLp p (Pi.single i b₁)) (toLp p (Pi.single i b₂)) = dist b₁ b₂ :=
   congr_arg ((↑) : ℝ≥0 → ℝ) <| nndist_toLp_single_same p β i b₁ b₂
 
-@[deprecated dist_toLp_single_same (since := "2024-04-27")]
-theorem dist_equiv_symm_single_same (i : ι) (b₁ b₂ : β i) :
-    dist
-        ((WithLp.equiv p (∀ i, β i)).symm (Pi.single i b₁))
-        ((WithLp.equiv p (∀ i, β i)).symm (Pi.single i b₂)) =
-      dist b₁ b₂ :=
-  dist_toLp_single_same _ _ _ _ _
-
 @[simp]
 lemma edist_toLp_single_same (i : ι) (b₁ b₂ : β i) :
     edist (toLp p (Pi.single i b₁)) (toLp p (Pi.single i b₂)) = edist b₁ b₂ := by
   simp only [edist_nndist, nndist_toLp_single_same p β i b₁ b₂]
-
-@[deprecated "WithLp.equiv has been deprecated, use `ofLp` instead" (since := "2024-04-27")]
-theorem edist_equiv_symm_single_same (i : ι) (b₁ b₂ : β i) :
-    edist
-        ((WithLp.equiv p (∀ i, β i)).symm (Pi.single i b₁))
-        ((WithLp.equiv p (∀ i, β i)).symm (Pi.single i b₂)) =
-      edist b₁ b₂ :=
-  edist_toLp_single_same _ _ _ _ _
 
 end Single
 
@@ -1016,12 +928,6 @@ lemma nnnorm_toLp_const {β} [SeminormedAddCommGroup β] (hp : p ≠ ∞) (b : �
       Finset.card_univ, nsmul_eq_mul, NNReal.mul_rpow, ← NNReal.rpow_mul,
       mul_one_div_cancel ne_zero, NNReal.rpow_one, ENNReal.toReal_div, ENNReal.toReal_one]
 
-@[deprecated nnnorm_toLp_const (since := "2024-04-27")]
-theorem nnnorm_equiv_symm_const {β} [SeminormedAddCommGroup β] (hp : p ≠ ∞) (b : β) :
-    ‖(WithLp.equiv p (ι → β)).symm (Function.const _ b)‖₊ =
-      (Fintype.card ι : ℝ≥0) ^ (1 / p).toReal * ‖b‖₊ :=
-  nnnorm_toLp_const hp _
-
 /-- When `IsEmpty ι`, this lemma does not hold without the additional assumption `p ≠ ∞` because
 the left-hand side simplifies to `0`, while the right-hand side simplifies to `‖b‖₊`. See
 `PiLp.nnnorm_toLp_const` for a version which exchanges the hypothesis `Nonempty ι`.
@@ -1034,12 +940,6 @@ lemma nnnorm_toLp_const' {β} [SeminormedAddCommGroup β] [Nonempty ι] (b : β)
       one_mul, nnnorm_eq_ciSup, Function.const_apply, ciSup_const]
   · exact nnnorm_toLp_const hp b
 
-@[deprecated nnnorm_toLp_const' (since := "2024-04-27")]
-theorem nnnorm_equiv_symm_const' {β} [SeminormedAddCommGroup β] [Nonempty ι] (b : β) :
-    ‖(WithLp.equiv p (ι → β)).symm (Function.const _ b)‖₊ =
-      (Fintype.card ι : ℝ≥0) ^ (1 / p).toReal * ‖b‖₊ :=
-  nnnorm_toLp_const' b
-
 /-- When `p = ∞`, this lemma does not hold without the additional assumption `Nonempty ι` because
 the left-hand side simplifies to `0`, while the right-hand side simplifies to `‖b‖₊`. See
 `PiLp.norm_toLp_const'` for a version which exchanges the hypothesis `p ≠ ∞` for
@@ -1048,12 +948,6 @@ lemma norm_toLp_const {β} [SeminormedAddCommGroup β] (hp : p ≠ ∞) (b : β)
     ‖toLp p (Function.const ι b)‖ =
       (Fintype.card ι : ℝ≥0) ^ (1 / p).toReal * ‖b‖ :=
   (congr_arg ((↑) : ℝ≥0 → ℝ) <| nnnorm_toLp_const hp b).trans <| by simp
-
-@[deprecated norm_toLp_const (since := "2024-04-27")]
-theorem norm_equiv_symm_const {β} [SeminormedAddCommGroup β] (hp : p ≠ ∞) (b : β) :
-    ‖(WithLp.equiv p (ι → β)).symm (Function.const _ b)‖ =
-      (Fintype.card ι : ℝ≥0) ^ (1 / p).toReal * ‖b‖ :=
-  norm_toLp_const hp  _
 
 /-- When `IsEmpty ι`, this lemma does not hold without the additional assumption `p ≠ ∞` because
 the left-hand side simplifies to `0`, while the right-hand side simplifies to `‖b‖₊`. See
@@ -1064,30 +958,13 @@ lemma norm_toLp_const' {β} [SeminormedAddCommGroup β] [Nonempty ι] (b : β) :
       (Fintype.card ι : ℝ≥0) ^ (1 / p).toReal * ‖b‖ :=
   (congr_arg ((↑) : ℝ≥0 → ℝ) <| nnnorm_toLp_const' b).trans <| by simp
 
-@[deprecated norm_toLp_const' (since := "2024-04-27")]
-theorem norm_equiv_symm_const' {β} [SeminormedAddCommGroup β] [Nonempty ι] (b : β) :
-    ‖(WithLp.equiv p (ι → β)).symm (Function.const _ b)‖ =
-      (Fintype.card ι : ℝ≥0) ^ (1 / p).toReal * ‖b‖ :=
-  norm_toLp_const' _
-
 lemma nnnorm_toLp_one {β} [SeminormedAddCommGroup β] (hp : p ≠ ∞) [One β] :
     ‖toLp p (1 : ι → β)‖₊ = (Fintype.card ι : ℝ≥0) ^ (1 / p).toReal * ‖(1 : β)‖₊ :=
   (nnnorm_toLp_const hp (1 : β)).trans rfl
 
-@[deprecated nnnorm_toLp_one (since := "2024-04-27")]
-theorem nnnorm_equiv_symm_one {β} [SeminormedAddCommGroup β] (hp : p ≠ ∞) [One β] :
-    ‖(WithLp.equiv p (ι → β)).symm 1‖₊ =
-      (Fintype.card ι : ℝ≥0) ^ (1 / p).toReal * ‖(1 : β)‖₊ :=
-  nnnorm_toLp_one hp
-
 lemma norm_toLp_one {β} [SeminormedAddCommGroup β] (hp : p ≠ ∞) [One β] :
     ‖toLp p (1 : ι → β)‖ = (Fintype.card ι : ℝ≥0) ^ (1 / p).toReal * ‖(1 : β)‖ :=
   (norm_toLp_const hp (1 : β)).trans rfl
-
-@[deprecated norm_toLp_one (since := "2024-04-27")]
-theorem norm_equiv_symm_one {β} [SeminormedAddCommGroup β] (hp : p ≠ ∞) [One β] :
-    ‖(WithLp.equiv p (ι → β)).symm 1‖ = (Fintype.card ι : ℝ≥0) ^ (1 / p).toReal * ‖(1 : β)‖ :=
-  norm_toLp_one hp
 
 variable (𝕜 p)
 

--- a/Mathlib/Analysis/Normed/Lp/ProdLp.lean
+++ b/Mathlib/Analysis/Normed/Lp/ProdLp.lean
@@ -108,22 +108,6 @@ variable {p α β}
 @[simp] lemma ofLp_fst (x : WithLp p (α × β)) : (ofLp x).fst = x.fst := rfl
 @[simp] lemma ofLp_snd (x : WithLp p (α × β)) : (ofLp x).snd = x.snd := rfl
 
-@[deprecated ofLp_fst (since := "2024-04-27")]
-theorem equiv_fst (x : WithLp p (α × β)) : (WithLp.equiv p (α × β) x).fst = x.fst :=
-  rfl
-
-@[deprecated toLp_fst (since := "2024-04-27")]
-theorem equiv_snd (x : WithLp p (α × β)) : (WithLp.equiv p (α × β) x).snd = x.snd :=
-  rfl
-
-@[deprecated toLp_snd (since := "2024-04-27")]
-theorem equiv_symm_fst (x : α × β) : ((WithLp.equiv p (α × β)).symm x).fst = x.fst :=
-  rfl
-
-@[deprecated ofLp_snd (since := "2024-04-27")]
-theorem equiv_symm_snd (x : α × β) : ((WithLp.equiv p (α × β)).symm x).snd = x.snd :=
-  rfl
-
 end equiv
 
 section DistNorm
@@ -462,16 +446,8 @@ instance instProdTopologicalSpace : TopologicalSpace (WithLp p (α × β)) :=
 @[continuity, fun_prop]
 lemma prod_continuous_toLp : Continuous (@toLp p (α × β)) := continuous_id
 
-@[deprecated prod_continuous_toLp (since := "2024-04-27")]
-theorem prod_continuous_equiv_symm : Continuous (WithLp.equiv p (α × β)).symm :=
-  prod_continuous_toLp _ _ _
-
 @[continuity, fun_prop]
 lemma prod_continuous_ofLp : Continuous (@ofLp p (α × β)) := continuous_id
-
-@[deprecated prod_continuous_ofLp (since := "2024-04-27")]
-theorem prod_continuous_equiv : Continuous (WithLp.equiv p (α × β)) :=
-  prod_continuous_ofLp _ _ _
 
 variable [T0Space α] [T0Space β]
 
@@ -495,16 +471,8 @@ instance instProdUniformSpace : UniformSpace (WithLp p (α × β)) :=
 lemma prod_uniformContinuous_toLp : UniformContinuous (@toLp p (α × β)) :=
   uniformContinuous_id
 
-@[deprecated prod_uniformContinuous_toLp (since := "2024-04-27")]
-theorem prod_uniformContinuous_equiv_symm : UniformContinuous (WithLp.equiv p (α × β)).symm :=
-  prod_uniformContinuous_toLp _ _ _
-
 lemma prod_uniformContinuous_ofLp : UniformContinuous (@ofLp p (α × β)) :=
   uniformContinuous_id
-
-@[deprecated prod_uniformContinuous_ofLp (since := "2024-04-27")]
-theorem prod_uniformContinuous_equiv : UniformContinuous (WithLp.equiv p (α × β)) :=
-  prod_uniformContinuous_ofLp _ _ _
 
 variable [CompleteSpace α] [CompleteSpace β]
 
@@ -603,19 +571,9 @@ lemma prod_lipschitzWith_ofLp [PseudoEMetricSpace α] [PseudoEMetricSpace β] :
     LipschitzWith 1 (@ofLp p (α × β)) :=
   prod_lipschitzWith_ofLp_aux p α β
 
-@[deprecated prod_lipschitzWith_ofLp (since := "2024-04-27")]
-theorem prod_lipschitzWith_equiv [PseudoEMetricSpace α] [PseudoEMetricSpace β] :
-    LipschitzWith 1 (WithLp.equiv p (α × β)) :=
-  prod_lipschitzWith_ofLp p α β
-
 lemma prod_antilipschitzWith_ofLp [PseudoEMetricSpace α] [PseudoEMetricSpace β] :
     AntilipschitzWith ((2 : ℝ≥0) ^ (1 / p).toReal) (@ofLp p (α × β)) :=
   prod_antilipschitzWith_ofLp_aux p α β
-
-@[deprecated prod_antilipschitzWith_ofLp (since := "2024-04-27")]
-theorem prod_antilipschitzWith_equiv [PseudoEMetricSpace α] [PseudoEMetricSpace β] :
-    AntilipschitzWith ((2 : ℝ≥0) ^ (1 / p).toReal) (WithLp.equiv p (α × β)) :=
-  prod_antilipschitzWith_ofLp p α β
 
 lemma prod_isometry_ofLp_infty [PseudoEMetricSpace α] [PseudoEMetricSpace β] :
     Isometry (@ofLp ∞ (α × β)) :=
@@ -624,11 +582,6 @@ lemma prod_isometry_ofLp_infty [PseudoEMetricSpace α] [PseudoEMetricSpace β] :
     (by
       simpa only [ENNReal.div_top, ENNReal.toReal_zero, NNReal.rpow_zero, ENNReal.coe_one,
         one_mul] using prod_antilipschitzWith_ofLp ∞ α β x y)
-
-@[deprecated prod_isometry_ofLp_infty (since := "2024-04-27")]
-theorem prod_infty_equiv_isometry [PseudoEMetricSpace α] [PseudoEMetricSpace β] :
-    Isometry (WithLp.equiv ∞ (α × β)) :=
-  prod_isometry_ofLp_infty _ _
 
 /-- Seminormed group instance on the product of two normed groups, using the `L^p`
 norm. -/
@@ -714,30 +667,14 @@ theorem prod_nnnorm_eq_sup (f : WithLp ∞ (α × β)) : ‖f‖₊ = ‖f.fst�
 @[simp] lemma prod_nnnorm_ofLp (f : WithLp ∞ (α × β)) : ‖ofLp f‖₊ = ‖f‖₊ := by
   rw [prod_nnnorm_eq_sup, Prod.nnnorm_def, ofLp_fst, ofLp_snd]
 
-@[deprecated prod_nnnorm_ofLp (since := "2024-04-27")]
-theorem prod_nnnorm_equiv (f : WithLp ∞ (α × β)) : ‖WithLp.equiv ⊤ _ f‖₊ = ‖f‖₊ :=
-  prod_nnnorm_ofLp _
-
 @[simp] lemma prod_nnnorm_toLp (f : α × β) : ‖toLp ⊤ f‖₊ = ‖f‖₊ :=
   (prod_nnnorm_ofLp _).symm
-
-@[deprecated prod_nnnorm_toLp (since := "2024-04-27")]
-theorem prod_nnnorm_equiv_symm (f : α × β) : ‖(WithLp.equiv ⊤ _).symm f‖₊ = ‖f‖₊ :=
-  prod_nnnorm_toLp _
 
 @[simp] lemma prod_norm_ofLp (f : WithLp ∞ (α × β)) : ‖ofLp f‖ = ‖f‖ :=
   congr_arg NNReal.toReal <| prod_nnnorm_ofLp f
 
-@[deprecated prod_norm_ofLp (since := "2024-04-27")]
-theorem prod_norm_equiv (f : WithLp ∞ (α × β)) : ‖WithLp.equiv ⊤ _ f‖ = ‖f‖ :=
-  prod_norm_ofLp _
-
 @[simp] lemma prod_norm_toLp (f : α × β) : ‖toLp ⊤ f‖ = ‖f‖ :=
   (prod_norm_ofLp _).symm
-
-@[deprecated prod_norm_toLp (since := "2024-04-27")]
-theorem prod_norm_equiv_symm (f : α × β) : ‖(WithLp.equiv ⊤ _).symm f‖ = ‖f‖ :=
-  prod_norm_toLp _
 
 section L1
 
@@ -815,10 +752,6 @@ section Single
     have hp0 : (p : ℝ) ≠ 0 := mod_cast (zero_lt_one.trans_le <| Fact.out (p := 1 ≤ (p : ℝ≥0∞))).ne'
     simp [prod_nnnorm_eq_add, NNReal.zero_rpow hp0, ← NNReal.rpow_mul, mul_inv_cancel₀ hp0]
 
-@[deprecated nnnorm_toLp_inl (since := "2024-04-27")]
-theorem nnnorm_equiv_symm_fst (x : α) : ‖(WithLp.equiv p (α × β)).symm (x, 0)‖₊ = ‖x‖₊ :=
-  nnnorm_toLp_inl ..
-
 @[simp] lemma nnnorm_toLp_inr (y : β) : ‖toLp p ((0 : α), y)‖₊ = ‖y‖₊ := by
   induction p generalizing hp with
   | top =>
@@ -827,25 +760,13 @@ theorem nnnorm_equiv_symm_fst (x : α) : ‖(WithLp.equiv p (α × β)).symm (x,
     have hp0 : (p : ℝ) ≠ 0 := mod_cast (zero_lt_one.trans_le <| Fact.out (p := 1 ≤ (p : ℝ≥0∞))).ne'
     simp [prod_nnnorm_eq_add, NNReal.zero_rpow hp0, ← NNReal.rpow_mul, mul_inv_cancel₀ hp0]
 
-@[deprecated nnnorm_toLp_inr (since := "2024-04-27")]
-lemma nnnorm_equiv_symm_snd (y : β) : ‖(WithLp.equiv p (α × β)).symm (0, y)‖₊ = ‖y‖₊ :=
-  nnnorm_toLp_inr ..
-
 @[simp]
 lemma norm_toLp_fst (x : α) : ‖toLp p (x, (0 : β))‖ = ‖x‖ :=
   congr_arg ((↑) : ℝ≥0 → ℝ) <| nnnorm_toLp_inl p α β x
 
-@[deprecated norm_toLp_fst (since := "2024-04-27")]
-theorem norm_equiv_symm_fst (x : α) : ‖(WithLp.equiv p (α × β)).symm (x, 0)‖ = ‖x‖ :=
-  norm_toLp_fst _ _ _ _
-
 @[simp]
 lemma norm_toLp_snd (y : β) : ‖toLp p ((0 : α), y)‖ = ‖y‖ :=
   congr_arg ((↑) : ℝ≥0 → ℝ) <| nnnorm_toLp_inr p α β y
-
-@[deprecated norm_toLp_snd (since := "2024-04-27")]
-theorem norm_equiv_symm_snd (y : β) : ‖(WithLp.equiv p (α × β)).symm (0, y)‖ = ‖y‖ :=
-  norm_toLp_snd _ _ _ _
 
 @[simp]
 lemma nndist_toLp_fst (x₁ x₂ : α) :
@@ -853,65 +774,29 @@ lemma nndist_toLp_fst (x₁ x₂ : α) :
   rw [nndist_eq_nnnorm, nndist_eq_nnnorm, ← toLp_sub, Prod.mk_sub_mk, sub_zero,
     nnnorm_toLp_inl]
 
-@[deprecated nndist_toLp_fst (since := "2024-04-27")]
-theorem nndist_equiv_symm_fst (x₁ x₂ : α) :
-    nndist ((WithLp.equiv p (α × β)).symm (x₁, 0)) ((WithLp.equiv p (α × β)).symm (x₂, 0)) =
-      nndist x₁ x₂ :=
-  nndist_toLp_fst _ _ _ _ _
-
 @[simp]
 lemma nndist_toLp_snd (y₁ y₂ : β) :
     nndist (toLp p ((0 : α), y₁)) (toLp p (0, y₂)) = nndist y₁ y₂ := by
   rw [nndist_eq_nnnorm, nndist_eq_nnnorm, ← toLp_sub, Prod.mk_sub_mk, sub_zero,
     nnnorm_toLp_inr]
 
-@[deprecated nndist_toLp_snd (since := "2024-04-27")]
-theorem nndist_equiv_symm_snd (y₁ y₂ : β) :
-    nndist ((WithLp.equiv p (α × β)).symm (0, y₁)) ((WithLp.equiv p (α × β)).symm (0, y₂)) =
-      nndist y₁ y₂ :=
-  nndist_toLp_snd _ _ _ _ _
-
 @[simp]
 lemma dist_toLp_fst (x₁ x₂ : α) : dist (toLp p (x₁, (0 : β))) (toLp p (x₂, 0)) = dist x₁ x₂ :=
   congr_arg ((↑) : ℝ≥0 → ℝ) <| nndist_toLp_fst p α β x₁ x₂
-
-@[deprecated dist_toLp_fst (since := "2024-04-27")]
-theorem dist_equiv_symm_fst (x₁ x₂ : α) :
-    dist ((WithLp.equiv p (α × β)).symm (x₁, 0)) ((WithLp.equiv p (α × β)).symm (x₂, 0)) =
-      dist x₁ x₂ :=
-  dist_toLp_fst _ _ _ _ _
 
 @[simp]
 lemma dist_toLp_snd (y₁ y₂ : β) :
     dist (toLp p ((0 : α), y₁)) (toLp p (0, y₂)) = dist y₁ y₂ :=
   congr_arg ((↑) : ℝ≥0 → ℝ) <| nndist_toLp_snd p α β y₁ y₂
 
-@[deprecated dist_toLp_snd (since := "2024-04-27")]
-theorem dist_equiv_symm_snd (y₁ y₂ : β) :
-    dist ((WithLp.equiv p (α × β)).symm (0, y₁)) ((WithLp.equiv p (α × β)).symm (0, y₂)) =
-      dist y₁ y₂ :=
-  dist_toLp_snd _ _ _ _ _
-
 @[simp]
 lemma edist_toLp_fst (x₁ x₂ : α) : edist (toLp p (x₁, (0 : β))) (toLp p (x₂, 0)) = edist x₁ x₂ := by
   simp only [edist_nndist, nndist_toLp_fst p α β x₁ x₂]
-
-@[deprecated edist_toLp_fst (since := "2024-04-27")]
-theorem edist_equiv_symm_fst (x₁ x₂ : α) :
-    edist ((WithLp.equiv p (α × β)).symm (x₁, 0)) ((WithLp.equiv p (α × β)).symm (x₂, 0)) =
-      edist x₁ x₂ :=
-  edist_toLp_fst _ _ _ _ _
 
 @[simp]
 lemma edist_toLp_snd (y₁ y₂ : β) :
     edist (toLp p ((0 : α), y₁)) (toLp p (0, y₂)) = edist y₁ y₂ := by
   simp only [edist_nndist, nndist_toLp_snd p α β y₁ y₂]
-
-@[deprecated edist_toLp_snd (since := "2024-04-27")]
-theorem edist_equiv_symm_snd (y₁ y₂ : β) :
-    edist ((WithLp.equiv p (α × β)).symm (0, y₁)) ((WithLp.equiv p (α × β)).symm (0, y₂)) =
-      edist y₁ y₂ :=
-  edist_toLp_snd _ _ _ _ _
 
 end Single
 

--- a/Mathlib/Analysis/Quaternion.lean
+++ b/Mathlib/Analysis/Quaternion.lean
@@ -153,14 +153,6 @@ lemma norm_toLp_equivTuple (x : ℍ) : ‖WithLp.toLp 2 (equivTuple ℝ x)‖ = 
   simp_rw [RCLike.inner_apply, starRingEnd_apply, star_trivial, ← sq]
   rfl
 
-@[deprecated norm_toLp_equivTuple (since := "2024-04-27")]
-theorem norm_piLp_equiv_symm_equivTuple (x : ℍ) :
-    ‖(WithLp.equiv 2 (Fin 4 → _)).symm (equivTuple ℝ x)‖ = ‖x‖ := by
-  rw [norm_eq_sqrt_real_inner, norm_eq_sqrt_real_inner, inner_self, normSq_def', PiLp.inner_apply,
-    Fin.sum_univ_four]
-  simp_rw [RCLike.inner_apply, starRingEnd_apply, star_trivial, ← sq]
-  rfl
-
 /-- `QuaternionAlgebra.linearEquivTuple` as a `LinearIsometryEquiv`. -/
 @[simps apply symm_apply]
 noncomputable def linearIsometryEquivTuple : ℍ ≃ₗᵢ[ℝ] EuclideanSpace ℝ (Fin 4) :=

--- a/Mathlib/MeasureTheory/Measure/Haar/InnerProductSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/Haar/InnerProductSpace.lean
@@ -135,17 +135,9 @@ equivalence. -/
 theorem PiLp.volume_preserving_ofLp : MeasurePreserving (@WithLp.ofLp 2 (ι → ℝ)) :=
   EuclideanSpace.volume_preserving_measurableEquiv ι
 
-@[deprecated PiLp.volume_preserving_ofLp (since := "2024-04-27")]
-theorem PiLp.volume_preserving_equiv : MeasurePreserving (WithLp.equiv 2 (ι → ℝ)) :=
-  EuclideanSpace.volume_preserving_measurableEquiv ι
-
 /-- The reverse direction of `PiLp.volume_preserving_measurableEquiv`, since
 `MeasurePreserving.symm` only works for `MeasurableEquiv`s. -/
 theorem PiLp.volume_preserving_toLp : MeasurePreserving (@WithLp.toLp 2 (ι → ℝ)) :=
-  (EuclideanSpace.volume_preserving_measurableEquiv ι).symm
-
-@[deprecated PiLp.volume_preserving_toLp (since := "2024-04-27")]
-theorem PiLp.volume_preserving_equiv_symm : MeasurePreserving (WithLp.equiv 2 (ι → ℝ)).symm :=
   (EuclideanSpace.volume_preserving_measurableEquiv ι).symm
 
 lemma volume_euclideanSpace_eq_dirac [IsEmpty ι] :


### PR DESCRIPTION
This PR removes some 15 month old deprecations. I forget why they weren't removed in previous cycles, but they seem okay to remove now.