### PR TITLE
[Merged by Bors] - chore(Order): golf entire `IsBoundedUnder.eventually_le` and `ωSup_zip` using `tauto` and `rfl`

### DIFF
--- a/Mathlib/Order/Filter/IsBounded.lean
+++ b/Mathlib/Order/Filter/IsBounded.lean
@@ -91,9 +91,7 @@ variable [Preorder α] {f : Filter β} {u : β → α} {s : Set β}
 
 lemma IsBoundedUnder.eventually_le (h : IsBoundedUnder (· ≤ ·) f u) :
     ∃ a, ∀ᶠ x in f, u x ≤ a := by
-  obtain ⟨a, ha⟩ := h
-  use a
-  exact eventually_map.1 ha
+  tauto
 
 lemma IsBoundedUnder.eventually_ge (h : IsBoundedUnder (· ≥ ·) f u) :
     ∃ a, ∀ᶠ x in f, a ≤ u x :=

--- a/Mathlib/Order/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/OmegaCompletePartialOrder.lean
@@ -422,8 +422,7 @@ instance : OmegaCompletePartialOrder (α × β) where
   le_ωSup c i := ⟨le_ωSup (c.map OrderHom.fst) i, le_ωSup (c.map OrderHom.snd) i⟩
 
 theorem ωSup_zip (c₀ : Chain α) (c₁ : Chain β) : ωSup (c₀.zip c₁) = (ωSup c₀, ωSup c₁) := by
-  apply eq_of_forall_ge_iff; rintro ⟨z₁, z₂⟩
-  simp [ωSup_le_iff, forall_and]
+  tauto
 
 end Prod
 

--- a/Mathlib/Order/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/OmegaCompletePartialOrder.lean
@@ -422,7 +422,7 @@ instance : OmegaCompletePartialOrder (α × β) where
   le_ωSup c i := ⟨le_ωSup (c.map OrderHom.fst) i, le_ωSup (c.map OrderHom.snd) i⟩
 
 theorem ωSup_zip (c₀ : Chain α) (c₁ : Chain β) : ωSup (c₀.zip c₁) = (ωSup c₀, ωSup c₁) := by
-  tauto
+  rfl
 
 end Prod
 

--- a/Mathlib/Order/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/OmegaCompletePartialOrder.lean
@@ -421,8 +421,7 @@ instance : OmegaCompletePartialOrder (α × β) where
   ωSup_le := fun _ _ h => ⟨ωSup_le _ _ fun i => (h i).1, ωSup_le _ _ fun i => (h i).2⟩
   le_ωSup c i := ⟨le_ωSup (c.map OrderHom.fst) i, le_ωSup (c.map OrderHom.snd) i⟩
 
-theorem ωSup_zip (c₀ : Chain α) (c₁ : Chain β) : ωSup (c₀.zip c₁) = (ωSup c₀, ωSup c₁) := by
-  rfl
+theorem ωSup_zip (c₀ : Chain α) (c₁ : Chain β) : ωSup (c₀.zip c₁) = (ωSup c₀, ωSup c₁) := rfl
 
 end Prod
 


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>IsBoundedUnder.eventually_le</code>: 29 ms before, <10 ms after  🎉</summary>

### Trace profiling of `IsBoundedUnder.eventually_le` before PR 28568
```diff
diff --git a/Mathlib/Order/Filter/IsBounded.lean b/Mathlib/Order/Filter/IsBounded.lean
index 0b39507eeb..2cccc61fed 100644
--- a/Mathlib/Order/Filter/IsBounded.lean
+++ b/Mathlib/Order/Filter/IsBounded.lean
@@ -89,6 +89,7 @@ lemma Tendsto.isBoundedUnder_comp {ι κ X : Type*} {r : X → X → Prop} {f :
 section Preorder
 variable [Preorder α] {f : Filter β} {u : β → α} {s : Set β}
 
+set_option trace.profiler true in
 lemma IsBoundedUnder.eventually_le (h : IsBoundedUnder (· ≤ ·) f u) :
     ∃ a, ∀ᶠ x in f, u x ≤ a := by
   obtain ⟨a, ha⟩ := h
```
```
ℹ [749/749] Built Mathlib.Order.Filter.IsBounded (2.5s)
info: Mathlib/Order/Filter/IsBounded.lean:93:0: [Elab.async] [0.029670] elaborating proof of Filter.IsBoundedUnder.eventually_le
  [Elab.definition.value] [0.029304] Filter.IsBoundedUnder.eventually_le
    [Elab.step] [0.029016] 
          obtain ⟨a, ha⟩ := h
          use a
          exact eventually_map.1 ha
      [Elab.step] [0.029003] 
            obtain ⟨a, ha⟩ := h
            use a
            exact eventually_map.1 ha
        [Elab.step] [0.025774] use a
Build completed successfully (749 jobs).
```

