### PR TITLE
[Merged by Bors] - feat: topological affine spaces

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -6269,6 +6269,7 @@ import Mathlib.Topology.Algebra.ContinuousMonoidHom
 import Mathlib.Topology.Algebra.Equicontinuity
 import Mathlib.Topology.Algebra.Field
 import Mathlib.Topology.Algebra.FilterBasis
+import Mathlib.Topology.Algebra.Group.AddTorsor
 import Mathlib.Topology.Algebra.Group.Basic
 import Mathlib.Topology.Algebra.Group.ClosedSubgroup
 import Mathlib.Topology.Algebra.Group.Compact

--- a/Mathlib/Analysis/Normed/Group/AddTorsor.lean
+++ b/Mathlib/Analysis/Normed/Group/AddTorsor.lean
@@ -7,10 +7,8 @@ import Mathlib.Analysis.Normed.Group.Constructions
 import Mathlib.Analysis.Normed.Group.Submodule
 import Mathlib.LinearAlgebra.AffineSpace.AffineSubspace.Basic
 import Mathlib.LinearAlgebra.AffineSpace.Midpoint
-import Mathlib.Topology.Algebra.MulAction
+import Mathlib.Topology.Algebra.Group.AddTorsor
 import Mathlib.Topology.MetricSpace.IsometricSMul
-import Mathlib.Topology.Metrizable.Uniformity
-import Mathlib.Topology.Sequences
 
 /-!
 # Torsors of additive normed group actions.
@@ -225,43 +223,9 @@ theorem uniformContinuous_vadd : UniformContinuous fun x : V × P => x.1 +ᵥ x.
 theorem uniformContinuous_vsub : UniformContinuous fun x : P × P => x.1 -ᵥ x.2 :=
   (LipschitzWith.prod_fst.vsub LipschitzWith.prod_snd).uniformContinuous
 
-instance (priority := 100) NormedAddTorsor.to_continuousVAdd : ContinuousVAdd V P where
+instance (priority := 100) : IsTopologicalAddTorsor P where
   continuous_vadd := uniformContinuous_vadd.continuous
-
-theorem continuous_vsub : Continuous fun x : P × P => x.1 -ᵥ x.2 :=
-  uniformContinuous_vsub.continuous
-
-theorem Filter.Tendsto.vsub {l : Filter α} {f g : α → P} {x y : P} (hf : Tendsto f l (𝓝 x))
-    (hg : Tendsto g l (𝓝 y)) : Tendsto (f -ᵥ g) l (𝓝 (x -ᵥ y)) :=
-  (continuous_vsub.tendsto (x, y)).comp (hf.prodMk_nhds hg)
-
-section
-
-variable [TopologicalSpace α]
-
-@[fun_prop]
-theorem Continuous.vsub {f g : α → P} (hf : Continuous f) (hg : Continuous g) :
-    Continuous (fun x ↦ f x -ᵥ g x) :=
-  continuous_vsub.comp₂ hf hg
-
-@[fun_prop]
-nonrec theorem ContinuousAt.vsub {f g : α → P} {x : α} (hf : ContinuousAt f x)
-    (hg : ContinuousAt g x) :
-    ContinuousAt (fun x ↦ f x -ᵥ g x) x :=
-  hf.vsub hg
-
-@[fun_prop]
-nonrec theorem ContinuousWithinAt.vsub {f g : α → P} {x : α} {s : Set α}
-    (hf : ContinuousWithinAt f s x) (hg : ContinuousWithinAt g s x) :
-    ContinuousWithinAt (fun x ↦ f x -ᵥ g x) s x :=
-  hf.vsub hg
-
-@[fun_prop]
-theorem ContinuousOn.vsub {f g : α → P} {s : Set α} (hf : ContinuousOn f s)
-    (hg : ContinuousOn g s) : ContinuousOn (fun x ↦ f x -ᵥ g x) s := fun x hx ↦
-  (hf x hx).vsub (hg x hx)
-
-end
+  continuous_vsub := uniformContinuous_vsub.continuous
 
 section
 
