### PR TITLE
[Merged by Bors] - feat: add priority to hint tactics

### DIFF
--- a/Mathlib/Tactic/Common.lean
+++ b/Mathlib/Tactic/Common.lean
@@ -127,20 +127,20 @@ import hierarchy.
 -/
 
 /-!
-# Register tactics with `hint`. Tactics are tried in reverse registration order.
+# Register tactics with `hint`. Tactics with larger priority run first.
 -/
 
 section Hint
 
-register_hint grind
-register_hint trivial
-register_hint tauto
-register_hint split
-register_hint intro
-register_hint aesop
-register_hint simp_all?
-register_hint exact?
-register_hint decide
-register_hint omega
+register_hint (priority := 200) grind
+register_hint (priority := 1000) trivial
+register_hint (priority := 500) tauto
+register_hint (priority := 1000) split
+register_hint (priority := 1000) intro
+register_hint (priority := 80) aesop
+register_hint (priority := 800) simp_all?
+register_hint (priority := 600) exact?
+register_hint (priority := 1000) decide
+register_hint (priority := 200) omega
 
 end Hint

--- a/Mathlib/Tactic/Hint.lean
+++ b/Mathlib/Tactic/Hint.lean
@@ -24,7 +24,6 @@ open Lean.Meta.Tactic.TryThis
 
 namespace Mathlib.Tactic.Hint
 
-
 /-- An environment extension for registering hint tactics with priorities. -/
 initialize hintExtension :
     SimplePersistentEnvExtension (Nat × TSyntax `tactic) (List (Nat × TSyntax `tactic)) ←
@@ -32,7 +31,6 @@ initialize hintExtension :
     addEntryFn := (·.cons)
     addImportedFn := mkStateFromImportedEntries (·.cons) {}
   }
-
 
 /-- Register a new hint tactic. -/
 def addHint (prio : Nat) (stx : TSyntax `tactic) : CoreM Unit := do
@@ -43,7 +41,6 @@ def getHints : CoreM (List (Nat × TSyntax `tactic)) :=
   return hintExtension.getState (← getEnv)
 
 open Lean.Elab.Command in
-
 /--
 Register a tactic for use with the `hint` tactic, e.g. `register_hint simp_all`.
 An optional priority can be provided with `register_hint (priority := n) tac`.

--- a/Mathlib/Tactic/Hint.lean
+++ b/Mathlib/Tactic/Hint.lean
@@ -24,28 +24,44 @@ open Lean.Meta.Tactic.TryThis
 
 namespace Mathlib.Tactic.Hint
 
-/-- An environment extension for registering hint tactics. -/
-initialize hintExtension : SimplePersistentEnvExtension (TSyntax `tactic) (List (TSyntax `tactic)) ←
+
+/-- An environment extension for registering hint tactics with priorities. -/
+initialize hintExtension :
+    SimplePersistentEnvExtension (Nat × TSyntax `tactic) (List (Nat × TSyntax `tactic)) ←
   registerSimplePersistentEnvExtension {
     addEntryFn := (·.cons)
     addImportedFn := mkStateFromImportedEntries (·.cons) {}
   }
 
+
 /-- Register a new hint tactic. -/
-def addHint (stx : TSyntax `tactic) : CoreM Unit := do
-  modifyEnv fun env => hintExtension.addEntry env stx
+def addHint (prio : Nat) (stx : TSyntax `tactic) : CoreM Unit := do
+  modifyEnv fun env => hintExtension.addEntry env (prio, stx)
 
 /-- Return the list of registered hint tactics. -/
-def getHints : CoreM (List (TSyntax `tactic)) := return hintExtension.getState (← getEnv)
+def getHints : CoreM (List (Nat × TSyntax `tactic)) :=
+  return hintExtension.getState (← getEnv)
 
 open Lean.Elab.Command in
+
 /--
 Register a tactic for use with the `hint` tactic, e.g. `register_hint simp_all`.
+An optional priority can be provided with `register_hint (priority := n) tac`.
+Tactics with larger priorities run before those with smaller priorities. The default
+priority is `1000`.
 -/
-elab (name := registerHintStx) "register_hint" tac:tactic : command => liftTermElabM do
+elab (name := registerHintStx)
+    "register_hint" p:("(" "priority" ":=" num ")")? tac:tactic : command =>
+    liftTermElabM do
   -- remove comments
+  let prio := match p with
+    | some stx =>
+        match stx.raw[3]?.bind Syntax.isNatLit? with
+        | some n => n
+        | none => 1000
+    | none => 1000
   let tac : TSyntax `tactic := ⟨tac.raw.copyHeadTailInfoFrom .missing⟩
-  addHint tac
+  addHint prio tac
 
 initialize
   Batteries.Linter.UnreachableTactic.ignoreTacticKindsRef.modify fun s => s.insert ``registerHintStx
@@ -100,7 +116,8 @@ If one tactic succeeds and closes the goal, we don't look at subsequent tactics.
 -- TODO With widget support, could we run the tactics in parallel
 --      and do live updates of the widget as results come in?
 def hint (stx : Syntax) : TacticM Unit := withMainContext do
-  let tacs := Nondet.ofList (← getHints)
+  let tacs := (← getHints).toArray.qsort (·.1 > ·.1) |>.toList.map (·.2)
+  let tacs := Nondet.ofList tacs
   let results := tacs.filterMapM fun t : TSyntax `tactic => do
     if let some msgs ← observing? (withMessageLog (withoutInfoTrees (evalTactic t))) then
       if msgs.hasErrors then

--- a/Mathlib/Tactic/Linarith.lean
+++ b/Mathlib/Tactic/Linarith.lean
@@ -11,4 +11,4 @@ import Mathlib.Tactic.Hint
 We register `linarith` with the `hint` tactic.
 -/
 
-register_hint linarith
+register_hint (priority := 100) linarith


### PR DESCRIPTION
- add optional priority to `register_hint`
- order hints by priority before execution
- annotate built-in hints with relative priorities

------
https://chatgpt.com/codex/tasks/task_e_68a01241678c832197538441361beb55