### PR TITLE
chore(Combinatorics/SimpleGraph/Triangle): golf entire `in{₀₁,₁₀,₀₂,₂₀,₁₂,₂₁}_iff'.mp` using `simp`

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Triangle/Tripartite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Triangle/Tripartite.lean
@@ -84,27 +84,27 @@ namespace Graph
 
 lemma in₀₁_iff' :
     (graph t).Adj (in₀ a) (in₁ b) ↔ ∃ x : α × β × γ, x ∈ t ∧ x.1 = a ∧ x.2.1 = b where
-  mp := by rintro ⟨⟩; exact ⟨_, ‹_›, by simp⟩
+  mp := by simp
   mpr := by rintro ⟨⟨a, b, c⟩, h, rfl, rfl⟩; constructor; assumption
 lemma in₁₀_iff' :
     (graph t).Adj (in₁ b) (in₀ a) ↔ ∃ x : α × β × γ, x ∈ t ∧ x.2.1 = b ∧ x.1 = a where
-  mp := by rintro ⟨⟩; exact ⟨_, ‹_›, by simp⟩
+  mp := by simp
   mpr := by rintro ⟨⟨a, b, c⟩, h, rfl, rfl⟩; constructor; assumption
 lemma in₀₂_iff' :
     (graph t).Adj (in₀ a) (in₂ c) ↔ ∃ x : α × β × γ, x ∈ t ∧ x.1 = a ∧ x.2.2 = c where
-  mp := by rintro ⟨⟩; exact ⟨_, ‹_›, by simp⟩
+  mp := by simp
   mpr := by rintro ⟨⟨a, b, c⟩, h, rfl, rfl⟩; constructor; assumption
 lemma in₂₀_iff' :
     (graph t).Adj (in₂ c) (in₀ a) ↔ ∃ x : α × β × γ, x ∈ t ∧ x.2.2 = c ∧ x.1 = a where
-  mp := by rintro ⟨⟩; exact ⟨_, ‹_›, by simp⟩
+  mp := by simp
   mpr := by rintro ⟨⟨a, b, c⟩, h, rfl, rfl⟩; constructor; assumption
 lemma in₁₂_iff' :
     (graph t).Adj (in₁ b) (in₂ c) ↔ ∃ x : α × β × γ, x ∈ t ∧ x.2.1 = b ∧ x.2.2 = c where
-  mp := by rintro ⟨⟩; exact ⟨_, ‹_›, by simp⟩
+  mp := by simp
   mpr := by rintro ⟨⟨a, b, c⟩, h, rfl, rfl⟩; constructor; assumption
 lemma in₂₁_iff' :
     (graph t).Adj (in₂ c) (in₁ b) ↔ ∃ x : α × β × γ, x ∈ t ∧ x.2.2 = c ∧ x.2.1 = b where
-  mp := by rintro ⟨⟩; exact ⟨_, ‹_›, by simp⟩
+  mp := by simp
   mpr := by rintro ⟨⟨a, b, c⟩, h, rfl, rfl⟩; constructor; assumption
 
 end Graph


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>in₀₁_iff'</code>: 15 ms before, 334 ms after </summary>

