### PR TITLE
[Merged by Bors] - chore(Data/List): golf entire `forall_mem_iff_getElem` using `simp`

### DIFF
--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -477,7 +477,7 @@ theorem forall_mem_iff_getElem {l : List α} {p : α → Prop} :
 theorem get_tail (l : List α) (i) (h : i < l.tail.length)
     (h' : i + 1 < l.length := (by simp only [length_tail] at h; omega)) :
     l.tail.get ⟨i, h⟩ = l.get ⟨i + 1, h'⟩ := by
-  cases l <;> [cases h; rfl]
+  simp
 
 /-! ### sublists -/
 


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>forall_mem_iff_getElem</code></summary>

### Trace profiling of `forall_mem_iff_getElem` before PR 28258
```diff
diff --git a/Mathlib/Data/List/Basic.lean b/Mathlib/Data/List/Basic.lean
index 390b78dfb8..02f0a31658 100644
--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -472,2 +472,3 @@ theorem exists_mem_iff_getElem {l : List α} {p : α → Prop} :
 
+set_option trace.profiler true in
 theorem forall_mem_iff_getElem {l : List α} {p : α → Prop} :
```
```
ℹ [426/426] Built Mathlib.Data.List.Basic
info: Mathlib/Data/List/Basic.lean:474:0: [Elab.async] [0.117502] elaborating proof of List.forall_mem_iff_getElem
  [Elab.definition.value] [0.117000] List.forall_mem_iff_getElem
    [Elab.step] [0.116517] simp [mem_iff_getElem, @forall_swap α]
      [Elab.step] [0.116508] simp [mem_iff_getElem, @forall_swap α]
        [Elab.step] [0.116498] simp [mem_iff_getElem, @forall_swap α]
          [Meta.Tactic.simp.discharge] [0.019233] IsEmpty.forall_iff discharge ❌️
                IsEmpty (∃ i h, l[i] = x)
Build completed successfully.
```

### Trace profiling of `forall_mem_iff_getElem` after PR 28258
```diff
diff --git a/Mathlib/Data/List/Basic.lean b/Mathlib/Data/List/Basic.lean
index 390b78dfb8..3d44057cfb 100644
--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -472,2 +472,3 @@ theorem exists_mem_iff_getElem {l : List α} {p : α → Prop} :
 
+set_option trace.profiler true in
 theorem forall_mem_iff_getElem {l : List α} {p : α → Prop} :
@@ -479,3 +480,3 @@ theorem get_tail (l : List α) (i) (h : i < l.tail.length)
     l.tail.get ⟨i, h⟩ = l.get ⟨i + 1, h'⟩ := by
-  cases l <;> [cases h; rfl]
+  simp
```
```
ℹ [426/426] Built Mathlib.Data.List.Basic
info: Mathlib/Data/List/Basic.lean:474:0: [Elab.async] [0.116800] elaborating proof of List.forall_mem_iff_getElem
  [Elab.definition.value] [0.116318] List.forall_mem_iff_getElem
    [Elab.step] [0.115904] simp [mem_iff_getElem, @forall_swap α]
      [Elab.step] [0.115896] simp [mem_iff_getElem, @forall_swap α]
        [Elab.step] [0.115885] simp [mem_iff_getElem, @forall_swap α]
          [Meta.Tactic.simp.discharge] [0.040480] IsEmpty.forall_iff discharge ❌️
                IsEmpty (∃ i h, l[i] = x)
Build completed successfully.
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
