### PR TITLE
[Merged by Bors] - doc(grw): fix example in doc-string

### DIFF
--- a/Mathlib/Tactic/GRewrite/Elab.lean
+++ b/Mathlib/Tactic/GRewrite/Elab.lean
@@ -60,16 +60,17 @@ declare_config_elab elabGRewriteConfig GRewrite.Config
 
 For example,
 ```lean
+variable {a b c d n : ℤ}
+
 example (h₁ : a < b) (h₂ : b ≤ c) : a + d ≤ c + d := by
   grewrite [h₁, h₂]; rfl
 
 example (h : a ≡ b [ZMOD n]) : a ^ 2 ≡ b ^ 2 [ZMOD n] := by
   grewrite [h]; rfl
 
-example : (h₁ : a ∣ b) (h₂ : c ∣ a * d) : a ∣ b * d := by
-  grewrite [h₁]
+example (h₁ : a ∣ b) (h₂ : b ∣ a ^ 2 * c) : a ∣ b ^ 2 * c := by
+  grewrite [h₁] at *
   exact h₂
-
 ```
 To be able to use `grewrite`, the relevant lemmas need to be tagged with `@[gcongr]`.
 To rewrite inside a transitive relation, you can also give it an `IsTrans` instance.
@@ -90,21 +91,22 @@ syntax (name := grewriteSeq) "grewrite" optConfig rwRuleSeq (location)? : tactic
 
 For example,
 ```lean
+variable {a b c d n : ℤ}
+
 example (h₁ : a < b) (h₂ : b ≤ c) : a + d ≤ c + d := by
   grw [h₁, h₂]
 
 example (h : a ≡ b [ZMOD n]) : a ^ 2 ≡ b ^ 2 [ZMOD n] := by
   grw [h]
 
-example : (h₁ : a ∣ b) (h₂ : c ∣ a * d) : a ∣ b * d := by
-  grw [h₁]
+example (h₁ : a ∣ b) (h₂ : b ∣ a ^ 2 * c) : a ∣ b ^ 2 * c := by
+  grw [h₁] at *
   exact h₂
-
 ```
 To be able to use `grw`, the relevant lemmas need to be tagged with `@[gcongr]`.
 To rewrite inside a transitive relation, you can also give it an `IsTrans` instance.
 -/
-macro (name := rwSeq) "grw " c:optConfig s:rwRuleSeq l:(location)? : tactic =>
+macro (name := grwSeq) "grw " c:optConfig s:rwRuleSeq l:(location)? : tactic =>
   match s with
   | `(rwRuleSeq| [$rs,*]%$rbrak) =>
     -- We show the `rfl` state on `]`

--- a/MathlibTest/GRewrite.lean
+++ b/MathlibTest/GRewrite.lean
@@ -153,6 +153,14 @@ example {a b : ℤ} (h1 : a ≡ 3 [ZMOD 5]) (h2 : b ≡ a ^ 2 + 1 [ZMOD 5]) :
 
 end modeq
 
+section dvd
+
+example {a b c : ℤ} (h₁ : a ∣ b) (h₂ : b ∣ a ^ 2 * c) : a ∣ b ^ 2 * c := by
+  grw [h₁] at *
+  exact h₂
+
+end dvd
+
 section wildcard
 
 /-! Rewriting at a wildcard `*`, i.e. `grw [h] at *`, will sometimes include a rewrite at `h` itself
@@ -303,3 +311,12 @@ example : ∃ n, n < 2 := by
   on_goal 2 => grw [← one_lt_two]
   exact 0
   refine zero_lt_one
+
+variable {a b c d n : ℤ}
+
+example (h : a ≡ b [ZMOD n]) : a ^ 2 ≡ b ^ 2 [ZMOD n] := by
+  grw [h]
+
+example (h₁ : a ∣ b) (h₂ : b ∣ a * d) : a ∣ b * d := by
+  grw [h₁] at h₂ ⊢
+  exact h₂


### PR DESCRIPTION
This PR fixes an example in the `grw` doc-string, and adds a test for it in the test file. This example only works as of recently, as the relevant `gcongr` lemmas have only now been tagged.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
