### PR TITLE
[Merged by Bors] - feat(Analysis/InnerProductSpace/Adjoint): some API for `innerSL`

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
@@ -248,6 +248,22 @@ theorem isAdjointPair_inner (A : E →L[𝕜] F) :
   intro x y
   simp only [sesqFormOfInner_apply_apply, adjoint_inner_left]
 
+theorem adjoint_innerSL_apply (x : E) :
+    adjoint (innerSL 𝕜 x) = (lsmul 𝕜 𝕜).flip x := by
+  ext
+  apply ext_inner_left 𝕜
+  intro y
+  simp [adjoint_inner_right]
+
+theorem innerSL_apply_comp (x : F) (f : E →L[𝕜] F) :
+    innerSL 𝕜 x ∘L f = innerSL 𝕜 (adjoint f x) := by
+  ext; simp [adjoint_inner_left]
+
+omit [CompleteSpace E] in
+theorem innerSL_apply_comp_of_isSymmetric (x : E) {f : E →L[𝕜] E} (hf : f.IsSymmetric) :
+    innerSL 𝕜 x ∘L f = innerSL 𝕜 (f x) := by
+  ext; simp [hf]
+
 end ContinuousLinearMap
 
 /-! ### Self-adjoint operators -/

--- a/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
@@ -250,10 +250,7 @@ theorem isAdjointPair_inner (A : E →L[𝕜] F) :
 
 theorem adjoint_innerSL_apply (x : E) :
     adjoint (innerSL 𝕜 x) = (lsmul 𝕜 𝕜).flip x := by
-  ext
-  apply ext_inner_left 𝕜
-  intro y
-  simp [adjoint_inner_right]
+  ext; exact ext_inner_left 𝕜 (fun _ => by simp [adjoint_inner_right])
 
 theorem innerSL_apply_comp (x : F) (f : E →L[𝕜] F) :
     innerSL 𝕜 x ∘L f = innerSL 𝕜 (adjoint f x) := by

--- a/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
@@ -249,8 +249,8 @@ theorem isAdjointPair_inner (A : E →L[𝕜] F) :
   simp only [sesqFormOfInner_apply_apply, adjoint_inner_left]
 
 theorem adjoint_innerSL_apply (x : E) :
-    adjoint (innerSL 𝕜 x) = (lsmul 𝕜 𝕜).flip x := by
-  ext; exact ext_inner_left 𝕜 (fun _ => by simp [adjoint_inner_right])
+    adjoint (innerSL 𝕜 x) = (lsmul 𝕜 𝕜).flip x :=
+  ext_ring <| ext_inner_left 𝕜 <| fun _ => by simp [adjoint_inner_right]
 
 theorem innerSL_apply_comp (x : F) (f : E →L[𝕜] F) :
     innerSL 𝕜 x ∘L f = innerSL 𝕜 (adjoint f x) := by

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm/Mul.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm/Mul.lean
@@ -191,6 +191,12 @@ def lsmul : R →L[𝕜] E →L[𝕜] E :=
 theorem lsmul_apply (c : R) (x : E) : lsmul 𝕜 R c x = c • x :=
   rfl
 
+variable {𝕜} in
+theorem comp_lsmul_flip_apply {F : Type*} [SeminormedAddCommGroup F] [NormedSpace 𝕜 F]
+    (f : E →L[𝕜] F) (x : E) :
+    f ∘L (lsmul 𝕜 𝕜).flip x = (lsmul 𝕜 𝕜).flip (f x) := by
+  ext; simp
+
 variable {R}
 
 theorem norm_toSpanSingleton (x : E) : ‖toSpanSingleton 𝕜 x‖ = ‖x‖ := by


### PR DESCRIPTION
In [bra-ket notation](https://en.wikipedia.org/wiki/Bra–ket_notation), these are:
- $\langle x|^\dagger=|x\rangle$,
- $f\circ|x\rangle=|f(x)\rangle$,
- $\langle x|\circ f=\langle f^\dagger(x)|$,

where $\langle x|$ is `innerSL _ x`, and $|x\rangle$ is `(lsmul _ _).flip x`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
