### PR TITLE
[Merged by Bors] - chore(NumberTheory/NumberField/CanonicalEmbedding): deprecate `measurableSet_interior_paramSet`

### DIFF
--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/NormLeOne.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/NormLeOne.lean
@@ -646,12 +646,7 @@ theorem interior_paramSet :
   simp [interior_pi_set Set.finite_univ, apply_ite]
 
 theorem measurableSet_interior_paramSet :
-    MeasurableSet (interior (paramSet K)) := by
-  rw [interior_paramSet]
-  refine MeasurableSet.univ_pi fun _ ↦ ?_
-  split_ifs
-  · exact measurableSet_Iio
-  · exact measurableSet_Ioo
+    MeasurableSet (interior (paramSet K)) := measurableSet_interior
 
 open scoped Classical in
 theorem closure_paramSet :

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/NormLeOne.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/NormLeOne.lean
@@ -645,8 +645,8 @@ theorem interior_paramSet :
     interior (paramSet K) = Set.univ.pi fun w ↦ if w = w₀ then Set.Iio 0 else Set.Ioo 0 1 := by
   simp [interior_pi_set Set.finite_univ, apply_ite]
 
-theorem measurableSet_interior_paramSet :
-    MeasurableSet (interior (paramSet K)) := measurableSet_interior
+@[deprecated (since := "2025-08-26")] alias measurableSet_interior_paramSet :=
+  measurableSet_interior
 
 open scoped Classical in
 theorem closure_paramSet :
@@ -853,7 +853,7 @@ theorem volume_interior_eq_volume_closure :
     refine MeasurableSet.preimage ?_ (continuous_normAtAllPlaces K).measurable
     refine MeasurableSet.image_of_continuousOn_injOn ?_ (continuous_expMapBasis K).continuousOn
       (injective_expMapBasis K).injOn
-    exact measurableSet_interior_paramSet K
+    exact measurableSet_interior
   refine le_antisymm (measure_mono interior_subset_closure) ?_
   refine (measure_mono (closure_normLeOne_subset K)).trans ?_
   refine le_of_eq_of_le ?_ (measure_mono (subset_interior_normLeOne K))


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
