### PR TITLE
[Merged by Bors] - feat(RingTheory): Standard open immersion

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -5654,6 +5654,7 @@ import Mathlib.RingTheory.RingHom.Flat
 import Mathlib.RingTheory.RingHom.Injective
 import Mathlib.RingTheory.RingHom.Integral
 import Mathlib.RingTheory.RingHom.Locally
+import Mathlib.RingTheory.RingHom.OpenImmersion
 import Mathlib.RingTheory.RingHom.Smooth
 import Mathlib.RingTheory.RingHom.StandardSmooth
 import Mathlib.RingTheory.RingHom.Surjective

--- a/Mathlib/RingTheory/Localization/Away/Basic.lean
+++ b/Mathlib/RingTheory/Localization/Away/Basic.lean
@@ -78,6 +78,11 @@ lemma algebraMap_pow_isUnit (n : ℕ) : IsUnit (algebraMap R S x ^ n) :=
 lemma algebraMap_isUnit : IsUnit (algebraMap R S x) :=
   IsLocalization.map_units _ (⟨x, 1, by simp⟩ : Submonoid.powers x)
 
+theorem associated_sec_fst (s : S) :
+    Associated (algebraMap R S (IsLocalization.Away.sec x s).1) s := by
+  rw [← IsLocalization.Away.sec_spec, map_pow]
+  exact associated_mul_unit_left _ _ <| .pow _ <| IsLocalization.Away.algebraMap_isUnit _
+
 lemma algebraMap_isUnit_iff {y : R} : IsUnit (algebraMap R S y) ↔ ∃ n, y ∣ x ^ n :=
   (IsLocalization.algebraMap_isUnit_iff <| .powers x).trans <| by simp [Submonoid.mem_powers_iff]
 

--- a/Mathlib/RingTheory/Localization/BaseChange.lean
+++ b/Mathlib/RingTheory/Localization/BaseChange.lean
@@ -196,8 +196,8 @@ end
 
 section
 
-variable {R S : Type*} [CommRing R] [CommRing S] [Algebra R S]
-    (r : R) (A : Type*) [CommRing A] [Algebra R A]
+variable {R S : Type*} [CommSemiring R] [CommSemiring S] [Algebra R S]
+    (r : R) (A : Type*) [CommSemiring A] [Algebra R A]
 
 instance IsLocalization.tensor (M : Submonoid R) [IsLocalization M A] :
     IsLocalization (Algebra.algebraMapSubmonoid S M) (S ⊗[R] A) := by

