### PR TITLE
[Merged by Bors] - chore: deprecate `Std.HashMap.mapVal` and `Std.Data.HashMap` module

### DIFF
--- a/Mathlib/Std/Data/HashMap.lean
+++ b/Mathlib/Std/Data/HashMap.lean
@@ -3,7 +3,7 @@ Copyright (c) 2024 Lean FRO. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
-import Std.Data.HashMap.Basic
+import Std.Data.HashMap.AdditionalOperations
 import Mathlib.Init
 
 /-!
@@ -17,6 +17,7 @@ namespace Std.HashMap
 variable {α β γ : Type _} [BEq α] [Hashable α]
 
 /-- Apply a function to the values of a hash map. -/
+@[deprecated Std.HashMap.map (since := "2025-08-18")]
 def mapVal (f : α → β → γ) (m : HashMap α β) : HashMap α γ :=
   m.fold (fun acc k v => acc.insert k (f k v)) ∅
 

--- a/Mathlib/Std/Data/HashMap.lean
+++ b/Mathlib/Std/Data/HashMap.lean
@@ -9,7 +9,7 @@ import Mathlib.Init
 /-!
 # Convenience functions for hash maps
 
-These will be reimplemented in the Lean standard library.
+This is now reimplemented in the Lean standard library.
 -/
 
 namespace Std.HashMap

--- a/Mathlib/Std/Data/HashMap.lean
+++ b/Mathlib/Std/Data/HashMap.lean
@@ -4,7 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 import Std.Data.HashMap.AdditionalOperations
-import Mathlib.Init
+import Mathlib.Tactic.Linter.DeprecatedModule
+
+deprecated_module (since := "2025-08-18")
 
 /-!
 # Convenience functions for hash maps

--- a/Mathlib/Tactic/Linarith/Oracle/FourierMotzkin.lean
+++ b/Mathlib/Tactic/Linarith/Oracle/FourierMotzkin.lean
@@ -88,7 +88,7 @@ def CompSource.flatten : CompSource → Std.HashMap Nat Nat
   | (CompSource.assump n) => (∅ : Std.HashMap Nat Nat).insert n 1
   | (CompSource.add c1 c2) =>
       (CompSource.flatten c1).mergeWith (fun _ b b' => b + b') (CompSource.flatten c2)
-  | (CompSource.scale n c) => (CompSource.flatten c).mapVal (fun _ v => v * n)
+  | (CompSource.scale n c) => (CompSource.flatten c).map (fun _ v => v * n)
 
 /-- Formats a `CompSource` for printing. -/
 def CompSource.toString : CompSource → String

--- a/Mathlib/Tactic/Linarith/Oracle/FourierMotzkin.lean
+++ b/Mathlib/Tactic/Linarith/Oracle/FourierMotzkin.lean
@@ -3,7 +3,6 @@ Copyright (c) 2020 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis
 -/
-import Mathlib.Std.Data.HashMap
 import Batteries.Lean.HashMap
 import Mathlib.Tactic.Linarith.Datatypes
 

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -342,6 +342,7 @@
   "Mathlib.Tactic.Attr.Register": ["Lean.Meta.Tactic.Simp.SimpTheorems"],
   "Mathlib.Tactic.ArithMult": ["Mathlib.Tactic.ArithMult.Init"],
   "Mathlib.Tactic.Algebraize": ["Mathlib.Algebra.Algebra.Tower"],
+  "Mathlib.Std.Data.HashMap": ["Std.Data.HashMap.AdditionalOperations"],
   "Mathlib.RingTheory.SimpleModule.Basic": ["Mathlib.Data.Matrix.Mul"],
   "Mathlib.RingTheory.PowerSeries.Evaluation":
   ["Mathlib.RingTheory.PowerSeries.PiTopology"],


### PR DESCRIPTION
Deprecates `Std.HashMap.mapVal` in favor of core's `Std.HashMap.map`, and since this was the only declaration in `Std.Data.HashMap`, deprecates the module `Std.Data.HashMap` as well.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
