### PR TITLE
[Merged by Bors] - feat(Tactic/ToAdditive): make `to_additive` translate binder names

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6121,6 +6121,7 @@ import Mathlib.Tactic.TautoSet
 import Mathlib.Tactic.TermCongr
 import Mathlib.Tactic.ToAdditive
 import Mathlib.Tactic.ToAdditive.Frontend
+import Mathlib.Tactic.ToAdditive.GuessName
 import Mathlib.Tactic.ToExpr
 import Mathlib.Tactic.ToLevel
 import Mathlib.Tactic.Trace

--- a/Mathlib/Algebra/Module/Submodule/Lattice.lean
+++ b/Mathlib/Algebra/Module/Submodule/Lattice.lean
@@ -298,8 +298,8 @@ theorem toAddSubmonoid_sSup (s : Set (Submodule R M)) :
           apply le_sSup
           rw [Subtype.range_coe_subtype]
           exact ⟨p, hp, rfl⟩
-        | one => simpa only [smul_zero] using zero_mem _
-        | mul _ _ _ _ mx my => revert mx my; simp_rw [smul_add]; exact add_mem }
+        | zero => simpa only [smul_zero] using zero_mem _
+        | add _ _ _ _ mx my => revert mx my; simp_rw [smul_add]; exact add_mem }
   refine le_antisymm (?_ : sSup s ≤ p) ?_
   · exact sSup_le fun q hq ↦ le_sSup <| Set.mem_image_of_mem toAddSubmonoid hq
   · exact sSup_le fun _ ⟨q, hq, hq'⟩ ↦ hq'.symm ▸ le_sSup hq

