### PR TITLE
[Merged by Bors] - feat: extend the theorems where `length`/`card`/`ncard`/`encard` equals a certain number to the number four

### DIFF
--- a/Mathlib/Algebra/FreeMonoid/Basic.lean
+++ b/Mathlib/Algebra/FreeMonoid/Basic.lean
@@ -182,6 +182,10 @@ theorem length_eq_two {v : FreeMonoid α} :
 theorem length_eq_three {v : FreeMonoid α} : v.length = 3 ↔ ∃ (a b c : α), v = of a * of b * of c :=
   List.length_eq_three
 
+@[to_additive]
+theorem length_eq_four {v : FreeMonoid α} :
+    v.length = 4 ↔ ∃ (a b c d : α), v = of a * of b * of c * of d := List.length_eq_four
+
 @[to_additive (attr := simp)]
 theorem length_mul (a b : FreeMonoid α) : (a * b).length = a.length + b.length :=
   List.length_append

--- a/Mathlib/Data/Finset/Card.lean
+++ b/Mathlib/Data/Finset/Card.lean
@@ -760,6 +760,19 @@ theorem card_eq_three : #s = 3 ↔ ∃ x y z, x ≠ y ∧ x ≠ z ∧ y ≠ z �
     simp only [xy, xz, yz, mem_insert, card_insert_of_notMem, not_false_iff, mem_singleton,
       or_self_iff, card_singleton]
 
+theorem card_eq_four : #s = 4 ↔
+    ∃ x y z w, x ≠ y ∧ x ≠ z ∧ x ≠ w ∧ y ≠ z ∧ y ≠ w ∧ z ≠ w ∧ s = {x, y, z, w} := by
+  constructor
+  · rw [card_eq_succ]
+    simp_rw [card_eq_three]
+    rintro ⟨a, _, abcd, rfl, b, c, d, bc, bd, cd, rfl⟩
+    simp_rw [mem_insert, mem_singleton, not_or] at abcd
+    exact ⟨a, b, c, d, abcd.1, abcd.2.1, abcd.2.2, bc, bd, cd, rfl⟩
+  · rintro ⟨x, y, z, w, xy, xz, xw, yz, yw, zw, rfl⟩
+    simp only [xy, xz, xw, yz, yw, zw, mem_insert,
+      card_insert_of_notMem, not_false_iff, mem_singleton,
+      or_self_iff, card_singleton]
+
 end DecidableEq
 
 theorem two_lt_card_iff : 2 < #s ↔ ∃ a b c, a ∈ s ∧ b ∈ s ∧ c ∈ s ∧ a ≠ b ∧ a ≠ c ∧ b ≠ c := by
@@ -774,6 +787,22 @@ theorem two_lt_card_iff : 2 < #s ↔ ∃ a b c, a ∈ s ∧ b ∈ s ∧ c ∈ s 
 
 theorem two_lt_card : 2 < #s ↔ ∃ a ∈ s, ∃ b ∈ s, ∃ c ∈ s, a ≠ b ∧ a ≠ c ∧ b ≠ c := by
   simp_rw [two_lt_card_iff, exists_and_left]
+
+theorem three_lt_card_iff : 3 < #s ↔
+    ∃ a b c d, a ∈ s ∧ b ∈ s ∧ c ∈ s ∧ d ∈ s ∧
+    a ≠ b ∧ a ≠ c ∧ a ≠ d ∧ b ≠ c ∧ b ≠ d ∧ c ≠ d := by
+  classical
+    simp_rw [lt_iff_add_one_le, le_card_iff_exists_subset_card, reduceAdd, card_eq_four,
+      ← exists_and_left, exists_comm (α := Finset α)]
+    constructor
+    · rintro ⟨a, b, c, d, t, hsub, hab, hac, had, hbc, hbd, hcd, rfl⟩
+      exact ⟨a, b, c, d, by simp_all [insert_subset_iff]⟩
+    · rintro ⟨a, b, c, d, ha, hb, hc, hd, hab, hac, had, hbc, hbd, hcd⟩
+      exact ⟨a, b, c, d, {a, b, c, d}, by simp_all [insert_subset_iff]⟩
+
+theorem three_lt_card : 3 < #s ↔ ∃ a ∈ s, ∃ b ∈ s, ∃ c ∈ s, ∃ d ∈ s,
+    a ≠ b ∧ a ≠ c ∧ a ≠ d ∧ b ≠ c ∧ b ≠ d ∧ c ≠ d := by
+  simp_rw [three_lt_card_iff, exists_and_left]
 
 /-! ### Inductions -/
 

