### PR TITLE
[Merged by Bors] - chore: rename valuation_posSubmonoid_ne_zero_of_compatible

### DIFF
--- a/Mathlib/RingTheory/Valuation/ValuativeRel.lean
+++ b/Mathlib/RingTheory/Valuation/ValuativeRel.lean
@@ -552,10 +552,19 @@ lemma isEquiv {Γ₁ Γ₂ : Type*}
   simp_rw [← Valuation.Compatible.rel_iff_le]
 
 @[simp]
-lemma valuation_posSubmonoid_ne_zero_of_compatible {Γ : Type*} [LinearOrderedCommMonoidWithZero Γ]
+lemma _root_.Valuation.map_posSubmonoid_ne_zero {Γ : Type*} [LinearOrderedCommMonoidWithZero Γ]
     (v : Valuation R Γ) [v.Compatible] (x : posSubmonoid R) :
-    v (x : R) ≠ 0 := by
+    v x ≠ 0 := by
   simp [(isEquiv v (valuation R)).ne_zero, valuation_posSubmonoid_ne_zero]
+
+@[deprecated (since := "2025-08-06")]
+alias valuation_posSubmonoid_ne_zero_of_compatible := _root_.Valuation.map_posSubmonoid_ne_zero
+
+@[simp]
+lemma _root_.Valuation.map_posSubmonoid_pos {Γ : Type*} [LinearOrderedCommMonoidWithZero Γ]
+    (v : Valuation R Γ) [v.Compatible] (x : posSubmonoid R) :
+    0 < v x :=
+  zero_lt_iff.mpr <| v.map_posSubmonoid_ne_zero x
 
 variable (R) in
 /-- An alias for endowing a ring with a preorder defined as the valuative relation. -/

--- a/Mathlib/RingTheory/Valuation/ValuativeRel.lean
+++ b/Mathlib/RingTheory/Valuation/ValuativeRel.lean
@@ -552,19 +552,19 @@ lemma isEquiv {Γ₁ Γ₂ : Type*}
   simp_rw [← Valuation.Compatible.rel_iff_le]
 
 @[simp]
-lemma _root_.Valuation.map_posSubmonoid_ne_zero {Γ : Type*} [LinearOrderedCommMonoidWithZero Γ]
+lemma _root_.Valuation.apply_posSubmonoid_ne_zero {Γ : Type*} [LinearOrderedCommMonoidWithZero Γ]
     (v : Valuation R Γ) [v.Compatible] (x : posSubmonoid R) :
-    v x ≠ 0 := by
+    v (x : R) ≠ 0 := by
   simp [(isEquiv v (valuation R)).ne_zero, valuation_posSubmonoid_ne_zero]
 
 @[deprecated (since := "2025-08-06")]
-alias valuation_posSubmonoid_ne_zero_of_compatible := _root_.Valuation.map_posSubmonoid_ne_zero
+alias valuation_posSubmonoid_ne_zero_of_compatible := _root_.Valuation.apply_posSubmonoid_ne_zero
 
 @[simp]
-lemma _root_.Valuation.map_posSubmonoid_pos {Γ : Type*} [LinearOrderedCommMonoidWithZero Γ]
+lemma _root_.Valuation.apply_posSubmonoid_pos {Γ : Type*} [LinearOrderedCommMonoidWithZero Γ]
     (v : Valuation R Γ) [v.Compatible] (x : posSubmonoid R) :
     0 < v x :=
-  zero_lt_iff.mpr <| v.map_posSubmonoid_ne_zero x
+  zero_lt_iff.mpr <| v.apply_posSubmonoid_ne_zero x
 
 variable (R) in
 /-- An alias for endowing a ring with a preorder defined as the valuative relation. -/


### PR DESCRIPTION
and sneak one more lemma in


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
