### PR TITLE
[Merged by Bors] - fix: handle `noncomputable section` in `to_additive`

### DIFF
--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -856,7 +856,7 @@ partial def transformDeclAux
     addDecl trgDecl.toDeclaration!
     setEnv <| addNoncomputable (← getEnv) tgt
   else
-    addAndCompile trgDecl.toDeclaration!
+    addAndCompile trgDecl.toDeclaration! (logCompileErrors := (IR.findEnvDecl env src).isSome)
   if let .defnDecl { hints := .abbrev, .. } := trgDecl.toDeclaration! then
     if (← getReducibilityStatus src) == .reducible then
       setReducibilityStatus tgt .reducible

--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -789,9 +789,11 @@ def findAuxDecls (e : Expr) (pre : Name) : NameSet :=
     else
       l
 
-/-- transform the declaration `src` and all declarations `pre._proof_i` occurring in `src`
+/-- Transform the declaration `src` and all declarations `pre._proof_i` occurring in `src`
 using the transforms dictionary.
+
 `replace_all`, `trace`, `ignore` and `reorder` are configuration options.
+
 `pre` is the declaration that got the `@[to_additive]` attribute and `tgt_pre` is the target of this
 declaration. -/
 partial def transformDeclAux

--- a/Mathlib/Tactic/ToAdditive/Frontend.lean
+++ b/Mathlib/Tactic/ToAdditive/Frontend.lean
@@ -852,6 +852,18 @@ partial def transformDeclAux
     | _ => panic! "unreachable"
   -- "Refold" all the aux lemmas that we unfolded.
   let trgDecl ← MetaM.run' <| declAbstractNestedProofs trgDecl
+  /- If `src` is explicitly marked as `noncomputable`, then add the new decl as a declaration but
+  do not compile it, and mark is as noncomputable. Otherwise, only log errors in compiling if `src`
+  has executable code.
+
+  Note that `noncomputable section` does not explicitly mark noncomputable definitions as
+  `noncomputable`, but simply abstains from logging compilation errors.
+
+  This is not a perfect solution, as ideally `to_additive` *should* complain when `src` should
+  produce executable code but fails to do so (e.g. outside of `noncomputable section`). However,
+  the `messages` and `infoState` are reset before this runs, so we cannot check for compilation
+  errors on `src`. The scope set by `noncomputable` section lives in the `CommandElabM` state
+  (which is inaccessible here), so we cannot test for `noncomputable section` directly. See [Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/to_additive.20and.20noncomputable/with/310541981). -/
   if isNoncomputable env src then
     addDecl trgDecl.toDeclaration!
     setEnv <| addNoncomputable (← getEnv) tgt

--- a/MathlibTest/toAdditive.lean
+++ b/MathlibTest/toAdditive.lean
@@ -251,21 +251,6 @@ def pi_nat_has_one {I : Type} : One ((x : I) → Nat)  := pi.has_one
 
 example : @pi_nat_has_one = @pi_nat_has_zero := rfl
 
