### PR TITLE
[Merged by Bors] - chore: generalize results about `Matrix.kroneckerTMul`

### DIFF
--- a/Mathlib/Data/Matrix/Kronecker.lean
+++ b/Mathlib/Data/Matrix/Kronecker.lean
@@ -523,16 +523,20 @@ open Kronecker
 open Algebra.TensorProduct
 
 section Semiring
-
-variable [CommSemiring R] [Semiring α] [Semiring β] [Algebra R α] [Algebra R β]
+variable [CommSemiring R]
 
 @[simp]
-theorem one_kroneckerTMul_one [DecidableEq m] [DecidableEq n] :
-    (1 : Matrix m m α) ⊗ₖₜ[R] (1 : Matrix n n α) = 1 :=
+theorem one_kroneckerTMul_one
+    [AddCommMonoidWithOne α] [AddCommMonoidWithOne β] [Module R α] [Module R β]
+    [DecidableEq m] [DecidableEq n] :
+    (1 : Matrix m m α) ⊗ₖₜ[R] (1 : Matrix n n β) = 1 :=
   kroneckerMap_one_one _ (zero_tmul _) (tmul_zero _) rfl
 
 unseal mul in
-theorem mul_kroneckerTMul_mul [Fintype m] [Fintype m'] (A : Matrix l m α) (B : Matrix m n α)
+theorem mul_kroneckerTMul_mul
+    [NonUnitalSemiring α] [NonUnitalSemiring β] [Module R α] [Module R β]
+    [IsScalarTower R α α] [SMulCommClass R α α] [IsScalarTower R β β] [SMulCommClass R β β]
+    [Fintype m] [Fintype m'] (A : Matrix l m α) (B : Matrix m n α)
     (A' : Matrix l' m' β) (B' : Matrix m' n' β) :
     (A * B) ⊗ₖₜ[R] (A' * B') = A ⊗ₖₜ[R] A' * B ⊗ₖₜ[R] B' :=
   kroneckerMapBilinear_mul_mul (TensorProduct.mk R α β) tmul_mul_tmul A B A' B'


### PR DESCRIPTION
This fixes a typo where both modules were accidentally the same, and also generalizes to non-unital rings.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
