### PR TITLE
[Merged by Bors] - refactor: state hypotheses of `BialgHom.ofAlgHom` as equalities of `AlgHom`s

### DIFF
--- a/Mathlib/Algebra/Algebra/Equiv.lean
+++ b/Mathlib/Algebra/Algebra/Equiv.lean
@@ -540,6 +540,10 @@ lemma ofBijective_apply (f : A₁ →ₐ[R] A₂) (hf : Function.Bijective f) (a
 lemma toLinearMap_ofBijective (f : A₁ →ₐ[R] A₂) (hf : Function.Bijective f) :
     (ofBijective f hf).toLinearMap = f := rfl
 
+@[simp]
+lemma toAlgHom_ofBijective (f : A₁ →ₐ[R] A₂) (hf : Function.Bijective f) :
+    AlgHomClass.toAlgHom (ofBijective f hf) = f := rfl
+
 section OfLinearEquiv
 
 variable (l : A₁ ≃ₗ[R] A₂) (map_one : l 1 = 1) (map_mul : ∀ x y : A₁, l (x * y) = l x * l y)
@@ -787,4 +791,3 @@ def ULift.algEquiv {R : Type u} {A : Type v} [CommSemiring R] [Semiring A] [Alge
     ULift.{w} A ≃ₐ[R] A where
   __ := ULift.ringEquiv
   commutes' _ := rfl
-

--- a/Mathlib/RingTheory/Bialgebra/Equiv.lean
+++ b/Mathlib/RingTheory/Bialgebra/Equiv.lean
@@ -299,14 +299,19 @@ theorem ofBialgHom_symm (f : A →ₐc[R] B) (g : B →ₐc[R] A) (h₁ h₂) :
     (ofBialgHom f g h₁ h₂).symm = ofBialgHom g f h₂ h₁ :=
   rfl
 
+end
+
+variable [Semiring A] [Semiring B] [Bialgebra R A] [Bialgebra R B]
+
 /-- Construct a bialgebra equiv from an algebra equiv respecting counit and comultiplication. -/
-@[simps apply] def ofAlgEquiv (f : A ≃ₐ[R] B) (counit_comp : counit ∘ₗ f.toLinearMap = counit)
-    (map_comp_comul : map f.toLinearMap f.toLinearMap ∘ₗ comul = comul ∘ₗ f.toLinearMap) :
-    A ≃ₐc[R] B where
+@[simps apply] def ofAlgEquiv (f : A ≃ₐ[R] B)
+    (counit_comp : (Bialgebra.counitAlgHom R B).comp f = Bialgebra.counitAlgHom R A)
+    (map_comp_comul : (Algebra.TensorProduct.map f f).comp (Bialgebra.comulAlgHom R A) =
+        (Bialgebra.comulAlgHom R B).comp f) : A ≃ₐc[R] B where
   __ := f
   map_smul' := map_smul f
-  counit_comp := counit_comp
-  map_comp_comul := map_comp_comul
+  counit_comp := congr($(counit_comp).toLinearMap)
+  map_comp_comul := congr($(map_comp_comul).toLinearMap)
 
 @[simp]
 lemma toLinearMap_ofAlgEquiv (f : A ≃ₐ[R] B) (counit_comp map_comp_comul) :
@@ -320,5 +325,4 @@ noncomputable def ofBijective (f : A →ₐc[R] B) (hf : Bijective f) : A ≃ₐ
 @[simp]
 lemma coe_ofBijective (f : A →ₐc[R] B) (hf : Bijective f) : (ofBijective f hf : A → B) = f := rfl
 
-end
 end BialgEquiv

--- a/Mathlib/RingTheory/Bialgebra/Hom.lean
+++ b/Mathlib/RingTheory/Bialgebra/Hom.lean
@@ -100,8 +100,10 @@ end BialgHomClass
 
 namespace BialgHom
 
-variable {R A B C D : Type*} [CommSemiring R] [Semiring A] [Algebra R A]
-  [Semiring B] [Algebra R B] [Semiring C] [Algebra R C] [Semiring D] [Algebra R D]
+variable {R A B C D : Type*} [CommSemiring R] [Semiring A] [Semiring B] [Semiring C] [Semiring D]
+
+section AlgebraCoalgebra
+variable [Algebra R A] [Algebra R B] [Algebra R C] [Algebra R D]
   [CoalgebraStruct R A] [CoalgebraStruct R B] [CoalgebraStruct R C] [CoalgebraStruct R D]
 
 instance funLike : FunLike (A →ₐc[R] B) A B where
@@ -126,15 +128,6 @@ def Simps.apply {R α β : Type*} [CommSemiring R]
     (f : α →ₐc[R] β) : α → β := f
 
 initialize_simps_projections BialgHom (toFun → apply)
-
-/-- Construct a bialgebra hom from an algebra hom respecting counit and comultiplication. -/
-@[simps] def ofAlgHom (f : A →ₐ[R] B) (counit_comp : counit ∘ₗ f.toLinearMap = counit)
-    (map_comp_comul : map f.toLinearMap f.toLinearMap ∘ₗ comul = comul ∘ₗ f.toLinearMap) :
-    A →ₐc[R] B where
-  __ := f
-  map_smul' := map_smul f
-  counit_comp := counit_comp
-  map_comp_comul := map_comp_comul
 
 @[simp]
 protected theorem coe_coe {F : Type*} [FunLike F A B] [BialgHomClass F R A B] (f : F) :
@@ -299,6 +292,21 @@ theorem one_apply (x : A) : (1 : A →ₐc[R] A) x = x :=
 theorem mul_apply (φ ψ : A →ₐc[R] A) (x : A) : (φ * ψ) x = φ (ψ x) :=
   rfl
 
+end AlgebraCoalgebra
+
+variable [Bialgebra R A] [Bialgebra R B]
+
+/-- Construct a bialgebra hom from an algebra hom respecting counit and comultiplication. -/
+@[simps!]
+def ofAlgHom (f : A →ₐ[R] B) (counit_comp : (counitAlgHom R B).comp f = counitAlgHom R A)
+    (map_comp_comul :
+      (Algebra.TensorProduct.map f f).comp (comulAlgHom _ _) = (comulAlgHom _ _).comp f) :
+    A →ₐc[R] B where
+  __ := f
+  map_smul' := map_smul f
+  counit_comp := congr(($counit_comp).toLinearMap)
+  map_comp_comul := congr(($map_comp_comul).toLinearMap)
+
 end BialgHom
 
 namespace Bialgebra
@@ -307,7 +315,7 @@ variable {R A : Type*} [CommSemiring R] [Semiring A] [Bialgebra R A]
 variable (R A) in
 /-- The unit of a bialgebra as a `BialgHom`. -/
 noncomputable def unitBialgHom : R →ₐc[R] A :=
-  .ofAlgHom (Algebra.ofId R A) (by ext; simp) (by ext; simp [Algebra.TensorProduct.one_def])
+  .ofAlgHom (Algebra.ofId R A) (by ext) (by ext)
 
 variable (R A) in
 /-- The counit of a bialgebra as a `BialgHom`. -/


### PR DESCRIPTION
... as opposed to equalities of `LinearMap`s, and similarly for `BialgEquiv.ofAlgEquiv`. This way, dedicated `ext` lemmas can fire.

From Toric


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
