### PR TITLE
[Merged by Bors] - feat(CategoryTheory): weaken assumptions for the stability of the left lifting property under transfinite compositions

### DIFF
--- a/Mathlib/CategoryTheory/LiftingProperties/Basic.lean
+++ b/Mathlib/CategoryTheory/LiftingProperties/Basic.lean
@@ -168,4 +168,16 @@ lemma hasLiftingProperty_iff {A B X Y : C} (i : A ⟶ B) (p : X ⟶ Y) :
 
 end Arrow
 
+/-- Given morphisms `i : A ⟶ B`, `p : X ⟶ Y`, `t : A ⟶ X`,
+this is the property that a lifting exists for all squares
+with `i` on left, `p` on the right and `t` on the top. -/
+def HasLiftingPropertyFixedTop (t : A ⟶ X) : Prop :=
+  ∀ (b : B ⟶ Y) (sq : CommSq t i p b), sq.HasLift
+
+/-- Given morphisms `i : A ⟶ B`, `p : X ⟶ Y`, `b : B ⟶ Y`,
+this is the property that a lifting exists for all squares
+with `i` on left, `p` on the right and `b` on the bottom. -/
+def HasLiftingPropertyFixedBot (b : B ⟶ Y) : Prop :=
+  ∀ (t : A ⟶ X) (sq : CommSq t i p b), sq.HasLift
+
 end CategoryTheory

--- a/Mathlib/CategoryTheory/SmallObject/TransfiniteCompositionLifting.lean
+++ b/Mathlib/CategoryTheory/SmallObject/TransfiniteCompositionLifting.lean
@@ -183,13 +183,18 @@ lemma map_lift {i : J} (hij : i < j) :
 end wellOrderInductionData
 
 variable {p} [SuccOrder J] [WellFoundedLT J]
-  (hF : ∀ (j : J) (_ : ¬IsMax j), HasLiftingProperty (F.map (homOfLE (Order.le_succ j))) p)
+
+section
+
+variable (hF : ∀ (j : J) (_ : ¬IsMax j),
+  HasLiftingPropertyFixedBot (F.map (homOfLE (Order.le_succ j))) p (c.ι.app _ ≫ g))
 
 open wellOrderInductionData in
 /-- The projective system `sqFunctor c p f g` has a `WellOrderInductionData` structure. -/
 noncomputable def wellOrderInductionData :
     (sqFunctor c p f g).WellOrderInductionData where
   succ j hj sq' :=
+    have := hF j hj sq'.f'
     have := hF j hj
     { f' := sq'.sq.lift
       w₁ := by
@@ -219,8 +224,17 @@ lemma hasLift : sq.HasLift := by
     fac_left := by rw [hl, hs]
     fac_right := hc.hom_ext (fun j ↦ by rw [reassoc_of% (hl j), SqStruct.w₂])}⟩⟩
 
+lemma hasLiftingPropertyFixedBot_ι_app_bot : HasLiftingPropertyFixedBot (c.ι.app ⊥) p g :=
+  fun _ sq ↦ hasLift hc hF sq
+
+end
+
+variable {c} (hF : ∀ (j : J) (_ : ¬IsMax j),
+  HasLiftingProperty (F.map (homOfLE (Order.le_succ j))) p)
+
+include hc hF
 lemma hasLiftingProperty_ι_app_bot : HasLiftingProperty (c.ι.app ⊥) p where
-  sq_hasLift sq := hasLift hc hF sq
+  sq_hasLift sq := hasLift hc (fun j hj _ _ ↦ by have := hF j hj; infer_instance) sq
 
 end transfiniteComposition
 


### PR DESCRIPTION
This PR introduces two predicates `HasLiftingPropertyFixedBot/Top` which assert the existence of a lifting in squares when the left/right/top (resp. left/right/bottom) morphisms are fixed. (This weakens the `HasLiftingProperty` class which assumes there is a lifting when we only fix the left and right morphisms.)
The `HasLiftingPropertyFixedTop` variant shall be used in the study of the homotopy theory of Kan complexes. The `HasLiftingPropertyFixedBot` variant will be used in the formalization of the model category structure on simplicial sets: this is the reason why this PR also weakens the assumptions in the proof that the left lifting property with respect to certain morphisms is stable under transfinite composition.

---

In https://github.com/joelriou/topcat-model-category/blob/c3fe37ef7a2f6bfa48c4b989aec12bbab25784b1/TopCatModelCategory/TopCat/SerreFibrationLocal.lean#L314 the content of this PR is used in an essential way in order to show that the property that a continuous map `E ⟶ B` is a Serre fibration is local on the base (this still depends on a `sorry`).

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
