### PR TITLE
[Merged by Bors] - chore(CategoryTheory): golf entire `preinclusion_map₂`, `mapForget_eq`, `uSwitch_map_uSwitch_map` and more using `rfl`

### DIFF
--- a/Mathlib/CategoryTheory/Bicategory/Coherence.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Coherence.lean
@@ -85,9 +85,7 @@ theorem preinclusion_obj (a : B) : (preinclusion B).obj ⟨a⟩ = a :=
 @[simp]
 theorem preinclusion_map₂ {a b : B} (f g : Discrete (Path.{v + 1} a b)) (η : f ⟶ g) :
     (preinclusion B).map₂ η = eqToHom (congr_arg _ (Discrete.ext (Discrete.eq_of_hom η))) := by
-  rcases η with ⟨⟨⟩⟩
-  cases Discrete.ext (by assumption)
-  convert (inclusionPath a b).map_id _
+  tauto
 
 /-- The normalization of the composition of `p : Path a b` and `f : Hom b c`.
 `p` will eventually be taken to be `nil` and we then get the normalization

--- a/Mathlib/CategoryTheory/Bicategory/Coherence.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Coherence.lean
@@ -85,7 +85,7 @@ theorem preinclusion_obj (a : B) : (preinclusion B).obj ⟨a⟩ = a :=
 @[simp]
 theorem preinclusion_map₂ {a b : B} (f g : Discrete (Path.{v + 1} a b)) (η : f ⟶ g) :
     (preinclusion B).map₂ η = eqToHom (congr_arg _ (Discrete.ext (Discrete.eq_of_hom η))) := by
-  tauto
+  rfl
 
 /-- The normalization of the composition of `p : Path a b` and `f : Hom b c`.
 `p` will eventually be taken to be `nil` and we then get the normalization

--- a/Mathlib/CategoryTheory/Bicategory/Coherence.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Coherence.lean
@@ -84,7 +84,7 @@ theorem preinclusion_obj (a : B) : (preinclusion B).obj ⟨a⟩ = a :=
 
 @[simp]
 theorem preinclusion_map₂ {a b : B} (f g : Discrete (Path.{v + 1} a b)) (η : f ⟶ g) :
-    (preinclusion B).map₂ η = eqToHom (congr_arg _ (Discrete.ext (Discrete.eq_of_hom η))) := by
+    (preinclusion B).map₂ η = eqToHom (congr_arg _ (Discrete.ext (Discrete.eq_of_hom η))) :=
   rfl
 
 /-- The normalization of the composition of `p : Path a b` and `f : Hom b c`.

--- a/Mathlib/CategoryTheory/Comma/Over/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Basic.lean
@@ -216,9 +216,7 @@ def mapId (Y : T) : map (𝟙 Y) ≅ 𝟭 _ := eqToIso (mapId_eq Y)
 /-- Mapping by `f` and then forgetting is the same as forgetting. -/
 theorem mapForget_eq {X Y : T} (f : X ⟶ Y) :
     (map f) ⋙ (forget Y) = (forget X) := by
-  fapply Functor.ext
-  · simp [Over, Over.map]
-  · simp
+  tauto
 
 /-- The natural isomorphism arising from `mapForget_eq`. -/
 def mapForget {X Y : T} (f : X ⟶ Y) :
@@ -626,9 +624,7 @@ def mapId (Y : T) : map (𝟙 Y) ≅ 𝟭 _ := eqToIso (mapId_eq Y)
 /-- Mapping by `f` and then forgetting is the same as forgetting. -/
 theorem mapForget_eq {X Y : T} (f : X ⟶ Y) :
     (map f) ⋙ (forget X) = (forget Y) := by
-  fapply Functor.ext
-  · dsimp [Under, Under.map]; intro x; exact rfl
-  · simp
+  tauto
 
 /-- The natural isomorphism arising from `mapForget_eq`. -/
 def mapForget {X Y : T} (f : X ⟶ Y) :

