### PR TITLE
[Merged by Bors] - chore(Data/Array): golf entire `extract_append_left'` using `simp`

### DIFF
--- a/Mathlib/Data/Array/Extract.lean
+++ b/Mathlib/Data/Array/Extract.lean
@@ -27,11 +27,7 @@ and should be upstreamed to replace that.
 -/
 theorem extract_append_left' {a b : Array α} {i j : Nat} (h : j ≤ a.size) :
     (a ++ b).extract i j = a.extract i j := by
-  apply ext
-  · simp only [size_extract, size_append]
-    omega
-  · intro h1 h2 h3
-    rw [getElem_extract, getElem_append_left, getElem_extract]
+  simp_all
 
 /--
 This is a stronger version of `Array.extract_append_right`,

--- a/Mathlib/Data/Array/Extract.lean
+++ b/Mathlib/Data/Array/Extract.lean
@@ -27,7 +27,7 @@ and should be upstreamed to replace that.
 -/
 theorem extract_append_left' {a b : Array α} {i j : Nat} (h : j ≤ a.size) :
     (a ++ b).extract i j = a.extract i j := by
-  simp_all
+  simp [h]
 
 /--
 This is a stronger version of `Array.extract_append_right`,


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>extract_append_left'</code>: 24 ms before, <10 ms after  🎉</summary>

### Trace profiling of `extract_append_left'` before PR 28310
```diff
diff --git a/Mathlib/Data/Array/Extract.lean b/Mathlib/Data/Array/Extract.lean
index 36272f553e..b09b7733a2 100644
--- a/Mathlib/Data/Array/Extract.lean
+++ b/Mathlib/Data/Array/Extract.lean
@@ -21,6 +21,7 @@ theorem extract_eq_nil_of_start_eq_end {a : Array α} :
   refine extract_empty_of_stop_le_start ?h
   exact Nat.le_refl i
 
+set_option trace.profiler true in
 /--
 This is a stronger version of `Array.extract_append_left`,
 and should be upstreamed to replace that.
```
```
ℹ [34/34] Built Mathlib.Data.Array.Extract
info: Mathlib/Data/Array/Extract.lean:25:0: [Elab.async] [0.024455] elaborating proof of Array.extract_append_left'
  [Elab.definition.value] [0.023883] Array.extract_append_left'
    [Elab.step] [0.023625] 
          apply ext
          · simp only [size_extract, size_append]
            omega
          · intro h1 h2 h3
            rw [getElem_extract, getElem_append_left, getElem_extract]
      [Elab.step] [0.023619] 
            apply ext
            · simp only [size_extract, size_append]
              omega
            · intro h1 h2 h3
              rw [getElem_extract, getElem_append_left, getElem_extract]
        [Elab.step] [0.021656] ·
              simp only [size_extract, size_append]
              omega
          [Elab.step] [0.021642] 
                simp only [size_extract, size_append]
                omega
            [Elab.step] [0.021637] 
                  simp only [size_extract, size_append]
                  omega
              [Elab.step] [0.018777] omega
info: Mathlib/Data/Array/Extract.lean:33:4: [Elab.async] [0.041278] Lean.addDecl
  [Kernel] [0.041260] typechecking declarations [Array.extract_append_left'._proof_1_1]
Build completed successfully.
```

### Trace profiling of `extract_append_left'` after PR 28310
```diff
diff --git a/Mathlib/Data/Array/Extract.lean b/Mathlib/Data/Array/Extract.lean
index 36272f553e..1cdfe6345d 100644
--- a/Mathlib/Data/Array/Extract.lean
+++ b/Mathlib/Data/Array/Extract.lean
@@ -21,17 +21,14 @@ theorem extract_eq_nil_of_start_eq_end {a : Array α} :
   refine extract_empty_of_stop_le_start ?h
   exact Nat.le_refl i
 
+set_option trace.profiler true in
 /--
 This is a stronger version of `Array.extract_append_left`,
 and should be upstreamed to replace that.
 -/
 theorem extract_append_left' {a b : Array α} {i j : Nat} (h : j ≤ a.size) :
     (a ++ b).extract i j = a.extract i j := by
-  apply ext
-  · simp only [size_extract, size_append]
-    omega
-  · intro h1 h2 h3
-    rw [getElem_extract, getElem_append_left, getElem_extract]
+  simp_all
 
 /--
 This is a stronger version of `Array.extract_append_right`,
```
```
✔ [34/34] Built Mathlib.Data.Array.Extract
Build completed successfully.
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
