### PR TITLE
[Merged by Bors] - chore(Probability): golf entire `comp_const` and `piFinset_eq_comap_restrict` using `rfl`

### DIFF
--- a/Mathlib/Probability/Kernel/Composition/MeasureComp.lean
+++ b/Mathlib/Probability/Kernel/Composition/MeasureComp.lean
@@ -75,7 +75,7 @@ instance [IsZeroOrProbabilityMeasure μ] [IsZeroOrMarkovKernel κ] :
 @[simp]
 lemma _root_.ProbabilityTheory.Kernel.comp_const (κ : Kernel β γ) (μ : Measure β) :
     κ ∘ₖ Kernel.const α μ = Kernel.const α (κ ∘ₘ μ) := by
-  tauto
+  rfl
 
 lemma map_comp (μ : Measure α) (κ : Kernel α β) {f : β → γ} (hf : Measurable f) :
     (κ ∘ₘ μ).map f = (κ.map f) ∘ₘ μ := by

--- a/Mathlib/Probability/Kernel/Composition/MeasureComp.lean
+++ b/Mathlib/Probability/Kernel/Composition/MeasureComp.lean
@@ -75,9 +75,7 @@ instance [IsZeroOrProbabilityMeasure μ] [IsZeroOrMarkovKernel κ] :
 @[simp]
 lemma _root_.ProbabilityTheory.Kernel.comp_const (κ : Kernel β γ) (μ : Measure β) :
     κ ∘ₖ Kernel.const α μ = Kernel.const α (κ ∘ₘ μ) := by
-  ext x s hs
-  rw [Kernel.comp_apply, bind_apply hs (by fun_prop), Kernel.const_apply, Kernel.const_apply,
-    bind_apply hs (by fun_prop)]
+  tauto
 
 lemma map_comp (μ : Measure α) (κ : Kernel α β) {f : β → γ} (hf : Measurable f) :
     (κ ∘ₘ μ).map f = (κ.map f) ∘ₘ μ := by

--- a/Mathlib/Probability/Kernel/Composition/MeasureComp.lean
+++ b/Mathlib/Probability/Kernel/Composition/MeasureComp.lean
@@ -74,8 +74,7 @@ instance [IsZeroOrProbabilityMeasure μ] [IsZeroOrMarkovKernel κ] :
 
 @[simp]
 lemma _root_.ProbabilityTheory.Kernel.comp_const (κ : Kernel β γ) (μ : Measure β) :
-    κ ∘ₖ Kernel.const α μ = Kernel.const α (κ ∘ₘ μ) := by
-  rfl
+    κ ∘ₖ Kernel.const α μ = Kernel.const α (κ ∘ₘ μ) := rfl
 
 lemma map_comp (μ : Measure α) (κ : Kernel α β) {f : β → γ} (hf : Measurable f) :
     (κ ∘ₘ μ).map f = (κ.map f) ∘ₘ μ := by

--- a/Mathlib/Probability/Process/Filtration.lean
+++ b/Mathlib/Probability/Process/Filtration.lean
@@ -384,7 +384,7 @@ def piFinset : @Filtration (Π i, X i) (Finset ι) _ pi where
 
 lemma piFinset_eq_comap_restrict (s : Finset ι) :
     piFinset (X := X) s = pi.comap s.toSet.restrict := by
-  tauto
+  rfl
 
 end piFinset
 

--- a/Mathlib/Probability/Process/Filtration.lean
+++ b/Mathlib/Probability/Process/Filtration.lean
@@ -383,8 +383,7 @@ def piFinset : @Filtration (Π i, X i) (Finset ι) _ pi where
   le' s := s.measurable_restrict.comap_le
 
 lemma piFinset_eq_comap_restrict (s : Finset ι) :
-    piFinset (X := X) s = pi.comap s.toSet.restrict := by
-  rfl
+    piFinset (X := X) s = pi.comap s.toSet.restrict := rfl
 
 end piFinset
 

--- a/Mathlib/Probability/Process/Filtration.lean
+++ b/Mathlib/Probability/Process/Filtration.lean
@@ -384,12 +384,7 @@ def piFinset : @Filtration (Π i, X i) (Finset ι) _ pi where
 
 lemma piFinset_eq_comap_restrict (s : Finset ι) :
     piFinset (X := X) s = pi.comap s.toSet.restrict := by
