### PR TITLE
[Merged by Bors] - chore(Geometry/RingedSpace): remove one porting note and one `erw`

### DIFF
--- a/Mathlib/Geometry/RingedSpace/PresheafedSpace/HasColimits.lean
+++ b/Mathlib/Geometry/RingedSpace/PresheafedSpace/HasColimits.lean
@@ -327,12 +327,6 @@ theorem colimitPresheafObjIsoComponentwiseLimit_inv_ι_app (F : J ⥤ Presheafed
       ← comp_c_app_assoc,
       congr_app (colimit.isoColimitCocone_ι_hom _ _), assoc]
   erw [limitObjIsoLimitCompEvaluation_inv_π_app_assoc, limMap_π_assoc]
-  -- Porting note: `convert` doesn't work due to meta variable, so change to a `suffices` block
-  set f := _
-  change _ ≫ f = _
-  suffices f_eq : f = 𝟙 _ by rw [f_eq, comp_id]
-  erw [← (F.obj j).presheaf.map_id]
-  change (F.obj j).presheaf.map _ ≫ _ = _
   simp
 
 @[simp]


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>colimitPresheafObjIsoComponentwiseLimit_inv_ι_app</code></summary>

### Trace profiling of `colimitPresheafObjIsoComponentwiseLimit_inv_ι_app` before PR 27926
```
info: Mathlib/Geometry/RingedSpace/PresheafedSpace/HasColimits.lean:318:0: [Elab.command] [1.040188] @[simp]
    theorem colimitPresheafObjIsoComponentwiseLimit_inv_ι_app (F : J ⥤ PresheafedSpace.{_, _, v} C)
        (U : Opens (Limits.colimit F).carrier) (j : J) :
        (colimitPresheafObjIsoComponentwiseLimit F U).inv ≫ (colimit.ι F j).c.app (op U) = limit.π _ (op j) :=
      by
      delta colimitPresheafObjIsoComponentwiseLimit
      rw [Iso.trans_inv, Iso.trans_inv, Iso.app_inv, sheafIsoOfIso_inv, pushforwardToOfIso_app,
        congr_app (Iso.symm_inv _)]
      dsimp
      rw [map_id, comp_id, assoc, assoc, assoc, NatTrans.naturality, ← comp_c_app_assoc,
        congr_app (colimit.isoColimitCocone_ι_hom _ _), assoc]
      erw [limitObjIsoLimitCompEvaluation_inv_π_app_assoc, limMap_π_assoc]
        -- Porting note: `convert` doesn't work due to meta variable, so change to a `suffices` block
        
      set f := _
      change _ ≫ f = _
      suffices f_eq : f = 𝟙 _ by rw [f_eq, comp_id]
      erw [← (F.obj j).presheaf.map_id]
      change (F.obj j).presheaf.map _ ≫ _ = _
      simp
  [Elab.definition.header] [0.097144] AlgebraicGeometry.PresheafedSpace.colimitPresheafObjIsoComponentwiseLimit_inv_ι_app
    [Elab.step] [0.025268] expected type: Type v, term
        Opens (Limits.colimit F).carrier
      [Elab.step] [0.020151] expected type: Type ?u.174516, term
          (Limits.colimit F).carrier
        [Elab.step] [0.019933] expected type: <not-available>, term
            (Limits.colimit F)
          [Elab.step] [0.019920] expected type: <not-available>, term
              Limits.colimit F
            [Meta.synthInstance] [0.018758] ✅️ HasColimit F
    [Elab.step] [0.070061] expected type: Prop, term
        (colimitPresheafObjIsoComponentwiseLimit F U).inv ≫ (colimit.ι F j).c.app (op U) = limit.π _ (op j)
      [Elab.step] [0.070046] expected type: Prop, term
          binrel% Eq✝ ((colimitPresheafObjIsoComponentwiseLimit F U).inv ≫ (colimit.ι F j).c.app (op U))
            (limit.π _ (op j))
        [Meta.synthInstance] [0.058249] ✅️ HasLimit (componentwiseDiagram F U)
  [Elab.attribute] [0.937317] applying [simp]
info: Mathlib/Geometry/RingedSpace/PresheafedSpace/HasColimits.lean:318:0: [Elab.async] [0.937262] elaborating proof of AlgebraicGeometry.PresheafedSpace.colimitPresheafObjIsoComponentwiseLimit_inv_ι_app
  [Elab.definition.value] [0.927035] AlgebraicGeometry.PresheafedSpace.colimitPresheafObjIsoComponentwiseLimit_inv_ι_app
    [Elab.step] [0.922546] 
          delta colimitPresheafObjIsoComponentwiseLimit
          rw [Iso.trans_inv, Iso.trans_inv, Iso.app_inv, sheafIsoOfIso_inv, pushforwardToOfIso_app,
            congr_app (Iso.symm_inv _)]
          dsimp
          rw [map_id, comp_id, assoc, assoc, assoc, NatTrans.naturality, ← comp_c_app_assoc,
            congr_app (colimit.isoColimitCocone_ι_hom _ _), assoc]
          erw [limitObjIsoLimitCompEvaluation_inv_π_app_assoc, limMap_π_assoc]
            -- Porting note: `convert` doesn't work due to meta variable, so change to a `suffices` block
            
          set f := _
          change _ ≫ f = _
          suffices f_eq : f = 𝟙 _ by rw [f_eq, comp_id]
          erw [← (F.obj j).presheaf.map_id]
          change (F.obj j).presheaf.map _ ≫ _ = _
          simp
      [Elab.step] [0.922530] 
            delta colimitPresheafObjIsoComponentwiseLimit
            rw [Iso.trans_inv, Iso.trans_inv, Iso.app_inv, sheafIsoOfIso_inv, pushforwardToOfIso_app,
              congr_app (Iso.symm_inv _)]
            dsimp
            rw [map_id, comp_id, assoc, assoc, assoc, NatTrans.naturality, ← comp_c_app_assoc,
              congr_app (colimit.isoColimitCocone_ι_hom _ _), assoc]
            erw [limitObjIsoLimitCompEvaluation_inv_π_app_assoc, limMap_π_assoc]
              -- Porting note: `convert` doesn't work due to meta variable, so change to a `suffices` block
              
            set f := _
            change _ ≫ f = _
            suffices f_eq : f = 𝟙 _ by rw [f_eq, comp_id]
            erw [← (F.obj j).presheaf.map_id]
            change (F.obj j).presheaf.map _ ≫ _ = _
            simp
        [Elab.step] [0.146177] rw [Iso.trans_inv, Iso.trans_inv, Iso.app_inv, sheafIsoOfIso_inv, pushforwardToOfIso_app,
              congr_app (Iso.symm_inv _)]
          [Elab.step] [0.146159] (rewrite [Iso.trans_inv, Iso.trans_inv, Iso.app_inv, sheafIsoOfIso_inv,
                  pushforwardToOfIso_app, congr_app (Iso.symm_inv _)];
                with_annotate_state"]" (try (with_reducible rfl)))
            [Elab.step] [0.146150] rewrite [Iso.trans_inv, Iso.trans_inv, Iso.app_inv, sheafIsoOfIso_inv,
                    pushforwardToOfIso_app, congr_app (Iso.symm_inv _)];
                  with_annotate_state"]" (try (with_reducible rfl))
              [Elab.step] [0.146140] rewrite [Iso.trans_inv, Iso.trans_inv, Iso.app_inv, sheafIsoOfIso_inv,
                      pushforwardToOfIso_app, congr_app (Iso.symm_inv _)];
                    with_annotate_state"]" (try (with_reducible rfl))
                [Elab.step] [0.144815] rewrite [Iso.trans_inv, Iso.trans_inv, Iso.app_inv, sheafIsoOfIso_inv,
                      pushforwardToOfIso_app, congr_app (Iso.symm_inv _)]
                  [Meta.check] [0.016973] ✅️ fun _a ↦
                        (((Limits.lim.mapIso
                                    (NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯))
                                      ⋯)).inv ≫
                                (limitObjIsoLimitCompEvaluation (pushforwardDiagramToColimit F).leftOp
                                    ((Opens.map
                                            (colimit.isoColimitCocone
                                                    { cocone := colimitCocone F,
                                                      isColimit := colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                      (op U))).inv) ≫
                              _a) ≫
                            (colimit.ι F j).c.app (op U) =
                          limit.π (componentwiseDiagram F U) (op j)
                  [Meta.check] [0.014416] ✅️ fun _a ↦
                        (((Limits.lim.mapIso
                                    (NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯))
                                      ⋯)).inv ≫
                                (limitObjIsoLimitCompEvaluation (pushforwardDiagramToColimit F).leftOp
                                    ((Opens.map
                                            (colimit.isoColimitCocone
                                                    { cocone := colimitCocone F,
                                                      isColimit := colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                      (op U))).inv) ≫
                              _a.app (op U)) ≫
                            (colimit.ι F j).c.app (op U) =
                          limit.π (componentwiseDiagram F U) (op j)
                  [Meta.check] [0.010654] ✅️ fun _a ↦
                        (((Limits.lim.mapIso
                                    (NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯))
                                      ⋯)).inv ≫
                                (limitObjIsoLimitCompEvaluation (pushforwardDiagramToColimit F).leftOp
                                    ((Opens.map
                                            (colimit.isoColimitCocone
                                                    { cocone := colimitCocone F,
                                                      isColimit := colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                      (op U))).inv) ≫
                              _a) ≫
                            (colimit.ι F j).c.app (op U) =
                          limit.π (componentwiseDiagram F U) (op j)
                  [Meta.check] [0.023805] ✅️ fun _a ↦
                        (((Limits.lim.mapIso
                                    (NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯))
                                      ⋯)).inv ≫
                                (limitObjIsoLimitCompEvaluation (pushforwardDiagramToColimit F).leftOp
                                    ((Opens.map
                                            (colimit.isoColimitCocone
                                                    { cocone := colimitCocone F,
                                                      isColimit := colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                      (op U))).inv) ≫
                              _a ≫ (Limits.colimit F).presheaf.map (eqToHom ⋯)) ≫
                            (colimit.ι F j).c.app (op U) =
                          limit.π (componentwiseDiagram F U) (op j)
        [Elab.step] [0.046171] dsimp
        [Elab.step] [0.362200] rw [map_id, comp_id, assoc, assoc, assoc, NatTrans.naturality, ← comp_c_app_assoc,
              congr_app (colimit.isoColimitCocone_ι_hom _ _), assoc]
          [Elab.step] [0.361801] (rewrite [map_id, comp_id, assoc, assoc, assoc, NatTrans.naturality, ←
                  comp_c_app_assoc, congr_app (colimit.isoColimitCocone_ι_hom _ _), assoc];
                with_annotate_state"]" (try (with_reducible rfl)))
            [Elab.step] [0.361793] rewrite [map_id, comp_id, assoc, assoc, assoc, NatTrans.naturality, ←
                    comp_c_app_assoc, congr_app (colimit.isoColimitCocone_ι_hom _ _), assoc];
                  with_annotate_state"]" (try (with_reducible rfl))
              [Elab.step] [0.361787] rewrite [map_id, comp_id, assoc, assoc, assoc, NatTrans.naturality, ←
                      comp_c_app_assoc, congr_app (colimit.isoColimitCocone_ι_hom _ _), assoc];
                    with_annotate_state"]" (try (with_reducible rfl))
                [Elab.step] [0.361130] rewrite [map_id, comp_id, assoc, assoc, assoc, NatTrans.naturality, ←
                      comp_c_app_assoc, congr_app (colimit.isoColimitCocone_ι_hom _ _), assoc]
                  [Meta.check] [0.046061] ✅️ fun _a ↦
                        ((limMap (NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)) ⋯).inv ≫
                                (limitObjIsoLimitCompEvaluation (pushforwardDiagramToColimit F).leftOp
                                    (op
                                      ((Opens.map
                                            (colimit.isoColimitCocone
                                                  { cocone := colimitCocone F,
                                                    isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                        U))).inv) ≫
                              ((colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).hom.c.app
                                    (op
                                      ((Opens.map
                                            (colimit.isoColimitCocone
                                                  { cocone := colimitCocone F,
                                                    isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                        U)) ≫
                                  _a) ≫
                                (Limits.colimit F).presheaf.map (eqToHom ⋯)) ≫
                            (colimit.ι F j).c.app (op U) =
                          limit.π (componentwiseDiagram F U) (op j)
                    [Meta.isDefEq] [0.014339] ✅️ autoParam
                          (∀ {X Y : Jᵒᵖ} (f : X ⟶ Y),
                            ((pushforwardDiagramToColimit F).leftOp ⋙
                                      (evaluation (Opens ↑(Limits.colimit (F ⋙ forget C)))ᵒᵖ C).obj
                                        (op
                                          ((Opens.map
                                                (colimit.isoColimitCocone
                                                      { cocone := colimitCocone F,
                                                        isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                            U))).map
                                  f ≫
                                (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom =
                              (mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)).hom ≫ (componentwiseDiagram F U).map f)
                          _auto✝ =?= ∀ {X Y : Jᵒᵖ} (f : X ⟶ Y),
                          ((pushforwardDiagramToColimit F).leftOp ⋙
                                    (evaluation
                                          (Opens
                                              ↑↑{ cocone := colimitCocone F,
                                                        isColimit := colimitCoconeIsColimit F }.cocone.pt)ᵒᵖ
                                          C).obj
                                      ((Opens.map
                                              (colimit.isoColimitCocone
                                                      { cocone := colimitCocone F,
                                                        isColimit := colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                        (op U))).map
                                f ≫
                              (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom =
                            (mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)).hom ≫ (componentwiseDiagram F U).map f
                      [Meta.isDefEq] [0.014330] ✅️ ∀ {X Y : Jᵒᵖ} (f : X ⟶ Y),
                            ((pushforwardDiagramToColimit F).leftOp ⋙
                                      (evaluation (Opens ↑(Limits.colimit (F ⋙ forget C)))ᵒᵖ C).obj
                                        (op
                                          ((Opens.map
                                                (colimit.isoColimitCocone
                                                      { cocone := colimitCocone F,
                                                        isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                            U))).map
                                  f ≫
                                (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom =
                              (mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)).hom ≫
                                (componentwiseDiagram F U).map
                                  f =?= ∀ {X Y : Jᵒᵖ} (f : X ⟶ Y),
                            ((pushforwardDiagramToColimit F).leftOp ⋙
                                      (evaluation
                                            (Opens
                                                ↑↑{ cocone := colimitCocone F,
                                                          isColimit := colimitCoconeIsColimit F }.cocone.pt)ᵒᵖ
                                            C).obj
                                        ((Opens.map
                                                (colimit.isoColimitCocone
                                                        { cocone := colimitCocone F,
                                                          isColimit := colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                          (op U))).map
                                  f ≫
                                (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom =
                              (mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)).hom ≫ (componentwiseDiagram F U).map f
                        [Meta.isDefEq] [0.014288] ✅️ ((pushforwardDiagramToColimit F).leftOp ⋙
                                      (evaluation (Opens ↑(Limits.colimit (F ⋙ forget C)))ᵒᵖ C).obj
                                        (op
                                          ((Opens.map
                                                (colimit.isoColimitCocone
                                                      { cocone := colimitCocone F,
                                                        isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                            U))).map
                                  f ≫
                                (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom =
                              (mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)).hom ≫
                                (componentwiseDiagram F U).map
                                  f =?= ((pushforwardDiagramToColimit F).leftOp ⋙
                                      (evaluation
                                            (Opens
                                                ↑↑{ cocone := colimitCocone F,
                                                          isColimit := colimitCoconeIsColimit F }.cocone.pt)ᵒᵖ
                                            C).obj
                                        ((Opens.map
                                                (colimit.isoColimitCocone
                                                        { cocone := colimitCocone F,
                                                          isColimit := colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                          (op U))).map
                                  f ≫
                                (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom =
                              (mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)).hom ≫ (componentwiseDiagram F U).map f
                          [Meta.isDefEq] [0.013035] ✅️ ((pushforwardDiagramToColimit F).leftOp ⋙
                                      (evaluation (Opens ↑(Limits.colimit (F ⋙ forget C)))ᵒᵖ C).obj
                                        (op
                                          ((Opens.map
                                                (colimit.isoColimitCocone
                                                      { cocone := colimitCocone F,
                                                        isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                            U))).map
                                  f ≫
                                (mapIso (F.obj (unop Y)).presheaf
                                    (eqToIso
                                      ⋯)).hom =?= ((pushforwardDiagramToColimit F).leftOp ⋙
                                      (evaluation
                                            (Opens
                                                ↑↑{ cocone := colimitCocone F,
                                                          isColimit := colimitCoconeIsColimit F }.cocone.pt)ᵒᵖ
                                            C).obj
                                        ((Opens.map
                                                (colimit.isoColimitCocone
                                                        { cocone := colimitCocone F,
                                                          isColimit := colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                          (op U))).map
                                  f ≫
                                (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom
                            [Meta.isDefEq] [0.013017] ✅️ inst✝³.toCategoryStruct.3
                                  (((pushforwardDiagramToColimit F).leftOp ⋙
                                        (evaluation (Opens ↑(Limits.colimit (F ⋙ forget C)))ᵒᵖ C).obj
                                          (op
                                            ((Opens.map
                                                  (colimit.isoColimitCocone
                                                        { cocone := colimitCocone F,
                                                          isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                              U))).map
                                    f)
                                  (mapIso (F.obj (unop Y)).presheaf
                                      (eqToIso
                                        ⋯)).hom =?= inst✝³.toCategoryStruct.3
                                  (((pushforwardDiagramToColimit F).leftOp ⋙
                                        (evaluation
                                              (Opens
                                                  ↑↑{ cocone := colimitCocone F,
                                                            isColimit := colimitCoconeIsColimit F }.cocone.pt)ᵒᵖ
                                              C).obj
                                          ((Opens.map
                                                  (colimit.isoColimitCocone
                                                          { cocone := colimitCocone F,
                                                            isColimit :=
                                                              colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                            (op U))).map
                                    f)
                                  (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom
                  [Meta.check] [0.027427] ✅️ fun _a ↦
                        ((limMap (NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)) ⋯).inv ≫
                                (limitObjIsoLimitCompEvaluation (pushforwardDiagramToColimit F).leftOp
                                    (op
                                      ((Opens.map
                                            (colimit.isoColimitCocone
                                                  { cocone := colimitCocone F,
                                                    isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                        U))).inv) ≫
                              _a ≫ (Limits.colimit F).presheaf.map (eqToHom ⋯)) ≫
                            (colimit.ι F j).c.app (op U) =
                          limit.π (componentwiseDiagram F U) (op j)
                  [Meta.check] [0.019082] ✅️ fun _a ↦
                        limMap (NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)) ⋯).inv ≫
                            (limitObjIsoLimitCompEvaluation (pushforwardDiagramToColimit F).leftOp
                                  (op
                                    ((Opens.map
                                          (colimit.isoColimitCocone
                                                { cocone := colimitCocone F,
                                                  isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                      U))).inv ≫
                              _a =
                          limit.π (componentwiseDiagram F U) (op j)
                  [Meta.check] [0.023213] ✅️ fun _a ↦
                        limMap (NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)) ⋯).inv ≫
                            (limitObjIsoLimitCompEvaluation (pushforwardDiagramToColimit F).leftOp
                                  (op
                                    ((Opens.map
                                          (colimit.isoColimitCocone
                                                { cocone := colimitCocone F,
                                                  isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                      U))).inv ≫
                              (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).hom.c.app
                                  (op
                                    ((Opens.map
                                          (colimit.isoColimitCocone
                                                { cocone := colimitCocone F,
                                                  isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                      U)) ≫
                                _a =
                          limit.π (componentwiseDiagram F U) (op j)
                  [Meta.isDefEq] [0.014000] ✅️ (colimit.isoColimitCocone
                                  { cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F }).hom.c.app
                          (op
                            ((Opens.map
                                  (colimit.isoColimitCocone
                                        { cocone := colimitCocone F,
                                          isColimit := colimitCoconeIsColimit F }).inv.base).obj
                              U)) ≫
                        (colimit.ι F j).c.app
                            (op
                              ((Opens.map
                                    (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).hom.base).obj
                                ((Opens.map
                                      (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                  U))) ≫
                          ((pushforward C (colimit.ι F j).base).obj (F.obj j).presheaf).map
                            (eqToHom
                              ⋯) =?= (Hom.c ?β).app ?U ≫
                        (Hom.c ?α).app (op ((Opens.map (Hom.base ?β)).obj (unop ?U))) ≫ ?h
                    [Meta.isDefEq] [0.011423] ✅️ (colimit.ι F j).c.app
                            (op
                              ((Opens.map
                                    (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).hom.base).obj
                                ((Opens.map
                                      (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                  U))) ≫
                          ((pushforward C (colimit.ι F j).base).obj (F.obj j).presheaf).map
                            (eqToHom
                              ⋯) =?= (Hom.c ?α).app
                            (op
                              ((Opens.map
                                    (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).hom.base).obj
                                (unop
                                  (op
                                    ((Opens.map
                                          (colimit.isoColimitCocone
                                                { cocone := colimitCocone F,
                                                  isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                      U))))) ≫
                          ?h
                  [Meta.check] [0.019734] ✅️ fun _a ↦
                        limMap (NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)) ⋯).inv ≫
                            (limitObjIsoLimitCompEvaluation (pushforwardDiagramToColimit F).leftOp
                                  (op
                                    ((Opens.map
                                          (colimit.isoColimitCocone
                                                { cocone := colimitCocone F,
                                                  isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                      U))).inv ≫
                              _a =
                          limit.π (componentwiseDiagram F U) (op j)
                  [Meta.check] [0.041226] ✅️ fun _a ↦
                        limMap (NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)) ⋯).inv ≫
                            (limitObjIsoLimitCompEvaluation (pushforwardDiagramToColimit F).leftOp
                                  (op
                                    ((Opens.map
                                          (colimit.isoColimitCocone
                                                { cocone := colimitCocone F,
                                                  isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                      U))).inv ≫
                              _a ≫ ((pushforward C (colimit.ι F j).base).obj (F.obj j).presheaf).map (eqToHom ⋯) =
                          limit.π (componentwiseDiagram F U) (op j)
                  [Meta.isDefEq] [0.013545] ✅️ (({ cocone := colimitCocone F,
                                          isColimit := colimitCoconeIsColimit F }.cocone.ι.app
                                  j).c.app
                            (op
                              ((Opens.map
                                    (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                U)) ≫
                          (F.obj j).presheaf.map (eqToHom ⋯)) ≫
                        ((pushforward C (colimit.ι F j).base).obj (F.obj j).presheaf).map (eqToHom ⋯) =?= (?f ≫ ?g) ≫ ?h
                  [Meta.check] [0.022526] ✅️ fun _a ↦
                        limMap (NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)) ⋯).inv ≫
                            (limitObjIsoLimitCompEvaluation (pushforwardDiagramToColimit F).leftOp
                                  (op
                                    ((Opens.map
                                          (colimit.isoColimitCocone
                                                { cocone := colimitCocone F,
                                                  isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                      U))).inv ≫
                              _a =
                          limit.π (componentwiseDiagram F U) (op j)
                    [Meta.isDefEq] [0.010494] ✅️ autoParam
                          (∀ {X Y : Jᵒᵖ} (f : X ⟶ Y),
                            ((pushforwardDiagramToColimit F).leftOp ⋙
                                      (evaluation (Opens ↑(Limits.colimit (F ⋙ forget C)))ᵒᵖ C).obj
                                        (op
                                          ((Opens.map
                                                (colimit.isoColimitCocone
                                                      { cocone := colimitCocone F,
                                                        isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                            U))).map
                                  f ≫
                                (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom =
                              (mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)).hom ≫ (componentwiseDiagram F U).map f)
                          _auto✝ =?= ∀ {X Y : Jᵒᵖ} (f : X ⟶ Y),
                          ((pushforwardDiagramToColimit F).leftOp ⋙
                                    (evaluation
                                          (Opens
                                              ↑↑{ cocone := colimitCocone F,
                                                        isColimit := colimitCoconeIsColimit F }.cocone.pt)ᵒᵖ
                                          C).obj
                                      ((Opens.map
                                              (colimit.isoColimitCocone
                                                      { cocone := colimitCocone F,
                                                        isColimit := colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                        (op U))).map
                                f ≫
                              (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom =
                            (mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)).hom ≫ (componentwiseDiagram F U).map f
                      [Meta.isDefEq] [0.010484] ✅️ ∀ {X Y : Jᵒᵖ} (f : X ⟶ Y),
                            ((pushforwardDiagramToColimit F).leftOp ⋙
                                      (evaluation (Opens ↑(Limits.colimit (F ⋙ forget C)))ᵒᵖ C).obj
                                        (op
                                          ((Opens.map
                                                (colimit.isoColimitCocone
                                                      { cocone := colimitCocone F,
                                                        isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                            U))).map
                                  f ≫
                                (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom =
                              (mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)).hom ≫
                                (componentwiseDiagram F U).map
                                  f =?= ∀ {X Y : Jᵒᵖ} (f : X ⟶ Y),
                            ((pushforwardDiagramToColimit F).leftOp ⋙
                                      (evaluation
                                            (Opens
                                                ↑↑{ cocone := colimitCocone F,
                                                          isColimit := colimitCoconeIsColimit F }.cocone.pt)ᵒᵖ
                                            C).obj
                                        ((Opens.map
                                                (colimit.isoColimitCocone
                                                        { cocone := colimitCocone F,
                                                          isColimit := colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                          (op U))).map
                                  f ≫
                                (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom =
                              (mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)).hom ≫ (componentwiseDiagram F U).map f
                        [Meta.isDefEq] [0.010433] ✅️ ((pushforwardDiagramToColimit F).leftOp ⋙
                                      (evaluation (Opens ↑(Limits.colimit (F ⋙ forget C)))ᵒᵖ C).obj
                                        (op
                                          ((Opens.map
                                                (colimit.isoColimitCocone
                                                      { cocone := colimitCocone F,
                                                        isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                            U))).map
                                  f ≫
                                (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom =
                              (mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)).hom ≫
                                (componentwiseDiagram F U).map
                                  f =?= ((pushforwardDiagramToColimit F).leftOp ⋙
                                      (evaluation
                                            (Opens
                                                ↑↑{ cocone := colimitCocone F,
                                                          isColimit := colimitCoconeIsColimit F }.cocone.pt)ᵒᵖ
                                            C).obj
                                        ((Opens.map
                                                (colimit.isoColimitCocone
                                                        { cocone := colimitCocone F,
                                                          isColimit := colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                          (op U))).map
                                  f ≫
                                (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom =
                              (mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)).hom ≫ (componentwiseDiagram F U).map f
        [Elab.step] [0.153503] erw [limitObjIsoLimitCompEvaluation_inv_π_app_assoc, limMap_π_assoc]
          [Elab.step] [0.149349] rw (transparency✝ := .default✝) [limitObjIsoLimitCompEvaluation_inv_π_app_assoc,
                limMap_π_assoc]
            [Elab.step] [0.149342] (rewrite (transparency✝ :=
                    .default✝) [limitObjIsoLimitCompEvaluation_inv_π_app_assoc, limMap_π_assoc];
                  with_annotate_state"]" (try (with_reducible rfl)))
              [Elab.step] [0.149338] rewrite (transparency✝ :=
                      .default✝) [limitObjIsoLimitCompEvaluation_inv_π_app_assoc, limMap_π_assoc];
                    with_annotate_state"]" (try (with_reducible rfl))
                [Elab.step] [0.149333] rewrite (transparency✝ :=
                        .default✝) [limitObjIsoLimitCompEvaluation_inv_π_app_assoc, limMap_π_assoc];
                      with_annotate_state"]" (try (with_reducible rfl))
                  [Elab.step] [0.148668] rewrite (transparency✝ :=
                        .default✝) [limitObjIsoLimitCompEvaluation_inv_π_app_assoc, limMap_π_assoc]
                    [Meta.isDefEq] [0.018626] ✅️ (limitObjIsoLimitCompEvaluation (pushforwardDiagramToColimit F).leftOp
                              (op
                                ((Opens.map
                                      (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                  U))).inv ≫
                          ({ cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F }.cocone.ι.app j).c.app
                              (op
                                ((Opens.map
                                      (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                  U)) ≫
                            (F.obj j).presheaf.map (eqToHom ⋯) ≫
                              ((pushforward C (colimit.ι F j).base).obj (F.obj j).presheaf).map
                                (eqToHom ⋯) =?= (limitObjIsoLimitCompEvaluation ?F ?k).inv ≫ (limit.π ?F ?j).app ?k ≫ ?h
                      [Meta.isDefEq.delta] [0.018438] ✅️ (limitObjIsoLimitCompEvaluation
                                (pushforwardDiagramToColimit F).leftOp
                                (op
                                  ((Opens.map
                                        (colimit.isoColimitCocone
                                              { cocone := colimitCocone F,
                                                isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                    U))).inv ≫
                            ({ cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F }.cocone.ι.app j).c.app
                                (op
                                  ((Opens.map
                                        (colimit.isoColimitCocone
                                              { cocone := colimitCocone F,
                                                isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                    U)) ≫
                              (F.obj j).presheaf.map (eqToHom ⋯) ≫
                                ((pushforward C (colimit.ι F j).base).obj (F.obj j).presheaf).map
                                  (eqToHom
                                    ⋯) =?= (limitObjIsoLimitCompEvaluation ?F ?k).inv ≫ (limit.π ?F ?j).app ?k ≫ ?h
                        [Meta.isDefEq] [0.015684] ✅️ ({ cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }.cocone.ι.app
                                      j).c.app
                                (op
                                  ((Opens.map
                                        (colimit.isoColimitCocone
                                              { cocone := colimitCocone F,
                                                isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                    U)) ≫
                              (F.obj j).presheaf.map (eqToHom ⋯) ≫
                                ((pushforward C (colimit.ι F j).base).obj (F.obj j).presheaf).map
                                  (eqToHom
                                    ⋯) =?= (limit.π (pushforwardDiagramToColimit F).leftOp ?j).app
                                (op
                                  ((Opens.map
                                        (colimit.isoColimitCocone
                                              { cocone := colimitCocone F,
                                                isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                    U)) ≫
                              ?h
                          [Meta.isDefEq.delta] [0.015635] ✅️ ({ cocone := colimitCocone F,
                                                isColimit := colimitCoconeIsColimit F }.cocone.ι.app
                                        j).c.app
                                  (op
                                    ((Opens.map
                                          (colimit.isoColimitCocone
                                                { cocone := colimitCocone F,
                                                  isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                      U)) ≫
                                (F.obj j).presheaf.map (eqToHom ⋯) ≫
                                  ((pushforward C (colimit.ι F j).base).obj (F.obj j).presheaf).map
                                    (eqToHom
                                      ⋯) =?= (limit.π (pushforwardDiagramToColimit F).leftOp ?j).app
                                  (op
                                    ((Opens.map
                                          (colimit.isoColimitCocone
                                                { cocone := colimitCocone F,
                                                  isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                      U)) ≫
                                ?h
                            [Meta.isDefEq] [0.012504] ✅️ ({ cocone := colimitCocone F,
                                                isColimit := colimitCoconeIsColimit F }.cocone.ι.app
                                        j).c.app
                                  (op
                                    ((Opens.map
                                          (colimit.isoColimitCocone
                                                { cocone := colimitCocone F,
                                                  isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                      U)) =?= (limit.π (pushforwardDiagramToColimit F).leftOp ?j).app
                                  (op
                                    ((Opens.map
                                          (colimit.isoColimitCocone
                                                { cocone := colimitCocone F,
                                                  isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                      U))
                              [Meta.isDefEq.delta] [0.012467] ✅️ ({ cocone := colimitCocone F,
                                                  isColimit := colimitCoconeIsColimit F }.cocone.ι.app
                                          j).c.app
                                    (op
                                      ((Opens.map
                                            (colimit.isoColimitCocone
                                                  { cocone := colimitCocone F,
                                                    isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                        U)) =?= (limit.π (pushforwardDiagramToColimit F).leftOp ?j).app
                                    (op
                                      ((Opens.map
                                            (colimit.isoColimitCocone
                                                  { cocone := colimitCocone F,
                                                    isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                        U))
                    [Meta.check] [0.032205] ✅️ fun _a ↦
                          limMap (NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)) ⋯).inv ≫
                              _a =
                            limit.π (componentwiseDiagram F U) (op j)
                      [Meta.isDefEq] [0.011807] ✅️ autoParam
                            (∀ {X Y : Jᵒᵖ} (f : X ⟶ Y),
                              ((pushforwardDiagramToColimit F).leftOp ⋙
                                        (evaluation (Opens ↑(Limits.colimit (F ⋙ forget C)))ᵒᵖ C).obj
                                          (op
                                            ((Opens.map
                                                  (colimit.isoColimitCocone
                                                        { cocone := colimitCocone F,
                                                          isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                              U))).map
                                    f ≫
                                  (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom =
                                (mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)).hom ≫ (componentwiseDiagram F U).map f)
                            _auto✝ =?= ∀ {X Y : Jᵒᵖ} (f : X ⟶ Y),
                            ((pushforwardDiagramToColimit F).leftOp ⋙
                                      (evaluation
                                            (Opens
                                                ↑↑{ cocone := colimitCocone F,
                                                          isColimit := colimitCoconeIsColimit F }.cocone.pt)ᵒᵖ
                                            C).obj
                                        ((Opens.map
                                                (colimit.isoColimitCocone
                                                        { cocone := colimitCocone F,
                                                          isColimit := colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                          (op U))).map
                                  f ≫
                                (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom =
                              (mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)).hom ≫ (componentwiseDiagram F U).map f
                        [Meta.isDefEq] [0.011776] ✅️ ∀ {X Y : Jᵒᵖ} (f : X ⟶ Y),
                              ((pushforwardDiagramToColimit F).leftOp ⋙
                                        (evaluation (Opens ↑(Limits.colimit (F ⋙ forget C)))ᵒᵖ C).obj
                                          (op
                                            ((Opens.map
                                                  (colimit.isoColimitCocone
                                                        { cocone := colimitCocone F,
                                                          isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                              U))).map
                                    f ≫
                                  (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom =
                                (mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)).hom ≫
                                  (componentwiseDiagram F U).map
                                    f =?= ∀ {X Y : Jᵒᵖ} (f : X ⟶ Y),
                              ((pushforwardDiagramToColimit F).leftOp ⋙
                                        (evaluation
                                              (Opens
                                                  ↑↑{ cocone := colimitCocone F,
                                                            isColimit := colimitCoconeIsColimit F }.cocone.pt)ᵒᵖ
                                              C).obj
                                          ((Opens.map
                                                  (colimit.isoColimitCocone
                                                          { cocone := colimitCocone F,
                                                            isColimit :=
                                                              colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                            (op U))).map
                                    f ≫
                                  (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom =
                                (mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)).hom ≫ (componentwiseDiagram F U).map f
                          [Meta.isDefEq] [0.011697] ✅️ ((pushforwardDiagramToColimit F).leftOp ⋙
                                        (evaluation (Opens ↑(Limits.colimit (F ⋙ forget C)))ᵒᵖ C).obj
                                          (op
                                            ((Opens.map
                                                  (colimit.isoColimitCocone
                                                        { cocone := colimitCocone F,
                                                          isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                              U))).map
                                    f ≫
                                  (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom =
                                (mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)).hom ≫
                                  (componentwiseDiagram F U).map
                                    f =?= ((pushforwardDiagramToColimit F).leftOp ⋙
                                        (evaluation
                                              (Opens
                                                  ↑↑{ cocone := colimitCocone F,
                                                            isColimit := colimitCoconeIsColimit F }.cocone.pt)ᵒᵖ
                                              C).obj
                                          ((Opens.map
                                                  (colimit.isoColimitCocone
                                                          { cocone := colimitCocone F,
                                                            isColimit :=
                                                              colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                            (op U))).map
                                    f ≫
                                  (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom =
                                (mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)).hom ≫ (componentwiseDiagram F U).map f
                            [Meta.isDefEq] [0.010926] ✅️ ((pushforwardDiagramToColimit F).leftOp ⋙
                                        (evaluation (Opens ↑(Limits.colimit (F ⋙ forget C)))ᵒᵖ C).obj
                                          (op
                                            ((Opens.map
                                                  (colimit.isoColimitCocone
                                                        { cocone := colimitCocone F,
                                                          isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                              U))).map
                                    f ≫
                                  (mapIso (F.obj (unop Y)).presheaf
                                      (eqToIso
                                        ⋯)).hom =?= ((pushforwardDiagramToColimit F).leftOp ⋙
                                        (evaluation
                                              (Opens
                                                  ↑↑{ cocone := colimitCocone F,
                                                            isColimit := colimitCoconeIsColimit F }.cocone.pt)ᵒᵖ
                                              C).obj
                                          ((Opens.map
                                                  (colimit.isoColimitCocone
                                                          { cocone := colimitCocone F,
                                                            isColimit :=
                                                              colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                            (op U))).map
                                    f ≫
                                  (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom
                              [Meta.isDefEq] [0.010889] ✅️ inst✝³.toCategoryStruct.3
                                    (((pushforwardDiagramToColimit F).leftOp ⋙
                                          (evaluation (Opens ↑(Limits.colimit (F ⋙ forget C)))ᵒᵖ C).obj
                                            (op
                                              ((Opens.map
                                                    (colimit.isoColimitCocone
                                                          { cocone := colimitCocone F,
                                                            isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                                U))).map
                                      f)
                                    (mapIso (F.obj (unop Y)).presheaf
                                        (eqToIso
                                          ⋯)).hom =?= inst✝³.toCategoryStruct.3
                                    (((pushforwardDiagramToColimit F).leftOp ⋙
                                          (evaluation
                                                (Opens
                                                    ↑↑{ cocone := colimitCocone F,
                                                              isColimit := colimitCoconeIsColimit F }.cocone.pt)ᵒᵖ
                                                C).obj
                                            ((Opens.map
                                                    (colimit.isoColimitCocone
                                                            { cocone := colimitCocone F,
                                                              isColimit :=
                                                                colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                              (op U))).map
                                      f)
                                    (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom
                    [Meta.synthInstance] [0.032731] ✅️ HasLimit (componentwiseDiagram F U)
                    [Meta.synthInstance] [0.037409] ✅️ HasLimit
                          ((pushforwardDiagramToColimit F).leftOp ⋙
                            (evaluation (Opens ↑(Limits.colimit (F ⋙ forget C)))ᵒᵖ C).obj
                              (op
                                ((Opens.map
                                      (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                  U)))
        [Elab.step] [0.014221] suffices f_eq : f = 𝟙 _ by rw [f_eq, comp_id]
          [Elab.step] [0.012150] refine_lift
                suffices f_eq : f = 𝟙 _ by rw [f_eq, comp_id];
                ?_
            [Elab.step] [0.012144] focus
                  (refine
                      no_implicit_lambda%
                        (suffices f_eq : f = 𝟙 _ by rw [f_eq, comp_id];
                        ?_);
                    rotate_right)
              [Elab.step] [0.012137] (refine
                        no_implicit_lambda%
                          (suffices f_eq : f = 𝟙 _ by rw [f_eq, comp_id];
                          ?_);
                      rotate_right)
                [Elab.step] [0.012133] (refine
                          no_implicit_lambda%
                            (suffices f_eq : f = 𝟙 _ by rw [f_eq, comp_id];
                            ?_);
                        rotate_right)
                  [Elab.step] [0.012129] (refine
                          no_implicit_lambda%
                            (suffices f_eq : f = 𝟙 _ by rw [f_eq, comp_id];
                            ?_);
                        rotate_right)
                    [Elab.step] [0.012125] refine
                            no_implicit_lambda%
                              (suffices f_eq : f = 𝟙 _ by rw [f_eq, comp_id];
                              ?_);
                          rotate_right
                      [Elab.step] [0.012121] refine
                              no_implicit_lambda%
                                (suffices f_eq : f = 𝟙 _ by rw [f_eq, comp_id];
                                ?_);
                            rotate_right
                        [Elab.step] [0.012108] refine
                              no_implicit_lambda%
                                (suffices f_eq : f = 𝟙 _ by rw [f_eq, comp_id];
                                ?_)
        [Elab.step] [0.013093] change (F.obj j).presheaf.map _ ≫ _ = _
        [Elab.step] [0.168494] simp
          [Meta.isDefEq] [0.021985] ❌️ eqToHom ?p =?= eqToHom ⋯
            [Meta.isDefEq] [0.021872] ❌️ ?p =?= colimit.isoColimitCocone_ι_hom
                    { cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F } j ▸
                  Eq.refl
                    ((Opens.map
                            (colimit.ι F j ≫
                                (colimit.isoColimitCocone
                                    { cocone := colimitCocone F,
                                      isColimit := colimitCoconeIsColimit F }).hom).base).op.obj
                      (op
                        ((Opens.map
                              (colimit.isoColimitCocone
                                    { cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F }).inv.base).obj
                          U)))
          [Meta.isDefEq] [0.021293] ❌️ eqToHom ?p =?= eqToHom ⋯
            [Meta.isDefEq] [0.021164] ❌️ ?p =?= colimit.isoColimitCocone_ι_hom
                    { cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F } j ▸
                  Eq.refl
                    ((Opens.map
                            (colimit.ι F j ≫
                                (colimit.isoColimitCocone
                                    { cocone := colimitCocone F,
                                      isColimit := colimitCoconeIsColimit F }).hom).base).op.obj
                      (op
                        ((Opens.map
                              (colimit.isoColimitCocone
                                    { cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F }).inv.base).obj
                          U)))
          [Meta.isDefEq] [0.010555] ✅️ (toPrefunctor ?F).map (eqToHom ?p) =?= (F.obj j).presheaf.map (eqToHom ⋯)
            [Meta.isDefEq.delta] [0.010532] ✅️ (toPrefunctor ?F).map (eqToHom ?p) =?= (F.obj j).presheaf.map (eqToHom ⋯)
              [Meta.isDefEq] [0.010242] ✅️ eqToHom ?p =?= eqToHom ⋯
                [Meta.isDefEq] [0.010214] ✅️ ?p =?= colimit.isoColimitCocone_ι_hom
                        { cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F } j ▸
                      Eq.refl
                        ((Opens.map
                                (colimit.ι F j ≫
                                    (colimit.isoColimitCocone
                                        { cocone := colimitCocone F,
                                          isColimit := colimitCoconeIsColimit F }).hom).base).op.obj
                          (op
                            ((Opens.map
                                  (colimit.isoColimitCocone
                                        { cocone := colimitCocone F,
                                          isColimit := colimitCoconeIsColimit F }).inv.base).obj
                              U)))
                  [Meta.isDefEq.assign] [0.010212] ✅️ ?p := colimit.isoColimitCocone_ι_hom
                          { cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F } j ▸
                        Eq.refl
                          ((Opens.map
                                  (colimit.ι F j ≫
                                      (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).hom).base).op.obj
                            (op
                              ((Opens.map
                                    (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                U)))
                    [Meta.isDefEq.assign.checkTypes] [0.010174] ✅️ (?p : op
                            ((Opens.map (colimit.ι (F ⋙ forget C) j)).obj
                              ((Opens.map
                                    (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                U)) =
                          op
                            ((Opens.map (colimit.ι F j).base).obj
                              ((Opens.map
                                    (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).hom.base).obj
                                ((Opens.map
                                      (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                  U)))) := (colimit.isoColimitCocone_ι_hom
                            { cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F } j ▸
                          Eq.refl
                            ((Opens.map
                                    (colimit.ι F j ≫
                                        (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).hom).base).op.obj
                              (op
                                ((Opens.map
                                      (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                  U))) : (Opens.map
                                  ({ cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F }.cocone.ι.app
                                      j).base).op.obj
                            (op
                              ((Opens.map
                                    (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                U)) =
                          (Opens.map
                                  (colimit.ι F j ≫
                                      (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).hom).base).op.obj
                            (op
                              ((Opens.map
                                    (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                U)))
                      [Meta.isDefEq] [0.010170] ✅️ op
                              ((Opens.map (colimit.ι (F ⋙ forget C) j)).obj
                                ((Opens.map
                                      (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                  U)) =
                            op
                              ((Opens.map (colimit.ι F j).base).obj
                                ((Opens.map
                                      (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).hom.base).obj
                                  ((Opens.map
                                        (colimit.isoColimitCocone
                                              { cocone := colimitCocone F,
                                                isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                    U))) =?= (Opens.map
                                    ({ cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F }.cocone.ι.app
                                        j).base).op.obj
                              (op
                                ((Opens.map
                                      (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                  U)) =
                            (Opens.map
                                    (colimit.ι F j ≫
                                        (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).hom).base).op.obj
                              (op
                                ((Opens.map
                                      (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                  U))
info: Mathlib/Geometry/RingedSpace/PresheafedSpace/HasColimits.lean:319:8: [Elab.async] [0.072478] Lean.addDecl
  [Kernel] [0.072444] typechecking declarations [AlgebraicGeometry.PresheafedSpace.colimitPresheafObjIsoComponentwiseLimit_inv_ι_app]
```

