### PR TITLE
[Merged by Bors] - chore: defer imports of `orderOf`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1156,7 +1156,6 @@ import Mathlib.Algebra.Tropical.BigOperators
 import Mathlib.Algebra.Tropical.Lattice
 import Mathlib.Algebra.Vertex.HVertexOperator
 import Mathlib.Algebra.Vertex.VertexOperator
-import Mathlib.Algebra.foo
 import Mathlib.AlgebraicGeometry.AffineScheme
 import Mathlib.AlgebraicGeometry.AffineSpace
 import Mathlib.AlgebraicGeometry.AffineTransitionLimit

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -1156,6 +1156,7 @@ import Mathlib.Algebra.Tropical.BigOperators
 import Mathlib.Algebra.Tropical.Lattice
 import Mathlib.Algebra.Vertex.HVertexOperator
 import Mathlib.Algebra.Vertex.VertexOperator
+import Mathlib.Algebra.foo
 import Mathlib.AlgebraicGeometry.AffineScheme
 import Mathlib.AlgebraicGeometry.AffineSpace
 import Mathlib.AlgebraicGeometry.AffineTransitionLimit
@@ -1767,6 +1768,7 @@ import Mathlib.Analysis.Normed.Order.Hom.Ultra
 import Mathlib.Analysis.Normed.Order.Lattice
 import Mathlib.Analysis.Normed.Order.UpperLower
 import Mathlib.Analysis.Normed.Ring.Basic
+import Mathlib.Analysis.Normed.Ring.Finite
 import Mathlib.Analysis.Normed.Ring.InfiniteSum
 import Mathlib.Analysis.Normed.Ring.Lemmas
 import Mathlib.Analysis.Normed.Ring.Ultra

--- a/Mathlib/Analysis/Calculus/ContDiff/FaaDiBruno.lean
+++ b/Mathlib/Analysis/Calculus/ContDiff/FaaDiBruno.lean
@@ -3,6 +3,7 @@ Copyright (c) 2024 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
+import Mathlib.Data.Finite.Card
 import Mathlib.Analysis.Analytic.Within
 import Mathlib.Analysis.Calculus.FDeriv.Analytic
 import Mathlib.Analysis.Calculus.ContDiff.FTaylorSeries

--- a/Mathlib/Analysis/Normed/Module/Ray.lean
+++ b/Mathlib/Analysis/Normed/Module/Ray.lean
@@ -5,6 +5,7 @@ Authors: Yury Kudryashov, Yaël Dillies
 -/
 import Mathlib.LinearAlgebra.Ray
 import Mathlib.Analysis.NormedSpace.Real
+import Mathlib.Algebra.Ring.Regular
 
 /-!
 # Rays in a real normed vector space

--- a/Mathlib/Analysis/Normed/Ring/Finite.lean
+++ b/Mathlib/Analysis/Normed/Ring/Finite.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2018 Patrick Massot. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Patrick Massot, Johannes Hölzl
+-/
+import Mathlib.Analysis.Normed.Ring.Lemmas
+import Mathlib.GroupTheory.OrderOfElement
+
+
+/-!
+# Finite order elements in normed rings.
+
+A finite order element in a normed ring has norm 1.
+
+The values of additive characters on finite cancellative monoids have norm 1.
+
+-/
+
+variable {α β : Type*}
+
+section NormedRing
+variable [NormedRing α] [NormMulClass α] [NormOneClass α] {a : α}
+
+protected lemma IsOfFinOrder.norm_eq_one (ha : IsOfFinOrder a) : ‖a‖ = 1 :=
+  ((normHom : α →*₀ ℝ).toMonoidHom.isOfFinOrder ha).eq_one <| norm_nonneg _
+
+example [Monoid β] (φ : β →* α) {x : β} {k : ℕ+} (h : x ^ (k : ℕ) = 1) :
+    ‖φ x‖ = 1 := (φ.isOfFinOrder <| isOfFinOrder_iff_pow_eq_one.2 ⟨_, k.2, h⟩).norm_eq_one
+
+@[simp] lemma AddChar.norm_apply {G : Type*} [AddLeftCancelMonoid G] [Finite G] (ψ : AddChar G α)
+    (x : G) : ‖ψ x‖ = 1 := (ψ.toMonoidHom.isOfFinOrder <| isOfFinOrder_of_finite _).norm_eq_one
+
+end NormedRing

