### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/AffineSpace): golf 11 lines from `affineIndependent_iff_indicator_eq_of_affineCombination_eq` using `simp_all`

### DIFF
--- a/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
@@ -195,18 +195,7 @@ theorem affineIndependent_iff_indicator_eq_of_affineCombination_eq (p : ι → P
           Finset.affineCombination_indicator_subset w2 p s1.subset_union_right,
           ← @vsub_eq_zero_iff_eq V, Finset.affineCombination_vsub] at heq
         exact ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi
-      · rw [← Finset.mem_coe, Finset.coe_union] at hi
-        have h₁ : Set.indicator (↑s1) w1 i = 0 := by
-          simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
-          intro h
-          by_contra
-          exact (mt (@Set.mem_union_left _ i ↑s1 ↑s2) hi) h
-        have h₂ : Set.indicator (↑s2) w2 i = 0 := by
-          simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
-          intro h
-          by_contra
-          exact (mt (@Set.mem_union_right _ i ↑s2 ↑s1) hi) h
-        simp [h₁, h₂]
+      · simp_all
     · intro ha s w hw hs i0 hi0
       let w1 : ι → k := Function.update (Function.const ι 0) i0 1
       have hw1 : ∑ i ∈ s, w1 i = 1 := by


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>affineIndependent_iff_indicator_eq_of_affineCombination_eq</code>: 150 ms before, 132 ms after  🎉</summary>

