### PR TITLE
[Merged by Bors] - doc(RingTheory): Fix misspellings of étale

### DIFF
--- a/Mathlib/AlgebraicGeometry/Morphisms/Etale.lean
+++ b/Mathlib/AlgebraicGeometry/Morphisms/Etale.lean
@@ -11,7 +11,7 @@ import Mathlib.CategoryTheory.Limits.MorphismProperty
 
 /-!
 
-# Etale morphisms
+# Étale morphisms
 
 A morphism of schemes `f : X ⟶ Y` is étale if it is smooth of relative dimension zero. We
 also define the category of schemes étale over `X`.
@@ -60,7 +60,7 @@ instance : MorphismProperty.HasOfPostcompProperty
   intro X Y f ⟨hft, hfu⟩
   exact inferInstanceAs <| IsEtale (pullback.diagonal f)
 
-/-- If `f ≫ g` is etale and `g` unramified, then `f` is étale. -/
+/-- If `f ≫ g` is étale and `g` unramified, then `f` is étale. -/
 lemma of_comp {Z : Scheme.{u}} (g : Y ⟶ Z) [IsEtale (f ≫ g)] [LocallyOfFiniteType g]
     [FormallyUnramified g] : IsEtale f :=
   of_postcomp _ (W' := @LocallyOfFiniteType ⊓ @FormallyUnramified) f g ⟨‹_›, ‹_›⟩ ‹_›

--- a/Mathlib/RingTheory/Etale/Basic.lean
+++ b/Mathlib/RingTheory/Etale/Basic.lean
@@ -9,7 +9,7 @@ import Mathlib.RingTheory.Unramified.Basic
 
 /-!
 
-# Etale morphisms
+# Étale morphisms
 
 An `R`-algebra `A` is formally étale if for every `R`-algebra `B`,
 every square-zero ideal `I : Ideal B` and `f : A →ₐ[R] B ⧸ I`, there exists
@@ -216,7 +216,7 @@ namespace RingHom
 variable {R S : Type u} [CommRing R] [CommRing S]
 
 /--
-A ring homomorphism `R →+* A` is formally etale if it is formally unramified and formally smooth.
+A ring homomorphism `R →+* A` is formally étale if it is formally unramified and formally smooth.
 See `Algebra.FormallyEtale`.
 -/
 @[algebraize Algebra.FormallyEtale]

--- a/Mathlib/RingTheory/Etale/Field.lean
+++ b/Mathlib/RingTheory/Etale/Field.lean
@@ -7,7 +7,7 @@ import Mathlib.RingTheory.Etale.Pi
 import Mathlib.RingTheory.Unramified.Field
 
 /-!
-# Etale algebras over fields
+# Étale algebras over fields
 
 ## Main results
 

--- a/Mathlib/RingTheory/Etale/Kaehler.lean
+++ b/Mathlib/RingTheory/Etale/Kaehler.lean
@@ -10,11 +10,11 @@ import Mathlib.RingTheory.Smooth.Kaehler
 import Mathlib.RingTheory.Flat.Localization
 
 /-!
-# The differential module and etale algebras
+# The differential module and étale algebras
 
 ## Main results
 - `KaehlerDifferential.tensorKaehlerEquivOfFormallyEtale`:
-  The canonical isomorphism `T ⊗[S] Ω[S⁄R] ≃ₗ[T] Ω[T⁄R]` for `T` a formally etale `S`-algebra.
+  The canonical isomorphism `T ⊗[S] Ω[S⁄R] ≃ₗ[T] Ω[T⁄R]` for `T` a formally étale `S`-algebra.
 - `Algebra.tensorH1CotangentOfIsLocalization`:
   The canonical isomorphism `T ⊗[S] H¹(L_{S⁄R}) ≃ₗ[T] H¹(L_{T⁄R})` for `T` a localization of `S`.
 -/
@@ -27,7 +27,7 @@ variable [Algebra R S] [Algebra R T] [Algebra S T] [IsScalarTower R S T]
 open TensorProduct
 
 /--
-The canonical isomorphism `T ⊗[S] Ω[S⁄R] ≃ₗ[T] Ω[T⁄R]` for `T` a formally etale `S`-algebra.
+The canonical isomorphism `T ⊗[S] Ω[S⁄R] ≃ₗ[T] Ω[T⁄R]` for `T` a formally étale `S`-algebra.
 Also see `S ⊗[R] Ω[A⁄R] ≃ₗ[S] Ω[S ⊗[R] A⁄S]` at `KaehlerDifferential.tensorKaehlerEquiv`.
 -/
 @[simps! apply] noncomputable
@@ -79,7 +79,7 @@ Suppose we have a morphism of extensions of `R`-algebras
 -/
 variable {P : Extension.{u} R S} {Q : Extension.{u} R T} (f : P.Hom Q)
 
-/-- If `P → Q` is formally etale, then `T ⊗ₛ (S ⊗ₚ Ω[P/R]) ≃ T ⊗_Q Ω[Q/R]`. -/
+/-- If `P → Q` is formally étale, then `T ⊗ₛ (S ⊗ₚ Ω[P/R]) ≃ T ⊗_Q Ω[Q/R]`. -/
 noncomputable
 def tensorCotangentSpace
     (H : f.toRingHom.FormallyEtale) :
@@ -217,7 +217,7 @@ def tensorCotangent [alg : Algebra P.Ring Q.Ring] (halg : algebraMap P.Ring Q.Ri
         simp only [LinearMap.liftBaseChange_tmul, map_smul]
         simp [Hom.mapKer, tensorCotangentInvFun_smul_mk] }
 
-/-- If `J ≃ Q ⊗ₚ I`, `S → T` is flat and `P → Q` is formally etale, then `T ⊗ H¹(L_P) ≃ H¹(L_Q)`. -/
+/-- If `J ≃ Q ⊗ₚ I`, `S → T` is flat and `P → Q` is formally étale, then `T ⊗ H¹(L_P) ≃ H¹(L_Q)`. -/
 noncomputable
 def tensorH1Cotangent [alg : Algebra P.Ring Q.Ring] (halg : algebraMap P.Ring Q.Ring = f.toRingHom)
     [Module.Flat S T]

--- a/Mathlib/RingTheory/Henselian.lean
+++ b/Mathlib/RingTheory/Henselian.lean
@@ -41,7 +41,7 @@ https://stacks.math.columbia.edu/tag/04GE
 
 ## TODO
 
-After a good API for etale ring homomorphisms has been developed,
+After a good API for étale ring homomorphisms has been developed,
 we can give more equivalent characterization of Henselian rings.
 
 In particular, this can give a proof that factorizations into coprime polynomials can be lifted

--- a/Mathlib/RingTheory/RingHom/Etale.lean
+++ b/Mathlib/RingTheory/RingHom/Etale.lean
@@ -7,7 +7,7 @@ import Mathlib.RingTheory.RingHom.Smooth
 import Mathlib.RingTheory.RingHom.Unramified
 
 /-!
-# Etale ring homomorphisms
+# Étale ring homomorphisms
 
 We show the meta properties of étale morphisms.
 -/
@@ -18,7 +18,7 @@ namespace RingHom
 
 variable {R S : Type u} [CommRing R] [CommRing S]
 
-/-- A ring hom `R →+* S` is etale, if `S` is an etale `R`-algebra. -/
+/-- A ring hom `R →+* S` is étale, if `S` is an étale `R`-algebra. -/
 @[algebraize RingHom.Etale.toAlgebra]
 def Etale {R S : Type u} [CommRing R] [CommRing S] (f : R →+* S) : Prop :=
   @Algebra.Etale R _ S _ f.toAlgebra


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
