### PR TITLE
[Merged by Bors] - chore(Analysis/Calculus/Deriv): deprecate `differentiableAt_comp_const_add`

### DIFF
--- a/Mathlib/Analysis/Calculus/Deriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Add.lean
@@ -172,12 +172,8 @@ theorem deriv_const_add' (c : F) : (deriv (c + f ·)) = deriv f :=
   funext fun _ ↦ deriv_const_add c
 
 lemma differentiableAt_comp_const_add {a b : 𝕜} :
-    DifferentiableAt 𝕜 (fun x ↦ f (b + x)) a ↔ DifferentiableAt 𝕜 f (b + a) := by
-  refine ⟨fun H ↦ ?_, fun H ↦ H.comp _ (differentiable_id.const_add _).differentiableAt⟩
-  convert DifferentiableAt.comp (b + a) (by simpa)
-    (differentiable_id.const_add (-b)).differentiableAt
-  ext
-  simp
+    DifferentiableAt 𝕜 (fun x ↦ f (b + x)) a ↔ DifferentiableAt 𝕜 f (b + a) :=
+  differentiableAt_comp_add_left b
 
 lemma differentiableAt_comp_add_const {a b : 𝕜} :
     DifferentiableAt 𝕜 (fun x ↦ f (x + b)) a ↔ DifferentiableAt 𝕜 f (a + b) := by

--- a/Mathlib/Analysis/Calculus/Deriv/Add.lean
+++ b/Mathlib/Analysis/Calculus/Deriv/Add.lean
@@ -171,17 +171,16 @@ theorem deriv_const_add (c : F) : deriv (c + f ·) x = deriv f x := by
 theorem deriv_const_add' (c : F) : (deriv (c + f ·)) = deriv f :=
   funext fun _ ↦ deriv_const_add c
 
-lemma differentiableAt_comp_const_add {a b : 𝕜} :
-    DifferentiableAt 𝕜 (fun x ↦ f (b + x)) a ↔ DifferentiableAt 𝕜 f (b + a) :=
-  differentiableAt_comp_add_left b
+@[deprecated (since := "2025-10-06")]
+alias differentiableAt_comp_const_add := differentiableAt_comp_add_left
 
 lemma differentiableAt_comp_add_const {a b : 𝕜} :
     DifferentiableAt 𝕜 (fun x ↦ f (x + b)) a ↔ DifferentiableAt 𝕜 f (a + b) := by
-  simpa [add_comm b] using differentiableAt_comp_const_add (f := f) (b := b)
+  grind [add_comm, differentiableAt_comp_add_left]
 
 lemma differentiableAt_iff_comp_const_add {a b : 𝕜} :
     DifferentiableAt 𝕜 f a ↔ DifferentiableAt 𝕜 (fun x ↦ f (b + x)) (-b + a) := by
-  simp [differentiableAt_comp_const_add]
+  simp [differentiableAt_comp_add_left]
 
 lemma differentiableAt_iff_comp_add_const {a b : 𝕜} :
     DifferentiableAt 𝕜 f a ↔ DifferentiableAt 𝕜 (fun x ↦ f (x + b)) (a - b) := by


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
