### PR TITLE
[Merged by Bors] - chore(SetTheory/Ordinal/CantorNormalForm): namespace results on the CNF

### DIFF
--- a/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
+++ b/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
@@ -35,25 +35,25 @@ universe u
 
 open List
 
-namespace Ordinal
+namespace Ordinal.CNF
 
 /-- Inducts on the base `b` expansion of an ordinal. -/
 @[elab_as_elim]
-noncomputable def CNFRec (b : Ordinal) {C : Ordinal → Sort*} (H0 : C 0)
+noncomputable def rec (b : Ordinal) {C : Ordinal → Sort*} (H0 : C 0)
     (H : ∀ o, o ≠ 0 → C (o % b ^ log b o) → C o) (o : Ordinal) : C o :=
-  if h : o = 0 then h ▸ H0 else H o h (CNFRec b H0 H (o % b ^ log b o))
+  if h : o = 0 then h ▸ H0 else H o h (rec b H0 H (o % b ^ log b o))
 termination_by o
 decreasing_by exact mod_opow_log_lt_self b h
 
 @[simp]
-theorem CNFRec_zero {C : Ordinal → Sort*} (b : Ordinal) (H0 : C 0)
-    (H : ∀ o, o ≠ 0 → C (o % b ^ log b o) → C o) : CNFRec b H0 H 0 = H0 := by
-  rw [CNFRec, dif_pos rfl]
+theorem rec_zero {C : Ordinal → Sort*} (b : Ordinal) (H0 : C 0)
+    (H : ∀ o, o ≠ 0 → C (o % b ^ log b o) → C o) : rec b H0 H 0 = H0 := by
+  rw [rec, dif_pos rfl]
 
-theorem CNFRec_pos (b : Ordinal) {o : Ordinal} {C : Ordinal → Sort*} (ho : o ≠ 0) (H0 : C 0)
+theorem rec_pos (b : Ordinal) {o : Ordinal} {C : Ordinal → Sort*} (ho : o ≠ 0) (H0 : C 0)
     (H : ∀ o, o ≠ 0 → C (o % b ^ log b o) → C o) :
-    CNFRec b H0 H o = H o ho (@CNFRec b C H0 H _) := by
-  rw [CNFRec, dif_neg]
+    rec b H0 H o = H o ho (@rec b C H0 H _) := by
+  rw [rec, dif_neg]
 
 /-- The Cantor normal form of an ordinal `o` is the list of coefficients and exponents in the
 base-`b` expansion of `o`.
@@ -62,40 +62,39 @@ We special-case `CNF 0 o = CNF 1 o = [(0, o)]` for `o ≠ 0`.
 
 `CNF b (b ^ u₁ * v₁ + b ^ u₂ * v₂) = [(u₁, v₁), (u₂, v₂)]` -/
 @[pp_nodot]
-def CNF (b o : Ordinal) : List (Ordinal × Ordinal) :=
-  CNFRec b [] (fun o _ IH ↦ (log b o, o / b ^ log b o)::IH) o
+def _root_.Ordinal.CNF (b o : Ordinal) : List (Ordinal × Ordinal) :=
+  rec b [] (fun o _ IH ↦ (log b o, o / b ^ log b o)::IH) o
 
 @[simp]
-theorem CNF_zero (b : Ordinal) : CNF b 0 = [] :=
-  CNFRec_zero b _ _
+theorem zero_right (b : Ordinal) : CNF b 0 = [] :=
+  rec_zero b _ _
 
 /-- Recursive definition for the Cantor normal form. -/
-theorem CNF_ne_zero {b o : Ordinal} (ho : o ≠ 0) :
+theorem ne_zero {b o : Ordinal} (ho : o ≠ 0) :
     CNF b o = (log b o, o / b ^ log b o)::CNF b (o % b ^ log b o) :=
-  CNFRec_pos b ho _ _
+  rec_pos b ho _ _
 
-theorem zero_CNF {o : Ordinal} (ho : o ≠ 0) : CNF 0 o = [(0, o)] := by simp [CNF_ne_zero ho]
+theorem zero_left {o : Ordinal} (ho : o ≠ 0) : CNF 0 o = [(0, o)] := by simp [CNF_ne_zero ho]
 
