### PR TITLE
[Merged by Bors] - chore(Algebra/Order): replace Co/ContravariantClass by established abbrevs

### DIFF
--- a/Mathlib/Algebra/BigOperators/Group/Multiset/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Multiset/Basic.lean
@@ -217,7 +217,7 @@ theorem prod_int_mod (s : Multiset ℤ) (n : ℤ) : s.prod % n = (s.map (· % n)
 section OrderedSub
 
 theorem sum_map_tsub [AddCommMonoid M] [PartialOrder M] [ExistsAddOfLE M]
-    [CovariantClass M M (· + ·) (· ≤ ·)] [ContravariantClass M M (· + ·) (· ≤ ·)] [Sub M]
+    [AddLeftMono M] [AddLeftReflectLE M] [Sub M]
     [OrderedSub M] (l : Multiset ι) {f g : ι → M} (hfg : ∀ x ∈ l, g x ≤ f x) :
     (l.map fun x ↦ f x - g x).sum = (l.map f).sum - (l.map g).sum :=
   eq_tsub_of_add_eq <| by

--- a/Mathlib/Algebra/MonoidAlgebra/Degree.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Degree.lean
@@ -484,8 +484,8 @@ lemma supDegree_mul
     exact add_mem (supDegree_mem_range D hp) (supDegree_mem_range D hq)
   · simp_rw [Finsupp.mem_support_iff, apply_supDegree_add_supDegree hD hadd]
     exact hpq
-  · have := covariantClass_le_of_lt B B (· + ·)
-    have := covariantClass_le_of_lt B B (Function.swap (· + ·))
+  · have := addLeftMono_of_addLeftStrictMono B
+    have := addRightMono_of_addRightStrictMono B
     exact fun a ha => (Finset.le_sup ha).trans (supDegree_mul_le hadd)
 
 lemma Monic.supDegree_mul_of_ne_zero_left

--- a/Mathlib/Algebra/Order/Group/DenselyOrdered.lean
+++ b/Mathlib/Algebra/Order/Group/DenselyOrdered.lean
@@ -38,34 +38,34 @@ section DenselyOrdered
 
 @[to_additive]
 private lemma exists_lt_mul_left [Group α] [LT α] [DenselyOrdered α]
-    [CovariantClass α α (Function.swap (· * ·)) (· < ·)] {a b c : α} (hc : c < a * b) :
+    [MulRightStrictMono α] {a b c : α} (hc : c < a * b) :
     ∃ a' < a, c < a' * b := by
   obtain ⟨a', hc', ha'⟩ := exists_between (div_lt_iff_lt_mul.2 hc)
   exact ⟨a', ha', div_lt_iff_lt_mul.1 hc'⟩
 
 @[to_additive]
 private lemma exists_lt_mul_right [CommGroup α] [LT α] [DenselyOrdered α]
-    [CovariantClass α α (· * ·) (· < ·)] {a b c : α} (hc : c < a * b) :
+    [MulLeftStrictMono α] {a b c : α} (hc : c < a * b) :
     ∃ b' < b, c < a * b' := by
   obtain ⟨a', hc', ha'⟩ := exists_between (div_lt_iff_lt_mul'.2 hc)
   exact ⟨a', ha', div_lt_iff_lt_mul'.1 hc'⟩
 
 @[to_additive]
 private lemma exists_mul_left_lt [Group α] [LT α] [DenselyOrdered α]
-    [CovariantClass α α (Function.swap (· * ·)) (· < ·)] {a b c : α} (hc : a * b < c) :
+    [MulRightStrictMono α] {a b c : α} (hc : a * b < c) :
     ∃ a' > a, a' * b < c := by
   obtain ⟨a', ha', hc'⟩ := exists_between (lt_div_iff_mul_lt.2 hc)
   exact ⟨a', ha', lt_div_iff_mul_lt.1 hc'⟩
 
 @[to_additive]
 private lemma exists_mul_right_lt [CommGroup α] [LT α] [DenselyOrdered α]
-    [CovariantClass α α (· * ·) (· < ·)] {a b c : α} (hc : a * b < c) :
+    [MulLeftStrictMono α] {a b c : α} (hc : a * b < c) :
     ∃ b' > b, a * b' < c := by
   obtain ⟨a', ha', hc'⟩ := exists_between (lt_div_iff_mul_lt'.2 hc)
   exact ⟨a', ha', lt_div_iff_mul_lt'.1 hc'⟩
 
 @[to_additive]
-lemma le_mul_of_forall_lt [CommGroup α] [LinearOrder α] [CovariantClass α α (· * ·) (· ≤ ·)]
+lemma le_mul_of_forall_lt [CommGroup α] [LinearOrder α] [MulLeftMono α]
     [DenselyOrdered α] {a b c : α} (h : ∀ a' > a, ∀ b' > b, c ≤ a' * b') :
     c ≤ a * b := by
   refine le_of_forall_gt_imp_ge_of_dense fun d hd ↦ ?_