### Trace profiling of `IsBoundedUnder.eventually_le` after PR 28568
```diff
diff --git a/Mathlib/Order/Filter/IsBounded.lean b/Mathlib/Order/Filter/IsBounded.lean
index 0b39507eeb..6c37d8738d 100644
--- a/Mathlib/Order/Filter/IsBounded.lean
+++ b/Mathlib/Order/Filter/IsBounded.lean
@@ -89,11 +89,10 @@ lemma Tendsto.isBoundedUnder_comp {ι κ X : Type*} {r : X → X → Prop} {f :
 section Preorder
 variable [Preorder α] {f : Filter β} {u : β → α} {s : Set β}
 
+set_option trace.profiler true in
 lemma IsBoundedUnder.eventually_le (h : IsBoundedUnder (· ≤ ·) f u) :
     ∃ a, ∀ᶠ x in f, u x ≤ a := by
-  obtain ⟨a, ha⟩ := h
-  use a
-  exact eventually_map.1 ha
+  tauto
 
 lemma IsBoundedUnder.eventually_ge (h : IsBoundedUnder (· ≥ ·) f u) :
     ∃ a, ∀ᶠ x in f, a ≤ u x :=
diff --git a/Mathlib/Order/OmegaCompletePartialOrder.lean b/Mathlib/Order/OmegaCompletePartialOrder.lean
index 219ddb0595..759fda09a7 100644
--- a/Mathlib/Order/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/OmegaCompletePartialOrder.lean
@@ -422,8 +422,7 @@ instance : OmegaCompletePartialOrder (α × β) where
   le_ωSup c i := ⟨le_ωSup (c.map OrderHom.fst) i, le_ωSup (c.map OrderHom.snd) i⟩
 
 theorem ωSup_zip (c₀ : Chain α) (c₁ : Chain β) : ωSup (c₀.zip c₁) = (ωSup c₀, ωSup c₁) := by
-  apply eq_of_forall_ge_iff; rintro ⟨z₁, z₂⟩
-  simp [ωSup_le_iff, forall_and]
+  tauto
 
 end Prod
 
```
```
ℹ [749/749] Built Mathlib.Order.Filter.IsBounded (2.5s)
info: Mathlib/Order/Filter/IsBounded.lean:93:0: [Elab.command] [0.015651] theorem eventually_le (h : IsBoundedUnder (· ≤ ·) f u) : ∃ a, ∀ᶠ x in f, u x ≤ a := by tauto
info: Mathlib/Order/Filter/IsBounded.lean:93:0: [Elab.command] [0.015910] theorem IsBoundedUnder.eventually_le (h : IsBoundedUnder (· ≤ ·) f u) :
        ∃ a, ∀ᶠ x in f, u x ≤ a := by tauto
info: Mathlib/Order/Filter/IsBounded.lean:93:0: [Elab.command] [0.015955] lemma IsBoundedUnder.eventually_le (h : IsBoundedUnder (· ≤ ·) f u) :
        ∃ a, ∀ᶠ x in f, u x ≤ a := by tauto
Build completed successfully (749 jobs).
```
</details>

---
<details>
<summary>Show trace profiling of <code>ωSup_zip</code>: 25 ms before, 13 ms after  🎉</summary>

