### PR TITLE
feat(Tactic/NormNum): better trace nodes

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6711,6 +6711,7 @@ import Mathlib.Util.Superscript
 import Mathlib.Util.SynthesizeUsing
 import Mathlib.Util.Tactic
 import Mathlib.Util.TermReduce
+import Mathlib.Util.Trace
 import Mathlib.Util.TransImports
 import Mathlib.Util.WhatsNew
 import Mathlib.Util.WithWeakNamespace

--- a/Mathlib/Util/Trace.lean
+++ b/Mathlib/Util/Trace.lean
@@ -14,8 +14,8 @@ namespace Mathlib.Meta
 
 /--
 A wrapper around `Lean.withTraceNode` where every node wraps a function `k : α → m β`.
-The resulting trace node includes output of the form `{a} ⇒ {(← k a)}` upon success,
-and `{a} ⇒ {err}` on error.
+The resulting trace node includes output of the form `{a} ==> {(← k a)}` upon success,
+and `{a} ==> {err}` on error.
 
 We do not include this result on the first line, as it would thwart attempts to group trace nodes
 from the same function name within the Firefox profiler data export.
@@ -25,7 +25,7 @@ Typically this should be used in extensible tactics like `norm_num` and `positiv
 def withTraceNodeApplication
   {α β : Type} {m : Type → Type} [Monad m] [MonadTrace m] [MonadRef m] [AddMessageContext m]
   [ToMessageData α] [ToMessageData β]
-  [MonadOptions m] [always : MonadAlwaysExcept Exception m] [MonadLiftT BaseIO m] (cls : Name)
+  [MonadOptions m] [MonadAlwaysExcept Exception m] [MonadLiftT BaseIO m] (cls : Name)
   (k_name : Name) (k : α → m β) (a : α) (collapsed : Bool := true) (tag : String := "") :
     m β :=
   withTraceNode cls

--- a/Mathlib/Util/Trace.lean
+++ b/Mathlib/Util/Trace.lean
@@ -1,0 +1,43 @@
+/-
+Copyright (c) 2025 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+-/
+
+import Mathlib.Init
+
+/-! # Tracing utilities -/
+
+open Lean
+
+namespace Mathlib.Meta
+
+/--
+A wrapper around `Lean.withTraceNode` where every node wraps a function `k : α → m β`.
+The resulting trace node includes output of the form `{a} ⇒ {(← k a)}` upon success,
+and `{a} ⇒ {err}` on error.
+
+Typically this should be used in extensible tactics like `norm_num` and `positivity`.
+-/
+def withTraceNodeApplication
+  {α β : Type} {m : Type → Type} [Monad m] [MonadTrace m] [MonadRef m] [AddMessageContext m]
+  [ToMessageData α] [ToMessageData β]
+  [MonadOptions m] [always : MonadAlwaysExcept Exception m] [MonadLiftT BaseIO m] (cls : Name)
+  (k_name : Name) (k : α → m β) (a : α) (collapsed : Bool := true) (tag : String := "") :
+    m β :=
+  withTraceNode cls
+    (return m!"{exceptEmoji ·} {.ofConstName k_name}")
+    (collapsed := collapsed) (tag := tag)
+    do
+      unless ← Lean.isTracingEnabledFor cls do
+        return ← k a
+      let _ := always.except
+      try
+        let b ← k a
+        Lean.addTrace cls <| .group m!"{a}{Format.line}⇒ {.nest 2 (toMessageData b)}"
+        return b
+      catch err =>
+        Lean.addTrace cls <| .group m!"{a}{Format.line}⇒ {.nest 2 err.toMessageData}"
+        throw err
+
+end Mathlib.Meta

--- a/Mathlib/Util/Trace.lean
+++ b/Mathlib/Util/Trace.lean
@@ -17,6 +17,9 @@ A wrapper around `Lean.withTraceNode` where every node wraps a function `k : α 
 The resulting trace node includes output of the form `{a} ⇒ {(← k a)}` upon success,
 and `{a} ⇒ {err}` on error.
 
+We do not include this result on the first line, as it would thwart attempts to group trace nodes
+from the same function name within the Firefox profiler data export.
+
 Typically this should be used in extensible tactics like `norm_num` and `positivity`.
 -/
 def withTraceNodeApplication
@@ -34,10 +37,10 @@ def withTraceNodeApplication
       let _ := always.except
       try
         let b ← k a
-        Lean.addTrace cls <| .group m!"{a}{Format.line}⇒ {.nest 2 (toMessageData b)}"
+        Lean.addTrace cls <| .group m!"{a}{Format.line}==> {.nest 2 (toMessageData b)}"
         return b
       catch err =>
