### PR TITLE
chore: clean up proofs typevec proofs

### DIFF
--- a/Mathlib/Data/TypeVec.lean
+++ b/Mathlib/Data/TypeVec.lean
@@ -569,8 +569,9 @@ theorem append_prod_appendFun {n} {α α' β β' : TypeVec.{u} n} {φ φ' ψ ψ'
 end Liftp'
 
 @[simp]
-theorem dropFun_diag {α} : dropFun (@prod.diag (n + 1) α) = prod.diag :=
-  funext (match n, · with | 0, _ | _+1, .fz | _+1, .fs _ => rfl)
+theorem dropFun_diag {α} : dropFun (@prod.diag (n + 1) α) = prod.diag := by
+  ext i : 2
+  rfl
 
 @[simp]
 theorem dropFun_subtypeVal {α} (p : α ⟹ «repeat» (n + 1) Prop) :
@@ -584,18 +585,21 @@ theorem lastFun_subtypeVal {α} (p : α ⟹ «repeat» (n + 1) Prop) :
 
 @[simp]
 theorem dropFun_toSubtype {α} (p : α ⟹ «repeat» (n + 1) Prop) :
-    dropFun (toSubtype p) = toSubtype _ :=
-  funext (match n, · with | 0, _ | _+1, .fz | _+1, .fs _ => rfl)
+    dropFun (toSubtype p) = toSubtype _ := by
+  ext i : 2
+  rfl
 
 @[simp]
 theorem lastFun_toSubtype {α} (p : α ⟹ «repeat» (n + 1) Prop) :
-    lastFun (toSubtype p) = _root_.id :=
-  funext fun ⟨_, _⟩ ↦ rfl
+    lastFun (toSubtype p) = _root_.id := by
+  ext i : 2
+  rfl
 
 @[simp]
 theorem dropFun_of_subtype {α} (p : α ⟹ «repeat» (n + 1) Prop) :
-    dropFun (ofSubtype p) = ofSubtype _ :=
-  funext (match n, · with | 0, _ | _+1, .fz | _+1, .fs _ => rfl)
+    dropFun (ofSubtype p) = ofSubtype _ := by
+  ext i : 2
+  rfl
 
 @[simp]
 theorem lastFun_of_subtype {α} (p : α ⟹ «repeat» (n + 1) Prop) :
@@ -610,13 +614,15 @@ attribute [simp] drop_append1'
 
 @[simp]
 theorem dropFun_prod {α α' β β' : TypeVec (n + 1)} (f : α ⟹ β) (f' : α' ⟹ β') :
-    dropFun (f ⊗' f') = (dropFun f ⊗' dropFun f') :=
-  funext (match n, · with | 0, _ | _+1, .fz | _+1, .fs _ => rfl)
+    dropFun (f ⊗' f') = (dropFun f ⊗' dropFun f') := by
+  ext i : 2
+  rfl
 
 @[simp]
 theorem lastFun_prod {α α' β β' : TypeVec (n + 1)} (f : α ⟹ β) (f' : α' ⟹ β') :
-    lastFun (f ⊗' f') = Prod.map (lastFun f) (lastFun f') :=
-  funext fun ⟨_, _⟩ ↦ rfl
+    lastFun (f ⊗' f') = Prod.map (lastFun f) (lastFun f') := by
+  ext i : 1
+  rfl
 
 @[simp]
 theorem dropFun_from_append1_drop_last {α : TypeVec (n + 1)} :

--- a/Mathlib/Data/TypeVec.lean
+++ b/Mathlib/Data/TypeVec.lean
@@ -54,8 +54,7 @@ open MvFunctor
 /-- Extensionality for arrows -/
 @[ext]
 theorem Arrow.ext {α β : TypeVec n} (f g : α ⟹ β) :
-    (∀ i, f i = g i) → f = g := by
-  intro h; funext i; apply h
+    (∀ i, f i = g i) → f = g := funext
 
 instance Arrow.inhabited (α β : TypeVec n) [∀ i, Inhabited (β i)] : Inhabited (α ⟹ β) :=
   ⟨fun _ _ => default⟩
@@ -570,9 +569,8 @@ theorem append_prod_appendFun {n} {α α' β β' : TypeVec.{u} n} {φ φ' ψ ψ'
 end Liftp'
 
 @[simp]
-theorem dropFun_diag {α} : dropFun (@prod.diag (n + 1) α) = prod.diag := by
-  ext i : 2
-  induction i <;> simp [dropFun, *] <;> rfl
+theorem dropFun_diag {α} : dropFun (@prod.diag (n + 1) α) = prod.diag :=
+  funext (match n, · with | 0, _ | _+1, .fz | _+1, .fs _ => rfl)
 
 @[simp]
 theorem dropFun_subtypeVal {α} (p : α ⟹ «repeat» (n + 1) Prop) :
@@ -586,21 +584,18 @@ theorem lastFun_subtypeVal {α} (p : α ⟹ «repeat» (n + 1) Prop) :
 
 @[simp]
 theorem dropFun_toSubtype {α} (p : α ⟹ «repeat» (n + 1) Prop) :
-    dropFun (toSubtype p) = toSubtype _ := by
-  ext i
-  induction i <;> simp [dropFun, *] <;> rfl
+    dropFun (toSubtype p) = toSubtype _ :=
+  funext (match n, · with | 0, _ | _+1, .fz | _+1, .fs _ => rfl)
 
 @[simp]
 theorem lastFun_toSubtype {α} (p : α ⟹ «repeat» (n + 1) Prop) :
-    lastFun (toSubtype p) = _root_.id := by
-  ext i : 2
-  induction i; simp [*]; rfl
+    lastFun (toSubtype p) = _root_.id :=
+  funext fun ⟨_, _⟩ ↦ rfl
 
 @[simp]
 theorem dropFun_of_subtype {α} (p : α ⟹ «repeat» (n + 1) Prop) :
-    dropFun (ofSubtype p) = ofSubtype _ := by
-  ext i : 2
-  induction i <;> simp [dropFun, *] <;> rfl
+    dropFun (ofSubtype p) = ofSubtype _ :=
+  funext (match n, · with | 0, _ | _+1, .fz | _+1, .fs _ => rfl)
 
 @[simp]
 theorem lastFun_of_subtype {α} (p : α ⟹ «repeat» (n + 1) Prop) :
@@ -615,15 +610,13 @@ attribute [simp] drop_append1'
 
 @[simp]
 theorem dropFun_prod {α α' β β' : TypeVec (n + 1)} (f : α ⟹ β) (f' : α' ⟹ β') :
-    dropFun (f ⊗' f') = (dropFun f ⊗' dropFun f') := by
-  ext i : 2
-  induction i <;> simp [dropFun, *] <;> rfl
+    dropFun (f ⊗' f') = (dropFun f ⊗' dropFun f') :=
+  funext (match n, · with | 0, _ | _+1, .fz | _+1, .fs _ => rfl)
 
 @[simp]
 theorem lastFun_prod {α α' β β' : TypeVec (n + 1)} (f : α ⟹ β) (f' : α' ⟹ β') :
-    lastFun (f ⊗' f') = Prod.map (lastFun f) (lastFun f') := by
-  ext i : 1
-  induction i; simp [lastFun, *]; rfl
+    lastFun (f ⊗' f') = Prod.map (lastFun f) (lastFun f') :=
+  funext fun ⟨_, _⟩ ↦ rfl
 
 @[simp]
 theorem dropFun_from_append1_drop_last {α : TypeVec (n + 1)} :
@@ -644,12 +637,10 @@ theorem prod_map_id {α β : TypeVec n} : (@TypeVec.id _ α ⊗' @TypeVec.id _ �
 
 @[simp]
 theorem subtypeVal_diagSub {α : TypeVec n} : subtypeVal (repeatEq α) ⊚ diagSub = prod.diag := by
-  ext i x
+  funext i
   induction i with
-  | fz => simp [comp, diagSub, subtypeVal, prod.diag]
-  | fs _ i_ih =>
-    simp only [comp, subtypeVal, diagSub, prod.diag] at *
-    apply i_ih
+  | fz => rfl
+  | fs _ i_ih => apply i_ih
 
 @[simp]
 theorem toSubtype_of_subtype {α : TypeVec n} (p : α ⟹ «repeat» n Prop) :
@@ -669,7 +660,7 @@ theorem subtypeVal_toSubtype {α : TypeVec n} (p : α ⟹ «repeat» n Prop) :
 theorem toSubtype_of_subtype_assoc
     {α β : TypeVec n} (p : α ⟹ «repeat» n Prop) (f : β ⟹ Subtype_ p) :
     @toSubtype n _ p ⊚ ofSubtype _ ⊚ f = f := by
-  rw [← comp_assoc, toSubtype_of_subtype]; simp
+  rw [← comp_assoc, toSubtype_of_subtype]; rfl
 
 @[simp]
 theorem toSubtype'_of_subtype' {α : TypeVec n} (r : α ⊗ α ⟹ «repeat» n Prop) :

--- a/Mathlib/Data/TypeVec.lean
+++ b/Mathlib/Data/TypeVec.lean
@@ -107,7 +107,7 @@ theorem last_append1 {α : TypeVec n} {β : Type*} : last (append1 α β) = β :
 
 @[simp]
 theorem append1_drop_last (α : TypeVec (n + 1)) : append1 (drop α) (last α) = α :=
-  funext fun i => by cases i <;> rfl
+  funext fun | .fz | .fs _ => rfl
 
 /-- cases on `(n+1)-length` vectors -/
 @[elab_as_elim]
@@ -143,7 +143,7 @@ def nilFun {α : TypeVec 0} {β : TypeVec 0} : α ⟹ β := fun i => by apply Fi
 
 theorem eq_of_drop_last_eq {α β : TypeVec (n + 1)} {f g : α ⟹ β} (h₀ : dropFun f = dropFun g)
     (h₁ : lastFun f = lastFun g) : f = g := by
-  refine funext (fun x => ?_)
+  funext x
   cases x
   · apply h₁
   · apply congr_fun h₀
@@ -257,7 +257,7 @@ protected def casesNil {β : TypeVec 0 → Sort*} (f : β Fin2.elim0) : ∀ v, �
 protected def casesCons (n : ℕ) {β : TypeVec (n + 1) → Sort*}
     (f : ∀ (t) (v : TypeVec n), β (v ::: t)) :
     ∀ v, β v :=
-  fun v : TypeVec (n + 1) => cast (by simp) (f v.last v.drop)
+  fun v : TypeVec (n + 1) => cast (congr rfl (append1_drop_last _)) (f v.last v.drop)
 
 protected theorem casesNil_append1 {β : TypeVec 0 → Sort*} (f : β Fin2.elim0) :
     TypeVec.casesNil f Fin2.elim0 = f :=
@@ -273,10 +273,10 @@ def typevecCasesNil₃ {β : ∀ v v' : TypeVec 0, v ⟹ v' → Sort*}
     (f : β Fin2.elim0 Fin2.elim0 nilFun) :
     ∀ v v' fs, β v v' fs := fun v v' fs => by
   refine cast ?_ f
-  have eq₁ : v = Fin2.elim0 := by funext i; contradiction
-  have eq₂ : v' = Fin2.elim0 := by funext i; contradiction
-  have eq₃ : fs = nilFun := by funext i; contradiction
-  cases eq₁; cases eq₂; cases eq₃; rfl
+  obtain rfl : v = Fin2.elim0 := by funext i; contradiction
+  obtain rfl : v' = Fin2.elim0 := by funext i; contradiction
+  obtain rfl : fs = nilFun := by funext i; contradiction
+  rfl
 
 /-- cases distinction for an arrow in the category of (n+1)-length type vectors -/
 def typevecCasesCons₃ (n : ℕ) {β : ∀ v v' : TypeVec (n + 1), v ⟹ v' → Sort*}
@@ -446,14 +446,14 @@ end
 theorem prod_fst_mk {α β : TypeVec n} (i : Fin2 n) (a : α i) (b : β i) :
     TypeVec.prod.fst i (prod.mk i a b) = a := by
   induction i with
-  | fz => simp_all only [prod.fst, prod.mk]
+  | fz => rfl
   | fs _ i_ih => apply i_ih
 
 @[simp]
 theorem prod_snd_mk {α β : TypeVec n} (i : Fin2 n) (a : α i) (b : β i) :
     TypeVec.prod.snd i (prod.mk i a b) = b := by
   induction i with
-  | fz => simp_all [prod.snd, prod.mk]
+  | fz => rfl
   | fs _ i_ih => apply i_ih
 
 /-- `prod` is functorial -/
@@ -554,7 +554,7 @@ theorem prod_id : ∀ {n} {α β : TypeVec.{u} n}, (id ⊗' id) = (id : α ⊗ �
   intros
   ext i a
   induction i with
-  | fz => cases a; rfl
+  | fz => rfl
   | fs _ i_ih => apply i_ih
 
 theorem append_prod_appendFun {n} {α α' β β' : TypeVec.{u} n} {φ φ' ψ ψ' : Type u}
@@ -674,7 +674,8 @@ theorem toSubtype'_of_subtype' {α : TypeVec n} (r : α ⊗ α ⟹ «repeat» n 
   ext i x
   induction i
   <;> dsimp only [id, toSubtype', comp, ofSubtype'] at *
-  <;> simp [*]
+  · rfl
+  · simp only [*]
 
 theorem subtypeVal_toSubtype' {α : TypeVec n} (r : α ⊗ α ⟹ «repeat» n Prop) :
     subtypeVal r ⊚ toSubtype' r = fun i x => prod.mk i x.1.fst x.1.snd := by


### PR DESCRIPTION
While adding variable universe corecs I found a lot of theorems in typevec that could do with a bit of a clean-up

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
