### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Preadditive): golf `Biproduct.column_nonzero_of_iso'` using `grind`

### DIFF
--- a/Mathlib/CategoryTheory/Preadditive/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Biproducts.lean
@@ -813,11 +813,7 @@ theorem Biproduct.column_nonzero_of_iso' {σ τ : Type} [Finite τ] {S : σ → 
   cases nonempty_fintype τ
   intro z
   have reassoced {t : τ} {W : C} (h : _ ⟶ W) :
-    biproduct.ι S s ≫ f ≫ biproduct.π T t ≫ h = 0 ≫ h := by
-    simp only [← Category.assoc]
-    apply eq_whisker
-    simp only [Category.assoc]
-    apply z
+    biproduct.ι S s ≫ f ≫ biproduct.π T t ≫ h = 0 ≫ h := by grind
   set x := biproduct.ι S s ≫ f ≫ inv f ≫ biproduct.π S s
   have h₁ : x = 𝟙 (S s) := by simp [x]
   have h₀ : x = 0 := by


### PR DESCRIPTION
Motivation: Make use of available automation (and shorten the proof).

---
<details>
<summary>Show trace profiling of <code>Biproduct.column_nonzero_of_iso'</code></summary>

### Trace profiling of `Biproduct.column_nonzero_of_iso'` before PR 28160
```diff
diff --git a/Mathlib/CategoryTheory/Preadditive/Biproducts.lean b/Mathlib/CategoryTheory/Preadditive/Biproducts.lean
index dcf5923dcd..2c7fa63181 100644
--- a/Mathlib/CategoryTheory/Preadditive/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Biproducts.lean
@@ -809,2 +809,3 @@ end
 
+set_option trace.profiler true in
 theorem Biproduct.column_nonzero_of_iso' {σ τ : Type} [Finite τ] {S : σ → C} [HasBiproduct S]
```
```
ℹ [822/822] Built Mathlib.CategoryTheory.Preadditive.Biproducts
info: Mathlib/CategoryTheory/Preadditive/Biproducts.lean:811:0: [Elab.async] [0.058343] elaborating proof of CategoryTheory.Biproduct.column_nonzero_of_iso'
  [Elab.definition.value] [0.056450] CategoryTheory.Biproduct.column_nonzero_of_iso'
    [Elab.step] [0.055092] 
          cases nonempty_fintype τ
          intro z
          have reassoced {t : τ} {W : C} (h : _ ⟶ W) : biproduct.ι S s ≫ f ≫ biproduct.π T t ≫ h = 0 ≫ h :=
            by
            simp only [← Category.assoc]
            apply eq_whisker
            simp only [Category.assoc]
            apply z
          set x := biproduct.ι S s ≫ f ≫ inv f ≫ biproduct.π S s
          have h₁ : x = 𝟙 (S s) := by simp [x]
          have h₀ : x = 0 := by
            dsimp [x]
            rw [← Category.id_comp (inv f), Category.assoc, ← biproduct.total]
            simp only [comp_sum_assoc]
            conv_lhs =>
              congr
              congr
              next => skip
              intro j; simp only [reassoced]
            simp
          exact h₁.symm.trans h₀
      [Elab.step] [0.055087] 
            cases nonempty_fintype τ
            intro z
            have reassoced {t : τ} {W : C} (h : _ ⟶ W) : biproduct.ι S s ≫ f ≫ biproduct.π T t ≫ h = 0 ≫ h :=
              by
              simp only [← Category.assoc]
              apply eq_whisker
              simp only [Category.assoc]
              apply z
            set x := biproduct.ι S s ≫ f ≫ inv f ≫ biproduct.π S s
            have h₁ : x = 𝟙 (S s) := by simp [x]
            have h₀ : x = 0 := by
              dsimp [x]
              rw [← Category.id_comp (inv f), Category.assoc, ← biproduct.total]
              simp only [comp_sum_assoc]
              conv_lhs =>
                congr
                congr
                next => skip
                intro j; simp only [reassoced]
              simp
            exact h₁.symm.trans h₀
        [Elab.step] [0.033623] have h₀ : x = 0 := by
              dsimp [x]
              rw [← Category.id_comp (inv f), Category.assoc, ← biproduct.total]
              simp only [comp_sum_assoc]
              conv_lhs =>
                congr
                congr
                next => skip
                intro j; simp only [reassoced]
              simp
          [Elab.step] [0.033560] focus
                refine
                  no_implicit_lambda%
                    (have h₀ : x = 0 := ?body✝;
                    ?_)
                case body✝ =>
                  with_annotate_state"by"
                    ( dsimp [x]
                      rw [← Category.id_comp (inv f), Category.assoc, ← biproduct.total]
                      simp only [comp_sum_assoc]
                      conv_lhs =>
                        congr
                        congr
                        next => skip
                        intro j; simp only [reassoced]
                      simp)
            [Elab.step] [0.033554] 
                  refine
                    no_implicit_lambda%
                      (have h₀ : x = 0 := ?body✝;
                      ?_)
                  case body✝ =>
                    with_annotate_state"by"
                      ( dsimp [x]
                        rw [← Category.id_comp (inv f), Category.assoc, ← biproduct.total]
                        simp only [comp_sum_assoc]
                        conv_lhs =>
                          congr
                          congr
                          next => skip
                          intro j; simp only [reassoced]
                        simp)
              [Elab.step] [0.033550] 
                    refine
                      no_implicit_lambda%
                        (have h₀ : x = 0 := ?body✝;
                        ?_)
                    case body✝ =>
                      with_annotate_state"by"
                        ( dsimp [x]
                          rw [← Category.id_comp (inv f), Category.assoc, ← biproduct.total]
                          simp only [comp_sum_assoc]
                          conv_lhs =>
                            congr
                            congr
                            next => skip
                            intro j; simp only [reassoced]
                          simp)
                [Elab.step] [0.032549] case body✝ =>
                      with_annotate_state"by"
                        ( dsimp [x]
                          rw [← Category.id_comp (inv f), Category.assoc, ← biproduct.total]
                          simp only [comp_sum_assoc]
                          conv_lhs =>
                            congr
                            congr
                            next => skip
                            intro j; simp only [reassoced]
                          simp)
                  [Elab.step] [0.032526] with_annotate_state"by"
                          ( dsimp [x]
                            rw [← Category.id_comp (inv f), Category.assoc, ← biproduct.total]
                            simp only [comp_sum_assoc]
                            conv_lhs =>
                              congr
                              congr
                              next => skip
                              intro j; simp only [reassoced]
                            simp)
                    [Elab.step] [0.032523] with_annotate_state"by"
                            ( dsimp [x]
                              rw [← Category.id_comp (inv f), Category.assoc, ← biproduct.total]
                              simp only [comp_sum_assoc]
                              conv_lhs =>
                                congr
                                congr
                                next => skip
                                intro j; simp only [reassoced]
                              simp)
                      [Elab.step] [0.032519] with_annotate_state"by"
                            ( dsimp [x]
                              rw [← Category.id_comp (inv f), Category.assoc, ← biproduct.total]
                              simp only [comp_sum_assoc]
                              conv_lhs =>
                                congr
                                congr
                                next => skip
                                intro j; simp only [reassoced]
                              simp)
                        [Elab.step] [0.032515] (
                              dsimp [x]
                              rw [← Category.id_comp (inv f), Category.assoc, ← biproduct.total]
                              simp only [comp_sum_assoc]
                              conv_lhs =>
                                congr
                                congr
                                next => skip
                                intro j; simp only [reassoced]
                              simp)
                          [Elab.step] [0.032512] 
                                dsimp [x]
                                rw [← Category.id_comp (inv f), Category.assoc, ← biproduct.total]
                                simp only [comp_sum_assoc]
                                conv_lhs =>
                                  congr
                                  congr
                                  next => skip
                                  intro j; simp only [reassoced]
                                simp
                            [Elab.step] [0.032508] 
                                  dsimp [x]
                                  rw [← Category.id_comp (inv f), Category.assoc, ← biproduct.total]
                                  simp only [comp_sum_assoc]
                                  conv_lhs =>
                                    congr
                                    congr
                                    next => skip
                                    intro j; simp only [reassoced]
                                  simp
                              [Elab.step] [0.019532] simp
                                [Meta.Tactic.simp.discharge] [0.014692] Finset.univ_eq_empty discharge ❌️
                                      IsEmpty τ
                                  [Meta.synthInstance] [0.014334] ❌️ Nonempty τ
Build completed successfully.
```