### Trace profiling of `affineIndependent_iff_indicator_eq_of_affineCombination_eq` before PR 28271
```diff
diff --git a/Mathlib/LinearAlgebra/AffineSpace/Independent.lean b/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
index 3058d16cf1..470fccd236 100644
--- a/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
@@ -171,6 +171,7 @@ theorem linearIndependent_set_iff_affineIndependent_vadd_union_singleton {s : Se
     exact Set.diff_singleton_eq_self fun h => hs 0 h rfl
   rw [h]
 
+set_option trace.profiler true in
 /-- A family is affinely independent if and only if any affine
 combinations (with sum of weights 1) that evaluate to the same point
 have equal `Set.indicator`. -/
```
```
ℹ [1164/1164] Built Mathlib.LinearAlgebra.AffineSpace.Independent
info: Mathlib/LinearAlgebra/AffineSpace/Independent.lean:175:0: [Elab.command] [0.018489] /-- A family is affinely independent if and only if any affine
    combinations (with sum of weights 1) that evaluate to the same point
    have equal `Set.indicator`. -/
    theorem affineIndependent_iff_indicator_eq_of_affineCombination_eq (p : ι → P) :
        AffineIndependent k p ↔
          ∀ (s1 s2 : Finset ι) (w1 w2 : ι → k),
            ∑ i ∈ s1, w1 i = 1 →
              ∑ i ∈ s2, w2 i = 1 →
                s1.affineCombination k p w1 = s2.affineCombination k p w2 →
                  Set.indicator (↑s1) w1 = Set.indicator (↑s2) w2 :=
      by
      classical
      constructor
      · intro ha s1 s2 w1 w2 hw1 hw2 heq
        ext i
        by_cases hi : i ∈ s1 ∪ s2
        · rw [← sub_eq_zero]
          rw [← Finset.sum_indicator_subset w1 (s1.subset_union_left (s₂ := s2))] at hw1
          rw [← Finset.sum_indicator_subset w2 (s1.subset_union_right)] at hw2
          have hws : (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 := by simp [hw1, hw2]
          rw [Finset.affineCombination_indicator_subset w1 p (s1.subset_union_left (s₂ := s2)),
            Finset.affineCombination_indicator_subset w2 p s1.subset_union_right, ← @vsub_eq_zero_iff_eq V,
            Finset.affineCombination_vsub] at heq
          exact ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi
        · rw [← Finset.mem_coe, Finset.coe_union] at hi
          have h₁ : Set.indicator (↑s1) w1 i = 0 :=
            by
            simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
            intro h
            by_contra
            exact (mt (@Set.mem_union_left _ i ↑s1 ↑s2) hi) h
          have h₂ : Set.indicator (↑s2) w2 i = 0 :=
            by
            simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
            intro h
            by_contra
            exact (mt (@Set.mem_union_right _ i ↑s2 ↑s1) hi) h
          simp [h₁, h₂]
      · intro ha s w hw hs i0 hi0
        let w1 : ι → k := Function.update (Function.const ι 0) i0 1
        have hw1 : ∑ i ∈ s, w1 i = 1 := by
          rw [Finset.sum_update_of_mem hi0]
          simp only [Finset.sum_const_zero, add_zero, const_apply]
        have hw1s : s.affineCombination k p w1 = p i0 :=
          s.affineCombination_of_eq_one_of_eq_zero w1 p hi0 (Function.update_self ..) fun _ _ hne =>
            Function.update_of_ne hne ..
        let w2 := w + w1
        have hw2 : ∑ i ∈ s, w2 i = 1 := by simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add]
        have hw2s : s.affineCombination k p w2 = p i0 := by
          simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd]
        replace ha := ha s s w2 w1 hw2 hw1 (hw1s.symm ▸ hw2s)
        have hws : w2 i0 - w1 i0 = 0 := by
          rw [← Finset.mem_coe] at hi0
          rw [← Set.indicator_of_mem hi0 w2, ← Set.indicator_of_mem hi0 w1, ha, sub_self]
        simpa [w2] using hws
  [Elab.definition.header] [0.013425] affineIndependent_iff_indicator_eq_of_affineCombination_eq
    [Elab.step] [0.013346] expected type: Prop, term
        AffineIndependent k p ↔
          ∀ (s1 s2 : Finset ι) (w1 w2 : ι → k),
            ∑ i ∈ s1, w1 i = 1 →
              ∑ i ∈ s2, w2 i = 1 →
                s1.affineCombination k p w1 = s2.affineCombination k p w2 →
                  Set.indicator (↑s1) w1 = Set.indicator (↑s2) w2
      [Elab.step] [0.013341] expected type: Prop, term
          Iff✝ (AffineIndependent k p)
            (∀ (s1 s2 : Finset ι) (w1 w2 : ι → k),
              ∑ i ∈ s1, w1 i = 1 →
                ∑ i ∈ s2, w2 i = 1 →
                  s1.affineCombination k p w1 = s2.affineCombination k p w2 →
                    Set.indicator (↑s1) w1 = Set.indicator (↑s2) w2)
        [Elab.step] [0.012551] expected type: Prop, term
            ∀ (s1 s2 : Finset ι) (w1 w2 : ι → k),
              ∑ i ∈ s1, w1 i = 1 →
                ∑ i ∈ s2, w2 i = 1 →
                  s1.affineCombination k p w1 = s2.affineCombination k p w2 →
                    Set.indicator (↑s1) w1 = Set.indicator (↑s2) w2
          [Elab.step] [0.012396] expected type: Sort ?u.14914, term
              ∑ i ∈ s1, w1 i = 1 →
                ∑ i ∈ s2, w2 i = 1 →
                  s1.affineCombination k p w1 = s2.affineCombination k p w2 →
                    Set.indicator (↑s1) w1 = Set.indicator (↑s2) w2
            [Elab.step] [0.010706] expected type: Sort ?u.15054, term
                ∑ i ∈ s2, w2 i = 1 →
                  s1.affineCombination k p w1 = s2.affineCombination k p w2 →
                    Set.indicator (↑s1) w1 = Set.indicator (↑s2) w2
              [Elab.step] [0.010237] expected type: Sort ?u.15095, term
                  s1.affineCombination k p w1 = s2.affineCombination k p w2 →
                    Set.indicator (↑s1) w1 = Set.indicator (↑s2) w2
info: Mathlib/LinearAlgebra/AffineSpace/Independent.lean:175:0: [Elab.async] [0.152838] elaborating proof of affineIndependent_iff_indicator_eq_of_affineCombination_eq
  [Elab.definition.value] [0.149786] affineIndependent_iff_indicator_eq_of_affineCombination_eq
    [Elab.step] [0.146682] classical
          constructor
          · intro ha s1 s2 w1 w2 hw1 hw2 heq
            ext i
            by_cases hi : i ∈ s1 ∪ s2
            · rw [← sub_eq_zero]
              rw [← Finset.sum_indicator_subset w1 (s1.subset_union_left (s₂ := s2))] at hw1
              rw [← Finset.sum_indicator_subset w2 (s1.subset_union_right)] at hw2
              have hws : (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 := by simp [hw1, hw2]
              rw [Finset.affineCombination_indicator_subset w1 p (s1.subset_union_left (s₂ := s2)),
                Finset.affineCombination_indicator_subset w2 p s1.subset_union_right, ← @vsub_eq_zero_iff_eq V,
                Finset.affineCombination_vsub] at heq
              exact ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi
            · rw [← Finset.mem_coe, Finset.coe_union] at hi
              have h₁ : Set.indicator (↑s1) w1 i = 0 :=
                by
                simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                intro h
                by_contra
                exact (mt (@Set.mem_union_left _ i ↑s1 ↑s2) hi) h
              have h₂ : Set.indicator (↑s2) w2 i = 0 :=
                by
                simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                intro h
                by_contra
                exact (mt (@Set.mem_union_right _ i ↑s2 ↑s1) hi) h
              simp [h₁, h₂]
          · intro ha s w hw hs i0 hi0
            let w1 : ι → k := Function.update (Function.const ι 0) i0 1
            have hw1 : ∑ i ∈ s, w1 i = 1 := by
              rw [Finset.sum_update_of_mem hi0]
              simp only [Finset.sum_const_zero, add_zero, const_apply]
            have hw1s : s.affineCombination k p w1 = p i0 :=
              s.affineCombination_of_eq_one_of_eq_zero w1 p hi0 (Function.update_self ..) fun _ _ hne =>
                Function.update_of_ne hne ..
            let w2 := w + w1
            have hw2 : ∑ i ∈ s, w2 i = 1 := by simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add]
            have hw2s : s.affineCombination k p w2 = p i0 := by
              simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd]
            replace ha := ha s s w2 w1 hw2 hw1 (hw1s.symm ▸ hw2s)
            have hws : w2 i0 - w1 i0 = 0 := by
              rw [← Finset.mem_coe] at hi0
              rw [← Set.indicator_of_mem hi0 w2, ← Set.indicator_of_mem hi0 w1, ha, sub_self]
            simpa [w2] using hws
      [Elab.step] [0.146678] classical
            constructor
            · intro ha s1 s2 w1 w2 hw1 hw2 heq
              ext i
              by_cases hi : i ∈ s1 ∪ s2
              · rw [← sub_eq_zero]
                rw [← Finset.sum_indicator_subset w1 (s1.subset_union_left (s₂ := s2))] at hw1
                rw [← Finset.sum_indicator_subset w2 (s1.subset_union_right)] at hw2
                have hws : (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 := by
                  simp [hw1, hw2]
                rw [Finset.affineCombination_indicator_subset w1 p (s1.subset_union_left (s₂ := s2)),
                  Finset.affineCombination_indicator_subset w2 p s1.subset_union_right, ← @vsub_eq_zero_iff_eq V,
                  Finset.affineCombination_vsub] at heq
                exact ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi
              · rw [← Finset.mem_coe, Finset.coe_union] at hi
                have h₁ : Set.indicator (↑s1) w1 i = 0 :=
                  by
                  simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                  intro h
                  by_contra
                  exact (mt (@Set.mem_union_left _ i ↑s1 ↑s2) hi) h
                have h₂ : Set.indicator (↑s2) w2 i = 0 :=
                  by
                  simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                  intro h
                  by_contra
                  exact (mt (@Set.mem_union_right _ i ↑s2 ↑s1) hi) h
                simp [h₁, h₂]
            · intro ha s w hw hs i0 hi0
              let w1 : ι → k := Function.update (Function.const ι 0) i0 1
              have hw1 : ∑ i ∈ s, w1 i = 1 := by
                rw [Finset.sum_update_of_mem hi0]
                simp only [Finset.sum_const_zero, add_zero, const_apply]
              have hw1s : s.affineCombination k p w1 = p i0 :=
                s.affineCombination_of_eq_one_of_eq_zero w1 p hi0 (Function.update_self ..) fun _ _ hne =>
                  Function.update_of_ne hne ..
              let w2 := w + w1
              have hw2 : ∑ i ∈ s, w2 i = 1 := by simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add]
              have hw2s : s.affineCombination k p w2 = p i0 := by
                simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd]
              replace ha := ha s s w2 w1 hw2 hw1 (hw1s.symm ▸ hw2s)
              have hws : w2 i0 - w1 i0 = 0 := by
                rw [← Finset.mem_coe] at hi0
                rw [← Set.indicator_of_mem hi0 w2, ← Set.indicator_of_mem hi0 w1, ha, sub_self]
              simpa [w2] using hws
        [Elab.step] [0.146673] classical
            constructor
            · intro ha s1 s2 w1 w2 hw1 hw2 heq
              ext i
              by_cases hi : i ∈ s1 ∪ s2
              · rw [← sub_eq_zero]
                rw [← Finset.sum_indicator_subset w1 (s1.subset_union_left (s₂ := s2))] at hw1
                rw [← Finset.sum_indicator_subset w2 (s1.subset_union_right)] at hw2
                have hws : (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 := by
                  simp [hw1, hw2]
                rw [Finset.affineCombination_indicator_subset w1 p (s1.subset_union_left (s₂ := s2)),
                  Finset.affineCombination_indicator_subset w2 p s1.subset_union_right, ← @vsub_eq_zero_iff_eq V,
                  Finset.affineCombination_vsub] at heq
                exact ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi
              · rw [← Finset.mem_coe, Finset.coe_union] at hi
                have h₁ : Set.indicator (↑s1) w1 i = 0 :=
                  by
                  simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                  intro h
                  by_contra
                  exact (mt (@Set.mem_union_left _ i ↑s1 ↑s2) hi) h
                have h₂ : Set.indicator (↑s2) w2 i = 0 :=
                  by
                  simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                  intro h
                  by_contra
                  exact (mt (@Set.mem_union_right _ i ↑s2 ↑s1) hi) h
                simp [h₁, h₂]
            · intro ha s w hw hs i0 hi0
              let w1 : ι → k := Function.update (Function.const ι 0) i0 1
              have hw1 : ∑ i ∈ s, w1 i = 1 := by
                rw [Finset.sum_update_of_mem hi0]
                simp only [Finset.sum_const_zero, add_zero, const_apply]
              have hw1s : s.affineCombination k p w1 = p i0 :=
                s.affineCombination_of_eq_one_of_eq_zero w1 p hi0 (Function.update_self ..) fun _ _ hne =>
                  Function.update_of_ne hne ..
              let w2 := w + w1
              have hw2 : ∑ i ∈ s, w2 i = 1 := by simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add]
              have hw2s : s.affineCombination k p w2 = p i0 := by
                simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd]
              replace ha := ha s s w2 w1 hw2 hw1 (hw1s.symm ▸ hw2s)
              have hws : w2 i0 - w1 i0 = 0 := by
                rw [← Finset.mem_coe] at hi0
                rw [← Set.indicator_of_mem hi0 w2, ← Set.indicator_of_mem hi0 w1, ha, sub_self]
              simpa [w2] using hws
          [Elab.step] [0.146464] 
                constructor
                · intro ha s1 s2 w1 w2 hw1 hw2 heq
                  ext i
                  by_cases hi : i ∈ s1 ∪ s2
                  · rw [← sub_eq_zero]
                    rw [← Finset.sum_indicator_subset w1 (s1.subset_union_left (s₂ := s2))] at hw1
                    rw [← Finset.sum_indicator_subset w2 (s1.subset_union_right)] at hw2
                    have hws : (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 := by
                      simp [hw1, hw2]
                    rw [Finset.affineCombination_indicator_subset w1 p (s1.subset_union_left (s₂ := s2)),
                      Finset.affineCombination_indicator_subset w2 p s1.subset_union_right, ← @vsub_eq_zero_iff_eq V,
                      Finset.affineCombination_vsub] at heq
                    exact ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi
                  · rw [← Finset.mem_coe, Finset.coe_union] at hi
                    have h₁ : Set.indicator (↑s1) w1 i = 0 :=
                      by
                      simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                      intro h
                      by_contra
                      exact (mt (@Set.mem_union_left _ i ↑s1 ↑s2) hi) h
                    have h₂ : Set.indicator (↑s2) w2 i = 0 :=
                      by
                      simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                      intro h
                      by_contra
                      exact (mt (@Set.mem_union_right _ i ↑s2 ↑s1) hi) h
                    simp [h₁, h₂]
                · intro ha s w hw hs i0 hi0
                  let w1 : ι → k := Function.update (Function.const ι 0) i0 1
                  have hw1 : ∑ i ∈ s, w1 i = 1 := by
                    rw [Finset.sum_update_of_mem hi0]
                    simp only [Finset.sum_const_zero, add_zero, const_apply]
                  have hw1s : s.affineCombination k p w1 = p i0 :=
                    s.affineCombination_of_eq_one_of_eq_zero w1 p hi0 (Function.update_self ..) fun _ _ hne =>
                      Function.update_of_ne hne ..
                  let w2 := w + w1
                  have hw2 : ∑ i ∈ s, w2 i = 1 := by simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add]
                  have hw2s : s.affineCombination k p w2 = p i0 := by
                    simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd]
                  replace ha := ha s s w2 w1 hw2 hw1 (hw1s.symm ▸ hw2s)
                  have hws : w2 i0 - w1 i0 = 0 := by
                    rw [← Finset.mem_coe] at hi0
                    rw [← Set.indicator_of_mem hi0 w2, ← Set.indicator_of_mem hi0 w1, ha, sub_self]
                  simpa [w2] using hws
            [Elab.step] [0.146457] 
                  constructor
                  · intro ha s1 s2 w1 w2 hw1 hw2 heq
                    ext i
                    by_cases hi : i ∈ s1 ∪ s2
                    · rw [← sub_eq_zero]
                      rw [← Finset.sum_indicator_subset w1 (s1.subset_union_left (s₂ := s2))] at hw1
                      rw [← Finset.sum_indicator_subset w2 (s1.subset_union_right)] at hw2
                      have hws : (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 := by
                        simp [hw1, hw2]
                      rw [Finset.affineCombination_indicator_subset w1 p (s1.subset_union_left (s₂ := s2)),
                        Finset.affineCombination_indicator_subset w2 p s1.subset_union_right, ← @vsub_eq_zero_iff_eq V,
                        Finset.affineCombination_vsub] at heq
                      exact ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi
                    · rw [← Finset.mem_coe, Finset.coe_union] at hi
                      have h₁ : Set.indicator (↑s1) w1 i = 0 :=
                        by
                        simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                        intro h
                        by_contra
                        exact (mt (@Set.mem_union_left _ i ↑s1 ↑s2) hi) h
                      have h₂ : Set.indicator (↑s2) w2 i = 0 :=
                        by
                        simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                        intro h
                        by_contra
                        exact (mt (@Set.mem_union_right _ i ↑s2 ↑s1) hi) h
                      simp [h₁, h₂]
                  · intro ha s w hw hs i0 hi0
                    let w1 : ι → k := Function.update (Function.const ι 0) i0 1
                    have hw1 : ∑ i ∈ s, w1 i = 1 := by
                      rw [Finset.sum_update_of_mem hi0]
                      simp only [Finset.sum_const_zero, add_zero, const_apply]
                    have hw1s : s.affineCombination k p w1 = p i0 :=
                      s.affineCombination_of_eq_one_of_eq_zero w1 p hi0 (Function.update_self ..) fun _ _ hne =>
                        Function.update_of_ne hne ..
                    let w2 := w + w1
                    have hw2 : ∑ i ∈ s, w2 i = 1 := by
                      simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add]
                    have hw2s : s.affineCombination k p w2 = p i0 := by
                      simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd]
                    replace ha := ha s s w2 w1 hw2 hw1 (hw1s.symm ▸ hw2s)
                    have hws : w2 i0 - w1 i0 = 0 := by
                      rw [← Finset.mem_coe] at hi0
                      rw [← Set.indicator_of_mem hi0 w2, ← Set.indicator_of_mem hi0 w1, ha, sub_self]
                    simpa [w2] using hws
              [Elab.step] [0.077731] ·
                    intro ha s1 s2 w1 w2 hw1 hw2 heq
                    ext i
                    by_cases hi : i ∈ s1 ∪ s2
                    · rw [← sub_eq_zero]
                      rw [← Finset.sum_indicator_subset w1 (s1.subset_union_left (s₂ := s2))] at hw1
                      rw [← Finset.sum_indicator_subset w2 (s1.subset_union_right)] at hw2
                      have hws : (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 := by
                        simp [hw1, hw2]
                      rw [Finset.affineCombination_indicator_subset w1 p (s1.subset_union_left (s₂ := s2)),
                        Finset.affineCombination_indicator_subset w2 p s1.subset_union_right, ← @vsub_eq_zero_iff_eq V,
                        Finset.affineCombination_vsub] at heq
                      exact ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi
                    · rw [← Finset.mem_coe, Finset.coe_union] at hi
                      have h₁ : Set.indicator (↑s1) w1 i = 0 :=
                        by
                        simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                        intro h
                        by_contra
                        exact (mt (@Set.mem_union_left _ i ↑s1 ↑s2) hi) h
                      have h₂ : Set.indicator (↑s2) w2 i = 0 :=
                        by
                        simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                        intro h
                        by_contra
                        exact (mt (@Set.mem_union_right _ i ↑s2 ↑s1) hi) h
                      simp [h₁, h₂]
                [Elab.step] [0.077721] 
                      intro ha s1 s2 w1 w2 hw1 hw2 heq
                      ext i
                      by_cases hi : i ∈ s1 ∪ s2
                      · rw [← sub_eq_zero]
                        rw [← Finset.sum_indicator_subset w1 (s1.subset_union_left (s₂ := s2))] at hw1
                        rw [← Finset.sum_indicator_subset w2 (s1.subset_union_right)] at hw2
                        have hws : (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 := by
                          simp [hw1, hw2]
                        rw [Finset.affineCombination_indicator_subset w1 p (s1.subset_union_left (s₂ := s2)),
                          Finset.affineCombination_indicator_subset w2 p s1.subset_union_right, ←
                          @vsub_eq_zero_iff_eq V, Finset.affineCombination_vsub] at heq
                        exact ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi
                      · rw [← Finset.mem_coe, Finset.coe_union] at hi
                        have h₁ : Set.indicator (↑s1) w1 i = 0 :=
                          by
                          simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                          intro h
                          by_contra
                          exact (mt (@Set.mem_union_left _ i ↑s1 ↑s2) hi) h
                        have h₂ : Set.indicator (↑s2) w2 i = 0 :=
                          by
                          simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                          intro h
                          by_contra
                          exact (mt (@Set.mem_union_right _ i ↑s2 ↑s1) hi) h
                        simp [h₁, h₂]
                  [Elab.step] [0.077717] 
                        intro ha s1 s2 w1 w2 hw1 hw2 heq
                        ext i
                        by_cases hi : i ∈ s1 ∪ s2
                        · rw [← sub_eq_zero]
                          rw [← Finset.sum_indicator_subset w1 (s1.subset_union_left (s₂ := s2))] at hw1
                          rw [← Finset.sum_indicator_subset w2 (s1.subset_union_right)] at hw2
                          have hws : (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 := by
                            simp [hw1, hw2]
                          rw [Finset.affineCombination_indicator_subset w1 p (s1.subset_union_left (s₂ := s2)),
                            Finset.affineCombination_indicator_subset w2 p s1.subset_union_right, ←
                            @vsub_eq_zero_iff_eq V, Finset.affineCombination_vsub] at heq
                          exact ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi
                        · rw [← Finset.mem_coe, Finset.coe_union] at hi
                          have h₁ : Set.indicator (↑s1) w1 i = 0 :=
                            by
                            simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                            intro h
                            by_contra
                            exact (mt (@Set.mem_union_left _ i ↑s1 ↑s2) hi) h
                          have h₂ : Set.indicator (↑s2) w2 i = 0 :=
                            by
                            simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                            intro h
                            by_contra
                            exact (mt (@Set.mem_union_right _ i ↑s2 ↑s1) hi) h
                          simp [h₁, h₂]
                    [Elab.step] [0.048167] ·
                          rw [← sub_eq_zero]
                          rw [← Finset.sum_indicator_subset w1 (s1.subset_union_left (s₂ := s2))] at hw1
                          rw [← Finset.sum_indicator_subset w2 (s1.subset_union_right)] at hw2
                          have hws : (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 := by
                            simp [hw1, hw2]
                          rw [Finset.affineCombination_indicator_subset w1 p (s1.subset_union_left (s₂ := s2)),
                            Finset.affineCombination_indicator_subset w2 p s1.subset_union_right, ←
                            @vsub_eq_zero_iff_eq V, Finset.affineCombination_vsub] at heq
                          exact ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi
                      [Elab.step] [0.048160] 
                            rw [← sub_eq_zero]
                            rw [← Finset.sum_indicator_subset w1 (s1.subset_union_left (s₂ := s2))] at hw1
                            rw [← Finset.sum_indicator_subset w2 (s1.subset_union_right)] at hw2
                            have hws : (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 := by
                              simp [hw1, hw2]
                            rw [Finset.affineCombination_indicator_subset w1 p (s1.subset_union_left (s₂ := s2)),
                              Finset.affineCombination_indicator_subset w2 p s1.subset_union_right, ←
                              @vsub_eq_zero_iff_eq V, Finset.affineCombination_vsub] at heq
                            exact ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi
                        [Elab.step] [0.048155] 
                              rw [← sub_eq_zero]
                              rw [← Finset.sum_indicator_subset w1 (s1.subset_union_left (s₂ := s2))] at hw1
                              rw [← Finset.sum_indicator_subset w2 (s1.subset_union_right)] at hw2
                              have hws : (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 := by
                                simp [hw1, hw2]
                              rw [Finset.affineCombination_indicator_subset w1 p (s1.subset_union_left (s₂ := s2)),
                                Finset.affineCombination_indicator_subset w2 p s1.subset_union_right, ←
                                @vsub_eq_zero_iff_eq V, Finset.affineCombination_vsub] at heq
                              exact ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi
                          [Elab.step] [0.023372] have hws :
                                (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 := by
                                simp [hw1, hw2]
                            [Elab.step] [0.023334] focus
                                  refine
                                    no_implicit_lambda%
                                      (have hws :
                                        (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 :=
                                        ?body✝;
                                      ?_)
                                  case body✝ => with_annotate_state"by" (simp [hw1, hw2])
                              [Elab.step] [0.023329] 
                                    refine
                                      no_implicit_lambda%
                                        (have hws :
                                          (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 :=
                                          ?body✝;
                                        ?_)
                                    case body✝ => with_annotate_state"by" (simp [hw1, hw2])
                                [Elab.step] [0.023326] 
                                      refine
                                        no_implicit_lambda%
                                          (have hws :
                                            (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 :=
                                            ?body✝;
                                          ?_)
                                      case body✝ => with_annotate_state"by" (simp [hw1, hw2])
                                  [Elab.step] [0.014578] case body✝ => with_annotate_state"by" (simp [hw1, hw2])
                                    [Elab.step] [0.014523] with_annotate_state"by" (simp [hw1, hw2])
                                      [Elab.step] [0.014520] with_annotate_state"by" (simp [hw1, hw2])
                                        [Elab.step] [0.014516] with_annotate_state"by" (simp [hw1, hw2])
                                          [Elab.step] [0.014513] (simp [hw1, hw2])
                                            [Elab.step] [0.014509] simp [hw1, hw2]
                                              [Elab.step] [0.014506] simp [hw1, hw2]
                                                [Elab.step] [0.014499] simp [hw1, hw2]
                          [Elab.step] [0.010284] exact
                                ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi
                    [Elab.step] [0.026518] ·
                          rw [← Finset.mem_coe, Finset.coe_union] at hi
                          have h₁ : Set.indicator (↑s1) w1 i = 0 :=
                            by
                            simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                            intro h
                            by_contra
                            exact (mt (@Set.mem_union_left _ i ↑s1 ↑s2) hi) h
                          have h₂ : Set.indicator (↑s2) w2 i = 0 :=
                            by
                            simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                            intro h
                            by_contra
                            exact (mt (@Set.mem_union_right _ i ↑s2 ↑s1) hi) h
                          simp [h₁, h₂]
                      [Elab.step] [0.026312] 
                            rw [← Finset.mem_coe, Finset.coe_union] at hi
                            have h₁ : Set.indicator (↑s1) w1 i = 0 :=
                              by
                              simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                              intro h
                              by_contra
                              exact (mt (@Set.mem_union_left _ i ↑s1 ↑s2) hi) h
                            have h₂ : Set.indicator (↑s2) w2 i = 0 :=
                              by
                              simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                              intro h
                              by_contra
                              exact (mt (@Set.mem_union_right _ i ↑s2 ↑s1) hi) h
                            simp [h₁, h₂]
                        [Elab.step] [0.026305] 
                              rw [← Finset.mem_coe, Finset.coe_union] at hi
                              have h₁ : Set.indicator (↑s1) w1 i = 0 :=
                                by
                                simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                                intro h
                                by_contra
                                exact (mt (@Set.mem_union_left _ i ↑s1 ↑s2) hi) h
                              have h₂ : Set.indicator (↑s2) w2 i = 0 :=
                                by
                                simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                                intro h
                                by_contra
                                exact (mt (@Set.mem_union_right _ i ↑s2 ↑s1) hi) h
                              simp [h₁, h₂]
                          [Elab.step] [0.010278] have h₁ : Set.indicator (↑s1) w1 i = 0 :=
                                by
                                simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                                intro h
                                by_contra
                                exact (mt (@Set.mem_union_left _ i ↑s1 ↑s2) hi) h
                            [Elab.step] [0.010254] focus
                                  refine
                                    no_implicit_lambda%
                                      (have h₁ : Set.indicator (↑s1) w1 i = 0 := ?body✝;
                                      ?_)
                                  case body✝ =>
                                    with_annotate_state"by"
                                      ( simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                                        intro h
                                        by_contra
                                        exact (mt (@Set.mem_union_left _ i ↑s1 ↑s2) hi) h)
                              [Elab.step] [0.010250] 
                                    refine
                                      no_implicit_lambda%
                                        (have h₁ : Set.indicator (↑s1) w1 i = 0 := ?body✝;
                                        ?_)
                                    case body✝ =>
                                      with_annotate_state"by"
                                        ( simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                                          intro h
                                          by_contra
                                          exact (mt (@Set.mem_union_left _ i ↑s1 ↑s2) hi) h)
                                [Elab.step] [0.010246] 
                                      refine
                                        no_implicit_lambda%
                                          (have h₁ : Set.indicator (↑s1) w1 i = 0 := ?body✝;
                                          ?_)
                                      case body✝ =>
                                        with_annotate_state"by"
                                          ( simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                                            intro h
                                            by_contra
                                            exact (mt (@Set.mem_union_left _ i ↑s1 ↑s2) hi) h)
                          [Elab.step] [0.010365] have h₂ : Set.indicator (↑s2) w2 i = 0 :=
                                by
                                simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                                intro h
                                by_contra
                                exact (mt (@Set.mem_union_right _ i ↑s2 ↑s1) hi) h
                            [Elab.step] [0.010302] focus
                                  refine
                                    no_implicit_lambda%
                                      (have h₂ : Set.indicator (↑s2) w2 i = 0 := ?body✝;
                                      ?_)
                                  case body✝ =>
                                    with_annotate_state"by"
                                      ( simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                                        intro h
                                        by_contra
                                        exact (mt (@Set.mem_union_right _ i ↑s2 ↑s1) hi) h)
                              [Elab.step] [0.010297] 
                                    refine
                                      no_implicit_lambda%
                                        (have h₂ : Set.indicator (↑s2) w2 i = 0 := ?body✝;
                                        ?_)
                                    case body✝ =>
                                      with_annotate_state"by"
                                        ( simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                                          intro h
                                          by_contra
                                          exact (mt (@Set.mem_union_right _ i ↑s2 ↑s1) hi) h)
                                [Elab.step] [0.010293] 
                                      refine
                                        no_implicit_lambda%
                                          (have h₂ : Set.indicator (↑s2) w2 i = 0 := ?body✝;
                                          ?_)
                                      case body✝ =>
                                        with_annotate_state"by"
                                          ( simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
                                            intro h
                                            by_contra
                                            exact (mt (@Set.mem_union_right _ i ↑s2 ↑s1) hi) h)
              [Elab.step] [0.068628] ·
                    intro ha s w hw hs i0 hi0
                    let w1 : ι → k := Function.update (Function.const ι 0) i0 1
                    have hw1 : ∑ i ∈ s, w1 i = 1 := by
                      rw [Finset.sum_update_of_mem hi0]
                      simp only [Finset.sum_const_zero, add_zero, const_apply]
                    have hw1s : s.affineCombination k p w1 = p i0 :=
                      s.affineCombination_of_eq_one_of_eq_zero w1 p hi0 (Function.update_self ..) fun _ _ hne =>
                        Function.update_of_ne hne ..
                    let w2 := w + w1
                    have hw2 : ∑ i ∈ s, w2 i = 1 := by
                      simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add]
                    have hw2s : s.affineCombination k p w2 = p i0 := by
                      simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd]
                    replace ha := ha s s w2 w1 hw2 hw1 (hw1s.symm ▸ hw2s)
                    have hws : w2 i0 - w1 i0 = 0 := by
                      rw [← Finset.mem_coe] at hi0
                      rw [← Set.indicator_of_mem hi0 w2, ← Set.indicator_of_mem hi0 w1, ha, sub_self]
                    simpa [w2] using hws
                [Elab.step] [0.068581] 
                      intro ha s w hw hs i0 hi0
                      let w1 : ι → k := Function.update (Function.const ι 0) i0 1
                      have hw1 : ∑ i ∈ s, w1 i = 1 := by
                        rw [Finset.sum_update_of_mem hi0]
                        simp only [Finset.sum_const_zero, add_zero, const_apply]
                      have hw1s : s.affineCombination k p w1 = p i0 :=
                        s.affineCombination_of_eq_one_of_eq_zero w1 p hi0 (Function.update_self ..) fun _ _ hne =>
                          Function.update_of_ne hne ..
                      let w2 := w + w1
                      have hw2 : ∑ i ∈ s, w2 i = 1 := by
                        simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add]
                      have hw2s : s.affineCombination k p w2 = p i0 := by
                        simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd]
                      replace ha := ha s s w2 w1 hw2 hw1 (hw1s.symm ▸ hw2s)
                      have hws : w2 i0 - w1 i0 = 0 := by
                        rw [← Finset.mem_coe] at hi0
                        rw [← Set.indicator_of_mem hi0 w2, ← Set.indicator_of_mem hi0 w1, ha, sub_self]
                      simpa [w2] using hws
                  [Elab.step] [0.068575] 
                        intro ha s w hw hs i0 hi0
                        let w1 : ι → k := Function.update (Function.const ι 0) i0 1
                        have hw1 : ∑ i ∈ s, w1 i = 1 :=
                          by
                          rw [Finset.sum_update_of_mem hi0]
                          simp only [Finset.sum_const_zero, add_zero, const_apply]
                        have hw1s : s.affineCombination k p w1 = p i0 :=
                          s.affineCombination_of_eq_one_of_eq_zero w1 p hi0 (Function.update_self ..) fun _ _ hne =>
                            Function.update_of_ne hne ..
                        let w2 := w + w1
                        have hw2 : ∑ i ∈ s, w2 i = 1 := by
                          simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add]
                        have hw2s : s.affineCombination k p w2 = p i0 := by
                          simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd]
                        replace ha := ha s s w2 w1 hw2 hw1 (hw1s.symm ▸ hw2s)
                        have hws : w2 i0 - w1 i0 = 0 := by
                          rw [← Finset.mem_coe] at hi0
                          rw [← Set.indicator_of_mem hi0 w2, ← Set.indicator_of_mem hi0 w1, ha, sub_self]
                        simpa [w2] using hws
                    [Elab.step] [0.014691] have hw2 : ∑ i ∈ s, w2 i = 1 := by
                          simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add]
                      [Elab.step] [0.014544] focus
                            refine
                              no_implicit_lambda%
                                (have hw2 : ∑ i ∈ s, w2 i = 1 := ?body✝;
                                ?_)
                            case body✝ =>
                              with_annotate_state"by"
                                (simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add])
                        [Elab.step] [0.014538] 
                              refine
                                no_implicit_lambda%
                                  (have hw2 : ∑ i ∈ s, w2 i = 1 := ?body✝;
                                  ?_)
                              case body✝ =>
                                with_annotate_state"by"
                                  (simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add])
                          [Elab.step] [0.014534] 
                                refine
                                  no_implicit_lambda%
                                    (have hw2 : ∑ i ∈ s, w2 i = 1 := ?body✝;
                                    ?_)
                                case body✝ =>
                                  with_annotate_state"by"
                                    (simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add])
                            [Elab.step] [0.012772] case body✝ =>
                                  with_annotate_state"by"
                                    (simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add])
                              [Elab.step] [0.012745] with_annotate_state"by"
                                      (simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add])
                                [Elab.step] [0.012742] with_annotate_state"by"
                                        (simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add])
                                  [Elab.step] [0.012738] with_annotate_state"by"
                                        (simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add])
                                    [Elab.step] [0.012734] (simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib,
                                            zero_add])
                                      [Elab.step] [0.012730] simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib,
                                              zero_add]
                                        [Elab.step] [0.012727] simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib,
                                                zero_add]
                                          [Elab.step] [0.012720] simp_all only [w2, Pi.add_apply,
                                                Finset.sum_add_distrib, zero_add]
                    [Elab.step] [0.017729] have hw2s : s.affineCombination k p w2 = p i0 := by
                          simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd]
                      [Elab.step] [0.017704] focus
                            refine
                              no_implicit_lambda%
                                (have hw2s : s.affineCombination k p w2 = p i0 := ?body✝;
                                ?_)
                            case body✝ =>
                              with_annotate_state"by"
                                (simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd])
                        [Elab.step] [0.017699] 
                              refine
                                no_implicit_lambda%
                                  (have hw2s : s.affineCombination k p w2 = p i0 := ?body✝;
                                  ?_)
                              case body✝ =>
                                with_annotate_state"by"
                                  (simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd])
                          [Elab.step] [0.017695] 
                                refine
                                  no_implicit_lambda%
                                    (have hw2s : s.affineCombination k p w2 = p i0 := ?body✝;
                                    ?_)
                                case body✝ =>
                                  with_annotate_state"by"
                                    (simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd])
                            [Elab.step] [0.014054] case body✝ =>
                                  with_annotate_state"by"
                                    (simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd])
                              [Elab.step] [0.013988] with_annotate_state"by"
                                      (simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd])
                                [Elab.step] [0.013985] with_annotate_state"by"
                                        (simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd])
                                  [Elab.step] [0.013982] with_annotate_state"by"
                                        (simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd])
                                    [Elab.step] [0.013979] (simp_all only [w2, ←
                                            Finset.weightedVSub_vadd_affineCombination, zero_vadd])
                                      [Elab.step] [0.013976] simp_all only [w2, ←
                                              Finset.weightedVSub_vadd_affineCombination, zero_vadd]
                                        [Elab.step] [0.013973] simp_all only [w2, ←
                                                Finset.weightedVSub_vadd_affineCombination, zero_vadd]
                                          [Elab.step] [0.013967] simp_all only [w2, ←
                                                Finset.weightedVSub_vadd_affineCombination, zero_vadd]
Build completed successfully.
```

