### PR TITLE
[Merged by Bors] - feat: `fun y ↦ x / y` as an involutive equivalence in commutative groups

### DIFF
--- a/Mathlib/Algebra/AddTorsor/Basic.lean
+++ b/Mathlib/Algebra/AddTorsor/Basic.lean
@@ -207,8 +207,8 @@ theorem injective_pointReflection_left_of_injective_two_nsmul {G P : Type*} [Add
 @[deprecated (since := "2024-11-18")] alias injective_pointReflection_left_of_injective_bit0 :=
 injective_pointReflection_left_of_injective_two_nsmul
 
-lemma pointReflection_eq_constSub {G : Type*} [AddCommGroup G] (x : G) :
-    pointReflection x = constSub (2 • x) := by
+lemma pointReflection_eq_divLeft {G : Type*} [AddCommGroup G] (x : G) :
+    pointReflection x = Equiv.subLeft (2 • x) := by
   ext; simp [pointReflection, sub_add_eq_add_sub, two_nsmul]
 
 end Equiv

--- a/Mathlib/Algebra/AddTorsor/Basic.lean
+++ b/Mathlib/Algebra/AddTorsor/Basic.lean
@@ -207,4 +207,8 @@ theorem injective_pointReflection_left_of_injective_two_nsmul {G P : Type*} [Add
 @[deprecated (since := "2024-11-18")] alias injective_pointReflection_left_of_injective_bit0 :=
 injective_pointReflection_left_of_injective_two_nsmul
 
+lemma pointReflection_eq_constSub {G : Type*} [AddCommGroup G] (x : G) :
+    pointReflection x = constSub (2 • x) := by
+  ext; simp [pointReflection, sub_add_eq_add_sub, two_nsmul]
+
 end Equiv

--- a/Mathlib/Algebra/AddTorsor/Basic.lean
+++ b/Mathlib/Algebra/AddTorsor/Basic.lean
@@ -207,7 +207,7 @@ theorem injective_pointReflection_left_of_injective_two_nsmul {G P : Type*} [Add
 @[deprecated (since := "2024-11-18")] alias injective_pointReflection_left_of_injective_bit0 :=
 injective_pointReflection_left_of_injective_two_nsmul
 
-lemma pointReflection_eq_divLeft {G : Type*} [AddCommGroup G] (x : G) :
+lemma pointReflection_eq_subLeft {G : Type*} [AddCommGroup G] (x : G) :
     pointReflection x = Equiv.subLeft (2 • x) := by
   ext; simp [pointReflection, sub_add_eq_add_sub, two_nsmul]
 

--- a/Mathlib/Algebra/AddTorsor/Basic.lean
+++ b/Mathlib/Algebra/AddTorsor/Basic.lean
@@ -207,6 +207,8 @@ theorem injective_pointReflection_left_of_injective_two_nsmul {G P : Type*} [Add
 @[deprecated (since := "2024-11-18")] alias injective_pointReflection_left_of_injective_bit0 :=
 injective_pointReflection_left_of_injective_two_nsmul
 
+/-- In the special case of additive commutative groups (as opposed to just additive torsors),
+`Equiv.pointReflection x` coincides with `Equiv.subLeft (2 • x)`. -/
 lemma pointReflection_eq_subLeft {G : Type*} [AddCommGroup G] (x : G) :
     pointReflection x = Equiv.subLeft (2 • x) := by
   ext; simp [pointReflection, sub_add_eq_add_sub, two_nsmul]

--- a/Mathlib/Algebra/Group/Basic.lean
+++ b/Mathlib/Algebra/Group/Basic.lean
@@ -1013,6 +1013,10 @@ theorem inv_mul_eq_inv_mul_iff_mul_eq_mul : b⁻¹ * a = d⁻¹ * c ↔ a * d = 
 theorem div_eq_div_iff_div_eq_div : a / b = c / d ↔ a / c = b / d := by
   rw [div_eq_iff_eq_mul, div_mul_eq_mul_div, div_eq_iff_eq_mul', mul_div_assoc]
 
+@[to_additive (attr := simp)]
+lemma const_div_involutive (a : G) : Function.Involutive (a / ·) :=
+  fun _ ↦ div_div_cancel ..
+
 end CommGroup
 
 section multiplicative

--- a/Mathlib/Algebra/Group/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Group/Equiv/Basic.lean
@@ -184,4 +184,28 @@ theorem inv_symm : (Equiv.inv G).symm = Equiv.inv G := rfl
 
 end InvolutiveInv
 
+section CommGroup
+
+variable [CommGroup G] (x : G)
+
+/-- The involution in a commutative group given by `fun y ↦ x / y` where `x` is fixed. -/
+@[to_additive (attr := simps)
+"The involution in an additive commutative group given by `fun y ↦ x - y` where `x` is fixed."]
+def constDiv : Perm G where
+  toFun := (x / ·)
+  invFun := (x / ·)
+  left_inv := div_div_self' _
+  right_inv := div_div_self' _
+
+@[to_additive (attr := simp)]
+lemma symm_constDiv : (constDiv x).symm = constDiv x := rfl
+
+@[to_additive (attr := simp)]
+lemma constDiv_involutive : Function.Involutive (constDiv x) := (constDiv x).left_inv
+
+@[to_additive (attr := simp)]
+lemma const_div_involutive : Function.Involutive (x / ·) := constDiv_involutive x
+
+end CommGroup
+
 end Equiv

--- a/Mathlib/Algebra/Group/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Group/Equiv/Basic.lean
@@ -184,28 +184,4 @@ theorem inv_symm : (Equiv.inv G).symm = Equiv.inv G := rfl
 
 end InvolutiveInv
 
-section CommGroup
-
-variable [CommGroup G] (x : G)
-
-/-- The involution in a commutative group given by `fun y ↦ x / y` where `x` is fixed. -/
-@[to_additive (attr := simps)
-"The involution in an additive commutative group given by `fun y ↦ x - y` where `x` is fixed."]
-def constDiv : Perm G where
-  toFun := (x / ·)
-  invFun := (x / ·)
-  left_inv := div_div_self' _
-  right_inv := div_div_self' _
-
-@[to_additive (attr := simp)]
-lemma symm_constDiv : (constDiv x).symm = constDiv x := rfl
-
-@[to_additive (attr := simp)]
-lemma constDiv_involutive : Function.Involutive (constDiv x) := (constDiv x).left_inv
-
-@[to_additive (attr := simp)]
-lemma const_div_involutive : Function.Involutive (x / ·) := constDiv_involutive x
-
-end CommGroup
-
 end Equiv

--- a/Mathlib/Algebra/Group/Units/Equiv.lean
+++ b/Mathlib/Algebra/Group/Units/Equiv.lean
@@ -159,6 +159,24 @@ theorem divRight_eq_mulRight_inv (a : G) : Equiv.divRight a = Equiv.mulRight a�
 
 end Group
 
+section CommGroup
+
+variable [CommGroup G]
+
+@[to_additive]
+lemma symm_divLeft (a : G) : (Equiv.divLeft a).symm = Equiv.divLeft a :=
+  ext fun _ ↦ inv_mul_eq_div _ _
+
+@[to_additive (attr := simp)]
+lemma divLeft_involutive (a : G) : Function.Involutive (Equiv.divLeft a) :=
+  fun _ ↦ div_div_cancel ..
+
+@[to_additive (attr := simp)]
+lemma const_div_involutive (a : G) : Function.Involutive (a / ·) :=
+  divLeft_involutive a
+
+end CommGroup
+
 end Equiv
 
 variable (α) in

--- a/Mathlib/Algebra/Group/Units/Equiv.lean
+++ b/Mathlib/Algebra/Group/Units/Equiv.lean
@@ -171,10 +171,6 @@ lemma symm_divLeft (a : G) : (Equiv.divLeft a).symm = Equiv.divLeft a :=
 lemma divLeft_involutive (a : G) : Function.Involutive (Equiv.divLeft a) :=
   fun _ ↦ div_div_cancel ..
 
-@[to_additive (attr := simp)]
-lemma const_div_involutive (a : G) : Function.Involutive (a / ·) :=
-  divLeft_involutive a
-
 end CommGroup
 
 end Equiv


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
