### PR TITLE
[Merged by Bors] - refactor: make the cone explicit in `ConvexCone.toPointedCone`

### DIFF
--- a/Mathlib/Analysis/Convex/Cone/Closure.lean
+++ b/Mathlib/Analysis/Convex/Cone/Closure.lean
@@ -58,7 +58,7 @@ lemma toConvexCone_closure_pointed (K : PointedCone 𝕜 E) : (K : ConvexCone �
 /-- The closure of a pointed cone inside a topological space as a pointed cone. This
 construction is mainly used for defining maps between proper cones. -/
 protected def closure (K : PointedCone 𝕜 E) : PointedCone 𝕜 E :=
-  ConvexCone.toPointedCone K.toConvexCone_closure_pointed
+  K.toConvexCone.closure.toPointedCone K.toConvexCone_closure_pointed
 
 @[simp, norm_cast]
 theorem coe_closure (K : PointedCone 𝕜 E) : (K.closure : Set E) = closure K :=

--- a/Mathlib/Geometry/Convex/Cone/Pointed.lean
+++ b/Mathlib/Geometry/Convex/Cone/Pointed.lean
@@ -63,7 +63,7 @@ instance instZero (C : PointedCone R E) : Zero C :=
   ⟨0, C.zero_mem⟩
 
 /-- The `PointedCone` constructed from a pointed `ConvexCone`. -/
-def _root_.ConvexCone.toPointedCone {C : ConvexCone R E} (hC : C.Pointed) : PointedCone R E where
+def _root_.ConvexCone.toPointedCone (C : ConvexCone R E) (hC : C.Pointed) : PointedCone R E where
   carrier := C
   add_mem' hx hy := C.add_mem hx hy
   zero_mem' := hC
@@ -83,7 +83,7 @@ lemma _root_.ConvexCone.mem_toPointedCone {C : ConvexCone R E} (hC : C.Pointed) 
   Iff.rfl
 
 @[simp, norm_cast]
-lemma _root_.ConvexCone.coe_toPointedCone {C : ConvexCone R E} (hC : C.Pointed) :
+lemma _root_.ConvexCone.coe_toPointedCone (C : ConvexCone R E) (hC : C.Pointed) :
     C.toPointedCone hC = C :=
   rfl
 


### PR DESCRIPTION
Otherwise it is impossible to know which cone we are talking about from the infoview as proofs are elided.

From Toric


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
