### PR TITLE
[Merged by Bors] - feat(Finset): `insert a (s \ {a}) = s` if `a ∈ s`

### DIFF
--- a/Mathlib/Data/Finset/SDiff.lean
+++ b/Mathlib/Data/Finset/SDiff.lean
@@ -170,6 +170,8 @@ theorem insert_sdiff_of_notMem (s : Finset α) {t : Finset α} {x : α} (h : x �
 
 theorem insert_sdiff_of_mem (s : Finset α) {x : α} (h : x ∈ t) : insert x s \ t = s \ t := by grind
 
+@[simp] lemma insert_sdiff_self_of_mem (ha : a ∈ s) : insert a (s \ {a}) = s := by grind
+
 @[simp] lemma insert_sdiff_cancel (ha : a ∉ s) : insert a s \ s = {a} := by grind
 
 @[simp]

--- a/Mathlib/Order/BooleanAlgebra/Set.lean
+++ b/Mathlib/Order/BooleanAlgebra/Set.lean
@@ -427,7 +427,7 @@ lemma insert_diff_self_of_notMem (h : a ∉ s) : insert a s \ {a} = s := by
 @[deprecated (since := "2025-05-23")]
 alias insert_diff_self_of_not_mem := insert_diff_self_of_notMem
 
-lemma insert_diff_self_of_mem (ha : a ∈ s) : insert a (s \ {a}) = s := by
+@[simp] lemma insert_diff_self_of_mem (ha : a ∈ s) : insert a (s \ {a}) = s := by
   ext; simp +contextual [or_and_left, em, ha]
 
 lemma insert_diff_subset : insert a s \ t ⊆ insert a (s \ t) := by


### PR DESCRIPTION
This follows the existing `Set` lemma (and that one is made simp too).

From MiscYD


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
