### PR TITLE
[Merged by Bors] - chore(Analysis/Calculus): golf entire `HasLineDerivWithinAt.congr_of_eventuallyEq`

### DIFF
--- a/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
@@ -344,10 +344,8 @@ theorem Filter.EventuallyEq.lineDifferentiableWithinAt_iff_of_mem
   h.lineDifferentiableWithinAt_iff (h.eq_of_nhdsWithin hx)
 
 lemma HasLineDerivWithinAt.congr_of_eventuallyEq (hf : HasLineDerivWithinAt 𝕜 f f' s x v)
-    (h'f : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) : HasLineDerivWithinAt 𝕜 f₁ f' s x v := by
-  apply HasDerivWithinAt.congr_of_eventuallyEq hf _ (by simp [hx])
-  have A : Continuous (fun (t : 𝕜) ↦ x + t • v) := by fun_prop
-  exact A.continuousWithinAt.preimage_mem_nhdsWithin'' h'f (by simp)
+    (h'f : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) : HasLineDerivWithinAt 𝕜 f₁ f' s x v :=
+  (EventuallyEq.hasLineDerivWithinAt_iff (id (EventuallyEq.symm h'f)) (id (Eq.symm hx))).mp hf
 
 theorem HasLineDerivAt.congr_of_eventuallyEq (h : HasLineDerivAt 𝕜 f f' x v) (h₁ : f₁ =ᶠ[𝓝 x] f) :
     HasLineDerivAt 𝕜 f₁ f' x v :=

--- a/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
@@ -345,7 +345,7 @@ theorem Filter.EventuallyEq.lineDifferentiableWithinAt_iff_of_mem
 
 lemma HasLineDerivWithinAt.congr_of_eventuallyEq (hf : HasLineDerivWithinAt 𝕜 f f' s x v)
     (h'f : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) : HasLineDerivWithinAt 𝕜 f₁ f' s x v :=
-  (EventuallyEq.hasLineDerivWithinAt_iff (EventuallyEq.symm h'f.eventually) hx.symm).mp hf
+  h'f.symm.hasLineDerivWithinAt_iff hx.symm |>.mp hf
 
 theorem HasLineDerivAt.congr_of_eventuallyEq (h : HasLineDerivAt 𝕜 f f' x v) (h₁ : f₁ =ᶠ[𝓝 x] f) :
     HasLineDerivAt 𝕜 f₁ f' x v :=

--- a/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
@@ -345,7 +345,7 @@ theorem Filter.EventuallyEq.lineDifferentiableWithinAt_iff_of_mem
 
 lemma HasLineDerivWithinAt.congr_of_eventuallyEq (hf : HasLineDerivWithinAt 𝕜 f f' s x v)
     (h'f : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) : HasLineDerivWithinAt 𝕜 f₁ f' s x v :=
-  (EventuallyEq.hasLineDerivWithinAt_iff (id (EventuallyEq.symm h'f)) (id (Eq.symm hx))).mp hf
+  (EventuallyEq.hasLineDerivWithinAt_iff (EventuallyEq.symm h'f.eventually) hx.symm).mp hf
 
 theorem HasLineDerivAt.congr_of_eventuallyEq (h : HasLineDerivAt 𝕜 f f' x v) (h₁ : f₁ =ᶠ[𝓝 x] f) :
     HasLineDerivAt 𝕜 f₁ f' x v :=


### PR DESCRIPTION
Motivation: Avoid (partial) proof duplication.

---
<details>
<summary>Show trace profiling of <code>HasLineDerivWithinAt.congr_of_eventuallyEq</code>: 235 ms before, <10 ms after  🎉</summary>

### Trace profiling of `HasLineDerivWithinAt.congr_of_eventuallyEq` before PR 28205
```diff
diff --git a/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean b/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
index 97ba668da2..c2a1379a95 100644
--- a/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
@@ -343,6 +343,7 @@ theorem Filter.EventuallyEq.lineDifferentiableWithinAt_iff_of_mem
     LineDifferentiableWithinAt 𝕜 f₀ s x v ↔ LineDifferentiableWithinAt 𝕜 f₁ s x v :=
   h.lineDifferentiableWithinAt_iff (h.eq_of_nhdsWithin hx)
 
+set_option trace.profiler true in
 lemma HasLineDerivWithinAt.congr_of_eventuallyEq (hf : HasLineDerivWithinAt 𝕜 f f' s x v)
     (h'f : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) : HasLineDerivWithinAt 𝕜 f₁ f' s x v := by
   apply HasDerivWithinAt.congr_of_eventuallyEq hf _ (by simp [hx])
```
```
ℹ [1850/1850] Built Mathlib.Analysis.Calculus.LineDeriv.Basic (7.1s)
info: Mathlib/Analysis/Calculus/LineDeriv/Basic.lean:347:0: [Elab.command] [0.044840] theorem congr_of_eventuallyEq (hf : HasLineDerivWithinAt 𝕜 f f' s x v) (h'f : f₁ =ᶠ[𝓝[s] x] f)
        (hx : f₁ x = f x) : HasLineDerivWithinAt 𝕜 f₁ f' s x v :=
      by
      apply HasDerivWithinAt.congr_of_eventuallyEq hf _ (by simp [hx])
      have A : Continuous (fun (t : 𝕜) ↦ x + t • v) := by fun_prop
      exact A.continuousWithinAt.preimage_mem_nhdsWithin'' h'f (by simp)
  [Elab.step] [0.028254] expected type: Type (max u_2 u_3), term
      E →L[𝕜] F
    [Elab.step] [0.028080] expected type: Type (max u_2 u_3), term
        ContinuousLinearMap✝ (RingHom.id✝ 𝕜) E F
      [Meta.synthInstance] [0.010377] ✅️ AddCommMonoid E
  [Elab.definition.header] [0.011416] HasLineDerivWithinAt.congr_of_eventuallyEq
info: Mathlib/Analysis/Calculus/LineDeriv/Basic.lean:347:0: [Elab.command] [0.045090] theorem HasLineDerivWithinAt.congr_of_eventuallyEq (hf : HasLineDerivWithinAt 𝕜 f f' s x v)
        (h'f : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) : HasLineDerivWithinAt 𝕜 f₁ f' s x v :=
      by
      apply HasDerivWithinAt.congr_of_eventuallyEq hf _ (by simp [hx])
      have A : Continuous (fun (t : 𝕜) ↦ x + t • v) := by fun_prop
      exact A.continuousWithinAt.preimage_mem_nhdsWithin'' h'f (by simp)
info: Mathlib/Analysis/Calculus/LineDeriv/Basic.lean:347:0: [Elab.command] [0.045180] lemma HasLineDerivWithinAt.congr_of_eventuallyEq (hf : HasLineDerivWithinAt 𝕜 f f' s x v)
        (h'f : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) : HasLineDerivWithinAt 𝕜 f₁ f' s x v :=
      by
      apply HasDerivWithinAt.congr_of_eventuallyEq hf _ (by simp [hx])
      have A : Continuous (fun (t : 𝕜) ↦ x + t • v) := by fun_prop
      exact A.continuousWithinAt.preimage_mem_nhdsWithin'' h'f (by simp)
info: Mathlib/Analysis/Calculus/LineDeriv/Basic.lean:347:0: [Elab.async] [0.241538] elaborating proof of HasLineDerivWithinAt.congr_of_eventuallyEq
  [Elab.definition.value] [0.235419] HasLineDerivWithinAt.congr_of_eventuallyEq
    [Elab.step] [0.234338] 
          apply HasDerivWithinAt.congr_of_eventuallyEq hf _ (by simp [hx])
          have A : Continuous (fun (t : 𝕜) ↦ x + t • v) := by fun_prop
          exact A.continuousWithinAt.preimage_mem_nhdsWithin'' h'f (by simp)
      [Elab.step] [0.234325] 
            apply HasDerivWithinAt.congr_of_eventuallyEq hf _ (by simp [hx])
            have A : Continuous (fun (t : 𝕜) ↦ x + t • v) := by fun_prop
            exact A.continuousWithinAt.preimage_mem_nhdsWithin'' h'f (by simp)
        [Elab.step] [0.032147] apply HasDerivWithinAt.congr_of_eventuallyEq hf _ (by simp [hx])
          [Elab.step] [0.030192] simp [hx]
            [Elab.step] [0.030185] simp [hx]
              [Elab.step] [0.030174] simp [hx]
                [Meta.isDefEq] [0.026327] ✅️ 0 • ?m =?= 0 • v
                  [Meta.isDefEq] [0.026186] ✅️ instHSMul =?= instHSMul
                    [Meta.isDefEq.delta] [0.026172] ✅️ instHSMul =?= instHSMul
                      [Meta.synthInstance] [0.025868] ✅️ SMulWithZero 𝕜 E
                        [Meta.synthInstance] [0.017680] ✅️ apply MulActionWithZero.toSMulWithZero to SMulWithZero 𝕜 E
                          [Meta.synthInstance.tryResolve] [0.017635] ✅️ SMulWithZero 𝕜 E ≟ SMulWithZero 𝕜 E
                            [Meta.isDefEq] [0.011750] ✅️ ?m.54 =?= MulActionWithZero.toSMulWithZero 𝕜 E
                              [Meta.isDefEq.assign] [0.011747] ✅️ ?m.54 := MulActionWithZero.toSMulWithZero 𝕜 E
                                [Meta.isDefEq.assign.checkTypes] [0.011728] ✅️ (?m.54 : SMulWithZero 𝕜
                                      E) := (MulActionWithZero.toSMulWithZero 𝕜 E : SMulWithZero 𝕜 E)
                                  [Meta.isDefEq] [0.011720] ✅️ SMulWithZero 𝕜 E =?= SMulWithZero 𝕜 E
        [Elab.step] [0.063437] have A : Continuous (fun (t : 𝕜) ↦ x + t • v) := by fun_prop
          [Elab.step] [0.063411] focus
                refine
                  no_implicit_lambda%
                    (have A : Continuous (fun (t : 𝕜) ↦ x + t • v) := ?body✝;
                    ?_)
                case body✝ => with_annotate_state"by" (fun_prop)
            [Elab.step] [0.063398] 
                  refine
                    no_implicit_lambda%
                      (have A : Continuous (fun (t : 𝕜) ↦ x + t • v) := ?body✝;
                      ?_)
                  case body✝ => with_annotate_state"by" (fun_prop)
              [Elab.step] [0.063390] 
                    refine
                      no_implicit_lambda%
                        (have A : Continuous (fun (t : 𝕜) ↦ x + t • v) := ?body✝;
                        ?_)
                    case body✝ => with_annotate_state"by" (fun_prop)
                [Elab.step] [0.025620] refine
                      no_implicit_lambda%
                        (have A : Continuous (fun (t : 𝕜) ↦ x + t • v) := ?body✝;
                        ?_)
                  [Elab.step] [0.025555] expected type: (fun t ↦ f₁ (x + t • v)) =ᶠ[𝓝[(fun t ↦ x + t • v) ⁻¹' s] 0]
                        fun t ↦ f (x + t • v), term
                      no_implicit_lambda%
                        (have A : Continuous (fun (t : 𝕜) ↦ x + t • v) := ?body✝;
                        ?_)
                    [Elab.step] [0.025544] expected type: (fun t ↦ f₁ (x + t • v)) =ᶠ[𝓝[(fun t ↦ x + t • v) ⁻¹' s] 0]
                          fun t ↦ f (x + t • v), term
                        (have A : Continuous (fun (t : 𝕜) ↦ x + t • v) := ?body✝;
                        ?_)
                      [Elab.step] [0.025534] expected type: (fun t ↦ f₁ (x + t • v)) =ᶠ[𝓝[(fun t ↦ x + t • v) ⁻¹' s] 0]
                            fun t ↦ f (x + t • v), term
                          have A : Continuous (fun (t : 𝕜) ↦ x + t • v) := ?body✝;
                          ?_
                        [Elab.step] [0.025437] expected type: Prop, term
                            Continuous (fun (t : 𝕜) ↦ x + t • v)
                          [Elab.step] [0.022733] expected type: 𝕜 → E, term
                              (fun (t : 𝕜) ↦ x + t • v)
                            [Elab.step] [0.022726] expected type: 𝕜 → E, term
                                fun (t : 𝕜) ↦ x + t • v
                              [Elab.step] [0.022644] expected type: E, term
                                  x + t • v
                                [Elab.step] [0.022634] expected type: E, term
                                    binop% HAdd.hAdd✝ x (t • v)
                                  [Meta.synthInstance] [0.012145] ✅️ HSMul 𝕜 E E
                [Elab.step] [0.037752] case body✝ => with_annotate_state"by" (fun_prop)
                  [Elab.step] [0.037590] with_annotate_state"by" (fun_prop)
                    [Elab.step] [0.037584] with_annotate_state"by" (fun_prop)
                      [Elab.step] [0.037576] with_annotate_state"by" (fun_prop)
                        [Elab.step] [0.037566] (fun_prop)
                          [Elab.step] [0.037560] fun_prop
                            [Elab.step] [0.037553] fun_prop
                              [Elab.step] [0.037537] fun_prop
                                [Meta.Tactic.fun_prop] [0.036033] [✅️] Continuous fun t ↦ x + t • v
                                  [Meta.Tactic.fun_prop] [0.035608] [✅️] applying: Continuous.add
                                    [Meta.Tactic.fun_prop] [0.026323] [✅️] Continuous fun x ↦ x • v
                                      [Meta.Tactic.fun_prop] [0.025780] [✅️] applying: Continuous.smul
                                        [Meta.synthInstance] [0.024459] ✅️ ContinuousSMul 𝕜 E
                                          [Meta.synthInstance] [0.010968] ❌️ apply @ModuleFilterBasis.continuousSMul to ContinuousSMul
                                                𝕜 E
                                            [Meta.synthInstance.tryResolve] [0.010896] ❌️ ContinuousSMul 𝕜
                                                  E ≟ ContinuousSMul ?m.91 ?m.92
                                              [Meta.isDefEq] [0.010866] ❌️ ContinuousSMul 𝕜
                                                    E =?= ContinuousSMul ?m.91 ?m.92
                                                [Meta.isDefEq] [0.010148] ✅️ DistribMulAction.toDistribSMul.toSMul =?= DistribMulAction.toDistribSMul.toSMul
                                                  [Meta.isDefEq.delta] [0.010090] ✅️ DistribMulAction.toDistribSMul.toSMul =?= DistribMulAction.toDistribSMul.toSMul
        [Elab.step] [0.138706] exact A.continuousWithinAt.preimage_mem_nhdsWithin'' h'f (by simp)
          [Elab.step] [0.088650] expected type: (fun t ↦ f₁ (x + t • v)) =ᶠ[𝓝[(fun t ↦ x + t • v) ⁻¹' s] 0] fun t ↦
                f (x + t • v), term
              A.continuousWithinAt.preimage_mem_nhdsWithin'' h'f (by simp)
            [Meta.isDefEq] [0.077764] ❌️ (fun t ↦ f₁ (x + t • v)) =ᶠ[𝓝[(fun t ↦ x + t • v) ⁻¹' s] 0] fun t ↦
                  f (x + t • v) =?= (fun t ↦ x + t • v) ⁻¹' ?m.112 ∈ 𝓝[(fun t ↦ x + t • v) ⁻¹' ?m.111] ?m.109
              [Meta.isDefEq] [0.077754] ❌️ (fun t ↦ f₁ (x + t • v)) =ᶠ[𝓝[(fun t ↦ x + t • v) ⁻¹' s] 0] fun t ↦
                    f (x + t • v) =?= (fun t ↦ x + t • v) ⁻¹' ?m.112 ∈ 𝓝[(fun t ↦ x + t • v) ⁻¹' ?m.111] ?m.109
                [Meta.isDefEq] [0.077673] ❌️ ∀ᶠ (x_1 : 𝕜) in 𝓝[(fun t ↦ x + t • v) ⁻¹' s] 0,
                      (fun t ↦ f₁ (x + t • v)) x_1 =
                        (fun t ↦ f (x + t • v))
                          x_1 =?= (fun t ↦ x + t • v) ⁻¹' ?m.112 ∈ 𝓝[(fun t ↦ x + t • v) ⁻¹' ?m.111] ?m.109
                  [Meta.isDefEq] [0.077611] ❌️ {x_1 |
                          (fun x_2 ↦ (fun t ↦ f₁ (x + t • v)) x_2 = (fun t ↦ f (x + t • v)) x_2) x_1} ∈
                        𝓝[(fun t ↦ x + t • v) ⁻¹' s]
                          0 =?= (fun t ↦ x + t • v) ⁻¹' ?m.112 ∈ 𝓝[(fun t ↦ x + t • v) ⁻¹' ?m.111] ?m.109
                    [Meta.isDefEq.delta] [0.017341] ❌️ {x_1 |
                            (fun x_2 ↦ (fun t ↦ f₁ (x + t • v)) x_2 = (fun t ↦ f (x + t • v)) x_2) x_1} ∈
                          𝓝[(fun t ↦ x + t • v) ⁻¹' s]
                            0 =?= (fun t ↦ x + t • v) ⁻¹' ?m.112 ∈ 𝓝[(fun t ↦ x + t • v) ⁻¹' ?m.111] ?m.109
                      [Meta.isDefEq] [0.012680] ❌️ {x_1 |
                            (fun x_2 ↦ (fun t ↦ f₁ (x + t • v)) x_2 = (fun t ↦ f (x + t • v)) x_2)
                              x_1} =?= (fun t ↦ x + t • v) ⁻¹' ?m.112
                        [Meta.isDefEq] [0.012627] ❌️ {x_1 |
                              (fun x_2 ↦ (fun t ↦ f₁ (x + t • v)) x_2 = (fun t ↦ f (x + t • v)) x_2)
                                x_1} =?= {x_1 | (fun t ↦ x + t • v) x_1 ∈ ?m.112}
                          [Meta.isDefEq] [0.010589] ❌️ fun x_1 ↦
                                (fun x_2 ↦ (fun t ↦ f₁ (x + t • v)) x_2 = (fun t ↦ f (x + t • v)) x_2)
                                  x_1 =?= fun x_1 ↦ (fun t ↦ x + t • v) x_1 ∈ ?m.112
                            [Meta.isDefEq] [0.010582] ❌️ (fun x ↦
                                    (fun t ↦ f₁ (x✝ + t • v)) x = (fun t ↦ f (x✝ + t • v)) x)
                                  x =?= (fun t ↦ x✝ + t • v) x ∈ ?m.112
                              [Meta.isDefEq] [0.010576] ❌️ (fun t ↦ f₁ (x✝ + t • v)) x =
                                    (fun t ↦ f (x✝ + t • v)) x =?= (fun t ↦ x✝ + t • v) x ∈ ?m.112
                                [Meta.isDefEq] [0.010563] ❌️ (fun t ↦ f₁ (x✝ + t • v)) x =
                                      (fun t ↦ f (x✝ + t • v))
                                        x =?= Set.instMembership.1 ?m.112 ((fun t ↦ x✝ + t • v) x)
                                  [Meta.isDefEq] [0.010550] ❌️ (fun t ↦ f₁ (x✝ + t • v)) x =
                                        (fun t ↦ f (x✝ + t • v)) x =?= Set.Mem ?m.112 ((fun t ↦ x✝ + t • v) x)
                                    [Meta.isDefEq] [0.010535] ❌️ (fun t ↦ f₁ (x✝ + t • v)) x =
                                          (fun t ↦ f (x✝ + t • v)) x =?= ?m.112 ((fun t ↦ x✝ + t • v) x)
                                      [Meta.isDefEq.assign] [0.010526] ❌️ ?m.112
                                            ((fun t ↦ x✝ + t • v)
                                              x) := (fun t ↦ f₁ (x✝ + t • v)) x = (fun t ↦ f (x✝ + t • v)) x
                                        [Meta.isDefEq] [0.010508] ❌️ (fun t ↦ x✝ + t • v)
                                              x =?= (fun t ↦ f (x✝ + t • v)) x
                                          [Meta.isDefEq] [0.010502] ❌️ x✝ + x • v =?= f (x✝ + x • v)
                                            [Meta.isDefEq] [0.010433] ❌️ instHAdd.1 x✝ (x • v) =?= f (x✝ + x • v)
                                              [Meta.isDefEq] [0.010417] ❌️ Add.add x✝ (x • v) =?= f (x✝ + x • v)
                    [Meta.isDefEq] [0.060224] ❌️ Filter.instMembership.1 (𝓝[(fun t ↦ x + t • v) ⁻¹' s] 0)
                          {x_1 |
                            (fun x_2 ↦ (fun t ↦ f₁ (x + t • v)) x_2 = (fun t ↦ f (x + t • v)) x_2)
                              x_1} =?= Filter.instMembership.1 (𝓝[(fun t ↦ x + t • v) ⁻¹' ?m.111] ?m.109)
                          ((fun t ↦ x + t • v) ⁻¹' ?m.112)
                      [Meta.isDefEq] [0.060183] ❌️ {x_1 |
                              (fun x_2 ↦ (fun t ↦ f₁ (x + t • v)) x_2 = (fun t ↦ f (x + t • v)) x_2) x_1} ∈
                            (𝓝[(fun t ↦ x + t • v) ⁻¹' s]
                                0).sets =?= (fun t ↦ x + t • v) ⁻¹' ?m.112 ∈
                            (𝓝[(fun t ↦ x + t • v) ⁻¹' ?m.111] ?m.109).sets
                        [Meta.isDefEq.delta] [0.021246] ❌️ {x_1 |
                                (fun x_2 ↦ (fun t ↦ f₁ (x + t • v)) x_2 = (fun t ↦ f (x + t • v)) x_2) x_1} ∈
                              (𝓝[(fun t ↦ x + t • v) ⁻¹' s]
                                  0).sets =?= (fun t ↦ x + t • v) ⁻¹' ?m.112 ∈
                              (𝓝[(fun t ↦ x + t • v) ⁻¹' ?m.111] ?m.109).sets
                          [Meta.isDefEq] [0.013694] ✅️ (𝓝[(fun t ↦ x + t • v) ⁻¹' s]
                                  0).sets =?= (𝓝[(fun t ↦ x + t • v) ⁻¹' ?m.111] ?m.109).sets
                            [Meta.isDefEq.delta] [0.013682] ✅️ (𝓝[(fun t ↦ x + t • v) ⁻¹' s]
                                    0).sets =?= (𝓝[(fun t ↦ x + t • v) ⁻¹' ?m.111] ?m.109).sets
                              [Meta.isDefEq] [0.013667] ✅️ 𝓝[(fun t ↦ x + t • v) ⁻¹' s]
                                    0 =?= 𝓝[(fun t ↦ x + t • v) ⁻¹' ?m.111] ?m.109
                                [Meta.isDefEq.delta] [0.013449] ✅️ 𝓝[(fun t ↦ x + t • v) ⁻¹' s]
                                      0 =?= 𝓝[(fun t ↦ x + t • v) ⁻¹' ?m.111] ?m.109
                                  [Meta.isDefEq] [0.012745] ✅️ (fun t ↦ x + t • v) ⁻¹'
                                        s =?= (fun t ↦ x + t • v) ⁻¹' ?m.111
                                    [Meta.isDefEq.delta] [0.012727] ✅️ (fun t ↦ x + t • v) ⁻¹'
                                          s =?= (fun t ↦ x + t • v) ⁻¹' ?m.111
                                      [Meta.isDefEq] [0.012137] ✅️ fun t ↦ x + t • v =?= fun t ↦ x + t • v
                                        [Meta.isDefEq] [0.011501] ✅️ x + t • v =?= x + t • v
                                          [Meta.isDefEq] [0.011142] ✅️ instHAdd.1 x (t • v) =?= instHAdd.1 x (t • v)
                                            [Meta.isDefEq] [0.011082] ✅️ Add.add x (t • v) =?= Add.add x (t • v)
                                              [Meta.isDefEq] [0.010696] ✅️ inst✝¹.toAddCommMonoid.toAddCommSemigroup.toAddCommMagma.toAdd.1
                                                    x
                                                    (t •
                                                      v) =?= NormedAddCommGroup.toENormedAddCommMonoid.toAddCommMonoid.toAddCommSemigroup.toAddCommMagma.toAdd.1
                                                    x (t • v)
                        [Meta.isDefEq] [0.038913] ❌️ Set.instMembership.1 (𝓝[(fun t ↦ x + t • v) ⁻¹' s] 0).sets
                              {x_1 |
                                (fun x_2 ↦ (fun t ↦ f₁ (x + t • v)) x_2 = (fun t ↦ f (x + t • v)) x_2)
                                  x_1} =?= Set.instMembership.1 (𝓝[(fun t ↦ x + t • v) ⁻¹' ?m.111] ?m.109).sets
                              ((fun t ↦ x + t • v) ⁻¹' ?m.112)
                          [Meta.isDefEq] [0.038878] ❌️ (𝓝[(fun t ↦ x + t • v) ⁻¹' s] 0).sets.Mem
                                {x_1 |
                                  (fun x_2 ↦ (fun t ↦ f₁ (x + t • v)) x_2 = (fun t ↦ f (x + t • v)) x_2)
                                    x_1} =?= (𝓝[(fun t ↦ x + t • v) ⁻¹' ?m.111] ?m.109).sets.Mem
                                ((fun t ↦ x + t • v) ⁻¹' ?m.112)
                            [Meta.isDefEq] [0.031752] ❌️ (𝓝[(fun t ↦ x + t • v) ⁻¹' s] 0).sets
                                  {x_1 |
                                    (fun x_2 ↦ (fun t ↦ f₁ (x + t • v)) x_2 = (fun t ↦ f (x + t • v)) x_2)
                                      x_1} =?= (𝓝[(fun t ↦ x + t • v) ⁻¹' ?m.111] ?m.109).sets
                                  ((fun t ↦ x + t • v) ⁻¹' ?m.112)
                              [Meta.isDefEq] [0.026255] ❌️ (𝓝[(fun t ↦ x + t • v) ⁻¹' s] 0).1
                                    {x_1 |
                                      (fun x_2 ↦ (fun t ↦ f₁ (x + t • v)) x_2 = (fun t ↦ f (x + t • v)) x_2)
                                        x_1} =?= (𝓝[(fun t ↦ x + t • v) ⁻¹' ?m.111] ?m.109).1
                                    ((fun t ↦ x + t • v) ⁻¹' ?m.112)
                                [Meta.isDefEq] [0.026153] ❌️ {s_1 |
                                        ∃ a ∈ 𝓝 0, ∃ b ∈ 𝓟 ((fun t ↦ x + t • v) ⁻¹' s), s_1 = a ∩ b}
                                      {x_1 |
                                        (fun x_2 ↦ (fun t ↦ f₁ (x + t • v)) x_2 = (fun t ↦ f (x + t • v)) x_2)
                                          x_1} =?= {s |
                                        ∃ a ∈ 𝓝 ?m.109, ∃ b ∈ 𝓟 ((fun t ↦ x + t • v) ⁻¹' ?m.111), s = a ∩ b}
                                      ((fun t ↦ x + t • v) ⁻¹' ?m.112)
                                  [Meta.isDefEq] [0.018272] ❌️ (fun s_1 ↦
                                          ∃ a ∈ 𝓝 0, ∃ b ∈ 𝓟 ((fun t ↦ x + t • v) ⁻¹' s), s_1 = a ∩ b)
                                        {x_1 |
                                          (fun x_2 ↦ (fun t ↦ f₁ (x + t • v)) x_2 = (fun t ↦ f (x + t • v)) x_2)
                                            x_1} =?= (fun s ↦
                                          ∃ a ∈ 𝓝 ?m.109, ∃ b ∈ 𝓟 ((fun t ↦ x + t • v) ⁻¹' ?m.111), s = a ∩ b)
                                        ((fun t ↦ x + t • v) ⁻¹' ?m.112)
                                    [Meta.isDefEq] [0.018265] ❌️ ∃ a ∈ 𝓝 0,
                                          ∃ b ∈ 𝓟 ((fun t ↦ x + t • v) ⁻¹' s),
                                            {x_1 |
                                                (fun x_2 ↦ (fun t ↦ f₁ (x + t • v)) x_2 = (fun t ↦ f (x + t • v)) x_2)
                                                  x_1} =
                                              a ∩
                                                b =?= ∃ a ∈ 𝓝 ?m.109,
                                          ∃ b ∈ 𝓟 ((fun t ↦ x + t • v) ⁻¹' ?m.111),
                                            (fun t ↦ x + t • v) ⁻¹' ?m.112 = a ∩ b
                                      [Meta.isDefEq] [0.018233] ❌️ fun a ↦
                                            a ∈ 𝓝 0 ∧
                                              ∃ b ∈ 𝓟 ((fun t ↦ x + t • v) ⁻¹' s),
                                                {x_1 |
                                                    (fun x_2 ↦
                                                        (fun t ↦ f₁ (x + t • v)) x_2 = (fun t ↦ f (x + t • v)) x_2)
                                                      x_1} =
                                                  a ∩
                                                    b =?= fun a ↦
                                            a ∈ 𝓝 ?m.109 ∧
                                              ∃ b ∈ 𝓟 ((fun t ↦ x + t • v) ⁻¹' ?m.111),
                                                (fun t ↦ x + t • v) ⁻¹' ?m.112 = a ∩ b
                                        [Meta.isDefEq] [0.018220] ❌️ a ∈ 𝓝 0 ∧
                                              ∃ b ∈ 𝓟 ((fun t ↦ x + t • v) ⁻¹' s),
                                                {x_1 |
                                                    (fun x_2 ↦
                                                        (fun t ↦ f₁ (x + t • v)) x_2 = (fun t ↦ f (x + t • v)) x_2)
                                                      x_1} =
                                                  a ∩
                                                    b =?= a ∈ 𝓝 ?m.109 ∧
                                              ∃ b ∈ 𝓟 ((fun t ↦ x + t • v) ⁻¹' ?m.111),
                                                (fun t ↦ x + t • v) ⁻¹' ?m.112 = a ∩ b
                                          [Meta.isDefEq] [0.018135] ❌️ ∃ b ∈ 𝓟 ((fun t ↦ x + t • v) ⁻¹' s),
                                                {x_1 |
                                                    (fun x_2 ↦
                                                        (fun t ↦ f₁ (x + t • v)) x_2 = (fun t ↦ f (x + t • v)) x_2)
                                                      x_1} =
                                                  a ∩
                                                    b =?= ∃ b ∈ 𝓟 ((fun t ↦ x + t • v) ⁻¹' ?m.111),
                                                (fun t ↦ x + t • v) ⁻¹' ?m.112 = a ∩ b
                                            [Meta.isDefEq] [0.018113] ❌️ fun b ↦
                                                  b ∈ 𝓟 ((fun t ↦ x + t • v) ⁻¹' s) ∧
                                                    {x_1 |
                                                        (fun x_2 ↦
                                                            (fun t ↦ f₁ (x + t • v)) x_2 = (fun t ↦ f (x + t • v)) x_2)
                                                          x_1} =
                                                      a ∩
                                                        b =?= fun b ↦
                                                  b ∈ 𝓟 ((fun t ↦ x + t • v) ⁻¹' ?m.111) ∧
                                                    (fun t ↦ x + t • v) ⁻¹' ?m.112 = a ∩ b
                                              [Meta.isDefEq] [0.018103] ❌️ b ∈ 𝓟 ((fun t ↦ x + t • v) ⁻¹' s) ∧
                                                    {x_1 |
                                                        (fun x_2 ↦
                                                            (fun t ↦ f₁ (x + t • v)) x_2 = (fun t ↦ f (x + t • v)) x_2)
                                                          x_1} =
                                                      a ∩
                                                        b =?= b ∈ 𝓟 ((fun t ↦ x + t • v) ⁻¹' ?m.111) ∧
                                                    (fun t ↦ x + t • v) ⁻¹' ?m.112 = a ∩ b
                                                [Meta.isDefEq] [0.010937] ❌️ {x_1 |
                                                        (fun x_2 ↦
                                                            (fun t ↦ f₁ (x + t • v)) x_2 = (fun t ↦ f (x + t • v)) x_2)
                                                          x_1} =
                                                      a ∩ b =?= (fun t ↦ x + t • v) ⁻¹' ?m.112 = a ∩ b
                                                  [Meta.isDefEq] [0.010782] ❌️ {x_1 |
                                                        (fun x_2 ↦
                                                            (fun t ↦ f₁ (x + t • v)) x_2 = (fun t ↦ f (x + t • v)) x_2)
                                                          x_1} =?= (fun t ↦ x + t • v) ⁻¹' ?m.112
                                                    [Meta.isDefEq] [0.010758] ❌️ {x_1 |
                                                          (fun x_2 ↦
                                                              (fun t ↦ f₁ (x + t • v)) x_2 =
                                                                (fun t ↦ f (x + t • v)) x_2)
                                                            x_1} =?= {x_1 | (fun t ↦ x + t • v) x_1 ∈ ?m.112}
          [Elab.step] [0.044069] simp
            [Elab.step] [0.044055] simp
              [Elab.step] [0.044043] simp
                [Meta.isDefEq] [0.036423] ✅️ 0 • ?m =?= 0 • v
                  [Meta.isDefEq] [0.036268] ✅️ instHSMul =?= instHSMul
                    [Meta.isDefEq.delta] [0.036247] ✅️ instHSMul =?= instHSMul
                      [Meta.synthInstance] [0.035497] ✅️ SMulWithZero 𝕜 E
                        [Meta.synthInstance] [0.020865] ✅️ apply MulActionWithZero.toSMulWithZero to SMulWithZero 𝕜 E
                          [Meta.synthInstance.tryResolve] [0.020824] ✅️ SMulWithZero 𝕜 E ≟ SMulWithZero 𝕜 E
                            [Meta.isDefEq] [0.017188] ✅️ ?m.120 =?= MulActionWithZero.toSMulWithZero 𝕜 E
                              [Meta.isDefEq.assign] [0.017185] ✅️ ?m.120 := MulActionWithZero.toSMulWithZero 𝕜 E
                                [Meta.isDefEq.assign.checkTypes] [0.017168] ✅️ (?m.120 : SMulWithZero 𝕜
                                      E) := (MulActionWithZero.toSMulWithZero 𝕜 E : SMulWithZero 𝕜 E)
                                  [Meta.isDefEq] [0.017165] ✅️ SMulWithZero 𝕜 E =?= SMulWithZero 𝕜 E
                                    [Meta.synthInstance] [0.014114] ✅️ Zero E
info: Mathlib/Analysis/Calculus/LineDeriv/Basic.lean:347:6: [Elab.async] [0.022735] Lean.addDecl
  [Kernel] [0.022289] ✅️ typechecking declarations [HasLineDerivWithinAt.congr_of_eventuallyEq]
Build completed successfully (1850 jobs).
```

### Trace profiling of `HasLineDerivWithinAt.congr_of_eventuallyEq` after PR 28205
```diff
diff --git a/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean b/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
index 97ba668da2..5ac4634382 100644
--- a/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
+++ b/Mathlib/Analysis/Calculus/LineDeriv/Basic.lean
@@ -343,11 +343,10 @@ theorem Filter.EventuallyEq.lineDifferentiableWithinAt_iff_of_mem
     LineDifferentiableWithinAt 𝕜 f₀ s x v ↔ LineDifferentiableWithinAt 𝕜 f₁ s x v :=
   h.lineDifferentiableWithinAt_iff (h.eq_of_nhdsWithin hx)
 
+set_option trace.profiler true in
 lemma HasLineDerivWithinAt.congr_of_eventuallyEq (hf : HasLineDerivWithinAt 𝕜 f f' s x v)
-    (h'f : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) : HasLineDerivWithinAt 𝕜 f₁ f' s x v := by
-  apply HasDerivWithinAt.congr_of_eventuallyEq hf _ (by simp [hx])
-  have A : Continuous (fun (t : 𝕜) ↦ x + t • v) := by fun_prop
-  exact A.continuousWithinAt.preimage_mem_nhdsWithin'' h'f (by simp)
+    (h'f : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) : HasLineDerivWithinAt 𝕜 f₁ f' s x v :=
+  (EventuallyEq.hasLineDerivWithinAt_iff (EventuallyEq.symm h'f.eventually) hx.symm).mp hf
 
 theorem HasLineDerivAt.congr_of_eventuallyEq (h : HasLineDerivAt 𝕜 f f' x v) (h₁ : f₁ =ᶠ[𝓝 x] f) :
     HasLineDerivAt 𝕜 f₁ f' x v := by
```
```
ℹ [1850/1850] Built Mathlib.Analysis.Calculus.LineDeriv.Basic (6.8s)
info: Mathlib/Analysis/Calculus/LineDeriv/Basic.lean:347:0: [Elab.command] [0.053877] theorem congr_of_eventuallyEq (hf : HasLineDerivWithinAt 𝕜 f f' s x v) (h'f : f₁ =ᶠ[𝓝[s] x] f)
        (hx : f₁ x = f x) : HasLineDerivWithinAt 𝕜 f₁ f' s x v :=
      (EventuallyEq.hasLineDerivWithinAt_iff (EventuallyEq.symm h'f.eventually) hx.symm).mp hf
  [Elab.step] [0.038023] expected type: Type (max u_2 u_3), term
      E →L[𝕜] F
    [Elab.step] [0.037231] expected type: Type (max u_2 u_3), term
        ContinuousLinearMap✝ (RingHom.id✝ 𝕜) E F
  [Elab.definition.header] [0.010772] HasLineDerivWithinAt.congr_of_eventuallyEq
info: Mathlib/Analysis/Calculus/LineDeriv/Basic.lean:347:0: [Elab.command] [0.054140] theorem HasLineDerivWithinAt.congr_of_eventuallyEq (hf : HasLineDerivWithinAt 𝕜 f f' s x v)
        (h'f : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) : HasLineDerivWithinAt 𝕜 f₁ f' s x v :=
      (EventuallyEq.hasLineDerivWithinAt_iff (EventuallyEq.symm h'f.eventually) hx.symm).mp hf
info: Mathlib/Analysis/Calculus/LineDeriv/Basic.lean:347:0: [Elab.command] [0.054209] lemma HasLineDerivWithinAt.congr_of_eventuallyEq (hf : HasLineDerivWithinAt 𝕜 f f' s x v)
        (h'f : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) : HasLineDerivWithinAt 𝕜 f₁ f' s x v :=
      (EventuallyEq.hasLineDerivWithinAt_iff (EventuallyEq.symm h'f.eventually) hx.symm).mp hf
Build completed successfully (1850 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
