### PR TITLE
[Merged by Bors] - chore: remove inlined lake-build-with-retry.sh from workflow, improve log messages

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -148,57 +148,6 @@ jobs:
           ls .lake/build/bin/check-yaml
           ls .lake/packages/importGraph/.lake/build/bin/graph
 
-          # TEMPORARY: remove everything below this after #27691 is merged
-          cat << 'EOF' > scripts/lake-build-with-retry.sh
-          #!/bin/bash
-          # Script to run lake build on a target until --no-build succeeds
-          # Usage: ./lake-build-with-retry.sh <target_name> [max_tries, default: 5]
-
-          # Make this script robust against unintentional errors.
-          # See e.g. http://redsymbol.net/articles/unofficial-bash-strict-mode/ for explanation.
-          set -euo pipefail
-          IFS=$'\n\t'
-
-          TARGET_NAME="$1"
-          MAX_TRIES="${2:-5}"
-
-          if [ -z "$TARGET_NAME" ]; then
-            echo "Usage: $0 <target_name> [max_tries, default: 5]"
-            echo "Example: $0 Mathlib 5"
-            exit 1
-          fi
-
-          echo "Building $TARGET_NAME with up to $MAX_TRIES attempts..."
-
-          counter=0
-          while true; do
-            counter=$((counter + 1))
-
-            echo "::group::{lake build: attempt $counter}"
-            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI $TARGET_NAME"
-            echo "::endgroup::"
-
-            echo "::group::{lake build --no-build: attempt $counter}"
-            set +e
-            lake build --no-build -v "$TARGET_NAME"
-            result=$?
-            set -e
-            echo "::endgroup::"
-
-            if [ $result -eq 0 ]; then
-              echo "lake build --no-build succeeded!"
-              exit 0
-            fi
-
-            if [ $counter -ge $MAX_TRIES ]; then
-              echo "Failed to build good oleans for $TARGET_NAME after $MAX_TRIES attempts!"
-              exit 1
-            fi
-          done
-          EOF
-
-          chmod 755 scripts/lake-build-with-retry.sh
-
       - name: cleanup .cache/mathlib
         # This needs write access to .cache/mathlib, so can't be run inside landrun.
         # However it is only using the `master` version of `cache`, so is safe to run outside landrun.

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -314,7 +314,14 @@ jobs:
 
       - name: Check if building Archive or Counterexamples failed
         if: steps.archive.outcome == 'failure' || steps.counterexamples.outcome == 'failure'
-        run: exit 1
+        run: |
+          if [ "${{ steps.archive.outcome }}" == "failure" ]; then
+            echo "❌ The \"build archive\" step above failed; please check its logs."
+          fi
+          if [ "${{ steps.counterexamples.outcome }}" == "failure" ]; then
+            echo "❌ The \"build counterexamples\" step above failed; please check its logs."
+          fi
+          exit 1
 
       # The cache secrets are available here, so we must not run any untrusted code.
       - name: put archive and counterexamples cache

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -158,57 +158,6 @@ jobs:
           ls .lake/build/bin/check-yaml
           ls .lake/packages/importGraph/.lake/build/bin/graph
 
