### PR TITLE
[Merged by Bors] - chore: change statement of IsStableUnderBaseChange.mk to use algebraMap

### DIFF
--- a/Mathlib/RingTheory/RingHom/Flat.lean
+++ b/Mathlib/RingTheory/RingHom/Flat.lean
@@ -63,11 +63,8 @@ lemma respectsIso : RespectsIso Flat := by
 lemma isStableUnderBaseChange : IsStableUnderBaseChange Flat := by
   apply IsStableUnderBaseChange.mk respectsIso
   introv h
-  replace h : Module.Flat R T := by
-    rw [RingHom.Flat] at h; convert h; ext; simp_rw [Algebra.smul_def]; rfl
-  suffices Module.Flat S (S ⊗[R] T) by
-    rw [RingHom.Flat]; convert this; congr; ext; simp_rw [Algebra.smul_def]; rfl
-  exact inferInstance
+  rw [flat_algebraMap_iff] at h ⊢
+  infer_instance
 
 lemma holdsForLocalizationAway : HoldsForLocalizationAway Flat := by
   introv R h

--- a/Mathlib/RingTheory/RingHom/Locally.lean
+++ b/Mathlib/RingTheory/RingHom/Locally.lean
@@ -307,15 +307,10 @@ lemma locally_isStableUnderBaseChange (hPi : RespectsIso P) (hPb : IsStableUnder
         (S := Submonoid.powers a.val) (A := Localization.Away a.val)]
       exact Algebra.IsPushout.out
   · intro a
-    have : (algebraMap (S ⊗[R] T) (S ⊗[R] Localization.Away a.val)).comp
-        Algebra.TensorProduct.includeLeftRingHom =
-        Algebra.TensorProduct.includeLeftRingHom := by
-      ext x
-      simp [RingHom.algebraMap_toAlgebra]
-    rw [this]
+    rw [← IsScalarTower.algebraMap_eq]
     apply hPb R (Localization.Away a.val)
-    rw [IsScalarTower.algebraMap_eq R T (Localization.Away a.val)]
-    apply hs a a.property
+    rw [IsScalarTower.algebraMap_eq R T]
+    exact hs a a.property
 
 /-- If `P` is preserved by localization away, then so is `Locally P`. -/
 lemma locally_localizationAwayPreserves (hPl : LocalizationAwayPreserves P) :

--- a/Mathlib/RingTheory/RingHom/Smooth.lean
+++ b/Mathlib/RingTheory/RingHom/Smooth.lean
@@ -51,8 +51,7 @@ lemma FormallySmooth.respectsIso : RespectsIso @FormallySmooth :=
 
 lemma FormallySmooth.isStableUnderBaseChange : IsStableUnderBaseChange @FormallySmooth := by
   refine .mk respectsIso ?_
-  intros R S T _ _ _ _ _ H
-  change (algebraMap _ _).FormallySmooth
+  introv H
   rw [formallySmooth_algebraMap] at H ⊢
   infer_instance
 

--- a/Mathlib/RingTheory/RingHom/Unramified.lean
+++ b/Mathlib/RingTheory/RingHom/Unramified.lean
@@ -49,8 +49,7 @@ lemma respectsIso :
 lemma isStableUnderBaseChange :
     IsStableUnderBaseChange FormallyUnramified := by
   refine .mk respectsIso ?_
-  intros R S T _ _ _ _ _ h
-  change (algebraMap _ _).FormallyUnramified
+  introv H
   rw [formallyUnramified_algebraMap] at h ⊢
   infer_instance
 

--- a/Mathlib/RingTheory/RingHom/Unramified.lean
+++ b/Mathlib/RingTheory/RingHom/Unramified.lean
@@ -50,7 +50,7 @@ lemma isStableUnderBaseChange :
     IsStableUnderBaseChange FormallyUnramified := by
   refine .mk respectsIso ?_
   introv H
-  rw [formallyUnramified_algebraMap] at h ⊢
+  rw [formallyUnramified_algebraMap] at H ⊢
   infer_instance
 
 lemma holdsForLocalizationAway :

--- a/Mathlib/RingTheory/RingHomProperties.lean
+++ b/Mathlib/RingTheory/RingHomProperties.lean
@@ -136,37 +136,22 @@ def IsStableUnderBaseChange : Prop :=
         ∀ [Algebra.IsPushout R S R' S'], P (algebraMap R S) → P (algebraMap R' S')
 
 theorem IsStableUnderBaseChange.mk (h₁ : RespectsIso @P)
