### PR TITLE
[Merged by Bors] - chore(Algebra/Order): golf `smul_nonneg_iff_pos_imp_nonneg` using `grind`

### DIFF
--- a/Mathlib/Algebra/Order/Module/Defs.lean
+++ b/Mathlib/Algebra/Order/Module/Defs.lean
@@ -946,8 +946,7 @@ lemma smul_nonpos_iff : a • b ≤ 0 ↔ 0 ≤ a ∧ b ≤ 0 ∨ a ≤ 0 ∧ 0 
   rw [← neg_nonneg, ← smul_neg, smul_nonneg_iff, neg_nonneg, neg_nonpos]
 
 lemma smul_nonneg_iff_pos_imp_nonneg : 0 ≤ a • b ↔ (0 < a → 0 ≤ b) ∧ (0 < b → 0 ≤ a) :=
-  smul_nonneg_iff.trans <| by
-    simp_rw [← not_le, ← or_iff_not_imp_left]; have := le_total a 0; have := le_total b 0; tauto
+  smul_nonneg_iff.trans <| by grind
 
 lemma smul_nonneg_iff_neg_imp_nonpos : 0 ≤ a • b ↔ (a < 0 → b ≤ 0) ∧ (b < 0 → a ≤ 0) := by
   rw [← neg_smul_neg, smul_nonneg_iff_pos_imp_nonneg]; simp only [neg_pos, neg_nonneg]


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>smul_nonneg_iff_pos_imp_nonneg</code></summary>

### Trace profiling of `smul_nonneg_iff_pos_imp_nonneg` before PR 27905
```
info: Mathlib/Algebra/Order/Module/Defs.lean:949:0: [Elab.command] [0.046177] theorem smul_nonneg_iff_pos_imp_nonneg : 0 ≤ a • b ↔ (0 < a → 0 ≤ b) ∧ (0 < b → 0 ≤ a) :=
      smul_nonneg_iff.trans <| by simp_rw [← not_le, ← or_iff_not_imp_left]; have := le_total a 0; have := le_total b 0;
        tauto
  [Elab.definition.header] [0.025241] smul_nonneg_iff_pos_imp_nonneg
    [Elab.step] [0.025039] expected type: Prop, term
        0 ≤ a • b ↔ (0 < a → 0 ≤ b) ∧ (0 < b → 0 ≤ a)
      [Elab.step] [0.025027] expected type: Prop, term
          Iff✝ (0 ≤ a • b) ((0 < a → 0 ≤ b) ∧ (0 < b → 0 ≤ a))
        [Elab.step] [0.015024] expected type: Prop, term
            0 ≤ a • b
          [Elab.step] [0.015014] expected type: Prop, term
              binrel% LE.le✝ 0 (a • b)
info: Mathlib/Algebra/Order/Module/Defs.lean:949:0: [Elab.command] [0.046343] lemma smul_nonneg_iff_pos_imp_nonneg : 0 ≤ a • b ↔ (0 < a → 0 ≤ b) ∧ (0 < b → 0 ≤ a) :=
      smul_nonneg_iff.trans <| by simp_rw [← not_le, ← or_iff_not_imp_left]; have := le_total a 0; have := le_total b 0;
        tauto
info: Mathlib/Algebra/Order/Module/Defs.lean:949:0: [Elab.async] [0.928801] elaborating proof of smul_nonneg_iff_pos_imp_nonneg
  [Elab.definition.value] [0.925582] smul_nonneg_iff_pos_imp_nonneg
    [Elab.step] [0.918618] simp_rw [← not_le, ← or_iff_not_imp_left]; have := le_total a 0; have := le_total b 0; tauto
      [Elab.step] [0.918605] simp_rw [← not_le, ← or_iff_not_imp_left]; have := le_total a 0; have := le_total b 0;
            tauto
        [Elab.step] [0.011815] simp_rw [← not_le, ← or_iff_not_imp_left]
        [Elab.step] [0.899019] tauto
          [Elab.step] [0.012555] assumption
          [Elab.step] [0.013428] assumption
          [Elab.step] [0.023964] assumption
          [Elab.step] [0.025600] assumption
          [Elab.step] [0.017303] assumption
          [Elab.step] [0.015417] assumption
          [Elab.step] [0.018547] assumption
```

