### PR TITLE
[Merged by Bors] - chore(Algebra/Order): generalize

### DIFF
--- a/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Unbundled/Basic.lean
@@ -351,6 +351,10 @@ variable [MonoidWithZero M₀]
 section Preorder
 variable [Preorder M₀] {a b : M₀} {m n : ℕ}
 
+@[simp] lemma pow_succ_nonneg [PosMulMono M₀] (ha : 0 ≤ a) : ∀ n, 0 ≤ a ^ (n + 1)
+  | 0 => (pow_one a).symm ▸ ha
+  | _ + 1 => pow_succ a _ ▸ mul_nonneg (pow_succ_nonneg ha _) ha
+
 @[simp] lemma pow_nonneg [ZeroLEOneClass M₀] [PosMulMono M₀] (ha : 0 ≤ a) : ∀ n, 0 ≤ a ^ n
   | 0 => pow_zero a ▸ zero_le_one
   | n + 1 => pow_succ a n ▸ mul_nonneg (pow_nonneg ha _) ha
@@ -442,13 +446,14 @@ lemma Bound.le_self_pow_of_pos [ZeroLEOneClass M₀] [PosMulMono M₀] (ha : 1 �
     a ≤ a ^ n := le_self_pow₀ ha hn.ne'
 
 @[mono, gcongr, bound]
-theorem pow_le_pow_left₀ [ZeroLEOneClass M₀] [PosMulMono M₀] [MulPosMono M₀]
+theorem pow_le_pow_left₀ [PosMulMono M₀] [MulPosMono M₀]
     (ha : 0 ≤ a) (hab : a ≤ b) : ∀ n, a ^ n ≤ b ^ n
   | 0 => by simp
-  | n + 1 => by simpa only [pow_succ']
-      using mul_le_mul hab (pow_le_pow_left₀ ha hab _) (pow_nonneg ha _) (ha.trans hab)
+  | 1 => by simpa using hab
+  | n + 2 => by simpa only [pow_succ']
+      using mul_le_mul hab (pow_le_pow_left₀ ha hab _) (pow_succ_nonneg ha _) (ha.trans hab)
 
-lemma pow_left_monotoneOn [ZeroLEOneClass M₀] [PosMulMono M₀] [MulPosMono M₀] :
+lemma pow_left_monotoneOn [PosMulMono M₀] [MulPosMono M₀] :
     MonotoneOn (fun a : M₀ ↦ a ^ n) {x | 0 ≤ x} :=
   fun _a ha _b _ hab ↦ pow_le_pow_left₀ ha hab _
 
@@ -506,23 +511,32 @@ lemma sq_pos_of_pos [PosMulStrictMono M₀] (ha : 0 < a) : 0 < a ^ 2 := by
   simpa only [sq] using mul_pos ha ha
 
 section strict_mono
-variable [ZeroLEOneClass M₀] [PosMulStrictMono M₀]
+variable [PosMulStrictMono M₀]
 
-@[simp] lemma pow_pos (ha : 0 < a) : ∀ n, 0 < a ^ n
+@[simp] lemma pow_succ_pos (ha : 0 < a) : ∀ n, 0 < a ^ (n + 1)
+  | 0 => by simpa using ha
+  | _ + 1 => pow_succ a _ ▸ mul_pos (pow_succ_pos ha _) ha
+
+@[simp] lemma pow_pos [ZeroLEOneClass M₀] (ha : 0 < a) : ∀ n, 0 < a ^ n
   | 0 => by nontriviality; rw [pow_zero]; exact zero_lt_one
   | _ + 1 => pow_succ a _ ▸ mul_pos (pow_pos ha _) ha
 
 @[gcongr, bound]
 lemma pow_lt_pow_left₀ [MulPosMono M₀] (hab : a < b)
     (ha : 0 ≤ a) : ∀ {n : ℕ}, n ≠ 0 → a ^ n < b ^ n
-  | n + 1, _ => by
+  | 1, _ => by simpa using hab
+  | n + 2, _ => by
     simpa only [pow_succ] using mul_lt_mul_of_le_of_lt_of_nonneg_of_pos
-      (pow_le_pow_left₀ ha hab.le _) hab ha (pow_pos (ha.trans_lt hab) _)
+      (pow_le_pow_left₀ ha hab.le _) hab ha (pow_succ_pos (ha.trans_lt hab) _)
 
 /-- See also `pow_left_strictMono₀` and `Nat.pow_left_strictMono`. -/
 lemma pow_left_strictMonoOn₀ [MulPosMono M₀] (hn : n ≠ 0) :
     StrictMonoOn (· ^ n : M₀ → M₀) {a | 0 ≤ a} :=
   fun _a ha _b _ hab ↦ pow_lt_pow_left₀ hab ha hn
+
+section ZeroLEOneClass
+
+variable [ZeroLEOneClass M₀]
 
 /-- See also `pow_right_strictMono'`. -/
 lemma pow_right_strictMono₀ (h : 1 < a) : StrictMono (a ^ ·) :=
@@ -541,8 +555,11 @@ lemma pow_le_pow_iff_right₀ (h : 1 < a) : a ^ n ≤ a ^ m ↔ n ≤ m :=
 lemma lt_self_pow₀ (h : 1 < a) (hm : 1 < m) : a < a ^ m := by
   simpa only [pow_one] using pow_lt_pow_right₀ h hm
 
+end ZeroLEOneClass
+
 lemma pow_right_strictAnti₀ (h₀ : 0 < a) (h₁ : a < 1) : StrictAnti (a ^ ·) :=
   strictAnti_nat_of_succ_lt fun n => by
+    have : ZeroLEOneClass M₀ := ⟨(h₀.trans h₁).le⟩
     simpa only [pow_succ, mul_one] using mul_lt_mul_of_pos_left h₁ (pow_pos h₀ n)
 
 lemma pow_le_pow_iff_right_of_lt_one₀ (ha₀ : 0 < a) (ha₁ : a < 1) : a ^ m ≤ a ^ n ↔ n ≤ m :=
@@ -594,7 +611,7 @@ lemma StrictMono.mul [PosMulStrictMono M₀] [MulPosStrictMono M₀] (hf : Stric
 end PartialOrder
 
 section LinearOrder
-variable [LinearOrder M₀] [ZeroLEOneClass M₀] [PosMulStrictMono M₀] {a b : M₀}
+variable [LinearOrder M₀] [PosMulStrictMono M₀] {a b : M₀}
   {m n : ℕ}
 
 lemma pow_le_pow_iff_left₀ [MulPosMono M₀] (ha : 0 ≤ a) (hb : 0 ≤ b) (hn : n ≠ 0) :
@@ -609,6 +626,10 @@ lemma pow_lt_pow_iff_left₀ [MulPosMono M₀] (ha : 0 ≤ a) (hb : 0 ≤ b) (hn
 lemma pow_left_inj₀ [MulPosMono M₀] (ha : 0 ≤ a) (hb : 0 ≤ b) (hn : n ≠ 0) :
     a ^ n = b ^ n ↔ a = b :=
   (pow_left_strictMonoOn₀ hn).eq_iff_eq ha hb
+
+section ZeroLEOneClass
+
+variable [ZeroLEOneClass M₀]
 
 lemma pow_right_injective₀ (ha₀ : 0 < a) (ha₁ : a ≠ 1) : Injective (a ^ ·) := by
   obtain ha₁ | ha₁ := ha₁.lt_or_gt
@@ -649,6 +670,8 @@ lemma one_le_sq_iff₀ (ha : 0 ≤ a) : 1 ≤ a ^ 2 ↔ 1 ≤ a :=
 
 lemma one_lt_sq_iff₀ (ha : 0 ≤ a) : 1 < a ^ 2 ↔ 1 < a :=
   one_lt_pow_iff_of_nonneg ha (Nat.succ_ne_zero _)
+
+end ZeroLEOneClass
 
 variable [MulPosMono M₀]
 
@@ -920,6 +943,7 @@ lemma zpow_pos (ha : 0 < a) : ∀ n : ℤ, 0 < a ^ n
   | (n : ℕ) => by rw [zpow_natCast]; exact pow_pos ha _
   | -(n + 1 : ℕ) => by rw [zpow_neg, inv_pos, zpow_natCast]; exact pow_pos ha _
 
+omit [ZeroLEOneClass G₀] in
 lemma zpow_left_strictMonoOn₀ [MulPosMono G₀] (hn : 0 < n) :
     StrictMonoOn (fun a : G₀ ↦ a ^ n) {a | 0 ≤ a} := by
   lift n to ℕ using hn.le; simpa using pow_left_strictMonoOn₀ (by omega)

--- a/Mathlib/Algebra/Order/Ring/Abs.lean
+++ b/Mathlib/Algebra/Order/Ring/Abs.lean
@@ -35,11 +35,11 @@ lemma odd_abs [LinearOrder α] [Ring α] {a : α} : Odd (abs a) ↔ Odd a := by
 
 section LinearOrderedRing
 
-variable [Ring α] [LinearOrder α] [IsStrictOrderedRing α] {n : ℕ} {a b : α}
+variable [Ring α] [LinearOrder α] [IsOrderedRing α] {n : ℕ} {a b : α}
 
-@[simp] lemma abs_one : |(1 : α)| = 1 := abs_of_pos zero_lt_one
+@[simp] lemma abs_one : |(1 : α)| = 1 := abs_of_nonneg zero_le_one
 
-lemma abs_two : |(2 : α)| = 2 := abs_of_pos zero_lt_two
+lemma abs_two : |(2 : α)| = 2 := abs_of_nonneg zero_le_two
 
 lemma abs_mul (a b : α) : |a * b| = |a| * |b| := by
   rw [abs_eq (mul_nonneg (abs_nonneg a) (abs_nonneg b))]
@@ -63,16 +63,30 @@ lemma Even.pow_abs (hn : Even n) (a : α) : |a| ^ n = a ^ n := by
 
 lemma abs_neg_one_pow (n : ℕ) : |(-1 : α) ^ n| = 1 := by rw [← pow_abs, abs_neg, abs_one, one_pow]
 
-lemma abs_pow_eq_one (a : α) (h : n ≠ 0) : |a ^ n| = 1 ↔ |a| = 1 := by
-  convert pow_left_inj₀ (abs_nonneg a) zero_le_one h
-  exacts [(pow_abs _ _).symm, (one_pow _).symm]
-
-omit [IsStrictOrderedRing α] in
+omit [IsOrderedRing α] in
 @[simp] lemma abs_mul_abs_self (a : α) : |a| * |a| = a * a :=
   abs_by_cases (fun x => x * x = a * a) rfl (neg_mul_neg a a)
 
 @[simp]
 lemma abs_mul_self (a : α) : |a * a| = a * a := by rw [abs_mul, abs_mul_abs_self]
+
+omit [IsOrderedRing α] in
+@[simp] lemma sq_abs (a : α) : |a| ^ 2 = a ^ 2 := by simpa only [sq] using abs_mul_abs_self a
+
+lemma abs_sq (x : α) : |x ^ 2| = x ^ 2 := by simpa only [sq] using abs_mul_self x
+
+lemma exists_abs_lt [Nontrivial α] (a : α) : ∃ b > 0, |a| < b :=
+  ⟨|a| + 1, lt_of_lt_of_le zero_lt_one <| by simp, lt_add_one |a|⟩
+
+end LinearOrderedRing
+
+section LinearStrictOrderedRing
+
+variable [Ring α] [LinearOrder α] [IsStrictOrderedRing α] {n : ℕ} {a b : α}
+
+lemma abs_pow_eq_one (a : α) (h : n ≠ 0) : |a ^ n| = 1 ↔ |a| = 1 := by
+  convert pow_left_inj₀ (abs_nonneg a) zero_le_one h
+  exacts [(pow_abs _ _).symm, (one_pow _).symm]
 
 lemma abs_eq_iff_mul_self_eq : |a| = |b| ↔ a * a = b * b := by
   rw [← abs_mul_abs_self, ← abs_mul_abs_self b]
@@ -88,11 +102,6 @@ lemma abs_le_iff_mul_self_le : |a| ≤ |b| ↔ a * a ≤ b * b := by
 
 lemma abs_le_one_iff_mul_self_le_one : |a| ≤ 1 ↔ a * a ≤ 1 := by
   simpa only [abs_one, one_mul] using abs_le_iff_mul_self_le (a := a) (b := 1)
-
-omit [IsStrictOrderedRing α] in
-@[simp] lemma sq_abs (a : α) : |a| ^ 2 = a ^ 2 := by simpa only [sq] using abs_mul_abs_self a
-
-lemma abs_sq (x : α) : |x ^ 2| = x ^ 2 := by simpa only [sq] using abs_mul_self x
 
 lemma sq_lt_sq : a ^ 2 < b ^ 2 ↔ |a| < |b| := by
   simpa only [sq_abs] using sq_lt_sq₀ (abs_nonneg a) (abs_nonneg b)
@@ -136,17 +145,13 @@ lemma sq_eq_sq_iff_abs_eq_abs (a b : α) : a ^ 2 = b ^ 2 ↔ |a| = |b| := by
 @[simp] lemma one_lt_sq_iff_one_lt_abs (a : α) : 1 < a ^ 2 ↔ 1 < |a| := by
   simpa only [one_pow, abs_one] using sq_lt_sq (a := 1) (b := a)
 
-lemma exists_abs_lt {α : Type*} [Ring α] [LinearOrder α] [IsStrictOrderedRing α]
-    (a : α) : ∃ b > 0, |a| < b :=
-  ⟨|a| + 1, lt_of_lt_of_le zero_lt_one <| by simp, lt_add_one |a|⟩
-
-end LinearOrderedRing
+end LinearStrictOrderedRing
 
 section LinearOrderedCommRing
 
-variable [CommRing α] [LinearOrder α] [IsStrictOrderedRing α] (a b : α) (n : ℕ)
+variable [CommRing α] [LinearOrder α] [IsOrderedRing α] (a b : α) (n : ℕ)
 
-omit [IsStrictOrderedRing α] in
+omit [IsOrderedRing α] in
 theorem abs_sub_sq (a b : α) : |a - b| * |a - b| = a * a + b * b - (1 + 1) * a * b := by
   rw [abs_mul_abs_self]
   simp only [mul_add, add_comm, add_left_comm, mul_comm, sub_eq_add_neg, mul_one, mul_neg,
@@ -168,7 +173,7 @@ private theorem abs_geomSum_le : |geomSum a b n| ≤ (n + 1) * max |a| |b| ^ n :
   exact mul_le_mul ih le_sup_left (abs_nonneg _) (mul_nonneg
     (@Nat.cast_succ α .. ▸ Nat.cast_nonneg _) <| pow_nonneg ((abs_nonneg _).trans le_sup_left) _)
 
-omit [LinearOrder α] [IsStrictOrderedRing α] in
+omit [LinearOrder α] [IsOrderedRing α] in
 private theorem pow_sub_pow_eq_sub_mul_geomSum :
     a ^ (n + 1) - b ^ (n + 1) = (a - b) * geomSum a b n := by
   induction n with | zero => simp [geomSum] | succ n ih => ?_

--- a/Mathlib/Algebra/Order/Ring/Abs.lean
+++ b/Mathlib/Algebra/Order/Ring/Abs.lean
@@ -149,22 +149,21 @@ end LinearStrictOrderedRing
 
 section LinearOrderedCommRing
 
-variable [CommRing α] [LinearOrder α] [IsOrderedRing α] (a b : α) (n : ℕ)
+variable [CommRing α] [LinearOrder α] (a b : α) (n : ℕ)
 
-omit [IsOrderedRing α] in
 theorem abs_sub_sq (a b : α) : |a - b| * |a - b| = a * a + b * b - (1 + 1) * a * b := by
   rw [abs_mul_abs_self]
   simp only [mul_add, add_comm, add_left_comm, mul_comm, sub_eq_add_neg, mul_one, mul_neg,
     neg_add_rev, neg_neg, add_assoc]
 
-lemma abs_unit_intCast (a : ℤˣ) : |((a : ℤ) : α)| = 1 := by
+lemma abs_unit_intCast [IsOrderedRing α] (a : ℤˣ) : |((a : ℤ) : α)| = 1 := by
   cases Int.units_eq_one_or a <;> simp_all
 
 private def geomSum : ℕ → α
   | 0 => 1
   | n + 1 => a * geomSum n + b ^ (n + 1)
 
-private theorem abs_geomSum_le : |geomSum a b n| ≤ (n + 1) * max |a| |b| ^ n := by
+private theorem abs_geomSum_le [IsOrderedRing α] : |geomSum a b n| ≤ (n + 1) * max |a| |b| ^ n := by
   induction n with | zero => simp [geomSum] | succ n ih => ?_
   refine (abs_add_le ..).trans ?_
   rw [abs_mul, abs_pow, Nat.cast_succ, add_one_mul]
@@ -173,14 +172,15 @@ private theorem abs_geomSum_le : |geomSum a b n| ≤ (n + 1) * max |a| |b| ^ n :
   exact mul_le_mul ih le_sup_left (abs_nonneg _) (mul_nonneg
     (@Nat.cast_succ α .. ▸ Nat.cast_nonneg _) <| pow_nonneg ((abs_nonneg _).trans le_sup_left) _)
 
-omit [LinearOrder α] [IsOrderedRing α] in
+omit [LinearOrder α] in
 private theorem pow_sub_pow_eq_sub_mul_geomSum :
     a ^ (n + 1) - b ^ (n + 1) = (a - b) * geomSum a b n := by
   induction n with | zero => simp [geomSum] | succ n ih => ?_
   rw [geomSum, mul_add, mul_comm a, ← mul_assoc, ← ih,
     sub_mul, sub_mul, ← pow_succ, ← pow_succ', mul_comm, sub_add_sub_cancel]
 
-theorem abs_pow_sub_pow_le : |a ^ n - b ^ n| ≤ |a - b| * n * max |a| |b| ^ (n - 1) := by
+theorem abs_pow_sub_pow_le [IsOrderedRing α] :
+    |a ^ n - b ^ n| ≤ |a - b| * n * max |a| |b| ^ (n - 1) := by
   obtain _ | n := n; · simp
   rw [Nat.add_sub_cancel, pow_sub_pow_eq_sub_mul_geomSum, abs_mul, mul_assoc, Nat.cast_succ]
   gcongr

--- a/Mathlib/Algebra/Order/Ring/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Basic.lean
@@ -19,15 +19,15 @@ open Function Int
 
 variable {α M R : Type*}
 
-theorem IsSquare.nonneg [Semiring R] [LinearOrder R] [IsRightCancelAdd R]
-    [ZeroLEOneClass R] [ExistsAddOfLE R] [PosMulMono R] [AddLeftStrictMono R]
+theorem IsSquare.nonneg [Semiring R] [LinearOrder R]
+    [ExistsAddOfLE R] [PosMulMono R] [AddLeftMono R]
     {x : R} (h : IsSquare x) : 0 ≤ x := by
   rcases h with ⟨y, rfl⟩
   exact mul_self_nonneg y
 
 @[simp]
-lemma not_isSquare_of_neg [Semiring R] [LinearOrder R] [IsRightCancelAdd R]
-    [ZeroLEOneClass R] [ExistsAddOfLE R] [PosMulMono R] [AddLeftStrictMono R]
+lemma not_isSquare_of_neg [Semiring R] [LinearOrder R]
+    [ExistsAddOfLE R] [PosMulMono R] [AddLeftMono R]
     {x : R} (h : x < 0) : ¬ IsSquare x :=
   (h.not_ge ·.nonneg)
 
@@ -85,6 +85,19 @@ lemma sq_pos_of_neg (ha : a < 0) : 0 < a ^ 2 := by rw [sq]; exact mul_pos_of_neg
 end StrictOrderedRing
 
 section LinearOrderedSemiring
+
+section IsOrderedRing
+
+variable [Semiring R] [LinearOrder R] [IsOrderedRing R] [ExistsAddOfLE R] {m n : ℕ}
+
+protected lemma Even.pow_nonneg (hn : Even n) (a : R) : 0 ≤ a ^ n := by
+  obtain ⟨k, rfl⟩ := hn; rw [pow_add]; exact mul_self_nonneg _
+
+lemma pow_four_le_pow_two_of_pow_two_le {a b : R} (h : a ^ 2 ≤ b) : a ^ 4 ≤ b ^ 2 :=
+  (pow_mul a 2 2).symm ▸ pow_le_pow_left₀ (sq_nonneg a) h 2
+
+end IsOrderedRing
+
 variable [Semiring R] [LinearOrder R] [IsStrictOrderedRing R] {a b : R} {m n : ℕ}
 
 /-- A function `f : α → R` is nonarchimedean if it satisfies the ultrametric inequality
@@ -148,9 +161,6 @@ protected lemma Even.add_pow_le (hn : Even n) :
       · rfl
       · simp [Nat.two_mul]
 
-lemma Even.pow_nonneg (hn : Even n) (a : R) : 0 ≤ a ^ n := by
-  obtain ⟨k, rfl⟩ := hn; rw [pow_add]; exact mul_self_nonneg _
-
 lemma Even.pow_pos (hn : Even n) (ha : a ≠ 0) : 0 < a ^ n :=
   (hn.pow_nonneg _).lt_of_ne' (pow_ne_zero _ ha)
 
@@ -211,8 +221,5 @@ lemma sq_pos_iff {a : R} : 0 < a ^ 2 ↔ a ≠ 0 := even_two.pow_pos_iff two_ne_
 
 alias ⟨_, sq_pos_of_ne_zero⟩ := sq_pos_iff
 alias pow_two_pos_of_ne_zero := sq_pos_of_ne_zero
-
-lemma pow_four_le_pow_two_of_pow_two_le (h : a ^ 2 ≤ b) : a ^ 4 ≤ b ^ 2 :=
-  (pow_mul a 2 2).symm ▸ pow_le_pow_left₀ (sq_nonneg a) h 2
 
 end LinearOrderedSemiring

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Basic.lean
@@ -682,23 +682,22 @@ theorem pos_iff_neg_of_mul_neg [ExistsAddOfLE R] [PosMulMono R] [MulPosMono R]
     (hab : a * b < 0) : 0 < a ↔ b < 0 :=
   ⟨neg_of_mul_neg_right hab ∘ le_of_lt, pos_of_mul_neg_left hab ∘ le_of_lt⟩
 
-lemma sq_nonneg [IsRightCancelAdd R]
-    [ZeroLEOneClass R] [ExistsAddOfLE R] [PosMulMono R] [AddLeftStrictMono R]
+lemma sq_nonneg [ExistsAddOfLE R] [PosMulMono R] [AddLeftMono R]
     (a : R) : 0 ≤ a ^ 2 := by
-  obtain ha | ha := le_total 0 a
-  · exact pow_nonneg ha _
-  obtain ⟨b, hab⟩ := exists_add_of_le ha
+  obtain ha | ha := le_or_gt 0 a
+  · exact pow_succ_nonneg ha _
+  obtain ⟨b, hab⟩ := exists_add_of_le ha.le
+  have hb : 0 < b := not_le.1 fun hb ↦
+    ((add_le_add_left hb a).trans_lt ((add_zero a).trans_lt ha)).ne' hab
   calc
-    0 ≤ b ^ 2 := pow_nonneg (not_lt.1 fun hb ↦ hab.not_gt <| add_neg_of_nonpos_of_neg ha hb) _
-    _ = a ^ 2 := add_left_injective (a * b) ?_
-  calc
-    b ^ 2 + a * b = (a + b) * b := by rw [add_comm, sq, add_mul]
-    _ = a * (a + b) := by simp [← hab]
-    _ = a ^ 2 + a * b := by rw [sq, mul_add]
+    0 ≤ b ^ 2 := pow_succ_nonneg hb.le _
+    _ = b ^ 2 + a * (a + b) := by rw [← hab, mul_zero, add_zero]
+    _ = a ^ 2 + (a + b) * b := by rw [add_mul, mul_add, sq, sq, add_comm, add_assoc]
+    _ = a ^ 2 := by rw [← hab, zero_mul, add_zero]
 
 @[simp]
-lemma sq_nonpos_iff [IsRightCancelAdd R] [ZeroLEOneClass R] [ExistsAddOfLE R]
-    [PosMulMono R] [AddLeftStrictMono R] [NoZeroDivisors R] (r : R) :
+lemma sq_nonpos_iff [ExistsAddOfLE R]
+    [PosMulMono R] [AddLeftMono R] [NoZeroDivisors R] (r : R) :
     r ^ 2 ≤ 0 ↔ r = 0 := by
   trans r ^ 2 = 0
   · rw [le_antisymm_iff, and_iff_left (sq_nonneg r)]
@@ -706,21 +705,18 @@ lemma sq_nonpos_iff [IsRightCancelAdd R] [ZeroLEOneClass R] [ExistsAddOfLE R]
 
 alias pow_two_nonneg := sq_nonneg
 
-lemma mul_self_nonneg [IsRightCancelAdd R]
-    [ZeroLEOneClass R] [ExistsAddOfLE R] [PosMulMono R] [AddLeftStrictMono R]
+lemma mul_self_nonneg [ExistsAddOfLE R] [PosMulMono R] [AddLeftMono R]
     (a : R) : 0 ≤ a * a := by simpa only [sq] using sq_nonneg a
 
 /-- The sum of two squares is zero iff both elements are zero. -/
-lemma mul_self_add_mul_self_eq_zero [IsRightCancelAdd R] [NoZeroDivisors R]
-    [ZeroLEOneClass R] [ExistsAddOfLE R] [PosMulMono R]
-    [AddLeftMono R] [AddLeftStrictMono R] :
+lemma mul_self_add_mul_self_eq_zero [NoZeroDivisors R]
+    [ExistsAddOfLE R] [PosMulMono R] [AddLeftMono R] :
     a * a + b * b = 0 ↔ a = 0 ∧ b = 0 := by
   rw [add_eq_zero_iff_of_nonneg, mul_self_eq_zero (M₀ := R), mul_self_eq_zero (M₀ := R)] <;>
     apply mul_self_nonneg
 
-lemma eq_zero_of_mul_self_add_mul_self_eq_zero [IsRightCancelAdd R] [NoZeroDivisors R]
-    [ZeroLEOneClass R] [ExistsAddOfLE R] [PosMulMono R]
-    [AddLeftMono R] [AddLeftStrictMono R]
+lemma eq_zero_of_mul_self_add_mul_self_eq_zero [NoZeroDivisors R]
+    [ExistsAddOfLE R] [PosMulMono R] [AddLeftMono R]
     (h : a * a + b * b = 0) : a = 0 :=
   (mul_self_add_mul_self_eq_zero.mp h).left
 


### PR DESCRIPTION
Remove some `ZeroLEOneClass` assumptions.

Change some `IsStrictOrderedRing` to `IsOrderedRing`.

Remove some `IsRightCancelAdd` and replace some `AddLeftStrictMono` by `AddLeftMono`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