### Trace profiling of `Biproduct.column_nonzero_of_iso'` after PR 28160
```diff
diff --git a/Mathlib/CategoryTheory/Preadditive/Biproducts.lean b/Mathlib/CategoryTheory/Preadditive/Biproducts.lean
index dcf5923dcd..e2028ffc0c 100644
--- a/Mathlib/CategoryTheory/Preadditive/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Biproducts.lean
@@ -809,2 +809,3 @@ end
 
+set_option trace.profiler true in
 theorem Biproduct.column_nonzero_of_iso' {σ τ : Type} [Finite τ] {S : σ → C} [HasBiproduct S]
@@ -815,7 +816,3 @@ theorem Biproduct.column_nonzero_of_iso' {σ τ : Type} [Finite τ] {S : σ →
   have reassoced {t : τ} {W : C} (h : _ ⟶ W) :
-    biproduct.ι S s ≫ f ≫ biproduct.π T t ≫ h = 0 ≫ h := by
-    simp only [← Category.assoc]
-    apply eq_whisker
-    simp only [Category.assoc]
-    apply z
+    biproduct.ι S s ≫ f ≫ biproduct.π T t ≫ h = 0 ≫ h := by grind
   set x := biproduct.ι S s ≫ f ≫ inv f ≫ biproduct.π S s
```
```
ℹ [822/822] Built Mathlib.CategoryTheory.Preadditive.Biproducts
info: Mathlib/CategoryTheory/Preadditive/Biproducts.lean:811:0: [Elab.async] [0.117897] elaborating proof of CategoryTheory.Biproduct.column_nonzero_of_iso'
  [Elab.definition.value] [0.116128] CategoryTheory.Biproduct.column_nonzero_of_iso'
    [Elab.step] [0.114957] 
          cases nonempty_fintype τ
          intro z
          have reassoced {t : τ} {W : C} (h : _ ⟶ W) : biproduct.ι S s ≫ f ≫ biproduct.π T t ≫ h = 0 ≫ h := by grind
          set x := biproduct.ι S s ≫ f ≫ inv f ≫ biproduct.π S s
          have h₁ : x = 𝟙 (S s) := by simp [x]
          have h₀ : x = 0 := by
            dsimp [x]
            rw [← Category.id_comp (inv f), Category.assoc, ← biproduct.total]
            simp only [comp_sum_assoc]
            conv_lhs =>
              congr
              congr
              next => skip
              intro j; simp only [reassoced]
            simp
          exact h₁.symm.trans h₀
      [Elab.step] [0.114951] 
            cases nonempty_fintype τ
            intro z
            have reassoced {t : τ} {W : C} (h : _ ⟶ W) : biproduct.ι S s ≫ f ≫ biproduct.π T t ≫ h = 0 ≫ h := by grind
            set x := biproduct.ι S s ≫ f ≫ inv f ≫ biproduct.π S s
            have h₁ : x = 𝟙 (S s) := by simp [x]
            have h₀ : x = 0 := by
              dsimp [x]
              rw [← Category.id_comp (inv f), Category.assoc, ← biproduct.total]
              simp only [comp_sum_assoc]
              conv_lhs =>
                congr
                congr
                next => skip
                intro j; simp only [reassoced]
              simp
            exact h₁.symm.trans h₀
        [Elab.step] [0.068466] have reassoced {t : τ} {W : C} (h : _ ⟶ W) :
              biproduct.ι S s ≫ f ≫ biproduct.π T t ≫ h = 0 ≫ h := by grind
          [Elab.step] [0.068434] focus
                refine
                  no_implicit_lambda%
                    (have reassoced {t : τ} {W : C} (h : _ ⟶ W) : biproduct.ι S s ≫ f ≫ biproduct.π T t ≫ h = 0 ≫ h :=
                      ?body✝;
                    ?_)
                case body✝ => with_annotate_state"by" (grind)
            [Elab.step] [0.068428] 
                  refine
                    no_implicit_lambda%
                      (have reassoced {t : τ} {W : C} (h : _ ⟶ W) : biproduct.ι S s ≫ f ≫ biproduct.π T t ≫ h = 0 ≫ h :=
                        ?body✝;
                      ?_)
                  case body✝ => with_annotate_state"by" (grind)
              [Elab.step] [0.068424] 
                    refine
                      no_implicit_lambda%
                        (have reassoced {t : τ} {W : C} (h : _ ⟶ W) :
                          biproduct.ι S s ≫ f ≫ biproduct.π T t ≫ h = 0 ≫ h := ?body✝;
                        ?_)
                    case body✝ => with_annotate_state"by" (grind)
                [Elab.step] [0.063261] case body✝ => with_annotate_state"by" (grind)
                  [Elab.step] [0.063211] with_annotate_state"by" (grind)
                    [Elab.step] [0.063208] with_annotate_state"by" (grind)
                      [Elab.step] [0.063205] with_annotate_state"by" (grind)
                        [Elab.step] [0.063201] (grind)
                          [Elab.step] [0.063198] grind
                            [Elab.step] [0.063194] grind
                              [Elab.step] [0.063187] grind
        [Elab.step] [0.033395] have h₀ : x = 0 := by
              dsimp [x]
              rw [← Category.id_comp (inv f), Category.assoc, ← biproduct.total]
              simp only [comp_sum_assoc]
              conv_lhs =>
                congr
                congr
                next => skip
                intro j; simp only [reassoced]
              simp
          [Elab.step] [0.033347] focus
                refine
                  no_implicit_lambda%
                    (have h₀ : x = 0 := ?body✝;
                    ?_)
                case body✝ =>
                  with_annotate_state"by"
                    ( dsimp [x]
                      rw [← Category.id_comp (inv f), Category.assoc, ← biproduct.total]
                      simp only [comp_sum_assoc]
                      conv_lhs =>
                        congr
                        congr
                        next => skip
                        intro j; simp only [reassoced]
                      simp)
            [Elab.step] [0.033342] 
                  refine
                    no_implicit_lambda%
                      (have h₀ : x = 0 := ?body✝;
                      ?_)
                  case body✝ =>
                    with_annotate_state"by"
                      ( dsimp [x]
                        rw [← Category.id_comp (inv f), Category.assoc, ← biproduct.total]
                        simp only [comp_sum_assoc]
                        conv_lhs =>
                          congr
                          congr
                          next => skip
                          intro j; simp only [reassoced]
                        simp)
              [Elab.step] [0.033338] 
                    refine
                      no_implicit_lambda%
                        (have h₀ : x = 0 := ?body✝;
                        ?_)
                    case body✝ =>
                      with_annotate_state"by"
                        ( dsimp [x]
                          rw [← Category.id_comp (inv f), Category.assoc, ← biproduct.total]
                          simp only [comp_sum_assoc]
                          conv_lhs =>
                            congr
                            congr
                            next => skip
                            intro j; simp only [reassoced]
                          simp)
                [Elab.step] [0.032316] case body✝ =>
                      with_annotate_state"by"
                        ( dsimp [x]
                          rw [← Category.id_comp (inv f), Category.assoc, ← biproduct.total]
                          simp only [comp_sum_assoc]
                          conv_lhs =>
                            congr
                            congr
                            next => skip
                            intro j; simp only [reassoced]
                          simp)
                  [Elab.step] [0.032293] with_annotate_state"by"
                          ( dsimp [x]
                            rw [← Category.id_comp (inv f), Category.assoc, ← biproduct.total]
                            simp only [comp_sum_assoc]
                            conv_lhs =>
                              congr
                              congr
                              next => skip
                              intro j; simp only [reassoced]
                            simp)
                    [Elab.step] [0.032290] with_annotate_state"by"
                            ( dsimp [x]
                              rw [← Category.id_comp (inv f), Category.assoc, ← biproduct.total]
                              simp only [comp_sum_assoc]
                              conv_lhs =>
                                congr
                                congr
                                next => skip
                                intro j; simp only [reassoced]
                              simp)
                      [Elab.step] [0.032286] with_annotate_state"by"
                            ( dsimp [x]
                              rw [← Category.id_comp (inv f), Category.assoc, ← biproduct.total]
                              simp only [comp_sum_assoc]
                              conv_lhs =>
                                congr
                                congr
                                next => skip
                                intro j; simp only [reassoced]
                              simp)
                        [Elab.step] [0.032282] (
                              dsimp [x]
                              rw [← Category.id_comp (inv f), Category.assoc, ← biproduct.total]
                              simp only [comp_sum_assoc]
                              conv_lhs =>
                                congr
                                congr
                                next => skip
                                intro j; simp only [reassoced]
                              simp)
                          [Elab.step] [0.032278] 
                                dsimp [x]
                                rw [← Category.id_comp (inv f), Category.assoc, ← biproduct.total]
                                simp only [comp_sum_assoc]
                                conv_lhs =>
                                  congr
                                  congr
                                  next => skip
                                  intro j; simp only [reassoced]
                                simp
                            [Elab.step] [0.032275] 
                                  dsimp [x]
                                  rw [← Category.id_comp (inv f), Category.assoc, ← biproduct.total]
                                  simp only [comp_sum_assoc]
                                  conv_lhs =>
                                    congr
                                    congr
                                    next => skip
                                    intro j; simp only [reassoced]
                                  simp
                              [Elab.step] [0.019358] simp
                                [Meta.Tactic.simp.discharge] [0.014621] Finset.univ_eq_empty discharge ❌️
                                      IsEmpty τ
                                  [Meta.synthInstance] [0.014096] ❌️ Nonempty τ
Build completed successfully.
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
