### PR TITLE
x chore(Topology/HomotopyGroup): inessential cleanups

### DIFF
--- a/Mathlib/Topology/Homotopy/HomotopyGroup.lean
+++ b/Mathlib/Topology/Homotopy/HomotopyGroup.lean
@@ -104,7 +104,7 @@ namespace GenLoop
 
 instance instFunLike : FunLike (Ω^ N X x) (I^N) X where
   coe f := f.1
-  coe_injective' := fun ⟨⟨f, _⟩, _⟩ ⟨⟨g, _⟩, _⟩ _ => by congr
+  coe_injective' := fun ⟨⟨f, _⟩, _⟩ ⟨⟨g, _⟩, _⟩ _ ↦ by congr
 
 @[ext]
 theorem ext (f g : Ω^ N X x) (H : ∀ y, f y = g y) : f = g :=
@@ -138,7 +138,7 @@ theorem boundary (f : Ω^ N X x) : ∀ y ∈ Cube.boundary N, f y = x :=
 
 /-- The constant `GenLoop` at `x`. -/
 def const : Ω^ N X x :=
-  ⟨ContinuousMap.const _ x, fun _ _ => rfl⟩
+  ⟨ContinuousMap.const _ x, fun _ _ ↦ rfl⟩
 
 @[simp]
 theorem const_apply {t} : (@const N X _ x) t = x :=
