### PR TITLE
[Merged by Bors] - chore: add `simp` attribute to `abs_mul`

### DIFF
--- a/Mathlib/Algebra/Order/Ring/Abs.lean
+++ b/Mathlib/Algebra/Order/Ring/Abs.lean
@@ -41,6 +41,7 @@ variable [Ring α] [LinearOrder α] [IsStrictOrderedRing α] {n : ℕ} {a b : α
 
 lemma abs_two : |(2 : α)| = 2 := abs_of_pos zero_lt_two
 
+@[simp]
 lemma abs_mul (a b : α) : |a * b| = |a| * |b| := by
   rw [abs_eq (mul_nonneg (abs_nonneg a) (abs_nonneg b))]
   rcases le_total a 0 with ha | ha <;> rcases le_total b 0 with hb | hb <;>

--- a/Mathlib/Algebra/Order/Ring/Abs.lean
+++ b/Mathlib/Algebra/Order/Ring/Abs.lean
@@ -72,8 +72,7 @@ omit [IsStrictOrderedRing α] in
 @[simp] lemma abs_mul_abs_self (a : α) : |a| * |a| = a * a :=
   abs_by_cases (fun x => x * x = a * a) rfl (neg_mul_neg a a)
 
-@[simp]
-lemma abs_mul_self (a : α) : |a * a| = a * a := by rw [abs_mul, abs_mul_abs_self]
+lemma abs_mul_self (a : α) : |a * a| = a * a := by simp
 
 lemma abs_eq_iff_mul_self_eq : |a| = |b| ↔ a * a = b * b := by
   rw [← abs_mul_abs_self, ← abs_mul_abs_self b]

--- a/Mathlib/NumberTheory/Ostrowski.lean
+++ b/Mathlib/NumberTheory/Ostrowski.lean
@@ -267,7 +267,7 @@ Every unbounded absolute value on `ℚ` is equivalent to the standard absolute v
 unique real place of `ℚ`. -/
 def real : AbsoluteValue ℚ ℝ where
   toFun x := |x|
-  map_mul' x y := by simpa using abs_mul (x : ℝ) (y : ℝ)
+  map_mul' x y := by simp
   nonneg' x := by simp
   eq_zero' x := by simp
   add_le' x y := by simpa using abs_add_le (x : ℝ) (y : ℝ)


### PR DESCRIPTION
See [Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/abs_mul.20simp).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
