### PR TITLE
[Merged by Bors] - chore(Order): deprecate `Codisjoint.ne_bot_of_ne_top'`, `OrderEmbedding.{w,}covBy_of_apply` and `OrderIso.map_{w,}covBy`

### DIFF
--- a/Mathlib/Order/Cover.lean
+++ b/Mathlib/Order/Cover.lean
@@ -120,13 +120,9 @@ alias ⟨_, WCovBy.toDual⟩ := toDual_wcovBy_toDual_iff
 
 alias ⟨_, WCovBy.ofDual⟩ := ofDual_wcovBy_ofDual_iff
 
-theorem OrderEmbedding.wcovBy_of_apply {α β : Type*} [Preorder α] [Preorder β]
-    (f : α ↪o β) {x y : α} (h : f x ⩿ f y) : x ⩿ y :=
-  WCovBy.of_image f h
+@[deprecated (since := "2025-11-07")] alias OrderEmbedding.wcovBy_of_apply := WCovBy.of_image
 
-theorem OrderIso.map_wcovBy {α β : Type*} [Preorder α] [Preorder β]
-    (f : α ≃o β) {x y : α} : f x ⩿ f y ↔ x ⩿ y :=
-  apply_wcovBy_apply_iff f
+@[deprecated (since := "2025-11-07")] alias OrderIso.map_wcovBy := apply_wcovBy_apply_iff
 
 end Preorder
 