-theorem one_CNF {o : Ordinal} (ho : o ≠ 0) : CNF 1 o = [(0, o)] := by simp [CNF_ne_zero ho]
+theorem one_left {o : Ordinal} (ho : o ≠ 0) : CNF 1 o = [(0, o)] := by simp [CNF_ne_zero ho]
 
-theorem CNF_of_le_one {b o : Ordinal} (hb : b ≤ 1) (ho : o ≠ 0) : CNF b o = [(0, o)] := by
+theorem of_le_one {b o : Ordinal} (hb : b ≤ 1) (ho : o ≠ 0) : CNF b o = [(0, o)] := by
   rcases le_one_iff.1 hb with (rfl | rfl)
   exacts [zero_CNF ho, one_CNF ho]
 
-theorem CNF_of_lt {b o : Ordinal} (ho : o ≠ 0) (hb : o < b) : CNF b o = [(0, o)] := by
+theorem of_lt {b o : Ordinal} (ho : o ≠ 0) (hb : o < b) : CNF b o = [(0, o)] := by
   rw [CNF_ne_zero ho, log_eq_zero hb, opow_zero, div_one, mod_one, CNF_zero]
 
 /-- Evaluating the Cantor normal form of an ordinal returns the ordinal. -/
-theorem CNF_foldr (b o : Ordinal) : (CNF b o).foldr (fun p r ↦ b ^ p.1 * p.2 + r) 0 = o := by
-  refine CNFRec b ?_ ?_ o
+protected theorem foldr (b o : Ordinal) : (CNF b o).foldr (fun p r ↦ b ^ p.1 * p.2 + r) 0 = o := by
+  refine rec b ?_ ?_ o
   · rw [CNF_zero, foldr_nil]
   · intro o ho IH
     rw [CNF_ne_zero ho, foldr_cons, IH, div_add_mod]
 
 /-- Every exponent in the Cantor normal form `CNF b o` is less or equal to `log b o`. -/
-theorem CNF_fst_le_log {b o : Ordinal.{u}} {x : Ordinal × Ordinal} :
-    x ∈ CNF b o → x.1 ≤ log b o := by
-  refine CNFRec b ?_ (fun o ho H ↦ ?_) o
+theorem fst_le_log {b o : Ordinal.{u}} {x : Ordinal × Ordinal} : x ∈ CNF b o → x.1 ≤ log b o := by
+  refine rec b ?_ (fun o ho H ↦ ?_) o
   · simp
   · rw [CNF_ne_zero ho, mem_cons]
     rintro (rfl | h)
@@ -103,17 +102,17 @@ theorem CNF_fst_le_log {b o : Ordinal.{u}} {x : Ordinal × Ordinal} :
     · exact (H h).trans (log_mono_right _ (mod_opow_log_lt_self b ho).le)
 
 /-- Every coefficient in a Cantor normal form is positive. -/
-theorem CNF_lt_snd {b o : Ordinal.{u}} {x : Ordinal × Ordinal} : x ∈ CNF b o → 0 < x.2 := by
-  refine CNFRec b (by simp) (fun o ho IH ↦ ?_) o
+theorem lt_snd {b o : Ordinal.{u}} {x : Ordinal × Ordinal} : x ∈ CNF b o → 0 < x.2 := by
+  refine rec b (by simp) (fun o ho IH ↦ ?_) o
   rw [CNF_ne_zero ho]
   rintro (h | ⟨_, h⟩)
   · exact div_opow_log_pos b ho
   · exact IH h
 
 /-- Every coefficient in the Cantor normal form `CNF b o` is less than `b`. -/
-theorem CNF_snd_lt {b o : Ordinal.{u}} (hb : 1 < b) {x : Ordinal × Ordinal} :
+theorem snd_lt {b o : Ordinal.{u}} (hb : 1 < b) {x : Ordinal × Ordinal} :
     x ∈ CNF b o → x.2 < b := by
