### PR TITLE
[Merged by Bors] - feat: `Module` actions by matrices on vectors

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -3251,6 +3251,7 @@ import Mathlib.Data.List.ToFinsupp
 import Mathlib.Data.List.Triplewise
 import Mathlib.Data.List.Zip
 import Mathlib.Data.MLList.BestFirst
+import Mathlib.Data.Matrix.Action
 import Mathlib.Data.Matrix.Auto
 import Mathlib.Data.Matrix.Basic
 import Mathlib.Data.Matrix.Basis

--- a/Mathlib/Data/Matrix/Action.lean
+++ b/Mathlib/Data/Matrix/Action.lean
@@ -59,7 +59,7 @@ instance : Module (Matrix n n R)ᵐᵒᵖ (n → R) where
   smul_zero _ := zero_vecMul _
   smul_add _ := add_vecMul _
 
-@[simp] lemma op_smul_eq_mulVec (A : (Matrix n n R)ᵐᵒᵖ) (v : n → R) : A • v = v ᵥ* A.unop := rfl
+@[simp] lemma op_smul_eq_vecMul (A : (Matrix n n R)ᵐᵒᵖ) (v : n → R) : A • v = v ᵥ* A.unop := rfl
 
 instance [DistribSMul S R] [IsScalarTower S R R] : SMulCommClass (Matrix n n R)ᵐᵒᵖ S (n → R) where
   smul_comm A s v := smul_vecMul s v A.unop

--- a/Mathlib/Data/Matrix/Action.lean
+++ b/Mathlib/Data/Matrix/Action.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2025 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+-/
+
+import Mathlib.Data.Matrix.Mul
+import Mathlib.Algebra.Ring.Opposite
+
+/-!
+# Actions by matrices on vectors through `*ᵥ` and `ᵥ*`, cast as `Module`s
+
+This file provides the left- and right- module structures of square matrices on vectors, via
+`Matrix.mulVec` and `Matrix.vecMul`.
+-/
+
+variable {n R S : Type*}
+
+namespace Matrix
+
+variable [Fintype n] [DecidableEq n] [Semiring R]
+
+/-! ## `*ᵥ` as a left-module -/
+
+section mulVec
+
+instance : Module (Matrix n n R) (n → R) where
+  smul := mulVec
+  one_smul := one_mulVec
+  mul_smul _ _ _ := (mulVec_mulVec _ _ _).symm
+  zero_smul := zero_mulVec
+  add_smul := add_mulVec
+  smul_zero := mulVec_zero
+  smul_add := mulVec_add
+
+@[simp] lemma smul_eq_mulVec (A : Matrix n n R) (v : n → R) : A • v = A *ᵥ v := rfl
+
+instance [DistribSMul S R] [SMulCommClass R S R] : SMulCommClass (Matrix n n R) S (n → R) where
+  smul_comm := letI := SMulCommClass.symm; mulVec_smul
+
+instance [DistribSMul S R] [SMulCommClass S R R] : SMulCommClass S (Matrix n n R) (n → R) where
+  smul_comm s A v := (mulVec_smul A s v).symm
+
+instance [DistribSMul S R] [IsScalarTower S R R] : IsScalarTower S (Matrix n n R) (n → R) where
+  smul_assoc := smul_mulVec
+
+end mulVec
+
+/-! ## `*ᵥ` as a right-module -/
+
+section vecMul
+
+instance : Module (Matrix n n R)ᵐᵒᵖ (n → R) where
+  smul A v := v ᵥ* A.unop
+  one_smul := Matrix.vecMul_one
+  mul_smul _ _ _ := (vecMul_vecMul _ _ _).symm
+  zero_smul := vecMul_zero
+  add_smul _ _ := vecMul_add _ _
+  smul_zero _ := zero_vecMul _
+  smul_add _ := add_vecMul _
+
+@[simp] lemma op_smul_eq_mulVec (A : (Matrix n n R)ᵐᵒᵖ) (v : n → R) : A • v = v ᵥ* A.unop := rfl
+
+instance [DistribSMul S R] [IsScalarTower S R R] : SMulCommClass (Matrix n n R)ᵐᵒᵖ S (n → R) where
+  smul_comm A s v := smul_vecMul s v A.unop
+
+instance [DistribSMul S R] [IsScalarTower S R R] : SMulCommClass S (Matrix n n R)ᵐᵒᵖ (n → R) where
+  smul_comm s A v := (smul_vecMul s v A.unop).symm
+
+instance [DistribSMul S R] [SMulCommClass S R R] : IsScalarTower S (Matrix n n R)ᵐᵒᵖ (n → R) where
+  smul_assoc s A v := vecMul_smul v s A.unop
+
+end vecMul
+
+end Matrix


### PR DESCRIPTION
These instances allow `Matrix.GeneralLinearGroup` to act on vectors.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]

-->
- [x] depends on: #28450

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
