### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Monoidal): golf `id_whiskerLeft_bimod` using `grind`

### DIFF
--- a/Mathlib/CategoryTheory/Monoidal/Bimod.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Bimod.lean
@@ -762,8 +762,7 @@ theorem id_whiskerLeft_bimod {X Y : Mon_ C} {M N : Bimod X Y} (f : M ⟶ N) :
   slice_rhs 4 5 => rw [← comp_whiskerRight, Mon_Class.one_mul]
   have : (λ_ (X.X ⊗ N.X)).inv ≫ (α_ (𝟙_ C) X.X N.X).inv ≫ ((λ_ X.X).hom ▷ N.X) = 𝟙 _ := by
     monoidal
-  slice_rhs 2 4 => rw [this]
-  slice_rhs 1 2 => rw [Category.comp_id]
+  grind
 
 theorem comp_whiskerLeft_bimod {W X Y Z : Mon_ C} (M : Bimod W X) (N : Bimod X Y)
     {P P' : Bimod Y Z} (f : P ⟶ P') :


### PR DESCRIPTION
Motivation: Make use of available automation (and shorten the proof).

---
<details>
<summary>Show trace profiling of <code>id_whiskerLeft_bimod</code></summary>

### Trace profiling of `id_whiskerLeft_bimod` before PR 28161
```diff
diff --git a/Mathlib/CategoryTheory/Monoidal/Bimod.lean b/Mathlib/CategoryTheory/Monoidal/Bimod.lean
index 181dfba04f..b9078d7560 100644
--- a/Mathlib/CategoryTheory/Monoidal/Bimod.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Bimod.lean
@@ -745,2 +745,3 @@ theorem whiskerLeft_comp_bimod {X Y Z : Mon_ C} (M : Bimod X Y) {N P Q : Bimod Y
 
+set_option trace.profiler true in
 theorem id_whiskerLeft_bimod {X Y : Mon_ C} {M N : Bimod X Y} (f : M ⟶ N) :
```
```
ℹ [616/616] Built Mathlib.CategoryTheory.Monoidal.Bimod
info: Mathlib/CategoryTheory/Monoidal/Bimod.lean:747:0: [Elab.command] [0.010424] theorem id_whiskerLeft_bimod {X Y : Mon_ C} {M N : Bimod X Y} (f : M ⟶ N) :
        whiskerLeft (regular X) f = (leftUnitorBimod M).hom ≫ f ≫ (leftUnitorBimod N).inv :=
      by
      dsimp [tensorHom, regular, leftUnitorBimod]
      ext
      apply coequalizer.hom_ext
      dsimp
      slice_lhs 1 2 => rw [ι_colimMap, parallelPairHom_app_one]
      dsimp [LeftUnitorBimod.hom]
      slice_rhs 1 2 => rw [coequalizer.π_desc]
      dsimp [LeftUnitorBimod.inv]
      slice_rhs 1 2 => rw [Hom.left_act_hom]
      slice_rhs 2 3 => rw [leftUnitor_inv_naturality]
      slice_rhs 3 4 => rw [whisker_exchange]
      slice_rhs 4 4 => rw [← Iso.inv_hom_id_assoc (α_ X.X X.X N.X) (X.X ◁ N.actLeft)]
      slice_rhs 5 7 => rw [← Category.assoc, ← coequalizer.condition]
      slice_rhs 3 4 => rw [associator_inv_naturality_left]
      slice_rhs 4 5 => rw [← comp_whiskerRight, Mon_Class.one_mul]
      have : (λ_ (X.X ⊗ N.X)).inv ≫ (α_ (𝟙_ C) X.X N.X).inv ≫ ((λ_ X.X).hom ▷ N.X) = 𝟙 _ := by monoidal
      slice_rhs 2 4 => rw [this]
      slice_rhs 1 2 => rw [Category.comp_id]
info: Mathlib/CategoryTheory/Monoidal/Bimod.lean:747:0: [Elab.async] [0.226417] elaborating proof of Bimod.id_whiskerLeft_bimod
  [Elab.definition.value] [0.220773] Bimod.id_whiskerLeft_bimod
    [Elab.step] [0.218211] 
          dsimp [tensorHom, regular, leftUnitorBimod]
          ext
          apply coequalizer.hom_ext
          dsimp
          slice_lhs 1 2 => rw [ι_colimMap, parallelPairHom_app_one]
          dsimp [LeftUnitorBimod.hom]
          slice_rhs 1 2 => rw [coequalizer.π_desc]
          dsimp [LeftUnitorBimod.inv]
          slice_rhs 1 2 => rw [Hom.left_act_hom]
          slice_rhs 2 3 => rw [leftUnitor_inv_naturality]
          slice_rhs 3 4 => rw [whisker_exchange]
          slice_rhs 4 4 => rw [← Iso.inv_hom_id_assoc (α_ X.X X.X N.X) (X.X ◁ N.actLeft)]
          slice_rhs 5 7 => rw [← Category.assoc, ← coequalizer.condition]
          slice_rhs 3 4 => rw [associator_inv_naturality_left]
          slice_rhs 4 5 => rw [← comp_whiskerRight, Mon_Class.one_mul]
          have : (λ_ (X.X ⊗ N.X)).inv ≫ (α_ (𝟙_ C) X.X N.X).inv ≫ ((λ_ X.X).hom ▷ N.X) = 𝟙 _ := by monoidal
          slice_rhs 2 4 => rw [this]
          slice_rhs 1 2 => rw [Category.comp_id]
      [Elab.step] [0.218203] 
            dsimp [tensorHom, regular, leftUnitorBimod]
            ext
            apply coequalizer.hom_ext
            dsimp
            slice_lhs 1 2 => rw [ι_colimMap, parallelPairHom_app_one]
            dsimp [LeftUnitorBimod.hom]
            slice_rhs 1 2 => rw [coequalizer.π_desc]
            dsimp [LeftUnitorBimod.inv]
            slice_rhs 1 2 => rw [Hom.left_act_hom]
            slice_rhs 2 3 => rw [leftUnitor_inv_naturality]
            slice_rhs 3 4 => rw [whisker_exchange]
            slice_rhs 4 4 => rw [← Iso.inv_hom_id_assoc (α_ X.X X.X N.X) (X.X ◁ N.actLeft)]
            slice_rhs 5 7 => rw [← Category.assoc, ← coequalizer.condition]
            slice_rhs 3 4 => rw [associator_inv_naturality_left]
            slice_rhs 4 5 => rw [← comp_whiskerRight, Mon_Class.one_mul]
            have : (λ_ (X.X ⊗ N.X)).inv ≫ (α_ (𝟙_ C) X.X N.X).inv ≫ ((λ_ X.X).hom ▷ N.X) = 𝟙 _ := by monoidal
            slice_rhs 2 4 => rw [this]
            slice_rhs 1 2 => rw [Category.comp_id]
        [Elab.step] [0.014945] dsimp
        [Elab.step] [0.020289] slice_lhs 1 2 => rw [ι_colimMap, parallelPairHom_app_one]
          [Elab.step] [0.020184] conv => lhs; slice 1 2; (rw [ι_colimMap, parallelPairHom_app_one])
            [Elab.step] [0.019058] lhs; slice 1 2; (rw [ι_colimMap, parallelPairHom_app_one])
              [Elab.step] [0.019053] lhs; slice 1 2; (rw [ι_colimMap, parallelPairHom_app_one])
                [Elab.step] [0.011887] (rw [ι_colimMap, parallelPairHom_app_one])
                  [Elab.step] [0.011872] rw [ι_colimMap, parallelPairHom_app_one]
                    [Elab.step] [0.011868] rw [ι_colimMap, parallelPairHom_app_one]
                      [Elab.step] [0.011864] rw [ι_colimMap, parallelPairHom_app_one]
                        [Elab.step] [0.011859] rewrite [ι_colimMap, parallelPairHom_app_one]
        [Elab.step] [0.012996] slice_rhs 1 2 => rw [coequalizer.π_desc]
          [Elab.step] [0.012921] conv => rhs; slice 1 2; (rw [coequalizer.π_desc])
            [Elab.step] [0.012393] rhs; slice 1 2; (rw [coequalizer.π_desc])
              [Elab.step] [0.012388] rhs; slice 1 2; (rw [coequalizer.π_desc])
        [Elab.step] [0.015033] dsimp [LeftUnitorBimod.inv]
        [Elab.step] [0.011918] slice_rhs 1 2 => rw [Hom.left_act_hom]
          [Elab.step] [0.011837] conv => rhs; slice 1 2; (rw [Hom.left_act_hom])
            [Elab.step] [0.011263] rhs; slice 1 2; (rw [Hom.left_act_hom])
              [Elab.step] [0.011257] rhs; slice 1 2; (rw [Hom.left_act_hom])
        [Elab.step] [0.013010] slice_rhs 2 3 => rw [leftUnitor_inv_naturality]
          [Elab.step] [0.012925] conv => rhs; slice 2 3; (rw [leftUnitor_inv_naturality])
            [Elab.step] [0.012322] rhs; slice 2 3; (rw [leftUnitor_inv_naturality])
              [Elab.step] [0.012317] rhs; slice 2 3; (rw [leftUnitor_inv_naturality])
                [Elab.step] [0.011080] slice 2 3
                  [Elab.step] [0.011073] slice 2 3
        [Elab.step] [0.013961] slice_rhs 3 4 => rw [whisker_exchange]
          [Elab.step] [0.013871] conv => rhs; slice 3 4; (rw [whisker_exchange])
            [Elab.step] [0.013253] rhs; slice 3 4; (rw [whisker_exchange])
              [Elab.step] [0.013249] rhs; slice 3 4; (rw [whisker_exchange])
                [Elab.step] [0.012020] slice 3 4
                  [Elab.step] [0.012013] slice 3 4
        [Elab.step] [0.012132] slice_rhs 4 4 => rw [← Iso.inv_hom_id_assoc (α_ X.X X.X N.X) (X.X ◁ N.actLeft)]
          [Elab.step] [0.012057] conv => rhs; slice 4 4;
                (rw [← Iso.inv_hom_id_assoc (α_ X.X X.X N.X) (X.X ◁ N.actLeft)])
            [Elab.step] [0.011481] rhs; slice 4 4; (rw [← Iso.inv_hom_id_assoc (α_ X.X X.X N.X) (X.X ◁ N.actLeft)])
              [Elab.step] [0.011476] rhs; slice 4 4; (rw [← Iso.inv_hom_id_assoc (α_ X.X X.X N.X) (X.X ◁ N.actLeft)])
        [Elab.step] [0.025366] slice_rhs 5 7 => rw [← Category.assoc, ← coequalizer.condition]
          [Elab.step] [0.025285] conv => rhs; slice 5 7; (rw [← Category.assoc, ← coequalizer.condition])
            [Elab.step] [0.023649] rhs; slice 5 7; (rw [← Category.assoc, ← coequalizer.condition])
              [Elab.step] [0.023644] rhs; slice 5 7; (rw [← Category.assoc, ← coequalizer.condition])
                [Elab.step] [0.018021] slice 5 7
                  [Elab.step] [0.018013] slice 5 7
        [Elab.step] [0.012992] slice_rhs 3 4 => rw [associator_inv_naturality_left]
          [Elab.step] [0.012920] conv => rhs; slice 3 4; (rw [associator_inv_naturality_left])
            [Elab.step] [0.012292] rhs; slice 3 4; (rw [associator_inv_naturality_left])
              [Elab.step] [0.012288] rhs; slice 3 4; (rw [associator_inv_naturality_left])
                [Elab.step] [0.011087] slice 3 4
                  [Elab.step] [0.011080] slice 3 4
        [Elab.step] [0.016288] slice_rhs 4 5 => rw [← comp_whiskerRight, Mon_Class.one_mul]
          [Elab.step] [0.016212] conv => rhs; slice 4 5; (rw [← comp_whiskerRight, Mon_Class.one_mul])
            [Elab.step] [0.015640] rhs; slice 4 5; (rw [← comp_whiskerRight, Mon_Class.one_mul])
              [Elab.step] [0.015635] rhs; slice 4 5; (rw [← comp_whiskerRight, Mon_Class.one_mul])
                [Elab.step] [0.013901] slice 4 5
                  [Elab.step] [0.013894] slice 4 5
        [Elab.step] [0.010912] have : (λ_ (X.X ⊗ N.X)).inv ≫ (α_ (𝟙_ C) X.X N.X).inv ≫ ((λ_ X.X).hom ▷ N.X) = 𝟙 _ := by
              monoidal
          [Elab.step] [0.010862] focus
                refine
                  no_implicit_lambda%
                    (have : (λ_ (X.X ⊗ N.X)).inv ≫ (α_ (𝟙_ C) X.X N.X).inv ≫ ((λ_ X.X).hom ▷ N.X) = 𝟙 _ := ?body✝;
                    ?_)
                case body✝ => with_annotate_state"by" (monoidal)
            [Elab.step] [0.010856] 
                  refine
                    no_implicit_lambda%
                      (have : (λ_ (X.X ⊗ N.X)).inv ≫ (α_ (𝟙_ C) X.X N.X).inv ≫ ((λ_ X.X).hom ▷ N.X) = 𝟙 _ := ?body✝;
                      ?_)
                  case body✝ => with_annotate_state"by" (monoidal)
              [Elab.step] [0.010851] 
                    refine
                      no_implicit_lambda%
                        (have : (λ_ (X.X ⊗ N.X)).inv ≫ (α_ (𝟙_ C) X.X N.X).inv ≫ ((λ_ X.X).hom ▷ N.X) = 𝟙 _ := ?body✝;
                        ?_)
                    case body✝ => with_annotate_state"by" (monoidal)
info: Mathlib/CategoryTheory/Monoidal/Bimod.lean:747:8: [Elab.async] [0.010185] Lean.addDecl
  [Kernel] [0.010169] typechecking declarations [Bimod.id_whiskerLeft_bimod]
Build completed successfully.
```

