### PR TITLE
[Merged by Bors] - feat(Analysis/Convex): doubly stochastic matrices have operator norm at most one

### DIFF
--- a/Mathlib/Analysis/Convex/Birkhoff.lean
+++ b/Mathlib/Analysis/Convex/Birkhoff.lean
@@ -9,6 +9,8 @@ import Mathlib.Analysis.Convex.Extreme
 import Mathlib.Combinatorics.Hall.Basic
 import Mathlib.Data.Matrix.DoublyStochastic
 import Mathlib.Tactic.Linarith
+import Mathlib.Analysis.Convex.Jensen
+import Mathlib.Analysis.Normed.Module.Convex
 
 /-!
 # Birkhoff's theorem
@@ -196,3 +198,12 @@ theorem extremePoints_doublyStochastic :
   aesop
 
 end LinearOrderedField
+
+open scoped Matrix.Norms.L2Operator
+
+theorem Matrix.l2_opNorm_le_one_of_mem_doublyStochastic {M : Matrix n n ℝ}
+    (hM : M ∈ doublyStochastic ℝ n) :
+    ‖M‖ ≤ 1 := by
+  rw [← SetLike.mem_coe, doublyStochastic_eq_convexHull_permMatrix] at hM
+  have ⟨_, ⟨σ, rfl⟩, hσ⟩ := convexOn_univ_norm.exists_ge_of_mem_convexHull (by simp) hM
+  exact hσ.trans (permMatrix_l2_opNorm_le _)

--- a/Mathlib/Analysis/Convex/Birkhoff.lean
+++ b/Mathlib/Analysis/Convex/Birkhoff.lean
@@ -6,11 +6,11 @@ Authors: Bhavik Mehta
 
 import Mathlib.Analysis.Convex.Combination
 import Mathlib.Analysis.Convex.Extreme
+import Mathlib.Analysis.Convex.Jensen
+import Mathlib.Analysis.Normed.Module.Convex
 import Mathlib.Combinatorics.Hall.Basic
 import Mathlib.Data.Matrix.DoublyStochastic
 import Mathlib.Tactic.Linarith
-import Mathlib.Analysis.Convex.Jensen
-import Mathlib.Analysis.Normed.Module.Convex
 
 /-!
 # Birkhoff's theorem

--- a/Mathlib/LinearAlgebra/Matrix/Permutation.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Permutation.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen
 -/
 
+import Mathlib.Analysis.CStarAlgebra.Matrix
 import Mathlib.Data.Matrix.PEquiv
 import Mathlib.Data.Set.Card
 import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
@@ -59,5 +60,39 @@ theorem trace_permutation [AddCommMonoidWithOne R] :
     trace (σ.permMatrix R) = (Function.fixedPoints σ).ncard := by
   delta trace
   simp [toPEquiv_apply, ← Set.ncard_coe_finset, Function.fixedPoints, Function.IsFixedPt]
+
+lemma permMatrix_mulVec {v : n → R} [CommRing R] :
+    σ.permMatrix R *ᵥ v = v ∘ σ := by
+  ext j
+  simp [mulVec_eq_sum, Pi.single, Function.update, Equiv.eq_symm_apply]
+
+lemma vecMul_permMatrix {v : n → R} [CommRing R] :
+    v ᵥ* σ.permMatrix R = v ∘ σ.symm := by
+  ext j
+  simp [vecMul_eq_sum, Pi.single, Function.update, ← Equiv.symm_apply_eq]
+
+open scoped Matrix.Norms.L2Operator
+
+variable {𝕜 : Type*} [RCLike 𝕜]
+
+/--
+The l2-operator norm of a permutation matrix is bounded above by 1.
+See `Matrix.permMatrix_l2_opNorm_eq` for the equality statement assuming the matrix is nonempty.
+-/
+theorem permMatrix_l2_opNorm_le : ‖σ.permMatrix 𝕜‖ ≤ 1 :=
+  ContinuousLinearMap.opNorm_le_bound _ (by simp) <| by
+    simp [EuclideanSpace.norm_eq, toEuclideanLin_apply, permMatrix_mulVec,
+      σ.sum_comp _ (fun i ↦ ‖_‖ ^ 2)]
+
+/--
+The l2-operator norm of a nonempty permutation matrix is equal to 1.
+Note that this is not true for the empty case, since the empty matrix has l2-operator norm 0.
+See `Matrix.permMatrix_l2_opNorm_le` for the inequality version of the empty case.
+-/
+theorem permMatrix_l2_opNorm_eq [Nonempty n] : ‖σ.permMatrix 𝕜‖ = 1 :=
+  le_antisymm (permMatrix_l2_opNorm_le σ) <| by
+    inhabit n
+    simpa [EuclideanSpace.norm_eq, permMatrix_mulVec, ← Equiv.eq_symm_apply, apply_ite] using
+      (σ.permMatrix 𝕜).l2_opNorm_mulVec (WithLp.toLp _ (Pi.single default 1))
 
 end Matrix


### PR DESCRIPTION
I chose to add the operator norm import to the permutation matrix and birkhoff files, since those ones are close to leaf files.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
