### PR TITLE
[Merged by Bors] - fix(LinearAlgebra/Dimension/ErdosKaplansky): authorship

### DIFF
--- a/Mathlib/LinearAlgebra/Dimension/ErdosKaplansky.lean
+++ b/Mathlib/LinearAlgebra/Dimension/ErdosKaplansky.lean
@@ -1,8 +1,7 @@
 /-
-Copyright (c) 2018 Mario Carneiro. All rights reserved.
+Copyright (c) 2023 Junyan Xu. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Mario Carneiro, Johannes Hölzl, Sander Dahmen,
-Kim Morrison, Chris Hughes, Anne Baanen, Junyan Xu
+Authors: Junyan Xu
 -/
 import Mathlib.Algebra.Field.Opposite
 import Mathlib.LinearAlgebra.Basis.VectorSpace
@@ -11,8 +10,6 @@ import Mathlib.SetTheory.Cardinal.Subfield
 
 /-!
 # Erdős-Kaplansky theorem
-
-For modules over a division ring, we have
 
 * `rank_dual_eq_card_dual_of_aleph0_le_rank`: The **Erdős-Kaplansky Theorem** which says that
   the dimension of an infinite-dimensional dual space over a division ring has dimension


### PR DESCRIPTION
See https://github.com/leanprover-community/mathlib4/pull/19827#discussion_r1929553441

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