### Trace profiling of `id_whiskerLeft_bimod` after PR 28161
```diff
diff --git a/Mathlib/CategoryTheory/Monoidal/Bimod.lean b/Mathlib/CategoryTheory/Monoidal/Bimod.lean
index 181dfba04f..e783d62991 100644
--- a/Mathlib/CategoryTheory/Monoidal/Bimod.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Bimod.lean
@@ -745,2 +745,3 @@ theorem whiskerLeft_comp_bimod {X Y Z : Mon_ C} (M : Bimod X Y) {N P Q : Bimod Y
 
+set_option trace.profiler true in
 theorem id_whiskerLeft_bimod {X Y : Mon_ C} {M N : Bimod X Y} (f : M ⟶ N) :
@@ -764,4 +765,3 @@ theorem id_whiskerLeft_bimod {X Y : Mon_ C} {M N : Bimod X Y} (f : M ⟶ N) :
     monoidal
-  slice_rhs 2 4 => rw [this]
-  slice_rhs 1 2 => rw [Category.comp_id]
+  grind
 
```
```
ℹ [616/616] Built Mathlib.CategoryTheory.Monoidal.Bimod
info: Mathlib/CategoryTheory/Monoidal/Bimod.lean:747:0: [Elab.command] [0.012076] theorem id_whiskerLeft_bimod {X Y : Mon_ C} {M N : Bimod X Y} (f : M ⟶ N) :
        whiskerLeft (regular X) f = (leftUnitorBimod M).hom ≫ f ≫ (leftUnitorBimod N).inv :=
      by
      dsimp [tensorHom, regular, leftUnitorBimod]
      ext
      apply coequalizer.hom_ext
      dsimp
      slice_lhs 1 2 => rw [ι_colimMap, parallelPairHom_app_one]
      dsimp [LeftUnitorBimod.hom]
      slice_rhs 1 2 => rw [coequalizer.π_desc]
      dsimp [LeftUnitorBimod.inv]
      slice_rhs 1 2 => rw [Hom.left_act_hom]
      slice_rhs 2 3 => rw [leftUnitor_inv_naturality]
      slice_rhs 3 4 => rw [whisker_exchange]
      slice_rhs 4 4 => rw [← Iso.inv_hom_id_assoc (α_ X.X X.X N.X) (X.X ◁ N.actLeft)]
      slice_rhs 5 7 => rw [← Category.assoc, ← coequalizer.condition]
      slice_rhs 3 4 => rw [associator_inv_naturality_left]
      slice_rhs 4 5 => rw [← comp_whiskerRight, Mon_Class.one_mul]
      have : (λ_ (X.X ⊗ N.X)).inv ≫ (α_ (𝟙_ C) X.X N.X).inv ≫ ((λ_ X.X).hom ▷ N.X) = 𝟙 _ := by monoidal
      grind
info: Mathlib/CategoryTheory/Monoidal/Bimod.lean:747:0: [Elab.async] [0.515119] elaborating proof of Bimod.id_whiskerLeft_bimod
  [Elab.definition.value] [0.510213] Bimod.id_whiskerLeft_bimod
    [Elab.step] [0.509058] 
          dsimp [tensorHom, regular, leftUnitorBimod]
          ext
          apply coequalizer.hom_ext
          dsimp
          slice_lhs 1 2 => rw [ι_colimMap, parallelPairHom_app_one]
          dsimp [LeftUnitorBimod.hom]
          slice_rhs 1 2 => rw [coequalizer.π_desc]
          dsimp [LeftUnitorBimod.inv]
          slice_rhs 1 2 => rw [Hom.left_act_hom]
          slice_rhs 2 3 => rw [leftUnitor_inv_naturality]
          slice_rhs 3 4 => rw [whisker_exchange]
          slice_rhs 4 4 => rw [← Iso.inv_hom_id_assoc (α_ X.X X.X N.X) (X.X ◁ N.actLeft)]
          slice_rhs 5 7 => rw [← Category.assoc, ← coequalizer.condition]
          slice_rhs 3 4 => rw [associator_inv_naturality_left]
          slice_rhs 4 5 => rw [← comp_whiskerRight, Mon_Class.one_mul]
          have : (λ_ (X.X ⊗ N.X)).inv ≫ (α_ (𝟙_ C) X.X N.X).inv ≫ ((λ_ X.X).hom ▷ N.X) = 𝟙 _ := by monoidal
          grind
      [Elab.step] [0.509051] 
            dsimp [tensorHom, regular, leftUnitorBimod]
            ext
            apply coequalizer.hom_ext
            dsimp
            slice_lhs 1 2 => rw [ι_colimMap, parallelPairHom_app_one]
            dsimp [LeftUnitorBimod.hom]
            slice_rhs 1 2 => rw [coequalizer.π_desc]
            dsimp [LeftUnitorBimod.inv]
            slice_rhs 1 2 => rw [Hom.left_act_hom]
            slice_rhs 2 3 => rw [leftUnitor_inv_naturality]
            slice_rhs 3 4 => rw [whisker_exchange]
            slice_rhs 4 4 => rw [← Iso.inv_hom_id_assoc (α_ X.X X.X N.X) (X.X ◁ N.actLeft)]
            slice_rhs 5 7 => rw [← Category.assoc, ← coequalizer.condition]
            slice_rhs 3 4 => rw [associator_inv_naturality_left]
            slice_rhs 4 5 => rw [← comp_whiskerRight, Mon_Class.one_mul]
            have : (λ_ (X.X ⊗ N.X)).inv ≫ (α_ (𝟙_ C) X.X N.X).inv ≫ ((λ_ X.X).hom ▷ N.X) = 𝟙 _ := by monoidal
            grind
        [Elab.step] [0.014951] dsimp
        [Elab.step] [0.022209] slice_lhs 1 2 => rw [ι_colimMap, parallelPairHom_app_one]
          [Elab.step] [0.022112] conv => lhs; slice 1 2; (rw [ι_colimMap, parallelPairHom_app_one])
            [Elab.step] [0.021025] lhs; slice 1 2; (rw [ι_colimMap, parallelPairHom_app_one])
              [Elab.step] [0.021020] lhs; slice 1 2; (rw [ι_colimMap, parallelPairHom_app_one])
                [Elab.step] [0.013900] (rw [ι_colimMap, parallelPairHom_app_one])
                  [Elab.step] [0.013885] rw [ι_colimMap, parallelPairHom_app_one]
                    [Elab.step] [0.013882] rw [ι_colimMap, parallelPairHom_app_one]
                      [Elab.step] [0.013878] rw [ι_colimMap, parallelPairHom_app_one]
                        [Elab.step] [0.013873] rewrite [ι_colimMap, parallelPairHom_app_one]
        [Elab.step] [0.013308] slice_rhs 1 2 => rw [coequalizer.π_desc]
          [Elab.step] [0.013236] conv => rhs; slice 1 2; (rw [coequalizer.π_desc])
            [Elab.step] [0.012716] rhs; slice 1 2; (rw [coequalizer.π_desc])
              [Elab.step] [0.012712] rhs; slice 1 2; (rw [coequalizer.π_desc])
        [Elab.step] [0.015593] dsimp [LeftUnitorBimod.inv]
        [Elab.step] [0.012131] slice_rhs 1 2 => rw [Hom.left_act_hom]
          [Elab.step] [0.012036] conv => rhs; slice 1 2; (rw [Hom.left_act_hom])
            [Elab.step] [0.011470] rhs; slice 1 2; (rw [Hom.left_act_hom])
              [Elab.step] [0.011466] rhs; slice 1 2; (rw [Hom.left_act_hom])
                [Elab.step] [0.010156] slice 1 2
                  [Elab.step] [0.010149] slice 1 2
        [Elab.step] [0.015161] slice_rhs 2 3 => rw [leftUnitor_inv_naturality]
          [Elab.step] [0.015092] conv => rhs; slice 2 3; (rw [leftUnitor_inv_naturality])
            [Elab.step] [0.014382] rhs; slice 2 3; (rw [leftUnitor_inv_naturality])
              [Elab.step] [0.014377] rhs; slice 2 3; (rw [leftUnitor_inv_naturality])
                [Elab.step] [0.013024] slice 2 3
                  [Elab.step] [0.013017] slice 2 3
        [Elab.step] [0.016056] slice_rhs 3 4 => rw [whisker_exchange]
          [Elab.step] [0.015966] conv => rhs; slice 3 4; (rw [whisker_exchange])
            [Elab.step] [0.015341] rhs; slice 3 4; (rw [whisker_exchange])
              [Elab.step] [0.015336] rhs; slice 3 4; (rw [whisker_exchange])
                [Elab.step] [0.014055] slice 3 4
                  [Elab.step] [0.014047] slice 3 4
        [Elab.step] [0.012730] slice_rhs 4 4 => rw [← Iso.inv_hom_id_assoc (α_ X.X X.X N.X) (X.X ◁ N.actLeft)]
          [Elab.step] [0.012656] conv => rhs; slice 4 4;
                (rw [← Iso.inv_hom_id_assoc (α_ X.X X.X N.X) (X.X ◁ N.actLeft)])
            [Elab.step] [0.012003] rhs; slice 4 4; (rw [← Iso.inv_hom_id_assoc (α_ X.X X.X N.X) (X.X ◁ N.actLeft)])
              [Elab.step] [0.011999] rhs; slice 4 4; (rw [← Iso.inv_hom_id_assoc (α_ X.X X.X N.X) (X.X ◁ N.actLeft)])
        [Elab.step] [0.026578] slice_rhs 5 7 => rw [← Category.assoc, ← coequalizer.condition]
          [Elab.step] [0.026484] conv => rhs; slice 5 7; (rw [← Category.assoc, ← coequalizer.condition])
            [Elab.step] [0.024993] rhs; slice 5 7; (rw [← Category.assoc, ← coequalizer.condition])
              [Elab.step] [0.024988] rhs; slice 5 7; (rw [← Category.assoc, ← coequalizer.condition])
                [Elab.step] [0.019779] slice 5 7
                  [Elab.step] [0.019772] slice 5 7
        [Elab.step] [0.014840] slice_rhs 3 4 => rw [associator_inv_naturality_left]
          [Elab.step] [0.014760] conv => rhs; slice 3 4; (rw [associator_inv_naturality_left])
            [Elab.step] [0.013988] rhs; slice 3 4; (rw [associator_inv_naturality_left])
              [Elab.step] [0.013983] rhs; slice 3 4; (rw [associator_inv_naturality_left])
                [Elab.step] [0.012415] slice 3 4
                  [Elab.step] [0.012407] slice 3 4
        [Elab.step] [0.019068] slice_rhs 4 5 => rw [← comp_whiskerRight, Mon_Class.one_mul]
          [Elab.step] [0.018987] conv => rhs; slice 4 5; (rw [← comp_whiskerRight, Mon_Class.one_mul])
            [Elab.step] [0.018416] rhs; slice 4 5; (rw [← comp_whiskerRight, Mon_Class.one_mul])
              [Elab.step] [0.018410] rhs; slice 4 5; (rw [← comp_whiskerRight, Mon_Class.one_mul])
                [Elab.step] [0.016594] slice 4 5
                  [Elab.step] [0.016586] slice 4 5
        [Elab.step] [0.011261] have : (λ_ (X.X ⊗ N.X)).inv ≫ (α_ (𝟙_ C) X.X N.X).inv ≫ ((λ_ X.X).hom ▷ N.X) = 𝟙 _ := by
              monoidal
          [Elab.step] [0.011212] focus
                refine
                  no_implicit_lambda%
                    (have : (λ_ (X.X ⊗ N.X)).inv ≫ (α_ (𝟙_ C) X.X N.X).inv ≫ ((λ_ X.X).hom ▷ N.X) = 𝟙 _ := ?body✝;
                    ?_)
                case body✝ => with_annotate_state"by" (monoidal)
            [Elab.step] [0.011206] 
                  refine
                    no_implicit_lambda%
                      (have : (λ_ (X.X ⊗ N.X)).inv ≫ (α_ (𝟙_ C) X.X N.X).inv ≫ ((λ_ X.X).hom ▷ N.X) = 𝟙 _ := ?body✝;
                      ?_)
                  case body✝ => with_annotate_state"by" (monoidal)
              [Elab.step] [0.011202] 
                    refine
                      no_implicit_lambda%
                        (have : (λ_ (X.X ⊗ N.X)).inv ≫ (α_ (𝟙_ C) X.X N.X).inv ≫ ((λ_ X.X).hom ▷ N.X) = 𝟙 _ := ?body✝;
                        ?_)
                    case body✝ => with_annotate_state"by" (monoidal)
        [Elab.step] [0.292954] grind
Build completed successfully.
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
