### PR TITLE
[Merged by Bors] - chore(RingTheory/Spectrum/Prime/Topology): remove unused section

### DIFF
--- a/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
+++ b/Mathlib/RingTheory/Spectrum/Prime/Topology.lean
@@ -1184,24 +1184,12 @@ lemma _root_.RingHom.IsIntegral.specComap_surjective {f : R →+* S} (hf : f.IsI
 
 end IsIntegral
 
-section LocalizationAtMinimal
+variable (R)
 
-variable {I : Ideal R} [hI : I.IsPrime]
-
-end LocalizationAtMinimal
-
-end CommSemiring
-
-end PrimeSpectrum
-
-section CommSemiring
-variable [CommSemiring R]
-
-open PrimeSpectrum in
 /-- Zero loci of minimal prime ideals of `R` are irreducible components in `Spec R` and any
 irreducible component is a zero locus of some minimal prime ideal. -/
 @[stacks 00ES]
-protected def minimalPrimes.equivIrreducibleComponents :
+protected def _root_.minimalPrimes.equivIrreducibleComponents :
     minimalPrimes R ≃o (irreducibleComponents <| PrimeSpectrum R)ᵒᵈ := by
   let e : {p : Ideal R | p.IsPrime ∧ ⊥ ≤ p} ≃o PrimeSpectrum R :=
     ⟨⟨fun x ↦ ⟨x.1, x.2.1⟩, fun x ↦ ⟨x.1, x.2, bot_le⟩, fun _ ↦ rfl, fun _ ↦ rfl⟩, Iff.rfl⟩
@@ -1210,19 +1198,15 @@ protected def minimalPrimes.equivIrreducibleComponents :
     (e.trans ((PrimeSpectrum.pointsEquivIrreducibleCloseds R).trans
     (TopologicalSpace.IrreducibleCloseds.orderIsoSubtype' (PrimeSpectrum R)).dual))
 
-namespace PrimeSpectrum
-
 lemma vanishingIdeal_irreducibleComponents :
-    vanishingIdeal '' (irreducibleComponents <| PrimeSpectrum R) =
-    minimalPrimes R := by
+    vanishingIdeal '' (irreducibleComponents <| PrimeSpectrum R) = minimalPrimes R := by
   rw [irreducibleComponents_eq_maximals_closed, minimalPrimes_eq_minimals,
     image_antitone_setOf_maximal (fun s t hs _ ↦ (vanishingIdeal_anti_mono_iff hs.1).symm),
     ← funext (@Set.mem_setOf_eq _ · Ideal.IsPrime), ← vanishingIdeal_isClosed_isIrreducible]
   rfl
 
 lemma zeroLocus_minimalPrimes :
-    zeroLocus ∘ (↑) '' minimalPrimes R =
-    irreducibleComponents (PrimeSpectrum R) := by
+    zeroLocus ∘ (↑) '' minimalPrimes R = irreducibleComponents (PrimeSpectrum R) := by
   rw [← vanishingIdeal_irreducibleComponents, ← Set.image_comp, Set.EqOn.image_eq_self]
   intros s hs
   simpa [zeroLocus_vanishingIdeal_eq_closure, closure_eq_iff_isClosed]
@@ -1244,9 +1228,9 @@ lemma zeroLocus_ideal_mem_irreducibleComponents {I : Ideal R} :
   conv_lhs => rw [← (isClosed_zeroLocus _).closure_eq]
   exact vanishingIdeal_mem_minimalPrimes.symm
 
-end PrimeSpectrum
-
 end CommSemiring
+
+end PrimeSpectrum
 
 namespace IsLocalRing
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
