### PR TITLE
[Merged by Bors] - chore(RingTheory): golf entire `smul_eq_zero_of_mem`, `hasEval`, `eq_of_prod_eq_prod` and `isIntegral_of_mem_ringOfIntegers`

### DIFF
--- a/Mathlib/RingTheory/Extension/Basic.lean
+++ b/Mathlib/RingTheory/Extension/Basic.lean
@@ -300,10 +300,8 @@ variable (x y : P.Cotangent) (w z : P.ker.Cotangent)
 end Cotangent
 
 lemma Cotangent.smul_eq_zero_of_mem (p : P.Ring) (hp : p ∈ P.ker) (m : P.ker.Cotangent) :
-    p • m = 0 := by
-  obtain ⟨x, rfl⟩ := Ideal.toCotangent_surjective _ m
-  rw [← map_smul, Ideal.toCotangent_eq_zero, Submodule.coe_smul, smul_eq_mul, pow_two]
-  exact Ideal.mul_mem_mul hp x.2
+    p • m = 0 :=
+  Ideal.Cotangent.smul_eq_zero_of_mem hp m
 
 attribute [local simp] RingHom.mem_ker
 

--- a/Mathlib/RingTheory/PowerSeries/Substitution.lean
+++ b/Mathlib/RingTheory/PowerSeries/Substitution.lean
@@ -50,10 +50,7 @@ theorem hasSubst_iff_hasEval_of_discreteTopology
     Function.const_def]
 
 theorem HasSubst.hasEval [TopologicalSpace S] {a : MvPowerSeries τ S} (ha : HasSubst a) :
-    HasEval a := by
-  rw [hasEval_iff]
-  apply MvPowerSeries.HasSubst.hasEval
-  simpa [hasSubst_iff] using ha
+    HasEval a := isTopologicallyNilpotent_of_constantCoeff_isNilpotent ha
 
 theorem HasSubst.of_constantCoeff_zero {a : MvPowerSeries τ S}
     (ha : MvPowerSeries.constantCoeff a = 0) : HasSubst a := by

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/FactorSet.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/FactorSet.lean
@@ -259,13 +259,12 @@ theorem eq_of_factors_eq_factors {a b : Associates α} (h : a.factors = b.factor
   have : a.factors.prod = b.factors.prod := by rw [h]
   rwa [factors_prod, factors_prod] at this
 
-theorem eq_of_prod_eq_prod [Nontrivial α] {a b : FactorSet α} (h : a.prod = b.prod) : a = b :=
-  FactorSet.unique h
+@[deprecated (since := "2025-10-06")] alias eq_of_prod_eq_prod := FactorSet.unique
 
 @[simp]
 theorem factors_mul (a b : Associates α) : (a * b).factors = a.factors + b.factors := by
   nontriviality α
-  refine eq_of_prod_eq_prod <| eq_of_factors_eq_factors ?_
+  refine FactorSet.unique <| eq_of_factors_eq_factors ?_
   rw [prod_add, factors_prod, factors_prod, factors_prod]
 
 @[gcongr]
@@ -432,12 +431,12 @@ theorem coprime_iff_inf_one {a b : α} (ha0 : a ≠ 0) (hb0 : b ≠ 0) :
 
 theorem factors_self [Nontrivial α] {p : Associates α} (hp : Irreducible p) :
     p.factors = WithTop.some {⟨p, hp⟩} :=
-  eq_of_prod_eq_prod
+  FactorSet.unique
     (by rw [factors_prod, FactorSet.prod.eq_def]; dsimp; rw [prod_singleton])
 
 theorem factors_prime_pow [Nontrivial α] {p : Associates α} (hp : Irreducible p) (k : ℕ) :
     factors (p ^ k) = WithTop.some (Multiset.replicate k ⟨p, hp⟩) :=
-  eq_of_prod_eq_prod
+  FactorSet.unique
     (by
       rw [Associates.factors_prod, FactorSet.prod.eq_def]
       dsimp; rw [Multiset.map_replicate, Multiset.prod_replicate, Subtype.coe_mk])
@@ -451,7 +450,7 @@ theorem prime_pow_le_iff_le_bcount [DecidableEq (Associates α)] {m p : Associat
 
 @[simp]
 theorem factors_one [Nontrivial α] : factors (1 : Associates α) = 0 := by
-  apply eq_of_prod_eq_prod
+  apply FactorSet.unique
   rw [Associates.factors_prod]
   exact Multiset.prod_zero
 

--- a/Mathlib/RingTheory/UniqueFactorizationDomain/FactorSet.lean
+++ b/Mathlib/RingTheory/UniqueFactorizationDomain/FactorSet.lean
@@ -259,9 +259,8 @@ theorem eq_of_factors_eq_factors {a b : Associates α} (h : a.factors = b.factor
   have : a.factors.prod = b.factors.prod := by rw [h]
   rwa [factors_prod, factors_prod] at this
 
-theorem eq_of_prod_eq_prod [Nontrivial α] {a b : FactorSet α} (h : a.prod = b.prod) : a = b := by
-  have : a.prod.factors = b.prod.factors := by rw [h]
-  rwa [prod_factors, prod_factors] at this
+theorem eq_of_prod_eq_prod [Nontrivial α] {a b : FactorSet α} (h : a.prod = b.prod) : a = b :=
+  FactorSet.unique h
 
 @[simp]
 theorem factors_mul (a b : Associates α) : (a * b).factors = a.factors + b.factors := by

--- a/Mathlib/RingTheory/Valuation/AlgebraInstances.lean
+++ b/Mathlib/RingTheory/Valuation/AlgebraInstances.lean
@@ -36,11 +36,8 @@ theorem algebraMap_injective : Injective (algebraMap v.valuationSubring L) :=
   (FaithfulSMul.algebraMap_injective K L).comp (IsFractionRing.injective _ _)
 
 theorem isIntegral_of_mem_ringOfIntegers {x : L} (hx : x ∈ integralClosure v.valuationSubring L) :
-    IsIntegral v.valuationSubring (⟨x, hx⟩ : integralClosure v.valuationSubring L) := by
-  obtain ⟨P, hPm, hP⟩ := hx
-  refine ⟨P, hPm, ?_⟩
-  rw [← Polynomial.aeval_def, ← Subalgebra.coe_eq_zero, Polynomial.aeval_subalgebra_coe,
-    Polynomial.aeval_def, Subtype.coe_mk, hP]
+    IsIntegral v.valuationSubring (⟨x, hx⟩ : integralClosure v.valuationSubring L) :=
+  integralClosure.isIntegral ⟨x, hx⟩
 
 theorem isIntegral_of_mem_ringOfIntegers' {x : (integralClosure v.valuationSubring L)} :
     IsIntegral v.valuationSubring (x : integralClosure v.valuationSubring L) := by


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
