### PR TITLE
[Merged by Bors] - feat(Analysis): add three little theorems relating argument to image

### DIFF
--- a/Mathlib/Analysis/Normed/Module/Convex.lean
+++ b/Mathlib/Analysis/Normed/Module/Convex.lean
@@ -147,7 +147,7 @@ theorem Eventually.segment_of_prod_nhdsWithin (hy : Tendsto y f (𝓝 x)) (hz : 
     (hr : ∀ᶠ p in f ×ˢ 𝓝[s] x, r p.1 p.2) (seg : ∀ᶠ χ in f, [y χ -[ℝ] z χ] ⊆ s) :
     ∀ᶠ χ in f, ∀ v ∈ [y χ -[ℝ] z χ], r χ v := by
   refine seg.mp <| .mono ?_ (fun _ => forall₂_imp)
-  apply segment_of_prod_nhds hy hz
+  apply Eventually.segment_of_prod_nhds hy hz
   simpa [nhdsWithin, prod_eq_inf, ← inf_assoc, eventually_inf_principal] using hr
 
 end Filter

--- a/Mathlib/Analysis/Normed/Module/Convex.lean
+++ b/Mathlib/Analysis/Normed/Module/Convex.lean
@@ -131,4 +131,25 @@ lemma norm_sub_le_of_mem_segment {x y z : E} (hy : y ∈ segment ℝ x z) :
   conv_rhs => rw [← one_mul (‖z - x‖)]
   gcongr
 
+namespace Filter
+
+open scoped Convex Topology
+variable {F : Type*} {l : Filter F} {x : E} {y z : F → E} {r : F → E → Prop}
+
+theorem Eventually.segment_of_prod_nhds (hy : Tendsto y l (𝓝 x)) (hz : Tendsto z l (𝓝 x))
+    (hr : ∀ᶠ p in l ×ˢ 𝓝 x, r p.1 p.2) : ∀ᶠ χ in l, ∀ v ∈ [y χ -[ℝ] z χ], r χ v := by
+  obtain ⟨p, hp, δ, hδ, hr⟩ := eventually_prod_nhds_iff.mp hr
+  rw [Metric.tendsto_nhds] at hy hz
+  filter_upwards [hp, hy δ hδ, hz δ hδ] with χ hp hy hz
+  exact fun v hv => hr hp <| convex_iff_segment_subset.mp (convex_ball x δ) hy hz hv
+
+theorem Eventually.segment_of_prod_nhdsWithin (hy : Tendsto y l (𝓝 x)) (hz : Tendsto z l (𝓝 x))
+    (hr : ∀ᶠ p in l ×ˢ 𝓝[s] x, r p.1 p.2) (seg : ∀ᶠ χ in l, [y χ -[ℝ] z χ] ⊆ s) :
+    ∀ᶠ χ in l, ∀ v ∈ [y χ -[ℝ] z χ], r χ v := by
+  refine seg.mp <| .mono ?_ (fun _ => forall₂_imp)
+  apply segment_of_prod_nhds hy hz
+  simpa [nhdsWithin, prod_eq_inf, ← inf_assoc, eventually_inf_principal] using hr
+
+end Filter
+
 end SeminormedAddCommGroup

--- a/Mathlib/Analysis/Normed/Module/Convex.lean
+++ b/Mathlib/Analysis/Normed/Module/Convex.lean
@@ -134,18 +134,18 @@ lemma norm_sub_le_of_mem_segment {x y z : E} (hy : y ∈ segment ℝ x z) :
 namespace Filter
 
 open scoped Convex Topology
-variable {F : Type*} {l : Filter F} {x : E} {y z : F → E} {r : F → E → Prop}
+variable {F : Type*} {f : Filter F} {x : E} {y z : F → E} {r : F → E → Prop}
 
-theorem Eventually.segment_of_prod_nhds (hy : Tendsto y l (𝓝 x)) (hz : Tendsto z l (𝓝 x))
-    (hr : ∀ᶠ p in l ×ˢ 𝓝 x, r p.1 p.2) : ∀ᶠ χ in l, ∀ v ∈ [y χ -[ℝ] z χ], r χ v := by
+theorem Eventually.segment_of_prod_nhds (hy : Tendsto y f (𝓝 x)) (hz : Tendsto z f (𝓝 x))
+    (hr : ∀ᶠ p in f ×ˢ 𝓝 x, r p.1 p.2) : ∀ᶠ χ in f, ∀ v ∈ [y χ -[ℝ] z χ], r χ v := by
   obtain ⟨p, hp, δ, hδ, hr⟩ := eventually_prod_nhds_iff.mp hr
   rw [Metric.tendsto_nhds] at hy hz
   filter_upwards [hp, hy δ hδ, hz δ hδ] with χ hp hy hz
   exact fun v hv => hr hp <| convex_iff_segment_subset.mp (convex_ball x δ) hy hz hv
 
-theorem Eventually.segment_of_prod_nhdsWithin (hy : Tendsto y l (𝓝 x)) (hz : Tendsto z l (𝓝 x))
-    (hr : ∀ᶠ p in l ×ˢ 𝓝[s] x, r p.1 p.2) (seg : ∀ᶠ χ in l, [y χ -[ℝ] z χ] ⊆ s) :
-    ∀ᶠ χ in l, ∀ v ∈ [y χ -[ℝ] z χ], r χ v := by
+theorem Eventually.segment_of_prod_nhdsWithin (hy : Tendsto y f (𝓝 x)) (hz : Tendsto z f (𝓝 x))
+    (hr : ∀ᶠ p in f ×ˢ 𝓝[s] x, r p.1 p.2) (seg : ∀ᶠ χ in f, [y χ -[ℝ] z χ] ⊆ s) :
+    ∀ᶠ χ in f, ∀ v ∈ [y χ -[ℝ] z χ], r χ v := by
   refine seg.mp <| .mono ?_ (fun _ => forall₂_imp)
   apply segment_of_prod_nhds hy hz
   simpa [nhdsWithin, prod_eq_inf, ← inf_assoc, eventually_inf_principal] using hr

--- a/Mathlib/Analysis/Normed/Module/Convex.lean
+++ b/Mathlib/Analysis/Normed/Module/Convex.lean
@@ -134,7 +134,7 @@ lemma norm_sub_le_of_mem_segment {x y z : E} (hy : y ∈ segment ℝ x z) :
 namespace Filter
 
 open scoped Convex Topology
-variable {F : Type*} {f : Filter F} {x : E} {y z : F → E} {r : F → E → Prop}
+variable {α : Type*} {f : Filter α} {x : E} {y z : α → E} {r : α → E → Prop}
 
 theorem Eventually.segment_of_prod_nhds (hy : Tendsto y f (𝓝 x)) (hz : Tendsto z f (𝓝 x))
     (hr : ∀ᶠ p in f ×ˢ 𝓝 x, r p.1 p.2) : ∀ᶠ χ in f, ∀ v ∈ [y χ -[ℝ] z χ], r χ v := by

--- a/Mathlib/Order/Filter/Prod.lean
+++ b/Mathlib/Order/Filter/Prod.lean
@@ -187,12 +187,16 @@ lemma Frequently.of_curry {la : Filter α} {lb : Filter β} {p : α × β → Pr
     (h : ∃ᶠ x in la, ∃ᶠ y in lb, p (x, y)) : ∃ᶠ xy in la ×ˢ lb, p xy :=
   h.uncurry
 
+theorem Eventually.image_of_prod {y : α → β} {r : α → β → Prop}
+    (hψ : Tendsto y f g) (hr : ∀ᶠ p in f ×ˢ g, r p.1 p.2) : ∀ᶠ x in f, r x (y x) := by
+  obtain ⟨p, hp, q, hq, hr⟩ := eventually_prod_iff.mp hr
+  filter_upwards [hp, hψ.eventually hq] with _ hp hq using hr hp hq
+
 /-- A fact that is eventually true about all pairs `l ×ˢ l` is eventually true about
 all diagonal pairs `(i, i)` -/
 theorem Eventually.diag_of_prod {p : α × α → Prop} (h : ∀ᶠ i in f ×ˢ f, p i) :
-    ∀ᶠ i in f, p (i, i) := by
-  obtain ⟨t, ht, s, hs, hst⟩ := eventually_prod_iff.1 h
-  apply (ht.and hs).mono fun x hx => hst hx.1 hx.2
+    ∀ᶠ i in f, p (i, i) :=
+  h.image_of_prod (r := p.curry) tendsto_id
 
 theorem Eventually.diag_of_prod_left {f : Filter α} {g : Filter γ} {p : (α × α) × γ → Prop} :
     (∀ᶠ x in (f ×ˢ f) ×ˢ g, p x) → ∀ᶠ x : α × γ in f ×ˢ g, p ((x.1, x.1), x.2) := by

--- a/Mathlib/Order/Filter/Prod.lean
+++ b/Mathlib/Order/Filter/Prod.lean
@@ -188,9 +188,9 @@ lemma Frequently.of_curry {la : Filter α} {lb : Filter β} {p : α × β → Pr
   h.uncurry
 
 theorem Eventually.image_of_prod {y : α → β} {r : α → β → Prop}
-    (hψ : Tendsto y f g) (hr : ∀ᶠ p in f ×ˢ g, r p.1 p.2) : ∀ᶠ x in f, r x (y x) := by
+    (hy : Tendsto y f g) (hr : ∀ᶠ p in f ×ˢ g, r p.1 p.2) : ∀ᶠ x in f, r x (y x) := by
   obtain ⟨p, hp, q, hq, hr⟩ := eventually_prod_iff.mp hr
-  filter_upwards [hp, hψ.eventually hq] with _ hp hq using hr hp hq
+  filter_upwards [hp, hy.eventually hq] with _ hp hq using hr hp hq
 
 /-- A fact that is eventually true about all pairs `l ×ˢ l` is eventually true about
 all diagonal pairs `(i, i)` -/


### PR DESCRIPTION
These relate argument to image under a continuous function, given a Prop that eventually holds on a product of filters in domain and codomain. In fact the second pair of statements concern a segment whose end-points are the image. They should prove useful in PRs 26300 and 26985.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
