### PR TITLE
[Merged by Bors] - chore: remove redundant arguments to `grind`

### DIFF
--- a/Mathlib/Data/List/OfFn.lean
+++ b/Mathlib/Data/List/OfFn.lean
@@ -104,8 +104,7 @@ theorem ofFn_getElem_eq_map {β : Type*} (l : List α) (f : α → β) :
 
 -- Note there is a now another `mem_ofFn` defined in Lean, with an existential on the RHS,
 -- which is marked as a simp lemma.
-theorem mem_ofFn' {n} (f : Fin n → α) (a : α) : a ∈ ofFn f ↔ a ∈ Set.range f := by
-  grind [Set.mem_range]
+theorem mem_ofFn' {n} (f : Fin n → α) (a : α) : a ∈ ofFn f ↔ a ∈ Set.range f := by grind
 
 theorem forall_mem_ofFn_iff {n : ℕ} {f : Fin n → α} {P : α → Prop} :
     (∀ i ∈ ofFn f, P i) ↔ ∀ j : Fin n, P (f j) := by simp

--- a/Mathlib/Geometry/Euclidean/Angle/Oriented/Basic.lean
+++ b/Mathlib/Geometry/Euclidean/Angle/Oriented/Basic.lean
@@ -794,8 +794,7 @@ theorem oangle_sign_smul_add_right (x y : V) (r : ℝ) :
       intro hz
     · simpa [hz] using (h' 0).1
     · simpa [hz] using (h' r').1
-  have hs : ∀ z : V × V, z ∈ s → o.oangle z.1 z.2 ≠ 0 ∧ o.oangle z.1 z.2 ≠ π := by
-    grind [Set.mem_image]
+  have hs : ∀ z : V × V, z ∈ s → o.oangle z.1 z.2 ≠ 0 ∧ o.oangle z.1 z.2 ≠ π := by grind
   have hx : (x, y) ∈ s := by
     convert Set.mem_image_of_mem (fun r' : ℝ => (x, r' • x + y)) (Set.mem_univ 0)
     simp

--- a/Mathlib/LinearAlgebra/LinearPMap.lean
+++ b/Mathlib/LinearAlgebra/LinearPMap.lean
@@ -829,7 +829,7 @@ theorem mem_range_iff {f : E →ₗ.[R] F} {y : F} : y ∈ Set.range f ↔ ∃ x
     use x
     rw [← h]
     exact f.mem_graph ⟨x, hx⟩
-  grind [mem_graph_iff, Set.mem_range]
+  grind [mem_graph_iff]
 
 theorem mem_domain_iff_of_eq_graph {f g : E →ₗ.[R] F} (h : f.graph = g.graph) {x : E} :
     x ∈ f.domain ↔ x ∈ g.domain := by simp_rw [mem_domain_iff, h]

--- a/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Lemmas.lean
@@ -270,8 +270,7 @@ lemma chainBotCoeff_mul_chainTopCoeff :
     simp only [root_reflectionPerm, reflection_apply_self, indexNeg_neg]; rw [← h₁]; abel
   have h₂' : P.root (-k) + P.root j = P.root (-m) := by
     simp only [root_reflectionPerm, reflection_apply_self, indexNeg_neg]; rw [← h₂]; abel
-  have h₃' : P.root (-k) + P.root j - P.root i ∈ range P.root := by
-    grind [Set.mem_range]
+  have h₃' : P.root (-k) + P.root j - P.root i ∈ range P.root := by grind
   /- Proceed to the main argument, following Geck's case splits. It's all just bookkeeping. -/
   rcases aux_0 hik_mem with hki | ⟨hki, hik⟩
   · /- Geck "Case 1" -/