-  apply le_antisymm
-  · simp_rw [piFinset, ← Set.piCongrLeft_comp_restrict, ← MeasurableEquiv.coe_piCongrLeft,
-      ← comap_comp]
-    exact MeasurableSpace.comap_mono <| (MeasurableEquiv.measurable _).comap_le
-  · rw [← piCongrLeft_comp_restrict, ← MeasurableEquiv.coe_piCongrLeft, ← comap_comp]
-    exact MeasurableSpace.comap_mono <| (MeasurableEquiv.measurable _).comap_le
+  tauto
 
 end piFinset
 


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>_root_.ProbabilityTheory.Kernel.comp_const</code>: 20 ms before, <10 ms after  🎉</summary>

### Trace profiling of `_root_.ProbabilityTheory.Kernel.comp_const` before PR 28569
```diff
diff --git a/Mathlib/Probability/Kernel/Composition/MeasureComp.lean b/Mathlib/Probability/Kernel/Composition/MeasureComp.lean
index 2cbfe2e461..ced849b4ca 100644
--- a/Mathlib/Probability/Kernel/Composition/MeasureComp.lean
+++ b/Mathlib/Probability/Kernel/Composition/MeasureComp.lean
@@ -72,6 +72,7 @@ instance [IsZeroOrProbabilityMeasure μ] [IsZeroOrMarkovKernel κ] :
     IsZeroOrProbabilityMeasure (κ ∘ₘ μ) := by
   rw [← snd_compProd]; infer_instance
 
+set_option trace.profiler true in
 @[simp]
 lemma _root_.ProbabilityTheory.Kernel.comp_const (κ : Kernel β γ) (μ : Measure β) :
     κ ∘ₖ Kernel.const α μ = Kernel.const α (κ ∘ₘ μ) := by
```
```
ℹ [1740/1740] Built Mathlib.Probability.Kernel.Composition.MeasureComp (1.6s)
info: Mathlib/Probability/Kernel/Composition/MeasureComp.lean:76:0: [Elab.command] [0.010029] @[simp]
    lemma _root_.ProbabilityTheory.Kernel.comp_const (κ : Kernel β γ) (μ : Measure β) :
        κ ∘ₖ Kernel.const α μ = Kernel.const α (κ ∘ₘ μ) :=
      by
      ext x s hs
      rw [Kernel.comp_apply, bind_apply hs (by fun_prop), Kernel.const_apply, Kernel.const_apply,
        bind_apply hs (by fun_prop)]
info: Mathlib/Probability/Kernel/Composition/MeasureComp.lean:76:0: [Elab.async] [0.020986] elaborating proof of ProbabilityTheory.Kernel.comp_const
  [Elab.definition.value] [0.020223] ProbabilityTheory.Kernel.comp_const
    [Elab.step] [0.019492] 
          ext x s hs
          rw [Kernel.comp_apply, bind_apply hs (by fun_prop), Kernel.const_apply, Kernel.const_apply,
            bind_apply hs (by fun_prop)]
      [Elab.step] [0.019479] 
            ext x s hs
            rw [Kernel.comp_apply, bind_apply hs (by fun_prop), Kernel.const_apply, Kernel.const_apply,
              bind_apply hs (by fun_prop)]
        [Elab.step] [0.017845] rw [Kernel.comp_apply, bind_apply hs (by fun_prop), Kernel.const_apply,
              Kernel.const_apply, bind_apply hs (by fun_prop)]
          [Elab.step] [0.017823] (rewrite [Kernel.comp_apply, bind_apply hs (by fun_prop), Kernel.const_apply,
                  Kernel.const_apply, bind_apply hs (by fun_prop)];
                with_annotate_state"]" (try (with_reducible rfl)))
            [Elab.step] [0.017815] rewrite [Kernel.comp_apply, bind_apply hs (by fun_prop), Kernel.const_apply,
                    Kernel.const_apply, bind_apply hs (by fun_prop)];
                  with_annotate_state"]" (try (with_reducible rfl))
              [Elab.step] [0.017809] rewrite [Kernel.comp_apply, bind_apply hs (by fun_prop), Kernel.const_apply,
                      Kernel.const_apply, bind_apply hs (by fun_prop)];
                    with_annotate_state"]" (try (with_reducible rfl))
                [Elab.step] [0.017492] rewrite [Kernel.comp_apply, bind_apply hs (by fun_prop), Kernel.const_apply,
                      Kernel.const_apply, bind_apply hs (by fun_prop)]
Build completed successfully (1740 jobs).
```