--- a/Mathlib/CategoryTheory/Comma/Over/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Basic.lean
@@ -215,8 +215,7 @@ def mapId (Y : T) : map (𝟙 Y) ≅ 𝟭 _ := eqToIso (mapId_eq Y)
 
 /-- Mapping by `f` and then forgetting is the same as forgetting. -/
 theorem mapForget_eq {X Y : T} (f : X ⟶ Y) :
-    (map f) ⋙ (forget Y) = (forget X) := by
-  rfl
+    (map f) ⋙ (forget Y) = (forget X) := rfl
 
 /-- The natural isomorphism arising from `mapForget_eq`. -/
 def mapForget {X Y : T} (f : X ⟶ Y) :
@@ -623,8 +622,7 @@ def mapId (Y : T) : map (𝟙 Y) ≅ 𝟭 _ := eqToIso (mapId_eq Y)
 
 /-- Mapping by `f` and then forgetting is the same as forgetting. -/
 theorem mapForget_eq {X Y : T} (f : X ⟶ Y) :
-    (map f) ⋙ (forget X) = (forget Y) := by
-  rfl
+    (map f) ⋙ (forget X) = (forget Y) := rfl
 
 /-- The natural isomorphism arising from `mapForget_eq`. -/
 def mapForget {X Y : T} (f : X ⟶ Y) :

--- a/Mathlib/CategoryTheory/Comma/Over/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Basic.lean
@@ -216,7 +216,7 @@ def mapId (Y : T) : map (𝟙 Y) ≅ 𝟭 _ := eqToIso (mapId_eq Y)
 /-- Mapping by `f` and then forgetting is the same as forgetting. -/
 theorem mapForget_eq {X Y : T} (f : X ⟶ Y) :
     (map f) ⋙ (forget Y) = (forget X) := by
-  tauto
+  rfl
 
 /-- The natural isomorphism arising from `mapForget_eq`. -/
 def mapForget {X Y : T} (f : X ⟶ Y) :
@@ -624,7 +624,7 @@ def mapId (Y : T) : map (𝟙 Y) ≅ 𝟭 _ := eqToIso (mapId_eq Y)
 /-- Mapping by `f` and then forgetting is the same as forgetting. -/
 theorem mapForget_eq {X Y : T} (f : X ⟶ Y) :
     (map f) ⋙ (forget X) = (forget Y) := by
-  tauto
+  rfl
 
 /-- The natural isomorphism arising from `mapForget_eq`. -/
 def mapForget {X Y : T} (f : X ⟶ Y) :

--- a/Mathlib/CategoryTheory/FintypeCat.lean
+++ b/Mathlib/CategoryTheory/FintypeCat.lean
@@ -237,7 +237,7 @@ lemma uSwitch_map_uSwitch_map {X Y : FintypeCat.{u}} (f : X ⟶ Y) :
     (equivEquivIso ((uSwitch.obj X).uSwitchEquiv.trans X.uSwitchEquiv)).hom ≫
       f ≫ (equivEquivIso ((uSwitch.obj Y).uSwitchEquiv.trans
       Y.uSwitchEquiv)).inv := by
-  tauto
+  rfl
 
 /-- `uSwitch.{u, v}` is an equivalence of categories with quasi-inverse `uSwitch.{v, u}`. -/
 noncomputable def uSwitchEquivalence : FintypeCat.{u} ≌ FintypeCat.{v} where

--- a/Mathlib/CategoryTheory/FintypeCat.lean
+++ b/Mathlib/CategoryTheory/FintypeCat.lean
@@ -236,8 +236,7 @@ lemma uSwitch_map_uSwitch_map {X Y : FintypeCat.{u}} (f : X ⟶ Y) :
     uSwitch.map (uSwitch.map f) =
     (equivEquivIso ((uSwitch.obj X).uSwitchEquiv.trans X.uSwitchEquiv)).hom ≫
       f ≫ (equivEquivIso ((uSwitch.obj Y).uSwitchEquiv.trans
-      Y.uSwitchEquiv)).inv := by
-  rfl
+      Y.uSwitchEquiv)).inv := rfl
 
 /-- `uSwitch.{u, v}` is an equivalence of categories with quasi-inverse `uSwitch.{v, u}`. -/
 noncomputable def uSwitchEquivalence : FintypeCat.{u} ≌ FintypeCat.{v} where

