### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Bicategory): move `map₂_eqToHom` earlier in the import graph

### DIFF
--- a/Mathlib/CategoryTheory/Bicategory/Functor/Prelax.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Functor/Prelax.lean
@@ -5,6 +5,7 @@ Authors: Yuma Mizuno, Calle Sönne
 -/
 
 import Mathlib.CategoryTheory.Bicategory.Basic
+import Mathlib.CategoryTheory.EqToHom
 
 /-!
 
@@ -191,6 +192,16 @@ lemma map₂_inv_hom_isIso {f g : a ⟶ b} (η : f ⟶ g) [IsIso η] :
   simp
 
 end
+
+lemma map₂_eqToHom {x y : B} (f g : x ⟶ y) (hfg : f = g) :
+    F.map₂ (eqToHom hfg) = eqToHom (by rw [← hfg]) := by
+  subst hfg
+  simp
+
+lemma map₂Iso_eqToIso {x y : B} (f g : x ⟶ y) (hfg : f = g) :
+    F.map₂Iso (eqToIso hfg) = eqToIso (by rw [← hfg]) := by
+  subst hfg
+  simp
 
 end PrelaxFunctor
 

--- a/Mathlib/CategoryTheory/Bicategory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Grothendieck.lean
@@ -101,6 +101,7 @@ lemma Hom.congr {a b : ∫ F} {f g : a ⟶ b} (h : f = g) :
 
 end
 
+attribute [local simp] PrelaxFunctor.map₂_eqToHom in
 /-- The category structure on `∫ F`. -/
 instance category : Category (∫ F) where
   toCategoryStruct := Pseudofunctor.Grothendieck.categoryStruct

--- a/Mathlib/CategoryTheory/Bicategory/LocallyDiscrete.lean
+++ b/Mathlib/CategoryTheory/Bicategory/LocallyDiscrete.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yuma Mizuno, Calle Sönne
 -/
 import Mathlib.CategoryTheory.Discrete.Basic
-import Mathlib.CategoryTheory.Bicategory.Functor.Prelax
 import Mathlib.CategoryTheory.Bicategory.Strict
 
 /-!

--- a/Mathlib/CategoryTheory/Bicategory/LocallyDiscrete.lean
+++ b/Mathlib/CategoryTheory/Bicategory/LocallyDiscrete.lean
@@ -106,17 +106,6 @@ instance locallyDiscreteBicategory.strict : Strict (LocallyDiscrete C) where
 
 end
 
-section
-
-variable {B : Type u₁} [Bicategory.{w₁, v₁} B] {C : Type u₂} [Bicategory.{w₂, v₂} C]
-
-@[simp]
-lemma PrelaxFunctor.map₂_eqToHom (F : PrelaxFunctor B C) {a b : B} {f g : a ⟶ b} (h : f = g) :
-    F.map₂ (eqToHom h) = eqToHom (F.congr_map h) := by
-  subst h; simp only [eqToHom_refl, PrelaxFunctor.map₂_id]
-
-end
-
 namespace Bicategory
 
 /-- A bicategory is locally discrete if the categories of 1-morphisms are discrete. -/

--- a/Mathlib/CategoryTheory/FiberedCategory/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/FiberedCategory/Grothendieck.lean
@@ -73,6 +73,7 @@ instance : IsFibered (forget F) :=
 
 variable (F) (S : 𝒮)
 
+attribute [local simp] PrelaxFunctor.map₂_eqToHom in
 /-- The inclusion map from `F(S)` into `∫ F`. -/
 @[simps]
 def ι : F.obj ⟨op S⟩ ⥤ ∫ F where


### PR DESCRIPTION
The lemma `PrelaxFunctor.map₂_eqToHom` currently sits in the file `CategoryTheory/Bicategory/LocallyDiscrete`. This has low discoverability, and it is unavailable to other files that deals with `eqToHoms`, such as `CategoryTheory/Bicategory/Functor/Strict`. 

We move the lemma in the file `Category/Bicategory/Functor/Prelax`. This comes at the cost of an extra import (`CategoryTheory.EqToHom`) in the file.

The lemma is unsimped for consistency with the corresponding lemma for ordinary categories, which is intentionally not a simp lemma.

We also sneak in the `eqToIso` version for completeness.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Feel free to disagree with the extra import. I think putting this lemma closer to the definition of prelax functors is what makes most sense.

An other possible home for this lemma is the file `CategoryTheory/Bicategory/EqToHom` that I introduce in #28242, but this would require that it imports prelax functors.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
