### PR TITLE
[Merged by Bors] - feat: separate linter error message for empty doc-strings

### DIFF
--- a/Mathlib/Tactic/FunProp/Decl.lean
+++ b/Mathlib/Tactic/FunProp/Decl.lean
@@ -36,7 +36,7 @@ structure FunPropDecls where
   decls : DiscrTree FunPropDecl := {}
   deriving Inhabited
 
-set_option linter.style.docString false in
+set_option linter.style.docString.empty false in
 /-- -/
 abbrev FunPropDeclsExt := SimpleScopedEnvExtension FunPropDecl FunPropDecls
 

--- a/Mathlib/Tactic/FunProp/Theorems.lean
+++ b/Mathlib/Tactic/FunProp/Theorems.lean
@@ -168,7 +168,7 @@ structure FunctionTheorem where
 
 private local instance : Ord Name := ⟨Name.quickCmp⟩
 
-set_option linter.style.docString false in
+set_option linter.style.docString.empty false in
 /-- -/
 structure FunctionTheorems where
   /-- map: function name → function property → function theorem -/
@@ -183,7 +183,7 @@ def FunctionTheorem.getProof (thm : FunctionTheorem) : MetaM Expr := do
   | .decl name => mkConstWithFreshMVarLevels name
   | .fvar id => return .fvar id
 
-set_option linter.style.docString false in
+set_option linter.style.docString.empty false in
 /-- -/
 abbrev FunctionTheoremsExt := SimpleScopedEnvExtension FunctionTheorem FunctionTheorems
 
@@ -202,7 +202,7 @@ initialize functionTheoremsExt : FunctionTheoremsExt ←
               thms.push e}
   }
 
-set_option linter.style.docString false in
+set_option linter.style.docString.empty false in
 /-- -/
 def getTheoremsForFunction (funName : Name) (funPropName : Name) :
     CoreM (Array FunctionTheorem) := do

--- a/Mathlib/Tactic/FunProp/Types.lean
+++ b/Mathlib/Tactic/FunProp/Types.lean
@@ -136,7 +136,7 @@ def Context.increaseTransitionDepth (ctx : Context) : Context :=
 /-- Monad to run `fun_prop` tactic in. -/
 abbrev FunPropM := ReaderT FunProp.Context <| StateT FunProp.State MetaM
 
-set_option linter.style.docString false in
+set_option linter.style.docString.empty false in
 /-- Result of `funProp`, it is a proof of function property `P f` -/
 structure Result where
   /-- -/

--- a/Mathlib/Tactic/Linter/DocString.lean
+++ b/Mathlib/Tactic/Linter/DocString.lean
@@ -55,7 +55,8 @@ namespace Style
 
 @[inherit_doc Mathlib.Linter.linter.style.docString]
 def docStringLinter : Linter where run := withSetOptionIn fun stx ↦ do
-  unless getLinterValue linter.style.docString (← getLinterOptions) do
+  unless getLinterValue linter.style.docString (← getLinterOptions) ||
+      getLinterValue linter.style.docString.empty (← getLinterOptions) do
     return
   if (← get).messages.hasErrors then
     return
@@ -73,7 +74,7 @@ def docStringLinter : Linter where run := withSetOptionIn fun stx ↦ do
     -- any leading whitespace before the actual string starts.
     let docString ← try getDocStringText ⟨docStx⟩ catch _ => continue
     if docString.trim.isEmpty then
-      Linter.logLint linter.style.docString.empty docStx m!"warning: this doc-string is empty"
+      Linter.logLintIf linter.style.docString.empty docStx m!"warning: this doc-string is empty"
       continue
     -- `startSubstring` is the whitespace between `/--` and the actual doc-string text.
     let startSubstring := match docStx with
@@ -83,7 +84,7 @@ def docStringLinter : Linter where run := withSetOptionIn fun stx ↦ do
     let start := deindentString currIndent startSubstring.toString
     if !#["\n", " "].contains start then
       let startRange := {start := startSubstring.startPos, stop := startSubstring.stopPos}
