### PR TITLE
[Merged by Bors] - chore(Tactic/FieldSimp): split discharger to standalone file

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5920,6 +5920,7 @@ import Mathlib.Tactic.FBinop
 import Mathlib.Tactic.FailIfNoProgress
 import Mathlib.Tactic.FastInstance
 import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.FieldSimp.Discharger
 import Mathlib.Tactic.FinCases
 import Mathlib.Tactic.Find
 import Mathlib.Tactic.FindSyntax

--- a/Mathlib/Tactic.lean
+++ b/Mathlib/Tactic.lean
@@ -88,6 +88,7 @@ import Mathlib.Tactic.FBinop
 import Mathlib.Tactic.FailIfNoProgress
 import Mathlib.Tactic.FastInstance
 import Mathlib.Tactic.FieldSimp
+import Mathlib.Tactic.FieldSimp.Discharger
 import Mathlib.Tactic.FinCases
 import Mathlib.Tactic.Find
 import Mathlib.Tactic.FindSyntax

--- a/Mathlib/Tactic/FieldSimp.lean
+++ b/Mathlib/Tactic/FieldSimp.lean
@@ -4,13 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel, David Renshaw
 -/
 
-import Lean.Elab.Tactic.Basic
-import Lean.Meta.Tactic.Simp.Main
-import Mathlib.Algebra.Group.Units.Basic
-import Mathlib.Tactic.Positivity.Core
-import Mathlib.Tactic.NormNum.Core
-import Mathlib.Util.DischargerAsTactic
-import Qq
+import Mathlib.Tactic.FieldSimp.Discharger
 
 /-!
 # `field_simp` tactic
@@ -21,70 +15,8 @@ Tactic to clear denominators in algebraic expressions, based on `simp` with a sp
 namespace Mathlib.Tactic.FieldSimp
 
 open Lean Elab.Tactic Parser.Tactic Lean.Meta
-open Qq
 
 initialize registerTraceClass `Tactic.field_simp
-
-/-- Constructs a trace message for the `discharge` function. -/
-private def dischargerTraceMessage {ε : Type*} (prop : Expr) :
-    Except ε (Option Expr) → SimpM MessageData
-| .error _ | .ok none => return m!"{crossEmoji} discharge {prop}"
-| .ok (some _) => return m!"{checkEmoji} discharge {prop}"
-
-open private Simp.dischargeUsingAssumption? from Lean.Meta.Tactic.Simp.Rewrite
-
-/-- Discharge strategy for the `field_simp` tactic. -/
-partial def discharge (prop : Expr) : SimpM (Option Expr) :=
-  withTraceNode `Tactic.field_simp (dischargerTraceMessage prop) do
-    -- Discharge strategy 1: Use assumptions
-    if let some r ← Simp.dischargeUsingAssumption? prop then
-      return some r
-
-    -- Discharge strategy 2: Normalize inequalities using NormNum
-    let prop : Q(Prop) ← (do pure prop)
-    let pf? ← match prop with
-    | ~q(($e : $α) ≠ $b) =>
-        try
-          let res ← Mathlib.Meta.NormNum.derive prop
-          match res with
-          | .isTrue pf => pure (some pf)
-          | _ => pure none
-        catch _ =>
-          pure none
-    | _ => pure none
-    if let some pf := pf? then return some pf
-
-    -- Discharge strategy 3: Use positivity
-    let pf? ←
-      try some <$> Mathlib.Meta.Positivity.solve prop
-      catch _ => pure none
-    if let some pf := pf? then return some pf
-
-    -- Discharge strategy 4: Use the simplifier
-    Simp.withIncDischargeDepth do
-      let ctx ← readThe Simp.Context
-      let stats : Simp.Stats := { (← get) with }
-
-      -- Porting note: mathlib3's analogous field_simp discharger `field_simp.ne_zero`
-      -- does not explicitly call `simp` recursively like this. It's unclear to me
-      -- whether this is because
-      --   1) Lean 3 simp dischargers automatically call `simp` recursively. (Do they?),
-      --   2) mathlib3 norm_num1 is able to handle any needed discharging, or
-      --   3) some other reason?
-      let ⟨simpResult, stats'⟩ ←
-        simp prop ctx #[(← Simp.getSimprocs)]
-          discharge stats
-      set { (← get) with usedTheorems := stats'.usedTheorems, diag := stats'.diag }
-      if simpResult.expr.isConstOf ``True then
-        try
-          return some (← mkOfEqTrue (← simpResult.getProof))
-        catch _ =>
-          return none
-      else
-        return none
-
-@[inherit_doc discharge]
-elab "field_simp_discharge" : tactic => wrapSimpDischarger Mathlib.Tactic.FieldSimp.discharge
 
 /-- The list of lemma's that aren't used in `field_simp`.
 

