### PR TITLE
[Merged by Bors] - feat(NumberTheory/Padics): norm of Int lt one iff p divides

### DIFF
--- a/Mathlib/Analysis/Normed/Ring/Basic.lean
+++ b/Mathlib/Analysis/Normed/Ring/Basic.lean
@@ -380,6 +380,14 @@ lemma nnnorm_natAbs (z : ℤ) :
     ‖(z.natAbs : α)‖₊ = ‖(z : α)‖₊ := by
   simp [← NNReal.coe_inj, - Nat.cast_natAbs, norm_natAbs]
 
+@[simp] lemma norm_intCast_abs (z : ℤ) :
+    ‖((|z| : ℤ) : α)‖ = ‖(z : α)‖ := by
+  simp [← norm_natAbs]
+
+@[simp] lemma nnnorm_intCast_abs (z : ℤ) :
+    ‖((|z| : ℤ) : α)‖₊ = ‖(z : α)‖₊ := by
+  simp [← nnnorm_natAbs]
+
 /-- If `α` is a seminormed ring, then `‖a ^ n‖₊ ≤ ‖a‖₊ ^ n` for `n > 0`.
 See also `nnnorm_pow_le`. -/
 theorem nnnorm_pow_le' (a : α) : ∀ {n : ℕ}, 0 < n → ‖a ^ n‖₊ ≤ ‖a‖₊ ^ n

--- a/Mathlib/Analysis/Normed/Ring/Basic.lean
+++ b/Mathlib/Analysis/Normed/Ring/Basic.lean
@@ -370,6 +370,16 @@ theorem Finset.nnnorm_prod_le {α : Type*} [NormedCommRing α] [NormOneClass α]
     (f : ι → α) : ‖∏ i ∈ s, f i‖₊ ≤ ∏ i ∈ s, ‖f i‖₊ :=
   (s.norm_prod_le f).trans_eq <| by simp [NNReal.coe_prod]
 
+lemma norm_natAbs (z : ℤ) :
+    ‖(z.natAbs : α)‖ = ‖(z : α)‖ := by
+  rcases z.natAbs_eq with hz | hz
+  · rw [← Int.cast_natCast, ← hz]
+  · rw [← Int.cast_natCast, ← norm_neg, ← Int.cast_neg, ← hz]
+
+lemma nnnorm_natAbs (z : ℤ) :
+    ‖(z.natAbs : α)‖₊ = ‖(z : α)‖₊ := by
+  simp [← NNReal.coe_inj, - Nat.cast_natAbs, norm_natAbs]
+
 /-- If `α` is a seminormed ring, then `‖a ^ n‖₊ ≤ ‖a‖₊ ^ n` for `n > 0`.
 See also `nnnorm_pow_le`. -/
 theorem nnnorm_pow_le' (a : α) : ∀ {n : ℕ}, 0 < n → ‖a ^ n‖₊ ≤ ‖a‖₊ ^ n

--- a/Mathlib/NumberTheory/Harmonic/Int.lean
+++ b/Mathlib/NumberTheory/Harmonic/Int.lean
@@ -42,7 +42,7 @@ theorem padicValRat_two_harmonic (n : ℕ) : padicValRat 2 (harmonic n) = -Nat.l
 /-- The 2-adic norm of the n-th harmonic number is 2 raised to the logarithm of n in base 2. -/
 lemma padicNorm_two_harmonic {n : ℕ} (hn : n ≠ 0) :
     ‖(harmonic n : ℚ_[2])‖ = 2 ^ (Nat.log 2 n) := by
-  rw [padicNormE.eq_padicNorm, padicNorm.eq_zpow_of_nonzero (harmonic_pos hn).ne',
+  rw [Padic.eq_padicNorm, padicNorm.eq_zpow_of_nonzero (harmonic_pos hn).ne',
     padicValRat_two_harmonic, neg_neg, zpow_natCast, Rat.cast_pow, Rat.cast_natCast, Nat.cast_ofNat]
 
 /-- The n-th harmonic number is not an integer for n ≥ 2. -/

--- a/Mathlib/NumberTheory/Padics/Complex.lean
+++ b/Mathlib/NumberTheory/Padics/Complex.lean
@@ -88,7 +88,7 @@ theorem valuation_def (x : PadicAlgCl p) : Valued.v x = ‖x‖₊ := rfl
 theorem valuation_p (p : ℕ) [Fact p.Prime] : Valued.v (p : PadicAlgCl p) = 1 / (p : ℝ≥0) := by
   rw [← map_natCast (algebraMap ℚ_[p] (PadicAlgCl p))]
   ext
-  rw [valuation_coe, norm_extends, padicNormE.norm_p, one_div, NNReal.coe_inv,
+  rw [valuation_coe, norm_extends, Padic.norm_p, one_div, NNReal.coe_inv,
     NNReal.coe_natCast]
 
 /-- The valuation on `PadicAlgCl p` has rank one. -/

--- a/Mathlib/NumberTheory/Padics/Hensel.lean
+++ b/Mathlib/NumberTheory/Padics/Hensel.lean
@@ -179,7 +179,7 @@ private def calc_eval_z' {z z' z1 : ℤ_[p]} (hz' : z' = z - z1) {n} (hz : ih n 
   have hdzne' : (↑(F.derivative.eval z) : ℚ_[p]) ≠ 0 := fun h => hdzne (Subtype.ext_iff_val.2 h)
   obtain ⟨q, hq⟩ := F.binomExpansion z (-z1)
   have : ‖(↑(F.derivative.eval z) * (↑(F.eval z) / ↑(F.derivative.eval z)) : ℚ_[p])‖ ≤ 1 := by
-    rw [Padic.mul]
+    rw [norm_mul]
     exact mul_le_one₀ (PadicInt.norm_le_one _) (norm_nonneg _) h1
   have : F.derivative.eval z * -z1 = -F.eval z := by
     calc
@@ -358,7 +358,7 @@ private theorem newton_seq_succ_dist_weak (n : ℕ) :
         (T_lt_one hnorm) (by simp)) (deriv_norm_pos hnorm))
     _ = ‖F.eval a‖ / ‖F.derivative.eval a‖ := by
       rw [T_gen, sq, pow_one, norm_div, ← mul_div_assoc, PadicInt.padic_norm_e_of_padicInt,
-        PadicInt.coe_mul, Padic.mul]
+        PadicInt.coe_mul, norm_mul]
       apply mul_div_mul_left
       apply deriv_norm_ne_zero; assumption
 

