### PR TITLE
feat(SuccOrder): simp lemma to refold `Order.succ` and `Order.pred`

### DIFF
--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -165,6 +165,9 @@ than `a`. If `a` is maximal, then `succ a = a`. -/
 def succ : α → α :=
   SuccOrder.succ
 
+@[simp]
+theorem _root_.SuccOrder.succ_eq_succ : @SuccOrder.succ α _ _ = Order.succ := rfl
+
 theorem le_succ : ∀ a : α, a ≤ succ a :=
   SuccOrder.le_succ
 
@@ -563,6 +566,9 @@ variable [Preorder α] [PredOrder α] {a b : α}
 than `a`. If `a` is minimal, then `pred a = a`. -/
 def pred : α → α :=
   PredOrder.pred
+
+@[simp]
+theorem _root_.PredOrder.pred_eq_pred : @PredOrder.pred α _ _ = Order.pred := rfl
 
 theorem pred_le : ∀ a : α, pred a ≤ a :=
   PredOrder.pred_le

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -1246,7 +1246,7 @@ variable {X Y : Type*} [Preorder X] [Preorder Y]
 -- See note [reducible non instances]
 /-- `SuccOrder` transfers across equivalences between orders. -/
 protected abbrev SuccOrder.ofOrderIso [SuccOrder X] (f : X ≃o Y) : SuccOrder Y where
-  succ y := f (succ (f.symm y))
+  succ y := f (Order.succ (f.symm y))
   le_succ y := by rw [← map_inv_le_iff f]; exact le_succ (f.symm y)
   max_of_succ_le h := by
     rw [← f.symm.isMax_apply]
@@ -1258,7 +1258,7 @@ protected abbrev SuccOrder.ofOrderIso [SuccOrder X] (f : X ≃o Y) : SuccOrder Y
 /-- `PredOrder` transfers across equivalences between orders. -/
 protected abbrev PredOrder.ofOrderIso [PredOrder X] (f : X ≃o Y) :
     PredOrder Y where
-  pred y := f (pred (f.symm y))
+  pred y := f (Order.pred (f.symm y))
   pred_le y := by rw [← le_map_inv_iff f]; exact pred_le (f.symm y)
   min_of_le_pred h := by
     rw [← f.symm.isMin_apply]


### PR DESCRIPTION
Adds `SuccOrder.succ_eq_succ` and `PredOrder.pred_eq_pred` to refold `SuccOrder.succ` and `PredOrder.pred` into `Order.succ` and `Order.pred`. These lemmas are marked `@[simp]`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
