### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Localization): golf `MorphismProperty.map_eq_iff_precomp` using `grind`

### DIFF
--- a/Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean
+++ b/Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean
@@ -965,8 +965,7 @@ lemma MorphismProperty.map_eq_iff_precomp {Y Z : C} (f₁ f₂ : Y ⟶ Z) :
       RightFraction.map_eq_iff] at h
     obtain ⟨Z, t₁, t₂, hst, hft, ht⟩ := h
     dsimp at t₁ t₂ hst hft ht
-    simp only [comp_id] at hst
-    exact ⟨Z, t₁, by simpa using ht, by rw [hft, hst]⟩
+    grind
   · rintro ⟨Z, s, hs, fac⟩
     simp only [← cancel_epi (Localization.isoOfHom L W s hs).hom,
       Localization.isoOfHom_hom, ← L.map_comp, fac]


### PR DESCRIPTION
Motivation: Make use of available automation (and shorten the proof).

---
<details>
<summary>Show trace profiling of <code>MorphismProperty.map_eq_iff_precomp</code></summary>

### Trace profiling of `MorphismProperty.map_eq_iff_precomp` before PR 28158
```diff
diff --git a/Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean b/Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean
index f616a2c221..c9fbba597e 100644
--- a/Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean
+++ b/Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean
@@ -958,2 +958,3 @@ lemma MorphismProperty.RightFraction.map_eq_iff
 
+set_option trace.profiler true in
 lemma MorphismProperty.map_eq_iff_precomp {Y Z : C} (f₁ f₂ : Y ⟶ Z) :
```
```
ℹ [575/575] Built Mathlib.CategoryTheory.Localization.CalculusOfFractions
info: Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean:960:0: [Elab.async] [0.020681] elaborating proof of CategoryTheory.MorphismProperty.map_eq_iff_precomp
  [Elab.definition.value] [0.019034] CategoryTheory.MorphismProperty.map_eq_iff_precomp
    [Elab.step] [0.017955] 
          constructor
          · intro h
            rw [← RightFraction.map_ofHom W _ L (Localization.inverts _ _), ←
              RightFraction.map_ofHom W _ L (Localization.inverts _ _), RightFraction.map_eq_iff] at h
            obtain ⟨Z, t₁, t₂, hst, hft, ht⟩ := h
            dsimp at t₁ t₂ hst hft ht
            simp only [comp_id] at hst
            exact ⟨Z, t₁, by simpa using ht, by rw [hft, hst]⟩
          · rintro ⟨Z, s, hs, fac⟩
            simp only [← cancel_epi (Localization.isoOfHom L W s hs).hom, Localization.isoOfHom_hom, ← L.map_comp, fac]
      [Elab.step] [0.017945] 
            constructor
            · intro h
              rw [← RightFraction.map_ofHom W _ L (Localization.inverts _ _), ←
                RightFraction.map_ofHom W _ L (Localization.inverts _ _), RightFraction.map_eq_iff] at h
              obtain ⟨Z, t₁, t₂, hst, hft, ht⟩ := h
              dsimp at t₁ t₂ hst hft ht
              simp only [comp_id] at hst
              exact ⟨Z, t₁, by simpa using ht, by rw [hft, hst]⟩
            · rintro ⟨Z, s, hs, fac⟩
              simp only [← cancel_epi (Localization.isoOfHom L W s hs).hom, Localization.isoOfHom_hom, ← L.map_comp,
                fac]
        [Elab.step] [0.011986] ·
              intro h
              rw [← RightFraction.map_ofHom W _ L (Localization.inverts _ _), ←
                RightFraction.map_ofHom W _ L (Localization.inverts _ _), RightFraction.map_eq_iff] at h
              obtain ⟨Z, t₁, t₂, hst, hft, ht⟩ := h
              dsimp at t₁ t₂ hst hft ht
              simp only [comp_id] at hst
              exact ⟨Z, t₁, by simpa using ht, by rw [hft, hst]⟩
          [Elab.step] [0.011979] 
                intro h
                rw [← RightFraction.map_ofHom W _ L (Localization.inverts _ _), ←
                  RightFraction.map_ofHom W _ L (Localization.inverts _ _), RightFraction.map_eq_iff] at h
                obtain ⟨Z, t₁, t₂, hst, hft, ht⟩ := h
                dsimp at t₁ t₂ hst hft ht
                simp only [comp_id] at hst
                exact ⟨Z, t₁, by simpa using ht, by rw [hft, hst]⟩
            [Elab.step] [0.011975] 
                  intro h
                  rw [← RightFraction.map_ofHom W _ L (Localization.inverts _ _), ←
                    RightFraction.map_ofHom W _ L (Localization.inverts _ _), RightFraction.map_eq_iff] at h
                  obtain ⟨Z, t₁, t₂, hst, hft, ht⟩ := h
                  dsimp at t₁ t₂ hst hft ht
                  simp only [comp_id] at hst
                  exact ⟨Z, t₁, by simpa using ht, by rw [hft, hst]⟩
Build completed successfully.
```

