### PR TITLE
[Merged by Bors] - feat: faster NoNatZeroDivisors instance

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1108,6 +1108,7 @@ import Mathlib.Algebra.Ring.Subsemiring.MulOpposite
 import Mathlib.Algebra.Ring.Subsemiring.Order
 import Mathlib.Algebra.Ring.Subsemiring.Pointwise
 import Mathlib.Algebra.Ring.SumsOfSquares
+import Mathlib.Algebra.Ring.Torsion
 import Mathlib.Algebra.Ring.TransferInstance
 import Mathlib.Algebra.Ring.ULift
 import Mathlib.Algebra.Ring.Units

--- a/Mathlib/Algebra/Group/Torsion.lean
+++ b/Mathlib/Algebra/Group/Torsion.lean
@@ -35,6 +35,9 @@ class IsMulTorsionFree where
 
 attribute [to_additive existing] isMulTorsionFree_iff
 
+instance [AddCommMonoid M] [IsAddTorsionFree M] : Lean.Grind.NoNatZeroDivisors M where
+  no_nat_zero_divisors _ _ _ hk habk := IsAddTorsionFree.nsmul_right_injective hk habk
+
 @[to_additive] instance Subsingleton.to_isMulTorsionFree [Subsingleton M] : IsMulTorsionFree M where
   pow_left_injective _ _ := injective_of_subsingleton _
 

--- a/Mathlib/Algebra/NoZeroSMulDivisors/Defs.lean
+++ b/Mathlib/Algebra/NoZeroSMulDivisors/Defs.lean
@@ -103,9 +103,3 @@ lemma noZeroSMulDivisors_int_iff_isAddTorsionFree [AddCommGroup G] :
 
 alias ⟨IsAddTorsionFree.of_noZeroSMulDivisors_nat, _⟩ := noZeroSMulDivisors_nat_iff_isAddTorsionFree
 alias ⟨IsAddTorsionFree.of_noZeroSMulDivisors_int, _⟩ := noZeroSMulDivisors_int_iff_isAddTorsionFree
-
-instance [AddCommGroup M] [NoZeroSMulDivisors ℕ M] : Lean.Grind.NoNatZeroDivisors M := .mk'
-  (eq_zero_of_mul_eq_zero := by
-    intro k a hk h
-    rw [← smul_eq_zero_iff_right hk]
-    exact h)

--- a/Mathlib/Algebra/Ring/Torsion.lean
+++ b/Mathlib/Algebra/Ring/Torsion.lean
@@ -1,0 +1,20 @@
+/-
+Copyright (c) 2025 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+import Mathlib.Algebra.Group.Torsion
+import Mathlib.Algebra.CharZero.Defs
+import Mathlib.Algebra.GroupWithZero.Basic
+import Mathlib.Algebra.Ring.Regular
+
+/-!
+# Torsion-free rings
+
+A characteristic zero domain is torsion-free.
+-/
+
+instance (R : Type*) [Semiring R] [IsDomain R] [CharZero R] : IsAddTorsionFree R where
+  nsmul_right_injective n h a b w := by
+    simp only [nsmul_eq_mul, mul_eq_mul_left_iff, Nat.cast_eq_zero] at w
+    grind

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -6,6 +6,7 @@ Authors: Oliver Nash
 import Mathlib.LinearAlgebra.RootSystem.Finite.CanonicalBilinear
 import Mathlib.LinearAlgebra.RootSystem.Reduced
 import Mathlib.LinearAlgebra.RootSystem.Irreducible
+import Mathlib.Algebra.Ring.Torsion
 
 /-!
 # Structural lemmas about finite crystallographic root pairings

--- a/MathlibTest/slow_instances.lean
+++ b/MathlibTest/slow_instances.lean
@@ -1,0 +1,20 @@
+import Mathlib
+
+variable {K : Type*} [Field K] {x : K}
+
+-- This one is dismally slow:
+-- #time
+-- #synth NoZeroSMulDivisors ℕ K
+
+set_option maxHeartbeats 3000 in -- uses under 2000 as of 2025-08-06
+/--
+error: failed to synthesize
+  Lean.Grind.NoNatZeroDivisors K
+
+Hint: Additional diagnostic information may be available using the `set_option diagnostics true` command.
+-/
+#guard_msgs in
+#synth Lean.Grind.NoNatZeroDivisors K
+
+set_option maxHeartbeats 6000 in -- uses about 4000 as of 2025-08-06
+example : x ^ 3 * x ^ 42 = x ^ 45 := by grind


### PR DESCRIPTION
This switches out the instance for `Lean.Grind.NoNatZeroDivisors` to a much faster-to-fail instance. This fixes the slow behaviour reported by @hrmacbeth at  [#lean4 > grind and ordered ring @ 💬](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/grind.20and.20ordered.20ring/near/530466710) and discussed further at [#mathlib4 > type-class inference slow/timing out @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/type-class.20inference.20slow.2Ftiming.20out/near/530602780)

It does require adding an import for the (newly added in #28031) `Mathlib.Algebra.Ring.Torsion` to keep a call to `grind` working. I hope we can actually move this import earlier so people don't get stuck on this instance being missing, and hence grind failing them.

- [x] depends on: #28031