--- a/Mathlib/MeasureTheory/Function/AEMeasurableOrder.lean
+++ b/Mathlib/MeasureTheory/Function/AEMeasurableOrder.lean
@@ -66,8 +66,7 @@ theorem MeasureTheory.aemeasurable_of_exist_almost_disjoint_supersets {α : Type
       _ ≤ ∑' (p : s) (q : ↥(s ∩ Ioi p)), μ (u p q ∩ v p q) := by
         gcongr with p q
         exact biInter_subset_of_mem q.2
-      _ = ∑' (p : s) (_ : ↥(s ∩ Ioi p)), (0 : ℝ≥0∞) := by
-        grind [Set.mem_inter_iff]
+      _ = ∑' (p : s) (_ : ↥(s ∩ Ioi p)), (0 : ℝ≥0∞) := by grind
       _ = 0 := by simp only [tsum_zero]
   have ff' : ∀ᵐ x ∂μ, f x = f' x := by
     have : ∀ᵐ x ∂μ, x ∉ t := by

--- a/Mathlib/MeasureTheory/Integral/FinMeasAdditive.lean
+++ b/Mathlib/MeasureTheory/Integral/FinMeasAdditive.lean
@@ -278,8 +278,7 @@ theorem map_setToSimpleFunc (T : Set α → F →L[ℝ] F') (h_add : FinMeasAddi
     rw [hx.2]
   · exact fun i => measurableSet_fiber _ _
   · grind [Finset.mem_filter]
-  · grind [Set.disjoint_iff, Set.subset_def, Set.mem_inter_iff, Set.mem_singleton_iff,
-      Set.mem_preimage]
+  · grind [Set.disjoint_iff]
 
 theorem setToSimpleFunc_congr' (T : Set α → E →L[ℝ] F) (h_add : FinMeasAdditive μ T) {f g : α →ₛ E}
     (hf : Integrable f μ) (hg : Integrable g μ)

--- a/Mathlib/MeasureTheory/PiSystem.lean
+++ b/Mathlib/MeasureTheory/PiSystem.lean
@@ -268,8 +268,8 @@ theorem mem_generatePiSystem_iUnion_elim {α β} {g : β → Set (Set α)} (h_pi
       else if b ∈ T_t' then f_t' b else (∅ : Set α)
     constructor
     · ext a
-      simp_rw [Set.mem_inter_iff, Set.mem_iInter, Finset.mem_union, or_imp]
-      grind [Set.mem_inter_iff]
+      simp_rw [Set.mem_inter_iff, Set.mem_iInter, Finset.mem_union]
+      grind
     intro b h_b
     split_ifs with hbs hbt hbt
     · refine h_pi b (f_s b) (h_s b hbs) (f_t' b) (h_t' b hbt) (Set.Nonempty.mono ?_ h_nonempty)

--- a/Mathlib/Order/ConditionallyCompleteLattice/Finset.lean
+++ b/Mathlib/Order/ConditionallyCompleteLattice/Finset.lean
@@ -114,9 +114,8 @@ theorem Set.Finite.ciSup_lt_iff {s : Set ι} {f : ι → α} (hs : s.Finite)
     · simp only [mem_range]
       refine ⟨x, ?_⟩
       simp [hx]
-  · intro H
-    have := hs.ciSup_mem_image _ h
-    grind [Set.mem_image]
+  · have := hs.ciSup_mem_image _ h
+    grind
 
 theorem Set.Finite.lt_ciInf_iff {s : Set ι} {f : ι → α} (hs : s.Finite)
     (h : ∃ x ∈ s, f x ≤ sInf ∅) :

--- a/Mathlib/Probability/Independence/Kernel.lean
+++ b/Mathlib/Probability/Independence/Kernel.lean
@@ -1056,7 +1056,7 @@ theorem iIndepFun.indepFun_finset (S T : Finset ι) (hST : Disjoint S T)
     f (↑i) ω) ⁻¹' Set.pi Set.univ sets_s = ⋂ i ∈ S, f i ⁻¹' sets_s' i := by
     ext1 x
     simp_rw [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
-    constructor <;> intro h <;> grind [Set.mem_preimage]
+    grind
   have h_eq_inter_T : (fun (ω : Ω) (i : ↥T) => f (↑i) ω) ⁻¹' Set.pi Set.univ sets_t
     = ⋂ i ∈ T, f i ⁻¹' sets_t' i := by
     ext1 x

--- a/Mathlib/RingTheory/Smooth/StandardSmoothCotangent.lean
+++ b/Mathlib/RingTheory/Smooth/StandardSmoothCotangent.lean
@@ -183,9 +183,8 @@ lemma sectionCotangent_zero_of_notMem_range (i : ι) (hi : i ∉ Set.range P.map
   classical
   contrapose hi
   rw [sectionCotangent_eq_iff] at hi
-  simp only [Basis.repr_self, map_zero, Pi.zero_apply, not_forall,
-    Finsupp.single_apply, ite_eq_right_iff] at hi
-  grind [Set.mem_range]
+  simp only [Basis.repr_self, map_zero, Pi.zero_apply, Finsupp.single_apply] at hi
+  grind
 
 @[deprecated (since := "2025-05-23")]
 alias sectionCotangent_zero_of_not_mem_range := sectionCotangent_zero_of_notMem_range

--- a/Mathlib/Topology/Algebra/IsUniformGroup/Basic.lean
+++ b/Mathlib/Topology/Algebra/IsUniformGroup/Basic.lean
@@ -399,11 +399,8 @@ theorem extend_Z_bilin : Continuous (extend (de.prodMap df) (fun p : β × δ =>
     rw [mem_map, mem_comap, nhds_prod_eq]
     exists (U' ×ˢ V') ×ˢ U' ×ˢ V'
     rw [mem_prod_same_iff]
-    simp only
-    constructor
-    · have := prod_mem_prod U'_nhds V'_nhds
-      tauto
-    · grind [Set.subset_def, Set.mem_preimage, Set.mem_prod]
+    have := prod_mem_prod U'_nhds V'_nhds
+    grind
 
 end IsDenseInducing
 

--- a/Mathlib/Topology/MetricSpace/Completion.lean
+++ b/Mathlib/Topology/MetricSpace/Completion.lean
@@ -129,7 +129,7 @@ protected theorem mem_uniformity_dist (s : Set (Completion α × Completion α))
         simp only [Real.dist_eq, mem_setOf_eq, preimage_setOf_eq, Completion.dist_self,
           Completion.dist_comm, zero_sub, abs_neg, r] at I
       exact lt_of_le_of_lt (le_abs_self _) I
-    grind [Set.subset_def]
+    grind
 
 /-- Reformulate `Completion.mem_uniformity_dist` in terms that are suitable for the definition
 of the metric space structure. -/


### PR DESCRIPTION
This PR cleans up some `grind` uses that have redundant arguments.

I observed that on the one hand new lemmas are getting tagged with `@[grind]`, and on the other hand `grind` is already being used to golf proofs using the same lemmas. Hence this PR.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
