### PR TITLE
[Merged by Bors] - feat(Order): add {WithTop,WithBot}.subtypeOrderIso

### DIFF
--- a/Mathlib/Order/Hom/WithTopBot.lean
+++ b/Mathlib/Order/Hom/WithTopBot.lean
@@ -63,6 +63,34 @@ def coeOrderHom {α : Type*} [Preorder α] : α ↪o WithTop α where
   inj' := WithTop.coe_injective
   map_rel_iff' := WithTop.coe_le_coe
 
+/-- Removing then adding ⊤ makes the type `OrderIso` to the original type. -/
+def subtypeOrderIso [DecidableEq α] [PartialOrder α] [OrderTop α] :
+    WithTop {a : α // a ≠ ⊤} ≃o α where
+  toFun
+  | .some a => a
+  | ⊤ => ⊤
+  invFun a := if h : a = ⊤ then ⊤ else .some ⟨a, h⟩
+  left_inv
+  | .some A => by simpa using A.prop
+  | ⊤ => by simp
+  right_inv A := by simp only; split_ifs with h <;> simp [*]
+  map_rel_iff' {a b} := match a, b with
+  | .some a, .some b => by simp
+  | .some a, ⊤ => by simp
+  | ⊤, .some b => by simpa using b.prop
+  | ⊤, ⊤ => by simp
+
+@[simp]
+theorem subtypeOrderIso_apply_coe [DecidableEq α] [PartialOrder α] [OrderTop α]
+    (a : {a : α // a ≠ ⊤}) :
+  subtypeOrderIso (a : WithTop {a : α // a ≠ ⊤}) = a := rfl
+
+theorem subtypeOrderIso_symm_apply [DecidableEq α] [PartialOrder α] [OrderTop α]
+    {a : α} (h : a ≠ ⊤) :
+    (subtypeOrderIso).symm a = (⟨a, h⟩ : {a : α // a ≠ ⊤}) := by
+  rw [OrderIso.symm_apply_eq]
+  rfl
+
 end WithTop
 
 namespace WithBot
@@ -108,6 +136,21 @@ def coeOrderHom {α : Type*} [Preorder α] : α ↪o WithBot α where
   toFun := (↑)
   inj' := WithBot.coe_injective
   map_rel_iff' := WithBot.coe_le_coe
+
+/-- Removing then adding ⊥ makes the type `OrderIso` to the original type. -/
+def subtypeOrderIso [DecidableEq α] [PartialOrder α] [OrderBot α] :
+    WithBot {a : α // a ≠ ⊥} ≃o α := (WithTop.subtypeOrderIso (α := αᵒᵈ)).dual
+
+@[simp]
+theorem subtypeOrderIso_apply_coe [DecidableEq α] [PartialOrder α] [OrderBot α]
+    (a : {a : α // a ≠ ⊥}) :
+  subtypeOrderIso (a : WithTop {a : α // a ≠ ⊥}) = a := rfl
+
+theorem subtypeOrderIso_symm_apply [DecidableEq α] [PartialOrder α] [OrderBot α]
+    {a : α} (h : a ≠ ⊥) :
+    (subtypeOrderIso).symm a = (⟨a, h⟩ : {a : α // a ≠ ⊥}) := by
+  rw [OrderIso.symm_apply_eq]
+  rfl
 
 end WithBot
 

--- a/Mathlib/Order/Hom/WithTopBot.lean
+++ b/Mathlib/Order/Hom/WithTopBot.lean
@@ -63,7 +63,9 @@ def coeOrderHom {α : Type*} [Preorder α] : α ↪o WithTop α where
   inj' := WithTop.coe_injective
   map_rel_iff' := WithTop.coe_le_coe
 
-/-- Removing then adding ⊤ makes the type `OrderIso` to the original type. -/
+/-- Any `OrderTop` is equivalent to `WithTop` of the subtype excluding `⊤`.
+
+See also `Equiv.optionSubtypeNe`. -/
 def subtypeOrderIso [PartialOrder α] [OrderTop α] [DecidablePred (· = (⊤ : α))] :
     WithTop {a : α // a ≠ ⊤} ≃o α where
   toFun a := (a.map (↑)).untopD ⊤
@@ -134,7 +136,9 @@ def coeOrderHom {α : Type*} [Preorder α] : α ↪o WithBot α where
   inj' := WithBot.coe_injective
   map_rel_iff' := WithBot.coe_le_coe
 
-/-- Removing then adding ⊥ makes the type `OrderIso` to the original type. -/
+/-- Any `OrderBot` is equivalent to `WithBot` of the subtype excluding `⊥`.
+
+See also `Equiv.optionSubtypeNe`. -/
 def subtypeOrderIso [PartialOrder α] [OrderBot α] [DecidablePred (· = (⊥ : α))] :
     WithBot {a : α // a ≠ ⊥} ≃o α := (WithTop.subtypeOrderIso (α := αᵒᵈ)).dual
 

--- a/Mathlib/Order/Hom/WithTopBot.lean
+++ b/Mathlib/Order/Hom/WithTopBot.lean
@@ -64,28 +64,25 @@ def coeOrderHom {α : Type*} [Preorder α] : α ↪o WithTop α where
   map_rel_iff' := WithTop.coe_le_coe
 
 /-- Removing then adding ⊤ makes the type `OrderIso` to the original type. -/
-def subtypeOrderIso [DecidableEq α] [PartialOrder α] [OrderTop α] :
+def subtypeOrderIso [PartialOrder α] [OrderTop α] [DecidablePred (· = (⊤ : α))] :
     WithTop {a : α // a ≠ ⊤} ≃o α where
-  toFun
-  | .some a => a
-  | ⊤ => ⊤
+  toFun a := (a.map (↑)).untopD ⊤
   invFun a := if h : a = ⊤ then ⊤ else .some ⟨a, h⟩
   left_inv
-  | .some A => by simpa using A.prop
+  | .some ⟨a, h⟩ => by simp [h]
   | ⊤ => by simp
-  right_inv A := by simp only; split_ifs with h <;> simp [*]
+  right_inv a := by dsimp only; split_ifs <;> simp [*]
   map_rel_iff' {a b} := match a, b with
   | .some a, .some b => by simp
-  | .some a, ⊤ => by simp
-  | ⊤, .some b => by simpa using b.prop
-  | ⊤, ⊤ => by simp
+  | ⊤, .some ⟨b, h⟩ => by simp [h]
+  | a, ⊤ => by simp
 
 @[simp]
-theorem subtypeOrderIso_apply_coe [DecidableEq α] [PartialOrder α] [OrderTop α]
+theorem subtypeOrderIso_apply_coe [PartialOrder α] [OrderTop α] [DecidablePred (· = (⊤ : α))]
     (a : {a : α // a ≠ ⊤}) :
   subtypeOrderIso (a : WithTop {a : α // a ≠ ⊤}) = a := rfl
 
-theorem subtypeOrderIso_symm_apply [DecidableEq α] [PartialOrder α] [OrderTop α]
+theorem subtypeOrderIso_symm_apply [PartialOrder α] [OrderTop α] [DecidablePred (· = (⊤ : α))]
     {a : α} (h : a ≠ ⊤) :
     (subtypeOrderIso).symm a = (⟨a, h⟩ : {a : α // a ≠ ⊤}) := by
   rw [OrderIso.symm_apply_eq]
@@ -138,15 +135,15 @@ def coeOrderHom {α : Type*} [Preorder α] : α ↪o WithBot α where
   map_rel_iff' := WithBot.coe_le_coe
 
 /-- Removing then adding ⊥ makes the type `OrderIso` to the original type. -/
-def subtypeOrderIso [DecidableEq α] [PartialOrder α] [OrderBot α] :
+def subtypeOrderIso [PartialOrder α] [OrderBot α] [DecidablePred (· = (⊥ : α))] :
     WithBot {a : α // a ≠ ⊥} ≃o α := (WithTop.subtypeOrderIso (α := αᵒᵈ)).dual
 
 @[simp]
-theorem subtypeOrderIso_apply_coe [DecidableEq α] [PartialOrder α] [OrderBot α]
+theorem subtypeOrderIso_apply_coe [PartialOrder α] [OrderBot α] [DecidablePred (· = (⊥ : α))]
     (a : {a : α // a ≠ ⊥}) :
   subtypeOrderIso (a : WithTop {a : α // a ≠ ⊥}) = a := rfl
 
-theorem subtypeOrderIso_symm_apply [DecidableEq α] [PartialOrder α] [OrderBot α]
+theorem subtypeOrderIso_symm_apply [PartialOrder α] [OrderBot α] [DecidablePred (· = (⊥ : α))]
     {a : α} (h : a ≠ ⊥) :
     (subtypeOrderIso).symm a = (⟨a, h⟩ : {a : α // a ≠ ⊥}) := by
   rw [OrderIso.symm_apply_eq]


### PR DESCRIPTION
Separated from #25970

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
