### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Adjunction): golf entire `conjugateEquiv_counit` using `simp`

### DIFF
--- a/Mathlib/CategoryTheory/Adjunction/Mates.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Mates.lean
@@ -275,12 +275,7 @@ def conjugateEquiv : (L₂ ⟶ L₁) ≃ (R₁ ⟶ R₂) :=
 theorem conjugateEquiv_counit (α : L₂ ⟶ L₁) (d : D) :
     L₂.map ((conjugateEquiv adj₁ adj₂ α).app _) ≫ adj₂.counit.app d =
       α.app _ ≫ adj₁.counit.app d := by
-  dsimp [conjugateEquiv]
-  rw [id_comp, comp_id]
-  have := mateEquiv_counit adj₁ adj₂ (L₂.leftUnitor.hom ≫ α ≫ L₁.rightUnitor.inv) d
-  dsimp at this
-  rw [this]
-  simp only [comp_id, id_comp]
+  simp
 
 /-- A component of a transposed form of the inverse conjugation definition. -/
 theorem conjugateEquiv_counit_symm (α : R₁ ⟶ R₂) (d : D) :


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>le_restrict_univ_iff_le</code></summary>

### Trace profiling of `le_restrict_univ_iff_le` before PR 27927
```diff
diff --git a/Mathlib/MeasureTheory/VectorMeasure/Basic.lean b/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
index ea1f771db5..ed29352f7e 100644
--- a/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
@@ -783,2 +783,3 @@ theorem le_restrict_empty : v ≤[∅] w := by
 
+set_option trace.profiler true in
 theorem le_restrict_univ_iff_le : v ≤[Set.univ] w ↔ v ≤ w := by
```
```
ℹ [1571/1571] Built Mathlib.MeasureTheory.VectorMeasure.Basic
info: Mathlib/MeasureTheory/VectorMeasure/Basic.lean:785:0: [Elab.async] [0.011869] elaborating proof of MeasureTheory.VectorMeasure.le_restrict_univ_iff_le
  [Elab.definition.value] [0.011258] MeasureTheory.VectorMeasure.le_restrict_univ_iff_le
    [Elab.step] [0.010766] 
          constructor
          · intro h s hs
            have := h s hs
            rwa [restrict_apply _ MeasurableSet.univ hs, Set.inter_univ, restrict_apply _ MeasurableSet.univ hs,
              Set.inter_univ] at this
          · intro h s hs
            rw [restrict_apply _ MeasurableSet.univ hs, Set.inter_univ, restrict_apply _ MeasurableSet.univ hs,
              Set.inter_univ]
            exact h s hs
      [Elab.step] [0.010754] 
            constructor
            · intro h s hs
              have := h s hs
              rwa [restrict_apply _ MeasurableSet.univ hs, Set.inter_univ, restrict_apply _ MeasurableSet.univ hs,
                Set.inter_univ] at this
            · intro h s hs
              rw [restrict_apply _ MeasurableSet.univ hs, Set.inter_univ, restrict_apply _ MeasurableSet.univ hs,
                Set.inter_univ]
              exact h s hs
Build completed successfully.
```

### Trace profiling of `le_restrict_univ_iff_le` after PR 27927
```diff
diff --git a/Mathlib/MeasureTheory/VectorMeasure/Basic.lean b/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
index ea1f771db5..d30684ef46 100644
--- a/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Basic.lean
@@ -783,12 +783,5 @@ theorem le_restrict_empty : v ≤[∅] w := by
 
+set_option trace.profiler true in
 theorem le_restrict_univ_iff_le : v ≤[Set.univ] w ↔ v ≤ w := by
-  constructor
-  · intro h s hs
-    have := h s hs
-    rwa [restrict_apply _ MeasurableSet.univ hs, Set.inter_univ,
-      restrict_apply _ MeasurableSet.univ hs, Set.inter_univ] at this
-  · intro h s hs
-    rw [restrict_apply _ MeasurableSet.univ hs, Set.inter_univ,
-      restrict_apply _ MeasurableSet.univ hs, Set.inter_univ]
-    exact h s hs
+  simp
 
```
```
✔ [1571/1571] Built Mathlib.MeasureTheory.VectorMeasure.Basic
Build completed successfully.
```
</details>
