### PR TITLE
fix(norm_cast): `@[norm_cast]` for `NNRat.cast_divNat`

### DIFF
--- a/Mathlib/Data/Rat/Cast/CharZero.lean
+++ b/Mathlib/Data/Rat/Cast/CharZero.lean
@@ -106,7 +106,7 @@ def castHom : ℚ≥0 →+* α where
 @[simp, norm_cast]
 lemma cast_zpow (q : ℚ≥0) (p : ℤ) : ↑(q ^ p) = ((q : α) ^ p : α) := map_zpow₀ (castHom α) ..
 
-@[simp]
+@[simp, norm_cast]
 lemma cast_divNat (a b : ℕ) : (divNat a b : α) = a / b := by
   rw [← cast_natCast, ← cast_natCast b, ← cast_div]
   congr

--- a/MathlibTest/norm_cast.lean
+++ b/MathlibTest/norm_cast.lean
@@ -140,3 +140,16 @@ lemma b (_h g : true) : true ∧ true := by
   constructor
   assumption_mod_cast
   assumption_mod_cast
+
+-- testing division of coerced naturals/integers
+
+example (x : ℝ) (hx : x = 3 / 5) : ((3 / 5 : ℚ) : ℂ) = x := by
+  rw [hx]
+  norm_cast
+
+example (x : ℝ) (n : Int) (hx : x = n / 5) : ((n / 5 : ℚ) : ℂ) = x := by
+  rw [hx]
+  norm_cast
+
+example {x : ℚ} (h : (x : ℝ) = 1 / 2) : x = 1 / 2 := by
+  exact_mod_cast h


### PR DESCRIPTION
This PR adds the `@[norm_cast]` tag to `NNRat.cast_divNat`. This fixes the problems reported in [#mathlib4 > exact_mod_cast and rationals @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/exact_mod_cast.20and.20rationals/near/483080107) and [#mathlib4 > norm_cast best practices @ 💬](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/norm_cast.20best.20practices/near/534243101). Now, `norm_cast` works better on a division of natural numbers/number literals.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