--- a/Mathlib/Analysis/Normed/Ring/Finite.lean
+++ b/Mathlib/Analysis/Normed/Ring/Finite.lean
@@ -3,8 +3,10 @@ Copyright (c) 2018 Patrick Massot. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Johannes Hölzl
 -/
-import Mathlib.Analysis.Normed.Ring.Lemmas
 import Mathlib.GroupTheory.OrderOfElement
+import Mathlib.Algebra.Group.AddChar
+import Mathlib.Algebra.Group.TypeTags.Finite
+import Mathlib.Analysis.Normed.Ring.Basic
 
 
 /-!

--- a/Mathlib/Analysis/Normed/Ring/Lemmas.lean
+++ b/Mathlib/Analysis/Normed/Ring/Lemmas.lean
@@ -3,8 +3,6 @@ Copyright (c) 2018 Patrick Massot. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Johannes Hölzl
 -/
-import Mathlib.Algebra.Group.AddChar
-import Mathlib.Algebra.Group.TypeTags.Finite
 import Mathlib.Algebra.Order.GroupWithZero.Finset
 import Mathlib.Analysis.Normed.Group.Bounded
 import Mathlib.Analysis.Normed.Group.Int

--- a/Mathlib/Analysis/Normed/Ring/Lemmas.lean
+++ b/Mathlib/Analysis/Normed/Ring/Lemmas.lean
@@ -10,7 +10,6 @@ import Mathlib.Analysis.Normed.Group.Bounded
 import Mathlib.Analysis.Normed.Group.Int
 import Mathlib.Analysis.Normed.Group.Uniform
 import Mathlib.Analysis.Normed.Ring.Basic
-import Mathlib.GroupTheory.OrderOfElement
 import Mathlib.Topology.MetricSpace.Dilation
 
 /-!
@@ -267,17 +266,3 @@ lemma comap_mul_right_cobounded {a : α} (ha : a ≠ 0) :
 end Filter
 
 end NonUnitalNormedRing
-
-section NormedRing
-variable [NormedRing α] [NormMulClass α] [NormOneClass α] {a : α}
-
-protected lemma IsOfFinOrder.norm_eq_one (ha : IsOfFinOrder a) : ‖a‖ = 1 :=
-  ((normHom : α →*₀ ℝ).toMonoidHom.isOfFinOrder ha).eq_one <| norm_nonneg _
-
-example [Monoid β] (φ : β →* α) {x : β} {k : ℕ+} (h : x ^ (k : ℕ) = 1) :
-    ‖φ x‖ = 1 := (φ.isOfFinOrder <| isOfFinOrder_iff_pow_eq_one.2 ⟨_, k.2, h⟩).norm_eq_one
-
-@[simp] lemma AddChar.norm_apply {G : Type*} [AddLeftCancelMonoid G] [Finite G] (ψ : AddChar G α)
-    (x : G) : ‖ψ x‖ = 1 := (ψ.toMonoidHom.isOfFinOrder <| isOfFinOrder_of_finite _).norm_eq_one
-
-end NormedRing

--- a/Mathlib/Analysis/NormedSpace/Connected.lean
+++ b/Mathlib/Analysis/NormedSpace/Connected.lean
@@ -24,7 +24,7 @@ We show several results related to the (path)-connectedness of subsets of real v
 Statements with connectedness instead of path-connectedness are also given.
 -/
 
-assert_not_exists Sugroup.index Nat.divisors
+assert_not_exists Subgroup.index Nat.divisors
 
 open Convex Set Metric
 

--- a/Mathlib/Analysis/NormedSpace/Connected.lean
+++ b/Mathlib/Analysis/NormedSpace/Connected.lean
@@ -24,6 +24,8 @@ We show several results related to the (path)-connectedness of subsets of real v
 Statements with connectedness instead of path-connectedness are also given.
 -/
 
+assert_not_exists Sugroup.index Nat.divisors
+
 open Convex Set Metric
 
 section TopologicalVectorSpace

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -9,6 +9,7 @@ import Mathlib.Algebra.Order.BigOperators.Expect
 import Mathlib.Algebra.Order.Star.Basic
 import Mathlib.Analysis.CStarAlgebra.Basic
 import Mathlib.Analysis.Normed.Operator.ContinuousLinearMap
+import Mathlib.Analysis.Normed.Ring.Finite
 import Mathlib.Data.Real.Sqrt
 import Mathlib.LinearAlgebra.Basis.VectorSpace
 


### PR DESCRIPTION
See [#mathlib4 > Warning that AlgebraicTopology can't import SetTheory](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Warning.20that.20AlgebraicTopology.20can't.20import.20SetTheory)