### PR TITLE
[Merged by Bors] - chore: golf `NormedSpace.sphere_nonempty`

### DIFF
--- a/Mathlib/Analysis/NormedSpace/Pointwise.lean
+++ b/Mathlib/Analysis/NormedSpace/Pointwise.lean
@@ -379,18 +379,6 @@ theorem smul_unitClosedBall_of_nonneg {r : ℝ} (hr : 0 ≤ r) :
 @[deprecated (since := "2024-12-01")]
 alias smul_closedUnitBall_of_nonneg := smul_unitClosedBall_of_nonneg
 
-/-- In a nontrivial real normed space, a sphere is nonempty if and only if its radius is
-nonnegative. -/
-@[simp]
-theorem NormedSpace.sphere_nonempty [Nontrivial E] {x : E} {r : ℝ} :
-    (sphere x r).Nonempty ↔ 0 ≤ r := by
-  obtain ⟨y, hy⟩ := exists_ne x
-  refine ⟨fun h => nonempty_closedBall.1 (h.mono sphere_subset_closedBall), fun hr =>
-    ⟨r • ‖y - x‖⁻¹ • (y - x) + x, ?_⟩⟩
-  have : ‖y - x‖ ≠ 0 := by simpa [sub_eq_zero]
-  simp only [mem_sphere_iff_norm, add_sub_cancel_right, norm_smul, Real.norm_eq_abs, norm_inv]
-  simp only [abs_norm]
-  rw [inv_mul_cancel₀ this, mul_one, abs_eq_self.mpr hr]
 
 theorem smul_sphere [Nontrivial E] (c : 𝕜) (x : E) {r : ℝ} (hr : 0 ≤ r) :
     c • sphere x r = sphere (c • x) (‖c‖ * r) := by

--- a/Mathlib/Analysis/NormedSpace/RCLike.lean
+++ b/Mathlib/Analysis/NormedSpace/RCLike.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kalle Kytölä
 -/
 import Mathlib.Analysis.RCLike.Basic
+import Mathlib.Analysis.NormedSpace.Real
 import Mathlib.Analysis.NormedSpace.OperatorNorm.Basic
-import Mathlib.Analysis.NormedSpace.Pointwise
 
 /-!
 # Normed spaces over R or C

--- a/Mathlib/Analysis/NormedSpace/Real.lean
+++ b/Mathlib/Analysis/NormedSpace/Real.lean
@@ -130,6 +130,15 @@ theorem nnnorm_surjective : Surjective (nnnorm : E → ℝ≥0) := fun c =>
 theorem range_nnnorm : range (nnnorm : E → ℝ≥0) = univ :=
   (nnnorm_surjective E).range_eq
 
+variable {E} in
+/-- In a nontrivial real normed space, a sphere is nonempty if and only if its radius is
+nonnegative. -/
+@[simp]
+theorem NormedSpace.sphere_nonempty {x : E} {r : ℝ} : (sphere x r).Nonempty ↔ 0 ≤ r := by
+  refine ⟨fun h => nonempty_closedBall.1 (h.mono sphere_subset_closedBall), fun hr => ?_⟩
+  obtain ⟨y, hy⟩ := exists_norm_eq E hr
+  exact ⟨x + y, by simpa using hy⟩
+
 end Surj
 
 theorem interior_closedBall' (x : E) (r : ℝ) : interior (closedBall x r) = ball x r := by


### PR DESCRIPTION
This result has nothing to do with pointwise operators on sets, and in finding the right file I also found a lemma which golfs it.

The motivation here was wanting this lemma in the file about operator norms.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
