### PR TITLE
[Merged by Bors] - feat: nontriviality of `SeparationQuotient` iff the topology is nontrivial

### DIFF
--- a/Mathlib/Topology/Inseparable.lean
+++ b/Mathlib/Topology/Inseparable.lean
@@ -556,6 +556,12 @@ theorem continuous_mk : Continuous (mk : X → SeparationQuotient X) :=
 theorem mk_eq_mk : mk x = mk y ↔ (x ~ᵢ y) :=
   Quotient.eq''
 
+protected theorem «forall» {P : SeparationQuotient X → Prop} : (∀ x, P x) ↔ ∀ x, P (.mk x) :=
+  Quotient.forall
+
+protected theorem «exists» {P : SeparationQuotient X → Prop} : (∃ x, P x) ↔ ∃ x, P (.mk x) :=
+  Quotient.exists
+
 theorem surjective_mk : Surjective (mk : X → SeparationQuotient X) :=
   Quot.mk_surjective
 
@@ -571,6 +577,14 @@ instance [Inhabited X] : Inhabited (SeparationQuotient X) :=
 
 instance [Subsingleton X] : Subsingleton (SeparationQuotient X) :=
   surjective_mk.subsingleton
+
+theorem subsingleton_separationQuotient_iff {t : TopologicalSpace α} :
+    Subsingleton (SeparationQuotient α) ↔ t = ⊤ := by
+  simp_rw [subsingleton_iff, ← forall_inseparable_iff, SeparationQuotient.forall, mk_eq_mk]
+
+theorem nontrivial_separationQuotient_iff {t : TopologicalSpace α} :
+    Nontrivial (SeparationQuotient α) ↔ t ≠ ⊤ := by
+  simpa only [not_subsingleton_iff_nontrivial] using subsingleton_separationQuotient_iff.not
 
 @[to_additive] instance [One X] : One (SeparationQuotient X) := ⟨mk 1⟩
 

--- a/Mathlib/Topology/Inseparable.lean
+++ b/Mathlib/Topology/Inseparable.lean
@@ -578,10 +578,14 @@ instance [Inhabited X] : Inhabited (SeparationQuotient X) :=
 instance [Subsingleton X] : Subsingleton (SeparationQuotient X) :=
   surjective_mk.subsingleton
 
+@[simp]
+theorem inseparableSetoid_eq_top_iff {t : TopologicalSpace α} :
+    inseparableSetoid α = ⊤ ↔ t = ⊤ :=
+  Setoid.eq_top_iff.trans TopologicalSpace.eq_top_iff_forall_inseparable.symm
+
 theorem subsingleton_iff {t : TopologicalSpace α} :
-    Subsingleton (SeparationQuotient α) ↔ t = ⊤ := by
-  simp_rw [_root_.subsingleton_iff, TopologicalSpace.eq_top_iff_forall_inseparable,
-    SeparationQuotient.forall, mk_eq_mk]
+    Subsingleton (SeparationQuotient α) ↔ t = ⊤ :=
+  Quotient.subsingleton_iff.trans inseparableSetoid_eq_top_iff
 
 theorem nontrivial_iff {t : TopologicalSpace α} :
     Nontrivial (SeparationQuotient α) ↔ t ≠ ⊤ := by

--- a/Mathlib/Topology/Inseparable.lean
+++ b/Mathlib/Topology/Inseparable.lean
@@ -580,7 +580,8 @@ instance [Subsingleton X] : Subsingleton (SeparationQuotient X) :=
 
 theorem subsingleton_iff {t : TopologicalSpace α} :
     Subsingleton (SeparationQuotient α) ↔ t = ⊤ := by
-  simp_rw [subsingleton_iff, ← forall_inseparable_iff, SeparationQuotient.forall, mk_eq_mk]
+  simp_rw [_root_.subsingleton_iff, TopologicalSpace.eq_top_iff_forall_inseparable,
+    SeparationQuotient.forall, mk_eq_mk]
 
 theorem nontrivial_iff {t : TopologicalSpace α} :
     Nontrivial (SeparationQuotient α) ↔ t ≠ ⊤ := by

--- a/Mathlib/Topology/Inseparable.lean
+++ b/Mathlib/Topology/Inseparable.lean
@@ -578,13 +578,13 @@ instance [Inhabited X] : Inhabited (SeparationQuotient X) :=
 instance [Subsingleton X] : Subsingleton (SeparationQuotient X) :=
   surjective_mk.subsingleton
 
-theorem subsingleton_separationQuotient_iff {t : TopologicalSpace α} :
+theorem subsingleton_iff {t : TopologicalSpace α} :
     Subsingleton (SeparationQuotient α) ↔ t = ⊤ := by
   simp_rw [subsingleton_iff, ← forall_inseparable_iff, SeparationQuotient.forall, mk_eq_mk]
 
-theorem nontrivial_separationQuotient_iff {t : TopologicalSpace α} :
+theorem nontrivial_iff {t : TopologicalSpace α} :
     Nontrivial (SeparationQuotient α) ↔ t ≠ ⊤ := by
