### PR TITLE
chore(gcongr): clean up imports

### DIFF
--- a/Archive/Imo/Imo2019Q4.lean
+++ b/Archive/Imo/Imo2019Q4.lean
@@ -7,7 +7,6 @@ import Mathlib.Data.Nat.Factorial.BigOperators
 import Mathlib.Data.Nat.Multiplicity
 import Mathlib.Data.Nat.Prime.Int
 import Mathlib.Tactic.IntervalCases
-import Mathlib.Tactic.GCongr
 
 /-!
 # IMO 2019 Q4

--- a/Mathlib/Algebra/ContinuedFractions/Computation/ApproximationCorollaries.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Computation/ApproximationCorollaries.lean
@@ -6,7 +6,6 @@ Authors: Kevin Kappelmann
 import Mathlib.Algebra.ContinuedFractions.Computation.Approximations
 import Mathlib.Algebra.ContinuedFractions.ConvergentsEquiv
 import Mathlib.Algebra.Order.Archimedean.Basic
-import Mathlib.Tactic.GCongr
 import Mathlib.Topology.Order.LeftRightNhds
 
 /-!

--- a/Mathlib/Algebra/ContinuedFractions/Computation/Approximations.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Computation/Approximations.lean
@@ -8,7 +8,6 @@ import Mathlib.Algebra.ContinuedFractions.Computation.CorrectnessTerminating
 import Mathlib.Algebra.Order.Ring.Basic
 import Mathlib.Data.Nat.Fib.Basic
 import Mathlib.Tactic.Monotonicity
-import Mathlib.Tactic.GCongr
 
 /-!
 # Approximations for Continued Fraction Computations (`GenContFract.of`)

--- a/Mathlib/Algebra/MvPolynomial/SchwartzZippel.lean
+++ b/Mathlib/Algebra/MvPolynomial/SchwartzZippel.lean
@@ -11,7 +11,6 @@ import Mathlib.Algebra.Order.Ring.Finset
 import Mathlib.Algebra.Polynomial.Roots
 import Mathlib.Data.Fin.Tuple.Finset
 import Mathlib.Tactic.Positivity.Finset
-import Mathlib.Tactic.GCongr
 
 /-!
 # The Schwartz-Zippel lemma

--- a/Mathlib/Algebra/Order/BigOperators/Expect.lean
+++ b/Mathlib/Algebra/Order/BigOperators/Expect.lean
@@ -8,7 +8,6 @@ import Mathlib.Algebra.Module.Rat
 import Mathlib.Algebra.Order.BigOperators.Ring.Finset
 import Mathlib.Algebra.Order.Module.Field
 import Mathlib.Algebra.Order.Module.Rat
-import Mathlib.Tactic.GCongr
 
 /-!
 # Order properties of the average over a finset

--- a/Mathlib/Algebra/Order/CauSeq/Basic.lean
+++ b/Mathlib/Algebra/Order/CauSeq/Basic.lean
@@ -10,7 +10,6 @@ import Mathlib.Algebra.Order.Group.MinMax
 import Mathlib.Algebra.Ring.Pi
 import Mathlib.Data.Setoid.Basic
 import Mathlib.GroupTheory.GroupAction.Ring
-import Mathlib.Tactic.GCongr
 
 /-!
 # Cauchy sequences

--- a/Mathlib/Algebra/Order/Chebyshev.lean
+++ b/Mathlib/Algebra/Order/Chebyshev.lean
@@ -6,7 +6,6 @@ Authors: Mantas Bakšys, Yaël Dillies
 import Mathlib.Algebra.Order.Monovary
 import Mathlib.Algebra.Order.Rearrangement
 import Mathlib.GroupTheory.Perm.Cycle.Basic
-import Mathlib.Tactic.GCongr
 import Mathlib.Tactic.Positivity
 
 /-!

--- a/Mathlib/Analysis/Convex/Segment.lean
+++ b/Mathlib/Analysis/Convex/Segment.lean
@@ -8,7 +8,6 @@ import Mathlib.Algebra.Order.Module.OrderedSMul
 import Mathlib.LinearAlgebra.AffineSpace.Midpoint
 import Mathlib.LinearAlgebra.LinearIndependent.Lemmas
 import Mathlib.LinearAlgebra.Ray
