### PR TITLE
linter indentation playground

### DIFF
--- a/Mathlib/AlgebraicTopology/SimplexCategory/Augmented.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/Augmented.lean
@@ -27,6 +27,7 @@ objects, and we provide a translation of the main constrcutions on augmented (co
 
 open CategoryTheory
 
+set_option linter.style.indentation false in -- TODO: disable on deriving indentation
 /-- The `AugmentedSimplexCategory` is the category obtained from `SimplexCategory` by adjoining an
 initial object. -/
 def AugmentedSimplexCategory := WithInitial SimplexCategory

--- a/Mathlib/AlgebraicTopology/SimplexCategory/GeneratorsRelations/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/GeneratorsRelations/Basic.lean
@@ -66,6 +66,7 @@ inductive homRel : HomRel (Paths FreeSimplexQuiver)
 
 end FreeSimplexQuiver
 
+set_option linter.style.indentation false in -- TODO: disable on deriving indentation
 /-- SimplexCategory is the category presented by generators and relation by the simplicial
 identities. -/
 def SimplexCategoryGenRel := Quotient FreeSimplexQuiver.homRel

--- a/Mathlib/CategoryTheory/Sites/Coherent/Basic.lean
+++ b/Mathlib/CategoryTheory/Sites/Coherent/Basic.lean
@@ -45,6 +45,7 @@ open Limits
 
 variable (C : Type*) [Category C]
 
+set_option linter.style.indentation false in -- linter false positive
 /--
 The condition `Precoherent C` is essentially the minimal condition required to define the
 coherent coverage on `C`.

--- a/Mathlib/Data/ENNReal/Basic.lean
+++ b/Mathlib/Data/ENNReal/Basic.lean
@@ -93,6 +93,7 @@ open Function Set NNReal
 
 variable {α : Type*}
 
+set_option linter.style.indentation false in -- TODO: disable on deriving indentation
 /-- The extended nonnegative real numbers. This is usually denoted [0, ∞],
   and is relevant as the codomain of a measure. -/
 def ENNReal := WithTop ℝ≥0

--- a/Mathlib/Data/EReal/Basic.lean
+++ b/Mathlib/Data/EReal/Basic.lean
@@ -26,6 +26,7 @@ open Function ENNReal NNReal Set
 
 noncomputable section
 
+set_option linter.style.indentation false in -- TODO: disable on deriving indentation
 /-- The type of extended real numbers `[-∞, ∞]`, constructed as `WithBot (WithTop ℝ)`. -/
 def EReal := WithBot (WithTop ℝ)
   deriving Bot, Zero, One, Nontrivial, AddMonoid, PartialOrder, AddCommMonoid

--- a/Mathlib/Data/Nat/Prime/Defs.lean
+++ b/Mathlib/Data/Nat/Prime/Defs.lean
@@ -434,6 +434,7 @@ alias ⟨Prime.prime, _root_.Prime.nat_prime⟩ := prime_iff
 theorem irreducible_iff_prime {p : ℕ} : Irreducible p ↔ _root_.Prime p :=
   prime_iff
 
+set_option linter.style.indentation false in -- TODO: disable on deriving indentation
 /-- The type of prime numbers -/
 def Primes :=
   { p : ℕ // p.Prime }

--- a/Mathlib/FieldTheory/RatFunc/Basic.lean
+++ b/Mathlib/FieldTheory/RatFunc/Basic.lean
@@ -241,6 +241,7 @@ macro "frac_tac" : tactic => `(tactic|
       add_comm, add_left_comm, mul_comm, mul_left_comm, sub_eq_add_neg, div_eq_mul_inv,
       add_mul, zero_mul, one_mul, neg_mul, mul_neg, add_neg_cancel])
 
+set_option linter.style.indentation false in -- linter false positive
 /-- Solve equations for `RatFunc K` by applying `RatFunc.induction_on`. -/
 macro "smul_tac" : tactic => `(tactic|
     repeat

--- a/Mathlib/Init.lean
+++ b/Mathlib/Init.lean
@@ -80,6 +80,7 @@ register_linter_set linter.mathlibStandardSet :=
   linter.style.setOption
   linter.style.show
   linter.style.maxHeartbeats
+  linter.style.indenting
   -- The `docPrime` linter is disabled: https://github.com/leanprover-community/mathlib4/issues/20560
 
 -- Check that all linter options mentioned in the mathlib standard linter set exist.

--- a/Mathlib/Init.lean
+++ b/Mathlib/Init.lean
@@ -80,7 +80,7 @@ register_linter_set linter.mathlibStandardSet :=
   linter.style.setOption
   linter.style.show
   linter.style.maxHeartbeats
-  linter.style.indenting
+  linter.style.indentation
   -- The `docPrime` linter is disabled: https://github.com/leanprover-community/mathlib4/issues/20560
 
 -- Check that all linter options mentioned in the mathlib standard linter set exist.

--- a/Mathlib/ModelTheory/Algebra/Ring/Basic.lean
+++ b/Mathlib/ModelTheory/Algebra/Ring/Basic.lean
@@ -53,6 +53,7 @@ inductive ringFunc : ℕ → Type
   | one : ringFunc 0
   deriving DecidableEq
 
+set_option linter.style.indentation false in -- TODO: disable on deriving indentation
 /-- The language of rings contains the operations (+,*,-,0,1) -/
 def Language.ring : Language :=
   { Functions := ringFunc

--- a/Mathlib/ModelTheory/Arithmetic/Presburger/Basic.lean
+++ b/Mathlib/ModelTheory/Arithmetic/Presburger/Basic.lean
@@ -34,6 +34,7 @@ inductive presburgerFunc : ℕ → Type
   | add : presburgerFunc 2
   deriving DecidableEq
 
+set_option linter.style.indentation false in -- TODO: disable on deriving indentation
 /-- The language of Presburger arithmetic, defined as (0, 1, +). -/
 def Language.presburger : Language :=
   { Functions := presburgerFunc

--- a/Mathlib/ModelTheory/Basic.lean
+++ b/Mathlib/ModelTheory/Basic.lean
@@ -67,6 +67,7 @@ abbrev IsRelational : Prop := ∀ n, IsEmpty (L.Functions n)
 /-- A language is algebraic when it has no relation symbols. -/
 abbrev IsAlgebraic : Prop := ∀ n, IsEmpty (L.Relations n)
 
+set_option linter.style.indentation false in -- TODO: disable on deriving indentation
 /-- The empty language has no symbols. -/
 protected def empty : Language := ⟨fun _ => Empty, fun _ => Empty⟩
   deriving IsAlgebraic, IsRelational

--- a/Mathlib/ModelTheory/Graph.lean
+++ b/Mathlib/ModelTheory/Graph.lean
@@ -41,6 +41,7 @@ inductive graphRel : ℕ → Type
   | adj : graphRel 2
   deriving DecidableEq
 
+set_option linter.style.indentation false in -- TODO: disable on deriving indentation
 /-- The language consisting of a single relation representing adjacency. -/
 protected def graph : Language := ⟨fun _ => Empty, graphRel⟩
   deriving IsRelational

--- a/Mathlib/ModelTheory/Order.lean
+++ b/Mathlib/ModelTheory/Order.lean
@@ -67,6 +67,7 @@ inductive orderRel : ℕ → Type
   | le : orderRel 2
   deriving DecidableEq
 
+set_option linter.style.indentation false in -- TODO: disable on deriving indentation
 /-- The relational language consisting of a single relation representing `≤`. -/
 protected def order : Language := ⟨fun _ => Empty, orderRel⟩
   deriving IsRelational

--- a/Mathlib/Util/Notation3.lean
+++ b/Mathlib/Util/Notation3.lean
@@ -111,6 +111,7 @@ structure MatchState where
   `foldl` and `foldr` expressions. For `foldl`, the arrays are stored in reverse order. -/
   foldState : Std.HashMap Name (Array Term)
 
+set_option linter.style.indentation false in -- TODO: disable on deriving indentation
 /-- A matcher is a delaboration function that transforms `MatchState`s. -/
 def Matcher := MatchState → DelabM MatchState
   deriving Inhabited


### PR DESCRIPTION
---

Trying out the changes in #27525.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
