### PR TITLE
[Merged by Bors] - chore(Combinatorics): golf entire `ofColex_inj`, `homOfEq_heq` and `mem_supp_of_adj_mem_supp`. deprecate `tail_cons_eq`.

### DIFF
--- a/Mathlib/Combinatorics/Colex.lean
+++ b/Mathlib/Combinatorics/Colex.lean
@@ -83,7 +83,7 @@ instance : Inhabited (Colex α) := ⟨⟨∅⟩⟩
 lemma ofColex_toColex (s : Finset α) : ofColex (toColex s) = s := rfl
 lemma toColex_inj {s t : Finset α} : toColex s = toColex t ↔ s = t := by simp
 @[simp]
-lemma ofColex_inj {s t : Colex α} : ofColex s = ofColex t ↔ s = t := by cases s; cases t; simp
+lemma ofColex_inj {s t : Colex α} : ofColex s = ofColex t ↔ s = t := Colex.ext_iff.symm
 lemma toColex_ne_toColex {s t : Finset α} : toColex s ≠ toColex t ↔ s ≠ t := by simp
 lemma ofColex_ne_ofColex {s t : Colex α} : ofColex s ≠ ofColex t ↔ s ≠ t := by simp
 

--- a/Mathlib/Combinatorics/Quiver/Basic.lean
+++ b/Mathlib/Combinatorics/Quiver/Basic.lean
@@ -120,8 +120,7 @@ lemma eq_homOfEq_iff {X X' Y Y' : V} (f : X ⟶ Y) (g : X' ⟶ Y')
   subst hX hY; simp
 
 lemma homOfEq_heq {X Y X' Y' : V} (hX : X = X') (hY : Y = Y') (f : X ⟶ Y) :
-    homOfEq f hX hY ≍ f := by
-  cases hX; cases hY; rfl
+    homOfEq f hX hY ≍ f := (heq_of_homOfEq_ext hX hY rfl).symm
 
 lemma homOfEq_heq_left_iff {X Y X' Y' : V} (f : X ⟶ Y) (g : X' ⟶ Y')
     (hX : X = X') (hY : Y = Y') :

--- a/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Connectivity/Connected.lean
@@ -515,11 +515,7 @@ lemma reachable_of_mem_supp {G : SimpleGraph V} (C : G.ConnectedComponent) {u v 
   exact ConnectedComponent.exact (hv ▸ hu)
 
 lemma mem_supp_of_adj_mem_supp {G : SimpleGraph V} (C : G.ConnectedComponent) {u v : V}
-    (hu : u ∈ C.supp) (hadj : G.Adj u v) : v ∈ C.supp := by
-  have hC : G.connectedComponentMk u = G.connectedComponentMk v :=
-    connectedComponentMk_eq_of_adj hadj
-  rw [hu] at hC
-  exact hC.symm
+    (hu : u ∈ C.supp) (hadj : G.Adj u v) : v ∈ C.supp := (mem_supp_congr_adj C hadj).mp hu
 
 /--
 Given a connected component `C` of a simple graph `G`, produce the induced graph on `C`.

--- a/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Hamiltonian.lean
@@ -83,8 +83,8 @@ lemma IsHamiltonianCycle.map {H : SimpleGraph β} (f : G →g H) (hf : Bijective
     intro x
     rcases p with (_ | ⟨y, p⟩)
     · cases hp.ne_nil rfl
-    simp only [map_cons, getVert_cons_succ, tail_cons_eq, support_copy,support_map]
-    rw [List.count_map_of_injective _ _ hf.injective, ← support_copy, ← tail_cons_eq]
+    simp only [map_cons, getVert_cons_succ, tail_cons, support_copy,support_map]
+    rw [List.count_map_of_injective _ _ hf.injective, ← support_copy, ← tail_cons]
     exact hp.isHamiltonian_tail _
 
 lemma isHamiltonianCycle_isCycle_and_isHamiltonian_tail :

--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -1010,11 +1010,14 @@ lemma tail_nil : (@nil _ G v).tail = .nil := rfl
 @[simp]
 lemma tail_cons_nil (h : G.Adj u v) : (Walk.cons h .nil).tail = .nil := rfl
 
-lemma tail_cons_eq (h : G.Adj u v) (p : G.Walk v w) :
+@[simp]
+lemma tail_cons (h : G.Adj u v) (p : G.Walk v w) :
     (p.cons h).tail = p.copy (getVert_zero p).symm rfl := by
   match p with
   | .nil => rfl
   | .cons h q => rfl
+
+@[deprecated (since := "2025-08-19")] alias tail_cons_eq := tail_cons
 
 @[simp]
 lemma dropLast_nil : (@nil _ G v).dropLast = nil := rfl
@@ -1067,7 +1070,7 @@ lemma cons_tail_eq (p : G.Walk x y) (hp : ¬ p.Nil) :
   cases p with
   | nil => simp at hp
   | cons h q =>
-    simp only [getVert_cons_succ, tail_cons_eq, cons_copy, copy_rfl_rfl]
+    simp only [getVert_cons_succ, tail_cons, cons_copy, copy_rfl_rfl]
 
 @[simp]
 lemma concat_dropLast (p : G.Walk x y) (hp : G.Adj p.penultimate y) :
@@ -1099,10 +1102,6 @@ lemma not_nil_of_tail_not_nil {p : G.Walk v w} (hp : ¬ p.tail.Nil) : ¬ p.Nil :
     p.tail.support = p.support.tail := by
   rw [← cons_support_tail p hp, List.tail_cons]
 
-@[simp]
-lemma tail_cons {t u v} (p : G.Walk u v) (h : G.Adj t u) :
-    (p.cons h).tail = p.copy (getVert_zero p).symm rfl := tail_cons_eq h p
-
 lemma support_tail_of_not_nil (p : G.Walk u v) (hnp : ¬p.Nil) :
     p.tail.support = p.support.tail := by
   match p with
@@ -1133,7 +1132,7 @@ theorem exists_boundary_dart {u v : V} (p : G.Walk u v) (S : Set V) (uS : u ∈ 
   match p with
   | .nil => rfl
   | .cons h q =>
-    simp only [getVert_cons_succ, tail_cons_eq]
+    simp only [getVert_cons_succ, tail_cons]
     exact getVert_copy q n (getVert_zero q).symm rfl
 
 lemma ext_support {u v} {p q : G.Walk u v} (h : p.support = q.support) :

--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -1493,5 +1493,3 @@ lemma isSubwalk_antisymm {u v} {p₁ p₂ : G.Walk u v} (h₁ : p₁.IsSubwalk p
 end Walk
 
 end SimpleGraph
-
-set_option linter.style.longFile 1700

--- a/Mathlib/Combinatorics/SimpleGraph/Walk.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Walk.lean
@@ -1101,10 +1101,7 @@ lemma not_nil_of_tail_not_nil {p : G.Walk v w} (hp : ¬ p.tail.Nil) : ¬ p.Nil :
 
 @[simp]
 lemma tail_cons {t u v} (p : G.Walk u v) (h : G.Adj t u) :
-    (p.cons h).tail = p.copy (getVert_zero p).symm rfl := by
-  match p with
-  | .nil => rfl
-  | .cons h q => rfl
+    (p.cons h).tail = p.copy (getVert_zero p).symm rfl := tail_cons_eq h p
 
 lemma support_tail_of_not_nil (p : G.Walk u v) (hnp : ¬p.Nil) :
     p.tail.support = p.support.tail := by


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
