### PR TITLE
[Merged by Bors] - chore(MeasureTheory/VectorMeasure): golf entire `le_restrict_univ_iff_le` using `simp`

### DIFF
--- a/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
@@ -782,15 +782,7 @@ theorem le_restrict_empty : v ≤[∅] w := by
   rw [restrict_empty, restrict_empty]
 
 theorem le_restrict_univ_iff_le : v ≤[Set.univ] w ↔ v ≤ w := by
-  constructor
-  · intro h s hs
-    have := h s hs
-    rwa [restrict_apply _ MeasurableSet.univ hs, Set.inter_univ,
-      restrict_apply _ MeasurableSet.univ hs, Set.inter_univ] at this
-  · intro h s hs
-    rw [restrict_apply _ MeasurableSet.univ hs, Set.inter_univ,
-      restrict_apply _ MeasurableSet.univ hs, Set.inter_univ]
-    exact h s hs
+  simp
 
 end
 


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>le_restrict_univ_iff_le</code></summary>

### Trace profiling of `le_restrict_univ_iff_le` before PR 27927
```diff
diff --git a/Mathlib/MeasureTheory/VectorMeasure/Basic.lean b/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
index ea1f771db5..ed29352f7e 100644
--- a/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
@@ -783,2 +783,3 @@ theorem le_restrict_empty : v ≤[∅] w := by
 
+set_option trace.profiler true in
 theorem le_restrict_univ_iff_le : v ≤[Set.univ] w ↔ v ≤ w := by
```
```
ℹ [1571/1571] Built Mathlib.MeasureTheory.VectorMeasure.Basic
info: Mathlib/MeasureTheory/VectorMeasure/Basic.lean:785:0: [Elab.async] [0.013973] elaborating proof of MeasureTheory.VectorMeasure.le_restrict_univ_iff_le
  [Elab.definition.value] [0.013158] MeasureTheory.VectorMeasure.le_restrict_univ_iff_le
    [Elab.step] [0.012720] 
          constructor
          · intro h s hs
            have := h s hs
            rwa [restrict_apply _ MeasurableSet.univ hs, Set.inter_univ, restrict_apply _ MeasurableSet.univ hs,
              Set.inter_univ] at this
          · intro h s hs
            rw [restrict_apply _ MeasurableSet.univ hs, Set.inter_univ, restrict_apply _ MeasurableSet.univ hs,
              Set.inter_univ]
            exact h s hs
      [Elab.step] [0.012710] 
            constructor
            · intro h s hs
              have := h s hs
              rwa [restrict_apply _ MeasurableSet.univ hs, Set.inter_univ, restrict_apply _ MeasurableSet.univ hs,
                Set.inter_univ] at this
            · intro h s hs
              rw [restrict_apply _ MeasurableSet.univ hs, Set.inter_univ, restrict_apply _ MeasurableSet.univ hs,
                Set.inter_univ]
              exact h s hs
Build completed successfully.
```

### Trace profiling of `le_restrict_univ_iff_le` after PR 27927
```diff
diff --git a/Mathlib/MeasureTheory/VectorMeasure/Basic.lean b/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
index ea1f771db5..d30684ef46 100644
--- a/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
@@ -783,12 +783,5 @@ theorem le_restrict_empty : v ≤[∅] w := by
 
+set_option trace.profiler true in
 theorem le_restrict_univ_iff_le : v ≤[Set.univ] w ↔ v ≤ w := by
-  constructor
-  · intro h s hs
-    have := h s hs
-    rwa [restrict_apply _ MeasurableSet.univ hs, Set.inter_univ,
-      restrict_apply _ MeasurableSet.univ hs, Set.inter_univ] at this
-  · intro h s hs
-    rw [restrict_apply _ MeasurableSet.univ hs, Set.inter_univ,
-      restrict_apply _ MeasurableSet.univ hs, Set.inter_univ]
-    exact h s hs
+  simp
 
```
```
✔ [1571/1571] Built Mathlib.MeasureTheory.VectorMeasure.Basic
Build completed successfully.
```
</details>
