### PR TITLE
feat(Combinatorics): basic definition of simplicial complexes

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2869,6 +2869,7 @@ import Mathlib.Combinatorics.SimpleGraph.Turan
 import Mathlib.Combinatorics.SimpleGraph.Tutte
 import Mathlib.Combinatorics.SimpleGraph.UniversalVerts
 import Mathlib.Combinatorics.SimpleGraph.Walk
+import Mathlib.Combinatorics.SimplicialComplex.Basic
 import Mathlib.Combinatorics.Young.SemistandardTableau
 import Mathlib.Combinatorics.Young.YoungDiagram
 import Mathlib.Computability.Ackermann

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2870,6 +2870,7 @@ import Mathlib.Combinatorics.SimpleGraph.Tutte
 import Mathlib.Combinatorics.SimpleGraph.UniversalVerts
 import Mathlib.Combinatorics.SimpleGraph.Walk
 import Mathlib.Combinatorics.SimplicialComplex.Basic
+import Mathlib.Combinatorics.SimplicialComplex.Hom
 import Mathlib.Combinatorics.Young.SemistandardTableau
 import Mathlib.Combinatorics.Young.YoungDiagram
 import Mathlib.Computability.Ackermann

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2871,6 +2871,7 @@ import Mathlib.Combinatorics.SimpleGraph.UniversalVerts
 import Mathlib.Combinatorics.SimpleGraph.Walk
 import Mathlib.Combinatorics.SimplicialComplex.Basic
 import Mathlib.Combinatorics.SimplicialComplex.Category
+import Mathlib.Combinatorics.SimplicialComplex.FacePoset
 import Mathlib.Combinatorics.SimplicialComplex.Hom
 import Mathlib.Combinatorics.Young.SemistandardTableau
 import Mathlib.Combinatorics.Young.YoungDiagram

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2870,6 +2870,7 @@ import Mathlib.Combinatorics.SimpleGraph.Tutte
 import Mathlib.Combinatorics.SimpleGraph.UniversalVerts
 import Mathlib.Combinatorics.SimpleGraph.Walk
 import Mathlib.Combinatorics.SimplicialComplex.Basic
+import Mathlib.Combinatorics.SimplicialComplex.Category
 import Mathlib.Combinatorics.SimplicialComplex.Hom
 import Mathlib.Combinatorics.Young.SemistandardTableau
 import Mathlib.Combinatorics.Young.YoungDiagram

