### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Idempotents): golf `split_imp_of_iso` using `grind`

### DIFF
--- a/Mathlib/CategoryTheory/Idempotents/Basic.lean
+++ b/Mathlib/CategoryTheory/Idempotents/Basic.lean
@@ -123,11 +123,7 @@ theorem split_imp_of_iso {X X' : C} (φ : X ≅ X') (p : X ⟶ X) (p' : X' ⟶ X
     ∃ (Y' : C) (i' : Y' ⟶ X') (e' : X' ⟶ Y'), i' ≫ e' = 𝟙 Y' ∧ e' ≫ i' = p' := by
   rcases h with ⟨Y, i, e, ⟨h₁, h₂⟩⟩
   use Y, i ≫ φ.hom, φ.inv ≫ e
-  constructor
-  · slice_lhs 2 3 => rw [φ.hom_inv_id]
-    rw [id_comp, h₁]
-  · slice_lhs 2 3 => rw [h₂]
-    rw [hpp', ← assoc, φ.inv_hom_id, id_comp]
+  grind
 
 theorem split_iff_of_iso {X X' : C} (φ : X ≅ X') (p : X ⟶ X) (p' : X' ⟶ X')
     (hpp' : p ≫ φ.hom = φ.hom ≫ p') :


### PR DESCRIPTION
Motivation: Make use of available automation (and shorten the proof).

---
<details>
<summary>Show trace profiling of <code>split_imp_of_iso</code></summary>

### Trace profiling of `split_imp_of_iso` before PR 28127
```diff
diff --git a/Mathlib/CategoryTheory/Idempotents/Basic.lean b/Mathlib/CategoryTheory/Idempotents/Basic.lean
index 208a8b6aa3..624e1605c4 100644
--- a/Mathlib/CategoryTheory/Idempotents/Basic.lean
+++ b/Mathlib/CategoryTheory/Idempotents/Basic.lean
@@ -119,2 +119,3 @@ variable {C}
 
+set_option trace.profiler true in
 theorem split_imp_of_iso {X X' : C} (φ : X ≅ X') (p : X ⟶ X) (p' : X' ⟶ X')
```
```
ℹ [865/865] Built Mathlib.CategoryTheory.Idempotents.Basic
info: Mathlib/CategoryTheory/Idempotents/Basic.lean:121:0: [Elab.command] [0.027523] theorem split_imp_of_iso {X X' : C} (φ : X ≅ X') (p : X ⟶ X) (p' : X' ⟶ X')
        (hpp' : p ≫ φ.hom = φ.hom ≫ p') (h : ∃ (Y : C) (i : Y ⟶ X) (e : X ⟶ Y), i ≫ e = 𝟙 Y ∧ e ≫ i = p) :
        ∃ (Y' : C) (i' : Y' ⟶ X') (e' : X' ⟶ Y'), i' ≫ e' = 𝟙 Y' ∧ e' ≫ i' = p' :=
      by
      rcases h with ⟨Y, i, e, ⟨h₁, h₂⟩⟩
      use Y, i ≫ φ.hom, φ.inv ≫ e
      constructor
      · slice_lhs 2 3 => rw [φ.hom_inv_id]
        rw [id_comp, h₁]
      · slice_lhs 2 3 => rw [h₂]
        rw [hpp', ← assoc, φ.inv_hom_id, id_comp]
  [Elab.definition.header] [0.027154] CategoryTheory.Idempotents.split_imp_of_iso
    [Elab.step] [0.017423] expected type: Prop, term
        ∃ (Y' : C) (i' : Y' ⟶ X') (e' : X' ⟶ Y'), i' ≫ e' = 𝟙 Y' ∧ e' ≫ i' = p'
      [Elab.step] [0.017415] expected type: Prop, term
          Exists✝ fun Y' : C => Exists✝ fun i' : Y' ⟶ X' => Exists✝ fun e' : X' ⟶ Y' => i' ≫ e' = 𝟙 Y' ∧ e' ≫ i' = p'
        [Elab.step] [0.017354] expected type: C → Prop, term
            fun Y' : C => Exists✝ fun i' : Y' ⟶ X' => Exists✝ fun e' : X' ⟶ Y' => i' ≫ e' = 𝟙 Y' ∧ e' ≫ i' = p'
          [Elab.step] [0.017349] expected type: C → Prop, term
              failed to pretty print term (use 'set_option pp.rawOnError true' for raw representation)
            [Elab.step] [0.017306] expected type: Prop, term
                Exists✝ fun i' : Y' ⟶ X' => Exists✝ fun e' : X' ⟶ Y' => i' ≫ e' = 𝟙 Y' ∧ e' ≫ i' = p'
              [Elab.step] [0.017247] expected type: (Y' ⟶ X') → Prop, term
                  fun i' : Y' ⟶ X' => Exists✝ fun e' : X' ⟶ Y' => i' ≫ e' = 𝟙 Y' ∧ e' ≫ i' = p'
                [Elab.step] [0.017243] expected type: (Y' ⟶ X') → Prop, term
                    failed to pretty print term (use 'set_option pp.rawOnError true' for raw representation)
                  [Elab.step] [0.012839] expected type: Prop, term
                      Exists✝ fun e' : X' ⟶ Y' => i' ≫ e' = 𝟙 Y' ∧ e' ≫ i' = p'
                    [Elab.step] [0.012761] expected type: (X' ⟶ Y') → Prop, term
                        fun e' : X' ⟶ Y' => i' ≫ e' = 𝟙 Y' ∧ e' ≫ i' = p'
                      [Elab.step] [0.012754] expected type: (X' ⟶ Y') → Prop, term
                          failed to pretty print term (use 'set_option pp.rawOnError true' for raw representation)
info: Mathlib/CategoryTheory/Idempotents/Basic.lean:121:0: [Elab.async] [0.102831] elaborating proof of CategoryTheory.Idempotents.split_imp_of_iso
  [Elab.definition.value] [0.101372] CategoryTheory.Idempotents.split_imp_of_iso
    [Elab.step] [0.100606] 
          rcases h with ⟨Y, i, e, ⟨h₁, h₂⟩⟩
          use Y, i ≫ φ.hom, φ.inv ≫ e
          constructor
          · slice_lhs 2 3 => rw [φ.hom_inv_id]
            rw [id_comp, h₁]
          · slice_lhs 2 3 => rw [h₂]
            rw [hpp', ← assoc, φ.inv_hom_id, id_comp]
      [Elab.step] [0.100599] 
            rcases h with ⟨Y, i, e, ⟨h₁, h₂⟩⟩
            use Y, i ≫ φ.hom, φ.inv ≫ e
            constructor
            · slice_lhs 2 3 => rw [φ.hom_inv_id]
              rw [id_comp, h₁]
            · slice_lhs 2 3 => rw [h₂]
              rw [hpp', ← assoc, φ.inv_hom_id, id_comp]
        [Elab.step] [0.070851] use Y, i ≫ φ.hom, φ.inv ≫ e
          [Elab.step] [0.030053] try with_reducible use_discharger
            [Elab.step] [0.030041] first
                | with_reducible use_discharger
                | skip
              [Elab.step] [0.030020] with_reducible use_discharger
                [Elab.step] [0.030015] with_reducible use_discharger
                  [Elab.step] [0.030009] with_reducible use_discharger
                    [Elab.step] [0.030004] use_discharger
                      [Elab.step] [0.030000] use_discharger
                        [Elab.step] [0.029995] use_discharger
                          [Elab.step] [0.012909] (apply And.intro✝) <;> use_discharger
                            [Elab.step] [0.012900] focus
                                  apply And.intro✝
                                  with_annotate_state"<;>" skip
                                  all_goals use_discharger
                              [Elab.step] [0.012892] 
                                    apply And.intro✝
                                    with_annotate_state"<;>" skip
                                    all_goals use_discharger
                                [Elab.step] [0.012886] 
                                      apply And.intro✝
                                      with_annotate_state"<;>" skip
                                      all_goals use_discharger
                                  [Elab.step] [0.012667] all_goals use_discharger
                                    [Elab.step] [0.012652] use_discharger
                                      [Elab.step] [0.012648] use_discharger
                                        [Elab.step] [0.012638] use_discharger
        [Elab.step] [0.016204] ·
              slice_lhs 2 3 => rw [φ.hom_inv_id]
              rw [id_comp, h₁]
          [Elab.step] [0.016182] 
                slice_lhs 2 3 => rw [φ.hom_inv_id]
                rw [id_comp, h₁]
            [Elab.step] [0.016176] 
                  slice_lhs 2 3 => rw [φ.hom_inv_id]
                  rw [id_comp, h₁]
              [Elab.step] [0.014739] slice_lhs 2 3 => rw [φ.hom_inv_id]
                [Elab.step] [0.010577] conv => lhs; slice 2 3; (rw [φ.hom_inv_id])
                  [Elab.step] [0.010062] lhs; slice 2 3; (rw [φ.hom_inv_id])
                    [Elab.step] [0.010055] lhs; slice 2 3; (rw [φ.hom_inv_id])
        [Elab.step] [0.012523] ·
              slice_lhs 2 3 => rw [h₂]
              rw [hpp', ← assoc, φ.inv_hom_id, id_comp]
          [Elab.step] [0.012505] 
                slice_lhs 2 3 => rw [h₂]
                rw [hpp', ← assoc, φ.inv_hom_id, id_comp]
            [Elab.step] [0.012500] 
                  slice_lhs 2 3 => rw [h₂]
                  rw [hpp', ← assoc, φ.inv_hom_id, id_comp]
              [Elab.step] [0.010272] slice_lhs 2 3 => rw [h₂]
Build completed successfully.
```

### Trace profiling of `split_imp_of_iso` after PR 28127
```diff
diff --git a/Mathlib/CategoryTheory/Idempotents/Basic.lean b/Mathlib/CategoryTheory/Idempotents/Basic.lean
index 208a8b6aa3..1737437552 100644
--- a/Mathlib/CategoryTheory/Idempotents/Basic.lean
+++ b/Mathlib/CategoryTheory/Idempotents/Basic.lean
@@ -119,2 +119,3 @@ variable {C}
 
+set_option trace.profiler true in
 theorem split_imp_of_iso {X X' : C} (φ : X ≅ X') (p : X ⟶ X) (p' : X' ⟶ X')
@@ -125,7 +126,3 @@ theorem split_imp_of_iso {X X' : C} (φ : X ≅ X') (p : X ⟶ X) (p' : X' ⟶ X
   use Y, i ≫ φ.hom, φ.inv ≫ e
-  constructor
-  · slice_lhs 2 3 => rw [φ.hom_inv_id]
-    rw [id_comp, h₁]
-  · slice_lhs 2 3 => rw [h₂]
-    rw [hpp', ← assoc, φ.inv_hom_id, id_comp]
+  grind
 
```
```
ℹ [865/865] Built Mathlib.CategoryTheory.Idempotents.Basic
info: Mathlib/CategoryTheory/Idempotents/Basic.lean:121:0: [Elab.command] [0.036767] theorem split_imp_of_iso {X X' : C} (φ : X ≅ X') (p : X ⟶ X) (p' : X' ⟶ X')
        (hpp' : p ≫ φ.hom = φ.hom ≫ p') (h : ∃ (Y : C) (i : Y ⟶ X) (e : X ⟶ Y), i ≫ e = 𝟙 Y ∧ e ≫ i = p) :
        ∃ (Y' : C) (i' : Y' ⟶ X') (e' : X' ⟶ Y'), i' ≫ e' = 𝟙 Y' ∧ e' ≫ i' = p' :=
      by
      rcases h with ⟨Y, i, e, ⟨h₁, h₂⟩⟩
      use Y, i ≫ φ.hom, φ.inv ≫ e
      grind
  [Elab.definition.header] [0.036242] CategoryTheory.Idempotents.split_imp_of_iso
    [Elab.step] [0.015287] expected type: Prop, term
        ∃ (Y : C) (i : Y ⟶ X) (e : X ⟶ Y), i ≫ e = 𝟙 Y ∧ e ≫ i = p
      [Elab.step] [0.015276] expected type: Prop, term
          Exists✝ fun Y : C => Exists✝ fun i : Y ⟶ X => Exists✝ fun e : X ⟶ Y => i ≫ e = 𝟙 Y ∧ e ≫ i = p
        [Elab.step] [0.015191] expected type: C → Prop, term
            fun Y : C => Exists✝ fun i : Y ⟶ X => Exists✝ fun e : X ⟶ Y => i ≫ e = 𝟙 Y ∧ e ≫ i = p
          [Elab.step] [0.015184] expected type: C → Prop, term
              failed to pretty print term (use 'set_option pp.rawOnError true' for raw representation)
            [Elab.step] [0.015123] expected type: Prop, term
                Exists✝ fun i : Y ⟶ X => Exists✝ fun e : X ⟶ Y => i ≫ e = 𝟙 Y ∧ e ≫ i = p
              [Elab.step] [0.015040] expected type: (Y ⟶ X) → Prop, term
                  fun i : Y ⟶ X => Exists✝ fun e : X ⟶ Y => i ≫ e = 𝟙 Y ∧ e ≫ i = p
                [Elab.step] [0.015035] expected type: (Y ⟶ X) → Prop, term
                    failed to pretty print term (use 'set_option pp.rawOnError true' for raw representation)
                  [Elab.step] [0.012467] expected type: Prop, term
                      Exists✝ fun e : X ⟶ Y => i ≫ e = 𝟙 Y ∧ e ≫ i = p
                    [Elab.step] [0.012360] expected type: (X ⟶ Y) → Prop, term
                        fun e : X ⟶ Y => i ≫ e = 𝟙 Y ∧ e ≫ i = p
                      [Elab.step] [0.012353] expected type: (X ⟶ Y) → Prop, term
                          failed to pretty print term (use 'set_option pp.rawOnError true' for raw representation)
    [Elab.step] [0.010782] expected type: Prop, term
        ∃ (Y' : C) (i' : Y' ⟶ X') (e' : X' ⟶ Y'), i' ≫ e' = 𝟙 Y' ∧ e' ≫ i' = p'
      [Elab.step] [0.010775] expected type: Prop, term
          Exists✝ fun Y' : C => Exists✝ fun i' : Y' ⟶ X' => Exists✝ fun e' : X' ⟶ Y' => i' ≫ e' = 𝟙 Y' ∧ e' ≫ i' = p'
        [Elab.step] [0.010718] expected type: C → Prop, term
            fun Y' : C => Exists✝ fun i' : Y' ⟶ X' => Exists✝ fun e' : X' ⟶ Y' => i' ≫ e' = 𝟙 Y' ∧ e' ≫ i' = p'
          [Elab.step] [0.010714] expected type: C → Prop, term
              failed to pretty print term (use 'set_option pp.rawOnError true' for raw representation)
            [Elab.step] [0.010668] expected type: Prop, term
                Exists✝ fun i' : Y' ⟶ X' => Exists✝ fun e' : X' ⟶ Y' => i' ≫ e' = 𝟙 Y' ∧ e' ≫ i' = p'
              [Elab.step] [0.010601] expected type: (Y' ⟶ X') → Prop, term
                  fun i' : Y' ⟶ X' => Exists✝ fun e' : X' ⟶ Y' => i' ≫ e' = 𝟙 Y' ∧ e' ≫ i' = p'
                [Elab.step] [0.010595] expected type: (Y' ⟶ X') → Prop, term
                    failed to pretty print term (use 'set_option pp.rawOnError true' for raw representation)
info: Mathlib/CategoryTheory/Idempotents/Basic.lean:121:0: [Elab.async] [0.045788] elaborating proof of CategoryTheory.Idempotents.split_imp_of_iso
  [Elab.definition.value] [0.045073] CategoryTheory.Idempotents.split_imp_of_iso
    [Elab.step] [0.044689] 
          rcases h with ⟨Y, i, e, ⟨h₁, h₂⟩⟩
          use Y, i ≫ φ.hom, φ.inv ≫ e
          grind
      [Elab.step] [0.044682] 
            rcases h with ⟨Y, i, e, ⟨h₁, h₂⟩⟩
            use Y, i ≫ φ.hom, φ.inv ≫ e
            grind
        [Elab.step] [0.023704] use Y, i ≫ φ.hom, φ.inv ≫ e
        [Elab.step] [0.020130] grind
Build completed successfully.
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
