### PR TITLE
[Merged by Bors] - chore(Topology/Category): golf entire `finiteCoproduct.ι_desc_apply`, `piIsoPi_hom_apply`, `prodIsoProd_hom_apply` and `pullbackIsoProdSubtype_hom_apply` using `tauto` and `rfl`

### DIFF
--- a/Mathlib/Topology/Category/CompHausLike/Limits.lean
+++ b/Mathlib/Topology/Category/CompHausLike/Limits.lean
@@ -111,9 +111,7 @@ lemma finiteCoproduct.ι_jointly_surjective (R : finiteCoproduct X) :
 
 lemma finiteCoproduct.ι_desc_apply {B : CompHausLike P} {π : (a : α) → X a ⟶ B} (a : α) :
     ∀ x, finiteCoproduct.desc X π (finiteCoproduct.ι X a x) = π a x := by
-  intro x
-  change (ι X a ≫ desc X π) _ = _
-  simp only [ι_desc]
+  tauto
 
 instance : HasCoproduct X where
   exists_colimit := ⟨finiteCoproduct.cofan X, finiteCoproduct.isColimit X⟩

--- a/Mathlib/Topology/Category/TopCat/Limits/Products.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Products.lean
@@ -62,7 +62,7 @@ theorem piIsoPi_inv_π_apply {ι : Type v} (α : ι → TopCat.{max v u}) (i : �
 
 theorem piIsoPi_hom_apply {ι : Type v} (α : ι → TopCat.{max v u}) (i : ι)
     (x : (∏ᶜ α : TopCat.{max v u})) : (piIsoPi α).hom x i = (Pi.π α i :) x := by
-  tauto
+  rfl
 
 /-- The inclusion to the coproduct as a bundled continuous map. -/
 abbrev sigmaι {ι : Type v} (α : ι → TopCat.{max v u}) (i : ι) : α i ⟶ TopCat.of (Σ i, α i) := by
@@ -163,7 +163,7 @@ theorem prodIsoProd_hom_snd (X Y : TopCat.{u}) :
 theorem prodIsoProd_hom_apply {X Y : TopCat.{u}} (x : ↑(X ⨯ Y)) :
     (prodIsoProd X Y).hom x = ((Limits.prod.fst : X ⨯ Y ⟶ _) x,
     (Limits.prod.snd : X ⨯ Y ⟶ _) x) := by
-  tauto
+  rfl
 
 @[reassoc (attr := simp), elementwise]
 theorem prodIsoProd_inv_fst (X Y : TopCat.{u}) :

--- a/Mathlib/Topology/Category/TopCat/Limits/Products.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Products.lean
@@ -61,8 +61,7 @@ theorem piIsoPi_inv_π_apply {ι : Type v} (α : ι → TopCat.{max v u}) (i : �
   ConcreteCategory.congr_hom (piIsoPi_inv_π α i) x
 
 theorem piIsoPi_hom_apply {ι : Type v} (α : ι → TopCat.{max v u}) (i : ι)
-    (x : (∏ᶜ α : TopCat.{max v u})) : (piIsoPi α).hom x i = (Pi.π α i :) x := by
-  rfl
+    (x : (∏ᶜ α : TopCat.{max v u})) : (piIsoPi α).hom x i = (Pi.π α i :) x := rfl
 
 /-- The inclusion to the coproduct as a bundled continuous map. -/
 abbrev sigmaι {ι : Type v} (α : ι → TopCat.{max v u}) (i : ι) : α i ⟶ TopCat.of (Σ i, α i) := by
@@ -162,8 +161,7 @@ theorem prodIsoProd_hom_snd (X Y : TopCat.{u}) :
 -- Note that `(x : X ⨯ Y)` would mean `(x : ↑X × ↑Y)` below:
 theorem prodIsoProd_hom_apply {X Y : TopCat.{u}} (x : ↑(X ⨯ Y)) :
     (prodIsoProd X Y).hom x = ((Limits.prod.fst : X ⨯ Y ⟶ _) x,
-    (Limits.prod.snd : X ⨯ Y ⟶ _) x) := by
-  rfl
+    (Limits.prod.snd : X ⨯ Y ⟶ _) x) := rfl
 
 @[reassoc (attr := simp), elementwise]
 theorem prodIsoProd_inv_fst (X Y : TopCat.{u}) :

--- a/Mathlib/Topology/Category/TopCat/Limits/Products.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Products.lean
@@ -62,9 +62,7 @@ theorem piIsoPi_inv_π_apply {ι : Type v} (α : ι → TopCat.{max v u}) (i : �
 
 theorem piIsoPi_hom_apply {ι : Type v} (α : ι → TopCat.{max v u}) (i : ι)
     (x : (∏ᶜ α : TopCat.{max v u})) : (piIsoPi α).hom x i = (Pi.π α i :) x := by
-  have := piIsoPi_inv_π α i
-  rw [Iso.inv_comp_eq] at this
-  exact ConcreteCategory.congr_hom this x
+  tauto
 
 /-- The inclusion to the coproduct as a bundled continuous map. -/
 abbrev sigmaι {ι : Type v} (α : ι → TopCat.{max v u}) (i : ι) : α i ⟶ TopCat.of (Σ i, α i) := by
@@ -165,9 +163,7 @@ theorem prodIsoProd_hom_snd (X Y : TopCat.{u}) :
 theorem prodIsoProd_hom_apply {X Y : TopCat.{u}} (x : ↑(X ⨯ Y)) :
     (prodIsoProd X Y).hom x = ((Limits.prod.fst : X ⨯ Y ⟶ _) x,
     (Limits.prod.snd : X ⨯ Y ⟶ _) x) := by
-  ext
-  · exact ConcreteCategory.congr_hom (prodIsoProd_hom_fst X Y) x
-  · exact ConcreteCategory.congr_hom (prodIsoProd_hom_snd X Y) x
+  tauto
 
 @[reassoc (attr := simp), elementwise]
 theorem prodIsoProd_inv_fst (X Y : TopCat.{u}) :

--- a/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
@@ -110,7 +110,7 @@ theorem pullbackIsoProdSubtype_hom_apply {f : X ⟶ Z} {g : Y ⟶ Z}
     (pullbackIsoProdSubtype f g).hom x =
       ⟨⟨pullback.fst f g x, pullback.snd f g x⟩, by
         simpa using CategoryTheory.congr_fun pullback.condition x⟩ := by
-  tauto
+  rfl
 
 theorem pullback_topology {X Y Z : TopCat.{u}} (f : X ⟶ Z) (g : Y ⟶ Z) :
     (pullback f g).str =

--- a/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
@@ -109,8 +109,7 @@ theorem pullbackIsoProdSubtype_hom_apply {f : X ⟶ Z} {g : Y ⟶ Z}
     (x : ↑(pullback f g)) :
     (pullbackIsoProdSubtype f g).hom x =
       ⟨⟨pullback.fst f g x, pullback.snd f g x⟩, by
-        simpa using CategoryTheory.congr_fun pullback.condition x⟩ := by
-  rfl
+        simpa using CategoryTheory.congr_fun pullback.condition x⟩ := rfl
 
 theorem pullback_topology {X Y Z : TopCat.{u}} (f : X ⟶ Z) (g : Y ⟶ Z) :
     (pullback f g).str =

--- a/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
@@ -110,9 +110,7 @@ theorem pullbackIsoProdSubtype_hom_apply {f : X ⟶ Z} {g : Y ⟶ Z}
     (pullbackIsoProdSubtype f g).hom x =
       ⟨⟨pullback.fst f g x, pullback.snd f g x⟩, by
         simpa using CategoryTheory.congr_fun pullback.condition x⟩ := by
-  apply Subtype.ext; apply Prod.ext
-  exacts [ConcreteCategory.congr_hom (pullbackIsoProdSubtype_hom_fst f g) x,
-    ConcreteCategory.congr_hom (pullbackIsoProdSubtype_hom_snd f g) x]
+  tauto
 
 theorem pullback_topology {X Y Z : TopCat.{u}} (f : X ⟶ Z) (g : Y ⟶ Z) :
     (pullback f g).str =


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>finiteCoproduct.ι_desc_apply</code>: 15 ms before, 25 ms after </summary>

### Trace profiling of `finiteCoproduct.ι_desc_apply` before PR 28574
```diff
diff --git a/Mathlib/Topology/Category/CompHausLike/Limits.lean b/Mathlib/Topology/Category/CompHausLike/Limits.lean
index 493c277fec..216c5888f2 100644
--- a/Mathlib/Topology/Category/CompHausLike/Limits.lean
+++ b/Mathlib/Topology/Category/CompHausLike/Limits.lean
@@ -109,6 +109,7 @@ lemma finiteCoproduct.ι_injective (a : α) : Function.Injective (finiteCoproduc
 lemma finiteCoproduct.ι_jointly_surjective (R : finiteCoproduct X) :
     ∃ (a : α) (r : X a), R = finiteCoproduct.ι X a r := ⟨R.fst, R.snd, rfl⟩
 
+set_option trace.profiler true in
 lemma finiteCoproduct.ι_desc_apply {B : CompHausLike P} {π : (a : α) → X a ⟶ B} (a : α) :
     ∀ x, finiteCoproduct.desc X π (finiteCoproduct.ι X a x) = π a x := by
   intro x
```
```
ℹ [985/985] Built Mathlib.Topology.Category.CompHausLike.Limits (1.9s)
info: Mathlib/Topology/Category/CompHausLike/Limits.lean:113:0: [Elab.command] [0.011940] theorem ι_desc_apply {B : CompHausLike P} {π : (a : α) → X a ⟶ B} (a : α) :
        ∀ x, finiteCoproduct.desc X π (finiteCoproduct.ι X a x) = π a x :=
      by
      intro x
      change (ι X a ≫ desc X π) _ = _
      simp only [ι_desc]
  [Elab.definition.header] [0.011212] CompHausLike.finiteCoproduct.ι_desc_apply
    [Elab.step] [0.010053] expected type: Sort ?u.7530, term
        ∀ x, finiteCoproduct.desc X π (finiteCoproduct.ι X a x) = π a x
info: Mathlib/Topology/Category/CompHausLike/Limits.lean:113:0: [Elab.command] [0.012175] theorem finiteCoproduct.ι_desc_apply {B : CompHausLike P} {π : (a : α) → X a ⟶ B} (a : α) :
        ∀ x, finiteCoproduct.desc X π (finiteCoproduct.ι X a x) = π a x :=
      by
      intro x
      change (ι X a ≫ desc X π) _ = _
      simp only [ι_desc]
info: Mathlib/Topology/Category/CompHausLike/Limits.lean:113:0: [Elab.command] [0.012211] lemma finiteCoproduct.ι_desc_apply {B : CompHausLike P} {π : (a : α) → X a ⟶ B} (a : α) :
        ∀ x, finiteCoproduct.desc X π (finiteCoproduct.ι X a x) = π a x :=
      by
      intro x
      change (ι X a ≫ desc X π) _ = _
      simp only [ι_desc]
info: Mathlib/Topology/Category/CompHausLike/Limits.lean:113:0: [Elab.async] [0.015416] elaborating proof of CompHausLike.finiteCoproduct.ι_desc_apply
  [Elab.definition.value] [0.014903] CompHausLike.finiteCoproduct.ι_desc_apply
    [Elab.step] [0.014576] 
          intro x
          change (ι X a ≫ desc X π) _ = _
          simp only [ι_desc]
      [Elab.step] [0.014564] 
            intro x
            change (ι X a ≫ desc X π) _ = _
            simp only [ι_desc]
        [Elab.step] [0.011699] change (ι X a ≫ desc X π) _ = _
Build completed successfully (985 jobs).
```

### Trace profiling of `finiteCoproduct.ι_desc_apply` after PR 28574
```diff
diff --git a/Mathlib/Topology/Category/CompHausLike/Limits.lean b/Mathlib/Topology/Category/CompHausLike/Limits.lean
index 493c277fec..b70ed614b6 100644
--- a/Mathlib/Topology/Category/CompHausLike/Limits.lean
+++ b/Mathlib/Topology/Category/CompHausLike/Limits.lean
@@ -109,11 +109,10 @@ lemma finiteCoproduct.ι_injective (a : α) : Function.Injective (finiteCoproduc
 lemma finiteCoproduct.ι_jointly_surjective (R : finiteCoproduct X) :
     ∃ (a : α) (r : X a), R = finiteCoproduct.ι X a r := ⟨R.fst, R.snd, rfl⟩
 
+set_option trace.profiler true in
 lemma finiteCoproduct.ι_desc_apply {B : CompHausLike P} {π : (a : α) → X a ⟶ B} (a : α) :
     ∀ x, finiteCoproduct.desc X π (finiteCoproduct.ι X a x) = π a x := by
-  intro x
-  change (ι X a ≫ desc X π) _ = _
-  simp only [ι_desc]
+  tauto
 
 instance : HasCoproduct X where
   exists_colimit := ⟨finiteCoproduct.cofan X, finiteCoproduct.isColimit X⟩
diff --git a/Mathlib/Topology/Category/TopCat/Limits/Products.lean b/Mathlib/Topology/Category/TopCat/Limits/Products.lean
index 0b74c2f6ee..353896fce8 100644
--- a/Mathlib/Topology/Category/TopCat/Limits/Products.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Products.lean
@@ -62,9 +62,7 @@ theorem piIsoPi_inv_π_apply {ι : Type v} (α : ι → TopCat.{max v u}) (i : 
 
 theorem piIsoPi_hom_apply {ι : Type v} (α : ι → TopCat.{max v u}) (i : ι)
     (x : (∏ᶜ α : TopCat.{max v u})) : (piIsoPi α).hom x i = (Pi.π α i :) x := by
-  have := piIsoPi_inv_π α i
-  rw [Iso.inv_comp_eq] at this
-  exact ConcreteCategory.congr_hom this x
+  tauto
 
 /-- The inclusion to the coproduct as a bundled continuous map. -/
 abbrev sigmaι {ι : Type v} (α : ι → TopCat.{max v u}) (i : ι) : α i ⟶ TopCat.of (Σ i, α i) := by
@@ -165,9 +163,7 @@ theorem prodIsoProd_hom_snd (X Y : TopCat.{u}) :
 theorem prodIsoProd_hom_apply {X Y : TopCat.{u}} (x : ↑(X ⨯ Y)) :
     (prodIsoProd X Y).hom x = ((Limits.prod.fst : X ⨯ Y ⟶ _) x,
     (Limits.prod.snd : X ⨯ Y ⟶ _) x) := by
-  ext
-  · exact ConcreteCategory.congr_hom (prodIsoProd_hom_fst X Y) x
-  · exact ConcreteCategory.congr_hom (prodIsoProd_hom_snd X Y) x
+  tauto
 
 @[reassoc (attr := simp), elementwise]
 theorem prodIsoProd_inv_fst (X Y : TopCat.{u}) :
diff --git a/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean b/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
index 66049170b3..68b42db21b 100644
--- a/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
+++ b/Mathlib/Topology/Category/TopCat/Limits/Pullbacks.lean
@@ -110,9 +110,7 @@ theorem pullbackIsoProdSubtype_hom_apply {f : X ⟶ Z} {g : Y ⟶ Z}
     (pullbackIsoProdSubtype f g).hom x =
       ⟨⟨pullback.fst f g x, pullback.snd f g x⟩, by
         simpa using CategoryTheory.congr_fun pullback.condition x⟩ := by
-  apply Subtype.ext; apply Prod.ext
-  exacts [ConcreteCategory.congr_hom (pullbackIsoProdSubtype_hom_fst f g) x,
-    ConcreteCategory.congr_hom (pullbackIsoProdSubtype_hom_snd f g) x]
+  tauto
 
 theorem pullback_topology {X Y Z : TopCat.{u}} (f : X ⟶ Z) (g : Y ⟶ Z) :
     (pullback f g).str =
```
```
✔ [982/985] Built Mathlib.Topology.Category.TopCat.Limits.Products (2.7s)
✔ [983/985] Built Mathlib.Topology.Category.TopCat.Limits.Pullbacks (2.4s)
✔ [984/985] Built Mathlib.CategoryTheory.Extensive (4.3s)
ℹ [985/985] Built Mathlib.Topology.Category.CompHausLike.Limits (3.0s)
info: Mathlib/Topology/Category/CompHausLike/Limits.lean:113:0: [Elab.command] [0.033044] theorem ι_desc_apply {B : CompHausLike P} {π : (a : α) → X a ⟶ B} (a : α) :
        ∀ x, finiteCoproduct.desc X π (finiteCoproduct.ι X a x) = π a x := by tauto
  [Elab.definition.header] [0.031659] CompHausLike.finiteCoproduct.ι_desc_apply
    [Elab.step] [0.030394] expected type: Sort ?u.7530, term
        ∀ x, finiteCoproduct.desc X π (finiteCoproduct.ι X a x) = π a x
      [Elab.step] [0.030250] expected type: Sort ?u.7534, term
          finiteCoproduct.desc X π (finiteCoproduct.ι X a x) = π a x
        [Elab.step] [0.030242] expected type: Sort ?u.7534, term
            binrel% Eq✝ (finiteCoproduct.desc X π (finiteCoproduct.ι X a x)) (π a x)
          [Elab.step] [0.025815] expected type: <not-available>, term
              finiteCoproduct.desc X π (finiteCoproduct.ι X a x)
            [Elab.step] [0.010204] expected type: (fun X ↦ ↑X.toTop) (finiteCoproduct X), term
                (finiteCoproduct.ι X a x)
              [Elab.step] [0.010186] expected type: (fun X ↦ ↑X.toTop) (finiteCoproduct X), term
                  finiteCoproduct.ι X a x
info: Mathlib/Topology/Category/CompHausLike/Limits.lean:113:0: [Elab.command] [0.033536] theorem finiteCoproduct.ι_desc_apply {B : CompHausLike P} {π : (a : α) → X a ⟶ B} (a : α) :
        ∀ x, finiteCoproduct.desc X π (finiteCoproduct.ι X a x) = π a x := by tauto
info: Mathlib/Topology/Category/CompHausLike/Limits.lean:113:0: [Elab.command] [0.033652] lemma finiteCoproduct.ι_desc_apply {B : CompHausLike P} {π : (a : α) → X a ⟶ B} (a : α) :
        ∀ x, finiteCoproduct.desc X π (finiteCoproduct.ι X a x) = π a x := by tauto
info: Mathlib/Topology/Category/CompHausLike/Limits.lean:113:0: [Elab.async] [0.025323] elaborating proof of CompHausLike.finiteCoproduct.ι_desc_apply
  [Elab.definition.value] [0.024806] CompHausLike.finiteCoproduct.ι_desc_apply
    [Elab.step] [0.024330] tauto
      [Elab.step] [0.024317] tauto
        [Elab.step] [0.024304] tauto
Build completed successfully (985 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
