### PR TITLE
[Merged by Bors] - chore(Algebra): more porting notes for Algebra

### DIFF
--- a/Mathlib/Algebra/Group/Submonoid/Membership.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Membership.lean
@@ -292,7 +292,7 @@ theorem mem_powers_iff (x z : M) : x ∈ powers z ↔ ∃ n : ℕ, z ^ n = x :=
 noncomputable instance decidableMemPowers : DecidablePred (· ∈ Submonoid.powers a) :=
   Classical.decPred _
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11215): TODO the following instance should follow from a more general principle
+-- TODO the following instance should follow from a more general principle
 -- See also https://github.com/leanprover-community/mathlib4/issues/2417
 noncomputable instance fintypePowers [Fintype M] : Fintype (powers a) :=
   inferInstanceAs <| Fintype {y // y ∈ powers a}

--- a/Mathlib/Algebra/Group/Units/Defs.lean
+++ b/Mathlib/Algebra/Group/Units/Defs.lean
@@ -79,7 +79,6 @@ namespace Units
 section Monoid
 variable [Monoid α]
 
--- Porting note: unclear whether this should be a `CoeHead` or `CoeTail`
 /-- A unit can be interpreted as a term in the base `Monoid`. -/
 @[to_additive /-- An additive unit can be interpreted as a term in the base `AddMonoid`. -/]
 instance : CoeHead αˣ α :=

--- a/Mathlib/Algebra/GroupWithZero/Action/Defs.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Defs.lean
@@ -74,7 +74,6 @@ See note [reducible non-instances]. -/
 protected abbrev ZeroHom.smulZeroClass [Zero B] [SMul M B] (f : ZeroHom A B)
     (smul : ∀ (c : M) (x), f (c • x) = c • f x) :
     SMulZeroClass M B where
-  -- Porting note: `simp` no longer works here.
   smul_zero c := by rw [← map_zero f, ← smul, smul_zero]
 
 /-- Push forward the multiplication of `R` on `M` along a compatible surjective map `f : R → S`.
@@ -355,9 +354,7 @@ variable [Monoid M] [AddMonoid A] [DistribMulAction M A]
 instance (priority := 100) DistribMulAction.toDistribSMul : DistribSMul M A :=
   { ‹DistribMulAction M A› with }
 
--- Porting note: this probably is no longer relevant.
-/-! Since Lean 3 does not have definitional eta for structures, we have to make sure
-that the definition of `DistribMulAction.toDistribSMul` was done correctly,
+/-! We make sure that the definition of `DistribMulAction.toDistribSMul` was done correctly,
 and the two paths from `DistribMulAction` to `SMul` are indeed definitionally equal. -/
 example :
     (DistribMulAction.toMulAction.toSMul : SMul M A) =

--- a/Mathlib/Algebra/GroupWithZero/Action/Pi.lean
+++ b/Mathlib/Algebra/GroupWithZero/Action/Pi.lean
@@ -84,7 +84,6 @@ theorem single_smul {α} [Monoid α] [∀ i, AddMonoid <| f i] [∀ i, DistribMu
     [DecidableEq I] (i : I) (r : α) (x : f i) : single i (r • x) = r • single i x :=
   single_op (fun i : I => (r • · : f i → f i)) (fun _ => smul_zero _) _ _
 
--- Porting note: Lean4 cannot infer the non-dependent function `f := fun _ => β`
 /-- A version of `Pi.single_smul` for non-dependent functions. It is useful in cases where Lean
 fails to apply `Pi.single_smul`. -/
 theorem single_smul' {α β} [Monoid α] [AddMonoid β] [DistribMulAction α β] [DecidableEq I] (i : I)

--- a/Mathlib/Algebra/GroupWithZero/Indicator.lean
+++ b/Mathlib/Algebra/GroupWithZero/Indicator.lean
@@ -99,11 +99,9 @@ end ZeroOne
 section MulZeroClass
 variable [MulZeroClass M₀]
 
---@[simp] Porting note: removing simp, bad lemma LHS not in normal form
 lemma support_mul_subset_left (f g : ι → M₀) : support (fun x ↦ f x * g x) ⊆ support f :=
   fun x hfg hf ↦ hfg <| by simp only [hf, zero_mul]
 
---@[simp] Porting note: removing simp, bad lemma LHS not in normal form
 lemma support_mul_subset_right (f g : ι → M₀) : support (fun x ↦ f x * g x) ⊆ support g :=
   fun x hfg hg => hfg <| by simp only [hg, mul_zero]
 

--- a/Mathlib/Algebra/GroupWithZero/NeZero.lean
+++ b/Mathlib/Algebra/GroupWithZero/NeZero.lean
@@ -41,10 +41,8 @@ section GroupWithZero
 
 variable {G₀ : Type*} [GroupWithZero G₀] {a : G₀}
 
--- Porting note: used `simpa` to prove `False` in lean3
 theorem inv_ne_zero (h : a ≠ 0) : a⁻¹ ≠ 0 := fun a_eq_0 => by
-  have := mul_inv_cancel₀ h
-  simp only [a_eq_0, mul_zero, zero_ne_one] at this
+  simpa [a_eq_0] using mul_inv_cancel₀ h
 
 @[simp high] -- should take priority over `IsUnit.inv_mul_cancel`
 theorem inv_mul_cancel₀ (h : a ≠ 0) : a⁻¹ * a = 1 :=

--- a/Mathlib/Algebra/GroupWithZero/Regular.lean
+++ b/Mathlib/Algebra/GroupWithZero/Regular.lean
@@ -56,15 +56,15 @@ theorem isRegular_iff_subsingleton : IsRegular (0 : R) ↔ Subsingleton R :=
 theorem IsLeftRegular.ne_zero [Nontrivial R] (la : IsLeftRegular a) : a ≠ 0 := by
   rintro rfl
   rcases exists_pair_ne R with ⟨x, y, xy⟩
-  refine xy (la (?_ : 0 * x = 0 * y)) -- Porting note: lean4 seems to need the type signature
-  rw [zero_mul, zero_mul]
+  refine xy (la ?_)
+  simp
 
 /-- A right-regular element of a `Nontrivial` `MulZeroClass` is non-zero. -/
 theorem IsRightRegular.ne_zero [Nontrivial R] (ra : IsRightRegular a) : a ≠ 0 := by
   rintro rfl
   rcases exists_pair_ne R with ⟨x, y, xy⟩
-  refine xy (ra (?_ : x * 0 = y * 0))
-  rw [mul_zero, mul_zero]
+  refine xy (ra ?_)
+  simp
 
 /-- A regular element of a `Nontrivial` `MulZeroClass` is non-zero. -/
 theorem IsRegular.ne_zero [Nontrivial R] (la : IsRegular a) : a ≠ 0 :=

--- a/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
+++ b/Mathlib/Algebra/GroupWithZero/Units/Basic.lean
@@ -214,11 +214,7 @@ theorem IsUnit.mk0 (x : G₀) (hx : x ≠ 0) : IsUnit x :=
 theorem isUnit_iff_ne_zero : IsUnit a ↔ a ≠ 0 :=
   (Units.exists_iff_ne_zero (p := (· = a))).trans (by simp)
 
-alias ⟨_, Ne.isUnit⟩ := isUnit_iff_ne_zero
-
--- Porting note: can't add this attribute?
--- https://github.com/leanprover-community/mathlib4/issues/740
--- attribute [protected] Ne.is_unit
+protected alias ⟨_, Ne.isUnit⟩ := isUnit_iff_ne_zero
 
 -- see Note [lower instance priority]
 instance (priority := 10) GroupWithZero.noZeroDivisors : NoZeroDivisors G₀ :=

--- a/Mathlib/Algebra/Homology/Additive.lean
+++ b/Mathlib/Algebra/Homology/Additive.lean
@@ -79,17 +79,7 @@ instance : AddCommGroup (C ⟶ D) :=
   Function.Injective.addCommGroup Hom.f HomologicalComplex.hom_f_injective
     (by cat_disch) (by cat_disch) (by cat_disch) (by cat_disch) (by cat_disch) (by cat_disch)
 
--- Porting note: proofs had to be provided here, otherwise Lean tries to apply
--- `Preadditive.add_comp/comp_add` to `HomologicalComplex V c`
 instance : Preadditive (HomologicalComplex V c) where
-  add_comp _ _ _ f f' g := by
-    ext
-    simp only [comp_f, add_f_apply]
-    rw [Preadditive.add_comp]
-  comp_add _ _ _ f g g' := by
-    ext
-    simp only [comp_f, add_f_apply]
-    rw [Preadditive.comp_add]
 
 /-- The `i`-th component of a chain map, as an additive map from chain maps to morphisms. -/
 @[simps!]

--- a/Mathlib/Algebra/Homology/Augment.lean
+++ b/Mathlib/Algebra/Homology/Augment.lean
@@ -121,7 +121,6 @@ def augmentTruncate (C : ChainComplex V ℕ) :
   hom :=
     { f := fun | 0 => 𝟙 _ | _+1 => 𝟙 _
       comm' := fun i j => by
-        -- Porting note: was an rcases n with (_|_|n) but that was causing issues
         match i with
         | 0 | 1 | n+2 =>
           rcases j with - | j <;> dsimp [augment, truncate] <;> simp
@@ -129,7 +128,6 @@ def augmentTruncate (C : ChainComplex V ℕ) :
   inv :=
     { f := fun | 0 => 𝟙 _ | _+1 => 𝟙 _
       comm' := fun i j => by
-        -- Porting note: was an rcases n with (_|_|n) but that was causing issues
         match i with
           | 0 | 1 | n+2 =>
           rcases j with - | j <;> dsimp [augment, truncate] <;> simp
@@ -286,25 +284,11 @@ def augmentTruncate (C : CochainComplex V ℕ) :
   hom :=
     { f := fun | 0 => 𝟙 _ | _+1 => 𝟙 _
       comm' := fun i j => by
-        rcases j with (_ | _ | j) <;> cases i <;>
-          · dsimp
-            -- Porting note https://github.com/leanprover-community/mathlib4/issues/10959
-            -- simp can't handle this now but aesop does
-            aesop }
+        rcases j with (_ | _ | j) <;> cases i <;> aesop }
   inv :=
     { f := fun | 0 => 𝟙 _ | _+1 => 𝟙 _
       comm' := fun i j => by
-        rcases j with (_ | _ | j) <;> rcases i with - | i <;>
-          · dsimp
-            -- Porting note https://github.com/leanprover-community/mathlib4/issues/10959
-            -- simp can't handle this now but aesop does
-            aesop }
-  hom_inv_id := by
-    ext i
-    cases i <;> simp
-  inv_hom_id := by
-    ext i
-    cases i <;> simp
+        rcases j with (_ | _ | j) <;> rcases i with - | i <;> aesop }
 
 @[simp]
 theorem augmentTruncate_hom_f_zero (C : CochainComplex V ℕ) :

--- a/Mathlib/Algebra/Homology/DifferentialObject.lean
+++ b/Mathlib/Algebra/Homology/DifferentialObject.lean
@@ -89,10 +89,8 @@ def dgoToHomologicalComplex :
       comm' := fun i j h => by
         dsimp at h ⊢
         subst h
-        simp only [dite_true, Category.assoc, eqToHom_f']
-        -- Porting note: this `rw` used to be part of the `simp`.
         have : f.f i ≫ Y.d i = X.d i ≫ f.f _ := (congr_fun f.comm i).symm
-        rw [reassoc_of% this] }
+        simp only [dite_true, Category.assoc, eqToHom_f', reassoc_of% this] }
 
 /-- The functor from homological complexes to differential graded objects.
 -/

--- a/Mathlib/Algebra/Homology/HomologicalComplex.lean
+++ b/Mathlib/Algebra/Homology/HomologicalComplex.lean
@@ -359,19 +359,19 @@ lemma XIsoOfEq_hom_naturality {K L : HomologicalComplex V c} (φ : K ⟶ L) {n n
 lemma XIsoOfEq_inv_naturality {K L : HomologicalComplex V c} (φ : K ⟶ L) {n n' : ι} (h : n = n') :
     φ.f n' ≫ (L.XIsoOfEq h).inv = (K.XIsoOfEq h).inv ≫ φ.f n := by subst h; simp
 
--- Porting note: removed @[simp] as the linter complained
 /-- If `C.d i j` and `C.d i j'` are both allowed, then we must have `j = j'`,
 and so the differentials only differ by an `eqToHom`.
 -/
+@[simp]
 theorem d_comp_eqToHom {i j j' : ι} (rij : c.Rel i j) (rij' : c.Rel i j') :
     C.d i j' ≫ eqToHom (congr_arg C.X (c.next_eq rij' rij)) = C.d i j := by
   obtain rfl := c.next_eq rij rij'
   simp only [eqToHom_refl, comp_id]
 
--- Porting note: removed @[simp] as the linter complained
 /-- If `C.d i j` and `C.d i' j` are both allowed, then we must have `i = i'`,
 and so the differentials only differ by an `eqToHom`.
 -/
+@[simp]
 theorem eqToHom_comp_d {i i' j : ι} (rij : c.Rel i j) (rij' : c.Rel i' j) :
     eqToHom (congr_arg C.X (c.prev_eq rij rij')) ≫ C.d i' j = C.d i j := by
   obtain rfl := c.prev_eq rij rij'

--- a/Mathlib/Algebra/Homology/Homotopy.lean
+++ b/Mathlib/Algebra/Homology/Homotopy.lean
@@ -484,9 +484,6 @@ def mkInductiveAux₂ :
       one comm_one succ n
     ⟨(P.xNextIso rfl).hom ≫ I.1, I.2.1 ≫ (Q.xPrevIso rfl).inv, by simpa using I.2.2⟩
 
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11647): during the port we marked these lemmas
--- with `@[eqns]` to emulate the old Lean 3 behaviour.
-
 @[simp] theorem mkInductiveAux₂_zero :
     mkInductiveAux₂ e zero comm_zero one comm_one succ 0 =
       ⟨0, zero ≫ (Q.xPrevIso rfl).inv, by simpa using comm_zero⟩ :=
@@ -611,9 +608,6 @@ def mkCoinductiveAux₂ :
   | n + 1 =>
     let I := mkCoinductiveAux₁ e zero one comm_one succ n
     ⟨I.1 ≫ (Q.xPrevIso rfl).inv, (P.xNextIso rfl).hom ≫ I.2.1, by simpa using I.2.2⟩
-
--- Porting note (https://github.com/leanprover-community/mathlib4/issues/11647): during the port we marked these lemmas with `@[eqns]`
--- to emulate the old Lean 3 behaviour.
 
 @[simp] theorem mkCoinductiveAux₂_zero :
     mkCoinductiveAux₂ e zero comm_zero one comm_one succ 0 =

--- a/Mathlib/Algebra/Homology/HomotopyCategory.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory.lean
@@ -95,8 +95,7 @@ lemma quotient_obj_surjective (X : HomotopyCategory V c) :
     ∃ (K : HomologicalComplex V c), (quotient _ _).obj K = X :=
   ⟨_, rfl⟩
 
--- Porting note: removed @[simp] attribute because it hinders the automatic application of the
--- more useful `quotient_map_out`
+-- Not `@[simp]` because it hinders the automatic application of the more useful `quotient_map_out`
 theorem quotient_obj_as (C : HomologicalComplex V c) : ((quotient V c).obj C).as = C :=
   rfl
 
@@ -104,7 +103,6 @@ theorem quotient_obj_as (C : HomologicalComplex V c) : ((quotient V c).obj C).as
 theorem quotient_map_out {C D : HomotopyCategory V c} (f : C ⟶ D) : (quotient V c).map f.out = f :=
   Quot.out_eq _
 
--- Porting note: added to ease the port
 theorem quot_mk_eq_quotient_map {C D : HomologicalComplex V c} (f : C ⟶ D) :
     Quot.mk _ f = (quotient V c).map f := rfl
 
@@ -205,7 +203,6 @@ namespace CategoryTheory
 
 variable {V} {W : Type*} [Category W] [Preadditive W]
 
--- Porting note: given a simpler definition of this functor
 /-- An additive functor induces a functor between homotopy categories. -/
 @[simps! obj]
 def Functor.mapHomotopyCategory (F : V ⥤ W) [F.Additive] (c : ComplexShape ι) :

--- a/Mathlib/Algebra/Jordan/Basic.lean
+++ b/Mathlib/Algebra/Jordan/Basic.lean
@@ -217,10 +217,9 @@ private theorem aux3 {a b c : A} :
     =
     2 • ⁅L a, L (b * c)⁆ + 2 • ⁅L b, L (c * a)⁆ + 2 • ⁅L c, L (a * b)⁆ := by
   rw [add_eq_right]
-  -- Porting note: was `nth_rw` instead of `conv_lhs`
-  conv_lhs => enter [1, 1, 2, 2, 2]; rw [mul_comm a b]
-  conv_lhs => enter [1, 2, 2, 2, 1]; rw [mul_comm c a]
-  conv_lhs => enter [   2, 2, 2, 2]; rw [mul_comm b c]
+  nth_rw 2 [mul_comm a b]
+  nth_rw 1 [mul_comm c a]
+  nth_rw 2 [mul_comm b c]
   iterate 3 rw [two_nsmul_lie_lmul_lmul_add_eq_lie_lmul_lmul_add]
   iterate 2 rw [← lie_skew (L (a * a)), ← lie_skew (L (b * b)), ← lie_skew (L (c * c))]
   abel

--- a/Mathlib/Algebra/Lie/Engel.lean
+++ b/Mathlib/Algebra/Lie/Engel.lean
@@ -142,8 +142,6 @@ end LieSubmodule
 
 section LieAlgebra
 
--- Porting note: somehow this doesn't hide `LieModule.IsNilpotent`, so `_root_.IsNilpotent` is used
--- a number of times below.
 open LieModule hiding IsNilpotent
 
 variable (R L)
@@ -155,7 +153,7 @@ Engel's theorem `LieAlgebra.isEngelian_of_isNoetherian` states that any Noetheri
 Engelian. -/
 def LieAlgebra.IsEngelian : Prop :=
   ∀ (M : Type u₄) [AddCommGroup M] [Module R M] [LieRingModule L M] [LieModule R L M],
-    (∀ x : L, _root_.IsNilpotent (toEnd R L M x)) → LieModule.IsNilpotent L M
+    (∀ x : L, IsNilpotent (toEnd R L M x)) → LieModule.IsNilpotent L M
 
 variable {R L}
 
@@ -218,7 +216,7 @@ theorem LieAlgebra.isEngelian_of_isNoetherian [IsNoetherian R L] : LieAlgebra.Is
   intro M _i1 _i2 _i3 _i4 h
   rw [← isNilpotent_range_toEnd_iff R]
   let L' := (toEnd R L M).range
-  replace h : ∀ y : L', _root_.IsNilpotent (y : Module.End R M) := by
+  replace h : ∀ y : L', IsNilpotent (y : Module.End R M) := by
     rintro ⟨-, ⟨y, rfl⟩⟩
     simp [h]
   change LieModule.IsNilpotent L' M
@@ -273,7 +271,7 @@ theorem LieModule.isNilpotent_iff_forall' [IsNoetherian R M] :
 
 /-- Engel's theorem. -/
 theorem LieAlgebra.isNilpotent_iff_forall [IsNoetherian R L] :
-    LieRing.IsNilpotent L ↔ ∀ x, _root_.IsNilpotent <| LieAlgebra.ad R L x :=
+    LieRing.IsNilpotent L ↔ ∀ x, IsNilpotent <| LieAlgebra.ad R L x :=
   LieModule.isNilpotent_iff_forall
 
 end LieAlgebra

--- a/Mathlib/Algebra/Lie/UniversalEnveloping.lean
+++ b/Mathlib/Algebra/Lie/UniversalEnveloping.lean
@@ -108,9 +108,8 @@ def lift : (L →ₗ⁅R⁆ A) ≃ (UniversalEnvelopingAlgebra R L →ₐ[R] A) 
     --   RingQuot.liftAlgHom_mkAlgHom_apply]
     simp only [LieHom.coe_comp, Function.comp_apply, AlgHom.coe_toLieHom,
       UniversalEnvelopingAlgebra.ι_apply, mkAlgHom]
-    dsimp [UniversalEnvelopingAlgebra]
-    rw [RingQuot.liftAlgHom_mkAlgHom_apply]
-    simp only [TensorAlgebra.lift_ι_apply, LieHom.coe_toLinearMap]
+    simp only [UniversalEnvelopingAlgebra, RingQuot.liftAlgHom_mkAlgHom_apply,
+      TensorAlgebra.lift_ι_apply, LieHom.coe_toLinearMap]
   right_inv F := by
     apply RingQuot.ringQuot_ext'
     ext
@@ -131,7 +130,7 @@ theorem lift_symm_apply (F : UniversalEnvelopingAlgebra R L →ₐ[R] A) :
 theorem ι_comp_lift : lift R f ∘ ι R = f :=
   funext <| LieHom.ext_iff.mp <| (lift R).symm_apply_apply f
 
--- Porting note: moved `@[simp]` to the next theorem (LHS simplifies)
+-- `simp`-normal form is `lift_ι_apply'`.
 theorem lift_ι_apply (x : L) : lift R f (ι R x) = f x := by
   rw [← Function.comp_apply (f := lift R f) (g := ι R) (x := x), ι_comp_lift]
 

--- a/Mathlib/Algebra/Module/Injective.lean
+++ b/Mathlib/Algebra/Module/Injective.lean
@@ -196,8 +196,8 @@ theorem extensionOfMax_is_max :
   fun _ ↦ (@zorn_le_nonempty (ExtensionOf i f) _ ⟨Inhabited.default⟩ fun _ hchain hnonempty =>
     ⟨ExtensionOf.max hchain hnonempty, ExtensionOf.le_max hchain hnonempty⟩).choose_spec.eq_of_ge
 
--- Porting note: helper function. Lean looks for an instance of `Sup (Type u)` when the
--- right hand side is substituted in directly
+-- Auxiliary definition: Lean looks for an instance of `Max (Type u)` if we would write
+-- `(x : (extensionOfMax i f).domain ⊔ (Submodule.span R {y}))`, so we encapsulate the cast instead.
 abbrev supExtensionOfMaxSingleton (y : N) : Submodule R N :=
   (extensionOfMax i f).domain ⊔ (Submodule.span R {y})
 

--- a/Mathlib/Algebra/Module/LinearMap/Defs.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Defs.lean
@@ -215,7 +215,7 @@ def toDistribMulActionHom (f : M →ₛₗ[σ] M₃) : DistribMulActionHom σ.to
 @[simp]
 theorem coe_toAddHom (f : M →ₛₗ[σ] M₃) : ⇑f.toAddHom = f := rfl
 
--- Porting note: no longer a `simp`
+@[simp]
 theorem toFun_eq_coe {f : M →ₛₗ[σ] M₃} : f.toFun = (f : M → M₃) := rfl
 
 @[ext]

--- a/Mathlib/Algebra/MonoidAlgebra/Division.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Division.lean
@@ -159,7 +159,7 @@ theorem of'_modOf (g : G) : of' k G g %ᵒᶠ g = 0 := by
 theorem divOf_add_modOf [IsCancelAdd G] (x : k[G]) (g : G) :
     of' k G g * (x /ᵒᶠ g) + x %ᵒᶠ g = x := by
   ext g'
-  rw [Finsupp.add_apply] -- Porting note: changed from `simp_rw` which can't see through the type
+  rw [Finsupp.add_apply]
   obtain ⟨d, rfl⟩ | h := em (∃ d, g' = g + d)
   swap
   · rw [modOf_apply_of_not_exists_add x _ _ h, of'_apply, single_mul_apply_of_not_exists_add _ _ h,

--- a/Mathlib/Algebra/MonoidAlgebra/Lift.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Lift.lean
@@ -61,7 +61,6 @@ theorem liftNC_mul {g_hom : Type*} [FunLike g_hom G R] [MulHomClass g_hom G R]
     (h_comm : ∀ {x y}, y ∈ a.support → Commute (f (b x)) (g y)) :
     liftNC (f : k →+ R) g (a * b) = liftNC (f : k →+ R) g a * liftNC (f : k →+ R) g b := by
   conv_rhs => rw [← sum_single a, ← sum_single b]
-  -- Porting note: `(liftNC _ g).map_finsuppSum` → `map_finsuppSum`
   simp_rw [mul_def, map_finsuppSum, liftNC_single, Finsupp.sum_mul, Finsupp.mul_sum]
   refine Finset.sum_congr rfl fun y hy => Finset.sum_congr rfl fun x _hx => ?_
   simp [mul_assoc, (h_comm hy).left_comm]

--- a/Mathlib/Algebra/MonoidAlgebra/Opposite.lean
+++ b/Mathlib/Algebra/MonoidAlgebra/Opposite.lean
@@ -46,13 +46,14 @@ protected noncomputable def opRingEquiv [Mul G] :
         (S := MonoidAlgebra kᵐᵒᵖ Gᵐᵒᵖ) _) ?_
       ext
       -- Porting note: `reducible` cannot be `local` so proof gets long.
-      simp only [AddMonoidHom.coe_comp, AddEquiv.coe_toAddMonoidHom, opAddEquiv_apply,
-        Function.comp_apply, singleAddHom_apply, AddMonoidHom.compr₂_apply, AddMonoidHom.coe_mul,
-        AddMonoidHom.coe_mulLeft, AddMonoidHom.compl₂_apply]
+      simp only [AddMonoidHom.coe_comp, Function.comp_apply, singleAddHom_apply,
+        AddMonoidHom.compr₂_apply, AddMonoidHom.coe_mul, AddMonoidHom.coe_mulLeft,
+        AddMonoidHom.compl₂_apply, AddEquiv.toAddMonoidHom_eq_coe,
+        AddEquiv.coe_addMonoidHom_trans]
       -- This used to be `rw`, but we need `erw` after https://github.com/leanprover/lean4/pull/2644
-      erw [AddEquiv.trans_apply, AddEquiv.trans_apply, AddEquiv.trans_apply, AddEquiv.trans_apply,
-        AddEquiv.trans_apply, AddEquiv.trans_apply, MulOpposite.opAddEquiv_symm_apply]
-      rw [MulOpposite.unop_mul (α := MonoidAlgebra k G), unop_op, unop_op, single_mul_single]
+      erw [AddEquiv.trans_apply, AddEquiv.trans_apply, AddEquiv.trans_apply,
+        MulOpposite.opAddEquiv_symm_apply]
+      rw [MulOpposite.unop_mul (α := MonoidAlgebra k G)]
       simp }
 
 theorem opRingEquiv_single [Mul G] (r : k) (x : G) :
@@ -95,9 +96,8 @@ protected noncomputable def opRingEquiv [AddCommMagma G] :
       rw [single_mul_single, mapRange_single, mapRange_single, mapRange_single, single_mul_single]
       simp only [opAddEquiv_apply, op_mul, add_comm] }
 
--- @[simp] -- Porting note (https://github.com/leanprover-community/mathlib4/issues/10618): simp can prove this.
--- More specifically, the LHS simplifies to `Finsupp.single`, which implies there's some
--- defeq abuse going on.
+-- Not `@[simp]` because the LHS simplifies further.
+-- TODO: the LHS simplifies to `Finsupp.single`, which implies there's some defeq abuse going on.
 theorem opRingEquiv_single [AddCommMagma G] (r : k) (x : G) :
     AddMonoidAlgebra.opRingEquiv (op (single x r)) = single x (op r) := by simp
 

--- a/Mathlib/Algebra/MvPolynomial/Division.lean
+++ b/Mathlib/Algebra/MvPolynomial/Division.lean
@@ -189,14 +189,11 @@ theorem monomial_dvd_monomial {r s : R} {i j : σ →₀ ℕ} :
     have hj := hx j
     have hi := hx i
     classical
-      simp_rw [coeff_monomial, if_pos] at hj hi
-      simp_rw [coeff_monomial_mul'] at hi hj
-      split_ifs at hi hj with hi hi
-      · exact ⟨Or.inr hi, _, hj⟩
-      · exact ⟨Or.inl hj, hj.symm ▸ dvd_zero _⟩
-    -- Porting note: two goals remain at this point in Lean 4
-    · simp_all only [or_true, dvd_mul_right, and_self]
-    · simp_all only [ite_self, le_refl, ite_true, dvd_mul_right, or_false, and_self]
+    simp_rw [coeff_monomial, if_pos] at hj hi
+    simp_rw [coeff_monomial_mul'] at hi hj
+    split_ifs at hj with hi
+    · exact ⟨Or.inr hi, _, hj⟩
+    · exact ⟨Or.inl hj, hj.symm ▸ dvd_zero _⟩
   · rintro ⟨h | hij, d, rfl⟩
     · simp_rw [h, monomial_zero, dvd_zero]
     · refine ⟨monomial (j - i) d, ?_⟩

--- a/Mathlib/Algebra/MvPolynomial/Eval.lean
+++ b/Mathlib/Algebra/MvPolynomial/Eval.lean
@@ -755,9 +755,7 @@ theorem eval₂_mem {f : R →+* S} {p : MvPolynomial σ R} {s : subS}
   | monomial_add a b f ha _ ih =>
     rw [eval₂_add, eval₂_monomial]
     refine add_mem (mul_mem ?_ <| prod_mem fun i _ => pow_mem (hv _) _) (ih fun i => ?_)
-    · have := hs a -- Porting note: was `simpa only [...]`
-      rwa [coeff_add, MvPolynomial.notMem_support_iff.1 ha, add_zero, coeff_monomial,
-        if_pos rfl] at this
+    · simpa [MvPolynomial.notMem_support_iff.1 ha] using hs a
     have := hs i
     rw [coeff_add, coeff_monomial] at this
     split_ifs at this with h

--- a/Mathlib/Algebra/MvPolynomial/Monad.lean
+++ b/Mathlib/Algebra/MvPolynomial/Monad.lean
@@ -331,7 +331,6 @@ instance monad : Monad fun σ => MvPolynomial σ R where
 
 instance lawfulFunctor : LawfulFunctor fun σ => MvPolynomial σ R where
   map_const := by intros; rfl
-  -- Porting note: I guess `map_const` no longer has a default implementation?
   id_map := by intros; simp [(· <$> ·)]
   comp_map := by intros; simp [(· <$> ·)]
 

--- a/Mathlib/Algebra/Notation/Pi/Basic.lean
+++ b/Mathlib/Algebra/Notation/Pi/Basic.lean
@@ -90,7 +90,7 @@ lemma mulSingle_apply (i : ι) (x : M) (i' : ι) :
     (mulSingle i x : ι → M) i' = if i' = i then x else 1 :=
   Function.update_apply (1 : ι → M) i x i'
 
--- Porting note: Same as above.
+-- Porting note: added type ascription (_ : ι → M)
 /-- On non-dependent functions, `Pi.mulSingle` is symmetric in the two indices. -/
 @[to_additive /-- On non-dependent functions, `Pi.single` is symmetric in the two indices. -/]
 lemma mulSingle_comm (i : ι) (x : M) (j : ι) :

--- a/Mathlib/Algebra/Order/CauSeq/Basic.lean
+++ b/Mathlib/Algebra/Order/CauSeq/Basic.lean
@@ -93,7 +93,6 @@ variable [Field α] [LinearOrder α] [IsStrictOrderedRing α] [Ring β]
   {abv : β → α} [IsAbsoluteValue abv] {f g : ℕ → β}
 
 -- see Note [nolint_ge]
---@[nolint ge_or_gt] -- Porting note: restore attribute
 theorem cauchy₂ (hf : IsCauSeq abv f) {ε : α} (ε0 : 0 < ε) :
     ∃ i, ∀ j ≥ i, ∀ k ≥ i, abv (f j - f k) < ε := by
   refine (hf _ (half_pos ε0)).imp fun i hi j ij k ik => ?_
@@ -183,7 +182,6 @@ def ofEq (f : CauSeq β abv) (g : ℕ → β) (e : ∀ i, f i = g i) : CauSeq β
 variable [IsAbsoluteValue abv]
 
 -- see Note [nolint_ge]
--- @[nolint ge_or_gt] -- Porting note: restore attribute
 theorem cauchy₂ (f : CauSeq β abv) {ε} :
     0 < ε → ∃ i, ∀ j ≥ i, ∀ k ≥ i, abv (f j - f k) < ε :=
   f.2.cauchy₂

--- a/Mathlib/Algebra/Order/CompleteField.lean
+++ b/Mathlib/Algebra/Order/CompleteField.lean
@@ -51,15 +51,8 @@ open scoped Pointwise
 
 /-- A field which is both linearly ordered and conditionally complete with respect to the order.
 This axiomatizes the reals. -/
--- @[protect_proj] -- Porting note: does not exist anymore
 class ConditionallyCompleteLinearOrderedField (α : Type*) extends
-    Field α, ConditionallyCompleteLinearOrder α where
-  -- extends `IsStrictOrderedRing α` produces
-  -- (kernel) declaration has free variables
-  -- 'ConditionallyCompleteLinearOrderedField.toIsStrictOrderedRing'
-  [toIsStrictOrderedRing : IsStrictOrderedRing α]
-
-attribute [instance] ConditionallyCompleteLinearOrderedField.toIsStrictOrderedRing
+    Field α, ConditionallyCompleteLinearOrder α, IsStrictOrderedRing α where
 
 -- see Note [lower instance priority]
 /-- Any conditionally complete linearly ordered field is archimedean. -/

--- a/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
@@ -174,7 +174,7 @@ instance instLinearOrderedCommMonoidWithZeroMultiplicativeOrderDual
     LinearOrderedCommMonoidWithZero (Multiplicative αᵒᵈ) where
   zero := Multiplicative.ofAdd (OrderDual.toDual ⊤)
   zero_mul := @top_add _ (_)
-  -- Porting note:  Here and elsewhere in the file, just `zero_mul` worked in Lean 3. See
+  -- Porting note:  Here and elsewhere in the file, just `top_add` worked in Lean 3. See
   -- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Type.20synonyms
   mul_zero := @add_top _ (_)
   zero_le_one := (le_top : (0 : α) ≤ ⊤)

--- a/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
@@ -174,8 +174,6 @@ instance instLinearOrderedCommMonoidWithZeroMultiplicativeOrderDual
     LinearOrderedCommMonoidWithZero (Multiplicative αᵒᵈ) where
   zero := Multiplicative.ofAdd (OrderDual.toDual ⊤)
   zero_mul := @top_add _ (_)
-  -- Porting note:  Here and elsewhere in the file, just `top_add` worked in Lean 3. See
-  -- https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Type.20synonyms
   mul_zero := @add_top _ (_)
   zero_le_one := (le_top : (0 : α) ≤ ⊤)
 

--- a/Mathlib/Algebra/Order/Hom/Ring.lean
+++ b/Mathlib/Algebra/Order/Hom/Ring.lean
@@ -57,13 +57,6 @@ add_decl_doc OrderRingHom.toRingHom
 @[inherit_doc]
 infixl:25 " →+*o " => OrderRingHom
 
-/- Porting note: Needed to reorder instance arguments below:
-`[Mul α] [Add α] [LE α] [Mul β] [Add β] [LE β]`
-to
-`[Mul α] [Mul β] [Add α] [Add β] [LE α] [LE β]`
-otherwise the [refl] attribute on `OrderRingIso.refl` complains.
-TODO: change back when `refl` attribute is fixed, github issue https://github.com/leanprover-community/mathlib4/issues/2505 -/
-
 /-- `OrderRingIso α β`, denoted as `α ≃+*o β`,
 is the type of order-preserving semiring isomorphisms between `α` and `β`.
 
@@ -71,7 +64,7 @@ When possible, instead of parametrizing results over `(f : OrderRingIso α β)`,
 you should parametrize over `(F : Type*) [OrderRingIsoClass F α β] (f : F)`.
 
 When you extend this structure, make sure to extend `OrderRingIsoClass`. -/
-structure OrderRingIso (α β : Type*) [Mul α] [Mul β] [Add α] [Add β] [LE α] [LE β] extends
+structure OrderRingIso (α β : Type*) [Mul α] [Add α] [Mul β] [Add β] [LE α] [LE β] extends
   α ≃+* β where
   /-- The proposition that the function preserves the order bijectively. -/
   map_le_map_iff' {a b : α} : toFun a ≤ toFun b ↔ a ≤ b
@@ -346,7 +339,6 @@ theorem toOrderIso_eq_coe (f : α ≃+*o β) : f.toOrderIso = f :=
 theorem coe_toRingEquiv (f : α ≃+*o β) : ⇑(f : α ≃+* β) = f :=
   rfl
 
--- Porting note: needed to add DFunLike.coe on the lhs, bad Equiv coercion otherwise
 @[simp, norm_cast]
 theorem coe_toOrderIso (f : α ≃+*o β) : DFunLike.coe (f : α ≃o β) = f :=
   rfl


### PR DESCRIPTION
I went through all porting notes for the Algebra folders between Group and Order. A lot of them are fixed now, some we won't fix (such as Lean 4 being stricter about type synonyms). Either way, we can get rid of a lot of them.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
