### PR TITLE
[Merged by Bors] - fix(RingTheory/Ideal): quick fix Oka.lean

### DIFF
--- a/Mathlib/RingTheory/Ideal/Oka.lean
+++ b/Mathlib/RingTheory/Ideal/Oka.lean
@@ -8,13 +8,13 @@ import Mathlib.RingTheory.Ideal.Colon
 /-!
 # Oka predicates
 
-This file introduces the notion of oka predicates and standard results about them.
+This file introduces the notion of Oka predicates and standard results about them.
 
 ## Main results
 
-- `Ideal.IsOka.isPrime_of_maximal_not_isOka`: if an ideal is maximal for not satisfying an oka
-  predicate then it is prime.
-- `Ideal.IsOka.forall_of_forall_prime`: if all prime ideals of a ring satisfy an oka predicate,
+- `Ideal.IsOka.isPrime_of_maximal_not`: if an ideal is maximal for not satisfying an Oka predicate,
+  then it is prime.
+- `Ideal.IsOka.forall_of_forall_prime`: if all prime ideals of a ring satisfy an Oka predicate,
   then all its ideals also satisfy the predicate.
 
 ## References
@@ -39,9 +39,9 @@ namespace IsOka
 
 variable {P : Ideal R → Prop}
 
-/-- If an ideal is maximal for not satisfying an oka predicate then it is prime. -/
+/-- If an ideal is maximal for not satisfying an Oka predicate then it is prime. -/
 @[stacks 05KE]