--- a/Mathlib/CategoryTheory/FintypeCat.lean
+++ b/Mathlib/CategoryTheory/FintypeCat.lean
@@ -237,10 +237,7 @@ lemma uSwitch_map_uSwitch_map {X Y : FintypeCat.{u}} (f : X ⟶ Y) :
     (equivEquivIso ((uSwitch.obj X).uSwitchEquiv.trans X.uSwitchEquiv)).hom ≫
       f ≫ (equivEquivIso ((uSwitch.obj Y).uSwitchEquiv.trans
       Y.uSwitchEquiv)).inv := by
-  ext x
-  simp only [comp_apply, equivEquivIso_apply_hom, Equiv.trans_apply]
-  rw [uSwitchEquiv_naturality f, ← uSwitchEquiv_naturality]
-  rfl
+  tauto
 
 /-- `uSwitch.{u, v}` is an equivalence of categories with quasi-inverse `uSwitch.{v, u}`. -/
 noncomputable def uSwitchEquivalence : FintypeCat.{u} ≌ FintypeCat.{v} where

--- a/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
@@ -82,7 +82,7 @@ theorem inclusion_obj (X : N C) :
 @[simp]
 theorem inclusion_map {X Y : N C} (f : X ⟶ Y) :
     inclusion.map f = eqToHom (congr_arg _ (Discrete.ext (Discrete.eq_of_hom f))) := by
-  tauto
+  rfl
 
 /-- Auxiliary definition for `normalize`. -/
 def normalizeObj : F C → NormalMonoidalObject C → NormalMonoidalObject C

--- a/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
@@ -82,9 +82,7 @@ theorem inclusion_obj (X : N C) :
 @[simp]
 theorem inclusion_map {X Y : N C} (f : X ⟶ Y) :
     inclusion.map f = eqToHom (congr_arg _ (Discrete.ext (Discrete.eq_of_hom f))) := by
-  rcases f with ⟨⟨⟩⟩
-  cases Discrete.ext (by assumption)
-  apply inclusion.map_id
+  tauto
 
 /-- Auxiliary definition for `normalize`. -/
 def normalizeObj : F C → NormalMonoidalObject C → NormalMonoidalObject C

--- a/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
@@ -81,8 +81,7 @@ theorem inclusion_obj (X : N C) :
 
 @[simp]
 theorem inclusion_map {X Y : N C} (f : X ⟶ Y) :
-    inclusion.map f = eqToHom (congr_arg _ (Discrete.ext (Discrete.eq_of_hom f))) := by
-  rfl
+    inclusion.map f = eqToHom (congr_arg _ (Discrete.ext (Discrete.eq_of_hom f))) := rfl
 
 /-- Auxiliary definition for `normalize`. -/
 def normalizeObj : F C → NormalMonoidalObject C → NormalMonoidalObject C
@@ -273,7 +272,6 @@ def normalizeIso : tensorFunc C ≅ normalize' C :=
     ext ⟨n⟩
     convert normalize_naturality n f using 1
     any_goals dsimp; rw [normalizeIsoApp_eq]
-    rfl
 
 /-- The isomorphism between an object and its normal form is natural. -/
 def fullNormalizeIso : 𝟭 (F C) ≅ fullNormalize C ⋙ inclusion :=

--- a/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
@@ -344,7 +344,7 @@ lemma map_isoClosure (P : MorphismProperty C) (F : C ⥤ D) :
 
 lemma map_id_eq_isoClosure (P : MorphismProperty C) :
     P.map (𝟭 _) = P.isoClosure := by
-  tauto
+  rfl
 
 lemma map_id (P : MorphismProperty C) [RespectsIso P] :
     P.map (𝟭 _) = P := by

