### PR TITLE
chore(MeasureTheory/OuterMeasure): modified theorem names from `measure_X` to `Measure.X` to enable use of dot notation

### DIFF
--- a/Mathlib/MeasureTheory/OuterMeasure/AE.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/AE.lean
@@ -41,8 +41,8 @@ variable {α β F : Type*} [FunLike F (Set α) ℝ≥0∞] [OuterMeasureClass F 
 
 /-- The “almost everywhere” filter of co-null sets. -/
 def ae (μ : F) : Filter α :=
-  .ofCountableUnion (μ · = 0) (fun _S hSc ↦ (measure_sUnion_null_iff hSc).2) fun _t ht _s hs ↦
-    measure_mono_null hs ht
+  .ofCountableUnion (μ · = 0) (fun _S hSc ↦ (Measure.sUnion_null_iff hSc).2) fun _t ht _s hs ↦
+    Measure.mono_null hs ht
 
 /-- `∀ᵐ a ∂μ, p a` means that `p a` for a.e. `a`, i.e. `p` holds true away from a null set.
 
@@ -101,7 +101,7 @@ theorem all_ae_of {ι : Sort*} {p : α → ι → Prop} (hp : ∀ᵐ a ∂μ, �
   filter_upwards [hp] with a ha using ha i
 
 lemma ae_iff_of_countable [Countable α] {p : α → Prop} : (∀ᵐ x ∂μ, p x) ↔ ∀ x, μ {x} ≠ 0 → p x := by
-  rw [ae_iff, measure_null_iff_singleton]
+  rw [ae_iff, Measure.null_iff_singleton]
   exacts [forall_congr' fun _ ↦ not_imp_comm, Set.to_countable _]
 
 theorem ae_ball_iff {ι : Type*} {S : Set ι} (hS : S.Countable) {p : α → ∀ i ∈ S, Prop} :
@@ -123,7 +123,7 @@ theorem ae_eq_trans {f g h : α → β} (h₁ : f =ᵐ[μ] g) (h₂ : g =ᵐ[μ]
   refine ⟨fun h a ha ↦ by simpa [ha] using (h {a}ᶜ).1, fun h s ↦ ⟨fun hs ↦ ?_, ?_⟩⟩
   · rw [← compl_empty_iff, ← not_nonempty_iff_eq_empty]
     rintro ⟨a, ha⟩
-    exact h _ <| measure_mono_null (singleton_subset_iff.2 ha) hs
+    exact h _ <| Measure.mono_null (singleton_subset_iff.2 ha) hs
   · rintro rfl
     simp
 
@@ -161,7 +161,7 @@ theorem diff_ae_eq_self : (s \ t : Set α) =ᵐ[μ] s ↔ μ (s ∩ t) = 0 := by
   simp [eventuallyLE_antisymm_iff, ae_le_set]
 
 theorem diff_null_ae_eq_self (ht : μ t = 0) : (s \ t : Set α) =ᵐ[μ] s :=
-  diff_ae_eq_self.mpr (measure_mono_null inter_subset_right ht)
+  diff_ae_eq_self.mpr (Measure.mono_null inter_subset_right ht)
 
 theorem ae_eq_set {s t : Set α} : s =ᵐ[μ] t ↔ μ (s \ t) = 0 ∧ μ (t \ s) = 0 := by
   simp [eventuallyLE_antisymm_iff, ae_le_set]
@@ -237,9 +237,9 @@ theorem _root_.Set.mulIndicator_ae_eq_one {M : Type*} [One M] {f : α → M} {s 
 @[mono]
 theorem measure_mono_ae (H : s ≤ᵐ[μ] t) : μ s ≤ μ t :=
   calc
-    μ s ≤ μ (s ∪ t) := measure_mono subset_union_left
+    μ s ≤ μ (s ∪ t) := Measure.mono subset_union_left
     _ = μ (t ∪ s \ t) := by rw [union_diff_self, Set.union_comm]
-    _ ≤ μ t + μ (s \ t) := measure_union_le _ _
+    _ ≤ μ t + μ (s \ t) := Measure.union_le _ _
     _ = μ t := by rw [ae_le_set.1 H, add_zero]
 
 alias _root_.Filter.EventuallyLE.measure_le := measure_mono_ae

--- a/Mathlib/MeasureTheory/OuterMeasure/Basic.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/Basic.lean
@@ -75,13 +75,13 @@ theorem biUnion_le {I : Set ι} (μ : F) (hI : I.Countable) (s : ι → Set α) 
   rw [biUnion_eq_iUnion]
   apply iUnion_le
 
-theorem measure_biUnion_finset_le (I : Finset ι) (s : ι → Set α) :
+theorem biUnion_finset_le (I : Finset ι) (s : ι → Set α) :
     μ (⋃ i ∈ I, s i) ≤ ∑ i ∈ I, μ (s i) :=
   (biUnion_le μ I.countable_toSet s).trans_eq <| I.tsum_subtype (μ <| s ·)
 
 theorem iUnion_fintype_le [Fintype ι] (μ : F) (s : ι → Set α) :
     μ (⋃ i, s i) ≤ ∑ i, μ (s i) := by
-  simpa using measure_biUnion_finset_le Finset.univ s
+  simpa using biUnion_finset_le Finset.univ s
 
 theorem measure_union_le (s t : Set α) : μ (s ∪ t) ≤ μ s + μ t := by
   simpa [union_eq_iUnion] using iUnion_fintype_le μ (cond · s t)

--- a/Mathlib/MeasureTheory/OuterMeasure/Basic.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/Basic.lean
@@ -43,109 +43,115 @@ section OuterMeasureClass
 variable {α ι F : Type*} [FunLike F (Set α) ℝ≥0∞] [OuterMeasureClass F α]
   {μ : F} {s t : Set α}
 
+namespace  Measure
+
 @[simp]
-theorem measure_empty : μ ∅ = 0 := OuterMeasureClass.measure_empty μ
+theorem empty : μ ∅ = 0 := OuterMeasureClass.measure_empty μ
 
 @[mono, gcongr]
-theorem measure_mono (h : s ⊆ t) : μ s ≤ μ t :=
+theorem mono (h : s ⊆ t) : μ s ≤ μ t :=
   OuterMeasureClass.measure_mono μ h
 
-theorem measure_mono_null (h : s ⊆ t) (ht : μ t = 0) : μ s = 0 :=
-  eq_bot_mono (measure_mono h) ht
+theorem mono_null (h : s ⊆ t) (ht : μ t = 0) : μ s = 0 :=
+  eq_bot_mono (mono h) ht
 
-lemma measure_eq_top_mono (h : s ⊆ t) (hs : μ s = ∞) : μ t = ∞ := eq_top_mono (measure_mono h) hs
-lemma measure_lt_top_mono (h : s ⊆ t) (ht : μ t < ∞) : μ s < ∞ := (measure_mono h).trans_lt ht
+protected lemma eq_top_mono (h : s ⊆ t) (hs : μ s = ∞) : μ t = ∞ := eq_top_mono (mono h) hs
+protected lemma lt_top_mono (h : s ⊆ t) (ht : μ t < ∞) : μ s < ∞ := mono h |>.trans_lt ht
 
-theorem measure_pos_of_superset (h : s ⊆ t) (hs : μ s ≠ 0) : 0 < μ t :=
-  hs.bot_lt.trans_le (measure_mono h)
+theorem pos_of_superset (h : s ⊆ t) (hs : μ s ≠ 0) : 0 < μ t :=
+  hs.bot_lt.trans_le (mono h)
 
-theorem measure_iUnion_le [Countable ι] (s : ι → Set α) : μ (⋃ i, s i) ≤ ∑' i, μ (s i) := by
-  refine rel_iSup_tsum μ measure_empty (· ≤ ·) (fun t ↦ ?_) _
+theorem iUnion_le [Countable ι] (s : ι → Set α) : μ (⋃ i, s i) ≤ ∑' i, μ (s i) := by
+  refine rel_iSup_tsum μ Measure.empty (· ≤ ·) (fun t ↦ ?_) _
   calc
     μ (⋃ i, t i) = μ (⋃ i, disjointed t i) := by rw [iUnion_disjointed]
     _ ≤ ∑' i, μ (disjointed t i) :=
       OuterMeasureClass.measure_iUnion_nat_le _ _ (disjoint_disjointed _)
     _ ≤ ∑' i, μ (t i) := by gcongr; exact disjointed_subset ..
 
-theorem measure_biUnion_le {I : Set ι} (μ : F) (hI : I.Countable) (s : ι → Set α) :
+theorem biUnion_le {I : Set ι} (μ : F) (hI : I.Countable) (s : ι → Set α) :
     μ (⋃ i ∈ I, s i) ≤ ∑' i : I, μ (s i) := by
   have := hI.to_subtype
   rw [biUnion_eq_iUnion]
-  apply measure_iUnion_le
+  apply iUnion_le
 
 theorem measure_biUnion_finset_le (I : Finset ι) (s : ι → Set α) :
     μ (⋃ i ∈ I, s i) ≤ ∑ i ∈ I, μ (s i) :=
-  (measure_biUnion_le μ I.countable_toSet s).trans_eq <| I.tsum_subtype (μ <| s ·)
+  (biUnion_le μ I.countable_toSet s).trans_eq <| I.tsum_subtype (μ <| s ·)
 
-theorem measure_iUnion_fintype_le [Fintype ι] (μ : F) (s : ι → Set α) :
+theorem iUnion_fintype_le [Fintype ι] (μ : F) (s : ι → Set α) :
     μ (⋃ i, s i) ≤ ∑ i, μ (s i) := by
   simpa using measure_biUnion_finset_le Finset.univ s
 
 theorem measure_union_le (s t : Set α) : μ (s ∪ t) ≤ μ s + μ t := by
-  simpa [union_eq_iUnion] using measure_iUnion_fintype_le μ (cond · s t)
+  simpa [union_eq_iUnion] using iUnion_fintype_le μ (cond · s t)
 
-lemma measure_univ_le_add_compl (s : Set α) : μ univ ≤ μ s + μ sᶜ :=
+lemma univ_le_add_compl (s : Set α) : μ univ ≤ μ s + μ sᶜ :=
   s.union_compl_self ▸ measure_union_le s sᶜ
 
-theorem measure_le_inter_add_diff (μ : F) (s t : Set α) : μ s ≤ μ (s ∩ t) + μ (s \ t) := by
+theorem le_inter_add_diff (μ : F) (s t : Set α) : μ s ≤ μ (s ∩ t) + μ (s \ t) := by
   simpa using measure_union_le (s ∩ t) (s \ t)
 
-theorem measure_diff_null (ht : μ t = 0) : μ (s \ t) = μ s :=
-  (measure_mono diff_subset).antisymm <| calc
-    μ s ≤ μ (s ∩ t) + μ (s \ t) := measure_le_inter_add_diff _ _ _
+theorem diff_null (ht : μ t = 0) : μ (s \ t) = μ s :=
+  (mono diff_subset).antisymm <| calc
+    μ s ≤ μ (s ∩ t) + μ (s \ t) := le_inter_add_diff _ _ _
     _ ≤ μ t + μ (s \ t) := by gcongr; apply inter_subset_right
     _ = μ (s \ t) := by simp [ht]
 
-theorem measure_biUnion_null_iff {I : Set ι} (hI : I.Countable) {s : ι → Set α} :
+theorem biUnion_null_iff {I : Set ι} (hI : I.Countable) {s : ι → Set α} :
     μ (⋃ i ∈ I, s i) = 0 ↔ ∀ i ∈ I, μ (s i) = 0 := by
-  refine ⟨fun h i hi ↦ measure_mono_null (subset_biUnion_of_mem hi) h, fun h ↦ ?_⟩
+  refine ⟨fun h i hi ↦ mono_null (subset_biUnion_of_mem hi) h, fun h ↦ ?_⟩
   have _ := hI.to_subtype
-  simpa [h] using measure_iUnion_le (μ := μ) fun x : I ↦ s x
+  simpa [h] using iUnion_le (μ := μ) fun x : I ↦ s x
 
-theorem measure_sUnion_null_iff {S : Set (Set α)} (hS : S.Countable) :
+theorem sUnion_null_iff {S : Set (Set α)} (hS : S.Countable) :
     μ (⋃₀ S) = 0 ↔ ∀ s ∈ S, μ s = 0 := by
-  rw [sUnion_eq_biUnion, measure_biUnion_null_iff hS]
+  rw [sUnion_eq_biUnion, biUnion_null_iff hS]
 
 @[simp]
-theorem measure_iUnion_null_iff {ι : Sort*} [Countable ι] {s : ι → Set α} :
+theorem iUnion_null_iff {ι : Sort*} [Countable ι] {s : ι → Set α} :
     μ (⋃ i, s i) = 0 ↔ ∀ i, μ (s i) = 0 := by
-  rw [← sUnion_range, measure_sUnion_null_iff (countable_range s), forall_mem_range]
+  rw [← sUnion_range, sUnion_null_iff (countable_range s), forall_mem_range]
 
-alias ⟨_, measure_iUnion_null⟩ := measure_iUnion_null_iff
+alias ⟨_, measure_iUnion_null⟩ := iUnion_null_iff
 
 @[simp]
-theorem measure_union_null_iff : μ (s ∪ t) = 0 ↔ μ s = 0 ∧ μ t = 0 := by
+theorem union_null_iff : μ (s ∪ t) = 0 ↔ μ s = 0 ∧ μ t = 0 := by
   simp [union_eq_iUnion, and_comm]
 
-theorem measure_union_null (hs : μ s = 0) (ht : μ t = 0) : μ (s ∪ t) = 0 := by simp [*]
+theorem union_null (hs : μ s = 0) (ht : μ t = 0) : μ (s ∪ t) = 0 := by simp [*]
 
-lemma measure_null_iff_singleton (hs : s.Countable) : μ s = 0 ↔ ∀ x ∈ s, μ {x} = 0 := by
-  rw [← measure_biUnion_null_iff hs, biUnion_of_singleton]
+lemma null_iff_singleton (hs : s.Countable) : μ s = 0 ↔ ∀ x ∈ s, μ {x} = 0 := by
+  rw [← biUnion_null_iff hs, biUnion_of_singleton]
 
 /-- Let `μ` be an (outer) measure; let `s : ι → Set α` be a sequence of sets, `S = ⋃ n, s n`.
 If `μ (S \ s n)` tends to zero along some nontrivial filter (usually `Filter.atTop` on `ι = ℕ`),
 then `μ S = ⨆ n, μ (s n)`. -/
-theorem measure_iUnion_of_tendsto_zero {ι} (μ : F) {s : ι → Set α} (l : Filter ι) [NeBot l]
+protected theorem iUnion_of_tendsto_zero {ι} (μ : F) {s : ι → Set α} (l : Filter ι) [NeBot l]
     (h0 : Tendsto (fun k => μ ((⋃ n, s n) \ s k)) l (𝓝 0)) : μ (⋃ n, s n) = ⨆ n, μ (s n) := by
-  refine le_antisymm ?_ <| iSup_le fun n ↦ measure_mono <| subset_iUnion _ _
+  refine le_antisymm ?_ <| iSup_le fun n ↦ mono <| subset_iUnion _ _
   set S := ⋃ n, s n
   set M := ⨆ n, μ (s n)
   have A : ∀ k, μ S ≤ M + μ (S \ s k) := fun k ↦ calc
-    μ S ≤ μ (S ∩ s k) + μ (S \ s k) := measure_le_inter_add_diff _ _ _
+    μ S ≤ μ (S ∩ s k) + μ (S \ s k) := le_inter_add_diff _ _ _
     _ ≤ μ (s k) + μ (S \ s k) := by gcongr; apply inter_subset_right
     _ ≤ M + μ (S \ s k) := by gcongr; exact le_iSup (μ ∘ s) k
   have B : Tendsto (fun k ↦ M + μ (S \ s k)) l (𝓝 M) := by simpa using tendsto_const_nhds.add h0
   exact ge_of_tendsto' B A
 
+end Measure
+
+open Measure
+
 /-- If a set has zero measure in a neighborhood of each of its points, then it has zero measure
 in a second-countable space. -/
-theorem measure_null_of_locally_null [TopologicalSpace α] [SecondCountableTopology α]
+theorem null_of_locally_null [TopologicalSpace α] [SecondCountableTopology α]
     (s : Set α) (hs : ∀ x ∈ s, ∃ u ∈ 𝓝[s] x, μ u = 0) : μ s = 0 := by
   choose! u hxu hu₀ using hs
   choose t ht using TopologicalSpace.countable_cover_nhdsWithin hxu
   rcases ht with ⟨ts, t_count, ht⟩
-  apply measure_mono_null ht
-  exact (measure_biUnion_null_iff t_count).2 fun x hx => hu₀ x (ts hx)
+  apply Measure.mono_null ht
+  exact (Measure.biUnion_null_iff t_count).2 fun x hx => hu₀ x (ts hx)
 
 /-- If `m s ≠ 0`, then for some point `x ∈ s` and any `t ∈ 𝓝[s] x` we have `0 < m t`. -/
 theorem exists_mem_forall_mem_nhdsWithin_pos_measure [TopologicalSpace α]
@@ -153,7 +159,7 @@ theorem exists_mem_forall_mem_nhdsWithin_pos_measure [TopologicalSpace α]
     ∃ x ∈ s, ∀ t ∈ 𝓝[s] x, 0 < μ t := by
   contrapose! hs
   simp only [nonpos_iff_eq_zero] at hs
-  exact measure_null_of_locally_null s hs
+  exact null_of_locally_null s hs
 
 end OuterMeasureClass
 
@@ -165,7 +171,7 @@ variable {α β : Type*} {m : OuterMeasure α}
 some nontrivial filter (usually `atTop` on `ι = ℕ`), then `m S = ⨆ n, m (s n)`. -/
 theorem iUnion_of_tendsto_zero {ι} (m : OuterMeasure α) {s : ι → Set α} (l : Filter ι) [NeBot l]
     (h0 : Tendsto (fun k => m ((⋃ n, s n) \ s k)) l (𝓝 0)) : m (⋃ n, s n) = ⨆ n, m (s n) :=
-  measure_iUnion_of_tendsto_zero m l h0
+  Measure.iUnion_of_tendsto_zero m l h0
 
 /-- If `s : ℕ → Set α` is a monotone sequence of sets such that `∑' k, m (s (k + 1) \ s k) ≠ ∞`,
 then `m (⋃ n, s n) = ⨆ n, m (s n)`. -/
@@ -173,9 +179,9 @@ theorem iUnion_nat_of_monotone_of_tsum_ne_top (m : OuterMeasure α) {s : ℕ →
     (h_mono : ∀ n, s n ⊆ s (n + 1)) (h0 : (∑' k, m (s (k + 1) \ s k)) ≠ ∞) :
     m (⋃ n, s n) = ⨆ n, m (s n) := by
   classical
-  refine measure_iUnion_of_tendsto_zero m atTop ?_
+  refine Measure.iUnion_of_tendsto_zero m atTop ?_
   refine tendsto_nhds_bot_mono' (ENNReal.tendsto_sum_nat_add _ h0) fun n => ?_
-  refine (m.mono ?_).trans (measure_iUnion_le _)
+  refine (m.mono ?_).trans (Measure.iUnion_le _)
   -- Current goal: `(⋃ k, s k) \ s n ⊆ ⋃ k, s (k + n + 1) \ s (k + n)`
   have h' : Monotone s := @monotone_nat_of_le_succ (Set α) _ _ h_mono
   simp only [diff_subset_iff, iUnion_subset_iff]

--- a/Mathlib/MeasureTheory/OuterMeasure/Basic.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/Basic.lean
@@ -83,14 +83,14 @@ theorem iUnion_fintype_le [Fintype ι] (μ : F) (s : ι → Set α) :
     μ (⋃ i, s i) ≤ ∑ i, μ (s i) := by
   simpa using biUnion_finset_le Finset.univ s
 
-theorem measure_union_le (s t : Set α) : μ (s ∪ t) ≤ μ s + μ t := by
+theorem union_le (s t : Set α) : μ (s ∪ t) ≤ μ s + μ t := by
   simpa [union_eq_iUnion] using iUnion_fintype_le μ (cond · s t)
 
 lemma univ_le_add_compl (s : Set α) : μ univ ≤ μ s + μ sᶜ :=
-  s.union_compl_self ▸ measure_union_le s sᶜ
+  s.union_compl_self ▸ union_le s sᶜ
 
 theorem le_inter_add_diff (μ : F) (s t : Set α) : μ s ≤ μ (s ∩ t) + μ (s \ t) := by
-  simpa using measure_union_le (s ∩ t) (s \ t)
+  simpa using union_le (s ∩ t) (s \ t)
 
 theorem diff_null (ht : μ t = 0) : μ (s \ t) = μ s :=
   (mono diff_subset).antisymm <| calc

--- a/Mathlib/MeasureTheory/OuterMeasure/BorelCantelli.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/BorelCantelli.lean
@@ -46,7 +46,7 @@ theorem measure_limsup_cofinite_eq_zero {s : ι → Set α} (hs : ∑' i, μ (s 
       gcongr
       rw [hasBasis_cofinite.limsup_eq_iInf_iSup, iUnion_subtype]
       exact iInter₂_subset _ t.finite_toSet
-    _ ≤ ∑' i : {i // i ∉ t}, μ (s i) := measure_iUnion_le _
+    _ ≤ ∑' i : {i // i ∉ t}, μ (s i) := Measure.iUnion_le _
 
 /-- One direction of the **Borel-Cantelli lemma**
 (sometimes called the "*first* Borel-Cantelli lemma"):
@@ -88,7 +88,7 @@ theorem ae_eventually_notMem {s : ℕ → Set α} (hs : (∑' i, μ (s i)) ≠ �
 theorem measure_liminf_cofinite_eq_zero [Infinite ι] {s : ι → Set α} (h : ∑' i, μ (s i) ≠ ∞) :
     μ (liminf s cofinite) = 0 := by
   rw [← le_zero_iff, ← measure_limsup_cofinite_eq_zero h]
-  exact measure_mono liminf_le_limsup
+  exact Measure.mono liminf_le_limsup
 
 theorem measure_liminf_atTop_eq_zero {s : ℕ → Set α} (h : (∑' i, μ (s i)) ≠ ∞) :
     μ (liminf s atTop) = 0 := by

--- a/Mathlib/MeasureTheory/OuterMeasure/Caratheodory.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/Caratheodory.lean
@@ -53,7 +53,7 @@ def IsCaratheodory (s : Set α) : Prop :=
 
 theorem isCaratheodory_iff_le' {s : Set α} :
     IsCaratheodory m s ↔ ∀ t, m (t ∩ s) + m (t \ s) ≤ m t :=
-  forall_congr' fun _ => le_antisymm_iff.trans <| and_iff_right <| measure_le_inter_add_diff _ _ _
+  forall_congr' fun _ => le_antisymm_iff.trans <| and_iff_right <| Measure.le_inter_add_diff _ _ _
 
 @[simp]
 theorem isCaratheodory_empty : IsCaratheodory m ∅ := by simp [IsCaratheodory, diff_empty]
@@ -132,7 +132,7 @@ theorem isCaratheodory_iUnion_of_disjoint {s : ℕ → Set α} (h : ∀ i, IsCar
       apply (isCaratheodory_iff_le' m).mpr
       intro t
       have hp : m (t ∩ ⋃ i, s i) ≤ ⨆ n, m (t ∩ ⋃ i < n, s i) := by
-        convert measure_iUnion_le (μ := m) fun i => t ∩ s i using 1
+        convert Measure.iUnion_le (μ := m) fun i => t ∩ s i using 1
         · simp [inter_iUnion]
         · simp [ENNReal.tsum_eq_iSup_nat, isCaratheodory_sum m h hd]
       refine le_trans (add_le_add_right hp _) ?_
@@ -150,7 +150,7 @@ lemma isCaratheodory_iUnion {s : ℕ → Set α} (h : ∀ i, m.IsCaratheodory (s
 
 theorem f_iUnion {s : ℕ → Set α} (h : ∀ i, IsCaratheodory m (s i)) (hd : Pairwise (Disjoint on s)) :
     m (⋃ i, s i) = ∑' i, m (s i) := by
-  refine le_antisymm (measure_iUnion_le s) ?_
+  refine le_antisymm (Measure.iUnion_le s) ?_
   rw [ENNReal.tsum_eq_iSup_nat]
   refine iSup_le fun n => ?_
   have := @isCaratheodory_sum _ m _ h hd univ n

--- a/Mathlib/MeasureTheory/OuterMeasure/Induced.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/Induced.lean
@@ -188,7 +188,7 @@ theorem inducedOuterMeasure_eq_iInf (s : Set α) :
   apply le_antisymm
   · simp only [le_iInf_iff]
     intro t ht hs
-    refine le_trans (measure_mono hs) ?_
+    refine le_trans (Measure.mono hs) ?_
     exact le_of_eq (inducedOuterMeasure_eq' _ msU m_mono _)
   · refine le_iInf ?_
     intro f
@@ -312,8 +312,8 @@ lemma null_of_trim_null {s : Set α} (h : m.trim s = 0) : m s = 0 :=
 
 @[simp]
 theorem trim_eq {s : Set α} (hs : MeasurableSet s) : m.trim s = m s :=
-  inducedOuterMeasure_eq' MeasurableSet.iUnion (fun f _hf => measure_iUnion_le f)
-    (fun _ _ _ _ h => measure_mono h) hs
+  inducedOuterMeasure_eq' MeasurableSet.iUnion (fun f _hf => Measure.iUnion_le f)
+    (fun _ _ _ _ h => Measure.mono h) hs
 
 theorem trim_congr {m₁ m₂ : OuterMeasure α} (H : ∀ {s : Set α}, MeasurableSet s → m₁ s = m₂ s) :
     m₁.trim = m₂.trim := by
@@ -341,8 +341,8 @@ theorem trim_eq_trim_iff {m₁ m₂ : OuterMeasure α} :
 theorem trim_eq_iInf (s : Set α) : m.trim s = ⨅ (t) (_ : s ⊆ t) (_ : MeasurableSet t), m t := by
   simp +singlePass only [iInf_comm]
   exact
-    inducedOuterMeasure_eq_iInf MeasurableSet.iUnion (fun f _ => measure_iUnion_le f)
-      (fun _ _ _ _ h => measure_mono h) s
+    inducedOuterMeasure_eq_iInf MeasurableSet.iUnion (fun f _ => Measure.iUnion_le f)
+      (fun _ _ _ _ h => Measure.mono h) s
 
 theorem trim_eq_iInf' (s : Set α) : m.trim s = ⨅ t : { t // s ⊆ t ∧ MeasurableSet t }, m t := by
   simp [iInf_subtype, iInf_and, trim_eq_iInf]
@@ -358,7 +358,7 @@ theorem trim_top : (⊤ : OuterMeasure α).trim = ⊤ :=
 theorem trim_zero : (0 : OuterMeasure α).trim = 0 :=
   ext fun s =>
     le_antisymm
-      ((measure_mono (subset_univ s)).trans_eq <| trim_eq _ MeasurableSet.univ)
+      ((Measure.mono (subset_univ s)).trans_eq <| trim_eq _ MeasurableSet.univ)
       (zero_le _)
 
 theorem trim_sum_ge {ι} (m : ι → OuterMeasure α) : (sum fun i => (m i).trim) ≤ (sum m).trim :=
@@ -389,7 +389,7 @@ theorem exists_measurable_superset_eq_trim (m : OuterMeasure α) (s : Set α) :
       tendsto_const_nhds.add ENNReal.tendsto_inv_nat_nhds_zero
     rw [add_zero] at this
     refine le_antisymm (ge_of_tendsto' this fun n => ?_) ?_
-    · exact le_trans (measure_mono <| iInter_subset t n) (hm' n).le
+    · exact le_trans (Measure.mono <| iInter_subset t n) (hm' n).le
     · refine iInf_le_of_le (⋂ n, t n) ?_
       refine iInf_le_of_le (subset_iInter hsub) ?_
       exact iInf_le _ (MeasurableSet.iInter hm)
@@ -407,7 +407,7 @@ theorem exists_measurable_superset_forall_eq_trim {ι} [Countable ι] (μ : ι �
   replace hst := subset_iInter hst
   replace ht := MeasurableSet.iInter ht
   refine ⟨⋂ i, t i, hst, ht, fun i => le_antisymm ?_ ?_⟩
-  exacts [hμt i ▸ (μ i).mono (iInter_subset _ _), (measure_mono hst).trans_eq ((μ i).trim_eq ht)]
+  exacts [hμt i ▸ (μ i).mono (iInter_subset _ _), (Measure.mono hst).trans_eq ((μ i).trim_eq ht)]
 
 /-- If `m₁ s = op (m₂ s) (m₃ s)` for all `s`, then the same is true for `m₁.trim`, `m₂.trim`,
 and `m₃ s`. -/
@@ -457,10 +457,10 @@ theorem restrict_trim {μ : OuterMeasure α} {s : Set α} (hs : MeasurableSet s)
     rcases μ.exists_measurable_superset_eq_trim (t ∩ s) with ⟨t', htt', ht', hμt'⟩
     rw [← hμt']
     rw [inter_subset] at htt'
-    refine (measure_mono htt').trans ?_
+    refine (Measure.mono htt').trans ?_
     rw [trim_eq _ (hs.compl.union ht'), restrict_apply, union_inter_distrib_right, compl_inter_self,
       Set.empty_union]
-    exact measure_mono inter_subset_left
+    exact Measure.mono inter_subset_left
   · rw [restrict_apply, trim_eq _ (ht.inter hs), restrict_apply]
 
 end OuterMeasure

--- a/Mathlib/MeasureTheory/OuterMeasure/OfFunction.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/OfFunction.lean
@@ -137,7 +137,7 @@ theorem le_ofFunction {μ : OuterMeasure α} :
   ⟨fun H s => le_trans (H s) (ofFunction_le s), fun H _ =>
     le_iInf fun f =>
       le_iInf fun hs =>
-        le_trans (μ.mono hs) <| le_trans (measure_iUnion_le f) <| ENNReal.tsum_le_tsum fun _ => H _⟩
+        le_trans (μ.mono hs) <| le_trans (Measure.iUnion_le f) <| ENNReal.tsum_le_tsum fun _ => H _⟩
 
 theorem isGreatest_ofFunction :
     IsGreatest { μ : OuterMeasure α | ∀ s, μ s ≤ m s } (OuterMeasure.ofFunction m m_empty) :=
@@ -156,7 +156,7 @@ theorem ofFunction_union_of_top_of_nonempty_inter {s t : Set α}
     (h : ∀ u, (s ∩ u).Nonempty → (t ∩ u).Nonempty → m u = ∞) :
     OuterMeasure.ofFunction m m_empty (s ∪ t) =
       OuterMeasure.ofFunction m m_empty s + OuterMeasure.ofFunction m m_empty t := by
-  refine le_antisymm (measure_union_le _ _) (le_iInf₂ fun f hf ↦ ?_)
+  refine le_antisymm (Measure.union_le _ _) (le_iInf₂ fun f hf ↦ ?_)
   set μ := OuterMeasure.ofFunction m m_empty
   rcases Classical.em (∃ i, (s ∩ f i).Nonempty ∧ (t ∩ f i).Nonempty) with (⟨i, hs, ht⟩ | he)
   · calc
@@ -171,7 +171,7 @@ theorem ofFunction_union_of_top_of_nonempty_inter {s t : Set α}
         μ.mono fun x hx =>
           let ⟨i, hi⟩ := mem_iUnion.1 (hf (hu hx))
           mem_iUnion.2 ⟨⟨i, ⟨x, hx, hi⟩⟩, hi⟩
-      _ ≤ ∑' i : I u, μ (f i) := measure_iUnion_le _
+      _ ≤ ∑' i : I u, μ (f i) := Measure.iUnion_le _
   calc
     μ s + μ t ≤ (∑' i : I s, μ (f i)) + ∑' i : I t, μ (f i) :=
       add_le_add (hI _ subset_union_left) (hI _ subset_union_right)
@@ -267,7 +267,7 @@ theorem boundedBy_eq (s : Set α) (m_empty : m ∅ = 0) (m_mono : ∀ ⦃t : Set
 
 @[simp]
 theorem boundedBy_eq_self (m : OuterMeasure α) : boundedBy m = m :=
-  ext fun _ => boundedBy_eq _ measure_empty (fun _ ht => measure_mono ht) measure_iUnion_le
+  ext fun _ => boundedBy_eq _ Measure.empty (fun _ ht => Measure.mono ht) Measure.iUnion_le
 
 theorem le_boundedBy {μ : OuterMeasure α} : μ ≤ boundedBy m ↔ ∀ s, μ s ≤ m s := by
   rw [boundedBy , le_ofFunction, forall_congr']; intro s

--- a/Mathlib/MeasureTheory/OuterMeasure/Operations.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/Operations.lean
@@ -56,7 +56,7 @@ instance instAdd : Add (OuterMeasure α) :=
       iUnion_nat := fun s _ =>
         calc
           m₁ (⋃ i, s i) + m₂ (⋃ i, s i) ≤ (∑' i, m₁ (s i)) + ∑' i, m₂ (s i) :=
-            add_le_add (measure_iUnion_le s) (measure_iUnion_le s)
+            add_le_add (Measure.iUnion_le s) (Measure.iUnion_le s)
           _ = _ := ENNReal.tsum_add.symm }⟩
 
 @[simp]
@@ -74,13 +74,13 @@ variable {R' : Type*} [SMul R' ℝ≥0∞] [IsScalarTower R' ℝ≥0∞ ℝ≥0�
 instance instSMul : SMul R (OuterMeasure α) :=
   ⟨fun c m =>
     { measureOf := fun s => c • m s
-      empty := by simp only [measure_empty]; rw [← smul_one_mul c]; simp
+      empty := by simp only [Measure.empty]; rw [← smul_one_mul c]; simp
       mono := fun {s t} h => by
         rw [← smul_one_mul c, ← smul_one_mul c (m t)]
         exact mul_left_mono (m.mono h)
       iUnion_nat := fun s _ => by
         simp_rw [← smul_one_mul c (m _), ENNReal.tsum_mul_left]
-        exact mul_left_mono (measure_iUnion_le _) }⟩
+        exact mul_left_mono (Measure.iUnion_le _) }⟩
 
 @[simp]
 theorem coe_smul (c : R) (m : OuterMeasure α) : ⇑(c • m) = c • ⇑m :=
@@ -144,7 +144,7 @@ instance orderBot : OrderBot (OuterMeasure α) :=
     bot_le := fun a s => by simp only [coe_zero, Pi.zero_apply, zero_le] }
 
 theorem univ_eq_zero_iff (m : OuterMeasure α) : m univ = 0 ↔ m = 0 :=
-  ⟨fun h => bot_unique fun s => (measure_mono <| subset_univ s).trans_eq h, fun h => h.symm ▸ rfl⟩
+  ⟨fun h => bot_unique fun s => (Measure.mono <| subset_univ s).trans_eq h, fun h => h.symm ▸ rfl⟩
 
 section Supremum
 
@@ -156,7 +156,7 @@ instance instSupSet : SupSet (OuterMeasure α) :=
       iUnion_nat := fun f _ =>
         iSup₂_le fun m hm =>
           calc
-            m (⋃ i, f i) ≤ ∑' i : ℕ, m (f i) := measure_iUnion_le _
+            m (⋃ i, f i) ≤ ∑' i : ℕ, m (f i) := Measure.iUnion_le _
             _ ≤ ∑' i, ⨆ m ∈ ms, (m : OuterMeasure α) (f i) :=
                ENNReal.tsum_le_tsum fun i => by apply le_iSup₂ m hm
              }⟩
@@ -201,7 +201,7 @@ def map {β} (f : α → β) : OuterMeasure α →ₗ[ℝ≥0∞] OuterMeasure �
     { measureOf := fun s => m (f ⁻¹' s)
       empty := m.empty
       mono := fun {_ _} h => m.mono (preimage_mono h)
-      iUnion_nat := fun s _ => by simpa using measure_iUnion_le fun i => f ⁻¹' s i }
+      iUnion_nat := fun s _ => by simpa using Measure.iUnion_le fun i => f ⁻¹' s i }
   map_add' _ _ := coe_fn_injective rfl
   map_smul' _ _ := coe_fn_injective rfl
 
@@ -251,9 +251,9 @@ theorem dirac_apply (a : α) (s : Set α) : dirac a s = indicator s (fun _ => 1)
 def sum {ι} (f : ι → OuterMeasure α) : OuterMeasure α where
   measureOf s := ∑' i, f i s
   empty := by simp
-  mono {_ _} h := ENNReal.tsum_le_tsum fun _ => measure_mono h
+  mono {_ _} h := ENNReal.tsum_le_tsum fun _ => Measure.mono h
   iUnion_nat s _ := by
-    rw [ENNReal.tsum_comm]; exact ENNReal.tsum_le_tsum fun i => measure_iUnion_le _
+    rw [ENNReal.tsum_comm]; exact ENNReal.tsum_le_tsum fun i => Measure.iUnion_le _
 
 @[simp]
 theorem sum_apply {ι} (f : ι → OuterMeasure α) (s : Set α) : sum f s = ∑' i, f i s :=
@@ -269,7 +269,7 @@ def comap {β} (f : α → β) : OuterMeasure β →ₗ[ℝ≥0∞] OuterMeasure
     { measureOf := fun s => m (f '' s)
       empty := by simp
       mono := fun {_ _} h => by gcongr
-      iUnion_nat := fun s _ => by simpa only [image_iUnion] using measure_iUnion_le _ }
+      iUnion_nat := fun s _ => by simpa only [image_iUnion] using Measure.iUnion_le _ }
   map_add' _ _ := rfl
   map_smul' _ _ := rfl
 


### PR DESCRIPTION
In this file there were many uses of `measure_` that needed changes to `Measure.` in order to enable the use of dot notation. Notes: 

* Making these changes (understandably) required protecting a couple of theorems to avoid recursive errors.
* Reviewers should be wary that the measures in question were not defined using `Measure`, but `OuterMeasureClass`, 
and some of the breakage occurring as a result of these changes could not be fixed using dot notation (since the results      that needed repair were already in the `OuterMeasure` namespace, and dot notation would need `MeasureTheory.OuterMeasure.Measure` and not `MeasureTheory.Measure`). I am not sure if this will be a problem.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
