### PR TITLE
[Merged by Bors] - chore(Logic/Equiv/Defs): avoid importing `PartialOrder`

### DIFF
--- a/Mathlib/Control/Traversable/Equiv.lean
+++ b/Mathlib/Control/Traversable/Equiv.lean
@@ -5,6 +5,7 @@ Authors: Simon Hudon
 -/
 import Mathlib.Control.Traversable.Lemmas
 import Mathlib.Logic.Equiv.Defs
+import Batteries.Tactic.SeqFocus
 
 /-!
 # Transferring `Traversable` instances along isomorphisms

--- a/Mathlib/Data/Nat/Bitwise.lean
+++ b/Mathlib/Data/Nat/Bitwise.lean
@@ -6,6 +6,7 @@ Authors: Markus Himmel, Alex Keizer
 import Mathlib.Algebra.Group.Nat.Even
 import Mathlib.Algebra.NeZero
 import Mathlib.Algebra.Ring.Nat
+import Mathlib.Data.Bool.Basic
 import Mathlib.Data.List.GetD
 import Mathlib.Data.Nat.Bits
 import Mathlib.Order.Basic

--- a/Mathlib/Logic/Equiv/Defs.lean
+++ b/Mathlib/Logic/Equiv/Defs.lean
@@ -3,7 +3,6 @@ Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Mario Carneiro
 -/
-import Mathlib.Data.Bool.Basic
 import Mathlib.Data.FunLike.Equiv
 import Mathlib.Data.Quot
 import Mathlib.Data.Subtype
@@ -531,8 +530,8 @@ def punitEquivPUnit : PUnit.{v} ≃ PUnit.{w} :=
 noncomputable def propEquivBool : Prop ≃ Bool where
   toFun p := @decide p (Classical.propDecidable _)
   invFun b := b
-  left_inv p := by simp [@Bool.decide_iff p (Classical.propDecidable _)]
-  right_inv b := by cases b <;> simp
+  left_inv p := by simp
+  right_inv b := by simp
 
 section
 

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -22,6 +22,7 @@
   "Batteries.Tactic.Relation.Rfl",
   "Batteries.Tactic.Relation.Symm",
   "Batteries.Tactic.Replace",
+  "Batteries.Tactic.SeqFocus",
   "Batteries.Tactic.Simpa",
   "Batteries.Tactic.SolveByElim",
   "Batteries.Tactic.SolveByElim.Backtrack",


### PR DESCRIPTION
I noticed that the defitinion of `Equiv` imports `ParitalOrder`, which is suspicious, and easy to fix.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
