### PR TITLE
[Merged by Bors] - feat(RingTheory/IntegralClosure/Algebra/Basic): Move IsIntegral.tmul and Algebra.IsIntegral.tensorProduct

### DIFF
--- a/Mathlib/RingTheory/IntegralClosure/Algebra/Basic.lean
+++ b/Mathlib/RingTheory/IntegralClosure/Algebra/Basic.lean
@@ -6,7 +6,6 @@ Authors: Kenny Lau
 import Mathlib.LinearAlgebra.Matrix.Charpoly.LinearMap
 import Mathlib.RingTheory.IntegralClosure.Algebra.Defs
 import Mathlib.RingTheory.IntegralClosure.IsIntegral.Basic
-import Mathlib.RingTheory.TensorProduct.Basic
 
 /-!
 # Integral closure of a subring.

--- a/Mathlib/RingTheory/IntegralClosure/Algebra/Basic.lean
+++ b/Mathlib/RingTheory/IntegralClosure/Algebra/Basic.lean
@@ -236,14 +236,14 @@ variable {R A : Type*} [CommRing R] [CommRing A] [Algebra R A]
 variable (B : Type*) [CommRing B] [Algebra R B]
 
 open scoped TensorProduct in
-lemma IsIntegral.base_change [Algebra.IsIntegral R A] :
+lemma Algebra.IsIntegral.base_change [Algebra.IsIntegral R A] :
     Algebra.IsIntegral B (B ⊗[R] A) := by
   refine ⟨fun x => ?_⟩
   induction x using TensorProduct.induction_on with
   | zero => exact isIntegral_zero
   | tmul b a =>
     obtain ⟨p, hp_monic, hp_eval⟩ := Algebra.IsIntegral.isIntegral (R := R) a
-    have a_int : IsIntegral B ((1 : B) ⊗ₜ[R] a) := by
+    have ha : IsIntegral B ((1 : B) ⊗ₜ[R] a) := by
       refine ⟨p.map (algebraMap R B), hp_monic.map (algebraMap R B), eval₂_map (p := p)
         (algebraMap R B) _ ((1 : B) ⊗ₜ[R] a) ▸ Eq.symm ?_⟩
       have diamond := (IsScalarTower.algebraMap_eq R B (B ⊗[R] A)) ▸
@@ -251,8 +251,8 @@ lemma IsIntegral.base_change [Algebra.IsIntegral R A] :
       rw [diamond, ←map_zero (@algebraMap A (B ⊗[R] A) _ _ Algebra.TensorProduct.rightAlgebra),
         ←hp_eval]
       exact hom_eval₂ _ _ _ a
-    have b_int : IsIntegral B (b ⊗ₜ[R] (1 : A)) := isIntegral_algebraMap
-    simpa only [Algebra.TensorProduct.tmul_mul_tmul, mul_one, one_mul] using b_int.mul a_int
+    have hb : IsIntegral B (b ⊗ₜ[R] (1 : A)) := isIntegral_algebraMap
+    simpa only [Algebra.TensorProduct.tmul_mul_tmul, mul_one, one_mul] using hb.mul ha
   | add _ _ hx hy => exact hx.add hy
 
 end BaseChange

--- a/Mathlib/RingTheory/IntegralClosure/Algebra/Basic.lean
+++ b/Mathlib/RingTheory/IntegralClosure/Algebra/Basic.lean
@@ -232,19 +232,22 @@ end
 
 section TensorProduct
 
-variable {R A B : Type*} [CommRing R] [CommRing A] [CommRing B] [Algebra R A] [Algebra R B]
+variable {R A B : Type*} [CommRing R] [CommRing A]
 
 open TensorProduct
 
