### PR TITLE
[Merged by Bors] - feat(GroupTheory/Finiteness): `AddMonoid.FG ℕ` and `AddGroup.FG ℤ`

### DIFF
--- a/Mathlib/GroupTheory/Finiteness.lean
+++ b/Mathlib/GroupTheory/Finiteness.lean
@@ -350,12 +350,20 @@ instance instMonoidFG [FG M] [FG N] : FG (M × N) where
 
 end Prod
 
-instance AddMonoid.FG.nat : FG ℕ := by
+namespace AddMonoid
+
+instance : FG ℕ := by
   rw [fg_iff, ← Nat.addSubmonoid_closure_one]
   exact ⟨{1}, rfl, by simp⟩
 
-instance AddGroup.FG.int : FG ℤ := by
+end AddMonoid
+
+namespace AddGroup
+
+instance : FG ℤ := by
   rw [fg_iff]
   refine ⟨{1}, ?_, by simp⟩
   ext x
   simp [AddSubgroup.mem_closure_singleton]
+
+end AddGroup

--- a/Mathlib/GroupTheory/Finiteness.lean
+++ b/Mathlib/GroupTheory/Finiteness.lean
@@ -349,3 +349,13 @@ instance instMonoidFG [FG M] [FG N] : FG (M × N) where
   fg_top := by rw [← Submonoid.top_prod_top]; exact .prod ‹FG M›.fg_top ‹FG N›.fg_top
 
 end Prod
+
+instance AddMonoid.FG.nat : FG ℕ := by
+  rw [fg_iff, ← Nat.addSubmonoid_closure_one]
+  exact ⟨{1}, rfl, by simp⟩
+
+instance AddGroup.FG.int : FG ℤ := by
+  rw [fg_iff]
+  refine ⟨{1}, ?_, by simp⟩
+  ext x
+  simp [AddSubgroup.mem_closure_singleton]


### PR DESCRIPTION
Note: [`Module.Finite.self`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/RingTheory/Finiteness/Basic.html#Module.Finite.self) gives equivalent results as `Module.Finite ℕ ℕ` and `Module.Finite ℤ ℤ`. But there is no instance from `Module.Finite` to `AddMonoid.FG` (there is one converse, [AddMonoid.FG.to_moduleFinite_nat](https://leanprover-community.github.io/mathlib4_docs/Mathlib/RingTheory/Finiteness/Defs.html#AddMonoid.FG.to_moduleFinite_nat)).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