--- a/Mathlib/Algebra/Order/Ring/Star.lean
+++ b/Mathlib/Algebra/Order/Ring/Star.lean
@@ -41,8 +41,8 @@ private lemma mul_le_mul_of_nonneg_left {R : Type*} [NonUnitalCommSemiring R] [P
     obtain ⟨x, rfl⟩ := h
     simp_rw [mul_assoc, mul_comm x, ← mul_assoc]
     exact conjugate_le_conjugate hab x
-  | one => simp
-  | mul x hx y hy =>
+  | zero => simp
+  | add x hx y hy =>
     simp only [← nonneg_iff, add_mul] at hx hy ⊢
     apply add_le_add <;> simp_all
 

--- a/Mathlib/Algebra/Ring/Submonoid/Basic.lean
+++ b/Mathlib/Algebra/Ring/Submonoid/Basic.lean
@@ -21,8 +21,8 @@ lemma mul_right_mem_add_closure (ha : a ∈ closure (S : Set R)) (hb : b ∈ S) 
     a * b ∈ closure (S : Set R) := by
   induction ha using closure_induction with
   | mem r hr => exact AddSubmonoid.mem_closure.mpr fun y hy => hy (mul_mem hr hb)
-  | one => simp only [zero_mul, zero_mem _]
-  | mul r s _ _ hr hs => simpa only [add_mul] using add_mem hr hs
+  | zero => simp only [zero_mul, zero_mem _]
+  | add r s _ _ hr hs => simpa only [add_mul] using add_mem hr hs
 
 /-- The product of two elements of the additive closure of a submonoid `M` is an element of the
 additive closure of `M`. -/
@@ -30,8 +30,8 @@ lemma mul_mem_add_closure (ha : a ∈ closure (S : Set R))
     (hb : b ∈ closure (S : Set R)) : a * b ∈ closure (S : Set R) := by
   induction hb using closure_induction with
   | mem r hr => exact MulMemClass.mul_right_mem_add_closure ha hr
-  | one => simp only [mul_zero, zero_mem _]
-  | mul r s _ _ hr hs => simpa only [mul_add] using add_mem hr hs
+  | zero => simp only [mul_zero, zero_mem _]
+  | add r s _ _ hr hs => simpa only [mul_add] using add_mem hr hs
 
 /-- The product of an element of `S` and an element of the additive closure of a multiplicative
 submonoid `S` is contained in the additive closure of `S`. -/

--- a/Mathlib/Algebra/Ring/Subring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Subring/Basic.lean
@@ -554,12 +554,12 @@ theorem mem_closure_iff {s : Set R} {x} :
       clear _hx _hy
       induction hx, hy using AddSubgroup.closure_induction₂ with
       | mem _ _ hx hy => exact AddSubgroup.subset_closure (mul_mem hx hy)
-      | one_left => simp
-      | one_right => simp
-      | mul_left _ _ _ _ _ _ h₁ h₂ => simpa [add_mul] using add_mem h₁ h₂
-      | mul_right _ _ _ _ _ _ h₁ h₂ => simpa [mul_add] using add_mem h₁ h₂
-      | inv_left _ _ _ _ h => simpa [neg_mul] using neg_mem h
-      | inv_right _ _ _ _ h => simpa [mul_neg] using neg_mem h,
+      | zero_left => simp
+      | zero_right => simp
+      | add_left _ _ _ _ _ _ h₁ h₂ => simpa [add_mul] using add_mem h₁ h₂
+      | add_right _ _ _ _ _ _ h₁ h₂ => simpa [mul_add] using add_mem h₁ h₂
+      | neg_left _ _ _ _ h => simpa [neg_mul] using neg_mem h
+      | neg_right _ _ _ _ h => simpa [mul_neg] using neg_mem h,
     fun h => by
       induction h using AddSubgroup.closure_induction with
       | mem x hx =>
@@ -567,9 +567,9 @@ theorem mem_closure_iff {s : Set R} {x} :
         | mem _ h => exact subset_closure h
         | one => exact one_mem _
         | mul _ _ _ _ h₁ h₂ => exact mul_mem h₁ h₂
-      | one => exact zero_mem _
-      | mul _ _ _ _ h₁ h₂ => exact add_mem h₁ h₂
-      | inv _ _ h => exact neg_mem h⟩
+      | zero => exact zero_mem _
+      | add _ _ _ _ h₁ h₂ => exact add_mem h₁ h₂
+      | neg _ _ h => exact neg_mem h⟩
 
 lemma closure_le_centralizer_centralizer (s : Set R) :
     closure s ≤ centralizer (centralizer s) :=
@@ -590,12 +590,12 @@ theorem exists_list_of_mem_closure {s : Set R} {x : R} (hx : x ∈ closure s) :
   | mem _ hx =>
     obtain ⟨l, hl, h⟩ := Submonoid.exists_list_of_mem_closure hx
     exact ⟨[l], by simp [h]; clear_aux_decl; tauto⟩
-  | one => exact ⟨[], List.forall_mem_nil _, rfl⟩
-  | mul _ _ _ _ hL hM =>
+  | zero => exact ⟨[], List.forall_mem_nil _, rfl⟩
+  | add _ _ _ _ hL hM =>
     obtain ⟨⟨L, HL1, HL2⟩, ⟨M, HM1, HM2⟩⟩ := And.intro hL hM
     exact ⟨L ++ M, List.forall_mem_append.2 ⟨HL1, HM1⟩, by
       rw [List.map_append, List.sum_append, HL2, HM2]⟩
-  | inv _ _ hL =>
+  | neg _ _ hL =>
     obtain ⟨L, hL⟩ := hL
     exact ⟨L.map (List.cons (-1)),
       List.forall_mem_map.2 fun j hj => List.forall_mem_cons.2 ⟨Or.inr rfl, hL.1 j hj⟩,

--- a/Mathlib/Algebra/Ring/Subsemiring/Basic.lean
+++ b/Mathlib/Algebra/Ring/Subsemiring/Basic.lean
@@ -522,8 +522,8 @@ theorem mem_closure_iff_exists_list {R} [Semiring R] {s : Set R} {x} :
       | mul x y _ _ ht hu =>
         obtain ⟨⟨t, ht1, ht2⟩, ⟨u, hu1, hu2⟩⟩ := And.intro ht hu
         exact ⟨t ++ u, List.forall_mem_append.2 ⟨ht1, hu1⟩, by rw [List.prod_append, ht2, hu2]⟩
-    | one => exact ⟨[], List.forall_mem_nil _, rfl⟩
-    | mul x y _ _ hL hM =>
+    | zero => exact ⟨[], List.forall_mem_nil _, rfl⟩
+    | add x y _ _ hL hM =>
       obtain ⟨⟨L, HL1, HL2⟩, ⟨M, HM1, HM2⟩⟩ := And.intro hL hM
       exact ⟨L ++ M, List.forall_mem_append.2 ⟨HL1, HM1⟩, by
         rw [List.map_append, List.sum_append, HL2, HM2]⟩

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Basic.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Basic.lean
@@ -305,10 +305,10 @@ instance CStarAlgebra.instNonnegSpectrumClass : NonnegSpectrumClass ℝ A :=
     | mem x hx =>
       obtain ⟨b, rfl⟩ := hx
       exact spectrum_star_mul_self_nonneg
-    | one =>
+    | zero =>
       nontriviality A
       simp
-    | mul x y x_mem y_mem hx hy =>
+    | add x y x_mem y_mem hx hy =>
       rw [← SpectrumRestricts.nnreal_iff] at hx hy ⊢
       rw [← StarOrderedRing.nonneg_iff] at x_mem y_mem
       exact hx.nnreal_add (.of_nonneg x_mem) (.of_nonneg y_mem) hy
@@ -373,11 +373,11 @@ lemma CStarAlgebra.spectralOrderedRing : @StarOrderedRing A _ (CStarAlgebra.spec
           rw [quasispectrumRestricts_iff_spectrumRestricts_inr' ℂ,
             SpectrumRestricts.nnreal_iff, Unitization.inr_mul, Unitization.inr_star]
           exact spectrum_star_mul_self_nonneg
-        | one =>
+        | zero =>
           rw [quasispectrumRestricts_iff_spectrumRestricts_inr' ℂ, SpectrumRestricts.nnreal_iff]
           nontriviality A
           simp
-        | mul x y _ _ hx hy =>
+        | add x y _ _ hx hy =>
           simp +singlePass only [← Unitization.isSelfAdjoint_inr (R := ℂ),
             quasispectrumRestricts_iff_spectrumRestricts_inr' ℂ] at hx hy ⊢
           rw [Unitization.inr_add]

--- a/Mathlib/Analysis/InnerProductSpace/StarOrder.lean
+++ b/Mathlib/Analysis/InnerProductSpace/StarOrder.lean
@@ -68,8 +68,8 @@ lemma instStarOrderedRingRCLike
       | mem _ hf =>
         obtain ⟨f, rfl⟩ := hf
         simpa using ContinuousLinearMap.IsPositive.adjoint_conj isPositive_one f
-      | one => exact isPositive_zero
-      | mul f g _ _ hf hg => exact hf.add hg
+      | zero => exact isPositive_zero
+      | add f g _ _ hf hg => exact hf.add hg
 
 instance instStarOrderedRing {H : Type*} [NormedAddCommGroup H]
     [InnerProductSpace ℂ H] [CompleteSpace H] : StarOrderedRing (H →L[ℂ] H) :=

--- a/Mathlib/Lean/Expr/Basic.lean
+++ b/Mathlib/Lean/Expr/Basic.lean
@@ -363,6 +363,11 @@ def getBinderName (e : Expr) : MetaM (Option Name) := do
   | .forallE (binderName := n) .. | .lam (binderName := n) .. => pure (some n)
   | _ => pure none
 
+/-- Map binder names in a nested forall `(a₁ : α₁) → ... → (aₙ : αₙ) → _` -/
+def mapForallBinderNames : Expr → (Name → Name) → Expr
+  | .forallE n d b bi, f => .forallE (f n) d (mapForallBinderNames b f) bi
+  | e, _ => e
+
 open Lean.Elab.Term
 /-- Annotates a `binderIdent` with the binder information from an `fvar`. -/
 def addLocalVarInfoForBinderIdent (fvar : Expr) (tk : TSyntax ``binderIdent) : MetaM Unit :=

--- a/Mathlib/LinearAlgebra/Span/Defs.lean
+++ b/Mathlib/LinearAlgebra/Span/Defs.lean
@@ -170,8 +170,8 @@ theorem span_eq_closure {s : Set M} : (span R s).toAddSubmonoid = closure (@univ
       | mem _ h =>
         obtain ⟨r₂, -, x, hx, rfl⟩ := h
         exact subset_closure ⟨r₁ * r₂, trivial, x, hx, mul_smul ..⟩
-      | one => simp only [smul_zero, zero_mem]
-      | mul _ _ _ _ h₁ h₂ => simpa only [smul_add] using add_mem h₁ h₂
+      | zero => simp only [smul_zero, zero_mem]
+      | add _ _ _ _ h₁ h₂ => simpa only [smul_add] using add_mem h₁ h₂
   case of_mem_closure =>
     refine closure_le.2 ?_ hx
     rintro - ⟨r, -, x, hx, rfl⟩

--- a/Mathlib/RingTheory/NonUnitalSubring/Basic.lean
+++ b/Mathlib/RingTheory/NonUnitalSubring/Basic.lean
@@ -471,20 +471,20 @@ theorem mem_closure_iff {s : Set R} {x} :
       clear _hx _hy
       induction hx, hy using AddSubgroup.closure_induction₂ with
       | mem _ _ hx hy => exact AddSubgroup.subset_closure (mul_mem hx hy)
-      | one_left => simp
-      | one_right => simp
-      | mul_left _ _ _ _ _ _ h₁ h₂ => simpa [add_mul] using add_mem h₁ h₂
-      | mul_right _ _ _ _ _ _ h₁ h₂ => simpa [mul_add] using add_mem h₁ h₂
-      | inv_left _ _ _ _ h => simpa [neg_mul] using neg_mem h
-      | inv_right _ _ _ _ h => simpa [mul_neg] using neg_mem h,
+      | zero_left => simp
+      | zero_right => simp
+      | add_left _ _ _ _ _ _ h₁ h₂ => simpa [add_mul] using add_mem h₁ h₂
+      | add_right _ _ _ _ _ _ h₁ h₂ => simpa [mul_add] using add_mem h₁ h₂
+      | neg_left _ _ _ _ h => simpa [neg_mul] using neg_mem h
+      | neg_right _ _ _ _ h => simpa [mul_neg] using neg_mem h,
   fun h => by
     induction h using AddSubgroup.closure_induction with
     | mem _ hx => induction hx using Subsemigroup.closure_induction with
       | mem _ h => exact subset_closure h
       | mul _ _ _ _ h₁ h₂ => exact mul_mem h₁ h₂
-    | one => exact zero_mem _
-    | mul _ _ _ _ h₁ h₂ => exact add_mem h₁ h₂
-    | inv _ _ h => exact neg_mem h⟩
+    | zero => exact zero_mem _
+    | add _ _ _ _ h₁ h₂ => exact add_mem h₁ h₂
+    | neg _ _ h => exact neg_mem h⟩
 
 /-- If all elements of `s : Set A` commute pairwise, then `closure s` is a commutative ring. -/
 def closureNonUnitalCommRingOfComm {R : Type u} [NonUnitalRing R] {s : Set R}

--- a/Mathlib/RingTheory/TwoSidedIdeal/Operations.lean
+++ b/Mathlib/RingTheory/TwoSidedIdeal/Operations.lean
@@ -196,9 +196,9 @@ lemma mem_span_iff_mem_addSubgroup_closure_absorbing {s : Set R}
     simp only [I, SetLike.mem_coe, mem_mk'] at hz
     induction hz using closure_induction with
     | mem x hx => exact hJ hx
-    | one => exact zero_mem _
-    | mul x y _ _ hx hy => exact J.add_mem hx hy
-    | inv x _ hx => exact J.neg_mem hx
+    | zero => exact zero_mem _
+    | add x y _ _ hx hy => exact J.add_mem hx hy
+    | neg x _ hx => exact J.neg_mem hx
 
 open Pointwise Set
 

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -273,6 +273,7 @@ import Mathlib.Tactic.TautoSet
 import Mathlib.Tactic.TermCongr
 import Mathlib.Tactic.ToAdditive
 import Mathlib.Tactic.ToAdditive.Frontend
+import Mathlib.Tactic.ToAdditive.GuessName
 import Mathlib.Tactic.ToExpr
 import Mathlib.Tactic.ToLevel
 import Mathlib.Tactic.Trace

--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -366,6 +366,199 @@ partial def _root_.String.splitCase (s : String) (i₀ : Pos := 0) (r : List Str
       return splitCase (s.extract i₁ s.endPos) 0 <| (s.extract 0 i₁)::r
   return splitCase s i₁ r
 
+/-- Helper for `capitalizeLike`. -/
+partial def capitalizeLikeAux (s : String) (i : String.Pos := 0) (p : String) : String :=
+  if p.atEnd i || s.atEnd i then
+    p
+  else
+    let j := p.next i
+    if (s.get i).isLower then
+      capitalizeLikeAux s j <| p.set i (p.get i |>.toLower)
+    else if (s.get i).isUpper then
+      capitalizeLikeAux s j <| p.set i (p.get i |>.toUpper)
+    else
+      capitalizeLikeAux s j p
+
+/-- Capitalizes `s` char-by-char like `r`. If `s` is longer, it leaves the tail untouched. -/
+def capitalizeLike (r : String) (s : String) :=
+  capitalizeLikeAux r 0 s
+
+/-- Capitalize First element of a list like `s`.
+Note that we need to capitalize multiple characters in some cases,
+in examples like `HMul` or `hAdd`. -/
+def capitalizeFirstLike (s : String) : List String → List String
+  | x :: r => capitalizeLike s x :: r
+  | [] => []
+
+/--
+Dictionary used by `guessName` to autogenerate names.
+
+Note: `guessName` capitalizes first element of the output according to
+capitalization of the input. Input and first element should therefore be lower-case,
+2nd element should be capitalized properly.
+-/
+def nameDict : String → List String
+  | "one"           => ["zero"]
+  | "mul"           => ["add"]
+  | "smul"          => ["vadd"]
+  | "inv"           => ["neg"]
+  | "div"           => ["sub"]
+  | "prod"          => ["sum"]
+  | "hmul"          => ["hadd"]
+  | "hsmul"         => ["hvadd"]
+  | "hdiv"          => ["hsub"]
+  | "hpow"          => ["hsmul"]
+  | "finprod"       => ["finsum"]
+  | "tprod"         => ["tsum"]
+  | "pow"           => ["nsmul"]
+  | "npow"          => ["nsmul"]
+  | "zpow"          => ["zsmul"]
+  | "mabs"          => ["abs"]
+  | "monoid"        => ["add", "Monoid"]
+  | "submonoid"     => ["add", "Submonoid"]
+  | "group"         => ["add", "Group"]
+  | "subgroup"      => ["add", "Subgroup"]
+  | "semigroup"     => ["add", "Semigroup"]
+  | "magma"         => ["add", "Magma"]
+  | "haar"          => ["add", "Haar"]
+  | "prehaar"       => ["add", "Prehaar"]
+  | "unit"          => ["add", "Unit"]
+  | "units"         => ["add", "Units"]
+  | "cyclic"        => ["add", "Cyclic"]
+  | "rootable"      => ["divisible"]
+  | "semigrp"       => ["add", "Semigrp"]
+  | "grp"           => ["add", "Grp"]
+  | "commute"       => ["add", "Commute"]
+  | "semiconj"      => ["add", "Semiconj"]
+  | "zpowers"       => ["zmultiples"]
+  | "powers"        => ["multiples"]
+  | "multipliable"  => ["summable"]
+  | "gpfree"        => ["apfree"]
+  | "quantale"      => ["add", "Quantale"]
+  | "square"        => ["even"]
+  | "mconv"         => ["conv"]
+  | "irreducible"   => ["add", "Irreducible"]
+  | "mlconvolution" => ["lconvolution"]
+  | x               => [x]
+
+/--
+Turn each element to lower-case, apply the `nameDict` and
+capitalize the output like the input.
+-/
+def applyNameDict : List String → List String
+  | x :: s => (capitalizeFirstLike x (nameDict x.toLower)) ++ applyNameDict s
+  | [] => []
+
+/--
+There are a few abbreviations we use. For example "Nonneg" instead of "ZeroLE"
+or "addComm" instead of "commAdd".
+Note: The input to this function is case sensitive!
+Todo: A lot of abbreviations here are manual fixes and there might be room to
+improve the naming logic to reduce the size of `fixAbbreviation`.
+-/
+def fixAbbreviation : List String → List String
+  | "is" :: "Cancel" :: "Add" :: s    => "isCancelAdd" :: fixAbbreviation s
+  | "Is" :: "Cancel" :: "Add" :: s    => "IsCancelAdd" :: fixAbbreviation s
+  | "is" :: "Left" :: "Cancel" :: "Add" :: s  => "isLeftCancelAdd" :: fixAbbreviation s
+  | "Is" :: "Left" :: "Cancel" :: "Add" :: s  => "IsLeftCancelAdd" :: fixAbbreviation s
+  | "is" :: "Right" :: "Cancel" :: "Add" :: s => "isRightCancelAdd" :: fixAbbreviation s
+  | "Is" :: "Right" :: "Cancel" :: "Add" :: s => "IsRightCancelAdd" :: fixAbbreviation s
+  | "cancel" :: "Add" :: s            => "addCancel" :: fixAbbreviation s
+  | "Cancel" :: "Add" :: s            => "AddCancel" :: fixAbbreviation s
+  | "left" :: "Cancel" :: "Add" :: s  => "addLeftCancel" :: fixAbbreviation s
+  | "Left" :: "Cancel" :: "Add" :: s  => "AddLeftCancel" :: fixAbbreviation s
+  | "right" :: "Cancel" :: "Add" :: s => "addRightCancel" :: fixAbbreviation s
+  | "Right" :: "Cancel" :: "Add" :: s => "AddRightCancel" :: fixAbbreviation s
+  | "cancel" :: "Comm" :: "Add" :: s  => "addCancelComm" :: fixAbbreviation s
+  | "Cancel" :: "Comm" :: "Add" :: s  => "AddCancelComm" :: fixAbbreviation s
+  | "comm" :: "Add" :: s              => "addComm" :: fixAbbreviation s
+  | "Comm" :: "Add" :: s              => "AddComm" :: fixAbbreviation s
+  | "Zero" :: "LE" :: s               => "Nonneg" :: fixAbbreviation s
+  | "zero" :: "_" :: "le" :: s        => "nonneg" :: fixAbbreviation s
+  | "zero" :: "LE" :: s               => "nonneg" :: fixAbbreviation s
+  | "Zero" :: "LT" :: s               => "Pos" :: fixAbbreviation s
+  | "zero" :: "_" :: "lt" :: s        => "pos" :: fixAbbreviation s
+  | "zero" :: "LT" :: s               => "pos" :: fixAbbreviation s
+  | "LE" :: "Zero" :: s               => "Nonpos" :: fixAbbreviation s
+  | "le" :: "_" :: "zero" :: s        => "nonpos" :: fixAbbreviation s
+  | "LT" :: "Zero" :: s               => "Neg" :: fixAbbreviation s
+  | "lt" :: "_" :: "zero" :: s        => "neg" :: fixAbbreviation s
+  | "Add" :: "Single" :: s            => "Single" :: fixAbbreviation s
+  | "add" :: "Single" :: s            => "single" :: fixAbbreviation s
+  | "add" :: "_" :: "single" :: s     => "single" :: fixAbbreviation s
+  | "Add" :: "Support" :: s           => "Support" :: fixAbbreviation s
+  | "add" :: "Support" :: s           => "support" :: fixAbbreviation s
+  | "add" :: "_" :: "support" :: s    => "support" :: fixAbbreviation s
+  | "Add" :: "TSupport" :: s          => "TSupport" :: fixAbbreviation s
+  | "add" :: "TSupport" :: s          => "tsupport" :: fixAbbreviation s
+  | "add" :: "_" :: "tsupport" :: s   => "tsupport" :: fixAbbreviation s
+  | "Add" :: "Indicator" :: s         => "Indicator" :: fixAbbreviation s
+  | "add" :: "Indicator" :: s         => "indicator" :: fixAbbreviation s
+  | "add" :: "_" :: "indicator" :: s  => "indicator" :: fixAbbreviation s
+  | "is" :: "Even" :: s             => "even" :: fixAbbreviation s
+  | "Is" :: "Even" :: s             => "Even" :: fixAbbreviation s
+  -- "Regular" is well-used in mathlib with various meanings (e.g. in
+  -- measure theory) and a direct translation
+  -- "regular" --> ["add", "Regular"] in `nameDict` above seems error-prone.
+  | "is" :: "Regular" :: s            => "isAddRegular" :: fixAbbreviation s
+  | "Is" :: "Regular" :: s            => "IsAddRegular" :: fixAbbreviation s
+  | "is" :: "Left" :: "Regular" :: s  => "isAddLeftRegular" :: fixAbbreviation s
+  | "Is" :: "Left" :: "Regular" :: s  => "IsAddLeftRegular" :: fixAbbreviation s
+  | "is" :: "Right" :: "Regular" :: s => "isAddRightRegular" :: fixAbbreviation s
+  | "Is" :: "Right" :: "Regular" :: s => "IsAddRightRegular" :: fixAbbreviation s
+  | "Has" :: "Fundamental" :: "Domain" :: s => "HasAddFundamentalDomain" :: fixAbbreviation s
+  | "has" :: "Fundamental" :: "Domain" :: s => "hasAddFundamentalDomain" :: fixAbbreviation s
+  | "Quotient" :: "Measure" :: s => "AddQuotientMeasure" :: fixAbbreviation s
+  | "quotient" :: "Measure" :: s => "addQuotientMeasure" :: fixAbbreviation s
+  -- the capitalization heuristic of `applyNameDict` doesn't work in the following cases
+  | "HSmul" :: s                      => "HSMul" :: fixAbbreviation s -- from `HPow`
+  | "NSmul" :: s                      => "NSMul" :: fixAbbreviation s -- from `NPow`
+  | "Nsmul" :: s                      => "NSMul" :: fixAbbreviation s -- from `Pow`
+  | "ZSmul" :: s                      => "ZSMul" :: fixAbbreviation s -- from `ZPow`
+  | "neg" :: "Fun" :: s               => "invFun" :: fixAbbreviation s
+  | "Neg" :: "Fun" :: s               => "InvFun" :: fixAbbreviation s
+  | "unique" :: "Prods" :: s          => "uniqueSums" :: fixAbbreviation s
+  | "Unique" :: "Prods" :: s          => "UniqueSums" :: fixAbbreviation s
+  | "order" :: "Of" :: s              => "addOrderOf" :: fixAbbreviation s
+  | "Order" :: "Of" :: s              => "AddOrderOf" :: fixAbbreviation s
+  | "is"::"Of"::"Fin"::"Order"::s     => "isOfFinAddOrder" :: fixAbbreviation s
+  | "Is"::"Of"::"Fin"::"Order"::s     => "IsOfFinAddOrder" :: fixAbbreviation s
+  | "is" :: "Central" :: "Scalar" :: s  => "isCentralVAdd" :: fixAbbreviation s
+  | "Is" :: "Central" :: "Scalar" :: s  => "IsCentralVAdd" :: fixAbbreviation s
+  | "is" :: "Scalar" :: "Tower" :: s  => "vaddAssocClass" :: fixAbbreviation s
+  | "Is" :: "Scalar" :: "Tower" :: s  => "VAddAssocClass" :: fixAbbreviation s
+  | "function" :: "_" :: "add" :: "Semiconj" :: s
+                                      => "function" :: "_" :: "semiconj" :: fixAbbreviation s
+  | "function" :: "_" :: "add" :: "Commute" :: s
+                                      => "function" :: "_" :: "commute" :: fixAbbreviation s
+  | "Zero" :: "Le" :: "Part" :: s         => "PosPart" :: fixAbbreviation s
+  | "Le" :: "Zero" :: "Part" :: s         => "NegPart" :: fixAbbreviation s
+  | "zero" :: "Le" :: "Part" :: s         => "posPart" :: fixAbbreviation s
+  | "le" :: "Zero" :: "Part" :: s         => "negPart" :: fixAbbreviation s
+  | "Division" :: "Add" :: "Monoid" :: s => "SubtractionMonoid" :: fixAbbreviation s
+  | "division" :: "Add" :: "Monoid" :: s => "subtractionMonoid" :: fixAbbreviation s
+  | "Sub" :: "Neg" :: "Zero" :: "Add" :: "Monoid" :: s => "SubNegZeroMonoid" :: fixAbbreviation s
+  | "sub" :: "Neg" :: "Zero" :: "Add" :: "Monoid" :: s => "subNegZeroMonoid" :: fixAbbreviation s
+  | "modular" :: "Character" :: s => "addModularCharacter" :: fixAbbreviation s
+  | "Modular" :: "Character" :: s => "AddModularCharacter" :: fixAbbreviation s
+  | x :: s                            => x :: fixAbbreviation s
+  | []                                => []
+
+/--
+Autogenerate additive name.
+This runs in several steps:
+1) Split according to capitalisation rule and at `_`.
+2) Apply word-by-word translation rules.
+3) Fix up abbreviations that are not word-by-word translations, like "addComm" or "Nonneg".
+-/
+def guessName : String → String :=
+  String.mapTokens '\'' <|
+  fun s =>
+    String.join <|
+    fixAbbreviation <|
+    applyNameDict <|
+    s.splitCase
+
 initialize registerTraceClass `to_additive
 initialize registerTraceClass `to_additive_detail
 
@@ -700,15 +893,21 @@ def expand (e : Expr) : MetaM Expr := do
 
 /-- Reorder pi-binders. See doc of `reorderAttr` for the interpretation of the argument -/
 def reorderForall (reorder : List (List Nat) := []) (src : Expr) : MetaM Expr := do
+  let tgt := src.mapForallBinderNames
+    fun
+    | .str p s => .str p (guessName s)
+    | n => n
+  trace[to_additive_detail] m!"renamed binder names from {src.getForallBinderNames} to " ++
+    m!"{tgt.getForallBinderNames}"
   if let some maxReorder := reorder.flatten.max? then
-    forallBoundedTelescope src (some (maxReorder + 1)) fun xs e => do
+    forallBoundedTelescope tgt (some (maxReorder + 1)) fun xs e => do
       if xs.size = maxReorder + 1 then
         mkForallFVars (xs.permute! reorder) e
       else
         throwError "the permutation\n{reorder}\nprovided by the `(reorder := ...)` option is \
           out of bounds, the type{indentExpr src}\nhas only {xs.size} arguments"
   else
-    return src
+    return tgt
 
 /-- Reorder lambda-binders. See doc of `reorderAttr` for the interpretation of the argument -/
 def reorderLambda (reorder : List (List Nat) := []) (src : Expr) : MetaM Expr := do
@@ -971,199 +1170,6 @@ def firstMultiplicativeArg (nm : Name) : MetaM Nat := do
     match l with
     | [] => return 0
     | (head :: tail) => return tail.foldl Nat.min head
-
-/-- Helper for `capitalizeLike`. -/
-partial def capitalizeLikeAux (s : String) (i : String.Pos := 0) (p : String) : String :=
-  if p.atEnd i || s.atEnd i then
-    p
-  else
-    let j := p.next i
-    if (s.get i).isLower then
-      capitalizeLikeAux s j <| p.set i (p.get i |>.toLower)
-    else if (s.get i).isUpper then
-      capitalizeLikeAux s j <| p.set i (p.get i |>.toUpper)
-    else
-      capitalizeLikeAux s j p
-
-/-- Capitalizes `s` char-by-char like `r`. If `s` is longer, it leaves the tail untouched. -/
-def capitalizeLike (r : String) (s : String) :=
-  capitalizeLikeAux r 0 s
-
-/-- Capitalize First element of a list like `s`.
-Note that we need to capitalize multiple characters in some cases,
-in examples like `HMul` or `hAdd`. -/
-def capitalizeFirstLike (s : String) : List String → List String
-  | x :: r => capitalizeLike s x :: r
-  | [] => []
-
-/--
-Dictionary used by `guessName` to autogenerate names.
-
-Note: `guessName` capitalizes first element of the output according to
-capitalization of the input. Input and first element should therefore be lower-case,
-2nd element should be capitalized properly.
--/
-def nameDict : String → List String
-  | "one"           => ["zero"]
-  | "mul"           => ["add"]
-  | "smul"          => ["vadd"]
-  | "inv"           => ["neg"]
-  | "div"           => ["sub"]
-  | "prod"          => ["sum"]
-  | "hmul"          => ["hadd"]
-  | "hsmul"         => ["hvadd"]
-  | "hdiv"          => ["hsub"]
-  | "hpow"          => ["hsmul"]
-  | "finprod"       => ["finsum"]
-  | "tprod"         => ["tsum"]
-  | "pow"           => ["nsmul"]
-  | "npow"          => ["nsmul"]
-  | "zpow"          => ["zsmul"]
-  | "mabs"          => ["abs"]
-  | "monoid"        => ["add", "Monoid"]
-  | "submonoid"     => ["add", "Submonoid"]
-  | "group"         => ["add", "Group"]
-  | "subgroup"      => ["add", "Subgroup"]
-  | "semigroup"     => ["add", "Semigroup"]
-  | "magma"         => ["add", "Magma"]
-  | "haar"          => ["add", "Haar"]
-  | "prehaar"       => ["add", "Prehaar"]
-  | "unit"          => ["add", "Unit"]
-  | "units"         => ["add", "Units"]
-  | "cyclic"        => ["add", "Cyclic"]
-  | "rootable"      => ["divisible"]
-  | "semigrp"       => ["add", "Semigrp"]
-  | "grp"           => ["add", "Grp"]
-  | "commute"       => ["add", "Commute"]
-  | "semiconj"      => ["add", "Semiconj"]
-  | "zpowers"       => ["zmultiples"]
-  | "powers"        => ["multiples"]
-  | "multipliable"  => ["summable"]
-  | "gpfree"        => ["apfree"]
-  | "quantale"      => ["add", "Quantale"]
-  | "square"        => ["even"]
-  | "mconv"         => ["conv"]
-  | "irreducible"   => ["add", "Irreducible"]
-  | "mlconvolution" => ["lconvolution"]
-  | x               => [x]
-
-/--
-Turn each element to lower-case, apply the `nameDict` and
-capitalize the output like the input.
--/
-def applyNameDict : List String → List String
-  | x :: s => (capitalizeFirstLike x (nameDict x.toLower)) ++ applyNameDict s
-  | [] => []
-
-/--
-There are a few abbreviations we use. For example "Nonneg" instead of "ZeroLE"
-or "addComm" instead of "commAdd".
-Note: The input to this function is case sensitive!
-Todo: A lot of abbreviations here are manual fixes and there might be room to
-improve the naming logic to reduce the size of `fixAbbreviation`.
--/
-def fixAbbreviation : List String → List String
-  | "is" :: "Cancel" :: "Add" :: s    => "isCancelAdd" :: fixAbbreviation s
-  | "Is" :: "Cancel" :: "Add" :: s    => "IsCancelAdd" :: fixAbbreviation s
-  | "is" :: "Left" :: "Cancel" :: "Add" :: s  => "isLeftCancelAdd" :: fixAbbreviation s
-  | "Is" :: "Left" :: "Cancel" :: "Add" :: s  => "IsLeftCancelAdd" :: fixAbbreviation s
-  | "is" :: "Right" :: "Cancel" :: "Add" :: s => "isRightCancelAdd" :: fixAbbreviation s
-  | "Is" :: "Right" :: "Cancel" :: "Add" :: s => "IsRightCancelAdd" :: fixAbbreviation s
-  | "cancel" :: "Add" :: s            => "addCancel" :: fixAbbreviation s
-  | "Cancel" :: "Add" :: s            => "AddCancel" :: fixAbbreviation s
-  | "left" :: "Cancel" :: "Add" :: s  => "addLeftCancel" :: fixAbbreviation s
-  | "Left" :: "Cancel" :: "Add" :: s  => "AddLeftCancel" :: fixAbbreviation s
-  | "right" :: "Cancel" :: "Add" :: s => "addRightCancel" :: fixAbbreviation s
-  | "Right" :: "Cancel" :: "Add" :: s => "AddRightCancel" :: fixAbbreviation s
-  | "cancel" :: "Comm" :: "Add" :: s  => "addCancelComm" :: fixAbbreviation s
-  | "Cancel" :: "Comm" :: "Add" :: s  => "AddCancelComm" :: fixAbbreviation s
-  | "comm" :: "Add" :: s              => "addComm" :: fixAbbreviation s
-  | "Comm" :: "Add" :: s              => "AddComm" :: fixAbbreviation s
-  | "Zero" :: "LE" :: s               => "Nonneg" :: fixAbbreviation s
-  | "zero" :: "_" :: "le" :: s        => "nonneg" :: fixAbbreviation s
-  | "zero" :: "LE" :: s               => "nonneg" :: fixAbbreviation s
-  | "Zero" :: "LT" :: s               => "Pos" :: fixAbbreviation s
-  | "zero" :: "_" :: "lt" :: s        => "pos" :: fixAbbreviation s
-  | "zero" :: "LT" :: s               => "pos" :: fixAbbreviation s
-  | "LE" :: "Zero" :: s               => "Nonpos" :: fixAbbreviation s
-  | "le" :: "_" :: "zero" :: s        => "nonpos" :: fixAbbreviation s
-  | "LT" :: "Zero" :: s               => "Neg" :: fixAbbreviation s
-  | "lt" :: "_" :: "zero" :: s        => "neg" :: fixAbbreviation s
-  | "Add" :: "Single" :: s            => "Single" :: fixAbbreviation s
-  | "add" :: "Single" :: s            => "single" :: fixAbbreviation s
-  | "add" :: "_" :: "single" :: s     => "single" :: fixAbbreviation s
-  | "Add" :: "Support" :: s           => "Support" :: fixAbbreviation s
-  | "add" :: "Support" :: s           => "support" :: fixAbbreviation s
-  | "add" :: "_" :: "support" :: s    => "support" :: fixAbbreviation s
-  | "Add" :: "TSupport" :: s          => "TSupport" :: fixAbbreviation s
-  | "add" :: "TSupport" :: s          => "tsupport" :: fixAbbreviation s
-  | "add" :: "_" :: "tsupport" :: s   => "tsupport" :: fixAbbreviation s
-  | "Add" :: "Indicator" :: s         => "Indicator" :: fixAbbreviation s
-  | "add" :: "Indicator" :: s         => "indicator" :: fixAbbreviation s
-  | "add" :: "_" :: "indicator" :: s  => "indicator" :: fixAbbreviation s
-  | "is" :: "Even" :: s             => "even" :: fixAbbreviation s
-  | "Is" :: "Even" :: s             => "Even" :: fixAbbreviation s
-  -- "Regular" is well-used in mathlib with various meanings (e.g. in
-  -- measure theory) and a direct translation
-  -- "regular" --> ["add", "Regular"] in `nameDict` above seems error-prone.
-  | "is" :: "Regular" :: s            => "isAddRegular" :: fixAbbreviation s
-  | "Is" :: "Regular" :: s            => "IsAddRegular" :: fixAbbreviation s
-  | "is" :: "Left" :: "Regular" :: s  => "isAddLeftRegular" :: fixAbbreviation s
-  | "Is" :: "Left" :: "Regular" :: s  => "IsAddLeftRegular" :: fixAbbreviation s
-  | "is" :: "Right" :: "Regular" :: s => "isAddRightRegular" :: fixAbbreviation s
-  | "Is" :: "Right" :: "Regular" :: s => "IsAddRightRegular" :: fixAbbreviation s
-  | "Has" :: "Fundamental" :: "Domain" :: s => "HasAddFundamentalDomain" :: fixAbbreviation s
-  | "has" :: "Fundamental" :: "Domain" :: s => "hasAddFundamentalDomain" :: fixAbbreviation s
-  | "Quotient" :: "Measure" :: s => "AddQuotientMeasure" :: fixAbbreviation s
-  | "quotient" :: "Measure" :: s => "addQuotientMeasure" :: fixAbbreviation s
-  -- the capitalization heuristic of `applyNameDict` doesn't work in the following cases
-  | "HSmul" :: s                      => "HSMul" :: fixAbbreviation s -- from `HPow`
-  | "NSmul" :: s                      => "NSMul" :: fixAbbreviation s -- from `NPow`
-  | "Nsmul" :: s                      => "NSMul" :: fixAbbreviation s -- from `Pow`
-  | "ZSmul" :: s                      => "ZSMul" :: fixAbbreviation s -- from `ZPow`
-  | "neg" :: "Fun" :: s               => "invFun" :: fixAbbreviation s
-  | "Neg" :: "Fun" :: s               => "InvFun" :: fixAbbreviation s
-  | "unique" :: "Prods" :: s          => "uniqueSums" :: fixAbbreviation s
-  | "Unique" :: "Prods" :: s          => "UniqueSums" :: fixAbbreviation s
-  | "order" :: "Of" :: s              => "addOrderOf" :: fixAbbreviation s
-  | "Order" :: "Of" :: s              => "AddOrderOf" :: fixAbbreviation s
-  | "is"::"Of"::"Fin"::"Order"::s     => "isOfFinAddOrder" :: fixAbbreviation s
-  | "Is"::"Of"::"Fin"::"Order"::s     => "IsOfFinAddOrder" :: fixAbbreviation s
-  | "is" :: "Central" :: "Scalar" :: s  => "isCentralVAdd" :: fixAbbreviation s
-  | "Is" :: "Central" :: "Scalar" :: s  => "IsCentralVAdd" :: fixAbbreviation s
-  | "is" :: "Scalar" :: "Tower" :: s  => "vaddAssocClass" :: fixAbbreviation s
-  | "Is" :: "Scalar" :: "Tower" :: s  => "VAddAssocClass" :: fixAbbreviation s
-  | "function" :: "_" :: "add" :: "Semiconj" :: s
-                                      => "function" :: "_" :: "semiconj" :: fixAbbreviation s
-  | "function" :: "_" :: "add" :: "Commute" :: s
-                                      => "function" :: "_" :: "commute" :: fixAbbreviation s
-  | "Zero" :: "Le" :: "Part" :: s         => "PosPart" :: fixAbbreviation s
-  | "Le" :: "Zero" :: "Part" :: s         => "NegPart" :: fixAbbreviation s
-  | "zero" :: "Le" :: "Part" :: s         => "posPart" :: fixAbbreviation s
-  | "le" :: "Zero" :: "Part" :: s         => "negPart" :: fixAbbreviation s
-  | "Division" :: "Add" :: "Monoid" :: s => "SubtractionMonoid" :: fixAbbreviation s
-  | "division" :: "Add" :: "Monoid" :: s => "subtractionMonoid" :: fixAbbreviation s
-  | "Sub" :: "Neg" :: "Zero" :: "Add" :: "Monoid" :: s => "SubNegZeroMonoid" :: fixAbbreviation s
-  | "sub" :: "Neg" :: "Zero" :: "Add" :: "Monoid" :: s => "subNegZeroMonoid" :: fixAbbreviation s
-  | "modular" :: "Character" :: s => "addModularCharacter" :: fixAbbreviation s
-  | "Modular" :: "Character" :: s => "AddModularCharacter" :: fixAbbreviation s
-  | x :: s                            => x :: fixAbbreviation s
-  | []                                => []
-
-/--
-Autogenerate additive name.
-This runs in several steps:
-1) Split according to capitalisation rule and at `_`.
-2) Apply word-by-word translation rules.
-3) Fix up abbreviations that are not word-by-word translations, like "addComm" or "Nonneg".
--/
-def guessName : String → String :=
-  String.mapTokens '\'' <|
-  fun s =>
-    String.join <|
-    fixAbbreviation <|
-    applyNameDict <|
-    s.splitCase
 
 /-- Return the provided target name or autogenerate one if one was not provided. -/
 def targetName (cfg : Config) (src : Name) : CoreM Name := do

--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -652,8 +652,7 @@ def expand (e : Expr) : MetaM Expr := do
 
 /-- Rename binder names in pi type. -/
 def renameBinderNames (src : Expr) : Expr :=
-  src.mapForallBinderNames
-    fun
+  src.mapForallBinderNames fun
     | .str p s => .str p (guessName s)
     | n => n
 

--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -3,24 +3,21 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Yury Kudryashov, Floris van Doorn, Jon Eugster
 -/
-import Mathlib.Data.Nat.Notation
-import Mathlib.Data.String.Defs
-import Mathlib.Data.Array.Defs
-import Mathlib.Lean.Expr.ReplaceRec
-import Mathlib.Lean.EnvExtension
-import Mathlib.Lean.Meta.Simp
-import Mathlib.Lean.Name
-import Lean.Elab.Tactic.Ext
-import Lean.Meta.Tactic.Symm
-import Lean.Meta.Tactic.Rfl
-import Lean.Meta.Match.MatcherInfo
-import Lean.Meta.AbstractNestedProofs
-import Batteries.Lean.NameMapAttribute
 import Batteries.Tactic.Lint -- useful to lint this file and for DiscrTree.elements
 import Batteries.Tactic.Trans
+import Lean.Elab.Tactic.Ext
+import Lean.Meta.Tactic.Rfl
+import Lean.Meta.Tactic.Symm
+import Lean.Meta.Tactic.TryThis
+import Mathlib.Data.Array.Defs
+import Mathlib.Data.Nat.Notation
+import Mathlib.Lean.EnvExtension
+import Mathlib.Lean.Expr.ReplaceRec
+import Mathlib.Lean.Meta.Simp
+import Mathlib.Lean.Name
 import Mathlib.Tactic.Eqns -- just to copy the attribute
 import Mathlib.Tactic.Simps.Basic
-import Lean.Meta.Tactic.TryThis
+import Mathlib.Tactic.ToAdditive.GuessName
 
 /-!
 # The `@[to_additive]` attribute.
@@ -172,7 +169,7 @@ identifiers appearing in the name, type, and body of a declaration and
 creating a new declaration by mapping those names to additive versions
 using a simple string-based dictionary and also using all declarations
 that have previously been labeled with `to_additive`. The dictionary is `ToAdditive.nameDict`
-and can be found in the `Tactic.ToAdditive.Frontend` file. If you introduce a new name which
+and can be found in the `Tactic.ToAdditive.GuessName` file. If you introduce a new name which
 should be translated by `to_additive` you should add the translation to this dictionary.
 
 In the `mul_comm'` example above, `to_additive` maps:
@@ -321,243 +318,6 @@ syntax (name := to_additive) "to_additive" "?"? toAdditiveRest : attr
 
 @[inherit_doc to_additive]
 macro "to_additive?" rest:toAdditiveRest : attr => `(attr| to_additive ? $rest)
-
-/-- A set of strings of names that end in a capital letter.
-* If the string contains a lowercase letter, the string should be split between the first occurrence
-  of a lower-case letter followed by an upper-case letter.
-* If multiple strings have the same prefix, they should be grouped by prefix
-* In this case, the second list should be prefix-free
-  (no element can be a prefix of a later element)
-
-Todo: automate the translation from `String` to an element in this `TreeMap`
-  (but this would require having something similar to the `rb_lmap` from Lean 3). -/
-def endCapitalNames : TreeMap String (List String) compare :=
-  -- todo: we want something like
-  -- endCapitalNamesOfList ["LE", "LT", "WF", "CoeTC", "CoeT", "CoeHTCT"]
-  .ofList [("LE", [""]), ("LT", [""]), ("WF", [""]), ("Coe", ["TC", "T", "HTCT"])]
-
-open String in
-/-- This function takes a String and splits it into separate parts based on the following
-[naming conventions](https://github.com/leanprover-community/mathlib4/wiki#naming-convention).
-
-E.g. `#eval "InvHMulLEConjugate₂SMul_ne_top".splitCase` yields
-`["Inv", "HMul", "LE", "Conjugate₂", "SMul", "_", "ne", "_", "top"]`. -/
-partial def _root_.String.splitCase (s : String) (i₀ : Pos := 0) (r : List String := []) :
-    List String := Id.run do
-  -- We test if we need to split between `i₀` and `i₁`.
-  let i₁ := s.next i₀
-  if s.atEnd i₁ then
-    -- If `i₀` is the last position, return the list.
-    let r := s::r
-    return r.reverse
-  /- We split the string in three cases
-  * We split on both sides of `_` to keep them there when rejoining the string;
-  * We split after a name in `endCapitalNames`;
-  * We split after a lower-case letter that is followed by an upper-case letter
-    (unless it is part of a name in `endCapitalNames`). -/
-  if s.get i₀ == '_' || s.get i₁ == '_' then
-    return splitCase (s.extract i₁ s.endPos) 0 <| (s.extract 0 i₁)::r
-  if (s.get i₁).isUpper then
-    if let some strs := endCapitalNames[s.extract 0 i₁]? then
-      if let some (pref, newS) := strs.findSome?
-        fun x : String ↦ (s.extract i₁ s.endPos).dropPrefix? x |>.map (x, ·.toString) then
-        return splitCase newS 0 <| (s.extract 0 i₁ ++ pref)::r
-    if !(s.get i₀).isUpper then
-      return splitCase (s.extract i₁ s.endPos) 0 <| (s.extract 0 i₁)::r
-  return splitCase s i₁ r
-
-/-- Helper for `capitalizeLike`. -/
-partial def capitalizeLikeAux (s : String) (i : String.Pos := 0) (p : String) : String :=
-  if p.atEnd i || s.atEnd i then
-    p
-  else
-    let j := p.next i
-    if (s.get i).isLower then
-      capitalizeLikeAux s j <| p.set i (p.get i |>.toLower)
-    else if (s.get i).isUpper then
-      capitalizeLikeAux s j <| p.set i (p.get i |>.toUpper)
-    else
-      capitalizeLikeAux s j p
-
-/-- Capitalizes `s` char-by-char like `r`. If `s` is longer, it leaves the tail untouched. -/
-def capitalizeLike (r : String) (s : String) :=
-  capitalizeLikeAux r 0 s
-
-/-- Capitalize First element of a list like `s`.
-Note that we need to capitalize multiple characters in some cases,
-in examples like `HMul` or `hAdd`. -/
-def capitalizeFirstLike (s : String) : List String → List String
-  | x :: r => capitalizeLike s x :: r
-  | [] => []
-
-/--
-Dictionary used by `guessName` to autogenerate names.
-
-Note: `guessName` capitalizes first element of the output according to
-capitalization of the input. Input and first element should therefore be lower-case,
-2nd element should be capitalized properly.
--/
-def nameDict : String → List String
-  | "one"           => ["zero"]
-  | "mul"           => ["add"]
-  | "smul"          => ["vadd"]
-  | "inv"           => ["neg"]
-  | "div"           => ["sub"]
-  | "prod"          => ["sum"]
-  | "hmul"          => ["hadd"]
-  | "hsmul"         => ["hvadd"]
-  | "hdiv"          => ["hsub"]
-  | "hpow"          => ["hsmul"]
-  | "finprod"       => ["finsum"]
-  | "tprod"         => ["tsum"]
-  | "pow"           => ["nsmul"]
-  | "npow"          => ["nsmul"]
-  | "zpow"          => ["zsmul"]
-  | "mabs"          => ["abs"]
-  | "monoid"        => ["add", "Monoid"]
-  | "submonoid"     => ["add", "Submonoid"]
-  | "group"         => ["add", "Group"]
-  | "subgroup"      => ["add", "Subgroup"]
-  | "semigroup"     => ["add", "Semigroup"]
-  | "magma"         => ["add", "Magma"]
-  | "haar"          => ["add", "Haar"]
-  | "prehaar"       => ["add", "Prehaar"]
-  | "unit"          => ["add", "Unit"]
-  | "units"         => ["add", "Units"]
-  | "cyclic"        => ["add", "Cyclic"]
-  | "rootable"      => ["divisible"]
-  | "semigrp"       => ["add", "Semigrp"]
-  | "grp"           => ["add", "Grp"]
-  | "commute"       => ["add", "Commute"]
-  | "semiconj"      => ["add", "Semiconj"]
-  | "zpowers"       => ["zmultiples"]
-  | "powers"        => ["multiples"]
-  | "multipliable"  => ["summable"]
-  | "gpfree"        => ["apfree"]
-  | "quantale"      => ["add", "Quantale"]
-  | "square"        => ["even"]
-  | "mconv"         => ["conv"]
-  | "irreducible"   => ["add", "Irreducible"]
-  | "mlconvolution" => ["lconvolution"]
-  | x               => [x]
-
-/--
-Turn each element to lower-case, apply the `nameDict` and
-capitalize the output like the input.
--/
-def applyNameDict : List String → List String
-  | x :: s => (capitalizeFirstLike x (nameDict x.toLower)) ++ applyNameDict s
-  | [] => []
-
-/--
-There are a few abbreviations we use. For example "Nonneg" instead of "ZeroLE"
-or "addComm" instead of "commAdd".
-Note: The input to this function is case sensitive!
-Todo: A lot of abbreviations here are manual fixes and there might be room to
-improve the naming logic to reduce the size of `fixAbbreviation`.
--/
-def fixAbbreviation : List String → List String
-  | "is" :: "Cancel" :: "Add" :: s    => "isCancelAdd" :: fixAbbreviation s
-  | "Is" :: "Cancel" :: "Add" :: s    => "IsCancelAdd" :: fixAbbreviation s
-  | "is" :: "Left" :: "Cancel" :: "Add" :: s  => "isLeftCancelAdd" :: fixAbbreviation s
-  | "Is" :: "Left" :: "Cancel" :: "Add" :: s  => "IsLeftCancelAdd" :: fixAbbreviation s
-  | "is" :: "Right" :: "Cancel" :: "Add" :: s => "isRightCancelAdd" :: fixAbbreviation s
-  | "Is" :: "Right" :: "Cancel" :: "Add" :: s => "IsRightCancelAdd" :: fixAbbreviation s
-  | "cancel" :: "Add" :: s            => "addCancel" :: fixAbbreviation s
-  | "Cancel" :: "Add" :: s            => "AddCancel" :: fixAbbreviation s
-  | "left" :: "Cancel" :: "Add" :: s  => "addLeftCancel" :: fixAbbreviation s
-  | "Left" :: "Cancel" :: "Add" :: s  => "AddLeftCancel" :: fixAbbreviation s
-  | "right" :: "Cancel" :: "Add" :: s => "addRightCancel" :: fixAbbreviation s
-  | "Right" :: "Cancel" :: "Add" :: s => "AddRightCancel" :: fixAbbreviation s
-  | "cancel" :: "Comm" :: "Add" :: s  => "addCancelComm" :: fixAbbreviation s
-  | "Cancel" :: "Comm" :: "Add" :: s  => "AddCancelComm" :: fixAbbreviation s
-  | "comm" :: "Add" :: s              => "addComm" :: fixAbbreviation s
-  | "Comm" :: "Add" :: s              => "AddComm" :: fixAbbreviation s
-  | "Zero" :: "LE" :: s               => "Nonneg" :: fixAbbreviation s
-  | "zero" :: "_" :: "le" :: s        => "nonneg" :: fixAbbreviation s
-  | "zero" :: "LE" :: s               => "nonneg" :: fixAbbreviation s
-  | "Zero" :: "LT" :: s               => "Pos" :: fixAbbreviation s
-  | "zero" :: "_" :: "lt" :: s        => "pos" :: fixAbbreviation s
-  | "zero" :: "LT" :: s               => "pos" :: fixAbbreviation s
-  | "LE" :: "Zero" :: s               => "Nonpos" :: fixAbbreviation s
-  | "le" :: "_" :: "zero" :: s        => "nonpos" :: fixAbbreviation s
-  | "LT" :: "Zero" :: s               => "Neg" :: fixAbbreviation s
-  | "lt" :: "_" :: "zero" :: s        => "neg" :: fixAbbreviation s
-  | "Add" :: "Single" :: s            => "Single" :: fixAbbreviation s
-  | "add" :: "Single" :: s            => "single" :: fixAbbreviation s
-  | "add" :: "_" :: "single" :: s     => "single" :: fixAbbreviation s
-  | "Add" :: "Support" :: s           => "Support" :: fixAbbreviation s
-  | "add" :: "Support" :: s           => "support" :: fixAbbreviation s
-  | "add" :: "_" :: "support" :: s    => "support" :: fixAbbreviation s
-  | "Add" :: "TSupport" :: s          => "TSupport" :: fixAbbreviation s
-  | "add" :: "TSupport" :: s          => "tsupport" :: fixAbbreviation s
-  | "add" :: "_" :: "tsupport" :: s   => "tsupport" :: fixAbbreviation s
-  | "Add" :: "Indicator" :: s         => "Indicator" :: fixAbbreviation s
-  | "add" :: "Indicator" :: s         => "indicator" :: fixAbbreviation s
-  | "add" :: "_" :: "indicator" :: s  => "indicator" :: fixAbbreviation s
-  | "is" :: "Even" :: s             => "even" :: fixAbbreviation s
-  | "Is" :: "Even" :: s             => "Even" :: fixAbbreviation s
-  -- "Regular" is well-used in mathlib with various meanings (e.g. in
-  -- measure theory) and a direct translation
-  -- "regular" --> ["add", "Regular"] in `nameDict` above seems error-prone.
-  | "is" :: "Regular" :: s            => "isAddRegular" :: fixAbbreviation s
-  | "Is" :: "Regular" :: s            => "IsAddRegular" :: fixAbbreviation s
-  | "is" :: "Left" :: "Regular" :: s  => "isAddLeftRegular" :: fixAbbreviation s
-  | "Is" :: "Left" :: "Regular" :: s  => "IsAddLeftRegular" :: fixAbbreviation s
-  | "is" :: "Right" :: "Regular" :: s => "isAddRightRegular" :: fixAbbreviation s
-  | "Is" :: "Right" :: "Regular" :: s => "IsAddRightRegular" :: fixAbbreviation s
-  | "Has" :: "Fundamental" :: "Domain" :: s => "HasAddFundamentalDomain" :: fixAbbreviation s
-  | "has" :: "Fundamental" :: "Domain" :: s => "hasAddFundamentalDomain" :: fixAbbreviation s
-  | "Quotient" :: "Measure" :: s => "AddQuotientMeasure" :: fixAbbreviation s
-  | "quotient" :: "Measure" :: s => "addQuotientMeasure" :: fixAbbreviation s
-  -- the capitalization heuristic of `applyNameDict` doesn't work in the following cases
-  | "HSmul" :: s                      => "HSMul" :: fixAbbreviation s -- from `HPow`
-  | "NSmul" :: s                      => "NSMul" :: fixAbbreviation s -- from `NPow`
-  | "Nsmul" :: s                      => "NSMul" :: fixAbbreviation s -- from `Pow`
-  | "ZSmul" :: s                      => "ZSMul" :: fixAbbreviation s -- from `ZPow`
-  | "neg" :: "Fun" :: s               => "invFun" :: fixAbbreviation s
-  | "Neg" :: "Fun" :: s               => "InvFun" :: fixAbbreviation s
-  | "unique" :: "Prods" :: s          => "uniqueSums" :: fixAbbreviation s
-  | "Unique" :: "Prods" :: s          => "UniqueSums" :: fixAbbreviation s
-  | "order" :: "Of" :: s              => "addOrderOf" :: fixAbbreviation s
-  | "Order" :: "Of" :: s              => "AddOrderOf" :: fixAbbreviation s
-  | "is"::"Of"::"Fin"::"Order"::s     => "isOfFinAddOrder" :: fixAbbreviation s
-  | "Is"::"Of"::"Fin"::"Order"::s     => "IsOfFinAddOrder" :: fixAbbreviation s
-  | "is" :: "Central" :: "Scalar" :: s  => "isCentralVAdd" :: fixAbbreviation s
-  | "Is" :: "Central" :: "Scalar" :: s  => "IsCentralVAdd" :: fixAbbreviation s
-  | "is" :: "Scalar" :: "Tower" :: s  => "vaddAssocClass" :: fixAbbreviation s
-  | "Is" :: "Scalar" :: "Tower" :: s  => "VAddAssocClass" :: fixAbbreviation s
-  | "function" :: "_" :: "add" :: "Semiconj" :: s
-                                      => "function" :: "_" :: "semiconj" :: fixAbbreviation s
-  | "function" :: "_" :: "add" :: "Commute" :: s
-                                      => "function" :: "_" :: "commute" :: fixAbbreviation s
-  | "Zero" :: "Le" :: "Part" :: s         => "PosPart" :: fixAbbreviation s
-  | "Le" :: "Zero" :: "Part" :: s         => "NegPart" :: fixAbbreviation s
-  | "zero" :: "Le" :: "Part" :: s         => "posPart" :: fixAbbreviation s
-  | "le" :: "Zero" :: "Part" :: s         => "negPart" :: fixAbbreviation s
-  | "Division" :: "Add" :: "Monoid" :: s => "SubtractionMonoid" :: fixAbbreviation s
-  | "division" :: "Add" :: "Monoid" :: s => "subtractionMonoid" :: fixAbbreviation s
-  | "Sub" :: "Neg" :: "Zero" :: "Add" :: "Monoid" :: s => "SubNegZeroMonoid" :: fixAbbreviation s
-  | "sub" :: "Neg" :: "Zero" :: "Add" :: "Monoid" :: s => "subNegZeroMonoid" :: fixAbbreviation s
-  | "modular" :: "Character" :: s => "addModularCharacter" :: fixAbbreviation s
-  | "Modular" :: "Character" :: s => "AddModularCharacter" :: fixAbbreviation s
-  | x :: s                            => x :: fixAbbreviation s
-  | []                                => []
-
-/--
-Autogenerate additive name.
-This runs in several steps:
-1) Split according to capitalisation rule and at `_`.
-2) Apply word-by-word translation rules.
-3) Fix up abbreviations that are not word-by-word translations, like "addComm" or "Nonneg".
--/
-def guessName : String → String :=
-  String.mapTokens '\'' <|
-  fun s =>
-    String.join <|
-    fixAbbreviation <|
-    applyNameDict <|
-    s.splitCase
 
 initialize registerTraceClass `to_additive
 initialize registerTraceClass `to_additive_detail

