### PR TITLE
[Merged by Bors] - chore(Data/List/Chain): rename `chain'_cons` to `chain'_cons_cons`

### DIFF
--- a/Archive/Imo/Imo2024Q5.lean
+++ b/Archive/Imo/Imo2024Q5.lean
@@ -234,7 +234,7 @@ lemma find?_eq_eq_find?_le {l : List (Cell N)} {r : Fin (N + 2)} (hne : l ≠ []
       simp only [h, decide_false, Bool.false_eq_true, not_false_eq_true, List.find?_cons_of_neg, h']
       rcases tail with ⟨⟩ | ⟨htail, ttail⟩
       · simp
-      · simp only [List.chain'_cons] at ha
+      · simp only [List.chain'_cons_cons] at ha
         rcases ha with ⟨ha1, ha2⟩
         simp only [List.head_cons] at hf
         simp only [ne_eq, reduceCtorEq, not_false_eq_true, List.head_cons, ha2, true_implies] at hi

--- a/Mathlib/Data/List/Chain.lean
+++ b/Mathlib/Data/List/Chain.lean
@@ -270,7 +270,7 @@ theorem chain'_append :
   | [a], l => by simp [chain'_cons', and_comm]
   | a :: b :: l₁, l₂ => by
     rw [cons_append, cons_append, chain'_cons_cons, chain'_cons_cons, ← cons_append, chain'_append,
-    and_assoc]
+      and_assoc]
     simp
 
 theorem Chain'.append (h₁ : Chain' R l₁) (h₂ : Chain' R l₂)

--- a/Mathlib/Data/List/Chain.lean
+++ b/Mathlib/Data/List/Chain.lean
@@ -174,14 +174,16 @@ theorem chain'_singleton (a : α) : Chain' R [a] :=
   Chain.nil
 
 @[simp]
-theorem chain'_cons {x y l} : Chain' R (x :: y :: l) ↔ R x y ∧ Chain' R (y :: l) :=
+theorem chain'_cons_cons {x y l} : Chain' R (x :: y :: l) ↔ R x y ∧ Chain' R (y :: l) :=
   chain_cons
+
+@[deprecated (since := "2025-08-12")] alias chain'_cons := chain'_cons_cons
 
 theorem chain'_isInfix : ∀ l : List α, Chain' (fun x y => [x, y] <:+: l) l
   | [] => chain'_nil
   | [_] => chain'_singleton _
   | a :: b :: l =>
-    chain'_cons.2
+    chain'_cons_cons.2
       ⟨⟨[], l, by simp⟩, (chain'_isInfix (b :: l)).imp fun _ _ h => h.trans ⟨[a], [], by simp⟩⟩
 
 theorem chain'_split {a : α} :
@@ -192,7 +194,7 @@ theorem chain'_split {a : α} :
 @[simp]
 theorem chain'_append_cons_cons {b c : α} {l₁ l₂ : List α} :
     Chain' R (l₁ ++ b :: c :: l₂) ↔ Chain' R (l₁ ++ [b]) ∧ R b c ∧ Chain' R (c :: l₂) := by
-  rw [chain'_split, chain'_cons]
+  rw [chain'_split, chain'_cons_cons]
 
 theorem chain'_iff_forall_rel_of_append_cons_cons {l : List α} :
     Chain' R l ↔ ∀ ⦃a b l₁ l₂⦄, l = l₁ ++ a :: b :: l₂ → R a b := by
@@ -203,7 +205,7 @@ theorem chain'_iff_forall_rel_of_append_cons_cons {l : List α} :
     match tail with
     | nil => exact fun _ ↦ chain'_singleton head
     | cons head' tail =>
-      refine fun h ↦ chain'_cons.mpr ⟨h (nil_append _).symm, ih fun ⦃a b l₁ l₂⦄ eq => ?_⟩
+      refine fun h ↦ chain'_cons_cons.mpr ⟨h (nil_append _).symm, ih fun ⦃a b l₁ l₂⦄ eq => ?_⟩
       apply h
       rw [eq, cons_append]
 
@@ -231,13 +233,15 @@ protected theorem Chain'.sublist [IsTrans α R] (hl : l₂.Chain' R) (h : l₁ <
   rw [chain'_iff_pairwise] at hl ⊢
   exact hl.sublist h
 
-theorem Chain'.cons {x y l} (h₁ : R x y) (h₂ : Chain' R (y :: l)) : Chain' R (x :: y :: l) :=
-  chain'_cons.2 ⟨h₁, h₂⟩
+theorem Chain'.cons_cons {x y l} (h₁ : R x y) (h₂ : Chain' R (y :: l)) : Chain' R (x :: y :: l) :=
+  chain'_cons_cons.2 ⟨h₁, h₂⟩
+
+@[deprecated (since := "2025-08-12")] alias Chain'.cons := Chain'.cons_cons
 
 theorem Chain'.tail : ∀ {l}, Chain' R l → Chain' R l.tail
   | [], _ => trivial
   | [_], _ => trivial
-  | _ :: _ :: _, h => (chain'_cons.mp h).right
+  | _ :: _ :: _, h => (chain'_cons_cons.mp h).right
 
 theorem Chain'.rel_head {x y l} (h : Chain' R (x :: y :: l)) : R x y :=
   rel_of_chain_cons h
@@ -248,7 +252,7 @@ theorem Chain'.rel_head? {x l} (h : Chain' R (x :: l)) ⦃y⦄ (hy : y ∈ head?
 
 theorem Chain'.cons' {x} : ∀ {l : List α}, Chain' R l → (∀ y ∈ l.head?, R x y) → Chain' R (x :: l)
   | [], _, _ => chain'_singleton x
-  | _ :: _, hl, H => hl.cons <| H _ rfl
+  | _ :: _, hl, H => hl.cons_cons <| H _ rfl
 
 lemma Chain'.cons_of_ne_nil {x : α} {l : List α} (l_ne_nil : l ≠ [])
     (hl : Chain' R l) (h : R x (l.head l_ne_nil)) : Chain' R (x :: l) := by
@@ -265,7 +269,8 @@ theorem chain'_append :
   | [], l => by simp
   | [a], l => by simp [chain'_cons', and_comm]
   | a :: b :: l₁, l₂ => by
-    rw [cons_append, cons_append, chain'_cons, chain'_cons, ← cons_append, chain'_append, and_assoc]
+    rw [cons_append, cons_append, chain'_cons_cons, chain'_cons_cons, ← cons_append, chain'_append,
+    and_assoc]
     simp
 
 theorem Chain'.append (h₁ : Chain' R l₁) (h₂ : Chain' R l₂)
@@ -298,7 +303,7 @@ theorem Chain'.take (h : Chain' R l) (n : ℕ) : Chain' R (take n l) :=
   h.prefix (take_prefix _ _)
 
 theorem chain'_pair {x y} : Chain' R [x, y] ↔ R x y := by
-  simp only [chain'_singleton, chain'_cons, and_true]
+  simp only [chain'_singleton, chain'_cons_cons, and_true]
 
 theorem Chain'.imp_head {x y} (h : ∀ {z}, R x z → R y z) {l} (hl : Chain' R (x :: l)) :
     Chain' R (y :: l) :=
@@ -308,7 +313,7 @@ theorem chain'_reverse : ∀ {l}, Chain' R (reverse l) ↔ Chain' (flip R) l
   | [] => Iff.rfl
   | [a] => by simp only [chain'_singleton, reverse_singleton]
   | a :: b :: l => by
-    rw [chain'_cons, reverse_cons, reverse_cons, append_assoc, cons_append, nil_append,
+    rw [chain'_cons_cons, reverse_cons, reverse_cons, append_assoc, cons_append, nil_append,
       chain'_split, ← reverse_cons, @chain'_reverse (b :: l), and_comm, chain'_pair, flip]
 
 theorem chain'_iff_get {R} : ∀ {l : List α}, Chain' R l ↔
@@ -317,7 +322,7 @@ theorem chain'_iff_get {R} : ∀ {l : List α}, Chain' R l ↔
   | [] => iff_of_true (by simp) (fun _ h => by simp at h)
   | [a] => iff_of_true (by simp) (fun _ h => by simp at h)
   | a :: b :: t => by
-    rw [← and_forall_add_one, chain'_cons, chain'_iff_get]
+    rw [← and_forall_add_one, chain'_cons_cons, chain'_iff_get]
     simp
 
 /-- If `l₁ l₂` and `l₃` are lists and `l₁ ++ l₂` and `l₂ ++ l₃` both satisfy
@@ -334,7 +339,7 @@ lemma chain'_flatten : ∀ {L : List (List α)}, [] ∉ L →
 | [l], _ => by simp [flatten]
 | (l₁ :: l₂ :: L), hL => by
     rw [mem_cons, not_or, ← Ne] at hL
-    rw [flatten, chain'_append, chain'_flatten hL.2, forall_mem_cons, chain'_cons]
+    rw [flatten, chain'_append, chain'_flatten hL.2, forall_mem_cons, chain'_cons_cons]
     rw [mem_cons, not_or, ← Ne] at hL
     simp only [forall_mem_cons, and_assoc, flatten, head?_append_of_ne_nil _ hL.2.1.symm]
     exact Iff.rfl.and (Iff.rfl.and <| Iff.rfl.and and_comm)
@@ -435,13 +440,13 @@ theorem Chain'.cons_of_le [LinearOrder α] {a : α} {as m : List α}
   cases m with
   | nil => simp only [List.chain'_singleton]
   | cons b bs =>
-    apply hm.cons
+    apply hm.cons_cons
     cases as with
     | nil =>
       simp only [le_iff_lt_or_eq, reduceCtorEq, or_false] at hmas
       exact (List.not_lt_nil _ hmas).elim
     | cons a' as =>
-      rw [List.chain'_cons] at ha
+      rw [List.chain'_cons_cons] at ha
       refine lt_of_le_of_lt ?_ ha.1
       rw [le_iff_lt_or_eq] at hmas
       rcases hmas with hmas | hmas
@@ -516,7 +521,7 @@ theorem Acc.list_chain' {l : List.chains r} (acc : ∀ a ∈ l.val.head?, Acc r 
       rcases l with - | ⟨b, l⟩
       · apply Acc.intro; rintro ⟨_⟩ ⟨_⟩
       /- l' is accessible by induction hypothesis -/
-      · apply ih b (List.chain'_cons.1 hl).1
+      · apply ih b (List.chain'_cons_cons.1 hl).1
     /- make l' a free variable and induct on l' -/
     revert hl
     rw [(by rfl : l = l'.1)]

--- a/Mathlib/GroupTheory/CoprodI.lean
+++ b/Mathlib/GroupTheory/CoprodI.lean
@@ -696,7 +696,7 @@ theorem of_word (w : Word M) (h : w ≠ empty) : ∃ (i j : _) (w' : NeWord M i 
     rcases l with - | ⟨y, l⟩
     · refine ⟨x.1, x.1, singleton x.2 hnot1.1, ?_⟩
       simp [toWord]
-    · rw [List.chain'_cons] at hchain
+    · rw [List.chain'_cons_cons] at hchain
       specialize hi hnot1.2 hchain.2 (by rintro ⟨rfl⟩)
       obtain ⟨i, j, w', hw' : w'.toList = y::l⟩ := hi
       obtain rfl : y = ⟨i, w'.head⟩ := by simpa [hw'] using w'.toList_head?

--- a/Mathlib/Topology/Category/Profinite/Nobeling/Span.lean
+++ b/Mathlib/Topology/Category/Profinite/Nobeling/Span.lean
@@ -215,7 +215,7 @@ theorem GoodProducts.spanFin [WellFoundedLT I] :
         | nil => exact (List.nil_lt_cons a []).le
         | cons b bs =>
           apply le_of_lt
-          rw [List.chain'_cons] at ha
+          rw [List.chain'_cons_cons] at ha
           exact (List.lt_iff_lex_lt _ _).mp (List.Lex.rel ha.1)
 
 end Fin


### PR DESCRIPTION
As suggested [in this discussion](https://github.com/leanprover-community/mathlib4/pull/25966#discussion_r2245475136), this PR renames `chain'_cons` to `chain'_cons_cons` and analogously `Chain'.cons` to `Chain'.cons_cons`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
