### PR TITLE
feat(AlgebraicTopology): characterize simply connectedness in terms of loops

### DIFF
--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/Basic.lean
@@ -349,4 +349,24 @@ fundamental groupoid of that space. -/
 abbrev fromPath {X : TopCat} {x₀ x₁ : X} (p : Path.Homotopic.Quotient x₀ x₁) :
     FundamentalGroupoid.mk x₀ ⟶ FundamentalGroupoid.mk x₁ := p
 
+/-- Variation of `fromPath` that uses `Path` instead of `Path.Homotopic.Quotient`. -/
+abbrev fromPath' {X : Type*} [TopologicalSpace X] {x₀ x₁ : X} (f : Path x₀ x₁) : mk x₀ ⟶ mk x₁ :=
+  Quotient.mk _ f
+
+@[simp] lemma fromPath'_refl {X : Type*} [TopologicalSpace X] {x : X} :
+    fromPath' (Path.refl x) = 𝟙 _ := rfl
+
+@[simp] lemma fromPath'_symm {X : Type*} [TopologicalSpace X] {x₀ x₁ : X} (f : Path x₀ x₁) :
+    fromPath' f.symm = inv (fromPath' f) := by
+  rw [← Groupoid.inv_eq_inv]
+  rfl
+
+@[simp] lemma fromPath'_trans {X : Type*} [TopologicalSpace X] {x₀ x₁ x₂ : X} (f : Path x₀ x₁)
+    (g : Path x₁ x₂) : fromPath' (f.trans g) = (fromPath' f) ≫ (fromPath' g) := rfl
+
+/-- Two paths are equal in the fundamental groupoid if and only if they are homotopic. -/
+theorem fromPath'_eq_iff_homotopic {X : Type*} [TopologicalSpace X] {x₀ x₁ : X}
+    (f : Path x₀ x₁) (g : Path x₀ x₁) : fromPath' f = fromPath' g ↔ f.Homotopic g :=
+  ⟨fun ih ↦ Quotient.exact ih, fun h ↦ Quotient.sound h⟩
+
 end FundamentalGroupoid

--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/SimplyConnected.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/SimplyConnected.lean
@@ -24,11 +24,7 @@ universe u
 
 noncomputable section
 
-open CategoryTheory
-
-open ContinuousMap
-
-open scoped ContinuousMap
+open CategoryTheory ContinuousMap FundamentalGroupoid
 
 /-- A simply connected space is one whose fundamental groupoid is equivalent to `Discrete Unit` -/
 @[mk_iff simply_connected_def]
@@ -88,3 +84,20 @@ theorem simply_connected_iff_paths_homotopic' {Y : Type*} [TopologicalSpace Y] :
       PathConnectedSpace Y ∧ ∀ {x y : Y} (p₁ p₂ : Path x y), Path.Homotopic p₁ p₂ := by
   convert simply_connected_iff_paths_homotopic (Y := Y)
   simp [Path.Homotopic.Quotient, Setoid.eq_top_iff]; rfl
+
+/-- A space is simply connected iff it is path connected and every loop is homotopic to the
+constant loop. -/
+theorem simply_connected_iff_loops_trivial {Y : Type*} [TopologicalSpace Y] :
+    SimplyConnectedSpace Y ↔
+      PathConnectedSpace Y ∧ ∀ {x : Y} (p : Path x x), p.Homotopic (Path.refl x) := by
+  trans
+  · exact simply_connected_iff_paths_homotopic'
+  rw [and_congr_right_iff]
+  intro _
+  constructor
+  · intro h x p
+    exact h p (Path.refl x)
+  · intro h _ _ p₁ p₂
+    have := (fromPath'_eq_iff_homotopic _ _).mpr (h (p₁.trans p₂.symm))
+    rw [← fromPath'_eq_iff_homotopic]
+    aesop_cat

--- a/Mathlib/AlgebraicTopology/FundamentalGroupoid/SimplyConnected.lean
+++ b/Mathlib/AlgebraicTopology/FundamentalGroupoid/SimplyConnected.lean
@@ -90,8 +90,7 @@ constant loop. -/
 theorem simply_connected_iff_loops_trivial {Y : Type*} [TopologicalSpace Y] :
     SimplyConnectedSpace Y ↔
       PathConnectedSpace Y ∧ ∀ {x : Y} (p : Path x x), p.Homotopic (Path.refl x) := by
-  trans
-  · exact simply_connected_iff_paths_homotopic'
+  apply Iff.trans simply_connected_iff_paths_homotopic'
   rw [and_congr_right_iff]
   intro _
   constructor


### PR DESCRIPTION
Show that a space is simply connected if and only if all loops within that space are homotopic to the constant loop. To be used in a proof that the `n`-sphere is simply connected for `n > 1`. 

---
This code was written at the University of Western Ontario as a part of the Fields Undergraduate Summer Research Program under the supervision of Chris Kapulkin and Daniel Carranza. 

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [x] depends on: #28126

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