--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -3,7 +3,6 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Yury Kudryashov, Floris van Doorn, Jon Eugster
 -/
-import Batteries.Tactic.Lint -- useful to lint this file and for DiscrTree.elements
 import Batteries.Tactic.Trans
 import Lean.Elab.Tactic.Ext
 import Lean.Meta.Tactic.Rfl
@@ -652,14 +651,11 @@ def expand (e : Expr) : MetaM Expr := do
   return e₂
 
 /-- Rename binder names in pi type. -/
-def renameBinderNames (src : Expr) : MetaM Expr := do
-  let tgt := src.mapForallBinderNames
+def renameBinderNames (src : Expr) : Expr :=
+  src.mapForallBinderNames
     fun
     | .str p s => .str p (guessName s)
     | n => n
-  trace[to_additive_detail] m!"renamed binder names from {src.getForallBinderNames} to " ++
-    m!"{tgt.getForallBinderNames}"
-  return tgt
 
 /-- Reorder pi-binders. See doc of `reorderAttr` for the interpretation of the argument -/
 def reorderForall (reorder : List (List Nat) := []) (src : Expr) : MetaM Expr := do
@@ -707,7 +703,7 @@ def updateDecl (tgt : Name) (srcDecl : ConstantInfo) (reorder : List (List Nat) 
   if 0 ∈ reorder.flatten then
     decl := decl.updateLevelParams decl.levelParams.swapFirstTwo
   decl := decl.updateType <| ← applyReplacementFun <| ← reorderForall reorder <|
-    ← renameBinderNames <| ← expand decl.type
+    renameBinderNames <| ← expand decl.type
   if let some v := decl.value? then
     decl := decl.updateValue <| ← applyReplacementFun <| ← reorderLambda reorder <| ← expand v
   else if let .opaqueInfo info := decl then -- not covered by `value?`

--- a/Mathlib/Tactic/ToAdditive/GuessName.lean
+++ b/Mathlib/Tactic/ToAdditive/GuessName.lean
@@ -7,7 +7,7 @@ Authors: Mario Carneiro, Yury Kudryashov, Floris van Doorn, Jon Eugster
 import Std.Data.TreeMap.Basic
 import Mathlib.Data.String.Defs
 
-/-~
+/-!
 # Name generation APIs for `to_additive`
 -/
 

--- a/Mathlib/Tactic/ToAdditive/GuessName.lean
+++ b/Mathlib/Tactic/ToAdditive/GuessName.lean
@@ -1,0 +1,255 @@
+/-
+Copyright (c) 2017 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, Yury Kudryashov, Floris van Doorn, Jon Eugster
+-/
+
+import Std.Data.TreeMap.Basic
+import Mathlib.Data.String.Defs
+
+/-~
+# Name generation APIs for `to_additive`
+-/
+
+open Std
+
+namespace ToAdditive
+
+/-- A set of strings of names that end in a capital letter.
+* If the string contains a lowercase letter, the string should be split between the first occurrence
+  of a lower-case letter followed by an upper-case letter.
+* If multiple strings have the same prefix, they should be grouped by prefix
+* In this case, the second list should be prefix-free
+  (no element can be a prefix of a later element)
+
+Todo: automate the translation from `String` to an element in this `TreeMap`
+  (but this would require having something similar to the `rb_lmap` from Lean 3). -/
+def endCapitalNames : TreeMap String (List String) compare :=
+  -- todo: we want something like
+  -- endCapitalNamesOfList ["LE", "LT", "WF", "CoeTC", "CoeT", "CoeHTCT"]
+  .ofList [("LE", [""]), ("LT", [""]), ("WF", [""]), ("Coe", ["TC", "T", "HTCT"])]
+
+open String in
+/-- This function takes a String and splits it into separate parts based on the following
+[naming conventions](https://github.com/leanprover-community/mathlib4/wiki#naming-convention).
+
+E.g. `#eval "InvHMulLEConjugate₂SMul_ne_top".splitCase` yields
+`["Inv", "HMul", "LE", "Conjugate₂", "SMul", "_", "ne", "_", "top"]`. -/
+partial def _root_.String.splitCase (s : String) (i₀ : Pos := 0) (r : List String := []) :
+    List String := Id.run do
+  -- We test if we need to split between `i₀` and `i₁`.
+  let i₁ := s.next i₀
+  if s.atEnd i₁ then
+    -- If `i₀` is the last position, return the list.
+    let r := s::r
+    return r.reverse
+  /- We split the string in three cases
+  * We split on both sides of `_` to keep them there when rejoining the string;
+  * We split after a name in `endCapitalNames`;
+  * We split after a lower-case letter that is followed by an upper-case letter
+    (unless it is part of a name in `endCapitalNames`). -/
+  if s.get i₀ == '_' || s.get i₁ == '_' then
+    return splitCase (s.extract i₁ s.endPos) 0 <| (s.extract 0 i₁)::r
+  if (s.get i₁).isUpper then
+    if let some strs := endCapitalNames[s.extract 0 i₁]? then
+      if let some (pref, newS) := strs.findSome?
+        fun x : String ↦ (s.extract i₁ s.endPos).dropPrefix? x |>.map (x, ·.toString) then
+        return splitCase newS 0 <| (s.extract 0 i₁ ++ pref)::r
+    if !(s.get i₀).isUpper then
+      return splitCase (s.extract i₁ s.endPos) 0 <| (s.extract 0 i₁)::r
+  return splitCase s i₁ r
+
+/-- Helper for `capitalizeLike`. -/
+partial def capitalizeLikeAux (s : String) (i : String.Pos := 0) (p : String) : String :=
+  if p.atEnd i || s.atEnd i then
+    p
+  else
+    let j := p.next i
+    if (s.get i).isLower then
+      capitalizeLikeAux s j <| p.set i (p.get i |>.toLower)
+    else if (s.get i).isUpper then
+      capitalizeLikeAux s j <| p.set i (p.get i |>.toUpper)
+    else
+      capitalizeLikeAux s j p
+
+/-- Capitalizes `s` char-by-char like `r`. If `s` is longer, it leaves the tail untouched. -/
+def capitalizeLike (r : String) (s : String) :=
+  capitalizeLikeAux r 0 s
+
+/-- Capitalize First element of a list like `s`.
+Note that we need to capitalize multiple characters in some cases,
+in examples like `HMul` or `hAdd`. -/
+def capitalizeFirstLike (s : String) : List String → List String
+  | x :: r => capitalizeLike s x :: r
+  | [] => []
+
+/--
+Dictionary used by `guessName` to autogenerate names.
+
+Note: `guessName` capitalizes first element of the output according to
+capitalization of the input. Input and first element should therefore be lower-case,
+2nd element should be capitalized properly.
+-/
+def nameDict : String → List String
+  | "one"           => ["zero"]
+  | "mul"           => ["add"]
+  | "smul"          => ["vadd"]
+  | "inv"           => ["neg"]
+  | "div"           => ["sub"]
+  | "prod"          => ["sum"]
+  | "hmul"          => ["hadd"]
+  | "hsmul"         => ["hvadd"]
+  | "hdiv"          => ["hsub"]
+  | "hpow"          => ["hsmul"]
+  | "finprod"       => ["finsum"]
+  | "tprod"         => ["tsum"]
+  | "pow"           => ["nsmul"]
+  | "npow"          => ["nsmul"]
+  | "zpow"          => ["zsmul"]
+  | "mabs"          => ["abs"]
+  | "monoid"        => ["add", "Monoid"]
+  | "submonoid"     => ["add", "Submonoid"]
+  | "group"         => ["add", "Group"]
+  | "subgroup"      => ["add", "Subgroup"]
+  | "semigroup"     => ["add", "Semigroup"]
+  | "magma"         => ["add", "Magma"]
+  | "haar"          => ["add", "Haar"]
+  | "prehaar"       => ["add", "Prehaar"]
+  | "unit"          => ["add", "Unit"]
+  | "units"         => ["add", "Units"]
+  | "cyclic"        => ["add", "Cyclic"]
+  | "rootable"      => ["divisible"]
+  | "semigrp"       => ["add", "Semigrp"]
+  | "grp"           => ["add", "Grp"]
+  | "commute"       => ["add", "Commute"]
+  | "semiconj"      => ["add", "Semiconj"]
+  | "zpowers"       => ["zmultiples"]
+  | "powers"        => ["multiples"]
+  | "multipliable"  => ["summable"]
+  | "gpfree"        => ["apfree"]
+  | "quantale"      => ["add", "Quantale"]
+  | "square"        => ["even"]
+  | "mconv"         => ["conv"]
+  | "irreducible"   => ["add", "Irreducible"]
+  | "mlconvolution" => ["lconvolution"]
+  | x               => [x]
+
+/--
+Turn each element to lower-case, apply the `nameDict` and
+capitalize the output like the input.
+-/
+def applyNameDict : List String → List String
+  | x :: s => (capitalizeFirstLike x (nameDict x.toLower)) ++ applyNameDict s
+  | [] => []
+
+/--
+There are a few abbreviations we use. For example "Nonneg" instead of "ZeroLE"
+or "addComm" instead of "commAdd".
+Note: The input to this function is case sensitive!
+Todo: A lot of abbreviations here are manual fixes and there might be room to
+improve the naming logic to reduce the size of `fixAbbreviation`.
+-/
+def fixAbbreviation : List String → List String
+  | "is" :: "Cancel" :: "Add" :: s    => "isCancelAdd" :: fixAbbreviation s
+  | "Is" :: "Cancel" :: "Add" :: s    => "IsCancelAdd" :: fixAbbreviation s
+  | "is" :: "Left" :: "Cancel" :: "Add" :: s  => "isLeftCancelAdd" :: fixAbbreviation s
+  | "Is" :: "Left" :: "Cancel" :: "Add" :: s  => "IsLeftCancelAdd" :: fixAbbreviation s
+  | "is" :: "Right" :: "Cancel" :: "Add" :: s => "isRightCancelAdd" :: fixAbbreviation s
+  | "Is" :: "Right" :: "Cancel" :: "Add" :: s => "IsRightCancelAdd" :: fixAbbreviation s
+  | "cancel" :: "Add" :: s            => "addCancel" :: fixAbbreviation s
+  | "Cancel" :: "Add" :: s            => "AddCancel" :: fixAbbreviation s
+  | "left" :: "Cancel" :: "Add" :: s  => "addLeftCancel" :: fixAbbreviation s
+  | "Left" :: "Cancel" :: "Add" :: s  => "AddLeftCancel" :: fixAbbreviation s
+  | "right" :: "Cancel" :: "Add" :: s => "addRightCancel" :: fixAbbreviation s
+  | "Right" :: "Cancel" :: "Add" :: s => "AddRightCancel" :: fixAbbreviation s
+  | "cancel" :: "Comm" :: "Add" :: s  => "addCancelComm" :: fixAbbreviation s
+  | "Cancel" :: "Comm" :: "Add" :: s  => "AddCancelComm" :: fixAbbreviation s
+  | "comm" :: "Add" :: s              => "addComm" :: fixAbbreviation s
+  | "Comm" :: "Add" :: s              => "AddComm" :: fixAbbreviation s
+  | "Zero" :: "LE" :: s               => "Nonneg" :: fixAbbreviation s
+  | "zero" :: "_" :: "le" :: s        => "nonneg" :: fixAbbreviation s
+  | "zero" :: "LE" :: s               => "nonneg" :: fixAbbreviation s
+  | "Zero" :: "LT" :: s               => "Pos" :: fixAbbreviation s
+  | "zero" :: "_" :: "lt" :: s        => "pos" :: fixAbbreviation s
+  | "zero" :: "LT" :: s               => "pos" :: fixAbbreviation s
+  | "LE" :: "Zero" :: s               => "Nonpos" :: fixAbbreviation s
+  | "le" :: "_" :: "zero" :: s        => "nonpos" :: fixAbbreviation s
+  | "LT" :: "Zero" :: s               => "Neg" :: fixAbbreviation s
+  | "lt" :: "_" :: "zero" :: s        => "neg" :: fixAbbreviation s
+  | "Add" :: "Single" :: s            => "Single" :: fixAbbreviation s
+  | "add" :: "Single" :: s            => "single" :: fixAbbreviation s
+  | "add" :: "_" :: "single" :: s     => "single" :: fixAbbreviation s
+  | "Add" :: "Support" :: s           => "Support" :: fixAbbreviation s
+  | "add" :: "Support" :: s           => "support" :: fixAbbreviation s
+  | "add" :: "_" :: "support" :: s    => "support" :: fixAbbreviation s
+  | "Add" :: "TSupport" :: s          => "TSupport" :: fixAbbreviation s
+  | "add" :: "TSupport" :: s          => "tsupport" :: fixAbbreviation s
+  | "add" :: "_" :: "tsupport" :: s   => "tsupport" :: fixAbbreviation s
+  | "Add" :: "Indicator" :: s         => "Indicator" :: fixAbbreviation s
+  | "add" :: "Indicator" :: s         => "indicator" :: fixAbbreviation s
+  | "add" :: "_" :: "indicator" :: s  => "indicator" :: fixAbbreviation s
+  | "is" :: "Even" :: s             => "even" :: fixAbbreviation s
+  | "Is" :: "Even" :: s             => "Even" :: fixAbbreviation s
+  -- "Regular" is well-used in mathlib with various meanings (e.g. in
+  -- measure theory) and a direct translation
+  -- "regular" --> ["add", "Regular"] in `nameDict` above seems error-prone.
+  | "is" :: "Regular" :: s            => "isAddRegular" :: fixAbbreviation s
+  | "Is" :: "Regular" :: s            => "IsAddRegular" :: fixAbbreviation s
+  | "is" :: "Left" :: "Regular" :: s  => "isAddLeftRegular" :: fixAbbreviation s
+  | "Is" :: "Left" :: "Regular" :: s  => "IsAddLeftRegular" :: fixAbbreviation s
+  | "is" :: "Right" :: "Regular" :: s => "isAddRightRegular" :: fixAbbreviation s
+  | "Is" :: "Right" :: "Regular" :: s => "IsAddRightRegular" :: fixAbbreviation s
+  | "Has" :: "Fundamental" :: "Domain" :: s => "HasAddFundamentalDomain" :: fixAbbreviation s
+  | "has" :: "Fundamental" :: "Domain" :: s => "hasAddFundamentalDomain" :: fixAbbreviation s
+  | "Quotient" :: "Measure" :: s => "AddQuotientMeasure" :: fixAbbreviation s
+  | "quotient" :: "Measure" :: s => "addQuotientMeasure" :: fixAbbreviation s
+  -- the capitalization heuristic of `applyNameDict` doesn't work in the following cases
+  | "HSmul" :: s                      => "HSMul" :: fixAbbreviation s -- from `HPow`
+  | "NSmul" :: s                      => "NSMul" :: fixAbbreviation s -- from `NPow`
+  | "Nsmul" :: s                      => "NSMul" :: fixAbbreviation s -- from `Pow`
+  | "ZSmul" :: s                      => "ZSMul" :: fixAbbreviation s -- from `ZPow`
+  | "neg" :: "Fun" :: s               => "invFun" :: fixAbbreviation s
+  | "Neg" :: "Fun" :: s               => "InvFun" :: fixAbbreviation s
+  | "unique" :: "Prods" :: s          => "uniqueSums" :: fixAbbreviation s
+  | "Unique" :: "Prods" :: s          => "UniqueSums" :: fixAbbreviation s
+  | "order" :: "Of" :: s              => "addOrderOf" :: fixAbbreviation s
+  | "Order" :: "Of" :: s              => "AddOrderOf" :: fixAbbreviation s
+  | "is"::"Of"::"Fin"::"Order"::s     => "isOfFinAddOrder" :: fixAbbreviation s
+  | "Is"::"Of"::"Fin"::"Order"::s     => "IsOfFinAddOrder" :: fixAbbreviation s
+  | "is" :: "Central" :: "Scalar" :: s  => "isCentralVAdd" :: fixAbbreviation s
+  | "Is" :: "Central" :: "Scalar" :: s  => "IsCentralVAdd" :: fixAbbreviation s
+  | "is" :: "Scalar" :: "Tower" :: s  => "vaddAssocClass" :: fixAbbreviation s
+  | "Is" :: "Scalar" :: "Tower" :: s  => "VAddAssocClass" :: fixAbbreviation s
+  | "function" :: "_" :: "add" :: "Semiconj" :: s
+                                      => "function" :: "_" :: "semiconj" :: fixAbbreviation s
+  | "function" :: "_" :: "add" :: "Commute" :: s
+                                      => "function" :: "_" :: "commute" :: fixAbbreviation s
+  | "Zero" :: "Le" :: "Part" :: s         => "PosPart" :: fixAbbreviation s
+  | "Le" :: "Zero" :: "Part" :: s         => "NegPart" :: fixAbbreviation s
+  | "zero" :: "Le" :: "Part" :: s         => "posPart" :: fixAbbreviation s
+  | "le" :: "Zero" :: "Part" :: s         => "negPart" :: fixAbbreviation s
+  | "Division" :: "Add" :: "Monoid" :: s => "SubtractionMonoid" :: fixAbbreviation s
+  | "division" :: "Add" :: "Monoid" :: s => "subtractionMonoid" :: fixAbbreviation s
+  | "Sub" :: "Neg" :: "Zero" :: "Add" :: "Monoid" :: s => "SubNegZeroMonoid" :: fixAbbreviation s
+  | "sub" :: "Neg" :: "Zero" :: "Add" :: "Monoid" :: s => "subNegZeroMonoid" :: fixAbbreviation s
+  | "modular" :: "Character" :: s => "addModularCharacter" :: fixAbbreviation s
+  | "Modular" :: "Character" :: s => "AddModularCharacter" :: fixAbbreviation s
+  | x :: s                            => x :: fixAbbreviation s
+  | []                                => []
+
+/--
+Autogenerate additive name.
+This runs in several steps:
+1) Split according to capitalisation rule and at `_`.
+2) Apply word-by-word translation rules.
+3) Fix up abbreviations that are not word-by-word translations, like "addComm" or "Nonneg".
+-/
+def guessName : String → String :=
+  String.mapTokens '\'' <|
+  fun s =>
+    String.join <|
+    fixAbbreviation <|
+    applyNameDict <|
+    s.splitCase
+
+end ToAdditive