--- a/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
@@ -343,8 +343,7 @@ lemma map_isoClosure (P : MorphismProperty C) (F : C ⥤ D) :
   · exact monotone_map _ (le_isoClosure P)
 
 lemma map_id_eq_isoClosure (P : MorphismProperty C) :
-    P.map (𝟭 _) = P.isoClosure := by
-  rfl
+    P.map (𝟭 _) = P.isoClosure := rfl
 
 lemma map_id (P : MorphismProperty C) [RespectsIso P] :
     P.map (𝟭 _) = P := by

--- a/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
@@ -344,12 +344,7 @@ lemma map_isoClosure (P : MorphismProperty C) (F : C ⥤ D) :
 
 lemma map_id_eq_isoClosure (P : MorphismProperty C) :
     P.map (𝟭 _) = P.isoClosure := by
-  apply le_antisymm
-  · rw [map_le_iff]
-    intro X Y f hf
-    exact P.le_isoClosure _ hf
-  · intro X Y f hf
-    exact hf
+  tauto
 
 lemma map_id (P : MorphismProperty C) [RespectsIso P] :
     P.map (𝟭 _) = P := by

--- a/Mathlib/CategoryTheory/Pi/Basic.lean
+++ b/Mathlib/CategoryTheory/Pi/Basic.lean
@@ -200,10 +200,7 @@ end EqToHom
 -- how `Functor.pi` commutes with `Pi.eval` and `Pi.comap`.
 @[simp]
 theorem pi'_eval (f : ∀ i, A ⥤ C i) (i : I) : pi' f ⋙ Pi.eval C i = f i := by
-  apply Functor.ext
-  · simp
-  · intro _
-    rfl
+  tauto
 
 /-- Two functors to a product category are equal iff they agree on every coordinate. -/
 theorem pi_ext (f f' : A ⥤ ∀ i, C i) (h : ∀ i, f ⋙ (Pi.eval C i) = f' ⋙ (Pi.eval C i)) :

--- a/Mathlib/CategoryTheory/Pi/Basic.lean
+++ b/Mathlib/CategoryTheory/Pi/Basic.lean
@@ -200,7 +200,7 @@ end EqToHom
 -- how `Functor.pi` commutes with `Pi.eval` and `Pi.comap`.
 @[simp]
 theorem pi'_eval (f : ∀ i, A ⥤ C i) (i : I) : pi' f ⋙ Pi.eval C i = f i := by
-  tauto
+  rfl
 
 /-- Two functors to a product category are equal iff they agree on every coordinate. -/
 theorem pi_ext (f f' : A ⥤ ∀ i, C i) (h : ∀ i, f ⋙ (Pi.eval C i) = f' ⋙ (Pi.eval C i)) :

--- a/Mathlib/CategoryTheory/Pi/Basic.lean
+++ b/Mathlib/CategoryTheory/Pi/Basic.lean
@@ -199,7 +199,7 @@ end EqToHom
 -- One could add some natural isomorphisms showing
 -- how `Functor.pi` commutes with `Pi.eval` and `Pi.comap`.
 @[simp]
-theorem pi'_eval (f : ∀ i, A ⥤ C i) (i : I) : pi' f ⋙ Pi.eval C i = f i := by
+theorem pi'_eval (f : ∀ i, A ⥤ C i) (i : I) : pi' f ⋙ Pi.eval C i = f i :=
   rfl
 
 /-- Two functors to a product category are equal iff they agree on every coordinate. -/

--- a/Mathlib/CategoryTheory/Quotient.lean
+++ b/Mathlib/CategoryTheory/Quotient.lean
@@ -236,9 +236,7 @@ theorem lift_obj_functor_obj (X : C) :
 
 theorem lift_map_functor_map {X Y : C} (f : X ⟶ Y) :
     (lift r F H).map ((functor r).map f) = F.map f := by
-  rw [← NatIso.naturality_1 (lift.isLift r F H)]
-  dsimp [lift, functor]
-  simp
+  tauto
 
 variable {r}
 

