### PR TITLE
[Merged by Bors] - chore(NumberTheory/NumberField/CanonicalEmbedding): golf entire `convexBodySumFun_continuous` using `fun_prop`

### DIFF
--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
@@ -307,11 +307,7 @@ variable (K)
 
 theorem convexBodySumFun_continuous :
     Continuous (convexBodySumFun : mixedSpace K → ℝ) := by
-  refine continuous_finset_sum Finset.univ fun w ↦ ?_
-  obtain hw | hw := isReal_or_isComplex w
-  all_goals
-  · simp only [normAtPlace_apply_of_isReal, normAtPlace_apply_of_isComplex, hw]
-    fun_prop
+  fun_prop
 
 /-- The convex body equal to the set of points `x : mixedSpace K` such that
   `∑ w real, ‖x w‖ + 2 * ∑ w complex, ‖x w‖ ≤ B`. -/


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>convexBodySumFun_continuous</code>: 55 ms before, 19 ms after  🎉</summary>

### Trace profiling of `convexBodySumFun_continuous` before PR 28302
```diff
diff --git a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
index 38eff7a7ff..0158146613 100644
--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
@@ -307,2 +307,3 @@ variable (K)
 
+set_option trace.profiler true in
 theorem convexBodySumFun_continuous :
```
```
ℹ [3003/3003] Built Mathlib.NumberTheory.NumberField.CanonicalEmbedding.ConvexBody
info: Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean:309:0: [Elab.async] [0.056262] elaborating proof of NumberField.mixedEmbedding.convexBodySumFun_continuous
  [Elab.definition.value] [0.055477] NumberField.mixedEmbedding.convexBodySumFun_continuous
    [Elab.step] [0.055045] 
          refine continuous_finset_sum Finset.univ fun w ↦ ?_
          obtain hw | hw := isReal_or_isComplex w
          all_goals
            · simp only [normAtPlace_apply_of_isReal, normAtPlace_apply_of_isComplex, hw]
              fun_prop
      [Elab.step] [0.055039] 
            refine continuous_finset_sum Finset.univ fun w ↦ ?_
            obtain hw | hw := isReal_or_isComplex w
            all_goals
              · simp only [normAtPlace_apply_of_isReal, normAtPlace_apply_of_isComplex, hw]
                fun_prop
        [Elab.step] [0.011600] refine continuous_finset_sum Finset.univ fun w ↦ ?_
          [Elab.step] [0.011190] expected type: Continuous convexBodySumFun, term
              continuous_finset_sum Finset.univ fun w ↦ ?_
        [Elab.step] [0.041791] all_goals
              · simp only [normAtPlace_apply_of_isReal, normAtPlace_apply_of_isComplex, hw]
                fun_prop
          [Elab.step] [0.022437] ·
                  simp only [normAtPlace_apply_of_isReal, normAtPlace_apply_of_isComplex, hw]
                  fun_prop
            [Elab.step] [0.022432] ·
                    simp only [normAtPlace_apply_of_isReal, normAtPlace_apply_of_isComplex, hw]
                    fun_prop
              [Elab.step] [0.022426] ·
                    simp only [normAtPlace_apply_of_isReal, normAtPlace_apply_of_isComplex, hw]
                    fun_prop
                [Elab.step] [0.022419] 
                      simp only [normAtPlace_apply_of_isReal, normAtPlace_apply_of_isComplex, hw]
                      fun_prop
                  [Elab.step] [0.022414] 
                        simp only [normAtPlace_apply_of_isReal, normAtPlace_apply_of_isComplex, hw]
                        fun_prop
                    [Elab.step] [0.018772] fun_prop
                      [Meta.Tactic.fun_prop] [0.016980] [✅️] w ∈ Finset.univ → Continuous fun a ↦ ↑w.mult * ‖a.1 ⟨w, hw⟩‖
                        [Meta.Tactic.fun_prop] [0.015869] [✅️] Continuous fun a ↦ ↑w.mult * ‖a.1 ⟨w, hw⟩‖
                          [Meta.Tactic.fun_prop] [0.013852] [✅️] applying: Continuous.comp'
          [Elab.step] [0.019032] ·
                  simp only [normAtPlace_apply_of_isReal, normAtPlace_apply_of_isComplex, hw]
                  fun_prop
            [Elab.step] [0.019027] ·
                    simp only [normAtPlace_apply_of_isReal, normAtPlace_apply_of_isComplex, hw]
                    fun_prop
              [Elab.step] [0.019021] ·
                    simp only [normAtPlace_apply_of_isReal, normAtPlace_apply_of_isComplex, hw]
                    fun_prop
                [Elab.step] [0.019015] 
                      simp only [normAtPlace_apply_of_isReal, normAtPlace_apply_of_isComplex, hw]
                      fun_prop
                  [Elab.step] [0.019010] 
                        simp only [normAtPlace_apply_of_isReal, normAtPlace_apply_of_isComplex, hw]
                        fun_prop
                    [Elab.step] [0.015215] fun_prop
                      [Meta.Tactic.fun_prop] [0.013446] [✅️] w ∈ Finset.univ → Continuous fun a ↦ ↑w.mult * ‖a.2 ⟨w, hw⟩‖
                        [Meta.Tactic.fun_prop] [0.012599] [✅️] Continuous fun a ↦ ↑w.mult * ‖a.2 ⟨w, hw⟩‖
                          [Meta.Tactic.fun_prop] [0.011963] [✅️] applying: Continuous.comp'
Build completed successfully.
```

### Trace profiling of `convexBodySumFun_continuous` after PR 28302
```diff
diff --git a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
index 38eff7a7ff..8ed359f1f9 100644
--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean
@@ -307,9 +307,6 @@ variable (K)
 
+set_option trace.profiler true in
 theorem convexBodySumFun_continuous :
     Continuous (convexBodySumFun : mixedSpace K → ℝ) := by
-  refine continuous_finset_sum Finset.univ fun w ↦ ?_
-  obtain hw | hw := isReal_or_isComplex w
-  all_goals
-  · simp only [normAtPlace_apply_of_isReal, normAtPlace_apply_of_isComplex, hw]
-    fun_prop
+  fun_prop
 
```
```
ℹ [3003/3003] Built Mathlib.NumberTheory.NumberField.CanonicalEmbedding.ConvexBody
info: Mathlib/NumberTheory/NumberField/CanonicalEmbedding/ConvexBody.lean:309:0: [Elab.async] [0.018940] elaborating proof of NumberField.mixedEmbedding.convexBodySumFun_continuous
  [Elab.definition.value] [0.018528] NumberField.mixedEmbedding.convexBodySumFun_continuous
    [Elab.step] [0.018261] fun_prop
      [Elab.step] [0.018255] fun_prop
        [Elab.step] [0.018247] fun_prop
          [Meta.Tactic.fun_prop] [0.016712] [✅️] Continuous convexBodySumFun
            [Meta.Tactic.fun_prop] [0.015174] [✅️] applying: continuous_finset_sum
Build completed successfully.
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