### Trace profiling of `in₀₁_iff'` before PR 28536
```diff
diff --git a/Mathlib/Combinatorics/SimpleGraph/Triangle/Tripartite.lean b/Mathlib/Combinatorics/SimpleGraph/Triangle/Tripartite.lean
index 21405818a3..81bff0151c 100644
--- a/Mathlib/Combinatorics/SimpleGraph/Triangle/Tripartite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Triangle/Tripartite.lean
@@ -82,6 +82,7 @@ namespace Graph
 @[simp] lemma in₂₁_iff : (graph t).Adj (in₂ c) (in₁ b) ↔ ∃ a, (a, b, c) ∈ t :=
   ⟨by rintro ⟨⟩; exact ⟨_, ‹_›⟩, fun ⟨_, h⟩ ↦ in₂₁ h⟩
 
+set_option trace.profiler true in
 lemma in₀₁_iff' :
     (graph t).Adj (in₀ a) (in₁ b) ↔ ∃ x : α × β × γ, x ∈ t ∧ x.1 = a ∧ x.2.1 = b where
   mp := by rintro ⟨⟩; exact ⟨_, ‹_›, by simp⟩
```
```
ℹ [997/997] Built Mathlib.Combinatorics.SimpleGraph.Triangle.Tripartite (3.5s)
info: Mathlib/Combinatorics/SimpleGraph/Triangle/Tripartite.lean:86:0: [Elab.command] [0.010227] theorem in₀₁_iff' :
        (graph t).Adj (in₀ a) (in₁ b) ↔ ∃ x : α × β × γ, x ∈ t ∧ x.1 = a ∧ x.2.1 = b
        where
      mp := by rintro ⟨⟩; exact ⟨_, ‹_›, by simp⟩
      mpr := by rintro ⟨⟨a, b, c⟩, h, rfl, rfl⟩; constructor; assumption
info: Mathlib/Combinatorics/SimpleGraph/Triangle/Tripartite.lean:86:0: [Elab.command] [0.010300] lemma in₀₁_iff' : (graph t).Adj (in₀ a) (in₁ b) ↔ ∃ x : α × β × γ, x ∈ t ∧ x.1 = a ∧ x.2.1 = b
        where
      mp := by rintro ⟨⟩; exact ⟨_, ‹_›, by simp⟩
      mpr := by rintro ⟨⟨a, b, c⟩, h, rfl, rfl⟩; constructor; assumption
info: Mathlib/Combinatorics/SimpleGraph/Triangle/Tripartite.lean:86:0: [Elab.async] [0.017152] elaborating proof of SimpleGraph.TripartiteFromTriangles.Graph.in₀₁_iff'
  [Elab.definition.value] [0.015437] SimpleGraph.TripartiteFromTriangles.Graph.in₀₁_iff'
    [Elab.step] [0.010307] rintro ⟨⟩; exact ⟨_, ‹_›, by simp⟩
      [Elab.step] [0.010293] rintro ⟨⟩; exact ⟨_, ‹_›, by simp⟩
Build completed successfully (997 jobs).
```

