### PR TITLE
[Merged by Bors] - chore(Data/Setoid/Basic): un-indent some doc-strings to match the style guide

### DIFF
--- a/Mathlib/Data/Setoid/Basic.lean
+++ b/Mathlib/Data/Setoid/Basic.lean
@@ -81,8 +81,8 @@ theorem ker_def {f : α → β} {x y : α} : ker f x y ↔ f x = f y :=
   Iff.rfl
 
 /-- Given types `α`, `β`, the product of two equivalence relations `r` on `α` and `s` on `β`:
-    `(x₁, x₂), (y₁, y₂) ∈ α × β` are related by `r.prod s` iff `x₁` is related to `y₁`
-    by `r` and `x₂` is related to `y₂` by `s`. -/
+`(x₁, x₂), (y₁, y₂) ∈ α × β` are related by `r.prod s` iff `x₁` is related to `y₁`
+by `r` and `x₂` is related to `y₂` by `s`. -/
 protected def prod (r : Setoid α) (s : Setoid β) :
     Setoid (α × β) where
   r x y := r x.1 y.1 ∧ s x.2 y.2
@@ -141,7 +141,7 @@ instance : Min (Setoid α) :=
         ⟨r.trans' h1.1 h2.1, s.trans' h1.2 h2.2⟩⟩⟩⟩
 
 /-- The infimum of 2 equivalence relations r and s is the same relation as the infimum
-    of the underlying binary operations. -/
+of the underlying binary operations. -/
 theorem inf_def {r s : Setoid α} : ⇑(r ⊓ s) = ⇑r ⊓ ⇑s :=
   rfl
 
@@ -156,7 +156,7 @@ instance : InfSet (Setoid α) :=
         r.trans' (h1 r hr) <| h2 r hr⟩ }⟩
 
 /-- The underlying binary operation of the infimum of a set of equivalence relations
-    is the infimum of the set's image under the map to the underlying binary operation. -/
+is the infimum of the set's image under the map to the underlying binary operation. -/
 theorem sInf_def {s : Set (Setoid α)} : ⇑(sInf s) = sInf ((⇑) '' s) := by
   ext
   simp only [sInf_image, iInf_apply, iInf_Prop_eq]
@@ -171,7 +171,7 @@ instance : PartialOrder (Setoid α) where
   le_antisymm _ _ h1 h2 := Setoid.ext fun _ _ => ⟨fun h => h1 h, fun h => h2 h⟩
 
 /-- The complete lattice of equivalence relations on a type, with bottom element `=`
