### PR TITLE
feat: `abs_natCast`

### DIFF
--- a/Mathlib/Data/Nat/Cast/Order/Ring.lean
+++ b/Mathlib/Data/Nat/Cast/Order/Ring.lean
@@ -22,9 +22,6 @@ section OrderedSemiring
 we use a generic collection of instances so that it applies in other settings (e.g., in a
 `StarOrderedRing`, or the `selfAdjoint` or `StarOrderedRing.positive` parts thereof). -/
 
-variable [AddMonoidWithOne α] [PartialOrder α]
-variable [AddLeftMono α] [ZeroLEOneClass α]
-
 /-- Specialisation of `Nat.cast_nonneg'`, which seems to be easier for Lean to use. -/
 @[simp]
 theorem cast_nonneg {α} [Semiring α] [PartialOrder α] [IsOrderedRing α] (n : ℕ) : 0 ≤ (n : α) :=
@@ -46,9 +43,11 @@ theorem cast_max {α} [Semiring α] [LinearOrder α] [IsStrictOrderedRing α] (m
     (↑(max m n : ℕ) : α) = max (m : α) n :=
   (@mono_cast α _).map_max
 
-section Nontrivial
+@[simp, norm_cast]
+theorem abs_natCast {α} [Ring α] [Lattice α] [IsOrderedRing α] (n : ℕ) : |(n : α)| = n :=
+  abs_of_nonneg n.cast_nonneg'
 
-variable [NeZero (1 : α)]
+section Nontrivial
 
 /-- Specialisation of `Nat.cast_pos'`, which seems to be easier for Lean to use. -/
 @[simp]
@@ -57,7 +56,8 @@ theorem cast_pos {α} [Semiring α] [PartialOrder α] [IsOrderedRing α] [Nontri
 
 /-- See also `Nat.ofNat_pos`, specialised for an `OrderedSemiring`. -/
 @[simp low]
-theorem ofNat_pos' {n : ℕ} [n.AtLeastTwo] : 0 < (ofNat(n) : α) :=
+theorem ofNat_pos' [AddMonoidWithOne α] [PartialOrder α] [AddLeftMono α] [ZeroLEOneClass α]
+    [NeZero (1 : α)] {n : ℕ} [n.AtLeastTwo] : 0 < (ofNat(n) : α) :=
   cast_pos'.mpr (NeZero.pos n)
 
 /-- Specialisation of `Nat.ofNat_pos'`, which seems to be easier for Lean to use. -/


### PR DESCRIPTION
We don't remove the existing [`Int.abs_natCast`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Order/Group/Unbundled/Int.html#Int.abs_natCast), as it has less imports.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

I also got rid of some `variable` blocks, which were being used for a grand total of a single theorem.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
