### PR TITLE
chore: make OmegaCompletePartialOrder a mixin

### DIFF
--- a/Mathlib/Control/LawfulFix.lean
+++ b/Mathlib/Control/LawfulFix.lean
@@ -32,7 +32,7 @@ functions `f`, such as the function that is defined iff its argument is not, fam
 halting problem. Instead, this requirement is limited to only functions that are `Continuous` in the
 sense of `ω`-complete partial orders, which excludes the example because it is not monotone
 (making the input argument less defined can make `f` more defined). -/
-class LawfulFix (α : Type*) [OmegaCompletePartialOrder α] extends Fix α where
+class LawfulFix (α : Type*) [PartialOrder α] [OmegaCompletePartialOrder α] extends Fix α where
   fix_eq : ∀ {f : α → α}, ωScottContinuous f → Fix.fix f = f (Fix.fix f)
 
 namespace Part
@@ -217,7 +217,7 @@ def monotoneUncurry [(x y : _) → Preorder <| γ x y] :
   toFun := uncurry
   monotone' _x _y h a := h a.1 a.2
 
-variable [(x y : _) → OmegaCompletePartialOrder <| γ x y]
+variable [(x y : _) → PartialOrder (γ x y)] [∀ x y, OmegaCompletePartialOrder <| γ x y]
 
 open OmegaCompletePartialOrder.Chain
 
@@ -244,7 +244,7 @@ open Fix
 instance hasFix [Fix <| (x : Sigma β) → γ x.1 x.2] : Fix ((x : _) → (y : β x) → γ x y) :=
   ⟨fun f ↦ curry (fix <| uncurry ∘ f ∘ curry)⟩
 
-variable [∀ x y, OmegaCompletePartialOrder <| γ x y]
+variable [∀ x y, PartialOrder (γ x y)] [∀ x y, OmegaCompletePartialOrder <| γ x y]
 
 section Curry
 

--- a/Mathlib/Data/Nat/Nth.lean
+++ b/Mathlib/Data/Nat/Nth.lean
@@ -9,7 +9,6 @@ import Mathlib.Data.Nat.SuccPred
 import Mathlib.Order.Interval.Set.Monotone
 import Mathlib.Order.OrderIsoNat
 import Mathlib.Order.WellFounded
-import Mathlib.Order.OmegaCompletePartialOrder
 import Mathlib.Data.Finset.Sort
 
 /-!

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineSubspace/Defs.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Myers
 -/
 import Mathlib.Order.Atoms
-import Mathlib.Order.OmegaCompletePartialOrder
 import Mathlib.LinearAlgebra.Span.Defs
 import Mathlib.LinearAlgebra.AffineSpace.Defs
 

--- a/Mathlib/Order/Category/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/Category/OmegaCompletePartialOrder.lean
@@ -33,9 +33,10 @@ universe u v
 structure ωCPO : Type (u + 1) where
   /-- The underlying type. -/
   carrier : Type u
+  [partialOrder : PartialOrder carrier]
   [str : OmegaCompletePartialOrder carrier]
 
-attribute [instance] ωCPO.str
+attribute [instance] ωCPO.partialOrder ωCPO.str
 
 namespace ωCPO
 
@@ -45,10 +46,10 @@ instance : CoeSort ωCPO Type* :=
   ⟨carrier⟩
 
 /-- Construct a bundled ωCPO from the underlying type and typeclass. -/
-abbrev of (α : Type*) [OmegaCompletePartialOrder α] : ωCPO where
+abbrev of (α : Type*) [PartialOrder α] [OmegaCompletePartialOrder α] : ωCPO where
   carrier := α
 
-theorem coe_of (α : Type*) [OmegaCompletePartialOrder α] : ↥(of α) = α :=
+theorem coe_of (α : Type*) [PartialOrder α] [OmegaCompletePartialOrder α] : ↥(of α) = α :=
   rfl
 
 instance : LargeCategory.{u} ωCPO where
