### PR TITLE
[Merged by Bors] - refactor: group matrix norm instance behind scopes

### DIFF
--- a/Mathlib/Analysis/CStarAlgebra/CStarMatrix.lean
+++ b/Mathlib/Analysis/CStarAlgebra/CStarMatrix.lean
@@ -632,7 +632,7 @@ private noncomputable def normedSpaceAux : NormedSpace ℂ (CStarMatrix m n A) :
 /- In this `Aux` section, we locally activate the following instances: a norm on `CStarMatrix`
 which induces a topology that is not defeq with the matrix one, and the elementwise norm on
 matrices, in order to show that the two topologies are in fact equal -/
-open scoped Matrix.Norms.Elementwise
+open scoped Matrix.ElementwiseNorm
 
 private lemma nnnorm_le_of_forall_inner_le {M : CStarMatrix m n A} {C : ℝ≥0}
     (h : ∀ v w, ‖⟪w, CStarMatrix.toCLM M v⟫_A‖₊ ≤ C * ‖v‖₊ * ‖w‖₊) : ‖M‖₊ ≤ C :=

--- a/Mathlib/Analysis/CStarAlgebra/CStarMatrix.lean
+++ b/Mathlib/Analysis/CStarAlgebra/CStarMatrix.lean
@@ -632,7 +632,7 @@ private noncomputable def normedSpaceAux : NormedSpace ℂ (CStarMatrix m n A) :
 /- In this `Aux` section, we locally activate the following instances: a norm on `CStarMatrix`
 which induces a topology that is not defeq with the matrix one, and the elementwise norm on
 matrices, in order to show that the two topologies are in fact equal -/
-open scoped Matrix.ElementwiseNorm
+open scoped Matrix.Norms.Elementwise
 
 private lemma nnnorm_le_of_forall_inner_le {M : CStarMatrix m n A} {C : ℝ≥0}
     (h : ∀ v w, ‖⟪w, CStarMatrix.toCLM M v⟫_A‖₊ ≤ C * ‖v‖₊ * ‖w‖₊) : ‖M‖₊ ≤ C :=

--- a/Mathlib/Analysis/CStarAlgebra/CStarMatrix.lean
+++ b/Mathlib/Analysis/CStarAlgebra/CStarMatrix.lean
@@ -632,7 +632,7 @@ private noncomputable def normedSpaceAux : NormedSpace ℂ (CStarMatrix m n A) :
 /- In this `Aux` section, we locally activate the following instances: a norm on `CStarMatrix`
 which induces a topology that is not defeq with the matrix one, and the elementwise norm on
 matrices, in order to show that the two topologies are in fact equal -/
-attribute [local instance] normedSpaceAux Matrix.normedAddCommGroup Matrix.normedSpace
+open scoped Matrix.Norms.Elementwise
 
 private lemma nnnorm_le_of_forall_inner_le {M : CStarMatrix m n A} {C : ℝ≥0}
     (h : ∀ v w, ‖⟪w, CStarMatrix.toCLM M v⟫_A‖₊ ≤ C * ‖v‖₊ * ‖w‖₊) : ‖M‖₊ ≤ C :=

