### PR TITLE
[Merged by Bors] - chore(MeasureTheory/Constructions): golf entire `inter_cylinder{,_same}` and `union_cylinder{,_same}` using `rfl`

### DIFF
--- a/Mathlib/MeasureTheory/Constructions/Cylinders.lean
+++ b/Mathlib/MeasureTheory/Constructions/Cylinders.lean
@@ -189,11 +189,11 @@ theorem inter_cylinder (s₁ s₂ : Finset ι) (S₁ : Set (∀ i : s₁, α i))
       cylinder (s₁ ∪ s₂)
         (Finset.restrict₂ Finset.subset_union_left ⁻¹' S₁ ∩
           Finset.restrict₂ Finset.subset_union_right ⁻¹' S₂) := by
-  tauto
+  rfl
 
 theorem inter_cylinder_same (s : Finset ι) (S₁ : Set (∀ i : s, α i)) (S₂ : Set (∀ i : s, α i)) :
     cylinder s S₁ ∩ cylinder s S₂ = cylinder s (S₁ ∩ S₂) := by
-  tauto
+  rfl
 
 theorem union_cylinder (s₁ s₂ : Finset ι) (S₁ : Set (∀ i : s₁, α i)) (S₂ : Set (∀ i : s₂, α i))
     [DecidableEq ι] :
@@ -201,11 +201,11 @@ theorem union_cylinder (s₁ s₂ : Finset ι) (S₁ : Set (∀ i : s₁, α i))
       cylinder (s₁ ∪ s₂)
         (Finset.restrict₂ Finset.subset_union_left ⁻¹' S₁ ∪
           Finset.restrict₂ Finset.subset_union_right ⁻¹' S₂) := by
-  tauto
+  rfl
 
 theorem union_cylinder_same (s : Finset ι) (S₁ : Set (∀ i : s, α i)) (S₂ : Set (∀ i : s, α i)) :
     cylinder s S₁ ∪ cylinder s S₂ = cylinder s (S₁ ∪ S₂) := by
-  tauto
+  rfl
 
 theorem compl_cylinder (s : Finset ι) (S : Set (∀ i : s, α i)) :
     (cylinder s S)ᶜ = cylinder s (Sᶜ) := by

--- a/Mathlib/MeasureTheory/Constructions/Cylinders.lean
+++ b/Mathlib/MeasureTheory/Constructions/Cylinders.lean
@@ -188,24 +188,20 @@ theorem inter_cylinder (s₁ s₂ : Finset ι) (S₁ : Set (∀ i : s₁, α i))
     cylinder s₁ S₁ ∩ cylinder s₂ S₂ =
       cylinder (s₁ ∪ s₂)
         (Finset.restrict₂ Finset.subset_union_left ⁻¹' S₁ ∩
-          Finset.restrict₂ Finset.subset_union_right ⁻¹' S₂) := by
-  rfl
+          Finset.restrict₂ Finset.subset_union_right ⁻¹' S₂) := rfl
 
 theorem inter_cylinder_same (s : Finset ι) (S₁ : Set (∀ i : s, α i)) (S₂ : Set (∀ i : s, α i)) :
-    cylinder s S₁ ∩ cylinder s S₂ = cylinder s (S₁ ∩ S₂) := by
-  rfl
+    cylinder s S₁ ∩ cylinder s S₂ = cylinder s (S₁ ∩ S₂) := rfl
 
 theorem union_cylinder (s₁ s₂ : Finset ι) (S₁ : Set (∀ i : s₁, α i)) (S₂ : Set (∀ i : s₂, α i))
     [DecidableEq ι] :
     cylinder s₁ S₁ ∪ cylinder s₂ S₂ =
       cylinder (s₁ ∪ s₂)
         (Finset.restrict₂ Finset.subset_union_left ⁻¹' S₁ ∪
-          Finset.restrict₂ Finset.subset_union_right ⁻¹' S₂) := by
-  rfl
+          Finset.restrict₂ Finset.subset_union_right ⁻¹' S₂) := rfl
 
 theorem union_cylinder_same (s : Finset ι) (S₁ : Set (∀ i : s, α i)) (S₂ : Set (∀ i : s, α i)) :
-    cylinder s S₁ ∪ cylinder s S₂ = cylinder s (S₁ ∪ S₂) := by
-  rfl
+    cylinder s S₁ ∪ cylinder s S₂ = cylinder s (S₁ ∪ S₂) := rfl
 
 theorem compl_cylinder (s : Finset ι) (S : Set (∀ i : s, α i)) :
     (cylinder s S)ᶜ = cylinder s (Sᶜ) := by

--- a/Mathlib/MeasureTheory/Constructions/Cylinders.lean
+++ b/Mathlib/MeasureTheory/Constructions/Cylinders.lean
@@ -189,11 +189,11 @@ theorem inter_cylinder (s₁ s₂ : Finset ι) (S₁ : Set (∀ i : s₁, α i))
       cylinder (s₁ ∪ s₂)
         (Finset.restrict₂ Finset.subset_union_left ⁻¹' S₁ ∩
           Finset.restrict₂ Finset.subset_union_right ⁻¹' S₂) := by
-  ext1 f; simp only [mem_inter_iff, mem_cylinder]; rfl
+  tauto
 
 theorem inter_cylinder_same (s : Finset ι) (S₁ : Set (∀ i : s, α i)) (S₂ : Set (∀ i : s, α i)) :
     cylinder s S₁ ∩ cylinder s S₂ = cylinder s (S₁ ∩ S₂) := by
-  classical rw [inter_cylinder]; rfl
+  tauto
 
 theorem union_cylinder (s₁ s₂ : Finset ι) (S₁ : Set (∀ i : s₁, α i)) (S₂ : Set (∀ i : s₂, α i))
     [DecidableEq ι] :
@@ -201,11 +201,11 @@ theorem union_cylinder (s₁ s₂ : Finset ι) (S₁ : Set (∀ i : s₁, α i))
       cylinder (s₁ ∪ s₂)
         (Finset.restrict₂ Finset.subset_union_left ⁻¹' S₁ ∪
           Finset.restrict₂ Finset.subset_union_right ⁻¹' S₂) := by
-  ext1 f; simp only [mem_union, mem_cylinder]; rfl
+  tauto
 
 theorem union_cylinder_same (s : Finset ι) (S₁ : Set (∀ i : s, α i)) (S₂ : Set (∀ i : s, α i)) :
     cylinder s S₁ ∪ cylinder s S₂ = cylinder s (S₁ ∪ S₂) := by
-  classical rw [union_cylinder]; rfl
+  tauto
 
 theorem compl_cylinder (s : Finset ι) (S : Set (∀ i : s, α i)) :
     (cylinder s S)ᶜ = cylinder s (Sᶜ) := by


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>inter_cylinder</code>: <10 ms before, <10 ms after  🎉</summary>

### Trace profiling of `inter_cylinder` before PR 28566
```diff
diff --git a/Mathlib/MeasureTheory/Constructions/Cylinders.lean b/Mathlib/MeasureTheory/Constructions/Cylinders.lean
index 0c1e925a61..cc8cbb5b97 100644
--- a/Mathlib/MeasureTheory/Constructions/Cylinders.lean
+++ b/Mathlib/MeasureTheory/Constructions/Cylinders.lean
@@ -183,6 +183,7 @@ theorem cylinder_eq_empty_iff [h_nonempty : Nonempty (∀ i, α i)] (s : Finset
   rw [h] at hf'
   exact notMem_empty _ hf'
 
+set_option trace.profiler true in
 theorem inter_cylinder (s₁ s₂ : Finset ι) (S₁ : Set (∀ i : s₁, α i)) (S₂ : Set (∀ i : s₂, α i))
     [DecidableEq ι] :
     cylinder s₁ S₁ ∩ cylinder s₂ S₂ =
```
```
ℹ [883/883] Built Mathlib.MeasureTheory.Constructions.Cylinders (2.0s)
info: Mathlib/MeasureTheory/Constructions/Cylinders.lean:187:0: [Elab.command] [0.022626] theorem inter_cylinder (s₁ s₂ : Finset ι) (S₁ : Set (∀ i : s₁, α i))
        (S₂ : Set (∀ i : s₂, α i)) [DecidableEq ι] :
        cylinder s₁ S₁ ∩ cylinder s₂ S₂ =
          cylinder (s₁ ∪ s₂)
            (Finset.restrict₂ Finset.subset_union_left ⁻¹' S₁ ∩ Finset.restrict₂ Finset.subset_union_right ⁻¹' S₂) :=
      by ext1 f; simp only [mem_inter_iff, mem_cylinder]; rfl
  [Elab.definition.header] [0.022211] MeasureTheory.inter_cylinder
    [Elab.step] [0.015116] expected type: Type (max ?u.2391 ?u.2396), term
        Set (∀ i : s₁, α i)
      [Elab.step] [0.015047] expected type: Type ?u.2405, term
          (∀ i : s₁, α i)
        [Elab.step] [0.015037] expected type: Type ?u.2405, term
            ∀ i : s₁, α i
          [Elab.step] [0.015028] expected type: Type ?u.2405, term
              forall (i : s₁), α i
            [Elab.step] [0.014325] expected type: Type ?u.2396, term
                α i
              [Elab.coe] [0.014154] adding coercion for i : { x // x ∈ s₁ } =?= ι
                [Meta.synthInstance] [0.014040] ✅️ CoeT { x // x ∈ s₁ } i ι
                  [Meta.synthInstance] [0.011160] ✅️ apply @instCoeTCOfCoe_1 to CoeTC { x // x ∈ s₁ } ι
                    [Meta.synthInstance.tryResolve] [0.011110] ✅️ CoeTC { x // x ∈ s₁ } ι ≟ CoeTC { x // x ∈ s₁ } ι
                      [Meta.isDefEq] [0.011028] ✅️ CoeTC { x // x ∈ s₁ } ι =?= CoeTC ?m.16 ?m.17
Build completed successfully (883 jobs).
```

### Trace profiling of `inter_cylinder` after PR 28566
```diff
diff --git a/Mathlib/MeasureTheory/Constructions/Cylinders.lean b/Mathlib/MeasureTheory/Constructions/Cylinders.lean
index 0c1e925a61..f97b20a91e 100644
--- a/Mathlib/MeasureTheory/Constructions/Cylinders.lean
+++ b/Mathlib/MeasureTheory/Constructions/Cylinders.lean
@@ -183,17 +183,18 @@ theorem cylinder_eq_empty_iff [h_nonempty : Nonempty (∀ i, α i)] (s : Finset
   rw [h] at hf'
   exact notMem_empty _ hf'
 
+set_option trace.profiler true in
 theorem inter_cylinder (s₁ s₂ : Finset ι) (S₁ : Set (∀ i : s₁, α i)) (S₂ : Set (∀ i : s₂, α i))
     [DecidableEq ι] :
     cylinder s₁ S₁ ∩ cylinder s₂ S₂ =
       cylinder (s₁ ∪ s₂)
         (Finset.restrict₂ Finset.subset_union_left ⁻¹' S₁ ∩
           Finset.restrict₂ Finset.subset_union_right ⁻¹' S₂) := by
-  ext1 f; simp only [mem_inter_iff, mem_cylinder]; rfl
+  tauto
 
 theorem inter_cylinder_same (s : Finset ι) (S₁ : Set (∀ i : s, α i)) (S₂ : Set (∀ i : s, α i)) :
     cylinder s S₁ ∩ cylinder s S₂ = cylinder s (S₁ ∩ S₂) := by
-  classical rw [inter_cylinder]; rfl
+  tauto
 
 theorem union_cylinder (s₁ s₂ : Finset ι) (S₁ : Set (∀ i : s₁, α i)) (S₂ : Set (∀ i : s₂, α i))
     [DecidableEq ι] :
@@ -201,11 +202,11 @@ theorem union_cylinder (s₁ s₂ : Finset ι) (S₁ : Set (∀ i : s₁, α i))
       cylinder (s₁ ∪ s₂)
         (Finset.restrict₂ Finset.subset_union_left ⁻¹' S₁ ∪
           Finset.restrict₂ Finset.subset_union_right ⁻¹' S₂) := by
-  ext1 f; simp only [mem_union, mem_cylinder]; rfl
+  tauto
 
 theorem union_cylinder_same (s : Finset ι) (S₁ : Set (∀ i : s, α i)) (S₂ : Set (∀ i : s, α i)) :
     cylinder s S₁ ∪ cylinder s S₂ = cylinder s (S₁ ∪ S₂) := by
-  classical rw [union_cylinder]; rfl
+  tauto
 
 theorem compl_cylinder (s : Finset ι) (S : Set (∀ i : s, α i)) :
     (cylinder s S)ᶜ = cylinder s (Sᶜ) := by
```
```
ℹ [883/883] Built Mathlib.MeasureTheory.Constructions.Cylinders (2.2s)
info: Mathlib/MeasureTheory/Constructions/Cylinders.lean:187:0: [Elab.command] [0.013859] theorem inter_cylinder (s₁ s₂ : Finset ι) (S₁ : Set (∀ i : s₁, α i))
        (S₂ : Set (∀ i : s₂, α i)) [DecidableEq ι] :
        cylinder s₁ S₁ ∩ cylinder s₂ S₂ =
          cylinder (s₁ ∪ s₂)
            (Finset.restrict₂ Finset.subset_union_left ⁻¹' S₁ ∩ Finset.restrict₂ Finset.subset_union_right ⁻¹' S₂) :=
      by tauto
  [Elab.definition.header] [0.013440] MeasureTheory.inter_cylinder
Build completed successfully (883 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
