### PR TITLE
[Merged by Bors] - feat(Algebra/Order): ArchimedeanClass ball for module

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -892,6 +892,7 @@ import Mathlib.Algebra.Order.Interval.Set.SuccPred
 import Mathlib.Algebra.Order.Invertible
 import Mathlib.Algebra.Order.Kleene
 import Mathlib.Algebra.Order.Module.Algebra
+import Mathlib.Algebra.Order.Module.Archimedean
 import Mathlib.Algebra.Order.Module.Basic
 import Mathlib.Algebra.Order.Module.Defs
 import Mathlib.Algebra.Order.Module.Equiv

--- a/Mathlib/Algebra/Order/Module/Archimedean.lean
+++ b/Mathlib/Algebra/Order/Module/Archimedean.lean
@@ -1,0 +1,105 @@
+/-
+Copyright (c) 2025 Weiyi Wang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Weiyi Wang
+-/
+
+import Mathlib.Algebra.Module.Submodule.Basic
+import Mathlib.Algebra.Module.Submodule.Lattice
+import Mathlib.Algebra.Order.Archimedean.Class
+import Mathlib.Algebra.Order.Module.Basic
+
+/-!
+# Archimedean classes for ordered module.
+
+## Main definitions
+* `ArchimedeanClass.ball` are `ArchimedeanClass.ballAddSubgroup` as a submodules.
+* `ArchimedeanClass.closedBall` are `ArchimedeanClass.closedBallAddSubgroup` as a submodules.
+-/
+
+namespace ArchimedeanClass
+
+variable {M : Type*} [AddCommGroup M] [LinearOrder M] [IsOrderedAddMonoid M]
+variable {K : Type*} [Ring K] [LinearOrder K] [IsOrderedRing K] [Archimedean K]
+variable [Module K M] [PosSMulMono K M]
+
+@[simp]
+theorem mk_smul (a : M) {k : K} (h : k ≠ 0) : mk (k • a) = mk a := by
+  have : Nontrivial K := nontrivial_iff.mpr ⟨k, 0, h⟩
+  obtain ⟨m, hm⟩ := Archimedean.arch 1 (show 0 < |k| by simpa using h)
+  obtain ⟨n, hn⟩ := Archimedean.arch |k| (show 0 < 1 by simp)
+  simp_rw [mk_eq_mk, abs_smul]
+  refine ⟨⟨m, ?_⟩, ⟨n, ?_⟩⟩
+  · rw [← smul_assoc]
+    exact le_smul_of_one_le_left (by simp) hm
+  · have : n • |a| = (n • (1 : K)) • |a| := by rw [smul_assoc, one_smul]
+    rw [this]
+    exact smul_le_smul_of_nonneg_right hn (by simp)
+
+theorem mk_le_mk_smul (a : M) (k : K) : mk a ≤ mk (k • a) := by
+  obtain rfl | h := eq_or_ne k 0
+  · simp
+  · rw [mk_smul a h]
+
+variable (K)
+
+/-- Given an upper set `s` of archimedean classes in a linearly ordered module `M` with Archimedean
+scalars, all elements belonging to these classes form a submodule, except when `s = ⊤` for which the
+set would be empty. For `s = ⊤`, we assign the junk value `⊥`.
+
+This has the same carrier as `ArchimedeanClass.addSubgroup`'s. -/
+noncomputable
+def submodule (s : UpperSet (ArchimedeanClass M)) : Submodule K M where
+  __ := addSubgroup s
+  smul_mem' k {a} := by
+    obtain rfl | hs := eq_or_ne s ⊤
+    · aesop
+    change a ∈ addSubgroup s → k • a ∈ addSubgroup s
+    simp_rw [mem_addSubgroup_iff hs]
+    refine fun h ↦ s.upper ?_ h
+    apply mk_le_mk_smul
+
+/-- An open ball defined by `ArchimedeanClass.submodule` of `UpperSet.Ioi c`.
+For `c = ⊤`, we assign the junk value `⊥`.
+
+This has the same carrier as `ArchimedeanClass.ballAddSubgroup`'s. -/
+noncomputable
+abbrev ball (c : ArchimedeanClass M) := submodule K (UpperSet.Ioi c)
+
+/-- A closed ball defined by `ArchimedeanClass.submodule` of `UpperSet.Ici c`.
+
+This has the same carrier as `ArchimedeanClass.closedBallAddSubgroup`'s. -/
+noncomputable
+abbrev closedBall (c : ArchimedeanClass M) := submodule K (UpperSet.Ici c)
+
+@[simp]
+theorem toAddSubgroup_ball (c : ArchimedeanClass M) :
+    (ball K c).toAddSubgroup = ballAddSubgroup c := rfl
+
+@[simp]
+theorem toAddSubgroup_closedBall (c : ArchimedeanClass M) :
+    (closedBall K c).toAddSubgroup = closedBallAddSubgroup c := rfl
+
+@[simp]
+theorem mem_ball_iff {a : M} {c : ArchimedeanClass M} (hc : c ≠ ⊤) : a ∈ ball K c ↔ c < mk a :=
+  mem_ballAddSubgroup_iff hc
+
+@[simp]
+theorem mem_closedBall_iff {a : M} {c : ArchimedeanClass M} : a ∈ closedBall K c ↔ c ≤ mk a :=
+  mem_closedBallAddSubgroup_iff
+
+variable (M) in
+@[simp]
+theorem ball_top : ball (M := M) K ⊤ = ⊥ :=
+  (Submodule.toAddSubgroup_inj _ _).mp <| ballAddSubgroup_top M
+
+variable (M) in
+@[simp]
+theorem closedBall_top : closedBall (M := M) K ⊤ = ⊥ :=
+  (Submodule.toAddSubgroup_inj _ _).mp <| closedBallAddSubgroup_top M
+
+theorem ball_antitone : Antitone (ball (M := M) K) := by
+  intro _ _ h
+  exact (Submodule.toAddSubgroup_le _ _).mp <| ballAddSubgroup_antitone h
+
+end ArchimedeanClass

--- a/Mathlib/Algebra/Order/Module/Archimedean.lean
+++ b/Mathlib/Algebra/Order/Module/Archimedean.lean
@@ -37,9 +37,7 @@ theorem mk_smul (a : M) {k : K} (h : k ≠ 0) : mk (k • a) = mk a := by
     exact smul_le_smul_of_nonneg_right hn (by simp)
 
 theorem mk_le_mk_smul (a : M) (k : K) : mk a ≤ mk (k • a) := by
-  obtain rfl | h := eq_or_ne k 0
-  · simp
-  · rw [mk_smul a h]
+  obtain rfl | h := eq_or_ne k 0 <;> simp [*]
 
 variable (K)
 

--- a/Mathlib/Algebra/Order/Module/Archimedean.lean
+++ b/Mathlib/Algebra/Order/Module/Archimedean.lean
@@ -10,7 +10,7 @@ import Mathlib.Algebra.Order.Archimedean.Class
 import Mathlib.Algebra.Order.Module.Basic
 
 /-!
-# Archimedean classes for ordered module.
+# Archimedean classes for ordered module
 
 ## Main definitions
 * `ArchimedeanClass.ball` are `ArchimedeanClass.ballAddSubgroup` as a submodules.


### PR DESCRIPTION
This continues #27885 and promotes `ArchimedeanClass.addSubgroup` to a submodule. Balls are promoted to submodules with shorter names `ball` and `closedBall`, as they will be used a lot in the proof of Hahn embedding theorem (if you don't agree with this I can rename them to `ballSubmodule` and `closedBallSubmodule`)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
