### PR TITLE
[Merged by Bors] - feat(Topology/Baire/Lemmas): residual sets in nonempty Baire spaces are not meagre

### DIFF
--- a/Mathlib/Topology/Baire/Lemmas.lean
+++ b/Mathlib/Topology/Baire/Lemmas.lean
@@ -171,18 +171,27 @@ theorem dense_iUnion_interior_of_closed [Countable ι] {f : ι → Set X} (hc : 
     (hU : ⋃ i, f i = univ) : Dense (⋃ i, interior (f i)) :=
   IsGδ.univ.dense_iUnion_interior_of_closed dense_univ hc hU.ge
 
+variable [Nonempty X]
+
 /-- One of the most useful consequences of Baire theorem: if a countable union of closed sets
 covers the space, then one of the sets has nonempty interior. -/
-theorem nonempty_interior_of_iUnion_of_closed [Nonempty X] [Countable ι] {f : ι → Set X}
+theorem nonempty_interior_of_iUnion_of_closed [Countable ι] {f : ι → Set X}
     (hc : ∀ i, IsClosed (f i)) (hU : ⋃ i, f i = univ) : ∃ i, (interior <| f i).Nonempty := by
   simpa using (dense_iUnion_interior_of_closed hc hU).nonempty
 
 /-- In a nonempty Baire space, any dense `Gδ` set is not meagre. -/
-theorem not_isMeagre_of_isGδ_of_dense [Nonempty X] {s : Set X} (hs : IsGδ s) (hd : Dense s) :
+theorem not_isMeagre_of_isGδ_of_dense {s : Set X} (hs : IsGδ s) (hd : Dense s) :
     ¬ IsMeagre s := by
   intro h
   rcases (mem_residual).1 h with ⟨t, hts, htG, hd'⟩
   rcases (hd.inter_of_Gδ hs htG hd').nonempty with ⟨x, hx₁, hx₂⟩
   exact hts hx₂ hx₁
+
+/-- In a nonempty Baire space, a residual set is not meagre. -/
+theorem not_isMeagre_of_mem_residual {s : Set X} (hs : s ∈ residual X) :
+    ¬ IsMeagre s := by
+  rcases (mem_residual (X := X)).1 hs with ⟨t, ht_sub, htGδ, ht_dense⟩
+  intro hs_meagre
+  exact not_isMeagre_of_isGδ_of_dense (X := X) htGδ ht_dense (hs_meagre.mono ht_sub)
 
 end BaireTheorem


### PR DESCRIPTION
In a nonempty Baire space, a residual set is not meagre.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
