### PR TITLE
[Merged by Bors] - chore(Algebra): golf entire `linearEquivFunOnFintype_lof`, `mem_valueMonoid`, `ofIsColimitCokernelCofork_f` and more using `tauto` and `rfl`

### DIFF
--- a/Mathlib/Algebra/DirectSum/Module.lean
+++ b/Mathlib/Algebra/DirectSum/Module.lean
@@ -151,7 +151,7 @@ variable {ι M}
 @[simp]
 theorem linearEquivFunOnFintype_lof [Fintype ι] (i : ι) (m : M i) :
     (linearEquivFunOnFintype R ι M) (lof R ι M i m) = Pi.single i m := by
-  tauto
+  rfl
 
 @[simp]
 theorem linearEquivFunOnFintype_symm_single [Fintype ι] (i : ι) (m : M i) :

--- a/Mathlib/Algebra/DirectSum/Module.lean
+++ b/Mathlib/Algebra/DirectSum/Module.lean
@@ -151,9 +151,7 @@ variable {ι M}
 @[simp]
 theorem linearEquivFunOnFintype_lof [Fintype ι] (i : ι) (m : M i) :
     (linearEquivFunOnFintype R ι M) (lof R ι M i m) = Pi.single i m := by
-  ext a
-  change (DFinsupp.equivFunOnFintype (lof R ι M i m)) a = _
-  convert _root_.congr_fun (DFinsupp.equivFunOnFintype_single i m) a
+  tauto
 
 @[simp]
 theorem linearEquivFunOnFintype_symm_single [Fintype ι] (i : ι) (m : M i) :

--- a/Mathlib/Algebra/GroupWithZero/Range.lean
+++ b/Mathlib/Algebra/GroupWithZero/Range.lean
@@ -100,9 +100,7 @@ codomain containing the range of `f`. -/
 abbrev valueGroup₀ := WithZero (valueGroup f)
 
 lemma mem_valueMonoid {b : Bˣ} (hb : b.val ∈ range f) : b ∈ valueMonoid f := by
-  rcases hb with ⟨c, _⟩
-  simp only [mem_valueMonoid_iff, mem_preimage, mem_range]
-  use c
+  tauto
 
 lemma mem_valueGroup {b : Bˣ} (hb : b.1 ∈ range f) : b ∈ valueGroup f := by
   suffices b ∈ valueMonoid f from Subgroup.mem_closure.mpr fun _ a ↦ a this

