### PR TITLE
chore: remove redundant arguments to grind

### DIFF
--- a/Mathlib/Algebra/Order/Archimedean/Basic.lean
+++ b/Mathlib/Algebra/Order/Archimedean/Basic.lean
@@ -442,12 +442,13 @@ theorem exists_pow_btwn {n : ℕ} (hn : n ≠ 0) {x y : K} (h : x < y) (hy : 0 <
     (or_iff_not_imp_left.mpr fun q1 ↦ (le_self_pow₀ (le_of_not_gt q1) hn).trans_lt qny)
   have xqn : max x 0 < q ^ n :=
     calc _ = y - (y - max x 0) := by rw [sub_sub_cancel]
-      _ ≤ (m * δ) ^ n - (y - max x 0) := sub_le_sub_right (Nat.find_spec ex) _
-      _ < (m * δ) ^ n - ((m * δ) ^ n - q ^ n) := by
-        refine sub_lt_sub_left ((le_abs_self _).trans_lt <| cont _ _ q1y.le ?_) _
+      _ ≤ (m * δ) ^ n - (y - max x 0) := by grw [← Nat.find_spec ex]
+      _ < (m * δ) ^ n - |(m * δ) ^ n - q ^ n| := by
+        gcongr 1
+        refine cont _ _ q1y.le ?_
         rw [← Nat.succ_pred_eq_of_pos m_pos, Nat.cast_succ, ← sub_mul,
           add_sub_cancel_left, one_mul, abs_eq_self.mpr (by positivity)]
-      _ = q ^ n := sub_sub_cancel ..
+      _ ≤ q ^ n := by grw [← le_abs_self, sub_sub_cancel]
   exact ⟨q, lt_of_le_of_ne (by positivity) fun q0 ↦
     (le_sup_right.trans_lt xqn).ne <| q0 ▸ (zero_pow hn).symm, le_sup_left.trans_lt xqn, qny⟩
 

--- a/Mathlib/Algebra/Order/Sub/Defs.lean
+++ b/Mathlib/Algebra/Order/Sub/Defs.lean
@@ -110,7 +110,8 @@ variable [AddLeftMono α]
 theorem tsub_le_tsub_left (h : a ≤ b) (c : α) : c - b ≤ c - a :=
   tsub_le_iff_left.mpr <| le_add_tsub.trans <| add_le_add_right h _
 
-@[gcongr] theorem tsub_le_tsub (hab : a ≤ b) (hcd : c ≤ d) : a - d ≤ b - c :=
+@[gcongr low] -- lower priority than `sub_le_sub`, for performance reasons
+theorem tsub_le_tsub (hab : a ≤ b) (hcd : c ≤ d) : a - d ≤ b - c :=
   (tsub_le_tsub_right hab _).trans <| tsub_le_tsub_left hcd _
 
 theorem antitone_const_tsub : Antitone fun x => c - x := fun _ _ hxy => tsub_le_tsub rfl.le hxy

--- a/Mathlib/Algebra/Polynomial/Derivative.lean
+++ b/Mathlib/Algebra/Polynomial/Derivative.lean
@@ -183,9 +183,7 @@ theorem natDegree_iterate_derivative (p : R[X]) (k : ℕ) :
     (derivative^[k] p).natDegree ≤ p.natDegree - k := by
   induction k with
   | zero => rw [Function.iterate_zero_apply, Nat.sub_zero]
-  | succ d hd =>
-      rw [Function.iterate_succ_apply', Nat.sub_succ']
-      exact (natDegree_derivative_le _).trans <| Nat.sub_le_sub_right hd 1
+  | succ d hd => grw [Function.iterate_succ_apply', natDegree_derivative_le, hd, Nat.sub_add_eq]
 
 @[simp]
 theorem derivative_natCast {n : ℕ} : derivative (n : R[X]) = 0 := by

--- a/Mathlib/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Degree.lean
+++ b/Mathlib/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Degree.lean
@@ -249,7 +249,7 @@ lemma natDegree_preΨ' {n : ℕ} (h : (n : R) ≠ 0) :
 
 lemma natDegree_preΨ'_pos {n : ℕ} (hn : 2 < n) (h : (n : R) ≠ 0) : 0 < (W.preΨ' n).natDegree := by
   simp_rw [W.natDegree_preΨ' h, Nat.div_pos_iff, zero_lt_two, true_and]
-  split_ifs <;> exact Nat.AtLeastTwo.prop.trans <| Nat.sub_le_sub_right (Nat.pow_le_pow_left hn 2) _
+  split_ifs <;> grw [← Nat.succ_le_of_lt hn] <;> norm_num
 
 @[simp]
 lemma leadingCoeff_preΨ' {n : ℕ} (h : (n : R) ≠ 0) :

--- a/Mathlib/Analysis/Asymptotics/Lemmas.lean
+++ b/Mathlib/Analysis/Asymptotics/Lemmas.lean
@@ -549,7 +549,7 @@ theorem IsBigOWith.right_le_sub_of_lt_one {f₁ f₂ : α → E'} (h : IsBigOWit
     mem_of_superset h.bound fun x hx => by
       simp only [mem_setOf_eq] at hx ⊢
       rw [mul_comm, one_div, ← div_eq_mul_inv, le_div_iff₀, mul_sub, mul_one, mul_comm]
-      · exact le_trans (sub_le_sub_left hx _) (norm_sub_norm_le _ _)
+      · grw [hx]; apply norm_sub_norm_le
       · exact sub_pos.2 hc
 
 theorem IsBigOWith.right_le_add_of_lt_one {f₁ f₂ : α → E'} (h : IsBigOWith c l f₁ f₂) (hc : c < 1) :

--- a/Mathlib/Analysis/Asymptotics/Lemmas.lean
+++ b/Mathlib/Analysis/Asymptotics/Lemmas.lean
@@ -549,7 +549,7 @@ theorem IsBigOWith.right_le_sub_of_lt_one {f₁ f₂ : α → E'} (h : IsBigOWit
     mem_of_superset h.bound fun x hx => by
       simp only [mem_setOf_eq] at hx ⊢
       rw [mul_comm, one_div, ← div_eq_mul_inv, le_div_iff₀, mul_sub, mul_one, mul_comm]
-      · grw [hx]; apply norm_sub_norm_le
+      · grw [← hx]; apply norm_sub_norm_le
       · exact sub_pos.2 hc
 
 theorem IsBigOWith.right_le_add_of_lt_one {f₁ f₂ : α → E'} (h : IsBigOWith c l f₁ f₂) (hc : c < 1) :

--- a/Mathlib/Analysis/Complex/UpperHalfPlane/Metric.lean
+++ b/Mathlib/Analysis/Complex/UpperHalfPlane/Metric.lean
@@ -268,7 +268,7 @@ theorem im_pos_of_dist_center_le {z : ℍ} {r : ℝ} {w : ℂ}
   calc
     0 < z.im * (Real.cosh r - Real.sinh r) := mul_pos z.im_pos (sub_pos.2 <| sinh_lt_cosh _)
     _ = (z.center r).im - z.im * Real.sinh r := mul_sub _ _ _
-    _ ≤ (z.center r).im - dist (z.center r : ℂ) w := sub_le_sub_left (by rwa [dist_comm]) _
+    _ ≤ (z.center r).im - dist (z.center r : ℂ) w := by grw [← h, dist_comm]
     _ ≤ w.im := sub_le_comm.1 <| (le_abs_self _).trans (abs_im_le_norm <| z.center r - w)
 
 theorem image_coe_closedBall (z : ℍ) (r : ℝ) :

--- a/Mathlib/Combinatorics/Hall/Finite.lean
+++ b/Mathlib/Combinatorics/Hall/Finite.lean
@@ -138,9 +138,7 @@ theorem hall_cond_of_compl {ι : Type u} {t : ι → Finset α} {s : Finset ι}
     exact absurd hx hc
   have : #s' = #(s ∪ s'.image fun z => z.1) - #s := by
     simp [disj, card_image_of_injective _ Subtype.coe_injective, Nat.add_sub_cancel_left]
-  rw [this, hus]
-  refine (Nat.sub_le_sub_right (ht _) _).trans ?_
-  rw [← card_sdiff]
+  grw [this, ht, hus, ← card_sdiff]
   · refine (card_le_card ?_).trans le_rfl
     intro t
     simp only [mem_biUnion, mem_sdiff, not_exists, mem_image, and_imp, mem_union,

--- a/Mathlib/Combinatorics/Hall/Finite.lean
+++ b/Mathlib/Combinatorics/Hall/Finite.lean
@@ -127,6 +127,7 @@ theorem hall_cond_of_restrict {ι : Type u} {t : ι → Finset α} {s : Finset �
     ext y
     simp
 
+attribute [local gcongr] Nat.sub_le_sub_right in
 theorem hall_cond_of_compl {ι : Type u} {t : ι → Finset α} {s : Finset ι}
     (hus : #s = #(s.biUnion t)) (ht : ∀ s : Finset ι, #s ≤ #(s.biUnion t))
     (s' : Finset (sᶜ : Set ι)) : #s' ≤ #(s'.biUnion fun x' => t x' \ s.biUnion t) := by

--- a/Mathlib/Combinatorics/SimpleGraph/Copy.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Copy.lean
@@ -563,7 +563,7 @@ lemma le_card_edgeFinset_killCopies [Fintype V] :
   let f (G' : {G' : G.Subgraph // Nonempty (H ≃g G'.coe)}) := (aux hH G'.2).some
   calc
     _ = #G.edgeFinset - card {G' : G.Subgraph // Nonempty (H ≃g G'.coe)} := ?_
-    _ ≤ #G.edgeFinset - #(univ.image f) := Nat.sub_le_sub_left card_image_le _
+    _ ≤ #G.edgeFinset - #(univ.image f) := by grw [card_image_le]
     _ = #G.edgeFinset - #(Set.range f).toFinset := by rw [Set.toFinset_range]
     _ ≤ #(G.edgeFinset \ (Set.range f).toFinset) := le_card_sdiff ..
     _ = #(G.killCopies H).edgeFinset := ?_

--- a/Mathlib/Combinatorics/SimpleGraph/Copy.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Copy.lean
@@ -563,7 +563,7 @@ lemma le_card_edgeFinset_killCopies [Fintype V] :
   let f (G' : {G' : G.Subgraph // Nonempty (H ≃g G'.coe)}) := (aux hH G'.2).some
   calc
     _ = #G.edgeFinset - card {G' : G.Subgraph // Nonempty (H ≃g G'.coe)} := ?_
-    _ ≤ #G.edgeFinset - #(univ.image f) := by grw [card_image_le]
+    _ ≤ #G.edgeFinset - #(univ.image f) := by grw [card_image_le, card_univ]
     _ = #G.edgeFinset - #(Set.range f).toFinset := by rw [Set.toFinset_range]
     _ ≤ #(G.edgeFinset \ (Set.range f).toFinset) := le_card_sdiff ..
     _ = #(G.killCopies H).edgeFinset := ?_

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Uniform.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Uniform.lean
@@ -328,8 +328,8 @@ lemma IsEquipartition.card_biUnion_offDiag_le' (hP : P.IsEquipartition) :
   suffices (#U - 1) * #U ≤ #A / #P.parts * (#A / #P.parts + 1) by
     rwa [Nat.mul_sub_right_distrib, one_mul, ← offDiag_card] at this
   have := hP.card_part_le_average_add_one hU
-  refine Nat.mul_le_mul ((Nat.sub_le_sub_right this 1).trans ?_) this
-  simp only [Nat.add_succ_sub_one, add_zero, le_rfl]
+  gcongr
+  exact Nat.sub_le_of_le_add this
 
 lemma IsEquipartition.card_biUnion_offDiag_le (hε : 0 < ε) (hP : P.IsEquipartition)
     (hP' : 4 / ε ≤ #P.parts) : #(P.parts.biUnion offDiag) ≤ ε / 2 * #A ^ 2 := by

--- a/Mathlib/Data/Finset/Card.lean
+++ b/Mathlib/Data/Finset/Card.lean
@@ -546,12 +546,8 @@ theorem card_sdiff (h : s ⊆ t) : #(t \ s) = #t - #s := by
 theorem card_sdiff_add_card_eq_card {s t : Finset α} (h : s ⊆ t) : #(t \ s) + #s = #t :=
   ((Nat.sub_eq_iff_eq_add (card_le_card h)).mp (card_sdiff h).symm).symm
 
-theorem le_card_sdiff (s t : Finset α) : #t - #s ≤ #(t \ s) :=
-  calc
-    #t - #s ≤ #t - #(s ∩ t) :=
-      Nat.sub_le_sub_left (card_le_card inter_subset_left) _
-    _ = #(t \ (s ∩ t)) := (card_sdiff inter_subset_right).symm
-    _ ≤ #(t \ s) := by rw [sdiff_inter_self_right t s]
+theorem le_card_sdiff (s t : Finset α) : #t - #s ≤ #(t \ s) := by
+  grw [← sdiff_inter_self_right, card_sdiff inter_subset_right, inter_subset_left]
 
 theorem card_le_card_sdiff_add_card : #s ≤ #(s \ t) + #t :=
   Nat.sub_le_iff_le_add.1 <| le_card_sdiff _ _

--- a/Mathlib/Data/Finset/Card.lean
+++ b/Mathlib/Data/Finset/Card.lean
@@ -546,6 +546,7 @@ theorem card_sdiff (h : s ⊆ t) : #(t \ s) = #t - #s := by
 theorem card_sdiff_add_card_eq_card {s t : Finset α} (h : s ⊆ t) : #(t \ s) + #s = #t :=
   ((Nat.sub_eq_iff_eq_add (card_le_card h)).mp (card_sdiff h).symm).symm
 
+attribute [local gcongr] Nat.sub_le_sub_left in
 theorem le_card_sdiff (s t : Finset α) : #t - #s ≤ #(t \ s) := by
   grw [← sdiff_inter_self_right, card_sdiff inter_subset_right, inter_subset_left]
 

--- a/Mathlib/Data/List/OfFn.lean
+++ b/Mathlib/Data/List/OfFn.lean
@@ -104,8 +104,7 @@ theorem ofFn_getElem_eq_map {β : Type*} (l : List α) (f : α → β) :
 
 -- Note there is a now another `mem_ofFn` defined in Lean, with an existential on the RHS,
 -- which is marked as a simp lemma.
-theorem mem_ofFn' {n} (f : Fin n → α) (a : α) : a ∈ ofFn f ↔ a ∈ Set.range f := by
-  grind [Set.mem_range]
+theorem mem_ofFn' {n} (f : Fin n → α) (a : α) : a ∈ ofFn f ↔ a ∈ Set.range f := by grind
 
 theorem forall_mem_ofFn_iff {n : ℕ} {f : Fin n → α} {P : α → Prop} :
     (∀ i ∈ ofFn f, P i) ↔ ∀ j : Fin n, P (f j) := by simp

--- a/Mathlib/Data/Nat/Basic.lean
+++ b/Mathlib/Data/Nat/Basic.lean
@@ -47,6 +47,10 @@ instance instNontrivial : Nontrivial ℕ := ⟨⟨0, 1, Nat.zero_ne_one⟩⟩
 
 attribute [gcongr] Nat.succ_le_succ Nat.div_le_div_right Nat.div_le_div
 
+@[gcongr]
+lemma sub_le_sub {a b c d : ℕ} (h₁ : a ≤ b) (h₂ : c ≤ d) : a - d ≤ b - c :=
+  Nat.le_trans (Nat.sub_le_sub_right h₁ d) (Nat.sub_le_sub_left h₂ b)
+
 /-! ### `succ`, `pred` -/
 
 lemma succ_injective : Injective Nat.succ := @succ.inj

--- a/Mathlib/Data/Nat/Basic.lean
+++ b/Mathlib/Data/Nat/Basic.lean
@@ -47,10 +47,6 @@ instance instNontrivial : Nontrivial ℕ := ⟨⟨0, 1, Nat.zero_ne_one⟩⟩
 
 attribute [gcongr] Nat.succ_le_succ Nat.div_le_div_right Nat.div_le_div
 
-@[gcongr]
-lemma sub_le_sub {a b c d : ℕ} (h₁ : a ≤ b) (h₂ : c ≤ d) : a - d ≤ b - c :=
-  Nat.le_trans (Nat.sub_le_sub_right h₁ d) (Nat.sub_le_sub_left h₂ b)
-
 /-! ### `succ`, `pred` -/
 
 lemma succ_injective : Injective Nat.succ := @succ.inj

--- a/Mathlib/Data/Nat/Squarefree.lean
+++ b/Mathlib/Data/Nat/Squarefree.lean
@@ -109,7 +109,7 @@ def minSqFacAux : ℕ → ℕ → Option ℕ
         exact Nat.minFac_lemma n k h
       if k ∣ n then
         let n' := n / k
-        have : Nat.sqrt n' - k < Nat.sqrt n + 2 - k :=
+        have : Nat.sqrt n' - k < Nat.sqrt n + 2 - k := by
           revert this; gcongr -- TODO: use `gconvert`
           apply div_le_self
         if k ∣ n' then some k else minSqFacAux n' (k + 2)

--- a/Mathlib/Data/Nat/Squarefree.lean
+++ b/Mathlib/Data/Nat/Squarefree.lean
@@ -109,8 +109,9 @@ def minSqFacAux : ℕ → ℕ → Option ℕ
         exact Nat.minFac_lemma n k h
       if k ∣ n then
         let n' := n / k
-        have : Nat.sqrt n' - k < Nat.sqrt n + 2 - k :=
-        lt_of_le_of_lt (Nat.sub_le_sub_right (Nat.sqrt_le_sqrt <| Nat.div_le_self _ _) k) this
+        have : Nat.sqrt n' - k < Nat.sqrt n + 2 - k := by
+          revert this; gcongr -- TODO: use `gconvert`
+          exact Nat.sqrt_le_sqrt <| Nat.div_le_self _ _
         if k ∣ n' then some k else minSqFacAux n' (k + 2)
       else minSqFacAux n (k + 2)
 termination_by n k => sqrt n + 2 - k
@@ -159,8 +160,9 @@ theorem minSqFacAux_has_prop {n : ℕ} (k) (n0 : 0 < n) (i) (e : k = 2 * i + 3)
     intro n' nd' nk
     have hn' := le_of_dvd n0 nd'
     refine
-      have : Nat.sqrt n' - k < Nat.sqrt n + 2 - k :=
-        lt_of_le_of_lt (Nat.sub_le_sub_right (Nat.sqrt_le_sqrt hn') _) (Nat.minFac_lemma n k h)
+      have : Nat.sqrt n' - k < Nat.sqrt n + 2 - k := by
+        have := (Nat.minFac_lemma n k h); revert this; gcongr -- TODO: use `gconvert`
+        exact Nat.sqrt_le_sqrt hn'
       @minSqFacAux_has_prop n' (k + 2) (pos_of_dvd_of_pos nd' n0) (i + 1)
         (by simp [e, left_distrib]) fun m m2 d => ?_
     rcases Nat.eq_or_lt_of_le (ih m m2 (dvd_trans d nd')) with me | ml

--- a/Mathlib/Geometry/Euclidean/Angle/Oriented/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Oriented/Basic.lean
@@ -794,8 +794,7 @@ theorem oangle_sign_smul_add_right (x y : V) (r : ℝ) :
       intro hz
     · simpa [hz] using (h' 0).1
     · simpa [hz] using (h' r').1
-  have hs : ∀ z : V × V, z ∈ s → o.oangle z.1 z.2 ≠ 0 ∧ o.oangle z.1 z.2 ≠ π := by
-    grind [Set.mem_image]
+  have hs : ∀ z : V × V, z ∈ s → o.oangle z.1 z.2 ≠ 0 ∧ o.oangle z.1 z.2 ≠ π := by grind
   have hx : (x, y) ∈ s := by
     convert Set.mem_image_of_mem (fun r' : ℝ => (x, r' • x + y)) (Set.mem_univ 0)
     simp

--- a/Mathlib/LinearAlgebra/LinearPMap.lean
+++ b/Mathlib/LinearAlgebra/LinearPMap.lean
@@ -829,7 +829,7 @@ theorem mem_range_iff {f : E →ₗ.[R] F} {y : F} : y ∈ Set.range f ↔ ∃ x
     use x
     rw [← h]
     exact f.mem_graph ⟨x, hx⟩
-  grind [mem_graph_iff, Set.mem_range]
+  grind [mem_graph_iff]
 
 theorem mem_domain_iff_of_eq_graph {f g : E →ₗ.[R] F} (h : f.graph = g.graph) {x : E} :
     x ∈ f.domain ↔ x ∈ g.domain := by simp_rw [mem_domain_iff, h]

--- a/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Lemmas.lean
@@ -270,8 +270,7 @@ lemma chainBotCoeff_mul_chainTopCoeff :
     simp only [root_reflectionPerm, reflection_apply_self, indexNeg_neg]; rw [← h₁]; abel
   have h₂' : P.root (-k) + P.root j = P.root (-m) := by
     simp only [root_reflectionPerm, reflection_apply_self, indexNeg_neg]; rw [← h₂]; abel
-  have h₃' : P.root (-k) + P.root j - P.root i ∈ range P.root := by
-    grind [Set.mem_range]
+  have h₃' : P.root (-k) + P.root j - P.root i ∈ range P.root := by grind
   /- Proceed to the main argument, following Geck's case splits. It's all just bookkeeping. -/
   rcases aux_0 hik_mem with hki | ⟨hki, hik⟩
   · /- Geck "Case 1" -/

--- a/Mathlib/MeasureTheory/Function/AEMeasurableOrder.lean
+++ b/Mathlib/MeasureTheory/Function/AEMeasurableOrder.lean
@@ -66,8 +66,7 @@ theorem MeasureTheory.aemeasurable_of_exist_almost_disjoint_supersets {α : Type
       _ ≤ ∑' (p : s) (q : ↥(s ∩ Ioi p)), μ (u p q ∩ v p q) := by
         gcongr with p q
         exact biInter_subset_of_mem q.2
-      _ = ∑' (p : s) (_ : ↥(s ∩ Ioi p)), (0 : ℝ≥0∞) := by
-        grind [Set.mem_inter_iff]
+      _ = ∑' (p : s) (_ : ↥(s ∩ Ioi p)), (0 : ℝ≥0∞) := by grind
       _ = 0 := by simp only [tsum_zero]
   have ff' : ∀ᵐ x ∂μ, f x = f' x := by
     have : ∀ᵐ x ∂μ, x ∉ t := by

--- a/Mathlib/MeasureTheory/Integral/Bochner/VitaliCaratheodory.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/VitaliCaratheodory.lean
@@ -443,7 +443,7 @@ theorem exists_lt_lowerSemicontinuous_integral_lt [SigmaFinite μ] (f : α → �
       LowerSemicontinuous g ∧
       Integrable (fun x => EReal.toReal (g x)) μ ∧
       (∀ᵐ x ∂μ, g x < ⊤) ∧ (∫ x, EReal.toReal (g x) ∂μ) < (∫ x, f x ∂μ) + ε := by
-  let δ : ℝ≥0 := ⟨ε / 2, (half_pos εpos).le⟩
+  let δ : ℝ := ε / 2
   have δpos : 0 < δ := half_pos εpos
   let fp : α → ℝ≥0 := fun x => Real.toNNReal (f x)
   have int_fp : Integrable (fun x => (fp x : ℝ)) μ := hf.real_toNNReal

--- a/Mathlib/MeasureTheory/Integral/Bochner/VitaliCaratheodory.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/VitaliCaratheodory.lean
@@ -476,7 +476,7 @@ theorem exists_lt_lowerSemicontinuous_integral_lt [SigmaFinite μ] (f : α → �
           apply sub_lt_sub_right
           convert gpint
           simp only [EReal.toReal_coe_ennreal]
-        _ ≤ (∫ x : α, ↑(fp x) ∂μ) + ↑δ - ((∫ x : α, ↑(fm x) ∂μ) - δ) := sub_le_sub_left gmint _
+        _ ≤ (∫ x : α, ↑(fp x) ∂μ) + ↑δ - ((∫ x : α, ↑(fm x) ∂μ) - δ) := by grw [gmint]
         _ = (∫ x : α, f x ∂μ) + 2 * δ := by
           simp_rw [integral_eq_integral_pos_part_sub_integral_neg_part hf]; ring
         _ = (∫ x : α, f x ∂μ) + ε := by congr 1; field_simp [δ, mul_comm]

--- a/Mathlib/MeasureTheory/Integral/FinMeasAdditive.lean
+++ b/Mathlib/MeasureTheory/Integral/FinMeasAdditive.lean
@@ -278,8 +278,7 @@ theorem map_setToSimpleFunc (T : Set α → F →L[ℝ] F') (h_add : FinMeasAddi
     rw [hx.2]
   · exact fun i => measurableSet_fiber _ _
   · grind [Finset.mem_filter]
-  · grind [Set.disjoint_iff, Set.subset_def, Set.mem_inter_iff, Set.mem_singleton_iff,
-      Set.mem_preimage]
+  · grind [Set.disjoint_iff]
 
 theorem setToSimpleFunc_congr' (T : Set α → E →L[ℝ] F) (h_add : FinMeasAdditive μ T) {f g : α →ₛ E}
     (hf : Integrable f μ) (hg : Integrable g μ)

--- a/Mathlib/MeasureTheory/PiSystem.lean
+++ b/Mathlib/MeasureTheory/PiSystem.lean
@@ -268,8 +268,8 @@ theorem mem_generatePiSystem_iUnion_elim {α β} {g : β → Set (Set α)} (h_pi
       else if b ∈ T_t' then f_t' b else (∅ : Set α)
     constructor
     · ext a
-      simp_rw [Set.mem_inter_iff, Set.mem_iInter, Finset.mem_union, or_imp]
-      grind [Set.mem_inter_iff]
+      simp_rw [Set.mem_inter_iff, Set.mem_iInter, Finset.mem_union]
+      grind
     intro b h_b
     split_ifs with hbs hbt hbt
     · refine h_pi b (f_s b) (h_s b hbs) (f_t' b) (h_t' b hbt) (Set.Nonempty.mono ?_ h_nonempty)

--- a/Mathlib/Order/ConditionallyCompleteLattice/Finset.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Finset.lean
@@ -114,9 +114,8 @@ theorem Set.Finite.ciSup_lt_iff {s : Set ι} {f : ι → α} (hs : s.Finite)
     · simp only [mem_range]
       refine ⟨x, ?_⟩
       simp [hx]
-  · intro H
-    have := hs.ciSup_mem_image _ h
-    grind [Set.mem_image]
+  · have := hs.ciSup_mem_image _ h
+    grind
 
 theorem Set.Finite.lt_ciInf_iff {s : Set ι} {f : ι → α} (hs : s.Finite)
     (h : ∃ x ∈ s, f x ≤ sInf ∅) :

--- a/Mathlib/Probability/Independence/Kernel.lean
+++ b/Mathlib/Probability/Independence/Kernel.lean
@@ -1056,7 +1056,7 @@ theorem iIndepFun.indepFun_finset (S T : Finset ι) (hST : Disjoint S T)
     f (↑i) ω) ⁻¹' Set.pi Set.univ sets_s = ⋂ i ∈ S, f i ⁻¹' sets_s' i := by
     ext1 x
     simp_rw [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
-    constructor <;> intro h <;> grind [Set.mem_preimage]
+    grind
   have h_eq_inter_T : (fun (ω : Ω) (i : ↥T) => f (↑i) ω) ⁻¹' Set.pi Set.univ sets_t
     = ⋂ i ∈ T, f i ⁻¹' sets_t' i := by
     ext1 x

--- a/Mathlib/RingTheory/Polynomial/Pochhammer.lean
+++ b/Mathlib/RingTheory/Polynomial/Pochhammer.lean
@@ -474,7 +474,9 @@ theorem monotoneOn_descPochhammer_eval (n : ℕ) :
     have ha_sub1 : n - 1 ≤ a := (sub_le_self (n : S) zero_le_one).trans ha
     have hb_sub1 : n - 1 ≤ b := (sub_le_self (n : S) zero_le_one).trans hb
     simp_rw [descPochhammer_succ_eval]
-    exact mul_le_mul (ih ha_sub1 hb_sub1 hab) (sub_le_sub_right hab (n : S))
-      (sub_nonneg_of_le ha) (descPochhammer_nonneg hb_sub1)
+    gcongr
+    · exact sub_nonneg_of_le ha
+    · exact descPochhammer_nonneg hb_sub1
+    exact ih ha_sub1 hb_sub1 hab
 
 end StrictOrderedRing

--- a/Mathlib/RingTheory/Smooth/StandardSmoothCotangent.lean
+++ b/Mathlib/RingTheory/Smooth/StandardSmoothCotangent.lean
@@ -183,9 +183,8 @@ lemma sectionCotangent_zero_of_notMem_range (i : ι) (hi : i ∉ Set.range P.map
   classical
   contrapose hi
   rw [sectionCotangent_eq_iff] at hi
-  simp only [Basis.repr_self, map_zero, Pi.zero_apply, not_forall,
-    Finsupp.single_apply, ite_eq_right_iff] at hi
-  grind [Set.mem_range]
+  simp only [Basis.repr_self, map_zero, Pi.zero_apply, Finsupp.single_apply] at hi
+  grind
 
 @[deprecated (since := "2025-05-23")]
 alias sectionCotangent_zero_of_not_mem_range := sectionCotangent_zero_of_notMem_range

--- a/Mathlib/Topology/Algebra/IsUniformGroup/Basic.lean
+++ b/Mathlib/Topology/Algebra/IsUniformGroup/Basic.lean
@@ -399,11 +399,8 @@ theorem extend_Z_bilin : Continuous (extend (de.prodMap df) (fun p : β × δ =>
     rw [mem_map, mem_comap, nhds_prod_eq]
     exists (U' ×ˢ V') ×ˢ U' ×ˢ V'
     rw [mem_prod_same_iff]
-    simp only
-    constructor
-    · have := prod_mem_prod U'_nhds V'_nhds
-      tauto
-    · grind [Set.subset_def, Set.mem_preimage, Set.mem_prod]
+    have := prod_mem_prod U'_nhds V'_nhds
+    grind
 
 end IsDenseInducing
 

--- a/Mathlib/Topology/ContinuousMap/Polynomial.lean
+++ b/Mathlib/Topology/ContinuousMap/Polynomial.lean
@@ -167,7 +167,7 @@ theorem polynomialFunctions.comap_compRightAlgHom_iccHomeoI (a b : ℝ) (h : a <
     (polynomialFunctions I).comap (compRightAlgHom ℝ ℝ (iccHomeoI a b h).symm) =
       polynomialFunctions (Set.Icc a b) := by
   ext f
-  fconstructor
+  constructor
   · rintro ⟨p, ⟨-, w⟩⟩
     rw [DFunLike.ext_iff] at w
     dsimp at w
@@ -191,11 +191,9 @@ theorem polynomialFunctions.comap_compRightAlgHom_iccHomeoI (a b : ℝ) (h : a <
         rw [mul_comm (b - a)⁻¹, ← neg_mul, ← add_mul, ← sub_eq_add_neg]
         have w₁ : 0 < (b - a)⁻¹ := inv_pos.mpr (sub_pos.mpr h)
         have w₂ : 0 ≤ (x : ℝ) - a := sub_nonneg.mpr x.2.1
-        have w₃ : (x : ℝ) - a ≤ b - a := sub_le_sub_right x.2.2 a
-        fconstructor
+        constructor
         · exact mul_nonneg w₂ (le_of_lt w₁)
-        · rw [← div_eq_mul_inv, div_le_one (sub_pos.mpr h)]
-          exact w₃
+        · grw [← div_eq_mul_inv, div_le_one (sub_pos.mpr h), x.2.2]
   · rintro ⟨p, ⟨-, rfl⟩⟩
     let q := p.comp ((b - a) • Polynomial.X + Polynomial.C a)
     refine ⟨q, ⟨?_, ?_⟩⟩

--- a/Mathlib/Topology/MetricSpace/Completion.lean
+++ b/Mathlib/Topology/MetricSpace/Completion.lean
@@ -129,7 +129,7 @@ protected theorem mem_uniformity_dist (s : Set (Completion α × Completion α))
         simp only [Real.dist_eq, mem_setOf_eq, preimage_setOf_eq, Completion.dist_self,
           Completion.dist_comm, zero_sub, abs_neg, r] at I
       exact lt_of_le_of_lt (le_abs_self _) I
-    grind [Set.subset_def]
+    grind
 
 /-- Reformulate `Completion.mem_uniformity_dist` in terms that are suitable for the definition
 of the metric space structure. -/


### PR DESCRIPTION
Oops, wrong branch

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
