### PR TITLE
[Merged by Bors] - feat(Algebra): toAlgebra_algebraMap

### DIFF
--- a/Mathlib/Algebra/Algebra/Defs.lean
+++ b/Mathlib/Algebra/Algebra/Defs.lean
@@ -259,7 +259,7 @@ theorem algebra_ext {R : Type*} [CommSemiring R] {A : Type*} [Semiring A] (P Q :
 
 /-- An auxiliary lemma used to prove theorems of the form
 `RingHom.X (algebraMap R S) ↔ Algebra.X R S`. -/
-lemma toAlgebra_algebraMap {R S : Type*} [CommSemiring R] [CommSemiring S] [Algebra R S] :
+lemma _root_.toAlgebra_algebraMap {R S : Type*} [CommSemiring R] [CommSemiring S] [Algebra R S] :
     (algebraMap R S).toAlgebra = ‹_› :=
   algebra_ext _ _ fun _ ↦ rfl
 

--- a/Mathlib/Algebra/Algebra/Defs.lean
+++ b/Mathlib/Algebra/Algebra/Defs.lean
@@ -259,7 +259,7 @@ theorem algebra_ext {R : Type*} [CommSemiring R] {A : Type*} [Semiring A] (P Q :
 
 /-- An auxiliary lemma used to prove theorems of the form
 `RingHom.X (algebraMap R S) ↔ Algebra.X R S`. -/
-lemma _root_.toAlgebra_algebraMap {R S : Type*} [CommSemiring R] [CommSemiring S] [Algebra R S] :
+lemma _root_.toAlgebra_algebraMap [Algebra R S] :
     (algebraMap R S).toAlgebra = ‹_› :=
   algebra_ext _ _ fun _ ↦ rfl
 

--- a/Mathlib/Algebra/Algebra/Defs.lean
+++ b/Mathlib/Algebra/Algebra/Defs.lean
@@ -257,6 +257,12 @@ theorem algebra_ext {R : Type*} [CommSemiring R] {A : Type*} [Semiring A] (P Q :
   rcases Q with @⟨⟨Q⟩⟩
   congr
 
+/-- An auxiliary lemma used to prove theorems of the form
+`RingHom.X (algebraMap R S) ↔ Algebra.X R S`. -/
+lemma toAlgebra_algebraMap {R S : Type*} [CommSemiring R] [CommSemiring S] [Algebra R S] :
+    (algebraMap R S).toAlgebra = ‹_› :=
+  algebra_ext _ _ fun _ ↦ rfl
+
 -- see Note [lower instance priority]
 instance (priority := 200) toModule {R A} {_ : CommSemiring R} {_ : Semiring A} [Algebra R A] :
     Module R A where
@@ -411,4 +417,3 @@ theorem algebraMap.coe_smul (A B C : Type*) [SMul A B] [CommSemiring B] [Semirin
   ((a • b : B) : C) = (a • b) • 1 := Algebra.algebraMap_eq_smul_one _
   _ = a • (b • 1) := smul_assoc ..
   _ = a • (b : C) := congrArg _ (Algebra.algebraMap_eq_smul_one b).symm
-

--- a/Mathlib/RingTheory/Etale/Basic.lean
+++ b/Mathlib/RingTheory/Etale/Basic.lean
@@ -226,8 +226,6 @@ def FormallyEtale (f : R →+* S) : Prop :=
 
 lemma formallyEtale_algebraMap [Algebra R S] :
     (algebraMap R S).FormallyEtale ↔ Algebra.FormallyEtale R S := by
-  delta FormallyEtale
-  congr!
-  exact Algebra.algebra_ext _ _ fun _ ↦ rfl
+  rw [FormallyEtale, toAlgebra_algebraMap]
 
 end RingHom

--- a/Mathlib/RingTheory/FinitePresentation.lean
+++ b/Mathlib/RingTheory/FinitePresentation.lean
@@ -393,9 +393,7 @@ def FinitePresentation (f : A →+* B) : Prop :=
 @[simp]
 lemma finitePresentation_algebraMap [Algebra A B] :
     (algebraMap A B).FinitePresentation ↔ Algebra.FinitePresentation A B := by
-  delta RingHom.FinitePresentation
-  congr!
-  exact Algebra.algebra_ext _ _ fun _ ↦ rfl
+  rw [RingHom.FinitePresentation, toAlgebra_algebraMap]
 
 namespace FiniteType
 

--- a/Mathlib/RingTheory/FiniteType.lean
+++ b/Mathlib/RingTheory/FiniteType.lean
@@ -218,9 +218,7 @@ def FiniteType (f : A →+* B) : Prop :=
 
 lemma finiteType_algebraMap [Algebra A B] :
     (algebraMap A B).FiniteType ↔ Algebra.FiniteType A B := by
-  delta FiniteType
-  congr!
-  exact Algebra.algebra_ext _ _ fun _ ↦ rfl
+  rw [FiniteType, toAlgebra_algebraMap]
 
 namespace Finite
 

--- a/Mathlib/RingTheory/Finiteness/Defs.lean
+++ b/Mathlib/RingTheory/Finiteness/Defs.lean
@@ -154,6 +154,11 @@ def Finite (f : A →+* B) : Prop :=
   letI : Algebra A B := f.toAlgebra
   Module.Finite A B
 
+@[simp]
+lemma finite_algebraMap [Algebra A B] :
+    (algebraMap A B).Finite ↔ Module.Finite A B := by
+  rw [RingHom.Finite, toAlgebra_algebraMap]
+
 end RingHom
 
 namespace AlgHom

--- a/Mathlib/RingTheory/RingHom/Etale.lean
+++ b/Mathlib/RingTheory/RingHom/Etale.lean
@@ -30,9 +30,7 @@ lemma Etale.toAlgebra {f : R →+* S} (hf : Etale f) :
 variable {R S : Type u} [CommRing R] [CommRing S] (f : R →+* S)
 
 lemma etale_algebraMap [Algebra R S] : (algebraMap R S).Etale ↔ Algebra.Etale R S := by
-  simp only [RingHom.Etale]
-  congr!
-  exact Algebra.algebra_ext _ _ fun _ ↦ rfl
+  rw [RingHom.Etale, toAlgebra_algebraMap]
 
 lemma etale_iff_formallyUnramified_and_smooth : f.Etale ↔ f.FormallyUnramified ∧ f.Smooth := by
   algebraize [f]

--- a/Mathlib/RingTheory/RingHom/Flat.lean
+++ b/Mathlib/RingTheory/RingHom/Flat.lean
@@ -26,9 +26,7 @@ def RingHom.Flat {R : Type u} {S : Type v} [CommRing R] [CommRing S] (f : R →+
 
 lemma flat_algebraMap_iff {R S : Type*} [CommRing R] [CommRing S] [Algebra R S] :
     (algebraMap R S).Flat ↔ Module.Flat R S := by
-  simp only [RingHom.Flat]
-  congr!
-  exact Algebra.algebra_ext _ _ fun _ ↦ rfl
+  rw [RingHom.Flat, toAlgebra_algebraMap]
 
 namespace RingHom.Flat
 

--- a/Mathlib/RingTheory/RingHom/Smooth.lean
+++ b/Mathlib/RingTheory/RingHom/Smooth.lean
@@ -34,9 +34,7 @@ lemma FormallySmooth.toAlgebra {f : R →+* S} (hf : FormallySmooth f) :
 
 lemma formallySmooth_algebraMap [Algebra R S] :
     (algebraMap R S).FormallySmooth ↔ Algebra.FormallySmooth R S := by
-  delta FormallySmooth
-  congr!
-  exact Algebra.algebra_ext _ _ fun _ ↦ rfl
+  rw [FormallySmooth, toAlgebra_algebraMap]
 
 lemma FormallySmooth.holdsForLocalizationAway : HoldsForLocalizationAway @FormallySmooth :=
   fun _ _ _ _ _ r _ ↦ formallySmooth_algebraMap.mpr <| .of_isLocalization (.powers r)
@@ -71,9 +69,7 @@ lemma Smooth.toAlgebra {f : R →+* S} (hf : Smooth f) :
 
 lemma smooth_algebraMap [Algebra R S] :
     (algebraMap R S).Smooth ↔ Algebra.Smooth R S := by
-  simp only [RingHom.Smooth]
-  congr!
-  exact Algebra.algebra_ext _ _ fun _ ↦ rfl
+  rw [RingHom.Smooth, toAlgebra_algebraMap]
 
 lemma smooth_def {f : R →+* S} : f.Smooth ↔ f.FormallySmooth ∧ f.FinitePresentation :=
   letI := f.toAlgebra

--- a/Mathlib/RingTheory/RingHom/Unramified.lean
+++ b/Mathlib/RingTheory/RingHom/Unramified.lean
@@ -27,9 +27,7 @@ def FormallyUnramified (f : R →+* S) : Prop :=
 
 lemma formallyUnramified_algebraMap [Algebra R S] :
     (algebraMap R S).FormallyUnramified ↔ Algebra.FormallyUnramified R S := by
-  delta FormallyUnramified
-  congr!
-  exact Algebra.algebra_ext _ _ fun _ ↦ rfl
+  rw [FormallyUnramified, toAlgebra_algebraMap]
 
 namespace FormallyUnramified
 


### PR DESCRIPTION
This PR adds the following lemma:
```lean
lemma toAlgebra_algebraMap [Algebra R S] : (algebraMap R S).toAlgebra = ‹_›
```

in order to prove theorems such as:
```lean
@[simp]
lemma finite_algebraMap [Algebra A B] :
    (algebraMap A B).Finite ↔ Module.Finite A B := by
  rw [RingHom.Finite, toAlgebra_algebraMap]
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

(Note: one could probably improve `algebraize` to automate this.)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
