### PR TITLE
[Merged by Bors] - fix: revert several flaky grind golfs

### DIFF
--- a/Mathlib/Algebra/ContinuedFractions/Computation/CorrectnessTerminating.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Computation/CorrectnessTerminating.lean
@@ -147,7 +147,11 @@ theorem compExactValue_correctness_of_stream_eq_some :
       -- use the IH to show that the following equality suffices
       suffices
         compExactValue ppconts pconts ifp_n.fr = compExactValue pconts conts ifp_succ_n.fr by
-        grind
+        #adaptation_note /-- 2025-08-10 replace the following with grind after
+        https://github.com/leanprover/lean4/issues/9825 is fixed -/
+        have : v = compExactValue ppconts pconts ifp_n.fr := IH nth_stream_eq
+        conv_lhs => rw [this]
+        assumption
       -- get the correspondence between ifp_n and ifp_succ_n
       obtain ⟨ifp_n', nth_stream_eq', ifp_n_fract_ne_zero, ⟨refl⟩⟩ :
         ∃ ifp_n, IntFractPair.stream v n = some ifp_n ∧
@@ -192,7 +196,12 @@ theorem compExactValue_correctness_of_stream_eq_some :
       field_simp [compExactValue, contsAux_recurrence s_nth_eq ppconts_eq pconts_eq,
         nextConts, nextNum, nextDen]
       have hfr : (IntFractPair.of (1 / ifp_n.fr)).fr = f := rfl
