### PR TITLE
[Merged by Bors] - feat(Geometry/Manifold/ContMDiff): add product lemmas for `ContMDiff`

### DIFF
--- a/Mathlib/Geometry/Manifold/ContMDiff/Constructions.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Constructions.lean
@@ -238,13 +238,13 @@ theorem contMDiff_prod_assoc :
       fun x : (M × M') × N => (x.1.1, x.1.2, x.2) :=
   contMDiff_fst.fst.prodMk <| contMDiff_fst.snd.prodMk contMDiff_snd
 
-/-- `ContMDiffAt.comp` for a function of two arguments -/
+/-- `ContMDiffAt.comp` for a function of two arguments. -/
 theorem ContMDiffAt.comp₂ {h : M' × N' → N} {f : M → M'} {g : M → N'} {x : M}
     (ha : ContMDiffAt (I'.prod J') J n h (f x, g x)) (fa : ContMDiffAt I I' n f x)
     (ga : ContMDiffAt I J' n g x) : ContMDiffAt I J n (fun x ↦ h (f x, g x)) x :=
   ha.comp (f := fun x ↦ (f x, g x)) _ (fa.prodMk ga)
 
-/-- `ContMDiffAt.comp₂`, with a separate argument for point equality -/
+/-- `ContMDiffAt.comp₂`, with a separate argument for point equality. -/
 theorem ContMDiffAt.comp₂_of_eq {h : M' × N' → N} {f : M → M'} {g : M → N'} {x : M} {y : M' × N'}
     (ha : ContMDiffAt (I'.prod J') J n h y) (fa : ContMDiffAt I I' n f x)
     (ga : ContMDiffAt I J' n g x) (e : (f x, g x) = y) :

--- a/Mathlib/Geometry/Manifold/ContMDiff/Constructions.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Constructions.lean
@@ -252,28 +252,28 @@ theorem ContMDiffAt.comp₂_of_eq {h : M' × N' → N} {f : M → M'} {g : M →
   rw [← e] at ha
   exact ha.comp₂ fa ga
 
-/-- Curried analytic functions are analytic in the first coordinate -/
+/-- Curried `C^n` functions are `C^n` in the first coordinate. -/
 theorem ContMDiffAt.curry_left {f : M → M' → N} {x : M} {y : M'}
     (fa : ContMDiffAt (I.prod I') J n (uncurry f) (x, y)) :
     ContMDiffAt I J n (fun x ↦ f x y) x :=
   fa.comp₂ contMDiffAt_id contMDiffAt_const
 alias ContMDiffAt.along_fst := ContMDiffAt.curry_left
 
-/-- Curried analytic functions are analytic in the second coordinate -/
+/-- Curried `C^n` functions are `C^n` in the second coordinate. -/
 theorem ContMDiffAt.curry_right {f : M → M' → N} {x : M} {y : M'}
     (fa : ContMDiffAt (I.prod I') J n (uncurry f) (x, y)) :
     ContMDiffAt I' J n (fun y ↦ f x y) y :=
   fa.comp₂ contMDiffAt_const contMDiffAt_id
 alias ContMDiffAt.along_snd := ContMDiffAt.curry_right
 
-/-- Curried analytic functions are analytic in the first coordinate -/
+/-- Curried `C^n` functions are `C^n` in the first coordinate. -/
 theorem ContMDiff.curry_left {f : M → M' → N}
     (fa : ContMDiff (I.prod I') J n (uncurry f)) {y : M'} :
     ContMDiff I J n (fun x ↦ f x y) :=
   fun _ ↦ (fa _).along_fst
 alias ContMDiff.along_fst := ContMDiff.curry_left
 
-/-- Curried analytic functions are analytic in the second coordinate -/
+/-- Curried `C^n` functions are `C^n` in the second coordinate. -/
 theorem ContMDiff.curry_right {f : M → M' → N} {x : M}
     (fa : ContMDiff (I.prod I') J n (uncurry f)) :
     ContMDiff I' J n (fun y ↦ f x y) :=

--- a/Mathlib/Geometry/Manifold/ContMDiff/Constructions.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Constructions.lean
@@ -252,6 +252,34 @@ theorem ContMDiffAt.comp₂_of_eq {h : M' × N' → N} {f : M → M'} {g : M →
   rw [← e] at ha
   exact ha.comp₂ fa ga
 
+/-- Curried analytic functions are analytic in the first coordinate -/
+theorem ContMDiffAt.curry_left {f : M → M' → N} {x : M} {y : M'}
+    (fa : ContMDiffAt (I.prod I') J n (uncurry f) (x, y)) :
+    ContMDiffAt I J n (fun x ↦ f x y) x :=
+  fa.comp₂ contMDiffAt_id contMDiffAt_const
+alias ContMDiffAt.along_fst := ContMDiffAt.curry_left
+
+/-- Curried analytic functions are analytic in the second coordinate -/
+theorem ContMDiffAt.curry_right {f : M → M' → N} {x : M} {y : M'}
+    (fa : ContMDiffAt (I.prod I') J n (uncurry f) (x, y)) :
+    ContMDiffAt I' J n (fun y ↦ f x y) y :=
+  fa.comp₂ contMDiffAt_const contMDiffAt_id
+alias ContMDiffAt.along_snd := ContMDiffAt.curry_right
+
+/-- Curried analytic functions are analytic in the first coordinate -/
+theorem ContMDiff.curry_left {f : M → M' → N}
+    (fa : ContMDiff (I.prod I') J n (uncurry f)) {y : M'} :
+    ContMDiff I J n (fun x ↦ f x y) :=
+  fun _ ↦ (fa _).along_fst
+alias ContMDiff.along_fst := ContMDiff.curry_left
+
+/-- Curried analytic functions are analytic in the second coordinate -/
+theorem ContMDiff.curry_right {f : M → M' → N} {x : M}
+    (fa : ContMDiff (I.prod I') J n (uncurry f)) :
+    ContMDiff I' J n (fun y ↦ f x y) :=
+  fun _ ↦ (fa _).along_snd
+alias ContMDiff.along_snd := ContMDiff.curry_right
+
 section prodMap
 
 variable {g : N → N'} {r : Set N} {y : N}

--- a/Mathlib/Geometry/Manifold/ContMDiff/Constructions.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Constructions.lean
@@ -238,6 +238,20 @@ theorem contMDiff_prod_assoc :
       fun x : (M × M') × N => (x.1.1, x.1.2, x.2) :=
   contMDiff_fst.fst.prodMk <| contMDiff_fst.snd.prodMk contMDiff_snd
 
+/-- `ContMDiffAt.comp` for a function of two arguments -/
+theorem ContMDiffAt.comp₂ {h : M' × N' → N} {f : M → M'} {g : M → N'} {x : M}
+    (ha : ContMDiffAt (I'.prod J') J n h (f x, g x)) (fa : ContMDiffAt I I' n f x)
+    (ga : ContMDiffAt I J' n g x) : ContMDiffAt I J n (fun x ↦ h (f x, g x)) x :=
+  ha.comp (f := fun x ↦ (f x, g x)) _ (fa.prodMk ga)
+
+/-- `ContMDiffAt.comp₂`, with a separate argument for point equality -/
+theorem ContMDiffAt.comp₂_of_eq {h : M' × N' → N} {f : M → M'} {g : M → N'} {x : M} {y : M' × N'}
+    (ha : ContMDiffAt (I'.prod J') J n h y) (fa : ContMDiffAt I I' n f x)
+    (ga : ContMDiffAt I J' n g x) (e : (f x, g x) = y) :
+    ContMDiffAt I J n (fun x ↦ h (f x, g x)) x := by
+  rw [← e] at ha
+  exact ha.comp₂ fa ga
+
 section prodMap
 
 variable {g : N → N'} {r : Set N} {y : N}

--- a/Mathlib/Geometry/Manifold/ContMDiff/Constructions.lean
+++ b/Mathlib/Geometry/Manifold/ContMDiff/Constructions.lean
@@ -238,6 +238,23 @@ theorem contMDiff_prod_assoc :
       fun x : (M × M') × N => (x.1.1, x.1.2, x.2) :=
   contMDiff_fst.fst.prodMk <| contMDiff_fst.snd.prodMk contMDiff_snd
 
+/-- `ContMDiffWithinAt.comp` for a function of two arguments. -/
+theorem ContMDiffWithinAt.comp₂ {h : M' × N' → N} {f : M → M'} {g : M → N'} {x : M}
+    {t : Set (M' × N')} (ha : ContMDiffWithinAt (I'.prod J') J n h t (f x, g x))
+    (fa : ContMDiffWithinAt I I' n f s x) (ga : ContMDiffWithinAt I J' n g s x)
+    (st : MapsTo (fun x ↦ (f x, g x)) s t) :
+    ContMDiffWithinAt I J n (fun x ↦ h (f x, g x)) s x :=
+  ha.comp (f := fun x ↦ (f x, g x)) _ (fa.prodMk ga) st
+
+/-- `ContMDiffWithinAt.comp₂`, with a separate argument for point equality. -/
+theorem ContMDiffWithinAt.comp₂_of_eq {h : M' × N' → N} {f : M → M'} {g : M → N'} {x : M}
+    {y : M' × N'} {t : Set (M' × N')} (ha : ContMDiffWithinAt (I'.prod J') J n h t y)
+    (fa : ContMDiffWithinAt I I' n f s x) (ga : ContMDiffWithinAt I J' n g s x)
+    (e : (f x, g x) = y) (st : MapsTo (fun x ↦ (f x, g x)) s t) :
+    ContMDiffWithinAt I J n (fun x ↦ h (f x, g x)) s x := by
+  rw [← e] at ha
+  exact ha.comp₂ fa ga st
+
 /-- `ContMDiffAt.comp` for a function of two arguments. -/
 theorem ContMDiffAt.comp₂ {h : M' × N' → N} {f : M → M'} {g : M → N'} {x : M}
     (ha : ContMDiffAt (I'.prod J') J n h (f x, g x)) (fa : ContMDiffAt I I' n f x)
@@ -253,6 +270,20 @@ theorem ContMDiffAt.comp₂_of_eq {h : M' × N' → N} {f : M → M'} {g : M →
   exact ha.comp₂ fa ga
 
 /-- Curried `C^n` functions are `C^n` in the first coordinate. -/
+theorem ContMDiffWithinAt.curry_left {f : M → M' → N} {x : M} {y : M'} {s : Set (M × M')}
+    (fa : ContMDiffWithinAt (I.prod I') J n (uncurry f) s (x, y)) :
+    ContMDiffWithinAt I J n (fun x ↦ f x y) {x | (x, y) ∈ s} x :=
+  fa.comp₂ contMDiffWithinAt_id contMDiffWithinAt_const (fun _ h ↦ h)
+alias ContMDiffWithinAt.along_fst := ContMDiffWithinAt.curry_left
+
+/-- Curried `C^n` functions are `C^n` in the second coordinate. -/
+theorem ContMDiffWithinAt.curry_right {f : M → M' → N} {x : M} {y : M'} {s : Set (M × M')}
+    (fa : ContMDiffWithinAt (I.prod I') J n (uncurry f) s (x, y)) :
+    ContMDiffWithinAt I' J n (fun y ↦ f x y) {y | (x, y) ∈ s} y :=
+  fa.comp₂ contMDiffWithinAt_const contMDiffWithinAt_id (fun _ h ↦ h)
+alias ContMDiffWithinAt.along_snd := ContMDiffWithinAt.curry_right
+
+/-- Curried `C^n` functions are `C^n` in the first coordinate. -/
 theorem ContMDiffAt.curry_left {f : M → M' → N} {x : M} {y : M'}
     (fa : ContMDiffAt (I.prod I') J n (uncurry f) (x, y)) :
     ContMDiffAt I J n (fun x ↦ f x y) x :=
@@ -265,6 +296,20 @@ theorem ContMDiffAt.curry_right {f : M → M' → N} {x : M} {y : M'}
     ContMDiffAt I' J n (fun y ↦ f x y) y :=
   fa.comp₂ contMDiffAt_const contMDiffAt_id
 alias ContMDiffAt.along_snd := ContMDiffAt.curry_right
+
+/-- Curried `C^n` functions are `C^n` in the first coordinate. -/
+theorem ContMDiffOn.curry_left {f : M → M' → N} {s : Set (M × M')}
+    (fa : ContMDiffOn (I.prod I') J n (uncurry f) s) {y : M'} :
+    ContMDiffOn I J n (fun x ↦ f x y) {x | (x, y) ∈ s} :=
+  fun x m ↦ (fa (x, y) m).along_fst
+alias ContMDiffOn.along_fst := ContMDiffOn.curry_left
+
+/-- Curried `C^n` functions are `C^n` in the second coordinate. -/
+theorem ContMDiffOn.curry_right {f : M → M' → N} {x : M} {s : Set (M × M')}
+    (fa : ContMDiffOn (I.prod I') J n (uncurry f) s) :
+    ContMDiffOn I' J n (fun y ↦ f x y) {y | (x, y) ∈ s} :=
+  fun y m ↦ (fa (x, y) m).along_snd
+alias ContMDiffOn.along_snd := ContMDiffOn.curry_right
 
 /-- Curried `C^n` functions are `C^n` in the first coordinate. -/
 theorem ContMDiff.curry_left {f : M → M' → N}


### PR DESCRIPTION
Add product lemmas for `ContMDiff`. These are analogous to the corresponding lemmas for `Continuous` in [`Mathlib.Topology.Constructions.SumProd`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/Constructions/SumProd.html#ContinuousAt.comp%E2%82%82).

This is upstreamed from [https://github.com/girving/ray](https://github.com/girving/ray).

Co-authored-by: Geoffrey Irving <irving@naml.us>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