@@ -278,21 +242,3 @@ theorem Filter.Tendsto.midpoint [Invertible (2 : R)] {l : Filter α} {f₁ f₂ 
   h₁.lineMap h₂ tendsto_const_nhds
 
 end
-
-section Pointwise
-
-open Pointwise
-
-theorem IsClosed.vadd_right_of_isCompact {s : Set V} {t : Set P} (hs : IsClosed s)
-    (ht : IsCompact t) : IsClosed (s +ᵥ t) := by
-  -- This result is still true for any `AddTorsor` where `-ᵥ` is continuous,
-  -- but we don't yet have a nice way to state it.
-  refine IsSeqClosed.isClosed (fun u p husv hup ↦ ?_)
-  choose! a ha v hv hav using husv
-  rcases ht.isSeqCompact hv with ⟨q, hqt, φ, φ_mono, hφq⟩
-  refine ⟨p -ᵥ q, hs.mem_of_tendsto ((hup.comp φ_mono.tendsto_atTop).vsub hφq)
-    (Eventually.of_forall fun n ↦ ?_), q, hqt, vsub_vadd _ _⟩
-  convert ha (φ n) using 1
-  exact (eq_vadd_iff_vsub_eq _ _ _).mp (hav (φ n)).symm
-
-end Pointwise

--- a/Mathlib/Analysis/Normed/Group/AddTorsor.lean
+++ b/Mathlib/Analysis/Normed/Group/AddTorsor.lean
@@ -223,7 +223,7 @@ theorem uniformContinuous_vadd : UniformContinuous fun x : V × P => x.1 +ᵥ x.
 theorem uniformContinuous_vsub : UniformContinuous fun x : P × P => x.1 -ᵥ x.2 :=
   (LipschitzWith.prod_fst.vsub LipschitzWith.prod_snd).uniformContinuous
 
-instance (priority := 100) : IsTopologicalAddTorsor P where
+instance : IsTopologicalAddTorsor P where
   continuous_vadd := uniformContinuous_vadd.continuous
   continuous_vsub := uniformContinuous_vsub.continuous
 

--- a/Mathlib/Topology/Algebra/Group/AddTorsor.lean
+++ b/Mathlib/Topology/Algebra/Group/AddTorsor.lean
@@ -1,0 +1,140 @@
+/-
+Copyright (c) 2025 Attila Gáspár. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Attila Gáspár
+-/
+import Mathlib.Algebra.AddTorsor.Basic
+import Mathlib.Topology.Algebra.Group.Pointwise
+
+/-!
+# Topological torsors of additive groups
+
+This file defines topological torsors of additive groups and proves some basic results.
+-/
+
+open Topology
+
+section AddTorsor
+
+variable {V P α : Type*} [AddGroup V] [TopologicalSpace V] [AddTorsor V P] [TopologicalSpace P]
+
+variable (P) in
+/-- A topological torsor over a topological additive group is a torsor where `+ᵥ` and `-ᵥ` are
+continuous. -/
+class IsTopologicalAddTorsor extends ContinuousVAdd V P where
+  continuous_vsub : Continuous (fun x : P × P => x.1 -ᵥ x.2)
+
+export IsTopologicalAddTorsor (continuous_vsub)
+
+attribute [fun_prop] continuous_vsub
+
+variable [IsTopologicalAddTorsor P]
+
+theorem Filter.Tendsto.vsub {l : Filter α} {f g : α → P} {x y : P} (hf : Tendsto f l (𝓝 x))
+    (hg : Tendsto g l (𝓝 y)) : Tendsto (f -ᵥ g) l (𝓝 (x -ᵥ y)) :=
+  (continuous_vsub.tendsto (x, y)).comp (hf.prodMk_nhds hg)
+
+variable [TopologicalSpace α]
+
+@[fun_prop]
+theorem Continuous.vsub {f g : α → P} (hf : Continuous f) (hg : Continuous g) :
+    Continuous (fun x ↦ f x -ᵥ g x) :=
+  continuous_vsub.comp₂ hf hg
+
+@[fun_prop]
+nonrec theorem ContinuousAt.vsub {f g : α → P} {x : α} (hf : ContinuousAt f x)
+    (hg : ContinuousAt g x) :
+    ContinuousAt (fun x ↦ f x -ᵥ g x) x :=
+  hf.vsub hg
+
+@[fun_prop]
+nonrec theorem ContinuousWithinAt.vsub {f g : α → P} {x : α} {s : Set α}
+    (hf : ContinuousWithinAt f s x) (hg : ContinuousWithinAt g s x) :
+    ContinuousWithinAt (fun x ↦ f x -ᵥ g x) s x :=
+  hf.vsub hg
+
+@[fun_prop]
+theorem ContinuousOn.vsub {f g : α → P} {s : Set α} (hf : ContinuousOn f s)
+    (hg : ContinuousOn g s) : ContinuousOn (fun x ↦ f x -ᵥ g x) s := fun x hx ↦
+  (hf x hx).vsub (hg x hx)
+
+include P in
+variable (V P) in
+/-- The underlying group of a topological torsor is a topological group. This is not an instance, as
+`P` cannot be inferred. -/
+theorem IsTopologicalAddTorsor.to_isTopologicalAddGroup : IsTopologicalAddGroup V where
+  continuous_add := by
+    have ⟨p⟩ : Nonempty P := inferInstance
+    conv =>
+      enter [1, x]
+      equals (x.1 +ᵥ x.2 +ᵥ p) -ᵥ p => rw [vadd_vadd, vadd_vsub]
+    fun_prop
+  continuous_neg := by
+    have ⟨p⟩ : Nonempty P := inferInstance
+    conv =>
+      enter [1, v]
+      equals p -ᵥ (v +ᵥ p) => rw [vsub_vadd_eq_vsub_sub, vsub_self, zero_sub]
+    fun_prop
+
+/-- The map `v ↦ v +ᵥ p` as a homeomorphism between `V` and `P`. -/
+@[simps!]
+def Homeomorph.vaddConst (p : P) : V ≃ₜ P where
+  __ := Equiv.vaddConst p
+  continuous_toFun := by fun_prop
+  continuous_invFun := by fun_prop
+
+section Pointwise
+
+open Pointwise
+
+theorem IsClosed.vadd_right_of_isCompact {s : Set V} {t : Set P} (hs : IsClosed s)
+    (ht : IsCompact t) : IsClosed (s +ᵥ t) := by
+  have ⟨p⟩ : Nonempty P := inferInstance
+  have cont : Continuous (· -ᵥ p) := by fun_prop
+  have := IsTopologicalAddTorsor.to_isTopologicalAddGroup V P
+  convert (hs.add_right_of_isCompact <| ht.image cont).preimage cont
+  rw [Set.eq_preimage_iff_image_eq <| by exact (Equiv.vaddConst p).symm.bijective,
+    ← Set.image2_vadd, Set.image_image2, ← Set.image2_add, Set.image2_image_right]
+  simp only [vadd_vsub_assoc]
+
+end Pointwise
+
+end AddTorsor
+
+section AddGroup
+
+variable {G : Type*} [AddGroup G] [TopologicalSpace G] [IsTopologicalAddGroup G]
+
+instance : IsTopologicalAddTorsor G where
+  toContinuousVAdd := inferInstance
+  continuous_vsub := by simp only [vsub_eq_sub, sub_eq_add_neg]; fun_prop
+
+end AddGroup
+
+section Prod
+
+variable
+  {V W P Q : Type*}
+  [AddCommGroup V] [TopologicalSpace V]
+  [AddTorsor V P] [TopologicalSpace P] [IsTopologicalAddTorsor P]
+  [AddCommGroup W] [TopologicalSpace W]
+  [AddTorsor W Q] [TopologicalSpace Q] [IsTopologicalAddTorsor Q]
+
+instance : IsTopologicalAddTorsor (P × Q) where
+  continuous_vadd := Continuous.prodMk (by fun_prop) (by fun_prop)
+  continuous_vsub := Continuous.prodMk (by fun_prop) (by fun_prop)
+
+end Prod
+
+section Pi
+
+variable
+  {ι : Type*} {V P : ι → Type*}
+  [∀ i, AddCommGroup (V i)] [∀ i, TopologicalSpace (V i)]
+  [∀ i, AddTorsor (V i) (P i)] [∀ i, TopologicalSpace (P i)] [∀ i, IsTopologicalAddTorsor (P i)]
+
+instance : IsTopologicalAddTorsor ((i : ι) → P i) where
+  continuous_vadd := continuous_pi <| by simp only [Pi.vadd_apply']; fun_prop
+  continuous_vsub := continuous_pi <| by simp only [Pi.vsub_apply]; fun_prop
+
+end Pi

--- a/Mathlib/Topology/Algebra/Group/AddTorsor.lean
+++ b/Mathlib/Topology/Algebra/Group/AddTorsor.lean
@@ -9,7 +9,8 @@ import Mathlib.Topology.Algebra.Group.Pointwise
 /-!
 # Topological torsors of additive groups
 
-This file defines topological torsors of additive groups and proves some basic results.
+This file defines topological torsors of additive groups, that is, torsors where `+ᵥ` and `-ᵥ` are
+continuous.
 -/
 
 open Topology
@@ -106,8 +107,7 @@ section AddGroup
 variable {G : Type*} [AddGroup G] [TopologicalSpace G] [IsTopologicalAddGroup G]
 
 instance : IsTopologicalAddTorsor G where
-  toContinuousVAdd := inferInstance
-  continuous_vsub := by simp only [vsub_eq_sub, sub_eq_add_neg]; fun_prop
+  continuous_vsub := by simp only [vsub_eq_sub]; fun_prop
 
 end AddGroup
 

--- a/Mathlib/Topology/Algebra/Group/Pointwise.lean
+++ b/Mathlib/Topology/Algebra/Group/Pointwise.lean
@@ -74,9 +74,8 @@ To fix the proof, we would need to make two additional assumptions:
 - for any `x ∈ t`, there is a continuous function `g : s • {x} → s` such that, for all
   `y ∈ s • {x}`, we have `y = (g y) • x`
 These are fairly specific hypotheses so we don't state this version of the lemmas, but an
-interesting fact is that these two assumptions are verified in the case of a `NormedAddTorsor`
-(or really, any `AddTorsor` with continuous `-ᵥ`). We prove this special case in
-`IsClosed.vadd_right_of_isCompact`. -/
+interesting fact is that these two assumptions are verified in the case of an
+`IsTopologicalAddTorsor`. We prove this special case in `IsClosed.vadd_right_of_isCompact`. -/
 
 @[to_additive]
 theorem MulAction.isClosedMap_quotient [CompactSpace α] :


### PR DESCRIPTION
This PR adds a typeclass `IsTopologicalAddTorsor` for topological affine spaces and generalizes basic results which currently assume `NormedAddTorsor`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
