### PR TITLE
[Merged by Bors] - chore: fix defeq abuse in `WithVal`

### DIFF
--- a/Mathlib/Topology/Algebra/Valued/WithVal.lean
+++ b/Mathlib/Topology/Algebra/Valued/WithVal.lean
@@ -85,13 +85,9 @@ def equiv : WithVal v ≃+* R := RingEquiv.refl _
 instance {R} [Ring R] (v : Valuation R Γ₀) : Valued (WithVal v) Γ₀ :=
   Valued.mk' (v.comap (WithVal.equiv v))
 
-@[simp]
-theorem apply_equiv (r : WithVal v) :
-    (Valued.v : Valuation (WithVal v) Γ₀) (WithVal.equiv v r) = v r :=
-  rfl
+@[simp] theorem apply_equiv (r : WithVal v) : v (WithVal.equiv v r) = Valued.v r := rfl
 
-@[simp]
-theorem apply_symm_equiv (r : R) : v ((WithVal.equiv v).symm r) = v r := rfl
+@[simp] theorem apply_symm_equiv (r : R) : Valued.v ((WithVal.equiv v).symm r) = v r := rfl
 
 end WithVal
 

--- a/Mathlib/Topology/Algebra/Valued/WithVal.lean
+++ b/Mathlib/Topology/Algebra/Valued/WithVal.lean
@@ -85,9 +85,9 @@ def equiv : WithVal v ≃+* R := RingEquiv.refl _
 instance {R} [Ring R] (v : Valuation R Γ₀) : Valued (WithVal v) Γ₀ :=
   Valued.mk' (v.comap (WithVal.equiv v))
 
-@[simp] theorem apply_equiv (r : WithVal v) : v (WithVal.equiv v r) = Valued.v r := rfl
+theorem apply_equiv (r : WithVal v) : v (equiv v r) = Valued.v r := rfl
 
-@[simp] theorem apply_symm_equiv (r : R) : Valued.v ((WithVal.equiv v).symm r) = v r := rfl
+@[simp] theorem apply_symm_equiv (r : R) : Valued.v ((equiv v).symm r) = v r := rfl
 
 end WithVal
 


### PR DESCRIPTION
Follow-up after #27110


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