### Trace profiling of `colimitPresheafObjIsoComponentwiseLimit_inv_ι_app` after PR 27926
```diff
diff --git a/Mathlib/Geometry/RingedSpace/PresheafedSpace/HasColimits.lean b/Mathlib/Geometry/RingedSpace/PresheafedSpace/HasColimits.lean
index 5771499b70..cbf879186d 100644
--- a/Mathlib/Geometry/RingedSpace/PresheafedSpace/HasColimits.lean
+++ b/Mathlib/Geometry/RingedSpace/PresheafedSpace/HasColimits.lean
@@ -316,2 +316,3 @@ def colimitPresheafObjIsoComponentwiseLimit (F : J ⥤ PresheafedSpace.{_, _, v}
 
+set_option trace.profiler true in
 @[simp]
@@ -329,8 +330,2 @@ theorem colimitPresheafObjIsoComponentwiseLimit_inv_ι_app (F : J ⥤ Presheafed
   erw [limitObjIsoLimitCompEvaluation_inv_π_app_assoc, limMap_π_assoc]
-  -- Porting note: `convert` doesn't work due to meta variable, so change to a `suffices` block
-  set f := _
-  change _ ≫ f = _
-  suffices f_eq : f = 𝟙 _ by rw [f_eq, comp_id]
-  erw [← (F.obj j).presheaf.map_id]
-  change (F.obj j).presheaf.map _ ≫ _ = _
   simp
```
```
info: Mathlib/Geometry/RingedSpace/PresheafedSpace/HasColimits.lean:318:0: [Elab.command] [1.024539] @[simp]
    theorem colimitPresheafObjIsoComponentwiseLimit_inv_ι_app (F : J ⥤ PresheafedSpace.{_, _, v} C)
        (U : Opens (Limits.colimit F).carrier) (j : J) :
        (colimitPresheafObjIsoComponentwiseLimit F U).inv ≫ (colimit.ι F j).c.app (op U) = limit.π _ (op j) :=
      by
      delta colimitPresheafObjIsoComponentwiseLimit
      rw [Iso.trans_inv, Iso.trans_inv, Iso.app_inv, sheafIsoOfIso_inv, pushforwardToOfIso_app,
        congr_app (Iso.symm_inv _)]
      dsimp
      rw [map_id, comp_id, assoc, assoc, assoc, NatTrans.naturality, ← comp_c_app_assoc,
        congr_app (colimit.isoColimitCocone_ι_hom _ _), assoc]
      erw [limitObjIsoLimitCompEvaluation_inv_π_app_assoc, limMap_π_assoc]
      simp
  [Elab.definition.header] [0.078196] AlgebraicGeometry.PresheafedSpace.colimitPresheafObjIsoComponentwiseLimit_inv_ι_app
    [Elab.step] [0.012578] expected type: Type v, term
        Opens (Limits.colimit F).carrier
    [Elab.step] [0.064806] expected type: Prop, term
        (colimitPresheafObjIsoComponentwiseLimit F U).inv ≫ (colimit.ι F j).c.app (op U) = limit.π _ (op j)
      [Elab.step] [0.064794] expected type: Prop, term
          binrel% Eq✝ ((colimitPresheafObjIsoComponentwiseLimit F U).inv ≫ (colimit.ι F j).c.app (op U))
            (limit.π _ (op j))
        [Meta.synthInstance] [0.046124] ✅️ HasLimit (componentwiseDiagram F U)
  [Elab.attribute] [0.941447] applying [simp]
info: Mathlib/Geometry/RingedSpace/PresheafedSpace/HasColimits.lean:318:0: [Elab.async] [0.941493] elaborating proof of AlgebraicGeometry.PresheafedSpace.colimitPresheafObjIsoComponentwiseLimit_inv_ι_app
  [Elab.definition.value] [0.933934] AlgebraicGeometry.PresheafedSpace.colimitPresheafObjIsoComponentwiseLimit_inv_ι_app
    [Elab.step] [0.922601] 
          delta colimitPresheafObjIsoComponentwiseLimit
          rw [Iso.trans_inv, Iso.trans_inv, Iso.app_inv, sheafIsoOfIso_inv, pushforwardToOfIso_app,
            congr_app (Iso.symm_inv _)]
          dsimp
          rw [map_id, comp_id, assoc, assoc, assoc, NatTrans.naturality, ← comp_c_app_assoc,
            congr_app (colimit.isoColimitCocone_ι_hom _ _), assoc]
          erw [limitObjIsoLimitCompEvaluation_inv_π_app_assoc, limMap_π_assoc]
          simp
      [Elab.step] [0.922582] 
            delta colimitPresheafObjIsoComponentwiseLimit
            rw [Iso.trans_inv, Iso.trans_inv, Iso.app_inv, sheafIsoOfIso_inv, pushforwardToOfIso_app,
              congr_app (Iso.symm_inv _)]
            dsimp
            rw [map_id, comp_id, assoc, assoc, assoc, NatTrans.naturality, ← comp_c_app_assoc,
              congr_app (colimit.isoColimitCocone_ι_hom _ _), assoc]
            erw [limitObjIsoLimitCompEvaluation_inv_π_app_assoc, limMap_π_assoc]
            simp
        [Elab.step] [0.135785] rw [Iso.trans_inv, Iso.trans_inv, Iso.app_inv, sheafIsoOfIso_inv, pushforwardToOfIso_app,
              congr_app (Iso.symm_inv _)]
          [Elab.step] [0.135770] (rewrite [Iso.trans_inv, Iso.trans_inv, Iso.app_inv, sheafIsoOfIso_inv,
                  pushforwardToOfIso_app, congr_app (Iso.symm_inv _)];
                with_annotate_state"]" (try (with_reducible rfl)))
            [Elab.step] [0.135762] rewrite [Iso.trans_inv, Iso.trans_inv, Iso.app_inv, sheafIsoOfIso_inv,
                    pushforwardToOfIso_app, congr_app (Iso.symm_inv _)];
                  with_annotate_state"]" (try (with_reducible rfl))
              [Elab.step] [0.135756] rewrite [Iso.trans_inv, Iso.trans_inv, Iso.app_inv, sheafIsoOfIso_inv,
                      pushforwardToOfIso_app, congr_app (Iso.symm_inv _)];
                    with_annotate_state"]" (try (with_reducible rfl))
                [Elab.step] [0.135146] rewrite [Iso.trans_inv, Iso.trans_inv, Iso.app_inv, sheafIsoOfIso_inv,
                      pushforwardToOfIso_app, congr_app (Iso.symm_inv _)]
                  [Meta.check] [0.011988] ✅️ fun _a ↦
                        (((Limits.lim.mapIso
                                    (NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯))
                                      ⋯)).inv ≫
                                (limitObjIsoLimitCompEvaluation (pushforwardDiagramToColimit F).leftOp
                                    ((Opens.map
                                            (colimit.isoColimitCocone
                                                    { cocone := colimitCocone F,
                                                      isColimit := colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                      (op U))).inv) ≫
                              _a) ≫
                            (colimit.ι F j).c.app (op U) =
                          limit.π (componentwiseDiagram F U) (op j)
                  [Meta.check] [0.013908] ✅️ fun _a ↦
                        (((Limits.lim.mapIso
                                    (NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯))
                                      ⋯)).inv ≫
                                (limitObjIsoLimitCompEvaluation (pushforwardDiagramToColimit F).leftOp
                                    ((Opens.map
                                            (colimit.isoColimitCocone
                                                    { cocone := colimitCocone F,
                                                      isColimit := colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                      (op U))).inv) ≫
                              _a.app (op U)) ≫
                            (colimit.ι F j).c.app (op U) =
                          limit.π (componentwiseDiagram F U) (op j)
                  [Meta.check] [0.010543] ✅️ fun _a ↦
                        (((Limits.lim.mapIso
                                    (NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯))
                                      ⋯)).inv ≫
                                (limitObjIsoLimitCompEvaluation (pushforwardDiagramToColimit F).leftOp
                                    ((Opens.map
                                            (colimit.isoColimitCocone
                                                    { cocone := colimitCocone F,
                                                      isColimit := colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                      (op U))).inv) ≫
                              _a) ≫
                            (colimit.ι F j).c.app (op U) =
                          limit.π (componentwiseDiagram F U) (op j)
                  [Meta.check] [0.020840] ✅️ fun _a ↦
                        (((Limits.lim.mapIso
                                    (NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯))
                                      ⋯)).inv ≫
                                (limitObjIsoLimitCompEvaluation (pushforwardDiagramToColimit F).leftOp
                                    ((Opens.map
                                            (colimit.isoColimitCocone
                                                    { cocone := colimitCocone F,
                                                      isColimit := colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                      (op U))).inv) ≫
                              _a ≫ (Limits.colimit F).presheaf.map (eqToHom ⋯)) ≫
                            (colimit.ι F j).c.app (op U) =
                          limit.π (componentwiseDiagram F U) (op j)
        [Elab.step] [0.043416] dsimp
        [Elab.step] [0.347288] rw [map_id, comp_id, assoc, assoc, assoc, NatTrans.naturality, ← comp_c_app_assoc,
              congr_app (colimit.isoColimitCocone_ι_hom _ _), assoc]
          [Elab.step] [0.347048] (rewrite [map_id, comp_id, assoc, assoc, assoc, NatTrans.naturality, ←
                  comp_c_app_assoc, congr_app (colimit.isoColimitCocone_ι_hom _ _), assoc];
                with_annotate_state"]" (try (with_reducible rfl)))
            [Elab.step] [0.347040] rewrite [map_id, comp_id, assoc, assoc, assoc, NatTrans.naturality, ←
                    comp_c_app_assoc, congr_app (colimit.isoColimitCocone_ι_hom _ _), assoc];
                  with_annotate_state"]" (try (with_reducible rfl))
              [Elab.step] [0.347035] rewrite [map_id, comp_id, assoc, assoc, assoc, NatTrans.naturality, ←
                      comp_c_app_assoc, congr_app (colimit.isoColimitCocone_ι_hom _ _), assoc];
                    with_annotate_state"]" (try (with_reducible rfl))
                [Elab.step] [0.346402] rewrite [map_id, comp_id, assoc, assoc, assoc, NatTrans.naturality, ←
                      comp_c_app_assoc, congr_app (colimit.isoColimitCocone_ι_hom _ _), assoc]
                  [Meta.check] [0.032750] ✅️ fun _a ↦
                        ((limMap (NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)) ⋯).inv ≫
                                (limitObjIsoLimitCompEvaluation (pushforwardDiagramToColimit F).leftOp
                                    (op
                                      ((Opens.map
                                            (colimit.isoColimitCocone
                                                  { cocone := colimitCocone F,
                                                    isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                        U))).inv) ≫
                              ((colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).hom.c.app
                                    (op
                                      ((Opens.map
                                            (colimit.isoColimitCocone
                                                  { cocone := colimitCocone F,
                                                    isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                        U)) ≫
                                  _a) ≫
                                (Limits.colimit F).presheaf.map (eqToHom ⋯)) ≫
                            (colimit.ι F j).c.app (op U) =
                          limit.π (componentwiseDiagram F U) (op j)
                  [Meta.check] [0.028063] ✅️ fun _a ↦
                        ((limMap (NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)) ⋯).inv ≫
                                (limitObjIsoLimitCompEvaluation (pushforwardDiagramToColimit F).leftOp
                                    (op
                                      ((Opens.map
                                            (colimit.isoColimitCocone
                                                  { cocone := colimitCocone F,
                                                    isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                        U))).inv) ≫
                              _a ≫ (Limits.colimit F).presheaf.map (eqToHom ⋯)) ≫
                            (colimit.ι F j).c.app (op U) =
                          limit.π (componentwiseDiagram F U) (op j)
                  [Meta.check] [0.019057] ✅️ fun _a ↦
                        limMap (NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)) ⋯).inv ≫
                            (limitObjIsoLimitCompEvaluation (pushforwardDiagramToColimit F).leftOp
                                  (op
                                    ((Opens.map
                                          (colimit.isoColimitCocone
                                                { cocone := colimitCocone F,
                                                  isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                      U))).inv ≫
                              _a =
                          limit.π (componentwiseDiagram F U) (op j)
                  [Meta.check] [0.022883] ✅️ fun _a ↦
                        limMap (NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)) ⋯).inv ≫
                            (limitObjIsoLimitCompEvaluation (pushforwardDiagramToColimit F).leftOp
                                  (op
                                    ((Opens.map
                                          (colimit.isoColimitCocone
                                                { cocone := colimitCocone F,
                                                  isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                      U))).inv ≫
                              (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).hom.c.app
                                  (op
                                    ((Opens.map
                                          (colimit.isoColimitCocone
                                                { cocone := colimitCocone F,
                                                  isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                      U)) ≫
                                _a =
                          limit.π (componentwiseDiagram F U) (op j)
                  [Meta.isDefEq] [0.013327] ✅️ (colimit.isoColimitCocone
                                  { cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F }).hom.c.app
                          (op
                            ((Opens.map
                                  (colimit.isoColimitCocone
                                        { cocone := colimitCocone F,
                                          isColimit := colimitCoconeIsColimit F }).inv.base).obj
                              U)) ≫
                        (colimit.ι F j).c.app
                            (op
                              ((Opens.map
                                    (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).hom.base).obj
                                ((Opens.map
                                      (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                  U))) ≫
                          ((pushforward C (colimit.ι F j).base).obj (F.obj j).presheaf).map
                            (eqToHom
                              ⋯) =?= (Hom.c ?β).app ?U ≫
                        (Hom.c ?α).app (op ((Opens.map (Hom.base ?β)).obj (unop ?U))) ≫ ?h
                    [Meta.isDefEq] [0.011046] ✅️ (colimit.ι F j).c.app
                            (op
                              ((Opens.map
                                    (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).hom.base).obj
                                ((Opens.map
                                      (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                  U))) ≫
                          ((pushforward C (colimit.ι F j).base).obj (F.obj j).presheaf).map
                            (eqToHom
                              ⋯) =?= (Hom.c ?α).app
                            (op
                              ((Opens.map
                                    (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).hom.base).obj
                                (unop
                                  (op
                                    ((Opens.map
                                          (colimit.isoColimitCocone
                                                { cocone := colimitCocone F,
                                                  isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                      U))))) ≫
                          ?h
                  [Meta.check] [0.019487] ✅️ fun _a ↦
                        limMap (NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)) ⋯).inv ≫
                            (limitObjIsoLimitCompEvaluation (pushforwardDiagramToColimit F).leftOp
                                  (op
                                    ((Opens.map
                                          (colimit.isoColimitCocone
                                                { cocone := colimitCocone F,
                                                  isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                      U))).inv ≫
                              _a =
                          limit.π (componentwiseDiagram F U) (op j)
                  [Meta.check] [0.042766] ✅️ fun _a ↦
                        limMap (NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)) ⋯).inv ≫
                            (limitObjIsoLimitCompEvaluation (pushforwardDiagramToColimit F).leftOp
                                  (op
                                    ((Opens.map
                                          (colimit.isoColimitCocone
                                                { cocone := colimitCocone F,
                                                  isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                      U))).inv ≫
                              _a ≫ ((pushforward C (colimit.ι F j).base).obj (F.obj j).presheaf).map (eqToHom ⋯) =
                          limit.π (componentwiseDiagram F U) (op j)
                  [Meta.isDefEq] [0.013346] ✅️ (({ cocone := colimitCocone F,
                                          isColimit := colimitCoconeIsColimit F }.cocone.ι.app
                                  j).c.app
                            (op
                              ((Opens.map
                                    (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                U)) ≫
                          (F.obj j).presheaf.map (eqToHom ⋯)) ≫
                        ((pushforward C (colimit.ι F j).base).obj (F.obj j).presheaf).map (eqToHom ⋯) =?= (?f ≫ ?g) ≫ ?h
                  [Meta.check] [0.019948] ✅️ fun _a ↦
                        limMap (NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)) ⋯).inv ≫
                            (limitObjIsoLimitCompEvaluation (pushforwardDiagramToColimit F).leftOp
                                  (op
                                    ((Opens.map
                                          (colimit.isoColimitCocone
                                                { cocone := colimitCocone F,
                                                  isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                      U))).inv ≫
                              _a =
                          limit.π (componentwiseDiagram F U) (op j)
        [Elab.step] [0.157932] erw [limitObjIsoLimitCompEvaluation_inv_π_app_assoc, limMap_π_assoc]
          [Elab.step] [0.154595] rw (transparency✝ := .default✝) [limitObjIsoLimitCompEvaluation_inv_π_app_assoc,
                limMap_π_assoc]
            [Elab.step] [0.154588] (rewrite (transparency✝ :=
                    .default✝) [limitObjIsoLimitCompEvaluation_inv_π_app_assoc, limMap_π_assoc];
                  with_annotate_state"]" (try (with_reducible rfl)))
              [Elab.step] [0.154584] rewrite (transparency✝ :=
                      .default✝) [limitObjIsoLimitCompEvaluation_inv_π_app_assoc, limMap_π_assoc];
                    with_annotate_state"]" (try (with_reducible rfl))
                [Elab.step] [0.154579] rewrite (transparency✝ :=
                        .default✝) [limitObjIsoLimitCompEvaluation_inv_π_app_assoc, limMap_π_assoc];
                      with_annotate_state"]" (try (with_reducible rfl))
                  [Elab.step] [0.153927] rewrite (transparency✝ :=
                        .default✝) [limitObjIsoLimitCompEvaluation_inv_π_app_assoc, limMap_π_assoc]
                    [Meta.isDefEq] [0.012088] ✅️ (limitObjIsoLimitCompEvaluation (pushforwardDiagramToColimit F).leftOp
                              (op
                                ((Opens.map
                                      (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                  U))).inv ≫
                          ({ cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F }.cocone.ι.app j).c.app
                              (op
                                ((Opens.map
                                      (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                  U)) ≫
                            (F.obj j).presheaf.map (eqToHom ⋯) ≫
                              ((pushforward C (colimit.ι F j).base).obj (F.obj j).presheaf).map
                                (eqToHom ⋯) =?= (limitObjIsoLimitCompEvaluation ?F ?k).inv ≫ (limit.π ?F ?j).app ?k ≫ ?h
                      [Meta.isDefEq.delta] [0.012000] ✅️ (limitObjIsoLimitCompEvaluation
                                (pushforwardDiagramToColimit F).leftOp
                                (op
                                  ((Opens.map
                                        (colimit.isoColimitCocone
                                              { cocone := colimitCocone F,
                                                isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                    U))).inv ≫
                            ({ cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F }.cocone.ι.app j).c.app
                                (op
                                  ((Opens.map
                                        (colimit.isoColimitCocone
                                              { cocone := colimitCocone F,
                                                isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                    U)) ≫
                              (F.obj j).presheaf.map (eqToHom ⋯) ≫
                                ((pushforward C (colimit.ι F j).base).obj (F.obj j).presheaf).map
                                  (eqToHom
                                    ⋯) =?= (limitObjIsoLimitCompEvaluation ?F ?k).inv ≫ (limit.π ?F ?j).app ?k ≫ ?h
                    [Meta.check] [0.023999] ✅️ fun _a ↦
                          limMap (NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)) ⋯).inv ≫
                              _a =
                            limit.π (componentwiseDiagram F U) (op j)
                    [Meta.synthInstance] [0.043793] ✅️ HasLimit (componentwiseDiagram F U)
                    [Meta.synthInstance] [0.050911] ✅️ HasLimit
                          ((pushforwardDiagramToColimit F).leftOp ⋙
                            (evaluation (Opens ↑(Limits.colimit (F ⋙ forget C)))ᵒᵖ C).obj
                              (op
                                ((Opens.map
                                      (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                  U)))
        [Elab.step] [0.237283] simp
          [Meta.isDefEq] [0.020018] ✅️ (NatIso.ofComponents ?app ?naturality).inv.app
                ?X =?= (NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)) ⋯).inv.app (op j)
            [Meta.isDefEq.delta] [0.019991] ✅️ (NatIso.ofComponents ?app ?naturality).inv.app
                  ?X =?= (NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)) ⋯).inv.app (op j)
              [Meta.isDefEq] [0.019797] ✅️ (NatIso.ofComponents ?app
                      ?naturality).inv =?= (NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯))
                      ⋯).inv
                [Meta.isDefEq.delta] [0.019779] ✅️ (NatIso.ofComponents ?app
                        ?naturality).inv =?= (NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯))
                        ⋯).inv
                  [Meta.isDefEq] [0.019743] ✅️ NatIso.ofComponents ?app
                        ?naturality =?= NatIso.ofComponents (fun X ↦ mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)) ⋯
                    [Meta.isDefEq] [0.017808] ✅️ ?naturality =?= @colimitPresheafObjIsoComponentwiseLimit._proof_5 J
                          inst✝⁴ C inst✝³ inst✝² inst✝¹ inst✝ F (hasColimitOfHasColimitsOfShape F) U
                      [Meta.isDefEq.assign] [0.017806] ✅️ ?naturality := @colimitPresheafObjIsoComponentwiseLimit._proof_5
                            J inst✝⁴ C inst✝³ inst✝² inst✝¹ inst✝ F (hasColimitOfHasColimitsOfShape F) U
                        [Meta.isDefEq.assign.checkTypes] [0.017713] ✅️ (?naturality : autoParam
                              (∀ {X Y : Jᵒᵖ} (f : X ⟶ Y),
                                ((pushforwardDiagramToColimit F).leftOp ⋙
                                          (evaluation (Opens ↑(Limits.colimit (F ⋙ forget C)))ᵒᵖ C).obj
                                            (op
                                              ((Opens.map
                                                    (colimit.isoColimitCocone
                                                          { cocone := colimitCocone F,
                                                            isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                                U))).map
                                      f ≫
                                    (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom =
                                  (mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)).hom ≫ (componentwiseDiagram F U).map f)
                              _auto✝) := (@colimitPresheafObjIsoComponentwiseLimit._proof_5 J inst✝⁴ C inst✝³ inst✝²
                              inst✝¹ inst✝ F (hasColimitOfHasColimitsOfShape F)
                              U : ∀ {X Y : Jᵒᵖ} (f : X ⟶ Y),
                              ((pushforwardDiagramToColimit F).leftOp ⋙
                                        (evaluation
                                              (Opens
                                                  ↑↑{ cocone := colimitCocone F,
                                                            isColimit := colimitCoconeIsColimit F }.cocone.pt)ᵒᵖ
                                              C).obj
                                          ((Opens.map
                                                  (colimit.isoColimitCocone
                                                          { cocone := colimitCocone F,
                                                            isColimit :=
                                                              colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                            (op U))).map
                                    f ≫
                                  (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom =
                                (mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)).hom ≫ (componentwiseDiagram F U).map f)
                          [Meta.isDefEq] [0.017709] ✅️ autoParam
                                (∀ {X Y : Jᵒᵖ} (f : X ⟶ Y),
                                  ((pushforwardDiagramToColimit F).leftOp ⋙
                                            (evaluation (Opens ↑(Limits.colimit (F ⋙ forget C)))ᵒᵖ C).obj
                                              (op
                                                ((Opens.map
                                                      (colimit.isoColimitCocone
                                                            { cocone := colimitCocone F,
                                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                                  U))).map
                                        f ≫
                                      (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom =
                                    (mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)).hom ≫
                                      (componentwiseDiagram F U).map f)
                                _auto✝ =?= ∀ {X Y : Jᵒᵖ} (f : X ⟶ Y),
                                ((pushforwardDiagramToColimit F).leftOp ⋙
                                          (evaluation
                                                (Opens
                                                    ↑↑{ cocone := colimitCocone F,
                                                              isColimit := colimitCoconeIsColimit F }.cocone.pt)ᵒᵖ
                                                C).obj
                                            ((Opens.map
                                                    (colimit.isoColimitCocone
                                                            { cocone := colimitCocone F,
                                                              isColimit :=
                                                                colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                              (op U))).map
                                      f ≫
                                    (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom =
                                  (mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)).hom ≫ (componentwiseDiagram F U).map f
                            [Meta.isDefEq] [0.017679] ✅️ ∀ {X Y : Jᵒᵖ} (f : X ⟶ Y),
                                  ((pushforwardDiagramToColimit F).leftOp ⋙
                                            (evaluation (Opens ↑(Limits.colimit (F ⋙ forget C)))ᵒᵖ C).obj
                                              (op
                                                ((Opens.map
                                                      (colimit.isoColimitCocone
                                                            { cocone := colimitCocone F,
                                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                                  U))).map
                                        f ≫
                                      (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom =
                                    (mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)).hom ≫
                                      (componentwiseDiagram F U).map
                                        f =?= ∀ {X Y : Jᵒᵖ} (f : X ⟶ Y),
                                  ((pushforwardDiagramToColimit F).leftOp ⋙
                                            (evaluation
                                                  (Opens
                                                      ↑↑{ cocone := colimitCocone F,
                                                                isColimit := colimitCoconeIsColimit F }.cocone.pt)ᵒᵖ
                                                  C).obj
                                              ((Opens.map
                                                      (colimit.isoColimitCocone
                                                              { cocone := colimitCocone F,
                                                                isColimit :=
                                                                  colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                                (op U))).map
                                        f ≫
                                      (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom =
                                    (mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)).hom ≫
                                      (componentwiseDiagram F U).map f
                              [Meta.isDefEq] [0.017646] ✅️ ((pushforwardDiagramToColimit F).leftOp ⋙
                                            (evaluation (Opens ↑(Limits.colimit (F ⋙ forget C)))ᵒᵖ C).obj
                                              (op
                                                ((Opens.map
                                                      (colimit.isoColimitCocone
                                                            { cocone := colimitCocone F,
                                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                                  U))).map
                                        f ≫
                                      (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom =
                                    (mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)).hom ≫
                                      (componentwiseDiagram F U).map
                                        f =?= ((pushforwardDiagramToColimit F).leftOp ⋙
                                            (evaluation
                                                  (Opens
                                                      ↑↑{ cocone := colimitCocone F,
                                                                isColimit := colimitCoconeIsColimit F }.cocone.pt)ᵒᵖ
                                                  C).obj
                                              ((Opens.map
                                                      (colimit.isoColimitCocone
                                                              { cocone := colimitCocone F,
                                                                isColimit :=
                                                                  colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                                (op U))).map
                                        f ≫
                                      (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom =
                                    (mapIso (F.obj (unop X)).presheaf (eqToIso ⋯)).hom ≫
                                      (componentwiseDiagram F U).map f
                                [Meta.isDefEq] [0.016839] ✅️ ((pushforwardDiagramToColimit F).leftOp ⋙
                                            (evaluation (Opens ↑(Limits.colimit (F ⋙ forget C)))ᵒᵖ C).obj
                                              (op
                                                ((Opens.map
                                                      (colimit.isoColimitCocone
                                                            { cocone := colimitCocone F,
                                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                                  U))).map
                                        f ≫
                                      (mapIso (F.obj (unop Y)).presheaf
                                          (eqToIso
                                            ⋯)).hom =?= ((pushforwardDiagramToColimit F).leftOp ⋙
                                            (evaluation
                                                  (Opens
                                                      ↑↑{ cocone := colimitCocone F,
                                                                isColimit := colimitCoconeIsColimit F }.cocone.pt)ᵒᵖ
                                                  C).obj
                                              ((Opens.map
                                                      (colimit.isoColimitCocone
                                                              { cocone := colimitCocone F,
                                                                isColimit :=
                                                                  colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                                (op U))).map
                                        f ≫
                                      (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom
                                  [Meta.isDefEq] [0.016824] ✅️ inst✝³.toCategoryStruct.3
                                        (((pushforwardDiagramToColimit F).leftOp ⋙
                                              (evaluation (Opens ↑(Limits.colimit (F ⋙ forget C)))ᵒᵖ C).obj
                                                (op
                                                  ((Opens.map
                                                        (colimit.isoColimitCocone
                                                              { cocone := colimitCocone F,
                                                                isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                                    U))).map
                                          f)
                                        (mapIso (F.obj (unop Y)).presheaf
                                            (eqToIso
                                              ⋯)).hom =?= inst✝³.toCategoryStruct.3
                                        (((pushforwardDiagramToColimit F).leftOp ⋙
                                              (evaluation
                                                    (Opens
                                                        ↑↑{ cocone := colimitCocone F,
                                                                  isColimit := colimitCoconeIsColimit F }.cocone.pt)ᵒᵖ
                                                    C).obj
                                                ((Opens.map
                                                        (colimit.isoColimitCocone
                                                                { cocone := colimitCocone F,
                                                                  isColimit :=
                                                                    colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                                  (op U))).map
                                          f)
                                        (mapIso (F.obj (unop Y)).presheaf (eqToIso ⋯)).hom
                                    [Meta.isDefEq] [0.014645] ✅️ ((pushforwardDiagramToColimit F).leftOp ⋙
                                              (evaluation (Opens ↑(Limits.colimit (F ⋙ forget C)))ᵒᵖ C).obj
                                                (op
                                                  ((Opens.map
                                                        (colimit.isoColimitCocone
                                                              { cocone := colimitCocone F,
                                                                isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                                    U))).map
                                          f =?= ((pushforwardDiagramToColimit F).leftOp ⋙
                                              (evaluation
                                                    (Opens
                                                        ↑↑{ cocone := colimitCocone F,
                                                                  isColimit := colimitCoconeIsColimit F }.cocone.pt)ᵒᵖ
                                                    C).obj
                                                ((Opens.map
                                                        (colimit.isoColimitCocone
                                                                { cocone := colimitCocone F,
                                                                  isColimit :=
                                                                    colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                                  (op U))).map
                                          f
                                      [Meta.isDefEq] [0.014628] ✅️ ((pushforwardDiagramToColimit F).leftOp ⋙
                                                  (evaluation (Opens ↑(Limits.colimit (F ⋙ forget C)))ᵒᵖ C).obj
                                                    (op
                                                      ((Opens.map
                                                            (colimit.isoColimitCocone
                                                                  { cocone := colimitCocone F,
                                                                    isColimit :=
                                                                      colimitCoconeIsColimit F }).inv.base).obj
                                                        U))).toPrefunctor.2
                                            f =?= ((pushforwardDiagramToColimit F).leftOp ⋙
                                                  (evaluation
                                                        (Opens
                                                            ↑↑{ cocone := colimitCocone F,
                                                                      isColimit :=
                                                                        colimitCoconeIsColimit F }.cocone.pt)ᵒᵖ
                                                        C).obj
                                                    ((Opens.map
                                                            (colimit.isoColimitCocone
                                                                    { cocone := colimitCocone F,
                                                                      isColimit :=
                                                                        colimitCoconeIsColimit
                                                                          F }).symm.hom.base).op.obj
                                                      (op U))).toPrefunctor.2
                                            f
                                        [Meta.isDefEq] [0.014549] ✅️ ((evaluation
                                                      (Opens ↑(Limits.colimit (F ⋙ forget C)))ᵒᵖ C).obj
                                                  (op
                                                    ((Opens.map
                                                          (colimit.isoColimitCocone
                                                                { cocone := colimitCocone F,
                                                                  isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                                      U))).map
                                              ((pushforwardDiagramToColimit F).leftOp.map
                                                f) =?= ((evaluation
                                                      (Opens
                                                          ↑↑{ cocone := colimitCocone F,
                                                                    isColimit := colimitCoconeIsColimit F }.cocone.pt)ᵒᵖ
                                                      C).obj
                                                  ((Opens.map
                                                          (colimit.isoColimitCocone
                                                                  { cocone := colimitCocone F,
                                                                    isColimit :=
                                                                      colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                                    (op U))).map
                                              ((pushforwardDiagramToColimit F).leftOp.map f)
                                          [Meta.isDefEq] [0.014534] ✅️ ((evaluation
                                                          (Opens ↑(Limits.colimit (F ⋙ forget C)))ᵒᵖ C).obj
                                                      (op
                                                        ((Opens.map
                                                              (colimit.isoColimitCocone
                                                                    { cocone := colimitCocone F,
                                                                      isColimit :=
                                                                        colimitCoconeIsColimit F }).inv.base).obj
                                                          U))).toPrefunctor.2
                                                ((pushforwardDiagramToColimit F).leftOp.map
                                                  f) =?= ((evaluation
                                                          (Opens
                                                              ↑↑{ cocone := colimitCocone F,
                                                                        isColimit :=
                                                                          colimitCoconeIsColimit F }.cocone.pt)ᵒᵖ
                                                          C).obj
                                                      ((Opens.map
                                                              (colimit.isoColimitCocone
                                                                      { cocone := colimitCocone F,
                                                                        isColimit :=
                                                                          colimitCoconeIsColimit
                                                                            F }).symm.hom.base).op.obj
                                                        (op U))).toPrefunctor.2
                                                ((pushforwardDiagramToColimit F).leftOp.map f)
                                            [Meta.isDefEq] [0.014406] ✅️ ((pushforwardDiagramToColimit F).leftOp.map
                                                      f).app
                                                  (op
                                                    ((Opens.map
                                                          (colimit.isoColimitCocone
                                                                { cocone := colimitCocone F,
                                                                  isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                                      U)) =?= ((pushforwardDiagramToColimit F).leftOp.map f).app
                                                  ((Opens.map
                                                          (colimit.isoColimitCocone
                                                                  { cocone := colimitCocone F,
                                                                    isColimit :=
                                                                      colimitCoconeIsColimit F }).symm.hom.base).op.obj
                                                    (op U))
                                              [Meta.isDefEq] [0.014386] ✅️ ((pushforwardDiagramToColimit F).leftOp.map
                                                        f).1
                                                    (op
                                                      ((Opens.map
                                                            (colimit.isoColimitCocone
                                                                  { cocone := colimitCocone F,
                                                                    isColimit :=
                                                                      colimitCoconeIsColimit F }).inv.base).obj
                                                        U)) =?= ((pushforwardDiagramToColimit F).leftOp.map f).1
                                                    ((Opens.map
                                                            (colimit.isoColimitCocone
                                                                    { cocone := colimitCocone F,
                                                                      isColimit :=
                                                                        colimitCoconeIsColimit
                                                                          F }).symm.hom.base).op.obj
                                                      (op U))
                                                [Meta.isDefEq] [0.010919] ✅️ ((pushforward C
                                                                (colimit.ι (F ⋙ forget C) (unop X))).map
                                                            (F.map f.unop).c).app
                                                        (op
                                                          ((Opens.map
                                                                (colimit.isoColimitCocone
                                                                      { cocone := colimitCocone F,
                                                                        isColimit :=
                                                                          colimitCoconeIsColimit F }).inv.base).obj
                                                            U)) ≫
                                                      ((Pushforward.comp ((F ⋙ forget C).map f.unop)
                                                                (colimit.ι (F ⋙ forget C) (unop X))
                                                                (F.obj (unop Y)).presheaf).inv ≫
                                                            (pushforwardEq ⋯ (F.obj (unop Y)).presheaf).hom).app
                                                        (op
                                                          ((Opens.map
                                                                (colimit.isoColimitCocone
                                                                      { cocone := colimitCocone F,
                                                                        isColimit :=
                                                                          colimitCoconeIsColimit F }).inv.base).obj
                                                            U)) =?= ((pushforward C
                                                                (colimit.ι (F ⋙ forget C) (unop X))).map
                                                            (F.map f.unop).c).app
                                                        ((Opens.map
                                                                (colimit.isoColimitCocone
                                                                        { cocone := colimitCocone F,
                                                                          isColimit :=
                                                                            colimitCoconeIsColimit
                                                                              F }).symm.hom.base).op.obj
                                                          (op U)) ≫
                                                      ((Pushforward.comp ((F ⋙ forget C).map f.unop)
                                                                (colimit.ι (F ⋙ forget C) (unop X))
                                                                (F.obj (unop Y)).presheaf).inv ≫
                                                            (pushforwardEq ⋯ (F.obj (unop Y)).presheaf).hom).app
                                                        ((Opens.map
                                                                (colimit.isoColimitCocone
                                                                        { cocone := colimitCocone F,
                                                                          isColimit :=
                                                                            colimitCoconeIsColimit
                                                                              F }).symm.hom.base).op.obj
                                                          (op U))
                                                  [Meta.isDefEq] [0.010872] ✅️ inst✝³.toCategoryStruct.3
                                                        (((pushforward C (colimit.ι (F ⋙ forget C) (unop X))).map
                                                              (F.map f.unop).c).app
                                                          (op
                                                            ((Opens.map
                                                                  (colimit.isoColimitCocone
                                                                        { cocone := colimitCocone F,
                                                                          isColimit :=
                                                                            colimitCoconeIsColimit F }).inv.base).obj
                                                              U)))
                                                        (((Pushforward.comp ((F ⋙ forget C).map f.unop)
                                                                  (colimit.ι (F ⋙ forget C) (unop X))
                                                                  (F.obj (unop Y)).presheaf).inv ≫
                                                              (pushforwardEq ⋯ (F.obj (unop Y)).presheaf).hom).app
                                                          (op
                                                            ((Opens.map
                                                                  (colimit.isoColimitCocone
                                                                        { cocone := colimitCocone F,
                                                                          isColimit :=
                                                                            colimitCoconeIsColimit F }).inv.base).obj
                                                              U))) =?= inst✝³.toCategoryStruct.3
                                                        (((pushforward C (colimit.ι (F ⋙ forget C) (unop X))).map
                                                              (F.map f.unop).c).app
                                                          ((Opens.map
                                                                  (colimit.isoColimitCocone
                                                                          { cocone := colimitCocone F,
                                                                            isColimit :=
                                                                              colimitCoconeIsColimit
                                                                                F }).symm.hom.base).op.obj
                                                            (op U)))
                                                        (((Pushforward.comp ((F ⋙ forget C).map f.unop)
                                                                  (colimit.ι (F ⋙ forget C) (unop X))
                                                                  (F.obj (unop Y)).presheaf).inv ≫
                                                              (pushforwardEq ⋯ (F.obj (unop Y)).presheaf).hom).app
                                                          ((Opens.map
                                                                  (colimit.isoColimitCocone
                                                                          { cocone := colimitCocone F,
                                                                            isColimit :=
                                                                              colimitCoconeIsColimit
                                                                                F }).symm.hom.base).op.obj
                                                            (op U)))
          [Meta.isDefEq] [0.036880] ❌️ eqToHom ?p =?= eqToHom ⋯
            [Meta.isDefEq] [0.036754] ❌️ ?p =?= colimit.isoColimitCocone_ι_hom
                    { cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F } j ▸
                  Eq.refl
                    ((Opens.map
                            (colimit.ι F j ≫
                                (colimit.isoColimitCocone
                                    { cocone := colimitCocone F,
                                      isColimit := colimitCoconeIsColimit F }).hom).base).op.obj
                      (op
                        ((Opens.map
                              (colimit.isoColimitCocone
                                    { cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F }).inv.base).obj
                          U)))
              [Meta.isDefEq.assign] [0.014492] ❌️ ?p := colimit.isoColimitCocone_ι_hom
                      { cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F } j ▸
                    Eq.refl
                      ((Opens.map
                              (colimit.ι F j ≫
                                  (colimit.isoColimitCocone
                                      { cocone := colimitCocone F,
                                        isColimit := colimitCoconeIsColimit F }).hom).base).op.obj
                        (op
                          ((Opens.map
                                (colimit.isoColimitCocone
                                      { cocone := colimitCocone F,
                                        isColimit := colimitCoconeIsColimit F }).inv.base).obj
                            U)))
                [Meta.isDefEq.assign.checkTypes] [0.014435] ❌️ (?p : op
                        ((Opens.map (colimit.ι (F ⋙ forget C) j)).obj
                          ((Opens.map
                                (colimit.isoColimitCocone
                                      { cocone := colimitCocone F,
                                        isColimit := colimitCoconeIsColimit F }).inv.base).obj
                            U)) =
                      op
                        ((Opens.map (colimit.ι (F ⋙ forget C) j)).obj
                          ((Opens.map
                                (colimit.isoColimitCocone
                                      { cocone := colimitCocone F,
                                        isColimit := colimitCoconeIsColimit F }).inv.base).obj
                            U))) := (colimit.isoColimitCocone_ι_hom
                        { cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F } j ▸
                      Eq.refl
                        ((Opens.map
                                (colimit.ι F j ≫
                                    (colimit.isoColimitCocone
                                        { cocone := colimitCocone F,
                                          isColimit := colimitCoconeIsColimit F }).hom).base).op.obj
                          (op
                            ((Opens.map
                                  (colimit.isoColimitCocone
                                        { cocone := colimitCocone F,
                                          isColimit := colimitCoconeIsColimit F }).inv.base).obj
                              U))) : (Opens.map
                              ({ cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F }.cocone.ι.app
                                  j).base).op.obj
                        (op
                          ((Opens.map
                                (colimit.isoColimitCocone
                                      { cocone := colimitCocone F,
                                        isColimit := colimitCoconeIsColimit F }).inv.base).obj
                            U)) =
                      (Opens.map
                              (colimit.ι F j ≫
                                  (colimit.isoColimitCocone
                                      { cocone := colimitCocone F,
                                        isColimit := colimitCoconeIsColimit F }).hom).base).op.obj
                        (op
                          ((Opens.map
                                (colimit.isoColimitCocone
                                      { cocone := colimitCocone F,
                                        isColimit := colimitCoconeIsColimit F }).inv.base).obj
                            U)))
                  [Meta.isDefEq] [0.014433] ❌️ op
                          ((Opens.map (colimit.ι (F ⋙ forget C) j)).obj
                            ((Opens.map
                                  (colimit.isoColimitCocone
                                        { cocone := colimitCocone F,
                                          isColimit := colimitCoconeIsColimit F }).inv.base).obj
                              U)) =
                        op
                          ((Opens.map (colimit.ι (F ⋙ forget C) j)).obj
                            ((Opens.map
                                  (colimit.isoColimitCocone
                                        { cocone := colimitCocone F,
                                          isColimit := colimitCoconeIsColimit F }).inv.base).obj
                              U)) =?= (Opens.map
                                ({ cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F }.cocone.ι.app
                                    j).base).op.obj
                          (op
                            ((Opens.map
                                  (colimit.isoColimitCocone
                                        { cocone := colimitCocone F,
                                          isColimit := colimitCoconeIsColimit F }).inv.base).obj
                              U)) =
                        (Opens.map
                                (colimit.ι F j ≫
                                    (colimit.isoColimitCocone
                                        { cocone := colimitCocone F,
                                          isColimit := colimitCoconeIsColimit F }).hom).base).op.obj
                          (op
                            ((Opens.map
                                  (colimit.isoColimitCocone
                                        { cocone := colimitCocone F,
                                          isColimit := colimitCoconeIsColimit F }).inv.base).obj
                              U))
                    [Meta.isDefEq] [0.013670] ❌️ op
                          ((Opens.map (colimit.ι (F ⋙ forget C) j)).obj
                            ((Opens.map
                                  (colimit.isoColimitCocone
                                        { cocone := colimitCocone F,
                                          isColimit := colimitCoconeIsColimit F }).inv.base).obj
                              U)) =?= (Opens.map
                                (colimit.ι F j ≫
                                    (colimit.isoColimitCocone
                                        { cocone := colimitCocone F,
                                          isColimit := colimitCoconeIsColimit F }).hom).base).op.obj
                          (op
                            ((Opens.map
                                  (colimit.isoColimitCocone
                                        { cocone := colimitCocone F,
                                          isColimit := colimitCoconeIsColimit F }).inv.base).obj
                              U))
                      [Meta.isDefEq] [0.013662] ❌️ op
                            ((Opens.map (colimit.ι (F ⋙ forget C) j)).obj
                              ((Opens.map
                                    (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                U)) =?= (Opens.map
                                    (colimit.ι F j ≫
                                        (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).hom).base).op.toPrefunctor.1
                            (op
                              ((Opens.map
                                    (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                U))
                        [Meta.isDefEq] [0.013635] ❌️ op
                              ((Opens.map (colimit.ι (F ⋙ forget C) j)).obj
                                ((Opens.map
                                      (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                  U)) =?= op
                              ((Opens.map
                                    (colimit.ι F j ≫
                                        (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).hom).base).obj
                                (unop
                                  (op
                                    ((Opens.map
                                          (colimit.isoColimitCocone
                                                { cocone := colimitCocone F,
                                                  isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                      U))))
                          [Meta.isDefEq] [0.013607] ❌️ (Opens.map (colimit.ι (F ⋙ forget C) j)).obj
                                ((Opens.map
                                      (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                  U) =?= (Opens.map
                                    (colimit.ι F j ≫
                                        (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).hom).base).obj
                                (unop
                                  (op
                                    ((Opens.map
                                          (colimit.isoColimitCocone
                                                { cocone := colimitCocone F,
                                                  isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                      U)))
                            [Meta.isDefEq] [0.013597] ❌️ (Opens.map (colimit.ι (F ⋙ forget C) j)).toPrefunctor.1
                                  ((Opens.map
                                        (colimit.isoColimitCocone
                                              { cocone := colimitCocone F,
                                                isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                    U) =?= (Opens.map
                                        (colimit.ι F j ≫
                                            (colimit.isoColimitCocone
                                                { cocone := colimitCocone F,
                                                  isColimit := colimitCoconeIsColimit F }).hom).base).toPrefunctor.1
                                  (unop
                                    (op
                                      ((Opens.map
                                            (colimit.isoColimitCocone
                                                  { cocone := colimitCocone F,
                                                    isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                        U)))
                              [Meta.isDefEq] [0.013549] ❌️ {
                                    carrier :=
                                      ⇑(ConcreteCategory.hom (colimit.ι (F ⋙ forget C) j)) ⁻¹'
                                        ↑((Opens.map
                                                (colimit.isoColimitCocone
                                                      { cocone := colimitCocone F,
                                                        isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                            U),
                                    is_open' :=
                                      ⋯ } =?= {
                                    carrier :=
                                      ⇑(ConcreteCategory.hom
                                            (colimit.ι F j ≫
                                                (colimit.isoColimitCocone
                                                    { cocone := colimitCocone F,
                                                      isColimit := colimitCoconeIsColimit F }).hom).base) ⁻¹'
                                        ↑(unop
                                            (op
                                              ((Opens.map
                                                    (colimit.isoColimitCocone
                                                          { cocone := colimitCocone F,
                                                            isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                                U))),
                                    is_open' := ⋯ }
                                [Meta.isDefEq] [0.013528] ❌️ ⇑(ConcreteCategory.hom (colimit.ι (F ⋙ forget C) j)) ⁻¹'
                                      ↑((Opens.map
                                              (colimit.isoColimitCocone
                                                    { cocone := colimitCocone F,
                                                      isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                          U) =?= ⇑(ConcreteCategory.hom
                                          (colimit.ι F j ≫
                                              (colimit.isoColimitCocone
                                                  { cocone := colimitCocone F,
                                                    isColimit := colimitCoconeIsColimit F }).hom).base) ⁻¹'
                                      ↑(unop
                                          (op
                                            ((Opens.map
                                                  (colimit.isoColimitCocone
                                                        { cocone := colimitCocone F,
                                                          isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                              U)))
                                  [Meta.isDefEq.delta] [0.010260] ❌️ ⇑(ConcreteCategory.hom
                                            (colimit.ι (F ⋙ forget C) j)) ⁻¹'
                                        ↑((Opens.map
                                                (colimit.isoColimitCocone
                                                      { cocone := colimitCocone F,
                                                        isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                            U) =?= ⇑(ConcreteCategory.hom
                                            (colimit.ι F j ≫
                                                (colimit.isoColimitCocone
                                                    { cocone := colimitCocone F,
                                                      isColimit := colimitCoconeIsColimit F }).hom).base) ⁻¹'
                                        ↑(unop
                                            (op
                                              ((Opens.map
                                                    (colimit.isoColimitCocone
                                                          { cocone := colimitCocone F,
                                                            isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                                U)))
                                    [Meta.isDefEq] [0.010255] ❌️ ⇑(ConcreteCategory.hom
                                            (colimit.ι (F ⋙ forget C)
                                              j)) =?= ⇑(ConcreteCategory.hom
                                            (colimit.ι F j ≫
                                                (colimit.isoColimitCocone
                                                    { cocone := colimitCocone F,
                                                      isColimit := colimitCoconeIsColimit F }).hom).base)
                                      [Meta.isDefEq] [0.010244] ❌️ ((fun X Y ↦ ContinuousMap.instFunLike) (↑(F.obj j))
                                                (Limits.colimit (F ⋙ forget C))).1
                                            (ConcreteCategory.hom
                                              (colimit.ι (F ⋙ forget C)
                                                j)) =?= ((fun X Y ↦ ContinuousMap.instFunLike) ↑(F.obj j)
                                                ↑{ cocone := colimitCocone F,
                                                        isColimit := colimitCoconeIsColimit F }.cocone.pt).1
                                            (ConcreteCategory.hom
                                              (colimit.ι F j ≫
                                                  (colimit.isoColimitCocone
                                                      { cocone := colimitCocone F,
                                                        isColimit := colimitCoconeIsColimit F }).hom).base)
                                        [Meta.isDefEq] [0.010227] ❌️ (ConcreteCategory.hom
                                                (colimit.ι (F ⋙ forget C)
                                                  j)).toFun =?= (ConcreteCategory.hom
                                                (colimit.ι F j ≫
                                                    (colimit.isoColimitCocone
                                                        { cocone := colimitCocone F,
                                                          isColimit := colimitCoconeIsColimit F }).hom).base).toFun
                                          [Meta.isDefEq] [0.010215] ❌️ (ConcreteCategory.hom
                                                  (colimit.ι (F ⋙ forget C)
                                                    j)).1 =?= (ConcreteCategory.hom
                                                  (colimit.ι F j ≫
                                                      (colimit.isoColimitCocone
                                                          { cocone := colimitCocone F,
                                                            isColimit := colimitCoconeIsColimit F }).hom).base).1
              [Meta.isDefEq.assign] [0.017826] ❌️ ?p := colimit.isoColimitCocone_ι_hom
                      { cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F } j ▸
                    Eq.refl
                      ((Opens.map
                              (colimit.ι F j ≫
                                  (colimit.isoColimitCocone
                                      { cocone := colimitCocone F,
                                        isColimit := colimitCoconeIsColimit F }).hom).base).op.obj
                        (op
                          ((Opens.map
                                (colimit.isoColimitCocone
                                      { cocone := colimitCocone F,
                                        isColimit := colimitCoconeIsColimit F }).inv.base).obj
                            U)))
                [Meta.isDefEq.assign.checkTypes] [0.017754] ❌️ (?p : op
                        ((Opens.map (colimit.ι (F ⋙ forget C) j)).obj
                          ((Opens.map
                                (colimit.isoColimitCocone
                                      { cocone := colimitCocone F,
                                        isColimit := colimitCoconeIsColimit F }).inv.base).obj
                            U)) =
                      op
                        ((Opens.map (colimit.ι (F ⋙ forget C) j)).obj
                          ((Opens.map
                                (colimit.isoColimitCocone
                                      { cocone := colimitCocone F,
                                        isColimit := colimitCoconeIsColimit F }).inv.base).obj
                            U))) := (colimit.isoColimitCocone_ι_hom
                        { cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F } j ▸
                      Eq.refl
                        ((Opens.map
                                (colimit.ι F j ≫
                                    (colimit.isoColimitCocone
                                        { cocone := colimitCocone F,
                                          isColimit := colimitCoconeIsColimit F }).hom).base).op.obj
                          (op
                            ((Opens.map
                                  (colimit.isoColimitCocone
                                        { cocone := colimitCocone F,
                                          isColimit := colimitCoconeIsColimit F }).inv.base).obj
                              U))) : fun {β} ↦
                      (Opens.map β.base).op.obj
                          (op
                            ((Opens.map
                                  (colimit.isoColimitCocone
                                        { cocone := colimitCocone F,
                                          isColimit := colimitCoconeIsColimit F }).inv.base).obj
                              U)) =
                        (Opens.map
                                (colimit.ι F j ≫
                                    (colimit.isoColimitCocone
                                        { cocone := colimitCocone F,
                                          isColimit := colimitCoconeIsColimit F }).hom).base).op.obj
                          (op
                            ((Opens.map
                                  (colimit.isoColimitCocone
                                        { cocone := colimitCocone F,
                                          isColimit := colimitCoconeIsColimit F }).inv.base).obj
                              U)))
                  [Meta.isDefEq] [0.017751] ❌️ op
                          ((Opens.map (colimit.ι (F ⋙ forget C) j)).obj
                            ((Opens.map
                                  (colimit.isoColimitCocone
                                        { cocone := colimitCocone F,
                                          isColimit := colimitCoconeIsColimit F }).inv.base).obj
                              U)) =
                        op
                          ((Opens.map (colimit.ι (F ⋙ forget C) j)).obj
                            ((Opens.map
                                  (colimit.isoColimitCocone
                                        { cocone := colimitCocone F,
                                          isColimit := colimitCoconeIsColimit F }).inv.base).obj
                              U)) =?= fun {β} ↦
                        (Opens.map β.base).op.obj
                            (op
                              ((Opens.map
                                    (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                U)) =
                          (Opens.map
                                  (colimit.ι F j ≫
                                      (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).hom).base).op.obj
                            (op
                              ((Opens.map
                                    (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                U))
                    [Meta.isDefEq] [0.017746] ❌️ op
                            ((Opens.map (colimit.ι (F ⋙ forget C) j)).obj
                              ((Opens.map
                                    (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                U)) =
                          op
                            ((Opens.map (colimit.ι (F ⋙ forget C) j)).obj
                              ((Opens.map
                                    (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                U)) =?= (Opens.map
                                  ({ cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F }.cocone.ι.app
                                      j).base).op.obj
                            (op
                              ((Opens.map
                                    (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                U)) =
                          (Opens.map
                                  (colimit.ι F j ≫
                                      (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).hom).base).op.obj
                            (op
                              ((Opens.map
                                    (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                U))
                      [Meta.isDefEq] [0.017009] ❌️ op
                            ((Opens.map (colimit.ι (F ⋙ forget C) j)).obj
                              ((Opens.map
                                    (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                U)) =?= (Opens.map
                                  (colimit.ι F j ≫
                                      (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).hom).base).op.obj
                            (op
                              ((Opens.map
                                    (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                U))
                        [Meta.isDefEq] [0.017001] ❌️ op
                              ((Opens.map (colimit.ι (F ⋙ forget C) j)).obj
                                ((Opens.map
                                      (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                  U)) =?= (Opens.map
                                      (colimit.ι F j ≫
                                          (colimit.isoColimitCocone
                                              { cocone := colimitCocone F,
                                                isColimit := colimitCoconeIsColimit F }).hom).base).op.toPrefunctor.1
                              (op
                                ((Opens.map
                                      (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                  U))
                          [Meta.isDefEq] [0.016976] ❌️ op
                                ((Opens.map (colimit.ι (F ⋙ forget C) j)).obj
                                  ((Opens.map
                                        (colimit.isoColimitCocone
                                              { cocone := colimitCocone F,
                                                isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                    U)) =?= op
                                ((Opens.map
                                      (colimit.ι F j ≫
                                          (colimit.isoColimitCocone
                                              { cocone := colimitCocone F,
                                                isColimit := colimitCoconeIsColimit F }).hom).base).obj
                                  (unop
                                    (op
                                      ((Opens.map
                                            (colimit.isoColimitCocone
                                                  { cocone := colimitCocone F,
                                                    isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                        U))))
                            [Meta.isDefEq] [0.016946] ❌️ (Opens.map (colimit.ι (F ⋙ forget C) j)).obj
                                  ((Opens.map
                                        (colimit.isoColimitCocone
                                              { cocone := colimitCocone F,
                                                isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                    U) =?= (Opens.map
                                      (colimit.ι F j ≫
                                          (colimit.isoColimitCocone
                                              { cocone := colimitCocone F,
                                                isColimit := colimitCoconeIsColimit F }).hom).base).obj
                                  (unop
                                    (op
                                      ((Opens.map
                                            (colimit.isoColimitCocone
                                                  { cocone := colimitCocone F,
                                                    isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                        U)))
                              [Meta.isDefEq] [0.016936] ❌️ (Opens.map (colimit.ι (F ⋙ forget C) j)).toPrefunctor.1
                                    ((Opens.map
                                          (colimit.isoColimitCocone
                                                { cocone := colimitCocone F,
                                                  isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                      U) =?= (Opens.map
                                          (colimit.ι F j ≫
                                              (colimit.isoColimitCocone
                                                  { cocone := colimitCocone F,
                                                    isColimit := colimitCoconeIsColimit F }).hom).base).toPrefunctor.1
                                    (unop
                                      (op
                                        ((Opens.map
                                              (colimit.isoColimitCocone
                                                    { cocone := colimitCocone F,
                                                      isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                          U)))
                                [Meta.isDefEq] [0.016889] ❌️ {
                                      carrier :=
                                        ⇑(ConcreteCategory.hom (colimit.ι (F ⋙ forget C) j)) ⁻¹'
                                          ↑((Opens.map
                                                  (colimit.isoColimitCocone
                                                        { cocone := colimitCocone F,
                                                          isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                              U),
                                      is_open' :=
                                        ⋯ } =?= {
                                      carrier :=
                                        ⇑(ConcreteCategory.hom
                                              (colimit.ι F j ≫
                                                  (colimit.isoColimitCocone
                                                      { cocone := colimitCocone F,
                                                        isColimit := colimitCoconeIsColimit F }).hom).base) ⁻¹'
                                          ↑(unop
                                              (op
                                                ((Opens.map
                                                      (colimit.isoColimitCocone
                                                            { cocone := colimitCocone F,
                                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                                  U))),
                                      is_open' := ⋯ }
                                  [Meta.isDefEq] [0.016868] ❌️ ⇑(ConcreteCategory.hom (colimit.ι (F ⋙ forget C) j)) ⁻¹'
                                        ↑((Opens.map
                                                (colimit.isoColimitCocone
                                                      { cocone := colimitCocone F,
                                                        isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                            U) =?= ⇑(ConcreteCategory.hom
                                            (colimit.ι F j ≫
                                                (colimit.isoColimitCocone
                                                    { cocone := colimitCocone F,
                                                      isColimit := colimitCoconeIsColimit F }).hom).base) ⁻¹'
                                        ↑(unop
                                            (op
                                              ((Opens.map
                                                    (colimit.isoColimitCocone
                                                          { cocone := colimitCocone F,
                                                            isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                                U)))
                                    [Meta.isDefEq.delta] [0.013665] ❌️ ⇑(ConcreteCategory.hom
                                              (colimit.ι (F ⋙ forget C) j)) ⁻¹'
                                          ↑((Opens.map
                                                  (colimit.isoColimitCocone
                                                        { cocone := colimitCocone F,
                                                          isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                              U) =?= ⇑(ConcreteCategory.hom
                                              (colimit.ι F j ≫
                                                  (colimit.isoColimitCocone
                                                      { cocone := colimitCocone F,
                                                        isColimit := colimitCoconeIsColimit F }).hom).base) ⁻¹'
                                          ↑(unop
                                              (op
                                                ((Opens.map
                                                      (colimit.isoColimitCocone
                                                            { cocone := colimitCocone F,
                                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                                  U)))
                                      [Meta.isDefEq] [0.013661] ❌️ ⇑(ConcreteCategory.hom
                                              (colimit.ι (F ⋙ forget C)
                                                j)) =?= ⇑(ConcreteCategory.hom
                                              (colimit.ι F j ≫
                                                  (colimit.isoColimitCocone
                                                      { cocone := colimitCocone F,
                                                        isColimit := colimitCoconeIsColimit F }).hom).base)
                                        [Meta.isDefEq] [0.013651] ❌️ ((fun X Y ↦ ContinuousMap.instFunLike) (↑(F.obj j))
                                                  (Limits.colimit (F ⋙ forget C))).1
                                              (ConcreteCategory.hom
                                                (colimit.ι (F ⋙ forget C)
                                                  j)) =?= ((fun X Y ↦ ContinuousMap.instFunLike) ↑(F.obj j)
                                                  ↑{ cocone := colimitCocone F,
                                                          isColimit := colimitCoconeIsColimit F }.cocone.pt).1
                                              (ConcreteCategory.hom
                                                (colimit.ι F j ≫
                                                    (colimit.isoColimitCocone
                                                        { cocone := colimitCocone F,
                                                          isColimit := colimitCoconeIsColimit F }).hom).base)
                                          [Meta.isDefEq] [0.013633] ❌️ (ConcreteCategory.hom
                                                  (colimit.ι (F ⋙ forget C)
                                                    j)).toFun =?= (ConcreteCategory.hom
                                                  (colimit.ι F j ≫
                                                      (colimit.isoColimitCocone
                                                          { cocone := colimitCocone F,
                                                            isColimit := colimitCoconeIsColimit F }).hom).base).toFun
                                            [Meta.isDefEq] [0.013622] ❌️ (ConcreteCategory.hom
                                                    (colimit.ι (F ⋙ forget C)
                                                      j)).1 =?= (ConcreteCategory.hom
                                                    (colimit.ι F j ≫
                                                        (colimit.isoColimitCocone
                                                            { cocone := colimitCocone F,
                                                              isColimit := colimitCoconeIsColimit F }).hom).base).1
          [Meta.isDefEq] [0.021315] ❌️ eqToHom ?p =?= eqToHom ⋯
            [Meta.isDefEq] [0.021164] ❌️ ?p =?= colimit.isoColimitCocone_ι_hom
                    { cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F } j ▸
                  Eq.refl
                    ((Opens.map
                            (colimit.ι F j ≫
                                (colimit.isoColimitCocone
                                    { cocone := colimitCocone F,
                                      isColimit := colimitCoconeIsColimit F }).hom).base).op.obj
                      (op
                        ((Opens.map
                              (colimit.isoColimitCocone
                                    { cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F }).inv.base).obj
                          U)))
          [Meta.isDefEq] [0.010396] ✅️ (toPrefunctor ?F).map (eqToHom ?p) =?= (F.obj j).presheaf.map (eqToHom ⋯)
            [Meta.isDefEq.delta] [0.010372] ✅️ (toPrefunctor ?F).map (eqToHom ?p) =?= (F.obj j).presheaf.map (eqToHom ⋯)
              [Meta.isDefEq] [0.010074] ✅️ eqToHom ?p =?= eqToHom ⋯
                [Meta.isDefEq] [0.010047] ✅️ ?p =?= colimit.isoColimitCocone_ι_hom
                        { cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F } j ▸
                      Eq.refl
                        ((Opens.map
                                (colimit.ι F j ≫
                                    (colimit.isoColimitCocone
                                        { cocone := colimitCocone F,
                                          isColimit := colimitCoconeIsColimit F }).hom).base).op.obj
                          (op
                            ((Opens.map
                                  (colimit.isoColimitCocone
                                        { cocone := colimitCocone F,
                                          isColimit := colimitCoconeIsColimit F }).inv.base).obj
                              U)))
                  [Meta.isDefEq.assign] [0.010045] ✅️ ?p := colimit.isoColimitCocone_ι_hom
                          { cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F } j ▸
                        Eq.refl
                          ((Opens.map
                                  (colimit.ι F j ≫
                                      (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).hom).base).op.obj
                            (op
                              ((Opens.map
                                    (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                U)))
                    [Meta.isDefEq.assign.checkTypes] [0.010004] ✅️ (?p : op
                            ((Opens.map (colimit.ι (F ⋙ forget C) j)).obj
                              ((Opens.map
                                    (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                U)) =
                          op
                            ((Opens.map (colimit.ι F j).base).obj
                              ((Opens.map
                                    (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).hom.base).obj
                                ((Opens.map
                                      (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                  U)))) := (colimit.isoColimitCocone_ι_hom
                            { cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F } j ▸
                          Eq.refl
                            ((Opens.map
                                    (colimit.ι F j ≫
                                        (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).hom).base).op.obj
                              (op
                                ((Opens.map
                                      (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                  U))) : (Opens.map
                                  ({ cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F }.cocone.ι.app
                                      j).base).op.obj
                            (op
                              ((Opens.map
                                    (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                U)) =
                          (Opens.map
                                  (colimit.ι F j ≫
                                      (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).hom).base).op.obj
                            (op
                              ((Opens.map
                                    (colimit.isoColimitCocone
                                          { cocone := colimitCocone F,
                                            isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                U)))
                      [Meta.isDefEq] [0.010000] ✅️ op
                              ((Opens.map (colimit.ι (F ⋙ forget C) j)).obj
                                ((Opens.map
                                      (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                  U)) =
                            op
                              ((Opens.map (colimit.ι F j).base).obj
                                ((Opens.map
                                      (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).hom.base).obj
                                  ((Opens.map
                                        (colimit.isoColimitCocone
                                              { cocone := colimitCocone F,
                                                isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                    U))) =?= (Opens.map
                                    ({ cocone := colimitCocone F, isColimit := colimitCoconeIsColimit F }.cocone.ι.app
                                        j).base).op.obj
                              (op
                                ((Opens.map
                                      (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                  U)) =
                            (Opens.map
                                    (colimit.ι F j ≫
                                        (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).hom).base).op.obj
                              (op
                                ((Opens.map
                                      (colimit.isoColimitCocone
                                            { cocone := colimitCocone F,
                                              isColimit := colimitCoconeIsColimit F }).inv.base).obj
                                  U))
info: Mathlib/Geometry/RingedSpace/PresheafedSpace/HasColimits.lean:319:8: [Elab.async] [0.056169] Lean.addDecl
  [Kernel] [0.056142] typechecking declarations [AlgebraicGeometry.PresheafedSpace.colimitPresheafObjIsoComponentwiseLimit_inv_ι_app]
```
</details>
