### PR TITLE
[Merged by Bors] - chore(AlgebraicGeometry): golf entire `range_fromSpecResidueField` using `simp`

### DIFF
--- a/Mathlib/AlgebraicGeometry/ResidueField.lean
+++ b/Mathlib/AlgebraicGeometry/ResidueField.lean
@@ -255,9 +255,7 @@ lemma fromSpecResidueField_apply (x : X.carrier) (s : Spec (X.residueField x)) :
 
 lemma range_fromSpecResidueField (x : X.carrier) :
     Set.range (X.fromSpecResidueField x).base = {x} := by
-  ext s
-  simp only [Set.mem_range, fromSpecResidueField_apply, Set.mem_singleton_iff]
-  grind
+  simp
 
 lemma descResidueField_fromSpecResidueField {K : Type*} [Field K] (X : Scheme) {x}
     (f : X.presheaf.stalk x ⟶ .of K) [IsLocalHom f.hom] :


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>range_fromSpecResidueField</code></summary>

### Trace profiling of `range_fromSpecResidueField` before PR 28265
```diff
diff --git a/Mathlib/AlgebraicGeometry/ResidueField.lean b/Mathlib/AlgebraicGeometry/ResidueField.lean
index f3382cac9f..9376415a75 100644
--- a/Mathlib/AlgebraicGeometry/ResidueField.lean
+++ b/Mathlib/AlgebraicGeometry/ResidueField.lean
@@ -255,2 +255,3 @@ lemma fromSpecResidueField_apply (x : X.carrier) (s : Spec (X.residueField x)) :
 
+set_option trace.profiler true in
 lemma range_fromSpecResidueField (x : X.carrier) :
```
```
ℹ [2193/2193] Built Mathlib.AlgebraicGeometry.ResidueField
info: Mathlib/AlgebraicGeometry/ResidueField.lean:257:0: [Elab.command] [0.010251] theorem range_fromSpecResidueField (x : X.carrier) :
        Set.range (X.fromSpecResidueField x).base = { x } :=
      by
      ext s
      simp only [Set.mem_range, fromSpecResidueField_apply, Set.mem_singleton_iff]
      grind
info: Mathlib/AlgebraicGeometry/ResidueField.lean:257:0: [Elab.command] [0.010389] lemma range_fromSpecResidueField (x : X.carrier) :
        Set.range (X.fromSpecResidueField x).base = { x } :=
      by
      ext s
      simp only [Set.mem_range, fromSpecResidueField_apply, Set.mem_singleton_iff]
      grind
info: Mathlib/AlgebraicGeometry/ResidueField.lean:257:0: [Elab.async] [0.022058] elaborating proof of AlgebraicGeometry.Scheme.range_fromSpecResidueField
  [Elab.definition.value] [0.021561] AlgebraicGeometry.Scheme.range_fromSpecResidueField
    [Elab.step] [0.021060] 
          ext s
          simp only [Set.mem_range, fromSpecResidueField_apply, Set.mem_singleton_iff]
          grind
      [Elab.step] [0.021045] 
            ext s
            simp only [Set.mem_range, fromSpecResidueField_apply, Set.mem_singleton_iff]
            grind
        [Elab.step] [0.012601] simp only [Set.mem_range, fromSpecResidueField_apply, Set.mem_singleton_iff]
Build completed successfully.
```

### Trace profiling of `range_fromSpecResidueField` after PR 28265
```diff
diff --git a/Mathlib/AlgebraicGeometry/ResidueField.lean b/Mathlib/AlgebraicGeometry/ResidueField.lean
index f3382cac9f..453beb93ab 100644
--- a/Mathlib/AlgebraicGeometry/ResidueField.lean
+++ b/Mathlib/AlgebraicGeometry/ResidueField.lean
@@ -255,7 +255,6 @@ lemma fromSpecResidueField_apply (x : X.carrier) (s : Spec (X.residueField x)) :
 
+set_option trace.profiler true in
 lemma range_fromSpecResidueField (x : X.carrier) :
     Set.range (X.fromSpecResidueField x).base = {x} := by
-  ext s
-  simp only [Set.mem_range, fromSpecResidueField_apply, Set.mem_singleton_iff]
-  grind
+  simp
 
```
```
ℹ [2193/2193] Built Mathlib.AlgebraicGeometry.ResidueField
info: Mathlib/AlgebraicGeometry/ResidueField.lean:257:0: [Elab.command] [0.015019] theorem range_fromSpecResidueField (x : X.carrier) :
        Set.range (X.fromSpecResidueField x).base = { x } := by simp
  [Elab.definition.header] [0.010788] AlgebraicGeometry.Scheme.range_fromSpecResidueField
info: Mathlib/AlgebraicGeometry/ResidueField.lean:257:0: [Elab.command] [0.015203] lemma range_fromSpecResidueField (x : X.carrier) :
        Set.range (X.fromSpecResidueField x).base = { x } := by simp
info: Mathlib/AlgebraicGeometry/ResidueField.lean:257:0: [Elab.async] [0.023048] elaborating proof of AlgebraicGeometry.Scheme.range_fromSpecResidueField
  [Elab.definition.value] [0.022551] AlgebraicGeometry.Scheme.range_fromSpecResidueField
    [Elab.step] [0.021821] simp
      [Elab.step] [0.021808] simp
        [Elab.step] [0.021793] simp
          [Meta.synthInstance] [0.010392] ❌️ Surjective (X.fromSpecResidueField x)
Build completed successfully.
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