--- a/Mathlib/NumberTheory/Padics/Hensel.lean
+++ b/Mathlib/NumberTheory/Padics/Hensel.lean
@@ -179,7 +179,7 @@ private def calc_eval_z' {z z' z1 : ℤ_[p]} (hz' : z' = z - z1) {n} (hz : ih n 
   have hdzne' : (↑(F.derivative.eval z) : ℚ_[p]) ≠ 0 := fun h => hdzne (Subtype.ext_iff_val.2 h)
   obtain ⟨q, hq⟩ := F.binomExpansion z (-z1)
   have : ‖(↑(F.derivative.eval z) * (↑(F.eval z) / ↑(F.derivative.eval z)) : ℚ_[p])‖ ≤ 1 := by
-    rw [padicNormE.mul]
+    rw [Padic.mul]
     exact mul_le_one₀ (PadicInt.norm_le_one _) (norm_nonneg _) h1
   have : F.derivative.eval z * -z1 = -F.eval z := by
     calc
@@ -358,7 +358,7 @@ private theorem newton_seq_succ_dist_weak (n : ℕ) :
         (T_lt_one hnorm) (by simp)) (deriv_norm_pos hnorm))
     _ = ‖F.eval a‖ / ‖F.derivative.eval a‖ := by
       rw [T_gen, sq, pow_one, norm_div, ← mul_div_assoc, PadicInt.padic_norm_e_of_padicInt,
-        PadicInt.coe_mul, padicNormE.mul]
+        PadicInt.coe_mul, Padic.mul]
       apply mul_div_mul_left
       apply deriv_norm_ne_zero; assumption
 

--- a/Mathlib/NumberTheory/Padics/PadicIntegers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicIntegers.lean
@@ -258,18 +258,22 @@ theorem norm_int_le_pow_iff_dvd {k : ℤ} {n : ℕ} :
     simpa [norm_intCast_eq_padic_norm]
   Padic.norm_int_le_pow_iff_dvd _ _
 
+@[simp]
 lemma norm_natCast_eq_one_iff {n : ℕ} :
     ‖(n : ℤ_[p])‖ = 1 ↔ p.Coprime n := by
   rw [norm_def, coe_natCast, Padic.norm_natCast_eq_one_iff]
 
+@[simp]
 lemma norm_natCast_lt_one_iff {n : ℕ} :
     ‖(n : ℤ_[p])‖ < 1 ↔ p ∣ n := by
   rw [norm_def, coe_natCast, Padic.norm_natCast_lt_one_iff]
 
+@[simp]
 lemma norm_intCast_eq_one_iff {z : ℤ} :
     ‖(z : ℤ_[p])‖ = 1 ↔ IsCoprime z p := by
   rw [norm_def, coe_intCast, Padic.norm_intCast_eq_one_iff]
 
+@[simp]
 lemma norm_intCast_lt_one_iff {z : ℤ} :
     ‖(z : ℤ_[p])‖ < 1 ↔ (p : ℤ) ∣ z := by
   rw [norm_def, coe_intCast, Padic.norm_intCast_lt_one_iff]

--- a/Mathlib/NumberTheory/Padics/PadicIntegers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicIntegers.lean
@@ -258,6 +258,22 @@ theorem norm_int_le_pow_iff_dvd {k : ℤ} {n : ℕ} :
     simpa [norm_intCast_eq_padic_norm]
   padicNormE.norm_int_le_pow_iff_dvd _ _
 
+lemma norm_natCast_eq_one_iff {n : ℕ} :
+    ‖(n : ℤ_[p])‖ = 1 ↔ p.Coprime n := by
+  rw [norm_def, coe_natCast, Padic.norm_natCast_eq_one_iff]
+
+lemma norm_natCast_lt_one_iff {n : ℕ} :
+    ‖(n : ℤ_[p])‖ < 1 ↔ p ∣ n := by
+  rw [norm_def, coe_natCast, Padic.norm_natCast_lt_one_iff]
+
+lemma norm_intCast_eq_one_iff {z : ℤ} :
+    ‖(z : ℤ_[p])‖ = 1 ↔ IsCoprime z p := by
+  rw [norm_def, coe_intCast, Padic.norm_intCast_eq_one_iff]
+
+lemma norm_intCast_lt_one_iff {z : ℤ} :
+    ‖(z : ℤ_[p])‖ < 1 ↔ (p : ℤ) ∣ z := by
+  rw [norm_def, coe_intCast, Padic.norm_intCast_lt_one_iff]
+
 /-! ### Valuation on `ℤ_[p]` -/
 
 lemma valuation_coe_nonneg : 0 ≤ (x : ℚ_[p]).valuation := by

--- a/Mathlib/NumberTheory/Padics/PadicIntegers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicIntegers.lean
@@ -76,7 +76,7 @@ def subring : Subring ℚ_[p] where
   carrier := { x : ℚ_[p] | ‖x‖ ≤ 1 }
   zero_mem' := by simp
   one_mem' := by simp
-  add_mem' hx hy := (padicNormE.nonarchimedean _ _).trans <| max_le_iff.2 ⟨hx, hy⟩
+  add_mem' hx hy := (Padic.nonarchimedean _ _).trans <| max_le_iff.2 ⟨hx, hy⟩
   mul_mem' hx hy := (padicNormE.mul _ _).trans_le <| mul_le_one₀ hx (norm_nonneg _) hy
   neg_mem' hx := (norm_neg _).trans_le hx
 