-      Linter.logLint linter.style.docString (.ofRange startRange)
+      Linter.logLintIf linter.style.docString (.ofRange startRange)
         s!"error: doc-strings should start with a single space or newline"
 
     let deIndentedDocString := deindentString currIndent docString
@@ -94,10 +95,10 @@ def docStringLinter : Linter where run := withSetOptionIn fun stx ↦ do
     let endRange (n : Nat) : Syntax := .ofRange
       {start := docStx.getTailPos?.get! - ⟨n⟩, stop := docStx.getTailPos?.get! - ⟨n⟩}
     if docTrim.takeRight 1 == "," then
-      Linter.logLint linter.style.docString (endRange (docString.length - tail + 3))
+      Linter.logLintIf linter.style.docString (endRange (docString.length - tail + 3))
         s!"error: doc-strings should not end with a comma"
     if tail + 1 != deIndentedDocString.length then
-      Linter.logLint linter.style.docString (endRange 3)
+      Linter.logLintIf linter.style.docString (endRange 3)
         s!"error: doc-strings should end with a single space or newline"
 
 initialize addLinter docStringLinter

--- a/Mathlib/Tactic/Linter/DocString.lean
+++ b/Mathlib/Tactic/Linter/DocString.lean
@@ -25,6 +25,14 @@ register_option linter.style.docString : Bool := {
 }
 
 /--
+The "empty doc string" warns on empty doc-strings.
+-/
+register_option linter.style.docString.empty : Bool := {
+  defValue := true
+  descr := "enable the style.docString.empty linter"
+}
+
+/--
 Extract all `declModifiers` from the input syntax. We later extract the `docstring` from it,
 but we avoid extracting directly the `docComment` node, to skip `#adaptation_note`s.
 -/
@@ -64,6 +72,9 @@ def docStringLinter : Linter where run := withSetOptionIn fun stx ↦ do
     -- `docString` contains e.g. trailing spaces before the `-/`, but does not contain
     -- any leading whitespace before the actual string starts.
     let docString ← try getDocStringText ⟨docStx⟩ catch _ => continue
+    if docString.trim.isEmpty then
+      Linter.logLint linter.style.docString.empty docStx m!"warning: this doc-string is empty"
+      continue
     -- `startSubstring` is the whitespace between `/--` and the actual doc-string text.
     let startSubstring := match docStx with
       | .node _ _ #[(.atom si ..), _] => si.getTrailing?.getD default

--- a/MathlibTest/DocString.lean
+++ b/MathlibTest/DocString.lean
@@ -31,6 +31,19 @@ Note: This linter can be disabled with `set_option linter.style.docString.empty 
 -/
 example : Nat := 0
 
+set_option linter.style.docString.empty false
+/---/
+example : Nat := 0
+
+set_option linter.style.docString.empty true
+set_option linter.style.docString false
+
+#guard_msgs in
+/--Missing space -/
+example : Nat := 1
+
+set_option linter.style.docString true
+
 /--
 warning: error: doc-strings should start with a single space or newline
 

--- a/MathlibTest/DocString.lean
+++ b/MathlibTest/DocString.lean
@@ -13,6 +13,25 @@ example : True := by
   trivial
 
 /--
+warning: warning: this doc-string is empty
+
+Note: This linter can be disabled with `set_option linter.style.docString.empty false`
+-/
+#guard_msgs in
+/---/
+example : Nat := 0
+
+/--
+warning: warning: this doc-string is empty
+
+Note: This linter can be disabled with `set_option linter.style.docString.empty false`
+-/
+#guard_msgs in
+/--
+-/
+example : Nat := 0
+
+/--
 warning: error: doc-strings should start with a single space or newline
 
 Note: This linter can be disabled with `set_option linter.style.docString false`


### PR DESCRIPTION
While functionally empty doc-strings are already linted for today, this provides a clearer error message.

Unlike the `docString` linter, this linter is enabled by default.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
