### PR TITLE
[Merged by Bors] - feat: convex hull of `s` is a singleton iff `s` is a singleton

### DIFF
--- a/Mathlib/Analysis/Convex/Hull.lean
+++ b/Mathlib/Analysis/Convex/Hull.lean
@@ -78,7 +78,7 @@ theorem convexHull_empty : convexHull 𝕜 (∅ : Set E) = ∅ :=
   convex_empty.convexHull_eq
 
 @[simp]
-theorem convexHull_empty_iff : convexHull 𝕜 s = ∅ ↔ s = ∅ := by
+theorem convexHull_eq_empty : convexHull 𝕜 s = ∅ ↔ s = ∅ := by
   constructor
   · intro h
     rw [← Set.subset_empty_iff, ← h]
@@ -86,10 +86,12 @@ theorem convexHull_empty_iff : convexHull 𝕜 s = ∅ ↔ s = ∅ := by
   · rintro rfl
     exact convexHull_empty
 
+@[deprecated (since := "2025-08-09")] alias convexHull_empty_iff := convexHull_eq_empty
+
 @[simp]
 theorem convexHull_nonempty_iff : (convexHull 𝕜 s).Nonempty ↔ s.Nonempty := by
   rw [nonempty_iff_ne_empty, nonempty_iff_ne_empty, Ne, Ne]
-  exact not_congr convexHull_empty_iff
+  exact not_congr convexHull_eq_empty
 
 protected alias ⟨_, Set.Nonempty.convexHull⟩ := convexHull_nonempty_iff
 
@@ -100,9 +102,19 @@ theorem segment_subset_convexHull (hx : x ∈ s) (hy : y ∈ s) : segment 𝕜 x
 theorem convexHull_singleton (x : E) : convexHull 𝕜 ({x} : Set E) = {x} :=
   (convex_singleton x).convexHull_eq
 
+@[simp] lemma convexHull_eq_singleton : convexHull 𝕜 s = {x} ↔ s = {x} where
+  mp hs := by
+    rw [← Set.Nonempty.subset_singleton_iff, ← hs]
+    · exact subset_convexHull ..
+    · by_contra! hs
+      simp_all [eq_comm (a := ∅)]
+  mpr hs := by simp [hs]
+
 @[simp]
 theorem convexHull_zero : convexHull 𝕜 (0 : Set E) = 0 :=
   convexHull_singleton 0
+
+@[simp] lemma convexHull_eq_zero : convexHull 𝕜 s = 0 ↔ s = 0 := convexHull_eq_singleton
 
 @[simp]
 theorem convexHull_pair [IsOrderedRing 𝕜] (x y : E) : convexHull 𝕜 {x, y} = segment 𝕜 x y := by


### PR DESCRIPTION
Also fix the misnamed `convexHull_empty_iff`.

From MiscYD


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
