### PR TITLE
[Merged by Bors] - refactor(Tactic/Linarith): switch to using AtomM in natToInt

### DIFF
--- a/Mathlib/Tactic/Linarith/Preprocessing.lean
+++ b/Mathlib/Tactic/Linarith/Preprocessing.lean
@@ -171,8 +171,10 @@ def natToInt : GlobalBranchingPreprocessor where
         let indices_b ← (getNatComparisons b).mapM getIndices
         pure <| (es.insertMany indices_a).insertMany indices_b
       catch _ => pure es
-    pure [(g, ((← nonnegs.toList.filterMapM fun p => do
-      mk_natCast_nonneg_prf ((← get).atoms[p.1]!, (← get).atoms[p.2]!)) ++ l : List Expr))]
+    let atoms : Array Expr := (← get).atoms
+    let nonneg_pfs : List Expr ← nonnegs.toList.filterMapM fun p => do
+      mk_natCast_nonneg_prf (atoms[p.1]!, atoms[p.2]!)
+    pure [(g, nonneg_pfs ++ l)]
 
 end natToInt
 

--- a/Mathlib/Tactic/Linarith/Preprocessing.lean
+++ b/Mathlib/Tactic/Linarith/Preprocessing.lean
@@ -129,11 +129,13 @@ def mk_natCast_nonneg_prf (p : Expr × Expr) : MetaM (Option Expr) :=
       trace[linarith] "Got exception when using cast {e.toMessageData}"
       return none
 
-
 /-- Ordering on `Expr`. -/
+@[deprecated
+  "Use `Expr.lt` and `Expr.equal` or `Expr.eqv` directly. \
+  If you need to order expressions, consider ordering them by order seen, with AtomM."
+  (since := "2025-08-31")]
 def Expr.Ord : Ord Expr :=
 ⟨fun a b => if Expr.lt a b then .lt else if a.equal b then .eq else .gt⟩
-
 
 /--
 If `h` is an equality or inequality between natural numbers,

--- a/Mathlib/Tactic/Linarith/Preprocessing.lean
+++ b/Mathlib/Tactic/Linarith/Preprocessing.lean
@@ -165,11 +165,11 @@ def natToInt : GlobalBranchingPreprocessor where
     let nonnegs ← l.foldlM (init := ∅) fun (es : TreeSet (Nat × Nat) lexOrd.compare) h => do
       try
         let (_, _, a, b) ← (← inferType h).ineq?
-        let cmps_a ← (getNatComparisons a).mapM fun p =>
+        let getIndices (p : Expr × Expr) : AtomM (ℕ × ℕ) := do
           return ((← AtomM.addAtom p.1).1, (← AtomM.addAtom p.2).1)
-        let cmps_b ← (getNatComparisons b).mapM fun p =>
-          return ((← AtomM.addAtom p.1).1, (← AtomM.addAtom p.2).1)
-        pure <| (es.insertMany cmps_a).insertMany cmps_b
+        let indices_a ← (getNatComparisons a).mapM getIndices
+        let indices_b ← (getNatComparisons b).mapM getIndices
+        pure <| (es.insertMany indices_a).insertMany indices_b
       catch _ => pure es
     pure [(g, ((← nonnegs.toList.filterMapM fun p => do
       mk_natCast_nonneg_prf ((← get).atoms[p.1]!, (← get).atoms[p.2]!)) ++ l : List Expr))]

--- a/MathlibTest/linarith.lean
+++ b/MathlibTest/linarith.lean
@@ -736,3 +736,40 @@ end findSquares
 -- `Expr.mdata` should be ignored by linarith
 example (x : Int) (h : x = -2) : x = no_index(-2) := by
   linarith [h]
+
+/-!
+From https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Adding.20an.20extra.20hypothesis.20breaks.20linarith/near/533973472
+-/
+namespace metavariables
+
+theorem foo {i m : ℕ} : i ∣ 2 ^ m → m = m := fun _ => rfl
+
+variable (k a i : ℕ)
+
+theorem base (h : (a : ℤ) * 2 ^ k = 2 ^ i) : True := by
+  have := foo ⟨2^k, by linarith⟩
+  guard_hyp this : i = i
+  trivial
+
+-- It's not clear which of the following should succeed and which should fail.
+-- For now this primarily serves to record behavior changes.
+
+theorem before_i (useless : i ≤ i) (h : (a : ℤ) * 2 ^ k = 2 ^ i) : True := by
+  have := foo ⟨2^k, by linarith⟩
+  guard_hyp this : i = i
+  trivial
+
+theorem before_k (useless : k ≤ k) (h : (a : ℤ) * 2 ^ k = 2 ^ i) : True := by
+  have := foo ⟨2^k, by linarith⟩
+  guard_hyp this : i = i
+  trivial
+
+theorem after_i_fails (h : (a : ℤ) * 2 ^ k = 2 ^ i) (useless : i ≤ i) : True := by
+  fail_if_success have := foo ⟨2^k, by linarith⟩
+  trivial
+
+theorem after_k_fails (h : (a : ℤ) * 2 ^ k = 2 ^ i) (useless : k ≤ k) : True := by
+  fail_if_success have := foo ⟨2^k, by linarith⟩
+  trivial
+
+end metavariables


### PR DESCRIPTION
This seems to result in a slight behavior change; the equations now end up being handled in `linarith` in the order they appear in the context, rather than in the order that `Expr.lt` sorts them. This matters when unifying metavariables, and sorting with `Expr.lt` increases the chance of non-determinism (as this can include metavariable names).

This follows on from #14586; at the time I did not contribute it as I did not have a test-case that changed behavior.

The metavariable assignment behavior here still feels pretty random ([#mathlib4 > Adding an extra hypothesis breaks linarith @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Adding.20an.20extra.20hypothesis.20breaks.20linarith/near/533973472)), but I think this change is probably still good.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
