### PR TITLE
[Merged by Bors] - chore(GroupTheory): golf entire `base_smul_def` and `summand_smul_def` using `rfl`

### DIFF
--- a/Mathlib/GroupTheory/PushoutI.lean
+++ b/Mathlib/GroupTheory/PushoutI.lean
@@ -467,17 +467,13 @@ noncomputable instance mulAction : MulAction (PushoutI φ) (NormalWord d) :=
 
 theorem base_smul_def (h : H) (w : NormalWord d) :
     base φ h • w = { w with head := h * w.head } := by
-  dsimp [NormalWord.mulAction, instHSMul, SMul.smul]
-  rw [lift_base]
-  rfl
+  tauto
 
 theorem summand_smul_def {i : ι} (g : G i) (w : NormalWord d) :
     of (φ := φ) i g • w = (equivPair i).symm
       { equivPair i w with
         head := g * (equivPair i w).head } := by
-  dsimp [NormalWord.mulAction, instHSMul, SMul.smul]
-  rw [lift_of]
-  rfl
+  tauto
 
 theorem of_smul_eq_smul {i : ι} (g : G i) (w : NormalWord d) :
     of (φ := φ) i g • w = g • w := by

--- a/Mathlib/GroupTheory/PushoutI.lean
+++ b/Mathlib/GroupTheory/PushoutI.lean
@@ -466,14 +466,12 @@ noncomputable instance mulAction : MulAction (PushoutI φ) (NormalWord d) :=
       smul_inv_smul, base_smul_def', MonoidHom.apply_ofInjective_symm]
 
 theorem base_smul_def (h : H) (w : NormalWord d) :
-    base φ h • w = { w with head := h * w.head } := by
-  rfl
+    base φ h • w = { w with head := h * w.head } := rfl
 
 theorem summand_smul_def {i : ι} (g : G i) (w : NormalWord d) :
     of (φ := φ) i g • w = (equivPair i).symm
       { equivPair i w with
-        head := g * (equivPair i w).head } := by
-  rfl
+        head := g * (equivPair i w).head } := rfl
 
 theorem of_smul_eq_smul {i : ι} (g : G i) (w : NormalWord d) :
     of (φ := φ) i g • w = g • w := by

--- a/Mathlib/GroupTheory/PushoutI.lean
+++ b/Mathlib/GroupTheory/PushoutI.lean
@@ -467,13 +467,13 @@ noncomputable instance mulAction : MulAction (PushoutI φ) (NormalWord d) :=
 
 theorem base_smul_def (h : H) (w : NormalWord d) :
     base φ h • w = { w with head := h * w.head } := by
-  tauto
+  rfl
 
 theorem summand_smul_def {i : ι} (g : G i) (w : NormalWord d) :
     of (φ := φ) i g • w = (equivPair i).symm
       { equivPair i w with
         head := g * (equivPair i w).head } := by
-  tauto
+  rfl
 
 theorem of_smul_eq_smul {i : ι} (g : G i) (w : NormalWord d) :
     of (φ := φ) i g • w = g • w := by


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>base_smul_def</code>: 14 ms before, <10 ms after  🎉</summary>

