### PR TITLE
chore(WithZero): clean

### DIFF
--- a/Mathlib/Data/Int/WithZero.lean
+++ b/Mathlib/Data/Int/WithZero.lean
@@ -41,9 +41,7 @@ namespace WithZeroMulInt
 def toNNReal {e : ℝ≥0} (he : e ≠ 0) : ℤᵐ⁰ →*₀ ℝ≥0 where
   toFun := fun x ↦ if hx : x = 0 then 0 else e ^ (WithZero.unzero hx).toAdd
   map_zero' := rfl
-  map_one' := by
-    rw [dif_neg one_ne_zero]
-    rfl
+  map_one' := rfl
   map_mul' x y := by
     by_cases hxy : x * y = 0
     · rcases zero_eq_mul.mp (Eq.symm hxy) with hx | hy

--- a/Mathlib/Data/Int/WithZero.lean
+++ b/Mathlib/Data/Int/WithZero.lean
@@ -42,8 +42,8 @@ def toNNReal {e : ℝ≥0} (he : e ≠ 0) : ℤᵐ⁰ →*₀ ℝ≥0 where
   toFun := fun x ↦ if hx : x = 0 then 0 else e ^ (WithZero.unzero hx).toAdd
   map_zero' := rfl
   map_one' := by
-    simp only [dif_neg one_ne_zero]
-    erw [toAdd_one, zpow_zero]
+    rw [dif_neg one_ne_zero]
+    rfl
   map_mul' x y := by
     by_cases hxy : x * y = 0
     · rcases zero_eq_mul.mp (Eq.symm hxy) with hx | hy

--- a/Mathlib/Data/Int/WithZero.lean
+++ b/Mathlib/Data/Int/WithZero.lean
@@ -44,31 +44,31 @@ def toNNReal {e : ℝ≥0} (he : e ≠ 0) : ℤᵐ⁰ →*₀ ℝ≥0 where
   map_one' := rfl
   map_mul' x y := by
     by_cases hxy : x * y = 0
-    · rcases zero_eq_mul.mp (Eq.symm hxy) with hx | hy
-      --either x = 0 or y = 0
+    · rcases zero_eq_mul.mp hxy.symm with hx | hy
+      -- either x = 0 or y = 0
       · rw [dif_pos hxy, dif_pos hx, MulZeroClass.zero_mul]
       · rw [dif_pos hxy, dif_pos hy, MulZeroClass.mul_zero]
     · obtain ⟨hx, hy⟩ := mul_ne_zero_iff.mp hxy