-  refine CNFRec b ?_ (fun o ho IH ↦ ?_) o
+  refine rec b ?_ (fun o ho IH ↦ ?_) o
   · simp
   · rw [CNF_ne_zero ho]
     intro h
@@ -122,8 +121,8 @@ theorem CNF_snd_lt {b o : Ordinal.{u}} (hb : 1 < b) {x : Ordinal × Ordinal} :
     · exact IH h
 
 /-- The exponents of the Cantor normal form are decreasing. -/
-theorem CNF_sorted (b o : Ordinal) : ((CNF b o).map Prod.fst).Sorted (· > ·) := by
-  refine CNFRec b ?_ (fun o ho IH ↦ ?_) o
+protected theorem sorted (b o : Ordinal) : ((CNF b o).map Prod.fst).Sorted (· > ·) := by
+  refine rec b ?_ (fun o ho IH ↦ ?_) o
   · rw [CNF_zero]
     exact sorted_nil
   · rcases le_or_gt b 1 with hb | hb
@@ -138,4 +137,4 @@ theorem CNF_sorted (b o : Ordinal) : ((CNF b o).map Prod.fst).Sorted (· > ·) :
         rcases H with ⟨⟨a, a'⟩, H, rfl⟩
         exact (CNF_fst_le_log H).trans_lt (log_mod_opow_log_lt_log_self hb hbo)
 
-end Ordinal
+end Ordinal.CNF

--- a/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
+++ b/Mathlib/SetTheory/Ordinal/CantorNormalForm.lean
@@ -39,21 +39,30 @@ namespace Ordinal.CNF
 
 /-- Inducts on the base `b` expansion of an ordinal. -/
 @[elab_as_elim]
-noncomputable def rec (b : Ordinal) {C : Ordinal → Sort*} (H0 : C 0)
+protected def rec (b : Ordinal) {C : Ordinal → Sort*} (H0 : C 0)
     (H : ∀ o, o ≠ 0 → C (o % b ^ log b o) → C o) (o : Ordinal) : C o :=
-  if h : o = 0 then h ▸ H0 else H o h (rec b H0 H (o % b ^ log b o))
+  if h : o = 0 then h ▸ H0 else H o h (CNF.rec b H0 H (o % b ^ log b o))
 termination_by o
 decreasing_by exact mod_opow_log_lt_self b h
 
+@[deprecated (since := "2025-08-18")]
+noncomputable alias _root_.Ordinal.CNFRec := CNF.rec
+
 @[simp]
 theorem rec_zero {C : Ordinal → Sort*} (b : Ordinal) (H0 : C 0)
-    (H : ∀ o, o ≠ 0 → C (o % b ^ log b o) → C o) : rec b H0 H 0 = H0 := by
-  rw [rec, dif_pos rfl]
+    (H : ∀ o, o ≠ 0 → C (o % b ^ log b o) → C o) : CNF.rec b H0 H 0 = H0 := by
+  rw [CNF.rec, dif_pos rfl]
+
+@[deprecated (since := "2025-08-18")]
+alias _root_.Ordinal.CNFRec_zero := rec_zero
 
 theorem rec_pos (b : Ordinal) {o : Ordinal} {C : Ordinal → Sort*} (ho : o ≠ 0) (H0 : C 0)
     (H : ∀ o, o ≠ 0 → C (o % b ^ log b o) → C o) :
-    rec b H0 H o = H o ho (@rec b C H0 H _) := by
-  rw [rec, dif_neg]
+    CNF.rec b H0 H o = H o ho (@CNF.rec b C H0 H _) := by
+  rw [CNF.rec, dif_neg]
+
+@[deprecated (since := "2025-08-18")]
+alias _root_.Ordinal.CNFRec_pos := rec_pos
 
 /-- The Cantor normal form of an ordinal `o` is the list of coefficients and exponents in the
 base-`b` expansion of `o`.
@@ -63,78 +72,113 @@ We special-case `CNF 0 o = CNF 1 o = [(0, o)]` for `o ≠ 0`.
 `CNF b (b ^ u₁ * v₁ + b ^ u₂ * v₂) = [(u₁, v₁), (u₂, v₂)]` -/
 @[pp_nodot]
 def _root_.Ordinal.CNF (b o : Ordinal) : List (Ordinal × Ordinal) :=