### Trace profiling of `base_smul_def` before PR 28563
```diff
diff --git a/Mathlib/GroupTheory/PushoutI.lean b/Mathlib/GroupTheory/PushoutI.lean
index 6b1bea567c..d1955509a7 100644
--- a/Mathlib/GroupTheory/PushoutI.lean
+++ b/Mathlib/GroupTheory/PushoutI.lean
@@ -465,6 +465,7 @@ noncomputable instance mulAction : MulAction (PushoutI φ) (NormalWord d) :=
       Word.rcons_eq_smul, equiv_fst_eq_mul_inv, map_mul, map_inv, mul_smul, inv_smul_smul,
       smul_inv_smul, base_smul_def', MonoidHom.apply_ofInjective_symm]
 
+set_option trace.profiler true in
 theorem base_smul_def (h : H) (w : NormalWord d) :
     base φ h • w = { w with head := h * w.head } := by
   dsimp [NormalWord.mulAction, instHSMul, SMul.smul]
```
```
ℹ [990/990] Built Mathlib.GroupTheory.PushoutI (5.7s)
info: Mathlib/GroupTheory/PushoutI.lean:469:0: [Elab.command] [0.071533] theorem base_smul_def (h : H) (w : NormalWord d) :
        base φ h • w = { w with head := h * w.head } :=
      by
      dsimp [NormalWord.mulAction, instHSMul, SMul.smul]
      rw [lift_base]
      rfl
  [Elab.definition.header] [0.064651] Monoid.PushoutI.NormalWord.base_smul_def
    [Elab.step] [0.063919] expected type: Sort ?u.122533, term
        base φ h • w = { w with head := h * w.head }
      [Elab.step] [0.063909] expected type: Sort ?u.122533, term
          binrel% Eq✝ (base φ h • w) { w with head := h * w.head }
        [Elab.step] [0.024792] expected type: <not-available>, term
            base φ h
          [Elab.step] [0.010165] expected type: (i : ι) → H →* G i, term
              φ
            [Meta.isDefEq] [0.010136] ✅️ (i : ?m.17) → ?m.19 →* ?m.18 i =?= (i : ι) → H →* G i
              [Meta.isDefEq] [0.010124] ✅️ ?m.19 →* ?m.18 i =?= H →* G i
                [Meta.isDefEq] [0.010020] ✅️ toMulOneClass =?= (inst✝³ i).toMulOneClass
                  [Meta.isDefEq.delta] [0.010003] ✅️ toMulOneClass =?= (inst✝³ i).toMulOneClass
        [Meta.synthInstance] [0.018399] ✅️ HSMul (PushoutI φ) (NormalWord d) (NormalWord d)
        [Elab.step] [0.019544] expected type: NormalWord d, term
            { w with head := h * w.head }
          [Elab.step] [0.017406] expected type: H, term
              h * w.head
            [Elab.step] [0.017385] expected type: H, term
                binop% HMul.hMul✝ h w.head
info: Mathlib/GroupTheory/PushoutI.lean:469:0: [Elab.async] [0.015077] elaborating proof of Monoid.PushoutI.NormalWord.base_smul_def
  [Elab.definition.value] [0.014242] Monoid.PushoutI.NormalWord.base_smul_def
    [Elab.step] [0.013438] 
          dsimp [NormalWord.mulAction, instHSMul, SMul.smul]
          rw [lift_base]
          rfl
      [Elab.step] [0.013421] 
            dsimp [NormalWord.mulAction, instHSMul, SMul.smul]
            rw [lift_base]
            rfl
Build completed successfully (990 jobs).
```

### Trace profiling of `base_smul_def` after PR 28563
```diff
diff --git a/Mathlib/GroupTheory/PushoutI.lean b/Mathlib/GroupTheory/PushoutI.lean
index 6b1bea567c..e161150bab 100644
--- a/Mathlib/GroupTheory/PushoutI.lean
+++ b/Mathlib/GroupTheory/PushoutI.lean
@@ -465,19 +465,16 @@ noncomputable instance mulAction : MulAction (PushoutI φ) (NormalWord d) :=
       Word.rcons_eq_smul, equiv_fst_eq_mul_inv, map_mul, map_inv, mul_smul, inv_smul_smul,
       smul_inv_smul, base_smul_def', MonoidHom.apply_ofInjective_symm]
 
+set_option trace.profiler true in
 theorem base_smul_def (h : H) (w : NormalWord d) :
     base φ h • w = { w with head := h * w.head } := by
-  dsimp [NormalWord.mulAction, instHSMul, SMul.smul]
-  rw [lift_base]
-  rfl
+  tauto
 
 theorem summand_smul_def {i : ι} (g : G i) (w : NormalWord d) :
     of (φ := φ) i g • w = (equivPair i).symm
       { equivPair i w with
         head := g * (equivPair i w).head } := by
-  dsimp [NormalWord.mulAction, instHSMul, SMul.smul]
-  rw [lift_of]
-  rfl
+  tauto
 
 theorem of_smul_eq_smul {i : ι} (g : G i) (w : NormalWord d) :
     of (φ := φ) i g • w = g • w := by
```
```
ℹ [990/990] Built Mathlib.GroupTheory.PushoutI (3.7s)
info: Mathlib/GroupTheory/PushoutI.lean:469:0: [Elab.command] [0.030019] theorem base_smul_def (h : H) (w : NormalWord d) :
        base φ h • w = { w with head := h * w.head } := by tauto
  [Elab.definition.header] [0.024390] Monoid.PushoutI.NormalWord.base_smul_def
    [Elab.step] [0.023783] expected type: Sort ?u.122533, term
        base φ h • w = { w with head := h * w.head }
      [Elab.step] [0.023775] expected type: Sort ?u.122533, term
          binrel% Eq✝ (base φ h • w) { w with head := h * w.head }
        [Meta.synthInstance] [0.010490] ✅️ HSMul (PushoutI φ) (NormalWord d) (NormalWord d)
Build completed successfully (990 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
