### PR TITLE
[Merged by Bors] - feat: `IsOrderBornology` instances for `ℕ` and `ℤ`

### DIFF
--- a/Mathlib/Order/Bounds/Basic.lean
+++ b/Mathlib/Order/Bounds/Basic.lean
@@ -552,29 +552,14 @@ theorem lowerBounds_singleton : lowerBounds {a} = Iic a :=
 -/
 
 
-theorem bddAbove_Icc : BddAbove (Icc a b) :=
-  ⟨b, fun _ => And.right⟩
-
-theorem bddBelow_Icc : BddBelow (Icc a b) :=
-  ⟨a, fun _ => And.left⟩
-
-theorem bddAbove_Ico : BddAbove (Ico a b) :=
-  bddAbove_Icc.mono Ico_subset_Icc_self
-
-theorem bddBelow_Ico : BddBelow (Ico a b) :=
-  bddBelow_Icc.mono Ico_subset_Icc_self
-
-theorem bddAbove_Ioc : BddAbove (Ioc a b) :=
-  bddAbove_Icc.mono Ioc_subset_Icc_self
-
-theorem bddBelow_Ioc : BddBelow (Ioc a b) :=
-  bddBelow_Icc.mono Ioc_subset_Icc_self
-
-theorem bddAbove_Ioo : BddAbove (Ioo a b) :=
-  bddAbove_Icc.mono Ioo_subset_Icc_self
-
-theorem bddBelow_Ioo : BddBelow (Ioo a b) :=
-  bddBelow_Icc.mono Ioo_subset_Icc_self
+@[simp] lemma bddAbove_Icc : BddAbove (Icc a b) := ⟨b, fun _ => And.right⟩
+@[simp] lemma bddBelow_Icc : BddBelow (Icc a b) := ⟨a, fun _ => And.left⟩
+@[simp] lemma bddAbove_Ico : BddAbove (Ico a b) := bddAbove_Icc.mono Ico_subset_Icc_self
+@[simp] lemma bddBelow_Ico : BddBelow (Ico a b) := bddBelow_Icc.mono Ico_subset_Icc_self
+@[simp] lemma bddAbove_Ioc : BddAbove (Ioc a b) := bddAbove_Icc.mono Ioc_subset_Icc_self
+@[simp] lemma bddBelow_Ioc : BddBelow (Ioc a b) := bddBelow_Icc.mono Ioc_subset_Icc_self
+@[simp] lemma bddAbove_Ioo : BddAbove (Ioo a b) := bddAbove_Icc.mono Ioo_subset_Icc_self
+@[simp] lemma bddBelow_Ioo : BddBelow (Ioo a b) := bddBelow_Icc.mono Ioo_subset_Icc_self
 
 theorem isGreatest_Icc (h : a ≤ b) : IsGreatest (Icc a b) b :=
   ⟨right_mem_Icc.2 h, fun _ => And.right⟩

--- a/Mathlib/Topology/Bornology/Real.lean
+++ b/Mathlib/Topology/Bornology/Real.lean
@@ -17,31 +17,15 @@ assert_not_exists IsTopologicalRing UniformContinuousConstSMul UniformOnFun
 
 open Metric Set
 
-instance instIsOrderBornology : IsOrderBornology ℝ where
-  isBounded_iff_bddBelow_bddAbove s := by
-    refine ⟨fun bdd ↦ ?_, fun h ↦ isBounded_of_bddAbove_of_bddBelow h.2 h.1⟩
-    obtain ⟨r, hr⟩ : ∃ r : ℝ, s ⊆ Icc (-r) r := by
-      simpa [Real.closedBall_eq_Icc] using bdd.subset_closedBall 0
-    exact ⟨bddBelow_Icc.mono hr, bddAbove_Icc.mono hr⟩
+instance Real.instIsOrderBornology : IsOrderBornology ℝ :=
+  .of_isCompactIcc 0 (by simp [closedBall_eq_Icc]) (by simp [closedBall_eq_Icc])
 
 namespace NNReal
-
-/-!
-Every instance is inherited from the corresponding structures on the reals.
--/
 
 instance : OrderTopology ℝ≥0 :=
   orderTopology_of_ordConnected (t := Ici 0)
 
--- TODO: generalize this to a broader class of subtypes
-instance : IsOrderBornology ℝ≥0 where
-  isBounded_iff_bddBelow_bddAbove s := by
-    refine ⟨fun bdd ↦ ?_, fun h ↦ isBounded_of_bddAbove_of_bddBelow h.2 h.1⟩
-    obtain ⟨r, hr⟩ : ∃ r : ℝ≥0, s ⊆ Icc 0 r := by
-      obtain ⟨rreal, hrreal⟩ := bdd.subset_closedBall 0
-      use rreal.toNNReal
-      simp only [← NNReal.closedBall_zero_eq_Icc', Real.coe_toNNReal']
-      exact subset_trans hrreal (Metric.closedBall_subset_closedBall (le_max_left rreal 0))
-    exact ⟨bddBelow_Icc.mono hr, bddAbove_Icc.mono hr⟩
+instance : IsOrderBornology ℝ≥0 := .of_isCompactIcc 0 (by simp) fun r ↦ by
+  obtain hr | hr := le_or_gt 0 r <;> simp [closedBall_zero_eq_Icc, *]
 
 end NNReal

