### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Shift): golf entire `shift_shift'` using `simp`

### DIFF
--- a/Mathlib/CategoryTheory/Shift/Basic.lean
+++ b/Mathlib/CategoryTheory/Shift/Basic.lean
@@ -355,9 +355,7 @@ abbrev shiftAdd (i j : A) : X⟦i + j⟧ ≅ X⟦i⟧⟦j⟧ :=
 
 theorem shift_shift' (i j : A) :
     f⟦i⟧'⟦j⟧' = (shiftAdd X i j).inv ≫ f⟦i + j⟧' ≫ (shiftAdd Y i j).hom := by
-  symm
-  rw [← Functor.comp_map, Iso.app_inv]
-  apply NatIso.naturality_1
+  simp
 
 variable (A)
 


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>shift_shift'</code></summary>

### Trace profiling of `shift_shift'` before PR 28269
```diff
diff --git a/Mathlib/CategoryTheory/Shift/Basic.lean b/Mathlib/CategoryTheory/Shift/Basic.lean
index 1a1764a297..e8f671f043 100644
--- a/Mathlib/CategoryTheory/Shift/Basic.lean
+++ b/Mathlib/CategoryTheory/Shift/Basic.lean
@@ -355,2 +355,3 @@ abbrev shiftAdd (i j : A) : X⟦i + j⟧ ≅ X⟦i⟧⟦j⟧ :=
 
+set_option trace.profiler true in
 theorem shift_shift' (i j : A) :
```
```
ℹ [620/620] Built Mathlib.CategoryTheory.Shift.Basic
info: Mathlib/CategoryTheory/Shift/Basic.lean:357:0: [Elab.command] [0.015894] theorem shift_shift' (i j : A) :
        f⟦i⟧'⟦j⟧' = (shiftAdd X i j).inv ≫ f⟦i + j⟧' ≫ (shiftAdd Y i j).hom :=
      by
      symm
      rw [← Functor.comp_map, Iso.app_inv]
      apply NatIso.naturality_1
  [Elab.definition.header] [0.013000] CategoryTheory.shift_shift'
    [Elab.step] [0.012854] expected type: Sort ?u.55823, term
        f⟦i⟧'⟦j⟧' = (shiftAdd X i j).inv ≫ f⟦i + j⟧' ≫ (shiftAdd Y i j).hom
      [Elab.step] [0.012842] expected type: Sort ?u.55823, term
          binrel% Eq✝ (f⟦i⟧'⟦j⟧') ((shiftAdd X i j).inv ≫ f⟦i + j⟧' ≫ (shiftAdd Y i j).hom)
info: Mathlib/CategoryTheory/Shift/Basic.lean:357:0: [Elab.async] [0.013184] elaborating proof of CategoryTheory.shift_shift'
  [Elab.definition.value] [0.012193] CategoryTheory.shift_shift'
    [Elab.step] [0.011583] 
          symm
          rw [← Functor.comp_map, Iso.app_inv]
          apply NatIso.naturality_1
      [Elab.step] [0.011569] 
            symm
            rw [← Functor.comp_map, Iso.app_inv]
            apply NatIso.naturality_1
Build completed successfully.
```

### Trace profiling of `shift_shift'` after PR 28269
```diff
diff --git a/Mathlib/CategoryTheory/Shift/Basic.lean b/Mathlib/CategoryTheory/Shift/Basic.lean
index 1a1764a297..3710421473 100644
--- a/Mathlib/CategoryTheory/Shift/Basic.lean
+++ b/Mathlib/CategoryTheory/Shift/Basic.lean
@@ -355,7 +355,6 @@ abbrev shiftAdd (i j : A) : X⟦i + j⟧ ≅ X⟦i⟧⟦j⟧ :=
 
+set_option trace.profiler true in
 theorem shift_shift' (i j : A) :
     f⟦i⟧'⟦j⟧' = (shiftAdd X i j).inv ≫ f⟦i + j⟧' ≫ (shiftAdd Y i j).hom := by
-  symm
-  rw [← Functor.comp_map, Iso.app_inv]
-  apply NatIso.naturality_1
+  simp
 
```
```
ℹ [620/620] Built Mathlib.CategoryTheory.Shift.Basic
info: Mathlib/CategoryTheory/Shift/Basic.lean:357:0: [Elab.command] [0.015797] theorem shift_shift' (i j : A) :
        f⟦i⟧'⟦j⟧' = (shiftAdd X i j).inv ≫ f⟦i + j⟧' ≫ (shiftAdd Y i j).hom := by simp
  [Elab.definition.header] [0.013066] CategoryTheory.shift_shift'
    [Elab.step] [0.012914] expected type: Sort ?u.55823, term
        f⟦i⟧'⟦j⟧' = (shiftAdd X i j).inv ≫ f⟦i + j⟧' ≫ (shiftAdd Y i j).hom
      [Elab.step] [0.012896] expected type: Sort ?u.55823, term
          binrel% Eq✝ (f⟦i⟧'⟦j⟧') ((shiftAdd X i j).inv ≫ f⟦i + j⟧' ≫ (shiftAdd Y i j).hom)
info: Mathlib/CategoryTheory/Shift/Basic.lean:357:0: [Elab.async] [0.020361] elaborating proof of CategoryTheory.shift_shift'
  [Elab.definition.value] [0.019246] CategoryTheory.shift_shift'
    [Elab.step] [0.018396] simp
      [Elab.step] [0.018381] simp
        [Elab.step] [0.018365] simp
Build completed successfully.
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
