### PR TITLE
chore(Combinatorics/Quiver): golf entire `lift_spec` using `rfl`

### DIFF
--- a/Mathlib/Combinatorics/Quiver/Symmetric.lean
+++ b/Mathlib/Combinatorics/Quiver/Symmetric.lean
@@ -166,11 +166,7 @@ def lift [HasReverse V'] (φ : Prefunctor V V') :
 
 theorem lift_spec [HasReverse V'] (φ : Prefunctor V V') :
     Symmetrify.of.comp (Symmetrify.lift φ) = φ := by
-  fapply Prefunctor.ext
-  · rintro X
-    rfl
-  · rintro X Y f
-    rfl
+  tauto
 
 theorem lift_reverse [h : HasInvolutiveReverse V']
     (φ : Prefunctor V V') {X Y : Symmetrify V} (f : X ⟶ Y) :

--- a/Mathlib/Combinatorics/Quiver/Symmetric.lean
+++ b/Mathlib/Combinatorics/Quiver/Symmetric.lean
@@ -166,7 +166,7 @@ def lift [HasReverse V'] (φ : Prefunctor V V') :
 
 theorem lift_spec [HasReverse V'] (φ : Prefunctor V V') :
     Symmetrify.of.comp (Symmetrify.lift φ) = φ := by
-  tauto
+  rfl
 
 theorem lift_reverse [h : HasInvolutiveReverse V']
     (φ : Prefunctor V V') {X Y : Symmetrify V} (f : X ⟶ Y) :

--- a/Mathlib/Combinatorics/Quiver/Symmetric.lean
+++ b/Mathlib/Combinatorics/Quiver/Symmetric.lean
@@ -165,7 +165,7 @@ def lift [HasReverse V'] (φ : Prefunctor V V') :
   | Sum.inr g => reverse (φ.map g)
 
 theorem lift_spec [HasReverse V'] (φ : Prefunctor V V') :
-    Symmetrify.of.comp (Symmetrify.lift φ) = φ := by
+    Symmetrify.of.comp (Symmetrify.lift φ) = φ :=
   rfl
 
 theorem lift_reverse [h : HasInvolutiveReverse V']


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>lift_spec</code>: <10 ms before, <10 ms after  🎉</summary>

### Trace profiling of `lift_spec` before PR 28560
```diff
diff --git a/Mathlib/Combinatorics/Quiver/Symmetric.lean b/Mathlib/Combinatorics/Quiver/Symmetric.lean
index 33e371b283..76a3371b36 100644
--- a/Mathlib/Combinatorics/Quiver/Symmetric.lean
+++ b/Mathlib/Combinatorics/Quiver/Symmetric.lean
@@ -164,6 +164,7 @@ def lift [HasReverse V'] (φ : Prefunctor V V') :
   | Sum.inl g => φ.map g
   | Sum.inr g => reverse (φ.map g)
 
+set_option trace.profiler true in
 theorem lift_spec [HasReverse V'] (φ : Prefunctor V V') :
     Symmetrify.of.comp (Symmetrify.lift φ) = φ := by
   fapply Prefunctor.ext
```
```
✔ [147/147] Built Mathlib.Combinatorics.Quiver.Symmetric (1.3s)
Build completed successfully (147 jobs).
```

### Trace profiling of `lift_spec` after PR 28560
```diff
diff --git a/Mathlib/Combinatorics/Quiver/Symmetric.lean b/Mathlib/Combinatorics/Quiver/Symmetric.lean
index 33e371b283..3adf874946 100644
--- a/Mathlib/Combinatorics/Quiver/Symmetric.lean
+++ b/Mathlib/Combinatorics/Quiver/Symmetric.lean
@@ -164,13 +164,10 @@ def lift [HasReverse V'] (φ : Prefunctor V V') :
   | Sum.inl g => φ.map g
   | Sum.inr g => reverse (φ.map g)
 
+set_option trace.profiler true in
 theorem lift_spec [HasReverse V'] (φ : Prefunctor V V') :
     Symmetrify.of.comp (Symmetrify.lift φ) = φ := by
-  fapply Prefunctor.ext
-  · rintro X
-    rfl
-  · rintro X Y f
-    rfl
+  tauto
 
 theorem lift_reverse [h : HasInvolutiveReverse V']
     (φ : Prefunctor V V') {X Y : Symmetrify V} (f : X ⟶ Y) :
```
```
✔ [147/147] Built Mathlib.Combinatorics.Quiver.Symmetric (1.2s)
Build completed successfully (147 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
