### PR TITLE
chore(Analysis): golf `inner_le_Lp_mul_Lq` using `simp_all`

### DIFF
--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -888,9 +888,7 @@ theorem inner_le_Lp_mul_Lq (hpq : p.HolderConjugate q) :
   have := ENNReal.coe_le_coe.2 (@NNReal.inner_le_Lp_mul_Lq _ s (fun i => ENNReal.toNNReal (f i))
     (fun i => ENNReal.toNNReal (g i)) _ _ hpq)
   simp [ENNReal.coe_rpow_of_nonneg, hpq.pos.le, hpq.symm.pos.le] at this
-  convert this using 1 <;> [skip; congr 2] <;> [skip; skip; simp; skip; simp] <;>
-    · refine Finset.sum_congr rfl fun i hi => ?_
-      simp [H'.1 i hi, H'.2 i hi, -WithZero.coe_mul]
+  simp_all
 
 /-- **Weighted Hölder inequality**. -/
 lemma inner_le_weight_mul_Lp_of_nonneg (s : Finset ι) {p : ℝ} (hp : 1 ≤ p) (w f : ι → ℝ≥0∞) :


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>inner_le_Lp_mul_Lq</code>: 471 ms before, 2275 ms after </summary>

### Trace profiling of `inner_le_Lp_mul_Lq` before PR 28542
```diff
diff --git a/Mathlib/Analysis/MeanInequalities.lean b/Mathlib/Analysis/MeanInequalities.lean
index 6799d09e0b..0f2c9c3d0b 100644
--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -868,6 +868,7 @@ namespace ENNReal
 
 variable (f g : ι → ℝ≥0∞) {p q : ℝ}
 
+set_option trace.profiler true in
 /-- **Hölder inequality**: the scalar product of two functions is bounded by the product of their
 `L^p` and `L^q` norms when `p` and `q` are conjugate exponents. Version for sums over finite sets,
 with `ℝ≥0∞`-valued functions. -/
```
```
ℹ [1905/1905] Built Mathlib.Analysis.MeanInequalities (2.7s)
info: Mathlib/Analysis/MeanInequalities.lean:872:0: [Elab.command] [0.017259] /--
    **Hölder inequality**: the scalar product of two functions is bounded by the product of their
    `L^p` and `L^q` norms when `p` and `q` are conjugate exponents. Version for sums over finite sets,
    with `ℝ≥0∞`-valued functions. -/
    theorem inner_le_Lp_mul_Lq (hpq : p.HolderConjugate q) :
        ∑ i ∈ s, f i * g i ≤ (∑ i ∈ s, f i ^ p) ^ (1 / p) * (∑ i ∈ s, g i ^ q) ^ (1 / q) :=
      by
      by_cases H : (∑ i ∈ s, f i ^ p) ^ (1 / p) = 0 ∨ (∑ i ∈ s, g i ^ q) ^ (1 / q) = 0
      · replace H : (∀ i ∈ s, f i = 0) ∨ ∀ i ∈ s, g i = 0 := by
          simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos, asymm hpq.symm.pos,
            sum_eq_zero_iff_of_nonneg] using H
        have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by rcases H with H | H <;> simp [H i hi]
        simp [sum_eq_zero this]
      push_neg at H
      by_cases H' : (∑ i ∈ s, f i ^ p) ^ (1 / p) = ⊤ ∨ (∑ i ∈ s, g i ^ q) ^ (1 / q) = ⊤
      · rcases H' with H' | H' <;> simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
      replace H' : (∀ i ∈ s, f i ≠ ⊤) ∧ ∀ i ∈ s, g i ≠ ⊤ := by
        simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos, hpq.pos, hpq.symm.pos, ENNReal.sum_eq_top,
          not_or] using H'
      have :=
        ENNReal.coe_le_coe.2
          (@NNReal.inner_le_Lp_mul_Lq _ s (fun i => ENNReal.toNNReal (f i)) (fun i => ENNReal.toNNReal (g i)) _ _ hpq)
      simp [ENNReal.coe_rpow_of_nonneg, hpq.pos.le, hpq.symm.pos.le] at this
      convert this using 1 <;> [skip; congr 2] <;> [skip; skip; simp; skip; simp] <;>
        · refine Finset.sum_congr rfl fun i hi => ?_
          simp [H'.1 i hi, H'.2 i hi, -WithZero.coe_mul]
  [Elab.definition.header] [0.016608] ENNReal.inner_le_Lp_mul_Lq
    [Elab.step] [0.016461] expected type: Sort ?u.50036, term
        ∑ i ∈ s, f i * g i ≤ (∑ i ∈ s, f i ^ p) ^ (1 / p) * (∑ i ∈ s, g i ^ q) ^ (1 / q)
      [Elab.step] [0.016455] expected type: Sort ?u.50036, term
          binrel% LE.le✝ (∑ i ∈ s, f i * g i) ((∑ i ∈ s, f i ^ p) ^ (1 / p) * (∑ i ∈ s, g i ^ q) ^ (1 / q))
info: Mathlib/Analysis/MeanInequalities.lean:872:0: [Elab.async] [0.475096] elaborating proof of ENNReal.inner_le_Lp_mul_Lq
  [Elab.definition.value] [0.471329] ENNReal.inner_le_Lp_mul_Lq
    [Elab.step] [0.469722] 
          by_cases H : (∑ i ∈ s, f i ^ p) ^ (1 / p) = 0 ∨ (∑ i ∈ s, g i ^ q) ^ (1 / q) = 0
          · replace H : (∀ i ∈ s, f i = 0) ∨ ∀ i ∈ s, g i = 0 := by
              simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos, asymm hpq.symm.pos,
                sum_eq_zero_iff_of_nonneg] using H
            have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by rcases H with H | H <;> simp [H i hi]
            simp [sum_eq_zero this]
          push_neg at H
          by_cases H' : (∑ i ∈ s, f i ^ p) ^ (1 / p) = ⊤ ∨ (∑ i ∈ s, g i ^ q) ^ (1 / q) = ⊤
          · rcases H' with H' | H' <;> simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
          replace H' : (∀ i ∈ s, f i ≠ ⊤) ∧ ∀ i ∈ s, g i ≠ ⊤ := by
            simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos, hpq.pos, hpq.symm.pos,
              ENNReal.sum_eq_top, not_or] using H'
          have :=
            ENNReal.coe_le_coe.2
              (@NNReal.inner_le_Lp_mul_Lq _ s (fun i => ENNReal.toNNReal (f i)) (fun i => ENNReal.toNNReal (g i)) _ _
                hpq)
          simp [ENNReal.coe_rpow_of_nonneg, hpq.pos.le, hpq.symm.pos.le] at this
          convert this using 1 <;> [skip; congr 2] <;> [skip; skip; simp; skip; simp] <;>
            · refine Finset.sum_congr rfl fun i hi => ?_
              simp [H'.1 i hi, H'.2 i hi, -WithZero.coe_mul]
      [Elab.step] [0.469715] 
            by_cases H : (∑ i ∈ s, f i ^ p) ^ (1 / p) = 0 ∨ (∑ i ∈ s, g i ^ q) ^ (1 / q) = 0
            · replace H : (∀ i ∈ s, f i = 0) ∨ ∀ i ∈ s, g i = 0 := by
                simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos, asymm hpq.symm.pos,
                  sum_eq_zero_iff_of_nonneg] using H
              have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by rcases H with H | H <;> simp [H i hi]
              simp [sum_eq_zero this]
            push_neg at H
            by_cases H' : (∑ i ∈ s, f i ^ p) ^ (1 / p) = ⊤ ∨ (∑ i ∈ s, g i ^ q) ^ (1 / q) = ⊤
            · rcases H' with H' | H' <;> simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
            replace H' : (∀ i ∈ s, f i ≠ ⊤) ∧ ∀ i ∈ s, g i ≠ ⊤ := by
              simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos, hpq.pos, hpq.symm.pos,
                ENNReal.sum_eq_top, not_or] using H'
            have :=
              ENNReal.coe_le_coe.2
                (@NNReal.inner_le_Lp_mul_Lq _ s (fun i => ENNReal.toNNReal (f i)) (fun i => ENNReal.toNNReal (g i)) _ _
                  hpq)
            simp [ENNReal.coe_rpow_of_nonneg, hpq.pos.le, hpq.symm.pos.le] at this
            convert this using 1 <;> [skip; congr 2] <;> [skip; skip; simp; skip; simp] <;>
              · refine Finset.sum_congr rfl fun i hi => ?_
                simp [H'.1 i hi, H'.2 i hi, -WithZero.coe_mul]
        [Elab.step] [0.177430] ·
              replace H : (∀ i ∈ s, f i = 0) ∨ ∀ i ∈ s, g i = 0 := by
                simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos, asymm hpq.symm.pos,
                  sum_eq_zero_iff_of_nonneg] using H
              have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by rcases H with H | H <;> simp [H i hi]
              simp [sum_eq_zero this]
          [Elab.step] [0.177416] 
                replace H : (∀ i ∈ s, f i = 0) ∨ ∀ i ∈ s, g i = 0 := by
                  simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos, asymm hpq.symm.pos,
                    sum_eq_zero_iff_of_nonneg] using H
                have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by rcases H with H | H <;> simp [H i hi]
                simp [sum_eq_zero this]
            [Elab.step] [0.177410] 
                  replace H : (∀ i ∈ s, f i = 0) ∨ ∀ i ∈ s, g i = 0 := by
                    simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos, asymm hpq.symm.pos,
                      sum_eq_zero_iff_of_nonneg] using H
                  have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by rcases H with H | H <;> simp [H i hi]
                  simp [sum_eq_zero this]
              [Elab.step] [0.143312] replace H : (∀ i ∈ s, f i = 0) ∨ ∀ i ∈ s, g i = 0 := by
                    simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos, asymm hpq.symm.pos,
                      sum_eq_zero_iff_of_nonneg] using H
                [Elab.step] [0.143267] have H : (∀ i ∈ s, f i = 0) ∨ ∀ i ∈ s, g i = 0 := by
                      simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos, asymm hpq.symm.pos,
                        sum_eq_zero_iff_of_nonneg] using H
                  [Elab.step] [0.143258] focus
                        refine
                          no_implicit_lambda%
                            (have H : (∀ i ∈ s, f i = 0) ∨ ∀ i ∈ s, g i = 0 := ?body✝;
                            ?_)
                        case body✝ =>
                          with_annotate_state"by"
                            (simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos, asymm hpq.symm.pos,
                                sum_eq_zero_iff_of_nonneg] using H)
                    [Elab.step] [0.143253] 
                          refine
                            no_implicit_lambda%
                              (have H : (∀ i ∈ s, f i = 0) ∨ ∀ i ∈ s, g i = 0 := ?body✝;
                              ?_)
                          case body✝ =>
                            with_annotate_state"by"
                              (simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos,
                                  asymm hpq.symm.pos, sum_eq_zero_iff_of_nonneg] using H)
                      [Elab.step] [0.143249] 
                            refine
                              no_implicit_lambda%
                                (have H : (∀ i ∈ s, f i = 0) ∨ ∀ i ∈ s, g i = 0 := ?body✝;
                                ?_)
                            case body✝ =>
                              with_annotate_state"by"
                                (simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos,
                                    asymm hpq.symm.pos, sum_eq_zero_iff_of_nonneg] using H)
                        [Elab.step] [0.141430] case body✝ =>
                              with_annotate_state"by"
                                (simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos,
                                    asymm hpq.symm.pos, sum_eq_zero_iff_of_nonneg] using H)
                          [Elab.step] [0.141399] with_annotate_state"by"
                                  (simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos,
                                      asymm hpq.symm.pos, sum_eq_zero_iff_of_nonneg] using H)
                            [Elab.step] [0.141396] with_annotate_state"by"
                                    (simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos,
                                        asymm hpq.symm.pos, sum_eq_zero_iff_of_nonneg] using H)
                              [Elab.step] [0.141391] with_annotate_state"by"
                                    (simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos,
                                        asymm hpq.symm.pos, sum_eq_zero_iff_of_nonneg] using H)
                                [Elab.step] [0.141386] (simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos,
                                        asymm hpq.pos, asymm hpq.symm.pos, sum_eq_zero_iff_of_nonneg] using H)
                                  [Elab.step] [0.141382] simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos,
                                          asymm hpq.pos, asymm hpq.symm.pos, sum_eq_zero_iff_of_nonneg] using H
                                    [Elab.step] [0.141378] simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos,
                                            asymm hpq.pos, asymm hpq.symm.pos, sum_eq_zero_iff_of_nonneg] using H
                                      [Elab.step] [0.141369] simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos,
                                            asymm hpq.pos, asymm hpq.symm.pos, sum_eq_zero_iff_of_nonneg] using H
                                        [Meta.Tactic.simp.discharge] [0.034860] IsEmpty.forall_iff discharge ❌️
                                              IsEmpty ι
                                          [Meta.synthInstance] [0.034390] ❌️ Nonempty ι
                                        [Meta.synthInstance] [0.022147] ✅️ PosMulReflectLT ℝ
                                          [Meta.synthInstance] [0.015979] ❌️ apply @LinearOrderedCommGroupWithZero.toPosMulReflectLT to PosMulReflectLT
                                                ℝ
                                            [Meta.synthInstance.tryResolve] [0.015962] ❌️ PosMulReflectLT
                                                  ℝ ≟ PosMulReflectLT ?m.135
                                              [Meta.isDefEq] [0.015947] ❌️ PosMulReflectLT ℝ =?= PosMulReflectLT ?m.135
                                                [Meta.isDefEq] [0.015895] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul
                                                  [Meta.isDefEq.delta] [0.015855] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul
                                                    [Meta.isDefEq] [0.015845] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass
                                                      [Meta.isDefEq] [0.010510] ❌️ {
                                                            toMul :=
                                                              Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMul,
                                                            toZero :=
                                                              Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toZero,
                                                            zero_mul := ⋯,
                                                            mul_zero :=
                                                              ⋯ } =?= {
                                                            toMul :=
                                                              LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMul,
                                                            toZero :=
                                                              LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toZero,
                                                            zero_mul := ⋯, mul_zero := ⋯ }
                                                        [Meta.isDefEq] [0.010418] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMul
              [Elab.step] [0.019688] have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by
                    rcases H with H | H <;> simp [H i hi]
                [Elab.step] [0.018376] refine_lift
                      have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by rcases H with H | H <;> simp [H i hi];
                      ?_
                  [Elab.step] [0.018371] focus
                        (refine
                            no_implicit_lambda%
                              (have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by rcases H with H | H <;> simp [H i hi];
                              ?_);
                          rotate_right)
                    [Elab.step] [0.018365] (refine
                              no_implicit_lambda%
                                (have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by rcases H with H | H <;> simp [H i hi];
                                ?_);
                            rotate_right)
                      [Elab.step] [0.018355] (refine
                                no_implicit_lambda%
                                  (have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by
                                    rcases H with H | H <;> simp [H i hi];
                                  ?_);
                              rotate_right)
                        [Elab.step] [0.018351] (refine
                                no_implicit_lambda%
                                  (have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by
                                    rcases H with H | H <;> simp [H i hi];
                                  ?_);
                              rotate_right)
                          [Elab.step] [0.018347] refine
                                  no_implicit_lambda%
                                    (have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by
                                      rcases H with H | H <;> simp [H i hi];
                                    ?_);
                                rotate_right
                            [Elab.step] [0.018344] refine
                                    no_implicit_lambda%
                                      (have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by
                                        rcases H with H | H <;> simp [H i hi];
                                      ?_);
                                  rotate_right
                              [Elab.step] [0.018330] refine
                                    no_implicit_lambda%
                                      (have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by
                                        rcases H with H | H <;> simp [H i hi];
                                      ?_)
                                [Elab.step] [0.010141] rcases H with H | H <;> simp [H i hi]
                                  [Elab.step] [0.010134] rcases H with H | H <;> simp [H i hi]
                                    [Elab.step] [0.010129] rcases H with H | H <;> simp [H i hi]
                                      [Elab.step] [0.010124] focus
                                            rcases H with H | H
                                            with_annotate_state"<;>" skip
                                            all_goals simp [H i hi]
                                        [Elab.step] [0.010118] 
                                              rcases H with H | H
                                              with_annotate_state"<;>" skip
                                              all_goals simp [H i hi]
                                          [Elab.step] [0.010112] 
                                                rcases H with H | H
                                                with_annotate_state"<;>" skip
                                                all_goals simp [H i hi]
              [Elab.step] [0.014389] simp [sum_eq_zero this]
        [Elab.step] [0.022447] · rcases H' with H' | H' <;> simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
          [Elab.step] [0.022435] rcases H' with H' | H' <;> simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
            [Elab.step] [0.022431] rcases H' with H' | H' <;>
                    simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
              [Elab.step] [0.022427] rcases H' with H' | H' <;>
                    simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
                [Elab.step] [0.022421] focus
                      rcases H' with H' | H'
                      with_annotate_state"<;>" skip
                      all_goals simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
                  [Elab.step] [0.022415] 
                        rcases H' with H' | H'
                        with_annotate_state"<;>" skip
                        all_goals simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
                    [Elab.step] [0.022411] 
                          rcases H' with H' | H'
                          with_annotate_state"<;>" skip
                          all_goals simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
                      [Elab.step] [0.021851] all_goals simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
                        [Elab.step] [0.010622] simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
                          [Elab.step] [0.010619] simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
                            [Elab.step] [0.010612] simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
                        [Elab.step] [0.011042] simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
                          [Elab.step] [0.011036] simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
                            [Elab.step] [0.011029] simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
        [Elab.step] [0.144086] replace H' : (∀ i ∈ s, f i ≠ ⊤) ∧ ∀ i ∈ s, g i ≠ ⊤ := by
              simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos, hpq.pos, hpq.symm.pos,
                ENNReal.sum_eq_top, not_or] using H'
          [Elab.step] [0.143860] have H' : (∀ i ∈ s, f i ≠ ⊤) ∧ ∀ i ∈ s, g i ≠ ⊤ := by
                simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos, hpq.pos, hpq.symm.pos,
                  ENNReal.sum_eq_top, not_or] using H'
            [Elab.step] [0.143849] focus
                  refine
                    no_implicit_lambda%
                      (have H' : (∀ i ∈ s, f i ≠ ⊤) ∧ ∀ i ∈ s, g i ≠ ⊤ := ?body✝;
                      ?_)
                  case body✝ =>
                    with_annotate_state"by"
                      (simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos, hpq.pos, hpq.symm.pos,
                          ENNReal.sum_eq_top, not_or] using H')
              [Elab.step] [0.143842] 
                    refine
                      no_implicit_lambda%
                        (have H' : (∀ i ∈ s, f i ≠ ⊤) ∧ ∀ i ∈ s, g i ≠ ⊤ := ?body✝;
                        ?_)
                    case body✝ =>
                      with_annotate_state"by"
                        (simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos, hpq.pos, hpq.symm.pos,
                            ENNReal.sum_eq_top, not_or] using H')
                [Elab.step] [0.143839] 
                      refine
                        no_implicit_lambda%
                          (have H' : (∀ i ∈ s, f i ≠ ⊤) ∧ ∀ i ∈ s, g i ≠ ⊤ := ?body✝;
                          ?_)
                      case body✝ =>
                        with_annotate_state"by"
                          (simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos, hpq.pos, hpq.symm.pos,
                              ENNReal.sum_eq_top, not_or] using H')
                  [Elab.step] [0.142048] case body✝ =>
                        with_annotate_state"by"
                          (simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos, hpq.pos, hpq.symm.pos,
                              ENNReal.sum_eq_top, not_or] using H')
                    [Elab.step] [0.142011] with_annotate_state"by"
                            (simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos, hpq.pos, hpq.symm.pos,
                                ENNReal.sum_eq_top, not_or] using H')
                      [Elab.step] [0.142008] with_annotate_state"by"
                              (simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos, hpq.pos, hpq.symm.pos,
                                  ENNReal.sum_eq_top, not_or] using H')
                        [Elab.step] [0.142004] with_annotate_state"by"
                              (simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos, hpq.pos, hpq.symm.pos,
                                  ENNReal.sum_eq_top, not_or] using H')
                          [Elab.step] [0.141999] (simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos,
                                  hpq.pos, hpq.symm.pos, ENNReal.sum_eq_top, not_or] using H')
                            [Elab.step] [0.141995] simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos,
                                    hpq.pos, hpq.symm.pos, ENNReal.sum_eq_top, not_or] using H'
                              [Elab.step] [0.141991] simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos,
                                      hpq.pos, hpq.symm.pos, ENNReal.sum_eq_top, not_or] using H'
                                [Elab.step] [0.141982] simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos,
                                      asymm hpq.symm.pos, hpq.pos, hpq.symm.pos, ENNReal.sum_eq_top, not_or] using H'
                                  [Meta.Tactic.simp.discharge] [0.024493] IsEmpty.forall_iff discharge ❌️
                                        IsEmpty ι
                                    [Meta.synthInstance] [0.024140] ❌️ Nonempty ι
                                  [Meta.synthInstance] [0.017838] ✅️ PosMulReflectLT ℝ
                                    [Meta.synthInstance] [0.012761] ❌️ apply @LinearOrderedCommGroupWithZero.toPosMulReflectLT to PosMulReflectLT
                                          ℝ
                                      [Meta.synthInstance.tryResolve] [0.012744] ❌️ PosMulReflectLT
                                            ℝ ≟ PosMulReflectLT ?m.261
                                        [Meta.isDefEq] [0.012732] ❌️ PosMulReflectLT ℝ =?= PosMulReflectLT ?m.261
                                          [Meta.isDefEq] [0.012682] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul
                                            [Meta.isDefEq.delta] [0.012655] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul
                                              [Meta.isDefEq] [0.012644] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass
        [Elab.step] [0.082150] simp [ENNReal.coe_rpow_of_nonneg, hpq.pos.le, hpq.symm.pos.le] at this
          [Meta.Tactic.simp.discharge] [0.034535] coe_rpow_of_nonneg discharge ✅️
                0 ≤ p⁻¹
            [Meta.synthInstance] [0.010380] ❌️ CanonicallyOrderedAdd ℝ
              [Meta.synthInstance] [0.010352] ❌️ apply @IdemSemiring.toCanonicallyOrderedAdd to CanonicallyOrderedAdd ℝ
                [Meta.synthInstance.tryResolve] [0.010337] ❌️ CanonicallyOrderedAdd ℝ ≟ CanonicallyOrderedAdd ?m.282
                  [Meta.isDefEq] [0.010326] ❌️ CanonicallyOrderedAdd ℝ =?= CanonicallyOrderedAdd ?m.282
                    [Meta.isDefEq] [0.010279] ❌️ Real.instAddMonoid.toAddZeroClass.toAdd =?= IdemSemiring.toSemiring.toNonAssocSemiring.toDistrib.toAdd
                      [Meta.isDefEq] [0.010156] ❌️ Real.instAddMonoid.toAddZeroClass.2 =?= IdemSemiring.toSemiring.toNonAssocSemiring.toDistrib.2
                        [Meta.isDefEq] [0.010134] ❌️ Real.instAddMonoid.toAdd =?= IdemSemiring.toSemiring.toNonAssocSemiring.toAdd
            [Meta.synthInstance] [0.018217] ✅️ PosMulReflectLT ℝ
              [Meta.synthInstance] [0.012802] ❌️ apply @LinearOrderedCommGroupWithZero.toPosMulReflectLT to PosMulReflectLT
                    ℝ
                [Meta.synthInstance.tryResolve] [0.012787] ❌️ PosMulReflectLT ℝ ≟ PosMulReflectLT ?m.282
                  [Meta.isDefEq] [0.012778] ❌️ PosMulReflectLT ℝ =?= PosMulReflectLT ?m.282
                    [Meta.isDefEq] [0.012729] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul
                      [Meta.isDefEq.delta] [0.012694] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul
                        [Meta.isDefEq] [0.012682] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass
        [Elab.step] [0.025837] convert this using 1 <;> [skip; congr 2] <;> [skip; skip; simp; skip; simp] <;>
              · refine Finset.sum_congr rfl fun i hi => ?_
                simp [H'.1 i hi, H'.2 i hi, -WithZero.coe_mul]
          [Elab.step] [0.025001] focus
                convert this using 1 <;> [skip; congr 2] <;> [skip; skip; simp; skip; simp]
                with_annotate_state"<;>" skip
                all_goals
                  · refine Finset.sum_congr rfl fun i hi => ?_
                    simp [H'.1 i hi, H'.2 i hi, -WithZero.coe_mul]
            [Elab.step] [0.024992] 
                  convert this using 1 <;> [skip; congr 2] <;> [skip; skip; simp; skip; simp]
                  with_annotate_state"<;>" skip
                  all_goals
                    · refine Finset.sum_congr rfl fun i hi => ?_
                      simp [H'.1 i hi, H'.2 i hi, -WithZero.coe_mul]
              [Elab.step] [0.024984] 
                    convert this using 1 <;> [skip; congr 2] <;> [skip; skip; simp; skip; simp]
                    with_annotate_state"<;>" skip
                    all_goals
                      · refine Finset.sum_congr rfl fun i hi => ?_
                        simp [H'.1 i hi, H'.2 i hi, -WithZero.coe_mul]
                [Elab.step] [0.017807] convert this using 1 <;> [skip; congr 2] <;> [skip; skip; simp; skip; simp]
                  [Elab.step] [0.017673] focus
                        (convert this using 1 <;> [skip; congr 2]; map_tacs [skip; skip; simp; skip; simp])
                    [Elab.step] [0.017668] (convert this using 1 <;> [skip; congr 2];
                            map_tacs [skip; skip; simp; skip; simp])
                      [Elab.step] [0.017665] (convert this using 1 <;> [skip; congr 2];
                              map_tacs [skip; skip; simp; skip; simp])
                        [Elab.step] [0.017661] (convert this using 1 <;> [skip; congr 2];
                              map_tacs [skip; skip; simp; skip; simp])
                          [Elab.step] [0.017657] convert this using 1 <;> [skip; congr 2];
                                map_tacs [skip; skip; simp; skip; simp]
                            [Elab.step] [0.017653] convert this using 1 <;> [skip; congr 2];
                                  map_tacs [skip; skip; simp; skip; simp]
                              [Elab.step] [0.015696] convert this using 1 <;> [skip; congr 2]
                                [Elab.step] [0.015654] focus (convert this using 1; map_tacs [skip; congr 2])
                                  [Elab.step] [0.015649] (convert this using 1; map_tacs [skip; congr 2])
                                    [Elab.step] [0.015646] (convert this using 1; map_tacs [skip; congr 2])
                                      [Elab.step] [0.015642] (convert this using 1; map_tacs [skip; congr 2])
                                        [Elab.step] [0.015638] convert this using 1; map_tacs [skip; congr 2]
                                          [Elab.step] [0.015631] convert this using 1; map_tacs [skip; congr 2]
Build completed successfully (1905 jobs).
```

