### PR TITLE
[Merged by Bors] - chore(Algebra/Order/Interval/Set): golf entire `one_sub_mem` using `simp_all`

### DIFF
--- a/Mathlib/Algebra/Order/Interval/Set/Instances.lean
+++ b/Mathlib/Algebra/Order/Interval/Set/Instances.lean
@@ -323,7 +323,7 @@ instance instCommSemigroup {R : Type*} [CommSemiring R] [PartialOrder R] [IsStri
 variable {β : Type*} [Ring β] [PartialOrder β] [IsOrderedRing β]
 
 theorem one_sub_mem {t : β} (ht : t ∈ Ioo (0 : β) 1) : 1 - t ∈ Ioo (0 : β) 1 := by
-  simp_all
+  grind [sub_pos, sub_lt_self_iff]
 
 theorem mem_iff_one_sub_mem {t : β} : t ∈ Ioo (0 : β) 1 ↔ 1 - t ∈ Ioo (0 : β) 1 :=
   ⟨one_sub_mem, fun h => sub_sub_cancel 1 t ▸ one_sub_mem h⟩

--- a/Mathlib/Algebra/Order/Interval/Set/Instances.lean
+++ b/Mathlib/Algebra/Order/Interval/Set/Instances.lean
@@ -323,9 +323,7 @@ instance instCommSemigroup {R : Type*} [CommSemiring R] [PartialOrder R] [IsStri
 variable {β : Type*} [Ring β] [PartialOrder β] [IsOrderedRing β]
 
 theorem one_sub_mem {t : β} (ht : t ∈ Ioo (0 : β) 1) : 1 - t ∈ Ioo (0 : β) 1 := by
-  rw [mem_Ioo] at *
-  refine ⟨sub_pos.2 ht.2, ?_⟩
-  exact lt_of_le_of_ne ((sub_le_self_iff 1).2 ht.1.le) (mt sub_eq_self.mp ht.1.ne')
+  simp_all
 
 theorem mem_iff_one_sub_mem {t : β} : t ∈ Ioo (0 : β) 1 ↔ 1 - t ∈ Ioo (0 : β) 1 :=
   ⟨one_sub_mem, fun h => sub_sub_cancel 1 t ▸ one_sub_mem h⟩

--- a/Mathlib/Algebra/Order/Interval/Set/Instances.lean
+++ b/Mathlib/Algebra/Order/Interval/Set/Instances.lean
@@ -323,7 +323,7 @@ instance instCommSemigroup {R : Type*} [CommSemiring R] [PartialOrder R] [IsStri
 variable {β : Type*} [Ring β] [PartialOrder β] [IsOrderedRing β]
 
 theorem one_sub_mem {t : β} (ht : t ∈ Ioo (0 : β) 1) : 1 - t ∈ Ioo (0 : β) 1 := by
-  simp_all
+  simp_all only [mem_Ioo, sub_pos, sub_lt_self_iff, and_self]
 
 theorem mem_iff_one_sub_mem {t : β} : t ∈ Ioo (0 : β) 1 ↔ 1 - t ∈ Ioo (0 : β) 1 :=
   ⟨one_sub_mem, fun h => sub_sub_cancel 1 t ▸ one_sub_mem h⟩

--- a/Mathlib/Algebra/Order/Interval/Set/Instances.lean
+++ b/Mathlib/Algebra/Order/Interval/Set/Instances.lean
@@ -323,7 +323,7 @@ instance instCommSemigroup {R : Type*} [CommSemiring R] [PartialOrder R] [IsStri
 variable {β : Type*} [Ring β] [PartialOrder β] [IsOrderedRing β]
 
 theorem one_sub_mem {t : β} (ht : t ∈ Ioo (0 : β) 1) : 1 - t ∈ Ioo (0 : β) 1 := by
-  grind [sub_pos, sub_lt_self_iff]
+  simp_all
 
 theorem mem_iff_one_sub_mem {t : β} : t ∈ Ioo (0 : β) 1 ↔ 1 - t ∈ Ioo (0 : β) 1 :=
   ⟨one_sub_mem, fun h => sub_sub_cancel 1 t ▸ one_sub_mem h⟩


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>one_sub_mem</code>: 29 ms before, 47 ms after </summary>

### Trace profiling of `one_sub_mem` before PR 28539
```diff
diff --git a/Mathlib/Algebra/Order/Interval/Set/Instances.lean b/Mathlib/Algebra/Order/Interval/Set/Instances.lean
index a3e0159054..a1a1bfc676 100644
--- a/Mathlib/Algebra/Order/Interval/Set/Instances.lean
+++ b/Mathlib/Algebra/Order/Interval/Set/Instances.lean
@@ -322,6 +322,7 @@ instance instCommSemigroup {R : Type*} [CommSemiring R] [PartialOrder R] [IsStri
 
 variable {β : Type*} [Ring β] [PartialOrder β] [IsOrderedRing β]
 
+set_option trace.profiler true in
 theorem one_sub_mem {t : β} (ht : t ∈ Ioo (0 : β) 1) : 1 - t ∈ Ioo (0 : β) 1 := by
   rw [mem_Ioo] at *
   refine ⟨sub_pos.2 ht.2, ?_⟩
```
```
ℹ [415/415] Built Mathlib.Algebra.Order.Interval.Set.Instances (1.4s)
info: Mathlib/Algebra/Order/Interval/Set/Instances.lean:326:0: [Elab.async] [0.029587] elaborating proof of Set.Ioo.one_sub_mem
  [Elab.definition.value] [0.029046] Set.Ioo.one_sub_mem
    [Elab.step] [0.028620] 
          rw [mem_Ioo] at *
          refine ⟨sub_pos.2 ht.2, ?_⟩
          exact lt_of_le_of_ne ((sub_le_self_iff 1).2 ht.1.le) (mt sub_eq_self.mp ht.1.ne')
      [Elab.step] [0.028608] 
            rw [mem_Ioo] at *
            refine ⟨sub_pos.2 ht.2, ?_⟩
            exact lt_of_le_of_ne ((sub_le_self_iff 1).2 ht.1.le) (mt sub_eq_self.mp ht.1.ne')
        [Elab.step] [0.017723] refine ⟨sub_pos.2 ht.2, ?_⟩
          [Meta.synthInstance] [0.014182] ✅️ AddRightStrictMono β
Build completed successfully (415 jobs).
```

### Trace profiling of `one_sub_mem` after PR 28539
```diff
diff --git a/Mathlib/Algebra/Order/Interval/Set/Instances.lean b/Mathlib/Algebra/Order/Interval/Set/Instances.lean
index a3e0159054..9ce1544a80 100644
--- a/Mathlib/Algebra/Order/Interval/Set/Instances.lean
+++ b/Mathlib/Algebra/Order/Interval/Set/Instances.lean
@@ -322,10 +322,9 @@ instance instCommSemigroup {R : Type*} [CommSemiring R] [PartialOrder R] [IsStri
 
 variable {β : Type*} [Ring β] [PartialOrder β] [IsOrderedRing β]
 
+set_option trace.profiler true in
 theorem one_sub_mem {t : β} (ht : t ∈ Ioo (0 : β) 1) : 1 - t ∈ Ioo (0 : β) 1 := by
-  rw [mem_Ioo] at *
-  refine ⟨sub_pos.2 ht.2, ?_⟩
-  exact lt_of_le_of_ne ((sub_le_self_iff 1).2 ht.1.le) (mt sub_eq_self.mp ht.1.ne')
+  simp_all
 
 theorem mem_iff_one_sub_mem {t : β} : t ∈ Ioo (0 : β) 1 ↔ 1 - t ∈ Ioo (0 : β) 1 :=
   ⟨one_sub_mem, fun h => sub_sub_cancel 1 t ▸ one_sub_mem h⟩
```
```
ℹ [415/415] Built Mathlib.Algebra.Order.Interval.Set.Instances (1.4s)
info: Mathlib/Algebra/Order/Interval/Set/Instances.lean:326:0: [Elab.async] [0.047387] elaborating proof of Set.Ioo.one_sub_mem
  [Elab.definition.value] [0.046889] Set.Ioo.one_sub_mem
    [Elab.step] [0.046569] simp_all
      [Elab.step] [0.046560] simp_all
        [Elab.step] [0.046551] simp_all
          [Meta.Tactic.simp.discharge] [0.010940] Ioo_eq_empty discharge ❌️
                ¬0 < 1
          [Meta.Tactic.simp.discharge] [0.010461] Ioo_eq_empty discharge ❌️
                ¬0 < 1
          [Meta.synthInstance] [0.012013] ✅️ AddRightStrictMono β
Build completed successfully (415 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
