### PR TITLE
[Merged by Bors] - chore(MeasureTheory/Function/SpecialFunctions): golf entire `AEMeasurable.inner` using `fun_prop`

### DIFF
--- a/Mathlib/MeasureTheory/Function/SpecialFunctions/Inner.lean
+++ b/Mathlib/MeasureTheory/Function/SpecialFunctions/Inner.lean
@@ -38,10 +38,7 @@ theorem Measurable.inner_const {_ : MeasurableSpace α} [MeasurableSpace E] [Ope
 theorem AEMeasurable.inner {m : MeasurableSpace α} [MeasurableSpace E] [OpensMeasurableSpace E]
     [SecondCountableTopology E] {μ : MeasureTheory.Measure α} {f g : α → E}
     (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) : AEMeasurable (fun x => ⟪f x, g x⟫) μ := by
-  refine ⟨fun x => ⟪hf.mk f x, hg.mk g x⟫, hf.measurable_mk.inner hg.measurable_mk, ?_⟩
-  refine hf.ae_eq_mk.mp (hg.ae_eq_mk.mono fun x hxg hxf => ?_)
-  dsimp only
-  congr
+  fun_prop
 
 @[measurability, fun_prop]
 theorem AEMeasurable.const_inner {m : MeasurableSpace α} [MeasurableSpace E]


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>AEMeasurable.inner</code>: <10 ms before, <10 ms after  🎉</summary>

### Trace profiling of `AEMeasurable.inner` before PR 28307
```diff
diff --git a/Mathlib/MeasureTheory/Function/SpecialFunctions/Inner.lean b/Mathlib/MeasureTheory/Function/SpecialFunctions/Inner.lean
index 7f8b6c921b..8a68cffed5 100644
--- a/Mathlib/MeasureTheory/Function/SpecialFunctions/Inner.lean
+++ b/Mathlib/MeasureTheory/Function/SpecialFunctions/Inner.lean
@@ -36,2 +36,3 @@ theorem Measurable.inner_const {_ : MeasurableSpace α} [MeasurableSpace E] [Ope
 
+set_option trace.profiler true in
 @[aesop safe 20 apply (rule_sets := [Measurable]), fun_prop]
```
```
ℹ [1920/1920] Built Mathlib.MeasureTheory.Function.SpecialFunctions.Inner
info: Mathlib/MeasureTheory/Function/SpecialFunctions/Inner.lean:38:0: [Elab.command] [0.012089] @[aesop safe 20 apply (rule_sets := [Measurable]), fun_prop]
    theorem inner {m : MeasurableSpace α} [MeasurableSpace E] [OpensMeasurableSpace E] [SecondCountableTopology E]
        {μ : MeasureTheory.Measure α} {f g : α → E} (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) :
        AEMeasurable (fun x => ⟪f x, g x⟫) μ :=
      by
      refine ⟨fun x => ⟪hf.mk f x, hg.mk g x⟫, hf.measurable_mk.inner hg.measurable_mk, ?_⟩
      refine hf.ae_eq_mk.mp (hg.ae_eq_mk.mono fun x hxg hxf => ?_)
      dsimp only
      congr
info: Mathlib/MeasureTheory/Function/SpecialFunctions/Inner.lean:38:0: [Elab.command] [0.012280] @[aesop safe 20 apply (rule_sets := [Measurable]), fun_prop]
    theorem AEMeasurable.inner {m : MeasurableSpace α} [MeasurableSpace E] [OpensMeasurableSpace E]
        [SecondCountableTopology E] {μ : MeasureTheory.Measure α} {f g : α → E} (hf : AEMeasurable f μ)
        (hg : AEMeasurable g μ) : AEMeasurable (fun x => ⟪f x, g x⟫) μ :=
      by
      refine ⟨fun x => ⟪hf.mk f x, hg.mk g x⟫, hf.measurable_mk.inner hg.measurable_mk, ?_⟩
      refine hf.ae_eq_mk.mp (hg.ae_eq_mk.mono fun x hxg hxf => ?_)
      dsimp only
      congr
Build completed successfully.
```

### Trace profiling of `AEMeasurable.inner` after PR 28307
```diff
diff --git a/Mathlib/MeasureTheory/Function/SpecialFunctions/Inner.lean b/Mathlib/MeasureTheory/Function/SpecialFunctions/Inner.lean
index 7f8b6c921b..0500a27d89 100644
--- a/Mathlib/MeasureTheory/Function/SpecialFunctions/Inner.lean
+++ b/Mathlib/MeasureTheory/Function/SpecialFunctions/Inner.lean
@@ -36,2 +36,3 @@ theorem Measurable.inner_const {_ : MeasurableSpace α} [MeasurableSpace E] [Ope
 
+set_option trace.profiler true in
 @[aesop safe 20 apply (rule_sets := [Measurable]), fun_prop]
@@ -40,6 +41,3 @@ theorem AEMeasurable.inner {m : MeasurableSpace α} [MeasurableSpace E] [OpensMe
     (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) : AEMeasurable (fun x => ⟪f x, g x⟫) μ := by
-  refine ⟨fun x => ⟪hf.mk f x, hg.mk g x⟫, hf.measurable_mk.inner hg.measurable_mk, ?_⟩
-  refine hf.ae_eq_mk.mp (hg.ae_eq_mk.mono fun x hxg hxf => ?_)
-  dsimp only
-  congr
+  fun_prop
 
```
```
ℹ [1920/1920] Built Mathlib.MeasureTheory.Function.SpecialFunctions.Inner
info: Mathlib/MeasureTheory/Function/SpecialFunctions/Inner.lean:38:0: [Elab.command] [0.011915] @[aesop safe 20 apply (rule_sets := [Measurable]), fun_prop]
    theorem inner {m : MeasurableSpace α} [MeasurableSpace E] [OpensMeasurableSpace E] [SecondCountableTopology E]
        {μ : MeasureTheory.Measure α} {f g : α → E} (hf : AEMeasurable f μ) (hg : AEMeasurable g μ) :
        AEMeasurable (fun x => ⟪f x, g x⟫) μ := by fun_prop
info: Mathlib/MeasureTheory/Function/SpecialFunctions/Inner.lean:38:0: [Elab.command] [0.012091] @[aesop safe 20 apply (rule_sets := [Measurable]), fun_prop]
    theorem AEMeasurable.inner {m : MeasurableSpace α} [MeasurableSpace E] [OpensMeasurableSpace E]
        [SecondCountableTopology E] {μ : MeasureTheory.Measure α} {f g : α → E} (hf : AEMeasurable f μ)
        (hg : AEMeasurable g μ) : AEMeasurable (fun x => ⟪f x, g x⟫) μ := by fun_prop
Build completed successfully.
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