### Trace profiling of `_root_.ProbabilityTheory.Kernel.comp_const` after PR 28569
```diff
diff --git a/Mathlib/Probability/Kernel/Composition/MeasureComp.lean b/Mathlib/Probability/Kernel/Composition/MeasureComp.lean
index 2cbfe2e461..38c1edaa80 100644
--- a/Mathlib/Probability/Kernel/Composition/MeasureComp.lean
+++ b/Mathlib/Probability/Kernel/Composition/MeasureComp.lean
@@ -72,12 +72,11 @@ instance [IsZeroOrProbabilityMeasure μ] [IsZeroOrMarkovKernel κ] :
     IsZeroOrProbabilityMeasure (κ ∘ₘ μ) := by
   rw [← snd_compProd]; infer_instance
 
+set_option trace.profiler true in
 @[simp]
 lemma _root_.ProbabilityTheory.Kernel.comp_const (κ : Kernel β γ) (μ : Measure β) :
     κ ∘ₖ Kernel.const α μ = Kernel.const α (κ ∘ₘ μ) := by
-  ext x s hs
-  rw [Kernel.comp_apply, bind_apply hs (by fun_prop), Kernel.const_apply, Kernel.const_apply,
-    bind_apply hs (by fun_prop)]
+  tauto
 
 lemma map_comp (μ : Measure α) (κ : Kernel α β) {f : β → γ} (hf : Measurable f) :
     (κ ∘ₘ μ).map f = (κ.map f) ∘ₘ μ := by
diff --git a/Mathlib/Probability/Process/Filtration.lean b/Mathlib/Probability/Process/Filtration.lean
index 13e2f0025b..78b9c37f5a 100644
--- a/Mathlib/Probability/Process/Filtration.lean
+++ b/Mathlib/Probability/Process/Filtration.lean
@@ -384,12 +384,7 @@ def piFinset : @Filtration (Π i, X i) (Finset ι) _ pi where
 
 lemma piFinset_eq_comap_restrict (s : Finset ι) :
     piFinset (X := X) s = pi.comap s.toSet.restrict := by
-  apply le_antisymm
-  · simp_rw [piFinset, ← Set.piCongrLeft_comp_restrict, ← MeasurableEquiv.coe_piCongrLeft,
-      ← comap_comp]
-    exact MeasurableSpace.comap_mono <| (MeasurableEquiv.measurable _).comap_le
-  · rw [← piCongrLeft_comp_restrict, ← MeasurableEquiv.coe_piCongrLeft, ← comap_comp]
-    exact MeasurableSpace.comap_mono <| (MeasurableEquiv.measurable _).comap_le
+  tauto
 
 end piFinset
 
```
```
✔ [1740/1740] Built Mathlib.Probability.Kernel.Composition.MeasureComp (2.4s)
Build completed successfully (1740 jobs).
```
</details>

---
<details>
<summary>Show trace profiling of <code>piFinset_eq_comap_restrict</code>: 28 ms before, <10 ms after  🎉</summary>

