### PR TITLE
chore(GroupTheory/Coxeter): golf entire `getElem_alternatingWord_swapIndices` using `grind [CoxeterSystem.getElem_alternatingWord]`

### DIFF
--- a/Mathlib/GroupTheory/Coxeter/Basic.lean
+++ b/Mathlib/GroupTheory/Coxeter/Basic.lean
@@ -445,14 +445,8 @@ lemma getElem_alternatingWord (i j : B) (p k : ℕ) (hk : k < p) :
 
 lemma getElem_alternatingWord_swapIndices (i j : B) (p k : ℕ) (h : k + 1 < p) :
      (alternatingWord i j p)[k+1]'(by simp [h]) =
-     (alternatingWord j i p)[k]'(by simp; omega) := by
-  rw [getElem_alternatingWord i j p (k+1) (by omega), getElem_alternatingWord j i p k (by omega)]
-  by_cases h_even : Even (p + k)
-  · rw [if_pos h_even, ← add_assoc]
-    simp only [ite_eq_right_iff, isEmpty_Prop, Nat.not_even_iff_odd, Even.add_one h_even,
-      IsEmpty.forall_iff]
-  · rw [if_neg h_even, ← add_assoc]
-    simp [Odd.add_one (Nat.not_even_iff_odd.mp h_even)]
+     (alternatingWord j i p)[k]'(by simp; grind) := by
+  grind [CoxeterSystem.getElem_alternatingWord]
 
 lemma listTake_alternatingWord (i j : B) (p k : ℕ) (h : k < 2 * p) :
     List.take k (alternatingWord i j (2 * p)) =


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>getElem_alternatingWord_swapIndices</code></summary>

### Trace profiling of `getElem_alternatingWord_swapIndices` before PR 27859
```diff
diff --git a/Mathlib/GroupTheory/Coxeter/Basic.lean b/Mathlib/GroupTheory/Coxeter/Basic.lean
index 728fc1fbe8..b83738fafa 100644
--- a/Mathlib/GroupTheory/Coxeter/Basic.lean
+++ b/Mathlib/GroupTheory/Coxeter/Basic.lean
@@ -421,2 +421,3 @@ lemma getElem_alternatingWord (i j : B) (p k : ℕ) (hk : k < p) :
 
+set_option trace.profiler true in
 lemma getElem_alternatingWord_swapIndices (i j : B) (p k : ℕ) (h : k + 1 < p) :
```
```
ℹ [1101/1101] Built Mathlib.GroupTheory.Coxeter.Basic
info: Mathlib/GroupTheory/Coxeter/Basic.lean:423:0: [Elab.command] [0.012972] theorem getElem_alternatingWord_swapIndices (i j : B) (p k : ℕ) (h : k + 1 < p) :
        (alternatingWord i j p)[k + 1]'(by simp [h]) = (alternatingWord j i p)[k]'(by simp; omega) :=
      by
      rw [getElem_alternatingWord i j p (k + 1) (by omega), getElem_alternatingWord j i p k (by omega)]
      by_cases h_even : Even (p + k)
      · rw [if_pos h_even, ← add_assoc]
        simp only [ite_eq_right_iff, isEmpty_Prop, Nat.not_even_iff_odd, Even.add_one h_even, IsEmpty.forall_iff]
      · rw [if_neg h_even, ← add_assoc]
        simp [Odd.add_one (Nat.not_even_iff_odd.mp h_even)]
  [Elab.definition.header] [0.011162] CoxeterSystem.getElem_alternatingWord_swapIndices
info: Mathlib/GroupTheory/Coxeter/Basic.lean:423:0: [Elab.command] [0.013108] lemma getElem_alternatingWord_swapIndices (i j : B) (p k : ℕ) (h : k + 1 < p) :
        (alternatingWord i j p)[k + 1]'(by simp [h]) = (alternatingWord j i p)[k]'(by simp; omega) :=
      by
      rw [getElem_alternatingWord i j p (k + 1) (by omega), getElem_alternatingWord j i p k (by omega)]
      by_cases h_even : Even (p + k)
      · rw [if_pos h_even, ← add_assoc]
        simp only [ite_eq_right_iff, isEmpty_Prop, Nat.not_even_iff_odd, Even.add_one h_even, IsEmpty.forall_iff]
      · rw [if_neg h_even, ← add_assoc]
        simp [Odd.add_one (Nat.not_even_iff_odd.mp h_even)]
info: Mathlib/GroupTheory/Coxeter/Basic.lean:423:0: [Elab.async] [0.028611] elaborating proof of CoxeterSystem.getElem_alternatingWord_swapIndices
  [Elab.definition.value] [0.027737] CoxeterSystem.getElem_alternatingWord_swapIndices
    [Elab.step] [0.027058] 
          rw [getElem_alternatingWord i j p (k + 1) (by omega), getElem_alternatingWord j i p k (by omega)]
          by_cases h_even : Even (p + k)
          · rw [if_pos h_even, ← add_assoc]
            simp only [ite_eq_right_iff, isEmpty_Prop, Nat.not_even_iff_odd, Even.add_one h_even, IsEmpty.forall_iff]
          · rw [if_neg h_even, ← add_assoc]
            simp [Odd.add_one (Nat.not_even_iff_odd.mp h_even)]
      [Elab.step] [0.027043] 
            rw [getElem_alternatingWord i j p (k + 1) (by omega), getElem_alternatingWord j i p k (by omega)]
            by_cases h_even : Even (p + k)
            · rw [if_pos h_even, ← add_assoc]
              simp only [ite_eq_right_iff, isEmpty_Prop, Nat.not_even_iff_odd, Even.add_one h_even, IsEmpty.forall_iff]
            · rw [if_neg h_even, ← add_assoc]
              simp [Odd.add_one (Nat.not_even_iff_odd.mp h_even)]
        [Elab.step] [0.010288] rw [getElem_alternatingWord i j p (k + 1) (by omega),
              getElem_alternatingWord j i p k (by omega)]
          [Elab.step] [0.010274] (rewrite [getElem_alternatingWord i j p (k + 1) (by omega),
                  getElem_alternatingWord j i p k (by omega)];
                with_annotate_state"]" (try (with_reducible rfl)))
            [Elab.step] [0.010265] rewrite [getElem_alternatingWord i j p (k + 1) (by omega),
                    getElem_alternatingWord j i p k (by omega)];
                  with_annotate_state"]" (try (with_reducible rfl))
              [Elab.step] [0.010256] rewrite [getElem_alternatingWord i j p (k + 1) (by omega),
                      getElem_alternatingWord j i p k (by omega)];
                    with_annotate_state"]" (try (with_reducible rfl))
Build completed successfully.
```

