### PR TITLE
[Merged by Bors] - feat(Analysis/InnerProductSpace/LinearMap): `innerSL 𝕜 x = innerSL 𝕜 y` iff `x = y`

### DIFF
--- a/Mathlib/Analysis/InnerProductSpace/Dual.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Dual.lean
@@ -71,7 +71,7 @@ theorem toDualMap_apply {x y : E} : toDualMap 𝕜 E x y = ⟪x, y⟫ :=
   rfl
 
 variable {𝕜} in
-theorem innerSL_inj {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] {x y : E} :
+@[simp] theorem innerSL_inj {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] {x y : E} :
     innerSL 𝕜 x = innerSL 𝕜 y ↔ x = y :=
   (toDualMap 𝕜 E).injective.eq_iff
 

--- a/Mathlib/Analysis/InnerProductSpace/Dual.lean
+++ b/Mathlib/Analysis/InnerProductSpace/Dual.lean
@@ -70,6 +70,11 @@ variable {E}
 theorem toDualMap_apply {x y : E} : toDualMap 𝕜 E x y = ⟪x, y⟫ :=
   rfl
 
+variable {𝕜} in
+theorem innerSL_inj {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] {x y : E} :
+    innerSL 𝕜 x = innerSL 𝕜 y ↔ x = y :=
+  (toDualMap 𝕜 E).injective.eq_iff
+
 section NullSubmodule
 
 open LinearMap

--- a/Mathlib/Analysis/InnerProductSpace/LinearMap.lean
+++ b/Mathlib/Analysis/InnerProductSpace/LinearMap.lean
@@ -196,6 +196,13 @@ theorem innerSL_apply_coe (v : E) : ⇑(innerSL 𝕜 v) = fun w => ⟪v, w⟫ :=
 theorem innerSL_apply (v w : E) : innerSL 𝕜 v w = ⟪v, w⟫ :=
   rfl
 
+variable {𝕜} in
+theorem innerSL_apply_inj {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] {x y : E} :
+    innerSL 𝕜 x = innerSL 𝕜 y ↔ x = y := by
+  refine ⟨fun h => ?_, fun h => h ▸ rfl⟩
+  rw [← sub_eq_zero]
+  simpa [← sub_eq_zero (a := inner 𝕜 x _), ← inner_sub_left] using congr($h (x - y))
+
 /-- The inner product as a continuous sesquilinear map, with the two arguments flipped. -/
 def innerSLFlip : E →L[𝕜] E →L⋆[𝕜] 𝕜 :=
   @ContinuousLinearMap.flipₗᵢ' 𝕜 𝕜 𝕜 E E 𝕜 _ _ _ _ _ _ _ _ _ (RingHom.id 𝕜) (starRingEnd 𝕜) _ _

--- a/Mathlib/Analysis/InnerProductSpace/LinearMap.lean
+++ b/Mathlib/Analysis/InnerProductSpace/LinearMap.lean
@@ -197,7 +197,7 @@ theorem innerSL_apply (v w : E) : innerSL 𝕜 v w = ⟪v, w⟫ :=
   rfl
 
 variable {𝕜} in
-theorem innerSL_apply_inj {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] {x y : E} :
+theorem innerSL_inj {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] {x y : E} :
     innerSL 𝕜 x = innerSL 𝕜 y ↔ x = y := by
   refine ⟨fun h => ?_, fun h => h ▸ rfl⟩
   rw [← sub_eq_zero]

--- a/Mathlib/Analysis/InnerProductSpace/LinearMap.lean
+++ b/Mathlib/Analysis/InnerProductSpace/LinearMap.lean
@@ -196,13 +196,6 @@ theorem innerSL_apply_coe (v : E) : ⇑(innerSL 𝕜 v) = fun w => ⟪v, w⟫ :=
 theorem innerSL_apply (v w : E) : innerSL 𝕜 v w = ⟪v, w⟫ :=
   rfl
 
-variable {𝕜} in
-theorem innerSL_inj {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] {x y : E} :
-    innerSL 𝕜 x = innerSL 𝕜 y ↔ x = y := by
-  refine ⟨fun h => ?_, fun h => h ▸ rfl⟩
-  rw [← sub_eq_zero]
-  simpa [← sub_eq_zero (a := inner 𝕜 x _), ← inner_sub_left] using congr($h (x - y))
-
 /-- The inner product as a continuous sesquilinear map, with the two arguments flipped. -/
 def innerSLFlip : E →L[𝕜] E →L⋆[𝕜] 𝕜 :=
   @ContinuousLinearMap.flipₗᵢ' 𝕜 𝕜 𝕜 E E 𝕜 _ _ _ _ _ _ _ _ _ (RingHom.id 𝕜) (starRingEnd 𝕜) _ _

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm/Mul.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm/Mul.lean
@@ -198,7 +198,7 @@ theorem comp_lsmul_flip_apply {F : Type*} [SeminormedAddCommGroup F] [NormedSpac
   ext; simp
 
 variable {𝕜} in
-theorem lsmul_flip_apply_inj {x y : E} :
+theorem lsmul_flip_inj {x y : E} :
     (lsmul 𝕜 R).flip x = (lsmul 𝕜 R).flip y ↔ x = y :=
   ⟨fun h => by simpa using congr($h 1), fun h => h ▸ rfl⟩
 

--- a/Mathlib/Analysis/NormedSpace/OperatorNorm/Mul.lean
+++ b/Mathlib/Analysis/NormedSpace/OperatorNorm/Mul.lean
@@ -197,6 +197,11 @@ theorem comp_lsmul_flip_apply {F : Type*} [SeminormedAddCommGroup F] [NormedSpac
     f ∘L (lsmul 𝕜 𝕜).flip x = (lsmul 𝕜 𝕜).flip (f x) := by
   ext; simp
 
+variable {𝕜} in
+theorem lsmul_flip_apply_inj {x y : E} :
+    (lsmul 𝕜 R).flip x = (lsmul 𝕜 R).flip y ↔ x = y :=
+  ⟨fun h => by simpa using congr($h 1), fun h => h ▸ rfl⟩
+
 variable {R}
 
 theorem norm_toSpanSingleton (x : E) : ‖toSpanSingleton 𝕜 x‖ = ‖x‖ := by


### PR DESCRIPTION
This adds `innerSL 𝕜 x = innerSL 𝕜 y` iff `x = y` and `(lsmul 𝕜 R).flip x = (lsmul 𝕜 R).flip y` iff `x = y`.

In [bra-ket notation](https://en.wikipedia.org/wiki/Bra–ket_notation), this is simply `|x⟩ = |y⟩` iff `x = y` and `⟨x| = ⟨y|` iff `x = y`, where `|x⟩ = (lsmul 𝕜 R).flip x` and `⟨x| = innerSL 𝕜 x`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
