### PR TITLE
[Merged by Bors] - chore(AlgebraicGeometry): change definition of Zariski topology

### DIFF
--- a/Mathlib/AlgebraicGeometry/Sites/BigZariski.lean
+++ b/Mathlib/AlgebraicGeometry/Sites/BigZariski.lean
@@ -35,11 +35,11 @@ namespace AlgebraicGeometry
 namespace Scheme
 
 /-- The Zariski pretopology on the category of schemes. -/
-def zariskiPretopology : Pretopology (Scheme.{u}) :=
+def zariskiPretopology : Pretopology Scheme.{u} :=
   pretopology @IsOpenImmersion
 
 /-- The Zariski topology on the category of schemes. -/
-abbrev zariskiTopology : GrothendieckTopology (Scheme.{u}) :=
+abbrev zariskiTopology : GrothendieckTopology Scheme.{u} :=
   grothendieckTopology IsOpenImmersion
 
 lemma zariskiTopology_eq : zariskiTopology.{u} = zariskiPretopology.toGrothendieck := rfl

--- a/Mathlib/AlgebraicGeometry/Sites/BigZariski.lean
+++ b/Mathlib/AlgebraicGeometry/Sites/BigZariski.lean
@@ -40,7 +40,9 @@ def zariskiPretopology : Pretopology (Scheme.{u}) :=
 
 /-- The Zariski topology on the category of schemes. -/
 abbrev zariskiTopology : GrothendieckTopology (Scheme.{u}) :=
-  zariskiPretopology.toGrothendieck
+  grothendieckTopology IsOpenImmersion
+
+lemma zariskiTopology_eq : zariskiTopology.{u} = zariskiPretopology.toGrothendieck := rfl
 
 instance subcanonical_zariskiTopology : zariskiTopology.Subcanonical := by
   apply GrothendieckTopology.Subcanonical.of_isSheaf_yoneda_obj


### PR DESCRIPTION
This PR changes the definition of the Zariski topology on `Scheme` from `zariskiPretopology.toGrothendieck` to `grothendieckTopology IsOpenImmersion`. Note that `grothendieckTopology` is an `abbrev` that uses `toGrothendieck`, so this definition should be strictly better and strictly unfolds to the old definition.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