-        Lean.addTrace cls <| .group m!"{a}{Format.line}⇒ {.nest 2 err.toMessageData}"
+        Lean.addTrace cls <| .group m!"{a}{Format.line}==> {.nest 2 err.toMessageData}"
         throw err
 
 end Mathlib.Meta

--- a/MathlibTest/norm_num_trace.lean
+++ b/MathlibTest/norm_num_trace.lean
@@ -17,16 +17,16 @@ open Mathlib.Meta.NormNum
 trace:
 [Tactic.norm_num] ✅️ evalMul
   [Tactic.norm_num] ✅️ evalOfNat
-    [Tactic.norm_num] 2 ⇒ isNat 2 (⋯)
+    [Tactic.norm_num] 2 ==> isNat 2 (⋯)
   [Tactic.norm_num] ✅️ evalAdd
     [Tactic.norm_num] ✅️ evalOfNat
-      [Tactic.norm_num] 1 ⇒ isNat 1 (⋯)
+      [Tactic.norm_num] 1 ==> isNat 1 (⋯)
     [Tactic.norm_num] ✅️ evalOfNat
-      [Tactic.norm_num] 1 ⇒ isNat 1 (⋯)
-    [Tactic.norm_num] 1 + 1 ⇒ isNat 2 (⋯)
-  [Tactic.norm_num] 2 * (1 + 1) ⇒ isNat 4 (⋯)
+      [Tactic.norm_num] 1 ==> isNat 1 (⋯)
+    [Tactic.norm_num] 1 + 1 ==> isNat 2 (⋯)
+  [Tactic.norm_num] 2 * (1 + 1) ==> isNat 4 (⋯)
 [Tactic.norm_num] ✅️ evalTrue
-  [Tactic.norm_num] True ⇒ isTrue (True.intro)
+  [Tactic.norm_num] True ==> isTrue (True.intro)
 -/
 #guard_msgs in
 example : 2 * (1 + 1) = 4 := by
@@ -36,52 +36,52 @@ set_option linter.unusedTactic false in
 /--
 trace: [Tactic.norm_num] ❌️ evalMul
   [Tactic.norm_num] ✅️ evalOfNat
-    [Tactic.norm_num] 2 ⇒ isNat 2 (⋯)
+    [Tactic.norm_num] 2 ==> isNat 2 (⋯)
   [Tactic.norm_num] ❌️ evalAdd
     [Tactic.norm_num] ✅️ evalOfNat
-      [Tactic.norm_num] 1 ⇒ isNat 1 (⋯)
-    [Tactic.norm_num] 1 + x ⇒ x: no norm_nums apply
-  [Tactic.norm_num] 2 * (1 + x) ⇒ 1 + x: no norm_nums apply
+      [Tactic.norm_num] 1 ==> isNat 1 (⋯)
+    [Tactic.norm_num] 1 + x ==> x: no norm_nums apply
+  [Tactic.norm_num] 2 * (1 + x) ==> 1 + x: no norm_nums apply
 [Tactic.norm_num] ❌️ evalAdd
   [Tactic.norm_num] ✅️ evalOfNat
-    [Tactic.norm_num] 1 ⇒ isNat 1 (⋯)
-  [Tactic.norm_num] 1 + x ⇒ x: no norm_nums apply
+    [Tactic.norm_num] 1 ==> isNat 1 (⋯)
+  [Tactic.norm_num] 1 + x ==> x: no norm_nums apply
 [Tactic.norm_num] ❌️ evalAdd
   [Tactic.norm_num] ✅️ evalOfNat
-    [Tactic.norm_num] 1 ⇒ isNat 1 (⋯)
-  [Tactic.norm_num] 1 + x ⇒ x: no norm_nums apply
+    [Tactic.norm_num] 1 ==> isNat 1 (⋯)
+  [Tactic.norm_num] 1 + x ==> x: no norm_nums apply
 [Tactic.norm_num] ❌️ evalMul
   [Tactic.norm_num] ✅️ evalOfNat
-    [Tactic.norm_num] 2 ⇒ isNat 2 (⋯)
+    [Tactic.norm_num] 2 ==> isNat 2 (⋯)
   [Tactic.norm_num] ❌️ evalAdd
     [Tactic.norm_num] ✅️ evalOfNat
-      [Tactic.norm_num] 1 ⇒ isNat 1 (⋯)
-    [Tactic.norm_num] 1 + x ⇒ x: no norm_nums apply
-  [Tactic.norm_num] 2 * (1 + x) ⇒ 1 + x: no norm_nums apply
+      [Tactic.norm_num] 1 ==> isNat 1 (⋯)
+    [Tactic.norm_num] 1 + x ==> x: no norm_nums apply
+  [Tactic.norm_num] 2 * (1 + x) ==> 1 + x: no norm_nums apply
 [Tactic.norm_num] ❌️ evalAdd
   [Tactic.norm_num] ✅️ evalOfNat
