### PR TITLE
[Merged by Bors] - chore(Algebra/BigOperators/Finsupp): golf entire `sum_ite_self_eq` using `simp_all`

### DIFF
--- a/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
@@ -89,9 +89,7 @@ theorem prod_ite_eq [DecidableEq α] (f : α →₀ M) (a : α) (b : α → M �
 
 theorem sum_ite_self_eq [DecidableEq α] {N : Type*} [AddCommMonoid N] (f : α →₀ N) (a : α) :
     (f.sum fun x v => ite (a = x) v 0) = f a := by
-  classical
-    convert f.sum_ite_eq a fun _ => id
-    simp [ite_eq_right_iff.2 Eq.symm]
+  simp_all
 
 /--
 The left hand side of `sum_ite_self_eq` simplifies; this is the variant that is useful for `simp`.


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>sum_ite_self_eq</code>: 77 ms before, 29 ms after  🎉</summary>

### Trace profiling of `sum_ite_self_eq` before PR 28537
```diff
diff --git a/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean b/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
index 70d6fcb06c..804532e4ab 100644
--- a/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
@@ -87,6 +87,7 @@ theorem prod_ite_eq [DecidableEq α] (f : α →₀ M) (a : α) (b : α → M 
   dsimp [Finsupp.prod]
   rw [f.support.prod_ite_eq]
 
+set_option trace.profiler true in
 theorem sum_ite_self_eq [DecidableEq α] {N : Type*} [AddCommMonoid N] (f : α →₀ N) (a : α) :
     (f.sum fun x v => ite (a = x) v 0) = f a := by
   classical
@@ -202,7 +203,6 @@ theorem map_finsuppProd [Zero M] [CommMonoid N] [CommMonoid P] {H : Type*}
     (h : H) (f : α →₀ M) (g : α → M → N) : h (f.prod g) = f.prod fun a b => h (g a b) :=
   map_prod h _ _
```
```
ℹ [766/766] Built Mathlib.Algebra.BigOperators.Finsupp.Basic (4.0s)
info: Mathlib/Algebra/BigOperators/Finsupp/Basic.lean:91:0: [Elab.command] [0.029096] theorem sum_ite_self_eq [DecidableEq α] {N : Type*} [AddCommMonoid N] (f : α →₀ N) (a : α) :
        (f.sum fun x v => ite (a = x) v 0) = f a := by
      classical
      convert f.sum_ite_eq a fun _ => id
      simp [ite_eq_right_iff.2 Eq.symm]
  [Elab.step] [0.014556] expected type: Sort ?u.8599, term
      α → ι →₀ A
    [Elab.step] [0.014533] expected type: Type (max u_4 u_2), term
        ι →₀ A
      [Elab.step] [0.014476] expected type: Type (max u_4 u_2), term
          Finsupp✝ ι A
        [Meta.synthInstance] [0.014332] ✅️ Zero A
  [Elab.definition.header] [0.012122] Finsupp.sum_ite_self_eq
info: Mathlib/Algebra/BigOperators/Finsupp/Basic.lean:91:0: [Elab.async] [0.078123] elaborating proof of Finsupp.sum_ite_self_eq
  [Elab.definition.value] [0.077160] Finsupp.sum_ite_self_eq
    [Elab.step] [0.075675] classical
          convert f.sum_ite_eq a fun _ => id
          simp [ite_eq_right_iff.2 Eq.symm]
      [Elab.step] [0.075659] classical
            convert f.sum_ite_eq a fun _ => id
            simp [ite_eq_right_iff.2 Eq.symm]
        [Elab.step] [0.075649] classical
            convert f.sum_ite_eq a fun _ => id
            simp [ite_eq_right_iff.2 Eq.symm]
          [Elab.step] [0.075399] 
                convert f.sum_ite_eq a fun _ => id
                simp [ite_eq_right_iff.2 Eq.symm]
            [Elab.step] [0.075389] 
                  convert f.sum_ite_eq a fun _ => id
                  simp [ite_eq_right_iff.2 Eq.symm]
              [Elab.step] [0.056040] convert f.sum_ite_eq a fun _ => id
                [Elab.step] [0.010471] expected type: (f.sum fun x v ↦ if a = x then id v else 0) =
                      if a ∈ f.support then id (f a) else 0, term
                    f.sum_ite_eq a fun _ => id
              [Elab.step] [0.019318] simp [ite_eq_right_iff.2 Eq.symm]
Build completed successfully (766 jobs).
```

### Trace profiling of `sum_ite_self_eq` after PR 28537
```diff
diff --git a/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean b/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
index 70d6fcb06c..8d7907ac04 100644
--- a/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
+++ b/Mathlib/Algebra/BigOperators/Finsupp/Basic.lean
@@ -87,11 +87,10 @@ theorem prod_ite_eq [DecidableEq α] (f : α →₀ M) (a : α) (b : α → M 
   dsimp [Finsupp.prod]
   rw [f.support.prod_ite_eq]
 
+set_option trace.profiler true in
 theorem sum_ite_self_eq [DecidableEq α] {N : Type*} [AddCommMonoid N] (f : α →₀ N) (a : α) :
     (f.sum fun x v => ite (a = x) v 0) = f a := by
-  classical
-    convert f.sum_ite_eq a fun _ => id
-    simp [ite_eq_right_iff.2 Eq.symm]
+  simp_all
```
```
ℹ [766/766] Built Mathlib.Algebra.BigOperators.Finsupp.Basic (4.1s)
info: Mathlib/Algebra/BigOperators/Finsupp/Basic.lean:91:0: [Elab.command] [0.021353] theorem sum_ite_self_eq [DecidableEq α] {N : Type*} [AddCommMonoid N] (f : α →₀ N) (a : α) :
        (f.sum fun x v => ite (a = x) v 0) = f a := by simp_all
  [Elab.definition.header] [0.011816] Finsupp.sum_ite_self_eq
info: Mathlib/Algebra/BigOperators/Finsupp/Basic.lean:91:0: [Elab.async] [0.029924] elaborating proof of Finsupp.sum_ite_self_eq
  [Elab.definition.value] [0.029376] Finsupp.sum_ite_self_eq
    [Elab.step] [0.028890] simp_all
      [Elab.step] [0.028875] simp_all
        [Elab.step] [0.028858] simp_all
Build completed successfully (766 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