--- a/Mathlib/RingTheory/RingHom/OpenImmersion.lean
+++ b/Mathlib/RingTheory/RingHom/OpenImmersion.lean
@@ -1,0 +1,96 @@
+/-
+Copyright (c) 2025 Kenny Lau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kenny Lau
+-/
+
+import Mathlib.RingTheory.LocalProperties.Basic
+
+/-! # Standard Open Immersion
+
+We define the ring hom property `RingHom.IsStandardOpenImmersion` which is one that is a
+localization map away from some element. We also define the equivalent
+`Algebra.IsStandardOpenImmersion`.
+-/
+
+namespace RingHom
+
+variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T] (f : R →+* S) (g : S →+* T)
+
+/-- A standard open immersion is one that is a localization map away from some element. -/
+@[algebraize RingHom.IsStandardOpenImmersion.toAlgebra]
+def IsStandardOpenImmersion : Prop :=
+  letI := f.toAlgebra
+  ∃ r : R, IsLocalization.Away r S
+
+variable (R S) in
+/-- A standard open immersion is one that is a localization map away from some element. -/
+@[mk_iff] class _root_.Algebra.IsStandardOpenImmersion [Algebra R S] : Prop where
+  exists_away : ∃ r : R, IsLocalization.Away r S
+
+lemma _root_.Algebra.IsStandardOpenImmersion.away (r : R) :
+    Algebra.IsStandardOpenImmersion R (Localization.Away r) :=
+  ⟨r, inferInstance⟩
+
+lemma isStandardOpenImmersion_algebraMap [Algebra R S] :
+    (algebraMap R S).IsStandardOpenImmersion ↔ Algebra.IsStandardOpenImmersion R S := by
+  rw [IsStandardOpenImmersion, Algebra.isStandardOpenImmersion_iff, toAlgebra_algebraMap]
+
+namespace IsStandardOpenImmersion
+
+lemma algebraMap' [Algebra R S] (r : R) [IsLocalization.Away r S] :
+    (algebraMap R S).IsStandardOpenImmersion :=
+  isStandardOpenImmersion_algebraMap.2 ⟨r, inferInstance⟩
+
+lemma toAlgebra {f : R →+* S} (hf : f.IsStandardOpenImmersion) :
+    @Algebra.IsStandardOpenImmersion R S _ _ f.toAlgebra :=
+  letI := f.toAlgebra; ⟨hf⟩
+
+/-- A bijective ring map is a standard open immersion. -/
+lemma of_bijective {f : R →+* S} (hf : Function.Bijective f) : f.IsStandardOpenImmersion :=
+  letI := f.toAlgebra
+  ⟨1, IsLocalization.away_of_isUnit_of_bijective _ isUnit_one hf⟩
+
+variable (R) in
+/-- The identity map of a ring is a standard open immersion. -/
+lemma id : (RingHom.id R).IsStandardOpenImmersion :=
+  of_bijective Function.bijective_id
+
+variable {f g} in
+/-- The composition of two standard open immersions is a standard open immersion. -/
+lemma comp (hf : f.IsStandardOpenImmersion) (hg : g.IsStandardOpenImmersion) :
+    (g.comp f).IsStandardOpenImmersion := by
+  algebraize [f, g, g.comp f]
+  obtain ⟨r, hr⟩ := hf
+  obtain ⟨s, hs⟩ := hg
+  let s' := (IsLocalization.Away.sec r s).1
+  -- factor this out?
+  have assoc : Associated (algebraMap R S s') s := by
+    unfold s'
+    rw [← IsLocalization.Away.sec_spec, map_pow]
+    exact associated_mul_unit_left _ _ (.pow _ <| IsLocalization.Away.algebraMap_isUnit _)
+  have : IsLocalization.Away (algebraMap R S s') T :=
+    IsLocalization.Away.of_associated assoc.symm
+  exact ⟨r * s', IsLocalization.Away.mul' S T r _⟩
+
+theorem containsIdentities : ContainsIdentities.{u} IsStandardOpenImmersion := id
+
+theorem stableUnderComposition : StableUnderComposition.{u} IsStandardOpenImmersion := @comp
+
+theorem respectsIso : RespectsIso.{u} IsStandardOpenImmersion :=
+  stableUnderComposition.respectsIso fun e ↦ of_bijective e.bijective
+
+theorem isStableUnderBaseChange : IsStableUnderBaseChange.{u} IsStandardOpenImmersion := by
+  refine .mk respectsIso ?_
+  introv h
+  rw [isStandardOpenImmersion_algebraMap] at h ⊢
+  obtain ⟨r, _⟩ := h
+  exact ⟨algebraMap R S r, inferInstance⟩
+
+theorem holdsForLocalizationAway : HoldsForLocalizationAway.{u} IsStandardOpenImmersion := by
+  introv R h
+  exact .algebraMap' r
+
+end IsStandardOpenImmersion
+
+end RingHom

--- a/Mathlib/RingTheory/RingHom/OpenImmersion.lean
+++ b/Mathlib/RingTheory/RingHom/OpenImmersion.lean
@@ -22,10 +22,10 @@ open IsLocalization Away
 variable {R S T : Type*} [CommSemiring R] [CommSemiring S] [CommSemiring T]
   [Algebra R S] [Algebra R T]
 
-variable (R S) in
 /-- A standard open immersion is one that is a localization map away from some element. -/
-@[mk_iff] class IsStandardOpenImmersion [Algebra R S] : Prop where
-  exists_away' : ∃ r : R, IsLocalization.Away r S
+@[mk_iff] class IsStandardOpenImmersion (R S : Type*) [CommRing R] [CommRing S]
+    [Algebra R S] : Prop where
+  exists_away (R S) : ∃ r : R, IsLocalization.Away r S
 
 variable (R S) in
 theorem exists_away [IsStandardOpenImmersion R S] : ∃ r : R, IsLocalization.Away r S :=

--- a/Mathlib/RingTheory/RingHom/OpenImmersion.lean
+++ b/Mathlib/RingTheory/RingHom/OpenImmersion.lean
@@ -8,8 +8,8 @@ import Mathlib.RingTheory.LocalProperties.Basic
 
 /-! # Standard Open Immersion
 
-We define the property `RingHom.IsStandardOpenImmersion` on ring homomorphisms: it means that the morphism is a
-localization map away from some element. We also define the equivalent
+We define the property `RingHom.IsStandardOpenImmersion` on ring homomorphisms: it means that the
+morphism is a localization map away from some element. We also define the equivalent
 `Algebra.IsStandardOpenImmersion`.
 -/
 

--- a/Mathlib/RingTheory/RingHom/OpenImmersion.lean
+++ b/Mathlib/RingTheory/RingHom/OpenImmersion.lean
@@ -31,8 +31,7 @@ variable (R S) in
 theorem exists_away [IsStandardOpenImmersion R S] : ∃ r : R, IsLocalization.Away r S :=
   IsStandardOpenImmersion.exists_away'
 
-lemma IsStandardOpenImmersion.away (r : R) :
-    IsStandardOpenImmersion R (Localization.Away r) :=
+instance (r : R) : IsStandardOpenImmersion R (Localization.Away r) :=
   ⟨r, inferInstance⟩
 
 variable (R S T) in

--- a/Mathlib/RingTheory/RingHom/OpenImmersion.lean
+++ b/Mathlib/RingTheory/RingHom/OpenImmersion.lean
@@ -15,6 +15,42 @@ localization map away from some element. We also define the equivalent
 
 universe u
 
+namespace Algebra
+
+open IsLocalization Away
+
+variable {R S T : Type*} [CommSemiring R] [CommSemiring S] [CommSemiring T]
+  [Algebra R S] [Algebra R T]
+
+variable (R S) in
+/-- A standard open immersion is one that is a localization map away from some element. -/
+@[mk_iff] class IsStandardOpenImmersion [Algebra R S] : Prop where
+  exists_away' : ∃ r : R, IsLocalization.Away r S
+
+variable (R S) in
+theorem exists_away [IsStandardOpenImmersion R S] : ∃ r : R, IsLocalization.Away r S :=
+  IsStandardOpenImmersion.exists_away'
+
+lemma IsStandardOpenImmersion.away (r : R) :
+    IsStandardOpenImmersion R (Localization.Away r) :=
+  ⟨r, inferInstance⟩
+
+variable (R S T) in
+@[trans] theorem IsStandardOpenImmersion.trans [Algebra S T] [IsScalarTower R S T]
+    [IsStandardOpenImmersion R S] [IsStandardOpenImmersion S T] :
+    IsStandardOpenImmersion R T :=
+  let ⟨r, _⟩ := exists_away R S
+  let ⟨s, _⟩ := exists_away S T
+  have : Away (algebraMap R S (sec r s).1) T :=
+    .of_associated (associated_sec_fst r s).symm
+  ⟨r * (sec r s).1, mul' S T r _⟩
+
+instance [IsStandardOpenImmersion R T] : IsStandardOpenImmersion S (TensorProduct R S T) :=
+  let ⟨r, _⟩ := exists_away R T
+  ⟨algebraMap R S r, inferInstance⟩
+
+end Algebra
+
 namespace RingHom
 
 variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T] (f : R →+* S) (g : S →+* T)
@@ -23,20 +59,11 @@ variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T] (f : R →+* S) 
 @[algebraize RingHom.IsStandardOpenImmersion.toAlgebra]
 def IsStandardOpenImmersion : Prop :=
   letI := f.toAlgebra
