### PR TITLE
[Merged by Bors] - chore: fix `rw[…]`/`simp[…]` whitespace typos (`rw […]`/`simp […]` expected)

### DIFF
--- a/Mathlib/Analysis/Complex/Hadamard.lean
+++ b/Mathlib/Analysis/Complex/Hadamard.lean
@@ -374,7 +374,7 @@ lemma sSupNormIm_scale_left (f : ℂ → E) {l u : ℝ} (hul : l < u) :
       constructor
       · norm_cast
         rw [Complex.div_re, Complex.normSq_ofReal, Complex.ofReal_re]
-        simp[hz₁]
+        simp [hz₁]
       · rw [div_mul_comm, div_self (by norm_cast; linarith)]
         simp [hz₂]
   rw [this]
@@ -571,7 +571,7 @@ lemma mem_verticalClosedStrip_of_scale_id_mem_verticalClosedStrip {z : ℂ} {l u
     · apply le_of_lt; simp [hul]
     · exact hz.1
   · rw [← sub_le_sub_iff_right (l / (u - l)), add_sub_assoc, sub_self, add_zero, div_sub_div_same,
-      div_le_one (by simp[hul]), sub_le_sub_iff_right l]
+      div_le_one (by simp [hul]), sub_le_sub_iff_right l]
     exact hz.2
 
 /-- The function `scale f l u` is `diffContOnCl`. -/

