### PR TITLE
[Merged by Bors] - golf(Analysis/Calculus): golf entire `LineDifferentiableAt.congr_of_eventuallyEq`

### DIFF
--- a/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
@@ -362,11 +362,8 @@ theorem LineDifferentiableWithinAt.congr_of_eventuallyEq (h : LineDifferentiable
 
 theorem LineDifferentiableAt.congr_of_eventuallyEq
     (h : LineDifferentiableAt 𝕜 f x v) (hL : f₁ =ᶠ[𝓝 x] f) :
-    LineDifferentiableAt 𝕜 f₁ x v := by
-  apply DifferentiableAt.congr_of_eventuallyEq h
-  let F := fun (t : 𝕜) ↦ x + t • v
-  rw [show x = F 0 by simp [F]] at hL
-  exact (Continuous.continuousAt (by fun_prop)).preimage_mem_nhds hL
+    LineDifferentiableAt 𝕜 f₁ x v :=
+  (EventuallyEq.lineDifferentiableAt_iff (id (EventuallyEq.symm hL))).mp h
 
 theorem Filter.EventuallyEq.lineDerivWithin_eq (hs : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) :
     lineDerivWithin 𝕜 f₁ s x v = lineDerivWithin 𝕜 f s x v := by

--- a/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
@@ -363,7 +363,7 @@ theorem LineDifferentiableWithinAt.congr_of_eventuallyEq (h : LineDifferentiable
 theorem LineDifferentiableAt.congr_of_eventuallyEq
     (h : LineDifferentiableAt 𝕜 f x v) (hL : f₁ =ᶠ[𝓝 x] f) :
     LineDifferentiableAt 𝕜 f₁ x v :=
-  (EventuallyEq.lineDifferentiableAt_iff (id (EventuallyEq.symm hL))).mp h
+  (EventuallyEq.lineDifferentiableAt_iff (EventuallyEq.symm hL)).mp h
 
 theorem Filter.EventuallyEq.lineDerivWithin_eq (hs : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) :
     lineDerivWithin 𝕜 f₁ s x v = lineDerivWithin 𝕜 f s x v := by

--- a/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
@@ -363,7 +363,7 @@ theorem LineDifferentiableWithinAt.congr_of_eventuallyEq (h : LineDifferentiable
 theorem LineDifferentiableAt.congr_of_eventuallyEq
     (h : LineDifferentiableAt 𝕜 f x v) (hL : f₁ =ᶠ[𝓝 x] f) :
     LineDifferentiableAt 𝕜 f₁ x v :=
-  (EventuallyEq.lineDifferentiableAt_iff (EventuallyEq.symm hL)).mp h
+  hL.symm.lineDifferentiableAt_iff.mp h
 
 theorem Filter.EventuallyEq.lineDerivWithin_eq (hs : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) :
     lineDerivWithin 𝕜 f₁ s x v = lineDerivWithin 𝕜 f s x v := by


### PR DESCRIPTION
Motivation: Avoid (partial) proof duplication.

---
<details>
<summary>Show trace profiling of <code>LineDifferentiableAt.congr_of_eventuallyEq</code>: 183 ms before, 13 ms after  🎉</summary>

### Trace profiling of `LineDifferentiableAt.congr_of_eventuallyEq` before PR 28203
```diff
diff --git a/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean b/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
index 97ba668da2..9061abccb9 100644
--- a/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
@@ -360,6 +360,7 @@ theorem LineDifferentiableWithinAt.congr_of_eventuallyEq (h : LineDifferentiable
     (h₁ : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) : LineDifferentiableWithinAt 𝕜 f₁ s x v :=
   (h.hasLineDerivWithinAt.congr_of_eventuallyEq h₁ hx).differentiableWithinAt
 
+set_option trace.profiler true in
 theorem LineDifferentiableAt.congr_of_eventuallyEq
     (h : LineDifferentiableAt 𝕜 f x v) (hL : f₁ =ᶠ[𝓝 x] f) :
     LineDifferentiableAt 𝕜 f₁ x v := by
```
```
ℹ [1850/1850] Built Mathlib.Analysis.Calculus.LineDeriv.Basic (7.1s)
info: Mathlib/Analysis/Calculus/LineDeriv/Basic.lean:364:0: [Elab.command] [0.068664] theorem congr_of_eventuallyEq (h : LineDifferentiableAt 𝕜 f x v) (hL : f₁ =ᶠ[𝓝 x] f) :
        LineDifferentiableAt 𝕜 f₁ x v :=
      by
      apply DifferentiableAt.congr_of_eventuallyEq h
      let F := fun (t : 𝕜) ↦ x + t • v
      rw [show x = F 0 by simp [F]] at hL
      exact (Continuous.continuousAt (by fun_prop)).preimage_mem_nhds hL
  [Elab.step] [0.057230] expected type: Type (max u_2 u_3), term
      E →L[𝕜] F
    [Elab.step] [0.057083] expected type: Type (max u_2 u_3), term
        ContinuousLinearMap✝ (RingHom.id✝ 𝕜) E F
      [Meta.synthInstance] [0.019120] ✅️ TopologicalSpace F
        [Meta.check] [0.017614] ✅️ PseudoMetricSpace.toUniformSpace.toTopologicalSpace
      [Meta.synthInstance] [0.021849] ✅️ AddCommMonoid F
info: Mathlib/Analysis/Calculus/LineDeriv/Basic.lean:364:0: [Elab.command] [0.069057] theorem LineDifferentiableAt.congr_of_eventuallyEq (h : LineDifferentiableAt 𝕜 f x v)
        (hL : f₁ =ᶠ[𝓝 x] f) : LineDifferentiableAt 𝕜 f₁ x v :=
      by
      apply DifferentiableAt.congr_of_eventuallyEq h
      let F := fun (t : 𝕜) ↦ x + t • v
      rw [show x = F 0 by simp [F]] at hL
      exact (Continuous.continuousAt (by fun_prop)).preimage_mem_nhds hL
info: Mathlib/Analysis/Calculus/LineDeriv/Basic.lean:364:0: [Elab.async] [0.184575] elaborating proof of LineDifferentiableAt.congr_of_eventuallyEq
  [Elab.definition.value] [0.183441] LineDifferentiableAt.congr_of_eventuallyEq
    [Elab.step] [0.182724] 
          apply DifferentiableAt.congr_of_eventuallyEq h
          let F := fun (t : 𝕜) ↦ x + t • v
          rw [show x = F 0 by simp [F]] at hL
          exact (Continuous.continuousAt (by fun_prop)).preimage_mem_nhds hL
      [Elab.step] [0.182707] 
            apply DifferentiableAt.congr_of_eventuallyEq h
            let F := fun (t : 𝕜) ↦ x + t • v
            rw [show x = F 0 by simp [F]] at hL
            exact (Continuous.continuousAt (by fun_prop)).preimage_mem_nhds hL
        [Elab.step] [0.031416] apply DifferentiableAt.congr_of_eventuallyEq h
          [Elab.step] [0.027970] expected type: <not-available>, term
              DifferentiableAt.congr_of_eventuallyEq h
            [Elab.step] [0.014835] expected type: DifferentiableAt 𝕜 (fun t ↦ f (x + t • v)) 0, term
                h
              [Meta.isDefEq] [0.014566] ✅️ DifferentiableAt ?m.35 ?m.43 ?m.45 =?= LineDifferentiableAt 𝕜 f x v
                [Meta.isDefEq] [0.014446] ✅️ DifferentiableAt ?m.35 ?m.43
                      ?m.45 =?= DifferentiableAt 𝕜 (fun t ↦ f (x + t • v)) 0
                  [Meta.isDefEq.delta] [0.014396] ✅️ DifferentiableAt ?m.35 ?m.43
                        ?m.45 =?= DifferentiableAt 𝕜 (fun t ↦ f (x + t • v)) 0
                    [Meta.synthInstance] [0.010443] ✅️ NormedSpace 𝕜 𝕜
        [Elab.step] [0.046785] let F := fun (t : 𝕜) ↦ x + t • v
          [Elab.step] [0.046590] refine_lift
                let F := fun (t : 𝕜) ↦ x + t • v;
                ?_
            [Elab.step] [0.046513] focus
                  (refine
                      no_implicit_lambda%
                        (let F := fun (t : 𝕜) ↦ x + t • v;
                        ?_);
                    rotate_right)
              [Elab.step] [0.046502] (refine
                        no_implicit_lambda%
                          (let F := fun (t : 𝕜) ↦ x + t • v;
                          ?_);
                      rotate_right)
                [Elab.step] [0.046497] (refine
                          no_implicit_lambda%
                            (let F := fun (t : 𝕜) ↦ x + t • v;
                            ?_);
                        rotate_right)
                  [Elab.step] [0.046491] (refine
                          no_implicit_lambda%
                            (let F := fun (t : 𝕜) ↦ x + t • v;
                            ?_);
                        rotate_right)
                    [Elab.step] [0.046486] refine
                            no_implicit_lambda%
                              (let F := fun (t : 𝕜) ↦ x + t • v;
                              ?_);
                          rotate_right
                      [Elab.step] [0.046481] refine
                              no_implicit_lambda%
                                (let F := fun (t : 𝕜) ↦ x + t • v;
                                ?_);
                            rotate_right
                        [Elab.step] [0.046459] refine
                              no_implicit_lambda%
                                (let F := fun (t : 𝕜) ↦ x + t • v;
                                ?_)
                          [Elab.step] [0.046320] expected type: (fun t ↦ f₁ (x + t • v)) =ᶠ[𝓝 0] fun t ↦
                                f (x + t • v), term
                              no_implicit_lambda%
                                (let F := fun (t : 𝕜) ↦ x + t • v;
                                ?_)
                            [Elab.step] [0.046226] expected type: (fun t ↦ f₁ (x + t • v)) =ᶠ[𝓝 0] fun t ↦
                                  f (x + t • v), term
                                let F := fun (t : 𝕜) ↦ x + t • v;
                                ?_
                              [Elab.step] [0.046128] expected type: ?m.47, term
                                  fun (t : 𝕜) ↦ x + t • v
                                [Elab.step] [0.045821] expected type: <not-available>, term
                                    x + t • v
                                  [Elab.step] [0.045756] expected type: <not-available>, term
                                      binop% HAdd.hAdd✝ x (t • v)
                                    [Meta.synthInstance] [0.024450] ✅️ HAdd E E E
                                    [Meta.synthInstance] [0.014007] ✅️ HSMul 𝕜 E E
        [Elab.step] [0.030540] rw [show x = F 0 by simp [F]] at hL
          [Elab.step] [0.030252] (rewrite [show x = F 0 by simp [F]] at hL;
                with_annotate_state"]" (try (with_reducible rfl)))
            [Elab.step] [0.030246] rewrite [show x = F 0 by simp [F]] at hL;
                  with_annotate_state"]" (try (with_reducible rfl))
              [Elab.step] [0.030241] rewrite [show x = F 0 by simp [F]] at hL;
                    with_annotate_state"]" (try (with_reducible rfl))
                [Elab.step] [0.029743] rewrite [show x = F 0 by simp [F]] at hL
                  [Elab.step] [0.024085] simp [F]
                    [Elab.step] [0.024076] simp [F]
                      [Elab.step] [0.024061] simp [F]
                        [Meta.isDefEq] [0.019244] ✅️ 0 • ?m =?= 0 • v
                          [Meta.isDefEq] [0.019108] ✅️ instHSMul =?= instHSMul
                            [Meta.isDefEq.delta] [0.019089] ✅️ instHSMul =?= instHSMul
                              [Meta.synthInstance] [0.018187] ✅️ SMulWithZero 𝕜 E
                                [Meta.synthInstance] [0.010198] ✅️ apply MulActionWithZero.toSMulWithZero to SMulWithZero
                                      𝕜 E
                                  [Meta.synthInstance.tryResolve] [0.010162] ✅️ SMulWithZero 𝕜 E ≟ SMulWithZero 𝕜 E
        [Elab.step] [0.073906] exact (Continuous.continuousAt (by fun_prop)).preimage_mem_nhds hL
          [Elab.step] [0.056898] fun_prop
            [Elab.step] [0.056884] fun_prop
              [Elab.step] [0.056866] fun_prop
                [Meta.Tactic.fun_prop] [0.055822] [✅️] Continuous F
                  [Meta.Tactic.fun_prop] [0.054075] [✅️] Continuous fun t ↦ x + t • v
                    [Meta.Tactic.fun_prop] [0.053605] [✅️] applying: Continuous.add
                      [Meta.synthInstance] [0.029155] ✅️ ContinuousAdd E
                        [Meta.synthInstance] [0.024127] ❌️ apply @IsTopologicalSemiring.toContinuousAdd to ContinuousAdd
                              E
                          [Meta.synthInstance.tryResolve] [0.024105] ❌️ ContinuousAdd E ≟ ContinuousAdd ?m.92
                            [Meta.isDefEq] [0.024098] ❌️ ContinuousAdd E =?= ContinuousAdd ?m.92
                              [Meta.isDefEq] [0.023996] ❌️ NormedAddCommGroup.toENormedAddCommMonoid.toAddCommMonoid.toAddCommSemigroup.toAddCommMagma.toAdd =?= NonUnitalNonAssocSemiring.toDistrib.toAdd
                                [Meta.isDefEq] [0.023499] ❌️ NormedAddCommGroup.toENormedAddCommMonoid.toAddCommMonoid.toAddCommSemigroup.toAddCommMagma.1 =?= NonUnitalNonAssocSemiring.toDistrib.2
                                  [Meta.isDefEq] [0.023430] ❌️ NormedAddCommGroup.toENormedAddCommMonoid.toAddCommMonoid.toAddCommSemigroup.toAdd =?= NonUnitalNonAssocSemiring.toAddCommMonoid.toAdd
                                    [Meta.isDefEq.delta] [0.022314] ❌️ NormedAddCommGroup.toENormedAddCommMonoid.toAddCommMonoid.toAddCommSemigroup.toAdd =?= NonUnitalNonAssocSemiring.toAddCommMonoid.toAdd
                                      [Meta.synthInstance] [0.013745] ❌️ NonUnitalNonAssocSemiring E
                      [Meta.Tactic.fun_prop] [0.019501] [✅️] Continuous fun x ↦ x • v
                        [Meta.Tactic.fun_prop] [0.018515] [✅️] applying: Continuous.smul
                          [Meta.synthInstance] [0.016110] ✅️ ContinuousSMul 𝕜 E
Build completed successfully (1850 jobs).
```

### Trace profiling of `LineDifferentiableAt.congr_of_eventuallyEq` after PR 28203
```diff
diff --git a/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean b/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
index 97ba668da2..f1e6859f9c 100644
--- a/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
@@ -360,13 +360,11 @@ theorem LineDifferentiableWithinAt.congr_of_eventuallyEq (h : LineDifferentiable
     (h₁ : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) : LineDifferentiableWithinAt 𝕜 f₁ s x v :=
   (h.hasLineDerivWithinAt.congr_of_eventuallyEq h₁ hx).differentiableWithinAt
 
+set_option trace.profiler true in
 theorem LineDifferentiableAt.congr_of_eventuallyEq
     (h : LineDifferentiableAt 𝕜 f x v) (hL : f₁ =ᶠ[𝓝 x] f) :
-    LineDifferentiableAt 𝕜 f₁ x v := by
-  apply DifferentiableAt.congr_of_eventuallyEq h
-  let F := fun (t : 𝕜) ↦ x + t • v
-  rw [show x = F 0 by simp [F]] at hL
-  exact (Continuous.continuousAt (by fun_prop)).preimage_mem_nhds hL
+    LineDifferentiableAt 𝕜 f₁ x v :=
+  hL.symm.lineDifferentiableAt_iff.mp h
 
 theorem Filter.EventuallyEq.lineDerivWithin_eq (hs : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) :
     lineDerivWithin 𝕜 f₁ s x v = lineDerivWithin 𝕜 f s x v := by
```
```
ℹ [1850/1850] Built Mathlib.Analysis.Calculus.LineDeriv.Basic (7.0s)
info: Mathlib/Analysis/Calculus/LineDeriv/Basic.lean:364:0: [Elab.command] [0.053082] theorem congr_of_eventuallyEq (h : LineDifferentiableAt 𝕜 f x v) (hL : f₁ =ᶠ[𝓝 x] f) :
        LineDifferentiableAt 𝕜 f₁ x v :=
      hL.symm.lineDifferentiableAt_iff.mp h
  [Elab.step] [0.042614] expected type: Type (max u_2 u_3), term
      E →L[𝕜] F
    [Elab.step] [0.042451] expected type: Type (max u_2 u_3), term
        ContinuousLinearMap✝ (RingHom.id✝ 𝕜) E F
      [Meta.synthInstance] [0.021006] ✅️ AddCommMonoid E
        [Meta.synthInstance.resume] [0.012861] propagating ENormedAddCommMonoid
              E to subgoal ENormedAddCommMonoid E of ESeminormedAddCommMonoid E
          [Meta.synthInstance.answer] [0.012846] ✅️ ESeminormedAddCommMonoid E
info: Mathlib/Analysis/Calculus/LineDeriv/Basic.lean:364:0: [Elab.command] [0.053354] theorem LineDifferentiableAt.congr_of_eventuallyEq (h : LineDifferentiableAt 𝕜 f x v)
        (hL : f₁ =ᶠ[𝓝 x] f) : LineDifferentiableAt 𝕜 f₁ x v :=
      hL.symm.lineDifferentiableAt_iff.mp h
info: Mathlib/Analysis/Calculus/LineDeriv/Basic.lean:364:0: [Elab.async] [0.014592] elaborating proof of LineDifferentiableAt.congr_of_eventuallyEq
  [Elab.definition.value] [0.013461] LineDifferentiableAt.congr_of_eventuallyEq
    [Elab.step] [0.011997] expected type: LineDifferentiableAt 𝕜 f₁ x v, term
        hL.symm.lineDifferentiableAt_iff.mp h
Build completed successfully (1850 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
