### PR TITLE
[Merged by Bors] - chore(SetTheory): golf entire `congToClass_empty` using `rfl`

### DIFF
--- a/Mathlib/SetTheory/ZFC/Class.lean
+++ b/Mathlib/SetTheory/ZFC/Class.lean
@@ -131,7 +131,7 @@ def congToClass (x : Set Class.{u}) : Class.{u} :=
 
 @[simp]
 theorem congToClass_empty : congToClass ∅ = ∅ := by
-  tauto
+  rfl
 
 /-- Convert a class into a conglomerate (a collection of classes) -/
 def classToCong (x : Class.{u}) : Set Class.{u} :=

--- a/Mathlib/SetTheory/ZFC/Class.lean
+++ b/Mathlib/SetTheory/ZFC/Class.lean
@@ -131,9 +131,7 @@ def congToClass (x : Set Class.{u}) : Class.{u} :=
 
 @[simp]
 theorem congToClass_empty : congToClass ∅ = ∅ := by
-  ext z
-  simp only [congToClass, not_empty_hom, iff_false]
-  exact Set.notMem_empty z
+  tauto
 
 /-- Convert a class into a conglomerate (a collection of classes) -/
 def classToCong (x : Class.{u}) : Set Class.{u} :=


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>congToClass_empty</code>: <10 ms before, <10 ms after  🎉</summary>

### Trace profiling of `congToClass_empty` before PR 28572
```diff
diff --git a/Mathlib/SetTheory/ZFC/Class.lean b/Mathlib/SetTheory/ZFC/Class.lean
index 43d3015eb2..2596971ce0 100644
--- a/Mathlib/SetTheory/ZFC/Class.lean
+++ b/Mathlib/SetTheory/ZFC/Class.lean
@@ -129,6 +129,7 @@ theorem univ_notMem_univ : univ ∉ univ :=
 def congToClass (x : Set Class.{u}) : Class.{u} :=
   { y | ↑y ∈ x }
 
+set_option trace.profiler true in
 @[simp]
 theorem congToClass_empty : congToClass ∅ = ∅ := by
   ext z
```
```
✔ [660/660] Built Mathlib.SetTheory.ZFC.Class (2.3s)
Build completed successfully (660 jobs).
```

### Trace profiling of `congToClass_empty` after PR 28572
```diff
diff --git a/Mathlib/SetTheory/ZFC/Class.lean b/Mathlib/SetTheory/ZFC/Class.lean
index 43d3015eb2..fa097799c0 100644
--- a/Mathlib/SetTheory/ZFC/Class.lean
+++ b/Mathlib/SetTheory/ZFC/Class.lean
@@ -129,11 +129,10 @@ theorem univ_notMem_univ : univ ∉ univ :=
 def congToClass (x : Set Class.{u}) : Class.{u} :=
   { y | ↑y ∈ x }
 
+set_option trace.profiler true in
 @[simp]
 theorem congToClass_empty : congToClass ∅ = ∅ := by
-  ext z
-  simp only [congToClass, not_empty_hom, iff_false]
-  exact Set.notMem_empty z
+  tauto
 
 /-- Convert a class into a conglomerate (a collection of classes) -/
 def classToCong (x : Class.{u}) : Set Class.{u} :=
```
```
✔ [660/660] Built Mathlib.SetTheory.ZFC.Class (2.5s)
Build completed successfully (660 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
