### PR TITLE
[Merged by Bors] - chore(RingTheory/PowerSeries): golf entire `trunc_one` using `grind`

### DIFF
--- a/Mathlib/RingTheory/PowerSeries/Trunc.lean
+++ b/Mathlib/RingTheory/PowerSeries/Trunc.lean
@@ -50,12 +50,7 @@ theorem trunc_zero (n) : trunc n (0 : R⟦X⟧) = 0 :=
 @[simp]
 theorem trunc_one (n) : trunc (n + 1) (1 : R⟦X⟧) = 1 :=
   Polynomial.ext fun m => by
-    rw [coeff_trunc, coeff_one, Polynomial.coeff_one]
-    split_ifs with h _ h'
-    · rfl
-    · rfl
-    · subst h'; simp at h
-    · rfl
+    grind [PowerSeries.coeff_trunc, PowerSeries.coeff_one, Polynomial.coeff_one]
 
 @[simp]
 theorem trunc_C (n) (a : R) : trunc (n + 1) (C R a) = Polynomial.C a :=


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>trunc_one</code>: 88 ms before, 87 ms after  🎉</summary>

### Trace profiling of `trunc_one` before PR 27856
```diff
diff --git a/Mathlib/RingTheory/PowerSeries/Trunc.lean b/Mathlib/RingTheory/PowerSeries/Trunc.lean
index 7b8a612d49..9e21778c21 100644
--- a/Mathlib/RingTheory/PowerSeries/Trunc.lean
+++ b/Mathlib/RingTheory/PowerSeries/Trunc.lean
@@ -47,6 +47,7 @@ theorem trunc_zero (n) : trunc n (0 : R⟦X⟧) = 0 :=
     rw [coeff_trunc, LinearMap.map_zero, Polynomial.coeff_zero]
     split_ifs <;> rfl
 
+set_option trace.profiler true in
 @[simp]
 theorem trunc_one (n) : trunc (n + 1) (1 : R⟦X⟧) = 1 :=
   Polynomial.ext fun m => by
```
```
ℹ [1292/1292] Built Mathlib.RingTheory.PowerSeries.Trunc (3.2s)
info: Mathlib/RingTheory/PowerSeries/Trunc.lean:51:0: [Elab.async] [0.089409] elaborating proof of PowerSeries.trunc_one
  [Elab.definition.value] [0.088361] PowerSeries.trunc_one
    [Elab.step] [0.086909] 
          rw [coeff_trunc, coeff_one, Polynomial.coeff_one]
          split_ifs with h _ h'
          · rfl
          · rfl
          · subst h'; simp at h
          · rfl
      [Elab.step] [0.086897] 
            rw [coeff_trunc, coeff_one, Polynomial.coeff_one]
            split_ifs with h _ h'
            · rfl
            · rfl
            · subst h'; simp at h
            · rfl
        [Elab.step] [0.038895] split_ifs with h _ h'
        [Elab.step] [0.043021] · subst h'; simp at h
          [Elab.step] [0.042999] subst h'; simp at h
            [Elab.step] [0.042991] subst h'; simp at h
              [Elab.step] [0.042673] simp at h
Build completed successfully (1292 jobs).
```

### Trace profiling of `trunc_one` after PR 27856
```diff
diff --git a/Mathlib/RingTheory/PowerSeries/Trunc.lean b/Mathlib/RingTheory/PowerSeries/Trunc.lean
index 7b8a612d49..d9f8019532 100644
--- a/Mathlib/RingTheory/PowerSeries/Trunc.lean
+++ b/Mathlib/RingTheory/PowerSeries/Trunc.lean
@@ -47,15 +47,11 @@ theorem trunc_zero (n) : trunc n (0 : R⟦X⟧) = 0 :=
     rw [coeff_trunc, LinearMap.map_zero, Polynomial.coeff_zero]
     split_ifs <;> rfl
 
+set_option trace.profiler true in
 @[simp]
 theorem trunc_one (n) : trunc (n + 1) (1 : R⟦X⟧) = 1 :=
   Polynomial.ext fun m => by
-    rw [coeff_trunc, coeff_one, Polynomial.coeff_one]
-    split_ifs with h _ h'
-    · rfl
-    · rfl
-    · subst h'; simp at h
-    · rfl
+    grind [PowerSeries.coeff_trunc, PowerSeries.coeff_one, Polynomial.coeff_one]
 
 @[simp]
 theorem trunc_C (n) (a : R) : trunc (n + 1) (C R a) = Polynomial.C a :=
```
```
ℹ [1292/1292] Built Mathlib.RingTheory.PowerSeries.Trunc (3.1s)
info: Mathlib/RingTheory/PowerSeries/Trunc.lean:51:0: [Elab.async] [0.087506] elaborating proof of PowerSeries.trunc_one
  [Elab.definition.value] [0.086697] PowerSeries.trunc_one
    [Elab.step] [0.083908] grind [PowerSeries.coeff_trunc, PowerSeries.coeff_one, Polynomial.coeff_one]
      [Elab.step] [0.083856] grind [PowerSeries.coeff_trunc, PowerSeries.coeff_one, Polynomial.coeff_one]
        [Elab.step] [0.083840] grind [PowerSeries.coeff_trunc, PowerSeries.coeff_one, Polynomial.coeff_one]
          [Meta.synthInstance] [0.010307] ✅️ Lean.Grind.NatModule (Lean.Grind.Ring.OfSemiring.Q ℕ)
          [Meta.synthInstance] [0.010255] ❌️ LE (MvPowerSeries PUnit.{1} R)
Build completed successfully (1292 jobs).
```
</details>

