### PR TITLE
[Merged by Bors] - feat(Order): add Teichmüller-Tukey lemma

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5026,6 +5026,7 @@ import Mathlib.Order.SupClosed
 import Mathlib.Order.SupIndep
 import Mathlib.Order.SymmDiff
 import Mathlib.Order.Synonym
+import Mathlib.Order.TeichmullerTukey
 import Mathlib.Order.TransfiniteIteration
 import Mathlib.Order.TypeTags
 import Mathlib.Order.ULift

--- a/Mathlib/Data/Set/Finite/Lattice.lean
+++ b/Mathlib/Data/Set/Finite/Lattice.lean
@@ -463,4 +463,11 @@ theorem DirectedOn.exists_mem_subset_of_finset_subset_biUnion {α ι : Type*} {f
   haveI := hn.coe_sort
   simpa using (directed_comp.2 hc.directed_val).exists_mem_subset_of_finset_subset_biUnion hs
 
+theorem DirectedOn.exists_mem_subset_of_finite_of_subset_sUnion {α : Type*} {c : Set (Set α)}
+    (hn : c.Nonempty) (hc : DirectedOn (· ⊆ ·) c) {s : Set α} (hs : s.Finite)
+    (hsc : s ⊆ sUnion c) : ∃ t ∈ c, s ⊆ t := by
+  rw [← hs.coe_toFinset, sUnion_eq_biUnion] at hsc
+  have := DirectedOn.exists_mem_subset_of_finset_subset_biUnion hn hc hsc
+  exact hs.coe_toFinset ▸ this
+
 end LinearOrder

--- a/Mathlib/Order/TeichmullerTukey.lean
+++ b/Mathlib/Order/TeichmullerTukey.lean
@@ -41,7 +41,9 @@ lemma exists_subset_of_finite_of_subset_sUnion_of_isChain_of_nonempty {c : Set (
     ∃ t ∈ c, s ⊆ t := by
   rcases eq_empty_or_nonempty s with rfl | sne
   · exact cne.imp fun t tc ↦ ⟨tc, empty_subset t⟩
-  · choose f hf using fun (x : s) ↦ sc x.2
+  · /- For every element of the finite subset, choose an element of the chain containing it and take
+    the maximum among them. -/
+    choose f hf using fun (x : s) ↦ sc x.2
     obtain ⟨_, ⟨y, rfl⟩, max⟩ := exists_maximal (@finite_range _ _ f sfin)
       (@range_nonempty _ _ sne.coe_sort f)
     refine ⟨f y, (forall_and.mp hf).left y, fun x xs ↦ ?_⟩
@@ -52,8 +54,11 @@ lemma exists_subset_of_finite_of_subset_sUnion_of_isChain_of_nonempty {c : Set (
 /-- **Teichmuller-Tukey lemma**. Every nonempty family of finite character has a maximal element. -/
 theorem exists_maximal_of_isOfFiniteCharacter {F} (hF : IsOfFiniteCharacter F) {x : Set α}
     (xF : x ∈ F) : ∃ m, x ⊆ m ∧ Maximal (· ∈ F) m := by
+  /- Apply Zorn's lemma. Take the union of the elements of a chain is its upper bound. -/
   refine zorn_subset_nonempty F (fun c cF cch cne ↦
     ⟨sUnion c, ?_, fun s sc ↦ subset_sUnion_of_mem sc⟩) x xF
+  /- Prove that the union belongs to F. Use the finite character property and the fact that any
+  finite subset of the union is also a subset of some element of the chain. -/
   refine (hF (sUnion c)).mpr (fun s sc sfin ↦ ?_)
   obtain ⟨t, tc, st⟩ :=
     exists_subset_of_finite_of_subset_sUnion_of_isChain_of_nonempty cne cch sc sfin

--- a/Mathlib/Order/TeichmullerTukey.lean
+++ b/Mathlib/Order/TeichmullerTukey.lean
@@ -51,14 +51,15 @@ subset of $X$ is in $F$ -/
 def IsOfFiniteCharacter := ∀ x, x ∈ F ↔ ∀ y ⊆ x, y.Finite → y ∈ F
 
 /-- **Teichmuller-Tukey lemma**. Every nonempty family of finite character has a maximal element. -/
-theorem exists_maximal_of_isOfFiniteCharacter {F} (hF : IsOfFiniteCharacter F) {x : Set α}
+theorem IsOfFiniteCharacter.exists_maximal {F} (hF : IsOfFiniteCharacter F) {x : Set α}
     (xF : x ∈ F) : ∃ m, x ⊆ m ∧ Maximal (· ∈ F) m := by
   /- Apply Zorn's lemma. Take the union of the elements of a chain as its upper bound. -/
   refine zorn_subset_nonempty F (fun c cF cch cne ↦
     ⟨sUnion c, ?_, fun s sc ↦ subset_sUnion_of_mem sc⟩) x xF
-  /- Prove that the union belongs to F. Use the finite character property and the fact that any
-  finite subset of the union is also a subset of some element of the chain. -/
-  refine (hF (sUnion c)).mpr (fun s sc sfin ↦ ?_)
+  /- Prove that the union belongs to `F`. -/
+  refine (hF (sUnion c)).mpr fun s sc sfin ↦ ?_
+  /- Use the finite character property and the fact that any finite subset of the union is also a
+  subset of some element of the chain. -/
   obtain ⟨t, tc, st⟩ := cch.exists_mem_subset_of_finite_of_subset_sUnion cne sc sfin
   exact (hF t).mp (cF tc) s st sfin
 

--- a/Mathlib/Order/TeichmullerTukey.lean
+++ b/Mathlib/Order/TeichmullerTukey.lean
@@ -32,18 +32,6 @@ open Set Finite
 
 variable {α : Type*} (F : Set (Set α))
 
-lemma DirectedOn.exists_mem_subset_of_finite_of_subset_sUnion {c : Set (Set α)}
-    (cne : c.Nonempty) (cdir : DirectedOn (· ⊆ ·) c) {s : Set α} (sc : s ⊆ sUnion c)
-    (sfin : s.Finite) : ∃ t ∈ c, s ⊆ t := by
-  rw [← sfin.coe_toFinset, sUnion_eq_biUnion] at sc
-  have := DirectedOn.exists_mem_subset_of_finset_subset_biUnion cne cdir sc
-  exact sfin.coe_toFinset ▸ this
-
-lemma IsChain.exists_mem_subset_of_finite_of_subset_sUnion {c : Set (Set α)}
-    (cne : c.Nonempty) (cch : IsChain (· ⊆ ·) c) {s : Set α} (sc : s ⊆ sUnion c) (sfin : s.Finite) :
-    ∃ t ∈ c, s ⊆ t := DirectedOn.exists_mem_subset_of_finite_of_subset_sUnion
-      cne cch.directedOn sc sfin
-
 namespace Order
 
 /-- A family of sets $F$ is of finite character iff for every set $X$, $X ∈ F$ iff every finite
@@ -60,7 +48,7 @@ theorem IsOfFiniteCharacter.exists_maximal {F} (hF : IsOfFiniteCharacter F) {x :
   refine (hF (sUnion c)).mpr fun s sc sfin ↦ ?_
   /- Use the finite character property and the fact that any finite subset of the union is also a
   subset of some element of the chain. -/
-  obtain ⟨t, tc, st⟩ := cch.exists_mem_subset_of_finite_of_subset_sUnion cne sc sfin
+  obtain ⟨t, tc, st⟩ := cch.directedOn.exists_mem_subset_of_finite_of_subset_sUnion cne sfin sc
   exact (hF t).mp (cF tc) s st sfin
 
 end Order

--- a/Mathlib/Order/TeichmullerTukey.lean
+++ b/Mathlib/Order/TeichmullerTukey.lean
@@ -20,7 +20,7 @@ Teichmuller-Tukey lemma.
 
 ## Main results
 
-- `exists_maximal_of_isOfFiniteCharacter` : Teichmuller-Tukey lemma, saying that every nonempty
+- `IsOfFiniteCharacter.exists_maximal` : Teichmuller-Tukey lemma, saying that every nonempty
   family of finite character has a maximal element.
 
 ## References

--- a/Mathlib/Order/TeichmullerTukey.lean
+++ b/Mathlib/Order/TeichmullerTukey.lean
@@ -54,7 +54,7 @@ lemma exists_subset_of_finite_of_subset_sUnion_of_isChain_of_nonempty {c : Set (
 /-- **Teichmuller-Tukey lemma**. Every nonempty family of finite character has a maximal element. -/
 theorem exists_maximal_of_isOfFiniteCharacter {F} (hF : IsOfFiniteCharacter F) {x : Set α}
     (xF : x ∈ F) : ∃ m, x ⊆ m ∧ Maximal (· ∈ F) m := by
-  /- Apply Zorn's lemma. Take the union of the elements of a chain is its upper bound. -/
+  /- Apply Zorn's lemma. Take the union of the elements of a chain as its upper bound. -/
   refine zorn_subset_nonempty F (fun c cF cch cne ↦
     ⟨sUnion c, ?_, fun s sc ↦ subset_sUnion_of_mem sc⟩) x xF
   /- Prove that the union belongs to F. Use the finite character property and the fact that any

--- a/Mathlib/Order/TeichmullerTukey.lean
+++ b/Mathlib/Order/TeichmullerTukey.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2025 Ansar Azhdarov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Ansar Azhdarov
+-/
+import Mathlib.Data.Set.Finite.Range
+import Mathlib.Order.Preorder.Finite
+import Mathlib.Order.Zorn
+
+/-!
+# Teichmuller-Tukey
+
+This file defines the notion of being of finite character for a family of sets and proves the
+Teichmuller-Tukey lemma.
+
+## Main definitions
+
+- `IsOfFiniteCharacter` : A family of sets $F$ is of finite character iff for every set $X$,
+  $X ∈ F$ iff every finite subset of $X$ is in $F$.
+
+## Main results
+
+- `exists_maximal_of_isOfFiniteCharacter` : Teichmuller-Tukey lemma, saying that every nonempty
+  family of finite character has a maximal element.
+
+## References
+
+- <https://en.wikipedia.org/wiki/Teichm%C3%BCller%E2%80%93Tukey_lemma>
+-/
+
+open Set Finite
+
+variable {α : Type*} (F : Set (Set α))
+
+/-- A family of sets $F$ is of finite character iff for every set $X$, $X ∈ F$ iff every finite
+subset of $X$ is in $F$ -/
+def IsOfFiniteCharacter := ∀ x, x ∈ F ↔ ∀ y ⊆ x, y.Finite → y ∈ F
+
+lemma exists_subset_of_finite_of_subset_sUnion_of_isChain_of_nonempty {c : Set (Set α)}
+    (cne : c.Nonempty) (cch : IsChain (· ⊆ ·) c) {s : Set α} (sc : s ⊆ sUnion c) (sfin : s.Finite) :
+    ∃ t ∈ c, s ⊆ t := by
+  rcases eq_empty_or_nonempty s with rfl | sne
+  · exact cne.imp fun t tc ↦ ⟨tc, empty_subset t⟩
+  · choose f hf using fun (x : s) ↦ sc x.2
+    obtain ⟨_, ⟨y, rfl⟩, max⟩ := exists_maximal (@finite_range _ _ f sfin)
+      (@range_nonempty _ _ sne.coe_sort f)
+    refine ⟨f y, (forall_and.mp hf).left y, fun x xs ↦ ?_⟩
+    rcases (cch.total (hf ⟨x, xs⟩).left (hf y).left) with h | h
+    · exact h (hf ⟨x, xs⟩).right
+    · exact max ⟨⟨x, xs⟩, rfl⟩ h (hf ⟨x, xs⟩).right
+
+/-- **Teichmuller-Tukey lemma**. Every nonempty family of finite character has a maximal element. -/
+theorem exists_maximal_of_isOfFiniteCharacter {F} (hF : IsOfFiniteCharacter F) {x : Set α}
+    (xF : x ∈ F) : ∃ m, x ⊆ m ∧ Maximal (· ∈ F) m := by
+  refine zorn_subset_nonempty F (fun c cF cch cne ↦
+    ⟨sUnion c, ?_, fun s sc ↦ subset_sUnion_of_mem sc⟩) x xF
+  refine (hF (sUnion c)).mpr (fun s sc sfin ↦ ?_)
+  obtain ⟨t, tc, st⟩ :=
+    exists_subset_of_finite_of_subset_sUnion_of_isChain_of_nonempty cne cch sc sfin
+  exact (hF t).mp (cF tc) s st sfin

--- a/Mathlib/Order/TeichmullerTukey.lean
+++ b/Mathlib/Order/TeichmullerTukey.lean
@@ -32,10 +32,6 @@ open Set Finite
 
 variable {α : Type*} (F : Set (Set α))
 
-/-- A family of sets $F$ is of finite character iff for every set $X$, $X ∈ F$ iff every finite
-subset of $X$ is in $F$ -/
-def IsOfFiniteCharacter := ∀ x, x ∈ F ↔ ∀ y ⊆ x, y.Finite → y ∈ F
-
 lemma DirectedOn.exists_mem_subset_of_finite_of_subset_sUnion {c : Set (Set α)}
     (cne : c.Nonempty) (cdir : DirectedOn (· ⊆ ·) c) {s : Set α} (sc : s ⊆ sUnion c)
     (sfin : s.Finite) : ∃ t ∈ c, s ⊆ t := by
@@ -48,6 +44,12 @@ lemma IsChain.exists_mem_subset_of_finite_of_subset_sUnion {c : Set (Set α)}
     ∃ t ∈ c, s ⊆ t := DirectedOn.exists_mem_subset_of_finite_of_subset_sUnion
       cne cch.directedOn sc sfin
 
+namespace Order
+
+/-- A family of sets $F$ is of finite character iff for every set $X$, $X ∈ F$ iff every finite
+subset of $X$ is in $F$ -/
+def IsOfFiniteCharacter := ∀ x, x ∈ F ↔ ∀ y ⊆ x, y.Finite → y ∈ F
+
 /-- **Teichmuller-Tukey lemma**. Every nonempty family of finite character has a maximal element. -/
 theorem exists_maximal_of_isOfFiniteCharacter {F} (hF : IsOfFiniteCharacter F) {x : Set α}
     (xF : x ∈ F) : ∃ m, x ⊆ m ∧ Maximal (· ∈ F) m := by
@@ -59,3 +61,5 @@ theorem exists_maximal_of_isOfFiniteCharacter {F} (hF : IsOfFiniteCharacter F) {
   refine (hF (sUnion c)).mpr (fun s sc sfin ↦ ?_)
   obtain ⟨t, tc, st⟩ := cch.exists_mem_subset_of_finite_of_subset_sUnion cne sc sfin
   exact (hF t).mp (cF tc) s st sfin
+
+end Order


### PR DESCRIPTION
We define the notion of being of finite character for a family of sets and prove the Teichmuller-Tukey lemma.
This contribution was created as part of the Utrecht Summerschool "Formalizing Mathematics in Lean" in July 2025.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
