### PR TITLE
chore: replace `ring` with `simp` where applicable

### DIFF
--- a/Mathlib/Algebra/Quaternion.lean
+++ b/Mathlib/Algebra/Quaternion.lean
@@ -901,7 +901,7 @@ theorem mul_imJ : (a * b).imJ = a.re * b.imJ - a.imI * b.imK + a.imJ * b.re + a.
 
 @[simp]
 theorem mul_imK : (a * b).imK = a.re * b.imK + a.imI * b.imJ - a.imJ * b.imI + a.imK * b.re :=
-  (QuaternionAlgebra.mul_imK a b).trans <| by ring
+  (QuaternionAlgebra.mul_imK a b).trans <| by simp
 
 @[simp, norm_cast]
 theorem coe_mul : ((x * y : R) : ℍ[R]) = x * y := QuaternionAlgebra.coe_mul x y

--- a/Mathlib/Analysis/BoxIntegral/UnitPartition.lean
+++ b/Mathlib/Analysis/BoxIntegral/UnitPartition.lean
@@ -478,7 +478,7 @@ theorem _root_.tendsto_card_div_pow_atTop_volume' (hs₁ : IsBounded s)
     (hs₄ : ∀ ⦃x y : ℝ⦄, 0 < x → x ≤ y → x • s ⊆ y • s) :
     Tendsto (fun x : ℝ ↦ (Nat.card ↑(s ∩ x⁻¹ • L) : ℝ) / x ^ card ι)
       atTop (𝓝 (volume.real s)) := by
-  rw [show volume.real s = volume.real s * 1 ^ card ι by ring]
+  rw [show volume.real s = volume.real s * 1 ^ card ι by simp]
   refine tendsto_of_tendsto_of_tendsto_of_le_of_le' ?_ ?_
     (tendsto_card_div_pow₃ s hs₁ hs₄) (tendsto_card_div_pow₄ s hs₁ hs₄)
   · refine Tendsto.congr' (tendsto_card_div_pow₅ s) (Tendsto.mul ?_ (Tendsto.pow ?_ _))

--- a/Mathlib/Analysis/Convex/SpecificFunctions/Basic.lean
+++ b/Mathlib/Analysis/Convex/SpecificFunctions/Basic.lean
@@ -45,7 +45,7 @@ theorem strictConvexOn_exp : StrictConvexOn ℝ univ exp := by
       exp y - exp x = exp y - exp y * exp (x - y) := by rw [← exp_add]; ring_nf
       _ = exp y * (1 - exp (x - y)) := by ring
       _ < exp y * -(x - y) := by gcongr; linarith [add_one_lt_exp h2.ne]
-      _ = exp y * (y - x) := by ring
+      _ = exp y * (y - x) := by simp
   · have h1 : 0 < z - y := by linarith
     rw [lt_div_iff₀ h1]
     calc
