### PR TITLE
[Merged by Bors] - chore(Data/Set): golf entire `compl_prod_eq_union` using `grind`

### DIFF
--- a/Mathlib/Data/Set/Prod.lean
+++ b/Mathlib/Data/Set/Prod.lean
@@ -131,14 +131,7 @@ theorem prod_inter_prod : s₁ ×ˢ t₁ ∩ s₂ ×ˢ t₂ = (s₁ ∩ s₂) ×
 
 lemma compl_prod_eq_union {α β : Type*} (s : Set α) (t : Set β) :
     (s ×ˢ t)ᶜ = (sᶜ ×ˢ univ) ∪ (univ ×ˢ tᶜ) := by
-  ext p
-  simp only [mem_compl_iff, mem_prod, not_and, mem_union, mem_univ, and_true, true_and]
-  constructor <;> intro h
-  · by_cases fst_in_s : p.fst ∈ s
-    · exact Or.inr (h fst_in_s)
-    · exact Or.inl fst_in_s
-  · intro fst_in_s
-    simpa only [fst_in_s, not_true, false_or] using h
+  grind
 
 @[simp]
 theorem disjoint_prod : Disjoint (s₁ ×ˢ t₁) (s₂ ×ˢ t₂) ↔ Disjoint s₁ s₂ ∨ Disjoint t₁ t₂ := by


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>compl_prod_eq_union</code>: 10 ms before, 16 ms after </summary>

### Trace profiling of `compl_prod_eq_union` before PR 28606
```diff
diff --git a/Mathlib/Data/Set/Prod.lean b/Mathlib/Data/Set/Prod.lean
index 55aacc6e21..f99b9ea194 100644
--- a/Mathlib/Data/Set/Prod.lean
+++ b/Mathlib/Data/Set/Prod.lean
@@ -129,6 +129,7 @@ theorem prod_inter_prod : s₁ ×ˢ t₁ ∩ s₂ ×ˢ t₂ = (s₁ ∩ s₂) ×
   ext ⟨x, y⟩
   simp [and_assoc, and_left_comm]
 
+set_option trace.profiler true in
 lemma compl_prod_eq_union {α β : Type*} (s : Set α) (t : Set β) :
     (s ×ˢ t)ᶜ = (sᶜ ×ˢ univ) ∪ (univ ×ˢ tᶜ) := by
   ext p
```
```
ℹ [368/368] Built Mathlib.Data.Set.Prod (2.3s)
info: Mathlib/Data/Set/Prod.lean:133:0: [Elab.command] [0.014692] theorem compl_prod_eq_union {α β : Type*} (s : Set α) (t : Set β) :
        (s ×ˢ t)ᶜ = (sᶜ ×ˢ univ) ∪ (univ ×ˢ tᶜ) := by
      ext p
      simp only [mem_compl_iff, mem_prod, not_and, mem_union, mem_univ, and_true, true_and]
      constructor <;> intro h
      · by_cases fst_in_s : p.fst ∈ s
        · exact Or.inr (h fst_in_s)
        · exact Or.inl fst_in_s
      · intro fst_in_s
        simpa only [fst_in_s, not_true, false_or] using h
  [Elab.definition.header] [0.013915] Set.compl_prod_eq_union
    [Elab.step] [0.013615] expected type: Sort ?u.4299, term
        (s ×ˢ t)ᶜ = (sᶜ ×ˢ univ) ∪ (univ ×ˢ tᶜ)
      [Elab.step] [0.013608] expected type: Sort ?u.4299, term
          binrel% Eq✝ (s ×ˢ t)ᶜ ((sᶜ ×ˢ univ) ∪ (univ ×ˢ tᶜ))
        [Elab.step] [0.010755] expected type: <not-available>, term
            Union.union✝ (sᶜ ×ˢ univ) (univ ×ˢ tᶜ)
info: Mathlib/Data/Set/Prod.lean:133:0: [Elab.command] [0.014746] lemma compl_prod_eq_union {α β : Type*} (s : Set α) (t : Set β) :
        (s ×ˢ t)ᶜ = (sᶜ ×ˢ univ) ∪ (univ ×ˢ tᶜ) := by
      ext p
      simp only [mem_compl_iff, mem_prod, not_and, mem_union, mem_univ, and_true, true_and]
      constructor <;> intro h
      · by_cases fst_in_s : p.fst ∈ s
        · exact Or.inr (h fst_in_s)
        · exact Or.inl fst_in_s
      · intro fst_in_s
        simpa only [fst_in_s, not_true, false_or] using h
info: Mathlib/Data/Set/Prod.lean:133:0: [Elab.async] [0.010868] elaborating proof of Set.compl_prod_eq_union
  [Elab.definition.value] [0.010258] Set.compl_prod_eq_union
Build completed successfully (368 jobs).
```

### Trace profiling of `compl_prod_eq_union` after PR 28606
```diff
diff --git a/Mathlib/Data/Set/Prod.lean b/Mathlib/Data/Set/Prod.lean
index 55aacc6e21..3ea6d5117e 100644
--- a/Mathlib/Data/Set/Prod.lean
+++ b/Mathlib/Data/Set/Prod.lean
@@ -129,16 +129,10 @@ theorem prod_inter_prod : s₁ ×ˢ t₁ ∩ s₂ ×ˢ t₂ = (s₁ ∩ s₂) ×
   ext ⟨x, y⟩
   simp [and_assoc, and_left_comm]
 
+set_option trace.profiler true in
 lemma compl_prod_eq_union {α β : Type*} (s : Set α) (t : Set β) :
     (s ×ˢ t)ᶜ = (sᶜ ×ˢ univ) ∪ (univ ×ˢ tᶜ) := by
-  ext p
-  simp only [mem_compl_iff, mem_prod, not_and, mem_union, mem_univ, and_true, true_and]
-  constructor <;> intro h
-  · by_cases fst_in_s : p.fst ∈ s
-    · exact Or.inr (h fst_in_s)
-    · exact Or.inl fst_in_s
-  · intro fst_in_s
-    simpa only [fst_in_s, not_true, false_or] using h
+  grind
 
 @[simp]
 theorem disjoint_prod : Disjoint (s₁ ×ˢ t₁) (s₂ ×ˢ t₂) ↔ Disjoint s₁ s₂ ∨ Disjoint t₁ t₂ := by
```
```
ℹ [368/368] Built Mathlib.Data.Set.Prod (2.1s)
info: Mathlib/Data/Set/Prod.lean:133:0: [Elab.command] [0.012252] theorem compl_prod_eq_union {α β : Type*} (s : Set α) (t : Set β) :
        (s ×ˢ t)ᶜ = (sᶜ ×ˢ univ) ∪ (univ ×ˢ tᶜ) := by grind
  [Elab.definition.header] [0.010273] Set.compl_prod_eq_union
info: Mathlib/Data/Set/Prod.lean:133:0: [Elab.command] [0.012858] lemma compl_prod_eq_union {α β : Type*} (s : Set α) (t : Set β) :
        (s ×ˢ t)ᶜ = (sᶜ ×ˢ univ) ∪ (univ ×ˢ tᶜ) := by grind
info: Mathlib/Data/Set/Prod.lean:133:0: [Elab.async] [0.016424] elaborating proof of Set.compl_prod_eq_union
  [Elab.definition.value] [0.016040] Set.compl_prod_eq_union
    [Elab.step] [0.015891] grind
      [Elab.step] [0.015882] grind
        [Elab.step] [0.015870] grind
Build completed successfully (368 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
