### PR TITLE
[Merged by Bors] - chore(CategoryTheory/Monoidal): golf entire `counitInv_app_comp_functor_map_η_inverse`

### DIFF
--- a/Mathlib/CategoryTheory/Monoidal/Functor.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Functor.lean
@@ -1088,11 +1088,8 @@ lemma counitInv_app_comp_functor_map_η_inverse :
 lemma counitInv_app_tensor_comp_functor_map_δ_inverse (X Y : C) :
     e.counitInv.app (e.functor.obj X ⊗ e.functor.obj Y) ≫
       e.functor.map (δ e.inverse (e.functor.obj X) (e.functor.obj Y)) =
-      μ e.functor X Y ≫ e.functor.map (e.unitIso.hom.app X ⊗ₘ e.unitIso.hom.app Y) := by
-  rw [← cancel_epi (δ e.functor _ _), Monoidal.δ_μ_assoc]
-  apply e.inverse.map_injective
-  simp [← cancel_epi (e.unitIso.hom.app (X ⊗ Y)), Functor.map_comp,
-    unitIso_hom_app_tensor_comp_inverse_map_δ_functor_assoc]
+      μ e.functor X Y ≫ e.functor.map (e.unitIso.hom.app X ⊗ₘ e.unitIso.hom.app Y) :=
+  counitIso_inv_app_tensor_comp_functor_map_δ_inverse e X Y
 
 @[reassoc (attr := simp)]
 lemma ε_comp_map_ε : ε e.inverse ≫ e.inverse.map (ε e.functor) = e.unit.app (𝟙_ C) :=


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