### Trace profiling of `inner_le_Lp_mul_Lq` after PR 28542
```diff
diff --git a/Mathlib/Analysis/MeanInequalities.lean b/Mathlib/Analysis/MeanInequalities.lean
index 6799d09e0b..2c14160005 100644
--- a/Mathlib/Analysis/MeanInequalities.lean
+++ b/Mathlib/Analysis/MeanInequalities.lean
@@ -868,6 +868,7 @@ namespace ENNReal
 
 variable (f g : ι → ℝ≥0∞) {p q : ℝ}
 
+set_option trace.profiler true in
 /-- **Hölder inequality**: the scalar product of two functions is bounded by the product of their
 `L^p` and `L^q` norms when `p` and `q` are conjugate exponents. Version for sums over finite sets,
 with `ℝ≥0∞`-valued functions. -/
@@ -888,9 +889,7 @@ theorem inner_le_Lp_mul_Lq (hpq : p.HolderConjugate q) :
   have := ENNReal.coe_le_coe.2 (@NNReal.inner_le_Lp_mul_Lq _ s (fun i => ENNReal.toNNReal (f i))
     (fun i => ENNReal.toNNReal (g i)) _ _ hpq)
   simp [ENNReal.coe_rpow_of_nonneg, hpq.pos.le, hpq.symm.pos.le] at this
-  convert this using 1 <;> [skip; congr 2] <;> [skip; skip; simp; skip; simp] <;>
-    · refine Finset.sum_congr rfl fun i hi => ?_
-      simp [H'.1 i hi, H'.2 i hi, -WithZero.coe_mul]
+  simp_all
 
 /-- **Weighted Hölder inequality**. -/
 lemma inner_le_weight_mul_Lp_of_nonneg (s : Finset ι) {p : ℝ} (hp : 1 ≤ p) (w f : ι → ℝ≥0∞) :
```
```
ℹ [1905/1905] Built Mathlib.Analysis.MeanInequalities (4.3s)
info: Mathlib/Analysis/MeanInequalities.lean:872:0: [Elab.command] [0.019242] /--
    **Hölder inequality**: the scalar product of two functions is bounded by the product of their
    `L^p` and `L^q` norms when `p` and `q` are conjugate exponents. Version for sums over finite sets,
    with `ℝ≥0∞`-valued functions. -/
    theorem inner_le_Lp_mul_Lq (hpq : p.HolderConjugate q) :
        ∑ i ∈ s, f i * g i ≤ (∑ i ∈ s, f i ^ p) ^ (1 / p) * (∑ i ∈ s, g i ^ q) ^ (1 / q) :=
      by
      by_cases H : (∑ i ∈ s, f i ^ p) ^ (1 / p) = 0 ∨ (∑ i ∈ s, g i ^ q) ^ (1 / q) = 0
      · replace H : (∀ i ∈ s, f i = 0) ∨ ∀ i ∈ s, g i = 0 := by
          simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos, asymm hpq.symm.pos,
            sum_eq_zero_iff_of_nonneg] using H
        have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by rcases H with H | H <;> simp [H i hi]
        simp [sum_eq_zero this]
      push_neg at H
      by_cases H' : (∑ i ∈ s, f i ^ p) ^ (1 / p) = ⊤ ∨ (∑ i ∈ s, g i ^ q) ^ (1 / q) = ⊤
      · rcases H' with H' | H' <;> simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
      replace H' : (∀ i ∈ s, f i ≠ ⊤) ∧ ∀ i ∈ s, g i ≠ ⊤ := by
        simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos, hpq.pos, hpq.symm.pos, ENNReal.sum_eq_top,
          not_or] using H'
      have :=
        ENNReal.coe_le_coe.2
          (@NNReal.inner_le_Lp_mul_Lq _ s (fun i => ENNReal.toNNReal (f i)) (fun i => ENNReal.toNNReal (g i)) _ _ hpq)
      simp [ENNReal.coe_rpow_of_nonneg, hpq.pos.le, hpq.symm.pos.le] at this
      simp_all
  [Elab.definition.header] [0.018460] ENNReal.inner_le_Lp_mul_Lq
    [Elab.step] [0.018296] expected type: Sort ?u.50036, term
        ∑ i ∈ s, f i * g i ≤ (∑ i ∈ s, f i ^ p) ^ (1 / p) * (∑ i ∈ s, g i ^ q) ^ (1 / q)
      [Elab.step] [0.018288] expected type: Sort ?u.50036, term
          binrel% LE.le✝ (∑ i ∈ s, f i * g i) ((∑ i ∈ s, f i ^ p) ^ (1 / p) * (∑ i ∈ s, g i ^ q) ^ (1 / q))
info: Mathlib/Analysis/MeanInequalities.lean:872:0: [Elab.async] [2.278103] elaborating proof of ENNReal.inner_le_Lp_mul_Lq
  [Elab.definition.value] [2.274956] ENNReal.inner_le_Lp_mul_Lq
    [Elab.step] [2.273397] 
          by_cases H : (∑ i ∈ s, f i ^ p) ^ (1 / p) = 0 ∨ (∑ i ∈ s, g i ^ q) ^ (1 / q) = 0
          · replace H : (∀ i ∈ s, f i = 0) ∨ ∀ i ∈ s, g i = 0 := by
              simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos, asymm hpq.symm.pos,
                sum_eq_zero_iff_of_nonneg] using H
            have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by rcases H with H | H <;> simp [H i hi]
            simp [sum_eq_zero this]
          push_neg at H
          by_cases H' : (∑ i ∈ s, f i ^ p) ^ (1 / p) = ⊤ ∨ (∑ i ∈ s, g i ^ q) ^ (1 / q) = ⊤
          · rcases H' with H' | H' <;> simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
          replace H' : (∀ i ∈ s, f i ≠ ⊤) ∧ ∀ i ∈ s, g i ≠ ⊤ := by
            simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos, hpq.pos, hpq.symm.pos,
              ENNReal.sum_eq_top, not_or] using H'
          have :=
            ENNReal.coe_le_coe.2
              (@NNReal.inner_le_Lp_mul_Lq _ s (fun i => ENNReal.toNNReal (f i)) (fun i => ENNReal.toNNReal (g i)) _ _
                hpq)
          simp [ENNReal.coe_rpow_of_nonneg, hpq.pos.le, hpq.symm.pos.le] at this
          simp_all
      [Elab.step] [2.273383] 
            by_cases H : (∑ i ∈ s, f i ^ p) ^ (1 / p) = 0 ∨ (∑ i ∈ s, g i ^ q) ^ (1 / q) = 0
            · replace H : (∀ i ∈ s, f i = 0) ∨ ∀ i ∈ s, g i = 0 := by
                simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos, asymm hpq.symm.pos,
                  sum_eq_zero_iff_of_nonneg] using H
              have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by rcases H with H | H <;> simp [H i hi]
              simp [sum_eq_zero this]
            push_neg at H
            by_cases H' : (∑ i ∈ s, f i ^ p) ^ (1 / p) = ⊤ ∨ (∑ i ∈ s, g i ^ q) ^ (1 / q) = ⊤
            · rcases H' with H' | H' <;> simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
            replace H' : (∀ i ∈ s, f i ≠ ⊤) ∧ ∀ i ∈ s, g i ≠ ⊤ := by
              simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos, hpq.pos, hpq.symm.pos,
                ENNReal.sum_eq_top, not_or] using H'
            have :=
              ENNReal.coe_le_coe.2
                (@NNReal.inner_le_Lp_mul_Lq _ s (fun i => ENNReal.toNNReal (f i)) (fun i => ENNReal.toNNReal (g i)) _ _
                  hpq)
            simp [ENNReal.coe_rpow_of_nonneg, hpq.pos.le, hpq.symm.pos.le] at this
            simp_all
        [Elab.step] [0.173027] ·
              replace H : (∀ i ∈ s, f i = 0) ∨ ∀ i ∈ s, g i = 0 := by
                simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos, asymm hpq.symm.pos,
                  sum_eq_zero_iff_of_nonneg] using H
              have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by rcases H with H | H <;> simp [H i hi]
              simp [sum_eq_zero this]
          [Elab.step] [0.173012] 
                replace H : (∀ i ∈ s, f i = 0) ∨ ∀ i ∈ s, g i = 0 := by
                  simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos, asymm hpq.symm.pos,
                    sum_eq_zero_iff_of_nonneg] using H
                have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by rcases H with H | H <;> simp [H i hi]
                simp [sum_eq_zero this]
            [Elab.step] [0.173006] 
                  replace H : (∀ i ∈ s, f i = 0) ∨ ∀ i ∈ s, g i = 0 := by
                    simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos, asymm hpq.symm.pos,
                      sum_eq_zero_iff_of_nonneg] using H
                  have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by rcases H with H | H <;> simp [H i hi]
                  simp [sum_eq_zero this]
              [Elab.step] [0.138471] replace H : (∀ i ∈ s, f i = 0) ∨ ∀ i ∈ s, g i = 0 := by
                    simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos, asymm hpq.symm.pos,
                      sum_eq_zero_iff_of_nonneg] using H
                [Elab.step] [0.138431] have H : (∀ i ∈ s, f i = 0) ∨ ∀ i ∈ s, g i = 0 := by
                      simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos, asymm hpq.symm.pos,
                        sum_eq_zero_iff_of_nonneg] using H
                  [Elab.step] [0.138422] focus
                        refine
                          no_implicit_lambda%
                            (have H : (∀ i ∈ s, f i = 0) ∨ ∀ i ∈ s, g i = 0 := ?body✝;
                            ?_)
                        case body✝ =>
                          with_annotate_state"by"
                            (simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos, asymm hpq.symm.pos,
                                sum_eq_zero_iff_of_nonneg] using H)
                    [Elab.step] [0.138416] 
                          refine
                            no_implicit_lambda%
                              (have H : (∀ i ∈ s, f i = 0) ∨ ∀ i ∈ s, g i = 0 := ?body✝;
                              ?_)
                          case body✝ =>
                            with_annotate_state"by"
                              (simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos,
                                  asymm hpq.symm.pos, sum_eq_zero_iff_of_nonneg] using H)
                      [Elab.step] [0.138412] 
                            refine
                              no_implicit_lambda%
                                (have H : (∀ i ∈ s, f i = 0) ∨ ∀ i ∈ s, g i = 0 := ?body✝;
                                ?_)
                            case body✝ =>
                              with_annotate_state"by"
                                (simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos,
                                    asymm hpq.symm.pos, sum_eq_zero_iff_of_nonneg] using H)
                        [Elab.step] [0.136245] case body✝ =>
                              with_annotate_state"by"
                                (simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos,
                                    asymm hpq.symm.pos, sum_eq_zero_iff_of_nonneg] using H)
                          [Elab.step] [0.136215] with_annotate_state"by"
                                  (simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos,
                                      asymm hpq.symm.pos, sum_eq_zero_iff_of_nonneg] using H)
                            [Elab.step] [0.136211] with_annotate_state"by"
                                    (simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos,
                                        asymm hpq.symm.pos, sum_eq_zero_iff_of_nonneg] using H)
                              [Elab.step] [0.136205] with_annotate_state"by"
                                    (simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos, asymm hpq.pos,
                                        asymm hpq.symm.pos, sum_eq_zero_iff_of_nonneg] using H)
                                [Elab.step] [0.136199] (simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos,
                                        asymm hpq.pos, asymm hpq.symm.pos, sum_eq_zero_iff_of_nonneg] using H)
                                  [Elab.step] [0.136194] simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos,
                                          asymm hpq.pos, asymm hpq.symm.pos, sum_eq_zero_iff_of_nonneg] using H
                                    [Elab.step] [0.136189] simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos,
                                            asymm hpq.pos, asymm hpq.symm.pos, sum_eq_zero_iff_of_nonneg] using H
                                      [Elab.step] [0.136178] simpa [ENNReal.rpow_eq_zero_iff, hpq.pos, hpq.symm.pos,
                                            asymm hpq.pos, asymm hpq.symm.pos, sum_eq_zero_iff_of_nonneg] using H
                                        [Meta.Tactic.simp.discharge] [0.031314] IsEmpty.forall_iff discharge ❌️
                                              IsEmpty ι
                                          [Meta.synthInstance] [0.030819] ❌️ Nonempty ι
                                        [Meta.synthInstance] [0.021862] ✅️ PosMulReflectLT ℝ
                                          [Meta.synthInstance] [0.015427] ❌️ apply @LinearOrderedCommGroupWithZero.toPosMulReflectLT to PosMulReflectLT
                                                ℝ
                                            [Meta.synthInstance.tryResolve] [0.015409] ❌️ PosMulReflectLT
                                                  ℝ ≟ PosMulReflectLT ?m.135
                                              [Meta.isDefEq] [0.015394] ❌️ PosMulReflectLT ℝ =?= PosMulReflectLT ?m.135
                                                [Meta.isDefEq] [0.015340] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul
                                                  [Meta.isDefEq.delta] [0.015295] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul
                                                    [Meta.isDefEq] [0.015284] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass
                                                      [Meta.isDefEq] [0.010413] ❌️ {
                                                            toMul :=
                                                              Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMul,
                                                            toZero :=
                                                              Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toZero,
                                                            zero_mul := ⋯,
                                                            mul_zero :=
                                                              ⋯ } =?= {
                                                            toMul :=
                                                              LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMul,
                                                            toZero :=
                                                              LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toZero,
                                                            zero_mul := ⋯, mul_zero := ⋯ }
                                                        [Meta.isDefEq] [0.010350] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMul
              [Elab.step] [0.020044] have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by
                    rcases H with H | H <;> simp [H i hi]
                [Elab.step] [0.018721] refine_lift
                      have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by rcases H with H | H <;> simp [H i hi];
                      ?_
                  [Elab.step] [0.018715] focus
                        (refine
                            no_implicit_lambda%
                              (have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by rcases H with H | H <;> simp [H i hi];
                              ?_);
                          rotate_right)
                    [Elab.step] [0.018708] (refine
                              no_implicit_lambda%
                                (have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by rcases H with H | H <;> simp [H i hi];
                                ?_);
                            rotate_right)
                      [Elab.step] [0.018704] (refine
                                no_implicit_lambda%
                                  (have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by
                                    rcases H with H | H <;> simp [H i hi];
                                  ?_);
                              rotate_right)
                        [Elab.step] [0.018699] (refine
                                no_implicit_lambda%
                                  (have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by
                                    rcases H with H | H <;> simp [H i hi];
                                  ?_);
                              rotate_right)
                          [Elab.step] [0.018695] refine
                                  no_implicit_lambda%
                                    (have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by
                                      rcases H with H | H <;> simp [H i hi];
                                    ?_);
                                rotate_right
                            [Elab.step] [0.018692] refine
                                    no_implicit_lambda%
                                      (have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by
                                        rcases H with H | H <;> simp [H i hi];
                                      ?_);
                                  rotate_right
                              [Elab.step] [0.018676] refine
                                    no_implicit_lambda%
                                      (have : ∀ i ∈ s, f i * g i = 0 := fun i hi => by
                                        rcases H with H | H <;> simp [H i hi];
                                      ?_)
                                [Elab.step] [0.010211] rcases H with H | H <;> simp [H i hi]
                                  [Elab.step] [0.010205] rcases H with H | H <;> simp [H i hi]
                                    [Elab.step] [0.010200] rcases H with H | H <;> simp [H i hi]
                                      [Elab.step] [0.010194] focus
                                            rcases H with H | H
                                            with_annotate_state"<;>" skip
                                            all_goals simp [H i hi]
                                        [Elab.step] [0.010189] 
                                              rcases H with H | H
                                              with_annotate_state"<;>" skip
                                              all_goals simp [H i hi]
                                          [Elab.step] [0.010183] 
                                                rcases H with H | H
                                                with_annotate_state"<;>" skip
                                                all_goals simp [H i hi]
              [Elab.step] [0.014468] simp [sum_eq_zero this]
        [Elab.step] [0.022065] · rcases H' with H' | H' <;> simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
          [Elab.step] [0.022054] rcases H' with H' | H' <;> simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
            [Elab.step] [0.022050] rcases H' with H' | H' <;>
                    simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
              [Elab.step] [0.022045] rcases H' with H' | H' <;>
                    simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
                [Elab.step] [0.022039] focus
                      rcases H' with H' | H'
                      with_annotate_state"<;>" skip
                      all_goals simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
                  [Elab.step] [0.022034] 
                        rcases H' with H' | H'
                        with_annotate_state"<;>" skip
                        all_goals simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
                    [Elab.step] [0.022031] 
                          rcases H' with H' | H'
                          with_annotate_state"<;>" skip
                          all_goals simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
                      [Elab.step] [0.021492] all_goals simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
                        [Elab.step] [0.010953] simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
                          [Elab.step] [0.010950] simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
                            [Elab.step] [0.010942] simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
                        [Elab.step] [0.010360] simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
                          [Elab.step] [0.010355] simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
                            [Elab.step] [0.010348] simp [H', -one_div, -sum_eq_zero_iff, -rpow_eq_zero_iff, H]
        [Elab.step] [0.145595] replace H' : (∀ i ∈ s, f i ≠ ⊤) ∧ ∀ i ∈ s, g i ≠ ⊤ := by
              simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos, hpq.pos, hpq.symm.pos,
                ENNReal.sum_eq_top, not_or] using H'
          [Elab.step] [0.145358] have H' : (∀ i ∈ s, f i ≠ ⊤) ∧ ∀ i ∈ s, g i ≠ ⊤ := by
                simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos, hpq.pos, hpq.symm.pos,
                  ENNReal.sum_eq_top, not_or] using H'
            [Elab.step] [0.145349] focus
                  refine
                    no_implicit_lambda%
                      (have H' : (∀ i ∈ s, f i ≠ ⊤) ∧ ∀ i ∈ s, g i ≠ ⊤ := ?body✝;
                      ?_)
                  case body✝ =>
                    with_annotate_state"by"
                      (simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos, hpq.pos, hpq.symm.pos,
                          ENNReal.sum_eq_top, not_or] using H')
              [Elab.step] [0.145343] 
                    refine
                      no_implicit_lambda%
                        (have H' : (∀ i ∈ s, f i ≠ ⊤) ∧ ∀ i ∈ s, g i ≠ ⊤ := ?body✝;
                        ?_)
                    case body✝ =>
                      with_annotate_state"by"
                        (simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos, hpq.pos, hpq.symm.pos,
                            ENNReal.sum_eq_top, not_or] using H')
                [Elab.step] [0.145339] 
                      refine
                        no_implicit_lambda%
                          (have H' : (∀ i ∈ s, f i ≠ ⊤) ∧ ∀ i ∈ s, g i ≠ ⊤ := ?body✝;
                          ?_)
                      case body✝ =>
                        with_annotate_state"by"
                          (simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos, hpq.pos, hpq.symm.pos,
                              ENNReal.sum_eq_top, not_or] using H')
                  [Elab.step] [0.143665] case body✝ =>
                        with_annotate_state"by"
                          (simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos, hpq.pos, hpq.symm.pos,
                              ENNReal.sum_eq_top, not_or] using H')
                    [Elab.step] [0.143629] with_annotate_state"by"
                            (simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos, hpq.pos, hpq.symm.pos,
                                ENNReal.sum_eq_top, not_or] using H')
                      [Elab.step] [0.143625] with_annotate_state"by"
                              (simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos, hpq.pos, hpq.symm.pos,
                                  ENNReal.sum_eq_top, not_or] using H')
                        [Elab.step] [0.143622] with_annotate_state"by"
                              (simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos, hpq.pos, hpq.symm.pos,
                                  ENNReal.sum_eq_top, not_or] using H')
                          [Elab.step] [0.143617] (simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos,
                                  hpq.pos, hpq.symm.pos, ENNReal.sum_eq_top, not_or] using H')
                            [Elab.step] [0.143613] simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos,
                                    hpq.pos, hpq.symm.pos, ENNReal.sum_eq_top, not_or] using H'
                              [Elab.step] [0.143610] simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos, asymm hpq.symm.pos,
                                      hpq.pos, hpq.symm.pos, ENNReal.sum_eq_top, not_or] using H'
                                [Elab.step] [0.143601] simpa [ENNReal.rpow_eq_top_iff, asymm hpq.pos,
                                      asymm hpq.symm.pos, hpq.pos, hpq.symm.pos, ENNReal.sum_eq_top, not_or] using H'
                                  [Meta.Tactic.simp.discharge] [0.024054] IsEmpty.forall_iff discharge ❌️
                                        IsEmpty ι
                                    [Meta.synthInstance] [0.023692] ❌️ Nonempty ι
                                  [Meta.synthInstance] [0.017921] ✅️ PosMulReflectLT ℝ
                                    [Meta.synthInstance] [0.012739] ❌️ apply @LinearOrderedCommGroupWithZero.toPosMulReflectLT to PosMulReflectLT
                                          ℝ
                                      [Meta.synthInstance.tryResolve] [0.012721] ❌️ PosMulReflectLT
                                            ℝ ≟ PosMulReflectLT ?m.261
                                        [Meta.isDefEq] [0.012708] ❌️ PosMulReflectLT ℝ =?= PosMulReflectLT ?m.261
                                          [Meta.isDefEq] [0.012657] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul
                                            [Meta.isDefEq.delta] [0.012630] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul
                                              [Meta.isDefEq] [0.012616] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass
        [Elab.step] [0.082708] simp [ENNReal.coe_rpow_of_nonneg, hpq.pos.le, hpq.symm.pos.le] at this
          [Meta.Tactic.simp.discharge] [0.034391] coe_rpow_of_nonneg discharge ✅️
                0 ≤ p⁻¹
            [Meta.synthInstance] [0.010144] ❌️ CanonicallyOrderedAdd ℝ
              [Meta.synthInstance] [0.010120] ❌️ apply @IdemSemiring.toCanonicallyOrderedAdd to CanonicallyOrderedAdd ℝ
                [Meta.synthInstance.tryResolve] [0.010107] ❌️ CanonicallyOrderedAdd ℝ ≟ CanonicallyOrderedAdd ?m.282
                  [Meta.isDefEq] [0.010099] ❌️ CanonicallyOrderedAdd ℝ =?= CanonicallyOrderedAdd ?m.282
                    [Meta.isDefEq] [0.010055] ❌️ Real.instAddMonoid.toAddZeroClass.toAdd =?= IdemSemiring.toSemiring.toNonAssocSemiring.toDistrib.toAdd
            [Meta.synthInstance] [0.018401] ✅️ PosMulReflectLT ℝ
              [Meta.synthInstance] [0.012824] ❌️ apply @LinearOrderedCommGroupWithZero.toPosMulReflectLT to PosMulReflectLT
                    ℝ
                [Meta.synthInstance.tryResolve] [0.012807] ❌️ PosMulReflectLT ℝ ≟ PosMulReflectLT ?m.282
                  [Meta.isDefEq] [0.012795] ❌️ PosMulReflectLT ℝ =?= PosMulReflectLT ?m.282
                    [Meta.isDefEq] [0.012747] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul
                      [Meta.isDefEq.delta] [0.012711] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul
                        [Meta.isDefEq] [0.012699] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass
        [Elab.step] [1.833055] simp_all
          [Meta.Tactic.simp.discharge] [0.023933] IsEmpty.forall_iff discharge ❌️
                IsEmpty ι
            [Meta.synthInstance] [0.023588] ❌️ Nonempty ι
          [Meta.Tactic.simp.discharge] [0.023222] IsEmpty.forall_iff discharge ❌️
                IsEmpty ι
            [Meta.synthInstance] [0.022878] ❌️ Nonempty ι
          [Meta.synthInstance] [0.018026] ✅️ PosMulReflectLT ℝ
            [Meta.synthInstance] [0.012613] ❌️ apply @LinearOrderedCommGroupWithZero.toPosMulReflectLT to PosMulReflectLT
                  ℝ
              [Meta.synthInstance.tryResolve] [0.012596] ❌️ PosMulReflectLT ℝ ≟ PosMulReflectLT ?m.283
                [Meta.isDefEq] [0.012506] ❌️ PosMulReflectLT ℝ =?= PosMulReflectLT ?m.283
                  [Meta.isDefEq] [0.012458] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul
                    [Meta.isDefEq.delta] [0.012423] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul
                      [Meta.isDefEq] [0.012412] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass
          [Meta.isDefEq] [0.018690] ❌️ ?a < 0 =?= p < 0
            [Meta.isDefEq] [0.018617] ❌️ 0 =?= 0
              [Meta.isDefEq] [0.018595] ❌️ Zero.toOfNat0 =?= Zero.toOfNat0
          [Meta.isDefEq] [0.018377] ❌️ ?a ≤ 0 =?= p ≤ 0
            [Meta.isDefEq] [0.018301] ❌️ 0 =?= 0
              [Meta.isDefEq] [0.018277] ❌️ Zero.toOfNat0 =?= Zero.toOfNat0
          [Meta.Tactic.simp.discharge] [0.075849] IsEmpty.forall_iff discharge ❌️
                IsEmpty (∀ i ∈ s, f i = 0 ∧ 0 < p)
            [Meta.Tactic.simp.discharge] [0.022226] IsEmpty.exists_iff discharge ❌️
                  IsEmpty ι
              [Meta.synthInstance] [0.022047] ❌️ Nonempty ι
          [Meta.isDefEq] [0.018301] ❌️ ?a ≤ 0 =?= p ≤ 0
            [Meta.isDefEq] [0.018230] ❌️ 0 =?= 0
              [Meta.isDefEq] [0.018200] ❌️ Zero.toOfNat0 =?= Zero.toOfNat0
          [Meta.Tactic.simp.discharge] [0.074207] IsEmpty.forall_iff discharge ❌️
                IsEmpty (∀ i ∈ s, f i = 0 ∧ 0 < p)
            [Meta.Tactic.simp.discharge] [0.021929] IsEmpty.exists_iff discharge ❌️
                  IsEmpty ι
              [Meta.synthInstance] [0.021755] ❌️ Nonempty ι
          [Meta.isDefEq] [0.018494] ❌️ ?a < 0 =?= p < 0
            [Meta.isDefEq] [0.018424] ❌️ 0 =?= 0
              [Meta.isDefEq] [0.018386] ❌️ Zero.toOfNat0 =?= Zero.toOfNat0
          [Meta.isDefEq] [0.017912] ❌️ 0 ≤ ?a =?= 0 ≤ p
            [Meta.isDefEq] [0.017830] ❌️ 0 =?= 0
              [Meta.isDefEq] [0.017806] ❌️ Zero.toOfNat0 =?= Zero.toOfNat0
          [Meta.Tactic.simp.discharge] [0.120263] IsEmpty.forall_iff discharge ❌️
                IsEmpty (∃ a ∈ s, f a = 0 ∧ p < 0 ∨ f a = ⊤ ∧ 0 < p)
            [Meta.Tactic.simp.discharge] [0.022592] IsEmpty.forall_iff discharge ❌️
                  IsEmpty ι
              [Meta.synthInstance] [0.022397] ❌️ Nonempty ι
            [Meta.Tactic.simp.discharge] [0.022254] IsEmpty.forall_iff discharge ❌️
                  IsEmpty ι
              [Meta.synthInstance] [0.022064] ❌️ Nonempty ι
          [Meta.isDefEq] [0.018541] ❌️ 0 ≤ ?a =?= 0 ≤ p
            [Meta.isDefEq] [0.018467] ❌️ 0 =?= 0
              [Meta.isDefEq] [0.018437] ❌️ Zero.toOfNat0 =?= Zero.toOfNat0
          [Meta.Tactic.simp.discharge] [0.053348] IsEmpty.forall_iff discharge ❌️
                IsEmpty (x ∈ s ∧ (f x = 0 ∧ p < 0 ∨ f x = ⊤ ∧ 0 < p))
          [Meta.isDefEq] [0.018650] ❌️ 0 ≤ ?a =?= 0 ≤ p
            [Meta.isDefEq] [0.018577] ❌️ 0 =?= 0
              [Meta.isDefEq] [0.018547] ❌️ Zero.toOfNat0 =?= Zero.toOfNat0
          [Meta.Tactic.simp.discharge] [0.029828] IsEmpty.forall_iff discharge ❌️
                IsEmpty (f x = 0 ∧ p < 0)
          [Meta.isDefEq] [0.018335] ❌️ 0 ≤ ?a =?= 0 ≤ p
            [Meta.isDefEq] [0.018264] ❌️ 0 =?= 0
              [Meta.isDefEq] [0.018235] ❌️ Zero.toOfNat0 =?= Zero.toOfNat0
          [Meta.isDefEq] [0.018341] ❌️ 0 ≤ ?a =?= 0 ≤ p
            [Meta.isDefEq] [0.018272] ❌️ 0 =?= 0
              [Meta.isDefEq] [0.018243] ❌️ Zero.toOfNat0 =?= Zero.toOfNat0
          [Meta.Tactic.simp.discharge] [0.022397] IsEmpty.forall_iff discharge ❌️
                IsEmpty ι
            [Meta.synthInstance] [0.022058] ❌️ Nonempty ι
          [Meta.isDefEq] [0.018356] ❌️ 0 ≤ ?a =?= 0 ≤ p
            [Meta.isDefEq] [0.018281] ❌️ 0 =?= 0
              [Meta.isDefEq] [0.018251] ❌️ Zero.toOfNat0 =?= Zero.toOfNat0
          [Meta.Tactic.simp.discharge] [0.023237] IsEmpty.forall_iff discharge ❌️
                IsEmpty ι
            [Meta.synthInstance] [0.022814] ❌️ Nonempty ι
          [Meta.Tactic.simp.discharge] [0.022473] IsEmpty.forall_iff discharge ❌️
                IsEmpty ι
            [Meta.synthInstance] [0.022077] ❌️ Nonempty ι
          [Meta.Tactic.simp.discharge] [0.022179] IsEmpty.forall_iff discharge ❌️
                IsEmpty ι
            [Meta.synthInstance] [0.021821] ❌️ Nonempty ι
          [Meta.synthInstance] [0.017515] ✅️ PosMulReflectLT ℝ
            [Meta.synthInstance] [0.012201] ❌️ apply @LinearOrderedCommGroupWithZero.toPosMulReflectLT to PosMulReflectLT
                  ℝ
              [Meta.synthInstance.tryResolve] [0.012179] ❌️ PosMulReflectLT ℝ ≟ PosMulReflectLT ?m.283
                [Meta.isDefEq] [0.012166] ❌️ PosMulReflectLT ℝ =?= PosMulReflectLT ?m.283
                  [Meta.isDefEq] [0.012114] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul
                    [Meta.isDefEq.delta] [0.012079] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass.toMul
                      [Meta.isDefEq] [0.012068] ❌️ Field.toSemifield.toDivisionSemiring.toGroupWithZero.toMulZeroOneClass.toMulZeroClass =?= LinearOrderedCommGroupWithZero.toCommGroupWithZero.toGroupWithZero.toMulZeroOneClass.toMulZeroClass
          [Meta.isDefEq] [0.018428] ❌️ ?a < 0 =?= q < 0
            [Meta.isDefEq] [0.018358] ❌️ 0 =?= 0
              [Meta.isDefEq] [0.018335] ❌️ Zero.toOfNat0 =?= Zero.toOfNat0
          [Meta.isDefEq] [0.018706] ❌️ ?a ≤ 0 =?= q ≤ 0
            [Meta.isDefEq] [0.018628] ❌️ 0 =?= 0
              [Meta.isDefEq] [0.018604] ❌️ Zero.toOfNat0 =?= Zero.toOfNat0
          [Meta.Tactic.simp.discharge] [0.076127] IsEmpty.forall_iff discharge ❌️
                IsEmpty (∀ i ∈ s, g i = 0 ∧ 0 < q)
            [Meta.Tactic.simp.discharge] [0.022701] IsEmpty.exists_iff discharge ❌️
                  IsEmpty ι
              [Meta.synthInstance] [0.022519] ❌️ Nonempty ι
          [Meta.isDefEq] [0.018516] ❌️ ?a ≤ 0 =?= q ≤ 0
            [Meta.isDefEq] [0.018445] ❌️ 0 =?= 0
              [Meta.isDefEq] [0.018416] ❌️ Zero.toOfNat0 =?= Zero.toOfNat0
          [Meta.Tactic.simp.discharge] [0.074796] IsEmpty.forall_iff discharge ❌️
                IsEmpty (∀ i ∈ s, g i = 0 ∧ 0 < q)
            [Meta.Tactic.simp.discharge] [0.022174] IsEmpty.exists_iff discharge ❌️
                  IsEmpty ι
              [Meta.synthInstance] [0.021998] ❌️ Nonempty ι
          [Meta.isDefEq] [0.018536] ❌️ ?a < 0 =?= q < 0
            [Meta.isDefEq] [0.018466] ❌️ 0 =?= 0
              [Meta.isDefEq] [0.018427] ❌️ Zero.toOfNat0 =?= Zero.toOfNat0
          [Meta.isDefEq] [0.018106] ❌️ 0 ≤ ?a =?= 0 ≤ q
            [Meta.isDefEq] [0.018027] ❌️ 0 =?= 0
              [Meta.isDefEq] [0.018004] ❌️ Zero.toOfNat0 =?= Zero.toOfNat0
          [Meta.Tactic.simp.discharge] [0.120256] IsEmpty.forall_iff discharge ❌️
                IsEmpty (∃ a ∈ s, g a = 0 ∧ q < 0 ∨ g a = ⊤ ∧ 0 < q)
            [Meta.Tactic.simp.discharge] [0.022369] IsEmpty.forall_iff discharge ❌️
                  IsEmpty ι
              [Meta.synthInstance] [0.022173] ❌️ Nonempty ι
            [Meta.Tactic.simp.discharge] [0.022163] IsEmpty.forall_iff discharge ❌️
                  IsEmpty ι
              [Meta.synthInstance] [0.021979] ❌️ Nonempty ι
          [Meta.isDefEq] [0.018406] ❌️ 0 ≤ ?a =?= 0 ≤ q
            [Meta.isDefEq] [0.018325] ❌️ 0 =?= 0
              [Meta.isDefEq] [0.018293] ❌️ Zero.toOfNat0 =?= Zero.toOfNat0
          [Meta.Tactic.simp.discharge] [0.052693] IsEmpty.forall_iff discharge ❌️
                IsEmpty (x ∈ s ∧ (g x = 0 ∧ q < 0 ∨ g x = ⊤ ∧ 0 < q))
          [Meta.isDefEq] [0.018568] ❌️ 0 ≤ ?a =?= 0 ≤ q
            [Meta.isDefEq] [0.018496] ❌️ 0 =?= 0
              [Meta.isDefEq] [0.018467] ❌️ Zero.toOfNat0 =?= Zero.toOfNat0
          [Meta.Tactic.simp.discharge] [0.030013] IsEmpty.forall_iff discharge ❌️
                IsEmpty (g x = 0 ∧ q < 0)
          [Meta.isDefEq] [0.018533] ❌️ 0 ≤ ?a =?= 0 ≤ q
            [Meta.isDefEq] [0.018461] ❌️ 0 =?= 0
              [Meta.isDefEq] [0.018432] ❌️ Zero.toOfNat0 =?= Zero.toOfNat0
          [Meta.isDefEq] [0.018494] ❌️ 0 ≤ ?a =?= 0 ≤ q
            [Meta.isDefEq] [0.018420] ❌️ 0 =?= 0
              [Meta.isDefEq] [0.018391] ❌️ Zero.toOfNat0 =?= Zero.toOfNat0
          [Meta.Tactic.simp.discharge] [0.022392] IsEmpty.forall_iff discharge ❌️
                IsEmpty ι
            [Meta.synthInstance] [0.022031] ❌️ Nonempty ι
          [Meta.isDefEq] [0.018778] ❌️ 0 ≤ ?a =?= 0 ≤ q
            [Meta.isDefEq] [0.018695] ❌️ 0 =?= 0
              [Meta.isDefEq] [0.018661] ❌️ Zero.toOfNat0 =?= Zero.toOfNat0
          [Meta.Tactic.simp.discharge] [0.022924] IsEmpty.forall_iff discharge ❌️
                IsEmpty ι
            [Meta.synthInstance] [0.022535] ❌️ Nonempty ι
          [Meta.Tactic.simp.discharge] [0.022412] IsEmpty.forall_iff discharge ❌️
                IsEmpty ι
            [Meta.synthInstance] [0.022046] ❌️ Nonempty ι
          [Meta.Tactic.simp.discharge] [0.022183] IsEmpty.forall_iff discharge ❌️
                IsEmpty ι
            [Meta.synthInstance] [0.021822] ❌️ Nonempty ι
          [Meta.Tactic.simp.discharge] [0.022367] IsEmpty.forall_iff discharge ❌️
                IsEmpty ι
            [Meta.synthInstance] [0.022017] ❌️ Nonempty ι
          [Meta.Tactic.simp.discharge] [0.022216] IsEmpty.forall_iff discharge ❌️
                IsEmpty ι
            [Meta.synthInstance] [0.021862] ❌️ Nonempty ι
Build completed successfully (1905 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
