### PR TITLE
[Merged by Bors] - feat: add `Matrix.vecMulVecLinear`

### DIFF
--- a/Mathlib/LinearAlgebra/Matrix/ToLin.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLin.lean
@@ -273,6 +273,27 @@ lemma Matrix.linearIndependent_cols_of_isUnit {R : Type*} [CommRing R] [Fintype 
 
 end mulVec
 
+section vecMulVec
+variable {m n R S A : Type*}
+variable [Semiring R] [Semiring S] [NonUnitalSemiring A] [Module R A] [Module S A]
+variable [SMulCommClass S R A] [SMulCommClass S A A] [IsScalarTower R A A]
+
+variable (R S) in
+/-- `vecMulVec` as a bilinear map.
+
+When `A` is noncommutative, `R` and `S` can be instantiated as `vecMulVecLinear A Aᵐᵒᵖ`. -/
+@[simps]
+def vecMulVecLinear : (m → A) →ₗ[R] (n → A) →ₗ[S] Matrix m n A where
+  toFun x := {
+    toFun y := vecMulVec x y
+    map_add' _ _ := vecMulVec_add _ _ _
+    map_smul' _ _ := vecMulVec_smul _ _ _
+  }
+  map_add' _ _ := LinearMap.ext fun _ => add_vecMulVec _ _ _
+  map_smul' _ _ := LinearMap.ext fun _ => smul_vecMulVec _ _ _
+
+end vecMulVec
+
 section ToMatrix'
 
 variable {R : Type*} [CommSemiring R]

--- a/Mathlib/LinearAlgebra/Matrix/ToLin.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLin.lean
@@ -283,7 +283,7 @@ variable (R S) in
 
 When `A` is noncommutative, `R` and `S` can be instantiated as `vecMulVecLinear A Aᵐᵒᵖ`. -/
 @[simps]
-def vecMulVecLinear : (m → A) →ₗ[R] (n → A) →ₗ[S] Matrix m n A where
+def vecMulVecBilin : (m → A) →ₗ[R] (n → A) →ₗ[S] Matrix m n A where
   toFun x :=
     { toFun y := vecMulVec x y
       map_add' _ _ := vecMulVec_add _ _ _

--- a/Mathlib/LinearAlgebra/Matrix/ToLin.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLin.lean
@@ -284,11 +284,10 @@ variable (R S) in
 When `A` is noncommutative, `R` and `S` can be instantiated as `vecMulVecLinear A Aᵐᵒᵖ`. -/
 @[simps]
 def vecMulVecLinear : (m → A) →ₗ[R] (n → A) →ₗ[S] Matrix m n A where
-  toFun x := {
-    toFun y := vecMulVec x y
-    map_add' _ _ := vecMulVec_add _ _ _
-    map_smul' _ _ := vecMulVec_smul _ _ _
-  }
+  toFun x :=
+    { toFun y := vecMulVec x y
+      map_add' _ _ := vecMulVec_add _ _ _
+      map_smul' _ _ := vecMulVec_smul _ _ _ }
   map_add' _ _ := LinearMap.ext fun _ => add_vecMulVec _ _ _
   map_smul' _ _ := LinearMap.ext fun _ => smul_vecMulVec _ _ _
 


### PR DESCRIPTION
This is the bilinear version of `Matrix.vecMulVec`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
