### PR TITLE
[Merged by Bors] - chore(Algebra): move some `Star` defs to more appropriate homes

### DIFF
--- a/Mathlib/Algebra/Module/LinearMap/Basic.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Basic.lean
@@ -14,7 +14,7 @@ import Mathlib.GroupTheory.GroupAction.DomAct.Basic
 -/
 
 
-assert_not_exists Submonoid Finset Star
+assert_not_exists Submonoid Finset TrivialStar
 
 open Function
 

--- a/Mathlib/Algebra/Module/LinearMap/Defs.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Defs.lean
@@ -51,7 +51,7 @@ linear map
 -/
 
 
-assert_not_exists Star DomMulAct Pi.module WCovBy.image Field
+assert_not_exists TrivialStar DomMulAct Pi.module WCovBy.image Field
 
 open Function
 

--- a/Mathlib/Algebra/Notation/Defs.lean
+++ b/Mathlib/Algebra/Notation/Defs.lean
@@ -81,6 +81,21 @@ variable {G : Type*}
 
 attribute [to_additive, notation_class] Inv
 
+section Star
+
+/-- Notation typeclass (with no default notation!) for an algebraic structure with a star operation.
+-/
+class Star (R : Type u) where
+  star : R → R
+
+export Star (star)
+
+/-- A star operation (e.g. complex conjugate).
+-/
+add_decl_doc star
+
+end Star
+
 section ite
 variable {α : Type*} (P : Prop) [Decidable P]
 

--- a/Mathlib/Algebra/Notation/Defs.lean
+++ b/Mathlib/Algebra/Notation/Defs.lean
@@ -16,6 +16,9 @@ Notation typeclass for `Inv`, the multiplicative analogue of `Neg`.
 We also introduce notation classes `SMul` and `VAdd` for multiplicative and additive
 actions.
 
+We introduce the notation typeclass `Star` for algebraic structures with a star operation. Note: to
+accommodate diverse notational preferences, no default notation is provided for `Star.star`.
+
 `SMul` is typically, but not exclusively, used for scalar multiplication-like operators.
 See the module `Algebra.AddTorsor` for a motivating example for the name `VAdd` (vector addition).
 

--- a/Mathlib/Algebra/Notation/Pi/Defs.lean
+++ b/Mathlib/Algebra/Notation/Pi/Defs.lean
@@ -10,7 +10,8 @@ import Mathlib.Util.AssertExists
 # Notation for algebraic operators on pi types
 
 This file provides only the notation for (pointwise) `0`, `1`, `+`, `*`, `•`, `^`, `⁻¹` on pi types.
-See `Mathlib/Algebra/Group/Pi/Basic.lean` for the `Monoid` and `Group` instances.
+See `Mathlib/Algebra/Group/Pi/Basic.lean` for the `Monoid` and `Group` instances. There is also
+an instance of the `Star` notation typeclass, but no default notation is included.
 -/
 
 assert_not_exists Set.range Monoid DenselyOrdered

--- a/Mathlib/Algebra/Notation/Pi/Defs.lean
+++ b/Mathlib/Algebra/Notation/Pi/Defs.lean
@@ -17,7 +17,7 @@ assert_not_exists Set.range Monoid DenselyOrdered
 
 open Function
 
-variable {ι α β : Type*} {G M : ι → Type*}
+variable {ι α β : Type*} {G M R : ι → Type*}
 
 namespace Pi
 