--- a/Mathlib/Topology/Instances/Int.lean
+++ b/Mathlib/Topology/Instances/Int.lean
@@ -9,6 +9,7 @@ import Mathlib.Topology.Instances.Discrete
 import Mathlib.Topology.MetricSpace.Bounded
 import Mathlib.Order.Filter.AtTopBot.Archimedean
 import Mathlib.Topology.MetricSpace.Basic
+import Mathlib.Topology.Order.Bornology
 
 /-!
 # Topology on the integers
@@ -61,11 +62,13 @@ instance : ProperSpace ℤ :=
     rw [closedBall_eq_Icc]
     exact (Set.finite_Icc _ _).isCompact⟩
 
+instance : IsOrderBornology ℤ :=
+  .of_isCompactIcc 0 (by simp [Int.closedBall_eq_Icc]) (by simp [Int.closedBall_eq_Icc])
+
 @[simp]
 theorem cobounded_eq : Bornology.cobounded ℤ = atBot ⊔ atTop := by
   simp_rw [← comap_dist_right_atTop (0 : ℤ), dist_eq', sub_zero,
     ← comap_abs_atTop, ← @Int.comap_cast_atTop ℝ, comap_comap]; rfl
-
 
 @[simp]
 theorem cofinite_eq : (cofinite : Filter ℤ) = atBot ⊔ atTop := by

--- a/Mathlib/Topology/Instances/Nat.lean
+++ b/Mathlib/Topology/Instances/Nat.lean
@@ -3,6 +3,7 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
+import Mathlib.Data.Nat.Lattice
 import Mathlib.Topology.Instances.Int
 
 /-!
@@ -56,6 +57,8 @@ instance : ProperSpace ℕ :=
   ⟨fun x r => by
     rw [closedBall_eq_Icc]
     exact (Set.finite_Icc _ _).isCompact⟩
+
+instance : IsOrderBornology ℕ := .of_isCompactIcc 0 (by simp) (by simp [Nat.closedBall_eq_Icc])
 
 instance : NoncompactSpace ℕ :=
   noncompactSpace_of_neBot <| by simp only [Filter.cocompact_eq_cofinite, Filter.cofinite_neBot]

--- a/Mathlib/Topology/MetricSpace/Bounded.lean
+++ b/Mathlib/Topology/MetricSpace/Bounded.lean
@@ -3,6 +3,7 @@ Copyright (c) 2015, 2017 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Robert Y. Lewis, Johannes Hölzl, Mario Carneiro, Sébastien Gouëzel
 -/
+import Mathlib.Topology.Order.Bornology
 import Mathlib.Topology.Order.Compact
 import Mathlib.Topology.MetricSpace.ProperSpace
 import Mathlib.Topology.MetricSpace.Cauchy
@@ -338,6 +339,16 @@ theorem isBounded_of_bddAbove_of_bddBelow {s : Set α} (h₁ : BddAbove s) (h₂
   let ⟨u, hu⟩ := h₁
   let ⟨l, hl⟩ := h₂
   (isBounded_Icc l u).subset (fun _x hx => mem_Icc.mpr ⟨hl hx, hu hx⟩)
+
+open Metric in
+lemma _root_.IsOrderBornology.of_isCompactIcc (x : α)
+    (bddBelow_ball : ∀ r, BddBelow (closedBall x r))
+    (bddAbove_ball : ∀ r, BddAbove (closedBall x r)) : IsOrderBornology α where
+  isBounded_iff_bddBelow_bddAbove s := by
+    refine ⟨?_, fun hs ↦ Metric.isBounded_of_bddAbove_of_bddBelow hs.2 hs.1⟩
+    rw [Metric.isBounded_iff_subset_closedBall x]
+    rintro ⟨r, hr⟩
+    exact ⟨(bddBelow_ball _).mono hr, (bddAbove_ball _).mono hr⟩
 
 end CompactIccSpace
 

--- a/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
+++ b/Mathlib/Topology/MetricSpace/Pseudo/Defs.lean
@@ -442,6 +442,8 @@ theorem nonempty_closedBall : (closedBall x ε).Nonempty ↔ 0 ≤ ε :=
 theorem closedBall_eq_empty : closedBall x ε = ∅ ↔ ε < 0 := by
   rw [← not_nonempty_iff_eq_empty, nonempty_closedBall, not_le]
 
+@[simp] alias ⟨_, closedBall_of_neg⟩ := closedBall_eq_empty
+
 /-- Closed balls and spheres coincide when the radius is non-positive -/
 theorem closedBall_eq_sphere_of_nonpos (hε : ε ≤ 0) : closedBall x ε = sphere x ε :=
   Set.ext fun _ => (hε.trans dist_nonneg).ge_iff_eq'


### PR DESCRIPTION
... using a new constructor assuming `IsCompactIcc`. As a result, I could make all existing instances on concrete types into one-liners.


---
As requested by @teorth.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