-  ∃ r : R, IsLocalization.Away r S
-
-variable (R S) in
-/-- A standard open immersion is one that is a localization map away from some element. -/
-@[mk_iff] class _root_.Algebra.IsStandardOpenImmersion [Algebra R S] : Prop where
-  exists_away : ∃ r : R, IsLocalization.Away r S
-
-lemma _root_.Algebra.IsStandardOpenImmersion.away (r : R) :
-    Algebra.IsStandardOpenImmersion R (Localization.Away r) :=
-  ⟨r, inferInstance⟩
+  Algebra.IsStandardOpenImmersion R S
 
 lemma isStandardOpenImmersion_algebraMap [Algebra R S] :
     (algebraMap R S).IsStandardOpenImmersion ↔ Algebra.IsStandardOpenImmersion R S := by
-  rw [IsStandardOpenImmersion, Algebra.isStandardOpenImmersion_iff, toAlgebra_algebraMap]
+  rw [IsStandardOpenImmersion, toAlgebra_algebraMap]
 
 namespace IsStandardOpenImmersion
 
@@ -46,7 +73,7 @@ lemma algebraMap' [Algebra R S] (r : R) [IsLocalization.Away r S] :
 
 lemma toAlgebra {f : R →+* S} (hf : f.IsStandardOpenImmersion) :
     @Algebra.IsStandardOpenImmersion R S _ _ f.toAlgebra :=
