### PR TITLE
[Merged by Bors] - feat(ENNReal): `x⁻¹ ^ n = (x ^ n)⁻¹`

### DIFF
--- a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
@@ -723,7 +723,6 @@ theorem inv_rpow (x : ℝ≥0∞) (y : ℝ) : x⁻¹ ^ y = (x ^ y)⁻¹ := by
     one_rpow]
 
 protected lemma inv_zpow (x : ℝ≥0∞) (n : ℤ) : x⁻¹ ^ n = (x ^ n)⁻¹ := by
-  field_simp
   simp [@one_div,← rpow_intCast, ENNReal.inv_rpow]
 
 lemma zero_zpow_def (n : ℤ) : (0 : ℝ≥0∞) ^ n = if 0 < n then 0 else if n = 0 then 1 else ⊤ := by

--- a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
@@ -654,13 +654,10 @@ lemma rpow_intCast (x : ℝ≥0∞) (n : ℤ) : x ^ (n : ℝ) = x ^ n := by
   cases n <;> simp only [Int.ofNat_eq_coe, Int.cast_natCast, rpow_natCast, zpow_natCast,
     Int.cast_negSucc, rpow_neg, zpow_negSucc]
 
-lemma NNReal_pow_le_one (m : ℤ) (n : NNReal) (hn : 1 ≤ n) (hm : m ≤ 0) :
+lemma ENNReal.coe_zpow_le_one_of_nonpos (m : ℤ) (n : NNReal) (hn : 1 ≤ n) (hm : m ≤ 0) :
     (n ^ m : ENNReal) ≤ 1 := by
-  convert_to (n ^ (m : ℝ) : ENNReal) ≤ 1
-  · simp
-  rw [←ENNReal.coe_rpow_of_ne_zero (by positivity)]
-  simp only [NNReal.rpow_intCast, coe_le_one_iff]
-  exact zpow_le_one_of_nonpos₀ hn hm
+  convert ENNReal.coe_le_coe.mpr (zpow_le_one_of_nonpos₀ hn hm)
+  rw [ENNReal.coe_zpow (by positivity)]
 
 theorem rpow_two (x : ℝ≥0∞) : x ^ (2 : ℝ) = x ^ 2 := rpow_ofNat x 2
 

--- a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
@@ -722,50 +722,6 @@ theorem inv_rpow (x : ℝ≥0∞) (y : ℝ) : x⁻¹ ^ y = (x ^ y)⁻¹ := by
   rw [← mul_rpow_of_ne_zero (ENNReal.inv_ne_zero.2 h_top) h0, ENNReal.inv_mul_cancel h0 h_top,
     one_rpow]
 