--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -118,6 +118,9 @@ theorem length_eq_two {l : List α} : l.length = 2 ↔ ∃ a b, l = [a, b] :=
 theorem length_eq_three {l : List α} : l.length = 3 ↔ ∃ a b c, l = [a, b, c] :=
   ⟨fun _ => let [a, b, c] := l; ⟨a, b, c, rfl⟩, fun ⟨_, _, _, e⟩ => e ▸ rfl⟩
 
+theorem length_eq_four {l : List α} : l.length = 4 ↔ ∃ a b c d, l = [a, b, c, d] :=
+  ⟨fun _ => let [a, b, c, d] := l; ⟨a, b, c, d, rfl⟩, fun ⟨_, _, _, _, e⟩ => e ▸ rfl⟩
+
 /-! ### set-theoretic notation of lists -/
 
 instance instSingletonList : Singleton α (List α) := ⟨fun x => [x]⟩

--- a/Mathlib/Data/Multiset/ZeroCons.lean
+++ b/Mathlib/Data/Multiset/ZeroCons.lean
@@ -466,7 +466,7 @@ theorem card_eq_three {s : Multiset α} : card s = 3 ↔ ∃ x y z, s = {x, y, z
         Exists.imp fun _b => Exists.imp fun _c => congr_arg _,
     fun ⟨_a, _b, _c, e⟩ => e.symm ▸ rfl⟩
 
-theorem card_eq_four {s : Multiset α} : card s = 4 ↔ ∃ w x y z, s = {w, x, y, z} :=
+theorem card_eq_four {s : Multiset α} : card s = 4 ↔ ∃ x y z w, s = {x, y, z, w} :=
   ⟨Quot.inductionOn s fun _l h =>
       (List.length_eq_four.mp h).imp fun _a =>
         Exists.imp fun _b => Exists.imp fun _c => Exists.imp fun _d => congr_arg _,

--- a/Mathlib/Data/Multiset/ZeroCons.lean
+++ b/Mathlib/Data/Multiset/ZeroCons.lean
@@ -466,6 +466,12 @@ theorem card_eq_three {s : Multiset α} : card s = 3 ↔ ∃ x y z, s = {x, y, z
         Exists.imp fun _b => Exists.imp fun _c => congr_arg _,
     fun ⟨_a, _b, _c, e⟩ => e.symm ▸ rfl⟩
 
+theorem card_eq_four {s : Multiset α} : card s = 4 ↔ ∃ w x y z, s = {w, x, y, z} :=
+  ⟨Quot.inductionOn s fun _l h =>
+      (List.length_eq_four.mp h).imp fun _a =>
+        Exists.imp fun _b => Exists.imp fun _c => Exists.imp fun _d => congr_arg _,
+    fun ⟨_a, _b, _c, _d, e⟩ => e.symm ▸ rfl⟩
+
 /-! ### Map for partial functions -/
 
 @[simp]

--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -1122,7 +1122,8 @@ theorem three_lt_ncard_iff (hs : s.Finite := by toFinite_tac) :
   simp_rw [ncard_eq_toFinset_card _ hs, Finset.three_lt_card_iff, Finite.mem_toFinset]
 
 theorem three_lt_ncard (hs : s.Finite := by toFinite_tac) :
-    3 < s.ncard ↔ ∃ a ∈ s, ∃ b ∈ s, ∃ c ∈ s, ∃ d ∈ s, a ≠ b ∧ a ≠ c ∧ a ≠ d ∧ b ≠ c ∧ b ≠ d ∧ c ≠ d := by
+    3 < s.ncard ↔
+    ∃ a ∈ s, ∃ b ∈ s, ∃ c ∈ s, ∃ d ∈ s, a ≠ b ∧ a ≠ c ∧ a ≠ d ∧ b ≠ c ∧ b ≠ d ∧ c ≠ d := by
   simp only [three_lt_ncard_iff hs, exists_and_left]
 
 theorem exists_ne_of_one_lt_ncard (hs : 1 < s.ncard) (a : α) : ∃ b, b ∈ s ∧ b ≠ a := by

--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -366,18 +366,18 @@ theorem encard_eq_three {α : Type u_1} {s : Set α} :
   rw [hs, encard_insert_of_notMem, encard_insert_of_notMem, encard_singleton] <;> aesop
 
 theorem encard_eq_four {α : Type u_1} {s : Set α} :
-    encard s = 4 ↔ ∃ w x y z, w ≠ x ∧ w ≠ y ∧ w ≠ z ∧ x ≠ y ∧ x ≠ z ∧ y ≠ z ∧ s = {w, x, y, z} := by
-  refine ⟨fun h ↦ ?_, fun ⟨w, x, y, z, hwx, hwy, hwz, hxy, hxz, hyz, hs⟩ ↦ ?_⟩
-  · obtain ⟨w, hw⟩ := nonempty_of_encard_ne_zero (s := s) (by rw [h]; simp)
-    rw [← insert_eq_of_mem hw, ← insert_diff_singleton,
+    encard s = 4 ↔ ∃ x y z w, x ≠ y ∧ x ≠ z ∧ x ≠ w ∧ y ≠ z ∧ y ≠ w ∧ z ≠ w ∧ s = {x, y, z, w} := by
+  refine ⟨fun h ↦ ?_, fun ⟨x, y, z, w, hxy, hxz, hxw, hyz, hyw, hzw, hs⟩ ↦ ?_⟩
+  · obtain ⟨x, hx⟩ := nonempty_of_encard_ne_zero (s := s) (by rw [h]; simp)
+    rw [← insert_eq_of_mem hx, ← insert_diff_singleton,
       encard_insert_of_notMem (fun h ↦ h.2 rfl), (by exact rfl : (4 : ℕ∞) = 3 + 1),
       WithTop.add_right_inj WithTop.one_ne_top, encard_eq_three] at h
-    obtain ⟨x, y, z, hxy, hxz, hyz, hs⟩ := h
-    refine ⟨w, x, y, z, ?_, ?_, ?_, hxy, hxz, hyz, ?_⟩
+    obtain ⟨y, z, w, hyz, hyw, hzw, hs⟩ := h
+    refine ⟨x, y, z, w, ?_, ?_, ?_, hyz, hyw, hzw, ?_⟩
     · rintro rfl; exact (hs.symm.subset (Or.inl rfl)).2 rfl
     · rintro rfl; exact (hs.symm.subset (Or.inr (Or.inl rfl))).2 rfl
     · rintro rfl; exact (hs.symm.subset (Or.inr (Or.inr rfl))).2 rfl
-    rw [← hs, insert_diff_singleton, insert_eq_of_mem hw]
+    rw [← hs, insert_diff_singleton, insert_eq_of_mem hx]
   rw [hs, encard_insert_of_notMem, encard_insert_of_notMem, encard_insert_of_notMem,
     encard_singleton] <;> aesop
 
@@ -1117,11 +1117,11 @@ theorem two_lt_ncard (hs : s.Finite := by toFinite_tac) :
   simp only [two_lt_ncard_iff hs, exists_and_left]
 
 theorem three_lt_ncard_iff (hs : s.Finite := by toFinite_tac) :
-    3 < s.ncard ↔ ∃ a b c d, a ∈ s ∧ b ∈ s ∧ c ∈ s ∧ d ∈ s ∧ a ≠ b ∧ a ≠ c ∧ a ≠ d ∧ b ≠ c ∧ b ≠ d ∧ c ≠ d := by
+    3 < s.ncard ↔ ∃ x y z w, x ∈ s ∧ y ∈ s ∧ z ∈ s ∧ w ∈ s ∧ x ≠ y ∧ x ≠ z ∧ x ≠ w ∧ y ≠ z ∧ y ≠ w ∧ z ≠ w := by
   simp_rw [ncard_eq_toFinset_card _ hs, Finset.three_lt_card_iff, Finite.mem_toFinset]
 
 theorem three_lt_ncard (hs : s.Finite := by toFinite_tac) :
-    3 < s.ncard ↔ ∃ a ∈ s, ∃ b ∈ s, ∃ c ∈ s, ∃ d ∈ s, a ≠ b ∧ a ≠ c ∧ a ≠ d ∧ b ≠ c ∧ b ≠ d ∧ c ≠ d := by
+    3 < s.ncard ↔ ∃ x ∈ s, ∃ y ∈ s, ∃ z ∈ s, ∃ w ∈ s, x ≠ y ∧ x ≠ z ∧ x ≠ w ∧ y ≠ z ∧ y ≠ w ∧ z ≠ w := by
   simp only [three_lt_ncard_iff hs, exists_and_left]
 
 theorem exists_ne_of_one_lt_ncard (hs : 1 < s.ncard) (a : α) : ∃ b, b ∈ s ∧ b ≠ a := by
@@ -1155,7 +1155,7 @@ theorem ncard_eq_three : s.ncard = 3 ↔ ∃ x y z, x ≠ y ∧ x ≠ z ∧ y �
   simp
 
 theorem ncard_eq_four : s.ncard = 4 ↔
-    ∃ w x y z, w ≠ x ∧ w ≠ y ∧ w ≠ z ∧ x ≠ y ∧ x ≠ z ∧ y ≠ z ∧ s = {w, x, y, z} := by
+    ∃ x y z w, x ≠ y ∧ x ≠ z ∧ x ≠ w ∧ y ≠ z ∧ y ≠ w ∧ z ≠ w ∧ s = {x, y, z, w} := by
   rw [← encard_eq_four, ncard_def]
   simp
 

--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -365,6 +365,22 @@ theorem encard_eq_three {α : Type u_1} {s : Set α} :
     rw [← hs, insert_diff_singleton, insert_eq_of_mem hx]
   rw [hs, encard_insert_of_notMem, encard_insert_of_notMem, encard_singleton] <;> aesop
 
+theorem encard_eq_four {α : Type u_1} {s : Set α} :
+    encard s = 4 ↔ ∃ w x y z, w ≠ x ∧ w ≠ y ∧ w ≠ z ∧ x ≠ y ∧ x ≠ z ∧ y ≠ z ∧ s = {w, x, y, z} := by
+  refine ⟨fun h ↦ ?_, fun ⟨w, x, y, z, hwx, hwy, hwz, hxy, hxz, hyz, hs⟩ ↦ ?_⟩
+  · obtain ⟨w, hw⟩ := nonempty_of_encard_ne_zero (s := s) (by rw [h]; simp)
+    rw [← insert_eq_of_mem hw, ← insert_diff_singleton,
+      encard_insert_of_notMem (fun h ↦ h.2 rfl), (by exact rfl : (4 : ℕ∞) = 3 + 1),
+      WithTop.add_right_inj WithTop.one_ne_top, encard_eq_three] at h
+    obtain ⟨x, y, z, hxy, hxz, hyz, hs⟩ := h
+    refine ⟨w, x, y, z, ?_, ?_, ?_, hxy, hxz, hyz, ?_⟩
+    · rintro rfl; exact (hs.symm.subset (Or.inl rfl)).2 rfl
+    · rintro rfl; exact (hs.symm.subset (Or.inr (Or.inl rfl))).2 rfl
+    · rintro rfl; exact (hs.symm.subset (Or.inr (Or.inr rfl))).2 rfl
+    rw [← hs, insert_diff_singleton, insert_eq_of_mem hw]
+  rw [hs, encard_insert_of_notMem, encard_insert_of_notMem, encard_insert_of_notMem,
+    encard_singleton] <;> aesop
+
 theorem Nat.encard_range (k : ℕ) : {i | i < k}.encard = k := by
   convert encard_coe_eq_coe_finsetCard (Finset.range k) using 1
   · rw [Finset.coe_range, Iio_def]
@@ -1128,6 +1144,11 @@ theorem ncard_eq_two : s.ncard = 2 ↔ ∃ x y, x ≠ y ∧ s = {x, y} := by
 
 theorem ncard_eq_three : s.ncard = 3 ↔ ∃ x y z, x ≠ y ∧ x ≠ z ∧ y ≠ z ∧ s = {x, y, z} := by
   rw [← encard_eq_three, ncard_def]
+  simp
+
+theorem ncard_eq_four : s.ncard = 4 ↔
+    ∃ w x y z, w ≠ x ∧ w ≠ y ∧ w ≠ z ∧ x ≠ y ∧ x ≠ z ∧ y ≠ z ∧ s = {w, x, y, z} := by
+  rw [← encard_eq_four, ncard_def]
   simp
 
 end ncard

--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -1117,11 +1117,11 @@ theorem two_lt_ncard (hs : s.Finite := by toFinite_tac) :
   simp only [two_lt_ncard_iff hs, exists_and_left]
 
 theorem three_lt_ncard_iff (hs : s.Finite := by toFinite_tac) :
-    3 < s.ncard ↔ ∃ x y z w, x ∈ s ∧ y ∈ s ∧ z ∈ s ∧ w ∈ s ∧ x ≠ y ∧ x ≠ z ∧ x ≠ w ∧ y ≠ z ∧ y ≠ w ∧ z ≠ w := by
+    3 < s.ncard ↔ ∃ a b c d, a ∈ s ∧ b ∈ s ∧ c ∈ s ∧ d ∈ s ∧ a ≠ b ∧ a ≠ c ∧ a ≠ d ∧ b ≠ c ∧ b ≠ d ∧ c ≠ d := by
   simp_rw [ncard_eq_toFinset_card _ hs, Finset.three_lt_card_iff, Finite.mem_toFinset]
 
 theorem three_lt_ncard (hs : s.Finite := by toFinite_tac) :
-    3 < s.ncard ↔ ∃ x ∈ s, ∃ y ∈ s, ∃ z ∈ s, ∃ w ∈ s, x ≠ y ∧ x ≠ z ∧ x ≠ w ∧ y ≠ z ∧ y ≠ w ∧ z ≠ w := by
+    3 < s.ncard ↔ ∃ a ∈ s, ∃ b ∈ s, ∃ c ∈ s, ∃ d ∈ s, a ≠ b ∧ a ≠ c ∧ a ≠ d ∧ b ≠ c ∧ b ≠ d ∧ c ≠ d := by
   simp only [three_lt_ncard_iff hs, exists_and_left]
 
 theorem exists_ne_of_one_lt_ncard (hs : 1 < s.ncard) (a : α) : ∃ b, b ∈ s ∧ b ≠ a := by

--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -1117,7 +1117,8 @@ theorem two_lt_ncard (hs : s.Finite := by toFinite_tac) :
   simp only [two_lt_ncard_iff hs, exists_and_left]
 
 theorem three_lt_ncard_iff (hs : s.Finite := by toFinite_tac) :
-    3 < s.ncard ↔ ∃ a b c d, a ∈ s ∧ b ∈ s ∧ c ∈ s ∧ d ∈ s ∧ a ≠ b ∧ a ≠ c ∧ a ≠ d ∧ b ≠ c ∧ b ≠ d ∧ c ≠ d := by
+    3 < s.ncard ↔
+    ∃ a b c d, a ∈ s ∧ b ∈ s ∧ c ∈ s ∧ d ∈ s ∧ a ≠ b ∧ a ≠ c ∧ a ≠ d ∧ b ≠ c ∧ b ≠ d ∧ c ≠ d := by
   simp_rw [ncard_eq_toFinset_card _ hs, Finset.three_lt_card_iff, Finite.mem_toFinset]
 
 theorem three_lt_ncard (hs : s.Finite := by toFinite_tac) :

--- a/Mathlib/Data/Set/Card.lean
+++ b/Mathlib/Data/Set/Card.lean
@@ -1116,6 +1116,14 @@ theorem two_lt_ncard (hs : s.Finite := by toFinite_tac) :
     2 < s.ncard ↔ ∃ a ∈ s, ∃ b ∈ s, ∃ c ∈ s, a ≠ b ∧ a ≠ c ∧ b ≠ c := by
   simp only [two_lt_ncard_iff hs, exists_and_left]
 
+theorem three_lt_ncard_iff (hs : s.Finite := by toFinite_tac) :
+    3 < s.ncard ↔ ∃ a b c d, a ∈ s ∧ b ∈ s ∧ c ∈ s ∧ d ∈ s ∧ a ≠ b ∧ a ≠ c ∧ a ≠ d ∧ b ≠ c ∧ b ≠ d ∧ c ≠ d := by
+  simp_rw [ncard_eq_toFinset_card _ hs, Finset.three_lt_card_iff, Finite.mem_toFinset]
+
+theorem three_lt_ncard (hs : s.Finite := by toFinite_tac) :
+    3 < s.ncard ↔ ∃ a ∈ s, ∃ b ∈ s, ∃ c ∈ s, ∃ d ∈ s, a ≠ b ∧ a ≠ c ∧ a ≠ d ∧ b ≠ c ∧ b ≠ d ∧ c ≠ d := by
+  simp only [three_lt_ncard_iff hs, exists_and_left]
+
 theorem exists_ne_of_one_lt_ncard (hs : 1 < s.ncard) (a : α) : ∃ b, b ∈ s ∧ b ≠ a := by
   have hsf := finite_of_ncard_ne_zero (zero_lt_one.trans hs).ne.symm
   rw [ncard_eq_toFinset_card _ hsf] at hs


### PR DESCRIPTION
While working on formalizing some math olympiad problems, I came across some that involve four elements from a set. In such cases, extending these sets of theorems to the number four may help.