### PR TITLE
[Merged by Bors] - feat(Algebra/Adjoin): singleton as aeval

### DIFF
--- a/Mathlib/RingTheory/Adjoin/Polynomial.lean
+++ b/Mathlib/RingTheory/Adjoin/Polynomial.lean
@@ -28,29 +28,50 @@ variable {R : Type u} {S : Type v} {T : Type w} {A : Type z} {A' B : Type*} {a b
 
 section aeval
 
+open Algebra
+
 variable [CommSemiring R] [Semiring A] [CommSemiring A'] [Semiring B]
 variable [Algebra R A] [Algebra R B]
 variable {p q : R[X]} (x : A)
 
 @[simp]
-theorem adjoin_X : Algebra.adjoin R ({X} : Set R[X]) = ⊤ := by
+theorem adjoin_X : adjoin R ({X} : Set R[X]) = ⊤ := by
   refine top_unique fun p _hp => ?_
-  set S := Algebra.adjoin R ({X} : Set R[X])
+  set S := adjoin R ({X} : Set R[X])
   rw [← sum_monomial_eq p]; simp only [← smul_X_eq_monomial]
-  exact S.sum_mem fun n _hn => S.smul_mem (S.pow_mem (Algebra.subset_adjoin rfl) _) _
+  exact S.sum_mem fun n _hn => S.smul_mem (S.pow_mem (subset_adjoin rfl) _) _
 
 variable (R)
 theorem _root_.Algebra.adjoin_singleton_eq_range_aeval (x : A) :
-    Algebra.adjoin R {x} = (Polynomial.aeval x).range := by
+    adjoin R {x} = (aeval x).range := by
   rw [← Algebra.map_top, ← adjoin_X, AlgHom.map_adjoin, Set.image_singleton, aeval_X]
 
 @[simp]
-theorem aeval_mem_adjoin_singleton :
-    aeval x p ∈ Algebra.adjoin R {x} := by
-  simpa only [Algebra.adjoin_singleton_eq_range_aeval] using Set.mem_range_self p
+theorem aeval_mem_adjoin_singleton : aeval x p ∈ adjoin R {x} := by
+  simpa only [adjoin_singleton_eq_range_aeval] using Set.mem_range_self p
+
+theorem _root_.Algebra.adjoin_mem_exists_aeval {a : A} (h : a ∈ Algebra.adjoin R {x}) :
+    ∃ p : R[X], aeval x p = a := by
+  rw [Algebra.adjoin_singleton_eq_range_aeval] at h
+  simp_all
+
+theorem _root_.Algebra.adjoin_eq_exists_aeval (a : Algebra.adjoin R {x}) :
+    ∃ p : R[X], aeval x p = a := by
+  have : (a : A) ∈ Algebra.adjoin R {x} := by simp
+  set y := (a : A) with h
+  rw [Algebra.adjoin_singleton_eq_range_aeval] at this
+  simp_all
+
+@[elab_as_elim]
+theorem _root_.Algebra.adjoin_singleton_induction {M : (adjoin R {x}) → Prop}
+    (a : adjoin R {x}) (f : ∀ (p : Polynomial R),
+    M (⟨aeval x p, aeval_mem_adjoin_singleton R x⟩ : adjoin R {x})) :
+    M a := by
+  obtain ⟨p, hp⟩ := Algebra.adjoin_eq_exists_aeval _ x a
+  aesop
 
 instance instCommSemiringAdjoinSingleton :
-    CommSemiring <| Algebra.adjoin R {x} :=
+    CommSemiring <| adjoin R {x} :=
   { mul_comm := fun ⟨p, hp⟩ ⟨q, hq⟩ ↦ by
       obtain ⟨p', rfl⟩ := Algebra.adjoin_singleton_eq_range_aeval R x ▸ hp
       obtain ⟨q', rfl⟩ := Algebra.adjoin_singleton_eq_range_aeval R x ▸ hq

--- a/Mathlib/RingTheory/Adjoin/Polynomial.lean
+++ b/Mathlib/RingTheory/Adjoin/Polynomial.lean
@@ -48,7 +48,7 @@ theorem _root_.Algebra.adjoin_singleton_eq_range_aeval (x : A) :
 
 @[simp]
 theorem aeval_mem_adjoin_singleton : aeval x p ∈ adjoin R {x} := by
-  simpa only [adjoin_singleton_eq_range_aeval] using Set.mem_range_self p
+  simp [adjoin_singleton_eq_range_aeval]
 
 theorem _root_.Algebra.adjoin_mem_exists_aeval {a : A} (h : a ∈ Algebra.adjoin R {x}) :
     ∃ p : R[X], aeval x p = a := by


### PR DESCRIPTION
For `x : A`, elements of `Algebra.adjoin R {x}` can be represented as a polynomial of `R` evaluated at the point `x`.
This PR introduces three (3) theorems related to this:
- `adjoin_mem_exists_aeval` rewrite an element of `A` in `adjoin R {x}` as the `aeval` of some polynomial.
- `adjoin_eq_exists_aeval` rewrite an element `adjoin R {x}` as the `aeval` of some polynomial.
- `adjoin_singleton_induction`: an induction principle reducing problems over `adjoin R {x}` to problems of the form `M (⟨aeval x p, aeval_mem_adjoin_singleton R x⟩ : adjoin R {x})`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
