### PR TITLE
feat(Subsemiring): mk_eq_zero

### DIFF
--- a/Mathlib/Algebra/Ring/Subsemiring/Defs.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/Defs.lean
@@ -193,6 +193,10 @@ theorem mem_mk {toSubmonoid : Submonoid R} (add_mem zero_mem) {x : R} :
 theorem coe_set_mk {toSubmonoid : Submonoid R} (add_mem zero_mem) :
     (mk toSubmonoid add_mem zero_mem : Set R) = toSubmonoid := rfl
 
+@[simp]
+theorem mk_eq_zero {S : Subsemiring R} (r : R) (hr : r ∈ S) :
+    (⟨r, hr⟩ : S) = 0 ↔ r = 0 := Subtype.ext_iff
+
 /-- Two subsemirings are equal if they have the same elements. -/
 @[ext]
 theorem ext {S T : Subsemiring R} (h : ∀ x, x ∈ S ↔ x ∈ T) : S = T :=


### PR DESCRIPTION
Add a `mk_eq_zero` lemma for `Subsemiring`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
