### PR TITLE
[Merged by Bors] - chore(Analysis/InnerProductSpace/Projection): fix docstrings

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Adjoint.lean
@@ -238,7 +238,7 @@ theorem norm_adjoint_comp_self (A : E →L[𝕜] F) :
           Real.sqrt_mul_self (norm_nonneg x)]
 
 /-- The C⋆-algebra instance when `𝕜 := ℂ` can be found in
-`Analysis/CStarAlgebra/ContinuousLinearMap`. -/
+`Mathlib/Analysis/CStarAlgebra/ContinuousLinearMap.lean`. -/
 instance : CStarRing (E →L[𝕜] E) where
   norm_mul_self_le x := le_of_eq <| Eq.symm <| norm_adjoint_comp_self x
 

--- a/Mathlib/Analysis/InnerProductSpace/Projection/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection/Basic.lean
@@ -605,6 +605,7 @@ theorem id_eq_sum_starProjection_self_orthogonalComplement [K.HasOrthogonalProje
   id_eq_sum_orthogonalProjection_self_orthogonalComplement :=
   id_eq_sum_starProjection_self_orthogonalComplement
 
+-- Porting note: The priority should be higher than `Submodule.coe_inner`.
 @[simp high]
 theorem inner_orthogonalProjection_eq_of_mem_right [K.HasOrthogonalProjection] (u : K) (v : E) :
     ⟪K.orthogonalProjection v, u⟫ = ⟪v, u⟫ :=
@@ -614,6 +615,7 @@ theorem inner_orthogonalProjection_eq_of_mem_right [K.HasOrthogonalProjection] (
       rw [starProjection_inner_eq_zero _ _ (Submodule.coe_mem _), add_zero]
     _ = ⟪v, u⟫ := by rw [← inner_add_left, add_sub_cancel]
 
+-- Porting note: The priority should be higher than `Submodule.coe_inner`.
 @[simp high]
 theorem inner_orthogonalProjection_eq_of_mem_left [K.HasOrthogonalProjection] (u : K) (v : E) :
     ⟪u, K.orthogonalProjection v⟫ = ⟪(u : E), v⟫ := by

--- a/Mathlib/Analysis/InnerProductSpace/Projection/Basic.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection/Basic.lean
@@ -560,7 +560,6 @@ theorem starProjection_orthogonalComplement_singleton_eq_zero (v : E) :
   rw [starProjection_apply, coe_eq_zero]
   exact orthogonalProjection_orthogonalComplement_singleton_eq_zero v
 
-
 /-- If the orthogonal projection to `K` is well-defined, then a vector splits as the sum of its
 orthogonal projections onto a complete submodule `K` and onto the orthogonal complement of `K`. -/
 theorem starProjection_add_starProjection_orthogonal [K.HasOrthogonalProjection]
@@ -606,7 +605,6 @@ theorem id_eq_sum_starProjection_self_orthogonalComplement [K.HasOrthogonalProje
   id_eq_sum_orthogonalProjection_self_orthogonalComplement :=
   id_eq_sum_starProjection_self_orthogonalComplement
 
--- Porting note: The priority should be higher than `Submodule.coe_inner`.
 @[simp high]
 theorem inner_orthogonalProjection_eq_of_mem_right [K.HasOrthogonalProjection] (u : K) (v : E) :
     ⟪K.orthogonalProjection v, u⟫ = ⟪v, u⟫ :=
@@ -616,7 +614,6 @@ theorem inner_orthogonalProjection_eq_of_mem_right [K.HasOrthogonalProjection] (
       rw [starProjection_inner_eq_zero _ _ (Submodule.coe_mem _), add_zero]
     _ = ⟪v, u⟫ := by rw [← inner_add_left, add_sub_cancel]
 
--- Porting note: The priority should be higher than `Submodule.coe_inner`.
 @[simp high]
 theorem inner_orthogonalProjection_eq_of_mem_left [K.HasOrthogonalProjection] (u : K) (v : E) :
     ⟪u, K.orthogonalProjection v⟫ = ⟪(u : E), v⟫ := by

--- a/Mathlib/Analysis/InnerProductSpace/Projection/FiniteDimensional.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection/FiniteDimensional.lean
@@ -283,8 +283,6 @@ theorem OrthogonalFamily.projection_directSum_coeAddHom [DecidableEq ι] {V : ι
   | zero => simp
   | of j x =>
     simp_rw [DirectSum.coeAddMonoidHom_of, DirectSum.of]
-    -- Porting note: was in the previous `simp_rw`, no longer works
-    -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
     erw [DFinsupp.singleAddHom_apply]
     obtain rfl | hij := Decidable.eq_or_ne i j
     · rw [orthogonalProjection_mem_subspace_eq_self, DFinsupp.single_eq_same]

--- a/Mathlib/Analysis/InnerProductSpace/Projection/FiniteDimensional.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection/FiniteDimensional.lean
@@ -283,7 +283,7 @@ theorem OrthogonalFamily.projection_directSum_coeAddHom [DecidableEq ι] {V : ι
   | zero => simp
   | of j x =>
     simp_rw [DirectSum.coeAddMonoidHom_of, DirectSum.of]
-      -- Porting note: was in the previous `simp_rw`, no longer works
+    -- Porting note: was in the previous `simp_rw`, no longer works
     -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
     erw [DFinsupp.singleAddHom_apply]
     obtain rfl | hij := Decidable.eq_or_ne i j

--- a/Mathlib/Analysis/InnerProductSpace/Projection/FiniteDimensional.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection/FiniteDimensional.lean
@@ -283,6 +283,8 @@ theorem OrthogonalFamily.projection_directSum_coeAddHom [DecidableEq ι] {V : ι
   | zero => simp
   | of j x =>
     simp_rw [DirectSum.coeAddMonoidHom_of, DirectSum.of]
+      -- Porting note: was in the previous `simp_rw`, no longer works
+    -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
     erw [DFinsupp.singleAddHom_apply]
     obtain rfl | hij := Decidable.eq_or_ne i j
     · rw [orthogonalProjection_mem_subspace_eq_self, DFinsupp.single_eq_same]

--- a/Mathlib/Analysis/InnerProductSpace/Projection/Minimal.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection/Minimal.lean
@@ -11,7 +11,7 @@ import Mathlib.Analysis.SpecificLimits.Basic
 
 This file shows the existence of minimizers (also known as the Hilbert projection theorem).
 This is the key tool that is used to define `Submodule.orthogonalProjection` in
-`Mathlib/Analysis/InnerProductSpace/Projection/Basic`.
+`Mathlib/Analysis/InnerProductSpace/Projection/Basic.lean`.
 -/
 
 variable {𝕜 E F : Type*} [RCLike 𝕜]
@@ -23,9 +23,6 @@ local notation "absR" => @abs ℝ _ _
 
 open Topology RCLike Real Filter InnerProductSpace
 
--- FIXME this monolithic proof causes a deterministic timeout with `-T50000`
--- It should be broken in a sequence of more manageable pieces,
--- perhaps with individual statements for the three steps below.
 /-- **Existence of minimizers**, aka the **Hilbert projection theorem**.
 
 Let `u` be a point in a real inner product space, and let `K` be a nonempty complete convex subset.

--- a/Mathlib/Analysis/InnerProductSpace/Projection/Submodule.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Projection/Submodule.lean
@@ -10,7 +10,7 @@ import Mathlib.Analysis.InnerProductSpace.Projection.Basic
 
 Here, the orthogonal projection is used to prove a series of more subtle lemmas about the
 orthogonal complement of subspaces of `E` (the orthogonal complement itself was
-defined in `Analysis.InnerProductSpace.Orthogonal`) such that they admit
+defined in `Mathlib/Analysis/InnerProductSpace/Orthogonal.lean`) such that they admit
 orthogonal projections; the lemma
 `Submodule.sup_orthogonal_of_hasOrthogonalProjection`,
 stating that for a subspace `K` of `E` such that `K` admits an orthogonal projection we have
@@ -177,7 +177,6 @@ theorem topologicalClosure_eq_top_iff [CompleteSpace E] :
   constructor <;> intro h
   · rw [← Submodule.triorthogonal_eq_orthogonal, h, Submodule.top_orthogonal_eq_bot]
   · rw [h, Submodule.bot_orthogonal_eq_top]
-
 
 theorem orthogonalProjection_eq_linearProjOfIsCompl [K.HasOrthogonalProjection] (x : E) :
     K.orthogonalProjection x =


### PR DESCRIPTION
Fixing docstring.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
