### PR TITLE
[Merged by Bors] - feat(autolabel): label script changes also

### DIFF
--- a/scripts/autolabel.lean
+++ b/scripts/autolabel.lean
@@ -115,7 +115,11 @@ def mathlibLabels : Array Label := #[
   { label := "t-geometric-group-theory",
     dirs := #["Mathlib" / "Geometry" / "Group"] },
   { label := "t-linter",
-    dirs := #["Mathlib" / "Tactic" / "Linter"] },
+    dirs := #[
+      "Mathlib" / "Tactic" / "Linter",
+      "scripts" / "lint-style.lean",
+      "scripts" / "lint-style.py",
+    ] },
   { label := "t-logic",
     dirs := #[
       "Mathlib" / "Logic",
@@ -138,7 +142,19 @@ def mathlibLabels : Array Label := #[
   { label := "t-topology",
     dirs := #["Mathlib" / "Topology"] },
   { label := "CI",
-    dirs := #[".github"] },
+    dirs := #[
+      ".github",
+      "scripts" /"bench",
+      "scripts",
+    ],
+    exclusions := #[
+      "scripts" / "lint-style.lean",
+      "scripts" / "lint-style.py",
+      "scripts" / "noshake.json",
+      "scripts" / "nolints.json",
+      "scripts" / "nolints-style.txt",
+      "scripts" / "nolints_prime_decls.txt",
+    ] },
   { label := "IMO",
     dirs := #["Archive" / "Imo"] },
   { label := "dependency-bump",
@@ -195,6 +211,13 @@ section Tests
 
 -- Test targeting a file instead of a directory
 #guard getMatchingLabels #["lake-manifest.json"] == #["dependency-bump"]
+
+-- Test linting of specific changes touching linting and CI.
+#guard getMatchingLabels #["scripts" / "add_deprecations.sh"] == #["CI"]
+#guard getMatchingLabels #["scripts" / "lint-style.lean"] == #["t-linter"]
+#guard getMatchingLabels #["Mathlib" / "Tactic" / "Linter" / "TextBased.lean",
+  "scripts" / "lint-style.lean", "scripts" / "lint-style.py"] == #["t-linter"]
+#guard getMatchingLabels #["scripts" / "noshake.json"] == #[]
 
 /-- Testing function to ensure the labels defined in `mathlibLabels` cover all
 subfolders of `Mathlib/`. -/


### PR DESCRIPTION
- changes to lint-style.{py,lean} are t-linter changes,
- changes to nolint.json, noshake.json, nolints-style.txt and nolint_prime_decls.txt don't get any area label;
- all other files in script are labelled as CI changes.

This matches the new meaning of the CI label, as also [discussed on zulip](https://leanprover.zulipchat.com/#narrow/channel/345428-mathlib-reviewers/topic/Proposal.3A.20automatic.20reviewer.20assignment/near/532789070).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