-    (h₂ :
-      ∀ ⦃R S T⦄ [CommRing R] [CommRing S] [CommRing T],
-        ∀ [Algebra R S] [Algebra R T],
-          P (algebraMap R T) →
-            P (Algebra.TensorProduct.includeLeftRingHom : S →+* TensorProduct R S T)) :
+    (h₂ : ∀ ⦃R S T⦄ [CommRing R] [CommRing S] [CommRing T] [Algebra R S] [Algebra R T],
+      P (algebraMap R T) → P (algebraMap S (S ⊗[R] T))) :
     IsStableUnderBaseChange @P := by
   introv R h H
   let e := h.symm.1.equiv
-  let f' :=
-    Algebra.TensorProduct.productMap (IsScalarTower.toAlgHom R R' S')
-      (IsScalarTower.toAlgHom R S S')
-  have : ∀ x, e x = f' x := by
-    intro x
-    change e.toLinearMap.restrictScalars R x = f'.toLinearMap x
-    congr 1
-    apply TensorProduct.ext'
-    intro x y
-    simp [e, f', IsBaseChange.equiv_tmul, Algebra.smul_def]
-  -- Porting Note: This had a lot of implicit inferences which didn't resolve anymore.
-  -- Added those in
-  convert h₁.1 (_ : R' →+* TensorProduct R R' S) (_ : TensorProduct R R' S ≃+* S')
-      (h₂ H : P (_ : R' →+* TensorProduct R R' S))
-  swap
-  · refine { e with map_mul' := fun x y => ?_ }
-    change e (x * y) = e x * e y
-    simp_rw [this]
-    exact map_mul f' _ _
-  · ext x
-    change _ = e (x ⊗ₜ[R] 1)
-    -- Porting note: Had `dsimp only [e]` here, which didn't work anymore
-    rw [h.symm.1.equiv_tmul, Algebra.smul_def, AlgHom.toLinearMap_apply, map_one, mul_one]
+  let f' := Algebra.TensorProduct.productMap (IsScalarTower.toAlgHom R R' S')
+    (IsScalarTower.toAlgHom R S S')
+  have hef (x : _) : e x = f' x := by
+    suffices e.toLinearMap.restrictScalars R = f'.toLinearMap from congr($this x)
+    exact ext' fun x y ↦ by simp [e, f', IsBaseChange.equiv_tmul, Algebra.smul_def]
+  have hemul (x y : _) : e (x * y) = e x * e y := by simp_rw [hef, map_mul]
+  convert h₁.1 _ { e with map_mul' := hemul } (h₂ H)
+  ext x
+  change _ = e (x ⊗ₜ[R] 1)
+  -- Porting note: Had `dsimp only [e]` here, which didn't work anymore
+  rw [h.symm.1.equiv_tmul, Algebra.smul_def, AlgHom.toLinearMap_apply, map_one, mul_one]
 
 attribute [local instance] Algebra.TensorProduct.rightAlgebra
 
@@ -179,7 +164,7 @@ theorem IsStableUnderBaseChange.pushout_inl (hP : RingHom.IsStableUnderBaseChang
       colimit.isoColimitCocone_ι_inv ⟨_, CommRingCat.pushoutCoconeIsColimit R S T⟩ WalkingSpan.left,
     CommRingCat.hom_comp, hP'.cancel_right_isIso]
   dsimp only [CommRingCat.pushoutCocone_inl, PushoutCocone.ι_app_left]
-  apply hP R T S (TensorProduct R S T)
+  apply hP R T S (S ⊗[R] T)
   exact H
 
 lemma IsStableUnderBaseChange.and (hP : IsStableUnderBaseChange P)


### PR DESCRIPTION
This PR changes the assumption of `IsStableUnderBaseChange.mk` from:
```lean
∀ ⦃R S T⦄ [CommRing R] [CommRing S] [CommRing T],
        ∀ [Algebra R S] [Algebra R T],
          P (algebraMap R T) →
            P (Algebra.TensorProduct.includeLeftRingHom : S →+* TensorProduct R S T)
```
To:
```lean
∀ ⦃R S T⦄ [CommRing R] [CommRing S] [CommRing T] [Algebra R S] [Algebra R T],
      P (algebraMap R T) → P (algebraMap S (S ⊗[R] T))
```
i.e. we now use `algebraMap S (S ⊗[R] T)` instead of `Algebra.TensorProduct.includeLeftRingHom` (which are defeq), because we have more API for the former. This allows some proofs to be shorter.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
