### PR TITLE
[Merged by Bors] - feat: `finCycle` as iterated `finRotate`

### DIFF
--- a/Mathlib/Logic/Equiv/Fin/Rotate.lean
+++ b/Mathlib/Logic/Equiv/Fin/Rotate.lean
@@ -1,16 +1,18 @@
 /-
 Copyright (c) 2025 Paul Lezeau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Paul Lezeau, Lawrence Wu
+Authors: Paul Lezeau, Lawrence Wu, Jeremy Tan
 -/
 import Mathlib.Algebra.Group.Fin.Basic
 import Mathlib.Logic.Equiv.Fin.Basic
 
-/-! # Maximum order cyclic permutations on `Fin n`
+/-!
+# Cyclic permutations on `Fin n`
 
-This file defines `finRotate`, which corresponds to the cycle `(1, ..., n)` on `Fin n`, and proves
-various lemmas about it.
-
+This file defines
+* `finRotate`, which corresponds to the cycle `(1, ..., n)` on `Fin n`
+* `finCycle`, the permutation that adds a fixed number to each element of `Fin n`
+and proves various lemmas about them.
 -/
 
 open Nat
@@ -108,3 +110,22 @@ theorem finRotate_symm_lt_iff_ne_zero [NeZero n] (i : Fin n) :
   · simp only [hc, Fin.not_lt_zero] at hi
   · rw [Fin.lt_iff_val_lt_val, coe_finRotate_symm_of_ne_zero hi]
     apply sub_lt (zero_lt_of_ne_zero <| Fin.val_ne_zero_iff.mpr hi) Nat.zero_lt_one
+
+/-- The permutation on `Fin n` that adds `k` to each number. -/
+@[simps]
+def finCycle (k : Fin n) : Equiv.Perm (Fin n) where
+  toFun i := i + k
+  invFun i := i - k
+  left_inv i := by haveI := NeZero.of_pos k.pos; simp
+  right_inv i := by haveI := NeZero.of_pos k.pos; simp
+
+lemma finCycle_eq_finRotate_iterate {k : Fin n} : finCycle k = (finRotate n)^[k.1] := by
+  match n with
+  | 0 => exact k.elim0
+  | n + 1 =>
+    ext i; induction k using Fin.induction with
+    | zero => simp
+    | succ k ih =>
+      rw [Fin.val_eq_val, Fin.coe_castSucc] at ih
+      rw [Fin.val_succ, Function.iterate_succ', Function.comp_apply, ← ih, finRotate_succ_apply,
+        finCycle_apply, finCycle_apply, add_assoc, Fin.coeSucc_eq_succ]


### PR DESCRIPTION
Originally used in #25786, but eventually discovered to be unnecessary.