### PR TITLE
chore(Tactic/DepRewrite): dsimplify more

### DIFF
--- a/Mathlib/Tactic/DepRewrite.lean
+++ b/Mathlib/Tactic/DepRewrite.lean
@@ -482,13 +482,16 @@ def _root_.Lean.MVarId.depRewrite (mvarId : MVarId) (e : Expr) (heq : Expr)
 
 /--
 The configuration used by `rw!` to call `dsimp`.
-This configuration uses only iota reduction (recursor application) to simplify terms.
+This configuration uses just enough simplification to be able to compute
+away applications of `Eq.rec` that `rw!` creates.
 -/
 private def depRwContext : MetaM Simp.Context :=
   Simp.mkContext
     {Lean.Meta.Simp.neutralConfig with
      etaStruct := .none
      iota := true
+     beta := true
+     proj := true
      failIfUnchanged := false}
 
 open Parser Elab Tactic

--- a/MathlibTest/depRewrite.lean
+++ b/MathlibTest/depRewrite.lean
@@ -302,3 +302,10 @@ example (f : Nat → Nat → Nat) : P (f (id n) (id n)) := by
   rewrite! (occs := .neg [1]) [eq]
   guard_target =ₐ P (f (id n) (id m))
   exact test_sorry
+
+
+-- make sure `dsimp` is doing enough
+example {n m : Nat} (u : Fin (n + m + 1)) : P u := by
+  rw! (castMode := .all) [Nat.add_assoc]
+  guard_target =ₛ @P (Fin (n + (m + 1))) u
+  exact test_sorry


### PR DESCRIPTION
The `depRwContext` isn't simplifying enough. Change it to simplify more.

There is an alternative, which is to use an empty config, but instruct `dsimp` to use a new lemma like `Eq.rec_refl`.

Another option would be to mark the `Eq.rec` generated in `visitAndCast` with metadata, and then write a dsimproc to reduce those when possible.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