### Trace profiling of `smul_nonneg_iff_pos_imp_nonneg` after PR 27905
```diff
diff --git a/Mathlib/Algebra/Order/Module/Defs.lean b/Mathlib/Algebra/Order/Module/Defs.lean
index 4671d02c82..fe308bfa56 100644
--- a/Mathlib/Algebra/Order/Module/Defs.lean
+++ b/Mathlib/Algebra/Order/Module/Defs.lean
@@ -947,5 +947,5 @@ lemma smul_nonpos_iff : a • b ≤ 0 ↔ 0 ≤ a ∧ b ≤ 0 ∨ a ≤ 0 ∧ 0
 
+set_option trace.profiler true in
 lemma smul_nonneg_iff_pos_imp_nonneg : 0 ≤ a • b ↔ (0 < a → 0 ≤ b) ∧ (0 < b → 0 ≤ a) :=
-  smul_nonneg_iff.trans <| by
-    simp_rw [← not_le, ← or_iff_not_imp_left]; have := le_total a 0; have := le_total b 0; tauto
+  smul_nonneg_iff.trans <| by grind
 
```
```
info: Mathlib/Algebra/Order/Module/Defs.lean:949:0: [Elab.command] [0.051023] theorem smul_nonneg_iff_pos_imp_nonneg : 0 ≤ a • b ↔ (0 < a → 0 ≤ b) ∧ (0 < b → 0 ≤ a) :=
      smul_nonneg_iff.trans <| by grind
  [Elab.step] [0.017878] expected type: Prop, term
      PosSMulStrictMono α β
    [Meta.synthInstance] [0.013888] ✅️ SMul α β
  [Elab.definition.header] [0.024110] smul_nonneg_iff_pos_imp_nonneg
    [Elab.step] [0.024060] expected type: Prop, term
        0 ≤ a • b ↔ (0 < a → 0 ≤ b) ∧ (0 < b → 0 ≤ a)
      [Elab.step] [0.024047] expected type: Prop, term
          Iff✝ (0 ≤ a • b) ((0 < a → 0 ≤ b) ∧ (0 < b → 0 ≤ a))
        [Elab.step] [0.017441] expected type: Prop, term
            0 ≤ a • b
          [Elab.step] [0.017427] expected type: Prop, term
              binrel% LE.le✝ 0 (a • b)
info: Mathlib/Algebra/Order/Module/Defs.lean:949:0: [Elab.command] [0.051127] lemma smul_nonneg_iff_pos_imp_nonneg : 0 ≤ a • b ↔ (0 < a → 0 ≤ b) ∧ (0 < b → 0 ≤ a) :=
      smul_nonneg_iff.trans <| by grind
info: Mathlib/Algebra/Order/Module/Defs.lean:949:0: [Elab.async] [0.826461] elaborating proof of smul_nonneg_iff_pos_imp_nonneg
  [Elab.definition.value] [0.825468] smul_nonneg_iff_pos_imp_nonneg
    [Elab.step] [0.817179] grind
      [Elab.step] [0.817163] grind
        [Elab.step] [0.817143] grind
          [Meta.synthInstance] [0.044942] ✅️ Lean.Grind.OrderedAdd α
            [Meta.check] [0.011166] ✅️ instOrderedAddOfAddRightMonoOfAddRightReflectLE α
          [Meta.synthInstance] [0.015939] ❌️ Lean.Grind.NoNatZeroDivisors α
          [Meta.synthInstance] [0.032126] ✅️ Lean.Grind.OrderedAdd β
          [Meta.synthInstance] [0.014158] ❌️ Lean.Grind.NoNatZeroDivisors β
          [Meta.synthInstance] [0.014767] ✅️ Lean.Grind.OrderedAdd β
          [Meta.synthInstance] [0.015521] ❌️ Lean.Grind.NoNatZeroDivisors β
          [Meta.synthInstance] [0.048655] ✅️ Lean.Grind.OrderedAdd α
            [Meta.check] [0.014186] ✅️ instOrderedAddOfAddRightMonoOfAddRightReflectLE α
          [Meta.synthInstance] [0.032966] ✅️ Lean.Grind.OrderedAdd β
          [Meta.synthInstance] [0.013361] ❌️ Lean.Grind.NoNatZeroDivisors β
          [Meta.synthInstance] [0.050529] ✅️ Lean.Grind.OrderedAdd α
            [Meta.check] [0.014273] ✅️ instOrderedAddOfAddRightMonoOfAddRightReflectLE α
          [Meta.synthInstance] [0.036890] ✅️ Lean.Grind.OrderedAdd α
            [Meta.check] [0.014399] ✅️ instOrderedAddOfAddRightMonoOfAddRightReflectLE α
          [Meta.synthInstance] [0.037650] ✅️ Lean.Grind.OrderedAdd α
          [Meta.synthInstance] [0.027002] ✅️ Lean.Grind.OrderedAdd β
          [Meta.synthInstance] [0.011600] ❌️ Lean.Grind.NoNatZeroDivisors β
info: Mathlib/Algebra/Order/Module/Defs.lean:950:30: [Elab.async] [0.021183] Lean.addDecl
  [Kernel] [0.021151] typechecking declarations [smul_nonneg_iff_pos_imp_nonneg._proof_1_1]
```
</details>