--- a/Mathlib/Analysis/CStarAlgebra/Matrix.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Matrix.lean
@@ -75,7 +75,7 @@ theorem entry_norm_bound_of_unitary {U : Matrix n n 𝕜} (hU : U ∈ Matrix.uni
   rw [← sq_le_one_iff₀ (norm_nonneg (U i j)), ← diag_eq_one, re_diag_eq_norm_sum]
   exact norm_sum
 
-open scoped Matrix.Norms.Elementwise in
+open scoped Matrix.ElementwiseNorm in
 /-- The entrywise sup norm of a unitary matrix is at most 1. -/
 theorem entrywise_sup_norm_bound_of_unitary {U : Matrix n n 𝕜} (hU : U ∈ Matrix.unitaryGroup n 𝕜) :
     ‖U‖ ≤ 1 := by

--- a/Mathlib/Analysis/CStarAlgebra/Matrix.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Matrix.lean
@@ -75,7 +75,7 @@ theorem entry_norm_bound_of_unitary {U : Matrix n n 𝕜} (hU : U ∈ Matrix.uni
   rw [← sq_le_one_iff₀ (norm_nonneg (U i j)), ← diag_eq_one, re_diag_eq_norm_sum]
   exact norm_sum
 
-open scoped Matrix.ElementwiseNorm in
+open scoped Matrix.Norms.Elementwise in
 /-- The entrywise sup norm of a unitary matrix is at most 1. -/
 theorem entrywise_sup_norm_bound_of_unitary {U : Matrix n n 𝕜} (hU : U ∈ Matrix.unitaryGroup n 𝕜) :
     ‖U‖ ≤ 1 := by

--- a/Mathlib/Analysis/CStarAlgebra/Matrix.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Matrix.lean
@@ -19,7 +19,7 @@ This transports the operator norm on `EuclideanSpace 𝕜 n →L[𝕜] Euclidean
 
 * `Matrix.instNormedRingL2Op`: the (necessarily unique) normed ring structure on `Matrix n n 𝕜`
   which ensure it is a `CStarRing` in `Matrix.instCStarRing`. This is a scoped instance in the
-  namespace `Matrix.L2OpNorm` in order to avoid choosing a global norm for `Matrix`.
+  namespace `Matrix.Norms.L2Operator` in order to avoid choosing a global norm for `Matrix`.
 
 ## Main statements
 
@@ -162,9 +162,9 @@ def instL2OpMetricSpace : MetricSpace (Matrix m n 𝕜) := by
     rw [← @IsUniformAddGroup.toUniformSpace_eq _ (Matrix.instUniformSpace m n 𝕜) _ _]
     rw [@IsUniformAddGroup.toUniformSpace_eq _ PseudoEMetricSpace.toUniformSpace _ _]
 
-scoped[Matrix.L2OpNorm] attribute [instance] Matrix.instL2OpMetricSpace
+scoped[Matrix.Norms.L2Operator] attribute [instance] Matrix.instL2OpMetricSpace
 
-open scoped Matrix.L2OpNorm
+open scoped Matrix.Norms.L2Operator
 
 /-- The norm structure on `Matrix m n 𝕜` arising from the operator norm given by the identification
 with (continuous) linear maps of `EuclideanSpace`. -/
@@ -172,7 +172,7 @@ def instL2OpNormedAddCommGroup : NormedAddCommGroup (Matrix m n 𝕜) where
   norm := l2OpNormedAddCommGroupAux.norm
   dist_eq := l2OpNormedAddCommGroupAux.dist_eq
 
-scoped[Matrix.L2OpNorm] attribute [instance] Matrix.instL2OpNormedAddCommGroup
+scoped[Matrix.Norms.L2Operator] attribute [instance] Matrix.instL2OpNormedAddCommGroup
 
 lemma l2_opNorm_def (A : Matrix m n 𝕜) :
     ‖A‖ = ‖(toEuclideanLin (𝕜 := 𝕜) (m := m) (n := n)).trans toContinuousLinearMap A‖ := rfl
@@ -225,7 +225,7 @@ def instL2OpNormedSpace : NormedSpace 𝕜 (Matrix m n 𝕜) where
     rw [l2_opNorm_def, LinearEquiv.map_smul]
     exact norm_smul_le r ((toEuclideanLin (𝕜 := 𝕜) (m := m) (n := n)).trans toContinuousLinearMap x)
 
-scoped[Matrix.L2OpNorm] attribute [instance] Matrix.instL2OpNormedSpace
+scoped[Matrix.Norms.L2Operator] attribute [instance] Matrix.instL2OpNormedSpace
 
 /-- The normed ring structure on `Matrix n n 𝕜` arising from the operator norm given by the
 identification with (continuous) linear endmorphisms of `EuclideanSpace 𝕜 n`. -/
@@ -233,7 +233,7 @@ def instL2OpNormedRing : NormedRing (Matrix n n 𝕜) where
   dist_eq := l2OpNormedRingAux.dist_eq
   norm_mul_le := l2OpNormedRingAux.norm_mul_le
 
-scoped[Matrix.L2OpNorm] attribute [instance] Matrix.instL2OpNormedRing
+scoped[Matrix.Norms.L2Operator] attribute [instance] Matrix.instL2OpNormedRing
 
 /-- This is the same as `Matrix.l2_opNorm_def`, but with a more bundled RHS for square matrices. -/
 lemma cstar_norm_def (A : Matrix n n 𝕜) : ‖A‖ = ‖toEuclideanCLM (n := n) (𝕜 := 𝕜) A‖ := rfl
@@ -247,14 +247,14 @@ identification with (continuous) linear endmorphisms of `EuclideanSpace 𝕜 n`.
 def instL2OpNormedAlgebra : NormedAlgebra 𝕜 (Matrix n n 𝕜) where
   norm_smul_le := norm_smul_le
 
-scoped[Matrix.L2OpNorm] attribute [instance] Matrix.instL2OpNormedAlgebra
+scoped[Matrix.Norms.L2Operator] attribute [instance] Matrix.instL2OpNormedAlgebra
 
 /-- The operator norm on `Matrix n n 𝕜` given by the identification with (continuous) linear
 endmorphisms of `EuclideanSpace 𝕜 n` makes it into a `L2OpRing`. -/
 lemma instCStarRing : CStarRing (Matrix n n 𝕜) where
   norm_mul_self_le M := le_of_eq <| Eq.symm <| l2_opNorm_conjTranspose_mul_self M
 
-scoped[Matrix.L2OpNorm] attribute [instance] Matrix.instCStarRing
+scoped[Matrix.Norms.L2Operator] attribute [instance] Matrix.instCStarRing
 
 end Matrix
 

--- a/Mathlib/Analysis/CStarAlgebra/Matrix.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Matrix.lean
@@ -75,8 +75,7 @@ theorem entry_norm_bound_of_unitary {U : Matrix n n 𝕜} (hU : U ∈ Matrix.uni
   rw [← sq_le_one_iff₀ (norm_nonneg (U i j)), ← diag_eq_one, re_diag_eq_norm_sum]
   exact norm_sum
 
-attribute [local instance] Matrix.normedAddCommGroup
-
+open scoped Matrix.Norms.Elementwise in
 /-- The entrywise sup norm of a unitary matrix is at most 1. -/
 theorem entrywise_sup_norm_bound_of_unitary {U : Matrix n n 𝕜} (hU : U ∈ Matrix.unitaryGroup n 𝕜) :
     ‖U‖ ≤ 1 := by

--- a/Mathlib/Analysis/Matrix.lean
+++ b/Mathlib/Analysis/Matrix.lean
@@ -10,7 +10,7 @@ import Mathlib.Analysis.InnerProductSpace.PiL2
 
 In this file we provide the following non-instances for norms on matrices:
 
-* The elementwise norm (with `open scoped Matrix.ElementwiseNorm`):
+* The elementwise norm (with `open scoped Matrix.Norms.Elementwise`):
 
   * `Matrix.seminormedAddCommGroup`
   * `Matrix.normedAddCommGroup`
@@ -18,7 +18,7 @@ In this file we provide the following non-instances for norms on matrices:
   * `Matrix.isBoundedSMul`
   * `Matrix.normSMulClass`
 
-* The Frobenius norm (with `open scoped Matrix.FrobeniusNorm`):
+* The Frobenius norm (with `open scoped Matrix.Norms.Frobenius`):
 
   * `Matrix.frobeniusSeminormedAddCommGroup`
   * `Matrix.frobeniusNormedAddCommGroup`
@@ -28,7 +28,7 @@ In this file we provide the following non-instances for norms on matrices:
   * `Matrix.frobeniusIsBoundedSMul`
   * `Matrix.frobeniusNormSMulClass`
 
-* The $L^\infty$ operator norm (with `open scoped Matrix.LInftyOpNorm`):
+* The $L^\infty$ operator norm (with `open scoped Matrix.Norms.Operator`):
 
   * `Matrix.linftyOpSeminormedAddCommGroup`
   * `Matrix.linftyOpNormedAddCommGroup`
@@ -210,7 +210,7 @@ matrix. -/
 protected def normedSpace : NormedSpace R (Matrix m n α) :=
   Pi.normedSpace
 
-namespace ElementwiseNorm
+namespace Norms.Elementwise
 
 attribute [scoped instance]
   Matrix.seminormedAddCommGroup
@@ -219,7 +219,7 @@ attribute [scoped instance]
   Matrix.isBoundedSMul
   Matrix.normSMulClass
 
-end ElementwiseNorm
+end Norms.Elementwise
 
 end NormedSpace
 
@@ -473,7 +473,7 @@ variable [DecidableEq n]
 
 end
 
-namespace LInftyOpNorm
+namespace Norms.Operator
 attribute [scoped instance]
   Matrix.linftyOpSeminormedAddCommGroup
   Matrix.linftyOpNormedAddCommGroup
@@ -485,7 +485,7 @@ attribute [scoped instance]
   Matrix.linftyOpNonUnitalNormedRing
   Matrix.linftyOpNormedRing
   Matrix.linftyOpNormedAlgebra
-end LInftyOpNorm
+end Norms.Operator
 
 end LinftyOp
 
@@ -678,7 +678,7 @@ end RCLike
 
 end frobenius
 
-namespace FrobeniusNorm
+namespace Norms.Frobenius
 attribute [scoped instance]
   Matrix.frobeniusSeminormedAddCommGroup
   Matrix.frobeniusNormedAddCommGroup
@@ -687,6 +687,6 @@ attribute [scoped instance]
   Matrix.frobeniusNormedAlgebra
   Matrix.frobeniusIsBoundedSMul
   Matrix.frobeniusNormSMulClass
-end FrobeniusNorm
+end Norms.Frobenius
 
 end Matrix

--- a/Mathlib/Analysis/Matrix.lean
+++ b/Mathlib/Analysis/Matrix.lean
@@ -10,7 +10,7 @@ import Mathlib.Analysis.InnerProductSpace.PiL2
 
 In this file we provide the following non-instances for norms on matrices:
 
-* The elementwise norm (with `open scoped Matrix.Norms.Elementwise`):
+* The elementwise norm (with `open scoped Matrix.ElementwiseNorm`):
 
   * `Matrix.seminormedAddCommGroup`
   * `Matrix.normedAddCommGroup`
@@ -18,7 +18,7 @@ In this file we provide the following non-instances for norms on matrices:
   * `Matrix.isBoundedSMul`
   * `Matrix.normSMulClass`
 
-* The Frobenius norm (with `open scoped Matrix.Norms.Frobenius`):
+* The Frobenius norm (with `open scoped Matrix.FrobeniusNorm`):
 
   * `Matrix.frobeniusSeminormedAddCommGroup`
   * `Matrix.frobeniusNormedAddCommGroup`
@@ -28,7 +28,7 @@ In this file we provide the following non-instances for norms on matrices:
   * `Matrix.frobeniusIsBoundedSMul`
   * `Matrix.frobeniusNormSMulClass`
 
-* The $L^\infty$ operator norm (with `open scoped Matrix.Norms.Operator`):
+* The $L^\infty$ operator norm (with `open scoped Matrix.LInftyOpNorm`):
 
   * `Matrix.linftyOpSeminormedAddCommGroup`
   * `Matrix.linftyOpNormedAddCommGroup`
@@ -209,7 +209,7 @@ matrix. -/
 protected def normedSpace : NormedSpace R (Matrix m n α) :=
   Pi.normedSpace
 
-namespace Norms.Elementwise
+namespace ElementwiseNorm
 
 attribute [scoped instance]
   Matrix.seminormedAddCommGroup
@@ -218,7 +218,7 @@ attribute [scoped instance]
   Matrix.isBoundedSMul
   Matrix.normSMulClass
 
-end Norms.Elementwise
+end ElementwiseNorm
 
 end NormedSpace
 
@@ -472,7 +472,7 @@ variable [DecidableEq n]
 
 end
 
-namespace Norms.Operator
+namespace LInftyOpNorm
 attribute [scoped instance]
   Matrix.linftyOpSeminormedAddCommGroup
   Matrix.linftyOpNormedAddCommGroup
@@ -484,7 +484,7 @@ attribute [scoped instance]
   Matrix.linftyOpNonUnitalNormedRing
   Matrix.linftyOpNormedRing
   Matrix.linftyOpNormedAlgebra
-end Norms.Operator
+end LInftyOpNorm
 
 end LinftyOp
 
@@ -677,7 +677,7 @@ end RCLike
 
 end frobenius
 
-namespace Norms.Frobenius
+namespace FrobeniusNorm
 attribute [scoped instance]
   Matrix.frobeniusSeminormedAddCommGroup
   Matrix.frobeniusNormedAddCommGroup
@@ -686,6 +686,6 @@ attribute [scoped instance]
   Matrix.frobeniusNormedAlgebra
   Matrix.frobeniusIsBoundedSMul
   Matrix.frobeniusNormSMulClass
-end Norms.Frobenius
+end FrobeniusNorm
 
 end Matrix

--- a/Mathlib/Analysis/Matrix.lean
+++ b/Mathlib/Analysis/Matrix.lean
@@ -46,7 +46,8 @@ of a matrix.
 
 The norm induced by the identification of `Matrix m n 𝕜` with
 `EuclideanSpace n 𝕜 →L[𝕜] EuclideanSpace m 𝕜` (i.e., the ℓ² operator norm) can be found in
-`Analysis.CStarAlgebra.Matrix`. It is separated to avoid extraneous imports in this file.
+`Mathlib/Analysis/CStarAlgebra/Matrix.lean` and `open scoped Matrix.L2OpNorm`.
+It is separated to avoid extraneous imports in this file.
 -/
 
 noncomputable section

--- a/Mathlib/Analysis/Matrix.lean
+++ b/Mathlib/Analysis/Matrix.lean
@@ -46,7 +46,7 @@ of a matrix.
 
 The norm induced by the identification of `Matrix m n 𝕜` with
 `EuclideanSpace n 𝕜 →L[𝕜] EuclideanSpace m 𝕜` (i.e., the ℓ² operator norm) can be found in
-`Mathlib/Analysis/CStarAlgebra/Matrix.lean` and `open scoped Matrix.L2OpNorm`.
+`Mathlib/Analysis/CStarAlgebra/Matrix.lean` and `open scoped Matrix.Norms.L2Operator`.
 It is separated to avoid extraneous imports in this file.
 -/
 

--- a/Mathlib/Analysis/Matrix.lean
+++ b/Mathlib/Analysis/Matrix.lean
@@ -10,7 +10,7 @@ import Mathlib.Analysis.InnerProductSpace.PiL2
 
 In this file we provide the following non-instances for norms on matrices:
 
-* The elementwise norm:
+* The elementwise norm (with `open scoped Matrix.Norms.Elementwise`):
 
   * `Matrix.seminormedAddCommGroup`
   * `Matrix.normedAddCommGroup`
@@ -18,7 +18,7 @@ In this file we provide the following non-instances for norms on matrices:
   * `Matrix.isBoundedSMul`
   * `Matrix.normSMulClass`
 
-* The Frobenius norm:
+* The Frobenius norm (with `open scoped Matrix.Norms.Frobenius`):
 
   * `Matrix.frobeniusSeminormedAddCommGroup`
   * `Matrix.frobeniusNormedAddCommGroup`
@@ -28,7 +28,7 @@ In this file we provide the following non-instances for norms on matrices:
   * `Matrix.frobeniusIsBoundedSMul`
   * `Matrix.frobeniusNormSMulClass`
 
-* The $L^\infty$ operator norm:
+* The $L^\infty$ operator norm (with `open scoped Matrix.Norms.Operator`):
 
   * `Matrix.linftyOpSeminormedAddCommGroup`
   * `Matrix.linftyOpNormedAddCommGroup`
@@ -72,7 +72,6 @@ declared as an instance because there are several natural choices for defining t
 matrix. -/
 protected def seminormedAddCommGroup : SeminormedAddCommGroup (Matrix m n α) :=
   Pi.seminormedAddCommGroup
-
 
 attribute [local instance] Matrix.seminormedAddCommGroup
 
@@ -209,6 +208,17 @@ declared as an instance because there are several natural choices for defining t
 matrix. -/
 protected def normedSpace : NormedSpace R (Matrix m n α) :=
   Pi.normedSpace
+
+namespace Norms.Elementwise
+
+attribute [scoped instance]
+  Matrix.seminormedAddCommGroup
+  Matrix.normedAddCommGroup
+  Matrix.normedSpace
+  Matrix.isBoundedSMul
+  Matrix.normSMulClass
+
+end Norms.Elementwise
 
 end NormedSpace
 
@@ -462,6 +472,20 @@ variable [DecidableEq n]
 
 end
 
+namespace Norms.Operator
+attribute [scoped instance]
+  Matrix.linftyOpSeminormedAddCommGroup
+  Matrix.linftyOpNormedAddCommGroup
+  Matrix.linftyOpNormedSpace
+  Matrix.linftyOpIsBoundedSMul
+  Matrix.linftyOpNormSMulClass
+  Matrix.linftyOpNonUnitalSemiNormedRing
+  Matrix.linftyOpSemiNormedRing
+  Matrix.linftyOpNonUnitalNormedRing
+  Matrix.linftyOpNormedRing
+  Matrix.linftyOpNormedAlgebra
+end Norms.Operator
+
 end LinftyOp
 
 /-! ### The Frobenius norm
@@ -652,5 +676,16 @@ def frobeniusNormedAlgebra [DecidableEq m] [NormedField R] [NormedAlgebra R α] 
 end RCLike
 
 end frobenius
+
+namespace Norms.Frobenius
+attribute [scoped instance]
+  Matrix.frobeniusSeminormedAddCommGroup
+  Matrix.frobeniusNormedAddCommGroup
+  Matrix.frobeniusNormedSpace
+  Matrix.frobeniusNormedRing
+  Matrix.frobeniusNormedAlgebra
+  Matrix.frobeniusIsBoundedSMul
+  Matrix.frobeniusNormSMulClass
+end Norms.Frobenius
 
 end Matrix

--- a/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
@@ -118,40 +118,25 @@ variable [RCLike 𝕂] [Fintype m] [DecidableEq m]
   [NormedRing 𝔸] [NormedAlgebra 𝕂 𝔸] [CompleteSpace 𝔸]
 
 nonrec theorem exp_add_of_commute (A B : Matrix m m 𝔸) (h : Commute A B) :
-    exp 𝕂 (A + B) = exp 𝕂 A * exp 𝕂 B := by
-  letI : SeminormedRing (Matrix m m 𝔸) := Matrix.linftyOpSemiNormedRing
-  letI : NormedRing (Matrix m m 𝔸) := Matrix.linftyOpNormedRing
-  letI : NormedAlgebra 𝕂 (Matrix m m 𝔸) := Matrix.linftyOpNormedAlgebra
-  exact exp_add_of_commute h
+    exp 𝕂 (A + B) = exp 𝕂 A * exp 𝕂 B :=
+  open scoped Norms.Operator in exp_add_of_commute h
 
 open scoped Function in -- required for scoped `on` notation
 nonrec theorem exp_sum_of_commute {ι} (s : Finset ι) (f : ι → Matrix m m 𝔸)
     (h : (s : Set ι).Pairwise (Commute on f)) :
     exp 𝕂 (∑ i ∈ s, f i) =
-      s.noncommProd (fun i => exp 𝕂 (f i)) fun _ hi _ hj _ => (h.of_refl hi hj).exp 𝕂 := by
-  letI : SeminormedRing (Matrix m m 𝔸) := Matrix.linftyOpSemiNormedRing
-  letI : NormedRing (Matrix m m 𝔸) := Matrix.linftyOpNormedRing
-  letI : NormedAlgebra 𝕂 (Matrix m m 𝔸) := Matrix.linftyOpNormedAlgebra
-  exact exp_sum_of_commute s f h
+      s.noncommProd (fun i => exp 𝕂 (f i)) fun _ hi _ hj _ => (h.of_refl hi hj).exp 𝕂 :=
+  open scoped Norms.Operator in exp_sum_of_commute s f h
 
-nonrec theorem exp_nsmul (n : ℕ) (A : Matrix m m 𝔸) : exp 𝕂 (n • A) = exp 𝕂 A ^ n := by
-  letI : SeminormedRing (Matrix m m 𝔸) := Matrix.linftyOpSemiNormedRing
-  letI : NormedRing (Matrix m m 𝔸) := Matrix.linftyOpNormedRing
-  letI : NormedAlgebra 𝕂 (Matrix m m 𝔸) := Matrix.linftyOpNormedAlgebra
-  exact exp_nsmul n A
+nonrec theorem exp_nsmul (n : ℕ) (A : Matrix m m 𝔸) : exp 𝕂 (n • A) = exp 𝕂 A ^ n :=
+  open scoped Norms.Operator in exp_nsmul n A
 
-nonrec theorem isUnit_exp (A : Matrix m m 𝔸) : IsUnit (exp 𝕂 A) := by
-  letI : SeminormedRing (Matrix m m 𝔸) := Matrix.linftyOpSemiNormedRing
-  letI : NormedRing (Matrix m m 𝔸) := Matrix.linftyOpNormedRing
-  letI : NormedAlgebra 𝕂 (Matrix m m 𝔸) := Matrix.linftyOpNormedAlgebra
-  exact isUnit_exp _ A
+nonrec theorem isUnit_exp (A : Matrix m m 𝔸) : IsUnit (exp 𝕂 A) :=
+  open scoped Norms.Operator in isUnit_exp _ A
 
 nonrec theorem exp_units_conj (U : (Matrix m m 𝔸)ˣ) (A : Matrix m m 𝔸) :
-    exp 𝕂 (U * A * U⁻¹) = U * exp 𝕂 A * U⁻¹ := by
-  letI : SeminormedRing (Matrix m m 𝔸) := Matrix.linftyOpSemiNormedRing
-  letI : NormedRing (Matrix m m 𝔸) := Matrix.linftyOpNormedRing
-  letI : NormedAlgebra 𝕂 (Matrix m m 𝔸) := Matrix.linftyOpNormedAlgebra
-  exact exp_units_conj _ U A
+    exp 𝕂 (U * A * U⁻¹) = U * exp 𝕂 A * U⁻¹ :=
+  open scoped Norms.Operator in exp_units_conj _ U A
 
 theorem exp_units_conj' (U : (Matrix m m 𝔸)ˣ) (A : Matrix m m 𝔸) :
     exp 𝕂 (U⁻¹ * A * U) = U⁻¹ * exp 𝕂 A * U :=
@@ -166,10 +151,7 @@ variable [RCLike 𝕂] [Fintype m] [DecidableEq m]
 
 theorem exp_neg (A : Matrix m m 𝔸) : exp 𝕂 (-A) = (exp 𝕂 A)⁻¹ := by
   rw [nonsing_inv_eq_ringInverse]
-  letI : SeminormedRing (Matrix m m 𝔸) := Matrix.linftyOpSemiNormedRing
-  letI : NormedRing (Matrix m m 𝔸) := Matrix.linftyOpNormedRing
-  letI : NormedAlgebra 𝕂 (Matrix m m 𝔸) := Matrix.linftyOpNormedAlgebra
-  exact (Ring.inverse_exp _ A).symm
+  open scoped Norms.Operator in exact (Ring.inverse_exp _ A).symm
 
 theorem exp_zsmul (z : ℤ) (A : Matrix m m 𝔸) : exp 𝕂 (z • A) = exp 𝕂 A ^ z := by
   obtain ⟨n, rfl | rfl⟩ := z.eq_nat_or_neg

--- a/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
@@ -119,24 +119,24 @@ variable [RCLike 𝕂] [Fintype m] [DecidableEq m]
 
 nonrec theorem exp_add_of_commute (A B : Matrix m m 𝔸) (h : Commute A B) :
     exp 𝕂 (A + B) = exp 𝕂 A * exp 𝕂 B :=
-  open scoped Norms.Operator in exp_add_of_commute h
+  open scoped LInftyOpNormNorms in exp_add_of_commute h
 
 open scoped Function in -- required for scoped `on` notation
 nonrec theorem exp_sum_of_commute {ι} (s : Finset ι) (f : ι → Matrix m m 𝔸)
     (h : (s : Set ι).Pairwise (Commute on f)) :
     exp 𝕂 (∑ i ∈ s, f i) =
       s.noncommProd (fun i => exp 𝕂 (f i)) fun _ hi _ hj _ => (h.of_refl hi hj).exp 𝕂 :=
-  open scoped Norms.Operator in exp_sum_of_commute s f h
+  open scoped LInftyOpNormNorms in exp_sum_of_commute s f h
 
 nonrec theorem exp_nsmul (n : ℕ) (A : Matrix m m 𝔸) : exp 𝕂 (n • A) = exp 𝕂 A ^ n :=
-  open scoped Norms.Operator in exp_nsmul n A
+  open scoped LInftyOpNormNorms in exp_nsmul n A
 
 nonrec theorem isUnit_exp (A : Matrix m m 𝔸) : IsUnit (exp 𝕂 A) :=
-  open scoped Norms.Operator in isUnit_exp _ A
+  open scoped LInftyOpNormNorms in isUnit_exp _ A
 
 nonrec theorem exp_units_conj (U : (Matrix m m 𝔸)ˣ) (A : Matrix m m 𝔸) :
     exp 𝕂 (U * A * U⁻¹) = U * exp 𝕂 A * U⁻¹ :=
-  open scoped Norms.Operator in exp_units_conj _ U A
+  open scoped LInftyOpNormNorms in exp_units_conj _ U A
 
 theorem exp_units_conj' (U : (Matrix m m 𝔸)ˣ) (A : Matrix m m 𝔸) :
     exp 𝕂 (U⁻¹ * A * U) = U⁻¹ * exp 𝕂 A * U :=
@@ -151,7 +151,7 @@ variable [RCLike 𝕂] [Fintype m] [DecidableEq m]
 
 theorem exp_neg (A : Matrix m m 𝔸) : exp 𝕂 (-A) = (exp 𝕂 A)⁻¹ := by
   rw [nonsing_inv_eq_ringInverse]
-  open scoped Norms.Operator in exact (Ring.inverse_exp _ A).symm
+  open scoped LInftyOpNormNorms in exact (Ring.inverse_exp _ A).symm
 
 theorem exp_zsmul (z : ℤ) (A : Matrix m m 𝔸) : exp 𝕂 (z • A) = exp 𝕂 A ^ z := by
   obtain ⟨n, rfl | rfl⟩ := z.eq_nat_or_neg

--- a/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
+++ b/Mathlib/Analysis/Normed/Algebra/MatrixExponential.lean
@@ -119,24 +119,24 @@ variable [RCLike 𝕂] [Fintype m] [DecidableEq m]
 
 nonrec theorem exp_add_of_commute (A B : Matrix m m 𝔸) (h : Commute A B) :
     exp 𝕂 (A + B) = exp 𝕂 A * exp 𝕂 B :=
-  open scoped LInftyOpNormNorms in exp_add_of_commute h
+  open scoped Norms.Operator in exp_add_of_commute h
 
 open scoped Function in -- required for scoped `on` notation
 nonrec theorem exp_sum_of_commute {ι} (s : Finset ι) (f : ι → Matrix m m 𝔸)
     (h : (s : Set ι).Pairwise (Commute on f)) :
     exp 𝕂 (∑ i ∈ s, f i) =
       s.noncommProd (fun i => exp 𝕂 (f i)) fun _ hi _ hj _ => (h.of_refl hi hj).exp 𝕂 :=
-  open scoped LInftyOpNormNorms in exp_sum_of_commute s f h
+  open scoped Norms.Operator in exp_sum_of_commute s f h
 
 nonrec theorem exp_nsmul (n : ℕ) (A : Matrix m m 𝔸) : exp 𝕂 (n • A) = exp 𝕂 A ^ n :=
-  open scoped LInftyOpNormNorms in exp_nsmul n A
+  open scoped Norms.Operator in exp_nsmul n A
 
 nonrec theorem isUnit_exp (A : Matrix m m 𝔸) : IsUnit (exp 𝕂 A) :=
-  open scoped LInftyOpNormNorms in isUnit_exp _ A
+  open scoped Norms.Operator in isUnit_exp _ A
 
 nonrec theorem exp_units_conj (U : (Matrix m m 𝔸)ˣ) (A : Matrix m m 𝔸) :
     exp 𝕂 (U * A * U⁻¹) = U * exp 𝕂 A * U⁻¹ :=
-  open scoped LInftyOpNormNorms in exp_units_conj _ U A
+  open scoped Norms.Operator in exp_units_conj _ U A
 
 theorem exp_units_conj' (U : (Matrix m m 𝔸)ˣ) (A : Matrix m m 𝔸) :
     exp 𝕂 (U⁻¹ * A * U) = U⁻¹ * exp 𝕂 A * U :=
@@ -151,7 +151,7 @@ variable [RCLike 𝕂] [Fintype m] [DecidableEq m]
 
 theorem exp_neg (A : Matrix m m 𝔸) : exp 𝕂 (-A) = (exp 𝕂 A)⁻¹ := by
   rw [nonsing_inv_eq_ringInverse]
-  open scoped LInftyOpNormNorms in exact (Ring.inverse_exp _ A).symm
+  open scoped Norms.Operator in exact (Ring.inverse_exp _ A).symm
 
 theorem exp_zsmul (z : ℤ) (A : Matrix m m 𝔸) : exp 𝕂 (z • A) = exp 𝕂 A ^ z := by
   obtain ⟨n, rfl | rfl⟩ := z.eq_nat_or_neg


### PR DESCRIPTION
It's possible that type synonyms are worth exploring here, but this is strictly better than the status quo where it can be easy to forget one of this family of instances.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
