### PR TITLE
[Merged by Bors] - feat: add `@[simp]` to `Multiset.cons_le_cons` and `Finset.insert_subset_insert`

### DIFF
--- a/Mathlib/Data/Finset/Insert.lean
+++ b/Mathlib/Data/Finset/Insert.lean
@@ -450,7 +450,7 @@ theorem insert_subset (ha : a ∈ t) (hs : s ⊆ t) : insert a s ⊆ t :=
 
 @[simp] theorem subset_insert (a : α) (s : Finset α) : s ⊆ insert a s := fun _b => mem_insert_of_mem
 
-@[gcongr]
+@[gcongr, simp]
 theorem insert_subset_insert (a : α) {s t : Finset α} (h : s ⊆ t) : insert a s ⊆ insert a t := by
   grind
 

--- a/Mathlib/Data/Multiset/ZeroCons.lean
+++ b/Mathlib/Data/Multiset/ZeroCons.lean
@@ -357,7 +357,7 @@ theorem le_cons_self (s : Multiset α) (a : α) : s ≤ a ::ₘ s :=
 theorem cons_le_cons_iff (a : α) : a ::ₘ s ≤ a ::ₘ t ↔ s ≤ t :=
   Quotient.inductionOn₂ s t fun _ _ => subperm_cons a
 
-theorem cons_le_cons (a : α) : s ≤ t → a ::ₘ s ≤ a ::ₘ t :=
+@[simp] theorem cons_le_cons (a : α) : s ≤ t → a ::ₘ s ≤ a ::ₘ t :=
   (cons_le_cons_iff a).2
 
 @[simp] lemma cons_lt_cons_iff : a ::ₘ s < a ::ₘ t ↔ s < t :=

--- a/Mathlib/Data/Multiset/ZeroCons.lean
+++ b/Mathlib/Data/Multiset/ZeroCons.lean
@@ -354,10 +354,10 @@ theorem lt_cons_self (s : Multiset α) (a : α) : s < a ::ₘ s :=
 theorem le_cons_self (s : Multiset α) (a : α) : s ≤ a ::ₘ s :=
   le_of_lt <| lt_cons_self _ _
 
-theorem cons_le_cons_iff (a : α) : a ::ₘ s ≤ a ::ₘ t ↔ s ≤ t :=
+@[simp] theorem cons_le_cons_iff (a : α) : a ::ₘ s ≤ a ::ₘ t ↔ s ≤ t :=
   Quotient.inductionOn₂ s t fun _ _ => subperm_cons a
 
-@[simp] theorem cons_le_cons (a : α) : s ≤ t → a ::ₘ s ≤ a ::ₘ t :=
+theorem cons_le_cons (a : α) : s ≤ t → a ::ₘ s ≤ a ::ₘ t :=
   (cons_le_cons_iff a).2
 
 @[simp] lemma cons_lt_cons_iff : a ::ₘ s < a ::ₘ t ↔ s < t :=


### PR DESCRIPTION
I see some other similar theorems such as `List.cons_sublist_cons` and `Finset.cons_subset_cons` are already marked with `@[simp]` annotations. Doing this enables the following statements to be proved simpler with a single `simp`, which in turn makes proofs more easily found by proof search tactics:

```lean
example a b c : {a, b} ≤ ({a, b, c} : Multiset ℝ) := by
  simp

example a b : {a, b} ≤ ({a, a, b, b} : Multiset ℝ) := by
  simp

example a b c : {a, b} ⊆ ({a, b, c} : Finset ℝ) := by
  simp
```