### Trace profiling of `MorphismProperty.map_eq_iff_precomp` after PR 28158
```diff
diff --git a/Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean b/Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean
index f616a2c221..0205e81051 100644
--- a/Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean
+++ b/Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean
@@ -958,2 +958,3 @@ lemma MorphismProperty.RightFraction.map_eq_iff
 
+set_option trace.profiler true in
 lemma MorphismProperty.map_eq_iff_precomp {Y Z : C} (f₁ f₂ : Y ⟶ Z) :
@@ -967,4 +968,3 @@ lemma MorphismProperty.map_eq_iff_precomp {Y Z : C} (f₁ f₂ : Y ⟶ Z) :
     dsimp at t₁ t₂ hst hft ht
-    simp only [comp_id] at hst
-    exact ⟨Z, t₁, by simpa using ht, by rw [hft, hst]⟩
+    grind
   · rintro ⟨Z, s, hs, fac⟩
```
```
ℹ [575/575] Built Mathlib.CategoryTheory.Localization.CalculusOfFractions
info: Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean:960:0: [Elab.async] [0.028281] elaborating proof of CategoryTheory.MorphismProperty.map_eq_iff_precomp
  [Elab.definition.value] [0.026656] CategoryTheory.MorphismProperty.map_eq_iff_precomp
    [Elab.step] [0.025753] 
          constructor
          · intro h
            rw [← RightFraction.map_ofHom W _ L (Localization.inverts _ _), ←
              RightFraction.map_ofHom W _ L (Localization.inverts _ _), RightFraction.map_eq_iff] at h
            obtain ⟨Z, t₁, t₂, hst, hft, ht⟩ := h
            dsimp at t₁ t₂ hst hft ht
            grind
          · rintro ⟨Z, s, hs, fac⟩
            simp only [← cancel_epi (Localization.isoOfHom L W s hs).hom, Localization.isoOfHom_hom, ← L.map_comp, fac]
      [Elab.step] [0.025747] 
            constructor
            · intro h
              rw [← RightFraction.map_ofHom W _ L (Localization.inverts _ _), ←
                RightFraction.map_ofHom W _ L (Localization.inverts _ _), RightFraction.map_eq_iff] at h
              obtain ⟨Z, t₁, t₂, hst, hft, ht⟩ := h
              dsimp at t₁ t₂ hst hft ht
              grind
            · rintro ⟨Z, s, hs, fac⟩
              simp only [← cancel_epi (Localization.isoOfHom L W s hs).hom, Localization.isoOfHom_hom, ← L.map_comp,
                fac]
        [Elab.step] [0.019869] ·
              intro h
              rw [← RightFraction.map_ofHom W _ L (Localization.inverts _ _), ←
                RightFraction.map_ofHom W _ L (Localization.inverts _ _), RightFraction.map_eq_iff] at h
              obtain ⟨Z, t₁, t₂, hst, hft, ht⟩ := h
              dsimp at t₁ t₂ hst hft ht
              grind
          [Elab.step] [0.019862] 
                intro h
                rw [← RightFraction.map_ofHom W _ L (Localization.inverts _ _), ←
                  RightFraction.map_ofHom W _ L (Localization.inverts _ _), RightFraction.map_eq_iff] at h
                obtain ⟨Z, t₁, t₂, hst, hft, ht⟩ := h
                dsimp at t₁ t₂ hst hft ht
                grind
            [Elab.step] [0.019858] 
                  intro h
                  rw [← RightFraction.map_ofHom W _ L (Localization.inverts _ _), ←
                    RightFraction.map_ofHom W _ L (Localization.inverts _ _), RightFraction.map_eq_iff] at h
                  obtain ⟨Z, t₁, t₂, hst, hft, ht⟩ := h
                  dsimp at t₁ t₂ hst hft ht
                  grind
              [Elab.step] [0.010227] grind
Build completed successfully.
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
