### PR TITLE
chore(Analysis/Normed/Group): golf entire `coe_inj` using `grind [DFunLike.coe_fn_eq]`

### DIFF
--- a/Mathlib/Analysis/Normed/Group/Hom.lean
+++ b/Mathlib/Analysis/Normed/Group/Hom.lean
@@ -92,7 +92,7 @@ instance toAddMonoidHomClass : AddMonoidHomClass (NormedAddGroupHom V₁ V₂) V
 initialize_simps_projections NormedAddGroupHom (toFun → apply)
 
 theorem coe_inj (H : (f : V₁ → V₂) = g) : f = g := by
-  cases f; cases g; congr
+  grind [DFunLike.coe_fn_eq]
 
 theorem coe_injective : @Function.Injective (NormedAddGroupHom V₁ V₂) (V₁ → V₂) toFun := by
   apply coe_inj


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>coe_inj</code>: <10 ms before, <10 ms after  🎉</summary>

### Trace profiling of `coe_inj` before PR 28541
```diff
diff --git a/Mathlib/Analysis/Normed/Group/Hom.lean b/Mathlib/Analysis/Normed/Group/Hom.lean
index 3779f80a73..21bdde6220 100644
--- a/Mathlib/Analysis/Normed/Group/Hom.lean
+++ b/Mathlib/Analysis/Normed/Group/Hom.lean
@@ -91,6 +91,7 @@ instance toAddMonoidHomClass : AddMonoidHomClass (NormedAddGroupHom V₁ V₂) V
 
 initialize_simps_projections NormedAddGroupHom (toFun → apply)
 
+set_option trace.profiler true in
 theorem coe_inj (H : (f : V₁ → V₂) = g) : f = g := by
   cases f; cases g; congr
 
```
```
ℹ [1487/1487] Built Mathlib.Analysis.Normed.Group.Hom (2.9s)
info: Mathlib/Analysis/Normed/Group/Hom.lean:95:0: [Elab.command] [0.016720] theorem coe_inj (H : (f : V₁ → V₂) = g) : f = g := by cases f; cases g; congr
  [Elab.definition.header] [0.015730] NormedAddGroupHom.coe_inj
    [Elab.step] [0.015594] expected type: Sort ?u.9077, term
        (f : V₁ → V₂) = g
      [Elab.step] [0.015586] expected type: Sort ?u.9077, term
          binrel% Eq✝ (f : V₁ → V₂) g
        [Meta.synthInstance] [0.014264] ✅️ CoeT (NormedAddGroupHom V₁ V₂) x (V₁ → V₂)
Build completed successfully (1487 jobs).
```

### Trace profiling of `coe_inj` after PR 28541
```diff
diff --git a/Mathlib/Analysis/Normed/Group/Hom.lean b/Mathlib/Analysis/Normed/Group/Hom.lean
index 3779f80a73..8ef0138b38 100644
--- a/Mathlib/Analysis/Normed/Group/Hom.lean
+++ b/Mathlib/Analysis/Normed/Group/Hom.lean
@@ -91,8 +91,9 @@ instance toAddMonoidHomClass : AddMonoidHomClass (NormedAddGroupHom V₁ V₂) V
 
 initialize_simps_projections NormedAddGroupHom (toFun → apply)
 
+set_option trace.profiler true in
 theorem coe_inj (H : (f : V₁ → V₂) = g) : f = g := by
-  cases f; cases g; congr
+  grind [DFunLike.coe_fn_eq]
 
 theorem coe_injective : @Function.Injective (NormedAddGroupHom V₁ V₂) (V₁ → V₂) toFun := by
   apply coe_inj
```
```
ℹ [1487/1487] Built Mathlib.Analysis.Normed.Group.Hom (2.8s)
info: Mathlib/Analysis/Normed/Group/Hom.lean:95:0: [Elab.command] [0.016377] theorem coe_inj (H : (f : V₁ → V₂) = g) : f = g := by grind [DFunLike.coe_fn_eq]
  [Elab.definition.header] [0.015314] NormedAddGroupHom.coe_inj
    [Elab.step] [0.015184] expected type: Sort ?u.9077, term
        (f : V₁ → V₂) = g
      [Elab.step] [0.015177] expected type: Sort ?u.9077, term
          binrel% Eq✝ (f : V₁ → V₂) g
        [Meta.synthInstance] [0.013829] ✅️ CoeT (NormedAddGroupHom V₁ V₂) x (V₁ → V₂)
Build completed successfully (1487 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
