### PR TITLE
[Merged by Bors] - chore(Topology/Algebra/Module): golf entire `det_one_smulRight` using `simp`

### DIFF
--- a/Mathlib/Topology/Algebra/Module/Determinant.lean
+++ b/Mathlib/Topology/Algebra/Module/Determinant.lean
@@ -28,14 +28,7 @@ theorem det_pi {ι R M : Type*} [Fintype ι] [CommRing R] [AddCommGroup M]
 
 theorem det_one_smulRight {𝕜 : Type*} [CommRing 𝕜] [TopologicalSpace 𝕜] [ContinuousMul 𝕜] (v : 𝕜) :
     ((1 : 𝕜 →L[𝕜] 𝕜).smulRight v).det = v := by
-  nontriviality 𝕜
-  have : (1 : 𝕜 →L[𝕜] 𝕜).smulRight v = v • (1 : 𝕜 →L[𝕜] 𝕜) := by
-    ext1
-    simp only [ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.one_apply,
-      Algebra.id.smul_eq_mul, one_mul, ContinuousLinearMap.coe_smul', Pi.smul_apply, mul_one]
-  rw [this, ContinuousLinearMap.det, ContinuousLinearMap.coe_smul,
-    ContinuousLinearMap.one_def, ContinuousLinearMap.coe_id, LinearMap.det_smul,
-    Module.finrank_self, LinearMap.det_id, pow_one, mul_one]
+  simp
 
 end ContinuousLinearMap
 


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>det_one_smulRight</code></summary>

### Trace profiling of `det_one_smulRight` before PR 28256
```diff
diff --git a/Mathlib/Topology/Algebra/Module/Determinant.lean b/Mathlib/Topology/Algebra/Module/Determinant.lean
index ef6fb2e8dd..408bcd3dff 100644
--- a/Mathlib/Topology/Algebra/Module/Determinant.lean
+++ b/Mathlib/Topology/Algebra/Module/Determinant.lean
@@ -28,2 +28,3 @@ theorem det_pi {ι R M : Type*} [Fintype ι] [CommRing R] [AddCommGroup M]
 
+set_option trace.profiler true in
 theorem det_one_smulRight {𝕜 : Type*} [CommRing 𝕜] [TopologicalSpace 𝕜] [ContinuousMul 𝕜] (v : 𝕜) :
```
```
ℹ [1689/1689] Built Mathlib.Topology.Algebra.Module.Determinant
info: Mathlib/Topology/Algebra/Module/Determinant.lean:30:0: [Elab.command] [0.047262] theorem det_one_smulRight {𝕜 : Type*} [CommRing 𝕜] [TopologicalSpace 𝕜] [ContinuousMul 𝕜]
        (v : 𝕜) : ((1 : 𝕜 →L[𝕜] 𝕜).smulRight v).det = v :=
      by
      nontriviality 𝕜
      have : (1 : 𝕜 →L[𝕜] 𝕜).smulRight v = v • (1 : 𝕜 →L[𝕜] 𝕜) :=
        by
        ext1
        simp only [ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.one_apply, Algebra.id.smul_eq_mul, one_mul,
          ContinuousLinearMap.coe_smul', Pi.smul_apply, mul_one]
      rw [this, ContinuousLinearMap.det, ContinuousLinearMap.coe_smul, ContinuousLinearMap.one_def,
        ContinuousLinearMap.coe_id, LinearMap.det_smul, Module.finrank_self, LinearMap.det_id, pow_one, mul_one]
  [Elab.definition.header] [0.046848] ContinuousLinearMap.det_one_smulRight
    [Elab.step] [0.044685] expected type: Sort ?u.5424, term
        ((1 : 𝕜 →L[𝕜] 𝕜).smulRight v).det = v
      [Elab.step] [0.044672] expected type: Sort ?u.5424, term
          binrel% Eq✝ ((1 : 𝕜 →L[𝕜] 𝕜).smulRight v).det v
        [Elab.step] [0.044535] expected type: <not-available>, term
            ((1 : 𝕜 →L[𝕜] 𝕜).smulRight v).det
          [Elab.step] [0.040788] expected type: <not-available>, term
              ((1 : 𝕜 →L[𝕜] 𝕜).smulRight v)
            [Elab.step] [0.040774] expected type: <not-available>, term
                (1 : 𝕜 →L[𝕜] 𝕜).smulRight v
              [Elab.step] [0.018918] expected type: <not-available>, term
                  (1 : 𝕜 →L[𝕜] 𝕜)
                [Elab.step] [0.013560] expected type: Type u_1, term
                    𝕜 →L[𝕜] 𝕜
                  [Elab.step] [0.013365] expected type: Type u_1, term
                      ContinuousLinearMap✝ (RingHom.id✝ 𝕜) 𝕜 𝕜
              [Meta.synthInstance] [0.011243] ✅️ IsScalarTower 𝕜 𝕜 𝕜
info: Mathlib/Topology/Algebra/Module/Determinant.lean:30:0: [Elab.async] [0.240160] elaborating proof of ContinuousLinearMap.det_one_smulRight
  [Elab.definition.value] [0.237643] ContinuousLinearMap.det_one_smulRight
    [Elab.step] [0.236285] 
          nontriviality 𝕜
          have : (1 : 𝕜 →L[𝕜] 𝕜).smulRight v = v • (1 : 𝕜 →L[𝕜] 𝕜) :=
            by
            ext1
            simp only [ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.one_apply, Algebra.id.smul_eq_mul,
              one_mul, ContinuousLinearMap.coe_smul', Pi.smul_apply, mul_one]
          rw [this, ContinuousLinearMap.det, ContinuousLinearMap.coe_smul, ContinuousLinearMap.one_def,
            ContinuousLinearMap.coe_id, LinearMap.det_smul, Module.finrank_self, LinearMap.det_id, pow_one, mul_one]
      [Elab.step] [0.236268] 
            nontriviality 𝕜
            have : (1 : 𝕜 →L[𝕜] 𝕜).smulRight v = v • (1 : 𝕜 →L[𝕜] 𝕜) :=
              by
              ext1
              simp only [ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.one_apply, Algebra.id.smul_eq_mul,
                one_mul, ContinuousLinearMap.coe_smul', Pi.smul_apply, mul_one]
            rw [this, ContinuousLinearMap.det, ContinuousLinearMap.coe_smul, ContinuousLinearMap.one_def,
              ContinuousLinearMap.coe_id, LinearMap.det_smul, Module.finrank_self, LinearMap.det_id, pow_one, mul_one]
        [Elab.step] [0.066652] nontriviality 𝕜
          [Meta.synthInstance] [0.015360] ❌️ Nontrivial 𝕜
          [Meta.Tactic.solveByElim] [0.018062] independent goals [Nontrivial 𝕜], working on them before []
            [Meta.Tactic.solveByElim] [0.017999] ❌️ working on: 𝕜 : Type u_1
                inst✝² : CommRing 𝕜
                inst✝¹ : TopologicalSpace 𝕜
                inst✝ : ContinuousMul 𝕜
                v : 𝕜
                ⊢ Nontrivial 𝕜
          [Elab.step] [0.030217] simp [nontriviality✝]
        [Elab.step] [0.082202] have : (1 : 𝕜 →L[𝕜] 𝕜).smulRight v = v • (1 : 𝕜 →L[𝕜] 𝕜) :=
              by
              ext1
              simp only [ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.one_apply, Algebra.id.smul_eq_mul,
                one_mul, ContinuousLinearMap.coe_smul', Pi.smul_apply, mul_one]
          [Elab.step] [0.081688] focus
                refine
                  no_implicit_lambda%
                    (have : (1 : 𝕜 →L[𝕜] 𝕜).smulRight v = v • (1 : 𝕜 →L[𝕜] 𝕜) := ?body✝;
                    ?_)
                case body✝ =>
                  with_annotate_state"by"
                    ( ext1
                      simp only [ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.one_apply,
                        Algebra.id.smul_eq_mul, one_mul, ContinuousLinearMap.coe_smul', Pi.smul_apply, mul_one])
            [Elab.step] [0.081676] 
                  refine
                    no_implicit_lambda%
                      (have : (1 : 𝕜 →L[𝕜] 𝕜).smulRight v = v • (1 : 𝕜 →L[𝕜] 𝕜) := ?body✝;
                      ?_)
                  case body✝ =>
                    with_annotate_state"by"
                      ( ext1
                        simp only [ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.one_apply,
                          Algebra.id.smul_eq_mul, one_mul, ContinuousLinearMap.coe_smul', Pi.smul_apply, mul_one])
              [Elab.step] [0.081670] 
                    refine
                      no_implicit_lambda%
                        (have : (1 : 𝕜 →L[𝕜] 𝕜).smulRight v = v • (1 : 𝕜 →L[𝕜] 𝕜) := ?body✝;
                        ?_)
                    case body✝ =>
                      with_annotate_state"by"
                        ( ext1
                          simp only [ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.one_apply,
                            Algebra.id.smul_eq_mul, one_mul, ContinuousLinearMap.coe_smul', Pi.smul_apply, mul_one])
                [Elab.step] [0.061129] refine
                      no_implicit_lambda%
                        (have : (1 : 𝕜 →L[𝕜] 𝕜).smulRight v = v • (1 : 𝕜 →L[𝕜] 𝕜) := ?body✝;
                        ?_)
                  [Elab.step] [0.061072] expected type: (smulRight 1 v).det = v, term
                      no_implicit_lambda%
                        (have : (1 : 𝕜 →L[𝕜] 𝕜).smulRight v = v • (1 : 𝕜 →L[𝕜] 𝕜) := ?body✝;
                        ?_)
                    [Elab.step] [0.061060] expected type: (smulRight 1 v).det = v, term
                        (have : (1 : 𝕜 →L[𝕜] 𝕜).smulRight v = v • (1 : 𝕜 →L[𝕜] 𝕜) := ?body✝;
                        ?_)
                      [Elab.step] [0.061049] expected type: (smulRight 1 v).det = v, term
                          have : (1 : 𝕜 →L[𝕜] 𝕜).smulRight v = v • (1 : 𝕜 →L[𝕜] 𝕜) := ?body✝;
                          ?_
                        [Elab.step] [0.060917] expected type: Sort ?u.10314, term
                            (1 : 𝕜 →L[𝕜] 𝕜).smulRight v = v • (1 : 𝕜 →L[𝕜] 𝕜)
                          [Elab.step] [0.060907] expected type: Sort ?u.10314, term
                              binrel% Eq✝ ((1 : 𝕜 →L[𝕜] 𝕜).smulRight v) (v • (1 : 𝕜 →L[𝕜] 𝕜))
                            [Elab.step] [0.029989] expected type: <not-available>, term
                                (1 : 𝕜 →L[𝕜] 𝕜).smulRight v
                              [Elab.step] [0.014935] expected type: <not-available>, term
                                  (1 : 𝕜 →L[𝕜] 𝕜)
                                [Elab.step] [0.011367] expected type: Type u_1, term
                                    𝕜 →L[𝕜] 𝕜
                                  [Elab.step] [0.011234] expected type: Type u_1, term
                                      ContinuousLinearMap✝ (RingHom.id✝ 𝕜) 𝕜 𝕜
                            [Meta.synthInstance] [0.027489] ✅️ HSMul 𝕜 (𝕜 →L[𝕜] 𝕜) (𝕜 →L[𝕜] 𝕜)
                [Elab.step] [0.020523] case body✝ =>
                      with_annotate_state"by"
                        ( ext1
                          simp only [ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.one_apply,
                            Algebra.id.smul_eq_mul, one_mul, ContinuousLinearMap.coe_smul', Pi.smul_apply, mul_one])
                  [Elab.step] [0.020201] with_annotate_state"by"
                          ( ext1
                            simp only [ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.one_apply,
                              Algebra.id.smul_eq_mul, one_mul, ContinuousLinearMap.coe_smul', Pi.smul_apply, mul_one])
                    [Elab.step] [0.020196] with_annotate_state"by"
                            ( ext1
                              simp only [ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.one_apply,
                                Algebra.id.smul_eq_mul, one_mul, ContinuousLinearMap.coe_smul', Pi.smul_apply, mul_one])
                      [Elab.step] [0.020190] with_annotate_state"by"
                            ( ext1
                              simp only [ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.one_apply,
                                Algebra.id.smul_eq_mul, one_mul, ContinuousLinearMap.coe_smul', Pi.smul_apply, mul_one])
                        [Elab.step] [0.020185] (
                              ext1
                              simp only [ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.one_apply,
                                Algebra.id.smul_eq_mul, one_mul, ContinuousLinearMap.coe_smul', Pi.smul_apply, mul_one])
                          [Elab.step] [0.020180] 
                                ext1
                                simp only [ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.one_apply,
                                  Algebra.id.smul_eq_mul, one_mul, ContinuousLinearMap.coe_smul', Pi.smul_apply,
                                  mul_one]
                            [Elab.step] [0.020175] 
                                  ext1
                                  simp only [ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.one_apply,
                                    Algebra.id.smul_eq_mul, one_mul, ContinuousLinearMap.coe_smul', Pi.smul_apply,
                                    mul_one]
                              [Elab.step] [0.017505] simp only [ContinuousLinearMap.smulRight_apply,
                                    ContinuousLinearMap.one_apply, Algebra.id.smul_eq_mul, one_mul,
                                    ContinuousLinearMap.coe_smul', Pi.smul_apply, mul_one]
        [Elab.step] [0.087323] rw [this, ContinuousLinearMap.det, ContinuousLinearMap.coe_smul,
              ContinuousLinearMap.one_def, ContinuousLinearMap.coe_id, LinearMap.det_smul, Module.finrank_self,
              LinearMap.det_id, pow_one, mul_one]
          [Elab.step] [0.087071] (rewrite [this, ContinuousLinearMap.det, ContinuousLinearMap.coe_smul,
                  ContinuousLinearMap.one_def, ContinuousLinearMap.coe_id, LinearMap.det_smul, Module.finrank_self,
                  LinearMap.det_id, pow_one, mul_one];
                with_annotate_state"]" (try (with_reducible rfl)))
            [Elab.step] [0.087064] rewrite [this, ContinuousLinearMap.det, ContinuousLinearMap.coe_smul,
                    ContinuousLinearMap.one_def, ContinuousLinearMap.coe_id, LinearMap.det_smul, Module.finrank_self,
                    LinearMap.det_id, pow_one, mul_one];
                  with_annotate_state"]" (try (with_reducible rfl))
              [Elab.step] [0.087058] rewrite [this, ContinuousLinearMap.det, ContinuousLinearMap.coe_smul,
                      ContinuousLinearMap.one_def, ContinuousLinearMap.coe_id, LinearMap.det_smul, Module.finrank_self,
                      LinearMap.det_id, pow_one, mul_one];
                    with_annotate_state"]" (try (with_reducible rfl))
                [Elab.step] [0.086684] rewrite [this, ContinuousLinearMap.det, ContinuousLinearMap.coe_smul,
                      ContinuousLinearMap.one_def, ContinuousLinearMap.coe_id, LinearMap.det_smul, Module.finrank_self,
                      LinearMap.det_id, pow_one, mul_one]
                  [Meta.synthInstance] [0.011660] ✅️ ContinuousConstSMul 𝕜 𝕜
info: Mathlib/Topology/Algebra/Module/Determinant.lean:30:8: [Elab.async] [0.015253] Lean.addDecl
  [Kernel] [0.015229] typechecking declarations [ContinuousLinearMap.det_one_smulRight]
Build completed successfully.
```

### Trace profiling of `det_one_smulRight` after PR 28256
```diff
diff --git a/Mathlib/Topology/Algebra/Module/Determinant.lean b/Mathlib/Topology/Algebra/Module/Determinant.lean
index ef6fb2e8dd..209c6e8670 100644
--- a/Mathlib/Topology/Algebra/Module/Determinant.lean
+++ b/Mathlib/Topology/Algebra/Module/Determinant.lean
@@ -28,12 +28,6 @@ theorem det_pi {ι R M : Type*} [Fintype ι] [CommRing R] [AddCommGroup M]
 
+set_option trace.profiler true in
 theorem det_one_smulRight {𝕜 : Type*} [CommRing 𝕜] [TopologicalSpace 𝕜] [ContinuousMul 𝕜] (v : 𝕜) :
     ((1 : 𝕜 →L[𝕜] 𝕜).smulRight v).det = v := by
-  nontriviality 𝕜
-  have : (1 : 𝕜 →L[𝕜] 𝕜).smulRight v = v • (1 : 𝕜 →L[𝕜] 𝕜) := by
-    ext1
-    simp only [ContinuousLinearMap.smulRight_apply, ContinuousLinearMap.one_apply,
-      Algebra.id.smul_eq_mul, one_mul, ContinuousLinearMap.coe_smul', Pi.smul_apply, mul_one]
-  rw [this, ContinuousLinearMap.det, ContinuousLinearMap.coe_smul,
-    ContinuousLinearMap.one_def, ContinuousLinearMap.coe_id, LinearMap.det_smul,
-    Module.finrank_self, LinearMap.det_id, pow_one, mul_one]
+  simp
 
```
```
ℹ [1689/1689] Built Mathlib.Topology.Algebra.Module.Determinant
info: Mathlib/Topology/Algebra/Module/Determinant.lean:30:0: [Elab.command] [0.055572] theorem det_one_smulRight {𝕜 : Type*} [CommRing 𝕜] [TopologicalSpace 𝕜] [ContinuousMul 𝕜]
        (v : 𝕜) : ((1 : 𝕜 →L[𝕜] 𝕜).smulRight v).det = v := by simp
  [Elab.definition.header] [0.054539] ContinuousLinearMap.det_one_smulRight
    [Elab.step] [0.053291] expected type: Sort ?u.5424, term
        ((1 : 𝕜 →L[𝕜] 𝕜).smulRight v).det = v
      [Elab.step] [0.053279] expected type: Sort ?u.5424, term
          binrel% Eq✝ ((1 : 𝕜 →L[𝕜] 𝕜).smulRight v).det v
        [Elab.step] [0.053003] expected type: <not-available>, term
            ((1 : 𝕜 →L[𝕜] 𝕜).smulRight v).det
          [Elab.step] [0.045536] expected type: <not-available>, term
              ((1 : 𝕜 →L[𝕜] 𝕜).smulRight v)
            [Elab.step] [0.045525] expected type: <not-available>, term
                (1 : 𝕜 →L[𝕜] 𝕜).smulRight v
              [Elab.step] [0.025408] expected type: <not-available>, term
                  (1 : 𝕜 →L[𝕜] 𝕜)
                [Elab.step] [0.017753] expected type: Type u_1, term
                    𝕜 →L[𝕜] 𝕜
                  [Elab.step] [0.017652] expected type: Type u_1, term
                      ContinuousLinearMap✝ (RingHom.id✝ 𝕜) 𝕜 𝕜
                    [Meta.synthInstance] [0.010927] ✅️ Module 𝕜 𝕜
                      [Meta.isDefEq] [0.010914] ✅️ Module 𝕜 𝕜 =?= Module 𝕜 𝕜
                        [Meta.isDefEq] [0.010888] ✅️ CommRing.toNonUnitalCommRing.toNonUnitalNonAssocCommRing.toNonUnitalNonAssocCommSemiring.toAddCommMonoid =?= CommRing.toCommSemiring.toNonAssocSemiring.toAddCommMonoid
                          [Meta.isDefEq] [0.010863] ✅️ CommRing.toNonUnitalCommRing.toNonUnitalNonAssocCommRing.toNonUnitalNonAssocCommSemiring.toNonUnitalNonAssocSemiring.1 =?= CommRing.toCommSemiring.toNonAssocSemiring.toNonUnitalNonAssocSemiring.1
                            [Meta.isDefEq] [0.010794] ✅️ {
                                  toAddMonoid := CommRing.toNonUnitalCommRing.toNonUnitalNonAssocCommRing.toAddMonoid,
                                  add_comm :=
                                    ⋯ } =?= CommRing.toCommSemiring.toNonAssocSemiring.toNonUnitalNonAssocSemiring.1
info: Mathlib/Topology/Algebra/Module/Determinant.lean:30:0: [Elab.async] [0.029548] elaborating proof of ContinuousLinearMap.det_one_smulRight
  [Elab.definition.value] [0.029072] ContinuousLinearMap.det_one_smulRight
    [Elab.step] [0.028312] simp
      [Elab.step] [0.028298] simp
        [Elab.step] [0.028280] simp
Build completed successfully.
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
