### PR TITLE
feat(Geometry/Euclidean/Centroid): define centroid and medians for simplices

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3696,6 +3696,7 @@ import Mathlib.Geometry.Euclidean.Angle.Unoriented.Conformal
 import Mathlib.Geometry.Euclidean.Angle.Unoriented.CrossProduct
 import Mathlib.Geometry.Euclidean.Angle.Unoriented.RightAngle
 import Mathlib.Geometry.Euclidean.Basic
+import Mathlib.Geometry.Euclidean.Centroid
 import Mathlib.Geometry.Euclidean.Circumcenter
 import Mathlib.Geometry.Euclidean.Congruence
 import Mathlib.Geometry.Euclidean.Incenter

--- a/Mathlib/Algebra/AddTorsor/Basic.lean
+++ b/Mathlib/Algebra/AddTorsor/Basic.lean
@@ -76,6 +76,10 @@ theorem vsub_sub_vsub_cancel_left (p₁ p₂ p₃ : P) : p₃ -ᵥ p₂ - (p₃ 
 theorem vadd_vsub_vadd_cancel_left (v : G) (p₁ p₂ : P) : (v +ᵥ p₁) -ᵥ (v +ᵥ p₂) = p₁ -ᵥ p₂ := by
   rw [vsub_vadd_eq_vsub_sub, vadd_vsub_assoc, add_sub_cancel_left]
 
+theorem vadd_vsub_vadd (v₁ v₂ : G) (p₁ p₂ : P) : (v₁ +ᵥ p₁) -ᵥ (v₂ +ᵥ p₂) = (v₁ - v₂)
+    + (p₁ -ᵥ p₂) := by
+  rw [vsub_vadd_eq_vsub_sub, vadd_vsub_assoc, add_sub_assoc, ← add_comm_sub]
+
 theorem vsub_vadd_comm (p₁ p₂ p₃ : P) : (p₁ -ᵥ p₂ : G) +ᵥ p₃ = (p₃ -ᵥ p₂) +ᵥ p₁ := by
   rw [← @vsub_eq_zero_iff_eq G, vadd_vsub_assoc, vsub_vadd_eq_vsub_sub]
   simp

--- a/Mathlib/Geometry/Euclidean/Centroid.lean
+++ b/Mathlib/Geometry/Euclidean/Centroid.lean
@@ -10,24 +10,29 @@ import Mathlib.Analysis.Normed.Affine.Convex
 /-!
 # Centroid and median of a simplex
 
-This file proves some lemmas involving centroids and medians of a simplex in affine space.
-The definitions of centroid is based on `Finset.univ.centroid` of a set of points,
-we use Simplex.centroid for abbreviation. This file also define the `faceOppositeCentroid`
-of a simplex, which is the centroid of the simplex with one vertex removed (centroid of the facet).
-The relations between the centroid, faceOppositeCentroid, and the vertices of a simplex are
-also proved in this file.  *Commandino's theorem* for n dimension simplex, the centroid lies one the
-median with ratio of n : 1. The median of a simplex is defined as the line through a vertex and the
-corresponding faceOppositeCentroid.
+This file proves several lemmas involving the centroids and medians of a simplex in affine space.
+The definition of the centroid is based on `Finset.univ.centroid` applied to the set of vertices.
+For convenience, we use `Simplex.centroid` as an abbreviation.
+
+This file also defines `faceOppositeCentroid`, which is the centroid of the facet of the simplex
+obtained by removing one vertex.
+
+We prove several relations among the centroid, the faceOppositeCentroid, and the vertices of
+the simplex. In particular, we prove a version of *Commandino's theorem* in arbitrary dimensions:
+the centroid lies on each median, dividing it in a ratio of `n : 1`, where `n` is the dimension
+of the simplex.
+
+The median of a simplex is defined as the line connecting a vertex to the corresponding
+faceOppositeCentroid.
 
 ## Main definitions
 
-* `centroid` is the centroid of a simplex, use the defnition of `Finset.univ.centroid` for a set of points.
-This is a abbreviation for convenience.
+* `centroid`: the centroid of a simplex, defined via `Finset.univ.centroid` on its vertices.
 
-* `faceOppositeCentroid` is the centroid of the simplex with one vertex removed.
+* `faceOppositeCentroid` is the centroid of the facet obtained by removing one vertex from the
+simplex.
 
-* `median` is the line through a vertex and the corresponding faceOppositeCentroid.
-
+* `median` is the line connecting a vertex to the corresponding faceOppositeCentroid.
 ## References
 
 * https://en.wikipedia.org/wiki/Median_(geometry)
@@ -49,26 +54,19 @@ variable [Module k V]
 variable [AffineSpace V P]
 variable {n : ℕ}
 
-variable {ι : Type*}
-
-lemma AffineIndependent.eq_zero_of_affineCombination_mem_affineSpan {p : ι → P}
-    (ha : AffineIndependent k p) {fs : Finset ι} {w : ι → k} (hw : ∑ i ∈ fs, w i = 1) {s : Set ι}
-    (hm : fs.affineCombination k p w ∈ affineSpan k (p '' s)) {i : ι} (hifs : i ∈ fs)
-    (his : i ∉ s) : w i = 0 := by
-  sorry
-
 /-- Centroid is an affineCombination of the points in simplex with centroid weight. -/
 abbrev centroid (t : Affine.Simplex k P n) : P := Finset.univ.centroid k t.points
 
-/-- The  -/
-theorem centroid_mem_affineSpan_range [CharZero k] {n : ℕ} (s : Simplex k P n) :
+/-- The centroid in the affine span. -/
+theorem centroid_mem_affineSpan [CharZero k] {n : ℕ} (s : Simplex k P n) :
     s.centroid ∈ affineSpan k (Set.range s.points) :=
   centroid_mem_affineSpan_of_card_eq_add_one k _ (card_fin (n + 1))
 
+/-- The centroid is equal to the affine combination of points with weights. -/
 theorem centroid_eq_affine_combination (s : Simplex k P n) :
-    s.centroid = affineCombination k univ s.points (centroidWeights k univ) := by
-  rw [centroid, Finset.centroid_def]
+    s.centroid = affineCombination k univ s.points (centroidWeights k univ) := by rfl
 
+/-- The centroid is not lies in the affine span of simplex points remove one. -/
 theorem centroid_not_mem_affineSpan_compl [CharZero k] (s : Simplex k P n) (i : Fin (n + 1)) :
     s.centroid ∉ affineSpan k (s.points '' {i}ᶜ) := by
   intro h
@@ -88,6 +86,7 @@ theorem centroid_not_mem_affineSpan_compl [CharZero k] (s : Simplex k P n) (i : 
   field_simp at h1
   norm_cast at h1
 
+/-- The vector from any point to the centroid is the average of vectors to the simplex vertices. -/
 theorem centroid_vsub_eq {n : ℕ} [CharZero k] (s : Simplex k P n) (p : P) :
     s.centroid -ᵥ p = ((1:k) / (n + 1)) • ∑ x, (s.points x -ᵥ p) := by
   rw [centroid, Finset.centroid_def]
@@ -96,10 +95,11 @@ theorem centroid_vsub_eq {n : ℕ} [CharZero k] (s : Simplex k P n) (p : P) :
     Nat.cast_add, Nat.cast_one, vadd_vsub, one_div,←smul_sum]
   · field_simp; exact div_self (by norm_cast)
 
+/-- The vector from a vertex to the centroid equals the average of vertex-to-vertex vectors. -/
 theorem centroid_vsub_point_eq_smul_sum_vsub {n : ℕ} [CharZero k] (s : Simplex k P n)
     (i : Fin (n + 1)) :
-    s.centroid -ᵥ s.points i = ((1:k) / (n + 1)) • ∑ x, (s.points x -ᵥ s.points i) := by
-  exact centroid_vsub_eq s (s.points i)
+    s.centroid -ᵥ s.points i = ((1:k) / (n + 1)) • ∑ x, (s.points x -ᵥ s.points i) :=
+  centroid_vsub_eq s (s.points i)
 
 theorem centroid_eq_smul_sum_vsub_vadd [CharZero k] (s : Simplex k P n) (i : Fin (n + 1)) :
     s.centroid = ((1:k) / (n + 1)) • ∑ x, (s.points x -ᵥ s.points i) +ᵥ s.points i := by
@@ -112,6 +112,7 @@ theorem smul_centroid_vsub_point_eq_sum_vsub [CharZero k] (s : Simplex k P n)
   field_simp
   rw [div_self (by norm_cast), one_smul]
 
+/-- The sum of vectors from the centroid to each vertex is zero. -/
 theorem centroid_weighted_vsub_eq_zero [CharZero k] (s : Simplex k P n) :
     ∑ i, (s.points i -ᵥ s.centroid) = 0 := by
   have h := centroid_vsub_eq s s.centroid
@@ -120,6 +121,7 @@ theorem centroid_weighted_vsub_eq_zero [CharZero k] (s : Simplex k P n) :
   rw [smul_eq_zero_iff_right (by exact inv_ne_zero (by norm_cast))] at h
   exact h
 
+/-- A point is centroid if and only if the sum of vectors from the point to all vertices is zero. -/
 theorem centroid_iff_sum_vsub_eq_zero [CharZero k] (s : Simplex k P n) (p : P) :
     p = s.centroid ↔ ∑ i, (s.points i -ᵥ p) = 0 := by
   constructor
@@ -143,6 +145,7 @@ variable [NeZero n]
 def faceOppositeCentroid (s : Affine.Simplex k P n) (i : Fin (n + 1)) : P :=
     (s.faceOpposite i).centroid
 
+/-- The faceOppositeCentroid lies in the affine span of all simplex vertices. -/
 theorem faceOppositeCentroid_mem_affineSpan [CharZero k] (s : Simplex k P n) (i : Fin (n + 1)) :
     s.faceOppositeCentroid i ∈ affineSpan k (Set.range s.points) := by
   unfold faceOppositeCentroid
@@ -151,8 +154,10 @@ theorem faceOppositeCentroid_mem_affineSpan [CharZero k] (s : Simplex k P n) (i 
     rcases hj with ⟨k, _, rfl⟩
     apply Set.mem_range_self
   apply affineSpan_mono _ h
-  exact centroid_mem_affineSpan_range (s.faceOpposite i)
+  exact centroid_mem_affineSpan (s.faceOpposite i)
 
+/-- The faceOppositeCentroid is the affine combination of the complement vertices with equal weights
+  1/n. -/
 theorem faceOppositeCentroid_eq_affineCombination (s : Affine.Simplex k P n) (i : Fin (n + 1)) :
     s.faceOppositeCentroid i = ((affineCombination k {i}ᶜ s.points) fun _ ↦ (↑n)⁻¹) := by
   unfold faceOppositeCentroid
@@ -163,6 +168,8 @@ theorem faceOppositeCentroid_eq_affineCombination (s : Affine.Simplex k P n) (i 
   simp only [Fintype.card_fin, card_singleton, add_tsub_cancel_right]
   rfl
 
+/-- The vector from a vertex to the faceOppositeCentroid equals the average of vertex-to-vertex
+displacements. -/
 theorem faceOppositeCentroid_vsub_point_eq_smul_sum_vsub [CharZero k] (s : Affine.Simplex k P n)
     (i : Fin (n + 1)) :
     s.faceOppositeCentroid i -ᵥ (s.points i) = (n : k)⁻¹ • ∑ x, (s.points x -ᵥ s.points i) := by
@@ -182,11 +189,14 @@ theorem faceOppositeCentroid_vsub_point_eq_smul_sum_vsub [CharZero k] (s : Affin
   rw [div_self]
   exact NeZero.ne (n:k)
 
+/-- The faceOppositeCentroid equals the average displacement from a vertex plus that vertex. -/
 theorem faceOppositeCentroid_eq_sum_vsub_vadd [CharZero k] (s : Affine.Simplex k P n)
     (i : Fin (n + 1)) :
     s.faceOppositeCentroid i = (n:k)⁻¹ • ∑ x, (s.points x -ᵥ s.points i) +ᵥ (s.points i) := by
   rw [←faceOppositeCentroid_vsub_point_eq_smul_sum_vsub s i, vsub_vadd]
 
+/-- The vector from a vertex to its faceOppositeCentroid equals the average of reversed
+displacements. -/
 theorem point_vsub_faceOppositeCentroid_eq_smul_sum_vsub [CharZero k] (s : Affine.Simplex k P n)
     (i : Fin (n + 1)) :
     s.points i -ᵥ s.faceOppositeCentroid i = (n : k)⁻¹ • ∑ x, (s.points i -ᵥ s.points x) := by
@@ -207,18 +217,14 @@ theorem smul_centroid_vsub_point_eq_smul_faceOppositeCentroid_vsub_point [CharZe
   rw [smul_faceOppositeCentroid_vsub_point_eq_sum_vsub s i,
     smul_centroid_vsub_point_eq_sum_vsub s i]
 
-theorem vadd_vsub_vadd_eq (v1 v2 : V) (p1 p2 : P) : (v1 +ᵥ p1) -ᵥ (v2 +ᵥ p2) = (v1 -ᵥ v2)
-    +ᵥ (p1 -ᵥ p2) := by
-  rw [vsub_vadd_eq_vsub_sub]
-  field_simp
-  rw [sub_add_comm,add_comm, ←add_sub_assoc, vadd_vsub_assoc]
-
+/-- The vector between two faceOppositeCentroids equals `n⁻¹` times the vector between the
+corresponding vertices. -/
 theorem faceOppositeCentroid_vsub_faceOppositeCentroid [CharZero k] (s : Affine.Simplex k P n)
     (i j : Fin (n + 1)) :
     s.faceOppositeCentroid i -ᵥ s.faceOppositeCentroid j =
     (n : k)⁻¹ • (s.points j -ᵥ s.points i) := by
   rw [faceOppositeCentroid_eq_sum_vsub_vadd s i, faceOppositeCentroid_eq_sum_vsub_vadd s j,
-    vadd_vsub_vadd_eq _ _ (s.points i) (s.points j)]
+    vadd_vsub_vadd _ _ (s.points i) (s.points j)]
   have h1 (i : Fin (n+1)): ∑ x,  (s.points x -ᵥ s.points i) = ∑ x,  (s.points x -ᵥ s.points 0
       - (s.points i-ᵥ s.points 0)) :=by
    apply sum_congr rfl
@@ -237,6 +243,8 @@ theorem faceOppositeCentroid_vsub_faceOppositeCentroid [CharZero k] (s : Affine.
     rw [one_div]
   rw [this, smul_smul, inv_eq_one_div, one_div_mul_cancel (NeZero.ne (n : k)), one_smul]
 
+/-- The vector from a vertex to its faceOppositeCentroid is `(n+1)` times the vector from the
+centroid to that faceOppositeCentroid. -/
 theorem faceOppositeCentroid_vsub_point_eq_smul_vsub [CharZero k] (s : Simplex k P n)
     (i : Fin (n + 1)) :
     s.faceOppositeCentroid i -ᵥ s.points i =
@@ -256,7 +264,8 @@ theorem point_vsub_faceOppositeCentroid_eq_smul_vsub [CharZero k] (s : Simplex k
   rw [← neg_vsub_eq_vsub_rev, faceOppositeCentroid_vsub_point_eq_smul_vsub, ← neg_smul,
     ← neg_smul_neg, neg_vsub_eq_vsub_rev, neg_neg]
 
-/-- Commandino's theorem -/
+/-- * Commandino's theorem * : For n-dimension simplex, the vector from a vertex to the centroid
+equals n times the vector from the centroid to the corresponding faceOppositeCentroid. -/
 theorem point_vsub_centroid_eq_smul_vsub [CharZero k]
     (s : Simplex k P n) (i : Fin (n + 1)) :
     s.points i -ᵥ s.centroid = (n : k) • (s.centroid -ᵥ s.faceOppositeCentroid i)  := by
@@ -294,18 +303,22 @@ theorem collinear_point_centroid_faceOppositeCentroid [CharZero k] (s : Simplex 
   rw [point_eq_smul_vsub_vadd_centroid]
   exact smul_vsub_vadd_mem_affineSpan_pair _ _ _
 
-/-- Define median as an line throught the point of simplex and corosponed faceOppositeCentroid. -/
+/-- The median of a simplex is the line through a vertex and its corresponding faceOppositeCentroid.
+-/
 def median (s : Simplex k P n) (i : Fin (n + 1)) : AffineSubspace k P :=
   line[k, s.points i, s.faceOppositeCentroid i]
 
+/-- The faceOppositeCentroid lines on the median through the corresponding vertex. -/
 theorem faceOppositeCentroid_mem_median (s : Simplex k P n) (i : Fin (n + 1)) :
     s.faceOppositeCentroid i ∈ s.median i := by
   simp [median, right_mem_affineSpan_pair]
 
+/-- A vertex lies on its median. -/
 theorem point_mem_median (s : Simplex k P n) (i : Fin (n + 1)) :
     s.points i ∈ s.median i := by
   simp [median, left_mem_affineSpan_pair]
 
+/-- The centroid lies on the median from any vertex. -/
 theorem centroid_mem_median [CharZero k] (s : Simplex k P n) (i : Fin (n + 1)) :
   s.centroid ∈ s.median i := by
   rw [median]
@@ -317,6 +330,7 @@ theorem centroid_mem_median [CharZero k] (s : Simplex k P n) (i : Fin (n + 1)) :
   rw [h]
   exact smul_vsub_vadd_mem_affineSpan_pair _ _ _
 
+/-- The median through a vertex is the same affine span of that vertex and the centroid. -/
 theorem median_eq_affineSpan_point_centroid [CharZero k] (s : Simplex k P n) (i : Fin (n + 1)) :
     s.median i = affineSpan k {s.points i, s.centroid} := by
   have h1 : s.median i ≤ affineSpan k {s.points i, s.centroid} := by
@@ -335,19 +349,7 @@ theorem median_eq_affineSpan_point_centroid [CharZero k] (s : Simplex k P n) (i 
     exact centroid_mem_median s i
   exact le_antisymm h1 h2
 
-theorem mem_median_eq_linemap [CharZero k] (s : Simplex k P n) (i : Fin (n + 1))
-    {p : P} (h : p ∈ s.median i) :
-    ∃ (r : k),
-    p = AffineMap.lineMap (s.faceOppositeCentroid i) (s.points i) r := by
-  rw [median] at h
-  set v := p -ᵥ s.faceOppositeCentroid i
-  have hp: p = v +ᵥ s.faceOppositeCentroid i := by rw [vsub_vadd]
-  rw [hp, vadd_right_mem_affineSpan_pair] at h
-  choose r hr using h
-  use r
-  rw [AffineMap.lineMap_apply, hr]
-  simp_rw [hp]
-
+/-- Replacing any vertex of a simplex with its centroid yields an affine independent set. -/
 theorem affineIndependent_centroid_replace_point [CharZero k] [NeZero n] (s : Simplex k P n)
     (i : Fin (n + 1)) : AffineIndependent k fun x => if x = i then s.centroid else s.points x := by
   set p : Fin (n + 1) → P := fun x => if x = i then s.centroid else s.points x with hp
@@ -422,7 +424,7 @@ theorem linearIndependent_point_compl_vsub_centroid [CharZero k] (s : Simplex k 
   rw [mem_compl, Finset.notMem_singleton] at hi
   exact hi
 
-/-- The medians of a simplex are concurrent at the centroid of the simplex -/
+/-- The medians of a simplex are concurrent at its centroid. -/
 theorem eq_centroid_of_forall_mem_median [CharZero k] (s : Simplex k P n) {hn : 1 < n} {p : P}
     (h : ∀ i, p ∈ s.median i) : p = s.centroid := by
   rw [←vsub_eq_zero_iff_eq]
@@ -474,10 +476,14 @@ variable {V : Type*} {P : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V
 
 variable {n : ℕ} [NeZero n]
 
+/-- The distance from a vertex to the centroid equals `n` times the distance from the centroid to
+the corresponding faceOppositeCentroid. -/
 theorem dist_point_centroid (s : Simplex ℝ P n) (i : Fin (n + 1)) :
     dist (s.points i) s.centroid = n * dist s.centroid (s.faceOppositeCentroid i) := by
   simp_rw [dist_eq_norm_vsub, s.point_vsub_centroid_eq_smul_vsub i, norm_smul, Real.norm_natCast]
 
+/-- The distance from a vertex to its faceOppositeCentroid equals `(n + 1)` times the distance from
+the centroid to that faceOppositeCentroid. -/
 theorem dist_point_faceOppositeCentroid (s : Simplex ℝ P n) (i : Fin (n + 1)) :
     dist (s.points i) (s.faceOppositeCentroid i) = (n+1)
     * dist s.centroid (s.faceOppositeCentroid i) := by
@@ -496,10 +502,14 @@ open EuclideanGeometry
 variable {V : Type*} {P : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [MetricSpace P]
   [NormedAddTorsor V P]
 
+/-- In a triangle, the distance from a vertex to the centroid equals twice the distance from the
+centroid to the faceOppositeCentroid. -/
 theorem dist_point_centroid (t : Affine.Triangle ℝ P) (i : Fin 3) :
     dist (t.points i) t.centroid = 2 * dist t.centroid (t.faceOppositeCentroid i) := by
   field_simp [EuclideanGeometry.dist_point_centroid]
 
+/-- In a triangle, the distance from a vertex to the faceOppositeCentroid equals three times the
+distance from the centroid to the faceOppositeCentroid. -/
 theorem dist_point_faceOppositeCentroid (t : Affine.Triangle ℝ P) (i : Fin 3) :
     dist (t.points i) (t.faceOppositeCentroid i) = 3 * dist t.centroid (t.faceOppositeCentroid i)
     := by

--- a/Mathlib/Geometry/Euclidean/Centroid.lean
+++ b/Mathlib/Geometry/Euclidean/Centroid.lean
@@ -3,7 +3,10 @@ Copyright (c) 2025 Chu Zheng. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chu Zheng
 -/
-import Mathlib.Geometry.Euclidean.Simplex
+
+import Mathlib.Analysis.InnerProductSpace.Defs
+import Mathlib.Analysis.Normed.Group.AddTorsor
+import Mathlib.LinearAlgebra.AffineSpace.FiniteDimensional
 
 /-!
 # Centroid and median of a simplex
@@ -250,7 +253,7 @@ theorem smul_centroid_vsub_point_eq_smul_faceOppositeCentroid_vsub_point [CharZe
   rw [smul_faceOppositeCentroid_vsub_point_eq_sum_vsub s i,
     smul_centroid_vsub_point_eq_sum_vsub s i]
 
-/-- The vector between two `faceOppositeCentroids` equals `n⁻¹` times the vector between the
+/-- The vector between two `faceOppositeCentroid` equals `n⁻¹` times the vector between the
 corresponding vertices. -/
 theorem faceOppositeCentroid_vsub_faceOppositeCentroid [CharZero k] (s : Affine.Simplex k P n)
     (i j : Fin (n + 1)) :

--- a/Mathlib/Geometry/Euclidean/Centroid.lean
+++ b/Mathlib/Geometry/Euclidean/Centroid.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chu Zheng
 -/
 import Mathlib.Geometry.Euclidean.Simplex
-import Mathlib.Analysis.Convex.Combination
-import Mathlib.Analysis.Normed.Affine.Convex
 
 /-!
 # Centroid and median of a simplex
@@ -44,12 +42,10 @@ namespace Affine
 
 namespace Simplex
 
-open Finset AffineSubspace EuclideanGeometry
+open Finset AffineSubspace
 
 variable {k : Type*} {V : Type*} {P : Type*} [DivisionRing k] [AddCommGroup V] [Module k V]
-[AffineSpace V P]
-
-variable {n : ℕ}
+variable [AffineSpace V P] {n : ℕ}
 
 /-- The centroid of a simplex is the `Finset.centroid` of the set of all its vertices. -/
 abbrev centroid (t : Affine.Simplex k P n) : P := Finset.univ.centroid k t.points

--- a/Mathlib/Geometry/Euclidean/Centroid.lean
+++ b/Mathlib/Geometry/Euclidean/Centroid.lean
@@ -1,0 +1,513 @@
+/-
+Copyright (c) 2025 Joseph Myers. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chu Zheng
+-/
+import Mathlib.Geometry.Euclidean.Simplex
+import Mathlib.Analysis.Convex.Combination
+import Mathlib.Analysis.Normed.Affine.Convex
+
+/-!
+# Centroid and median of a simplex
+
+This file proves some lemmas involving centroids and medians of a simplex in affine space.
+The definitions of centroid is based on `Finset.univ.centroid` of a set of points,
+we use Simplex.centroid for abbreviation. This file also define the `faceOppositeCentroid`
+of a simplex, which is the centroid of the simplex with one vertex removed (centroid of the facet).
+The relations between the centroid, faceOppositeCentroid, and the vertices of a simplex are
+also proved in this file.  *Commandino's theorem* for n dimension simplex, the centroid lies one the
+median with ratio of n : 1. The median of a simplex is defined as the line through a vertex and the
+corresponding faceOppositeCentroid.
+
+## Main definitions
+
+* `centroid` is the centroid of a simplex, use the defnition of `Finset.univ.centroid` for a set of points.
+This is a abbreviation for convenience.
+
+* `faceOppositeCentroid` is the centroid of the simplex with one vertex removed.
+
+* `median` is the line through a vertex and the corresponding faceOppositeCentroid.
+
+## References
+
+* https://en.wikipedia.org/wiki/Median_(geometry)
+* https://en.wikipedia.org/wiki/Commandino%27s_theorem
+
+-/
+
+noncomputable section
+
+namespace Affine
+
+namespace Simplex
+
+open Finset AffineSubspace EuclideanGeometry
+
+variable {k : Type*} {V : Type*} {P : Type*}
+variable [DivisionRing k] [AddCommGroup V]
+variable [Module k V]
+variable [AffineSpace V P]
+variable {n : ℕ}
+
+variable {ι : Type*}
+
+lemma AffineIndependent.eq_zero_of_affineCombination_mem_affineSpan {p : ι → P}
+    (ha : AffineIndependent k p) {fs : Finset ι} {w : ι → k} (hw : ∑ i ∈ fs, w i = 1) {s : Set ι}
+    (hm : fs.affineCombination k p w ∈ affineSpan k (p '' s)) {i : ι} (hifs : i ∈ fs)
+    (his : i ∉ s) : w i = 0 := by
+  sorry
+
+/-- Centroid is an affineCombination of the points in simplex with centroid weight. -/
+abbrev centroid (t : Affine.Simplex k P n) : P := Finset.univ.centroid k t.points
+
+/-- The  -/
+theorem centroid_mem_affineSpan_range [CharZero k] {n : ℕ} (s : Simplex k P n) :
+    s.centroid ∈ affineSpan k (Set.range s.points) :=
+  centroid_mem_affineSpan_of_card_eq_add_one k _ (card_fin (n + 1))
+
+theorem centroid_eq_affine_combination (s : Simplex k P n) :
+    s.centroid = affineCombination k univ s.points (centroidWeights k univ) := by
+  rw [centroid, Finset.centroid_def]
+
+theorem centroid_not_mem_affineSpan_compl [CharZero k] (s : Simplex k P n) (i : Fin (n + 1)) :
+    s.centroid ∉ affineSpan k (s.points '' {i}ᶜ) := by
+  intro h
+  rw [s.centroid_eq_affine_combination] at h
+  set w:= (centroidWeights k (univ: Finset (Fin (n + 1)))) with wdef
+  have hw: ∑ i, w i = 1 := by
+    rw [sum_centroidWeights_eq_one_of_card_ne_zero]
+    simp
+  have hi: i ∈ univ := by simp
+  have hi' : i ∉ ({i}ᶜ : Set (Fin (n+1))) := by simp
+  have h1:= AffineIndependent.eq_zero_of_affineCombination_mem_affineSpan s.independent hw h hi hi'
+  have h2 : w i = (1:k)/(n+1) := by
+    rw [wdef, centroidWeights_apply, card_univ, Fintype.card_fin]
+    simp only [Nat.cast_add, Nat.cast_one]
+    field_simp
+  rw [h2] at h1
+  field_simp at h1
+  norm_cast at h1
+
+theorem centroid_vsub_eq {n : ℕ} [CharZero k] (s : Simplex k P n) (p : P) :
+    s.centroid -ᵥ p = ((1:k) / (n + 1)) • ∑ x, (s.points x -ᵥ p) := by
+  rw [centroid, Finset.centroid_def]
+  rw [affineCombination_eq_weightedVSubOfPoint_vadd_of_sum_eq_one _ _ _ ?_ p]
+  · simp only [weightedVSubOfPoint_apply, centroidWeights_apply, card_univ, Fintype.card_fin,
+    Nat.cast_add, Nat.cast_one, vadd_vsub, one_div,←smul_sum]
+  · field_simp; exact div_self (by norm_cast)
+
+theorem centroid_vsub_point_eq_smul_sum_vsub {n : ℕ} [CharZero k] (s : Simplex k P n)
+    (i : Fin (n + 1)) :
+    s.centroid -ᵥ s.points i = ((1:k) / (n + 1)) • ∑ x, (s.points x -ᵥ s.points i) := by
+  exact centroid_vsub_eq s (s.points i)
+
+theorem centroid_eq_smul_sum_vsub_vadd [CharZero k] (s : Simplex k P n) (i : Fin (n + 1)) :
+    s.centroid = ((1:k) / (n + 1)) • ∑ x, (s.points x -ᵥ s.points i) +ᵥ s.points i := by
+  rw [← centroid_vsub_point_eq_smul_sum_vsub s i, vsub_vadd]
+
+theorem smul_centroid_vsub_point_eq_sum_vsub [CharZero k] (s : Simplex k P n)
+    (i : Fin (n + 1)) :
+    ((n:k) + 1) • (s.centroid -ᵥ s.points i) = ∑ x, (s.points x -ᵥ s.points i) := by
+  rw [centroid_eq_smul_sum_vsub_vadd s i, vadd_vsub, smul_smul]
+  field_simp
+  rw [div_self (by norm_cast), one_smul]
+
+theorem centroid_weighted_vsub_eq_zero [CharZero k] (s : Simplex k P n) :
+    ∑ i, (s.points i -ᵥ s.centroid) = 0 := by
+  have h := centroid_vsub_eq s s.centroid
+  simp only [vsub_self, one_div] at h
+  symm at h
+  rw [smul_eq_zero_iff_right (by exact inv_ne_zero (by norm_cast))] at h
+  exact h
+
+theorem centroid_iff_sum_vsub_eq_zero [CharZero k] (s : Simplex k P n) (p : P) :
+    p = s.centroid ↔ ∑ i, (s.points i -ᵥ p) = 0 := by
+  constructor
+  · intro h
+    rw [h, centroid_weighted_vsub_eq_zero]
+  · intro h
+    rw [← vsub_eq_zero_iff_eq]
+    have : ∑ i, (s.points i -ᵥ p) = ∑ i, ((s.points i -ᵥ s.centroid) - (p -ᵥ s.centroid)) := by
+      apply sum_congr rfl
+      intro x hx
+      rw [vsub_sub_vsub_cancel_right _ _ s.centroid]
+    rw [this, sum_sub_distrib, centroid_weighted_vsub_eq_zero] at h
+    simp only [sum_const, card_univ, Fintype.card_fin, zero_sub, neg_eq_zero] at h
+    have h' : ((n:k) + 1) • (p -ᵥ s.centroid) = 0 := by norm_cast
+    rw [smul_eq_zero_iff_right (by norm_cast)] at h'
+    exact h'
+
+variable [NeZero n]
+
+/-- A faceOppositeCentroid is the centroid of simplex faceOpposite for the i indexed point. -/
+def faceOppositeCentroid (s : Affine.Simplex k P n) (i : Fin (n + 1)) : P :=
+    (s.faceOpposite i).centroid
+
+theorem faceOppositeCentroid_mem_affineSpan [CharZero k] (s : Simplex k P n) (i : Fin (n + 1)) :
+    s.faceOppositeCentroid i ∈ affineSpan k (Set.range s.points) := by
+  unfold faceOppositeCentroid
+  have h : Set.range (s.faceOpposite i).points ⊆ Set.range s.points := by
+    intro j hj
+    rcases hj with ⟨k, _, rfl⟩
+    apply Set.mem_range_self
+  apply affineSpan_mono _ h
+  exact centroid_mem_affineSpan_range (s.faceOpposite i)
+
+theorem faceOppositeCentroid_eq_affineCombination (s : Affine.Simplex k P n) (i : Fin (n + 1)) :
+    s.faceOppositeCentroid i = ((affineCombination k {i}ᶜ s.points) fun _ ↦ (↑n)⁻¹) := by
+  unfold faceOppositeCentroid
+  have : s.faceOpposite i = s.face (fs := {i}ᶜ) (by simp [card_compl, NeZero.one_le]) := by rfl
+  rw [this]
+  unfold centroid
+  rw [face_centroid_eq_centroid, centroid_def, centroidWeights_eq_const, card_compl]
+  simp only [Fintype.card_fin, card_singleton, add_tsub_cancel_right]
+  rfl
+
+theorem faceOppositeCentroid_vsub_point_eq_smul_sum_vsub [CharZero k] (s : Affine.Simplex k P n)
+    (i : Fin (n + 1)) :
+    s.faceOppositeCentroid i -ᵥ (s.points i) = (n : k)⁻¹ • ∑ x, (s.points x -ᵥ s.points i) := by
+  rw [faceOppositeCentroid_eq_affineCombination]
+  rw [affineCombination_eq_weightedVSubOfPoint_vadd_of_sum_eq_one _ _ _
+    ?_ (s.points i)]
+  · simp only [weightedVSubOfPoint_apply, vadd_vsub]
+    have h (i: Fin (n+1)) : ∑ i_1 ∈ {i}ᶜ, (n:k)⁻¹ • (s.points i_1 -ᵥ s.points i) =
+      ∑ i_1 : (Fin (n + 1)) , ((n:k)⁻¹ • (s.points i_1 -ᵥ s.points i)) :=by
+      rw [←Finset.sum_compl_add_sum {i}]
+      simp
+    rw [h i]
+    field_simp
+    rw [smul_sum]
+  simp [sum_const, card_compl]
+  field_simp
+  rw [div_self]
+  exact NeZero.ne (n:k)
+
+theorem faceOppositeCentroid_eq_sum_vsub_vadd [CharZero k] (s : Affine.Simplex k P n)
+    (i : Fin (n + 1)) :
+    s.faceOppositeCentroid i = (n:k)⁻¹ • ∑ x, (s.points x -ᵥ s.points i) +ᵥ (s.points i) := by
+  rw [←faceOppositeCentroid_vsub_point_eq_smul_sum_vsub s i, vsub_vadd]
+
+theorem point_vsub_faceOppositeCentroid_eq_smul_sum_vsub [CharZero k] (s : Affine.Simplex k P n)
+    (i : Fin (n + 1)) :
+    s.points i -ᵥ s.faceOppositeCentroid i = (n : k)⁻¹ • ∑ x, (s.points i -ᵥ s.points x) := by
+  rw [← neg_vsub_eq_vsub_rev, faceOppositeCentroid_vsub_point_eq_smul_sum_vsub, ← neg_smul,
+    Lean.Grind.Ring.neg_eq_mul_neg_one, ← smul_smul, smul_sum]
+  simp only [neg_smul, one_smul, neg_vsub_eq_vsub_rev]
+
+theorem smul_faceOppositeCentroid_vsub_point_eq_sum_vsub [CharZero k] (s : Affine.Simplex k P n)
+    (i : Fin (n + 1)) :
+    (n:k) • (s.faceOppositeCentroid i -ᵥ s.points i) =  ∑ x, (s.points x -ᵥ s.points i) :=by
+  field_simp [faceOppositeCentroid_eq_sum_vsub_vadd, smul_smul, div_self (NeZero.ne ( n : k)),
+    one_smul]
+
+theorem smul_centroid_vsub_point_eq_smul_faceOppositeCentroid_vsub_point [CharZero k]
+    (s : Affine.Simplex k P n) (i : Fin (n + 1)) :
+    ((n + 1) : k) • (s.centroid -ᵥ s.points i) =
+    (n : k) • (s.faceOppositeCentroid i -ᵥ s.points i) := by
+  rw [smul_faceOppositeCentroid_vsub_point_eq_sum_vsub s i,
+    smul_centroid_vsub_point_eq_sum_vsub s i]
+
+theorem vadd_vsub_vadd_eq (v1 v2 : V) (p1 p2 : P) : (v1 +ᵥ p1) -ᵥ (v2 +ᵥ p2) = (v1 -ᵥ v2)
+    +ᵥ (p1 -ᵥ p2) := by
+  rw [vsub_vadd_eq_vsub_sub]
+  field_simp
+  rw [sub_add_comm,add_comm, ←add_sub_assoc, vadd_vsub_assoc]
+
+theorem faceOppositeCentroid_vsub_faceOppositeCentroid [CharZero k] (s : Affine.Simplex k P n)
+    (i j : Fin (n + 1)) :
+    s.faceOppositeCentroid i -ᵥ s.faceOppositeCentroid j =
+    (n : k)⁻¹ • (s.points j -ᵥ s.points i) := by
+  rw [faceOppositeCentroid_eq_sum_vsub_vadd s i, faceOppositeCentroid_eq_sum_vsub_vadd s j,
+    vadd_vsub_vadd_eq _ _ (s.points i) (s.points j)]
+  have h1 (i : Fin (n+1)): ∑ x,  (s.points x -ᵥ s.points i) = ∑ x,  (s.points x -ᵥ s.points 0
+      - (s.points i-ᵥ s.points 0)) :=by
+   apply sum_congr rfl
+   simp
+  simp_rw [h1 i, h1 j, sum_sub_distrib]
+  field_simp
+  rw [smul_sub, smul_sub, one_div, sub_sub_sub_cancel_left, ← smul_sub, ← smul_sub,
+    vsub_sub_vsub_cancel_right]
+  have : (s.points i -ᵥ s.points j) = -(s.points j -ᵥ s.points i) := by simp
+  rw [this, ← sub_eq_add_neg, add_smul, sub_eq_iff_eq_add ,one_smul, smul_add, add_comm]
+  field_simp
+  have : ((1:k) / ↑n) • n • (s.points j -ᵥ s.points i) = (n : k)⁻¹ •
+      (n : k) • (s.points j -ᵥ s.points i) := by
+    norm_cast0
+    congr 1
+    rw [one_div]
+  rw [this, smul_smul, inv_eq_one_div, one_div_mul_cancel (NeZero.ne (n : k)), one_smul]
+
+theorem faceOppositeCentroid_vsub_point_eq_smul_vsub [CharZero k] (s : Simplex k P n)
+    (i : Fin (n + 1)) :
+    s.faceOppositeCentroid i -ᵥ s.points i =
+    ((n + 1) : k) • (s.faceOppositeCentroid i -ᵥ s.centroid) := by
+  rw [← vsub_sub_vsub_cancel_right _ (s.centroid) (s.points i)]
+  rw [faceOppositeCentroid_vsub_point_eq_smul_sum_vsub, centroid_vsub_point_eq_smul_sum_vsub,
+    ← sub_smul, smul_smul]
+  congr
+  field_simp [mul_sub]
+  rw [add_div, one_div, div_self (NeZero.ne (n : k)), div_self (by norm_cast)]
+  norm_num
+
+theorem point_vsub_faceOppositeCentroid_eq_smul_vsub [CharZero k] (s : Simplex k P n)
+    (i : Fin (n + 1)) :
+    s.points i -ᵥ s.faceOppositeCentroid i =
+    ((n + 1) : k) • (s.centroid -ᵥ s.faceOppositeCentroid i) := by
+  rw [← neg_vsub_eq_vsub_rev, faceOppositeCentroid_vsub_point_eq_smul_vsub, ← neg_smul,
+    ← neg_smul_neg, neg_vsub_eq_vsub_rev, neg_neg]
+
+/-- Commandino's theorem -/
+theorem point_vsub_centroid_eq_smul_vsub [CharZero k]
+    (s : Simplex k P n) (i : Fin (n + 1)) :
+    s.points i -ᵥ s.centroid = (n : k) • (s.centroid -ᵥ s.faceOppositeCentroid i)  := by
+  symm
+  rw [← vsub_sub_vsub_cancel_right _ _ (s.points i),
+    faceOppositeCentroid_vsub_point_eq_smul_sum_vsub,
+    centroid_vsub_point_eq_smul_sum_vsub, ← neg_vsub_eq_vsub_rev,
+    centroid_vsub_point_eq_smul_sum_vsub, ← sub_smul, smul_smul, ← neg_smul]
+  congr
+  simp_rw [mul_sub, sub_eq_iff_eq_add, neg_add_eq_sub]
+  symm
+  field_simp [sub_eq_iff_eq_add, NeZero.ne (n : k)]
+  rw [div_self (by norm_cast)]
+
+theorem centroid_vsub_point_eq_smul_vsub [CharZero k]
+    (s : Simplex k P n) (i : Fin (n + 1)) :
+    s.centroid -ᵥ s.points i = (n : k) • (s.faceOppositeCentroid i -ᵥ s.centroid) := by
+  rw [← neg_vsub_eq_vsub_rev, point_vsub_centroid_eq_smul_vsub, ← neg_smul_neg,
+    neg_vsub_eq_vsub_rev, ← neg_smul, neg_neg]
+
+theorem centroid_eq_smul_vsub_vadd_point [CharZero k] (s : Simplex k P n) (i : Fin (n + 1)) :
+    s.centroid = (n : k) • (s.faceOppositeCentroid i -ᵥ s.centroid) +ᵥ s.points i := by
+  rw [← centroid_vsub_point_eq_smul_vsub, vsub_vadd]
+
+theorem point_eq_smul_vsub_vadd_centroid [CharZero k] (s : Simplex k P n) (i : Fin (n + 1)) :
+    s.points i = (-n : k) • (s.faceOppositeCentroid i -ᵥ s.centroid) +ᵥ s.centroid := by
+  rw [← neg_vsub_eq_vsub_rev, neg_smul_neg, ← point_vsub_centroid_eq_smul_vsub, vsub_vadd]
+
+/-- The centroid, a vertex, and the corresponding faceOppositeCentroid of a simplex are collinear.
+-/
+theorem collinear_point_centroid_faceOppositeCentroid [CharZero k] (s : Simplex k P n)
+    (i : Fin (n + 1)) :
+    Collinear k {s.points i, s.centroid, s.faceOppositeCentroid i} := by
+  apply collinear_insert_of_mem_affineSpan_pair
+  rw [point_eq_smul_vsub_vadd_centroid]
+  exact smul_vsub_vadd_mem_affineSpan_pair _ _ _
+
+/-- Define median as an line throught the point of simplex and corosponed faceOppositeCentroid. -/
+def median (s : Simplex k P n) (i : Fin (n + 1)) : AffineSubspace k P :=
+  line[k, s.points i, s.faceOppositeCentroid i]
+
+theorem faceOppositeCentroid_mem_median (s : Simplex k P n) (i : Fin (n + 1)) :
+    s.faceOppositeCentroid i ∈ s.median i := by
+  simp [median, right_mem_affineSpan_pair]
+
+theorem point_mem_median (s : Simplex k P n) (i : Fin (n + 1)) :
+    s.points i ∈ s.median i := by
+  simp [median, left_mem_affineSpan_pair]
+
+theorem centroid_mem_median [CharZero k] (s : Simplex k P n) (i : Fin (n + 1)) :
+  s.centroid ∈ s.median i := by
+  rw [median]
+  have h : s.centroid = ((n:k) * (1/ (n + 1))) • (s.faceOppositeCentroid i -ᵥ s.points i)
+    +ᵥ s.points i := by
+    rw [eq_vadd_iff_vsub_eq, centroid_vsub_point_eq_smul_vsub,
+      faceOppositeCentroid_vsub_point_eq_smul_vsub, smul_smul,one_div,mul_assoc,
+      inv_mul_cancel₀ (by norm_cast), mul_one]
+  rw [h]
+  exact smul_vsub_vadd_mem_affineSpan_pair _ _ _
+
+theorem median_eq_affineSpan_point_centroid [CharZero k] (s : Simplex k P n) (i : Fin (n + 1)) :
+    s.median i = affineSpan k {s.points i, s.centroid} := by
+  have h1 : s.median i ≤ affineSpan k {s.points i, s.centroid} := by
+    unfold median
+    apply affineSpan_pair_le_of_right_mem
+    have h : s.faceOppositeCentroid i = (-1 / (n:k)) • (s.points i -ᵥ s.centroid) +ᵥ s.centroid
+        := by
+      rw[point_eq_smul_vsub_vadd_centroid, vadd_vsub, smul_smul]
+      field_simp
+      rw [div_mul_cancel₀ _ (NeZero.ne (n:k)), neg_one_smul,neg_neg, vsub_vadd]
+    rw [h]
+    exact smul_vsub_rev_vadd_mem_affineSpan_pair _ _ _
+  have h2 : affineSpan k {s.points i, s.centroid} ≤ s.median i := by
+    rw [median]
+    apply affineSpan_pair_le_of_right_mem
+    exact centroid_mem_median s i
+  exact le_antisymm h1 h2
+
+theorem mem_median_eq_linemap [CharZero k] (s : Simplex k P n) (i : Fin (n + 1))
+    {p : P} (h : p ∈ s.median i) :
+    ∃ (r : k),
+    p = AffineMap.lineMap (s.faceOppositeCentroid i) (s.points i) r := by
+  rw [median] at h
+  set v := p -ᵥ s.faceOppositeCentroid i
+  have hp: p = v +ᵥ s.faceOppositeCentroid i := by rw [vsub_vadd]
+  rw [hp, vadd_right_mem_affineSpan_pair] at h
+  choose r hr using h
+  use r
+  rw [AffineMap.lineMap_apply, hr]
+  simp_rw [hp]
+
+theorem affineIndependent_centroid_replace_point [CharZero k] [NeZero n] (s : Simplex k P n)
+    (i : Fin (n + 1)) : AffineIndependent k fun x => if x = i then s.centroid else s.points x := by
+  set p : Fin (n + 1) → P := fun x => if x = i then s.centroid else s.points x with hp
+  have hi : p i ∉ affineSpan k (p '' {x : Fin (n+1) | x ≠ i}) := by
+    simp_rw [hp, if_pos]
+    have h : (p '' {x : Fin (n+1) | x ≠ i}) = s.points '' {i}ᶜ := by ext x; simp; grind
+    rw [h]
+    exact centroid_not_mem_affineSpan_compl s i
+  apply AffineIndependent.affineIndependent_of_notMem_span ?_ hi
+  have hsub := (s.faceOpposite i).independent.range
+  set q : {y // y ≠ i} → P := fun x => if x.val = i then s.centroid else s.points x
+  have hq: Set.range q = Set.range (s.faceOpposite i).points :=by
+    simp
+    ext x
+    unfold q
+    constructor
+    · intro hx
+      simp at hx
+      obtain ⟨a, ha1,ha2⟩ := hx
+      rw [if_neg (by simp [ha1])] at ha2
+      rw [←ha2]
+      tauto
+    · intro hx
+      simp at hx
+      obtain ⟨a, ha⟩ := hx
+      simp only [ne_eq, Set.mem_range, Subtype.exists]
+      grind
+  rw [← hq] at hsub
+  refine AffineIndependent.of_set_of_injective hsub ?_
+  have q_inj: Function.Injective q := by
+    unfold q
+    intro x y hxy
+    simp at hxy
+    rw [if_neg (by grind), if_neg (by grind)] at hxy
+    apply s.independent.injective at hxy
+    grind
+  exact q_inj
+
+theorem linearIndependent_point_compl_vsub_centroid [CharZero k] (s : Simplex k P n)
+    (i₀ : Fin (n + 1)) :
+    LinearIndependent k fun i : { x // x ∈ ({i₀}ᶜ : Finset (Fin (n+1))) } =>
+    (s.points i -ᵥ s.centroid : V) := by
+  set p : Fin (n + 1) → P := fun x => if x = i₀ then s.centroid else s.points x
+  have h := affineIndependent_iff_linearIndependent_vsub k p i₀
+  unfold p at h
+  have h1 := affineIndependent_centroid_replace_point s i₀
+  have h2 := h.1 h1
+  simp at h2
+  set f : { x // x ∈ ({i₀}ᶜ : Finset (Fin (n+1))) } → { x // x ≠ i₀ } :=
+    have h (x : { x // x ∈ ({i₀}ᶜ : Finset (Fin (n+1))) }) : x.val ≠ i₀ := by
+      simp
+      grind [mem_compl, Finset.notMem_singleton]
+    fun x => ⟨x.val,h x⟩
+    with hf
+  have f_inj : Function.Injective f := by
+    intro x y hxy
+    unfold f at hxy
+    simp at hxy
+    grind
+  have h3:= h2.comp f f_inj
+  conv at h3 =>
+    enter [2]
+    ext i
+    rw [Function.comp_apply]
+  convert h3 using 1
+  funext i
+  congr 2
+  rw [if_neg]
+  rw [hf]
+  simp
+  have hi := i.prop
+  rw [mem_compl, Finset.notMem_singleton] at hi
+  exact hi
+
+/-- The medians of a simplex are concurrent at the centroid of the simplex -/
+theorem eq_centroid_of_forall_mem_median [CharZero k] (s : Simplex k P n) {hn : 1 < n} {p : P}
+    (h : ∀ i, p ∈ s.median i) : p = s.centroid := by
+  rw [←vsub_eq_zero_iff_eq]
+  set i₀: Fin (n+1) := 0
+  set v := p -ᵥ s.centroid
+  have hp : p = v +ᵥ s.centroid := by rw [vsub_vadd]
+  let s' : Finset (Fin (n + 1)) := {i₀}ᶜ
+  let u : s' → V := fun i => s.points i -ᵥ s.centroid
+  have h_span : ∀ i : s', v ∈ (Submodule.span k ({u i} : Set V)) := by
+    intro i
+    unfold u
+    have hi := h i
+    rw [median_eq_affineSpan_point_centroid, hp, vadd_right_mem_affineSpan_pair] at hi
+    have h2 := right_mem_affineSpan_pair k (s.points i) s.centroid
+    obtain ⟨t, ht⟩ := hi
+    rw [← ht]
+    apply Submodule.smul_mem
+    simp only [Submodule.mem_span_singleton_self]
+  have hi : LinearIndependent k u := linearIndependent_point_compl_vsub_centroid s i₀
+  have he : ∃ i j : s', i ≠ j := by
+    simp only [ne_eq, Subtype.exists, Subtype.mk.injEq, exists_prop]
+    have hcard: s'.card = n := by
+      rw [Finset.card_compl, Fintype.card_fin]
+      simp
+    have hcard' : 1 < #s' :=by grind
+    rw [Finset.one_lt_card_iff] at hcard'
+    grind
+  choose i j hij using he
+  have h_ij : Disjoint ({i}: Set { x // x ∈ s' }) {j} := by
+    simp [hij]
+  set u_i := Submodule.span k ({u i} : Set V)
+  set u_j := Submodule.span k ({u j} : Set V)
+  have h_disjoint : Disjoint u_i u_j := by
+    have x:= LinearIndependent.disjoint_span_image hi h_ij
+    simp at x
+    exact x
+  exact Submodule.disjoint_def.1 h_disjoint _ (h_span i) (h_span j)
+
+end Simplex
+
+end Affine
+
+namespace EuclideanGeometry
+
+open RealInnerProductSpace Finset Affine EuclideanGeometry
+
+variable {V : Type*} {P : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [MetricSpace P]
+  [NormedAddTorsor V P]
+
+variable {n : ℕ} [NeZero n]
+
+theorem dist_point_centroid (s : Simplex ℝ P n) (i : Fin (n + 1)) :
+    dist (s.points i) s.centroid = n * dist s.centroid (s.faceOppositeCentroid i) := by
+  simp_rw [dist_eq_norm_vsub, s.point_vsub_centroid_eq_smul_vsub i, norm_smul, Real.norm_natCast]
+
+theorem dist_point_faceOppositeCentroid (s : Simplex ℝ P n) (i : Fin (n + 1)) :
+    dist (s.points i) (s.faceOppositeCentroid i) = (n+1)
+    * dist s.centroid (s.faceOppositeCentroid i) := by
+  simp_rw [dist_eq_norm_vsub, s.point_vsub_faceOppositeCentroid_eq_smul_vsub i,
+    norm_smul]
+  norm_cast
+
+end EuclideanGeometry
+
+namespace Affine
+
+namespace Triangle
+
+open EuclideanGeometry
+
+variable {V : Type*} {P : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [MetricSpace P]
+  [NormedAddTorsor V P]
+
+theorem dist_point_centroid (t : Affine.Triangle ℝ P) (i : Fin 3) :
+    dist (t.points i) t.centroid = 2 * dist t.centroid (t.faceOppositeCentroid i) := by
+  field_simp [EuclideanGeometry.dist_point_centroid]
+
+theorem dist_point_faceOppositeCentroid (t : Affine.Triangle ℝ P) (i : Fin 3) :
+    dist (t.points i) (t.faceOppositeCentroid i) = 3 * dist t.centroid (t.faceOppositeCentroid i)
+    := by
+  rw [EuclideanGeometry.dist_point_faceOppositeCentroid]
+  norm_cast
+
+end Triangle
+
+end Affine
+
+end

--- a/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Combination.lean
@@ -1031,6 +1031,20 @@ theorem eq_affineCombination_of_mem_affineSpan_of_fintype [Fintype ι] {p1 : P} 
     simp only [Finset.mem_coe, Set.indicator_apply, ← hw]
     rw [Fintype.sum_extend_by_zero s w]
 
+/-- A point in the `affineSpan` of a subset of an indexed family is an
+`affineCombination` with sum of weights 1, using only points in the given subset. -/
+lemma eq_affineCombination_of_mem_affineSpan_image {p₁ : P} {p : ι → P} {s : Set ι}
+    (h : p₁ ∈ affineSpan k (p '' s)) :
+    ∃ (fs : Finset ι) (w : ι → k), ↑fs ⊆ s ∧ ∑ i ∈ fs, w i = 1 ∧
+      p₁ = fs.affineCombination k p w := by
+  classical
+  rw [Set.image_eq_range] at h
+  obtain ⟨fs', w', hw', rfl⟩ := eq_affineCombination_of_mem_affineSpan h
+  refine ⟨fs'.map (Function.Embedding.subtype _), fun i ↦ if hi : i ∈ s then w' ⟨i, hi⟩ else 0,
+    (by simp), (by simp [hw']), ?_⟩
+  simp only [Finset.affineCombination_map, Function.Embedding.coe_subtype]
+  exact fs'.affineCombination_congr (by simp) (by simp)
+
 variable (k V)
 
 /-- A point is in the `affineSpan` of an indexed family if and only

--- a/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
@@ -345,6 +345,19 @@ theorem AffineIndependent.of_set_of_injective {p : ι → P}
     (⟨fun i => ⟨p i, Set.mem_range_self _⟩, fun _ _ h => hi (Subtype.mk_eq_mk.1 h)⟩ :
       ι ↪ Set.range p)
 
+/-- If an affine combination of affinely independent points lies in the affine span of a subset
+of those points, all weights outside that subset are zero. -/
+lemma AffineIndependent.eq_zero_of_affineCombination_mem_affineSpan {p : ι → P}
+    (ha : AffineIndependent k p) {fs : Finset ι} {w : ι → k} (hw : ∑ i ∈ fs, w i = 1) {s : Set ι}
+    (hm : fs.affineCombination k p w ∈ affineSpan k (p '' s)) {i : ι} (hifs : i ∈ fs)
+    (his : i ∉ s) : w i = 0 := by
+  obtain ⟨fs', w', hfs's, hw', he⟩ := eq_affineCombination_of_mem_affineSpan_image hm
+  have hi' : (fs : Set ι).indicator w i = 0 := by
+    rw [ha.indicator_eq_of_affineCombination_eq fs fs' w w' hw hw' he]
+    exact Set.indicator_of_notMem (Set.notMem_subset hfs's his) w'
+  rw [Set.indicator_apply_eq_zero] at hi'
+  exact hi' (Finset.mem_coe.2 hifs)
+
 section Composition
 
 variable {V₂ P₂ : Type*} [AddCommGroup V₂] [Module k V₂] [AffineSpace V₂ P₂]

--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -1914,6 +1914,8 @@ Q2226624:
 
 Q2226625:
   title: Commandino's theorem
+  decl: Affine.Simplex.point_vsub_centroid_eq_smul_vsub
+  authors: Chu Zheng
 
 Q2226640:
   title: Cramér’s decomposition theorem


### PR DESCRIPTION
This file proves several lemmas involving the centroids and medians of a simplex in affine space. 

definitions:
- `centroid` is the centroid of a simplex, defined as abbreviation of the `Finset.univ.centroid`.
- `faceOppositeCentroid` is the centroid of the facet obtained as `(Simplex.faceOpposite i).centroid`
- `median` is the line connecting a vertex to the faceOppositeCentroid.

Main Results:
- Commandino's theorem
-  The medians of a simplex are concurrent at the centroid

I'm not quite sure whether `Geometry/Euclidean/Centroid` is the best place for these definitions or if they belong in `LinearAlgebra/AffineSpace/Combination`. However, it seems that we already have definitions like Circumcenter, Incenter, and other related positional concepts in the euclidean folder.

---

- [x] depends on: #27865
- [x] depends on: #26822  (by @jsm28 )

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
