### PR TITLE
[Merged by Bors] - chore(Probability/Independence): golf 9 lines from `iIndepFun.indepFun_finset` using `grind`

### DIFF
--- a/Mathlib/Probability/Independence/Kernel.lean
+++ b/Mathlib/Probability/Independence/Kernel.lean
@@ -1080,16 +1080,7 @@ theorem iIndepFun.indepFun_finset (S T : Finset ι) (hST : Disjoint S T)
     ext1 x
     simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
     constructor <;> intro h
-    · intro i hi
-      rcases hi with hiS | hiT
-      · replace h := h.1 i hiS
-        simp_rw [sets_s', sets_t', dif_pos hiS, dif_neg (Finset.disjoint_left.mp hST hiS)]
-        simp only [sets_s'] at h
-        exact ⟨by rwa [dif_pos hiS] at h, Set.mem_univ _⟩
-      · replace h := h.2 i hiT
-        simp_rw [sets_s', sets_t', dif_pos hiT, dif_neg (Finset.disjoint_right.mp hST hiT)]
-        simp only [sets_t'] at h
-        exact ⟨Set.mem_univ _, by rwa [dif_pos hiT] at h⟩
+    · grind
     · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩
   have h_meas_inter : ∀ i ∈ S ∪ T, MeasurableSet (sets_s' i ∩ sets_t' i) := by
     intros i hi_mem


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>iIndepFun.indepFun_finset</code>: 1481 ms before, 1589 ms after </summary>

### Trace profiling of `iIndepFun.indepFun_finset` before PR 28327
```diff
diff --git a/Mathlib/Probability/Independence/Kernel.lean b/Mathlib/Probability/Independence/Kernel.lean
index 392c3b3d7a..da6bf2c57f 100644
--- a/Mathlib/Probability/Independence/Kernel.lean
+++ b/Mathlib/Probability/Independence/Kernel.lean
@@ -1012,6 +1012,7 @@ section iIndepFun
 variable {β : ι → Type*} {m : ∀ i, MeasurableSpace (β i)} {f : ∀ i, Ω → β i}
 
 
+set_option trace.profiler true in
 /-- If `f` is a family of mutually independent random variables (`iIndepFun m f μ`) and `S, T` are
 two disjoint finite index sets, then the tuple formed by `f i` for `i ∈ S` is independent of the
 tuple `(f i)_i` for `i ∈ T`. -/
```
```
ℹ [1740/1740] Built Mathlib.Probability.Independence.Kernel
info: Mathlib/Probability/Independence/Kernel.lean:1016:0: [Elab.command] [0.011610] /--
    If `f` is a family of mutually independent random variables (`iIndepFun m f μ`) and `S, T` are
    two disjoint finite index sets, then the tuple formed by `f i` for `i ∈ S` is independent of the
    tuple `(f i)_i` for `i ∈ T`. -/
    theorem indepFun_finset (S T : Finset ι) (hST : Disjoint S T) (hf_Indep : iIndepFun f κ μ)
        (hf_meas : ∀ i, Measurable (f i)) : IndepFun (fun a (i : S) => f i a) (fun a (i : T) => f i a) κ μ :=
      by
      rcases eq_or_ne μ 0 with rfl | hμ
      · simp
      obtain ⟨η, η_eq, hη⟩ : ∃ (η : Kernel α Ω), κ =ᵐ[μ] η ∧ IsMarkovKernel η :=
        exists_ae_eq_isMarkovKernel hf_Indep.ae_isProbabilityMeasure hμ
      apply
        IndepFun.congr
          (Filter.EventuallyEq.symm η_eq)
            -- We introduce π-systems, built from the π-system of boxes which generates `MeasurableSpace.pi`.
            
      let πSβ := Set.pi (Set.univ : Set S) '' Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s}
      let πS := {s : Set Ω | ∃ t ∈ πSβ, (fun a (i : S) => f i a) ⁻¹' t = s}
      have hπS_pi : IsPiSystem πS := by exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _
      have hπS_gen : (MeasurableSpace.pi.comap fun a (i : S) => f i a) = generateFrom πS :=
        by
        rw [generateFrom_pi.symm, comap_generateFrom]
        congr
      let πTβ := Set.pi (Set.univ : Set T) '' Set.pi (Set.univ : Set T) fun i => {s : Set (β i) | MeasurableSet[m i] s}
      let πT := {s : Set Ω | ∃ t ∈ πTβ, (fun a (i : T) => f i a) ⁻¹' t = s}
      have hπT_pi : IsPiSystem πT := by exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _
      have hπT_gen : (MeasurableSpace.pi.comap fun a (i : T) => f i a) = generateFrom πT :=
        by
        rw [generateFrom_pi.symm, comap_generateFrom]
        congr
          -- To prove independence, we prove independence of the generating π-systems.
          
      refine
        IndepSets.indep (Measurable.comap_le (measurable_pi_iff.mpr fun i => hf_meas i))
          (Measurable.comap_le (measurable_pi_iff.mpr fun i => hf_meas i)) hπS_pi hπT_pi hπS_gen hπT_gen ?_
      rintro _ _ ⟨s, ⟨sets_s, hs1, hs2⟩, rfl⟩ ⟨t, ⟨sets_t, ht1, ht2⟩, rfl⟩
      simp only [Set.mem_univ_pi, Set.mem_setOf_eq] at hs1 ht1
      rw [← hs2, ← ht2]
      classical
      let sets_s' : ∀ i : ι, Set (β i) := fun i => dite (i ∈ S) (fun hi => sets_s ⟨i, hi⟩) fun _ => Set.univ
      have h_sets_s'_eq : ∀ {i} (hi : i ∈ S), sets_s' i = sets_s ⟨i, hi⟩ := by intro i hi; simp_rw [sets_s', dif_pos hi]
      have h_sets_s'_univ : ∀ {i} (_hi : i ∈ T), sets_s' i = Set.univ := by intro i hi;
        simp_rw [sets_s', dif_neg (Finset.disjoint_right.mp hST hi)]
      let sets_t' : ∀ i : ι, Set (β i) := fun i => dite (i ∈ T) (fun hi => sets_t ⟨i, hi⟩) fun _ => Set.univ
      have h_sets_t'_univ : ∀ {i} (_hi : i ∈ S), sets_t' i = Set.univ := by intro i hi;
        simp_rw [sets_t', dif_neg (Finset.disjoint_left.mp hST hi)]
      have h_meas_s' : ∀ i ∈ S, MeasurableSet (sets_s' i) := by intro i hi; rw [h_sets_s'_eq hi]; exact hs1 _
      have h_meas_t' : ∀ i ∈ T, MeasurableSet (sets_t' i) := by intro i hi; simp_rw [sets_t', dif_pos hi]; exact ht1 _
      have h_eq_inter_S : (fun (ω : Ω) (i : ↥S) => f (↑i) ω) ⁻¹' Set.pi Set.univ sets_s = ⋂ i ∈ S, f i ⁻¹' sets_s' i :=
        by
        ext1 x
        simp_rw [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
        grind
      have h_eq_inter_T : (fun (ω : Ω) (i : ↥T) => f (↑i) ω) ⁻¹' Set.pi Set.univ sets_t = ⋂ i ∈ T, f i ⁻¹' sets_t' i :=
        by
        ext1 x
        simp only [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
        constructor <;> intro h
        · intro i hi; simp_rw [sets_t', dif_pos hi]; exact h ⟨i, hi⟩
        · grind
      replace hf_Indep := hf_Indep.congr η_eq
      rw [iIndepFun_iff_measure_inter_preimage_eq_mul] at hf_Indep
      have h_Inter_inter :
        ((⋂ i ∈ S, f i ⁻¹' sets_s' i) ∩ ⋂ i ∈ T, f i ⁻¹' sets_t' i) = ⋂ i ∈ S ∪ T, f i ⁻¹' (sets_s' i ∩ sets_t' i) :=
        by
        ext1 x
        simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
        constructor <;> intro h
        · intro i hi
          rcases hi with hiS | hiT
          · replace h := h.1 i hiS
            simp_rw [sets_s', sets_t', dif_pos hiS, dif_neg (Finset.disjoint_left.mp hST hiS)]
            simp only [sets_s'] at h
            exact ⟨by rwa [dif_pos hiS] at h, Set.mem_univ _⟩
          · replace h := h.2 i hiT
            simp_rw [sets_s', sets_t', dif_pos hiT, dif_neg (Finset.disjoint_right.mp hST hiT)]
            simp only [sets_t'] at h
            exact ⟨Set.mem_univ _, by rwa [dif_pos hiT] at h⟩
        · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩
      have h_meas_inter : ∀ i ∈ S ∪ T, MeasurableSet (sets_s' i ∩ sets_t' i) :=
        by
        intros i hi_mem
        rw [Finset.mem_union] at hi_mem
        rcases hi_mem with hi_mem | hi_mem
        · rw [h_sets_t'_univ hi_mem, Set.inter_univ]
          exact h_meas_s' i hi_mem
        · rw [h_sets_s'_univ hi_mem, Set.univ_inter]
          exact h_meas_t' i hi_mem
      filter_upwards [hf_Indep S h_meas_s', hf_Indep T h_meas_t', hf_Indep (S ∪ T) h_meas_inter] with a h_indepS
        h_indepT h_indepST
      rw [h_eq_inter_S, h_eq_inter_T, h_indepS, h_indepT, h_Inter_inter, h_indepST, Finset.prod_union hST]
      congr 1
      · refine Finset.prod_congr rfl fun i hi => ?_
        rw [h_sets_t'_univ hi, Set.inter_univ]
      · refine Finset.prod_congr rfl fun i hi => ?_
        rw [h_sets_s'_univ hi, Set.univ_inter]
info: Mathlib/Probability/Independence/Kernel.lean:1016:0: [Elab.command] [0.011921] /--
    If `f` is a family of mutually independent random variables (`iIndepFun m f μ`) and `S, T` are
    two disjoint finite index sets, then the tuple formed by `f i` for `i ∈ S` is independent of the
    tuple `(f i)_i` for `i ∈ T`. -/
    theorem iIndepFun.indepFun_finset (S T : Finset ι) (hST : Disjoint S T) (hf_Indep : iIndepFun f κ μ)
        (hf_meas : ∀ i, Measurable (f i)) : IndepFun (fun a (i : S) => f i a) (fun a (i : T) => f i a) κ μ :=
      by
      rcases eq_or_ne μ 0 with rfl | hμ
      · simp
      obtain ⟨η, η_eq, hη⟩ : ∃ (η : Kernel α Ω), κ =ᵐ[μ] η ∧ IsMarkovKernel η :=
        exists_ae_eq_isMarkovKernel hf_Indep.ae_isProbabilityMeasure hμ
      apply
        IndepFun.congr
          (Filter.EventuallyEq.symm η_eq)
            -- We introduce π-systems, built from the π-system of boxes which generates `MeasurableSpace.pi`.
            
      let πSβ := Set.pi (Set.univ : Set S) '' Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s}
      let πS := {s : Set Ω | ∃ t ∈ πSβ, (fun a (i : S) => f i a) ⁻¹' t = s}
      have hπS_pi : IsPiSystem πS := by exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _
      have hπS_gen : (MeasurableSpace.pi.comap fun a (i : S) => f i a) = generateFrom πS :=
        by
        rw [generateFrom_pi.symm, comap_generateFrom]
        congr
      let πTβ := Set.pi (Set.univ : Set T) '' Set.pi (Set.univ : Set T) fun i => {s : Set (β i) | MeasurableSet[m i] s}
      let πT := {s : Set Ω | ∃ t ∈ πTβ, (fun a (i : T) => f i a) ⁻¹' t = s}
      have hπT_pi : IsPiSystem πT := by exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _
      have hπT_gen : (MeasurableSpace.pi.comap fun a (i : T) => f i a) = generateFrom πT :=
        by
        rw [generateFrom_pi.symm, comap_generateFrom]
        congr
          -- To prove independence, we prove independence of the generating π-systems.
          
      refine
        IndepSets.indep (Measurable.comap_le (measurable_pi_iff.mpr fun i => hf_meas i))
          (Measurable.comap_le (measurable_pi_iff.mpr fun i => hf_meas i)) hπS_pi hπT_pi hπS_gen hπT_gen ?_
      rintro _ _ ⟨s, ⟨sets_s, hs1, hs2⟩, rfl⟩ ⟨t, ⟨sets_t, ht1, ht2⟩, rfl⟩
      simp only [Set.mem_univ_pi, Set.mem_setOf_eq] at hs1 ht1
      rw [← hs2, ← ht2]
      classical
      let sets_s' : ∀ i : ι, Set (β i) := fun i => dite (i ∈ S) (fun hi => sets_s ⟨i, hi⟩) fun _ => Set.univ
      have h_sets_s'_eq : ∀ {i} (hi : i ∈ S), sets_s' i = sets_s ⟨i, hi⟩ := by intro i hi; simp_rw [sets_s', dif_pos hi]
      have h_sets_s'_univ : ∀ {i} (_hi : i ∈ T), sets_s' i = Set.univ := by intro i hi;
        simp_rw [sets_s', dif_neg (Finset.disjoint_right.mp hST hi)]
      let sets_t' : ∀ i : ι, Set (β i) := fun i => dite (i ∈ T) (fun hi => sets_t ⟨i, hi⟩) fun _ => Set.univ
      have h_sets_t'_univ : ∀ {i} (_hi : i ∈ S), sets_t' i = Set.univ := by intro i hi;
        simp_rw [sets_t', dif_neg (Finset.disjoint_left.mp hST hi)]
      have h_meas_s' : ∀ i ∈ S, MeasurableSet (sets_s' i) := by intro i hi; rw [h_sets_s'_eq hi]; exact hs1 _
      have h_meas_t' : ∀ i ∈ T, MeasurableSet (sets_t' i) := by intro i hi; simp_rw [sets_t', dif_pos hi]; exact ht1 _
      have h_eq_inter_S : (fun (ω : Ω) (i : ↥S) => f (↑i) ω) ⁻¹' Set.pi Set.univ sets_s = ⋂ i ∈ S, f i ⁻¹' sets_s' i :=
        by
        ext1 x
        simp_rw [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
        grind
      have h_eq_inter_T : (fun (ω : Ω) (i : ↥T) => f (↑i) ω) ⁻¹' Set.pi Set.univ sets_t = ⋂ i ∈ T, f i ⁻¹' sets_t' i :=
        by
        ext1 x
        simp only [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
        constructor <;> intro h
        · intro i hi; simp_rw [sets_t', dif_pos hi]; exact h ⟨i, hi⟩
        · grind
      replace hf_Indep := hf_Indep.congr η_eq
      rw [iIndepFun_iff_measure_inter_preimage_eq_mul] at hf_Indep
      have h_Inter_inter :
        ((⋂ i ∈ S, f i ⁻¹' sets_s' i) ∩ ⋂ i ∈ T, f i ⁻¹' sets_t' i) = ⋂ i ∈ S ∪ T, f i ⁻¹' (sets_s' i ∩ sets_t' i) :=
        by
        ext1 x
        simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
        constructor <;> intro h
        · intro i hi
          rcases hi with hiS | hiT
          · replace h := h.1 i hiS
            simp_rw [sets_s', sets_t', dif_pos hiS, dif_neg (Finset.disjoint_left.mp hST hiS)]
            simp only [sets_s'] at h
            exact ⟨by rwa [dif_pos hiS] at h, Set.mem_univ _⟩
          · replace h := h.2 i hiT
            simp_rw [sets_s', sets_t', dif_pos hiT, dif_neg (Finset.disjoint_right.mp hST hiT)]
            simp only [sets_t'] at h
            exact ⟨Set.mem_univ _, by rwa [dif_pos hiT] at h⟩
        · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩
      have h_meas_inter : ∀ i ∈ S ∪ T, MeasurableSet (sets_s' i ∩ sets_t' i) :=
        by
        intros i hi_mem
        rw [Finset.mem_union] at hi_mem
        rcases hi_mem with hi_mem | hi_mem
        · rw [h_sets_t'_univ hi_mem, Set.inter_univ]
          exact h_meas_s' i hi_mem
        · rw [h_sets_s'_univ hi_mem, Set.univ_inter]
          exact h_meas_t' i hi_mem
      filter_upwards [hf_Indep S h_meas_s', hf_Indep T h_meas_t', hf_Indep (S ∪ T) h_meas_inter] with a h_indepS
        h_indepT h_indepST
      rw [h_eq_inter_S, h_eq_inter_T, h_indepS, h_indepT, h_Inter_inter, h_indepST, Finset.prod_union hST]
      congr 1
      · refine Finset.prod_congr rfl fun i hi => ?_
        rw [h_sets_t'_univ hi, Set.inter_univ]
      · refine Finset.prod_congr rfl fun i hi => ?_
        rw [h_sets_s'_univ hi, Set.univ_inter]
info: Mathlib/Probability/Independence/Kernel.lean:1016:0: [Elab.async] [1.501551] elaborating proof of ProbabilityTheory.Kernel.iIndepFun.indepFun_finset
  [Elab.definition.value] [1.480871] ProbabilityTheory.Kernel.iIndepFun.indepFun_finset
    [Elab.step] [1.414036] 
          rcases eq_or_ne μ 0 with rfl | hμ
          · simp
          obtain ⟨η, η_eq, hη⟩ : ∃ (η : Kernel α Ω), κ =ᵐ[μ] η ∧ IsMarkovKernel η :=
            exists_ae_eq_isMarkovKernel hf_Indep.ae_isProbabilityMeasure hμ
          apply
            IndepFun.congr
              (Filter.EventuallyEq.symm η_eq)
                -- We introduce π-systems, built from the π-system of boxes which generates `MeasurableSpace.pi`.
                
          let πSβ :=
            Set.pi (Set.univ : Set S) '' Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s}
          let πS := {s : Set Ω | ∃ t ∈ πSβ, (fun a (i : S) => f i a) ⁻¹' t = s}
          have hπS_pi : IsPiSystem πS := by exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _
          have hπS_gen : (MeasurableSpace.pi.comap fun a (i : S) => f i a) = generateFrom πS :=
            by
            rw [generateFrom_pi.symm, comap_generateFrom]
            congr
          let πTβ :=
            Set.pi (Set.univ : Set T) '' Set.pi (Set.univ : Set T) fun i => {s : Set (β i) | MeasurableSet[m i] s}
          let πT := {s : Set Ω | ∃ t ∈ πTβ, (fun a (i : T) => f i a) ⁻¹' t = s}
          have hπT_pi : IsPiSystem πT := by exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _
          have hπT_gen : (MeasurableSpace.pi.comap fun a (i : T) => f i a) = generateFrom πT :=
            by
            rw [generateFrom_pi.symm, comap_generateFrom]
            congr
              -- To prove independence, we prove independence of the generating π-systems.
              
          refine
            IndepSets.indep (Measurable.comap_le (measurable_pi_iff.mpr fun i => hf_meas i))
              (Measurable.comap_le (measurable_pi_iff.mpr fun i => hf_meas i)) hπS_pi hπT_pi hπS_gen hπT_gen ?_
          rintro _ _ ⟨s, ⟨sets_s, hs1, hs2⟩, rfl⟩ ⟨t, ⟨sets_t, ht1, ht2⟩, rfl⟩
          simp only [Set.mem_univ_pi, Set.mem_setOf_eq] at hs1 ht1
          rw [← hs2, ← ht2]
          classical
          let sets_s' : ∀ i : ι, Set (β i) := fun i => dite (i ∈ S) (fun hi => sets_s ⟨i, hi⟩) fun _ => Set.univ
          have h_sets_s'_eq : ∀ {i} (hi : i ∈ S), sets_s' i = sets_s ⟨i, hi⟩ := by intro i hi;
            simp_rw [sets_s', dif_pos hi]
          have h_sets_s'_univ : ∀ {i} (_hi : i ∈ T), sets_s' i = Set.univ := by intro i hi;
            simp_rw [sets_s', dif_neg (Finset.disjoint_right.mp hST hi)]
          let sets_t' : ∀ i : ι, Set (β i) := fun i => dite (i ∈ T) (fun hi => sets_t ⟨i, hi⟩) fun _ => Set.univ
          have h_sets_t'_univ : ∀ {i} (_hi : i ∈ S), sets_t' i = Set.univ := by intro i hi;
            simp_rw [sets_t', dif_neg (Finset.disjoint_left.mp hST hi)]
          have h_meas_s' : ∀ i ∈ S, MeasurableSet (sets_s' i) := by intro i hi; rw [h_sets_s'_eq hi]; exact hs1 _
          have h_meas_t' : ∀ i ∈ T, MeasurableSet (sets_t' i) := by intro i hi; simp_rw [sets_t', dif_pos hi];
            exact ht1 _
          have h_eq_inter_S :
            (fun (ω : Ω) (i : ↥S) => f (↑i) ω) ⁻¹' Set.pi Set.univ sets_s = ⋂ i ∈ S, f i ⁻¹' sets_s' i :=
            by
            ext1 x
            simp_rw [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
            grind
          have h_eq_inter_T :
            (fun (ω : Ω) (i : ↥T) => f (↑i) ω) ⁻¹' Set.pi Set.univ sets_t = ⋂ i ∈ T, f i ⁻¹' sets_t' i :=
            by
            ext1 x
            simp only [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
            constructor <;> intro h
            · intro i hi; simp_rw [sets_t', dif_pos hi]; exact h ⟨i, hi⟩
            · grind
          replace hf_Indep := hf_Indep.congr η_eq
          rw [iIndepFun_iff_measure_inter_preimage_eq_mul] at hf_Indep
          have h_Inter_inter :
            ((⋂ i ∈ S, f i ⁻¹' sets_s' i) ∩ ⋂ i ∈ T, f i ⁻¹' sets_t' i) =
              ⋂ i ∈ S ∪ T, f i ⁻¹' (sets_s' i ∩ sets_t' i) :=
            by
            ext1 x
            simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
            constructor <;> intro h
            · intro i hi
              rcases hi with hiS | hiT
              · replace h := h.1 i hiS
                simp_rw [sets_s', sets_t', dif_pos hiS, dif_neg (Finset.disjoint_left.mp hST hiS)]
                simp only [sets_s'] at h
                exact ⟨by rwa [dif_pos hiS] at h, Set.mem_univ _⟩
              · replace h := h.2 i hiT
                simp_rw [sets_s', sets_t', dif_pos hiT, dif_neg (Finset.disjoint_right.mp hST hiT)]
                simp only [sets_t'] at h
                exact ⟨Set.mem_univ _, by rwa [dif_pos hiT] at h⟩
            · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩
          have h_meas_inter : ∀ i ∈ S ∪ T, MeasurableSet (sets_s' i ∩ sets_t' i) :=
            by
            intros i hi_mem
            rw [Finset.mem_union] at hi_mem
            rcases hi_mem with hi_mem | hi_mem
            · rw [h_sets_t'_univ hi_mem, Set.inter_univ]
              exact h_meas_s' i hi_mem
            · rw [h_sets_s'_univ hi_mem, Set.univ_inter]
              exact h_meas_t' i hi_mem
          filter_upwards [hf_Indep S h_meas_s', hf_Indep T h_meas_t', hf_Indep (S ∪ T) h_meas_inter] with a h_indepS
            h_indepT h_indepST
          rw [h_eq_inter_S, h_eq_inter_T, h_indepS, h_indepT, h_Inter_inter, h_indepST, Finset.prod_union hST]
          congr 1
          · refine Finset.prod_congr rfl fun i hi => ?_
            rw [h_sets_t'_univ hi, Set.inter_univ]
          · refine Finset.prod_congr rfl fun i hi => ?_
            rw [h_sets_s'_univ hi, Set.univ_inter]
      [Elab.step] [1.414018] 
            rcases eq_or_ne μ 0 with rfl | hμ
            · simp
            obtain ⟨η, η_eq, hη⟩ : ∃ (η : Kernel α Ω), κ =ᵐ[μ] η ∧ IsMarkovKernel η :=
              exists_ae_eq_isMarkovKernel hf_Indep.ae_isProbabilityMeasure hμ
            apply
              IndepFun.congr
                (Filter.EventuallyEq.symm η_eq)
                  -- We introduce π-systems, built from the π-system of boxes which generates `MeasurableSpace.pi`.
                  
            let πSβ :=
              Set.pi (Set.univ : Set S) '' Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s}
            let πS := {s : Set Ω | ∃ t ∈ πSβ, (fun a (i : S) => f i a) ⁻¹' t = s}
            have hπS_pi : IsPiSystem πS := by exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _
            have hπS_gen : (MeasurableSpace.pi.comap fun a (i : S) => f i a) = generateFrom πS :=
              by
              rw [generateFrom_pi.symm, comap_generateFrom]
              congr
            let πTβ :=
              Set.pi (Set.univ : Set T) '' Set.pi (Set.univ : Set T) fun i => {s : Set (β i) | MeasurableSet[m i] s}
            let πT := {s : Set Ω | ∃ t ∈ πTβ, (fun a (i : T) => f i a) ⁻¹' t = s}
            have hπT_pi : IsPiSystem πT := by exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _
            have hπT_gen : (MeasurableSpace.pi.comap fun a (i : T) => f i a) = generateFrom πT :=
              by
              rw [generateFrom_pi.symm, comap_generateFrom]
              congr
                -- To prove independence, we prove independence of the generating π-systems.
                
            refine
              IndepSets.indep (Measurable.comap_le (measurable_pi_iff.mpr fun i => hf_meas i))
                (Measurable.comap_le (measurable_pi_iff.mpr fun i => hf_meas i)) hπS_pi hπT_pi hπS_gen hπT_gen ?_
            rintro _ _ ⟨s, ⟨sets_s, hs1, hs2⟩, rfl⟩ ⟨t, ⟨sets_t, ht1, ht2⟩, rfl⟩
            simp only [Set.mem_univ_pi, Set.mem_setOf_eq] at hs1 ht1
            rw [← hs2, ← ht2]
            classical
            let sets_s' : ∀ i : ι, Set (β i) := fun i => dite (i ∈ S) (fun hi => sets_s ⟨i, hi⟩) fun _ => Set.univ
            have h_sets_s'_eq : ∀ {i} (hi : i ∈ S), sets_s' i = sets_s ⟨i, hi⟩ := by intro i hi;
              simp_rw [sets_s', dif_pos hi]
            have h_sets_s'_univ : ∀ {i} (_hi : i ∈ T), sets_s' i = Set.univ := by intro i hi;
              simp_rw [sets_s', dif_neg (Finset.disjoint_right.mp hST hi)]
            let sets_t' : ∀ i : ι, Set (β i) := fun i => dite (i ∈ T) (fun hi => sets_t ⟨i, hi⟩) fun _ => Set.univ
            have h_sets_t'_univ : ∀ {i} (_hi : i ∈ S), sets_t' i = Set.univ := by intro i hi;
              simp_rw [sets_t', dif_neg (Finset.disjoint_left.mp hST hi)]
            have h_meas_s' : ∀ i ∈ S, MeasurableSet (sets_s' i) := by intro i hi; rw [h_sets_s'_eq hi]; exact hs1 _
            have h_meas_t' : ∀ i ∈ T, MeasurableSet (sets_t' i) := by intro i hi; simp_rw [sets_t', dif_pos hi];
              exact ht1 _
            have h_eq_inter_S :
              (fun (ω : Ω) (i : ↥S) => f (↑i) ω) ⁻¹' Set.pi Set.univ sets_s = ⋂ i ∈ S, f i ⁻¹' sets_s' i :=
              by
              ext1 x
              simp_rw [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
              grind
            have h_eq_inter_T :
              (fun (ω : Ω) (i : ↥T) => f (↑i) ω) ⁻¹' Set.pi Set.univ sets_t = ⋂ i ∈ T, f i ⁻¹' sets_t' i :=
              by
              ext1 x
              simp only [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
              constructor <;> intro h
              · intro i hi; simp_rw [sets_t', dif_pos hi]; exact h ⟨i, hi⟩
              · grind
            replace hf_Indep := hf_Indep.congr η_eq
            rw [iIndepFun_iff_measure_inter_preimage_eq_mul] at hf_Indep
            have h_Inter_inter :
              ((⋂ i ∈ S, f i ⁻¹' sets_s' i) ∩ ⋂ i ∈ T, f i ⁻¹' sets_t' i) =
                ⋂ i ∈ S ∪ T, f i ⁻¹' (sets_s' i ∩ sets_t' i) :=
              by
              ext1 x
              simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
              constructor <;> intro h
              · intro i hi
                rcases hi with hiS | hiT
                · replace h := h.1 i hiS
                  simp_rw [sets_s', sets_t', dif_pos hiS, dif_neg (Finset.disjoint_left.mp hST hiS)]
                  simp only [sets_s'] at h
                  exact ⟨by rwa [dif_pos hiS] at h, Set.mem_univ _⟩
                · replace h := h.2 i hiT
                  simp_rw [sets_s', sets_t', dif_pos hiT, dif_neg (Finset.disjoint_right.mp hST hiT)]
                  simp only [sets_t'] at h
                  exact ⟨Set.mem_univ _, by rwa [dif_pos hiT] at h⟩
              · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩
            have h_meas_inter : ∀ i ∈ S ∪ T, MeasurableSet (sets_s' i ∩ sets_t' i) :=
              by
              intros i hi_mem
              rw [Finset.mem_union] at hi_mem
              rcases hi_mem with hi_mem | hi_mem
              · rw [h_sets_t'_univ hi_mem, Set.inter_univ]
                exact h_meas_s' i hi_mem
              · rw [h_sets_s'_univ hi_mem, Set.univ_inter]
                exact h_meas_t' i hi_mem
            filter_upwards [hf_Indep S h_meas_s', hf_Indep T h_meas_t', hf_Indep (S ∪ T) h_meas_inter] with a h_indepS
              h_indepT h_indepST
            rw [h_eq_inter_S, h_eq_inter_T, h_indepS, h_indepT, h_Inter_inter, h_indepST, Finset.prod_union hST]
            congr 1
            · refine Finset.prod_congr rfl fun i hi => ?_
              rw [h_sets_t'_univ hi, Set.inter_univ]
            · refine Finset.prod_congr rfl fun i hi => ?_
              rw [h_sets_s'_univ hi, Set.univ_inter]
        [Elab.step] [0.012797] obtain ⟨η, η_eq, hη⟩ : ∃ (η : Kernel α Ω), κ =ᵐ[μ] η ∧ IsMarkovKernel η :=
              exists_ae_eq_isMarkovKernel hf_Indep.ae_isProbabilityMeasure hμ
        [Elab.step] [0.022035] let πSβ :=
              Set.pi (Set.univ : Set S) '' Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s}
          [Elab.step] [0.021981] refine_lift
                let πSβ :=
                  Set.pi (Set.univ : Set S) ''
                    Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s};
                ?_
            [Elab.step] [0.021973] focus
                  (refine
                      no_implicit_lambda%
                        (let πSβ :=
                          Set.pi (Set.univ : Set S) ''
                            Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s};
                        ?_);
                    rotate_right)
              [Elab.step] [0.021963] (refine
                        no_implicit_lambda%
                          (let πSβ :=
                            Set.pi (Set.univ : Set S) ''
                              Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s};
                          ?_);
                      rotate_right)
                [Elab.step] [0.021956] (refine
                          no_implicit_lambda%
                            (let πSβ :=
                              Set.pi (Set.univ : Set S) ''
                                Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s};
                            ?_);
                        rotate_right)
                  [Elab.step] [0.021948] (refine
                          no_implicit_lambda%
                            (let πSβ :=
                              Set.pi (Set.univ : Set S) ''
                                Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s};
                            ?_);
                        rotate_right)
                    [Elab.step] [0.021941] refine
                            no_implicit_lambda%
                              (let πSβ :=
                                Set.pi (Set.univ : Set S) ''
                                  Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s};
                              ?_);
                          rotate_right
                      [Elab.step] [0.021934] refine
                              no_implicit_lambda%
                                (let πSβ :=
                                  Set.pi (Set.univ : Set S) ''
                                    Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s};
                                ?_);
                            rotate_right
                        [Elab.step] [0.021902] refine
                              no_implicit_lambda%
                                (let πSβ :=
                                  Set.pi (Set.univ : Set S) ''
                                    Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s};
                                ?_)
                          [Elab.step] [0.021763] expected type: IndepFun (fun a i ↦ f (↑i) a) (fun a i ↦ f (↑i) a) η
                                μ, term
                              no_implicit_lambda%
                                (let πSβ :=
                                  Set.pi (Set.univ : Set S) ''
                                    Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s};
                                ?_)
                            [Elab.step] [0.021752] expected type: IndepFun (fun a i ↦ f (↑i) a) (fun a i ↦ f (↑i) a) η
                                  μ, term
                                let πSβ :=
                                  Set.pi (Set.univ : Set S) ''
                                    Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s};
                                ?_
                              [Elab.step] [0.021594] expected type: Set (Set ((i : { x // x ∈ S }) → β ↑i)), term
                                  Set.pi (Set.univ : Set S) ''
                                    Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s}
                                [Elab.step] [0.021354] expected type: Set (Set ((i : { x // x ∈ S }) → β ↑i)), term
                                    image✝ (Set.pi (Set.univ : Set S))
                                      (Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s})
                                  [Elab.step] [0.012004] expected type: Set ((i : { x // x ∈ S }) → Set (β ↑i)), term
                                      Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s}
        [Elab.step] [0.413975] have hπS_pi : IsPiSystem πS := by exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _
          [Elab.step] [0.413911] focus
                refine
                  no_implicit_lambda%
                    (have hπS_pi : IsPiSystem πS := ?body✝;
                    ?_)
                case body✝ => with_annotate_state"by" (exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _)
            [Elab.step] [0.413901] 
                  refine
                    no_implicit_lambda%
                      (have hπS_pi : IsPiSystem πS := ?body✝;
                      ?_)
                  case body✝ => with_annotate_state"by" (exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _)
              [Elab.step] [0.413895] 
                    refine
                      no_implicit_lambda%
                        (have hπS_pi : IsPiSystem πS := ?body✝;
                        ?_)
                    case body✝ => with_annotate_state"by" (exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _)
                [Elab.step] [0.413307] case body✝ =>
                      with_annotate_state"by" (exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _)
                  [Elab.step] [0.413281] with_annotate_state"by" (exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _)
                    [Elab.step] [0.413275] with_annotate_state"by" (exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _)
                      [Elab.step] [0.413269] with_annotate_state"by" (exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _)
                        [Elab.step] [0.413262] (exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _)
                          [Elab.step] [0.413255] exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _
                            [Elab.step] [0.413248] exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _
                              [Elab.step] [0.413236] exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _
                                [Elab.step] [0.412550] expected type: IsPiSystem πS, term
                                    IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _
                                  [Meta.isDefEq] [0.411447] ❌️ IsPiSystem
                                        πS =?= IsPiSystem
[… 2297 lines omitted …]
                        with_annotate_state"by"
                          ( ext1 x
                            simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
                            constructor <;> intro h
                            · intro i hi
                              rcases hi with hiS | hiT
                              · replace h := h.1 i hiS
                                simp_rw [sets_s', sets_t', dif_pos hiS, dif_neg (Finset.disjoint_left.mp hST hiS)]
                                simp only [sets_s'] at h
                                exact ⟨by rwa [dif_pos hiS] at h, Set.mem_univ _⟩
                              · replace h := h.2 i hiT
                                simp_rw [sets_s', sets_t', dif_pos hiT, dif_neg (Finset.disjoint_right.mp hST hiT)]
                                simp only [sets_t'] at h
                                exact ⟨Set.mem_univ _, by rwa [dif_pos hiT] at h⟩
                            · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩)
                  [Elab.step] [0.122578] 
                        refine
                          no_implicit_lambda%
                            (have h_Inter_inter :
                              ((⋂ i ∈ S, f i ⁻¹' sets_s' i) ∩ ⋂ i ∈ T, f i ⁻¹' sets_t' i) =
                                ⋂ i ∈ S ∪ T, f i ⁻¹' (sets_s' i ∩ sets_t' i) :=
                              ?body✝;
                            ?_)
                        case body✝ =>
                          with_annotate_state"by"
                            ( ext1 x
                              simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
                              constructor <;> intro h
                              · intro i hi
                                rcases hi with hiS | hiT
                                · replace h := h.1 i hiS
                                  simp_rw [sets_s', sets_t', dif_pos hiS, dif_neg (Finset.disjoint_left.mp hST hiS)]
                                  simp only [sets_s'] at h
                                  exact ⟨by rwa [dif_pos hiS] at h, Set.mem_univ _⟩
                                · replace h := h.2 i hiT
                                  simp_rw [sets_s', sets_t', dif_pos hiT, dif_neg (Finset.disjoint_right.mp hST hiT)]
                                  simp only [sets_t'] at h
                                  exact ⟨Set.mem_univ _, by rwa [dif_pos hiT] at h⟩
                              · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩)
                    [Elab.step] [0.122566] 
                          refine
                            no_implicit_lambda%
                              (have h_Inter_inter :
                                ((⋂ i ∈ S, f i ⁻¹' sets_s' i) ∩ ⋂ i ∈ T, f i ⁻¹' sets_t' i) =
                                  ⋂ i ∈ S ∪ T, f i ⁻¹' (sets_s' i ∩ sets_t' i) :=
                                ?body✝;
                              ?_)
                          case body✝ =>
                            with_annotate_state"by"
                              ( ext1 x
                                simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
                                constructor <;> intro h
                                · intro i hi
                                  rcases hi with hiS | hiT
                                  · replace h := h.1 i hiS
                                    simp_rw [sets_s', sets_t', dif_pos hiS, dif_neg (Finset.disjoint_left.mp hST hiS)]
                                    simp only [sets_s'] at h
                                    exact ⟨by rwa [dif_pos hiS] at h, Set.mem_univ _⟩
                                  · replace h := h.2 i hiT
                                    simp_rw [sets_s', sets_t', dif_pos hiT, dif_neg (Finset.disjoint_right.mp hST hiT)]
                                    simp only [sets_t'] at h
                                    exact ⟨Set.mem_univ _, by rwa [dif_pos hiT] at h⟩
                                · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩)
                      [Elab.step] [0.011860] refine
                            no_implicit_lambda%
                              (have h_Inter_inter :
                                ((⋂ i ∈ S, f i ⁻¹' sets_s' i) ∩ ⋂ i ∈ T, f i ⁻¹' sets_t' i) =
                                  ⋂ i ∈ S ∪ T, f i ⁻¹' (sets_s' i ∩ sets_t' i) :=
                                ?body✝;
                              ?_)
                        [Elab.step] [0.011786] expected type: ∀ᵐ (a : α) ∂μ,
                              (η a)
                                  ((fun a i ↦ f (↑i) a) ⁻¹' univ.pi sets_s ∩ (fun a i ↦ f (↑i) a) ⁻¹' univ.pi sets_t) =
                                (η a) ((fun a i ↦ f (↑i) a) ⁻¹' univ.pi sets_s) *
                                  (η a) ((fun a i ↦ f (↑i) a) ⁻¹' univ.pi sets_t), term
                            no_implicit_lambda%
                              (have h_Inter_inter :
                                ((⋂ i ∈ S, f i ⁻¹' sets_s' i) ∩ ⋂ i ∈ T, f i ⁻¹' sets_t' i) =
                                  ⋂ i ∈ S ∪ T, f i ⁻¹' (sets_s' i ∩ sets_t' i) :=
                                ?body✝;
                              ?_)
                          [Elab.step] [0.011776] expected type: ∀ᵐ (a : α) ∂μ,
                                (η a)
                                    ((fun a i ↦ f (↑i) a) ⁻¹' univ.pi sets_s ∩
                                      (fun a i ↦ f (↑i) a) ⁻¹' univ.pi sets_t) =
                                  (η a) ((fun a i ↦ f (↑i) a) ⁻¹' univ.pi sets_s) *
                                    (η a) ((fun a i ↦ f (↑i) a) ⁻¹' univ.pi sets_t), term
                              (have h_Inter_inter :
                                ((⋂ i ∈ S, f i ⁻¹' sets_s' i) ∩ ⋂ i ∈ T, f i ⁻¹' sets_t' i) =
                                  ⋂ i ∈ S ∪ T, f i ⁻¹' (sets_s' i ∩ sets_t' i) :=
                                ?body✝;
                              ?_)
                            [Elab.step] [0.011762] expected type: ∀ᵐ (a : α) ∂μ,
                                  (η a)
                                      ((fun a i ↦ f (↑i) a) ⁻¹' univ.pi sets_s ∩
                                        (fun a i ↦ f (↑i) a) ⁻¹' univ.pi sets_t) =
                                    (η a) ((fun a i ↦ f (↑i) a) ⁻¹' univ.pi sets_s) *
                                      (η a) ((fun a i ↦ f (↑i) a) ⁻¹' univ.pi sets_t), term
                                have h_Inter_inter :
                                  ((⋂ i ∈ S, f i ⁻¹' sets_s' i) ∩ ⋂ i ∈ T, f i ⁻¹' sets_t' i) =
                                    ⋂ i ∈ S ∪ T, f i ⁻¹' (sets_s' i ∩ sets_t' i) :=
                                  ?body✝;
                                ?_
                              [Elab.step] [0.011579] expected type: Sort ?u.81043, term
                                  ((⋂ i ∈ S, f i ⁻¹' sets_s' i) ∩ ⋂ i ∈ T, f i ⁻¹' sets_t' i) =
                                    ⋂ i ∈ S ∪ T, f i ⁻¹' (sets_s' i ∩ sets_t' i)
                                [Elab.step] [0.011569] expected type: Sort ?u.81043, term
                                    binrel% Eq✝ ((⋂ i ∈ S, f i ⁻¹' sets_s' i) ∩ ⋂ i ∈ T, f i ⁻¹' sets_t' i)
                                      (⋂ i ∈ S ∪ T, f i ⁻¹' (sets_s' i ∩ sets_t' i))
                      [Elab.step] [0.110667] case body✝ =>
                            with_annotate_state"by"
                              ( ext1 x
                                simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
                                constructor <;> intro h
                                · intro i hi
                                  rcases hi with hiS | hiT
                                  · replace h := h.1 i hiS
                                    simp_rw [sets_s', sets_t', dif_pos hiS, dif_neg (Finset.disjoint_left.mp hST hiS)]
                                    simp only [sets_s'] at h
                                    exact ⟨by rwa [dif_pos hiS] at h, Set.mem_univ _⟩
                                  · replace h := h.2 i hiT
                                    simp_rw [sets_s', sets_t', dif_pos hiT, dif_neg (Finset.disjoint_right.mp hST hiT)]
                                    simp only [sets_t'] at h
                                    exact ⟨Set.mem_univ _, by rwa [dif_pos hiT] at h⟩
                                · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩)
                        [Elab.step] [0.110572] with_annotate_state"by"
                                ( ext1 x
                                  simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
                                  constructor <;> intro h
                                  · intro i hi
                                    rcases hi with hiS | hiT
                                    · replace h := h.1 i hiS
                                      simp_rw [sets_s', sets_t', dif_pos hiS, dif_neg (Finset.disjoint_left.mp hST hiS)]
                                      simp only [sets_s'] at h
                                      exact ⟨by rwa [dif_pos hiS] at h, Set.mem_univ _⟩
                                    · replace h := h.2 i hiT
                                      simp_rw [sets_s', sets_t', dif_pos hiT,
                                        dif_neg (Finset.disjoint_right.mp hST hiT)]
                                      simp only [sets_t'] at h
                                      exact ⟨Set.mem_univ _, by rwa [dif_pos hiT] at h⟩
                                  · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩)
                          [Elab.step] [0.110567] with_annotate_state"by"
                                  ( ext1 x
                                    simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
                                    constructor <;> intro h
                                    · intro i hi
                                      rcases hi with hiS | hiT
                                      · replace h := h.1 i hiS
                                        simp_rw [sets_s', sets_t', dif_pos hiS,
                                          dif_neg (Finset.disjoint_left.mp hST hiS)]
                                        simp only [sets_s'] at h
                                        exact ⟨by rwa [dif_pos hiS] at h, Set.mem_univ _⟩
                                      · replace h := h.2 i hiT
                                        simp_rw [sets_s', sets_t', dif_pos hiT,
                                          dif_neg (Finset.disjoint_right.mp hST hiT)]
                                        simp only [sets_t'] at h
                                        exact ⟨Set.mem_univ _, by rwa [dif_pos hiT] at h⟩
                                    · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩)
                            [Elab.step] [0.110561] with_annotate_state"by"
                                  ( ext1 x
                                    simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
                                    constructor <;> intro h
                                    · intro i hi
                                      rcases hi with hiS | hiT
                                      · replace h := h.1 i hiS
                                        simp_rw [sets_s', sets_t', dif_pos hiS,
                                          dif_neg (Finset.disjoint_left.mp hST hiS)]
                                        simp only [sets_s'] at h
                                        exact ⟨by rwa [dif_pos hiS] at h, Set.mem_univ _⟩
                                      · replace h := h.2 i hiT
                                        simp_rw [sets_s', sets_t', dif_pos hiT,
                                          dif_neg (Finset.disjoint_right.mp hST hiT)]
                                        simp only [sets_t'] at h
                                        exact ⟨Set.mem_univ _, by rwa [dif_pos hiT] at h⟩
                                    · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩)
                              [Elab.step] [0.110554] (
                                    ext1 x
                                    simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
                                    constructor <;> intro h
                                    · intro i hi
                                      rcases hi with hiS | hiT
                                      · replace h := h.1 i hiS
                                        simp_rw [sets_s', sets_t', dif_pos hiS,
                                          dif_neg (Finset.disjoint_left.mp hST hiS)]
                                        simp only [sets_s'] at h
                                        exact ⟨by rwa [dif_pos hiS] at h, Set.mem_univ _⟩
                                      · replace h := h.2 i hiT
                                        simp_rw [sets_s', sets_t', dif_pos hiT,
                                          dif_neg (Finset.disjoint_right.mp hST hiT)]
                                        simp only [sets_t'] at h
                                        exact ⟨Set.mem_univ _, by rwa [dif_pos hiT] at h⟩
                                    · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩)
                                [Elab.step] [0.110548] 
                                      ext1 x
                                      simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
                                      constructor <;> intro h
                                      · intro i hi
                                        rcases hi with hiS | hiT
                                        · replace h := h.1 i hiS
                                          simp_rw [sets_s', sets_t', dif_pos hiS,
                                            dif_neg (Finset.disjoint_left.mp hST hiS)]
                                          simp only [sets_s'] at h
                                          exact ⟨by rwa [dif_pos hiS] at h, Set.mem_univ _⟩
                                        · replace h := h.2 i hiT
                                          simp_rw [sets_s', sets_t', dif_pos hiT,
                                            dif_neg (Finset.disjoint_right.mp hST hiT)]
                                          simp only [sets_t'] at h
                                          exact ⟨Set.mem_univ _, by rwa [dif_pos hiT] at h⟩
                                      · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩
                                  [Elab.step] [0.110540] 
                                        ext1 x
                                        simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
                                        constructor <;> intro h
                                        · intro i hi
                                          rcases hi with hiS | hiT
                                          · replace h := h.1 i hiS
                                            simp_rw [sets_s', sets_t', dif_pos hiS,
                                              dif_neg (Finset.disjoint_left.mp hST hiS)]
                                            simp only [sets_s'] at h
                                            exact ⟨by rwa [dif_pos hiS] at h, Set.mem_univ _⟩
                                          · replace h := h.2 i hiT
                                            simp_rw [sets_s', sets_t', dif_pos hiT,
                                              dif_neg (Finset.disjoint_right.mp hST hiT)]
                                            simp only [sets_t'] at h
                                            exact ⟨Set.mem_univ _, by rwa [dif_pos hiT] at h⟩
                                        · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩
                                    [Elab.step] [0.034752] simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage,
                                          Finset.mem_union]
                                    [Elab.step] [0.071023] ·
                                          intro i hi
                                          rcases hi with hiS | hiT
                                          · replace h := h.1 i hiS
                                            simp_rw [sets_s', sets_t', dif_pos hiS,
                                              dif_neg (Finset.disjoint_left.mp hST hiS)]
                                            simp only [sets_s'] at h
                                            exact ⟨by rwa [dif_pos hiS] at h, Set.mem_univ _⟩
                                          · replace h := h.2 i hiT
                                            simp_rw [sets_s', sets_t', dif_pos hiT,
                                              dif_neg (Finset.disjoint_right.mp hST hiT)]
                                            simp only [sets_t'] at h
                                            exact ⟨Set.mem_univ _, by rwa [dif_pos hiT] at h⟩
                                      [Elab.step] [0.070940] 
                                            intro i hi
                                            rcases hi with hiS | hiT
                                            · replace h := h.1 i hiS
                                              simp_rw [sets_s', sets_t', dif_pos hiS,
                                                dif_neg (Finset.disjoint_left.mp hST hiS)]
                                              simp only [sets_s'] at h
                                              exact ⟨by rwa [dif_pos hiS] at h, Set.mem_univ _⟩
                                            · replace h := h.2 i hiT
                                              simp_rw [sets_s', sets_t', dif_pos hiT,
                                                dif_neg (Finset.disjoint_right.mp hST hiT)]
                                              simp only [sets_t'] at h
                                              exact ⟨Set.mem_univ _, by rwa [dif_pos hiT] at h⟩
                                        [Elab.step] [0.070932] 
                                              intro i hi
                                              rcases hi with hiS | hiT
                                              · replace h := h.1 i hiS
                                                simp_rw [sets_s', sets_t', dif_pos hiS,
                                                  dif_neg (Finset.disjoint_left.mp hST hiS)]
                                                simp only [sets_s'] at h
                                                exact ⟨by rwa [dif_pos hiS] at h, Set.mem_univ _⟩
                                              · replace h := h.2 i hiT
                                                simp_rw [sets_s', sets_t', dif_pos hiT,
                                                  dif_neg (Finset.disjoint_right.mp hST hiT)]
                                                simp only [sets_t'] at h
                                                exact ⟨Set.mem_univ _, by rwa [dif_pos hiT] at h⟩
                                          [Elab.step] [0.034983] ·
                                                replace h := h.1 i hiS
                                                simp_rw [sets_s', sets_t', dif_pos hiS,
                                                  dif_neg (Finset.disjoint_left.mp hST hiS)]
                                                simp only [sets_s'] at h
                                                exact ⟨by rwa [dif_pos hiS] at h, Set.mem_univ _⟩
                                            [Elab.step] [0.034957] 
                                                  replace h := h.1 i hiS
                                                  simp_rw [sets_s', sets_t', dif_pos hiS,
                                                    dif_neg (Finset.disjoint_left.mp hST hiS)]
                                                  simp only [sets_s'] at h
                                                  exact ⟨by rwa [dif_pos hiS] at h, Set.mem_univ _⟩
                                              [Elab.step] [0.034949] 
                                                    replace h := h.1 i hiS
                                                    simp_rw [sets_s', sets_t', dif_pos hiS,
                                                      dif_neg (Finset.disjoint_left.mp hST hiS)]
                                                    simp only [sets_s'] at h
                                                    exact ⟨by rwa [dif_pos hiS] at h, Set.mem_univ _⟩
                                                [Elab.step] [0.024106] simp_rw [sets_s', sets_t', dif_pos hiS,
                                                      dif_neg (Finset.disjoint_left.mp hST hiS)]
                                          [Elab.step] [0.034839] ·
                                                replace h := h.2 i hiT
                                                simp_rw [sets_s', sets_t', dif_pos hiT,
                                                  dif_neg (Finset.disjoint_right.mp hST hiT)]
                                                simp only [sets_t'] at h
                                                exact ⟨Set.mem_univ _, by rwa [dif_pos hiT] at h⟩
                                            [Elab.step] [0.034815] 
                                                  replace h := h.2 i hiT
                                                  simp_rw [sets_s', sets_t', dif_pos hiT,
                                                    dif_neg (Finset.disjoint_right.mp hST hiT)]
                                                  simp only [sets_t'] at h
                                                  exact ⟨Set.mem_univ _, by rwa [dif_pos hiT] at h⟩
                                              [Elab.step] [0.034805] 
                                                    replace h := h.2 i hiT
                                                    simp_rw [sets_s', sets_t', dif_pos hiT,
                                                      dif_neg (Finset.disjoint_right.mp hST hiT)]
                                                    simp only [sets_t'] at h
                                                    exact ⟨Set.mem_univ _, by rwa [dif_pos hiT] at h⟩
                                                [Elab.step] [0.027466] simp_rw [sets_s', sets_t', dif_pos hiT,
                                                      dif_neg (Finset.disjoint_right.mp hST hiT)]
                                                  [Elab.step] [0.011121] simp only [sets_t']
              [Elab.step] [0.018517] have h_meas_inter : ∀ i ∈ S ∪ T, MeasurableSet (sets_s' i ∩ sets_t' i) :=
                    by
                    intros i hi_mem
                    rw [Finset.mem_union] at hi_mem
                    rcases hi_mem with hi_mem | hi_mem
                    · rw [h_sets_t'_univ hi_mem, Set.inter_univ]
                      exact h_meas_s' i hi_mem
                    · rw [h_sets_s'_univ hi_mem, Set.univ_inter]
                      exact h_meas_t' i hi_mem
                [Elab.step] [0.018484] focus
                      refine
                        no_implicit_lambda%
                          (have h_meas_inter : ∀ i ∈ S ∪ T, MeasurableSet (sets_s' i ∩ sets_t' i) := ?body✝;
                          ?_)
                      case body✝ =>
                        with_annotate_state"by"
                          ( intros i hi_mem
                            rw [Finset.mem_union] at hi_mem
                            rcases hi_mem with hi_mem | hi_mem
                            · rw [h_sets_t'_univ hi_mem, Set.inter_univ]
                              exact h_meas_s' i hi_mem
                            · rw [h_sets_s'_univ hi_mem, Set.univ_inter]
                              exact h_meas_t' i hi_mem)
                  [Elab.step] [0.018473] 
                        refine
                          no_implicit_lambda%
                            (have h_meas_inter : ∀ i ∈ S ∪ T, MeasurableSet (sets_s' i ∩ sets_t' i) := ?body✝;
                            ?_)
                        case body✝ =>
                          with_annotate_state"by"
                            ( intros i hi_mem
                              rw [Finset.mem_union] at hi_mem
                              rcases hi_mem with hi_mem | hi_mem
                              · rw [h_sets_t'_univ hi_mem, Set.inter_univ]
                                exact h_meas_s' i hi_mem
                              · rw [h_sets_s'_univ hi_mem, Set.univ_inter]
                                exact h_meas_t' i hi_mem)
                    [Elab.step] [0.018466] 
                          refine
                            no_implicit_lambda%
                              (have h_meas_inter : ∀ i ∈ S ∪ T, MeasurableSet (sets_s' i ∩ sets_t' i) := ?body✝;
                              ?_)
                          case body✝ =>
                            with_annotate_state"by"
                              ( intros i hi_mem
                                rw [Finset.mem_union] at hi_mem
                                rcases hi_mem with hi_mem | hi_mem
                                · rw [h_sets_t'_univ hi_mem, Set.inter_univ]
                                  exact h_meas_s' i hi_mem
                                · rw [h_sets_s'_univ hi_mem, Set.univ_inter]
                                  exact h_meas_t' i hi_mem)
                      [Elab.step] [0.011006] case body✝ =>
                            with_annotate_state"by"
                              ( intros i hi_mem
                                rw [Finset.mem_union] at hi_mem
                                rcases hi_mem with hi_mem | hi_mem
                                · rw [h_sets_t'_univ hi_mem, Set.inter_univ]
                                  exact h_meas_s' i hi_mem
                                · rw [h_sets_s'_univ hi_mem, Set.univ_inter]
                                  exact h_meas_t' i hi_mem)
                        [Elab.step] [0.010959] with_annotate_state"by"
                                ( intros i hi_mem
                                  rw [Finset.mem_union] at hi_mem
                                  rcases hi_mem with hi_mem | hi_mem
                                  · rw [h_sets_t'_univ hi_mem, Set.inter_univ]
                                    exact h_meas_s' i hi_mem
                                  · rw [h_sets_s'_univ hi_mem, Set.univ_inter]
                                    exact h_meas_t' i hi_mem)
                          [Elab.step] [0.010950] with_annotate_state"by"
                                  ( intros i hi_mem
                                    rw [Finset.mem_union] at hi_mem
                                    rcases hi_mem with hi_mem | hi_mem
                                    · rw [h_sets_t'_univ hi_mem, Set.inter_univ]
                                      exact h_meas_s' i hi_mem
                                    · rw [h_sets_s'_univ hi_mem, Set.univ_inter]
                                      exact h_meas_t' i hi_mem)
                            [Elab.step] [0.010942] with_annotate_state"by"
                                  ( intros i hi_mem
                                    rw [Finset.mem_union] at hi_mem
                                    rcases hi_mem with hi_mem | hi_mem
                                    · rw [h_sets_t'_univ hi_mem, Set.inter_univ]
                                      exact h_meas_s' i hi_mem
                                    · rw [h_sets_s'_univ hi_mem, Set.univ_inter]
                                      exact h_meas_t' i hi_mem)
                              [Elab.step] [0.010930] (
                                    intros i hi_mem
                                    rw [Finset.mem_union] at hi_mem
                                    rcases hi_mem with hi_mem | hi_mem
                                    · rw [h_sets_t'_univ hi_mem, Set.inter_univ]
                                      exact h_meas_s' i hi_mem
                                    · rw [h_sets_s'_univ hi_mem, Set.univ_inter]
                                      exact h_meas_t' i hi_mem)
                                [Elab.step] [0.010918] 
                                      intros i hi_mem
                                      rw [Finset.mem_union] at hi_mem
                                      rcases hi_mem with hi_mem | hi_mem
                                      · rw [h_sets_t'_univ hi_mem, Set.inter_univ]
                                        exact h_meas_s' i hi_mem
                                      · rw [h_sets_s'_univ hi_mem, Set.univ_inter]
                                        exact h_meas_t' i hi_mem
                                  [Elab.step] [0.010905] 
                                        intros i hi_mem
                                        rw [Finset.mem_union] at hi_mem
                                        rcases hi_mem with hi_mem | hi_mem
                                        · rw [h_sets_t'_univ hi_mem, Set.inter_univ]
                                          exact h_meas_s' i hi_mem
                                        · rw [h_sets_s'_univ hi_mem, Set.univ_inter]
                                          exact h_meas_t' i hi_mem
              [Elab.step] [0.037632] filter_upwards [hf_Indep S h_meas_s', hf_Indep T h_meas_t',
                    hf_Indep (S ∪ T) h_meas_inter] with a h_indepS h_indepT h_indepST
                [Elab.step] [0.021063] dsimp -zeta✝ only [Set.mem_setOf_eq✝]
              [Elab.step] [0.033502] rw [h_eq_inter_S, h_eq_inter_T, h_indepS, h_indepT, h_Inter_inter, h_indepST,
                    Finset.prod_union hST]
                [Elab.step] [0.033467] (rewrite [h_eq_inter_S, h_eq_inter_T, h_indepS, h_indepT, h_Inter_inter,
                        h_indepST, Finset.prod_union hST];
                      with_annotate_state"]" (try (with_reducible rfl)))
                  [Elab.step] [0.033461] rewrite [h_eq_inter_S, h_eq_inter_T, h_indepS, h_indepT, h_Inter_inter,
                          h_indepST, Finset.prod_union hST];
                        with_annotate_state"]" (try (with_reducible rfl))
                    [Elab.step] [0.033455] rewrite [h_eq_inter_S, h_eq_inter_T, h_indepS, h_indepT, h_Inter_inter,
                            h_indepST, Finset.prod_union hST];
                          with_annotate_state"]" (try (with_reducible rfl))
                      [Elab.step] [0.032483] rewrite [h_eq_inter_S, h_eq_inter_T, h_indepS, h_indepT, h_Inter_inter,
                            h_indepST, Finset.prod_union hST]
                        [Elab.step] [0.012350] expected type: <not-available>, term
                            Finset.prod_union hST
                          [Meta.synthInstance] [0.010113] ✅️ DecidableEq ι
              [Elab.step] [0.033900] congr 1
                [Meta.isDefEq] [0.011357] ❌️ ∏ x ∈ S,
                      (η a) (f x ⁻¹' (sets_s' x ∩ sets_t' x)) =?= ∏ i ∈ S, (η a) (f i ⁻¹' sets_s' i)
                [Meta.isDefEq] [0.010393] ❌️ ∏ x ∈ T,
                      (η a) (f x ⁻¹' (sets_s' x ∩ sets_t' x)) =?= ∏ i ∈ T, (η a) (f i ⁻¹' sets_t' i)
    [Meta.instantiateMVars] [0.062456] Or.casesOn (eq_or_ne μ 0)
          (fun h ↦
            Eq.ndrec (motive := fun {μ} ↦ iIndepFun f κ μ → IndepFun (fun a i ↦ f (↑i) a) (fun a i ↦ f (↑i) a) κ μ)
              (fun hf_Indep ↦ of_eq_true indepFun_zero_right._simp_1) (Eq.symm h) hf_Indep)
          fun hμ ↦
          Exists.casesOn (exists_ae_eq_isMarkovKernel (ae_isProbabilityMeasure hf_Indep) hμ) fun η h ↦
            And.casesOn h fun η_eq hη ↦
              IndepFun.congr (Filter.EventuallyEq.symm η_eq)
                (let πSβ := univ.pi '' univ.pi fun i ↦ {s | MeasurableSet s};
                let πS := {s | ∃ t ∈ πSβ, (fun a i ↦ f (↑i) a) ⁻¹' t = s};
                have hπS_pi := IsPiSystem.comap isPiSystem_pi fun a i ↦ f (↑i) a;
                have hπS_gen :=
                  Eq.mpr
                    (id
                      (congrArg (fun _a ↦ MeasurableSpace.comap (fun a i ↦ f (↑i) a) _a = generateFrom πS)
                        (Eq.symm generateFrom_pi)))
                    (Eq.mpr (id (congrArg (fun _a ↦ _a = generateFrom πS) comap_generateFrom))
                      ((fun {α} s s_1 e_s ↦ e_s ▸ Eq.refl (generateFrom s))
                        ((preimage fun a i ↦ f (↑i) a) '' (univ.pi '' univ.pi fun i ↦ {s | MeasurableSet s})) πS
                        (Eq.refl
                          ((preimage fun a i ↦ f (↑i) a) '' (univ.pi '' univ.pi fun i ↦ {s | MeasurableSet s})))));
                let πTβ := univ.pi '' univ.pi fun i ↦ {s | MeasurableSet s};
                let πT := {s | ∃ t ∈ πTβ, (fun a i ↦ f (↑i) a) ⁻¹' t = s};
                have hπT_pi := IsPiSystem.comap isPiSystem_pi fun a i ↦ f (↑i) a;
                have hπT_gen :=
                  Eq.mpr
                    (id
                      (congrArg (fun _a ↦ MeasurableSpace.comap (fun a i ↦ f (↑i) a) _a = generateFrom πT)
                        (Eq.symm generateFrom_pi)))
                    (Eq.mpr (id (congrArg (fun _a ↦ _a = generateFrom πT) comap_generateFrom))
                      ((fun {α} s s_1 e_s ↦ e_s ▸ Eq.refl (generateFrom s))
                        ((preimage fun a i ↦ f (↑i) a) '' (univ.pi '' univ.pi fun i ↦ {s | MeasurableSet s})) πT
                        (Eq.refl
                          ((preimage fun a i ↦ f (↑i) a) '' (univ.pi '' univ.pi fun i ↦ {s | MeasurableSet s})))));
                IndepSets.indep (Measurable.comap_le (measurable_pi_iff.mpr fun i ↦ hf_meas ↑i))
                  (Measurable.comap_le (measurable_pi_iff.mpr fun i ↦ hf_meas ↑i)) hπS_pi hπT_pi hπS_gen hπT_gen
                  fun t1 t2 a ↦
                  Exists.casesOn (motive := fun x ↦ t2 ∈ πT → ∀ᵐ (a : α) ∂μ, (η a) (t1 ∩ t2) = (η a) t1 * (η a) t2) a
                    fun s h ↦
                    And.casesOn (motive := fun x ↦ t2 ∈ πT → ∀ᵐ (a : α) ∂μ, (η a) (t1 ∩ t2) = (η a) t1 * (η a) t2) h
                      fun left right ↦
                      Exists.casesOn (motive := fun x ↦ t2 ∈ πT → ∀ᵐ (a : α) ∂μ, (η a) (t1 ∩ t2) = (η a) t1 * (η a) t2)
                        left fun sets_s h ↦
                        And.casesOn (motive := fun x ↦ t2 ∈ πT → ∀ᵐ (a : α) ∂μ, (η a) (t1 ∩ t2) = (η a) t1 * (η a) t2) h
                          fun hs1 hs2 ↦
                          Eq.ndrec (motive := fun t1 ↦ t2 ∈ πT → ∀ᵐ (a : α) ∂μ, (η a) (t1 ∩ t2) = (η a) t1 * (η a) t2)
                            (fun a ↦
                              Exists.casesOn a fun t h ↦
                                And.casesOn h fun left right ↦
                                  Exists.casesOn left fun sets_t h ↦
                                    And.casesOn h fun ht1 ht2 ↦
                                      right ▸
                                        Eq.mpr (id (congrArg ⋯ ⋯))
                                          (Eq.mpr (id ⋯)
                                            (let sets_s' := ⋯;
                                            ⋯)))
                            right)
info: Mathlib/Probability/Independence/Kernel.lean:1019:8: [Elab.async] [0.022366] Lean.addDecl
  [Kernel] [0.022338] typechecking declarations [ProbabilityTheory.Kernel.iIndepFun.indepFun_finset]
Build completed successfully.
```

### Trace profiling of `iIndepFun.indepFun_finset` after PR 28327
```diff
diff --git a/Mathlib/Probability/Independence/Kernel.lean b/Mathlib/Probability/Independence/Kernel.lean
index 392c3b3d7a..f2248d5972 100644
--- a/Mathlib/Probability/Independence/Kernel.lean
+++ b/Mathlib/Probability/Independence/Kernel.lean
@@ -1012,6 +1012,7 @@ section iIndepFun
 variable {β : ι → Type*} {m : ∀ i, MeasurableSpace (β i)} {f : ∀ i, Ω → β i}
 
 
+set_option trace.profiler true in
 /-- If `f` is a family of mutually independent random variables (`iIndepFun m f μ`) and `S, T` are
 two disjoint finite index sets, then the tuple formed by `f i` for `i ∈ S` is independent of the
 tuple `(f i)_i` for `i ∈ T`. -/
@@ -1080,16 +1081,7 @@ theorem iIndepFun.indepFun_finset (S T : Finset ι) (hST : Disjoint S T)
     ext1 x
     simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
     constructor <;> intro h
-    · intro i hi
-      rcases hi with hiS | hiT
-      · replace h := h.1 i hiS
-        simp_rw [sets_s', sets_t', dif_pos hiS, dif_neg (Finset.disjoint_left.mp hST hiS)]
-        simp only [sets_s'] at h
-        exact ⟨by rwa [dif_pos hiS] at h, Set.mem_univ _⟩
-      · replace h := h.2 i hiT
-        simp_rw [sets_s', sets_t', dif_pos hiT, dif_neg (Finset.disjoint_right.mp hST hiT)]
-        simp only [sets_t'] at h
-        exact ⟨Set.mem_univ _, by rwa [dif_pos hiT] at h⟩
+    · grind
     · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩
   have h_meas_inter : ∀ i ∈ S ∪ T, MeasurableSet (sets_s' i ∩ sets_t' i) := by
     intros i hi_mem
```
```
ℹ [1740/1740] Built Mathlib.Probability.Independence.Kernel
info: Mathlib/Probability/Independence/Kernel.lean:1016:0: [Elab.command] [0.011919] /--
    If `f` is a family of mutually independent random variables (`iIndepFun m f μ`) and `S, T` are
    two disjoint finite index sets, then the tuple formed by `f i` for `i ∈ S` is independent of the
    tuple `(f i)_i` for `i ∈ T`. -/
    theorem indepFun_finset (S T : Finset ι) (hST : Disjoint S T) (hf_Indep : iIndepFun f κ μ)
        (hf_meas : ∀ i, Measurable (f i)) : IndepFun (fun a (i : S) => f i a) (fun a (i : T) => f i a) κ μ :=
      by
      rcases eq_or_ne μ 0 with rfl | hμ
      · simp
      obtain ⟨η, η_eq, hη⟩ : ∃ (η : Kernel α Ω), κ =ᵐ[μ] η ∧ IsMarkovKernel η :=
        exists_ae_eq_isMarkovKernel hf_Indep.ae_isProbabilityMeasure hμ
      apply
        IndepFun.congr
          (Filter.EventuallyEq.symm η_eq)
            -- We introduce π-systems, built from the π-system of boxes which generates `MeasurableSpace.pi`.
            
      let πSβ := Set.pi (Set.univ : Set S) '' Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s}
      let πS := {s : Set Ω | ∃ t ∈ πSβ, (fun a (i : S) => f i a) ⁻¹' t = s}
      have hπS_pi : IsPiSystem πS := by exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _
      have hπS_gen : (MeasurableSpace.pi.comap fun a (i : S) => f i a) = generateFrom πS :=
        by
        rw [generateFrom_pi.symm, comap_generateFrom]
        congr
      let πTβ := Set.pi (Set.univ : Set T) '' Set.pi (Set.univ : Set T) fun i => {s : Set (β i) | MeasurableSet[m i] s}
      let πT := {s : Set Ω | ∃ t ∈ πTβ, (fun a (i : T) => f i a) ⁻¹' t = s}
      have hπT_pi : IsPiSystem πT := by exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _
      have hπT_gen : (MeasurableSpace.pi.comap fun a (i : T) => f i a) = generateFrom πT :=
        by
        rw [generateFrom_pi.symm, comap_generateFrom]
        congr
          -- To prove independence, we prove independence of the generating π-systems.
          
      refine
        IndepSets.indep (Measurable.comap_le (measurable_pi_iff.mpr fun i => hf_meas i))
          (Measurable.comap_le (measurable_pi_iff.mpr fun i => hf_meas i)) hπS_pi hπT_pi hπS_gen hπT_gen ?_
      rintro _ _ ⟨s, ⟨sets_s, hs1, hs2⟩, rfl⟩ ⟨t, ⟨sets_t, ht1, ht2⟩, rfl⟩
      simp only [Set.mem_univ_pi, Set.mem_setOf_eq] at hs1 ht1
      rw [← hs2, ← ht2]
      classical
      let sets_s' : ∀ i : ι, Set (β i) := fun i => dite (i ∈ S) (fun hi => sets_s ⟨i, hi⟩) fun _ => Set.univ
      have h_sets_s'_eq : ∀ {i} (hi : i ∈ S), sets_s' i = sets_s ⟨i, hi⟩ := by intro i hi; simp_rw [sets_s', dif_pos hi]
      have h_sets_s'_univ : ∀ {i} (_hi : i ∈ T), sets_s' i = Set.univ := by intro i hi;
        simp_rw [sets_s', dif_neg (Finset.disjoint_right.mp hST hi)]
      let sets_t' : ∀ i : ι, Set (β i) := fun i => dite (i ∈ T) (fun hi => sets_t ⟨i, hi⟩) fun _ => Set.univ
      have h_sets_t'_univ : ∀ {i} (_hi : i ∈ S), sets_t' i = Set.univ := by intro i hi;
        simp_rw [sets_t', dif_neg (Finset.disjoint_left.mp hST hi)]
      have h_meas_s' : ∀ i ∈ S, MeasurableSet (sets_s' i) := by intro i hi; rw [h_sets_s'_eq hi]; exact hs1 _
      have h_meas_t' : ∀ i ∈ T, MeasurableSet (sets_t' i) := by intro i hi; simp_rw [sets_t', dif_pos hi]; exact ht1 _
      have h_eq_inter_S : (fun (ω : Ω) (i : ↥S) => f (↑i) ω) ⁻¹' Set.pi Set.univ sets_s = ⋂ i ∈ S, f i ⁻¹' sets_s' i :=
        by
        ext1 x
        simp_rw [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
        grind
      have h_eq_inter_T : (fun (ω : Ω) (i : ↥T) => f (↑i) ω) ⁻¹' Set.pi Set.univ sets_t = ⋂ i ∈ T, f i ⁻¹' sets_t' i :=
        by
        ext1 x
        simp only [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
        constructor <;> intro h
        · intro i hi; simp_rw [sets_t', dif_pos hi]; exact h ⟨i, hi⟩
        · grind
      replace hf_Indep := hf_Indep.congr η_eq
      rw [iIndepFun_iff_measure_inter_preimage_eq_mul] at hf_Indep
      have h_Inter_inter :
        ((⋂ i ∈ S, f i ⁻¹' sets_s' i) ∩ ⋂ i ∈ T, f i ⁻¹' sets_t' i) = ⋂ i ∈ S ∪ T, f i ⁻¹' (sets_s' i ∩ sets_t' i) :=
        by
        ext1 x
        simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
        constructor <;> intro h
        · grind
        · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩
      have h_meas_inter : ∀ i ∈ S ∪ T, MeasurableSet (sets_s' i ∩ sets_t' i) :=
        by
        intros i hi_mem
        rw [Finset.mem_union] at hi_mem
        rcases hi_mem with hi_mem | hi_mem
        · rw [h_sets_t'_univ hi_mem, Set.inter_univ]
          exact h_meas_s' i hi_mem
        · rw [h_sets_s'_univ hi_mem, Set.univ_inter]
          exact h_meas_t' i hi_mem
      filter_upwards [hf_Indep S h_meas_s', hf_Indep T h_meas_t', hf_Indep (S ∪ T) h_meas_inter] with a h_indepS
        h_indepT h_indepST
      rw [h_eq_inter_S, h_eq_inter_T, h_indepS, h_indepT, h_Inter_inter, h_indepST, Finset.prod_union hST]
      congr 1
      · refine Finset.prod_congr rfl fun i hi => ?_
        rw [h_sets_t'_univ hi, Set.inter_univ]
      · refine Finset.prod_congr rfl fun i hi => ?_
        rw [h_sets_s'_univ hi, Set.univ_inter]
info: Mathlib/Probability/Independence/Kernel.lean:1016:0: [Elab.command] [0.012238] /--
    If `f` is a family of mutually independent random variables (`iIndepFun m f μ`) and `S, T` are
    two disjoint finite index sets, then the tuple formed by `f i` for `i ∈ S` is independent of the
    tuple `(f i)_i` for `i ∈ T`. -/
    theorem iIndepFun.indepFun_finset (S T : Finset ι) (hST : Disjoint S T) (hf_Indep : iIndepFun f κ μ)
        (hf_meas : ∀ i, Measurable (f i)) : IndepFun (fun a (i : S) => f i a) (fun a (i : T) => f i a) κ μ :=
      by
      rcases eq_or_ne μ 0 with rfl | hμ
      · simp
      obtain ⟨η, η_eq, hη⟩ : ∃ (η : Kernel α Ω), κ =ᵐ[μ] η ∧ IsMarkovKernel η :=
        exists_ae_eq_isMarkovKernel hf_Indep.ae_isProbabilityMeasure hμ
      apply
        IndepFun.congr
          (Filter.EventuallyEq.symm η_eq)
            -- We introduce π-systems, built from the π-system of boxes which generates `MeasurableSpace.pi`.
            
      let πSβ := Set.pi (Set.univ : Set S) '' Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s}
      let πS := {s : Set Ω | ∃ t ∈ πSβ, (fun a (i : S) => f i a) ⁻¹' t = s}
      have hπS_pi : IsPiSystem πS := by exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _
      have hπS_gen : (MeasurableSpace.pi.comap fun a (i : S) => f i a) = generateFrom πS :=
        by
        rw [generateFrom_pi.symm, comap_generateFrom]
        congr
      let πTβ := Set.pi (Set.univ : Set T) '' Set.pi (Set.univ : Set T) fun i => {s : Set (β i) | MeasurableSet[m i] s}
      let πT := {s : Set Ω | ∃ t ∈ πTβ, (fun a (i : T) => f i a) ⁻¹' t = s}
      have hπT_pi : IsPiSystem πT := by exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _
      have hπT_gen : (MeasurableSpace.pi.comap fun a (i : T) => f i a) = generateFrom πT :=
        by
        rw [generateFrom_pi.symm, comap_generateFrom]
        congr
          -- To prove independence, we prove independence of the generating π-systems.
          
      refine
        IndepSets.indep (Measurable.comap_le (measurable_pi_iff.mpr fun i => hf_meas i))
          (Measurable.comap_le (measurable_pi_iff.mpr fun i => hf_meas i)) hπS_pi hπT_pi hπS_gen hπT_gen ?_
      rintro _ _ ⟨s, ⟨sets_s, hs1, hs2⟩, rfl⟩ ⟨t, ⟨sets_t, ht1, ht2⟩, rfl⟩
      simp only [Set.mem_univ_pi, Set.mem_setOf_eq] at hs1 ht1
      rw [← hs2, ← ht2]
      classical
      let sets_s' : ∀ i : ι, Set (β i) := fun i => dite (i ∈ S) (fun hi => sets_s ⟨i, hi⟩) fun _ => Set.univ
      have h_sets_s'_eq : ∀ {i} (hi : i ∈ S), sets_s' i = sets_s ⟨i, hi⟩ := by intro i hi; simp_rw [sets_s', dif_pos hi]
      have h_sets_s'_univ : ∀ {i} (_hi : i ∈ T), sets_s' i = Set.univ := by intro i hi;
        simp_rw [sets_s', dif_neg (Finset.disjoint_right.mp hST hi)]
      let sets_t' : ∀ i : ι, Set (β i) := fun i => dite (i ∈ T) (fun hi => sets_t ⟨i, hi⟩) fun _ => Set.univ
      have h_sets_t'_univ : ∀ {i} (_hi : i ∈ S), sets_t' i = Set.univ := by intro i hi;
        simp_rw [sets_t', dif_neg (Finset.disjoint_left.mp hST hi)]
      have h_meas_s' : ∀ i ∈ S, MeasurableSet (sets_s' i) := by intro i hi; rw [h_sets_s'_eq hi]; exact hs1 _
      have h_meas_t' : ∀ i ∈ T, MeasurableSet (sets_t' i) := by intro i hi; simp_rw [sets_t', dif_pos hi]; exact ht1 _
      have h_eq_inter_S : (fun (ω : Ω) (i : ↥S) => f (↑i) ω) ⁻¹' Set.pi Set.univ sets_s = ⋂ i ∈ S, f i ⁻¹' sets_s' i :=
        by
        ext1 x
        simp_rw [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
        grind
      have h_eq_inter_T : (fun (ω : Ω) (i : ↥T) => f (↑i) ω) ⁻¹' Set.pi Set.univ sets_t = ⋂ i ∈ T, f i ⁻¹' sets_t' i :=
        by
        ext1 x
        simp only [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
        constructor <;> intro h
        · intro i hi; simp_rw [sets_t', dif_pos hi]; exact h ⟨i, hi⟩
        · grind
      replace hf_Indep := hf_Indep.congr η_eq
      rw [iIndepFun_iff_measure_inter_preimage_eq_mul] at hf_Indep
      have h_Inter_inter :
        ((⋂ i ∈ S, f i ⁻¹' sets_s' i) ∩ ⋂ i ∈ T, f i ⁻¹' sets_t' i) = ⋂ i ∈ S ∪ T, f i ⁻¹' (sets_s' i ∩ sets_t' i) :=
        by
        ext1 x
        simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
        constructor <;> intro h
        · grind
        · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩
      have h_meas_inter : ∀ i ∈ S ∪ T, MeasurableSet (sets_s' i ∩ sets_t' i) :=
        by
        intros i hi_mem
        rw [Finset.mem_union] at hi_mem
        rcases hi_mem with hi_mem | hi_mem
        · rw [h_sets_t'_univ hi_mem, Set.inter_univ]
          exact h_meas_s' i hi_mem
        · rw [h_sets_s'_univ hi_mem, Set.univ_inter]
          exact h_meas_t' i hi_mem
      filter_upwards [hf_Indep S h_meas_s', hf_Indep T h_meas_t', hf_Indep (S ∪ T) h_meas_inter] with a h_indepS
        h_indepT h_indepST
      rw [h_eq_inter_S, h_eq_inter_T, h_indepS, h_indepT, h_Inter_inter, h_indepST, Finset.prod_union hST]
      congr 1
      · refine Finset.prod_congr rfl fun i hi => ?_
        rw [h_sets_t'_univ hi, Set.inter_univ]
      · refine Finset.prod_congr rfl fun i hi => ?_
        rw [h_sets_s'_univ hi, Set.univ_inter]
info: Mathlib/Probability/Independence/Kernel.lean:1016:0: [Elab.async] [1.622686] elaborating proof of ProbabilityTheory.Kernel.iIndepFun.indepFun_finset
  [Elab.definition.value] [1.588589] ProbabilityTheory.Kernel.iIndepFun.indepFun_finset
    [Elab.step] [1.553677] 
          rcases eq_or_ne μ 0 with rfl | hμ
          · simp
          obtain ⟨η, η_eq, hη⟩ : ∃ (η : Kernel α Ω), κ =ᵐ[μ] η ∧ IsMarkovKernel η :=
            exists_ae_eq_isMarkovKernel hf_Indep.ae_isProbabilityMeasure hμ
          apply
            IndepFun.congr
              (Filter.EventuallyEq.symm η_eq)
                -- We introduce π-systems, built from the π-system of boxes which generates `MeasurableSpace.pi`.
                
          let πSβ :=
            Set.pi (Set.univ : Set S) '' Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s}
          let πS := {s : Set Ω | ∃ t ∈ πSβ, (fun a (i : S) => f i a) ⁻¹' t = s}
          have hπS_pi : IsPiSystem πS := by exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _
          have hπS_gen : (MeasurableSpace.pi.comap fun a (i : S) => f i a) = generateFrom πS :=
            by
            rw [generateFrom_pi.symm, comap_generateFrom]
            congr
          let πTβ :=
            Set.pi (Set.univ : Set T) '' Set.pi (Set.univ : Set T) fun i => {s : Set (β i) | MeasurableSet[m i] s}
          let πT := {s : Set Ω | ∃ t ∈ πTβ, (fun a (i : T) => f i a) ⁻¹' t = s}
          have hπT_pi : IsPiSystem πT := by exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _
          have hπT_gen : (MeasurableSpace.pi.comap fun a (i : T) => f i a) = generateFrom πT :=
            by
            rw [generateFrom_pi.symm, comap_generateFrom]
            congr
              -- To prove independence, we prove independence of the generating π-systems.
              
          refine
            IndepSets.indep (Measurable.comap_le (measurable_pi_iff.mpr fun i => hf_meas i))
              (Measurable.comap_le (measurable_pi_iff.mpr fun i => hf_meas i)) hπS_pi hπT_pi hπS_gen hπT_gen ?_
          rintro _ _ ⟨s, ⟨sets_s, hs1, hs2⟩, rfl⟩ ⟨t, ⟨sets_t, ht1, ht2⟩, rfl⟩
          simp only [Set.mem_univ_pi, Set.mem_setOf_eq] at hs1 ht1
          rw [← hs2, ← ht2]
          classical
          let sets_s' : ∀ i : ι, Set (β i) := fun i => dite (i ∈ S) (fun hi => sets_s ⟨i, hi⟩) fun _ => Set.univ
          have h_sets_s'_eq : ∀ {i} (hi : i ∈ S), sets_s' i = sets_s ⟨i, hi⟩ := by intro i hi;
            simp_rw [sets_s', dif_pos hi]
          have h_sets_s'_univ : ∀ {i} (_hi : i ∈ T), sets_s' i = Set.univ := by intro i hi;
            simp_rw [sets_s', dif_neg (Finset.disjoint_right.mp hST hi)]
          let sets_t' : ∀ i : ι, Set (β i) := fun i => dite (i ∈ T) (fun hi => sets_t ⟨i, hi⟩) fun _ => Set.univ
          have h_sets_t'_univ : ∀ {i} (_hi : i ∈ S), sets_t' i = Set.univ := by intro i hi;
            simp_rw [sets_t', dif_neg (Finset.disjoint_left.mp hST hi)]
          have h_meas_s' : ∀ i ∈ S, MeasurableSet (sets_s' i) := by intro i hi; rw [h_sets_s'_eq hi]; exact hs1 _
          have h_meas_t' : ∀ i ∈ T, MeasurableSet (sets_t' i) := by intro i hi; simp_rw [sets_t', dif_pos hi];
            exact ht1 _
          have h_eq_inter_S :
            (fun (ω : Ω) (i : ↥S) => f (↑i) ω) ⁻¹' Set.pi Set.univ sets_s = ⋂ i ∈ S, f i ⁻¹' sets_s' i :=
            by
            ext1 x
            simp_rw [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
            grind
          have h_eq_inter_T :
            (fun (ω : Ω) (i : ↥T) => f (↑i) ω) ⁻¹' Set.pi Set.univ sets_t = ⋂ i ∈ T, f i ⁻¹' sets_t' i :=
            by
            ext1 x
            simp only [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
            constructor <;> intro h
            · intro i hi; simp_rw [sets_t', dif_pos hi]; exact h ⟨i, hi⟩
            · grind
          replace hf_Indep := hf_Indep.congr η_eq
          rw [iIndepFun_iff_measure_inter_preimage_eq_mul] at hf_Indep
          have h_Inter_inter :
            ((⋂ i ∈ S, f i ⁻¹' sets_s' i) ∩ ⋂ i ∈ T, f i ⁻¹' sets_t' i) =
              ⋂ i ∈ S ∪ T, f i ⁻¹' (sets_s' i ∩ sets_t' i) :=
            by
            ext1 x
            simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
            constructor <;> intro h
            · grind
            · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩
          have h_meas_inter : ∀ i ∈ S ∪ T, MeasurableSet (sets_s' i ∩ sets_t' i) :=
            by
            intros i hi_mem
            rw [Finset.mem_union] at hi_mem
            rcases hi_mem with hi_mem | hi_mem
            · rw [h_sets_t'_univ hi_mem, Set.inter_univ]
              exact h_meas_s' i hi_mem
            · rw [h_sets_s'_univ hi_mem, Set.univ_inter]
              exact h_meas_t' i hi_mem
          filter_upwards [hf_Indep S h_meas_s', hf_Indep T h_meas_t', hf_Indep (S ∪ T) h_meas_inter] with a h_indepS
            h_indepT h_indepST
          rw [h_eq_inter_S, h_eq_inter_T, h_indepS, h_indepT, h_Inter_inter, h_indepST, Finset.prod_union hST]
          congr 1
          · refine Finset.prod_congr rfl fun i hi => ?_
            rw [h_sets_t'_univ hi, Set.inter_univ]
          · refine Finset.prod_congr rfl fun i hi => ?_
            rw [h_sets_s'_univ hi, Set.univ_inter]
      [Elab.step] [1.553668] 
            rcases eq_or_ne μ 0 with rfl | hμ
            · simp
            obtain ⟨η, η_eq, hη⟩ : ∃ (η : Kernel α Ω), κ =ᵐ[μ] η ∧ IsMarkovKernel η :=
              exists_ae_eq_isMarkovKernel hf_Indep.ae_isProbabilityMeasure hμ
            apply
              IndepFun.congr
                (Filter.EventuallyEq.symm η_eq)
                  -- We introduce π-systems, built from the π-system of boxes which generates `MeasurableSpace.pi`.
                  
            let πSβ :=
              Set.pi (Set.univ : Set S) '' Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s}
            let πS := {s : Set Ω | ∃ t ∈ πSβ, (fun a (i : S) => f i a) ⁻¹' t = s}
            have hπS_pi : IsPiSystem πS := by exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _
            have hπS_gen : (MeasurableSpace.pi.comap fun a (i : S) => f i a) = generateFrom πS :=
              by
              rw [generateFrom_pi.symm, comap_generateFrom]
              congr
            let πTβ :=
              Set.pi (Set.univ : Set T) '' Set.pi (Set.univ : Set T) fun i => {s : Set (β i) | MeasurableSet[m i] s}
            let πT := {s : Set Ω | ∃ t ∈ πTβ, (fun a (i : T) => f i a) ⁻¹' t = s}
            have hπT_pi : IsPiSystem πT := by exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _
            have hπT_gen : (MeasurableSpace.pi.comap fun a (i : T) => f i a) = generateFrom πT :=
              by
              rw [generateFrom_pi.symm, comap_generateFrom]
              congr
                -- To prove independence, we prove independence of the generating π-systems.
                
            refine
              IndepSets.indep (Measurable.comap_le (measurable_pi_iff.mpr fun i => hf_meas i))
                (Measurable.comap_le (measurable_pi_iff.mpr fun i => hf_meas i)) hπS_pi hπT_pi hπS_gen hπT_gen ?_
            rintro _ _ ⟨s, ⟨sets_s, hs1, hs2⟩, rfl⟩ ⟨t, ⟨sets_t, ht1, ht2⟩, rfl⟩
            simp only [Set.mem_univ_pi, Set.mem_setOf_eq] at hs1 ht1
            rw [← hs2, ← ht2]
            classical
            let sets_s' : ∀ i : ι, Set (β i) := fun i => dite (i ∈ S) (fun hi => sets_s ⟨i, hi⟩) fun _ => Set.univ
            have h_sets_s'_eq : ∀ {i} (hi : i ∈ S), sets_s' i = sets_s ⟨i, hi⟩ := by intro i hi;
              simp_rw [sets_s', dif_pos hi]
            have h_sets_s'_univ : ∀ {i} (_hi : i ∈ T), sets_s' i = Set.univ := by intro i hi;
              simp_rw [sets_s', dif_neg (Finset.disjoint_right.mp hST hi)]
            let sets_t' : ∀ i : ι, Set (β i) := fun i => dite (i ∈ T) (fun hi => sets_t ⟨i, hi⟩) fun _ => Set.univ
            have h_sets_t'_univ : ∀ {i} (_hi : i ∈ S), sets_t' i = Set.univ := by intro i hi;
              simp_rw [sets_t', dif_neg (Finset.disjoint_left.mp hST hi)]
            have h_meas_s' : ∀ i ∈ S, MeasurableSet (sets_s' i) := by intro i hi; rw [h_sets_s'_eq hi]; exact hs1 _
            have h_meas_t' : ∀ i ∈ T, MeasurableSet (sets_t' i) := by intro i hi; simp_rw [sets_t', dif_pos hi];
              exact ht1 _
            have h_eq_inter_S :
              (fun (ω : Ω) (i : ↥S) => f (↑i) ω) ⁻¹' Set.pi Set.univ sets_s = ⋂ i ∈ S, f i ⁻¹' sets_s' i :=
              by
              ext1 x
              simp_rw [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
              grind
            have h_eq_inter_T :
              (fun (ω : Ω) (i : ↥T) => f (↑i) ω) ⁻¹' Set.pi Set.univ sets_t = ⋂ i ∈ T, f i ⁻¹' sets_t' i :=
              by
              ext1 x
              simp only [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
              constructor <;> intro h
              · intro i hi; simp_rw [sets_t', dif_pos hi]; exact h ⟨i, hi⟩
              · grind
            replace hf_Indep := hf_Indep.congr η_eq
            rw [iIndepFun_iff_measure_inter_preimage_eq_mul] at hf_Indep
            have h_Inter_inter :
              ((⋂ i ∈ S, f i ⁻¹' sets_s' i) ∩ ⋂ i ∈ T, f i ⁻¹' sets_t' i) =
                ⋂ i ∈ S ∪ T, f i ⁻¹' (sets_s' i ∩ sets_t' i) :=
              by
              ext1 x
              simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
              constructor <;> intro h
              · grind
              · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩
            have h_meas_inter : ∀ i ∈ S ∪ T, MeasurableSet (sets_s' i ∩ sets_t' i) :=
              by
              intros i hi_mem
              rw [Finset.mem_union] at hi_mem
              rcases hi_mem with hi_mem | hi_mem
              · rw [h_sets_t'_univ hi_mem, Set.inter_univ]
                exact h_meas_s' i hi_mem
              · rw [h_sets_s'_univ hi_mem, Set.univ_inter]
                exact h_meas_t' i hi_mem
            filter_upwards [hf_Indep S h_meas_s', hf_Indep T h_meas_t', hf_Indep (S ∪ T) h_meas_inter] with a h_indepS
              h_indepT h_indepST
            rw [h_eq_inter_S, h_eq_inter_T, h_indepS, h_indepT, h_Inter_inter, h_indepST, Finset.prod_union hST]
            congr 1
            · refine Finset.prod_congr rfl fun i hi => ?_
              rw [h_sets_t'_univ hi, Set.inter_univ]
            · refine Finset.prod_congr rfl fun i hi => ?_
              rw [h_sets_s'_univ hi, Set.univ_inter]
        [Elab.step] [0.012067] obtain ⟨η, η_eq, hη⟩ : ∃ (η : Kernel α Ω), κ =ᵐ[μ] η ∧ IsMarkovKernel η :=
              exists_ae_eq_isMarkovKernel hf_Indep.ae_isProbabilityMeasure hμ
        [Elab.step] [0.023889] let πSβ :=
              Set.pi (Set.univ : Set S) '' Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s}
          [Elab.step] [0.023765] refine_lift
                let πSβ :=
                  Set.pi (Set.univ : Set S) ''
                    Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s};
                ?_
            [Elab.step] [0.023760] focus
                  (refine
                      no_implicit_lambda%
                        (let πSβ :=
                          Set.pi (Set.univ : Set S) ''
                            Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s};
                        ?_);
                    rotate_right)
              [Elab.step] [0.023751] (refine
                        no_implicit_lambda%
                          (let πSβ :=
                            Set.pi (Set.univ : Set S) ''
                              Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s};
                          ?_);
                      rotate_right)
                [Elab.step] [0.023745] (refine
                          no_implicit_lambda%
                            (let πSβ :=
                              Set.pi (Set.univ : Set S) ''
                                Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s};
                            ?_);
                        rotate_right)
                  [Elab.step] [0.023740] (refine
                          no_implicit_lambda%
                            (let πSβ :=
                              Set.pi (Set.univ : Set S) ''
                                Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s};
                            ?_);
                        rotate_right)
                    [Elab.step] [0.023735] refine
                            no_implicit_lambda%
                              (let πSβ :=
                                Set.pi (Set.univ : Set S) ''
                                  Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s};
                              ?_);
                          rotate_right
                      [Elab.step] [0.023731] refine
                              no_implicit_lambda%
                                (let πSβ :=
                                  Set.pi (Set.univ : Set S) ''
                                    Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s};
                                ?_);
                            rotate_right
                        [Elab.step] [0.023706] refine
                              no_implicit_lambda%
                                (let πSβ :=
                                  Set.pi (Set.univ : Set S) ''
                                    Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s};
                                ?_)
                          [Elab.step] [0.023631] expected type: IndepFun (fun a i ↦ f (↑i) a) (fun a i ↦ f (↑i) a) η
                                μ, term
                              no_implicit_lambda%
                                (let πSβ :=
                                  Set.pi (Set.univ : Set S) ''
                                    Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s};
                                ?_)
                            [Elab.step] [0.023622] expected type: IndepFun (fun a i ↦ f (↑i) a) (fun a i ↦ f (↑i) a) η
                                  μ, term
                                let πSβ :=
                                  Set.pi (Set.univ : Set S) ''
                                    Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s};
                                ?_
                              [Elab.step] [0.023513] expected type: Set (Set ((i : { x // x ∈ S }) → β ↑i)), term
                                  Set.pi (Set.univ : Set S) ''
                                    Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s}
                                [Elab.step] [0.023270] expected type: Set (Set ((i : { x // x ∈ S }) → β ↑i)), term
                                    image✝ (Set.pi (Set.univ : Set S))
                                      (Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s})
                                  [Elab.step] [0.015936] expected type: Set ((i : { x // x ∈ S }) → Set (β ↑i)), term
                                      Set.pi (Set.univ : Set S) fun i => {s : Set (β i) | MeasurableSet[m i] s}
        [Elab.step] [0.430726] have hπS_pi : IsPiSystem πS := by exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _
          [Elab.step] [0.430665] focus
                refine
                  no_implicit_lambda%
                    (have hπS_pi : IsPiSystem πS := ?body✝;
                    ?_)
                case body✝ => with_annotate_state"by" (exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _)
            [Elab.step] [0.430656] 
                  refine
                    no_implicit_lambda%
                      (have hπS_pi : IsPiSystem πS := ?body✝;
                      ?_)
                  case body✝ => with_annotate_state"by" (exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _)
              [Elab.step] [0.430648] 
                    refine
                      no_implicit_lambda%
                        (have hπS_pi : IsPiSystem πS := ?body✝;
                        ?_)
                    case body✝ => with_annotate_state"by" (exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _)
                [Elab.step] [0.430037] case body✝ =>
                      with_annotate_state"by" (exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _)
                  [Elab.step] [0.430012] with_annotate_state"by" (exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _)
                    [Elab.step] [0.430006] with_annotate_state"by" (exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _)
                      [Elab.step] [0.429999] with_annotate_state"by" (exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _)
                        [Elab.step] [0.429992] (exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _)
                          [Elab.step] [0.429985] exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _
                            [Elab.step] [0.429979] exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _
                              [Elab.step] [0.429967] exact IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _
                                [Elab.step] [0.429260] expected type: IsPiSystem πS, term
                                    IsPiSystem.comap (@isPiSystem_pi _ _ ?_) _
                                  [Meta.isDefEq] [0.428172] ❌️ IsPiSystem
                                        πS =?= IsPiSystem
                                        {s | ∃ t ∈ univ.pi '' univ.pi fun i ↦ {s | MeasurableSet s}, ?m.48509 ⁻¹' t = s}
                                    [Meta.isDefEq.delta] [0.134517] ❌️ IsPiSystem
                                          πS =?= IsPiSystem
                                          {s |
                                            ∃ t ∈ univ.pi '' univ.pi fun i ↦ {s | MeasurableSet s}, ?m.48509 ⁻¹' t = s}
                                      [Meta.isDefEq] [0.134441] ❌️ πS =?= {s |
                                            ∃ t ∈ univ.pi '' univ.pi fun i ↦ {s | MeasurableSet s}, ?m.48509 ⁻¹' t = s}
                                        [Meta.isDefEq] [0.134430] ❌️ {s |
                                              ∃ t ∈ πSβ,
                                                (fun a i ↦ f (↑i) a) ⁻¹' t =
                                                  s} =?= {s |
                                              ∃ t ∈ univ.pi '' univ.pi fun i ↦ {s | MeasurableSet s},
                                                ?m.48509 ⁻¹' t = s}
                                          [Meta.isDefEq.delta] [0.069085] ❌️ {s |
                                                ∃ t ∈ πSβ,
                                                  (fun a i ↦ f (↑i) a) ⁻¹' t =
                                                    s} =?= {s |
                                                ∃ t ∈ univ.pi '' univ.pi fun i ↦ {s | MeasurableSet s},
                                                  ?m.48509 ⁻¹' t = s}
                                            [Meta.isDefEq] [0.069064] ❌️ fun s ↦
                                                  ∃ t ∈ πSβ,
                                                    (fun a i ↦ f (↑i) a) ⁻¹' t =
                                                      s =?= fun s ↦
                                                  ∃ t ∈ univ.pi '' univ.pi fun i ↦ {s | MeasurableSet s},
                                                    ?m.48509 ⁻¹' t = s
                                              [Meta.isDefEq] [0.069045] ❌️ ∃ t ∈ πSβ,
                                                    (fun a i ↦ f (↑i) a) ⁻¹' t =
                                                      s =?= ∃ t ∈ univ.pi '' univ.pi fun i ↦ {s | MeasurableSet s},
                                                    ?m.48509 ⁻¹' t = s
                                                [Meta.isDefEq] [0.068983] ❌️ fun t ↦
                                                      t ∈ πSβ ∧
                                                        (fun a i ↦ f (↑i) a) ⁻¹' t =
                                                          s =?= fun t ↦
                                                      (t ∈ univ.pi '' univ.pi fun i ↦ {s | MeasurableSet s}) ∧
                                                        ?m.48509 ⁻¹' t = s
                                                  [Meta.isDefEq] [0.068838] ❌️ t ∈ πSβ ∧
[… 1919 lines omitted …]
                    simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
                    constructor <;> intro h
                    · grind
                    · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩
                  have h_meas_inter : ∀ i ∈ S ∪ T, MeasurableSet (sets_s' i ∩ sets_t' i) :=
                    by
                    intros i hi_mem
                    rw [Finset.mem_union] at hi_mem
                    rcases hi_mem with hi_mem | hi_mem
                    · rw [h_sets_t'_univ hi_mem, Set.inter_univ]
                      exact h_meas_s' i hi_mem
                    · rw [h_sets_s'_univ hi_mem, Set.univ_inter]
                      exact h_meas_t' i hi_mem
                  filter_upwards [hf_Indep S h_meas_s', hf_Indep T h_meas_t', hf_Indep (S ∪ T) h_meas_inter] with a
                    h_indepS h_indepT h_indepST
                  rw [h_eq_inter_S, h_eq_inter_T, h_indepS, h_indepT, h_Inter_inter, h_indepST, Finset.prod_union hST]
                  congr 1
                  · refine Finset.prod_congr rfl fun i hi => ?_
                    rw [h_sets_t'_univ hi, Set.inter_univ]
                  · refine Finset.prod_congr rfl fun i hi => ?_
                    rw [h_sets_s'_univ hi, Set.univ_inter]
              [Elab.step] [0.012466] have h_meas_t' : ∀ i ∈ T, MeasurableSet (sets_t' i) := by intro i hi;
                    simp_rw [sets_t', dif_pos hi]; exact ht1 _
                [Elab.step] [0.012404] focus
                      refine
                        no_implicit_lambda%
                          (have h_meas_t' : ∀ i ∈ T, MeasurableSet (sets_t' i) := ?body✝;
                          ?_)
                      case body✝ => with_annotate_state"by" (intro i hi; simp_rw [sets_t', dif_pos hi]; exact ht1 _)
                  [Elab.step] [0.012399] 
                        refine
                          no_implicit_lambda%
                            (have h_meas_t' : ∀ i ∈ T, MeasurableSet (sets_t' i) := ?body✝;
                            ?_)
                        case body✝ => with_annotate_state"by" (intro i hi; simp_rw [sets_t', dif_pos hi]; exact ht1 _)
                    [Elab.step] [0.012395] 
                          refine
                            no_implicit_lambda%
                              (have h_meas_t' : ∀ i ∈ T, MeasurableSet (sets_t' i) := ?body✝;
                              ?_)
                          case body✝ => with_annotate_state"by" (intro i hi; simp_rw [sets_t', dif_pos hi]; exact ht1 _)
                      [Elab.step] [0.011494] case body✝ =>
                            with_annotate_state"by" (intro i hi; simp_rw [sets_t', dif_pos hi]; exact ht1 _)
                        [Elab.step] [0.011472] with_annotate_state"by"
                                (intro i hi; simp_rw [sets_t', dif_pos hi]; exact ht1 _)
                          [Elab.step] [0.011468] with_annotate_state"by"
                                  (intro i hi; simp_rw [sets_t', dif_pos hi]; exact ht1 _)
                            [Elab.step] [0.011464] with_annotate_state"by"
                                  (intro i hi; simp_rw [sets_t', dif_pos hi]; exact ht1 _)
                              [Elab.step] [0.011460] (intro i hi; simp_rw [sets_t', dif_pos hi]; exact ht1 _)
                                [Elab.step] [0.011456] intro i hi; simp_rw [sets_t', dif_pos hi]; exact ht1 _
                                  [Elab.step] [0.011451] intro i hi; simp_rw [sets_t', dif_pos hi]; exact ht1 _
                                    [Elab.step] [0.011113] simp_rw [sets_t', dif_pos hi]
              [Elab.step] [0.200022] have h_eq_inter_S :
                    (fun (ω : Ω) (i : ↥S) => f (↑i) ω) ⁻¹' Set.pi Set.univ sets_s = ⋂ i ∈ S, f i ⁻¹' sets_s' i :=
                    by
                    ext1 x
                    simp_rw [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
                    grind
                [Elab.step] [0.199974] focus
                      refine
                        no_implicit_lambda%
                          (have h_eq_inter_S :
                            (fun (ω : Ω) (i : ↥S) => f (↑i) ω) ⁻¹' Set.pi Set.univ sets_s =
                              ⋂ i ∈ S, f i ⁻¹' sets_s' i :=
                            ?body✝;
                          ?_)
                      case body✝ =>
                        with_annotate_state"by"
                          ( ext1 x
                            simp_rw [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
                            grind)
                  [Elab.step] [0.199966] 
                        refine
                          no_implicit_lambda%
                            (have h_eq_inter_S :
                              (fun (ω : Ω) (i : ↥S) => f (↑i) ω) ⁻¹' Set.pi Set.univ sets_s =
                                ⋂ i ∈ S, f i ⁻¹' sets_s' i :=
                              ?body✝;
                            ?_)
                        case body✝ =>
                          with_annotate_state"by"
                            ( ext1 x
                              simp_rw [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
                              grind)
                    [Elab.step] [0.199962] 
                          refine
                            no_implicit_lambda%
                              (have h_eq_inter_S :
                                (fun (ω : Ω) (i : ↥S) => f (↑i) ω) ⁻¹' Set.pi Set.univ sets_s =
                                  ⋂ i ∈ S, f i ⁻¹' sets_s' i :=
                                ?body✝;
                              ?_)
                          case body✝ =>
                            with_annotate_state"by"
                              ( ext1 x
                                simp_rw [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
                                grind)
                      [Elab.step] [0.195259] case body✝ =>
                            with_annotate_state"by"
                              ( ext1 x
                                simp_rw [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
                                grind)
                        [Elab.step] [0.195181] with_annotate_state"by"
                                ( ext1 x
                                  simp_rw [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
                                  grind)
                          [Elab.step] [0.195176] with_annotate_state"by"
                                  ( ext1 x
                                    simp_rw [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
                                    grind)
                            [Elab.step] [0.195171] with_annotate_state"by"
                                  ( ext1 x
                                    simp_rw [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
                                    grind)
                              [Elab.step] [0.195166] (
                                    ext1 x
                                    simp_rw [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
                                    grind)
                                [Elab.step] [0.195162] 
                                      ext1 x
                                      simp_rw [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
                                      grind
                                  [Elab.step] [0.195155] 
                                        ext1 x
                                        simp_rw [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
                                        grind
                                    [Elab.step] [0.015756] simp_rw [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
                                    [Elab.step] [0.178905] grind
              [Elab.step] [0.109236] have h_eq_inter_T :
                    (fun (ω : Ω) (i : ↥T) => f (↑i) ω) ⁻¹' Set.pi Set.univ sets_t = ⋂ i ∈ T, f i ⁻¹' sets_t' i :=
                    by
                    ext1 x
                    simp only [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
                    constructor <;> intro h
                    · intro i hi; simp_rw [sets_t', dif_pos hi]; exact h ⟨i, hi⟩
                    · grind
                [Elab.step] [0.109205] focus
                      refine
                        no_implicit_lambda%
                          (have h_eq_inter_T :
                            (fun (ω : Ω) (i : ↥T) => f (↑i) ω) ⁻¹' Set.pi Set.univ sets_t =
                              ⋂ i ∈ T, f i ⁻¹' sets_t' i :=
                            ?body✝;
                          ?_)
                      case body✝ =>
                        with_annotate_state"by"
                          ( ext1 x
                            simp only [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
                            constructor <;> intro h
                            · intro i hi; simp_rw [sets_t', dif_pos hi]; exact h ⟨i, hi⟩
                            · grind)
                  [Elab.step] [0.109192] 
                        refine
                          no_implicit_lambda%
                            (have h_eq_inter_T :
                              (fun (ω : Ω) (i : ↥T) => f (↑i) ω) ⁻¹' Set.pi Set.univ sets_t =
                                ⋂ i ∈ T, f i ⁻¹' sets_t' i :=
                              ?body✝;
                            ?_)
                        case body✝ =>
                          with_annotate_state"by"
                            ( ext1 x
                              simp only [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
                              constructor <;> intro h
                              · intro i hi; simp_rw [sets_t', dif_pos hi]; exact h ⟨i, hi⟩
                              · grind)
                    [Elab.step] [0.109184] 
                          refine
                            no_implicit_lambda%
                              (have h_eq_inter_T :
                                (fun (ω : Ω) (i : ↥T) => f (↑i) ω) ⁻¹' Set.pi Set.univ sets_t =
                                  ⋂ i ∈ T, f i ⁻¹' sets_t' i :=
                                ?body✝;
                              ?_)
                          case body✝ =>
                            with_annotate_state"by"
                              ( ext1 x
                                simp only [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
                                constructor <;> intro h
                                · intro i hi; simp_rw [sets_t', dif_pos hi]; exact h ⟨i, hi⟩
                                · grind)
                      [Elab.step] [0.103714] case body✝ =>
                            with_annotate_state"by"
                              ( ext1 x
                                simp only [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
                                constructor <;> intro h
                                · intro i hi; simp_rw [sets_t', dif_pos hi]; exact h ⟨i, hi⟩
                                · grind)
                        [Elab.step] [0.103588] with_annotate_state"by"
                                ( ext1 x
                                  simp only [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
                                  constructor <;> intro h
                                  · intro i hi; simp_rw [sets_t', dif_pos hi]; exact h ⟨i, hi⟩
                                  · grind)
                          [Elab.step] [0.103578] with_annotate_state"by"
                                  ( ext1 x
                                    simp only [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
                                    constructor <;> intro h
                                    · intro i hi; simp_rw [sets_t', dif_pos hi]; exact h ⟨i, hi⟩
                                    · grind)
                            [Elab.step] [0.103569] with_annotate_state"by"
                                  ( ext1 x
                                    simp only [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
                                    constructor <;> intro h
                                    · intro i hi; simp_rw [sets_t', dif_pos hi]; exact h ⟨i, hi⟩
                                    · grind)
                              [Elab.step] [0.103557] (
                                    ext1 x
                                    simp only [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
                                    constructor <;> intro h
                                    · intro i hi; simp_rw [sets_t', dif_pos hi]; exact h ⟨i, hi⟩
                                    · grind)
                                [Elab.step] [0.103547] 
                                      ext1 x
                                      simp only [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
                                      constructor <;> intro h
                                      · intro i hi; simp_rw [sets_t', dif_pos hi]; exact h ⟨i, hi⟩
                                      · grind
                                  [Elab.step] [0.103533] 
                                        ext1 x
                                        simp only [Set.mem_preimage, Set.mem_univ_pi, Set.mem_iInter]
                                        constructor <;> intro h
                                        · intro i hi; simp_rw [sets_t', dif_pos hi]; exact h ⟨i, hi⟩
                                        · grind
                                    [Elab.step] [0.087215] · grind
                                      [Elab.step] [0.087117] grind
                                        [Elab.step] [0.087106] grind
                                          [Elab.step] [0.087087] grind
              [Elab.step] [0.262175] have h_Inter_inter :
                    ((⋂ i ∈ S, f i ⁻¹' sets_s' i) ∩ ⋂ i ∈ T, f i ⁻¹' sets_t' i) =
                      ⋂ i ∈ S ∪ T, f i ⁻¹' (sets_s' i ∩ sets_t' i) :=
                    by
                    ext1 x
                    simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
                    constructor <;> intro h
                    · grind
                    · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩
                [Elab.step] [0.259911] focus
                      refine
                        no_implicit_lambda%
                          (have h_Inter_inter :
                            ((⋂ i ∈ S, f i ⁻¹' sets_s' i) ∩ ⋂ i ∈ T, f i ⁻¹' sets_t' i) =
                              ⋂ i ∈ S ∪ T, f i ⁻¹' (sets_s' i ∩ sets_t' i) :=
                            ?body✝;
                          ?_)
                      case body✝ =>
                        with_annotate_state"by"
                          ( ext1 x
                            simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
                            constructor <;> intro h
                            · grind
                            · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩)
                  [Elab.step] [0.259898] 
                        refine
                          no_implicit_lambda%
                            (have h_Inter_inter :
                              ((⋂ i ∈ S, f i ⁻¹' sets_s' i) ∩ ⋂ i ∈ T, f i ⁻¹' sets_t' i) =
                                ⋂ i ∈ S ∪ T, f i ⁻¹' (sets_s' i ∩ sets_t' i) :=
                              ?body✝;
                            ?_)
                        case body✝ =>
                          with_annotate_state"by"
                            ( ext1 x
                              simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
                              constructor <;> intro h
                              · grind
                              · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩)
                    [Elab.step] [0.259893] 
                          refine
                            no_implicit_lambda%
                              (have h_Inter_inter :
                                ((⋂ i ∈ S, f i ⁻¹' sets_s' i) ∩ ⋂ i ∈ T, f i ⁻¹' sets_t' i) =
                                  ⋂ i ∈ S ∪ T, f i ⁻¹' (sets_s' i ∩ sets_t' i) :=
                                ?body✝;
                              ?_)
                          case body✝ =>
                            with_annotate_state"by"
                              ( ext1 x
                                simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
                                constructor <;> intro h
                                · grind
                                · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩)
                      [Elab.step] [0.019667] refine
                            no_implicit_lambda%
                              (have h_Inter_inter :
                                ((⋂ i ∈ S, f i ⁻¹' sets_s' i) ∩ ⋂ i ∈ T, f i ⁻¹' sets_t' i) =
                                  ⋂ i ∈ S ∪ T, f i ⁻¹' (sets_s' i ∩ sets_t' i) :=
                                ?body✝;
                              ?_)
                        [Elab.step] [0.019516] expected type: ∀ᵐ (a : α) ∂μ,
                              (η a)
                                  ((fun a i ↦ f (↑i) a) ⁻¹' univ.pi sets_s ∩ (fun a i ↦ f (↑i) a) ⁻¹' univ.pi sets_t) =
                                (η a) ((fun a i ↦ f (↑i) a) ⁻¹' univ.pi sets_s) *
                                  (η a) ((fun a i ↦ f (↑i) a) ⁻¹' univ.pi sets_t), term
                            no_implicit_lambda%
                              (have h_Inter_inter :
                                ((⋂ i ∈ S, f i ⁻¹' sets_s' i) ∩ ⋂ i ∈ T, f i ⁻¹' sets_t' i) =
                                  ⋂ i ∈ S ∪ T, f i ⁻¹' (sets_s' i ∩ sets_t' i) :=
                                ?body✝;
                              ?_)
                          [Elab.step] [0.019504] expected type: ∀ᵐ (a : α) ∂μ,
                                (η a)
                                    ((fun a i ↦ f (↑i) a) ⁻¹' univ.pi sets_s ∩
                                      (fun a i ↦ f (↑i) a) ⁻¹' univ.pi sets_t) =
                                  (η a) ((fun a i ↦ f (↑i) a) ⁻¹' univ.pi sets_s) *
                                    (η a) ((fun a i ↦ f (↑i) a) ⁻¹' univ.pi sets_t), term
                              (have h_Inter_inter :
                                ((⋂ i ∈ S, f i ⁻¹' sets_s' i) ∩ ⋂ i ∈ T, f i ⁻¹' sets_t' i) =
                                  ⋂ i ∈ S ∪ T, f i ⁻¹' (sets_s' i ∩ sets_t' i) :=
                                ?body✝;
                              ?_)
                            [Elab.step] [0.019477] expected type: ∀ᵐ (a : α) ∂μ,
                                  (η a)
                                      ((fun a i ↦ f (↑i) a) ⁻¹' univ.pi sets_s ∩
                                        (fun a i ↦ f (↑i) a) ⁻¹' univ.pi sets_t) =
                                    (η a) ((fun a i ↦ f (↑i) a) ⁻¹' univ.pi sets_s) *
                                      (η a) ((fun a i ↦ f (↑i) a) ⁻¹' univ.pi sets_t), term
                                have h_Inter_inter :
                                  ((⋂ i ∈ S, f i ⁻¹' sets_s' i) ∩ ⋂ i ∈ T, f i ⁻¹' sets_t' i) =
                                    ⋂ i ∈ S ∪ T, f i ⁻¹' (sets_s' i ∩ sets_t' i) :=
                                  ?body✝;
                                ?_
                              [Elab.step] [0.019245] expected type: Sort ?u.81043, term
                                  ((⋂ i ∈ S, f i ⁻¹' sets_s' i) ∩ ⋂ i ∈ T, f i ⁻¹' sets_t' i) =
                                    ⋂ i ∈ S ∪ T, f i ⁻¹' (sets_s' i ∩ sets_t' i)
                                [Elab.step] [0.019233] expected type: Sort ?u.81043, term
                                    binrel% Eq✝ ((⋂ i ∈ S, f i ⁻¹' sets_s' i) ∩ ⋂ i ∈ T, f i ⁻¹' sets_t' i)
                                      (⋂ i ∈ S ∪ T, f i ⁻¹' (sets_s' i ∩ sets_t' i))
                                  [Elab.step] [0.011866] expected type: <not-available>, term
                                      Inter.inter✝ (⋂ i ∈ S, f i ⁻¹' sets_s' i) (⋂ i ∈ T, f i ⁻¹' sets_t' i)
                      [Elab.step] [0.240197] case body✝ =>
                            with_annotate_state"by"
                              ( ext1 x
                                simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
                                constructor <;> intro h
                                · grind
                                · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩)
                        [Elab.step] [0.240107] with_annotate_state"by"
                                ( ext1 x
                                  simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
                                  constructor <;> intro h
                                  · grind
                                  · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩)
                          [Elab.step] [0.240096] with_annotate_state"by"
                                  ( ext1 x
                                    simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
                                    constructor <;> intro h
                                    · grind
                                    · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩)
                            [Elab.step] [0.240086] with_annotate_state"by"
                                  ( ext1 x
                                    simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
                                    constructor <;> intro h
                                    · grind
                                    · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩)
                              [Elab.step] [0.240074] (
                                    ext1 x
                                    simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
                                    constructor <;> intro h
                                    · grind
                                    · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩)
                                [Elab.step] [0.240064] 
                                      ext1 x
                                      simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
                                      constructor <;> intro h
                                      · grind
                                      · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩
                                  [Elab.step] [0.240054] 
                                        ext1 x
                                        simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage, Finset.mem_union]
                                        constructor <;> intro h
                                        · grind
                                        · exact ⟨fun i hi => (h i (Or.inl hi)).1, fun i hi => (h i (Or.inr hi)).2⟩
                                    [Elab.step] [0.022194] simp_rw [Set.mem_inter_iff, Set.mem_iInter, Set.mem_preimage,
                                          Finset.mem_union]
                                    [Elab.step] [0.213930] · grind
                                      [Elab.step] [0.213880] grind
                                        [Elab.step] [0.213873] grind
                                          [Elab.step] [0.213855] grind
              [Elab.step] [0.010516] have h_meas_inter : ∀ i ∈ S ∪ T, MeasurableSet (sets_s' i ∩ sets_t' i) :=
                    by
                    intros i hi_mem
                    rw [Finset.mem_union] at hi_mem
                    rcases hi_mem with hi_mem | hi_mem
                    · rw [h_sets_t'_univ hi_mem, Set.inter_univ]
                      exact h_meas_s' i hi_mem
                    · rw [h_sets_s'_univ hi_mem, Set.univ_inter]
                      exact h_meas_t' i hi_mem
                [Elab.step] [0.010490] focus
                      refine
                        no_implicit_lambda%
                          (have h_meas_inter : ∀ i ∈ S ∪ T, MeasurableSet (sets_s' i ∩ sets_t' i) := ?body✝;
                          ?_)
                      case body✝ =>
                        with_annotate_state"by"
                          ( intros i hi_mem
                            rw [Finset.mem_union] at hi_mem
                            rcases hi_mem with hi_mem | hi_mem
                            · rw [h_sets_t'_univ hi_mem, Set.inter_univ]
                              exact h_meas_s' i hi_mem
                            · rw [h_sets_s'_univ hi_mem, Set.univ_inter]
                              exact h_meas_t' i hi_mem)
                  [Elab.step] [0.010481] 
                        refine
                          no_implicit_lambda%
                            (have h_meas_inter : ∀ i ∈ S ∪ T, MeasurableSet (sets_s' i ∩ sets_t' i) := ?body✝;
                            ?_)
                        case body✝ =>
                          with_annotate_state"by"
                            ( intros i hi_mem
                              rw [Finset.mem_union] at hi_mem
                              rcases hi_mem with hi_mem | hi_mem
                              · rw [h_sets_t'_univ hi_mem, Set.inter_univ]
                                exact h_meas_s' i hi_mem
                              · rw [h_sets_s'_univ hi_mem, Set.univ_inter]
                                exact h_meas_t' i hi_mem)
                    [Elab.step] [0.010473] 
                          refine
                            no_implicit_lambda%
                              (have h_meas_inter : ∀ i ∈ S ∪ T, MeasurableSet (sets_s' i ∩ sets_t' i) := ?body✝;
                              ?_)
                          case body✝ =>
                            with_annotate_state"by"
                              ( intros i hi_mem
                                rw [Finset.mem_union] at hi_mem
                                rcases hi_mem with hi_mem | hi_mem
                                · rw [h_sets_t'_univ hi_mem, Set.inter_univ]
                                  exact h_meas_s' i hi_mem
                                · rw [h_sets_s'_univ hi_mem, Set.univ_inter]
                                  exact h_meas_t' i hi_mem)
              [Elab.step] [0.012790] filter_upwards [hf_Indep S h_meas_s', hf_Indep T h_meas_t',
                    hf_Indep (S ∪ T) h_meas_inter] with a h_indepS h_indepT h_indepST
              [Elab.step] [0.041687] congr 1
                [Meta.isDefEq] [0.011064] ❌️ ∏ x ∈ S,
                      (η a) (f x ⁻¹' (sets_s' x ∩ sets_t' x)) =?= ∏ i ∈ S, (η a) (f i ⁻¹' sets_s' i)
                [Meta.isDefEq] [0.010650] ❌️ ∏ x ∈ T,
                      (η a) (f x ⁻¹' (sets_s' x ∩ sets_t' x)) =?= ∏ i ∈ T, (η a) (f i ⁻¹' sets_t' i)
    [Meta.instantiateMVars] [0.032585] Or.casesOn (eq_or_ne μ 0)
          (fun h ↦
            Eq.ndrec (motive := fun {μ} ↦ iIndepFun f κ μ → IndepFun (fun a i ↦ f (↑i) a) (fun a i ↦ f (↑i) a) κ μ)
              (fun hf_Indep ↦ of_eq_true indepFun_zero_right._simp_1) (Eq.symm h) hf_Indep)
          fun hμ ↦
          Exists.casesOn (exists_ae_eq_isMarkovKernel (ae_isProbabilityMeasure hf_Indep) hμ) fun η h ↦
            And.casesOn h fun η_eq hη ↦
              IndepFun.congr (Filter.EventuallyEq.symm η_eq)
                (let πSβ := univ.pi '' univ.pi fun i ↦ {s | MeasurableSet s};
                let πS := {s | ∃ t ∈ πSβ, (fun a i ↦ f (↑i) a) ⁻¹' t = s};
                have hπS_pi := IsPiSystem.comap isPiSystem_pi fun a i ↦ f (↑i) a;
                have hπS_gen :=
                  Eq.mpr
                    (id
                      (congrArg (fun _a ↦ MeasurableSpace.comap (fun a i ↦ f (↑i) a) _a = generateFrom πS)
                        (Eq.symm generateFrom_pi)))
                    (Eq.mpr (id (congrArg (fun _a ↦ _a = generateFrom πS) comap_generateFrom))
                      ((fun {α} s s_1 e_s ↦ e_s ▸ Eq.refl (generateFrom s))
                        ((preimage fun a i ↦ f (↑i) a) '' (univ.pi '' univ.pi fun i ↦ {s | MeasurableSet s})) πS
                        (Eq.refl
                          ((preimage fun a i ↦ f (↑i) a) '' (univ.pi '' univ.pi fun i ↦ {s | MeasurableSet s})))));
                let πTβ := univ.pi '' univ.pi fun i ↦ {s | MeasurableSet s};
                let πT := {s | ∃ t ∈ πTβ, (fun a i ↦ f (↑i) a) ⁻¹' t = s};
                have hπT_pi := IsPiSystem.comap isPiSystem_pi fun a i ↦ f (↑i) a;
                have hπT_gen :=
                  Eq.mpr
                    (id
                      (congrArg (fun _a ↦ MeasurableSpace.comap (fun a i ↦ f (↑i) a) _a = generateFrom πT)
                        (Eq.symm generateFrom_pi)))
                    (Eq.mpr (id (congrArg (fun _a ↦ _a = generateFrom πT) comap_generateFrom))
                      ((fun {α} s s_1 e_s ↦ e_s ▸ Eq.refl (generateFrom s))
                        ((preimage fun a i ↦ f (↑i) a) '' (univ.pi '' univ.pi fun i ↦ {s | MeasurableSet s})) πT
                        (Eq.refl
                          ((preimage fun a i ↦ f (↑i) a) '' (univ.pi '' univ.pi fun i ↦ {s | MeasurableSet s})))));
                IndepSets.indep (Measurable.comap_le (measurable_pi_iff.mpr fun i ↦ hf_meas ↑i))
                  (Measurable.comap_le (measurable_pi_iff.mpr fun i ↦ hf_meas ↑i)) hπS_pi hπT_pi hπS_gen hπT_gen
                  fun t1 t2 a ↦
                  Exists.casesOn (motive := fun x ↦ t2 ∈ πT → ∀ᵐ (a : α) ∂μ, (η a) (t1 ∩ t2) = (η a) t1 * (η a) t2) a
                    fun s h ↦
                    And.casesOn (motive := fun x ↦ t2 ∈ πT → ∀ᵐ (a : α) ∂μ, (η a) (t1 ∩ t2) = (η a) t1 * (η a) t2) h
                      fun left right ↦
                      Exists.casesOn (motive := fun x ↦ t2 ∈ πT → ∀ᵐ (a : α) ∂μ, (η a) (t1 ∩ t2) = (η a) t1 * (η a) t2)
                        left fun sets_s h ↦
                        And.casesOn (motive := fun x ↦ t2 ∈ πT → ∀ᵐ (a : α) ∂μ, (η a) (t1 ∩ t2) = (η a) t1 * (η a) t2) h
                          fun hs1 hs2 ↦
                          Eq.ndrec (motive := fun t1 ↦ t2 ∈ πT → ∀ᵐ (a : α) ∂μ, (η a) (t1 ∩ t2) = (η a) t1 * (η a) t2)
                            (fun a ↦
                              Exists.casesOn a fun t h ↦
                                And.casesOn h fun left right ↦
                                  Exists.casesOn left fun sets_t h ↦
                                    And.casesOn h fun ht1 ht2 ↦
                                      right ▸
                                        Eq.mpr (id (congrArg ⋯ ⋯))
                                          (Eq.mpr (id ⋯)
                                            (let sets_s' := ⋯;
                                            ⋯)))
                            right)
  [Elab.def.maxSharing] [0.011719] share common exprs
  [Elab.def.processPreDef] [0.017333] process pre-definitions
info: Mathlib/Probability/Independence/Kernel.lean:1019:8: [Elab.async] [0.020016] Lean.addDecl
  [Kernel] [0.019993] typechecking declarations [ProbabilityTheory.Kernel.iIndepFun.indepFun_finset]
Build completed successfully.
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