@@ -90,8 +91,9 @@ instance (J : Type v) (f : J → ωCPO.{v}) : HasProduct f :=
 
 end HasProducts
 
-instance omegaCompletePartialOrderEqualizer {α β : Type*} [OmegaCompletePartialOrder α]
-    [OmegaCompletePartialOrder β] (f g : α →𝒄 β) :
+instance omegaCompletePartialOrderEqualizer {α β : Type*}
+    [PartialOrder α] [OmegaCompletePartialOrder α]
+    [PartialOrder β] [OmegaCompletePartialOrder β] (f g : α →𝒄 β) :
     OmegaCompletePartialOrder { a : α // f a = g a } :=
   OmegaCompletePartialOrder.subtype _ fun c hc => by
     rw [f.continuous, g.continuous]
@@ -102,7 +104,9 @@ instance omegaCompletePartialOrderEqualizer {α β : Type*} [OmegaCompletePartia
 namespace HasEqualizers
 
 /-- The equalizer inclusion function as a `ContinuousHom`. -/
-def equalizerι {α β : Type*} [OmegaCompletePartialOrder α] [OmegaCompletePartialOrder β]
+def equalizerι {α β : Type*}
+    [PartialOrder α] [OmegaCompletePartialOrder α]
+    [PartialOrder β] [OmegaCompletePartialOrder β]
     (f g : α →𝒄 β) : { a : α // f a = g a } →𝒄 α :=
   .mk (OrderHom.Subtype.val _) fun _ => rfl
 

--- a/Mathlib/Order/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/OmegaCompletePartialOrder.lean
@@ -161,7 +161,7 @@ call `ωSup`). In this sense, it is strictly weaker than join complete
 semi-lattices as only ω-sized totally ordered sets have a supremum.
 
 See the definition on page 114 of [gunter1992]. -/
-class OmegaCompletePartialOrder (α : Type*) extends PartialOrder α where
+class OmegaCompletePartialOrder (α : Type*) [PartialOrder α] where
   /-- The supremum of an increasing sequence -/
   ωSup : Chain α → α
   /-- `ωSup` is an upper bound of the increasing sequence -/
@@ -170,6 +170,9 @@ class OmegaCompletePartialOrder (α : Type*) extends PartialOrder α where
   ωSup_le : ∀ (c : Chain α) (x), (∀ i, c i ≤ x) → ωSup c ≤ x
 
 namespace OmegaCompletePartialOrder
+variable [PartialOrder α]
+
+section
 variable [OmegaCompletePartialOrder α]
 
 /-- Transfer an `OmegaCompletePartialOrder` on `β` to an `OmegaCompletePartialOrder` on `α`
@@ -228,16 +231,18 @@ lemma ωSup_eq_of_isLUB {c : Chain α} {a : α} (h : IsLUB (Set.range c) a) : a 
 
 /-- A subset `p : α → Prop` of the type closed under `ωSup` induces an
 `OmegaCompletePartialOrder` on the subtype `{a : α // p a}`. -/
-def subtype {α : Type*} [OmegaCompletePartialOrder α] (p : α → Prop)
+def subtype {α : Type*} [PartialOrder α] [OmegaCompletePartialOrder α] (p : α → Prop)
     (hp : ∀ c : Chain α, (∀ i ∈ c, p i) → p (ωSup c)) : OmegaCompletePartialOrder (Subtype p) :=
   OmegaCompletePartialOrder.lift (OrderHom.Subtype.val p)
     (fun c => ⟨ωSup _, hp (c.map (OrderHom.Subtype.val p)) fun _ ⟨n, q⟩ => q.symm ▸ (c n).2⟩)
     (fun _ _ h => h) (fun _ => rfl)
 
+end
+
 section Continuity
 
-variable [OmegaCompletePartialOrder β]
-variable [OmegaCompletePartialOrder γ]
+variable [PartialOrder β]
+variable [PartialOrder γ]
 variable {f : α → β} {g : β → γ}
 
 /-- A function `f` between `ω`-complete partial orders is `ωScottContinuous` if it is
@@ -252,13 +257,19 @@ lemma ωScottContinuous.monotone (h : ωScottContinuous f) : Monotone f :=
   ScottContinuousOn.monotone _ (fun a b hab => by
     use pair a b hab; exact range_pair a b hab) h
 
+lemma ωScottContinuous.id : ωScottContinuous (id : α → α) := ScottContinuousOn.id
+
+lemma ωScottContinuous.const {x : β} : ωScottContinuous (Function.const α x) := by
+  simp [ωScottContinuous, ScottContinuousOn, Set.range_nonempty]
+
+variable [OmegaCompletePartialOrder α]
+
 lemma ωScottContinuous.isLUB {c : Chain α} (hf : ωScottContinuous f) :
     IsLUB (Set.range (c.map ⟨f, hf.monotone⟩)) (f (ωSup c)) := by
   simpa [map_coe, OrderHom.coe_mk, Set.range_comp]
     using hf (by simp) (Set.range_nonempty _) (isChain_range c).directedOn (isLUB_range_ωSup c)
 
-lemma ωScottContinuous.id : ωScottContinuous (id : α → α) := ScottContinuousOn.id
-
+variable [OmegaCompletePartialOrder β]
 lemma ωScottContinuous.map_ωSup (hf : ωScottContinuous f) (c : Chain α) :
     f (ωSup c) = ωSup (c.map ⟨f, hf.monotone⟩) := ωSup_eq_of_isLUB hf.isLUB
 
@@ -284,13 +295,12 @@ lemma ωScottContinuous_iff_map_ωSup_of_orderHom {f : α →o β} :
 alias ⟨ωScottContinuous.map_ωSup_of_orderHom, ωScottContinuous.of_map_ωSup_of_orderHom⟩ :=
   ωScottContinuous_iff_map_ωSup_of_orderHom
 
+variable [OmegaCompletePartialOrder γ]
+
 lemma ωScottContinuous.comp (hg : ωScottContinuous g) (hf : ωScottContinuous f) :
     ωScottContinuous (g.comp f) :=
   ωScottContinuous.of_monotone_map_ωSup
     ⟨hg.monotone.comp hf.monotone, by simp [hf.map_ωSup, hg.map_ωSup, map_comp]⟩
-
-lemma ωScottContinuous.const {x : β} : ωScottContinuous (Function.const α x) := by
-  simp [ωScottContinuous, ScottContinuousOn, Set.range_nonempty]
 
 end Continuity
 
@@ -372,7 +382,7 @@ end Part
 
 section Pi
 
-variable {β : α → Type*}
+variable {β : α → Type*} [∀ a, PartialOrder (β a)]
 
 instance [∀ a, OmegaCompletePartialOrder (β a)] :
     OmegaCompletePartialOrder (∀ a, β a) where
@@ -386,7 +396,7 @@ instance [∀ a, OmegaCompletePartialOrder (β a)] :
 namespace OmegaCompletePartialOrder
 
 variable [∀ x, OmegaCompletePartialOrder <| β x]
-variable [OmegaCompletePartialOrder γ]
+variable [PartialOrder γ] [OmegaCompletePartialOrder γ]
 variable {f : γ → ∀ x, β x}
 
 lemma ωScottContinuous.apply₂ (hf : ωScottContinuous f) (a : α) : ωScottContinuous (f · a) :=
@@ -406,9 +416,9 @@ end Pi
 
 namespace Prod
 
-variable [OmegaCompletePartialOrder α]
-variable [OmegaCompletePartialOrder β]
-variable [OmegaCompletePartialOrder γ]
+variable [PartialOrder α] [OmegaCompletePartialOrder α]
+variable [PartialOrder β] [OmegaCompletePartialOrder β]
+variable [PartialOrder γ] [OmegaCompletePartialOrder γ]
 
 /-- The supremum of a chain in the product `ω`-CPO. -/
 @[simps]
@@ -437,7 +447,7 @@ instance (priority := 100) [CompleteLattice α] : OmegaCompletePartialOrder α w
   ωSup_le := fun ⟨c, _⟩ s hs => by simpa only [iSup_le_iff]
   le_ωSup := fun ⟨c, _⟩ i => le_iSup_of_le i le_rfl
 
-variable [OmegaCompletePartialOrder α] [CompleteLattice β] {f g : α → β}
+variable [PartialOrder α] [CompleteLattice β] {f g : α → β}
 
 -- TODO Prove this result for `ScottContinuousOn` and deduce this as a special case
 -- https://github.com/leanprover-community/mathlib4/pull/15412
@@ -445,6 +455,8 @@ open Chain in
 lemma ωScottContinuous.prodMk (hf : ωScottContinuous f) (hg : ωScottContinuous g) :
     ωScottContinuous fun x => (f x, g x) := ScottContinuousOn.prodMk (fun a b hab => by
   use pair a b hab; exact range_pair a b hab) hf hg
+
+variable [OmegaCompletePartialOrder α]
 
 lemma ωScottContinuous.iSup {f : ι → α → β} (hf : ∀ i, ωScottContinuous (f i)) :
     ωScottContinuous (⨆ i, f i) := by
@@ -473,7 +485,7 @@ end CompleteLattice
 
 namespace CompleteLattice
 
-variable [OmegaCompletePartialOrder α] [CompleteLinearOrder β] {f g : α → β}
+variable [PartialOrder α] [OmegaCompletePartialOrder α] [CompleteLinearOrder β] {f g : α → β}
 
 -- TODO Prove this result for `ScottContinuousOn` and deduce this as a special case
 -- Also consider if it holds in greater generality (e.g. finite sets)
@@ -494,8 +506,10 @@ lemma ωScottContinuous.inf (hf : ωScottContinuous f) (hg : ωScottContinuous g
 end CompleteLattice
 
 namespace OmegaCompletePartialOrder
-variable [OmegaCompletePartialOrder α] [OmegaCompletePartialOrder β]
-variable [OmegaCompletePartialOrder γ] [OmegaCompletePartialOrder δ]
+variable [PartialOrder α] [OmegaCompletePartialOrder α]
+variable [PartialOrder β] [OmegaCompletePartialOrder β]
+variable [PartialOrder γ] [OmegaCompletePartialOrder γ]
+variable [PartialOrder δ] [OmegaCompletePartialOrder δ]
 
 namespace OrderHom
 
@@ -566,6 +580,7 @@ protected theorem monotone (f : α →𝒄 β) : Monotone f :=
 theorem apply_mono {f g : α →𝒄 β} {x y : α} (h₁ : f ≤ g) (h₂ : x ≤ y) : f x ≤ g y :=
   OrderHom.apply_mono (show (f : α →o β) ≤ g from h₁) h₂
 
+omit [OmegaCompletePartialOrder α] in
 theorem ωSup_bind {β γ : Type v} (c : Chain α) (f : α →o Part β) (g : α →o β → Part γ) :
     ωSup (c.map (f.partBind g)) = ωSup (c.map f) >>= ωSup (c.map g) := by
   apply eq_of_forall_ge_iff; intro x

--- a/Mathlib/Topology/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Topology/OmegaCompletePartialOrder.lean
@@ -24,7 +24,7 @@ universe u
 
 open Topology.IsScott in
 @[simp] lemma Topology.IsScott.ωScottContinuous_iff_continuous {α : Type*}
-    [OmegaCompletePartialOrder α] [TopologicalSpace α]
+    [PartialOrder α] [OmegaCompletePartialOrder α] [TopologicalSpace α]
     [Topology.IsScott α (Set.range fun c : Chain α => Set.range c)] {f : α → Prop} :
     ωScottContinuous f ↔ Continuous f := by
   rw [ωScottContinuous, scottContinuousOn_iff_continuous (fun a b hab => by
@@ -44,14 +44,18 @@ theorem isωSup_iff_isLUB {α : Type u} [Preorder α] {c : Chain α} {x : α} :
     IsωSup c x ↔ IsLUB (range c) x := by
   simp [IsωSup, IsLUB, IsLeast, upperBounds, lowerBounds]
 
-variable (α : Type u) [OmegaCompletePartialOrder α]
+variable (α : Type u) [PartialOrder α]
 
 /-- The characteristic function of open sets is monotone and preserves
 the limits of chains. -/
 def IsOpen (s : Set α) : Prop :=
   ωScottContinuous fun x ↦ x ∈ s
 
-theorem isOpen_univ : IsOpen α univ := @CompleteLattice.ωScottContinuous.top α Prop _ _
+theorem IsOpen.isUpperSet {s : Set α} (hs : IsOpen α s) : IsUpperSet s := hs.monotone
+
+variable [OmegaCompletePartialOrder α]
+
+theorem isOpen_univ : IsOpen α univ := @CompleteLattice.ωScottContinuous.top α Prop _ _ _
 
 theorem IsOpen.inter (s t : Set α) : IsOpen α s → IsOpen α t → IsOpen α (s ∩ t) :=
   CompleteLattice.ωScottContinuous.inf
@@ -60,8 +64,6 @@ theorem isOpen_sUnion (s : Set (Set α)) (hs : ∀ t ∈ s, IsOpen α t) : IsOpe
   simp only [IsOpen] at hs ⊢
   convert CompleteLattice.ωScottContinuous.sSup hs
   aesop
-
-theorem IsOpen.isUpperSet {s : Set α} (hs : IsOpen α s) : IsUpperSet s := hs.monotone
 
 end Scott
 
@@ -74,7 +76,7 @@ abbrev Scott (α : Type u) := α
 set_option linter.deprecated false in
 /-- Deprecated, use `WithScott`. -/
 @[deprecated Topology.WithScott.instTopologicalSpace (since := "2025-07-02")]
-abbrev Scott.topologicalSpace (α : Type u) [OmegaCompletePartialOrder α] :
+abbrev Scott.topologicalSpace (α : Type u) [PartialOrder α] [OmegaCompletePartialOrder α] :
     TopologicalSpace (Scott α) where
   IsOpen := Scott.IsOpen α
   isOpen_univ := Scott.isOpen_univ α
@@ -85,22 +87,23 @@ attribute [local instance] Scott.topologicalSpace
 
 set_option linter.deprecated false in
 @[deprecated isOpen_iff_continuous_mem (since := "2025-07-02")]
-lemma isOpen_iff_ωScottContinuous_mem {α} [OmegaCompletePartialOrder α] {s : Set (Scott α)} :
+lemma isOpen_iff_ωScottContinuous_mem {α} [PartialOrder α] [OmegaCompletePartialOrder α]
+    {s : Set (Scott α)} :
     IsOpen s ↔ ωScottContinuous fun x ↦ x ∈ s := by rfl
 
 set_option linter.deprecated false in
 @[deprecated "Use `WithScott` API" (since := "2025-07-02")]
-lemma scott_eq_Scott {α} [OmegaCompletePartialOrder α] :
+lemma scott_eq_Scott {α} [PartialOrder α] [OmegaCompletePartialOrder α] :
     Topology.scott α (Set.range fun c : Chain α => Set.range c) = Scott.topologicalSpace α := by
   ext U
   letI := Topology.scott α (Set.range fun c : Chain α => Set.range c)
   rw [isOpen_iff_ωScottContinuous_mem, @isOpen_iff_continuous_mem,
-    @Topology.IsScott.ωscottContinuous_iff_continuous _ _
+    @Topology.IsScott.ωscottContinuous_iff_continuous _ _ _
       (Topology.scott α (Set.range fun c : Chain α => Set.range c)) ({ topology_eq_scott := rfl })]
 
 section notBelow
 
-variable {α : Type*} [OmegaCompletePartialOrder α]
+variable {α : Type*} [PartialOrder α] [OmegaCompletePartialOrder α]
 
 set_option linter.deprecated false in
 /-- `notBelow` is an open set in `Scott α` used
@@ -122,15 +125,18 @@ end notBelow
 
 open Scott hiding IsOpen IsOpen.isUpperSet
 
-theorem isωSup_ωSup {α} [OmegaCompletePartialOrder α] (c : Chain α) : IsωSup c (ωSup c) := by
+theorem isωSup_ωSup {α} [PartialOrder α] [OmegaCompletePartialOrder α] (c : Chain α) :
+    IsωSup c (ωSup c) := by
   constructor
   · apply le_ωSup
   · apply ωSup_le
 
 set_option linter.deprecated false in
 @[deprecated Topology.IsScott.ωscottContinuous_iff_continuous (since := "2025-07-02")]
-theorem scottContinuous_of_continuous {α β} [OmegaCompletePartialOrder α]
-    [OmegaCompletePartialOrder β] (f : Scott α → Scott β) (hf : _root_.Continuous f) :
+theorem scottContinuous_of_continuous {α β}
+    [PartialOrder α] [OmegaCompletePartialOrder α]
+    [PartialOrder β] [OmegaCompletePartialOrder β]
+    (f : Scott α → Scott β) (hf : _root_.Continuous f) :
     OmegaCompletePartialOrder.ωScottContinuous f := by
   rw [ωScottContinuous_iff_monotone_map_ωSup]
   have h : Monotone f := fun x y h ↦ by
@@ -148,7 +154,9 @@ theorem scottContinuous_of_continuous {α β} [OmegaCompletePartialOrder α]
 
 set_option linter.deprecated false in
 @[deprecated Topology.IsScott.ωscottContinuous_iff_continuous (since := "2025-07-02")]
-theorem continuous_of_scottContinuous {α β} [OmegaCompletePartialOrder α]
-    [OmegaCompletePartialOrder β] (f : Scott α → Scott β) (hf : ωScottContinuous f) :
+theorem continuous_of_scottContinuous {α β}
+    [PartialOrder α] [OmegaCompletePartialOrder α]
+    [PartialOrder β] [OmegaCompletePartialOrder β]
+    (f : Scott α → Scott β) (hf : ωScottContinuous f) :
     Continuous f := by
   rw [continuous_def]; exact fun s hs ↦ hs.comp hf

--- a/Mathlib/Topology/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Topology/OmegaCompletePartialOrder.lean
@@ -24,7 +24,7 @@ universe u
 
 open Topology.IsScott in
 @[simp] lemma Topology.IsScott.ωScottContinuous_iff_continuous {α : Type*}
-    [PartialOrder α] [OmegaCompletePartialOrder α] [TopologicalSpace α]
+    [PartialOrder α] [TopologicalSpace α]
     [Topology.IsScott α (Set.range fun c : Chain α => Set.range c)] {f : α → Prop} :
     ωScottContinuous f ↔ Continuous f := by
   rw [ωScottContinuous, scottContinuousOn_iff_continuous (fun a b hab => by
@@ -98,7 +98,7 @@ lemma scott_eq_Scott {α} [PartialOrder α] [OmegaCompletePartialOrder α] :
   ext U
   letI := Topology.scott α (Set.range fun c : Chain α => Set.range c)
   rw [isOpen_iff_ωScottContinuous_mem, @isOpen_iff_continuous_mem,
-    @Topology.IsScott.ωscottContinuous_iff_continuous _ _ _
+    @Topology.IsScott.ωscottContinuous_iff_continuous _ _
       (Topology.scott α (Set.range fun c : Chain α => Set.range c)) ({ topology_eq_scott := rfl })]
 
 section notBelow


### PR DESCRIPTION
I've noted typeclass searches often getting distracted looking for a `OmegaCompletePartialOrder` when they just want an `LE` or a `Preorder`.

Let's benchmark to see it if has a nontrivial effect. Not certain if this is desirable if the performance change is neutral (or even negative).