### PR TITLE
[Merged by Bors] - chore: move Fin lemmas out of the BitVec file

### DIFF
--- a/Mathlib/Algebra/Group/Fin/Basic.lean
+++ b/Mathlib/Algebra/Group/Fin/Basic.lean
@@ -90,6 +90,12 @@ instance instAddRightCancelSemigroup (n : ℕ) : AddRightCancelSemigroup (Fin n)
 
 /-! ### Miscellaneous lemmas -/
 
+open scoped Fin.NatCast Fin.IntCast in
+/-- Variant of `Fin.intCast_def` with `Nat.cast` on the RHS. -/
+theorem intCast_def' {n : Nat} [NeZero n] (x : Int) :
+    (x : Fin n) = if 0 ≤ x then ↑x.natAbs else -↑x.natAbs :=
+  Fin.intCast_def _
+
 lemma coe_sub_one (a : Fin (n + 1)) : ↑(a - 1) = if a = 0 then n else a - 1 := by
   cases n
   · simp

--- a/Mathlib/Data/BitVec.lean
+++ b/Mathlib/Data/BitVec.lean
@@ -66,28 +66,6 @@ instance : CommSemiring (BitVec w) :=
     (fun _ => rfl) /- toFin_natCast -/
 -- The statement in the new API would be: `n#(k.succ) = ((n / 2)#k).concat (n % 2 != 0)`
 
--- Variant of `Fin.intCast_def` for when we are using the `Fin.CommRing` instance.
-open Fin.CommRing in
-theorem _root_.Fin.intCast_def' {n : Nat} [NeZero n] (x : Int) :
-    (x : Fin n) = if 0 ≤ x then Fin.ofNat n x.natAbs else -Fin.ofNat n x.natAbs := by
-  unfold Fin.instCommRing
-  dsimp [Int.cast, IntCast.intCast, Int.castDef]
-  split <;> (simp [Fin.intCast]; omega)
-
-open Fin.CommRing in
-@[simp] theorem _root_.Fin.val_intCast {n : Nat} [NeZero n] (x : Int) :
-    (x : Fin n).val = (x % n).toNat := by
-  rw [Fin.intCast_def']
-  split <;> rename_i h
-  · simp [Int.emod_natAbs_of_nonneg h]
-  · simp only [Fin.ofNat_eq_cast, Fin.val_neg, Fin.natCast_eq_zero, Fin.val_natCast]
-    split <;> rename_i h
-    · rw [← Int.natCast_dvd] at h
-      rw [Int.emod_eq_zero_of_dvd h, Int.toNat_zero]
-    · rw [Int.emod_natAbs_of_neg (by omega) (NeZero.ne n), if_neg (by rwa [← Int.natCast_dvd] at h)]
-      have : x % n < n := Int.emod_lt_of_pos x (by have := NeZero.ne n; omega)
-      omega
-
 -- TODO: move to the Lean4 repository.
 open Fin.CommRing in
 theorem ofFin_intCast (z : ℤ) : ofFin (z : Fin (2^w)) = ↑z := by

--- a/Mathlib/Data/ZMod/Defs.lean
+++ b/Mathlib/Data/ZMod/Defs.lean
@@ -45,11 +45,6 @@ open Nat.ModEq Int
 
 open scoped Fin.IntCast Fin.NatCast
 
-/-- Variant of `Fin.intCast_def` with `Nat.cast` on the RHS. -/
-theorem intCast_def' {n : Nat} [NeZero n] (x : Int) :
-    (x : Fin n) = if 0 ≤ x then ↑x.natAbs else -↑x.natAbs :=
-  Fin.intCast_def _
-
 @[simp] theorem val_intCast {n : Nat} [NeZero n] (x : Int) :
     (x : Fin n).val = (x % n).toNat := by
   rw [Fin.intCast_def']

--- a/Mathlib/Data/ZMod/Defs.lean
+++ b/Mathlib/Data/ZMod/Defs.lean
@@ -43,6 +43,26 @@ to register the ring structure on `ZMod n` as type class instance.
 
 open Nat.ModEq Int
 
+open scoped Fin.IntCast Fin.NatCast
+
+/-- Variant of `Fin.intCast_def` with `Nat.cast` on the RHS. -/
+theorem intCast_def' {n : Nat} [NeZero n] (x : Int) :
+    (x : Fin n) = if 0 ≤ x then ↑x.natAbs else -↑x.natAbs :=
+  Fin.intCast_def _
+
+@[simp] theorem val_intCast {n : Nat} [NeZero n] (x : Int) :
+    (x : Fin n).val = (x % n).toNat := by
+  rw [Fin.intCast_def']
+  split <;> rename_i h
+  · simp [Int.emod_natAbs_of_nonneg h]
+  · simp only [Fin.val_neg, Fin.natCast_eq_zero, Fin.val_natCast]
+    split <;> rename_i h
+    · rw [← Int.natCast_dvd] at h
+      rw [Int.emod_eq_zero_of_dvd h, Int.toNat_zero]
+    · rw [Int.emod_natAbs_of_neg (by omega) (NeZero.ne n), if_neg (by rwa [← Int.natCast_dvd] at h)]
+      have : x % n < n := Int.emod_lt_of_pos x (by have := NeZero.ne n; omega)
+      omega
+
 /-- Multiplicative commutative semigroup structure on `Fin n`. -/
 instance instCommSemigroup (n : ℕ) : CommSemigroup (Fin n) :=
   { inferInstanceAs (Mul (Fin n)) with


### PR DESCRIPTION
This lemma doesn't belong in a file about BitVec, it's part of the ring structure on Fin.

One of the proofs can be greatly golfed.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
