### PR TITLE
[Merged by Bors] - feat(ModuleCat): `IsZero M ↔ Subsingleton M`

### DIFF
--- a/Mathlib/Algebra/Category/ModuleCat/Basic.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Basic.lean
@@ -340,6 +340,14 @@ theorem subsingleton_of_isZero (h : IsZero M) : Subsingleton M := by
   rw [← LinearMap.id_apply (R := R) x, ← ModuleCat.hom_id]
   simp only [(CategoryTheory.Limits.IsZero.iff_id_eq_zero M).mp h, hom_zero, LinearMap.zero_apply]
 
+lemma isZero_iff_subsingleton : IsZero M ↔ Subsingleton M where
+  mp := subsingleton_of_isZero
+  mpr _ := isZero_of_subsingleton M
+
+@[simp]
+lemma isZero_of_iff_subsingleton {M : Type*} [AddCommGroup M] [Module R M] :
+    IsZero (of R M) ↔ Subsingleton M := isZero_iff_subsingleton
+
 end AddCommGroup
 
 section SMul


### PR DESCRIPTION
And make the corollary `IsZero (of R M) ↔ Subsingleton M` a simp lemma.

From ClassFieldTheory


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
