### PR TITLE
[Merged by Bors] - feat(AlgebraicGeometry): jointly surjective topology

### DIFF
--- a/Mathlib/AlgebraicGeometry/Sites/MorphismProperty.lean
+++ b/Mathlib/AlgebraicGeometry/Sites/MorphismProperty.lean
@@ -83,24 +83,21 @@ def jointlySurjectivePretopology [IsJointlySurjectivePreserving ⊤] : Pretopolo
 /-- The jointly surjective topology on `Scheme` is defined by the same condition as the jointly
 surjective pretopology. -/
 def jointlySurjectiveTopology [IsJointlySurjectivePreserving ⊤] :
-    GrothendieckTopology Scheme.{u} where
-  sieves X s := jointlySurjectivePretopology X s
-  top_mem' X x := ⟨X, x, 𝟙 X, trivial, by simp⟩
-  pullback_stable' X B s b hs x := by
-    obtain ⟨-, y, -, ⟨Y, u, hu⟩, hyx⟩ := jointlySurjectivePretopology.pullbacks b s hs x
-    refine ⟨pullback u b, y, pullback.snd u b, ?_, hyx⟩
-    rw [Sieve.pullback_apply, ← pullback.condition]
-    exact s.downward_closed hu (pullback.fst u b)
-  transitive' X s hs t hst x :=
-    let ⟨Y, y, u, hsu, hyx⟩ := hs x
-    let ⟨Z, z, v, htv, hzy⟩ := hst hsu y
-    ⟨Z, z, v ≫ u, htv, by simp [hzy, hyx]⟩
+    GrothendieckTopology Scheme.{u} :=
+  jointlySurjectivePretopology.toGrothendieck.copy (fun X s ↦ jointlySurjectivePretopology X ↑s) <|
+    funext fun _ ↦ Set.ext fun s ↦
+      ⟨fun ⟨_, hp, hps⟩ x ↦ let ⟨Y, y, u, hu, hyx⟩ := hp x; ⟨Y, y, u, hps _ hu, hyx⟩,
+      fun hs ↦ ⟨s, hs, le_rfl⟩⟩
+
+theorem mem_jointlySurjectiveTopology_iff_jointlySurjectivePretopology
+    [IsJointlySurjectivePreserving ⊤] {X : Scheme.{u}} {s : Sieve X} :
+    s ∈ jointlySurjectiveTopology X ↔ jointlySurjectivePretopology X ↑s :=
+  Iff.rfl
 
 lemma jointlySurjectiveTopology_eq_toGrothendieck_jointlySurjectivePretopology
     [IsJointlySurjectivePreserving ⊤] :
     jointlySurjectiveTopology.{u} = jointlySurjectivePretopology.toGrothendieck :=
-  GrothendieckTopology.ext <| funext fun _ ↦ Set.ext fun s ↦ ⟨fun hs ↦ ⟨s, hs, le_rfl⟩,
-    fun ⟨_, hp, hps⟩ x ↦ let ⟨Y, y, u, hu, hyx⟩ := hp x; ⟨Y, y, u, hps _ hu, hyx⟩⟩
+  GrothendieckTopology.copy_eq
 
 lemma pretopology_le_inf [IsJointlySurjectivePreserving ⊤] :
     pretopology P ≤ jointlySurjectivePretopology ⊓ P.pretopology := by

--- a/Mathlib/AlgebraicGeometry/Sites/MorphismProperty.lean
+++ b/Mathlib/AlgebraicGeometry/Sites/MorphismProperty.lean
@@ -59,7 +59,7 @@ abbrev grothendieckTopology : GrothendieckTopology Scheme.{u} :=
 
 Note: The assumption `IsJointlySurjectivePreserving ⊤` is mathematically unneeded, and only here
 to reduce imports. To satisfy it, use `AlgebraicGeometry.Scheme.isJointlySurjectivePreserving`. -/
-def surjectiveFamiliesPretopology [IsJointlySurjectivePreserving ⊤] : Pretopology Scheme.{u} where
+def jointlySurjectivePretopology [IsJointlySurjectivePreserving ⊤] : Pretopology Scheme.{u} where
   coverings X S :=
     ∀ x : X, ∃ (Y : Scheme.{u}) (y : Y) (f : Y ⟶ X) (hf : S f), f.base y = x
   has_isos X Y f hf x := by
@@ -77,8 +77,33 @@ def surjectiveFamiliesPretopology [IsJointlySurjectivePreserving ⊤] : Pretopol
     use Z, z, g ≫ f
     simpa [hz, hy] using Presieve.bind_comp f hf hg
 
