### PR TITLE
[Merged by Bors] - chore(Algebra/DirectSum): golf entire `mulHom_of_of` using `simp`

### DIFF
--- a/Mathlib/Algebra/DirectSum/Ring.lean
+++ b/Mathlib/Algebra/DirectSum/Ring.lean
@@ -199,9 +199,7 @@ theorem mulHom_apply (a b : ⨁ i, A i) : mulHom A a b = a * b := rfl
 
 theorem mulHom_of_of {i j} (a : A i) (b : A j) :
     mulHom A (of A i a) (of A j b) = of A (i + j) (GradedMonoid.GMul.mul a b) := by
-  unfold mulHom
-  simp only [toAddMonoid_of, flip_apply, coe_comp, Function.comp_apply]
-  rfl
+  simp
 
 theorem of_mul_of {i j} (a : A i) (b : A j) :
     of A i a * of A j b = of _ (i + j) (GradedMonoid.GMul.mul a b) :=


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>mulHom_of_of</code></summary>

### Trace profiling of `mulHom_of_of` before PR 27907
```diff
diff --git a/Mathlib/Algebra/DirectSum/Ring.lean b/Mathlib/Algebra/DirectSum/Ring.lean
index 3c0aa8ee9d..b6073e7a7b 100644
--- a/Mathlib/Algebra/DirectSum/Ring.lean
+++ b/Mathlib/Algebra/DirectSum/Ring.lean
@@ -199,2 +199,3 @@ theorem mulHom_apply (a b : ⨁ i, A i) : mulHom A a b = a * b := rfl
 
+set_option trace.profiler true in
 theorem mulHom_of_of {i j} (a : A i) (b : A j) :
```
```
ℹ [821/821] Built Mathlib.Algebra.DirectSum.Ring
info: Mathlib/Algebra/DirectSum/Ring.lean:201:0: [Elab.command] [0.011121] theorem mulHom_of_of {i j} (a : A i) (b : A j) :
        mulHom A (of A i a) (of A j b) = of A (i + j) (GradedMonoid.GMul.mul a b) :=
      by
      unfold mulHom
      simp only [toAddMonoid_of, flip_apply, coe_comp, Function.comp_apply]
      rfl
info: Mathlib/Algebra/DirectSum/Ring.lean:201:0: [Elab.async] [0.030327] elaborating proof of DirectSum.mulHom_of_of
  [Elab.definition.value] [0.028933] DirectSum.mulHom_of_of
    [Elab.step] [0.027626] 
          unfold mulHom
          simp only [toAddMonoid_of, flip_apply, coe_comp, Function.comp_apply]
          rfl
      [Elab.step] [0.027610] 
            unfold mulHom
            simp only [toAddMonoid_of, flip_apply, coe_comp, Function.comp_apply]
            rfl
        [Elab.step] [0.025082] simp only [toAddMonoid_of, flip_apply, coe_comp, Function.comp_apply]
Build completed successfully.
```

### Trace profiling of `mulHom_of_of` after PR 27907
```diff
diff --git a/Mathlib/Algebra/DirectSum/Ring.lean b/Mathlib/Algebra/DirectSum/Ring.lean
index 3c0aa8ee9d..5cc83bf9de 100644
--- a/Mathlib/Algebra/DirectSum/Ring.lean
+++ b/Mathlib/Algebra/DirectSum/Ring.lean
@@ -199,7 +199,6 @@ theorem mulHom_apply (a b : ⨁ i, A i) : mulHom A a b = a * b := rfl
 
+set_option trace.profiler true in
 theorem mulHom_of_of {i j} (a : A i) (b : A j) :
     mulHom A (of A i a) (of A j b) = of A (i + j) (GradedMonoid.GMul.mul a b) := by
-  unfold mulHom
-  simp only [toAddMonoid_of, flip_apply, coe_comp, Function.comp_apply]
-  rfl
+  simp
 
```
```
ℹ [821/821] Built Mathlib.Algebra.DirectSum.Ring
info: Mathlib/Algebra/DirectSum/Ring.lean:201:0: [Elab.command] [0.010936] theorem mulHom_of_of {i j} (a : A i) (b : A j) :
        mulHom A (of A i a) (of A j b) = of A (i + j) (GradedMonoid.GMul.mul a b) := by simp
info: Mathlib/Algebra/DirectSum/Ring.lean:201:0: [Elab.async] [0.034277] elaborating proof of DirectSum.mulHom_of_of
  [Elab.definition.value] [0.030702] DirectSum.mulHom_of_of
    [Elab.step] [0.029993] simp
      [Elab.step] [0.029983] simp
        [Elab.step] [0.029969] simp
Build completed successfully.
```
</details>