-          # TEMPORARY: remove everything below this after #27691 is merged
-          cat << 'EOF' > scripts/lake-build-with-retry.sh
-          #!/bin/bash
-          # Script to run lake build on a target until --no-build succeeds
-          # Usage: ./lake-build-with-retry.sh <target_name> [max_tries, default: 5]
-
-          # Make this script robust against unintentional errors.
-          # See e.g. http://redsymbol.net/articles/unofficial-bash-strict-mode/ for explanation.
-          set -euo pipefail
-          IFS=$'\n\t'
-
-          TARGET_NAME="$1"
-          MAX_TRIES="${2:-5}"
-
-          if [ -z "$TARGET_NAME" ]; then
-            echo "Usage: $0 <target_name> [max_tries, default: 5]"
-            echo "Example: $0 Mathlib 5"
-            exit 1
-          fi
-
-          echo "Building $TARGET_NAME with up to $MAX_TRIES attempts..."
-
-          counter=0
-          while true; do
-            counter=$((counter + 1))
-
-            echo "::group::{lake build: attempt $counter}"
-            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI $TARGET_NAME"
-            echo "::endgroup::"
-
-            echo "::group::{lake build --no-build: attempt $counter}"
-            set +e
-            lake build --no-build -v "$TARGET_NAME"
-            result=$?
-            set -e
-            echo "::endgroup::"
-
-            if [ $result -eq 0 ]; then
-              echo "lake build --no-build succeeded!"
-              exit 0
-            fi
-
-            if [ $counter -ge $MAX_TRIES ]; then
-              echo "Failed to build good oleans for $TARGET_NAME after $MAX_TRIES attempts!"
-              exit 1
-            fi
-          done
-          EOF
-
-          chmod 755 scripts/lake-build-with-retry.sh
-
       - name: cleanup .cache/mathlib
         # This needs write access to .cache/mathlib, so can't be run inside landrun.
         # However it is only using the `master` version of `cache`, so is safe to run outside landrun.

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -324,7 +324,14 @@ jobs:
 
       - name: Check if building Archive or Counterexamples failed
         if: steps.archive.outcome == 'failure' || steps.counterexamples.outcome == 'failure'
-        run: exit 1
+        run: |
+          if [ "${{ steps.archive.outcome }}" == "failure" ]; then
+            echo "❌ The \"build archive\" step above failed; please check its logs."
+          fi
+          if [ "${{ steps.counterexamples.outcome }}" == "failure" ]; then
+            echo "❌ The \"build counterexamples\" step above failed; please check its logs."
+          fi
+          exit 1
 
       # The cache secrets are available here, so we must not run any untrusted code.
       - name: put archive and counterexamples cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -331,7 +331,14 @@ jobs:
 
       - name: Check if building Archive or Counterexamples failed
         if: steps.archive.outcome == 'failure' || steps.counterexamples.outcome == 'failure'
-        run: exit 1
+        run: |
+          if [ "${{ steps.archive.outcome }}" == "failure" ]; then
+            echo "❌ The \"build archive\" step above failed; please check its logs."
+          fi
+          if [ "${{ steps.counterexamples.outcome }}" == "failure" ]; then
+            echo "❌ The \"build counterexamples\" step above failed; please check its logs."
+          fi
+          exit 1
 
       # The cache secrets are available here, so we must not run any untrusted code.
       - name: put archive and counterexamples cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,57 +165,6 @@ jobs:
           ls .lake/build/bin/check-yaml
           ls .lake/packages/importGraph/.lake/build/bin/graph
 
-          # TEMPORARY: remove everything below this after #27691 is merged
-          cat << 'EOF' > scripts/lake-build-with-retry.sh
-          #!/bin/bash
-          # Script to run lake build on a target until --no-build succeeds
-          # Usage: ./lake-build-with-retry.sh <target_name> [max_tries, default: 5]
-
-          # Make this script robust against unintentional errors.
-          # See e.g. http://redsymbol.net/articles/unofficial-bash-strict-mode/ for explanation.
-          set -euo pipefail
-          IFS=$'\n\t'
-
-          TARGET_NAME="$1"
-          MAX_TRIES="${2:-5}"
-
-          if [ -z "$TARGET_NAME" ]; then
-            echo "Usage: $0 <target_name> [max_tries, default: 5]"
-            echo "Example: $0 Mathlib 5"
-            exit 1
-          fi
-
-          echo "Building $TARGET_NAME with up to $MAX_TRIES attempts..."
-
-          counter=0
-          while true; do
-            counter=$((counter + 1))
-
-            echo "::group::{lake build: attempt $counter}"
-            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI $TARGET_NAME"
-            echo "::endgroup::"
-
-            echo "::group::{lake build --no-build: attempt $counter}"
-            set +e
-            lake build --no-build -v "$TARGET_NAME"
-            result=$?
-            set -e
-            echo "::endgroup::"
-
-            if [ $result -eq 0 ]; then
-              echo "lake build --no-build succeeded!"
-              exit 0
-            fi
-
-            if [ $counter -ge $MAX_TRIES ]; then
-              echo "Failed to build good oleans for $TARGET_NAME after $MAX_TRIES attempts!"
-              exit 1
-            fi
-          done
-          EOF
-
-          chmod 755 scripts/lake-build-with-retry.sh
-
       - name: cleanup .cache/mathlib
         # This needs write access to .cache/mathlib, so can't be run inside landrun.
         # However it is only using the `master` version of `cache`, so is safe to run outside landrun.

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -162,57 +162,6 @@ jobs:
           ls .lake/build/bin/check-yaml
           ls .lake/packages/importGraph/.lake/build/bin/graph
 
