### PR TITLE
chore(Topology/Valued): golf using local finite order of WithZeroTopology

### DIFF
--- a/Mathlib/Topology/Algebra/GroupWithZero.lean
+++ b/Mathlib/Topology/Algebra/GroupWithZero.lean
@@ -156,6 +156,14 @@ lemma tendsto_inv_iff₀ {l : Filter α} {f : α → G₀} (hx : x ≠ 0) :
     Tendsto (fun x ↦ (f x)⁻¹) l (𝓝 x⁻¹) ↔ Tendsto f l (𝓝 x) := by
   simp only [nhds_inv₀ hx, ← Filter.comap_inv, tendsto_comap_iff, Function.comp_def, inv_inv]
 
+theorem IsCompact.inv₀ {s : Set G₀} (hs : IsCompact s) (hs' : 0 ∉ s) : IsCompact s⁻¹ := by
+  rw [← Set.image_inv_eq_inv]
+  refine hs.image_of_continuousOn ?_
+  refine continuousOn_of_forall_continuousAt ?_
+  intro x hx
+  refine continuousAt_inv₀ ?_
+  grind
+
 end NhdsInv
 
 /-!

--- a/Mathlib/Topology/Algebra/Valued/LocallyCompact.lean
+++ b/Mathlib/Topology/Algebra/Valued/LocallyCompact.lean
@@ -170,96 +170,44 @@ section CompactDVR
 
 open Valued
 
+open WithZeroTopology in
 lemma locallyFiniteOrder_units_mrange_of_isCompact_integer (hc : IsCompact (X := K) 𝒪[K]) :
     Nonempty (LocallyFiniteOrder (MonoidHom.mrange (Valued.v : Valuation K Γ₀))ˣ):= by
   -- TODO: generalize to `Valuation.Integer`, which will require showing that `IsCompact`
   -- pulls back across `TopologicalSpace.induced` from a `LocallyCompactSpace`.
-  constructor
-  refine LocallyFiniteOrder.ofFiniteIcc ?_
-  -- We only need to show that we can construct a finite set for some set between
-  -- a non-zero `z : Γ₀` and 1, because we can scale/invert this set to cover the whole group.
-  suffices ∀ z : (MonoidHom.mrange (Valued.v : Valuation K Γ₀))ˣ, (Set.Icc z 1).Finite by
-    rintro x y
-    rcases lt_trichotomy y x with hxy | rfl | hxy
-    · rw [Set.Icc_eq_empty_of_lt]
-      · exact Set.finite_empty
-      · simp [hxy]
-    · simp
-    wlog h : x ≤ 1 generalizing x y
-    · push_neg at h
-      specialize this y⁻¹ x⁻¹ (inv_lt_inv' hxy) (inv_le_one_of_one_le (h.trans hxy).le)
-      refine (this.inv).subset ?_
-      rw [Set.inv_Icc]
-      intro
-      simp +contextual
-    generalize_proofs _ _ _ _ hxu hyu
-    rcases le_total y 1 with hy | hy
-    · exact (this x).subset (Set.Icc_subset_Icc_right hy)
-    · have H : (Set.Icc y⁻¹ 1).Finite := this _
-      refine ((this x).union H.inv).subset (le_of_eq ?_)
-      rw [Set.inv_Icc, inv_one, Set.Icc_union_Icc_eq_Icc] <;>
-      simp [h, hy]
-  -- We can construct a family of spheres at every single element of the valuation ring
-  -- outside of a closed ball, which will cover.
-  -- Since we are in a compact space, this cover has a finite subcover.
-  -- First, we need to pick a threshold element with a nontrivial valuation less than 1,
-  -- which will form -- the inner closed ball of the cover, which we need to cover 0.
-  intro z
-  obtain ⟨a, ha⟩ := z.val.prop
-  rcases lt_or_ge 1 z with hz1 | hz1
-  · rw [Set.Icc_eq_empty_of_lt]
-    · exact Set.finite_empty
-    · simp [hz1]
-  have z0' : 0 < (z : MonoidHom.mrange (Valued.v : Valuation K Γ₀)) := by simp
-  have z0 : 0 < ((z : MonoidHom.mrange (Valued.v : Valuation K Γ₀)) : Γ₀) :=
-    Subtype.coe_lt_coe.mpr z0'
-  have a0 : 0 < v a := by simp [ha, z0]
-  -- Construct our cover, which has an inner closed ball, and spheres for each element
-  -- outside of the closed ball. These are all open sets by the nonarchimedean property.
-  let U : K → Set K := fun y ↦ if v (y : K) ≤ z
-    then {w | v (w : K) ≤ z}
-    else {w | v (w : K) = v (y : K)}
-  have := hc.elim_finite_subcover U
-  specialize this ?_ ?_
-  · intro w
-    simp only [U]
-    split_ifs with hw
-    · exact Valued.isOpen_closedball _ z0.ne'
-    · refine Valued.isOpen_sphere _ ?_
-      push_neg at hw
-      refine (hw.trans' ?_).ne'
-      simp [z0]
-  · intro w
-    simp only [integer, SetLike.mem_coe, Valuation.mem_integer_iff, Set.mem_iUnion, U]
-    intro hw
-    use if v w ≤ z then a else w
-    split_ifs <;>
-    simp_all
-  -- For each element of the valuation ring that is bigger than our threshold element above,
-  -- there must be something in the cover that has the precise valuation of the element,
-  -- because it must be outside the inner closed ball, and thus is covered by some sphere.
-  obtain ⟨t, ht⟩ := this
-  classical
-  refine (t.finite_toSet.dependent_image ?_).subset ?_
-  · refine fun i hi ↦ if hi' : v i ≤ z then z else Units.mk0 ⟨(v i), by simp⟩ ?_
-    push_neg at hi'
-    exact Subtype.coe_injective.ne_iff.mp (hi'.trans' z0).ne'
-  · intro i
-    simp only [Set.mem_Icc, Finset.mem_coe, exists_prop, Set.mem_setOf_eq, and_imp]
-    -- we get the `c` from the cover that covers our arbitrary `i` with its set
-    obtain ⟨c, hc⟩ := i.val.prop
-    intro hzi hi1
-    have hj := ht (hc.trans_le hi1)
-    simp only [Set.mem_iUnion, exists_prop, U] at hj
-    obtain ⟨j, hj, hj'⟩ := hj
-    use j, hj
-    -- and this `c` is either less than or greater than (or equal to) the threshold element
-    split_ifs at hj' with hcj
-    · simp only [Set.mem_setOf_eq, hc, Subtype.coe_le_coe, Units.val_le_val] at hj'
-      simp [hcj, le_antisymm hj' hzi]
-    · simp only [Set.mem_setOf_eq] at hj'
-      rw [dif_neg hcj]
-      simp [← hj', hc]
+  -- specify the topology again to increase priority to override subtype topology
+  let : TopologicalSpace (MonoidHom.mrange (Valued.v : Valuation K Γ₀)) := topologicalSpace
+  let v' : Valuation K (MonoidHom.mrange (Valued.v : Valuation K Γ₀)) :=
+   -- can't use mrangeRestrict directly, no CommGroupWithZero on MonoidHom mranges
+  { __ := v.toMonoidWithZeroHom.mrangeRestrict
+    map_zero' := by simp [Subtype.ext_iff]
+    map_add_le_max' := by simp [← Subtype.coe_le_coe] }
+  have : @Continuous _ _ _ topologicalSpace v' := by
+    rw [continuous_iff_continuousAt]
+    intro x
+    rcases GroupWithZero.eq_zero_or_unit x with (rfl | ⟨x, rfl⟩)
+    · rw [ContinuousAt, map_zero, WithZeroTopology.tendsto_zero]
+      rintro ⟨-, y, rfl⟩ hy
+      rw [Filter.Eventually, Valued.mem_nhds_zero]
+      use Units.mk0 (v y) (by simpa [Subtype.ext_iff] using hy)
+      simp [v', ← Subtype.coe_lt_coe]
+    · have v_ne : v' x ≠ 0 := by simp [v', Subtype.ext_iff]
+      rw [ContinuousAt, WithZeroTopology.tendsto_of_ne_zero v_ne]
+      simp [v', Subtype.ext_iff]
+      apply Valued.loc_const
+      simp
+  rw [← locallyCompactSpace_iff_locallyFiniteOrder_units]
+  refine locallyCompactSpace_of_compact_Iic one_ne_zero ?_
+  convert hc.image_of_continuousOn this.continuousOn
+  ext ⟨-, x, rfl⟩
+  simp only [Set.mem_Iic, ← Subtype.coe_le_coe, OneMemClass.coe_one, Lean.Elab.WF.paramLet,
+    OneHom.toFun_eq_coe, MonoidHom.toOneHom_coe, Valuation.coe_mk, MonoidWithZeroHom.coe_mk,
+    ZeroHom.coe_mk, Set.mem_image, SetLike.mem_coe, Valuation.mem_integer_iff, Subtype.ext_iff,
+    MonoidHom.coe_mrangeRestrict, MonoidHom.coe_mk, ZeroHom.toFun_eq_coe,
+    MonoidWithZeroHom.toZeroHom_coe, Valuation.toMonoidWithZeroHom_coe_eq_coe, OneHom.coe_mk, v']
+  -- ideally, grind should solve this directly, but using it gives deterministic heartbeat timeout
+  constructor <;>
+  grind
 
 lemma mulArchimedean_mrange_of_isCompact_integer (hc : IsCompact (X := K) 𝒪[K]) :
     MulArchimedean (MonoidHom.mrange (Valued.v : Valuation K Γ₀)) := by

--- a/Mathlib/Topology/Compactness/Compact.lean
+++ b/Mathlib/Topology/Compactness/Compact.lean
@@ -795,6 +795,11 @@ instance : NoncompactSpace ℤ :=
 theorem finite_of_compact_of_discrete [CompactSpace X] [DiscreteTopology X] : Finite X :=
   Finite.of_finite_univ <| isCompact_univ.finite_of_discrete
 
+instance DiscreteTopology.instLocallyCompactSpace [DiscreteTopology X] : LocallyCompactSpace X where
+  local_compact_nhds x s hs := by
+    use {x}
+    simpa using hs
+
 lemma Set.Infinite.exists_accPt_cofinite_inf_principal_of_subset_isCompact
     {K : Set X} (hs : s.Infinite) (hK : IsCompact K) (hsub : s ⊆ K) :
     ∃ x ∈ K, AccPt x (cofinite ⊓ 𝓟 s) :=


### PR DESCRIPTION
have to juggle in a version of `mrangeRestrict`
which works on valuations,
and also juggle the scoped topology over
the subtype topology

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

- [ ] depends on: #28325