@@ -183,7 +183,7 @@ variable [DecidableEq N]
 @[simps]
 def toLoop (i : N) (p : Ω^ N X x) : Ω (Ω^ { j // j ≠ i } X x) const where
   toFun t :=
-    ⟨(p.val.comp (Cube.insertAt i)).curry t, fun y yH =>
+    ⟨(p.val.comp (Cube.insertAt i)).curry t, fun y yH ↦
       p.property (Cube.insertAt i (t, y)) (Cube.insertAt_boundary i <| Or.inr yH)⟩
   source' := by ext t; refine p.property (Cube.insertAt i (0, t)) ⟨i, Or.inl ?_⟩; simp
   target' := by ext t; refine p.property (Cube.insertAt i (1, t)) ⟨i, Or.inr ?_⟩; simp
@@ -246,7 +246,7 @@ theorem fromLoop_apply (i : N) {p : Ω (Ω^ { j // j ≠ i } X x) const} {t : I^
 
 /-- Composition with `Cube.insertAt` as a continuous map. -/
 abbrev cCompInsert (i : N) : C(C(I^N, X), C(I × I^{ j // j ≠ i }, X)) :=
-  ⟨fun f => f.comp (Cube.insertAt i),
+  ⟨fun f ↦ f.comp (Cube.insertAt i),
     (toContinuousMap <| Cube.insertAt i).continuous_precomp⟩
 
 /-- A homotopy between `n+1`-dimensional loops `p` and `q` constant on the boundary
@@ -264,7 +264,7 @@ theorem homotopyTo_apply (i : N) {p q : Ω^ N X x} (H : p.1.HomotopyRel q.1 <| C
 
 theorem homotopicTo (i : N) {p q : Ω^ N X x} :
     Homotopic p q → (toLoop i p).Homotopic (toLoop i q) := by
-  refine Nonempty.map fun H => ⟨⟨⟨fun t => ⟨homotopyTo i H t, ?_⟩, ?_⟩, ?_, ?_⟩, ?_⟩
+  refine Nonempty.map fun H ↦ ⟨⟨⟨fun t ↦ ⟨homotopyTo i H t, ?_⟩, ?_⟩, ?_, ?_⟩, ?_⟩
   · rintro y ⟨i, iH⟩
     rw [homotopyTo_apply, H.eq_fst, p.2]
     all_goals apply Cube.insertAt_boundary; right; exact ⟨i, iH⟩
@@ -294,7 +294,7 @@ theorem homotopicTo (i : N) {p q : Ω^ N X x} :
 
 theorem homotopicFrom (i : N) {p q : Ω^ N X x} :
     (toLoop i p).Homotopic (toLoop i q) → Homotopic p q := by
-  refine Nonempty.map fun H => ⟨⟨homotopyFrom i H, ?_, ?_⟩, ?_⟩
+  refine Nonempty.map fun H ↦ ⟨⟨homotopyFrom i H, ?_, ?_⟩, ?_⟩
   pick_goal 3
   · rintro t y ⟨j, jH⟩
     erw [homotopyFrom_apply]
@@ -318,7 +318,7 @@ theorem homotopicFrom (i : N) {p q : Ω^ N X x} :
 /-- Concatenation of two `GenLoop`s along the `i`th coordinate. -/
 def transAt (i : N) (f g : Ω^ N X x) : Ω^ N X x :=
   copy (fromLoop i <| (toLoop i f).trans <| toLoop i g)
-    (fun t => if (t i : ℝ) ≤ 1 / 2
+    (fun t ↦ if (t i : ℝ) ≤ 1 / 2
       then f (Function.update t i <| Set.projIcc 0 1 zero_le_one (2 * t i))
       else g (Function.update t i <| Set.projIcc 0 1 zero_le_one (2 * t i - 1)))
     (by
@@ -332,7 +332,7 @@ def transAt (i : N) (f g : Ω^ N X x) : Ω^ N X x :=
 
 /-- Reversal of a `GenLoop` along the `i`th coordinate. -/
 def symmAt (i : N) (f : Ω^ N X x) : Ω^ N X x :=
-  (copy (fromLoop i (toLoop i f).symm) fun t => f fun j => if j = i then σ (t i) else t j) <| by
+  (copy (fromLoop i (toLoop i f).symm) fun t ↦ f fun j ↦ if j = i then σ (t i) else t j) <| by
     ext1; change _ = f _; congr; ext1; simp
 
 theorem transAt_distrib {i j : N} (h : i ≠ j) (a b c d : Ω^ N X x) :
@@ -368,10 +368,8 @@ open GenLoop
 /-- Equivalence between the homotopy group of X and the fundamental group of
   `Ω^{j // j ≠ i} x`. -/
 def homotopyGroupEquivFundamentalGroup (i : N) :
-    HomotopyGroup N X x ≃ FundamentalGroup (Ω^ { j // j ≠ i } X x) const := by
-  refine Equiv.trans ?_ (CategoryTheory.Groupoid.isoEquivHom _ _).symm
-  apply Quotient.congr (loopHomeo i).toEquiv
-  exact fun p q => ⟨homotopicTo i, homotopicFrom i⟩
+    HomotopyGroup N X x ≃ FundamentalGroup (Ω^ { j // j ≠ i } X x) const :=
+  Quotient.congr (loopHomeo i).toEquiv fun _ _ ↦ ⟨homotopicTo i, homotopicFrom i⟩
 
 /-- Homotopy group of finite index, denoted as `π_n` within the Topology namespace. -/
 abbrev HomotopyGroup.Pi (n) (X : Type*) [TopologicalSpace X] (x : X) :=
@@ -382,7 +380,7 @@ abbrev HomotopyGroup.Pi (n) (X : Type*) [TopologicalSpace X] (x : X) :=
 /-- The 0-dimensional generalized loops based at `x` are in bijection with `X`. -/
 def genLoopHomeoOfIsEmpty (N x) [IsEmpty N] : Ω^ N X x ≃ₜ X where
   toFun f := f 0
-  invFun y := ⟨ContinuousMap.const _ y, fun _ ⟨i, _⟩ => isEmptyElim i⟩
+  invFun y := ⟨ContinuousMap.const _ y, fun _ ⟨i, _⟩ ↦ isEmptyElim i⟩
   left_inv f := by ext; exact congr_arg f (Subsingleton.elim _ _)
   continuous_invFun := ContinuousMap.const'.2.subtype_mk _
 
@@ -396,13 +394,13 @@ def homotopyGroupEquivZerothHomotopyOfIsEmpty (N x) [IsEmpty N] :
       intros a₁ a₂
       constructor <;> rintro ⟨H⟩
       exacts
-        [⟨{ toFun := fun t => H ⟨t, isEmptyElim⟩
+        [⟨{ toFun := fun t ↦ H ⟨t, isEmptyElim⟩
             source' := (H.apply_zero _).trans (congr_arg a₁ <| Subsingleton.elim _ _)
             target' := (H.apply_one _).trans (congr_arg a₂ <| Subsingleton.elim _ _) }⟩,
-        ⟨{  toFun := fun t0 => H t0.fst
-            map_zero_left := fun _ => H.source.trans (congr_arg a₁ <| Subsingleton.elim _ _)
-            map_one_left := fun _ => H.target.trans (congr_arg a₂ <| Subsingleton.elim _ _)
-            prop' := fun _ _ ⟨i, _⟩ => isEmptyElim i }⟩])
+        ⟨{  toFun := fun t0 ↦ H t0.fst
+            map_zero_left := fun _ ↦ H.source.trans (congr_arg a₁ <| Subsingleton.elim _ _)
+            map_one_left := fun _ ↦ H.target.trans (congr_arg a₂ <| Subsingleton.elim _ _)
+            prop' := fun _ _ ⟨i, _⟩ ↦ isEmptyElim i }⟩])
 
 /-- The 0th homotopy "group" is in bijection with `ZerothHomotopy`. -/
 def HomotopyGroup.pi0EquivZerothHomotopy : π_ 0 X x ≃ ZerothHomotopy X :=
@@ -411,11 +409,11 @@ def HomotopyGroup.pi0EquivZerothHomotopy : π_ 0 X x ≃ ZerothHomotopy X :=
 /-- The 1-dimensional generalized loops based at `x` are in bijection with loops at `x`. -/
 def genLoopEquivOfUnique (N) [Unique N] : Ω^ N X x ≃ Ω X x where
   toFun p :=
-    Path.mk ⟨fun t => p fun _ => t, by continuity⟩
-      (GenLoop.boundary _ (fun _ => 0) ⟨default, Or.inl rfl⟩)
-      (GenLoop.boundary _ (fun _ => 1) ⟨default, Or.inr rfl⟩)
+    Path.mk ⟨fun t ↦ p fun _ ↦ t, by continuity⟩
+      (GenLoop.boundary _ (fun _ ↦ 0) ⟨default, Or.inl rfl⟩)
+      (GenLoop.boundary _ (fun _ ↦ 1) ⟨default, Or.inr rfl⟩)
   invFun p :=
-    ⟨⟨fun c => p (c default), by continuity⟩,
+    ⟨⟨fun c ↦ p (c default), by continuity⟩,
       by
       rintro y ⟨i, iH | iH⟩ <;> cases Unique.eq_default i <;> apply (congr_arg p iH).trans
       exacts [p.source, p.target]⟩
@@ -428,23 +426,22 @@ def genLoopEquivOfUnique (N) [Unique N] : Ω^ N X x ≃ Ω X x where
 /-- The homotopy group at `x` indexed by a singleton is in bijection with the fundamental group,
   i.e. the loops based at `x` up to homotopy. -/
 def homotopyGroupEquivFundamentalGroupOfUnique (N) [Unique N] :
-    HomotopyGroup N X x ≃ FundamentalGroup X x := by
-  refine Equiv.trans ?_ (CategoryTheory.Groupoid.isoEquivHom _ _).symm
-  refine Quotient.congr (genLoopEquivOfUnique N) ?_
-  intros a₁ a₂; constructor <;> rintro ⟨H⟩
-  · exact
-      ⟨{  toFun := fun tx => H (tx.fst, fun _ => tx.snd)
-          map_zero_left := fun _ => H.apply_zero _
-          map_one_left := fun _ => H.apply_one _
-          prop' := fun t y iH => H.prop' _ _ ⟨default, iH⟩ }⟩
-  refine
-    ⟨⟨⟨⟨fun tx => H (tx.fst, tx.snd default), H.continuous.comp ?_⟩, fun y => ?_, fun y => ?_⟩, ?_⟩⟩
-  · fun_prop
-  · exact (H.apply_zero _).trans (congr_arg a₁ (eq_const_of_unique y).symm)
-  · exact (H.apply_one _).trans (congr_arg a₂ (eq_const_of_unique y).symm)
-  · rintro t y ⟨i, iH⟩
-    cases Unique.eq_default i
-    exact (H.eq_fst _ iH).trans (congr_arg a₁ (eq_const_of_unique y).symm)
+    HomotopyGroup N X x ≃ FundamentalGroup X x :=
+  Quotient.congr (genLoopEquivOfUnique N) fun a₁ a₂ ↦ by
+    constructor <;> rintro ⟨H⟩
+    · exact
+        ⟨{  toFun := fun tx ↦ H (tx.fst, fun _ ↦ tx.snd)
+            map_zero_left := fun _ ↦ H.apply_zero _
+            map_one_left := fun _ ↦ H.apply_one _
+            prop' := fun t y iH ↦ H.prop' _ _ ⟨default, iH⟩ }⟩
+    refine
+      ⟨⟨⟨⟨fun tx ↦ H (tx.fst, tx.snd default), H.continuous.comp ?_⟩, fun y ↦ ?_, fun y ↦ ?_⟩, ?_⟩⟩
+    · fun_prop
+    · exact (H.apply_zero _).trans (congr_arg a₁ (eq_const_of_unique y).symm)
+    · exact (H.apply_one _).trans (congr_arg a₂ (eq_const_of_unique y).symm)
+    · rintro t y ⟨i, iH⟩
+      cases Unique.eq_default i
+      exact (H.eq_fst _ iH).trans (congr_arg a₁ (eq_const_of_unique y).symm)
 
 /-- The first homotopy group at `x` is in bijection with the fundamental group. -/
 def HomotopyGroup.pi1EquivFundamentalGroup : π_ 1 X x ≃ FundamentalGroup X x :=
@@ -479,13 +476,13 @@ theorem auxGroup_indep (i j : N) : (auxGroup i : Group (HomotopyGroup N X x)) = 
 theorem transAt_indep {i} (j) (f g : Ω^ N X x) :
     (⟦transAt i f g⟧ : HomotopyGroup N X x) = ⟦transAt j f g⟧ := by
   simp_rw [← fromLoop_trans_toLoop]
-  let m := fun (G) (_ : Group G) => ((· * ·) : G → G → G)
+  let m := fun (G) (_ : Group G) ↦ ((· * ·) : G → G → G)
   exact congr_fun₂ (congr_arg (m <| HomotopyGroup N X x) <| auxGroup_indep i j) ⟦g⟧ ⟦f⟧
 
 theorem symmAt_indep {i} (j) (f : Ω^ N X x) :
     (⟦symmAt i f⟧ : HomotopyGroup N X x) = ⟦symmAt j f⟧ := by
   simp_rw [← fromLoop_symm_toLoop]
-  let inv := fun (G) (_ : Group G) => ((·⁻¹) : G → G)
+  let inv := fun (G) (_ : Group G) ↦ ((·⁻¹) : G → G)
   exact congr_fun (congr_arg (inv <| HomotopyGroup N X x) <| auxGroup_indep i j) ⟦f⟧
 
 /-- Characterization of multiplicative identity -/


### PR DESCRIPTION
---

It's necessary to include this in #28234 for it to build, so closing.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
