### PR TITLE
[Merged by Bors] - chore(MeasureTheory/Integral): golf entire `lintegral_mul_le_Lp_mul_Lq_of_ne_zero_of_eq_top` using `simp [*]`

### DIFF
--- a/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
+++ b/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
@@ -138,10 +138,7 @@ theorem lintegral_mul_eq_zero_of_lintegral_rpow_eq_zero {p : ℝ} (hp0 : 0 ≤ p
 theorem lintegral_mul_le_Lp_mul_Lq_of_ne_zero_of_eq_top {p q : ℝ} (hp0_lt : 0 < p) (hq0 : 0 ≤ q)
     {f g : α → ℝ≥0∞} (hf_top : ∫⁻ a, f a ^ p ∂μ = ⊤) (hg_nonzero : (∫⁻ a, g a ^ q ∂μ) ≠ 0) :
     (∫⁻ a, (f * g) a ∂μ) ≤ (∫⁻ a, f a ^ p ∂μ) ^ (1 / p) * (∫⁻ a, g a ^ q ∂μ) ^ (1 / q) := by
-  refine le_trans le_top (le_of_eq ?_)
-  have hp0_inv_lt : 0 < 1 / p := by simp [hp0_lt]
-  rw [hf_top, ENNReal.top_rpow_of_pos hp0_inv_lt]
-  simp [hq0, hg_nonzero]
+  simp_all
 
 /-- Hölder's inequality for functions `α → ℝ≥0∞`. The integral of the product of two functions
 is bounded by the product of their `ℒp` and `ℒq` seminorms when `p` and `q` are conjugate

--- a/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
+++ b/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
@@ -138,7 +138,7 @@ theorem lintegral_mul_eq_zero_of_lintegral_rpow_eq_zero {p : ℝ} (hp0 : 0 ≤ p
 theorem lintegral_mul_le_Lp_mul_Lq_of_ne_zero_of_eq_top {p q : ℝ} (hp0_lt : 0 < p) (hq0 : 0 ≤ q)
     {f g : α → ℝ≥0∞} (hf_top : ∫⁻ a, f a ^ p ∂μ = ⊤) (hg_nonzero : (∫⁻ a, g a ^ q ∂μ) ≠ 0) :
     (∫⁻ a, (f * g) a ∂μ) ≤ (∫⁻ a, f a ^ p ∂μ) ^ (1 / p) * (∫⁻ a, g a ^ q ∂μ) ^ (1 / q) := by
-  simp_all
+  simp [*]
 
 /-- Hölder's inequality for functions `α → ℝ≥0∞`. The integral of the product of two functions
 is bounded by the product of their `ℒp` and `ℒq` seminorms when `p` and `q` are conjugate


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>lintegral_mul_le_Lp_mul_Lq_of_ne_zero_of_eq_top</code>: 260 ms before, 204 ms after  🎉</summary>

### Trace profiling of `lintegral_mul_le_Lp_mul_Lq_of_ne_zero_of_eq_top` before PR 28306
```diff
diff --git a/Mathlib/MeasureTheory/Integral/MeanInequalities.lean b/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
index fdbafb94b4..97bccd3c06 100644
--- a/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
+++ b/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
@@ -135,6 +135,7 @@ theorem lintegral_mul_eq_zero_of_lintegral_rpow_eq_zero {p : ℝ} (hp0 : 0 ≤ p
   have hf_eq_zero : f =ᵐ[μ] 0 := ae_eq_zero_of_lintegral_rpow_eq_zero hp0 hf hf_zero
   exact hf_eq_zero.mul (ae_eq_refl g)
 
+set_option trace.profiler true in
 theorem lintegral_mul_le_Lp_mul_Lq_of_ne_zero_of_eq_top {p q : ℝ} (hp0_lt : 0 < p) (hq0 : 0 ≤ q)
     {f g : α → ℝ≥0∞} (hf_top : ∫⁻ a, f a ^ p ∂μ = ⊤) (hg_nonzero : (∫⁻ a, g a ^ q ∂μ) ≠ 0) :
     (∫⁻ a, (f * g) a ∂μ) ≤ (∫⁻ a, f a ^ p ∂μ) ^ (1 / p) * (∫⁻ a, g a ^ q ∂μ) ^ (1 / q) := by
```
```
ℹ [1969/1969] Built Mathlib.MeasureTheory.Integral.MeanInequalities (3.9s)
info: Mathlib/MeasureTheory/Integral/MeanInequalities.lean:139:0: [Elab.command] [0.050647] theorem lintegral_mul_le_Lp_mul_Lq_of_ne_zero_of_eq_top {p q : ℝ} (hp0_lt : 0 < p)
        (hq0 : 0 ≤ q) {f g : α → ℝ≥0∞} (hf_top : ∫⁻ a, f a ^ p ∂μ = ⊤) (hg_nonzero : (∫⁻ a, g a ^ q ∂μ) ≠ 0) :
        (∫⁻ a, (f * g) a ∂μ) ≤ (∫⁻ a, f a ^ p ∂μ) ^ (1 / p) * (∫⁻ a, g a ^ q ∂μ) ^ (1 / q) :=
      by
      refine le_trans le_top (le_of_eq ?_)
      have hp0_inv_lt : 0 < 1 / p := by simp [hp0_lt]
      rw [hf_top, ENNReal.top_rpow_of_pos hp0_inv_lt]
      simp [hq0, hg_nonzero]
  [Elab.definition.header] [0.049467] ENNReal.lintegral_mul_le_Lp_mul_Lq_of_ne_zero_of_eq_top
    [Elab.step] [0.031833] expected type: Sort ?u.6947, term
        (∫⁻ a, (f * g) a ∂μ) ≤ (∫⁻ a, f a ^ p ∂μ) ^ (1 / p) * (∫⁻ a, g a ^ q ∂μ) ^ (1 / q)
      [Elab.step] [0.031813] expected type: Sort ?u.6947, term
          binrel% LE.le✝ (∫⁻ a, (f * g) a ∂μ) ((∫⁻ a, f a ^ p ∂μ) ^ (1 / p) * (∫⁻ a, g a ^ q ∂μ) ^ (1 / q))
        [Elab.step] [0.014441] expected type: <not-available>, term
            lintegral✝ μ (expand_binders% (f✝ => f✝) a, (f * g) a)
          [Elab.step] [0.014137] expected type: α → ℝ≥0∞, term
              expand_binders% (f✝ => f✝) a, (f * g) a
            [Elab.step] [0.013995] expected type: α → ℝ≥0∞, term
                expand_binders% (f✝ => f✝) (a), (f * g) a
              [Elab.step] [0.013834] expected type: α → ℝ≥0∞, term
                  fun a : _ ↦ expand_binders% (f✝ => f✝), (f * g) a
                [Elab.step] [0.013825] expected type: α → ℝ≥0∞, term
                    failed to pretty print term (use 'set_option pp.rawOnError true' for raw representation)
                  [Elab.step] [0.013740] expected type: ℝ≥0∞, term
                      expand_binders% (f✝ => f✝), (f * g) a
                    [Elab.step] [0.013669] expected type: ℝ≥0∞, term
                        (f * g) a
                      [Elab.step] [0.013595] expected type: <not-available>, term
                          (f * g)
                        [Elab.step] [0.013587] expected type: <not-available>, term
                            f * g
                          [Elab.step] [0.013575] expected type: <not-available>, term
                              binop% HMul.hMul✝ f g
info: Mathlib/MeasureTheory/Integral/MeanInequalities.lean:139:0: [Elab.async] [0.267217] elaborating proof of ENNReal.lintegral_mul_le_Lp_mul_Lq_of_ne_zero_of_eq_top
  [Elab.definition.value] [0.260308] ENNReal.lintegral_mul_le_Lp_mul_Lq_of_ne_zero_of_eq_top
    [Elab.step] [0.253917] 
          refine le_trans le_top (le_of_eq ?_)
          have hp0_inv_lt : 0 < 1 / p := by simp [hp0_lt]
          rw [hf_top, ENNReal.top_rpow_of_pos hp0_inv_lt]
          simp [hq0, hg_nonzero]
      [Elab.step] [0.253899] 
            refine le_trans le_top (le_of_eq ?_)
            have hp0_inv_lt : 0 < 1 / p := by simp [hp0_lt]
            rw [hf_top, ENNReal.top_rpow_of_pos hp0_inv_lt]
            simp [hq0, hg_nonzero]
        [Elab.step] [0.048338] have hp0_inv_lt : 0 < 1 / p := by simp [hp0_lt]
          [Elab.step] [0.048186] focus
                refine
                  no_implicit_lambda%
                    (have hp0_inv_lt : 0 < 1 / p := ?body✝;
                    ?_)
                case body✝ => with_annotate_state"by" (simp [hp0_lt])
            [Elab.step] [0.048172] 
                  refine
                    no_implicit_lambda%
                      (have hp0_inv_lt : 0 < 1 / p := ?body✝;
                      ?_)
                  case body✝ => with_annotate_state"by" (simp [hp0_lt])
              [Elab.step] [0.048163] 
                    refine
                      no_implicit_lambda%
                        (have hp0_inv_lt : 0 < 1 / p := ?body✝;
                        ?_)
                    case body✝ => with_annotate_state"by" (simp [hp0_lt])
                [Elab.step] [0.044801] case body✝ => with_annotate_state"by" (simp [hp0_lt])
                  [Elab.step] [0.044710] with_annotate_state"by" (simp [hp0_lt])
                    [Elab.step] [0.044702] with_annotate_state"by" (simp [hp0_lt])
                      [Elab.step] [0.044693] with_annotate_state"by" (simp [hp0_lt])
                        [Elab.step] [0.044683] (simp [hp0_lt])
                          [Elab.step] [0.044676] simp [hp0_lt]
                            [Elab.step] [0.044668] simp [hp0_lt]
                              [Elab.step] [0.044654] simp [hp0_lt]
                                [Meta.synthInstance] [0.034531] ✅️ PosMulReflectLT ℝ
                                  [Meta.synthInstance] [0.025739] ❌️ apply @LinearOrderedCommGroupWithZero.toPosMulReflectLT to PosMulReflectLT
                                        ℝ
                                    [Meta.synthInstance.tryResolve] [0.025711] ❌️ PosMulReflectLT
                                          ℝ ≟ PosMulReflectLT ?m.111
                                      [Meta.isDefEq] [0.025701] ❌️ PosMulReflectLT ℝ =?= PosMulReflectLT ?m.111
                                        [Meta.isDefEq] [0.025619] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul
                                          [Meta.isDefEq.delta] [0.025561] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul
                                            [Meta.isDefEq] [0.025544] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass
                                              [Meta.isDefEq] [0.017854] ❌️ {
                                                    toMul :=
                                                      Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMul,
                                                    toZero :=
                                                      Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toZero,
                                                    zero_mul := ⋯,
                                                    mul_zero :=
                                                      ⋯ } =?= {
                                                    toMul :=
                                                      LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMul,
                                                    toZero :=
                                                      LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toZero,
                                                    zero_mul := ⋯, mul_zero := ⋯ }
                                                [Meta.isDefEq] [0.017762] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMul
                                                  [Meta.isDefEq] [0.010126] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulOneClass.2 =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulOneClass.2
                                                    [Meta.isDefEq] [0.010062] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMul
        [Elab.step] [0.193644] simp [hq0, hg_nonzero]
          [Meta.Tactic.simp.discharge] [0.054177] lintegral_of_isEmpty discharge ❌️
                IsEmpty α
            [Meta.synthInstance] [0.053375] ❌️ Nonempty α
          [Meta.Tactic.simp.discharge] [0.127689] top_mul discharge ✅️
                (∫⁻ (a : α), g a ^ q ∂μ) ^ q⁻¹ ≠ 0
            [Meta.synthInstance] [0.047527] ✅️ PosMulReflectLT ℝ
              [Meta.synthInstance] [0.035292] ❌️ apply @LinearOrderedCommGroupWithZero.toPosMulReflectLT to PosMulReflectLT
                    ℝ
                [Meta.synthInstance.tryResolve] [0.035266] ❌️ PosMulReflectLT ℝ ≟ PosMulReflectLT ?m.116
                  [Meta.isDefEq] [0.035246] ❌️ PosMulReflectLT ℝ =?= PosMulReflectLT ?m.116
                    [Meta.isDefEq] [0.035160] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul
                      [Meta.isDefEq.delta] [0.035084] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul
                        [Meta.isDefEq] [0.035066] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass
                          [Meta.isDefEq] [0.027017] ❌️ {
                                toMul := Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMul,
                                toZero := Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toZero,
                                zero_mul := ⋯,
                                mul_zero :=
                                  ⋯ } =?= {
                                toMul :=
                                  LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMul,
                                toZero :=
                                  LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toZero,
                                zero_mul := ⋯, mul_zero := ⋯ }
                            [Meta.isDefEq] [0.026909] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMul
                              [Meta.isDefEq.delta] [0.015054] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMul
                                [Meta.isDefEq] [0.015034] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulOneClass =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulOneClass
                                  [Meta.isDefEq.delta] [0.014918] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulOneClass =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulOneClass
                                    [Meta.isDefEq] [0.014899] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass
                                      [Meta.isDefEq] [0.012326] ❌️ {
                                            toOne := Field.toSemifield.toDivisionSemiring.toGroupWithZero.toOne,
                                            toMul := Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMul,
                                            one_mul := ⋯, mul_one := ⋯,
                                            toZero := Field.toSemifield.toDivisionSemiring.toGroupWithZero.toZero,
                                            zero_mul := ⋯,
                                            mul_zero :=
                                              ⋯ } =?= {
                                            toOne :=
                                              LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toOne,
                                            toMul :=
                                              LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMul,
                                            one_mul := ⋯, mul_one := ⋯,
                                            toZero :=
                                              LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toZero,
                                            zero_mul := ⋯, mul_zero := ⋯ }
                                        [Meta.isDefEq] [0.012261] ❌️ {
                                              toOne := Field.toSemifield.toDivisionSemiring.toGroupWithZero.toOne,
                                              toMul := Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMul,
                                              one_mul := ⋯,
                                              mul_one :=
                                                ⋯ } =?= {
                                              toOne :=
                                                LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toOne,
                                              toMul :=
                                                LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMul,
                                              one_mul := ⋯, mul_one := ⋯ }
                                          [Meta.isDefEq] [0.011813] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toOne =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toOne
                              [Meta.isDefEq] [0.011828] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulOneClass.2 =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulOneClass.2
                                [Meta.isDefEq] [0.011749] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMul
            [Meta.isDefEq] [0.045858] ❌️ ?a < 0 =?= q < 0
              [Meta.isDefEq] [0.045715] ❌️ 0 =?= 0
                [Meta.isDefEq] [0.045676] ❌️ Zero.toOfNat0 =?= Zero.toOfNat0
                  [Meta.isDefEq.delta] [0.020561] ❌️ Zero.toOfNat0 =?= Zero.toOfNat0
                    [Meta.isDefEq] [0.020550] ❌️ LinearOrderedCommMonoidWithZero.toCommMonoidWithZero.toMonoidWithZero.toMulZeroOneClass.toMulZeroClass.toZero =?= Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toZero
                      [Meta.isDefEq.delta] [0.013131] ❌️ LinearOrderedCommMonoidWithZero.toCommMonoidWithZero.toMonoidWithZero.toMulZeroOneClass.toMulZeroClass.toZero =?= Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toZero
                        [Meta.isDefEq] [0.013121] ❌️ LinearOrderedCommMonoidWithZero.toCommMonoidWithZero.toMonoidWithZero.toMulZeroOneClass.toMulZeroClass =?= Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass
                  [Meta.isDefEq] [0.025095] ❌️ { ofNat := Zero.zero } =?= { ofNat := Zero.zero }
                    [Meta.isDefEq] [0.025063] ❌️ Zero.zero =?= Zero.zero
                      [Meta.isDefEq.delta] [0.024654] ❌️ Zero.zero =?= Zero.zero
                        [Meta.isDefEq] [0.024642] ❌️ LinearOrderedCommMonoidWithZero.toCommMonoidWithZero.toMonoidWithZero.toMulZeroOneClass.toMulZeroClass.toZero =?= Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toZero
                          [Meta.isDefEq.delta] [0.019611] ❌️ LinearOrderedCommMonoidWithZero.toCommMonoidWithZero.toMonoidWithZero.toMulZeroOneClass.toMulZeroClass.toZero =?= Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toZero
                            [Meta.isDefEq] [0.019599] ❌️ LinearOrderedCommMonoidWithZero.toCommMonoidWithZero.toMonoidWithZero.toMulZeroOneClass.toMulZeroClass =?= Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass
                              [Meta.isDefEq] [0.012762] ❌️ {
                                    toMul :=
                                      LinearOrderedCommMonoidWithZero.toCommMonoidWithZero.toMonoidWithZero.toMulZeroOneClass.toMul,
                                    toZero :=
                                      LinearOrderedCommMonoidWithZero.toCommMonoidWithZero.toMonoidWithZero.toMulZeroOneClass.toZero,
                                    zero_mul := ⋯,
                                    mul_zero :=
                                      ⋯ } =?= {
                                    toMul :=
                                      Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMul,
                                    toZero :=
                                      Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toZero,
                                    zero_mul := ⋯, mul_zero := ⋯ }
                                [Meta.isDefEq] [0.012718] ❌️ LinearOrderedCommMonoidWithZero.toCommMonoidWithZero.toMonoidWithZero.toMulZeroOneClass.toMul =?= Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMul
Build completed successfully (1969 jobs).
```

### Trace profiling of `lintegral_mul_le_Lp_mul_Lq_of_ne_zero_of_eq_top` after PR 28306
```diff
diff --git a/Mathlib/MeasureTheory/Integral/MeanInequalities.lean b/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
index fdbafb94b4..248c56a039 100644
--- a/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
+++ b/Mathlib/MeasureTheory/Integral/MeanInequalities.lean
@@ -135,13 +135,11 @@ theorem lintegral_mul_eq_zero_of_lintegral_rpow_eq_zero {p : ℝ} (hp0 : 0 ≤ p
   have hf_eq_zero : f =ᵐ[μ] 0 := ae_eq_zero_of_lintegral_rpow_eq_zero hp0 hf hf_zero
   exact hf_eq_zero.mul (ae_eq_refl g)
 
+set_option trace.profiler true in
 theorem lintegral_mul_le_Lp_mul_Lq_of_ne_zero_of_eq_top {p q : ℝ} (hp0_lt : 0 < p) (hq0 : 0 ≤ q)
     {f g : α → ℝ≥0∞} (hf_top : ∫⁻ a, f a ^ p ∂μ = ⊤) (hg_nonzero : (∫⁻ a, g a ^ q ∂μ) ≠ 0) :
     (∫⁻ a, (f * g) a ∂μ) ≤ (∫⁻ a, f a ^ p ∂μ) ^ (1 / p) * (∫⁻ a, g a ^ q ∂μ) ^ (1 / q) := by
-  refine le_trans le_top (le_of_eq ?_)
-  have hp0_inv_lt : 0 < 1 / p := by simp [hp0_lt]
-  rw [hf_top, ENNReal.top_rpow_of_pos hp0_inv_lt]
-  simp [hq0, hg_nonzero]
+  simp [*]
 
 /-- Hölder's inequality for functions `α → ℝ≥0∞`. The integral of the product of two functions
 is bounded by the product of their `ℒp` and `ℒq` seminorms when `p` and `q` are conjugate
```
```
ℹ [1969/1969] Built Mathlib.MeasureTheory.Integral.MeanInequalities (3.7s)
info: Mathlib/MeasureTheory/Integral/MeanInequalities.lean:139:0: [Elab.command] [0.052906] theorem lintegral_mul_le_Lp_mul_Lq_of_ne_zero_of_eq_top {p q : ℝ} (hp0_lt : 0 < p)
        (hq0 : 0 ≤ q) {f g : α → ℝ≥0∞} (hf_top : ∫⁻ a, f a ^ p ∂μ = ⊤) (hg_nonzero : (∫⁻ a, g a ^ q ∂μ) ≠ 0) :
        (∫⁻ a, (f * g) a ∂μ) ≤ (∫⁻ a, f a ^ p ∂μ) ^ (1 / p) * (∫⁻ a, g a ^ q ∂μ) ^ (1 / q) := by simp [*]
  [Elab.definition.header] [0.052014] ENNReal.lintegral_mul_le_Lp_mul_Lq_of_ne_zero_of_eq_top
    [Elab.step] [0.041552] expected type: Sort ?u.6947, term
        (∫⁻ a, (f * g) a ∂μ) ≤ (∫⁻ a, f a ^ p ∂μ) ^ (1 / p) * (∫⁻ a, g a ^ q ∂μ) ^ (1 / q)
      [Elab.step] [0.041539] expected type: Sort ?u.6947, term
          binrel% LE.le✝ (∫⁻ a, (f * g) a ∂μ) ((∫⁻ a, f a ^ p ∂μ) ^ (1 / p) * (∫⁻ a, g a ^ q ∂μ) ^ (1 / q))
        [Elab.step] [0.017111] expected type: <not-available>, term
            lintegral✝ μ (expand_binders% (f✝ => f✝) a, (f * g) a)
          [Elab.step] [0.016628] expected type: α → ℝ≥0∞, term
              expand_binders% (f✝ => f✝) a, (f * g) a
            [Elab.step] [0.016451] expected type: α → ℝ≥0∞, term
                expand_binders% (f✝ => f✝) (a), (f * g) a
              [Elab.step] [0.016260] expected type: α → ℝ≥0∞, term
                  fun a : _ ↦ expand_binders% (f✝ => f✝), (f * g) a
                [Elab.step] [0.016250] expected type: α → ℝ≥0∞, term
                    failed to pretty print term (use 'set_option pp.rawOnError true' for raw representation)
                  [Elab.step] [0.016157] expected type: ℝ≥0∞, term
                      expand_binders% (f✝ => f✝), (f * g) a
                    [Elab.step] [0.016093] expected type: ℝ≥0∞, term
                        (f * g) a
                      [Elab.step] [0.016010] expected type: <not-available>, term
                          (f * g)
                        [Elab.step] [0.016002] expected type: <not-available>, term
                            f * g
                          [Elab.step] [0.015906] expected type: <not-available>, term
                              binop% HMul.hMul✝ f g
                            [Meta.synthInstance] [0.010437] ✅️ HMul (α → ℝ≥0∞) (α → ℝ≥0∞) (α → ℝ≥0∞)
info: Mathlib/MeasureTheory/Integral/MeanInequalities.lean:139:0: [Elab.async] [0.204474] elaborating proof of ENNReal.lintegral_mul_le_Lp_mul_Lq_of_ne_zero_of_eq_top
  [Elab.definition.value] [0.203593] ENNReal.lintegral_mul_le_Lp_mul_Lq_of_ne_zero_of_eq_top
    [Elab.step] [0.201562] simp [*]
      [Elab.step] [0.201547] simp [*]
        [Elab.step] [0.201527] simp [*]
          [Meta.Tactic.simp.discharge] [0.049467] lintegral_of_isEmpty discharge ❌️
                IsEmpty α
            [Meta.synthInstance] [0.048702] ❌️ Nonempty α
          [Meta.Tactic.simp.discharge] [0.052874] top_rpow_of_pos discharge ✅️
                0 < p⁻¹
            [Meta.synthInstance] [0.045943] ✅️ PosMulReflectLT ℝ
              [Meta.synthInstance] [0.036937] ❌️ apply @LinearOrderedCommGroupWithZero.toPosMulReflectLT to PosMulReflectLT
                    ℝ
                [Meta.synthInstance.tryResolve] [0.036876] ❌️ PosMulReflectLT ℝ ≟ PosMulReflectLT ?m.86
                  [Meta.isDefEq] [0.036845] ❌️ PosMulReflectLT ℝ =?= PosMulReflectLT ?m.86
                    [Meta.isDefEq] [0.036663] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul
                      [Meta.isDefEq.delta] [0.036546] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul
                        [Meta.isDefEq] [0.036506] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass
                          [Meta.isDefEq.delta] [0.012740] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass
                            [Meta.isDefEq] [0.012707] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass
                          [Meta.isDefEq] [0.023726] ❌️ {
                                toMul := Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMul,
                                toZero := Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toZero,
                                zero_mul := ⋯,
                                mul_zero :=
                                  ⋯ } =?= {
                                toMul :=
                                  LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMul,
                                toZero :=
                                  LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toZero,
                                zero_mul := ⋯, mul_zero := ⋯ }
                            [Meta.isDefEq] [0.023593] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMul
                              [Meta.isDefEq] [0.013577] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulOneClass.2 =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulOneClass.2
                                [Meta.isDefEq] [0.013507] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMul
          [Meta.Tactic.simp.discharge] [0.077838] top_mul discharge ✅️
                (∫⁻ (a : α), g a ^ q ∂μ) ^ q⁻¹ ≠ 0
            [Meta.isDefEq] [0.048486] ❌️ ?a < 0 =?= q < 0
              [Meta.isDefEq] [0.048339] ❌️ 0 =?= 0
                [Meta.isDefEq] [0.048295] ❌️ Zero.toOfNat0 =?= Zero.toOfNat0
                  [Meta.isDefEq.delta] [0.032000] ❌️ Zero.toOfNat0 =?= Zero.toOfNat0
                    [Meta.isDefEq] [0.031988] ❌️ LinearOrderedCommMonoidWithZero.toCommMonoidWithZero.toMonoidWithZero.toMulZeroOneClass.toMulZeroClass.toZero =?= Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toZero
                      [Meta.isDefEq.delta] [0.019662] ❌️ LinearOrderedCommMonoidWithZero.toCommMonoidWithZero.toMonoidWithZero.toMulZeroOneClass.toMulZeroClass.toZero =?= Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toZero
                        [Meta.isDefEq] [0.019652] ❌️ LinearOrderedCommMonoidWithZero.toCommMonoidWithZero.toMonoidWithZero.toMulZeroOneClass.toMulZeroClass =?= Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass
                          [Meta.isDefEq] [0.012541] ❌️ {
                                toMul :=
                                  LinearOrderedCommMonoidWithZero.toCommMonoidWithZero.toMonoidWithZero.toMulZeroOneClass.toMul,
                                toZero :=
                                  LinearOrderedCommMonoidWithZero.toCommMonoidWithZero.toMonoidWithZero.toMulZeroOneClass.toZero,
                                zero_mul := ⋯,
                                mul_zero :=
                                  ⋯ } =?= {
                                toMul := Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMul,
                                toZero := Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toZero,
                                zero_mul := ⋯, mul_zero := ⋯ }
                            [Meta.isDefEq] [0.012413] ❌️ LinearOrderedCommMonoidWithZero.toCommMonoidWithZero.toMonoidWithZero.toMulZeroOneClass.toMul =?= Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMul
                      [Meta.isDefEq] [0.012296] ❌️ LinearOrderedCommMonoidWithZero.toCommMonoidWithZero.toMonoidWithZero.toMulZeroOneClass.toMulZeroClass.2 =?= Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.2
                        [Meta.isDefEq] [0.012233] ❌️ LinearOrderedCommMonoidWithZero.toCommMonoidWithZero.toMonoidWithZero.toMulZeroOneClass.toZero =?= Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toZero
                          [Meta.isDefEq.delta] [0.010570] ❌️ LinearOrderedCommMonoidWithZero.toCommMonoidWithZero.toMonoidWithZero.toMulZeroOneClass.toZero =?= Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toZero
                            [Meta.isDefEq] [0.010525] ❌️ LinearOrderedCommMonoidWithZero.toCommMonoidWithZero.toMonoidWithZero.toMulZeroOneClass =?= Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass
                  [Meta.isDefEq] [0.016272] ❌️ { ofNat := Zero.zero } =?= { ofNat := Zero.zero }
                    [Meta.isDefEq] [0.016242] ❌️ Zero.zero =?= Zero.zero
                      [Meta.isDefEq.delta] [0.015744] ❌️ Zero.zero =?= Zero.zero
                        [Meta.isDefEq] [0.015735] ❌️ LinearOrderedCommMonoidWithZero.toCommMonoidWithZero.toMonoidWithZero.toMulZeroOneClass.toMulZeroClass.toZero =?= Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toZero
                          [Meta.isDefEq.delta] [0.010244] ❌️ LinearOrderedCommMonoidWithZero.toCommMonoidWithZero.toMonoidWithZero.toMulZeroOneClass.toMulZeroClass.toZero =?= Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toZero
                            [Meta.isDefEq] [0.010237] ❌️ LinearOrderedCommMonoidWithZero.toCommMonoidWithZero.toMonoidWithZero.toMulZeroOneClass.toMulZeroClass =?= Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass
Build completed successfully (1969 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
