### PR TITLE
[Merged by Bors] - feat: list exists unique decidability

### DIFF
--- a/Mathlib/Logic/ExistsUnique.lean
+++ b/Mathlib/Logic/ExistsUnique.lean
@@ -141,6 +141,7 @@ theorem ExistsUnique.unique₂ {p : α → Sort*} [∀ x, Subsingleton (p x)]
   simp only [existsUnique_iff_exists] at h
   exact h.unique ⟨hpy₁, hqy₁⟩ ⟨hpy₂, hqy₂⟩
 
+/-- This invokes the two `Decidable` arguments $O(n)$ times. -/
 instance List.decidableBExistsUnique {α : Type*} [DecidableEq α] (p : α → Prop) [DecidablePred p] :
     (l : List α) → Decidable (∃! x, x ∈ l ∧ p x)
   | [] => .isFalse <| by simp

--- a/Mathlib/Logic/ExistsUnique.lean
+++ b/Mathlib/Logic/ExistsUnique.lean
@@ -149,5 +149,5 @@ instance List.decidableBExistsUnique {α : Type*} [DecidableEq α] (p : α → P
       decidable_of_iff (∀ y ∈ xs, p y → x = y) (⟨fun h ↦ ⟨x, by grind⟩,
         fun ⟨z, h⟩ y hy hp ↦ (h.2 x ⟨mem_cons_self, hx⟩).trans (by grind)⟩)
     else
-      have := List.decidableBExistUnique p xs
+      have := List.decidableBExistsUnique p xs
       decidable_of_iff (∃! x, x ∈ xs ∧ p x) (by grind)

--- a/Mathlib/Logic/ExistsUnique.lean
+++ b/Mathlib/Logic/ExistsUnique.lean
@@ -144,7 +144,7 @@ theorem ExistsUnique.unique₂ {p : α → Sort*} [∀ x, Subsingleton (p x)]
 instance List.decidableBExU {α : Type*} [DecidableEq α] (p : α → Prop) [DecidablePred p]
     (l : List α) :
     Decidable (∃! x, x ∈ l ∧ p x) :=
-  decidable_of_iff (∃ y ∈ l, ∀ x ∈ l, p x ↔ x = y) (⟨
+  decidable_of_iff (∃ y ∈ l, ∀ x ∈ l, p x ↔ x = y) ⟨
     fun ⟨x, hx, h⟩ ↦ ⟨x, ⟨hx, (h x hx).mpr rfl⟩, fun y hy ↦ (h y hy.1).mp hy.2⟩,
     fun ⟨y, hy, h⟩ ↦ ⟨y, hy.1, fun x hx ↦ ⟨(h x ⟨hx, ·⟩), (· ▸ hy.2)⟩⟩
-  ⟩)
+  ⟩

--- a/Mathlib/Logic/ExistsUnique.lean
+++ b/Mathlib/Logic/ExistsUnique.lean
@@ -141,7 +141,7 @@ theorem ExistsUnique.unique₂ {p : α → Sort*} [∀ x, Subsingleton (p x)]
   simp only [existsUnique_iff_exists] at h
   exact h.unique ⟨hpy₁, hqy₁⟩ ⟨hpy₂, hqy₂⟩
 
-instance List.decidableBExistUnique {α : Type*} [DecidableEq α] (p : α → Prop) [DecidablePred p] :
+instance List.decidableBExistsUnique {α : Type*} [DecidableEq α] (p : α → Prop) [DecidablePred p] :
     (l : List α) → Decidable (∃! x, x ∈ l ∧ p x)
   | [] => .isFalse <| by simp
   | x :: xs =>

--- a/Mathlib/Logic/ExistsUnique.lean
+++ b/Mathlib/Logic/ExistsUnique.lean
@@ -140,3 +140,11 @@ theorem ExistsUnique.unique₂ {p : α → Sort*} [∀ x, Subsingleton (p x)]
     (hpy₁ : p y₁) (hqy₁ : q y₁ hpy₁) (hpy₂ : p y₂) (hqy₂ : q y₂ hpy₂) : y₁ = y₂ := by
   simp only [existsUnique_iff_exists] at h
   exact h.unique ⟨hpy₁, hqy₁⟩ ⟨hpy₂, hqy₂⟩
+
+instance List.decidableBExU {α : Type*} [DecidableEq α] (p : α → Prop) [DecidablePred p]
+    (l : List α) :
+    Decidable (∃! x, x ∈ l ∧ p x) :=
+  decidable_of_iff (∃ y ∈ l, ∀ x ∈ l, p x ↔ x = y) (⟨
+    fun ⟨x, hx, h⟩ ↦ ⟨x, ⟨hx, (h x hx).mpr rfl⟩, fun y hy ↦ (h y hy.1).mp hy.2⟩,
+    fun ⟨y, hy, h⟩ ↦ ⟨y, hy.1, fun x hx ↦ ⟨(h x ⟨hx, ·⟩), (· ▸ hy.2)⟩⟩
+  ⟩)

--- a/Mathlib/Logic/ExistsUnique.lean
+++ b/Mathlib/Logic/ExistsUnique.lean
@@ -146,18 +146,8 @@ instance List.decidableBExistUnique {α : Type*} [DecidableEq α] (p : α → Pr
   | [] => .isFalse <| by simp
   | x :: xs =>
     if hx : p x then
-      decidable_of_iff (∀ y ∈ xs, p y → x = y) (by
-        refine ⟨fun h ↦ ⟨x, ⟨⟨mem_cons_self, hx⟩, fun y hy ↦ ?_⟩⟩, fun ⟨z, h⟩ y hy hp ↦ ?_⟩
-        · rcases List.eq_or_mem_of_mem_cons hy.1 with (rfl | hxs)
-          · rfl
-          · exact (h y hxs hy.2).symm
-        · exact (h.2 x ⟨mem_cons_self, hx⟩).trans (h.2 y ⟨mem_cons_of_mem x hy, hp⟩).symm)
+      decidable_of_iff (∀ y ∈ xs, p y → x = y) (⟨fun h ↦ ⟨x, by grind⟩,
+        fun ⟨z, h⟩ y hy hp ↦ (h.2 x ⟨mem_cons_self, hx⟩).trans (by grind)⟩)
     else
-      letI := List.decidableBExistUnique p xs
-      decidable_of_iff (∃! x, x ∈ xs ∧ p x) (by
-        refine ⟨fun ⟨z, h⟩ ↦ ⟨z, ⟨mem_cons_of_mem x h.1.1, h.1.2⟩, fun y hy ↦ h.2 y ⟨?_, hy.2⟩⟩,
-          fun ⟨z, hy, h⟩ ↦ ⟨z, ⟨?_, hy.2⟩, fun y hy ↦ h y ⟨mem_cons_of_mem x hy.1, hy.2⟩⟩⟩
-        all_goals
-          rcases List.eq_or_mem_of_mem_cons hy.1 with (rfl | hxs)
-          · exact hx.elim hy.2
-          · exact hxs)
+      have := List.decidableBExistUnique p xs
+      decidable_of_iff (∃! x, x ∈ xs ∧ p x) (by grind)


### PR DESCRIPTION
The `ExistsUnique` analog to `List.decidableBEx`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
