### PR TITLE
[Merged by Bors] - feat: replace aesop_cat with a configurable discharger

### DIFF
--- a/Mathlib/Algebra/Category/Grp/Basic.lean
+++ b/Mathlib/Algebra/Category/Grp/Basic.lean
@@ -501,7 +501,7 @@ theorem int_hom_ext {G : AddCommGrp.{0}} (f g : AddCommGrp.of ℤ ⟶ G)
 -- the forgetful functor is representable.
 theorem injective_of_mono {G H : AddCommGrp.{0}} (f : G ⟶ H) [Mono f] : Function.Injective f :=
   fun g₁ g₂ h => by
-  have t0 : asHom g₁ ≫ f = asHom g₂ ≫ f := by aesop_cat
+  have t0 : asHom g₁ ≫ f = asHom g₂ ≫ f := by cat_disch
   have t1 : asHom g₁ = asHom g₂ := (cancel_mono _).1 t0
   apply asHom_injective t1
 
@@ -651,4 +651,3 @@ theorem MonoidHom.comp_id_commGrp {G : CommGrp.{u}} {H : Type u} [Monoid H] (f :
 theorem MonoidHom.id_commGrp_comp {G : Type u} [Monoid G] {H : CommGrp.{u}} (f : G →* H) :
     MonoidHom.comp (CommGrp.Hom.hom (𝟙 H)) f = f := by
   simp
-

--- a/Mathlib/Algebra/Category/Grp/Biproducts.lean
+++ b/Mathlib/Algebra/Category/Grp/Biproducts.lean
@@ -38,7 +38,7 @@ instance : HasFiniteBiproducts AddCommGrp :=
 def binaryProductLimitCone (G H : AddCommGrp.{u}) : Limits.LimitCone (pair G H) where
   cone := BinaryFan.mk (ofHom (AddMonoidHom.fst G H)) (ofHom (AddMonoidHom.snd G H))
   isLimit := BinaryFan.IsLimit.mk _ (fun l r => ofHom (AddMonoidHom.prod l.hom r.hom))
-    (fun _ _ => rfl) (fun _ _ => rfl) (by aesop_cat)
+    (fun _ _ => rfl) (fun _ _ => rfl) (by cat_disch)
 
 @[simp]
 theorem binaryProductLimitCone_cone_π_app_left (G H : AddCommGrp.{u}) :

--- a/Mathlib/Algebra/Category/Grp/CartesianMonoidal.lean
+++ b/Mathlib/Algebra/Category/Grp/CartesianMonoidal.lean
@@ -23,7 +23,7 @@ namespace Grp
 def binaryProductLimitCone (G H : Grp.{u}) : LimitCone (pair G H) where
   cone := BinaryFan.mk (ofHom (MonoidHom.fst G H)) (ofHom (MonoidHom.snd G H))
   isLimit := BinaryFan.IsLimit.mk _ (fun l r => ofHom (MonoidHom.prod l.hom r.hom))
-    (fun _ _ => rfl) (fun _ _ => rfl) (by aesop_cat)
+    (fun _ _ => rfl) (fun _ _ => rfl) (by cat_disch)
 
 /-- We choose `Grp.of (G × H)` as the product of `G` and `H` and `Grp.of PUnit` as
 the terminal object. -/
@@ -53,7 +53,7 @@ namespace AddGrp
 def binaryProductLimitCone (G H : AddGrp.{u}) : LimitCone (pair G H) where
   cone := BinaryFan.mk (ofHom (AddMonoidHom.fst G H)) (ofHom (AddMonoidHom.snd G H))
   isLimit := BinaryFan.IsLimit.mk _ (fun l r => ofHom (AddMonoidHom.prod l.hom r.hom))
-    (fun _ _ => rfl) (fun _ _ => rfl) (by aesop_cat)
+    (fun _ _ => rfl) (fun _ _ => rfl) (by cat_disch)
 
 /-- We choose `AddGrp.of (G × H)` as the product of `G` and `H` and `AddGrp.of PUnit` as
 the terminal object. -/
@@ -83,7 +83,7 @@ namespace CommGrp
 def binaryProductLimitCone (G H : CommGrp.{u}) : LimitCone (pair G H) where
   cone := BinaryFan.mk (ofHom (MonoidHom.fst G H)) (ofHom (MonoidHom.snd G H))
   isLimit := BinaryFan.IsLimit.mk _ (fun l r => ofHom (MonoidHom.prod l.hom r.hom))
-    (fun _ _ => rfl) (fun _ _ => rfl) (by aesop_cat)
+    (fun _ _ => rfl) (fun _ _ => rfl) (by cat_disch)
 
 /-- We choose `CommGrp.of (G × H)` as the product of `G` and `H` and `CommGrp.of PUnit` as
 the terminal object. -/

--- a/Mathlib/Algebra/Category/Grp/EpiMono.lean
+++ b/Mathlib/Algebra/Category/Grp/EpiMono.lean
@@ -34,7 +34,7 @@ variable [Group A] [Group B]
 
 @[to_additive]
 theorem ker_eq_bot_of_cancel {f : A →* B} (h : ∀ u v : f.ker →* A, f.comp u = f.comp v → u = v) :
-    f.ker = ⊥ := by simpa using congr_arg range (h f.ker.subtype 1 (by aesop_cat))
+    f.ker = ⊥ := by simpa using congr_arg range (h f.ker.subtype 1 (by cat_disch))
 
 end
 

--- a/Mathlib/Algebra/Category/Grp/LeftExactFunctor.lean
+++ b/Mathlib/Algebra/Category/Grp/LeftExactFunctor.lean
@@ -77,7 +77,7 @@ noncomputable def unitIsoAux (F : C ⥤ AddCommGrp.{v}) [PreservesFiniteLimits F
   letI : F.Monoidal := .ofChosenFiniteProducts _
   refine CommGrp_.mkIso Multiplicative.toAdd.toIso (by
     erw [Functor.mapCommGrp_obj_grp_one]
-    aesop_cat) ?_
+    cat_disch) ?_
   dsimp [-Functor.comp_map, -ConcreteCategory.forget_map_eq_coe, -forget_map]
   have : F.Additive := Functor.additive_of_preserves_binary_products _
   simp only [Category.id_comp]
@@ -85,7 +85,7 @@ noncomputable def unitIsoAux (F : C ⥤ AddCommGrp.{v}) [PreservesFiniteLimits F
   erw [Functor.comp_map, F.map_add, Functor.Monoidal.μ_comp F (forget AddCommGrp) X X,
     Category.assoc, ← Functor.map_comp, Preadditive.comp_add, Functor.Monoidal.μ_fst,
     Functor.Monoidal.μ_snd]
-  aesop_cat
+  cat_disch
 
 /-- Implementation, see `leftExactFunctorForgetEquivalence`. -/
 noncomputable def unitIso : 𝟭 (C ⥤ₗ AddCommGrp) ≅

--- a/Mathlib/Algebra/Category/ModuleCat/Basic.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Basic.lean
@@ -491,10 +491,10 @@ def smulNatTrans : R →+* End (forget₂ (ModuleCat R) AddCommGrp) where
   toFun r :=
     { app := fun M => M.smul r
       naturality := fun _ _ _ => smul_naturality _ r }
-  map_one' := NatTrans.ext (by aesop_cat)
-  map_zero' := NatTrans.ext (by aesop_cat)
-  map_mul' _ _ := NatTrans.ext (by aesop_cat)
-  map_add' _ _ := NatTrans.ext (by aesop_cat)
+  map_one' := NatTrans.ext (by cat_disch)
+  map_zero' := NatTrans.ext (by cat_disch)
+  map_mul' _ _ := NatTrans.ext (by cat_disch)
+  map_add' _ _ := NatTrans.ext (by cat_disch)
 
 /-- Given `A : AddCommGrp` and a ring morphism `R →+* End A`, this is a type synonym
 for `A`, on which we shall define a structure of `R`-module. -/

--- a/Mathlib/Algebra/Category/ModuleCat/Differentials/Presheaf.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Differentials/Presheaf.lean
@@ -53,10 +53,10 @@ this is the type of relative `φ`-derivation of a presheaf of `R`-modules `M`. -
 structure Derivation where
   /-- the underlying additive map `R.obj X →+ M.obj X` of a derivation -/
   d {X : Dᵒᵖ} : R.obj X →+ M.obj X
-  d_mul {X : Dᵒᵖ} (a b : R.obj X) : d (a * b) = a • d b + b • d a := by aesop_cat
+  d_mul {X : Dᵒᵖ} (a b : R.obj X) : d (a * b) = a • d b + b • d a := by cat_disch
   d_map {X Y : Dᵒᵖ} (f : X ⟶ Y) (x : R.obj X) :
-    d (R.map f x) = M.map f (d x) := by aesop_cat
-  d_app {X : Cᵒᵖ} (a : S.obj X) : d (φ.app X a) = 0 := by aesop_cat
+    d (R.map f x) = M.map f (d x) := by cat_disch
+  d_app {X : Cᵒᵖ} (a : S.obj X) : d (φ.app X a) = 0 := by cat_disch
 
 namespace Derivation
 
@@ -92,9 +92,9 @@ structure Universal where
   desc {M' : PresheafOfModules (R ⋙ forget₂ CommRingCat RingCat)}
     (d' : M'.Derivation φ) : M ⟶ M'
   fac {M' : PresheafOfModules (R ⋙ forget₂ CommRingCat RingCat)}
-    (d' : M'.Derivation φ) : d.postcomp (desc d') = d' := by aesop_cat
+    (d' : M'.Derivation φ) : d.postcomp (desc d') = d' := by cat_disch
   postcomp_injective {M' : PresheafOfModules (R ⋙ forget₂ CommRingCat RingCat)}
-    (φ φ' : M ⟶ M') (h : d.postcomp φ = d.postcomp φ') : φ = φ' := by aesop_cat
+    (φ φ' : M ⟶ M') (h : d.postcomp φ = d.postcomp φ') : φ = φ' := by cat_disch
 
 attribute [simp] Universal.fac
 

--- a/Mathlib/Algebra/Category/ModuleCat/Monoidal/Symmetric.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Monoidal/Symmetric.lean
@@ -77,7 +77,7 @@ instance symmetricCategory : SymmetricCategory (ModuleCat.{u} R) where
   symmetry _ _ := by
     ext : 1
     apply TensorProduct.ext'
-    aesop_cat
+    cat_disch
 
 @[simp]
 theorem braiding_hom_apply {M N : ModuleCat.{u} R} (m : M) (n : N) :

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf.lean
@@ -48,7 +48,7 @@ structure PresheafOfModules where
   map_comp {X Y Z : Cᵒᵖ} (f : X ⟶ Y) (g : Y ⟶ Z) :
     map (f ≫ g) = map f ≫ (ModuleCat.restrictScalars _).map (map g) ≫
       (ModuleCat.restrictScalarsComp' (R.map f).hom (R.map g).hom (R.map (f ≫ g)).hom
-        (congrArg RingCat.Hom.hom <| R.map_comp f g)).inv.app _ := by aesop_cat
+        (congrArg RingCat.Hom.hom <| R.map_comp f g)).inv.app _ := by cat_disch
 
 namespace PresheafOfModules
 
@@ -71,7 +71,7 @@ structure Hom where
   app (X : Cᵒᵖ) : M₁.obj X ⟶ M₂.obj X
   naturality {X Y : Cᵒᵖ} (f : X ⟶ Y) :
       M₁.map f ≫ (ModuleCat.restrictScalars (R.map f).hom).map (app Y) =
-        app X ≫ M₂.map f := by aesop_cat
+        app X ≫ M₂.map f := by cat_disch
 
 attribute [reassoc (attr := simp)] Hom.naturality
 
@@ -104,7 +104,7 @@ lemma naturality_apply (f : M₁ ⟶ M₂) {X Y : Cᵒᵖ} (g : X ⟶ Y) (x : M�
 def isoMk (app : ∀ (X : Cᵒᵖ), M₁.obj X ≅ M₂.obj X)
     (naturality : ∀ ⦃X Y : Cᵒᵖ⦄ (f : X ⟶ Y),
       M₁.map f ≫ (ModuleCat.restrictScalars (R.map f).hom).map (app Y).hom =
-        (app X).hom ≫ M₂.map f := by aesop_cat) : M₁ ≅ M₂ where
+        (app X).hom ≫ M₂.map f := by cat_disch) : M₁ ≅ M₂ where
   hom := { app := fun X ↦ (app X).hom }
   inv :=
     { app := fun X ↦ (app X).inv
@@ -270,7 +270,7 @@ noncomputable def unit : PresheafOfModules R where
       (Y := (ModuleCat.restrictScalars (R.map f).hom).obj (ModuleCat.of (R.obj Y) (R.obj Y)))
     { toFun := fun x ↦ R.map f x
       map_add' := by simp
-      map_smul' := by aesop_cat }
+      map_smul' := by cat_disch }
 
 lemma unit_map_one {X Y : Cᵒᵖ} (f : X ⟶ Y) : (unit R).map f (1 : R.obj X) = (1 : R.obj Y) :=
   (R.map f).hom.map_one

--- a/Mathlib/Algebra/Category/ModuleCat/Presheaf.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Presheaf.lean
@@ -44,7 +44,7 @@ structure PresheafOfModules where
   map_id (X : Cᵒᵖ) :
     map (𝟙 X) = (ModuleCat.restrictScalarsId' (R.map (𝟙 X)).hom
       (congrArg RingCat.Hom.hom (R.map_id X))).inv.app _ := by
-        aesop_cat
+        cat_disch
   map_comp {X Y Z : Cᵒᵖ} (f : X ⟶ Y) (g : Y ⟶ Z) :
     map (f ≫ g) = map f ≫ (ModuleCat.restrictScalars _).map (map g) ≫
       (ModuleCat.restrictScalarsComp' (R.map f).hom (R.map g).hom (R.map (f ≫ g)).hom

--- a/Mathlib/Algebra/Category/ModuleCat/Topology/Basic.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Topology/Basic.lean
@@ -116,8 +116,8 @@ def _root_.CategoryTheory.Iso.toContinuousLinearEquiv
     {X Y : TopModuleCat R} (e : X ≅ Y) : X ≃L[R] Y where
   __ := e.hom.hom
   invFun := e.inv.hom
-  left_inv x := by aesop_cat
-  right_inv x := by aesop_cat
+  left_inv x := by cat_disch
+  right_inv x := by cat_disch
 
 instance {X Y : TopModuleCat R} : AddCommGroup (X ⟶ Y) where
   add f g := ofHom (f.hom + g.hom)

--- a/Mathlib/Algebra/Homology/Additive.lean
+++ b/Mathlib/Algebra/Homology/Additive.lean
@@ -76,7 +76,7 @@ theorem zsmul_f_apply (n : ℤ) (f : C ⟶ D) (i : ι) : (n • f).f i = n • f
 
 instance : AddCommGroup (C ⟶ D) :=
   Function.Injective.addCommGroup Hom.f HomologicalComplex.hom_f_injective
-    (by aesop_cat) (by aesop_cat) (by aesop_cat) (by aesop_cat) (by aesop_cat) (by aesop_cat)
+    (by cat_disch) (by cat_disch) (by cat_disch) (by cat_disch) (by cat_disch) (by cat_disch)
 
 -- Porting note: proofs had to be provided here, otherwise Lean tries to apply
 -- `Preadditive.add_comp/comp_add` to `HomologicalComplex V c`
@@ -159,7 +159,7 @@ def NatTrans.mapHomologicalComplex {F G : W₁ ⥤ W₂}
 @[simp]
 theorem NatTrans.mapHomologicalComplex_id
     (c : ComplexShape ι) (F : W₁ ⥤ W₂) [F.PreservesZeroMorphisms] :
-    NatTrans.mapHomologicalComplex (𝟙 F) c = 𝟙 (F.mapHomologicalComplex c) := by aesop_cat
+    NatTrans.mapHomologicalComplex (𝟙 F) c = 𝟙 (F.mapHomologicalComplex c) := by cat_disch
 
 @[simp]
 theorem NatTrans.mapHomologicalComplex_comp (c : ComplexShape ι) {F G H : W₁ ⥤ W₂}

--- a/Mathlib/Algebra/Homology/Additive.lean
+++ b/Mathlib/Algebra/Homology/Additive.lean
@@ -167,7 +167,7 @@ theorem NatTrans.mapHomologicalComplex_comp (c : ComplexShape ι) {F G H : W₁ 
     (α : F ⟶ G) (β : G ⟶ H) :
     NatTrans.mapHomologicalComplex (α ≫ β) c =
       NatTrans.mapHomologicalComplex α c ≫ NatTrans.mapHomologicalComplex β c := by
-  aesop_cat
+  cat_disch
 
 @[reassoc]
 theorem NatTrans.mapHomologicalComplex_naturality {c : ComplexShape ι} {F G : W₁ ⥤ W₂}

--- a/Mathlib/Algebra/Homology/CommSq.lean
+++ b/Mathlib/Algebra/Homology/CommSq.lean
@@ -60,7 +60,7 @@ noncomputable def CommSq.isColimitEquivIsColimitCokernelCofork (sq : CommSq f g 
       (fun s ↦ PushoutCocone.IsColimit.desc h
         (biprod.inl ≫ s.π) (biprod.inr ≫ s.π) (by
           rw [← sub_eq_zero, ← assoc, ← assoc, ← Preadditive.sub_comp]
-          convert s.condition <;> aesop_cat))
+          convert s.condition <;> cat_disch))
       (fun s ↦ by
         dsimp
         ext
@@ -96,7 +96,7 @@ noncomputable def CommSq.isColimitEquivIsColimitCokernelCofork (sq : CommSq f g 
         apply Cofork.IsColimit.hom_ext h
         convert (h.fac (CokernelCofork.ofπ (biprod.desc s.inl s.inr)
           (by simp [s.condition])) .one).symm
-        aesop_cat)
+        cat_disch)
   left_inv _ := Subsingleton.elim _ _
   right_inv _ := Subsingleton.elim _ _
 
@@ -139,7 +139,7 @@ noncomputable def CommSq.isLimitEquivIsLimitKernelFork (sq : CommSq fst snd f g)
       (fun s ↦ PullbackCone.IsLimit.lift h
         (s.ι ≫ biprod.fst) (s.ι ≫ biprod.snd) (by
           rw [← sub_eq_zero, assoc, assoc, ← Preadditive.comp_sub]
-          convert s.condition <;> aesop_cat))
+          convert s.condition <;> cat_disch))
       (fun s ↦ by
         dsimp
         ext
@@ -173,7 +173,7 @@ noncomputable def CommSq.isLimitEquivIsLimitKernelFork (sq : CommSq fst snd f g)
         apply Fork.IsLimit.hom_ext h
         convert (h.fac (KernelFork.ofι (biprod.lift s.fst s.snd)
           (by simp [s.condition])) .zero).symm
-        aesop_cat)
+        cat_disch)
   left_inv _ := Subsingleton.elim _ _
   right_inv _ := Subsingleton.elim _ _
 

--- a/Mathlib/Algebra/Homology/DerivedCategory/SingleTriangle.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/SingleTriangle.lean
@@ -62,8 +62,8 @@ noncomputable def singleTriangleIso :
       triangleOfSES (hS.map_of_exact (HomologicalComplex.single C (ComplexShape.up ℤ) 0)) := by
   let e := (SingleFunctors.evaluation _ _ 0).mapIso (singleFunctorsPostcompQIso C)
   refine Triangle.isoMk _ _ (e.app S.X₁) (e.app S.X₂) (e.app S.X₃) ?_ ?_ ?_
-  · aesop_cat
-  · aesop_cat
+  · cat_disch
+  · cat_disch
   · dsimp [singleδ, e]
     rw [Category.assoc, Category.assoc, ← Functor.map_comp, SingleFunctors.inv_hom_id_hom_app]
     erw [Functor.map_id]

--- a/Mathlib/Algebra/Homology/Double.lean
+++ b/Mathlib/Algebra/Homology/Double.lean
@@ -177,7 +177,7 @@ noncomputable def evalCompCoyonedaCorepresentableBySingle (i : ι) [DecidableEq 
   homEquiv {K} :=
     { toFun g := (singleObjXSelf c i X).inv ≫ g.f i
       invFun f := mkHomFromSingle f (fun j hj ↦ (hi j hj).elim)
-      left_inv g := by aesop_cat
+      left_inv g := by cat_disch
       right_inv f := by simp }
   homEquiv_comp := by simp
 

--- a/Mathlib/Algebra/Homology/ExactSequence.lean
+++ b/Mathlib/Algebra/Homology/ExactSequence.lean
@@ -56,13 +56,13 @@ theorem ShortComplex.mapToComposableArrows_app_2 {S₁ S₂ : ShortComplex C} (�
 @[simp]
 theorem ShortComplex.mapToComposableArrows_id {S₁ : ShortComplex C} :
     (ShortComplex.mapToComposableArrows (𝟙 S₁)) = 𝟙 S₁.toComposableArrows := by
-  aesop_cat
+  cat_disch
 
 @[simp]
 theorem ShortComplex.mapToComposableArrows_comp {S₁ S₂ S₃ : ShortComplex C} (φ : S₁ ⟶ S₂)
     (ψ : S₂ ⟶ S₃) : ShortComplex.mapToComposableArrows (φ ≫ ψ) =
       ShortComplex.mapToComposableArrows φ ≫ ShortComplex.mapToComposableArrows ψ := by
-  aesop_cat
+  cat_disch
 
 namespace ComposableArrows
 

--- a/Mathlib/Algebra/Homology/HomologicalBicomplex.lean
+++ b/Mathlib/Algebra/Homology/HomologicalBicomplex.lean
@@ -177,7 +177,7 @@ def flipEquivalenceUnitIso :
     𝟭 (HomologicalComplex₂ C c₁ c₂) ≅ flipFunctor C c₁ c₂ ⋙ flipFunctor C c₂ c₁ :=
   NatIso.ofComponents (fun K => HomologicalComplex.Hom.isoOfComponents (fun i₁ =>
     HomologicalComplex.Hom.isoOfComponents (fun _ => Iso.refl _)
-    (by simp)) (by aesop_cat)) (by aesop_cat)
+    (by simp)) (by cat_disch)) (by cat_disch)
 
 /-- Auxiliary definition for `HomologicalComplex₂.flipEquivalence`. -/
 @[simps!]
@@ -185,7 +185,7 @@ def flipEquivalenceCounitIso :
     flipFunctor C c₂ c₁ ⋙ flipFunctor C c₁ c₂ ≅ 𝟭 (HomologicalComplex₂ C c₂ c₁) :=
   NatIso.ofComponents (fun K => HomologicalComplex.Hom.isoOfComponents (fun i₂ =>
     HomologicalComplex.Hom.isoOfComponents (fun _ => Iso.refl _)
-    (by simp)) (by aesop_cat)) (by aesop_cat)
+    (by simp)) (by cat_disch)) (by cat_disch)
 
 /-- Flipping a complex of complexes over the diagonal, as an equivalence of categories. -/
 @[simps]

--- a/Mathlib/Algebra/Homology/HomologicalComplex.lean
+++ b/Mathlib/Algebra/Homology/HomologicalComplex.lean
@@ -55,8 +55,8 @@ The composite of any two differentials `d i j ≫ d j k` must be zero.
 structure HomologicalComplex (c : ComplexShape ι) where
   X : ι → V
   d : ∀ i j, X i ⟶ X j
-  shape : ∀ i j, ¬c.Rel i j → d i j = 0 := by aesop_cat
-  d_comp_d' : ∀ i j k, c.Rel i j → c.Rel j k → d i j ≫ d j k = 0 := by aesop_cat
+  shape : ∀ i j, ¬c.Rel i j → d i j = 0 := by cat_disch
+  d_comp_d' : ∀ i j k, c.Rel i j → c.Rel j k → d i j ≫ d j k = 0 := by cat_disch
 
 namespace HomologicalComplex
 
@@ -214,7 +214,7 @@ commuting with the differentials.
 @[ext]
 structure Hom (A B : HomologicalComplex V c) where
   f : ∀ i, A.X i ⟶ B.X i
-  comm' : ∀ i j, c.Rel i j → f i ≫ B.d i j = A.d i j ≫ f j := by aesop_cat
+  comm' : ∀ i j, c.Rel i j → f i ≫ B.d i j = A.d i j ≫ f j := by cat_disch
 
 @[reassoc (attr := simp)]
 theorem Hom.comm {A B : HomologicalComplex V c} (f : A.Hom B) (i j : ι) :
@@ -269,7 +269,7 @@ theorem eqToHom_f {C₁ C₂ : HomologicalComplex V c} (h : C₁ = C₂) (n : ι
 
 -- We'll use this later to show that `HomologicalComplex V c` is preadditive when `V` is.
 theorem hom_f_injective {C₁ C₂ : HomologicalComplex V c} :
-    Function.Injective fun f : Hom C₁ C₂ => f.f := by aesop_cat
+    Function.Injective fun f : Hom C₁ C₂ => f.f := by cat_disch
 
 instance (X Y : HomologicalComplex V c) : Zero (X ⟶ Y) :=
   ⟨{ f := fun _ => 0}⟩
@@ -496,7 +496,7 @@ def isoApp (f : C₁ ≅ C₂) (i : ι) : C₁.X i ≅ C₂.X i :=
 which commute with the differentials. -/
 @[simps]
 def isoOfComponents (f : ∀ i, C₁.X i ≅ C₂.X i)
-    (hf : ∀ i j, c.Rel i j → (f i).hom ≫ C₂.d i j = C₁.d i j ≫ (f j).hom := by aesop_cat) :
+    (hf : ∀ i j, c.Rel i j → (f i).hom ≫ C₂.d i j = C₁.d i j ≫ (f j).hom := by cat_disch) :
     C₁ ≅ C₂ where
   hom :=
     { f := fun i => (f i).hom

--- a/Mathlib/Algebra/Homology/Homotopy.lean
+++ b/Mathlib/Algebra/Homology/Homotopy.lean
@@ -118,8 +118,8 @@ which are zero unless `c.Rel j i`, satisfying the homotopy condition.
 @[ext]
 structure Homotopy (f g : C ⟶ D) where
   hom : ∀ i j, C.X i ⟶ D.X j
-  zero : ∀ i j, ¬c.Rel j i → hom i j = 0 := by aesop_cat
-  comm : ∀ i, f.f i = dNext i hom + prevD i hom + g.f i := by aesop_cat
+  zero : ∀ i j, ¬c.Rel j i → hom i j = 0 := by cat_disch
+  comm : ∀ i, f.f i = dNext i hom + prevD i hom + g.f i := by cat_disch
 
 variable {f g}
 
@@ -136,8 +136,8 @@ def equivSubZero : Homotopy f g ≃ Homotopy (f - g) 0 where
     { hom := fun i j => h.hom i j
       zero := fun _ _ w => h.zero _ _ w
       comm := fun i => by simpa [sub_eq_iff_eq_add] using h.comm i }
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
+  left_inv := by cat_disch
+  right_inv := by cat_disch
 
 /-- Equal chain maps are homotopic. -/
 @[simps]

--- a/Mathlib/Algebra/Homology/HomotopyCategory.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory.lean
@@ -245,12 +245,12 @@ def NatTrans.mapHomotopyCategory {F G : V ⥤ W} [F.Additive] [G.Additive] (α :
 
 @[simp]
 theorem NatTrans.mapHomotopyCategory_id (c : ComplexShape ι) (F : V ⥤ W) [F.Additive] :
-    NatTrans.mapHomotopyCategory (𝟙 F) c = 𝟙 (F.mapHomotopyCategory c) := by aesop_cat
+    NatTrans.mapHomotopyCategory (𝟙 F) c = 𝟙 (F.mapHomotopyCategory c) := by cat_disch
 
 @[simp]
 theorem NatTrans.mapHomotopyCategory_comp (c : ComplexShape ι) {F G H : V ⥤ W} [F.Additive]
     [G.Additive] [H.Additive] (α : F ⟶ G) (β : G ⟶ H) :
     NatTrans.mapHomotopyCategory (α ≫ β) c =
-      NatTrans.mapHomotopyCategory α c ≫ NatTrans.mapHomotopyCategory β c := by aesop_cat
+      NatTrans.mapHomotopyCategory α c ≫ NatTrans.mapHomotopyCategory β c := by cat_disch
 
 end CategoryTheory

--- a/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/HomComplex.lean
@@ -138,7 +138,7 @@ lemma ofHoms_v (ψ : ∀ (p : ℤ), F.X p ⟶ G.X p) (p : ℤ) :
   simp only [ofHoms, mk_v, eqToHom_refl, comp_id]
 
 @[simp]
-lemma ofHoms_zero : ofHoms (fun p => (0 : F.X p ⟶ G.X p)) = 0 := by aesop_cat
+lemma ofHoms_zero : ofHoms (fun p => (0 : F.X p ⟶ G.X p)) = 0 := by cat_disch
 
 @[simp]
 lemma ofHoms_v_comp_d (ψ : ∀ (p : ℤ), F.X p ⟶ G.X p) (p q q' : ℤ) (hpq : p + 0 = q) :
@@ -181,15 +181,15 @@ lemma d_comp_ofHom_v (φ : F ⟶ G) (p' p q : ℤ) (hpq : p + 0 = q) :
 
 @[simp]
 lemma ofHom_add (φ₁ φ₂ : F ⟶ G) :
-    Cochain.ofHom (φ₁ + φ₂) = Cochain.ofHom φ₁ + Cochain.ofHom φ₂ := by aesop_cat
+    Cochain.ofHom (φ₁ + φ₂) = Cochain.ofHom φ₁ + Cochain.ofHom φ₂ := by cat_disch
 
 @[simp]
 lemma ofHom_sub (φ₁ φ₂ : F ⟶ G) :
-    Cochain.ofHom (φ₁ - φ₂) = Cochain.ofHom φ₁ - Cochain.ofHom φ₂ := by aesop_cat
+    Cochain.ofHom (φ₁ - φ₂) = Cochain.ofHom φ₁ - Cochain.ofHom φ₂ := by cat_disch
 
 @[simp]
 lemma ofHom_neg (φ : F ⟶ G) :
-    Cochain.ofHom (-φ) = -Cochain.ofHom φ := by aesop_cat
+    Cochain.ofHom (-φ) = -Cochain.ofHom φ := by cat_disch
 
 /-- The cochain of degree `-1` given by an homotopy between two morphism of complexes. -/
 def ofHomotopy {φ₁ φ₂ : F ⟶ G} (ho : Homotopy φ₁ φ₂) : Cochain F G (-1) :=
@@ -380,7 +380,7 @@ protected lemma comp_id {n : ℤ} (z₁ : Cochain F G n) :
 
 @[simp]
 lemma ofHoms_comp (φ : ∀ (p : ℤ), F.X p ⟶ G.X p) (ψ : ∀ (p : ℤ), G.X p ⟶ K.X p) :
-    (ofHoms φ).comp (ofHoms ψ) (zero_add 0) = ofHoms (fun p => φ p ≫ ψ p) := by aesop_cat
+    (ofHoms φ).comp (ofHoms ψ) (zero_add 0) = ofHoms (fun p => φ p ≫ ψ p) := by cat_disch
 
 @[simp]
 lemma ofHom_comp (f : F ⟶ G) (g : G ⟶ K) :
@@ -669,10 +669,10 @@ def homOf (z : Cocycle F G 0) : F ⟶ G where
       using Cochain.congr_v hz i (i + 1) rfl
 
 @[simp]
-lemma homOf_ofHom_eq_self (φ : F ⟶ G) : homOf (ofHom φ) = φ := by aesop_cat
+lemma homOf_ofHom_eq_self (φ : F ⟶ G) : homOf (ofHom φ) = φ := by cat_disch
 
 @[simp]
-lemma ofHom_homOf_eq_self (z : Cocycle F G 0) : ofHom (homOf z) = z := by aesop_cat
+lemma ofHom_homOf_eq_self (z : Cocycle F G 0) : ofHom (homOf z) = z := by cat_disch
 
 @[simp]
 lemma cochain_ofHom_homOf_eq_coe (z : Cocycle F G 0) :
@@ -688,7 +688,7 @@ def equivHom : (F ⟶ G) ≃+ Cocycle F G 0 where
   invFun := homOf
   left_inv := homOf_ofHom_eq_self
   right_inv := ofHom_homOf_eq_self
-  map_add' := by aesop_cat
+  map_add' := by cat_disch
 
 variable (K)
 
@@ -791,18 +791,18 @@ def map : Cochain ((Φ.mapHomologicalComplex _).obj K) ((Φ.mapHomologicalComple
 lemma map_v (p q : ℤ) (hpq : p + n = q) : (z.map Φ).v p q hpq = Φ.map (z.v p q hpq) := rfl
 
 @[simp]
-protected lemma map_add : (z + z').map Φ = z.map Φ + z'.map Φ := by aesop_cat
+protected lemma map_add : (z + z').map Φ = z.map Φ + z'.map Φ := by cat_disch
 
 @[simp]
-protected lemma map_neg : (-z).map Φ = -z.map Φ := by aesop_cat
+protected lemma map_neg : (-z).map Φ = -z.map Φ := by cat_disch
 
 @[simp]
-protected lemma map_sub : (z - z').map Φ = z.map Φ - z'.map Φ := by aesop_cat
+protected lemma map_sub : (z - z').map Φ = z.map Φ - z'.map Φ := by cat_disch
 
 variable (K L n)
 
 @[simp]
-protected lemma map_zero : (0 : Cochain K L n).map Φ = 0 := by aesop_cat
+protected lemma map_zero : (0 : Cochain K L n).map Φ = 0 := by cat_disch
 
 @[simp]
 lemma map_comp {n₁ n₂ n₁₂ : ℤ} (z₁ : Cochain F G n₁) (z₂ : Cochain G K n₂) (h : n₁ + n₂ = n₁₂)
@@ -814,7 +814,7 @@ lemma map_comp {n₁ n₂ n₁₂ : ℤ} (z₁ : Cochain F G n₁) (z₂ : Cocha
 
 @[simp]
 lemma map_ofHom :
-    (Cochain.ofHom f).map Φ = Cochain.ofHom ((Φ.mapHomologicalComplex _).map f) := by aesop_cat
+    (Cochain.ofHom f).map Φ = Cochain.ofHom ((Φ.mapHomologicalComplex _).map f) := by cat_disch
 
 end Cochain
 

--- a/Mathlib/Algebra/Homology/HomotopyCategory/MappingCone.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/MappingCone.lean
@@ -111,7 +111,7 @@ lemma inr_fst :
 
 @[simp]
 lemma inr_snd :
-    (Cochain.ofHom (inr φ)).comp (snd φ) (zero_add 0) = Cochain.ofHom (𝟙 G) := by aesop_cat
+    (Cochain.ofHom (inr φ)).comp (snd φ) (zero_add 0) = Cochain.ofHom (𝟙 G) := by cat_disch
 
 /-! In order to obtain identities of cochains involving `inl`, `inr`, `fst` and `snd`,
 it is often convenient to use an `ext` lemma, and use simp lemmas like `inl_v_f_fst_v`,
@@ -381,7 +381,7 @@ lemma inr_f_desc_f (p : ℤ) :
   simp [desc]
 
 @[reassoc (attr := simp)]
-lemma inr_desc : inr φ ≫ desc φ α β eq = β := by aesop_cat
+lemma inr_desc : inr φ ≫ desc φ α β eq = β := by cat_disch
 
 lemma desc_f (p q : ℤ) (hpq : p + 1 = q) :
     (desc φ α β eq).f p = (fst φ).1.v p q hpq ≫ α.v q p (by omega) +

--- a/Mathlib/Algebra/Homology/HomotopyCategory/Triangulated.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/Triangulated.lean
@@ -177,7 +177,7 @@ lemma mappingConeCompTriangleh_distinguished :
       distTriang (HomotopyCategory C (ComplexShape.up ℤ)) := by
   refine ⟨_, _, (mappingConeCompTriangle f g).mor₁, ⟨?_⟩⟩
   refine Triangle.isoMk _ _ (Iso.refl _) (Iso.refl _) (isoOfHomotopyEquiv
-    (mappingConeCompHomotopyEquiv f g)) (by aesop_cat) (by simp) ?_
+    (mappingConeCompHomotopyEquiv f g)) (by cat_disch) (by simp) ?_
   dsimp [mappingConeCompTriangleh]
   rw [CategoryTheory.Functor.map_id, comp_id, ← Functor.map_comp_assoc]
   congr 2

--- a/Mathlib/Algebra/Homology/HomotopyCofiber.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCofiber.lean
@@ -361,7 +361,7 @@ noncomputable def descEquiv (K : HomologicalComplex C c) (hc : ∀ j, ∃ i, c.R
   right_inv f := (eq_desc φ f hc).symm
   left_inv := fun ⟨α, hα⟩ => by
     rw [descSigma_ext_iff]
-    aesop_cat
+    cat_disch
 
 end homotopyCofiber
 

--- a/Mathlib/Algebra/Homology/HomotopyCofiber.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCofiber.lean
@@ -312,7 +312,7 @@ lemma inrX_desc_f (i : ι) :
 
 @[reassoc (attr := simp)]
 lemma inr_desc :
-    inr φ ≫ desc φ α hα = α := by aesop_cat
+    inr φ ≫ desc φ α hα = α := by cat_disch
 
 @[reassoc (attr := simp)]
 lemma inrCompHomotopy_hom_desc_hom (hc : ∀ j, ∃ i, c.Rel i j) (i j : ι) :

--- a/Mathlib/Algebra/Homology/Linear.lean
+++ b/Mathlib/Algebra/Homology/Linear.lean
@@ -39,10 +39,10 @@ lemma smul_f_apply (r : R) (f : X ⟶ Y) (n : ι) : (r • f).f n = r • f.f n 
 lemma units_smul_f_apply (r : Rˣ) (f : X ⟶ Y) (n : ι) : (r • f).f n = r • f.f n := rfl
 
 instance (X Y : HomologicalComplex C c) : Module R (X ⟶ Y) where
-  one_smul a := by aesop_cat
-  smul_zero := by aesop_cat
-  smul_add := by aesop_cat
-  zero_smul := by aesop_cat
+  one_smul a := by cat_disch
+  smul_zero := by cat_disch
+  smul_add := by cat_disch
+  zero_smul := by cat_disch
   add_smul _ _ _ := by ext; apply add_smul
   mul_smul _ _ _ := by ext; apply mul_smul
 

--- a/Mathlib/Algebra/Homology/ShortComplex/Basic.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Basic.lean
@@ -57,9 +57,9 @@ structure Hom (S₁ S₂ : ShortComplex C) where
   /-- the morphism on the right objects -/
   τ₃ : S₁.X₃ ⟶ S₂.X₃
   /-- the left commutative square of a morphism in `ShortComplex` -/
-  comm₁₂ : τ₁ ≫ S₂.f = S₁.f ≫ τ₂ := by aesop_cat
+  comm₁₂ : τ₁ ≫ S₂.f = S₁.f ≫ τ₂ := by cat_disch
   /-- the right commutative square of a morphism in `ShortComplex` -/
-  comm₂₃ : τ₂ ≫ S₂.g = S₁.g ≫ τ₃ := by aesop_cat
+  comm₂₃ : τ₂ ≫ S₂.g = S₁.g ≫ τ₃ := by cat_disch
 
 attribute [reassoc] Hom.comm₁₂ Hom.comm₂₃
 attribute [local simp] Hom.comm₁₂ Hom.comm₂₃ Hom.comm₁₂_assoc Hom.comm₂₃_assoc
@@ -155,7 +155,7 @@ instance (f : S₁ ⟶ S₂) [IsIso f] : IsIso f.τ₃ := (inferInstance : IsIso
   app S := S.g
 
 @[reassoc (attr := simp)]
-lemma π₁Toπ₂_comp_π₂Toπ₃ : (π₁Toπ₂ : (_ : _ ⥤ C) ⟶ _) ≫ π₂Toπ₃ = 0 := by aesop_cat
+lemma π₁Toπ₂_comp_π₂Toπ₃ : (π₁Toπ₂ : (_ : _ ⥤ C) ⟶ _) ≫ π₂Toπ₃ = 0 := by cat_disch
 
 variable {D}
 variable [HasZeroMorphisms D]
@@ -203,8 +203,8 @@ def _root_.CategoryTheory.Functor.mapShortComplex (F : C ⥤ D) [F.PreservesZero
 /-- A constructor for isomorphisms in the category `ShortComplex C` -/
 @[simps]
 def isoMk (e₁ : S₁.X₁ ≅ S₂.X₁) (e₂ : S₁.X₂ ≅ S₂.X₂) (e₃ : S₁.X₃ ≅ S₂.X₃)
-    (comm₁₂ : e₁.hom ≫ S₂.f = S₁.f ≫ e₂.hom := by aesop_cat)
-    (comm₂₃ : e₂.hom ≫ S₂.g = S₁.g ≫ e₃.hom := by aesop_cat) :
+    (comm₁₂ : e₁.hom ≫ S₂.f = S₁.f ≫ e₂.hom := by cat_disch)
+    (comm₂₃ : e₂.hom ≫ S₂.g = S₁.g ≫ e₃.hom := by cat_disch) :
     S₁ ≅ S₂ where
   hom := ⟨e₁.hom, e₂.hom, e₃.hom, comm₁₂, comm₂₃⟩
   inv := homMk e₁.inv e₂.inv e₃.inv

--- a/Mathlib/Algebra/Homology/ShortComplex/Exact.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Exact.lean
@@ -389,13 +389,13 @@ lemma exact_iff_epi_kernel_lift [S.HasHomology] [HasKernel S.g] :
     S.Exact ↔ Epi (kernel.lift S.g S.f S.zero) := by
   rw [exact_iff_epi_toCycles]
   apply (MorphismProperty.epimorphisms C).arrow_mk_iso_iff
-  exact Arrow.isoMk (Iso.refl _) S.cyclesIsoKernel (by aesop_cat)
+  exact Arrow.isoMk (Iso.refl _) S.cyclesIsoKernel (by cat_disch)
 
 lemma exact_iff_mono_cokernel_desc [S.HasHomology] [HasCokernel S.f] :
     S.Exact ↔ Mono (cokernel.desc S.f S.g S.zero) := by
   rw [exact_iff_mono_fromOpcycles]
   refine (MorphismProperty.monomorphisms C).arrow_mk_iso_iff (Iso.symm ?_)
-  exact Arrow.isoMk S.opcyclesIsoCokernel.symm (Iso.refl _) (by aesop_cat)
+  exact Arrow.isoMk S.opcyclesIsoCokernel.symm (Iso.refl _) (by cat_disch)
 
 lemma QuasiIso.exact_iff {S₁ S₂ : ShortComplex C} (φ : S₁ ⟶ S₂)
     [S₁.HasHomology] [S₂.HasHomology] [QuasiIso φ] : S₁.Exact ↔ S₂.Exact := by
@@ -473,11 +473,11 @@ structure Splitting (S : ShortComplex C) where
   /-- a section of `S.g` -/
   s : S.X₃ ⟶ S.X₂
   /-- the condition that `r` is a retraction of `S.f` -/
-  f_r : S.f ≫ r = 𝟙 _ := by aesop_cat
+  f_r : S.f ≫ r = 𝟙 _ := by cat_disch
   /-- the condition that `s` is a section of `S.g` -/
-  s_g : s ≫ S.g = 𝟙 _ := by aesop_cat
+  s_g : s ≫ S.g = 𝟙 _ := by cat_disch
   /-- the compatibility between the given section and retraction -/
-  id : r ≫ S.f + S.g ≫ s = 𝟙 _ := by aesop_cat
+  id : r ≫ S.f + S.g ≫ s = 𝟙 _ := by cat_disch
 
 namespace Splitting
 

--- a/Mathlib/Algebra/Homology/ShortComplex/FunctorEquivalence.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/FunctorEquivalence.lean
@@ -41,9 +41,9 @@ def inverse : (J ⥤ ShortComplex C) ⥤ ShortComplex (J ⥤ C) where
   obj F :=
     { f := whiskerLeft F π₁Toπ₂
       g := whiskerLeft F π₂Toπ₃
-      zero := by aesop_cat }
+      zero := by cat_disch }
   map φ := Hom.mk (whiskerRight φ π₁) (whiskerRight φ π₂) (whiskerRight φ π₃)
-    (by aesop_cat) (by aesop_cat)
+    (by cat_disch) (by cat_disch)
 
 /-- The unit isomorphism of the equivalence
 `ShortComplex.functorEquivalence : ShortComplex (J ⥤ C) ≌ J ⥤ ShortComplex C`. -/
@@ -53,7 +53,7 @@ def unitIso : 𝟭 _ ≅ functor J C ⋙ inverse J C :=
     (NatIso.ofComponents (fun _ => Iso.refl _) (by simp))
     (NatIso.ofComponents (fun _ => Iso.refl _) (by simp))
     (NatIso.ofComponents (fun _ => Iso.refl _) (by simp))
-    (by aesop_cat) (by aesop_cat)) (by aesop_cat)
+    (by cat_disch) (by cat_disch)) (by cat_disch)
 
 /-- The counit isomorphism of the equivalence
 `ShortComplex.functorEquivalence : ShortComplex (J ⥤ C) ≌ J ⥤ ShortComplex C`. -/
@@ -61,7 +61,7 @@ def unitIso : 𝟭 _ ≅ functor J C ⋙ inverse J C :=
 def counitIso : inverse J C ⋙ functor J C ≅ 𝟭 _ :=
   NatIso.ofComponents (fun _ => NatIso.ofComponents
     (fun _ => isoMk (Iso.refl _) (Iso.refl _) (Iso.refl _)
-      (by simp) (by simp)) (by aesop_cat)) (by aesop_cat)
+      (by simp) (by simp)) (by cat_disch)) (by cat_disch)
 
 end FunctorEquivalence
 

--- a/Mathlib/Algebra/Homology/ShortComplex/HomologicalComplex.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/HomologicalComplex.lean
@@ -50,7 +50,7 @@ when `c.prev j = i` and `c.next j = k`. -/
 noncomputable def natIsoSc' (i j k : ι) (hi : c.prev j = i) (hk : c.next j = k) :
     shortComplexFunctor C c j ≅ shortComplexFunctor' C c i j k :=
   NatIso.ofComponents (fun K => ShortComplex.isoMk (K.XIsoOfEq hi) (Iso.refl _) (K.XIsoOfEq hk)
-    (by simp) (by simp)) (by aesop_cat)
+    (by simp) (by simp)) (by cat_disch)
 
 variable {C c}
 
@@ -538,7 +538,7 @@ lemma iCyclesIso_inv_hom_id :
   (K.iCyclesIso i j hj h).inv_hom_id
 
 lemma isIso_homologyι : IsIso (K.homologyι i) :=
-  ShortComplex.isIso_homologyι _ (by aesop_cat)
+  ShortComplex.isIso_homologyι _ (by cat_disch)
 
 /-- The canonical isomorphism `K.homology i ≅ K.opcycles i`
 when the differential from `i` is zero. -/
@@ -585,7 +585,7 @@ lemma pOpcyclesIso_inv_hom_id :
   (K.pOpcyclesIso i j hi h).inv_hom_id
 
 lemma isIso_homologyπ : IsIso (K.homologyπ j) :=
-  ShortComplex.isIso_homologyπ _ (by aesop_cat)
+  ShortComplex.isIso_homologyπ _ (by cat_disch)
 
 /-- The canonical isomorphism `K.cycles j ≅ K.homology j`
 when the differential to `j` is zero. -/

--- a/Mathlib/Algebra/Homology/ShortComplex/Homology.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Homology.lean
@@ -54,7 +54,7 @@ structure HomologyData where
   iso : left.H ≅ right.H
   /-- the pentagon relation expressing the compatibility of the left
   and right homology data -/
-  comm : left.π ≫ iso.hom ≫ right.ι = left.i ≫ right.p := by aesop_cat
+  comm : left.π ≫ iso.hom ≫ right.ι = left.i ≫ right.p := by cat_disch
 
 attribute [reassoc (attr := simp)] HomologyData.comm
 

--- a/Mathlib/Algebra/Homology/ShortComplex/LeftHomology.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/LeftHomology.lean
@@ -996,7 +996,7 @@ noncomputable def leftHomologyIsCokernel :
 lemma liftCycles_comp_cyclesMap (φ : S ⟶ S₁) [S₁.HasLeftHomology] :
     S.liftCycles k hk ≫ cyclesMap φ =
       S₁.liftCycles (k ≫ φ.τ₂) (by rw [assoc, φ.comm₂₃, reassoc_of% hk, zero_comp]) := by
-  aesop_cat
+  cat_disch
 
 variable {S}
 

--- a/Mathlib/Algebra/Homology/ShortComplex/LeftHomology.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/LeftHomology.lean
@@ -272,11 +272,11 @@ structure LeftHomologyMapData where
   /-- the induced map on left homology -/
   φH : h₁.H ⟶ h₂.H
   /-- commutation with `i` -/
-  commi : φK ≫ h₂.i = h₁.i ≫ φ.τ₂ := by aesop_cat
+  commi : φK ≫ h₂.i = h₁.i ≫ φ.τ₂ := by cat_disch
   /-- commutation with `f'` -/
-  commf' : h₁.f' ≫ φK = φ.τ₁ ≫ h₂.f' := by aesop_cat
+  commf' : h₁.f' ≫ φK = φ.τ₁ ≫ h₂.f' := by cat_disch
   /-- commutation with `π` -/
-  commπ : h₁.π ≫ φH = φK ≫ h₂.π := by aesop_cat
+  commπ : h₁.π ≫ φH = φK ≫ h₂.π := by cat_disch
 
 namespace LeftHomologyMapData
 
@@ -958,7 +958,7 @@ lemma liftCycles_i : S.liftCycles k hk ≫ S.iCycles = k :=
 
 @[reassoc]
 lemma comp_liftCycles {A' : C} (α : A' ⟶ A) :
-    α ≫ S.liftCycles k hk = S.liftCycles (α ≫ k) (by rw [assoc, hk, comp_zero]) := by aesop_cat
+    α ≫ S.liftCycles k hk = S.liftCycles (α ≫ k) (by rw [assoc, hk, comp_zero]) := by cat_disch
 
 /-- Via `S.iCycles : S.cycles ⟶ S.X₂`, the object `S.cycles` identifies to the
 kernel of `S.g : S.X₂ ⟶ S.X₃`. -/
@@ -1026,7 +1026,7 @@ lemma hasCokernel [S.HasLeftHomology] [HasKernel S.g] :
   haveI : HasColimit (parallelPair h.f' 0) := ⟨⟨⟨_, h.hπ'⟩⟩⟩
   let e : parallelPair (kernel.lift S.g S.f S.zero) 0 ≅ parallelPair h.f' 0 :=
     parallelPair.ext (Iso.refl _) (IsLimit.conePointUniqueUpToIso (kernelIsKernel S.g) h.hi)
-      (by aesop_cat) (by simp)
+      (by cat_disch) (by simp)
   exact hasColimit_of_iso e
 
 end HasLeftHomology

--- a/Mathlib/Algebra/Homology/ShortComplex/Limits.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Limits.lean
@@ -64,7 +64,7 @@ variable [HasLimit (F ⋙ π₁)] [HasLimit (F ⋙ π₂)] [HasLimit (F ⋙ π�
 of the three components `J ⥤ C`. -/
 noncomputable def limitCone : Cone F :=
   Cone.mk (ShortComplex.mk (limMap (whiskerLeft F π₁Toπ₂)) (limMap (whiskerLeft F π₂Toπ₃))
-      (by aesop_cat))
+      (by cat_disch))
     { app := fun j => Hom.mk (limit.π _ _) (limit.π _ _) (limit.π _ _)
         (by simp) (by simp)
       naturality := fun _ _ f => by
@@ -72,15 +72,15 @@ noncomputable def limitCone : Cone F :=
 
 /-- `limitCone F` becomes limit after the application of `π₁ : ShortComplex C ⥤ C`. -/
 noncomputable def isLimitπ₁MapConeLimitCone : IsLimit (π₁.mapCone (limitCone F)) :=
-  (IsLimit.ofIsoLimit (limit.isLimit _) (Cones.ext (Iso.refl _) (by aesop_cat)))
+  (IsLimit.ofIsoLimit (limit.isLimit _) (Cones.ext (Iso.refl _) (by cat_disch)))
 
 /-- `limitCone F` becomes limit after the application of `π₂ : ShortComplex C ⥤ C`. -/
 noncomputable def isLimitπ₂MapConeLimitCone : IsLimit (π₂.mapCone (limitCone F)) :=
-  (IsLimit.ofIsoLimit (limit.isLimit _) (Cones.ext (Iso.refl _) (by aesop_cat)))
+  (IsLimit.ofIsoLimit (limit.isLimit _) (Cones.ext (Iso.refl _) (by cat_disch)))
 
 /-- `limitCone F` becomes limit after the application of `π₃ : ShortComplex C ⥤ C`. -/
 noncomputable def isLimitπ₃MapConeLimitCone : IsLimit (π₃.mapCone (limitCone F)) :=
-  (IsLimit.ofIsoLimit (limit.isLimit _) (Cones.ext (Iso.refl _) (by aesop_cat)))
+  (IsLimit.ofIsoLimit (limit.isLimit _) (Cones.ext (Iso.refl _) (by cat_disch)))
 
 /-- `limitCone F` is limit. -/
 noncomputable def isLimitLimitCone : IsLimit (limitCone F) :=
@@ -194,7 +194,7 @@ variable [HasColimit (F ⋙ π₁)] [HasColimit (F ⋙ π₂)] [HasColimit (F �
 of the three components `J ⥤ C`. -/
 noncomputable def colimitCocone : Cocone F :=
   Cocone.mk (ShortComplex.mk (colimMap (whiskerLeft F π₁Toπ₂)) (colimMap (whiskerLeft F π₂Toπ₃))
-      (by aesop_cat))
+      (by cat_disch))
     { app := fun j => Hom.mk (colimit.ι (F ⋙ π₁) _) (colimit.ι (F ⋙ π₂) _)
         (colimit.ι (F ⋙ π₃) _) (by simp) (by simp)
       naturality := fun _ _ f => by
@@ -206,17 +206,17 @@ noncomputable def colimitCocone : Cocone F :=
 /-- `colimitCocone F` becomes colimit after the application of `π₁ : ShortComplex C ⥤ C`. -/
 noncomputable def isColimitπ₁MapCoconeColimitCocone :
     IsColimit (π₁.mapCocone (colimitCocone F)) :=
-  (IsColimit.ofIsoColimit (colimit.isColimit _) (Cocones.ext (Iso.refl _) (by aesop_cat)))
+  (IsColimit.ofIsoColimit (colimit.isColimit _) (Cocones.ext (Iso.refl _) (by cat_disch)))
 
 /-- `colimitCocone F` becomes colimit after the application of `π₂ : ShortComplex C ⥤ C`. -/
 noncomputable def isColimitπ₂MapCoconeColimitCocone :
     IsColimit (π₂.mapCocone (colimitCocone F)) :=
-  (IsColimit.ofIsoColimit (colimit.isColimit _) (Cocones.ext (Iso.refl _) (by aesop_cat)))
+  (IsColimit.ofIsoColimit (colimit.isColimit _) (Cocones.ext (Iso.refl _) (by cat_disch)))
 
 /-- `colimitCocone F` becomes colimit after the application of `π₃ : ShortComplex C ⥤ C`. -/
 noncomputable def isColimitπ₃MapCoconeColimitCocone :
     IsColimit (π₃.mapCocone (colimitCocone F)) :=
-  (IsColimit.ofIsoColimit (colimit.isColimit _) (Cocones.ext (Iso.refl _) (by aesop_cat)))
+  (IsColimit.ofIsoColimit (colimit.isColimit _) (Cocones.ext (Iso.refl _) (by cat_disch)))
 
 /-- `colimitCocone F` is colimit. -/
 noncomputable def isColimitColimitCocone : IsColimit (colimitCocone F) :=

--- a/Mathlib/Algebra/Homology/ShortComplex/Linear.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Linear.lean
@@ -38,12 +38,12 @@ instance : SMul R (S₁ ⟶ S₂) where
 @[simp] lemma smul_τ₃ (a : R) (φ : S₁ ⟶ S₂) : (a • φ).τ₃ = a • φ.τ₃ := rfl
 
 instance : Module R (S₁ ⟶ S₂) where
-  zero_smul := by aesop_cat
-  one_smul := by aesop_cat
-  smul_zero := by aesop_cat
-  smul_add := by aesop_cat
-  add_smul := by aesop_cat
-  mul_smul := by aesop_cat
+  zero_smul := by cat_disch
+  one_smul := by cat_disch
+  smul_zero := by cat_disch
+  smul_add := by cat_disch
+  add_smul := by cat_disch
+  mul_smul := by cat_disch
 
 instance : Linear R (ShortComplex C) where
 

--- a/Mathlib/Algebra/Homology/ShortComplex/Preadditive.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/Preadditive.lean
@@ -361,17 +361,17 @@ in homology. -/
 structure Homotopy where
   /-- a morphism `S₁.X₁ ⟶ S₂.X₁` -/
   h₀ : S₁.X₁ ⟶ S₂.X₁
-  h₀_f : h₀ ≫ S₂.f = 0 := by aesop_cat
+  h₀_f : h₀ ≫ S₂.f = 0 := by cat_disch
   /-- a morphism `S₁.X₂ ⟶ S₂.X₁` -/
   h₁ : S₁.X₂ ⟶ S₂.X₁
   /-- a morphism `S₁.X₃ ⟶ S₂.X₂` -/
   h₂ : S₁.X₃ ⟶ S₂.X₂
   /-- a morphism `S₁.X₃ ⟶ S₂.X₃` -/
   h₃ : S₁.X₃ ⟶ S₂.X₃
-  g_h₃ : S₁.g ≫ h₃ = 0 := by aesop_cat
-  comm₁ : φ₁.τ₁ = S₁.f ≫ h₁ + h₀ + φ₂.τ₁ := by aesop_cat
-  comm₂ : φ₁.τ₂ = S₁.g ≫ h₂ + h₁ ≫ S₂.f + φ₂.τ₂ := by aesop_cat
-  comm₃ : φ₁.τ₃ = h₃ + h₂ ≫ S₂.g + φ₂.τ₃ := by aesop_cat
+  g_h₃ : S₁.g ≫ h₃ = 0 := by cat_disch
+  comm₁ : φ₁.τ₁ = S₁.f ≫ h₁ + h₀ + φ₂.τ₁ := by cat_disch
+  comm₂ : φ₁.τ₂ = S₁.g ≫ h₂ + h₁ ≫ S₂.f + φ₂.τ₂ := by cat_disch
+  comm₃ : φ₁.τ₃ = h₃ + h₂ ≫ S₂.g + φ₂.τ₃ := by cat_disch
 
 attribute [reassoc (attr := simp)] Homotopy.h₀_f Homotopy.g_h₃
 
@@ -527,8 +527,8 @@ def equivSubZero : Homotopy φ₁ φ₂ ≃ Homotopy (φ₁ - φ₂) 0 where
   toFun h := (h.sub (refl φ₂)).trans (ofEq (sub_self φ₂))
   invFun h := ((ofEq (sub_add_cancel φ₁ φ₂).symm).trans
     (h.add (refl φ₂))).trans (ofEq (zero_add φ₂))
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
+  left_inv := by cat_disch
+  right_inv := by cat_disch
 
 variable {φ₁ φ₂}
 

--- a/Mathlib/Algebra/Homology/ShortComplex/RightHomology.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/RightHomology.lean
@@ -362,11 +362,11 @@ structure RightHomologyMapData where
   /-- the induced map on right homology -/
   φH : h₁.H ⟶ h₂.H
   /-- commutation with `p` -/
-  commp : h₁.p ≫ φQ = φ.τ₂ ≫ h₂.p := by aesop_cat
+  commp : h₁.p ≫ φQ = φ.τ₂ ≫ h₂.p := by cat_disch
   /-- commutation with `g'` -/
-  commg' : φQ ≫ h₂.g' = h₁.g' ≫ φ.τ₃ := by aesop_cat
+  commg' : φQ ≫ h₂.g' = h₁.g' ≫ φ.τ₃ := by cat_disch
   /-- commutation with `ι` -/
-  commι : φH ≫ h₂.ι = h₁.ι ≫ φQ := by aesop_cat
+  commι : φH ≫ h₂.ι = h₁.ι ≫ φQ := by cat_disch
 
 namespace RightHomologyMapData
 

--- a/Mathlib/Algebra/Homology/ShortComplex/SnakeLemma.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/SnakeLemma.lean
@@ -492,7 +492,7 @@ noncomputable def functorP : SnakeInput C ⥤ C where
   map f := pullback.map _ _ _ _ f.f₁.τ₂ f.f₀.τ₃ f.f₁.τ₃ f.f₁.comm₂₃.symm
       (congr_arg ShortComplex.Hom.τ₃ f.comm₀₁.symm)
   map_id _ := by dsimp [P]; simp
-  map_comp _ _ := by dsimp [P]; aesop_cat
+  map_comp _ _ := by dsimp [P]; cat_disch
 
 @[reassoc]
 lemma naturality_φ₂ (f : S₁ ⟶ S₂) : S₁.φ₂ ≫ f.f₂.τ₂ = functorP.map f ≫ S₂.φ₂ := by

--- a/Mathlib/Algebra/Homology/ShortComplex/SnakeLemma.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/SnakeLemma.lean
@@ -72,8 +72,8 @@ structure SnakeInput where
   v₁₂ : L₁ ⟶ L₂
   /-- the morphism from the second row to the third row -/
   v₂₃ : L₂ ⟶ L₃
-  w₀₂ : v₀₁ ≫ v₁₂ = 0 := by aesop_cat
-  w₁₃ : v₁₂ ≫ v₂₃ = 0 := by aesop_cat
+  w₀₂ : v₀₁ ≫ v₁₂ = 0 := by cat_disch
+  w₁₃ : v₁₂ ≫ v₂₃ = 0 := by cat_disch
   /-- `L₀` is the kernel of `v₁₂ : L₁ ⟶ L₂`. -/
   h₀ : IsLimit (KernelFork.ofι _ w₀₂)
   /-- `L₃` is the cokernel of `v₁₂ : L₁ ⟶ L₂`. -/
@@ -406,9 +406,9 @@ structure Hom where
   f₂ : S₁.L₂ ⟶ S₂.L₂
   /-- a morphism between the third lines -/
   f₃ : S₁.L₃ ⟶ S₂.L₃
-  comm₀₁ : f₀ ≫ S₂.v₀₁ = S₁.v₀₁ ≫ f₁ := by aesop_cat
-  comm₁₂ : f₁ ≫ S₂.v₁₂ = S₁.v₁₂ ≫ f₂ := by aesop_cat
-  comm₂₃ : f₂ ≫ S₂.v₂₃ = S₁.v₂₃ ≫ f₃ := by aesop_cat
+  comm₀₁ : f₀ ≫ S₂.v₀₁ = S₁.v₀₁ ≫ f₁ := by cat_disch
+  comm₁₂ : f₁ ≫ S₂.v₁₂ = S₁.v₁₂ ≫ f₂ := by cat_disch
+  comm₂₃ : f₂ ≫ S₂.v₂₃ = S₁.v₂₃ ≫ f₃ := by cat_disch
 
 namespace Hom
 

--- a/Mathlib/Algebra/Homology/Single.lean
+++ b/Mathlib/Algebra/Homology/Single.lean
@@ -220,7 +220,7 @@ noncomputable def toSingle₀Equiv (C : ChainComplex V ℕ) (X : V) :
   invFun f := HomologicalComplex.mkHomToSingle f.1 (fun i hi => by
     obtain rfl : i = 1 := by simpa using hi.symm
     exact f.2)
-  left_inv φ := by aesop_cat
+  left_inv φ := by cat_disch
   right_inv f := by simp
 
 @[simp]
@@ -237,8 +237,8 @@ noncomputable def fromSingle₀Equiv (C : ChainComplex V ℕ) (X : V) :
     ((single₀ V).obj X ⟶ C) ≃ (X ⟶ C.X 0) where
   toFun f := f.f 0
   invFun f := HomologicalComplex.mkHomFromSingle f (fun i hi => by simp at hi)
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
+  left_inv := by cat_disch
+  right_inv := by cat_disch
 
 @[simp]
 lemma fromSingle₀Equiv_symm_apply_f_zero
@@ -286,8 +286,8 @@ noncomputable def fromSingle₀Equiv (C : CochainComplex V ℕ) (X : V) :
   invFun f := HomologicalComplex.mkHomFromSingle f.1 (fun i hi => by
     obtain rfl : i = 1 := by simpa using hi.symm
     exact f.2)
-  left_inv φ := by aesop_cat
-  right_inv := by aesop_cat
+  left_inv φ := by cat_disch
+  right_inv := by cat_disch
 
 @[simp]
 lemma fromSingle₀Equiv_symm_apply_f_zero {C : CochainComplex V ℕ} {X : V}
@@ -303,8 +303,8 @@ noncomputable def toSingle₀Equiv (C : CochainComplex V ℕ) (X : V) :
     (C ⟶ (single₀ V).obj X) ≃ (C.X 0 ⟶ X) where
   toFun f := f.f 0
   invFun f := HomologicalComplex.mkHomToSingle f (fun i hi => by simp at hi)
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
+  left_inv := by cat_disch
+  right_inv := by cat_disch
 
 @[simp]
 lemma toSingle₀Equiv_symm_apply_f_zero

--- a/Mathlib/Algebra/Homology/TotalComplex.lean
+++ b/Mathlib/Algebra/Homology/TotalComplex.lean
@@ -376,13 +376,13 @@ lemma d₂_mapMap (i₁ : I₁) (i₂ : I₂) (i₁₂ : I₁₂) :
 lemma mapMap_D₁ (i₁₂ i₁₂' : I₁₂) :
     GradedObject.mapMap (toGradedObjectMap φ) _ i₁₂ ≫ L.D₁ c₁₂ i₁₂ i₁₂' =
       K.D₁ c₁₂ i₁₂ i₁₂' ≫ GradedObject.mapMap (toGradedObjectMap φ) _ i₁₂' := by
-  aesop_cat
+  cat_disch
 
 @[reassoc]
 lemma mapMap_D₂ (i₁₂ i₁₂' : I₁₂) :
     GradedObject.mapMap (toGradedObjectMap φ) _ i₁₂ ≫ L.D₂ c₁₂ i₁₂ i₁₂' =
       K.D₂ c₁₂ i₁₂ i₁₂' ≫ GradedObject.mapMap (toGradedObjectMap φ) _ i₁₂' := by
-  aesop_cat
+  cat_disch
 
 end mapAux
 

--- a/Mathlib/AlgebraicGeometry/Cover/MorphismProperty.lean
+++ b/Mathlib/AlgebraicGeometry/Cover/MorphismProperty.lean
@@ -348,7 +348,7 @@ structure Cover.Hom {X : Scheme.{u}} (𝒰 𝒱 : Cover.{v} P X) where
   /-- The morphism between open subsets associated to a morphism of covers. -/
   app (j : 𝒰.J) : 𝒰.obj j ⟶ 𝒱.obj (idx j)
   app_prop (j : 𝒰.J) : P (app j) := by infer_instance
-  w (j : 𝒰.J) : app j ≫ 𝒱.map _ = 𝒰.map _ := by aesop_cat
+  w (j : 𝒰.J) : app j ≫ 𝒱.map _ = 𝒰.map _ := by cat_disch
 
 attribute [reassoc (attr := simp)] Cover.Hom.w
 

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/StructureSheaf.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/StructureSheaf.lean
@@ -182,7 +182,7 @@ def structurePresheafInCommRing : Presheaf CommRingCat (ProjectiveSpectrum.top �
 valued structure presheaf. -/
 def structurePresheafCompForget :
     structurePresheafInCommRing 𝒜 ⋙ forget CommRingCat ≅ (structureSheafInType 𝒜).1 :=
-  NatIso.ofComponents (fun _ => Iso.refl _) (by aesop_cat)
+  NatIso.ofComponents (fun _ => Iso.refl _) (by cat_disch)
 
 end ProjectiveSpectrum.StructureSheaf
 

--- a/Mathlib/AlgebraicGeometry/Scheme.lean
+++ b/Mathlib/AlgebraicGeometry/Scheme.lean
@@ -410,7 +410,7 @@ def Hom.copyBase {X Y : Scheme} (f : X.Hom Y) (g : X → Y) (h : f.base = g) : X
   prop x := by
     subst h
     convert f.prop x using 4
-    aesop_cat
+    cat_disch
 
 lemma Hom.copyBase_eq {X Y : Scheme} (f : X.Hom Y) (g : X → Y) (h : f.base = g) :
     f.copyBase g h = f := by
@@ -418,7 +418,7 @@ lemma Hom.copyBase_eq {X Y : Scheme} (f : X.Hom Y) (g : X → Y) (h : f.base = g
   obtain ⟨⟨⟨f₁, f₂⟩, f₃⟩, f₄⟩ := f
   simp only [Hom.copyBase, LocallyRingedSpace.Hom.toShHom_mk]
   congr
-  aesop_cat
+  cat_disch
 
 end Scheme
 

--- a/Mathlib/AlgebraicGeometry/Sites/Representability.lean
+++ b/Mathlib/AlgebraicGeometry/Sites/Representability.lean
@@ -126,7 +126,7 @@ instance [Presheaf.IsLocallySurjective Scheme.zariskiTopology (Sigma.desc f)] :
     Sheaf.IsLocallySurjective (yonedaGluedToSheaf hf) :=
   Presheaf.isLocallySurjective_of_isLocallySurjective_fac _
     (show Sigma.desc (fun i ↦ yoneda.map (toGlued hf i)) ≫
-      (yonedaGluedToSheaf hf).val = Sigma.desc f by aesop_cat)
+      (yonedaGluedToSheaf hf).val = Sigma.desc f by cat_disch)
 
 lemma comp_toGlued_eq {U : Scheme} {i j : ι} (a : U ⟶ X i) (b : U ⟶ X j)
     (h : yoneda.map a ≫ f i = yoneda.map b ≫ f j) :

--- a/Mathlib/AlgebraicTopology/CechNerve.lean
+++ b/Mathlib/AlgebraicTopology/CechNerve.lean
@@ -147,14 +147,14 @@ def cechNerveEquiv (X : SimplicialObject.Augmented C) (F : Arrow C) :
 abbrev cechNerveAdjunction : (Augmented.toArrow : _ ⥤ Arrow C) ⊣ augmentedCechNerve :=
   Adjunction.mkOfHomEquiv
     { homEquiv := cechNerveEquiv
-      homEquiv_naturality_left_symm := by dsimp [cechNerveEquiv]; aesop_cat
+      homEquiv_naturality_left_symm := by dsimp [cechNerveEquiv]; cat_disch
       homEquiv_naturality_right := by
         dsimp [cechNerveEquiv]
         -- The next three lines were not needed before https://github.com/leanprover/lean4/pull/2644
         intro X Y Y' f g
         change equivalenceLeftToRight X Y' (f ≫ g) =
           equivalenceLeftToRight X Y f ≫ augmentedCechNerve.map g
-        aesop_cat
+        cat_disch
     }
 
 end SimplicialObject

--- a/Mathlib/AlgebraicTopology/DoldKan/Normalized.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Normalized.lean
@@ -67,7 +67,7 @@ def PInftyToNormalizedMooreComplex (X : SimplicialObject A) : K[X] ⟶ N[X] :=
 
 @[reassoc (attr := simp)]
 theorem PInftyToNormalizedMooreComplex_comp_inclusionOfMooreComplexMap (X : SimplicialObject A) :
-    PInftyToNormalizedMooreComplex X ≫ inclusionOfMooreComplexMap X = PInfty := by aesop_cat
+    PInftyToNormalizedMooreComplex X ≫ inclusionOfMooreComplexMap X = PInfty := by cat_disch
 
 @[reassoc (attr := simp)]
 theorem PInftyToNormalizedMooreComplex_naturality {X Y : SimplicialObject A} (f : X ⟶ Y) :
@@ -77,7 +77,7 @@ theorem PInftyToNormalizedMooreComplex_naturality {X Y : SimplicialObject A} (f 
 
 @[reassoc (attr := simp)]
 theorem PInfty_comp_PInftyToNormalizedMooreComplex (X : SimplicialObject A) :
-    PInfty ≫ PInftyToNormalizedMooreComplex X = PInftyToNormalizedMooreComplex X := by aesop_cat
+    PInfty ≫ PInftyToNormalizedMooreComplex X = PInftyToNormalizedMooreComplex X := by cat_disch
 
 @[reassoc (attr := simp)]
 theorem inclusionOfMooreComplexMap_comp_PInfty (X : SimplicialObject A) :

--- a/Mathlib/AlgebraicTopology/DoldKan/Normalized.lean
+++ b/Mathlib/AlgebraicTopology/DoldKan/Normalized.lean
@@ -73,7 +73,7 @@ theorem PInftyToNormalizedMooreComplex_comp_inclusionOfMooreComplexMap (X : Simp
 theorem PInftyToNormalizedMooreComplex_naturality {X Y : SimplicialObject A} (f : X ⟶ Y) :
     AlternatingFaceMapComplex.map f ≫ PInftyToNormalizedMooreComplex Y =
       PInftyToNormalizedMooreComplex X ≫ NormalizedMooreComplex.map f := by
-  aesop_cat
+  cat_disch
 
 @[reassoc (attr := simp)]
 theorem PInfty_comp_PInftyToNormalizedMooreComplex (X : SimplicialObject A) :

--- a/Mathlib/AlgebraicTopology/ExtraDegeneracy.lean
+++ b/Mathlib/AlgebraicTopology/ExtraDegeneracy.lean
@@ -62,13 +62,13 @@ structure ExtraDegeneracy (X : SimplicialObject.Augmented C) where
   s' : point.obj X ⟶ drop.obj X _⦋0⦌
   /-- the extra degeneracy -/
   s : ∀ n : ℕ, drop.obj X _⦋n⦌ ⟶ drop.obj X _⦋n + 1⦌
-  s'_comp_ε : s' ≫ X.hom.app (op ⦋0⦌) = 𝟙 _ := by aesop_cat
-  s₀_comp_δ₁ : s 0 ≫ X.left.δ 1 = X.hom.app (op ⦋0⦌) ≫ s' := by aesop_cat
-  s_comp_δ₀ : ∀ n : ℕ, s n ≫ X.left.δ 0 = 𝟙 _ := by aesop_cat
+  s'_comp_ε : s' ≫ X.hom.app (op ⦋0⦌) = 𝟙 _ := by cat_disch
+  s₀_comp_δ₁ : s 0 ≫ X.left.δ 1 = X.hom.app (op ⦋0⦌) ≫ s' := by cat_disch
+  s_comp_δ₀ : ∀ n : ℕ, s n ≫ X.left.δ 0 = 𝟙 _ := by cat_disch
   s_comp_δ :
-    ∀ (n : ℕ) (i : Fin (n + 2)), s (n + 1) ≫ X.left.δ i.succ = X.left.δ i ≫ s n := by aesop_cat
+    ∀ (n : ℕ) (i : Fin (n + 2)), s (n + 1) ≫ X.left.δ i.succ = X.left.δ i ≫ s n := by cat_disch
   s_comp_σ :
-    ∀ (n : ℕ) (i : Fin (n + 1)), s n ≫ X.left.σ i.succ = X.left.σ i ≫ s (n + 1) := by aesop_cat
+    ∀ (n : ℕ) (i : Fin (n + 1)), s n ≫ X.left.σ i.succ = X.left.σ i ≫ s (n + 1) := by cat_disch
 
 namespace ExtraDegeneracy
 

--- a/Mathlib/AlgebraicTopology/ModelCategory/Cylinder.lean
+++ b/Mathlib/AlgebraicTopology/ModelCategory/Cylinder.lean
@@ -52,8 +52,8 @@ structure Precylinder (A : C) where
   i₁ : A ⟶ I
   /-- the codiagonal of the (pre)cylinder -/
   π : I ⟶ A
-  i₀_π : i₀ ≫ π = 𝟙 A := by aesop_cat
-  i₁_π : i₁ ≫ π = 𝟙 A := by aesop_cat
+  i₀_π : i₀ ≫ π = 𝟙 A := by cat_disch
+  i₁_π : i₁ ≫ π = 𝟙 A := by cat_disch
 
 namespace Precylinder
 
@@ -96,7 +96,7 @@ lemma inr_i : coprod.inr ≫ P.i = P.i₁ := by simp [i]
 end
 
 @[simp, reassoc]
-lemma symm_i [HasBinaryCoproducts C] : P.symm.i = (coprod.braiding A A).hom ≫ P.i := by aesop_cat
+lemma symm_i [HasBinaryCoproducts C] : P.symm.i = (coprod.braiding A A).hom ≫ P.i := by cat_disch
 
 end Precylinder
 
@@ -210,7 +210,7 @@ noncomputable def ofFactorizationData : Cylinder A where
   π := h.p
 
 @[simp]
-lemma ofFactorizationData_i : (ofFactorizationData h).i = h.i := by aesop_cat
+lemma ofFactorizationData_i : (ofFactorizationData h).i = h.i := by cat_disch
 
 instance : (ofFactorizationData h).IsVeryGood where
   cofibration_i := by simpa using inferInstanceAs (Cofibration h.i)

--- a/Mathlib/AlgebraicTopology/MooreComplex.lean
+++ b/Mathlib/AlgebraicTopology/MooreComplex.lean
@@ -129,7 +129,7 @@ def map (f : X ⟶ Y) : obj X ⟶ obj Y :=
         erw [kernelSubobject_arrow_comp_assoc]
         rw [zero_comp, comp_zero]))
     fun n => by
-    cases n <;> dsimp [objD, objX] <;> aesop_cat
+    cases n <;> dsimp [objD, objX] <;> cat_disch
 
 end NormalizedMooreComplex
 

--- a/Mathlib/AlgebraicTopology/RelativeCellComplex/AttachCells.lean
+++ b/Mathlib/AlgebraicTopology/RelativeCellComplex/AttachCells.lean
@@ -54,7 +54,7 @@ structure AttachCells where
   isColimit₂ : IsColimit cofan₂
   /-- the coproduct of the maps `g (π i) : A (π i) ⟶ B (π i)` for all `i : ι`. -/
   m : cofan₁.pt ⟶ cofan₂.pt
-  hm (i : ι) : cofan₁.inj i ≫ m = g (π i) ≫ cofan₂.inj i := by aesop_cat
+  hm (i : ι) : cofan₁.inj i ≫ m = g (π i) ≫ cofan₂.inj i := by cat_disch
   /-- the top morphism of the pushout square -/
   g₁ : cofan₁.pt ⟶ X₁
   /-- the bottom morphism of the pushout square -/

--- a/Mathlib/AlgebraicTopology/SimplicialNerve.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialNerve.lean
@@ -182,17 +182,17 @@ noncomputable def functor {J K : Type u} [LinearOrder J] [LinearOrder K]
   map_id i := by
     ext
     simp only [eId, EnrichedCategory.id]
-    exact Functor.ext (by aesop_cat)
+    exact Functor.ext (by cat_disch)
   map_comp i j k := by
     ext
     simp only [eComp, EnrichedCategory.comp]
-    exact Functor.ext (by aesop_cat)
+    exact Functor.ext (by cat_disch)
 
 lemma functor_id (J : Type u) [LinearOrder J] :
     (functor (OrderHom.id (α := J))) = EnrichedFunctor.id _ _ := by
   refine EnrichedFunctor.ext _ (fun _ ↦ rfl) fun i j ↦ ?_
   ext
-  exact Functor.ext (by aesop_cat)
+  exact Functor.ext (by cat_disch)
 
 lemma functor_comp {J K L : Type u} [LinearOrder J] [LinearOrder K]
     [LinearOrder L] (f : J →o K) (g : K →o L) :
@@ -200,7 +200,7 @@ lemma functor_comp {J K L : Type u} [LinearOrder J] [LinearOrder K]
       (functor f).comp _ (functor g) := by
   refine EnrichedFunctor.ext _ (fun _ ↦ rfl) fun i j ↦ ?_
   ext
-  exact Functor.ext (by aesop_cat)
+  exact Functor.ext (by cat_disch)
 
 end SimplicialThickening
 

--- a/Mathlib/AlgebraicTopology/SimplicialObject/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialObject/Basic.lean
@@ -957,7 +957,7 @@ def simplicialCosimplicialAugmentedEquiv :
       rw [← f.op_unop]
       simp_rw [← op_comp]
       congr 1
-      aesop_cat
+      cat_disch
   counitIso := NatIso.ofComponents fun X => X.leftOpRightOpIso
 
 end CategoryTheory

--- a/Mathlib/AlgebraicTopology/SimplicialObject/Split.lean
+++ b/Mathlib/AlgebraicTopology/SimplicialObject/Split.lean
@@ -311,7 +311,7 @@ structure Hom (S₁ S₂ : Split C) where
   F : S₁.X ⟶ S₂.X
   /-- the morphism between the "nondegenerate" `n`-simplices for all `n : ℕ` -/
   f : ∀ n : ℕ, S₁.s.N n ⟶ S₂.s.N n
-  comm : ∀ n : ℕ, S₁.s.ι n ≫ F.app (op ⦋n⦌) = f n ≫ S₂.s.ι n := by aesop_cat
+  comm : ∀ n : ℕ, S₁.s.ι n ≫ F.app (op ⦋n⦌) = f n ≫ S₂.s.ι n := by cat_disch
 
 @[ext]
 theorem Hom.ext {S₁ S₂ : Split C} (Φ₁ Φ₂ : Hom S₁ S₂) (h : ∀ n : ℕ, Φ₁.f n = Φ₂.f n) : Φ₁ = Φ₂ := by

--- a/Mathlib/CategoryTheory/Abelian/CommSq.lean
+++ b/Mathlib/CategoryTheory/Abelian/CommSq.lean
@@ -57,7 +57,7 @@ lemma hom_eq_add_up_to_refinements (h : IsPushout t l r b) {T : C} (x₄ : T ⟶
   refine ⟨T', π, inferInstance, u ≫ biprod.fst, u ≫ biprod.snd, ?_⟩
   simp only [hu, assoc, ← Preadditive.comp_add]
   congr
-  aesop_cat
+  cat_disch
 
 /--
 Given a commutative diagram in an abelian category

--- a/Mathlib/CategoryTheory/Abelian/Ext.lean
+++ b/Mathlib/CategoryTheory/Abelian/Ext.lean
@@ -41,7 +41,7 @@ def Ext (n : ℕ) : Cᵒᵖ ⥤ C ⥤ ModuleCat R :=
     { obj := fun Y => (((linearYoneda R C).obj Y).rightOp.leftDerived n).leftOp
       -- Porting note: if we use dot notation for any of
       -- `NatTrans.leftOp` / `NatTrans.rightOp` / `NatTrans.leftDerived`
-      -- then `aesop_cat` can not discharge the `map_id` and `map_comp` goals.
+      -- then `cat_disch` can not discharge the `map_id` and `map_comp` goals.
       -- This should be investigated further.
       map := fun f =>
         NatTrans.leftOp (NatTrans.leftDerived (NatTrans.rightOp ((linearYoneda R C).map f)) n) }

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckAxioms/Colim.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckAxioms/Colim.lean
@@ -80,7 +80,7 @@ lemma IsColimit.mono_ι_app_of_isFiltered
         simp only [Category.id_comp, ← X.map_comp, Under.w] }
   have := NatTrans.mono_of_mono_app f
   exact colim.map_mono' f (isColimitConstCocone _ _)
-    ((Functor.Final.isColimitWhiskerEquiv _ _).symm hc) (c.ι.app j₀) (by aesop_cat)
+    ((Functor.Final.isColimitWhiskerEquiv _ _).symm hc) (c.ι.app j₀) (by cat_disch)
 
 section
 

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/ModuleEmbedding/GabrielPopescu.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/ModuleEmbedding/GabrielPopescu.lean
@@ -131,7 +131,7 @@ theorem GabrielPopescu.preservesInjectiveObjects (G : C) (hG : IsSeparator G) :
       intro f hf
       simpa [d] using Sigma.ι _ ⟨f, hf⟩ ≫= hl
     · rw [ModuleCat.mono_iff_injective]
-      aesop_cat
+      cat_disch
 
 /-- Right exactness follows because `tensorObj G` is a left adjoint. -/
 theorem GabrielPopescu.preservesFiniteLimits (G : C) (hG : IsSeparator G) :

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/ModuleEmbedding/GabrielPopescu.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/ModuleEmbedding/GabrielPopescu.lean
@@ -124,7 +124,7 @@ theorem GabrielPopescu.preservesInjectiveObjects (G : C) (hG : IsSeparator G) :
       preadditiveCoyonedaObj_obj_isModule]
     refine Module.Baer.injective (fun M g => ?_)
     have h := exists_d_comp_eq_d hG B (ModuleCat.ofHom
-      ⟨⟨fun i => i.1.unop, by aesop_cat⟩, by aesop_cat⟩) ?_ (ModuleCat.ofHom g)
+      ⟨⟨fun i => i.1.unop, by cat_disch⟩, by cat_disch⟩) ?_ (ModuleCat.ofHom g)
     · obtain ⟨l, hl⟩ := h
       refine ⟨((preadditiveCoyonedaObj G).map l).hom ∘ₗ
         (Preadditive.homSelfLinearEquivEndMulOpposite G).symm.toLinearMap, ?_⟩

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/Monomorphisms.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/Monomorphisms.lean
@@ -73,7 +73,7 @@ lemma mono : Mono f := by
         rw [Category.id_comp, Category.assoc, ← Functor.map_comp]
         rfl }
   have : Mono φ := NatTrans.mono_of_mono_app φ
-  exact colim.map_mono' φ (isColimitConstCocone J X) (h.isColimit) f (by aesop_cat)
+  exact colim.map_mono' φ (isColimitConstCocone J X) (h.isColimit) f (by cat_disch)
 
 instance mono_map (j j' : J) (f : j ⟶ j') : Mono (h.F.map f) :=
   ((h.ici j).iic ⟨j', leOfHom f⟩).mono

--- a/Mathlib/CategoryTheory/Abelian/Images.lean
+++ b/Mathlib/CategoryTheory/Abelian/Images.lean
@@ -122,6 +122,6 @@ def coimageImageComparisonFunctor : Arrow C ⥤ Arrow C where
   obj f := Arrow.mk (coimageImageComparison f.hom)
   map {f g} η := Arrow.homMk
     (cokernel.map _ _ (kernel.map _ _ η.left η.right (by simp)) η.left (by simp))
-    (kernel.map _ _ η.right (cokernel.map _ _ η.left η.right (by simp)) (by simp)) (by aesop_cat)
+    (kernel.map _ _ η.right (cokernel.map _ _ η.left η.right (by simp)) (by simp)) (by cat_disch)
 
 end CategoryTheory.Abelian

--- a/Mathlib/CategoryTheory/Abelian/Projective/Resolution.lean
+++ b/Mathlib/CategoryTheory/Abelian/Projective/Resolution.lean
@@ -237,7 +237,7 @@ lemma ProjectiveResolution.iso_inv_naturality {X Y : C} (f : X ⟶ Y)
   apply HomotopyCategory.eq_of_homotopy
   apply liftHomotopy f
   all_goals
-    aesop_cat
+    cat_disch
 
 @[reassoc]
 lemma ProjectiveResolution.iso_hom_naturality {X Y : C} (f : X ⟶ Y)

--- a/Mathlib/CategoryTheory/Abelian/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Abelian/Yoneda.lean
@@ -44,7 +44,7 @@ theorem preadditiveCoyonedaObj_map_surjective {G : C} [Projective G] (hG : IsSep
   · simp only [ShortComplex.map_f]
     infer_instance
   · suffices φ.map.Surjective by simpa [AddCommGrp.epi_iff_surjective, Functor.coe_mapAddHom]
-    exact fun f => ⟨f (𝟙 G), by aesop_cat⟩
+    exact fun f => ⟨f (𝟙 G), by cat_disch⟩
   · simp [AddCommGrp.mono_iff_injective, Functor.coe_mapAddHom, Functor.map_injective]
 
 end

--- a/Mathlib/CategoryTheory/Action/Basic.lean
+++ b/Mathlib/CategoryTheory/Action/Basic.lean
@@ -85,7 +85,7 @@ commuting with the action of `G`.
 structure Hom (M N : Action V G) where
   /-- The morphism between the underlying objects of this action -/
   hom : M.V ⟶ N.V
-  comm : ∀ g : G, M.ρ g ≫ hom = hom ≫ N.ρ g := by aesop_cat
+  comm : ∀ g : G, M.ρ g ≫ hom = hom ≫ N.ρ g := by cat_disch
 
 namespace Hom
 
@@ -140,7 +140,7 @@ from an isomorphism of the underlying objects,
 where the forward direction commutes with the group action. -/
 @[simps]
 def mkIso {M N : Action V G} (f : M.V ≅ N.V)
-    (comm : ∀ g : G, M.ρ g ≫ f.hom = f.hom ≫ N.ρ g := by aesop_cat) : M ≅ N where
+    (comm : ∀ g : G, M.ρ g ≫ f.hom = f.hom ≫ N.ρ g := by cat_disch) : M ≅ N where
   hom :=
     { hom := f.hom
       comm := comm }

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -330,12 +330,12 @@ structure CoreHomEquiv (F : C ⥤ D) (G : D ⥤ C) where
   homEquiv_naturality_left_symm :
     ∀ {X' X Y} (f : X' ⟶ X) (g : X ⟶ G.obj Y),
       (homEquiv X' Y).symm (f ≫ g) = F.map f ≫ (homEquiv X Y).symm g := by
-    aesop_cat
+    cat_disch
   /-- The property that describes how `homEquiv` transforms compositions `F X ⟶ Y ⟶ Y'` -/
   homEquiv_naturality_right :
     ∀ {X Y Y'} (f : F.obj X ⟶ Y) (g : Y ⟶ Y'),
       (homEquiv X Y') (f ≫ g) = (homEquiv X Y) f ≫ G.map g := by
-    aesop_cat
+    cat_disch
 
 namespace CoreHomEquiv
 
@@ -367,13 +367,13 @@ structure CoreUnitCounit (F : C ⥤ D) (G : D ⥤ C) where
   left_triangle :
     whiskerRight unit F ≫ (associator F G F).hom ≫ whiskerLeft F counit =
       NatTrans.id (𝟭 C ⋙ F) := by
-    aesop_cat
+    cat_disch
   /-- Equality of the composition of the unit, associator, and counit with the identity
   `G ⟶ G (F G) ⟶ (F G) F ⟶ G = NatTrans.id G` -/
   right_triangle :
     whiskerLeft G unit ≫ (associator G F G).inv ≫ whiskerRight counit G =
       NatTrans.id (G ⋙ 𝟭 C) := by
-    aesop_cat
+    cat_disch
 
 namespace CoreUnitCounit
 

--- a/Mathlib/CategoryTheory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Basic.lean
@@ -103,10 +103,10 @@ structure Adjunction (F : C ⥤ D) (G : D ⥤ C) where
   counit : G.comp F ⟶ 𝟭 D
   /-- Equality of the composition of the unit and counit with the identity `F ⟶ FGF ⟶ F = 𝟙` -/
   left_triangle_components (X : C) :
-      F.map (unit.app X) ≫ counit.app (F.obj X) = 𝟙 (F.obj X) := by aesop_cat
+      F.map (unit.app X) ≫ counit.app (F.obj X) = 𝟙 (F.obj X) := by cat_disch
   /-- Equality of the composition of the unit and counit with the identity `G ⟶ GFG ⟶ G = 𝟙` -/
   right_triangle_components (Y : D) :
-      unit.app (G.obj Y) ≫ G.map (counit.app Y) = 𝟙 (G.obj Y) := by aesop_cat
+      unit.app (G.obj Y) ≫ G.map (counit.app Y) = 𝟙 (G.obj Y) := by cat_disch
 
 /-- The notation `F ⊣ G` stands for `Adjunction F G` representing that `F` is left adjoint to `G` -/
 infixl:15 " ⊣ " => Adjunction
@@ -315,9 +315,9 @@ structure CoreHomEquivUnitCounit (F : C ⥤ D) (G : D ⥤ C) where
   /-- The counit of an adjunction -/
   counit : G ⋙ F ⟶ 𝟭 D
   /-- The relationship between the unit and hom set equivalence of an adjunction -/
-  homEquiv_unit : ∀ {X Y f}, (homEquiv X Y) f = unit.app X ≫ G.map f := by aesop_cat
+  homEquiv_unit : ∀ {X Y f}, (homEquiv X Y) f = unit.app X ≫ G.map f := by cat_disch
   /-- The relationship between the counit and hom set equivalence of an adjunction -/
-  homEquiv_counit : ∀ {X Y g}, (homEquiv X Y).symm g = F.map g ≫ counit.app Y := by aesop_cat
+  homEquiv_counit : ∀ {X Y g}, (homEquiv X Y).symm g = F.map g ≫ counit.app Y := by cat_disch
 
 /-- This is an auxiliary data structure useful for constructing adjunctions.
 See `Adjunction.mkOfHomEquiv`.

--- a/Mathlib/CategoryTheory/Adjunction/Comma.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Comma.lean
@@ -48,7 +48,7 @@ def leftAdjointOfStructuredArrowInitialsAux (A : C) (B : D) :
   left_inv g := by
     let B' : StructuredArrow A G := StructuredArrow.mk ((⊥_ StructuredArrow A G).hom ≫ G.map g)
     let g' : ⊥_ StructuredArrow A G ⟶ B' := StructuredArrow.homMk g rfl
-    have : initial.to _ = g' := by aesop_cat
+    have : initial.to _ = g' := by cat_disch
     change CommaMorphism.right (initial.to B') = _
     rw [this]
     rfl
@@ -89,12 +89,12 @@ def rightAdjointOfCostructuredArrowTerminalsAux (B : D) (A : C) :
     (G.obj B ⟶ A) ≃ (B ⟶ (⊤_ CostructuredArrow G A).left) where
   toFun g := CommaMorphism.left (terminal.from (CostructuredArrow.mk g))
   invFun g := G.map g ≫ (⊤_ CostructuredArrow G A).hom
-  left_inv := by aesop_cat
+  left_inv := by cat_disch
   right_inv g := by
     let B' : CostructuredArrow G A :=
       CostructuredArrow.mk (G.map g ≫ (⊤_ CostructuredArrow G A).hom)
     let g' : B' ⟶ ⊤_ CostructuredArrow G A := CostructuredArrow.homMk g rfl
-    have : terminal.from _ = g' := by aesop_cat
+    have : terminal.from _ = g' := by cat_disch
     change CommaMorphism.left (terminal.from B') = _
     rw [this]
     rfl

--- a/Mathlib/CategoryTheory/Adjunction/Lifting/Left.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Lifting/Left.lean
@@ -163,8 +163,8 @@ noncomputable def constructLeftAdjoint [∀ X : B, RegularEpi (adj₁.counit.app
   erw [Cofork.IsColimit.homIso_natural, Cofork.IsColimit.homIso_natural]
   erw [adj₂.homEquiv_naturality_right]
   simp_rw [Functor.comp_map]
-  -- This used to be `simp`, but we need `aesop_cat` after https://github.com/leanprover/lean4/pull/2644
-  aesop_cat
+  -- This used to be `simp`, but we need `cat_disch` after https://github.com/leanprover/lean4/pull/2644
+  cat_disch
 
 end LiftLeftAdjoint
 

--- a/Mathlib/CategoryTheory/Adjunction/Mates.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Mates.lean
@@ -419,8 +419,8 @@ def conjugateIsoEquiv : (L₂ ≅ L₁) ≃ (R₁ ≅ R₂) where
     hom := (conjugateEquiv adj₁ adj₂).symm β.hom
     inv := (conjugateEquiv adj₂ adj₁).symm β.inv
   }
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
+  left_inv := by cat_disch
+  right_inv := by cat_disch
 
 end ConjugateIsomorphism
 

--- a/Mathlib/CategoryTheory/Adjunction/Parametrized.lean
+++ b/Mathlib/CategoryTheory/Adjunction/Parametrized.lean
@@ -52,7 +52,7 @@ structure ParametrizedAdjunction where
   adj (X₁ : C₁) : F.obj X₁ ⊣ G.obj (op X₁)
   unit_whiskerRight_map {X₁ Y₁ : C₁} (f : X₁ ⟶ Y₁) :
     (adj X₁).unit ≫ whiskerRight (F.map f) _ = (adj Y₁).unit ≫ whiskerLeft _ (G.map f.op) :=
-      by aesop_cat
+      by cat_disch
 
 /-- The notation `F ⊣₂ G` stands for `ParametrizedAdjunction F G`
 representing that the bifunctor `F` is the left adjoint to `G`
@@ -71,7 +71,7 @@ the compatibility is stated in terms of `Adjunction.homEquiv`. -/
 def mk' (adj : ∀ (X₁ : C₁), F.obj X₁ ⊣ G.obj (op X₁))
     (h : ∀ {X₁ Y₁ : C₁} (f : X₁ ⟶ Y₁) {X₂ : C₂} {X₃ : C₃} (g : (F.obj Y₁).obj X₂ ⟶ X₃),
       (adj X₁).homEquiv X₂ X₃ ((F.map f).app X₂ ≫ g) =
-        (adj Y₁).homEquiv X₂ X₃ g ≫ (G.map f.op).app X₃ := by aesop_cat) :
+        (adj Y₁).homEquiv X₂ X₃ g ≫ (G.map f.op).app X₃ := by cat_disch) :
     F ⊣₂ G where
   adj := adj
   unit_whiskerRight_map {X₁ Y₁} f := by

--- a/Mathlib/CategoryTheory/Bicategory/Adjunction/Adj.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Adjunction/Adj.lean
@@ -82,7 +82,7 @@ structure Hom₂ (α β : a ⟶ b) where
   τl : α.l ⟶ β.l
   /-- the morphism in the opposite direction between right adjoints -/
   τr : β.r ⟶ α.r
-  conjugateEquiv_τl : conjugateEquiv β.adj α.adj τl = τr := by aesop_cat
+  conjugateEquiv_τl : conjugateEquiv β.adj α.adj τl = τr := by cat_disch
 
 lemma Hom₂.conjugateEquiv_symm_τr {α β : a ⟶ b} (p : Hom₂ α β) :
     (conjugateEquiv β.adj α.adj).symm p.τr = p.τl := by

--- a/Mathlib/CategoryTheory/Bicategory/Adjunction/Basic.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Adjunction/Basic.lean
@@ -82,9 +82,9 @@ structure Adjunction (f : a ⟶ b) (g : b ⟶ a) where
   /-- The counit of an adjunction. -/
   counit : g ≫ f ⟶ 𝟙 b
   /-- The composition of the unit and the counit is equal to the identity up to unitors. -/
-  left_triangle : leftZigzag unit counit = (λ_ _).hom ≫ (ρ_ _).inv := by aesop_cat
+  left_triangle : leftZigzag unit counit = (λ_ _).hom ≫ (ρ_ _).inv := by cat_disch
   /-- The composition of the unit and the counit is equal to the identity up to unitors. -/
-  right_triangle : rightZigzag unit counit = (ρ_ _).hom ≫ (λ_ _).inv := by aesop_cat
+  right_triangle : rightZigzag unit counit = (ρ_ _).hom ≫ (λ_ _).inv := by cat_disch
 
 @[inherit_doc] scoped infixr:15 " ⊣ " => Bicategory.Adjunction
 
@@ -238,7 +238,7 @@ structure Equivalence (a b : B) where
   /-- The composition `inv ≫ hom` is isomorphic to the identity. -/
   counit : inv ≫ hom ≅ 𝟙 b
   /-- The composition of the unit and the counit is equal to the identity up to unitors. -/
-  left_triangle : leftZigzagIso unit counit = λ_ hom ≪≫ (ρ_ hom).symm := by aesop_cat
+  left_triangle : leftZigzagIso unit counit = λ_ hom ≪≫ (ρ_ hom).symm := by cat_disch
 
 @[inherit_doc] scoped infixr:10 " ≌ " => Bicategory.Equivalence
 

--- a/Mathlib/CategoryTheory/Bicategory/Basic.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Basic.lean
@@ -69,60 +69,60 @@ class Bicategory (B : Type u) extends CategoryStruct.{v} B where
   rightUnitor {a b : B} (f : a ⟶ b) : f ≫ 𝟙 b ≅ f
   -- axioms for left whiskering:
   whiskerLeft_id : ∀ {a b c} (f : a ⟶ b) (g : b ⟶ c), whiskerLeft f (𝟙 g) = 𝟙 (f ≫ g) := by
-    aesop_cat
+    cat_disch
   whiskerLeft_comp :
     ∀ {a b c} (f : a ⟶ b) {g h i : b ⟶ c} (η : g ⟶ h) (θ : h ⟶ i),
       whiskerLeft f (η ≫ θ) = whiskerLeft f η ≫ whiskerLeft f θ := by
-    aesop_cat
+    cat_disch
   id_whiskerLeft :
     ∀ {a b} {f g : a ⟶ b} (η : f ⟶ g),
       whiskerLeft (𝟙 a) η = (leftUnitor f).hom ≫ η ≫ (leftUnitor g).inv := by
-    aesop_cat
+    cat_disch
   comp_whiskerLeft :
     ∀ {a b c d} (f : a ⟶ b) (g : b ⟶ c) {h h' : c ⟶ d} (η : h ⟶ h'),
       whiskerLeft (f ≫ g) η =
         (associator f g h).hom ≫ whiskerLeft f (whiskerLeft g η) ≫ (associator f g h').inv := by
-    aesop_cat
+    cat_disch
   -- axioms for right whiskering:
   id_whiskerRight : ∀ {a b c} (f : a ⟶ b) (g : b ⟶ c), whiskerRight (𝟙 f) g = 𝟙 (f ≫ g) := by
-    aesop_cat
+    cat_disch
   comp_whiskerRight :
     ∀ {a b c} {f g h : a ⟶ b} (η : f ⟶ g) (θ : g ⟶ h) (i : b ⟶ c),
       whiskerRight (η ≫ θ) i = whiskerRight η i ≫ whiskerRight θ i := by
-    aesop_cat
+    cat_disch
   whiskerRight_id :
     ∀ {a b} {f g : a ⟶ b} (η : f ⟶ g),
       whiskerRight η (𝟙 b) = (rightUnitor f).hom ≫ η ≫ (rightUnitor g).inv := by
-    aesop_cat
+    cat_disch
   whiskerRight_comp :
     ∀ {a b c d} {f f' : a ⟶ b} (η : f ⟶ f') (g : b ⟶ c) (h : c ⟶ d),
       whiskerRight η (g ≫ h) =
         (associator f g h).inv ≫ whiskerRight (whiskerRight η g) h ≫ (associator f' g h).hom := by
-    aesop_cat
+    cat_disch
   -- associativity of whiskerings:
   whisker_assoc :
     ∀ {a b c d} (f : a ⟶ b) {g g' : b ⟶ c} (η : g ⟶ g') (h : c ⟶ d),
       whiskerRight (whiskerLeft f η) h =
         (associator f g h).hom ≫ whiskerLeft f (whiskerRight η h) ≫ (associator f g' h).inv := by
-    aesop_cat
+    cat_disch
   -- exchange law of left and right whiskerings:
   whisker_exchange :
     ∀ {a b c} {f g : a ⟶ b} {h i : b ⟶ c} (η : f ⟶ g) (θ : h ⟶ i),
       whiskerLeft f θ ≫ whiskerRight η i = whiskerRight η h ≫ whiskerLeft g θ := by
-    aesop_cat
+    cat_disch
   -- pentagon identity:
   pentagon :
     ∀ {a b c d e} (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d) (i : d ⟶ e),
       whiskerRight (associator f g h).hom i ≫
           (associator f (g ≫ h) i).hom ≫ whiskerLeft f (associator g h i).hom =
         (associator (f ≫ g) h i).hom ≫ (associator f g (h ≫ i)).hom := by
-    aesop_cat
+    cat_disch
   -- triangle identity:
   triangle :
     ∀ {a b c} (f : a ⟶ b) (g : b ⟶ c),
       (associator f (𝟙 b) g).hom ≫ whiskerLeft f (leftUnitor g).hom
       = whiskerRight (rightUnitor f).hom g := by
-    aesop_cat
+    cat_disch
 
 namespace Bicategory
 

--- a/Mathlib/CategoryTheory/Bicategory/Extension.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Extension.lean
@@ -66,7 +66,7 @@ variable {s t : LeftExtension f g}
 
 /-- To construct a morphism between left extensions, we need a 2-morphism between the extensions,
 and to check that it is compatible with the units. -/
-abbrev homMk (η : s.extension ⟶ t.extension) (w : s.unit ≫ f ◁ η = t.unit := by aesop_cat) :
+abbrev homMk (η : s.extension ⟶ t.extension) (w : s.unit ≫ f ◁ η = t.unit := by cat_disch) :
     s ⟶ t :=
   StructuredArrow.homMk η w
 
@@ -184,7 +184,7 @@ variable {s t : LeftLift f g}
 
 /-- To construct a morphism between left lifts, we need a 2-morphism between the lifts,
 and to check that it is compatible with the units. -/
-abbrev homMk (η : s.lift ⟶ t.lift) (w : s.unit ≫ η ▷ f = t.unit := by aesop_cat) :
+abbrev homMk (η : s.lift ⟶ t.lift) (w : s.unit ≫ η ▷ f = t.unit := by cat_disch) :
     s ⟶ t :=
   StructuredArrow.homMk η w
 

--- a/Mathlib/CategoryTheory/Bicategory/Free.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Free.lean
@@ -315,7 +315,7 @@ def liftHom₂ : ∀ {a b : FreeBicategory B} {f g : a ⟶ b}, Hom₂ f g → (l
 
 attribute [local simp] whisker_exchange in
 theorem liftHom₂_congr {a b : FreeBicategory B} {f g : a ⟶ b} {η θ : Hom₂ f g} (H : Rel η θ) :
-    liftHom₂ F η = liftHom₂ F θ := by induction H <;> (dsimp [liftHom₂]; aesop_cat)
+    liftHom₂ F η = liftHom₂ F θ := by induction H <;> (dsimp [liftHom₂]; cat_disch)
 
 /-- A prefunctor from a quiver `B` to a bicategory `C` can be lifted to a pseudofunctor from
 `free_bicategory B` to `C`.
@@ -338,9 +338,9 @@ def lift : Pseudofunctor (FreeBicategory B) C where
   map₂_whisker_left := by
     intro a b c f g h η
     induction η using Quot.rec
-    · aesop_cat
+    · cat_disch
     · rfl
-  map₂_whisker_right := by intro _ _ _ _ _ η h; dsimp; induction η using Quot.rec <;> aesop_cat
+  map₂_whisker_right := by intro _ _ _ _ _ η h; dsimp; induction η using Quot.rec <;> cat_disch
 
 end
 

--- a/Mathlib/CategoryTheory/Bicategory/Functor/Lax.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/Lax.lean
@@ -62,24 +62,24 @@ structure LaxFunctor (B : Type u₁) [Bicategory.{w₁, v₁} B] (C : Type u₂)
   /-- Naturality of the lax functoriality constraint, on the left. -/
   mapComp_naturality_left :
     ∀ {a b c : B} {f f' : a ⟶ b} (η : f ⟶ f') (g : b ⟶ c),
-      mapComp f g ≫ map₂ (η ▷ g) = map₂ η ▷ map g ≫ mapComp f' g:= by aesop_cat
+      mapComp f g ≫ map₂ (η ▷ g) = map₂ η ▷ map g ≫ mapComp f' g:= by cat_disch
   /-- Naturality of the lax functoriality constraint, on the right. -/
   mapComp_naturality_right :
     ∀ {a b c : B} (f : a ⟶ b) {g g' : b ⟶ c} (η : g ⟶ g'),
-     mapComp f g ≫ map₂ (f ◁ η) = map f ◁ map₂ η ≫ mapComp f g' := by aesop_cat
+     mapComp f g ≫ map₂ (f ◁ η) = map f ◁ map₂ η ≫ mapComp f g' := by cat_disch
   /-- Lax associativity. -/
   map₂_associator :
     ∀ {a b c d : B} (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d),
       mapComp f g ▷ map h ≫ mapComp (f ≫ g) h ≫ map₂ (α_ f g h).hom =
-      (α_ (map f) (map g) (map h)).hom ≫ map f ◁ mapComp g h ≫ mapComp f (g ≫ h) := by aesop_cat
+      (α_ (map f) (map g) (map h)).hom ≫ map f ◁ mapComp g h ≫ mapComp f (g ≫ h) := by cat_disch
   /-- Lax left unity. -/
   map₂_leftUnitor :
     ∀ {a b : B} (f : a ⟶ b),
-      map₂ (λ_ f).inv = (λ_ (map f)).inv ≫ mapId a ▷ map f ≫ mapComp (𝟙 a) f := by aesop_cat
+      map₂ (λ_ f).inv = (λ_ (map f)).inv ≫ mapId a ▷ map f ≫ mapComp (𝟙 a) f := by cat_disch
   /-- Lax right unity. -/
   map₂_rightUnitor :
     ∀ {a b : B} (f : a ⟶ b),
-      map₂ (ρ_ f).inv = (ρ_ (map f)).inv ≫ map f ◁ mapId b ≫ mapComp f (𝟙 b) := by aesop_cat
+      map₂ (ρ_ f).inv = (ρ_ (map f)).inv ≫ map f ◁ mapId b ≫ mapComp f (𝟙 b) := by cat_disch
 
 initialize_simps_projections LaxFunctor (+toPrelaxFunctor, -obj, -map, -map₂)
 
@@ -172,7 +172,7 @@ structure PseudoCore (F : LaxFunctor B C) where
   /-- The isomorphism giving rise to the lax functoriality constraint -/
   mapCompIso {a b c : B} (f : a ⟶ b) (g : b ⟶ c) : F.map (f ≫ g) ≅ F.map f ≫ F.map g
   /-- `mapIdIso` gives rise to the lax unity constraint -/
-  mapIdIso_inv {a : B} : (mapIdIso a).inv = F.mapId a := by aesop_cat
+  mapIdIso_inv {a : B} : (mapIdIso a).inv = F.mapId a := by cat_disch
   /-- `mapCompIso` gives rise to the lax functoriality constraint -/
   mapCompIso_inv {a b c : B} (f : a ⟶ b) (g : b ⟶ c) : (mapCompIso f g).inv = F.mapComp f g := by
     aesop_cat

--- a/Mathlib/CategoryTheory/Bicategory/Functor/Lax.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/Lax.lean
@@ -175,7 +175,7 @@ structure PseudoCore (F : LaxFunctor B C) where
   mapIdIso_inv {a : B} : (mapIdIso a).inv = F.mapId a := by cat_disch
   /-- `mapCompIso` gives rise to the lax functoriality constraint -/
   mapCompIso_inv {a b c : B} (f : a ⟶ b) (g : b ⟶ c) : (mapCompIso f g).inv = F.mapComp f g := by
-    aesop_cat
+    cat_disch
 
 attribute [simp] PseudoCore.mapIdIso_inv PseudoCore.mapCompIso_inv
 

--- a/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
@@ -45,10 +45,10 @@ def pseudofunctorOfIsLocallyDiscrete
           map f ◁ (mapComp g h).inv ≫ (mapComp f (g ≫ h)).inv = eqToHom (by simp) := by cat_disch)
     (map₂_left_unitor : ∀ {b₀ b₁ : B} (f : b₀ ⟶ b₁),
       (mapComp (𝟙 b₀) f).hom ≫ (mapId b₀).hom ▷ map f ≫ (λ_ (map f)).hom = eqToHom (by simp) := by
-        aesop_cat)
+        cat_disch)
     (map₂_right_unitor : ∀ {b₀ b₁ : B} (f : b₀ ⟶ b₁),
       (mapComp f (𝟙 b₁)).hom ≫ map f ◁ (mapId b₁).hom ≫ (ρ_ (map f)).hom = eqToHom (by simp) := by
-        aesop_cat) :
+        cat_disch) :
     Pseudofunctor B C where
   obj := obj
   map := map
@@ -76,13 +76,13 @@ def oplaxFunctorOfIsLocallyDiscrete
     (map₂_associator : ∀ {b₀ b₁ b₂ b₃ : B} (f : b₀ ⟶ b₁) (g : b₁ ⟶ b₂) (h : b₂ ⟶ b₃),
       eqToHom (by simp) ≫ mapComp f (g ≫ h) ≫ map f ◁ mapComp g h =
         mapComp (f ≫ g) h ≫ mapComp f g ▷ map h ≫ (α_ (map f) (map g) (map h)).hom := by
-          aesop_cat)
+          cat_disch)
     (map₂_left_unitor : ∀ {b₀ b₁ : B} (f : b₀ ⟶ b₁),
       mapComp (𝟙 b₀) f ≫ mapId b₀ ▷ map f ≫ (λ_ (map f)).hom = eqToHom (by simp) := by
-        aesop_cat)
+        cat_disch)
     (map₂_right_unitor : ∀ {b₀ b₁ : B} (f : b₀ ⟶ b₁),
       mapComp f (𝟙 b₁) ≫ map f ◁ mapId b₁ ≫ (ρ_ (map f)).hom = eqToHom (by simp) := by
-        aesop_cat) :
+        cat_disch) :
     OplaxFunctor B C where
   obj := obj
   map := map
@@ -167,10 +167,10 @@ def mkPseudofunctor {B₀ C : Type*} [Category B₀] [Bicategory C]
           map f ◁ (mapComp g h).inv ≫ (mapComp f (g ≫ h)).inv = eqToHom (by simp) := by cat_disch)
     (map₂_left_unitor : ∀ {b₀ b₁ : B₀} (f : b₀ ⟶ b₁),
       (mapComp (𝟙 b₀) f).hom ≫ (mapId b₀).hom ▷ map f ≫ (λ_ (map f)).hom = eqToHom (by simp) := by
-        aesop_cat)
+        cat_disch)
     (map₂_right_unitor : ∀ {b₀ b₁ : B₀} (f : b₀ ⟶ b₁),
       (mapComp f (𝟙 b₁)).hom ≫ map f ◁ (mapId b₁).hom ≫ (ρ_ (map f)).hom = eqToHom (by simp) := by
-        aesop_cat) :
+        cat_disch) :
     Pseudofunctor (LocallyDiscrete B₀) C :=
   pseudofunctorOfIsLocallyDiscrete (fun b ↦ obj b.as) (fun f ↦ map f.as)
     (fun _ ↦ mapId _) (fun _ _ ↦ mapComp _ _) (fun _ _ _ ↦ map₂_associator _ _ _)

--- a/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/LocallyDiscrete.lean
@@ -42,7 +42,7 @@ def pseudofunctorOfIsLocallyDiscrete
     (map₂_associator : ∀ {b₀ b₁ b₂ b₃ : B} (f : b₀ ⟶ b₁) (g : b₁ ⟶ b₂) (h : b₂ ⟶ b₃),
       (mapComp (f ≫ g) h).hom ≫
         (mapComp f g).hom ▷ map h ≫ (α_ (map f) (map g) (map h)).hom ≫
-          map f ◁ (mapComp g h).inv ≫ (mapComp f (g ≫ h)).inv = eqToHom (by simp) := by aesop_cat)
+          map f ◁ (mapComp g h).inv ≫ (mapComp f (g ≫ h)).inv = eqToHom (by simp) := by cat_disch)
     (map₂_left_unitor : ∀ {b₀ b₁ : B} (f : b₀ ⟶ b₁),
       (mapComp (𝟙 b₀) f).hom ≫ (mapId b₀).hom ▷ map f ≫ (λ_ (map f)).hom = eqToHom (by simp) := by
         aesop_cat)
@@ -164,7 +164,7 @@ def mkPseudofunctor {B₀ C : Type*} [Category B₀] [Bicategory C]
     (map₂_associator : ∀ {b₀ b₁ b₂ b₃ : B₀} (f : b₀ ⟶ b₁) (g : b₁ ⟶ b₂) (h : b₂ ⟶ b₃),
       (mapComp (f ≫ g) h).hom ≫
         (mapComp f g).hom ▷ map h ≫ (α_ (map f) (map g) (map h)).hom ≫
-          map f ◁ (mapComp g h).inv ≫ (mapComp f (g ≫ h)).inv = eqToHom (by simp) := by aesop_cat)
+          map f ◁ (mapComp g h).inv ≫ (mapComp f (g ≫ h)).inv = eqToHom (by simp) := by cat_disch)
     (map₂_left_unitor : ∀ {b₀ b₁ : B₀} (f : b₀ ⟶ b₁),
       (mapComp (𝟙 b₀) f).hom ≫ (mapId b₀).hom ▷ map f ≫ (λ_ (map f)).hom = eqToHom (by simp) := by
         aesop_cat)

--- a/Mathlib/CategoryTheory/Bicategory/Functor/Oplax.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/Oplax.lean
@@ -58,28 +58,28 @@ structure OplaxFunctor (B : Type u₁) [Bicategory.{w₁, v₁} B] (C : Type u�
   mapComp_naturality_left :
     ∀ {a b c : B} {f f' : a ⟶ b} (η : f ⟶ f') (g : b ⟶ c),
       map₂ (η ▷ g) ≫ mapComp f' g = mapComp f g ≫ map₂ η ▷ map g := by
-    aesop_cat
+    cat_disch
   /-- Naturality of the lax functoriality constraint, on the right. -/
   mapComp_naturality_right :
     ∀ {a b c : B} (f : a ⟶ b) {g g' : b ⟶ c} (η : g ⟶ g'),
       map₂ (f ◁ η) ≫ mapComp f g' = mapComp f g ≫ map f ◁ map₂ η := by
-    aesop_cat
+    cat_disch
   /-- Oplax associativity. -/
   map₂_associator :
     ∀ {a b c d : B} (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d),
       map₂ (α_ f g h).hom ≫ mapComp f (g ≫ h) ≫ map f ◁ mapComp g h =
       mapComp (f ≫ g) h ≫ mapComp f g ▷ map h ≫ (α_ (map f) (map g) (map h)).hom := by
-    aesop_cat
+    cat_disch
   /-- Oplax left unity. -/
   map₂_leftUnitor :
     ∀ {a b : B} (f : a ⟶ b),
       map₂ (λ_ f).hom = mapComp (𝟙 a) f ≫ mapId a ▷ map f ≫ (λ_ (map f)).hom := by
-    aesop_cat
+    cat_disch
   /-- Oplax right unity. -/
   map₂_rightUnitor :
     ∀ {a b : B} (f : a ⟶ b),
       map₂ (ρ_ f).hom = mapComp f (𝟙 b) ≫ map f ◁ mapId b ≫ (ρ_ (map f)).hom := by
-    aesop_cat
+    cat_disch
 
 initialize_simps_projections OplaxFunctor (+toPrelaxFunctor, -obj, -map, -map₂)
 

--- a/Mathlib/CategoryTheory/Bicategory/Functor/Oplax.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/Oplax.lean
@@ -174,10 +174,10 @@ structure PseudoCore (F : OplaxFunctor B C) where
   /-- The isomorphism giving rise to the oplax functoriality constraint -/
   mapCompIso {a b c : B} (f : a ⟶ b) (g : b ⟶ c) : F.map (f ≫ g) ≅ F.map f ≫ F.map g
   /-- `mapIdIso` gives rise to the oplax unity constraint -/
-  mapIdIso_hom : ∀ {a : B}, (mapIdIso a).hom = F.mapId a := by aesop_cat
+  mapIdIso_hom : ∀ {a : B}, (mapIdIso a).hom = F.mapId a := by cat_disch
   /-- `mapCompIso` gives rise to the oplax functoriality constraint -/
   mapCompIso_hom :
-    ∀ {a b c : B} (f : a ⟶ b) (g : b ⟶ c), (mapCompIso f g).hom = F.mapComp f g := by aesop_cat
+    ∀ {a b c : B} (f : a ⟶ b) (g : b ⟶ c), (mapCompIso f g).hom = F.mapComp f g := by cat_disch
 
 attribute [simp] PseudoCore.mapIdIso_hom PseudoCore.mapCompIso_hom
 

--- a/Mathlib/CategoryTheory/Bicategory/Functor/Prelax.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/Prelax.lean
@@ -102,7 +102,7 @@ structure PrelaxFunctor (B : Type u₁) [Bicategory.{w₁, v₁} B] (C : Type u�
   map₂_id : ∀ {a b : B} (f : a ⟶ b), map₂ (𝟙 f) = 𝟙 (map f) := by aesop -- TODO: why not aesop_cat?
   /-- Prelax functors preserves compositions of 2-morphisms. -/
   map₂_comp : ∀ {a b : B} {f g h : a ⟶ b} (η : f ⟶ g) (θ : g ⟶ h),
-      map₂ (η ≫ θ) = map₂ η ≫ map₂ θ := by aesop_cat
+      map₂ (η ≫ θ) = map₂ η ≫ map₂ θ := by cat_disch
 
 namespace PrelaxFunctor
 

--- a/Mathlib/CategoryTheory/Bicategory/Functor/Prelax.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/Prelax.lean
@@ -99,7 +99,7 @@ This structure will be extended to define `LaxFunctor` and `OplaxFunctor`.
 structure PrelaxFunctor (B : Type u₁) [Bicategory.{w₁, v₁} B] (C : Type u₂) [Bicategory.{w₂, v₂} C]
     extends PrelaxFunctorStruct B C where
   /-- Prelax functors preserves identity 2-morphisms. -/
-  map₂_id : ∀ {a b : B} (f : a ⟶ b), map₂ (𝟙 f) = 𝟙 (map f) := by aesop -- TODO: why not aesop_cat?
+  map₂_id : ∀ {a b : B} (f : a ⟶ b), map₂ (𝟙 f) = 𝟙 (map f) := by aesop -- TODO: why not cat_disch?
   /-- Prelax functors preserves compositions of 2-morphisms. -/
   map₂_comp : ∀ {a b : B} {f g h : a ⟶ b} (η : f ⟶ g) (θ : g ⟶ h),
       map₂ (η ≫ θ) = map₂ η ≫ map₂ θ := by cat_disch

--- a/Mathlib/CategoryTheory/Bicategory/Functor/Pseudofunctor.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/Pseudofunctor.lean
@@ -59,25 +59,25 @@ structure Pseudofunctor (B : Type u₁) [Bicategory.{w₁, v₁} B] (C : Type u�
   map₂_whisker_left :
     ∀ {a b c : B} (f : a ⟶ b) {g h : b ⟶ c} (η : g ⟶ h),
       map₂ (f ◁ η) = (mapComp f g).hom ≫ map f ◁ map₂ η ≫ (mapComp f h).inv := by
-    aesop_cat
+    cat_disch
   map₂_whisker_right :
     ∀ {a b c : B} {f g : a ⟶ b} (η : f ⟶ g) (h : b ⟶ c),
       map₂ (η ▷ h) = (mapComp f h).hom ≫ map₂ η ▷ map h ≫ (mapComp g h).inv := by
-    aesop_cat
+    cat_disch
   map₂_associator :
     ∀ {a b c d : B} (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d),
       map₂ (α_ f g h).hom = (mapComp (f ≫ g) h).hom ≫ (mapComp f g).hom ▷ map h ≫
       (α_ (map f) (map g) (map h)).hom ≫ map f ◁ (mapComp g h).inv ≫
       (mapComp f (g ≫ h)).inv := by
-    aesop_cat
+    cat_disch
   map₂_left_unitor :
     ∀ {a b : B} (f : a ⟶ b),
       map₂ (λ_ f).hom = (mapComp (𝟙 a) f).hom ≫ (mapId a).hom ▷ map f ≫ (λ_ (map f)).hom := by
-    aesop_cat
+    cat_disch
   map₂_right_unitor :
     ∀ {a b : B} (f : a ⟶ b),
       map₂ (ρ_ f).hom = (mapComp f (𝟙 b)).hom ≫ map f ◁ (mapId b).hom ≫ (ρ_ (map f)).hom := by
-    aesop_cat
+    cat_disch
 
 initialize_simps_projections Pseudofunctor (+toPrelaxFunctor, -obj, -map, -map₂)
 
@@ -146,7 +146,7 @@ def comp (F : Pseudofunctor B C) (G : Pseudofunctor C D) : Pseudofunctor B D whe
   toPrelaxFunctor := F.toPrelaxFunctor.comp G.toPrelaxFunctor
   mapId := fun a => G.map₂Iso (F.mapId a) ≪≫ G.mapId (F.obj a)
   mapComp := fun f g => (G.map₂Iso (F.mapComp f g)) ≪≫ G.mapComp (F.map f) (F.map g)
-  -- Note: whilst these are all provable by `aesop_cat`, the proof is very slow
+  -- Note: whilst these are all provable by `cat_disch`, the proof is very slow
   map₂_whisker_left f η := by simp
   map₂_whisker_right η h := by simp
   map₂_associator f g h := by simp

--- a/Mathlib/CategoryTheory/Bicategory/Functor/Pseudofunctor.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/Pseudofunctor.lean
@@ -243,7 +243,7 @@ lemma whiskerLeft_mapId_inv (f : a ⟶ b) : F.map f ◁ (F.mapId b).inv =
 
 /-- More flexible variant of `mapId`. (See the file `Bicategory.Functor.Strict`
 for applications to strict bicategories.) -/
-def mapId' {b : B} (f : b ⟶ b) (hf : f = 𝟙 b := by aesop_cat) :
+def mapId' {b : B} (f : b ⟶ b) (hf : f = 𝟙 b := by cat_disch) :
     F.map f ≅ 𝟙 (F.obj b) :=
   F.map₂Iso (eqToIso (by rw [hf])) ≪≫ F.mapId _
 
@@ -254,7 +254,7 @@ lemma mapId'_eq_mapId (b : B) :
 /-- More flexible variant of `mapComp`. (See `Bicategory.Functor.Strict`
 for applications to strict bicategories.) -/
 def mapComp' {b₀ b₁ b₂ : B} (f : b₀ ⟶ b₁) (g : b₁ ⟶ b₂) (fg : b₀ ⟶ b₂)
-    (h : f ≫ g = fg := by aesop_cat) :
+    (h : f ≫ g = fg := by cat_disch) :
     F.map fg ≅ F.map f ≫ F.map g :=
   F.map₂Iso (eqToIso (by rw [h])) ≪≫ F.mapComp f g
 

--- a/Mathlib/CategoryTheory/Bicategory/Functor/Strict.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/Strict.lean
@@ -84,7 +84,7 @@ lemma mapComp'_hom_comp_mapComp'_hom_whiskerRight (hf : f₀₂ ≫ f₂₃ = f)
     (F.mapComp' f₀₂ f₂₃ f).hom ≫ (F.mapComp' f₀₁ f₁₂ f₀₂ h₀₂).hom ▷ F.map f₂₃ =
     (F.mapComp' f₀₁ f₁₃ f).hom ≫ F.map f₀₁ ◁ (F.mapComp' f₁₂ f₂₃ f₁₃ h₁₃).hom ≫
       (α_ _ _ _).inv := by
-  rw [F.mapComp'_hom_comp_whiskerLeft_mapComp'_hom_assoc _ _ _ _ _ f h₀₂ h₁₃ (by aesop_cat)]
+  rw [F.mapComp'_hom_comp_whiskerLeft_mapComp'_hom_assoc _ _ _ _ _ f h₀₂ h₁₃ (by cat_disch)]
   simp
 
 @[reassoc]

--- a/Mathlib/CategoryTheory/Bicategory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Grothendieck.lean
@@ -172,7 +172,7 @@ variable (F)
 
 /-- The natural isomorphism witnessing the pseudo-unity constraint of `Grothendieck.map`. -/
 def mapIdIso : map (𝟙 F) ≅ 𝟭 (∫ F) :=
-  NatIso.ofComponents (fun _ ↦ eqToIso (by aesop_cat))
+  NatIso.ofComponents (fun _ ↦ eqToIso (by cat_disch))
 
 lemma map_id_eq : map (𝟙 F) = 𝟭 (∫ F) :=
   Functor.ext_of_iso (mapIdIso F) (fun x ↦ by simp [map]) (fun x ↦ by simp [mapIdIso])
@@ -181,7 +181,7 @@ end
 
 /-- The natural isomorphism witnessing the pseudo-functoriality of `Grothendieck.map`. -/
 def mapCompIso (α : F ⟶ G) (β : G ⟶ H) : map (α ≫ β) ≅ map α ⋙ map β :=
-  NatIso.ofComponents (fun _ ↦ eqToIso (by aesop_cat)) (fun f ↦ by
+  NatIso.ofComponents (fun _ ↦ eqToIso (by cat_disch)) (fun f ↦ by
     dsimp
     simp only [comp_id, id_comp]
     ext <;> simp)

--- a/Mathlib/CategoryTheory/Bicategory/LocallyDiscrete.lean
+++ b/Mathlib/CategoryTheory/Bicategory/LocallyDiscrete.lean
@@ -47,8 +47,8 @@ theorem mk_as (a : LocallyDiscrete C) : mk a.as = a := rfl
 def locallyDiscreteEquiv : LocallyDiscrete C ≃ C where
   toFun := LocallyDiscrete.as
   invFun := LocallyDiscrete.mk
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
+  left_inv := by cat_disch
+  right_inv := by cat_disch
 
 instance [DecidableEq C] : DecidableEq (LocallyDiscrete C) :=
   locallyDiscreteEquiv.decidableEq

--- a/Mathlib/CategoryTheory/Bicategory/Modification/Oplax.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Modification/Oplax.lean
@@ -47,7 +47,7 @@ structure Modification (η θ : F ⟶ G) where
   naturality :
     ∀ {a b : B} (f : a ⟶ b),
       F.map f ◁ app b ≫ θ.naturality f = η.naturality f ≫ app a ▷ G.map f := by
-    aesop_cat
+    cat_disch
 
 attribute [reassoc (attr := simp)] Modification.naturality
 

--- a/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Oplax.lean
+++ b/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Oplax.lean
@@ -220,7 +220,7 @@ structure OplaxTrans.StrongCore {F G : OplaxFunctor B C} (η : F ⟶ G) where
   /-- The underlying 2-isomorphisms of the naturality constraint. -/
   naturality {a b : B} (f : a ⟶ b) : F.map f ≫ η.app b ≅ η.app a ≫ G.map f
   /-- The 2-isomorphisms agree with the underlying 2-morphism of the oplax transformation. -/
-  naturality_hom {a b : B} (f : a ⟶ b) : (naturality f).hom = η.naturality f := by aesop_cat
+  naturality_hom {a b : B} (f : a ⟶ b) : (naturality f).hom = η.naturality f := by cat_disch
 
 attribute [simp] OplaxTrans.StrongCore.naturality_hom
 

--- a/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Oplax.lean
+++ b/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Oplax.lean
@@ -65,18 +65,18 @@ structure OplaxTrans (F G : OplaxFunctor B C) where
   /-- Naturality of the oplax naturality constraint. -/
   naturality_naturality {a b : B} {f g : a ⟶ b} (η : f ⟶ g) :
       F.map₂ η ▷ app b ≫ naturality g = naturality f ≫ app a ◁ G.map₂ η := by
-    aesop_cat
+    cat_disch
   /-- Oplax unity. -/
   naturality_id (a : B) :
       naturality (𝟙 a) ≫ app a ◁ G.mapId a =
         F.mapId a ▷ app a ≫ (λ_ (app a)).hom ≫ (ρ_ (app a)).inv := by
-    aesop_cat
+    cat_disch
   /-- Oplax functoriality. -/
   naturality_comp {a b c : B} (f : a ⟶ b) (g : b ⟶ c) :
       naturality (f ≫ g) ≫ app a ◁ G.mapComp f g =
         F.mapComp f g ▷ app c ≫ (α_ _ _ _).hom ≫ F.map f ◁ naturality g ≫
           (α_ _ _ _).inv ≫ naturality f ▷ G.map g ≫ (α_ _ _ _).hom := by
-    aesop_cat
+    cat_disch
 
 attribute [reassoc (attr := simp)] OplaxTrans.naturality_naturality OplaxTrans.naturality_id
   OplaxTrans.naturality_comp
@@ -194,16 +194,16 @@ structure StrongTrans (F G : OplaxFunctor B C) where
   naturality {a b : B} (f : a ⟶ b) : F.map f ≫ app b ≅ app a ≫ G.map f
   naturality_naturality {a b : B} {f g : a ⟶ b} (η : f ⟶ g) :
       F.map₂ η ▷ app b ≫ (naturality g).hom = (naturality f).hom ≫ app a ◁ G.map₂ η := by
-    aesop_cat
+    cat_disch
   naturality_id (a : B) :
       (naturality (𝟙 a)).hom ≫ app a ◁ G.mapId a =
         F.mapId a ▷ app a ≫ (λ_ (app a)).hom ≫ (ρ_ (app a)).inv := by
-    aesop_cat
+    cat_disch
   naturality_comp {a b c : B} (f : a ⟶ b) (g : b ⟶ c) :
       (naturality (f ≫ g)).hom ≫ app a ◁ G.mapComp f g =
         F.mapComp f g ▷ app c ≫ (α_ _ _ _).hom ≫ F.map f ◁ (naturality g).hom ≫
         (α_ _ _ _).inv ≫ (naturality f).hom ▷ G.map g ≫ (α_ _ _ _).hom := by
-    aesop_cat
+    cat_disch
 
 @[deprecated (since := "2025-04-23")] alias StrongOplaxNatTrans := StrongTrans
 

--- a/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Pseudo.lean
+++ b/Mathlib/CategoryTheory/Bicategory/NaturalTransformation/Pseudo.lean
@@ -58,18 +58,18 @@ structure StrongTrans (F G : Pseudofunctor B C) where
   /-- Naturality of the strong naturality constraint. -/
   naturality_naturality {a b : B} {f g : a ⟶ b} (η : f ⟶ g) :
       F.map₂ η ▷ app b ≫ (naturality g).hom = (naturality f).hom ≫ app a ◁ G.map₂ η := by
-    aesop_cat
+    cat_disch
   /-- Oplax unity. -/
   naturality_id (a : B) :
       (naturality (𝟙 a)).hom ≫ app a ◁ (G.mapId a).hom =
         (F.mapId a).hom ▷ app a ≫ (λ_ (app a)).hom ≫ (ρ_ (app a)).inv := by
-    aesop_cat
+    cat_disch
   /-- Oplax functoriality. -/
   naturality_comp {a b c : B} (f : a ⟶ b) (g : b ⟶ c) :
       (naturality (f ≫ g)).hom ≫ app a ◁ (G.mapComp f g).hom =
         (F.mapComp f g).hom ▷ app c ≫ (α_ _ _ _).hom ≫ F.map f ◁ (naturality g).hom ≫
         (α_ _ _ _).inv ≫ (naturality f).hom ▷ G.map g ≫ (α_ _ _ _).hom := by
-    aesop_cat
+    cat_disch
 
 attribute [reassoc (attr := simp)] StrongTrans.naturality_naturality
   StrongTrans.naturality_id StrongTrans.naturality_comp

--- a/Mathlib/CategoryTheory/Bicategory/Strict.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Strict.lean
@@ -35,16 +35,16 @@ isomorphisms given by equalities.
 -/
 class Bicategory.Strict : Prop where
   /-- Identity morphisms are left identities for composition. -/
-  id_comp : ∀ {a b : B} (f : a ⟶ b), 𝟙 a ≫ f = f := by aesop_cat
+  id_comp : ∀ {a b : B} (f : a ⟶ b), 𝟙 a ≫ f = f := by cat_disch
   /-- Identity morphisms are right identities for composition. -/
-  comp_id : ∀ {a b : B} (f : a ⟶ b), f ≫ 𝟙 b = f := by aesop_cat
+  comp_id : ∀ {a b : B} (f : a ⟶ b), f ≫ 𝟙 b = f := by cat_disch
   /-- Composition in a bicategory is associative. -/
   assoc : ∀ {a b c d : B} (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d), (f ≫ g) ≫ h = f ≫ g ≫ h := by
     aesop_cat
   /-- The left unitors are given by equalities -/
-  leftUnitor_eqToIso : ∀ {a b : B} (f : a ⟶ b), λ_ f = eqToIso (id_comp f) := by aesop_cat
+  leftUnitor_eqToIso : ∀ {a b : B} (f : a ⟶ b), λ_ f = eqToIso (id_comp f) := by cat_disch
   /-- The right unitors are given by equalities -/
-  rightUnitor_eqToIso : ∀ {a b : B} (f : a ⟶ b), ρ_ f = eqToIso (comp_id f) := by aesop_cat
+  rightUnitor_eqToIso : ∀ {a b : B} (f : a ⟶ b), ρ_ f = eqToIso (comp_id f) := by cat_disch
   /-- The associators are given by equalities -/
   associator_eqToIso :
     ∀ {a b c d : B} (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d), α_ f g h = eqToIso (assoc f g h) := by

--- a/Mathlib/CategoryTheory/Bicategory/Strict.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Strict.lean
@@ -40,7 +40,7 @@ class Bicategory.Strict : Prop where
   comp_id : ∀ {a b : B} (f : a ⟶ b), f ≫ 𝟙 b = f := by cat_disch
   /-- Composition in a bicategory is associative. -/
   assoc : ∀ {a b c d : B} (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d), (f ≫ g) ≫ h = f ≫ g ≫ h := by
-    aesop_cat
+    cat_disch
   /-- The left unitors are given by equalities -/
   leftUnitor_eqToIso : ∀ {a b : B} (f : a ⟶ b), λ_ f = eqToIso (id_comp f) := by cat_disch
   /-- The right unitors are given by equalities -/
@@ -48,7 +48,7 @@ class Bicategory.Strict : Prop where
   /-- The associators are given by equalities -/
   associator_eqToIso :
     ∀ {a b c d : B} (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d), α_ f g h = eqToIso (assoc f g h) := by
-    aesop_cat
+    cat_disch
 
 -- see Note [lower instance priority]
 /-- Category structure on a strict bicategory -/

--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -160,21 +160,41 @@ macro (name := aesop_cat_nonterminal) "aesop_cat_nonterminal" c:Aesop.tactic_cla
 
 attribute [aesop safe (rule_sets := [CategoryTheory])] Subsingleton.elim
 
+open Lean Elab Tactic in
+def categoryTheoryDischarger : TacticM Unit := do
+  if ← getBoolOption `mathlib.tactic.category.grind then
+    if ← getBoolOption `mathlib.tactic.category.log_grind then
+      logInfo "Category theory discharger using `grind`."
+    evalTacticSeq (← `(tacticSeq|
+      intros; (try dsimp only) <;> ((try ext); grind (gen := 20) (ematch := 20))))
+  else
+    if ← getBoolOption `mathlib.tactic.category.log_aesop then
+      logInfo "Category theory discharger using `aesop`."
+    evalTactic (← `(tactic| aesop_cat))
+
+elab (name := cat_disch) "cat_disch" : tactic =>
+  categoryTheoryDischarger
+
+set_option mathlib.tactic.category.grind true
+
 /-- The typeclass `Category C` describes morphisms associated to objects of type `C`.
 The universe levels of the objects and morphisms are unconstrained, and will often need to be
 specified explicitly, as `Category.{v} C`. (See also `LargeCategory` and `SmallCategory`.) -/
 @[pp_with_univ, stacks 0014]
 class Category (obj : Type u) : Type max u (v + 1) extends CategoryStruct.{v} obj where
   /-- Identity morphisms are left identities for composition. -/
-  id_comp : ∀ {X Y : obj} (f : X ⟶ Y), 𝟙 X ≫ f = f := by aesop_cat
+  id_comp : ∀ {X Y : obj} (f : X ⟶ Y), 𝟙 X ≫ f = f := by cat_disch
   /-- Identity morphisms are right identities for composition. -/
-  comp_id : ∀ {X Y : obj} (f : X ⟶ Y), f ≫ 𝟙 Y = f := by aesop_cat
+  comp_id : ∀ {X Y : obj} (f : X ⟶ Y), f ≫ 𝟙 Y = f := by cat_disch
   /-- Composition in a category is associative. -/
   assoc : ∀ {W X Y Z : obj} (f : W ⟶ X) (g : X ⟶ Y) (h : Y ⟶ Z), (f ≫ g) ≫ h = f ≫ g ≫ h := by
-    aesop_cat
+    cat_disch
 
 attribute [simp] Category.id_comp Category.comp_id Category.assoc
 attribute [trans] CategoryStruct.comp
+
+attribute [grind =] Category.id_comp Category.comp_id
+attribute [grind _=_] Category.assoc
 
 example {C} [Category C] {X Y : C} (f : X ⟶ Y) : 𝟙 X ≫ f = f := by simp
 example {C} [Category C] {X Y : C} (f : X ⟶ Y) : f ≫ 𝟙 Y = f := by simp

--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -161,7 +161,7 @@ macro (name := aesop_cat_nonterminal) "aesop_cat_nonterminal" c:Aesop.tactic_cla
 attribute [aesop safe (rule_sets := [CategoryTheory])] Subsingleton.elim
 
 open Lean Elab Tactic in
-/-- A tactic for discharging easy category theory goals, widely used as an autoparamter.
+/-- A tactic for discharging easy category theory goals, widely used as an autoparameter.
 Currently this defaults to the `aesop_cat` wrapper around `aesop`, but by setting
 the option `mathlib.tactic.category.grind` to `true`, it will use the `grind` tactic instead.
 -/

--- a/Mathlib/CategoryTheory/Category/Basic.lean
+++ b/Mathlib/CategoryTheory/Category/Basic.lean
@@ -161,6 +161,10 @@ macro (name := aesop_cat_nonterminal) "aesop_cat_nonterminal" c:Aesop.tactic_cla
 attribute [aesop safe (rule_sets := [CategoryTheory])] Subsingleton.elim
 
 open Lean Elab Tactic in
+/-- A tactic for discharging easy category theory goals, widely used as an autoparamter.
+Currently this defaults to the `aesop_cat` wrapper around `aesop`, but by setting
+the option `mathlib.tactic.category.grind` to `true`, it will use the `grind` tactic instead.
+-/
 def categoryTheoryDischarger : TacticM Unit := do
   if ← getBoolOption `mathlib.tactic.category.grind then
     if ← getBoolOption `mathlib.tactic.category.log_grind then
@@ -172,6 +176,7 @@ def categoryTheoryDischarger : TacticM Unit := do
       logInfo "Category theory discharger using `aesop`."
     evalTactic (← `(tactic| aesop_cat))
 
+@[inherit_doc categoryTheoryDischarger]
 elab (name := cat_disch) "cat_disch" : tactic =>
   categoryTheoryDischarger
 

--- a/Mathlib/CategoryTheory/Category/Cat.lean
+++ b/Mathlib/CategoryTheory/Category/Cat.lean
@@ -219,9 +219,9 @@ def typeToCat : Type u ⥤ Cat where
       cases f
       simp only [eqToHom_refl, Cat.id_map, Category.comp_id, Category.id_comp]
       apply ULift.ext
-      aesop_cat
+      cat_disch
     · simp
-  map_comp f g := by apply Functor.ext; aesop_cat
+  map_comp f g := by apply Functor.ext; cat_disch
 
 instance : Functor.Faithful typeToCat.{u} where
   map_injective {_X} {_Y} _f _g h :=
@@ -233,7 +233,7 @@ instance : Functor.Full typeToCat.{u} where
     · intro x y f
       dsimp
       apply ULift.ext
-      aesop_cat
+      cat_disch
     · rintro ⟨x⟩
       apply Discrete.ext
       rfl⟩

--- a/Mathlib/CategoryTheory/Category/Cat.lean
+++ b/Mathlib/CategoryTheory/Category/Cat.lean
@@ -193,8 +193,8 @@ defines an isomorphism in `Cat`. -/
 def isoOfEquiv {C D : Cat.{v, u}} (e : C ≌ D)
     (h₁ : ∀ (X : C), e.inverse.obj (e.functor.obj X) = X)
     (h₂ : ∀ (Y : D), e.functor.obj (e.inverse.obj Y) = Y)
-    (h₃ : ∀ (X : C), e.unitIso.hom.app X = eqToHom (h₁ X).symm := by aesop_cat)
-    (h₄ : ∀ (Y : D), e.counitIso.hom.app Y = eqToHom (h₂ Y) := by aesop_cat) :
+    (h₃ : ∀ (X : C), e.unitIso.hom.app X = eqToHom (h₁ X).symm := by cat_disch)
+    (h₄ : ∀ (Y : D), e.counitIso.hom.app Y = eqToHom (h₂ Y) := by cat_disch) :
     C ≅ D where
   hom := e.functor
   inv := e.inverse

--- a/Mathlib/CategoryTheory/Category/Cat/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/Adjunction.lean
@@ -47,7 +47,7 @@ def typeToCatObjectsAdj : typeToCat ⊣ Cat.objects :=
       naturality := fun _ _ _  ↦  Functor.hext (fun _ ↦ rfl)
         (by intro ⟨_⟩ ⟨_⟩ f
             obtain rfl := Discrete.eq_of_hom f
-            aesop_cat ) } }
+            cat_disch ) } }
 
 /-- The connected components functor -/
 def connectedComponents : Cat.{v, u} ⥤ Type u where
@@ -67,10 +67,10 @@ def connectedComponentsTypeToCatAdj : connectedComponents ⊣ typeToCat :=
         naturality := fun _ _ _ =>
           funext (fun xcc => by
             obtain ⟨x,h⟩ := Quotient.exists_rep xcc
-            aesop_cat) }
+            cat_disch) }
     homEquiv_counit := fun {C X G} => by
       funext cc
       obtain ⟨_, _⟩ := Quotient.exists_rep cc
-      aesop_cat }
+      cat_disch }
 
 end CategoryTheory.Cat

--- a/Mathlib/CategoryTheory/Category/Cat/Limit.lean
+++ b/Mathlib/CategoryTheory/Category/Cat/Limit.lean
@@ -147,7 +147,7 @@ instance : PreservesLimits Cat.objects.{v, v} where
     { preservesLimit := fun {F} =>
         preservesLimit_of_preserves_limit_cone (HasLimits.limitConeIsLimit F)
           (Limits.IsLimit.ofIsoLimit (limit.isLimit (F ⋙ Cat.objects))
-            (Cones.ext (by rfl) (by aesop_cat))) }
+            (Cones.ext (by rfl) (by cat_disch))) }
 
 end Cat
 

--- a/Mathlib/CategoryTheory/Category/Factorisation.lean
+++ b/Mathlib/CategoryTheory/Category/Factorisation.lean
@@ -35,7 +35,7 @@ structure Factorisation {X Y : C} (f : X ⟶ Y) where
   /-- The morphism out of the factorisation midpoint. -/
   π   : mid ⟶ Y
   /-- The factorisation condition. -/
-  ι_π : ι ≫ π = f := by aesop_cat
+  ι_π : ι ≫ π = f := by cat_disch
 
 attribute [simp] Factorisation.ι_π
 
@@ -50,9 +50,9 @@ protected structure Hom (d e : Factorisation f) : Type (max u v) where
   /-- The morphism between the midpoints of the factorizations. -/
   h : d.mid ⟶ e.mid
   /-- The left commuting triangle of the factorization morphism. -/
-  ι_h : d.ι ≫ h = e.ι := by aesop_cat
+  ι_h : d.ι ≫ h = e.ι := by cat_disch
   /-- The right commuting triangle of the factorization morphism. -/
-  h_π : h ≫ e.π = d.π := by aesop_cat
+  h_π : h ≫ e.π = d.π := by cat_disch
 
 attribute [simp] Factorisation.Hom.ι_h Factorisation.Hom.h_π
 

--- a/Mathlib/CategoryTheory/Category/GaloisConnection.lean
+++ b/Mathlib/CategoryTheory/Category/GaloisConnection.lean
@@ -30,8 +30,8 @@ def GaloisConnection.adjunction {l : X → Y} {u : Y → X} (gc : GaloisConnecti
     { homEquiv := fun X Y =>
         { toFun := fun f => CategoryTheory.homOfLE (gc.le_u f.le)
           invFun := fun f => CategoryTheory.homOfLE (gc.l_le f.le)
-          left_inv := by aesop_cat
-          right_inv := by aesop_cat } }
+          left_inv := by cat_disch
+          right_inv := by cat_disch } }
 
 end
 

--- a/Mathlib/CategoryTheory/Category/Init.lean
+++ b/Mathlib/CategoryTheory/Category/Init.lean
@@ -17,7 +17,8 @@ they're declared is imported, so we must put this declaration into its own file.
 
 declare_aesop_rule_sets [CategoryTheory]
 
-/-- Option to control whether the category theory library should use `grind` or `aesop`. -/
+/-- Option to control whether the category theory library should use `grind` or `aesop`
+in the `cat_disch` tactic, which is widely used as an autoparameter. -/
 register_option mathlib.tactic.category.grind : Bool := {
   defValue := false
   descr := "The category theory library should use `grind` instead of `aesop`."

--- a/Mathlib/CategoryTheory/Category/Init.lean
+++ b/Mathlib/CategoryTheory/Category/Init.lean
@@ -16,3 +16,21 @@ they're declared is imported, so we must put this declaration into its own file.
 -/
 
 declare_aesop_rule_sets [CategoryTheory]
+
+/-- Option to control whether the category theory library should use `grind` or `aesop`. -/
+register_option mathlib.tactic.category.grind : Bool := {
+  defValue := false
+  descr := "The category theory library should use `grind` instead of `aesop`."
+}
+
+/-- Log a message whenever the category theory discharger uses `grind`. -/
+register_option mathlib.tactic.category.log_grind : Bool := {
+  defValue := false
+  descr := "Log a message whenever the category theory discharger uses `grind`."
+}
+
+/-- Log a message whenever the category theory discharger uses `aesop`. -/
+register_option mathlib.tactic.category.log_aesop : Bool := {
+  defValue := false
+  descr := "Log a message whenever the category theory discharger uses `aesop`."
+}

--- a/Mathlib/CategoryTheory/Category/Pairwise.lean
+++ b/Mathlib/CategoryTheory/Category/Pairwise.lean
@@ -82,7 +82,7 @@ instance : CategoryStruct (Pairwise ι) where
 section
 
 open Lean Elab Tactic in
-/-- A helper tactic for `aesop_cat` and `Pairwise`. -/
+/-- A helper tactic for `cat_disch` and `Pairwise`. -/
 def pairwiseCases : TacticM Unit := do
   evalTactic (← `(tactic| casesm* (_ : Pairwise _) ⟶ (_ : Pairwise _)))
 

--- a/Mathlib/CategoryTheory/Center/Linear.lean
+++ b/Mathlib/CategoryTheory/Center/Linear.lean
@@ -31,14 +31,14 @@ variable (R : Type w) [Ring R] (C : Type u) [Category.{v} C] [Preadditive C]
 def toCatCenter [Linear R C] : R →+* CatCenter C where
   toFun a :=
     { app := fun X => a • 𝟙 X }
-  map_one' := by aesop_cat
+  map_one' := by cat_disch
   map_mul' a b := by
     rw [mul_comm]
     ext X
     dsimp only [CatCenter.mul_app']
     rw [Linear.smul_comp, Linear.comp_smul, smul_smul]
     simp
-  map_zero' := by aesop_cat
+  map_zero' := by cat_disch
   map_add' a b := by
     ext X
     dsimp

--- a/Mathlib/CategoryTheory/Closed/Cartesian.lean
+++ b/Mathlib/CategoryTheory/Closed/Cartesian.lean
@@ -249,7 +249,7 @@ theorem coev_app_comp_pre_app (f : B ⟶ A) [Exponentiable B] :
 @[simp]
 theorem pre_id (A : C) [Exponentiable A] : pre (𝟙 A) = 𝟙 _ := by
   simp only [pre, Functor.map_id]
-  aesop_cat
+  cat_disch
 
 @[simp]
 theorem pre_map {A₁ A₂ A₃ : C} [Exponentiable A₁] [Exponentiable A₂] [Exponentiable A₃]

--- a/Mathlib/CategoryTheory/Closed/FunctorCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/Closed/FunctorCategory/Basic.lean
@@ -68,7 +68,7 @@ noncomputable def homEquiv : (F₁ ⊗ F₂ ⟶ F₃) ≃ (F₂ ⟶ functorEnric
           ← enrichedOrdinaryCategorySelf_eHomWhiskerLeft]
         let α : Under.mk (𝟙 j) ⟶ (Under.map φ).obj (Under.mk (𝟙 j')) := Under.homMk φ
         exact (enrichedHom_condition C (Under.forget j ⋙ F₁) (Under.forget j ⋙ F₃) α).symm }
-  left_inv f := by aesop_cat
+  left_inv f := by cat_disch
   right_inv g := by
     ext j
     dsimp

--- a/Mathlib/CategoryTheory/CodiscreteCategory.lean
+++ b/Mathlib/CategoryTheory/CodiscreteCategory.lean
@@ -49,8 +49,8 @@ theorem Codiscrete.mk_as {α : Type u} (X : Codiscrete α) : Codiscrete.mk X.as 
 def codiscreteEquiv {α : Type u} : Codiscrete α ≃ α where
   toFun := Codiscrete.as
   invFun := Codiscrete.mk
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
+  left_inv := by cat_disch
+  right_inv := by cat_disch
 
 instance {α : Type u} [DecidableEq α] : DecidableEq (Codiscrete α) :=
   codiscreteEquiv.decidableEq

--- a/Mathlib/CategoryTheory/CommSq.lean
+++ b/Mathlib/CategoryTheory/CommSq.lean
@@ -41,7 +41,7 @@ is a commuting square.
 -/
 structure CommSq {W X Y Z : C} (f : W ⟶ X) (g : W ⟶ Y) (h : X ⟶ Z) (i : Y ⟶ Z) : Prop where
   /-- The square commutes. -/
-  w : f ≫ h = g ≫ i := by aesop_cat
+  w : f ≫ h = g ≫ i := by cat_disch
 
 attribute [reassoc] CommSq.w
 
@@ -158,9 +158,9 @@ structure LiftStruct (sq : CommSq f i p g) where
   /-- The lift. -/
   l : B ⟶ X
   /-- The upper left triangle commutes. -/
-  fac_left : i ≫ l = f := by aesop_cat
+  fac_left : i ≫ l = f := by cat_disch
   /-- The lower right triangle commutes. -/
-  fac_right : l ≫ p = g := by aesop_cat
+  fac_right : l ≫ p = g := by cat_disch
 
 namespace LiftStruct
 
@@ -187,8 +187,8 @@ in the opposite category. -/
 def opEquiv (sq : CommSq f i p g) : LiftStruct sq ≃ LiftStruct sq.op where
   toFun := op
   invFun := unop
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
+  left_inv := by cat_disch
+  right_inv := by cat_disch
 
 /-- Equivalences of `LiftStruct` for a square in the opposite category and
 the corresponding square in the original category. -/
@@ -196,8 +196,8 @@ def unopEquiv {A B X Y : Cᵒᵖ} {f : A ⟶ X} {i : A ⟶ B} {p : X ⟶ Y} {g :
     (sq : CommSq f i p g) : LiftStruct sq ≃ LiftStruct sq.unop where
   toFun := unop
   invFun := op
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
+  left_inv := by cat_disch
+  right_inv := by cat_disch
 
 end LiftStruct
 

--- a/Mathlib/CategoryTheory/Comma/Arrow.lean
+++ b/Mathlib/CategoryTheory/Comma/Arrow.lean
@@ -154,7 +154,7 @@ theorem isIso_of_isIso_left_of_isIso_right {f g : Arrow T} (ff : f ⟶ g) [IsIso
   out := by
     let inverse : g ⟶ f := ⟨inv ff.left, inv ff.right, (by simp)⟩
     apply Exists.intro inverse
-    aesop_cat
+    cat_disch
 
 /-- Create an isomorphism between arrows,
 by providing isomorphisms between the domains and codomains,

--- a/Mathlib/CategoryTheory/Comma/Arrow.lean
+++ b/Mathlib/CategoryTheory/Comma/Arrow.lean
@@ -125,7 +125,7 @@ lemma arrow_mk_eqToHom_comp {X' X Y : T} (f : X ⟶ Y) (h : X' = X) :
     category. -/
 @[simps]
 def homMk {f g : Arrow T} (u : f.left ⟶ g.left) (v : f.right ⟶ g.right)
-    (w : u ≫ g.hom = f.hom ≫ v := by aesop_cat) : f ⟶ g where
+    (w : u ≫ g.hom = f.hom ≫ v := by cat_disch) : f ⟶ g where
   left := u
   right := v
   w := w
@@ -133,7 +133,7 @@ def homMk {f g : Arrow T} (u : f.left ⟶ g.left) (v : f.right ⟶ g.right)
 /-- We can also build a morphism in the arrow category out of any commutative square in `T`. -/
 @[simps]
 def homMk' {X Y : T} {f : X ⟶ Y} {P Q : T} {g : P ⟶ Q} (u : X ⟶ P) (v : Y ⟶ Q)
-    (w : u ≫ g = f ≫ v := by aesop_cat) :
+    (w : u ≫ g = f ≫ v := by cat_disch) :
     Arrow.mk f ⟶ Arrow.mk g where
   left := u
   right := v
@@ -161,13 +161,13 @@ by providing isomorphisms between the domains and codomains,
 and a proof that the square commutes. -/
 @[simps!]
 def isoMk {f g : Arrow T} (l : f.left ≅ g.left) (r : f.right ≅ g.right)
-    (h : l.hom ≫ g.hom = f.hom ≫ r.hom := by aesop_cat) : f ≅ g :=
+    (h : l.hom ≫ g.hom = f.hom ≫ r.hom := by cat_disch) : f ≅ g :=
   Comma.isoMk l r h
 
 /-- A variant of `Arrow.isoMk` that creates an iso between two `Arrow.mk`s with a better type
 signature. -/
 abbrev isoMk' {W X Y Z : T} (f : W ⟶ X) (g : Y ⟶ Z) (e₁ : W ≅ Y) (e₂ : X ≅ Z)
-    (h : e₁.hom ≫ g = f ≫ e₂.hom := by aesop_cat) : Arrow.mk f ≅ Arrow.mk g :=
+    (h : e₁.hom ≫ g = f ≫ e₂.hom := by cat_disch) : Arrow.mk f ≅ Arrow.mk g :=
   Arrow.isoMk e₁ e₂ h
 
 theorem hom.congr_left {f g : Arrow T} {φ₁ φ₂ : f ⟶ g} (h : φ₁ = φ₂) : φ₁.left = φ₂.left := by

--- a/Mathlib/CategoryTheory/Comma/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Basic.lean
@@ -87,7 +87,7 @@ structure CommaMorphism (X Y : Comma L R) where
   left : X.left ⟶ Y.left
   /-- Morphism on right objects -/
   right : X.right ⟶ Y.right
-  w : L.map left ≫ Y.hom = X.hom ≫ R.map right := by aesop_cat
+  w : L.map left ≫ Y.hom = X.hom ≫ R.map right := by cat_disch
 
 -- Satisfying the inhabited linter
 instance CommaMorphism.inhabited [Inhabited (Comma L R)] :
@@ -211,7 +211,7 @@ directions give a commutative square.
 -/
 @[simps]
 def isoMk {X Y : Comma L₁ R₁} (l : X.left ≅ Y.left) (r : X.right ≅ Y.right)
-    (h : L₁.map l.hom ≫ Y.hom = X.hom ≫ R₁.map r.hom := by aesop_cat) : X ≅ Y where
+    (h : L₁.map l.hom ≫ Y.hom = X.hom ≫ R₁.map r.hom := by cat_disch) : X ≅ Y where
   hom :=
     { left := l.hom
       right := r.hom
@@ -265,7 +265,7 @@ instance full_map [F.Faithful] [F₁.Full] [F₂.Full] [IsIso α] [IsIso β] : (
         erw [← α.naturality_assoc, β.naturality]
         dsimp
         rw [F₁.map_preimage, F₂.map_preimage]
-        simpa using φ.w) }, by aesop_cat⟩
+        simpa using φ.w) }, by cat_disch⟩
 
 instance essSurj_map [F₁.EssSurj] [F₂.EssSurj] [F.Full] [IsIso α] [IsIso β] :
     (map α β).EssSurj where

--- a/Mathlib/CategoryTheory/Comma/Over/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Basic.lean
@@ -67,7 +67,7 @@ theorem comp_left (a b c : Over X) (f : a ⟶ b) (g : b ⟶ c) : (f ≫ g).left 
   rfl
 
 @[reassoc (attr := simp)]
-theorem w {A B : Over X} (f : A ⟶ B) : f.left ≫ B.hom = A.hom := by have := f.w; aesop_cat
+theorem w {A B : Over X} (f : A ⟶ B) : f.left ≫ B.hom = A.hom := by have := f.w; cat_disch
 
 /-- To give an object in the over category, it suffices to give a morphism with codomain `X`. -/
 @[simps! left hom]
@@ -491,7 +491,7 @@ theorem comp_right (a b c : Under X) (f : a ⟶ b) (g : b ⟶ c) : (f ≫ g).rig
   rfl
 
 @[reassoc (attr := simp)]
-theorem w {A B : Under X} (f : A ⟶ B) : A.hom ≫ f.right = B.hom := by have := f.w; aesop_cat
+theorem w {A B : Under X} (f : A ⟶ B) : A.hom ≫ f.right = B.hom := by have := f.w; cat_disch
 
 /-- To give an object in the under category, it suffices to give an arrow with domain `X`. -/
 @[simps! right hom]
@@ -906,7 +906,7 @@ def ofStructuredArrowProjEquivalence.functor (F : D ⥤ T) (Y : T) (X : D) :
     StructuredArrow X (StructuredArrow.proj Y F) ⥤ StructuredArrow Y (Under.forget X ⋙ F) :=
   Functor.toStructuredArrow
     (Functor.toUnder (StructuredArrow.proj X _ ⋙ StructuredArrow.proj Y _) _
-      (fun g => by exact g.hom) (fun m => by have := m.w; aesop_cat)) _ _
+      (fun g => by exact g.hom) (fun m => by have := m.w; cat_disch)) _ _
     (fun f => f.right.hom) (by simp)
 
 /-- The inverse functor of `ofStructuredArrowProjEquivalence.functor`. -/
@@ -915,7 +915,7 @@ def ofStructuredArrowProjEquivalence.inverse (F : D ⥤ T) (Y : T) (X : D) :
     StructuredArrow Y (Under.forget X ⋙ F) ⥤ StructuredArrow X (StructuredArrow.proj Y F) :=
   Functor.toStructuredArrow
     (Functor.toStructuredArrow (StructuredArrow.proj Y _ ⋙ Under.forget X) _ _
-      (fun g => by exact g.hom) (fun m => by have := m.w; aesop_cat)) _ _
+      (fun g => by exact g.hom) (fun m => by have := m.w; cat_disch)) _ _
     (fun f => f.right.hom) (by simp)
 
 /-- Characterization of the structured arrow category on the projection functor of any
@@ -934,15 +934,15 @@ def ofDiagEquivalence.functor (X : T × T) :
     StructuredArrow X (Functor.diag _) ⥤ StructuredArrow X.2 (Under.forget X.1) :=
   Functor.toStructuredArrow
     (Functor.toUnder (StructuredArrow.proj X _) _
-      (fun f => by exact f.hom.1) (fun m => by have := m.w; aesop_cat)) _ _
-    (fun f => f.hom.2) (fun m => by have := m.w; aesop_cat)
+      (fun f => by exact f.hom.1) (fun m => by have := m.w; cat_disch)) _ _
+    (fun f => f.hom.2) (fun m => by have := m.w; cat_disch)
 
 /-- The inverse functor of `ofDiagEquivalence.functor`. -/
 @[simps!]
 def ofDiagEquivalence.inverse (X : T × T) :
     StructuredArrow X.2 (Under.forget X.1) ⥤ StructuredArrow X (Functor.diag _) :=
   Functor.toStructuredArrow (StructuredArrow.proj _ _ ⋙ Under.forget _) _ _
-    (fun f => (f.right.hom, f.hom)) (fun m => by have := m.w; aesop_cat)
+    (fun f => (f.right.hom, f.hom)) (fun m => by have := m.w; cat_disch)
 
 /-- Characterization of the structured arrow category on the diagonal functor `T ⥤ T × T`. -/
 def ofDiagEquivalence (X : T × T) :
@@ -1003,7 +1003,7 @@ def ofCostructuredArrowProjEquivalence.functor (F : T ⥤ D) (Y : D) (X : T) :
     CostructuredArrow (CostructuredArrow.proj F Y) X ⥤ CostructuredArrow (Over.forget X ⋙ F) Y :=
   Functor.toCostructuredArrow
     (Functor.toOver (CostructuredArrow.proj _ X ⋙ CostructuredArrow.proj F Y) _
-      (fun g => by exact g.hom) (fun m => by have := m.w; aesop_cat)) _ _
+      (fun g => by exact g.hom) (fun m => by have := m.w; cat_disch)) _ _
     (fun f => f.left.hom) (by simp)
 
 /-- The inverse functor of `ofCostructuredArrowProjEquivalence.functor`. -/
@@ -1012,7 +1012,7 @@ def ofCostructuredArrowProjEquivalence.inverse (F : T ⥤ D) (Y : D) (X : T) :
     CostructuredArrow (Over.forget X ⋙ F) Y ⥤ CostructuredArrow (CostructuredArrow.proj F Y) X :=
   Functor.toCostructuredArrow
     (Functor.toCostructuredArrow (CostructuredArrow.proj _ Y ⋙ Over.forget X) _ _
-      (fun g => by exact g.hom) (fun m => by have := m.w; aesop_cat)) _ _
+      (fun g => by exact g.hom) (fun m => by have := m.w; cat_disch)) _ _
     (fun f => f.left.hom) (by simp)
 
 /-- Characterization of the costructured arrow category on the projection functor of any
@@ -1032,16 +1032,16 @@ def ofDiagEquivalence.functor (X : T × T) :
     CostructuredArrow (Functor.diag _) X ⥤ CostructuredArrow (Over.forget X.1) X.2 :=
   Functor.toCostructuredArrow
     (Functor.toOver (CostructuredArrow.proj _ X) _
-      (fun g => by exact g.hom.1) (fun m => by have := congrArg (·.1) m.w; aesop_cat))
+      (fun g => by exact g.hom.1) (fun m => by have := congrArg (·.1) m.w; cat_disch))
     _ _
-    (fun f => f.hom.2) (fun m => by have := congrArg (·.2) m.w; aesop_cat)
+    (fun f => f.hom.2) (fun m => by have := congrArg (·.2) m.w; cat_disch)
 
 /-- The inverse functor of `ofDiagEquivalence.functor`. -/
 @[simps!]
 def ofDiagEquivalence.inverse (X : T × T) :
     CostructuredArrow (Over.forget X.1) X.2 ⥤ CostructuredArrow (Functor.diag _) X :=
   Functor.toCostructuredArrow (CostructuredArrow.proj _ _ ⋙ Over.forget _) _ X
-    (fun f => (f.left.hom, f.hom)) (fun m => by have := m.w; aesop_cat)
+    (fun f => (f.left.hom, f.hom)) (fun m => by have := m.w; cat_disch)
 
 /-- Characterization of the costructured arrow category on the diagonal functor `T ⥤ T × T`. -/
 def ofDiagEquivalence (X : T × T) :

--- a/Mathlib/CategoryTheory/Comma/Over/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Basic.lean
@@ -91,7 +91,7 @@ end
 /-- To give a morphism in the over category, it suffices to give an arrow fitting in a commutative
     triangle. -/
 @[simps! left]
-def homMk {U V : Over X} (f : U.left ⟶ V.left) (w : f ≫ V.hom = U.hom := by aesop_cat) : U ⟶ V :=
+def homMk {U V : Over X} (f : U.left ⟶ V.left) (w : f ≫ V.hom = U.hom := by cat_disch) : U ⟶ V :=
   CostructuredArrow.homMk f w
 
 @[simp]
@@ -109,7 +109,7 @@ lemma homMk_comp {U V W : Over X} (f : U.left ⟶ V.left) (g : V.left ⟶ W.left
 direction gives a commutative triangle.
 -/
 @[simps! hom_left inv_left]
-def isoMk {f g : Over X} (hl : f.left ≅ g.left) (hw : hl.hom ≫ g.hom = f.hom := by aesop_cat) :
+def isoMk {f g : Over X} (hl : f.left ≅ g.left) (hw : hl.hom ≫ g.hom = f.hom := by cat_disch) :
     f ≅ g :=
   CostructuredArrow.isoMk hl hw
 
@@ -501,7 +501,7 @@ def mk {X Y : T} (f : X ⟶ Y) : Under X :=
 /-- To give a morphism in the under category, it suffices to give a morphism fitting in a
     commutative triangle. -/
 @[simps! right]
-def homMk {U V : Under X} (f : U.right ⟶ V.right) (w : U.hom ≫ f = V.hom := by aesop_cat) : U ⟶ V :=
+def homMk {U V : Under X} (f : U.right ⟶ V.right) (w : U.hom ≫ f = V.hom := by cat_disch) : U ⟶ V :=
   StructuredArrow.homMk f w
 
 @[simp]
@@ -519,7 +519,7 @@ lemma homMk_comp {U V W : Under X} (f : U.right ⟶ V.right) (g : V.right ⟶ W.
 direction gives a commutative triangle.
 -/
 def isoMk {f g : Under X} (hr : f.right ≅ g.right)
-    (hw : f.hom ≫ hr.hom = g.hom := by aesop_cat) : f ≅ g :=
+    (hw : f.hom ≫ hr.hom = g.hom := by cat_disch) : f ≅ g :=
   StructuredArrow.isoMk hr hw
 
 @[simp]
@@ -925,7 +925,7 @@ def ofStructuredArrowProjEquivalence (F : D ⥤ T) (Y : T) (X : D) :
   functor := ofStructuredArrowProjEquivalence.functor F Y X
   inverse := ofStructuredArrowProjEquivalence.inverse F Y X
   unitIso := NatIso.ofComponents (fun _ => Iso.refl _) (by simp)
-  counitIso := NatIso.ofComponents (fun _ => Iso.refl _) (by aesop_cat)
+  counitIso := NatIso.ofComponents (fun _ => Iso.refl _) (by cat_disch)
 
 /-- The canonical functor from the structured arrow category on the diagonal functor
 `T ⥤ T × T` to the structured arrow category on `Under.forget`. -/
@@ -950,7 +950,7 @@ def ofDiagEquivalence (X : T × T) :
   functor := ofDiagEquivalence.functor X
   inverse := ofDiagEquivalence.inverse X
   unitIso := NatIso.ofComponents (fun _ => Iso.refl _) (by simp)
-  counitIso := NatIso.ofComponents (fun _ => Iso.refl _) (by aesop_cat)
+  counitIso := NatIso.ofComponents (fun _ => Iso.refl _) (by cat_disch)
 
 /-- A version of `StructuredArrow.ofDiagEquivalence` with the roles of the first and second
 projection swapped. -/
@@ -1023,7 +1023,7 @@ def ofCostructuredArrowProjEquivalence (F : T ⥤ D) (Y : D) (X : T) :
   functor := ofCostructuredArrowProjEquivalence.functor F Y X
   inverse := ofCostructuredArrowProjEquivalence.inverse F Y X
   unitIso := NatIso.ofComponents (fun _ => Iso.refl _) (by simp)
-  counitIso := NatIso.ofComponents (fun _ => Iso.refl _) (by aesop_cat)
+  counitIso := NatIso.ofComponents (fun _ => Iso.refl _) (by cat_disch)
 
 /-- The canonical functor from the costructured arrow category on the diagonal functor
 `T ⥤ T × T` to the costructured arrow category on `Under.forget`. -/
@@ -1049,7 +1049,7 @@ def ofDiagEquivalence (X : T × T) :
   functor := ofDiagEquivalence.functor X
   inverse := ofDiagEquivalence.inverse X
   unitIso := NatIso.ofComponents (fun _ => Iso.refl _) (by simp)
-  counitIso := NatIso.ofComponents (fun _ => Iso.refl _) (by aesop_cat)
+  counitIso := NatIso.ofComponents (fun _ => Iso.refl _) (by cat_disch)
 
 /-- A version of `CostructuredArrow.ofDiagEquivalence` with the roles of the first and second
 projection swapped. -/

--- a/Mathlib/CategoryTheory/Comma/Over/Pullback.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Pullback.lean
@@ -65,7 +65,7 @@ def mapPullbackAdj {X Y : C} (f : X ⟶ Y) : Over.map f ⊣ pullback f :=
             Over.homMk (pullback.lift u.left x.hom <| by simp)
           invFun := fun v => Over.homMk (v.left ≫ pullback.fst _ _) <| by
             simp [← Over.w v, pullback.condition]
-          left_inv := by aesop_cat
+          left_inv := by cat_disch
           right_inv := fun v => by
             ext
             dsimp
@@ -165,7 +165,7 @@ def mapPushoutAdj {X Y : C} (f : X ⟶ Y) : pushout f ⊣ map f :=
         ext
         · simp
         · simpa using (Under.w u).symm
-      right_inv := by aesop_cat
+      right_inv := by cat_disch
     }
   }
 

--- a/Mathlib/CategoryTheory/Comma/Presheaf/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Presheaf/Basic.lean
@@ -228,8 +228,8 @@ def restrictedYoneda (A : Cᵒᵖ ⥤ Type v) : Over A ⥤ (CostructuredArrow yo
 def toOverYonedaCompRestrictedYoneda (A : Cᵒᵖ ⥤ Type v) :
     CostructuredArrow.toOver yoneda A ⋙ restrictedYoneda A ≅ yoneda :=
   NatIso.ofComponents
-    (fun s => NatIso.ofComponents (fun _ => OverArrows.costructuredArrowIso _ _) (by aesop_cat))
-    (by aesop_cat)
+    (fun s => NatIso.ofComponents (fun _ => OverArrows.costructuredArrowIso _ _) (by cat_disch))
+    (by cat_disch)
 
 /-! ### Construction of the backward functor `((CostructuredArrow yoneda A)ᵒᵖ ⥤ Type v) ⥤ Over A` -/
 
@@ -403,7 +403,7 @@ def yonedaCollectionPresheafToA (F : (CostructuredArrow yoneda A)ᵒᵖ ⥤ Type
 @[simps! obj map]
 def costructuredArrowPresheafToOver (A : Cᵒᵖ ⥤ Type v) :
     ((CostructuredArrow yoneda A)ᵒᵖ ⥤ Type v) ⥤ Over A :=
-  (yonedaCollectionFunctor A).toOver _ (yonedaCollectionPresheafToA) (by aesop_cat)
+  (yonedaCollectionFunctor A).toOver _ (yonedaCollectionPresheafToA) (by cat_disch)
 
 section unit
 
@@ -461,16 +461,16 @@ def unitAuxAuxAux {F : Cᵒᵖ ⥤ Type v} (η : F ⟶ A) (X : C) :
 @[simps!]
 def unitAuxAux {F : Cᵒᵖ ⥤ Type v} (η : F ⟶ A) :
     yonedaCollectionPresheaf A (restrictedYonedaObj η) ≅ F :=
-  NatIso.ofComponents (fun X => unitAuxAuxAux η X.unop) (by aesop_cat)
+  NatIso.ofComponents (fun X => unitAuxAuxAux η X.unop) (by cat_disch)
 
 /-- Intermediate stage of assembling the unit. -/
 @[simps! hom]
 def unitAux (η : Over A) : (restrictedYoneda A ⋙ costructuredArrowPresheafToOver A).obj η ≅ η :=
-  Over.isoMk (unitAuxAux η.hom) (by aesop_cat)
+  Over.isoMk (unitAuxAux η.hom) (by cat_disch)
 
 /-- The unit of the equivalence we're constructing. -/
 def unit (A : Cᵒᵖ ⥤ Type v) : 𝟭 (Over A) ≅ restrictedYoneda A ⋙ costructuredArrowPresheafToOver A :=
-  Iso.symm <| NatIso.ofComponents unitAux (by aesop_cat)
+  Iso.symm <| NatIso.ofComponents unitAux (by cat_disch)
 
 end unit
 
@@ -502,7 +502,7 @@ lemma counitForward_val_snd (s : CostructuredArrow yoneda A) (x : F.obj (op s)) 
 @[simp]
 lemma counitForward_naturality₁ {G : (CostructuredArrow yoneda A)ᵒᵖ ⥤ Type v} (η : F ⟶ G)
     (s : (CostructuredArrow yoneda A)ᵒᵖ) (x : F.obj s) : counitForward G s.unop (η.app s x) =
-      OverArrows.map₁ (counitForward F s.unop x) (yonedaCollectionPresheafMap₁ η) (by aesop_cat) :=
+      OverArrows.map₁ (counitForward F s.unop x) (yonedaCollectionPresheafMap₁ η) (by cat_disch) :=
   OverArrows.ext <| YonedaCollection.ext (by simp) (by simp)
 
 @[simp]
@@ -542,11 +542,11 @@ def counitAuxAux (F : (CostructuredArrow yoneda A)ᵒᵖ ⥤ Type v) (s : Costru
 @[simps! hom]
 def counitAux (F : (CostructuredArrow yoneda A)ᵒᵖ ⥤ Type v) :
     F ≅ restrictedYonedaObj (yonedaCollectionPresheafToA F) :=
-  NatIso.ofComponents (fun s => counitAuxAux F s.unop) (by aesop_cat)
+  NatIso.ofComponents (fun s => counitAuxAux F s.unop) (by cat_disch)
 
 /-- The counit of the equivalence we're constructing. -/
 def counit (A : Cᵒᵖ ⥤ Type v) : (costructuredArrowPresheafToOver A ⋙ restrictedYoneda A) ≅ 𝟭 _ :=
-  Iso.symm <| NatIso.ofComponents counitAux (by aesop_cat)
+  Iso.symm <| NatIso.ofComponents counitAux (by cat_disch)
 
 end counit
 
@@ -586,7 +586,7 @@ def CostructuredArrow.toOverCompYoneda (A : Cᵒᵖ ⥤ Type v) (T : Over A) :
       (Iso.homCongr
         ((CostructuredArrow.toOverCompOverEquivPresheafCostructuredArrow A).app X.unop)
         (Iso.refl _)).toIso)
-    (by aesop_cat)
+    (by cat_disch)
 
 @[simp]
 theorem CostructuredArrow.overEquivPresheafCostructuredArrow_inverse_map_toOverCompYoneda
@@ -620,7 +620,7 @@ def CostructuredArrow.toOverCompCoyoneda (A : Cᵒᵖ ⥤ Type v) :
     (overEquivPresheafCostructuredArrow A).fullyFaithfulFunctor.homEquiv.toIso ≪≫
       (Iso.homCongr
         ((CostructuredArrow.toOverCompOverEquivPresheafCostructuredArrow A).app X.unop)
-        (Iso.refl _)).toIso)) (by aesop_cat)
+        (Iso.refl _)).toIso)) (by cat_disch)
 
 @[simp]
 theorem CostructuredArrow.overEquivPresheafCostructuredArrow_inverse_map_toOverCompCoyoneda

--- a/Mathlib/CategoryTheory/Comma/Presheaf/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Presheaf/Basic.lean
@@ -238,7 +238,7 @@ lemma map_mkPrecomp_eqToHom {F : (CostructuredArrow yoneda A)ᵒᵖ ⥤ Type v} 
     {g g' : yoneda.obj Y ⟶ A} (h : g = g') {x : F.obj (op (CostructuredArrow.mk g'))} :
     F.map (CostructuredArrow.mkPrecomp g f).op (F.map (eqToHom (by rw [h])) x) =
       F.map (eqToHom (by rw [h])) (F.map (CostructuredArrow.mkPrecomp g' f).op x) := by
-  aesop_cat
+  cat_disch
 
 attribute [local simp] map_mkPrecomp_eqToHom
 
@@ -342,7 +342,7 @@ attribute [local simp] CostructuredArrow.mkPrecomp_id CostructuredArrow.mkPrecom
 
 @[simp]
 lemma map₁_id : YonedaCollection.map₁ (𝟙 F) (X := X) = id := by
-  aesop_cat
+  cat_disch
 
 @[simp]
 lemma map₁_comp {G H : (CostructuredArrow yoneda A)ᵒᵖ ⥤ Type v} (η : F ⟶ G) (μ : G ⟶ H) :
@@ -514,7 +514,7 @@ lemma counitForward_naturality₂ (s t : (CostructuredArrow yoneda A)ᵒᵖ) (f 
       f ≫ eqToHom (by simp [← CostructuredArrow.eq_mk]) := by
     apply Quiver.Hom.unop_inj
     simp
-  aesop_cat
+  cat_disch
 
 /-- Backward direction of the counit. -/
 def counitBackward (F : (CostructuredArrow yoneda A)ᵒᵖ ⥤ Type v) (s : CostructuredArrow yoneda A) :

--- a/Mathlib/CategoryTheory/Comma/StructuredArrow/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/StructuredArrow/Basic.lean
@@ -74,7 +74,7 @@ theorem mk_hom_eq_self (f : S ⟶ T.obj Y) : (mk f).hom = f :=
 
 @[reassoc (attr := simp)]
 theorem w {A B : StructuredArrow S T} (f : A ⟶ B) : A.hom ≫ T.map f.right = B.hom := by
-  have := f.w; aesop_cat
+  have := f.w; cat_disch
 
 @[simp]
 theorem comp_right {X Y Z : StructuredArrow S T} (f : X ⟶ Y) (g : Y ⟶ Z) :
@@ -159,7 +159,7 @@ theorem obj_ext (x y : StructuredArrow S T) (hr : x.right = y.right)
   cases x
   cases y
   cases hr
-  aesop_cat
+  cat_disch
 
 theorem ext {A B : StructuredArrow S T} (f g : A ⟶ B) : f.right = g.right → f = g :=
   CommaMorphism.ext (Subsingleton.elim _ _)
@@ -512,7 +512,7 @@ theorem obj_ext (x y : CostructuredArrow S T) (hl : x.left = y.left)
   cases x
   cases y
   cases hl
-  aesop_cat
+  cat_disch
 
 theorem ext {A B : CostructuredArrow S T} (f g : A ⟶ B) (h : f.left = g.left) : f = g :=
   CommaMorphism.ext h (Subsingleton.elim _ _)

--- a/Mathlib/CategoryTheory/Comma/StructuredArrow/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/StructuredArrow/Basic.lean
@@ -98,7 +98,7 @@ and to check that the triangle commutes.
 -/
 @[simps right]
 def homMk {f f' : StructuredArrow S T} (g : f.right ⟶ f'.right)
-    (w : f.hom ≫ T.map g = f'.hom := by aesop_cat) : f ⟶ f' where
+    (w : f.hom ≫ T.map g = f'.hom := by cat_disch) : f ⟶ f' where
   left := 𝟙 f.left
   right := g
   w := by
@@ -117,7 +117,7 @@ def homMk' (f : StructuredArrow S T) (g : f.right ⟶ Y') : f ⟶ mk (f.hom ≫ 
   left := 𝟙 _
   right := g
 
-lemma homMk'_id (f : StructuredArrow S T) : homMk' f (𝟙 f.right) = eqToHom (by aesop_cat) := by
+lemma homMk'_id (f : StructuredArrow S T) : homMk' f (𝟙 f.right) = eqToHom (by cat_disch) := by
   ext
   simp [eqToHom_right]
 
@@ -150,7 +150,7 @@ and to check that the triangle commutes.
 -/
 @[simps! hom_right inv_right]
 def isoMk {f f' : StructuredArrow S T} (g : f.right ≅ f'.right)
-    (w : f.hom ≫ T.map g.hom = f'.hom := by aesop_cat) :
+    (w : f.hom ≫ T.map g.hom = f'.hom := by cat_disch) :
     f ≅ f' :=
   Comma.isoMk (eqToIso (by ext)) g (by simpa using w.symm)
 
@@ -455,7 +455,7 @@ and to check that the triangle commutes.
 -/
 @[simps! left]
 def homMk {f f' : CostructuredArrow S T} (g : f.left ⟶ f'.left)
-    (w : S.map g ≫ f'.hom = f.hom := by aesop_cat) : f ⟶ f' where
+    (w : S.map g ≫ f'.hom = f.hom := by cat_disch) : f ⟶ f' where
   left := g
   right := 𝟙 f.right
 
@@ -471,7 +471,7 @@ def homMk' (f : CostructuredArrow S T) (g : Y' ⟶ f.left) : mk (S.map g ≫ f.h
   left := g
   right := 𝟙 _
 
-lemma homMk'_id (f : CostructuredArrow S T) : homMk' f (𝟙 f.left) = eqToHom (by aesop_cat) := by
+lemma homMk'_id (f : CostructuredArrow S T) : homMk' f (𝟙 f.left) = eqToHom (by cat_disch) := by
   ext
   simp [eqToHom_left]
 
@@ -504,7 +504,7 @@ and to check that the triangle commutes.
 -/
 @[simps! hom_left inv_left]
 def isoMk {f f' : CostructuredArrow S T} (g : f.left ≅ f'.left)
-    (w : S.map g.hom ≫ f'.hom = f.hom := by aesop_cat) : f ≅ f' :=
+    (w : S.map g.hom ≫ f'.hom = f.hom := by cat_disch) : f ≅ f' :=
   Comma.isoMk g (eqToIso (by ext)) (by simpa using w)
 
 theorem obj_ext (x y : CostructuredArrow S T) (hl : x.left = y.left)

--- a/Mathlib/CategoryTheory/Comma/StructuredArrow/Small.lean
+++ b/Mathlib/CategoryTheory/Comma/StructuredArrow/Small.lean
@@ -30,7 +30,7 @@ instance small_proj_preimage_of_locallySmall {𝒢 : Set C} [Small.{v₁} 𝒢] 
   suffices (proj S T).obj ⁻¹' 𝒢 = Set.range fun f : Σ G : 𝒢, S ⟶ T.obj G => mk f.2 by
     rw [this]
     infer_instance
-  exact Set.ext fun X => ⟨fun h => ⟨⟨⟨_, h⟩, X.hom⟩, (eq_mk _).symm⟩, by aesop_cat⟩
+  exact Set.ext fun X => ⟨fun h => ⟨⟨⟨_, h⟩, X.hom⟩, (eq_mk _).symm⟩, by cat_disch⟩
 
 end StructuredArrow
 
@@ -43,7 +43,7 @@ instance small_proj_preimage_of_locallySmall {𝒢 : Set C} [Small.{v₁} 𝒢] 
   suffices (proj S T).obj ⁻¹' 𝒢 = Set.range fun f : Σ G : 𝒢, S.obj G ⟶ T => mk f.2 by
     rw [this]
     infer_instance
-  exact Set.ext fun X => ⟨fun h => ⟨⟨⟨_, h⟩, X.hom⟩, (eq_mk _).symm⟩, by aesop_cat⟩
+  exact Set.ext fun X => ⟨fun h => ⟨⟨⟨_, h⟩, X.hom⟩, (eq_mk _).symm⟩, by cat_disch⟩
 
 end CostructuredArrow
 

--- a/Mathlib/CategoryTheory/ComposableArrows.lean
+++ b/Mathlib/CategoryTheory/ComposableArrows.lean
@@ -236,7 +236,7 @@ lemma mk₀_surjective (F : ComposableArrows C 0) : ∃ (X : C), F = mk₀ X :=
 @[simps!]
 def homMk₁ {F G : ComposableArrows C 1}
     (left : F.obj' 0 ⟶ G.obj' 0) (right : F.obj' 1 ⟶ G.obj' 1)
-    (w : F.map' 0 1 ≫ right = left ≫ G.map' 0 1 := by aesop_cat) :
+    (w : F.map' 0 1 ≫ right = left ≫ G.map' 0 1 := by cat_disch) :
     F ⟶ G :=
   homMk (fun i => match i with
       | ⟨0, _⟩ => left
@@ -258,7 +258,7 @@ lemma hom_ext₁ {F G : ComposableArrows C 1} {φ φ' : F ⟶ G}
 @[simps!]
 def isoMk₁ {F G : ComposableArrows C 1}
     (left : F.obj' 0 ≅ G.obj' 0) (right : F.obj' 1 ≅ G.obj' 1)
-    (w : F.map' 0 1 ≫ right.hom = left.hom ≫ G.map' 0 1 := by aesop_cat) :
+    (w : F.map' 0 1 ≫ right.hom = left.hom ≫ G.map' 0 1 := by cat_disch) :
     F ≅ G where
   hom := homMk₁ left.hom right.hom w
   inv := homMk₁ left.inv right.inv (by

--- a/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/Basic.lean
@@ -252,11 +252,11 @@ class ConcreteCategory (C : Type u) [Category.{v} C]
   (hom : ∀ {X Y}, (X ⟶ Y) → FC X Y)
   /-- Convert a bundled function to a morphism of `C`. -/
   (ofHom : ∀ {X Y}, FC X Y → (X ⟶ Y))
-  (hom_ofHom : ∀ {X Y} (f : FC X Y), hom (ofHom f) = f := by aesop_cat)
-  (ofHom_hom : ∀ {X Y} (f : X ⟶ Y), ofHom (hom f) = f := by aesop_cat)
-  (id_apply : ∀ {X} (x : CC X), hom (𝟙 X) x = x := by aesop_cat)
+  (hom_ofHom : ∀ {X Y} (f : FC X Y), hom (ofHom f) = f := by cat_disch)
+  (ofHom_hom : ∀ {X Y} (f : X ⟶ Y), ofHom (hom f) = f := by cat_disch)
+  (id_apply : ∀ {X} (x : CC X), hom (𝟙 X) x = x := by cat_disch)
   (comp_apply : ∀ {X Y Z} (f : X ⟶ Y) (g : Y ⟶ Z) (x : CC X),
-    hom (f ≫ g) x = hom g (hom f x) := by aesop_cat)
+    hom (f ≫ g) x = hom g (hom f x) := by cat_disch)
 
 export ConcreteCategory (id_apply comp_apply)
 

--- a/Mathlib/CategoryTheory/ConcreteCategory/BundledHom.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/BundledHom.lean
@@ -36,7 +36,7 @@ structure BundledHom where
   hom_ext : ∀ {α β : Type u} (Iα : c α) (Iβ : c β), Function.Injective (toFun Iα Iβ) := by
     aesop_cat
   /-- compatibility with identities -/
-  id_toFun : ∀ {α : Type u} (I : c α), toFun I I (id I) = _root_.id := by aesop_cat
+  id_toFun : ∀ {α : Type u} (I : c α), toFun I I (id I) = _root_.id := by cat_disch
   /-- compatibility with the composition -/
   comp_toFun :
     ∀ {α β γ : Type u} (Iα : c α) (Iβ : c β) (Iγ : c γ) (f : hom Iα Iβ) (g : hom Iβ Iγ),

--- a/Mathlib/CategoryTheory/ConcreteCategory/BundledHom.lean
+++ b/Mathlib/CategoryTheory/ConcreteCategory/BundledHom.lean
@@ -34,14 +34,14 @@ structure BundledHom where
   comp : ∀ {α β γ : Type u} (Iα : c α) (Iβ : c β) (Iγ : c γ), hom Iβ Iγ → hom Iα Iβ → hom Iα Iγ
   /-- a bundled morphism is determined by the underlying map -/
   hom_ext : ∀ {α β : Type u} (Iα : c α) (Iβ : c β), Function.Injective (toFun Iα Iβ) := by
-    aesop_cat
+    cat_disch
   /-- compatibility with identities -/
   id_toFun : ∀ {α : Type u} (I : c α), toFun I I (id I) = _root_.id := by cat_disch
   /-- compatibility with the composition -/
   comp_toFun :
     ∀ {α β γ : Type u} (Iα : c α) (Iβ : c β) (Iγ : c γ) (f : hom Iα Iβ) (g : hom Iβ Iγ),
       toFun Iα Iγ (comp Iα Iβ Iγ g f) = toFun Iβ Iγ g ∘ toFun Iα Iβ f := by
-    aesop_cat
+    cat_disch
 
 attribute [class] BundledHom
 
@@ -62,7 +62,7 @@ instance category : Category (Bundled c) where
   id := fun X => BundledHom.id 𝒞 (α := X) X.str
   comp := fun {X Y Z} f g => BundledHom.comp 𝒞 (α := X) (β := Y) (γ := Z) X.str Y.str Z.str g f
   comp_id _ := by apply 𝒞.hom_ext; simp
-  assoc _ _ _ := by apply 𝒞.hom_ext; aesop_cat
+  assoc _ _ _ := by apply 𝒞.hom_ext; cat_disch
   id_comp _ := by apply 𝒞.hom_ext; simp
 
 /-- A category given by `BundledHom` is a concrete category. -/

--- a/Mathlib/CategoryTheory/Conj.lean
+++ b/Mathlib/CategoryTheory/Conj.lean
@@ -72,7 +72,7 @@ theorem conj_pow (f : End X) (n : ℕ) : α.conj (f ^ n) = α.conj f ^ n :=
 def conjAut : Aut X ≃* Aut Y :=
   (Aut.unitsEndEquivAut X).symm.trans <| (Units.mapEquiv α.conj).trans <| Aut.unitsEndEquivAut Y
 
-theorem conjAut_apply (f : Aut X) : α.conjAut f = α.symm ≪≫ f ≪≫ α := by aesop_cat
+theorem conjAut_apply (f : Aut X) : α.conjAut f = α.symm ≪≫ f ≪≫ α := by cat_disch
 
 @[simp]
 theorem conjAut_hom (f : Aut X) : (α.conjAut f).hom = α.conj f.hom :=

--- a/Mathlib/CategoryTheory/Core.lean
+++ b/Mathlib/CategoryTheory/Core.lean
@@ -133,22 +133,22 @@ lemma coreId {F : C ⥤ D} : (Iso.refl F).core = Iso.refl F.core := rfl
 lemma coreWhiskerLeft {E : Type u₃} [Category.{v₃} E] (F : C ⥤ D) {G H : D ⥤ E} (η : G ≅ H) :
     (isoWhiskerLeft F η).core =
     F.coreComp G ≪≫ isoWhiskerLeft F.core η.core ≪≫ (F.coreComp H).symm := by
-  aesop_cat
+  cat_disch
 
 lemma coreWhiskerRight {E : Type u₃} [Category.{v₃} E] {F G : C ⥤ D} (η : F ≅ G) (H : D ⥤ E) :
     (isoWhiskerRight η H ).core =
     F.coreComp H ≪≫ isoWhiskerRight η.core H.core ≪≫ (G.coreComp H).symm := by
-  aesop_cat
+  cat_disch
 
 lemma coreLeftUnitor {F : C ⥤ D} :
     F.leftUnitor.core =
     (𝟭 C).coreComp F ≪≫ isoWhiskerRight (Functor.coreId C) _ ≪≫ F.core.leftUnitor := by
-  aesop_cat
+  cat_disch
 
 lemma coreRightUnitor {F : C ⥤ D} :
     F.rightUnitor.core =
     (F).coreComp (𝟭 D) ≪≫ isoWhiskerLeft _ (Functor.coreId D) ≪≫ F.core.rightUnitor := by
-  aesop_cat
+  cat_disch
 
 lemma coreAssociator {E : Type u₃} [Category.{v₃} E] {E' : Type u₄} [Category.{v₄} E']
     (F : C ⥤ D) (G : D ⥤ E) (H : E ⥤ E') :
@@ -156,7 +156,7 @@ lemma coreAssociator {E : Type u₃} [Category.{v₃} E] {E' : Type u₄} [Categ
     (F ⋙ G).coreComp H ≪≫ isoWhiskerRight (F.coreComp G) H.core ≪≫
       Functor.associator F.core G.core H.core ≪≫ (isoWhiskerLeft F.core (G.coreComp H)).symm ≪≫
       (F.coreComp (G ⋙ H)).symm := by
-  aesop_cat
+  cat_disch
 
 end Iso
 

--- a/Mathlib/CategoryTheory/Dialectica/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Dialectica/Monoidal.lean
@@ -83,7 +83,7 @@ instance : MonoidalCategoryStruct (Dial C) where
   associator := associatorImpl
 
 theorem id_tensorHom_id (X₁ X₂ : Dial C) : (𝟙 X₁ ⊗ₘ 𝟙 X₂ : _ ⟶ _) = 𝟙 (X₁ ⊗ X₂ : Dial C) := by
-  aesop_cat
+  cat_disch
 
 @[deprecated (since := "2025-07-14")] alias tensor_id := id_tensorHom_id
 

--- a/Mathlib/CategoryTheory/Dialectica/Monoidal.lean
+++ b/Mathlib/CategoryTheory/Dialectica/Monoidal.lean
@@ -95,7 +95,7 @@ theorem tensor_comp {X₁ Y₁ Z₁ X₂ Y₂ Z₂ : Dial C}
 theorem associator_naturality {X₁ X₂ X₃ Y₁ Y₂ Y₃ : Dial C}
     (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (f₃ : X₃ ⟶ Y₃) :
     tensorHom (tensorHom f₁ f₂) f₃ ≫ (associator Y₁ Y₂ Y₃).hom =
-    (associator X₁ X₂ X₃).hom ≫ tensorHom f₁ (tensorHom f₂ f₃) := by aesop_cat
+    (associator X₁ X₂ X₃).hom ≫ tensorHom f₁ (tensorHom f₂ f₃) := by cat_disch
 
 theorem leftUnitor_naturality {X Y : Dial C} (f : X ⟶ Y) :
     (𝟙 (𝟙_ (Dial C)) ⊗ₘ f) ≫ (λ_ Y).hom = (λ_ X).hom ≫ f := by
@@ -113,7 +113,7 @@ theorem pentagon (W X Y Z : Dial C) :
 
 theorem triangle (X Y : Dial C) :
     (associator X (𝟙_ (Dial C)) Y).hom ≫ tensorHom (𝟙 X) (leftUnitor Y).hom =
-    tensorHom (rightUnitor X).hom (𝟙 Y) := by aesop_cat
+    tensorHom (rightUnitor X).hom (𝟙 Y) := by cat_disch
 
 instance : MonoidalCategory (Dial C) :=
   .ofTensorHom
@@ -131,23 +131,23 @@ instance : MonoidalCategory (Dial C) :=
     simp [Subobject.inf_pullback, ← Subobject.pullback_comp, inf_comm]
 
 theorem symmetry (X Y : Dial C) :
-    (braiding X Y).hom ≫ (braiding Y X).hom = 𝟙 (tensorObj X Y) := by aesop_cat
+    (braiding X Y).hom ≫ (braiding Y X).hom = 𝟙 (tensorObj X Y) := by cat_disch
 
 theorem braiding_naturality_right (X : Dial C) {Y Z : Dial C} (f : Y ⟶ Z) :
-    tensorHom (𝟙 X) f ≫ (braiding X Z).hom = (braiding X Y).hom ≫ tensorHom f (𝟙 X) := by aesop_cat
+    tensorHom (𝟙 X) f ≫ (braiding X Z).hom = (braiding X Y).hom ≫ tensorHom f (𝟙 X) := by cat_disch
 
 theorem braiding_naturality_left {X Y : Dial C} (f : X ⟶ Y) (Z : Dial C) :
-    tensorHom f (𝟙 Z) ≫ (braiding Y Z).hom = (braiding X Z).hom ≫ tensorHom (𝟙 Z) f := by aesop_cat
+    tensorHom f (𝟙 Z) ≫ (braiding Y Z).hom = (braiding X Z).hom ≫ tensorHom (𝟙 Z) f := by cat_disch
 
 theorem hexagon_forward (X Y Z : Dial C) :
     (associator X Y Z).hom ≫ (braiding X (Y ⊗ Z)).hom ≫ (associator Y Z X).hom =
       tensorHom (braiding X Y).hom (𝟙 Z) ≫ (associator Y X Z).hom ≫
-      tensorHom (𝟙 Y) (braiding X Z).hom := by aesop_cat
+      tensorHom (𝟙 Y) (braiding X Z).hom := by cat_disch
 
 theorem hexagon_reverse (X Y Z : Dial C) :
     (associator X Y Z).inv ≫ (braiding (X ⊗ Y) Z).hom ≫ (associator Z X Y).inv =
       tensorHom (𝟙 X) (braiding Y Z).hom ≫ (associator X Z Y).inv ≫
-      tensorHom (braiding X Z).hom (𝟙 Y) := by aesop_cat
+      tensorHom (braiding X Z).hom (𝟙 Y) := by cat_disch
 
 instance : SymmetricCategory (Dial C) where
   braiding := braiding

--- a/Mathlib/CategoryTheory/DifferentialObject.lean
+++ b/Mathlib/CategoryTheory/DifferentialObject.lean
@@ -304,7 +304,7 @@ def shiftZero : shiftFunctor C (0 : S) ≅ 𝟭 (DifferentialObject S C) := by
   · erw [← NatTrans.naturality]
     dsimp
     simp only [shiftFunctorZero_hom_app_shift, Category.assoc]
-  · aesop_cat
+  · cat_disch
 
 end
 

--- a/Mathlib/CategoryTheory/DifferentialObject.lean
+++ b/Mathlib/CategoryTheory/DifferentialObject.lean
@@ -39,7 +39,7 @@ structure DifferentialObject where
   /-- The differential of a differential object. -/
   d : obj ⟶ obj⟦(1 : S)⟧
   /-- The differential `d` satisfies that `d² = 0`. -/
-  d_squared : d ≫ d⟦(1 : S)⟧' = 0 := by aesop_cat
+  d_squared : d ≫ d⟦(1 : S)⟧' = 0 := by cat_disch
 
 attribute [reassoc (attr := simp)] DifferentialObject.d_squared
 
@@ -52,7 +52,7 @@ namespace DifferentialObject
 structure Hom (X Y : DifferentialObject S C) where
   /-- The morphism between underlying objects of the two differentiable objects. -/
   f : X.obj ⟶ Y.obj
-  comm : X.d ≫ f⟦1⟧' = f ≫ Y.d := by aesop_cat
+  comm : X.d ≫ f⟦1⟧' = f ≫ Y.d := by cat_disch
 
 attribute [reassoc (attr := simp)] Hom.comm
 
@@ -76,7 +76,7 @@ instance categoryOfDifferentialObjects : Category (DifferentialObject S C) where
   comp f g := Hom.comp f g
 
 @[ext]
-theorem ext {A B : DifferentialObject S C} {f g : A ⟶ B} (w : f.f = g.f := by aesop_cat) : f = g :=
+theorem ext {A B : DifferentialObject S C} {f g : A ⟶ B} (w : f.f = g.f := by cat_disch) : f = g :=
   Hom.ext w
 
 @[simp]

--- a/Mathlib/CategoryTheory/DinatTrans.lean
+++ b/Mathlib/CategoryTheory/DinatTrans.lean
@@ -36,7 +36,7 @@ structure DinatTrans (F G : Cᵒᵖ ⥤ C ⥤ D) : Type max u₁ v₂ where
   /-- The commutativity square for a given morphism. -/
   dinaturality {X Y : C} (f : X ⟶ Y) :
     (F.map f.op).app X ≫ app X ≫ (G.obj (op X)).map f =
-    (F.obj (op Y)).map f ≫ app Y ≫ (G.map f.op).app Y := by aesop_cat
+    (F.obj (op Y)).map f ≫ app Y ≫ (G.map f.op).app Y := by cat_disch
 
 attribute [reassoc (attr := simp)] DinatTrans.dinaturality
 

--- a/Mathlib/CategoryTheory/Discrete/Basic.lean
+++ b/Mathlib/CategoryTheory/Discrete/Basic.lean
@@ -103,7 +103,7 @@ Use:
 attribute [local aesop safe tactic (rule_sets := [CategoryTheory])]
   CategoryTheory.Discrete.discreteCases
 ```
-to locally gives `aesop_cat` the ability to call `cases` on
+to locally gives `cat_disch` the ability to call `cases` on
 `Discrete` and `(_ : Discrete _) ⟶ (_ : Discrete _)` hypotheses.
 -/
 def discreteCases : TacticM Unit := do

--- a/Mathlib/CategoryTheory/Discrete/Basic.lean
+++ b/Mathlib/CategoryTheory/Discrete/Basic.lean
@@ -58,8 +58,8 @@ theorem Discrete.mk_as {α : Type u₁} (X : Discrete α) : Discrete.mk X.as = X
 def discreteEquiv {α : Type u₁} : Discrete α ≃ α where
   toFun := Discrete.as
   invFun := Discrete.mk
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
+  left_inv := by cat_disch
+  right_inv := by cat_disch
 
 instance {α : Type u₁} [DecidableEq α] : DecidableEq (Discrete α) :=
   discreteEquiv.decidableEq
@@ -87,7 +87,7 @@ instance [Inhabited α] : Inhabited (Discrete α) :=
   ⟨⟨default⟩⟩
 
 instance [Subsingleton α] : Subsingleton (Discrete α) :=
-  ⟨by aesop_cat⟩
+  ⟨by cat_disch⟩
 
 instance instSubsingletonDiscreteHom (X Y : Discrete α) : Subsingleton (X ⟶ Y) :=
   show Subsingleton (ULift (PLift _)) from inferInstance
@@ -125,12 +125,12 @@ theorem eq_of_hom {X Y : Discrete α} (i : X ⟶ Y) : X.as = Y.as :=
 /-- Promote an equation between the wrapped terms in `X Y : Discrete α` to a morphism `X ⟶ Y`
 in the discrete category. -/
 protected abbrev eqToHom {X Y : Discrete α} (h : X.as = Y.as) : X ⟶ Y :=
-  eqToHom (by aesop_cat)
+  eqToHom (by cat_disch)
 
 /-- Promote an equation between the wrapped terms in `X Y : Discrete α` to an isomorphism `X ≅ Y`
 in the discrete category. -/
 protected abbrev eqToIso {X Y : Discrete α} (h : X.as = Y.as) : X ≅ Y :=
-  eqToIso (by aesop_cat)
+  eqToIso (by cat_disch)
 
 /-- A variant of `eqToHom` that lifts terms to the discrete category. -/
 abbrev eqToHom' {a b : α} (h : a = b) : Discrete.mk a ⟶ Discrete.mk b :=
@@ -147,7 +147,7 @@ theorem id_def (X : Discrete α) : ULift.up (PLift.up (Eq.refl X.as)) = 𝟙 X :
 variable {C : Type u₂} [Category.{v₂} C]
 
 instance {I : Type u₁} {i j : Discrete I} (f : i ⟶ j) : IsIso f :=
-  ⟨⟨Discrete.eqToHom (eq_of_hom f).symm, by aesop_cat⟩⟩
+  ⟨⟨Discrete.eqToHom (eq_of_hom f).symm, by cat_disch⟩⟩
 
 attribute [local aesop safe tactic (rule_sets := [CategoryTheory])]
   CategoryTheory.Discrete.discreteCases
@@ -166,7 +166,7 @@ theorem functor_obj {I : Type u₁} (F : I → C) (i : I) :
   rfl
 
 theorem functor_map {I : Type u₁} (F : I → C) {i : Discrete I} (f : i ⟶ i) :
-    (Discrete.functor F).map f = 𝟙 (F i.as) := by aesop_cat
+    (Discrete.functor F).map f = 𝟙 (F i.as) := by cat_disch
 
 @[simp]
 theorem functor_obj_eq_as {I : Type u₁} (F : I → C) (X : Discrete I) :
@@ -214,7 +214,7 @@ instance {I : Type*} {F G : Discrete I ⥤ C} (f : ∀ i, F.obj i ⟶ G.obj i) [
 
 @[simp]
 theorem natIso_app {I : Type u₁} {F G : Discrete I ⥤ C} (f : ∀ i : Discrete I, F.obj i ≅ G.obj i)
-    (i : Discrete I) : (Discrete.natIso f).app i = f i := by aesop_cat
+    (i : Discrete I) : (Discrete.natIso f).app i = f i := by cat_disch
 
 /-- Every functor `F` from a discrete category is naturally isomorphic (actually, equal) to
   `Discrete.functor (F.obj)`. -/
@@ -270,7 +270,7 @@ variable {C : Type u₂} [Category.{v₂} C]
 @[simp]
 theorem functor_map_id (F : Discrete J ⥤ C) {j : Discrete J} (f : j ⟶ j) :
     F.map f = 𝟙 (F.obj j) := by
-  have h : f = 𝟙 j := by aesop_cat
+  have h : f = 𝟙 j := by cat_disch
   rw [h]
   simp
 
@@ -292,7 +292,7 @@ def piEquivalenceFunctorDiscrete (J : Type u₂) (C : Type u₁) [Category.{v₁
       rintro ⟨x⟩ ⟨y⟩ f
       obtain rfl : x = y := Discrete.eq_of_hom f
       obtain rfl : f = 𝟙 _ := rfl
-      simp))) (by aesop_cat)
+      simp))) (by cat_disch)
 
 /-- A category is discrete when there is at most one morphism between two objects,
 in which case they are equal. -/
@@ -312,7 +312,7 @@ variable {C : Type*} [Category C] [IsDiscrete C]
 lemma obj_ext_of_isDiscrete {X Y : C} (f : X ⟶ Y) : X = Y := IsDiscrete.eq_of_hom f
 
 instance isIso_of_isDiscrete {X Y : C} (f : X ⟶ Y) : IsIso f :=
-  ⟨eqToHom (IsDiscrete.eq_of_hom f).symm, by aesop_cat⟩
+  ⟨eqToHom (IsDiscrete.eq_of_hom f).symm, by cat_disch⟩
 
 instance : IsDiscrete Cᵒᵖ where
   eq_of_hom := by

--- a/Mathlib/CategoryTheory/Elements.lean
+++ b/Mathlib/CategoryTheory/Elements.lean
@@ -140,7 +140,7 @@ instance : (π F).Faithful where
 
 instance : (π F).ReflectsIsomorphisms where
   reflects {X Y} f h := ⟨⟨⟨inv ((π F).map f),
-    by rw [← map_snd f, ← FunctorToTypes.map_comp_apply]; simp⟩, by aesop_cat⟩⟩
+    by rw [← map_snd f, ← FunctorToTypes.map_comp_apply]; simp⟩, by cat_disch⟩⟩
 
 /-- A natural transformation between functors induces a functor between the categories of elements.
 -/

--- a/Mathlib/CategoryTheory/Elements.lean
+++ b/Mathlib/CategoryTheory/Elements.lean
@@ -66,7 +66,7 @@ instance categoryOfElements (F : C ⥤ Type w) : Category.{v} F.Elements where
 @[simps]
 def NatTrans.mapElements {F G : C ⥤ Type w} (φ : F ⟶ G) : F.Elements ⥤ G.Elements where
   obj := fun ⟨X, x⟩ ↦ ⟨_, φ.app X x⟩
-  map {p q} := fun ⟨f, h⟩ ↦ ⟨f, by have hb := congrFun (φ.naturality f) p.2; aesop_cat⟩
+  map {p q} := fun ⟨f, h⟩ ↦ ⟨f, by have hb := congrFun (φ.naturality f) p.2; cat_disch⟩
 
 /-- The functor mapping functors `C ⥤ Type w` to their category of elements -/
 @[simps]

--- a/Mathlib/CategoryTheory/Endofunctor/Algebra.lean
+++ b/Mathlib/CategoryTheory/Endofunctor/Algebra.lean
@@ -62,7 +62,7 @@ structure Hom (A₀ A₁ : Algebra F) where
   /-- underlying morphism between the carriers -/
   f : A₀.1 ⟶ A₁.1
   /-- compatibility condition -/
-  h : F.map f ≫ A₁.str = A₀.str ≫ f := by aesop_cat
+  h : F.map f ≫ A₁.str = A₀.str ≫ f := by cat_disch
 
 attribute [reassoc (attr := simp)] Hom.h
 
@@ -85,7 +85,7 @@ instance (F : C ⥤ C) : CategoryStruct (Algebra F) where
   comp := @Hom.comp _ _ _
 
 @[ext]
-lemma ext {A B : Algebra F} {f g : A ⟶ B} (w : f.f = g.f := by aesop_cat) : f = g :=
+lemma ext {A B : Algebra F} {f g : A ⟶ B} (w : f.f = g.f := by cat_disch) : f = g :=
   Hom.ext w
 
 @[simp]
@@ -113,7 +113,7 @@ instance (F : C ⥤ C) : Category (Algebra F) := { }
 commutes with the structure morphisms.
 -/
 @[simps!]
-def isoMk (h : A₀.1 ≅ A₁.1) (w : F.map h.hom ≫ A₁.str = A₀.str ≫ h.hom := by aesop_cat) :
+def isoMk (h : A₀.1 ≅ A₁.1) (w : F.map h.hom ≫ A₁.str = A₀.str ≫ h.hom := by cat_disch) :
     A₀ ≅ A₁ where
   hom := { f := h.hom }
   inv :=
@@ -133,7 +133,7 @@ theorem iso_of_iso (f : A₀ ⟶ A₁) [IsIso f.1] : IsIso f :=
   ⟨⟨{ f := inv f.1
       h := by
         rw [IsIso.eq_comp_inv f.1, Category.assoc, ← f.h]
-        simp }, by aesop_cat, by aesop_cat⟩⟩
+        simp }, by cat_disch, by cat_disch⟩⟩
 
 instance forget_reflects_iso : (forget F).ReflectsIsomorphisms where reflects := iso_of_iso
 
@@ -252,7 +252,7 @@ structure Hom (V₀ V₁ : Coalgebra F) where
   /-- underlying morphism between two carriers -/
   f : V₀.1 ⟶ V₁.1
   /-- compatibility condition -/
-  h : V₀.str ≫ F.map f = f ≫ V₁.str := by aesop_cat
+  h : V₀.str ≫ F.map f = f ≫ V₁.str := by cat_disch
 
 attribute [reassoc (attr := simp)] Hom.h
 
@@ -275,7 +275,7 @@ instance (F : C ⥤ C) : CategoryStruct (Coalgebra F) where
   comp := @Hom.comp _ _ _
 
 @[ext]
-lemma ext {A B : Coalgebra F} {f g : A ⟶ B} (w : f.f = g.f := by aesop_cat) : f = g :=
+lemma ext {A B : Coalgebra F} {f g : A ⟶ B} (w : f.f = g.f := by cat_disch) : f = g :=
   Hom.ext w
 
 @[simp]
@@ -303,7 +303,7 @@ instance (F : C ⥤ C) : Category (Coalgebra F) := { }
 commutes with the structure morphisms.
 -/
 @[simps]
-def isoMk (h : V₀.1 ≅ V₁.1) (w : V₀.str ≫ F.map h.hom = h.hom ≫ V₁.str := by aesop_cat) :
+def isoMk (h : V₀.1 ≅ V₁.1) (w : V₀.str ≫ F.map h.hom = h.hom ≫ V₁.str := by cat_disch) :
     V₀ ≅ V₁ where
   hom := { f := h.hom }
   inv :=
@@ -323,7 +323,7 @@ theorem iso_of_iso (f : V₀ ⟶ V₁) [IsIso f.1] : IsIso f :=
   ⟨⟨{ f := inv f.1
       h := by
         rw [IsIso.eq_inv_comp f.1, ← Category.assoc, ← f.h, Category.assoc]
-        simp }, by aesop_cat, by aesop_cat⟩⟩
+        simp }, by cat_disch, by cat_disch⟩⟩
 
 instance forget_reflects_iso : (forget F).ReflectsIsomorphisms where reflects := iso_of_iso
 

--- a/Mathlib/CategoryTheory/Endomorphism.lean
+++ b/Mathlib/CategoryTheory/Endomorphism.lean
@@ -146,8 +146,8 @@ def toEnd (X : C) : Aut X →* End X := (Units.coeHom (End X)).comp (Aut.unitsEn
 def autMulEquivOfIso {X Y : C} (h : X ≅ Y) : Aut X ≃* Aut Y where
   toFun x := { hom := h.inv ≫ x.hom ≫ h.hom, inv := h.inv ≫ x.inv ≫ h.hom }
   invFun y := { hom := h.hom ≫ y.hom ≫ h.inv, inv := h.hom ≫ y.inv ≫ h.inv }
-  left_inv _ := by aesop_cat
-  right_inv _ := by aesop_cat
+  left_inv _ := by cat_disch
+  right_inv _ := by cat_disch
   map_mul' := by simp [Aut_mul_def]
 
 end Aut

--- a/Mathlib/CategoryTheory/Enriched/Basic.lean
+++ b/Mathlib/CategoryTheory/Enriched/Basic.lean
@@ -58,10 +58,10 @@ class EnrichedCategory (C : Type u₁) where
   id (X : C) : 𝟙_ V ⟶ Hom X X
   /-- Composition of two morphisms in this category -/
   comp (X Y Z : C) : Hom X Y ⊗ Hom Y Z ⟶ Hom X Z
-  id_comp (X Y : C) : (λ_ (Hom X Y)).inv ≫ id X ▷ _ ≫ comp X X Y = 𝟙 _ := by aesop_cat
-  comp_id (X Y : C) : (ρ_ (Hom X Y)).inv ≫ _ ◁ id Y ≫ comp X Y Y = 𝟙 _ := by aesop_cat
+  id_comp (X Y : C) : (λ_ (Hom X Y)).inv ≫ id X ▷ _ ≫ comp X X Y = 𝟙 _ := by cat_disch
+  comp_id (X Y : C) : (ρ_ (Hom X Y)).inv ≫ _ ◁ id Y ≫ comp X Y Y = 𝟙 _ := by cat_disch
   assoc (W X Y Z : C) : (α_ _ _ _).inv ≫ comp W X Y ▷ _ ≫ comp W Y Z =
-    _ ◁ comp X Y Z ≫ comp W X Z := by aesop_cat
+    _ ◁ comp X Y Z ≫ comp W X Z := by cat_disch
 
 @[inherit_doc EnrichedCategory.Hom] notation X " ⟶[" V "] " Y:10 => (EnrichedCategory.Hom X Y : V)
 
@@ -275,7 +275,7 @@ structure EnrichedFunctor (C : Type u₁) [EnrichedCategory V C] (D : Type u₂)
   obj : C → D
   /-- The `V`-morphism from `X ⟶[V] Y` to `F.obj X ⟶[V] F.obj Y`, for all `X Y : C` -/
   map : ∀ X Y : C, (X ⟶[V] Y) ⟶ obj X ⟶[V] obj Y
-  map_id : ∀ X : C, eId V X ≫ map X X = eId V (obj X) := by aesop_cat
+  map_id : ∀ X : C, eId V X ≫ map X X = eId V (obj X) := by cat_disch
   map_comp :
     ∀ X Y Z : C,
       eComp V X Y Z ≫ map X Z = (map X Y ⊗ₘ map Y Z) ≫ eComp V (obj X) (obj Y) (obj Z) := by
@@ -544,7 +544,7 @@ def enrichedNatTransYonedaTypeIsoYonedaNatTrans {C : Type v} [EnrichedCategory (
         inv := fun σ =>
           { app := fun X x => (σ x).app X
             naturality := fun X Y => by ext ⟨x, f⟩; exact (σ x).naturality f } })
-    (by aesop_cat)
+    (by cat_disch)
 
 end
 

--- a/Mathlib/CategoryTheory/Enriched/Basic.lean
+++ b/Mathlib/CategoryTheory/Enriched/Basic.lean
@@ -279,7 +279,7 @@ structure EnrichedFunctor (C : Type u₁) [EnrichedCategory V C] (D : Type u₂)
   map_comp :
     ∀ X Y Z : C,
       eComp V X Y Z ≫ map X Z = (map X Y ⊗ₘ map Y Z) ≫ eComp V (obj X) (obj Y) (obj Z) := by
-    aesop_cat
+    cat_disch
 
 attribute [reassoc (attr := simp)] EnrichedFunctor.map_id
 

--- a/Mathlib/CategoryTheory/Enriched/FunctorCategory.lean
+++ b/Mathlib/CategoryTheory/Enriched/FunctorCategory.lean
@@ -393,13 +393,13 @@ noncomputable def functorEnrichedComp [HasFunctorEnrichedHom V F₁ F₂]
 lemma functorEnriched_id_comp [HasFunctorEnrichedHom V F₁ F₂] [HasFunctorEnrichedHom V F₁ F₁] :
     (λ_ (functorEnrichedHom V F₁ F₂)).inv ≫
       functorEnrichedId V F₁ ▷ functorEnrichedHom V F₁ F₂ ≫
-        functorEnrichedComp V F₁ F₁ F₂ = 𝟙 (functorEnrichedHom V F₁ F₂) := by aesop_cat
+        functorEnrichedComp V F₁ F₁ F₂ = 𝟙 (functorEnrichedHom V F₁ F₂) := by cat_disch
 
 @[reassoc (attr := simp)]
 lemma functorEnriched_comp_id [HasFunctorEnrichedHom V F₁ F₂] [HasFunctorEnrichedHom V F₂ F₂] :
     (ρ_ (functorEnrichedHom V F₁ F₂)).inv ≫
       functorEnrichedHom V F₁ F₂ ◁ functorEnrichedId V F₂ ≫
-        functorEnrichedComp V F₁ F₂ F₂ = 𝟙 (functorEnrichedHom V F₁ F₂) := by aesop_cat
+        functorEnrichedComp V F₁ F₂ F₂ = 𝟙 (functorEnrichedHom V F₁ F₂) := by cat_disch
 
 @[reassoc]
 lemma functorEnriched_assoc [HasFunctorEnrichedHom V F₁ F₂] [HasFunctorEnrichedHom V F₂ F₃]
@@ -433,7 +433,7 @@ noncomputable def functorHomEquiv [HasFunctorEnrichedHom V F₁ F₂] [HasEnrich
   (homEquiv V).trans (isLimitConeFunctorEnrichedHom V F₁ F₂).homEquiv
 
 lemma functorHomEquiv_id [HasFunctorEnrichedHom V F₁ F₁] [HasEnrichedHom V F₁ F₁] :
-    (functorHomEquiv V) (𝟙 F₁) = functorEnrichedId V F₁ := by aesop_cat
+    (functorHomEquiv V) (𝟙 F₁) = functorEnrichedId V F₁ := by cat_disch
 
 variable {F₁ F₂ F₃} in
 lemma functorHomEquiv_comp [HasFunctorEnrichedHom V F₁ F₂] [HasEnrichedHom V F₁ F₂]

--- a/Mathlib/CategoryTheory/Enriched/Ordinary/Basic.lean
+++ b/Mathlib/CategoryTheory/Enriched/Ordinary/Basic.lean
@@ -40,10 +40,10 @@ class EnrichedOrdinaryCategory extends EnrichedCategory V C where
   /-- morphisms `X ⟶ Y` in the category identify morphisms
     `𝟙_ V ⟶ (X ⟶[V] Y)` in `V` -/
   homEquiv {X Y : C} : (X ⟶ Y) ≃ (𝟙_ V ⟶ (X ⟶[V] Y))
-  homEquiv_id (X : C) : homEquiv (𝟙 X) = eId V X := by aesop_cat
+  homEquiv_id (X : C) : homEquiv (𝟙 X) = eId V X := by cat_disch
   homEquiv_comp {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) :
     homEquiv (f ≫ g) = (λ_ _).inv ≫ (homEquiv f ⊗ₘ homEquiv g) ≫
-      eComp V X Y Z := by aesop_cat
+      eComp V X Y Z := by cat_disch
 
 variable [EnrichedOrdinaryCategory V C] {C}
 

--- a/Mathlib/CategoryTheory/EpiMono.lean
+++ b/Mathlib/CategoryTheory/EpiMono.lean
@@ -42,7 +42,7 @@ structure SplitMono {X Y : C} (f : X ⟶ Y) where
   /-- The map splitting `f` -/
   retraction : Y ⟶ X
   /-- `f` composed with `retraction` is the identity -/
-  id : f ≫ retraction = 𝟙 X := by aesop_cat
+  id : f ≫ retraction = 𝟙 X := by cat_disch
 
 attribute [reassoc (attr := simp)] SplitMono.id
 
@@ -72,7 +72,7 @@ structure SplitEpi {X Y : C} (f : X ⟶ Y) where
   /-- The map splitting `f` -/
   section_ : Y ⟶ X
   /-- `section_` composed with `f` is the identity -/
-  id : section_ ≫ f = 𝟙 Y := by aesop_cat
+  id : section_ ≫ f = 𝟙 Y := by cat_disch
 
 attribute [reassoc (attr := simp)] SplitEpi.id
 

--- a/Mathlib/CategoryTheory/EqToHom.lean
+++ b/Mathlib/CategoryTheory/EqToHom.lean
@@ -217,7 +217,7 @@ instance {X Y : C} (h : X = Y) : IsIso (eqToHom h) :=
 
 @[simp]
 theorem inv_eqToHom {X Y : C} (h : X = Y) : inv (eqToHom h) = eqToHom h.symm := by
-  aesop_cat
+  cat_disch
 
 variable {D : Type u₂} [Category.{v₂} D]
 

--- a/Mathlib/CategoryTheory/EqToHom.lean
+++ b/Mathlib/CategoryTheory/EqToHom.lean
@@ -227,7 +227,7 @@ namespace Functor
   because usually you don't really want to do this. -/
 theorem ext {F G : C ⥤ D} (h_obj : ∀ X, F.obj X = G.obj X)
     (h_map : ∀ X Y f,
-      F.map f = eqToHom (h_obj X) ≫ G.map f ≫ eqToHom (h_obj Y).symm := by aesop_cat) :
+      F.map f = eqToHom (h_obj X) ≫ G.map f ≫ eqToHom (h_obj Y).symm := by cat_disch) :
     F = G := by
   match F, G with
   | mk F_pre _ _ , mk G_pre _ _ =>
@@ -241,7 +241,7 @@ theorem ext {F G : C ⥤ D} (h_obj : ∀ X, F.obj X = G.obj X)
     simpa using h_map X Y f
 
 lemma ext_of_iso {F G : C ⥤ D} (e : F ≅ G) (hobj : ∀ X, F.obj X = G.obj X)
-    (happ : ∀ X, e.hom.app X = eqToHom (hobj X) := by aesop_cat) : F = G :=
+    (happ : ∀ X, e.hom.app X = eqToHom (hobj X) := by cat_disch) : F = G :=
   Functor.ext hobj (fun X Y f => by
     rw [← cancel_mono (e.hom.app Y), e.hom.naturality f, happ, happ, Category.assoc,
     Category.assoc, eqToHom_trans, eqToHom_refl, Category.comp_id])
@@ -313,7 +313,7 @@ theorem eqToHom_map (F : C ⥤ D) {X Y : C} (p : X = Y) :
 
 @[reassoc (attr := simp)]
 theorem eqToHom_map_comp (F : C ⥤ D) {X Y Z : C} (p : X = Y) (q : Y = Z) :
-    F.map (eqToHom p) ≫ F.map (eqToHom q) = F.map (eqToHom <| p.trans q) := by aesop_cat
+    F.map (eqToHom p) ≫ F.map (eqToHom q) = F.map (eqToHom <| p.trans q) := by cat_disch
 
 /-- See the note on `eqToHom_map` regarding using this as a `simp` lemma.
 -/
@@ -322,7 +322,7 @@ theorem eqToIso_map (F : C ⥤ D) {X Y : C} (p : X = Y) :
 
 @[simp]
 theorem eqToIso_map_trans (F : C ⥤ D) {X Y Z : C} (p : X = Y) (q : Y = Z) :
-    F.mapIso (eqToIso p) ≪≫ F.mapIso (eqToIso q) = F.mapIso (eqToIso <| p.trans q) := by aesop_cat
+    F.mapIso (eqToIso p) ≪≫ F.mapIso (eqToIso q) = F.mapIso (eqToIso <| p.trans q) := by cat_disch
 
 @[simp]
 theorem eqToHom_app {F G : C ⥤ D} (h : F = G) (X : C) :

--- a/Mathlib/CategoryTheory/Equivalence.lean
+++ b/Mathlib/CategoryTheory/Equivalence.lean
@@ -93,7 +93,7 @@ structure Equivalence (C : Type u₁) (D : Type u₂) [Category.{v₁} C] [Categ
   transformations to avoid abusing defeq or inserting natural transformations like `F ⟶ F𝟭`. -/
   functor_unitIso_comp :
     ∀ X : C, functor.map (unitIso.hom.app X) ≫ counitIso.hom.app (functor.obj X) =
-      𝟙 (functor.obj X) := by aesop_cat
+      𝟙 (functor.obj X) := by cat_disch
 
 @[inherit_doc Equivalence]
 infixr:10 " ≌ " => Equivalence
@@ -567,11 +567,11 @@ def changeFunctor (e : C ≌ D) {G : C ⥤ D} (iso : e.functor ≅ G) : C ≌ D 
   counitIso := isoWhiskerLeft _ iso.symm ≪≫ e.counitIso
 
 /-- Compatibility of `changeFunctor` with identity isomorphisms of functors -/
-theorem changeFunctor_refl (e : C ≌ D) : e.changeFunctor (Iso.refl _) = e := by aesop_cat
+theorem changeFunctor_refl (e : C ≌ D) : e.changeFunctor (Iso.refl _) = e := by cat_disch
 
 /-- Compatibility of `changeFunctor` with the composition of isomorphisms of functors -/
 theorem changeFunctor_trans (e : C ≌ D) {G G' : C ⥤ D} (iso₁ : e.functor ≅ G) (iso₂ : G ≅ G') :
-    (e.changeFunctor iso₁).changeFunctor iso₂ = e.changeFunctor (iso₁ ≪≫ iso₂) := by aesop_cat
+    (e.changeFunctor iso₁).changeFunctor iso₂ = e.changeFunctor (iso₁ ≪≫ iso₂) := by cat_disch
 
 /-- If `e : C ≌ D` is an equivalence of categories, and `iso : e.functor ≅ G` is
 an isomorphism, then there is an equivalence of categories whose inverse is `G`. -/

--- a/Mathlib/CategoryTheory/Equivalence/Symmetry.lean
+++ b/Mathlib/CategoryTheory/Equivalence/Symmetry.lean
@@ -36,7 +36,7 @@ variable (C : Type*) [Category C] (D : Type*) [Category D]
 def symmEquivFunctor : (C ≌ D) ⥤ (D ≌ C)ᵒᵖ where
   obj e := Opposite.op e.symm
   map {e f} α := (mkHom <| conjugateEquiv f.toAdjunction e.toAdjunction <| asNatTrans α).op
-  map_comp _ _ := Quiver.Hom.unop_inj (by aesop_cat)
+  map_comp _ _ := Quiver.Hom.unop_inj (by cat_disch)
 
 /-- The inverse functor of the equivalence `(C ≌ D) ≌ (D ≌ C)ᵒᵖ`. -/
 @[simps!]
@@ -45,7 +45,7 @@ def symmEquivInverse : (D ≌ C)ᵒᵖ ⥤ (C ≌ D) :=
     { obj e := Opposite.op e.symm
       map {e f} α := Quiver.Hom.op <| mkHom <|
         conjugateEquiv e.symm.toAdjunction f.symm.toAdjunction |>.invFun <| asNatTrans α
-      map_comp _ _ := Quiver.Hom.unop_inj (by aesop_cat) }
+      map_comp _ _ := Quiver.Hom.unop_inj (by cat_disch) }
 
 /-- Taking the symmetric of an equivalence induces an equivalence of categories
 `(C ≌ D) ≌ (D ≌ C)ᵒᵖ`. -/

--- a/Mathlib/CategoryTheory/Equivalence/Symmetry.lean
+++ b/Mathlib/CategoryTheory/Equivalence/Symmetry.lean
@@ -81,7 +81,7 @@ an isomorphism `e ≌ f` via `inverseFunctor` with the way we get one through
 lemma inverseFunctorMapIso_symm_eq_isoInverseOfIsoFunctor {e f : C ≌ D} (α : e ≅ f) :
     Iso.unop ((inverseFunctor C D).mapIso α.symm) =
     Iso.isoInverseOfIsoFunctor ((functorFunctor _ _).mapIso α) := by
-  aesop_cat
+  cat_disch
 
 /-- An "unopped" version of the equivalence `inverseFunctorObj'. -/
 @[simps!]

--- a/Mathlib/CategoryTheory/EssentiallySmall.lean
+++ b/Mathlib/CategoryTheory/EssentiallySmall.lean
@@ -249,7 +249,7 @@ instance essentiallySmall_fullSubcategory_mem (s : Set C) [Small.{w} s] [Locally
     EssentiallySmall.{w} (ObjectProperty.FullSubcategory (· ∈ s)) :=
   suffices Small.{w} (ObjectProperty.FullSubcategory (· ∈ s)) from
     essentiallySmall_of_small_of_locallySmall _
-  small_of_injective (f := fun x => (⟨x.1, x.2⟩ : s)) (by aesop_cat)
+  small_of_injective (f := fun x => (⟨x.1, x.2⟩ : s)) (by cat_disch)
 
 end FullSubcategory
 

--- a/Mathlib/CategoryTheory/Extensive.lean
+++ b/Mathlib/CategoryTheory/Extensive.lean
@@ -482,7 +482,7 @@ lemma FinitaryPreExtensive.hasPullbacks_of_is_coproduct [FinitaryPreExtensive C]
   { hom := Sigma.desc (fun j ↦ if h : j = i then eqToHom (congr_arg f h) ≫ coprod.inl else
       Sigma.ι (fun j : ({i}ᶜ : Set ι) ↦ f j) ⟨j, h⟩ ≫ coprod.inr)
     inv := coprod.desc (Sigma.ι f i) (Sigma.desc fun j ↦ Sigma.ι f j)
-    hom_inv_id := by aesop_cat
+    hom_inv_id := by cat_disch
     inv_hom_id := by
       ext j
       · simp

--- a/Mathlib/CategoryTheory/FiberedCategory/BasedCategory.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/BasedCategory.lean
@@ -54,7 +54,7 @@ def BasedCategory.ofFunctor {𝒳 : Type u₂} [Category.{v₂} 𝒳] (p : 𝒳 
 with the projections. -/
 structure BasedFunctor (𝒳 : BasedCategory.{v₂, u₂} 𝒮) (𝒴 : BasedCategory.{v₃, u₃} 𝒮) extends
     𝒳.obj ⥤ 𝒴.obj where
-  w : toFunctor ⋙ 𝒴.p = 𝒳.p := by aesop_cat
+  w : toFunctor ⋙ 𝒴.p = 𝒳.p := by cat_disch
 
 /-- Notation for `BasedFunctor`. -/
 scoped infixr:26 " ⥤ᵇ " => BasedFunctor
@@ -133,7 +133,7 @@ end BasedFunctor
 underlying functors, such that for all `a : 𝒳`, `α.app a` lifts `𝟙 S` whenever `𝒳.p.obj a = S`. -/
 structure BasedNatTrans {𝒳 : BasedCategory.{v₂, u₂} 𝒮} {𝒴 : BasedCategory.{v₃, u₃} 𝒮}
     (F G : 𝒳 ⥤ᵇ 𝒴) extends CategoryTheory.NatTrans F.toFunctor G.toFunctor where
-  isHomLift' : ∀ (a : 𝒳.obj), IsHomLift 𝒴.p (𝟙 (𝒳.p.obj a)) (toNatTrans.app a) := by aesop_cat
+  isHomLift' : ∀ (a : 𝒳.obj), IsHomLift 𝒴.p (𝟙 (𝒳.p.obj a)) (toNatTrans.app a) := by cat_disch
 
 namespace BasedNatTrans
 

--- a/Mathlib/CategoryTheory/FiberedCategory/Cartesian.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/Cartesian.lean
@@ -336,7 +336,7 @@ instance of_iso (φ : a ≅ b) [IsHomLift p f φ.hom] : IsStronglyCartesian p f 
   universal_property' := by
     intro a' g τ hτ
     use τ ≫ φ.inv
-    refine ⟨?_, by aesop_cat⟩
+    refine ⟨?_, by cat_disch⟩
     simpa using (IsHomLift.comp p (g ≫ f) (isoOfIsoLift p f φ).inv τ φ.inv)
 
 instance of_isIso (φ : a ⟶ b) [IsHomLift p f φ] [IsIso φ] : IsStronglyCartesian p f φ :=

--- a/Mathlib/CategoryTheory/FiberedCategory/Cocartesian.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/Cocartesian.lean
@@ -326,7 +326,7 @@ instance of_iso (φ : a ≅ b) [IsHomLift p f φ.hom] : IsStronglyCocartesian p 
   universal_property' := by
     intro b' g τ hτ
     use φ.inv ≫ τ
-    refine ⟨?_, by aesop_cat⟩
+    refine ⟨?_, by cat_disch⟩
     simpa [← assoc] using (IsHomLift.comp p (isoOfIsoLift p f φ).inv (f ≫ g) φ.inv τ)
 
 instance of_isIso (φ : a ⟶ b) [IsHomLift p f φ] [IsIso φ] : IsStronglyCocartesian p f φ :=

--- a/Mathlib/CategoryTheory/FintypeCat.lean
+++ b/Mathlib/CategoryTheory/FintypeCat.lean
@@ -101,8 +101,8 @@ def equivEquivIso {A B : FintypeCat} : A ≃ B ≃ (A ≅ B) where
       invFun := i.inv
       left_inv := congr_fun i.hom_inv_id
       right_inv := congr_fun i.inv_hom_id }
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
+  left_inv := by cat_disch
+  right_inv := by cat_disch
 
 instance (X Y : FintypeCat) : Finite (X ⟶ Y) :=
   inferInstanceAs <| Finite (X → Y)

--- a/Mathlib/CategoryTheory/Functor/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/Basic.lean
@@ -121,7 +121,7 @@ protected theorem id_comp (F : C ⥤ D) : 𝟭 C ⋙ F = F := by cases F; rfl
 theorem map_dite (F : C ⥤ D) {X Y : C} {P : Prop} [Decidable P]
     (f : P → (X ⟶ Y)) (g : ¬P → (X ⟶ Y)) :
     F.map (if h : P then f h else g h) = if h : P then F.map (f h) else F.map (g h) := by
-  aesop_cat
+  cat_disch
 
 @[simp]
 theorem toPrefunctor_comp (F : C ⥤ D) (G : D ⥤ E) :

--- a/Mathlib/CategoryTheory/Functor/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/Basic.lean
@@ -37,9 +37,9 @@ structure Functor (C : Type u₁) [Category.{v₁} C] (D : Type u₂) [Category.
     Type max v₁ v₂ u₁ u₂
     extends Prefunctor C D where
   /-- A functor preserves identity morphisms. -/
-  map_id : ∀ X : C, map (𝟙 X) = 𝟙 (obj X) := by aesop_cat
+  map_id : ∀ X : C, map (𝟙 X) = 𝟙 (obj X) := by cat_disch
   /-- A functor preserves composition. -/
-  map_comp : ∀ {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z), map (f ≫ g) = map f ≫ map g := by aesop_cat
+  map_comp : ∀ {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z), map (f ≫ g) = map f ≫ map g := by cat_disch
 
 /-- The prefunctor between the underlying quivers. -/
 add_decl_doc Functor.toPrefunctor

--- a/Mathlib/CategoryTheory/Functor/Category.lean
+++ b/Mathlib/CategoryTheory/Functor/Category.lean
@@ -129,7 +129,7 @@ theorem id_hcomp_app {H : E ⥤ C} (α : F ⟶ G) (X : E) : (𝟙 H ◫ α).app 
 -- but relying on the definitional equality causes bad problems with elaboration later.)
 theorem exchange {I J K : D ⥤ E} (α : F ⟶ G) (β : G ⟶ H) (γ : I ⟶ J) (δ : J ⟶ K) :
     (α ≫ β) ◫ (γ ≫ δ) = (α ◫ γ) ≫ β ◫ δ := by
-  aesop_cat
+  cat_disch
 
 end NatTrans
 

--- a/Mathlib/CategoryTheory/Functor/Const.lean
+++ b/Mathlib/CategoryTheory/Functor/Const.lean
@@ -97,7 +97,7 @@ def compConstIso (F : C ⥤ D) :
     F ⋙ Functor.const J ≅ Functor.const J ⋙ (whiskeringRight J C D).obj F :=
   NatIso.ofComponents
     (fun X => NatIso.ofComponents (fun _ => Iso.refl _) (by simp))
-    (by aesop_cat)
+    (by cat_disch)
 
 /-- The canonical isomorphism
 `const D ⋙ (whiskeringLeft J _ _).obj F ≅ const J` -/

--- a/Mathlib/CategoryTheory/Functor/Currying.lean
+++ b/Mathlib/CategoryTheory/Functor/Currying.lean
@@ -153,7 +153,7 @@ lemma curry_obj_injective {F₁ F₂ : C × D ⥤ E} (h : curry.obj F₁ = curry
   rw [← uncurry_obj_curry_obj F₁, ← uncurry_obj_curry_obj F₂, h]
 
 lemma curry_obj_uncurry_obj (F : B ⥤ C ⥤ D) : curry.obj (uncurry.obj F) = F :=
-  Functor.ext (fun _ => Functor.ext (by simp) (by simp)) (by aesop_cat)
+  Functor.ext (fun _ => Functor.ext (by simp) (by simp)) (by cat_disch)
 
 lemma uncurry_obj_injective {F₁ F₂ : B ⥤ C ⥤ D} (h : uncurry.obj F₁ = uncurry.obj F₂) :
     F₁ = F₂ := by

--- a/Mathlib/CategoryTheory/Functor/Derived/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Functor/Derived/Adjunction.lean
@@ -47,9 +47,9 @@ open Functor
 def derived' [G'.IsLeftDerivedFunctor α W₁] [F'.IsRightDerivedFunctor β W₂]
     (η : 𝟭 D₁ ⟶ G' ⋙ F') (ε : F' ⋙ G' ⟶ 𝟭 D₂)
     (hη : ∀ (X₁ : C₁), η.app (L₁.obj X₁) ≫ F'.map (α.app X₁) =
-      L₁.map (adj.unit.app X₁) ≫ β.app (G.obj X₁) := by aesop_cat)
+      L₁.map (adj.unit.app X₁) ≫ β.app (G.obj X₁) := by cat_disch)
     (hε : ∀ (X₂ : C₂), G'.map (β.app X₂) ≫ ε.app (L₂.obj X₂) =
-      α.app (F.obj X₂) ≫ L₂.map (adj.counit.app X₂) := by aesop_cat) : G' ⊣ F' where
+      α.app (F.obj X₂) ≫ L₂.map (adj.counit.app X₂) := by cat_disch) : G' ⊣ F' where
   unit := η
   counit := ε
   left_triangle_components := by

--- a/Mathlib/CategoryTheory/Functor/EpiMono.lean
+++ b/Mathlib/CategoryTheory/Functor/EpiMono.lean
@@ -194,8 +194,8 @@ noncomputable def splitEpiEquiv [Full F] [Faithful F] : SplitEpi f ≃ SplitEpi 
     apply F.map_injective
     simp only [map_comp, map_preimage, map_id]
     apply SplitEpi.id⟩
-  left_inv := by aesop_cat
-  right_inv x := by aesop_cat
+  left_inv := by cat_disch
+  right_inv x := by cat_disch
 
 @[simp]
 theorem isSplitEpi_iff [Full F] [Faithful F] : IsSplitEpi (F.map f) ↔ IsSplitEpi f := by
@@ -212,8 +212,8 @@ noncomputable def splitMonoEquiv [Full F] [Faithful F] : SplitMono f ≃ SplitMo
     apply F.map_injective
     simp only [map_comp, map_preimage, map_id]
     apply SplitMono.id⟩
-  left_inv := by aesop_cat
-  right_inv x := by aesop_cat
+  left_inv := by cat_disch
+  right_inv x := by cat_disch
 
 @[simp]
 theorem isSplitMono_iff [Full F] [Faithful F] : IsSplitMono (F.map f) ↔ IsSplitMono f := by

--- a/Mathlib/CategoryTheory/Functor/FullyFaithful.lean
+++ b/Mathlib/CategoryTheory/Functor/FullyFaithful.lean
@@ -46,7 +46,7 @@ class Full (F : C ⥤ D) : Prop where
 class Faithful (F : C ⥤ D) : Prop where
   /-- `F.map` is injective for each `X Y : C`. -/
   map_injective : ∀ {X Y : C}, Function.Injective (F.map : (X ⟶ Y) → (F.obj X ⟶ F.obj Y)) := by
-    aesop_cat
+    cat_disch
 
 variable {X Y : C}
 

--- a/Mathlib/CategoryTheory/Functor/FullyFaithful.lean
+++ b/Mathlib/CategoryTheory/Functor/FullyFaithful.lean
@@ -117,8 +117,8 @@ in order to express that `F` is a fully faithful functor. -/
 structure FullyFaithful where
   /-- The inverse map `(F.obj X ⟶ F.obj Y) ⟶ (X ⟶ Y)` of `F.map`. -/
   preimage {X Y : C} (f : F.obj X ⟶ F.obj Y) : X ⟶ Y
-  map_preimage {X Y : C} (f : F.obj X ⟶ F.obj Y) : F.map (preimage f) = f := by aesop_cat
-  preimage_map {X Y : C} (f : X ⟶ Y) : preimage (F.map f) = f := by aesop_cat
+  map_preimage {X Y : C} (f : F.obj X ⟶ F.obj Y) : F.map (preimage f) = f := by cat_disch
+  preimage_map {X Y : C} (f : X ⟶ Y) : preimage (F.map f) = f := by cat_disch
 
 namespace FullyFaithful
 
@@ -204,8 +204,8 @@ lemma isIso_of_isIso_map {X Y : C} (f : X ⟶ Y) [IsIso (F.map f)] :
 def isoEquiv {X Y : C} : (X ≅ Y) ≃ (F.obj X ≅ F.obj Y) where
   toFun := F.mapIso
   invFun := hF.preimageIso
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
+  left_inv := by cat_disch
+  right_inv := by cat_disch
 
 /-- Fully faithful functors are stable by composition. -/
 @[simps]

--- a/Mathlib/CategoryTheory/Functor/FunctorHom.lean
+++ b/Mathlib/CategoryTheory/Functor/FunctorHom.lean
@@ -37,7 +37,7 @@ structure HomObj (A : C ⥤ Type w) where
   /-- The morphism `F.obj c ⟶ G.obj c` associated with `a : A.obj c`. -/
   app (c : C) (a : A.obj c) : F.obj c ⟶ G.obj c
   naturality {c d : C} (f : c ⟶ d) (a : A.obj c) :
-    F.map f ≫ app d (A.map f a) = app c a ≫ G.map f := by aesop_cat
+    F.map f ≫ app d (A.map f a) = app c a ≫ G.map f := by cat_disch
 
 /-- When `F`, `G`, and `A` are all functors `C ⥤ Type w`, then `HomObj F G A` is in
 bijection with `F ⊗ A ⟶ G`. -/

--- a/Mathlib/CategoryTheory/Functor/Functorial.lean
+++ b/Mathlib/CategoryTheory/Functor/Functorial.lean
@@ -25,7 +25,7 @@ class Functorial (F : C → D) : Type max v₁ v₂ u₁ u₂ where
   we can write `map F f : F X ⟶ F Y` for the action of `F` on a morphism `f : X ⟶ Y`. -/
   map (F) : ∀ {X Y : C}, (X ⟶ Y) → (F X ⟶ F Y)
   /-- A functorial map preserves identities. -/
-  map_id : ∀ {X : C}, map (𝟙 X) = 𝟙 (F X) := by aesop_cat
+  map_id : ∀ {X : C}, map (𝟙 X) = 𝟙 (F X) := by cat_disch
   /-- A functorial map preserves composition of morphisms. -/
   map_comp : ∀ {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z}, map (f ≫ g) = map f ≫ map g := by
     aesop_cat

--- a/Mathlib/CategoryTheory/Functor/Functorial.lean
+++ b/Mathlib/CategoryTheory/Functor/Functorial.lean
@@ -28,7 +28,7 @@ class Functorial (F : C → D) : Type max v₁ v₂ u₁ u₂ where
   map_id : ∀ {X : C}, map (𝟙 X) = 𝟙 (F X) := by cat_disch
   /-- A functorial map preserves composition of morphisms. -/
   map_comp : ∀ {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z}, map (f ≫ g) = map f ≫ map g := by
-    aesop_cat
+    cat_disch
 
 attribute [simp] Functorial.map_id Functorial.map_comp
 export Functorial (map)

--- a/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
+++ b/Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean
@@ -103,7 +103,7 @@ noncomputable def homEquivOfIsRightKanExtension (G : D ⥤ H) :
   toFun β := whiskerLeft _ β ≫ α
   invFun β := liftOfIsRightKanExtension _ α _ β
   left_inv β := Functor.hom_ext_of_isRightKanExtension _ α _ _ (by simp)
-  right_inv := by aesop_cat
+  right_inv := by cat_disch
 
 lemma isRightKanExtension_of_iso {F' F'' : D ⥤ H} (e : F' ≅ F'') {L : C ⥤ D} {F : C ⥤ H}
     (α : L ⋙ F' ⟶ F) (α' : L ⋙ F'' ⟶ F) (comm : whiskerLeft L e.hom ≫ α' = α)
@@ -195,7 +195,7 @@ noncomputable def homEquivOfIsLeftKanExtension (G : D ⥤ H) :
   toFun β := α ≫ whiskerLeft _ β
   invFun β := descOfIsLeftKanExtension _ α _ β
   left_inv β := Functor.hom_ext_of_isLeftKanExtension _ α _ _ (by simp)
-  right_inv := by aesop_cat
+  right_inv := by cat_disch
 
 lemma isLeftKanExtension_of_iso {F' : D ⥤ H} {F'' : D ⥤ H} (e : F' ≅ F'')
     {L : C ⥤ D} {F : C ⥤ H} (α : F ⟶ L ⋙ F') (α' : F ⟶ L ⋙ F'')
@@ -609,7 +609,7 @@ noncomputable def isColimitCoconeOfIsLeftKanExtension {c : Cocone F} (hc : IsCol
   fac s := by
     have : F'.descOfIsLeftKanExtension α ((const D).obj c.pt) c.ι ≫
         (Functor.const _).map (hc.desc (Cocone.mk _ (α ≫ whiskerLeft L s.ι))) = s.ι :=
-      F'.hom_ext_of_isLeftKanExtension α _ _ (by aesop_cat)
+      F'.hom_ext_of_isLeftKanExtension α _ _ (by cat_disch)
     exact congr_app this
   uniq s m hm := hc.hom_ext (fun j ↦ by
     have := hm (L.obj j)
@@ -660,7 +660,7 @@ noncomputable def isLimitConeOfIsRightKanExtension {c : Cone F} (hc : IsLimit c)
   fac s := by
     have : (Functor.const _).map (hc.lift (Cone.mk _ (whiskerLeft L s.π ≫ α))) ≫
         F'.liftOfIsRightKanExtension α ((const D).obj c.pt) c.π = s.π :=
-      F'.hom_ext_of_isRightKanExtension α _ _ (by aesop_cat)
+      F'.hom_ext_of_isRightKanExtension α _ _ (by cat_disch)
     exact congr_app this
   uniq s m hm := hc.hom_ext (fun j ↦ by
     have := hm (L.obj j)

--- a/Mathlib/CategoryTheory/GradedObject.lean
+++ b/Mathlib/CategoryTheory/GradedObject.lean
@@ -168,10 +168,10 @@ def comapEq {β γ : Type w} {f g : β → γ} (h : f = g) : comap C f ≅ comap
   inv := { app := fun X b => eqToHom (by dsimp; simp only [h]) }
 
 theorem comapEq_symm {β γ : Type w} {f g : β → γ} (h : f = g) :
-    comapEq C h.symm = (comapEq C h).symm := by aesop_cat
+    comapEq C h.symm = (comapEq C h).symm := by cat_disch
 
 theorem comapEq_trans {β γ : Type w} {f g h : β → γ} (k : f = g) (l : g = h) :
-    comapEq C (k.trans l) = comapEq C k ≪≫ comapEq C l := by aesop_cat
+    comapEq C (k.trans l) = comapEq C k ≪≫ comapEq C l := by cat_disch
 
 theorem eqToHom_apply {β : Type w} {X Y : β → C} (h : X = Y) (b : β) :
     (eqToHom h : X ⟶ Y) b = eqToHom (by rw [h]) := by
@@ -195,7 +195,7 @@ end
 instance hasShift {β : Type*} [AddCommGroup β] (s : β) : HasShift (GradedObjectWithShift s C) ℤ :=
   hasShiftMk _ _
     { F := fun n => comap C fun b : β => b + n • s
-      zero := comapEq C (by aesop_cat) ≪≫ Pi.comapId β fun _ => C
+      zero := comapEq C (by cat_disch) ≪≫ Pi.comapId β fun _ => C
       add := fun m n => comapEq C (by ext; dsimp; rw [add_comm m n, add_zsmul, add_assoc]) ≪≫
           (Pi.comapComp _ _ _).symm }
 
@@ -407,12 +407,12 @@ lemma congr_mapMap (φ₁ φ₂ : X ⟶ Y) (h : φ₁ = φ₂) : mapMap φ₁ p 
 variable (X)
 
 @[simp]
-lemma mapMap_id : mapMap (𝟙 X) p = 𝟙 _ := by aesop_cat
+lemma mapMap_id : mapMap (𝟙 X) p = 𝟙 _ := by cat_disch
 
 variable {X Z}
 
 @[simp, reassoc]
-lemma mapMap_comp [Z.HasMap p] : mapMap (φ ≫ ψ) p = mapMap φ p ≫ mapMap ψ p := by aesop_cat
+lemma mapMap_comp [Z.HasMap p] : mapMap (φ ≫ ψ) p = mapMap φ p ≫ mapMap ψ p := by cat_disch
 
 /-- The isomorphism of `J`-graded objects `X.mapObj p ≅ Y.mapObj p` induced by an
 isomorphism `X ≅ Y` of graded objects and a map `p : I → J`. -/

--- a/Mathlib/CategoryTheory/GradedObject.lean
+++ b/Mathlib/CategoryTheory/GradedObject.lean
@@ -228,7 +228,7 @@ open ZeroObject
 instance hasZeroObject [HasZeroObject C] [HasZeroMorphisms C] (β : Type w) :
     HasZeroObject.{max w v} (GradedObject β C) := by
   refine ⟨⟨fun _ => 0, fun X => ⟨⟨⟨fun b => 0⟩, fun f => ?_⟩⟩, fun X =>
-    ⟨⟨⟨fun b => 0⟩, fun f => ?_⟩⟩⟩⟩ <;> aesop_cat
+    ⟨⟨⟨fun b => 0⟩, fun f => ?_⟩⟩⟩⟩ <;> cat_disch
 
 end
 

--- a/Mathlib/CategoryTheory/GradedObject/Braiding.lean
+++ b/Mathlib/CategoryTheory/GradedObject/Braiding.lean
@@ -47,14 +47,14 @@ lemma braiding_naturality_right [HasTensor X Y] [HasTensor Y X] [HasTensor X Z] 
     (f : Y ⟶ Z) :
     whiskerLeft X f ≫ (braiding X Z).hom = (braiding X Y).hom ≫ whiskerRight f X  := by
   dsimp [braiding]
-  aesop_cat
+  cat_disch
 
 variable {X Y} in
 lemma braiding_naturality_left [HasTensor Y Z] [HasTensor Z Y] [HasTensor X Z] [HasTensor Z X]
     (f : X ⟶ Y) :
     whiskerRight f Z ≫ (braiding Y Z).hom = (braiding X Z).hom ≫ whiskerLeft Z f  := by
   dsimp [braiding]
-  aesop_cat
+  cat_disch
 
 lemma hexagon_forward [HasTensor X Y] [HasTensor Y X] [HasTensor Y Z]
     [HasTensor Z X] [HasTensor X Z]
@@ -136,7 +136,7 @@ end Braided
 lemma symmetry [SymmetricCategory C] [HasTensor X Y] [HasTensor Y X] :
     (braiding X Y).hom ≫ (braiding Y X).hom = 𝟙 _ := by
   dsimp [braiding]
-  aesop_cat
+  cat_disch
 
 end Monoidal
 

--- a/Mathlib/CategoryTheory/GradedObject/Monoidal.lean
+++ b/Mathlib/CategoryTheory/GradedObject/Monoidal.lean
@@ -314,7 +314,7 @@ lemma associator_naturality (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (f₃ 
     [HasGoodTensor₁₂Tensor Y₁ Y₂ Y₃] [HasGoodTensorTensor₂₃ Y₁ Y₂ Y₃] :
     tensorHom (tensorHom f₁ f₂) f₃ ≫ (associator Y₁ Y₂ Y₃).hom =
       (associator X₁ X₂ X₃).hom ≫ tensorHom f₁ (tensorHom f₂ f₃) := by
-        aesop_cat
+        cat_disch
 
 end
 

--- a/Mathlib/CategoryTheory/GradedObject/Trifunctor.lean
+++ b/Mathlib/CategoryTheory/GradedObject/Trifunctor.lean
@@ -322,10 +322,10 @@ noncomputable def isColimitCofan₃MapBifunctor₁₂BifunctorMapObj (j : J) :
   let Z := (((mapTrifunctor (bifunctorComp₁₂ F₁₂ G) I₁ I₂ I₃).obj X₁).obj X₂).obj X₃
   let p' : I₁ × I₂ × I₃ → ρ₁₂.I₁₂ × I₃ := fun ⟨i₁, i₂, i₃⟩ => ⟨ρ₁₂.p ⟨i₁, i₂⟩, i₃⟩
   let e : ∀ (i₁₂ : ρ₁₂.I₁₂) (i₃ : I₃), p' ⁻¹' {(i₁₂, i₃)} ≃ ρ₁₂.p ⁻¹' {i₁₂} := fun i₁₂ i₃ =>
-    { toFun := fun ⟨⟨i₁, i₂, i₃'⟩, hi⟩ => ⟨⟨i₁, i₂⟩, by aesop_cat⟩
-      invFun := fun ⟨⟨i₁, i₂⟩, hi⟩ => ⟨⟨i₁, i₂, i₃⟩, by aesop_cat⟩
+    { toFun := fun ⟨⟨i₁, i₂, i₃'⟩, hi⟩ => ⟨⟨i₁, i₂⟩, by cat_disch⟩
+      invFun := fun ⟨⟨i₁, i₂⟩, hi⟩ => ⟨⟨i₁, i₂, i₃⟩, by cat_disch⟩
       left_inv := fun ⟨⟨i₁, i₂, i₃'⟩, hi⟩ => by
-        obtain rfl : i₃ = i₃' := by aesop_cat
+        obtain rfl : i₃ = i₃' := by cat_disch
         rfl }
   let c₁₂'' : ∀ (i : ρ₁₂.q ⁻¹' {j}), CofanMapObjFun Z p' (i.1.1, i.1.2) :=
     fun ⟨⟨i₁₂, i₃⟩, hi⟩ => by
@@ -500,10 +500,10 @@ noncomputable def isColimitCofan₃MapBifunctorBifunctor₂₃MapObj (j : J) :
   let Z := (((mapTrifunctor (bifunctorComp₂₃ F G₂₃) I₁ I₂ I₃).obj X₁).obj X₂).obj X₃
   let p' : I₁ × I₂ × I₃ → I₁ × ρ₂₃.I₂₃ := fun ⟨i₁, i₂, i₃⟩ => ⟨i₁, ρ₂₃.p ⟨i₂, i₃⟩⟩
   let e : ∀ (i₁ : I₁) (i₂₃ : ρ₂₃.I₂₃) , p' ⁻¹' {(i₁, i₂₃)} ≃ ρ₂₃.p ⁻¹' {i₂₃} := fun i₁ i₂₃ =>
-    { toFun := fun ⟨⟨i₁', i₂, i₃⟩, hi⟩ => ⟨⟨i₂, i₃⟩, by aesop_cat⟩
-      invFun := fun ⟨⟨i₂, i₃⟩, hi⟩  => ⟨⟨i₁, i₂, i₃⟩, by aesop_cat⟩
+    { toFun := fun ⟨⟨i₁', i₂, i₃⟩, hi⟩ => ⟨⟨i₂, i₃⟩, by cat_disch⟩
+      invFun := fun ⟨⟨i₂, i₃⟩, hi⟩  => ⟨⟨i₁, i₂, i₃⟩, by cat_disch⟩
       left_inv := fun ⟨⟨i₁', i₂, i₃⟩, hi⟩ => by
-        obtain rfl : i₁ = i₁' := by aesop_cat
+        obtain rfl : i₁ = i₁' := by cat_disch
         rfl }
   let c₂₃'' : ∀ (i : ρ₂₃.q ⁻¹' {j}), CofanMapObjFun Z p' (i.1.1, i.1.2) :=
     fun ⟨⟨i₁, i₂₃⟩, hi⟩ => by

--- a/Mathlib/CategoryTheory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Grothendieck.lean
@@ -91,7 +91,7 @@ theorem ext {X Y : Grothendieck F} (f g : Hom X Y) (w_base : f.base = g.base)
   cases f; cases g
   congr
   dsimp at w_base
-  aesop_cat
+  cat_disch
 
 /-- The identity morphism in the Grothendieck category.
 -/

--- a/Mathlib/CategoryTheory/Groupoid.lean
+++ b/Mathlib/CategoryTheory/Groupoid.lean
@@ -41,9 +41,9 @@ class Groupoid (obj : Type u) : Type max u (v + 1) extends Category.{v} obj wher
   /-- The inverse morphism -/
   inv : ∀ {X Y : obj}, (X ⟶ Y) → (Y ⟶ X)
   /-- `inv f` composed `f` is the identity -/
-  inv_comp : ∀ {X Y : obj} (f : X ⟶ Y), comp (inv f) f = id Y := by aesop_cat
+  inv_comp : ∀ {X Y : obj} (f : X ⟶ Y), comp (inv f) f = id Y := by cat_disch
   /-- `f` composed with `inv f` is the identity -/
-  comp_inv : ∀ {X Y : obj} (f : X ⟶ Y), comp f (inv f) = id X := by aesop_cat
+  comp_inv : ∀ {X Y : obj} (f : X ⟶ Y), comp f (inv f) = id X := by cat_disch
 
 initialize_simps_projections Groupoid (-Hom)
 

--- a/Mathlib/CategoryTheory/GuitartExact/Opposite.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/Opposite.lean
@@ -93,7 +93,7 @@ lemma guitartExact_op_iff : w.op.GuitartExact ↔ w.GuitartExact := by
   · intro
     let w₁ : TwoSquare T (opOp C₁) (opOp C₂) T.op.op := 𝟙 _
     let w₂ : TwoSquare B.op.op (unopUnop C₃) (unopUnop C₄) B := 𝟙 _
-    have : w = (w₁ ≫ᵥ w.op.op) ≫ᵥ w₂ := by aesop_cat
+    have : w = (w₁ ≫ᵥ w.op.op) ≫ᵥ w₂ := by cat_disch
     rw [this]
     infer_instance
   · intro

--- a/Mathlib/CategoryTheory/HomCongr.lean
+++ b/Mathlib/CategoryTheory/HomCongr.lean
@@ -63,8 +63,8 @@ there is a bijection between `X ≅ Y` and `X₁ ≅ Y₁`. -/
 def isoCongr {X₁ Y₁ X₂ Y₂ : C} (f : X₁ ≅ X₂) (g : Y₁ ≅ Y₂) : (X₁ ≅ Y₁) ≃ (X₂ ≅ Y₂) where
   toFun h := f.symm.trans <| h.trans <| g
   invFun h := f.trans <| h.trans <| g.symm
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
+  left_inv := by cat_disch
+  right_inv := by cat_disch
 
 /-- If `X₁` is isomorphic to `X₂`, then there is a bijection between `X₁ ≅ Y` and `X₂ ≅ Y`. -/
 def isoCongrLeft {X₁ X₂ Y : C} (f : X₁ ≅ X₂) : (X₁ ≅ Y) ≃ (X₂ ≅ Y) :=

--- a/Mathlib/CategoryTheory/Idempotents/FunctorExtension.lean
+++ b/Mathlib/CategoryTheory/Idempotents/FunctorExtension.lean
@@ -104,7 +104,7 @@ def functorExtension₁CompWhiskeringLeftToKaroubiIso :
         { hom := { f := (F.obj X).p }
           inv := { f := (F.obj X).p } })
       (fun {X Y} f => by simp))
-    (by aesop_cat)
+    (by cat_disch)
 
 /-- The counit isomorphism of the equivalence `(C ⥤ Karoubi D) ≌ (Karoubi C ⥤ Karoubi D)`. -/
 def KaroubiUniversal₁.counitIso :
@@ -181,7 +181,7 @@ def functorExtension₂CompWhiskeringLeftToKaroubiIso :
         { hom := { f := 𝟙 _ }
           inv := { f := 𝟙 _ } })
       (by simp))
-    (by aesop_cat)
+    (by cat_disch)
 
 section IsIdempotentComplete
 

--- a/Mathlib/CategoryTheory/Idempotents/HomologicalComplex.lean
+++ b/Mathlib/CategoryTheory/Idempotents/HomologicalComplex.lean
@@ -120,8 +120,8 @@ def inverse : HomologicalComplex (Karoubi C) c ⥤ Karoubi (HomologicalComplex C
 `Karoubi (HomologicalComplex C c) ≌ HomologicalComplex (Karoubi C) c`. -/
 @[simps!]
 def counitIso : inverse ⋙ functor ≅ 𝟭 (HomologicalComplex (Karoubi C) c) :=
-  eqToIso (Functor.ext (fun P => HomologicalComplex.ext (by aesop_cat) (by simp))
-    (by aesop_cat))
+  eqToIso (Functor.ext (fun P => HomologicalComplex.ext (by cat_disch) (by simp))
+    (by cat_disch))
 
 /-- The unit isomorphism of the equivalence
 `Karoubi (HomologicalComplex C c) ≌ HomologicalComplex (Karoubi C) c`. -/

--- a/Mathlib/CategoryTheory/Idempotents/HomologicalComplex.lean
+++ b/Mathlib/CategoryTheory/Idempotents/HomologicalComplex.lean
@@ -69,7 +69,7 @@ def obj (P : Karoubi (HomologicalComplex C c)) : HomologicalComplex (Karoubi C) 
     ⟨P.X.X n, P.p.f n, by
       simpa only [HomologicalComplex.comp_f] using HomologicalComplex.congr_hom P.idem n⟩
   d i j := { f := P.p.f i ≫ P.X.d i j }
-  shape i j hij := by simp only [hom_eq_zero_iff]; aesop_cat
+  shape i j hij := by simp only [hom_eq_zero_iff]; cat_disch
 
 /-- The functor `Karoubi (HomologicalComplex C c) ⥤ HomologicalComplex (Karoubi C) c`,
 on morphisms. -/

--- a/Mathlib/CategoryTheory/Idempotents/Karoubi.lean
+++ b/Mathlib/CategoryTheory/Idempotents/Karoubi.lean
@@ -43,7 +43,7 @@ structure Karoubi where
   /-- an endomorphism of the object -/
   p : X ⟶ X
   /-- the condition that the given endomorphism is an idempotent -/
-  idem : p ≫ p = p := by aesop_cat
+  idem : p ≫ p = p := by cat_disch
 
 namespace Karoubi
 
@@ -69,7 +69,7 @@ structure Hom (P Q : Karoubi C) where
   /-- a morphism between the underlying objects -/
   f : P.X ⟶ Q.X
   /-- compatibility of the given morphism with the given idempotents -/
-  comm : P.p ≫ f ≫ Q.p = f := by aesop_cat
+  comm : P.p ≫ f ≫ Q.p = f := by cat_disch
 
 instance [Preadditive C] (P Q : Karoubi C) : Inhabited (Hom P Q) :=
   ⟨⟨0, by rw [zero_comp, comp_zero]⟩⟩

--- a/Mathlib/CategoryTheory/Idempotents/KaroubiKaroubi.lean
+++ b/Mathlib/CategoryTheory/Idempotents/KaroubiKaroubi.lean
@@ -46,7 +46,7 @@ instance [Preadditive C] : Functor.Additive (inverse C) where
 /-- The unit isomorphism of the equivalence -/
 @[simps!]
 def unitIso : 𝟭 (Karoubi C) ≅ toKaroubi (Karoubi C) ⋙ inverse C :=
-  eqToIso (Functor.ext (by aesop_cat) (by simp))
+  eqToIso (Functor.ext (by cat_disch) (by simp))
 
 attribute [local simp] p_comm_f in
 /-- The counit isomorphism of the equivalence -/

--- a/Mathlib/CategoryTheory/IsConnected.lean
+++ b/Mathlib/CategoryTheory/IsConnected.lean
@@ -89,7 +89,7 @@ private def liftToDiscrete {α : Type u₂} (F : J ⥤ Discrete α) : J ⥤ Disc
 /-- Implementation detail of `isoConstant`. -/
 private def factorThroughDiscrete {α : Type u₂} (F : J ⥤ Discrete α) :
     liftToDiscrete F ⋙ Discrete.functor F.obj ≅ F :=
-  NatIso.ofComponents (fun _ => eqToIso Function.apply_invFun_apply) (by aesop_cat)
+  NatIso.ofComponents (fun _ => eqToIso Function.apply_invFun_apply) (by cat_disch)
 
 end IsPreconnected.IsoConstantAux
 

--- a/Mathlib/CategoryTheory/Iso.lean
+++ b/Mathlib/CategoryTheory/Iso.lean
@@ -50,10 +50,10 @@ structure Iso {C : Type u} [Category.{v} C] (X Y : C) where
   /-- The backwards direction of an isomorphism. -/
   inv : Y ⟶ X
   /-- Composition of the two directions of an isomorphism is the identity on the source. -/
-  hom_inv_id : hom ≫ inv = 𝟙 X := by aesop_cat
+  hom_inv_id : hom ≫ inv = 𝟙 X := by cat_disch
   /-- Composition of the two directions of an isomorphism in reverse order
   is the identity on the target. -/
-  inv_hom_id : inv ≫ hom = 𝟙 Y := by aesop_cat
+  inv_hom_id : inv ≫ hom = 𝟙 Y := by cat_disch
 
 attribute [reassoc (attr := simp)] Iso.hom_inv_id Iso.inv_hom_id
 
@@ -211,16 +211,16 @@ theorem hom_eq_inv (α : X ≅ Y) (β : Y ≅ X) : α.hom = β.inv ↔ β.hom = 
 def homToEquiv (α : X ≅ Y) {Z : C} : (Z ⟶ X) ≃ (Z ⟶ Y) where
   toFun f := f ≫ α.hom
   invFun g := g ≫ α.inv
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
+  left_inv := by cat_disch
+  right_inv := by cat_disch
 
 /-- The bijection `(X ⟶ Z) ≃ (Y ⟶ Z)` induced by `α : X ≅ Y`. -/
 @[simps]
 def homFromEquiv (α : X ≅ Y) {Z : C} : (X ⟶ Z) ≃ (Y ⟶ Z) where
   toFun f := α.inv ≫ f
   invFun g := α.hom ≫ g
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
+  left_inv := by cat_disch
+  right_inv := by cat_disch
 
 end Iso
 

--- a/Mathlib/CategoryTheory/Join/Basic.lean
+++ b/Mathlib/CategoryTheory/Join/Basic.lean
@@ -348,7 +348,7 @@ lemma mkNatTransComp
       whiskerLeft (Prod.fst C D) βₗ ≫ whiskerRight (edgeTransform C D) F'' := by cat_disch) :
     mkNatTrans (αₗ ≫ βₗ) (αᵣ ≫ βᵣ) (by simp [← h', reassoc_of% h]) =
     mkNatTrans αₗ αᵣ h ≫ mkNatTrans βₗ βᵣ h' := by
-  apply natTrans_ext <;> aesop_cat
+  apply natTrans_ext <;> cat_disch
 
 end
 
@@ -482,12 +482,12 @@ def mapWhiskerRight {Fₗ : C ⥤ E} {Gₗ : C ⥤ E} (α : Fₗ ⟶ Gₗ) (H : 
 lemma mapWhiskerRight_comp {Fₗ : C ⥤ E} {Gₗ : C ⥤ E} {Hₗ : C ⥤ E}
     (α : Fₗ ⟶ Gₗ) (β : Gₗ ⟶ Hₗ) (H : D ⥤ E') :
     mapWhiskerRight (α ≫ β) H = mapWhiskerRight α H ≫ mapWhiskerRight β H := by
-  aesop_cat
+  cat_disch
 
 @[simp]
 lemma mapWhiskerRight_id (Fₗ : C ⥤ E) (H : D ⥤ E') :
     mapWhiskerRight (𝟙 Fₗ) H = 𝟙 _ := by
-  aesop_cat
+  cat_disch
 
 /-- A natural transformation `Fᵣ ⟶ Gᵣ` induces a natural transformation
   `mapPair H Fᵣ ⟶ mapPair H Gᵣ` for every `H : C ⥤ E`. -/
@@ -502,12 +502,12 @@ def mapWhiskerLeft (H : C ⥤ E) {Fᵣ : D ⥤ E'} {Gᵣ : D ⥤ E'} (α : Fᵣ 
 lemma mapWhiskerLeft_comp {Fᵣ : D ⥤ E'} {Gᵣ : D ⥤ E'} {Hᵣ : D ⥤ E'}
     (H : C ⥤ E) (α : Fᵣ ⟶ Gᵣ) (β : Gᵣ ⟶ Hᵣ) :
     mapWhiskerLeft H (α ≫ β) = mapWhiskerLeft H α ≫ mapWhiskerLeft H β := by
-  aesop_cat
+  cat_disch
 
 @[simp]
 lemma mapWhiskerLeft_id (H : C ⥤ E) (Fᵣ : D ⥤ E') :
     mapWhiskerLeft H (𝟙 Fᵣ) = 𝟙 _ := by
-  aesop_cat
+  cat_disch
 
 /-- One can exchange `mapWhiskerLeft` and `mapWhiskerRight`. -/
 lemma mapWhisker_exchange (Fₗ : C ⥤ E) (Gₗ : C ⥤ E) (Fᵣ : D ⥤ E') (Gᵣ : D ⥤ E')
@@ -515,7 +515,7 @@ lemma mapWhisker_exchange (Fₗ : C ⥤ E) (Gₗ : C ⥤ E) (Fᵣ : D ⥤ E') (G
     mapWhiskerLeft Fₗ αᵣ ≫ mapWhiskerRight αₗ Gᵣ =
       mapWhiskerRight αₗ Fᵣ ≫ mapWhiskerLeft Gₗ αᵣ := by
   ext
-  aesop_cat
+  cat_disch
 
 /-- A natural isomorphism `Fᵣ ≅ Gᵣ` induces a natural isomorphism
   `mapPair H Fᵣ ≅ mapPair H Gᵣ` for every `H : C ⥤ E`. -/

--- a/Mathlib/CategoryTheory/Join/Basic.lean
+++ b/Mathlib/CategoryTheory/Join/Basic.lean
@@ -283,7 +283,7 @@ def mkNatTrans {F : C ⋆ D ⥤ E} {F' : C ⋆ D ⥤ E}
     (αₗ : inclLeft C D ⋙ F ⟶ inclLeft C D ⋙ F') (αᵣ : inclRight C D ⋙ F ⟶ inclRight C D ⋙ F')
     (h : whiskerRight (edgeTransform C D) F ≫ whiskerLeft (Prod.snd C D) αᵣ =
       whiskerLeft (Prod.fst C D) αₗ ≫ whiskerRight (edgeTransform C D) F' :=
-      by aesop_cat) :
+      by cat_disch) :
     F ⟶ F' where
   app x := match x with
     | left x => αₗ.app x
@@ -300,7 +300,7 @@ variable {F : C ⋆ D ⥤ E} {F' : C ⋆ D ⥤ E}
     (αₗ : inclLeft C D ⋙ F ⟶ inclLeft C D ⋙ F') (αᵣ : inclRight C D ⋙ F ⟶ inclRight C D ⋙ F')
     (h : whiskerRight (edgeTransform C D) F ≫ whiskerLeft (Prod.snd C D) αᵣ =
       whiskerLeft (Prod.fst C D) αₗ ≫ whiskerRight (edgeTransform C D) F' :=
-      by aesop_cat)
+      by cat_disch)
 
 @[simp]
 lemma mkNatTrans_app_left (c : C) : (mkNatTrans αₗ αᵣ h).app (left c) = αₗ.app c := rfl
@@ -343,9 +343,9 @@ lemma mkNatTransComp
     (βᵣ : inclRight C D ⋙ F' ⟶ inclRight C D ⋙ F'')
     (h : whiskerRight (edgeTransform C D) F ≫ whiskerLeft (Prod.snd C D) αᵣ =
       whiskerLeft (Prod.fst C D) αₗ ≫ whiskerRight (edgeTransform C D) F' :=
-      by aesop_cat)
+      by cat_disch)
     (h' : whiskerRight (edgeTransform C D) F' ≫ whiskerLeft (Prod.snd C D) βᵣ =
-      whiskerLeft (Prod.fst C D) βₗ ≫ whiskerRight (edgeTransform C D) F'' := by aesop_cat) :
+      whiskerLeft (Prod.fst C D) βₗ ≫ whiskerRight (edgeTransform C D) F'' := by cat_disch) :
     mkNatTrans (αₗ ≫ βₗ) (αᵣ ≫ βᵣ) (by simp [← h', reassoc_of% h]) =
     mkNatTrans αₗ αᵣ h ≫ mkNatTrans βₗ βᵣ h' := by
   apply natTrans_ext <;> aesop_cat
@@ -360,7 +360,7 @@ def mkNatIso {F : C ⋆ D ⥤ E} {G : C ⋆ D ⥤ E}
     (eₗ : inclLeft C D ⋙ F ≅ inclLeft C D ⋙ G)
     (eᵣ : inclRight C D ⋙ F ≅ inclRight C D ⋙ G)
     (h : whiskerRight (edgeTransform C D) F ≫ (isoWhiskerLeft (Prod.snd C D) eᵣ).hom =
-      (isoWhiskerLeft (Prod.fst C D) eₗ).hom ≫ whiskerRight (edgeTransform C D) G := by aesop_cat) :
+      (isoWhiskerLeft (Prod.fst C D) eₗ).hom ≫ whiskerRight (edgeTransform C D) G := by cat_disch) :
     F ≅ G where
   hom := mkNatTrans eₗ.hom eᵣ.hom (by simpa using h)
   inv := mkNatTrans eₗ.inv eᵣ.inv (by rw [Eq.comm, ← isoWhiskerLeft_inv, ← isoWhiskerLeft_inv,

--- a/Mathlib/CategoryTheory/Join/Opposites.lean
+++ b/Mathlib/CategoryTheory/Join/Opposites.lean
@@ -32,16 +32,16 @@ def opEquiv : (C ⋆ D)ᵒᵖ ≌ Dᵒᵖ ⋆ Cᵒᵖ where
       | op (left _) => Iso.refl _
       | op (right _) => Iso.refl _ )
     (@fun
-      | op (left _), op (left _), _ => by aesop_cat
-      | op (right _), op (left _), _ => by aesop_cat
-      | op (right _), op (right _), _ => by aesop_cat)
+      | op (left _), op (left _), _ => by cat_disch
+      | op (right _), op (left _), _ => by cat_disch
+      | op (right _), op (right _), _ => by cat_disch)
   counitIso := NatIso.ofComponents
     (fun
       | left _ => Iso.refl _
       | right _ => Iso.refl _)
   functor_unitIso_comp
-    | op (left _) => by aesop_cat
-    | op (right _) => by aesop_cat
+    | op (left _) => by cat_disch
+    | op (right _) => by cat_disch
 
 variable {C} in
 @[simp]

--- a/Mathlib/CategoryTheory/LiftingProperties/Adjunction.lean
+++ b/Mathlib/CategoryTheory/LiftingProperties/Adjunction.lean
@@ -57,8 +57,8 @@ def rightAdjointLiftStructEquiv : sq.LiftStruct ≃ (sq.right_adjoint adj).LiftS
       fac_right := by
         rw [← Adjunction.homEquiv_naturality_right_symm, l.fac_right]
         apply (adj.homEquiv _ _).left_inv }
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
+  left_inv := by cat_disch
+  right_inv := by cat_disch
 
 /-- A square has a lifting if and only if its (right) adjoint square has a lifting. -/
 theorem right_adjoint_hasLift_iff : HasLift (sq.right_adjoint adj) ↔ HasLift sq := by
@@ -102,8 +102,8 @@ def leftAdjointLiftStructEquiv :
       fac_right := by
         rw [← adj.homEquiv_naturality_right, l.fac_right]
         apply (adj.homEquiv _ _).right_inv }
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
+  left_inv := by cat_disch
+  right_inv := by cat_disch
 
 /-- A (left) adjoint square has a lifting if and only if the original square has a lifting. -/
 theorem left_adjoint_hasLift_iff : HasLift (sq.left_adjoint adj) ↔ HasLift sq := by

--- a/Mathlib/CategoryTheory/Limits/ConeCategory.lean
+++ b/Mathlib/CategoryTheory/Limits/ConeCategory.lean
@@ -152,8 +152,8 @@ def Cone.isLimitEquivIsTerminal {F : J ⥤ C} (c : Cone F) : IsLimit c ≃ IsTer
   IsLimit.isoUniqueConeMorphism.toEquiv.trans
     { toFun := fun _ => IsTerminal.ofUnique _
       invFun := fun h s => ⟨⟨IsTerminal.from h s⟩, fun a => IsTerminal.hom_ext h a _⟩
-      left_inv := by aesop_cat
-      right_inv := by aesop_cat }
+      left_inv := by cat_disch
+      right_inv := by cat_disch }
 
 theorem hasLimit_iff_hasTerminal_cone (F : J ⥤ C) : HasLimit F ↔ HasTerminal (Cone F) :=
   ⟨fun _ => (Cone.isLimitEquivIsTerminal _ (limit.isLimit F)).hasTerminal, fun h =>
@@ -311,8 +311,8 @@ def Cocone.isColimitEquivIsInitial {F : J ⥤ C} (c : Cocone F) : IsColimit c �
   IsColimit.isoUniqueCoconeMorphism.toEquiv.trans
     { toFun := fun _ => IsInitial.ofUnique _
       invFun := fun h s => ⟨⟨IsInitial.to h s⟩, fun a => IsInitial.hom_ext h a _⟩
-      left_inv := by aesop_cat
-      right_inv := by aesop_cat }
+      left_inv := by cat_disch
+      right_inv := by cat_disch }
 
 theorem hasColimit_iff_hasInitial_cocone (F : J ⥤ C) : HasColimit F ↔ HasInitial (Cocone F) :=
   ⟨fun _ => (Cocone.isColimitEquivIsInitial _ (colimit.isColimit F)).hasInitial, fun h =>

--- a/Mathlib/CategoryTheory/Limits/Cones.lean
+++ b/Mathlib/CategoryTheory/Limits/Cones.lean
@@ -254,7 +254,7 @@ structure ConeMorphism (A B : Cone F) where
   /-- A morphism between the two vertex objects of the cones -/
   hom : A.pt ⟶ B.pt
   /-- The triangle consisting of the two natural transformations and `hom` commutes -/
-  w : ∀ j : J, hom ≫ B.π.app j = A.π.app j := by aesop_cat
+  w : ∀ j : J, hom ≫ B.π.app j = A.π.app j := by cat_disch
 
 attribute [reassoc (attr := simp)] ConeMorphism.w
 
@@ -296,7 +296,7 @@ namespace Cones
   maps. -/
 @[aesop apply safe (rule_sets := [CategoryTheory]), simps]
 def ext {c c' : Cone F} (φ : c.pt ≅ c'.pt)
-    (w : ∀ j, c.π.app j = φ.hom ≫ c'.π.app j := by aesop_cat) : c ≅ c' where
+    (w : ∀ j, c.π.app j = φ.hom ≫ c'.π.app j := by cat_disch) : c ≅ c' where
   hom := { hom := φ.hom }
   inv :=
     { hom := φ.inv
@@ -312,7 +312,7 @@ isomorphism of cones.
 -/
 theorem cone_iso_of_hom_iso {K : J ⥤ C} {c d : Cone K} (f : c ⟶ d) [i : IsIso f.hom] : IsIso f :=
   ⟨⟨{   hom := inv f.hom
-        w := fun j => (asIso f.hom).inv_comp_eq.2 (f.w j).symm }, by aesop_cat⟩⟩
+        w := fun j => (asIso f.hom).inv_comp_eq.2 (f.w j).symm }, by cat_disch⟩⟩
 
 /-- There is a morphism from an extended cone to the original cone. -/
 @[simps]
@@ -337,7 +337,7 @@ def extendIso (s : Cone F) {X : C} (f : X ≅ s.pt) : s.extend f.hom ≅ s where
   inv := { hom := f.inv }
 
 instance {s : Cone F} {X : C} (f : X ⟶ s.pt) [IsIso f] : IsIso (Cones.extend s f) :=
-  ⟨(extendIso s (asIso f)).inv, by aesop_cat⟩
+  ⟨(extendIso s (asIso f)).inv, by cat_disch⟩
 
 /--
 Functorially postcompose a cone for `F` by a natural transformation `F ⟶ G` to give a cone for `G`.
@@ -432,7 +432,7 @@ def functorialityCompFunctoriality (H : D ⥤ E) :
 instance functoriality_full [G.Full] [G.Faithful] : (functoriality F G).Full where
   map_surjective t :=
     ⟨{ hom := G.preimage t.hom
-       w := fun j => G.map_injective (by simpa using t.w j) }, by aesop_cat⟩
+       w := fun j => G.map_injective (by simpa using t.w j) }, by cat_disch⟩
 
 instance functoriality_faithful [G.Faithful] : (Cones.functoriality F G).Faithful where
   map_injective {_X} {_Y} f g h :=
@@ -472,7 +472,7 @@ structure CoconeMorphism (A B : Cocone F) where
   /-- A morphism between the (co)vertex objects in `C` -/
   hom : A.pt ⟶ B.pt
   /-- The triangle made from the two natural transformations and `hom` commutes -/
-  w : ∀ j : J, A.ι.app j ≫ hom = B.ι.app j := by aesop_cat
+  w : ∀ j : J, A.ι.app j ≫ hom = B.ι.app j := by cat_disch
 
 instance inhabitedCoconeMorphism (A : Cocone F) : Inhabited (CoconeMorphism A A) :=
   ⟨{ hom := 𝟙 _ }⟩
@@ -513,7 +513,7 @@ namespace Cocones
   maps. -/
 @[aesop apply safe (rule_sets := [CategoryTheory]), simps]
 def ext {c c' : Cocone F} (φ : c.pt ≅ c'.pt)
-    (w : ∀ j, c.ι.app j ≫ φ.hom = c'.ι.app j := by aesop_cat) : c ≅ c' where
+    (w : ∀ j, c.ι.app j ≫ φ.hom = c'.ι.app j := by cat_disch) : c ≅ c' where
   hom := { hom := φ.hom }
   inv :=
     { hom := φ.inv
@@ -530,7 +530,7 @@ isomorphism of cocones.
 theorem cocone_iso_of_hom_iso {K : J ⥤ C} {c d : Cocone K} (f : c ⟶ d) [i : IsIso f.hom] :
     IsIso f :=
   ⟨⟨{ hom := inv f.hom
-      w := fun j => (asIso f.hom).comp_inv_eq.2 (f.w j).symm }, by aesop_cat⟩⟩
+      w := fun j => (asIso f.hom).comp_inv_eq.2 (f.w j).symm }, by cat_disch⟩⟩
 
 /-- There is a morphism from a cocone to its extension. -/
 @[simps]
@@ -555,7 +555,7 @@ def extendIso (s : Cocone F) {X : C} (f : s.pt ≅ X) : s ≅ s.extend f.hom whe
   inv := { hom := f.inv }
 
 instance {s : Cocone F} {X : C} (f : s.pt ⟶ X) [IsIso f] : IsIso (Cocones.extend s f) :=
-  ⟨(extendIso s (asIso f)).inv, by aesop_cat⟩
+  ⟨(extendIso s (asIso f)).inv, by cat_disch⟩
 
 /-- Functorially precompose a cocone for `F` by a natural transformation `G ⟶ F` to give a cocone
 for `G`. -/
@@ -647,7 +647,7 @@ def functorialityCompFunctoriality (H : D ⥤ E) :
 instance functoriality_full [G.Full] [G.Faithful] : (functoriality F G).Full where
   map_surjective t :=
     ⟨{ hom := G.preimage t.hom
-       w := fun j => G.map_injective (by simpa using t.w j) }, by aesop_cat⟩
+       w := fun j => G.map_injective (by simpa using t.w j) }, by cat_disch⟩
 
 instance functoriality_faithful [G.Faithful] : (functoriality F G).Faithful where
   map_injective {_X} {_Y} f g h :=

--- a/Mathlib/CategoryTheory/Limits/Cones.lean
+++ b/Mathlib/CategoryTheory/Limits/Cones.lean
@@ -126,7 +126,7 @@ instance inhabitedCone (F : Discrete PUnit ⥤ C) : Inhabited (Cone F) :=
               intro X Y f
               match X, Y, f with
               | .mk A, .mk B, .up g =>
-                aesop_cat
+                cat_disch
            }
   }⟩
 

--- a/Mathlib/CategoryTheory/Limits/Constructions/Over/Connected.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/Over/Connected.lean
@@ -55,7 +55,7 @@ def raiseCone [IsConnected J] {B : C} {F : J ⥤ Over B} (c : Cone (F ⋙ forget
 
 theorem raised_cone_lowers_to_original [IsConnected J] {B : C} {F : J ⥤ Over B}
     (c : Cone (F ⋙ forget B)) :
-    (forget B).mapCone (raiseCone c) = c := by aesop_cat
+    (forget B).mapCone (raiseCone c) = c := by cat_disch
 
 /-- (Impl) Show that the raised cone is a limit. -/
 def raisedConeIsLimit [IsConnected J] {B : C} {F : J ⥤ Over B} {c : Cone (F ⋙ forget B)}

--- a/Mathlib/CategoryTheory/Limits/Constructions/Over/Products.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/Over/Products.lean
@@ -56,7 +56,7 @@ variable {f : Y ⟶ X} {g : Z ⟶ X}
 def pullbackConeEquivBinaryFan : PullbackCone f g ≌ BinaryFan (Over.mk f) (.mk g) where
   functor.obj c := .mk (Over.homMk (U := .mk (c.fst ≫ f)) (V := .mk f) c.fst rfl)
       (Over.homMk (U := .mk (c.fst ≫ f)) (V := .mk g) c.snd c.condition.symm)
-  functor.map {c₁ c₂} a := { hom := Over.homMk a.hom, w := by rintro (_ | _) <;> aesop_cat }
+  functor.map {c₁ c₂} a := { hom := Over.homMk a.hom, w := by rintro (_ | _) <;> cat_disch }
   inverse.obj c := PullbackCone.mk c.fst.left c.snd.left (c.fst.w.trans c.snd.w.symm)
   inverse.map {c₁ c₂} a := {
     hom := a.hom.left
@@ -117,7 +117,7 @@ variable {f : X ⟶ Y} {g : X ⟶ Z}
 def pushoutCoconeEquivBinaryCofan : PushoutCocone f g ≌ BinaryCofan (Under.mk f) (.mk g) where
   functor.obj c := .mk (Under.homMk (U := .mk f) (V := .mk (f ≫ c.inl)) c.inl rfl)
       (Under.homMk (U := .mk g) (V := .mk (f ≫ c.inl)) c.inr c.condition.symm)
-  functor.map {c₁ c₂} a := { hom := Under.homMk a.hom, w := by rintro (_ | _) <;> aesop_cat }
+  functor.map {c₁ c₂} a := { hom := Under.homMk a.hom, w := by rintro (_ | _) <;> cat_disch }
   inverse.obj c := .mk c.inl.right c.inr.right (c.inl.w.symm.trans c.inr.w)
   inverse.map {c₁ c₂} a := {
     hom := a.hom.right
@@ -270,7 +270,7 @@ def conesEquivFunctor (B : C) {J : Type w} (F : Discrete J ⥤ Over B) :
       π :=
         { app := fun ⟨j⟩ => Over.homMk (c.π.app (some j)) (c.w (WidePullbackShape.Hom.term j))
           -- Porting note (https://github.com/leanprover-community/mathlib4/issues/10888): added proof for `naturality`
-          naturality := fun ⟨X⟩ ⟨Y⟩ ⟨⟨f⟩⟩ => by dsimp at f ⊢; aesop_cat } }
+          naturality := fun ⟨X⟩ ⟨Y⟩ ⟨⟨f⟩⟩ => by dsimp at f ⊢; cat_disch } }
   map f := { hom := Over.homMk f.hom }
 
 -- Porting note: unfortunately `aesop` can't cope with a `cases` rule here for the type synonym
@@ -286,7 +286,7 @@ def conesEquivUnitIso (B : C) (F : Discrete J ⥤ Over B) :
   NatIso.ofComponents fun _ => Cones.ext
     { hom := 𝟙 _
       inv := 𝟙 _ }
-    (by rintro (j | j) <;> aesop_cat)
+    (by rintro (j | j) <;> cat_disch)
 
 -- TODO: Can we add `:= by aesop` to the second arguments of `NatIso.ofComponents` and
 --       `Cones.ext`?

--- a/Mathlib/CategoryTheory/Limits/Constructions/ZeroObjects.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/ZeroObjects.lean
@@ -32,7 +32,7 @@ def binaryFanZeroLeft (X : C) : BinaryFan (0 : C) X :=
 
 /-- The limit cone for the product with a zero object is limiting. -/
 def binaryFanZeroLeftIsLimit (X : C) : IsLimit (binaryFanZeroLeft X) :=
-  BinaryFan.isLimitMk (fun s => BinaryFan.snd s) (by aesop_cat) (by simp)
+  BinaryFan.isLimitMk (fun s => BinaryFan.snd s) (by cat_disch) (by simp)
     (fun s m _ h₂ => by simpa using h₂)
 
 instance hasBinaryProduct_zero_left (X : C) : HasBinaryProduct (0 : C) X :=
@@ -57,7 +57,7 @@ def binaryFanZeroRight (X : C) : BinaryFan X (0 : C) :=
 
 /-- The limit cone for the product with a zero object is limiting. -/
 def binaryFanZeroRightIsLimit (X : C) : IsLimit (binaryFanZeroRight X) :=
-  BinaryFan.isLimitMk (fun s => BinaryFan.fst s) (by simp) (by aesop_cat)
+  BinaryFan.isLimitMk (fun s => BinaryFan.fst s) (by simp) (by cat_disch)
     (fun s m h₁ _ => by simpa using h₁)
 
 instance hasBinaryProduct_zero_right (X : C) : HasBinaryProduct X (0 : C) :=
@@ -82,7 +82,7 @@ def binaryCofanZeroLeft (X : C) : BinaryCofan (0 : C) X :=
 
 /-- The colimit cocone for the coproduct with a zero object is colimiting. -/
 def binaryCofanZeroLeftIsColimit (X : C) : IsColimit (binaryCofanZeroLeft X) :=
-  BinaryCofan.isColimitMk (fun s => BinaryCofan.inr s) (by aesop_cat) (by simp)
+  BinaryCofan.isColimitMk (fun s => BinaryCofan.inr s) (by cat_disch) (by simp)
     (fun s m _ h₂ => by simpa using h₂)
 
 instance hasBinaryCoproduct_zero_left (X : C) : HasBinaryCoproduct (0 : C) X :=
@@ -107,7 +107,7 @@ def binaryCofanZeroRight (X : C) : BinaryCofan X (0 : C) :=
 
 /-- The colimit cocone for the coproduct with a zero object is colimiting. -/
 def binaryCofanZeroRightIsColimit (X : C) : IsColimit (binaryCofanZeroRight X) :=
-  BinaryCofan.isColimitMk (fun s => BinaryCofan.inl s) (by simp) (by aesop_cat)
+  BinaryCofan.isColimitMk (fun s => BinaryCofan.inl s) (by simp) (by cat_disch)
     (fun s m h₁ _ => by simpa using h₁)
 
 instance hasBinaryCoproduct_zero_right (X : C) : HasBinaryCoproduct X (0 : C) :=

--- a/Mathlib/CategoryTheory/Limits/ExactFunctor.lean
+++ b/Mathlib/CategoryTheory/Limits/ExactFunctor.lean
@@ -232,10 +232,10 @@ def LeftExactFunctor.whiskeringLeft : (C ⥤ₗ D) ⥤ (D ⥤ₗ E) ⥤ (C ⥤�
       naturality := fun _ _ f => ((Functor.whiskeringLeft C D E).map η).naturality f }
   map_id X := by
     rw [ObjectProperty.FullSubcategory.id_def]
-    aesop_cat
+    cat_disch
   map_comp f g := by
     rw [ObjectProperty.FullSubcategory.comp_def]
-    aesop_cat
+    cat_disch
 
 /-- Whiskering a left exact functor by a left exact functor yields a left exact functor. -/
 @[simps! obj_obj obj_map map_app_app]
@@ -256,10 +256,10 @@ def RightExactFunctor.whiskeringLeft : (C ⥤ᵣ D) ⥤ (D ⥤ᵣ E) ⥤ (C ⥤�
       naturality := fun _ _ f => ((Functor.whiskeringLeft C D E).map η).naturality f }
   map_id X := by
     rw [ObjectProperty.FullSubcategory.id_def]
-    aesop_cat
+    cat_disch
   map_comp f g := by
     rw [ObjectProperty.FullSubcategory.comp_def]
-    aesop_cat
+    cat_disch
 
 /-- Whiskering a right exact functor by a right exact functor yields a right exact functor. -/
 @[simps! obj_obj obj_map map_app_app]
@@ -281,10 +281,10 @@ def ExactFunctor.whiskeringLeft : (C ⥤ₑ D) ⥤ (D ⥤ₑ E) ⥤ (C ⥤ₑ E)
       naturality := fun _ _ f => ((Functor.whiskeringLeft C D E).map η).naturality f }
   map_id X := by
     rw [ObjectProperty.FullSubcategory.id_def]
-    aesop_cat
+    cat_disch
   map_comp f g := by
     rw [ObjectProperty.FullSubcategory.comp_def]
-    aesop_cat
+    cat_disch
 
 /-- Whiskering an exact functor by an exact functor yields an exact functor. -/
 @[simps! obj_obj obj_map map_app_app]

--- a/Mathlib/CategoryTheory/Limits/Final.lean
+++ b/Mathlib/CategoryTheory/Limits/Final.lean
@@ -898,14 +898,14 @@ lemma final_fromPUnit_of_isTerminal (hc : Limits.IsTerminal c) : (fromPUnit c).F
   out c' := by
     letI : Inhabited (StructuredArrow c' (fromPUnit c)) := ⟨.mk (Y := default) (hc.from c')⟩
     letI : Subsingleton (StructuredArrow c' (fromPUnit c)) :=
-      ⟨fun i j ↦ StructuredArrow.obj_ext _ _ (by aesop_cat) (hc.hom_ext _ _)⟩
+      ⟨fun i j ↦ StructuredArrow.obj_ext _ _ (by cat_disch) (hc.hom_ext _ _)⟩
     infer_instance
 
 lemma initial_fromPUnit_of_isInitial (hc : Limits.IsInitial c) : (fromPUnit c).Initial where
   out c' := by
     letI : Inhabited (CostructuredArrow (fromPUnit c) c') := ⟨.mk (Y := default) (hc.to c')⟩
     letI : Subsingleton (CostructuredArrow (fromPUnit c) c') :=
-      ⟨fun i j ↦ CostructuredArrow.obj_ext _ _ (by aesop_cat) (hc.hom_ext _ _)⟩
+      ⟨fun i j ↦ CostructuredArrow.obj_ext _ _ (by cat_disch) (hc.hom_ext _ _)⟩
     infer_instance
 
 end

--- a/Mathlib/CategoryTheory/Limits/Fubini.lean
+++ b/Mathlib/CategoryTheory/Limits/Fubini.lean
@@ -51,9 +51,9 @@ structure DiagramOfCones where
   obj : ∀ j : J, Cone (F.obj j)
   /-- For each map, a map of cones. -/
   map : ∀ {j j' : J} (f : j ⟶ j'), (Cones.postcompose (F.map f)).obj (obj j) ⟶ obj j'
-  id : ∀ j : J, (map (𝟙 j)).hom = 𝟙 _ := by aesop_cat
+  id : ∀ j : J, (map (𝟙 j)).hom = 𝟙 _ := by cat_disch
   comp : ∀ {j₁ j₂ j₃ : J} (f : j₁ ⟶ j₂) (g : j₂ ⟶ j₃),
-    (map (f ≫ g)).hom = (map f).hom ≫ (map g).hom := by aesop_cat
+    (map (f ≫ g)).hom = (map f).hom ≫ (map g).hom := by cat_disch
 
 /-- A structure carrying a diagram of cocones over the functors `F.obj j`.
 -/
@@ -62,9 +62,9 @@ structure DiagramOfCocones where
   obj : ∀ j : J, Cocone (F.obj j)
   /-- For each map, a map of cocones. -/
   map : ∀ {j j' : J} (f : j ⟶ j'), (obj j) ⟶ (Cocones.precompose (F.map f)).obj (obj j')
-  id : ∀ j : J, (map (𝟙 j)).hom = 𝟙 _ := by aesop_cat
+  id : ∀ j : J, (map (𝟙 j)).hom = 𝟙 _ := by cat_disch
   comp : ∀ {j₁ j₂ j₃ : J} (f : j₁ ⟶ j₂) (g : j₂ ⟶ j₃),
-    (map (f ≫ g)).hom = (map f).hom ≫ (map g).hom := by aesop_cat
+    (map (f ≫ g)).hom = (map f).hom ≫ (map g).hom := by cat_disch
 
 variable {F}
 

--- a/Mathlib/CategoryTheory/Limits/HasLimits.lean
+++ b/Mathlib/CategoryTheory/Limits/HasLimits.lean
@@ -272,7 +272,7 @@ def limit.homIso' (F : J ⥤ C) [HasLimit F] (W : C) :
   (limit.isLimit F).homIso' W
 
 theorem limit.lift_extend {F : J ⥤ C} [HasLimit F] (c : Cone F) {X : C} (f : X ⟶ c.pt) :
-    limit.lift F (c.extend f) = f ≫ limit.lift F c := by aesop_cat
+    limit.lift F (c.extend f) = f ≫ limit.lift F c := by cat_disch
 
 /-- If a functor `F` has a limit, so does any naturally isomorphic functor.
 -/
@@ -383,7 +383,7 @@ we obtain a formula for `limit.pre F E`.
 -/
 theorem limit.pre_eq (s : LimitCone (E ⋙ F)) (t : LimitCone F) :
     limit.pre F E = (limit.isoLimitCone t).hom ≫ s.isLimit.lift (t.cone.whisker E) ≫
-      (limit.isoLimitCone s).inv := by aesop_cat
+      (limit.isoLimitCone s).inv := by cat_disch
 
 end Pre
 
@@ -508,8 +508,8 @@ def constLimAdj : (const J : C ⥤ J ⥤ C) ⊣ lim := Adjunction.mk' {
     { toFun := fun f => limit.lift _ ⟨c, f⟩
       invFun := fun f =>
         { app := fun _ => f ≫ limit.π _ _ }
-      left_inv := by aesop_cat
-      right_inv := by aesop_cat }
+      left_inv := by cat_disch
+      right_inv := by cat_disch }
   unit := { app := fun _ => limit.lift _ ⟨_, 𝟙 _⟩ }
   counit := { app := fun g => { app := limit.π _ } } }
 
@@ -1024,7 +1024,7 @@ theorem colimit.pre_map' [HasColimitsOfShape K C] (F : J ⥤ C) {E₁ E₂ : K �
   simp
 
 theorem colimit.pre_id (F : J ⥤ C) :
-    colimit.pre F (𝟭 _) = colim.map (Functor.leftUnitor F).hom := by aesop_cat
+    colimit.pre F (𝟭 _) = colim.map (Functor.leftUnitor F).hom := by cat_disch
 
 theorem colimit.map_post {D : Type u'} [Category.{v'} D] [HasColimitsOfShape J D]
     (H : C ⥤ D) :
@@ -1053,8 +1053,8 @@ def colimConstAdj : (colim : (J ⥤ C) ⥤ C) ⊣ const J := Adjunction.mk' {
     { toFun := fun g =>
         { app := fun _ => colimit.ι _ _ ≫ g }
       invFun := fun g => colimit.desc _ ⟨_, g⟩
-      left_inv := by aesop_cat
-      right_inv := by aesop_cat }
+      left_inv := by cat_disch
+      right_inv := by cat_disch }
   unit := { app := fun g => { app := colimit.ι _ } }
   counit := { app := fun _ => colimit.desc _ ⟨_, 𝟙 _⟩ } }
 

--- a/Mathlib/CategoryTheory/Limits/HasLimits.lean
+++ b/Mathlib/CategoryTheory/Limits/HasLimits.lean
@@ -484,7 +484,7 @@ theorem limit.map_pre' [HasLimitsOfShape K C] (F : J ⥤ C) {E₁ E₂ : K ⥤ J
   ext1; simp
 
 theorem limit.id_pre (F : J ⥤ C) : limit.pre F (𝟭 _) = lim.map (Functor.leftUnitor F).inv := by
-  aesop_cat
+  cat_disch
 
 theorem limit.map_post {D : Type u'} [Category.{v'} D] [HasLimitsOfShape J D] (H : C ⥤ D) :
     /- H (limit F) ⟶ H (limit G) ⟶ limit (G ⋙ H) vs
@@ -918,7 +918,7 @@ theorem colimit.pre_eq (s : ColimitCocone (E ⋙ F)) (t : ColimitCocone F) :
     colimit.pre F E =
       (colimit.isoColimitCocone s).hom ≫
         s.isColimit.desc (t.cocone.whisker E) ≫ (colimit.isoColimitCocone t).inv := by
-  aesop_cat
+  cat_disch
 
 end Pre
 

--- a/Mathlib/CategoryTheory/Limits/IsLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/IsLimit.lean
@@ -55,14 +55,14 @@ structure IsLimit (t : Cone F) where
   fac : ∀ (s : Cone F) (j : J), lift s ≫ t.π.app j = s.π.app j := by cat_disch
   /-- It is the unique such map to do this -/
   uniq : ∀ (s : Cone F) (m : s.pt ⟶ t.pt) (_ : ∀ j : J, m ≫ t.π.app j = s.π.app j), m = lift s := by
-    aesop_cat
+    cat_disch
 
 attribute [reassoc (attr := simp)] IsLimit.fac
 
 namespace IsLimit
 
 instance subsingleton {t : Cone F} : Subsingleton (IsLimit t) :=
-  ⟨by intro P Q; cases P; cases Q; congr; aesop_cat⟩
+  ⟨by intro P Q; cases P; cases Q; congr; cat_disch⟩
 
 /-- Given a natural transformation `α : F ⟶ G`, we give a morphism from the cone point
 of any cone over `F` to the cone point of a limit cone over `G`. -/
@@ -347,7 +347,7 @@ def conePointsIsoOfEquivalence {F : J ⥤ C} {s : Cone F} {G : K ⥤ C} {t : Con
       simp
     inv_hom_id := by
       apply hom_ext Q
-      aesop_cat }
+      cat_disch }
 
 end Equivalence
 
@@ -512,14 +512,14 @@ structure IsColimit (t : Cocone F) where
   /-- `desc` is the unique such map -/
   uniq :
     ∀ (s : Cocone F) (m : t.pt ⟶ s.pt) (_ : ∀ j : J, t.ι.app j ≫ m = s.ι.app j), m = desc s := by
-    aesop_cat
+    cat_disch
 
 attribute [reassoc (attr := simp)] IsColimit.fac
 
 namespace IsColimit
 
 instance subsingleton {t : Cocone F} : Subsingleton (IsColimit t) :=
-  ⟨by intro P Q; cases P; cases Q; congr; aesop_cat⟩
+  ⟨by intro P Q; cases P; cases Q; congr; cat_disch⟩
 
 /-- Given a natural transformation `α : F ⟶ G`, we give a morphism from the cocone point
 of a colimit cocone over `F` to the cocone point of any cocone over `G`. -/
@@ -809,7 +809,7 @@ def coconePointsIsoOfEquivalence {F : J ⥤ C} {s : Cocone F} {G : K ⥤ C} {t :
       simp
     inv_hom_id := by
       apply hom_ext Q
-      aesop_cat }
+      cat_disch }
 
 end Equivalence
 

--- a/Mathlib/CategoryTheory/Limits/IsLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/IsLimit.lean
@@ -52,7 +52,7 @@ structure IsLimit (t : Cone F) where
   /-- There is a morphism from any cone point to `t.pt` -/
   lift : ∀ s : Cone F, s.pt ⟶ t.pt
   /-- The map makes the triangle with the two natural transformations commute -/
-  fac : ∀ (s : Cone F) (j : J), lift s ≫ t.π.app j = s.π.app j := by aesop_cat
+  fac : ∀ (s : Cone F) (j : J), lift s ≫ t.π.app j = s.π.app j := by cat_disch
   /-- It is the unique such map to do this -/
   uniq : ∀ (s : Cone F) (m : s.pt ⟶ t.pt) (_ : ∀ j : J, m ≫ t.π.app j = s.π.app j), m = lift s := by
     aesop_cat
@@ -161,8 +161,8 @@ theorem ofIsoLimit_lift {r t : Cone F} (P : IsLimit r) (i : r ≅ t) (s) :
 def equivIsoLimit {r t : Cone F} (i : r ≅ t) : IsLimit r ≃ IsLimit t where
   toFun h := h.ofIsoLimit i
   invFun h := h.ofIsoLimit i.symm
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
+  left_inv := by cat_disch
+  right_inv := by cat_disch
 
 @[simp]
 theorem equivIsoLimit_apply {r t : Cone F} (i : r ≅ t) (P : IsLimit r) :
@@ -213,8 +213,8 @@ def ofConeEquiv {D : Type u₄} [Category.{v₄} D] {G : K ⥤ D} (h : Cone G �
     IsLimit (h.functor.obj c) ≃ IsLimit c where
   toFun P := ofIsoLimit (ofRightAdjoint h.toAdjunction P) (h.unitIso.symm.app c)
   invFun := ofRightAdjoint h.symm.toAdjunction
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
+  left_inv := by cat_disch
+  right_inv := by cat_disch
 
 @[simp]
 theorem ofConeEquiv_apply_desc {D : Type u₄} [Category.{v₄} D] {G : K ⥤ D} (h : Cone G ≌ Cone F)
@@ -303,7 +303,7 @@ def ofWhiskerEquivalence {s : Cone F} (e : K ≌ J) (P : IsLimit (s.whisker e.fu
 /-- Given an equivalence of diagrams `e`, `s` is a limit cone iff `s.whisker e.functor` is.
 -/
 def whiskerEquivalenceEquiv {s : Cone F} (e : K ≌ J) : IsLimit s ≃ IsLimit (s.whisker e.functor) :=
-  ⟨fun h => h.whiskerEquivalence e, ofWhiskerEquivalence e, by aesop_cat, by aesop_cat⟩
+  ⟨fun h => h.whiskerEquivalence e, ofWhiskerEquivalence e, by cat_disch, by cat_disch⟩
 
 /-- A limit cone extended by an isomorphism is a limit cone. -/
 def extendIso {s : Cone F} {X : C} (i : X ⟶ s.pt) [IsIso i] (hs : IsLimit s) :
@@ -358,7 +358,7 @@ def homEquiv (h : IsLimit t) {W : C} : (W ⟶ t.pt) ≃ ((Functor.const J).obj W
   toFun f := (t.extend f).π
   invFun π := h.lift (Cone.mk _ π)
   left_inv f := h.hom_ext (by simp)
-  right_inv π := by aesop_cat
+  right_inv π := by cat_disch
 
 /-- The universal property of a limit cone: a map `W ⟶ X` is the same as
   a cone on `F` with cone point `W`. -/
@@ -508,7 +508,7 @@ structure IsColimit (t : Cocone F) where
   /-- `t.pt` maps to all other cocone covertices -/
   desc : ∀ s : Cocone F, t.pt ⟶ s.pt
   /-- The map `desc` makes the diagram with the natural transformations commute -/
-  fac : ∀ (s : Cocone F) (j : J), t.ι.app j ≫ desc s = s.ι.app j := by aesop_cat
+  fac : ∀ (s : Cocone F) (j : J), t.ι.app j ≫ desc s = s.ι.app j := by cat_disch
   /-- `desc` is the unique such map -/
   uniq :
     ∀ (s : Cocone F) (m : t.pt ⟶ s.pt) (_ : ∀ j : J, t.ι.app j ≫ m = s.ι.app j), m = desc s := by
@@ -618,8 +618,8 @@ theorem ofIsoColimit_desc {r t : Cocone F} (P : IsColimit r) (i : r ≅ t) (s) :
 def equivIsoColimit {r t : Cocone F} (i : r ≅ t) : IsColimit r ≃ IsColimit t where
   toFun h := h.ofIsoColimit i
   invFun h := h.ofIsoColimit i.symm
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
+  left_inv := by cat_disch
+  right_inv := by cat_disch
 
 @[simp]
 theorem equivIsoColimit_apply {r t : Cocone F} (i : r ≅ t) (P : IsColimit r) :
@@ -675,8 +675,8 @@ def ofCoconeEquiv {D : Type u₄} [Category.{v₄} D] {G : K ⥤ D} (h : Cocone 
     {c : Cocone G} : IsColimit (h.functor.obj c) ≃ IsColimit c where
   toFun P := ofIsoColimit (ofLeftAdjoint h.symm.toAdjunction P) (h.unitIso.symm.app c)
   invFun := ofLeftAdjoint h.toAdjunction
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
+  left_inv := by cat_disch
+  right_inv := by cat_disch
 
 @[simp]
 theorem ofCoconeEquiv_apply_desc {D : Type u₄} [Category.{v₄} D] {G : K ⥤ D}
@@ -768,7 +768,7 @@ def ofWhiskerEquivalence {s : Cocone F} (e : K ≌ J) (P : IsColimit (s.whisker 
 -/
 def whiskerEquivalenceEquiv {s : Cocone F} (e : K ≌ J) :
     IsColimit s ≃ IsColimit (s.whisker e.functor) :=
-  ⟨fun h => h.whiskerEquivalence e, ofWhiskerEquivalence e, by aesop_cat, by aesop_cat⟩
+  ⟨fun h => h.whiskerEquivalence e, ofWhiskerEquivalence e, by cat_disch, by cat_disch⟩
 
 /-- A colimit cocone extended by an isomorphism is a colimit cocone. -/
 def extendIso {s : Cocone F} {X : C} (i : s.pt ⟶ X) [IsIso i] (hs : IsColimit s) :
@@ -821,7 +821,7 @@ def homEquiv (h : IsColimit t) {W : C} : (t.pt ⟶ W) ≃ (F ⟶ (const J).obj W
       { pt := W
         ι }
   left_inv f := h.hom_ext (by simp)
-  right_inv ι := by aesop_cat
+  right_inv ι := by cat_disch
 
 @[simp]
 lemma homEquiv_apply (h : IsColimit t) {W : C} (f : t.pt ⟶ W) :

--- a/Mathlib/CategoryTheory/Limits/MonoCoprod.lean
+++ b/Mathlib/CategoryTheory/Limits/MonoCoprod.lean
@@ -61,7 +61,7 @@ theorem binaryCofan_inr {A B : C} [MonoCoprod C] (c : BinaryCofan A B) (hc : IsC
   haveI hc' : IsColimit (BinaryCofan.mk c.inr c.inl) :=
     BinaryCofan.IsColimit.mk _ (fun f₁ f₂ => hc.desc (BinaryCofan.mk f₂ f₁))
       (by simp) (by simp)
-      (fun f₁ f₂ m h₁ h₂ => BinaryCofan.IsColimit.hom_ext hc (by aesop_cat) (by aesop_cat))
+      (fun f₁ f₂ m h₁ h₂ => BinaryCofan.IsColimit.hom_ext hc (by cat_disch) (by cat_disch))
   exact binaryCofan_inl _ hc'
 
 instance {A B : C} [MonoCoprod C] [HasBinaryCoproduct A B] : Mono (coprod.inl : A ⟶ A ⨿ B) :=

--- a/Mathlib/CategoryTheory/Limits/MonoCoprod.lean
+++ b/Mathlib/CategoryTheory/Limits/MonoCoprod.lean
@@ -128,7 +128,7 @@ def isColimitBinaryCofanSum : IsColimit (binaryCofanSum c c₁ c₂ hc₁ hc₂)
     (fun f₁ f₂ => Cofan.IsColimit.hom_ext hc₂ _ _ (by simp))
     (fun f₁ f₂ m hm₁ hm₂ => by
       apply Cofan.IsColimit.hom_ext hc
-      rintro (i₁|i₂) <;> aesop_cat)
+      rintro (i₁|i₂) <;> cat_disch)
 
 lemma mono_binaryCofanSum_inl [MonoCoprod C] :
     Mono (binaryCofanSum c c₁ c₂ hc₁ hc₂).inl :=

--- a/Mathlib/CategoryTheory/Limits/Opposites.lean
+++ b/Mathlib/CategoryTheory/Limits/Opposites.lean
@@ -845,7 +845,7 @@ instance hasPushouts_opposite [HasPullbacks C] : HasPushouts Cᵒᵖ := by
 def spanOp {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) :
     span f.op g.op ≅ walkingCospanOpEquiv.inverse ⋙ (cospan f g).op :=
   NatIso.ofComponents (by rintro (_ | _ | _) <;> rfl)
-    (by rintro (_ | _ | _) (_ | _ | _) f <;> cases f <;> aesop_cat)
+    (by rintro (_ | _ | _) (_ | _ | _) f <;> cases f <;> cat_disch)
 
 /-- The canonical isomorphism relating `(Cospan f g).op` and `Span f.op g.op` -/
 @[simps!]
@@ -864,7 +864,7 @@ def opCospan {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) :
 def cospanOp {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z) :
     cospan f.op g.op ≅ walkingSpanOpEquiv.inverse ⋙ (span f g).op :=
   NatIso.ofComponents (by rintro (_ | _ | _) <;> rfl)
-    (by rintro (_ | _ | _) (_ | _ | _) f <;> cases f <;> aesop_cat)
+    (by rintro (_ | _ | _) (_ | _ | _) f <;> cases f <;> cat_disch)
 
 /-- The canonical isomorphism relating `(Span f g).op` and `Cospan f.op g.op` -/
 @[simps!]

--- a/Mathlib/CategoryTheory/Limits/Preserves/Bifunctor.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Bifunctor.lean
@@ -147,7 +147,7 @@ lemma ι_comp_isoObjConePointsOfIsColimit_inv (j : J₁ × J₂) :
       (isoObjCoconePointsOfIsColimit G hc₁ hc₂ hc₃).inv =
     (G.map <| c₁.ι.app j.1).app (K₂.obj j.2) ≫ (G.obj c₁.pt).map (c₂.ι.app j.2) := by
   dsimp [isoObjCoconePointsOfIsColimit, Functor.mapCocone₂]
-  aesop_cat
+  cat_disch
 
 /-- Characterize the forward direction of the isomorphism
 `PreservesColimit₂.isoObjCoconePointsOfIsColimit` w.r.t the canonical maps to the colimit. -/
@@ -274,7 +274,7 @@ lemma isoObjConePointsOfIsLimit_hom_comp_π (j : J₁ × J₂) :
     (isoObjConePointsOfIsLimit G hc₁ hc₂ hc₃).hom ≫ c₃.π.app j =
     (G.map <| c₁.π.app j.1).app c₂.pt ≫ (G.obj <| K₁.obj j.1).map (c₂.π.app j.2) := by
   dsimp [isoObjConePointsOfIsLimit, Functor.mapCocone₂]
-  aesop_cat
+  cat_disch
 
 /-- Characterize the inverse direction of the isomorphism
 `PreservesLimit₂.isoObjConePointsOfIsLimit` w.r.t the canonical maps to the limit. -/

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Kernels.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Kernels.lean
@@ -51,7 +51,7 @@ def isLimitMapConeEquiv :
     IsLimit (G.mapCone c) ≃ IsLimit (c.map G) := by
   refine (IsLimit.postcomposeHomEquiv ?_ _).symm.trans (IsLimit.equivIsoLimit ?_)
   refine parallelPair.ext (Iso.refl _) (Iso.refl _) ?_ ?_ <;> simp
-  exact Cones.ext (Iso.refl _) (by rintro (_ | _) <;> aesop_cat)
+  exact Cones.ext (Iso.refl _) (by rintro (_ | _) <;> cat_disch)
 
 /-- A limit kernel fork is mapped to a limit kernel fork by a functor `G` when this functor
 preserves the corresponding limit. -/
@@ -178,7 +178,7 @@ def isColimitMapCoconeEquiv :
     IsColimit (G.mapCocone c) ≃ IsColimit (c.map G) := by
   refine (IsColimit.precomposeHomEquiv ?_ _).symm.trans (IsColimit.equivIsoColimit ?_)
   refine parallelPair.ext (Iso.refl _) (Iso.refl _) ?_ ?_ <;> simp
-  exact Cocones.ext (Iso.refl _) (by rintro (_ | _) <;> aesop_cat)
+  exact Cocones.ext (Iso.refl _) (by rintro (_ | _) <;> cat_disch)
 
 /-- A colimit cokernel cofork is mapped to a colimit cokernel cofork by a functor `G`
 when this functor preserves the corresponding colimit. -/

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Terminal.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Terminal.lean
@@ -56,8 +56,8 @@ def IsTerminal.isTerminalIffObj [PreservesLimit (Functor.empty.{0} C) G]
     IsTerminal X ≃ IsTerminal (G.obj X) where
   toFun := IsTerminal.isTerminalObj G X
   invFun := IsTerminal.isTerminalOfObj G X
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
+  left_inv := by cat_disch
+  right_inv := by cat_disch
 
 /-- Preserving the terminal object implies preserving all limits of the empty diagram. -/
 lemma preservesLimitsOfShape_pempty_of_preservesTerminal [PreservesLimit (Functor.empty.{0} C) G] :
@@ -146,8 +146,8 @@ def IsInitial.isInitialIffObj [PreservesColimit (Functor.empty.{0} C) G]
     IsInitial X ≃ IsInitial (G.obj X) where
   toFun := IsInitial.isInitialObj G X
   invFun := IsInitial.isInitialOfObj G X
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
+  left_inv := by cat_disch
+  right_inv := by cat_disch
 
 /-- Preserving the initial object implies preserving all colimits of the empty diagram. -/
 lemma preservesColimitsOfShape_pempty_of_preservesInitial

--- a/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Zero.lean
+++ b/Mathlib/CategoryTheory/Limits/Preserves/Shapes/Zero.lean
@@ -117,7 +117,7 @@ instance (F : C ⥤ D ⥤ E) [F.PreservesZeroMorphisms] (Y : D) :
 
 omit [HasZeroMorphisms C] in
 @[simp] lemma whiskerRight_zero {F G : C ⥤ D} (H : D ⥤ E) [H.PreservesZeroMorphisms] :
-    whiskerRight (0 : F ⟶ G) H = 0 := by aesop_cat
+    whiskerRight (0 : F ⟶ G) H = 0 := by cat_disch
 
 end ZeroMorphisms
 

--- a/Mathlib/CategoryTheory/Limits/Presheaf.lean
+++ b/Mathlib/CategoryTheory/Limits/Presheaf.lean
@@ -80,7 +80,7 @@ def restrictedYonedaHomEquiv' (P : Cᵒᵖ ⥤ Type v₁) (E : ℰ) :
         let ψ : CostructuredArrow.mk (yonedaEquiv.symm (P.toPrefunctor.map φ x)) ⟶
           CostructuredArrow.mk (yonedaEquiv.symm x) := CostructuredArrow.homMk φ.unop (by
             dsimp [yonedaEquiv]
-            aesop_cat )
+            cat_disch )
         simpa using (f.naturality ψ).symm }
   invFun g :=
     { app := fun y => yonedaEquiv (y.hom ≫ g)

--- a/Mathlib/CategoryTheory/Limits/Presheaf.lean
+++ b/Mathlib/CategoryTheory/Limits/Presheaf.lean
@@ -101,7 +101,7 @@ def restrictedYonedaHomEquiv' (P : Cᵒᵖ ⥤ Type v₁) (E : ℰ) :
       erw [yonedaEquiv_apply]
       dsimp [CostructuredArrow.mk]
       erw [this]
-    exact yonedaEquiv.injective (by aesop_cat)
+    exact yonedaEquiv.injective (by cat_disch)
   right_inv g := by
     ext X x
     dsimp

--- a/Mathlib/CategoryTheory/Limits/Shapes/BinaryBiproducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/BinaryBiproducts.lean
@@ -907,23 +907,23 @@ def biprod.braiding' (P Q : C) : P ⊞ Q ≅ Q ⊞ P where
   inv := biprod.desc biprod.inr biprod.inl
 
 theorem biprod.braiding'_eq_braiding {P Q : C} : biprod.braiding' P Q = biprod.braiding P Q := by
-  aesop_cat
+  cat_disch
 
 /-- The braiding isomorphism can be passed through a map by swapping the order. -/
 @[reassoc]
 theorem biprod.braid_natural {W X Y Z : C} (f : X ⟶ Y) (g : Z ⟶ W) :
     biprod.map f g ≫ (biprod.braiding _ _).hom = (biprod.braiding _ _).hom ≫ biprod.map g f := by
-  aesop_cat
+  cat_disch
 
 @[reassoc]
 theorem biprod.braiding_map_braiding {W X Y Z : C} (f : W ⟶ Y) (g : X ⟶ Z) :
     (biprod.braiding X W).hom ≫ biprod.map f g ≫ (biprod.braiding Y Z).hom = biprod.map g f := by
-  aesop_cat
+  cat_disch
 
 @[reassoc (attr := simp)]
 theorem biprod.symmetry' (P Q : C) :
     biprod.lift biprod.snd biprod.fst ≫ biprod.lift biprod.snd biprod.fst = 𝟙 (P ⊞ Q) := by
-  aesop_cat
+  cat_disch
 
 /-- The braiding isomorphism is symmetric. -/
 @[reassoc]
@@ -941,14 +941,14 @@ def biprod.associator (P Q R : C) : (P ⊞ Q) ⊞ R ≅ P ⊞ (Q ⊞ R) where
 theorem biprod.associator_natural {U V W X Y Z : C} (f : U ⟶ X) (g : V ⟶ Y) (h : W ⟶ Z) :
     biprod.map (biprod.map f g) h ≫ (biprod.associator _ _ _).hom
       = (biprod.associator _ _ _).hom ≫ biprod.map f (biprod.map g h) := by
-  aesop_cat
+  cat_disch
 
 /-- The associator isomorphism can be passed through a map by swapping the order. -/
 @[reassoc]
 theorem biprod.associator_inv_natural {U V W X Y Z : C} (f : U ⟶ X) (g : V ⟶ Y) (h : W ⟶ Z) :
     biprod.map f (biprod.map g h) ≫ (biprod.associator _ _ _).inv
       = (biprod.associator _ _ _).inv ≫ biprod.map (biprod.map f g) h := by
-  aesop_cat
+  cat_disch
 
 end
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/BinaryBiproducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/BinaryBiproducts.lean
@@ -67,13 +67,13 @@ structure BinaryBiconeMorphism {P Q : C} (A B : BinaryBicone P Q) where
   /-- A morphism between the two vertex objects of the bicones -/
   hom : A.pt ⟶ B.pt
   /-- The triangle consisting of the two natural transformations and `hom` commutes -/
-  wfst : hom ≫ B.fst = A.fst := by aesop_cat
+  wfst : hom ≫ B.fst = A.fst := by cat_disch
   /-- The triangle consisting of the two natural transformations and `hom` commutes -/
-  wsnd : hom ≫ B.snd = A.snd := by aesop_cat
+  wsnd : hom ≫ B.snd = A.snd := by cat_disch
   /-- The triangle consisting of the two natural transformations and `hom` commutes -/
-  winl : A.inl ≫ hom = B.inl := by aesop_cat
+  winl : A.inl ≫ hom = B.inl := by cat_disch
   /-- The triangle consisting of the two natural transformations and `hom` commutes -/
-  winr : A.inr ≫ hom = B.inr := by aesop_cat
+  winr : A.inr ≫ hom = B.inr := by cat_disch
 
 attribute [reassoc (attr := simp)] BinaryBiconeMorphism.wfst BinaryBiconeMorphism.wsnd
 attribute [reassoc (attr := simp)] BinaryBiconeMorphism.winl BinaryBiconeMorphism.winr
@@ -102,10 +102,10 @@ namespace BinaryBicones
   maps. -/
 @[aesop apply safe (rule_sets := [CategoryTheory]), simps]
 def ext {P Q : C} {c c' : BinaryBicone P Q} (φ : c.pt ≅ c'.pt)
-    (winl : c.inl ≫ φ.hom = c'.inl := by aesop_cat)
-    (winr : c.inr ≫ φ.hom = c'.inr := by aesop_cat)
-    (wfst : φ.hom ≫ c'.fst = c.fst := by aesop_cat)
-    (wsnd : φ.hom ≫ c'.snd = c.snd := by aesop_cat) : c ≅ c' where
+    (winl : c.inl ≫ φ.hom = c'.inl := by cat_disch)
+    (winr : c.inr ≫ φ.hom = c'.inr := by cat_disch)
+    (wfst : φ.hom ≫ c'.fst = c.fst := by cat_disch)
+    (wsnd : φ.hom ≫ c'.snd = c.snd := by cat_disch) : c ≅ c' where
   hom := { hom := φ.hom }
   inv :=
     { hom := φ.inv
@@ -143,7 +143,7 @@ instance functoriality_full [F.Full] [F.Faithful] : (functoriality P Q F).Full w
       winl := F.map_injective (by simpa using t.winl)
       winr := F.map_injective (by simpa using t.winr)
       wfst := F.map_injective (by simpa using t.wfst)
-      wsnd := F.map_injective (by simpa using t.wsnd) }, by aesop_cat⟩
+      wsnd := F.map_injective (by simpa using t.wsnd) }, by cat_disch⟩
 
 instance functoriality_faithful [F.Faithful] : (functoriality P Q F).Faithful where
   map_injective {_X} {_Y} f g h :=

--- a/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
@@ -139,7 +139,7 @@ def mapPair : F ⟶ G where
   app
     | ⟨left⟩ => f
     | ⟨right⟩ => g
-  naturality := fun ⟨X⟩ ⟨Y⟩ ⟨⟨u⟩⟩ => by aesop_cat
+  naturality := fun ⟨X⟩ ⟨Y⟩ ⟨⟨u⟩⟩ => by cat_disch
 
 @[simp]
 theorem mapPair_left : (mapPair f g).app ⟨left⟩ = f :=
@@ -156,7 +156,7 @@ def mapPairIso (f : F.obj ⟨left⟩ ≅ G.obj ⟨left⟩) (g : F.obj ⟨right�
   NatIso.ofComponents (fun j ↦ match j with
     | ⟨left⟩ => f
     | ⟨right⟩ => g)
-    (fun ⟨⟨u⟩⟩ => by aesop_cat)
+    (fun ⟨⟨u⟩⟩ => by cat_disch)
 
 end
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
@@ -81,9 +81,9 @@ structure BiconeMorphism {F : J → C} (A B : Bicone F) where
   /-- A morphism between the two vertex objects of the bicones -/
   hom : A.pt ⟶ B.pt
   /-- The triangle consisting of the two natural transformations and `hom` commutes -/
-  wπ : ∀ j : J, hom ≫ B.π j = A.π j := by aesop_cat
+  wπ : ∀ j : J, hom ≫ B.π j = A.π j := by cat_disch
   /-- The triangle consisting of the two natural transformations and `hom` commutes -/
-  wι : ∀ j : J, A.ι j ≫ hom = B.ι j := by aesop_cat
+  wι : ∀ j : J, A.ι j ≫ hom = B.ι j := by cat_disch
 
 attribute [reassoc (attr := simp)] BiconeMorphism.wι BiconeMorphism.wπ
 
@@ -110,8 +110,8 @@ namespace Bicones
   maps. -/
 @[aesop apply safe (rule_sets := [CategoryTheory]), simps]
 def ext {c c' : Bicone F} (φ : c.pt ≅ c'.pt)
-    (wι : ∀ j, c.ι j ≫ φ.hom = c'.ι j := by aesop_cat)
-    (wπ : ∀ j, φ.hom ≫ c'.π j = c.π j := by aesop_cat) : c ≅ c' where
+    (wι : ∀ j, c.ι j ≫ φ.hom = c'.ι j := by cat_disch)
+    (wπ : ∀ j, φ.hom ≫ c'.π j = c.π j := by cat_disch) : c ≅ c' where
   hom := { hom := φ.hom }
   inv :=
     { hom := φ.inv
@@ -142,7 +142,7 @@ instance functoriality_full [G.PreservesZeroMorphisms] [G.Full] [G.Faithful] :
   map_surjective t :=
    ⟨{ hom := G.preimage t.hom
       wι := fun j => G.map_injective (by simpa using t.wι j)
-      wπ := fun j => G.map_injective (by simpa using t.wπ j) }, by aesop_cat⟩
+      wπ := fun j => G.map_injective (by simpa using t.wπ j) }, by cat_disch⟩
 
 instance functoriality_faithful [G.PreservesZeroMorphisms] [G.Faithful] :
     (functoriality F G).Faithful where
@@ -877,7 +877,7 @@ def kernelForkBiproductToSubtype (p : Set K) :
         · simp
         · replace w := w =≫ biproduct.π _ ⟨j, not_not.mp h⟩
           simpa using w.symm)
-      (by aesop_cat)
+      (by cat_disch)
 
 instance (p : Set K) : HasKernel (biproduct.toSubtype f p) :=
   HasLimit.mk (kernelForkBiproductToSubtype f p)
@@ -914,7 +914,7 @@ def cokernelCoforkBiproductFromSubtype (p : Set K) :
         · simp
         · replace w := biproduct.ι _ (⟨j, not_not.mp h⟩ : p) ≫= w
           simpa using w.symm)
-      (by aesop_cat)
+      (by cat_disch)
 
 instance (p : Set K) : HasCokernel (biproduct.fromSubtype f p) :=
   HasColimit.mk (cokernelCoforkBiproductFromSubtype f p)

--- a/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Biproducts.lean
@@ -129,7 +129,7 @@ def functoriality (G : C ⥤ D) [Functor.PreservesZeroMorphisms G] :
       ι := fun j => G.map (A.ι j)
       ι_π := fun i j => (Functor.map_comp _ _ _).symm.trans <| by
         rw [A.ι_π]
-        aesop_cat }
+        cat_disch }
   map f :=
     { hom := G.map f.hom
       wπ := fun j => by simp [-BiconeMorphism.wπ, ← f.wπ j]

--- a/Mathlib/CategoryTheory/Limits/Shapes/Diagonal.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Diagonal.lean
@@ -198,7 +198,7 @@ theorem pullback_fst_map_snd_isPullback :
         (by simp [condition])) :=
   IsPullback.of_iso_pullback ⟨by ext <;> simp [condition_assoc]⟩
     (pullbackDiagonalMapIso f i i₁ i₂).symm (pullbackDiagonalMapIso.inv_fst f i i₁ i₂)
-    (by aesop_cat)
+    (by cat_disch)
 
 end
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/End.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/End.lean
@@ -80,7 +80,7 @@ variable {F}
 isomorphisms of wedges. -/
 @[simps!]
 def ext {W₁ W₂ : Wedge F} (e : W₁.pt ≅ W₂.pt)
-    (he : ∀ j : J, W₁.ι j = e.hom ≫ W₂.ι j := by aesop_cat) : W₁ ≅ W₂ :=
+    (he : ∀ j : J, W₁.ι j = e.hom ≫ W₂.ι j := by cat_disch) : W₁ ≅ W₂ :=
   Cones.ext e (fun j =>
     match j with
     | .left _ => he _
@@ -144,7 +144,7 @@ variable {F}
 isomorphisms of cowedges. -/
 @[simps!]
 def ext {W₁ W₂ : Cowedge F} (e : W₁.pt ≅ W₂.pt)
-    (he : ∀ j : J, W₁.π j ≫ e.hom  = W₂.π j := by aesop_cat) : W₁ ≅ W₂ :=
+    (he : ∀ j : J, W₁.π j ≫ e.hom  = W₂.π j := by cat_disch) : W₁ ≅ W₂ :=
   Cocones.ext e (fun j =>
     match j with
     | .right _ => he _
@@ -257,7 +257,7 @@ lemma end_.map_comp {F'' : Jᵒᵖ ⥤ J ⥤ C} [HasEnd F''] (g : F' ⟶ F'') :
   aesop_cat
 
 @[simp]
-lemma end_.map_id : end_.map (𝟙 F) = 𝟙 _ := by aesop_cat
+lemma end_.map_id : end_.map (𝟙 F) = 𝟙 _ := by cat_disch
 
 end
 
@@ -330,7 +330,7 @@ lemma coend.map_comp {F'' : Jᵒᵖ ⥤ J ⥤ C} [HasCoend F''] (g : F' ⟶ F'')
   aesop_cat
 
 @[simp]
-lemma coend.map_id : coend.map (𝟙 F) = 𝟙 _ := by aesop_cat
+lemma coend.map_id : coend.map (𝟙 F) = 𝟙 _ := by cat_disch
 
 end
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/End.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/End.lean
@@ -254,7 +254,7 @@ lemma end_.map_π (j : J) :
 @[reassoc (attr := simp)]
 lemma end_.map_comp {F'' : Jᵒᵖ ⥤ J ⥤ C} [HasEnd F''] (g : F' ⟶ F'') :
     end_.map f ≫ end_.map g = end_.map (f ≫ g) := by
-  aesop_cat
+  cat_disch
 
 @[simp]
 lemma end_.map_id : end_.map (𝟙 F) = 𝟙 _ := by cat_disch
@@ -327,7 +327,7 @@ lemma coend.ι_map (j : J) :
 @[reassoc (attr := simp)]
 lemma coend.map_comp {F'' : Jᵒᵖ ⥤ J ⥤ C} [HasCoend F''] (g : F' ⟶ F'') :
     coend.map f ≫ coend.map g = coend.map (f ≫ g) := by
-  aesop_cat
+  cat_disch
 
 @[simp]
 lemma coend.map_id : coend.map (𝟙 F) = 𝟙 _ := by cat_disch

--- a/Mathlib/CategoryTheory/Limits/Shapes/Equalizers.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Equalizers.lean
@@ -603,7 +603,7 @@ it suffices to give an isomorphism between the cone points
 and check that it commutes with the `ι` morphisms.
 -/
 @[simps]
-def Fork.ext {s t : Fork f g} (i : s.pt ≅ t.pt) (w : i.hom ≫ t.ι = s.ι := by aesop_cat) :
+def Fork.ext {s t : Fork f g} (i : s.pt ≅ t.pt) (w : i.hom ≫ t.ι = s.ι := by cat_disch) :
     s ≅ t where
   hom := Fork.mkHom i.hom w
   inv := Fork.mkHom i.inv (by rw [← w, Iso.inv_hom_id_assoc])
@@ -625,9 +625,9 @@ def Fork.isLimitEquivOfIsos {X Y : C} {f g : X ⟶ Y} {X' Y' : C}
     (c : Fork f g)
     {f' g' : X' ⟶ Y'} (c' : Fork f' g')
     (e₀ : X ≅ X') (e₁ : Y ≅ Y') (e : c.pt ≅ c'.pt)
-    (comm₁ : e₀.hom ≫ f' = f ≫ e₁.hom := by aesop_cat)
-    (comm₂ : e₀.hom ≫ g' = g ≫ e₁.hom := by aesop_cat)
-    (comm₃ : e.hom ≫ c'.ι = c.ι ≫ e₀.hom := by aesop_cat) :
+    (comm₁ : e₀.hom ≫ f' = f ≫ e₁.hom := by cat_disch)
+    (comm₂ : e₀.hom ≫ g' = g ≫ e₁.hom := by cat_disch)
+    (comm₃ : e.hom ≫ c'.ι = c.ι ≫ e₀.hom := by cat_disch) :
     IsLimit c ≃ IsLimit c' :=
   let i : parallelPair f g ≅ parallelPair f' g' := parallelPair.ext e₀ e₁ comm₁.symm comm₂.symm
   IsLimit.equivOfNatIsoOfIso i c c' (Fork.ext e comm₃)
@@ -639,9 +639,9 @@ one is a limit, then the other one is as well.
 def Fork.isLimitOfIsos {X' Y' : C} (c : Fork f g) (hc : IsLimit c)
     {f' g' : X' ⟶ Y'} (c' : Fork f' g')
     (e₀ : X ≅ X') (e₁ : Y ≅ Y') (e : c.pt ≅ c'.pt)
-    (comm₁ : e₀.hom ≫ f' = f ≫ e₁.hom := by aesop_cat)
-    (comm₂ : e₀.hom ≫ g' = g ≫ e₁.hom := by aesop_cat)
-    (comm₃ : e.hom ≫ c'.ι = c.ι ≫ e₀.hom := by aesop_cat) : IsLimit c' :=
+    (comm₁ : e₀.hom ≫ f' = f ≫ e₁.hom := by cat_disch)
+    (comm₂ : e₀.hom ≫ g' = g ≫ e₁.hom := by cat_disch)
+    (comm₃ : e.hom ≫ c'.ι = c.ι ≫ e₀.hom := by cat_disch) : IsLimit c' :=
   (Fork.isLimitEquivOfIsos c c' e₀ e₁ e) hc
 
 /-- Helper function for constructing morphisms between coequalizer coforks.
@@ -667,7 +667,7 @@ it suffices to give an isomorphism between the cocone points
 and check that it commutes with the `π` morphisms.
 -/
 @[simps]
-def Cofork.ext {s t : Cofork f g} (i : s.pt ≅ t.pt) (w : s.π ≫ i.hom = t.π := by aesop_cat) :
+def Cofork.ext {s t : Cofork f g} (i : s.pt ≅ t.pt) (w : s.π ≫ i.hom = t.π := by cat_disch) :
     s ≅ t where
   hom := Cofork.mkHom i.hom w
   inv := Cofork.mkHom i.inv (by rw [Iso.comp_inv_eq, w])
@@ -684,9 +684,9 @@ def Cofork.isColimitEquivOfIsos {X Y : C} {f g : X ⟶ Y} {X' Y' : C}
     (c : Cofork f g)
     {f' g' : X' ⟶ Y'} (c' : Cofork f' g')
     (e₀ : X ≅ X') (e₁ : Y ≅ Y') (e : c.pt ≅ c'.pt)
-    (comm₁ : e₀.hom ≫ f' = f ≫ e₁.hom := by aesop_cat)
-    (comm₂ : e₀.hom ≫ g' = g ≫ e₁.hom := by aesop_cat)
-    (comm₃ : e₁.inv ≫ c.π ≫ e.hom = c'.π := by aesop_cat) :
+    (comm₁ : e₀.hom ≫ f' = f ≫ e₁.hom := by cat_disch)
+    (comm₂ : e₀.hom ≫ g' = g ≫ e₁.hom := by cat_disch)
+    (comm₃ : e₁.inv ≫ c.π ≫ e.hom = c'.π := by cat_disch) :
     IsColimit c ≃ IsColimit c' :=
   let i : parallelPair f g ≅ parallelPair f' g' := parallelPair.ext e₀ e₁ comm₁.symm comm₂.symm
   IsColimit.equivOfNatIsoOfIso i c c' (Cofork.ext e (by rw [← comm₃, ← Category.assoc]; rfl))
@@ -698,9 +698,9 @@ if one is a colimit, then the other one is as well.
 def Cofork.isColimitOfIsos {X' Y' : C} (c : Cofork f g) (hc : IsColimit c)
     {f' g' : X' ⟶ Y'} (c' : Cofork f' g')
     (e₀ : X ≅ X') (e₁ : Y ≅ Y') (e : c.pt ≅ c'.pt)
-    (comm₁ : e₀.hom ≫ f' = f ≫ e₁.hom := by aesop_cat)
-    (comm₂ : e₀.hom ≫ g' = g ≫ e₁.hom := by aesop_cat)
-    (comm₃ : e₁.inv ≫ c.π ≫ e.hom = c'.π := by aesop_cat) : IsColimit c' :=
+    (comm₁ : e₀.hom ≫ f' = f ≫ e₁.hom := by cat_disch)
+    (comm₂ : e₀.hom ≫ g' = g ≫ e₁.hom := by cat_disch)
+    (comm₃ : e₁.inv ≫ c.π ≫ e.hom = c'.π := by cat_disch) : IsColimit c' :=
   (Cofork.isColimitEquivOfIsos c c' e₀ e₁ e) hc
 
 variable (f g)

--- a/Mathlib/CategoryTheory/Limits/Shapes/Images.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Images.lean
@@ -72,7 +72,7 @@ structure MonoFactorisation (f : X ⟶ Y) where
   m : I ⟶ Y
   [m_mono : Mono m]
   e : X ⟶ I
-  fac : e ≫ m = f := by aesop_cat
+  fac : e ≫ m = f := by cat_disch
 
 attribute [inherit_doc MonoFactorisation] MonoFactorisation.I MonoFactorisation.m
   MonoFactorisation.m_mono MonoFactorisation.e MonoFactorisation.fac
@@ -160,7 +160,7 @@ variable {f}
 /-- Data exhibiting that a given factorisation through a mono is initial. -/
 structure IsImage (F : MonoFactorisation f) where
   lift : ∀ F' : MonoFactorisation f, F.I ⟶ F'.I
-  lift_fac : ∀ F' : MonoFactorisation f, lift F' ≫ F'.m = F.m := by aesop_cat
+  lift_fac : ∀ F' : MonoFactorisation f, lift F' ≫ F'.m = F.m := by cat_disch
 
 attribute [inherit_doc IsImage] IsImage.lift IsImage.lift_fac
 
@@ -443,20 +443,20 @@ instance (h : f = f') : IsIso (image.eqToHom h) :=
       ⟨(cancel_mono (image.ι f)).1 (by
           -- Porting note: added let's for used to be a simp [image.eqToHom]
           let F : MonoFactorisation f' :=
-            ⟨image f, image.ι f, factorThruImage f, (by aesop_cat)⟩
+            ⟨image f, image.ι f, factorThruImage f, (by cat_disch)⟩
           dsimp [image.eqToHom]
           rw [Category.id_comp,Category.assoc,image.lift_fac F]
           let F' : MonoFactorisation f :=
-            ⟨image f', image.ι f', factorThruImage f', (by aesop_cat)⟩
+            ⟨image f', image.ι f', factorThruImage f', (by cat_disch)⟩
           rw [image.lift_fac F'] ),
         (cancel_mono (image.ι f')).1 (by
           -- Porting note: added let's for used to be a simp [image.eqToHom]
           let F' : MonoFactorisation f :=
-            ⟨image f', image.ι f', factorThruImage f', (by aesop_cat)⟩
+            ⟨image f', image.ι f', factorThruImage f', (by cat_disch)⟩
           dsimp [image.eqToHom]
           rw [Category.id_comp,Category.assoc,image.lift_fac F']
           let F : MonoFactorisation f' :=
-            ⟨image f, image.ι f, factorThruImage f, (by aesop_cat)⟩
+            ⟨image f, image.ι f, factorThruImage f, (by cat_disch)⟩
           rw [image.lift_fac F])⟩⟩⟩
 
 /-- An equation between morphisms gives an isomorphism between the images. -/
@@ -678,7 +678,7 @@ attribute [local ext] ImageMap
 We make a replacement -/
 theorem ImageMap.map_uniq_aux {f g : Arrow C} [HasImage f.hom] [HasImage g.hom] {sq : f ⟶ g}
     (map : image f.hom ⟶ image g.hom)
-    (map_ι : map ≫ image.ι g.hom = image.ι f.hom ≫ sq.right := by aesop_cat)
+    (map_ι : map ≫ image.ι g.hom = image.ι f.hom ≫ sq.right := by cat_disch)
     (map' : image f.hom ⟶ image g.hom)
     (map_ι' : map' ≫ image.ι g.hom = image.ι f.hom ≫ sq.right) : (map = map') := by
   have : map ≫ image.ι g.hom = map' ≫ image.ι g.hom := by rw [map_ι,map_ι']
@@ -692,7 +692,7 @@ theorem ImageMap.map_uniq {f g : Arrow C} [HasImage f.hom] [HasImage g.hom]
 @[simp]
 theorem ImageMap.mk.injEq' {f g : Arrow C} [HasImage f.hom] [HasImage g.hom] {sq : f ⟶ g}
     (map : image f.hom ⟶ image g.hom)
-    (map_ι : map ≫ image.ι g.hom = image.ι f.hom ≫ sq.right := by aesop_cat)
+    (map_ι : map ≫ image.ι g.hom = image.ι f.hom ≫ sq.right := by cat_disch)
     (map' : image f.hom ⟶ image g.hom)
     (map_ι' : map' ≫ image.ι g.hom = image.ι f.hom ≫ sq.right) : (map = map') = True := by
   simp only [Functor.id_obj, eq_iff_iff, iff_true]

--- a/Mathlib/CategoryTheory/Limits/Shapes/IsTerminal.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/IsTerminal.lean
@@ -38,14 +38,14 @@ variable {C : Type u₁} [Category.{v₁} C]
 def asEmptyCone (X : C) : Cone (Functor.empty.{0} C) :=
   { pt := X
     π :=
-    { app := by aesop_cat } }
+    { app := by cat_disch } }
 
 /-- Construct a cocone for the empty diagram given an object. -/
 @[simps]
 def asEmptyCocone (X : C) : Cocone (Functor.empty.{0} C) :=
   { pt := X
     ι :=
-    { app := by aesop_cat } }
+    { app := by cat_disch } }
 
 /-- `X` is terminal if the cone it induces on the empty diagram is limiting. -/
 abbrev IsTerminal (X : C) :=
@@ -57,11 +57,11 @@ abbrev IsInitial (X : C) :=
 
 /-- An object `Y` is terminal iff for every `X` there is a unique morphism `X ⟶ Y`. -/
 def isTerminalEquivUnique (F : Discrete.{0} PEmpty.{1} ⥤ C) (Y : C) :
-    IsLimit (⟨Y, by aesop_cat, by simp⟩ : Cone F) ≃ ∀ X : C, Unique (X ⟶ Y) where
+    IsLimit (⟨Y, by cat_disch, by simp⟩ : Cone F) ≃ ∀ X : C, Unique (X ⟶ Y) where
   toFun t X :=
-    { default := t.lift ⟨X, ⟨by aesop_cat, by simp⟩⟩
+    { default := t.lift ⟨X, ⟨by cat_disch, by simp⟩⟩
       uniq := fun f =>
-        t.uniq ⟨X, ⟨by aesop_cat, by simp⟩⟩ f (by simp) }
+        t.uniq ⟨X, ⟨by cat_disch, by simp⟩⟩ f (by simp) }
   invFun u :=
     { lift := fun s => (u s.pt).default
       uniq := fun s _ _ => (u s.pt).2 _ }
@@ -103,10 +103,10 @@ def IsTerminal.equivOfIso {X Y : C} (e : X ≅ Y) :
 
 /-- An object `X` is initial iff for every `Y` there is a unique morphism `X ⟶ Y`. -/
 def isInitialEquivUnique (F : Discrete.{0} PEmpty.{1} ⥤ C) (X : C) :
-    IsColimit (⟨X, ⟨by aesop_cat, by simp⟩⟩ : Cocone F) ≃ ∀ Y : C, Unique (X ⟶ Y) where
+    IsColimit (⟨X, ⟨by cat_disch, by simp⟩⟩ : Cocone F) ≃ ∀ Y : C, Unique (X ⟶ Y) where
   toFun t X :=
-    { default := t.desc ⟨X, ⟨by aesop_cat, by simp⟩⟩
-      uniq := fun f => t.uniq ⟨X, ⟨by aesop_cat, by simp⟩⟩ f (by simp) }
+    { default := t.desc ⟨X, ⟨by cat_disch, by simp⟩⟩
+      uniq := fun f => t.uniq ⟨X, ⟨by cat_disch, by simp⟩⟩ f (by simp) }
   invFun u :=
     { desc := fun s => (u s.pt).default
       uniq := fun s _ _ => (u s.pt).2 _ }
@@ -215,7 +215,7 @@ variable (X : C) {F₁ : Discrete.{w} PEmpty ⥤ C} {F₂ : Discrete.{w'} PEmpty
     as long as the cone points are isomorphic. -/
 def isLimitChangeEmptyCone {c₁ : Cone F₁} (hl : IsLimit c₁) (c₂ : Cone F₂) (hi : c₁.pt ≅ c₂.pt) :
     IsLimit c₂ where
-  lift c := hl.lift ⟨c.pt, by aesop_cat, by simp⟩ ≫ hi.hom
+  lift c := hl.lift ⟨c.pt, by cat_disch, by simp⟩ ≫ hi.hom
   uniq c f _ := by
     dsimp
     rw [← hl.uniq _ (f ≫ hi.inv) _]
@@ -244,7 +244,7 @@ def isLimitEquivIsTerminalOfIsEmpty {J : Type*} [Category J] [IsEmpty J] {F : J 
     as long as the cocone points are isomorphic. -/
 def isColimitChangeEmptyCocone {c₁ : Cocone F₁} (hl : IsColimit c₁) (c₂ : Cocone F₂)
     (hi : c₁.pt ≅ c₂.pt) : IsColimit c₂ where
-  desc c := hi.inv ≫ hl.desc ⟨c.pt, by aesop_cat, by simp⟩
+  desc c := hi.inv ≫ hl.desc ⟨c.pt, by cat_disch, by simp⟩
   uniq c f _ := by
     dsimp
     rw [← hl.uniq _ (hi.hom ≫ f) _]

--- a/Mathlib/CategoryTheory/Limits/Shapes/Kernels.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Kernels.lean
@@ -570,12 +570,12 @@ theorem CokernelCofork.π_ofπ {X Y P : C} (f : X ⟶ Y) (π : Y ⟶ P) (w : f �
 
 /-- Every cokernel cofork `s` is isomorphic (actually, equal) to `cofork.ofπ (cofork.π s) _`. -/
 def isoOfπ (s : Cofork f 0) : s ≅ Cofork.ofπ (Cofork.π s) (Cofork.condition s) :=
-  Cocones.ext (Iso.refl _) fun j => by cases j <;> aesop_cat
+  Cocones.ext (Iso.refl _) fun j => by cases j <;> cat_disch
 
 /-- If `π = π'`, then `CokernelCofork.of_π π _` and `CokernelCofork.of_π π' _` are isomorphic. -/
 def ofπCongr {P : C} {π π' : Y ⟶ P} {w : f ≫ π = 0} (h : π = π') :
     CokernelCofork.ofπ π w ≅ CokernelCofork.ofπ π' (by rw [← h, w]) :=
-  Cocones.ext (Iso.refl _) fun j => by cases j <;> aesop_cat
+  Cocones.ext (Iso.refl _) fun j => by cases j <;> cat_disch
 
 /-- If `s` is a colimit cokernel cofork, then every `k : Y ⟶ W` satisfying `f ≫ k = 0` induces
     `l : s.X ⟶ W` such that `cofork.π s ≫ l = k`. -/

--- a/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
@@ -683,7 +683,7 @@ variable {I} in
 /-- Constructor for isomorphisms between multicoforks. -/
 @[simps!]
 def ext {K K' : Multicofork I}
-    (e : K.pt ≅ K'.pt) (h : ∀ (i : J.R), K.π i ≫ e.hom = K'.π i := by aesop_cat) :
+    (e : K.pt ≅ K'.pt) (h : ∀ (i : J.R), K.π i ≫ e.hom = K'.π i := by cat_disch) :
     K ≅ K' :=
   Cocones.ext e (by rintro (i | j) <;> simp [h])
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Multiequalizer.lean
@@ -232,7 +232,7 @@ def multicospan : WalkingMulticospan J ⥤ C where
   map_id := by
     rintro (_ | _) <;> rfl
   map_comp := by
-    rintro (_ | _) (_ | _) (_ | _) (_ | _ | _) (_ | _ | _) <;> aesop_cat
+    rintro (_ | _) (_ | _) (_ | _) (_ | _ | _) (_ | _ | _) <;> cat_disch
 
 variable [HasProduct I.left] [HasProduct I.right]
 
@@ -280,7 +280,7 @@ def multispan : WalkingMultispan J ⥤ C where
   map_id := by
     rintro (_ | _) <;> rfl
   map_comp := by
-    rintro (_ | _) (_ | _) (_ | _) (_ | _ | _) (_ | _ | _) <;> aesop_cat
+    rintro (_ | _) (_ | _) (_ | _) (_ | _ | _) (_ | _ | _) <;> cat_disch
 
 @[simp]
 theorem multispan_obj_left (a) : I.multispan.obj (WalkingMultispan.left a) = I.left a :=

--- a/Mathlib/CategoryTheory/Limits/Shapes/PiProd.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/PiProd.lean
@@ -65,6 +65,6 @@ lemma Pi.map_eq_prod_map [∀ i, Decidable (P i)] : Pi.map f =
   rw [← Category.assoc, Iso.eq_comp_inv]
   dsimp only [IsLimit.conePointUniqueUpToIso, binaryFanOfProp, prodIsProd]
   apply prod.hom_ext
-  all_goals aesop_cat
+  all_goals cat_disch
 
 end CategoryTheory.Limits

--- a/Mathlib/CategoryTheory/Limits/Shapes/Preorder/TransfiniteCompositionOfShape.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Preorder/TransfiniteCompositionOfShape.lean
@@ -51,7 +51,7 @@ structure TransfiniteCompositionOfShape [SuccOrder J] [WellFoundedLT J] where
   incl : F ⟶ (Functor.const _).obj Y
   /-- the colimit of `F` identifies to `Y` -/
   isColimit : IsColimit (Cocone.mk Y incl)
-  fac : isoBot.inv ≫ incl.app ⊥ = f := by aesop_cat
+  fac : isoBot.inv ≫ incl.app ⊥ = f := by cat_disch
 
 namespace TransfiniteCompositionOfShape
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
@@ -371,7 +371,7 @@ lemma Pi.map_comp_map' {f g : α → C} {h : β → C} [HasProduct f] [HasProduc
 lemma Pi.map'_eq {f : α → C} {g : β → C} [HasProduct f] [HasProduct g] {p p' : β → α}
     {q : ∀ (b : β), f (p b) ⟶ g b} {q' : ∀ (b : β), f (p' b) ⟶ g b} (hp : p = p')
     (hq : ∀ (b : β), eqToHom (hp ▸ rfl) ≫ q b = q' b) : Pi.map' p q = Pi.map' p' q' := by
-  aesop_cat
+  cat_disch
 
 /-- Construct an isomorphism between categorical products (indexed by the same type)
 from a family of isomorphisms between the factors.
@@ -489,7 +489,7 @@ lemma Sigma.map'_eq {f : α → C} {g : β → C} [HasCoproduct f] [HasCoproduct
     {p p' : α → β} {q : ∀ (a : α), f a ⟶ g (p a)} {q' : ∀ (a : α), f a ⟶ g (p' a)}
     (hp : p = p') (hq : ∀ (a : α), q a ≫ eqToHom (hp ▸ rfl) = q' a) :
     Sigma.map' p q = Sigma.map' p' q' := by
-  aesop_cat
+  cat_disch
 
 /-- Construct an isomorphism between categorical coproducts (indexed by the same type)
 from a family of isomorphisms between the factors.
@@ -564,7 +564,7 @@ def Sigma.whiskerEquiv {J K : Type*} {f : J → C} {g : K → C} (e : J ≃ K) (
   inv := Sigma.map' e.symm fun k => eqToHom (by simp) ≫ (w (e.symm k)).hom
 
 #adaptation_note /-- nightly-2024-04-01
-The last proof was previously by `aesop_cat`. -/
+The last proof was previously by `cat_disch`. -/
 instance {ι : Type*} (f : ι → Type*) (g : (i : ι) → (f i) → C)
     [∀ i, HasProduct (g i)] [HasProduct fun i => ∏ᶜ g i] :
     HasProduct fun p : Σ i, f i => g p.1 p.2 where
@@ -583,7 +583,7 @@ def piPiIso {ι : Type*} (f : ι → Type*) (g : (i : ι) → (f i) → C)
   inv := Pi.lift fun i => Pi.lift fun x => Pi.π _ (⟨i, x⟩ : Σ i, f i)
 
 #adaptation_note /-- nightly-2024-04-01
-The last proof was previously by `aesop_cat`. -/
+The last proof was previously by `cat_disch`. -/
 instance {ι : Type*} (f : ι → Type*) (g : (i : ι) → (f i) → C)
     [∀ i, HasCoproduct (g i)] [HasCoproduct fun i => ∐ g i] :
     HasCoproduct fun p : Σ i, f i => g p.1 p.2 where
@@ -706,8 +706,8 @@ def piConstAdj [Limits.HasProducts.{v} C] (X : C) :
   unit := { app n i := Limits.Pi.π (fun _ : n ↦ X) i }
   counit :=
   { app Y := (Limits.Pi.lift id).op,
-    naturality _ _ _ := by apply Quiver.Hom.unop_inj; aesop_cat }
-  left_triangle_components _ := by apply Quiver.Hom.unop_inj; aesop_cat
+    naturality _ _ _ := by apply Quiver.Hom.unop_inj; cat_disch }
+  left_triangle_components _ := by apply Quiver.Hom.unop_inj; cat_disch
 
 /-- The functor sending `(X, n)` to the coproduct of copies of `X` indexed by `n`. -/
 @[simps]

--- a/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Products.lean
@@ -111,9 +111,9 @@ lemma hasProduct_of_equiv_of_iso (f : α → C) (g : β → C)
   just a convenience lemma to avoid having to go through `Discrete` -/
 @[simps]
 def mkFanLimit {f : β → C} (t : Fan f) (lift : ∀ s : Fan f, s.pt ⟶ t.pt)
-    (fac : ∀ (s : Fan f) (j : β), lift s ≫ t.proj j = s.proj j := by aesop_cat)
+    (fac : ∀ (s : Fan f) (j : β), lift s ≫ t.proj j = s.proj j := by cat_disch)
     (uniq : ∀ (s : Fan f) (m : s.pt ⟶ t.pt) (_ : ∀ j : β, m ≫ t.proj j = s.proj j),
-      m = lift s := by aesop_cat) :
+      m = lift s := by cat_disch) :
     IsLimit t :=
   { lift }
 
@@ -141,9 +141,9 @@ lemma Fan.IsLimit.hom_ext {I : Type*} {F : I → C} {c : Fan F} (hc : IsLimit c)
   just a convenience lemma to avoid having to go through `Discrete` -/
 @[simps]
 def mkCofanColimit {f : β → C} (s : Cofan f) (desc : ∀ t : Cofan f, s.pt ⟶ t.pt)
-    (fac : ∀ (t : Cofan f) (j : β), s.inj j ≫ desc t = t.inj j := by aesop_cat)
+    (fac : ∀ (t : Cofan f) (j : β), s.inj j ≫ desc t = t.inj j := by cat_disch)
     (uniq : ∀ (t : Cofan f) (m : s.pt ⟶ t.pt) (_ : ∀ j : β, s.inj j ≫ m = t.inj j),
-      m = desc t := by aesop_cat) :
+      m = desc t := by cat_disch) :
     IsColimit s :=
   { desc }
 
@@ -253,7 +253,7 @@ theorem Pi.lift_π {β : Type w} {f : β → C} [HasProduct f] {P : C} (p : ∀ 
 /-- A version of `Cones.ext` for `Fan`s. -/
 @[simps!]
 def Fan.ext {f : β → C} {c₁ c₂ : Fan f} (e : c₁.pt ≅ c₂.pt)
-    (w : ∀ (b : β), c₁.proj b = e.hom ≫ c₂.proj b := by aesop_cat) : c₁ ≅ c₂ :=
+    (w : ∀ (b : β), c₁.proj b = e.hom ≫ c₂.proj b := by cat_disch) : c₁ ≅ c₂ :=
   Cones.ext e (fun ⟨j⟩ => w j)
 
 /-- A collection of morphisms `f b ⟶ P` induces a morphism `∐ f ⟶ P`. -/
@@ -273,7 +273,7 @@ instance {f : β → C} [HasCoproduct f] : IsIso (Sigma.desc (fun a ↦ Sigma.ι
 /-- A version of `Cocones.ext` for `Cofan`s. -/
 @[simps!]
 def Cofan.ext {f : β → C} {c₁ c₂ : Cofan f} (e : c₁.pt ≅ c₂.pt)
-    (w : ∀ (b : β), c₁.inj b ≫ e.hom = c₂.inj b := by aesop_cat) : c₁ ≅ c₂ :=
+    (w : ∀ (b : β), c₁.inj b ≫ e.hom = c₂.inj b := by cat_disch) : c₁ ≅ c₂ :=
   Cocones.ext e (fun ⟨j⟩ => w j)
 
 /-- A cofan `c` on `f` such that the induced map `∐ f ⟶ c.pt` is an iso, is a coproduct. -/

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Categorical/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Categorical/Basic.lean
@@ -95,7 +95,7 @@ structure Hom (x y : F ⊡ G) where
   snd : x.snd ⟶ y.snd
   /-- the compatibility condition on `fst` and `snd` with respect to the structure
   isomorphisms -/
-  w : F.map fst ≫ y.iso.hom = x.iso.hom ≫ G.map snd := by aesop_cat
+  w : F.map fst ≫ y.iso.hom = x.iso.hom ≫ G.map snd := by cat_disch
 
 attribute [reassoc (attr := simp)] Hom.w
 
@@ -149,7 +149,7 @@ variable {F G} in
 @[simps!]
 def mkIso {x y : F ⊡ G}
     (eₗ : x.fst ≅ y.fst) (eᵣ : x.snd ≅ y.snd)
-    (w : F.map eₗ.hom ≫ y.iso.hom = x.iso.hom ≫ G.map eᵣ.hom := by aesop_cat) :
+    (w : F.map eₗ.hom ≫ y.iso.hom = x.iso.hom ≫ G.map eᵣ.hom := by cat_disch) :
     x ≅ y where
   hom := ⟨eₗ.hom, eᵣ.hom, w⟩
   inv := ⟨eₗ.inv, eᵣ.inv, by simpa using F.map eₗ.inv ≫= w.symm =≫ G.map eᵣ.inv⟩
@@ -181,7 +181,7 @@ end
 lemma isIso_iff {x y : F ⊡ G} (f : x ⟶ y) :
     IsIso f ↔ (IsIso f.fst ∧ IsIso f.snd) where
   mp h := ⟨inferInstance, inferInstance⟩
-  mpr | ⟨h₁, h₂⟩ => ⟨⟨inv f.fst, inv f.snd, by aesop_cat⟩, by aesop_cat⟩
+  mpr | ⟨h₁, h₂⟩ => ⟨⟨inv f.fst, inv f.snd, by cat_disch⟩, by cat_disch⟩
 
 end
 
@@ -304,7 +304,7 @@ def mkNatIso {J K : X ⥤ F ⊡ G}
       (associator _ _ _).hom ≫
         whiskerLeft J (CatCommSq.iso (π₁ F G) (π₂ F G) F G).hom ≫
         (associator _ _ _).inv ≫
-        whiskerRight e₂.hom G := by aesop_cat) :
+        whiskerRight e₂.hom G := by cat_disch) :
     J ≅ K :=
   NatIso.ofComponents
     (fun x ↦ CategoricalPullback.mkIso (e₁.app x) (e₂.app x)
@@ -337,7 +337,7 @@ variable {J K : X ⥤ F ⊡ G}
       (associator _ _ _).hom ≫
         whiskerLeft J (CatCommSq.iso (π₁ F G) (π₂ F G) F G).hom ≫
         (associator _ _ _).inv ≫
-        whiskerRight e₂.hom G := by aesop_cat)
+        whiskerRight e₂.hom G := by cat_disch)
 
 @[simp]
 lemma toCatCommSqOver_mapIso_mkNatIso_eq_mkIso :

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Categorical/Basic.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Categorical/Basic.lean
@@ -355,7 +355,7 @@ lemma mkNatIso_eq :
         (by simpa [functorEquiv, toCatCommSqOver] using coh)) := by
   rw [← toCatCommSqOver_mapIso_mkNatIso_eq_mkIso e₁ e₂ coh]
   dsimp [Equivalence.fullyFaithfulFunctor]
-  aesop_cat
+  cat_disch
 
 end
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Categorical/CatCospanTransform.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Categorical/CatCospanTransform.lean
@@ -122,12 +122,12 @@ structure CatCospanTransformMorphism
   left_coherence :
       ψ.squareLeft.iso.hom ≫ Functor.whiskerRight left F' =
       Functor.whiskerLeft F base ≫ ψ'.squareLeft.iso.hom := by
-    aesop_cat
+    cat_disch
   /-- the coherence condition for the right square -/
   right_coherence :
       ψ.squareRight.iso.hom ≫ Functor.whiskerRight right G' =
       Functor.whiskerLeft G base ≫ ψ'.squareRight.iso.hom := by
-    aesop_cat
+    cat_disch
 
 namespace CatCospanTransform
 
@@ -214,11 +214,11 @@ def mkIso {ψ ψ' : CatCospanTransform F G F' G'}
     (left_coherence :
         ψ.squareLeft.iso.hom ≫ Functor.whiskerRight left.hom F' =
         Functor.whiskerLeft F base.hom ≫ ψ'.squareLeft.iso.hom := by
-      aesop_cat)
+      cat_disch)
     (right_coherence :
         ψ.squareRight.iso.hom ≫ Functor.whiskerRight right.hom G' =
         Functor.whiskerLeft G base.hom ≫ ψ'.squareRight.iso.hom := by
-      aesop_cat) :
+      cat_disch) :
     ψ ≅ ψ' where
   hom :=
     { left := left.hom
@@ -300,7 +300,7 @@ lemma comp_whiskerRight : (η ≫ η') ▷ φ = η ▷ φ ≫ η' ▷ φ := by c
 @[reassoc]
 lemma whiskerRight_comp :
     η ▷ (φ.comp τ) = (α_ _ _ _).inv ≫ (η ▷ φ) ▷ τ ≫ (α_ _ _ _ ).hom := by
-  aesop_cat
+  cat_disch
 
 @[simp]
 lemma whiskerleft_id : ψ ◁ 𝟙 φ = 𝟙 _ := by cat_disch
@@ -314,7 +314,7 @@ lemma whiskerLeft_comp : ψ ◁ (θ ≫ θ') = (ψ ◁ θ) ≫ (ψ ◁ θ') := b
 @[reassoc]
 lemma comp_whiskerLeft :
     (ψ.comp φ) ◁ γ = (α_ _ _ _).hom ≫ (ψ ◁ (φ ◁ γ)) ≫ (α_ _ _ _).inv := by
-  aesop_cat
+  cat_disch
 
 @[reassoc]
 lemma pentagon
@@ -324,17 +324,17 @@ lemma pentagon
     {σ : CatCospanTransform F''' G''' F'''' G''''} :
     (α_ ψ φ τ).hom ▷ σ ≫ (α_ ψ (φ.comp τ) σ).hom ≫ ψ ◁ (α_ φ τ σ).hom =
       (α_ (ψ.comp φ) τ σ).hom ≫ (α_ ψ φ (τ.comp σ)).hom := by
-  aesop_cat
+  cat_disch
 
 @[reassoc]
 lemma triangle :
     (α_ ψ (.id _ _) φ).hom ≫ ψ ◁ (λ_ φ).hom = (ρ_ ψ).hom ▷ φ := by
-  aesop_cat
+  cat_disch
 
 @[reassoc]
 lemma triangle_inv :
      (α_ ψ (.id _ _) φ).inv ≫ (ρ_ ψ).hom ▷ φ = ψ ◁ (λ_ φ).hom := by
-  aesop_cat
+  cat_disch
 
 section Isos
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Categorical/CatCospanTransform.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/Categorical/CatCospanTransform.lean
@@ -286,16 +286,16 @@ variable
     (γ : τ ⟶ τ')
 
 @[reassoc]
-lemma whisker_exchange : ψ ◁ θ ≫ η ▷ φ' = η ▷ φ ≫ ψ' ◁ θ := by aesop_cat
+lemma whisker_exchange : ψ ◁ θ ≫ η ▷ φ' = η ▷ φ ≫ ψ' ◁ θ := by cat_disch
 
 @[simp]
-lemma id_whiskerRight : 𝟙 ψ ▷ φ = 𝟙 _ := by aesop_cat
+lemma id_whiskerRight : 𝟙 ψ ▷ φ = 𝟙 _ := by cat_disch
 
 @[reassoc]
-lemma whiskerRight_id : η ▷ (.id _ _) = (ρ_ _).hom ≫ η ≫ (ρ_ _).inv := by aesop_cat
+lemma whiskerRight_id : η ▷ (.id _ _) = (ρ_ _).hom ≫ η ≫ (ρ_ _).inv := by cat_disch
 
 @[simp, reassoc]
-lemma comp_whiskerRight : (η ≫ η') ▷ φ = η ▷ φ ≫ η' ▷ φ := by aesop_cat
+lemma comp_whiskerRight : (η ≫ η') ▷ φ = η ▷ φ ≫ η' ▷ φ := by cat_disch
 
 @[reassoc]
 lemma whiskerRight_comp :
@@ -303,13 +303,13 @@ lemma whiskerRight_comp :
   aesop_cat
 
 @[simp]
-lemma whiskerleft_id : ψ ◁ 𝟙 φ = 𝟙 _ := by aesop_cat
+lemma whiskerleft_id : ψ ◁ 𝟙 φ = 𝟙 _ := by cat_disch
 
 @[reassoc]
-lemma id_whiskerLeft : (.id _ _) ◁ η = (λ_ _).hom ≫ η ≫ (λ_ _).inv := by aesop_cat
+lemma id_whiskerLeft : (.id _ _) ◁ η = (λ_ _).hom ≫ η ≫ (λ_ _).inv := by cat_disch
 
 @[simp, reassoc]
-lemma whiskerLeft_comp : ψ ◁ (θ ≫ θ') = (ψ ◁ θ) ≫ (ψ ◁ θ') := by aesop_cat
+lemma whiskerLeft_comp : ψ ◁ (θ ≫ θ') = (ψ ◁ θ) ≫ (ψ ◁ θ') := by cat_disch
 
 @[reassoc]
 lemma comp_whiskerLeft :

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/CommSq.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/CommSq.lean
@@ -346,7 +346,7 @@ theorem of_horiz_isIso_mono [IsIso fst] [Mono g] (sq : CommSq fst snd f g) :
     (by
       refine
         PullbackCone.IsLimit.mk _ (fun s => s.fst ≫ inv fst) (by simp)
-          (fun s => ?_) (by aesop_cat)
+          (fun s => ?_) (by cat_disch)
       simp only [← cancel_mono g, Category.assoc, ← sq.w, IsIso.inv_hom_id_assoc, s.condition])
 
 theorem of_horiz_isIso [IsIso fst] [IsIso g] (sq : CommSq fst snd f g) :

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/HasPullback.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/HasPullback.lean
@@ -318,8 +318,8 @@ instance pullback.map_isIso {W X Y Z S T : C} (f₁ : W ⟶ S) (f₂ : X ⟶ S) 
   refine ⟨⟨pullback.map _ _ _ _ (inv i₁) (inv i₂) (inv i₃) ?_ ?_, ?_, ?_⟩⟩
   · rw [IsIso.comp_inv_eq, Category.assoc, eq₁, IsIso.inv_hom_id_assoc]
   · rw [IsIso.comp_inv_eq, Category.assoc, eq₂, IsIso.inv_hom_id_assoc]
-  · aesop_cat
-  · aesop_cat
+  · cat_disch
+  · cat_disch
 
 /-- If `f₁ = f₂` and `g₁ = g₂`, we may construct a canonical
 isomorphism `pullback f₁ g₁ ≅ pullback f₂ g₂` -/
@@ -342,15 +342,15 @@ instance pushout.map_isIso {W X Y Z S T : C} (f₁ : S ⟶ W) (f₂ : S ⟶ X) [
   refine ⟨⟨pushout.map _ _ _ _ (inv i₁) (inv i₂) (inv i₃) ?_ ?_, ?_, ?_⟩⟩
   · rw [IsIso.comp_inv_eq, Category.assoc, eq₁, IsIso.inv_hom_id_assoc]
   · rw [IsIso.comp_inv_eq, Category.assoc, eq₂, IsIso.inv_hom_id_assoc]
-  · aesop_cat
-  · aesop_cat
+  · cat_disch
+  · cat_disch
 
 theorem pullback.mapDesc_comp {X Y S T S' : C} (f : X ⟶ T) (g : Y ⟶ T) (i : T ⟶ S) (i' : S ⟶ S')
     [HasPullback f g] [HasPullback (f ≫ i) (g ≫ i)] [HasPullback (f ≫ i ≫ i') (g ≫ i ≫ i')]
     [HasPullback ((f ≫ i) ≫ i') ((g ≫ i) ≫ i')] :
     pullback.mapDesc f g (i ≫ i') = pullback.mapDesc f g i ≫ pullback.mapDesc _ _ i' ≫
     (pullback.congrHom (Category.assoc _ _ _) (Category.assoc _ _ _)).hom := by
-  aesop_cat
+  cat_disch
 
 /-- If `f₁ = f₂` and `g₁ = g₂`, we may construct a canonical
 isomorphism `pushout f₁ g₁ ≅ pullback f₂ g₂` -/
@@ -372,7 +372,7 @@ theorem pushout.mapLift_comp {X Y S T S' : C} (f : T ⟶ X) (g : T ⟶ Y) (i : S
     pushout.mapLift f g (i' ≫ i) =
       (pushout.congrHom (Category.assoc _ _ _) (Category.assoc _ _ _)).hom ≫
         pushout.mapLift _ _ i' ≫ pushout.mapLift f g i := by
-  aesop_cat
+  cat_disch
 
 section
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/HasPullback.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/HasPullback.lean
@@ -123,13 +123,13 @@ abbrev pushout.inr {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z) [HasPushout f g] : Z 
 /-- A pair of morphisms `h : W ⟶ X` and `k : W ⟶ Y` satisfying `h ≫ f = k ≫ g` induces a morphism
     `pullback.lift : W ⟶ pullback f g`. -/
 abbrev pullback.lift {W X Y Z : C} {f : X ⟶ Z} {g : Y ⟶ Z} [HasPullback f g] (h : W ⟶ X)
-    (k : W ⟶ Y) (w : h ≫ f = k ≫ g := by aesop_cat) : W ⟶ pullback f g :=
+    (k : W ⟶ Y) (w : h ≫ f = k ≫ g := by cat_disch) : W ⟶ pullback f g :=
   limit.lift _ (PullbackCone.mk h k w)
 
 /-- A pair of morphisms `h : Y ⟶ W` and `k : Z ⟶ W` satisfying `f ≫ h = g ≫ k` induces a morphism
     `pushout.desc : pushout f g ⟶ W`. -/
 abbrev pushout.desc {W X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} [HasPushout f g] (h : Y ⟶ W) (k : Z ⟶ W)
-    (w : f ≫ h = g ≫ k := by aesop_cat) : pushout f g ⟶ W :=
+    (w : f ≫ h = g ≫ k := by cat_disch) : pushout f g ⟶ W :=
   colimit.desc _ (PushoutCocone.mk h k w)
 
 /-- The cone associated to a pullback is a limit cone. -/
@@ -225,7 +225,7 @@ theorem pushout.hom_ext {X Y Z : C} {f : X ⟶ Y} {g : X ⟶ Z} [HasPushout f g]
 def pushoutIsPushout {X Y Z : C} (f : X ⟶ Y) (g : X ⟶ Z) [HasPushout f g] :
     IsColimit (PushoutCocone.mk (pushout.inl f g) (pushout.inr _ _) pushout.condition) :=
   PushoutCocone.IsColimit.mk _ (fun s => pushout.desc s.inl s.inr s.condition) (by simp) (by simp)
-    (by aesop_cat)
+    (by cat_disch)
 
 @[simp]
 lemma pullback.lift_fst_snd {X Y Z : C} (f : X ⟶ Z) (g : Y ⟶ Z) [HasPullback f g] :

--- a/Mathlib/CategoryTheory/Limits/Shapes/Pullback/PullbackCone.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Pullback/PullbackCone.lean
@@ -143,8 +143,8 @@ theorem equalizer_ext (t : PullbackCone f g) {W : C} {k l : W ⟶ t.pt} (h₀ : 
 
 /-- To construct an isomorphism of pullback cones, it suffices to construct an isomorphism
 of the cone points and check it commutes with `fst` and `snd`. -/
-def ext {s t : PullbackCone f g} (i : s.pt ≅ t.pt) (w₁ : s.fst = i.hom ≫ t.fst := by aesop_cat)
-    (w₂ : s.snd = i.hom ≫ t.snd := by aesop_cat) : s ≅ t :=
+def ext {s t : PullbackCone f g} (i : s.pt ≅ t.pt) (w₁ : s.fst = i.hom ≫ t.fst := by cat_disch)
+    (w₂ : s.snd = i.hom ≫ t.snd := by cat_disch) : s ≅ t :=
   WalkingCospan.ext i w₁ w₂
 
 /-- The natural isomorphism between a pullback cone and the corresponding pullback cone
@@ -360,8 +360,8 @@ theorem coequalizer_ext (t : PushoutCocone f g) {W : C} {k l : t.pt ⟶ W}
 
 /-- To construct an isomorphism of pushout cocones, it suffices to construct an isomorphism
 of the cocone points and check it commutes with `inl` and `inr`. -/
-def ext {s t : PushoutCocone f g} (i : s.pt ≅ t.pt) (w₁ : s.inl ≫ i.hom = t.inl := by aesop_cat)
-    (w₂ : s.inr ≫ i.hom = t.inr := by aesop_cat) : s ≅ t :=
+def ext {s t : PushoutCocone f g} (i : s.pt ≅ t.pt) (w₁ : s.inl ≫ i.hom = t.inl := by cat_disch)
+    (w₂ : s.inr ≫ i.hom = t.inr := by cat_disch) : s ≅ t :=
   WalkingSpan.ext i w₁ w₂
 
 /-- The natural isomorphism between a pushout cocone and the corresponding pushout cocone

--- a/Mathlib/CategoryTheory/Limits/Shapes/Reflexive.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Reflexive.lean
@@ -327,7 +327,7 @@ variable {A B : C}
 /-- Bundle the data of a parallel pair along with a common section as a functor out of the walking
 reflexive pair -/
 def reflexivePair (f g : A ⟶ B) (s : B ⟶ A)
-    (sl : s ≫ f = 𝟙 B := by aesop_cat) (sr : s ≫ g = 𝟙 B := by aesop_cat) :
+    (sl : s ≫ f = 𝟙 B := by cat_disch) (sr : s ≫ g = 𝟙 B := by cat_disch) :
     (WalkingReflexivePair ⥤ C) where
   obj x :=
     match x with
@@ -399,9 +399,9 @@ section NatTrans
 
 variable {F G : WalkingReflexivePair ⥤ C}
   (e₀ : F.obj zero ⟶ G.obj zero) (e₁ : F.obj one ⟶ G.obj one)
-  (h₁ : F.map left ≫ e₀ = e₁ ≫ G.map left := by aesop_cat)
-  (h₂ : F.map right ≫ e₀ = e₁ ≫ G.map right := by aesop_cat)
-  (h₃ : F.map reflexion ≫ e₁ = e₀ ≫ G.map reflexion := by aesop_cat)
+  (h₁ : F.map left ≫ e₀ = e₁ ≫ G.map left := by cat_disch)
+  (h₂ : F.map right ≫ e₀ = e₁ ≫ G.map right := by cat_disch)
+  (h₃ : F.map reflexion ≫ e₁ = e₀ ≫ G.map reflexion := by cat_disch)
 
 /-- A constructor for natural transformations between functors from `WalkingReflexivePair`. -/
 def mkNatTrans : F ⟶ G where
@@ -428,9 +428,9 @@ variable {F G : WalkingReflexivePair ⥤ C}
 /-- Constructor for natural isomorphisms between functors out of `WalkingReflexivePair`. -/
 @[simps!]
 def mkNatIso (e₀ : F.obj zero ≅ G.obj zero) (e₁ : F.obj one ≅ G.obj one)
-    (h₁ : F.map left ≫ e₀.hom = e₁.hom ≫ G.map left := by aesop_cat)
-    (h₂ : F.map right ≫ e₀.hom = e₁.hom ≫ G.map right := by aesop_cat)
-    (h₃ : F.map reflexion ≫ e₁.hom = e₀.hom ≫ G.map reflexion := by aesop_cat) :
+    (h₁ : F.map left ≫ e₀.hom = e₁.hom ≫ G.map left := by cat_disch)
+    (h₂ : F.map right ≫ e₀.hom = e₁.hom ≫ G.map right := by cat_disch)
+    (h₃ : F.map reflexion ≫ e₁.hom = e₀.hom ≫ G.map reflexion := by cat_disch) :
     F ≅ G where
   hom := mkNatTrans e₀.hom e₁.hom
   inv := mkNatTrans e₀.inv e₁.inv

--- a/Mathlib/CategoryTheory/Limits/Shapes/RegularMono.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/RegularMono.lean
@@ -47,7 +47,7 @@ class RegularMono (f : X ⟶ Y) where
   /-- Another map from the codomain of `f` to `Z` -/
   right : Y ⟶ Z
   /-- `f` equalizes the two maps -/
-  w : f ≫ left = f ≫ right := by aesop_cat
+  w : f ≫ left = f ≫ right := by cat_disch
   /-- `f` is the equalizer of the two maps -/
   isLimit : IsLimit (Fork.ofι f w)
 
@@ -175,7 +175,7 @@ class RegularEpi (f : X ⟶ Y) where
   /-- Two maps to the domain of `f` -/
   (left right : W ⟶ X)
   /-- `f` coequalizes the two maps -/
-  w : left ≫ f = right ≫ f := by aesop_cat
+  w : left ≫ f = right ≫ f := by cat_disch
   /-- `f` is the coequalizer -/
   isColimit : IsColimit (Cofork.ofπ f w)
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/SplitCoequalizer.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/SplitCoequalizer.lean
@@ -60,13 +60,13 @@ structure IsSplitCoequalizer {Z : C} (π : Y ⟶ Z) where
   /-- A map in the opposite direction to `f` and `g` -/
   leftSection : Y ⟶ X
   /-- Composition of `π` with `f` and with `g` agree -/
-  condition : f ≫ π = g ≫ π := by aesop_cat
+  condition : f ≫ π = g ≫ π := by cat_disch
   /-- `rightSection` splits `π` -/
-  rightSection_π : rightSection ≫ π = 𝟙 Z := by aesop_cat
+  rightSection_π : rightSection ≫ π = 𝟙 Z := by cat_disch
   /-- `leftSection` splits `g` -/
-  leftSection_bottom : leftSection ≫ g = 𝟙 Y := by aesop_cat
+  leftSection_bottom : leftSection ≫ g = 𝟙 Y := by cat_disch
   /-- `leftSection` composed with `f` is `pi` composed with `rightSection` -/
-  leftSection_top : leftSection ≫ f = π ≫ rightSection := by aesop_cat
+  leftSection_top : leftSection ≫ f = π ≫ rightSection := by cat_disch
 
 instance {X : C} : Inhabited (IsSplitCoequalizer (𝟙 X) (𝟙 X) (𝟙 X)) where
   default := { rightSection := 𝟙 X, leftSection := 𝟙 X }

--- a/Mathlib/CategoryTheory/Limits/Shapes/SplitEqualizer.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/SplitEqualizer.lean
@@ -64,13 +64,13 @@ structure IsSplitEqualizer {W : C} (ι : W ⟶ X) where
   /-- A map in the opposite direction to `f` and `g` -/
   rightRetraction : Y ⟶ X
   /-- Composition of `ι` with `f` and with `g` agree -/
-  condition : ι ≫ f = ι ≫ g := by aesop_cat
+  condition : ι ≫ f = ι ≫ g := by cat_disch
   /-- `leftRetraction` splits `ι` -/
-  ι_leftRetraction : ι ≫ leftRetraction = 𝟙 W := by aesop_cat
+  ι_leftRetraction : ι ≫ leftRetraction = 𝟙 W := by cat_disch
   /-- `rightRetraction` splits `g` -/
-  bottom_rightRetraction : g ≫ rightRetraction = 𝟙 X := by aesop_cat
+  bottom_rightRetraction : g ≫ rightRetraction = 𝟙 X := by cat_disch
   /-- `f` composed with `rightRetraction` is `leftRetraction` composed with `ι` -/
-  top_rightRetraction : f ≫ rightRetraction = leftRetraction ≫ ι := by aesop_cat
+  top_rightRetraction : f ≫ rightRetraction = leftRetraction ≫ ι := by cat_disch
 
 instance {X : C} : Inhabited (IsSplitEqualizer (𝟙 X) (𝟙 X) (𝟙 X)) where
   default := { leftRetraction := 𝟙 X, rightRetraction := 𝟙 X }

--- a/Mathlib/CategoryTheory/Limits/Shapes/Terminal.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Terminal.lean
@@ -43,7 +43,7 @@ section Univ
 variable (X : C) {F₁ : Discrete.{w} PEmpty ⥤ C} {F₂ : Discrete.{w'} PEmpty ⥤ C}
 
 theorem hasTerminalChangeDiagram (h : HasLimit F₁) : HasLimit F₂ :=
-  ⟨⟨⟨⟨limit F₁, by aesop_cat, by simp⟩,
+  ⟨⟨⟨⟨limit F₁, by cat_disch, by simp⟩,
     isLimitChangeEmptyCone C (limit.isLimit F₁) _ (eqToIso rfl)⟩⟩⟩
 
 theorem hasTerminalChangeUniverse [h : HasLimitsOfShape (Discrete.{w} PEmpty) C] :
@@ -51,7 +51,7 @@ theorem hasTerminalChangeUniverse [h : HasLimitsOfShape (Discrete.{w} PEmpty) C]
   has_limit _ := hasTerminalChangeDiagram C (h.1 (Functor.empty C))
 
 theorem hasInitialChangeDiagram (h : HasColimit F₁) : HasColimit F₂ :=
-  ⟨⟨⟨⟨colimit F₁, by aesop_cat, by simp⟩,
+  ⟨⟨⟨⟨colimit F₁, by cat_disch, by simp⟩,
     isColimitChangeEmptyCocone C (colimit.isColimit F₁) _ (eqToIso rfl)⟩⟩⟩
 
 theorem hasInitialChangeUniverse [h : HasColimitsOfShape (Discrete.{w} PEmpty) C] :
@@ -92,7 +92,7 @@ theorem hasTerminal_of_unique (X : C) [∀ Y, Nonempty (Y ⟶ X)] [∀ Y, Subsin
     ⟨Classical.inhabited_of_nonempty', (Subsingleton.elim · _)⟩⟩
 
 theorem IsTerminal.hasTerminal {X : C} (h : IsTerminal X) : HasTerminal C :=
-  { has_limit := fun F => HasLimit.mk ⟨⟨X, by aesop_cat, by simp⟩,
+  { has_limit := fun F => HasLimit.mk ⟨⟨X, by cat_disch, by simp⟩,
     isLimitChangeEmptyCone _ h _ (Iso.refl _)⟩ }
 
 /-- We can more explicitly show that a category has an initial object by specifying the object,
@@ -104,7 +104,7 @@ theorem hasInitial_of_unique (X : C) [∀ Y, Nonempty (X ⟶ Y)] [∀ Y, Subsing
 
 theorem IsInitial.hasInitial {X : C} (h : IsInitial X) : HasInitial C where
   has_colimit F :=
-    HasColimit.mk ⟨⟨X, by aesop_cat, by simp⟩, isColimitChangeEmptyCocone _ h _ (Iso.refl _)⟩
+    HasColimit.mk ⟨⟨X, by cat_disch, by simp⟩, isColimitChangeEmptyCocone _ h _ (Iso.refl _)⟩
 
 /-- The map from an object to the terminal object. -/
 abbrev terminal.from [HasTerminal C] (P : C) : P ⟶ ⊤_ C :=
@@ -194,7 +194,7 @@ def limitConstTerminal {J : Type*} [Category J] {C : Type*} [Category C] [HasTer
 theorem limitConstTerminal_inv_π {J : Type*} [Category J] {C : Type*} [Category C] [HasTerminal C]
     {j : J} :
     limitConstTerminal.inv ≫ limit.π ((CategoryTheory.Functor.const J).obj (⊤_ C)) j =
-      terminal.from _ := by aesop_cat
+      terminal.from _ := by cat_disch
 
 instance {J : Type*} [Category J] {C : Type*} [Category C] [HasInitial C] :
     HasColimit ((CategoryTheory.Functor.const J).obj (⊥_ C)) :=
@@ -218,7 +218,7 @@ def colimitConstInitial {J : Type*} [Category J] {C : Type*} [Category C] [HasIn
 theorem ι_colimitConstInitial_hom {J : Type*} [Category J] {C : Type*} [Category C] [HasInitial C]
     {j : J} :
     colimit.ι ((CategoryTheory.Functor.const J).obj (⊥_ C)) j ≫ colimitConstInitial.hom =
-      initial.to _ := by aesop_cat
+      initial.to _ := by cat_disch
 
 instance (priority := 100) initial.mono_from [HasInitial C] [InitialMonoClass C] (X : C)
     (f : ⊥_ C ⟶ X) : Mono f :=

--- a/Mathlib/CategoryTheory/Limits/Shapes/WideEqualizers.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/WideEqualizers.lean
@@ -449,7 +449,7 @@ theorem Cotrident.ofCocone_ι {F : WalkingParallelFamily J ⥤ C} (t : Cocone F)
 -/
 @[simps]
 def Trident.mkHom [Nonempty J] {s t : Trident f} (k : s.pt ⟶ t.pt)
-    (w : k ≫ t.ι = s.ι := by aesop_cat) : s ⟶ t where
+    (w : k ≫ t.ι = s.ι := by cat_disch) : s ⟶ t where
   hom := k
   w := by
     rintro ⟨_ | _⟩
@@ -462,7 +462,7 @@ and check that it commutes with the `ι` morphisms.
 -/
 @[simps]
 def Trident.ext [Nonempty J] {s t : Trident f} (i : s.pt ≅ t.pt)
-    (w : i.hom ≫ t.ι = s.ι := by aesop_cat) : s ≅ t where
+    (w : i.hom ≫ t.ι = s.ι := by cat_disch) : s ≅ t where
   hom := Trident.mkHom i.hom w
   inv := Trident.mkHom i.inv (by rw [← w, Iso.inv_hom_id_assoc])
 
@@ -470,7 +470,7 @@ def Trident.ext [Nonempty J] {s t : Trident f} (i : s.pt ≅ t.pt)
 -/
 @[simps]
 def Cotrident.mkHom [Nonempty J] {s t : Cotrident f} (k : s.pt ⟶ t.pt)
-    (w : s.π ≫ k = t.π := by aesop_cat) : s ⟶ t where
+    (w : s.π ≫ k = t.π := by cat_disch) : s ⟶ t where
   hom := k
   w := by
     rintro ⟨_ | _⟩
@@ -482,7 +482,7 @@ it suffices to give an isomorphism between the cocone points
 and check that it commutes with the `π` morphisms.
 -/
 def Cotrident.ext [Nonempty J] {s t : Cotrident f} (i : s.pt ≅ t.pt)
-    (w : s.π ≫ i.hom = t.π := by aesop_cat) : s ≅ t where
+    (w : s.π ≫ i.hom = t.π := by cat_disch) : s ≅ t where
   hom := Cotrident.mkHom i.hom w
   inv := Cotrident.mkHom i.inv (by rw [Iso.comp_inv_eq, w])
 

--- a/Mathlib/CategoryTheory/Limits/Shapes/WideEqualizers.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/WideEqualizers.lean
@@ -95,8 +95,8 @@ instance WalkingParallelFamily.category : SmallCategory (WalkingParallelFamily J
   Hom := WalkingParallelFamily.Hom J
   id := WalkingParallelFamily.Hom.id
   comp := WalkingParallelFamily.Hom.comp
-  assoc f g h := by cases f <;> cases g <;> cases h <;> aesop_cat
-  comp_id f := by cases f <;> aesop_cat
+  assoc f g h := by cases f <;> cases g <;> cases h <;> cat_disch
+  comp_id f := by cases f <;> cat_disch
 
 @[simp]
 theorem WalkingParallelFamily.hom_id (X : WalkingParallelFamily J) :
@@ -133,7 +133,7 @@ def parallelFamily : WalkingParallelFamily J ⥤ C where
     | _, _, line j => f j
   map_comp := by
     rintro _ _ _ ⟨⟩ ⟨⟩ <;>
-      · aesop_cat
+      · cat_disch
 
 @[simp]
 theorem parallelFamily_obj_zero : (parallelFamily f).obj zero = X :=
@@ -152,8 +152,8 @@ theorem parallelFamily_map_left {j : J} : (parallelFamily f).map (line j) = f j 
 @[simps!]
 def diagramIsoParallelFamily (F : WalkingParallelFamily J ⥤ C) :
     F ≅ parallelFamily fun j => F.map (line j) :=
-  NatIso.ofComponents (fun j => eqToIso <| by cases j <;> aesop_cat) <| by
-    rintro _ _ (_ | _) <;> aesop_cat
+  NatIso.ofComponents (fun j => eqToIso <| by cases j <;> cat_disch) <| by
+    rintro _ _ (_ | _) <;> cat_disch
 
 /-- `WalkingParallelPair` as a category is equivalent to a special case of
 `WalkingParallelFamily`. -/
@@ -164,10 +164,10 @@ def walkingParallelFamilyEquivWalkingParallelPair :
     parallelFamily fun p => cond p.down WalkingParallelPairHom.left WalkingParallelPairHom.right
   inverse := parallelPair (line (ULift.up true)) (line (ULift.up false))
   unitIso := NatIso.ofComponents (fun X => eqToIso (by cases X <;> rfl)) (by
-    rintro _ _ (_ | ⟨_ | _⟩) <;> aesop_cat)
+    rintro _ _ (_ | ⟨_ | _⟩) <;> cat_disch)
   counitIso := NatIso.ofComponents (fun X => eqToIso (by cases X <;> rfl)) (by
-    rintro _ _ (_ | _ | _) <;> aesop_cat)
-  functor_unitIso_comp := by rintro (_ | _) <;> aesop_cat
+    rintro _ _ (_ | _ | _) <;> cat_disch)
+  functor_unitIso_comp := by rintro (_ | _) <;> cat_disch
 
 /-- A trident on `f` is just a `Cone (parallelFamily f)`. -/
 abbrev Trident :=
@@ -386,8 +386,8 @@ def Cone.ofTrident {F : WalkingParallelFamily J ⥤ C} (t : Trident fun j => F.m
     Cone F where
   pt := t.pt
   π :=
-    { app := fun X => t.π.app X ≫ eqToHom (by cases X <;> aesop_cat)
-      naturality := fun j j' g => by cases g <;> aesop_cat }
+    { app := fun X => t.π.app X ≫ eqToHom (by cases X <;> cat_disch)
+      naturality := fun j j' g => by cases g <;> cat_disch }
 
 /-- This is a helper construction that can be useful when verifying that a category has all
     coequalizers. Given `F : WalkingParallelFamily ⥤ C`, which is really the same as
@@ -401,18 +401,18 @@ def Cocone.ofCotrident {F : WalkingParallelFamily J ⥤ C} (t : Cotrident fun j 
     Cocone F where
   pt := t.pt
   ι :=
-    { app := fun X => eqToHom (by cases X <;> aesop_cat) ≫ t.ι.app X
+    { app := fun X => eqToHom (by cases X <;> cat_disch) ≫ t.ι.app X
       naturality := fun j j' g => by cases g <;> simp [Cotrident.app_one t] }
 
 @[simp]
 theorem Cone.ofTrident_π {F : WalkingParallelFamily J ⥤ C} (t : Trident fun j => F.map (line j))
-    (j) : (Cone.ofTrident t).π.app j = t.π.app j ≫ eqToHom (by cases j <;> aesop_cat) :=
+    (j) : (Cone.ofTrident t).π.app j = t.π.app j ≫ eqToHom (by cases j <;> cat_disch) :=
   rfl
 
 @[simp]
 theorem Cocone.ofCotrident_ι {F : WalkingParallelFamily J ⥤ C}
     (t : Cotrident fun j => F.map (line j)) (j) :
-    (Cocone.ofCotrident t).ι.app j = eqToHom (by cases j <;> aesop_cat) ≫ t.ι.app j :=
+    (Cocone.ofCotrident t).ι.app j = eqToHom (by cases j <;> cat_disch) ≫ t.ι.app j :=
   rfl
 
 /-- Given `F : WalkingParallelFamily ⥤ C`, which is really the same as
@@ -422,8 +422,8 @@ def Trident.ofCone {F : WalkingParallelFamily J ⥤ C} (t : Cone F) :
     Trident fun j => F.map (line j) where
   pt := t.pt
   π :=
-    { app := fun X => t.π.app X ≫ eqToHom (by cases X <;> aesop_cat)
-      naturality := by rintro _ _ (_ | _) <;> aesop_cat }
+    { app := fun X => t.π.app X ≫ eqToHom (by cases X <;> cat_disch)
+      naturality := by rintro _ _ (_ | _) <;> cat_disch }
 
 /-- Given `F : WalkingParallelFamily ⥤ C`, which is really the same as
     `parallelFamily (F.map left) (F.map right)` and a cocone on `F`, we get a cotrident on
@@ -432,17 +432,17 @@ def Cotrident.ofCocone {F : WalkingParallelFamily J ⥤ C} (t : Cocone F) :
     Cotrident fun j => F.map (line j) where
   pt := t.pt
   ι :=
-    { app := fun X => eqToHom (by cases X <;> aesop_cat) ≫ t.ι.app X
-      naturality := by rintro _ _ (_ | _) <;> aesop_cat }
+    { app := fun X => eqToHom (by cases X <;> cat_disch) ≫ t.ι.app X
+      naturality := by rintro _ _ (_ | _) <;> cat_disch }
 
 @[simp]
 theorem Trident.ofCone_π {F : WalkingParallelFamily J ⥤ C} (t : Cone F) (j) :
-    (Trident.ofCone t).π.app j = t.π.app j ≫ eqToHom (by cases j <;> aesop_cat) :=
+    (Trident.ofCone t).π.app j = t.π.app j ≫ eqToHom (by cases j <;> cat_disch) :=
   rfl
 
 @[simp]
 theorem Cotrident.ofCocone_ι {F : WalkingParallelFamily J ⥤ C} (t : Cocone F) (j) :
-    (Cotrident.ofCocone t).ι.app j = eqToHom (by cases j <;> aesop_cat) ≫ t.ι.app j :=
+    (Cotrident.ofCocone t).ι.app j = eqToHom (by cases j <;> cat_disch) ≫ t.ι.app j :=
   rfl
 
 /-- Helper function for constructing morphisms between wide equalizer tridents.

--- a/Mathlib/CategoryTheory/Limits/Shapes/WidePullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/WidePullbacks.lean
@@ -326,7 +326,7 @@ theorem hom_eq_lift (g : X ⟶ widePullback _ _ arrows) :
     g = lift (g ≫ base arrows) (fun j => g ≫ π arrows j) (by simp) := by
   apply eq_lift_of_comp_eq
   · simp
-  · rfl  -- Porting note: quite a few missing refl's in aesop_cat now
+  · rfl  -- Porting note: quite a few missing refl's in cat_disch now
 
 @[ext 1100]
 theorem hom_ext (g1 g2 : X ⟶ widePullback _ _ arrows) : (∀ j : J,

--- a/Mathlib/CategoryTheory/Limits/Shapes/WidePullbacks.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/WidePullbacks.lean
@@ -115,7 +115,7 @@ def wideCospan (B : C) (objs : J → C) (arrows : ∀ j : J, objs j ⟶ B) : Wid
 /-- Every diagram is naturally isomorphic (actually, equal) to a `wideCospan` -/
 def diagramIsoWideCospan (F : WidePullbackShape J ⥤ C) :
     F ≅ wideCospan (F.obj none) (fun j => F.obj (some j)) fun j => F.map (Hom.term j) :=
-  NatIso.ofComponents fun j => eqToIso <| by aesop_cat
+  NatIso.ofComponents fun j => eqToIso <| by cat_disch
 
 /-- Construct a cone over a wide cospan. -/
 @[simps]

--- a/Mathlib/CategoryTheory/Limits/Shapes/ZeroMorphisms.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/ZeroMorphisms.lean
@@ -45,9 +45,9 @@ class HasZeroMorphisms where
   /-- Every morphism space has zero -/
   [zero : ∀ X Y : C, Zero (X ⟶ Y)]
   /-- `f` composed with `0` is `0` -/
-  comp_zero : ∀ {X Y : C} (f : X ⟶ Y) (Z : C), f ≫ (0 : Y ⟶ Z) = (0 : X ⟶ Z) := by aesop_cat
+  comp_zero : ∀ {X Y : C} (f : X ⟶ Y) (Z : C), f ≫ (0 : Y ⟶ Z) = (0 : X ⟶ Z) := by cat_disch
   /-- `0` composed with `f` is `0` -/
-  zero_comp : ∀ (X : C) {Y Z : C} (f : Y ⟶ Z), (0 : X ⟶ Y) ≫ f = (0 : X ⟶ Z) := by aesop_cat
+  zero_comp : ∀ (X : C) {Y Z : C} (f : Y ⟶ Z), (0 : X ⟶ Y) ≫ f = (0 : X ⟶ Z) := by cat_disch
 
 attribute [instance] HasZeroMorphisms.zero
 
@@ -64,7 +64,7 @@ theorem zero_comp [HasZeroMorphisms C] {X : C} {Y Z : C} {f : Y ⟶ Z} :
   HasZeroMorphisms.zero_comp X f
 
 instance hasZeroMorphismsPEmpty : HasZeroMorphisms (Discrete PEmpty) where
-  zero := by aesop_cat
+  zero := by cat_disch
 
 instance hasZeroMorphismsPUnit : HasZeroMorphisms (Discrete PUnit) where
   zero X Y := by repeat (constructor)
@@ -361,8 +361,8 @@ def idZeroEquivIsoZero (X : C) : 𝟙 X = 0 ≃ (X ≅ 0) where
     { hom := 0
       inv := 0 }
   invFun i := zero_of_target_iso_zero (𝟙 X) i
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
+  left_inv := by cat_disch
+  right_inv := by cat_disch
 
 @[simp]
 theorem idZeroEquivIsoZero_apply_hom (X : C) (h : 𝟙 X = 0) : ((idZeroEquivIsoZero X) h).hom = 0 :=
@@ -424,9 +424,9 @@ def isIsoZeroEquiv (X Y : C) : IsIso (0 : X ⟶ Y) ≃ 𝟙 X = 0 ∧ 𝟙 Y = 0
     rw [← IsIso.hom_inv_id (0 : X ⟶ Y)]
     rw [← IsIso.inv_hom_id (0 : X ⟶ Y)]
     simp only [comp_zero,and_self,zero_comp]
-  invFun h := ⟨⟨(0 : Y ⟶ X), by aesop_cat⟩⟩
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
+  invFun h := ⟨⟨(0 : Y ⟶ X), by cat_disch⟩⟩
+  left_inv := by cat_disch
+  right_inv := by cat_disch
 
 /-- A zero morphism `0 : X ⟶ X` is an isomorphism if and only if
 the identity on `X` is zero.
@@ -472,7 +472,7 @@ end IsIso
 /-- If there are zero morphisms, any initial object is a zero object. -/
 theorem hasZeroObject_of_hasInitial_object [HasZeroMorphisms C] [HasInitial C] :
     HasZeroObject C := by
-  refine ⟨⟨⊥_ C, fun X => ⟨⟨⟨0⟩, by aesop_cat⟩⟩, fun X => ⟨⟨⟨0⟩, fun f => ?_⟩⟩⟩⟩
+  refine ⟨⟨⊥_ C, fun X => ⟨⟨⟨0⟩, by cat_disch⟩⟩, fun X => ⟨⟨⟨0⟩, fun f => ?_⟩⟩⟩⟩
   calc
     f = f ≫ 𝟙 _ := (Category.comp_id _).symm
     _ = f ≫ 0 := by congr!; subsingleton
@@ -481,7 +481,7 @@ theorem hasZeroObject_of_hasInitial_object [HasZeroMorphisms C] [HasInitial C] :
 /-- If there are zero morphisms, any terminal object is a zero object. -/
 theorem hasZeroObject_of_hasTerminal_object [HasZeroMorphisms C] [HasTerminal C] :
     HasZeroObject C := by
-  refine ⟨⟨⊤_ C, fun X => ⟨⟨⟨0⟩, fun f => ?_⟩⟩, fun X => ⟨⟨⟨0⟩, by aesop_cat⟩⟩⟩⟩
+  refine ⟨⟨⊤_ C, fun X => ⟨⟨⟨0⟩, fun f => ?_⟩⟩, fun X => ⟨⟨⟨0⟩, by cat_disch⟩⟩⟩⟩
   calc
     f = 𝟙 _ ≫ f := (Category.id_comp _).symm
     _ = 0 ≫ f := by congr!; subsingleton

--- a/Mathlib/CategoryTheory/Limits/Shapes/ZeroMorphisms.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/ZeroMorphisms.lean
@@ -453,8 +453,8 @@ def isIsoZeroEquivIsoZero (X Y : C) : IsIso (0 : X ⟶ Y) ≃ (X ≅ 0) × (Y �
     fconstructor
     · exact (idZeroEquivIsoZero X) hX
     · exact (idZeroEquivIsoZero Y) hY
-  · aesop_cat
-  · aesop_cat
+  · cat_disch
+  · cat_disch
 
 theorem isIso_of_source_target_iso_zero {X Y : C} (f : X ⟶ Y) (i : X ≅ 0) (j : Y ≅ 0) :
     IsIso f := by

--- a/Mathlib/CategoryTheory/Limits/VanKampen.lean
+++ b/Mathlib/CategoryTheory/Limits/VanKampen.lean
@@ -774,9 +774,9 @@ include hau in
 lemma IsUniversalColimit.nonempty_isColimit_of_pullbackCone_left
     (s : ∀ i, PullbackCone v (f i)) (hs : ∀ i, IsLimit (s i))
     (t : PullbackCone v u) (ht : IsLimit t) (d : Cofan (fun i : ι ↦ (s i).pt)) (e : d.pt ≅ t.pt)
-    (hu : ∀ i, a.inj i ≫ u = f i := by aesop_cat)
-    (he₁ : ∀ i, d.inj i ≫ e.hom ≫ t.fst = (s i).fst := by aesop_cat)
-    (he₂ : ∀ i, d.inj i ≫ e.hom ≫ t.snd = (s i).snd ≫ a.inj i := by aesop_cat) :
+    (hu : ∀ i, a.inj i ≫ u = f i := by cat_disch)
+    (he₁ : ∀ i, d.inj i ≫ e.hom ≫ t.fst = (s i).fst := by cat_disch)
+    (he₂ : ∀ i, d.inj i ≫ e.hom ≫ t.snd = (s i).snd ≫ a.inj i := by cat_disch) :
     Nonempty (IsColimit d) := by
   let iso : d ≅ (Cofan.mk _ fun i : ι ↦ PullbackCone.IsLimit.lift ht
       (s i).fst ((s i).snd ≫ a.inj i) (by simp [hu, (s i).condition])) :=
@@ -802,9 +802,9 @@ include hau hP in
 lemma IsUniversalColimit.nonempty_isColimit_of_isPullback_left
     {Z : C} {p₁ : Z ⟶ B} {p₂ : Z ⟶ a.pt} (h : IsPullback p₁ p₂ v u)
     (d : Cofan P) (e : d.pt ≅ Z)
-    (hu : ∀ i, a.inj i ≫ u = f i := by aesop_cat)
-    (he₁ : ∀ i, d.inj i ≫ e.hom ≫ p₁ = q₁ i := by aesop_cat)
-    (he₂ : ∀ i, d.inj i ≫ e.hom ≫ p₂ = q₂ i ≫ a.inj i := by aesop_cat) :
+    (hu : ∀ i, a.inj i ≫ u = f i := by cat_disch)
+    (he₁ : ∀ i, d.inj i ≫ e.hom ≫ p₁ = q₁ i := by cat_disch)
+    (he₂ : ∀ i, d.inj i ≫ e.hom ≫ p₂ = q₂ i ≫ a.inj i := by cat_disch) :
     Nonempty (IsColimit d) :=
   hau.nonempty_isColimit_of_pullbackCone_left f u v (fun i ↦ (hP i).cone)
     (fun i ↦ (hP i).isLimit) h.cone h.isLimit d e
@@ -813,7 +813,7 @@ include hau hP in
 /-- Pullbacks distribute over universal coproducts on the left: This is the isomorphism
 `∐ (B ×[S] Xᵢ) ≅ B ×[S] (∐ Xᵢ)`. -/
 lemma IsUniversalColimit.isPullback_of_isColimit_left {d : Cofan P} (hd : IsColimit d)
-    (hu : ∀ i, a.inj i ≫ u = f i := by aesop_cat)
+    (hu : ∀ i, a.inj i ≫ u = f i := by cat_disch)
     [HasPullback v u] :
     IsPullback (Cofan.IsColimit.desc hd q₁) (Cofan.IsColimit.desc hd (q₂ · ≫ a.inj _))
       v u := by
@@ -837,9 +837,9 @@ include hau in
 lemma IsUniversalColimit.nonempty_isColimit_of_pullbackCone_right
     (s : ∀ i, PullbackCone (f i) v) (hs : ∀ i, IsLimit (s i))
     (t : PullbackCone u v) (ht : IsLimit t) (d : Cofan (fun i : ι ↦ (s i).pt)) (e : d.pt ≅ t.pt)
-    (hu : ∀ i, a.inj i ≫ u = f i := by aesop_cat)
-    (he₁ : ∀ i, d.inj i ≫ e.hom ≫ t.fst = (s i).fst ≫ a.inj i := by aesop_cat)
-    (he₂ : ∀ i, d.inj i ≫ e.hom ≫ t.snd = (s i).snd := by aesop_cat) :
+    (hu : ∀ i, a.inj i ≫ u = f i := by cat_disch)
+    (he₁ : ∀ i, d.inj i ≫ e.hom ≫ t.fst = (s i).fst ≫ a.inj i := by cat_disch)
+    (he₂ : ∀ i, d.inj i ≫ e.hom ≫ t.snd = (s i).snd := by cat_disch) :
     Nonempty (IsColimit d) := by
   let iso : d ≅ (Cofan.mk _ fun i : ι ↦ PullbackCone.IsLimit.lift ht
       ((s i).fst ≫ a.inj i) ((s i).snd) (by simp [hu, (s i).condition])) :=
@@ -865,9 +865,9 @@ include hau hP in
 lemma IsUniversalColimit.nonempty_isColimit_of_isPullback_right
     {Z : C} {p₁ : Z ⟶ a.pt} {p₂ : Z ⟶ B} (h : IsPullback p₁ p₂ u v)
     (d : Cofan P) (e : d.pt ≅ Z)
-    (hu : ∀ i, a.inj i ≫ u = f i := by aesop_cat)
-    (he₁ : ∀ i, d.inj i ≫ e.hom ≫ p₁ = q₁ i ≫ a.inj i := by aesop_cat)
-    (he₂ : ∀ i, d.inj i ≫ e.hom ≫ p₂ = q₂ i := by aesop_cat) :
+    (hu : ∀ i, a.inj i ≫ u = f i := by cat_disch)
+    (he₁ : ∀ i, d.inj i ≫ e.hom ≫ p₁ = q₁ i ≫ a.inj i := by cat_disch)
+    (he₂ : ∀ i, d.inj i ≫ e.hom ≫ p₂ = q₂ i := by cat_disch) :
     Nonempty (IsColimit d) :=
   hau.nonempty_isColimit_of_pullbackCone_right f u v (fun i ↦ (hP i).cone)
     (fun i ↦ (hP i).isLimit) h.cone h.isLimit d e
@@ -876,7 +876,7 @@ include hau hP in
 /-- Pullbacks distribute over universal coproducts on the right: This is the isomorphism
 `∐ (Xᵢ ×[S] B) ≅ (∐ Xᵢ) ×[S] B`. -/
 lemma IsUniversalColimit.isPullback_of_isColimit_right {d : Cofan P} (hd : IsColimit d)
-    (hu : ∀ i, a.inj i ≫ u = f i := by aesop_cat)
+    (hu : ∀ i, a.inj i ≫ u = f i := by cat_disch)
     [HasPullback u v] :
     IsPullback (Cofan.IsColimit.desc hd (q₁ · ≫ a.inj _)) (Cofan.IsColimit.desc hd q₂)
       u v := by
@@ -905,10 +905,10 @@ lemma IsUniversalColimit.nonempty_isColimit_prod_of_pullbackCone
     (s : ∀ (i : ι) (j : ι'), PullbackCone (f i) (g j))
     (hs : ∀ i j, IsLimit (s i j)) (t : PullbackCone u v) (ht : IsLimit t)
     {d : Cofan (fun p : ι × ι' ↦ (s p.1 p.2).pt)} (e : d.pt ≅ t.pt)
-    (hu : ∀ i, a.inj i ≫ u = f i := by aesop_cat)
-    (hv : ∀ i, b.inj i ≫ v = g i := by aesop_cat)
-    (he₁ : ∀ i j, d.inj (i, j) ≫ e.hom ≫ t.fst = (s _ _).fst ≫ a.inj _ := by aesop_cat)
-    (he₂ : ∀ i j, d.inj (i, j) ≫ e.hom ≫ t.snd = (s _ _).snd ≫ b.inj _ := by aesop_cat) :
+    (hu : ∀ i, a.inj i ≫ u = f i := by cat_disch)
+    (hv : ∀ i, b.inj i ≫ v = g i := by cat_disch)
+    (he₁ : ∀ i j, d.inj (i, j) ≫ e.hom ≫ t.fst = (s _ _).fst ≫ a.inj _ := by cat_disch)
+    (he₂ : ∀ i j, d.inj (i, j) ≫ e.hom ≫ t.snd = (s _ _).snd ≫ b.inj _ := by cat_disch) :
     Nonempty (IsColimit d) := by
   let c (i : ι) : Cofan (fun j : ι' ↦ (s i j).pt) :=
     Cofan.mk (pullback (f i) v) fun j ↦ pullback.lift (s i j).fst ((s i j).snd ≫ b.inj j)
@@ -936,10 +936,10 @@ lemma IsUniversalColimit.nonempty_isColimit_prod_of_isPullback
     (hP : ∀ i j, IsPullback (q₁ i j) (q₂ i j) (f i) (g j))
     {Z : C} {p₁ : Z ⟶ a.pt} {p₂ : Z ⟶ b.pt} (h : IsPullback p₁ p₂ u v)
     {d : Cofan P} (e : d.pt ≅ Z)
-    (hu : ∀ i, a.inj i ≫ u = f i := by aesop_cat)
-    (hv : ∀ i, b.inj i ≫ v = g i := by aesop_cat)
-    (he₁ : ∀ i j, d.inj (i, j) ≫ e.hom ≫ p₁ = q₁ _ _ ≫ a.inj _ := by aesop_cat)
-    (he₂ : ∀ i j, d.inj (i, j) ≫ e.hom ≫ p₂ = q₂ _ _ ≫ b.inj _ := by aesop_cat) :
+    (hu : ∀ i, a.inj i ≫ u = f i := by cat_disch)
+    (hv : ∀ i, b.inj i ≫ v = g i := by cat_disch)
+    (he₁ : ∀ i j, d.inj (i, j) ≫ e.hom ≫ p₁ = q₁ _ _ ≫ a.inj _ := by cat_disch)
+    (he₂ : ∀ i j, d.inj (i, j) ≫ e.hom ≫ p₂ = q₂ _ _ ≫ b.inj _ := by cat_disch) :
     Nonempty (IsColimit d) :=
   IsUniversalColimit.nonempty_isColimit_prod_of_pullbackCone hau hbu f g u v
     (fun i j ↦ (hP i j).cone) (fun i j ↦ (hP i j).isLimit) h.cone h.isLimit e
@@ -948,8 +948,8 @@ include hau hbu in
 lemma IsUniversalColimit.isPullback_prod_of_isColimit [HasPullback u v]
     {P : ι × ι' → C} {q₁ : ∀ i j, P (i, j) ⟶ X i} {q₂ : ∀ i j, P (i, j) ⟶ Y j}
     (hP : ∀ i j, IsPullback (q₁ i j) (q₂ i j) (f i) (g j)) (d : Cofan P) (hd : IsColimit d)
-    (hu : ∀ i, a.inj i ≫ u = f i := by aesop_cat)
-    (hv : ∀ i, b.inj i ≫ v = g i := by aesop_cat) :
+    (hu : ∀ i, a.inj i ≫ u = f i := by cat_disch)
+    (hv : ∀ i, b.inj i ≫ v = g i := by cat_disch) :
     IsPullback
       (Cofan.IsColimit.desc hd (fun p ↦ q₁ p.1 p.2 ≫ a.inj _))
       (Cofan.IsColimit.desc hd (fun p ↦ q₂ p.1 p.2 ≫ b.inj _)) u v := by

--- a/Mathlib/CategoryTheory/Limits/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Limits/Yoneda.lean
@@ -33,7 +33,7 @@ variable {C : Type u} [Category.{v} C]
 @[simps]
 def colimitCocone (X : Cᵒᵖ) : Cocone (coyoneda.obj X) where
   pt := PUnit
-  ι := { app := by aesop_cat }
+  ι := { app := by cat_disch }
 
 /-- The proposed colimit cocone over `coyoneda.obj X` is a colimit cocone.
 -/

--- a/Mathlib/CategoryTheory/Linear/Basic.lean
+++ b/Mathlib/CategoryTheory/Linear/Basic.lean
@@ -44,10 +44,10 @@ class Linear (R : Type w) [Semiring R] (C : Type u) [Category.{v} C] [Preadditiv
   homModule : ∀ X Y : C, Module R (X ⟶ Y) := by infer_instance
   /-- compatibility of the scalar multiplication with the post-composition -/
   smul_comp : ∀ (X Y Z : C) (r : R) (f : X ⟶ Y) (g : Y ⟶ Z), (r • f) ≫ g = r • f ≫ g := by
-    aesop_cat
+    cat_disch
   /-- compatibility of the scalar multiplication with the pre-composition -/
   comp_smul : ∀ (X Y Z : C) (f : X ⟶ Y) (r : R) (g : Y ⟶ Z), f ≫ (r • g) = r • f ≫ g := by
-    aesop_cat
+    cat_disch
 
 attribute [instance] Linear.homModule
 

--- a/Mathlib/CategoryTheory/Linear/LinearFunctor.lean
+++ b/Mathlib/CategoryTheory/Linear/LinearFunctor.lean
@@ -31,7 +31,7 @@ variable (R : Type*) [Semiring R] {C D : Type*} [Category C] [Category D]
 /-- An additive functor `F` is `R`-linear provided `F.map` is an `R`-module morphism. -/
 class Functor.Linear : Prop where
   /-- the functor induces a linear map on morphisms -/
-  map_smul : ∀ {X Y : C} (f : X ⟶ Y) (r : R), F.map (r • f) = r • F.map f := by aesop_cat
+  map_smul : ∀ {X Y : C} (f : X ⟶ Y) (r : R), F.map (r • f) = r • F.map f := by cat_disch
 
 lemma Functor.linear_iff (F : C ⥤ D) :
     Functor.Linear R F ↔ ∀ (X : C) (r : R), F.map (r • 𝟙 X) = r • 𝟙 (F.obj X) := by

--- a/Mathlib/CategoryTheory/Localization/Construction.lean
+++ b/Mathlib/CategoryTheory/Localization/Construction.lean
@@ -148,7 +148,7 @@ def lift : W.Localization ⥤ D :=
       rintro ⟨X⟩ ⟨Y⟩ f₁ f₂ r
       -- Porting note: rest of proof was `rcases r with ⟨⟩; tidy`
       rcases r with (_ | _ | ⟨f, hf⟩ | ⟨f, hf⟩)
-      · aesop_cat
+      · cat_disch
       · simp
       all_goals
         dsimp

--- a/Mathlib/CategoryTheory/Localization/Construction.lean
+++ b/Mathlib/CategoryTheory/Localization/Construction.lean
@@ -271,11 +271,11 @@ def natTransExtension {F₁ F₂ : W.Localization ⥤ D} (τ : W.Q ⋙ F₁ ⟶ 
 
 @[simp]
 theorem whiskerLeft_natTransExtension {F G : W.Localization ⥤ D} (τ : W.Q ⋙ F ⟶ W.Q ⋙ G) :
-    whiskerLeft W.Q (natTransExtension τ) = τ := by aesop_cat
+    whiskerLeft W.Q (natTransExtension τ) = τ := by cat_disch
 
 -- This is not a simp lemma, because the simp norm form of the left-hand side uses `whiskerLeft`.
 theorem natTransExtension_hcomp {F G : W.Localization ⥤ D} (τ : W.Q ⋙ F ⟶ W.Q ⋙ G) :
-    𝟙 W.Q ◫ natTransExtension τ = τ := by aesop_cat
+    𝟙 W.Q ◫ natTransExtension τ = τ := by cat_disch
 
 theorem natTrans_hcomp_injective {F G : W.Localization ⥤ D} {τ₁ τ₂ : F ⟶ G}
     (h : 𝟙 W.Q ◫ τ₁ = 𝟙 W.Q ◫ τ₂) : τ₁ = τ₂ := by

--- a/Mathlib/CategoryTheory/Localization/Resolution.lean
+++ b/Mathlib/CategoryTheory/Localization/Resolution.lean
@@ -89,7 +89,7 @@ variable {Φ} {X₂ : C₂}
 structure Hom (R R' : Φ.RightResolution X₂) where
   /-- a morphism in the source category -/
   f : R.X₁ ⟶ R'.X₁
-  comm : R.w ≫ Φ.functor.map f = R'.w := by aesop_cat
+  comm : R.w ≫ Φ.functor.map f = R'.w := by cat_disch
 
 attribute [reassoc (attr := simp)] Hom.comm
 
@@ -133,7 +133,7 @@ variable {Φ} {X₂ : C₂}
 structure Hom (L L' : Φ.LeftResolution X₂) where
   /-- a morphism in the source category -/
   f : L.X₁ ⟶ L'.X₁
-  comm : Φ.functor.map f ≫ L'.w = L.w := by aesop_cat
+  comm : Φ.functor.map f ≫ L'.w = L.w := by cat_disch
 
 attribute [reassoc (attr := simp)] Hom.comm
 

--- a/Mathlib/CategoryTheory/Localization/Trifunctor.lean
+++ b/Mathlib/CategoryTheory/Localization/Trifunctor.lean
@@ -145,8 +145,8 @@ and `Lifting₃ L₁ L₂ L₃ W₁ W₂ W₃ F₂ F₂'` hold. -/
 noncomputable def lift₃NatIso : F₁' ≅ F₂' where
   hom := lift₃NatTrans L₁ L₂ L₃ W₁ W₂ W₃ F₁ F₂ F₁' F₂' e.hom
   inv := lift₃NatTrans L₁ L₂ L₃ W₁ W₂ W₃ F₂ F₁ F₂' F₁' e.inv
-  hom_inv_id := natTrans₃_ext L₁ L₂ L₃ W₁ W₂ W₃ (by aesop_cat)
-  inv_hom_id := natTrans₃_ext L₁ L₂ L₃ W₁ W₂ W₃ (by aesop_cat)
+  hom_inv_id := natTrans₃_ext L₁ L₂ L₃ W₁ W₂ W₃ (by cat_disch)
+  inv_hom_id := natTrans₃_ext L₁ L₂ L₃ W₁ W₂ W₃ (by cat_disch)
 
 end
 

--- a/Mathlib/CategoryTheory/Monad/Adjunction.lean
+++ b/Mathlib/CategoryTheory/Monad/Adjunction.lean
@@ -335,7 +335,7 @@ instance comparison_essSurj [Reflective R] :
 
 lemma comparison_full [R.Full] {L : C ⥤ D} (adj : L ⊣ R) :
     (Monad.comparison adj).Full where
-  map_surjective f := ⟨R.preimage f.f, by aesop_cat⟩
+  map_surjective f := ⟨R.preimage f.f, by cat_disch⟩
 
 end Reflective
 
@@ -363,7 +363,7 @@ instance comparison_essSurj [Coreflective R] :
 
 lemma comparison_full [R.Full] {L : C ⥤ D} (adj : R ⊣ L) :
     (Comonad.comparison adj).Full where
-  map_surjective f := ⟨R.preimage f.f, by aesop_cat⟩
+  map_surjective f := ⟨R.preimage f.f, by cat_disch⟩
 
 end Coreflective
 

--- a/Mathlib/CategoryTheory/Monad/Algebra.lean
+++ b/Mathlib/CategoryTheory/Monad/Algebra.lean
@@ -41,9 +41,9 @@ structure Algebra (T : Monad C) : Type max u₁ v₁ where
   /-- The structure morphism associated to an algebra. -/
   a : (T : C ⥤ C).obj A ⟶ A
   /-- The unit axiom associated to an algebra. -/
-  unit : T.η.app A ≫ a = 𝟙 A := by aesop_cat
+  unit : T.η.app A ≫ a = 𝟙 A := by cat_disch
   /-- The associativity axiom associated to an algebra. -/
-  assoc : T.μ.app A ≫ a = (T : C ⥤ C).map a ≫ a := by aesop_cat
+  assoc : T.μ.app A ≫ a = (T : C ⥤ C).map a ≫ a := by cat_disch
 
 attribute [reassoc] Algebra.unit Algebra.assoc
 
@@ -57,7 +57,7 @@ structure Hom (A B : Algebra T) where
   /-- The underlying morphism associated to a morphism of algebras. -/
   f : A.A ⟶ B.A
   /-- Compatibility with the structure morphism, for a morphism of algebras. -/
-  h : (T : C ⥤ C).map f ≫ B.a = A.a ≫ f := by aesop_cat
+  h : (T : C ⥤ C).map f ≫ B.a = A.a ≫ f := by cat_disch
 
 -- Porting note: no need to restate axioms in lean4.
 --restate_axiom hom.h
@@ -113,7 +113,7 @@ commutes with the structure morphisms.
 -/
 @[simps]
 def isoMk {A B : Algebra T} (h : A.A ≅ B.A)
-    (w : (T : C ⥤ C).map h.hom ≫ B.a = A.a ≫ h.hom := by aesop_cat) : A ≅ B where
+    (w : (T : C ⥤ C).map h.hom ≫ B.a = A.a ≫ h.hom := by cat_disch) : A ≅ B where
   hom := { f := h.hom }
   inv :=
     { f := h.inv
@@ -172,7 +172,7 @@ theorem algebra_iso_of_iso {A B : Algebra T} (f : A ⟶ B) [IsIso f.f] : IsIso f
         h := by
           rw [IsIso.eq_comp_inv f.f, Category.assoc, ← f.h]
           simp },
-      by aesop_cat⟩⟩
+      by cat_disch⟩⟩
 
 instance forget_reflects_iso : T.forget.ReflectsIsomorphisms where
   -- Porting note: Is this the right approach to introduce instances?
@@ -261,9 +261,9 @@ structure Coalgebra (G : Comonad C) : Type max u₁ v₁ where
   /-- The structure morphism associated to a coalgebra. -/
   a : A ⟶ (G : C ⥤ C).obj A
   /-- The counit axiom associated to a coalgebra. -/
-  counit : a ≫ G.ε.app A = 𝟙 A := by aesop_cat
+  counit : a ≫ G.ε.app A = 𝟙 A := by cat_disch
   /-- The coassociativity axiom associated to a coalgebra. -/
-  coassoc : a ≫ G.δ.app A = a ≫ G.map a := by aesop_cat
+  coassoc : a ≫ G.δ.app A = a ≫ G.map a := by cat_disch
 
 
 -- Porting note: no need to restate axioms in lean4.
@@ -284,7 +284,7 @@ structure Hom (A B : Coalgebra G) where
   /-- The underlying morphism associated to a morphism of coalgebras. -/
   f : A.A ⟶ B.A
   /-- Compatibility with the structure morphism, for a morphism of coalgebras. -/
-  h : A.a ≫ (G : C ⥤ C).map f = f ≫ B.a := by aesop_cat
+  h : A.a ≫ (G : C ⥤ C).map f = f ≫ B.a := by cat_disch
 
 -- Porting note: no need to restate axioms in lean4.
 --restate_axiom hom.h
@@ -337,7 +337,7 @@ commutes with the structure morphisms.
 -/
 @[simps]
 def isoMk {A B : Coalgebra G} (h : A.A ≅ B.A)
-    (w : A.a ≫ (G : C ⥤ C).map h.hom = h.hom ≫ B.a := by aesop_cat) : A ≅ B where
+    (w : A.a ≫ (G : C ⥤ C).map h.hom = h.hom ≫ B.a := by cat_disch) : A ≅ B where
   hom := { f := h.hom }
   inv :=
     { f := h.inv
@@ -396,7 +396,7 @@ theorem coalgebra_iso_of_iso {A B : Coalgebra G} (f : A ⟶ B) [IsIso f.f] : IsI
         h := by
           rw [IsIso.eq_inv_comp f.f, ← f.h_assoc]
           simp },
-      by aesop_cat⟩⟩
+      by cat_disch⟩⟩
 
 instance forget_reflects_iso : G.forget.ReflectsIsomorphisms where
   -- Porting note: Is this the right approach to introduce instances?

--- a/Mathlib/CategoryTheory/Monad/Basic.lean
+++ b/Mathlib/CategoryTheory/Monad/Basic.lean
@@ -67,7 +67,7 @@ structure Comonad extends C ⥤ C where
   /-- The comultiplication for the comonad. -/
   δ : toFunctor ⟶ toFunctor ⋙ toFunctor
   coassoc : ∀ X, NatTrans.app δ _ ≫ toFunctor.map (δ.app X) = δ.app _ ≫ δ.app _ := by
-    aesop_cat
+    cat_disch
   left_counit : ∀ X : C, δ.app X ≫ ε.app (toFunctor.obj X) = 𝟙 _ := by cat_disch
   right_counit : ∀ X : C, δ.app X ≫ toFunctor.map (ε.app X) = 𝟙 _ := by cat_disch
 
@@ -112,7 +112,7 @@ attribute [reassoc (attr := simp)] Comonad.coassoc Comonad.left_counit Comonad.r
 structure MonadHom (T₁ T₂ : Monad C) extends NatTrans (T₁ : C ⥤ C) T₂ where
   app_η : ∀ X, T₁.η.app X ≫ app X = T₂.η.app X := by cat_disch
   app_μ : ∀ X, T₁.μ.app X ≫ app X = (T₁.map (app X) ≫ app _) ≫ T₂.μ.app X := by
-    aesop_cat
+    cat_disch
 
 initialize_simps_projections MonadHom (+toNatTrans, -app)
 
@@ -149,7 +149,7 @@ instance : Category (Monad C) where
     { toNatTrans :=
         { app := fun X => f.app X ≫ g.app X
           naturality := fun X Y h => by rw [assoc, f.1.naturality_assoc, g.1.naturality] } }
-  -- `aesop_cat` can fill in these proofs, but is unfortunately slightly slow.
+  -- `cat_disch` can fill in these proofs, but is unfortunately slightly slow.
   id_comp _ := MonadHom.ext (by funext; simp only [NatTrans.id_app, id_comp])
   comp_id _ := MonadHom.ext (by funext; simp only [NatTrans.id_app, comp_id])
   assoc _ _ _ := MonadHom.ext (by funext; simp only [assoc])
@@ -160,7 +160,7 @@ instance : Category (Comonad C) where
     { toNatTrans :=
         { app := fun X => f.app X ≫ g.app X
           naturality := fun X Y h => by rw [assoc, f.1.naturality_assoc, g.1.naturality] } }
-  -- `aesop_cat` can fill in these proofs, but is unfortunately slightly slow.
+  -- `cat_disch` can fill in these proofs, but is unfortunately slightly slow.
   id_comp _ := ComonadHom.ext (by funext; simp only [NatTrans.id_app, id_comp])
   comp_id _ := ComonadHom.ext (by funext; simp only [NatTrans.id_app, comp_id])
   assoc _ _ _ := ComonadHom.ext (by funext; simp only [assoc])

--- a/Mathlib/CategoryTheory/Monad/Basic.lean
+++ b/Mathlib/CategoryTheory/Monad/Basic.lean
@@ -41,9 +41,9 @@ structure Monad extends C ⥤ C where
   η : 𝟭 _ ⟶ toFunctor
   /-- The multiplication for the monad. -/
   μ : toFunctor ⋙ toFunctor ⟶ toFunctor
-  assoc : ∀ X, toFunctor.map (NatTrans.app μ X) ≫ μ.app _ = μ.app _ ≫ μ.app _ := by aesop_cat
-  left_unit : ∀ X : C, η.app (toFunctor.obj X) ≫ μ.app _ = 𝟙 _ := by aesop_cat
-  right_unit : ∀ X : C, toFunctor.map (η.app X) ≫ μ.app _ = 𝟙 _ := by aesop_cat
+  assoc : ∀ X, toFunctor.map (NatTrans.app μ X) ≫ μ.app _ = μ.app _ ≫ μ.app _ := by cat_disch
+  left_unit : ∀ X : C, η.app (toFunctor.obj X) ≫ μ.app _ = 𝟙 _ := by cat_disch
+  right_unit : ∀ X : C, toFunctor.map (η.app X) ≫ μ.app _ = 𝟙 _ := by cat_disch
 
 @[reassoc]
 lemma Monad.unit_naturality (T : Monad C) ⦃X Y : C⦄ (f : X ⟶ Y) :
@@ -68,8 +68,8 @@ structure Comonad extends C ⥤ C where
   δ : toFunctor ⟶ toFunctor ⋙ toFunctor
   coassoc : ∀ X, NatTrans.app δ _ ≫ toFunctor.map (δ.app X) = δ.app _ ≫ δ.app _ := by
     aesop_cat
-  left_counit : ∀ X : C, δ.app X ≫ ε.app (toFunctor.obj X) = 𝟙 _ := by aesop_cat
-  right_counit : ∀ X : C, δ.app X ≫ toFunctor.map (ε.app X) = 𝟙 _ := by aesop_cat
+  left_counit : ∀ X : C, δ.app X ≫ ε.app (toFunctor.obj X) = 𝟙 _ := by cat_disch
+  right_counit : ∀ X : C, δ.app X ≫ toFunctor.map (ε.app X) = 𝟙 _ := by cat_disch
 
 @[reassoc]
 lemma Comonad.counit_naturality (T : Comonad C) ⦃X Y : C⦄ (f : X ⟶ Y) :
@@ -110,7 +110,7 @@ attribute [reassoc (attr := simp)] Comonad.coassoc Comonad.left_counit Comonad.r
 /-- A morphism of monads is a natural transformation compatible with η and μ. -/
 @[ext]
 structure MonadHom (T₁ T₂ : Monad C) extends NatTrans (T₁ : C ⥤ C) T₂ where
-  app_η : ∀ X, T₁.η.app X ≫ app X = T₂.η.app X := by aesop_cat
+  app_η : ∀ X, T₁.η.app X ≫ app X = T₂.η.app X := by cat_disch
   app_μ : ∀ X, T₁.μ.app X ≫ app X = (T₁.map (app X) ≫ app _) ≫ T₂.μ.app X := by
     aesop_cat
 
@@ -119,8 +119,8 @@ initialize_simps_projections MonadHom (+toNatTrans, -app)
 /-- A morphism of comonads is a natural transformation compatible with ε and δ. -/
 @[ext]
 structure ComonadHom (M N : Comonad C) extends NatTrans (M : C ⥤ C) N where
-  app_ε : ∀ X, app X ≫ N.ε.app X = M.ε.app X := by aesop_cat
-  app_δ : ∀ X, app X ≫ N.δ.app X = M.δ.app X ≫ app _ ≫ N.map (app X) := by aesop_cat
+  app_ε : ∀ X, app X ≫ N.ε.app X = M.ε.app X := by cat_disch
+  app_δ : ∀ X, app X ≫ N.δ.app X = M.δ.app X ≫ app _ ≫ N.map (app X) := by cat_disch
 
 initialize_simps_projections ComonadHom (+toNatTrans, -app)
 
@@ -193,9 +193,9 @@ theorem comp_toNatTrans {T₁ T₂ T₃ : Comonad C} (f : T₁ ⟶ T₂) (g : T�
 direction is a monad morphism. -/
 @[simps]
 def MonadIso.mk {M N : Monad C} (f : (M : C ⥤ C) ≅ N)
-    (f_η : ∀ (X : C), M.η.app X ≫ f.hom.app X = N.η.app X := by aesop_cat)
+    (f_η : ∀ (X : C), M.η.app X ≫ f.hom.app X = N.η.app X := by cat_disch)
     (f_μ : ∀ (X : C), M.μ.app X ≫ f.hom.app X =
-    (M.map (f.hom.app X) ≫ f.hom.app (N.obj X)) ≫ N.μ.app X := by aesop_cat) : M ≅ N where
+    (M.map (f.hom.app X) ≫ f.hom.app (N.obj X)) ≫ N.μ.app X := by cat_disch) : M ≅ N where
   hom :=
     { toNatTrans := f.hom
       app_η := f_η
@@ -213,9 +213,9 @@ def MonadIso.mk {M N : Monad C} (f : (M : C ⥤ C) ≅ N)
 direction is a comonad morphism. -/
 @[simps]
 def ComonadIso.mk {M N : Comonad C} (f : (M : C ⥤ C) ≅ N)
-    (f_ε : ∀ (X : C), f.hom.app X ≫ N.ε.app X = M.ε.app X := by aesop_cat)
+    (f_ε : ∀ (X : C), f.hom.app X ≫ N.ε.app X = M.ε.app X := by cat_disch)
     (f_δ : ∀ (X : C), f.hom.app X ≫ N.δ.app X =
-    M.δ.app X ≫ f.hom.app (M.obj X) ≫ N.map (f.hom.app X) := by aesop_cat) : M ≅ N where
+    M.δ.app X ≫ f.hom.app (M.obj X) ≫ N.map (f.hom.app X) := by cat_disch) : M ≅ N where
   hom :=
     { toNatTrans := f.hom
       app_ε := f_ε

--- a/Mathlib/CategoryTheory/Monoidal/Action/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Action/Basic.lean
@@ -121,8 +121,8 @@ class MonoidalLeftAction [MonoidalCategory C] extends
   actionHom_def {c c' : C} {d d' : D} (f : c ⟶ c') (g : d ⟶ d') :
       f ⊙ₗₘ g = f ⊵ₗ d ≫ c' ⊴ₗ g := by
     aesop_cat
-  actionHomRight_id (c : C) (d : D) : c ⊴ₗ 𝟙 d = 𝟙 (c ⊙ₗ d) := by aesop_cat
-  id_actionHomLeft (c : C) (d : D) : 𝟙 c ⊵ₗ d = 𝟙 (c ⊙ₗ d) := by aesop_cat
+  actionHomRight_id (c : C) (d : D) : c ⊴ₗ 𝟙 d = 𝟙 (c ⊙ₗ d) := by cat_disch
+  id_actionHomLeft (c : C) (d : D) : 𝟙 c ⊵ₗ d = 𝟙 (c ⊙ₗ d) := by cat_disch
   actionHom_comp
       {c c' c'' : C} {d d' d'' : D} (f₁ : c ⟶ c') (f₂ : c' ⟶ c'')
       (g₁ : d ⟶ d') (g₂ : d' ⟶ d'') :
@@ -435,8 +435,8 @@ class MonoidalRightAction [MonoidalCategory C] extends
   actionHom_def {c c' : C} {d d' : D} (f : d ⟶ d') (g : c ⟶ c') :
       f ⊙ᵣₘ g = f ⊵ᵣ c ≫ d' ⊴ᵣ g := by
     aesop_cat
-  actionHomRight_id (c : C) (d : D) : d ⊴ᵣ 𝟙 c = 𝟙 (d ⊙ᵣ c) := by aesop_cat
-  id_actionHomLeft (c : C) (d : D) : 𝟙 d ⊵ᵣ c = 𝟙 (d ⊙ᵣ c) := by aesop_cat
+  actionHomRight_id (c : C) (d : D) : d ⊴ᵣ 𝟙 c = 𝟙 (d ⊙ᵣ c) := by cat_disch
+  id_actionHomLeft (c : C) (d : D) : 𝟙 d ⊵ᵣ c = 𝟙 (d ⊙ᵣ c) := by cat_disch
   actionHom_comp
       {c c' c'' : C} {d d' d'' : D} (f₁ : d ⟶ d') (f₂ : d' ⟶ d'')
       (g₁ : c ⟶ c') (g₂ : c' ⟶ c'') :

--- a/Mathlib/CategoryTheory/Monoidal/Action/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Action/Basic.lean
@@ -120,40 +120,40 @@ class MonoidalLeftAction [MonoidalCategory C] extends
     MonoidalLeftActionStruct C D where
   actionHom_def {c c' : C} {d d' : D} (f : c ⟶ c') (g : d ⟶ d') :
       f ⊙ₗₘ g = f ⊵ₗ d ≫ c' ⊴ₗ g := by
-    aesop_cat
+    cat_disch
   actionHomRight_id (c : C) (d : D) : c ⊴ₗ 𝟙 d = 𝟙 (c ⊙ₗ d) := by cat_disch
   id_actionHomLeft (c : C) (d : D) : 𝟙 c ⊵ₗ d = 𝟙 (c ⊙ₗ d) := by cat_disch
   actionHom_comp
       {c c' c'' : C} {d d' d'' : D} (f₁ : c ⟶ c') (f₂ : c' ⟶ c'')
       (g₁ : d ⟶ d') (g₂ : d' ⟶ d'') :
       (f₁ ≫ f₂) ⊙ₗₘ (g₁ ≫ g₂) = (f₁ ⊙ₗₘ g₁) ≫ (f₂ ⊙ₗₘ g₂) := by
-    aesop_cat
+    cat_disch
   actionAssocIso_hom_naturality
       {c₁ c₂ c₃ c₄ : C} {d₁ d₂ : D} (f : c₁ ⟶ c₂) (g : c₃ ⟶ c₄) (h : d₁ ⟶ d₂) :
       ((f ⊗ₘ g) ⊙ₗₘ h) ≫ (αₗ c₂ c₄ d₂).hom =
         (αₗ c₁ c₃ d₁).hom ≫ (f ⊙ₗₘ g ⊙ₗₘ h) := by
-    aesop_cat
+    cat_disch
   actionUnitIso_hom_naturality {d d' : D} (f : d ⟶ d') :
       (λₗ d).hom ≫ f = (𝟙_ C) ⊴ₗ f ≫ (λₗ d').hom := by
-    aesop_cat
+    cat_disch
   whiskerLeft_actionHomLeft (c : C) {c' c'' : C} (f : c' ⟶ c'') (d : D) :
       (c ◁ f) ⊵ₗ d = (αₗ _ _ _).hom ≫ c ⊴ₗ f ⊵ₗ d ≫ (αₗ _ _ _).inv := by
-    aesop_cat
+    cat_disch
   whiskerRight_actionHomLeft {c c' : C} (c'' : C) (f : c ⟶ c') (d : D) :
       (f ▷ c'') ⊵ₗ d = (αₗ c c'' d).hom ≫
         f ⊵ₗ (c'' ⊙ₗ d : D) ≫ (αₗ c' c'' d).inv := by
-    aesop_cat
+    cat_disch
   associator_actionHom (c₁ c₂ c₃ : C) (d : D) :
       (α_ c₁ c₂ c₃).hom ⊵ₗ d ≫ (αₗ c₁ (c₂ ⊗ c₃) d).hom ≫
         c₁ ⊴ₗ (αₗ c₂ c₃ d).hom =
       (αₗ (c₁ ⊗ c₂ : C) c₃ d).hom ≫ (αₗ c₁ c₂ (c₃ ⊙ₗ d)).hom := by
-    aesop_cat
+    cat_disch
   leftUnitor_actionHom (c : C) (d : D) :
       (λ_ c).hom ⊵ₗ d = (αₗ _ _ _).hom ≫ (λₗ _).hom := by
-    aesop_cat
+    cat_disch
   rightUnitor_actionHom (c : C) (d : D) :
       (ρ_ c).hom ⊵ₗ d = (αₗ _ _ _).hom ≫ c ⊴ₗ (λₗ _).hom := by
-    aesop_cat
+    cat_disch
 
 attribute [reassoc] MonoidalLeftAction.actionHom_def
 attribute [reassoc, simp] MonoidalLeftAction.id_actionHomLeft
@@ -434,39 +434,39 @@ class MonoidalRightAction [MonoidalCategory C] extends
     MonoidalRightActionStruct C D where
   actionHom_def {c c' : C} {d d' : D} (f : d ⟶ d') (g : c ⟶ c') :
       f ⊙ᵣₘ g = f ⊵ᵣ c ≫ d' ⊴ᵣ g := by
-    aesop_cat
+    cat_disch
   actionHomRight_id (c : C) (d : D) : d ⊴ᵣ 𝟙 c = 𝟙 (d ⊙ᵣ c) := by cat_disch
   id_actionHomLeft (c : C) (d : D) : 𝟙 d ⊵ᵣ c = 𝟙 (d ⊙ᵣ c) := by cat_disch
   actionHom_comp
       {c c' c'' : C} {d d' d'' : D} (f₁ : d ⟶ d') (f₂ : d' ⟶ d'')
       (g₁ : c ⟶ c') (g₂ : c' ⟶ c'') :
       (f₁ ≫ f₂) ⊙ᵣₘ (g₁ ≫ g₂) = (f₁ ⊙ᵣₘ g₁) ≫ (f₂ ⊙ᵣₘ g₂) := by
-    aesop_cat
+    cat_disch
   actionAssocIso_hom_naturality
       {d₁ d₂ : D} {c₁ c₂ c₃ c₄ : C} (f : d₁ ⟶ d₂) (g : c₁ ⟶ c₂) (h : c₃ ⟶ c₄) :
       (f ⊙ᵣₘ g ⊗ₘ h) ≫ (αᵣ d₂ c₂ c₄).hom =
         (αᵣ d₁ c₁ c₃).hom ≫ ((f ⊙ᵣₘ g) ⊙ᵣₘ h) := by
-    aesop_cat
+    cat_disch
   actionUnitIso_hom_naturality {d d' : D} (f : d ⟶ d') :
       (ρᵣ d).hom ≫ f = f ⊵ᵣ (𝟙_ C) ≫ (ρᵣ d').hom := by
-    aesop_cat
+    cat_disch
   actionHomRight_whiskerRight {c' c'' : C} (f : c' ⟶ c'') (c : C) (d : D) :
      d ⊴ᵣ (f ▷ c) = (αᵣ _ _ _).hom ≫ ((d ⊴ᵣ f) ⊵ᵣ c) ≫ (αᵣ _ _ _).inv := by
-    aesop_cat
+    cat_disch
   whiskerRight_actionHomLeft (c : C) {c' c'' : C} (f : c' ⟶ c'') (d : D) :
      d ⊴ᵣ (c ◁ f) = (αᵣ d c c').hom ≫ (d ⊙ᵣ c) ⊴ᵣ f ≫ (αᵣ d c c'').inv := by
-    aesop_cat
+    cat_disch
   actionHom_associator (c₁ c₂ c₃ : C) (d : D) :
       d ⊴ᵣ (α_ c₁ c₂ c₃).hom ≫ (αᵣ d c₁ (c₂ ⊗ c₃)).hom ≫
         (αᵣ (d ⊙ᵣ c₁ : D) c₂ c₃).hom =
       (αᵣ d (c₁ ⊗ c₂ : C) c₃).hom ≫ (αᵣ d c₁ c₂).hom ⊵ᵣ c₃ := by
-    aesop_cat
+    cat_disch
   actionHom_leftUnitor (c : C) (d : D) :
       d ⊴ᵣ (λ_ c).hom = (αᵣ _ _ _).hom ≫ (ρᵣ _).hom ⊵ᵣ c := by
-    aesop_cat
+    cat_disch
   actionHom_rightUnitor (c : C) (d : D) :
       d ⊴ᵣ (ρ_ c).hom = (αᵣ _ _ _).hom ≫ (ρᵣ _).hom := by
-    aesop_cat
+    cat_disch
 
 attribute [reassoc] MonoidalRightAction.actionHom_def
 attribute [reassoc, simp] MonoidalRightAction.id_actionHomLeft

--- a/Mathlib/CategoryTheory/Monoidal/Action/LinearFunctor.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Action/LinearFunctor.lean
@@ -47,15 +47,15 @@ class LaxLeftLinear
   /-- The "μₗ" morphism. -/
   μₗ (F) (c : C) (d : D) : c ⊙ₗ F.obj d ⟶ F.obj (c ⊙ₗ d)
   μₗ_naturality_left (F) {c c': C} (f : c ⟶ c') (d : D) :
-    f ⊵ₗ F.obj d ≫ μₗ c' d = μₗ c d ≫ F.map (f ⊵ₗ d) := by aesop_cat
+    f ⊵ₗ F.obj d ≫ μₗ c' d = μₗ c d ≫ F.map (f ⊵ₗ d) := by cat_disch
   μₗ_naturality_right (F) (c : C) {d d' : D} (f : d ⟶ d') :
-    c ⊴ₗ F.map f ≫ μₗ c d' = μₗ c d ≫ F.map (c ⊴ₗ f) := by aesop_cat
+    c ⊴ₗ F.map f ≫ μₗ c d' = μₗ c d ≫ F.map (c ⊴ₗ f) := by cat_disch
   μₗ_associativity (F) (c c' : C) (d : D) :
     μₗ (c ⊗ c') d ≫ F.map (αₗ _ _ _).hom =
     (αₗ c c' (F.obj d)).hom ≫ c ⊴ₗ μₗ c' d ≫
-      μₗ c (c' ⊙ₗ d) := by aesop_cat
+      μₗ c (c' ⊙ₗ d) := by cat_disch
   μₗ_unitality (F) (d : D) :
-    (λₗ (F.obj d)).hom = μₗ (𝟙_ C) d ≫ F.map (λₗ d).hom := by aesop_cat
+    (λₗ (F.obj d)).hom = μₗ (𝟙_ C) d ≫ F.map (λₗ d).hom := by cat_disch
 
 namespace LaxLeftLinear
 
@@ -101,17 +101,17 @@ class OplaxLeftLinear
   δₗ (F) (c : C) (d : D) : F.obj (c ⊙ₗ d) ⟶ c ⊙ₗ F.obj d
   δₗ_naturality_left (F) {c c': C} (f : c ⟶ c') (d : D) :
     F.map (f ⊵ₗ d) ≫ δₗ c' d =
-    δₗ c d ≫ f ⊵ₗ F.obj d := by aesop_cat
+    δₗ c d ≫ f ⊵ₗ F.obj d := by cat_disch
   δₗ_naturality_right (F) (c : C) {d d' : D} (f : d ⟶ d') :
     F.map (c ⊴ₗ f) ≫ δₗ c d' =
-    δₗ c d ≫ c ⊴ₗ F.map f := by aesop_cat
+    δₗ c d ≫ c ⊴ₗ F.map f := by cat_disch
   δₗ_associativity (F) (c c' : C) (d : D) :
     δₗ (c ⊗ c') d ≫ (αₗ _ _ _).hom =
     F.map (αₗ _ _ _).hom ≫ δₗ c (c' ⊙ₗ d) ≫
-      c ⊴ₗ δₗ c' d := by aesop_cat
+      c ⊴ₗ δₗ c' d := by cat_disch
   δₗ_unitality_inv (F) (d : D) :
     (λₗ (F.obj d)).inv =
-    F.map (λₗ d).inv ≫ δₗ (𝟙_ C) d := by aesop_cat
+    F.map (λₗ d).inv ≫ δₗ (𝟙_ C) d := by cat_disch
 
 namespace OplaxLeftLinear
 
@@ -209,15 +209,15 @@ class LaxRightLinear
   /-- The "μᵣ" morphism. -/
   μᵣ (F) (d : D) (c : C) : F.obj d ⊙ᵣ c ⟶ F.obj (d ⊙ᵣ c)
   μᵣ_naturality_right (F) (d : D) {c c': C} (f : c ⟶ c') :
-    F.obj d ⊴ᵣ f ≫ μᵣ d c' = μᵣ d c ≫ F.map (d ⊴ᵣ f) := by aesop_cat
+    F.obj d ⊴ᵣ f ≫ μᵣ d c' = μᵣ d c ≫ F.map (d ⊴ᵣ f) := by cat_disch
   μᵣ_naturality_left (F) {d d' : D} (f : d ⟶ d') (c : C) :
-    F.map f ⊵ᵣ c ≫ μᵣ d' c = μᵣ d c ≫ F.map (f ⊵ᵣ c) := by aesop_cat
+    F.map f ⊵ᵣ c ≫ μᵣ d' c = μᵣ d c ≫ F.map (f ⊵ᵣ c) := by cat_disch
   μᵣ_associativity (F) (d : D) (c c' : C) :
     μᵣ d (c ⊗ c') ≫ F.map (αᵣ _ _ _).hom =
     (αᵣ (F.obj d) c c').hom ≫ (μᵣ d c) ⊵ᵣ c' ≫
-      μᵣ (d ⊙ᵣ c) c' := by aesop_cat
+      μᵣ (d ⊙ᵣ c) c' := by cat_disch
   μᵣ_unitality (F) (d : D) :
-    (ρᵣ (F.obj d)).hom = μᵣ d (𝟙_ C) ≫ F.map (ρᵣ d).hom := by aesop_cat
+    (ρᵣ (F.obj d)).hom = μᵣ d (𝟙_ C) ≫ F.map (ρᵣ d).hom := by cat_disch
 
 namespace LaxRightLinear
 
@@ -263,17 +263,17 @@ class OplaxRightLinear
   δᵣ (F) (d : D) (c : C) : F.obj (d ⊙ᵣ c) ⟶ (F.obj d) ⊙ᵣ c
   δᵣ_naturality_right (F) (d : D) {c c': C} (f : c ⟶ c') :
     F.map (d ⊴ᵣ f) ≫ δᵣ d c' =
-    δᵣ d c ≫ F.obj d ⊴ᵣ f := by aesop_cat
+    δᵣ d c ≫ F.obj d ⊴ᵣ f := by cat_disch
   δᵣ_naturality_left (F) {d d' : D} (f : d ⟶ d') (c : C) :
     F.map (f ⊵ᵣ c) ≫ δᵣ d' c =
-    δᵣ d c ≫ F.map f ⊵ᵣ c := by aesop_cat
+    δᵣ d c ≫ F.map f ⊵ᵣ c := by cat_disch
   δᵣ_associativity (F) (d : D) (c c' : C) :
     δᵣ d (c ⊗ c') ≫ (αᵣ _ _ _).hom =
     F.map (αᵣ _ _ _).hom ≫ δᵣ (d ⊙ᵣ c) c' ≫
-      δᵣ d c ⊵ᵣ c' := by aesop_cat
+      δᵣ d c ⊵ᵣ c' := by cat_disch
   δᵣ_unitality_inv (F) (d : D) :
     (ρᵣ (F.obj d)).inv =
-    F.map (ρᵣ d).inv ≫ δᵣ d (𝟙_ C) := by aesop_cat
+    F.map (ρᵣ d).inv ≫ δᵣ d (𝟙_ C) := by cat_disch
 
 namespace OplaxRightLinear
 

--- a/Mathlib/CategoryTheory/Monoidal/Bimod.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Bimod.lean
@@ -86,10 +86,10 @@ structure Bimod (A B : Mon_ C) where
   actRight_one : X ◁ η ≫ actRight = (ρ_ X).hom := by cat_disch
   right_assoc :
     X ◁ μ ≫ actRight = (α_ X B.X B.X).inv ≫ actRight ▷ B.X ≫ actRight := by
-    aesop_cat
+    cat_disch
   middle_assoc :
     actLeft ▷ B.X ≫ actRight = (α_ A.X X B.X).hom ≫ A.X ◁ actRight ≫ actLeft := by
-    aesop_cat
+    cat_disch
 
 attribute [reassoc (attr := simp)] Bimod.one_actLeft Bimod.actRight_one Bimod.left_assoc
   Bimod.right_assoc Bimod.middle_assoc

--- a/Mathlib/CategoryTheory/Monoidal/Bimod.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Bimod.lean
@@ -78,12 +78,12 @@ structure Bimod (A B : Mon_ C) where
   X : C
   /-- The left action of this bimodule object -/
   actLeft : A.X ⊗ X ⟶ X
-  one_actLeft : η ▷ X ≫ actLeft = (λ_ X).hom := by aesop_cat
+  one_actLeft : η ▷ X ≫ actLeft = (λ_ X).hom := by cat_disch
   left_assoc :
-    μ ▷ X ≫ actLeft = (α_ A.X A.X X).hom ≫ A.X ◁ actLeft ≫ actLeft := by aesop_cat
+    μ ▷ X ≫ actLeft = (α_ A.X A.X X).hom ≫ A.X ◁ actLeft ≫ actLeft := by cat_disch
   /-- The right action of this bimodule object -/
   actRight : X ⊗ B.X ⟶ X
-  actRight_one : X ◁ η ≫ actRight = (ρ_ X).hom := by aesop_cat
+  actRight_one : X ◁ η ≫ actRight = (ρ_ X).hom := by cat_disch
   right_assoc :
     X ◁ μ ≫ actRight = (α_ X B.X B.X).inv ≫ actRight ▷ B.X ≫ actRight := by
     aesop_cat
@@ -103,8 +103,8 @@ variable {A B : Mon_ C} (M : Bimod A B)
 structure Hom (M N : Bimod A B) where
   /-- The morphism between `M`'s monoidal category and `N`'s monoidal category -/
   hom : M.X ⟶ N.X
-  left_act_hom : M.actLeft ≫ hom = (A.X ◁ hom) ≫ N.actLeft := by aesop_cat
-  right_act_hom : M.actRight ≫ hom = (hom ▷ B.X) ≫ N.actRight := by aesop_cat
+  left_act_hom : M.actLeft ≫ hom = (A.X ◁ hom) ≫ N.actLeft := by cat_disch
+  right_act_hom : M.actRight ≫ hom = (hom ▷ B.X) ≫ N.actRight := by cat_disch
 
 attribute [reassoc (attr := simp)] Hom.left_act_hom Hom.right_act_hom
 

--- a/Mathlib/CategoryTheory/Monoidal/Bimon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Bimon_.lean
@@ -38,10 +38,10 @@ A bimonoid object in a braided category `C` is a object that is simultaneously m
 objects, and structure morphisms of them satisfy appropriate consistency conditions.
 -/
 class Bimon_Class (M : C) extends Mon_Class M, Comon_Class M where
-  mul_comul (M) : μ[M] ≫ Δ[M] = (Δ[M] ⊗ₘ Δ[M]) ≫ tensorμ M M M M ≫ (μ[M] ⊗ₘ μ[M]) := by aesop_cat
-  one_comul (M) : η[M] ≫ Δ[M] = η[M ⊗ M] := by aesop_cat
-  mul_counit (M) : μ[M] ≫ ε[M] = ε[M ⊗ M] := by aesop_cat
-  one_counit (M) : η[M] ≫ ε[M] = 𝟙 (𝟙_ C) := by aesop_cat
+  mul_comul (M) : μ[M] ≫ Δ[M] = (Δ[M] ⊗ₘ Δ[M]) ≫ tensorμ M M M M ≫ (μ[M] ⊗ₘ μ[M]) := by cat_disch
+  one_comul (M) : η[M] ≫ Δ[M] = η[M ⊗ M] := by cat_disch
+  mul_counit (M) : μ[M] ≫ ε[M] = ε[M ⊗ M] := by cat_disch
+  one_counit (M) : η[M] ≫ ε[M] = 𝟙 (𝟙_ C) := by cat_disch
 
 namespace Bimon_Class
 

--- a/Mathlib/CategoryTheory/Monoidal/Braided/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided/Basic.lean
@@ -208,7 +208,7 @@ by a faithful monoidal functor.
 def BraidedCategory.ofFaithful {C D : Type*} [Category C] [Category D] [MonoidalCategory C]
     [MonoidalCategory D] (F : C ⥤ D) [F.Monoidal] [F.Faithful] [BraidedCategory D]
     (β : ∀ X Y : C, X ⊗ Y ≅ Y ⊗ X)
-    (w : ∀ X Y, μ F _ _ ≫ F.map (β X Y).hom = (β_ _ _).hom ≫ μ F _ _ := by aesop_cat) :
+    (w : ∀ X Y, μ F _ _ ≫ F.map (β X Y).hom = (β_ _ _).hom ≫ μ F _ _ := by cat_disch) :
     BraidedCategory C where
   braiding := β
   braiding_naturality_left := by
@@ -371,7 +371,7 @@ A symmetric monoidal category is a braided monoidal category for which the braid
 class SymmetricCategory (C : Type u) [Category.{v} C] [MonoidalCategory.{v} C] extends
     BraidedCategory.{v} C where
   -- braiding symmetric:
-  symmetry : ∀ X Y : C, (β_ X Y).hom ≫ (β_ Y X).hom = 𝟙 (X ⊗ Y) := by aesop_cat
+  symmetry : ∀ X Y : C, (β_ X Y).hom ≫ (β_ Y X).hom = 𝟙 (X ⊗ Y) := by cat_disch
 
 attribute [reassoc (attr := simp)] SymmetricCategory.symmetry
 
@@ -388,7 +388,7 @@ which preserves the braiding.
 -/
 class Functor.LaxBraided (F : C ⥤ D) extends F.LaxMonoidal where
   braided : ∀ X Y : C, μ X Y ≫ F.map (β_ X Y).hom =
-    (β_ (F.obj X) (F.obj Y)).hom ≫ μ Y X := by aesop_cat
+    (β_ (F.obj X) (F.obj Y)).hom ≫ μ Y X := by cat_disch
 
 namespace Functor.LaxBraided
 
@@ -473,9 +473,9 @@ section
 variable {F G : LaxBraidedFunctor C D} (e : ∀ X, F.obj X ≅ G.obj X)
     (naturality : ∀ {X Y : C} (f : X ⟶ Y), F.map f ≫ (e Y).hom = (e X).hom ≫ G.map f := by
       aesop_cat)
-    (unit : ε F.toFunctor ≫ (e (𝟙_ C)).hom = ε G.toFunctor := by aesop_cat)
+    (unit : ε F.toFunctor ≫ (e (𝟙_ C)).hom = ε G.toFunctor := by cat_disch)
     (tensor : ∀ X Y, μ F.toFunctor X Y ≫ (e (X ⊗ Y)).hom =
-      ((e X).hom ⊗ₘ (e Y).hom) ≫ μ G.toFunctor X Y := by aesop_cat)
+      ((e X).hom ⊗ₘ (e Y).hom) ≫ μ G.toFunctor X Y := by cat_disch)
 
 /-- Constructor for isomorphisms between lax braided functors. -/
 def isoOfComponents :

--- a/Mathlib/CategoryTheory/Monoidal/Braided/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Braided/Basic.lean
@@ -50,23 +50,23 @@ class BraidedCategory (C : Type u) [Category.{v} C] [MonoidalCategory.{v} C] whe
   braiding_naturality_right :
     ∀ (X : C) {Y Z : C} (f : Y ⟶ Z),
       X ◁ f ≫ (braiding X Z).hom = (braiding X Y).hom ≫ f ▷ X := by
-    aesop_cat
+    cat_disch
   braiding_naturality_left :
     ∀ {X Y : C} (f : X ⟶ Y) (Z : C),
       f ▷ Z ≫ (braiding Y Z).hom = (braiding X Z).hom ≫ Z ◁ f := by
-    aesop_cat
+    cat_disch
   /-- The first hexagon identity. -/
   hexagon_forward :
     ∀ X Y Z : C,
       (α_ X Y Z).hom ≫ (braiding X (Y ⊗ Z)).hom ≫ (α_ Y Z X).hom =
         ((braiding X Y).hom ▷ Z) ≫ (α_ Y X Z).hom ≫ (Y ◁ (braiding X Z).hom) := by
-    aesop_cat
+    cat_disch
   /-- The second hexagon identity. -/
   hexagon_reverse :
     ∀ X Y Z : C,
       (α_ X Y Z).inv ≫ (braiding (X ⊗ Y) Z).hom ≫ (α_ Z X Y).inv =
         (X ◁ (braiding Y Z).hom) ≫ (α_ X Z Y).inv ≫ ((braiding X Z).hom ▷ Y) := by
-    aesop_cat
+    cat_disch
 
 attribute [reassoc (attr := simp)]
   BraidedCategory.braiding_naturality_left
@@ -472,7 +472,7 @@ section
 
 variable {F G : LaxBraidedFunctor C D} (e : ∀ X, F.obj X ≅ G.obj X)
     (naturality : ∀ {X Y : C} (f : X ⟶ Y), F.map f ≫ (e Y).hom = (e X).hom ≫ G.map f := by
-      aesop_cat)
+      cat_disch)
     (unit : ε F.toFunctor ≫ (e (𝟙_ C)).hom = ε G.toFunctor := by cat_disch)
     (tensor : ∀ X Y, μ F.toFunctor X Y ≫ (e (X ⊗ Y)).hom =
       ((e X).hom ⊗ₘ (e Y).hom) ≫ μ G.toFunctor X Y := by cat_disch)

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Basic.lean
@@ -256,7 +256,7 @@ lemma lift_fst_snd {X Y : C} : lift (fst X Y) (snd X Y) = 𝟙 (X ⊗ Y) := by e
 @[simp]
 lemma lift_comp_fst_snd {X Y Z : C} (f : X ⟶ Y ⊗ Z) :
     lift (f ≫ fst _ _) (f ≫ snd _ _) = f := by
-  aesop_cat
+  cat_disch
 
 @[reassoc (attr := simp)]
 lemma whiskerLeft_fst (X : C) {Y Z : C} (f : Y ⟶ Z) : X ◁ f ≫ fst _ _ = fst _ _ := by
@@ -293,12 +293,12 @@ lemma lift_fst_comp_snd_comp {W X Y Z : C} (g : W ⟶ X) (g' : Y ⟶ Z) :
 @[reassoc (attr := simp)]
 lemma lift_whiskerRight {X Y Z W : C} (f : X ⟶ Y) (g : X ⟶ Z) (h : Y ⟶ W) :
     lift f g ≫ (h ▷ Z) = lift (f ≫ h) g := by
-  aesop_cat
+  cat_disch
 
 @[reassoc (attr := simp)]
 lemma lift_whiskerLeft {X Y Z W : C} (f : X ⟶ Y) (g : X ⟶ Z) (h : Z ⟶ W) :
     lift f g ≫ (Y ◁ h) = lift f (g ≫ h) := by
-  aesop_cat
+  cat_disch
 
 @[reassoc (attr := simp)]
 lemma associator_hom_fst (X Y Z : C) :
@@ -340,12 +340,12 @@ lemma associator_inv_snd (X Y Z : C) :
 @[reassoc (attr := simp)]
 lemma lift_lift_associator_hom {X Y Z W : C} (f : X ⟶ Y) (g : X ⟶ Z) (h : X ⟶ W) :
     lift (lift f g) h ≫ (α_ Y Z W).hom = lift f (lift g h) := by
-  aesop_cat
+  cat_disch
 
 @[reassoc (attr := simp)]
 lemma lift_lift_associator_inv {X Y Z W : C} (f : X ⟶ Y) (g : X ⟶ Z) (h : X ⟶ W) :
     lift f (lift g h) ≫ (α_ Y Z W).inv = lift (lift f g) h := by
-  aesop_cat
+  cat_disch
 
 lemma leftUnitor_hom (X : C) : (λ_ X).hom = snd _ _ := by simp [snd_def]
 lemma rightUnitor_hom (X : C) : (ρ_ X).hom = fst _ _ := by simp [fst_def]
@@ -378,13 +378,13 @@ lemma whiskerRight_toUnit_comp_leftUnitor_hom (X Y : C) : toUnit X ▷ Y ≫ (λ
 lemma lift_leftUnitor_hom {X Y : C} (f : X ⟶ 𝟙_ C) (g : X ⟶ Y) :
     lift f g ≫ (λ_ Y).hom = g := by
   rw [← Iso.eq_comp_inv]
-  aesop_cat
+  cat_disch
 
 @[reassoc (attr := simp)]
 lemma lift_rightUnitor_hom {X Y : C} (f : X ⟶ Y) (g : X ⟶ 𝟙_ C) :
     lift f g ≫ (ρ_ Y).hom = f := by
   rw [← Iso.eq_comp_inv]
-  aesop_cat
+  cat_disch
 
 /-- Universal property of the cartesian product: Maps to `X ⊗ Y` correspond to pairs of maps to `X`
 and to `Y`. -/
@@ -512,14 +512,14 @@ instance terminalComparison_isIso_of_preservesLimits [PreservesLimit (Functor.em
 
 @[simp]
 lemma preservesTerminalIso_id : preservesTerminalIso (𝟭 C) = .refl _ := by
-  aesop_cat
+  cat_disch
 
 @[simp]
 lemma preservesTerminalIso_comp [PreservesLimit (Functor.empty.{0} C) F]
     [PreservesLimit (Functor.empty.{0} D) G] [PreservesLimit (Functor.empty.{0} C) (F ⋙ G)] :
     preservesTerminalIso (F ⋙ G) =
       G.mapIso (preservesTerminalIso F) ≪≫ preservesTerminalIso G := by
-  aesop_cat
+  cat_disch
 
 end terminalComparison
 

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Basic.lean
@@ -62,8 +62,8 @@ class CartesianMonoidalCategory (C : Type u) [Category.{v} C] extends MonoidalCa
   snd (X Y : C) : X ⊗ Y ⟶ Y
   /-- The monoidal product is the categorical product. -/
   tensorProductIsBinaryProduct (X Y : C) : IsLimit <| BinaryFan.mk (fst X Y) (snd X Y)
-  fst_def (X Y : C) : fst X Y = X ◁ isTerminalTensorUnit.from Y ≫ (ρ_ X).hom := by aesop_cat
-  snd_def (X Y : C) : snd X Y = isTerminalTensorUnit.from X ▷ Y ≫ (λ_ Y).hom := by aesop_cat
+  fst_def (X Y : C) : fst X Y = X ◁ isTerminalTensorUnit.from Y ≫ (ρ_ X).hom := by cat_disch
+  snd_def (X Y : C) : snd X Y = isTerminalTensorUnit.from X ▷ Y ≫ (λ_ Y).hom := by cat_disch
 
 @[deprecated (since := "2025-05-15")] alias ChosenFiniteProducts := CartesianMonoidalCategory
 
@@ -415,11 +415,11 @@ theorem braiding_inv_fst (X Y : C) : (β_ X Y).inv ≫ fst _ _ = snd _ _ := by
 theorem braiding_inv_snd (X Y : C) : (β_ X Y).inv ≫ snd _ _ = fst _ _ := by
   simp [fst_def, snd_def, ← BraidedCategory.braiding_inv_naturality_right_assoc]
 
-theorem lift_snd_fst {X Y : C} : lift (snd X Y) (fst X Y) = (β_ X Y).hom := by aesop_cat
+theorem lift_snd_fst {X Y : C} : lift (snd X Y) (fst X Y) = (β_ X Y).hom := by cat_disch
 
 @[simp, reassoc]
 lemma lift_snd_comp_fst_comp {W X Y Z : C} (g : W ⟶ X) (g' : Y ⟶ Z) :
-    lift (snd _ _ ≫ g') (fst _ _ ≫ g) = (β_ _ _).hom ≫ (g' ⊗ₘ g) := by aesop_cat
+    lift (snd _ _ ≫ g') (fst _ _ ≫ g) = (β_ _ _).hom ≫ (g' ⊗ₘ g) := by cat_disch
 
 @[reassoc (attr := simp)]
 lemma lift_braiding_hom {T X Y : C} (f : T ⟶ X) (g : T ⟶ Y) :
@@ -812,7 +812,7 @@ lemma lift_δ (f : X ⟶ Y) (g : X ⟶ Z) : F.map (lift f g) ≫ δ F _ _ = lift
   ext <;> simp [← map_comp]
 
 lemma δ_of_cartesianMonoidalCategory (X Y : C) :
-    δ F X Y = CartesianMonoidalCategory.prodComparison F X Y := by aesop_cat
+    δ F X Y = CartesianMonoidalCategory.prodComparison F X Y := by cat_disch
 
 variable [PreservesFiniteProducts F]
 

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/FunctorCategory.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/FunctorCategory.lean
@@ -60,7 +60,7 @@ def isLimit : IsLimit (BinaryFan.mk (fst F₁ F₂) (snd F₁ F₂)) :=
     (IsLimit.postcomposeHomEquiv (mapPairIso (by exact Iso.refl _) (by exact Iso.refl _)) _).1
       (IsLimit.ofIsoLimit
         (tensorProductIsBinaryProduct (X := F₁.obj j) (Y := F₂.obj j))
-        (Cones.ext (Iso.refl _) (by rintro ⟨_ | _⟩; all_goals aesop_cat))))
+        (Cones.ext (Iso.refl _) (by rintro ⟨_ | _⟩; all_goals cat_disch))))
 
 end chosenProd
 

--- a/Mathlib/CategoryTheory/Monoidal/Cartesian/Mon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Cartesian/Mon_.lean
@@ -134,7 +134,7 @@ def yonedaMonObj : Cᵒᵖ ⥤ MonCat.{v} where
       map_mul' f₁ f₂ := by
         change φ.unop ≫ lift f₁ f₂ ≫ μ = lift (φ.unop ≫ f₁) (φ.unop ≫ f₂) ≫ μ
         rw [← Category.assoc]
-        aesop_cat }
+        cat_disch }
   map_id _ := MonCat.hom_ext (MonoidHom.ext Category.id_comp)
   map_comp _ _ := MonCat.hom_ext (MonoidHom.ext (Category.assoc _ _))
 

--- a/Mathlib/CategoryTheory/Monoidal/Category.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Category.lean
@@ -156,7 +156,7 @@ These associators and unitors satisfy the pentagon and triangle equations. -/
 class MonoidalCategory (C : Type u) [𝒞 : Category.{v} C] extends MonoidalCategoryStruct C where
   tensorHom_def {X₁ Y₁ X₂ Y₂ : C} (f : X₁ ⟶ Y₁) (g : X₂ ⟶ Y₂) :
     f ⊗ₘ g = (f ▷ X₂) ≫ (Y₁ ◁ g) := by
-      aesop_cat
+      cat_disch
   /-- Tensor product of identity maps is the identity: `𝟙 X₁ ⊗ₘ 𝟙 X₂ = 𝟙 (X₁ ⊗ X₂)` -/
   id_tensorHom_id : ∀ X₁ X₂ : C, 𝟙 X₁ ⊗ₘ 𝟙 X₂ = 𝟙 (X₁ ⊗ X₂) := by cat_disch
   /--
@@ -166,28 +166,28 @@ class MonoidalCategory (C : Type u) [𝒞 : Category.{v} C] extends MonoidalCate
   tensor_comp :
     ∀ {X₁ Y₁ Z₁ X₂ Y₂ Z₂ : C} (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (g₁ : Y₁ ⟶ Z₁) (g₂ : Y₂ ⟶ Z₂),
       (f₁ ≫ g₁) ⊗ₘ (f₂ ≫ g₂) = (f₁ ⊗ₘ f₂) ≫ (g₁ ⊗ₘ g₂) := by
-    aesop_cat
+    cat_disch
   whiskerLeft_id : ∀ (X Y : C), X ◁ 𝟙 Y = 𝟙 (X ⊗ Y) := by
-    aesop_cat
+    cat_disch
   id_whiskerRight : ∀ (X Y : C), 𝟙 X ▷ Y = 𝟙 (X ⊗ Y) := by
-    aesop_cat
+    cat_disch
   /-- Naturality of the associator isomorphism: `(f₁ ⊗ₘ f₂) ⊗ₘ f₃ ≃ f₁ ⊗ₘ (f₂ ⊗ₘ f₃)` -/
   associator_naturality :
     ∀ {X₁ X₂ X₃ Y₁ Y₂ Y₃ : C} (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (f₃ : X₃ ⟶ Y₃),
       ((f₁ ⊗ₘ f₂) ⊗ₘ f₃) ≫ (α_ Y₁ Y₂ Y₃).hom = (α_ X₁ X₂ X₃).hom ≫ (f₁ ⊗ₘ (f₂ ⊗ₘ f₃)) := by
-    aesop_cat
+    cat_disch
   /--
   Naturality of the left unitor, commutativity of `𝟙_ C ⊗ X ⟶ 𝟙_ C ⊗ Y ⟶ Y` and `𝟙_ C ⊗ X ⟶ X ⟶ Y`
   -/
   leftUnitor_naturality :
     ∀ {X Y : C} (f : X ⟶ Y), 𝟙_ _ ◁ f ≫ (λ_ Y).hom = (λ_ X).hom ≫ f := by
-    aesop_cat
+    cat_disch
   /--
   Naturality of the right unitor: commutativity of `X ⊗ 𝟙_ C ⟶ Y ⊗ 𝟙_ C ⟶ Y` and `X ⊗ 𝟙_ C ⟶ X ⟶ Y`
   -/
   rightUnitor_naturality :
     ∀ {X Y : C} (f : X ⟶ Y), f ▷ 𝟙_ _ ≫ (ρ_ Y).hom = (ρ_ X).hom ≫ f := by
-    aesop_cat
+    cat_disch
   /--
   The pentagon identity relating the isomorphism between `X ⊗ (Y ⊗ (Z ⊗ W))` and `((X ⊗ Y) ⊗ Z) ⊗ W`
   -/
@@ -195,13 +195,13 @@ class MonoidalCategory (C : Type u) [𝒞 : Category.{v} C] extends MonoidalCate
     ∀ W X Y Z : C,
       (α_ W X Y).hom ▷ Z ≫ (α_ W (X ⊗ Y) Z).hom ≫ W ◁ (α_ X Y Z).hom =
         (α_ (W ⊗ X) Y Z).hom ≫ (α_ W X (Y ⊗ Z)).hom := by
-    aesop_cat
+    cat_disch
   /--
   The identity relating the isomorphisms between `X ⊗ (𝟙_ C ⊗ Y)`, `(X ⊗ 𝟙_ C) ⊗ Y` and `X ⊗ Y`
   -/
   triangle :
     ∀ X Y : C, (α_ X (𝟙_ _) Y).hom ≫ X ◁ (λ_ Y).hom = (ρ_ X).hom ▷ Y := by
-    aesop_cat
+    cat_disch
 
 attribute [reassoc] MonoidalCategory.tensorHom_def
 attribute [reassoc, simp] MonoidalCategory.whiskerLeft_id
@@ -337,7 +337,7 @@ instance whiskerLeft_isIso (X : C) {Y Z : C} (f : Y ⟶ Z) [IsIso f] : IsIso (X 
 @[simp]
 theorem inv_whiskerLeft (X : C) {Y Z : C} (f : Y ⟶ Z) [IsIso f] :
     inv (X ◁ f) = X ◁ inv f := by
-  aesop_cat
+  cat_disch
 
 @[simp]
 lemma whiskerLeftIso_refl (W X : C) :
@@ -365,7 +365,7 @@ instance whiskerRight_isIso {X Y : C} (f : X ⟶ Y) (Z : C) [IsIso f] : IsIso (f
 @[simp]
 theorem inv_whiskerRight {X Y : C} (f : X ⟶ Y) (Z : C) [IsIso f] :
     inv (f ▷ Z) = inv f ▷ Z := by
-  aesop_cat
+  cat_disch
 
 @[simp]
 lemma whiskerRightIso_refl (X W : C) :
@@ -700,39 +700,39 @@ A constructor for monoidal categories that requires `tensorHom` instead of `whis
 -/
 abbrev ofTensorHom [MonoidalCategoryStruct C]
     (id_tensorHom_id : ∀ X₁ X₂ : C, tensorHom (𝟙 X₁) (𝟙 X₂) = 𝟙 (tensorObj X₁ X₂) := by
-      aesop_cat)
+      cat_disch)
     (id_tensorHom : ∀ (X : C) {Y₁ Y₂ : C} (f : Y₁ ⟶ Y₂), tensorHom (𝟙 X) f = whiskerLeft X f := by
-      aesop_cat)
+      cat_disch)
     (tensorHom_id : ∀ {X₁ X₂ : C} (f : X₁ ⟶ X₂) (Y : C), tensorHom f (𝟙 Y) = whiskerRight f Y := by
-      aesop_cat)
+      cat_disch)
     (tensor_comp :
       ∀ {X₁ Y₁ Z₁ X₂ Y₂ Z₂ : C} (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (g₁ : Y₁ ⟶ Z₁) (g₂ : Y₂ ⟶ Z₂),
         tensorHom (f₁ ≫ g₁) (f₂ ≫ g₂) = tensorHom f₁ f₂ ≫ tensorHom g₁ g₂ := by
-          aesop_cat)
+          cat_disch)
     (associator_naturality :
       ∀ {X₁ X₂ X₃ Y₁ Y₂ Y₃ : C} (f₁ : X₁ ⟶ Y₁) (f₂ : X₂ ⟶ Y₂) (f₃ : X₃ ⟶ Y₃),
         tensorHom (tensorHom f₁ f₂) f₃ ≫ (associator Y₁ Y₂ Y₃).hom =
           (associator X₁ X₂ X₃).hom ≫ tensorHom f₁ (tensorHom f₂ f₃) := by
-            aesop_cat)
+            cat_disch)
     (leftUnitor_naturality :
       ∀ {X Y : C} (f : X ⟶ Y),
         tensorHom (𝟙 (𝟙_ C)) f ≫ (leftUnitor Y).hom = (leftUnitor X).hom ≫ f := by
-          aesop_cat)
+          cat_disch)
     (rightUnitor_naturality :
       ∀ {X Y : C} (f : X ⟶ Y),
         tensorHom f (𝟙 (𝟙_ C)) ≫ (rightUnitor Y).hom = (rightUnitor X).hom ≫ f := by
-          aesop_cat)
+          cat_disch)
     (pentagon :
       ∀ W X Y Z : C,
         tensorHom (associator W X Y).hom (𝟙 Z) ≫
             (associator W (tensorObj X Y) Z).hom ≫ tensorHom (𝟙 W) (associator X Y Z).hom =
           (associator (tensorObj W X) Y Z).hom ≫ (associator W X (tensorObj Y Z)).hom := by
-            aesop_cat)
+            cat_disch)
     (triangle :
       ∀ X Y : C,
         (associator X (𝟙_ C) Y).hom ≫ tensorHom (𝟙 X) (leftUnitor Y).hom =
           tensorHom (rightUnitor X).hom (𝟙 Y) := by
-            aesop_cat) :
+            cat_disch) :
       MonoidalCategory C where
   tensorHom_def := by intros; simp [← id_tensorHom, ← tensorHom_id, ← tensor_comp]
   whiskerLeft_id := by intros; simp [← id_tensorHom, ← id_tensorHom_id]

--- a/Mathlib/CategoryTheory/Monoidal/Category.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Category.lean
@@ -158,7 +158,7 @@ class MonoidalCategory (C : Type u) [𝒞 : Category.{v} C] extends MonoidalCate
     f ⊗ₘ g = (f ▷ X₂) ≫ (Y₁ ◁ g) := by
       aesop_cat
   /-- Tensor product of identity maps is the identity: `𝟙 X₁ ⊗ₘ 𝟙 X₂ = 𝟙 (X₁ ⊗ X₂)` -/
-  id_tensorHom_id : ∀ X₁ X₂ : C, 𝟙 X₁ ⊗ₘ 𝟙 X₂ = 𝟙 (X₁ ⊗ X₂) := by aesop_cat
+  id_tensorHom_id : ∀ X₁ X₂ : C, 𝟙 X₁ ⊗ₘ 𝟙 X₂ = 𝟙 (X₁ ⊗ X₂) := by cat_disch
   /--
   Tensor product of compositions is composition of tensor products:
   `(f₁ ≫ g₁) ⊗ₘ (f₂ ≫ g₂) = (f₁ ⊗ₘ f₂) ≫ (g₁ ⊗ₘ g₂)`

--- a/Mathlib/CategoryTheory/Monoidal/Center.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Center.lean
@@ -53,9 +53,9 @@ structure HalfBraiding (X : C) where
   monoidal : ∀ U U', (β (U ⊗ U')).hom =
       (α_ _ _ _).inv ≫
         ((β U).hom ▷ U') ≫ (α_ _ _ _).hom ≫ (U ◁ (β U').hom) ≫ (α_ _ _ _).inv := by
-    aesop_cat
+    cat_disch
   naturality : ∀ {U U'} (f : U ⟶ U'), (X ◁ f) ≫ (β U').hom = (β U).hom ≫ (f ▷ X) := by
-    aesop_cat
+    cat_disch
 
 attribute [reassoc, simp] HalfBraiding.monoidal -- the reassoc lemma is redundant as a simp lemma
 
@@ -340,7 +340,7 @@ def braiding (X Y : Center C) : X ⊗ Y ≅ Y ⊗ X :=
 instance braidedCategoryCenter : BraidedCategory (Center C) where
   braiding := braiding
 
--- `aesop_cat` handles the hexagon axioms
+-- `cat_disch` handles the hexagon axioms
 section
 
 variable [BraidedCategory C]

--- a/Mathlib/CategoryTheory/Monoidal/Center.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Center.lean
@@ -78,7 +78,7 @@ variable {C}
 structure Hom (X Y : Center C) where
   /-- The underlying morphism between the first components of the objects involved -/
   f : X.1 ⟶ Y.1
-  comm : ∀ U, (f ▷ U) ≫ (Y.2.β U).hom = (X.2.β U).hom ≫ (U ◁ f) := by aesop_cat
+  comm : ∀ U, (f ▷ U) ≫ (Y.2.β U).hom = (X.2.β U).hom ≫ (U ◁ f) := by cat_disch
 
 attribute [reassoc (attr := simp)] Hom.comm
 

--- a/Mathlib/CategoryTheory/Monoidal/CommGrp_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CommGrp_.lean
@@ -152,8 +152,8 @@ def mkIso' {G H : C} (e : G ≅ H) [Grp_Class G] [IsCommMon G] [Grp_Class H] [Is
 
 /-- Construct an isomorphism of group objects by giving an isomorphism between the underlying
 objects and checking compatibility with unit and multiplication only in the forward direction. -/
-abbrev mkIso {G H : CommGrp_ C} (e : G.X ≅ H.X) (one_f : η[G.X] ≫ e.hom = η[H.X] := by aesop_cat)
-    (mul_f : μ[G.X] ≫ e.hom = (e.hom ⊗ₘ e.hom) ≫ μ[H.X] := by aesop_cat) : G ≅ H :=
+abbrev mkIso {G H : CommGrp_ C} (e : G.X ≅ H.X) (one_f : η[G.X] ≫ e.hom = η[H.X] := by cat_disch)
+    (mul_f : μ[G.X] ≫ e.hom = (e.hom ⊗ₘ e.hom) ≫ μ[H.X] := by cat_disch) : G ≅ H :=
   have : IsMon_Hom e.hom := ⟨one_f, mul_f⟩
   mkIso' e
 
@@ -187,7 +187,7 @@ def mapCommGrp : CommGrp_ C ⥤ CommGrp_ D where
             dsimp
             rw [← Functor.LaxBraided.braided_assoc, ← Functor.map_comp, IsCommMon.mul_comm] } }
   map f := F.mapMon.map f
-  map_id X := show F.mapMon.map (𝟙 X.toGrp_.toMon_) = _ by aesop_cat
+  map_id X := show F.mapMon.map (𝟙 X.toGrp_.toMon_) = _ by cat_disch
 
 protected instance Faithful.mapCommGrp [F.Faithful] : F.mapCommGrp.Faithful where
   map_injective hfg := F.mapMon.map_injective hfg

--- a/Mathlib/CategoryTheory/Monoidal/CommMon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/CommMon_.lean
@@ -129,8 +129,8 @@ def mkIso' {M N : C} (e : M ≅ N) [Mon_Class M] [IsCommMon M] [Mon_Class N] [Is
 underlying objects and checking compatibility with unit and multiplication only in the forward
 direction. -/
 @[simps!]
-abbrev mkIso {M N : CommMon_ C} (e : M.X ≅ N.X) (one_f : η[M.X] ≫ e.hom = η[N.X] := by aesop_cat)
-    (mul_f : μ[M.X] ≫ e.hom = (e.hom ⊗ₘ e.hom) ≫ μ[N.X] := by aesop_cat) : M ≅ N :=
+abbrev mkIso {M N : CommMon_ C} (e : M.X ≅ N.X) (one_f : η[M.X] ≫ e.hom = η[N.X] := by cat_disch)
+    (mul_f : μ[M.X] ≫ e.hom = (e.hom ⊗ₘ e.hom) ≫ μ[N.X] := by cat_disch) : M ≅ N :=
   have : IsMon_Hom e.hom := ⟨one_f, mul_f⟩
   mkIso' e
 

--- a/Mathlib/CategoryTheory/Monoidal/Comon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Comon_.lean
@@ -40,9 +40,9 @@ class Comon_Class (X : C) where
   counit : X ⟶ 𝟙_ C
   /-- The comultiplication morphism of a comonoid object. -/
   comul : X ⟶ X ⊗ X
-  counit_comul (X) : comul ≫ counit ▷ X = (λ_ X).inv := by aesop_cat
-  comul_counit (X) : comul ≫ X ◁ counit = (ρ_ X).inv := by aesop_cat
-  comul_assoc (X) : comul ≫ X ◁ comul = comul ≫ (comul ▷ X) ≫ (α_ X X X).hom := by aesop_cat
+  counit_comul (X) : comul ≫ counit ▷ X = (λ_ X).inv := by cat_disch
+  comul_counit (X) : comul ≫ X ◁ counit = (ρ_ X).inv := by cat_disch
+  comul_assoc (X) : comul ≫ X ◁ comul = comul ≫ (comul ▷ X) ≫ (α_ X X X).hom := by cat_disch
 
 namespace Comon_Class
 
@@ -69,8 +69,8 @@ variable {M N O : C} [Comon_Class M] [Comon_Class N] [Comon_Class O]
 
 /-- The property that a morphism between comonoid objects is a comonoid morphism. -/
 class IsComon_Hom (f : M ⟶ N) : Prop where
-  hom_counit (f) : f ≫ ε = ε := by aesop_cat
-  hom_comul (f) : f ≫ Δ = Δ ≫ (f ⊗ₘ f) := by aesop_cat
+  hom_counit (f) : f ≫ ε = ε := by cat_disch
+  hom_comul (f) : f ≫ Δ = Δ ≫ (f ⊗ₘ f) := by cat_disch
 
 attribute [reassoc (attr := simp)] IsComon_Hom.hom_counit IsComon_Hom.hom_comul
 
@@ -144,8 +144,8 @@ attribute [instance] Hom.is_comon_hom
 /-- Construct a morphism `M ⟶ N` of `Comon_ C` from a map `f : M ⟶ N` and a `IsComon_Hom f`
 instance. -/
 abbrev Hom.mk' {M N : Comon_ C} (f : M.X ⟶ N.X)
-    (f_counit : f ≫ ε[N.X] = ε[M.X] := by aesop_cat)
-    (f_comul : f ≫ Δ[N.X] = Δ[M.X] ≫ (f ⊗ₘ f) := by aesop_cat) :
+    (f_counit : f ≫ ε[N.X] = ε[M.X] := by cat_disch)
+    (f_comul : f ≫ Δ[N.X] = Δ[M.X] ≫ (f ⊗ₘ f) := by cat_disch) :
     Hom M N :=
   have : IsComon_Hom f := ⟨f_counit, f_comul⟩
   .mk f
@@ -197,7 +197,7 @@ instance {A B : Comon_ C} (f : A ⟶ B) [e : IsIso ((forget C).map f)] : IsIso f
 /-- The forgetful functor from comonoid objects to the ambient category reflects isomorphisms. -/
 instance : (forget C).ReflectsIsomorphisms where
   reflects f e :=
-    ⟨⟨{ hom := inv f.hom }, by aesop_cat⟩⟩
+    ⟨⟨{ hom := inv f.hom }, by cat_disch⟩⟩
 
 /-- Construct an isomorphism of comonoids by giving an isomorphism between the underlying objects
 and checking compatibility with counit and comultiplication only in the forward direction.
@@ -211,10 +211,10 @@ def mkIso' {M N : Comon_ C} (f : M.X ≅ N.X) [IsComon_Hom f.hom] : M ≅ N wher
 and checking compatibility with counit and comultiplication only in the forward direction.
 -/
 @[simps]
-def mkIso {M N : Comon_ C} (f : M.X ≅ N.X) (f_counit : f.hom ≫ ε[N.X] = ε[M.X] := by aesop_cat)
-    (f_comul : f.hom ≫ Δ[N.X] = Δ[M.X] ≫ (f.hom ⊗ₘ f.hom) := by aesop_cat) : M ≅ N :=
+def mkIso {M N : Comon_ C} (f : M.X ≅ N.X) (f_counit : f.hom ≫ ε[N.X] = ε[M.X] := by cat_disch)
+    (f_comul : f.hom ≫ Δ[N.X] = Δ[M.X] ≫ (f.hom ⊗ₘ f.hom) := by cat_disch) : M ≅ N :=
   have : IsComon_Hom f.hom := ⟨f_counit, f_comul⟩
-  ⟨⟨f.hom⟩, ⟨f.inv⟩, by aesop_cat, by aesop_cat⟩
+  ⟨⟨f.hom⟩, ⟨f.inv⟩, by cat_disch, by cat_disch⟩
 
 @[simps]
 instance uniqueHomToTrivial (A : Comon_ C) : Unique (A ⟶ trivial C) where

--- a/Mathlib/CategoryTheory/Monoidal/Free/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Basic.lean
@@ -366,7 +366,7 @@ instance : (project f).Monoidal :=
     { εIso := Iso.refl _
       μIso := fun _ _ ↦ Iso.refl _
   -- Porting note: `μIso_hom_natural_left` was proved in mathlib3 by tidy, using induction.
-  -- We probably don't expect `aesop_cat` to handle this yet, see https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Aesop.20and.20cases
+  -- We probably don't expect `cat_disch` to handle this yet, see https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Aesop.20and.20cases
   -- In any case I don't understand why we need to specify `using Quotient.recOn`.
       μIso_hom_natural_left := fun f _ => by
         induction f using Quotient.recOn

--- a/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
@@ -141,7 +141,7 @@ variable (C)
 @[simp]
 def normalize : F C ⥤ N C ⥤ N C where
   obj X := normalizeObj' X
-  map {X Y} := Quotient.lift normalizeMapAux (by aesop_cat)
+  map {X Y} := Quotient.lift normalizeMapAux (by cat_disch)
 
 /-- A variant of the normalization functor where we consider the result as an object in the free
     monoidal category (rather than an object of the discrete subcategory of objects in normal
@@ -326,7 +326,7 @@ end
 
 instance : Groupoid.{u} (F C) :=
   { (inferInstance : Category (F C)) with
-    inv := Quotient.lift (fun f => ⟦inverseAux f⟧) (by aesop_cat) }
+    inv := Quotient.lift (fun f => ⟦inverseAux f⟧) (by cat_disch) }
 
 end Groupoid
 

--- a/Mathlib/CategoryTheory/Monoidal/Functor.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Functor.lean
@@ -66,24 +66,24 @@ class LaxMonoidal (F : C ⥤ D) where
   μ_natural_left (F) :
     ∀ {X Y : C} (f : X ⟶ Y) (X' : C),
       F.map f ▷ F.obj X' ≫ μ Y X' = μ X X' ≫ F.map (f ▷ X') := by
-    aesop_cat
+    cat_disch
   μ_natural_right (F) :
     ∀ {X Y : C} (X' : C) (f : X ⟶ Y) ,
       F.obj X' ◁ F.map f ≫ μ X' Y = μ X' X ≫ F.map (X' ◁ f) := by
-    aesop_cat
+    cat_disch
   /-- associativity of the tensorator -/
   associativity (F) :
     ∀ X Y Z : C,
       μ X Y ▷ F.obj Z ≫ μ (X ⊗ Y) Z ≫ F.map (α_ X Y Z).hom =
         (α_ (F.obj X) (F.obj Y) (F.obj Z)).hom ≫ F.obj X ◁ μ Y Z ≫ μ X (Y ⊗ Z) := by
-    aesop_cat
+    cat_disch
   -- unitality
   left_unitality (F) :
     ∀ X : C, (λ_ (F.obj X)).hom = ε ▷ F.obj X ≫ μ (𝟙_ C) X ≫ F.map (λ_ X).hom := by
-      aesop_cat
+      cat_disch
   right_unitality (F) :
     ∀ X : C, (ρ_ (F.obj X)).hom = F.obj X ◁ ε ≫ μ X (𝟙_ C) ≫ F.map (ρ_ X).hom := by
-    aesop_cat
+    cat_disch
 
 namespace LaxMonoidal
 
@@ -164,20 +164,20 @@ variable {F : C ⥤ D}
     (μ_natural :
       ∀ {X Y X' Y' : C} (f : X ⟶ Y) (g : X' ⟶ Y'),
         (F.map f ⊗ₘ F.map g) ≫ μ Y Y' = μ X X' ≫ F.map (f ⊗ₘ g) := by
-      aesop_cat)
+      cat_disch)
     /- associativity of the tensorator -/
     (associativity :
       ∀ X Y Z : C,
         (μ X Y ⊗ₘ 𝟙 (F.obj Z)) ≫ μ (X ⊗ Y) Z ≫ F.map (α_ X Y Z).hom =
           (α_ (F.obj X) (F.obj Y) (F.obj Z)).hom ≫ (𝟙 (F.obj X) ⊗ₘ μ Y Z) ≫ μ X (Y ⊗ Z) := by
-      aesop_cat)
+      cat_disch)
     /- unitality -/
     (left_unitality :
       ∀ X : C, (λ_ (F.obj X)).hom = (ε ⊗ₘ 𝟙 (F.obj X)) ≫ μ (𝟙_ C) X ≫ F.map (λ_ X).hom := by
-        aesop_cat)
+        cat_disch)
     (right_unitality :
       ∀ X : C, (ρ_ (F.obj X)).hom = (𝟙 (F.obj X) ⊗ₘ ε) ≫ μ X (𝟙_ C) ≫ F.map (ρ_ X).hom := by
-        aesop_cat)
+        cat_disch)
 
 /--
 A constructor for lax monoidal functors whose axioms are described by `tensorHom` instead of
@@ -239,24 +239,24 @@ class OplaxMonoidal (F : C ⥤ D) where
   δ_natural_left (F) :
     ∀ {X Y : C} (f : X ⟶ Y) (X' : C),
       δ X X' ≫ F.map f ▷ F.obj X' = F.map (f ▷ X') ≫ δ Y X' := by
-    aesop_cat
+    cat_disch
   δ_natural_right (F) :
     ∀ {X Y : C} (X' : C) (f : X ⟶ Y) ,
       δ X' X ≫ F.obj X' ◁ F.map f = F.map (X' ◁ f) ≫ δ X' Y := by
-    aesop_cat
+    cat_disch
   /-- associativity of the tensorator -/
   oplax_associativity (F) :
     ∀ X Y Z : C,
       δ (X ⊗ Y) Z ≫ δ X Y ▷ F.obj Z ≫ (α_ (F.obj X) (F.obj Y) (F.obj Z)).hom =
         F.map (α_ X Y Z).hom ≫ δ X (Y ⊗ Z) ≫ F.obj X ◁ δ Y Z := by
-    aesop_cat
+    cat_disch
   -- unitality
   oplax_left_unitality (F) :
     ∀ X : C, (λ_ (F.obj X)).inv = F.map (λ_ X).inv ≫ δ (𝟙_ C) X ≫ η ▷ F.obj X := by
-      aesop_cat
+      cat_disch
   oplax_right_unitality (F) :
     ∀ X : C, (ρ_ (F.obj X)).inv = F.map (ρ_ X).inv ≫ δ X (𝟙_ C) ≫ F.obj X ◁ η := by
-      aesop_cat
+      cat_disch
 
 namespace OplaxMonoidal
 
@@ -564,25 +564,25 @@ structure CoreMonoidal where
   μIso_hom_natural_left :
     ∀ {X Y : C} (f : X ⟶ Y) (X' : C),
       F.map f ▷ F.obj X' ≫ (μIso Y X').hom = (μIso X X').hom ≫ F.map (f ▷ X') := by
-    aesop_cat
+    cat_disch
   μIso_hom_natural_right :
     ∀ {X Y : C} (X' : C) (f : X ⟶ Y) ,
       F.obj X' ◁ F.map f ≫ (μIso X' Y).hom = (μIso X' X).hom ≫ F.map (X' ◁ f) := by
-    aesop_cat
+    cat_disch
   /-- associativity of the tensorator -/
   associativity :
     ∀ X Y Z : C,
       (μIso X Y).hom ▷ F.obj Z ≫ (μIso (X ⊗ Y) Z).hom ≫ F.map (α_ X Y Z).hom =
         (α_ (F.obj X) (F.obj Y) (F.obj Z)).hom ≫ F.obj X ◁ (μIso Y Z).hom ≫
           (μIso X (Y ⊗ Z)).hom := by
-    aesop_cat
+    cat_disch
   -- unitality
   left_unitality :
     ∀ X : C, (λ_ (F.obj X)).hom = εIso.hom ▷ F.obj X ≫ (μIso (𝟙_ C) X).hom ≫ F.map (λ_ X).hom := by
-      aesop_cat
+      cat_disch
   right_unitality :
     ∀ X : C, (ρ_ (F.obj X)).hom = F.obj X ◁ εIso.hom ≫ (μIso X (𝟙_ C)).hom ≫ F.map (ρ_ X).hom := by
-    aesop_cat
+    cat_disch
 
 namespace CoreMonoidal
 

--- a/Mathlib/CategoryTheory/Monoidal/Functor.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Functor.lean
@@ -358,10 +358,10 @@ open LaxMonoidal OplaxMonoidal
 and both data give inverse isomorphisms. -/
 @[ext]
 class Monoidal (F : C ⥤ D) extends F.LaxMonoidal, F.OplaxMonoidal where
-  ε_η (F) : ε ≫ η = 𝟙 _ := by aesop_cat
-  η_ε (F) : η ≫ ε = 𝟙 _ := by aesop_cat
-  μ_δ (F) (X Y : C) : μ X Y ≫ δ X Y = 𝟙 _ := by aesop_cat
-  δ_μ (F) (X Y : C) : δ X Y ≫ μ X Y = 𝟙 _ := by aesop_cat
+  ε_η (F) : ε ≫ η = 𝟙 _ := by cat_disch
+  η_ε (F) : η ≫ ε = 𝟙 _ := by cat_disch
+  μ_δ (F) (X Y : C) : μ X Y ≫ δ X Y = 𝟙 _ := by cat_disch
+  δ_μ (F) (X Y : C) : δ X Y ≫ μ X Y = 𝟙 _ := by cat_disch
 
 namespace Monoidal
 
@@ -913,9 +913,9 @@ def rightAdjointLaxMonoidal : G.LaxMonoidal where
 this typeclass expresses compatibilities between the adjunction and the (op)lax
 monoidal structures. -/
 class IsMonoidal [G.LaxMonoidal] : Prop where
-  leftAdjoint_ε : ε G = adj.homEquiv _ _ (η F) := by aesop_cat
+  leftAdjoint_ε : ε G = adj.homEquiv _ _ (η F) := by cat_disch
   leftAdjoint_μ (X Y : D) :
-    μ G X Y = adj.homEquiv _ _ (δ F _ _ ≫ (adj.counit.app X ⊗ₘ adj.counit.app Y)) := by aesop_cat
+    μ G X Y = adj.homEquiv _ _ (δ F _ _ ≫ (adj.counit.app X ⊗ₘ adj.counit.app Y)) := by cat_disch
 
 instance :
     letI := adj.rightAdjointLaxMonoidal

--- a/Mathlib/CategoryTheory/Monoidal/Grp_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Grp_.lean
@@ -30,8 +30,8 @@ section
 class Grp_Class (X : C) extends Mon_Class X where
   /-- The inverse in a group object -/
   inv : X ⟶ X
-  left_inv (X) : lift inv (𝟙 X) ≫ mul = toUnit _ ≫ one := by aesop_cat
-  right_inv (X) : lift (𝟙 X) inv ≫ mul = toUnit _ ≫ one := by aesop_cat
+  left_inv (X) : lift inv (𝟙 X) ≫ mul = toUnit _ ≫ one := by cat_disch
+  right_inv (X) : lift (𝟙 X) inv ≫ mul = toUnit _ ≫ one := by cat_disch
 
 namespace Mon_Class
 
@@ -315,8 +315,8 @@ def mkIso' {G H : C} (e : G ≅ H) [Grp_Class G] [Grp_Class H] [IsMon_Hom e.hom]
 /-- Construct an isomorphism of group objects by giving an isomorphism between the underlying
 objects and checking compatibility with unit and multiplication only in the forward direction. -/
 @[simps!]
-abbrev mkIso {G H : Grp_ C} (e : G.X ≅ H.X) (one_f : η[G.X] ≫ e.hom = η[H.X] := by aesop_cat)
-    (mul_f : μ[G.X] ≫ e.hom = (e.hom ⊗ₘ e.hom) ≫ μ[H.X] := by aesop_cat) : G ≅ H :=
+abbrev mkIso {G H : Grp_ C} (e : G.X ≅ H.X) (one_f : η[G.X] ≫ e.hom = η[H.X] := by cat_disch)
+    (mul_f : μ[G.X] ≫ e.hom = (e.hom ⊗ₘ e.hom) ≫ μ[H.X] := by cat_disch) : G ≅ H :=
   have : IsMon_Hom e.hom := ⟨one_f, mul_f⟩
   mkIso' e
 

--- a/Mathlib/CategoryTheory/Monoidal/Hopf_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Hopf_.lean
@@ -32,8 +32,8 @@ A Hopf monoid in a braided category `C` is a bimonoid object in `C` equipped wit
 class Hopf_Class (X : C) extends Bimon_Class X where
   /-- The antipode is an endomorphism of the underlying object of the Hopf monoid. -/
   antipode : X ⟶ X
-  antipode_left (X) : Δ ≫ antipode ▷ X ≫ μ = ε ≫ η := by aesop_cat
-  antipode_right (X) : Δ ≫ X ◁ antipode ≫ μ = ε ≫ η := by aesop_cat
+  antipode_left (X) : Δ ≫ antipode ▷ X ≫ μ = ε ≫ η := by cat_disch
+  antipode_right (X) : Δ ≫ X ◁ antipode ≫ μ = ε ≫ η := by cat_disch
 
 namespace Hopf_Class
 

--- a/Mathlib/CategoryTheory/Monoidal/Internal/Types/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Internal/Types/Basic.lean
@@ -66,14 +66,14 @@ noncomputable def monTypeEquivalenceMon : Mon_ (Type u) ≌ MonCat.{u} where
   unitIso := Iso.refl _
   counitIso := NatIso.ofComponents
     (fun A => MulEquiv.toMonCatIso { Equiv.refl _ with map_mul' := fun _ _ => rfl })
-    (by aesop_cat)
+    (by cat_disch)
 
 /-- The equivalence `Mon_ (Type u) ≌ MonCat.{u}`
 is naturally compatible with the forgetful functors to `Type u`.
 -/
 noncomputable def monTypeEquivalenceMonForget :
     MonTypeEquivalenceMon.functor ⋙ forget MonCat ≅ Mon_.forget (Type u) :=
-  NatIso.ofComponents (fun _ => Iso.refl _) (by aesop_cat)
+  NatIso.ofComponents (fun _ => Iso.refl _) (by cat_disch)
 
 noncomputable instance monTypeInhabited : Inhabited (Mon_ (Type u)) :=
   ⟨MonTypeEquivalenceMon.inverse.obj (MonCat.of PUnit)⟩
@@ -114,7 +114,7 @@ noncomputable def commMonTypeEquivalenceCommMon : CommMon_ (Type u) ≌ CommMonC
   unitIso := Iso.refl _
   counitIso := NatIso.ofComponents
     (fun A => MulEquiv.toCommMonCatIso { Equiv.refl _ with map_mul' := fun _ _ => rfl })
-    (by aesop_cat)
+    (by cat_disch)
 
 /-- The equivalences `Mon_ (Type u) ≌ MonCat.{u}` and `CommMon_ (Type u) ≌ CommMonCat.{u}`
 are naturally compatible with the forgetful functors to `MonCat` and `Mon_ (Type u)`.

--- a/Mathlib/CategoryTheory/Monoidal/Internal/Types/CommGrp_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Internal/Types/CommGrp_.lean
@@ -61,7 +61,7 @@ noncomputable def commGrpTypeEquivalenceCommGrp : CommGrp_ (Type u) ≌ CommGrp.
   unitIso := Iso.refl _
   counitIso := NatIso.ofComponents
     (fun A => MulEquiv.toCommGrpIso { Equiv.refl _ with map_mul' := fun _ _ => rfl })
-    (by aesop_cat)
+    (by cat_disch)
 
 /-- The equivalences `Grp_ (Type u) ≌ Grp.{u}` and `CommGrp_ (Type u) ≌ CommGrp.{u}`
 are naturally compatible with the forgetful functors to `Grp` and `Grp_ (Type u)`.

--- a/Mathlib/CategoryTheory/Monoidal/Internal/Types/Grp_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Internal/Types/Grp_.lean
@@ -57,7 +57,7 @@ noncomputable def grpTypeEquivalenceGrp : Grp_ (Type u) ≌ Grp.{u} where
   unitIso := Iso.refl _
   counitIso := NatIso.ofComponents
     (fun A => MulEquiv.toGrpIso { Equiv.refl _ with map_mul' := fun _ _ => rfl })
-    (by aesop_cat)
+    (by cat_disch)
 
 /-- The equivalences `Mon_ (Type u) ≌ MonCat.{u}` and `Grp_ (Type u) ≌ Grp.{u}`
 are naturally compatible with the forgetful functors to `MonCat` and `Mon_ (Type u)`.

--- a/Mathlib/CategoryTheory/Monoidal/Linear.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Linear.lean
@@ -29,9 +29,9 @@ variable [MonoidalCategory C]
 -/
 class MonoidalLinear [MonoidalPreadditive C] : Prop where
   whiskerLeft_smul : ∀ (X : C) {Y Z : C} (r : R) (f : Y ⟶ Z) , X ◁ (r • f) = r • (X ◁ f) := by
-    aesop_cat
+    cat_disch
   smul_whiskerRight : ∀ (r : R) {Y Z : C} (f : Y ⟶ Z) (X : C), (r • f) ▷ X = r • (f ▷ X) := by
-    aesop_cat
+    cat_disch
 
 attribute [simp] MonoidalLinear.whiskerLeft_smul MonoidalLinear.smul_whiskerRight
 

--- a/Mathlib/CategoryTheory/Monoidal/Mod_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Mod_.lean
@@ -34,9 +34,9 @@ class Mod_Class (X : D) where
   /-- The action map -/
   smul : M ⊙ₗ X ⟶ X
   /-- The identity acts trivially. -/
-  one_smul' (X) : η ⊵ₗ X ≫ smul = (λₗ X).hom := by aesop_cat
+  one_smul' (X) : η ⊵ₗ X ≫ smul = (λₗ X).hom := by cat_disch
   /-- The action map is compatible with multiplication. -/
-  mul_smul' (X) : μ ⊵ₗ X ≫ smul = (αₗ M M X).hom ≫ M ⊴ₗ smul ≫ smul := by aesop_cat
+  mul_smul' (X) : μ ⊵ₗ X ≫ smul = (αₗ M M X).hom ≫ M ⊴ₗ smul ≫ smul := by cat_disch
 
 attribute [reassoc] Mod_Class.mul_smul' Mod_Class.one_smul'
 
@@ -95,7 +95,7 @@ variable (A : C) [Mon_Class A]
 /-- A morphism in `D` is a morphism of `A`-module objects if it commutes with
 the action maps -/
 class IsMod_Hom {M N : D} [Mod_Class A M] [Mod_Class A N] (f : M ⟶ N) where
-  smul_hom : γ[M] ≫ f = A ⊴ₗ f ≫ γ[N] := by aesop_cat
+  smul_hom : γ[M] ≫ f = A ⊴ₗ f ≫ γ[N] := by cat_disch
 
 attribute [reassoc (attr := simp)] IsMod_Hom.smul_hom
 
@@ -140,7 +140,7 @@ taking a morphism without a [isMod_Hom] instance, as well as the relevant
 equality to put such an instance. -/
 @[simps!]
 def Hom.mk' {M N : Mod_ D A} (f : M.X ⟶ N.X)
-    (smul_hom : γ[M.X] ≫ f = A ⊴ₗ f ≫ γ[N.X] := by aesop_cat) : Hom M N :=
+    (smul_hom : γ[M.X] ≫ f = A ⊴ₗ f ≫ γ[N.X] := by cat_disch) : Hom M N :=
   letI : IsMod_Hom A f := ⟨smul_hom⟩
   ⟨f⟩
 
@@ -150,7 +150,7 @@ a `Mod_Class` instance (rather than bundled as `Mod_`),
 as well as the relevant equality to put such an instance. -/
 @[simps!]
 def Hom.mk'' {M N : D} [Mod_Class A M] [Mod_Class A N] (f : M ⟶ N)
-    (smul_hom : γ[M] ≫ f = A ⊴ₗ f ≫ γ[N] := by aesop_cat) :
+    (smul_hom : γ[M] ≫ f = A ⊴ₗ f ≫ γ[N] := by cat_disch) :
     Hom (.mk (A := A) M) (.mk (A := A) N) :=
   letI : IsMod_Hom A f := ⟨smul_hom⟩
   ⟨f⟩

--- a/Mathlib/CategoryTheory/Monoidal/Mon_.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Mon_.lean
@@ -33,13 +33,13 @@ class Mon_Class (X : C) where
   one : 𝟙_ C ⟶ X
   /-- The multiplication morphism of a monoid object. -/
   mul : X ⊗ X ⟶ X
-  one_mul (X) : one ▷ X ≫ mul = (λ_ X).hom := by aesop_cat
-  mul_one (X) : X ◁ one ≫ mul = (ρ_ X).hom := by aesop_cat
+  one_mul (X) : one ▷ X ≫ mul = (λ_ X).hom := by cat_disch
+  mul_one (X) : X ◁ one ≫ mul = (ρ_ X).hom := by cat_disch
   -- Obviously there is some flexibility stating this axiom.
   -- This one has left- and right-hand sides matching the statement of `Monoid.mul_assoc`,
   -- and chooses to place the associator on the right-hand side.
   -- The heuristic is that unitors and associators "don't have much weight".
-  mul_assoc (X) : (mul ▷ X) ≫ mul = (α_ X X X).hom ≫ (X ◁ mul) ≫ mul := by aesop_cat
+  mul_assoc (X) : (mul ▷ X) ≫ mul = (α_ X X X).hom ≫ (X ◁ mul) ≫ mul := by cat_disch
 
 namespace Mon_Class
 
@@ -72,8 +72,8 @@ variable {M N O : C} [Mon_Class M] [Mon_Class N] [Mon_Class O]
 
 /-- The property that a morphism between monoid objects is a monoid morphism. -/
 class IsMon_Hom (f : M ⟶ N) : Prop where
-  one_hom (f) : η ≫ f = η := by aesop_cat
-  mul_hom (f) : μ ≫ f = (f ⊗ₘ f) ≫ μ := by aesop_cat
+  one_hom (f) : η ≫ f = η := by cat_disch
+  mul_hom (f) : μ ≫ f = (f ⊗ₘ f) ≫ μ := by cat_disch
 
 attribute [reassoc (attr := simp)] IsMon_Hom.one_hom IsMon_Hom.mul_hom
 
@@ -142,8 +142,8 @@ attribute [instance] Hom.is_mon_hom
 
 /-- Construct a morphism `M ⟶ N` of `Mon_ C` from a map `f : M ⟶ N` and a `IsMon_Hom f` instance. -/
 abbrev Hom.mk' {M N : Mon_ C} (f : M.X ⟶ N.X)
-    (one_f : η ≫ f = η := by aesop_cat)
-    (mul_f : μ ≫ f = (f ⊗ₘ f) ≫ μ := by aesop_cat) : Hom M N :=
+    (one_f : η ≫ f = η := by cat_disch)
+    (mul_f : μ ≫ f = (f ⊗ₘ f) ≫ μ := by cat_disch) : Hom M N :=
   have : IsMon_Hom f := ⟨one_f, mul_f⟩
   .mk f
 
@@ -201,7 +201,7 @@ instance {A B : Mon_ C} (f : A ⟶ B) [e : IsIso ((forget C).map f)] : IsIso f.h
 
 /-- The forgetful functor from monoid objects to the ambient category reflects isomorphisms. -/
 instance : (forget C).ReflectsIsomorphisms where
-  reflects f e := ⟨⟨.mk' (inv f.hom), by aesop_cat⟩⟩
+  reflects f e := ⟨⟨.mk' (inv f.hom), by cat_disch⟩⟩
 
 instance {M N : Mon_ C} {f : M ⟶ N} [IsIso f] : IsIso f.hom :=
   inferInstanceAs <| IsIso <| (forget C).map f
@@ -216,8 +216,8 @@ def mkIso' {M N : C} [Mon_Class M] [Mon_Class N] (e : M ≅ N) [IsMon_Hom e.hom]
 /-- Construct an isomorphism of monoid objects by giving an isomorphism between the underlying
 objects and checking compatibility with unit and multiplication only in the forward direction. -/
 @[simps!]
-abbrev mkIso {M N : Mon_ C} (e : M.X ≅ N.X) (one_f : η[M.X] ≫ e.hom = η[N.X] := by aesop_cat)
-    (mul_f : μ[M.X] ≫ e.hom = (e.hom ⊗ₘ e.hom) ≫ μ[N.X] := by aesop_cat) : M ≅ N :=
+abbrev mkIso {M N : Mon_ C} (e : M.X ≅ N.X) (one_f : η[M.X] ≫ e.hom = η[N.X] := by cat_disch)
+    (mul_f : μ[M.X] ≫ e.hom = (e.hom ⊗ₘ e.hom) ≫ μ[N.X] := by cat_disch) : M ≅ N :=
   have : IsMon_Hom e.hom := ⟨one_f, mul_f⟩
   mkIso' e
 
@@ -836,7 +836,7 @@ variable [BraidedCategory.{v₁} C]
 
 /-- Predicate for a monoid object to be commutative. -/
 class IsCommMon (X : C) [Mon_Class X] where
-  mul_comm (X) : (β_ X X).hom ≫ μ = μ := by aesop_cat
+  mul_comm (X) : (β_ X X).hom ≫ μ = μ := by cat_disch
 
 open scoped Mon_Class
 

--- a/Mathlib/CategoryTheory/Monoidal/NaturalTransformation.lean
+++ b/Mathlib/CategoryTheory/Monoidal/NaturalTransformation.lean
@@ -42,8 +42,8 @@ open Functor.LaxMonoidal
 /-- A natural transformation between (lax) monoidal functors is monoidal if it satisfies
 `ε F ≫ τ.app (𝟙_ C) = ε G` and `μ F X Y ≫ app (X ⊗ Y) = (app X ⊗ₘ app Y) ≫ μ G X Y`. -/
 class IsMonoidal : Prop where
-  unit : ε F₁ ≫ τ.app (𝟙_ C) = ε F₂ := by aesop_cat
-  tensor (X Y : C) : μ F₁ _ _ ≫ τ.app (X ⊗ Y) = (τ.app X ⊗ₘ τ.app Y) ≫ μ F₂ _ _ := by aesop_cat
+  unit : ε F₁ ≫ τ.app (𝟙_ C) = ε F₂ := by cat_disch
+  tensor (X Y : C) : μ F₁ _ _ ≫ τ.app (X ⊗ Y) = (τ.app X ⊗ₘ τ.app Y) ≫ μ F₂ _ _ := by cat_disch
 
 namespace IsMonoidal
 
@@ -198,9 +198,9 @@ open Functor.LaxMonoidal
 def isoOfComponents {F G : LaxMonoidalFunctor C D} (e : ∀ X, F.obj X ≅ G.obj X)
     (naturality : ∀ {X Y : C} (f : X ⟶ Y), F.map f ≫ (e Y).hom = (e X).hom ≫ G.map f := by
       aesop_cat)
-    (unit : ε F.toFunctor ≫ (e (𝟙_ C)).hom = ε G.toFunctor := by aesop_cat)
+    (unit : ε F.toFunctor ≫ (e (𝟙_ C)).hom = ε G.toFunctor := by cat_disch)
     (tensor : ∀ X Y, μ F.toFunctor X Y ≫ (e (X ⊗ Y)).hom =
-      ((e X).hom ⊗ₘ (e Y).hom) ≫ μ G.toFunctor X Y := by aesop_cat) :
+      ((e X).hom ⊗ₘ (e Y).hom) ≫ μ G.toFunctor X Y := by cat_disch) :
     F ≅ G :=
   @isoMk _ _ _ _ _ _ _ _ (NatIso.ofComponents e naturality) (by constructor <;> assumption)
 

--- a/Mathlib/CategoryTheory/Monoidal/NaturalTransformation.lean
+++ b/Mathlib/CategoryTheory/Monoidal/NaturalTransformation.lean
@@ -197,7 +197,7 @@ open Functor.LaxMonoidal
 @[simps!]
 def isoOfComponents {F G : LaxMonoidalFunctor C D} (e : ∀ X, F.obj X ≅ G.obj X)
     (naturality : ∀ {X Y : C} (f : X ⟶ Y), F.map f ≫ (e Y).hom = (e X).hom ≫ G.map f := by
-      aesop_cat)
+      cat_disch)
     (unit : ε F.toFunctor ≫ (e (𝟙_ C)).hom = ε G.toFunctor := by cat_disch)
     (tensor : ∀ X Y, μ F.toFunctor X Y ≫ (e (X ⊗ Y)).hom =
       ((e X).hom ⊗ₘ (e Y).hom) ≫ μ G.toFunctor X Y := by cat_disch) :

--- a/Mathlib/CategoryTheory/Monoidal/Preadditive.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Preadditive.lean
@@ -29,10 +29,10 @@ Note we don't `extend Preadditive C` here, as `Abelian C` already extends it,
 and we'll need to have both typeclasses sometimes.
 -/
 class MonoidalPreadditive : Prop where
-  whiskerLeft_zero : ∀ {X Y Z : C}, X ◁ (0 : Y ⟶ Z) = 0 := by aesop_cat
-  zero_whiskerRight : ∀ {X Y Z : C}, (0 : Y ⟶ Z) ▷ X = 0 := by aesop_cat
-  whiskerLeft_add : ∀ {X Y Z : C} (f g : Y ⟶ Z), X ◁ (f + g) = X ◁ f + X ◁ g := by aesop_cat
-  add_whiskerRight : ∀ {X Y Z : C} (f g : Y ⟶ Z), (f + g) ▷ X = f ▷ X + g ▷ X := by aesop_cat
+  whiskerLeft_zero : ∀ {X Y Z : C}, X ◁ (0 : Y ⟶ Z) = 0 := by cat_disch
+  zero_whiskerRight : ∀ {X Y Z : C}, (0 : Y ⟶ Z) ▷ X = 0 := by cat_disch
+  whiskerLeft_add : ∀ {X Y Z : C} (f g : Y ⟶ Z), X ◁ (f + g) = X ◁ f + X ◁ g := by cat_disch
+  add_whiskerRight : ∀ {X Y Z : C} (f g : Y ⟶ Z), (f + g) ▷ X = f ▷ X + g ▷ X := by cat_disch
 
 attribute [simp] MonoidalPreadditive.whiskerLeft_zero MonoidalPreadditive.zero_whiskerRight
 attribute [simp] MonoidalPreadditive.whiskerLeft_add MonoidalPreadditive.add_whiskerRight

--- a/Mathlib/CategoryTheory/Monoidal/Rigid/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Rigid/Basic.lean
@@ -81,10 +81,10 @@ class ExactPairing (X Y : C) where
   evaluation' : Y ⊗ X ⟶ 𝟙_ C
   coevaluation_evaluation' :
     Y ◁ coevaluation' ≫ (α_ _ _ _).inv ≫ evaluation' ▷ Y = (ρ_ Y).hom ≫ (λ_ Y).inv := by
-    aesop_cat
+    cat_disch
   evaluation_coevaluation' :
     coevaluation' ▷ X ≫ (α_ _ _ _).hom ≫ X ◁ evaluation' = (λ_ X).hom ≫ (ρ_ X).inv := by
-    aesop_cat
+    cat_disch
 
 namespace ExactPairing
 

--- a/Mathlib/CategoryTheory/Monoidal/Subcategory.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Subcategory.lean
@@ -63,7 +63,7 @@ class IsMonoidal (P : ObjectProperty C) : Prop extends
 /-- A property of objects is a monoidal closed if it is closed under taking internal homs
 -/
 class IsMonoidalClosed (P : ObjectProperty C) [MonoidalClosed C] : Prop where
-  prop_ihom (X Y : C) : P X → P Y → P ((ihom X).obj Y) := by aesop_cat
+  prop_ihom (X Y : C) : P X → P Y → P ((ihom X).obj Y) := by cat_disch
 
 lemma prop_ihom (P : ObjectProperty C) [MonoidalClosed C] [P.IsMonoidalClosed]
     {X Y : C} (hX : P X) (hY : P Y) : P ((ihom X).obj Y) :=

--- a/Mathlib/CategoryTheory/Monoidal/Transport.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Transport.lean
@@ -46,13 +46,13 @@ structure InducingFunctorData [MonoidalCategoryStruct D] (F : D ⥤ C) where
     F.obj X ⊗ F.obj Y ≅ F.obj (X ⊗ Y)
   whiskerLeft_eq : ∀ (X : D) {Y₁ Y₂ : D} (f : Y₁ ⟶ Y₂),
     F.map (X ◁ f) = (μIso _ _).inv ≫ (F.obj X ◁ F.map f) ≫ (μIso _ _).hom := by
-    aesop_cat
+    cat_disch
   whiskerRight_eq : ∀ {X₁ X₂ : D} (f : X₁ ⟶ X₂) (Y : D),
     F.map (f ▷ Y) = (μIso _ _).inv ≫ (F.map f ▷ F.obj Y) ≫ (μIso _ _).hom := by
-    aesop_cat
+    cat_disch
   tensorHom_eq : ∀ {X₁ Y₁ X₂ Y₂ : D} (f : X₁ ⟶ Y₁) (g : X₂ ⟶ Y₂),
     F.map (f ⊗ₘ g) = (μIso _ _).inv ≫ (F.map f ⊗ₘ F.map g) ≫ (μIso _ _).hom := by
-    aesop_cat
+    cat_disch
   /-- Analogous to `CategoryTheory.LaxMonoidalFunctor.εIso` -/
   εIso : 𝟙_ _ ≅ F.obj (𝟙_ _)
   associator_eq : ∀ X Y Z : D,
@@ -60,15 +60,15 @@ structure InducingFunctorData [MonoidalCategoryStruct D] (F : D ⥤ C) where
       (((μIso _ _).symm ≪≫ ((μIso _ _).symm ⊗ᵢ .refl _))
         ≪≫ α_ (F.obj X) (F.obj Y) (F.obj Z)
         ≪≫ ((.refl _ ⊗ᵢ μIso _ _) ≪≫ μIso _ _)).hom := by
-    aesop_cat
+    cat_disch
   leftUnitor_eq : ∀ X : D,
     F.map (λ_ X).hom =
       (((μIso _ _).symm ≪≫ (εIso.symm ⊗ᵢ .refl _)) ≪≫ λ_ (F.obj X)).hom := by
-    aesop_cat
+    cat_disch
   rightUnitor_eq : ∀ X : D,
     F.map (ρ_ X).hom =
       (((μIso _ _).symm ≪≫ (.refl _ ⊗ᵢ εIso.symm)) ≪≫ ρ_ (F.obj X)).hom := by
-    aesop_cat
+    cat_disch
 
 /--
 Induce the lawfulness of the monoidal structure along an faithful functor of (plain) categories,
@@ -83,11 +83,11 @@ def induced [MonoidalCategoryStruct D] (F : D ⥤ C) [F.Faithful]
   tensorHom_def {X₁ Y₁ X₂ Y₂} f g := F.map_injective <| by
     rw [fData.tensorHom_eq, Functor.map_comp, fData.whiskerRight_eq, fData.whiskerLeft_eq]
     simp only [tensorHom_def, assoc, Iso.hom_inv_id_assoc]
-  id_tensorHom_id X₁ X₂ := F.map_injective <| by cases fData; aesop_cat
-  tensor_comp {X₁ Y₁ Z₁ X₂ Y₂ Z₂} f₁ f₂ g₁ g₂ := F.map_injective <| by cases fData; aesop_cat
+  id_tensorHom_id X₁ X₂ := F.map_injective <| by cases fData; cat_disch
+  tensor_comp {X₁ Y₁ Z₁ X₂ Y₂ Z₂} f₁ f₂ g₁ g₂ := F.map_injective <| by cases fData; cat_disch
   whiskerLeft_id X Y := F.map_injective <| by simp [fData.whiskerLeft_eq]
   id_whiskerRight X Y := F.map_injective <| by simp [fData.whiskerRight_eq]
-  triangle X Y := F.map_injective <| by cases fData; aesop_cat
+  triangle X Y := F.map_injective <| by cases fData; cat_disch
   pentagon W X Y Z := F.map_injective <| by
     simp only [Functor.map_comp, fData.whiskerRight_eq, fData.associator_eq, Iso.trans_assoc,
       Iso.trans_hom, Iso.symm_hom, tensorIso_hom, Iso.refl_hom, tensorHom_id, id_tensorHom,

--- a/Mathlib/CategoryTheory/Monoidal/Types/Coyoneda.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Types/Coyoneda.lean
@@ -21,7 +21,7 @@ instance (C : Type u) [Category.{v} C] [MonoidalCategory C] :
   Functor.LaxMonoidal.ofTensorHom
     (ε := fun _ => 𝟙 _)
     (μ := fun X Y p ↦ (λ_ (𝟙_ C)).inv ≫ (p.1 ⊗ₘ p.2))
-    (μ_natural := by aesop_cat)
+    (μ_natural := by cat_disch)
     (associativity := fun X Y Z => by
       ext ⟨⟨f, g⟩, h⟩; dsimp at f g h
       dsimp; simp only [Iso.cancel_iso_inv_left, Category.assoc]

--- a/Mathlib/CategoryTheory/MorphismProperty/Comma.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Comma.lean
@@ -166,7 +166,7 @@ def isoFromComma [Q.RespectsIso] [W.RespectsIso] {X Y : P.Comma L R Q W}
 components and naturality in the forward direction. -/
 @[simps!]
 def isoMk [Q.RespectsIso] [W.RespectsIso] {X Y : P.Comma L R Q W} (l : X.left ≅ Y.left)
-    (r : X.right ≅ Y.right) (h : L.map l.hom ≫ Y.hom = X.hom ≫ R.map r.hom := by aesop_cat) :
+    (r : X.right ≅ Y.right) (h : L.map l.hom ≫ Y.hom = X.hom ≫ R.map r.hom := by cat_disch) :
     X ≅ Y :=
   isoFromComma (CategoryTheory.Comma.isoMk l r h)
 
@@ -334,7 +334,7 @@ protected def Over.mk {A : T} (f : A ⟶ X) (hf : P f) : P.Over Q X where
 /-- Make a morphism in `P.Over Q X` from a morphism in `T` with compatibilities. -/
 @[simps hom]
 protected def Over.homMk {A B : P.Over Q X} (f : A.left ⟶ B.left)
-    (w : f ≫ B.hom = A.hom := by aesop_cat) (hf : Q f := by trivial) : A ⟶ B where
+    (w : f ≫ B.hom = A.hom := by cat_disch) (hf : Q f := by trivial) : A ⟶ B where
   __ := CategoryTheory.Over.homMk f w
   prop_hom_left := hf
   prop_hom_right := trivial
@@ -342,7 +342,7 @@ protected def Over.homMk {A B : P.Over Q X} (f : A.left ⟶ B.left)
 /-- Make an isomorphism in `P.Over Q X` from an isomorphism in `T` with compatibilities. -/
 @[simps! hom_left inv_left]
 protected def Over.isoMk [Q.RespectsIso] {A B : P.Over Q X} (f : A.left ≅ B.left)
-    (w : f.hom ≫ B.hom = A.hom := by aesop_cat) : A ≅ B :=
+    (w : f.hom ≫ B.hom = A.hom := by cat_disch) : A ≅ B :=
   Comma.isoMk f (Discrete.eqToIso' rfl)
 
 @[ext]
@@ -395,7 +395,7 @@ protected def Under.mk {A : T} (f : X ⟶ A) (hf : P f) : P.Under Q X where
 /-- Make a morphism in `P.Under Q X` from a morphism in `T` with compatibilities. -/
 @[simps hom]
 protected def Under.homMk {A B : P.Under Q X} (f : A.right ⟶ B.right)
-    (w : A.hom ≫ f = B.hom := by aesop_cat) (hf : Q f := by trivial) : A ⟶ B where
+    (w : A.hom ≫ f = B.hom := by cat_disch) (hf : Q f := by trivial) : A ⟶ B where
   __ := CategoryTheory.Under.homMk f w
   prop_hom_left := trivial
   prop_hom_right := hf
@@ -403,7 +403,7 @@ protected def Under.homMk {A B : P.Under Q X} (f : A.right ⟶ B.right)
 /-- Make an isomorphism in `P.Under Q X` from an isomorphism in `T` with compatibilities. -/
 @[simps! hom_right inv_right]
 protected def Under.isoMk [Q.RespectsIso] {A B : P.Under Q X} (f : A.right ≅ B.right)
-    (w : A.hom ≫ f.hom = B.hom := by aesop_cat) : A ≅ B :=
+    (w : A.hom ≫ f.hom = B.hom := by cat_disch) : A ≅ B :=
   Comma.isoMk (Discrete.eqToIso' rfl) f
 
 @[ext]

--- a/Mathlib/CategoryTheory/MorphismProperty/Factorization.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Factorization.lean
@@ -47,7 +47,7 @@ structure MapFactorizationData {X Y : C} (f : X ⟶ Y) where
   i : X ⟶ Z
   /-- the second morphism in the factorization -/
   p : Z ⟶ Y
-  fac : i ≫ p = f := by aesop_cat
+  fac : i ≫ p = f := by cat_disch
   hi : W₁ i
   hp : W₂ p
 
@@ -89,7 +89,7 @@ structure FunctorialFactorizationData where
   i : Arrow.leftFunc ⟶ Z
   /-- the second morphism in the factorizations -/
   p : Z ⟶ Arrow.rightFunc
-  fac : i ≫ p = Arrow.leftToRight := by aesop_cat
+  fac : i ≫ p = Arrow.leftToRight := by cat_disch
   hi (f : Arrow C) : W₁ (i.app f)
   hp (f : Arrow C) : W₂ (p.app f)
 

--- a/Mathlib/CategoryTheory/MorphismProperty/OverAdjunction.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/OverAdjunction.lean
@@ -120,7 +120,7 @@ noncomputable def Over.mapPullbackAdj [Q.HasOfPostcompProperty Q] (hPf : P f) (h
               simp only [map_obj_left, Functor.const_obj_obj, pullback_obj_left, Functor.id_obj,
                 Category.assoc, pullback.condition, map_obj_hom, ← pullback_obj_hom, Over.w_assoc])
             (Q.comp_mem _ _ h.prop_hom_left (Q.pullback_fst _ _ hQf))
-          left_inv := by aesop_cat
+          left_inv := by cat_disch
           right_inv := fun h ↦ by
             ext
             dsimp

--- a/Mathlib/CategoryTheory/NatIso.lean
+++ b/Mathlib/CategoryTheory/NatIso.lean
@@ -161,7 +161,7 @@ theorem cancel_natIso_inv_right_assoc {W X X' : D} {Y : C} (f : W ⟶ X) (g : X 
 
 @[simp]
 theorem inv_inv_app {F G : C ⥤ D} (e : F ≅ G) (X : C) : inv (e.inv.app X) = e.hom.app X := by
-  aesop_cat
+  cat_disch
 
 end
 
@@ -200,7 +200,7 @@ theorem isIso_inv_app (α : F ⟶ G) {_ : IsIso α} (X) : (inv α).app X = inv (
 @[simp]
 theorem inv_map_inv_app (F : C ⥤ D ⥤ E) {X Y : C} (e : X ≅ Y) (Z : D) :
     inv ((F.map e.inv).app Z) = (F.map e.hom).app Z := by
-  aesop_cat
+  cat_disch
 
 /-- Construct a natural isomorphism between functors by giving object level isomorphisms,
 and checking naturality only in the forward direction.

--- a/Mathlib/CategoryTheory/NatIso.lean
+++ b/Mathlib/CategoryTheory/NatIso.lean
@@ -208,7 +208,7 @@ and checking naturality only in the forward direction.
 @[simps]
 def ofComponents (app : ∀ X : C, F.obj X ≅ G.obj X)
     (naturality : ∀ {X Y : C} (f : X ⟶ Y),
-      F.map f ≫ (app Y).hom = (app X).hom ≫ G.map f := by aesop_cat) :
+      F.map f ≫ (app Y).hom = (app X).hom ≫ G.map f := by cat_disch) :
     F ≅ G where
   hom := { app := fun X => (app X).hom }
   inv :=

--- a/Mathlib/CategoryTheory/NatTrans.lean
+++ b/Mathlib/CategoryTheory/NatTrans.lean
@@ -47,7 +47,7 @@ structure NatTrans (F G : C ⥤ D) : Type max u₁ v₂ where
   /-- The component of a natural transformation. -/
   app : ∀ X : C, F.obj X ⟶ G.obj X
   /-- The naturality square for a given morphism. -/
-  naturality : ∀ ⦃X Y : C⦄ (f : X ⟶ Y), F.map f ≫ app Y = app X ≫ G.map f := by aesop_cat
+  naturality : ∀ ⦃X Y : C⦄ (f : X ⟶ Y), F.map f ≫ app Y = app X ≫ G.map f := by cat_disch
 
 -- Rather arbitrarily, we say that the 'simpler' form is
 -- components of natural transformations moving earlier.

--- a/Mathlib/CategoryTheory/NatTrans.lean
+++ b/Mathlib/CategoryTheory/NatTrans.lean
@@ -54,7 +54,7 @@ structure NatTrans (F G : C ⥤ D) : Type max u₁ v₂ where
 attribute [reassoc (attr := simp)] NatTrans.naturality
 
 theorem congr_app {F G : C ⥤ D} {α β : NatTrans F G} (h : α = β) (X : C) : α.app X = β.app X := by
-  aesop_cat
+  cat_disch
 
 namespace NatTrans
 

--- a/Mathlib/CategoryTheory/Opposites.lean
+++ b/Mathlib/CategoryTheory/Opposites.lean
@@ -358,13 +358,13 @@ theorem op_comp {H : C ⥤ D} (α : F ⟶ G) (β : G ⟶ H) :
 lemma op_whiskerRight {E : Type*} [Category E] {H : D ⥤ E} (α : F ⟶ G) :
     NatTrans.op (whiskerRight α H) =
     (Functor.opComp _ _).hom ≫ whiskerRight (NatTrans.op α) H.op ≫ (Functor.opComp _ _).inv := by
-  aesop_cat
+  cat_disch
 
 @[reassoc]
 lemma op_whiskerLeft {E : Type*} [Category E] {H : E ⥤ C} (α : F ⟶ G) :
     NatTrans.op (whiskerLeft H α) =
     (Functor.opComp _ _).hom ≫ whiskerLeft H.op (NatTrans.op α) ≫ (Functor.opComp _ _).inv := by
-  aesop_cat
+  cat_disch
 
 /-- The "unopposite" of a natural transformation. -/
 @[simps]
@@ -386,14 +386,14 @@ lemma unop_whiskerRight {F G : Cᵒᵖ ⥤ Dᵒᵖ} {E : Type*} [Category E] {H 
     NatTrans.unop (whiskerRight α H) =
     (Functor.unopComp _ _).hom ≫ whiskerRight (NatTrans.unop α) H.unop ≫
       (Functor.unopComp _ _).inv := by
-  aesop_cat
+  cat_disch
 
 @[reassoc]
 lemma unop_whiskerLeft {F G : Cᵒᵖ ⥤ Dᵒᵖ} {E : Type*} [Category E] {H : Eᵒᵖ ⥤ Cᵒᵖ} (α : F ⟶ G) :
     NatTrans.unop (whiskerLeft H α) =
     (Functor.unopComp _ _).hom ≫ whiskerLeft H.unop (NatTrans.unop α) ≫
       (Functor.unopComp _ _).inv := by
-  aesop_cat
+  cat_disch
 
 /-- Given a natural transformation `α : F.op ⟶ G.op`,
 we can take the "unopposite" of each component obtaining a natural transformation `G ⟶ F`.
@@ -447,7 +447,7 @@ theorem leftOp_comp (α : F ⟶ G) (β : G ⟶ H) : NatTrans.leftOp (α ≫ β) 
 lemma leftOpWhiskerRight {E : Type*} [Category E] {H : E ⥤ C} (α : F ⟶ G) :
     (whiskerLeft H α).leftOp = (Functor.leftOpComp H G).hom ≫ whiskerLeft _ α.leftOp ≫
       (Functor.leftOpComp H F).inv := by
-  aesop_cat
+  cat_disch
 
 /-- Given a natural transformation `α : F.leftOp ⟶ G.leftOp`, for `F G : C ⥤ Dᵒᵖ`,
 taking `op` of each component gives a natural transformation `G ⟶ F`.
@@ -489,7 +489,7 @@ theorem rightOp_comp (α : F ⟶ G) (β : G ⟶ H) : NatTrans.rightOp (α ≫ β
 lemma rightOpWhiskerRight {E : Type*} [Category E] {H : D ⥤ E} (α : F ⟶ G) :
     (whiskerRight α H).rightOp = (Functor.rightOpComp G H).hom ≫ whiskerRight α.rightOp H.op ≫
       (Functor.rightOpComp F H).inv := by
-  aesop_cat
+  cat_disch
 
 /-- Given a natural transformation `α : F.rightOp ⟶ G.rightOp`, for `F G : Cᵒᵖ ⥤ D`,
 taking `unop` of each component gives a natural transformation `G ⟶ F`.
@@ -627,59 +627,59 @@ theorem unop_symm {F G : Cᵒᵖ ⥤ Dᵒᵖ} (α : F ≅ G) : NatIso.unop α.sy
 lemma op_isoWhiskerRight {E : Type*} [Category E] {H : D ⥤ E} (α : F ≅ G) :
     NatIso.op (isoWhiskerRight α H) =
     (Functor.opComp _ _) ≪≫ isoWhiskerRight (NatIso.op α) H.op ≪≫ (Functor.opComp _ _).symm := by
-  aesop_cat
+  cat_disch
 
 lemma op_isoWhiskerLeft {E : Type*} [Category E] {H : E ⥤ C} (α : F ≅ G) :
     NatIso.op (isoWhiskerLeft H α) =
     (Functor.opComp _ _) ≪≫ isoWhiskerLeft H.op (NatIso.op α) ≪≫ (Functor.opComp _ _).symm := by
-  aesop_cat
+  cat_disch
 
 lemma unop_whiskerRight {F G : Cᵒᵖ ⥤ Dᵒᵖ} {E : Type*} [Category E] {H : Dᵒᵖ ⥤ Eᵒᵖ} (α : F ≅ G) :
     NatIso.unop (isoWhiskerRight α H) =
     (Functor.unopComp _ _) ≪≫ isoWhiskerRight (NatIso.unop α) H.unop ≪≫
       (Functor.unopComp _ _).symm := by
-  aesop_cat
+  cat_disch
 
 lemma unop_whiskerLeft {F G : Cᵒᵖ ⥤ Dᵒᵖ} {E : Type*} [Category E] {H : Eᵒᵖ ⥤ Cᵒᵖ} (α : F ≅ G) :
     NatIso.unop (isoWhiskerLeft H α) =
     (Functor.unopComp _ _) ≪≫ isoWhiskerLeft H.unop (NatIso.unop α) ≪≫
       (Functor.unopComp _ _).symm := by
-  aesop_cat
+  cat_disch
 
 lemma op_leftUnitor :
     NatIso.op F.leftUnitor =
     F.op.leftUnitor.symm ≪≫
       isoWhiskerRight (Functor.opId C).symm F.op ≪≫
       (Functor.opComp _ _).symm := by
-  aesop_cat
+  cat_disch
 
 lemma op_rightUnitor :
     NatIso.op F.rightUnitor =
     F.op.rightUnitor.symm ≪≫
       isoWhiskerLeft F.op (Functor.opId D).symm ≪≫
       (Functor.opComp _ _).symm := by
-  aesop_cat
+  cat_disch
 
 lemma op_associator {E E' : Type*} [Category E] [Category E'] {F : C ⥤ D} {G : D ⥤ E} {H : E ⥤ E'} :
     NatIso.op (Functor.associator F G H) =
       Functor.opComp _ _ ≪≫ isoWhiskerLeft F.op (Functor.opComp _ _) ≪≫
         (Functor.associator F.op G.op H.op).symm ≪≫
         isoWhiskerRight (Functor.opComp _ _).symm H.op ≪≫ (Functor.opComp _ _).symm := by
-  aesop_cat
+  cat_disch
 
 lemma unop_leftUnitor {F : Cᵒᵖ ⥤ Dᵒᵖ} :
     NatIso.unop F.leftUnitor =
     F.unop.leftUnitor.symm ≪≫
       isoWhiskerRight (Functor.unopId C).symm F.unop ≪≫
       (Functor.unopComp _ _).symm := by
-  aesop_cat
+  cat_disch
 
 lemma unop_rightUnitor {F : Cᵒᵖ ⥤ Dᵒᵖ} :
     NatIso.unop F.rightUnitor =
     F.unop.rightUnitor.symm ≪≫
       isoWhiskerLeft F.unop (Functor.unopId D).symm ≪≫
       (Functor.unopComp _ _).symm := by
-  aesop_cat
+  cat_disch
 
 lemma unop_associator {E E' : Type*} [Category E] [Category E']
     {F : Cᵒᵖ ⥤ Dᵒᵖ} {G : Dᵒᵖ ⥤ Eᵒᵖ} {H : Eᵒᵖ ⥤ E'ᵒᵖ} :
@@ -687,7 +687,7 @@ lemma unop_associator {E E' : Type*} [Category E] [Category E']
       Functor.unopComp _ _ ≪≫ isoWhiskerLeft F.unop (Functor.unopComp _ _) ≪≫
         (Functor.associator F.unop G.unop H.unop).symm ≪≫
         isoWhiskerRight (Functor.unopComp _ _).symm H.unop ≪≫ (Functor.unopComp _ _).symm := by
-  aesop_cat
+  cat_disch
 
 end NatIso
 
@@ -782,7 +782,7 @@ def opUnopEquiv : (C ⥤ D)ᵒᵖ ≌ Cᵒᵖ ⥤ Dᵒᵖ where
         dsimp [opUnopIso]
         rw [show f = f.unop.op by simp, ← op_comp, ← op_comp]
         congr 1
-        aesop_cat)
+        cat_disch)
   counitIso := NatIso.ofComponents fun F => F.unopOpIso
 
 /-- The equivalence of functor categories induced by `leftOp` and `rightOp`.
@@ -802,7 +802,7 @@ def leftOpRightOpEquiv : (Cᵒᵖ ⥤ D)ᵒᵖ ≌ C ⥤ Dᵒᵖ where
         dsimp
         rw [show η = η.unop.op by simp, ← op_comp, ← op_comp]
         congr 1
-        aesop_cat)
+        cat_disch)
   counitIso := NatIso.ofComponents fun F => F.leftOpRightOpIso
 
 instance {F : C ⥤ D} [EssSurj F] : EssSurj F.op where

--- a/Mathlib/CategoryTheory/Pi/Basic.lean
+++ b/Mathlib/CategoryTheory/Pi/Basic.lean
@@ -286,7 +286,7 @@ lemma isIso_pi_iff {X Y : ∀ i, C i} (f : X ⟶ Y) :
   · intro _ i
     exact (Pi.isoApp (asIso f) i).isIso_hom
   · intro
-    exact ⟨fun i => inv (f i), by aesop_cat, by aesop_cat⟩
+    exact ⟨fun i => inv (f i), by cat_disch, by cat_disch⟩
 
 variable (C)
 

--- a/Mathlib/CategoryTheory/Preadditive/AdditiveFunctor.lean
+++ b/Mathlib/CategoryTheory/Preadditive/AdditiveFunctor.lean
@@ -38,7 +38,7 @@ namespace CategoryTheory
 class Functor.Additive {C D : Type*} [Category C] [Category D] [Preadditive C] [Preadditive D]
   (F : C ⥤ D) : Prop where
   /-- the addition of two morphisms is mapped to the sum of their images -/
-  map_add : ∀ {X Y : C} {f g : X ⟶ Y}, F.map (f + g) = F.map f + F.map g := by aesop_cat
+  map_add : ∀ {X Y : C} {f g : X ⟶ Y}, F.map (f + g) = F.map f + F.map g := by cat_disch
 
 section Preadditive
 

--- a/Mathlib/CategoryTheory/Preadditive/Basic.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Basic.lean
@@ -58,9 +58,9 @@ variable (C : Type u) [Category.{v} C]
 class Preadditive where
   homGroup : ∀ P Q : C, AddCommGroup (P ⟶ Q) := by infer_instance
   add_comp : ∀ (P Q R : C) (f f' : P ⟶ Q) (g : Q ⟶ R), (f + f') ≫ g = f ≫ g + f' ≫ g := by
-    aesop_cat
+    cat_disch
   comp_add : ∀ (P Q R : C) (f : P ⟶ Q) (g g' : Q ⟶ R), f ≫ (g + g') = f ≫ g + f ≫ g' := by
-    aesop_cat
+    cat_disch
 
 attribute [inherit_doc Preadditive] Preadditive.homGroup Preadditive.add_comp Preadditive.comp_add
 
@@ -329,7 +329,7 @@ theorem kernelForkOfFork_ofι {P : C} (ι : P ⟶ X) (w : ι ≫ f = ι ≫ g) :
 def isLimitForkOfKernelFork {c : KernelFork (f - g)} (i : IsLimit c) :
     IsLimit (forkOfKernelFork c) :=
   Fork.IsLimit.mk' _ fun s =>
-    ⟨i.lift (kernelForkOfFork s), i.fac _ _, fun h => by apply Fork.IsLimit.hom_ext i; aesop_cat⟩
+    ⟨i.lift (kernelForkOfFork s), i.fac _ _, fun h => by apply Fork.IsLimit.hom_ext i; cat_disch⟩
 
 @[simp]
 theorem isLimitForkOfKernelFork_lift {c : KernelFork (f - g)} (i : IsLimit c) (s : Fork f g) :
@@ -339,7 +339,7 @@ theorem isLimitForkOfKernelFork_lift {c : KernelFork (f - g)} (i : IsLimit c) (s
 /-- An equalizer of `f` and `g` is a kernel of `f - g`. -/
 def isLimitKernelForkOfFork {c : Fork f g} (i : IsLimit c) : IsLimit (kernelForkOfFork c) :=
   Fork.IsLimit.mk' _ fun s =>
-    ⟨i.lift (forkOfKernelFork s), i.fac _ _, fun h => by apply Fork.IsLimit.hom_ext i; aesop_cat⟩
+    ⟨i.lift (forkOfKernelFork s), i.fac _ _, fun h => by apply Fork.IsLimit.hom_ext i; cat_disch⟩
 
 variable (f g)
 
@@ -385,7 +385,7 @@ def isColimitCoforkOfCokernelCofork {c : CokernelCofork (f - g)} (i : IsColimit 
     IsColimit (coforkOfCokernelCofork c) :=
   Cofork.IsColimit.mk' _ fun s =>
     ⟨i.desc (cokernelCoforkOfCofork s), i.fac _ _, fun h => by
-      apply Cofork.IsColimit.hom_ext i; aesop_cat⟩
+      apply Cofork.IsColimit.hom_ext i; cat_disch⟩
 
 @[simp]
 theorem isColimitCoforkOfCokernelCofork_desc {c : CokernelCofork (f - g)} (i : IsColimit c)
@@ -398,7 +398,7 @@ def isColimitCokernelCoforkOfCofork {c : Cofork f g} (i : IsColimit c) :
     IsColimit (cokernelCoforkOfCofork c) :=
   Cofork.IsColimit.mk' _ fun s =>
     ⟨i.desc (coforkOfCokernelCofork s), i.fac _ _, fun h => by
-      apply Cofork.IsColimit.hom_ext i; aesop_cat⟩
+      apply Cofork.IsColimit.hom_ext i; cat_disch⟩
 
 variable (f g)
 

--- a/Mathlib/CategoryTheory/Preadditive/CommGrp_.lean
+++ b/Mathlib/CategoryTheory/Preadditive/CommGrp_.lean
@@ -72,7 +72,7 @@ def commGrpEquivalenceAux : CommGrp_.forget C ⋙ toCommGrp C ≅
       convert (Mon_Class.lift_comp_one_left 0 _).symm
       · simp
       · infer_instance
-  · aesop_cat
+  · cat_disch
 
 /-- An additive category is equivalent to its category of commutative group objects. -/
 @[simps!]

--- a/Mathlib/CategoryTheory/Preadditive/OfBiproducts.lean
+++ b/Mathlib/CategoryTheory/Preadditive/OfBiproducts.lean
@@ -84,7 +84,7 @@ theorem distrib (f g h k : X ⟶ Y) : (f +ᵣ g) +ₗ h +ᵣ k = (f +ₗ h) +ᵣ
   have hd₁ : biprod.inl ≫ diag = biprod.lift f h := by ext <;> simp [diag]
   have hd₂ : biprod.inr ≫ diag = biprod.lift g k := by ext <;> simp [diag]
   have h₁ : biprod.lift (f +ᵣ g) (h +ᵣ k) = biprod.lift (𝟙 X) (𝟙 X) ≫ diag := by
-    ext <;> aesop_cat
+    ext <;> cat_disch
   have h₂ : diag ≫ biprod.desc (𝟙 Y) (𝟙 Y) = biprod.desc (f +ₗ h) (g +ₗ k) := by
     ext <;> simp [reassoc_of% hd₁, reassoc_of% hd₂]
   rw [leftAdd, h₁, Category.assoc, h₂, rightAdd]

--- a/Mathlib/CategoryTheory/Preadditive/Opposite.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Opposite.lean
@@ -81,11 +81,11 @@ theorem op_sum (X Y : C) {ι : Type*} (s : Finset ι) (f : ι → (X ⟶ Y)) :
 @[simps]
 def Preadditive.homSelfLinearEquivEndMulOpposite (G : C) : (G ⟶ G) ≃ₗ[(End G)ᵐᵒᵖ] (End G)ᵐᵒᵖ where
   toFun f := ⟨f⟩
-  map_add' := by aesop_cat
-  map_smul' := by aesop_cat
+  map_add' := by cat_disch
+  map_smul' := by cat_disch
   invFun := fun ⟨f⟩ => f
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
+  left_inv := by cat_disch
+  right_inv := by cat_disch
 
 variable {D : Type*} [Category D] [Preadditive D]
 

--- a/Mathlib/CategoryTheory/Preadditive/Projective/Basic.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Projective/Basic.lean
@@ -112,19 +112,19 @@ instance Type.enoughProjectives : EnoughProjectives (Type u) where
 
 instance {P Q : C} [HasBinaryCoproduct P Q] [Projective P] [Projective Q] : Projective (P ⨿ Q) where
   factors f e epi := ⟨coprod.desc (factorThru (coprod.inl ≫ f) e) (factorThru (coprod.inr ≫ f) e),
-    by aesop_cat⟩
+    by cat_disch⟩
 
 instance {β : Type v} (g : β → C) [HasCoproduct g] [∀ b, Projective (g b)] : Projective (∐ g) where
-  factors f e epi := ⟨Sigma.desc fun b => factorThru (Sigma.ι g b ≫ f) e, by aesop_cat⟩
+  factors f e epi := ⟨Sigma.desc fun b => factorThru (Sigma.ι g b ≫ f) e, by cat_disch⟩
 
 instance {P Q : C} [HasZeroMorphisms C] [HasBinaryBiproduct P Q] [Projective P] [Projective Q] :
     Projective (P ⊞ Q) where
   factors f e epi := ⟨biprod.desc (factorThru (biprod.inl ≫ f) e) (factorThru (biprod.inr ≫ f) e),
-    by aesop_cat⟩
+    by cat_disch⟩
 
 instance {β : Type v} (g : β → C) [HasZeroMorphisms C] [HasBiproduct g] [∀ b, Projective (g b)] :
     Projective (⨁ g) where
-  factors f e epi := ⟨biproduct.desc fun b => factorThru (biproduct.ι g b ≫ f) e, by aesop_cat⟩
+  factors f e epi := ⟨biproduct.desc fun b => factorThru (biproduct.ι g b ≫ f) e, by cat_disch⟩
 
 theorem projective_iff_preservesEpimorphisms_coyoneda_obj (P : C) :
     Projective P ↔ (coyoneda.obj (op P)).PreservesEpimorphisms :=

--- a/Mathlib/CategoryTheory/Quotient.lean
+++ b/Mathlib/CategoryTheory/Quotient.lean
@@ -276,11 +276,11 @@ lemma natTransLift_app (F G : Quotient r ⥤ D)
 lemma comp_natTransLift {F G H : Quotient r ⥤ D}
     (τ : Quotient.functor r ⋙ F ⟶ Quotient.functor r ⋙ G)
     (τ' : Quotient.functor r ⋙ G ⟶ Quotient.functor r ⋙ H) :
-    natTransLift r τ ≫ natTransLift r τ' =  natTransLift r (τ ≫ τ') := by aesop_cat
+    natTransLift r τ ≫ natTransLift r τ' =  natTransLift r (τ ≫ τ') := by cat_disch
 
 @[simp]
 lemma natTransLift_id (F : Quotient r ⥤ D) :
-    natTransLift r (𝟙 (Quotient.functor r ⋙ F)) = 𝟙 _ := by aesop_cat
+    natTransLift r (𝟙 (Quotient.functor r ⋙ F)) = 𝟙 _ := by cat_disch
 
 /-- In order to define a natural isomorphism `F ≅ G` with `F G : Quotient r ⥤ D`, it suffices
 to do so after precomposing with `Quotient.functor r`. -/
@@ -296,7 +296,7 @@ variable (D)
 
 instance full_whiskeringLeft_functor :
     ((whiskeringLeft C _ D).obj (functor r)).Full where
-  map_surjective f := ⟨natTransLift r f, by aesop_cat⟩
+  map_surjective f := ⟨natTransLift r f, by cat_disch⟩
 
 instance faithful_whiskeringLeft_functor :
     ((whiskeringLeft C _ D).obj (functor r)).Faithful := ⟨by apply natTrans_ext⟩

--- a/Mathlib/CategoryTheory/Retract.lean
+++ b/Mathlib/CategoryTheory/Retract.lean
@@ -26,7 +26,7 @@ structure Retract (X Y : C) where
   i : X ⟶ Y
   /-- the split epimorphism -/
   r : Y ⟶ X
-  retract : i ≫ r = 𝟙 X := by aesop_cat
+  retract : i ≫ r = 𝟙 X := by cat_disch
 
 namespace Retract
 

--- a/Mathlib/CategoryTheory/Shift/Basic.lean
+++ b/Mathlib/CategoryTheory/Shift/Basic.lean
@@ -75,13 +75,13 @@ structure ShiftMkCore where
   assoc_hom_app : ∀ (m₁ m₂ m₃ : A) (X : C),
     (add (m₁ + m₂) m₃).hom.app X ≫ (F m₃).map ((add m₁ m₂).hom.app X) =
       eqToHom (by rw [add_assoc]) ≫ (add m₁ (m₂ + m₃)).hom.app X ≫
-        (add m₂ m₃).hom.app ((F m₁).obj X) := by aesop_cat
+        (add m₂ m₃).hom.app ((F m₁).obj X) := by cat_disch
   /-- compatibility with the left addition with 0 -/
   zero_add_hom_app : ∀ (n : A) (X : C), (add 0 n).hom.app X =
-    eqToHom (by dsimp; rw [zero_add]) ≫ (F n).map (zero.inv.app X) := by aesop_cat
+    eqToHom (by dsimp; rw [zero_add]) ≫ (F n).map (zero.inv.app X) := by cat_disch
   /-- compatibility with the right addition with 0 -/
   add_zero_hom_app : ∀ (n : A) (X : C), (add n 0).hom.app X =
-    eqToHom (by dsimp; rw [add_zero]) ≫ zero.inv.app ((F n).obj X) := by aesop_cat
+    eqToHom (by dsimp; rw [add_zero]) ≫ zero.inv.app ((F n).obj X) := by cat_disch
 
 namespace ShiftMkCore
 

--- a/Mathlib/CategoryTheory/Shift/CommShift.lean
+++ b/Mathlib/CategoryTheory/Shift/CommShift.lean
@@ -107,8 +107,8 @@ satisfy coherence properties with respect to `0 : A` and the addition in `A`. -/
 class CommShift where
   /-- The commutation isomorphisms for all `a`-shifts this functor is equipped with -/
   iso (a : A) : shiftFunctor C a ⋙ F ≅ F ⋙ shiftFunctor D a
-  zero : iso 0 = CommShift.isoZero F A := by aesop_cat
-  add (a b : A) : iso (a + b) = CommShift.isoAdd (iso a) (iso b) := by aesop_cat
+  zero : iso 0 = CommShift.isoZero F A := by cat_disch
+  add (a b : A) : iso (a + b) = CommShift.isoAdd (iso a) (iso b) := by cat_disch
 
 variable {A}
 
@@ -266,7 +266,7 @@ which commute with a shift by an additive monoid `A`, this typeclass
 asserts a compatibility of `τ` with these shifts. -/
 class CommShift : Prop where
   shift_comm (a : A) : (F₁.commShiftIso a).hom ≫ Functor.whiskerRight τ _ =
-    Functor.whiskerLeft _ τ ≫ (F₂.commShiftIso a).hom := by aesop_cat
+    Functor.whiskerLeft _ τ ≫ (F₂.commShiftIso a).hom := by cat_disch
 
 section
 

--- a/Mathlib/CategoryTheory/Shift/ShiftSequence.lean
+++ b/Mathlib/CategoryTheory/Shift/ShiftSequence.lean
@@ -60,7 +60,7 @@ noncomputable def ShiftSequence.tautological : ShiftSequence F M where
     isoWhiskerRight (shiftFunctorAdd' C n a a' ha').symm _
   shiftIso_zero a := by
     rw [shiftFunctorAdd'_zero_add]
-    aesop_cat
+    cat_disch
   shiftIso_add n m a a' a'' ha' ha'' := by
     ext X
     dsimp

--- a/Mathlib/CategoryTheory/Shift/SingleFunctors.lean
+++ b/Mathlib/CategoryTheory/Shift/SingleFunctors.lean
@@ -108,7 +108,7 @@ structure Hom where
   /-- a family of natural transformations `F.functor a ⟶ G.functor a` -/
   hom (a : A) : F.functor a ⟶ G.functor a
   comm (n a a' : A) (ha' : n + a = a') : (F.shiftIso n a a' ha').hom ≫ hom a =
-    whiskerRight (hom a') (shiftFunctor D n) ≫ (G.shiftIso n a a' ha').hom := by aesop_cat
+    whiskerRight (hom a') (shiftFunctor D n) ≫ (G.shiftIso n a a' ha').hom := by cat_disch
 
 namespace Hom
 

--- a/Mathlib/CategoryTheory/SingleObj.lean
+++ b/Mathlib/CategoryTheory/SingleObj.lean
@@ -115,8 +115,8 @@ def mapHom : (M →* N) ≃ SingleObj M ⥤ SingleObj N where
     { toFun := fun x => f.map ((toEnd M) x)
       map_one' := f.map_id _
       map_mul' := fun x y => f.map_comp y x }
-  left_inv := by aesop_cat
-  right_inv := by aesop_cat
+  left_inv := by cat_disch
+  right_inv := by cat_disch
 
 theorem mapHom_id : mapHom M M (MonoidHom.id M) = 𝟭 _ :=
   rfl

--- a/Mathlib/CategoryTheory/Sites/CompatiblePlus.lean
+++ b/Mathlib/CategoryTheory/Sites/CompatiblePlus.lean
@@ -124,7 +124,7 @@ theorem plusCompIso_whiskerLeft {F G : D ⥤ E} (η : F ⟶ G) (P : Cᵒᵖ ⥤ 
     NatTrans.naturality_assoc, GrothendieckTopology.diagramNatTrans_app]
   simp only [← Category.assoc]
   congr 1
-  aesop_cat
+  cat_disch
 
 /-- The isomorphism between `P⁺ ⋙ F` and `(P ⋙ F)⁺`, functorially in `F`. -/
 @[simps! hom_app inv_app]

--- a/Mathlib/CategoryTheory/Sites/CoverLifting.lean
+++ b/Mathlib/CategoryTheory/Sites/CoverLifting.lean
@@ -284,7 +284,7 @@ lemma sheafAdjunctionCocontinuous_counit_app_val (F : Sheaf J A) :
     (fullyFaithfulSheafToPresheaf K A) (fullyFaithfulSheafToPresheaf J A)
     (G.sheafPushforwardContinuousCompSheafToPresheafIso A J K).symm
     (G.sheafPushforwardCocontinuousCompSheafToPresheafIso A J K).symm F).trans
-      (by aesop_cat)
+      (by cat_disch)
 
 lemma sheafAdjunctionCocontinuous_homEquiv_apply_val {F : Sheaf K A} {H : Sheaf J A}
     (f : (G.sheafPushforwardContinuous A J K).obj F ⟶ H) :

--- a/Mathlib/CategoryTheory/Sites/DenseSubsite/Basic.lean
+++ b/Mathlib/CategoryTheory/Sites/DenseSubsite/Basic.lean
@@ -52,7 +52,7 @@ structure Presieve.CoverByImageStructure (G : C ⥤ D) {V U : D} (f : V ⟶ U) w
   obj : C
   lift : V ⟶ G.obj obj
   map : G.obj obj ⟶ U
-  fac : lift ≫ map = f := by aesop_cat
+  fac : lift ≫ map = f := by cat_disch
 attribute [nolint docBlame] Presieve.CoverByImageStructure.obj Presieve.CoverByImageStructure.lift
   Presieve.CoverByImageStructure.map Presieve.CoverByImageStructure.fac
 

--- a/Mathlib/CategoryTheory/Sites/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Sites/Grothendieck.lean
@@ -432,7 +432,7 @@ structure Arrow.Relation {S : J.Cover X} (I₁ I₂ : S.Arrow) where
   /-- The second arrow defining the relation. -/
   g₂ : Z ⟶ I₂.Y
   /-- The relation itself. -/
-  w : g₁ ≫ I₁.f = g₂ ≫ I₂.f := by aesop_cat
+  w : g₁ ≫ I₁.f = g₂ ≫ I₂.f := by cat_disch
 
 attribute [reassoc] Arrow.Relation.w
 

--- a/Mathlib/CategoryTheory/Sites/Limits.lean
+++ b/Mathlib/CategoryTheory/Sites/Limits.lean
@@ -81,7 +81,7 @@ def multiforkEvaluationCone (F : K ⥤ Sheaf J D) (E : Cone (F ⋙ sheafToPreshe
           Category.assoc, Presheaf.IsSheaf.amalgamate_map]
         dsimp [Multifork.ofι]
         erw [Category.assoc, ← E.w f]
-        aesop_cat }
+        cat_disch }
 
 variable [HasLimitsOfShape K D]
 

--- a/Mathlib/CategoryTheory/Sites/OneHypercover.lean
+++ b/Mathlib/CategoryTheory/Sites/OneHypercover.lean
@@ -85,7 +85,7 @@ lemma sieve₁_eq_pullback_sieve₁' {W : C} (p₁ : W ⟶ E.X i₁) (p₂ : W �
   ext Z g
   constructor
   · rintro ⟨j, h, fac₁, fac₂⟩
-    exact ⟨_, h, _, ⟨j⟩, by aesop_cat⟩
+    exact ⟨_, h, _, ⟨j⟩, by cat_disch⟩
   · rintro ⟨_, h, w, ⟨j⟩, fac⟩
     exact ⟨j, h, by simpa using fac.symm =≫ pullback.fst _ _,
       by simpa using fac.symm =≫ pullback.snd _ _⟩
@@ -138,8 +138,8 @@ structure Hom (E F : PreOneHypercover S) extends
   s₁ {i j : E.I₀} (k : E.I₁ i j) : F.I₁ (s₀ i) (s₀ j)
   /-- The refinement morphisms between objects in the coverings of the fibre products over `S`. -/
   h₁ {i j : E.I₀} (k : E.I₁ i j) : E.Y k ⟶ F.Y (s₁ k)
-  w₁₁ {i j : E.I₀} (k : E.I₁ i j) : h₁ k ≫ F.p₁ (s₁ k) = E.p₁ k ≫ h₀ i := by aesop_cat
-  w₁₂ {i j : E.I₀} (k : E.I₁ i j) : h₁ k ≫ F.p₂ (s₁ k) = E.p₂ k ≫ h₀ j := by aesop_cat
+  w₁₁ {i j : E.I₀} (k : E.I₁ i j) : h₁ k ≫ F.p₁ (s₁ k) = E.p₁ k ≫ h₀ i := by cat_disch
+  w₁₂ {i j : E.I₀} (k : E.I₁ i j) : h₁ k ≫ F.p₂ (s₁ k) = E.p₂ k ≫ h₀ j := by cat_disch
 
 attribute [reassoc] Hom.w₁₁ Hom.w₁₂
 

--- a/Mathlib/CategoryTheory/Sites/OneHypercover.lean
+++ b/Mathlib/CategoryTheory/Sites/OneHypercover.lean
@@ -95,7 +95,7 @@ lemma sieve₁'_eq_sieve₁ : E.sieve₁' i₁ i₂ = E.sieve₁ (pullback.fst _
   rw [← Sieve.pullback_id (S := E.sieve₁' i₁ i₂),
     sieve₁_eq_pullback_sieve₁' _ _ _ pullback.condition]
   congr
-  aesop_cat
+  cat_disch
 
 end
 

--- a/Mathlib/CategoryTheory/Sites/Over.lean
+++ b/Mathlib/CategoryTheory/Sites/Over.lean
@@ -108,7 +108,7 @@ lemma functorPushforward_over_map {X Y : C} (f : X ⟶ Y) (Z : Over X) (S : Siev
     exact S.downward_closed ha _
   · intro hg
     exact ⟨Over.mk (g.left ≫ Z.hom), Over.homMk g.left,
-      Over.homMk (𝟙 _) (by simpa using Over.w g), hg, by aesop_cat⟩
+      Over.homMk (𝟙 _) (by simpa using Over.w g), hg, by cat_disch⟩
 
 end Sieve
 

--- a/Mathlib/CategoryTheory/Sites/Sheaf.lean
+++ b/Mathlib/CategoryTheory/Sites/Sheaf.lean
@@ -481,7 +481,7 @@ theorem Sheaf.Hom.add_app (f g : P ⟶ Q) (U) : (f + g).1.app U = f.1.app U + g.
 instance Sheaf.Hom.addCommGroup : AddCommGroup (P ⟶ Q) :=
   Function.Injective.addCommGroup (fun f : Sheaf.Hom P Q => f.1)
     (fun _ _ h => Sheaf.Hom.ext h) rfl (fun _ _ => rfl) (fun _ => rfl) (fun _ _ => rfl)
-    (fun _ _ => by aesop_cat) (fun _ _ => by aesop_cat)
+    (fun _ _ => by cat_disch) (fun _ _ => by cat_disch)
 
 instance : Preadditive (Sheaf J A) where
   homGroup _ _ := Sheaf.Hom.addCommGroup

--- a/Mathlib/CategoryTheory/Sites/SheafOfTypes.lean
+++ b/Mathlib/CategoryTheory/Sites/SheafOfTypes.lean
@@ -185,7 +185,7 @@ theorem yonedaFamily_fromCocone_compatible (S : Sieve X) (s : Cocone (diagram S.
   have hF := @Hs ⟨Over.mk (g₁ ≫ f₁), hgf₁⟩ ⟨Over.mk (g₂ ≫ f₂), hgf₂⟩ F
   have hF₁ := @Hs ⟨Over.mk (g₁ ≫ f₁), hgf₁⟩ ⟨Over.mk f₁, hf₁⟩ F₁
   have hF₂ := @Hs ⟨Over.mk (g₂ ≫ f₂), hgf₂⟩ ⟨Over.mk f₂, hf₂⟩ F₂
-  aesop_cat
+  cat_disch
 
 /--
 The base of a sieve `S` is a colimit of `S` iff all Yoneda-presheaves satisfy
@@ -205,7 +205,7 @@ theorem forallYonedaIsSheaf_iff_colimit (S : Sieve X) :
         replace H := H s.pt (yonedaFamilyOfElements_fromCocone S.arrows s)
           (yonedaFamily_fromCocone_compatible S s)
         have ht := H.choose_spec.1 f.obj.hom f.property
-        aesop_cat
+        cat_disch
       uniq := by
         intro s Fs HFs
         replace H := H s.pt (yonedaFamilyOfElements_fromCocone S.arrows s)

--- a/Mathlib/CategoryTheory/Sites/Sheafification.lean
+++ b/Mathlib/CategoryTheory/Sites/Sheafification.lean
@@ -233,6 +233,6 @@ variable (J D)
 @[simps!]
 noncomputable def sheafificationNatIso :
     𝟭 (Sheaf J D) ≅ sheafToPresheaf J D ⋙ presheafToSheaf J D :=
-  NatIso.ofComponents (fun P => sheafificationIso P) (by aesop_cat)
+  NatIso.ofComponents (fun P => sheafificationIso P) (by cat_disch)
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Sites/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Sites/Whiskering.lean
@@ -101,7 +101,7 @@ def multicospanComp : (S.index (P ⋙ F)).multicospan ≅ (S.index P).multicospa
       | WalkingMulticospan.right _ => Iso.refl _)
     (by
       rintro (a | b) (a | b) (f | f | f)
-      all_goals aesop_cat)
+      all_goals cat_disch)
 
 /-- Mapping the multifork associated to a cover `S : J.Cover X` and a presheaf `P` with
 respect to a functor `F` is isomorphic (upto a natural isomorphism of the underlying functors)

--- a/Mathlib/CategoryTheory/Sites/ZeroHypercover.lean
+++ b/Mathlib/CategoryTheory/Sites/ZeroHypercover.lean
@@ -102,7 +102,7 @@ structure Hom (E : PreZeroHypercover.{w} S) (F : PreZeroHypercover.{w'} S) where
   s₀ (i : E.I₀) : F.I₀
   /-- The refinement morphisms between objects in the coverings of `S`. -/
   h₀ (i : E.I₀) : E.X i ⟶ F.X (s₀ i)
-  w₀ (i : E.I₀) : h₀ i ≫ F.f (s₀ i) = E.f i := by aesop_cat
+  w₀ (i : E.I₀) : h₀ i ≫ F.f (s₀ i) = E.f i := by cat_disch
 
 attribute [reassoc (attr := simp)] Hom.w₀
 

--- a/Mathlib/CategoryTheory/SmallObject/TransfiniteCompositionLifting.lean
+++ b/Mathlib/CategoryTheory/SmallObject/TransfiniteCompositionLifting.lean
@@ -90,8 +90,8 @@ F.obj j     | p
 structure SqStruct (j : J) where
   /-- a morphism `F.obj j ⟶ X` -/
   f' : F.obj j ⟶ X
-  w₁ : F.map (homOfLE bot_le) ≫ f' = f := by aesop_cat
-  w₂ : f' ≫ p = c.ι.app j ≫ g := by aesop_cat
+  w₁ : F.map (homOfLE bot_le) ≫ f' = f := by cat_disch
+  w₂ : f' ≫ p = c.ι.app j ≫ g := by cat_disch
 
 namespace SqStruct
 
@@ -197,7 +197,7 @@ noncomputable def wellOrderInductionData :
         simp only [← sq'.w₁]
         conv_rhs => rw [← sq'.sq.fac_left, ← F.map_comp_assoc]
         rfl }
-  map_succ j hj sq' := by aesop_cat
+  map_succ j hj sq' := by cat_disch
   lift j hj s := lift hj s
   map_lift j hj s i hij := map_lift hj s hij
 

--- a/Mathlib/CategoryTheory/Square.lean
+++ b/Mathlib/CategoryTheory/Square.lean
@@ -78,10 +78,10 @@ structure Hom (sq₁ sq₂ : Square C) where
   τ₃ : sq₁.X₃ ⟶ sq₂.X₃
   /-- the bottom-right morphism -/
   τ₄ : sq₁.X₄ ⟶ sq₂.X₄
-  comm₁₂ : sq₁.f₁₂ ≫ τ₂ = τ₁ ≫ sq₂.f₁₂ := by aesop_cat
-  comm₁₃ : sq₁.f₁₃ ≫ τ₃ = τ₁ ≫ sq₂.f₁₃ := by aesop_cat
-  comm₂₄ : sq₁.f₂₄ ≫ τ₄ = τ₂ ≫ sq₂.f₂₄ := by aesop_cat
-  comm₃₄ : sq₁.f₃₄ ≫ τ₄ = τ₃ ≫ sq₂.f₃₄ := by aesop_cat
+  comm₁₂ : sq₁.f₁₂ ≫ τ₂ = τ₁ ≫ sq₂.f₁₂ := by cat_disch
+  comm₁₃ : sq₁.f₁₃ ≫ τ₃ = τ₁ ≫ sq₂.f₁₃ := by cat_disch
+  comm₂₄ : sq₁.f₂₄ ≫ τ₄ = τ₂ ≫ sq₂.f₂₄ := by cat_disch
+  comm₃₄ : sq₁.f₃₄ ≫ τ₄ = τ₃ ≫ sq₂.f₃₄ := by cat_disch
 
 namespace Hom
 

--- a/Mathlib/CategoryTheory/Subobject/Lattice.lean
+++ b/Mathlib/CategoryTheory/Subobject/Lattice.lean
@@ -693,14 +693,14 @@ def subobjectOrderIso {X : C} (Y : Subobject X) : Subobject (Y : C) ≃o Set.Iic
     ⟨Subobject.mk (Z.arrow ≫ Y.arrow),
       Set.mem_Iic.mpr (le_of_comm ((underlyingIso _).hom ≫ Z.arrow) (by simp))⟩
   invFun Z := Subobject.mk (ofLE _ _ Z.2)
-  left_inv Z := mk_eq_of_comm _ (underlyingIso _) (by aesop_cat)
+  left_inv Z := mk_eq_of_comm _ (underlyingIso _) (by cat_disch)
   right_inv Z := Subtype.ext (mk_eq_of_comm _ (underlyingIso _) (by simp [← Iso.eq_inv_comp]))
   map_rel_iff' {W Z} := by
     dsimp
     constructor
     · intro h
       exact le_of_comm (((underlyingIso _).inv ≫ ofLE _ _ (Subtype.mk_le_mk.mp h) ≫
-        (underlyingIso _).hom)) (by aesop_cat)
+        (underlyingIso _).hom)) (by cat_disch)
     · intro h
       exact Subtype.mk_le_mk.mpr (le_of_comm
         ((underlyingIso _).hom ≫ ofLE _ _ h ≫ (underlyingIso _).inv) (by simp))

--- a/Mathlib/CategoryTheory/Subobject/Limits.lean
+++ b/Mathlib/CategoryTheory/Subobject/Limits.lean
@@ -140,7 +140,7 @@ theorem kernelSubobjectMap_arrow (sq : Arrow.mk f ⟶ Arrow.mk f') :
   simp [kernelSubobjectMap]
 
 @[simp]
-theorem kernelSubobjectMap_id : kernelSubobjectMap (𝟙 (Arrow.mk f)) = 𝟙 _ := by aesop_cat
+theorem kernelSubobjectMap_id : kernelSubobjectMap (𝟙 (Arrow.mk f)) = 𝟙 _ := by cat_disch
 
 @[simp]
 theorem kernelSubobjectMap_comp {X'' Y'' : C} {f'' : X'' ⟶ Y''} [HasKernel f'']
@@ -151,7 +151,7 @@ theorem kernelSubobjectMap_comp {X'' Y'' : C} {f'' : X'' ⟶ Y''} [HasKernel f''
 @[reassoc]
 theorem kernel_map_comp_kernelSubobjectIso_inv (sq : Arrow.mk f ⟶ Arrow.mk f') :
     kernel.map f f' sq.1 sq.2 sq.3.symm ≫ (kernelSubobjectIso _).inv =
-      (kernelSubobjectIso _).inv ≫ kernelSubobjectMap sq := by aesop_cat
+      (kernelSubobjectIso _).inv ≫ kernelSubobjectMap sq := by cat_disch
 
 @[reassoc]
 theorem kernelSubobjectIso_comp_kernel_map (sq : Arrow.mk f ⟶ Arrow.mk f') :

--- a/Mathlib/CategoryTheory/Subobject/Limits.lean
+++ b/Mathlib/CategoryTheory/Subobject/Limits.lean
@@ -146,7 +146,7 @@ theorem kernelSubobjectMap_id : kernelSubobjectMap (𝟙 (Arrow.mk f)) = 𝟙 _ 
 theorem kernelSubobjectMap_comp {X'' Y'' : C} {f'' : X'' ⟶ Y''} [HasKernel f'']
     (sq : Arrow.mk f ⟶ Arrow.mk f') (sq' : Arrow.mk f' ⟶ Arrow.mk f'') :
     kernelSubobjectMap (sq ≫ sq') = kernelSubobjectMap sq ≫ kernelSubobjectMap sq' := by
-  aesop_cat
+  cat_disch
 
 @[reassoc]
 theorem kernel_map_comp_kernelSubobjectIso_inv (sq : Arrow.mk f ⟶ Arrow.mk f') :

--- a/Mathlib/CategoryTheory/Subobject/MonoOver.lean
+++ b/Mathlib/CategoryTheory/Subobject/MonoOver.lean
@@ -125,13 +125,13 @@ theorem w {f g : MonoOver X} (k : f ⟶ g) : k.left ≫ g.arrow = f.arrow :=
 
 /-- Convenience constructor for a morphism in monomorphisms over `X`. -/
 abbrev homMk {f g : MonoOver X} (h : f.obj.left ⟶ g.obj.left)
-    (w : h ≫ g.arrow = f.arrow := by aesop_cat) : f ⟶ g :=
+    (w : h ≫ g.arrow = f.arrow := by cat_disch) : f ⟶ g :=
   Over.homMk h w
 
 /-- Convenience constructor for an isomorphism in monomorphisms over `X`. -/
 @[simps]
 def isoMk {f g : MonoOver X} (h : f.obj.left ≅ g.obj.left)
-    (w : h.hom ≫ g.arrow = f.arrow := by aesop_cat) : f ≅ g where
+    (w : h.hom ≫ g.arrow = f.arrow := by cat_disch) : f ≅ g where
   hom := homMk h.hom w
   inv := homMk h.inv (by rw [h.inv_comp_eq, w])
 

--- a/Mathlib/CategoryTheory/Subterminal.lean
+++ b/Mathlib/CategoryTheory/Subterminal.lean
@@ -87,7 +87,7 @@ theorem IsSubterminal.isIso_diag (hA : IsSubterminal A) [HasBinaryProduct A A] :
   ⟨⟨Limits.prod.fst,
       ⟨by simp, by
         rw [IsSubterminal.def] at hA
-        aesop_cat⟩⟩⟩
+        cat_disch⟩⟩⟩
 
 /-- If the diagonal morphism of `A` is an isomorphism, then it is subterminal.
 The converse of `isSubterminal.isIso_diag`.

--- a/Mathlib/CategoryTheory/Sums/Basic.lean
+++ b/Mathlib/CategoryTheory/Sums/Basic.lean
@@ -45,7 +45,7 @@ section
 
 variable (C : Type u₁) [Category.{v₁} C] (D : Type u₂) [Category.{v₂} D]
 
-/- Porting note: `aesop_cat` not firing on `assoc` where autotac in Lean 3 did -/
+/- Porting note: `cat_disch` not firing on `assoc` where autotac in Lean 3 did -/
 
 /-- `sum C D` gives the direct sum of two categories.
 -/

--- a/Mathlib/CategoryTheory/Sums/Products.lean
+++ b/Mathlib/CategoryTheory/Sums/Products.lean
@@ -107,7 +107,7 @@ def natTransOfWhiskerLeftInlInr {F G : A ⊕ A' ⥤ B}
 @[simp]
 lemma natTransOfWhiskerLeftInlInr_id {F : A ⊕ A' ⥤ B} :
     natTransOfWhiskerLeftInlInr (𝟙 (Sum.inl_ A A' ⋙ F)) (𝟙 (Sum.inr_ A A' ⋙ F)) = 𝟙 F := by
-  aesop_cat
+  cat_disch
 
 @[simp]
 lemma natTransOfWhiskerLeftInlInr_comp {F G H : A ⊕ A' ⥤ B}
@@ -115,7 +115,7 @@ lemma natTransOfWhiskerLeftInlInr_comp {F G H : A ⊕ A' ⥤ B}
     (ν₁ : Sum.inl_ A A' ⋙ G ⟶ Sum.inl_ A A' ⋙ H) (ν₂ : Sum.inr_ A A' ⋙ G ⟶ Sum.inr_ A A' ⋙ H) :
     natTransOfWhiskerLeftInlInr (η₁ ≫ ν₁) (η₂ ≫ ν₂) = natTransOfWhiskerLeftInlInr η₁ η₂ ≫
       natTransOfWhiskerLeftInlInr ν₁ ν₂ := by
-  aesop_cat
+  cat_disch
 
 /-- A consequence of `functorEquiv`: we can construct a natural isomorphism of functors
 `A ⊕ A' ⥤ B` from the data of natural isomorphisms of their whiskering with `inl_` and `inr_`. -/
@@ -132,7 +132,7 @@ lemma natIsoOfWhiskerLeftInlInr_eq {F G : A ⊕ A' ⥤ B}
     (Sum.functorEquiv A A' B).unitIso.app _ ≪≫
       (Sum.functorEquiv A A' B).inverse.mapIso (Iso.prod η₁ η₂) ≪≫
       (Sum.functorEquiv A A' B).unitIso.symm.app _ := by
-  aesop_cat
+  cat_disch
 
 namespace Swap
 

--- a/Mathlib/CategoryTheory/Triangulated/Basic.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Basic.lean
@@ -290,7 +290,7 @@ def productTriangle.lift {T' : Triangle C} (φ : ∀ j, T' ⟶ T j) :
   comm₃ := by
     dsimp
     rw [← cancel_mono (piComparison _ _), assoc, assoc, assoc, IsIso.inv_hom_id, comp_id]
-    aesop_cat
+    cat_disch
 
 /-- The triangle `productTriangle T` satisfies the universal property of the categorical
 product of the triangles `T`. -/

--- a/Mathlib/CategoryTheory/Triangulated/Basic.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Basic.lean
@@ -104,11 +104,11 @@ structure TriangleMorphism (T₁ : Triangle C) (T₂ : Triangle C) where
   /-- the third morphism in a triangle morphism -/
   hom₃ : T₁.obj₃ ⟶ T₂.obj₃
   /-- the first commutative square of a triangle morphism -/
-  comm₁ : T₁.mor₁ ≫ hom₂ = hom₁ ≫ T₂.mor₁ := by aesop_cat
+  comm₁ : T₁.mor₁ ≫ hom₂ = hom₁ ≫ T₂.mor₁ := by cat_disch
   /-- the second commutative square of a triangle morphism -/
-  comm₂ : T₁.mor₂ ≫ hom₃ = hom₂ ≫ T₂.mor₂ := by aesop_cat
+  comm₂ : T₁.mor₂ ≫ hom₃ = hom₂ ≫ T₂.mor₂ := by cat_disch
   /-- the third commutative square of a triangle morphism -/
-  comm₃ : T₁.mor₃ ≫ hom₁⟦1⟧' = hom₃ ≫ T₂.mor₃ := by aesop_cat
+  comm₃ : T₁.mor₃ ≫ hom₁⟦1⟧' = hom₃ ≫ T₂.mor₃ := by cat_disch
 
 attribute [reassoc (attr := simp)] TriangleMorphism.comm₁ TriangleMorphism.comm₂
   TriangleMorphism.comm₃
@@ -169,9 +169,9 @@ lemma comp_hom₃ {X Y Z : Triangle C} (f : X ⟶ Y) (g : Y ⟶ Z) :
 @[simps]
 def Triangle.homMk (A B : Triangle C)
     (hom₁ : A.obj₁ ⟶ B.obj₁) (hom₂ : A.obj₂ ⟶ B.obj₂) (hom₃ : A.obj₃ ⟶ B.obj₃)
-    (comm₁ : A.mor₁ ≫ hom₂ = hom₁ ≫ B.mor₁ := by aesop_cat)
-    (comm₂ : A.mor₂ ≫ hom₃ = hom₂ ≫ B.mor₂ := by aesop_cat)
-    (comm₃ : A.mor₃ ≫ hom₁⟦1⟧' = hom₃ ≫ B.mor₃ := by aesop_cat) :
+    (comm₁ : A.mor₁ ≫ hom₂ = hom₁ ≫ B.mor₁ := by cat_disch)
+    (comm₂ : A.mor₂ ≫ hom₃ = hom₂ ≫ B.mor₂ := by cat_disch)
+    (comm₃ : A.mor₃ ≫ hom₁⟦1⟧' = hom₃ ≫ B.mor₃ := by cat_disch) :
     A ⟶ B where
   hom₁ := hom₁
   hom₂ := hom₂
@@ -184,9 +184,9 @@ def Triangle.homMk (A B : Triangle C)
 @[simps]
 def Triangle.isoMk (A B : Triangle C)
     (iso₁ : A.obj₁ ≅ B.obj₁) (iso₂ : A.obj₂ ≅ B.obj₂) (iso₃ : A.obj₃ ≅ B.obj₃)
-    (comm₁ : A.mor₁ ≫ iso₂.hom = iso₁.hom ≫ B.mor₁ := by aesop_cat)
-    (comm₂ : A.mor₂ ≫ iso₃.hom = iso₂.hom ≫ B.mor₂ := by aesop_cat)
-    (comm₃ : A.mor₃ ≫ iso₁.hom⟦1⟧' = iso₃.hom ≫ B.mor₃ := by aesop_cat) : A ≅ B where
+    (comm₁ : A.mor₁ ≫ iso₂.hom = iso₁.hom ≫ B.mor₁ := by cat_disch)
+    (comm₂ : A.mor₂ ≫ iso₃.hom = iso₂.hom ≫ B.mor₂ := by cat_disch)
+    (comm₃ : A.mor₃ ≫ iso₁.hom⟦1⟧' = iso₃.hom ≫ B.mor₃ := by cat_disch) : A ≅ B where
   hom := Triangle.homMk _ _ iso₁.hom iso₂.hom iso₃.hom comm₁ comm₂ comm₃
   inv := Triangle.homMk _ _ iso₁.inv iso₂.inv iso₃.inv
     (by simp only [← cancel_mono iso₂.hom, assoc, Iso.inv_hom_id, comp_id,
@@ -249,7 +249,7 @@ def binaryProductTriangleIsoBinaryBiproductTriangle
     (X₁ X₂ : C) [HasZeroMorphisms C] [HasBinaryBiproduct X₁ X₂] :
     binaryProductTriangle X₁ X₂ ≅ binaryBiproductTriangle X₁ X₂ :=
   Triangle.isoMk _ _ (Iso.refl _) (biprod.isoProd X₁ X₂).symm (Iso.refl _)
-    (by aesop_cat) (by simp) (by simp)
+    (by cat_disch) (by simp) (by simp)
 
 section
 
@@ -295,7 +295,7 @@ def productTriangle.lift {T' : Triangle C} (φ : ∀ j, T' ⟶ T j) :
 /-- The triangle `productTriangle T` satisfies the universal property of the categorical
 product of the triangles `T`. -/
 def productTriangle.isLimitFan : IsLimit (productTriangle.fan T) :=
-  mkFanLimit _ (fun s => productTriangle.lift T s.proj) (fun s j => by aesop_cat) (by
+  mkFanLimit _ (fun s => productTriangle.lift T s.proj) (fun s j => by cat_disch) (by
     intro s m hm
     ext1
     all_goals

--- a/Mathlib/CategoryTheory/Triangulated/Functor.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Functor.lean
@@ -67,7 +67,7 @@ instance [Full F] [Faithful F] : Full F.mapTriangle where
       comm₃ := F.map_injective (by
         rw [← cancel_mono ((F.commShiftIso (1 : ℤ)).hom.app Y.obj₁)]
         simpa only [mapTriangle_obj, map_comp, assoc, commShiftIso_hom_naturality,
-          map_preimage, Triangle.mk_mor₃] using f.comm₃) }, by aesop_cat⟩
+          map_preimage, Triangle.mk_mor₃] using f.comm₃) }, by cat_disch⟩
 
 section Additive
 
@@ -84,7 +84,7 @@ noncomputable def mapTriangleCommShiftIso (n : ℤ) :
         Linear.comp_units_smul, ← F.commShiftIso_hom_naturality_assoc]
       rw [F.map_shiftFunctorComm_hom_app T.obj₁ 1 n]
       simp only [comp_obj, assoc, Iso.inv_hom_id_app_assoc,
-        ← Functor.map_comp, Iso.inv_hom_id_app, map_id, comp_id])) (by aesop_cat)
+        ← Functor.map_comp, Iso.inv_hom_id_app, map_id, comp_id])) (by cat_disch)
 
 attribute [simps!] mapTriangleCommShiftIso
 
@@ -114,7 +114,7 @@ def mapTriangleRotateIso :
   NatIso.ofComponents
     (fun T => Triangle.isoMk _ _ (Iso.refl _) (Iso.refl _)
       ((F.commShiftIso (1 : ℤ)).symm.app _)
-      (by simp) (by simp) (by simp)) (by aesop_cat)
+      (by simp) (by simp) (by simp)) (by cat_disch)
 
 /-- `F.mapTriangle` commutes with the inverse of the rotation of triangles. -/
 @[simps!]
@@ -123,7 +123,7 @@ noncomputable def mapTriangleInvRotateIso [F.Additive] :
       Pretriangulated.invRotate C ⋙ F.mapTriangle :=
   NatIso.ofComponents
     (fun T => Triangle.isoMk _ _ ((F.commShiftIso (-1 : ℤ)).symm.app _) (Iso.refl _) (Iso.refl _)
-      (by simp) (by simp) (by simp)) (by aesop_cat)
+      (by simp) (by simp) (by simp)) (by cat_disch)
 
 
 variable (C) in
@@ -147,7 +147,7 @@ def mapTriangleIso {F₁ F₂ : C ⥤ D} (e : F₁ ≅ F₂) [F₁.CommShift ℤ
     Triangle.isoMk _ _ (e.app _) (e.app _) (e.app _) (by simp) (by simp) (by
       dsimp
       simp only [assoc, NatTrans.shift_app_comm e.hom (1 : ℤ) T.obj₁,
-        NatTrans.naturality_assoc])) (by aesop_cat)
+        NatTrans.naturality_assoc])) (by cat_disch)
 
 end Additive
 

--- a/Mathlib/CategoryTheory/Triangulated/Opposite/Triangle.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Opposite/Triangle.lean
@@ -76,7 +76,7 @@ noncomputable def unitIso : 𝟭 _ ≅ functor C ⋙ inverse C :=
     (Triangle.isoMk _ _ (Iso.refl _) (Iso.refl _) (Iso.refl _) (by simp) (by simp)
       (Quiver.Hom.op_inj
         (by simp [shift_unop_opShiftFunctorEquivalence_counitIso_inv_app]))))
-    (fun {T₁ T₂} f => Quiver.Hom.unop_inj (by aesop_cat))
+    (fun {T₁ T₂} f => Quiver.Hom.unop_inj (by cat_disch))
 
 /-- The counit isomorphism of the
 equivalence `triangleOpEquivalence C : (Triangle C)ᵒᵖ ≌ Triangle Cᵒᵖ` . -/
@@ -92,7 +92,7 @@ noncomputable def counitIso : inverse C ⋙ functor C ≅ 𝟭 _ :=
         opShiftFunctorEquivalence_counitIso_inv_app_shift, ← Functor.map_comp,
         Iso.hom_inv_id_app, Functor.map_id]
       simp only [Functor.id_obj, comp_id])
-    (by aesop_cat)
+    (by cat_disch)
 
 end TriangleOpEquivalence
 

--- a/Mathlib/CategoryTheory/Triangulated/Pretriangulated.lean
+++ b/Mathlib/CategoryTheory/Triangulated/Pretriangulated.lean
@@ -172,7 +172,7 @@ lemma distinguished_cocone_triangle₂ {Z X : C} (h : Z ⟶ X⟦(1 : ℤ)⟧) :
   refine ⟨T'.obj₂, ((shiftEquiv C (1 : ℤ)).unitIso.app X).hom ≫ T'.mor₁, T'.mor₂,
     isomorphic_distinguished _ (inv_rot_of_distTriang _ (inv_rot_of_distTriang _ mem)) _ ?_⟩
   exact Triangle.isoMk _ _ ((shiftEquiv C (1 : ℤ)).unitIso.app X) (Iso.refl _) (Iso.refl _)
-    (by aesop_cat) (by aesop_cat)
+    (by cat_disch) (by cat_disch)
     (by dsimp; simp only [shift_shiftFunctorCompIsoId_inv_app, id_comp])
 
 /-- A commutative square involving the morphisms `mor₂` of two distinguished triangles
@@ -232,7 +232,7 @@ include hT
 lemma yoneda_exact₂ {X : C} (f : T.obj₂ ⟶ X) (hf : T.mor₁ ≫ f = 0) :
     ∃ (g : T.obj₃ ⟶ X), f = T.mor₂ ≫ g := by
   obtain ⟨g, ⟨hg₁, _⟩⟩ := complete_distinguished_triangle_morphism T _ hT
-    (contractible_distinguished₁ X) 0 f (by aesop_cat)
+    (contractible_distinguished₁ X) 0 f (by cat_disch)
   exact ⟨g, by simpa using hg₁.symm⟩
 
 lemma yoneda_exact₃ {X : C} (f : T.obj₃ ⟶ X) (hf : T.mor₂ ≫ f = 0) :
@@ -242,12 +242,12 @@ lemma yoneda_exact₃ {X : C} (f : T.obj₃ ⟶ X) (hf : T.mor₂ ≫ f = 0) :
 lemma coyoneda_exact₂ {X : C} (f : X ⟶ T.obj₂) (hf : f ≫ T.mor₂ = 0) :
     ∃ (g : X ⟶ T.obj₁), f = g ≫ T.mor₁ := by
   obtain ⟨a, ⟨ha₁, _⟩⟩ := complete_distinguished_triangle_morphism₁ _ T
-    (contractible_distinguished X) hT f 0 (by aesop_cat)
+    (contractible_distinguished X) hT f 0 (by cat_disch)
   exact ⟨a, by simpa using ha₁⟩
 
 lemma coyoneda_exact₁ {X : C} (f : X ⟶ T.obj₁⟦(1 : ℤ)⟧) (hf : f ≫ T.mor₁⟦1⟧' = 0) :
     ∃ (g : X ⟶ T.obj₃), f = g ≫ T.mor₃ :=
-  coyoneda_exact₂ _ (rot_of_distTriang _ (rot_of_distTriang _ hT)) f (by aesop_cat)
+  coyoneda_exact₂ _ (rot_of_distTriang _ (rot_of_distTriang _ hT)) f (by cat_disch)
 
 lemma coyoneda_exact₃ {X : C} (f : X ⟶ T.obj₃) (hf : f ≫ T.mor₃ = 0) :
     ∃ (g : X ⟶ T.obj₂), f = g ≫ T.mor₂ :=
@@ -525,7 +525,7 @@ lemma binaryBiproductTriangle_distinguished (X₁ X₂ : C) :
   dsimp at he₁ he₂
   refine isomorphic_distinguished _ mem _ (Iso.symm ?_)
   refine Triangle.isoMk _ _ (Iso.refl _) e (Iso.refl _)
-    (by aesop_cat) (by aesop_cat) (by simp)
+    (by cat_disch) (by cat_disch) (by simp)
 
 lemma binaryProductTriangle_distinguished (X₁ X₂ : C) :
     binaryProductTriangle X₁ X₂ ∈ distTriang C :=
@@ -564,8 +564,8 @@ lemma productTriangle_distinguished {J : Type*} (T : J → Triangle C)
   let φ : ∀ j, T' ⟶ T j := fun j => completeDistinguishedTriangleMorphism _ _
     hT' (hT j) (Pi.π _ j) (Pi.π _ j) (by simp [f₁, T'])
   let φ' := productTriangle.lift _ φ
-  have h₁ : φ'.hom₁ = 𝟙 _ := by aesop_cat
-  have h₂ : φ'.hom₂ = 𝟙 _ := by aesop_cat
+  have h₁ : φ'.hom₁ = 𝟙 _ := by cat_disch
+  have h₂ : φ'.hom₂ = 𝟙 _ := by cat_disch
   have : IsIso φ'.hom₁ := by rw [h₁]; infer_instance
   have : IsIso φ'.hom₂ := by rw [h₂]; infer_instance
   suffices IsIso φ'.hom₃ by

--- a/Mathlib/CategoryTheory/Triangulated/TriangleShift.lean
+++ b/Mathlib/CategoryTheory/Triangulated/TriangleShift.lean
@@ -72,7 +72,7 @@ noncomputable def Triangle.shiftFunctorZero : Triangle.shiftFunctor C 0 ≅ 𝟭
         simp only [one_smul, assoc, shiftFunctorComm_zero_hom_app,
           ← Functor.map_comp, Iso.inv_hom_id_app, Functor.id_obj, Functor.map_id,
           comp_id, NatTrans.naturality, Functor.id_map]))
-    (by aesop_cat)
+    (by cat_disch)
 
 /-- The canonical isomorphism
 `Triangle.shiftFunctor C n ≅ Triangle.shiftFunctor C a ⋙ Triangle.shiftFunctor C b`
@@ -104,7 +104,7 @@ noncomputable def Triangle.shiftFunctorAdd' (a b n : ℤ) (h : a + b = n) :
         erw [← NatTrans.naturality_assoc]
         simp only [shiftFunctorAdd'_eq_shiftFunctorAdd, Int.negOnePow_add,
           shiftFunctorComm_hom_app_comp_shift_shiftFunctorAdd_hom_app, add_comm a]))
-    (by aesop_cat)
+    (by cat_disch)
 
 /-- Rotating triangles three times identifies with the shift by `1`. -/
 noncomputable def rotateRotateRotateIso :
@@ -112,7 +112,7 @@ noncomputable def rotateRotateRotateIso :
   NatIso.ofComponents
     (fun T => Triangle.isoMk _ _ (Iso.refl _) (Iso.refl _) (Iso.refl _)
       (by simp) (by simp) (by simp))
-    (by aesop_cat)
+    (by cat_disch)
 
 /-- Rotating triangles three times backwards identifies with the shift by `-1`. -/
 noncomputable def invRotateInvRotateInvRotateIso :
@@ -124,7 +124,7 @@ noncomputable def invRotateInvRotateInvRotateIso :
       (by
         dsimp [shiftFunctorCompIsoId]
         simp [shiftFunctorComm_eq C _ _ _ (add_neg_cancel (1 : ℤ))]))
-    (by aesop_cat)
+    (by cat_disch)
 
 /-- The inverse of the rotation of triangles can be expressed using a double
 rotation and the shift by `-1`. -/

--- a/Mathlib/CategoryTheory/Types.lean
+++ b/Mathlib/CategoryTheory/Types.lean
@@ -150,7 +150,7 @@ theorem comp (x : F.obj X) : (σ ≫ τ).app X x = τ.app X (σ.app X x) :=
 @[simp]
 theorem eqToHom_map_comp_apply (p : X = Y) (q : Y = Z) (x : F.obj X) :
     F.map (eqToHom q) (F.map (eqToHom p) x) = F.map (eqToHom <| p.trans q) x := by
-  aesop_cat
+  cat_disch
 
 variable {D : Type u'} [𝒟 : Category.{u'} D] (I J : D ⥤ C) (ρ : I ⟶ J) {W : D}
 
@@ -359,7 +359,7 @@ instance : SplitEpiCategory (Type u) where
 end CategoryTheory
 
 -- We prove `equivIsoIso` and then use that to sneakily construct `equivEquivIso`.
--- (In this order the proofs are handled by `aesop_cat`.)
+-- (In this order the proofs are handled by `cat_disch`.)
 /-- Equivalences (between types in the same universe) are the same as (isomorphic to) isomorphisms
 of types. -/
 @[simps]

--- a/Mathlib/CategoryTheory/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Whiskering.lean
@@ -251,7 +251,7 @@ lemma isoWhiskerRight_symm {G H : C ⥤ D} (α : G ≅ H) (F : D ⥤ E) :
 @[simp]
 lemma isoWhiskerRight_refl (F : C ⥤ D) (G : D ⥤ E) :
     isoWhiskerRight (Iso.refl F) G = Iso.refl _ := by
-  aesop_cat
+  cat_disch
 
 instance isIso_whiskerLeft (F : C ⥤ D) {G H : D ⥤ E} (α : G ⟶ H) [IsIso α] :
     IsIso (whiskerLeft F α) :=
@@ -297,45 +297,45 @@ variable {B : Type u₄} [Category.{v₄} B]
 theorem whiskerLeft_twice (F : B ⥤ C) (G : C ⥤ D) {H K : D ⥤ E} (α : H ⟶ K) :
     whiskerLeft F (whiskerLeft G α) =
     (Functor.associator _ _ _).inv ≫ whiskerLeft (F ⋙ G) α ≫ (Functor.associator _ _ _).hom := by
-  aesop_cat
+  cat_disch
 
 @[simp]
 theorem whiskerRight_twice {H K : B ⥤ C} (F : C ⥤ D) (G : D ⥤ E) (α : H ⟶ K) :
     whiskerRight (whiskerRight α F) G =
     (Functor.associator _ _ _).hom ≫ whiskerRight α (F ⋙ G) ≫ (Functor.associator _ _ _).inv := by
-  aesop_cat
+  cat_disch
 
 theorem whiskerRight_left (F : B ⥤ C) {G H : C ⥤ D} (α : G ⟶ H) (K : D ⥤ E) :
     whiskerRight (whiskerLeft F α) K =
     (Functor.associator _ _ _).hom ≫ whiskerLeft F (whiskerRight α K) ≫
       (Functor.associator _ _ _).inv := by
-  aesop_cat
+  cat_disch
 
 @[simp]
 theorem isoWhiskerLeft_twice (F : B ⥤ C) (G : C ⥤ D) {H K : D ⥤ E} (α : H ≅ K) :
     isoWhiskerLeft F (isoWhiskerLeft G α) =
     (Functor.associator _ _ _).symm ≪≫ isoWhiskerLeft (F ⋙ G) α ≪≫ Functor.associator _ _ _ := by
-  aesop_cat
+  cat_disch
 
 @[simp, reassoc]
 theorem isoWhiskerRight_twice {H K : B ⥤ C} (F : C ⥤ D) (G : D ⥤ E) (α : H ≅ K) :
     isoWhiskerRight (isoWhiskerRight α F) G =
     Functor.associator _ _ _ ≪≫ isoWhiskerRight α (F ⋙ G) ≪≫ (Functor.associator _ _ _).symm := by
-  aesop_cat
+  cat_disch
 
 @[reassoc]
 theorem isoWhiskerRight_left (F : B ⥤ C) {G H : C ⥤ D} (α : G ≅ H) (K : D ⥤ E) :
     isoWhiskerRight (isoWhiskerLeft F α) K =
     Functor.associator _ _ _ ≪≫ isoWhiskerLeft F (isoWhiskerRight α K) ≪≫
       (Functor.associator _ _ _).symm := by
-  aesop_cat
+  cat_disch
 
 @[reassoc]
 theorem isoWhiskerLeft_right (F : B ⥤ C) {G H : C ⥤ D} (α : G ≅ H) (K : D ⥤ E) :
     isoWhiskerLeft F (isoWhiskerRight α K) =
     (Functor.associator _ _ _).symm ≪≫ isoWhiskerRight (isoWhiskerLeft F α) K ≪≫
       Functor.associator _ _ _ := by
-  aesop_cat
+  cat_disch
 
 end
 

--- a/Mathlib/CategoryTheory/Whiskering.lean
+++ b/Mathlib/CategoryTheory/Whiskering.lean
@@ -348,22 +348,22 @@ variable {A : Type u₁} [Category.{v₁} A] {B : Type u₂} [Category.{v₂} B]
 @[reassoc]
 theorem triangleIso :
     associator F (𝟭 B) G ≪≫ isoWhiskerLeft F (leftUnitor G) =
-      isoWhiskerRight (rightUnitor F) G := by aesop_cat
+      isoWhiskerRight (rightUnitor F) G := by cat_disch
 
 @[reassoc]
 theorem pentagonIso :
     isoWhiskerRight (associator F G H) K ≪≫
         associator F (G ⋙ H) K ≪≫ isoWhiskerLeft F (associator G H K) =
-      associator (F ⋙ G) H K ≪≫ associator F G (H ⋙ K) := by aesop_cat
+      associator (F ⋙ G) H K ≪≫ associator F G (H ⋙ K) := by cat_disch
 
 theorem triangle :
     (associator F (𝟭 B) G).hom ≫ whiskerLeft F (leftUnitor G).hom =
-      whiskerRight (rightUnitor F).hom G := by aesop_cat
+      whiskerRight (rightUnitor F).hom G := by cat_disch
 
 theorem pentagon :
     whiskerRight (associator F G H).hom K ≫
         (associator F (G ⋙ H) K).hom ≫ whiskerLeft F (associator G H K).hom =
-      (associator (F ⋙ G) H K).hom ≫ (associator F G (H ⋙ K)).hom := by aesop_cat
+      (associator (F ⋙ G) H K).hom ≫ (associator F G (H ⋙ K)).hom := by cat_disch
 
 variable {C₁ C₂ C₃ D₁ D₂ D₃ : Type*} [Category C₁] [Category C₂] [Category C₃]
   [Category D₁] [Category D₂] [Category D₃] (E : Type*) [Category E]

--- a/Mathlib/CategoryTheory/WithTerminal/Basic.lean
+++ b/Mathlib/CategoryTheory/WithTerminal/Basic.lean
@@ -141,7 +141,7 @@ def map {D : Type*} [Category D] (F : C ⥤ D) : WithTerminal C ⥤ WithTerminal
 def mapId (C : Type*) [Category C] : map (𝟭 C) ≅ 𝟭 (WithTerminal C) :=
   NatIso.ofComponents (fun X => match X with
     | of _ => Iso.refl _
-    | star => Iso.refl _) (by aesop_cat)
+    | star => Iso.refl _) (by cat_disch)
 
 /-- A natural isomorphism between the functor `map (F ⋙ G) ` and `map F ⋙ map G `. -/
 @[simps!]
@@ -149,7 +149,7 @@ def mapComp {D E : Type*} [Category D] [Category E] (F : C ⥤ D) (G : D ⥤ E) 
     map (F ⋙ G) ≅ map F ⋙ map G :=
   NatIso.ofComponents (fun X => match X with
     | of _ => Iso.refl _
-    | star => Iso.refl _) (by aesop_cat)
+    | star => Iso.refl _) (by cat_disch)
 
 /-- From a natural transformation of functors `C ⥤ D`, the induced natural transformation
 of functors `WithTerminal C ⥤ WithTerminal D`. -/
@@ -265,7 +265,7 @@ instance {X : WithTerminal C} : Unique (X ⟶ star) where
     match X with
     | of _ => PUnit.unit
     | star => PUnit.unit
-  uniq := by aesop_cat
+  uniq := by cat_disch
 
 /-- `WithTerminal.star` is terminal. -/
 def starTerminal : Limits.IsTerminal (star : WithTerminal C) :=
@@ -522,7 +522,7 @@ def map {D : Type*} [Category D] (F : C ⥤ D) : WithInitial C ⥤ WithInitial D
 def mapId (C : Type*) [Category C] : map (𝟭 C) ≅ 𝟭 (WithInitial C) :=
   NatIso.ofComponents (fun X => match X with
     | of _ => Iso.refl _
-    | star => Iso.refl _) (by aesop_cat)
+    | star => Iso.refl _) (by cat_disch)
 
 /-- A natural isomorphism between the functor `map (F ⋙ G) ` and `map F ⋙ map G `. -/
 @[simps!]
@@ -530,7 +530,7 @@ def mapComp {D E : Type*} [Category D] [Category E] (F : C ⥤ D) (G : D ⥤ E) 
     map (F ⋙ G) ≅ map F ⋙ map G :=
   NatIso.ofComponents (fun X => match X with
     | of _ => Iso.refl _
-    | star => Iso.refl _) (by aesop_cat)
+    | star => Iso.refl _) (by cat_disch)
 
 /-- From a natural transformation of functors `C ⥤ D`, the induced natural transformation
 of functors `WithInitial C ⥤ WithInitial D`. -/
@@ -645,7 +645,7 @@ instance {X : WithInitial C} : Unique (star ⟶ X) where
     match X with
     | of _x => PUnit.unit
     | star => PUnit.unit
-  uniq := by aesop_cat
+  uniq := by cat_disch
 
 /-- `WithInitial.star` is initial. -/
 def starInitial : Limits.IsInitial (star : WithInitial C) :=

--- a/Mathlib/CategoryTheory/WithTerminal/Basic.lean
+++ b/Mathlib/CategoryTheory/WithTerminal/Basic.lean
@@ -96,8 +96,8 @@ instance : Category.{v} (WithTerminal C) where
     -- Porting note: it would be nice to automate this away as well.
     -- I tried splitting this into separate `Quiver` and `Category` instances,
     -- so the `false_of_from_star` destruct rule below can be used here.
-    -- That works, but causes mysterious failures of `aesop_cat` in `map`.
-    cases a <;> cases b <;> cases c <;> cases d <;> try aesop_cat
+    -- That works, but causes mysterious failures of `cat_disch` in `map`.
+    cases a <;> cases b <;> cases c <;> cases d <;> try cat_disch
     · exact (h : PEmpty).elim
     · exact (g : PEmpty).elim
     · exact (h : PEmpty).elim
@@ -478,7 +478,7 @@ instance : Category.{v} (WithInitial C) where
   assoc {a b c d} f g h := by
     -- Porting note: it would be nice to automate this away as well.
     -- See the note on `Category (WithTerminal C)`
-    cases a <;> cases b <;> cases c <;> cases d <;> try aesop_cat
+    cases a <;> cases b <;> cases c <;> cases d <;> try cat_disch
     · exact (g : PEmpty).elim
     · exact (f : PEmpty).elim
     · exact (f : PEmpty).elim

--- a/Mathlib/CategoryTheory/WithTerminal/Cone.lean
+++ b/Mathlib/CategoryTheory/WithTerminal/Cone.lean
@@ -72,7 +72,7 @@ private def coneLift : Cone K ⥤ Cone (liftFromOver.obj K) where
   map {t₁ t₂} f := {
     hom := f.hom.left
     w
-    | star => by aesop_cat
+    | star => by cat_disch
     | of a => by simp [← Comma.comp_left]
   }
 
@@ -184,7 +184,7 @@ private def coconeLift : Cocone K ⥤ Cocone (liftFromUnder.obj K) where
   map {t₁ t₂} f := {
     hom := f.hom.right
     w
-    | star => by aesop_cat
+    | star => by cat_disch
     | of a => by simp [← Comma.comp_right]
   }
 

--- a/Mathlib/CategoryTheory/Yoneda.lean
+++ b/Mathlib/CategoryTheory/Yoneda.lean
@@ -628,7 +628,7 @@ lemma isIso_of_yoneda_map_bijective {X Y : C} (f : X ⟶ Y)
     (hf : ∀ (T : C), Function.Bijective (fun (x : T ⟶ X) => x ≫ f)) :
     IsIso f := by
   obtain ⟨g, hg : g ≫ f = 𝟙 Y⟩ := (hf Y).2 (𝟙 Y)
-  exact ⟨g, (hf _).1 (by aesop_cat), hg⟩
+  exact ⟨g, (hf _).1 (by cat_disch), hg⟩
 
 lemma isIso_iff_yoneda_map_bijective {X Y : C} (f : X ⟶ Y) :
     IsIso f ↔ (∀ (T : C), Function.Bijective (fun (x : T ⟶ X) => x ≫ f)) := by

--- a/Mathlib/Combinatorics/Quiver/ReflQuiver.lean
+++ b/Mathlib/Combinatorics/Quiver/ReflQuiver.lean
@@ -44,7 +44,7 @@ instance catToReflQuiver {C : Type u} [inst : Category.{v} C] : ReflQuiver.{v+1,
 structure ReflPrefunctor (V : Type u₁) [ReflQuiver.{v₁} V] (W : Type u₂) [ReflQuiver.{v₂} W]
     extends Prefunctor V W where
   /-- A functor preserves identity morphisms. -/
-  map_id : ∀ X : V, map (𝟙rq X) = 𝟙rq (obj X) := by aesop_cat
+  map_id : ∀ X : V, map (𝟙rq X) = 𝟙rq (obj X) := by cat_disch
 
 namespace ReflPrefunctor
 

--- a/Mathlib/Geometry/Manifold/Sheaf/Smooth.lean
+++ b/Mathlib/Geometry/Manifold/Sheaf/Smooth.lean
@@ -322,7 +322,7 @@ def smoothSheafCommRing.evalHom (x : TopCat.of M) :
     (smoothSheafCommRing IM I M R).presheaf.stalk x ⟶ CommRingCat.of R := by
   refine CategoryTheory.Limits.colimit.desc _ ⟨_, ⟨fun U ↦ ?_, ?_⟩⟩
   · apply smoothSheafCommRing.evalAt
-  · aesop_cat
+  · cat_disch
 
 /-- Canonical ring homomorphism from the stalk of `smoothSheafCommRing IM I M R` at `x` to `R`,
 given by evaluating sections at `x`. -/

--- a/Mathlib/Geometry/RingedSpace/LocallyRingedSpace.lean
+++ b/Mathlib/Geometry/RingedSpace/LocallyRingedSpace.lean
@@ -277,7 +277,7 @@ def emptyTo (X : LocallyRingedSpace.{u}) : ∅ ⟶ X :=
 noncomputable
 instance {X : LocallyRingedSpace.{u}} : Unique (∅ ⟶ X) where
   default := LocallyRingedSpace.emptyTo X
-  uniq f := by ext ⟨⟩ x; aesop_cat
+  uniq f := by ext ⟨⟩ x; cat_disch
 
 /-- The empty space is initial in `LocallyRingedSpace`. -/
 noncomputable

--- a/Mathlib/RepresentationTheory/Rep.lean
+++ b/Mathlib/RepresentationTheory/Rep.lean
@@ -896,8 +896,8 @@ def unitIso (V : Rep k G) : V ≅ (toModuleMonoidAlgebra ⋙ ofModuleMonoidAlgeb
 def equivalenceModuleMonoidAlgebra : Rep k G ≌ ModuleCat.{u} (MonoidAlgebra k G) where
   functor := toModuleMonoidAlgebra
   inverse := ofModuleMonoidAlgebra
-  unitIso := NatIso.ofComponents (fun V => unitIso V) (by aesop_cat)
-  counitIso := NatIso.ofComponents (fun M => counitIso M) (by aesop_cat)
+  unitIso := NatIso.ofComponents (fun V => unitIso V) (by cat_disch)
+  counitIso := NatIso.ofComponents (fun M => counitIso M) (by cat_disch)
 
 -- TODO Verify that the equivalence with `ModuleCat (MonoidAlgebra k G)` is a monoidal functor.
 end

--- a/Mathlib/Topology/Category/Profinite/AsLimit.lean
+++ b/Mathlib/Topology/Category/Profinite/AsLimit.lean
@@ -43,9 +43,9 @@ variable (X : Profinite.{u})
 def fintypeDiagram : DiscreteQuotient X ⥤ FintypeCat where
   obj S := @FintypeCat.of S (Fintype.ofFinite S)
   map f := DiscreteQuotient.ofLE f.le
-  -- Porting note: `map_comp` used to be proved by default by `aesop_cat`.
-  -- once `aesop_cat` can prove this again, remove the entire `map_comp` here.
-  map_comp _ _ := by funext; aesop_cat
+  -- Porting note: `map_comp` used to be proved by default by `cat_disch`.
+  -- once `cat_disch` can prove this again, remove the entire `map_comp` here.
+  map_comp _ _ := by funext; cat_disch
 
 /-- An abbreviation for `X.fintypeDiagram ⋙ FintypeCat.toProfinite`. -/
 abbrev diagram : DiscreteQuotient X ⥤ Profinite :=

--- a/Mathlib/Topology/Category/TopCat/Limits/Products.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Products.lean
@@ -90,7 +90,7 @@ def sigmaCofanIsColimit {ι : Type v} (β : ι → TopCat.{max v u}) : IsColimit
     congr
   fac s j := by
     cases j
-    aesop_cat
+    cat_disch
 
 /-- The coproduct is homeomorphic to the disjoint union of the topological spaces.
 -/

--- a/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
@@ -138,7 +138,7 @@ theorem range_pullback_to_prod {X Y Z : TopCat} (f : X ⟶ Z) (g : Y ⟶ Z) :
     rintro ⟨⟨⟩⟩ <;>
       rw [← ConcreteCategory.comp_apply, ← ConcreteCategory.comp_apply, limit.lift_π] <;>
       -- This used to be `simp` before https://github.com/leanprover/lean4/pull/2644
-      aesop_cat
+      cat_disch
 
 /-- The pullback along an embedding is (isomorphic to) the preimage. -/
 noncomputable

--- a/Mathlib/Topology/Sheaves/CommRingCat.lean
+++ b/Mathlib/Topology/Sheaves/CommRingCat.lean
@@ -244,8 +244,8 @@ def pullback {X Y : TopCatᵒᵖ} (f : X ⟶ Y) (R : TopCommRingCat) :
   { toFun g := f.unop ≫ g
     map_one' := rfl
     map_zero' := rfl
-    map_add' := by aesop_cat
-    map_mul' := by aesop_cat }
+    map_add' := by cat_disch
+    map_mul' := by cat_disch }
 
 /-- A homomorphism of topological rings can be postcomposed with functions from a source space `X`;
 this is a ring homomorphism (with respect to the pointwise ring operations on functions). -/

--- a/Mathlib/Topology/Sheaves/Presheaf.lean
+++ b/Mathlib/Topology/Sheaves/Presheaf.lean
@@ -210,7 +210,7 @@ theorem pushforward_eq' {X Y : TopCat.{w}} {f g : X ⟶ Y} (h : f = g) (ℱ : X.
 @[simp]
 theorem pushforwardEq_hom_app {X Y : TopCat.{w}} {f g : X ⟶ Y}
     (h : f = g) (ℱ : X.Presheaf C) (U) :
-    (pushforwardEq h ℱ).hom.app U = ℱ.map (eqToHom (by aesop_cat)) := by
+    (pushforwardEq h ℱ).hom.app U = ℱ.map (eqToHom (by cat_disch)) := by
   simp [pushforwardEq]
 
 variable (C)

--- a/Mathlib/Topology/Sheaves/Sheaf.lean
+++ b/Mathlib/Topology/Sheaves/Sheaf.lean
@@ -84,7 +84,7 @@ nonrec def IsSheaf (F : Presheaf.{w, v, u} C X) : Prop :=
 /-- The presheaf valued in `Unit` over any topological space is a sheaf.
 -/
 theorem isSheaf_unit (F : Presheaf (CategoryTheory.Discrete Unit) X) : F.IsSheaf :=
-  fun x U S _ x _ => ⟨eqToHom (Subsingleton.elim _ _), by aesop_cat, fun _ => by aesop_cat⟩
+  fun x U S _ x _ => ⟨eqToHom (Subsingleton.elim _ _), by cat_disch, fun _ => by cat_disch⟩
 
 theorem isSheaf_iso_iff {F G : Presheaf C X} (α : F ≅ G) : F.IsSheaf ↔ G.IsSheaf :=
   Presheaf.isSheaf_of_iso_iff α

--- a/Mathlib/Topology/Sheaves/SheafCondition/PairwiseIntersections.lean
+++ b/Mathlib/Topology/Sheaves/SheafCondition/PairwiseIntersections.lean
@@ -219,7 +219,7 @@ def pairwiseCoconeIso :
     (Pairwise.cocone U).op ≅
       (Cones.postcomposeEquivalence (NatIso.op (pairwiseDiagramIso U :) :)).functor.obj
         ((opensLeCoverCocone U).op.whisker (pairwiseToOpensLeCover U).op) :=
-  Cones.ext (Iso.refl _) (by aesop_cat)
+  Cones.ext (Iso.refl _) (by cat_disch)
 
 end SheafCondition
 

--- a/Mathlib/Topology/Sheaves/Skyscraper.lean
+++ b/Mathlib/Topology/Sheaves/Skyscraper.lean
@@ -93,14 +93,14 @@ def SkyscraperPresheafFunctor.map' {a b : C} (f : a ⟶ b) :
 theorem SkyscraperPresheafFunctor.map'_id {a : C} :
     SkyscraperPresheafFunctor.map' p₀ (𝟙 a) = 𝟙 _ := by
   ext U
-  simp only [SkyscraperPresheafFunctor.map'_app]; split_ifs <;> aesop_cat
+  simp only [SkyscraperPresheafFunctor.map'_app]; split_ifs <;> cat_disch
 
 theorem SkyscraperPresheafFunctor.map'_comp {a b c : C} (f : a ⟶ b) (g : b ⟶ c) :
     SkyscraperPresheafFunctor.map' p₀ (f ≫ g) =
       SkyscraperPresheafFunctor.map' p₀ f ≫ SkyscraperPresheafFunctor.map' p₀ g := by
   ext U
   simp only [SkyscraperPresheafFunctor.map'_app]
-  split_ifs with h <;> aesop_cat
+  split_ifs with h <;> cat_disch
 
 /-- Taking skyscraper presheaf at a point is functorial: `c ↦ skyscraper p₀ c` defines a functor by
 sending every `f : a ⟶ b` to the natural transformation `α` defined as: `α(U) = f : a ⟶ b` if

--- a/MathlibTest/aesop_cat.lean
+++ b/MathlibTest/aesop_cat.lean
@@ -2,7 +2,7 @@ import Mathlib.CategoryTheory.Category.Basic
 
 structure Foo where
   x : Nat
-  w : x = 37 := by aesop_cat
+  w : x = 37 := by cat_disch
 
 /-- warning: declaration uses 'sorry' -/
 #guard_msgs in


### PR DESCRIPTION
This PR
* replaces `aesop_cat` with `cat_disch`
* by default, `cat_disch` calls the original implementation of `aesop_cat`
* but an option configures it to call `grind` instead
* and adds logging options

To make further use of `grind` in the category theory library:
1. Turn on `set_option mathlib.tactic.category.log_aesop`.
2. Run `lake build`
3. In files that report they are using `aesop` as the discharger, add `set_option mathlib.tactic.category.grind true` (and leave this set in your PR), and fix any problems.
4. Eventually, we can consider changing over the defaults.

I have a branch `grind_cat` which starts switching over to the `grind` based discharger. It can close many goals that `aesop_cat` can't.

This looks like a huge PR, but besides the changes to `Mathlib/CategoryTheory/Category/Basic.lean` and `Mathlib/CategoryTheory/Category/Init.lean`, all other changes are search and replace `by aesop_cat` to `by cat_disch`.