-  simpa only [not_subsingleton_iff_nontrivial] using subsingleton_separationQuotient_iff.not
+  simpa only [not_subsingleton_iff_nontrivial] using subsingleton_iff.not
 
 @[to_additive] instance [One X] : One (SeparationQuotient X) := ⟨mk 1⟩
 

--- a/Mathlib/Topology/Order.lean
+++ b/Mathlib/Topology/Order.lean
@@ -622,13 +622,14 @@ The corresponding `bot` lemma is handled more generally by `inseparable_iff_eq`.
 @[simp]
 theorem inseparable_top (x y : α) : @Inseparable α ⊤ x y := nhds_top.trans nhds_top.symm
 
-theorem forall_inseparable_iff {t : TopologicalSpace α} : (∀ x y : α, Inseparable x y) ↔ t = ⊤ where
-  mp h := ext_nhds fun x => nhds_top ▸ top_unique fun _ hs a => mem_of_mem_nhds <| h x a ▸ hs
-  mpr h := h ▸ inseparable_top
+theorem TopologicalSpace.eq_top_iff_forall_inseparable {t : TopologicalSpace α} :
+    t = ⊤ ↔ (∀ x y : α, Inseparable x y) where
+  mp h := h ▸ inseparable_top
+  mpr h := ext_nhds fun x => nhds_top ▸ top_unique fun _ hs a => mem_of_mem_nhds <| h x a ▸ hs
 
-theorem exists_not_inseparable_iff {t : TopologicalSpace α} :
-    (∃ x y : α, ¬Inseparable x y) ↔ t ≠ ⊤ := by
-  simpa using forall_inseparable_iff.not
+theorem TopologicalSpace.ne_top_iff_exists_not_inseparable {t : TopologicalSpace α} :
+    t ≠ ⊤ ↔ ∃ x y : α, ¬Inseparable x y := by
+  simpa using eq_top_iff_forall_inseparable.not
 
 open TopologicalSpace
 

--- a/Mathlib/Topology/Order.lean
+++ b/Mathlib/Topology/Order.lean
@@ -616,6 +616,20 @@ theorem isOpen_sup {t₁ t₂ : TopologicalSpace α} {s : Set α} :
     IsOpen[t₁ ⊔ t₂] s ↔ IsOpen[t₁] s ∧ IsOpen[t₂] s :=
   Iff.rfl
 
+/-- In the trivial topology no points are separable.
+
+The corresponding `bot` lemma is handled more generally by `inseparable_iff_eq`. -/
+@[simp]
+theorem inseparable_top (x y : α) : @Inseparable α ⊤ x y := nhds_top.trans nhds_top.symm
+
+theorem forall_inseparable_iff {t : TopologicalSpace α} : (∀ x y : α, Inseparable x y) ↔ t = ⊤ := by
+  refine ⟨fun h => ext_nhds fun x => nhds_top ▸ ?_, fun h => h ▸ inseparable_top⟩
+  exact top_unique fun s hs a =>  mem_of_mem_nhds (h x a ▸ hs)
+
+theorem exists_not_inseparable_iff {t : TopologicalSpace α} :
+    (∃ x y : α, ¬Inseparable x y) ↔ t ≠ ⊤ := by
+  simpa using forall_inseparable_iff.not
+
 open TopologicalSpace
 
 variable {γ : Type*} {f : α → β} {ι : Sort*}

--- a/Mathlib/Topology/Order.lean
+++ b/Mathlib/Topology/Order.lean
@@ -622,9 +622,9 @@ The corresponding `bot` lemma is handled more generally by `inseparable_iff_eq`.
 @[simp]
 theorem inseparable_top (x y : α) : @Inseparable α ⊤ x y := nhds_top.trans nhds_top.symm
 
-theorem forall_inseparable_iff {t : TopologicalSpace α} : (∀ x y : α, Inseparable x y) ↔ t = ⊤ := by
-  refine ⟨fun h => ext_nhds fun x => nhds_top ▸ ?_, fun h => h ▸ inseparable_top⟩
-  exact top_unique fun s hs a =>  mem_of_mem_nhds (h x a ▸ hs)
+theorem forall_inseparable_iff {t : TopologicalSpace α} : (∀ x y : α, Inseparable x y) ↔ t = ⊤ where
+  mp h := ext_nhds fun x => nhds_top ▸ top_unique fun _ hs a => mem_of_mem_nhds <| h x a ▸ hs
+  mpr h := h ▸ inseparable_top
 
 theorem exists_not_inseparable_iff {t : TopologicalSpace α} :
     (∃ x y : α, ¬Inseparable x y) ↔ t ≠ ⊤ := by


### PR DESCRIPTION
This contains the mathematical content of [#Is there code for X? > Typeclass for nontrivial topology @ 💬](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/Typeclass.20for.20nontrivial.20topology/near/533192558), without yet committing to any designated API to make it easier to use.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
