### PR TITLE
[Merged by Bors] - feat(Topology/ContinuousMap/Lattice): add instance `IsOrderedAddMonoid`

### DIFF
--- a/Mathlib/Topology/ContinuousMap/Lattice.lean
+++ b/Mathlib/Topology/ContinuousMap/Lattice.lean
@@ -28,14 +28,9 @@ section Lattice
 /-! `C(α, β)`is a lattice ordered group -/
 
 @[to_additive]
-instance instMulLeftMono [PartialOrder β] [Mul β] [ContinuousMul β] [MulLeftMono β] :
-    MulLeftMono C(α, β) :=
-  ⟨fun _ _ _ hg₁₂ x => mul_le_mul_left' (hg₁₂ x) _⟩
-
-@[to_additive]
-instance instMulRightMono [PartialOrder β] [Mul β] [ContinuousMul β] [MulRightMono β] :
-    MulRightMono C(α, β) :=
-  ⟨fun _ _ _ hg₁₂ x => mul_le_mul_right' (hg₁₂ x) _⟩
+instance [PartialOrder β] [CommMonoid β] [IsOrderedMonoid β] [ContinuousMul β] :
+    IsOrderedMonoid C(α, β) where
+  mul_le_mul_left _ _ hfg c x := mul_le_mul_left' (hfg x) (c x)
 
 variable [Group β] [IsTopologicalGroup β] [Lattice β] [TopologicalLattice β]
 
@@ -46,14 +41,5 @@ lemma coe_mabs (f : C(α, β)) : ⇑|f|ₘ = |⇑f|ₘ := rfl
 lemma mabs_apply (f : C(α, β)) (x : α) : |f|ₘ x = |f x|ₘ := rfl
 
 end Lattice
-
-section IsOrderedAddMonoid
-
-variable [AddCommMonoid β] [ContinuousAdd β] [PartialOrder β] [IsOrderedAddMonoid β]
-
-instance : IsOrderedAddMonoid C(α, β) where
-  add_le_add_left _ _ hfg c := add_le_add_left hfg c
-
-end IsOrderedAddMonoid
 
 end ContinuousMap

--- a/Mathlib/Topology/ContinuousMap/Lattice.lean
+++ b/Mathlib/Topology/ContinuousMap/Lattice.lean
@@ -20,10 +20,10 @@ in terms of `ContinuousMap.abs`.
 
 namespace ContinuousMap
 
-section Lattice
-
 variable {α : Type*} [TopologicalSpace α]
 variable {β : Type*} [TopologicalSpace β]
+
+section Lattice
 
 /-! `C(α, β)`is a lattice ordered group -/
 
@@ -46,5 +46,14 @@ lemma coe_mabs (f : C(α, β)) : ⇑|f|ₘ = |⇑f|ₘ := rfl
 lemma mabs_apply (f : C(α, β)) (x : α) : |f|ₘ x = |f x|ₘ := rfl
 
 end Lattice
+
+section IsOrderedAddMonoid
+
+variable [AddCommMonoid β] [ContinuousAdd β] [PartialOrder β] [IsOrderedAddMonoid β]
+
+instance : IsOrderedAddMonoid C(α, β) where
+  add_le_add_left _ _ hfg c := add_le_add_left hfg c
+
+end IsOrderedAddMonoid
 
 end ContinuousMap


### PR DESCRIPTION
add instance `IsOrderedAddMonoid C(α, β)`

motivation: with this one can use [PositiveLinearMap.mk₀](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Order/Module/PositiveLinearMap.html#PositiveLinearMap.mk%E2%82%80), which will be used in the proof of uniqueness of measure, cf. https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Uniqueness.20in.20Riesz.E2.80.93Markov.E2.80.93Kakutani.20representation.20theorem .