### PR TITLE
[Merged by Bors] - feat: `LinearMap.mapMatrix` is itself a linear map

### DIFF
--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -33,8 +33,7 @@ assert_not_exists TrivialStar
 universe u u' v w
 
 variable {l m n o : Type*} {m' : o → Type*} {n' : o → Type*}
-variable {R : Type*} {S : Type*} {T : Type*} {A : Type*}
-variable {α : Type v} {β : Type w} {γ : Type*}
+variable {R S T A α β γ : Type*}
 
 namespace Matrix
 

--- a/Mathlib/Data/Matrix/Basic.lean
+++ b/Mathlib/Data/Matrix/Basic.lean
@@ -33,7 +33,8 @@ assert_not_exists TrivialStar
 universe u u' v w
 
 variable {l m n o : Type*} {m' : o → Type*} {n' : o → Type*}
-variable {R : Type*} {S : Type*} {T : Type*} {α : Type v} {β : Type w} {γ : Type*}
+variable {R : Type*} {S : Type*} {T : Type*} {A : Type*}
+variable {α : Type v} {β : Type w} {γ : Type*}
 
 namespace Matrix
 
@@ -370,6 +371,7 @@ end Equiv
 
 namespace AddMonoidHom
 
+section AddZeroClass
 variable [AddZeroClass α] [AddZeroClass β] [AddZeroClass γ]
 
 /-- The `AddMonoidHom` between spaces of matrices induced by an `AddMonoidHom` between their
@@ -391,6 +393,28 @@ theorem mapMatrix_comp (f : β →+ γ) (g : α →+ β) :
 
 @[simp] lemma entryAddMonoidHom_comp_mapMatrix (f : α →+ β) (i : m) (j : n) :
     (entryAddMonoidHom β i j).comp f.mapMatrix = f.comp (entryAddMonoidHom α i j) := rfl
+
+@[simp]
+theorem mapMatrix_zero : (0 : α →+ β).mapMatrix = (0 : Matrix m n α →+ _) := rfl
+
+end AddZeroClass
+
+@[simp]
+theorem mapMatrix_add [AddZeroClass α] [AddCommMonoid β] (f g : α →+ β) :
+    (f + g).mapMatrix = (f.mapMatrix + g.mapMatrix : Matrix m n α →+ _) := rfl
+
+@[simp]
+theorem mapMatrix_sub [AddZeroClass α] [AddCommGroup β] (f g : α →+ β) :
+    (f - g).mapMatrix = (f.mapMatrix - g.mapMatrix : Matrix m n α →+ _) := rfl
+
+@[simp]
+theorem mapMatrix_neg [AddZeroClass α] [AddCommGroup β] (f : α →+ β) :
+    (-f).mapMatrix = (-f.mapMatrix : Matrix m n α →+ _) := rfl
+
+@[simp]
+theorem mapMatrix_smul [Monoid A] [AddZeroClass α] [AddMonoid β] [DistribMulAction A β]
+    (a : A) (f : α →+ β) :
+    (a • f).mapMatrix = (a • f.mapMatrix : Matrix m n α →+ _) := rfl
 
 end AddMonoidHom
 
@@ -429,9 +453,11 @@ end AddEquiv
 namespace LinearMap
 
 variable [Semiring R] [Semiring S] [Semiring T]
+variable {σᵣₛ : R →+* S} {σₛₜ : S →+* T} {σᵣₜ : R →+* T} [RingHomCompTriple σᵣₛ σₛₜ σᵣₜ]
+
+section AddCommMonoid
 variable [AddCommMonoid α] [AddCommMonoid β] [AddCommMonoid γ]
 variable [Module R α] [Module S β] [Module T γ]
-variable {σᵣₛ : R →+* S} {σₛₜ : S →+* T} {σᵣₜ : R →+* T} [RingHomCompTriple σᵣₛ σₛₜ σᵣₜ]
 
 /-- The `LinearMap` between spaces of matrices induced by a `LinearMap` between their
 coefficients. This is `Matrix.map` as a `LinearMap`. -/
@@ -452,6 +478,45 @@ theorem mapMatrix_comp (f : β →ₛₗ[σₛₜ] γ) (g : α →ₛₗ[σᵣ�
 
 @[simp] lemma entryLinearMap_comp_mapMatrix (f : α →ₛₗ[σᵣₛ] β) (i : m) (j : n) :
     (entryLinearMap S _ i j).comp f.mapMatrix = f.comp (entryLinearMap R _ i j) := rfl
+
+@[simp]
+theorem mapMatrix_zero : (0 : α →ₛₗ[σᵣₛ] β).mapMatrix = (0 : Matrix m n α →ₛₗ[_] _) := rfl
+
+@[simp]
+theorem mapMatrix_add (f g : α →ₛₗ[σᵣₛ] β) :
+    (f + g).mapMatrix = (f.mapMatrix + g.mapMatrix : Matrix m n α →ₛₗ[_] _) := rfl
+
+@[simp]
+theorem mapMatrix_smul [Monoid A] [DistribMulAction A β] [SMulCommClass S A β]
+    (a : A) (f : α →ₛₗ[σᵣₛ] β) :
+    (a • f).mapMatrix = (a • f.mapMatrix : Matrix m n α →ₛₗ[_] _) := rfl
+
+variable (A) in
+/-- `LinearMap.mapMatrix` is itself linear in the map being applied.
+
+Alternative, this is `Matrix.map` as a bilinear map. -/
+@[simps]
+def mapMatrixLinear [Semiring A] [Module A β] [SMulCommClass S A β] :
+    (α →ₛₗ[σᵣₛ] β) →ₗ[A] (Matrix m n α →ₛₗ[σᵣₛ] Matrix m n β) where
+  toFun := mapMatrix
+  map_add' := mapMatrix_add
+  map_smul' := mapMatrix_smul
+
+end AddCommMonoid
+
+section
+variable [AddCommMonoid α] [AddCommGroup β]
+variable [Module R α] [Module S β]
+
+@[simp]
+theorem mapMatrix_sub (f g : α →ₛₗ[σᵣₛ] β) :
+    (f - g).mapMatrix = (f.mapMatrix - g.mapMatrix : Matrix m n α →ₛₗ[σᵣₛ] _) := rfl
+
+@[simp]
+theorem mapMatrix_neg (f : α →ₛₗ[σᵣₛ] β) :
+    (-f).mapMatrix = (-f.mapMatrix : Matrix m n α →ₛₗ[σᵣₛ] _) := rfl
+
+end
 
 end LinearMap
 


### PR DESCRIPTION
This is motivated by #25692, where I want to lift the bilinear map to the tensor product.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]

-->
- [x] depends on: #28358

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
