### PR TITLE
[Merged by Bors] - chore(Data/List): golf entire `idxOf_eq_length_iff` using `grind`

### DIFF
--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -528,16 +528,7 @@ theorem idxOf_cons_ne {a b : α} (l : List α) : b ≠ a → idxOf a (b :: l) = 
   | h => by simp only [idxOf_cons, Bool.cond_eq_ite, beq_iff_eq, if_neg h]
 
 theorem idxOf_eq_length_iff {a : α} {l : List α} : idxOf a l = length l ↔ a ∉ l := by
-  induction l with
-  | nil => exact iff_of_true rfl not_mem_nil
-  | cons b l ih =>
-    simp only [length, mem_cons, idxOf_cons]
-    rw [cond_eq_if]
-    split_ifs with h <;> simp at h
-    · exact iff_of_false (by rintro ⟨⟩) fun H => H <| Or.inl h.symm
-    · simp only [Ne.symm h, false_or]
-      rw [← ih]
-      exact succ_inj
+  grind
 
 @[simp]
 theorem idxOf_of_notMem {l : List α} {a : α} : a ∉ l → idxOf a l = length l :=


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>idxOf_eq_length_iff</code>: 104 ms before, 24 ms after  🎉</summary>

### Trace profiling of `idxOf_eq_length_iff` before PR 28590
```diff
diff --git a/Mathlib/Data/List/Basic.lean b/Mathlib/Data/List/Basic.lean
index 9120dea54a..2b2dd2b76a 100644
--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -527,6 +527,7 @@ theorem idxOf_cons_eq {a b : α} (l : List α) : b = a → idxOf a (b :: l) = 0
 theorem idxOf_cons_ne {a b : α} (l : List α) : b ≠ a → idxOf a (b :: l) = succ (idxOf a l)
   | h => by simp only [idxOf_cons, Bool.cond_eq_ite, beq_iff_eq, if_neg h]
 
+set_option trace.profiler true in
 theorem idxOf_eq_length_iff {a : α} {l : List α} : idxOf a l = length l ↔ a ∉ l := by
   induction l with
   | nil => exact iff_of_true rfl not_mem_nil
```
```
ℹ [431/431] Built Mathlib.Data.List.Basic (2.0s)
info: Mathlib/Data/List/Basic.lean:531:0: [Elab.async] [0.104377] elaborating proof of List.idxOf_eq_length_iff
  [Elab.definition.value] [0.103682] List.idxOf_eq_length_iff
    [Elab.step] [0.103281] induction l with
          | nil => exact iff_of_true rfl not_mem_nil
          | cons b l ih =>
            simp only [length, mem_cons, idxOf_cons]
            rw [cond_eq_if]
            split_ifs with h <;> simp at h
            · exact iff_of_false (by rintro ⟨⟩) fun H => H <| Or.inl h.symm
            · simp only [Ne.symm h, false_or]
              rw [← ih]
              exact succ_inj
      [Elab.step] [0.103268] induction l with
            | nil => exact iff_of_true rfl not_mem_nil
            | cons b l ih =>
              simp only [length, mem_cons, idxOf_cons]
              rw [cond_eq_if]
              split_ifs with h <;> simp at h
              · exact iff_of_false (by rintro ⟨⟩) fun H => H <| Or.inl h.symm
              · simp only [Ne.symm h, false_or]
                rw [← ih]
                exact succ_inj
        [Elab.step] [0.103257] induction l with
            | nil => exact iff_of_true rfl not_mem_nil
            | cons b l ih =>
              simp only [length, mem_cons, idxOf_cons]
              rw [cond_eq_if]
              split_ifs with h <;> simp at h
              · exact iff_of_false (by rintro ⟨⟩) fun H => H <| Or.inl h.symm
              · simp only [Ne.symm h, false_or]
                rw [← ih]
                exact succ_inj
          [Elab.step] [0.101212] 
                simp only [length, mem_cons, idxOf_cons]
                rw [cond_eq_if]
                split_ifs with h <;> simp at h
                · exact iff_of_false (by rintro ⟨⟩) fun H => H <| Or.inl h.symm
                · simp only [Ne.symm h, false_or]
                  rw [← ih]
                  exact succ_inj
            [Elab.step] [0.101182] 
                  simp only [length, mem_cons, idxOf_cons]
                  rw [cond_eq_if]
                  split_ifs with h <;> simp at h
                  · exact iff_of_false (by rintro ⟨⟩) fun H => H <| Or.inl h.symm
                  · simp only [Ne.symm h, false_or]
                    rw [← ih]
                    exact succ_inj
              [Elab.step] [0.085979] split_ifs with h <;> simp at h
                [Elab.step] [0.085910] focus
                      split_ifs with h
                      with_annotate_state"<;>" skip
                      all_goals simp at h
                  [Elab.step] [0.085900] 
                        split_ifs with h
                        with_annotate_state"<;>" skip
                        all_goals simp at h
                    [Elab.step] [0.085892] 
                          split_ifs with h
                          with_annotate_state"<;>" skip
                          all_goals simp at h
                      [Elab.step] [0.081108] split_ifs with h
Build completed successfully (431 jobs).
```

### Trace profiling of `idxOf_eq_length_iff` after PR 28590
```diff
diff --git a/Mathlib/Data/List/Basic.lean b/Mathlib/Data/List/Basic.lean
index 9120dea54a..b32134ed29 100644
--- a/Mathlib/Data/List/Basic.lean
+++ b/Mathlib/Data/List/Basic.lean
@@ -527,17 +527,9 @@ theorem idxOf_cons_eq {a b : α} (l : List α) : b = a → idxOf a (b :: l) = 0
 theorem idxOf_cons_ne {a b : α} (l : List α) : b ≠ a → idxOf a (b :: l) = succ (idxOf a l)
   | h => by simp only [idxOf_cons, Bool.cond_eq_ite, beq_iff_eq, if_neg h]
 
+set_option trace.profiler true in
 theorem idxOf_eq_length_iff {a : α} {l : List α} : idxOf a l = length l ↔ a ∉ l := by
-  induction l with
-  | nil => exact iff_of_true rfl not_mem_nil
-  | cons b l ih =>
-    simp only [length, mem_cons, idxOf_cons]
-    rw [cond_eq_if]
-    split_ifs with h <;> simp at h
-    · exact iff_of_false (by rintro ⟨⟩) fun H => H <| Or.inl h.symm
-    · simp only [Ne.symm h, false_or]
-      rw [← ih]
-      exact succ_inj
+  grind
 
```
```
ℹ [431/431] Built Mathlib.Data.List.Basic (2.5s)
info: Mathlib/Data/List/Basic.lean:531:0: [Elab.async] [0.024881] elaborating proof of List.idxOf_eq_length_iff
  [Elab.definition.value] [0.024415] List.idxOf_eq_length_iff
    [Elab.step] [0.024206] grind
      [Elab.step] [0.024193] grind
        [Elab.step] [0.024177] grind
Build completed successfully (431 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