--- a/Mathlib/Tactic/FieldSimp/Discharger.lean
+++ b/Mathlib/Tactic/FieldSimp/Discharger.lean
@@ -1,0 +1,104 @@
+/-
+Copyright (c) 2019 Sébastien Gouëzel. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sébastien Gouëzel, David Renshaw
+-/
+
+import Mathlib.Tactic.Positivity.Core
+import Mathlib.Util.DischargerAsTactic
+
+/-!
+# Discharger for `field_simp` tactic
+
+The `field_simp` tactic (implemented downstream from this file) clears denominators in algebraic
+expressions. In order to do this, the denominators need to be certified as nonzero. This file
+contains the discharger which carries out these checks.
+
+Currently the discharger tries four strategies:
+1. `assumption`
+2. `positivity`
+3. `norm_num`
+4. `simp` with the same simp-context as the `field_simp` call which invoked it
+
+TODO: Ideally the discharger would be just `positivity` (which, despite the name, has robust
+handling of general `≠ 0` goals, not just `> 0` goals). We need the other strategies currently to
+get (a cheap approximation of) `positivity` on fields without a partial order.
+
+The refactor of `positivity` to avoid a partial order assumption would be large but not
+fundamentally difficult.
+
+### Main declarations
+
+* `Mathlib.Tactic.FieldSimp.discharge`: the discharger, of type `Expr → SimpM (Option Expr)`
+
+* `field_simp_discharge`: tactic syntax for the discharger (most useful for testing/debugging)
+
+-/
+
+namespace Mathlib.Tactic.FieldSimp
+
+open Lean Elab.Tactic Parser.Tactic Lean.Meta
+open Qq
+
+/-- Constructs a trace message for the `discharge` function. -/
+private def dischargerTraceMessage {ε : Type*} (prop : Expr) :
+    Except ε (Option Expr) → SimpM MessageData
+| .error _ | .ok none => return m!"{crossEmoji} discharge {prop}"
+| .ok (some _) => return m!"{checkEmoji} discharge {prop}"
+
+open private Simp.dischargeUsingAssumption? from Lean.Meta.Tactic.Simp.Rewrite
+
+/-- Discharge strategy for the `field_simp` tactic. -/
+partial def discharge (prop : Expr) : SimpM (Option Expr) :=
+  withTraceNode `Tactic.field_simp (dischargerTraceMessage prop) do
+    -- Discharge strategy 1: Use assumptions
+    if let some r ← Simp.dischargeUsingAssumption? prop then
+      return some r
+
+    -- Discharge strategy 2: Normalize inequalities using NormNum
+    let prop : Q(Prop) ← (do pure prop)
+    let pf? ← match prop with
+    | ~q(($e : $α) ≠ $b) =>
+        try
+          let res ← Mathlib.Meta.NormNum.derive prop
+          match res with
+          | .isTrue pf => pure (some pf)
+          | _ => pure none
+        catch _ =>
+          pure none
+    | _ => pure none
+    if let some pf := pf? then return some pf
+
+    -- Discharge strategy 3: Use positivity
+    let pf? ←
+      try some <$> Mathlib.Meta.Positivity.solve prop
+      catch _ => pure none
+    if let some pf := pf? then return some pf
+
+    -- Discharge strategy 4: Use the simplifier
+    Simp.withIncDischargeDepth do
+      let ctx ← readThe Simp.Context
+      let stats : Simp.Stats := { (← get) with }
+
+      -- Porting note: mathlib3's analogous field_simp discharger `field_simp.ne_zero`
+      -- does not explicitly call `simp` recursively like this. It's unclear to me
+      -- whether this is because
+      --   1) Lean 3 simp dischargers automatically call `simp` recursively. (Do they?),
+      --   2) mathlib3 norm_num1 is able to handle any needed discharging, or
+      --   3) some other reason?
+      let ⟨simpResult, stats'⟩ ←
+        simp prop ctx #[(← Simp.getSimprocs)]
+          discharge stats
+      set { (← get) with usedTheorems := stats'.usedTheorems, diag := stats'.diag }
+      if simpResult.expr.isConstOf ``True then
+        try
+          return some (← mkOfEqTrue (← simpResult.getProof))
+        catch _ =>
+          return none
+      else
+        return none
+
+@[inherit_doc discharge]
+elab "field_simp_discharge" : tactic => wrapSimpDischarger Mathlib.Tactic.FieldSimp.discharge
+
+end Mathlib.Tactic.FieldSimp


### PR DESCRIPTION
The `field_simp` tactic code will grow substantially after a planned refactor by @FLDutchmann @grunweg and me. This PR splits the discharger part of the tactic into a standalone file, which improves structure and should also make the main PR easier to review.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
