### PR TITLE
chore(Finsupp/Indicator): make non-classical

### DIFF
--- a/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
@@ -513,6 +513,8 @@ theorem prod_dvd_prod_of_subset_of_dvd [Zero M] [CommMonoid N] {f1 f2 : α →�
     apply prod_dvd_prod_of_dvd
     exact h2
 
+variable [DecidableEq α] [DecidableEq M]
+
 lemma indicator_eq_sum_attach_single [AddCommMonoid M] {s : Finset α} (f : ∀ a ∈ s, M) :
     indicator s f = ∑ x ∈ s.attach, single ↑x (f x x.2) := by
   rw [← sum_single (indicator s f), sum, sum_subset (support_indicator_subset _ _), ← sum_attach]

--- a/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
@@ -513,6 +513,8 @@ theorem prod_dvd_prod_of_subset_of_dvd [Zero M] [CommMonoid N] {f1 f2 : α →�
     apply prod_dvd_prod_of_dvd
     exact h2
 
+section indicator
+
 variable [DecidableEq α] [DecidableEq M]
 
 lemma indicator_eq_sum_attach_single [AddCommMonoid M] {s : Finset α} (f : ∀ a ∈ s, M) :
@@ -535,6 +537,7 @@ lemma prod_indicator_index_eq_prod_attach [Zero M] [CommMonoid N]
   refine Finset.prod_congr rfl (fun _ _ => ?_)
   rw [indicator_of_mem]
 
+omit [DecidableEq α] [DecidableEq M] in
 @[to_additive (attr := simp)]
 lemma prod_attach_index [CommMonoid N] {s : Finset α} (f : α → M) {h : α → M → N} :
     ∏ x ∈ s.attach, h x (f x) = ∏ x ∈ s, h x (f x) :=
@@ -545,6 +548,8 @@ lemma prod_indicator_index [Zero M] [CommMonoid N]
     {s : Finset α} (f : α → M) {h : α → M → N} (h_zero : ∀ a ∈ s, h a 0 = 1) :
     (indicator s (fun x _ ↦ f x)).prod h = ∏ x ∈ s, h x (f x) := by
   simp +contextual [h_zero]
+
+end indicator
 
 @[to_additive]
 lemma prod_mul_eq_prod_mul_of_exists [Zero M] [CommMonoid N]

--- a/Mathlib/Data/Finsupp/Indicator.lean
+++ b/Mathlib/Data/Finsupp/Indicator.lean
@@ -24,16 +24,12 @@ variable {ι α : Type*}
 
 namespace Finsupp
 
-variable [Zero α] {s : Finset ι} (f : ∀ i ∈ s, α) {i : ι}
+variable [DecidableEq α] [Zero α] [DecidableEq ι] {s : Finset ι} (f : ∀ i ∈ s, α) {i : ι}
 
 /-- Create an element of `ι →₀ α` from a finset `s` and a function `f` defined on this finset. -/
 def indicator (s : Finset ι) (f : ∀ i ∈ s, α) : ι →₀ α where
-  toFun i :=
-    haveI := Classical.decEq ι
-    if H : i ∈ s then f i H else 0
-  support :=
-    haveI := Classical.decEq α
-    ({i | f i.1 i.2 ≠ 0} : Finset s).map (Embedding.subtype _)
+  toFun i := if H : i ∈ s then f i H else 0
+  support := ({i | f i.1 i.2 ≠ 0} : Finset s).map (Embedding.subtype _)
   mem_support_toFun i := by
     classical simp
 
@@ -48,9 +44,8 @@ theorem indicator_of_notMem (hi : i ∉ s) (f : ∀ i ∈ s, α) : indicator s f
 variable (s i)
 
 @[simp]
-theorem indicator_apply [DecidableEq ι] : indicator s f i = if hi : i ∈ s then f i hi else 0 := by
+theorem indicator_apply : indicator s f i = if hi : i ∈ s then f i hi else 0 := by
   simp only [indicator, ne_eq, coe_mk]
-  congr
 
 theorem indicator_injective : Injective fun f : ∀ i ∈ s, α => indicator s f := by
   intro a b h


### PR DESCRIPTION
This was surprising to see on a data-carrying definition.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
