### PR TITLE
[Merged by Bors] - chore(Data/Fintype): golf entire `image_subtype_univ_ssubset_image_univ` using `grind`

### DIFF
--- a/Mathlib/Data/Fintype/Sum.lean
+++ b/Mathlib/Data/Fintype/Sum.lean
@@ -80,18 +80,7 @@ theorem image_subtype_ne_univ_eq_image_erase [Fintype α] [DecidableEq β] (k : 
 theorem image_subtype_univ_ssubset_image_univ [Fintype α] [DecidableEq β] (k : β) (b : α → β)
     (hk : k ∈ Finset.image b univ) (p : β → Prop) [DecidablePred p] (hp : ¬p k) :
     image (fun i : { a // p (b a) } => b ↑i) univ ⊂ image b univ := by
-  constructor
-  · intro x hx
-    rcases mem_image.1 hx with ⟨y, _, hy⟩
-    exact hy ▸ mem_image_of_mem b (mem_univ (y : α))
-  · intro h
-    rw [mem_image] at hk
-    rcases hk with ⟨k', _, hk'⟩
-    subst hk'
-    have := h (mem_image_of_mem b (mem_univ k'))
-    rw [mem_image] at this
-    rcases this with ⟨j, _, hj'⟩
-    exact hp (hj' ▸ j.2)
+  grind
 
 /-- Any injection from a finset `s` in a fintype `α` to a finset `t` of the same cardinality as `α`
 can be extended to a bijection between `α` and `t`. -/


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>image_subtype_univ_ssubset_image_univ</code>: 11 ms before, 33 ms after </summary>

### Trace profiling of `image_subtype_univ_ssubset_image_univ` before PR 28304
```diff
diff --git a/Mathlib/Data/Fintype/Sum.lean b/Mathlib/Data/Fintype/Sum.lean
index cb60d2d5ed..57b1de8b14 100644
--- a/Mathlib/Data/Fintype/Sum.lean
+++ b/Mathlib/Data/Fintype/Sum.lean
@@ -51,4 +51,2 @@ variable [Fintype α] [Fintype β]
 
-@[simp] lemma univ_disjSum_univ : univ.disjSum univ = (univ : Finset (α ⊕ β)) := rfl
-@[simp] lemma toLeft_univ : (univ : Finset (α ⊕ β)).toLeft = univ := by ext; simp
 @[simp] lemma toRight_univ : (univ : Finset (α ⊕ β)).toRight = univ := by ext; simp
@@ -79,2 +77,3 @@ theorem image_subtype_ne_univ_eq_image_erase [Fintype α] [DecidableEq β] (k :
 
+set_option trace.profiler true in
 theorem image_subtype_univ_ssubset_image_univ [Fintype α] [DecidableEq β] (k : β) (b : α → β)
```
```
ℹ [587/587] Built Mathlib.Data.Fintype.Sum
info: Mathlib/Data/Fintype/Sum.lean:79:0: [Elab.async] [0.011950] elaborating proof of image_subtype_univ_ssubset_image_univ
  [Elab.definition.value] [0.011215] image_subtype_univ_ssubset_image_univ
    [Elab.step] [0.010690] 
          constructor
          · intro x hx
            rcases mem_image.1 hx with ⟨y, _, hy⟩
            exact hy ▸ mem_image_of_mem b (mem_univ (y : α))
          · intro h
            rw [mem_image] at hk
            rcases hk with ⟨k', _, hk'⟩
            subst hk'
            have := h (mem_image_of_mem b (mem_univ k'))
            rw [mem_image] at this
            rcases this with ⟨j, _, hj'⟩
            exact hp (hj' ▸ j.2)
      [Elab.step] [0.010683] 
            constructor
            · intro x hx
              rcases mem_image.1 hx with ⟨y, _, hy⟩
              exact hy ▸ mem_image_of_mem b (mem_univ (y : α))
            · intro h
              rw [mem_image] at hk
              rcases hk with ⟨k', _, hk'⟩
              subst hk'
              have := h (mem_image_of_mem b (mem_univ k'))
              rw [mem_image] at this
              rcases this with ⟨j, _, hj'⟩
              exact hp (hj' ▸ j.2)
Build completed successfully.
```

### Trace profiling of `image_subtype_univ_ssubset_image_univ` after PR 28304
```diff
diff --git a/Mathlib/Data/Fintype/Sum.lean b/Mathlib/Data/Fintype/Sum.lean
index cb60d2d5ed..8821801e41 100644
--- a/Mathlib/Data/Fintype/Sum.lean
+++ b/Mathlib/Data/Fintype/Sum.lean
@@ -51,4 +51,2 @@ variable [Fintype α] [Fintype β]
 
-@[simp] lemma univ_disjSum_univ : univ.disjSum univ = (univ : Finset (α ⊕ β)) := rfl
-@[simp] lemma toLeft_univ : (univ : Finset (α ⊕ β)).toLeft = univ := by ext; simp
 @[simp] lemma toRight_univ : (univ : Finset (α ⊕ β)).toRight = univ := by ext; simp
@@ -79,2 +77,3 @@ theorem image_subtype_ne_univ_eq_image_erase [Fintype α] [DecidableEq β] (k :
 
+set_option trace.profiler true in
 theorem image_subtype_univ_ssubset_image_univ [Fintype α] [DecidableEq β] (k : β) (b : α → β)
@@ -82,14 +81,3 @@ theorem image_subtype_univ_ssubset_image_univ [Fintype α] [DecidableEq β] (k :
     image (fun i : { a // p (b a) } => b ↑i) univ ⊂ image b univ := by
-  constructor
-  · intro x hx
-    rcases mem_image.1 hx with ⟨y, _, hy⟩
-    exact hy ▸ mem_image_of_mem b (mem_univ (y : α))
-  · intro h
-    rw [mem_image] at hk
-    rcases hk with ⟨k', _, hk'⟩
-    subst hk'
-    have := h (mem_image_of_mem b (mem_univ k'))
-    rw [mem_image] at this
-    rcases this with ⟨j, _, hj'⟩
-    exact hp (hj' ▸ j.2)
+  grind
 
```
```
ℹ [587/587] Built Mathlib.Data.Fintype.Sum
info: Mathlib/Data/Fintype/Sum.lean:79:0: [Elab.async] [0.033152] elaborating proof of image_subtype_univ_ssubset_image_univ
  [Elab.definition.value] [0.032680] image_subtype_univ_ssubset_image_univ
    [Elab.step] [0.032532] grind
      [Elab.step] [0.032525] grind
        [Elab.step] [0.032516] grind
Build completed successfully.
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
