### PR TITLE
[Merged by Bors] - chore(RingTheory/Valuation): golf entire `val_eq_one_iff` using `simp`

### DIFF
--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -397,9 +397,7 @@ theorem val_le_one_iff (v : Valuation K Γ₀) {x : K} (h : x ≠ 0) : v x ≤ 1
   simp [one_le_inv₀ (v.pos_iff.2 h)]
 
 theorem val_eq_one_iff (v : Valuation K Γ₀) {x : K} : v x = 1 ↔ v x⁻¹ = 1 := by
-  by_cases h : x = 0
-  · simp only [map_inv₀, inv_eq_one]
-  · simpa only [le_antisymm_iff, And.comm] using and_congr (one_le_val_iff v h) (val_le_one_iff v h)
+  simp
 
 theorem val_le_one_or_val_inv_lt_one (v : Valuation K Γ₀) (x : K) : v x ≤ 1 ∨ v x⁻¹ < 1 := by
   by_cases h : x = 0


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>val_eq_one_iff</code></summary>

### Trace profiling of `val_eq_one_iff` before PR 28270
```diff
diff --git a/Mathlib/RingTheory/Valuation/Basic.lean b/Mathlib/RingTheory/Valuation/Basic.lean
index 951f270b74..fbd4b39d5f 100644
--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -398,2 +398,3 @@ theorem val_le_one_iff (v : Valuation K Γ₀) {x : K} (h : x ≠ 0) : v x ≤ 1
 
+set_option trace.profiler true in
 theorem val_eq_one_iff (v : Valuation K Γ₀) {x : K} : v x = 1 ↔ v x⁻¹ = 1 := by
```
```
ℹ [1191/1191] Built Mathlib.RingTheory.Valuation.Basic
info: Mathlib/RingTheory/Valuation/Basic.lean:400:0: [Elab.command] [0.021648] theorem val_eq_one_iff (v : Valuation K Γ₀) {x : K} : v x = 1 ↔ v x⁻¹ = 1 :=
      by
      by_cases h : x = 0
      · simp only [map_inv₀, inv_eq_one]
      · simpa only [le_antisymm_iff, And.comm] using and_congr (one_le_val_iff v h) (val_le_one_iff v h)
  [Elab.definition.header] [0.020152] Valuation.val_eq_one_iff
    [Elab.step] [0.019328] expected type: Prop, term
        v x = 1 ↔ v x⁻¹ = 1
      [Elab.step] [0.019320] expected type: Prop, term
          Iff✝ (v x = 1) (v x⁻¹ = 1)
        [Elab.step] [0.014688] expected type: Prop, term
            v x⁻¹ = 1
          [Elab.step] [0.014679] expected type: Prop, term
              binrel% Eq✝ (v x⁻¹) 1
            [Elab.step] [0.014296] expected type: <not-available>, term
                v x⁻¹
              [Elab.step] [0.013414] expected type: K, term
                  x⁻¹
                [Elab.step] [0.013403] expected type: K, term
                    Inv.inv✝ x
                  [Meta.synthInstance] [0.013146] ✅️ Inv K
info: Mathlib/RingTheory/Valuation/Basic.lean:400:0: [Elab.async] [0.044763] elaborating proof of Valuation.val_eq_one_iff
  [Elab.definition.value] [0.043711] Valuation.val_eq_one_iff
    [Elab.step] [0.043150] 
          by_cases h : x = 0
          · simp only [map_inv₀, inv_eq_one]
          · simpa only [le_antisymm_iff, And.comm] using and_congr (one_le_val_iff v h) (val_le_one_iff v h)
      [Elab.step] [0.043137] 
            by_cases h : x = 0
            · simp only [map_inv₀, inv_eq_one]
            · simpa only [le_antisymm_iff, And.comm] using and_congr (one_le_val_iff v h) (val_le_one_iff v h)
        [Elab.step] [0.017062] · simp only [map_inv₀, inv_eq_one]
          [Elab.step] [0.017042] simp only [map_inv₀, inv_eq_one]
            [Elab.step] [0.017033] simp only [map_inv₀, inv_eq_one]
              [Elab.step] [0.017017] simp only [map_inv₀, inv_eq_one]
        [Elab.step] [0.019882] ·
              simpa only [le_antisymm_iff, And.comm] using and_congr (one_le_val_iff v h) (val_le_one_iff v h)
          [Elab.step] [0.019682] simpa only [le_antisymm_iff, And.comm] using
                  and_congr (one_le_val_iff v h) (val_le_one_iff v h)
            [Elab.step] [0.019674] simpa only [le_antisymm_iff, And.comm] using
                    and_congr (one_le_val_iff v h) (val_le_one_iff v h)
              [Elab.step] [0.019661] simpa only [le_antisymm_iff, And.comm] using
                    and_congr (one_le_val_iff v h) (val_le_one_iff v h)
Build completed successfully.
```

### Trace profiling of `val_eq_one_iff` after PR 28270
```diff
diff --git a/Mathlib/RingTheory/Valuation/Basic.lean b/Mathlib/RingTheory/Valuation/Basic.lean
index 951f270b74..83400a3c13 100644
--- a/Mathlib/RingTheory/Valuation/Basic.lean
+++ b/Mathlib/RingTheory/Valuation/Basic.lean
@@ -398,6 +398,5 @@ theorem val_le_one_iff (v : Valuation K Γ₀) {x : K} (h : x ≠ 0) : v x ≤ 1
 
+set_option trace.profiler true in
 theorem val_eq_one_iff (v : Valuation K Γ₀) {x : K} : v x = 1 ↔ v x⁻¹ = 1 := by
-  by_cases h : x = 0
-  · simp only [map_inv₀, inv_eq_one]
-  · simpa only [le_antisymm_iff, And.comm] using and_congr (one_le_val_iff v h) (val_le_one_iff v h)
+  simp
 
```
```
ℹ [1191/1191] Built Mathlib.RingTheory.Valuation.Basic
info: Mathlib/RingTheory/Valuation/Basic.lean:400:0: [Elab.command] [0.010653] theorem val_eq_one_iff (v : Valuation K Γ₀) {x : K} : v x = 1 ↔ v x⁻¹ = 1 := by simp
info: Mathlib/RingTheory/Valuation/Basic.lean:400:0: [Elab.async] [0.019615] elaborating proof of Valuation.val_eq_one_iff
  [Elab.definition.value] [0.018986] Valuation.val_eq_one_iff
    [Elab.step] [0.017680] simp
      [Elab.step] [0.017663] simp
        [Elab.step] [0.017644] simp
Build completed successfully.
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