--- a/Mathlib/Topology/ContinuousMap/StarOrdered.lean
+++ b/Mathlib/Topology/ContinuousMap/StarOrdered.lean
@@ -80,8 +80,8 @@ instance instStarOrderedRing {R : Type*}
         StarOrderedRing.le_iff]
       rintro ⟨p, hp_mem, hp⟩
       induction hp_mem using AddSubmonoid.closure_induction_left generalizing f g with
-      | one => exact ⟨0, zero_mem _, by ext x; congrm($(hp) x)⟩
-      | mul_left s s_mem p p_mem hp' =>
+      | zero => exact ⟨0, zero_mem _, by ext x; congrm($(hp) x)⟩
+      | add_left s s_mem p p_mem hp' =>
         obtain ⟨s, rfl⟩ := s_mem
         simp only at *
         have h₀ : (star s * s + p) 0 = 0 := by simpa using congr($(hp) 0).symm
@@ -99,8 +99,8 @@ instance instStarOrderedRing {R : Type*}
       | mem s s_mem =>
         obtain ⟨s, rfl⟩ := s_mem
         exact fun x ↦ le_add_of_nonneg_right (star_mul_self_nonneg (s x))
-      | one => simp
-      | mul g₁ g₂ _ _ h₁ h₂ => calc
+      | zero => simp
+      | add g₁ g₂ _ _ h₁ h₂ => calc
           f ≤ f + g₁ := h₁ f
           _ ≤ (f + g₁) + g₂ := h₂ (f + g₁)
           _ = f + (g₁ + g₂) := add_assoc _ _ _


### PR DESCRIPTION
Currently, `to_additive` does not translate binder names like `(one : motive 0 (zero_mem _))` in `AddSubmonoid.closure_induction`. This makes `induction` tactic create confusing case names. This PR makes `to_additive` also translate binder names in the declaration.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
