### PR TITLE
feat(Data/Set): show the `Alternative` instance on `Set` is lawful

### DIFF
--- a/Mathlib/Data/Set/Functor.lean
+++ b/Mathlib/Data/Set/Functor.lean
@@ -7,6 +7,7 @@ import Mathlib.Control.Basic
 import Mathlib.Data.Set.Defs
 import Mathlib.Data.Set.Lattice.Image
 import Mathlib.Data.Set.Notation
+import Batteries.Control.AlternativeMonad
 
 /-!
 # Functoriality of `Set`
@@ -76,6 +77,23 @@ instance : Alternative Set :=
     orElse := fun s t => s ∪ (t ())
     failure := ∅ }
 
+@[simp]
+theorem failure_def : (failure : Set α) = ∅ :=
+  rfl
+
+@[simp]
+theorem orElse_def (s : Set α) (t : Set α) : (s <|> t) = s ∪ t :=
+  rfl
+
+instance : LawfulAlternative Set where
+  map_failure f := by simp
+  failure_seq := by simp [Set.ext_iff]
+  orElse_failure := by simp
+  failure_orElse := by simp
+  orElse_assoc x y z := by simp [Set.union_assoc]
+  map_orElse x y f := by simp [Set.image_union]
+  __ := inferInstanceAs (LawfulMonad Set)
+
 /-! ### Monadic coercion lemmas -/
 
 variable {β : Set α} {γ : Set β}
@@ -135,6 +153,13 @@ end Set
 def SetM (α : Type u) := Set α
 
 instance : Monad SetM := Set.monad
+
+instance : AlternativeMonad SetM where
+  __ := Set.instAlternative
+
+instance : LawfulMonad SetM := Set.instLawfulMonad
+
+instance : LawfulAlternative SetM := Set.instLawfulAlternative
 
 /-- Evaluates the `SetM` monad, yielding a `Set`.
 Implementation note: this is the identity function. -/


### PR DESCRIPTION
This PR adds a `LawfulAlternative` instance for `Set`, and also exposes the lawful instances for `SetM`.
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
