### PR TITLE
chore(AlgebraicGeometry/Morphisms): golf entire `exists_of_res_zero_of_qcqs`

### DIFF
--- a/Mathlib/AlgebraicGeometry/Morphisms/QuasiSeparated.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/QuasiSeparated.lean
@@ -361,13 +361,10 @@ lemma exists_of_res_eq_of_qcqs_of_top {X : Scheme.{u}} [CompactSpace X] [QuasiSe
   exists_of_res_eq_of_qcqs (U := ⊤) CompactSpace.isCompact_univ isQuasiSeparated_univ hfg
 
 lemma exists_of_res_zero_of_qcqs {X : Scheme.{u}} {U : TopologicalSpace.Opens X}
-    (hU : IsCompact U.carrier) (hU' : IsQuasiSeparated U.carrier)
+    (hU : IsCompact U.carrier) (_ : IsQuasiSeparated U.carrier)
     {f s : Γ(X, U)} (hf : f |_ X.basicOpen s = 0) :
-    ∃ n, s ^ n * f = 0 := by
-  suffices h : ∃ n, s ^ n * f = s ^ n * 0 by
-    simpa using h
-  apply exists_of_res_eq_of_qcqs hU hU'
-  simpa
+    ∃ n, s ^ n * f = 0 :=
+  exists_pow_mul_eq_zero_of_res_basicOpen_eq_zero_of_isCompact X hU f s hf
 
 lemma exists_of_res_zero_of_qcqs_of_top {X : Scheme} [CompactSpace X] [QuasiSeparatedSpace X]
     {f s : Γ(X, ⊤)} (hf : f |_ X.basicOpen s = 0) :


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