--- a/Mathlib/Combinatorics/SimplicialComplex/Basic.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Basic.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2025 Sebastian Kumar, Xiangyu Li. All rights
+reserved. Released under Apache 2.0 license as described in the file
+LICENSE.
+Authors: Sebastian Kumar, Xiangyu Li
+-/
+import Mathlib.Data.Finset.Image
+
+/-!
+# Simplicial complexes
+
+This file introduces finite (abstract) simplicial complexes in a purely combinatorial form.
+
+A simplicial complex on a vertex type `V` is a downward-closed set of finite subsets of `V`
+(its *faces*).
+
+Only the basic structure and elementary remarks appear here. Morphisms, categorical bundling,
+and geometric realisation are handled in later files.
+
+## Main definitions
+
+* `SimplicialComplex V` :
+  a structure with `faces : Set (Finset V)` which is closed under taking subsets.
+* `Face X` :
+  the subtype of faces of a given complex `X` (i.e. `Finset V` equipped with the proof
+  that it lies in `X.faces`).
+
+## Implementation notes
+
+* We do not assume that the empty face belongs to `faces`; if a later development
+  requires this, it should be added as an extra hypothesis.
+* We do not require singletons to be a face.
+
+## References
+
+* <https://en.wikipedia.org/wiki/Simplicial_complex>
+
+## Tags
+
+simplicial complex, combinatorial topology
+-/
+
+open Function
+
+universe u
+
+/-- A simplicial complex on a vertex type `V` is a downward‑closed family
+of finite vertex sets (faces). -/
+@[ext] structure SimplicialComplex (V : Type u) where
+  /-- The collection of faces (finite vertex sets). -/
+  faces : Set (Finset V)
+  /-- Downward closure: every subset of a face is again a face. -/
+  downward_closed :
+    ∀ ⦃s t : Finset V⦄, s ∈ faces → t ⊆ s → t ∈ faces
+
+namespace SimplicialComplex
+
+variable {V : Type u}
+
+/-- A face of `X` (as a subtype). -/
+abbrev Face (X : SimplicialComplex V) := {A : Finset V // A ∈ X.faces}
+
+end SimplicialComplex

--- a/Mathlib/Combinatorics/SimplicialComplex/Basic.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Basic.lean
@@ -1,7 +1,6 @@
 /-
-Copyright (c) 2025 Sebastian Kumar, Xiangyu Li. All rights
-reserved. Released under Apache 2.0 license as described in the file
-LICENSE.
+Copyright (c) 2025 Sebastian Kumar, Xiangyu Li. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sebastian Kumar, Xiangyu Li
 -/
 import Mathlib.Data.Finset.Image

--- a/Mathlib/Combinatorics/SimplicialComplex/Basic.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2025 Sebastian Kumar, Xiangyu Li. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sebastian Kumar, Xiangyu Li
 -/
-import Mathlib.Data.Finset.Image
+import Mathlib.Data.Finset.Defs
 
 /-!
 # Simplicial complexes

--- a/Mathlib/Combinatorics/SimplicialComplex/Basic.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2025 Sebastian Kumar, Xiangyu Li. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sebastian Kumar, Xiangyu Li
 -/
-import Mathlib.Data.Finset.Defs
+import Mathlib.Data.Finset.Image
 
 /-!
 # Simplicial complexes
@@ -21,18 +21,14 @@ and geometric realisation are handled in later files.
 * `SimplicialComplex V` :
   a structure with `faces : Set (Finset V)` which is closed under taking subsets.
 * `Face X` :
-  the subtype of faces of a given complex `X` (i.e. `Finset V` equipped with the proof
-  that it lies in `X.faces`).
+  the subtype of nonempty faces of a given complex `X` (i.e. `Finset V` equipped with the proof
+  that it lies in `X.faces` and is nonempty).
 
 ## Implementation notes
 
 * We do not assume that the empty face belongs to `faces`; if a later development
   requires this, it should be added as an extra hypothesis.
 * We do not require singletons to be a face.
-
-## References
-
-* <https://en.wikipedia.org/wiki/Simplicial_complex>
 
 ## Tags
 
@@ -51,12 +47,3 @@ of finite vertex sets (faces). -/
   /-- Downward closure: every subset of a face is again a face. -/
   downward_closed :
     ∀ ⦃s t : Finset V⦄, s ∈ faces → t ⊆ s → t ∈ faces
-
-namespace SimplicialComplex
-
-variable {V : Type u}
-
-/-- A face of `X` (as a subtype). -/
-abbrev Face (X : SimplicialComplex V) := {A : Finset V // A ∈ X.faces}
-
-end SimplicialComplex

--- a/Mathlib/Combinatorics/SimplicialComplex/Category.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Category.lean
@@ -5,7 +5,6 @@ Authors: Xiangyu Li
 -/
 import Mathlib.Combinatorics.SimplicialComplex.Hom
 import Mathlib.CategoryTheory.Iso
-import Mathlib.CategoryTheory.ConcreteCategory.Basic
 
 /-!
 # The category of simplicial complexes (with varying vertex types)

--- a/Mathlib/Combinatorics/SimplicialComplex/Category.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Category.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Xiangyu Li. All rights.
+Copyright (c) 2025 Xiangyu Li. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Xiangyu Li
 -/

--- a/Mathlib/Combinatorics/SimplicialComplex/Category.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Category.lean
@@ -1,0 +1,134 @@
+/-
+Copyright (c) 2025 Xiangyu Li. All rights.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Xiangyu Li
+-/
+import Mathlib.Combinatorics.SimplicialComplex.Hom
+import Mathlib.CategoryTheory.Iso
+import Mathlib.CategoryTheory.ConcreteCategory.Basic
+
+/-!
+# The category of simplicial complexes (with varying vertex types)
+
+We build a category whose objects are pairs `(U, X)` with a type of vertices `U`
+equipped with `[DecidableEq U]` and a simplicial complex `X : SimplicialComplex U`.
+Morphisms are simplicial maps between the underlying complexes.
+
+## Main definitions
+
+* `SimplicialComplexCat` — objects of the category.
+* `SimplicialComplexCat.Hom` — morphisms (simplicial maps).
+* `Category SimplicialComplexCat` — the category instance.
+* `SimplicialComplexCat.hom_ext` — extensionality for morphisms.
+* `SimplicialComplexCat.Iso.isoOfEquiv` — build an iso from a vertex equivalence that
+  preserves faces in both directions.
+
+## Main lemmas
+
+* Pointwise evaluation lemmas:
+  `id_toFun`, `comp_toFun`, `id_apply`, `comp_apply`.
+
+## Tags
+
+simplicial complex, category, simplicial map
+-/
+
+open CategoryTheory SimplicialComplex
+
+universe u
+
+/-- Objects for the category of simpliclicial complexes:
+a vertex type with `[DecidableEq]` and a simplicial complex on it. -/
+structure SimplicialComplexCat where
+  /-- The vertex type underlying the simplicial complex. -/
+  U : Type u
+  /-- Decidable equality on the vertex type `U`. -/
+  [decU : DecidableEq U]
+  /-- The simplicial complex on the vertex type `U`. -/
+  X : SimplicialComplex U
+attribute [instance] SimplicialComplexCat.decU
+
+namespace SimplicialComplexCat
+
+@[simp] lemma eta (A : SimplicialComplexCat) :
+    SimplicialComplexCat.mk A.U A.X = A := by cases A; rfl
+
+/-- Morphisms are simplicial maps between the underlying complexes. -/
+abbrev Hom (A B : SimplicialComplexCat) :=
+  SimplicialComplex.Hom A.X B.X
+
+/-- Category structure on the big category. -/
+instance : Category SimplicialComplexCat where
+  Hom A B := Hom A B
+  id A := SimplicialComplex.Hom.id A.X
+  -- `f ≫ g` is `Hom.comp g f`
+  comp f g := SimplicialComplex.Hom.comp g f
+  id_comp := by
+    intro A B f; simp
+  comp_id := by
+    intro A B f; simp
+  assoc := by
+    intro A B C D f g h; simp
+
+/-- View a morphism as a function on vertices. -/
+instance (A B : SimplicialComplexCat) :
+    CoeFun (A ⟶ B) (fun _ ↦ A.U → B.U) :=
+  ⟨fun φ => φ.toFun⟩
+
+/-- Extensionality: `f g : A ⟶ B` are equal if `∀ x, f x = g x`. -/
+@[ext] lemma hom_ext
+  {A B : SimplicialComplexCat} {f g : A ⟶ B}
+  (h : ∀ x, f x = g x) : f = g := by
+  exact SimplicialComplex.Hom.ext (funext h)
+
+/-- The identity morphism coerces to the identity function on vertices. -/
+@[simp] lemma id_toFun (A : SimplicialComplexCat) :
+    ((𝟙 A : A ⟶ A) : A.U → A.U) = id := rfl
+
+/-- Composition of morphisms coerces to the usual composition of the underlying functions. -/
+@[simp] lemma comp_toFun {A B C : SimplicialComplexCat}
+    (f : B ⟶ C) (g : A ⟶ B) :
+    ((g ≫ f : A ⟶ C) : A.U → C.U) = f.toFun ∘ g.toFun := rfl
+
+/-- Pointwise identity. -/
+@[simp] lemma id_apply (A : SimplicialComplexCat) (x : A.U) :
+    ((𝟙 A : A ⟶ A) : A.U → A.U) x = x := rfl
+
+/-- Pointwise composition. -/
+@[simp] lemma comp_apply {A B C : SimplicialComplexCat}
+    (f : B ⟶ C) (g : A ⟶ B) (x : A.U) :
+    ((g ≫ f : A ⟶ C) : A.U → C.U) x = f (g x) := rfl
+
+namespace Iso
+
+variable {A B : SimplicialComplexCat}
+
+/-- Build a categorical isomorphism from a vertex equivalence that preserves faces in both
+directions. -/
+def isoOfEquiv
+    (e : A.U ≃ B.U)
+    (h₁ : ∀ ⦃s : Finset A.U⦄, s ∈ A.X.faces → s.image e ∈ B.X.faces)
+    (h₂ : ∀ ⦃t : Finset B.U⦄, t ∈ B.X.faces → t.image e.symm ∈ A.X.faces)
+  : A ≅ B :=
+{ hom :=
+  { toFun := e
+    map_faces := by intro s hs; simpa using h₁ hs },
+  inv :=
+  { toFun := e.symm
+    map_faces := by intro t ht; simpa using h₂ ht },
+  hom_inv_id := by
+    ext x; simp,
+  inv_hom_id := by
+    ext y; simp }
+
+@[simp] lemma isoOfEquiv_hom_toFun
+  (e : A.U ≃ B.U) h₁ h₂ :
+  (isoOfEquiv e h₁ h₂).hom.toFun = e := rfl
+
+@[simp] lemma isoOfEquiv_inv_toFun
+  (e : A.U ≃ B.U) h₁ h₂ :
+  (isoOfEquiv e h₁ h₂).inv.toFun = e.symm := rfl
+
+end Iso
+
+end SimplicialComplexCat

--- a/Mathlib/Combinatorics/SimplicialComplex/FacePoset.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/FacePoset.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2025 Xiangyu Li. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Xiangyu Li
+-/
+import Mathlib.CategoryTheory.Category.Basic
+import Mathlib.Combinatorics.SimplicialComplex.Hom
+import Mathlib.CategoryTheory.Functor.Basic
+
+/-!
+# Face poset (as a thin category) of a simplicial complex
+
+For a simplicial complex `X` on vertices `α`, the set of faces `X.faces : Set (Finset α)`
+carries the natural order by inclusion of the underlying finsets. We view the subtype `X.faces`
+as a poset/partial order and promote it to a **thin category**, with a unique morphism `A ⟶ B`
+exactly when `A ≤ B` (i.e. `↑A ⊆ ↑B`). This category will index the geometric realisation diagram.
+
+## Main definitions
+
+* `Category (X.faces)` — a thin category where `Hom A B` is inhabited iff `A ≤ B`.
+* `SimplicialComplex.Hom.face_functor (φ : Hom X Y)` — the functor on face categories
+  induced by a simplicial map, sending a face `s` to its image `φ.image_face s`.
+
+## Implementation notes
+
+* Morphisms are implemented as `PLift ((A : Finset α) ⊆ (B : Finset α))`.
+* Identities and composition use `subset_rfl` and `subset_trans`.
+* This file stays lightweight: only `Category.Basic` and `Functor.Basic` are imported.
+
+## Tags
+
+simplicial complex, face poset, thin category, combinatorics
+-/
+
+namespace SimplicialComplex
+
+variable {α β : Type*}
+variable [DecidableEq α] [DecidableEq β]
+variable {X : SimplicialComplex α} {Y : SimplicialComplex β}
+
+omit [DecidableEq α] in
+/-- Simplify `A ≤ B` to inclusion of the underlying finsets. -/
+@[simp] lemma face_le_iff {A B : X.faces} :
+    (A ≤ B) ↔ ((A : Finset α) ⊆ (B : Finset α)) := Iff.rfl
+
+open CategoryTheory
+
+/-- A thin category structure on `X.Face`, with at most one morphism `A ⟶ B` when `A ≤ B`. -/
+instance : Category (X.faces) where
+  Hom A B := PLift ((A : Finset α) ⊆ (B : Finset α))
+  id _ := ⟨subset_rfl⟩
+  comp f g := ⟨subset_trans f.down g.down⟩
+  id_comp _ := rfl
+  comp_id _ := rfl
+  assoc _ _ _ := rfl
+
+/-- The functor on face-posets induced by a simplicial map. -/
+noncomputable def Hom.face_functor (φ : Hom X Y) :
+    X.faces ⥤ Y.faces where
+  obj s := Hom.image_face φ s
+  map {A B} f := by
+    refine ⟨?subset⟩
+    intro y hy
+    rcases Finset.mem_image.mp hy with ⟨x, hxA, rfl⟩
+    have hxB : (x : α) ∈ (B : Finset α) := f.down hxA
+    exact Finset.mem_image.mpr ⟨x, hxB, rfl⟩
+  map_id _ := rfl
+  map_comp _ _ := rfl
+
+end SimplicialComplex

--- a/Mathlib/Combinatorics/SimplicialComplex/Hom.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Hom.lean
@@ -56,10 +56,7 @@ namespace SimplicialComplex
 
 A term `φ : Hom K L` consists of a function `toFun : U → V` together with
 `map_faces`, which states: for every `s ∈ K.faces`, the image
-`Finset.image toFun s` is in `L.faces`.
-
-The `@[ext]` attribute provides extensionality: two morphisms are equal when
-their `toFun` agree pointwise. -/
+`Finset.image toFun s` is in `L.faces`. -/
 @[ext] structure Hom (K : SimplicialComplex U) (L : SimplicialComplex V) where
   /-- The underlying map on vertices. Use coercion to treat a morphism as `U → V`. -/
   toFun : U → V
@@ -118,5 +115,3 @@ mapping a face along `f ∘ g` equals first mapping along `g` then along `f`. -/
 end Hom
 
 end SimplicialComplex
-
-#lint

--- a/Mathlib/Combinatorics/SimplicialComplex/Hom.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Hom.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2025 Sebastian Kumar, Xiangyu Li. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sebastian Kumar, Xiangyu Li
+-/
+import Mathlib.Combinatorics.SimplicialComplex.Basic
+
+/-!
+# Morphisms of simplicial complexes
+
+This file defines simplicial maps between abstract simplicial complexes.
+
+Given a function `φ : U → V`, the image of a face `s : Finset U` is `s.image φ`.
+A morphism `φ : Hom K L` is a vertex function such that for every `s ∈ K.faces`,
+we have `Finset.image φ s ∈ L.faces`.
+
+We also define identity and composition for these morphisms. The actual category
+instance lives in `Category.lean`, so this file has no category-theory imports.
+
+## Main definitions
+
+* `SimplicialComplex.Hom K L` : a simplicial map `K ⟶ L`.
+* `SimplicialComplex.Iso K L` : an isomorphism of simplicial complexes.
+
+## Main results
+
+* `Hom.comp_id`, `Hom.id_comp`, `Hom.assoc`.
+* `Hom.ext` (extensionality: morphisms equal if their vertex maps are equal).
+* `Hom.image_face` and its compatibility with `id` and `comp`.
+
+## Implementation notes
+
+* Faces are modeled by `Finset`, so we push forward along vertex functions using
+  `Finset.image`. This requires `[DecidableEq]` on the codomain vertex type,
+  because `Finset.image` deduplicates equal vertices.
+* A `Hom` stores only the underlying vertex function `toFun : U → V` together
+  with a proof that faces are preserved. Coercions let you use a morphism
+  directly as a function on vertices.
+
+## Tags
+
+simplicial complex, simplicial map
+-/
+
+open Function
+
+variable {U V W X : Type*}
+variable [DecidableEq U] [DecidableEq V] [DecidableEq W] [DecidableEq X]
+variable {K : SimplicialComplex U} {L : SimplicialComplex V}
+variable {M : SimplicialComplex W} {N : SimplicialComplex X}
+
+namespace SimplicialComplex
+
+/-- A morphism of simplicial complexes sends each face to a face via the
+`Finset.image` of the underlying vertex function.
+
+A term `φ : Hom K L` consists of a function `toFun : U → V` together with
+`map_faces`, which states: for every `s ∈ K.faces`, the image
+`Finset.image toFun s` is in `L.faces`.
+
+The `@[ext]` attribute provides extensionality: two morphisms are equal when
+their `toFun` agree pointwise. -/
+@[ext] structure Hom (K : SimplicialComplex U) (L : SimplicialComplex V) where
+  /-- The underlying map on vertices. Use coercion to treat a morphism as `U → V`. -/
+  toFun : U → V
+  /-- Face preservation: the image of every face of `K` is a face of `L`. -/
+  map_faces :
+    ∀ ⦃s : Finset U⦄, s ∈ K.faces → Finset.image toFun s ∈ L.faces
+
+namespace Hom
+
+/-- Identity morphism on a simplicial complex. -/
+@[simp] protected def id (L : SimplicialComplex V) : Hom L L where
+  toFun := id
+  map_faces := by
+    intro s hs; simpa using hs
+
+/-- Composition of morphisms. (`comp f g = f ∘ g` on vertices.) -/
+def comp (f : Hom L M) (g : Hom K L) : Hom K M where
+  toFun := f.toFun ∘ g.toFun
+  map_faces := by
+    intro s hs
+    have hL : Finset.image g.toFun s ∈ L.faces := g.map_faces hs
+    simpa [Finset.image_image, Function.comp] using f.map_faces hL
+
+omit [DecidableEq U] in
+/-- Associativity of composition. -/
+@[simp] theorem assoc (f : Hom M N) (g : Hom L M) (h : Hom K L) :
+    comp f (comp g h) = comp (comp f g) h := rfl
+
+/-- Right identity. -/
+@[simp] theorem comp_id (f : Hom L M) :
+    comp f (Hom.id _) = f := rfl
+
+omit [DecidableEq U] in
+/-- Left identity. -/
+@[simp] theorem id_comp (f : Hom K L) :
+    comp (Hom.id _) f = f := rfl
+
+/-- The induced map on faces: given a face `s` of `K`, take its `Finset.image`
+under the vertex function to obtain a face of `L`. -/
+@[simps] def image_face (φ : Hom K L) (s : Face K) : Face L :=
+  ⟨s.1.image φ.toFun, by simpa using φ.map_faces s.property⟩
+
+/-- The induced face map of the identity morphism is the identity on faces. -/
+@[simp] lemma image_face_id (s : K.Face) :
+    (Hom.id K).image_face s = s := by
+  ext v; simp [image_face]
+
+omit [DecidableEq U] in
+/-- Compatibility of induced face maps with composition:
+mapping a face along `f ∘ g` equals first mapping along `g` then along `f`. -/
+@[simp] lemma image_face_comp (f : Hom L M) (g : Hom K L) (s : K.Face) :
+    (Hom.comp f g).image_face s = f.image_face (g.image_face s) := by
+  ext v
+  simp [Hom.image_face, Hom.comp, Function.comp, Finset.image_image]
+
+end Hom
+
+end SimplicialComplex

--- a/Mathlib/Combinatorics/SimplicialComplex/Hom.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Hom.lean
@@ -70,7 +70,7 @@ their `toFun` agree pointwise. -/
 namespace Hom
 
 /-- Identity morphism on a simplicial complex. -/
-@[simp] protected def id (L : SimplicialComplex V) : Hom L L where
+protected def id (L : SimplicialComplex V) : Hom L L where
   toFun := id
   map_faces := by
     intro s hs; simpa using hs
@@ -105,7 +105,7 @@ under the vertex function to obtain a face of `L`. -/
 /-- The induced face map of the identity morphism is the identity on faces. -/
 @[simp] lemma image_face_id (s : K.Face) :
     (Hom.id K).image_face s = s := by
-  ext v; simp [image_face]
+  ext v; simp [image_face, SimplicialComplex.Hom.id]
 
 omit [DecidableEq U] in
 /-- Compatibility of induced face maps with composition:
@@ -118,3 +118,5 @@ mapping a face along `f ∘ g` equals first mapping along `g` then along `f`. -/
 end Hom
 
 end SimplicialComplex
+
+#lint

--- a/Mathlib/Combinatorics/SimplicialComplex/Hom.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Hom.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sebastian Kumar, Xiangyu Li
 -/
 import Mathlib.Combinatorics.SimplicialComplex.Basic
+import Mathlib.Data.Finset.Image
 
 /-!
 # Morphisms of simplicial complexes

--- a/Mathlib/Combinatorics/SimplicialComplex/Hom.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Hom.lean
@@ -97,18 +97,18 @@ omit [DecidableEq U] in
 
 /-- The induced map on faces: given a face `s` of `K`, take its `Finset.image`
 under the vertex function to obtain a face of `L`. -/
-@[simps] def image_face (φ : Hom K L) (s : Face K) : Face L :=
+@[simps] def image_face (φ : Hom K L) (s : K.faces) : L.faces :=
   ⟨s.1.image φ.toFun, by simpa using φ.map_faces s.property⟩
 
 /-- The induced face map of the identity morphism is the identity on faces. -/
-@[simp] lemma image_face_id (s : K.Face) :
+@[simp] lemma image_face_id (s : K.faces) :
     (Hom.id K).image_face s = s := by
   ext v; simp [image_face, SimplicialComplex.Hom.id]
 
 omit [DecidableEq U] in
 /-- Compatibility of induced face maps with composition:
 mapping a face along `f ∘ g` equals first mapping along `g` then along `f`. -/
-@[simp] lemma image_face_comp (f : Hom L M) (g : Hom K L) (s : K.Face) :
+@[simp] lemma image_face_comp (f : Hom L M) (g : Hom K L) (s : K.faces) :
     (Hom.comp f g).image_face s = f.image_face (g.image_face s) := by
   ext v
   simp [Hom.image_face, Hom.comp, Function.comp, Finset.image_image]


### PR DESCRIPTION
This PR introduces the basic definition of a finite (abstract) simplicial complex, located in Mathlib/Combinatorics/SimplicialComplex/Basic.lean.

---

This is our first contribution to mathlib. This work was done as part of the Fields Institute Summer Undergraduate Program on formalization in topological combinatorics. Eventually, we aim to formalize Lovasz's proof of the Kneser Conjecture and this is a small stepping stone in that direction. Some other commits will shortly depend on this one.

We would like to acknowledge the Fields Institute for Research in Mathematical Sciences for their sponsorship. We would also like to thank our supervisors, Professor Chris Kapulkin and Mr. Daniel Carranza, for their guidance and support throughout this project. We would also like to thank our group members Tom Lindquist and Quang Minh Nguyen for our fruitful discussions.