### PR TITLE
[Merged by Bors] - chore(LinearAlgebra/Multilinear): golf entire `LinearMap.curry_uncurryLeft` using `tauto`

### DIFF
--- a/Mathlib/LinearAlgebra/Multilinear/Curry.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Curry.lean
@@ -84,9 +84,7 @@ theorem MultilinearMap.curryLeft_apply (f : MultilinearMap R M M₂) (x : M 0)
 @[simp]
 theorem LinearMap.curry_uncurryLeft (f : M 0 →ₗ[R] MultilinearMap R (fun i :
     Fin n => M i.succ) M₂) : f.uncurryLeft.curryLeft = f := by
-  ext m x
-  simp only [tail_cons, LinearMap.uncurryLeft_apply, MultilinearMap.curryLeft_apply]
-  rw [cons_zero]
+  tauto
 
 @[simp]
 theorem MultilinearMap.uncurry_curryLeft (f : MultilinearMap R M M₂) :


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>LinearMap.curry_uncurryLeft</code>: 29 ms before, <10 ms after  🎉</summary>

### Trace profiling of `LinearMap.curry_uncurryLeft` before PR 28579
```diff
diff --git a/Mathlib/LinearAlgebra/Multilinear/Curry.lean b/Mathlib/LinearAlgebra/Multilinear/Curry.lean
index dbccfc807a..476c9d0431 100644
--- a/Mathlib/LinearAlgebra/Multilinear/Curry.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Curry.lean
@@ -81,6 +81,7 @@ theorem MultilinearMap.curryLeft_apply (f : MultilinearMap R M M₂) (x : M 0)
     (m : ∀ i : Fin n, M i.succ) : f.curryLeft x m = f (cons x m) :=
   rfl
 
+set_option trace.profiler true in
 @[simp]
 theorem LinearMap.curry_uncurryLeft (f : M 0 →ₗ[R] MultilinearMap R (fun i :
     Fin n => M i.succ) M₂) : f.uncurryLeft.curryLeft = f := by
```
```
ℹ [1020/1020] Built Mathlib.LinearAlgebra.Multilinear.Curry (5.2s)
info: Mathlib/LinearAlgebra/Multilinear/Curry.lean:85:0: [Elab.command] [0.013325] @[simp]
    theorem curry_uncurryLeft (f : M 0 →ₗ[R] MultilinearMap R (fun i : Fin n => M i.succ) M₂) :
        f.uncurryLeft.curryLeft = f := by
      ext m x
      simp only [tail_cons, LinearMap.uncurryLeft_apply, MultilinearMap.curryLeft_apply]
      rw [cons_zero]
info: Mathlib/LinearAlgebra/Multilinear/Curry.lean:85:0: [Elab.command] [0.017322] @[simp]
    theorem LinearMap.curry_uncurryLeft (f : M 0 →ₗ[R] MultilinearMap R (fun i : Fin n => M i.succ) M₂) :
        f.uncurryLeft.curryLeft = f := by
      ext m x
      simp only [tail_cons, LinearMap.uncurryLeft_apply, MultilinearMap.curryLeft_apply]
      rw [cons_zero]
info: Mathlib/LinearAlgebra/Multilinear/Curry.lean:85:0: [Elab.async] [0.031134] elaborating proof of LinearMap.curry_uncurryLeft
  [Elab.definition.value] [0.028815] LinearMap.curry_uncurryLeft
    [Elab.step] [0.027882] 
          ext m x
          simp only [tail_cons, LinearMap.uncurryLeft_apply, MultilinearMap.curryLeft_apply]
          rw [cons_zero]
      [Elab.step] [0.027865] 
            ext m x
            simp only [tail_cons, LinearMap.uncurryLeft_apply, MultilinearMap.curryLeft_apply]
            rw [cons_zero]
        [Elab.step] [0.015578] ext m x
Build completed successfully (1020 jobs).
```

### Trace profiling of `LinearMap.curry_uncurryLeft` after PR 28579
```diff
diff --git a/Mathlib/LinearAlgebra/Multilinear/Curry.lean b/Mathlib/LinearAlgebra/Multilinear/Curry.lean
index dbccfc807a..b2a83e5e67 100644
--- a/Mathlib/LinearAlgebra/Multilinear/Curry.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Curry.lean
@@ -81,12 +81,11 @@ theorem MultilinearMap.curryLeft_apply (f : MultilinearMap R M M₂) (x : M 0)
     (m : ∀ i : Fin n, M i.succ) : f.curryLeft x m = f (cons x m) :=
   rfl
 
+set_option trace.profiler true in
 @[simp]
 theorem LinearMap.curry_uncurryLeft (f : M 0 →ₗ[R] MultilinearMap R (fun i :
     Fin n => M i.succ) M₂) : f.uncurryLeft.curryLeft = f := by
-  ext m x
-  simp only [tail_cons, LinearMap.uncurryLeft_apply, MultilinearMap.curryLeft_apply]
-  rw [cons_zero]
+  tauto
 
 @[simp]
 theorem MultilinearMap.uncurry_curryLeft (f : MultilinearMap R M M₂) :
```
```
ℹ [1020/1020] Built Mathlib.LinearAlgebra.Multilinear.Curry (3.7s)
info: Mathlib/LinearAlgebra/Multilinear/Curry.lean:85:0: [Elab.command] [0.013201] @[simp]
    theorem curry_uncurryLeft (f : M 0 →ₗ[R] MultilinearMap R (fun i : Fin n => M i.succ) M₂) :
        f.uncurryLeft.curryLeft = f := by tauto
  [Elab.definition.header] [0.010177] LinearMap.curry_uncurryLeft
info: Mathlib/LinearAlgebra/Multilinear/Curry.lean:85:0: [Elab.command] [0.013429] @[simp]
    theorem LinearMap.curry_uncurryLeft (f : M 0 →ₗ[R] MultilinearMap R (fun i : Fin n => M i.succ) M₂) :
        f.uncurryLeft.curryLeft = f := by tauto
info: Mathlib/LinearAlgebra/Multilinear/Curry.lean:85:0: [Elab.async] [0.010006] elaborating proof of LinearMap.curry_uncurryLeft
info: Mathlib/LinearAlgebra/Multilinear/Curry.lean:86:8: [Elab.async] [0.015366] Lean.addDecl
  [Kernel] [0.015318] ✅️ typechecking declarations [LinearMap.curry_uncurryLeft]
Build completed successfully (1020 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
