### PR TITLE
[Merged by Bors] - chore(Data/List): golf entire `mem_map_swap` using `simp`

### DIFF
--- a/Mathlib/Data/List/ProdSigma.lean
+++ b/Mathlib/Data/List/ProdSigma.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Mario Carneiro
 -/
 import Mathlib.Data.List.Basic
-import Mathlib.Data.Prod.Basic
 
 /-!
 # Lists in product and sigma types

--- a/Mathlib/Data/List/ProdSigma.lean
+++ b/Mathlib/Data/List/ProdSigma.lean
@@ -79,9 +79,6 @@ theorem mem_sigma {l₁ : List α} {l₂ : ∀ a, List (σ a)} {a : α} {b : σ 
 @[simp 1100]
 theorem mem_map_swap (x : α) (y : β) (xs : List (α × β)) :
     (y, x) ∈ map Prod.swap xs ↔ (x, y) ∈ xs := by
-  induction' xs with x xs xs_ih
-  · simp only [not_mem_nil, map_nil]
-  · obtain ⟨a, b⟩ := x
-    simp only [mem_cons, Prod.mk_inj, map, Prod.swap_prod_mk, xs_ih, and_comm]
+  simp
 
 end List


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>mem_map_swap</code></summary>

### Trace profiling of `mem_map_swap` before PR 28261
```diff
diff --git a/Mathlib/Data/List/ProdSigma.lean b/Mathlib/Data/List/ProdSigma.lean
index 5f1e1b0f0e..042e493b36 100644
--- a/Mathlib/Data/List/ProdSigma.lean
+++ b/Mathlib/Data/List/ProdSigma.lean
@@ -78,2 +78,3 @@ theorem mem_sigma {l₁ : List α} {l₂ : ∀ a, List (σ a)} {a : α} {b : σ
 
+set_option trace.profiler true in
 @[simp 1100]
```
```
ℹ [430/430] Built Mathlib.Data.List.ProdSigma
info: Mathlib/Data/List/ProdSigma.lean:80:0: [Elab.async] [0.012689] elaborating proof of List.mem_map_swap
  [Elab.definition.value] [0.011915] List.mem_map_swap
    [Elab.step] [0.011520] 
          induction' xs with x xs xs_ih
          · simp only [not_mem_nil, map_nil]
          · obtain ⟨a, b⟩ := x
            simp only [mem_cons, Prod.mk_inj, map, Prod.swap_prod_mk, xs_ih, and_comm]
      [Elab.step] [0.011504] 
            induction' xs with x xs xs_ih
            · simp only [not_mem_nil, map_nil]
            · obtain ⟨a, b⟩ := x
              simp only [mem_cons, Prod.mk_inj, map, Prod.swap_prod_mk, xs_ih, and_comm]
Build completed successfully.
```

### Trace profiling of `mem_map_swap` after PR 28261
```diff
diff --git a/Mathlib/Data/List/ProdSigma.lean b/Mathlib/Data/List/ProdSigma.lean
index 5f1e1b0f0e..e89357f07c 100644
--- a/Mathlib/Data/List/ProdSigma.lean
+++ b/Mathlib/Data/List/ProdSigma.lean
@@ -6,3 +6,2 @@ Authors: Leonardo de Moura, Mario Carneiro
 import Mathlib.Data.List.Basic
-import Mathlib.Data.Prod.Basic
 
@@ -78,2 +77,3 @@ theorem mem_sigma {l₁ : List α} {l₂ : ∀ a, List (σ a)} {a : α} {b : σ
 
+set_option trace.profiler true in
 @[simp 1100]
@@ -81,6 +81,3 @@ theorem mem_map_swap (x : α) (y : β) (xs : List (α × β)) :
     (y, x) ∈ map Prod.swap xs ↔ (x, y) ∈ xs := by
-  induction' xs with x xs xs_ih
-  · simp only [not_mem_nil, map_nil]
-  · obtain ⟨a, b⟩ := x
-    simp only [mem_cons, Prod.mk_inj, map, Prod.swap_prod_mk, xs_ih, and_comm]
+  simp
 
```
```
ℹ [427/427] Built Mathlib.Data.List.ProdSigma
info: Mathlib/Data/List/ProdSigma.lean:79:0: [Elab.async] [0.024407] elaborating proof of List.mem_map_swap
  [Elab.definition.value] [0.023520] List.mem_map_swap
    [Elab.step] [0.023090] simp
      [Elab.step] [0.023075] simp
        [Elab.step] [0.023060] simp
Build completed successfully.
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