@@ -306,9 +302,7 @@ theorem covBy_of_eq_or_eq (hab : a < b) (h : ∀ c, a ≤ c → c ≤ b → c = 
 
 @[deprecated (since := "2025-11-07")] alias OrderEmbedding.covBy_of_apply := CovBy.of_image
 
-theorem OrderIso.map_covBy {α β : Type*} [Preorder α] [Preorder β]
-    (f : α ≃o β) {x y : α} : f x ⋖ f y ↔ x ⋖ y :=
-  apply_covBy_apply_iff f
+@[deprecated (since := "2025-11-07")] alias OrderIso.map_covBy := apply_covBy_apply_iff
 
 end Preorder
 

--- a/Mathlib/Order/Cover.lean
+++ b/Mathlib/Order/Cover.lean
@@ -121,17 +121,12 @@ alias ⟨_, WCovBy.toDual⟩ := toDual_wcovBy_toDual_iff
 alias ⟨_, WCovBy.ofDual⟩ := ofDual_wcovBy_ofDual_iff
 
 theorem OrderEmbedding.wcovBy_of_apply {α β : Type*} [Preorder α] [Preorder β]
-    (f : α ↪o β) {x y : α} (h : f x ⩿ f y) : x ⩿ y := by
-  use f.le_iff_le.1 h.1
-  intro a
-  rw [← f.lt_iff_lt, ← f.lt_iff_lt]
-  apply h.2
+    (f : α ↪o β) {x y : α} (h : f x ⩿ f y) : x ⩿ y :=
+  WCovBy.of_image f h
 
 theorem OrderIso.map_wcovBy {α β : Type*} [Preorder α] [Preorder β]
-    (f : α ≃o β) {x y : α} : f x ⩿ f y ↔ x ⩿ y := by
-  use f.toOrderEmbedding.wcovBy_of_apply
-  conv_lhs => rw [← f.symm_apply_apply x, ← f.symm_apply_apply y]
-  exact f.symm.toOrderEmbedding.wcovBy_of_apply
+    (f : α ≃o β) {x y : α} : f x ⩿ f y ↔ x ⩿ y :=
+  apply_wcovBy_apply_iff f
 
 end Preorder
 
@@ -310,17 +305,12 @@ theorem covBy_of_eq_or_eq (hab : a < b) (h : ∀ c, a ≤ c → c ≤ b → c = 
   ⟨hab, fun c ha hb => (h c ha.le hb.le).elim ha.ne' hb.ne⟩
 
 theorem OrderEmbedding.covBy_of_apply {α β : Type*} [Preorder α] [Preorder β]
-    (f : α ↪o β) {x y : α} (h : f x ⋖ f y) : x ⋖ y := by
-  use f.lt_iff_lt.1 h.1
-  intro a
-  rw [← f.lt_iff_lt, ← f.lt_iff_lt]
-  apply h.2
+    (f : α ↪o β) {x y : α} (h : f x ⋖ f y) : x ⋖ y :=
+  CovBy.of_image f h
 
 theorem OrderIso.map_covBy {α β : Type*} [Preorder α] [Preorder β]
-    (f : α ≃o β) {x y : α} : f x ⋖ f y ↔ x ⋖ y := by
-  use f.toOrderEmbedding.covBy_of_apply
-  conv_lhs => rw [← f.symm_apply_apply x, ← f.symm_apply_apply y]
-  exact f.symm.toOrderEmbedding.covBy_of_apply
+    (f : α ≃o β) {x y : α} : f x ⋖ f y ↔ x ⋖ y :=
+  apply_covBy_apply_iff f
 
 end Preorder
 

--- a/Mathlib/Order/Cover.lean
+++ b/Mathlib/Order/Cover.lean
@@ -304,9 +304,7 @@ theorem apply_covBy_apply_iff {E : Type*} [EquivLike E α β] [OrderIsoClass E �
 theorem covBy_of_eq_or_eq (hab : a < b) (h : ∀ c, a ≤ c → c ≤ b → c = a ∨ c = b) : a ⋖ b :=
   ⟨hab, fun c ha hb => (h c ha.le hb.le).elim ha.ne' hb.ne⟩
 
-theorem OrderEmbedding.covBy_of_apply {α β : Type*} [Preorder α] [Preorder β]
-    (f : α ↪o β) {x y : α} (h : f x ⋖ f y) : x ⋖ y :=
-  CovBy.of_image f h
+@[deprecated (since := "2025-11-07")] alias OrderEmbedding.covBy_of_apply := CovBy.of_image
 
 theorem OrderIso.map_covBy {α β : Type*} [Preorder α] [Preorder β]
     (f : α ≃o β) {x y : α} : f x ⋖ f y ↔ x ⋖ y :=

--- a/Mathlib/Order/Disjoint.lean
+++ b/Mathlib/Order/Disjoint.lean
@@ -268,6 +268,7 @@ theorem bot_codisjoint : Codisjoint ⊥ a ↔ a = ⊤ :=
 lemma Codisjoint.ne_bot_of_ne_top (h : Codisjoint a b) (ha : a ≠ ⊤) : b ≠ ⊥ := by
   rintro rfl; exact ha <| by simpa using h
 
+@[deprecated ne_bot_of_ne_top (since := "2025-11-07")]
 lemma Codisjoint.ne_bot_of_ne_top' (h : Codisjoint a b) (hb : b ≠ ⊤) : a ≠ ⊥ :=
   ne_bot_of_ne_top h.symm hb
 

--- a/Mathlib/Order/Disjoint.lean
+++ b/Mathlib/Order/Disjoint.lean
@@ -268,8 +268,8 @@ theorem bot_codisjoint : Codisjoint ⊥ a ↔ a = ⊤ :=
 lemma Codisjoint.ne_bot_of_ne_top (h : Codisjoint a b) (ha : a ≠ ⊤) : b ≠ ⊥ := by
   rintro rfl; exact ha <| by simpa using h
 
-lemma Codisjoint.ne_bot_of_ne_top' (h : Codisjoint a b) (hb : b ≠ ⊤) : a ≠ ⊥ := by
-  rintro rfl; exact hb <| by simpa using h
+lemma Codisjoint.ne_bot_of_ne_top' (h : Codisjoint a b) (hb : b ≠ ⊤) : a ≠ ⊥ :=
+  ne_bot_of_ne_top h.symm hb
 
 end PartialBoundedOrder
 

--- a/Mathlib/Order/Interval/Set/SuccPred.lean
+++ b/Mathlib/Order/Interval/Set/SuccPred.lean
@@ -66,8 +66,8 @@ lemma insert_Icc_succ_left_eq_Icc (h : a ≤ b) : insert a (Icc (succ a) b) = Ic
   ext x; simp [or_and_left, eq_comm, ← le_iff_eq_or_succ_le]; aesop
 
 lemma insert_Icc_right_eq_Icc_succ (h : a ≤ succ b) :
-    insert (succ b) (Icc a b) = Icc a (succ b) := by
-  ext x; simp [or_and_left, le_succ_iff_eq_or_le]; simp_all
+    insert (succ b) (Icc a b) = Icc a (succ b) :=
+  (Icc_succ_right h).symm
 
 lemma insert_Ico_right_eq_Ico_succ_of_not_isMax (h : a ≤ b) (hb : ¬ IsMax b) :
     insert b (Ico a b) = Ico a (succ b) := by
@@ -147,8 +147,8 @@ lemma insert_Icc_pred_right_eq_Icc (h : a ≤ b) : insert b (Icc a (pred b)) = I
   ext x; simp [or_and_left, ← le_iff_eq_or_le_pred]; simp_all
 
 lemma insert_Icc_left_eq_Icc_pred (h : pred a ≤ b) :
-    insert (pred a) (Icc a b) = Icc (pred a) b := by
-  ext x; simp [or_and_left, pred_le_iff_eq_or_le]; simp_all
+    insert (pred a) (Icc a b) = Icc (pred a) b :=
+  (Icc_pred_left h).symm
 
 lemma insert_Ioc_left_eq_Ioc_pred_of_not_isMin (h : a ≤ b) (ha : ¬ IsMin a) :
     insert a (Ioc a b) = Ioc (pred a) b := by

--- a/Mathlib/Order/Interval/Set/SuccPred.lean
+++ b/Mathlib/Order/Interval/Set/SuccPred.lean
@@ -66,8 +66,8 @@ lemma insert_Icc_succ_left_eq_Icc (h : a ≤ b) : insert a (Icc (succ a) b) = Ic
   ext x; simp [or_and_left, eq_comm, ← le_iff_eq_or_succ_le]; aesop
 
 lemma insert_Icc_right_eq_Icc_succ (h : a ≤ succ b) :
-    insert (succ b) (Icc a b) = Icc a (succ b) :=
-  (Icc_succ_right h).symm
+    insert (succ b) (Icc a b) = Icc a (succ b) := by
+  ext x; simp [or_and_left, le_succ_iff_eq_or_le]; simp_all
 
 lemma insert_Ico_right_eq_Ico_succ_of_not_isMax (h : a ≤ b) (hb : ¬ IsMax b) :
     insert b (Ico a b) = Ico a (succ b) := by
@@ -147,8 +147,8 @@ lemma insert_Icc_pred_right_eq_Icc (h : a ≤ b) : insert b (Icc a (pred b)) = I
   ext x; simp [or_and_left, ← le_iff_eq_or_le_pred]; simp_all
 
 lemma insert_Icc_left_eq_Icc_pred (h : pred a ≤ b) :
-    insert (pred a) (Icc a b) = Icc (pred a) b :=
-  (Icc_pred_left h).symm
+    insert (pred a) (Icc a b) = Icc (pred a) b := by
+  ext x; simp [or_and_left, pred_le_iff_eq_or_le]; simp_all
 
 lemma insert_Ioc_left_eq_Ioc_pred_of_not_isMin (h : a ≤ b) (ha : ¬ IsMin a) :
     insert a (Ioc a b) = Ioc (pred a) b := by

--- a/Mathlib/Order/SuccPred/Basic.lean
+++ b/Mathlib/Order/SuccPred/Basic.lean
@@ -346,7 +346,7 @@ theorem _root_.OrderIso.map_succ [PartialOrder β] [SuccOrder β] (f : α ≃o �
     f (succ a) = succ (f a) := by
   by_cases h : IsMax a
   · rw [h.succ_eq, (f.isMax_apply.2 h).succ_eq]
-  · exact (f.map_covBy.2 <| covBy_succ_of_not_isMax h).succ_eq.symm
+  · exact ((apply_covBy_apply_iff f).2 <| covBy_succ_of_not_isMax h).succ_eq.symm
 
 section NoMaxOrder
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