-      --  x Equiv≠ 0 and y ≠ 0
+      -- x Equiv ≠ 0 and y ≠ 0
       rw [dif_neg hxy, dif_neg hx, dif_neg hy, ← zpow_add' (Or.inl he), ← toAdd_mul]
       congr
       rw [← WithZero.coe_inj, WithZero.coe_mul, coe_unzero hx, coe_unzero hy, coe_unzero hxy]
 
 theorem toNNReal_pos_apply {e : ℝ≥0} (he : e ≠ 0) {x : ℤᵐ⁰} (hx : x = 0) :
     toNNReal he x = 0 := by
-  simp only [toNNReal, MonoidWithZeroHom.coe_mk, ZeroHom.coe_mk]
+  simp_rw [toNNReal, MonoidWithZeroHom.coe_mk, ZeroHom.coe_mk]
   split_ifs; rfl
 
 theorem toNNReal_neg_apply {e : ℝ≥0} (he : e ≠ 0) {x : ℤᵐ⁰} (hx : x ≠ 0) :
     toNNReal he x = e ^ (WithZero.unzero hx).toAdd := by
-  simp only [toNNReal, MonoidWithZeroHom.coe_mk, ZeroHom.coe_mk]
+  simp_rw [toNNReal, MonoidWithZeroHom.coe_mk, ZeroHom.coe_mk]
   split_ifs
   · tauto
   · rfl
 
 /-- `toNNReal` sends nonzero elements to nonzero elements. -/
 theorem toNNReal_ne_zero {e : ℝ≥0} {m : ℤᵐ⁰} (he : e ≠ 0) (hm : m ≠ 0) : toNNReal he m ≠ 0 := by
-  simp only [ne_eq, map_eq_zero, hm, not_false_eq_true]
+  simpa using hm
 
 /-- `toNNReal` sends nonzero elements to positive elements. -/
 theorem toNNReal_pos {e : ℝ≥0} {m : ℤᵐ⁰} (he : e ≠ 0) (hm : m ≠ 0) : 0 < toNNReal he m :=
@@ -78,11 +78,11 @@ theorem toNNReal_pos {e : ℝ≥0} {m : ℤᵐ⁰} (he : e ≠ 0) (hm : m ≠ 0)
 theorem toNNReal_strictMono {e : ℝ≥0} (he : 1 < e) :
     StrictMono (toNNReal (ne_zero_of_lt he)) := by
   intro x y hxy
-  simp only [toNNReal, MonoidWithZeroHom.coe_mk, ZeroHom.coe_mk]
+  simp_rw [toNNReal, MonoidWithZeroHom.coe_mk, ZeroHom.coe_mk]
   split_ifs with hx hy hy
-  · simp only [hy, not_lt_zero'] at hxy
+  · simp_rw [hy, not_lt_zero'] at hxy
   · exact zpow_pos he.bot_lt _
-  · simp only [hy, not_lt_zero'] at hxy
+  · simp_rw [hy, not_lt_zero'] at hxy
   · rw [zpow_lt_zpow_iff_right₀ he, Multiplicative.toAdd_lt, ← coe_lt_coe, coe_unzero hx,
       WithZero.coe_unzero hy]
     exact hxy
@@ -90,10 +90,10 @@ theorem toNNReal_strictMono {e : ℝ≥0} (he : 1 < e) :
 theorem toNNReal_eq_one_iff {e : ℝ≥0} (m : ℤᵐ⁰) (he0 : e ≠ 0) (he1 : e ≠ 1) :
     toNNReal he0 m = 1 ↔ m = 1 := by
   by_cases hm : m = 0
-  · simp only [hm, map_zero, zero_ne_one]
-  · refine ⟨fun h1 ↦ ?_, fun h1 ↦ h1 ▸ map_one _⟩
-    rw [toNNReal_neg_apply he0 hm, zpow_eq_one_iff_right₀ (zero_le e) he1, toAdd_eq_zero] at h1
-    rw [← WithZero.coe_unzero hm, h1, coe_one]
+  · simp_rw [hm, map_zero, zero_ne_one]
+  · refine ⟨fun h₁ ↦ ?_, fun h₁ ↦ h₁ ▸ map_one _⟩
+    rw [toNNReal_neg_apply he0 hm, zpow_eq_one_iff_right₀ (zero_le e) he1, toAdd_eq_zero] at h₁
+    rw [← WithZero.coe_unzero hm, h₁, coe_one]
 
 theorem toNNReal_lt_one_iff {e : ℝ≥0} {m : ℤᵐ⁰} (he : 1 < e) :
     toNNReal (ne_zero_of_lt he) m < 1 ↔ m < 1 := by

--- a/Mathlib/Geometry/RingedSpace/PresheafedSpace/Gluing.lean
+++ b/Mathlib/Geometry/RingedSpace/PresheafedSpace/Gluing.lean
@@ -324,6 +324,9 @@ def ιInvAppπApp {i : D.J} (U : Opens (D.U i).carrier) (j) :
     exact colimit.w 𝖣.diagram.multispan (WalkingMultispan.Hom.fst (j, k))
   · exact D.opensImagePreimageMap i j U
 
+set_option maxHeartbeats 600000 in
+-- Porting note: time out started in `erw [... congr_app (pullbackSymmetry_hom_comp_snd _ _)]` and
+-- the last congr has a very difficult `rfl : eqToHom _ ≫ eqToHom _ ≫ ... = eqToHom ... `
 /-- (Implementation) The natural map `Γ(𝒪_{U_i}, U) ⟶ Γ(𝒪_X, 𝖣.ι i '' U)`.
 This forms the inverse of `(𝖣.ι i).c.app (op U)`. -/
 def ιInvApp {i : D.J} (U : Opens (D.U i).carrier) :
@@ -338,9 +341,9 @@ def ιInvApp {i : D.J} (U : Opens (D.U i).carrier) :
             let f : Y ⟶ X := f'.unop; have : f' = f.op := rfl; clear_value f; subst this
             rcases f with (_ | ⟨j, k⟩ | ⟨j, k⟩)
             · simp
-            · simp_rw [Functor.const_obj_obj, Functor.const_obj_map, Category.id_comp]
-              rfl
-            simp_rw [Functor.const_obj_obj, Functor.const_obj_map, Category.id_comp]
+            · simp only [Functor.const_obj_obj, Functor.const_obj_map, Category.id_comp]
+              congr 1
+            simp only [Functor.const_obj_obj, Functor.const_obj_map, Category.id_comp]
             -- It remains to show that the blue is equal to red + green in the original diagram.
             -- The proof strategy is illustrated in ![this diagram](https://i.imgur.com/mBzV1Rx.png)
             -- where we prove red = pink = light-blue = green = blue.
@@ -349,8 +352,10 @@ def ιInvApp {i : D.J} (U : Opens (D.U i).carrier) :
                   (D.f j k).c.app _ ≫ (D.V (j, k)).presheaf.map (eqToHom _) =
                 D.opensImagePreimageMap _ _ _ ≫
                   ((D.f k j).c.app _ ≫ (D.t j k).c.app _) ≫ (D.V (j, k)).presheaf.map (eqToHom _)
-            rw [opensImagePreimageMap_app_assoc, Category.assoc, opensImagePreimageMap_app_assoc,
-                (D.t j k).c.naturality_assoc, snd_invApp_t_app_assoc,
+            rw [opensImagePreimageMap_app_assoc]
+            simp_rw [Category.assoc]
+            rw [opensImagePreimageMap_app_assoc, (D.t j k).c.naturality_assoc,
+                snd_invApp_t_app_assoc,
                 ← PresheafedSpace.comp_c_app_assoc]
             -- light-blue = green is relatively easy since the part that differs does not involve
             -- partial inverses.
@@ -360,12 +365,14 @@ def ιInvApp {i : D.J} (U : Opens (D.U i).carrier) :
               rw [← 𝖣.t_fac_assoc, 𝖣.t'_comp_eq_pullbackSymmetry_assoc,
                 pullbackSymmetry_hom_comp_snd_assoc, pullback.condition, 𝖣.t_fac_assoc]
             rw [congr_app this,
-                PresheafedSpace.comp_c_app_assoc (pullbackSymmetry _ _).hom, Category.assoc]
+                PresheafedSpace.comp_c_app_assoc (pullbackSymmetry _ _).hom]
+            simp_rw [Category.assoc]
             congr 1
-            rw [← IsIso.eq_inv_comp, IsOpenImmersion.inv_invApp]
-            simp_rw [Category.assoc, NatTrans.naturality_assoc]
-            erw [← PresheafedSpace.comp_c_app_assoc]
-            rw [congr_app (pullbackSymmetry_hom_comp_snd _ _)]
+            rw [← IsIso.eq_inv_comp,
+                IsOpenImmersion.inv_invApp]
+            simp_rw [Category.assoc]
+            erw [NatTrans.naturality_assoc, ← PresheafedSpace.comp_c_app_assoc,
+              congr_app (pullbackSymmetry_hom_comp_snd _ _)]
             simp_rw [Category.assoc]
             erw [IsOpenImmersion.inv_naturality_assoc, IsOpenImmersion.inv_naturality_assoc,
               IsOpenImmersion.inv_naturality_assoc, IsOpenImmersion.app_invApp_assoc]

--- a/Mathlib/Geometry/RingedSpace/PresheafedSpace/Gluing.lean
+++ b/Mathlib/Geometry/RingedSpace/PresheafedSpace/Gluing.lean
@@ -324,9 +324,6 @@ def ιInvAppπApp {i : D.J} (U : Opens (D.U i).carrier) (j) :
     exact colimit.w 𝖣.diagram.multispan (WalkingMultispan.Hom.fst (j, k))
   · exact D.opensImagePreimageMap i j U
 
-set_option maxHeartbeats 600000 in
--- Porting note: time out started in `erw [... congr_app (pullbackSymmetry_hom_comp_snd _ _)]` and
--- the last congr has a very difficult `rfl : eqToHom _ ≫ eqToHom _ ≫ ... = eqToHom ... `
 /-- (Implementation) The natural map `Γ(𝒪_{U_i}, U) ⟶ Γ(𝒪_X, 𝖣.ι i '' U)`.
 This forms the inverse of `(𝖣.ι i).c.app (op U)`. -/
 def ιInvApp {i : D.J} (U : Opens (D.U i).carrier) :
@@ -341,9 +338,9 @@ def ιInvApp {i : D.J} (U : Opens (D.U i).carrier) :
             let f : Y ⟶ X := f'.unop; have : f' = f.op := rfl; clear_value f; subst this
             rcases f with (_ | ⟨j, k⟩ | ⟨j, k⟩)
             · simp
-            · simp only [Functor.const_obj_obj, Functor.const_obj_map, Category.id_comp]
-              congr 1
-            simp only [Functor.const_obj_obj, Functor.const_obj_map, Category.id_comp]
+            · simp_rw [Functor.const_obj_obj, Functor.const_obj_map, Category.id_comp]
+              rfl
+            simp_rw [Functor.const_obj_obj, Functor.const_obj_map, Category.id_comp]
             -- It remains to show that the blue is equal to red + green in the original diagram.
             -- The proof strategy is illustrated in ![this diagram](https://i.imgur.com/mBzV1Rx.png)
             -- where we prove red = pink = light-blue = green = blue.
@@ -352,10 +349,8 @@ def ιInvApp {i : D.J} (U : Opens (D.U i).carrier) :
                   (D.f j k).c.app _ ≫ (D.V (j, k)).presheaf.map (eqToHom _) =
                 D.opensImagePreimageMap _ _ _ ≫
                   ((D.f k j).c.app _ ≫ (D.t j k).c.app _) ≫ (D.V (j, k)).presheaf.map (eqToHom _)
-            rw [opensImagePreimageMap_app_assoc]
-            simp_rw [Category.assoc]
-            rw [opensImagePreimageMap_app_assoc, (D.t j k).c.naturality_assoc,
-                snd_invApp_t_app_assoc,
+            rw [opensImagePreimageMap_app_assoc, Category.assoc, opensImagePreimageMap_app_assoc,
+                (D.t j k).c.naturality_assoc, snd_invApp_t_app_assoc,
                 ← PresheafedSpace.comp_c_app_assoc]
             -- light-blue = green is relatively easy since the part that differs does not involve
             -- partial inverses.
@@ -365,14 +360,12 @@ def ιInvApp {i : D.J} (U : Opens (D.U i).carrier) :
               rw [← 𝖣.t_fac_assoc, 𝖣.t'_comp_eq_pullbackSymmetry_assoc,
                 pullbackSymmetry_hom_comp_snd_assoc, pullback.condition, 𝖣.t_fac_assoc]
             rw [congr_app this,
-                PresheafedSpace.comp_c_app_assoc (pullbackSymmetry _ _).hom]
-            simp_rw [Category.assoc]
+                PresheafedSpace.comp_c_app_assoc (pullbackSymmetry _ _).hom, Category.assoc]
             congr 1
-            rw [← IsIso.eq_inv_comp,
-                IsOpenImmersion.inv_invApp]
-            simp_rw [Category.assoc]
-            erw [NatTrans.naturality_assoc, ← PresheafedSpace.comp_c_app_assoc,
-              congr_app (pullbackSymmetry_hom_comp_snd _ _)]
+            rw [← IsIso.eq_inv_comp, IsOpenImmersion.inv_invApp]
+            simp_rw [Category.assoc, NatTrans.naturality_assoc]
+            erw [← PresheafedSpace.comp_c_app_assoc]
+            rw [congr_app (pullbackSymmetry_hom_comp_snd _ _)]
             simp_rw [Category.assoc]
             erw [IsOpenImmersion.inv_naturality_assoc, IsOpenImmersion.inv_naturality_assoc,
               IsOpenImmersion.inv_naturality_assoc, IsOpenImmersion.app_invApp_assoc]


### PR DESCRIPTION
We replace `erw` this with defeq abuse (which seems to be accepted as okay inside proofs), and clean up the rest of the file.

I might start trying to remove `erw`s in Mathlib.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
