### PR TITLE
[Merged by Bors] - chore(Combinatorics/SimpleGraph/Connectivity): golf entire `adj_toSubgraph_mapLe` using `simp`

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
@@ -191,8 +191,6 @@ theorem toSubgraph_map (f : G →g G') (p : G.Walk u v) :
 
 lemma adj_toSubgraph_mapLe {G' : SimpleGraph V} {w x : V} {p : G.Walk u v} (h : G ≤ G') :
     (p.mapLe h).toSubgraph.Adj w x ↔ p.toSubgraph.Adj w x := by
-  simp only [toSubgraph_map, Subgraph.map_adj]
-  nth_rewrite 1 [← Hom.ofLE_apply h w, ← Hom.ofLE_apply h x]
   simp
 
 @[simp]


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>adj_toSubgraph_mapLe</code></summary>

### Trace profiling of `adj_toSubgraph_mapLe` before PR 28264
```diff
diff --git a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
index b3728f6007..f43856898c 100644
--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
@@ -191,2 +191,3 @@ theorem toSubgraph_map (f : G →g G') (p : G.Walk u v) :
 
+set_option trace.profiler true in
 lemma adj_toSubgraph_mapLe {G' : SimpleGraph V} {w x : V} {p : G.Walk u v} (h : G ≤ G') :
```
```
ℹ [891/891] Built Mathlib.Combinatorics.SimpleGraph.Connectivity.Subgraph
info: Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean:193:0: [Elab.async] [0.018397] elaborating proof of SimpleGraph.Walk.adj_toSubgraph_mapLe
  [Elab.definition.value] [0.017549] SimpleGraph.Walk.adj_toSubgraph_mapLe
    [Elab.step] [0.017073] 
          simp only [toSubgraph_map, Subgraph.map_adj]
          nth_rewrite 1 [← Hom.ofLE_apply h w, ← Hom.ofLE_apply h x]
          simp
      [Elab.step] [0.017056] 
            simp only [toSubgraph_map, Subgraph.map_adj]
            nth_rewrite 1 [← Hom.ofLE_apply h w, ← Hom.ofLE_apply h x]
            simp
Build completed successfully.
```

### Trace profiling of `adj_toSubgraph_mapLe` after PR 28264
```diff
diff --git a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
index b3728f6007..2a8c88761e 100644
--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Subgraph.lean
@@ -191,6 +191,5 @@ theorem toSubgraph_map (f : G →g G') (p : G.Walk u v) :
 
+set_option trace.profiler true in
 lemma adj_toSubgraph_mapLe {G' : SimpleGraph V} {w x : V} {p : G.Walk u v} (h : G ≤ G') :
     (p.mapLe h).toSubgraph.Adj w x ↔ p.toSubgraph.Adj w x := by
-  simp only [toSubgraph_map, Subgraph.map_adj]
-  nth_rewrite 1 [← Hom.ofLE_apply h w, ← Hom.ofLE_apply h x]
   simp
```
```
✔ [891/891] Built Mathlib.Combinatorics.SimpleGraph.Connectivity.Subgraph
Build completed successfully.
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