@@ -190,10 +190,10 @@ variable {p}
 
 theorem norm_le_one (z : ℤ_[p]) : ‖z‖ ≤ 1 := z.2
 
-theorem nonarchimedean (q r : ℤ_[p]) : ‖q + r‖ ≤ max ‖q‖ ‖r‖ := padicNormE.nonarchimedean _ _
+theorem nonarchimedean (q r : ℤ_[p]) : ‖q + r‖ ≤ max ‖q‖ ‖r‖ := Padic.nonarchimedean _ _
 
 theorem norm_add_eq_max_of_ne {q r : ℤ_[p]} : ‖q‖ ≠ ‖r‖ → ‖q + r‖ = max ‖q‖ ‖r‖ :=
-  padicNormE.add_eq_max_of_ne
+  Padic.add_eq_max_of_ne
 
 theorem norm_eq_of_norm_add_lt_right {z1 z2 : ℤ_[p]} (h : ‖z1 + z2‖ < ‖z2‖) : ‖z1‖ = ‖z2‖ :=
   by_contra fun hne =>
@@ -212,7 +212,7 @@ theorem norm_intCast_eq_padic_norm (z : ℤ) : ‖(z : ℤ_[p])‖ = ‖(z : ℚ
 theorem norm_eq_padic_norm {q : ℚ_[p]} (hq : ‖q‖ ≤ 1) : @norm ℤ_[p] _ ⟨q, hq⟩ = ‖q‖ := rfl
 
 @[simp]
-theorem norm_p : ‖(p : ℤ_[p])‖ = (p : ℝ)⁻¹ := padicNormE.norm_p
+theorem norm_p : ‖(p : ℤ_[p])‖ = (p : ℝ)⁻¹ := Padic.norm_p
 
 theorem norm_p_pow (n : ℕ) : ‖(p : ℤ_[p]) ^ n‖ = (p : ℝ) ^ (-n : ℤ) := by simp
 
@@ -250,13 +250,13 @@ variable {p}
 
 theorem norm_int_lt_one_iff_dvd (k : ℤ) : ‖(k : ℤ_[p])‖ < 1 ↔ (p : ℤ) ∣ k :=
   suffices ‖(k : ℚ_[p])‖ < 1 ↔ ↑p ∣ k by rwa [norm_intCast_eq_padic_norm]
-  padicNormE.norm_int_lt_one_iff_dvd k
+  Padic.norm_intCast_lt_one_iff
 
 theorem norm_int_le_pow_iff_dvd {k : ℤ} {n : ℕ} :
     ‖(k : ℤ_[p])‖ ≤ (p : ℝ) ^ (-n : ℤ) ↔ (p ^ n : ℤ) ∣ k :=
   suffices ‖(k : ℚ_[p])‖ ≤ (p : ℝ) ^ (-n : ℤ) ↔ (p ^ n : ℤ) ∣ k by
     simpa [norm_intCast_eq_padic_norm]
-  padicNormE.norm_int_le_pow_iff_dvd _ _
+  Padic.norm_int_le_pow_iff_dvd _ _
 
 lemma norm_natCast_eq_one_iff {n : ℕ} :
     ‖(n : ℤ_[p])‖ = 1 ↔ p.Coprime n := by
@@ -530,7 +530,7 @@ instance isFractionRing : IsFractionRing ℤ_[p] ℚ_[p] where
           intro h0
           rw [h0, norm_zero] at hx
           exact hx zero_le_one
-        rw [ha, padicNormE.mul, padicNormE.norm_p_pow, Padic.norm_eq_zpow_neg_valuation hx,
+        rw [ha, padicNormE.mul, Padic.norm_p_pow, Padic.norm_eq_zpow_neg_valuation hx,
           ← zpow_add', hn_coe, neg_neg, neg_add_cancel, zpow_zero]
         exact Or.inl (Nat.cast_ne_zero.mpr (NeZero.ne p))
       use

--- a/Mathlib/NumberTheory/Padics/PadicNumbers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicNumbers.lean
@@ -839,6 +839,7 @@ theorem norm_int_le_one (z : ℤ) : ‖(z : ℚ_[p])‖ ≤ 1 :=
   suffices ‖((z : ℚ) : ℚ_[p])‖ ≤ 1 by simpa
   norm_rat_le_one <| by simp [hp.1.ne_one]
 
+@[simp]
 theorem norm_intCast_lt_one_iff {k : ℤ} : ‖(k : ℚ_[p])‖ < 1 ↔ ↑p ∣ k := by
   constructor
   · intro h
@@ -861,17 +862,20 @@ theorem norm_intCast_lt_one_iff {k : ℤ} : ‖(k : ℚ_[p])‖ < 1 ↔ ↑p ∣
 
 @[deprecated (since := "2025-08-15")] alias norm_int_lt_one_iff_dvd := norm_intCast_lt_one_iff
 
+@[simp]
 lemma norm_natCast_lt_one_iff {n : ℕ} :
     ‖(n : ℚ_[p])‖ < 1 ↔ p ∣ n := by
   simpa [Int.natCast_dvd_natCast] using norm_intCast_lt_one_iff (p := p) (k := n)
 
+@[simp]
 lemma norm_intCast_eq_one_iff {z : ℤ} :
     ‖(z : ℚ_[p])‖ = 1 ↔ IsCoprime z p := by
   rw [← not_iff_not]
-  simp [Nat.coprime_comm, ← norm_natCast_lt_one_iff,
+  simp [Nat.coprime_comm, ← norm_natCast_lt_one_iff, - norm_intCast_lt_one_iff,
     Int.isCoprime_iff_gcd_eq_one, Nat.coprime_iff_gcd_eq_one, Int.gcd,
     ← hp.out.dvd_iff_not_coprime, norm_natAbs, - cast_natAbs, norm_int_le_one]
 
+@[simp]
 lemma norm_natCast_eq_one_iff {n : ℕ} :
     ‖(n : ℚ_[p])‖ = 1 ↔ p.Coprime n := by
   simpa [p.coprime_comm] using norm_intCast_eq_one_iff (p := p) (z := n)

--- a/Mathlib/NumberTheory/Padics/PadicNumbers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicNumbers.lean
@@ -1111,7 +1111,6 @@ theorem addValuation.apply {x : ℚ_[p]} (hx : x ≠ 0) :
     Padic.addValuation x = (x.valuation : WithTop ℤ) := by
   simp only [Padic.addValuation, AddValuation.of_apply, addValuationDef, if_neg hx]
 
-
 section NormLEIff
 
 /-! ### Various characterizations of open unit balls -/

--- a/Mathlib/NumberTheory/Padics/PadicNumbers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicNumbers.lean
@@ -3,11 +3,12 @@ Copyright (c) 2018 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis
 -/
+import Mathlib.Analysis.Normed.Field.Lemmas
+import Mathlib.Analysis.Normed.Ring.Ultra
+import Mathlib.RingTheory.Int.Basic
 import Mathlib.RingTheory.Valuation.Basic
 import Mathlib.NumberTheory.Padics.PadicNorm
-import Mathlib.Analysis.Normed.Field.Lemmas
 import Mathlib.Tactic.Peel
-import Mathlib.Topology.MetricSpace.Ultra.Basic
 
 /-!
 # p-adic numbers
@@ -1091,6 +1092,28 @@ def addValuation : AddValuation ℚ_[p] (WithTop ℤ) :=
 theorem addValuation.apply {x : ℚ_[p]} (hx : x ≠ 0) :
     Padic.addValuation x = (x.valuation : WithTop ℤ) := by
   simp only [Padic.addValuation, AddValuation.of_apply, addValuationDef, if_neg hx]
+
+lemma norm_natCast_eq_one_iff {n : ℕ} :
+    ‖(n : ℚ_[p])‖ = 1 ↔ p.Coprime n := by
+  rcases eq_or_ne n 0 with rfl | hn
+  · simp [hp.out.ne_one]
+  rw [norm_eq_zpow_neg_valuation (by exact_mod_cast hn), zpow_neg]
+  rw [inv_eq_one, zpow_eq_one_iff_right₀ (by simp) (by simp [hp.out.ne_one])]
+  simp [hp.out.ne_one, hn, hp.out.coprime_iff_not_dvd]
+
+lemma norm_natCast_lt_one_iff {n : ℕ} :
+    ‖(n : ℚ_[p])‖ < 1 ↔ p ∣ n := by
+  simp [hp.out.dvd_iff_not_coprime, ← norm_natCast_eq_one_iff, lt_iff_le_and_ne,
+    IsUltrametricDist.norm_natCast_le_one]
+
+lemma norm_intCast_eq_one_iff {z : ℤ} :
+    ‖(z : ℚ_[p])‖ = 1 ↔ IsCoprime z p := by
+  rw [Int.isCoprime_iff_nat_coprime, Nat.coprime_comm, Int.natAbs_cast, ← norm_natCast_eq_one_iff,
+    norm_natAbs]
+
+lemma norm_intCast_lt_one_iff {z : ℤ} :
+    ‖(z : ℚ_[p])‖ < 1 ↔ (p : ℤ) ∣ z := by
+  rw [Int.natCast_dvd, ← norm_natAbs, norm_natCast_lt_one_iff]
 
 section NormLEIff
 

--- a/Mathlib/NumberTheory/Padics/PadicNumbers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicNumbers.lean
@@ -742,25 +742,26 @@ end NormedSpace
 
 end Padic
 
-namespace padicNormE
+namespace Padic
+
+variable {p : ℕ} [hp : Fact p.Prime]
 
 section NormedSpace
 
-variable {p : ℕ} [hp : Fact p.Prime]
 -- Porting note: Linter thinks this is a duplicate simp lemma, so `priority` is assigned
 @[simp (high)]
-protected theorem mul (q r : ℚ_[p]) : ‖q * r‖ = ‖q‖ * ‖r‖ := by simp [Norm.norm, map_mul]
+protected theorem padicNormE.mul (q r : ℚ_[p]) : ‖q * r‖ = ‖q‖ * ‖r‖ := by simp [Norm.norm, map_mul]
 
-protected theorem is_norm (q : ℚ_[p]) : ↑(padicNormE q) = ‖q‖ := rfl
+protected theorem padicNormE.is_norm (q : ℚ_[p]) : ↑(padicNormE q) = ‖q‖ := rfl
 
 theorem nonarchimedean (q r : ℚ_[p]) : ‖q + r‖ ≤ max ‖q‖ ‖r‖ := by
   dsimp [norm]
-  exact mod_cast nonarchimedean' _ _
+  exact mod_cast padicNormE.nonarchimedean' _ _
 
 theorem add_eq_max_of_ne {q r : ℚ_[p]} (h : ‖q‖ ≠ ‖r‖) : ‖q + r‖ = max ‖q‖ ‖r‖ := by
   dsimp [norm] at h ⊢
   have : padicNormE q ≠ padicNormE r := mod_cast h
-  exact mod_cast add_eq_max_of_ne' this
+  exact mod_cast padicNormE.add_eq_max_of_ne' this
 
 @[simp]
 theorem eq_padicNorm (q : ℚ) : ‖(q : ℚ_[p])‖ = padicNorm p q := by
@@ -795,13 +796,13 @@ instance : NontriviallyNormedField ℚ_[p] :=
         rw [norm_inv, norm_p, inv_inv]
         exact mod_cast hp.1.one_lt⟩ }
 
-protected theorem image {q : ℚ_[p]} : q ≠ 0 → ∃ n : ℤ, ‖q‖ = ↑((p : ℚ) ^ (-n)) :=
+protected theorem padicNormE.image {q : ℚ_[p]} : q ≠ 0 → ∃ n : ℤ, ‖q‖ = ↑((p : ℚ) ^ (-n)) :=
   Quotient.inductionOn q fun f hf ↦
     have : ¬f ≈ 0 := (PadicSeq.ne_zero_iff_nequiv_zero f).1 hf
     let ⟨n, hn⟩ := PadicSeq.norm_values_discrete f this
     ⟨n, by rw [← hn]; rfl⟩
 
-protected theorem is_rat (q : ℚ_[p]) : ∃ q' : ℚ, ‖q‖ = q' := by
+protected theorem padicNormE.is_rat (q : ℚ_[p]) : ∃ q' : ℚ, ‖q‖ = q' := by
   classical
   exact if h : q = 0 then ⟨0, by simp [h]⟩
   else
@@ -824,7 +825,7 @@ theorem norm_rat_le_one : ∀ {q : ℚ} (_ : ¬p ∣ q.den), ‖(q : ℚ_[p])‖
       norm_num [this]
     else by
       have hnz' : (⟨n, d, hn, hd⟩ : ℚ) ≠ 0 := mt Rat.zero_iff_num_zero.1 hnz
-      rw [padicNormE.eq_padicNorm]
+      rw [eq_padicNorm]
       norm_cast
       -- Porting note: `Nat.cast_zero` instead of another `norm_cast` call
       rw [padicNorm.eq_zpow_of_nonzero hnz', padicValRat, neg_sub,
@@ -838,7 +839,7 @@ theorem norm_int_le_one (z : ℤ) : ‖(z : ℚ_[p])‖ ≤ 1 :=
   suffices ‖((z : ℚ) : ℚ_[p])‖ ≤ 1 by simpa
   norm_rat_le_one <| by simp [hp.1.ne_one]
 
-theorem norm_int_lt_one_iff_dvd (k : ℤ) : ‖(k : ℚ_[p])‖ < 1 ↔ ↑p ∣ k := by
+theorem norm_intCast_lt_one_iff {k : ℤ} : ‖(k : ℚ_[p])‖ < 1 ↔ ↑p ∣ k := by
   constructor
   · intro h
     contrapose! h
@@ -846,7 +847,7 @@ theorem norm_int_lt_one_iff_dvd (k : ℤ) : ‖(k : ℚ_[p])‖ < 1 ↔ ↑p ∣
     rw [eq_comm]
     calc
       ‖(k : ℚ_[p])‖ = ‖((k : ℚ) : ℚ_[p])‖ := by norm_cast
-      _ = padicNorm p k := padicNormE.eq_padicNorm _
+      _ = padicNorm p k := eq_padicNorm _
       _ = 1 := mod_cast (int_eq_one_iff k).mpr h
   · rintro ⟨x, rfl⟩
     push_cast
@@ -855,8 +856,25 @@ theorem norm_int_lt_one_iff_dvd (k : ℤ) : ‖(k : ℚ_[p])‖ < 1 ↔ ↑p ∣
       _ ≤ ‖(p : ℚ_[p])‖ * 1 :=
         mul_le_mul le_rfl (by simpa using norm_int_le_one _) (norm_nonneg _) (norm_nonneg _)
       _ < 1 := by
-        rw [mul_one, padicNormE.norm_p]
+        rw [mul_one, norm_p]
         exact inv_lt_one_of_one_lt₀ <| mod_cast hp.1.one_lt
+
+@[deprecated (since := "2025-08-15")] alias norm_int_lt_one_iff_dvd := norm_intCast_lt_one_iff
+
+lemma norm_natCast_lt_one_iff {n : ℕ} :
+    ‖(n : ℚ_[p])‖ < 1 ↔ p ∣ n := by
+  simpa [Int.natCast_dvd_natCast] using norm_intCast_lt_one_iff (p := p) (k := n)
+
+lemma norm_intCast_eq_one_iff {z : ℤ} :
+    ‖(z : ℚ_[p])‖ = 1 ↔ IsCoprime z p := by
+  rw [← not_iff_not]
+  simp [Nat.coprime_comm, ← norm_natCast_lt_one_iff,
+    Int.isCoprime_iff_gcd_eq_one, Nat.coprime_iff_gcd_eq_one, Int.gcd,
+    ← hp.out.dvd_iff_not_coprime, norm_natAbs, - cast_natAbs, norm_int_le_one]
+
+lemma norm_natCast_eq_one_iff {n : ℕ} :
+    ‖(n : ℚ_[p])‖ = 1 ↔ p.Coprime n := by
+  simpa [p.coprime_comm] using norm_intCast_eq_one_iff (p := p) (z := n)
 
 theorem norm_int_le_pow_iff_dvd (k : ℤ) (n : ℕ) :
     ‖(k : ℚ_[p])‖ ≤ (p : ℝ) ^ (-n : ℤ) ↔ (p ^ n : ℤ) ∣ k := by
@@ -867,38 +885,13 @@ theorem norm_int_le_pow_iff_dvd (k : ℤ) (n : ℕ) :
 
 theorem eq_of_norm_add_lt_right {z1 z2 : ℚ_[p]} (h : ‖z1 + z2‖ < ‖z2‖) : ‖z1‖ = ‖z2‖ :=
   _root_.by_contradiction fun hne ↦
-    not_lt_of_ge (by rw [padicNormE.add_eq_max_of_ne hne]; apply le_max_right) h
+    not_lt_of_ge (by rw [add_eq_max_of_ne hne]; apply le_max_right) h
 
 theorem eq_of_norm_add_lt_left {z1 z2 : ℚ_[p]} (h : ‖z1 + z2‖ < ‖z1‖) : ‖z1‖ = ‖z2‖ :=
   _root_.by_contradiction fun hne ↦
-    not_lt_of_ge (by rw [padicNormE.add_eq_max_of_ne hne]; apply le_max_left) h
+    not_lt_of_ge (by rw [add_eq_max_of_ne hne]; apply le_max_left) h
 
 end NormedSpace
-
-end padicNormE
-
-namespace Padic
-
-variable {p : ℕ} [hp : Fact p.Prime]
-
-lemma norm_intCast_lt_one_iff {z : ℤ} :
-    ‖(z : ℚ_[p])‖ < 1 ↔ (p : ℤ) ∣ z :=
-  padicNormE.norm_int_lt_one_iff_dvd _
-
-lemma norm_natCast_lt_one_iff {n : ℕ} :
-    ‖(n : ℚ_[p])‖ < 1 ↔ p ∣ n := by
-  simpa [Int.natCast_dvd_natCast] using norm_intCast_lt_one_iff (p := p) (z := n)
-
-lemma norm_intCast_eq_one_iff {z : ℤ} :
-    ‖(z : ℚ_[p])‖ = 1 ↔ IsCoprime z p := by
-  rw [← not_iff_not]
-  simp [Nat.coprime_comm, ← norm_natCast_lt_one_iff,
-    Int.isCoprime_iff_gcd_eq_one, Nat.coprime_iff_gcd_eq_one, Int.gcd,
-    ← hp.out.dvd_iff_not_coprime, norm_natAbs, - cast_natAbs, padicNormE.norm_int_le_one]
-
-lemma norm_natCast_eq_one_iff {n : ℕ} :
-    ‖(n : ℚ_[p])‖ = 1 ↔ p.Coprime n := by
-  simpa [p.coprime_comm] using norm_intCast_eq_one_iff (p := p) (z := n)
 
 instance complete : CauSeq.IsComplete ℚ_[p] norm where
   isComplete f := by
@@ -927,7 +920,7 @@ theorem padicNormE_lim_le {f : CauSeq ℚ_[p] norm} {a : ℝ} (ha : 0 < a) (hf :
   obtain ⟨N, hN⟩ := Setoid.symm (CauSeq.equiv_lim f) _ ha
   calc
     ‖f.lim‖ = ‖f.lim - f N + f N‖ := by simp
-    _ ≤ max ‖f.lim - f N‖ ‖f N‖ := padicNormE.nonarchimedean _ _
+    _ ≤ max ‖f.lim - f N‖ ‖f N‖ := nonarchimedean _ _
     _ ≤ a := max_le (le_of_lt (hN _ le_rfl)) (hf _)
 
 open Filter Set
@@ -977,7 +970,7 @@ lemma valuation_ratCast (q : ℚ) : valuation (q : ℚ_[p]) = padicValRat p q :=
   · simp only [Rat.cast_zero, valuation_zero, padicValRat.zero]
   refine neg_injective ((zpow_right_strictMono₀ (mod_cast hp.out.one_lt)).injective
     <| (norm_eq_zpow_neg_valuation (mod_cast hq)).symm.trans ?_)
-  rw [padicNormE.eq_padicNorm, ← Rat.cast_natCast, ← Rat.cast_zpow, Rat.cast_inj]
+  rw [eq_padicNorm, ← Rat.cast_natCast, ← Rat.cast_zpow, Rat.cast_inj]
   exact padicNorm.eq_zpow_of_nonzero hq
 
 @[simp]
@@ -1007,7 +1000,7 @@ theorem le_valuation_add {x y : ℚ_[p]} (hxy : x + y ≠ 0) :
   · simpa only [hx, zero_add] using min_le_right _ _
   by_cases hy : y = 0
   · simpa only [hy, add_zero] using min_le_left _ _
-  have : ‖x + y‖ ≤ max ‖x‖ ‖y‖ := padicNormE.nonarchimedean x y
+  have : ‖x + y‖ ≤ max ‖x‖ ‖y‖ := nonarchimedean x y
   simpa only [norm_eq_zpow_neg_valuation hxy, norm_eq_zpow_neg_valuation hx,
     norm_eq_zpow_neg_valuation hy, le_max_iff,
     zpow_le_zpow_iff_right₀ (mod_cast hp.out.one_lt : 1 < (p : ℝ)), neg_le_neg_iff, ← min_le_iff]

--- a/Mathlib/NumberTheory/Padics/PadicNumbers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicNumbers.lean
@@ -859,6 +859,24 @@ theorem norm_int_lt_one_iff_dvd (k : ℤ) : ‖(k : ℚ_[p])‖ < 1 ↔ ↑p ∣
         rw [mul_one, padicNormE.norm_p]
         exact inv_lt_one_of_one_lt₀ <| mod_cast hp.1.one_lt
 
+lemma norm_intCast_lt_one_iff {z : ℤ} :
+    ‖(z : ℚ_[p])‖ < 1 ↔ (p : ℤ) ∣ z :=
+  padicNormE.norm_int_lt_one_iff_dvd _
+
+lemma norm_natCast_lt_one_iff {n : ℕ} :
+    ‖(n : ℚ_[p])‖ < 1 ↔ p ∣ n := by
+  simpa [Int.natCast_dvd_natCast] using norm_intCast_lt_one_iff (p := p) (z := n)
+
+lemma norm_intCast_eq_one_iff {z : ℤ} :
+    ‖(z : ℚ_[p])‖ = 1 ↔ IsCoprime z p := by
+  rw [← not_iff_not]
+  simp [Int.isCoprime_iff_nat_coprime, Nat.coprime_comm, ← norm_natCast_lt_one_iff,
+    ← hp.out.dvd_iff_not_coprime, norm_natAbs, - cast_natAbs, IsUltrametricDist.norm_intCast_le_one]
+
+lemma norm_natCast_eq_one_iff {n : ℕ} :
+    ‖(n : ℚ_[p])‖ = 1 ↔ p.Coprime n := by
+  simpa [p.coprime_comm] using norm_intCast_eq_one_iff (p := p) (z := n)
+
 theorem norm_int_le_pow_iff_dvd (k : ℤ) (n : ℕ) :
     ‖(k : ℚ_[p])‖ ≤ (p : ℝ) ^ (-n : ℤ) ↔ (p ^ n : ℤ) ∣ k := by
   have : (p : ℝ) ^ (-n : ℤ) = (p : ℚ) ^ (-n : ℤ) := by simp
@@ -1093,27 +1111,6 @@ theorem addValuation.apply {x : ℚ_[p]} (hx : x ≠ 0) :
     Padic.addValuation x = (x.valuation : WithTop ℤ) := by
   simp only [Padic.addValuation, AddValuation.of_apply, addValuationDef, if_neg hx]
 
-lemma norm_natCast_eq_one_iff {n : ℕ} :
-    ‖(n : ℚ_[p])‖ = 1 ↔ p.Coprime n := by
-  rcases eq_or_ne n 0 with rfl | hn
-  · simp [hp.out.ne_one]
-  rw [norm_eq_zpow_neg_valuation (by exact_mod_cast hn), zpow_neg]
-  rw [inv_eq_one, zpow_eq_one_iff_right₀ (by simp) (by simp [hp.out.ne_one])]
-  simp [hp.out.ne_one, hn, hp.out.coprime_iff_not_dvd]
-
-lemma norm_natCast_lt_one_iff {n : ℕ} :
-    ‖(n : ℚ_[p])‖ < 1 ↔ p ∣ n := by
-  simp [hp.out.dvd_iff_not_coprime, ← norm_natCast_eq_one_iff, lt_iff_le_and_ne,
-    IsUltrametricDist.norm_natCast_le_one]
-
-lemma norm_intCast_eq_one_iff {z : ℤ} :
-    ‖(z : ℚ_[p])‖ = 1 ↔ IsCoprime z p := by
-  rw [Int.isCoprime_iff_nat_coprime, Nat.coprime_comm, Int.natAbs_cast, ← norm_natCast_eq_one_iff,
-    norm_natAbs]
-
-lemma norm_intCast_lt_one_iff {z : ℤ} :
-    ‖(z : ℚ_[p])‖ < 1 ↔ (p : ℤ) ∣ z := by
-  rw [Int.natCast_dvd, ← norm_natAbs, norm_natCast_lt_one_iff]
 
 section NormLEIff
 

--- a/Mathlib/NumberTheory/Padics/PadicNumbers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicNumbers.lean
@@ -858,25 +858,6 @@ theorem norm_int_lt_one_iff_dvd (k : ℤ) : ‖(k : ℚ_[p])‖ < 1 ↔ ↑p ∣
         rw [mul_one, padicNormE.norm_p]
         exact inv_lt_one_of_one_lt₀ <| mod_cast hp.1.one_lt
 
-lemma norm_intCast_lt_one_iff {z : ℤ} :
-    ‖(z : ℚ_[p])‖ < 1 ↔ (p : ℤ) ∣ z :=
-  padicNormE.norm_int_lt_one_iff_dvd _
-
-lemma norm_natCast_lt_one_iff {n : ℕ} :
-    ‖(n : ℚ_[p])‖ < 1 ↔ p ∣ n := by
-  simpa [Int.natCast_dvd_natCast] using norm_intCast_lt_one_iff (p := p) (z := n)
-
-lemma norm_intCast_eq_one_iff {z : ℤ} :
-    ‖(z : ℚ_[p])‖ = 1 ↔ IsCoprime z p := by
-  rw [← not_iff_not]
-  simp [Nat.coprime_comm, ← norm_natCast_lt_one_iff,
-    Int.isCoprime_iff_gcd_eq_one, Nat.coprime_iff_gcd_eq_one, Int.gcd,
-    ← hp.out.dvd_iff_not_coprime, norm_natAbs, - cast_natAbs, padicNormE.norm_int_le_one]
-
-lemma norm_natCast_eq_one_iff {n : ℕ} :
-    ‖(n : ℚ_[p])‖ = 1 ↔ p.Coprime n := by
-  simpa [p.coprime_comm] using norm_intCast_eq_one_iff (p := p) (z := n)
-
 theorem norm_int_le_pow_iff_dvd (k : ℤ) (n : ℕ) :
     ‖(k : ℚ_[p])‖ ≤ (p : ℝ) ^ (-n : ℤ) ↔ (p ^ n : ℤ) ∣ k := by
   have : (p : ℝ) ^ (-n : ℤ) = (p : ℚ) ^ (-n : ℤ) := by simp
@@ -899,6 +880,25 @@ end padicNormE
 namespace Padic
 
 variable {p : ℕ} [hp : Fact p.Prime]
+
+lemma norm_intCast_lt_one_iff {z : ℤ} :
+    ‖(z : ℚ_[p])‖ < 1 ↔ (p : ℤ) ∣ z :=
+  padicNormE.norm_int_lt_one_iff_dvd _
+
+lemma norm_natCast_lt_one_iff {n : ℕ} :
+    ‖(n : ℚ_[p])‖ < 1 ↔ p ∣ n := by
+  simpa [Int.natCast_dvd_natCast] using norm_intCast_lt_one_iff (p := p) (z := n)
+
+lemma norm_intCast_eq_one_iff {z : ℤ} :
+    ‖(z : ℚ_[p])‖ = 1 ↔ IsCoprime z p := by
+  rw [← not_iff_not]
+  simp [Nat.coprime_comm, ← norm_natCast_lt_one_iff,
+    Int.isCoprime_iff_gcd_eq_one, Nat.coprime_iff_gcd_eq_one, Int.gcd,
+    ← hp.out.dvd_iff_not_coprime, norm_natAbs, - cast_natAbs, padicNormE.norm_int_le_one]
+
+lemma norm_natCast_eq_one_iff {n : ℕ} :
+    ‖(n : ℚ_[p])‖ = 1 ↔ p.Coprime n := by
+  simpa [p.coprime_comm] using norm_intCast_eq_one_iff (p := p) (z := n)
 
 instance complete : CauSeq.IsComplete ℚ_[p] norm where
   isComplete f := by

--- a/Mathlib/NumberTheory/Padics/PadicNumbers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicNumbers.lean
@@ -3,10 +3,9 @@ Copyright (c) 2018 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis
 -/
-import Mathlib.Analysis.Normed.Field.Lemmas
-import Mathlib.NumberTheory.Padics.PadicNorm
-import Mathlib.RingTheory.Int.Basic
 import Mathlib.RingTheory.Valuation.Basic
+import Mathlib.NumberTheory.Padics.PadicNorm
+import Mathlib.Analysis.Normed.Field.Lemmas
 import Mathlib.Tactic.Peel
 import Mathlib.Topology.MetricSpace.Ultra.Basic
 
@@ -870,7 +869,8 @@ lemma norm_natCast_lt_one_iff {n : ℕ} :
 lemma norm_intCast_eq_one_iff {z : ℤ} :
     ‖(z : ℚ_[p])‖ = 1 ↔ IsCoprime z p := by
   rw [← not_iff_not]
-  simp [Int.isCoprime_iff_nat_coprime, Nat.coprime_comm, ← norm_natCast_lt_one_iff,
+  simp [Nat.coprime_comm, ← norm_natCast_lt_one_iff,
+    Int.isCoprime_iff_gcd_eq_one, Nat.coprime_iff_gcd_eq_one, Int.gcd,
     ← hp.out.dvd_iff_not_coprime, norm_natAbs, - cast_natAbs, padicNormE.norm_int_le_one]
 
 lemma norm_natCast_eq_one_iff {n : ℕ} :

--- a/Mathlib/NumberTheory/Padics/PadicNumbers.lean
+++ b/Mathlib/NumberTheory/Padics/PadicNumbers.lean
@@ -4,11 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis
 -/
 import Mathlib.Analysis.Normed.Field.Lemmas
-import Mathlib.Analysis.Normed.Ring.Ultra
+import Mathlib.NumberTheory.Padics.PadicNorm
 import Mathlib.RingTheory.Int.Basic
 import Mathlib.RingTheory.Valuation.Basic
-import Mathlib.NumberTheory.Padics.PadicNorm
 import Mathlib.Tactic.Peel
+import Mathlib.Topology.MetricSpace.Ultra.Basic
 
 /-!
 # p-adic numbers
@@ -871,7 +871,7 @@ lemma norm_intCast_eq_one_iff {z : ℤ} :
     ‖(z : ℚ_[p])‖ = 1 ↔ IsCoprime z p := by
   rw [← not_iff_not]
   simp [Int.isCoprime_iff_nat_coprime, Nat.coprime_comm, ← norm_natCast_lt_one_iff,
-    ← hp.out.dvd_iff_not_coprime, norm_natAbs, - cast_natAbs, IsUltrametricDist.norm_intCast_le_one]
+    ← hp.out.dvd_iff_not_coprime, norm_natAbs, - cast_natAbs, padicNormE.norm_int_le_one]
 
 lemma norm_natCast_eq_one_iff {n : ℕ} :
     ‖(n : ℚ_[p])‖ = 1 ↔ p.Coprime n := by

--- a/Mathlib/NumberTheory/Padics/RingHoms.lean
+++ b/Mathlib/NumberTheory/Padics/RingHoms.lean
@@ -166,7 +166,7 @@ theorem exists_mem_range : ∃ n : ℕ, n < p ∧ x - n ∈ maximalIdeal ℤ_[p]
     rw [norm_sub_rev] at hr
     calc
       _ = ‖(r : ℚ_[p]) - x + x‖ := by ring_nf
-      _ ≤ _ := padicNormE.nonarchimedean _ _
+      _ ≤ _ := Padic.nonarchimedean _ _
       _ ≤ _ := max_le (le_of_lt hr) x.2
   obtain ⟨n, hzn, hnp, hn⟩ := exists_mem_range_of_norm_rat_le_one r H
   lift n to ℕ using hzn
@@ -175,7 +175,7 @@ theorem exists_mem_range : ∃ n : ℕ, n < p ∧ x - n ∈ maximalIdeal ℤ_[p]
   · exact mod_cast hnp
   simp only [norm_def, coe_sub, coe_natCast] at hn ⊢
   rw [show (x - n : ℚ_[p]) = x - r + (r - n) by ring]
-  apply lt_of_le_of_lt (padicNormE.nonarchimedean _ _)
+  apply lt_of_le_of_lt (Padic.nonarchimedean _ _)
   apply max_lt hr
   simpa using hn
 
@@ -695,9 +695,9 @@ lemma toZModPow_ofIntSeq_of_pow_dvd_sub
     have H' : ‖(p ^ n * e : ℚ_[p])‖ < ‖(((x.appr n) - f (N + n) : ℤ) : ℚ_[p])‖ := by
       refine LE.le.trans_lt ?_ H
       simpa using mul_le_mul_of_nonneg le_rfl e.2 (show 0 ≤ (↑p ^ n)⁻¹ by simp) zero_le_one
-    rw [padicNormE.add_eq_max_of_ne H'.ne, sup_eq_right.mpr H'.le] at hN
+    rw [Padic.add_eq_max_of_ne H'.ne, sup_eq_right.mpr H'.le] at hN
     exact lt_asymm hN H
-  rw [padicNormE.norm_int_le_pow_iff_dvd, ← Nat.cast_pow,
+  rw [Padic.norm_int_le_pow_iff_dvd, ← Nat.cast_pow,
     ← ZMod.intCast_eq_intCast_iff_dvd_sub, Int.cast_natCast] at this
   refine this.symm.trans ?_
   clear * - hi


### PR DESCRIPTION
On the way to p-1 roots of unity

With helper lemmas for natCast
and simplification of norms of Int.natAbs
Move some lemmas out of `padicNormE` namespace into `Padic` namespace
which is similar to already existing lemmas in `PadicInt` namespace


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
