### PR TITLE
[Merged by Bors] - chore(Data/Fin): golf entire `coe_int_add_eq_mod` using `omega`

### DIFF
--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -248,10 +248,7 @@ theorem coe_int_add_eq_ite {n : Nat} (u v : Fin n) :
 
 theorem coe_int_add_eq_mod {n : Nat} (u v : Fin n) :
     ((u + v : Fin n) : Int) = ((u : Int) + (v : Int)) % n := by
-  rw [coe_int_add_eq_ite]
-  split
-  · rw [Int.emod_eq_of_lt] <;> omega
-  · rw [Int.emod_eq_sub_self_emod, Int.emod_eq_of_lt] <;> omega
+  omega
 
 -- Write `a + b` as `if (a + b : ℕ) < n then (a + b : ℤ) else (a + b : ℤ) - n` and
 -- similarly `a - b` as `if (b : ℕ) ≤ a then (a - b : ℤ) else (a - b : ℤ) + n`.


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>coe_int_add_eq_mod</code> (21 ms before, <10 ms after)</summary>

### Trace profiling of `coe_int_add_eq_mod` before PR 28297
```diff
diff --git a/Mathlib/Data/Fin/Basic.lean b/Mathlib/Data/Fin/Basic.lean
index 91773666f1..b14c2a53b8 100644
--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -248,2 +248,3 @@ theorem coe_int_add_eq_ite {n : Nat} (u v : Fin n) :
 
+set_option trace.profiler true in
 theorem coe_int_add_eq_mod {n : Nat} (u v : Fin n) :
```
```
ℹ [480/480] Built Mathlib.Data.Fin.Basic
info: Mathlib/Data/Fin/Basic.lean:250:0: [Elab.command] [0.022465] theorem coe_int_add_eq_mod {n : Nat} (u v : Fin n) :
        ((u + v : Fin n) : Int) = ((u : Int) + (v : Int)) % n :=
      by
      rw [coe_int_add_eq_ite]
      split
      · rw [Int.emod_eq_of_lt] <;> omega
      · rw [Int.emod_eq_sub_self_emod, Int.emod_eq_of_lt] <;> omega
  [Elab.definition.header] [0.022089] Fin.coe_int_add_eq_mod
    [Elab.step] [0.021925] expected type: Sort ?u.10190, term
        ((u + v : Fin n) : Int) = ((u : Int) + (v : Int)) % n
      [Elab.step] [0.021919] expected type: Sort ?u.10190, term
          binrel% Eq✝ ((u + v : Fin n) : Int) (((u : Int) + (v : Int)) % n)
        [Elab.step] [0.012149] expected type: <not-available>, term
            (v : Int)
          [Elab.coe] [0.012060] adding coercion for v : Fin n =?= ℤ
            [Meta.synthInstance] [0.011961] ✅️ CoeT (Fin n) v ℤ
info: Mathlib/Data/Fin/Basic.lean:250:0: [Elab.async] [0.021344] elaborating proof of Fin.coe_int_add_eq_mod
  [Elab.definition.value] [0.020901] Fin.coe_int_add_eq_mod
    [Elab.step] [0.020571] 
          rw [coe_int_add_eq_ite]
          split
          · rw [Int.emod_eq_of_lt] <;> omega
          · rw [Int.emod_eq_sub_self_emod, Int.emod_eq_of_lt] <;> omega
      [Elab.step] [0.020554] 
            rw [coe_int_add_eq_ite]
            split
            · rw [Int.emod_eq_of_lt] <;> omega
            · rw [Int.emod_eq_sub_self_emod, Int.emod_eq_of_lt] <;> omega
Build completed successfully.
```

### Trace profiling of `coe_int_add_eq_mod` after PR 28297
```diff
diff --git a/Mathlib/Data/Fin/Basic.lean b/Mathlib/Data/Fin/Basic.lean
index 91773666f1..3d24881180 100644
--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -248,8 +248,6 @@ theorem coe_int_add_eq_ite {n : Nat} (u v : Fin n) :
 
+set_option trace.profiler true in
 theorem coe_int_add_eq_mod {n : Nat} (u v : Fin n) :
     ((u + v : Fin n) : Int) = ((u : Int) + (v : Int)) % n := by
-  rw [coe_int_add_eq_ite]
-  split
-  · rw [Int.emod_eq_of_lt] <;> omega
-  · rw [Int.emod_eq_sub_self_emod, Int.emod_eq_of_lt] <;> omega
+  omega
 
```
```
ℹ [480/480] Built Mathlib.Data.Fin.Basic
info: Mathlib/Data/Fin/Basic.lean:250:0: [Elab.command] [0.021324] theorem coe_int_add_eq_mod {n : Nat} (u v : Fin n) :
        ((u + v : Fin n) : Int) = ((u : Int) + (v : Int)) % n := by omega
  [Elab.definition.header] [0.020953] Fin.coe_int_add_eq_mod
    [Elab.step] [0.020794] expected type: Sort ?u.10190, term
        ((u + v : Fin n) : Int) = ((u : Int) + (v : Int)) % n
      [Elab.step] [0.020785] expected type: Sort ?u.10190, term
          binrel% Eq✝ ((u + v : Fin n) : Int) (((u : Int) + (v : Int)) % n)
Build completed successfully.
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
