### PR TITLE
[Merged by Bors] - feat: semilinearize `LinearMap.mapMatrix` and `LinearEquiv.mapMatrix`

### DIFF
--- a/Mathlib/Data/Matrix/Defs.lean
+++ b/Mathlib/Data/Matrix/Defs.lean
@@ -280,6 +280,11 @@ protected theorem map_smul [SMul R α] [SMul R β] (f : α → β) (r : R) (hf :
     (M : Matrix m n α) : (r • M).map f = r • M.map f :=
   ext fun _ _ => hf _
 
+protected theorem map_smulₛₗ [SMul R α] [SMul S β] (f : α → β) (σ : R → S) (r : R)
+    (hf : ∀ a, f (r • a) = σ r • f a)
+    (M : Matrix m n α) : (r • M).map f = σ r • M.map f :=
+  ext fun _ _ => hf _
+
 /-- The scalar action via `Mul.toSMul` is transformed by the same map as the elements
 of the matrix, when `f` preserves multiplication. -/
 theorem map_smul' [Mul α] [Mul β] (f : α → β) (r : α) (A : Matrix n n α)


### PR DESCRIPTION
I don't have a particularly strong motivation here, but the generalization is trivial, and I wanted to check if it conflicted with the work in #28359 (it does not, but that PR now depends on this one).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