-protected lemma inv_zpow (x : ℝ≥0∞) (n : ℤ) : x⁻¹ ^ n = (x ^ n)⁻¹ := by
-  simp [← rpow_intCast, ENNReal.inv_rpow]
-
-lemma zero_zpow_def (n : ℤ) : (0 : ℝ≥0∞) ^ n = if 0 < n then 0 else if n = 0 then 1 else ⊤ := by
-  rw [← rpow_intCast,zero_rpow_def]; simp
-
-lemma top_zpow (n : ℤ) : (⊤ : ℝ≥0∞) ^ n = if 0 < n then ⊤ else if n = 0 then 1
-    else 0 := by
-  rw [← inv_zero, ENNReal.inv_zpow, zero_zpow_def]; split_ifs with h; all_goals simp
-
-protected lemma inv_zpow' (x : ℝ≥0∞) (n : ℤ) : x⁻¹ ^ n = x ^ (-n) := by
-  by_cases h0 : x = 0
-  · rw[h0, zero_zpow_def]
-    simp
-    rw [top_zpow]
-    split_ifs with ha hb hc hd he hf
-    all_goals try linarith
-    all_goals try rfl
-    have : n = 0 := (Int.le_antisymm (Int.not_lt.mp ha) (Int.not_lt.mp hf))
-    contradiction
-  by_cases h1 : x = ⊤
-  · rw [h1, inv_top, zero_zpow_def, top_zpow]
-    split_ifs with a b c d e f g h
-    all_goals try simp;
-    all_goals try linarith
-    · rw [neg_eq_zero] at f
-      contradiction
-    · rw [neg_eq_zero] at h
-      contradiction
-    simp only [Int.neg_pos, not_lt] at g a
-    have : n = 0 := Eq.symm (Int.le_antisymm g a)
-    contradiction
-  rw [ENNReal.inv_zpow, ←ENNReal.eq_inv_of_mul_eq_one_left]
-  rw [←ENNReal.zpow_add]
-  · simp
-  · exact h0
-  exact h1
-
-lemma zpow_le_one_of_nonpos {n : ℤ} (hn : n ≤ 0) {x : ℝ≥0∞} (hx : 1 ≤ x) : x ^ n ≤ 1 := by
-  obtain ⟨m, rfl⟩ := neg_surjective n
-  lift m to ℕ using by simpa using hn
-  rw [← ENNReal.inv_zpow', ENNReal.inv_zpow, ENNReal.inv_le_one]
-  exact mod_cast one_le_pow₀ hx
-
 theorem div_rpow_of_nonneg (x y : ℝ≥0∞) {z : ℝ} (hz : 0 ≤ z) : (x / y) ^ z = x ^ z / y ^ z := by
   rw [div_eq_mul_inv, mul_rpow_of_nonneg _ _ hz, inv_rpow, div_eq_mul_inv]
 

--- a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
@@ -654,7 +654,7 @@ lemma rpow_intCast (x : ℝ≥0∞) (n : ℤ) : x ^ (n : ℝ) = x ^ n := by
   cases n <;> simp only [Int.ofNat_eq_coe, Int.cast_natCast, rpow_natCast, zpow_natCast,
     Int.cast_negSucc, rpow_neg, zpow_negSucc]
 
-lemma ENNReal.coe_zpow_le_one_of_nonpos (m : ℤ) (n : NNReal) (hn : 1 ≤ n) (hm : m ≤ 0) :
+lemma coe_zpow_le_one_of_nonpos (m : ℤ) (n : NNReal) (hn : 1 ≤ n) (hm : m ≤ 0) :
     (n ^ m : ENNReal) ≤ 1 := by
   convert ENNReal.coe_le_coe.mpr (zpow_le_one_of_nonpos₀ hn hm)
   rw [ENNReal.coe_zpow (by positivity)]

--- a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
@@ -723,7 +723,7 @@ theorem inv_rpow (x : ℝ≥0∞) (y : ℝ) : x⁻¹ ^ y = (x ^ y)⁻¹ := by
     one_rpow]
 
 protected lemma inv_zpow (x : ℝ≥0∞) (n : ℤ) : x⁻¹ ^ n = (x ^ n)⁻¹ := by
-  simp [@one_div,← rpow_intCast, ENNReal.inv_rpow]
+  simp [← rpow_intCast, ENNReal.inv_rpow]
 
 lemma zero_zpow_def (n : ℤ) : (0 : ℝ≥0∞) ^ n = if 0 < n then 0 else if n = 0 then 1 else ⊤ := by
   rw [← rpow_intCast,zero_rpow_def]; simp

--- a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
@@ -658,7 +658,8 @@ lemma NNReal_pow_le_one (m : ℤ) (n : NNReal) (hn : 1 ≤ n) (hm : m ≤ 0) :
     (n ^ m : ENNReal) ≤ 1 := by
   convert_to (n ^ (m : ℝ) : ENNReal) ≤ 1
   · simp
-  rw [←ENNReal.coe_rpow_of_ne_zero (by positivity)]; simp only [NNReal.rpow_intCast, coe_le_one_iff]
+  rw [←ENNReal.coe_rpow_of_ne_zero (by positivity)]
+  simp only [NNReal.rpow_intCast, coe_le_one_iff]
   exact zpow_le_one_of_nonpos₀ hn hm
 
 theorem rpow_two (x : ℝ≥0∞) : x ^ (2 : ℝ) = x ^ 2 := rpow_ofNat x 2

