### PR TITLE
[Merged by Bors] - chore(Analysis): golf entire `HasGradientAtFilter.hasDerivAtFilter`, `liftIsometry_symm_apply` and `mapL_apply` using `tauto` and `rfl`

### DIFF
--- a/Mathlib/Analysis/Calculus/Gradient/Basic.lean
+++ b/Mathlib/Analysis/Calculus/Gradient/Basic.lean
@@ -156,9 +156,7 @@ variable {g : 𝕜 → 𝕜} {g' u : 𝕜} {L' : Filter 𝕜}
 
 theorem HasGradientAtFilter.hasDerivAtFilter (h : HasGradientAtFilter g g' u L') :
     HasDerivAtFilter g (starRingEnd 𝕜 g') u L' := by
-  have : ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) (starRingEnd 𝕜 g') = (toDual 𝕜 𝕜) g' := by
-    ext; simp
-  rwa [HasDerivAtFilter, this]
+  tauto
 
 theorem HasDerivAtFilter.hasGradientAtFilter (h : HasDerivAtFilter g g' u L') :
     HasGradientAtFilter g (starRingEnd 𝕜 g') u L' := by

--- a/Mathlib/Analysis/NormedSpace/PiTensorProduct/InjectiveSeminorm.lean
+++ b/Mathlib/Analysis/NormedSpace/PiTensorProduct/InjectiveSeminorm.lean
@@ -297,11 +297,7 @@ theorem tprodL_coe : (tprodL 𝕜).toMultilinearMap = tprod 𝕜 (s := E) := by
 @[simp]
 theorem liftIsometry_symm_apply (l : (⨂[𝕜] i, E i) →L[𝕜] F) :
     (liftIsometry 𝕜 E F).symm l = l.compContinuousMultilinearMap (tprodL 𝕜) := by
-  ext m
-  change (liftEquiv 𝕜 E F).symm l m = _
-  simp only [liftEquiv_symm_apply, lift_symm, MultilinearMap.coe_mkContinuous,
-    LinearMap.compMultilinearMap_apply, ContinuousLinearMap.coe_coe,
-    ContinuousLinearMap.compContinuousMultilinearMap_coe, Function.comp_apply, tprodL_toFun]
+  tauto
 
 @[simp]
 theorem liftIsometry_tprodL :
@@ -337,12 +333,7 @@ theorem mapL_coe : (mapL f).toLinearMap = map (fun i ↦ (f i).toLinearMap) := b
 
 @[simp]
 theorem mapL_apply (x : ⨂[𝕜] i, E i) : mapL f x = map (fun i ↦ (f i).toLinearMap) x := by
-  induction x using PiTensorProduct.induction_on with
-  | smul_tprod =>
-    simp only [mapL, map_smul, liftIsometry_apply_apply, lift.tprod,
-    ContinuousMultilinearMap.coe_coe, ContinuousMultilinearMap.compContinuousLinearMap_apply,
-    tprodL_toFun, map_tprod, ContinuousLinearMap.coe_coe]
-  | add _ _ hx hy => simp only [map_add, hx, hy]
+  tauto
 
 /-- Given submodules `pᵢ ⊆ Eᵢ`, this is the natural map: `⨂[𝕜] i, pᵢ → ⨂[𝕜] i, Eᵢ`.
 This is the continuous version of `PiTensorProduct.mapIncl`.

--- a/Mathlib/Analysis/NormedSpace/PiTensorProduct/InjectiveSeminorm.lean
+++ b/Mathlib/Analysis/NormedSpace/PiTensorProduct/InjectiveSeminorm.lean
@@ -297,7 +297,7 @@ theorem tprodL_coe : (tprodL 𝕜).toMultilinearMap = tprod 𝕜 (s := E) := by
 @[simp]
 theorem liftIsometry_symm_apply (l : (⨂[𝕜] i, E i) →L[𝕜] F) :
     (liftIsometry 𝕜 E F).symm l = l.compContinuousMultilinearMap (tprodL 𝕜) := by
-  tauto
+  rfl
 
 @[simp]
 theorem liftIsometry_tprodL :
@@ -333,7 +333,7 @@ theorem mapL_coe : (mapL f).toLinearMap = map (fun i ↦ (f i).toLinearMap) := b
 
 @[simp]
 theorem mapL_apply (x : ⨂[𝕜] i, E i) : mapL f x = map (fun i ↦ (f i).toLinearMap) x := by
-  tauto
+  rfl
 
 /-- Given submodules `pᵢ ⊆ Eᵢ`, this is the natural map: `⨂[𝕜] i, pᵢ → ⨂[𝕜] i, Eᵢ`.
 This is the continuous version of `PiTensorProduct.mapIncl`.


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>HasGradientAtFilter.hasDerivAtFilter</code>: 324 ms before, 26 ms after  🎉</summary>

### Trace profiling of `HasGradientAtFilter.hasDerivAtFilter` before PR 28558
```diff
diff --git a/Mathlib/Analysis/Calculus/Gradient/Basic.lean b/Mathlib/Analysis/Calculus/Gradient/Basic.lean
index 836221ccf3..006cb65688 100644
--- a/Mathlib/Analysis/Calculus/Gradient/Basic.lean
+++ b/Mathlib/Analysis/Calculus/Gradient/Basic.lean
@@ -154,6 +154,7 @@ section OneDimension
 
 variable {g : 𝕜 → 𝕜} {g' u : 𝕜} {L' : Filter 𝕜}
 
+set_option trace.profiler true in
 theorem HasGradientAtFilter.hasDerivAtFilter (h : HasGradientAtFilter g g' u L') :
     HasDerivAtFilter g (starRingEnd 𝕜 g') u L' := by
   have : ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) (starRingEnd 𝕜 g') = (toDual 𝕜 𝕜) g' := by
```
```
ℹ [2086/2086] Built Mathlib.Analysis.Calculus.Gradient.Basic (4.4s)
info: Mathlib/Analysis/Calculus/Gradient/Basic.lean:158:0: [Elab.command] [0.077182] theorem hasDerivAtFilter (h : HasGradientAtFilter g g' u L') :
        HasDerivAtFilter g (starRingEnd 𝕜 g') u L' :=
      by
      have : ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) (starRingEnd 𝕜 g') = (toDual 𝕜 𝕜) g' := by ext; simp
      rwa [HasDerivAtFilter, this]
  [Elab.definition.header] [0.071511] HasGradientAtFilter.hasDerivAtFilter
    [Elab.step] [0.019228] expected type: Prop, term
        HasGradientAtFilter g g' u L'
    [Elab.step] [0.052190] expected type: Prop, term
        HasDerivAtFilter g (starRingEnd 𝕜 g') u L'
      [Meta.synthInstance] [0.037008] ✅️ ContinuousSMul 𝕜 𝕜
        [Meta.synthInstance] [0.019129] ✅️ apply @IsTopologicalRing.toIsTopologicalSemiring to IsTopologicalSemiring 𝕜
          [Meta.synthInstance.tryResolve] [0.019091] ✅️ IsTopologicalSemiring 𝕜 ≟ IsTopologicalSemiring 𝕜
            [Meta.isDefEq] [0.017149] ✅️ IsTopologicalSemiring 𝕜 =?= IsTopologicalSemiring ?m.29
              [Meta.isDefEq] [0.017098] ✅️ Field.toSemifield.toDivisionSemiring.toNonUnitalNonAssocSemiring =?= NonUnitalNonAssocRing.toNonUnitalNonAssocSemiring
                [Meta.isDefEq] [0.017028] ✅️ Field.toSemifield.toDivisionSemiring.toNonUnitalNonAssocSemiring =?= {
                      toAddMonoid := NonUnitalNonAssocRing.toAddCommGroup.toAddMonoid, add_comm := ⋯,
                      toMul := NonUnitalNonAssocRing.toMul, left_distrib := ⋯, right_distrib := ⋯, zero_mul := ⋯,
                      mul_zero := ⋯ }
                  [Meta.isDefEq] [0.017014] ✅️ Field.toSemifield.toDivisionSemiring.toNonUnitalSemiring.1 =?= {
                        toAddMonoid := NonUnitalNonAssocRing.toAddCommGroup.toAddMonoid, add_comm := ⋯,
                        toMul := NonUnitalNonAssocRing.toMul, left_distrib := ⋯, right_distrib := ⋯, zero_mul := ⋯,
                        mul_zero := ⋯ }
                    [Meta.isDefEq] [0.015330] ✅️ Field.toSemifield.toDivisionSemiring.toNonUnitalSemiring.1.toAddCommMonoid =?= {
                          toAddMonoid := NonUnitalNonAssocRing.toAddCommGroup.toAddMonoid, add_comm := ⋯ }
                      [Meta.isDefEq] [0.015316] ✅️ Field.toSemifield.toDivisionSemiring.toNonUnitalSemiring.1.1 =?= {
                            toAddMonoid := NonUnitalNonAssocRing.toAddCommGroup.toAddMonoid, add_comm := ⋯ }
                        [Meta.isDefEq] [0.015177] ✅️ Field.toSemifield.toDivisionSemiring.toNonUnitalSemiring.1.1.toAddMonoid =?= NonUnitalNonAssocRing.toAddCommGroup.toAddMonoid
                          [Meta.isDefEq] [0.015106] ✅️ Field.toSemifield.toDivisionSemiring.toNonUnitalSemiring.1.1.1 =?= NonUnitalNonAssocRing.toAddCommGroup.toSubNegMonoid.1
                            [Meta.isDefEq.onFailure] [0.014986] ✅️ Field.toSemifield.toDivisionSemiring.toNonUnitalSemiring.1.1.1 =?= NonUnitalNonAssocRing.toAddCommGroup.toSubNegMonoid.1
                              [Meta.isDefEq] [0.014035] ✅️ Field.toSemifield.toDivisionSemiring.toNonUnitalSemiring.1.1.1 =?= NormedCommRing.toNonUnitalNormedCommRing.toNonUnitalCommRing.toNonUnitalNonAssocCommRing.toSubNegMonoid.1
                                [Meta.isDefEq] [0.013895] ✅️ Field.toSemifield.toDivisionSemiring.toNonUnitalSemiring.1.1.1 =?= NormedField.toNormedCommRing.toAddMonoid
                                  [Meta.isDefEq] [0.013785] ✅️ Field.toSemifield.toDivisionSemiring.toNonUnitalSemiring.1.1.1 =?= NormedField.toNormedCommRing.toAddCommMonoid.1
                                    [Meta.isDefEq] [0.013679] ✅️ Field.toSemifield.toDivisionSemiring.toNonUnitalSemiring.1.1 =?= NormedField.toNormedCommRing.toAddCommMonoid
                                      [Meta.isDefEq] [0.011626] ✅️ Field.toSemifield.toDivisionSemiring.toNonUnitalSemiring.1.1 =?= NormedField.toNormedCommRing.toNonUnitalNonAssocSemiring.1
                                        [Meta.isDefEq] [0.011408] ✅️ Field.toSemifield.toDivisionSemiring.toNonUnitalSemiring.1 =?= NormedField.toNormedCommRing.toNonUnitalNonAssocSemiring
                                          [Meta.isDefEq] [0.011153] ✅️ Field.toSemifield.toDivisionSemiring.toNonUnitalSemiring.1 =?= NormedField.toNormedCommRing.toNonUnitalSemiring.1
                                            [Meta.isDefEq] [0.010965] ✅️ Field.toSemifield.toDivisionSemiring.toNonUnitalSemiring =?= NormedField.toNormedCommRing.toNonUnitalSemiring
                                              [Meta.isDefEq] [0.010944] ✅️ Field.toSemifield.toDivisionSemiring.toSemiring.1 =?= NormedField.toNormedCommRing.toSemiring.1
                                                [Meta.whnf] [0.010322] Non-easy whnf: Field.toSemifield.toDivisionSemiring.toSemiring
                                                  [Meta.whnf] [0.010314] Non-easy whnf: Field.toSemifield.toDivisionSemiring.1
                                                    [Meta.whnf] [0.010293] Non-easy whnf: Field.toSemifield.toCommSemiring.1
                                                      [Meta.whnf] [0.010257] Non-easy whnf: inst✝³.toRing.1
                                                        [Meta.whnf] [0.010253] Non-easy whnf: inst✝³.toRing
                                                          [Meta.whnf] [0.010247] Non-easy whnf: inst✝³.toCommRing.1
                                                            [Meta.whnf] [0.010244] Non-easy whnf: inst✝³.toCommRing
                                                              [Meta.whnf] [0.010238] Non-easy whnf: inst✝³.toField.1
                                                                [Meta.whnf] [0.010233] Non-easy whnf: inst✝³.toField
                                                                  [Meta.whnf] [0.010226] Non-easy whnf: inst✝³.toNormedField.2
                                                                    [Meta.whnf] [0.010221] Non-easy whnf: inst✝³.toNormedField
info: Mathlib/Analysis/Calculus/Gradient/Basic.lean:158:0: [Elab.command] [0.077452] theorem HasGradientAtFilter.hasDerivAtFilter (h : HasGradientAtFilter g g' u L') :
        HasDerivAtFilter g (starRingEnd 𝕜 g') u L' :=
      by
      have : ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) (starRingEnd 𝕜 g') = (toDual 𝕜 𝕜) g' := by ext; simp
      rwa [HasDerivAtFilter, this]
info: Mathlib/Analysis/Calculus/Gradient/Basic.lean:158:0: [Elab.async] [0.324880] elaborating proof of HasGradientAtFilter.hasDerivAtFilter
  [Elab.definition.value] [0.323521] HasGradientAtFilter.hasDerivAtFilter
    [Elab.step] [0.322337] 
          have : ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) (starRingEnd 𝕜 g') = (toDual 𝕜 𝕜) g' := by ext; simp
          rwa [HasDerivAtFilter, this]
      [Elab.step] [0.322326] 
            have : ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) (starRingEnd 𝕜 g') = (toDual 𝕜 𝕜) g' := by ext; simp
            rwa [HasDerivAtFilter, this]
        [Elab.step] [0.246424] have :
              ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) (starRingEnd 𝕜 g') = (toDual 𝕜 𝕜) g' := by ext; simp
          [Elab.step] [0.246399] focus
                refine
                  no_implicit_lambda%
                    (have : ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) (starRingEnd 𝕜 g') = (toDual 𝕜 𝕜) g' :=
                      ?body✝;
                    ?_)
                case body✝ => with_annotate_state"by" (ext; simp)
            [Elab.step] [0.246383] 
                  refine
                    no_implicit_lambda%
                      (have : ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) (starRingEnd 𝕜 g') = (toDual 𝕜 𝕜) g' :=
                        ?body✝;
                      ?_)
                  case body✝ => with_annotate_state"by" (ext; simp)
              [Elab.step] [0.246374] 
                    refine
                      no_implicit_lambda%
                        (have : ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) (starRingEnd 𝕜 g') = (toDual 𝕜 𝕜) g' :=
                          ?body✝;
                        ?_)
                    case body✝ => with_annotate_state"by" (ext; simp)
                [Elab.step] [0.129317] refine
                      no_implicit_lambda%
                        (have : ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) (starRingEnd 𝕜 g') = (toDual 𝕜 𝕜) g' :=
                          ?body✝;
                        ?_)
                  [Elab.step] [0.129244] expected type: HasDerivAtFilter g ((starRingEnd 𝕜) g') u L', term
                      no_implicit_lambda%
                        (have : ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) (starRingEnd 𝕜 g') = (toDual 𝕜 𝕜) g' :=
                          ?body✝;
                        ?_)
                    [Elab.step] [0.129237] expected type: HasDerivAtFilter g ((starRingEnd 𝕜) g') u L', term
                        (have : ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) (starRingEnd 𝕜 g') = (toDual 𝕜 𝕜) g' :=
                          ?body✝;
                        ?_)
                      [Elab.step] [0.129227] expected type: HasDerivAtFilter g ((starRingEnd 𝕜) g') u L', term
                          have : ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) (starRingEnd 𝕜 g') = (toDual 𝕜 𝕜) g' :=
                            ?body✝;
                          ?_
                        [Elab.step] [0.129071] expected type: Sort ?u.35930, term
                            ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) (starRingEnd 𝕜 g') = (toDual 𝕜 𝕜) g'
                          [Elab.step] [0.129062] expected type: Sort ?u.35930, term
                              binrel% Eq✝ (ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) (starRingEnd 𝕜 g'))
                                ((toDual 𝕜 𝕜) g')
                            [Elab.step] [0.079658] expected type: <not-available>, term
                                ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) (starRingEnd 𝕜 g')
                              [Elab.step] [0.026622] expected type: ?m.21 →L[?m.27] ?m.28, term
                                  (1 : 𝕜 →L[𝕜] 𝕜)
                                [Elab.step] [0.019404] expected type: Type u_1, term
                                    𝕜 →L[𝕜] 𝕜
                                  [Elab.step] [0.019229] expected type: Type u_1, term
                                      ContinuousLinearMap✝ (RingHom.id✝ 𝕜) 𝕜 𝕜
                              [Meta.synthInstance] [0.021520] ✅️ ContinuousSMul 𝕜 𝕜
                            [Elab.step] [0.041933] expected type: <not-available>, term
                                (toDual 𝕜 𝕜) g'
                              [Meta.synthInstance] [0.032953] ✅️ CoeFun (𝕜 ≃ₗᵢ⋆[𝕜] StrongDual 𝕜 𝕜) fun x ↦
                                    𝕜 → StrongDual 𝕜 𝕜
                                [Meta.check] [0.025804] ✅️ LinearIsometryEquiv.instCoeFun
                                  [Meta.isDefEq] [0.010457] ✅️ Module 𝕜 (StrongDual 𝕜 𝕜) =?= Module 𝕜 (𝕜 →L[𝕜] 𝕜)
                                    [Meta.isDefEq] [0.010431] ✅️ ContinuousLinearMap.toSeminormedAddCommGroup.toAddCommMonoid =?= ContinuousLinearMap.addCommMonoid
                                      [Meta.isDefEq] [0.010421] ✅️ {
                                            toAddMonoid := ContinuousLinearMap.toSeminormedAddCommGroup.toAddMonoid,
                                            add_comm := ⋯ } =?= ContinuousLinearMap.addCommMonoid
                                        [Meta.isDefEq] [0.010404] ✅️ {
                                              toAddMonoid := ContinuousLinearMap.toSeminormedAddCommGroup.toAddMonoid,
                                              add_comm :=
                                                ⋯ } =?= { toAdd := ContinuousLinearMap.add, add_assoc := ⋯,
                                              toZero := ContinuousLinearMap.zero, zero_add := ⋯, add_zero := ⋯,
                                              nsmul := fun x1 x2 ↦ x1 • x2, nsmul_zero := ⋯, nsmul_succ := ⋯,
                                              add_comm := ⋯ }
                                          [Meta.isDefEq] [0.010392] ✅️ ContinuousLinearMap.toSeminormedAddCommGroup.toAddMonoid =?= {
                                                toAdd := ContinuousLinearMap.add, add_assoc := ⋯,
                                                toZero := ContinuousLinearMap.zero, zero_add := ⋯, add_zero := ⋯,
                                                nsmul := fun x1 x2 ↦ x1 • x2, nsmul_zero := ⋯, nsmul_succ := ⋯ }
                                            [Meta.isDefEq] [0.010385] ✅️ ContinuousLinearMap.toSeminormedAddCommGroup.toSubNegMonoid.1 =?= {
                                                  toAdd := ContinuousLinearMap.add, add_assoc := ⋯,
                                                  toZero := ContinuousLinearMap.zero, zero_add := ⋯, add_zero := ⋯,
                                                  nsmul := fun x1 x2 ↦ x1 • x2, nsmul_zero := ⋯, nsmul_succ := ⋯ }
                                              [Meta.isDefEq] [0.010308] ✅️ {
                                                    toAddSemigroup := ContinuousLinearMap.addCommMonoid.toAddSemigroup,
                                                    toZero := ContinuousLinearMap.addCommMonoid.toZero, zero_add := ⋯,
                                                    add_zero := ⋯, nsmul := fun x1 x2 ↦ x1 • x2, nsmul_zero := ⋯,
                                                    nsmul_succ :=
                                                      ⋯ } =?= { toAdd := ContinuousLinearMap.add, add_assoc := ⋯,
                                                    toZero := ContinuousLinearMap.zero, zero_add := ⋯, add_zero := ⋯,
                                                    nsmul := fun x1 x2 ↦ x1 • x2, nsmul_zero := ⋯, nsmul_succ := ⋯ }
                [Elab.step] [0.117036] case body✝ => with_annotate_state"by" (ext; simp)
                  [Elab.step] [0.116833] with_annotate_state"by" (ext; simp)
                    [Elab.step] [0.116825] with_annotate_state"by" (ext; simp)
                      [Elab.step] [0.116817] with_annotate_state"by" (ext; simp)
                        [Elab.step] [0.116808] (ext; simp)
                          [Elab.step] [0.116800] ext; simp
                            [Elab.step] [0.116792] ext; simp
                              [Elab.step] [0.023272] ext
                                [Meta.isDefEq] [0.014782] ✅️ ?f =
                                      ?g =?= ContinuousLinearMap.smulRight 1 ((starRingEnd 𝕜) g') = (toDual 𝕜 𝕜) g'
                              [Elab.step] [0.093490] simp
                                [Meta.isDefEq] [0.011156] ✅️ (ContinuousLinearMap.smulRight ?c ?f)
                                      ?x =?= (ContinuousLinearMap.smulRight 1 ((starRingEnd 𝕜) g')) 1
                                  [Meta.isDefEq] [0.010884] ✅️ ContinuousLinearMap.smulRight ?c
                                        ?f =?= ContinuousLinearMap.smulRight 1 ((starRingEnd 𝕜) g')
                                [Meta.isDefEq] [0.012606] ❌️ ?f 1 =?= ((toDual 𝕜 𝕜) g') 1
                                [Meta.isDefEq] [0.023888] ✅️ ((toDual ?𝕜 ?E) ?x) ?y =?= ((toDual 𝕜 𝕜) g') 1
                                  [Meta.isDefEq] [0.013961] ✅️ (toDual ?𝕜 𝕜) ?x =?= (toDual 𝕜 𝕜) g'
                                    [Meta.isDefEq] [0.013464] ✅️ toDual ?𝕜 𝕜 =?= toDual 𝕜 𝕜
        [Elab.step] [0.075876] rwa [HasDerivAtFilter, this]
          [Elab.step] [0.075525] (rw [HasDerivAtFilter, this]; assumption)
            [Elab.step] [0.075510] rw [HasDerivAtFilter, this]; assumption
              [Elab.step] [0.075500] rw [HasDerivAtFilter, this]; assumption
                [Elab.step] [0.071153] rw [HasDerivAtFilter, this]
                  [Elab.step] [0.071142] (rewrite [HasDerivAtFilter, this];
                        with_annotate_state"]" (try (with_reducible rfl)))
                    [Elab.step] [0.071135] rewrite [HasDerivAtFilter, this];
                          with_annotate_state"]" (try (with_reducible rfl))
                      [Elab.step] [0.071127] rewrite [HasDerivAtFilter, this];
                            with_annotate_state"]" (try (with_reducible rfl))
                        [Elab.step] [0.070666] rewrite [HasDerivAtFilter, this]
                          [Meta.synthInstance] [0.034940] ✅️ ContinuousSMul 𝕜 𝕜
info: Mathlib/Analysis/Calculus/Gradient/Basic.lean:158:8: [Elab.async] [0.018779] Lean.addDecl
  [Kernel] [0.018600] ✅️ typechecking declarations [HasGradientAtFilter.hasDerivAtFilter]
Build completed successfully (2086 jobs).
```

### Trace profiling of `HasGradientAtFilter.hasDerivAtFilter` after PR 28558
```diff
diff --git a/Mathlib/Analysis/Calculus/Gradient/Basic.lean b/Mathlib/Analysis/Calculus/Gradient/Basic.lean
index 836221ccf3..ef259e734f 100644
--- a/Mathlib/Analysis/Calculus/Gradient/Basic.lean
+++ b/Mathlib/Analysis/Calculus/Gradient/Basic.lean
@@ -154,11 +154,10 @@ section OneDimension
 
 variable {g : 𝕜 → 𝕜} {g' u : 𝕜} {L' : Filter 𝕜}
 
+set_option trace.profiler true in
 theorem HasGradientAtFilter.hasDerivAtFilter (h : HasGradientAtFilter g g' u L') :
     HasDerivAtFilter g (starRingEnd 𝕜 g') u L' := by
-  have : ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) (starRingEnd 𝕜 g') = (toDual 𝕜 𝕜) g' := by
-    ext; simp
-  rwa [HasDerivAtFilter, this]
+  tauto
 
 theorem HasDerivAtFilter.hasGradientAtFilter (h : HasDerivAtFilter g g' u L') :
     HasGradientAtFilter g (starRingEnd 𝕜 g') u L' := by
diff --git a/Mathlib/Analysis/NormedSpace/PiTensorProduct/InjectiveSeminorm.lean b/Mathlib/Analysis/NormedSpace/PiTensorProduct/InjectiveSeminorm.lean
index 95d1540f92..6425395be8 100644
--- a/Mathlib/Analysis/NormedSpace/PiTensorProduct/InjectiveSeminorm.lean
+++ b/Mathlib/Analysis/NormedSpace/PiTensorProduct/InjectiveSeminorm.lean
@@ -297,11 +297,7 @@ theorem tprodL_coe : (tprodL 𝕜).toMultilinearMap = tprod 𝕜 (s := E) := by
 @[simp]
 theorem liftIsometry_symm_apply (l : (⨂[𝕜] i, E i) →L[𝕜] F) :
     (liftIsometry 𝕜 E F).symm l = l.compContinuousMultilinearMap (tprodL 𝕜) := by
-  ext m
-  change (liftEquiv 𝕜 E F).symm l m = _
-  simp only [liftEquiv_symm_apply, lift_symm, MultilinearMap.coe_mkContinuous,
-    LinearMap.compMultilinearMap_apply, ContinuousLinearMap.coe_coe,
-    ContinuousLinearMap.compContinuousMultilinearMap_coe, Function.comp_apply, tprodL_toFun]
+  tauto
 
 @[simp]
 theorem liftIsometry_tprodL :
@@ -337,12 +333,7 @@ theorem mapL_coe : (mapL f).toLinearMap = map (fun i ↦ (f i).toLinearMap) := b
 
 @[simp]
 theorem mapL_apply (x : ⨂[𝕜] i, E i) : mapL f x = map (fun i ↦ (f i).toLinearMap) x := by
-  induction x using PiTensorProduct.induction_on with
-  | smul_tprod =>
-    simp only [mapL, map_smul, liftIsometry_apply_apply, lift.tprod,
-    ContinuousMultilinearMap.coe_coe, ContinuousMultilinearMap.compContinuousLinearMap_apply,
-    tprodL_toFun, map_tprod, ContinuousLinearMap.coe_coe]
-  | add _ _ hx hy => simp only [map_add, hx, hy]
+  tauto
 
 /-- Given submodules `pᵢ ⊆ Eᵢ`, this is the natural map: `⨂[𝕜] i, pᵢ → ⨂[𝕜] i, Eᵢ`.
 This is the continuous version of `PiTensorProduct.mapIncl`.
```
```
ℹ [2086/2086] Built Mathlib.Analysis.Calculus.Gradient.Basic (4.3s)
info: Mathlib/Analysis/Calculus/Gradient/Basic.lean:158:0: [Elab.command] [0.063573] theorem hasDerivAtFilter (h : HasGradientAtFilter g g' u L') :
        HasDerivAtFilter g (starRingEnd 𝕜 g') u L' := by tauto
  [Elab.definition.header] [0.051258] HasGradientAtFilter.hasDerivAtFilter
    [Elab.step] [0.041267] expected type: Prop, term
        HasDerivAtFilter g (starRingEnd 𝕜 g') u L'
      [Meta.synthInstance] [0.026897] ✅️ ContinuousSMul 𝕜 𝕜
info: Mathlib/Analysis/Calculus/Gradient/Basic.lean:158:0: [Elab.command] [0.063847] theorem HasGradientAtFilter.hasDerivAtFilter (h : HasGradientAtFilter g g' u L') :
        HasDerivAtFilter g (starRingEnd 𝕜 g') u L' := by tauto
info: Mathlib/Analysis/Calculus/Gradient/Basic.lean:158:0: [Elab.async] [0.026129] elaborating proof of HasGradientAtFilter.hasDerivAtFilter
  [Elab.definition.value] [0.025613] HasGradientAtFilter.hasDerivAtFilter
    [Elab.step] [0.025330] tauto
      [Elab.step] [0.025321] tauto
        [Elab.step] [0.025309] tauto
          [Elab.step] [0.023296] assumption
            [Meta.isDefEq] [0.023275] ✅️ HasDerivAtFilter g ((starRingEnd 𝕜) g') u L' =?= HasGradientAtFilter g g' u L'
              [Meta.isDefEq] [0.023240] ✅️ HasDerivAtFilter g ((starRingEnd 𝕜) g') u
                    L' =?= HasFDerivAtFilter g ((toDual 𝕜 𝕜) g') u L'
                [Meta.isDefEq] [0.023194] ✅️ HasFDerivAtFilter g (ContinuousLinearMap.smulRight 1 ((starRingEnd 𝕜) g'))
                      u L' =?= HasFDerivAtFilter g ((toDual 𝕜 𝕜) g') u L'
                  [Meta.isDefEq] [0.019563] ✅️ ContinuousLinearMap.smulRight 1 ((starRingEnd 𝕜) g') =?= (toDual 𝕜 𝕜) g'
                    [Meta.isDefEq] [0.019423] ✅️ let __src := (↑1).smulRight ((starRingEnd 𝕜) g');
                        { toLinearMap := __src, cont := ⋯ } =?= (toDual 𝕜 𝕜) g'
                      [Meta.isDefEq] [0.019402] ✅️ { toLinearMap := (↑1).smulRight ((starRingEnd 𝕜) g'),
                            cont := ⋯ } =?= (toDual 𝕜 𝕜) g'
                        [Meta.isDefEq] [0.019393] ✅️ { toLinearMap := (↑1).smulRight ((starRingEnd 𝕜) g'),
                              cont := ⋯ } =?= EquivLike.toFunLike.1 (toDual 𝕜 𝕜) g'
                          [Meta.isDefEq] [0.019381] ✅️ { toLinearMap := (↑1).smulRight ((starRingEnd 𝕜) g'),
                                cont := ⋯ } =?= EquivLike.coe (toDual 𝕜 𝕜) g'
                            [Meta.isDefEq] [0.019372] ✅️ { toLinearMap := (↑1).smulRight ((starRingEnd 𝕜) g'),
                                  cont := ⋯ } =?= LinearIsometryEquiv.instEquivLike.1 (toDual 𝕜 𝕜) g'
                              [Meta.isDefEq] [0.019355] ✅️ { toLinearMap := (↑1).smulRight ((starRingEnd 𝕜) g'),
                                    cont := ⋯ } =?= (↑(toDual 𝕜 𝕜).toLinearEquiv).toFun g'
                                [Meta.isDefEq] [0.019343] ✅️ { toLinearMap := (↑1).smulRight ((starRingEnd 𝕜) g'),
                                      cont := ⋯ } =?= (↑(toDual 𝕜 𝕜).toLinearEquiv).toAddHom.1 g'
                                  [Meta.isDefEq] [0.019069] ✅️ { toLinearMap := (↑1).smulRight ((starRingEnd 𝕜) g'),
                                        cont :=
                                          ⋯ } =?= (⇑↑(LinearEquiv.ofTop (LinearMap.range (toDualMap 𝕜 𝕜).toLinearMap)
                                                ⋯) ∘
                                          ⇑↑(LinearEquiv.ofInjective (toDualMap 𝕜 𝕜).toLinearMap ⋯))
                                        g'
                                    [Meta.isDefEq] [0.019058] ✅️ { toLinearMap := (↑1).smulRight ((starRingEnd 𝕜) g'),
                                          cont :=
                                            ⋯ } =?= ↑(LinearEquiv.ofTop (LinearMap.range (toDualMap 𝕜 𝕜).toLinearMap) ⋯)
                                          (↑(LinearEquiv.ofInjective (toDualMap 𝕜 𝕜).toLinearMap ⋯) g')
                                      [Meta.isDefEq] [0.019050] ✅️ { toLinearMap := (↑1).smulRight ((starRingEnd 𝕜) g'),
                                            cont :=
                                              ⋯ } =?= LinearMap.instFunLike.1
                                            (↑(LinearEquiv.ofTop (LinearMap.range (toDualMap 𝕜 𝕜).toLinearMap) ⋯))
                                            (↑(LinearEquiv.ofInjective (toDualMap 𝕜 𝕜).toLinearMap ⋯) g')
                                        [Meta.isDefEq] [0.019025] ✅️ {
                                              toLinearMap := (↑1).smulRight ((starRingEnd 𝕜) g'),
                                              cont :=
                                                ⋯ } =?= (↑(LinearEquiv.ofTop
                                                    (LinearMap.range (toDualMap 𝕜 𝕜).toLinearMap) ⋯)).toFun
                                              (↑(LinearEquiv.ofInjective (toDualMap 𝕜 𝕜).toLinearMap ⋯) g')
                                          [Meta.isDefEq] [0.019016] ✅️ {
                                                toLinearMap := (↑1).smulRight ((starRingEnd 𝕜) g'),
                                                cont :=
                                                  ⋯ } =?= (↑(LinearEquiv.ofTop
                                                        (LinearMap.range (toDualMap 𝕜 𝕜).toLinearMap) ⋯)).toAddHom.1
                                                (↑(LinearEquiv.ofInjective (toDualMap 𝕜 𝕜).toLinearMap ⋯) g')
                                            [Meta.isDefEq] [0.018926] ✅️ {
                                                  toLinearMap := (↑1).smulRight ((starRingEnd 𝕜) g'),
                                                  cont :=
                                                    ⋯ } =?= ↑(↑(LinearEquiv.ofInjective (toDualMap 𝕜 𝕜).toLinearMap ⋯)
                                                    g')
                                              [Meta.isDefEq] [0.018915] ✅️ {
                                                    toLinearMap := (↑1).smulRight ((starRingEnd 𝕜) g'),
                                                    cont :=
                                                      ⋯ } =?= (↑(LinearEquiv.ofInjective (toDualMap 𝕜 𝕜).toLinearMap ⋯)
                                                      g').1
                                                [Meta.isDefEq] [0.018663] ✅️ {
                                                      toLinearMap := (↑1).smulRight ((starRingEnd 𝕜) g'),
                                                      cont := ⋯ } =?= (toDualMap 𝕜 𝕜).toLinearMap g'
                                                  [Meta.isDefEq] [0.018654] ✅️ {
                                                        toLinearMap := (↑1).smulRight ((starRingEnd 𝕜) g'),
                                                        cont :=
                                                          ⋯ } =?= LinearMap.instFunLike.1 (toDualMap 𝕜 𝕜).toLinearMap g'
                                                    [Meta.isDefEq] [0.018640] ✅️ {
                                                          toLinearMap := (↑1).smulRight ((starRingEnd 𝕜) g'),
                                                          cont := ⋯ } =?= (toDualMap 𝕜 𝕜).toFun g'
                                                      [Meta.isDefEq] [0.018631] ✅️ {
                                                            toLinearMap := (↑1).smulRight ((starRingEnd 𝕜) g'),
                                                            cont := ⋯ } =?= (toDualMap 𝕜 𝕜).toAddHom.1 g'
                                                        [Meta.isDefEq] [0.018276] ✅️ {
                                                              toLinearMap := (↑1).smulRight ((starRingEnd 𝕜) g'),
                                                              cont :=
                                                                ⋯ } =?= ((innerₛₗ 𝕜) g').mkContinuousOfExistsBound ⋯
                                                          [Meta.isDefEq] [0.018263] ✅️ {
                                                                toLinearMap := (↑1).smulRight ((starRingEnd 𝕜) g'),
                                                                cont :=
                                                                  ⋯ } =?= { toLinearMap := (innerₛₗ 𝕜) g', cont := ⋯ }
                                                            [Meta.isDefEq] [0.012681] ✅️ (↑1).smulRight
                                                                  ((starRingEnd 𝕜) g') =?= (innerₛₗ 𝕜) g'
                                                              [Meta.isDefEq] [0.012596] ✅️ {
                                                                    toFun := fun b ↦ ↑1 b • (starRingEnd 𝕜) g',
                                                                    map_add' := ⋯, map_smul' := ⋯ } =?= (innerₛₗ 𝕜) g'
                                                                [Meta.isDefEq] [0.012565] ✅️ {
                                                                      toFun := fun b ↦ ↑1 b • (starRingEnd 𝕜) g',
                                                                      map_add' := ⋯,
                                                                      map_smul' :=
                                                                        ⋯ } =?= LinearMap.instFunLike.1 (innerₛₗ 𝕜) g'
                                                                  [Meta.isDefEq] [0.012552] ✅️ {
                                                                        toFun := fun b ↦ ↑1 b • (starRingEnd 𝕜) g',
                                                                        map_add' := ⋯,
                                                                        map_smul' := ⋯ } =?= (innerₛₗ 𝕜).toFun g'
                                                                    [Meta.isDefEq] [0.012543] ✅️ {
                                                                          toFun := fun b ↦ ↑1 b • (starRingEnd 𝕜) g',
                                                                          map_add' := ⋯,
                                                                          map_smul' := ⋯ } =?= (innerₛₗ 𝕜).toAddHom.1 g'
                                                                      [Meta.isDefEq] [0.012400] ✅️ {
                                                                            toFun := fun b ↦ ↑1 b • (starRingEnd 𝕜) g',
                                                                            map_add' := ⋯,
                                                                            map_smul' :=
                                                                              ⋯ } =?= { toFun := (fun v w ↦ ⟪v, w⟫) g',
                                                                            map_add' := ⋯, map_smul' := ⋯ }
info: Mathlib/Analysis/Calculus/Gradient/Basic.lean:158:8: [Elab.async] [0.013901] Lean.addDecl
  [Kernel] [0.013541] ✅️ typechecking declarations [HasGradientAtFilter.hasDerivAtFilter]
Build completed successfully (2086 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