--- a/Mathlib/Algebra/Homology/ShortComplex/LeftHomology.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/LeftHomology.lean
@@ -153,7 +153,7 @@ def ofIsColimitCokernelCofork (hg : S.g = 0) (c : CokernelCofork S.f) (hc : IsCo
 
 @[simp] lemma ofIsColimitCokernelCofork_f' (hg : S.g = 0) (c : CokernelCofork S.f)
     (hc : IsColimit c) : (ofIsColimitCokernelCofork S hg c hc).f' = S.f := by
-  tauto
+  rfl
 
 /-- When the second map `S.g` is zero, this is the left homology data on `S` given by
 the chosen `cokernel S.f` -/

--- a/Mathlib/Algebra/Homology/ShortComplex/LeftHomology.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/LeftHomology.lean
@@ -153,10 +153,7 @@ def ofIsColimitCokernelCofork (hg : S.g = 0) (c : CokernelCofork S.f) (hc : IsCo
 
 @[simp] lemma ofIsColimitCokernelCofork_f' (hg : S.g = 0) (c : CokernelCofork S.f)
     (hc : IsColimit c) : (ofIsColimitCokernelCofork S hg c hc).f' = S.f := by
-  rw [← cancel_mono (ofIsColimitCokernelCofork S hg c hc).i, f'_i,
-    ofIsColimitCokernelCofork_i]
-  dsimp
-  rw [comp_id]
+  tauto
 
 /-- When the second map `S.g` is zero, this is the left homology data on `S` given by
 the chosen `cokernel S.f` -/

--- a/Mathlib/Algebra/Lie/OfAssociative.lean
+++ b/Mathlib/Algebra/Lie/OfAssociative.lean
@@ -341,10 +341,7 @@ theorem toEnd_comp_subtype_mem (m : M) (hm : m ∈ (N : Submodule R M)) :
 @[simp]
 theorem toEnd_restrict_eq_toEnd (h := N.toEnd_comp_subtype_mem x) :
     (toEnd R L M x).restrict h = toEnd R L N x := by
-  ext
-  simp only [LinearMap.restrict_coe_apply, toEnd_apply_apply, ← coe_bracket,
-    SetLike.coe_eq_coe]
-  rfl
+  tauto
 
 lemma mapsTo_pow_toEnd_sub_algebraMap {φ : R} {k : ℕ} {x : L} :
     MapsTo ((toEnd R L M x - algebraMap R (Module.End R M) φ) ^ k) N N := by

--- a/Mathlib/Algebra/Lie/OfAssociative.lean
+++ b/Mathlib/Algebra/Lie/OfAssociative.lean
@@ -341,7 +341,7 @@ theorem toEnd_comp_subtype_mem (m : M) (hm : m ∈ (N : Submodule R M)) :
 @[simp]
 theorem toEnd_restrict_eq_toEnd (h := N.toEnd_comp_subtype_mem x) :
     (toEnd R L M x).restrict h = toEnd R L N x := by
-  tauto
+  rfl
 
 lemma mapsTo_pow_toEnd_sub_algebraMap {φ : R} {k : ℕ} {x : L} :
     MapsTo ((toEnd R L M x - algebraMap R (Module.End R M) φ) ^ k) N N := by

--- a/Mathlib/Algebra/Polynomial/AlgebraMap.lean
+++ b/Mathlib/Algebra/Polynomial/AlgebraMap.lean
@@ -175,9 +175,7 @@ theorem mapAlgHom_comp (C : Type*) [Semiring C] [Algebra R C] (f : B →ₐ[R] C
 
 theorem mapAlgHom_eq_eval₂AlgHom'_CAlgHom (f : A →ₐ[R] B) : mapAlgHom f = eval₂AlgHom'
     (CAlgHom.comp f) X (fun a => (commute_X (C (f a))).symm) := by
-  apply AlgHom.ext
-  intro x
-  congr
+  tauto
 
 /-- If `A` and `B` are isomorphic as `R`-algebras, then so are their polynomial rings -/
 def mapAlgEquiv (f : A ≃ₐ[R] B) : Polynomial A ≃ₐ[R] Polynomial B :=
@@ -244,8 +242,7 @@ lemma eval_map_algebraMap (P : R[X]) (b : B) :
 /-- `mapAlg` is the morphism induced by `R → S`. -/
 theorem mapAlg_eq_map (S : Type v) [Semiring S] [Algebra R S] (p : R[X]) :
     mapAlg R S p = map (algebraMap R S) p := by
-  simp only [mapAlg, aeval_def, eval₂_eq_sum, map, algebraMap_apply, RingHom.coe_comp]
-  ext; congr
+  tauto
 
 theorem aeval_zero : aeval x (0 : R[X]) = 0 :=
   map_zero (aeval x)

--- a/Mathlib/Algebra/Polynomial/AlgebraMap.lean
+++ b/Mathlib/Algebra/Polynomial/AlgebraMap.lean
@@ -175,7 +175,7 @@ theorem mapAlgHom_comp (C : Type*) [Semiring C] [Algebra R C] (f : B →ₐ[R] C
 
 theorem mapAlgHom_eq_eval₂AlgHom'_CAlgHom (f : A →ₐ[R] B) : mapAlgHom f = eval₂AlgHom'
     (CAlgHom.comp f) X (fun a => (commute_X (C (f a))).symm) := by
-  tauto
+  rfl
 
 /-- If `A` and `B` are isomorphic as `R`-algebras, then so are their polynomial rings -/
 def mapAlgEquiv (f : A ≃ₐ[R] B) : Polynomial A ≃ₐ[R] Polynomial B :=
@@ -242,7 +242,7 @@ lemma eval_map_algebraMap (P : R[X]) (b : B) :
 /-- `mapAlg` is the morphism induced by `R → S`. -/
 theorem mapAlg_eq_map (S : Type v) [Semiring S] [Algebra R S] (p : R[X]) :
     mapAlg R S p = map (algebraMap R S) p := by
-  tauto
+  rfl
 
 theorem aeval_zero : aeval x (0 : R[X]) = 0 :=
   map_zero (aeval x)

--- a/Mathlib/Algebra/Polynomial/Coeff.lean
+++ b/Mathlib/Algebra/Polynomial/Coeff.lean
@@ -43,9 +43,7 @@ theorem coeff_add (p q : R[X]) (n : ℕ) : coeff (p + q) n = coeff p n + coeff q
 @[simp]
 theorem coeff_smul [SMulZeroClass S R] (r : S) (p : R[X]) (n : ℕ) :
     coeff (r • p) n = r • coeff p n := by
-  rcases p with ⟨⟩
-  simp_rw [← ofFinsupp_smul, coeff]
-  exact Finsupp.smul_apply _ _ _
+  tauto
 
 theorem support_smul [SMulZeroClass S R] (r : S) (p : R[X]) :
     support (r • p) ⊆ support p := by

--- a/Mathlib/Algebra/Polynomial/Coeff.lean
+++ b/Mathlib/Algebra/Polynomial/Coeff.lean
@@ -43,7 +43,7 @@ theorem coeff_add (p q : R[X]) (n : ℕ) : coeff (p + q) n = coeff p n + coeff q
 @[simp]
 theorem coeff_smul [SMulZeroClass S R] (r : S) (p : R[X]) (n : ℕ) :
     coeff (r • p) n = r • coeff p n := by
-  tauto
+  rfl
 
 theorem support_smul [SMulZeroClass S R] (r : S) (p : R[X]) :
     support (r • p) ⊆ support p := by

--- a/Mathlib/Algebra/RingQuot.lean
+++ b/Mathlib/Algebra/RingQuot.lean
@@ -242,9 +242,7 @@ theorem sub_quot {R : Type uR} [Ring R] (r : R → R → Prop) {a b} :
 
 theorem smul_quot [Algebra S R] {n : S} {a : R} :
     (n • ⟨Quot.mk _ a⟩ : RingQuot r) = ⟨Quot.mk _ (n • a)⟩ := by
-  change smul r _ _ = _
-  rw [smul]
-  rfl
+  tauto
 
 instance instIsScalarTower [CommSemiring T] [SMul S T] [Algebra S R] [Algebra T R]
     [IsScalarTower S T R] : IsScalarTower S T (RingQuot r) :=

--- a/Mathlib/Algebra/RingQuot.lean
+++ b/Mathlib/Algebra/RingQuot.lean
@@ -242,7 +242,7 @@ theorem sub_quot {R : Type uR} [Ring R] (r : R → R → Prop) {a b} :
 
 theorem smul_quot [Algebra S R] {n : S} {a : R} :
     (n • ⟨Quot.mk _ a⟩ : RingQuot r) = ⟨Quot.mk _ (n • a)⟩ := by
-  tauto
+  rfl
 
 instance instIsScalarTower [CommSemiring T] [SMul S T] [Algebra S R] [Algebra T R]
     [IsScalarTower S T R] : IsScalarTower S T (RingQuot r) :=

--- a/Mathlib/Algebra/SkewMonoidAlgebra/Basic.lean
+++ b/Mathlib/Algebra/SkewMonoidAlgebra/Basic.lean
@@ -213,9 +213,7 @@ theorem coeff_add (p q : SkewMonoidAlgebra k G) (a : G) :
 @[simp]
 theorem coeff_smul {S} [SMulZeroClass S k] (r : S) (p : SkewMonoidAlgebra k G) (a : G) :
     coeff (r • p) a = r • coeff p a := by
-  rcases p
-  simp_rw [← ofFinsupp_smul, coeff]
-  exact Finsupp.smul_apply _ _ _
+  tauto
 
 end Coeff
 

--- a/Mathlib/Algebra/SkewMonoidAlgebra/Basic.lean
+++ b/Mathlib/Algebra/SkewMonoidAlgebra/Basic.lean
@@ -213,7 +213,7 @@ theorem coeff_add (p q : SkewMonoidAlgebra k G) (a : G) :
 @[simp]
 theorem coeff_smul {S} [SMulZeroClass S k] (r : S) (p : SkewMonoidAlgebra k G) (a : G) :
     coeff (r • p) a = r • coeff p a := by
-  tauto
+  rfl
 
 end Coeff
 


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>linearEquivFunOnFintype_lof</code>: 81 ms before, 12 ms after  🎉</summary>

### Trace profiling of `linearEquivFunOnFintype_lof` before PR 28556
```diff
diff --git a/Mathlib/Algebra/DirectSum/Module.lean b/Mathlib/Algebra/DirectSum/Module.lean
index 9f114bb72d..453547fa5d 100644
--- a/Mathlib/Algebra/DirectSum/Module.lean
+++ b/Mathlib/Algebra/DirectSum/Module.lean
@@ -148,6 +148,7 @@ def linearEquivFunOnFintype [Fintype ι] : (⨁ i, M i) ≃ₗ[R] ∀ i, M i :=
 
 variable {ι M}
 
+set_option trace.profiler true in
 @[simp]
 theorem linearEquivFunOnFintype_lof [Fintype ι] (i : ι) (m : M i) :
     (linearEquivFunOnFintype R ι M) (lof R ι M i m) = Pi.single i m := by
```
```
ℹ [1122/1122] Built Mathlib.Algebra.DirectSum.Module (3.7s)
info: Mathlib/Algebra/DirectSum/Module.lean:152:0: [Elab.command] [0.017342] @[simp]
    theorem linearEquivFunOnFintype_lof [Fintype ι] (i : ι) (m : M i) :
        (linearEquivFunOnFintype R ι M) (lof R ι M i m) = Pi.single i m :=
      by
      ext a
      change (DFinsupp.equivFunOnFintype (lof R ι M i m)) a = _
      convert _root_.congr_fun (DFinsupp.equivFunOnFintype_single i m) a
info: Mathlib/Algebra/DirectSum/Module.lean:152:0: [Elab.async] [0.083896] elaborating proof of DirectSum.linearEquivFunOnFintype_lof
  [Elab.definition.value] [0.081072] DirectSum.linearEquivFunOnFintype_lof
    [Elab.step] [0.079142] 
          ext a
          change (DFinsupp.equivFunOnFintype (lof R ι M i m)) a = _
          convert _root_.congr_fun (DFinsupp.equivFunOnFintype_single i m) a
      [Elab.step] [0.079123] 
            ext a
            change (DFinsupp.equivFunOnFintype (lof R ι M i m)) a = _
            convert _root_.congr_fun (DFinsupp.equivFunOnFintype_single i m) a
        [Elab.step] [0.018446] change (DFinsupp.equivFunOnFintype (lof R ι M i m)) a = _
          [Elab.step] [0.017469] expected type: Prop, term
              (DFinsupp.equivFunOnFintype (lof R ι M i m)) a = _
            [Elab.step] [0.017457] expected type: Prop, term
                binrel% Eq✝ ((DFinsupp.equivFunOnFintype (lof R ι M i m)) a) _
              [Elab.step] [0.017290] expected type: <not-available>, term
                  (DFinsupp.equivFunOnFintype (lof R ι M i m)) a
                [Elab.step] [0.017226] expected type: <not-available>, term
                    (DFinsupp.equivFunOnFintype (lof R ι M i m))
                  [Elab.step] [0.017215] expected type: <not-available>, term
                      DFinsupp.equivFunOnFintype (lof R ι M i m)
        [Elab.step] [0.058501] convert _root_.congr_fun (DFinsupp.equivFunOnFintype_single i m) a
Build completed successfully (1122 jobs).
```

### Trace profiling of `linearEquivFunOnFintype_lof` after PR 28556
```diff
diff --git a/Mathlib/Algebra/DirectSum/Module.lean b/Mathlib/Algebra/DirectSum/Module.lean
index 9f114bb72d..51e7d0aff8 100644
--- a/Mathlib/Algebra/DirectSum/Module.lean
+++ b/Mathlib/Algebra/DirectSum/Module.lean
@@ -148,12 +148,11 @@ def linearEquivFunOnFintype [Fintype ι] : (⨁ i, M i) ≃ₗ[R] ∀ i, M i :=
 
 variable {ι M}
 
+set_option trace.profiler true in
 @[simp]
 theorem linearEquivFunOnFintype_lof [Fintype ι] (i : ι) (m : M i) :
     (linearEquivFunOnFintype R ι M) (lof R ι M i m) = Pi.single i m := by
-  ext a
-  change (DFinsupp.equivFunOnFintype (lof R ι M i m)) a = _
-  convert _root_.congr_fun (DFinsupp.equivFunOnFintype_single i m) a
+  tauto
 
 @[simp]
 theorem linearEquivFunOnFintype_symm_single [Fintype ι] (i : ι) (m : M i) :
diff --git a/Mathlib/Algebra/GroupWithZero/Range.lean b/Mathlib/Algebra/GroupWithZero/Range.lean
index fdd5278569..1fe25c4437 100644
--- a/Mathlib/Algebra/GroupWithZero/Range.lean
+++ b/Mathlib/Algebra/GroupWithZero/Range.lean
@@ -100,9 +100,7 @@ codomain containing the range of `f`. -/
 abbrev valueGroup₀ := WithZero (valueGroup f)
 
 lemma mem_valueMonoid {b : Bˣ} (hb : b.val ∈ range f) : b ∈ valueMonoid f := by
-  rcases hb with ⟨c, _⟩
-  simp only [mem_valueMonoid_iff, mem_preimage, mem_range]
-  use c
+  tauto
 
 lemma mem_valueGroup {b : Bˣ} (hb : b.1 ∈ range f) : b ∈ valueGroup f := by
   suffices b ∈ valueMonoid f from Subgroup.mem_closure.mpr fun _ a ↦ a this
diff --git a/Mathlib/Algebra/Homology/ShortComplex/LeftHomology.lean b/Mathlib/Algebra/Homology/ShortComplex/LeftHomology.lean
index 4434f1d449..e3961157eb 100644
--- a/Mathlib/Algebra/Homology/ShortComplex/LeftHomology.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/LeftHomology.lean
@@ -153,10 +153,7 @@ def ofIsColimitCokernelCofork (hg : S.g = 0) (c : CokernelCofork S.f) (hc : IsCo
 
 @[simp] lemma ofIsColimitCokernelCofork_f' (hg : S.g = 0) (c : CokernelCofork S.f)
     (hc : IsColimit c) : (ofIsColimitCokernelCofork S hg c hc).f' = S.f := by
-  rw [← cancel_mono (ofIsColimitCokernelCofork S hg c hc).i, f'_i,
-    ofIsColimitCokernelCofork_i]
-  dsimp
-  rw [comp_id]
+  tauto
 
 /-- When the second map `S.g` is zero, this is the left homology data on `S` given by
 the chosen `cokernel S.f` -/
diff --git a/Mathlib/Algebra/Lie/OfAssociative.lean b/Mathlib/Algebra/Lie/OfAssociative.lean
index c50ddbb4e8..a62abca315 100644
--- a/Mathlib/Algebra/Lie/OfAssociative.lean
+++ b/Mathlib/Algebra/Lie/OfAssociative.lean
@@ -341,10 +341,7 @@ theorem toEnd_comp_subtype_mem (m : M) (hm : m ∈ (N : Submodule R M)) :
 @[simp]
 theorem toEnd_restrict_eq_toEnd (h := N.toEnd_comp_subtype_mem x) :
     (toEnd R L M x).restrict h = toEnd R L N x := by
-  ext
-  simp only [LinearMap.restrict_coe_apply, toEnd_apply_apply, ← coe_bracket,
-    SetLike.coe_eq_coe]
-  rfl
+  tauto
 
 lemma mapsTo_pow_toEnd_sub_algebraMap {φ : R} {k : ℕ} {x : L} :
     MapsTo ((toEnd R L M x - algebraMap R (Module.End R M) φ) ^ k) N N := by
diff --git a/Mathlib/Algebra/Polynomial/AlgebraMap.lean b/Mathlib/Algebra/Polynomial/AlgebraMap.lean
index a7add7b33f..e49df2df8d 100644
--- a/Mathlib/Algebra/Polynomial/AlgebraMap.lean
+++ b/Mathlib/Algebra/Polynomial/AlgebraMap.lean
@@ -175,9 +175,7 @@ theorem mapAlgHom_comp (C : Type*) [Semiring C] [Algebra R C] (f : B →ₐ[R] C
 
 theorem mapAlgHom_eq_eval₂AlgHom'_CAlgHom (f : A →ₐ[R] B) : mapAlgHom f = eval₂AlgHom'
     (CAlgHom.comp f) X (fun a => (commute_X (C (f a))).symm) := by
-  apply AlgHom.ext
-  intro x
-  congr
+  tauto
 
 /-- If `A` and `B` are isomorphic as `R`-algebras, then so are their polynomial rings -/
 def mapAlgEquiv (f : A ≃ₐ[R] B) : Polynomial A ≃ₐ[R] Polynomial B :=
@@ -244,8 +242,7 @@ lemma eval_map_algebraMap (P : R[X]) (b : B) :
 /-- `mapAlg` is the morphism induced by `R → S`. -/
 theorem mapAlg_eq_map (S : Type v) [Semiring S] [Algebra R S] (p : R[X]) :
     mapAlg R S p = map (algebraMap R S) p := by
-  simp only [mapAlg, aeval_def, eval₂_eq_sum, map, algebraMap_apply, RingHom.coe_comp]
-  ext; congr
+  tauto
 
 theorem aeval_zero : aeval x (0 : R[X]) = 0 :=
   map_zero (aeval x)
diff --git a/Mathlib/Algebra/Polynomial/Coeff.lean b/Mathlib/Algebra/Polynomial/Coeff.lean
index b89c65aa6a..9edad6136e 100644
--- a/Mathlib/Algebra/Polynomial/Coeff.lean
+++ b/Mathlib/Algebra/Polynomial/Coeff.lean
@@ -43,9 +43,7 @@ theorem coeff_add (p q : R[X]) (n : ℕ) : coeff (p + q) n = coeff p n + coeff q
 @[simp]
 theorem coeff_smul [SMulZeroClass S R] (r : S) (p : R[X]) (n : ℕ) :
     coeff (r • p) n = r • coeff p n := by
-  rcases p with ⟨⟩
-  simp_rw [← ofFinsupp_smul, coeff]
-  exact Finsupp.smul_apply _ _ _
+  tauto
 
 theorem support_smul [SMulZeroClass S R] (r : S) (p : R[X]) :
     support (r • p) ⊆ support p := by
diff --git a/Mathlib/Algebra/RingQuot.lean b/Mathlib/Algebra/RingQuot.lean
index 8e42eb3c42..64a264b5a2 100644
--- a/Mathlib/Algebra/RingQuot.lean
+++ b/Mathlib/Algebra/RingQuot.lean
@@ -242,9 +242,7 @@ theorem sub_quot {R : Type uR} [Ring R] (r : R → R → Prop) {a b} :
 
 theorem smul_quot [Algebra S R] {n : S} {a : R} :
     (n • ⟨Quot.mk _ a⟩ : RingQuot r) = ⟨Quot.mk _ (n • a)⟩ := by
-  change smul r _ _ = _
-  rw [smul]
-  rfl
+  tauto
 
 instance instIsScalarTower [CommSemiring T] [SMul S T] [Algebra S R] [Algebra T R]
     [IsScalarTower S T R] : IsScalarTower S T (RingQuot r) :=
diff --git a/Mathlib/Algebra/SkewMonoidAlgebra/Basic.lean b/Mathlib/Algebra/SkewMonoidAlgebra/Basic.lean
index 5d63000eda..90ac5ac68f 100644
--- a/Mathlib/Algebra/SkewMonoidAlgebra/Basic.lean
+++ b/Mathlib/Algebra/SkewMonoidAlgebra/Basic.lean
@@ -213,9 +213,7 @@ theorem coeff_add (p q : SkewMonoidAlgebra k G) (a : G) :
 @[simp]
 theorem coeff_smul {S} [SMulZeroClass S k] (r : S) (p : SkewMonoidAlgebra k G) (a : G) :
     coeff (r • p) a = r • coeff p a := by
-  rcases p
-  simp_rw [← ofFinsupp_smul, coeff]
-  exact Finsupp.smul_apply _ _ _
+  tauto
 
 end Coeff
 
```
```
ℹ [1122/1122] Built Mathlib.Algebra.DirectSum.Module (3.8s)
info: Mathlib/Algebra/DirectSum/Module.lean:152:0: [Elab.command] [0.023466] @[simp]
    theorem linearEquivFunOnFintype_lof [Fintype ι] (i : ι) (m : M i) :
        (linearEquivFunOnFintype R ι M) (lof R ι M i m) = Pi.single i m := by tauto
info: Mathlib/Algebra/DirectSum/Module.lean:152:0: [Elab.async] [0.013767] elaborating proof of DirectSum.linearEquivFunOnFintype_lof
  [Elab.definition.value] [0.012260] DirectSum.linearEquivFunOnFintype_lof
    [Elab.step] [0.011580] tauto
      [Elab.step] [0.011563] tauto
        [Elab.step] [0.011547] tauto
Build completed successfully (1122 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
