### PR TITLE
feat(Counterexamples): a nontrivial valuation with discrete topology

### DIFF
--- a/Counterexamples.lean
+++ b/Counterexamples.lean
@@ -5,6 +5,7 @@ import Counterexamples.CliffordAlgebraNotInjective
 import Counterexamples.Cyclotomic105
 import Counterexamples.DirectSumIsInternal
 import Counterexamples.DiscreteTopologyNonDiscreteUniformity
+import Counterexamples.DiscreteTopologyWithNontrivialValuation
 import Counterexamples.GameMultiplication
 import Counterexamples.Girard
 import Counterexamples.HomogeneousPrimeNotPrime

--- a/Counterexamples/DiscreteTopologyWithNontrivialValuation.lean
+++ b/Counterexamples/DiscreteTopologyWithNontrivialValuation.lean
@@ -1,6 +1,23 @@
+/-
+Copyright (c) 2025 Kenny Lau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kenny Lau
+-/
+
 import Mathlib.FieldTheory.RatFunc.AsPolynomial
 import Mathlib.RingTheory.Valuation.RankOne
 import Mathlib.Topology.Algebra.Valued.ValuativeRel
+
+/-!
+# A Non-Trivial Valuation with a Discrete Topology
+
+In this file we construct a valuation on `K[X]` satisfying `1 < v(X)`, and show that this valuation
+is non-trivial (and even rank one), but has a discrete topology.
+
+At the end, the `example` shows that this is not possible for fields.
+
+-/
+
 
 -- Do these belong to another file?
 namespace Valuation

--- a/Counterexamples/DiscreteTopologyWithNontrivialValuation.lean
+++ b/Counterexamples/DiscreteTopologyWithNontrivialValuation.lean
@@ -20,7 +20,7 @@ lemma IsEquiv.isNontrivial (hv : v₁.IsEquiv v₂) [v₁.IsNontrivial] : v₂.I
   hv.isNontrivial_iff_isNontrivial.mp ‹_›
 
 lemma IsEquiv.isNontrivial' (hv : v₁.IsEquiv v₂) [v₂.IsNontrivial] : v₁.IsNontrivial :=
-  hv.isNontrivial_iff_isNontrivial.mpr ‹_›
+  hv.symm.isNontrivial
 
 end Valuation
 

--- a/Counterexamples/DiscreteTopologyWithNontrivialValuation.lean
+++ b/Counterexamples/DiscreteTopologyWithNontrivialValuation.lean
@@ -106,6 +106,23 @@ attribute [local instance] compatible
 nonrec theorem isEquiv : (valuation K[X]).IsEquiv (infinityValuation K) :=
   isEquiv _ _
 
+theorem isNontrivial : (infinityValuation K).IsNontrivial where
+  exists_val_nontrivial := ⟨X, by simpa using by decide⟩
+attribute [local instance] isNontrivial
+
+theorem isNontrivial' : IsNontrivial K[X] :=
+  isNontrivial_iff_isNontrivial.mpr <| (isEquiv K).isNontrivial'
+attribute [local instance] isNontrivial'
+
+theorem isRankLeOne' : IsRankLeOne K[X] :=
+  .of_compatible_mulArchimedean (infinityValuation K)
+attribute [local instance] isRankLeOne'
+
+/-- An arbitrary rank one instance on `valuation K[X]`. -/
+noncomputable def rankOne' : (valuation K[X]).RankOne :=
+  instRankOneValueGroupWithZeroValuationOfIsNontrivialOfIsRankLeOne
+attribute [local instance] rankOne'
+
 @[simp] theorem valuation_lt_one_iff (p : K[X]) : valuation K[X] p < 1 ↔ p = 0 := by
   rw [(isEquiv K).lt_one_iff_lt_one]
   exact ⟨fun hp ↦ by_contra fun hp0 ↦ not_le_of_gt hp (one_le_valuation p hp0), (· ▸ by simp)⟩
@@ -115,20 +132,17 @@ theorem isValuativeTopology : IsValuativeTopology K[X] where
     fun ⟨γ, hγ⟩ ↦ mem_nhds_discrete.mpr <| hγ ⟨0, by simp⟩⟩
 attribute [local instance] isValuativeTopology
 
-theorem isNontrivial : IsNontrivial K[X] :=
-  isNontrivial_iff_isNontrivial.mpr <| (isEquiv K).isNontrivial'
-attribute [local instance] isNontrivial
-
 /-- With the valuation on `K[X]` sending `X` to `37` and `K` to `1`, we get a non-trivial (rank one)
 valuation but with a discrete topology. -/
-example : IsValuativeTopology K[X] ∧ IsNontrivial K[X] ∧ DiscreteTopology K[X] :=
-  ⟨inferInstance, inferInstance, inferInstance⟩
+example : IsValuativeTopology K[X] ∧ Nonempty (valuation K[X]).RankOne ∧
+    IsNontrivial K[X] ∧ DiscreteTopology K[X] :=
+  ⟨inferInstance, ⟨inferInstance⟩, inferInstance, inferInstance⟩
 
 end Polynomial
 
 open ValuativeRel
 
