### PR TITLE
[Merged by Bors] - chore(LinearAlgebra): golf entire `congr_symm`, `LinearMap.toMatrix_smulBasis_left`, `LinearMap.toMatrix_smulBasis_right` and more using `rfl`

### DIFF
--- a/Mathlib/LinearAlgebra/BilinearForm/Hom.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Hom.lean
@@ -206,7 +206,7 @@ theorem congr_apply (e : M ≃ₗ[R] M') (B : BilinForm R M) (x y : M') :
 
 @[simp]
 theorem congr_symm (e : M ≃ₗ[R] M') : (congr e).symm = congr e.symm := by
-  tauto
+  rfl
 
 @[simp]
 theorem congr_refl : congr (LinearEquiv.refl R M) = LinearEquiv.refl R _ :=

--- a/Mathlib/LinearAlgebra/BilinearForm/Hom.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Hom.lean
@@ -206,9 +206,7 @@ theorem congr_apply (e : M ≃ₗ[R] M') (B : BilinForm R M) (x y : M') :
 
 @[simp]
 theorem congr_symm (e : M ≃ₗ[R] M') : (congr e).symm = congr e.symm := by
-  ext
-  simp only [congr_apply, LinearEquiv.symm_symm]
-  rfl
+  tauto
 
 @[simp]
 theorem congr_refl : congr (LinearEquiv.refl R M) = LinearEquiv.refl R _ :=

--- a/Mathlib/LinearAlgebra/Matrix/ToLin.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLin.lean
@@ -674,13 +674,13 @@ theorem LinearMap.toMatrix_smulBasis_left {G} [Group G] [DistribMulAction G M₁
     [SMulCommClass G R M₁] (g : G) (f : M₁ →ₗ[R] M₂) :
     LinearMap.toMatrix (g • v₁) v₂ f =
       LinearMap.toMatrix v₁ v₂ (f ∘ₗ DistribMulAction.toLinearMap _ _ g) := by
-  tauto
+  rfl
 
 theorem LinearMap.toMatrix_smulBasis_right {G} [Group G] [DistribMulAction G M₂]
     [SMulCommClass G R M₂] (g : G) (f : M₁ →ₗ[R] M₂) :
     LinearMap.toMatrix v₁ (g • v₂) f =
       LinearMap.toMatrix v₁ v₂ (DistribMulAction.toLinearMap _ _ g⁻¹ ∘ₗ f) := by
-  tauto
+  rfl
 
 end Finite
 

--- a/Mathlib/LinearAlgebra/Matrix/ToLin.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLin.lean
@@ -674,17 +674,13 @@ theorem LinearMap.toMatrix_smulBasis_left {G} [Group G] [DistribMulAction G M₁
     [SMulCommClass G R M₁] (g : G) (f : M₁ →ₗ[R] M₂) :
     LinearMap.toMatrix (g • v₁) v₂ f =
       LinearMap.toMatrix v₁ v₂ (f ∘ₗ DistribMulAction.toLinearMap _ _ g) := by
-  ext
-  rw [LinearMap.toMatrix_apply, LinearMap.toMatrix_apply]
-  dsimp
+  tauto
 
 theorem LinearMap.toMatrix_smulBasis_right {G} [Group G] [DistribMulAction G M₂]
     [SMulCommClass G R M₂] (g : G) (f : M₁ →ₗ[R] M₂) :
     LinearMap.toMatrix v₁ (g • v₂) f =
       LinearMap.toMatrix v₁ v₂ (DistribMulAction.toLinearMap _ _ g⁻¹ ∘ₗ f) := by
-  ext
-  rw [LinearMap.toMatrix_apply, LinearMap.toMatrix_apply]
-  dsimp
+  tauto
 
 end Finite
 

--- a/Mathlib/LinearAlgebra/Multilinear/Curry.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Curry.lean
@@ -84,7 +84,7 @@ theorem MultilinearMap.curryLeft_apply (f : MultilinearMap R M M₂) (x : M 0)
 @[simp]
 theorem LinearMap.curry_uncurryLeft (f : M 0 →ₗ[R] MultilinearMap R (fun i :
     Fin n => M i.succ) M₂) : f.uncurryLeft.curryLeft = f := by
-  tauto
+  rfl
 
 @[simp]
 theorem MultilinearMap.uncurry_curryLeft (f : MultilinearMap R M M₂) :

--- a/Mathlib/LinearAlgebra/TensorProduct/Graded/External.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Graded/External.lean
@@ -104,7 +104,7 @@ def gradedComm :
 /-- The braiding is symmetric. -/
 @[simp]
 theorem gradedComm_symm : (gradedComm R 𝒜 ℬ).symm = gradedComm R ℬ 𝒜 := by
-  tauto
+  rfl
 
 theorem gradedComm_of_tmul_of (i j : ι) (a : 𝒜 i) (b : ℬ j) :
     gradedComm R 𝒜 ℬ (lof R _ 𝒜 i a ⊗ₜ lof R _ ℬ j b) =

--- a/Mathlib/LinearAlgebra/TensorProduct/Graded/External.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Graded/External.lean
@@ -104,9 +104,7 @@ def gradedComm :
 /-- The braiding is symmetric. -/
 @[simp]
 theorem gradedComm_symm : (gradedComm R 𝒜 ℬ).symm = gradedComm R ℬ 𝒜 := by
-  rw [gradedComm, gradedComm, LinearEquiv.trans_symm, LinearEquiv.symm_symm]
-  ext
-  rfl
+  tauto
 
 theorem gradedComm_of_tmul_of (i j : ι) (a : 𝒜 i) (b : ℬ j) :
     gradedComm R 𝒜 ℬ (lof R _ 𝒜 i a ⊗ₜ lof R _ ℬ j b) =


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>congr_symm</code>: 24 ms before, 28 ms after </summary>

### Trace profiling of `congr_symm` before PR 28564
```diff
diff --git a/Mathlib/LinearAlgebra/BilinearForm/Hom.lean b/Mathlib/LinearAlgebra/BilinearForm/Hom.lean
index c056a51a5b..90cb2cd345 100644
--- a/Mathlib/LinearAlgebra/BilinearForm/Hom.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Hom.lean
@@ -204,6 +204,7 @@ theorem congr_apply (e : M ≃ₗ[R] M') (B : BilinForm R M) (x y : M') :
     congr e B x y = B (e.symm x) (e.symm y) :=
   rfl
 
+set_option trace.profiler true in
 @[simp]
 theorem congr_symm (e : M ≃ₗ[R] M') : (congr e).symm = congr e.symm := by
   ext
```
```
ℹ [1062/1062] Built Mathlib.LinearAlgebra.BilinearForm.Hom (3.4s)
info: Mathlib/LinearAlgebra/BilinearForm/Hom.lean:208:0: [Elab.command] [0.026792] @[simp]
    theorem congr_symm (e : M ≃ₗ[R] M') : (congr e).symm = congr e.symm :=
      by
      ext
      simp only [congr_apply, LinearEquiv.symm_symm]
      rfl
info: Mathlib/LinearAlgebra/BilinearForm/Hom.lean:208:0: [Elab.async] [0.024764] elaborating proof of LinearMap.BilinForm.congr_symm
  [Elab.definition.value] [0.023696] LinearMap.BilinForm.congr_symm
    [Elab.step] [0.022888] 
          ext
          simp only [congr_apply, LinearEquiv.symm_symm]
          rfl
      [Elab.step] [0.022873] 
            ext
            simp only [congr_apply, LinearEquiv.symm_symm]
            rfl
info: Mathlib/LinearAlgebra/BilinearForm/Hom.lean:209:8: [Elab.async] [0.011246] Lean.addDecl
  [Kernel] [0.011207] ✅️ typechecking declarations [LinearMap.BilinForm.congr_symm]
Build completed successfully (1062 jobs).
```

### Trace profiling of `congr_symm` after PR 28564
```diff
diff --git a/Mathlib/LinearAlgebra/BilinearForm/Hom.lean b/Mathlib/LinearAlgebra/BilinearForm/Hom.lean
index c056a51a5b..ce976f69d7 100644
--- a/Mathlib/LinearAlgebra/BilinearForm/Hom.lean
+++ b/Mathlib/LinearAlgebra/BilinearForm/Hom.lean
@@ -204,11 +204,10 @@ theorem congr_apply (e : M ≃ₗ[R] M') (B : BilinForm R M) (x y : M') :
     congr e B x y = B (e.symm x) (e.symm y) :=
   rfl
 
+set_option trace.profiler true in
 @[simp]
 theorem congr_symm (e : M ≃ₗ[R] M') : (congr e).symm = congr e.symm := by
-  ext
-  simp only [congr_apply, LinearEquiv.symm_symm]
-  rfl
+  tauto
 
 @[simp]
 theorem congr_refl : congr (LinearEquiv.refl R M) = LinearEquiv.refl R _ :=
diff --git a/Mathlib/LinearAlgebra/Matrix/ToLin.lean b/Mathlib/LinearAlgebra/Matrix/ToLin.lean
index e78673e1fa..b05d64e287 100644
--- a/Mathlib/LinearAlgebra/Matrix/ToLin.lean
+++ b/Mathlib/LinearAlgebra/Matrix/ToLin.lean
@@ -681,17 +681,13 @@ theorem LinearMap.toMatrix_smulBasis_left {G} [Group G] [DistribMulAction G M₁
     [SMulCommClass G R M₁] (g : G) (f : M₁ →ₗ[R] M₂) :
     LinearMap.toMatrix (g • v₁) v₂ f =
       LinearMap.toMatrix v₁ v₂ (f ∘ₗ DistribMulAction.toLinearMap _ _ g) := by
-  ext
-  rw [LinearMap.toMatrix_apply, LinearMap.toMatrix_apply]
-  dsimp
+  tauto
 
 theorem LinearMap.toMatrix_smulBasis_right {G} [Group G] [DistribMulAction G M₂]
     [SMulCommClass G R M₂] (g : G) (f : M₁ →ₗ[R] M₂) :
     LinearMap.toMatrix v₁ (g • v₂) f =
       LinearMap.toMatrix v₁ v₂ (DistribMulAction.toLinearMap _ _ g⁻¹ ∘ₗ f) := by
-  ext
-  rw [LinearMap.toMatrix_apply, LinearMap.toMatrix_apply]
-  dsimp
+  tauto
 
 end Finite
 
diff --git a/Mathlib/LinearAlgebra/Multilinear/Curry.lean b/Mathlib/LinearAlgebra/Multilinear/Curry.lean
index dbccfc807a..9175992b1f 100644
--- a/Mathlib/LinearAlgebra/Multilinear/Curry.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Curry.lean
@@ -84,9 +84,7 @@ theorem MultilinearMap.curryLeft_apply (f : MultilinearMap R M M₂) (x : M 0)
 @[simp]
 theorem LinearMap.curry_uncurryLeft (f : M 0 →ₗ[R] MultilinearMap R (fun i :
     Fin n => M i.succ) M₂) : f.uncurryLeft.curryLeft = f := by
-  ext m x
-  simp only [tail_cons, LinearMap.uncurryLeft_apply, MultilinearMap.curryLeft_apply]
-  rw [cons_zero]
+  tauto
 
 @[simp]
 theorem MultilinearMap.uncurry_curryLeft (f : MultilinearMap R M M₂) :
diff --git a/Mathlib/LinearAlgebra/TensorProduct/Graded/External.lean b/Mathlib/LinearAlgebra/TensorProduct/Graded/External.lean
index 140f4599b3..a5fc97375b 100644
--- a/Mathlib/LinearAlgebra/TensorProduct/Graded/External.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Graded/External.lean
@@ -104,9 +104,7 @@ def gradedComm :
 /-- The braiding is symmetric. -/
 @[simp]
 theorem gradedComm_symm : (gradedComm R 𝒜 ℬ).symm = gradedComm R ℬ 𝒜 := by
-  rw [gradedComm, gradedComm, LinearEquiv.trans_symm, LinearEquiv.symm_symm]
-  ext
-  rfl
+  tauto
 
 theorem gradedComm_of_tmul_of (i j : ι) (a : 𝒜 i) (b : ℬ j) :
     gradedComm R 𝒜 ℬ (lof R _ 𝒜 i a ⊗ₜ lof R _ ℬ j b) =
```
```
ℹ [1062/1062] Built Mathlib.LinearAlgebra.BilinearForm.Hom (3.4s)
info: Mathlib/LinearAlgebra/BilinearForm/Hom.lean:208:0: [Elab.command] [0.022737] @[simp]
    theorem congr_symm (e : M ≃ₗ[R] M') : (congr e).symm = congr e.symm := by tauto
info: Mathlib/LinearAlgebra/BilinearForm/Hom.lean:208:0: [Elab.async] [0.030155] elaborating proof of LinearMap.BilinForm.congr_symm
  [Elab.definition.value] [0.028158] LinearMap.BilinForm.congr_symm
    [Elab.step] [0.027405] tauto
      [Elab.step] [0.027386] tauto
        [Elab.step] [0.027369] tauto
          [Elab.step] [0.019442] rfl
            [Elab.step] [0.019158] eq_refl
              [Meta.isDefEq] [0.019142] ✅️ (congr e).symm =?= congr e.symm
                [Meta.isDefEq] [0.019026] ✅️ (congr
                        e).symm =?= (LinearEquiv.congrLeft R R e.symm).congrRight.trans
                      (LinearEquiv.congrLeft (M →ₗ[R] R) R e.symm)
                  [Meta.isDefEq] [0.018960] ✅️ have __src := (↑(congr e)).inverse (congr e).invFun ⋯ ⋯;
                      let __src := (congr e).toEquiv.symm;
                      { toFun := ⇑((↑(congr e)).inverse (congr e).invFun ⋯ ⋯), map_add' := ⋯, map_smul' := ⋯,
                        invFun := (congr e).toEquiv.symm.invFun, left_inv := ⋯,
                        right_inv :=
                          ⋯ } =?= (LinearEquiv.congrLeft R R e.symm).congrRight.trans
                        (LinearEquiv.congrLeft (M →ₗ[R] R) R e.symm)
                    [Meta.isDefEq] [0.018936] ✅️ { toFun := ⇑((↑(congr e)).inverse (congr e).invFun ⋯ ⋯), map_add' := ⋯,
                          map_smul' := ⋯, invFun := (congr e).toEquiv.symm.invFun, left_inv := ⋯,
                          right_inv :=
                            ⋯ } =?= (LinearEquiv.congrLeft R R e.symm).congrRight.trans
                          (LinearEquiv.congrLeft (M →ₗ[R] R) R e.symm)
                      [Meta.isDefEq] [0.018834] ✅️ { toFun := ⇑((↑(congr e)).inverse (congr e).invFun ⋯ ⋯),
                            map_add' := ⋯, map_smul' := ⋯, invFun := (congr e).toEquiv.symm.invFun, left_inv := ⋯,
                            right_inv :=
                              ⋯ } =?= let __src :=
                            ↑(LinearEquiv.congrLeft (M →ₗ[R] R) R e.symm) ∘ₗ
                              ↑(LinearEquiv.congrLeft R R e.symm).congrRight;
                          let __src_1 :=
                            (LinearEquiv.congrLeft R R e.symm).congrRight.toEquiv.trans
                              (LinearEquiv.congrLeft (M →ₗ[R] R) R e.symm).toEquiv;
                          { toLinearMap := __src, invFun := __src_1.invFun, left_inv := ⋯, right_inv := ⋯ }
                        [Meta.isDefEq] [0.018825] ✅️ { toFun := ⇑((↑(congr e)).inverse (congr e).invFun ⋯ ⋯),
                              map_add' := ⋯, map_smul' := ⋯, invFun := (congr e).toEquiv.symm.invFun, left_inv := ⋯,
                              right_inv :=
                                ⋯ } =?= {
                              toLinearMap :=
                                ↑(LinearEquiv.congrLeft (M →ₗ[R] R) R e.symm) ∘ₗ
                                  ↑(LinearEquiv.congrLeft R R e.symm).congrRight,
                              invFun :=
                                ((LinearEquiv.congrLeft R R e.symm).congrRight.toEquiv.trans
                                    (LinearEquiv.congrLeft (M →ₗ[R] R) R e.symm).toEquiv).invFun,
                              left_inv := ⋯, right_inv := ⋯ }
                          [Meta.isDefEq] [0.011340] ✅️ { toFun := ⇑((↑(congr e)).inverse (congr e).invFun ⋯ ⋯),
                                map_add' := ⋯,
                                map_smul' :=
                                  ⋯ } =?= ↑(LinearEquiv.congrLeft (M →ₗ[R] R) R e.symm) ∘ₗ
                                ↑(LinearEquiv.congrLeft R R e.symm).congrRight
                            [Meta.isDefEq] [0.011274] ✅️ { toFun := ⇑((↑(congr e)).inverse (congr e).invFun ⋯ ⋯),
                                  map_add' := ⋯,
                                  map_smul' :=
                                    ⋯ } =?= {
                                  toFun :=
                                    ⇑↑(LinearEquiv.congrLeft (M →ₗ[R] R) R e.symm) ∘
                                      ⇑↑(LinearEquiv.congrLeft R R e.symm).congrRight,
                                  map_add' := ⋯, map_smul' := ⋯ }
                              [Meta.isDefEq] [0.010754] ✅️ { toFun := ⇑((↑(congr e)).inverse (congr e).invFun ⋯ ⋯),
                                    map_add' :=
                                      ⋯ } =?= {
                                    toFun :=
                                      ⇑↑(LinearEquiv.congrLeft (M →ₗ[R] R) R e.symm) ∘
                                        ⇑↑(LinearEquiv.congrLeft R R e.symm).congrRight,
                                    map_add' := ⋯ }
info: Mathlib/LinearAlgebra/BilinearForm/Hom.lean:209:8: [Elab.async] [0.100749] Lean.addDecl
  [Kernel] [0.100672] ✅️ typechecking declarations [LinearMap.BilinForm.congr_symm]
Build completed successfully (1062 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
