### PR TITLE
feat(Combinatorics/SimplicialComplex/Topology): add standard simplices and geometric realisation (colimit + functoriality)

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2869,6 +2869,7 @@ import Mathlib.Combinatorics.SimpleGraph.Turan
 import Mathlib.Combinatorics.SimpleGraph.Tutte
 import Mathlib.Combinatorics.SimpleGraph.UniversalVerts
 import Mathlib.Combinatorics.SimpleGraph.Walk
+import Mathlib.Combinatorics.SimplicialComplex.Basic
 import Mathlib.Combinatorics.Young.SemistandardTableau
 import Mathlib.Combinatorics.Young.YoungDiagram
 import Mathlib.Computability.Ackermann

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2870,6 +2870,7 @@ import Mathlib.Combinatorics.SimpleGraph.Tutte
 import Mathlib.Combinatorics.SimpleGraph.UniversalVerts
 import Mathlib.Combinatorics.SimpleGraph.Walk
 import Mathlib.Combinatorics.SimplicialComplex.Basic
+import Mathlib.Combinatorics.SimplicialComplex.Hom
 import Mathlib.Combinatorics.Young.SemistandardTableau
 import Mathlib.Combinatorics.Young.YoungDiagram
 import Mathlib.Computability.Ackermann

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2871,6 +2871,7 @@ import Mathlib.Combinatorics.SimpleGraph.UniversalVerts
 import Mathlib.Combinatorics.SimpleGraph.Walk
 import Mathlib.Combinatorics.SimplicialComplex.Basic
 import Mathlib.Combinatorics.SimplicialComplex.Category
+import Mathlib.Combinatorics.SimplicialComplex.FacePoset
 import Mathlib.Combinatorics.SimplicialComplex.Hom
 import Mathlib.Combinatorics.Young.SemistandardTableau
 import Mathlib.Combinatorics.Young.YoungDiagram

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2873,6 +2873,13 @@ import Mathlib.Combinatorics.SimplicialComplex.Basic
 import Mathlib.Combinatorics.SimplicialComplex.Category
 import Mathlib.Combinatorics.SimplicialComplex.FacePoset
 import Mathlib.Combinatorics.SimplicialComplex.Hom
+import Mathlib.Combinatorics.SimplicialComplex.Topology.GeomReal.Basic
+import Mathlib.Combinatorics.SimplicialComplex.Topology.GeomReal.Colimit
+import Mathlib.Combinatorics.SimplicialComplex.Topology.GeomReal.Diagram
+import Mathlib.Combinatorics.SimplicialComplex.Topology.GeomReal.Functor
+import Mathlib.Combinatorics.SimplicialComplex.Topology.GeomReal.Map
+import Mathlib.Combinatorics.SimplicialComplex.Topology.Simplex
+import Mathlib.Combinatorics.SimplicialComplex.Topology.SimplexMap
 import Mathlib.Combinatorics.Young.SemistandardTableau
 import Mathlib.Combinatorics.Young.YoungDiagram
 import Mathlib.Computability.Ackermann

--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -2870,6 +2870,7 @@ import Mathlib.Combinatorics.SimpleGraph.Tutte
 import Mathlib.Combinatorics.SimpleGraph.UniversalVerts
 import Mathlib.Combinatorics.SimpleGraph.Walk
 import Mathlib.Combinatorics.SimplicialComplex.Basic
+import Mathlib.Combinatorics.SimplicialComplex.Category
 import Mathlib.Combinatorics.SimplicialComplex.Hom
 import Mathlib.Combinatorics.Young.SemistandardTableau
 import Mathlib.Combinatorics.Young.YoungDiagram