@@ -87,7 +87,7 @@ theorem strictConcaveOn_log_Ioi : StrictConcaveOn ℝ (Ioi 0) log := by
       y⁻¹ * (y - x) = 1 - x / y := by field_simp
       _ < -log (x / y) := by linarith [log_lt_sub_one_of_pos hxy' hxy'']
       _ = -(log x - log y) := by rw [log_div hx.ne' hy.ne']
-      _ = log y - log x := by ring
+      _ = log y - log x := by simp
 
 /-- **Bernoulli's inequality** for real exponents, strict version: for `1 < p` and `-1 ≤ s`, with
 `s ≠ 0`, we have `1 + p * s < (1 + s) ^ p`. -/

--- a/Mathlib/Analysis/InnerProductSpace/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Basic.lean
@@ -484,7 +484,7 @@ theorem re_inner_eq_norm_add_mul_self_sub_norm_mul_self_sub_norm_mul_self_div_tw
 theorem re_inner_eq_norm_mul_self_add_norm_mul_self_sub_norm_sub_mul_self_div_two (x y : E) :
     re ⟪x, y⟫ = (‖x‖ * ‖x‖ + ‖y‖ * ‖y‖ - ‖x - y‖ * ‖x - y‖) / 2 := by
   rw [@norm_sub_mul_self 𝕜]
-  ring
+  simp
 
 /-- Polarization identity: The real part of the inner product, in terms of the norm. -/
 theorem re_inner_eq_norm_add_mul_self_sub_norm_sub_mul_self_div_four (x y : E) :

--- a/Mathlib/Analysis/InnerProductSpace/Symmetric.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Symmetric.lean
@@ -239,7 +239,7 @@ theorem IsSymmetric.inner_map_self_eq_zero {T : E →ₗ[𝕜] E} (hT : T.IsSymm
   refine ⟨fun h x => ?_, fun h => by simp_rw [h, inner_zero_left, forall_const]⟩
   rw [← @inner_self_eq_zero 𝕜, hT.inner_map_polarization]
   simp_rw [h _]
-  ring
+  simp
 
 theorem ker_le_ker_of_range {S T : E →ₗ[𝕜] E} (hS : S.IsSymmetric) (hT : T.IsSymmetric)
     (h : range S ≤ range T) : ker T ≤ ker S := by

--- a/Mathlib/Analysis/MellinTransform.lean
+++ b/Mathlib/Analysis/MellinTransform.lean
@@ -136,7 +136,7 @@ theorem mellin_comp_mul_left (f : ℝ → E) (s : ℂ) {a : ℝ} (ha : 0 < a) :
         (Ioi 0) := fun t ht ↦ by
     dsimp only
     rw [ofReal_mul, mul_cpow_ofReal_nonneg ha.le (le_of_lt ht), ← mul_smul,
-      (by ring : 1 - s = -(s - 1)), cpow_neg, inv_mul_cancel_left₀]
+      (by simp : 1 - s = -(s - 1)), cpow_neg, inv_mul_cancel_left₀]
     rw [Ne, cpow_eq_zero_iff, ofReal_eq_zero, not_and_or]
     exact Or.inl ha.ne'
   rw [setIntegral_congr_fun measurableSet_Ioi this, integral_smul,
@@ -388,7 +388,7 @@ theorem mellin_hasDerivAt_of_isBigO_rpow [NormedSpace ℂ E] {a b : ℝ}
     have u1 : HasDerivAt (fun z : ℂ => (t : ℂ) ^ (z - 1)) (t ^ (y - 1) * log t) y := by
       convert ((hasDerivAt_id' y).sub_const 1).const_cpow (Or.inl ht') using 1
       rw [ofReal_log (le_of_lt ht)]
-      ring
+      simp
     exact u1.smul_const (f t)
   have main := hasDerivAt_integral_of_dominated_loc_of_deriv_le hv0 h1 h2 h3 h4 h5 h6
   simpa only [F', mul_smul] using main

--- a/Mathlib/Analysis/SpecialFunctions/Complex/Arctan.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Complex/Arctan.lean
@@ -108,7 +108,7 @@ lemma hasSum_arctan_aux {z : ℂ} (hz : ‖z‖ < 1) :
   have c₁ := add_lt_add b₁.1 b₂.1
   have c₂ := add_lt_add b₁.2 b₂.2
   rw [show -(π / 2) + -(π / 2) = -π by ring] at c₁
-  rw [show π / 2 + π / 2 = π by ring] at c₂
+  rw [show π / 2 + π / 2 = π by simp] at c₂
   exact ⟨c₁, c₂.le⟩
 
 /-- The power series expansion of `Complex.arctan`, valid on the open unit disc. -/

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/Beta.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/Beta.lean
@@ -176,7 +176,7 @@ theorem betaIntegral_recurrence {u v : ℂ} (hu : 0 < re u) (hv : 0 < re v) :
       have B : HasDerivAt (fun y : ℂ => 1 - y) (-1) ↑x := by
         apply HasDerivAt.const_sub; apply hasDerivAt_id
       convert HasDerivAt.comp (↑x) A B using 1
-      ring
+      simp
     convert (U.mul V).comp_ofReal using 1
     ring
   have h_int := ((betaIntegral_convergent hu hv').const_mul u).sub
@@ -196,9 +196,9 @@ theorem betaIntegral_recurrence {u v : ℂ} (hu : 0 < re u) (hv : 0 < re v) :
   · rw [betaIntegral, betaIntegral, ← sub_eq_zero]
     convert int_ev <;> ring
   · apply IntervalIntegrable.const_mul
-    convert betaIntegral_convergent hu hv'; ring
+    convert betaIntegral_convergent hu hv'; simp
   · apply IntervalIntegrable.const_mul
-    convert betaIntegral_convergent hu' hv; ring
+    convert betaIntegral_convergent hu' hv; simp
 
 /-- Explicit formula for the Beta function when second argument is a positive integer. -/
 theorem betaIntegral_eval_nat_add_one_right {u : ℂ} (hu : 0 < re u) (n : ℕ) :
@@ -265,7 +265,7 @@ theorem GammaSeq_eq_approx_Gamma_integral {s : ℂ} (hs : 0 < re s) {n : ℕ} (h
   push_cast
   have hn' : (n : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr hn
   have A : (n : ℂ) ^ s = (n : ℂ) ^ (s - 1) * n := by
-    conv_lhs => rw [(by ring : s = s - 1 + 1), cpow_add _ _ hn']
+    conv_lhs => rw [(by simp : s = s - 1 + 1), cpow_add _ _ hn']
     simp
   have B : ((x : ℂ) * ↑n) ^ (s - 1) = (x : ℂ) ^ (s - 1) * (n : ℂ) ^ (s - 1) := by
     rw [← ofReal_natCast,

--- a/Mathlib/Analysis/SpecialFunctions/Gamma/BohrMollerup.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gamma/BohrMollerup.lean
@@ -225,7 +225,7 @@ theorem tendsto_logGammaSeq_of_le_one (hf_conv : ConvexOn ℝ (Ioi 0) f)
     Tendsto (logGammaSeq x) atTop (𝓝 <| f x - f 1) := by
   refine tendsto_of_tendsto_of_tendsto_of_le_of_le' (f := logGammaSeq x)
     (g := fun n ↦ f x - f 1 - x * (log (n + 1) - log n)) ?_ tendsto_const_nhds ?_ ?_
-  · have : f x - f 1 = f x - f 1 - x * 0 := by ring
+  · have : f x - f 1 = f x - f 1 - x * 0 := by simp
     nth_rw 2 [this]
     exact Tendsto.sub tendsto_const_nhds (tendsto_log_nat_add_one_sub_log.const_mul _)
   · filter_upwards with n
@@ -263,7 +263,7 @@ theorem tendsto_logGammaSeq (hf_conv : ConvexOn ℝ (Ioi 0) f)
       have := logGammaSeq_add_one (x - 1) (n - 1)
       rw [sub_add_cancel, Nat.sub_add_cancel hn] at this
       rw [this]
-      ring
+      simp
     replace hm :=
       ((Tendsto.congr' this hm).add (tendsto_const_nhds : Tendsto (fun _ => log (x - 1)) _ _)).comp
         (tendsto_add_atTop_nat 1)
@@ -280,7 +280,7 @@ theorem tendsto_logGammaSeq (hf_conv : ConvexOn ℝ (Ioi 0) f)
       rw [sub_add_cancel, Nat.add_sub_cancel]
     rw [this] at hm
     convert hm.sub (tendsto_log_nat_add_one_sub_log.const_mul x) using 2
-    · ring
+    · simp
     · have := hf_feq ((Nat.cast_nonneg m).trans_lt hy)
       rw [sub_add_cancel] at this
       rw [this]

--- a/Mathlib/Analysis/SpecialFunctions/Gaussian/FourierTransform.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Gaussian/FourierTransform.lean
@@ -114,7 +114,7 @@ theorem tendsto_verticalIntegral (hb : 0 < b.re) (c : ℝ) :
       (Eventually.of_forall fun _ => norm_nonneg _)
       ((eventually_ge_atTop (0 : ℝ)).mp
         (Eventually.of_forall fun T hT => verticalIntegral_norm_le hb c hT))
-  rw [(by ring : 0 = 2 * |c| * 0)]
+  rw [(by simp : 0 = 2 * |c| * 0)]
   refine (tendsto_exp_atBot.comp (tendsto_neg_atTop_atBot.comp ?_)).const_mul _
   apply tendsto_atTop_add_const_right
   simp_rw [sq, ← mul_assoc, ← sub_mul]

--- a/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ImproperIntegrals.lean
@@ -276,6 +276,6 @@ theorem integral_Ioi_inv_one_add_sq {i : ℝ} :
 
 @[simp]
 theorem integral_univ_inv_one_add_sq : ∫ (x : ℝ), (1 + x ^ 2)⁻¹ = π :=
-  (by ring : π = (π / 2) - (-(π / 2))) ▸ integral_of_hasDerivAt_of_tendsto hasDerivAt_arctan'
+  (by simp : π = (π / 2) - (-(π / 2))) ▸ integral_of_hasDerivAt_of_tendsto hasDerivAt_arctan'
     integrable_inv_one_add_sq (tendsto_nhds_of_tendsto_nhdsWithin tendsto_arctan_atBot)
     (tendsto_nhds_of_tendsto_nhdsWithin tendsto_arctan_atTop)

--- a/Mathlib/Analysis/SpecialFunctions/Integrability/LogMeromorphic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrability/LogMeromorphic.lean
@@ -47,7 +47,7 @@ theorem intervalIntegrable_log_norm_meromorphicOn (hf : MeromorphicOn f [[a, b]]
     · apply IntervalIntegrable.finsum
       intro i
       apply IntervalIntegrable.const_mul
-      rw [(by ring : a = ((a - i) + i)), (by ring : b = ((b - i) + i))]
+      rw [(by simp : a = ((a - i) + i)), (by simp : b = ((b - i) + i))]
       apply IntervalIntegrable.comp_sub_right (f := (log ‖·‖)) _ i
       simp [norm_eq_abs, log_abs]
     · apply ContinuousOn.intervalIntegrable

--- a/Mathlib/Analysis/SpecialFunctions/Integrals/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals/Basic.lean
@@ -136,7 +136,7 @@ theorem integral_cpow {r : ℂ} (h : -1 < r.re ∨ r ≠ -1 ∧ (0 : ℝ) ∉ [[
     · rcases le_total c 0 with (hc | hc)
       · rw [max_eq_left hc] at hx; exact hx.2.ne
       · rw [min_eq_left hc] at hx; exact hx.1.ne'
-    · contrapose! hr; rw [hr]; ring
+    · contrapose! hr; rw [hr]; simp
   · exact intervalIntegrable_cpow' h
 
 theorem integral_rpow {r : ℝ} (h : -1 < r ∨ r ≠ -1 ∧ (0 : ℝ) ∉ [[a, b]]) :

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Asymptotics.lean
@@ -106,12 +106,12 @@ theorem tendsto_rpow_div_mul_add (a b c : ℝ) (hb : 0 ≠ b) :
 /-- The function `x ^ (1 / x)` tends to `1` at `+∞`. -/
 theorem tendsto_rpow_div : Tendsto (fun x => x ^ ((1 : ℝ) / x)) atTop (𝓝 1) := by
   convert tendsto_rpow_div_mul_add (1 : ℝ) _ (0 : ℝ) zero_ne_one
-  ring
+  simp
 
 /-- The function `x ^ (-1 / x)` tends to `1` at `+∞`. -/
 theorem tendsto_rpow_neg_div : Tendsto (fun x => x ^ (-(1 : ℝ) / x)) atTop (𝓝 1) := by
   convert tendsto_rpow_div_mul_add (-(1 : ℝ)) _ (0 : ℝ) zero_ne_one
-  ring
+  simp
 
 /-- The function `exp(x) / x ^ s` tends to `+∞` at `+∞`, for any real number `s`. -/
 theorem tendsto_exp_div_rpow_atTop (s : ℝ) : Tendsto (fun x : ℝ => exp x / x ^ s) atTop atTop := by

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Deriv.lean
@@ -264,7 +264,7 @@ theorem hasDerivAt_ofReal_cpow_const' {x : ℝ} (hx : x ≠ 0) {r : ℂ} (hr : r
       rw [real_smul, ofReal_neg 1, ofReal_one]; ring
     suffices HasDerivAt (fun y : ℂ => y ^ (r + 1)) ((r + 1) * ↑(-x) ^ r) ↑(-x) by
       exact this.comp_ofReal
-    conv in ↑_ ^ _ => rw [(by ring : r = r + 1 - 1)]
+    conv in ↑_ ^ _ => rw [(by simp : r = r + 1 - 1)]
     convert HasDerivAt.cpow_const ?_ ?_ using 1
     · rw [add_sub_cancel_right, add_sub_cancel_right]; exact (mul_one _).symm
     · exact hasDerivAt_id ((-x : ℝ) : ℂ)

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Real.lean
@@ -97,7 +97,7 @@ theorem rpow_def_of_neg {x : ℝ} (hx : x < 0) (y : ℝ) : x ^ y = exp (log x * 
       Complex.ofReal_sin, mul_add, ← Complex.ofReal_mul, ← mul_assoc, ← Complex.ofReal_mul,
       Complex.add_re, Complex.ofReal_re, Complex.mul_re, Complex.I_re, Complex.ofReal_im,
       Real.log_neg_eq_log]
-    ring
+    simp
   · rw [Complex.ofReal_eq_zero]
     exact ne_of_lt hx
 

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Arctan.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Arctan.lean
@@ -275,7 +275,7 @@ theorem arctan_add_eq_add_pi (h : 1 < x * y) (hx : 0 < x) :
     sub_eq_iff_eq_add, ← sub_eq_iff_eq_add', sub_eq_add_neg, ← arctan_neg, add_comm] at k
   convert k.symm using 3
   field_simp
-  rw [show -x + -y = -(x + y) by ring, show x * y - 1 = -(1 - x * y) by ring, neg_div_neg_eq]
+  rw [show -x + -y = -(x + y) by ring, show x * y - 1 = -(1 - x * y) by simp, neg_div_neg_eq]
 
 theorem arctan_add_eq_sub_pi (h : 1 < x * y) (hx : x < 0) :
     arctan x + arctan y = arctan ((x + y) / (1 - x * y)) - π := by

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Basic.lean
@@ -868,7 +868,7 @@ theorem tan_pi_div_six : tan (π / 6) = 1 / √3 := by
 @[simp]
 theorem tan_pi_div_three : tan (π / 3) = √3 := by
   rw [tan_eq_sin_div_cos, sin_pi_div_three, cos_pi_div_three]
-  ring
+  simp
 
 theorem tan_pos_of_pos_of_lt_pi_div_two {x : ℝ} (h0x : 0 < x) (hxp : x < π / 2) : 0 < tan x := by
   rw [tan_eq_sin_div_cos]

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/Cotangent.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/Cotangent.lean
@@ -220,6 +220,6 @@ theorem cot_series_rep (hz : x ∈ ℂ_ℤ) :
   have h1 := cot_series_rep' hz
   simp only [one_div, Nat.cast_add, Nat.cast_one] at *
   rw [h0, ← h1]
-  ring
+  simp
 
 end MittagLeffler

--- a/Mathlib/Analysis/SpecialFunctions/Trigonometric/EulerSineProd.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Trigonometric/EulerSineProd.lean
@@ -178,13 +178,13 @@ theorem integral_cos_pow_eq (n : ℕ) :
   have R : IntervalIntegrable _ volume (π / 2) π := (continuous_sin.pow n).intervalIntegrable _ _
   rw [← integral_add_adjacent_intervals L R]
   congr 1
-  · nth_rw 1 [(by ring : 0 = π / 2 - π / 2)]
-    nth_rw 3 [(by ring : π / 2 = π / 2 - 0)]
+  · nth_rw 1 [(by simp : 0 = π / 2 - π / 2)]
+    nth_rw 3 [(by simp : π / 2 = π / 2 - 0)]
     rw [← integral_comp_sub_left]
     refine integral_congr fun x _ => ?_
     rw [cos_pi_div_two_sub]
-  · nth_rw 3 [(by ring : π = π / 2 + π / 2)]
-    nth_rw 2 [(by ring : π / 2 = 0 + π / 2)]
+  · nth_rw 3 [(by simp : π = π / 2 + π / 2)]
+    nth_rw 2 [(by simp : π / 2 = 0 + π / 2)]
     rw [← integral_comp_add_right]
     refine integral_congr fun x _ => ?_
     rw [sin_add_pi_div_two]

--- a/Mathlib/Combinatorics/SimpleGraph/Regularity/Chunk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Regularity/Chunk.lean
@@ -345,7 +345,7 @@ private theorem edgeDensity_chunk_aux [Nonempty α] (hP)
   rw [← sub_nonneg] at hGε
   have : 0 ≤ ε := by sz_positivity
   calc
-    _ = G.edgeDensity U V ^ 2 - 1 * ε ^ 5 / 25 + 0 ^ 10 / 2500 := by ring
+    _ = G.edgeDensity U V ^ 2 - 1 * ε ^ 5 / 25 + 0 ^ 10 / 2500 := by simp
     _ ≤ G.edgeDensity U V ^ 2 - G.edgeDensity U V * ε ^ 5 / 25 + ε ^ 10 / 2500 := by
       gcongr; exact mod_cast G.edgeDensity_le_one ..
     _ = (G.edgeDensity U V - ε ^ 5 / 50) ^ 2 := by ring

--- a/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean
+++ b/Mathlib/Computability/AkraBazzi/GrowsPolynomially.lean
@@ -374,7 +374,7 @@ protected lemma GrowsPolynomially.add {f g : ℝ → ℝ} (hf : GrowsPolynomiall
   intro u hu
   have hbx : b * x ≤ x := calc
     b * x ≤ 1 * x := by gcongr; exact le_of_lt hb.2
-        _ = x := by ring
+        _ = x := by simp
   have fx_nonneg : 0 ≤ f x := hf' x hbx
   have gx_nonneg : 0 ≤ g x := hg' x hbx
   refine ⟨?lb, ?ub⟩

--- a/Mathlib/Computability/AkraBazzi/SumTransform.lean
+++ b/Mathlib/Computability/AkraBazzi/SumTransform.lean
@@ -136,7 +136,7 @@ lemma eventually_b_le_r : ∀ᶠ (n : ℕ) in atTop, ∀ i, (b i : ℝ) * n - (n
 lemma eventually_r_le_b : ∀ᶠ (n : ℕ) in atTop, ∀ i, r i n ≤ (b i : ℝ) * n + (n / log n ^ 2) := by
   filter_upwards [R.dist_r_b'] with n hn
   intro i
-  calc r i n = b i * n + (r i n - b i * n) := by ring
+  calc r i n = b i * n + (r i n - b i * n) := by simp
              _ ≤ b i * n + ‖r i n - b i * n‖ := by gcongr; exact Real.le_norm_self _
              _ ≤ b i * n + n / log n ^ 2 := by gcongr; exact hn i
 

--- a/Mathlib/FieldTheory/Finite/GaloisField.lean
+++ b/Mathlib/FieldTheory/Finite/GaloisField.lean
@@ -53,7 +53,7 @@ theorem galois_poly_separable {K : Type*} [CommRing K] (p q : ℕ) [CharP K p] (
   use 1, X ^ q - X - 1
   rw [← CharP.cast_eq_zero_iff K[X] p] at h
   rw [derivative_sub, derivative_X_pow, derivative_X, C_eq_natCast, h]
-  ring
+  simp
 
 variable (p : ℕ) [Fact p.Prime] (n : ℕ)
 

--- a/Mathlib/InformationTheory/KullbackLeibler/KLFun.lean
+++ b/Mathlib/InformationTheory/KullbackLeibler/KLFun.lean
@@ -84,7 +84,7 @@ section Derivatives
 /-- The derivative of `klFun` at `x ≠ 0` is `log x`. -/
 lemma hasDerivAt_klFun (hx : x ≠ 0) : HasDerivAt klFun (log x) x := by
   convert ((hasDerivAt_mul_log hx).add (hasDerivAt_const x 1)).sub (hasDerivAt_id x) using 1
-  ring
+  simp
 
 lemma not_differentiableAt_klFun_zero : ¬ DifferentiableAt ℝ klFun 0 := by
   unfold klFun; simpa using not_DifferentiableAt_log_mul_zero

--- a/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
+++ b/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
@@ -401,7 +401,7 @@ private theorem lintegral_Lp_add_le_aux {p q : ℝ} (hpq : p.HolderConjugate q) 
     lintegral_rpow_add_le_add_eLpNorm_mul_lintegral_rpow_add hpq hf hf_top hg hg_top
   have h_one_div_q : 1 / q = 1 - 1 / p := by
     nth_rw 2 [← hpq.inv_add_inv_eq_one]
-    ring
+    simp
   simp_rw [h_one_div_q, sub_eq_add_neg 1 (1 / p), ENNReal.rpow_add _ _ h_add_zero h_add_top,
     rpow_one] at h
   conv_rhs at h => enter [2]; rw [mul_comm]

--- a/Mathlib/MeasureTheory/Measure/Real.lean
+++ b/Mathlib/MeasureTheory/Measure/Real.lean
@@ -314,7 +314,7 @@ theorem measureReal_diff' (hm : MeasurableSet t)
     (h₁ : μ s ≠ ∞ := by finiteness) (h₂ : μ t ≠ ∞ := by finiteness) :
     μ.real (s \ t) = μ.real (s ∪ t) - μ.real t := by
   rw [union_comm, ← measureReal_add_diff hm h₂ h₁]
-  ring
+  simp
 
 theorem measureReal_diff (h : s₂ ⊆ s₁) (h₂ : MeasurableSet s₂) (h₁ : μ s₁ ≠ ∞ := by finiteness) :
     μ.real (s₁ \ s₂) = μ.real s₁ - μ.real s₂ := by

--- a/Mathlib/NumberTheory/Cyclotomic/Three.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Three.lean
@@ -80,7 +80,7 @@ private lemma lambda_sq : λ ^ 2 = -3 * η := by
   calc (λ ^ 2 : K) = η ^ 2 + η + 1 - 3 * η := by
         simp only [RingOfIntegers.map_mk, IsUnit.unit_spec]; ring
   _ = 0 - 3 * η := by simpa using hζ.isRoot_cyclotomic (by decide)
-  _ = -3 * η := by ring
+  _ = -3 * η := by simp
 
 /-- We have that `η ^ 2 = -η - 1`. -/
 lemma eta_sq : (η ^ 2 : 𝓞 K) = -η - 1 := by
@@ -157,7 +157,7 @@ lemma cube_sub_one_eq_mul : x ^ 3 - 1 = (x - 1) * (x - η) * (x - η ^ 2) := by
   calc _ = x ^ 3 - x ^ 2 * (η ^ 2 + η + 1) + x * (η ^ 2 + η + η ^ 3) - η ^ 3 := by ring
   _ = x ^ 3 - x ^ 2 * (η ^ 2 + η + 1) + x * (η ^ 2 + η + 1) - 1 := by
     simp [hζ.toInteger_cube_eq_one]
-  _ = x ^ 3 - 1 := by rw [eta_sq_add_eta_add_one hζ]; ring
+  _ = x ^ 3 - 1 := by rw [eta_sq_add_eta_add_one hζ]; simp
 
 variable [NumberField K] [IsCyclotomicExtension {3} ℚ K]
 

--- a/Mathlib/NumberTheory/DirichletCharacter/GaussSum.lean
+++ b/Mathlib/NumberTheory/DirichletCharacter/GaussSum.lean
@@ -17,7 +17,7 @@ lemma gaussSum_aux_of_mulShift (χ : DirichletCharacter R N) {d : ℕ}
     (hd : d ∣ N) (he : e.mulShift d = 1) {u : (ZMod N)ˣ} (hu : ZMod.unitsMap hd u = 1) :
     χ u * gaussSum χ e = gaussSum χ e := by
   suffices e.mulShift u = e by conv_lhs => rw [← this, gaussSum_mulShift]
-  rw [(by ring : u.val = (u - 1) + 1), ← mulShift_mul, mulShift_one, mul_eq_right]
+  rw [(by simp : u.val = (u - 1) + 1), ← mulShift_mul, mulShift_one, mul_eq_right]
   rsuffices ⟨a, ha⟩ : (d : ℤ) ∣ (u.val.val - 1 : ℤ)
   · have : u.val - 1 = ↑(u.val.val - 1 : ℤ) := by simp only [ZMod.natCast_val, Int.cast_sub,
       ZMod.intCast_cast, ZMod.cast_id', id_eq, Int.cast_one]

--- a/Mathlib/NumberTheory/FLT/Four.lean
+++ b/Mathlib/NumberTheory/FLT/Four.lean
@@ -228,7 +228,7 @@ theorem not_minimal {a b c : ℤ} (h : Minimal a b c) (ha2 : a % 2 = 1) (hc : 0 
     by_contra h1
     rw [h1] at hs
     have h2 : b' ^ 2 ≤ 0 := by
-      rw [hs, (by ring : -d ^ 2 * m = -(d ^ 2 * m))]
+      rw [hs, (by simp : -d ^ 2 * m = -(d ^ 2 * m))]
       exact neg_nonpos.mpr ((mul_nonneg_iff_of_pos_right h4).mpr (sq_nonneg d))
     have h2' : 0 ≤ b' ^ 2 := by apply sq_nonneg b'
     exact absurd (lt_of_le_of_ne h2' (Ne.symm (pow_ne_zero _ h2b0))) (not_lt.mpr h2)

--- a/Mathlib/NumberTheory/FLT/Three.lean
+++ b/Mathlib/NumberTheory/FLT/Three.lean
@@ -406,7 +406,7 @@ lemma lambda_sq_not_dvd_a_add_eta_sq_mul_b : ¬ λ ^ 2 ∣ (S.a + η ^ 2 * S.b) 
   intro ⟨k, hk⟩
   rcases S.hab with ⟨k', hk'⟩
   refine S.hb ⟨(k - k') * (-η), ?_⟩
-  rw [show S.a + η ^ 2 * S.b = S.a + S.b - S.b + η ^ 2 * S.b by ring, hk',
+  rw [show S.a + η ^ 2 * S.b = S.a + S.b - S.b + η ^ 2 * S.b by simp, hk',
     show λ ^ 2 * k' - S.b + η ^ 2 * S.b = λ * (S.b * (η +1) + λ * k') by rw [coe_eta]; ring,
     pow_two, mul_assoc] at hk
   simp only [mul_eq_mul_left_iff, hζ.zeta_sub_one_prime'.ne_zero, or_false] at hk

--- a/Mathlib/NumberTheory/Harmonic/GammaDeriv.lean
+++ b/Mathlib/NumberTheory/Harmonic/GammaDeriv.lean
@@ -62,7 +62,7 @@ lemma deriv_Gamma_nat (n : ℕ) :
   have derivLB (n : ℕ) (hn : 0 < n) : log n ≤ deriv f (n + 1) := by
     refine (le_of_eq ?_).trans <| hc.slope_le_deriv (mem_Ioi.mpr <| Nat.cast_pos.mpr hn)
       (by positivity : _ < (_ : ℝ)) (by linarith) (hder <| by positivity)
-    rw [slope_def_field, show n + 1 - n = (1 : ℝ) by ring, div_one, h_rec n (by positivity),
+    rw [slope_def_field, show n + 1 - n = (1 : ℝ) by simp, div_one, h_rec n (by positivity),
       add_sub_cancel_left]
   have derivUB (n : ℕ) : deriv f (n + 1) ≤ log (n + 1) := by
     refine (hc.deriv_le_slope (by positivity : (0 : ℝ) < n + 1) (by positivity : (0 : ℝ) < n + 2)

--- a/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
+++ b/Mathlib/NumberTheory/Harmonic/ZetaAsymp.lean
@@ -169,7 +169,7 @@ lemma term_of_lt {n : ℕ} (hn : 0 < n) {s : ℝ} (hs : 1 < s) :
       congr 1
       · rw [show -s + 1 = -(s - 1) by ring, div_neg, ← neg_div, mul_comm, mul_one_div, neg_sub,
           rpow_neg (Nat.cast_nonneg _), one_div, rpow_neg (by linarith), one_div]
-      · rw [show -(s + 1) + 1 = -s by ring, div_neg, ← neg_div, neg_sub, div_mul_eq_mul_div,
+      · rw [show -(s + 1) + 1 = -s by simp, div_neg, ← neg_div, neg_sub, div_mul_eq_mul_div,
           mul_div_assoc, rpow_neg (Nat.cast_nonneg _), one_div, rpow_neg (by linarith), one_div]
 
 lemma term_sum_of_lt (N : ℕ) {s : ℝ} (hs : 1 < s) :

--- a/Mathlib/NumberTheory/LSeries/Convergence.lean
+++ b/Mathlib/NumberTheory/LSeries/Convergence.lean
@@ -82,7 +82,7 @@ lemma LSeries.abscissaOfAbsConv_le_of_forall_lt_LSeriesSummable' {f : ℕ → �
 of `f` is bounded by `x + 1`. -/
 lemma LSeries.abscissaOfAbsConv_le_of_le_const_mul_rpow {f : ℕ → ℂ} {x : ℝ}
     (h : ∃ C, ∀ n ≠ 0, ‖f n‖ ≤ C * n ^ x) : abscissaOfAbsConv f ≤ x + 1 := by
-  rw [show x = x + 1 - 1 by ring] at h
+  rw [show x = x + 1 - 1 by simp] at h
   by_contra! H
   obtain ⟨y, hy₁, hy₂⟩ := EReal.exists_between_coe_real H
   exact (LSeriesSummable_of_le_const_mul_rpow (s := y) (EReal.coe_lt_coe_iff.mp hy₁) h
@@ -94,7 +94,7 @@ of `f` is bounded by `x + 1`. -/
 lemma LSeries.abscissaOfAbsConv_le_of_isBigO_rpow {f : ℕ → ℂ} {x : ℝ}
     (h : f =O[atTop] fun n ↦ (n : ℝ) ^ x) :
     abscissaOfAbsConv f ≤ x + 1 := by
-  rw [show x = x + 1 - 1 by ring] at h
+  rw [show x = x + 1 - 1 by simp] at h
   by_contra! H
   obtain ⟨y, hy₁, hy₂⟩ := EReal.exists_between_coe_real H
   exact (LSeriesSummable_of_isBigO_rpow (s := y) (EReal.coe_lt_coe_iff.mp hy₁) h

--- a/Mathlib/NumberTheory/LSeries/SumCoeff.lean
+++ b/Mathlib/NumberTheory/LSeries/SumCoeff.lean
@@ -345,7 +345,7 @@ theorem LSeries_tendsto_sub_mul_nhds_one_of_tendsto_sum_div
     rw [show 𝓝 l = 𝓝 (0 + 1 * l) by congr; ring]
     have h₃ : Tendsto (fun s : ℝ ↦ s * l) (𝓝[>] 1) (𝓝 (1 * l)) :=
       tendsto_nhdsWithin_of_tendsto_nhds (ContinuousAt.tendsto (by fun_prop))
-    exact (this.add h₃).congr fun _ ↦ by ring
+    exact (this.add h₃).congr fun _ ↦ by simp
   refine tendsto_zero_iff_norm_tendsto_zero.mpr <| tendsto_of_le_liminf_of_limsup_le ?_ ?_ h₂ ?_
   · exact le_liminf_of_le h₂.isCoboundedUnder_ge (univ_mem' (fun _ ↦ norm_nonneg _))
   · refine le_of_forall_pos_le_add fun ε hε ↦ ?_

--- a/Mathlib/NumberTheory/Padics/PadicVal/Basic.lean
+++ b/Mathlib/NumberTheory/Padics/PadicVal/Basic.lean
@@ -241,7 +241,7 @@ protected theorem defn (p : ℕ) [hp : Fact p.Prime] {q : ℚ} {n d : ℤ} (hqz 
     multiplicity_mul (Nat.prime_iff_prime_int.1 hp.1)]
   · rw [Nat.cast_add, Nat.cast_add]
     simp_rw [Int.natCast_multiplicity p q.den]
-    ring
+    simp
   · simpa [finite_int_prime_iff, hc2] using hd
   · simpa [finite_int_prime_iff, hqz, hc2] using hd
 

--- a/Mathlib/NumberTheory/Padics/RingHoms.lean
+++ b/Mathlib/NumberTheory/Padics/RingHoms.lean
@@ -174,7 +174,7 @@ theorem exists_mem_range : ∃ n : ℕ, n < p ∧ x - n ∈ maximalIdeal ℤ_[p]
   constructor
   · exact mod_cast hnp
   simp only [norm_def, coe_sub, coe_natCast] at hn ⊢
-  rw [show (x - n : ℚ_[p]) = x - r + (r - n) by ring]
+  rw [show (x - n : ℚ_[p]) = x - r + (r - n) by simp]
   apply lt_of_le_of_lt (padicNormE.nonarchimedean _ _)
   apply max_lt hr
   simpa using hn

--- a/Mathlib/NumberTheory/Pell.lean
+++ b/Mathlib/NumberTheory/Pell.lean
@@ -118,10 +118,10 @@ theorem prop (a : Solution₁ d) : a.x ^ 2 - d * a.y ^ 2 = 1 :=
   is_pell_solution_iff_mem_unitary.mpr a.property
 
 /-- An alternative form of the equation, suitable for rewriting `x^2`. -/
-theorem prop_x (a : Solution₁ d) : a.x ^ 2 = 1 + d * a.y ^ 2 := by rw [← a.prop]; ring
+theorem prop_x (a : Solution₁ d) : a.x ^ 2 = 1 + d * a.y ^ 2 := by rw [← a.prop]; simp
 
 /-- An alternative form of the equation, suitable for rewriting `d * y^2`. -/
-theorem prop_y (a : Solution₁ d) : d * a.y ^ 2 = a.x ^ 2 - 1 := by rw [← a.prop]; ring
+theorem prop_y (a : Solution₁ d) : d * a.y ^ 2 = a.x ^ 2 - 1 := by rw [← a.prop]; simp
 
 /-- Two solutions are equal if their `x` and `y` components are equal. -/
 @[ext]

--- a/Mathlib/NumberTheory/PythagoreanTriples.lean
+++ b/Mathlib/NumberTheory/PythagoreanTriples.lean
@@ -320,7 +320,7 @@ private theorem coprime_sq_sub_sq_add_of_even_odd {m n : ℤ} (h : Int.gcd m n =
 private theorem coprime_sq_sub_sq_add_of_odd_even {m n : ℤ} (h : Int.gcd m n = 1) (hm : m % 2 = 1)
     (hn : n % 2 = 0) : Int.gcd (m ^ 2 - n ^ 2) (m ^ 2 + n ^ 2) = 1 := by
   rw [Int.gcd, ← Int.natAbs_neg (m ^ 2 - n ^ 2)]
-  rw [(by ring : -(m ^ 2 - n ^ 2) = n ^ 2 - m ^ 2), add_comm]
+  rw [(by simp : -(m ^ 2 - n ^ 2) = n ^ 2 - m ^ 2), add_comm]
   apply coprime_sq_sub_sq_add_of_even_odd _ hn hm; rwa [Int.gcd_comm]
 
 private theorem coprime_sq_sub_mul_of_even_odd {m n : ℤ} (h : Int.gcd m n = 1) (hm : m % 2 = 0)
@@ -358,7 +358,7 @@ private theorem coprime_sq_sub_mul_of_even_odd {m n : ℤ} (h : Int.gcd m n = 1)
 private theorem coprime_sq_sub_mul_of_odd_even {m n : ℤ} (h : Int.gcd m n = 1) (hm : m % 2 = 1)
     (hn : n % 2 = 0) : Int.gcd (m ^ 2 - n ^ 2) (2 * m * n) = 1 := by
   rw [Int.gcd, ← Int.natAbs_neg (m ^ 2 - n ^ 2)]
-  rw [(by ring : 2 * m * n = 2 * n * m), (by ring : -(m ^ 2 - n ^ 2) = n ^ 2 - m ^ 2)]
+  rw [(by ring : 2 * m * n = 2 * n * m), (by simp : -(m ^ 2 - n ^ 2) = n ^ 2 - m ^ 2)]
   apply coprime_sq_sub_mul_of_even_odd _ hn hm; rwa [Int.gcd_comm]
 
 private theorem coprime_sq_sub_mul {m n : ℤ} (h : Int.gcd m n = 1)
@@ -607,7 +607,7 @@ theorem coprime_classification' {x y z : ℤ} (h : PythagoreanTriple x y z)
       apply And.intro h_odd.1
       constructor
       · rw [h_odd.2]
-        ring
+        simp
       rcases ht2 with h_pos | h_neg
       · apply And.intro h_pos
         constructor

--- a/Mathlib/NumberTheory/SumTwoSquares.lean
+++ b/Mathlib/NumberTheory/SumTwoSquares.lean
@@ -91,7 +91,7 @@ theorem ZMod.isSquare_neg_one_mul {m n : ℕ} (hc : m.Coprime n) (hm : IsSquare 
 theorem Nat.Prime.mod_four_ne_three_of_dvd_isSquare_neg_one {p n : ℕ} (hpp : p.Prime) (hp : p ∣ n)
     (hs : IsSquare (-1 : ZMod n)) : p % 4 ≠ 3 := by
   obtain ⟨y, h⟩ := ZMod.isSquare_neg_one_of_dvd hp hs
-  rw [← sq, eq_comm, show (-1 : ZMod p) = -1 ^ 2 by ring] at h
+  rw [← sq, eq_comm, show (-1 : ZMod p) = -1 ^ 2 by simp] at h
   haveI : Fact p.Prime := ⟨hpp⟩
   exact ZMod.mod_four_ne_three_of_sq_eq_neg_sq' one_ne_zero h
 

--- a/Mathlib/Probability/Moments/Variance.lean
+++ b/Mathlib/Probability/Moments/Variance.lean
@@ -226,7 +226,7 @@ lemma variance_const_add [IsProbabilityMeasure μ] (hX : AEStronglyMeasurable X 
 
 lemma variance_fun_neg : Var[fun ω ↦ -X ω; μ] = Var[X; μ] := by
   convert variance_mul (-1) X μ
-  · ext; ring
+  · ext; simp
   · simp
 
 lemma variance_neg : Var[-X; μ] = Var[X; μ] := variance_fun_neg

--- a/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
+++ b/Mathlib/Topology/ContinuousMap/CompactlySupported.lean
@@ -707,7 +707,7 @@ lemma exists_add_nnrealPart_add_eq (f g : C_c(α, ℝ)) : ∃ (h : C_c(α, ℝ�
       · simp only [hfgx, sup_of_le_right, zero_add, hfx, sup_of_le_left, hgx, add_zero] at hhx
         rw [sup_of_le_right (neg_nonpos.mpr hfx), sup_of_le_left (neg_nonneg.mpr hgx),
           sup_of_le_left (neg_nonneg.mpr hfgx), hhx]
-        ring
+        simp
   · rcases le_total 0 (g x) with hgx | hgx
     · rcases le_total 0 (f x + g x) with hfgx | hfgx
       · simp only [hfgx, sup_of_le_left, add_comm, hfx, sup_of_le_right, hgx, zero_add] at hhx
@@ -717,7 +717,7 @@ lemma exists_add_nnrealPart_add_eq (f g : C_c(α, ℝ)) : ∃ (h : C_c(α, ℝ�
       · simp only [hfgx, sup_of_le_right, zero_add, hfx, hgx, sup_of_le_left] at hhx
         rw [sup_of_le_left (neg_nonneg.mpr hfx), sup_of_le_right (neg_nonpos.mpr hgx),
           sup_of_le_left (neg_nonneg.mpr hfgx), hhx]
-        ring
+        simp
     · simp only [(add_nonpos hfx hgx), sup_of_le_right, zero_add, hfx, hgx, add_zero,
         coe_eq_zero] at hhx
       rw [sup_of_le_left (neg_nonneg.mpr hfx),

--- a/Mathlib/Topology/MetricSpace/GromovHausdorffRealized.lean
+++ b/Mathlib/Topology/MetricSpace/GromovHausdorffRealized.lean
@@ -146,7 +146,7 @@ private theorem candidates_dist_bound (fA : f ∈ candidates X Y) :
       _ = dist (α := X ⊕ Y) (inl x) (inl y) := by
         rw [@Sum.dist_eq X Y]
         rfl
-      _ = 1 * dist (α := X ⊕ Y) (inl x) (inl y) := by ring
+      _ = 1 * dist (α := X ⊕ Y) (inl x) (inl y) := by simp
       _ ≤ maxVar X Y * dist (inl x) (inl y) := by gcongr; exact one_le_maxVar X Y
   | inl x, inr y =>
     calc
@@ -164,7 +164,7 @@ private theorem candidates_dist_bound (fA : f ∈ candidates X Y) :
       _ = dist (α := X ⊕ Y) (inr x) (inr y) := by
         rw [@Sum.dist_eq X Y]
         rfl
-      _ = 1 * dist (α := X ⊕ Y) (inr x) (inr y) := by ring
+      _ = 1 * dist (α := X ⊕ Y) (inr x) (inr y) := by simp
       _ ≤ maxVar X Y * dist (inr x) (inr y) := by gcongr; exact one_le_maxVar X Y
 
 /-- Technical lemma to prove that candidates are Lipschitz -/

--- a/Mathlib/Topology/MetricSpace/Kuratowski.lean
+++ b/Mathlib/Topology/MetricSpace/Kuratowski.lean
@@ -49,7 +49,7 @@ theorem embeddingOfSubset_dist_le (a b : α) :
   refine lp.norm_le_of_forall_le dist_nonneg fun n => ?_
   simp only [lp.coeFn_sub, Pi.sub_apply, embeddingOfSubset_coe]
   convert abs_dist_sub_le a b (x n) using 2
-  ring
+  simp
 
 /-- When the reference set is dense, the embedding map is an isometry on its image. -/
 theorem embeddingOfSubset_isometry (H : DenseRange x) : Isometry (embeddingOfSubset x) := by


### PR DESCRIPTION
Same motivation as in kim-em's #24064:

> Consider replacing a tactic with a (ahem) simpler alternative.