### PR TITLE
[Merged by Bors] - fix: include .lake in artifact upload

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -267,7 +267,11 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: mathlib4_artifact
-          path: pr-branch/
+          include-hidden-files: true
+          # we exclude .git since there may be secrets in there
+          path: |
+            pr-branch/
+            !pr-branch/.git/
 
       # The cache secrets are available here, so we must not run any untrusted code.
       - name: upload cache

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -277,7 +277,11 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: mathlib4_artifact
-          path: pr-branch/
+          include-hidden-files: true
+          # we exclude .git since there may be secrets in there
+          path: |
+            pr-branch/
+            !pr-branch/.git/
 
       # The cache secrets are available here, so we must not run any untrusted code.
       - name: upload cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -284,7 +284,11 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: mathlib4_artifact
-          path: pr-branch/
+          include-hidden-files: true
+          # we exclude .git since there may be secrets in there
+          path: |
+            pr-branch/
+            !pr-branch/.git/
 
       # The cache secrets are available here, so we must not run any untrusted code.
       - name: upload cache

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -281,7 +281,11 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: mathlib4_artifact
-          path: pr-branch/
+          include-hidden-files: true
+          # we exclude .git since there may be secrets in there
+          path: |
+            pr-branch/
+            !pr-branch/.git/
 
       # The cache secrets are available here, so we must not run any untrusted code.
       - name: upload cache


### PR DESCRIPTION
Follow-up to #28062. It turns out `.olean` files are stored in `.lake` which are excluded by default by the `actions/upload-artifact` action. We use the `include-hidden-files` option, taking care to exclude the `.git` folder which may include secrets like `GITHUB_TOKEN`, etc.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
