### PR TITLE
[Merged by Bors] - chore: postpone some Cardinal imports

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -4208,6 +4208,7 @@ import Mathlib.LinearAlgebra.QuadraticForm.Real
 import Mathlib.LinearAlgebra.QuadraticForm.TensorProduct
 import Mathlib.LinearAlgebra.QuadraticForm.TensorProduct.Isometries
 import Mathlib.LinearAlgebra.Quotient.Basic
+import Mathlib.LinearAlgebra.Quotient.Card
 import Mathlib.LinearAlgebra.Quotient.Defs
 import Mathlib.LinearAlgebra.Quotient.Pi
 import Mathlib.LinearAlgebra.Ray

--- a/Mathlib/Algebra/Exact.lean
+++ b/Mathlib/Algebra/Exact.lean
@@ -26,8 +26,6 @@ import Mathlib.LinearAlgebra.Quotient.Basic
 * add the multiplicative case (`Function.Exact` will become `Function.AddExact`?)
 -/
 
-
-
 variable {R M M' N N' P P' : Type*}
 
 namespace Function

--- a/Mathlib/Algebra/FiveLemma.lean
+++ b/Mathlib/Algebra/FiveLemma.lean
@@ -39,6 +39,8 @@ In theory, we could prove these in the multiplicative version and let `to_additi
 the additive variants. But `Function.Exact` currently has no multiplicative analogue (yet).
 -/
 
+assert_not_exists Cardinal
+
 namespace AddMonoidHom
 
 variable {M₁ M₂ M₃ M₄ M₅ N₁ N₂ N₃ N₄ N₅ : Type*}

--- a/Mathlib/Algebra/Module/Presentation/Basic.lean
+++ b/Mathlib/Algebra/Module/Presentation/Basic.lean
@@ -36,6 +36,8 @@ generators and relations.
 
 -/
 
+assert_not_exists Cardinal
+
 universe w' w'' w₀ w₁ v'' v' v u
 
 namespace Module

--- a/Mathlib/Algebra/Module/Presentation/Free.lean
+++ b/Mathlib/Algebra/Module/Presentation/Free.lean
@@ -17,6 +17,8 @@ see `Module.free_iff_exists_presentation`.
 
 -/
 
+assert_not_exists Cardinal
+
 universe w w₀ w₁ v u
 
 namespace Module

--- a/Mathlib/Analysis/Convex/Combination.lean
+++ b/Mathlib/Analysis/Convex/Combination.lean
@@ -23,6 +23,7 @@ mathematical arguments go: one doesn't change weights, but merely adds some. Thi
 lemmas unconditional on the sum of the weights being `1`.
 -/
 
+assert_not_exists Cardinal
 
 open Set Function Pointwise
 

--- a/Mathlib/LinearAlgebra/Isomorphisms.lean
+++ b/Mathlib/LinearAlgebra/Isomorphisms.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Kevin Buzzard, Yury Kudryashov
 -/
 import Mathlib.LinearAlgebra.Quotient.Basic
+import Mathlib.LinearAlgebra.Quotient.Card
 
 /-!
 # Isomorphism theorems for modules.

--- a/Mathlib/LinearAlgebra/Quotient/Basic.lean
+++ b/Mathlib/LinearAlgebra/Quotient/Basic.lean
@@ -8,7 +8,6 @@ import Mathlib.GroupTheory.QuotientGroup.Basic
 import Mathlib.LinearAlgebra.Pi
 import Mathlib.LinearAlgebra.Quotient.Defs
 import Mathlib.LinearAlgebra.Span.Basic
-import Mathlib.SetTheory.Cardinal.Finite
 
 /-!
 # Quotients by submodules
@@ -25,6 +24,8 @@ import Mathlib.SetTheory.Cardinal.Finite
   in `q`
 
 -/
+
+assert_not_exists Cardinal
 
 -- For most of this file we work over a noncommutative ring
 section Ring
@@ -103,11 +104,6 @@ variable (p)
 
 noncomputable instance Quotient.fintype [Fintype M] (S : Submodule R M) : Fintype (M ⧸ S) :=
   @_root_.Quotient.fintype _ _ _ fun _ _ => Classical.dec _
-
-theorem card_eq_card_quotient_mul_card (S : Submodule R M) :
-    Nat.card M = Nat.card S * Nat.card (M ⧸ S) := by
-  rw [mul_comm, ← Nat.card_prod]
-  exact Nat.card_congr AddSubgroup.addGroupEquivQuotientProdAddSubgroup
 
 section
 

--- a/Mathlib/LinearAlgebra/Quotient/Card.lean
+++ b/Mathlib/LinearAlgebra/Quotient/Card.lean
@@ -3,9 +3,9 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Kevin Buzzard, Yury Kudryashov
 -/
-import Mathlib.GroupTheory.QuotientGroup.Basic
 import Mathlib.LinearAlgebra.Quotient.Defs
 import Mathlib.SetTheory.Cardinal.Finite
+import Mathlib.GroupTheory.Coset.Basic
 
 /-! Results about the cardinality of a quotient module. -/
 

--- a/Mathlib/LinearAlgebra/Quotient/Card.lean
+++ b/Mathlib/LinearAlgebra/Quotient/Card.lean
@@ -1,0 +1,23 @@
+/-
+Copyright (c) 2017 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl, Mario Carneiro, Kevin Buzzard, Yury Kudryashov
+-/
+import Mathlib.GroupTheory.QuotientGroup.Basic
+import Mathlib.LinearAlgebra.Quotient.Defs
+import Mathlib.SetTheory.Cardinal.Finite
+
+/-! Results about the cardinality of a quotient module. -/
+
+namespace Submodule
+
+open LinearMap QuotientAddGroup
+
+variable {R M : Type*} [Ring R] [AddCommGroup M] [Module R M]
+
+theorem card_eq_card_quotient_mul_card (S : Submodule R M) :
+    Nat.card M = Nat.card S * Nat.card (M ⧸ S) := by
+  rw [mul_comm, ← Nat.card_prod]
+  exact Nat.card_congr AddSubgroup.addGroupEquivQuotientProdAddSubgroup
+
+end Submodule

--- a/Mathlib/LinearAlgebra/TensorProduct/Quotient.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Quotient.lean
@@ -34,6 +34,8 @@ Quotient, Tensor Product
 
 -/
 
+assert_not_exists Cardinal
+
 namespace TensorProduct
 
 variable {R M N : Type*} [CommRing R]

--- a/Mathlib/LinearAlgebra/TensorProduct/RightExactness.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/RightExactness.lean
@@ -84,6 +84,8 @@ to compute some kernels.
 
 -/
 
+assert_not_exists Cardinal
+
 section Modules
 
 open TensorProduct LinearMap

--- a/Mathlib/RingTheory/Jacobson/Radical.lean
+++ b/Mathlib/RingTheory/Jacobson/Radical.lean
@@ -24,6 +24,8 @@ it is in fact a two-sided ideal, and equals the intersection of all maximal righ
 * [F. Lorenz, *Algebra: Volume II: Fields with Structure, Algebras and Advanced Topics*][Lorenz2008]
 -/
 
+assert_not_exists Cardinal
+
 namespace Module
 
 open Submodule

--- a/Mathlib/RingTheory/Nilpotent/Lemmas.lean
+++ b/Mathlib/RingTheory/Nilpotent/Lemmas.lean
@@ -14,6 +14,8 @@ import Mathlib.RingTheory.Nilpotent.Defs
 This file contains results about nilpotent elements that involve ring theory.
 -/
 
+assert_not_exists Cardinal
+
 universe u v
 
 open Function Module Set


### PR DESCRIPTION
See [#mathlib4 > Warning that AlgebraicTopology can't import SetTheory @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Warning.20that.20AlgebraicTopology.20can't.20import.20SetTheory/near/533832533).

This postpones the theory of cardinals further through the basics of linear algebra.