-/-- Does not happen for fields. -/
+/-- Does not happen for fields (even without assuming rank one). -/
 example {F : Type*} [Field F] [ValuativeRel F] [TopologicalSpace F]
     (h : IsValuativeTopology F ∧ IsNontrivial F ∧ DiscreteTopology F) :
     False := by

--- a/Counterexamples/DiscreteTopologyWithNontrivialValuation.lean
+++ b/Counterexamples/DiscreteTopologyWithNontrivialValuation.lean
@@ -91,11 +91,11 @@ theorem discreteTopology : DiscreteTopology K[X] :=
 attribute [local instance] discreteTopology
 
 /-- `X` is sent to `37`. -/
-noncomputable def rankOne' : (infinityValuation K).RankOne where
+noncomputable def rankOne : (infinityValuation K).RankOne where
   exists_val_nontrivial := ⟨X, by simpa using by decide⟩
   hom := toNNReal (e := 37) (by norm_num)
   strictMono' := toNNReal_strictMono (by norm_num)
-attribute [local instance] rankOne'
+attribute [local instance] rankOne
 
 open ValuativeRel
 

--- a/Counterexamples/DiscreteTopologyWithNontrivialValuation.lean
+++ b/Counterexamples/DiscreteTopologyWithNontrivialValuation.lean
@@ -118,10 +118,7 @@ theorem isRankLeOne' : IsRankLeOne K[X] :=
   .of_compatible_mulArchimedean (infinityValuation K)
 attribute [local instance] isRankLeOne'
 
-/-- An arbitrary rank one instance on `valuation K[X]`. -/
-noncomputable def rankOne' : (valuation K[X]).RankOne :=
-  instRankOneValueGroupWithZeroValuationOfIsNontrivialOfIsRankLeOne
-attribute [local instance] rankOne'
+noncomputable example : (valuation K[X]).RankOne := inferInstance
 
 @[simp] theorem valuation_lt_one_iff (p : K[X]) : valuation K[X] p < 1 ↔ p = 0 := by
   rw [(isEquiv K).lt_one_iff_lt_one]

--- a/Counterexamples/DiscreteTopologyWithNontrivialValuation.lean
+++ b/Counterexamples/DiscreteTopologyWithNontrivialValuation.lean
@@ -123,10 +123,6 @@ attribute [local instance] compatible
 nonrec theorem isEquiv : (valuation K[X]).IsEquiv (infinityValuation K) :=
   isEquiv _ _
 
-theorem isNontrivial : (infinityValuation K).IsNontrivial where
-  exists_val_nontrivial := ⟨X, by simpa using by decide⟩
-attribute [local instance] isNontrivial
-
 theorem isNontrivial' : IsNontrivial K[X] :=
   isNontrivial_iff_isNontrivial.mpr <| (isEquiv K).isNontrivial'
 attribute [local instance] isNontrivial'