--- a/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/NNReal.lean
@@ -654,6 +654,13 @@ lemma rpow_intCast (x : ℝ≥0∞) (n : ℤ) : x ^ (n : ℝ) = x ^ n := by
   cases n <;> simp only [Int.ofNat_eq_coe, Int.cast_natCast, rpow_natCast, zpow_natCast,
     Int.cast_negSucc, rpow_neg, zpow_negSucc]
 
+lemma NNReal_pow_le_one (m : ℤ) (n : NNReal) (hn : 1 ≤ n) (hm : m ≤ 0) :
+    (n ^ m : ENNReal) ≤ 1 := by
+  convert_to (n ^ (m : ℝ) : ENNReal) ≤ 1
+  · simp
+  rw [←ENNReal.coe_rpow_of_ne_zero (by positivity)]; simp only [NNReal.rpow_intCast, coe_le_one_iff]
+  exact zpow_le_one_of_nonpos₀ hn hm
+
 theorem rpow_two (x : ℝ≥0∞) : x ^ (2 : ℝ) = x ^ 2 := rpow_ofNat x 2
 
 theorem mul_rpow_eq_ite (x y : ℝ≥0∞) (z : ℝ) :

--- a/Mathlib/Data/ENNReal/Inv.lean
+++ b/Mathlib/Data/ENNReal/Inv.lean
@@ -643,6 +643,12 @@ theorem coe_zpow (hr : r ≠ 0) (n : ℤ) : (↑(r ^ n) : ℝ≥0∞) = (r : ℝ
   · have : r ^ n.succ ≠ 0 := pow_ne_zero (n + 1) hr
     simp only [zpow_negSucc, coe_inv this, coe_pow]
 
+lemma zero_zpow_def (n : ℤ) : (0 : ℝ≥0∞) ^ n = if n = 0 then 1 else if 0 < n then 0 else ⊤ := by
+  obtain ((_ | n) | n) := n <;> simp [-Nat.cast_add, -Int.natCast_add]
+
+lemma top_zpow_def (n : ℤ) : (⊤ : ℝ≥0∞) ^ n = if n = 0 then 1 else if 0 < n then ⊤ else 0 := by
+  obtain ((_ | n) | n) := n <;> simp [-Nat.cast_add, -Int.natCast_add]
+
 theorem zpow_pos (ha : a ≠ 0) (h'a : a ≠ ∞) (n : ℤ) : 0 < a ^ n := by
   cases n
   · simpa using ENNReal.pow_pos ha.bot_lt _
@@ -718,74 +724,24 @@ protected theorem zpow_add {x : ℝ≥0∞} (hx : x ≠ 0) (h'x : x ≠ ∞) (m 
   replace hx : x ≠ 0 := by simpa only [Ne, coe_eq_zero] using hx
   simp only [← coe_zpow hx, zpow_add₀ hx, coe_mul]
 
-protected theorem zpow_neg {x : ℝ≥0∞} (x_ne_zero : x ≠ 0) (x_ne_top : x ≠ ⊤) (m : ℤ) :
-    x ^ (-m) = (x ^ m)⁻¹ :=
-  ENNReal.eq_inv_of_mul_eq_one_left (by simp [← ENNReal.zpow_add x_ne_zero x_ne_top])
+protected theorem zpow_neg (x : ℝ≥0∞) (m : ℤ) : x ^ (-m) = (x ^ m)⁻¹ := by
+  obtain hx₀ | hx₀ := eq_or_ne x 0
+  · obtain hm | hm | hm := lt_trichotomy m 0 <;>
+      simp_all [zero_zpow_def, ne_of_lt, ne_of_gt, lt_asymm]
+  obtain hx | hx := eq_or_ne x ⊤
+  · obtain hm | hm | hm := lt_trichotomy m 0 <;>
+      simp_all [top_zpow_def, ne_of_lt, ne_of_gt, lt_asymm]
+  exact ENNReal.eq_inv_of_mul_eq_one_left (by simp [← ENNReal.zpow_add hx₀ hx])
 
 protected theorem zpow_sub {x : ℝ≥0∞} (x_ne_zero : x ≠ 0) (x_ne_top : x ≠ ⊤) (m n : ℤ) :
     x ^ (m - n) = (x ^ m) * (x ^ n)⁻¹ := by
-  rw [sub_eq_add_neg, ENNReal.zpow_add x_ne_zero x_ne_top, ENNReal.zpow_neg x_ne_zero x_ne_top n]
+  rw [sub_eq_add_neg, ENNReal.zpow_add x_ne_zero x_ne_top, ENNReal.zpow_neg]
 
 protected lemma inv_zpow (x : ℝ≥0∞) (n : ℤ) : x⁻¹ ^ n = (x ^ n)⁻¹ := by
-  rcases lt_trichotomy (0 : ℤ) n with (H | rfl | H)
-  · lift n to ℕ using Int.le_of_lt H
-    simp only [zpow_natCast]
-    exact Eq.symm ENNReal.inv_pow
-  · simp
-  · obtain ⟨a, rfl | rfl⟩ := Int.eq_nat_or_neg n
-    · simp
-      exact Eq.symm ENNReal.inv_pow
-    · simp_all only [Int.neg_neg_iff_pos, Int.natCast_pos]
-      rw [zpow_neg_coe_of_pos x⁻¹ H, ← ENNReal.inv_pow, zpow_neg_coe_of_pos x H]
-
-lemma zero_zpow_def (n : ℤ) : (0 : ℝ≥0∞) ^ n = if 0 < n then 0 else if n = 0 then 1 else ⊤ := by
-  have : (0 : ENNReal) ≠ ⊤ := zero_ne_top
-  rcases lt_trichotomy (0 : ℤ) n with (H | rfl | H)
-  swap; · simp
-  · split_ifs with ha
-    swap; · linarith
-    lift n to ℕ using Int.le_of_lt H
-    rw [zpow_natCast]
-    simp only [pow_eq_zero_iff', ne_eq, true_and]
-    exact Nat.ne_zero_iff_zero_lt.mpr <| Int.natCast_pos.mp H
-  · split_ifs with ha hb
-    all_goals try linarith
-    induction n
-    all_goals try linarith
-    rw [neg_sub_comm,neg_sub_left,←Int.negSucc_eq, zpow_negSucc]
-    simp
-
-lemma top_zpow (n : ℤ) : (⊤ : ℝ≥0∞) ^ n = if 0 < n then ⊤ else if n = 0 then 1
-    else 0 := by
-  rw [← inv_zero, ENNReal.inv_zpow, zero_zpow_def]; split_ifs with h; all_goals simp
+  cases n <;> simp [ENNReal.inv_pow]
 
 protected lemma inv_zpow' (x : ℝ≥0∞) (n : ℤ) : x⁻¹ ^ n = x ^ (-n) := by
-  by_cases h0 : x = 0
-  · rw[h0, zero_zpow_def]
-    simp
-    rw [top_zpow]
-    split_ifs with ha hb hc hd he hf
-    all_goals try linarith
-    all_goals try rfl
-    have : n = 0 := (Int.le_antisymm (Int.not_lt.mp ha) (Int.not_lt.mp hf))
-    contradiction
-  by_cases h1 : x = ⊤
-  · rw [h1, inv_top, zero_zpow_def, top_zpow]
-    split_ifs with a b c d e f g h
-    all_goals try simp;
-    all_goals try linarith
-    · rw [neg_eq_zero] at f
-      contradiction
-    · rw [neg_eq_zero] at h
-      contradiction
-    simp only [Int.neg_pos, not_lt] at g a
-    have : n = 0 := Eq.symm (Int.le_antisymm g a)
-    contradiction
-  rw [ENNReal.inv_zpow, ←ENNReal.eq_inv_of_mul_eq_one_left]
-  rw [←ENNReal.zpow_add]
-  · simp
-  · exact h0
-  exact h1
+  rw [ENNReal.zpow_neg, ENNReal.inv_zpow]
 
 lemma zpow_le_one_of_nonpos {n : ℤ} (hn : n ≤ 0) {x : ℝ≥0∞} (hx : 1 ≤ x) : x ^ n ≤ 1 := by
   obtain ⟨m, rfl⟩ := neg_surjective n


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