--- a/Mathlib/Combinatorics/Quiver/Path/Decomposition.lean
+++ b/Mathlib/Combinatorics/Quiver/Path/Decomposition.lean
@@ -28,7 +28,7 @@ theorem exists_notMem_mem_hom_path_path_of_notMem_mem {a b : V} (p : Path a b) (
   induction' h_len : p.length with n ih generalizing a b S ha_not_in_S hb_in_S
   · obtain rfl := eq_of_length_zero p h_len
     exact (ha_not_in_S hb_in_S).elim
-  · have h_pos : 0 < p.length := by rw[h_len]; simp only [lt_add_iff_pos_left, add_pos_iff,
+  · have h_pos : 0 < p.length := by rw [h_len]; simp only [lt_add_iff_pos_left, add_pos_iff,
       Nat.lt_one_iff, pos_of_gt, or_true]
     have h_ne : p.length ≠ 0 := ne_of_gt h_pos
     obtain ⟨c, p', e, rfl⟩ := (length_ne_zero_iff_eq_cons p).mp h_ne

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -1015,7 +1015,7 @@ theorem filterMap_eq_map_iff_forall_eq_some {f : α → Option β} {g : α → �
     induction l with | nil => simp | cons a l ih => ?_
     rcases ha : f a with - | b <;> simp [ha]
     · intro h
-      simpa [show (filterMap f l).length = l.length + 1 from by simp[h], Nat.add_one_le_iff]
+      simpa [show (filterMap f l).length = l.length + 1 from by simp [h], Nat.add_one_le_iff]
         using List.length_filterMap_le f l
     · rintro rfl h
       exact ⟨rfl, ih h⟩

--- a/Mathlib/Data/Matrix/Basis.lean
+++ b/Mathlib/Data/Matrix/Basis.lean
@@ -84,7 +84,7 @@ lemma map_single (i : m) (j : n) (a : α) {β : Type*} [Zero β]
 theorem single_mem_matrix {S : Set α} (hS : 0 ∈ S) {i : m} {j : n} {a : α} :
     Matrix.single i j a ∈ S.matrix ↔ a ∈ S := by
   simp only [Set.mem_matrix, single, of_apply]
-  conv_lhs => intro _ _; rw[ite_mem]
+  conv_lhs => intro _ _; rw [ite_mem]
   simp [hS]
 
 end Zero

--- a/Mathlib/Data/UInt.lean
+++ b/Mathlib/Data/UInt.lean
@@ -75,7 +75,7 @@ run_cmd
         change (z * a).toBitVec = BitVec.ofInt _ z * a.toBitVec
         rw [toBitVec_mul]
         congr 1
-        rw[toBitVec_intCast]
+        rw [toBitVec_intCast]
         rfl
 
     end $typeName

--- a/Mathlib/GroupTheory/Coxeter/Inversion.lean
+++ b/Mathlib/GroupTheory/Coxeter/Inversion.lean
@@ -262,7 +262,7 @@ theorem getD_rightInvSeq (ω : List B) (j : ℕ) :
       simp [ih j']
 
 lemma getElem_rightInvSeq (ω : List B) (j : ℕ) (h : j < ω.length) :
-    (ris ω)[j]'(by simp[h]) =
+    (ris ω)[j]'(by simp [h]) =
     (π (ω.drop (j + 1)))⁻¹
       * (Option.map (cs.simple) ω[j]?).getD 1
       * π (ω.drop (j + 1)) := by
@@ -286,7 +286,7 @@ theorem getD_leftInvSeq (ω : List B) (j : ℕ) :
       simp [← mul_assoc, wordProd_cons]
 
 lemma getElem_leftInvSeq (ω : List B) (j : ℕ) (h : j < ω.length) :
-    (lis ω)[j]'(by simp[h]) =
+    (lis ω)[j]'(by simp [h]) =
     cs.wordProd (List.take j ω) * s ω[j] * (cs.wordProd (List.take j ω))⁻¹ := by
   rw [← List.getD_eq_getElem (lis ω) 1, getD_leftInvSeq]
   simp [h]
@@ -453,8 +453,8 @@ lemma getElem_succ_leftInvSeq_alternatingWord
     (i j : B) (p k : ℕ) (h : k + 1 < 2 * p) :
     (lis (alternatingWord i j (2 * p)))[k + 1]'(by simpa using h) =
     MulAut.conj (s i) ((lis (alternatingWord j i (2 * p)))[k]'(by simp; omega)) := by
-  rw [cs.getElem_leftInvSeq (alternatingWord i j (2 * p)) (k + 1) (by simp[h]),
-    cs.getElem_leftInvSeq (alternatingWord j i (2 * p)) k (by simp[]; omega)]
+  rw [cs.getElem_leftInvSeq (alternatingWord i j (2 * p)) (k + 1) (by simp [h]),
+    cs.getElem_leftInvSeq (alternatingWord j i (2 * p)) k (by simp; omega)]
   simp only [MulAut.conj, listTake_succ_alternatingWord i j p k h, cs.wordProd_cons, mul_assoc,
     mul_inv_rev, inv_simple, MonoidHom.coe_mk, OneHom.coe_mk, MulEquiv.coe_mk, Equiv.coe_fn_mk,
     mul_right_inj, mul_left_inj]

--- a/Mathlib/LinearAlgebra/Basis/VectorSpace.lean
+++ b/Mathlib/LinearAlgebra/Basis/VectorSpace.lean
@@ -248,7 +248,7 @@ theorem LinearMap.exists_leftInverse_of_injective (f : V →ₗ[K] V') (hf_inj :
   have fb_eq : f b = hC ⟨f b, BC b.2⟩ := by
     change f b = Basis.extend this _
     simp_rw [Basis.extend_apply_self]
-  dsimp []
+  dsimp
   rw [Basis.ofVectorSpace_apply_self, fb_eq, hC.constr_basis]
   exact leftInverse_invFun (LinearMap.ker_eq_bot.1 hf_inj) _
 

--- a/Mathlib/MeasureTheory/Measure/Prod.lean
+++ b/Mathlib/MeasureTheory/Measure/Prod.lean
@@ -809,7 +809,7 @@ protected theorem prodMap {ω : Type*} {mω : MeasurableSpace ω} {υ : Measure 
     (hf : QuasiMeasurePreserving f μ ν) (hg : QuasiMeasurePreserving g τ υ) :
     QuasiMeasurePreserving (Prod.map f g) (μ.prod τ) (ν.prod υ) := by
   refine ⟨by fun_prop, ?_⟩
-  rw[← map_prod_map _ _ (by fun_prop) (by fun_prop)]
+  rw [← map_prod_map _ _ (by fun_prop) (by fun_prop)]
   exact hf.absolutelyContinuous.prod hg.absolutelyContinuous
 
 end QuasiMeasurePreserving

--- a/Mathlib/MeasureTheory/Measure/WithDensity.lean
+++ b/Mathlib/MeasureTheory/Measure/WithDensity.lean
@@ -734,7 +734,7 @@ theorem mconv_withDensity_eq_mlconvolution₀ {f g : G → ℝ≥0∞}
     lintegral_congr (fun x ↦ by apply (lintegral_mul_left_eq_self _ x⁻¹).symm),
     lintegral_lintegral_swap]
   · simp only [Pi.mul_apply, mul_inv_cancel_left, mlconvolution_def]
-    conv in (∫⁻ _ , _ ∂μ) * φ _ => rw[(lintegral_mul_const'' _ (by fun_prop)).symm]
+    conv in (∫⁻ _ , _ ∂μ) * φ _ => rw [(lintegral_mul_const'' _ (by fun_prop)).symm]
   all_goals first | fun_prop | simp; fun_prop
 
 @[to_additive]


### PR DESCRIPTION
Motivation: Consistent spacing makes ad-hoc searches (say using `grep`) easier.