--- a/Counterexamples/DiscreteTopologyWithNontrivialValuation.lean
+++ b/Counterexamples/DiscreteTopologyWithNontrivialValuation.lean
@@ -1,0 +1,109 @@
+import Mathlib.FieldTheory.RatFunc.AsPolynomial
+import Mathlib.RingTheory.Valuation.RankOne
+import Mathlib.Topology.Algebra.Valued.ValuativeRel
+
+-- MOVE
+namespace Valuation
+
+variable {R Γ₀ Γ'₀ : Type*} [Ring R]
+  [LinearOrderedCommMonoidWithZero Γ₀] [LinearOrderedCommMonoidWithZero Γ'₀]
+  {v₁ : Valuation R Γ₀} {v₂ : Valuation R Γ'₀}
+
+attribute [mk_iff] Valuation.IsNontrivial
+
+lemma IsEquiv.isNontrivial_iff_isNontrivial (hv : v₁.IsEquiv v₂) :
+    v₁.IsNontrivial ↔ v₂.IsNontrivial := by
+  rw [isNontrivial_iff, isNontrivial_iff]
+  simp_rw [ne_eq, ← v₁.map_zero, ← v₁.map_one, ← v₂.map_zero, ← v₂.map_one, hv.val_eq]
+
+lemma IsEquiv.isNontrivial (hv : v₁.IsEquiv v₂) [v₁.IsNontrivial] : v₂.IsNontrivial :=
+  hv.isNontrivial_iff_isNontrivial.mp ‹_›
+
+lemma IsEquiv.isNontrivial' (hv : v₁.IsEquiv v₂) [v₂.IsNontrivial] : v₁.IsNontrivial :=
+  hv.isNontrivial_iff_isNontrivial.mpr ‹_›
+
+end Valuation
+
+namespace Polynomial
+
+open WithZero WithZeroMulInt NNReal
+
+variable (K : Type*) [Field K]
+
+/-- The valuation on `K[X]` that corresponds to the "point at infinity" on the projective line `ℙ¹`,
+sending `X` to `WithZero.exp 1`. -/
+noncomputable def infinityValuation : Valuation K[X] ℤᵐ⁰ :=
+  ((idealX K).valuation (RatFunc K)).comap <| RingHomClass.toRingHom <| aeval .X⁻¹
+
+@[simp] lemma infinityValuation_X : infinityValuation K X = exp 1 := by
+  simp [infinityValuation, exp]
+
+/-- The valuative relation defined by `infinityValuation K`. -/
+def infinityValuativeRel : ValuativeRel K[X] :=
+  .ofValuation <| infinityValuation K
+attribute [local instance] infinityValuativeRel
+
+/-- The discrete topology on `K[X]`. -/
+def topology : TopologicalSpace K[X] :=
+  ⊥
+attribute [local instance] topology
+
+theorem discreteTopology : DiscreteTopology K[X] :=
+  discreteTopology_bot K[X]
+attribute [local instance] discreteTopology
+
+/-- `X` is sent to `37`. -/
+noncomputable def rankOne' : (infinityValuation K).RankOne where
+  exists_val_nontrivial := ⟨X, by simpa using by decide⟩
+  hom := toNNReal (e := 37) (by norm_num)
+  strictMono' := toNNReal_strictMono (by norm_num)
+attribute [local instance] rankOne'
+
+open ValuativeRel
+
+theorem compatible : (infinityValuation K).Compatible :=
+  .ofValuation _
+attribute [local instance] compatible
+
+nonrec theorem isEquiv : (valuation K[X]).IsEquiv (infinityValuation K) :=
+  isEquiv _ _
+
+@[simp] theorem valuation_lt_one_iff (p : K[X]) : valuation K[X] p < 1 ↔ p = 0 := by
+  rw [(isEquiv K).lt_one_iff_lt_one, infinityValuation, Valuation.comap_apply]
+  sorry
+
+theorem isValuativeTopology : IsValuativeTopology K[X] where
+  mem_nhds_iff {s x} := ⟨fun hsx ↦ ⟨1, by simp [mem_of_mem_nhds hsx]⟩,
+    fun ⟨γ, hγ⟩ ↦ mem_nhds_discrete.mpr <| hγ ⟨0, by simp⟩⟩
+attribute [local instance] isValuativeTopology
+
+theorem isNontrivial : IsNontrivial K[X] :=
+  isNontrivial_iff_isNontrivial.mpr <| (isEquiv K).isNontrivial'
+attribute [local instance] isNontrivial
+
+/-- With the valuation on `K[X]` sending `X` to `37` and `K` to `1`, we get a non-trivial (rank one)
+valuation but with a discrete topology. -/
+example : IsValuativeTopology K[X] ∧ IsNontrivial K[X] ∧ DiscreteTopology K[X] :=
+  ⟨inferInstance, inferInstance, inferInstance⟩
+
+end Polynomial
+
+open ValuativeRel
+
+/-- Does not happen for fields. -/
+example {F : Type*} [Field F] [ValuativeRel F] [TopologicalSpace F]
+    (h : IsValuativeTopology F ∧ IsNontrivial F ∧ DiscreteTopology F) :
+    False := by
+  obtain ⟨_, _, _⟩ := h
+  -- This proof can be simplified with other unmerged PR's.
+  obtain ⟨γ, -, hγ⟩ := (IsValuativeTopology.hasBasis_nhds_zero F).mem_iff.mp
+    (mem_nhds_discrete.mpr (Set.mem_singleton 0))
+  have := isNontrivial_iff_isNontrivial.mp (inferInstanceAs (IsNontrivial F))
+  obtain ⟨x, h0x, hx1⟩ := Valuation.IsNontrivial.exists_lt_one (v := valuation F)
+  obtain ⟨a, b, hab⟩ := valuation_surjective (R := F) γ
+  have := @hγ (x * (a / b)) (by simp [hab, hx1])
+  rw [Set.mem_singleton_iff, mul_eq_zero, div_eq_zero_iff] at this
+  obtain rfl | rfl | hb0 := this
+  · exact h0x (map_zero _)
+  · simp [eq_comm] at hab
+  · exact val_posSubmonoid_ne_zero b hb0


### PR DESCRIPTION
This file constructs a valuation on `K[X]` satisfying `IsValuativeTopology K[X] ∧ Nonempty (valuation K[X]).RankOne ∧ IsNontrivial K[X] ∧ DiscreteTopology K[X]`, and proves that `IsValuativeTopology F ∧ IsNontrivial F ∧ DiscreteTopology F` is not possible if `F` is a field.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