-import Mathlib.Tactic.GCongr
 
 /-!
 # Segments in vector spaces

--- a/Mathlib/Analysis/Convex/Star.lean
+++ b/Mathlib/Analysis/Convex/Star.lean
@@ -7,7 +7,6 @@ import Mathlib.Algebra.GroupWithZero.Action.Pointwise.Set
 import Mathlib.Algebra.Module.LinearMap.Prod
 import Mathlib.Algebra.Order.Module.Synonym
 import Mathlib.Analysis.Convex.Segment
-import Mathlib.Tactic.GCongr
 import Mathlib.Tactic.Module
 
 /-!

--- a/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
+++ b/Mathlib/Combinatorics/Additive/PluenneckeRuzsa.lean
@@ -6,7 +6,6 @@ Authors: Yaël Dillies, George Shakan
 import Mathlib.Algebra.Order.Field.Rat
 import Mathlib.Combinatorics.Enumerative.DoubleCounting
 import Mathlib.Tactic.FieldSimp
-import Mathlib.Tactic.GCongr
 import Mathlib.Tactic.Positivity
 import Mathlib.Tactic.Ring
 import Mathlib.Algebra.Group.Pointwise.Finset.Basic

--- a/Mathlib/Combinatorics/Enumerative/Catalan.lean
+++ b/Mathlib/Combinatorics/Enumerative/Catalan.lean
@@ -7,7 +7,6 @@ import Mathlib.Algebra.BigOperators.Fin
 import Mathlib.Algebra.BigOperators.NatAntidiagonal
 import Mathlib.Data.Nat.Choose.Central
 import Mathlib.Tactic.FieldSimp
-import Mathlib.Tactic.GCongr
 import Mathlib.Tactic.Positivity
 
 /-!

--- a/Mathlib/Combinatorics/SetFamily/FourFunctions.lean
+++ b/Mathlib/Combinatorics/SetFamily/FourFunctions.lean
@@ -13,7 +13,6 @@ import Mathlib.Order.Booleanisation
 import Mathlib.Order.Sublattice
 import Mathlib.Tactic.Positivity.Basic
 import Mathlib.Tactic.Ring
-import Mathlib.Tactic.GCongr
 
 /-!
 # The four functions theorem and corollaries

--- a/Mathlib/Combinatorics/SimpleGraph/Density.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Density.lean
@@ -7,7 +7,6 @@ import Mathlib.Algebra.Order.Field.Basic
 import Mathlib.Combinatorics.SimpleGraph.Basic
 import Mathlib.Data.Rat.Cast.Order
 import Mathlib.Order.Partition.Finpartition
-import Mathlib.Tactic.GCongr
 import Mathlib.Tactic.NormNum
 import Mathlib.Tactic.Positivity
 import Mathlib.Tactic.Ring

--- a/Mathlib/Combinatorics/SimpleGraph/Triangle/Basic.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Triangle/Basic.lean
@@ -8,7 +8,6 @@ import Mathlib.Algebra.Order.Ring.Abs
 import Mathlib.Combinatorics.Enumerative.DoubleCounting
 import Mathlib.Combinatorics.SimpleGraph.Clique
 import Mathlib.Data.Finset.Sym
-import Mathlib.Tactic.GCongr
 import Mathlib.Tactic.Positivity
 
 /-!

--- a/Mathlib/Data/Nat/Basic.lean
+++ b/Mathlib/Data/Nat/Basic.lean
@@ -6,7 +6,7 @@ Authors: Floris van Doorn, Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 import Mathlib.Data.Nat.Init
 import Mathlib.Logic.Nontrivial.Defs
 import Mathlib.Tactic.Contrapose
-import Mathlib.Tactic.GCongr
+import Mathlib.Tactic.GCongr.CoreAttrs
 import Mathlib.Tactic.GRewrite
 import Mathlib.Util.AssertExists
 

--- a/Mathlib/Data/Nat/Basic.lean
+++ b/Mathlib/Data/Nat/Basic.lean
@@ -6,7 +6,8 @@ Authors: Floris van Doorn, Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 import Mathlib.Data.Nat.Init
 import Mathlib.Logic.Nontrivial.Defs
 import Mathlib.Tactic.Contrapose
-import Mathlib.Tactic.GCongr.Core
+import Mathlib.Tactic.GCongr
+import Mathlib.Tactic.GRewrite
 import Mathlib.Util.AssertExists
 
 /-!