@@ -134,4 +134,19 @@ lemma _root_.Function.const_pow (a : M) (b : α) : const ι a ^ b = const ι (a 
 lemma pow_comp (f : β → M) (a : α) (g : ι → β) : (f ^ a) ∘ g = f ∘ g ^ a := rfl
 
 end Pow
+
+section Star
+
+variable [∀ i, Star (R i)]
+
+instance : Star (∀ i, R i) where star x i := star (x i)
+
+@[simp]
+theorem star_apply (x : ∀ i, R i) (i : ι) : star x i = star (x i) := rfl
+
+theorem star_def (x : ∀ i, R i) : star x = fun i => star (x i) := rfl
+
+end Star
+
+
 end Pi

--- a/Mathlib/Algebra/Notation/Prod.lean
+++ b/Mathlib/Algebra/Notation/Prod.lean
@@ -16,7 +16,7 @@ We also prove trivial `simp` lemmas:
 
 assert_not_exists Monoid DenselyOrdered
 
-variable {G : Type*} {H : Type*} {M : Type*} {N : Type*} {P : Type*}
+variable {G H M N P R S : Type*}
 
 namespace Prod
 
@@ -167,5 +167,22 @@ lemma pow_def (p : α × β) (c : E) : p ^ c = (p.1 ^ c, p.2 ^ c) := rfl
 lemma pow_swap (p : α × β) (c : E) : (p ^ c).swap = p.swap ^ c := rfl
 
 end Pow
+
+section Star
+
+variable [Star R] [Star S]
+
+instance : Star (R × S) where star x := (star x.1, star x.2)
+
+@[simp]
+theorem fst_star (x : R × S) : (star x).1 = star x.1 := rfl
+
+@[simp]
+theorem snd_star (x : R × S) : (star x).2 = star x.2 := rfl
+
+theorem star_def (x : R × S) : star x = (star x.1, star x.2) := rfl
+
+end Star
+
 
 end Prod

--- a/Mathlib/Algebra/Notation/Prod.lean
+++ b/Mathlib/Algebra/Notation/Prod.lean
@@ -8,10 +8,13 @@ import Mathlib.Algebra.Notation.Defs
 import Mathlib.Data.Prod.Basic
 
 /-!
-# `Zero` and `One` instances on `M × N`
+# Arithmetic operators on (pairwise) product types
 
-In this file we define `0` and `1` on `M × N` as the pair `(0, 0)` and `(1, 1)` respectively.
-We also prove trivial `simp` lemmas:
+This file provides only the notation for (componentwise) `0`, `1`, `+`, `*`, `•`, `^`, `⁻¹` on
+(pairwise) product types. See `Mathlib/Algebra/Group/Prod.lean` for the `Monoid` and `Group`
+instances. There is also an instance of the `Star` notation typeclass, but no default notation is
+included.
+
 -/
 
 assert_not_exists Monoid DenselyOrdered

--- a/Mathlib/Algebra/RingQuot.lean
+++ b/Mathlib/Algebra/RingQuot.lean
@@ -20,7 +20,7 @@ definition, which is made irreducible for this purpose.
 Since everything runs in parallel for quotients of `R`-algebras, we do that case at the same time.
 -/
 
-assert_not_exists Star.star
+assert_not_exists TrivialStar
 
 universe uR uS uT uA u₄
 

--- a/Mathlib/Algebra/Star/Basic.lean
+++ b/Mathlib/Algebra/Star/Basic.lean
@@ -37,6 +37,8 @@ universe u v w
 
 open MulOpposite
 
+variable {R : Type u}
+
 /-- `StarMemClass S G` states `S` is a type of subsets `s ⊆ G` closed under star. -/
 class StarMemClass (S R : Type*) [Star R] [SetLike S R] : Prop where
   /-- Closure under star. -/

--- a/Mathlib/Algebra/Star/Basic.lean
+++ b/Mathlib/Algebra/Star/Basic.lean
@@ -37,19 +37,6 @@ universe u v w
 
 open MulOpposite
 
-/-- Notation typeclass (with no default notation!) for an algebraic structure with a star operation.
--/
-class Star (R : Type u) where
-  star : R → R
-
-variable {R : Type u}
-
-export Star (star)
-
-/-- A star operation (e.g. complex conjugate).
--/
-add_decl_doc star
-
 /-- `StarMemClass S G` states `S` is a type of subsets `s ⊆ G` closed under star. -/
 class StarMemClass (S R : Type*) [Star R] [SetLike S R] : Prop where
   /-- Closure under star. -/

--- a/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
+++ b/Mathlib/Algebra/Star/NonUnitalSubalgebra.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Algebra.NonUnitalSubalgebra
 import Mathlib.Algebra.Star.StarAlgHom
 import Mathlib.Algebra.Star.Center
 import Mathlib.Algebra.Star.SelfAdjoint
+import Mathlib.Algebra.Star.Prod
 
 /-!
 # Non-unital Star Subalgebras

--- a/Mathlib/Algebra/Star/Pi.lean
+++ b/Mathlib/Algebra/Star/Pi.lean
@@ -11,7 +11,7 @@ import Mathlib.Algebra.Ring.Pi
 # Basic Results about Star on Pi Types
 
 This file provides basic results about the star on product types defined in
-`Mathlib.Algebra.Notation.Pi.Defs`.
+`Mathlib/Algebra/Notation/Pi/Defs.lean`.
 -/
 
 

--- a/Mathlib/Algebra/Star/Pi.lean
+++ b/Mathlib/Algebra/Star/Pi.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
 import Mathlib.Algebra.Star.Basic
+import Mathlib.Algebra.Notation.Pi.Defs
 import Mathlib.Algebra.Ring.Pi
 
 /-!
@@ -23,15 +24,6 @@ variable {f : I → Type v}
 
 -- The family of types already equipped with instances
 namespace Pi
-
-instance [∀ i, Star (f i)] : Star (∀ i, f i) where star x i := star (x i)
-
-@[simp]
-theorem star_apply [∀ i, Star (f i)] (x : ∀ i, f i) (i : I) : star x i = star (x i) :=
-  rfl
-
-theorem star_def [∀ i, Star (f i)] (x : ∀ i, f i) : star x = fun i => star (x i) :=
-  rfl
 
 instance [∀ i, Star (f i)] [∀ i, TrivialStar (f i)] : TrivialStar (∀ i, f i) where
   star_trivial _ := funext fun _ => star_trivial _

--- a/Mathlib/Algebra/Star/Pi.lean
+++ b/Mathlib/Algebra/Star/Pi.lean
@@ -8,10 +8,10 @@ import Mathlib.Algebra.Notation.Pi.Defs
 import Mathlib.Algebra.Ring.Pi
 
 /-!
-# `star` on pi types
+# Basic Results about Star on Pi Types
 
-We put a `Star` structure on pi types that operates elementwise, such that it describes the
-complex conjugation of vectors.
+This file provides basic results about the star on product types defined in
+`Mathlib.Algebra.Notation.Pi.Defs`.
 -/
 
 

--- a/Mathlib/Algebra/Star/Prod.lean
+++ b/Mathlib/Algebra/Star/Prod.lean
@@ -10,7 +10,7 @@ import Mathlib.Algebra.Star.Basic
 # Basic Results about Star on Product Type
 
 This file provides basic results about the star on product types defined in
-`Mathlib.Algebra.Notation.Prod.lean`.
+`Mathlib/Algebra/Notation/Prod.lean`.
 
 -/
 

--- a/Mathlib/Algebra/Star/Prod.lean
+++ b/Mathlib/Algebra/Star/Prod.lean
@@ -19,19 +19,6 @@ variable {R : Type u} {S : Type v}
 
 namespace Prod
 
-instance [Star R] [Star S] : Star (R × S) where star x := (star x.1, star x.2)
-
-@[simp]
-theorem fst_star [Star R] [Star S] (x : R × S) : (star x).1 = star x.1 :=
-  rfl
-
-@[simp]
-theorem snd_star [Star R] [Star S] (x : R × S) : (star x).2 = star x.2 :=
-  rfl
-
-theorem star_def [Star R] [Star S] (x : R × S) : star x = (star x.1, star x.2) :=
-  rfl
-
 instance [Star R] [Star S] [TrivialStar R] [TrivialStar S] : TrivialStar (R × S) where
   star_trivial _ := Prod.ext (star_trivial _) (star_trivial _)
 

--- a/Mathlib/Algebra/Star/Prod.lean
+++ b/Mathlib/Algebra/Star/Prod.lean
@@ -7,9 +7,11 @@ import Mathlib.Algebra.Ring.Prod
 import Mathlib.Algebra.Star.Basic
 
 /-!
-# `Star` on product types
+# Basic Results about Star on Product Type
 
-We put a `Star` structure on product types that operates elementwise.
+This file provides basic results about the star on product types defined in
+`Mathlib.Algebra.Notation.Prod.lean`.
+
 -/
 
 

--- a/Mathlib/Algebra/Star/SelfAdjoint.lean
+++ b/Mathlib/Algebra/Star/SelfAdjoint.lean
@@ -5,7 +5,6 @@ Authors: Frédéric Dupuis
 -/
 import Mathlib.Algebra.Group.Subgroup.Defs
 import Mathlib.Algebra.Module.Defs
-import Mathlib.Algebra.Star.Pi
 import Mathlib.Algebra.Star.Rat
 
 /-!

--- a/Mathlib/Algebra/Star/StarAlgHom.lean
+++ b/Mathlib/Algebra/Star/StarAlgHom.lean
@@ -7,8 +7,6 @@ import Mathlib.Algebra.Algebra.Equiv
 import Mathlib.Algebra.Algebra.NonUnitalHom
 import Mathlib.Algebra.Algebra.Prod
 import Mathlib.Algebra.Algebra.Pi
-import Mathlib.Algebra.Star.Prod
-import Mathlib.Algebra.Star.Pi
 import Mathlib.Algebra.Star.StarRingHom
 
 /-!

--- a/Mathlib/Analysis/CStarAlgebra/Basic.lean
+++ b/Mathlib/Analysis/CStarAlgebra/Basic.lean
@@ -6,6 +6,7 @@ Authors: Frédéric Dupuis
 import Mathlib.Analysis.Normed.Group.Hom
 import Mathlib.Analysis.Normed.Module.Basic
 import Mathlib.Analysis.Normed.Operator.LinearIsometry
+import Mathlib.Algebra.Star.Pi
 import Mathlib.Algebra.Star.SelfAdjoint
 import Mathlib.Algebra.Star.Subalgebra
 import Mathlib.Algebra.Star.Unitary

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -28,7 +28,7 @@ Under various conditions, multiplication of infinite matrices makes sense.
 These have not yet been implemented.
 -/
 
-assert_not_exists Star
+assert_not_exists TrivialStar
 
 universe u u' v w
 

--- a/Mathlib/Data/Matrix/ConjTranspose.lean
+++ b/Mathlib/Data/Matrix/ConjTranspose.lean
@@ -9,7 +9,6 @@ import Mathlib.Algebra.BigOperators.RingEquiv
 import Mathlib.Algebra.Module.Pi
 import Mathlib.Algebra.Star.BigOperators
 import Mathlib.Algebra.Star.Module
-import Mathlib.Algebra.Star.Pi
 import Mathlib.Data.Fintype.BigOperators
 import Mathlib.Data.Matrix.Basis
 import Mathlib.Data.Matrix.Mul

--- a/Mathlib/Data/Matrix/Defs.lean
+++ b/Mathlib/Data/Matrix/Defs.lean
@@ -39,7 +39,7 @@ form `fun i j ↦ _` or even `(fun i j ↦ _ : Matrix m n α)`, as these are not
 as having the right type. Instead, `Matrix.of` should be used.
 -/
 
-assert_not_exists Algebra Star
+assert_not_exists Algebra TrivialStar
 
 universe u u' v w
 

--- a/Mathlib/Data/Matrix/Diagonal.lean
+++ b/Mathlib/Data/Matrix/Diagonal.lean
@@ -21,7 +21,7 @@ This file defines diagonal matrices and the `AddCommMonoidWithOne` structure on 
 * `Matrix.instAddCommMonoidWithOne`: matrices are an additive commutative monoid with one
 -/
 
-assert_not_exists Algebra Star
+assert_not_exists Algebra TrivialStar
 
 universe u u' v w
 

--- a/Mathlib/Data/Matrix/Mul.lean
+++ b/Mathlib/Data/Matrix/Mul.lean
@@ -46,7 +46,7 @@ Under various conditions, multiplication of infinite matrices makes sense.
 These have not yet been implemented.
 -/
 
-assert_not_exists Algebra Field Star
+assert_not_exists Algebra Field TrivialStar
 
 universe u u' v w
 

--- a/Mathlib/Data/NNReal/Basic.lean
+++ b/Mathlib/Data/NNReal/Basic.lean
@@ -22,7 +22,7 @@ As a consequence, it is a bit of a random collection of results, and is a good t
 This file uses `ℝ≥0` as a localized notation for `NNReal`.
 -/
 
-assert_not_exists Star
+assert_not_exists TrivialStar
 
 open Function
 open scoped BigOperators

--- a/Mathlib/Data/NNReal/Defs.lean
+++ b/Mathlib/Data/NNReal/Defs.lean
@@ -45,7 +45,7 @@ of `x` with `↑x`. This tactic also works for a function `f : α → ℝ` with 
 This file defines `ℝ≥0` as a localized notation for `NNReal`.
 -/
 
-assert_not_exists Star
+assert_not_exists TrivialStar
 
 open Function
 

--- a/Mathlib/LinearAlgebra/Matrix/DotProduct.lean
+++ b/Mathlib/LinearAlgebra/Matrix/DotProduct.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl, Patrick Massot, Casper Putz, Anne Baanen
 -/
 import Mathlib.Algebra.Order.Star.Basic
 import Mathlib.Data.Matrix.RowCol
+import Mathlib.Algebra.Star.Pi
 
 /-!
 # Dot product of two vectors

--- a/Mathlib/Topology/Algebra/Module/Basic.lean
+++ b/Mathlib/Topology/Algebra/Module/Basic.lean
@@ -18,7 +18,7 @@ import Mathlib.LinearAlgebra.Quotient.Defs
 We use the class `ContinuousSMul` for topological (semi) modules and topological vector spaces.
 -/
 
-assert_not_exists Star.star
+assert_not_exists TrivialStar
 
 open LinearMap (ker range)
 open Topology Filter Pointwise

--- a/Mathlib/Topology/Algebra/Module/Equiv.lean
+++ b/Mathlib/Topology/Algebra/Module/Equiv.lean
@@ -13,7 +13,7 @@ Continuous semilinear / linear / star-linear equivalences between topological mo
 by `M ≃SL[σ] M₂`, `M ≃L[R] M₂` and `M ≃L⋆[R] M₂`.
 -/
 
-assert_not_exists Star.star
+assert_not_exists TrivialStar
 
 open LinearMap (ker range)
 open Topology Filter Pointwise

--- a/Mathlib/Topology/Algebra/Module/LinearMap.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearMap.lean
@@ -18,7 +18,7 @@ modules which are continuous. The set of continuous semilinear maps between the 
 Plain linear maps are denoted by `M →L[R] M₂` and star-linear maps by `M →L⋆[R] M₂`.
 -/
 
-assert_not_exists Star.star
+assert_not_exists TrivialStar
 
 open LinearMap (ker range)
 open Topology Filter Pointwise

--- a/Mathlib/Topology/Algebra/Module/LinearMapPiProd.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearMapPiProd.lean
@@ -10,7 +10,7 @@ import Mathlib.Topology.Algebra.Module.LinearMap
 # Continuous linear maps on products and Pi types
 -/
 
-assert_not_exists Star.star
+assert_not_exists TrivialStar
 
 open LinearMap (ker range)
 open Topology Filter Pointwise

--- a/Mathlib/Topology/Algebra/Star.lean
+++ b/Mathlib/Topology/Algebra/Star.lean
@@ -3,10 +3,9 @@ Copyright (c) 2022 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
-import Mathlib.Algebra.Star.Pi
-import Mathlib.Algebra.Star.Prod
 import Mathlib.Topology.Algebra.Constructions
 import Mathlib.Topology.ContinuousMap.Defs
+import Mathlib.Algebra.Star.Basic
 
 /-!
 # Continuity of `star`

--- a/Mathlib/Topology/ContinuousMap/Periodic.lean
+++ b/Mathlib/Topology/ContinuousMap/Periodic.lean
@@ -10,7 +10,7 @@ import Mathlib.Topology.ContinuousMap.Algebra
 # Sums of translates of a continuous function is a period continuous function.
 
 -/
-assert_not_exists StoneCech StarModule
+assert_not_exists StoneCech dite_div_dite
 
 namespace ContinuousMap
 

--- a/Mathlib/Topology/ContinuousMap/Periodic.lean
+++ b/Mathlib/Topology/ContinuousMap/Periodic.lean
@@ -10,7 +10,7 @@ import Mathlib.Topology.ContinuousMap.Algebra
 # Sums of translates of a continuous function is a period continuous function.
 
 -/
-assert_not_exists StoneCech dite_div_dite
+assert_not_exists StoneCech StarModule
 
 namespace ContinuousMap
 


### PR DESCRIPTION
Defining `Star` instances in some files causes collisions with guards against import creep. This PR is a minor fix for this that moves a few definitions and basic results "further back". A more substantial Defs/Basic split may be needed beyond this, but that's a more substantial task.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
