### PR TITLE
[Merged by Bors] - fix: allow build steps to access timezone

### DIFF
--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -43,7 +43,7 @@ jobs:
       test-outcome: ${{ steps.test.outcome }}
     defaults: # On Hoskinson runners, landrun is already installed.
       run:
-        shell: landrun --rox /usr --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT -- bash -euxo pipefail {0}
+        shell: landrun --rox /usr --ro /etc/timezone --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT -- bash -euxo pipefail {0}
     steps:
       - name: cleanup
         shell: bash    # This *just* deletes old files, so is safe to run outside landrun.
@@ -61,10 +61,6 @@ jobs:
           else
               : # Do nothing on failure, but suppress errors
           fi
-
-      - name: Setup timezone
-        # This is needed so we can use Lean's date library to lint deprecated attributes
-        uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
 
       # The Hoskinson runners may not have jq installed, so do that now.
       - name: 'Setup jq'

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Setup timezone
         # This is needed so we can use Lean's date library to lint deprecated attributes
-        uses: szenius/set-timezone@v2.0
+        uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
 
       # The Hoskinson runners may not have jq installed, so do that now.
       - name: 'Setup jq'

--- a/.github/build.in.yml
+++ b/.github/build.in.yml
@@ -62,6 +62,10 @@ jobs:
               : # Do nothing on failure, but suppress errors
           fi
 
+      - name: Setup timezone
+        # This is needed so we can use Lean's date library to lint deprecated attributes
+        uses: szenius/set-timezone@v2.0
+
       # The Hoskinson runners may not have jq installed, so do that now.
       - name: 'Setup jq'
         uses: dcarbone/install-jq-action@f0e10f46ff84f4d32178b4b76e1ef180b16f82c3 # v3.1.1

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -53,7 +53,7 @@ jobs:
       test-outcome: ${{ steps.test.outcome }}
     defaults: # On Hoskinson runners, landrun is already installed.
       run:
-        shell: landrun --rox /usr --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT -- bash -euxo pipefail {0}
+        shell: landrun --rox /usr --ro /etc/timezone --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT -- bash -euxo pipefail {0}
     steps:
       - name: cleanup
         shell: bash    # This *just* deletes old files, so is safe to run outside landrun.
@@ -71,10 +71,6 @@ jobs:
           else
               : # Do nothing on failure, but suppress errors
           fi
-
-      - name: Setup timezone
-        # This is needed so we can use Lean's date library to lint deprecated attributes
-        uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
 
       # The Hoskinson runners may not have jq installed, so do that now.
       - name: 'Setup jq'

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Setup timezone
         # This is needed so we can use Lean's date library to lint deprecated attributes
-        uses: szenius/set-timezone@v2.0
+        uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
 
       # The Hoskinson runners may not have jq installed, so do that now.
       - name: 'Setup jq'

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -72,6 +72,10 @@ jobs:
               : # Do nothing on failure, but suppress errors
           fi
 
+      - name: Setup timezone
+        # This is needed so we can use Lean's date library to lint deprecated attributes
+        uses: szenius/set-timezone@v2.0
+
       # The Hoskinson runners may not have jq installed, so do that now.
       - name: 'Setup jq'
         uses: dcarbone/install-jq-action@f0e10f46ff84f4d32178b4b76e1ef180b16f82c3 # v3.1.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,10 @@ jobs:
               : # Do nothing on failure, but suppress errors
           fi
 
+      - name: Setup timezone
+        # This is needed so we can use Lean's date library to lint deprecated attributes
+        uses: szenius/set-timezone@v2.0
+
       # The Hoskinson runners may not have jq installed, so do that now.
       - name: 'Setup jq'
         uses: dcarbone/install-jq-action@f0e10f46ff84f4d32178b4b76e1ef180b16f82c3 # v3.1.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Setup timezone
         # This is needed so we can use Lean's date library to lint deprecated attributes
-        uses: szenius/set-timezone@v2.0
+        uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
 
       # The Hoskinson runners may not have jq installed, so do that now.
       - name: 'Setup jq'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
       test-outcome: ${{ steps.test.outcome }}
     defaults: # On Hoskinson runners, landrun is already installed.
       run:
-        shell: landrun --rox /usr --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT -- bash -euxo pipefail {0}
+        shell: landrun --rox /usr --ro /etc/timezone --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT -- bash -euxo pipefail {0}
     steps:
       - name: cleanup
         shell: bash    # This *just* deletes old files, so is safe to run outside landrun.
@@ -78,10 +78,6 @@ jobs:
           else
               : # Do nothing on failure, but suppress errors
           fi
-
-      - name: Setup timezone
-        # This is needed so we can use Lean's date library to lint deprecated attributes
-        uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
 
       # The Hoskinson runners may not have jq installed, so do that now.
       - name: 'Setup jq'

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -57,7 +57,7 @@ jobs:
       test-outcome: ${{ steps.test.outcome }}
     defaults: # On Hoskinson runners, landrun is already installed.
       run:
-        shell: landrun --rox /usr --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT -- bash -euxo pipefail {0}
+        shell: landrun --rox /usr --ro /etc/timezone --rw /dev --rox /home/lean/.elan --rox /home/lean/actions-runner/_work --rox /home/lean/.cache/mathlib/ --rw pr-branch/.lake/ --env PATH --env HOME --env GITHUB_OUTPUT -- bash -euxo pipefail {0}
     steps:
       - name: cleanup
         shell: bash    # This *just* deletes old files, so is safe to run outside landrun.
@@ -75,10 +75,6 @@ jobs:
           else
               : # Do nothing on failure, but suppress errors
           fi
-
-      - name: Setup timezone
-        # This is needed so we can use Lean's date library to lint deprecated attributes
-        uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
 
       # The Hoskinson runners may not have jq installed, so do that now.
       - name: 'Setup jq'

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Setup timezone
         # This is needed so we can use Lean's date library to lint deprecated attributes
-        uses: szenius/set-timezone@v2.0
+        uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
 
       # The Hoskinson runners may not have jq installed, so do that now.
       - name: 'Setup jq'

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -76,6 +76,10 @@ jobs:
               : # Do nothing on failure, but suppress errors
           fi
 
+      - name: Setup timezone
+        # This is needed so we can use Lean's date library to lint deprecated attributes
+        uses: szenius/set-timezone@v2.0
+
       # The Hoskinson runners may not have jq installed, so do that now.
       - name: 'Setup jq'
         uses: dcarbone/install-jq-action@f0e10f46ff84f4d32178b4b76e1ef180b16f82c3 # v3.1.1


### PR DESCRIPTION
## Problem

The deprecated attribute linter was failing with timezone database errors:
```
unable to locate share/zoneinfo in the local timezone database at /etc/localtime
```

This was happening because the linter uses `Std.Time.PlainDate.now` to compare dates, which requires timezone information.

## Solution

Add `-ro /etc/timezone` to `landrun` shell options.

## Changes

- Add timezone permissions to `shell` in `.github/build.in.yml`
- Regenerated all build workflow files (`build.yml`, `bors.yml`, `build_fork.yml`)

This should fix the deprecated attribute linter failures in CI.