### Trace profiling of `in₀₁_iff'` after PR 28536
```diff
diff --git a/Mathlib/Combinatorics/SimpleGraph/Triangle/Tripartite.lean b/Mathlib/Combinatorics/SimpleGraph/Triangle/Tripartite.lean
index 21405818a3..8a706ded18 100644
--- a/Mathlib/Combinatorics/SimpleGraph/Triangle/Tripartite.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Triangle/Tripartite.lean
@@ -82,29 +82,30 @@ namespace Graph
 @[simp] lemma in₂₁_iff : (graph t).Adj (in₂ c) (in₁ b) ↔ ∃ a, (a, b, c) ∈ t :=
   ⟨by rintro ⟨⟩; exact ⟨_, ‹_›⟩, fun ⟨_, h⟩ ↦ in₂₁ h⟩
 
+set_option trace.profiler true in
 lemma in₀₁_iff' :
     (graph t).Adj (in₀ a) (in₁ b) ↔ ∃ x : α × β × γ, x ∈ t ∧ x.1 = a ∧ x.2.1 = b where
-  mp := by rintro ⟨⟩; exact ⟨_, ‹_›, by simp⟩
+  mp := by simp
   mpr := by rintro ⟨⟨a, b, c⟩, h, rfl, rfl⟩; constructor; assumption
 lemma in₁₀_iff' :
     (graph t).Adj (in₁ b) (in₀ a) ↔ ∃ x : α × β × γ, x ∈ t ∧ x.2.1 = b ∧ x.1 = a where
-  mp := by rintro ⟨⟩; exact ⟨_, ‹_›, by simp⟩
+  mp := by simp
   mpr := by rintro ⟨⟨a, b, c⟩, h, rfl, rfl⟩; constructor; assumption
 lemma in₀₂_iff' :
     (graph t).Adj (in₀ a) (in₂ c) ↔ ∃ x : α × β × γ, x ∈ t ∧ x.1 = a ∧ x.2.2 = c where
-  mp := by rintro ⟨⟩; exact ⟨_, ‹_›, by simp⟩
+  mp := by simp
   mpr := by rintro ⟨⟨a, b, c⟩, h, rfl, rfl⟩; constructor; assumption
 lemma in₂₀_iff' :
     (graph t).Adj (in₂ c) (in₀ a) ↔ ∃ x : α × β × γ, x ∈ t ∧ x.2.2 = c ∧ x.1 = a where
-  mp := by rintro ⟨⟩; exact ⟨_, ‹_›, by simp⟩
+  mp := by simp
   mpr := by rintro ⟨⟨a, b, c⟩, h, rfl, rfl⟩; constructor; assumption
 lemma in₁₂_iff' :
     (graph t).Adj (in₁ b) (in₂ c) ↔ ∃ x : α × β × γ, x ∈ t ∧ x.2.1 = b ∧ x.2.2 = c where
-  mp := by rintro ⟨⟩; exact ⟨_, ‹_›, by simp⟩
+  mp := by simp
   mpr := by rintro ⟨⟨a, b, c⟩, h, rfl, rfl⟩; constructor; assumption
 lemma in₂₁_iff' :
     (graph t).Adj (in₂ c) (in₁ b) ↔ ∃ x : α × β × γ, x ∈ t ∧ x.2.2 = c ∧ x.2.1 = b where
-  mp := by rintro ⟨⟩; exact ⟨_, ‹_›, by simp⟩
+  mp := by simp
   mpr := by rintro ⟨⟨a, b, c⟩, h, rfl, rfl⟩; constructor; assumption
 
 end Graph
```
```
ℹ [997/997] Built Mathlib.Combinatorics.SimpleGraph.Triangle.Tripartite (3.7s)
info: Mathlib/Combinatorics/SimpleGraph/Triangle/Tripartite.lean:86:0: [Elab.command] [0.013104] theorem in₀₁_iff' :
        (graph t).Adj (in₀ a) (in₁ b) ↔ ∃ x : α × β × γ, x ∈ t ∧ x.1 = a ∧ x.2.1 = b
        where
      mp := by simp
      mpr := by rintro ⟨⟨a, b, c⟩, h, rfl, rfl⟩; constructor; assumption
info: Mathlib/Combinatorics/SimpleGraph/Triangle/Tripartite.lean:86:0: [Elab.command] [0.013203] lemma in₀₁_iff' : (graph t).Adj (in₀ a) (in₁ b) ↔ ∃ x : α × β × γ, x ∈ t ∧ x.1 = a ∧ x.2.1 = b
        where
      mp := by simp
      mpr := by rintro ⟨⟨a, b, c⟩, h, rfl, rfl⟩; constructor; assumption
info: Mathlib/Combinatorics/SimpleGraph/Triangle/Tripartite.lean:86:0: [Elab.async] [0.334754] elaborating proof of SimpleGraph.TripartiteFromTriangles.Graph.in₀₁_iff'
  [Elab.definition.value] [0.333635] SimpleGraph.TripartiteFromTriangles.Graph.in₀₁_iff'
    [Elab.step] [0.327987] simp
      [Elab.step] [0.327975] simp
        [Elab.step] [0.327961] simp
          [Meta.Tactic.simp.discharge] [0.036229] IsEmpty.exists_iff discharge ❌️
                IsEmpty γ
            [Meta.synthInstance] [0.035488] ❌️ Nonempty γ
          [Meta.Tactic.simp.discharge] [0.254329] IsEmpty.exists_iff discharge ❌️
                IsEmpty (α × β × γ)
            [Meta.synthInstance] [0.093922] ❌️ Nonempty (α × β × γ)
            [Meta.synthInstance] [0.017873] ❌️ Nonempty α
            [Meta.synthInstance] [0.125837] ❌️ Nonempty (β × γ)
              [Meta.synthInstance] [0.026689] ✅️ apply @GeneralizedHeytingAlgebra.toOrderTop to OrderTop (β × γ)
                [Meta.synthInstance.tryResolve] [0.026637] ✅️ OrderTop (β × γ) ≟ OrderTop (β × γ)
                  [Meta.isDefEq] [0.026513] ✅️ ?m.39 =?= GeneralizedHeytingAlgebra.toOrderTop
                    [Meta.isDefEq.assign] [0.026510] ✅️ ?m.39 := GeneralizedHeytingAlgebra.toOrderTop
                      [Meta.isDefEq.assign.checkTypes] [0.026496] ✅️ (?m.39 : OrderTop
                            (β × γ)) := (GeneralizedHeytingAlgebra.toOrderTop : OrderTop (β × γ))
                        [Meta.isDefEq] [0.026487] ✅️ OrderTop (β × γ) =?= OrderTop (β × γ)
                          [Meta.synthInstance] [0.026414] ❌️ GeneralizedHeytingAlgebra (β × γ)
                            [Meta.synthInstance] [0.010062] ✅️ apply @Prod.instGeneralizedHeytingAlgebra to GeneralizedHeytingAlgebra
                                  (β × γ)
                            [Meta.synthInstance] [0.010770] ✅️ apply @CompleteLinearOrder.toCompletelyDistribLattice to CompletelyDistribLattice
                                  (β × γ)
                              [Meta.synthInstance.tryResolve] [0.010698] ✅️ CompletelyDistribLattice
                                    (β × γ) ≟ CompletelyDistribLattice (β × γ)
            [Meta.synthInstance] [0.013457] ❌️ Nonempty β
Build completed successfully (997 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