--- a/Mathlib/NumberTheory/FLT/Polynomial.lean
+++ b/Mathlib/NumberTheory/FLT/Polynomial.lean
@@ -8,7 +8,6 @@ import Mathlib.Algebra.GroupWithZero.Defs
 import Mathlib.NumberTheory.FLT.Basic
 import Mathlib.NumberTheory.FLT.MasonStothers
 import Mathlib.RingTheory.Polynomial.Content
-import Mathlib.Tactic.GCongr
 
 /-!
 # Fermat's Last Theorem for polynomials over a field

--- a/Mathlib/NumberTheory/FermatPsp.lean
+++ b/Mathlib/NumberTheory/FermatPsp.lean
@@ -6,7 +6,6 @@ Authors: Niels Voss
 import Mathlib.Algebra.Order.Archimedean.Basic
 import Mathlib.FieldTheory.Finite.Basic
 import Mathlib.Order.Filter.Cofinite
-import Mathlib.Tactic.GCongr
 
 /-!
 # Fermat Pseudoprimes

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -6,7 +6,7 @@ Authors: Jeremy Avigad, Mario Carneiro
 import Mathlib.Data.Subtype
 import Mathlib.Order.Defs.LinearOrder
 import Mathlib.Order.Notation
-import Mathlib.Tactic.GCongr
+import Mathlib.Tactic.GCongr.CoreAttrs
 import Mathlib.Tactic.GRewrite
 import Mathlib.Tactic.Spread
 import Mathlib.Tactic.Convert

--- a/Mathlib/Order/Basic.lean
+++ b/Mathlib/Order/Basic.lean
@@ -6,7 +6,8 @@ Authors: Jeremy Avigad, Mario Carneiro
 import Mathlib.Data.Subtype
 import Mathlib.Order.Defs.LinearOrder
 import Mathlib.Order.Notation
-import Mathlib.Tactic.GCongr.Core
+import Mathlib.Tactic.GCongr
+import Mathlib.Tactic.GRewrite
 import Mathlib.Tactic.Spread
 import Mathlib.Tactic.Convert
 import Mathlib.Tactic.Inhabit

--- a/Mathlib/Order/Filter/AtTopBot/Archimedean.lean
+++ b/Mathlib/Order/Filter/AtTopBot/Archimedean.lean
@@ -6,7 +6,6 @@ Authors: Johannes Hölzl, Yury Kudryashov
 import Mathlib.Algebra.Order.Archimedean.Basic
 import Mathlib.Order.Filter.AtTopBot.Group
 import Mathlib.Order.Filter.CountablyGenerated
-import Mathlib.Tactic.GCongr
 
 /-!
 # `Filter.atTop` filter and archimedean (semi)rings/fields

--- a/Mathlib/Tactic/GCongr/CoreAttrs.lean
+++ b/Mathlib/Tactic/GCongr/CoreAttrs.lean
@@ -29,8 +29,8 @@ attribute [gcongr] mt
   And.imp And.imp_left GCongr.and_right_mono
   imp_imp_imp GCongr.imp_trans GCongr.imp_right_mono
   forall_imp Exists.imp
-  List.Sublist.append List.Sublist.append_left List.Sublist.append_right
-  List.Sublist.reverse List.drop_sublist_drop_left List.Sublist.drop
-  List.Perm.append_left List.Perm.append_right List.Perm.append List.Perm.map
+
+  List.Sublist.append List.Sublist.reverse List.drop_sublist_drop_left List.Sublist.drop
+  List.Perm.append List.Perm.map
 
 end Mathlib.Tactic.GCongr

--- a/Mathlib/Topology/EMetricSpace/Paracompact.lean
+++ b/Mathlib/Topology/EMetricSpace/Paracompact.lean
@@ -3,7 +3,6 @@ Copyright (c) 2021 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import Mathlib.Tactic.GCongr
 import Mathlib.Topology.Compactness.Paracompact
 import Mathlib.Topology.EMetricSpace.Basic
 import Mathlib.SetTheory.Cardinal.Order


### PR DESCRIPTION
This PR removes redundant `gcongr` imports. And when we do import `gcongr`, we now also import the core `@[gcongr]` tags, and also `grw`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