### Trace profiling of `affineIndependent_iff_indicator_eq_of_affineCombination_eq` after PR 28271
```diff
diff --git a/Mathlib/LinearAlgebra/AffineSpace/Independent.lean b/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
index 3058d16cf1..64f9f68b47 100644
--- a/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Independent.lean
@@ -171,6 +171,7 @@ theorem linearIndependent_set_iff_affineIndependent_vadd_union_singleton {s : Se
     exact Set.diff_singleton_eq_self fun h => hs 0 h rfl
   rw [h]
 
+set_option trace.profiler true in
 /-- A family is affinely independent if and only if any affine
 combinations (with sum of weights 1) that evaluate to the same point
 have equal `Set.indicator`. -/
@@ -195,18 +196,7 @@ theorem affineIndependent_iff_indicator_eq_of_affineCombination_eq (p : ι → P
           Finset.affineCombination_indicator_subset w2 p s1.subset_union_right,
           ← @vsub_eq_zero_iff_eq V, Finset.affineCombination_vsub] at heq
         exact ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi
-      · rw [← Finset.mem_coe, Finset.coe_union] at hi
-        have h₁ : Set.indicator (↑s1) w1 i = 0 := by
-          simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
-          intro h
-          by_contra
-          exact (mt (@Set.mem_union_left _ i ↑s1 ↑s2) hi) h
-        have h₂ : Set.indicator (↑s2) w2 i = 0 := by
-          simp only [Set.indicator, Finset.mem_coe, ite_eq_right_iff]
-          intro h
-          by_contra
-          exact (mt (@Set.mem_union_right _ i ↑s2 ↑s1) hi) h
-        simp [h₁, h₂]
+      · simp_all
     · intro ha s w hw hs i0 hi0
       let w1 : ι → k := Function.update (Function.const ι 0) i0 1
       have hw1 : ∑ i ∈ s, w1 i = 1 := by
```
```
ℹ [1164/1164] Built Mathlib.LinearAlgebra.AffineSpace.Independent
info: Mathlib/LinearAlgebra/AffineSpace/Independent.lean:175:0: [Elab.command] [0.018359] /-- A family is affinely independent if and only if any affine
    combinations (with sum of weights 1) that evaluate to the same point
    have equal `Set.indicator`. -/
    theorem affineIndependent_iff_indicator_eq_of_affineCombination_eq (p : ι → P) :
        AffineIndependent k p ↔
          ∀ (s1 s2 : Finset ι) (w1 w2 : ι → k),
            ∑ i ∈ s1, w1 i = 1 →
              ∑ i ∈ s2, w2 i = 1 →
                s1.affineCombination k p w1 = s2.affineCombination k p w2 →
                  Set.indicator (↑s1) w1 = Set.indicator (↑s2) w2 :=
      by
      classical
      constructor
      · intro ha s1 s2 w1 w2 hw1 hw2 heq
        ext i
        by_cases hi : i ∈ s1 ∪ s2
        · rw [← sub_eq_zero]
          rw [← Finset.sum_indicator_subset w1 (s1.subset_union_left (s₂ := s2))] at hw1
          rw [← Finset.sum_indicator_subset w2 (s1.subset_union_right)] at hw2
          have hws : (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 := by simp [hw1, hw2]
          rw [Finset.affineCombination_indicator_subset w1 p (s1.subset_union_left (s₂ := s2)),
            Finset.affineCombination_indicator_subset w2 p s1.subset_union_right, ← @vsub_eq_zero_iff_eq V,
            Finset.affineCombination_vsub] at heq
          exact ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi
        · simp_all
      · intro ha s w hw hs i0 hi0
        let w1 : ι → k := Function.update (Function.const ι 0) i0 1
        have hw1 : ∑ i ∈ s, w1 i = 1 := by
          rw [Finset.sum_update_of_mem hi0]
          simp only [Finset.sum_const_zero, add_zero, const_apply]
        have hw1s : s.affineCombination k p w1 = p i0 :=
          s.affineCombination_of_eq_one_of_eq_zero w1 p hi0 (Function.update_self ..) fun _ _ hne =>
            Function.update_of_ne hne ..
        let w2 := w + w1
        have hw2 : ∑ i ∈ s, w2 i = 1 := by simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add]
        have hw2s : s.affineCombination k p w2 = p i0 := by
          simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd]
        replace ha := ha s s w2 w1 hw2 hw1 (hw1s.symm ▸ hw2s)
        have hws : w2 i0 - w1 i0 = 0 := by
          rw [← Finset.mem_coe] at hi0
          rw [← Set.indicator_of_mem hi0 w2, ← Set.indicator_of_mem hi0 w1, ha, sub_self]
        simpa [w2] using hws
  [Elab.definition.header] [0.014185] affineIndependent_iff_indicator_eq_of_affineCombination_eq
    [Elab.step] [0.014114] expected type: Prop, term
        AffineIndependent k p ↔
          ∀ (s1 s2 : Finset ι) (w1 w2 : ι → k),
            ∑ i ∈ s1, w1 i = 1 →
              ∑ i ∈ s2, w2 i = 1 →
                s1.affineCombination k p w1 = s2.affineCombination k p w2 →
                  Set.indicator (↑s1) w1 = Set.indicator (↑s2) w2
      [Elab.step] [0.014109] expected type: Prop, term
          Iff✝ (AffineIndependent k p)
            (∀ (s1 s2 : Finset ι) (w1 w2 : ι → k),
              ∑ i ∈ s1, w1 i = 1 →
                ∑ i ∈ s2, w2 i = 1 →
                  s1.affineCombination k p w1 = s2.affineCombination k p w2 →
                    Set.indicator (↑s1) w1 = Set.indicator (↑s2) w2)
        [Elab.step] [0.013355] expected type: Prop, term
            ∀ (s1 s2 : Finset ι) (w1 w2 : ι → k),
              ∑ i ∈ s1, w1 i = 1 →
                ∑ i ∈ s2, w2 i = 1 →
                  s1.affineCombination k p w1 = s2.affineCombination k p w2 →
                    Set.indicator (↑s1) w1 = Set.indicator (↑s2) w2
          [Elab.step] [0.013210] expected type: Sort ?u.14914, term
              ∑ i ∈ s1, w1 i = 1 →
                ∑ i ∈ s2, w2 i = 1 →
                  s1.affineCombination k p w1 = s2.affineCombination k p w2 →
                    Set.indicator (↑s1) w1 = Set.indicator (↑s2) w2
            [Elab.step] [0.010454] expected type: Sort ?u.15054, term
                ∑ i ∈ s2, w2 i = 1 →
                  s1.affineCombination k p w1 = s2.affineCombination k p w2 →
                    Set.indicator (↑s1) w1 = Set.indicator (↑s2) w2
info: Mathlib/LinearAlgebra/AffineSpace/Independent.lean:175:0: [Elab.async] [0.134788] elaborating proof of affineIndependent_iff_indicator_eq_of_affineCombination_eq
  [Elab.definition.value] [0.131747] affineIndependent_iff_indicator_eq_of_affineCombination_eq
    [Elab.step] [0.128786] classical
          constructor
          · intro ha s1 s2 w1 w2 hw1 hw2 heq
            ext i
            by_cases hi : i ∈ s1 ∪ s2
            · rw [← sub_eq_zero]
              rw [← Finset.sum_indicator_subset w1 (s1.subset_union_left (s₂ := s2))] at hw1
              rw [← Finset.sum_indicator_subset w2 (s1.subset_union_right)] at hw2
              have hws : (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 := by simp [hw1, hw2]
              rw [Finset.affineCombination_indicator_subset w1 p (s1.subset_union_left (s₂ := s2)),
                Finset.affineCombination_indicator_subset w2 p s1.subset_union_right, ← @vsub_eq_zero_iff_eq V,
                Finset.affineCombination_vsub] at heq
              exact ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi
            · simp_all
          · intro ha s w hw hs i0 hi0
            let w1 : ι → k := Function.update (Function.const ι 0) i0 1
            have hw1 : ∑ i ∈ s, w1 i = 1 := by
              rw [Finset.sum_update_of_mem hi0]
              simp only [Finset.sum_const_zero, add_zero, const_apply]
            have hw1s : s.affineCombination k p w1 = p i0 :=
              s.affineCombination_of_eq_one_of_eq_zero w1 p hi0 (Function.update_self ..) fun _ _ hne =>
                Function.update_of_ne hne ..
            let w2 := w + w1
            have hw2 : ∑ i ∈ s, w2 i = 1 := by simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add]
            have hw2s : s.affineCombination k p w2 = p i0 := by
              simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd]
            replace ha := ha s s w2 w1 hw2 hw1 (hw1s.symm ▸ hw2s)
            have hws : w2 i0 - w1 i0 = 0 := by
              rw [← Finset.mem_coe] at hi0
              rw [← Set.indicator_of_mem hi0 w2, ← Set.indicator_of_mem hi0 w1, ha, sub_self]
            simpa [w2] using hws
      [Elab.step] [0.128780] classical
            constructor
            · intro ha s1 s2 w1 w2 hw1 hw2 heq
              ext i
              by_cases hi : i ∈ s1 ∪ s2
              · rw [← sub_eq_zero]
                rw [← Finset.sum_indicator_subset w1 (s1.subset_union_left (s₂ := s2))] at hw1
                rw [← Finset.sum_indicator_subset w2 (s1.subset_union_right)] at hw2
                have hws : (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 := by
                  simp [hw1, hw2]
                rw [Finset.affineCombination_indicator_subset w1 p (s1.subset_union_left (s₂ := s2)),
                  Finset.affineCombination_indicator_subset w2 p s1.subset_union_right, ← @vsub_eq_zero_iff_eq V,
                  Finset.affineCombination_vsub] at heq
                exact ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi
              · simp_all
            · intro ha s w hw hs i0 hi0
              let w1 : ι → k := Function.update (Function.const ι 0) i0 1
              have hw1 : ∑ i ∈ s, w1 i = 1 := by
                rw [Finset.sum_update_of_mem hi0]
                simp only [Finset.sum_const_zero, add_zero, const_apply]
              have hw1s : s.affineCombination k p w1 = p i0 :=
                s.affineCombination_of_eq_one_of_eq_zero w1 p hi0 (Function.update_self ..) fun _ _ hne =>
                  Function.update_of_ne hne ..
              let w2 := w + w1
              have hw2 : ∑ i ∈ s, w2 i = 1 := by simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add]
              have hw2s : s.affineCombination k p w2 = p i0 := by
                simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd]
              replace ha := ha s s w2 w1 hw2 hw1 (hw1s.symm ▸ hw2s)
              have hws : w2 i0 - w1 i0 = 0 := by
                rw [← Finset.mem_coe] at hi0
                rw [← Set.indicator_of_mem hi0 w2, ← Set.indicator_of_mem hi0 w1, ha, sub_self]
              simpa [w2] using hws
        [Elab.step] [0.128774] classical
            constructor
            · intro ha s1 s2 w1 w2 hw1 hw2 heq
              ext i
              by_cases hi : i ∈ s1 ∪ s2
              · rw [← sub_eq_zero]
                rw [← Finset.sum_indicator_subset w1 (s1.subset_union_left (s₂ := s2))] at hw1
                rw [← Finset.sum_indicator_subset w2 (s1.subset_union_right)] at hw2
                have hws : (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 := by
                  simp [hw1, hw2]
                rw [Finset.affineCombination_indicator_subset w1 p (s1.subset_union_left (s₂ := s2)),
                  Finset.affineCombination_indicator_subset w2 p s1.subset_union_right, ← @vsub_eq_zero_iff_eq V,
                  Finset.affineCombination_vsub] at heq
                exact ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi
              · simp_all
            · intro ha s w hw hs i0 hi0
              let w1 : ι → k := Function.update (Function.const ι 0) i0 1
              have hw1 : ∑ i ∈ s, w1 i = 1 := by
                rw [Finset.sum_update_of_mem hi0]
                simp only [Finset.sum_const_zero, add_zero, const_apply]
              have hw1s : s.affineCombination k p w1 = p i0 :=
                s.affineCombination_of_eq_one_of_eq_zero w1 p hi0 (Function.update_self ..) fun _ _ hne =>
                  Function.update_of_ne hne ..
              let w2 := w + w1
              have hw2 : ∑ i ∈ s, w2 i = 1 := by simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add]
              have hw2s : s.affineCombination k p w2 = p i0 := by
                simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd]
              replace ha := ha s s w2 w1 hw2 hw1 (hw1s.symm ▸ hw2s)
              have hws : w2 i0 - w1 i0 = 0 := by
                rw [← Finset.mem_coe] at hi0
                rw [← Set.indicator_of_mem hi0 w2, ← Set.indicator_of_mem hi0 w1, ha, sub_self]
              simpa [w2] using hws
          [Elab.step] [0.128544] 
                constructor
                · intro ha s1 s2 w1 w2 hw1 hw2 heq
                  ext i
                  by_cases hi : i ∈ s1 ∪ s2
                  · rw [← sub_eq_zero]
                    rw [← Finset.sum_indicator_subset w1 (s1.subset_union_left (s₂ := s2))] at hw1
                    rw [← Finset.sum_indicator_subset w2 (s1.subset_union_right)] at hw2
                    have hws : (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 := by
                      simp [hw1, hw2]
                    rw [Finset.affineCombination_indicator_subset w1 p (s1.subset_union_left (s₂ := s2)),
                      Finset.affineCombination_indicator_subset w2 p s1.subset_union_right, ← @vsub_eq_zero_iff_eq V,
                      Finset.affineCombination_vsub] at heq
                    exact ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi
                  · simp_all
                · intro ha s w hw hs i0 hi0
                  let w1 : ι → k := Function.update (Function.const ι 0) i0 1
                  have hw1 : ∑ i ∈ s, w1 i = 1 := by
                    rw [Finset.sum_update_of_mem hi0]
                    simp only [Finset.sum_const_zero, add_zero, const_apply]
                  have hw1s : s.affineCombination k p w1 = p i0 :=
                    s.affineCombination_of_eq_one_of_eq_zero w1 p hi0 (Function.update_self ..) fun _ _ hne =>
                      Function.update_of_ne hne ..
                  let w2 := w + w1
                  have hw2 : ∑ i ∈ s, w2 i = 1 := by simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add]
                  have hw2s : s.affineCombination k p w2 = p i0 := by
                    simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd]
                  replace ha := ha s s w2 w1 hw2 hw1 (hw1s.symm ▸ hw2s)
                  have hws : w2 i0 - w1 i0 = 0 := by
                    rw [← Finset.mem_coe] at hi0
                    rw [← Set.indicator_of_mem hi0 w2, ← Set.indicator_of_mem hi0 w1, ha, sub_self]
                  simpa [w2] using hws
            [Elab.step] [0.128537] 
                  constructor
                  · intro ha s1 s2 w1 w2 hw1 hw2 heq
                    ext i
                    by_cases hi : i ∈ s1 ∪ s2
                    · rw [← sub_eq_zero]
                      rw [← Finset.sum_indicator_subset w1 (s1.subset_union_left (s₂ := s2))] at hw1
                      rw [← Finset.sum_indicator_subset w2 (s1.subset_union_right)] at hw2
                      have hws : (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 := by
                        simp [hw1, hw2]
                      rw [Finset.affineCombination_indicator_subset w1 p (s1.subset_union_left (s₂ := s2)),
                        Finset.affineCombination_indicator_subset w2 p s1.subset_union_right, ← @vsub_eq_zero_iff_eq V,
                        Finset.affineCombination_vsub] at heq
                      exact ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi
                    · simp_all
                  · intro ha s w hw hs i0 hi0
                    let w1 : ι → k := Function.update (Function.const ι 0) i0 1
                    have hw1 : ∑ i ∈ s, w1 i = 1 := by
                      rw [Finset.sum_update_of_mem hi0]
                      simp only [Finset.sum_const_zero, add_zero, const_apply]
                    have hw1s : s.affineCombination k p w1 = p i0 :=
                      s.affineCombination_of_eq_one_of_eq_zero w1 p hi0 (Function.update_self ..) fun _ _ hne =>
                        Function.update_of_ne hne ..
                    let w2 := w + w1
                    have hw2 : ∑ i ∈ s, w2 i = 1 := by
                      simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add]
                    have hw2s : s.affineCombination k p w2 = p i0 := by
                      simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd]
                    replace ha := ha s s w2 w1 hw2 hw1 (hw1s.symm ▸ hw2s)
                    have hws : w2 i0 - w1 i0 = 0 := by
                      rw [← Finset.mem_coe] at hi0
                      rw [← Set.indicator_of_mem hi0 w2, ← Set.indicator_of_mem hi0 w1, ha, sub_self]
                    simpa [w2] using hws
              [Elab.step] [0.060569] ·
                    intro ha s1 s2 w1 w2 hw1 hw2 heq
                    ext i
                    by_cases hi : i ∈ s1 ∪ s2
                    · rw [← sub_eq_zero]
                      rw [← Finset.sum_indicator_subset w1 (s1.subset_union_left (s₂ := s2))] at hw1
                      rw [← Finset.sum_indicator_subset w2 (s1.subset_union_right)] at hw2
                      have hws : (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 := by
                        simp [hw1, hw2]
                      rw [Finset.affineCombination_indicator_subset w1 p (s1.subset_union_left (s₂ := s2)),
                        Finset.affineCombination_indicator_subset w2 p s1.subset_union_right, ← @vsub_eq_zero_iff_eq V,
                        Finset.affineCombination_vsub] at heq
                      exact ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi
                    · simp_all
                [Elab.step] [0.060557] 
                      intro ha s1 s2 w1 w2 hw1 hw2 heq
                      ext i
                      by_cases hi : i ∈ s1 ∪ s2
                      · rw [← sub_eq_zero]
                        rw [← Finset.sum_indicator_subset w1 (s1.subset_union_left (s₂ := s2))] at hw1
                        rw [← Finset.sum_indicator_subset w2 (s1.subset_union_right)] at hw2
                        have hws : (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 := by
                          simp [hw1, hw2]
                        rw [Finset.affineCombination_indicator_subset w1 p (s1.subset_union_left (s₂ := s2)),
                          Finset.affineCombination_indicator_subset w2 p s1.subset_union_right, ←
                          @vsub_eq_zero_iff_eq V, Finset.affineCombination_vsub] at heq
                        exact ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi
                      · simp_all
                  [Elab.step] [0.060553] 
                        intro ha s1 s2 w1 w2 hw1 hw2 heq
                        ext i
                        by_cases hi : i ∈ s1 ∪ s2
                        · rw [← sub_eq_zero]
                          rw [← Finset.sum_indicator_subset w1 (s1.subset_union_left (s₂ := s2))] at hw1
                          rw [← Finset.sum_indicator_subset w2 (s1.subset_union_right)] at hw2
                          have hws : (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 := by
                            simp [hw1, hw2]
                          rw [Finset.affineCombination_indicator_subset w1 p (s1.subset_union_left (s₂ := s2)),
                            Finset.affineCombination_indicator_subset w2 p s1.subset_union_right, ←
                            @vsub_eq_zero_iff_eq V, Finset.affineCombination_vsub] at heq
                          exact ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi
                        · simp_all
                    [Elab.step] [0.047014] ·
                          rw [← sub_eq_zero]
                          rw [← Finset.sum_indicator_subset w1 (s1.subset_union_left (s₂ := s2))] at hw1
                          rw [← Finset.sum_indicator_subset w2 (s1.subset_union_right)] at hw2
                          have hws : (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 := by
                            simp [hw1, hw2]
                          rw [Finset.affineCombination_indicator_subset w1 p (s1.subset_union_left (s₂ := s2)),
                            Finset.affineCombination_indicator_subset w2 p s1.subset_union_right, ←
                            @vsub_eq_zero_iff_eq V, Finset.affineCombination_vsub] at heq
                          exact ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi
                      [Elab.step] [0.047005] 
                            rw [← sub_eq_zero]
                            rw [← Finset.sum_indicator_subset w1 (s1.subset_union_left (s₂ := s2))] at hw1
                            rw [← Finset.sum_indicator_subset w2 (s1.subset_union_right)] at hw2
                            have hws : (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 := by
                              simp [hw1, hw2]
                            rw [Finset.affineCombination_indicator_subset w1 p (s1.subset_union_left (s₂ := s2)),
                              Finset.affineCombination_indicator_subset w2 p s1.subset_union_right, ←
                              @vsub_eq_zero_iff_eq V, Finset.affineCombination_vsub] at heq
                            exact ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi
                        [Elab.step] [0.047001] 
                              rw [← sub_eq_zero]
                              rw [← Finset.sum_indicator_subset w1 (s1.subset_union_left (s₂ := s2))] at hw1
                              rw [← Finset.sum_indicator_subset w2 (s1.subset_union_right)] at hw2
                              have hws : (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 := by
                                simp [hw1, hw2]
                              rw [Finset.affineCombination_indicator_subset w1 p (s1.subset_union_left (s₂ := s2)),
                                Finset.affineCombination_indicator_subset w2 p s1.subset_union_right, ←
                                @vsub_eq_zero_iff_eq V, Finset.affineCombination_vsub] at heq
                              exact ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi
                          [Elab.step] [0.023015] have hws :
                                (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 := by
                                simp [hw1, hw2]
                            [Elab.step] [0.022978] focus
                                  refine
                                    no_implicit_lambda%
                                      (have hws :
                                        (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 :=
                                        ?body✝;
                                      ?_)
                                  case body✝ => with_annotate_state"by" (simp [hw1, hw2])
                              [Elab.step] [0.022974] 
                                    refine
                                      no_implicit_lambda%
                                        (have hws :
                                          (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 :=
                                          ?body✝;
                                        ?_)
                                    case body✝ => with_annotate_state"by" (simp [hw1, hw2])
                                [Elab.step] [0.022971] 
                                      refine
                                        no_implicit_lambda%
                                          (have hws :
                                            (∑ i ∈ s1 ∪ s2, (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) i) = 0 :=
                                            ?body✝;
                                          ?_)
                                      case body✝ => with_annotate_state"by" (simp [hw1, hw2])
                                  [Elab.step] [0.014786] case body✝ => with_annotate_state"by" (simp [hw1, hw2])
                                    [Elab.step] [0.014731] with_annotate_state"by" (simp [hw1, hw2])
                                      [Elab.step] [0.014728] with_annotate_state"by" (simp [hw1, hw2])
                                        [Elab.step] [0.014725] with_annotate_state"by" (simp [hw1, hw2])
                                          [Elab.step] [0.014721] (simp [hw1, hw2])
                                            [Elab.step] [0.014718] simp [hw1, hw2]
                                              [Elab.step] [0.014715] simp [hw1, hw2]
                                                [Elab.step] [0.014709] simp [hw1, hw2]
                          [Elab.step] [0.010380] exact
                                ha (s1 ∪ s2) (Set.indicator (↑s1) w1 - Set.indicator (↑s2) w2) hws heq i hi
                    [Elab.step] [0.010297] · simp_all
                      [Elab.step] [0.010038] simp_all
                        [Elab.step] [0.010035] simp_all
                          [Elab.step] [0.010030] simp_all
              [Elab.step] [0.067859] ·
                    intro ha s w hw hs i0 hi0
                    let w1 : ι → k := Function.update (Function.const ι 0) i0 1
                    have hw1 : ∑ i ∈ s, w1 i = 1 := by
                      rw [Finset.sum_update_of_mem hi0]
                      simp only [Finset.sum_const_zero, add_zero, const_apply]
                    have hw1s : s.affineCombination k p w1 = p i0 :=
                      s.affineCombination_of_eq_one_of_eq_zero w1 p hi0 (Function.update_self ..) fun _ _ hne =>
                        Function.update_of_ne hne ..
                    let w2 := w + w1
                    have hw2 : ∑ i ∈ s, w2 i = 1 := by
                      simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add]
                    have hw2s : s.affineCombination k p w2 = p i0 := by
                      simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd]
                    replace ha := ha s s w2 w1 hw2 hw1 (hw1s.symm ▸ hw2s)
                    have hws : w2 i0 - w1 i0 = 0 := by
                      rw [← Finset.mem_coe] at hi0
                      rw [← Set.indicator_of_mem hi0 w2, ← Set.indicator_of_mem hi0 w1, ha, sub_self]
                    simpa [w2] using hws
                [Elab.step] [0.067812] 
                      intro ha s w hw hs i0 hi0
                      let w1 : ι → k := Function.update (Function.const ι 0) i0 1
                      have hw1 : ∑ i ∈ s, w1 i = 1 := by
                        rw [Finset.sum_update_of_mem hi0]
                        simp only [Finset.sum_const_zero, add_zero, const_apply]
                      have hw1s : s.affineCombination k p w1 = p i0 :=
                        s.affineCombination_of_eq_one_of_eq_zero w1 p hi0 (Function.update_self ..) fun _ _ hne =>
                          Function.update_of_ne hne ..
                      let w2 := w + w1
                      have hw2 : ∑ i ∈ s, w2 i = 1 := by
                        simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add]
                      have hw2s : s.affineCombination k p w2 = p i0 := by
                        simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd]
                      replace ha := ha s s w2 w1 hw2 hw1 (hw1s.symm ▸ hw2s)
                      have hws : w2 i0 - w1 i0 = 0 := by
                        rw [← Finset.mem_coe] at hi0
                        rw [← Set.indicator_of_mem hi0 w2, ← Set.indicator_of_mem hi0 w1, ha, sub_self]
                      simpa [w2] using hws
                  [Elab.step] [0.067806] 
                        intro ha s w hw hs i0 hi0
                        let w1 : ι → k := Function.update (Function.const ι 0) i0 1
                        have hw1 : ∑ i ∈ s, w1 i = 1 :=
                          by
                          rw [Finset.sum_update_of_mem hi0]
                          simp only [Finset.sum_const_zero, add_zero, const_apply]
                        have hw1s : s.affineCombination k p w1 = p i0 :=
                          s.affineCombination_of_eq_one_of_eq_zero w1 p hi0 (Function.update_self ..) fun _ _ hne =>
                            Function.update_of_ne hne ..
                        let w2 := w + w1
                        have hw2 : ∑ i ∈ s, w2 i = 1 := by
                          simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add]
                        have hw2s : s.affineCombination k p w2 = p i0 := by
                          simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd]
                        replace ha := ha s s w2 w1 hw2 hw1 (hw1s.symm ▸ hw2s)
                        have hws : w2 i0 - w1 i0 = 0 := by
                          rw [← Finset.mem_coe] at hi0
                          rw [← Set.indicator_of_mem hi0 w2, ← Set.indicator_of_mem hi0 w1, ha, sub_self]
                        simpa [w2] using hws
                    [Elab.step] [0.014941] have hw2 : ∑ i ∈ s, w2 i = 1 := by
                          simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add]
                      [Elab.step] [0.014792] focus
                            refine
                              no_implicit_lambda%
                                (have hw2 : ∑ i ∈ s, w2 i = 1 := ?body✝;
                                ?_)
                            case body✝ =>
                              with_annotate_state"by"
                                (simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add])
                        [Elab.step] [0.014788] 
                              refine
                                no_implicit_lambda%
                                  (have hw2 : ∑ i ∈ s, w2 i = 1 := ?body✝;
                                  ?_)
                              case body✝ =>
                                with_annotate_state"by"
                                  (simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add])
                          [Elab.step] [0.014785] 
                                refine
                                  no_implicit_lambda%
                                    (have hw2 : ∑ i ∈ s, w2 i = 1 := ?body✝;
                                    ?_)
                                case body✝ =>
                                  with_annotate_state"by"
                                    (simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add])
                            [Elab.step] [0.012975] case body✝ =>
                                  with_annotate_state"by"
                                    (simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add])
                              [Elab.step] [0.012948] with_annotate_state"by"
                                      (simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add])
                                [Elab.step] [0.012944] with_annotate_state"by"
                                        (simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add])
                                  [Elab.step] [0.012940] with_annotate_state"by"
                                        (simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib, zero_add])
                                    [Elab.step] [0.012936] (simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib,
                                            zero_add])
                                      [Elab.step] [0.012934] simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib,
                                              zero_add]
                                        [Elab.step] [0.012930] simp_all only [w2, Pi.add_apply, Finset.sum_add_distrib,
                                                zero_add]
                                          [Elab.step] [0.012924] simp_all only [w2, Pi.add_apply,
                                                Finset.sum_add_distrib, zero_add]
                    [Elab.step] [0.019018] have hw2s : s.affineCombination k p w2 = p i0 := by
                          simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd]
                      [Elab.step] [0.018991] focus
                            refine
                              no_implicit_lambda%
                                (have hw2s : s.affineCombination k p w2 = p i0 := ?body✝;
                                ?_)
                            case body✝ =>
                              with_annotate_state"by"
                                (simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd])
                        [Elab.step] [0.018986] 
                              refine
                                no_implicit_lambda%
                                  (have hw2s : s.affineCombination k p w2 = p i0 := ?body✝;
                                  ?_)
                              case body✝ =>
                                with_annotate_state"by"
                                  (simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd])
                          [Elab.step] [0.018982] 
                                refine
                                  no_implicit_lambda%
                                    (have hw2s : s.affineCombination k p w2 = p i0 := ?body✝;
                                    ?_)
                                case body✝ =>
                                  with_annotate_state"by"
                                    (simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd])
                            [Elab.step] [0.015284] case body✝ =>
                                  with_annotate_state"by"
                                    (simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd])
                              [Elab.step] [0.015215] with_annotate_state"by"
                                      (simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd])
                                [Elab.step] [0.015212] with_annotate_state"by"
                                        (simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd])
                                  [Elab.step] [0.015208] with_annotate_state"by"
                                        (simp_all only [w2, ← Finset.weightedVSub_vadd_affineCombination, zero_vadd])
                                    [Elab.step] [0.015205] (simp_all only [w2, ←
                                            Finset.weightedVSub_vadd_affineCombination, zero_vadd])
                                      [Elab.step] [0.015202] simp_all only [w2, ←
                                              Finset.weightedVSub_vadd_affineCombination, zero_vadd]
                                        [Elab.step] [0.015198] simp_all only [w2, ←
                                                Finset.weightedVSub_vadd_affineCombination, zero_vadd]
                                          [Elab.step] [0.015193] simp_all only [w2, ←
                                                Finset.weightedVSub_vadd_affineCombination, zero_vadd]
Build completed successfully.
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
