### PR TITLE
[Merged by Bors] - chore(Analysis/Calculus): golf entire `HasLineDerivAt.congr_of_eventuallyEq`

### DIFF
--- a/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
@@ -350,11 +350,8 @@ lemma HasLineDerivWithinAt.congr_of_eventuallyEq (hf : HasLineDerivWithinAt 𝕜
   exact A.continuousWithinAt.preimage_mem_nhdsWithin'' h'f (by simp)
 
 theorem HasLineDerivAt.congr_of_eventuallyEq (h : HasLineDerivAt 𝕜 f f' x v) (h₁ : f₁ =ᶠ[𝓝 x] f) :
-    HasLineDerivAt 𝕜 f₁ f' x v := by
-  apply HasDerivAt.congr_of_eventuallyEq h
-  let F := fun (t : 𝕜) ↦ x + t • v
-  rw [show x = F 0 by simp [F]] at h₁
-  exact (Continuous.continuousAt (by fun_prop)).preimage_mem_nhds h₁
+    HasLineDerivAt 𝕜 f₁ f' x v :=
+  (EventuallyEq.hasLineDerivAt_iff (id (EventuallyEq.symm h₁))).mp h
 
 theorem LineDifferentiableWithinAt.congr_of_eventuallyEq (h : LineDifferentiableWithinAt 𝕜 f s x v)
     (h₁ : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) : LineDifferentiableWithinAt 𝕜 f₁ s x v :=

--- a/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
@@ -351,7 +351,7 @@ lemma HasLineDerivWithinAt.congr_of_eventuallyEq (hf : HasLineDerivWithinAt 𝕜
 
 theorem HasLineDerivAt.congr_of_eventuallyEq (h : HasLineDerivAt 𝕜 f f' x v) (h₁ : f₁ =ᶠ[𝓝 x] f) :
     HasLineDerivAt 𝕜 f₁ f' x v :=
-  (EventuallyEq.hasLineDerivAt_iff (EventuallyEq.symm h₁)).mp h
+  (EventuallyEq.hasLineDerivAt_iff h₁.symm).mp h
 
 theorem LineDifferentiableWithinAt.congr_of_eventuallyEq (h : LineDifferentiableWithinAt 𝕜 f s x v)
     (h₁ : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) : LineDifferentiableWithinAt 𝕜 f₁ s x v :=

--- a/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
@@ -351,7 +351,7 @@ lemma HasLineDerivWithinAt.congr_of_eventuallyEq (hf : HasLineDerivWithinAt 𝕜
 
 theorem HasLineDerivAt.congr_of_eventuallyEq (h : HasLineDerivAt 𝕜 f f' x v) (h₁ : f₁ =ᶠ[𝓝 x] f) :
     HasLineDerivAt 𝕜 f₁ f' x v :=
-  (EventuallyEq.hasLineDerivAt_iff (id (EventuallyEq.symm h₁))).mp h
+  (EventuallyEq.hasLineDerivAt_iff (EventuallyEq.symm h₁)).mp h
 
 theorem LineDifferentiableWithinAt.congr_of_eventuallyEq (h : LineDifferentiableWithinAt 𝕜 f s x v)
     (h₁ : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) : LineDifferentiableWithinAt 𝕜 f₁ s x v :=


### PR DESCRIPTION
Motivation: Avoid (partial) proof duplication.

---
<details>
<summary>Show trace profiling of <code>HasLineDerivAt.congr_of_eventuallyEq</code>: 170 ms before, 17 ms after  🎉</summary>

### Trace profiling of `HasLineDerivAt.congr_of_eventuallyEq` before PR 28204
```diff
diff --git a/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean b/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
index 97ba668da2..493092d45c 100644
--- a/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
@@ -349,6 +349,7 @@ lemma HasLineDerivWithinAt.congr_of_eventuallyEq (hf : HasLineDerivWithinAt 𝕜
   have A : Continuous (fun (t : 𝕜) ↦ x + t • v) := by fun_prop
   exact A.continuousWithinAt.preimage_mem_nhdsWithin'' h'f (by simp)
 
+set_option trace.profiler true in
 theorem HasLineDerivAt.congr_of_eventuallyEq (h : HasLineDerivAt 𝕜 f f' x v) (h₁ : f₁ =ᶠ[𝓝 x] f) :
     HasLineDerivAt 𝕜 f₁ f' x v := by
   apply HasDerivAt.congr_of_eventuallyEq h
```
```
ℹ [1850/1850] Built Mathlib.Analysis.Calculus.LineDeriv.Basic (7.1s)
info: Mathlib/Analysis/Calculus/LineDeriv/Basic.lean:353:0: [Elab.command] [0.069880] theorem congr_of_eventuallyEq (h : HasLineDerivAt 𝕜 f f' x v) (h₁ : f₁ =ᶠ[𝓝 x] f) :
        HasLineDerivAt 𝕜 f₁ f' x v := by
      apply HasDerivAt.congr_of_eventuallyEq h
      let F := fun (t : 𝕜) ↦ x + t • v
      rw [show x = F 0 by simp [F]] at h₁
      exact (Continuous.continuousAt (by fun_prop)).preimage_mem_nhds h₁
  [Elab.step] [0.059065] expected type: Type (max u_2 u_3), term
      E →L[𝕜] F
    [Elab.step] [0.058901] expected type: Type (max u_2 u_3), term
        ContinuousLinearMap✝ (RingHom.id✝ 𝕜) E F
      [Meta.synthInstance] [0.032476] ✅️ TopologicalSpace E
        [Meta.synthInstance] [0.027567] ❌️ apply inst✝⁴ to NontriviallyNormedField E
          [Meta.synthInstance.tryResolve] [0.027549] ❌️ NontriviallyNormedField E ≟ NontriviallyNormedField 𝕜
            [Meta.isDefEq] [0.027543] ❌️ NontriviallyNormedField E =?= NontriviallyNormedField 𝕜
              [Meta.isDefEq.onFailure] [0.027490] ❌️ NontriviallyNormedField E =?= NontriviallyNormedField 𝕜
info: Mathlib/Analysis/Calculus/LineDeriv/Basic.lean:353:0: [Elab.command] [0.070174] theorem HasLineDerivAt.congr_of_eventuallyEq (h : HasLineDerivAt 𝕜 f f' x v)
        (h₁ : f₁ =ᶠ[𝓝 x] f) : HasLineDerivAt 𝕜 f₁ f' x v :=
      by
      apply HasDerivAt.congr_of_eventuallyEq h
      let F := fun (t : 𝕜) ↦ x + t • v
      rw [show x = F 0 by simp [F]] at h₁
      exact (Continuous.continuousAt (by fun_prop)).preimage_mem_nhds h₁
info: Mathlib/Analysis/Calculus/LineDeriv/Basic.lean:353:0: [Elab.async] [0.179800] elaborating proof of HasLineDerivAt.congr_of_eventuallyEq
  [Elab.definition.value] [0.169873] HasLineDerivAt.congr_of_eventuallyEq
    [Elab.step] [0.169248] 
          apply HasDerivAt.congr_of_eventuallyEq h
          let F := fun (t : 𝕜) ↦ x + t • v
          rw [show x = F 0 by simp [F]] at h₁
          exact (Continuous.continuousAt (by fun_prop)).preimage_mem_nhds h₁
      [Elab.step] [0.169234] 
            apply HasDerivAt.congr_of_eventuallyEq h
            let F := fun (t : 𝕜) ↦ x + t • v
            rw [show x = F 0 by simp [F]] at h₁
            exact (Continuous.continuousAt (by fun_prop)).preimage_mem_nhds h₁
        [Elab.step] [0.033338] let F := fun (t : 𝕜) ↦ x + t • v
          [Elab.step] [0.033315] refine_lift
                let F := fun (t : 𝕜) ↦ x + t • v;
                ?_
            [Elab.step] [0.033310] focus
                  (refine
                      no_implicit_lambda%
                        (let F := fun (t : 𝕜) ↦ x + t • v;
                        ?_);
                    rotate_right)
              [Elab.step] [0.033302] (refine
                        no_implicit_lambda%
                          (let F := fun (t : 𝕜) ↦ x + t • v;
                          ?_);
                      rotate_right)
                [Elab.step] [0.033296] (refine
                          no_implicit_lambda%
                            (let F := fun (t : 𝕜) ↦ x + t • v;
                            ?_);
                        rotate_right)
                  [Elab.step] [0.033291] (refine
                          no_implicit_lambda%
                            (let F := fun (t : 𝕜) ↦ x + t • v;
                            ?_);
                        rotate_right)
                    [Elab.step] [0.033287] refine
                            no_implicit_lambda%
                              (let F := fun (t : 𝕜) ↦ x + t • v;
                              ?_);
                          rotate_right
                      [Elab.step] [0.033283] refine
                              no_implicit_lambda%
                                (let F := fun (t : 𝕜) ↦ x + t • v;
                                ?_);
                            rotate_right
                        [Elab.step] [0.033261] refine
                              no_implicit_lambda%
                                (let F := fun (t : 𝕜) ↦ x + t • v;
                                ?_)
                          [Elab.step] [0.033208] expected type: (fun t ↦ f₁ (x + t • v)) =ᶠ[𝓝 0] fun t ↦
                                f (x + t • v), term
                              no_implicit_lambda%
                                (let F := fun (t : 𝕜) ↦ x + t • v;
                                ?_)
                            [Elab.step] [0.033202] expected type: (fun t ↦ f₁ (x + t • v)) =ᶠ[𝓝 0] fun t ↦
                                  f (x + t • v), term
                                let F := fun (t : 𝕜) ↦ x + t • v;
                                ?_
                              [Elab.step] [0.033106] expected type: ?m.45, term
                                  fun (t : 𝕜) ↦ x + t • v
                                [Elab.step] [0.033053] expected type: <not-available>, term
                                    x + t • v
                                  [Elab.step] [0.033043] expected type: <not-available>, term
                                      binop% HAdd.hAdd✝ x (t • v)
                                    [Meta.synthInstance] [0.011402] ✅️ HAdd E E E
                                    [Meta.synthInstance] [0.016023] ✅️ HSMul 𝕜 E E
        [Elab.step] [0.056466] rw [show x = F 0 by simp [F]] at h₁
          [Elab.step] [0.056264] (rewrite [show x = F 0 by simp [F]] at h₁;
                with_annotate_state"]" (try (with_reducible rfl)))
            [Elab.step] [0.056258] rewrite [show x = F 0 by simp [F]] at h₁;
                  with_annotate_state"]" (try (with_reducible rfl))
              [Elab.step] [0.056253] rewrite [show x = F 0 by simp [F]] at h₁;
                    with_annotate_state"]" (try (with_reducible rfl))
                [Elab.step] [0.055767] rewrite [show x = F 0 by simp [F]] at h₁
                  [Elab.step] [0.052705] simp [F]
                    [Elab.step] [0.052692] simp [F]
                      [Elab.step] [0.052678] simp [F]
                        [Meta.isDefEq] [0.044696] ✅️ 0 • ?m =?= 0 • v
                          [Meta.isDefEq] [0.044437] ✅️ instHSMul =?= instHSMul
                            [Meta.isDefEq.delta] [0.044411] ✅️ instHSMul =?= instHSMul
                              [Meta.synthInstance] [0.044136] ✅️ SMulWithZero 𝕜 E
                                [Meta.synthInstance] [0.026790] ✅️ apply MulActionWithZero.toSMulWithZero to SMulWithZero
                                      𝕜 E
                                  [Meta.synthInstance.tryResolve] [0.026707] ✅️ SMulWithZero 𝕜 E ≟ SMulWithZero 𝕜 E
                                    [Meta.isDefEq] [0.019032] ✅️ ?m.67 =?= MulActionWithZero.toSMulWithZero 𝕜 E
                                      [Meta.isDefEq.assign] [0.019025] ✅️ ?m.67 := MulActionWithZero.toSMulWithZero 𝕜 E
                                        [Meta.isDefEq.assign.checkTypes] [0.018987] ✅️ (?m.67 : SMulWithZero 𝕜
                                              E) := (MulActionWithZero.toSMulWithZero 𝕜 E : SMulWithZero 𝕜 E)
                                          [Meta.isDefEq] [0.018979] ✅️ SMulWithZero 𝕜 E =?= SMulWithZero 𝕜 E
                                            [Meta.synthInstance] [0.015901] ✅️ Zero E
        [Elab.step] [0.077800] exact (Continuous.continuousAt (by fun_prop)).preimage_mem_nhds h₁
          [Elab.step] [0.062362] fun_prop
            [Elab.step] [0.062350] fun_prop
              [Elab.step] [0.062334] fun_prop
                [Meta.Tactic.fun_prop] [0.061226] [✅️] Continuous F
                  [Meta.Tactic.fun_prop] [0.059665] [✅️] Continuous fun t ↦ x + t • v
                    [Meta.Tactic.fun_prop] [0.059384] [✅️] applying: Continuous.add
                      [Meta.synthInstance] [0.016038] ✅️ ContinuousAdd E
                        [Meta.synthInstance] [0.011655] ❌️ apply @IsTopologicalSemiring.toContinuousAdd to ContinuousAdd
                              E
                          [Meta.synthInstance.tryResolve] [0.011634] ❌️ ContinuousAdd E ≟ ContinuousAdd ?m.90
                            [Meta.isDefEq] [0.011628] ❌️ ContinuousAdd E =?= ContinuousAdd ?m.90
                              [Meta.isDefEq] [0.011532] ❌️ NormedAddCommGroup.toENormedAddCommMonoid.toAddCommMonoid.toAddCommSemigroup.toAddCommMagma.toAdd =?= NonUnitalNonAssocSemiring.toDistrib.toAdd
                                [Meta.isDefEq] [0.011344] ❌️ NormedAddCommGroup.toENormedAddCommMonoid.toAddCommMonoid.toAddCommSemigroup.toAddCommMagma.1 =?= NonUnitalNonAssocSemiring.toDistrib.2
                                  [Meta.isDefEq] [0.011305] ❌️ NormedAddCommGroup.toENormedAddCommMonoid.toAddCommMonoid.toAddCommSemigroup.toAdd =?= NonUnitalNonAssocSemiring.toAddCommMonoid.toAdd
                                    [Meta.isDefEq.delta] [0.010875] ❌️ NormedAddCommGroup.toENormedAddCommMonoid.toAddCommMonoid.toAddCommSemigroup.toAdd =?= NonUnitalNonAssocSemiring.toAddCommMonoid.toAdd
                      [Meta.Tactic.fun_prop] [0.040150] [✅️] Continuous fun x ↦ x • v
                        [Meta.Tactic.fun_prop] [0.038993] [✅️] applying: Continuous.smul
                          [Meta.synthInstance] [0.037041] ✅️ ContinuousSMul 𝕜 E
Build completed successfully (1850 jobs).
```

### Trace profiling of `HasLineDerivAt.congr_of_eventuallyEq` after PR 28204
```diff
diff --git a/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean b/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
index 97ba668da2..b5600c87d2 100644
--- a/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
@@ -349,12 +349,10 @@ lemma HasLineDerivWithinAt.congr_of_eventuallyEq (hf : HasLineDerivWithinAt 𝕜
   have A : Continuous (fun (t : 𝕜) ↦ x + t • v) := by fun_prop
   exact A.continuousWithinAt.preimage_mem_nhdsWithin'' h'f (by simp)
 
+set_option trace.profiler true in
 theorem HasLineDerivAt.congr_of_eventuallyEq (h : HasLineDerivAt 𝕜 f f' x v) (h₁ : f₁ =ᶠ[𝓝 x] f) :
-    HasLineDerivAt 𝕜 f₁ f' x v := by
-  apply HasDerivAt.congr_of_eventuallyEq h
-  let F := fun (t : 𝕜) ↦ x + t • v
-  rw [show x = F 0 by simp [F]] at h₁
-  exact (Continuous.continuousAt (by fun_prop)).preimage_mem_nhds h₁
+    HasLineDerivAt 𝕜 f₁ f' x v :=
+  (EventuallyEq.hasLineDerivAt_iff (EventuallyEq.symm h₁)).mp h
 
 theorem LineDifferentiableWithinAt.congr_of_eventuallyEq (h : LineDifferentiableWithinAt 𝕜 f s x v)
     (h₁ : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) : LineDifferentiableWithinAt 𝕜 f₁ s x v :=
```
```
ℹ [1850/1850] Built Mathlib.Analysis.Calculus.LineDeriv.Basic (6.7s)
info: Mathlib/Analysis/Calculus/LineDeriv/Basic.lean:353:0: [Elab.command] [0.030358] theorem congr_of_eventuallyEq (h : HasLineDerivAt 𝕜 f f' x v) (h₁ : f₁ =ᶠ[𝓝 x] f) :
        HasLineDerivAt 𝕜 f₁ f' x v :=
      (EventuallyEq.hasLineDerivAt_iff (EventuallyEq.symm h₁)).mp h
  [Elab.step] [0.014668] expected type: Type (max u_2 u_3), term
      E →L[𝕜] F
    [Elab.step] [0.014538] expected type: Type (max u_2 u_3), term
        ContinuousLinearMap✝ (RingHom.id✝ 𝕜) E F
info: Mathlib/Analysis/Calculus/LineDeriv/Basic.lean:353:0: [Elab.command] [0.030661] theorem HasLineDerivAt.congr_of_eventuallyEq (h : HasLineDerivAt 𝕜 f f' x v)
        (h₁ : f₁ =ᶠ[𝓝 x] f) : HasLineDerivAt 𝕜 f₁ f' x v :=
      (EventuallyEq.hasLineDerivAt_iff (EventuallyEq.symm h₁)).mp h
info: Mathlib/Analysis/Calculus/LineDeriv/Basic.lean:353:0: [Elab.async] [0.018140] elaborating proof of HasLineDerivAt.congr_of_eventuallyEq
  [Elab.definition.value] [0.017158] HasLineDerivAt.congr_of_eventuallyEq
Build completed successfully (1850 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