-    and top element the trivial equivalence relation. -/
+and top element the trivial equivalence relation. -/
 instance completeLattice : CompleteLattice (Setoid α) :=
   { (completeLatticeOfInf (Setoid α)) fun _ =>
       ⟨fun _ hr _ _ h => h _ hr, fun _ hr _ _ h _ hr' => hr hr' h⟩ with
@@ -222,7 +222,7 @@ section EqvGen
 open Relation
 
 /-- The inductively defined equivalence closure of a binary relation r is the infimum
-    of the set of all equivalence relations containing r. -/
+of the set of all equivalence relations containing r. -/
 theorem eqvGen_eq (r : α → α → Prop) :
     EqvGen.setoid r = sInf { s : Setoid α | ∀ ⦃x y⦄, r x y → s x y } :=
   le_antisymm
@@ -232,7 +232,7 @@ theorem eqvGen_eq (r : α → α → Prop) :
     (sInf_le fun _ _ h => EqvGen.rel _ _ h)
 
 /-- The supremum of two equivalence relations r and s is the equivalence closure of the binary
-    relation `x is related to y by r or s`. -/
+relation `x is related to y by r or s`. -/
 theorem sup_eq_eqvGen (r s : Setoid α) :
     r ⊔ s = EqvGen.setoid fun x y => r x y ∨ s x y := by
   rw [eqvGen_eq]
@@ -240,12 +240,12 @@ theorem sup_eq_eqvGen (r s : Setoid α) :
   simp only [le_def, or_imp, ← forall_and]
 
 /-- The supremum of 2 equivalence relations r and s is the equivalence closure of the
-    supremum of the underlying binary operations. -/
+supremum of the underlying binary operations. -/
 theorem sup_def {r s : Setoid α} : r ⊔ s = EqvGen.setoid (⇑r ⊔ ⇑s) := by
   rw [sup_eq_eqvGen]; rfl
 
 /-- The supremum of a set S of equivalence relations is the equivalence closure of the binary
-    relation `there exists r ∈ S relating x and y`. -/
+relation `there exists r ∈ S relating x and y`. -/
 theorem sSup_eq_eqvGen (S : Set (Setoid α)) :
     sSup S = EqvGen.setoid fun x y => ∃ r : Setoid α, r ∈ S ∧ r x y := by
   rw [eqvGen_eq]
@@ -255,7 +255,7 @@ theorem sSup_eq_eqvGen (S : Set (Setoid α)) :
   exact ⟨fun H x y r hr => H hr, fun H r hr x y => H r hr⟩
 
 /-- The supremum of a set of equivalence relations is the equivalence closure of the
-    supremum of the set's image under the map to the underlying binary operation. -/
+supremum of the set's image under the map to the underlying binary operation. -/
 theorem sSup_def {s : Set (Setoid α)} : sSup s = EqvGen.setoid (sSup ((⇑) '' s)) := by
   rw [sSup_eq_eqvGen, sSup_image]
   congr with (x y)
@@ -271,7 +271,7 @@ theorem eqvGen_idem (r : α → α → Prop) : EqvGen.setoid (EqvGen.setoid r) =
   eqvGen_of_setoid _
 
 /-- The equivalence closure of a binary relation r is contained in any equivalence
-    relation containing r. -/
+relation containing r. -/
 theorem eqvGen_le {r : α → α → Prop} {s : Setoid α} (h : ∀ x y, r x y → s x y) :
     EqvGen.setoid r ≤ s := by rw [eqvGen_eq]; exact sInf_le h
 
@@ -281,7 +281,7 @@ theorem eqvGen_mono {r s : α → α → Prop} (h : ∀ x y, r x y → s x y) :
   eqvGen_le fun _ _ hr => EqvGen.rel _ _ <| h _ _ hr
 
 /-- There is a Galois insertion of equivalence relations on α into binary relations
-    on α, with equivalence closure the lower adjoint. -/
+on α, with equivalence closure the lower adjoint. -/
 def gi : @GaloisInsertion (α → α → Prop) (Setoid α) _ _ EqvGen.setoid (⇑) where
   choice r _ := EqvGen.setoid r
   gc _ s := ⟨fun H _ _ h => H <| EqvGen.rel _ _ h, fun H => eqvGen_of_setoid s ▸ eqvGen_mono H⟩
@@ -293,7 +293,7 @@ end EqvGen
 open Function
 
 /-- A function from α to β is injective iff its kernel is the bottom element of the complete lattice
-    of equivalence relations on α. -/
+of equivalence relations on α. -/
 theorem injective_iff_ker_bot (f : α → β) : Injective f ↔ ker f = ⊥ :=
   (@eq_bot_iff (Setoid α) _ _ (ker f)).symm
 
@@ -315,12 +315,12 @@ theorem lift_unique {r : Setoid α} {f : α → β} (H : r ≤ ker f) (g : Quoti
   rw [← Quotient.mk, Quotient.lift_mk f H, Hg, Function.comp_apply, Quotient.mk''_eq_mk]
 
 /-- Given a map f from α to β, the natural map from the quotient of α by the kernel of f is
-    injective. -/
+injective. -/
 theorem ker_lift_injective (f : α → β) : Injective (@Quotient.lift _ _ (ker f) f fun _ _ h => h) :=
   fun x y => Quotient.inductionOn₂' x y fun _ _ h => Quotient.sound' h
 
 /-- Given a map f from α to β, the kernel of f is the unique equivalence relation on α whose
-    induced map from the quotient of α to β is injective. -/
+induced map from the quotient of α to β is injective. -/
 theorem ker_eq_lift_of_injective {r : Setoid α} (f : α → β) (H : ∀ x y, r x y → f x = f y)
     (h : Injective (Quotient.lift f H)) : ker f = r :=
   le_antisymm
@@ -331,7 +331,7 @@ theorem ker_eq_lift_of_injective {r : Setoid α} (f : α → β) (H : ∀ x y, r
 variable (r : Setoid α) (f : α → β)
 
 /-- The first isomorphism theorem for sets: the quotient of α by the kernel of a function f
-    bijects with f's image. -/
+bijects with f's image. -/
 noncomputable def quotientKerEquivRange : Quotient (ker f) ≃ Set.range f :=
   Equiv.ofBijective
     ((@Quotient.lift _ (Set.range f) (ker f) fun x => ⟨f x, Set.mem_range_self x⟩) fun _ _ h =>
@@ -360,14 +360,14 @@ noncomputable def quotientKerEquivOfSurjective (hf : Surjective f) : Quotient (k
 variable {r f}
 
 /-- Given a function `f : α → β` and equivalence relation `r` on `α`, the equivalence
-    closure of the relation on `f`'s image defined by '`x ≈ y` iff the elements of `f⁻¹(x)` are
-    related to the elements of `f⁻¹(y)` by `r`.' -/
+closure of the relation on `f`'s image defined by '`x ≈ y` iff the elements of `f⁻¹(x)` are
+related to the elements of `f⁻¹(y)` by `r`.' -/
 def map (r : Setoid α) (f : α → β) : Setoid β :=
   Relation.EqvGen.setoid (Relation.Map r f f)
 
 /-- Given a surjective function f whose kernel is contained in an equivalence relation r, the
-    equivalence relation on f's codomain defined by x ≈ y ↔ the elements of f⁻¹(x) are related to
-    the elements of f⁻¹(y) by r. -/
+equivalence relation on f's codomain defined by x ≈ y ↔ the elements of f⁻¹(x) are related to
+the elements of f⁻¹(y) by r. -/
 def mapOfSurjective (r : Setoid α) (f : α → β) (h : ker f ≤ r) (hf : Surjective f) : Setoid β :=
   ⟨Relation.Map r f f, Relation.map_equivalence r.iseqv f hf h⟩
 
@@ -387,7 +387,7 @@ theorem comap_rel (f : α → β) (r : Setoid β) (x y : α) : comap f r x y ↔
   Iff.rfl
 
 /-- Given a map `f : N → M` and an equivalence relation `r` on `β`, the equivalence relation
-    induced on `α` by `f` equals the kernel of `r`'s quotient map composed with `f`. -/
+induced on `α` by `f` equals the kernel of `r`'s quotient map composed with `f`. -/
 theorem comap_eq {f : α → β} {r : Setoid β} : comap f r = ker (@Quotient.mk'' _ r ∘ f) :=
   ext fun x y => show _ ↔ ⟦_⟧ = ⟦_⟧ by rw [Quotient.eq]; rfl
 


### PR DESCRIPTION
The style guide asks for subsequent lines in doc-strings to not be indented ([zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Style.20.3Abicycle.3A.20.3A.20indenting.20second.20lines.20in.20doc-strings/with/513186492)). This fixes some violations.

Found by the linter in #27996.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