-          # TEMPORARY: remove everything below this after #27691 is merged
-          cat << 'EOF' > scripts/lake-build-with-retry.sh
-          #!/bin/bash
-          # Script to run lake build on a target until --no-build succeeds
-          # Usage: ./lake-build-with-retry.sh <target_name> [max_tries, default: 5]
-
-          # Make this script robust against unintentional errors.
-          # See e.g. http://redsymbol.net/articles/unofficial-bash-strict-mode/ for explanation.
-          set -euo pipefail
-          IFS=$'\n\t'
-
-          TARGET_NAME="$1"
-          MAX_TRIES="${2:-5}"
-
-          if [ -z "$TARGET_NAME" ]; then
-            echo "Usage: $0 <target_name> [max_tries, default: 5]"
-            echo "Example: $0 Mathlib 5"
-            exit 1
-          fi
-
-          echo "Building $TARGET_NAME with up to $MAX_TRIES attempts..."
-
-          counter=0
-          while true; do
-            counter=$((counter + 1))
-
-            echo "::group::{lake build: attempt $counter}"
-            bash -o pipefail -c "env LEAN_ABORT_ON_PANIC=1 lake build --wfail -KCI $TARGET_NAME"
-            echo "::endgroup::"
-
-            echo "::group::{lake build --no-build: attempt $counter}"
-            set +e
-            lake build --no-build -v "$TARGET_NAME"
-            result=$?
-            set -e
-            echo "::endgroup::"
-
-            if [ $result -eq 0 ]; then
-              echo "lake build --no-build succeeded!"
-              exit 0
-            fi
-
-            if [ $counter -ge $MAX_TRIES ]; then
-              echo "Failed to build good oleans for $TARGET_NAME after $MAX_TRIES attempts!"
-              exit 1
-            fi
-          done
-          EOF
-
-          chmod 755 scripts/lake-build-with-retry.sh
-
       - name: cleanup .cache/mathlib
         # This needs write access to .cache/mathlib, so can't be run inside landrun.
         # However it is only using the `master` version of `cache`, so is safe to run outside landrun.

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -328,7 +328,14 @@ jobs:
 
       - name: Check if building Archive or Counterexamples failed
         if: steps.archive.outcome == 'failure' || steps.counterexamples.outcome == 'failure'
-        run: exit 1
+        run: |
+          if [ "${{ steps.archive.outcome }}" == "failure" ]; then
+            echo "❌ The \"build archive\" step above failed; please check its logs."
+          fi
+          if [ "${{ steps.counterexamples.outcome }}" == "failure" ]; then
+            echo "❌ The \"build counterexamples\" step above failed; please check its logs."
+          fi
+          exit 1
 
       # The cache secrets are available here, so we must not run any untrusted code.
       - name: put archive and counterexamples cache


### PR DESCRIPTION
To merge #27691, I had to inline a copy of  `lake-build-with-retry.sh` into the workflow file (since the workflow always tries to run the `master` branch version of scripts, etc.). Now that that file  exists in the `master` branch, we can remove this code.

I also improved the log messages for the step checking if the archive + counterexamples builds failed.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
