### PR TITLE
chore(MeasureTheory/OuterMeasure):change `measure_mono_null` to `Measure.mono_null` to enable dot notation.

### DIFF
--- a/Mathlib/MeasureTheory/Constructions/Pi.lean
+++ b/Mathlib/MeasureTheory/Constructions/Pi.lean
@@ -349,7 +349,7 @@ theorem pi_eval_preimage_null {i : ι} {s : Set (α i)} (hs : μ i s = 0) :
   classical
   -- WLOG, `s` is measurable
   rcases exists_measurable_superset_of_null hs with ⟨t, hst, _, hμt⟩
-  suffices Measure.pi μ (eval i ⁻¹' t) = 0 from measure_mono_null (preimage_mono hst) this
+  suffices Measure.pi μ (eval i ⁻¹' t) = 0 from Measure.mono_null (preimage_mono hst) this
   -- Now rewrite it as `Set.pi`, and apply `pi_pi`
   rw [← univ_pi_update_univ, pi_pi]
   apply Finset.prod_eq_zero (Finset.mem_univ i)
@@ -509,7 +509,7 @@ end Intervals
 /-- If one of the measures `μ i` has no atoms, them `Measure.pi µ`
 has no atoms. The instance below assumes that all `μ i` have no atoms. -/
 theorem pi_noAtoms (i : ι) [NoAtoms (μ i)] : NoAtoms (Measure.pi μ) :=
-  ⟨fun x => flip measure_mono_null (pi_hyperplane μ i (x i)) (singleton_subset_iff.2 rfl)⟩
+  ⟨fun x => flip Measure.mono_null (pi_hyperplane μ i (x i)) (singleton_subset_iff.2 rfl)⟩
 
 instance pi_noAtoms' [h : Nonempty ι] [∀ i, NoAtoms (μ i)] : NoAtoms (Measure.pi μ) :=
   h.elim fun i => pi_noAtoms i

--- a/Mathlib/MeasureTheory/Function/AEMeasurableSequence.lean
+++ b/Mathlib/MeasureTheory/Function/AEMeasurableSequence.lean
@@ -102,7 +102,7 @@ theorem aeSeq_eq_fun_ae [Countable ι] (hf : ∀ i, AEMeasurable (f i) μ)
     (hp : ∀ᵐ x ∂μ, p x fun n => f n x) : ∀ᵐ a : α ∂μ, ∀ i : ι, aeSeq hf p i a = f i a :=
   haveI h_ss : { a : α | ¬∀ i : ι, aeSeq hf p i a = f i a } ⊆ (aeSeqSet hf p)ᶜ := fun _ =>
     mt fun hx i => aeSeq_eq_fun_of_mem_aeSeqSet hf hx i
-  measure_mono_null h_ss (measure_compl_aeSeqSet_eq_zero hf hp)
+  Measure.mono_null h_ss (measure_compl_aeSeqSet_eq_zero hf hp)
 
 theorem aeSeq_n_eq_fun_n_ae [Countable ι] (hf : ∀ i, AEMeasurable (f i) μ)
     (hp : ∀ᵐ x ∂μ, p x fun n => f n x) (n : ι) : aeSeq hf p n =ᵐ[μ] f n :=
@@ -115,7 +115,7 @@ theorem iSup [SupSet β] [Countable ι] (hf : ∀ i, AEMeasurable (f i) μ)
     intro x hx
     congr
     exact funext fun i => aeSeq_eq_fun_of_mem_aeSeqSet hf hx i
-  exact measure_mono_null (Set.compl_subset_compl.mpr h_ss) (measure_compl_aeSeqSet_eq_zero hf hp)
+  exact Measure.mono_null (Set.compl_subset_compl.mpr h_ss) (measure_compl_aeSeqSet_eq_zero hf hp)
 
 theorem iInf [InfSet β] [Countable ι] (hf : ∀ i, AEMeasurable (f i) μ)
     (hp : ∀ᵐ x ∂μ, p x fun n ↦ f n x) : ⨅ n, aeSeq hf p n =ᵐ[μ] ⨅ n, f n :=

--- a/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
+++ b/Mathlib/MeasureTheory/Function/ConvergenceInMeasure.lean
@@ -267,7 +267,7 @@ theorem TendstoInMeasure.exists_seq_tendsto_ae (hfg : TendstoInMeasure μ f atTo
       all_goals simp
     exact le_trans hNx.le h_inv_n_le_k
   rw [ae_iff]
-  refine ⟨ExistsSeqTendstoAe.seqTendstoAeSeq_strictMono hfg, measure_mono_null (fun x => ?_) hμs⟩
+  refine ⟨ExistsSeqTendstoAe.seqTendstoAeSeq_strictMono hfg, Measure.mono_null (fun x => ?_) hμs⟩
   rw [Set.mem_setOf_eq, ← @Classical.not_not (x ∈ s), not_imp_not]
   exact h_tendsto x
 

--- a/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/LpSeminorm/Basic.lean
@@ -728,7 +728,7 @@ lemma eLpNormEssSup_indicator_const_eq (s : Set α) (c : ε) (hμs : μ s ≠ 0)
   by_contra! h
   have h' := ae_iff.mp (ae_lt_of_essSup_lt h)
   push_neg at h'
-  refine hμs (measure_mono_null (fun x hx_mem => ?_) h')
+  refine hμs (Measure.mono_null (fun x hx_mem => ?_) h')
   rw [Set.mem_setOf_eq, Set.indicator_of_mem hx_mem]
 
 lemma eLpNorm_indicator_const₀ (hs : NullMeasurableSet s μ) (hp : p ≠ 0) (hp_top : p ≠ ∞) :

--- a/Mathlib/MeasureTheory/Group/Action.lean
+++ b/Mathlib/MeasureTheory/Group/Action.lean
@@ -284,7 +284,7 @@ theorem measure_isOpen_pos_of_smulInvariant_of_compact_ne_zero (hK : IsCompact K
   let ⟨t, ht⟩ := hK.exists_finite_cover_smul G hU hne
   pos_iff_ne_zero.2 fun hμU =>
     hμK <|
-      measure_mono_null ht <|
+      Measure.mono_null ht <|
         (measure_biUnion_null_iff t.countable_toSet).2 fun _ _ => by rwa [measure_smul]
 
 /-- If measure `μ` is invariant under an additive group action and is nonzero on a compact set `K`,

--- a/Mathlib/MeasureTheory/Group/Prod.lean
+++ b/Mathlib/MeasureTheory/Group/Prod.lean
@@ -150,7 +150,7 @@ theorem quasiMeasurePreserving_inv : QuasiMeasurePreserving (Inv.inv : G → G) 
       or_self_iff] using this
   have hsm' : MeasurableSet (s⁻¹ ×ˢ s⁻¹) := hsm.inv.prod hsm.inv
   simp_rw [map_apply hf hsm', prod_apply_symm (μ := μ) (ν := μ) (hf hsm'), preimage_preimage,
-    mk_preimage_prod, inv_preimage, inv_inv, measure_mono_null inter_subset_right hμs,
+    mk_preimage_prod, inv_preimage, inv_inv, Measure.mono_null inter_subset_right hμs,
     lintegral_zero]
 
 @[to_additive (attr := simp)]

--- a/Mathlib/MeasureTheory/Measure/AEDisjoint.lean
+++ b/Mathlib/MeasureTheory/Measure/AEDisjoint.lean
@@ -121,7 +121,7 @@ theorem exists_disjoint_diff (h : AEDisjoint μ s t) :
       simpa using ⟨hx.1, fun hxt => hx.2 <| subset_toMeasurable _ _ ⟨hx.1, hxt⟩⟩⟩
 
 theorem of_null_right (h : μ t = 0) : AEDisjoint μ s t :=
-  measure_mono_null inter_subset_right h
+  Measure.mono_null inter_subset_right h
 
 theorem of_null_left (h : μ s = 0) : AEDisjoint μ s t :=
   AEDisjoint.symm (of_null_right h)

--- a/Mathlib/MeasureTheory/Measure/AEMeasurable.lean
+++ b/Mathlib/MeasureTheory/Measure/AEMeasurable.lean
@@ -102,7 +102,7 @@ theorem sum_measure [Countable ι] {μ : ι → Measure α} (h : ∀ i, AEMeasur
     · rcases hx with ⟨i, hi⟩
       rw [hs _ _ hi]
       exact fun h => ⟨i, h, hi⟩
-  · refine measure_mono_null (fun x (hx : f x ≠ g x) => ?_) (hsμ i)
+  · refine Measure.mono_null (fun x (hx : f x ≠ g x) => ?_) (hsμ i)
     contrapose! hx
     refine (piecewise_eq_of_notMem _ _ _ ?_).symm
     exact fun h => hx (mem_iInter.1 h i)
@@ -383,7 +383,7 @@ lemma MeasureTheory.NullMeasurable.aemeasurable {f : α → β}
   have hvm : MeasurableSet v := .biUnion hSc fun s hs ↦ (hUm s hs).diff (hTm s hs)
   have hvμ : μ v = 0 := (measure_biUnion_null_iff hSc).2 fun s hs ↦ ae_le_set.1 <|
     ((hUeq s hs).trans (hTeq s hs).symm).le
-  refine ⟨v.piecewise (fun _ ↦ default) f, ?_, measure_mono_null (fun x ↦
+  refine ⟨v.piecewise (fun _ ↦ default) f, ?_, Measure.mono_null (fun x ↦
     not_imp_comm.2 fun hxv ↦ (piecewise_eq_of_notMem _ _ _ hxv).symm) hvμ⟩
   refine measurable_of_restrict_of_restrict_compl hvm ?_ ?_
   · rw [restrict_piecewise]

--- a/Mathlib/MeasureTheory/Measure/AbsolutelyContinuous.lean
+++ b/Mathlib/MeasureTheory/Measure/AbsolutelyContinuous.lean
@@ -63,7 +63,7 @@ namespace AbsolutelyContinuous
 theorem mk (h : ∀ ⦃s : Set α⦄, MeasurableSet s → ν s = 0 → μ s = 0) : μ ≪ ν := by
   intro s hs
   rcases exists_measurable_superset_of_null hs with ⟨t, h1t, h2t, h3t⟩
-  exact measure_mono_null h1t (h h2t h3t)
+  exact Measure.mono_null h1t (h h2t h3t)
 
 @[refl]
 protected theorem refl {_m0 : MeasurableSpace α} (μ : Measure α) : μ ≪ μ :=

--- a/Mathlib/MeasureTheory/Measure/Decomposition/Exhaustion.lean
+++ b/Mathlib/MeasureTheory/Measure/Decomposition/Exhaustion.lean
@@ -245,7 +245,7 @@ lemma measure_eq_top_of_subset_compl_sigmaFiniteSetWRT' [IsFiniteMeasure ν]
       (ht.inter measurableSet_sigmaFiniteSetWRT'.compl)
   intro t ht_subset hst ht
   refine measure_eq_top_of_subset_compl_sigmaFiniteSetWRT'_of_measurableSet ht ht_subset ?_
-  exact fun hνt ↦ hνs (measure_mono_null hst hνt)
+  exact fun hνt ↦ hνs (Measure.mono_null hst hνt)
 
 end IsFiniteMeasure
 

--- a/Mathlib/MeasureTheory/Measure/EverywherePos.lean
+++ b/Mathlib/MeasureTheory/Measure/EverywherePos.lean
@@ -67,7 +67,7 @@ lemma exists_isOpen_everywherePosSubset_eq_diff (μ : Measure α) (s : Set α) :
   rcases mem_nhds_iff.1 vx with ⟨w, wv, w_open, xw⟩
   have A : w ⊆ {x | ∃ n ∈ 𝓝[s] x, μ n = 0} := by
     intro y yw
-    refine ⟨s ∩ w, inter_mem_nhdsWithin _ (w_open.mem_nhds yw), measure_mono_null ?_ hx⟩
+    refine ⟨s ∩ w, inter_mem_nhdsWithin _ (w_open.mem_nhds yw), Measure.mono_null ?_ hx⟩
     rw [inter_comm]
     exact (inter_subset_inter_left _ wv).trans hv
   have B : w ∈ 𝓝 x := w_open.mem_nhds xw
@@ -99,7 +99,7 @@ lemma measure_eq_zero_of_subset_diff_everywherePosSubset
     (hk : IsCompact k) (h'k : k ⊆ s \ μ.everywherePosSubset s) : μ k = 0 := by
   apply hk.induction_on (p := fun t ↦ μ t = 0)
   · exact measure_empty
-  · exact fun s t hst ht ↦ measure_mono_null hst ht
+  · exact fun s t hst ht ↦ Measure.mono_null hst ht
   · exact fun s t hs ht ↦ measure_union_null hs ht
   · intro x hx
     obtain ⟨u, ux, hu⟩ : ∃ u ∈ 𝓝[s] x, μ u = 0 := by

--- a/Mathlib/MeasureTheory/Measure/GiryMonad.lean
+++ b/Mathlib/MeasureTheory/Measure/GiryMonad.lean
@@ -151,7 +151,7 @@ theorem le_ae_join (m : Measure (Measure α)) : (ae m).bind ae ≤ ae m.join := 
   rcases exists_measurable_superset_of_null hs with ⟨t, hst, htm, ht⟩
   rw [join_apply htm, lintegral_eq_zero_iff (measurable_coe htm)] at ht
   rw [mem_bind']
-  exact ht.mono fun _ ↦ measure_mono_null hst
+  exact ht.mono fun _ ↦ Measure.mono_null hst
 
 theorem ae_ae_of_ae_join {m : Measure (Measure α)} {p : α → Prop} (h : ∀ᵐ a ∂m.join, p a) :
     ∀ᵐ μ ∂m, ∀ᵐ a ∂μ, p a :=

--- a/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpace.lean
@@ -1356,7 +1356,7 @@ theorem tendsto_measure_Ici_atBot [Preorder α] [(atBot : Filter α).IsCountably
 variable [PartialOrder α] {a b : α}
 
 theorem Iio_ae_eq_Iic' (ha : μ {a} = 0) : Iio a =ᵐ[μ] Iic a := by
-  rw [← Iic_diff_right, diff_ae_eq_self, measure_mono_null Set.inter_subset_right ha]
+  rw [← Iic_diff_right, diff_ae_eq_self, Measure.mono_null Set.inter_subset_right ha]
 
 theorem Ioi_ae_eq_Ici' (ha : μ {a} = 0) : Ioi a =ᵐ[μ] Ici a :=
   Iio_ae_eq_Iic' (α := αᵒᵈ) ha

--- a/Mathlib/MeasureTheory/Measure/MeasureSpaceDef.lean
+++ b/Mathlib/MeasureTheory/Measure/MeasureSpaceDef.lean
@@ -215,7 +215,7 @@ theorem exists_measurable_superset_of_null (h : μ s = 0) : ∃ t, s ⊆ t ∧ M
 
 theorem exists_measurable_superset_iff_measure_eq_zero :
     (∃ t, s ⊆ t ∧ MeasurableSet t ∧ μ t = 0) ↔ μ s = 0 :=
-  ⟨fun ⟨_t, hst, _, ht⟩ => measure_mono_null hst ht, exists_measurable_superset_of_null⟩
+  ⟨fun ⟨_t, hst, _, ht⟩ => Measure.mono_null hst ht, exists_measurable_superset_of_null⟩
 
 theorem measure_biUnion_lt_top {s : Set β} {f : β → Set α} (hs : s.Finite)
     (hfin : ∀ i ∈ s, μ (f i) < ∞) : μ (⋃ i ∈ s, f i) < ∞ := by
@@ -262,10 +262,10 @@ theorem measure_inter_lt_top_of_right_ne_top (ht_finite : μ t ≠ ∞) : μ (s 
   measure_lt_top_of_subset inter_subset_right ht_finite
 
 theorem measure_inter_null_of_null_right (S : Set α) {T : Set α} (h : μ T = 0) : μ (S ∩ T) = 0 :=
-  measure_mono_null inter_subset_right h
+  Measure.mono_null inter_subset_right h
 
 theorem measure_inter_null_of_null_left {S : Set α} (T : Set α) (h : μ S = 0) : μ (S ∩ T) = 0 :=
-  measure_mono_null inter_subset_left h
+  Measure.mono_null inter_subset_left h
 
 /-! ### The almost everywhere filter -/
 section ae

--- a/Mathlib/MeasureTheory/Measure/MutuallySingular.lean
+++ b/Mathlib/MeasureTheory/Measure/MutuallySingular.lean
@@ -45,7 +45,7 @@ namespace MutuallySingular
 theorem mk {s t : Set α} (hs : μ s = 0) (ht : ν t = 0) (hst : univ ⊆ s ∪ t) :
     MutuallySingular μ ν := by
   use toMeasurable μ s, measurableSet_toMeasurable _ _, (measure_toMeasurable _).trans hs
-  refine measure_mono_null (fun x hx => (hst trivial).resolve_left fun hxs => hx ?_) ht
+  refine Measure.mono_null (fun x hx => (hst trivial).resolve_left fun hxs => hx ?_) ht
   exact subset_toMeasurable _ _ hxs
 
 /-- A set such that `μ h.nullSet = 0` and `ν h.nullSetᶜ = 0`. -/
@@ -110,7 +110,7 @@ theorem sum_left {ι : Type*} [Countable ι] {μ : ι → Measure α} : sum μ �
   choose s hsm hsμ hsν using H
   refine ⟨⋂ i, s i, MeasurableSet.iInter hsm, ?_, ?_⟩
   · rw [sum_apply _ (MeasurableSet.iInter hsm), ENNReal.tsum_eq_zero]
-    exact fun i => measure_mono_null (iInter_subset _ _) (hsμ i)
+    exact fun i => Measure.mono_null (iInter_subset _ _) (hsμ i)
   · rwa [compl_iInter, measure_iUnion_null_iff]
 
 @[simp]
@@ -140,7 +140,7 @@ theorem smul_nnreal (r : ℝ≥0) (h : ν ⟂ₘ μ) : r • ν ⟂ₘ μ :=
 lemma restrict (h : μ ⟂ₘ ν) (s : Set α) : μ.restrict s ⟂ₘ ν := by
   refine ⟨h.nullSet, h.measurableSet_nullSet, ?_, h.measure_compl_nullSet⟩
   rw [Measure.restrict_apply h.measurableSet_nullSet]
-  exact measure_mono_null Set.inter_subset_left h.measure_nullSet
+  exact Measure.mono_null Set.inter_subset_left h.measure_nullSet
 
 end MutuallySingular
 

--- a/Mathlib/MeasureTheory/Measure/OpenPos.lean
+++ b/Mathlib/MeasureTheory/Measure/OpenPos.lean
@@ -99,7 +99,7 @@ theorem _root_.IsClosed.measure_eq_one_iff_eq_univ [OpensMeasurableSpace X] [IsP
 
 /-- A null set has empty interior. -/
 theorem interior_eq_empty_of_null (hs : μ s = 0) : interior s = ∅ :=
-  isOpen_interior.eq_empty_of_measure_zero <| measure_mono_null interior_subset hs
+  isOpen_interior.eq_empty_of_measure_zero <| Measure.mono_null interior_subset hs
 
 /-- A property satisfied almost everywhere is satisfied on a dense subset. -/
 theorem dense_of_ae {p : X → Prop} (hp : ∀ᵐ x ∂μ, p x) : Dense {x | p x} := by
@@ -263,7 +263,7 @@ lemma IsMeagre.of_isSigmaCompact_null [T2Space X] (h₁s : IsSigmaCompact s) (h�
     IsMeagre s := by
   rcases h₁s with ⟨K, hcompact, hcover⟩
   have h (n : ℕ) : IsNowhereDense (K n) := by
-    have : μ (K n) = 0 := measure_mono_null (hcover ▸ subset_iUnion K n) h₂s
+    have : μ (K n) = 0 := Measure.mono_null (hcover ▸ subset_iUnion K n) h₂s
     exact .of_isClosed_null (hcompact n).isClosed this
   rw [isMeagre_iff_countable_union_isNowhereDense]
   exact ⟨range K, fun t ⟨n, hn⟩ ↦ hn ▸ h n, countable_range K, hcover.symm.subset⟩

--- a/Mathlib/MeasureTheory/Measure/Real.lean
+++ b/Mathlib/MeasureTheory/Measure/Real.lean
@@ -116,7 +116,7 @@ theorem measureReal_restrict_apply_self (s : Set α) : (μ.restrict s).real s = 
 theorem measureReal_mono_null (h : s₁ ⊆ s₂) (h₂ : μ.real s₂ = 0) (h'₂ : μ s₂ ≠ ∞ := by finiteness) :
     μ.real s₁ = 0 := by
   rw [measureReal_eq_zero_iff h'₂] at h₂
-  simp [Measure.real, measure_mono_null h h₂]
+  simp [Measure.real, Measure.mono_null h h₂]
 
 theorem measureReal_le_measureReal_union_left (h : μ t ≠ ∞ := by finiteness) :
     μ.real s ≤ μ.real (s ∪ t) := by

--- a/Mathlib/MeasureTheory/Measure/Restrict.lean
+++ b/Mathlib/MeasureTheory/Measure/Restrict.lean
@@ -972,7 +972,7 @@ theorem map_restrict_ae_le_map_indicator_ae [Zero β] (hs : MeasurableSet s) :
   · rw [mem_map_indicator_ae_iff_mem_map_restrict_ae_of_zero_mem ht hs]
     exact id
   rw [mem_map_indicator_ae_iff_of_zero_notMem ht, mem_map_restrict_ae_iff hs]
-  exact fun h => measure_mono_null (Set.inter_subset_left.trans Set.subset_union_left) h
+  exact fun h => Measure.mono_null (Set.inter_subset_left.trans Set.subset_union_left) h
 
 variable [Zero β]
 

--- a/Mathlib/MeasureTheory/Measure/Restrict.lean
+++ b/Mathlib/MeasureTheory/Measure/Restrict.lean
@@ -391,7 +391,7 @@ theorem QuasiMeasurePreserving.restrict {ν : Measure β} {f : α → β}
   absolutelyContinuous := by
     refine AbsolutelyContinuous.mk fun u hum ↦ ?_
     suffices ν (u ∩ t) = 0 → μ (f ⁻¹' u ∩ s) = 0 by simpa [hum, hf.measurable, hf.measurable hum]
-    refine fun hu ↦ measure_mono_null ?_ (hf.preimage_null hu)
+    refine fun hu ↦ Measure.mono_null ?_ (hf.preimage_null hu)
     rw [preimage_inter]
     gcongr
     assumption

--- a/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/Finite.lean
@@ -222,7 +222,7 @@ theorem ite_ae_eq_of_measure_zero {γ} (f : α → γ) (g : α → γ) (s : Set 
     (fun x => ite (x ∈ s) (f x) (g x)) =ᵐ[μ] g := by
   have h_ss : sᶜ ⊆ { a : α | ite (a ∈ s) (f a) (g a) = g a } := fun x hx => by
     simp [(Set.mem_compl_iff _ _).mp hx]
-  refine measure_mono_null ?_ hs_zero
+  refine Measure.mono_null ?_ hs_zero
   conv_rhs => rw [← compl_compl s]
   rwa [Set.compl_subset_compl]
 

--- a/Mathlib/MeasureTheory/Measure/Typeclasses/NoAtoms.lean
+++ b/Mathlib/MeasureTheory/Measure/Typeclasses/NoAtoms.lean
@@ -45,9 +45,9 @@ theorem Measure.restrict_singleton' {a : α} : μ.restrict {a} = 0 := by
 instance Measure.restrict.instNoAtoms (s : Set α) : NoAtoms (μ.restrict s) := by
   refine ⟨fun x => ?_⟩
   obtain ⟨t, hxt, ht1, ht2⟩ := exists_measurable_superset_of_null (measure_singleton x : μ {x} = 0)
-  apply measure_mono_null hxt
+  apply Measure.mono_null hxt
   rw [Measure.restrict_apply ht1]
-  apply measure_mono_null inter_subset_left ht2
+  apply Measure.mono_null inter_subset_left ht2
 
 theorem _root_.Set.Countable.measure_zero (h : s.Countable) (μ : Measure α) [NoAtoms μ] :
     μ s = 0 := by
@@ -76,7 +76,7 @@ theorem _root_.Finset.measure_zero (s : Finset α) (μ : Measure α) [NoAtoms μ
   s.finite_toSet.measure_zero μ
 
 theorem insert_ae_eq_self (a : α) (s : Set α) : (insert a s : Set α) =ᵐ[μ] s :=
-  union_ae_eq_right.2 <| measure_mono_null diff_subset (measure_singleton _)
+  union_ae_eq_right.2 <| Measure.mono_null diff_subset (measure_singleton _)
 
 section
 

--- a/Mathlib/MeasureTheory/OuterMeasure/AE.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/AE.lean
@@ -37,12 +37,14 @@ open scoped ENNReal
 
 namespace MeasureTheory
 
+open Measure
+
 variable {α β F : Type*} [FunLike F (Set α) ℝ≥0∞] [OuterMeasureClass F α] {μ : F} {s t : Set α}
 
 /-- The “almost everywhere” filter of co-null sets. -/
 def ae (μ : F) : Filter α :=
   .ofCountableUnion (μ · = 0) (fun _S hSc ↦ (measure_sUnion_null_iff hSc).2) fun _t ht _s hs ↦
-    measure_mono_null hs ht
+    mono_null hs ht
 
 /-- `∀ᵐ a ∂μ, p a` means that `p a` for a.e. `a`, i.e. `p` holds true away from a null set.
 
@@ -123,7 +125,7 @@ theorem ae_eq_trans {f g h : α → β} (h₁ : f =ᵐ[μ] g) (h₂ : g =ᵐ[μ]
   refine ⟨fun h a ha ↦ by simpa [ha] using (h {a}ᶜ).1, fun h s ↦ ⟨fun hs ↦ ?_, ?_⟩⟩
   · rw [← compl_empty_iff, ← not_nonempty_iff_eq_empty]
     rintro ⟨a, ha⟩
-    exact h _ <| measure_mono_null (singleton_subset_iff.2 ha) hs
+    exact h _ <| mono_null (singleton_subset_iff.2 ha) hs
   · rintro rfl
     simp
 
@@ -161,7 +163,7 @@ theorem diff_ae_eq_self : (s \ t : Set α) =ᵐ[μ] s ↔ μ (s ∩ t) = 0 := by
   simp [eventuallyLE_antisymm_iff, ae_le_set]
 
 theorem diff_null_ae_eq_self (ht : μ t = 0) : (s \ t : Set α) =ᵐ[μ] s :=
-  diff_ae_eq_self.mpr (measure_mono_null inter_subset_right ht)
+  diff_ae_eq_self.mpr (mono_null inter_subset_right ht)
 
 theorem ae_eq_set {s t : Set α} : s =ᵐ[μ] t ↔ μ (s \ t) = 0 ∧ μ (t \ s) = 0 := by
   simp [eventuallyLE_antisymm_iff, ae_le_set]

--- a/Mathlib/MeasureTheory/OuterMeasure/Basic.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/Basic.lean
@@ -98,7 +98,7 @@ theorem measure_diff_null (ht : μ t = 0) : μ (s \ t) = μ s :=
 
 theorem measure_biUnion_null_iff {I : Set ι} (hI : I.Countable) {s : ι → Set α} :
     μ (⋃ i ∈ I, s i) = 0 ↔ ∀ i ∈ I, μ (s i) = 0 := by
-  refine ⟨fun h i hi ↦ measure_mono_null (subset_biUnion_of_mem hi) h, fun h ↦ ?_⟩
+  refine ⟨fun h i hi ↦ Measure.mono_null (subset_biUnion_of_mem hi) h, fun h ↦ ?_⟩
   have _ := hI.to_subtype
   simpa [h] using measure_iUnion_le (μ := μ) fun x : I ↦ s x
 
@@ -144,7 +144,7 @@ theorem measure_null_of_locally_null [TopologicalSpace α] [SecondCountableTopol
   choose! u hxu hu₀ using hs
   choose t ht using TopologicalSpace.countable_cover_nhdsWithin hxu
   rcases ht with ⟨ts, t_count, ht⟩
-  apply measure_mono_null ht
+  apply Measure.mono_null ht
   exact (measure_biUnion_null_iff t_count).2 fun x hx => hu₀ x (ts hx)
 
 /-- If `m s ≠ 0`, then for some point `x ∈ s` and any `t ∈ 𝓝[s] x` we have `0 < m t`. -/

--- a/Mathlib/MeasureTheory/OuterMeasure/Basic.lean
+++ b/Mathlib/MeasureTheory/OuterMeasure/Basic.lean
@@ -50,7 +50,7 @@ theorem measure_empty : μ ∅ = 0 := OuterMeasureClass.measure_empty μ
 theorem measure_mono (h : s ⊆ t) : μ s ≤ μ t :=
   OuterMeasureClass.measure_mono μ h
 
-theorem measure_mono_null (h : s ⊆ t) (ht : μ t = 0) : μ s = 0 :=
+theorem Measure.mono_null (h : s ⊆ t) (ht : μ t = 0) : μ s = 0 :=
   eq_bot_mono (measure_mono h) ht
 
 lemma measure_eq_top_mono (h : s ⊆ t) (hs : μ s = ∞) : μ t = ∞ := eq_top_mono (measure_mono h) hs

--- a/Mathlib/MeasureTheory/VectorMeasure/Decomposition/Jordan.lean
+++ b/Mathlib/MeasureTheory/VectorMeasure/Decomposition/Jordan.lean
@@ -470,8 +470,8 @@ theorem absolutelyContinuous_ennreal_iff (s : SignedMeasure α) (μ : VectorMeas
     rw [totalVariation, Measure.add_apply, hpos, hneg, toMeasureOfZeroLE_apply _ _ _ hS₁,
       toMeasureOfLEZero_apply _ _ _ hS₁]
     rw [← VectorMeasure.AbsolutelyContinuous.ennrealToMeasure] at h
-    simp [h (measure_mono_null (i.inter_subset_right) hS₂),
-      h (measure_mono_null (iᶜ.inter_subset_right) hS₂)]
+    simp [h (Measure.mono_null (i.inter_subset_right) hS₂),
+      h (Measure.mono_null (iᶜ.inter_subset_right) hS₂)]
   · refine VectorMeasure.AbsolutelyContinuous.mk fun S hS₁ hS₂ => ?_
     rw [← VectorMeasure.ennrealToMeasure_apply hS₁] at hS₂
     exact null_of_totalVariation_zero s (h hS₂)
@@ -506,8 +506,8 @@ theorem mutuallySingular_iff (s t : SignedMeasure α) :
       simp [hu₂ _ Set.inter_subset_right]
   · rintro ⟨u, hmeas, hu₁, hu₂⟩
     exact
-      ⟨u, hmeas, fun t htu => null_of_totalVariation_zero _ (measure_mono_null htu hu₁),
-        fun t htv => null_of_totalVariation_zero _ (measure_mono_null htv hu₂)⟩
+      ⟨u, hmeas, fun t htu => null_of_totalVariation_zero _ (Measure.mono_null htu hu₁),
+        fun t htv => null_of_totalVariation_zero _ (Measure.mono_null htv hu₂)⟩
 
 theorem mutuallySingular_ennreal_iff (s : SignedMeasure α) (μ : VectorMeasure α ℝ≥0∞) :
     s ⟂ᵥ μ ↔ s.totalVariation ⟂ₘ μ.ennrealToMeasure := by
@@ -523,10 +523,10 @@ theorem mutuallySingular_ennreal_iff (s : SignedMeasure α) (μ : VectorMeasure 
   · rintro ⟨u, hmeas, hu₁, hu₂⟩
     refine
       VectorMeasure.MutuallySingular.mk u hmeas
-        (fun t htu _ => null_of_totalVariation_zero _ (measure_mono_null htu hu₁)) fun t htv hmt =>
+        (fun t htu _ => null_of_totalVariation_zero _ (Measure.mono_null htu hu₁)) fun t htv hmt =>
         ?_
     rw [← VectorMeasure.ennrealToMeasure_apply hmt]
-    exact measure_mono_null htv hu₂
+    exact Measure.mono_null htv hu₂
 
 theorem totalVariation_mutuallySingular_iff (s : SignedMeasure α) (μ : Measure α) :
     s.totalVariation ⟂ₘ μ ↔

--- a/Mathlib/Probability/ConditionalProbability.lean
+++ b/Mathlib/Probability/ConditionalProbability.lean
@@ -235,7 +235,7 @@ lemma cond_cond_eq_cond_inter' (hms : MeasurableSet s) (hmt : MeasurableSet t) (
   ext u
   rw [cond_apply hmt, cond_apply hms, cond_apply hms, cond_apply (hms.inter hmt)]
   obtain hst | hst := eq_or_ne (μ (s ∩ t)) 0
-  · have : μ (s ∩ t ∩ u) = 0 := measure_mono_null Set.inter_subset_left hst
+  · have : μ (s ∩ t ∩ u) = 0 := Measure.mono_null Set.inter_subset_left hst
     simp [this, ← Set.inter_assoc]
   · have hcs' : μ s ≠ 0 :=
       (measure_pos_of_superset Set.inter_subset_left hst).ne'


### PR DESCRIPTION
There are several results named `measure_X` in the library that may benefit from being changed to `Measure.X` to open the use of dot notation. This PR addresses just one of these, and the ensuing breakage.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