-theorem IsIntegral.tmul (x : A) {y : B} (h : IsIntegral R y) : IsIntegral A (x ⊗ₜ[R] y) := by
+theorem IsIntegral.tmul [Ring B] [Algebra R A] [Algebra R B]
+    (x : A) {y : B} (h : IsIntegral R y) : IsIntegral A (x ⊗ₜ[R] y) := by
   rw [← mul_one x, ← smul_eq_mul, ← smul_tmul']
   exact smul _ (h.map_of_comp_eq (algebraMap R A)
     (Algebra.TensorProduct.includeRight (R := R) (A := A) (B := B)).toRingHom
     Algebra.TensorProduct.includeLeftRingHom_comp_algebraMap)
 
-variable (R A B) [int : Algebra.IsIntegral R B]
+variable (R A B)
 
-instance IsIntegral.tensorProduct : Algebra.IsIntegral A (A ⊗[R] B) where
+instance Algebra.IsIntegral.tensorProduct [CommRing B]
+    [Algebra R A] [Algebra R B] [int : Algebra.IsIntegral R B] :
+    Algebra.IsIntegral A (A ⊗[R] B) where
   isIntegral p := p.induction_on isIntegral_zero (fun _ s ↦ .tmul _ <| int.1 s) (fun _ _ ↦ .add)
 
 end TensorProduct

--- a/Mathlib/RingTheory/IntegralClosure/Algebra/Basic.lean
+++ b/Mathlib/RingTheory/IntegralClosure/Algebra/Basic.lean
@@ -6,6 +6,7 @@ Authors: Kenny Lau
 import Mathlib.LinearAlgebra.Matrix.Charpoly.LinearMap
 import Mathlib.RingTheory.IntegralClosure.Algebra.Defs
 import Mathlib.RingTheory.IntegralClosure.IsIntegral.Basic
+import Mathlib.RingTheory.TensorProduct.Basic
 
 /-!
 # Integral closure of a subring.
@@ -228,3 +229,30 @@ instance Algebra.IsIntegral.prod [Algebra.IsIntegral R A] [Algebra.IsIntegral R 
     (Algebra.isIntegral_def.mp ‹_› x.1).pair (Algebra.isIntegral_def.mp ‹_› x.2)
 
 end
+
+section BaseChange
+
+variable {R A : Type*} [CommRing R] [CommRing A] [Algebra R A]
+variable (B : Type*) [CommRing B] [Algebra R B]
+
+open scoped TensorProduct in
+lemma IsIntegral.base_change [Algebra.IsIntegral R A] :
+    Algebra.IsIntegral B (B ⊗[R] A) := by
+  refine ⟨fun x => ?_⟩
+  induction x using TensorProduct.induction_on with
+  | zero => exact isIntegral_zero
+  | tmul b a =>
+    obtain ⟨p, hp_monic, hp_eval⟩ := Algebra.IsIntegral.isIntegral (R := R) a
+    have a_int : IsIntegral B ((1 : B) ⊗ₜ[R] a) := by
+      refine ⟨p.map (algebraMap R B), hp_monic.map (algebraMap R B), eval₂_map (p := p)
+        (algebraMap R B) _ ((1 : B) ⊗ₜ[R] a) ▸ Eq.symm ?_⟩
+      have diamond := (IsScalarTower.algebraMap_eq R B (B ⊗[R] A)) ▸
+        (@IsScalarTower.algebraMap_eq _ _ _ _ _ _ _ Algebra.TensorProduct.rightAlgebra _ _)
+      rw [diamond, ←map_zero (@algebraMap A (B ⊗[R] A) _ _ Algebra.TensorProduct.rightAlgebra),
+        ←hp_eval]
+      exact hom_eval₂ _ _ _ a
+    have b_int : IsIntegral B (b ⊗ₜ[R] (1 : A)) := isIntegral_algebraMap
+    simpa only [Algebra.TensorProduct.tmul_mul_tmul, mul_one, one_mul] using b_int.mul a_int
+  | add _ _ hx hy => exact hx.add hy
+
+end BaseChange

--- a/Mathlib/RingTheory/IntegralClosure/IsIntegralClosure/Basic.lean
+++ b/Mathlib/RingTheory/IntegralClosure/IsIntegralClosure/Basic.lean
@@ -249,21 +249,9 @@ theorem IsIntegral.det {n : Type*} [Fintype n] [DecidableEq n] {M : Matrix n n A
 theorem IsIntegral.pow_iff {x : A} {n : ℕ} (hn : 0 < n) : IsIntegral R (x ^ n) ↔ IsIntegral R x :=
   ⟨IsIntegral.of_pow hn, fun hx ↦ hx.pow n⟩
 
-open TensorProduct
-
-theorem IsIntegral.tmul (x : A) {y : B} (h : IsIntegral R y) : IsIntegral A (x ⊗ₜ[R] y) := by
-  rw [← mul_one x, ← smul_eq_mul, ← smul_tmul']
-  exact smul _ (h.map_of_comp_eq (algebraMap R A)
-    (Algebra.TensorProduct.includeRight (R := R) (A := A) (B := B)).toRingHom
-    Algebra.TensorProduct.includeLeftRingHom_comp_algebraMap)
-
 section Pushout
 
 variable (R S A) [Algebra R S] [int : Algebra.IsIntegral R S]
-
-instance Algebra.IsIntegral.tensorProduct : Algebra.IsIntegral A (A ⊗[R] S) where
-  isIntegral p := p.induction_on isIntegral_zero (fun _ s ↦ .tmul _ <| int.1 s) (fun _ _ ↦ .add)
-
 variable (SA : Type*) [CommRing SA] [Algebra R SA] [Algebra S SA] [Algebra A SA]
   [IsScalarTower R S SA] [IsScalarTower R A SA]
 


### PR DESCRIPTION
This PR moves `IsIntegral.tmul` and `Algebra.IsIntegral.tensorProduct` from [Mathlib/RingTheory/IntegralClosure/IsIntegralClosure/Basic.lean](https://github.com/leanprover-community/mathlib4/blob/00a5ef39c56c192564ce42fbc20fc3591669364b/Mathlib/RingTheory/IntegralClosure/IsIntegralClosure/Basic.lean#L254-L265) to [Mathlib/RingTheory/IntegralClosure/Algebra/Basic.lean](https://github.com/leanprover-community/mathlib4/blob/00a5ef39c56c192564ce42fbc20fc3591669364b/Mathlib/RingTheory/IntegralClosure/Algebra/Basic.lean).