### Trace profiling of `piFinset_eq_comap_restrict` before PR 28569
```diff
diff --git a/Mathlib/Probability/Process/Filtration.lean b/Mathlib/Probability/Process/Filtration.lean
index 13e2f0025b..eb3bc149ba 100644
--- a/Mathlib/Probability/Process/Filtration.lean
+++ b/Mathlib/Probability/Process/Filtration.lean
@@ -382,6 +382,7 @@ def piFinset : @Filtration (Π i, X i) (Finset ι) _ pi where
     exact comap_mono (measurable_restrict₂ hst).comap_le
   le' s := s.measurable_restrict.comap_le
 
+set_option trace.profiler true in
 lemma piFinset_eq_comap_restrict (s : Finset ι) :
     piFinset (X := X) s = pi.comap s.toSet.restrict := by
   apply le_antisymm
```
```
ℹ [2340/2340] Built Mathlib.Probability.Process.Filtration (1.9s)
info: Mathlib/Probability/Process/Filtration.lean:386:0: [Elab.async] [0.029171] elaborating proof of MeasureTheory.Filtration.piFinset_eq_comap_restrict
  [Elab.definition.value] [0.028128] MeasureTheory.Filtration.piFinset_eq_comap_restrict
    [Elab.step] [0.027661] 
          apply le_antisymm
          · simp_rw [piFinset, ← Set.piCongrLeft_comp_restrict, ← MeasurableEquiv.coe_piCongrLeft, ← comap_comp]
            exact MeasurableSpace.comap_mono <| (MeasurableEquiv.measurable _).comap_le
          · rw [← piCongrLeft_comp_restrict, ← MeasurableEquiv.coe_piCongrLeft, ← comap_comp]
            exact MeasurableSpace.comap_mono <| (MeasurableEquiv.measurable _).comap_le
      [Elab.step] [0.027653] 
            apply le_antisymm
            · simp_rw [piFinset, ← Set.piCongrLeft_comp_restrict, ← MeasurableEquiv.coe_piCongrLeft, ← comap_comp]
              exact MeasurableSpace.comap_mono <| (MeasurableEquiv.measurable _).comap_le
            · rw [← piCongrLeft_comp_restrict, ← MeasurableEquiv.coe_piCongrLeft, ← comap_comp]
              exact MeasurableSpace.comap_mono <| (MeasurableEquiv.measurable _).comap_le
        [Elab.step] [0.017833] ·
              simp_rw [piFinset, ← Set.piCongrLeft_comp_restrict, ← MeasurableEquiv.coe_piCongrLeft, ← comap_comp]
              exact MeasurableSpace.comap_mono <| (MeasurableEquiv.measurable _).comap_le
          [Elab.step] [0.017819] 
                simp_rw [piFinset, ← Set.piCongrLeft_comp_restrict, ← MeasurableEquiv.coe_piCongrLeft, ← comap_comp]
                exact MeasurableSpace.comap_mono <| (MeasurableEquiv.measurable _).comap_le
            [Elab.step] [0.017815] 
                  simp_rw [piFinset, ← Set.piCongrLeft_comp_restrict, ← MeasurableEquiv.coe_piCongrLeft, ← comap_comp]
                  exact MeasurableSpace.comap_mono <| (MeasurableEquiv.measurable _).comap_le
              [Elab.step] [0.013352] simp_rw [piFinset, ← Set.piCongrLeft_comp_restrict, ←
                    MeasurableEquiv.coe_piCongrLeft, ← comap_comp]
Build completed successfully (2340 jobs).
```

### Trace profiling of `piFinset_eq_comap_restrict` after PR 28569
```diff
diff --git a/Mathlib/Probability/Kernel/Composition/MeasureComp.lean b/Mathlib/Probability/Kernel/Composition/MeasureComp.lean
index 2cbfe2e461..7f242dd0c5 100644
--- a/Mathlib/Probability/Kernel/Composition/MeasureComp.lean
+++ b/Mathlib/Probability/Kernel/Composition/MeasureComp.lean
@@ -75,9 +75,7 @@ instance [IsZeroOrProbabilityMeasure μ] [IsZeroOrMarkovKernel κ] :
 @[simp]
 lemma _root_.ProbabilityTheory.Kernel.comp_const (κ : Kernel β γ) (μ : Measure β) :
     κ ∘ₖ Kernel.const α μ = Kernel.const α (κ ∘ₘ μ) := by
-  ext x s hs
-  rw [Kernel.comp_apply, bind_apply hs (by fun_prop), Kernel.const_apply, Kernel.const_apply,
-    bind_apply hs (by fun_prop)]
+  tauto
 
 lemma map_comp (μ : Measure α) (κ : Kernel α β) {f : β → γ} (hf : Measurable f) :
     (κ ∘ₘ μ).map f = (κ.map f) ∘ₘ μ := by
diff --git a/Mathlib/Probability/Process/Filtration.lean b/Mathlib/Probability/Process/Filtration.lean
index 13e2f0025b..ce51705c7f 100644
--- a/Mathlib/Probability/Process/Filtration.lean
+++ b/Mathlib/Probability/Process/Filtration.lean
@@ -382,14 +382,10 @@ def piFinset : @Filtration (Π i, X i) (Finset ι) _ pi where
     exact comap_mono (measurable_restrict₂ hst).comap_le
   le' s := s.measurable_restrict.comap_le
 
+set_option trace.profiler true in
 lemma piFinset_eq_comap_restrict (s : Finset ι) :
     piFinset (X := X) s = pi.comap s.toSet.restrict := by
-  apply le_antisymm
-  · simp_rw [piFinset, ← Set.piCongrLeft_comp_restrict, ← MeasurableEquiv.coe_piCongrLeft,
-      ← comap_comp]
-    exact MeasurableSpace.comap_mono <| (MeasurableEquiv.measurable _).comap_le
-  · rw [← piCongrLeft_comp_restrict, ← MeasurableEquiv.coe_piCongrLeft, ← comap_comp]
-    exact MeasurableSpace.comap_mono <| (MeasurableEquiv.measurable _).comap_le
+  tauto
 
 end piFinset
 
```
```
✔ [2340/2340] Built Mathlib.Probability.Process.Filtration (1.7s)
Build completed successfully (2340 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
