### PR TITLE
feat(Logic): tag Injective, Surjective, and Bijective with fun_prop

### DIFF
--- a/Mathlib/Tactic/FunProp.lean
+++ b/Mathlib/Tactic/FunProp.lean
@@ -342,3 +342,19 @@ There are four types of theorems that are used a bit differently.
     is used together with `aesop` to discharge the `2 ≤ ∞` subgoal.
 
 -/
+
+namespace Function
+
+/-! # Injectivity -/
+
+attribute [fun_prop] Injective injective_id Injective.comp
+
+/-! # Surjectivity -/
+
+attribute [fun_prop] Surjective surjective_id Surjective.comp
+
+/-! # Bijectivity -/
+
+attribute [fun_prop] Bijective bijective_id Bijective.comp Bijective.injective Bijective.surjective
+
+end Function


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Zulip:
* [#Is there code for X? > surjective is not funprop!](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/surjective.20is.20not.20funprop!)
* [#mathlib4 > &#96;fun_prop&#96; for Injective/Surjective/Bijective?](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/.60fun_prop.60.20for.20Injective.2FSurjective.2FBijective.3F)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
