### PR TITLE
chore: deprecate `BialgHom.coe_toLinearMap`

### DIFF
--- a/Mathlib/RingTheory/Bialgebra/Hom.lean
+++ b/Mathlib/RingTheory/Bialgebra/Hom.lean
@@ -148,19 +148,10 @@ theorem coe_coalgHom_mk {f : A →ₗc[R] B} (h h₁) :
     ((⟨f, h, h₁⟩ : A →ₐc[R] B) : A →ₗc[R] B) = f := by
   rfl
 
-@[simp, norm_cast]
-theorem coe_toCoalgHom (f : A →ₐc[R] B) : ⇑(f : A →ₗc[R] B) = f :=
-  rfl
+@[simp, norm_cast] lemma coe_toCoalgHom (f : A →ₐc[R] B) : ⇑(f : A →ₗc[R] B) = f := rfl
+@[norm_cast] lemma coe_toAlgHom (f : A →ₐc[R] B) : ⇑(f : A →ₐ[R] B) = f := by simp
 
 lemma toCoalgHom_apply (f : A →ₐc[R] B) (a : A) : f.toCoalgHom a = f a := rfl
-
-@[simp, norm_cast]
-theorem coe_toLinearMap (f : A →ₐc[R] B) : ⇑(f : A →ₗ[R] B) = f :=
-  rfl
-
-@[norm_cast]
-theorem coe_toAlgHom (f : A →ₐc[R] B) : ⇑(f : A →ₐ[R] B) = f :=
-  rfl
 
 theorem toAlgHom_toLinearMap (f : A →ₐc[R] B) :
     ((f : A →ₐ[R] B) : A →ₗ[R] B) = f := by

--- a/Mathlib/RingTheory/Bialgebra/Hom.lean
+++ b/Mathlib/RingTheory/Bialgebra/Hom.lean
@@ -151,6 +151,9 @@ theorem coe_coalgHom_mk {f : A →ₗc[R] B} (h h₁) :
 @[simp, norm_cast] lemma coe_toCoalgHom (f : A →ₐc[R] B) : ⇑(f : A →ₗc[R] B) = f := rfl
 @[norm_cast] lemma coe_toAlgHom (f : A →ₐc[R] B) : ⇑(f : A →ₐ[R] B) = f := by simp
 
+@[deprecated "Use the `CoalgHom` API." (since := "2025-08-10")]
+lemma coe_toLinearMap (f : A →ₐc[R] B) : ⇑(f : A →ₗ[R] B) = f := rfl
+
 lemma toCoalgHom_apply (f : A →ₐc[R] B) (a : A) : f.toCoalgHom a = f a := rfl
 
 theorem toAlgHom_toLinearMap (f : A →ₐc[R] B) :

--- a/Mathlib/RingTheory/Bialgebra/Hom.lean
+++ b/Mathlib/RingTheory/Bialgebra/Hom.lean
@@ -151,8 +151,8 @@ theorem coe_coalgHom_mk {f : A →ₗc[R] B} (h h₁) :
 @[simp, norm_cast] lemma coe_toCoalgHom (f : A →ₐc[R] B) : ⇑(f : A →ₗc[R] B) = f := rfl
 @[norm_cast] lemma coe_toAlgHom (f : A →ₐc[R] B) : ⇑(f : A →ₐ[R] B) = f := by simp
 
-@[deprecated "Use the `CoalgHom` API." (since := "2025-08-10")]
-lemma coe_toLinearMap (f : A →ₐc[R] B) : ⇑(f : A →ₗ[R] B) = f := rfl
+@[deprecated LinearMap.coe_coe (since := "2025-11-15")]
+lemma coe_toLinearMap (f : A →ₐc[R] B) : ⇑(f : A →ₗ[R] B) = f := by dsimp only [LinearMap.coe_coe]
 
 lemma toCoalgHom_apply (f : A →ₐc[R] B) (a : A) : f.toCoalgHom a = f a := rfl
 


### PR DESCRIPTION
`BialgHom.toLinearMap` is a fake projection.

From Toric

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
