### PR TITLE
[Merged by Bors] - feat(Topology/Algebra/Module/LinearMap): add `ContinuousLinearMap.isIdempotentElem_toLinearMap_iff`

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
@@ -353,8 +353,7 @@ theorem isStarProjection_iff_isIdempotentElem_and_isStarNormal :
   rw [isStarProjection_iff, and_congr_right_iff]
   exact fun h => IsIdempotentElem.isSelfAdjoint_iff_isStarNormal h
 
-open ContinuousLinearMap
-
+open ContinuousLinearMap in
 omit [CompleteSpace E] in
 /-- An idempotent operator `T` is symmetric iff `(range T)ᗮ = ker T`. -/
 theorem IsIdempotentElem.isSymmetric_iff_orthogonal_range (h : IsIdempotentElem T) :

--- a/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
@@ -353,11 +353,13 @@ theorem isStarProjection_iff_isIdempotentElem_and_isStarNormal :
   rw [isStarProjection_iff, and_congr_right_iff]
   exact fun h => IsIdempotentElem.isSelfAdjoint_iff_isStarNormal h
 
+open ContinuousLinearMap
+
 omit [CompleteSpace E] in
 /-- An idempotent operator `T` is symmetric iff `(range T)ᗮ = ker T`. -/
 theorem IsIdempotentElem.isSymmetric_iff_orthogonal_range (h : IsIdempotentElem T) :
     T.IsSymmetric ↔ (LinearMap.range T)ᗮ = LinearMap.ker T :=
-  LinearMap.IsIdempotentElem.isSymmetric_iff_orthogonal_range congr(LinearMapClass.linearMap $h.eq)
+  LinearMap.IsIdempotentElem.isSymmetric_iff_orthogonal_range h.toLinearMap
 
 open ContinuousLinearMap in
 /-- Star projection operators are equal iff their range are. -/
