### PR TITLE
feat(Topology): add instance for PreconnectedSpace.infinite

### DIFF
--- a/Mathlib/Topology/Separation/Connected.lean
+++ b/Mathlib/Topology/Separation/Connected.lean
@@ -39,6 +39,8 @@ theorem IsPreconnected.infinite_of_nontrivial [T1Space X] {s : Set X} (h : IsPre
 theorem PreconnectedSpace.infinite [PreconnectedSpace X] [Nontrivial X] [T1Space X] : Infinite X :=
   infinite_univ_iff.mp <| isPreconnected_univ.infinite_of_nontrivial nontrivial_univ
 
+instance [PreconnectedSpace X] [Nontrivial X] [T1Space X] : Infinite X := PreconnectedSpace.infinite
+
 @[deprecated (since := "2025-03-21")]
 alias ConnectedSpace.infinite := PreconnectedSpace.infinite
 
@@ -51,4 +53,3 @@ instance (priority := 100) ConnectedSpace.neBot_nhdsWithin_compl_of_nontrivial_o
   replace contra := nonempty_inter isOpen_compl_singleton
     contra (compl_union_self _) (Set.nonempty_compl_of_nontrivial _) (singleton_nonempty _)
   simp [compl_inter_self {x}] at contra
-


### PR DESCRIPTION
Add `instance {X : Type*} [TopologicalSpace X] [PreconnectedSpace X] [Nontrivial X] [T1Space X] : Infinite X := PreconnectedSpace.infinite` to the library. Allows inference of the fact that, for example, nontrivial Euclidean space is infinite.

---
To provide additional context, I am relatively new to contributing to Mathlib, and I am doing so as a part of the Fields Undergraduate Summer Research Program hosted at the University of Western Ontario and supervised by Chris Kapulkin and Daniel Carranza. My goal is to prove that the `n`-sphere is simply connected for `n > 1`.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
