### PR TITLE
[Merged by Bors] - chore(Nat/Factorization/Induction): recursors

### DIFF
--- a/Mathlib/Data/Nat/Factorization/Induction.lean
+++ b/Mathlib/Data/Nat/Factorization/Induction.lean
@@ -86,9 +86,10 @@ lemma _root_.induction_on_primes {motive : ℕ → Prop} (zero : motive 0) (one 
   · rw [pow_succ', mul_assoc]
     exact prime_mul _ _ hp ih
 
-lemma prime_composite_induction {P : ℕ → Prop} (zero : P 0) (one : P 1)
-    (prime : ∀ p : ℕ, p.Prime → P p) (composite : ∀ a, 2 ≤ a → P a → ∀ b, 2 ≤ b → P b → P (a * b))
-    (n : ℕ) : P n := by
+lemma prime_composite_induction {motive : ℕ → Prop} (zero : motive 0) (one : motive 1)
+    (prime : ∀ p : ℕ, p.Prime → motive p)
+    (composite : ∀ a, 2 ≤ a → motive a → ∀ b, 2 ≤ b → motive b → motive (a * b))
+    (n : ℕ) : motive n := by
   refine induction_on_primes zero one ?_ _
   rintro p (_ | _ | a) hp ha
   · simpa

--- a/Mathlib/Data/Nat/Factorization/Induction.lean
+++ b/Mathlib/Data/Nat/Factorization/Induction.lean
@@ -20,19 +20,20 @@ variable {a b m n p : ℕ}
 /-- Given `P 0, P 1` and a way to extend `P a` to `P (p ^ n * a)` for prime `p` not dividing `a`,
 we can define `P` for all natural numbers. -/
 @[elab_as_elim]
-def recOnPrimePow {P : ℕ → Sort*} (h0 : P 0) (h1 : P 1)
-    (h : ∀ a p n : ℕ, p.Prime → ¬p ∣ a → 0 < n → P a → P (p ^ n * a)) : ∀ a : ℕ, P a := fun a =>
+def recOnPrimePow {motive : ℕ → Sort*} (zero : motive 0) (one : motive 1)
+    (prime_pow_mul : ∀ a p n : ℕ, p.Prime → ¬p ∣ a → 0 < n → motive a → motive (p ^ n * a))
+    (a : ℕ) : motive a :=
   Nat.strongRecOn' a fun n =>
     match n with
-    | 0 => fun _ => h0
-    | 1 => fun _ => h1
+    | 0 => fun _ => zero
+    | 1 => fun _ => one
     | k + 2 => fun hk => by
       letI p := (k + 2).minFac
       haveI hp : Prime p := minFac_prime (succ_succ_ne_one k)
       letI t := (k + 2).factorization p
       haveI hpt : p ^ t ∣ k + 2 := ordProj_dvd _ _
       haveI htp : 0 < t := hp.factorization_pos_of_dvd (k + 1).succ_ne_zero (k + 2).minFac_dvd
-      convert h ((k + 2) / p ^ t) p t hp _ htp (hk _ (Nat.div_lt_of_lt_mul _)) using 1
+      convert prime_pow_mul ((k + 2) / p ^ t) p t hp _ htp (hk _ (Nat.div_lt_of_lt_mul _)) using 1
       · rw [Nat.mul_div_cancel' hpt]
       · rw [Nat.dvd_div_iff_mul_dvd hpt, ← Nat.pow_succ]
         exact pow_succ_factorization_not_dvd (k + 1).succ_ne_zero hp
@@ -41,15 +42,18 @@ def recOnPrimePow {P : ℕ → Sort*} (h0 : P 0) (h1 : P 1)
 /-- Given `P 0`, `P 1`, and `P (p ^ n)` for positive prime powers, and a way to extend `P a` and
 `P b` to `P (a * b)` when `a, b` are positive coprime, we can define `P` for all natural numbers. -/
 @[elab_as_elim]
-def recOnPosPrimePosCoprime {P : ℕ → Sort*} (hp : ∀ p n : ℕ, Prime p → 0 < n → P (p ^ n))
-    (h0 : P 0) (h1 : P 1) (h : ∀ a b, 1 < a → 1 < b → Coprime a b → P a → P b → P (a * b)) :
-    ∀ a, P a :=
-  recOnPrimePow h0 h1 <| by
+def recOnPosPrimePosCoprime {motive : ℕ → Sort*}
+    (prime_pow : ∀ p n : ℕ, Prime p → 0 < n → motive (p ^ n))
+    (zero : motive 0) (one : motive 1)
+    (coprime : ∀ a b, 1 < a → 1 < b → Coprime a b → motive a → motive b → motive (a * b)) :
+    ∀ a, motive a :=
+  recOnPrimePow zero one <| by
     intro a p n hp' hpa hn hPa
     by_cases ha1 : a = 1
     · rw [ha1, mul_one]
-      exact hp p n hp' hn
-    refine h (p ^ n) a (hp'.one_lt.trans_le (le_self_pow hn.ne' _)) ?_ ?_ (hp _ _ hp' hn) hPa
+      exact prime_pow p n hp' hn
+    refine coprime (p ^ n) a (hp'.one_lt.trans_le (le_self_pow hn.ne' _)) ?_ ?_
+      (prime_pow _ _ hp' hn) hPa
     · contrapose! hpa
       simp [lt_one_iff.1 (lt_of_le_of_ne hpa ha1)]
     · simpa [hn, Prime.coprime_iff_not_dvd hp']
@@ -57,31 +61,30 @@ def recOnPosPrimePosCoprime {P : ℕ → Sort*} (hp : ∀ p n : ℕ, Prime p →
 /-- Given `P 0`, `P (p ^ n)` for all prime powers, and a way to extend `P a` and `P b` to
 `P (a * b)` when `a, b` are positive coprime, we can define `P` for all natural numbers. -/
 @[elab_as_elim]
-def recOnPrimeCoprime {P : ℕ → Sort*} (h0 : P 0) (hp : ∀ p n : ℕ, Prime p → P (p ^ n))
-    (h : ∀ a b, 1 < a → 1 < b → Coprime a b → P a → P b → P (a * b)) : ∀ a, P a :=
-  recOnPosPrimePosCoprime (fun p n h _ => hp p n h) h0 (hp 2 0 prime_two) h
+def recOnPrimeCoprime {motive : ℕ → Sort*} (zero : motive 0)
+    (prime_pow : ∀ p n : ℕ, Prime p → motive (p ^ n))
+    (coprime : ∀ a b, 1 < a → 1 < b → Coprime a b → motive a → motive b → motive (a * b)) :
+    ∀ a, motive a :=
+  recOnPosPrimePosCoprime (fun p n h _ => prime_pow p n h) zero (prime_pow 2 0 prime_two) coprime
 
 /-- Given `P 0`, `P 1`, `P p` for all primes, and a way to extend `P a` and `P b` to
 `P (a * b)`, we can define `P` for all natural numbers. -/
 @[elab_as_elim]
-def recOnMul {P : ℕ → Sort*} (h0 : P 0) (h1 : P 1) (hp : ∀ p, Prime p → P p)
-    (h : ∀ a b, P a → P b → P (a * b)) : ∀ a, P a :=
-  let rec
-    /-- The predicate holds on prime powers -/
-    hp'' (p n : ℕ) (hp' : Prime p) : P (p ^ n) :=
-    match n with
-    | 0 => h1
-    | n + 1 => h _ _ (hp'' p n hp') (hp p hp')
-  recOnPrimeCoprime h0 hp'' fun a b _ _ _ => h a b
+def recOnMul {motive : ℕ → Sort*} (zero : motive 0) (one : motive 1)
+    (prime : ∀ p, Prime p → motive p)
+    (mul : ∀ a b, motive a → motive b → motive (a * b)) : ∀ a, motive a :=
+  recOnPrimeCoprime zero
+    (fun p n hp' => Nat.rec one (fun _ ih => mul _ _ ih (prime p hp')) n)
+    (fun a b _ _ _ => mul a b)
 
-lemma _root_.induction_on_primes {P : ℕ → Prop} (h₀ : P 0) (h₁ : P 1)
-    (h : ∀ p a : ℕ, p.Prime → P a → P (p * a)) : ∀ n, P n := by
-  refine recOnPrimePow h₀ h₁ ?_
+lemma _root_.induction_on_primes {motive : ℕ → Prop} (zero : motive 0) (one : motive 1)
+    (prime_mul : ∀ p a : ℕ, p.Prime → motive a → motive (p * a)) : ∀ n, motive n := by
+  refine recOnPrimePow zero one ?_
   rintro a p n hp - - ha
   induction' n with n ih
   · simpa using ha
   · rw [pow_succ', mul_assoc]
-    exact h _ _ hp ih
+    exact prime_mul _ _ hp ih
 
 lemma prime_composite_induction {P : ℕ → Prop} (zero : P 0) (one : P 1)
     (prime : ∀ p : ℕ, p.Prime → P p) (composite : ∀ a, 2 ≤ a → P a → ∀ b, 2 ≤ b → P b → P (a * b))

--- a/Mathlib/FieldTheory/KummerExtension.lean
+++ b/Mathlib/FieldTheory/KummerExtension.lean
@@ -101,9 +101,9 @@ theorem X_pow_sub_C_irreducible_of_odd
     {n : ℕ} (hn : Odd n) {a : K} (ha : ∀ p : ℕ, p.Prime → p ∣ n → ∀ b : K, b ^ p ≠ a) :
     Irreducible (X ^ n - C a) := by
   induction n using induction_on_primes generalizing K a with
-  | h₀ => simp [← Nat.not_even_iff_odd] at hn
-  | h₁ => simpa using irreducible_X_sub_C a
-  | h p n hp IH =>
+  | zero => simp [← Nat.not_even_iff_odd] at hn
+  | one => simpa using irreducible_X_sub_C a
+  | prime_mul p n hp IH =>
     rw [mul_comm]
     apply X_pow_mul_sub_C_irreducible
       (X_pow_sub_C_irreducible_of_prime hp (ha p hp (dvd_mul_right _ _)))

--- a/Mathlib/NumberTheory/SumFourSquares.lean
+++ b/Mathlib/NumberTheory/SumFourSquares.lean
@@ -196,10 +196,10 @@ theorem sum_four_squares (n : ℕ) : ∃ a b c d : ℕ, a ^ 2 + b ^ 2 + c ^ 2 + 
   -- The proof is by induction on prime factorization. The case of prime `n` was proved above,
   -- the inductive step follows from `Nat.euler_four_squares`.
   induction n using Nat.recOnMul with
-  | h0 => exact ⟨0, 0, 0, 0, rfl⟩
-  | h1 => exact ⟨1, 0, 0, 0, rfl⟩
-  | hp p hp => exact hp.sum_four_squares
-  | h m n hm hn =>
+  | zero => exact ⟨0, 0, 0, 0, rfl⟩
+  | one => exact ⟨1, 0, 0, 0, rfl⟩
+  | prime p hp => exact hp.sum_four_squares
+  | mul m n hm hn =>
     rcases hm with ⟨a, b, c, d, rfl⟩
     rcases hn with ⟨w, x, y, z, rfl⟩
     exact ⟨_, _, _, _, euler_four_squares _ _ _ _ _ _ _ _⟩

--- a/Mathlib/NumberTheory/SumTwoSquares.lean
+++ b/Mathlib/NumberTheory/SumTwoSquares.lean
@@ -101,9 +101,9 @@ theorem ZMod.isSquare_neg_one_iff {n : ℕ} (hn : Squarefree n) :
     IsSquare (-1 : ZMod n) ↔ ∀ {q : ℕ}, q.Prime → q ∣ n → q % 4 ≠ 3 := by
   refine ⟨fun H q hqp hqd => hqp.mod_four_ne_three_of_dvd_isSquare_neg_one hqd H, fun H => ?_⟩
   induction n using induction_on_primes with
-  | h₀ => exact False.elim (hn.ne_zero rfl)
-  | h₁ => exact ⟨0, by simp only [mul_zero, eq_iff_true_of_subsingleton]⟩
-  | h p n hpp ih =>
+  | zero => exact False.elim (hn.ne_zero rfl)
+  | one => exact ⟨0, by simp only [mul_zero, eq_iff_true_of_subsingleton]⟩
+  | prime_mul p n hpp ih =>
     haveI : Fact p.Prime := ⟨hpp⟩
     have hcp : p.Coprime n := by
       by_contra hc
@@ -138,9 +138,9 @@ theorem ZMod.isSquare_neg_one_iff' {n : ℕ} (hn : Squarefree n) :
 theorem Nat.eq_sq_add_sq_of_isSquare_mod_neg_one {n : ℕ} (h : IsSquare (-1 : ZMod n)) :
     ∃ x y : ℕ, n = x ^ 2 + y ^ 2 := by
   induction n using induction_on_primes with
-  | h₀ => exact ⟨0, 0, rfl⟩
-  | h₁ => exact ⟨0, 1, rfl⟩
-  | h p n hpp ih =>
+  | zero => exact ⟨0, 0, rfl⟩
+  | one => exact ⟨0, 1, rfl⟩
+  | prime_mul p n hpp ih =>
     haveI : Fact p.Prime := ⟨hpp⟩
     have hp : IsSquare (-1 : ZMod p) := ZMod.isSquare_neg_one_of_dvd ⟨n, rfl⟩ h
     obtain ⟨u, v, huv⟩ := Nat.Prime.sq_add_sq (ZMod.exists_sq_eq_neg_one_iff.mp hp)


### PR DESCRIPTION
Name the motive `motive` and name the minor premises according to their constructors. Also clean up `Nat.recOnMul.hp''`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
