### PR TITLE
[Merged by Bors] - chore(SetTheory/ZFC): scope sUnion notation

### DIFF
--- a/Mathlib/SetTheory/ZFC/Basic.lean
+++ b/Mathlib/SetTheory/ZFC/Basic.lean
@@ -470,14 +470,14 @@ def sUnion : ZFSet → ZFSet :=
           fun b hb => ⟨b, PSet.Equiv.symm hb⟩⟩
 
 @[inherit_doc]
-prefix:110 "⋃₀ " => ZFSet.sUnion
+scoped prefix:110 "⋃₀ " => ZFSet.sUnion
 
 /-- The intersection operator, the collection of elements in all of the elements of a ZFC set. We
 define `⋂₀ ∅ = ∅`. -/
 def sInter (x : ZFSet) : ZFSet := (⋃₀ x).sep (fun y => ∀ z ∈ x, y ∈ z)
 
 @[inherit_doc]
-prefix:110 "⋂₀ " => ZFSet.sInter
+scoped prefix:110 "⋂₀ " => ZFSet.sInter
 
 @[simp]
 theorem mem_sUnion {x y : ZFSet.{u}} : y ∈ ⋃₀ x ↔ ∃ z ∈ x, y ∈ z :=

--- a/Mathlib/SetTheory/ZFC/Basic.lean
+++ b/Mathlib/SetTheory/ZFC/Basic.lean
@@ -460,7 +460,9 @@ theorem sUnion_lem {α β : Type u} (A : α → PSet) (B : β → PSet) (αβ : 
     match A a, B b, ea, eb, c, d, hd with
     | _, _, rfl, rfl, _, _, hd => exact hd
 
-/-- The union operator, the collection of elements of elements of a ZFC set -/
+/-- The union operator, the collection of elements of elements of a ZFC set. Uses `⋃₀` notation,
+scoped under the `ZFSet` namespace.
+-/
 def sUnion : ZFSet → ZFSet :=
   Quotient.map PSet.sUnion
     fun ⟨_, A⟩ ⟨_, B⟩ ⟨αβ, βα⟩ =>
@@ -473,7 +475,7 @@ def sUnion : ZFSet → ZFSet :=
 scoped prefix:110 "⋃₀ " => ZFSet.sUnion
 
 /-- The intersection operator, the collection of elements in all of the elements of a ZFC set. We
-define `⋂₀ ∅ = ∅`. -/
+define `⋂₀ ∅ = ∅`. Uses `⋂₀` notation, scoped under the `ZFSet` namespace. -/
 def sInter (x : ZFSet) : ZFSet := (⋃₀ x).sep (fun y => ∀ z ∈ x, y ∈ z)
 
 @[inherit_doc]

--- a/Mathlib/SetTheory/ZFC/Class.lean
+++ b/Mathlib/SetTheory/ZFC/Class.lean
@@ -148,14 +148,16 @@ theorem classToCong_empty : classToCong ∅ = ∅ := by
 def powerset (x : Class) : Class :=
   congToClass (Set.powerset x)
 
-/-- The union of a class is the class of all members of ZFC sets in the class -/
+/-- The union of a class is the class of all members of ZFC sets in the class. Uses `⋃₀` notation,
+scoped under the `Class` namespace. -/
 def sUnion (x : Class) : Class :=
   ⋃₀ classToCong x
 
 @[inherit_doc]
 scoped prefix:110 "⋃₀ " => Class.sUnion
 
-/-- The intersection of a class is the class of all members of ZFC sets in the class -/
+/-- The intersection of a class is the class of all members of ZFC sets in the class .
+Uses `⋂₀` notation, scoped under the `Class` namespace. -/
 def sInter (x : Class) : Class :=
   ⋂₀ classToCong x
 

--- a/Mathlib/SetTheory/ZFC/Class.lean
+++ b/Mathlib/SetTheory/ZFC/Class.lean
@@ -153,14 +153,14 @@ def sUnion (x : Class) : Class :=
   ⋃₀ classToCong x
 
 @[inherit_doc]
-prefix:110 "⋃₀ " => Class.sUnion
+scoped prefix:110 "⋃₀ " => Class.sUnion
 
 /-- The intersection of a class is the class of all members of ZFC sets in the class -/
 def sInter (x : Class) : Class :=
   ⋂₀ classToCong x
 
 @[inherit_doc]
-prefix:110 "⋂₀ " => Class.sInter
+scoped prefix:110 "⋂₀ " => Class.sInter
 
 theorem ofSet.inj {x y : ZFSet.{u}} (h : (x : Class.{u}) = y) : x = y :=
   ZFSet.ext fun z => by
@@ -223,6 +223,7 @@ theorem sUnion_apply {x : Class} {y : ZFSet} : (⋃₀ x) y ↔ ∃ z : ZFSet, x
     exact ⟨z, hxz, hyz⟩
   · exact fun ⟨z, hxz, hyz⟩ => ⟨_, coe_mem.2 hxz, hyz⟩
 
+open scoped ZFSet in
 @[simp, norm_cast]
 theorem coe_sUnion (x : ZFSet.{u}) : ↑(⋃₀ x : ZFSet) = ⋃₀ (x : Class.{u}) :=
   ext fun y =>
@@ -241,6 +242,7 @@ theorem sInter_apply {x : Class.{u}} {y : ZFSet.{u}} : (⋂₀ x) y ↔ ∀ z : 
   rintro H - ⟨z, rfl, hxz⟩
   exact H _ hxz
 
+open scoped ZFSet in
 @[simp, norm_cast]
 theorem coe_sInter {x : ZFSet.{u}} (h : x.Nonempty) : ↑(⋂₀ x : ZFSet) = ⋂₀ (x : Class.{u}) :=
   Set.ext fun _ => (ZFSet.mem_sInter h).trans sInter_apply.symm


### PR DESCRIPTION
it causes elaboration clash with regular Set notation when type is unspecified

zulip thread:
https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Unscoped.20.60.E2.8B.83.E2.82.80.60.20and.20.60.E2.8B.82.E2.82.80.60


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
