### PR TITLE
 feat(RingTheory/Ideal/GoingDown): Lift of prime ideals of going down algebras, and Krull dimension

### DIFF
--- a/Mathlib/RingTheory/Ideal/GoingDown.lean
+++ b/Mathlib/RingTheory/Ideal/GoingDown.lean
@@ -162,12 +162,8 @@ any prime ideal `q` in `S` lying over the last element of `L` can be extended to
 chain in `S` of the same length which ends at `q`. -/
 noncomputable def liftOfLTSeries [Algebra.HasGoingDown R S]
     (L : LTSeries (PrimeSpectrum R)) (q : PrimeSpectrum S)
-    [q.asIdeal.LiesOver L.last.asIdeal] :
-    Σ' (f : (i : Fin (L.length + 1)) → PrimeSpectrum S),
-    (∀ i, (f i).asIdeal.LiesOver (L.toFun i).asIdeal) ∧
-    (∀ j : Fin L.length, f j.castSucc < f j.succ) :=
-  ⟨fun i => (liftOfLTSeries_toFun L q i).val,
-    ⟨fun i => (liftOfLTSeries_toFun L q i).property, liftOfLTSeries_step L q⟩⟩
+    [q.asIdeal.LiesOver L.last.asIdeal] : LTSeries (PrimeSpectrum S) :=
+  ⟨L.length, fun i => (liftOfLTSeries_toFun L q i).val, liftOfLTSeries_step L q⟩
 
 /-- If `Spec S → Spec R` is surjective and `S` has the going down property over `R`, then
 `ringKrullDim R ≤ ringKrullDim S`. -/
@@ -185,6 +181,6 @@ theorem ringKrullDim_le_of_surjective_spec [Algebra.HasGoingDown R S]
   · haveI : q.asIdeal.LiesOver L.last.asIdeal :=
       ((PrimeSpectrum.specComap_asIdeal (algebraMap R S) q) ▸ PrimeSpectrum.ext_iff.mp hq)
         ▸ inferInstance
-    refine ⟨⟨L.length, fun i => (liftOfLTSeries L q).fst i, (liftOfLTSeries L q).snd.right⟩, by rfl⟩
+    exact ⟨liftOfLTSeries L q, by tauto⟩
 
 end Algebra.HasGoingDown

--- a/Mathlib/RingTheory/Ideal/GoingDown.lean
+++ b/Mathlib/RingTheory/Ideal/GoingDown.lean
@@ -147,14 +147,14 @@ chain. -/
 lemma liftOfLTSeries_step [Algebra.HasGoingDown R S]
     (L : LTSeries (PrimeSpectrum R)) (q : PrimeSpectrum S) [q.asIdeal.LiesOver L.last.asIdeal] :
     ∀ (j : Fin L.length),
-    (liftOfLTSeries_toFun L q (⟨↑j.castSucc, by omega⟩)).val
-      < (liftOfLTSeries_toFun L q (⟨↑j.succ, by omega⟩)).val := by
+    (liftOfLTSeries_toFun L q (j.castSucc)).val
+      < (liftOfLTSeries_toFun L q (j.succ)).val := by
   intro j
   rw [liftOfLTSeries_toFun]
   simp only [show (↑j.castSucc ≠ L.length) from by simp; omega, dif_neg (not_false)]
   exact (@Ideal.exists_ideal_lt_liesOver_of_lt _ _ _ _ _ _ _ _ _ _
-    (liftOfLTSeries_toFun L q ⟨j.val + 1, by omega⟩).val.asIdeal _
-      (liftOfLTSeries_toFun L q ⟨j.val + 1, _⟩).property
+    (liftOfLTSeries_toFun L q j.succ).val.asIdeal _
+      (liftOfLTSeries_toFun L q j.succ).property
         (L.step (⟨j.val, by omega⟩))).choose_spec.1
 
 /-- Given an `R`-algebra `S` with the going-down property and a chain `L` of prime ideals in `R`,
@@ -164,10 +164,10 @@ noncomputable def liftOfLTSeries [Algebra.HasGoingDown R S]
     (L : LTSeries (PrimeSpectrum R)) (q : PrimeSpectrum S)
     [q.asIdeal.LiesOver L.last.asIdeal] :
     Σ' (f : (i : Fin (L.length + 1)) → PrimeSpectrum S),
