### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Sites): golf `isSheafFor_bind` using `grind`

### DIFF
--- a/Mathlib/CategoryTheory/Sites/Canonical.lean
+++ b/Mathlib/CategoryTheory/Sites/Canonical.lean
@@ -81,11 +81,7 @@ theorem isSheafFor_bind (P : Cᵒᵖ ⥤ Type v) (U : Sieve X) (B : ∀ ⦃Y⦄ 
     trans s (m ≫ l ≫ h ≫ f) this
     · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
       rw [op_comp, FunctorToTypes.map_comp_apply] at this
-      rw [this]
-      change s _ _ = s _ _
-      -- Porting note: the proof was `by simp`
-      congr 1
-      simp only [assoc]
+      grind
     · have h : s _ _ = _ := (ht hf _ hm).symm
       -- Porting note: this was done by `simp only [assoc] at`
       conv_lhs at h => congr; rw [assoc, assoc]


### PR DESCRIPTION
Motivation: Make use of available automation (and shorten the proof).

<details>
<summary>Show trace profiling of <code> isSheafFor_bind </code></summary>

### Before
```
ℹ [838/838] Replayed Mathlib.CategoryTheory.Sites.Canonical
info: Mathlib/CategoryTheory/Sites/Canonical.lean:48:0: [Elab.command] [0.014550] /--
    To show `P` is a sheaf for the binding of `U` with `B`, it suffices to show that `P` is a sheaf for
    `U`, that `P` is a sheaf for each sieve in `B`, and that it is separated for any pullback of any
    sieve in `B`.
    
    This is mostly an auxiliary lemma to show `isSheafFor_trans`.
    Adapted from [Elephant], Lemma C2.1.7(i) with suggestions as mentioned in
    https://math.stackexchange.com/a/358709/
    -/
    theorem isSheafFor_bind (P : Cᵒᵖ ⥤ Type v) (U : Sieve X) (B : ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄, U f → Sieve Y)
        (hU : Presieve.IsSheafFor P (U : Presieve X))
        (hB : ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄ (hf : U f), Presieve.IsSheafFor P (B hf : Presieve Y))
        (hB' :
          ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄ (h : U f) ⦃Z⦄ (g : Z ⟶ Y), Presieve.IsSeparatedFor P (((B h).pullback g) : Presieve Z)) :
        Presieve.IsSheafFor P (Sieve.bind (U : Presieve X) B : Presieve X) :=
      by
      intro s hs
      let y : ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄ (hf : U f), Presieve.FamilyOfElements P (B hf : Presieve Y) := fun Y f hf Z g hg =>
        s _ (Presieve.bind_comp _ _ hg)
      have hy : ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄ (hf : U f), (y hf).Compatible :=
        by
        intro Y f H Y₁ Y₂ Z g₁ g₂ f₁ f₂ hf₁ hf₂ comm
        apply hs
        apply reassoc_of% comm
      let t : Presieve.FamilyOfElements P (U : Presieve X) := fun Y f hf => (hB hf).amalgamate (y hf) (hy hf)
      have ht : ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄ (hf : U f), (y hf).IsAmalgamation (t f hf) := fun Y f hf => (hB hf).isAmalgamation _
      have hT : t.Compatible := by
        rw [Presieve.compatible_iff_sieveCompatible]
        intro Z W f h hf
        apply (hB (U.downward_closed hf h)).isSeparatedFor.ext
        intro Y l hl
        apply (hB' hf (l ≫ h)).ext
        intro M m hm
        have : bind U B (m ≫ l ≫ h ≫ f) := by simpa using (Presieve.bind_comp f hf hm : bind U B _)
        trans s (m ≫ l ≫ h ≫ f) this
        · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
          rw [op_comp, FunctorToTypes.map_comp_apply] at this
          rw [this]
          change
            s _ _ =
              s _
                _
                  -- Porting note: the proof was `by simp`
                  
          congr 1
          simp only [assoc]
        · have h : s _ _ = _ := (ht hf _ hm).symm
          conv_lhs at h => congr; rw [assoc, assoc]
          rw [h]
          simp only [op_comp, assoc, FunctorToTypes.map_comp_apply]
      refine ⟨hU.amalgamate t hT, ?_, ?_⟩
      · rintro Z _ ⟨Y, f, g, hg, hf, rfl⟩
        rw [op_comp, FunctorToTypes.map_comp_apply, Presieve.IsSheafFor.valid_glue _ _ _ hg]
        apply ht hg _ hf
      · intro y hy
        apply hU.isSeparatedFor.ext
        intro Y f hf
        apply (hB hf).isSeparatedFor.ext
        intro Z g hg
        rw [← FunctorToTypes.map_comp_apply, ← op_comp, hy _ (Presieve.bind_comp _ _ hg), hU.valid_glue _ _ hf,
          ht hf _ hg]
  [Elab.definition.header] [0.013428] CategoryTheory.Sheaf.isSheafFor_bind
info: Mathlib/CategoryTheory/Sites/Canonical.lean:48:0: [Elab.async] [0.114179] elaborating proof of CategoryTheory.Sheaf.isSheafFor_bind
  [Elab.definition.value] [0.110524] CategoryTheory.Sheaf.isSheafFor_bind
    [Elab.step] [0.104029] 
          intro s hs
          let y : ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄ (hf : U f), Presieve.FamilyOfElements P (B hf : Presieve Y) := fun Y f hf Z g hg =>
            s _ (Presieve.bind_comp _ _ hg)
          have hy : ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄ (hf : U f), (y hf).Compatible :=
            by
            intro Y f H Y₁ Y₂ Z g₁ g₂ f₁ f₂ hf₁ hf₂ comm
            apply hs
            apply reassoc_of% comm
          let t : Presieve.FamilyOfElements P (U : Presieve X) := fun Y f hf => (hB hf).amalgamate (y hf) (hy hf)
          have ht : ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄ (hf : U f), (y hf).IsAmalgamation (t f hf) := fun Y f hf =>
            (hB hf).isAmalgamation _
          have hT : t.Compatible := by
            rw [Presieve.compatible_iff_sieveCompatible]
            intro Z W f h hf
            apply (hB (U.downward_closed hf h)).isSeparatedFor.ext
            intro Y l hl
            apply (hB' hf (l ≫ h)).ext
            intro M m hm
            have : bind U B (m ≫ l ≫ h ≫ f) := by simpa using (Presieve.bind_comp f hf hm : bind U B _)
            trans s (m ≫ l ≫ h ≫ f) this
            · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
              rw [op_comp, FunctorToTypes.map_comp_apply] at this
              rw [this]
              change
                s _ _ =
                  s _
                    _
                      -- Porting note: the proof was `by simp`
                      
              congr 1
              simp only [assoc]
            · have h : s _ _ = _ := (ht hf _ hm).symm
              conv_lhs at h => congr; rw [assoc, assoc]
              rw [h]
              simp only [op_comp, assoc, FunctorToTypes.map_comp_apply]
          refine ⟨hU.amalgamate t hT, ?_, ?_⟩
          · rintro Z _ ⟨Y, f, g, hg, hf, rfl⟩
            rw [op_comp, FunctorToTypes.map_comp_apply, Presieve.IsSheafFor.valid_glue _ _ _ hg]
            apply ht hg _ hf
          · intro y hy
            apply hU.isSeparatedFor.ext
            intro Y f hf
            apply (hB hf).isSeparatedFor.ext
            intro Z g hg
            rw [← FunctorToTypes.map_comp_apply, ← op_comp, hy _ (Presieve.bind_comp _ _ hg), hU.valid_glue _ _ hf,
              ht hf _ hg]
      [Elab.step] [0.104019] 
            intro s hs
            let y : ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄ (hf : U f), Presieve.FamilyOfElements P (B hf : Presieve Y) :=
              fun Y f hf Z g hg => s _ (Presieve.bind_comp _ _ hg)
            have hy : ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄ (hf : U f), (y hf).Compatible :=
              by
              intro Y f H Y₁ Y₂ Z g₁ g₂ f₁ f₂ hf₁ hf₂ comm
              apply hs
              apply reassoc_of% comm
            let t : Presieve.FamilyOfElements P (U : Presieve X) := fun Y f hf => (hB hf).amalgamate (y hf) (hy hf)
            have ht : ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄ (hf : U f), (y hf).IsAmalgamation (t f hf) := fun Y f hf =>
              (hB hf).isAmalgamation _
            have hT : t.Compatible := by
              rw [Presieve.compatible_iff_sieveCompatible]
              intro Z W f h hf
              apply (hB (U.downward_closed hf h)).isSeparatedFor.ext
              intro Y l hl
              apply (hB' hf (l ≫ h)).ext
              intro M m hm
              have : bind U B (m ≫ l ≫ h ≫ f) := by simpa using (Presieve.bind_comp f hf hm : bind U B _)
              trans s (m ≫ l ≫ h ≫ f) this
              · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
                rw [op_comp, FunctorToTypes.map_comp_apply] at this
                rw [this]
                change
                  s _ _ =
                    s _
                      _
                        -- Porting note: the proof was `by simp`
                        
                congr 1
                simp only [assoc]
              · have h : s _ _ = _ := (ht hf _ hm).symm
                conv_lhs at h => congr; rw [assoc, assoc]
                rw [h]
                simp only [op_comp, assoc, FunctorToTypes.map_comp_apply]
            refine ⟨hU.amalgamate t hT, ?_, ?_⟩
            · rintro Z _ ⟨Y, f, g, hg, hf, rfl⟩
              rw [op_comp, FunctorToTypes.map_comp_apply, Presieve.IsSheafFor.valid_glue _ _ _ hg]
              apply ht hg _ hf
            · intro y hy
              apply hU.isSeparatedFor.ext
              intro Y f hf
              apply (hB hf).isSeparatedFor.ext
              intro Z g hg
              rw [← FunctorToTypes.map_comp_apply, ← op_comp, hy _ (Presieve.bind_comp _ _ hg), hU.valid_glue _ _ hf,
                ht hf _ hg]
        [Elab.step] [0.070744] have hT : t.Compatible :=
              by
              rw [Presieve.compatible_iff_sieveCompatible]
              intro Z W f h hf
              apply (hB (U.downward_closed hf h)).isSeparatedFor.ext
              intro Y l hl
              apply (hB' hf (l ≫ h)).ext
              intro M m hm
              have : bind U B (m ≫ l ≫ h ≫ f) := by simpa using (Presieve.bind_comp f hf hm : bind U B _)
              trans s (m ≫ l ≫ h ≫ f) this
              · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
                rw [op_comp, FunctorToTypes.map_comp_apply] at this
                rw [this]
                change
                  s _ _ =
                    s _
                      _
                        -- Porting note: the proof was `by simp`
                        
                congr 1
                simp only [assoc]
              · have h : s _ _ = _ := (ht hf _ hm).symm
                conv_lhs at h => congr; rw [assoc, assoc]
                rw [h]
                simp only [op_comp, assoc, FunctorToTypes.map_comp_apply]
          [Elab.step] [0.070651] focus
                refine
                  no_implicit_lambda%
                    (have hT : t.Compatible := ?body✝;
                    ?_)
                case body✝ =>
                  with_annotate_state"by"
                    ( rw [Presieve.compatible_iff_sieveCompatible]
                      intro Z W f h hf
                      apply (hB (U.downward_closed hf h)).isSeparatedFor.ext
                      intro Y l hl
                      apply (hB' hf (l ≫ h)).ext
                      intro M m hm
                      have : bind U B (m ≫ l ≫ h ≫ f) := by simpa using (Presieve.bind_comp f hf hm : bind U B _)
                      trans s (m ≫ l ≫ h ≫ f) this
                      · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
                        rw [op_comp, FunctorToTypes.map_comp_apply] at this
                        rw [this]
                        change
                          s _ _ =
                            s _
                              _
                                -- Porting note: the proof was `by simp`
                                
                        congr 1
                        simp only [assoc]
                      · have h : s _ _ = _ := (ht hf _ hm).symm
                        conv_lhs at h => congr; rw [assoc, assoc]
                        rw [h]
                        simp only [op_comp, assoc, FunctorToTypes.map_comp_apply])
            [Elab.step] [0.070647] 
                  refine
                    no_implicit_lambda%
                      (have hT : t.Compatible := ?body✝;
                      ?_)
                  case body✝ =>
                    with_annotate_state"by"
                      ( rw [Presieve.compatible_iff_sieveCompatible]
                        intro Z W f h hf
                        apply (hB (U.downward_closed hf h)).isSeparatedFor.ext
                        intro Y l hl
                        apply (hB' hf (l ≫ h)).ext
                        intro M m hm
                        have : bind U B (m ≫ l ≫ h ≫ f) := by simpa using (Presieve.bind_comp f hf hm : bind U B _)
                        trans s (m ≫ l ≫ h ≫ f) this
                        · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
                          rw [op_comp, FunctorToTypes.map_comp_apply] at this
                          rw [this]
                          change
                            s _ _ =
                              s _
                                _
                                  -- Porting note: the proof was `by simp`
                                  
                          congr 1
                          simp only [assoc]
                        · have h : s _ _ = _ := (ht hf _ hm).symm
                          conv_lhs at h => congr; rw [assoc, assoc]
                          rw [h]
                          simp only [op_comp, assoc, FunctorToTypes.map_comp_apply])
              [Elab.step] [0.070644] 
                    refine
                      no_implicit_lambda%
                        (have hT : t.Compatible := ?body✝;
                        ?_)
                    case body✝ =>
                      with_annotate_state"by"
                        ( rw [Presieve.compatible_iff_sieveCompatible]
                          intro Z W f h hf
                          apply (hB (U.downward_closed hf h)).isSeparatedFor.ext
                          intro Y l hl
                          apply (hB' hf (l ≫ h)).ext
                          intro M m hm
                          have : bind U B (m ≫ l ≫ h ≫ f) := by simpa using (Presieve.bind_comp f hf hm : bind U B _)
                          trans s (m ≫ l ≫ h ≫ f) this
                          · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
                            rw [op_comp, FunctorToTypes.map_comp_apply] at this
                            rw [this]
                            change
                              s _ _ =
                                s _
                                  _
                                    -- Porting note: the proof was `by simp`
                                    
                            congr 1
                            simp only [assoc]
                          · have h : s _ _ = _ := (ht hf _ hm).symm
                            conv_lhs at h => congr; rw [assoc, assoc]
                            rw [h]
                            simp only [op_comp, assoc, FunctorToTypes.map_comp_apply])
                [Elab.step] [0.070400] case body✝ =>
                      with_annotate_state"by"
                        ( rw [Presieve.compatible_iff_sieveCompatible]
                          intro Z W f h hf
                          apply (hB (U.downward_closed hf h)).isSeparatedFor.ext
                          intro Y l hl
                          apply (hB' hf (l ≫ h)).ext
                          intro M m hm
                          have : bind U B (m ≫ l ≫ h ≫ f) := by simpa using (Presieve.bind_comp f hf hm : bind U B _)
                          trans s (m ≫ l ≫ h ≫ f) this
                          · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
                            rw [op_comp, FunctorToTypes.map_comp_apply] at this
                            rw [this]
                            change
                              s _ _ =
                                s _
                                  _
                                    -- Porting note: the proof was `by simp`
                                    
                            congr 1
                            simp only [assoc]
                          · have h : s _ _ = _ := (ht hf _ hm).symm
                            conv_lhs at h => congr; rw [assoc, assoc]
                            rw [h]
                            simp only [op_comp, assoc, FunctorToTypes.map_comp_apply])
                  [Elab.step] [0.070383] with_annotate_state"by"
                          ( rw [Presieve.compatible_iff_sieveCompatible]
                            intro Z W f h hf
                            apply (hB (U.downward_closed hf h)).isSeparatedFor.ext
                            intro Y l hl
                            apply (hB' hf (l ≫ h)).ext
                            intro M m hm
                            have : bind U B (m ≫ l ≫ h ≫ f) := by simpa using (Presieve.bind_comp f hf hm : bind U B _)
                            trans s (m ≫ l ≫ h ≫ f) this
                            · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
                              rw [op_comp, FunctorToTypes.map_comp_apply] at this
                              rw [this]
                              change
                                s _ _ =
                                  s _
                                    _
                                      -- Porting note: the proof was `by simp`
                                      
                              congr 1
                              simp only [assoc]
                            · have h : s _ _ = _ := (ht hf _ hm).symm
                              conv_lhs at h => congr; rw [assoc, assoc]
                              rw [h]
                              simp only [op_comp, assoc, FunctorToTypes.map_comp_apply])
                    [Elab.step] [0.070380] with_annotate_state"by"
                            ( rw [Presieve.compatible_iff_sieveCompatible]
                              intro Z W f h hf
                              apply (hB (U.downward_closed hf h)).isSeparatedFor.ext
                              intro Y l hl
                              apply (hB' hf (l ≫ h)).ext
                              intro M m hm
                              have : bind U B (m ≫ l ≫ h ≫ f) := by
                                simpa using (Presieve.bind_comp f hf hm : bind U B _)
                              trans s (m ≫ l ≫ h ≫ f) this
                              · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
                                rw [op_comp, FunctorToTypes.map_comp_apply] at this
                                rw [this]
                                change
                                  s _ _ =
                                    s _
                                      _
                                        -- Porting note: the proof was `by simp`
                                        
                                congr 1
                                simp only [assoc]
                              · have h : s _ _ = _ := (ht hf _ hm).symm
                                conv_lhs at h => congr; rw [assoc, assoc]
                                rw [h]
                                simp only [op_comp, assoc, FunctorToTypes.map_comp_apply])
                      [Elab.step] [0.070377] with_annotate_state"by"
                            ( rw [Presieve.compatible_iff_sieveCompatible]
                              intro Z W f h hf
                              apply (hB (U.downward_closed hf h)).isSeparatedFor.ext
                              intro Y l hl
                              apply (hB' hf (l ≫ h)).ext
                              intro M m hm
                              have : bind U B (m ≫ l ≫ h ≫ f) := by
                                simpa using (Presieve.bind_comp f hf hm : bind U B _)
                              trans s (m ≫ l ≫ h ≫ f) this
                              · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
                                rw [op_comp, FunctorToTypes.map_comp_apply] at this
                                rw [this]
                                change
                                  s _ _ =
                                    s _
                                      _
                                        -- Porting note: the proof was `by simp`
                                        
                                congr 1
                                simp only [assoc]
                              · have h : s _ _ = _ := (ht hf _ hm).symm
                                conv_lhs at h => congr; rw [assoc, assoc]
                                rw [h]
                                simp only [op_comp, assoc, FunctorToTypes.map_comp_apply])
                        [Elab.step] [0.070374] (
                              rw [Presieve.compatible_iff_sieveCompatible]
                              intro Z W f h hf
                              apply (hB (U.downward_closed hf h)).isSeparatedFor.ext
                              intro Y l hl
                              apply (hB' hf (l ≫ h)).ext
                              intro M m hm
                              have : bind U B (m ≫ l ≫ h ≫ f) := by
                                simpa using (Presieve.bind_comp f hf hm : bind U B _)
                              trans s (m ≫ l ≫ h ≫ f) this
                              · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
                                rw [op_comp, FunctorToTypes.map_comp_apply] at this
                                rw [this]
                                change
                                  s _ _ =
                                    s _
                                      _
                                        -- Porting note: the proof was `by simp`
                                        
                                congr 1
                                simp only [assoc]
                              · have h : s _ _ = _ := (ht hf _ hm).symm
                                conv_lhs at h => congr; rw [assoc, assoc]
                                rw [h]
                                simp only [op_comp, assoc, FunctorToTypes.map_comp_apply])
                          [Elab.step] [0.070371] 
                                rw [Presieve.compatible_iff_sieveCompatible]
                                intro Z W f h hf
                                apply (hB (U.downward_closed hf h)).isSeparatedFor.ext
                                intro Y l hl
                                apply (hB' hf (l ≫ h)).ext
                                intro M m hm
                                have : bind U B (m ≫ l ≫ h ≫ f) := by
                                  simpa using (Presieve.bind_comp f hf hm : bind U B _)
                                trans s (m ≫ l ≫ h ≫ f) this
                                · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
                                  rw [op_comp, FunctorToTypes.map_comp_apply] at this
                                  rw [this]
                                  change
                                    s _ _ =
                                      s _
                                        _
                                          -- Porting note: the proof was `by simp`
                                          
                                  congr 1
                                  simp only [assoc]
                                · have h : s _ _ = _ := (ht hf _ hm).symm
                                  conv_lhs at h => congr; rw [assoc, assoc]
                                  rw [h]
                                  simp only [op_comp, assoc, FunctorToTypes.map_comp_apply]
                            [Elab.step] [0.070366] 
                                  rw [Presieve.compatible_iff_sieveCompatible]
                                  intro Z W f h hf
                                  apply (hB (U.downward_closed hf h)).isSeparatedFor.ext
                                  intro Y l hl
                                  apply (hB' hf (l ≫ h)).ext
                                  intro M m hm
                                  have : bind U B (m ≫ l ≫ h ≫ f) := by
                                    simpa using (Presieve.bind_comp f hf hm : bind U B _)
                                  trans s (m ≫ l ≫ h ≫ f) this
                                  · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
                                    rw [op_comp, FunctorToTypes.map_comp_apply] at this
                                    rw [this]
                                    change
                                      s _ _ =
                                        s _
                                          _
                                            -- Porting note: the proof was `by simp`
                                            
                                    congr 1
                                    simp only [assoc]
                                  · have h : s _ _ = _ := (ht hf _ hm).symm
                                    conv_lhs at h => congr; rw [assoc, assoc]
                                    rw [h]
                                    simp only [op_comp, assoc, FunctorToTypes.map_comp_apply]
                              [Elab.step] [0.048056] have : bind U B (m ≫ l ≫ h ≫ f) := by
                                    simpa using (Presieve.bind_comp f hf hm : bind U B _)
                                [Elab.step] [0.048035] focus
                                      refine
                                        no_implicit_lambda%
                                          (have : bind U B (m ≫ l ≫ h ≫ f) := ?body✝;
                                          ?_)
                                      case body✝ =>
                                        with_annotate_state"by" (simpa using (Presieve.bind_comp f hf hm : bind U B _))
                                  [Elab.step] [0.048032] 
                                        refine
                                          no_implicit_lambda%
                                            (have : bind U B (m ≫ l ≫ h ≫ f) := ?body✝;
                                            ?_)
                                        case body✝ =>
                                          with_annotate_state"by"
                                            (simpa using (Presieve.bind_comp f hf hm : bind U B _))
                                    [Elab.step] [0.048029] 
                                          refine
                                            no_implicit_lambda%
                                              (have : bind U B (m ≫ l ≫ h ≫ f) := ?body✝;
                                              ?_)
                                          case body✝ =>
                                            with_annotate_state"by"
                                              (simpa using (Presieve.bind_comp f hf hm : bind U B _))
                                      [Elab.step] [0.018655] refine
                                            no_implicit_lambda%
                                              (have : bind U B (m ≫ l ≫ h ≫ f) := ?body✝;
                                              ?_)
                                        [Elab.step] [0.018606] expected type: P.map m.op (P.map l.op (t (h ≫ f) ⋯)) =
                                              P.map m.op (P.map l.op (P.map h.op (t f hf))), term
                                            no_implicit_lambda%
                                              (have : bind U B (m ≫ l ≫ h ≫ f) := ?body✝;
                                              ?_)
                                          [Elab.step] [0.018603] expected type: P.map m.op (P.map l.op (t (h ≫ f) ⋯)) =
                                                P.map m.op (P.map l.op (P.map h.op (t f hf))), term
                                              (have : bind U B (m ≫ l ≫ h ≫ f) := ?body✝;
                                              ?_)
                                            [Elab.step] [0.018598] expected type: P.map m.op
                                                    (P.map l.op (t (h ≫ f) ⋯)) =
                                                  P.map m.op (P.map l.op (P.map h.op (t f hf))), term
                                                have : bind U B (m ≫ l ≫ h ≫ f) := ?body✝;
                                                ?_
                                              [Elab.step] [0.018298] expected type: Prop, term
                                                  bind U B (m ≫ l ≫ h ≫ f)
                                                [Elab.step] [0.012305] expected type: M ⟶ X, term
                                                    (m ≫ l ≫ h ≫ f)
                                                  [Elab.step] [0.012300] expected type: M ⟶ X, term
                                                      m ≫ l ≫ h ≫ f
                                                    [Elab.step] [0.010181] expected type: M ⟶ X, term
                                                        CategoryStruct.comp✝ m (l ≫ h ≫ f)
                                      [Elab.step] [0.029363] case body✝ =>
                                            with_annotate_state"by"
                                              (simpa using (Presieve.bind_comp f hf hm : bind U B _))
                                        [Elab.step] [0.029326] with_annotate_state"by"
                                                (simpa using (Presieve.bind_comp f hf hm : bind U B _))
                                          [Elab.step] [0.029323] with_annotate_state"by"
                                                  (simpa using (Presieve.bind_comp f hf hm : bind U B _))
                                            [Elab.step] [0.029319] with_annotate_state"by"
                                                  (simpa using (Presieve.bind_comp f hf hm : bind U B _))
                                              [Elab.step] [0.029316] (simpa using
                                                      (Presieve.bind_comp f hf hm : bind U B _))
                                                [Elab.step] [0.029313] simpa using
                                                        (Presieve.bind_comp f hf hm : bind U B _)
                                                  [Elab.step] [0.029309] simpa using
                                                          (Presieve.bind_comp f hf hm : bind U B _)
                                                    [Elab.step] [0.029303] simpa using
                                                          (Presieve.bind_comp f hf hm : bind U B _)
                                                      [Elab.step] [0.011381] expected type: <not-available>, term
                                                          (Presieve.bind_comp f hf hm : bind U B _)
Build completed successfully.
```

### After
```
ℹ [838/838] Replayed Mathlib.CategoryTheory.Sites.Canonical
info: Mathlib/CategoryTheory/Sites/Canonical.lean:48:0: [Elab.command] [0.013801] /--
    To show `P` is a sheaf for the binding of `U` with `B`, it suffices to show that `P` is a sheaf for
    `U`, that `P` is a sheaf for each sieve in `B`, and that it is separated for any pullback of any
    sieve in `B`.
    
    This is mostly an auxiliary lemma to show `isSheafFor_trans`.
    Adapted from [Elephant], Lemma C2.1.7(i) with suggestions as mentioned in
    https://math.stackexchange.com/a/358709/
    -/
    theorem isSheafFor_bind (P : Cᵒᵖ ⥤ Type v) (U : Sieve X) (B : ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄, U f → Sieve Y)
        (hU : Presieve.IsSheafFor P (U : Presieve X))
        (hB : ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄ (hf : U f), Presieve.IsSheafFor P (B hf : Presieve Y))
        (hB' :
          ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄ (h : U f) ⦃Z⦄ (g : Z ⟶ Y), Presieve.IsSeparatedFor P (((B h).pullback g) : Presieve Z)) :
        Presieve.IsSheafFor P (Sieve.bind (U : Presieve X) B : Presieve X) :=
      by
      intro s hs
      let y : ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄ (hf : U f), Presieve.FamilyOfElements P (B hf : Presieve Y) := fun Y f hf Z g hg =>
        s _ (Presieve.bind_comp _ _ hg)
      have hy : ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄ (hf : U f), (y hf).Compatible :=
        by
        intro Y f H Y₁ Y₂ Z g₁ g₂ f₁ f₂ hf₁ hf₂ comm
        apply hs
        apply reassoc_of% comm
      let t : Presieve.FamilyOfElements P (U : Presieve X) := fun Y f hf => (hB hf).amalgamate (y hf) (hy hf)
      have ht : ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄ (hf : U f), (y hf).IsAmalgamation (t f hf) := fun Y f hf => (hB hf).isAmalgamation _
      have hT : t.Compatible := by
        rw [Presieve.compatible_iff_sieveCompatible]
        intro Z W f h hf
        apply (hB (U.downward_closed hf h)).isSeparatedFor.ext
        intro Y l hl
        apply (hB' hf (l ≫ h)).ext
        intro M m hm
        have : bind U B (m ≫ l ≫ h ≫ f) := by simpa using (Presieve.bind_comp f hf hm : bind U B _)
        trans s (m ≫ l ≫ h ≫ f) this
        · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
          rw [op_comp, FunctorToTypes.map_comp_apply] at this
          grind
        · have h : s _ _ = _ := (ht hf _ hm).symm
          conv_lhs at h => congr; rw [assoc, assoc]
          rw [h]
          simp only [op_comp, assoc, FunctorToTypes.map_comp_apply]
      refine ⟨hU.amalgamate t hT, ?_, ?_⟩
      · rintro Z _ ⟨Y, f, g, hg, hf, rfl⟩
        rw [op_comp, FunctorToTypes.map_comp_apply, Presieve.IsSheafFor.valid_glue _ _ _ hg]
        apply ht hg _ hf
      · intro y hy
        apply hU.isSeparatedFor.ext
        intro Y f hf
        apply (hB hf).isSeparatedFor.ext
        intro Z g hg
        rw [← FunctorToTypes.map_comp_apply, ← op_comp, hy _ (Presieve.bind_comp _ _ hg), hU.valid_glue _ _ hf,
          ht hf _ hg]
  [Elab.definition.header] [0.012686] CategoryTheory.Sheaf.isSheafFor_bind
info: Mathlib/CategoryTheory/Sites/Canonical.lean:48:0: [Elab.async] [0.155829] elaborating proof of CategoryTheory.Sheaf.isSheafFor_bind
  [Elab.definition.value] [0.151988] CategoryTheory.Sheaf.isSheafFor_bind
    [Elab.step] [0.146449] 
          intro s hs
          let y : ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄ (hf : U f), Presieve.FamilyOfElements P (B hf : Presieve Y) := fun Y f hf Z g hg =>
            s _ (Presieve.bind_comp _ _ hg)
          have hy : ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄ (hf : U f), (y hf).Compatible :=
            by
            intro Y f H Y₁ Y₂ Z g₁ g₂ f₁ f₂ hf₁ hf₂ comm
            apply hs
            apply reassoc_of% comm
          let t : Presieve.FamilyOfElements P (U : Presieve X) := fun Y f hf => (hB hf).amalgamate (y hf) (hy hf)
          have ht : ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄ (hf : U f), (y hf).IsAmalgamation (t f hf) := fun Y f hf =>
            (hB hf).isAmalgamation _
          have hT : t.Compatible := by
            rw [Presieve.compatible_iff_sieveCompatible]
            intro Z W f h hf
            apply (hB (U.downward_closed hf h)).isSeparatedFor.ext
            intro Y l hl
            apply (hB' hf (l ≫ h)).ext
            intro M m hm
            have : bind U B (m ≫ l ≫ h ≫ f) := by simpa using (Presieve.bind_comp f hf hm : bind U B _)
            trans s (m ≫ l ≫ h ≫ f) this
            · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
              rw [op_comp, FunctorToTypes.map_comp_apply] at this
              grind
            · have h : s _ _ = _ := (ht hf _ hm).symm
              conv_lhs at h => congr; rw [assoc, assoc]
              rw [h]
              simp only [op_comp, assoc, FunctorToTypes.map_comp_apply]
          refine ⟨hU.amalgamate t hT, ?_, ?_⟩
          · rintro Z _ ⟨Y, f, g, hg, hf, rfl⟩
            rw [op_comp, FunctorToTypes.map_comp_apply, Presieve.IsSheafFor.valid_glue _ _ _ hg]
            apply ht hg _ hf
          · intro y hy
            apply hU.isSeparatedFor.ext
            intro Y f hf
            apply (hB hf).isSeparatedFor.ext
            intro Z g hg
            rw [← FunctorToTypes.map_comp_apply, ← op_comp, hy _ (Presieve.bind_comp _ _ hg), hU.valid_glue _ _ hf,
              ht hf _ hg]
      [Elab.step] [0.146439] 
            intro s hs
            let y : ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄ (hf : U f), Presieve.FamilyOfElements P (B hf : Presieve Y) :=
              fun Y f hf Z g hg => s _ (Presieve.bind_comp _ _ hg)
            have hy : ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄ (hf : U f), (y hf).Compatible :=
              by
              intro Y f H Y₁ Y₂ Z g₁ g₂ f₁ f₂ hf₁ hf₂ comm
              apply hs
              apply reassoc_of% comm
            let t : Presieve.FamilyOfElements P (U : Presieve X) := fun Y f hf => (hB hf).amalgamate (y hf) (hy hf)
            have ht : ∀ ⦃Y⦄ ⦃f : Y ⟶ X⦄ (hf : U f), (y hf).IsAmalgamation (t f hf) := fun Y f hf =>
              (hB hf).isAmalgamation _
            have hT : t.Compatible := by
              rw [Presieve.compatible_iff_sieveCompatible]
              intro Z W f h hf
              apply (hB (U.downward_closed hf h)).isSeparatedFor.ext
              intro Y l hl
              apply (hB' hf (l ≫ h)).ext
              intro M m hm
              have : bind U B (m ≫ l ≫ h ≫ f) := by simpa using (Presieve.bind_comp f hf hm : bind U B _)
              trans s (m ≫ l ≫ h ≫ f) this
              · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
                rw [op_comp, FunctorToTypes.map_comp_apply] at this
                grind
              · have h : s _ _ = _ := (ht hf _ hm).symm
                conv_lhs at h => congr; rw [assoc, assoc]
                rw [h]
                simp only [op_comp, assoc, FunctorToTypes.map_comp_apply]
            refine ⟨hU.amalgamate t hT, ?_, ?_⟩
            · rintro Z _ ⟨Y, f, g, hg, hf, rfl⟩
              rw [op_comp, FunctorToTypes.map_comp_apply, Presieve.IsSheafFor.valid_glue _ _ _ hg]
              apply ht hg _ hf
            · intro y hy
              apply hU.isSeparatedFor.ext
              intro Y f hf
              apply (hB hf).isSeparatedFor.ext
              intro Z g hg
              rw [← FunctorToTypes.map_comp_apply, ← op_comp, hy _ (Presieve.bind_comp _ _ hg), hU.valid_glue _ _ hf,
                ht hf _ hg]
        [Elab.step] [0.115973] have hT : t.Compatible :=
              by
              rw [Presieve.compatible_iff_sieveCompatible]
              intro Z W f h hf
              apply (hB (U.downward_closed hf h)).isSeparatedFor.ext
              intro Y l hl
              apply (hB' hf (l ≫ h)).ext
              intro M m hm
              have : bind U B (m ≫ l ≫ h ≫ f) := by simpa using (Presieve.bind_comp f hf hm : bind U B _)
              trans s (m ≫ l ≫ h ≫ f) this
              · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
                rw [op_comp, FunctorToTypes.map_comp_apply] at this
                grind
              · have h : s _ _ = _ := (ht hf _ hm).symm
                conv_lhs at h => congr; rw [assoc, assoc]
                rw [h]
                simp only [op_comp, assoc, FunctorToTypes.map_comp_apply]
          [Elab.step] [0.115875] focus
                refine
                  no_implicit_lambda%
                    (have hT : t.Compatible := ?body✝;
                    ?_)
                case body✝ =>
                  with_annotate_state"by"
                    ( rw [Presieve.compatible_iff_sieveCompatible]
                      intro Z W f h hf
                      apply (hB (U.downward_closed hf h)).isSeparatedFor.ext
                      intro Y l hl
                      apply (hB' hf (l ≫ h)).ext
                      intro M m hm
                      have : bind U B (m ≫ l ≫ h ≫ f) := by simpa using (Presieve.bind_comp f hf hm : bind U B _)
                      trans s (m ≫ l ≫ h ≫ f) this
                      · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
                        rw [op_comp, FunctorToTypes.map_comp_apply] at this
                        grind
                      · have h : s _ _ = _ := (ht hf _ hm).symm
                        conv_lhs at h => congr; rw [assoc, assoc]
                        rw [h]
                        simp only [op_comp, assoc, FunctorToTypes.map_comp_apply])
            [Elab.step] [0.115871] 
                  refine
                    no_implicit_lambda%
                      (have hT : t.Compatible := ?body✝;
                      ?_)
                  case body✝ =>
                    with_annotate_state"by"
                      ( rw [Presieve.compatible_iff_sieveCompatible]
                        intro Z W f h hf
                        apply (hB (U.downward_closed hf h)).isSeparatedFor.ext
                        intro Y l hl
                        apply (hB' hf (l ≫ h)).ext
                        intro M m hm
                        have : bind U B (m ≫ l ≫ h ≫ f) := by simpa using (Presieve.bind_comp f hf hm : bind U B _)
                        trans s (m ≫ l ≫ h ≫ f) this
                        · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
                          rw [op_comp, FunctorToTypes.map_comp_apply] at this
                          grind
                        · have h : s _ _ = _ := (ht hf _ hm).symm
                          conv_lhs at h => congr; rw [assoc, assoc]
                          rw [h]
                          simp only [op_comp, assoc, FunctorToTypes.map_comp_apply])
              [Elab.step] [0.115867] 
                    refine
                      no_implicit_lambda%
                        (have hT : t.Compatible := ?body✝;
                        ?_)
                    case body✝ =>
                      with_annotate_state"by"
                        ( rw [Presieve.compatible_iff_sieveCompatible]
                          intro Z W f h hf
                          apply (hB (U.downward_closed hf h)).isSeparatedFor.ext
                          intro Y l hl
                          apply (hB' hf (l ≫ h)).ext
                          intro M m hm
                          have : bind U B (m ≫ l ≫ h ≫ f) := by simpa using (Presieve.bind_comp f hf hm : bind U B _)
                          trans s (m ≫ l ≫ h ≫ f) this
                          · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
                            rw [op_comp, FunctorToTypes.map_comp_apply] at this
                            grind
                          · have h : s _ _ = _ := (ht hf _ hm).symm
                            conv_lhs at h => congr; rw [assoc, assoc]
                            rw [h]
                            simp only [op_comp, assoc, FunctorToTypes.map_comp_apply])
                [Elab.step] [0.115627] case body✝ =>
                      with_annotate_state"by"
                        ( rw [Presieve.compatible_iff_sieveCompatible]
                          intro Z W f h hf
                          apply (hB (U.downward_closed hf h)).isSeparatedFor.ext
                          intro Y l hl
                          apply (hB' hf (l ≫ h)).ext
                          intro M m hm
                          have : bind U B (m ≫ l ≫ h ≫ f) := by simpa using (Presieve.bind_comp f hf hm : bind U B _)
                          trans s (m ≫ l ≫ h ≫ f) this
                          · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
                            rw [op_comp, FunctorToTypes.map_comp_apply] at this
                            grind
                          · have h : s _ _ = _ := (ht hf _ hm).symm
                            conv_lhs at h => congr; rw [assoc, assoc]
                            rw [h]
                            simp only [op_comp, assoc, FunctorToTypes.map_comp_apply])
                  [Elab.step] [0.115611] with_annotate_state"by"
                          ( rw [Presieve.compatible_iff_sieveCompatible]
                            intro Z W f h hf
                            apply (hB (U.downward_closed hf h)).isSeparatedFor.ext
                            intro Y l hl
                            apply (hB' hf (l ≫ h)).ext
                            intro M m hm
                            have : bind U B (m ≫ l ≫ h ≫ f) := by simpa using (Presieve.bind_comp f hf hm : bind U B _)
                            trans s (m ≫ l ≫ h ≫ f) this
                            · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
                              rw [op_comp, FunctorToTypes.map_comp_apply] at this
                              grind
                            · have h : s _ _ = _ := (ht hf _ hm).symm
                              conv_lhs at h => congr; rw [assoc, assoc]
                              rw [h]
                              simp only [op_comp, assoc, FunctorToTypes.map_comp_apply])
                    [Elab.step] [0.115608] with_annotate_state"by"
                            ( rw [Presieve.compatible_iff_sieveCompatible]
                              intro Z W f h hf
                              apply (hB (U.downward_closed hf h)).isSeparatedFor.ext
                              intro Y l hl
                              apply (hB' hf (l ≫ h)).ext
                              intro M m hm
                              have : bind U B (m ≫ l ≫ h ≫ f) := by
                                simpa using (Presieve.bind_comp f hf hm : bind U B _)
                              trans s (m ≫ l ≫ h ≫ f) this
                              · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
                                rw [op_comp, FunctorToTypes.map_comp_apply] at this
                                grind
                              · have h : s _ _ = _ := (ht hf _ hm).symm
                                conv_lhs at h => congr; rw [assoc, assoc]
                                rw [h]
                                simp only [op_comp, assoc, FunctorToTypes.map_comp_apply])
                      [Elab.step] [0.115605] with_annotate_state"by"
                            ( rw [Presieve.compatible_iff_sieveCompatible]
                              intro Z W f h hf
                              apply (hB (U.downward_closed hf h)).isSeparatedFor.ext
                              intro Y l hl
                              apply (hB' hf (l ≫ h)).ext
                              intro M m hm
                              have : bind U B (m ≫ l ≫ h ≫ f) := by
                                simpa using (Presieve.bind_comp f hf hm : bind U B _)
                              trans s (m ≫ l ≫ h ≫ f) this
                              · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
                                rw [op_comp, FunctorToTypes.map_comp_apply] at this
                                grind
                              · have h : s _ _ = _ := (ht hf _ hm).symm
                                conv_lhs at h => congr; rw [assoc, assoc]
                                rw [h]
                                simp only [op_comp, assoc, FunctorToTypes.map_comp_apply])
                        [Elab.step] [0.115602] (
                              rw [Presieve.compatible_iff_sieveCompatible]
                              intro Z W f h hf
                              apply (hB (U.downward_closed hf h)).isSeparatedFor.ext
                              intro Y l hl
                              apply (hB' hf (l ≫ h)).ext
                              intro M m hm
                              have : bind U B (m ≫ l ≫ h ≫ f) := by
                                simpa using (Presieve.bind_comp f hf hm : bind U B _)
                              trans s (m ≫ l ≫ h ≫ f) this
                              · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
                                rw [op_comp, FunctorToTypes.map_comp_apply] at this
                                grind
                              · have h : s _ _ = _ := (ht hf _ hm).symm
                                conv_lhs at h => congr; rw [assoc, assoc]
                                rw [h]
                                simp only [op_comp, assoc, FunctorToTypes.map_comp_apply])
                          [Elab.step] [0.115598] 
                                rw [Presieve.compatible_iff_sieveCompatible]
                                intro Z W f h hf
                                apply (hB (U.downward_closed hf h)).isSeparatedFor.ext
                                intro Y l hl
                                apply (hB' hf (l ≫ h)).ext
                                intro M m hm
                                have : bind U B (m ≫ l ≫ h ≫ f) := by
                                  simpa using (Presieve.bind_comp f hf hm : bind U B _)
                                trans s (m ≫ l ≫ h ≫ f) this
                                · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
                                  rw [op_comp, FunctorToTypes.map_comp_apply] at this
                                  grind
                                · have h : s _ _ = _ := (ht hf _ hm).symm
                                  conv_lhs at h => congr; rw [assoc, assoc]
                                  rw [h]
                                  simp only [op_comp, assoc, FunctorToTypes.map_comp_apply]
                            [Elab.step] [0.115594] 
                                  rw [Presieve.compatible_iff_sieveCompatible]
                                  intro Z W f h hf
                                  apply (hB (U.downward_closed hf h)).isSeparatedFor.ext
                                  intro Y l hl
                                  apply (hB' hf (l ≫ h)).ext
                                  intro M m hm
                                  have : bind U B (m ≫ l ≫ h ≫ f) := by
                                    simpa using (Presieve.bind_comp f hf hm : bind U B _)
                                  trans s (m ≫ l ≫ h ≫ f) this
                                  · have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
                                    rw [op_comp, FunctorToTypes.map_comp_apply] at this
                                    grind
                                  · have h : s _ _ = _ := (ht hf _ hm).symm
                                    conv_lhs at h => congr; rw [assoc, assoc]
                                    rw [h]
                                    simp only [op_comp, assoc, FunctorToTypes.map_comp_apply]
                              [Elab.step] [0.043295] have : bind U B (m ≫ l ≫ h ≫ f) := by
                                    simpa using (Presieve.bind_comp f hf hm : bind U B _)
                                [Elab.step] [0.043275] focus
                                      refine
                                        no_implicit_lambda%
                                          (have : bind U B (m ≫ l ≫ h ≫ f) := ?body✝;
                                          ?_)
                                      case body✝ =>
                                        with_annotate_state"by" (simpa using (Presieve.bind_comp f hf hm : bind U B _))
                                  [Elab.step] [0.043271] 
                                        refine
                                          no_implicit_lambda%
                                            (have : bind U B (m ≫ l ≫ h ≫ f) := ?body✝;
                                            ?_)
                                        case body✝ =>
                                          with_annotate_state"by"
                                            (simpa using (Presieve.bind_comp f hf hm : bind U B _))
                                    [Elab.step] [0.043268] 
                                          refine
                                            no_implicit_lambda%
                                              (have : bind U B (m ≫ l ≫ h ≫ f) := ?body✝;
                                              ?_)
                                          case body✝ =>
                                            with_annotate_state"by"
                                              (simpa using (Presieve.bind_comp f hf hm : bind U B _))
                                      [Elab.step] [0.033468] case body✝ =>
                                            with_annotate_state"by"
                                              (simpa using (Presieve.bind_comp f hf hm : bind U B _))
                                        [Elab.step] [0.033431] with_annotate_state"by"
                                                (simpa using (Presieve.bind_comp f hf hm : bind U B _))
                                          [Elab.step] [0.033427] with_annotate_state"by"
                                                  (simpa using (Presieve.bind_comp f hf hm : bind U B _))
                                            [Elab.step] [0.033422] with_annotate_state"by"
                                                  (simpa using (Presieve.bind_comp f hf hm : bind U B _))
                                              [Elab.step] [0.033418] (simpa using
                                                      (Presieve.bind_comp f hf hm : bind U B _))
                                                [Elab.step] [0.033415] simpa using
                                                        (Presieve.bind_comp f hf hm : bind U B _)
                                                  [Elab.step] [0.033410] simpa using
                                                          (Presieve.bind_comp f hf hm : bind U B _)
                                                    [Elab.step] [0.033404] simpa using
                                                          (Presieve.bind_comp f hf hm : bind U B _)
                                                      [Elab.step] [0.013249] expected type: <not-available>, term
                                                          (Presieve.bind_comp f hf hm : bind U B _)
                              [Elab.step] [0.058366] ·
                                    have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
                                    rw [op_comp, FunctorToTypes.map_comp_apply] at this
                                    grind
                                [Elab.step] [0.058223] 
                                      have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
                                      rw [op_comp, FunctorToTypes.map_comp_apply] at this
                                      grind
                                  [Elab.step] [0.058219] 
                                        have := ht (U.downward_closed hf h) _ ((B _).downward_closed hl m)
                                        rw [op_comp, FunctorToTypes.map_comp_apply] at this
                                        grind
                                    [Elab.step] [0.054534] grind
Build completed successfully.
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