+@[deprecated (since := "2025-08-18")] alias surjectiveFamiliesPretopology :=
+  jointlySurjectivePretopology
+
+/-- The jointly surjective topology on `Scheme` is defined by the same condition as the jointly
+surjective pretopology. -/
+def jointlySurjectiveTopology [IsJointlySurjectivePreserving ⊤] :
+    GrothendieckTopology Scheme.{u} where
+  sieves X s := jointlySurjectivePretopology X s
+  top_mem' X x := ⟨X, x, 𝟙 X, trivial, by simp⟩
+  pullback_stable' X B s b hs x := by
+    obtain ⟨-, y, -, ⟨Y, u, hu⟩, hyx⟩ := jointlySurjectivePretopology.pullbacks b s hs x
+    refine ⟨pullback u b, y, pullback.snd u b, ?_, hyx⟩
+    rw [Sieve.pullback_apply, ← pullback.condition]
+    exact s.downward_closed hu (pullback.fst u b)
+  transitive' X s hs t hst x :=
+    let ⟨Y, y, u, hsu, hyx⟩ := hs x
+    let ⟨Z, z, v, htv, hzy⟩ := hst hsu y
+    ⟨Z, z, v ≫ u, htv, by simp [hzy, hyx]⟩
+
+lemma jointlySurjectiveTopology_eq_toGrothendieck_jointlySurjectivePretopology
+    [IsJointlySurjectivePreserving ⊤] :
+    jointlySurjectiveTopology.{u} = jointlySurjectivePretopology.toGrothendieck :=
+  GrothendieckTopology.ext <| funext fun _ ↦ Set.ext fun s ↦ ⟨fun hs ↦ ⟨s, hs, le_rfl⟩,
+    fun ⟨_, hp, hps⟩ x ↦ let ⟨Y, y, u, hu, hyx⟩ := hp x; ⟨Y, y, u, hps _ hu, hyx⟩⟩
+
 lemma pretopology_le_inf [IsJointlySurjectivePreserving ⊤] :
-    pretopology P ≤ surjectiveFamiliesPretopology ⊓ P.pretopology := by
+    pretopology P ≤ jointlySurjectivePretopology ⊓ P.pretopology := by
   rintro X S ⟨𝒰, rfl⟩
   refine ⟨fun x ↦ ?_, fun ⟨i⟩ ↦ 𝒰.map_prop i⟩
   obtain ⟨a, ha⟩ := 𝒰.covers x
@@ -94,7 +119,7 @@ in the intersection can have up to `Type (u + 1)` many components, while in the 
 of `AlgebraicGeometry.Scheme.pretopology` we only allow `Type u` many components.
 -/
 lemma grothendieckTopology_eq_inf [IsJointlySurjectivePreserving ⊤] :
-    grothendieckTopology P = (surjectiveFamiliesPretopology ⊓ P.pretopology).toGrothendieck := by
+    grothendieckTopology P = (jointlySurjectivePretopology ⊓ P.pretopology).toGrothendieck := by
   apply le_antisymm ((Pretopology.gi Scheme.{u}).gc.monotone_l (pretopology_le_inf P))
   intro X S ⟨T, ⟨hs, hP⟩, hle⟩
   let _ : Type (u + 1) := Presieve X

--- a/Mathlib/CategoryTheory/Sites/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Sites/Grothendieck.lean
@@ -138,10 +138,12 @@ def copy (J : GrothendieckTopology C) (s : ∀ X : C, Set (Sieve X)) (h : J.siev
   pullback_stable' := h ▸ J.pullback_stable'
   transitive' := h ▸ J.transitive'
 
+@[simp]
 theorem sieves_copy {J : GrothendieckTopology C} {s : ∀ X : C, Set (Sieve X)} {h : J.sieves = s} :
     (J.copy s h).sieves = s :=
   rfl
 
+@[simp]
 theorem coe_copy {J : GrothendieckTopology C} {s : ∀ X : C, Set (Sieve X)} {h : J.sieves = s} :
     ⇑(J.copy s h) = s :=
   rfl

--- a/Mathlib/CategoryTheory/Sites/Grothendieck.lean
+++ b/Mathlib/CategoryTheory/Sites/Grothendieck.lean
@@ -129,6 +129,27 @@ theorem transitive (hS : S ∈ J X) (R : Sieve X) (h : ∀ ⦃Y⦄ ⦃f : Y ⟶ 
 
 theorem covering_of_eq_top : S = ⊤ → S ∈ J X := fun h => h.symm ▸ J.top_mem X
 
+/-- Given a `GrothendieckTopology` and a set of sieves `s` that is equal, form a new
+`GrothendieckTopology` whose set of sieves is definitionally equal to `s`. -/
+def copy (J : GrothendieckTopology C) (s : ∀ X : C, Set (Sieve X)) (h : J.sieves = s) :
+    GrothendieckTopology C where
+  sieves := s
+  top_mem' := h ▸ J.top_mem'
+  pullback_stable' := h ▸ J.pullback_stable'
+  transitive' := h ▸ J.transitive'
+
+theorem sieves_copy {J : GrothendieckTopology C} {s : ∀ X : C, Set (Sieve X)} {h : J.sieves = s} :
+    (J.copy s h).sieves = s :=
+  rfl
+
+theorem coe_copy {J : GrothendieckTopology C} {s : ∀ X : C, Set (Sieve X)} {h : J.sieves = s} :
+    ⇑(J.copy s h) = s :=
+  rfl
+
+theorem copy_eq {J : GrothendieckTopology C} {s : ∀ X : C, Set (Sieve X)} {h : J.sieves = s} :
+    J.copy s h = J :=
+  GrothendieckTopology.ext h.symm
+
 /-- If `S` is a subset of `R`, and `S` is covering, then `R` is covering as well.
 
 See also discussion after [MM92] Chapter III, Section 2, Definition 1. -/


### PR DESCRIPTION
We define `jointlySurjectiveTopology` to have the same condition as `jointlySurjectivePretopology`, which is the new name of the former `surjectiveFamiliesPretopology`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
