### PR TITLE
feat(Data/Finset): `Multiset.eq_of_le_of_card_eq` and `Finset.eq_of_subet_of_card_eq`

### DIFF
--- a/Mathlib/Data/Finset/Card.lean
+++ b/Mathlib/Data/Finset/Card.lean
@@ -267,7 +267,7 @@ theorem eq_of_subset_of_card_le {s t : Finset α} (h : s ⊆ t) (h₂ : #t ≤ #
   eq_of_veq <| Multiset.eq_of_le_of_card_le (val_le_iff.mpr h) h₂
 
 theorem eq_of_subset_of_card_eq {s t : Finset α} (h : s ⊆ t) (h₂ : #s = #t) : s = t :=
-  eq_of_subset_of_card_le h (le_of_eq h₂.symm)
+  eq_of_subset_of_card_le h h₂.ge
 
 theorem eq_iff_card_le_of_subset (hst : s ⊆ t) : #t ≤ #s ↔ s = t :=
   ⟨eq_of_subset_of_card_le hst, (ge_of_eq <| congr_arg _ ·)⟩

--- a/Mathlib/Data/Finset/Card.lean
+++ b/Mathlib/Data/Finset/Card.lean
@@ -266,6 +266,9 @@ theorem card_filter_le (s : Finset α) (p : α → Prop) [DecidablePred p] :
 theorem eq_of_subset_of_card_le {s t : Finset α} (h : s ⊆ t) (h₂ : #t ≤ #s) : s = t :=
   eq_of_veq <| Multiset.eq_of_le_of_card_le (val_le_iff.mpr h) h₂
 
+theorem eq_of_subset_of_card_eq {s t : Finset α} (h : s ⊆ t) (h₂ : #s = #t) : s = t :=
+  eq_of_subset_of_card_le h (le_of_eq h₂.symm)
+
 theorem eq_iff_card_le_of_subset (hst : s ⊆ t) : #t ≤ #s ↔ s = t :=
   ⟨eq_of_subset_of_card_le hst, (ge_of_eq <| congr_arg _ ·)⟩
 

--- a/Mathlib/Data/Multiset/Defs.lean
+++ b/Mathlib/Data/Multiset/Defs.lean
@@ -229,6 +229,9 @@ theorem card_le_card {s t : Multiset α} (h : s ≤ t) : card s ≤ card t :=
 theorem eq_of_le_of_card_le {s t : Multiset α} (h : s ≤ t) : card t ≤ card s → s = t :=
   leInductionOn h fun s h₂ => congr_arg _ <| s.eq_of_length_le h₂
 
+theorem eq_of_le_of_card_eq {s t : Multiset α} (h : s ≤ t) (h₂ : s.card = t.card) : s = t :=
+  eq_of_le_of_card_le h (le_of_eq h₂.symm)
+
 @[gcongr]
 theorem card_lt_card {s t : Multiset α} (h : s < t) : card s < card t :=
   lt_of_not_ge fun h₂ => _root_.ne_of_lt h <| eq_of_le_of_card_le (le_of_lt h) h₂

--- a/Mathlib/Data/Multiset/Defs.lean
+++ b/Mathlib/Data/Multiset/Defs.lean
@@ -230,7 +230,7 @@ theorem eq_of_le_of_card_le {s t : Multiset α} (h : s ≤ t) : card t ≤ card 
   leInductionOn h fun s h₂ => congr_arg _ <| s.eq_of_length_le h₂
 
 theorem eq_of_le_of_card_eq {s t : Multiset α} (h : s ≤ t) (h₂ : s.card = t.card) : s = t :=
-  eq_of_le_of_card_le h (le_of_eq h₂.symm)
+  eq_of_le_of_card_le h h₂.ge
 
 @[gcongr]
 theorem card_lt_card {s t : Multiset α} (h : s < t) : card s < card t :=


### PR DESCRIPTION
As the conditions `s ⊆ t` for `Finset` and `s ≤ t` for `Multiset` both imply `card s ≤ card t`, the conditions `card t ≤ card s` in both `Finset.eq_of_subset_of_card_le` and `Multiset.eq_of_le_of_card_le` can be specialized to `card s = card t`, and due to this I'd argue `card s = card t` might be more common than `card t ≤ card s` in some cases. A similar theorem `Sublist.eq_of_length` for `Sublist` is already available in Lean. Adding these two theorems can aid proof search in such cases.