-    (∀ i, (f i).asIdeal.LiesOver (L.toFun (⟨i, by omega⟩)).asIdeal) ∧
+    (∀ i, (f i).asIdeal.LiesOver (L.toFun i).asIdeal) ∧
     (∀ j : Fin L.length, f j.castSucc < f j.succ) :=
-  ⟨fun i => (liftOfLTSeries_toFun L q ⟨i, _⟩).val,
-    ⟨fun i => (liftOfLTSeries_toFun L q ⟨i, _⟩).property, liftOfLTSeries_step L q⟩⟩
+  ⟨fun i => (liftOfLTSeries_toFun L q i).val,
+    ⟨fun i => (liftOfLTSeries_toFun L q i).property, liftOfLTSeries_step L q⟩⟩
 
 /-- If `Spec S → Spec R` is surjective and `S` has the going down property over `R`, then
 `ringKrullDim R ≤ ringKrullDim S`. -/
@@ -185,7 +185,6 @@ theorem ringKrullDim_le_of_surjective_spec [Algebra.HasGoingDown R S]
   · haveI : q.asIdeal.LiesOver L.last.asIdeal :=
       ((PrimeSpectrum.specComap_asIdeal (algebraMap R S) q) ▸ PrimeSpectrum.ext_iff.mp hq)
         ▸ inferInstance
-    refine ⟨⟨L.length, fun i => (liftOfLTSeries L q).fst ⟨i, by omega⟩,
-      fun j => (liftOfLTSeries L q).snd.right j⟩, by rfl⟩
+    refine ⟨⟨L.length, fun i => (liftOfLTSeries L q).fst i, (liftOfLTSeries L q).snd.right⟩, by rfl⟩
 
 end Algebra.HasGoingDown

--- a/Mathlib/RingTheory/Ideal/GoingDown.lean
+++ b/Mathlib/RingTheory/Ideal/GoingDown.lean
@@ -169,4 +169,23 @@ noncomputable def liftOfLTSeries [Algebra.HasGoingDown R S]
   ⟨fun i => (liftOfLTSeries_toFun L q ⟨i, _⟩).val,
     ⟨fun i => (liftOfLTSeries_toFun L q ⟨i, _⟩).property, liftOfLTSeries_step L q⟩⟩
 
+/-- If `Spec S → Spec R` is surjective and `S` has the going down property over `R`, then
+`ringKrullDim R ≤ ringKrullDim S`. -/
+theorem ringKrullDim_le_of_surjective_spec [Algebra.HasGoingDown R S]
+    (h : Function.Surjective (RingHom.specComap (algebraMap R S))) :
+    ringKrullDim R ≤ ringKrullDim S := by
+  refine iSup_le fun L => ?_
+  suffices ∃ L' : LTSeries (PrimeSpectrum S), L.length ≤ L'.length by
+    obtain ⟨L, hL⟩:= this
+    exact le_trans (WithBot.coe_le_coe.mpr (WithTop.coe_le_coe.mpr hL))
+      (le_iSup (fun A => (A.length : WithBot ℕ∞)) L)
+  obtain ⟨q, hq⟩ := h L.last
+  by_cases L.length = 0
+  · exact ⟨⟨0, fun _ => q, fun i => i.elim0⟩, (by simpa)⟩
+  · haveI : q.asIdeal.LiesOver L.last.asIdeal :=
+      ((PrimeSpectrum.specComap_asIdeal (algebraMap R S) q) ▸ PrimeSpectrum.ext_iff.mp hq)
+        ▸ inferInstance
+    refine ⟨⟨L.length, fun i => (liftOfLTSeries L q).fst ⟨i, by omega⟩,
+      fun j => (liftOfLTSeries L q).snd.right j⟩, by rfl⟩
+
 end Algebra.HasGoingDown

--- a/Mathlib/RingTheory/Ideal/GoingDown.lean
+++ b/Mathlib/RingTheory/Ideal/GoingDown.lean
@@ -128,7 +128,7 @@ instance of_flat [Module.Flat R S] : Algebra.HasGoingDown R S := by
   apply PrimeSpectrum.specComap_surjective_of_faithfullyFlat
 
 /-- Constructs a lift of a chain of prime ideals from `R` to `S` using the going-down property. -/
