### PR TITLE
[Merged by Bors] - feat: very simple congruence lemmata for circleAverage

### DIFF
--- a/Mathlib/MeasureTheory/Integral/CircleAverage.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleAverage.lean
@@ -117,6 +117,31 @@ theorem circleAverage_congr_codiscreteWithin
   apply ae_restrict_le_codiscreteWithin measurableSet_uIoc
   apply codiscreteWithin.mono (by tauto) (circleMap_preimage_codiscrete hR hf)
 
+/-- If two functions agree on the circle, then their circle averages agree. -/
+theorem circleAverage_congr_sphere {f₁ f₂ : ℂ → E} (hf : Set.EqOn f₁ f₂ (sphere c |R|)) :
+    circleAverage f₁ c R = circleAverage f₂ c R := by
+  unfold circleAverage
+  congr 1
+  apply intervalIntegral.integral_congr (fun x ↦ by simp [hf (circleMap_mem_sphere' c R x)])
+
+/--
+The circle average of a function `f` on the unit sphere equals the circle average of the function
+`z ↦ f z⁻¹`.
+-/
+@[simp]
+theorem circleAverage_zero_one_congr_inv {f : ℂ → E} :
+    circleAverage (f ·⁻¹) 0 1 = circleAverage f 0 1 := by
+  unfold circleAverage
+  congr 1
+  calc ∫ (θ : ℝ) in 0..2 * π, f (circleMap 0 1 θ)⁻¹
+  _ = ∫ (θ : ℝ) in 0..2 * π, f (circleMap 0 1 (-θ)) := by
+    simp [circleMap_zero_inv]
+  _ = ∫ (θ : ℝ) in 0..2 * π, f (circleMap 0 1 θ) := by
+    rw [intervalIntegral.integral_comp_neg (fun w ↦ f (circleMap 0 1 w))]
+    have t₀ : Function.Periodic (fun w ↦ f (circleMap 0 1 w)) (2 * π) :=
+      fun x ↦ by simp [periodic_circleMap 0 1 x]
+    simpa using (t₀.intervalIntegral_add_eq_of_pos two_pi_pos (-(2 * π)) 0)
+
 /-!
 ## Constant Functions
 -/

--- a/Mathlib/MeasureTheory/Integral/CircleAverage.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleAverage.lean
@@ -125,6 +125,19 @@ theorem circleAverage_congr_sphere {f₁ f₂ : ℂ → E} (hf : Set.EqOn f₁ f
   apply intervalIntegral.integral_congr (fun x ↦ by simp [hf (circleMap_mem_sphere' c R x)])
 
 /--
+Express the circle average over an arbitrary circle as a circle average over the unit circle.
+-/
+theorem circleAverage_eq_circleAverage_zero_one :
+    circleAverage f c R = (circleAverage (fun z ↦ f (R * z + c)) 0 1) := by
+  unfold circleAverage
+  congr
+  ext θ
+  unfold circleMap
+  congr 1
+  ring_nf
+  simp
+
+/--
 The circle average of a function `f` on the unit sphere equals the circle average of the function
 `z ↦ f z⁻¹`.
 -/

--- a/Mathlib/MeasureTheory/Integral/CircleAverage.lean
+++ b/Mathlib/MeasureTheory/Integral/CircleAverage.lean
@@ -122,18 +122,15 @@ theorem circleAverage_congr_sphere {f₁ f₂ : ℂ → E} (hf : Set.EqOn f₁ f
     circleAverage f₁ c R = circleAverage f₂ c R := by
   unfold circleAverage
   congr 1
-  apply intervalIntegral.integral_congr (fun x ↦ by simp [hf (circleMap_mem_sphere' c R x)])
+  exact intervalIntegral.integral_congr (fun x ↦ by simp [hf (circleMap_mem_sphere' c R x)])
 
 /--
 Express the circle average over an arbitrary circle as a circle average over the unit circle.
 -/
 theorem circleAverage_eq_circleAverage_zero_one :
     circleAverage f c R = (circleAverage (fun z ↦ f (R * z + c)) 0 1) := by
-  unfold circleAverage
-  congr
-  ext θ
-  unfold circleMap
-  congr 1
+  unfold circleAverage circleMap
+  congr with θ
   ring_nf
   simp
 
@@ -146,10 +143,10 @@ theorem circleAverage_zero_one_congr_inv {f : ℂ → E} :
     circleAverage (f ·⁻¹) 0 1 = circleAverage f 0 1 := by
   unfold circleAverage
   congr 1
-  calc ∫ (θ : ℝ) in 0..2 * π, f (circleMap 0 1 θ)⁻¹
-  _ = ∫ (θ : ℝ) in 0..2 * π, f (circleMap 0 1 (-θ)) := by
+  calc ∫ θ in 0..2 * π, f (circleMap 0 1 θ)⁻¹
+  _ = ∫ θ in 0..2 * π, f (circleMap 0 1 (-θ)) := by
     simp [circleMap_zero_inv]
-  _ = ∫ (θ : ℝ) in 0..2 * π, f (circleMap 0 1 θ) := by
+  _ = ∫ θ in 0..2 * π, f (circleMap 0 1 θ) := by
     rw [intervalIntegral.integral_comp_neg (fun w ↦ f (circleMap 0 1 w))]
     have t₀ : Function.Periodic (fun w ↦ f (circleMap 0 1 w)) (2 * π) :=
       fun x ↦ by simp [periodic_circleMap 0 1 x]


### PR DESCRIPTION
Establish very simple congruence lemmata for `circleAverage`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
