### PR TITLE
[Merged by Bors] - chore(Analysis/SpecialFunctions): golf entire `rpow_eq_top_of_nonneg` using `simp`

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
@@ -554,7 +554,7 @@ lemma rpow_lt_top_iff_of_pos {x : ℝ≥0∞} {y : ℝ} (hy : 0 < y) : x ^ y < �
   simp only [lt_top_iff_ne_top, Ne, rpow_eq_top_iff_of_pos hy]
 
 theorem rpow_eq_top_of_nonneg (x : ℝ≥0∞) {y : ℝ} (hy0 : 0 ≤ y) : x ^ y = ⊤ → x = ⊤ := by
-  grind [ENNReal.rpow_eq_top_iff]
+  simp +contextual [ENNReal.rpow_eq_top_iff, hy0.not_gt]
 
 -- This is an unsafe rule since we want to try `rpow_ne_top_of_ne_zero` if `y < 0`.
 @[aesop (rule_sets := [finiteness]) unsafe apply]

--- a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
@@ -554,12 +554,7 @@ lemma rpow_lt_top_iff_of_pos {x : ℝ≥0∞} {y : ℝ} (hy : 0 < y) : x ^ y < �
   simp only [lt_top_iff_ne_top, Ne, rpow_eq_top_iff_of_pos hy]
 
 theorem rpow_eq_top_of_nonneg (x : ℝ≥0∞) {y : ℝ} (hy0 : 0 ≤ y) : x ^ y = ⊤ → x = ⊤ := by
-  rw [ENNReal.rpow_eq_top_iff]
-  rintro (h|h)
-  · exfalso
-    rw [lt_iff_not_ge] at h
-    exact h.right hy0
-  · exact h.left
+  grind [ENNReal.rpow_eq_top_iff]
 
 -- This is an unsafe rule since we want to try `rpow_ne_top_of_ne_zero` if `y < 0`.
 @[aesop (rule_sets := [finiteness]) unsafe apply]


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>rpow_eq_top_of_nonneg</code>: <10 ms before, 18 ms after </summary>

### Trace profiling of `rpow_eq_top_of_nonneg` before PR 27857
```diff
diff --git a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
index 75b232ee4e..5d2ddf1fce 100644
--- a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
@@ -553,6 +553,7 @@ theorem rpow_eq_top_iff_of_pos {x : ℝ≥0∞} {y : ℝ} (hy : 0 < y) : x ^ y =
 lemma rpow_lt_top_iff_of_pos {x : ℝ≥0∞} {y : ℝ} (hy : 0 < y) : x ^ y < ∞ ↔ x < ∞ := by
   simp only [lt_top_iff_ne_top, Ne, rpow_eq_top_iff_of_pos hy]
 
+set_option trace.profiler true in
 theorem rpow_eq_top_of_nonneg (x : ℝ≥0∞) {y : ℝ} (hy0 : 0 ≤ y) : x ^ y = ⊤ → x = ⊤ := by
   rw [ENNReal.rpow_eq_top_iff]
   rintro (h|h)
```
```
✔ [1872/1872] Built Mathlib.Analysis.SpecialFunctions.Pow.NNReal (6.0s)
Build completed successfully (1872 jobs).
```

### Trace profiling of `rpow_eq_top_of_nonneg` after PR 27857
```diff
diff --git a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
index 75b232ee4e..68dc37f940 100644
--- a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
@@ -553,13 +553,9 @@ theorem rpow_eq_top_iff_of_pos {x : ℝ≥0∞} {y : ℝ} (hy : 0 < y) : x ^ y =
 lemma rpow_lt_top_iff_of_pos {x : ℝ≥0∞} {y : ℝ} (hy : 0 < y) : x ^ y < ∞ ↔ x < ∞ := by
   simp only [lt_top_iff_ne_top, Ne, rpow_eq_top_iff_of_pos hy]
 
+set_option trace.profiler true in
 theorem rpow_eq_top_of_nonneg (x : ℝ≥0∞) {y : ℝ} (hy0 : 0 ≤ y) : x ^ y = ⊤ → x = ⊤ := by
-  rw [ENNReal.rpow_eq_top_iff]
-  rintro (h|h)
-  · exfalso
-    rw [lt_iff_not_ge] at h
-    exact h.right hy0
-  · exact h.left
+  simp +contextual [ENNReal.rpow_eq_top_iff, hy0.not_gt]
 
 -- This is an unsafe rule since we want to try `rpow_ne_top_of_ne_zero` if `y < 0`.
 @[aesop (rule_sets := [finiteness]) unsafe apply]
```
```
ℹ [1872/1872] Built Mathlib.Analysis.SpecialFunctions.Pow.NNReal (6.0s)
info: Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean:557:0: [Elab.async] [0.018873] elaborating proof of ENNReal.rpow_eq_top_of_nonneg
  [Elab.definition.value] [0.018350] ENNReal.rpow_eq_top_of_nonneg
    [Elab.step] [0.018131] simp +contextual [ENNReal.rpow_eq_top_iff, hy0.not_gt]
      [Elab.step] [0.018118] simp +contextual [ENNReal.rpow_eq_top_iff, hy0.not_gt]
        [Elab.step] [0.018101] simp +contextual [ENNReal.rpow_eq_top_iff, hy0.not_gt]
Build completed successfully (1872 jobs).
```
</details>
