### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Localization): golf `MorphismProperty.map_eq_iff_postcomp` using `grind`

### DIFF
--- a/Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean
+++ b/Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean
@@ -756,8 +756,7 @@ lemma MorphismProperty.map_eq_iff_postcomp {X Y : C} (f₁ f₂ : X ⟶ Y) :
       LeftFraction.map_eq_iff] at h
     obtain ⟨Z, t₁, t₂, hst, hft, ht⟩ := h
     dsimp at t₁ t₂ hst hft ht
-    simp only [id_comp] at hst
-    exact ⟨Z, t₁, by simpa using ht, by rw [hft, hst]⟩
+    grind
   · rintro ⟨Z, s, hs, fac⟩
     simp only [← cancel_mono (Localization.isoOfHom L W s hs).hom,
       Localization.isoOfHom_hom, ← L.map_comp, fac]


### PR DESCRIPTION
Motivation: Make use of available automation (and shorten the proof).

---
<details>
<summary>Show trace profiling of <code>MorphismProperty.map_eq_iff_postcomp</code></summary>

### Trace profiling of `MorphismProperty.map_eq_iff_postcomp` before PR 28159
```diff
diff --git a/Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean b/Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean
index f616a2c221..5ba7ce4488 100644
--- a/Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean
+++ b/Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean
@@ -749,2 +749,3 @@ lemma MorphismProperty.LeftFraction.map_eq_iff
 
+set_option trace.profiler true in
 lemma MorphismProperty.map_eq_iff_postcomp {X Y : C} (f₁ f₂ : X ⟶ Y) :
```
```
ℹ [575/575] Built Mathlib.CategoryTheory.Localization.CalculusOfFractions
info: Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean:751:0: [Elab.async] [0.024495] elaborating proof of CategoryTheory.MorphismProperty.map_eq_iff_postcomp
  [Elab.definition.value] [0.022831] CategoryTheory.MorphismProperty.map_eq_iff_postcomp
    [Elab.step] [0.021688] 
          constructor
          · intro h
            rw [← LeftFraction.map_ofHom W _ L (Localization.inverts _ _), ←
              LeftFraction.map_ofHom W _ L (Localization.inverts _ _), LeftFraction.map_eq_iff] at h
            obtain ⟨Z, t₁, t₂, hst, hft, ht⟩ := h
            dsimp at t₁ t₂ hst hft ht
            simp only [id_comp] at hst
            exact ⟨Z, t₁, by simpa using ht, by rw [hft, hst]⟩
          · rintro ⟨Z, s, hs, fac⟩
            simp only [← cancel_mono (Localization.isoOfHom L W s hs).hom, Localization.isoOfHom_hom, ← L.map_comp, fac]
      [Elab.step] [0.021682] 
            constructor
            · intro h
              rw [← LeftFraction.map_ofHom W _ L (Localization.inverts _ _), ←
                LeftFraction.map_ofHom W _ L (Localization.inverts _ _), LeftFraction.map_eq_iff] at h
              obtain ⟨Z, t₁, t₂, hst, hft, ht⟩ := h
              dsimp at t₁ t₂ hst hft ht
              simp only [id_comp] at hst
              exact ⟨Z, t₁, by simpa using ht, by rw [hft, hst]⟩
            · rintro ⟨Z, s, hs, fac⟩
              simp only [← cancel_mono (Localization.isoOfHom L W s hs).hom, Localization.isoOfHom_hom, ← L.map_comp,
                fac]
        [Elab.step] [0.014379] ·
              intro h
              rw [← LeftFraction.map_ofHom W _ L (Localization.inverts _ _), ←
                LeftFraction.map_ofHom W _ L (Localization.inverts _ _), LeftFraction.map_eq_iff] at h
              obtain ⟨Z, t₁, t₂, hst, hft, ht⟩ := h
              dsimp at t₁ t₂ hst hft ht
              simp only [id_comp] at hst
              exact ⟨Z, t₁, by simpa using ht, by rw [hft, hst]⟩
          [Elab.step] [0.014371] 
                intro h
                rw [← LeftFraction.map_ofHom W _ L (Localization.inverts _ _), ←
                  LeftFraction.map_ofHom W _ L (Localization.inverts _ _), LeftFraction.map_eq_iff] at h
                obtain ⟨Z, t₁, t₂, hst, hft, ht⟩ := h
                dsimp at t₁ t₂ hst hft ht
                simp only [id_comp] at hst
                exact ⟨Z, t₁, by simpa using ht, by rw [hft, hst]⟩
            [Elab.step] [0.014365] 
                  intro h
                  rw [← LeftFraction.map_ofHom W _ L (Localization.inverts _ _), ←
                    LeftFraction.map_ofHom W _ L (Localization.inverts _ _), LeftFraction.map_eq_iff] at h
                  obtain ⟨Z, t₁, t₂, hst, hft, ht⟩ := h
                  dsimp at t₁ t₂ hst hft ht
                  simp only [id_comp] at hst
                  exact ⟨Z, t₁, by simpa using ht, by rw [hft, hst]⟩
Build completed successfully.
```

