### PR TITLE
[Merged by Bors] - chore(Data/Int): golf entire `le_natCast_sub` using `omega`

### DIFF
--- a/Mathlib/Data/Int/Lemmas.lean
+++ b/Mathlib/Data/Int/Lemmas.lean
@@ -21,9 +21,7 @@ open Nat
 namespace Int
 
 theorem le_natCast_sub (m n : ℕ) : (m - n : ℤ) ≤ ↑(m - n : ℕ) := by
-  by_cases h : m ≥ n
-  · exact le_of_eq (Int.ofNat_sub h).symm
-  · simp [le_of_not_ge h]
+  omega
 
 /-! ### `succ` and `pred` -/
 


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>le_natCast_sub</code> (20 ms before, <10 ms after)</summary>

### Trace profiling of `le_natCast_sub` before PR 28299
```diff
diff --git a/Mathlib/Data/Int/Lemmas.lean b/Mathlib/Data/Int/Lemmas.lean
index ac1ca078a2..2a26314260 100644
--- a/Mathlib/Data/Int/Lemmas.lean
+++ b/Mathlib/Data/Int/Lemmas.lean
@@ -22,2 +22,3 @@ namespace Int
 
+set_option trace.profiler true in
 theorem le_natCast_sub (m n : ℕ) : (m - n : ℤ) ≤ ↑(m - n : ℕ) := by
```
```
ℹ [629/629] Built Mathlib.Data.Int.Lemmas
info: Mathlib/Data/Int/Lemmas.lean:24:0: [Elab.async] [0.020812] elaborating proof of Int.le_natCast_sub
  [Elab.definition.value] [0.020452] Int.le_natCast_sub
    [Elab.step] [0.020104] 
          by_cases h : m ≥ n
          · exact le_of_eq (Int.ofNat_sub h).symm
          · simp [le_of_not_ge h]
      [Elab.step] [0.020095] 
            by_cases h : m ≥ n
            · exact le_of_eq (Int.ofNat_sub h).symm
            · simp [le_of_not_ge h]
        [Elab.step] [0.017594] · simp [le_of_not_ge h]
          [Elab.step] [0.017565] simp [le_of_not_ge h]
            [Elab.step] [0.017561] simp [le_of_not_ge h]
              [Elab.step] [0.017553] simp [le_of_not_ge h]
Build completed successfully.
```

### Trace profiling of `le_natCast_sub` after PR 28299
```diff
diff --git a/Mathlib/Data/Int/Lemmas.lean b/Mathlib/Data/Int/Lemmas.lean
index ac1ca078a2..3af2a60b4b 100644
--- a/Mathlib/Data/Int/Lemmas.lean
+++ b/Mathlib/Data/Int/Lemmas.lean
@@ -22,6 +22,5 @@ namespace Int
 
+set_option trace.profiler true in
 theorem le_natCast_sub (m n : ℕ) : (m - n : ℤ) ≤ ↑(m - n : ℕ) := by
-  by_cases h : m ≥ n
-  · exact le_of_eq (Int.ofNat_sub h).symm
-  · simp [le_of_not_ge h]
+  omega
 
```
```
✔ [629/629] Built Mathlib.Data.Int.Lemmas
Build completed successfully.
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