-  rec b [] (fun o _ IH ↦ (log b o, o / b ^ log b o)::IH) o
+  CNF.rec b [] (fun o _ IH ↦ (log b o, o / b ^ log b o)::IH) o
 
 @[simp]
 theorem zero_right (b : Ordinal) : CNF b 0 = [] :=
   rec_zero b _ _
 
+@[deprecated (since := "2025-08-18")]
+alias _root_.Ordinal.CNF_zero := zero_right
+
 /-- Recursive definition for the Cantor normal form. -/
-theorem ne_zero {b o : Ordinal} (ho : o ≠ 0) :
+protected theorem ne_zero {b o : Ordinal} (ho : o ≠ 0) :
     CNF b o = (log b o, o / b ^ log b o)::CNF b (o % b ^ log b o) :=
   rec_pos b ho _ _
 
-theorem zero_left {o : Ordinal} (ho : o ≠ 0) : CNF 0 o = [(0, o)] := by simp [CNF_ne_zero ho]
+@[deprecated (since := "2025-08-18")]
+alias _root_.Ordinal.CNF_ne_zero := CNF.ne_zero
 
-theorem one_left {o : Ordinal} (ho : o ≠ 0) : CNF 1 o = [(0, o)] := by simp [CNF_ne_zero ho]
+protected theorem zero_left {o : Ordinal} (ho : o ≠ 0) : CNF 0 o = [(0, o)] := by
+  simp [CNF.ne_zero ho]
 
-theorem of_le_one {b o : Ordinal} (hb : b ≤ 1) (ho : o ≠ 0) : CNF b o = [(0, o)] := by
+@[deprecated (since := "2025-08-18")]
+alias _root_.Ordinal.zero_CNF := CNF.zero_left
+
+protected theorem one_left {o : Ordinal} (ho : o ≠ 0) : CNF 1 o = [(0, o)] := by
+  simp [CNF.ne_zero ho]
+
+@[deprecated (since := "2025-08-18")]
+alias _root_.Ordinal.one_CNF := CNF.one_left
+
+protected theorem of_le_one {b o : Ordinal} (hb : b ≤ 1) (ho : o ≠ 0) : CNF b o = [(0, o)] := by
   rcases le_one_iff.1 hb with (rfl | rfl)
-  exacts [zero_CNF ho, one_CNF ho]
+  exacts [CNF.zero_left ho, CNF.one_left ho]
 
-theorem of_lt {b o : Ordinal} (ho : o ≠ 0) (hb : o < b) : CNF b o = [(0, o)] := by
-  rw [CNF_ne_zero ho, log_eq_zero hb, opow_zero, div_one, mod_one, CNF_zero]
+@[deprecated (since := "2025-08-18")]
+alias _root_.Ordinal.CNF_of_le_one := CNF.of_le_one
+
+protected theorem of_lt {b o : Ordinal} (ho : o ≠ 0) (hb : o < b) : CNF b o = [(0, o)] := by
+  rw [CNF.ne_zero ho, log_eq_zero hb, opow_zero, div_one, mod_one, zero_right]
+
+@[deprecated (since := "2025-08-18")]
+alias _root_.Ordinal.CNF_of_lt := CNF.of_lt
 
 /-- Evaluating the Cantor normal form of an ordinal returns the ordinal. -/
 protected theorem foldr (b o : Ordinal) : (CNF b o).foldr (fun p r ↦ b ^ p.1 * p.2 + r) 0 = o := by
-  refine rec b ?_ ?_ o
-  · rw [CNF_zero, foldr_nil]
+  refine CNF.rec b ?_ ?_ o
+  · rw [zero_right, foldr_nil]
   · intro o ho IH
-    rw [CNF_ne_zero ho, foldr_cons, IH, div_add_mod]
+    rw [CNF.ne_zero ho, foldr_cons, IH, div_add_mod]
+
+@[deprecated (since := "2025-08-18")]
+alias _root_.Ordinal.CNF_foldr := CNF.foldr
 
 /-- Every exponent in the Cantor normal form `CNF b o` is less or equal to `log b o`. -/
 theorem fst_le_log {b o : Ordinal.{u}} {x : Ordinal × Ordinal} : x ∈ CNF b o → x.1 ≤ log b o := by
