### PR TITLE
[Merged by Bors] - chore(Analysis/Fourier): golf entire `fourier_zero` and `fourier_zero'` using `simp`

### DIFF
--- a/Mathlib/Analysis/Fourier/AddCircle.lean
+++ b/Mathlib/Analysis/Fourier/AddCircle.lean
@@ -125,13 +125,10 @@ theorem fourier_coe_apply' {n : ℤ} {x : ℝ} :
 
 -- simp normal form is `fourier_zero'`
 theorem fourier_zero {x : AddCircle T} : fourier 0 x = 1 := by
-  induction x using QuotientAddGroup.induction_on
-  simp only [fourier_coe_apply]
-  norm_num
+  simp
 
-theorem fourier_zero' {x : AddCircle T} : @toCircle T 0 = (1 : ℂ) := by
-  have : fourier 0 x = @toCircle T 0 := by rw [fourier_apply, zero_smul]
-  rw [← this]; exact fourier_zero
+theorem fourier_zero' : @toCircle T 0 = (1 : ℂ) := by
+  simp
 
 -- simp normal form is *also* `fourier_zero'`
 theorem fourier_eval_zero (n : ℤ) : fourier n (0 : AddCircle T) = 1 := by


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>fourier_zero</code></summary>

### Trace profiling of `fourier_zero` before PR 28260
```diff
diff --git a/Mathlib/Analysis/Fourier/AddCircle.lean b/Mathlib/Analysis/Fourier/AddCircle.lean
index 6238f58476..99dbb05621 100644
--- a/Mathlib/Analysis/Fourier/AddCircle.lean
+++ b/Mathlib/Analysis/Fourier/AddCircle.lean
@@ -126,2 +126,3 @@ theorem fourier_coe_apply' {n : ℤ} {x : ℝ} :
 -- simp normal form is `fourier_zero'`
+set_option trace.profiler true in
 theorem fourier_zero {x : AddCircle T} : fourier 0 x = 1 := by
```
```
ℹ [2482/2482] Built Mathlib.Analysis.Fourier.AddCircle
info: Mathlib/Analysis/Fourier/AddCircle.lean:128:0: [Elab.async] [0.066690] elaborating proof of fourier_zero
  [Elab.definition.value] [0.066228] fourier_zero
    [Elab.step] [0.065930] 
          induction x using QuotientAddGroup.induction_on
          simp only [fourier_coe_apply]
          norm_num
      [Elab.step] [0.065922] 
            induction x using QuotientAddGroup.induction_on
            simp only [fourier_coe_apply]
            norm_num
        [Elab.step] [0.055636] simp only [fourier_coe_apply]
Build completed successfully.
```

### Trace profiling of `fourier_zero` after PR 28260
```diff
diff --git a/Mathlib/Analysis/Fourier/AddCircle.lean b/Mathlib/Analysis/Fourier/AddCircle.lean
index 6238f58476..0542519008 100644
--- a/Mathlib/Analysis/Fourier/AddCircle.lean
+++ b/Mathlib/Analysis/Fourier/AddCircle.lean
@@ -126,10 +126,8 @@ theorem fourier_coe_apply' {n : ℤ} {x : ℝ} :
 -- simp normal form is `fourier_zero'`
+set_option trace.profiler true in
 theorem fourier_zero {x : AddCircle T} : fourier 0 x = 1 := by
-  induction x using QuotientAddGroup.induction_on
-  simp only [fourier_coe_apply]
-  norm_num
+  simp
 
-theorem fourier_zero' {x : AddCircle T} : @toCircle T 0 = (1 : ℂ) := by
-  have : fourier 0 x = @toCircle T 0 := by rw [fourier_apply, zero_smul]
-  rw [← this]; exact fourier_zero
+theorem fourier_zero' : @toCircle T 0 = (1 : ℂ) := by
+  simp
 
```
```
ℹ [2482/2482] Built Mathlib.Analysis.Fourier.AddCircle
info: Mathlib/Analysis/Fourier/AddCircle.lean:128:0: [Elab.async] [0.041217] elaborating proof of fourier_zero
  [Elab.definition.value] [0.040843] fourier_zero
    [Elab.step] [0.040316] simp
      [Elab.step] [0.040305] simp
        [Elab.step] [0.040291] simp
          [Meta.isDefEq] [0.013042] ✅️ 0 • ?m =?= 0 • x
            [Meta.isDefEq] [0.010734] ✅️ instHSMul =?= instHSMul
              [Meta.isDefEq.delta] [0.010705] ✅️ instHSMul =?= instHSMul
                [Meta.synthInstance] [0.010613] ✅️ SMulWithZero ℤ (AddCircle T)
                  [Meta.synthInstance] [0.010175] ✅️ apply @AddGroup.intSMulWithZero to SMulWithZero ℤ (AddCircle T)
                    [Meta.synthInstance.tryResolve] [0.010141] ✅️ SMulWithZero ℤ
                          (AddCircle T) ≟ SMulWithZero ℤ (AddCircle T)
          [Meta.isDefEq] [0.010882] ❌️ ↑1 =?= ↑1