-noncomputable def liftOfLTSeries_toFun [Algebra.HasGoingDown R S]
+noncomputable def liftOfLTSeriesToFun [Algebra.HasGoingDown R S]
     (L : LTSeries (PrimeSpectrum R)) (q : PrimeSpectrum S) [q.asIdeal.LiesOver L.last.asIdeal] :
     (i : Fin (L.length + 1)) →
     {q : PrimeSpectrum S // q.asIdeal.LiesOver (L.toFun i).asIdeal} :=
@@ -136,25 +136,25 @@ noncomputable def liftOfLTSeries_toFun [Algebra.HasGoingDown R S]
     if h : i.val = L.length then
       ⟨q, (congr_arg L.toFun (Fin.ext (h.trans (Fin.val_last L.length).symm))) ▸ ‹_›⟩
     else
-      let prev := liftOfLTSeries_toFun L q ⟨i.val + 1, _⟩
+      let prev := liftOfLTSeriesToFun L q ⟨i.val + 1, _⟩
       let lift := @Ideal.exists_ideal_lt_liesOver_of_lt _ _ _ _ _ _ _ _ _ _ prev.val.asIdeal _
         prev.property <| L.step ⟨i, by omega⟩
       ⟨⟨lift.choose, lift.choose_spec.2.1⟩, lift.choose_spec.2.2⟩
 termination_by i => L.length - i.val
 
-/-- Shows that the lift constructed by `liftOfLTSeries_toFun` preserves the ordering of the given
+/-- Shows that the lift constructed by `liftOfLTSeriesToFun` preserves the ordering of the given
 chain. -/
 lemma liftOfLTSeries_step [Algebra.HasGoingDown R S]
     (L : LTSeries (PrimeSpectrum R)) (q : PrimeSpectrum S) [q.asIdeal.LiesOver L.last.asIdeal] :
     ∀ (j : Fin L.length),
-    (liftOfLTSeries_toFun L q (j.castSucc)).val
-      < (liftOfLTSeries_toFun L q (j.succ)).val := by
+    (liftOfLTSeriesToFun L q (j.castSucc)).val
+      < (liftOfLTSeriesToFun L q (j.succ)).val := by
   intro j
-  rw [liftOfLTSeries_toFun]
+  rw [liftOfLTSeriesToFun]
   simp only [show (↑j.castSucc ≠ L.length) from by simp; omega, dif_neg (not_false)]
   exact (@Ideal.exists_ideal_lt_liesOver_of_lt _ _ _ _ _ _ _ _ _ _
-    (liftOfLTSeries_toFun L q j.succ).val.asIdeal _
-      (liftOfLTSeries_toFun L q j.succ).property
+    (liftOfLTSeriesToFun L q j.succ).val.asIdeal _
+      (liftOfLTSeriesToFun L q j.succ).property
         (L.step (⟨j.val, by omega⟩))).choose_spec.1
 
 /-- Given an `R`-algebra `S` with the going-down property and a chain `L` of prime ideals in `R`,
@@ -163,7 +163,7 @@ chain in `S` of the same length which ends at `q`. -/
 noncomputable def liftOfLTSeries [Algebra.HasGoingDown R S]
     (L : LTSeries (PrimeSpectrum R)) (q : PrimeSpectrum S)
     [q.asIdeal.LiesOver L.last.asIdeal] : LTSeries (PrimeSpectrum S) :=
-  ⟨L.length, fun i => (liftOfLTSeries_toFun L q i).val, liftOfLTSeries_step L q⟩
+  ⟨L.length, fun i => (liftOfLTSeriesToFun L q i).val, liftOfLTSeries_step L q⟩
 
 /-- If `Spec S → Spec R` is surjective and `S` has the going down property over `R`, then
 `ringKrullDim R ≤ ringKrullDim S`. -/


### PR DESCRIPTION
Adds `Algebra.HasGoingDown.liftOfLTSeries` and `Algebra.HasGoingDown.ringKrullDim_le_of_surjective_spec`.

`liftOfLTSeries` lifts a chain of prime ideals with fixed end point.

`ringKrullDim_le_of_surjective_spec` shows that, for a going down algebra, if the corresponding affine spectrum map is surjective, then its Krull dimension increases.
