### PR TITLE
[Merged by Bors] - feat: accept `docComment` syntax for docstrings in `to_additive`

### DIFF
--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -101,7 +101,7 @@ syntax toAdditiveOption := "(" toAdditiveAttrOption <|> toAdditiveReorderOption 
 syntax toAdditiveNameHint := (ppSpace (&"existing" <|> &"self"))?
 /-- Remaining arguments of `to_additive`. -/
 syntax toAdditiveRest :=
-  toAdditiveNameHint (ppSpace toAdditiveOption)* (ppSpace ident)? (ppSpace str)?
+  toAdditiveNameHint (ppSpace toAdditiveOption)* (ppSpace ident)? (ppSpace (str <|> docComment))?
 
 /-- The attribute `to_additive` can be used to automatically transport theorems
 and definitions (but not inductive types and structures) from a multiplicative
@@ -1238,10 +1238,19 @@ def elabToAdditive : Syntax → CoreM Config
         as there is only one declaration for the attributes.\n\
         Instead, you can write the attributes in the usual way."
     trace[to_additive_detail] "attributes: {attrs}; reorder arguments: {reorder}"
+    let doc ← doc.mapM fun
+      | `(str|$doc:str) => do
+        -- TODO: deprecate `str` docstring syntax in Mathlib
+        return doc.getString
+      | `(docComment|$doc:docComment) => do
+        -- TODO: rely on `addDocString`s call to `validateDocComment` after removing `str` support
+        validateDocComment doc
+        return (← getDocStringText doc).removeLeadingSpaces
+      | _ => throwUnsupportedSyntax
     return {
       trace := trace.isSome
       tgt := match tgt with | some tgt => tgt.getId | none => Name.anonymous
-      doc := doc.bind (·.raw.isStrLit?)
+      doc
       allowAutoName := false
       attrs, reorder, existing, self
       ref := (tgt.map (·.raw)).getD tk }

--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -1245,6 +1245,9 @@ def elabToAdditive : Syntax → CoreM Config
       | `(docComment|$doc:docComment) => do
         -- TODO: rely on `addDocString`s call to `validateDocComment` after removing `str` support
         validateDocComment doc
+        /- Note: the following replicates the behavior of `addDocString`. However, this means that
+        trailing whitespace might appear in docstrings added via `docComment` syntax when compared
+        to those added via `str` syntax. See this [Zulip thread](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/Why.20do.20docstrings.20include.20trailing.20whitespace.3F/with/533553356). -/
         return (← getDocStringText doc).removeLeadingSpaces
       | _ => throwUnsupportedSyntax
     return {

--- a/MathlibTest/toAdditive.lean
+++ b/MathlibTest/toAdditive.lean
@@ -574,19 +574,19 @@ def barMul {β : Type} [Mul β] (x y : β) : β := fooMul instAddNat x y
 @[to_additive /-- (via `docComment` syntax) I am an additive docstring! -/]
 theorem mulTrivial : True := trivial
 
-@[to_additive "(via `str` syntax) I am an additive docstring!"]
-theorem mulTrivial' : True := trivial
-
-/--
-info: (via `docComment` syntax) I am an additive docstring! ⏎
----
-info: (via `str` syntax) I am an additive docstring!
--/
+/-- info: (via `docComment` syntax) I am an additive docstring! -/
 #guard_msgs in
 run_cmd
   let some doc  ← findDocString? (← getEnv) `addTrivial
     | throwError "no `docComment` docstring found"
-  let some doc' ← findDocString? (← getEnv) `addTrivial'
+  logInfo doc
+
+@[to_additive "(via `str` syntax) I am an additive docstring!"]
+theorem mulTrivial' : True := trivial
+
+/-- info: (via `str` syntax) I am an additive docstring! -/
+#guard_msgs in
+run_cmd
+  let some doc ← findDocString? (← getEnv) `addTrivial'
     | throwError "no `str` docstring found"
   logInfo doc
-  logInfo doc'

--- a/MathlibTest/toAdditive.lean
+++ b/MathlibTest/toAdditive.lean
@@ -571,11 +571,22 @@ def barMul {β : Type} [Mul β] (x y : β) : β := fooMul instAddNat x y
 
 /-! Test that additive docstrings work -/
 
-@[to_additive /-- I am an additive docstring! -/]
+@[to_additive /-- (via `docComment` syntax) I am an additive docstring! -/]
 theorem mulTrivial : True := trivial
 
-/-- info: I am an additive docstring! -/
+@[to_additive "(via `str` syntax) I am an additive docstring!"]
+theorem mulTrivial' : True := trivial
+
+/--
+info: (via `docComment` syntax) I am an additive docstring! ⏎
+---
+info: (via `str` syntax) I am an additive docstring!
+-/
 #guard_msgs in
 run_cmd
-  let some doc ← findDocString? (← getEnv) `addTrivial | throwError "no docstring found"
+  let some doc  ← findDocString? (← getEnv) `addTrivial
+    | throwError "no `docComment` docstring found"
+  let some doc' ← findDocString? (← getEnv) `addTrivial'
+    | throwError "no `str` docstring found"
   logInfo doc
+  logInfo doc'

--- a/MathlibTest/toAdditive.lean
+++ b/MathlibTest/toAdditive.lean
@@ -568,3 +568,14 @@ def fooMul {α β : Type} (_ : (no_index Add) α) [Mul β] (x y : β) : β := x 
 
 @[to_additive] -- this would not translate `fooMul`
 def barMul {β : Type} [Mul β] (x y : β) : β := fooMul instAddNat x y
+
+/-! Test that additive docstrings work -/
+
+@[to_additive /-- I am an additive docstring! -/]
+theorem mulTrivial : True := trivial
+
+/-- info: I am an additive docstring! -/
+#guard_msgs in
+run_cmd
+  let some doc ← findDocString? (← getEnv) `addTrivial | throwError "no docstring found"
+  logInfo doc

--- a/MathlibTest/toAdditive.lean
+++ b/MathlibTest/toAdditive.lean
@@ -587,6 +587,6 @@ theorem mulTrivial' : True := trivial
 /-- info: (via `str` syntax) I am an additive docstring! -/
 #guard_msgs in
 run_cmd
-  let some doc ← findDocString? (← getEnv) `addTrivial'
+  let some doc ← findDocString? (← getEnv) ``addTrivial'
     | throwError "no `str` docstring found"
   logInfo doc

--- a/MathlibTest/toAdditive.lean
+++ b/MathlibTest/toAdditive.lean
@@ -577,7 +577,7 @@ theorem mulTrivial : True := trivial
 /-- info: (via `docComment` syntax) I am an additive docstring! -/
 #guard_msgs in
 run_cmd
-  let some doc  ← findDocString? (← getEnv) `addTrivial
+  let some doc  ← findDocString? (← getEnv) ``addTrivial
     | throwError "no `docComment` docstring found"
   logInfo doc
 


### PR DESCRIPTION
This PR adds support to `to_additive` to accept additive docstrings written in `docComment` syntax, e.g. `@[to_additive /-- I am an additive docstring! -/]` It does not remove support for or deprecate existing `str` syntax for `to_additive` docstrings, nor does it reformat existing `to_additive` docstrings in Mathlib; see #28066 and #28135.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
