### PR TITLE
[Merged by Bors] - chore(AlgebraicGeometry): golf entire `app_eq_invApp_app_of_comp_eq_aux` using `simp_all`

### DIFF
--- a/Mathlib/AlgebraicGeometry/OpenImmersion.lean
+++ b/Mathlib/AlgebraicGeometry/OpenImmersion.lean
@@ -627,11 +627,7 @@ lemma isoOfRangeEq_inv_fac {X Y Z : Scheme.{u}} (f : X ⟶ Z) (g : Y ⟶ Z)
 theorem app_eq_invApp_app_of_comp_eq_aux {X Y U : Scheme.{u}} (f : Y ⟶ U) (g : U ⟶ X) (fg : Y ⟶ X)
     (H : fg = f ≫ g) [h : IsOpenImmersion g] (V : U.Opens) :
     f ⁻¹ᵁ V = fg ⁻¹ᵁ (g ''ᵁ V) := by
-  subst H
-  rw [Scheme.comp_base, Opens.map_comp_obj]
-  congr 1
-  ext1
-  exact (Set.preimage_image_eq _ h.base_open.injective).symm
+  simp_all
 
 /-- The `fg` argument is to avoid nasty stuff about dependent types. -/
 theorem app_eq_appIso_inv_app_of_comp_eq {X Y U : Scheme.{u}} (f : Y ⟶ U) (g : U ⟶ X) (fg : Y ⟶ X)


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>app_eq_invApp_app_of_comp_eq_aux</code>: <10 ms before, <10 ms after  🎉</summary>

### Trace profiling of `app_eq_invApp_app_of_comp_eq_aux` before PR 28540
```diff
diff --git a/Mathlib/AlgebraicGeometry/OpenImmersion.lean b/Mathlib/AlgebraicGeometry/OpenImmersion.lean
index 2853909ba2..e786f436ee 100644
--- a/Mathlib/AlgebraicGeometry/OpenImmersion.lean
+++ b/Mathlib/AlgebraicGeometry/OpenImmersion.lean
@@ -624,6 +624,7 @@ lemma isoOfRangeEq_inv_fac {X Y Z : Scheme.{u}} (f : X ⟶ Z) (g : Y ⟶ Z)
     (isoOfRangeEq f g e).inv ≫ f = g :=
   lift_fac _ _ (le_of_eq e.symm)
 
+set_option trace.profiler true in
 theorem app_eq_invApp_app_of_comp_eq_aux {X Y U : Scheme.{u}} (f : Y ⟶ U) (g : U ⟶ X) (fg : Y ⟶ X)
     (H : fg = f ≫ g) [h : IsOpenImmersion g] (V : U.Opens) :
     f ⁻¹ᵁ V = fg ⁻¹ᵁ (g ''ᵁ V) := by
```
```
ℹ [2080/2080] Built Mathlib.AlgebraicGeometry.OpenImmersion (4.4s)
info: Mathlib/AlgebraicGeometry/OpenImmersion.lean:628:0: [Elab.command] [0.012864] theorem app_eq_invApp_app_of_comp_eq_aux {X Y U : Scheme.{u}} (f : Y ⟶ U) (g : U ⟶ X)
        (fg : Y ⟶ X) (H : fg = f ≫ g) [h : IsOpenImmersion g] (V : U.Opens) : f ⁻¹ᵁ V = fg ⁻¹ᵁ (g ''ᵁ V) :=
      by
      subst H
      rw [Scheme.comp_base, Opens.map_comp_obj]
      congr 1
      ext1
      exact (Set.preimage_image_eq _ h.base_open.injective).symm
  [Elab.definition.header] [0.011176] AlgebraicGeometry.IsOpenImmersion.app_eq_invApp_app_of_comp_eq_aux
info: Mathlib/AlgebraicGeometry/OpenImmersion.lean:628:0: [Elab.async] [0.010206] elaborating proof of AlgebraicGeometry.IsOpenImmersion.app_eq_invApp_app_of_comp_eq_aux
Build completed successfully (2080 jobs).
```

### Trace profiling of `app_eq_invApp_app_of_comp_eq_aux` after PR 28540
```diff
diff --git a/Mathlib/AlgebraicGeometry/OpenImmersion.lean b/Mathlib/AlgebraicGeometry/OpenImmersion.lean
index 2853909ba2..ee4364106f 100644
--- a/Mathlib/AlgebraicGeometry/OpenImmersion.lean
+++ b/Mathlib/AlgebraicGeometry/OpenImmersion.lean
@@ -624,14 +624,11 @@ lemma isoOfRangeEq_inv_fac {X Y Z : Scheme.{u}} (f : X ⟶ Z) (g : Y ⟶ Z)
     (isoOfRangeEq f g e).inv ≫ f = g :=
   lift_fac _ _ (le_of_eq e.symm)
 
+set_option trace.profiler true in
 theorem app_eq_invApp_app_of_comp_eq_aux {X Y U : Scheme.{u}} (f : Y ⟶ U) (g : U ⟶ X) (fg : Y ⟶ X)
     (H : fg = f ≫ g) [h : IsOpenImmersion g] (V : U.Opens) :
     f ⁻¹ᵁ V = fg ⁻¹ᵁ (g ''ᵁ V) := by
-  subst H
-  rw [Scheme.comp_base, Opens.map_comp_obj]
-  congr 1
-  ext1
-  exact (Set.preimage_image_eq _ h.base_open.injective).symm
+  simp_all
 
 /-- The `fg` argument is to avoid nasty stuff about dependent types. -/
 theorem app_eq_appIso_inv_app_of_comp_eq {X Y U : Scheme.{u}} (f : Y ⟶ U) (g : U ⟶ X) (fg : Y ⟶ X)
```
```
ℹ [2080/2080] Built Mathlib.AlgebraicGeometry.OpenImmersion (3.2s)
info: Mathlib/AlgebraicGeometry/OpenImmersion.lean:628:0: [Elab.command] [0.012871] theorem app_eq_invApp_app_of_comp_eq_aux {X Y U : Scheme.{u}} (f : Y ⟶ U) (g : U ⟶ X)
        (fg : Y ⟶ X) (H : fg = f ≫ g) [h : IsOpenImmersion g] (V : U.Opens) : f ⁻¹ᵁ V = fg ⁻¹ᵁ (g ''ᵁ V) := by simp_all
  [Elab.definition.header] [0.011138] AlgebraicGeometry.IsOpenImmersion.app_eq_invApp_app_of_comp_eq_aux
Build completed successfully (2080 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