### Trace profiling of `ωSup_zip` before PR 28568
```diff
diff --git a/Mathlib/Order/OmegaCompletePartialOrder.lean b/Mathlib/Order/OmegaCompletePartialOrder.lean
index 219ddb0595..7d813efc08 100644
--- a/Mathlib/Order/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/OmegaCompletePartialOrder.lean
@@ -421,6 +420,7 @@ instance : OmegaCompletePartialOrder (α × β) where
   ωSup_le := fun _ _ h => ⟨ωSup_le _ _ fun i => (h i).1, ωSup_le _ _ fun i => (h i).2⟩
   le_ωSup c i := ⟨le_ωSup (c.map OrderHom.fst) i, le_ωSup (c.map OrderHom.snd) i⟩
 
+set_option trace.profiler true in
 theorem ωSup_zip (c₀ : Chain α) (c₁ : Chain β) : ωSup (c₀.zip c₁) = (ωSup c₀, ωSup c₁) := by
   apply eq_of_forall_ge_iff; rintro ⟨z₁, z₂⟩
   simp [ωSup_le_iff, forall_and]
```
```
ℹ [552/552] Built Mathlib.Order.OmegaCompletePartialOrder (3.1s)
info: Mathlib/Order/OmegaCompletePartialOrder.lean:424:0: [Elab.async] [0.027082] elaborating proof of Prod.ωSup_zip
  [Elab.definition.value] [0.025244] Prod.ωSup_zip
    [Elab.step] [0.024383] 
          apply eq_of_forall_ge_iff; rintro ⟨z₁, z₂⟩
          simp [ωSup_le_iff, forall_and]
      [Elab.step] [0.024368] 
            apply eq_of_forall_ge_iff; rintro ⟨z₁, z₂⟩
            simp [ωSup_le_iff, forall_and]
        [Elab.step] [0.023210] simp [ωSup_le_iff, forall_and]
Build completed successfully (552 jobs).
```

### Trace profiling of `ωSup_zip` after PR 28568
```diff
diff --git a/Mathlib/Order/Filter/IsBounded.lean b/Mathlib/Order/Filter/IsBounded.lean
index 0b39507eeb..55bad37314 100644
--- a/Mathlib/Order/Filter/IsBounded.lean
+++ b/Mathlib/Order/Filter/IsBounded.lean
@@ -91,9 +91,7 @@ variable [Preorder α] {f : Filter β} {u : β → α} {s : Set β}
 
 lemma IsBoundedUnder.eventually_le (h : IsBoundedUnder (· ≤ ·) f u) :
     ∃ a, ∀ᶠ x in f, u x ≤ a := by
-  obtain ⟨a, ha⟩ := h
-  use a
-  exact eventually_map.1 ha
+  tauto
 
 lemma IsBoundedUnder.eventually_ge (h : IsBoundedUnder (· ≥ ·) f u) :
     ∃ a, ∀ᶠ x in f, a ≤ u x :=
diff --git a/Mathlib/Order/OmegaCompletePartialOrder.lean b/Mathlib/Order/OmegaCompletePartialOrder.lean
index 219ddb0595..e52102f720 100644
--- a/Mathlib/Order/OmegaCompletePartialOrder.lean
+++ b/Mathlib/Order/OmegaCompletePartialOrder.lean
@@ -421,9 +420,9 @@ instance : OmegaCompletePartialOrder (α × β) where
   ωSup_le := fun _ _ h => ⟨ωSup_le _ _ fun i => (h i).1, ωSup_le _ _ fun i => (h i).2⟩
   le_ωSup c i := ⟨le_ωSup (c.map OrderHom.fst) i, le_ωSup (c.map OrderHom.snd) i⟩
 
+set_option trace.profiler true in
 theorem ωSup_zip (c₀ : Chain α) (c₁ : Chain β) : ωSup (c₀.zip c₁) = (ωSup c₀, ωSup c₁) := by
-  apply eq_of_forall_ge_iff; rintro ⟨z₁, z₂⟩
-  simp [ωSup_le_iff, forall_and]
+  tauto
 
 end Prod
 
```
```
ℹ [552/552] Built Mathlib.Order.OmegaCompletePartialOrder (3.1s)
info: Mathlib/Order/OmegaCompletePartialOrder.lean:424:0: [Elab.command] [0.014348] theorem ωSup_zip (c₀ : Chain α) (c₁ : Chain β) : ωSup (c₀.zip c₁) = (ωSup c₀, ωSup c₁) := by
      tauto
  [Elab.definition.header] [0.013159] Prod.ωSup_zip
    [Elab.step] [0.011493] expected type: Sort ?u.22301, term
        ωSup (c₀.zip c₁) = (ωSup c₀, ωSup c₁)
      [Elab.step] [0.011481] expected type: Sort ?u.22301, term
          binrel% Eq✝ (ωSup (c₀.zip c₁)) (ωSup c₀, ωSup c₁)
        [Elab.step] [0.010391] expected type: <not-available>, term
            ωSup (c₀.zip c₁)
info: Mathlib/Order/OmegaCompletePartialOrder.lean:424:0: [Elab.async] [0.013177] elaborating proof of Prod.ωSup_zip
  [Elab.definition.value] [0.012696] Prod.ωSup_zip
    [Elab.step] [0.012302] tauto
      [Elab.step] [0.012286] tauto
        [Elab.step] [0.012266] tauto
Build completed successfully (552 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
