### PR TITLE
[Merged by Bors] - chore: deprecate `Mathlib.Lean.Message`

### DIFF
--- a/Mathlib/Lean/Message.lean
+++ b/Mathlib/Lean/Message.lean
@@ -3,14 +3,7 @@ Copyright (c) 2022 Floris van Doorn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
-import Mathlib.Init
 import Lean.Message
+import Mathlib.Tactic.Linter.DeprecatedModule
 
-/-!
-# Additional operations on MessageData and related types
--/
-
-open Lean Std MessageData
-
-instance {α β : Type} [ToMessageData α] [ToMessageData β] : ToMessageData (α × β) :=
-  ⟨fun x => paren <| toMessageData x.1 ++ ofFormat "," ++ Format.line ++ toMessageData x.2⟩
+deprecated_module (since := "2025-08-18")


### PR DESCRIPTION
This PR deprecates a module which contained a single instance that is now present in `Lean.Message` as of https://github.com/leanprover/lean4/pull/2658 (v4.2.0).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
