### PR TITLE
[Merged by Bors] - chore(ModelTheory/Semantics): golf entire `realize_all_liftAt_one_self` using `simp`

### DIFF
--- a/Mathlib/ModelTheory/Semantics.lean
+++ b/Mathlib/ModelTheory/Semantics.lean
@@ -481,13 +481,7 @@ variable [Nonempty M]
 
 theorem realize_all_liftAt_one_self {n : ℕ} {φ : L.BoundedFormula α n} {v : α → M}
     {xs : Fin n → M} : (φ.liftAt 1 n).all.Realize v xs ↔ φ.Realize v xs := by
-  inhabit M
-  simp only [realize_all, realize_liftAt_one_self]
-  refine ⟨fun h => ?_, fun h a => ?_⟩
-  · refine (congr rfl (funext fun i => ?_)).mp (h default)
-    simp
-  · refine (congr rfl (funext fun i => ?_)).mp h
-    simp
+  simp
 
 end BoundedFormula
 


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>realize_all_liftAt_one_self</code></summary>

### Trace profiling of `realize_all_liftAt_one_self` before PR 27928
```diff
diff --git a/Mathlib/ModelTheory/Semantics.lean b/Mathlib/ModelTheory/Semantics.lean
index 06e8fbd227..fcd443601a 100644
--- a/Mathlib/ModelTheory/Semantics.lean
+++ b/Mathlib/ModelTheory/Semantics.lean
@@ -481,2 +481,3 @@ variable [Nonempty M]
 
+set_option trace.profiler true in
 theorem realize_all_liftAt_one_self {n : ℕ} {φ : L.BoundedFormula α n} {v : α → M}
```
```
ℹ [828/828] Built Mathlib.ModelTheory.Semantics
info: Mathlib/ModelTheory/Semantics.lean:483:0: [Elab.async] [0.019664] elaborating proof of FirstOrder.Language.BoundedFormula.realize_all_liftAt_one_self
  [Elab.definition.value] [0.018253] FirstOrder.Language.BoundedFormula.realize_all_liftAt_one_self
    [Elab.step] [0.017467] 
          inhabit M
          simp only [realize_all, realize_liftAt_one_self]
          refine ⟨fun h => ?_, fun h a => ?_⟩
          · refine (congr rfl (funext fun i => ?_)).mp (h default)
            simp
          · refine (congr rfl (funext fun i => ?_)).mp h
            simp
      [Elab.step] [0.017447] 
            inhabit M
            simp only [realize_all, realize_liftAt_one_self]
            refine ⟨fun h => ?_, fun h a => ?_⟩
            · refine (congr rfl (funext fun i => ?_)).mp (h default)
              simp
            · refine (congr rfl (funext fun i => ?_)).mp h
              simp
Build completed successfully.
```

### Trace profiling of `realize_all_liftAt_one_self` after PR 27928
```diff
diff --git a/Mathlib/ModelTheory/Semantics.lean b/Mathlib/ModelTheory/Semantics.lean
index 06e8fbd227..73e78a4b00 100644
--- a/Mathlib/ModelTheory/Semantics.lean
+++ b/Mathlib/ModelTheory/Semantics.lean
@@ -481,11 +481,6 @@ variable [Nonempty M]
 
+set_option trace.profiler true in
 theorem realize_all_liftAt_one_self {n : ℕ} {φ : L.BoundedFormula α n} {v : α → M}
     {xs : Fin n → M} : (φ.liftAt 1 n).all.Realize v xs ↔ φ.Realize v xs := by
-  inhabit M
-  simp only [realize_all, realize_liftAt_one_self]
-  refine ⟨fun h => ?_, fun h a => ?_⟩
-  · refine (congr rfl (funext fun i => ?_)).mp (h default)
-    simp
-  · refine (congr rfl (funext fun i => ?_)).mp h
-    simp
+  simp
 
```
```
✔ [828/828] Built Mathlib.ModelTheory.Semantics
Build completed successfully.
```
</details>