### Trace profiling of `getElem_alternatingWord_swapIndices` after PR 27859
```diff
diff --git a/Mathlib/GroupTheory/Coxeter/Basic.lean b/Mathlib/GroupTheory/Coxeter/Basic.lean
index 728fc1fbe8..54ecbb62fe 100644
--- a/Mathlib/GroupTheory/Coxeter/Basic.lean
+++ b/Mathlib/GroupTheory/Coxeter/Basic.lean
@@ -421,12 +421,7 @@ lemma getElem_alternatingWord (i j : B) (p k : ℕ) (hk : k < p) :
 
+set_option trace.profiler true in
 lemma getElem_alternatingWord_swapIndices (i j : B) (p k : ℕ) (h : k + 1 < p) :
      (alternatingWord i j p)[k+1]'(by simp [h]) =
-     (alternatingWord j i p)[k]'(by simp; omega) := by
-  rw [getElem_alternatingWord i j p (k+1) (by omega), getElem_alternatingWord j i p k (by omega)]
-  by_cases h_even : Even (p + k)
-  · rw [if_pos h_even, ← add_assoc]
-    simp only [ite_eq_right_iff, isEmpty_Prop, Nat.not_even_iff_odd, Even.add_one h_even,
-      IsEmpty.forall_iff]
-  · rw [if_neg h_even, ← add_assoc]
-    simp [Odd.add_one (Nat.not_even_iff_odd.mp h_even)]
+     (alternatingWord j i p)[k]'(by simp; grind) := by
+  grind [CoxeterSystem.getElem_alternatingWord]
 
```
```
ℹ [1101/1101] Built Mathlib.GroupTheory.Coxeter.Basic
info: Mathlib/GroupTheory/Coxeter/Basic.lean:423:0: [Elab.command] [0.026042] theorem getElem_alternatingWord_swapIndices (i j : B) (p k : ℕ) (h : k + 1 < p) :
        (alternatingWord i j p)[k + 1]'(by simp [h]) = (alternatingWord j i p)[k]'(by simp; grind) := by
      grind [CoxeterSystem.getElem_alternatingWord]
  [Elab.definition.header] [0.024944] CoxeterSystem.getElem_alternatingWord_swapIndices
    [Elab.step] [0.018977] simp; grind
      [Elab.step] [0.018965] simp; grind
        [Elab.step] [0.015732] grind
info: Mathlib/GroupTheory/Coxeter/Basic.lean:423:0: [Elab.command] [0.026140] lemma getElem_alternatingWord_swapIndices (i j : B) (p k : ℕ) (h : k + 1 < p) :
        (alternatingWord i j p)[k + 1]'(by simp [h]) = (alternatingWord j i p)[k]'(by simp; grind) := by
      grind [CoxeterSystem.getElem_alternatingWord]
info: Mathlib/GroupTheory/Coxeter/Basic.lean:423:0: [Elab.async] [0.482406] elaborating proof of CoxeterSystem.getElem_alternatingWord_swapIndices
  [Elab.definition.value] [0.481936] CoxeterSystem.getElem_alternatingWord_swapIndices
    [Elab.step] [0.481472] grind [CoxeterSystem.getElem_alternatingWord]
      [Elab.step] [0.481459] grind [CoxeterSystem.getElem_alternatingWord]
        [Elab.step] [0.481437] grind [CoxeterSystem.getElem_alternatingWord]
Build completed successfully.
```
</details>