Build completed successfully.
```
</details>

---
<details>
<summary>Show trace profiling of <code>fourier_zero'</code></summary>

### Trace profiling of `fourier_zero'` before PR 28260
```diff
diff --git a/Mathlib/Analysis/Fourier/AddCircle.lean b/Mathlib/Analysis/Fourier/AddCircle.lean
index 6238f58476..c97c6382dd 100644
--- a/Mathlib/Analysis/Fourier/AddCircle.lean
+++ b/Mathlib/Analysis/Fourier/AddCircle.lean
@@ -131,2 +131,3 @@ theorem fourier_zero {x : AddCircle T} : fourier 0 x = 1 := by
 
+set_option trace.profiler true in
 theorem fourier_zero' {x : AddCircle T} : @toCircle T 0 = (1 : ℂ) := by
```
```
ℹ [2482/2482] Built Mathlib.Analysis.Fourier.AddCircle
info: Mathlib/Analysis/Fourier/AddCircle.lean:133:0: [Elab.command] [0.040228] theorem fourier_zero' {x : AddCircle T} : @toCircle T 0 = (1 : ℂ) :=
      by
      have : fourier 0 x = @toCircle T 0 := by rw [fourier_apply, zero_smul]
      rw [← this]; exact fourier_zero
  [Elab.definition.header] [0.039678] fourier_zero'
    [Elab.step] [0.039292] expected type: Sort ?u.10460, term
        @toCircle T 0 = (1 : ℂ)
      [Elab.step] [0.039281] expected type: Sort ?u.10460, term
          binrel% Eq✝ (@toCircle T 0) (1 : ℂ)
        [Meta.synthInstance] [0.023079] ❌️ CoeT ℂ x Circle
info: Mathlib/Analysis/Fourier/AddCircle.lean:133:0: [Elab.async] [0.050645] elaborating proof of fourier_zero'
  [Elab.definition.value] [0.049639] fourier_zero'
    [Elab.step] [0.049079] 
          have : fourier 0 x = @toCircle T 0 := by rw [fourier_apply, zero_smul]
          rw [← this]; exact fourier_zero
      [Elab.step] [0.049067] 
            have : fourier 0 x = @toCircle T 0 := by rw [fourier_apply, zero_smul]
            rw [← this]; exact fourier_zero
        [Elab.step] [0.047714] have : fourier 0 x = @toCircle T 0 := by rw [fourier_apply, zero_smul]
          [Elab.step] [0.047690] focus
                refine
                  no_implicit_lambda%
                    (have : fourier 0 x = @toCircle T 0 := ?body✝;
                    ?_)
                case body✝ => with_annotate_state"by" (rw [fourier_apply, zero_smul])
            [Elab.step] [0.047680] 
                  refine
                    no_implicit_lambda%
                      (have : fourier 0 x = @toCircle T 0 := ?body✝;
                      ?_)
                  case body✝ => with_annotate_state"by" (rw [fourier_apply, zero_smul])
              [Elab.step] [0.047675] 
                    refine
                      no_implicit_lambda%
                        (have : fourier 0 x = @toCircle T 0 := ?body✝;
                        ?_)
                    case body✝ => with_annotate_state"by" (rw [fourier_apply, zero_smul])
                [Elab.step] [0.016566] refine
                      no_implicit_lambda%
                        (have : fourier 0 x = @toCircle T 0 := ?body✝;
                        ?_)
                  [Elab.step] [0.016520] expected type: ↑(toCircle 0) = 1, term
                      no_implicit_lambda%
                        (have : fourier 0 x = @toCircle T 0 := ?body✝;
                        ?_)
                    [Elab.step] [0.016512] expected type: ↑(toCircle 0) = 1, term
                        (have : fourier 0 x = @toCircle T 0 := ?body✝;
                        ?_)
                      [Elab.step] [0.016502] expected type: ↑(toCircle 0) = 1, term
                          have : fourier 0 x = @toCircle T 0 := ?body✝;
                          ?_
                        [Elab.step] [0.016409] expected type: Sort ?u.12245, term
                            fourier 0 x = @toCircle T 0
                          [Elab.step] [0.016398] expected type: Sort ?u.12245, term
                              binrel% Eq✝ (fourier 0 x) (@toCircle T 0)
                [Elab.step] [0.031091] case body✝ => with_annotate_state"by" (rw [fourier_apply, zero_smul])
                  [Elab.step] [0.031024] with_annotate_state"by" (rw [fourier_apply, zero_smul])
                    [Elab.step] [0.031018] with_annotate_state"by" (rw [fourier_apply, zero_smul])
                      [Elab.step] [0.031012] with_annotate_state"by" (rw [fourier_apply, zero_smul])
                        [Elab.step] [0.031006] (rw [fourier_apply, zero_smul])
                          [Elab.step] [0.031000] rw [fourier_apply, zero_smul]
                            [Elab.step] [0.030995] rw [fourier_apply, zero_smul]
                              [Elab.step] [0.030987] rw [fourier_apply, zero_smul]
                                [Elab.step] [0.030977] (rewrite [fourier_apply, zero_smul];
                                      with_annotate_state"]" (try (with_reducible rfl)))
                                  [Elab.step] [0.030972] rewrite [fourier_apply, zero_smul];
                                        with_annotate_state"]" (try (with_reducible rfl))
                                    [Elab.step] [0.030964] rewrite [fourier_apply, zero_smul];
                                          with_annotate_state"]" (try (with_reducible rfl))
                                      [Elab.step] [0.026599] rewrite [fourier_apply, zero_smul]
                                        [Meta.isDefEq] [0.016855] ✅️ 0 • x =?= 0 • ?m
                                          [Meta.isDefEq] [0.015512] ✅️ instHSMul =?= instHSMul
                                            [Meta.isDefEq.delta] [0.015494] ✅️ instHSMul =?= instHSMul
                                              [Meta.synthInstance] [0.015404] ✅️ SMulWithZero ℤ (AddCircle T)
                                                [Meta.synthInstance] [0.014948] ✅️ apply @AddGroup.intSMulWithZero to SMulWithZero
                                                      ℤ (AddCircle T)
                                                  [Meta.synthInstance.tryResolve] [0.014922] ✅️ SMulWithZero ℤ
                                                        (AddCircle T) ≟ SMulWithZero ℤ (AddCircle T)
                                                    [Meta.isDefEq] [0.014466] ✅️ SMulWithZero ℤ
                                                          (AddCircle T) =?= SMulWithZero ℤ ?m.13159
                                                      [Meta.synthInstance] [0.010847] ✅️ Zero (AddCircle T)
Build completed successfully.
```

