### PR TITLE
[Merged by Bors] - chore(Algebra/Group): update the "slow-failing instance priority" note

### DIFF
--- a/Mathlib/Algebra/Group/Conj.lean
+++ b/Mathlib/Algebra/Group/Conj.lean
@@ -164,38 +164,25 @@ theorem map_surjective {f : α →* β} (hf : Function.Surjective f) :
   obtain ⟨a, rfl⟩ := hf b
   exact ⟨ConjClasses.mk a, rfl⟩
 
--- Porting note: This has not been adapted to mathlib4, is it still accurate?
 library_note "slow-failing instance priority"/--
 Certain instances trigger further searches when they are considered as candidate instances;
 these instances should be assigned a priority lower than the default of 1000 (for example, 900).
 
 The conditions for this rule are as follows:
 * a class `C` has instances `instT : C T` and `instT' : C T'`
-* types `T` and `T'` are both specializations of another type `S`
+* types `T` and `T'` are both reducible specializations of another type `S`
 * the parameters supplied to `S` to produce `T` are not (fully) determined by `instT`,
   instead they have to be found by instance search
 If those conditions hold, the instance `instT` should be assigned lower priority.
 
-For example, suppose the search for an instance of `DecidableEq (Multiset α)` tries the
-candidate instance `Con.quotient.decidableEq (c : Con M) : decidableEq c.quotient`.
-Since `Multiset` and `Con.quotient` are both quotient types, unification will check
-that the relations `List.perm` and `c.toSetoid.r` unify. However, `c.toSetoid` depends on
-a `Mul M` instance, so this unification triggers a search for `Mul (List α)`;
-this will traverse all subclasses of `Mul` before failing.
-On the other hand, the search for an instance of `DecidableEq (Con.quotient c)` for `c : Con M`
-can quickly reject the candidate instance `Multiset.decidableEq` because the type of
-`List.perm : List ?m_1 → List ?m_1 → Prop` does not unify with `M → M → Prop`.
-Therefore, we should assign `Con.quotient.decidableEq` a lower priority because it fails slowly.
-(In terms of the rules above, `C := DecidableEq`, `T := Con.quotient`,
-`instT := Con.quotient.decidableEq`, `T' := Multiset`, `instT' := Multiset.decidableEq`,
-and `S := Quot`.)
+Note that there is no issue unless `T` and `T'` are reducibly equal to `S`, Otherwise the instance
+discrimination tree can distinguish them, and the note does not apply.
 
 If the type involved is a free variable (rather than an instantiation of some type `S`),
 the instance priority should be even lower, see Note [lower instance priority].
 -/
 
--- see Note [slow-failing instance priority]
-instance (priority := 900) [DecidableRel (IsConj : α → α → Prop)] : DecidableEq (ConjClasses α) :=
+instance [DecidableRel (IsConj : α → α → Prop)] : DecidableEq (ConjClasses α) :=
   inferInstanceAs <| DecidableEq <| Quotient (IsConj.setoid α)
 
 end Monoid


### PR DESCRIPTION
This note needed to be updated for Lean 4. The issue is a lot less important since the discrimination tree will see that e.g. `Multiset` and `Con` are not the same.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
