### PR TITLE
[Merged by Bors] - chore(Analysis/LocallyConvex): deprecate `polar_weak_closed`

### DIFF
--- a/Mathlib/Analysis/LocallyConvex/Polar.lean
+++ b/Mathlib/Analysis/LocallyConvex/Polar.lean
@@ -122,10 +122,7 @@ theorem tripolar_eq_polar (s : Set E) : B.polar (B.flip.polar (B.polar s)) = B.p
 
 /-- The polar set is closed in the weak topology induced by `B.flip`. -/
 theorem polar_weak_closed (s : Set E) : IsClosed[WeakBilin.instTopologicalSpace B.flip]
-    (B.polar s) := by
-  rw [polar_eq_iInter]
-  refine isClosed_iInter fun x => isClosed_iInter fun _ => ?_
-  exact isClosed_le (WeakBilin.eval_continuous B.flip x).norm continuous_const
+    (B.polar s) := polar_isClosed B s
 
 theorem sInter_polar_finite_subset_eq_polar (s : Set E) :
     ⋂₀ (B.polar '' { F | F.Finite ∧ F ⊆ s }) = B.polar s := by

--- a/Mathlib/Analysis/LocallyConvex/Polar.lean
+++ b/Mathlib/Analysis/LocallyConvex/Polar.lean
@@ -23,7 +23,7 @@ any bilinear form `B : E →ₗ[𝕜] F →ₗ[𝕜] 𝕜`, where `𝕜` is a no
 
 * `LinearMap.polar_eq_iInter`: The polar as an intersection.
 * `LinearMap.subset_bipolar`: The polar is a subset of the bipolar.
-* `LinearMap.polar_weak_closed`: The polar is closed in the weak topology induced by `B.flip`.
+* `LinearMap.polar_isClosed`: The polar is closed in the weak topology induced by `B.flip`.
 
 ## References
 
@@ -62,6 +62,7 @@ theorem polar_mem (s : Set E) (y : F) (hy : y ∈ B.polar s) : ∀ x ∈ s, ‖B
 theorem polar_eq_biInter_preimage (s : Set E) :
     B.polar s = ⋂ x ∈ s, ((B x) ⁻¹' Metric.closedBall (0 : 𝕜) 1) := by aesop
 
+-- TODO: this theorem is abusing defeq between F and WeakBilin B.flip
 theorem polar_isClosed (s : Set E) : IsClosed (X := WeakBilin B.flip) (B.polar s) := by
   rw [polar_eq_biInter_preimage]
   exact isClosed_biInter
@@ -120,9 +121,7 @@ theorem subset_bipolar (s : Set E) : s ⊆ B.flip.polar (B.polar s) := fun x hx 
 theorem tripolar_eq_polar (s : Set E) : B.polar (B.flip.polar (B.polar s)) = B.polar s :=
   (B.polar_antitone (B.subset_bipolar s)).antisymm (subset_bipolar B.flip (B.polar s))
 
-/-- The polar set is closed in the weak topology induced by `B.flip`. -/
-theorem polar_weak_closed (s : Set E) : IsClosed[WeakBilin.instTopologicalSpace B.flip]
-    (B.polar s) := polar_isClosed B s
+@[deprecated (since := "2025-10-06")] alias polar_weak_closed := polar_isClosed
 
 theorem sInter_polar_finite_subset_eq_polar (s : Set E) :
     ⋂₀ (B.polar '' { F | F.Finite ∧ F ⊆ s }) = B.polar s := by


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