### Trace profiling of `MorphismProperty.map_eq_iff_postcomp` after PR 28159
```diff
diff --git a/Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean b/Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean
index f616a2c221..6b5e64c84a 100644
--- a/Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean
+++ b/Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean
@@ -749,2 +749,3 @@ lemma MorphismProperty.LeftFraction.map_eq_iff
 
+set_option trace.profiler true in
 lemma MorphismProperty.map_eq_iff_postcomp {X Y : C} (f₁ f₂ : X ⟶ Y) :
@@ -758,4 +759,3 @@ lemma MorphismProperty.map_eq_iff_postcomp {X Y : C} (f₁ f₂ : X ⟶ Y) :
     dsimp at t₁ t₂ hst hft ht
-    simp only [id_comp] at hst
-    exact ⟨Z, t₁, by simpa using ht, by rw [hft, hst]⟩
+    grind
   · rintro ⟨Z, s, hs, fac⟩
```
```
ℹ [575/575] Built Mathlib.CategoryTheory.Localization.CalculusOfFractions
info: Mathlib/CategoryTheory/Localization/CalculusOfFractions.lean:751:0: [Elab.async] [0.075146] elaborating proof of CategoryTheory.MorphismProperty.map_eq_iff_postcomp
  [Elab.definition.value] [0.073581] CategoryTheory.MorphismProperty.map_eq_iff_postcomp
    [Elab.step] [0.072676] 
          constructor
          · intro h
            rw [← LeftFraction.map_ofHom W _ L (Localization.inverts _ _), ←
              LeftFraction.map_ofHom W _ L (Localization.inverts _ _), LeftFraction.map_eq_iff] at h
            obtain ⟨Z, t₁, t₂, hst, hft, ht⟩ := h
            dsimp at t₁ t₂ hst hft ht
            grind
          · rintro ⟨Z, s, hs, fac⟩
            simp only [← cancel_mono (Localization.isoOfHom L W s hs).hom, Localization.isoOfHom_hom, ← L.map_comp, fac]
      [Elab.step] [0.072670] 
            constructor
            · intro h
              rw [← LeftFraction.map_ofHom W _ L (Localization.inverts _ _), ←
                LeftFraction.map_ofHom W _ L (Localization.inverts _ _), LeftFraction.map_eq_iff] at h
              obtain ⟨Z, t₁, t₂, hst, hft, ht⟩ := h
              dsimp at t₁ t₂ hst hft ht
              grind
            · rintro ⟨Z, s, hs, fac⟩
              simp only [← cancel_mono (Localization.isoOfHom L W s hs).hom, Localization.isoOfHom_hom, ← L.map_comp,
                fac]
        [Elab.step] [0.066110] ·
              intro h
              rw [← LeftFraction.map_ofHom W _ L (Localization.inverts _ _), ←
                LeftFraction.map_ofHom W _ L (Localization.inverts _ _), LeftFraction.map_eq_iff] at h
              obtain ⟨Z, t₁, t₂, hst, hft, ht⟩ := h
              dsimp at t₁ t₂ hst hft ht
              grind
          [Elab.step] [0.066101] 
                intro h
                rw [← LeftFraction.map_ofHom W _ L (Localization.inverts _ _), ←
                  LeftFraction.map_ofHom W _ L (Localization.inverts _ _), LeftFraction.map_eq_iff] at h
                obtain ⟨Z, t₁, t₂, hst, hft, ht⟩ := h
                dsimp at t₁ t₂ hst hft ht
                grind
            [Elab.step] [0.066096] 
                  intro h
                  rw [← LeftFraction.map_ofHom W _ L (Localization.inverts _ _), ←
                    LeftFraction.map_ofHom W _ L (Localization.inverts _ _), LeftFraction.map_eq_iff] at h
                  obtain ⟨Z, t₁, t₂, hst, hft, ht⟩ := h
                  dsimp at t₁ t₂ hst hft ht
                  grind
              [Elab.step] [0.055571] grind
Build completed successfully.
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