@@ -74,7 +74,7 @@ lemma le_mul_of_forall_lt [CommGroup α] [LinearOrder α] [CovariantClass α α 
   exact (h a' ha' b' hb').trans hd.le
 
 @[to_additive]
-lemma mul_le_of_forall_lt [CommGroup α] [LinearOrder α] [CovariantClass α α (· * ·) (· ≤ ·)]
+lemma mul_le_of_forall_lt [CommGroup α] [LinearOrder α] [MulLeftMono α]
     [DenselyOrdered α] {a b c : α} (h : ∀ a' < a, ∀ b' < b, a' * b' ≤ c) :
     a * b ≤ c := by
   refine le_of_forall_lt_imp_le_of_dense fun d hd ↦ ?_

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/Basic.lean
@@ -336,19 +336,19 @@ theorem trichotomy_of_mul_eq_mul
     · exact False.elim <| ne_of_lt (mul_lt_mul_of_lt_of_lt hca hdb) h.symm
 
 @[to_additive]
-lemma mul_max [CovariantClass α α (· * ·) (· ≤ ·)] (a b c : α) :
+lemma mul_max [MulLeftMono α] (a b c : α) :
     a * max b c = max (a * b) (a * c) := mul_left_mono.map_max
 
 @[to_additive]
-lemma max_mul [CovariantClass α α (swap (· * ·)) (· ≤ ·)] (a b c : α) :
+lemma max_mul [MulRightMono α] (a b c : α) :
     max a b * c = max (a * c) (b * c) := mul_right_mono.map_max
 
 @[to_additive]
-lemma mul_min [CovariantClass α α (· * ·) (· ≤ ·)] (a b c : α) :
+lemma mul_min [MulLeftMono α] (a b c : α) :
     a * min b c = min (a * b) (a * c) := mul_left_mono.map_min
 
 @[to_additive]
-lemma min_mul [CovariantClass α α (swap (· * ·)) (· ≤ ·)] (a b c : α) :
+lemma min_mul [MulRightMono α] (a b c : α) :
     min a b * c = min (a * c) (b * c) := mul_right_mono.map_min
 
 @[to_additive] lemma min_lt_max_of_mul_lt_mul

--- a/Mathlib/Algebra/Order/Monoid/Unbundled/WithTop.lean
+++ b/Mathlib/Algebra/Order/Monoid/Unbundled/WithTop.lean
@@ -187,17 +187,17 @@ protected theorem add_lt_add_of_lt_of_le [Preorder α] [AddLeftMono α]
     w + x < y + z :=
   (WithTop.add_lt_add_right hx hwy).trans_le <| add_le_add_left hxz _
 
-lemma addLECancellable_of_ne_top [LE α] [ContravariantClass α α (· + ·) (· ≤ ·)]
+lemma addLECancellable_of_ne_top [LE α] [AddLeftReflectLE α]
     (hx : x ≠ ⊤) : AddLECancellable x := fun _b _c ↦ WithTop.le_of_add_le_add_left hx
 
-lemma addLECancellable_of_lt_top [Preorder α] [ContravariantClass α α (· + ·) (· ≤ ·)]
+lemma addLECancellable_of_lt_top [Preorder α] [AddLeftReflectLE α]
     (hx : x < ⊤) : AddLECancellable x := addLECancellable_of_ne_top hx.ne
 
-lemma addLECancellable_coe [LE α] [ContravariantClass α α (· + ·) (· ≤ ·)] (a : α) :
+lemma addLECancellable_coe [LE α] [AddLeftReflectLE α] (a : α) :
     AddLECancellable (a : WithTop α) := addLECancellable_of_ne_top coe_ne_top
 
 lemma addLECancellable_iff_ne_top [Nonempty α] [Preorder α]
-    [ContravariantClass α α (· + ·) (· ≤ ·)] : AddLECancellable x ↔ x ≠ ⊤ where
+    [AddLeftReflectLE α] : AddLECancellable x ↔ x ≠ ⊤ where
   mp := by rintro h rfl; exact (coe_lt_top <| Classical.arbitrary _).not_ge <| h <| by simp
   mpr := addLECancellable_of_ne_top
 
@@ -528,17 +528,17 @@ protected theorem add_lt_add_of_lt_of_le [Preorder α] [AddLeftMono α]
     w + x < y + z :=
   (WithBot.add_lt_add_right hx hwy).trans_le <| add_le_add_left hxz _
 
-lemma addLECancellable_of_ne_bot [LE α] [ContravariantClass α α (· + ·) (· ≤ ·)]
+lemma addLECancellable_of_ne_bot [LE α] [AddLeftReflectLE α]
     (hx : x ≠ ⊥) : AddLECancellable x := fun _b _c ↦ WithBot.le_of_add_le_add_left hx
 
-lemma addLECancellable_of_lt_bot [Preorder α] [ContravariantClass α α (· + ·) (· ≤ ·)]
+lemma addLECancellable_of_lt_bot [Preorder α] [AddLeftReflectLE α]
     (hx : x < ⊥) : AddLECancellable x := addLECancellable_of_ne_bot hx.ne
 
-lemma addLECancellable_coe [LE α] [ContravariantClass α α (· + ·) (· ≤ ·)] (a : α) :
+lemma addLECancellable_coe [LE α] [AddLeftReflectLE α] (a : α) :
     AddLECancellable (a : WithBot α) := addLECancellable_of_ne_bot coe_ne_bot
 
 lemma addLECancellable_iff_ne_bot [Nonempty α] [Preorder α]
-    [ContravariantClass α α (· + ·) (· ≤ ·)] : AddLECancellable x ↔ x ≠ ⊥ where
+    [AddLeftReflectLE α] : AddLECancellable x ↔ x ≠ ⊥ where
   mp := by rintro h rfl; exact (bot_lt_coe <| Classical.arbitrary _).not_ge <| h <| by simp
   mpr := addLECancellable_of_ne_bot
 

--- a/Mathlib/Data/DFinsupp/Order.lean
+++ b/Mathlib/Data/DFinsupp/Order.lean
@@ -244,7 +244,7 @@ variable (α)
 instance : OrderedSub (Π₀ i, α i) :=
   ⟨fun _ _ _ ↦ forall_congr' fun _ ↦ tsub_le_iff_right⟩
 
-instance [∀ i, CovariantClass (α i) (α i) (· + ·) (· ≤ ·)] : CanonicallyOrderedAdd (Π₀ i, α i) where
+instance [∀ i, AddLeftMono (α i)] : CanonicallyOrderedAdd (Π₀ i, α i) where
   exists_add_of_le := by
     intro f g h
     exists g - f

--- a/Mathlib/Data/Finsupp/Order.lean
+++ b/Mathlib/Data/Finsupp/Order.lean
@@ -181,7 +181,7 @@ instance tsub : Sub (ι →₀ α) :=
 instance orderedSub : OrderedSub (ι →₀ α) :=
   ⟨fun _n _m _k => forall_congr' fun _x => tsub_le_iff_right⟩
 
-instance [CovariantClass α α (· + ·) (· ≤ ·)] : CanonicallyOrderedAdd (ι →₀ α) where
+instance [AddLeftMono α] : CanonicallyOrderedAdd (ι →₀ α) where
   exists_add_of_le := fun {f g} h => ⟨g - f, ext fun x => (add_tsub_cancel_of_le <| h x).symm⟩
   le_self_add := fun _f _g _x => le_self_add
 

--- a/Mathlib/Order/Filter/IsBounded.lean
+++ b/Mathlib/Order/Filter/IsBounded.lean
@@ -373,7 +373,7 @@ end add_and_sum
 section add_and_sum
 
 variable {α : Type*} {R : Type*} [LinearOrder R] [Add R] {f : Filter α} [f.NeBot]
-  [CovariantClass R R (fun a b ↦ a + b) (· ≤ ·)] [CovariantClass R R (fun a b ↦ b + a) (· ≤ ·)]
+  [AddLeftMono R] [AddRightMono R]
   {u v : α → R}
 
 lemma isCoboundedUnder_ge_add (hu : f.IsBoundedUnder (· ≤ ·) u)

--- a/Mathlib/Probability/Kernel/Defs.lean
+++ b/Mathlib/Probability/Kernel/Defs.lean
@@ -100,8 +100,8 @@ noncomputable instance instAddCommMonoid : AddCommMonoid (Kernel α β) :=
 
 instance instPartialOrder : PartialOrder (Kernel α β) := .lift _ DFunLike.coe_injective
 
-instance instCovariantAddLE {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] :
-    CovariantClass (Kernel α β) (Kernel α β) (· + ·) (· ≤ ·) :=
+instance {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] :
+    AddLeftMono (Kernel α β) :=
   ⟨fun _ _ _ hμ a ↦ add_le_add_left (hμ a) _⟩
 
 noncomputable

--- a/Mathlib/Topology/Algebra/Order/LiminfLimsup.lean
+++ b/Mathlib/Topology/Algebra/Order/LiminfLimsup.lean
@@ -32,7 +32,7 @@ variable {ι α β R S : Type*} {X : ι → Type*}
 section LiminfLimsupAdd
 
 variable [AddCommGroup α] [ConditionallyCompleteLinearOrder α] [DenselyOrdered α]
-  [CovariantClass α α (fun a b ↦ a + b) fun x1 x2 ↦ x1 ≤ x2]
+  [AddLeftMono α]
   {f : Filter ι} [f.NeBot] {u v : ι → α}
 
 lemma le_limsup_add (h₁ : IsBoundedUnder (fun x1 x2 ↦ x1 ≤ x2) f u := by isBoundedDefault)


### PR DESCRIPTION
... `Add/MulLeft/Right(Strict)Mono` and `Add/MulLeft/RightReflectLE`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
