### PR TITLE
refactor: simplify implementation of `filter_upwards`

### DIFF
--- a/Mathlib/Order/Filter/Defs.lean
+++ b/Mathlib/Order/Filter/Defs.lean
@@ -414,7 +414,7 @@ syntax (name := filterUpwards) "filter_upwards" (" [" term,* "]")?
 
 elab_rules : tactic
 | `(tactic| filter_upwards $[[$[$args],*]]? $[with $wth*]? $[using $usingArg]?) => do
-  focus do
+  focus <| withMainContext do
     let m ← mkFreshExprSyntheticOpaqueMVar (← mkFreshTypeMVar)
     let mut pf ← ``(Filter.univ_mem' $(← Term.exprToSyntax m))
     for e in args.getD #[] do

--- a/Mathlib/Order/Filter/Defs.lean
+++ b/Mathlib/Order/Filter/Defs.lean
@@ -414,21 +414,20 @@ syntax (name := filterUpwards) "filter_upwards" (" [" term,* "]")?
 
 elab_rules : tactic
 | `(tactic| filter_upwards $[[$[$args],*]]? $[with $wth*]? $[using $usingArg]?) => do
-  let config : ApplyConfig := {newGoals := ApplyNewGoals.nonDependentOnly}
-  for e in args.getD #[] |>.reverse do
-    let goal ← getMainGoal
-    replaceMainGoal <| ← goal.withContext <| runTermElab do
-      let m ← mkFreshExprMVar none
-      let lem ← Term.elabTermEnsuringType
-        (← ``(Filter.mp_mem $e $(← Term.exprToSyntax m))) (← goal.getType)
-      goal.assign lem
-      return [m.mvarId!]
-  liftMetaTactic fun goal => do
-    goal.apply (← mkConstWithFreshMVarLevels ``Filter.univ_mem') config
-  evalTactic <|← `(tactic| dsimp -zeta only [Set.mem_setOf_eq])
-  if let some l := wth then
-    evalTactic <|← `(tactic| intro $[$l]*)
-  if let some e := usingArg then
-    evalTactic <|← `(tactic| exact $e)
+  focus do
+    let m ← mkFreshExprSyntheticOpaqueMVar (← mkFreshTypeMVar)
+    let mut pf ← ``(Filter.univ_mem' $(← Term.exprToSyntax m))
+    for e in args.getD #[] do
+      pf ← ``(Filter.mp_mem $e $pf)
+    evalTactic <| ← `(tactic| refine $pf)
+    let sideGoals ← getGoals
+    setGoals [m.mvarId!]
+    evalTactic <| ← `(tactic| dsimp -zeta only [Set.mem_setOf_eq])
+    if let some l := wth then
+      evalTactic <| ← `(tactic| intro $[$l]*)
+    if let some e := usingArg then
+      evalTactic <| ← `(tactic| exact $e)
+    appendGoals sideGoals
+    pruneSolvedGoals
 
 end Mathlib.Tactic

--- a/Mathlib/Order/Filter/Defs.lean
+++ b/Mathlib/Order/Filter/Defs.lean
@@ -428,6 +428,5 @@ elab_rules : tactic
     if let some e := usingArg then
       evalTactic <| ← `(tactic| exact $e)
     appendGoals sideGoals
-    pruneSolvedGoals
 
 end Mathlib.Tactic


### PR DESCRIPTION
This PR makes a few changes to `filter_upwards`:
- it uses `focus`, which prevents multiGoalLinter from ever blaming the tactics used inside its implementation
- it constructs the whole proof syntax and elaborates it at once using `evalTactic` and `refine`, rather than using the lower-level TermElab API, which can lose track of goals
- it's written in a way that doesn't require goals to be in some particular order

This was motivated by some multiGoalLinter issues I ran into when working on https://github.com/leanprover/lean4/pull/9942

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
