### PR TITLE
[Merged by Bors] - chore(Topology/Category/Profinite/Nobeling): golf entire `lt_iff_lex_lt` using `simp`

### DIFF
--- a/Mathlib/Topology/Category/Profinite/Nobeling/Basic.lean
+++ b/Mathlib/Topology/Category/Profinite/Nobeling/Basic.lean
@@ -304,7 +304,7 @@ instance : LinearOrder (Products I) :=
 
 @[simp]
 theorem lt_iff_lex_lt (l m : Products I) : l < m ↔ List.Lex (· < ·) l.val m.val := by
-  cases l; cases m; rw [Subtype.mk_lt_mk]; exact Iff.rfl
+  simp
 
 instance [WellFoundedLT I] : WellFoundedLT (Products I) := by
   have : (· < · : Products I → _ → _) = (fun l m ↦ List.Lex (· < ·) l.val m.val) := by


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>lt_iff_lex_lt</code></summary>

### Trace profiling of `lt_iff_lex_lt` before PR 28259
```diff
diff --git a/Mathlib/Topology/Category/Profinite/Nobeling/Basic.lean b/Mathlib/Topology/Category/Profinite/Nobeling/Basic.lean
index 4ec04c9603..bacce7925f 100644
--- a/Mathlib/Topology/Category/Profinite/Nobeling/Basic.lean
+++ b/Mathlib/Topology/Category/Profinite/Nobeling/Basic.lean
@@ -304,2 +304,3 @@ instance : LinearOrder (Products I) :=
 
+set_option trace.profiler true in
 @[simp]
```
```
ℹ [1742/1742] Built Mathlib.Topology.Category.Profinite.Nobeling.Basic
info: Mathlib/Topology/Category/Profinite/Nobeling/Basic.lean:306:0: [Elab.command] [0.023013] @[simp]
    theorem lt_iff_lex_lt (l m : Products I) : l < m ↔ List.Lex (· < ·) l.val m.val := by cases l; cases m;
      rw [Subtype.mk_lt_mk]; exact Iff.rfl
  [Elab.definition.header] [0.021366] Profinite.NobelingProof.Products.lt_iff_lex_lt
    [Elab.step] [0.011149] expected type: Prop, term
        l < m ↔ List.Lex (· < ·) l.val m.val
      [Elab.step] [0.011132] expected type: Prop, term
          Iff✝ (l < m) (List.Lex (· < ·) l.val m.val)
Build completed successfully.
```

### Trace profiling of `lt_iff_lex_lt` after PR 28259
```diff
diff --git a/Mathlib/Topology/Category/Profinite/Nobeling/Basic.lean b/Mathlib/Topology/Category/Profinite/Nobeling/Basic.lean
index 4ec04c9603..756291dc3c 100644
--- a/Mathlib/Topology/Category/Profinite/Nobeling/Basic.lean
+++ b/Mathlib/Topology/Category/Profinite/Nobeling/Basic.lean
@@ -304,5 +304,6 @@ instance : LinearOrder (Products I) :=
 
+set_option trace.profiler true in
 @[simp]
 theorem lt_iff_lex_lt (l m : Products I) : l < m ↔ List.Lex (· < ·) l.val m.val := by
-  cases l; cases m; rw [Subtype.mk_lt_mk]; exact Iff.rfl
+  simp
 
```
```
ℹ [1742/1742] Built Mathlib.Topology.Category.Profinite.Nobeling.Basic
info: Mathlib/Topology/Category/Profinite/Nobeling/Basic.lean:306:0: [Elab.command] [0.016226] @[simp]
    theorem lt_iff_lex_lt (l m : Products I) : l < m ↔ List.Lex (· < ·) l.val m.val := by simp
  [Elab.definition.header] [0.015484] Profinite.NobelingProof.Products.lt_iff_lex_lt
    [Elab.step] [0.010318] expected type: Prop, term
        l < m ↔ List.Lex (· < ·) l.val m.val
      [Elab.step] [0.010296] expected type: Prop, term
          Iff✝ (l < m) (List.Lex (· < ·) l.val m.val)
Build completed successfully.
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
