### PR TITLE
[Merged by Bors] - chore(CategoryTheory/SmallObject/Iteration): golf `map_id` using `grind`

### DIFF
--- a/Mathlib/CategoryTheory/SmallObject/Iteration/FunctorOfCocone.lean
+++ b/Mathlib/CategoryTheory/SmallObject/Iteration/FunctorOfCocone.lean
@@ -63,9 +63,7 @@ def map (i₁ i₂ : J) (hi : i₁ ≤ i₂) (hi₂ : i₂ ≤ j) :
 lemma map_id (i : J) (hi : i ≤ j) :
     map c i i (by rfl) hi = 𝟙 _:= by
   dsimp [map]
-  obtain hi' | rfl := hi.lt_or_eq
-  · rw [dif_pos hi', F.map_id, id_comp, Iso.hom_inv_id]
-  · rw [dif_neg (by simp), dif_neg (by simp)]
+  grind
 
 lemma map_comp (i₁ i₂ i₃ : J) (hi : i₁ ≤ i₂) (hi' : i₂ ≤ i₃) (hi₃ : i₃ ≤ j) :
     map c i₁ i₃ (hi.trans hi') hi₃ =


### PR DESCRIPTION
Motivation: Make use of available automation (and shorten the proof).

---
<details>
<summary>Show trace profiling of <code>map_id</code></summary>

### Trace profiling of `map_id` before PR 28128
```diff
diff --git a/Mathlib/CategoryTheory/SmallObject/Iteration/FunctorOfCocone.lean b/Mathlib/CategoryTheory/SmallObject/Iteration/FunctorOfCocone.lean
index c75826a229..0889ba1521 100644
--- a/Mathlib/CategoryTheory/SmallObject/Iteration/FunctorOfCocone.lean
+++ b/Mathlib/CategoryTheory/SmallObject/Iteration/FunctorOfCocone.lean
@@ -62,2 +62,3 @@ def map (i₁ i₂ : J) (hi : i₁ ≤ i₂) (hi₂ : i₂ ≤ j) :
 
+set_option trace.profiler true in
 lemma map_id (i : J) (hi : i ≤ j) :
```
```
ℹ [791/791] Built Mathlib.CategoryTheory.SmallObject.Iteration.FunctorOfCocone
info: Mathlib/CategoryTheory/SmallObject/Iteration/FunctorOfCocone.lean:64:0: [Elab.command] [0.018921] theorem map_id (i : J) (hi : i ≤ j) : map c i i (by rfl) hi = 𝟙 _ :=
      by
      dsimp [map]
      obtain hi' | rfl := hi.lt_or_eq
      · rw [dif_pos hi', F.map_id, id_comp, Iso.hom_inv_id]
      · rw [dif_neg (by simp), dif_neg (by simp)]
info: Mathlib/CategoryTheory/SmallObject/Iteration/FunctorOfCocone.lean:64:0: [Elab.command] [0.019067] lemma map_id (i : J) (hi : i ≤ j) : map c i i (by rfl) hi = 𝟙 _ :=
      by
      dsimp [map]
      obtain hi' | rfl := hi.lt_or_eq
      · rw [dif_pos hi', F.map_id, id_comp, Iso.hom_inv_id]
      · rw [dif_neg (by simp), dif_neg (by simp)]
info: Mathlib/CategoryTheory/SmallObject/Iteration/FunctorOfCocone.lean:64:0: [Elab.async] [0.033326] elaborating proof of CategoryTheory.SmallObject.SuccStruct.ofCocone.map_id
  [Elab.definition.value] [0.031820] CategoryTheory.SmallObject.SuccStruct.ofCocone.map_id
    [Elab.step] [0.031207] 
          dsimp [map]
          obtain hi' | rfl := hi.lt_or_eq
          · rw [dif_pos hi', F.map_id, id_comp, Iso.hom_inv_id]
          · rw [dif_neg (by simp), dif_neg (by simp)]
      [Elab.step] [0.031200] 
            dsimp [map]
            obtain hi' | rfl := hi.lt_or_eq
            · rw [dif_pos hi', F.map_id, id_comp, Iso.hom_inv_id]
            · rw [dif_neg (by simp), dif_neg (by simp)]
Build completed successfully.
```

### Trace profiling of `map_id` after PR 28128
```diff
diff --git a/Mathlib/CategoryTheory/SmallObject/Iteration/FunctorOfCocone.lean b/Mathlib/CategoryTheory/SmallObject/Iteration/FunctorOfCocone.lean
index c75826a229..eaf9226088 100644
--- a/Mathlib/CategoryTheory/SmallObject/Iteration/FunctorOfCocone.lean
+++ b/Mathlib/CategoryTheory/SmallObject/Iteration/FunctorOfCocone.lean
@@ -62,2 +62,3 @@ def map (i₁ i₂ : J) (hi : i₁ ≤ i₂) (hi₂ : i₂ ≤ j) :
 
+set_option trace.profiler true in
 lemma map_id (i : J) (hi : i ≤ j) :
@@ -65,5 +66,3 @@ lemma map_id (i : J) (hi : i ≤ j) :
   dsimp [map]
-  obtain hi' | rfl := hi.lt_or_eq
-  · rw [dif_pos hi', F.map_id, id_comp, Iso.hom_inv_id]
-  · rw [dif_neg (by simp), dif_neg (by simp)]
+  grind
 
```
```
ℹ [791/791] Built Mathlib.CategoryTheory.SmallObject.Iteration.FunctorOfCocone
info: Mathlib/CategoryTheory/SmallObject/Iteration/FunctorOfCocone.lean:64:0: [Elab.command] [0.018917] theorem map_id (i : J) (hi : i ≤ j) : map c i i (by rfl) hi = 𝟙 _ :=
      by
      dsimp [map]
      grind
info: Mathlib/CategoryTheory/SmallObject/Iteration/FunctorOfCocone.lean:64:0: [Elab.command] [0.019053] lemma map_id (i : J) (hi : i ≤ j) : map c i i (by rfl) hi = 𝟙 _ :=
      by
      dsimp [map]
      grind
info: Mathlib/CategoryTheory/SmallObject/Iteration/FunctorOfCocone.lean:64:0: [Elab.async] [0.046553] elaborating proof of CategoryTheory.SmallObject.SuccStruct.ofCocone.map_id
  [Elab.definition.value] [0.046026] CategoryTheory.SmallObject.SuccStruct.ofCocone.map_id
    [Elab.step] [0.045869] 
          dsimp [map]
          grind
      [Elab.step] [0.045862] 
            dsimp [map]
            grind
        [Elab.step] [0.039298] grind
Build completed successfully.
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
