### PR TITLE
[Merged by Bors] - chore(Combinatorics/SimpleGraph): golf entire `dist_ne_zero_iff_ne_and_reachable` using `simp`

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Metric.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
@@ -230,8 +230,7 @@ theorem dist_comm : G.dist u v = G.dist v u := by
   rw [dist, dist, edist_comm]
 
 lemma dist_ne_zero_iff_ne_and_reachable : G.dist u v ≠ 0 ↔ u ≠ v ∧ G.Reachable u v := by
-  rw [ne_eq, dist_eq_zero_iff_eq_or_not_reachable.not]
-  push_neg; rfl
+  simp
 
 lemma Reachable.of_dist_ne_zero (h : G.dist u v ≠ 0) : G.Reachable u v :=
   (dist_ne_zero_iff_ne_and_reachable.mp h).2


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>dist_ne_zero_iff_ne_and_reachable</code></summary>

### Trace profiling of `dist_ne_zero_iff_ne_and_reachable` before PR 28268
```diff
diff --git a/Mathlib/Combinatorics/SimpleGraph/Metric.lean b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
index 6f764e0dd6..973a09d909 100644
--- a/Mathlib/Combinatorics/SimpleGraph/Metric.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
@@ -231,2 +231,3 @@ theorem dist_comm : G.dist u v = G.dist v u := by
 
+set_option trace.profiler true in
 lemma dist_ne_zero_iff_ne_and_reachable : G.dist u v ≠ 0 ↔ u ≠ v ∧ G.Reachable u v := by
```
```
ℹ [825/825] Built Mathlib.Combinatorics.SimpleGraph.Metric
info: Mathlib/Combinatorics/SimpleGraph/Metric.lean:233:0: [Elab.async] [0.019540] elaborating proof of SimpleGraph.dist_ne_zero_iff_ne_and_reachable
  [Elab.definition.value] [0.019091] SimpleGraph.dist_ne_zero_iff_ne_and_reachable
    [Elab.step] [0.018775] 
          rw [ne_eq, dist_eq_zero_iff_eq_or_not_reachable.not]
          push_neg; rfl
      [Elab.step] [0.018761] 
            rw [ne_eq, dist_eq_zero_iff_eq_or_not_reachable.not]
            push_neg; rfl
        [Elab.step] [0.014793] rw [ne_eq, dist_eq_zero_iff_eq_or_not_reachable.not]
          [Elab.step] [0.014778] (rewrite [ne_eq, dist_eq_zero_iff_eq_or_not_reachable.not];
                with_annotate_state"]" (try (with_reducible rfl)))
            [Elab.step] [0.014769] rewrite [ne_eq, dist_eq_zero_iff_eq_or_not_reachable.not];
                  with_annotate_state"]" (try (with_reducible rfl))
              [Elab.step] [0.014760] rewrite [ne_eq, dist_eq_zero_iff_eq_or_not_reachable.not];
                    with_annotate_state"]" (try (with_reducible rfl))
                [Elab.step] [0.012559] rewrite [ne_eq, dist_eq_zero_iff_eq_or_not_reachable.not]
Build completed successfully.
```

### Trace profiling of `dist_ne_zero_iff_ne_and_reachable` after PR 28268
```diff
diff --git a/Mathlib/Combinatorics/SimpleGraph/Metric.lean b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
index 6f764e0dd6..dae987d51a 100644
--- a/Mathlib/Combinatorics/SimpleGraph/Metric.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Metric.lean
@@ -231,5 +231,5 @@ theorem dist_comm : G.dist u v = G.dist v u := by
 
+set_option trace.profiler true in
 lemma dist_ne_zero_iff_ne_and_reachable : G.dist u v ≠ 0 ↔ u ≠ v ∧ G.Reachable u v := by
-  rw [ne_eq, dist_eq_zero_iff_eq_or_not_reachable.not]
-  push_neg; rfl
+  simp
 
```
```
✔ [825/825] Built Mathlib.Combinatorics.SimpleGraph.Metric
Build completed successfully.
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
