### PR TITLE
[Merged by Bors] - chore(Algebra/Polynomial): golf entire `natDegree_X_pow_add_C` using `simp`

### DIFF
--- a/Mathlib/Algebra/Polynomial/Degree/Operations.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Operations.lean
@@ -627,9 +627,7 @@ theorem zero_notMem_multiset_map_X_add_C {α : Type*} (m : Multiset α) (f : α 
 alias zero_nmem_multiset_map_X_add_C := zero_notMem_multiset_map_X_add_C
 
 theorem natDegree_X_pow_add_C {n : ℕ} {r : R} : (X ^ n + C r).natDegree = n := by
-  by_cases hn : n = 0
-  · rw [hn, pow_zero, ← C_1, ← RingHom.map_add, natDegree_C]
-  · exact natDegree_eq_of_degree_eq_some (degree_X_pow_add_C (pos_iff_ne_zero.mpr hn) r)
+  simp
 
 theorem X_pow_add_C_ne_one {n : ℕ} (hn : 0 < n) (a : R) : (X : R[X]) ^ n + C a ≠ 1 := fun h =>
   hn.ne' <| by simpa only [natDegree_X_pow_add_C, natDegree_one] using congr_arg natDegree h


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>natDegree_X_pow_add_C</code></summary>

### Trace profiling of `natDegree_X_pow_add_C` before PR 27908
```
info: Mathlib/Algebra/Polynomial/Degree/Operations.lean:630:0: [Elab.command] [0.030973] theorem natDegree_X_pow_add_C {n : ℕ} {r : R} : (X ^ n + C r).natDegree = n :=
      by
      by_cases hn : n = 0
      · rw [hn, pow_zero, ← C_1, ← RingHom.map_add, natDegree_C]
      · exact natDegree_eq_of_degree_eq_some (degree_X_pow_add_C (pos_iff_ne_zero.mpr hn) r)
  [Elab.definition.header] [0.030044] Polynomial.natDegree_X_pow_add_C
    [Elab.step] [0.022654] expected type: Sort ?u.34224, term
        (X ^ n + C r).natDegree = n
      [Elab.step] [0.022643] expected type: Sort ?u.34224, term
          binrel% Eq✝ (X ^ n + C r).natDegree n
        [Elab.step] [0.011874] expected type: ?m.34511, term
            (X ^ n + C r).natDegree
          [Elab.step] [0.011843] expected type: <not-available>, term
              (X ^ n + C r)
            [Elab.step] [0.011833] expected type: <not-available>, term
                X ^ n + C r
              [Elab.step] [0.011821] expected type: <not-available>, term
                  binop% HAdd.hAdd✝ (X ^ n) (C r)
info: Mathlib/Algebra/Polynomial/Degree/Operations.lean:630:0: [Elab.async] [0.011463] elaborating proof of Polynomial.natDegree_X_pow_add_C
  [Elab.definition.value] [0.010271] Polynomial.natDegree_X_pow_add_C
```

### Trace profiling of `natDegree_X_pow_add_C` after PR 27908
```diff
diff --git a/Mathlib/Algebra/Polynomial/Degree/Operations.lean b/Mathlib/Algebra/Polynomial/Degree/Operations.lean
index 27cb6a2aef..edc93fb175 100644
--- a/Mathlib/Algebra/Polynomial/Degree/Operations.lean
+++ b/Mathlib/Algebra/Polynomial/Degree/Operations.lean
@@ -628,6 +628,5 @@ alias zero_nmem_multiset_map_X_add_C := zero_notMem_multiset_map_X_add_C
 
+set_option trace.profiler true in
 theorem natDegree_X_pow_add_C {n : ℕ} {r : R} : (X ^ n + C r).natDegree = n := by
-  by_cases hn : n = 0
-  · rw [hn, pow_zero, ← C_1, ← RingHom.map_add, natDegree_C]
-  · exact natDegree_eq_of_degree_eq_some (degree_X_pow_add_C (pos_iff_ne_zero.mpr hn) r)
+  simp
 
```
```
info: Mathlib/Algebra/Polynomial/Degree/Operations.lean:630:0: [Elab.command] [0.021895] theorem natDegree_X_pow_add_C {n : ℕ} {r : R} : (X ^ n + C r).natDegree = n := by simp
  [Elab.definition.header] [0.021202] Polynomial.natDegree_X_pow_add_C
    [Elab.step] [0.014715] expected type: Sort ?u.34224, term
        (X ^ n + C r).natDegree = n
      [Elab.step] [0.014708] expected type: Sort ?u.34224, term
          binrel% Eq✝ (X ^ n + C r).natDegree n
```
</details>