-    [Tactic.norm_num] 2 ⇒ isNat 2 (⋯)
+    [Tactic.norm_num] 2 ==> isNat 2 (⋯)
   [Tactic.norm_num] ❌️ evalMul
     [Tactic.norm_num] ✅️ evalOfNat
-      [Tactic.norm_num] 2 ⇒ isNat 2 (⋯)
-    [Tactic.norm_num] 2 * x ⇒ x: no norm_nums apply
-  [Tactic.norm_num] 2 + 2 * x ⇒ 2 * x: no norm_nums apply
+      [Tactic.norm_num] 2 ==> isNat 2 (⋯)
+    [Tactic.norm_num] 2 * x ==> x: no norm_nums apply
+  [Tactic.norm_num] 2 + 2 * x ==> 2 * x: no norm_nums apply
 [Tactic.norm_num] ❌️ evalMul
   [Tactic.norm_num] ✅️ evalOfNat
-    [Tactic.norm_num] 2 ⇒ isNat 2 (⋯)
-  [Tactic.norm_num] 2 * x ⇒ x: no norm_nums apply
+    [Tactic.norm_num] 2 ==> isNat 2 (⋯)
+  [Tactic.norm_num] 2 * x ==> x: no norm_nums apply
 [Tactic.norm_num] ❌️ evalMul
   [Tactic.norm_num] ✅️ evalOfNat
-    [Tactic.norm_num] 2 ⇒ isNat 2 (⋯)
-  [Tactic.norm_num] 2 * x ⇒ x: no norm_nums apply
+    [Tactic.norm_num] 2 ==> isNat 2 (⋯)
+  [Tactic.norm_num] 2 * x ==> x: no norm_nums apply
 [Tactic.norm_num] ❌️ evalAdd
   [Tactic.norm_num] ✅️ evalOfNat
-    [Tactic.norm_num] 2 ⇒ isNat 2 (⋯)
+    [Tactic.norm_num] 2 ==> isNat 2 (⋯)
   [Tactic.norm_num] ❌️ evalMul
     [Tactic.norm_num] ✅️ evalOfNat
-      [Tactic.norm_num] 2 ⇒ isNat 2 (⋯)
-    [Tactic.norm_num] 2 * x ⇒ x: no norm_nums apply
-  [Tactic.norm_num] 2 + 2 * x ⇒ 2 * x: no norm_nums apply
+      [Tactic.norm_num] 2 ==> isNat 2 (⋯)
+    [Tactic.norm_num] 2 * x ==> x: no norm_nums apply
+  [Tactic.norm_num] 2 + 2 * x ==> 2 * x: no norm_nums apply
 -/
 #guard_msgs in
 example (x : ℕ) : 2 * (1 + x) = 2 + 2 * x := by

--- a/MathlibTest/norm_num_trace.lean
+++ b/MathlibTest/norm_num_trace.lean
@@ -84,6 +84,6 @@ trace: [Tactic.norm_num] ❌️ evalMul
   [Tactic.norm_num] 2 + 2 * x ⇒ 2 * x: no norm_nums apply
 -/
 #guard_msgs in
-example (x : ℕ):  2 * (1 + x) = 2 + 2 * x := by
+example (x : ℕ) : 2 * (1 + x) = 2 + 2 * x := by
   norm_num
   rw [mul_add]