-section test_noncomputable
-
-@[to_additive Bar.bar]
-noncomputable def Foo.foo (h : ∃ _ : α, True) : α := Classical.choose h
-
-@[to_additive Bar.bar']
-def Foo.foo' : ℕ := 2
-
-theorem Bar.bar'_works : Bar.bar' = 2 := by decide
-
-run_cmd (do
-  if !isNoncomputable (← getEnv) `Test.Bar.bar then throwError "bar shouldn't be computable"
-  if isNoncomputable (← getEnv) `Test.Bar.bar' then throwError "bar' should be computable")
-end test_noncomputable
-
 section instances
 
 class FooClass (α) : Prop where
@@ -595,3 +580,77 @@ run_cmd
   let some doc ← findDocString? (← getEnv) ``addTrivial'
     | throwError "no `str` docstring found"
   logInfo doc
+
+/-! Test handling of noncomputability -/
+
+elab "#computability " decl:ident : command => do
+  let name ← liftCoreM (realizeGlobalConstNoOverloadWithInfo decl)
+  let markedNonComp := isNoncomputable (← getEnv) name
+  let hasNoExec := (IR.findEnvDecl (← getEnv) name).isNone
+  let desc :=
+    if markedNonComp then "is marked noncomputable"
+    else if hasNoExec then "has no executable code"
+    else "is computable"
+  logInfo m!"`{name}` {desc}"
+
+/- Both should be computable -/
+
+@[to_additive]
+def mulComputableTest : Nat := 0
+
+/-- info: `mulComputableTest` is computable -/
+#guard_msgs in #computability mulComputableTest
+/-- info: `addComputableTest` is computable -/
+#guard_msgs in #computability addComputableTest
+
+/- Both should be marked noncomputable -/
+
+@[to_additive]
+noncomputable def mulMarkedNoncomputable : Nat := 0
+
+/-- info: `mulMarkedNoncomputable` is marked noncomputable -/
+#guard_msgs in #computability mulMarkedNoncomputable
+/-- info: `addMarkedNoncomputable` is marked noncomputable -/
+#guard_msgs in #computability addMarkedNoncomputable
+
+noncomputable section
+
+/- Compilation should succeed despite `noncomputable` -/
+
+@[to_additive]
+def mulComputableTest' : Nat := 0
+
+/-- info: `mulComputableTest'` is computable -/
+#guard_msgs in #computability mulComputableTest'
+/-- info: `addComputableTest'` is computable -/
+#guard_msgs in #computability addComputableTest'
+
+/- Both should be marked noncomputable -/
+
+@[to_additive]
+noncomputable def mulMarkedNoncomputable' : Nat := 0
+
+/-- info: `mulMarkedNoncomputable'` is marked noncomputable -/
+#guard_msgs in #computability mulMarkedNoncomputable'
+/-- info: `addMarkedNoncomputable'` is marked noncomputable -/
+#guard_msgs in #computability addMarkedNoncomputable'
+
+/-
+Compilation should fail silently.
+
+If `mulNoExec` ever becomes marked noncomputable (meaning Lean's handling of
+`noncomputable section` has changed), then the check for executable code in
+`Mathlib.Tactic.ToAdditive.Frontend` should be replaced with a simple `isNoncomputable` check and
+mark `addNoExec` `noncomputable` as well (plus a check for whether the original declaration is an
+axiom, if `to_additive` ever handles axioms).
+-/
+
+@[to_additive]
+def mulNoExec {G} (n : Nonempty G) : G := Classical.choice n
+
+/-- info: `mulNoExec` has no executable code -/
+#guard_msgs in #computability mulNoExec
+/-- info: `addNoExec` has no executable code -/
+#guard_msgs in #computability addNoExec
+
+end


### PR DESCRIPTION
This PR allows `to_additive` to succeed for unmarked noncomputable defs in `noncomputable section`s. Previously, `to_additive` on an unmarked noncomputable defs in `noncomputable section` would fail, since `noncomputable section` does not explicitly mark its noncomputable defs as `noncomputable` in the environment extension; instead, compilation just fails silently. This PR matches that behavior for the generated declaration when the original declaration has no executable code.

Note that we cannot test for `noncomputable section` directly, since this is stored in the `CommandElabM` scopes, while the attribute's `add` function runs in `CoreM`. Hence, we use the lack of executable code as a proxy for `noncomputable section`.

However, this is not a perfect workaround: if a definition tagged with `to_additive` is outside of `noncomputable section` but is not computable, compilation of the original declaration will fail and an error will be logged. But since the original now has no executable code, the generated `to_additive` declaration will be added without error. The messages and infostate are reset before running the attribute's `add`, so it is not possible to detect such a compilation error on the original declaration without a potentially costly recompilation of the original declaration.

See [Zulip](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/to_additive.20and.20noncomputable/with/310541981).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
