### PR TITLE
[Merged by Bors] - feat: computable shrink

### DIFF
--- a/Mathlib/Logic/Small/Defs.lean
+++ b/Mathlib/Logic/Small/Defs.lean
@@ -43,12 +43,12 @@ def Shrink (α : Type v) [Small.{w} α] : Type w :=
 
 /-- A computable implementation of `equivShrink`
 
-  Justification of safeness:
-    `Shrink α` has no memory layout in the compiler that needs to be conformed to.
-    There is no other computable way to construct or destructure an object of type `Shrink α`.
-    There is also no other computable way to modify the content of a shrink
+  The `implemented_by` using this to implement `equivShrink` is safe because:
+  * `Shrink α` has no memory layout in the compiler that needs to be conformed to.
+  * There is no other computable way to construct or destructure an object of type `Shrink α`.
+  * There is also no other computable way to modify the content of a shrink
     (as it always needs `Classical.choose_spec`).
-    As a consequence adding this implemented_by is safe -/
+  * As a consequence adding this implemented_by is safe. -/
 @[inline]
 private unsafe def equivShrinkImpl (α : Type v) [Small.{u, v} α] : α ≃ Shrink.{u, v} α :=
   ⟨unsafeCast, unsafeCast, lcProof, lcProof⟩

--- a/Mathlib/Logic/Small/Defs.lean
+++ b/Mathlib/Logic/Small/Defs.lean
@@ -41,13 +41,14 @@ theorem Small.mk' {α : Type v} {S : Type w} (e : α ≃ S) : Small.{w} α :=
 def Shrink (α : Type v) [Small.{w} α] : Type w :=
   Classical.choose (@Small.equiv_small α _)
 
-/-- A computable implementation of `equivShrink`
+/--
+A computable implementation of `equivShrink`
 
-  The `implemented_by` using this to implement `equivShrink` is safe because:
-  * `Shrink α` has no memory layout in the compiler that needs to be conformed to.
-  * There is no other computable way to construct or destructure an object of type `Shrink α`.
-  * There is also no other computable way to modify the content of a shrink
-    (as it always needs `Classical.choose_spec`).
+The `implemented_by` using this to implement `equivShrink` is safe because:
+* `Shrink α` has no memory layout in the compiler that needs to be conformed to.
+* There is no other computable way to construct or destructure an object of type `Shrink α`.
+* There is also no other computable way to modify the content of a shrink
+  (as it always needs `Classical.choose_spec`).
 -/
 @[inline]
 private unsafe def equivShrinkImpl (α : Type v) [Small.{u, v} α] : α ≃ Shrink.{u, v} α :=

--- a/Mathlib/Logic/Small/Defs.lean
+++ b/Mathlib/Logic/Small/Defs.lean
@@ -41,7 +41,14 @@ theorem Small.mk' {α : Type v} {S : Type w} (e : α ≃ S) : Small.{w} α :=
 def Shrink (α : Type v) [Small.{w} α] : Type w :=
   Classical.choose (@Small.equiv_small α _)
 
-/-- A computable implementation of `equivShrink` -/
+/-- A computable implementation of `equivShrink`
+
+  Justification of safeness:
+    `Shrink α` has no memory layout in the compiler that needs to be conformed to.
+    There is no other computable way to construct or destructure an object of type `Shrink α`.
+    There is also no other computable way to modify the content of a shrink
+    (as it always needs `Classical.choose_spec`).
+    As a consequence adding this implemented_by is safe -/
 @[inline]
 private unsafe def equivShrinkImpl (α : Type v) [Small.{u, v} α] : α ≃ Shrink.{u, v} α :=
   ⟨unsafeCast, unsafeCast, lcProof, lcProof⟩

--- a/Mathlib/Logic/Small/Defs.lean
+++ b/Mathlib/Logic/Small/Defs.lean
@@ -52,6 +52,7 @@ def Shrink (α : Type v) [Small.{w} α] : Type w :=
     There is also no other computable way to modify the content of a shrink
     (as it always needs `Classical.choose_spec`).
     As a consequence adding this implemented_by is safe -/
+@[inline]
 private unsafe def equivShrinkImpl (α : Type v) [Small.{u, v} α] : α ≃ Shrink.{u, v} α :=
   ⟨unsafeCast, unsafeCast, lcProof, lcProof⟩
 

--- a/Mathlib/Logic/Small/Defs.lean
+++ b/Mathlib/Logic/Small/Defs.lean
@@ -48,7 +48,7 @@ def Shrink (α : Type v) [Small.{w} α] : Type w :=
   * There is no other computable way to construct or destructure an object of type `Shrink α`.
   * There is also no other computable way to modify the content of a shrink
     (as it always needs `Classical.choose_spec`).
-  * As a consequence adding this implemented_by is safe. -/
+-/
 @[inline]
 private unsafe def equivShrinkImpl (α : Type v) [Small.{u, v} α] : α ≃ Shrink.{u, v} α :=
   ⟨unsafeCast, unsafeCast, lcProof, lcProof⟩

--- a/Mathlib/Logic/Small/Defs.lean
+++ b/Mathlib/Logic/Small/Defs.lean
@@ -42,7 +42,7 @@ def Shrink (α : Type v) [Small.{w} α] : Type w :=
   Classical.choose (@Small.equiv_small α _)
 
 /--
-A computable implementation of `equivShrink`
+A computable implementation of `equivShrink`.
 
 The `implemented_by` using this to implement `equivShrink` is safe because:
 * `Shrink α` has no memory layout in the compiler that needs to be conformed to.

--- a/Mathlib/Logic/Small/Defs.lean
+++ b/Mathlib/Logic/Small/Defs.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Kim Morrison
+Authors: Kim Morrison, William Sørensen, Robin Arnez
 -/
 import Mathlib.Logic.Equiv.Defs
 import Mathlib.Tactic.MkIffOfInductiveProp
@@ -41,17 +41,7 @@ theorem Small.mk' {α : Type v} {S : Type w} (e : α ≃ S) : Small.{w} α :=
 def Shrink (α : Type v) [Small.{w} α] : Type w :=
   Classical.choose (@Small.equiv_small α _)
 
-/-- A computable implementation of `equivShrink`
-
-  Thanks @Rob23oba
-  https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/Making.20Shrink.20computable/near/522918952
-
-  Justification of safeness:
-    `Shrink α` has no memory layout in the compiler that needs to be conformed to.
-    There is no other computable way to construct or destructure an object of type `Shrink α`.
-    There is also no other computable way to modify the content of a shrink
-    (as it always needs `Classical.choose_spec`).
-    As a consequence adding this implemented_by is safe -/
+/-- A computable implementation of `equivShrink` -/
 @[inline]
 private unsafe def equivShrinkImpl (α : Type v) [Small.{u, v} α] : α ≃ Shrink.{u, v} α :=
   ⟨unsafeCast, unsafeCast, lcProof, lcProof⟩


### PR DESCRIPTION
It is very useful for `QPF` to have computable shrink.

Justification of safeness:

>   `Shrink α` has no memory layout in the compiler that needs to be conformed to. There is no other computable way to construct or destructure an object of type `Shrink α`. There is also no other computable way to modify the content of a shrink (as it always needs `Classical.choose_spec`). As a consequence adding this implemented_by is safe 

As discussed on the thread:  https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/Making.20Shrink.20computable/near/522918952

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
