### PR TITLE
[Merged by Bors] - feat(Topology/Homotopy/Path): Add IsEquiv instance for Path.Homotopic

### DIFF
--- a/Mathlib/Topology/Homotopy/Path.lean
+++ b/Mathlib/Topology/Homotopy/Path.lean
@@ -247,6 +247,11 @@ theorem trans ⦃p₀ p₁ p₂ : Path x₀ x₁⦄ (h₀ : p₀.Homotopic p₁)
 theorem equivalence : Equivalence (@Homotopic X _ x₀ x₁) :=
   ⟨refl, (symm ·), (trans · ·)⟩
 
+instance : IsEquiv (Path x₀ x₁) Homotopic where
+  refl := refl
+  symm := symm
+  trans := trans
+
 nonrec theorem map {p q : Path x₀ x₁} (h : p.Homotopic q) (f : C(X, Y)) :
     Homotopic (p.map f.continuous) (q.map f.continuous) :=
   h.map fun F => F.map f


### PR DESCRIPTION
Add `instance : IsEquiv (Path x₀ x₁) Homotopic` to the library. Allow use of lemmas like `of_eq` when proving two paths are homotopic.

---
To provide additional context, I am relatively new to contributing to Mathlib, and I am doing so as a part of the Fields Undergraduate Summer Research Program hosted at the University of Western Ontario and supervised by Chris Kapulkin and Daniel Carranza. My goal is to prove that the `n`-sphere is simply connected for `n > 1`.

Also, I am not super familiar with `IsEquiv` and when it should/shouldn't be used. I just wanted to use a lemma like `Path.Homotopic.of_eq` at one point while working on my code, and thought this was the best way to add such a result to the library.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
