### PR TITLE
[Merged by Bors] - feat: torsion-free modules

### DIFF
--- a/Mathlib/Algebra/Module/Torsion.lean
+++ b/Mathlib/Algebra/Module/Torsion.lean
@@ -5,6 +5,7 @@ Authors: Pierre-Alexandre Bazin
 -/
 import Mathlib.Algebra.DirectSum.Module
 import Mathlib.Algebra.Module.ZMod
+import Mathlib.Algebra.Regular.Opposite
 import Mathlib.GroupTheory.Torsion
 import Mathlib.LinearAlgebra.Isomorphisms
 import Mathlib.RingTheory.Coprime.Ideal
@@ -84,8 +85,11 @@ TODO: Prove it. -/
 class IsTorsionFree where
   isSMulRegular ⦃r : R⦄ : IsRegular r → IsSMulRegular M r
 
+instance : IsTorsionFree R R where isSMulRegular _r hr := hr.1
+instance : IsTorsionFree Rᵐᵒᵖ R where isSMulRegular _r hr := hr.unop.2
+
 instance [IsAddTorsionFree M] : IsTorsionFree ℕ M where
-  isSMulRegular {n} hn := nsmul_right_injective (by simpa [isRegular_iff_ne_zero] using hn)
+  isSMulRegular n hn := nsmul_right_injective (by simpa [isRegular_iff_ne_zero] using hn)
 
 end AddCommMonoid
 
@@ -93,7 +97,7 @@ section AddCommGroup
 variable [AddCommGroup M]
 
 instance [IsAddTorsionFree M] : IsTorsionFree ℤ M where
-  isSMulRegular {n} hn := zsmul_right_injective (by simpa [isRegular_iff_ne_zero] using hn)
+  isSMulRegular n hn := zsmul_right_injective (by simpa [isRegular_iff_ne_zero] using hn)
 
 end AddCommGroup
 end Module

--- a/Mathlib/Algebra/Module/Torsion.lean
+++ b/Mathlib/Algebra/Module/Torsion.lean
@@ -42,7 +42,7 @@ import Mathlib.RingTheory.SimpleModule.Basic
   Similar lemmas for `torsion'` and `torsion`.
 * `Submodule.torsionBy_isInternal` : a `∏ i, p i`-torsion module is the internal direct sum of its
   `p i`-torsion submodules when the `p i` are pairwise coprime. A more general version with coprime
-  ideals is `Submodule.torsionBySet_is_internal`.
+  ideals is `Submodule.torsionBySet_isInternal`.
 * `Submodule.noZeroSMulDivisors_iff_torsion_bot` : a module over a domain has
   `NoZeroSMulDivisors` (that is, there is no non-zero `a`, `x` such that `a • x = 0`)
   iff its torsion submodule is trivial.
@@ -57,10 +57,48 @@ import Mathlib.RingTheory.SimpleModule.Basic
 * The letters `a`, `b`, ... are used for scalars (in `R`), while `x`, `y`, ... are used for vectors
   (in `M`).
 
+## TODO
+
+* Move the advanced material to a new file `RingTheory.Torsion`.
+* Replace `NoZeroSMulDivisors` with `Module.IsTorsionFree`
+
 ## Tags
 
 Torsion, submodule, module, quotient
 -/
+
+/-! ### Torsion-free modules -/
+
+namespace Module
+variable {R M : Type*} [Semiring R]
+
+section AddCommMonoid
+variable [AddCommMonoid M] [Module R M]
+
+variable (R M) in
+/-- A `R`-module `M` is torsion-free if scalar multiplication by an element `r : R` is injective if
+multiplication (on `R`) by `r` is.
+
+For domains, this is equivalent to the usual condition of `r • m = 0 → r = 0 ∨ m = 0`.
+TODO: Prove it. -/
+class IsTorsionFree where
+  isSMulRegular ⦃r : R⦄ : IsRegular r → IsSMulRegular M r
+
+instance [IsAddTorsionFree M] : IsTorsionFree ℕ M where
+  isSMulRegular {n} hn := nsmul_right_injective (by simpa [isRegular_iff_ne_zero] using hn)
+
+end AddCommMonoid
+
+section AddCommGroup
+variable [AddCommGroup M]
+
+instance [IsAddTorsionFree M] : IsTorsionFree ℤ M where
+  isSMulRegular {n} hn := zsmul_right_injective (by simpa [isRegular_iff_ne_zero] using hn)
+
+end AddCommGroup
+end Module
+
+/-! ### Torsion -/
 
 namespace Ideal
 


### PR DESCRIPTION
Provide some very minimal API for torsion-free modules. This is mostly to agree on the definition. We can't add much further API before refactoring `Algebra.Module.Torsion` to have imports as light as `NoZeroSMulDivisors` and making `Module.IsTorsion` a class.

From ClassFieldTheory


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
