### PR TITLE
[Merged by Bors] - chore: replace `aesop` with `simp_all` where applicable

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean
@@ -382,8 +382,8 @@ lemma prod_congr_of_eq_on_inter {ι M : Type*} {s₁ s₂ : Finset ι} {f g : ι
     (h : ∀ a ∈ s₁, a ∈ s₂ → f a = g a) :
     ∏ a ∈ s₁, f a = ∏ a ∈ s₂, g a := by
   classical
-  conv_lhs => rw [← sdiff_union_inter s₁ s₂, prod_union_eq_right (by aesop)]
-  conv_rhs => rw [← sdiff_union_inter s₂ s₁, prod_union_eq_right (by aesop), inter_comm]
+  conv_lhs => rw [← sdiff_union_inter s₁ s₂, prod_union_eq_right (by simp_all)]
+  conv_rhs => rw [← sdiff_union_inter s₂ s₁, prod_union_eq_right (by simp_all), inter_comm]
   exact prod_congr rfl (by simpa)
 
 @[to_additive]

--- a/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
+++ b/Mathlib/Algebra/GroupWithZero/NonZeroDivisors.lean
@@ -77,7 +77,7 @@ lemma nonZeroDivisorsLeft_eq_right (M₀ : Type*) [CommMonoidWithZero M₀] :
     nonZeroDivisorsLeft M₀ = {x : M₀ | x ≠ 0} := by
   ext x
   simp only [SetLike.mem_coe, mem_nonZeroDivisorsLeft_iff, mul_eq_zero, Set.mem_setOf_eq]
-  refine ⟨fun h ↦ ?_, fun hx y hx' ↦ by aesop⟩
+  refine ⟨fun h ↦ ?_, fun hx y hx' ↦ by simp_all⟩
   contrapose! h
   exact ⟨1, Or.inl h, one_ne_zero⟩
 

--- a/Mathlib/Algebra/Lie/Weights/Killing.lean
+++ b/Mathlib/Algebra/Lie/Weights/Killing.lean
@@ -473,7 +473,7 @@ lemma isCompl_ker_weight_span_coroot (α : Weight K H L) :
       using isCompl_top_bot
   else
     rw [← coe_corootSpace_eq_span_singleton]
-    apply Module.Dual.isCompl_ker_of_disjoint_of_ne_bot (by aesop)
+    apply Module.Dual.isCompl_ker_of_disjoint_of_ne_bot (by simp_all)
       (disjoint_ker_weight_corootSpace α)
     replace hα : corootSpace α ≠ ⊥ := by simpa using hα
     rwa [ne_eq, ← LieSubmodule.toSubmodule_inj] at hα

--- a/Mathlib/Algebra/Module/Submodule/Pointwise.lean
+++ b/Mathlib/Algebra/Module/Submodule/Pointwise.lean
@@ -434,7 +434,7 @@ lemma set_smul_eq_map [SMulCommClass R R N] :
       · refine fun h ↦ h fun r n hr hn ↦ ?_
         rw [mem_set_smul_def, mem_sInf]
         exact fun p hp ↦ hp hr hn
-      · aesop
+      · simp_all
 
 lemma mem_set_smul (x : M) [SMulCommClass R R N] :
     x ∈ sR • N ↔ ∃ (c : R →₀ N), (c.support : Set R) ⊆ sR ∧ x = c.sum fun r m ↦ r • m := by

--- a/Mathlib/Algebra/Module/Submodule/Union.lean
+++ b/Mathlib/Algebra/Module/Submodule/Union.lean
@@ -62,7 +62,7 @@ lemma Submodule.iUnion_ssubset_of_forall_ne_top_of_card_lt (s : Finset ι) (p : 
       suffices ∃ z₁ z₂, z₁ ≠ z₂ ∧ f z₁ = f z₂ by
         obtain ⟨z₁, z₂, hne, heq⟩ := this
         exact ⟨f z₁, hf' (mem_univ _), z₁, z₁.property, z₂, z₂.property,
-          Subtype.coe_ne_coe.mpr hne, by specialize hf z₁; aesop, by specialize hf z₂; aesop⟩
+          Subtype.coe_ne_coe.mpr hne, by specialize hf z₁; simp_all, by specialize hf z₂; aesop⟩
       have key : s.card < sxy.encard := by
         refine lt_of_add_lt_add_right <| lt_of_lt_of_le h₂ ?_
         have : Injective (fun t : K ↦ x + t • y) :=

--- a/Mathlib/Algebra/SkewMonoidAlgebra/Basic.lean
+++ b/Mathlib/Algebra/SkewMonoidAlgebra/Basic.lean
@@ -448,7 +448,7 @@ theorem induction_on {p : SkewMonoidAlgebra k G → Prop} (f : SkewMonoidAlgebra
     (zero : p 0) (single : ∀ g a, p (single g a)) (add : ∀ f g :
     SkewMonoidAlgebra k G, p f → p g → p (f + g)) : p f := by
   rw [← sum_single f, sum_def']
-  exact Finset.sum_induction _ _ add zero (by aesop)
+  exact Finset.sum_induction _ _ add zero (by simp_all)
 
 /-- Slightly less general but more convenient version of `SkewMonoidAlgebra.induction_on`. -/
 @[induction_eliminator]

--- a/Mathlib/Analysis/Analytic/Composition.lean
+++ b/Mathlib/Analysis/Analytic/Composition.lean
@@ -641,7 +641,7 @@ theorem compPartialSumTarget_tendsto_prod_atTop :
   · intro m n hmn a ha
     have : ∀ i, i < m.1 → i < n.1 := fun i hi => lt_of_lt_of_le hi hmn.1
     have : ∀ i, i < m.2 → i < n.2 := fun i hi => lt_of_lt_of_le hi hmn.2
-    aesop
+    simp_all
   · rintro ⟨n, c⟩
     simp only [mem_compPartialSumTarget_iff]
     obtain ⟨n, hn⟩ : BddAbove ((Finset.univ.image fun i : Fin c.length => c.blocksFun i) : Set ℕ) :=

--- a/Mathlib/Analysis/Analytic/OfScalars.lean
+++ b/Mathlib/Analysis/Analytic/OfScalars.lean
@@ -194,7 +194,7 @@ theorem ofScalars_radius_ge_inv_of_tendsto {r : ℝ≥0} (hr : r ≠ 0)
   refine Summable.of_norm_bounded_eventually (g := fun n ↦ ‖‖c n‖ * r' ^ n‖) ?_ ?_
   · refine summable_of_ratio_test_tendsto_lt_one hr' ?_ ?_
     · refine (hc.eventually_ne (NNReal.coe_ne_zero.mpr hr)).mp (Eventually.of_forall ?_)
-      aesop
+      simp_all
     · simp_rw [norm_norm]
       exact tendsto_succ_norm_div_norm c hrz hc
   · filter_upwards [eventually_cofinite_ne 0] with n hn
@@ -241,7 +241,7 @@ theorem ofScalars_radius_eq_top_of_tendsto (hc : ∀ᶠ n in atTop, c n ≠ 0)
     · apply summable_of_ratio_test_tendsto_lt_one zero_lt_one (hc.mp (Eventually.of_forall ?_))
       · simp only [norm_norm]
         exact mul_zero (_ : ℝ) ▸ tendsto_succ_norm_div_norm _ hrz (NNReal.coe_zero ▸ hc')
-      · aesop
+      · simp_all
     · filter_upwards [eventually_cofinite_ne 0] with n hn
       simp only [norm_mul, norm_norm, norm_pow, NNReal.norm_eq]
       gcongr
@@ -250,7 +250,7 @@ theorem ofScalars_radius_eq_top_of_tendsto (hc : ∀ᶠ n in atTop, c n ≠ 0)
 /-- If `‖c n.succ‖ / ‖c n‖` is unbounded, then the radius of convergence is zero. -/
 theorem ofScalars_radius_eq_zero_of_tendsto [NormOneClass E]
     (hc : Tendsto (fun n ↦ ‖c n.succ‖ / ‖c n‖) atTop atTop) : (ofScalars E c).radius = 0 := by
-  suffices (ofScalars E c).radius ≤ 0 by aesop
+  suffices (ofScalars E c).radius ≤ 0 by simp_all
   refine le_of_forall_nnreal_lt (fun r hr ↦ ?_)
   rw [← coe_zero, coe_le_coe]
   have := FormalMultilinearSeries.summable_norm_mul_pow _ hr
@@ -269,7 +269,7 @@ theorem ofScalars_radius_eq_zero_of_tendsto [NormOneClass E]
     · convert hc
       rw [pow_succ, div_mul_cancel_left₀, NNReal.coe_inv]
       aesop
-    · aesop
+    · simp_all
     · refine Ne.lt_of_le (fun hr' ↦ Not.elim ?_ hc) (norm_nonneg _)
       rw [← hr']
       simp [this]
@@ -300,7 +300,7 @@ theorem ofScalars_radius_eq_inv_of_tendsto_ENNReal [NormOneClass E] {r : ℝ≥0
     refine tendsto_ofReal_nhds_top.mp (Tendsto.congr' ?_ ((tendsto_add_atTop_iff_nat 1).mpr hc'))
     filter_upwards [hc'.eventually_ne top_ne_zero] with n hn
     apply (ofReal_div_of_pos (Ne.lt_of_le (Ne.symm ?_) (norm_nonneg _))).symm
-    aesop
+    simp_all
   · have hr' := toReal_ne_zero.mp hr.ne.symm
     have hr'' := toNNReal_ne_zero.mpr hr' -- this result could go in ENNReal
     convert ofScalars_radius_eq_inv_of_tendsto E c hr'' ?_

--- a/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Continuity.lean
+++ b/Mathlib/Analysis/CStarAlgebra/ContinuousFunctionalCalculus/Continuity.lean
@@ -97,7 +97,7 @@ theorem tendsto_cfc_fun {l : Filter X} {F : X → R → R} {f : R → R} {a : A}
     intro t
     simp only [eventually_comap, Subtype.forall]
     peel h_tendsto t with ht x _
-    aesop
+    simp_all
   · simpa [cfc_apply_of_not_predicate a ha] using tendsto_const_nhds
 
 /-- If `f : X → R → R` tends to `f x₀` uniformly (along `𝓝 x₀`) on the spectrum of `a`,
@@ -450,7 +450,7 @@ theorem tendsto_cfcₙ_fun {l : Filter X} {F : X → R → R} {f : R → R} {a :
     intro t
     simp only [eventually_comap, Subtype.forall]
     peel h_tendsto t with ht x _
-    aesop
+    simp_all
   · simpa [cfcₙ_apply_of_not_predicate a ha] using tendsto_const_nhds
 
 /-- If `f : X → R → R` tends to `f x₀` uniformly (along `𝓝 x₀`) on the spectrum of `a`,

--- a/Mathlib/Analysis/Calculus/FDeriv/Symmetric.lean
+++ b/Mathlib/Analysis/Calculus/FDeriv/Symmetric.lean
@@ -599,7 +599,7 @@ theorem ContDiffWithinAt.isSymmSndFDerivWithinAt {n : WithTop ℕ∞}
     apply fderivWithin_fderivWithin_eq_of_eventuallyEq
     filter_upwards [u_open.mem_nhds hy.2] with z hz
     change (z ∈ s) = (z ∈ s ∩ u)
-    aesop
+    simp_all
   have B : Tendsto (fun k ↦ fderivWithin 𝕜 (fderivWithin 𝕜 f s) s (y k)) atTop
       (𝓝 (fderivWithin 𝕜 (fderivWithin 𝕜 f s) s x)) := by
     have : Tendsto y atTop (𝓝[s ∩ u] x) := by

--- a/Mathlib/Analysis/Complex/Tietze.lean
+++ b/Mathlib/Analysis/Complex/Tietze.lean
@@ -106,7 +106,7 @@ a bounded continuous function `g : Y →ᵇ ℝ` of the same norm such that `g �
 theorem exists_norm_eq_restrict_eq (f : s →ᵇ E) :
     ∃ g : X →ᵇ E, ‖g‖ = ‖f‖ ∧ g.restrict s = f := by
   by_cases hf : ‖f‖ = 0; · exact ⟨0, by aesop⟩
-  have := Metric.instTietzeExtensionClosedBall.{u, v} 𝕜 (0 : E) (by aesop : 0 < ‖f‖)
+  have := Metric.instTietzeExtensionClosedBall.{u, v} 𝕜 (0 : E) (by simp_all : 0 < ‖f‖)
   have hf' x : f x ∈ Metric.closedBall 0 ‖f‖ := by simpa using f.norm_coe_le_norm x
   obtain ⟨g, hg_mem, hg⟩ := (f : C(s, E)).exists_forall_mem_restrict_eq hs hf'
   simp only [Metric.mem_closedBall, dist_zero_right] at hg_mem

--- a/Mathlib/Analysis/Convex/Jensen.lean
+++ b/Mathlib/Analysis/Convex/Jensen.lean
@@ -215,8 +215,8 @@ lemma StrictConvexOn.map_sum_eq_iff' (hf : StrictConvexOn 𝕜 s f) (h₀ : ∀ 
     (h₁ : ∑ i ∈ t, w i = 1) (hmem : ∀ i ∈ t, p i ∈ s) :
     f (∑ i ∈ t, w i • p i) = ∑ i ∈ t, w i • f (p i) ↔
       ∀ j ∈ t, w j ≠ 0 → p j = ∑ i ∈ t, w i • p i := by
-  have hw (i) (_ : i ∈ t) : w i • p i ≠ 0 → w i ≠ 0 := by aesop
-  have hw' (i) (_ : i ∈ t) : w i • f (p i) ≠ 0 → w i ≠ 0 := by aesop
+  have hw (i) (_ : i ∈ t) : w i • p i ≠ 0 → w i ≠ 0 := by simp_all
+  have hw' (i) (_ : i ∈ t) : w i • f (p i) ≠ 0 → w i ≠ 0 := by simp_all
   rw [← sum_filter_of_ne hw, ← sum_filter_of_ne hw', hf.map_sum_eq_iff]
   · simp
   · simp +contextual [(h₀ _ _).lt_iff_ne']

--- a/Mathlib/Analysis/LocallyConvex/AbsConvex.lean
+++ b/Mathlib/Analysis/LocallyConvex/AbsConvex.lean
@@ -287,7 +287,7 @@ theorem convexHull_union_neg_eq_absConvexHull {s : Set E} :
     convexHull ℝ (s ∪ -s) = absConvexHull ℝ s := by
   rw [absConvexHull_eq_convexHull_balancedHull]
   exact le_antisymm (convexHull_mono (union_subset (subset_balancedHull ℝ)
-    (fun _ _ => by rw [mem_balancedHull_iff]; use -1; aesop)))
+    (fun _ _ => by rw [mem_balancedHull_iff]; use -1; simp_all)))
     (by
       rw [← Convex.convexHull_eq (convex_convexHull ℝ (s ∪ -s))]
       exact convexHull_mono balancedHull_subset_convexHull_union_neg)

--- a/Mathlib/Analysis/Normed/Group/CocompactMap.lean
+++ b/Mathlib/Analysis/Normed/Group/CocompactMap.lean
@@ -35,7 +35,7 @@ theorem CocompactMapClass.norm_le [ProperSpace F] [FunLike 𝓕 E F] [CocompactM
   rcases closedBall_compl_subset_of_mem_cocompact h 0 with ⟨r, hr⟩
   use r
   intro x hx
-  suffices x ∈ f⁻¹' (Metric.closedBall 0 ε)ᶜ by aesop
+  suffices x ∈ f⁻¹' (Metric.closedBall 0 ε)ᶜ by simp_all
   apply hr
   simp [hx]
 

--- a/Mathlib/Analysis/Normed/Group/ZeroAtInfty.lean
+++ b/Mathlib/Analysis/Normed/Group/ZeroAtInfty.lean
@@ -29,9 +29,9 @@ theorem ZeroAtInftyContinuousMapClass.norm_le (f : 𝓕) (ε : ℝ) (hε : 0 < �
   rcases Metric.closedBall_compl_subset_of_mem_cocompact h 0 with ⟨r, hr⟩
   use r
   intro x hr'
-  suffices x ∈ (fun x ↦ ‖f x‖) ⁻¹' Metric.ball 0 ε by aesop
+  suffices x ∈ (fun x ↦ ‖f x‖) ⁻¹' Metric.ball 0 ε by simp_all
   apply hr
-  aesop
+  simp_all
 
 variable [ProperSpace E]
 

--- a/Mathlib/Analysis/NormedSpace/FunctionSeries.lean
+++ b/Mathlib/Analysis/NormedSpace/FunctionSeries.lean
@@ -73,7 +73,7 @@ theorem tendstoUniformlyOn_tsum_of_cofinite_eventually {ι : Type*} {f : ι → 
   simp only [comp_apply, Subtype.forall, imp_false]
   apply fun i hi => HN i ?_ x hx
   have :  i ∉ hN.toFinset := fun hg ↦ hi (Finset.union_subset_left hn hg)
-  aesop
+  simp_all
 
 theorem tendstoUniformlyOn_tsum_nat_eventually {α F : Type*} [NormedAddCommGroup F]
     [CompleteSpace F] {f : ℕ → α → F} {u : ℕ → ℝ} (hu : Summable u) {s : Set α}

--- a/Mathlib/Analysis/SpecialFunctions/Pow/Continuity.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Pow/Continuity.lean
@@ -430,7 +430,7 @@ theorem continuousOn_rpow_const_compl_zero {r : ℝ} :
 @[fun_prop]
 theorem continuousOn_rpow_const {r : ℝ} {s : Set ℝ≥0}
     (h : 0 ∉ s ∨ 0 ≤ r) : ContinuousOn (fun z : ℝ≥0 => z ^ r) s :=
-  h.elim (fun _ ↦ ContinuousOn.mono (s := {0}ᶜ) (by fun_prop) (by aesop))
+  h.elim (fun _ ↦ ContinuousOn.mono (s := {0}ᶜ) (by fun_prop) (by simp_all))
     (NNReal.continuous_rpow_const · |>.continuousOn)
 
 end NNReal

--- a/Mathlib/Analysis/SpecificLimits/Basic.lean
+++ b/Mathlib/Analysis/SpecificLimits/Basic.lean
@@ -112,7 +112,7 @@ theorem tendsto_mul_add_inv_atTop_nhds_zero (a c : ℝ) (ha : a ≠ 0) :
 theorem Filter.EventuallyEq.div_mul_cancel {α G : Type*} [GroupWithZero G] {f g : α → G}
     {l : Filter α} (hg : Tendsto g l (𝓟 {0}ᶜ)) : (fun x ↦ f x / g x * g x) =ᶠ[l] fun x ↦ f x := by
   filter_upwards [hg.le_comap <| preimage_mem_comap (m := g) (mem_principal_self {0}ᶜ)] with x hx
-  aesop
+  simp_all
 
 /-- If `g` tends to `∞`, then eventually for all `x` we have `(f x / g x) * g x = f x`. -/
 theorem Filter.EventuallyEq.div_mul_cancel_atTop {α K : Type*}

--- a/Mathlib/CategoryTheory/Comma/Arrow.lean
+++ b/Mathlib/CategoryTheory/Comma/Arrow.lean
@@ -102,7 +102,7 @@ lemma mk_eq_mk_iff {X Y X' Y' : T} (f : X ⟶ Y) (f' : X' ⟶ Y') :
 lemma ext {f g : Arrow T}
     (h₁ : f.left = g.left) (h₂ : f.right = g.right)
     (h₃ : f.hom = eqToHom h₁ ≫ g.hom ≫ eqToHom h₂.symm) : f = g :=
-  (mk_eq_mk_iff _ _).2 (by aesop)
+  (mk_eq_mk_iff _ _).2 (by simp_all)
 
 @[simp]
 lemma arrow_mk_comp_eqToHom {X Y Y' : T} (f : X ⟶ Y) (h : Y = Y') :

--- a/Mathlib/CategoryTheory/Comma/Over/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Basic.lean
@@ -101,7 +101,7 @@ lemma homMk_eta {U V : Over X} (f : U ⟶ V) (h) :
 
 /-- This is useful when `homMk (· ≫ ·)` appears under `Functor.map` or a natural equivalence. -/
 lemma homMk_comp {U V W : Over X} (f : U.left ⟶ V.left) (g : V.left ⟶ W.left) (w_f w_g) :
-    homMk (f ≫ g) (by aesop) = homMk f w_f ≫ homMk g w_g := by
+    homMk (f ≫ g) (by simp_all) = homMk f w_f ≫ homMk g w_g := by
   ext
   simp
 

--- a/Mathlib/CategoryTheory/Limits/Types/ColimitType.lean
+++ b/Mathlib/CategoryTheory/Limits/Types/ColimitType.lean
@@ -210,7 +210,7 @@ lemma of_equiv {c' : CoconeTypes.{w₂} F} (e : c.pt ≃ c'.pt)
     convert Function.Bijective.comp e.bijective hc.bijective
     ext y
     obtain ⟨j, x, rfl⟩ := F.ιColimitType_jointly_surjective y
-    aesop
+    simp_all
 
 end IsColimit
 

--- a/Mathlib/CategoryTheory/Limits/Types/Limits.lean
+++ b/Mathlib/CategoryTheory/Limits/Types/Limits.lean
@@ -110,7 +110,7 @@ noncomputable def limitCone : Cone F where
 @[ext]
 lemma limitCone_pt_ext {x y : (limitCone F).pt}
     (w : (equivShrink F.sections).symm x = (equivShrink F.sections).symm y) : x = y := by
-  aesop
+  simp_all
 
 /-- (internal implementation) the fact that the proposed limit cone is the limit -/
 @[simps]

--- a/Mathlib/CategoryTheory/Types.lean
+++ b/Mathlib/CategoryTheory/Types.lean
@@ -232,7 +232,7 @@ def uliftFunctorTrivial : uliftFunctor.{u, u} ≅ 𝟭 _ :=
 def homOfElement {X : Type u} (x : X) : PUnit ⟶ X := fun _ => x
 
 theorem homOfElement_eq_iff {X : Type u} (x y : X) : homOfElement x = homOfElement y ↔ x = y :=
-  ⟨fun H => congr_fun H PUnit.unit, by aesop⟩
+  ⟨fun H => congr_fun H PUnit.unit, by simp_all⟩
 
 /-- A morphism in `Type` is a monomorphism if and only if it is injective. -/
 @[stacks 003C]

--- a/Mathlib/Combinatorics/Additive/FreimanHom.lean
+++ b/Mathlib/Combinatorics/Additive/FreimanHom.lean
@@ -209,11 +209,11 @@ lemma isMulFreimanHom_const {b : β} (hb : b ∈ B) : IsMulFreimanHom n A B fun 
 
 @[to_additive (attr := simp)]
 lemma isMulFreimanHom_zero_iff : IsMulFreimanHom 0 A B f ↔ MapsTo f A B :=
-  ⟨fun h => h.mapsTo, fun h => ⟨h, by aesop⟩⟩
+  ⟨fun h => h.mapsTo, fun h => ⟨h, by simp_all⟩⟩
 
 @[to_additive (attr := simp)]
 lemma isMulFreimanIso_zero_iff : IsMulFreimanIso 0 A B f ↔ BijOn f A B :=
-  ⟨fun h => h.bijOn, fun h => ⟨h, by aesop⟩⟩
+  ⟨fun h => h.bijOn, fun h => ⟨h, by simp_all⟩⟩
 
 @[to_additive (attr := simp) isAddFreimanHom_one_iff]
 lemma isMulFreimanHom_one_iff : IsMulFreimanHom 1 A B f ↔ MapsTo f A B :=

--- a/Mathlib/Combinatorics/Schnirelmann.lean
+++ b/Mathlib/Combinatorics/Schnirelmann.lean
@@ -159,7 +159,7 @@ lemma schnirelmannDensity_le_iff_forall {x : ℝ} :
 
 lemma schnirelmannDensity_congr' {B : Set ℕ} [DecidablePred (· ∈ B)]
     (h : ∀ n > 0, n ∈ A ↔ n ∈ B) : schnirelmannDensity A = schnirelmannDensity B := by
-  rw [schnirelmannDensity, schnirelmannDensity]; congr; ext ⟨n, hn⟩; congr 3; ext x; aesop
+  rw [schnirelmannDensity, schnirelmannDensity]; congr; ext ⟨n, hn⟩; congr 3; ext x; simp_all
 
 /-- The Schnirelmann density is unaffected by adding `0`. -/
 @[simp] lemma schnirelmannDensity_insert_zero [DecidablePred (· ∈ insert 0 A)] :
@@ -173,7 +173,7 @@ lemma schnirelmannDensity_diff_singleton_zero [DecidablePred (· ∈ A \ {0})] :
 
 lemma schnirelmannDensity_congr {B : Set ℕ} [DecidablePred (· ∈ B)] (h : A = B) :
     schnirelmannDensity A = schnirelmannDensity B :=
-  schnirelmannDensity_congr' (by aesop)
+  schnirelmannDensity_congr' (by simp_all)
 
 /--
 If the Schnirelmann density is `0`, there is a positive natural for which

--- a/Mathlib/Combinatorics/SimpleGraph/CompleteMultipartite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/CompleteMultipartite.lean
@@ -44,7 +44,7 @@ def IsCompleteMultipartite.setoid (h : G.IsCompleteMultipartite) : Setoid α :=
 lemma completeMultipartiteGraph.isCompleteMultipartite {ι : Type*} (V : ι → Type*) :
     (completeMultipartiteGraph V).IsCompleteMultipartite := by
   intro
-  aesop
+  simp_all
 
 /-- The graph isomorphism from a graph `G` that `IsCompleteMultipartite` to the corresponding
 `completeMultipartiteGraph` (see also `isCompleteMultipartite_iff`) -/

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
@@ -272,15 +272,15 @@ lemma neighborSet_toSubgraph_startpoint {u v} {p : G.Walk u v}
   ext v
   simp_all only [Subgraph.mem_neighborSet, Set.mem_singleton_iff,
     SimpleGraph.Walk.toSubgraph_adj_iff, Sym2.eq, Sym2.rel_iff', Prod.mk.injEq, Prod.swap_prod_mk]
-  refine ⟨?_, by aesop⟩
+  refine ⟨?_, by simp_all⟩
   rintro ⟨i, hl | hr⟩
   · have : i = 0 := by
       apply hp.getVert_injOn (by rw [Set.mem_setOf]; omega) (by rw [Set.mem_setOf]; omega)
-      aesop
-    aesop
+      simp_all
+    simp_all
   · have : i + 1 = 0 := by
       apply hp.getVert_injOn (by rw [Set.mem_setOf]; omega) (by rw [Set.mem_setOf]; omega)
-      aesop
+      simp_all
     contradiction
 
 lemma neighborSet_toSubgraph_endpoint {u v} {p : G.Walk u v}
@@ -345,7 +345,7 @@ lemma neighborSet_toSubgraph_endpoint {u} {p : G.Walk u u} (hpc : p.IsCycle) :
   · rcases (hpc.getVert_endpoint_iff (by omega)).mp hr.2 with h1 | h2
     · contradiction
     · simp only [penultimate, ← h2, add_tsub_cancel_right]
-      aesop
+      simp_all
 
 lemma neighborSet_toSubgraph_internal {u} {i : ℕ} {p : G.Walk u u} (hpc : p.IsCycle)
     (h : i ≠ 0) (h' : i < p.length) :
@@ -361,7 +361,7 @@ lemma neighborSet_toSubgraph_internal {u} {i : ℕ} {p : G.Walk u u} (hpc : p.Is
   rintro ⟨i', ⟨hl1, hl2⟩ | ⟨hr1, hr2⟩⟩
   · apply hpc.getVert_injOn' (by rw [Set.mem_setOf_eq]; omega)
       (by rw [Set.mem_setOf_eq]; omega) at hl1
-    aesop
+    simp_all
   · apply hpc.getVert_injOn (by rw [Set.mem_setOf_eq]; omega)
       (by rw [Set.mem_setOf_eq]; omega) at hr2
     aesop

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/WalkDecomp.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/WalkDecomp.lean
@@ -197,7 +197,7 @@ lemma getVert_takeUntil {u v : V} {n : ℕ} {p : G.Walk u v} (hw : w ∈ p.suppo
       simp_all
     simp only [support_cons, List.mem_cons, huw, false_or] at hw
     by_cases hn0 : n = 0
-    · aesop
+    · simp_all
     simp only [takeUntil_cons hw ((Ne.eq_def _ _).mpr huw).symm, length_cons,
       getVert_cons _ _ hn0] at hn ⊢
     apply q.getVert_takeUntil hw

--- a/Mathlib/Combinatorics/SimpleGraph/Matching.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Matching.lean
@@ -408,7 +408,7 @@ lemma Walk.IsCycle.adj_toSubgraph_iff_of_isCycles [LocallyFinite G] {u} {p : G.W
         (Set.Nonempty.mono (p.toSubgraph.neighborSet_subset v) <|
           Set.nonempty_of_ncard_ne_zero <| by simp [
           hp.ncard_neighborSet_toSubgraph_eq_two (by aesop)]),
-      hp.ncard_neighborSet_toSubgraph_eq_two (by aesop)]
+      hp.ncard_neighborSet_toSubgraph_eq_two (by simp_all)]
 
 open scoped symmDiff
 
@@ -566,7 +566,7 @@ lemma IsAlternating.sup_edge {u x : V} (halt : G.IsAlternating G') (hnadj : ¬G'
     rcases h2.1 with ⟨h2l1, h2l2⟩ | ⟨h2r1,h2r2⟩
     · subst h2l1 h2l2
       exact (hx' _ hww' hl.symm).symm
-    · aesop
+    · simp_all
   · rw [G'.adj_congr_of_sym2 (by aesop : s(v, w) = s(u, x))]
     simp only [hnadj, false_iff, not_not]
     rcases hr.1 with ⟨hrl1, hrl2⟩ | ⟨hrr1, hrr2⟩

--- a/Mathlib/Combinatorics/SimpleGraph/Operations.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Operations.lean
@@ -162,7 +162,7 @@ instance : DecidableRel (edge s t).Adj := fun _ _ ↦ by
 
 @[simp]
 lemma edge_self_eq_bot : edge s s = ⊥ := by
-  ext; rw [edge_adj]; aesop
+  ext; rw [edge_adj]; simp_all
 
 lemma sup_edge_self : G ⊔ edge s s = G := by simp
 

--- a/Mathlib/Combinatorics/SimpleGraph/Paths.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Paths.lean
@@ -295,7 +295,7 @@ lemma IsPath.getVert_injOn {p : G.Walk u v} (hp : p.IsPath) :
     Set.InjOn p.getVert {i | i ≤ p.length} := by
   intro n hn m hm hnm
   induction p generalizing n m with
-  | nil => aesop
+  | nil => simp_all
   | @cons v w u h p ihp =>
     simp only [length_cons, Set.mem_setOf_eq] at hn hm hnm
     by_cases hn0 : n = 0 <;> by_cases hm0 : m = 0
@@ -304,7 +304,7 @@ lemma IsPath.getVert_injOn {p : G.Walk u v} (hp : p.IsPath) :
       have hvp : v ∉ p.support := by aesop
       exact (hvp (Walk.mem_support_iff_exists_getVert.mpr ⟨(m - 1), ⟨hnm.symm, by omega⟩⟩)).elim
     · simp only [hm0, Walk.getVert_cons p h hn0] at hnm
-      have hvp : v ∉ p.support := by aesop
+      have hvp : v ∉ p.support := by simp_all
       exact (hvp (Walk.mem_support_iff_exists_getVert.mpr ⟨(n - 1), ⟨hnm, by omega⟩⟩)).elim
     · simp only [Walk.getVert_cons _ _ hn0, Walk.getVert_cons _ _ hm0] at hnm
       have := ihp hp.of_cons (by omega : (n - 1) ≤ p.length)
@@ -313,7 +313,7 @@ lemma IsPath.getVert_injOn {p : G.Walk u v} (hp : p.IsPath) :
 
 lemma IsPath.getVert_eq_start_iff {i : ℕ} {p : G.Walk u w} (hp : p.IsPath) (hi : i ≤ p.length) :
     p.getVert i = u ↔ i = 0 := by
-  refine ⟨?_, by aesop⟩
+  refine ⟨?_, by simp_all⟩
   intro h
   by_cases hi : i = 0
   · exact hi

--- a/Mathlib/Combinatorics/SimpleGraph/Prod.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Prod.lean
@@ -155,7 +155,7 @@ lemma length_boxProd {a₁ a₂ : α} {b₁ b₂ : β} [DecidableEq α] [Decidab
   | .cons x w' => next c =>
     unfold ofBoxProdLeft ofBoxProdRight
     rw [length_cons, length_boxProd w']
-    have disj : (G.Adj a₁ c.1 ∧ b₁ = c.2) ∨ (H.Adj b₁ c.2 ∧ a₁ = c.1) := by aesop
+    have disj : (G.Adj a₁ c.1 ∧ b₁ = c.2) ∨ (H.Adj b₁ c.2 ∧ a₁ = c.1) := by simp_all
     rcases disj with h₁ | h₂
     · simp only [h₁, and_self, ↓reduceDIte, length_cons, Or.by_cases]
       rw [add_comm, add_comm w'.ofBoxProdLeft.length 1, add_assoc]

--- a/Mathlib/Combinatorics/SimpleGraph/Tutte.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Tutte.lean
@@ -203,7 +203,7 @@ private theorem tutte_exists_isPerfectMatching_of_near_matchings {x a b c : V}
       Disjoint.left_le_of_le_sup_right induce_le ?_⟩
     rw [disjoint_edge]
     rw [ConnectedComponent.adj_spanningCoe_toSimpleGraph]
-    aesop
+    simp_all
   push_neg at hxc
   have hacc := ((cycles.connectedComponentMk c).mem_supp_congr_adj hcac.symm).mp rfl
   have (G : SimpleGraph V) : LocallyFinite G := fun _ ↦ Fintype.ofFinite _

--- a/Mathlib/Computability/AkraBazzi/SumTransform.lean
+++ b/Mathlib/Computability/AkraBazzi/SumTransform.lean
@@ -242,7 +242,7 @@ lemma eventually_log_b_mul_pos : ∀ᶠ (n : ℕ) in atTop, ∀ i, 0 < log (b i 
     | inr hn => -- R.n₀ ≤ n
       rw [R.h_rec n hn]
       have := R.g_nonneg
-      refine add_pos_of_pos_of_nonneg (Finset.sum_pos ?sum_elems univ_nonempty) (by aesop)
+      refine add_pos_of_pos_of_nonneg (Finset.sum_pos ?sum_elems univ_nonempty) (by simp_all)
       exact fun i _ => mul_pos (R.a_pos i) <| h_ind _ (R.r_lt_n i _ hn)
 
 @[aesop safe apply]
@@ -439,13 +439,13 @@ lemma isEquivalent_smoothingFn_sub_self (i : α) :
   calc (fun (n : ℕ) => 1 / log (b i * n) - 1 / log n)
         =ᶠ[atTop] fun (n : ℕ) => (log n - log (b i * n)) / (log (b i * n) * log n) := by
             filter_upwards [eventually_gt_atTop 1, R.eventually_log_b_mul_pos] with n hn hn'
-            have h_log_pos : 0 < log n := Real.log_pos <| by aesop
+            have h_log_pos : 0 < log n := Real.log_pos <| by simp_all
             simp only [one_div]
             rw [inv_sub_inv (by have := hn' i; positivity) (by aesop)]
       _ =ᶠ[atTop] (fun (n : ℕ) ↦ (log n - log (b i) - log n) / ((log (b i) + log n) * log n)) := by
             filter_upwards [eventually_ne_atTop 0] with n hn
             have : 0 < b i := R.b_pos i
-            rw [log_mul (by positivity) (by aesop), sub_add_eq_sub_sub]
+            rw [log_mul (by positivity) (by simp_all), sub_add_eq_sub_sub]
       _ = (fun (n : ℕ) => -log (b i) / ((log (b i) + log n) * log n)) := by ext; congr; ring
       _ ~[atTop] (fun (n : ℕ) => -log (b i) / (log n * log n)) := by
             refine IsEquivalent.div (IsEquivalent.refl) <| IsEquivalent.mul ?_ (IsEquivalent.refl)

--- a/Mathlib/Data/ENNReal/Holder.lean
+++ b/Mathlib/Data/ENNReal/Holder.lean
@@ -171,7 +171,7 @@ lemma lt_top_iff_one_lt : p < ∞ ↔ 1 < q := by
 
 lemma sub_one_mul_inv (hp : p ≠ ⊤) : (p - 1) * p⁻¹ = q⁻¹ := by
   have := pos p q |>.ne'
-  rw [ENNReal.sub_mul (by aesop), ENNReal.mul_inv_cancel this (by omega)]
+  rw [ENNReal.sub_mul (by simp_all), ENNReal.mul_inv_cancel this (by omega)]
   simp [one_sub_inv p q]
 
 end HolderConjugate

--- a/Mathlib/Data/Finset/Basic.lean
+++ b/Mathlib/Data/Finset/Basic.lean
@@ -123,7 +123,7 @@ theorem erase_empty (a : α) : erase ∅ a = ∅ :=
   rfl
 
 protected lemma Nontrivial.erase_nonempty (hs : s.Nontrivial) : (s.erase a).Nonempty :=
-  (hs.exists_ne a).imp <| by aesop
+  (hs.exists_ne a).imp <| by simp_all
 
 @[simp] lemma erase_nonempty (ha : a ∈ s) : (s.erase a).Nonempty ↔ s.Nontrivial := by
   simp only [Finset.Nonempty, mem_erase, and_comm (b := _ ∈ _)]

--- a/Mathlib/Data/Finset/Card.lean
+++ b/Mathlib/Data/Finset/Card.lean
@@ -248,7 +248,7 @@ theorem fiber_card_ne_zero_iff_mem_image (s : Finset α) (f : α → β) [Decida
 
 lemma card_filter_le_iff (s : Finset α) (P : α → Prop) [DecidablePred P] (n : ℕ) :
     #(s.filter P) ≤ n ↔ ∀ s' ⊆ s, n < #s' → ∃ a ∈ s', ¬ P a :=
-  (s.1.card_filter_le_iff P n).trans ⟨fun H s' hs' h ↦ H s'.1 (by aesop) h,
+  (s.1.card_filter_le_iff P n).trans ⟨fun H s' hs' h ↦ H s'.1 (by simp_all) h,
     fun H s' hs' h ↦ H ⟨s', nodup_of_le hs' s.2⟩ (fun _ hx ↦ Multiset.subset_of_le hs' hx) h⟩
 
 @[simp]

--- a/Mathlib/Data/Finset/Lattice/Prod.lean
+++ b/Mathlib/Data/Finset/Lattice/Prod.lean
@@ -47,7 +47,7 @@ variable {ι κ α β : Type*} [SemilatticeSup α] [SemilatticeSup β] [OrderBot
     obtain ⟨a, ha⟩ := hs
     obtain ⟨b, hb⟩ := ht
     simp only [Prod.map, Finset.sup_le_iff, mem_product, and_imp, Prod.forall, Prod.le_def]
-    exact ⟨fun h ↦ ⟨fun i hi ↦ (h _ _ hi hb).1, fun j hj ↦ (h _ _ ha hj).2⟩, by aesop⟩
+    exact ⟨fun h ↦ ⟨fun i hi ↦ (h _ _ hi hb).1, fun j hj ↦ (h _ _ ha hj).2⟩, by simp_all⟩
 
 end Prod
 
@@ -131,7 +131,7 @@ lemma prodMk_sup'_sup' (hs : s.Nonempty) (ht : t.Nonempty) (f : ι → α) (g : 
     obtain ⟨a, ha⟩ := hs
     obtain ⟨b, hb⟩ := ht
     simp only [Prod.map, sup'_le_iff, mem_product, and_imp, Prod.forall, Prod.le_def]
-    exact ⟨by aesop, fun h ↦ ⟨fun i hi ↦ (h _ _ hi hb).1, fun j hj ↦ (h _ _ ha hj).2⟩⟩
+    exact ⟨by simp_all, fun h ↦ ⟨fun i hi ↦ (h _ _ hi hb).1, fun j hj ↦ (h _ _ ha hj).2⟩⟩
 
 /-- See also `Finset.prodMk_sup'_sup'`. -/
 -- @[simp] -- TODO: Why does `Prod.map_apply` simplify the LHS?

--- a/Mathlib/Data/Finset/Sym.lean
+++ b/Mathlib/Data/Finset/Sym.lean
@@ -58,7 +58,7 @@ theorem sym2_insert [DecidableEq α] (a : α) (s : Finset α) :
     (insert a s).sym2 = ((insert a s).image fun b => s(a, b)) ∪ s.sym2 := by
   obtain ha | ha := Decidable.em (a ∈ s)
   · simp only [insert_eq_of_mem ha, right_eq_union, image_subset_iff]
-    aesop
+    simp_all
   · simpa [map_eq_image] using sym2_cons a s ha
 
 theorem sym2_map (f : α ↪ β) (s : Finset α) : (s.map f).sym2 = s.sym2.map (.sym2Map f) :=

--- a/Mathlib/Data/Finsupp/Defs.lean
+++ b/Mathlib/Data/Finsupp/Defs.lean
@@ -335,7 +335,7 @@ lemma range_mapRange (e : M → N) (he₀ : e 0 = 0) :
   · intro h
     classical
     choose f h using h
-    use onFinset g.support (fun x ↦ if x ∈ g.support then f x else 0) (by aesop)
+    use onFinset g.support (fun x ↦ if x ∈ g.support then f x else 0) (by simp_all)
     ext i
     simp only [mapRange_apply, onFinset_apply]
     split_ifs <;> simp_all

--- a/Mathlib/Data/Int/GCD.lean
+++ b/Mathlib/Data/Int/GCD.lean
@@ -273,10 +273,10 @@ variable [GroupWithZero α] {a b : α} {m n : ℕ}
 protected lemma Commute.pow_eq_pow_iff_of_coprime (hab : Commute a b) (hmn : m.Coprime n) :
     a ^ m = b ^ n ↔ ∃ c, a = c ^ n ∧ b = c ^ m := by
   refine ⟨fun h ↦ ?_, by rintro ⟨c, rfl, rfl⟩; rw [← pow_mul, ← pow_mul']⟩
-  by_cases m = 0; · aesop
-  by_cases n = 0; · aesop
-  by_cases hb : b = 0; · exact ⟨0, by aesop⟩
-  by_cases ha : a = 0; · exact ⟨0, by have := h.symm; aesop⟩
+  by_cases m = 0; · simp_all
+  by_cases n = 0; · simp_all
+  by_cases hb : b = 0; · exact ⟨0, by simp_all⟩
+  by_cases ha : a = 0; · exact ⟨0, by have := h.symm; simp_all⟩
   refine ⟨a ^ Nat.gcdB m n * b ^ Nat.gcdA m n, ?_, ?_⟩ <;>
   · refine (pow_one _).symm.trans ?_
     conv_lhs => rw [← zpow_natCast, ← hmn, Nat.gcd_eq_gcd_ab]

--- a/Mathlib/Data/List/Nodup.lean
+++ b/Mathlib/Data/List/Nodup.lean
@@ -251,7 +251,7 @@ lemma nodup_tail_reverse (l : List α) (h : l[0]? = l.getLast?) :
   | nil => simp
   | cons a l ih =>
     by_cases hl : l = []
-    · aesop
+    · simp_all
     · simp_all only [List.tail_reverse, List.nodup_reverse,
         List.dropLast_cons_of_ne_nil hl, List.tail_cons]
       simp only [length_cons, Nat.zero_lt_succ, getElem?_eq_getElem,

--- a/Mathlib/Data/List/TakeDrop.lean
+++ b/Mathlib/Data/List/TakeDrop.lean
@@ -73,7 +73,7 @@ lemma drop_length_sub_one {l : List α} (h : l ≠ []) : l.drop (l.length - 1) =
   | nil => aesop
   | cons a l ih =>
     by_cases hl : l = []
-    · aesop
+    · simp_all
     rw [length_cons, Nat.add_one_sub_one, List.drop_length_cons hl a]
     simp [getLast_cons, hl]
 

--- a/Mathlib/Data/Matrix/Basis.lean
+++ b/Mathlib/Data/Matrix/Basis.lean
@@ -360,7 +360,7 @@ variable [Fintype n] [Semiring α]
 theorem row_eq_zero_of_commute_single {i j k : n} {M : Matrix n n α}
     (hM : Commute (single i j 1) M) (hkj : k ≠ j) : M j k = 0 := by
   have := ext_iff.mpr hM i k
-  aesop
+  simp_all
 
 @[deprecated (since := "2025-05-05")]
 alias row_eq_zero_of_commute_stdBasisMatrix := row_eq_zero_of_commute_single
@@ -368,7 +368,7 @@ alias row_eq_zero_of_commute_stdBasisMatrix := row_eq_zero_of_commute_single
 theorem col_eq_zero_of_commute_single {i j k : n} {M : Matrix n n α}
     (hM : Commute (single i j 1) M) (hki : k ≠ i) : M k i = 0 := by
   have := ext_iff.mpr hM k j
-  aesop
+  simp_all
 
 @[deprecated (since := "2025-05-05")]
 alias col_eq_zero_of_commute_stdBasisMatrix := col_eq_zero_of_commute_single
@@ -376,7 +376,7 @@ alias col_eq_zero_of_commute_stdBasisMatrix := col_eq_zero_of_commute_single
 theorem diag_eq_of_commute_single {i j : n} {M : Matrix n n α}
     (hM : Commute (single i j 1) M) : M i i = M j j := by
   have := ext_iff.mpr hM i j
-  aesop
+  simp_all
 
 @[deprecated (since := "2025-05-05")]
 alias diag_eq_of_commute_stdBasisMatrix := diag_eq_of_commute_single

--- a/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
+++ b/Mathlib/Data/Matrix/ColumnRowPartitioned.lean
@@ -112,7 +112,7 @@ lemma fromRows_inj : Function.Injective2 (@fromRows R m₁ m₂ n) := by
 lemma fromCols_inj : Function.Injective2 (@fromCols R m n₁ n₂) := by
   intros x1 x2 y1 y2
   simp only [← Matrix.ext_iff]
-  aesop
+  simp_all
 
 lemma fromCols_ext_iff (A₁ : Matrix m n₁ R) (A₂ : Matrix m n₂ R) (B₁ : Matrix m n₁ R)
     (B₂ : Matrix m n₂ R) :

--- a/Mathlib/Data/Matroid/Minor/Restrict.lean
+++ b/Mathlib/Data/Matroid/Minor/Restrict.lean
@@ -137,7 +137,7 @@ theorem restrict_finite {R : Set α} (hR : R.Finite) : (M ↾ R).Finite :=
   rw [Dep, restrict_indep_iff, restrict_ground_eq]; tauto
 
 @[simp] theorem restrict_ground_eq_self (M : Matroid α) : (M ↾ M.E) = M := by
-  refine ext_indep rfl ?_; aesop
+  refine ext_indep rfl ?_; simp_all
 
 theorem restrict_restrict_eq {R₁ R₂ : Set α} (M : Matroid α) (hR : R₂ ⊆ R₁) :
     (M ↾ R₁) ↾ R₂ = M ↾ R₂ := by

--- a/Mathlib/Data/Multiset/DershowitzManna.lean
+++ b/Mathlib/Data/Multiset/DershowitzManna.lean
@@ -144,7 +144,7 @@ private lemma transGen_oneStep_of_isDershowitzMannaLT :
     ⟨X + Z, Y', z, add_right_comm .., by simp [hN, add_comm (_ + _)], by simp [Y']⟩
   · rw [add_add_tsub_cancel (filter_le ..), hM]
   · simp only [sub_filter_eq_filter_not, mem_filter, Y'] at hy
-    simpa [hy.2] using hYZ y (by aesop)
+    simpa [hy.2] using hYZ y (by simp_all)
 
 private lemma isDershowitzMannaLT_of_transGen_oneStep (hMN : TransGen OneStep M N) :
     IsDershowitzMannaLT M N :=

--- a/Mathlib/Data/Nat/Prime/Defs.lean
+++ b/Mathlib/Data/Nat/Prime/Defs.lean
@@ -137,7 +137,7 @@ theorem prime_iff_not_exists_mul_eq {p : ℕ} :
   simp_rw [prime_def_lt, dvd_def, exists_imp]
   refine and_congr_right fun hp ↦ forall_congr' fun m ↦ (forall_congr' fun h ↦ ?_).trans forall_comm
   simp_rw [Ne, forall_comm (β := _ = _), eq_comm, imp_false, not_lt]
-  refine forall₂_congr fun n hp ↦ ⟨by aesop, fun hpn ↦ ?_⟩
+  refine forall₂_congr fun n hp ↦ ⟨by simp_all, fun hpn ↦ ?_⟩
   have := mul_ne_zero_iff.mp (hp ▸ show p ≠ 0 by omega)
   exact (Nat.mul_eq_right (by omega)).mp
     (hp.symm.trans (hpn.antisymm (hp ▸ Nat.le_mul_of_pos_left _ (by omega))))

--- a/Mathlib/Geometry/Group/Growth/QuotientInter.lean
+++ b/Mathlib/Geometry/Group/Growth/QuotientInter.lean
@@ -46,7 +46,7 @@ lemma card_pow_quotient_mul_pow_inter_subgroup_le :
       have hπa₂ : π a₂ = 1 := (QuotientGroup.eq_one_iff _).2 ha₂
       have hπb : π b₁ = π b₂ := by
         simpa [hπφ, Set.mem_image_of_mem π, hb₁, hb₂, hπa₁, hπa₂] using congr(π $hab)
-      aesop
+      simp_all
     _ ≤ #(A ^ (m + n)) := by
       gcongr
       simp only [mul_subset_iff, mem_image, exists_exists_and_eq_and, Finset.mem_filter, and_imp,

--- a/Mathlib/Geometry/Manifold/VectorField/LieBracket.lean
+++ b/Mathlib/Geometry/Manifold/VectorField/LieBracket.lean
@@ -178,7 +178,7 @@ theorem mlieBracketWithin_inter (ht : t ∈ 𝓝 x) :
   apply mlieBracketWithin_congr_set
   filter_upwards [ht] with y hy
   change (y ∈ s ∩ t) = (y ∈ s)
-  aesop
+  simp_all
 
 theorem mlieBracketWithin_of_mem_nhds (h : s ∈ 𝓝 x) :
     mlieBracketWithin I V W s x = mlieBracket I V W x := by

--- a/Mathlib/GroupTheory/CoprodI.lean
+++ b/Mathlib/GroupTheory/CoprodI.lean
@@ -345,7 +345,7 @@ theorem rcons_inj {i} : Function.Injective (rcons : Pair M i → Word M) := by
   rintro ⟨m, w, h⟩ ⟨m', w', h'⟩ he
   by_cases hm : m = 1 <;> by_cases hm' : m' = 1
   · simp only [rcons, dif_pos hm, dif_pos hm'] at he
-    aesop
+    simp_all
   · exfalso
     simp only [rcons, dif_pos hm, dif_neg hm'] at he
     rw [he] at h

--- a/Mathlib/GroupTheory/FreeGroup/Basic.lean
+++ b/Mathlib/GroupTheory/FreeGroup/Basic.lean
@@ -652,7 +652,7 @@ theorem Red.exact : mk L₁ = mk L₂ ↔ Join Red L₁ L₂ :=
 @[to_additive /-- The canonical map from the type to the additive free group is an injection. -/]
 theorem of_injective : Function.Injective (@of α) := fun _ _ H => by
   let ⟨L₁, hx, hy⟩ := Red.exact.1 H
-  simp [Red.singleton_iff] at hx hy; aesop
+  simp [Red.singleton_iff] at hx hy; simp_all
 
 section lift
 

--- a/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
+++ b/Mathlib/GroupTheory/SpecificGroups/Cyclic.lean
@@ -693,8 +693,8 @@ lemma not_isCyclic_iff_exponent_eq_prime [Group α] {p : ℕ} (hp : p.Prime)
       Function.Embedding.coeFn_mk] at this
   obtain ⟨a, ha, ha'⟩ := this
   interval_cases a
-  · exact False.elim <| hg <| orderOf_eq_one_iff.mp <| by aesop
-  · aesop
+  · exact False.elim <| hg <| orderOf_eq_one_iff.mp <| by simp_all
+  · simp_all
   · exact False.elim <| h_cyc <| isCyclic_of_orderOf_eq_card g <| by omega
 
 end Exponent

--- a/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/LinearIndependent/Lemmas.lean
@@ -323,7 +323,7 @@ private lemma LinearIndependent.pair_add_smul_add_smul_iff_aux (h : a * d ≠ b 
       refine ⟨c • 1, -a • 1, ?_, by aesop⟩
       simp only [smul_assoc, one_smul, neg_smul]
       module
-    refine ⟨d • 1, -b • 1, ?_, by contrapose! hbd; aesop⟩
+    refine ⟨d • 1, -b • 1, ?_, by contrapose! hbd; simp_all⟩
     simp only [smul_add, smul_assoc, one_smul, smul_smul, mul_comm d, h]
     module
   refine ⟨fun h' ↦ ⟨?_, h⟩, fun ⟨h₁, h₂⟩ ↦ pair_add_smul_add_smul_iff_aux _ _ _ _ h₂ h₁⟩

--- a/Mathlib/LinearAlgebra/RootSystem/Base.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Base.lean
@@ -100,7 +100,7 @@ lemma root_ne_neg_of_ne [Nontrivial R] {i j : ι}
   intro contra
   have := linearIndepOn_iff'.mp b.linearIndepOn_root ({i, j} : Finset ι) 1
     (by simp [Set.insert_subset_iff, hi, hj]) (by simp [Finset.sum_pair hij, contra])
-  aesop
+  simp_all
 
 lemma linearIndependent_pair_of_ne {i j : b.support} (hij : i ≠ j) :
     LinearIndependent R ![P.root i, P.root j] := by
@@ -219,7 +219,7 @@ lemma pos_or_neg_of_sum_smul_root_mem (f : ι → ℤ)
     · change 0 ≤ f' ⟨i, hi⟩
       simp [← hc]
     · replace hi : i ∉ f.support := by contrapose! hi; exact hf₀ hi
-      aesop
+      simp_all
   refine Pi.lt_def.mpr ⟨aux, ?_⟩
   by_contra! contra
   replace contra : f = 0 := le_antisymm contra aux
@@ -242,7 +242,7 @@ lemma not_nonneg_iff_neg_of_sum_mem_range_root (f : ι → ℤ)
   replace hf : ∑ j ∈ b.support, (-f) j • P.root j ∈ range P.root := by
     rw [← neg_mem_range_root_iff]; simpa
   have := b.not_nonpos_iff_pos_of_sum_mem_range_root (-f) hf (by simpa)
-  aesop
+  simp_all
 
 lemma sub_notMem_range_root
     {i j : ι} (hi : i ∈ b.support) (hj : j ∈ b.support) :
@@ -421,7 +421,7 @@ lemma height_one_of_mem_support {i : ι} (hi : i ∈ b.support) :
     b.height i = 1 := by
   classical
   have : P.root i = ∑ j ∈ b.support, (Pi.single i 1 : ι → ℤ) j • P.root j := by
-    rw [Finset.sum_eq_single_of_mem i hi (by aesop)]; simp
+    rw [Finset.sum_eq_single_of_mem i hi (by simp_all)]; simp
   simpa [height_eq_sum this]
 
 lemma height_add {i j k : ι} (hk : P.root k = P.root i + P.root j) :
@@ -497,7 +497,7 @@ lemma IsPos.sub {i j k : ι}
 lemma IsPos.exists_mem_support_pos_pairingIn [P.IsCrystallographic] {i : ι} (h₀ : b.IsPos i) :
     ∃ j ∈ b.support, 0 < P.pairingIn ℤ j i := by
   by_contra! contra
-  suffices P.pairingIn ℤ i i ≤ 0 by aesop
+  suffices P.pairingIn ℤ i i ≤ 0 by simp_all
   obtain ⟨f, hf₀, hf₁, hf₂⟩ := b.exists_root_eq_sum_int i
   replace hf₁ : 0 < f := by
     refine hf₁.resolve_right ?_
@@ -513,7 +513,7 @@ lemma IsPos.exists_mem_support_pos_pairingIn [P.IsCrystallographic] {i : ι} (h�
   refine Finset.sum_nonpos fun j _ ↦ ?_
   by_cases hj : j ∈ Function.support f
   · exact smul_nonpos_of_nonneg_of_nonpos (hf₁.le j) (contra j (hf₀ hj))
-  · aesop
+  · simp_all
 
 lemma exists_mem_support_pos_pairingIn_ne_zero [P.IsCrystallographic] (i : ι) :
     ∃ j ∈ b.support, P.pairingIn ℤ j i ≠ 0 := by
@@ -535,7 +535,7 @@ lemma IsPos.add_zsmul {i j k : ι} {z : ℤ} (hij : i ≠ j)
     rw [contra, isPos_iff, height_reflectionPerm_self, height_one_of_mem_support hj] at hi
     omega
   induction z generalizing i k with
-  | zero => aesop
+  | zero => simp_all
   | succ w hw =>
     obtain ⟨l, hl⟩ : P.root i + (w : ℤ) • P.root j ∈ range P.root := by
       replace hk : P.root i + (w + 1) • P.root j ∈ range P.root := ⟨k, by rw [hk]; module⟩
@@ -656,7 +656,7 @@ lemma forall_mem_support_invtSubmodule_iff (q : Submodule R M) :
   refine ⟨fun hq i ↦ ?_, fun hq i _ ↦ hq i⟩
   letI := P.indexNeg
   have (j : ι) : P.reflection (-j) = P.reflection j := by ext x; simp [reflection_apply, two_smul]
-  refine b.induction_reflect i (by aesop) hq ?_
+  refine b.induction_reflect i (by simp_all) hq ?_
   clear i
   intro i j hi hj
   rw [reflection_reflectionPerm]

--- a/Mathlib/LinearAlgebra/RootSystem/CartanMatrix.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/CartanMatrix.lean
@@ -127,7 +127,7 @@ lemma cartanMatrix_mem_of_ne {i j : b.support} (hij : i ≠ j) :
   have h₂ : P.pairingIn ℤ i j ≤ 0 := b.cartanMatrix_le_zero_of_ne i j hij
   suffices P.pairingIn ℤ i j ≠ -4 by aesop
   by_contra contra
-  replace contra : P.pairingIn ℤ j i = -1 ∧ P.pairingIn ℤ i j = -4 := ⟨by aesop, contra⟩
+  replace contra : P.pairingIn ℤ j i = -1 ∧ P.pairingIn ℤ i j = -4 := ⟨by simp_all, contra⟩
   rw [pairingIn_neg_one_neg_four_iff] at contra
   refine (not_linearIndependent_iff.mpr ?_) b.linearIndepOn_root
   refine ⟨⟨{i, j}, by simpa⟩, Finsupp.single i (1 : R) + Finsupp.single j (2 : R), ?_⟩
@@ -179,15 +179,15 @@ lemma induction_on_cartanMatrix [P.IsReduced] [P.IsIrreducible]
     rw [hq_mem]
     induction hx using Submodule.span_induction with
     | mem x hx =>
-      obtain ⟨l, hl, rfl⟩ : ∃ l : b.support, p l ∧ P.root l = x := by aesop
+      obtain ⟨l, hl, rfl⟩ : ∃ l : b.support, p l ∧ P.root l = x := by simp_all
       replace hk : b.cartanMatrix k l ≠ 0 := by
         rwa [ne_eq, cartanMatrix_apply_eq_zero_iff_symm, cartanMatrix_apply_eq_zero_iff_pairing]
       tauto
-    | zero => aesop
+    | zero => simp_all
     | add x y hx hy hx' hy' =>
-      replace hk : P.coroot' k x ≠ 0 ∨ P.coroot' k y ≠ 0 := by by_contra! contra; aesop
+      replace hk : P.coroot' k x ≠ 0 ∨ P.coroot' k y ≠ 0 := by by_contra! contra; simp_all
       tauto
-    | smul a x hx hx' => aesop
+    | smul a x hx hx' => simp_all
   have hq : ∀ k, q ∈ invtSubmodule (P.reflection k) := by
     rw [← b.forall_mem_support_invtSubmodule_iff]
     refine fun k hkb ↦ (mem_invtSubmodule _).mpr fun x hx ↦ ?_

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/G2.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/G2.lean
@@ -575,8 +575,8 @@ lemma mem_allRoots (i : ι) :
     induction hx using Submodule.span_induction with
     | zero => simp
     | mem => aesop
-    | add => aesop
-    | smul => aesop
+    | add => simp_all
+    | smul => simp_all
   simpa using LinearMap.congr_fun key (P.root i)
 
 open scoped Classical in

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -105,7 +105,7 @@ lemma pairingIn_pairingIn_mem_set_of_isCrystal_of_isRed [P.IsReduced] :
         (-3, -1), (2, 2), (-2, -2)} : Set (ℤ × ℤ)) := by
   have := P.reflexive_left
   rcases eq_or_ne i j with rfl | h₁; · simp
-  rcases eq_or_ne (α i) (-α j) with h₂ | h₂; · aesop
+  rcases eq_or_ne (α i) (-α j) with h₂ | h₂; · simp_all
   have aux₁ := P.pairingIn_pairingIn_mem_set_of_isCrystallographic i j
   have aux₂ : P.pairingIn ℤ i j * P.pairingIn ℤ j i ≠ 4 := P.coxeterWeightIn_ne_four ℤ h₁ h₂
   aesop -- #24551 (this should be faster)
@@ -117,7 +117,7 @@ lemma pairingIn_pairingIn_mem_set_of_isCrystal_of_isRed' [P.IsReduced]
         (-3, -1)} : Set (ℤ × ℤ)) := by
   have := P.reflexive_left
   have := P.pairingIn_pairingIn_mem_set_of_isCrystal_of_isRed i j
-  aesop
+  simp_all
 
 variable {P} in
 lemma RootPositiveForm.rootLength_le_of_pairingIn_eq (B : P.RootPositiveForm ℤ) {i j : ι}
@@ -174,7 +174,7 @@ lemma pairingIn_pairingIn_mem_set_of_length_eq_of_ne {B : P.InvariantForm}
     (P.pairingIn ℤ i j, P.pairingIn ℤ j i) ∈ ({(0, 0), (1, 1), (-1, -1)} : Set (ℤ × ℤ)) := by
   have := P.reflexive_left
   have := P.pairingIn_pairingIn_mem_set_of_length_eq len_eq
-  aesop
+  simp_all
 
 omit [Finite ι] in
 lemma coxeterWeightIn_eq_zero_iff :
@@ -206,7 +206,7 @@ lemma root_sub_root_mem_of_pairingIn_pos (h : 0 < P.pairingIn ℤ i j) (h' : i �
       have aux₂ := (linearIndependent_iff_coxeterWeightIn_ne_four P ℤ).mp hli
       have aux₃ : P.coxeterWeightIn ℤ i j ≠ 0 := by
         simpa only [ne_eq, P.coxeterWeightIn_eq_zero_iff] using h.ne'
-      aesop
+      simp_all
     simp_rw [coxeterWeightIn, Int.mul_mem_one_two_three_iff, mem_insert_iff, mem_singleton_iff,
       Prod.mk.injEq] at this
     omega

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Nondegenerate.lean
@@ -276,7 +276,7 @@ lemma rootForm_restrict_nondegenerate_of_isAnisotropic :
 lemma orthogonal_rootSpan_eq :
     P.RootForm.orthogonal (P.rootSpan R) = LinearMap.ker P.RootForm := by
   rw [← LinearMap.BilinForm.orthogonal_top_eq_ker P.rootForm_symmetric.isRefl]
-  refine le_antisymm ?_ (by intro; aesop)
+  refine le_antisymm ?_ (by intro; simp_all)
   rintro x hx y -
   simp only [LinearMap.BilinForm.mem_orthogonal_iff, LinearMap.BilinForm.IsOrtho] at hx ⊢
   obtain ⟨u, hu, v, hv, rfl⟩ : ∃ᵉ (u ∈ P.rootSpan R) (v ∈ LinearMap.ker P.RootForm), u + v = y := by

--- a/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Basic.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/GeckConstruction/Basic.lean
@@ -163,7 +163,7 @@ lemma ω_mul_e [Fintype ι] (i : b.support) :
   · simp [ω, e, f]
   · simp only [ω, e, f, mul_ite, mul_zero, Fintype.sum_sum_type, Matrix.mul_apply, Matrix.of_apply,
       Matrix.fromBlocks_apply₁₂, Matrix.fromBlocks_apply₂₂, Finset.sum_ite_eq']
-    rw [Finset.sum_eq_single_of_mem i (Finset.mem_univ _) (by aesop)]
+    rw [Finset.sum_eq_single_of_mem i (Finset.mem_univ _) (by simp_all)]
     simp [← ite_and, and_comm, - indexNeg_neg, neg_eq_iff_eq_neg]
   · simp [ω, e, f]
   · simp only [ω, e, f, Matrix.mul_apply, Fintype.sum_sum_type, Matrix.fromBlocks_apply₂₁,

--- a/Mathlib/LinearAlgebra/RootSystem/Reduced.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Reduced.lean
@@ -56,7 +56,7 @@ lemma isReduced_iff' : P.IsReduced ↔ ∀ i j : ι, i ≠ j →
 lemma IsReduced.linearIndependent [P.IsReduced] (h : i ≠ j) (h' : P.root i ≠ -P.root j) :
     LinearIndependent R ![P.root i, P.root j] := by
   have := IsReduced.eq_or_eq_neg (P := P) i j
-  aesop
+  simp_all
 
 lemma IsReduced.linearIndependent_iff [Nontrivial R] [P.IsReduced] :
     LinearIndependent R ![P.root i, P.root j] ↔ i ≠ j ∧ P.root i ≠ - P.root j := by

--- a/Mathlib/LinearAlgebra/Span/Defs.lean
+++ b/Mathlib/LinearAlgebra/Span/Defs.lean
@@ -550,7 +550,7 @@ theorem subset_span_finite_of_subset_span {s : Set M} {t : Finset M} (ht : (t : 
   | insert a t hat IH =>
     obtain ⟨T, hTs, htT⟩ := IH (by simp_all [Set.insert_subset_iff])
     obtain ⟨T', hT's, haT'⟩ := mem_span_finite_of_mem_span (ht (Finset.mem_insert_self _ _))
-    refine ⟨T ∪ T', by aesop, ?_⟩
+    refine ⟨T ∪ T', by simp_all, ?_⟩
     simp only [Finset.coe_insert, Finset.coe_union, span_union, insert_subset_iff, SetLike.mem_coe]
     exact ⟨mem_sup_right haT', htT.trans (le_sup_left (a := span R _))⟩
 

--- a/Mathlib/MeasureTheory/Function/AEMeasurableOrder.lean
+++ b/Mathlib/MeasureTheory/Function/AEMeasurableOrder.lean
@@ -54,7 +54,7 @@ theorem MeasureTheory.aemeasurable_of_exist_almost_disjoint_supersets {α : Type
     intro i
     exact MeasurableSet.biInter (s_count.mono inter_subset_left) fun b _ => (huv i b).1
   let f' : α → β := fun x => ⨅ i : s, piecewise (u' i) (fun _ => (i : β)) (fun _ => (⊤ : β)) x
-  have f'_meas : Measurable f' := by fun_prop (disch := aesop)
+  have f'_meas : Measurable f' := by fun_prop (disch := simp_all)
   let t := ⋃ (p : s) (q : ↥(s ∩ Ioi p)), u' p ∩ v p q
   have μt : μ t ≤ 0 :=
     calc

--- a/Mathlib/MeasureTheory/Group/GeometryOfNumbers.lean
+++ b/Mathlib/MeasureTheory/Group/GeometryOfNumbers.lean
@@ -109,7 +109,7 @@ theorem exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure [NormedAddC
   suffices Set.Nonempty (⋂ n, Z n) by
     erw [← Set.iInter_inter, K.iInter_smul_eq_self h_zero] at this
     · obtain ⟨x, hx⟩ := this
-      exact ⟨⟨x, by aesop⟩, by aesop⟩
+      exact ⟨⟨x, by simp_all⟩, by aesop⟩
     · exact (exists_seq_strictAnti_tendsto (0 : ℝ≥0)).choose_spec.2.2
   have h_clos : IsClosed ((L : Set E) \ {0}) := by
     rsuffices ⟨U, hU⟩ : ∃ U : Set E, IsOpen U ∧  U ∩ L = {0}
@@ -128,7 +128,7 @@ theorem exists_ne_zero_mem_lattice_of_measure_mul_two_pow_le_measure [NormedAddC
         exact ⟨-y, h_symm _ hy, by simp⟩
       obtain ⟨x, hx_nz, hx_mem⟩ := exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure
         fund h_symm' (S n).convex this
-      exact ⟨x, hx_mem, by aesop⟩
+      exact ⟨x, hx_mem, by simp_all⟩
     refine lt_of_le_of_lt h ?_
     rw [ConvexBody.coe_smul', NNReal.smul_def, addHaar_smul_of_nonneg _ (NNReal.coe_nonneg _)]
     rw [show μ s < _ ↔ 1 * μ s < _ by rw [one_mul]]

--- a/Mathlib/MeasureTheory/Integral/Lebesgue/Markov.lean
+++ b/Mathlib/MeasureTheory/Integral/Lebesgue/Markov.lean
@@ -71,7 +71,7 @@ lemma setLIntegral_le_meas {s t : Set α} (hs : MeasurableSet s)
     {f : α → ℝ≥0∞} (hf : ∀ a ∈ s, a ∈ t → f a ≤ 1)
     (hf' : ∀ a ∈ s, a ∉ t → f a = 0) : ∫⁻ a in s, f a ∂μ ≤ μ t := by
   rw [← lintegral_indicator hs]
-  refine lintegral_le_meas (fun a ↦ ?_) (by aesop)
+  refine lintegral_le_meas (fun a ↦ ?_) (by simp_all)
   by_cases has : a ∈ s <;> [by_cases hat : a ∈ t; skip] <;> simp [*]
 
 theorem lintegral_eq_top_of_measure_eq_top_ne_zero {f : α → ℝ≥0∞} (hf : AEMeasurable f μ)

--- a/Mathlib/MeasureTheory/Measure/Dirac.lean
+++ b/Mathlib/MeasureTheory/Measure/Dirac.lean
@@ -104,7 +104,7 @@ theorem restrict_singleton (μ : Measure α) (a : α) : μ.restrict {a} = μ {a}
 
 /-- Two measures on a countable space are equal if they agree on singletons. -/
 theorem ext_of_singleton [Countable α] {μ ν : Measure α} (h : ∀ a, μ {a} = ν {a}) : μ = ν :=
-  ext_of_sUnion_eq_univ (countable_range singleton) (by aesop) (by aesop)
+  ext_of_sUnion_eq_univ (countable_range singleton) (by aesop) (by simp_all)
 
 /-- Two measures on a countable space are equal if and only if they agree on singletons. -/
 theorem ext_iff_singleton [Countable α] {μ ν : Measure α} : μ = ν ↔ ∀ a, μ {a} = ν {a} :=

--- a/Mathlib/NumberTheory/Cyclotomic/Basic.lean
+++ b/Mathlib/NumberTheory/Cyclotomic/Basic.lean
@@ -372,7 +372,7 @@ protected theorem finite [IsDomain B] [h₁ : Finite S] [h₂ : IsCyclotomicExte
     simp [← top_toSubmodule, ← empty, toSubmodule_bot, Submodule.one_eq_span]
   | @insert n S _ _ H =>
     by_cases hn : n = 0
-    · have : insert n S \ {0} = S \ {0} := by aesop
+    · have : insert n S \ {0} = S \ {0} := by simp_all
       rw [eq_self_sdiff_zero, this, ← eq_self_sdiff_zero] at h₂
       exact H A B
     have : IsCyclotomicExtension S A (adjoin A {b : B | ∃ n : ℕ, n ∈ S ∧ n ≠ 0 ∧ b ^ n = 1}) :=

--- a/Mathlib/NumberTheory/Divisors.lean
+++ b/Mathlib/NumberTheory/Divisors.lean
@@ -138,8 +138,8 @@ theorem mem_divisorsAntidiagonal {x : ℕ × ℕ} :
 @[simp]
 lemma toFinset_divisorsAntidiagonalList {n : ℕ} :
     n.divisorsAntidiagonalList.toFinset = n.divisorsAntidiagonal := by
-  rw [divisorsAntidiagonalList, divisorsAntidiagonal, List.toFinset_filterMap (f_inj := by aesop),
-    List.toFinset_range'_1_1]
+  rw [divisorsAntidiagonalList, divisorsAntidiagonal, List.toFinset_filterMap
+    (f_inj := by simp_all), List.toFinset_range'_1_1]
 
 lemma sorted_divisorsAntidiagonalList_fst {n : ℕ} :
     n.divisorsAntidiagonalList.Sorted (·.fst < ·.fst) := by

--- a/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
+++ b/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
@@ -215,7 +215,7 @@ theorem tendsto_sub_mul_tsum_nat_rpow :
     Tendsto (fun s : ℝ ↦ (s - 1) * ∑' (n : ℕ), 1 / (n : ℝ) ^ s) (𝓝[>] 1) (𝓝 1) := by
   rw [← tendsto_ofReal_iff, ofReal_one]
   have : Tendsto (fun s : ℝ ↦ (s : ℂ)) (𝓝[>] 1) (𝓝[{s | 1 < re s}] 1) :=
-    continuous_ofReal.continuousWithinAt.tendsto_nhdsWithin (fun _ _ ↦ by aesop)
+    continuous_ofReal.continuousWithinAt.tendsto_nhdsWithin (fun _ _ ↦ by simp_all)
   apply (tendsto_sub_mul_tsum_nat_cpow.comp this).congr fun s ↦ ?_
   simp only [one_div, Function.comp_apply, ofReal_mul, ofReal_sub, ofReal_one, ofReal_tsum,
     ofReal_inv, ofReal_cpow (Nat.cast_nonneg _), ofReal_natCast]

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/Basic.lean
@@ -247,7 +247,7 @@ volume zero. -/
 theorem volume_eq_zero (w : {w // IsReal w}) :
     volume ({x : mixedSpace K | x.1 w = 0}) = 0 := by
   let A : AffineSubspace ℝ (mixedSpace K) :=
-    Submodule.toAffineSubspace (Submodule.mk ⟨⟨{x | x.1 w = 0}, by aesop⟩, rfl⟩ (by aesop))
+    Submodule.toAffineSubspace (Submodule.mk ⟨⟨{x | x.1 w = 0}, by simp_all⟩, rfl⟩ (by simp_all))
   convert Measure.addHaar_affineSubspace volume A fun h ↦ ?_
   simpa [A] using (h ▸ Set.mem_univ _ : 1 ∈ A)
 
@@ -1143,7 +1143,7 @@ variable {K}
 theorem realSpace.volume_eq_zero [NumberField K] (w : InfinitePlace K) :
     volume ({x : realSpace K | x w = 0}) = 0 := by
   let A : AffineSubspace ℝ (realSpace K) :=
-    Submodule.toAffineSubspace (Submodule.mk ⟨⟨{x | x w = 0}, by aesop⟩, rfl⟩ (by aesop))
+    Submodule.toAffineSubspace (Submodule.mk ⟨⟨{x | x w = 0}, by simp_all⟩, rfl⟩ (by simp_all))
   convert Measure.addHaar_affineSubspace volume A fun h ↦ ?_
   simpa [A] using (h ▸ Set.mem_univ _ : 1 ∈ A)
 

--- a/Mathlib/Order/Atoms.lean
+++ b/Mathlib/Order/Atoms.lean
@@ -627,7 +627,7 @@ theorem le_iff_atom_le_imp {a b : α} : a ≤ b ↔ ∀ c : α, IsAtom c → c �
 theorem eq_iff_atom_le_iff {a b : α} : a = b ↔ ∀ c, IsAtom c → (c ≤ a ↔ c ≤ b) := by
   refine ⟨fun h => by simp [h], fun h => ?_⟩
   rw [le_antisymm_iff, le_iff_atom_le_imp, le_iff_atom_le_imp]
-  aesop
+  simp_all
 
 end IsAtomistic
 

--- a/Mathlib/Order/BooleanAlgebra/Basic.lean
+++ b/Mathlib/Order/BooleanAlgebra/Basic.lean
@@ -254,7 +254,7 @@ theorem le_sdiff_right : x ≤ y \ x ↔ x = ⊥ :=
   ⟨fun h => disjoint_self.1 (disjoint_sdiff_self_right.mono_right h), fun h => h.le.trans bot_le⟩
 
 @[simp] lemma sdiff_eq_right : x \ y = y ↔ x = ⊥ ∧ y = ⊥ := by
-  rw [disjoint_sdiff_self_left.eq_iff]; aesop
+  rw [disjoint_sdiff_self_left.eq_iff]; simp_all
 
 lemma sdiff_ne_right : x \ y ≠ y ↔ x ≠ ⊥ ∨ y ≠ ⊥ := sdiff_eq_right.not.trans not_and_or
 

--- a/Mathlib/Order/CompactlyGenerated/Basic.lean
+++ b/Mathlib/Order/CompactlyGenerated/Basic.lean
@@ -575,7 +575,7 @@ theorem exists_sSupIndep_disjoint_sSup_atoms (b c : α) (hbc : b ≤ c)
   simp_rw [maximal_subset_iff] at zorn
   obtain ⟨s, ⟨s_ind, b_inf_Sup_s, s_atoms⟩, s_max⟩ := zorn
   refine ⟨s, s_ind, b_inf_Sup_s, le_antisymm ?_ ?_, fun a ha ↦ (s_atoms a ha).1⟩
-  · aesop
+  · simp_all
   rw [← h, sSup_le_iff]
   intro a ha
   rw [← inf_eq_left]

--- a/Mathlib/Order/Interval/Set/OrdConnectedLinear.lean
+++ b/Mathlib/Order/Interval/Set/OrdConnectedLinear.lean
@@ -53,7 +53,7 @@ lemma Set.ordConnected_iff_disjoint_Ioo_empty [LinearOrder α] [LocallyFiniteOrd
   refine ⟨fun h' x hx y hy hxy ↦ ?_, fun h' ↦ ordConnected_of_Ioo fun x hx y hy hxy z hz ↦ ?_⟩
   · suffices ∀ z, x < z → y ≤ z by ext z; simpa using this z
     intro z hz
-    suffices z ∉ Ioo x y by aesop
+    suffices z ∉ Ioo x y by simp_all
     exact fun contra ↦ hxy contra <| h'.out hx hy <| mem_Icc_of_Ioo contra
   · by_contra hz'
     obtain ⟨x', hx', hx''⟩ :=

--- a/Mathlib/Order/Interval/Set/SuccPred.lean
+++ b/Mathlib/Order/Interval/Set/SuccPred.lean
@@ -67,7 +67,7 @@ lemma insert_Icc_succ_left_eq_Icc (h : a ≤ b) : insert a (Icc (succ a) b) = Ic
 
 lemma insert_Icc_right_eq_Icc_succ (h : a ≤ succ b) :
     insert (succ b) (Icc a b) = Icc a (succ b) := by
-  ext x; simp [or_and_left, le_succ_iff_eq_or_le]; aesop
+  ext x; simp [or_and_left, le_succ_iff_eq_or_le]; simp_all
 
 @[deprecated (since := "2025-04-19")]
 alias insert_Icc_eq_Icc_succ_right := insert_Icc_right_eq_Icc_succ
@@ -153,11 +153,11 @@ lemma Ioc_pred_pred_eq_Ico_of_not_isMin (ha : ¬ IsMin a) (b : α) :
 /-! ##### Inserting into intervals -/
 
 lemma insert_Icc_pred_right_eq_Icc (h : a ≤ b) : insert b (Icc a (pred b)) = Icc a b := by
-  ext x; simp [or_and_left, ← le_iff_eq_or_le_pred]; aesop
+  ext x; simp [or_and_left, ← le_iff_eq_or_le_pred]; simp_all
 
 lemma insert_Icc_left_eq_Icc_pred (h : pred a ≤ b) :
     insert (pred a) (Icc a b) = Icc (pred a) b := by
-  ext x; simp [or_and_left, pred_le_iff_eq_or_le]; aesop
+  ext x; simp [or_and_left, pred_le_iff_eq_or_le]; simp_all
 
 @[deprecated (since := "2025-04-19")]
 alias insert_Icc_eq_Icc_pred_left := insert_Icc_left_eq_Icc_pred

--- a/Mathlib/Order/SupIndep.lean
+++ b/Mathlib/Order/SupIndep.lean
@@ -370,7 +370,7 @@ theorem iSupIndep.injOn (ht : iSupIndep t) : InjOn t {i | t i ≠ ⊥} := by
 
 theorem iSupIndep.injective (ht : iSupIndep t) (h_ne_bot : ∀ i, t i ≠ ⊥) : Injective t := by
   suffices univ = {i | t i ≠ ⊥} by rw [injective_iff_injOn_univ, this]; exact ht.injOn
-  aesop
+  simp_all
 
 theorem iSupIndep_pair {i j : ι} (hij : i ≠ j) (huniv : ∀ k, k = i ∨ k = j) :
     iSupIndep t ↔ Disjoint (t i) (t j) := by

--- a/Mathlib/Order/WithBot.lean
+++ b/Mathlib/Order/WithBot.lean
@@ -988,7 +988,7 @@ section WithBotWithTop
 
 lemma WithBot.eq_top_iff_forall_ge [Preorder α] [Nonempty α] [NoTopOrder α]
     {x : WithBot (WithTop α)} : x = ⊤ ↔ ∀ a : α, a ≤ x := by
-  refine ⟨by aesop, fun H ↦ ?_⟩
+  refine ⟨by simp_all, fun H ↦ ?_⟩
   induction x
   · simp at H
   · simpa [WithTop.eq_top_iff_forall_ge] using H

--- a/Mathlib/RepresentationTheory/Basic.lean
+++ b/Mathlib/RepresentationTheory/Basic.lean
@@ -526,7 +526,7 @@ lemma leftRegular_norm_apply :
       linearCombination _ (fun _ => 1) := by
   ext i : 2
   simpa [Representation.norm] using Finset.sum_bijective _
-    (Group.mulRight_bijective i) (by aesop) (by aesop)
+    (Group.mulRight_bijective i) (by simp_all) (by simp_all)
 
 lemma leftRegular_norm_eq_zero_iff (x : G →₀ k) :
     (leftRegular k G).norm x = 0 ↔ x.linearCombination k (fun _ => (1 : k)) = 0 := by

--- a/Mathlib/RingTheory/Ideal/AssociatedPrime/Finiteness.lean
+++ b/Mathlib/RingTheory/Ideal/AssociatedPrime/Finiteness.lean
@@ -72,7 +72,7 @@ theorem Submodule.isQuotientEquivQuotientPrime_iff {N₁ N₂ : Submodule A M} :
       simp [← Quotient.mk_smul, SetLike.le_def, submoduleOf]
     · rw [mapQ, ← range_eq_top, range_liftQ, range_comp]
       have := congr($(hx').submoduleOf N₂)
-      rw [submoduleOf_self, submoduleOf_sup_of_le (by aesop) (by aesop),
+      rw [submoduleOf_self, submoduleOf_sup_of_le (by simp_all) (by simp_all),
         submoduleOf_span_singleton_of_mem _ hxN₂] at this
       simpa [← span_singleton_eq_range, LinearMap.range_toSpanSingleton] using this.symm
 

--- a/Mathlib/RingTheory/Ideal/Maximal.lean
+++ b/Mathlib/RingTheory/Ideal/Maximal.lean
@@ -177,7 +177,7 @@ lemma isPrime_of_maximally_disjoint (I : Ideal α)
   ne_top' := by
     rintro rfl
     have : 1 ∈ (S : Set α) := S.one_mem
-    aesop
+    simp_all
   mem_or_mem' {x y} hxy := by
     by_contra! rid
     have hx := maximally_disjoint (I ⊔ span {x}) (Submodule.lt_sup_iff_notMem.mpr rid.1)

--- a/Mathlib/RingTheory/IntegralClosure/IntegrallyClosed.lean
+++ b/Mathlib/RingTheory/IntegralClosure/IntegrallyClosed.lean
@@ -84,7 +84,7 @@ theorem AlgHom.isIntegrallyClosedIn (f : A →ₐ[R] B) (hf : Function.Injective
     aesop
   · rintro ⟨y, rfl⟩
     apply (isIntegral_algHom_iff f hf).mp
-    aesop
+    simp_all
 
 /-- Being integrally closed is preserved under algebra isomorphisms. -/
 theorem AlgEquiv.isIntegrallyClosedIn (e : A ≃ₐ[R] B) :
@@ -109,9 +109,9 @@ theorem isIntegrallyClosedIn_iff {R A : Type*} [CommRing R] [CommRing A] [Algebr
         ∀ {x : A}, IsIntegral R x → ∃ y, algebraMap R A y = x := by
   constructor
   · rintro ⟨_, cl⟩
-    aesop
+    simp_all
   · rintro ⟨inj, cl⟩
-    refine ⟨inj, by aesop, ?_⟩
+    refine ⟨inj, by simp_all, ?_⟩
     rintro ⟨y, rfl⟩
     apply isIntegral_algebraMap
 

--- a/Mathlib/RingTheory/KrullDimension/NonZeroDivisors.lean
+++ b/Mathlib/RingTheory/KrullDimension/NonZeroDivisors.lean
@@ -95,7 +95,7 @@ lemma ringKrullDim_add_enatCard_le_ringKrullDim_mvPolynomial (σ : Type*) :
     push_cast
     exact ringKrullDim_add_natCard_le_ringKrullDim_mvPolynomial _
   · simp only [ENat.card_eq_top_of_infinite, WithBot.coe_top]
-    suffices ringKrullDim (MvPolynomial σ R) = ⊤ by aesop
+    suffices ringKrullDim (MvPolynomial σ R) = ⊤ by simp_all
     rw [WithBot.eq_top_iff_forall_ge]
     intro n
     let ι := Infinite.natEmbedding σ ∘ Fin.val (n := n + 1)

--- a/Mathlib/RingTheory/MvPolynomial/Symmetric/NewtonIdentities.lean
+++ b/Mathlib/RingTheory/MvPolynomial/Symmetric/NewtonIdentities.lean
@@ -156,7 +156,7 @@ private theorem sum_filter_pairs_eq_sum_powersetCard_mem_filter_antidiagonal_sum
   apply sum_finset_product
   simp only [mem_filter, mem_powersetCard_univ, mem_univ, and_true, and_iff_right_iff_imp]
   rintro p hp
-  have : #p.fst ≤ k := by apply le_of_lt; aesop
+  have : #p.fst ≤ k := by apply le_of_lt; simp_all
   aesop
 
 private lemma filter_pairs_lt (k : ℕ) :

--- a/Mathlib/Topology/Algebra/IsUniformGroup/Basic.lean
+++ b/Mathlib/Topology/Algebra/IsUniformGroup/Basic.lean
@@ -382,7 +382,7 @@ theorem extend_Z_bilin : Continuous (extend (de.prodMap df) (fun p : β × δ =>
     intro U h
     rcases mem_closure_iff_nhds.1 ((de.prodMap df).dense (x₀, y₀)) U h with ⟨x, x_in, ⟨z, z_x⟩⟩
     exists z
-    aesop
+    simp_all
   · suffices map (fun p : (β × δ) × β × δ => (fun p : β × δ => φ p.1 p.2) p.2 -
       (fun p : β × δ => φ p.1 p.2) p.1)
         (comap (fun p : (β × δ) × β × δ => ((e p.1.1, f p.1.2), (e p.2.1, f p.2.2)))

--- a/Mathlib/Topology/Category/Profinite/Nobeling/Basic.lean
+++ b/Mathlib/Topology/Category/Profinite/Nobeling/Basic.lean
@@ -119,7 +119,7 @@ theorem proj_prop_eq_self (hh : ∀ i x, x ∈ C → x i ≠ false → J i) : π
 
 theorem proj_comp_of_subset (h : ∀ i, J i → K i) : (Proj J ∘ Proj K) =
     (Proj J : (I → Bool) → (I → Bool)) := by
-  ext x i; dsimp [Proj]; aesop
+  ext x i; dsimp [Proj]; simp_all
 
 theorem proj_eq_of_subset (h : ∀ i, J i → K i) : π (π C K) J = π C J := by
   ext x
@@ -156,13 +156,13 @@ theorem projRestricts_eq_comp (hJK : ∀ i, J i → K i) (hKL : ∀ i, K i → L
     ProjRestricts C hJK ∘ ProjRestricts C hKL = ProjRestricts C (fun i ↦ hKL i ∘ hJK i) := by
   ext x i
   simp only [π, Proj, Function.comp_apply, ProjRestricts_coe]
-  aesop
+  simp_all
 
 theorem projRestricts_comp_projRestrict (h : ∀ i, J i → K i) :
     ProjRestricts C h ∘ ProjRestrict C K = ProjRestrict C J := by
   ext x i
   simp only [π, Proj, Function.comp_apply, ProjRestricts_coe, ProjRestrict_coe]
-  aesop
+  simp_all
 
 variable (J)
 

--- a/Mathlib/Topology/Compactness/Compact.lean
+++ b/Mathlib/Topology/Compactness/Compact.lean
@@ -998,7 +998,7 @@ lemma IsCompact.sigma_exists_finite_sigma_eq {X : ι → Type*} [∀ i, Topologi
     simp only [Set.mem_sigma_iff, Finset.mem_coe, Set.mem_preimage, and_iff_right_iff_imp]
     intro hx
     obtain ⟨i, hi⟩ := Set.mem_iUnion.mp (hs hx)
-    aesop
+    simp_all
 
 /-- The coproduct of the cocompact filters on two topological spaces is the cocompact filter on
 their product. -/

--- a/Mathlib/Topology/GDelta/Basic.lean
+++ b/Mathlib/Topology/GDelta/Basic.lean
@@ -88,7 +88,7 @@ lemma isGδ_iff_eq_iInter_nat {s : Set X} :
     rcases Set.eq_empty_or_nonempty T with rfl | hT
     · exact ⟨fun _n ↦ univ, fun _n ↦ isOpen_univ, by simp⟩
     · obtain ⟨f, hf⟩ : ∃ (f : ℕ → Set X), T = range f := Countable.exists_eq_range T_count hT
-      exact ⟨f, by aesop, by simp [hf]⟩
+      exact ⟨f, by simp_all, by simp [hf]⟩
   · rintro ⟨f, hf, rfl⟩
     exact .iInter_of_isOpen hf
 

--- a/Mathlib/Topology/Order/IntermediateValue.lean
+++ b/Mathlib/Topology/Order/IntermediateValue.lean
@@ -642,7 +642,7 @@ theorem Continuous.strictMono_of_inj_boundedOrder [BoundedOrder α] {f : α → 
   by_cases ha : f a ≤ f ⊥
   · obtain ⟨u, hu⟩ := intermediate_value_Ioc le_top hf_c.continuousOn ⟨H.trans_le ha, hf⟩
     have : u = ⊥ := hf_i hu.2
-    aesop
+    simp_all
   · by_cases hb : f ⊥ < f b
     · obtain ⟨u, hu⟩ := intermediate_value_Ioo bot_le hf_c.continuousOn ⟨hb, H⟩
       rw [hf_i hu.2] at hu
@@ -651,7 +651,7 @@ theorem Continuous.strictMono_of_inj_boundedOrder [BoundedOrder α] {f : α → 
       replace hb : f b < f ⊥ := lt_of_le_of_ne hb <| hf_i.ne (lt_of_lt_of_le' hab bot_le).ne'
       obtain ⟨u, hu⟩ := intermediate_value_Ioo' hab.le hf_c.continuousOn ⟨hb, ha⟩
       have : u = ⊥ := hf_i hu.2
-      aesop
+      simp_all
 
 theorem Continuous.strictAnti_of_inj_boundedOrder [BoundedOrder α] {f : α → δ}
     (hf_c : Continuous f) (hf : f ⊤ ≤ f ⊥) (hf_i : Injective f) : StrictAnti f :=

--- a/Mathlib/Topology/Order/IsLUB.lean
+++ b/Mathlib/Topology/Order/IsLUB.lean
@@ -226,14 +226,14 @@ theorem Dense.exists_seq_strictMono_tendsto_of_lt [DenselyOrdered α] [FirstCoun
     exact ⟨z, mem_inter hzx hyz⟩
   have hx : IsLUB (Ioo y x ∩ s) x := hs.isLUB_inter_iff isOpen_Ioo |>.mpr <| isLUB_Ioo hy
   apply hx.exists_seq_strictMono_tendsto_of_notMem (by simp) hnonempty |>.imp
-  aesop
+  simp_all
 
 theorem Dense.exists_seq_strictMono_tendsto [DenselyOrdered α] [NoMinOrder α]
     [FirstCountableTopology α] {s : Set α} (hs : Dense s) (x : α) :
     ∃ u : ℕ → α, StrictMono u ∧ (∀ n, u n ∈ (Iio x ∩ s)) ∧ Tendsto u atTop (𝓝 x) := by
   obtain ⟨y, hy⟩ := exists_lt x
   apply hs.exists_seq_strictMono_tendsto_of_lt (exists_lt x).choose_spec |>.imp
-  aesop
+  simp_all
 
 theorem DenseRange.exists_seq_strictMono_tendsto_of_lt {β : Type*} [LinearOrder β]
     [DenselyOrdered α] [FirstCountableTopology α] {f : β → α} {x y : α} (hf : DenseRange f)

--- a/Mathlib/Topology/Order/LawsonTopology.lean
+++ b/Mathlib/Topology/Order/LawsonTopology.lean
@@ -208,7 +208,7 @@ lemma lawsonClosed_iff_dirSupClosed_of_isLowerSet (s : Set α) (h : IsLowerSet s
     IsClosed[L] s ↔ DirSupClosed s := by
   rw [lawsonClosed_iff_scottClosed_of_isLowerSet L S _ h,
     @IsScott.isClosed_iff_isLowerSet_and_dirSupClosed]
-  aesop
+  simp_all
 
 end Preorder
 

--- a/Mathlib/Topology/Separation/CompletelyRegular.lean
+++ b/Mathlib/Topology/Separation/CompletelyRegular.lean
@@ -213,7 +213,7 @@ lemma separatesPoints_continuous_of_t35Space [T35Space X] :
   intro x y x_ne_y
   obtain ⟨f, f_cont, f_zero, f_one⟩ :=
     CompletelyRegularSpace.completely_regular x {y} isClosed_singleton x_ne_y
-  exact ⟨fun x ↦ f x, continuous_subtype_val.comp f_cont, by aesop⟩
+  exact ⟨fun x ↦ f x, continuous_subtype_val.comp f_cont, by simp_all⟩
 
 @[deprecated (since := "2025-04-13")]
 alias separatesPoints_continuous_of_completelyRegularSpace := separatesPoints_continuous_of_t35Space
@@ -223,7 +223,7 @@ lemma separatesPoints_continuous_of_t35Space_Icc [T35Space X] :
   intro x y x_ne_y
   obtain ⟨f, f_cont, f_zero, f_one⟩ :=
     CompletelyRegularSpace.completely_regular x {y} isClosed_singleton x_ne_y
-  exact ⟨f, f_cont, by aesop⟩
+  exact ⟨f, f_cont, by simp_all⟩
 
 @[deprecated (since := "2025-04-13")]
 alias separatesPoints_continuous_of_completelyRegularSpace_Icc :=

--- a/Mathlib/Topology/Sets/CompactOpenCovered.lean
+++ b/Mathlib/Topology/Sets/CompactOpenCovered.lean
@@ -71,7 +71,7 @@ lemma iff_isCompactOpenCovered_sigmaMk :
       · simpa [h] using (V _ _).2
       · simp [h]
     · dsimp only
-      exact Set.isCompact_sigma hs fun i ↦ (by aesop)
+      exact Set.isCompact_sigma hs fun i ↦ (by simp_all)
     · aesop
   · obtain ⟨s, t, hs, hc, heq'⟩ := hc.sigma_exists_finite_sigma_eq
     have (i : ι) (hi : i ∈ s) : IsOpen (t i) := by
@@ -93,7 +93,7 @@ lemma of_iUnion_eq_of_finite (s : Set (Set S)) (hs : ⋃ t ∈ s, t = U) (hf : s
     have : Finite s := hf
     exact isCompact_iUnion (fun _ ↦ hVeq _ _)
   · simp [Set.image_iUnion, ← hs]
-    aesop
+    simp_all
 
 /-- If `U` is compact-open covered and the `X i` have a basis of compact opens,
 `U` can be written as the union of images of elements of the basis. -/

--- a/Mathlib/Topology/Spectral/Prespectral.lean
+++ b/Mathlib/Topology/Spectral/Prespectral.lean
@@ -37,7 +37,7 @@ This is the variant with an indexed basis instead. -/
 lemma PrespectralSpace.of_isTopologicalBasis' {ι : Type*} {b : ι → Set X}
     (basis : IsTopologicalBasis (Set.range b)) (isCompact_basis : ∀ i, IsCompact (b i)) :
     PrespectralSpace X :=
-  .of_isTopologicalBasis basis (by aesop)
+  .of_isTopologicalBasis basis (by simp_all)
 
 instance (priority := low) [NoetherianSpace X] : PrespectralSpace X :=
   .of_isTopologicalBasis isTopologicalBasis_opens fun _ _ ↦ NoetherianSpace.isCompact _


### PR DESCRIPTION
Motivation: `aesop` runs `simp_all` by default, so these ~160 `aesop` calls seem to be just `simp_all` in disguise. It seems better to use plain `simp_all` instead.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
