### PR TITLE
[Merged by Bors] - feat: deprecate `str` syntax for `to_additive` docstrings in Mathlib

### DIFF
--- a/Mathlib/Algebra/Group/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Group/Equiv/Basic.lean
@@ -82,8 +82,8 @@ variable [MulOneClass M] [MulOneClass M₁] [MulOneClass M₂] [MulOneClass M₃
 /-- The equivalence `(M₁ →* N) ≃ (M₂ →* N)` obtained by postcomposition with
 a multiplicative equivalence `e : M₁ ≃* M₂`. -/
 @[to_additive (attr := simps)
-"The equivalence `(M₁ →+ N) ≃ (M₂ →+ N)` obtained by postcomposition with
-an additive equivalence `e : M₁ ≃+ M₂`."]
+/-- The equivalence `(M₁ →+ N) ≃ (M₂ →+ N)` obtained by postcomposition with
+an additive equivalence `e : M₁ ≃+ M₂`. -/]
 def monoidHomCongrLeftEquiv (e : M₁ ≃* M₂) : (M₁ →* N) ≃ (M₂ →* N) where
   toFun f := f.comp e.symm.toMonoidHom
   invFun f := f.comp e.toMonoidHom
@@ -93,8 +93,8 @@ def monoidHomCongrLeftEquiv (e : M₁ ≃* M₂) : (M₁ →* N) ≃ (M₂ →* 
 /-- The equivalence `(M →* N₁) ≃ (M →* N₂)` obtained by postcomposition with
 a multiplicative equivalence `e : N₁ ≃* N₂`. -/
 @[to_additive (attr := simps)
-"The equivalence `(M →+ N₁) ≃ (M →+ N₂)` obtained by postcomposition with
-an additive equivalence `e : N₁ ≃+ N₂`."]
+/-- The equivalence `(M →+ N₁) ≃ (M →+ N₂)` obtained by postcomposition with
+an additive equivalence `e : N₁ ≃+ N₂`. -/]
 def monoidHomCongrRightEquiv (e : N₁ ≃* N₂) : (M →* N₁) ≃ (M →* N₂) where
   toFun := e.toMonoidHom.comp
   invFun := e.symm.toMonoidHom.comp
@@ -134,8 +134,8 @@ variable [MulOneClass M] [MulOneClass M₁] [MulOneClass M₂] [MulOneClass M₃
 /-- The isomorphism `(M₁ →* N) ≃* (M₂ →* N)` obtained by postcomposition with
 a multiplicative equivalence `e : M₁ ≃* M₂`. -/
 @[to_additive (attr := simps! apply)
-"The isomorphism `(M₁ →+ N) ≃+ (M₂ →+ N)` obtained by postcomposition with
-an additive equivalence `e : M₁ ≃+ M₂`."]
+/-- The isomorphism `(M₁ →+ N) ≃+ (M₂ →+ N)` obtained by postcomposition with
+an additive equivalence `e : M₁ ≃+ M₂`. -/]
 def monoidHomCongrLeft (e : M₁ ≃* M₂) : (M₁ →* N) ≃* (M₂ →* N) where
   __ := e.monoidHomCongrLeftEquiv
   map_mul' f g := by ext; simp
@@ -143,8 +143,8 @@ def monoidHomCongrLeft (e : M₁ ≃* M₂) : (M₁ →* N) ≃* (M₂ →* N) w
 /-- The isomorphism `(M →* N₁) ≃* (M →* N₂)` obtained by postcomposition with
 a multiplicative equivalence `e : N₁ ≃* N₂`. -/
 @[to_additive (attr := simps! apply)
-"The isomorphism `(M →+ N₁) ≃+ (M →+ N₂)` obtained by postcomposition with
-an additive equivalence `e : N₁ ≃+ N₂`."]
+/-- The isomorphism `(M →+ N₁) ≃+ (M →+ N₂)` obtained by postcomposition with
+an additive equivalence `e : N₁ ≃+ N₂`. -/]
 def monoidHomCongrRight (e : N₁ ≃* N₂) : (M →* N₁) ≃* (M →* N₂) where
   __ := e.monoidHomCongrRightEquiv
   map_mul' f g := by ext; simp

--- a/Mathlib/Algebra/Order/Group/Equiv.lean
+++ b/Mathlib/Algebra/Order/Group/Equiv.lean
@@ -13,13 +13,13 @@ import Mathlib.Algebra.Order.Group.Synonym
 variable (α : Type*) [Mul α]
 
 /-- `toLex` as a `MulEquiv`. -/
-@[to_additive "`toLex` as a `AddEquiv`."]
+@[to_additive /-- `toLex` as an `AddEquiv`. -/]
 def toLexMulEquiv : α ≃* Lex α where
   toEquiv := toLex
   map_mul' _ _ := by simp
 
 /-- `ofLex` as a `MulEquiv`. -/
-@[to_additive "`ofLex` as a `AddEquiv`."]
+@[to_additive /-- `ofLex` as an `AddEquiv`. -/]
 def ofLexMulEquiv : Lex α ≃* α where
   toEquiv := ofLex
   map_mul' _ _ := by simp

--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -1243,7 +1243,7 @@ def elabToAdditive : Syntax → CoreM Config
     trace[to_additive_detail] "attributes: {attrs}; reorder arguments: {reorder}"
     let doc ← doc.mapM fun
       | `(str|$doc:str) => open Linter in do
-        -- Deprecate `str` docstring syntax in Mathlib
+        -- Deprecate `str` docstring syntax
         if getLinterValue linter.deprecated (← getLinterOptions) then
           logWarningAt doc <| .tagged ``Linter.deprecatedAttr
             m!"String syntax for `to_additive` docstrings is deprecated: Use \

--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -20,6 +20,7 @@ import Batteries.Tactic.Lint -- useful to lint this file and for DiscrTree.eleme
 import Batteries.Tactic.Trans
 import Mathlib.Tactic.Eqns -- just to copy the attribute
 import Mathlib.Tactic.Simps.Basic
+import Lean.Meta.Tactic.TryThis
 
 /-!
 # The `@[to_additive]` attribute.
@@ -128,7 +129,7 @@ has a doc string, a doc string for the additive version should be passed explici
 
 ```
 /-- Multiplication is commutative -/
-@[to_additive "Addition is commutative"]
+@[to_additive /-- Addition is commutative -/]
 theorem mul_comm' {α} [CommSemigroup α] (x y : α) : x * y = y * x := CommSemigroup.mul_comm
 ```
 
@@ -1205,6 +1206,8 @@ def proceedFields (src tgt : Name) : CoreM Unit := do
         return ctors.toArray.map (.mkSimple ·.lastComponentAsString)
     | _ => pure #[]
 
+open Tactic.TryThis in
+open private addSuggestionCore in addSuggestion in
 /-- Elaboration of the configuration options for `to_additive`. -/
 def elabToAdditive : Syntax → CoreM Config
   | `(attr| to_additive%$tk $[?%$trace]? $existing?
@@ -1240,7 +1243,18 @@ def elabToAdditive : Syntax → CoreM Config
     trace[to_additive_detail] "attributes: {attrs}; reorder arguments: {reorder}"
     let doc ← doc.mapM fun
       | `(str|$doc:str) => do
-        -- TODO: deprecate `str` docstring syntax in Mathlib
+        -- Deprecate `str` docstring syntax in Mathlib
+        if (← getMainModule).getRoot == `Mathlib then
+          logWarningAt doc <| .tagged ``Linter.deprecatedAttr
+            m!"String syntax for `to_additive` docstrings is deprecated in favor of \
+              docstring syntax: `@[to_additive /-- example -/]`."
+          addSuggestionCore doc
+            (header := "Update deprecated string syntax to:\n")
+            (codeActionPrefix? := "Update to: ")
+            (isInline := true)
+            #[{
+              suggestion := "/-- " ++ doc.getString.trim ++ " -/"
+            }]
         return doc.getString
       | `(docComment|$doc:docComment) => do
         -- TODO: rely on `addDocString`s call to `validateDocComment` after removing `str` support

--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -1242,9 +1242,9 @@ def elabToAdditive : Syntax → CoreM Config
         Instead, you can write the attributes in the usual way."
     trace[to_additive_detail] "attributes: {attrs}; reorder arguments: {reorder}"
     let doc ← doc.mapM fun
-      | `(str|$doc:str) => do
+      | `(str|$doc:str) => open Linter in do
         -- Deprecate `str` docstring syntax in Mathlib
-        if (← getMainModule).getRoot == `Mathlib then
+        if getLinterValue linter.deprecated (← getLinterOptions) then
           logWarningAt doc <| .tagged ``Linter.deprecatedAttr
             m!"String syntax for `to_additive` docstrings is deprecated: Use \
               docstring syntax instead (e.g. `@[to_additive /-- example -/]`)"

--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -1246,10 +1246,10 @@ def elabToAdditive : Syntax → CoreM Config
         -- Deprecate `str` docstring syntax in Mathlib
         if (← getMainModule).getRoot == `Mathlib then
           logWarningAt doc <| .tagged ``Linter.deprecatedAttr
-            m!"String syntax for `to_additive` docstrings is deprecated in favor of \
-              docstring syntax: `@[to_additive /-- example -/]`."
+            m!"String syntax for `to_additive` docstrings is deprecated: Use \
+              docstring syntax instead (e.g. `@[to_additive /-- example -/]`)"
           addSuggestionCore doc
-            (header := "Update deprecated string syntax to:\n")
+            (header := "Update deprecated syntax to:\n")
             (codeActionPrefix? := "Update to: ")
             (isInline := true)
             #[{

--- a/MathlibTest/toAdditive.lean
+++ b/MathlibTest/toAdditive.lean
@@ -581,6 +581,11 @@ run_cmd
     | throwError "no `docComment` docstring found"
   logInfo doc
 
+/--
+warning: String syntax for `to_additive` docstrings is deprecated:
+Use docstring syntax instead (e.g. `@[to_additive /-- example -/]`)
+-/
+#guard_msgs in
 @[to_additive "(via `str` syntax) I am an additive docstring!"]
 theorem mulTrivial' : True := trivial
 


### PR DESCRIPTION
This PR deprecates `str` syntax for `to_additive` docstrings in favor of `docComment` syntax: `@[to_additive /-- I am an additive docstring! -/]` instead of `@[to_additive "I am an additive docstring!"]`. It does so by adding a warning and an interactive suggestion/code action to replace the `str` syntax with the corresponding `docComment` syntax.

It also reformats docstrings which have appeared since writing #28066.

This deprecation attempts to hew closely to the standard deprecation trappings, but makes two idiosyncratic choices:
* Since docstrings are usually verbose, we split the role of the interactive suggestion from the role of the logged message. The logged message describes the cause of the error (in general), while trying to emulate the standard phrasing:
  > String syntax for `to_additive` docstrings is deprecated: Use docstring syntax instead (e.g. `@[to_additive /-- example -/]`)
  
  while the interactive suggestion only suggests the replacement:
  > Update deprecated syntax to:
  > /-- \<clickable new docstring here> -/
* Likewise, to keep the code action as concise and communicative as possible, instead of saying "Replace \`\<old>\` with \`\<new>\`", we say "Update to: \<new>". (We also don't include backticks, since they are not rendered in code action titles and the colon is sufficient separation.)

See also [this zulip thread](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Deprecating.20.60str.60.20syntax.20for.20docstrings.20in.20.60to_additive.60/with/533665799).

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [x] depends on: #28066 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