-  refine rec b ?_ (fun o ho H ↦ ?_) o
+  refine CNF.rec b ?_ (fun o ho H ↦ ?_) o
   · simp
-  · rw [CNF_ne_zero ho, mem_cons]
+  · rw [CNF.ne_zero ho, mem_cons]
     rintro (rfl | h)
     · rfl
     · exact (H h).trans (log_mono_right _ (mod_opow_log_lt_self b ho).le)
 
+@[deprecated (since := "2025-08-18")]
+alias _root_.Ordinal.CNF_fst_le_log := fst_le_log
+
 /-- Every coefficient in a Cantor normal form is positive. -/
 theorem lt_snd {b o : Ordinal.{u}} {x : Ordinal × Ordinal} : x ∈ CNF b o → 0 < x.2 := by
-  refine rec b (by simp) (fun o ho IH ↦ ?_) o
-  rw [CNF_ne_zero ho]
+  refine CNF.rec b (by simp) (fun o ho IH ↦ ?_) o
+  rw [CNF.ne_zero ho]
   rintro (h | ⟨_, h⟩)
   · exact div_opow_log_pos b ho
   · exact IH h
 
+@[deprecated (since := "2025-08-18")]
+alias _root_.Ordinal.CNF_lt_snd := lt_snd
+
 /-- Every coefficient in the Cantor normal form `CNF b o` is less than `b`. -/
 theorem snd_lt {b o : Ordinal.{u}} (hb : 1 < b) {x : Ordinal × Ordinal} :
     x ∈ CNF b o → x.2 < b := by
-  refine rec b ?_ (fun o ho IH ↦ ?_) o
+  refine CNF.rec b ?_ (fun o ho IH ↦ ?_) o
   · simp
-  · rw [CNF_ne_zero ho]
+  · rw [CNF.ne_zero ho]
     intro h
     obtain rfl | h := mem_cons.mp h
     · exact div_opow_log_lt o hb
     · exact IH h
 
+@[deprecated (since := "2025-08-18")]
+alias _root_.Ordinal.CNF_snd_lt := snd_lt
+
 /-- The exponents of the Cantor normal form are decreasing. -/
 protected theorem sorted (b o : Ordinal) : ((CNF b o).map Prod.fst).Sorted (· > ·) := by
-  refine rec b ?_ (fun o ho IH ↦ ?_) o
-  · rw [CNF_zero]
+  refine CNF.rec b ?_ (fun o ho IH ↦ ?_) o
+  · rw [zero_right]
     exact sorted_nil
   · rcases le_or_gt b 1 with hb | hb
-    · rw [CNF_of_le_one hb ho]
+    · rw [CNF.of_le_one hb ho]
       exact sorted_singleton _
     · obtain hob | hbo := lt_or_ge o b
-      · rw [CNF_of_lt ho hob]
+      · rw [CNF.of_lt ho hob]
         exact sorted_singleton _
-      · rw [CNF_ne_zero ho, map_cons, sorted_cons]
+      · rw [CNF.ne_zero ho, map_cons, sorted_cons]
         refine ⟨fun a H ↦ ?_, IH⟩
         rw [mem_map] at H
         rcases H with ⟨⟨a, a'⟩, H, rfl⟩
-        exact (CNF_fst_le_log H).trans_lt (log_mod_opow_log_lt_log_self hb hbo)
+        exact (fst_le_log H).trans_lt (log_mod_opow_log_lt_log_self hb hbo)
+
+@[deprecated (since := "2025-08-18")]
+alias _root_.Ordinal.CNF_sorted := CNF.sorted
 
 end Ordinal.CNF


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Besides avoiding the smurf naming (and being an excuse for fixing other awkward names, like `CNFRec` and `zero_CNF`), this makes room for a future `Ordinal.CNF.coeff : Ordinal →₀ Ordinal`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
