### PR TITLE
[Merged by Bors] - feat: `erw?` supports all arguments that `erw` does

### DIFF
--- a/MathlibTest/ErwQuestion.lean
+++ b/MathlibTest/ErwQuestion.lean
@@ -1,5 +1,7 @@
 import Mathlib.Tactic.ErwQuestion
 
+section Single
+
 def f (x : Nat) := x + 1
 def a := 37
 theorem f_a : f a = 38 := rfl
@@ -80,3 +82,98 @@ are not defeq.
 -/
 #guard_msgs in
 example : f b = 38 := by erw? [f_a]
+
+end Single
+
+section Sequence
+
+def c := 38
+theorem f_c : f c = 39 := rfl
+
+/--
+info: Debugging `erw?`
+---
+info: ❌️ at reducible transparency,
+  b
+and
+  a
+are not defeq, but they are at default transparency.
+---
+info: ❌️ at reducible transparency,
+  f 38
+and
+  f c
+are not defeq, but they are at default transparency.
+-/
+#guard_msgs in
+example : f (f b) = 39 := by erw? [f_a, f_c]
+
+end Sequence
+
+section Location
+
+/--
+info: Debugging `erw?`
+---
+info: ❌️ at reducible transparency,
+  b
+and
+  a
+are not defeq, but they are at default transparency.
+-/
+#guard_msgs in
+example (h : f b = c) : c = 38 := by
+  erw? [f_a] at h
+  exact h.symm
+
+set_option tactic.erw?.verbose true in
+/--
+info: Debugging `erw?`
+---
+info: ❌️ at reducible transparency,
+  b
+and
+  a
+are not defeq, but they are at default transparency.
+---
+info: Expression appearing in h:
+  f b = c
+
+Expression from `erw`: f a = c
+
+❌️ at reducible transparency,
+  f b = c
+and
+  f a = c
+are not defeq.
+
+✅️ at reducible transparency,
+  c
+and
+  c
+are defeq.
+
+❌️ at reducible transparency,
+  Eq (f b)
+and
+  Eq (f a)
+are not defeq.
+
+❌️ at reducible transparency,
+  f b
+and
+  f a
+are not defeq.
+
+❌️ at reducible transparency,
+  b
+and
+  a
+are not defeq.
+-/
+#guard_msgs in
+example (h : f b = c) : c = 38 := by
+  erw? [f_a] at h
+  exact h.symm
+
+end Location


### PR DESCRIPTION
This PR teaches `erw?` how to deal with multiple arguments and how to rewrite at a hypothesis, so that it can be used everywhere that `erw` can. (And ideally `erw` can then be removed from those places.)

In addition to the new tests, I picked a few places in the library to run as test cases with more complicated terms (but `extract_goals` didn't really work there...)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
