### PR TITLE
[Merged by Bors] - feat: dcongr_heq

### DIFF
--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -51,6 +51,20 @@ theorem congr_arg_heq {β : α → Sort*} (f : ∀ a, β a) :
     ∀ {a₁ a₂ : α}, a₁ = a₂ → f a₁ ≍ f a₂
   | _, _, rfl => HEq.rfl
 
+theorem dcongr_heq
+    {α₁ α₂ : Sort _}
+    {β₁ : α₁ → Sort _} {β₂ : α₂ → Sort _}
+    {f₁ : ∀ a, β₁ a} {f₂ : ∀ a, β₂ a}
+    {a₁ : α₁} {a₂ : α₂}
+    (hargs : a₁ ≍ a₂)
+    (ht : ∀ a₁ a₂, a₁ ≍ a₂ → β₁ a₁ = β₂ a₂)
+    (hf : α₁ = α₂ → β₁ ≍ β₂ → f₁ ≍ f₂) :
+    f₁ a₁ ≍ f₂ a₂ := by
+  cases hargs
+  cases funext fun v => ht v v .rfl
+  cases hf rfl .rfl
+  rfl
+
 @[simp] theorem eq_iff_eq_cancel_left {b c : α} : (∀ {a}, a = b ↔ a = c) ↔ b = c :=
   ⟨fun h ↦ by rw [← h], fun h a ↦ by rw [h]⟩
 

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -51,15 +51,15 @@ theorem congr_arg_heq {β : α → Sort*} (f : ∀ a, β a) :
     ∀ {a₁ a₂ : α}, a₁ = a₂ → f a₁ ≍ f a₂
   | _, _, rfl => HEq.rfl
 
-theorem dcongr_heq
+theorem dcongr_heq.{u, v}
     {α₁ α₂ : Sort u}
     {β₁ : α₁ → Sort v} {β₂ : α₂ → Sort v}
     {fn₁ : ∀ a, β₁ a} {fn₂ : ∀ a, β₂ a}
-    {arg₁ : α₁} {arg₂ : α₂}
-    (hargs : arg₁ ≍ arg₂)
-    (ht : ∀ arg₁ arg₂, arg₁ ≍ arg₂ → β₁ arg₁ = β₂ arg₂)
+    {a₁ : α₁} {a₂ : α₂}
+    (hargs : a₁ ≍ a₂)
+    (ht : ∀ t₁ t₂, t₁ ≍ t₂ → β₁ t₁ = β₂ t₂)
     (hf : α₁ = α₂ → β₁ ≍ β₂ → fn₁ ≍ fn₂) :
-    fn₁ arg₁ ≍ fn₂ arg₂ := by
+    fn₁ a₁ ≍ fn₂ a₂ := by
   cases hargs
   cases funext fun v => ht v v .rfl
   cases hf rfl .rfl

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -52,14 +52,14 @@ theorem congr_arg_heq {β : α → Sort*} (f : ∀ a, β a) :
   | _, _, rfl => HEq.rfl
 
 theorem dcongr_heq
-    {α₁ α₂ : Sort _}
-    {β₁ : α₁ → Sort _} {β₂ : α₂ → Sort _}
-    {f₁ : ∀ a, β₁ a} {f₂ : ∀ a, β₂ a}
-    {a₁ : α₁} {a₂ : α₂}
-    (hargs : a₁ ≍ a₂)
-    (ht : ∀ a₁ a₂, a₁ ≍ a₂ → β₁ a₁ = β₂ a₂)
-    (hf : α₁ = α₂ → β₁ ≍ β₂ → f₁ ≍ f₂) :
-    f₁ a₁ ≍ f₂ a₂ := by
+    {α₁ α₂ : Sort u}
+    {β₁ : α₁ → Sort v} {β₂ : α₂ → Sort v}
+    {fn₁ : ∀ a, β₁ a} {fn₂ : ∀ a, β₂ a}
+    {arg₁ : α₁} {arg₂ : α₂}
+    (hargs : arg₁ ≍ arg₂)
+    (ht : ∀ arg₁ arg₂, arg₁ ≍ arg₂ → β₁ arg₁ = β₂ arg₂)
+    (hf : α₁ = α₂ → β₁ ≍ β₂ → fn₁ ≍ fn₂) :
+    fn₁ arg₁ ≍ fn₂ arg₂ := by
   cases hargs
   cases funext fun v => ht v v .rfl
   cases hf rfl .rfl

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -54,12 +54,12 @@ theorem congr_arg_heq {β : α → Sort*} (f : ∀ a, β a) :
 theorem dcongr_heq.{u, v}
     {α₁ α₂ : Sort u}
     {β₁ : α₁ → Sort v} {β₂ : α₂ → Sort v}
-    {fn₁ : ∀ a, β₁ a} {fn₂ : ∀ a, β₂ a}
+    {f₁ : ∀ a, β₁ a} {f₂ : ∀ a, β₂ a}
     {a₁ : α₁} {a₂ : α₂}
     (hargs : a₁ ≍ a₂)
     (ht : ∀ t₁ t₂, t₁ ≍ t₂ → β₁ t₁ = β₂ t₂)
-    (hf : α₁ = α₂ → β₁ ≍ β₂ → fn₁ ≍ fn₂) :
-    fn₁ a₁ ≍ fn₂ a₂ := by
+    (hf : α₁ = α₂ → β₁ ≍ β₂ → f₁ ≍ f₂) :
+    f₁ a₁ ≍ f₂ a₂ := by
   cases hargs
   cases funext fun v => ht v v .rfl
   cases hf rfl .rfl


### PR DESCRIPTION
`dcongr_heq` is very useful for proofs about typevecs as these are highly dependent

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
