### PR TITLE
[Merged by Bors] - feat(algebraic topology): decidable equality on simplex category homs

### DIFF
--- a/Mathlib/AlgebraicTopology/SimplexCategory/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/Basic.lean
@@ -26,6 +26,9 @@ open Simplicial CategoryTheory Limits
 
 namespace SimplexCategory
 
+instance {n m : ℕ} : DecidableEq (⦋n⦌ ⟶ ⦋m⦌) := fun a b =>
+  decidable_of_iff (a.toOrderHom = b.toOrderHom) SimplexCategory.Hom.ext_iff.symm
+
 section Init
 
 /-- The constant morphism from ⦋0⦌. -/
@@ -414,16 +417,16 @@ noncomputable instance :
 @[simp]
 lemma δ_zero_mkOfSucc {n : ℕ} (i : Fin n) :
     δ 0 ≫ mkOfSucc i = SimplexCategory.const _ ⦋n⦌ i.succ := by
-  haveI :  Decidable (∀ {n : ℕ} (i : Fin n), δ 0 ≫ mkOfSucc i = ⦋0⦌.const ⦋n⦌ i.succ) :=
-    Classical.propDecidable (∀ {n : ℕ} (i : Fin n), δ 0 ≫ mkOfSucc i = ⦋0⦌.const ⦋n⦌ i.succ)
-  sorry -- decide +revert fails
+  ext x
+  fin_cases x
+  rfl
 
 @[simp]
 lemma δ_one_mkOfSucc {n : ℕ} (i : Fin n) :
     δ 1 ≫ mkOfSucc i = SimplexCategory.const _ ⦋n⦌ i.castSucc := by
   ext x
   fin_cases x
-  aesop
+  rfl
 
 /-- If `i + 1 < j`, `mkOfSucc i ≫ δ j` is the morphism `⦋1⦌ ⟶ ⦋n⦌` that
 sends `0` and `1` to `i` and `i + 1`, respectively. -/

--- a/Mathlib/AlgebraicTopology/SimplexCategory/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/Basic.lean
@@ -410,10 +410,6 @@ lemma factor_δ_spec {m n : ℕ} (f : ⦋m⦌ ⟶ ⦋n + 1⦌) (j : Fin (n + 2))
   ext k : 3
   cases j using Fin.cases <;> simp_all [factor_δ, δ, σ]
 
-noncomputable instance :
-    Decidable (∀ {n : ℕ} (i : Fin n), δ 0 ≫ mkOfSucc i = ⦋0⦌.const ⦋n⦌ i.succ) :=
-  Classical.propDecidable (∀ {n : ℕ} (i : Fin n), δ 0 ≫ mkOfSucc i = ⦋0⦌.const ⦋n⦌ i.succ)
-
 @[simp]
 lemma δ_zero_mkOfSucc {n : ℕ} (i : Fin n) :
     δ 0 ≫ mkOfSucc i = SimplexCategory.const _ ⦋n⦌ i.succ := by

--- a/Mathlib/AlgebraicTopology/SimplexCategory/Basic.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/Basic.lean
@@ -407,12 +407,16 @@ lemma factor_δ_spec {m n : ℕ} (f : ⦋m⦌ ⟶ ⦋n + 1⦌) (j : Fin (n + 2))
   ext k : 3
   cases j using Fin.cases <;> simp_all [factor_δ, δ, σ]
 
+noncomputable instance :
+    Decidable (∀ {n : ℕ} (i : Fin n), δ 0 ≫ mkOfSucc i = ⦋0⦌.const ⦋n⦌ i.succ) :=
+  Classical.propDecidable (∀ {n : ℕ} (i : Fin n), δ 0 ≫ mkOfSucc i = ⦋0⦌.const ⦋n⦌ i.succ)
+
 @[simp]
 lemma δ_zero_mkOfSucc {n : ℕ} (i : Fin n) :
     δ 0 ≫ mkOfSucc i = SimplexCategory.const _ ⦋n⦌ i.succ := by
-  ext x
-  fin_cases x
-  rfl
+  haveI :  Decidable (∀ {n : ℕ} (i : Fin n), δ 0 ≫ mkOfSucc i = ⦋0⦌.const ⦋n⦌ i.succ) :=
+    Classical.propDecidable (∀ {n : ℕ} (i : Fin n), δ 0 ≫ mkOfSucc i = ⦋0⦌.const ⦋n⦌ i.succ)
+  sorry -- decide +revert fails
 
 @[simp]
 lemma δ_one_mkOfSucc {n : ℕ} (i : Fin n) :

--- a/Mathlib/AlgebraicTopology/SimplexCategory/Defs.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/Defs.lean
@@ -147,12 +147,6 @@ theorem Hom.ext {a b : SimplexCategory} (f g : a ⟶ b) :
     f.toOrderHom = g.toOrderHom → f = g :=
   Hom.ext' _ _
 
-noncomputable instance {n m : ℕ} : DecidableEq (Fin n → Fin m) :=
-  Classical.typeDecidableEq (Fin n → Fin m)
-
-noncomputable instance {n m : ℕ} : DecidableEq (⦋n⦌ ⟶ ⦋m⦌) := fun a b =>
-  decidable_of_iff (a.toOrderHom = b.toOrderHom) SimplexCategory.Hom.ext_iff.symm
-
 /-- The truncated simplex category. -/
 def Truncated (n : ℕ) :=
   ObjectProperty.FullSubcategory fun a : SimplexCategory => a.len ≤ n

--- a/Mathlib/AlgebraicTopology/SimplexCategory/Defs.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/Defs.lean
@@ -147,6 +147,12 @@ theorem Hom.ext {a b : SimplexCategory} (f g : a ⟶ b) :
     f.toOrderHom = g.toOrderHom → f = g :=
   Hom.ext' _ _
 
+noncomputable instance {n m : ℕ} : DecidableEq (Fin n → Fin m) :=
+  Classical.typeDecidableEq (Fin n → Fin m)
+
+noncomputable instance {n m : ℕ} : DecidableEq (⦋n⦌ ⟶ ⦋m⦌) := fun a b =>
+  decidable_of_iff (a.toOrderHom = b.toOrderHom) SimplexCategory.Hom.ext_iff.symm
+
 /-- The truncated simplex category. -/
 def Truncated (n : ℕ) :=
   ObjectProperty.FullSubcategory fun a : SimplexCategory => a.len ≤ n

--- a/Mathlib/Order/Hom/Basic.lean
+++ b/Mathlib/Order/Hom/Basic.lean
@@ -261,6 +261,10 @@ theorem coe_copy (f : α →o β) (f' : α → β) (h : f' = f) : (f.copy f' h) 
 theorem copy_eq (f : α →o β) (f' : α → β) (h : f' = f) : f.copy f' h = f :=
   DFunLike.ext' h
 
+instance {α : Type*} (β : Type*) [PartialOrder α] [PartialOrder β] [DecidableEq (α → β)] :
+    DecidableEq (α →o β) := fun a b =>
+  decidable_of_iff (a.toFun = b.toFun) OrderHom.ext_iff.symm
+
 /-- The identity function as bundled monotone function. -/
 @[simps -fullyApplied]
 def id : α →o α :=


### PR DESCRIPTION
As arrows in the simplex category are order preserving functions of finite ordinals, the hom types in `SimplexCategory` are decidable.

Co-authored by: @robin-carlier and @joelriou 

---

This is currently not used for anything so maybe we should abandon this direction?

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