--- a/MathlibTest/norm_num_trace.lean
+++ b/MathlibTest/norm_num_trace.lean
@@ -1,0 +1,89 @@
+import Mathlib.Tactic.NormNum.Basic
+
+/-!
+# Tests of `norm_num` trace nodes
+
+These tests should be updated without much thought, unless a change specifically is targetting the
+trace format. In those cases, it is best to temporarily uncomment `#guard_msgs` and check the trace
+nodes behave correctly in the infoview. -/
+
+set_option trace.Tactic.norm_num true
+-- proofs would make this unstable (and hard to read)
+set_option pp.proofs false
+-- print shorter names
+open Mathlib.Meta.NormNum
+
+/--
+trace:
+[Tactic.norm_num] ✅️ evalMul
+  [Tactic.norm_num] ✅️ evalOfNat
+    [Tactic.norm_num] 2 ⇒ isNat 2 (⋯)
+  [Tactic.norm_num] ✅️ evalAdd
+    [Tactic.norm_num] ✅️ evalOfNat
+      [Tactic.norm_num] 1 ⇒ isNat 1 (⋯)
+    [Tactic.norm_num] ✅️ evalOfNat
+      [Tactic.norm_num] 1 ⇒ isNat 1 (⋯)
+    [Tactic.norm_num] 1 + 1 ⇒ isNat 2 (⋯)
+  [Tactic.norm_num] 2 * (1 + 1) ⇒ isNat 4 (⋯)
+[Tactic.norm_num] ✅️ evalTrue
+  [Tactic.norm_num] True ⇒ isTrue (True.intro)
+-/
+#guard_msgs in
+example : 2 * (1 + 1) = 4 := by
+  norm_num
+
+set_option linter.unusedTactic false in
+/--
+trace: [Tactic.norm_num] ❌️ evalMul
+  [Tactic.norm_num] ✅️ evalOfNat
+    [Tactic.norm_num] 2 ⇒ isNat 2 (⋯)
+  [Tactic.norm_num] ❌️ evalAdd
+    [Tactic.norm_num] ✅️ evalOfNat
+      [Tactic.norm_num] 1 ⇒ isNat 1 (⋯)
+    [Tactic.norm_num] 1 + x ⇒ x: no norm_nums apply
+  [Tactic.norm_num] 2 * (1 + x) ⇒ 1 + x: no norm_nums apply
+[Tactic.norm_num] ❌️ evalAdd
+  [Tactic.norm_num] ✅️ evalOfNat
+    [Tactic.norm_num] 1 ⇒ isNat 1 (⋯)
+  [Tactic.norm_num] 1 + x ⇒ x: no norm_nums apply
+[Tactic.norm_num] ❌️ evalAdd
+  [Tactic.norm_num] ✅️ evalOfNat
+    [Tactic.norm_num] 1 ⇒ isNat 1 (⋯)
+  [Tactic.norm_num] 1 + x ⇒ x: no norm_nums apply
+[Tactic.norm_num] ❌️ evalMul
+  [Tactic.norm_num] ✅️ evalOfNat
+    [Tactic.norm_num] 2 ⇒ isNat 2 (⋯)
+  [Tactic.norm_num] ❌️ evalAdd
+    [Tactic.norm_num] ✅️ evalOfNat
+      [Tactic.norm_num] 1 ⇒ isNat 1 (⋯)
+    [Tactic.norm_num] 1 + x ⇒ x: no norm_nums apply
+  [Tactic.norm_num] 2 * (1 + x) ⇒ 1 + x: no norm_nums apply
+[Tactic.norm_num] ❌️ evalAdd
+  [Tactic.norm_num] ✅️ evalOfNat
+    [Tactic.norm_num] 2 ⇒ isNat 2 (⋯)
+  [Tactic.norm_num] ❌️ evalMul
+    [Tactic.norm_num] ✅️ evalOfNat
+      [Tactic.norm_num] 2 ⇒ isNat 2 (⋯)
+    [Tactic.norm_num] 2 * x ⇒ x: no norm_nums apply
+  [Tactic.norm_num] 2 + 2 * x ⇒ 2 * x: no norm_nums apply
+[Tactic.norm_num] ❌️ evalMul
+  [Tactic.norm_num] ✅️ evalOfNat
+    [Tactic.norm_num] 2 ⇒ isNat 2 (⋯)
+  [Tactic.norm_num] 2 * x ⇒ x: no norm_nums apply
+[Tactic.norm_num] ❌️ evalMul
+  [Tactic.norm_num] ✅️ evalOfNat
+    [Tactic.norm_num] 2 ⇒ isNat 2 (⋯)
+  [Tactic.norm_num] 2 * x ⇒ x: no norm_nums apply
+[Tactic.norm_num] ❌️ evalAdd
+  [Tactic.norm_num] ✅️ evalOfNat
+    [Tactic.norm_num] 2 ⇒ isNat 2 (⋯)
+  [Tactic.norm_num] ❌️ evalMul
+    [Tactic.norm_num] ✅️ evalOfNat
+      [Tactic.norm_num] 2 ⇒ isNat 2 (⋯)
+    [Tactic.norm_num] 2 * x ⇒ x: no norm_nums apply
+  [Tactic.norm_num] 2 + 2 * x ⇒ 2 * x: no norm_nums apply
+-/
+#guard_msgs in
+example (x : ℕ):  2 * (1 + x) = 2 + 2 * x := by
+  norm_num
+  rw [mul_add]


### PR DESCRIPTION
Comparing the infoview on the first example in the test file

| Before | After |
|---|---|
| <img width="387" height="241" alt="image" src="https://github.com/user-attachments/assets/a1f798de-d51e-4f2a-862f-ee44b15aa874" /> | <img width="277" height="183" alt="image" src="https://github.com/user-attachments/assets/ca1dc8ce-18cf-49dd-9cf4-90c92058170b" />|

In the after version, the extension names are all clickable.

Similar to #21450.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