-theorem isPrime_of_maximal_not_isOka (hP : IsOka P) {I : Ideal R}
+theorem isPrime_of_maximal_not (hP : IsOka P) {I : Ideal R}
     (hI : Maximal (¬P ·) I) : I.IsPrime where
   ne_top' hI' := hI.prop (hI' ▸ hP.top)
   mem_or_mem' := by
@@ -52,13 +52,13 @@ theorem isPrime_of_maximal_not_isOka (hP : IsOka P) {I : Ideal R}
       (fun H ↦ hb <| H ▸ mem_colon_singleton.2 (mul_comm a b ▸ hab))
     exact hI.prop (hP.oka h₁ h₂)
 
-/-- If all prime ideals of a ring satisfy an oka predicate, then all its ideals also satisfy the
+/-- If all prime ideals of a ring satisfy an Oka predicate, then all its ideals also satisfy the
 predicate. `hmax` is generaly obtained using Zorn's lemma. -/
 theorem forall_of_forall_prime (hP : IsOka P)
     (hmax : (∃ I, ¬P I) → ∃ I, Maximal (¬P ·) I) (hprime : ∀ I, I.IsPrime → P I) : ∀ I, P I := by
   by_contra!
   obtain ⟨I, hI⟩ := hmax this
-  exact hI.prop <| hprime I (hP.isPrime_of_maximal_not_isOka hI)
+  exact hI.prop <| hprime I (hP.isPrime_of_maximal_not hI)
 
 end IsOka
 

--- a/Mathlib/RingTheory/Ideal/Oka.lean
+++ b/Mathlib/RingTheory/Ideal/Oka.lean
@@ -42,14 +42,15 @@ variable {P : Ideal R → Prop}
 /-- If an ideal is maximal for not satisfying an oka predicate then it is prime. -/
 @[stacks 05KE]
 theorem isPrime_of_maximal_not_isOka (hP : IsOka P) {I : Ideal R}
-    (hI : Maximal (¬P ·) I) : I.IsPrime := by
-  by_contra h
-  have I_ne_top : I ≠ ⊤ := fun hI' ↦ hI.prop (hI' ▸ hP.top)
-  obtain ⟨a, ha, b, hb, hab⟩ := (not_isPrime_iff.1 h).resolve_left I_ne_top
-  have h₁ : P (I ⊔ span {a}) := of_not_not <| hI.not_prop_of_gt (Submodule.lt_sup_iff_notMem.2 ha)
-  have h₂ : P (I.colon (span {a})) := of_not_not <| hI.not_prop_of_gt <| lt_of_le_of_ne le_colon
-    (fun H ↦ hb <| H ▸ mem_colon_singleton.2 (mul_comm a b ▸ hab))
-  exact hI.prop (hP.oka h₁ h₂)
+    (hI : Maximal (¬P ·) I) : I.IsPrime where
+  ne_top' hI' := hI.prop (hI' ▸ hP.top)
+  mem_or_mem' := by
+    by_contra!
+    obtain ⟨a, b, hab, ha, hb⟩ := this
+    have h₁ : P (I ⊔ span {a}) := of_not_not <| hI.not_prop_of_gt (Submodule.lt_sup_iff_notMem.2 ha)
+    have h₂ : P (I.colon (span {a})) := of_not_not <| hI.not_prop_of_gt <| lt_of_le_of_ne le_colon
+      (fun H ↦ hb <| H ▸ mem_colon_singleton.2 (mul_comm a b ▸ hab))
+    exact hI.prop (hP.oka h₁ h₂)
 
 /-- If all prime ideals of a ring satisfy an oka predicate, then all its ideals also satisfy the
 predicate. `hmax` is generaly obtained using Zorn's lemma. -/

--- a/Mathlib/RingTheory/Ideal/Oka.lean
+++ b/Mathlib/RingTheory/Ideal/Oka.lean
@@ -60,11 +60,6 @@ theorem forall_of_forall_prime (hP : IsOka P)
   obtain ⟨I, hI⟩ := hmax this
   exact hI.prop <| hprime I (hP.isPrime_of_maximal_not_isOka hI)
 
-@[deprecated forall_of_forall_prime (since := "2025-08-16")]
-theorem forall_of_forall_prime_isOka (hP : IsOka P)
-    (hmax : (∃ I, ¬P I) → ∃ I, Maximal (¬P ·) I) (hprime : ∀ I, I.IsPrime → P I) : ∀ I, P I :=
-  forall_of_forall_prime hP hmax hprime
-
 end IsOka
 
 end Ideal

--- a/Mathlib/RingTheory/Ideal/Oka.lean
+++ b/Mathlib/RingTheory/Ideal/Oka.lean
@@ -12,10 +12,10 @@ This file introduces the notion of oka predicates and standard results about the
 
 ## Main results
 
-- `Ideal.isPrime_of_maximal_not_isOka`: if an ideal is maximal for not satisfying an oka predicate
-  then it is prime.
-- `IsOka.forall_of_forall_prime`: if all prime ideals of a ring satisfy an oka predicate, then all
-  its ideals also satisfy the predicate.
+- `Ideal.IsOka.isPrime_of_maximal_not_isOka`: if an ideal is maximal for not satisfying an oka
+  predicate then it is prime.
+- `Ideal.IsOka.forall_of_forall_prime`: if all prime ideals of a ring satisfy an oka predicate,
+  then all its ideals also satisfy the predicate.
 
 ## References
 
@@ -53,11 +53,16 @@ theorem isPrime_of_maximal_not_isOka (hP : IsOka P) {I : Ideal R}
 
 /-- If all prime ideals of a ring satisfy an oka predicate, then all its ideals also satisfy the
 predicate. `hmax` is generaly obtained using Zorn's lemma. -/
-theorem forall_of_forall_prime_isOka (hP : IsOka P)
+theorem forall_of_forall_prime (hP : IsOka P)
     (hmax : (∃ I, ¬P I) → ∃ I, Maximal (¬P ·) I) (hprime : ∀ I, I.IsPrime → P I) : ∀ I, P I := by
   by_contra!
   obtain ⟨I, hI⟩ := hmax this
   exact hI.prop <| hprime I (hP.isPrime_of_maximal_not_isOka hI)
+
+@[deprecated forall_of_forall_prime (since := "2025-08-16")]
+theorem forall_of_forall_prime_isOka (hP : IsOka P)
+    (hmax : (∃ I, ¬P I) → ∃ I, Maximal (¬P ·) I) (hprime : ∀ I, I.IsPrime → P I) : ∀ I, P I :=
+  forall_of_forall_prime hP hmax hprime
 
 end IsOka
 


### PR DESCRIPTION
I just noticed a naming discrepancy between the doc and the actual name of results in `Oka.lean` that I missed in #27200.

The deprecation may not *really* be necessary since the theorem was added yesterday but better be safe.

This PR is also the occasion to clean a little bit the proof of `IsOka.isPrime_of_maximal_not_isOka`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