-  letI := f.toAlgebra; ⟨hf⟩
+  letI := f.toAlgebra; hf
 
 /-- A bijective ring map is a standard open immersion. -/
 lemma of_bijective {f : R →+* S} (hf : Function.Bijective f) : f.IsStandardOpenImmersion :=
@@ -65,15 +92,7 @@ lemma comp (hf : f.IsStandardOpenImmersion) (hg : g.IsStandardOpenImmersion) :
   algebraize [f, g, g.comp f]
   obtain ⟨r, hr⟩ := hf
   obtain ⟨s, hs⟩ := hg
-  let s' := (IsLocalization.Away.sec r s).1
-  -- factor this out?
-  have assoc : Associated (algebraMap R S s') s := by
-    unfold s'
-    rw [← IsLocalization.Away.sec_spec, map_pow]
-    exact associated_mul_unit_left _ _ (.pow _ <| IsLocalization.Away.algebraMap_isUnit _)
-  have : IsLocalization.Away (algebraMap R S s') T :=
-    IsLocalization.Away.of_associated assoc.symm
-  exact ⟨r * s', IsLocalization.Away.mul' S T r _⟩
+  exact .trans _ S _
 
 theorem containsIdentities : ContainsIdentities.{u} IsStandardOpenImmersion := id
 
@@ -86,8 +105,7 @@ theorem isStableUnderBaseChange : IsStableUnderBaseChange.{u} IsStandardOpenImme
   refine .mk respectsIso ?_
   introv h
   rw [isStandardOpenImmersion_algebraMap] at h ⊢
-  obtain ⟨r, _⟩ := h
-  exact ⟨algebraMap R S r, inferInstance⟩
+  infer_instance
 
 theorem holdsForLocalizationAway : HoldsForLocalizationAway.{u} IsStandardOpenImmersion := by
   introv R h

--- a/Mathlib/RingTheory/RingHom/OpenImmersion.lean
+++ b/Mathlib/RingTheory/RingHom/OpenImmersion.lean
@@ -13,6 +13,8 @@ localization map away from some element. We also define the equivalent
 `Algebra.IsStandardOpenImmersion`.
 -/
 
+universe u
+
 namespace RingHom
 
 variable {R S T : Type*} [CommRing R] [CommRing S] [CommRing T] (f : R →+* S) (g : S →+* T)

--- a/Mathlib/RingTheory/RingHom/OpenImmersion.lean
+++ b/Mathlib/RingTheory/RingHom/OpenImmersion.lean
@@ -65,7 +65,7 @@ lemma isStandardOpenImmersion_algebraMap [Algebra R S] :
 
 namespace IsStandardOpenImmersion
 
-lemma algebraMap' [Algebra R S] (r : R) [IsLocalization.Away r S] :
+protected lemma algebraMap [Algebra R S] (r : R) [IsLocalization.Away r S] :
     (algebraMap R S).IsStandardOpenImmersion :=
   isStandardOpenImmersion_algebraMap.2 ⟨r, inferInstance⟩
 
@@ -107,7 +107,7 @@ theorem isStableUnderBaseChange : IsStableUnderBaseChange.{u} IsStandardOpenImme
 
 theorem holdsForLocalizationAway : HoldsForLocalizationAway.{u} IsStandardOpenImmersion := by
   introv R h
-  exact .algebraMap' r
+  exact .algebraMap r
 
 end IsStandardOpenImmersion
 

--- a/Mathlib/RingTheory/RingHom/OpenImmersion.lean
+++ b/Mathlib/RingTheory/RingHom/OpenImmersion.lean
@@ -8,7 +8,7 @@ import Mathlib.RingTheory.LocalProperties.Basic
 
 /-! # Standard Open Immersion
 
-We define the ring hom property `RingHom.IsStandardOpenImmersion` which is one that is a
+We define the property `RingHom.IsStandardOpenImmersion` on ring homomorphisms: it means that the morphism is a
 localization map away from some element. We also define the equivalent
 `Algebra.IsStandardOpenImmersion`.
 -/

--- a/Mathlib/RingTheory/RingHom/OpenImmersion.lean
+++ b/Mathlib/RingTheory/RingHom/OpenImmersion.lean
@@ -23,13 +23,11 @@ variable {R S T : Type*} [CommSemiring R] [CommSemiring S] [CommSemiring T]
   [Algebra R S] [Algebra R T]
 
 /-- A standard open immersion is one that is a localization map away from some element. -/
-@[mk_iff] class IsStandardOpenImmersion (R S : Type*) [CommRing R] [CommRing S]
+@[mk_iff] class IsStandardOpenImmersion (R S : Type*) [CommSemiring R] [CommSemiring S]
     [Algebra R S] : Prop where
   exists_away (R S) : ∃ r : R, IsLocalization.Away r S
 
-variable (R S) in
-theorem exists_away [IsStandardOpenImmersion R S] : ∃ r : R, IsLocalization.Away r S :=
-  IsStandardOpenImmersion.exists_away'
+open IsStandardOpenImmersion
 
 instance (r : R) : IsStandardOpenImmersion R (Localization.Away r) :=
   ⟨r, inferInstance⟩
@@ -44,7 +42,8 @@ variable (R S T) in
     .of_associated (associated_sec_fst r s).symm
   ⟨r * (sec r s).1, mul' S T r _⟩
 
-instance [IsStandardOpenImmersion R T] : IsStandardOpenImmersion S (TensorProduct R S T) :=
+open _root_.TensorProduct in
+instance [IsStandardOpenImmersion R T] : IsStandardOpenImmersion S (S ⊗[R] T) :=
   let ⟨r, _⟩ := exists_away R T
   ⟨algebraMap R S r, inferInstance⟩
 


### PR DESCRIPTION
We define the ring hom property `RingHom.IsStandardOpenImmersion` which is one that is a localization map away from some element.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