--- a/Mathlib/CategoryTheory/Quotient.lean
+++ b/Mathlib/CategoryTheory/Quotient.lean
@@ -235,7 +235,7 @@ theorem lift_obj_functor_obj (X : C) :
     (lift r F H).obj ((functor r).obj X) = F.obj X := rfl
 
 theorem lift_map_functor_map {X Y : C} (f : X ⟶ Y) :
-    (lift r F H).map ((functor r).map f) = F.map f := by
+    (lift r F H).map ((functor r).map f) = F.map f :=
   rfl
 
 variable {r}

--- a/Mathlib/CategoryTheory/Quotient.lean
+++ b/Mathlib/CategoryTheory/Quotient.lean
@@ -236,7 +236,7 @@ theorem lift_obj_functor_obj (X : C) :
 
 theorem lift_map_functor_map {X Y : C} (f : X ⟶ Y) :
     (lift r F H).map ((functor r).map f) = F.map f := by
-  tauto
+  rfl
 
 variable {r}
 


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>preinclusion_map₂</code>: 166 ms before, 33 ms after  🎉</summary>

### Trace profiling of `preinclusion_map₂` before PR 28559
```diff
diff --git a/Mathlib/CategoryTheory/Bicategory/Coherence.lean b/Mathlib/CategoryTheory/Bicategory/Coherence.lean
index e5ce271970..61a115654e 100644
--- a/Mathlib/CategoryTheory/Bicategory/Coherence.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Coherence.lean
@@ -84,6 +84,7 @@ def preinclusion (B : Type u) [Quiver.{v + 1} B] :
 theorem preinclusion_obj (a : B) : (preinclusion B).obj ⟨a⟩ = a :=
   rfl
 
+set_option trace.profiler true in
 @[simp]
 theorem preinclusion_map₂ {a b : B} (f g : Discrete (Path.{v + 1} a b)) (η : f ⟶ g) :
     (preinclusion B).map₂ η = eqToHom (congr_arg _ (Discrete.ext (Discrete.eq_of_hom η))) := by
```
```
ℹ [503/503] Built Mathlib.CategoryTheory.Bicategory.Coherence (3.8s)
info: Mathlib/CategoryTheory/Bicategory/Coherence.lean:88:0: [Elab.command] [0.017892] @[simp]
    theorem preinclusion_map₂ {a b : B} (f g : Discrete (Path.{v + 1} a b)) (η : f ⟶ g) :
        (preinclusion B).map₂ η = eqToHom (congr_arg _ (Discrete.ext (Discrete.eq_of_hom η))) :=
      by
      rcases η with ⟨⟨⟩⟩
      cases Discrete.ext (by assumption)
      convert (inclusionPath a b).map_id _
  [Elab.definition.header] [0.012532] CategoryTheory.FreeBicategory.preinclusion_map₂
    [Elab.step] [0.010910] expected type: Prop, term
        (preinclusion B).map₂ η = eqToHom (congr_arg _ (Discrete.ext (Discrete.eq_of_hom η)))
      [Elab.step] [0.010898] expected type: Prop, term
          binrel% Eq✝ ((preinclusion B).map₂ η) (eqToHom (congr_arg _ (Discrete.ext (Discrete.eq_of_hom η))))
info: Mathlib/CategoryTheory/Bicategory/Coherence.lean:88:0: [Elab.async] [0.170229] elaborating proof of CategoryTheory.FreeBicategory.preinclusion_map₂
  [Elab.definition.value] [0.165791] CategoryTheory.FreeBicategory.preinclusion_map₂
    [Elab.step] [0.160852] 
          rcases η with ⟨⟨⟩⟩
          cases Discrete.ext (by assumption)
          convert (inclusionPath a b).map_id _
      [Elab.step] [0.160840] 
            rcases η with ⟨⟨⟩⟩
            cases Discrete.ext (by assumption)
            convert (inclusionPath a b).map_id _
        [Elab.step] [0.153245] convert (inclusionPath a b).map_id _
info: Mathlib/CategoryTheory/Bicategory/Coherence.lean:89:8: [Elab.async] [0.012802] Lean.addDecl
  [Kernel] [0.012744] ✅️ typechecking declarations [CategoryTheory.FreeBicategory.preinclusion_map₂]
Build completed successfully (503 jobs).
```

