### PR TITLE
[Merged by Bors] - feat(Data/Matrix/Vec): `star x.vec = (x.map star).vec`

### DIFF
--- a/Mathlib/Data/Matrix/ConjTranspose.lean
+++ b/Mathlib/Data/Matrix/ConjTranspose.lean
@@ -128,6 +128,14 @@ theorem conjTranspose_apply [Star α] (M : Matrix m n α) (i j) :
 theorem conjTranspose_conjTranspose [InvolutiveStar α] (M : Matrix m n α) : Mᴴᴴ = M :=
   Matrix.ext <| by simp
 
+theorem conjTranspose_transpose [Star α] (M : Matrix m n α) :
+    Mᴴᵀ = M.map star :=
+  rfl
+
+theorem transpose_conjTranspose [Star α] (M : Matrix m n α) :
+    Mᵀᴴ = M.map star :=
+  rfl
+
 theorem conjTranspose_injective [InvolutiveStar α] :
     Function.Injective (conjTranspose : Matrix m n α → Matrix n m α) :=
   (map_injective star_injective).comp transpose_injective

--- a/Mathlib/Data/Matrix/Vec.lean
+++ b/Mathlib/Data/Matrix/Vec.lean
@@ -76,17 +76,20 @@ theorem vec_sum [AddCommMonoid R] (s : Finset ι) (A : ι → Matrix m n R) :
   ext
   simp_rw [vec, Finset.sum_apply, vec, Matrix.sum_apply]
 
-theorem vec_dotProduct_vec [NonUnitalNonAssocSemiring R] [Fintype m] [Fintype n]
+theorem vec_dotProduct_vec [AddCommMonoid R] [Mul R] [Fintype m] [Fintype n]
     (A B : Matrix m n R) :
     vec A ⬝ᵥ vec B = (Aᵀ * B).trace := by
   simp_rw [Matrix.trace, Matrix.diag, Matrix.mul_apply, dotProduct, vec, transpose_apply,
     ← Finset.univ_product_univ, Finset.sum_product]
 
-theorem star_vec_dotProduct_vec [NonUnitalNonAssocSemiring R] [StarRing R] [Fintype m] [Fintype n]
+theorem star_vec [Star R] (x : Matrix m n R) :
+    star x.vec = (xᴴᵀ).vec :=
+  rfl
+
+theorem star_vec_dotProduct_vec [AddCommMonoid R] [Mul R] [Star R] [Fintype m] [Fintype n]
     (A B : Matrix m n R) :
     star (vec A) ⬝ᵥ vec B = (Aᴴ * B).trace := by
-  simp_rw [Matrix.trace, Matrix.diag, Matrix.mul_apply, dotProduct, vec, conjTranspose_apply,
-    ← Finset.univ_product_univ, Finset.sum_product, Pi.star_apply, vec]
+  simp_rw [star_vec, vec_dotProduct_vec, transpose_transpose]
 
 theorem vec_hadamard [Mul R] (A B : Matrix m n R) : vec (A ⊙ B) = vec A * vec B := rfl
 

--- a/Mathlib/Data/Matrix/Vec.lean
+++ b/Mathlib/Data/Matrix/Vec.lean
@@ -83,13 +83,13 @@ theorem vec_dotProduct_vec [AddCommMonoid R] [Mul R] [Fintype m] [Fintype n]
     ← Finset.univ_product_univ, Finset.sum_product]
 
 theorem star_vec [Star R] (x : Matrix m n R) :
-    star x.vec = (xᴴᵀ).vec :=
+    star x.vec = (x.map star).vec :=
   rfl
 
 theorem star_vec_dotProduct_vec [AddCommMonoid R] [Mul R] [Star R] [Fintype m] [Fintype n]
     (A B : Matrix m n R) :
     star (vec A) ⬝ᵥ vec B = (Aᴴ * B).trace := by
-  simp_rw [star_vec, vec_dotProduct_vec, transpose_transpose]
+  simp_rw [star_vec, vec_dotProduct_vec, ← conjTranspose_transpose, transpose_transpose]
 
 theorem vec_hadamard [Mul R] (A B : Matrix m n R) : vec (A ⊙ B) = vec A * vec B := rfl
 


### PR DESCRIPTION
This adds `star x.vec = (x.map star).vec` and `xᴴᵀ = x.map star = xᵀᴴ`.

This also generalizes:
- `Matrix.vec_dotProduct_vec`: from `NonUnitalNonAssocSemiring` to `AddCommMonoid` and `Mul` as we only need matrix multiplication to be defined for this.
- `Matrix.star_vec_dotProduct_vec`: from `NonUnitalNonAssocSemiring` and `StarRing` to `AddCommMonoid`, `Mul`, and `Star`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
