### PR TITLE
[Merged by Bors] - chore(RingTheory): golf entire `coeff_opRingEquiv` and `comp_assoc` using `rfl`

### DIFF
--- a/Mathlib/RingTheory/FractionalIdeal/Extended.lean
+++ b/Mathlib/RingTheory/FractionalIdeal/Extended.lean
@@ -60,7 +60,7 @@ def extended (I : FractionalIdeal M K) : FractionalIdeal N L where
 
 local notation "map_f" => (IsLocalization.map (S := K) L f hf)
 
-lemma mem_extended_iff (x : L) : (x ∈ I.extended L hf) ↔ x ∈ span B (map_f '' I) := by
+lemma mem_extended_iff (x : L) : x ∈ I.extended L hf ↔ x ∈ span B (map_f '' I) := by
   constructor <;> { intro hx; simpa }
 
 @[simp]

--- a/Mathlib/RingTheory/Polynomial/Opposites.lean
+++ b/Mathlib/RingTheory/Polynomial/Opposites.lean
@@ -76,10 +76,7 @@ theorem opRingEquiv_symm_C_mul_X_pow (r : Rᵐᵒᵖ) (n : ℕ) :
 
 @[simp]
 theorem coeff_opRingEquiv (p : R[X]ᵐᵒᵖ) (n : ℕ) :
-    (opRingEquiv R p).coeff n = op ((unop p).coeff n) := by
-  induction p with | _ p
-  cases p
-  rfl
+    (opRingEquiv R p).coeff n = op ((unop p).coeff n) := rfl
 
 @[simp]
 theorem support_opRingEquiv (p : R[X]ᵐᵒᵖ) : (opRingEquiv R p).support = (unop p).support := by

--- a/Mathlib/RingTheory/PolynomialLaw/Basic.lean
+++ b/Mathlib/RingTheory/PolynomialLaw/Basic.lean
@@ -252,8 +252,7 @@ def comp (g : N →ₚₗ[R] P) (f : M →ₚₗ[R] N) : M →ₚₗ[R] P where
 theorem comp_toFun' (S : Type u) [CommSemiring S] [Algebra R S] :
     (g.comp f).toFun' S = (g.toFun' S).comp (f.toFun' S) := rfl
 
-theorem comp_assoc : h.comp (g.comp f) = (h.comp g).comp f := by
-  ext; simp only [comp_toFun']; rfl
+theorem comp_assoc : h.comp (g.comp f) = (h.comp g).comp f := rfl
 
 theorem comp_id : g.comp id = g := by ext; rfl
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