### Trace profiling of `fourier_zero'` after PR 28260
```diff
diff --git a/Mathlib/Analysis/Fourier/AddCircle.lean b/Mathlib/Analysis/Fourier/AddCircle.lean
index 6238f58476..f13a398896 100644
--- a/Mathlib/Analysis/Fourier/AddCircle.lean
+++ b/Mathlib/Analysis/Fourier/AddCircle.lean
@@ -127,9 +127,7 @@ theorem fourier_coe_apply' {n : ℤ} {x : ℝ} :
 theorem fourier_zero {x : AddCircle T} : fourier 0 x = 1 := by
-  induction x using QuotientAddGroup.induction_on
-  simp only [fourier_coe_apply]
-  norm_num
+  simp
 
-theorem fourier_zero' {x : AddCircle T} : @toCircle T 0 = (1 : ℂ) := by
-  have : fourier 0 x = @toCircle T 0 := by rw [fourier_apply, zero_smul]
-  rw [← this]; exact fourier_zero
+set_option trace.profiler true in
+theorem fourier_zero' : @toCircle T 0 = (1 : ℂ) := by
+  simp
 
```
```
ℹ [2482/2482] Built Mathlib.Analysis.Fourier.AddCircle
info: Mathlib/Analysis/Fourier/AddCircle.lean:131:0: [Elab.command] [0.045555] theorem fourier_zero' : @toCircle T 0 = (1 : ℂ) := by simp
  [Elab.definition.header] [0.044962] fourier_zero'
    [Elab.step] [0.044931] expected type: Sort ?u.10311, term
        @toCircle T 0 = (1 : ℂ)
      [Elab.step] [0.044920] expected type: Sort ?u.10311, term
          binrel% Eq✝ (@toCircle T 0) (1 : ℂ)
        [Meta.synthInstance] [0.031268] ❌️ CoeT ℂ x Circle
info: Mathlib/Analysis/Fourier/AddCircle.lean:131:0: [Elab.async] [0.027859] elaborating proof of fourier_zero'
  [Elab.definition.value] [0.027542] fourier_zero'
    [Elab.step] [0.027179] simp
      [Elab.step] [0.027169] simp
        [Elab.step] [0.027156] simp
          [Meta.isDefEq] [0.011252] ❌️ ↑1 =?= ↑1
            [Meta.isDefEq.delta] [0.010804] ❌️ ↑1 =?= ↑1
              [Meta.isDefEq] [0.010774] ❌️ 1 =?= 1
                [Meta.isDefEq] [0.010717] ❌️ { x // 0 ≤ x } =?= Circle
                  [Meta.isDefEq] [0.010706] ❌️ { x // 0 ≤ x } =?= ↥(Submonoid.unitSphere ℂ)
                    [Meta.isDefEq] [0.010684] ❌️ fun x ↦ 0 ≤ x =?= fun x ↦ x ∈ Submonoid.unitSphere ℂ
                      [Meta.isDefEq] [0.010675] ❌️ 0 ≤ x =?= x ∈ Submonoid.unitSphere ℂ
Build completed successfully.
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