### Trace profiling of `preinclusion_map₂` after PR 28559
```diff
diff --git a/Mathlib/CategoryTheory/Bicategory/Coherence.lean b/Mathlib/CategoryTheory/Bicategory/Coherence.lean
index e5ce271970..29da16cbb6 100644
--- a/Mathlib/CategoryTheory/Bicategory/Coherence.lean
+++ b/Mathlib/CategoryTheory/Bicategory/Coherence.lean
@@ -84,12 +84,11 @@ def preinclusion (B : Type u) [Quiver.{v + 1} B] :
 theorem preinclusion_obj (a : B) : (preinclusion B).obj ⟨a⟩ = a :=
   rfl
 
+set_option trace.profiler true in
 @[simp]
 theorem preinclusion_map₂ {a b : B} (f g : Discrete (Path.{v + 1} a b)) (η : f ⟶ g) :
     (preinclusion B).map₂ η = eqToHom (congr_arg _ (Discrete.ext (Discrete.eq_of_hom η))) := by
-  rcases η with ⟨⟨⟩⟩
-  cases Discrete.ext (by assumption)
-  convert (inclusionPath a b).map_id _
+  tauto
 
 /-- The normalization of the composition of `p : Path a b` and `f : Hom b c`.
 `p` will eventually be taken to be `nil` and we then get the normalization
diff --git a/Mathlib/CategoryTheory/Comma/Over/Basic.lean b/Mathlib/CategoryTheory/Comma/Over/Basic.lean
index 1372cd7356..623f4dc454 100644
--- a/Mathlib/CategoryTheory/Comma/Over/Basic.lean
+++ b/Mathlib/CategoryTheory/Comma/Over/Basic.lean
@@ -216,9 +216,7 @@ def mapId (Y : T) : map (𝟙 Y) ≅ 𝟭 _ := eqToIso (mapId_eq Y)
 /-- Mapping by `f` and then forgetting is the same as forgetting. -/
 theorem mapForget_eq {X Y : T} (f : X ⟶ Y) :
     (map f) ⋙ (forget Y) = (forget X) := by
-  fapply Functor.ext
-  · dsimp [Over, Over.map]; intro x; exact rfl
-  · intros x y u; simp
+  tauto
 
 /-- The natural isomorphism arising from `mapForget_eq`. -/
 def mapForget {X Y : T} (f : X ⟶ Y) :
@@ -626,9 +624,7 @@ def mapId (Y : T) : map (𝟙 Y) ≅ 𝟭 _ := eqToIso (mapId_eq Y)
 /-- Mapping by `f` and then forgetting is the same as forgetting. -/
 theorem mapForget_eq {X Y : T} (f : X ⟶ Y) :
     (map f) ⋙ (forget X) = (forget Y) := by
-  fapply Functor.ext
-  · dsimp [Under, Under.map]; intro x; exact rfl
-  · intros x y u; simp
+  tauto
 
 /-- The natural isomorphism arising from `mapForget_eq`. -/
 def mapForget {X Y : T} (f : X ⟶ Y) :
diff --git a/Mathlib/CategoryTheory/FintypeCat.lean b/Mathlib/CategoryTheory/FintypeCat.lean
index ba51103beb..947f2743b8 100644
--- a/Mathlib/CategoryTheory/FintypeCat.lean
+++ b/Mathlib/CategoryTheory/FintypeCat.lean
@@ -237,10 +237,7 @@ lemma uSwitch_map_uSwitch_map {X Y : FintypeCat.{u}} (f : X ⟶ Y) :
     (equivEquivIso ((uSwitch.obj X).uSwitchEquiv.trans X.uSwitchEquiv)).hom ≫
       f ≫ (equivEquivIso ((uSwitch.obj Y).uSwitchEquiv.trans
       Y.uSwitchEquiv)).inv := by
-  ext x
-  simp only [comp_apply, equivEquivIso_apply_hom, Equiv.trans_apply]
-  rw [uSwitchEquiv_naturality f, ← uSwitchEquiv_naturality]
-  rfl
+  tauto
 
 /-- `uSwitch.{u, v}` is an equivalence of categories with quasi-inverse `uSwitch.{v, u}`. -/
 noncomputable def uSwitchEquivalence : FintypeCat.{u} ≌ FintypeCat.{v} where
diff --git a/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean b/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
index d71f89c163..8739b63337 100644
--- a/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Free/Coherence.lean
@@ -83,9 +83,7 @@ theorem inclusion_obj (X : N C) :
 @[simp]
 theorem inclusion_map {X Y : N C} (f : X ⟶ Y) :
     inclusion.map f = eqToHom (congr_arg _ (Discrete.ext (Discrete.eq_of_hom f))) := by
-  rcases f with ⟨⟨⟩⟩
-  cases Discrete.ext (by assumption)
-  apply inclusion.map_id
+  tauto
 
 /-- Auxiliary definition for `normalize`. -/
 def normalizeObj : F C → NormalMonoidalObject C → NormalMonoidalObject C
diff --git a/Mathlib/CategoryTheory/MorphismProperty/Basic.lean b/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
index e49349dfd8..59072358d3 100644
--- a/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
+++ b/Mathlib/CategoryTheory/MorphismProperty/Basic.lean
@@ -344,12 +344,7 @@ lemma map_isoClosure (P : MorphismProperty C) (F : C ⥤ D) :
 
 lemma map_id_eq_isoClosure (P : MorphismProperty C) :
     P.map (𝟭 _) = P.isoClosure := by
-  apply le_antisymm
-  · rw [map_le_iff]
-    intro X Y f hf
-    exact P.le_isoClosure _ hf
-  · intro X Y f hf
-    exact hf
+  tauto
 
 lemma map_id (P : MorphismProperty C) [RespectsIso P] :
     P.map (𝟭 _) = P := by
diff --git a/Mathlib/CategoryTheory/Pi/Basic.lean b/Mathlib/CategoryTheory/Pi/Basic.lean
index e721041ea4..41af15d2d0 100644
--- a/Mathlib/CategoryTheory/Pi/Basic.lean
+++ b/Mathlib/CategoryTheory/Pi/Basic.lean
@@ -208,11 +208,7 @@ end EqToHom
 -- how `Functor.pi` commutes with `Pi.eval` and `Pi.comap`.
 @[simp]
 theorem pi'_eval (f : ∀ i, A ⥤ C i) (i : I) : pi' f ⋙ Pi.eval C i = f i := by
-  apply Functor.ext
-  · intro _ _ _
-    simp
-  · intro _
-    rfl
+  tauto
 
 /-- Two functors to a product category are equal iff they agree on every coordinate. -/
 theorem pi_ext (f f' : A ⥤ ∀ i, C i) (h : ∀ i, f ⋙ (Pi.eval C i) = f' ⋙ (Pi.eval C i)) :
diff --git a/Mathlib/CategoryTheory/Quotient.lean b/Mathlib/CategoryTheory/Quotient.lean
index c66247076c..b73eaf476d 100644
--- a/Mathlib/CategoryTheory/Quotient.lean
+++ b/Mathlib/CategoryTheory/Quotient.lean
@@ -237,9 +237,7 @@ theorem lift_obj_functor_obj (X : C) :
 
 theorem lift_map_functor_map {X Y : C} (f : X ⟶ Y) :
     (lift r F H).map ((functor r).map f) = F.map f := by
-  rw [← NatIso.naturality_1 (lift.isLift r F H)]
-  dsimp [lift, functor]
-  simp
+  tauto
 
 variable {r}
 
```
```
✔ [489/503] Built Mathlib.CategoryTheory.Quotient (2.2s)
✔ [490/503] Built Mathlib.CategoryTheory.PathCategory.Basic (1.9s)
✔ [491/503] Built Mathlib.CategoryTheory.Pi.Basic (4.5s)
✔ [492/503] Built Mathlib.CategoryTheory.Groupoid (1.8s)
✔ [493/503] Built Mathlib.CategoryTheory.Discrete.Basic (2.9s)
✔ [494/503] Built Mathlib.CategoryTheory.EpiMono (1.9s)
✔ [495/503] Built Mathlib.CategoryTheory.Bicategory.LocallyDiscrete (2.2s)
✔ [496/503] Built Mathlib.CategoryTheory.Types (1.9s)
✔ [497/503] Built Mathlib.CategoryTheory.Category.Cat (2.0s)
✔ [498/503] Built Mathlib.Tactic.CategoryTheory.ToApp (1.8s)
✔ [499/503] Built Mathlib.CategoryTheory.Bicategory.Functor.Oplax (2.0s)
✔ [500/503] Built Mathlib.CategoryTheory.Bicategory.Functor.Lax (3.2s)
✔ [501/503] Built Mathlib.CategoryTheory.Bicategory.Functor.Pseudofunctor (4.5s)
✔ [502/503] Built Mathlib.CategoryTheory.Bicategory.Free (5.3s)
ℹ [503/503] Built Mathlib.CategoryTheory.Bicategory.Coherence (3.9s)
info: Mathlib/CategoryTheory/Bicategory/Coherence.lean:88:0: [Elab.command] [0.020377] @[simp]
    theorem preinclusion_map₂ {a b : B} (f g : Discrete (Path.{v + 1} a b)) (η : f ⟶ g) :
        (preinclusion B).map₂ η = eqToHom (congr_arg _ (Discrete.ext (Discrete.eq_of_hom η))) := by tauto
  [Elab.definition.header] [0.011267] CategoryTheory.FreeBicategory.preinclusion_map₂
info: Mathlib/CategoryTheory/Bicategory/Coherence.lean:88:0: [Elab.async] [0.033437] elaborating proof of CategoryTheory.FreeBicategory.preinclusion_map₂
  [Elab.definition.value] [0.032541] CategoryTheory.FreeBicategory.preinclusion_map₂
    [Elab.step] [0.032026] tauto
      [Elab.step] [0.032010] tauto
        [Elab.step] [0.031994] tauto
          [Elab.step] [0.020006] rfl
            [Elab.step] [0.019397] eq_refl
              [Meta.isDefEq] [0.019374] ✅️ (preinclusion B).map₂ η =?= eqToHom ⋯
                [Meta.isDefEq] [0.019302] ✅️ (preinclusion B).map₂ η =?= ⋯.mpr (𝟙 ((preinclusion B).map g))
                  [Meta.isDefEq] [0.019274] ✅️ (preinclusion B).map₂ η =?= ⋯ ▸ 𝟙 ((preinclusion B).map g)
                    [Meta.isDefEq] [0.016614] ✅️ (preinclusion B).toPrelaxFunctorStruct.2
                          η =?= ⋯ ▸ 𝟙 ((preinclusion B).map g)
                      [Meta.isDefEq] [0.014779] ✅️ (inclusionPath { as := a }.as { as := b }.as).map
                            η =?= ⋯ ▸ 𝟙 ((preinclusion B).map g)
                        [Meta.isDefEq] [0.013158] ✅️ (inclusionPath { as := a }.as { as := b }.as).2
                              η =?= ⋯ ▸ 𝟙 ((preinclusion B).map g)
                          [Meta.isDefEq] [0.011394] ✅️ id
                                (ULift.casesOn η fun down ↦
                                  PLift.casesOn down fun h ↦ eqToHom ⋯) =?= ⋯ ▸ 𝟙 ((preinclusion B).map g)
Build completed successfully (503 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