--- a/Mathlib/Combinatorics/SimplicialComplex/Basic.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Basic.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2025 Sebastian Kumar, Xiangyu Li. All rights
+reserved. Released under Apache 2.0 license as described in the file
+LICENSE.
+Authors: Sebastian Kumar, Xiangyu Li
+-/
+import Mathlib.Data.Finset.Image
+
+/-!
+# Simplicial complexes
+
+This file introduces finite (abstract) simplicial complexes in a purely combinatorial form.
+
+A simplicial complex on a vertex type `V` is a downward-closed set of finite subsets of `V`
+(its *faces*).
+
+Only the basic structure and elementary remarks appear here. Morphisms, categorical bundling,
+and geometric realisation are handled in later files.
+
+## Main definitions
+
+* `SimplicialComplex V` :
+  a structure with `faces : Set (Finset V)` which is closed under taking subsets.
+* `Face X` :
+  the subtype of faces of a given complex `X` (i.e. `Finset V` equipped with the proof
+  that it lies in `X.faces`).
+
+## Implementation notes
+
+* We do not assume that the empty face belongs to `faces`; if a later development
+  requires this, it should be added as an extra hypothesis.
+* We do not require singletons to be a face.
+
+## References
+
+* <https://en.wikipedia.org/wiki/Simplicial_complex>
+
+## Tags
+
+simplicial complex, combinatorial topology
+-/
+
+open Function
+
+universe u
+
+/-- A simplicial complex on a vertex type `V` is a downward‑closed family
+of finite vertex sets (faces). -/
+@[ext] structure SimplicialComplex (V : Type u) where
+  /-- The collection of faces (finite vertex sets). -/
+  faces : Set (Finset V)
+  /-- Downward closure: every subset of a face is again a face. -/
+  downward_closed :
+    ∀ ⦃s t : Finset V⦄, s ∈ faces → t ⊆ s → t ∈ faces
+
+namespace SimplicialComplex
+
+variable {V : Type u}
+
+/-- A face of `X` (as a subtype). -/
+abbrev Face (X : SimplicialComplex V) := {A : Finset V // A ∈ X.faces}
+
+end SimplicialComplex

--- a/Mathlib/Combinatorics/SimplicialComplex/Basic.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Basic.lean
@@ -1,7 +1,6 @@
 /-
-Copyright (c) 2025 Sebastian Kumar, Xiangyu Li. All rights
-reserved. Released under Apache 2.0 license as described in the file
-LICENSE.
+Copyright (c) 2025 Sebastian Kumar, Xiangyu Li. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sebastian Kumar, Xiangyu Li
 -/
 import Mathlib.Data.Finset.Image

--- a/Mathlib/Combinatorics/SimplicialComplex/Basic.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2025 Sebastian Kumar, Xiangyu Li. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sebastian Kumar, Xiangyu Li
 -/
-import Mathlib.Data.Finset.Image
+import Mathlib.Data.Finset.Defs
 
 /-!
 # Simplicial complexes

--- a/Mathlib/Combinatorics/SimplicialComplex/Basic.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2025 Sebastian Kumar, Xiangyu Li. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sebastian Kumar, Xiangyu Li
 -/
-import Mathlib.Data.Finset.Defs
+import Mathlib.Data.Finset.Image
 
 /-!
 # Simplicial complexes
@@ -21,18 +21,14 @@ and geometric realisation are handled in later files.
 * `SimplicialComplex V` :
   a structure with `faces : Set (Finset V)` which is closed under taking subsets.
 * `Face X` :
-  the subtype of faces of a given complex `X` (i.e. `Finset V` equipped with the proof
-  that it lies in `X.faces`).
+  the subtype of nonempty faces of a given complex `X` (i.e. `Finset V` equipped with the proof
+  that it lies in `X.faces` and is nonempty).
 
 ## Implementation notes
 
 * We do not assume that the empty face belongs to `faces`; if a later development
   requires this, it should be added as an extra hypothesis.
 * We do not require singletons to be a face.
-
-## References
-
-* <https://en.wikipedia.org/wiki/Simplicial_complex>
 
 ## Tags
 
@@ -51,12 +47,3 @@ of finite vertex sets (faces). -/
   /-- Downward closure: every subset of a face is again a face. -/
   downward_closed :
     ∀ ⦃s t : Finset V⦄, s ∈ faces → t ⊆ s → t ∈ faces
-
-namespace SimplicialComplex
-
-variable {V : Type u}
-
-/-- A face of `X` (as a subtype). -/
-abbrev Face (X : SimplicialComplex V) := {A : Finset V // A ∈ X.faces}
-
-end SimplicialComplex

--- a/Mathlib/Combinatorics/SimplicialComplex/Category.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Category.lean
@@ -5,7 +5,6 @@ Authors: Xiangyu Li
 -/
 import Mathlib.Combinatorics.SimplicialComplex.Hom
 import Mathlib.CategoryTheory.Iso
-import Mathlib.CategoryTheory.ConcreteCategory.Basic
 
 /-!
 # The category of simplicial complexes (with varying vertex types)

--- a/Mathlib/Combinatorics/SimplicialComplex/Category.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Category.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Xiangyu Li. All rights.
+Copyright (c) 2025 Xiangyu Li. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Xiangyu Li
 -/

--- a/Mathlib/Combinatorics/SimplicialComplex/Category.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Category.lean
@@ -1,0 +1,134 @@
+/-
+Copyright (c) 2025 Xiangyu Li. All rights.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Xiangyu Li
+-/
+import Mathlib.Combinatorics.SimplicialComplex.Hom
+import Mathlib.CategoryTheory.Iso
+import Mathlib.CategoryTheory.ConcreteCategory.Basic
+
+/-!
+# The category of simplicial complexes (with varying vertex types)
+
+We build a category whose objects are pairs `(U, X)` with a type of vertices `U`
+equipped with `[DecidableEq U]` and a simplicial complex `X : SimplicialComplex U`.
+Morphisms are simplicial maps between the underlying complexes.
+
+## Main definitions
+
+* `SimplicialComplexCat` — objects of the category.
+* `SimplicialComplexCat.Hom` — morphisms (simplicial maps).
+* `Category SimplicialComplexCat` — the category instance.
+* `SimplicialComplexCat.hom_ext` — extensionality for morphisms.
+* `SimplicialComplexCat.Iso.isoOfEquiv` — build an iso from a vertex equivalence that
+  preserves faces in both directions.
+
+## Main lemmas
+
+* Pointwise evaluation lemmas:
+  `id_toFun`, `comp_toFun`, `id_apply`, `comp_apply`.
+
+## Tags
+
+simplicial complex, category, simplicial map
+-/
+
+open CategoryTheory SimplicialComplex
+
+universe u
+
+/-- Objects for the category of simpliclicial complexes:
+a vertex type with `[DecidableEq]` and a simplicial complex on it. -/
+structure SimplicialComplexCat where
+  /-- The vertex type underlying the simplicial complex. -/
+  U : Type u
+  /-- Decidable equality on the vertex type `U`. -/
+  [decU : DecidableEq U]
+  /-- The simplicial complex on the vertex type `U`. -/
+  X : SimplicialComplex U
+attribute [instance] SimplicialComplexCat.decU
+
+namespace SimplicialComplexCat
+
+@[simp] lemma eta (A : SimplicialComplexCat) :
+    SimplicialComplexCat.mk A.U A.X = A := by cases A; rfl
+
+/-- Morphisms are simplicial maps between the underlying complexes. -/
+abbrev Hom (A B : SimplicialComplexCat) :=
+  SimplicialComplex.Hom A.X B.X
+
+/-- Category structure on the big category. -/
+instance : Category SimplicialComplexCat where
+  Hom A B := Hom A B
+  id A := SimplicialComplex.Hom.id A.X
+  -- `f ≫ g` is `Hom.comp g f`
+  comp f g := SimplicialComplex.Hom.comp g f
+  id_comp := by
+    intro A B f; simp
+  comp_id := by
+    intro A B f; simp
+  assoc := by
+    intro A B C D f g h; simp
+
+/-- View a morphism as a function on vertices. -/
+instance (A B : SimplicialComplexCat) :
+    CoeFun (A ⟶ B) (fun _ ↦ A.U → B.U) :=
+  ⟨fun φ => φ.toFun⟩
+
+/-- Extensionality: `f g : A ⟶ B` are equal if `∀ x, f x = g x`. -/
+@[ext] lemma hom_ext
+  {A B : SimplicialComplexCat} {f g : A ⟶ B}
+  (h : ∀ x, f x = g x) : f = g := by
+  exact SimplicialComplex.Hom.ext (funext h)
+
+/-- The identity morphism coerces to the identity function on vertices. -/
+@[simp] lemma id_toFun (A : SimplicialComplexCat) :
+    ((𝟙 A : A ⟶ A) : A.U → A.U) = id := rfl
+
+/-- Composition of morphisms coerces to the usual composition of the underlying functions. -/
+@[simp] lemma comp_toFun {A B C : SimplicialComplexCat}
+    (f : B ⟶ C) (g : A ⟶ B) :
+    ((g ≫ f : A ⟶ C) : A.U → C.U) = f.toFun ∘ g.toFun := rfl
+
+/-- Pointwise identity. -/
+@[simp] lemma id_apply (A : SimplicialComplexCat) (x : A.U) :
+    ((𝟙 A : A ⟶ A) : A.U → A.U) x = x := rfl
+
+/-- Pointwise composition. -/
+@[simp] lemma comp_apply {A B C : SimplicialComplexCat}
+    (f : B ⟶ C) (g : A ⟶ B) (x : A.U) :
+    ((g ≫ f : A ⟶ C) : A.U → C.U) x = f (g x) := rfl
+
+namespace Iso
+
+variable {A B : SimplicialComplexCat}
+
+/-- Build a categorical isomorphism from a vertex equivalence that preserves faces in both
+directions. -/
+def isoOfEquiv
+    (e : A.U ≃ B.U)
+    (h₁ : ∀ ⦃s : Finset A.U⦄, s ∈ A.X.faces → s.image e ∈ B.X.faces)
+    (h₂ : ∀ ⦃t : Finset B.U⦄, t ∈ B.X.faces → t.image e.symm ∈ A.X.faces)
+  : A ≅ B :=
+{ hom :=
+  { toFun := e
+    map_faces := by intro s hs; simpa using h₁ hs },
+  inv :=
+  { toFun := e.symm
+    map_faces := by intro t ht; simpa using h₂ ht },
+  hom_inv_id := by
+    ext x; simp,
+  inv_hom_id := by
+    ext y; simp }
+
+@[simp] lemma isoOfEquiv_hom_toFun
+  (e : A.U ≃ B.U) h₁ h₂ :
+  (isoOfEquiv e h₁ h₂).hom.toFun = e := rfl
+
+@[simp] lemma isoOfEquiv_inv_toFun
+  (e : A.U ≃ B.U) h₁ h₂ :
+  (isoOfEquiv e h₁ h₂).inv.toFun = e.symm := rfl
+
+end Iso
+
+end SimplicialComplexCat

--- a/Mathlib/Combinatorics/SimplicialComplex/FacePoset.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/FacePoset.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2025 Xiangyu Li. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Xiangyu Li
+-/
+import Mathlib.CategoryTheory.Category.Basic
+import Mathlib.Combinatorics.SimplicialComplex.Hom
+import Mathlib.CategoryTheory.Functor.Basic
+
+/-!
+# Face poset (as a thin category) of a simplicial complex
+
+For a simplicial complex `X` on vertices `α`, the set of faces `X.faces : Set (Finset α)`
+carries the natural order by inclusion of the underlying finsets. We view the subtype `X.faces`
+as a poset/partial order and promote it to a **thin category**, with a unique morphism `A ⟶ B`
+exactly when `A ≤ B` (i.e. `↑A ⊆ ↑B`). This category will index the geometric realisation diagram.
+
+## Main definitions
+
+* `Category (X.faces)` — a thin category where `Hom A B` is inhabited iff `A ≤ B`.
+* `SimplicialComplex.Hom.face_functor (φ : Hom X Y)` — the functor on face categories
+  induced by a simplicial map, sending a face `s` to its image `φ.image_face s`.
+
+## Implementation notes
+
+* Morphisms are implemented as `PLift ((A : Finset α) ⊆ (B : Finset α))`.
+* Identities and composition use `subset_rfl` and `subset_trans`.
+* This file stays lightweight: only `Category.Basic` and `Functor.Basic` are imported.
+
+## Tags
+
+simplicial complex, face poset, thin category, combinatorics
+-/
+
+namespace SimplicialComplex
+
+variable {α β : Type*}
+variable [DecidableEq α] [DecidableEq β]
+variable {X : SimplicialComplex α} {Y : SimplicialComplex β}
+
+omit [DecidableEq α] in
+/-- Simplify `A ≤ B` to inclusion of the underlying finsets. -/
+@[simp] lemma face_le_iff {A B : X.faces} :
+    (A ≤ B) ↔ ((A : Finset α) ⊆ (B : Finset α)) := Iff.rfl
+
+open CategoryTheory
+
+/-- A thin category structure on `X.Face`, with at most one morphism `A ⟶ B` when `A ≤ B`. -/
+instance : Category (X.faces) where
+  Hom A B := PLift ((A : Finset α) ⊆ (B : Finset α))
+  id _ := ⟨subset_rfl⟩
+  comp f g := ⟨subset_trans f.down g.down⟩
+  id_comp _ := rfl
+  comp_id _ := rfl
+  assoc _ _ _ := rfl
+
+/-- The functor on face-posets induced by a simplicial map. -/
+noncomputable def Hom.face_functor (φ : Hom X Y) :
+    X.faces ⥤ Y.faces where
+  obj s := Hom.image_face φ s
+  map {A B} f := by
+    refine ⟨?subset⟩
+    intro y hy
+    rcases Finset.mem_image.mp hy with ⟨x, hxA, rfl⟩
+    have hxB : (x : α) ∈ (B : Finset α) := f.down hxA
+    exact Finset.mem_image.mpr ⟨x, hxB, rfl⟩
+  map_id _ := rfl
+  map_comp _ _ := rfl
+
+end SimplicialComplex

--- a/Mathlib/Combinatorics/SimplicialComplex/Hom.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Hom.lean
@@ -56,10 +56,7 @@ namespace SimplicialComplex
 
 A term `φ : Hom K L` consists of a function `toFun : U → V` together with
 `map_faces`, which states: for every `s ∈ K.faces`, the image
-`Finset.image toFun s` is in `L.faces`.
-
-The `@[ext]` attribute provides extensionality: two morphisms are equal when
-their `toFun` agree pointwise. -/
+`Finset.image toFun s` is in `L.faces`. -/
 @[ext] structure Hom (K : SimplicialComplex U) (L : SimplicialComplex V) where
   /-- The underlying map on vertices. Use coercion to treat a morphism as `U → V`. -/
   toFun : U → V
@@ -118,5 +115,3 @@ mapping a face along `f ∘ g` equals first mapping along `g` then along `f`. -/
 end Hom
 
 end SimplicialComplex
-
-#lint

--- a/Mathlib/Combinatorics/SimplicialComplex/Hom.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Hom.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2025 Sebastian Kumar, Xiangyu Li. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sebastian Kumar, Xiangyu Li
+-/
+import Mathlib.Combinatorics.SimplicialComplex.Basic
+
+/-!
+# Morphisms of simplicial complexes
+
+This file defines simplicial maps between abstract simplicial complexes.
+
+Given a function `φ : U → V`, the image of a face `s : Finset U` is `s.image φ`.
+A morphism `φ : Hom K L` is a vertex function such that for every `s ∈ K.faces`,
+we have `Finset.image φ s ∈ L.faces`.
+
+We also define identity and composition for these morphisms. The actual category
+instance lives in `Category.lean`, so this file has no category-theory imports.
+
+## Main definitions
+
+* `SimplicialComplex.Hom K L` : a simplicial map `K ⟶ L`.
+* `SimplicialComplex.Iso K L` : an isomorphism of simplicial complexes.
+
+## Main results
+
+* `Hom.comp_id`, `Hom.id_comp`, `Hom.assoc`.
+* `Hom.ext` (extensionality: morphisms equal if their vertex maps are equal).
+* `Hom.image_face` and its compatibility with `id` and `comp`.
+
+## Implementation notes
+
+* Faces are modeled by `Finset`, so we push forward along vertex functions using
+  `Finset.image`. This requires `[DecidableEq]` on the codomain vertex type,
+  because `Finset.image` deduplicates equal vertices.
+* A `Hom` stores only the underlying vertex function `toFun : U → V` together
+  with a proof that faces are preserved. Coercions let you use a morphism
+  directly as a function on vertices.
+
+## Tags
+
+simplicial complex, simplicial map
+-/
+
+open Function
+
+variable {U V W X : Type*}
+variable [DecidableEq U] [DecidableEq V] [DecidableEq W] [DecidableEq X]
+variable {K : SimplicialComplex U} {L : SimplicialComplex V}
+variable {M : SimplicialComplex W} {N : SimplicialComplex X}
+
+namespace SimplicialComplex
+
+/-- A morphism of simplicial complexes sends each face to a face via the
+`Finset.image` of the underlying vertex function.
+
+A term `φ : Hom K L` consists of a function `toFun : U → V` together with
+`map_faces`, which states: for every `s ∈ K.faces`, the image
+`Finset.image toFun s` is in `L.faces`.
+
+The `@[ext]` attribute provides extensionality: two morphisms are equal when
+their `toFun` agree pointwise. -/
+@[ext] structure Hom (K : SimplicialComplex U) (L : SimplicialComplex V) where
+  /-- The underlying map on vertices. Use coercion to treat a morphism as `U → V`. -/
+  toFun : U → V
+  /-- Face preservation: the image of every face of `K` is a face of `L`. -/
+  map_faces :
+    ∀ ⦃s : Finset U⦄, s ∈ K.faces → Finset.image toFun s ∈ L.faces
+
+namespace Hom
+
+/-- Identity morphism on a simplicial complex. -/
+@[simp] protected def id (L : SimplicialComplex V) : Hom L L where
+  toFun := id
+  map_faces := by
+    intro s hs; simpa using hs
+
+/-- Composition of morphisms. (`comp f g = f ∘ g` on vertices.) -/
+def comp (f : Hom L M) (g : Hom K L) : Hom K M where
+  toFun := f.toFun ∘ g.toFun
+  map_faces := by
+    intro s hs
+    have hL : Finset.image g.toFun s ∈ L.faces := g.map_faces hs
+    simpa [Finset.image_image, Function.comp] using f.map_faces hL
+
+omit [DecidableEq U] in
+/-- Associativity of composition. -/
+@[simp] theorem assoc (f : Hom M N) (g : Hom L M) (h : Hom K L) :
+    comp f (comp g h) = comp (comp f g) h := rfl
+
+/-- Right identity. -/
+@[simp] theorem comp_id (f : Hom L M) :
+    comp f (Hom.id _) = f := rfl
+
+omit [DecidableEq U] in
+/-- Left identity. -/
+@[simp] theorem id_comp (f : Hom K L) :
+    comp (Hom.id _) f = f := rfl
+
+/-- The induced map on faces: given a face `s` of `K`, take its `Finset.image`
+under the vertex function to obtain a face of `L`. -/
+@[simps] def image_face (φ : Hom K L) (s : Face K) : Face L :=
+  ⟨s.1.image φ.toFun, by simpa using φ.map_faces s.property⟩
+
+/-- The induced face map of the identity morphism is the identity on faces. -/
+@[simp] lemma image_face_id (s : K.Face) :
+    (Hom.id K).image_face s = s := by
+  ext v; simp [image_face]
+
+omit [DecidableEq U] in
+/-- Compatibility of induced face maps with composition:
+mapping a face along `f ∘ g` equals first mapping along `g` then along `f`. -/
+@[simp] lemma image_face_comp (f : Hom L M) (g : Hom K L) (s : K.Face) :
+    (Hom.comp f g).image_face s = f.image_face (g.image_face s) := by
+  ext v
+  simp [Hom.image_face, Hom.comp, Function.comp, Finset.image_image]
+
+end Hom
+
+end SimplicialComplex

--- a/Mathlib/Combinatorics/SimplicialComplex/Hom.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Hom.lean
@@ -70,7 +70,7 @@ their `toFun` agree pointwise. -/
 namespace Hom
 
 /-- Identity morphism on a simplicial complex. -/
-@[simp] protected def id (L : SimplicialComplex V) : Hom L L where
+protected def id (L : SimplicialComplex V) : Hom L L where
   toFun := id
   map_faces := by
     intro s hs; simpa using hs
@@ -105,7 +105,7 @@ under the vertex function to obtain a face of `L`. -/
 /-- The induced face map of the identity morphism is the identity on faces. -/
 @[simp] lemma image_face_id (s : K.Face) :
     (Hom.id K).image_face s = s := by
-  ext v; simp [image_face]
+  ext v; simp [image_face, SimplicialComplex.Hom.id]
 
 omit [DecidableEq U] in
 /-- Compatibility of induced face maps with composition:
@@ -118,3 +118,5 @@ mapping a face along `f ∘ g` equals first mapping along `g` then along `f`. -/
 end Hom
 
 end SimplicialComplex
+
+#lint

--- a/Mathlib/Combinatorics/SimplicialComplex/Hom.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Hom.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sebastian Kumar, Xiangyu Li
 -/
 import Mathlib.Combinatorics.SimplicialComplex.Basic
+import Mathlib.Data.Finset.Image
 
 /-!
 # Morphisms of simplicial complexes

--- a/Mathlib/Combinatorics/SimplicialComplex/Hom.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Hom.lean
@@ -97,18 +97,18 @@ omit [DecidableEq U] in
 
 /-- The induced map on faces: given a face `s` of `K`, take its `Finset.image`
 under the vertex function to obtain a face of `L`. -/
-@[simps] def image_face (φ : Hom K L) (s : Face K) : Face L :=
+@[simps] def image_face (φ : Hom K L) (s : K.faces) : L.faces :=
   ⟨s.1.image φ.toFun, by simpa using φ.map_faces s.property⟩
 
 /-- The induced face map of the identity morphism is the identity on faces. -/
-@[simp] lemma image_face_id (s : K.Face) :
+@[simp] lemma image_face_id (s : K.faces) :
     (Hom.id K).image_face s = s := by
   ext v; simp [image_face, SimplicialComplex.Hom.id]
 
 omit [DecidableEq U] in
 /-- Compatibility of induced face maps with composition:
 mapping a face along `f ∘ g` equals first mapping along `g` then along `f`. -/
-@[simp] lemma image_face_comp (f : Hom L M) (g : Hom K L) (s : K.Face) :
+@[simp] lemma image_face_comp (f : Hom L M) (g : Hom K L) (s : K.faces) :
     (Hom.comp f g).image_face s = f.image_face (g.image_face s) := by
   ext v
   simp [Hom.image_face, Hom.comp, Function.comp, Finset.image_image]

--- a/Mathlib/Combinatorics/SimplicialComplex/Topology/GeomReal/Basic.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Topology/GeomReal/Basic.lean
@@ -1,0 +1,222 @@
+/-
+Copyright (c) 2025 Xiangyu Li. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Xiangyu Li
+-/
+import Mathlib.Combinatorics.SimplicialComplex.Basic
+import Mathlib.Combinatorics.SimplicialComplex.Topology.Simplex
+
+/-!
+# Geometric realisation of a simplicial complex
+
+For a simplicial complex `X`, its **geometric realisation** `|X|` is the space of
+formal convex combinations of vertices contained in a single face of `X`. Concretely, a
+point is given by a supporting face `A : Finset U` together with barycentric coordinates
+`w : U → ℝ` supported on `A`, summing to `1`, and with all coordinates in `[0, 1]`.
+
+We equip `|X|` with the **final topology** with respect to the family of inclusions
+`Simplex s → |X|` over all faces `s ∈ X.faces`. This makes the inclusions continuous and
+characterises continuity out of `|X|` by checking on each face.
+
+## Main definitions
+
+* `GeomReal X` : the type of points in the geometric realisation of `X`.
+* `GeomReal.inclusion` : the inclusion `Simplex s → |X|` for a face `s`.
+* `GeomReal.toSimplex` : turn `p : |X|` into a point of the simplex on its supporting face.
+* `GeomReal.instTopologicalSpace` : the final (coinduced supremum) topology on `|X|`.
+
+## Main results
+
+* `GeomReal.inclusion_continuous` : each inclusion `Simplex s → |X|` is continuous.
+* `GeomReal.inclusion_toSimplex`, `GeomReal.toSimplex_inclusion` :
+  the two “change of packaging” maps are inverse up to `shrink`.
+* `GeomReal.continuous_iff` : continuity out of `|X|` can be checked on each face.
+* `GeomReal.function_ext` : functions out of `|X|` agree if they agree on every face.
+* `GeomReal.ext_weight` : extensionality by weights: `p = q` if `p.weight = q.weight`.
+
+## Implementation notes
+
+* The topology on `|X|` is `⨆ s, coinduced (inclusion s)`. We use
+  `continuous_iff_coinduced_le` to prove `inclusion_continuous` and `continuous_iff`.
+
+## Tags
+
+simplicial complex, geometric realisation, final topology
+-/
+
+open Simplex SimplicialComplex
+
+variable {U : Type*} [DecidableEq U]
+variable {X : SimplicialComplex U}
+variable {Y : Type*} [TopologicalSpace Y]
+
+/-- A point of the geometric realisation `|X|` is a convex combination of vertices in a single
+face. We store the supporting face, the weight function, and the usual barycentric axioms. -/
+@[ext] structure GeomReal (X : SimplicialComplex U) where
+  /-- The supporting face. -/
+  face : Finset U
+  /-- Proof that the supporting face is indeed a face of `X`. -/
+  face_mem : face ∈ X.faces
+  /-- Barycentric coordinates on vertices. -/
+  weight : U → ℝ
+  /-- The support of `weight` is exactly `face`. -/
+  support_eq : ∀ v, v ∈ face ↔ weight v ≠ 0
+  /-- The weights sum to `1` on the face. -/
+  sum_eq_one : (∑ v ∈ face, weight v) = 1
+  /-- Every weight lies in `[0, 1]`. -/
+  range_mem_Icc : ∀ v, weight v ∈ Set.Icc (0 : ℝ) 1
+
+/-- Coerce a geometric–realisation point to its weight function. -/
+instance {X} : CoeFun (GeomReal (U := U) X) (fun _ ↦ U → ℝ) :=
+  ⟨GeomReal.weight⟩
+
+namespace GeomReal
+
+/-- **Extensionality by weights for points**
+Two points in the geometric realisation are equal as soon as their weight
+functions coincide. In particular, the supporting face then also agrees since
+`v ∈ p.face ↔ p.weight v ≠ 0`. -/
+lemma ext_weight
+    {U : Type _} [DecidableEq U]
+    {X : SimplicialComplex U} {p q : GeomReal X}
+    (hweight : p.weight = q.weight) : p = q := by
+  have hface : p.face = q.face := by
+    ext v
+    have hp : v ∈ p.face ↔ p.weight v ≠ 0 := p.support_eq v
+    have hq : v ∈ q.face ↔ q.weight v ≠ 0 := q.support_eq v
+    have hw : p.weight v = q.weight v := congrArg (fun f => f v) hweight
+    constructor
+    · intro hv
+      have : p.weight v ≠ 0 := hp.mp hv
+      exact hq.mpr (by simpa [hw] using this)
+    · intro hv
+      have : q.weight v ≠ 0 := hq.mp hv
+      exact hp.mpr (by simpa [hw] using this)
+  exact
+    (by
+      cases p with
+      | mk p_face p_face_mem p_weight p_support p_sum p_icc =>
+        cases q with
+        | mk q_face q_face_mem q_weight q_support q_sum q_icc =>
+          cases hface
+          cases hweight
+          rfl)
+
+/-- The canonical inclusion of a standard simplex (over the face `s`) into `|X|`. -/
+noncomputable def inclusion (s : X.faces) :
+    Simplex s.1 → GeomReal X := fun pt => by
+  let A' := supportFinset pt
+  have hsub : A' ⊆ s.1 := by
+    intro v hv; exact (Finset.mem_filter.1 hv).1
+  have hA' : (A' : Finset U) ∈ X.faces := X.downward_closed s.property hsub
+  have hsupport : ∀ v, v ∈ A' ↔ pt v ≠ 0 := by
+    intro v; dsimp [A']; exact mem_supportFinset pt
+  have hsum : (∑ v ∈ A', pt v) = 1 := by
+    have hvanish :
+        ∀ v ∈ s.1, v ∉ A' → pt v = 0 := by
+      intro v _ hv; by_contra hne; exact hv ((hsupport v).mpr hne)
+    have hEq : (∑ v ∈ A', pt v) = (∑ v ∈ s.1, pt v) :=
+      Finset.sum_subset hsub hvanish
+    simpa [hEq] using pt.sum_eq_one
+  exact
+    { face := A'
+      face_mem := hA'
+      weight := pt
+      support_eq := hsupport
+      sum_eq_one := hsum
+      range_mem_Icc := pt.range_mem_Icc }
+
+/-- The final topology on `|X|`, i.e., the supremum of the topologies coinduced by the inclusions
+`Simplex s → |X|`. -/
+noncomputable instance instTopologicalSpace (X : SimplicialComplex U) :
+    TopologicalSpace (GeomReal X) :=
+  ⨆ (s : X.faces),
+    TopologicalSpace.coinduced (inclusion s) (inferInstance : TopologicalSpace (Simplex s.1))
+
+/-- Each face inclusion map is continuous. -/
+@[simp] lemma inclusion_continuous (s : X.faces) : Continuous (inclusion s) := by
+  refine (continuous_iff_coinduced_le).2 ?_
+  exact le_iSup_of_le s le_rfl
+
+/-- View `p : |X|` as a point of the simplex on its supporting face. -/
+noncomputable def toSimplex (p : GeomReal X) :
+    Simplex p.face := by
+  refine
+    { weight := p.weight
+      support_subset := ?_
+      sum_eq_one := by simpa using p.sum_eq_one
+      range_mem_Icc := p.range_mem_Icc }
+  intro v hv
+  have : v ∉ p.face := hv
+  have : ¬ p.weight v ≠ 0 := (not_congr (p.support_eq v)).mp this
+  exact not_not.mp this
+
+omit [DecidableEq U] in
+/-- The weight function does not change when passing to `p.toSimplex`. -/
+@[simp] lemma toSimplex_weight (p : GeomReal X) :
+    (toSimplex (X := X) p : U → ℝ) = p.weight := rfl
+
+/-- Repackaging via `toSimplex` and then including recovers the original point. -/
+@[simp] lemma inclusion_toSimplex (p : GeomReal X) :
+    inclusion (s := ⟨p.face, p.face_mem⟩) (toSimplex p) = p := by
+  ext v
+  · change v ∈ Simplex.supportFinset (toSimplex p) ↔ v ∈ p.face
+    have h₁ :
+        v ∈ Simplex.supportFinset (toSimplex p) ↔
+          (toSimplex p : U → ℝ) v ≠ 0 :=
+      Simplex.mem_supportFinset (toSimplex p) (v := v)
+    have h₂ : v ∈ p.face ↔ p.weight v ≠ 0 := p.support_eq v
+    simpa [toSimplex_weight (X := X) p] using h₁.trans h₂.symm
+  · rfl
+
+/-- `toSimplex` after an inclusion is `shrink`. -/
+@[simp] lemma toSimplex_inclusion (t : X.faces) (p : Simplex t.1) :
+    toSimplex (inclusion t p) = Simplex.shrink p := by
+  apply Simplex.ext
+  funext v; rfl
+
+omit [DecidableEq U] in
+/-- Face inclusions commute with the `simplexEmbedding` maps. -/
+@[simp] lemma inclusion_simplexEmbedding
+    {X : SimplicialComplex U} [DecidableEq U]
+    {A B : X.faces} (hAB : (A : Finset U) ⊆ (B : Finset U))
+    (p : Simplex A.1) :
+  inclusion (s := B) (simplexEmbedding hAB p) = inclusion (s := A) p := by
+  ext v
+  · change v ∈ (Simplex.supportFinset (simplexEmbedding hAB p)) ↔
+           v ∈ Simplex.supportFinset p
+    simp [Simplex.supportFinset_simplexEmbedding, Simplex.mem_supportFinset]
+  · rfl
+
+/-- On `|X|`, continuity can be checked on each face inclusion. -/
+lemma continuous_iff (f : GeomReal X → Y) :
+    Continuous f ↔ ∀ s : X.faces, Continuous (fun p => f (inclusion s p)) := by
+  constructor
+  · intro hf s
+    exact hf.comp (inclusion_continuous (X := X) s)
+  · intro h
+    refine (continuous_iff_coinduced_le).2 ?_
+    have H : (⨆ s : X.faces,
+          TopologicalSpace.coinduced
+            (fun p => f (inclusion s p))
+            (inferInstance : TopologicalSpace (Simplex s.1)))
+        ≤ (inferInstance : TopologicalSpace Y) :=
+      iSup_le (fun s => (continuous_iff_coinduced_le).1 (h s))
+    simpa [instTopologicalSpace] using H
+
+
+/-- **Extensionality for maps out of `|X|`.** Two maps `f, g : |X| → Y` are equal if they agree
+on each included simplex. -/
+lemma function_ext {X : SimplicialComplex U} {Y : Type*}
+  (f g : GeomReal X → Y) (h_agree : ∀ s : X.faces, f ∘ inclusion s = g ∘ inclusion s) :
+  f = g := by
+  funext p
+  let s : X.faces := ⟨p.face, p.face_mem⟩
+  have hp : inclusion s (toSimplex p) = p := inclusion_toSimplex (p := p)
+  calc
+    f p = f (inclusion s (toSimplex p)) := by rw [hp]
+    _   = g (inclusion s (toSimplex p)) := by
+      simpa using congrFun (h_agree s) (toSimplex p)
+    _   = g p := by rw [hp]
+
+end GeomReal

--- a/Mathlib/Combinatorics/SimplicialComplex/Topology/GeomReal/Basic.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Topology/GeomReal/Basic.lean
@@ -77,9 +77,7 @@ omit [DecidableEq U] in
 Two points in the geometric realisation are equal as soon as their weight
 functions coincide. In particular, the supporting face then also agrees since
 `v ∈ p.face ↔ p.weight v ≠ 0`. -/
-lemma ext_weight
-    {U : Type _} [DecidableEq U]
-    {X : SimplicialComplex U} {p q : GeomReal X}
+lemma ext_weight {X : SimplicialComplex U} {p q : GeomReal X}
     (hweight : p.weight = q.weight) : p = q := by
   have hface : p.face = q.face := by
     ext v
@@ -221,3 +219,5 @@ lemma function_ext {X : SimplicialComplex U} {Y : Type*}
     _   = g p := by rw [hp]
 
 end GeomReal
+
+#lint

--- a/Mathlib/Combinatorics/SimplicialComplex/Topology/GeomReal/Basic.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Topology/GeomReal/Basic.lean
@@ -72,6 +72,7 @@ instance {X} : CoeFun (GeomReal (U := U) X) (fun _ ↦ U → ℝ) :=
 
 namespace GeomReal
 
+omit [DecidableEq U] in
 /-- **Extensionality by weights for points**
 Two points in the geometric realisation are equal as soon as their weight
 functions coincide. In particular, the supporting face then also agrees since

--- a/Mathlib/Combinatorics/SimplicialComplex/Topology/GeomReal/Basic.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Topology/GeomReal/Basic.lean
@@ -219,5 +219,3 @@ lemma function_ext {X : SimplicialComplex U} {Y : Type*}
     _   = g p := by rw [hp]
 
 end GeomReal
-
-#lint

--- a/Mathlib/Combinatorics/SimplicialComplex/Topology/GeomReal/Colimit.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Topology/GeomReal/Colimit.lean
@@ -5,6 +5,7 @@ Authors: Xiangyu Li
 -/
 import Mathlib.Topology.Category.TopCat.Limits.Basic
 import Mathlib.Combinatorics.SimplicialComplex.Topology.GeomReal.Diagram
+import Mathlib.Combinatorics.SimplicialComplex.Topology.GeomReal.Basic
 
 
 /-!

--- a/Mathlib/Combinatorics/SimplicialComplex/Topology/GeomReal/Colimit.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Topology/GeomReal/Colimit.lean
@@ -1,0 +1,166 @@
+/-
+Copyright (c) 2025 Xiangyu Li. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Xiangyu Li
+-/
+import Mathlib.Topology.Category.TopCat.Limits.Basic
+import Mathlib.Combinatorics.SimplicialComplex.Topology.GeomReal.Diagram
+
+
+/-!
+# Geometric realisation as a colimit
+
+We show that the geometric realisation `|X|` of a simplicial complex `X`, equipped with the
+coherent (final) topology from the inclusions of standard simplices, is a **colimit** of the
+face diagram `δ_X : X.faces ⥤ TopCat`.
+
+## Main definitions
+
+* `GeomReal.geom_real_cocone` : the cocone from `δ_X` to `|X|`.
+* `GeomReal.desc`   : the mediating map from `|X|` to any cocone on `δ_X`.
+
+## Main statements
+
+* `GeomReal.geom_real_is_colimit`  : `geom_real_cocone X` is a colimit cocone.
+* `GeomReal.geom_real_colimit_iso` : the canonical isomorphism `colimit (δ_X) ≅ |X|`.
+
+## Implementation notes
+
+The legs of the cocone are the inclusion maps `Simplex s → |X|`.
+The mediating map to a cocone `s` is defined by sending a point `p : |X|`
+to the value of the leg at the face supporting `p`, applied to the canonical
+`toSimplex p`. Naturality is reduced to the compatibility of inclusions with
+`simplexEmbedding`.
+
+## Tags
+
+simplicial complex, geometric realisation, colimit, category theory
+-/
+
+open CategoryTheory CategoryTheory.Limits
+
+variable {U : Type*} [DecidableEq U]
+variable {X : SimplicialComplex U}
+
+namespace GeomReal
+
+/-- The cocone from the face diagram `δ_X` to the geometric realisation `|X|`.
+
+The vertex is `TopCat.of (GeomReal X)`, and the leg at a face `s` is the inclusion
+`Simplex s → |X|`. Naturality follows from the fact that inclusions commute with
+`simplexEmbedding` along face inclusions. -/
+noncomputable def geom_real_cocone (X : SimplicialComplex U) :
+    Cocone (delta X) :=
+{ pt := TopCat.of (GeomReal X)
+  ι :=
+  { app := fun s =>
+      TopCat.ofHom <|ContinuousMap.mk (inclusion s) (inclusion_continuous s)
+    naturality := by
+      intro A B f
+      ext p
+      simp [delta_map] } }
+
+/-- The mediating map `|X| → s.pt` for a cocone `s : Cocone (δ_X)`.
+
+Given `p : |X|` supported on a face `A ≤ X`, we apply the leg `s.ι.app A`
+to the canonical `toSimplex p : Simplex A`. -/
+noncomputable def desc {X : SimplicialComplex U} (s : Cocone (delta X)) :
+    GeomReal X → s.pt := fun p => (s.ι.app ⟨p.face, p.face_mem⟩) (toSimplex p)
+
+/-- Compatibility of `desc` with face inclusions.
+
+Precomposing `desc s` with the inclusion of a face `t` equals the
+corresponding leg of the cocone `s`. -/
+lemma desc_comp_inclusion
+    {X : SimplicialComplex U} (s : Cocone (delta X)) (t : X.faces) :
+    (desc s) ∘ inclusion t = fun p => (s.ι.app t) p := by
+  funext p
+  set A' : Finset U := Simplex.supportFinset p
+  have hsub : A' ⊆ t.1 := by
+    intro v hv; exact (Finset.mem_filter.1 hv).1
+  have hA' : (A' : Finset U) ∈ X.faces :=
+    X.downward_closed t.property hsub
+  let A : X.faces := ⟨A', hA'⟩
+  let hAt : A ⟶ t := ⟨hsub⟩
+  dsimp [desc, Function.comp]
+  have hto :
+      toSimplex (inclusion t p)
+        = Simplex.shrink p := toSimplex_inclusion t p
+  have hnat := s.ι.naturality hAt
+  have hpoint :
+      (s.ι.app A) (Simplex.shrink p)
+        = (s.ι.app t)
+            ((delta X).map hAt (Simplex.shrink p)) := by
+    have := congrArg (fun (f : (delta X).obj A ⟶ _) =>
+        (ConcreteCategory.hom f) (Simplex.shrink p)) hnat.symm
+    simpa using this
+  have hδ :
+      (delta X).map hAt (Simplex.shrink p)
+        = Simplex.simplexEmbedding hAt.down (Simplex.shrink p) := rfl
+  have hse :
+      Simplex.simplexEmbedding hAt.down (Simplex.shrink p) = p :=
+    Simplex.simplexEmbedding_shrink p
+  simpa [hto, hδ, hse] using hpoint
+
+/-- Continuity of the mediating map `desc`. -/
+lemma desc_continuous {X : SimplicialComplex U} (s : Cocone (delta X)) :
+    Continuous (desc s) := by
+  refine
+    (continuous_iff (desc s)).2 ?_
+  intro t
+  change Continuous ((desc s) ∘ inclusion t)
+  simpa [desc_comp_inclusion s t]
+    using (s.ι.app t).hom.continuous
+
+/-- `|X|` is a colimit of the face diagram `δ_X`.
+
+This provides the universal property: for any cocone `s` on `δ_X`, there is a
+unique continuous map `|X| → s.pt` compatible with the cocone legs. -/
+noncomputable def geom_real_is_colimit (X : SimplicialComplex U) :
+    IsColimit (geom_real_cocone X) :=
+{ desc := fun s =>
+    TopCat.ofHom <|
+      ContinuousMap.mk
+        (desc s)
+        (desc_continuous s)
+  fac := by
+    intro s A
+    ext p
+    change desc s (inclusion A p) = (s.ι.app A) p
+    set A' : X.faces :=
+      ⟨(inclusion A p).face,
+        (inclusion A p).face_mem⟩
+    have hA' : (A' : Finset U) ⊆ (A : Finset U) := by
+      intro v hv
+      have hv_ne : p.weight v ≠ 0 := by
+        have hv' : (inclusion A p).weight v ≠ 0 :=
+          ((inclusion A p).support_eq v).1 hv
+        simpa [inclusion] using hv'
+      have hv_supp : v ∈ Simplex.supportFinset p :=
+        (Simplex.mem_supportFinset p).2 hv_ne
+      exact (Finset.mem_filter.1 hv_supp).1
+    let f : A' ⟶ A := ⟨hA'⟩
+    have nat :=
+      congrArg
+        (fun g =>
+          (ConcreteCategory.hom g)
+            (toSimplex (inclusion A p)))
+        (s.ι.naturality f)
+    simp [delta_map, toSimplex_inclusion] at nat
+    simpa using nat.symm
+  uniq := by
+    intro s m hm
+    ext p
+    have h :=
+      congrArg
+        (fun k => (ConcreteCategory.hom k) (toSimplex p))
+        (hm ⟨p.face, p.face_mem⟩)
+    simpa [geom_real_cocone, desc, inclusion_toSimplex] using h}
+
+/-- The canonical isomorphism `colimit δₓ ≅ |X|` in `TopCat`. -/
+noncomputable def geom_real_colimit_iso (X : SimplicialComplex U) :
+    colimit (delta X) ≅ TopCat.of (GeomReal X) :=
+  IsColimit.coconePointUniqueUpToIso
+    (colimit.isColimit _) (geom_real_is_colimit X)
+
+end GeomReal

--- a/Mathlib/Combinatorics/SimplicialComplex/Topology/GeomReal/Diagram.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Topology/GeomReal/Diagram.lean
@@ -5,7 +5,7 @@ Authors: Xiangyu Li
 -/
 import Mathlib.Topology.Category.TopCat.Basic
 import Mathlib.Combinatorics.SimplicialComplex.FacePoset
-import Mathlib.Combinatorics.SimplicialComplex.Topology.GeomReal.Basic
+import Mathlib.Combinatorics.SimplicialComplex.Topology.Simplex
 
 /-!
 # Face diagram for geometric realisation

--- a/Mathlib/Combinatorics/SimplicialComplex/Topology/GeomReal/Diagram.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Topology/GeomReal/Diagram.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2025 Xiangyu Li. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Xiangyu Li
+-/
+import Mathlib.Topology.Category.TopCat.Basic
+import Mathlib.Combinatorics.SimplicialComplex.FacePoset
+import Mathlib.Combinatorics.SimplicialComplex.Topology.GeomReal.Basic
+
+/-!
+# Face diagram for geometric realisation
+
+For a simplicial complex `X`, we define the **face diagram**
+`δ_X : X.faces ⥤ TopCat`. It sends a face `s` to its standard simplex
+`Simplex s`, and an inclusion of faces to the extension map
+`simplexEmbedding`. In later files we use this diagram to express the
+geometric realisation `|X|` as a colimit.
+
+## Main definitions
+
+* `GeomReal.delta` : the face diagram `δ_X : X.faces ⥤ TopCat`.
+
+## Implementation notes
+
+The object part is `s ↦ TopCat.of (Simplex s)`. A morphism `A ⟶ B` is a face inclusion
+and is mapped to the continuous extension `simplexEmbedding` between the corresponding
+standard simplices.
+
+## Tags
+
+simplicial complex, geometric realisation, diagram, colimit
+-/
+
+namespace GeomReal
+
+open CategoryTheory TopCat Simplex SimplicialComplex
+
+variable {U : Type*}
+variable (X : SimplicialComplex U)
+
+/-- The face diagram `δ_X : X.faces ⥤ TopCat` that sends a face to its standard simplex and a
+face inclusion to the corresponding extension map `simplexEmbedding`. -/
+noncomputable def delta :
+    X.faces ⥤ TopCat where
+  obj s := of (Simplex s.1)
+  map {A B} f :=
+    ofHom <|ContinuousMap.mk
+        (simplexEmbedding (f.down)) (simplexEmbedding_continuous (f.down))
+  map_id := by intro A; rfl
+  map_comp := by intros A B C f g; rfl
+
+/-- Object-level description of `δ_X`. -/
+@[simp] lemma delta_obj (s : X.faces) :
+    (delta X).obj s = of (Simplex (U := U) s.1) :=
+  rfl
+
+/-- Morphism-level description of `δ_X`. -/
+@[simp] lemma delta_map {A B : X.faces} (f : A ⟶ B) :
+    (delta X).map f =
+      ofHom
+        (ContinuousMap.mk (simplexEmbedding (f.down))
+                          (simplexEmbedding_continuous (f.down))) :=
+  rfl
+
+end GeomReal

--- a/Mathlib/Combinatorics/SimplicialComplex/Topology/GeomReal/Functor.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Topology/GeomReal/Functor.lean
@@ -1,0 +1,190 @@
+/-
+Copyright (c) 2025 Xiangyu Li. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Xiangyu Li
+-/
+import Mathlib.Combinatorics.SimplicialComplex.Hom
+import Mathlib.Combinatorics.SimplicialComplex.Category
+import Mathlib.Combinatorics.SimplicialComplex.Topology.GeomReal.Map
+import Mathlib.CategoryTheory.Functor.Basic
+
+/-!
+# Functoriality of geometric realisation
+
+We show that geometric realisation is functorial with respect to simplicial maps and package
+this as a functor `SimplicialComplexCat ⥤ TopCat`.
+
+Besides constructing the functor, we record concrete `[simp]` lemmas for the push-forward on
+barycentric coordinates, expressing that it preserves identities and compositions.
+
+## Main definitions
+
+* `GeomReal.geomRealFunctor` :
+  the functor `SimplicialComplexCat ⥤ TopCat` sending `X` to `|X|` and a simplicial map
+  `φ : X ⟶ Y` to the induced continuous map `|φ| : |X| ⟶ |Y|`.
+
+## Main results
+
+* `[simp] GeomReal.map_geom_real_id` :
+  for the identity simplicial map, the concrete push-forward `map_geom_real` is `id`.
+* `[simp] GeomReal.map_geom_real_comp` :
+  `map_geom_real (ψ ∘ φ) = map_geom_real ψ ∘ map_geom_real φ`.
+
+These concrete identities are used to verify the functor laws for `geomRealFunctor`.
+
+## Implementation notes
+
+* The functorial map on morphisms is the abstract colimit map `GeomReal.map`. For the functor
+  laws we switch to the concrete description via `GeomReal.map_eq_map_geom_real`, then use
+  function extensionality on weights (`GeomReal.ext_weight`) to close the goals.
+* We freely use `ConcreteCategory.hom` to view morphisms in `TopCat` as continuous maps.
+
+## Tags
+
+simplicial complex, geometric realisation, functor, category theory
+-/
+
+universe u
+variable {U V W : Type u} [DecidableEq U] [DecidableEq V] [DecidableEq W]
+variable {X : SimplicialComplex U} {Y : SimplicialComplex V} {Z : SimplicialComplex W}
+
+open CategoryTheory SimplicialComplex SimplicialComplex.Hom
+open SimplicialComplexCat GeomReal
+
+namespace GeomReal
+
+/-- **Identity law for the concrete map on realisations.**
+
+The concrete push-forward `map_geom_real` sends the identity simplicial map to the identity
+continuous map on `|X|`. -/
+@[simp]
+lemma map_geom_real_id : map_geom_real (Hom.id X) = id := by
+  funext p
+  have h_weight :
+      (map_geom_real (Hom.id X) p : U → ℝ) = p.weight := by
+    funext y
+    dsimp [map_geom_real, push_forward, Hom.id]
+    by_cases hy : y ∈ p.face
+    · have hfilter :
+          p.face.filter (fun x : U ↦ x = y) = {y} := by
+        ext x; by_cases hxy : x = y
+        · subst hxy; simp [Finset.mem_filter, hy]
+        · simp [Finset.mem_filter, hxy]
+      rw [hfilter]; simp
+    · have hfilter :
+          p.face.filter (fun x : U ↦ x = y) = ∅ := by
+        ext x; by_cases hxy : x = y
+        · subst hxy; simp [Finset.mem_filter, hy]
+        · simp [Finset.mem_filter, hxy]
+      have hw0 : p.weight y = 0 := by
+        by_contra hne
+        exact hy ((p.support_eq y).mpr hne)
+      rw [hfilter]; simp [hw0]
+  exact ext_weight h_weight
+
+omit [DecidableEq U] in
+/-- **Composition law for the concrete map on realisations.**
+
+For simplicial maps `φ : X ⟶ Y` and `ψ : Y ⟶ Z` one has
+`map_geom_real (ψ ∘ φ) = map_geom_real ψ ∘ map_geom_real φ`. -/
+@[simp]
+lemma map_geom_real_comp (φ : Hom X Y) (ψ : Hom Y Z) :
+    map_geom_real (comp ψ φ) = map_geom_real ψ ∘ map_geom_real φ := by
+  funext p
+  have h_face :
+      (map_geom_real (comp ψ φ) p).face
+        = (map_geom_real ψ (map_geom_real φ p)).face := by
+    dsimp [map_geom_real, push_forward]
+    simp [Finset.image_image, comp]
+  have h_weight :
+      (map_geom_real (comp ψ φ) p : W → ℝ)
+        = (map_geom_real ψ (map_geom_real φ p) : W → ℝ) := by
+    funext y
+    dsimp [map_geom_real, push_forward]
+    let I : Finset V := p.face.image φ.toFun
+    calc
+      (∑ x ∈ p.face.filter (fun x : U ↦ ψ.toFun (φ.toFun x) = y), p.weight x)
+          = ∑ x ∈ p.face, (if ψ.toFun (φ.toFun x) = y then p.weight x else 0) := by
+            simp [Finset.sum_filter]
+      _ = ∑ x ∈ p.face,
+            (∑ z ∈ I.filter (fun z : V ↦ ψ.toFun z = y),
+               if φ.toFun x = z then p.weight x else 0) := by
+        apply Finset.sum_congr rfl
+        intro x hx
+        have hxIm : φ.toFun x ∈ I := Finset.mem_image_of_mem _ hx
+        by_cases hψ : ψ.toFun (φ.toFun x) = y
+        · have : φ.toFun x ∈ I.filter (fun z : V ↦ ψ.toFun z = y) :=
+            Finset.mem_filter.mpr ⟨hxIm, hψ⟩
+          simp [this, hψ]
+        · have : φ.toFun x ∉ I.filter (fun z : V ↦ ψ.toFun z = y) := by
+            intro hmem; exact hψ (Finset.mem_filter.mp hmem).2
+          simp [this, hψ]
+      _ = ∑ z ∈ I.filter (fun z : V ↦ ψ.toFun z = y),
+            ∑ x ∈ p.face, if φ.toFun x = z then p.weight x else 0 := by
+        simpa using
+          Finset.sum_comm
+            (s := p.face)
+            (t := I.filter (fun z : V ↦ ψ.toFun z = y))
+            (f := fun x (z : V) => if φ.toFun x = z then p.weight x else 0)
+      _ = ∑ z ∈ I.filter (fun z : V ↦ ψ.toFun z = y),
+            ∑ x ∈ p.face.filter (fun x : U ↦ φ.toFun x = z), p.weight x := by
+        apply Finset.sum_congr rfl
+        intro z hz
+        simp [Finset.sum_filter]
+  exact ext_weight h_weight
+
+
+/-- **Geometric realisation as a functor** `SimplicialComplexCat ⥤ TopCat`.
+
+* On objects: `X ↦ |X|`.
+* On morphisms: a simplicial map `φ : X ⟶ Y` is sent to the induced continuous map
+  `|φ| : |X| ⟶ |Y|` (implemented as the abstract colimit map `GeomReal.map`).
+
+The functor laws follow from the concrete identities
+`map_geom_real_id` and `map_geom_real_comp` via `GeomReal.map_eq_map_geom_real`. -/
+noncomputable def geomRealFunctor : SimplicialComplexCat ⥤ TopCat where
+  obj A := TopCat.of (GeomReal A.X)
+  map {A B} (f : A ⟶ B) := map f
+
+  map_id A := by
+    ext p <;>
+      (suffices hEq : (ConcreteCategory.hom (map (𝟙 A))) p = p
+        from by simp [hEq]
+       exact
+         calc
+           (ConcreteCategory.hom (map (𝟙 A))) p
+               = map_geom_real (Hom.id A.X) p := by
+                 simpa using
+                   congrArg (fun (k : GeomReal A.X → GeomReal A.X) => k p)
+                            (map_eq_map_geom_real (Hom.id A.X))
+           _   = p := by
+                 simp
+      )
+
+  map_comp {A B C} (f : A ⟶ B) (g : B ⟶ C) := by
+    ext p <;>
+      (suffices hEq :
+          (ConcreteCategory.hom (map (f ≫ g))) p
+            = (ConcreteCategory.hom (map g)) ((ConcreteCategory.hom (map f)) p)
+        from by simp [hEq]
+       exact
+         calc
+           (ConcreteCategory.hom (map (f ≫ g))) p
+               = map_geom_real (comp g f) p := by
+                 simpa using
+                   congrArg (fun (k : GeomReal A.X → GeomReal C.X) => k p)
+                            (map_eq_map_geom_real (comp g f))
+           _   = (ConcreteCategory.hom (map g)) (map_geom_real f p) := by
+                 simpa using
+                   congrArg (fun (k : GeomReal B.X → GeomReal C.X) =>
+                     k (map_geom_real f p))
+                     (map_eq_map_geom_real g).symm
+           _   = (ConcreteCategory.hom (map g))
+                   ((ConcreteCategory.hom (map f)) p) := by
+                 simpa using
+                   congrArg (fun x => (ConcreteCategory.hom (map g)) x)
+                     (congrArg (fun (k : GeomReal A.X → GeomReal B.X) => k p)
+                       (map_eq_map_geom_real f).symm)
+      )
+
+end GeomReal

--- a/Mathlib/Combinatorics/SimplicialComplex/Topology/GeomReal/Map.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Topology/GeomReal/Map.lean
@@ -80,7 +80,6 @@ noncomputable def map_nat_trans (φ : Hom X Y) :
 /-- The induced continuous map on geometric realisations `|φ| : |X| ⟶ |Y|`
 constructed via colimit functoriality for the face diagrams. -/
 noncomputable def map (φ : Hom X Y)
-  [HasColimit (delta X)]
   [HasColimit (delta Y)]
   [HasColimit (φ.face_functor ⋙ delta Y)] :
   of (GeomReal X) ⟶ of (GeomReal Y) := by

--- a/Mathlib/Combinatorics/SimplicialComplex/Topology/GeomReal/Map.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Topology/GeomReal/Map.lean
@@ -1,0 +1,372 @@
+/-
+Copyright (c) 2025 Quang Minh Nguyen, Xiangyu Li. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Minh Nguyen, Xiangyu Li
+-/
+import Mathlib.Combinatorics.SimplicialComplex.Topology.GeomReal.Colimit
+import Mathlib.Combinatorics.SimplicialComplex.Topology.SimplexMap
+import Mathlib.Combinatorics.SimplicialComplex.Category
+
+/-!
+# Induced map on geometric realisations
+
+Given a simplicial map `φ : X ⟶ Y`, we construct the induced continuous map on geometric
+realisations `|φ| : |X| ⟶ |Y|`.
+
+There are two complementary constructions.
+
+* **Abstract**: use colimit functoriality for the face diagram `δ_X : X.faces ⥤ TopCat`,
+  built from standard simplices and face inclusions, to obtain a map
+  `|X| ⟶ |Y|` from a natural transformation
+  `δ_X ⟶ φ.face_functor ⋙ δ_Y`.
+* **Concrete**: push barycentric coordinates forward along `φ` by summing weights over fibres
+  `φ ⁻¹ {y}`. We prove that this map agrees with the abstract one.
+
+## Main definitions
+
+* `GeomReal.map_nat_trans` :
+  the natural transformation `δ_X ⟶ φ.face_functor ⋙ δ_Y` whose component at a face `s`
+  is `Simplex.map φ s`.
+* `GeomReal.map` :
+  the induced map `|φ| ⟶ |Y|` in `TopCat` obtained from colimit functoriality.
+* `GeomReal.push_forward` :
+  the barycentric push-forward of weights along `φ`.
+* `GeomReal.map_geom_real` :
+  the concrete map on geometric realisations defined via `push_forward`.
+
+## Main results
+
+* `GeomReal.comp_inclusion_face` :
+  compatibility of `map_geom_real` with inclusions of faces.
+* `GeomReal.map_comp_inclusion_concrete` :
+  the abstract and concrete maps agree after precomposing with each inclusion.
+* `GeomReal.map_eq_map_geom_real` :
+  the abstract `map` equals the concrete `map_geom_real`.
+
+## Implementation notes
+
+* The abstract map is
+  `(geom_real_colimit_iso X).inv ≫ colim.map (map_nat_trans φ) ≫
+   colimit.pre (delta Y) φ.face_functor ≫ (geom_real_colimit_iso Y).hom`.
+* Naturality on simplices is packaged in `Simplex.map_naturality`.
+
+## Tags
+
+simplicial complex, geometric realisation, colimit, functoriality
+-/
+
+open CategoryTheory CategoryTheory.Limits TopCat
+open SimplicialComplex Simplex
+
+universe u
+variable {U V : Type u} [DecidableEq U] [DecidableEq V]
+variable {X : SimplicialComplex U} {Y : SimplicialComplex V}
+
+namespace GeomReal
+
+/-- The natural transformation used to define `|φ| : |X| ⟶ |Y|`.
+
+Its component at a face `s : X.faces` is the map of standard simplices
+`Simplex.map φ s`, viewed as a morphism in `TopCat`. -/
+noncomputable def map_nat_trans (φ : Hom X Y) :
+    delta X ⟶ φ.face_functor ⋙ delta Y :=
+{ app := fun s =>
+    ofHom (ContinuousMap.mk (map φ s) (map_continuous φ s)),
+  naturality := by
+    intro A B f
+    ext p
+    simpa [delta_map, Functor.comp_obj, Functor.comp_map, ContinuousMap.comp_apply]
+      using map_naturality φ f (p : Simplex (U := U) A.1)}
+
+/-- The induced continuous map on geometric realisations `|φ| : |X| ⟶ |Y|`
+constructed via colimit functoriality for the face diagrams. -/
+noncomputable def map (φ : Hom X Y)
+  [HasColimit (delta X)]
+  [HasColimit (delta Y)]
+  [HasColimit (φ.face_functor ⋙ delta Y)] :
+  of (GeomReal X) ⟶ of (GeomReal Y) := by
+  let map₁ := colim.map (map_nat_trans φ)
+  let map₂ := colimit.pre (delta Y) φ.face_functor
+  exact (geom_real_colimit_iso X).inv ≫ map₁ ≫ map₂ ≫ (geom_real_colimit_iso Y).hom
+
+section ConcreteMap
+
+/-- Barycentric push-forward of weights along a simplicial map.
+
+Given `p : |X|` and `y : V`, `push_forward φ p y` is
+`∑_{x ∈ p.face, φ x = y} p.weight x`. This is used to define the concrete
+map on geometric realisations. -/
+noncomputable def push_forward (φ : Hom X Y) (p : GeomReal X) (y : V) : ℝ :=
+  ∑ x ∈ p.face.filter (fun x : U ↦ φ.toFun x = y), p.weight x
+
+/-- The concrete induced map on geometric realisations:
+push barycentric coordinates forward along `φ`. -/
+noncomputable def map_geom_real (φ : Hom X Y) : GeomReal X → GeomReal Y := by
+  intro p
+  let B : Finset V := p.face.image φ.toFun
+  have hB : (B : Finset V) ∈ Y.faces := by
+    simpa using φ.map_faces p.face_mem
+  let w : V → ℝ := push_forward φ p
+  have h_support : ∀ y, y ∈ B ↔ w y ≠ 0 := by
+    intro y;
+    have mp : y ∈ B → w y ≠ 0 := by
+      intro hy
+      rcases (Finset.mem_image).1 hy with ⟨x, hx, rfl⟩
+      have hx₀ : p.weight x ≠ 0 := (p.support_eq x).1 hx
+      have hx_in : x ∈ p.face.filter (fun z : U ↦ φ.toFun z = φ.toFun x) := by
+        exact (Finset.mem_filter).2 ⟨hx, rfl⟩
+      have h_weight_pos: (0 : ℝ) < p.weight x := by
+        have := (p.range_mem_Icc x).1
+        exact lt_of_le_of_ne' this hx₀
+      have h_w_pos : (0 : ℝ) < w (φ.toFun x) := by
+        have h_le : p.weight x ≤ w (φ.toFun x) := by
+          have hx_le :=
+            Finset.single_le_sum
+              (fun z _ ↦ (p.range_mem_Icc z).1)
+              hx_in
+          simpa [w, push_forward] using hx_le
+        exact lt_of_lt_of_le h_weight_pos h_le
+      exact (ne_of_gt h_w_pos)
+    have mpr : w y ≠ 0 → y ∈ B := by
+      intro hny
+      by_contra hnot
+      have h_card_zero : (p.face.filter (fun x : U ↦ φ.toFun x = y)).card = 0 := by
+        apply Finset.card_eq_zero.2
+        apply (Finset.eq_empty_iff_forall_notMem).2
+        intro x hx_in
+        have : y ∈ B := by
+          rcases (Finset.mem_filter).1 hx_in with ⟨hx_face, hxy⟩
+          exact (Finset.mem_image).2 ⟨x, hx_face, hxy⟩
+        exact hnot this
+      have h_wy_zero : w y = 0 := by
+        have h_empty :
+            (p.face.filter (fun x : U ↦ φ.toFun x = y)) = (∅ : Finset U) := by
+          simpa using (Finset.card_eq_zero.1 h_card_zero)
+        simp [w, push_forward, h_empty]
+      exact (hny h_wy_zero).elim
+    simpa using ⟨mp, mpr⟩
+  have h_sum : ∑ y ∈ B, w y = 1 := by
+    dsimp [w]
+    let gfun := fun y => ∑ x ∈ p.face.filter (fun x => φ.toFun x = y), p.weight x
+    calc
+      ∑ y ∈ B, w y
+        = ∑ y ∈ B, ∑ x ∈ p.face.filter (fun x => φ.toFun x = y), p.weight x := rfl
+      _ = ∑ y ∈ B, ∑ x ∈ p.face, if φ.toFun x = y then p.weight x else 0 := by
+        apply Finset.sum_congr rfl
+        intro y hy
+        rw [Finset.sum_filter]
+      _ = ∑ x ∈ p.face, ∑ y ∈ B, if φ.toFun x = y then p.weight x else 0 := by
+        rw [Finset.sum_comm]
+      _ = ∑ x ∈ p.face, p.weight x := by
+        apply Finset.sum_congr rfl
+        intro x hx
+        have : φ.toFun x ∈ B := Finset.mem_image_of_mem φ.toFun hx
+        simp [this]
+    simpa using p.sum_eq_one
+  have h_Icc : ∀ y, w y ∈ Set.Icc (0 : ℝ) 1 := by
+    intro y
+    have h₀ : 0 ≤ w y :=
+      Finset.sum_nonneg (fun x hx => (p.range_mem_Icc x).1)
+    have h₁ : w y ≤ 1 := by
+      let total := h_sum
+      by_cases hy : y ∈ B
+      · have h_nonneg : ∀ z ∈ B, 0 ≤ w z := by
+          intro z hz
+          apply Finset.sum_nonneg
+          intro x hx
+          exact (p.range_mem_Icc x).1
+        have h_le_sum : w y ≤ ∑ z ∈ B, w z :=
+          Finset.single_le_sum h_nonneg hy
+        simpa [total] using h_le_sum
+      · have hwy0 : w y = 0 := by
+          by_contra hne
+          have : y ∈ B := (h_support y).mpr hne
+          exact hy this
+        simp [hwy0]
+    exact ⟨h₀, h₁⟩
+  exact
+    { face          := B
+      face_mem      := hB
+      weight        := w
+      support_eq    := h_support
+      sum_eq_one    := h_sum
+      range_mem_Icc := h_Icc }
+
+/-- Compatibility of a colimit leg with the canonical isomorphism
+`colimit (δ_X) ≅ |X|`.
+
+More precisely, the morphism `colimit.ι (delta X) s` followed by
+`(geom_real_colimit_iso X).hom` *is* the leg of the canonical cocone
+`geom_real_cocone X` at `s`. This is a convenient rewrite when composing
+morphisms landing in `|X|`. -/
+@[simp, reassoc]
+lemma colimit_ι_comp_geom_real_colimit_iso_hom
+    (X : SimplicialComplex U) (s : X.faces) :
+  colimit.ι (delta X) s ≫ (geom_real_colimit_iso X).hom
+    = (geom_real_cocone X).ι.app s := by
+  simp [geom_real_colimit_iso, geom_real_cocone]
+
+/-- The inverse-direction companion to
+`colimit_ι_comp_geom_real_colimit_iso_hom`.
+
+Composing the cocone leg `(geom_real_cocone X).ι.app s` with
+`(geom_real_colimit_iso X).inv` yields the canonical colimit leg
+`colimit.ι (delta X) s`. This form is often what one needs when
+rewriting maps **into** the abstract colimit. -/
+@[simp, reassoc]
+lemma geom_real_cocone_ι_comp_iso_inv
+    (X : SimplicialComplex U) (s : X.faces) :
+  (geom_real_cocone X).ι.app s ≫ (geom_real_colimit_iso X).inv
+    = colimit.ι (delta X) s := by
+  let i := geom_real_colimit_iso X
+  have h :
+      (geom_real_cocone X).ι.app s
+        = colimit.ι (delta X) s ≫ i.hom := by
+    rw[colimit_ι_comp_geom_real_colimit_iso_hom (X := X) (s := s).symm]
+  calc
+    (geom_real_cocone X).ι.app s ≫ i.inv
+        = (colimit.ι (delta X) s ≫ i.hom) ≫ i.inv := by
+          simp [h]
+    _ = colimit.ι (delta X) s := by simp
+
+/-- Compatibility on faces: on the inclusion of a face `s`, the concrete map
+`map_geom_real φ` factors through the simplex-level map `Simplex.map φ s`. -/
+lemma comp_inclusion_face (φ : Hom X Y) (s : X.faces) :
+  (map_geom_real φ) ∘ inclusion s
+    = inclusion (s := φ.image_face s) ∘ Simplex.map φ s := by
+  funext p
+  set lp := (map_geom_real φ) (inclusion s p)
+  set rp := (inclusion (s := φ.image_face s) (Simplex.map φ s p))
+  have hweight : lp.weight = rp.weight := by
+    funext y
+    subst lp; subst rp
+    dsimp [map_geom_real, inclusion, Simplex.map]
+    set SA := (Simplex.supportFinset p).filter (fun x : U => φ.toFun x = y)
+    set SB := s.1.filter (fun x : U => φ.toFun x = y)
+    have hsub : SA ⊆ SB := by
+      intro x hx
+      rcases Finset.mem_filter.1 hx with ⟨hxSupp, hxy⟩
+      exact Finset.mem_filter.2 ⟨(Finset.mem_filter.1 hxSupp).1, hxy⟩
+    have hzero :
+        ∀ x ∈ SB, x ∉ SA → p.weight x = 0 := by
+      intro x hxSB hxNot
+      have hx_not_supp : x ∉ Simplex.supportFinset p := by
+        intro hxSupp
+        exact hxNot (Finset.mem_filter.2 ⟨hxSupp, (Finset.mem_filter.1 hxSB).2⟩)
+      have : ¬ p.weight x ≠ 0 := by
+        intro hne; exact hx_not_supp ((Simplex.mem_supportFinset p).mpr hne)
+      exact not_not.mp this
+    simpa [SA, SB] using Finset.sum_subset hsub hzero
+  exact GeomReal.ext_weight hweight
+
+private lemma concrete_side_into_colimit
+    (φ : Hom X Y) (s : X.faces) :
+  (geom_real_colimit_iso Y).inv ∘
+    ((map_geom_real φ) ∘ inclusion s)
+  = (map_nat_trans φ).app s ≫
+      (geom_real_cocone Y).ι.app ((φ.face_functor).obj s) ≫
+      (geom_real_colimit_iso Y).inv := by
+  let iY := geom_real_colimit_iso Y
+  funext p
+  have h := congrArg (fun f => f p) (comp_inclusion_face φ s)
+  exact congrArg (fun z => (ConcreteCategory.hom iY.inv) z) h
+
+private lemma abstract_side_into_colimit
+    (φ : Hom X Y) (s : X.faces)
+    [HasColimit (delta X)]
+    [HasColimit (delta Y)]
+    [HasColimit (φ.face_functor ⋙ delta Y)] :
+  (geom_real_colimit_iso Y).inv ∘ (map φ) ∘ inclusion s
+    = (map_nat_trans φ).app s ≫
+      (geom_real_cocone Y).ι.app ((φ.face_functor).obj s) ≫
+      (geom_real_colimit_iso Y).inv := by
+  let iX := geom_real_colimit_iso X
+  let iY := geom_real_colimit_iso Y
+  funext p
+  have h₀' :
+    (geom_real_cocone X).ι.app s ≫
+      map φ
+    =
+    (geom_real_cocone X).ι.app s ≫ iX.inv ≫
+      colim.map (map_nat_trans φ) ≫
+      colimit.pre (delta (U := V) Y) φ.face_functor ≫
+      iY.hom := by
+    simp [map, iX, iY]
+  have h₀ :
+    ((geom_real_cocone X).ι.app s ≫
+      map φ) ≫ iY.inv
+    =
+    ((geom_real_cocone X).ι.app s ≫ iX.inv) ≫
+      colim.map (map_nat_trans φ) ≫
+      colimit.pre (delta Y) φ.face_functor := by
+    simpa [Category.assoc] using congrArg (fun f => f ≫ iY.inv) h₀'
+  have h :
+    ((geom_real_cocone X).ι.app s ≫
+      map φ) ≫ iY.inv
+    =
+    ((map_nat_trans φ).app s ≫
+      (geom_real_cocone (U := V) Y).ι.app ((φ.face_functor).obj s)) ≫ iY.inv := by
+    calc
+      ((geom_real_cocone X).ι.app s ≫ map φ) ≫ iY.inv
+          =
+        ((geom_real_cocone X).ι.app s ≫ iX.inv) ≫
+          colim.map (map_nat_trans φ) ≫
+          colimit.pre (delta (U := V) Y) φ.face_functor := h₀
+      _ =
+        (colimit.ι (delta X) s) ≫
+          colim.map (map_nat_trans φ) ≫
+          colimit.pre (delta Y) φ.face_functor := by
+        rw [geom_real_cocone_ι_comp_iso_inv]
+      _ =
+        (map_nat_trans φ).app s ≫
+          colimit.ι (delta Y) ((φ.face_functor).obj s) := by
+        simp
+      _ =
+        (map_nat_trans φ).app s ≫
+          ((geom_real_cocone Y).ι.app ((φ.face_functor).obj s) ≫ iY.inv) := by
+        rw [geom_real_cocone_ι_comp_iso_inv]
+  have h' := congrArg (fun f => (ConcreteCategory.hom f) p) h
+  simpa [ConcreteCategory.comp_apply, Category.assoc,
+         geom_real_cocone, inclusion] using h'
+
+/-- The abstract and concrete constructions agree after precomposing with every
+face inclusion. -/
+lemma map_comp_inclusion_concrete (φ : Hom X Y) (s : X.faces)
+    [HasColimit (delta X)]
+    [HasColimit (delta Y)]
+    [HasColimit (φ.face_functor ⋙ delta Y)] :
+  (map φ : GeomReal X → GeomReal Y) ∘ inclusion s
+    =
+  map_geom_real φ ∘ inclusion s := by
+  funext p
+  let iX := geom_real_colimit_iso X
+  let iY := geom_real_colimit_iso Y
+  have h :
+    iY.inv ( (map φ) ((inclusion s) p) ) = iY.inv ( (map_geom_real φ) ((inclusion s) p) ) := by
+    let target_expr := ((map_nat_trans φ).app s ≫
+        (geom_real_cocone Y).ι.app (φ.face_functor.obj s) ≫ iY.inv) p
+    have h_abs : iY.inv (map φ (inclusion s p)) = target_expr := by
+      exact congr_fun (abstract_side_into_colimit φ s) p
+    have h_conc : iY.inv (map_geom_real φ (inclusion s p)) = target_expr := by
+      exact congr_fun (concrete_side_into_colimit φ s) p
+    rw [h_abs, h_conc]
+  have h_inj : Function.Injective ⇑(iY.inv) := by
+    intro _ _ hab
+    replace hab := congr_arg ⇑(iY.hom) hab
+    simpa [← ConcreteCategory.comp_apply] using hab
+  exact h_inj h
+
+/-- The abstract induced map on geometric realisations equals the concrete
+push-forward of barycentric coordinates. -/
+lemma map_eq_map_geom_real (φ : Hom X Y)
+  [HasColimit (delta X)]
+  [HasColimit (delta Y)]
+  [HasColimit (φ.face_functor ⋙ delta Y)] :
+  (map φ : GeomReal X → GeomReal Y) = map_geom_real φ := by
+  apply function_ext
+  intro s
+  exact map_comp_inclusion_concrete φ s
+
+end ConcreteMap
+
+end GeomReal

--- a/Mathlib/Combinatorics/SimplicialComplex/Topology/GeomReal/Map.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Topology/GeomReal/Map.lean
@@ -5,7 +5,6 @@ Authors: Quang Minh Nguyen, Xiangyu Li
 -/
 import Mathlib.Combinatorics.SimplicialComplex.Topology.GeomReal.Colimit
 import Mathlib.Combinatorics.SimplicialComplex.Topology.SimplexMap
-import Mathlib.Combinatorics.SimplicialComplex.Category
 
 /-!
 # Induced map on geometric realisations

--- a/Mathlib/Combinatorics/SimplicialComplex/Topology/Simplex.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Topology/Simplex.lean
@@ -3,7 +3,8 @@ Copyright (c) 2025 Xiangyu Li. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Xiangyu Li
 -/
-import Mathlib.Topology.Algebra.Ring.Real
+import Mathlib.Topology.MetricSpace.Pseudo.Defs
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 
 /-!
 # Standard simplices

--- a/Mathlib/Combinatorics/SimplicialComplex/Topology/Simplex.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Topology/Simplex.lean
@@ -1,0 +1,194 @@
+/-
+Copyright (c) 2025 Xiangyu Li. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Xiangyu Li
+-/
+import Mathlib.Topology.Algebra.Ring.Real
+
+/-!
+# Standard simplices
+
+For a finite vertex set `A : Finset U`, the **standard simplex** `Simplex A` consists of
+barycentric coordinate functions `w : U → ℝ` that are supported on `A`, sum to `1` over `A`,
+and take values in `[0, 1]`. This file develops the basic API for standard simplices, including
+their topology, support, and the canonical “extend” and “shrink” maps.
+
+This file is independent of the theory of simplicial complexes; it is intended for use in
+constructions such as geometric realisation.
+
+## Main definitions
+
+* `Simplex A` : the standard simplex on the finite set `A`.
+* `Simplex.supportFinset` : the vertices with non-zero barycentric weight.
+* `Simplex.simplexEmbedding` : extend a simplex on `A` to any superset `B ⊇ A`.
+* `Simplex.shrink` : restrict a simplex to its minimal support.
+
+## Main results
+
+* `Simplex.mem_supportFinset` : `v ∈ supportFinset p ↔ p v ≠ 0`.
+* `Simplex.simplexEmbedding_apply` :
+  the weight function is unchanged by `simplexEmbedding`. (`[simp]`)
+* `Simplex.simplexEmbedding_shrink` :
+  `shrink` is a left inverse to `simplexEmbedding` along the inclusion
+  `supportFinset p ⊆ A`. (`[simp]`)
+* `Simplex.supportFinset_simplexEmbedding` :
+  the support is unchanged by `simplexEmbedding`. (`[simp]`)
+* `Simplex.simplexEmbedding_continuous` :
+  `simplexEmbedding` is continuous. (`[simp]`)
+
+## Implementation notes
+
+* We treat `Simplex A` as a structure with a coercion to `U → ℝ`. The topology on `Simplex A`
+  is the topology induced by this coercion from the product topology on `U → ℝ`.
+* The “extend” map is defined by reusing the same weight function and checking the axioms
+  on the larger face; the “shrink” map filters down to the minimal support and reuses weights.
+
+## Tags
+
+simplex, barycentric coordinates, convex hull
+-/
+
+universe u
+
+variable {U : Type u} [DecidableEq U]
+
+/-- A point in the standard simplex on a finite vertex set `A`, defined by its
+barycentric coordinates. -/
+@[ext] structure Simplex (A : Finset U) where
+  /-- The barycentric coordinate (weight) assigned to each vertex `v : U`.
+  It is zero outside the support `A`. -/
+  weight : U → ℝ
+  /-- Outside the face `A`, the coordinates vanish. -/
+  support_subset : ∀ ⦃v⦄, v ∉ A → weight v = 0
+  /-- The barycentric coordinates sum to `1` over the face `A`. -/
+  sum_eq_one : (∑ v ∈ A, weight v) = 1
+  /-- Each coordinate lies in the closed interval `[0, 1]`. -/
+  range_mem_Icc : ∀ v, weight v ∈ Set.Icc (0 : ℝ) 1
+
+namespace Simplex
+
+variable {A : Finset U}
+
+/-- Coerces a `Simplex` to its underlying weight function. -/
+instance : CoeFun (Simplex A) (fun _ ↦ U → ℝ) := ⟨Simplex.weight⟩
+
+/-- The topology on a simplex is the subspace topology from the product topology on `U → ℝ`. -/
+instance : TopologicalSpace (Simplex A) :=
+  TopologicalSpace.induced (fun x ↦ (x : U → ℝ)) inferInstance
+
+/-- The finite support of a point `p : Simplex A` (the vertices with non-zero weight). -/
+noncomputable def supportFinset (p : Simplex A) : Finset U :=
+  A.filter (fun v ↦ p v ≠ 0)
+
+/-- A vertex `v` is in the support of `p` if and only if its weight `p v` is non-zero. -/
+@[simp] lemma mem_supportFinset (p : Simplex A) {v : U} :
+    v ∈ supportFinset p ↔ p v ≠ 0 := by
+  by_cases hv : v ∈ A
+  · simp [supportFinset, hv]
+  · have : p v = 0 := p.support_subset hv
+    simp [supportFinset, hv, this]
+
+/-! ### Extension and shrink maps -/
+
+section Extension
+
+variable {A B : Finset U}
+
+/-- Extends a simplex on `A` to a simplex on a superset `B ⊇ A`. -/
+noncomputable def simplexEmbedding (hAB : A ⊆ B) :
+    Simplex (U := U) A → Simplex (U := U) B :=
+  fun p =>
+  { weight := p
+    support_subset := by
+      intro v hvB
+      have : v ∉ A := fun h ↦ hvB (hAB h)
+      exact p.support_subset this
+    sum_eq_one := by
+      have hvanish :
+          ∀ v ∈ B, v ∉ A → (p : U → ℝ) v = (0 : ℝ) := by
+        intro v _ hvA; exact p.support_subset hvA
+      have hsum : (∑ v ∈ B, p v) = ∑ v ∈ A, p v :=
+        (Finset.sum_subset hAB hvanish).symm
+      simpa [hsum] using p.sum_eq_one
+    range_mem_Icc := p.range_mem_Icc }
+
+omit [DecidableEq U] in
+/-- The weight function of a simplex is unchanged by `simplexEmbedding`. -/
+@[simp] lemma simplexEmbedding_apply {hAB : A ⊆ B}
+    (p : Simplex A) {v : U} :
+    (simplexEmbedding hAB p : U → ℝ) v = p v :=
+  rfl
+
+end Extension
+
+section Shrink
+
+variable {A : Finset U}
+
+/-- Restricts a simplex to its minimal support. -/
+noncomputable def shrink (p : Simplex A) :
+    Simplex (supportFinset p) := by
+  set A' := supportFinset p with hA'
+  refine
+  { weight := fun v ↦ p v
+    support_subset := ?_
+    sum_eq_one := ?_
+    range_mem_Icc := p.range_mem_Icc }
+  · intro v hv
+    have h₁ : v ∈ A' ↔ p v ≠ 0 := mem_supportFinset p
+    have : p v = 0 := by
+      by_contra hne; exact hv ((h₁.mpr hne))
+    simp [this]
+  · have hsub : A' ⊆ A := by
+      intro v hv; exact (Finset.mem_filter.1 hv).1
+    have hvanish :
+        ∀ v ∈ A, v ∉ A' → p v = 0 := by
+      intro v _ hv
+      have h₁ : v ∈ A' ↔ p v ≠ 0 := mem_supportFinset p
+      by_contra hne; exact hv ((h₁.mpr hne))
+    have hsum : (∑ v ∈ A', p v) = (∑ v ∈ A, p v) :=
+      Finset.sum_subset hsub hvanish
+    have : (∑ v ∈ A', p v) = 1 := by
+      simpa [hsum] using p.sum_eq_one
+    simpa [hA'] using this
+
+/-- Extending a shrunk simplex back to the original vertex set recovers the original point. -/
+@[simp] lemma simplexEmbedding_shrink (p : Simplex (U := U) A) :
+    simplexEmbedding (U := U)
+      (A := supportFinset p) (B := A)
+      (by
+        intro v hv; exact (Finset.mem_filter.1 hv).1)
+      (shrink (U := U) p) = p := by
+  ext v
+  by_cases hv : v ∈ supportFinset p
+  · simp [simplexEmbedding_apply, shrink]
+  · have hpv0 : p v = 0 := by
+      have h₁ : v ∈ supportFinset p ↔ p v ≠ 0 := mem_supportFinset p
+      have : p v ≠ 0 → False := by
+        intro hne; exact hv ((h₁.mpr hne))
+      by_contra hne; exact this hne
+    simp [simplexEmbedding_apply, shrink, hpv0]
+
+end Shrink
+
+omit [DecidableEq U] in
+/-- The `simplexEmbedding` map is continuous. -/
+@[simp] lemma simplexEmbedding_continuous {A B : Finset U} (hAB : A ⊆ B) :
+    Continuous (simplexEmbedding hAB) := by
+  -- prove continuity into the ambient product space `U → ℝ`
+  have h₁ :
+      Continuous fun p : Simplex (U := U) A ↦
+        ((simplexEmbedding (U := U) hAB p : Simplex (U := U) B) : U → ℝ) := by
+    simpa [simplexEmbedding_apply] using
+      (continuous_induced_dom :
+        Continuous fun p : Simplex (U := U) A ↦ (p : U → ℝ))
+  -- the target `Simplex B` has the subspace topology, so this suffices
+  simpa using (continuous_induced_rng.2 h₁)
+
+/-- The support of a simplex is unchanged after embedding it in a larger simplex. -/
+@[simp] lemma supportFinset_simplexEmbedding {A B : Finset U}
+    (hAB : A ⊆ B) (p : Simplex (U := U) A) :
+    supportFinset (simplexEmbedding (U := U) hAB p) = supportFinset p := by
+  ext v; simp [simplexEmbedding_apply]
+
+end Simplex

--- a/Mathlib/Combinatorics/SimplicialComplex/Topology/SimplexMap.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Topology/SimplexMap.lean
@@ -1,0 +1,236 @@
+/-
+Copyright (c) 2025 Xiangyu Li. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Xiangyu Li
+-/
+import Mathlib.Combinatorics.SimplicialComplex.FacePoset
+import Mathlib.Combinatorics.SimplicialComplex.Topology.Simplex
+
+/-!
+# Maps on standard simplices
+
+Given a simplicial map `φ : X ⟶ Y` and a face `s` of `X`, we define a continuous map
+`Simplex.map φ s : Simplex s.1 → Simplex (s.1.image φ.toFun)`. Concretely, the weights are
+pushed forward along `φ` by summing the barycentric coordinates over the fibres `φ ⁻¹ {y}`.
+
+This construction is the simplex-level ingredient for the induced map on geometric
+realisations, and serves as the component of the natural transformation between the face
+diagrams used to build `|X|` as a colimit.
+
+## Main definitions
+
+* `Simplex.map` : the continuous map between standard simplices induced by a simplicial map.
+
+## Main results
+
+* `Simplex.map_continuous` : the map `Simplex.map φ s` is continuous.
+* `Simplex.map_naturality` : `Simplex.map` is natural with respect to face inclusions.
+* `Simplex.supportFinset_map` : the support of `Simplex.map φ s p` is the image of the support
+  of `p` under `φ`.
+
+## Implementation notes
+
+* Continuity is proved using `continuous_finset_sum` together with `continuous_apply`,
+  after expressing each output coordinate as a finite sum of input coordinates.
+* We index the push-forward by `s.1.filter (fun x ↦ φ.toFun x = y)`.
+* Basic summation lemmas (`sum_congr`, `single_le_sum`, etc.) verify that the weights
+  remain in `Set.Icc 0 1` and still sum to `1`.
+
+## Tags
+
+simplex, simplicial map, barycentric coordinates
+-/
+
+open Simplex SimplicialComplex Finset
+
+variable {U V W : Type*} [DecidableEq U] [DecidableEq V] [DecidableEq W]
+variable {X : SimplicialComplex U} {Y : SimplicialComplex V} {Z : SimplicialComplex W}
+
+namespace Simplex
+
+omit [DecidableEq U] in
+/-- A helper for continuity: for a fixed vertex `x : U`, the evaluation map
+`p ↦ (p : U → ℝ) x` on `Simplex A` is continuous. -/
+private lemma continuous_weight_eval {A : Finset U} (x : U) :
+  Continuous (fun p : Simplex A => (p : U → ℝ) x) := by
+  apply (continuous_apply x).comp
+  exact continuous_induced_dom
+
+/-- The continuous map on standard simplices induced by a simplicial map.
+
+Given `φ : X ⟶ Y` and a face `s : X.faces`, `map φ s : Simplex s.1 → Simplex (s.1.image φ.toFun)`
+pushes barycentric weights forward along the fibres of `φ.toFun`. -/
+noncomputable def map (φ : Hom X Y) (s : X.faces) : Simplex s.1 → Simplex (s.1.image φ.toFun) := by
+  intro p
+  set B : Finset V := s.1.image φ.toFun with hB
+  set w : V → ℝ :=
+    fun y ↦ ∑ x ∈ s.1.filter (fun x ↦ φ.toFun x = y), p.weight x
+    with hw
+
+  /- `∑ y ∈ B, w y = 1` -/
+  have h_sum : ∑ y ∈ B, w y = 1 := by
+    calc
+      _ = ∑ y ∈ B,
+            ∑ x ∈ s.1.filter (fun x ↦ φ.toFun x = y), p.weight x := by
+              simp [hw]
+      _ = ∑ y ∈ B,
+            ∑ x ∈ s.1, if φ.toFun x = y then p.weight x else 0 := by
+              refine Finset.sum_congr rfl ?_
+              intro y _
+              simp [Finset.sum_filter]
+      _ = ∑ x ∈ s.1,
+            ∑ y ∈ B, if φ.toFun x = y then p.weight x else 0 := by
+              simpa using
+                Finset.sum_comm
+                  (f := fun y (x : U) =>
+                    if _ : φ.toFun x = y then p.weight x else 0)
+                  (s := B) (t := s.1)
+      _ = ∑ x ∈ s.1, p.weight x := by
+              refine Finset.sum_congr rfl ?_
+              intro x hx
+              have : φ.toFun x ∈ B := by
+                have : φ.toFun x ∈ s.1.image φ.toFun :=
+                  Finset.mem_image_of_mem _ hx
+                simpa [hB] using this
+              simp [this]
+      _ = 1 := p.sum_eq_one
+
+  /- Support zero outside `B`. -/
+  have h_support_zero : ∀ {y}, y ∉ B → w y = 0 := by
+    intro y hyB
+    have h_empty :
+        (s.1.filter fun x : U ↦ φ.toFun x = y) = (∅ : Finset U) := by
+      apply Finset.eq_empty_iff_forall_notMem.2
+      intro x hx
+      rcases Finset.mem_filter.1 hx with ⟨hx₁, hxy⟩
+      have : (φ.toFun x) ∈ B := by
+        have : φ.toFun x ∈ s.1.image φ.toFun :=
+          Finset.mem_image_of_mem _ hx₁
+        simpa [hB] using this
+      have : y ∈ B := by simpa [hxy] using this
+      exact (hyB this).elim
+    dsimp [w] at *
+    simp [h_empty] at *
+
+  /- `w y ∈ [0,1]` for all `y`. -/
+  have h_Icc : ∀ y, w y ∈ Set.Icc (0 : ℝ) 1 := by
+    intro y
+    have h₀ : (0 : ℝ) ≤ w y := by
+      dsimp [w]
+      exact Finset.sum_nonneg fun _ _ ↦ (p.range_mem_Icc _).1
+    have h₁ : w y ≤ 1 := by
+      by_cases hy : y ∈ B
+      · have h_nonneg : ∀ z ∈ B, (0 : ℝ) ≤ w z := by
+          intro z hz
+          dsimp [w]
+          exact Finset.sum_nonneg fun _ _ ↦ (p.range_mem_Icc _).1
+        have : w y ≤ ∑ z ∈ B, w z :=
+          Finset.single_le_sum h_nonneg hy
+        simpa [h_sum] using this
+      · have : w y = 0 := h_support_zero hy
+        simp [this]
+    exact ⟨h₀, h₁⟩
+
+  exact
+    { weight         := w
+      support_subset := by
+        intro y hy
+        have hyB : y ∉ B := by simpa [hB] using hy
+        simpa using h_support_zero hyB
+      sum_eq_one     := by simpa [hB] using h_sum
+      range_mem_Icc  := by simpa [hB] using h_Icc }
+
+omit [DecidableEq U] in
+/-- Continuity of `Simplex.map`. -/
+@[simp] lemma map_continuous (φ : Hom X Y) (s : X.faces) :
+    Continuous (map (U := U) (V := V) φ s) := by
+  have h_prod :
+      Continuous (fun p : Simplex (U := U) s.1 ↦
+        (map (U := U) (V := V) φ s p : V → ℝ)) := by
+    refine continuous_pi ?_
+    intro y
+    have :
+        Continuous (fun p : Simplex (U := U) s.1 ↦
+          ∑ x ∈ s.1.filter (fun x : U ↦ φ.toFun x = y), (p : U → ℝ) x) := by
+      apply continuous_finset_sum
+      intro x hx
+      exact continuous_weight_eval x
+    simpa [map] using this
+  simpa using (continuous_induced_rng.2 h_prod)
+
+omit [DecidableEq U] in
+/-- **Naturality of `Simplex.map` with respect to face inclusions.**
+
+For a morphism `f : A ⟶ B` in the face poset, the diagram
+
+Simplex A       ⟶      Simplex B
+    |                      |
+    |                      |
+    v                      v
+Simplex (φ(A))  ⟶     Simplex (φ(B))
+
+commutes, where the horizontal arrows are the `simplexEmbedding`s and the vertical arrows
+are `Simplex.map`. -/
+lemma map_naturality (φ : Hom X Y) {A B : X.faces} (f : A ⟶ B)
+  (p : Simplex (U := U) A.1) :
+  map φ B (simplexEmbedding (hAB := f.down) p)
+    =
+  simplexEmbedding (hAB := ((φ.face_functor).map f).down) (map φ A p) := by
+  ext y
+  unfold map
+  simp only [simplexEmbedding_apply]
+  let P : U → Prop := fun x' => φ.toFun x' = y
+  let s_A := A.1.filter P
+  let s_B := B.1.filter P
+  apply Eq.symm
+  apply Finset.sum_subset
+  · exact Finset.filter_subset_filter _ f.down
+  · intro x hx_in_sB hx_not_in_sA
+    have hx_not_in_A : x ∉ A.1 := by
+      intro hx_in_A
+      have Px_true : P x := (Finset.mem_filter.1 hx_in_sB).2
+      have hx_in_sA : x ∈ s_A := Finset.mem_filter.2 ⟨hx_in_A, Px_true⟩
+      exact hx_not_in_sA hx_in_sA
+    exact p.support_subset hx_not_in_A
+
+/-- The support of the image of a point under `Simplex.map` equals the image of the support. -/
+@[simp] lemma supportFinset_map
+  (φ : Hom X Y) (s : X.faces) (p : Simplex (U := U) s.1) :
+  Simplex.supportFinset (Simplex.map (X := X) (Y := Y) φ s p)
+    = (Simplex.supportFinset p).image φ.toFun := by
+  ext y
+  constructor
+  · intro hy
+    have hy0 :
+        (Simplex.map (X := X) (Y := Y) φ s p : V → ℝ) y ≠ 0 := by
+      simpa [Simplex.mem_supportFinset] using hy
+    set S := s.1.filter (fun x : U => φ.toFun x = y)
+    have hexists : ∃ x ∈ S, p.weight x ≠ 0 := by
+      by_contra hnone
+      have hzero : ∀ x ∈ S, p.weight x = 0 := by
+        intro x hx; by_contra hxne; exact hnone ⟨x, hx, hxne⟩
+      have hsum : (∑ x ∈ S, p.weight x) = 0 := Finset.sum_eq_zero hzero
+      have : (Simplex.map (X := X) (Y := Y) φ s p : V → ℝ) y = 0 := by
+        simpa [Simplex.map, S] using hsum
+      exact hy0 this
+    rcases hexists with ⟨x, hxS, hxne⟩
+    exact Finset.mem_image.mpr
+      ⟨x, (Simplex.mem_supportFinset p).2 hxne, (Finset.mem_filter.1 hxS).2⟩
+  · intro hy
+    rcases Finset.mem_image.1 hy with ⟨x, hxSupp, hxy⟩
+    set S := s.1.filter (fun z : U => φ.toFun z = y)
+    have hxA : x ∈ s.1 := (Finset.mem_filter.1 hxSupp).1
+    have hxS : x ∈ S := by exact Finset.mem_filter.2 ⟨hxA, by simp [hxy]⟩
+    have hxne : p.weight x ≠ 0 := (Simplex.mem_supportFinset p).1 hxSupp
+    have hxpos : (0 : ℝ) < p.weight x := by
+      have hx0 : (0 : ℝ) ≤ p.weight x := (p.range_mem_Icc x).1
+      exact lt_of_le_of_ne' hx0 hxne
+    have h_le :
+        p.weight x ≤ ∑ z ∈ S, p.weight z :=
+      Finset.single_le_sum (fun z _ => (p.range_mem_Icc z).1) hxS
+    have hw_pos :
+        (0 : ℝ) < (Simplex.map (X := X) (Y := Y) φ s p : V → ℝ) y :=
+      lt_of_lt_of_le hxpos (by simpa [Simplex.map, S])
+    exact (Simplex.mem_supportFinset _).2 (ne_of_gt hw_pos)
+
+end Simplex

--- a/Mathlib/Combinatorics/SimplicialComplex/Topology/SimplexMap.lean
+++ b/Mathlib/Combinatorics/SimplicialComplex/Topology/SimplexMap.lean
@@ -5,6 +5,7 @@ Authors: Xiangyu Li
 -/
 import Mathlib.Combinatorics.SimplicialComplex.FacePoset
 import Mathlib.Combinatorics.SimplicialComplex.Topology.Simplex
+import Mathlib.Topology.Algebra.Ring.Real
 
 /-!
 # Maps on standard simplices


### PR DESCRIPTION
Introduce the standard simplex on a finite vertex set and build the geometric realisation |X| of a simplicial complex. Prove that |X| is the colimit of the face diagram δ_X : X.faces ⥤ TopCat, and define the induced map on realisations |φ| : |X| ⟶ |Y| for a simplicial map φ. Show that the abstract map from colimit functoriality agrees with the concrete push-forward of barycentric coordinates. Package these into a functor SimplicialComplexCat ⥤ TopCat.

---

This is our first contribution to mathlib. This work was done as part of the Fields Institute Summer Undergraduate Program on formalization in topological combinatorics. Eventually, we aim to formalize Lovasz's proof of the Kneser Conjecture and this lays the groundwork to do this.

We would like to acknowledge the Fields Institute for Research in Mathematical Sciences for their sponsorship. We would also like to thank our supervisors, Professor Chris Kapulkin and Mr. Daniel Carranza, for their guidance and support throughout this project. I would also like to thank our group members Sebastian Kumar, Tom Lindquist and Quang Minh Nguyen for our fruitful discussions.

- [ ] depends on: #28125