### PR TITLE
[Merged by Bors] - doc(1000.yaml): add Dirichlet's unit theorem

### DIFF
--- a/docs/1000.yaml
+++ b/docs/1000.yaml
@@ -1449,6 +1449,10 @@ Q1227061:
 
 Q1227702:
   title: Dirichlet's unit theorem
+  decls: 
+    - NumberField.Units.basisModTorsion
+    - NumberField.Units.exist_unique_eq_mul_prod
+  authors: Xavier Roblot
 
 Q1227703:
   title: Dirichlet's approximation theorem


### PR DESCRIPTION
This was added in #5960 but wasn't added to 1000.yaml


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