-      grind
+      #adaptation_note /-- 2025-08-10 replace the following with grind after
+        https://github.com/leanprover/lean4/issues/9825 is fixed -/
+      rw [one_div, if_neg _, ← one_div, hfr]
+      · field_simp [pA, pB, ppA, ppB, pconts, ppconts, hA, hB]
+        ac_rfl
+      · rwa [inv_eq_one_div, hfr]
 
 open GenContFract (of_terminatedAt_n_iff_succ_nth_intFractPair_stream_eq_none)
 

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -292,6 +292,28 @@ lemma apply_eq_or (i j : ι) :
   replace h₂ : P.pairing i j' = 0 := by rw [← P.algebraMap_pairingIn ℤ, h₂, map_zero]
   exact (B.apply_root_root_zero_iff i j').mpr h₂
 
+#adaptation_note /-- 2025-08-10 delete this after
+  https://github.com/leanprover/lean4/issues/9825 is fixed -/
+theorem exists_apply_eq_or_aux {x y z : R}
+    (hij : x = 2 * y ∨ x = 3 * y ∨ y = 2 * x ∨ y = 3 * x)
+    (hik : x = 2 * z ∨ x = 3 * z ∨ z = 2 * x ∨ z = 3 * x)
+    (hjk : y = 2 * z ∨ y = 3 * z ∨ z = 2 * y ∨ z = 3 * y) :
+    x = 0 ∧ y = 0 ∧ z = 0 := by
+  /- The below proof (due to Mario Carneiro, Johan Commelin, Bhavik Mehta, Jingting Wang) should
+     not really be necessary: we should have a tactic to crush this. -/
+  suffices y = 0 ∨ z = 0 by apply this.elim <;> rintro rfl <;> simp_all
+  let S : Finset (ℕ × ℕ) := {(1, 2), (1, 3), (2, 1), (3, 1)}
+  obtain ⟨⟨ab, hab, hxy⟩, ⟨cd, hcd, hxz⟩, ⟨ef, hef, hyz⟩⟩ :
+    (∃ ab ∈ S, ab.1 * x = ab.2 * y) ∧
+    (∃ cd ∈ S, cd.1 * x = cd.2 * z) ∧
+    (∃ ef ∈ S, ef.1 * y = ef.2 * z) := by
+    simp_all only [Finset.mem_insert, Finset.mem_singleton, exists_eq_or_imp, Nat.cast_one, one_mul,
+      Nat.cast_ofNat, eq_comm, exists_eq_left, and_self, S]
+  have : (ab.1 * cd.2 * ef.1 : R) ≠ ab.2 * cd.1 * ef.2 := by norm_cast; clear! R; decide +revert
+  have : (ab.1 * cd.2 * ef.1 - ab.2 * cd.1 * ef.2) * (y * z) = 0 := by
+    linear_combination z * cd.1 * ef.2 * hxy - ab.1 * ef.1 * y * hxz + ab.1 * x * cd.1 * hyz
+  simp_all only [ne_eq, mul_eq_zero, sub_eq_zero, false_or, S]
+
 /-- A reduced irreducible finite crystallographic root system has roots of at most two different
 lengths. -/
 lemma exists_apply_eq_or [Nonempty ι] : ∃ i j, ∀ k,
@@ -308,7 +330,10 @@ lemma exists_apply_eq_or [Nonempty ι] : ∃ i j, ∀ k,
     have hij := (B.apply_eq_or i j).resolve_left hji_ne.symm
     have hik := (B.apply_eq_or i k).resolve_left hki_ne.symm
     have hjk := (B.apply_eq_or j k).resolve_left hkj_ne.symm
-    grind
+    #adaptation_note /-- 2025-08-10 replace the following with grind after
+  https://github.com/leanprover/lean4/issues/9825 is fixed -/
+    have := exists_apply_eq_or_aux hij hik hjk
+    aesop
 
 lemma apply_eq_or_of_apply_ne
     (h : B.form (α i) (α i) ≠ B.form (α j) (α j)) (k : ι) :

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/Lemmas.lean
@@ -6,7 +6,6 @@ Authors: Oliver Nash
 import Mathlib.LinearAlgebra.RootSystem.Finite.CanonicalBilinear
 import Mathlib.LinearAlgebra.RootSystem.Reduced
 import Mathlib.LinearAlgebra.RootSystem.Irreducible
-import Mathlib.Algebra.Ring.Torsion
 
 /-!
 # Structural lemmas about finite crystallographic root pairings
@@ -26,6 +25,9 @@ root pairings.
   a root.
 
 -/
+
+#adaptation_note /-- 2025-08-10 add back `import Mathlib.Algebra.Ring.Torsion` after
+  https://github.com/leanprover/lean4/issues/9825 is fixed -/
 
 noncomputable section
 

--- a/Mathlib/Topology/Instances/CantorSet.lean
+++ b/Mathlib/Topology/Instances/CantorSet.lean
@@ -84,7 +84,15 @@ theorem preCantorSet_antitone : Antitone preCantorSet := by
       simp only [Set.mem_image, Set.mem_Icc, forall_exists_index, and_imp] <;>
       intro y _ _ _ <;> constructor <;> linarith
   | succ m ih =>
-    grind [preCantorSet_succ, Set.image_union, Set.subset_def, Set.mem_union, Set.mem_image]
+    simp only [preCantorSet_succ, Set.union_subset_iff, Set.image_union]
+    #adaptation_note /-- 2025-08-10 replace the following with the commented-out grind proof after
+  https://github.com/leanprover/lean4/issues/9825 is fixed -/
+    constructor
+    · constructor <;> apply Set.subset_union_of_subset_left
+      exacts [Set.image_mono ih.left, Set.image_mono ih.right]
+    · constructor <;> apply Set.subset_union_of_subset_right
+      exacts [Set.image_mono ih.left, Set.image_mono ih.right]
+    -- grind [preCantorSet_succ, Set.image_union, Set.subset_def, Set.mem_union, Set.mem_image]
 
 lemma preCantorSet_subset_unitInterval {n : ℕ} : preCantorSet n ⊆ Set.Icc 0 1 := by
   rw [← preCantorSet_zero]

--- a/Mathlib/Topology/Instances/CantorSet.lean
+++ b/Mathlib/Topology/Instances/CantorSet.lean
@@ -84,9 +84,9 @@ theorem preCantorSet_antitone : Antitone preCantorSet := by
       simp only [Set.mem_image, Set.mem_Icc, forall_exists_index, and_imp] <;>
       intro y _ _ _ <;> constructor <;> linarith
   | succ m ih =>
-    simp only [preCantorSet_succ, Set.union_subset_iff, Set.image_union]
     #adaptation_note /-- 2025-08-10 replace the following with the commented-out grind proof after
   https://github.com/leanprover/lean4/issues/9825 is fixed -/
+    simp only [preCantorSet_succ, Set.union_subset_iff, Set.image_union]
     constructor
     · constructor <;> apply Set.subset_union_of_subset_left
       exacts [Set.image_mono ih.left, Set.image_mono ih.right]


### PR DESCRIPTION
These proofs (and probably others) are causing CI failures. We can revert this after https://github.com/leanprover/lean4/pull/9825 is fixed.

cf. [#mathlib4 > Failing CI @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Failing.20CI/near/533684295)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
