### PR TITLE
[Merged by Bors] - feat: forgetful functor from over category preserves connected limits

### DIFF
--- a/Mathlib/CategoryTheory/Limits/Constructions/Over/Connected.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/Over/Connected.lean
@@ -82,8 +82,8 @@ instance forgetCreatesConnectedLimits [IsConnected J] {B : C} :
 /-- The forgetful functor from the over category preserves any connected limit. -/
 instance forgetPreservedConnectedLimits [IsConnected J] {B : C} :
     PreservesLimitsOfShape J (forget B) where
-  preservesLimit {K} := {
-    preserves {c} hc := ⟨{
+  preservesLimit := {
+    preserves hc := ⟨{
       lift s := (forget B).map (hc.lift (CreatesConnected.raiseCone s))
       fac s j := by
         rw [Functor.mapCone_π_app, ← Functor.map_comp, hc.fac,

--- a/Mathlib/CategoryTheory/Limits/Constructions/Over/Connected.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/Over/Connected.lean
@@ -80,7 +80,7 @@ instance forgetCreatesConnectedLimits [IsConnected J] {B : C} :
         makesLimit := CreatesConnected.raisedConeIsLimit t }
 
 /-- The forgetful functor from the over category preserves any connected limit. -/
-instance forgetPreservedConnectedLimits [IsConnected J] {B : C} :
+instance forgetPreservesConnectedLimits [IsConnected J] {B : C} :
     PreservesLimitsOfShape J (forget B) where
   preservesLimit := {
     preserves hc := ⟨{

--- a/Mathlib/CategoryTheory/Limits/Constructions/Over/Connected.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/Over/Connected.lean
@@ -79,6 +79,21 @@ instance forgetCreatesConnectedLimits [IsConnected J] {B : C} :
         validLift := eqToIso (CreatesConnected.raised_cone_lowers_to_original c)
         makesLimit := CreatesConnected.raisedConeIsLimit t }
 
+/-- The forgetful functor from the over category preserves any connected limit. -/
+instance forgetPreservedConnectedLimits [IsConnected J] {B : C} :
+    PreservesLimitsOfShape J (forget B) where
+  preservesLimit {K} := {
+    preserves {c} hc := ⟨{
+      lift s := (forget B).map (hc.lift (CreatesConnected.raiseCone s))
+      fac s j := by
+        rw [Functor.mapCone_π_app, ← Functor.map_comp, hc.fac,
+          CreatesConnected.raiseCone_π_app, forget_map, homMk_left _ _]
+      uniq s m fac :=
+        congrArg (forget B).map (hc.uniq (CreatesConnected.raiseCone s)
+          (Over.homMk m (by simp [← fac])) fun j => (forget B).map_injective (fac j))
+    }⟩
+  }
+
 /-- The over category has any connected limit which the original category has. -/
 instance has_connected_limits {B : C} [IsConnected J] [HasLimitsOfShape J C] :
     HasLimitsOfShape J (Over B) where

--- a/Mathlib/CategoryTheory/Limits/Constructions/Over/Connected.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/Over/Connected.lean
@@ -10,10 +10,9 @@ import Mathlib.CategoryTheory.IsConnected
 /-!
 # Connected limits in the over category
 
-Shows that the forgetful functor `Over B ⥤ C` creates connected limits, in particular `Over B` has
-any connected limit which `C` has.
-Shows that the forgetful functor `Over B ⥤ C` preserves connected limits, without having to assume
-that `C` has any limits.
+Shows that the forgetful functor `Over B ⥤ C` creates and preserves connected limits,
+the latter without assuming that `C` has any limits.
+In particular, `Over B` has any connected limit which `C` has.
 -/
 
 

--- a/Mathlib/CategoryTheory/Limits/Constructions/Over/Connected.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/Over/Connected.lean
@@ -12,6 +12,8 @@ import Mathlib.CategoryTheory.IsConnected
 
 Shows that the forgetful functor `Over B ⥤ C` creates connected limits, in particular `Over B` has
 any connected limit which `C` has.
+Shows that the forgetful functor `Over B ⥤ C` preserves connected limits, without having to assume
+that `C` has any limits.
 -/
 
 

--- a/Mathlib/CategoryTheory/Limits/Constructions/Over/Connected.lean
+++ b/Mathlib/CategoryTheory/Limits/Constructions/Over/Connected.lean
@@ -86,7 +86,7 @@ instance forgetPreservesConnectedLimits [IsConnected J] {B : C} :
   preservesLimit := {
     preserves hc := ⟨{
       lift s := (forget B).map (hc.lift (CreatesConnected.raiseCone s))
-      fac s j := by
+      fac _ _ := by
         rw [Functor.mapCone_π_app, ← Functor.map_comp, hc.fac,
           CreatesConnected.raiseCone_π_app, forget_map, homMk_left _ _]
       uniq s m fac :=


### PR DESCRIPTION
Prove that `Over.forget` preserves connected limits.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
