### PR TITLE
[Merged by Bors] - chore(Topology/MetricSpace/Ultra): deprecate `mem_ball_iff` and `mem_closedBall_iff` (duplicates)

### DIFF
--- a/Mathlib/Topology/MetricSpace/Ultra/Basic.lean
+++ b/Mathlib/Topology/MetricSpace/Ultra/Basic.lean
@@ -71,13 +71,7 @@ lemma ball_eq_of_mem {x y : X} {r : ℝ} (h : y ∈ ball x r) : ball x r = ball 
   constructor <;> intro h' <;>
   exact (dist_triangle_max _ _ _).trans_lt (max_lt h' (dist_comm x _ ▸ h))
 
-lemma mem_ball_iff {x y : X} {r : ℝ} : y ∈ ball x r ↔ x ∈ ball y r := by
-  cases lt_or_ge 0 r with
-  | inl hr =>
-    constructor <;> intro h <;>
-    rw [← ball_eq_of_mem h] <;>
-    simp [hr]
-  | inr hr => simp [ball_eq_empty.mpr hr]
+@[deprecated (since := "2025-08-16")] alias mem_ball_iff := mem_ball_comm
 
 lemma ball_subset_trichotomy :
     ball x r ⊆ ball y s ∨ ball y s ⊆ ball x r ∨ Disjoint (ball x r) (ball y s) := by
@@ -103,14 +97,7 @@ lemma closedBall_eq_of_mem {x y : X} {r : ℝ} (h : y ∈ closedBall x r) :
   constructor <;> intro h' <;>
   exact (dist_triangle_max _ _ _).trans (max_le h' (dist_comm x _ ▸ h))
 
-lemma mem_closedBall_iff {x y : X} {r : ℝ} :
-    y ∈ closedBall x r ↔ x ∈ closedBall y r := by
-  cases le_or_gt 0 r with
-  | inl hr =>
-    constructor <;> intro h <;>
-    rw [← closedBall_eq_of_mem h] <;>
-    simp [hr]
-  | inr hr => simp [closedBall_eq_empty.mpr hr]
+@[deprecated (since := "2025-08-16")] alias mem_closedBall_iff := mem_closedBall_comm
 
 lemma closedBall_subset_trichotomy :
     closedBall x r ⊆ closedBall y s ∨ closedBall y s ⊆ closedBall x r ∨


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