@@ -590,8 +592,8 @@ theorem _root_.ContinuousLinearMap.isSelfAdjoint_toLinearMap_iff (T : E →L[�
 theorem isStarProjection_toContinuousLinearMap_iff {T : E →ₗ[𝕜] E} :
     have := FiniteDimensional.complete 𝕜 E
     IsStarProjection (toContinuousLinearMap T) ↔ IsStarProjection T := by
-  simp [isStarProjection_iff, isSelfAdjoint_toContinuousLinearMap_iff, IsIdempotentElem,
-    ContinuousLinearMap.ext_iff, LinearMap.ext_iff, ← Module.End.mul_apply]
+  simp [isStarProjection_iff, isSelfAdjoint_toContinuousLinearMap_iff,
+    ← ContinuousLinearMap.isIdempotentElem_toLinearMap_iff]
 
 open LinearMap in
 /-- Star projection operators are equal iff their range are. -/

--- a/Mathlib/Analysis/InnerProductSpace/Positive.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Positive.lean
@@ -359,8 +359,7 @@ end PartialOrder
 @[grind →]
 theorem IsIdempotentElem.isPositive_iff_isSelfAdjoint
     {p : E →L[𝕜] E} (hp : IsIdempotentElem p) : p.IsPositive ↔ IsSelfAdjoint p := by
-  rw [← isPositive_toLinearMap_iff, IsIdempotentElem.isPositive_iff_isSymmetric
-    (congr(LinearMapClass.linearMap $hp.eq))]
+  rw [← isPositive_toLinearMap_iff, IsIdempotentElem.isPositive_iff_isSymmetric hp.toLinearMap]
   exact isSelfAdjoint_iff_isSymmetric.symm
 
 /-- A star projection operator is positive.

--- a/Mathlib/Topology/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearMap.lean
@@ -1140,12 +1140,12 @@ theorem ContinuousLinearMap.closedComplemented_ker_of_rightInverse {R : Type*} [
 
 namespace ContinuousLinearMap
 
-theorem IsIdempotentElem.toLinearMap_iff {R M : Type*} [Semiring R] [TopologicalSpace M]
+theorem isIdempotentElem_toLinearMap_iff {R M : Type*} [Semiring R] [TopologicalSpace M]
     [AddCommMonoid M] [Module R M] {f : M →L[R] M} :
     IsIdempotentElem f.toLinearMap ↔ IsIdempotentElem f := by
   simp only [IsIdempotentElem, Module.End.mul_eq_comp, ← coe_comp, mul_def, coe_inj]
 
-alias ⟨_, IsIdempotentElem.toLinearMap⟩ := IsIdempotentElem.toLinearMap_iff
+alias ⟨_, IsIdempotentElem.toLinearMap⟩ := isIdempotentElem_toLinearMap_iff
 
 variable {R M : Type*} [Ring R] [TopologicalSpace M] [AddCommGroup M] [Module R M]
 

--- a/Mathlib/Topology/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearMap.lean
@@ -1140,6 +1140,7 @@ theorem ContinuousLinearMap.closedComplemented_ker_of_rightInverse {R : Type*} [
 
 namespace ContinuousLinearMap
 
+@[grind =]
 theorem isIdempotentElem_toLinearMap_iff {R M : Type*} [Semiring R] [TopologicalSpace M]
     [AddCommMonoid M] [Module R M] {f : M →L[R] M} :
     IsIdempotentElem f.toLinearMap ↔ IsIdempotentElem f := by

--- a/Mathlib/Topology/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearMap.lean
@@ -1139,15 +1139,23 @@ theorem ContinuousLinearMap.closedComplemented_ker_of_rightInverse {R : Type*} [
   ⟨f₁.projKerOfRightInverse f₂ h, f₁.projKerOfRightInverse_apply_idem f₂ h⟩
 
 namespace ContinuousLinearMap
+
+theorem IsIdempotentElem.toLinearMap_iff {R M : Type*} [Semiring R] [TopologicalSpace M]
+    [AddCommMonoid M] [Module R M] {f : M →L[R] M} :
+    IsIdempotentElem f.toLinearMap ↔ IsIdempotentElem f := by
+  simp only [IsIdempotentElem, Module.End.mul_eq_comp, ← coe_comp, mul_def, coe_inj]
+
+alias ⟨_, IsIdempotentElem.toLinearMap⟩ := IsIdempotentElem.toLinearMap_iff
+
 variable {R M : Type*} [Ring R] [TopologicalSpace M] [AddCommGroup M] [Module R M]
+
+open ContinuousLinearMap
 
 /-- Idempotent operators are equal iff their range and kernels are. -/
 lemma IsIdempotentElem.ext_iff {p q : M →L[R] M}
     (hp : IsIdempotentElem p) (hq : IsIdempotentElem q) :
     p = q ↔ range p = range q ∧ ker p = ker q := by
-  simpa using LinearMap.IsIdempotentElem.ext_iff
-    congr(LinearMapClass.linearMap $hp.eq)
-    congr(LinearMapClass.linearMap $hq.eq)
+  simpa using LinearMap.IsIdempotentElem.ext_iff hp.toLinearMap hq.toLinearMap
 
 alias ⟨_, IsIdempotentElem.ext⟩ := IsIdempotentElem.ext_iff
 
@@ -1157,8 +1165,7 @@ lemma IsIdempotentElem.range_mem_invtSubmodule_iff {f T : M →L[R] M}
     (hf : IsIdempotentElem f) :
     LinearMap.range f ∈ Module.End.invtSubmodule T ↔ f ∘L T ∘L f = T ∘L f := by
   simpa [← ContinuousLinearMap.coe_comp] using
-    LinearMap.IsIdempotentElem.range_mem_invtSubmodule_iff (T := T)
-    congr(LinearMapClass.linearMap $hf.eq)
+    LinearMap.IsIdempotentElem.range_mem_invtSubmodule_iff (T := T) hf.toLinearMap
 
 alias ⟨IsIdempotentElem.conj_eq_of_range_mem_invtSubmodule,
   IsIdempotentElem.range_mem_invtSubmodule⟩ := IsIdempotentElem.range_mem_invtSubmodule_iff
@@ -1169,8 +1176,7 @@ lemma IsIdempotentElem.ker_mem_invtSubmodule_iff {f T : M →L[R] M}
     (hf : IsIdempotentElem f) :
     LinearMap.ker f ∈ Module.End.invtSubmodule T ↔ f ∘L T ∘L f = f ∘L T := by
   simpa [← ContinuousLinearMap.coe_comp] using
-    LinearMap.IsIdempotentElem.ker_mem_invtSubmodule_iff (T := T)
-    congr(LinearMapClass.linearMap $hf.eq)
+    LinearMap.IsIdempotentElem.ker_mem_invtSubmodule_iff (T := T) hf.toLinearMap
 
 alias ⟨IsIdempotentElem.conj_eq_of_ker_mem_invtSubmodule,
   IsIdempotentElem.ker_mem_invtSubmodule⟩ := IsIdempotentElem.ker_mem_invtSubmodule_iff
@@ -1181,9 +1187,8 @@ lemma IsIdempotentElem.commute_iff {f T : M →L[R] M}
     (hf : IsIdempotentElem f) :
     Commute f T ↔ (LinearMap.range f ∈ Module.End.invtSubmodule T
       ∧ LinearMap.ker f ∈ Module.End.invtSubmodule T) := by
-  simpa [Commute, SemiconjBy, Module.End.mul_eq_comp, ← ContinuousLinearMap.coe_comp] using
-    LinearMap.IsIdempotentElem.commute_iff (T := T)
-    congr(LinearMapClass.linearMap $hf.eq)
+  simpa [Commute, SemiconjBy, Module.End.mul_eq_comp, ← coe_comp] using
+    LinearMap.IsIdempotentElem.commute_iff (T := T) hf.toLinearMap
 
 variable [IsTopologicalAddGroup M]
 
@@ -1195,16 +1200,15 @@ theorem IsIdempotentElem.commute_iff_of_isUnit {f T : M →L[R] M} (hT : IsUnit 
   have := hT.map ContinuousLinearMap.toLinearMapRingHom
   lift T to (M →L[R] M)ˣ using hT
   simpa [Commute, SemiconjBy, Module.End.mul_eq_comp, ← ContinuousLinearMap.coe_comp] using
-    LinearMap.IsIdempotentElem.commute_iff_of_isUnit
-    this congr(LinearMapClass.linearMap $hf.eq)
+    LinearMap.IsIdempotentElem.commute_iff_of_isUnit this hf.toLinearMap
 
 theorem IsIdempotentElem.range_eq_ker {p : M →L[R] M} (hp : IsIdempotentElem p) :
     LinearMap.range p = LinearMap.ker (1 - p) :=
-  LinearMap.IsIdempotentElem.range_eq_ker congr(LinearMapClass.linearMap $hp.eq)
+  LinearMap.IsIdempotentElem.range_eq_ker hp.toLinearMap
 
 theorem IsIdempotentElem.ker_eq_range {p : M →L[R] M} (hp : IsIdempotentElem p) :
     LinearMap.ker p = LinearMap.range (1 - p) :=
-  LinearMap.IsIdempotentElem.ker_eq_range congr(LinearMapClass.linearMap $hp.eq)
+  LinearMap.IsIdempotentElem.ker_eq_range hp.toLinearMap
 
 open ContinuousLinearMap in
 theorem IsIdempotentElem.isClosed_range [T1Space M] {p : M →L[R] M}


### PR DESCRIPTION
Instead of having to annoyingly do `congr(LinearMapClass.linearMap $h.eq)` over and over to use results for idempotent linear maps, we can just do `h.toLinearMap`, where `h : IsIdempotentElem T` for some continuous linear map `T`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
