### PR TITLE
[Merged by Bors] - chore(Data/Nat): golf entire `two_mul_odd_div_two` using `omega`

### DIFF
--- a/Mathlib/Data/Nat/Init.lean
+++ b/Mathlib/Data/Nat/Init.lean
@@ -120,7 +120,7 @@ lemma div_lt_self' (a b : ℕ) : (a + 1) / (b + 2) < a + 1 :=
 @[deprecated (since := "2025-06-05")] protected alias div_le_self' := Nat.div_le_self
 
 lemma two_mul_odd_div_two (hn : n % 2 = 1) : 2 * (n / 2) = n - 1 := by
-  conv => rhs; rw [← Nat.mod_add_div n 2, hn, Nat.add_sub_cancel_left]
+  omega
 
 /-! ### `pow` -/
 


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>two_mul_odd_div_two</code>: <10 ms before, 14 ms after </summary>

### Trace profiling of `two_mul_odd_div_two` before PR 28578
```diff
+set_option trace.profiler true in
 lemma two_mul_odd_div_two (hn : n % 2 = 1) : 2 * (n / 2) = n - 1 := by
   conv => rhs; rw [← Nat.mod_add_div n 2, hn, Nat.add_sub_cancel_left]
```
```
ℹ [45/45] Built Mathlib.Data.Nat.Init (1.5s)
info: Mathlib/Data/Nat/Init.lean:117:0: [Elab.command] [0.010215] lemma two_mul_odd_div_two (hn : n % 2 = 1) : 2 * (n / 2) = n - 1 := by
      conv => rhs; rw [← Nat.mod_add_div n 2, hn, Nat.add_sub_cancel_left]
Build completed successfully (45 jobs).
```

### Trace profiling of `two_mul_odd_div_two` after PR 28578
```diff
+set_option trace.profiler true in
 lemma two_mul_odd_div_two (hn : n % 2 = 1) : 2 * (n / 2) = n - 1 := by
-  conv => rhs; rw [← Nat.mod_add_div n 2, hn, Nat.add_sub_cancel_left]
+  omega
 
 /-! ### `pow` -/
 
```
```
ℹ [45/45] Built Mathlib.Data.Nat.Init (1.3s)
info: Mathlib/Data/Nat/Init.lean:117:0: [Elab.command] [0.010189] theorem two_mul_odd_div_two (hn : n % 2 = 1) : 2 * (n / 2) = n - 1 := by omega
info: Mathlib/Data/Nat/Init.lean:117:0: [Elab.command] [0.010265] lemma two_mul_odd_div_two (hn : n % 2 = 1) : 2 * (n / 2) = n - 1 := by omega
info: Mathlib/Data/Nat/Init.lean:117:0: [Elab.async] [0.013853] elaborating proof of Nat.two_mul_odd_div_two
  [Elab.definition.value] [0.013581] Nat.two_mul_odd_div_two
    [Elab.step] [0.013359] omega
      [Elab.step] [0.013344] omega
        [Elab.step] [0.013329] omega
info: Mathlib/Data/Nat/Init.lean:118:2: [Elab.async] [0.010633] Lean.addDecl
  [Kernel] [0.010613] ✅️ typechecking declarations [Nat.two_mul_odd_div_two._proof_1_1]
Build completed successfully (45 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
