### PR TITLE
feat(Logic/Basic): minor additions and simplification of proofs

### DIFF
--- a/Archive/Examples/IfNormalization/Result.lean
+++ b/Archive/Examples/IfNormalization/Result.lean
@@ -24,7 +24,7 @@ We add some local simp lemmas so we can unfold the definitions of the normalizat
 attribute [local simp] normalized hasNestedIf hasConstantIf hasRedundantIf disjoint vars
   List.disjoint
 
-attribute [local simp] apply_ite ite_eq_iff'
+attribute [local simp] apply_ite ite_eq_iff_and
 
 variable {b : Bool} {f : ℕ → Bool} {i : ℕ} {t e : IfExpr}
 
@@ -71,7 +71,7 @@ def normalize (l : AList (fun _ : ℕ => Bool)) :
       ⟨if t' = e' then t' else .ite (var v) t' e', by
         refine ⟨fun f => ?_, ?_, fun w b => ?_⟩
         · -- eval = eval
-          simp? says simp only [apply_ite, eval_ite_var, ite_eq_iff']
+          simp? says simp only [apply_ite, eval_ite_var, ite_eq_iff_and]
           cases hfv : f v
           · simp_all
             congr

--- a/Archive/Examples/IfNormalization/WithoutAesop.lean
+++ b/Archive/Examples/IfNormalization/WithoutAesop.lean
@@ -58,7 +58,7 @@ def normalize' (l : AList (fun _ : ℕ => Bool)) :
       have ⟨e', he₁, he₂, he₃⟩ := normalize' (l.insert v false) e
       ⟨if t' = e' then t' else .ite (var v) t' e', by
         refine ⟨fun f => ?_, ?_, fun w b => ?_⟩
-        · simp only [eval, apply_ite, ite_eq_iff']
+        · simp only [eval, apply_ite, ite_eq_iff_and]
           cases hfv : f v
           · simp +contextual only [cond_false, h, he₁]
             refine ⟨fun _ => ?_, fun _ => ?_⟩

--- a/Mathlib/Algebra/ContinuedFractions/Computation/Translations.lean
+++ b/Mathlib/Algebra/ContinuedFractions/Computation/Translations.lean
@@ -86,7 +86,7 @@ theorem succ_nth_stream_eq_some_iff {ifp_succ_n : IntFractPair K} :
       ∃ ifp_n : IntFractPair K,
         IntFractPair.stream v n = some ifp_n ∧
           ifp_n.fr ≠ 0 ∧ IntFractPair.of ifp_n.fr⁻¹ = ifp_succ_n := by
-  simp [IntFractPair.stream, ite_eq_iff, Option.bind_eq_some_iff]
+  simp [IntFractPair.stream, ite_eq_iff_or, Option.bind_eq_some_iff]
 
 /-- An easier to use version of one direction of
 `GenContFract.IntFractPair.succ_nth_stream_eq_some_iff`. -/

--- a/Mathlib/Algebra/MvPolynomial/Variables.lean
+++ b/Mathlib/Algebra/MvPolynomial/Variables.lean
@@ -328,7 +328,7 @@ lemma leadingCoeff_toLex : p.leadingCoeff toLex = p.coeff (ofLex <| p.supDegree 
 
 lemma supDegree_toLex_C (r : R) : supDegree toLex (C (σ := σ) r) = 0 := by
   classical
-    exact (supDegree_single _ r).trans (ite_eq_iff'.mpr ⟨fun _ => rfl, fun _ => rfl⟩)
+    exact (supDegree_single _ r).trans (ite_eq_iff_and.mpr ⟨fun _ => rfl, fun _ => rfl⟩)
 
 lemma leadingCoeff_toLex_C (r : R) : leadingCoeff toLex (C (σ := σ) r) = r :=
   leadingCoeff_single toLex.injective _ r

--- a/Mathlib/Algebra/Notation/Indicator.lean
+++ b/Mathlib/Algebra/Notation/Indicator.lean
@@ -271,7 +271,7 @@ alias mulIndicator_preimage_of_not_mem := mulIndicator_preimage_of_notMem
 @[to_additive]
 lemma mem_range_mulIndicator {r : M} {s : Set α} {f : α → M} :
     r ∈ range (mulIndicator s f) ↔ r = 1 ∧ s ≠ univ ∨ r ∈ f '' s := by
-  simp [mulIndicator, ite_eq_iff, exists_or, eq_univ_iff_forall, and_comm, or_comm,
+  simp [mulIndicator, ite_eq_iff_or, exists_or, eq_univ_iff_forall, and_comm, or_comm,
     @eq_comm _ r 1]
 
 @[to_additive]

--- a/Mathlib/LinearAlgebra/Matrix/Rank.lean
+++ b/Mathlib/LinearAlgebra/Matrix/Rank.lean
@@ -329,7 +329,7 @@ theorem cRank_diagonal [DecidableEq m] (w : m → R) :
   set w' : {i // (w i) ≠ 0} → _ := fun i ↦ (diagonal w) i
   have h : LinearIndependent R w' := by
     have hli' := Pi.linearIndependent_single_of_ne_zero (R := R)
-      (v := fun i : m ↦ if w i = 0 then (1 : R) else w i) (by simp [ite_eq_iff'])
+      (v := fun i : m ↦ if w i = 0 then (1 : R) else w i) (by simp [ite_eq_iff_and])
     convert hli'.comp Subtype.val Subtype.val_injective
     ext ⟨j, hj⟩ k
     simp [w', diagonal, hj, Pi.single_apply, eq_comm]

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -1000,18 +1000,8 @@ alias beq_eq_decide := Bool.beq_eq_decide_eq
 
 @[ext]
 theorem beq_ext {α : Type*} (inst1 : BEq α) (inst2 : BEq α)
-    (h : ∀ x y, @BEq.beq _ inst1 x y = @BEq.beq _ inst2 x y) :
-    inst1 = inst2 := by
-  have ⟨beq1⟩ := inst1
-  have ⟨beq2⟩ := inst2
-  congr
-  funext x y
-  exact h x y
+    (h : ∀ x y, @BEq.beq _ inst1 x y = @BEq.beq _ inst2 x y) : inst1 = inst2 :=
+  match inst1, inst2, funext₂ h with | ⟨_⟩, ⟨_⟩, rfl => rfl
 
 theorem lawful_beq_subsingleton {α : Type*} (inst1 : BEq α) (inst2 : BEq α)
-    [@LawfulBEq α inst1] [@LawfulBEq α inst2] :
-    inst1 = inst2 := by
-  apply beq_ext
-  intro x y
-  classical
-  simp only [beq_eq_decide]
+    [@LawfulBEq α inst1] [@LawfulBEq α inst2] : inst1 = inst2 := by ext; simp

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -803,7 +803,7 @@ section ite
 variable {α : Sort*} {σ : α → Sort*} {P Q R : Prop} [Decidable P]
   {a b c : α} {A : P → α} {B : ¬P → α}
 
-theorem apply_dite_iff_or (f : α → Prop) :
+theorem apply_dite_iff_exists (f : α → Prop) :
     f (dite P A B) ↔ (∃ h, f (A h)) ∨ (∃ h, f (B h)) := by
   by_cases h : P
   · rw [dif_pos h, exists_prop_of_true h, eq_false (exists_prop_of_false (· h)), or_false]
@@ -811,9 +811,9 @@ theorem apply_dite_iff_or (f : α → Prop) :
 
 theorem apply_ite_iff_or (f : α → Prop) :
     f (ite P a b) ↔ (P ∧ f a) ∨ (¬P ∧ f b) :=
-  .trans (apply_dite_iff_or f) (by simp only [exists_prop])
+  .trans (apply_dite_iff_exists f) (by simp only [exists_prop])
 
-theorem apply_dite_iff_and (f : α → Prop) :
+theorem apply_dite_iff_forall (f : α → Prop) :
     f (dite P A B) ↔ (∀ h, f (A h)) ∧ (∀ h, f (B h)) := by
   by_cases h : P
   · rw [dif_pos h, forall_prop_of_true h, forall_prop_of_false (· h), and_true]
@@ -821,32 +821,47 @@ theorem apply_dite_iff_and (f : α → Prop) :
 
 theorem apply_ite_iff_and (f : α → Prop) :
     f (ite P a b) ↔ (P → f a) ∧ (¬P → f b) :=
-  apply_dite_iff_and f
+  apply_dite_iff_forall f
 
--- in the future, we could possibly migrate the following names to the more descriptive
--- `dite_eq_iff_or` ..., `dite_eq_iff_and` ... rather than using `'`
+theorem dite_eq_iff_exists : dite P A B = c ↔ (∃ h, A h = c) ∨ ∃ h, B h = c :=
+  apply_dite_iff_exists (· = c)
 
-theorem dite_eq_iff : dite P A B = c ↔ (∃ h, A h = c) ∨ ∃ h, B h = c := apply_dite_iff_or (· = c)
+@[deprecated (since := "2025-08-29")] alias dite_eq_iff := dite_eq_iff_exists
 
-theorem eq_dite_iff : c = dite P A B ↔ (∃ h, c = A h) ∨ ∃ h, c = B h := apply_dite_iff_or (c = ·)
+theorem eq_dite_iff_exists : c = dite P A B ↔ (∃ h, c = A h) ∨ ∃ h, c = B h :=
+  apply_dite_iff_exists (c = ·)
 
-theorem ite_eq_iff : ite P a b = c ↔ P ∧ a = c ∨ ¬P ∧ b = c := apply_ite_iff_or (· = c)
+theorem ite_eq_iff_or : ite P a b = c ↔ P ∧ a = c ∨ ¬P ∧ b = c :=
+  apply_ite_iff_or (· = c)
 
-theorem eq_ite_iff : a = ite P b c ↔ P ∧ a = b ∨ ¬P ∧ a = c := apply_ite_iff_or (a = ·)
+@[deprecated (since := "2025-08-29")] alias ite_eq_iff := ite_eq_iff_or
 
-theorem dite_eq_iff' : dite P A B = c ↔ (∀ h, A h = c) ∧ ∀ h, B h = c := apply_dite_iff_and (· = c)
+theorem eq_ite_iff_or : a = ite P b c ↔ P ∧ a = b ∨ ¬P ∧ a = c :=
+  apply_ite_iff_or (a = ·)
 
-theorem eq_dite_iff' : c = dite P A B ↔ (∀ h, c = A h) ∧ ∀ h, c = B h := apply_dite_iff_and (c = ·)
+@[deprecated (since := "2025-08-29")] alias eq_ite_iff := eq_ite_iff_or
 
-theorem ite_eq_iff' : ite P a b = c ↔ (P → a = c) ∧ (¬P → b = c) := apply_ite_iff_and (· = c)
+theorem dite_eq_iff_forall : dite P A B = c ↔ (∀ h, A h = c) ∧ ∀ h, B h = c :=
+  apply_dite_iff_forall (· = c)
 
-theorem eq_ite_iff' : a = ite P b c ↔ (P → a = b) ∧ (¬P → a = c) := apply_ite_iff_and (a = ·)
+@[deprecated (since := "2025-08-29")] alias dite_eq_iff' := dite_eq_iff_forall
+
+theorem eq_dite_iff_forall : c = dite P A B ↔ (∀ h, c = A h) ∧ ∀ h, c = B h :=
+  apply_dite_iff_forall (c = ·)
+
+theorem ite_eq_iff_and : ite P a b = c ↔ (P → a = c) ∧ (¬P → b = c) :=
+  apply_ite_iff_and (· = c)
+
+@[deprecated (since := "2025-08-29")] alias ite_eq_iff' := ite_eq_iff_and
+
+theorem eq_ite_iff_and : a = ite P b c ↔ (P → a = b) ∧ (¬P → a = c) :=
+  apply_ite_iff_and (a = ·)
 
 theorem dite_ne_left_iff : dite P (fun _ ↦ a) B ≠ a ↔ ∃ h, a ≠ B h := by
-  simp [apply_dite_iff_or (· ≠ a), eq_comm]
+  simp [apply_dite_iff_exists (· ≠ a), eq_comm]
 
 theorem dite_ne_right_iff : (dite P A fun _ ↦ b) ≠ b ↔ ∃ h, A h ≠ b := by
-  simp [apply_dite_iff_or (· ≠ b)]
+  simp [apply_dite_iff_exists (· ≠ b)]
 
 theorem ite_ne_left_iff : ite P a b ≠ a ↔ ¬P ∧ a ≠ b :=
   dite_ne_left_iff.trans <| by rw [exists_prop]
@@ -855,10 +870,10 @@ theorem ite_ne_right_iff : ite P a b ≠ b ↔ P ∧ a ≠ b :=
   dite_ne_right_iff.trans <| by rw [exists_prop]
 
 protected theorem Ne.dite_eq_left_iff (h : ∀ h, a ≠ B h) : dite P (fun _ ↦ a) B = a ↔ P :=
-  by simp_all [apply_dite_iff_or (· = a), eq_comm]
+  by simp_all [apply_dite_iff_exists (· = a), eq_comm]
 
 protected theorem Ne.dite_eq_right_iff (h : ∀ h, A h ≠ b) : (dite P A fun _ ↦ b) = b ↔ ¬P :=
-  by simp_all [apply_dite_iff_or (· = b)]
+  by simp_all [apply_dite_iff_exists (· = b)]
 
 protected theorem Ne.ite_eq_left_iff (h : a ≠ b) : ite P a b = a ↔ P :=
   Ne.dite_eq_left_iff fun _ ↦ h
@@ -921,7 +936,7 @@ theorem ite_or : ite (P ∨ Q) a b = ite P a (ite Q a b) := by
 theorem dite_dite_comm {B : Q → α} {C : ¬P → ¬Q → α} (h : P → ¬Q) :
     (if p : P then A p else if q : Q then B q else C p q) =
      if q : Q then B q else if p : P then A p else C p q :=
-  dite_eq_iff'.2 ⟨
+  dite_eq_iff_forall.2 ⟨
     fun p ↦ by rw [dif_neg (h p), dif_pos p],
     fun np ↦ by congr; funext _; rw [dif_neg np]⟩
 
@@ -936,14 +951,18 @@ variable {P Q}
 
 theorem ite_prop_iff_or : (if P then Q else R) ↔ (P ∧ Q ∨ ¬P ∧ R) := apply_ite_iff_or id
 
-theorem dite_prop_iff_or {Q : P → Prop} {R : ¬P → Prop} :
-    dite P Q R ↔ (∃ p, Q p) ∨ (∃ p, R p) := apply_dite_iff_or id
+theorem dite_prop_iff_exists {Q : P → Prop} {R : ¬P → Prop} :
+    dite P Q R ↔ (∃ p, Q p) ∨ (∃ p, R p) := apply_dite_iff_exists id
+
+@[deprecated (since := "2025-08-29")] alias dite_prop_iff_or := dite_prop_iff_exists
 
 -- TODO make this a simp lemma in a future PR
 theorem ite_prop_iff_and : (if P then Q else R) ↔ ((P → Q) ∧ (¬P → R)) := apply_ite_iff_and id
 
-theorem dite_prop_iff_and {Q : P → Prop} {R : ¬P → Prop} :
-    dite P Q R ↔ (∀ h, Q h) ∧ (∀ h, R h) := apply_dite_iff_and id
+theorem dite_prop_iff_forall {Q : P → Prop} {R : ¬P → Prop} :
+    dite P Q R ↔ (∀ h, Q h) ∧ (∀ h, R h) := apply_dite_iff_forall id
+
+@[deprecated (since := "2025-08-29")] alias dite_prop_iff_and := dite_prop_iff_forall
 
 section congr
 
@@ -976,11 +995,11 @@ variable {α β : Type*} [Membership α β] {p : Prop} [Decidable p]
 
 theorem mem_dite {a : α} {s : p → β} {t : ¬p → β} :
     (a ∈ if h : p then s h else t h) ↔ (∀ h, a ∈ s h) ∧ (∀ h, a ∈ t h) :=
-  apply_dite_iff_and (a ∈ ·)
+  apply_dite_iff_forall (a ∈ ·)
 
 theorem dite_mem {a : p → α} {b : ¬p → α} {s : β} :
     (if h : p then a h else b h) ∈ s ↔ (∀ h, a h ∈ s) ∧ (∀ h, b h ∈ s) :=
-  apply_dite_iff_and (· ∈ s)
+  apply_dite_iff_forall (· ∈ s)
 
 theorem mem_ite {a : α} {s t : β} : (a ∈ if p then s else t) ↔ (p → a ∈ s) ∧ (¬p → a ∈ t) :=
   mem_dite

--- a/Mathlib/Logic/Basic.lean
+++ b/Mathlib/Logic/Basic.lean
@@ -803,27 +803,50 @@ section ite
 variable {α : Sort*} {σ : α → Sort*} {P Q R : Prop} [Decidable P]
   {a b c : α} {A : P → α} {B : ¬P → α}
 
-theorem dite_eq_iff : dite P A B = c ↔ (∃ h, A h = c) ∨ ∃ h, B h = c := by
-  by_cases P <;> simp [*, exists_prop_of_true, exists_prop_of_false]
+theorem apply_dite_iff_or (f : α → Prop) :
+    f (dite P A B) ↔ (∃ h, f (A h)) ∨ (∃ h, f (B h)) := by
+  by_cases h : P
+  · rw [dif_pos h, exists_prop_of_true h, eq_false (exists_prop_of_false (· h)), or_false]
+  · rw [dif_neg h, exists_prop_of_true h, eq_false (exists_prop_of_false    h),  false_or]
 
-theorem ite_eq_iff : ite P a b = c ↔ P ∧ a = c ∨ ¬P ∧ b = c :=
-  dite_eq_iff.trans <| by rw [exists_prop, exists_prop]
+theorem apply_ite_iff_or (f : α → Prop) :
+    f (ite P a b) ↔ (P ∧ f a) ∨ (¬P ∧ f b) :=
+  .trans (apply_dite_iff_or f) (by simp only [exists_prop])
 
-theorem eq_ite_iff : a = ite P b c ↔ P ∧ a = b ∨ ¬P ∧ a = c :=
-  eq_comm.trans <| ite_eq_iff.trans <| (Iff.rfl.and eq_comm).or (Iff.rfl.and eq_comm)
+theorem apply_dite_iff_and (f : α → Prop) :
+    f (dite P A B) ↔ (∀ h, f (A h)) ∧ (∀ h, f (B h)) := by
+  by_cases h : P
+  · rw [dif_pos h, forall_prop_of_true h, forall_prop_of_false (· h), and_true]
+  · rw [dif_neg h, forall_prop_of_true h, forall_prop_of_false    h,  true_and]
 
-theorem dite_eq_iff' : dite P A B = c ↔ (∀ h, A h = c) ∧ ∀ h, B h = c :=
-  ⟨fun he ↦ ⟨fun h ↦ (dif_pos h).symm.trans he, fun h ↦ (dif_neg h).symm.trans he⟩, fun he ↦
-    (em P).elim (fun h ↦ (dif_pos h).trans <| he.1 h) fun h ↦ (dif_neg h).trans <| he.2 h⟩
+theorem apply_ite_iff_and (f : α → Prop) :
+    f (ite P a b) ↔ (P → f a) ∧ (¬P → f b) :=
+  apply_dite_iff_and f
 
-theorem ite_eq_iff' : ite P a b = c ↔ (P → a = c) ∧ (¬P → b = c) := dite_eq_iff'
+-- in the future, we could possibly migrate the following names to the more descriptive
+-- `dite_eq_iff_or` ..., `dite_eq_iff_and` ... rather than using `'`
+
+theorem dite_eq_iff : dite P A B = c ↔ (∃ h, A h = c) ∨ ∃ h, B h = c := apply_dite_iff_or (· = c)
+
+theorem eq_dite_iff : c = dite P A B ↔ (∃ h, c = A h) ∨ ∃ h, c = B h := apply_dite_iff_or (c = ·)
+
+theorem ite_eq_iff : ite P a b = c ↔ P ∧ a = c ∨ ¬P ∧ b = c := apply_ite_iff_or (· = c)
+
+theorem eq_ite_iff : a = ite P b c ↔ P ∧ a = b ∨ ¬P ∧ a = c := apply_ite_iff_or (a = ·)
+
+theorem dite_eq_iff' : dite P A B = c ↔ (∀ h, A h = c) ∧ ∀ h, B h = c := apply_dite_iff_and (· = c)
+
+theorem eq_dite_iff' : c = dite P A B ↔ (∀ h, c = A h) ∧ ∀ h, c = B h := apply_dite_iff_and (c = ·)
+
+theorem ite_eq_iff' : ite P a b = c ↔ (P → a = c) ∧ (¬P → b = c) := apply_ite_iff_and (· = c)
+
+theorem eq_ite_iff' : a = ite P b c ↔ (P → a = b) ∧ (¬P → a = c) := apply_ite_iff_and (a = ·)
 
 theorem dite_ne_left_iff : dite P (fun _ ↦ a) B ≠ a ↔ ∃ h, a ≠ B h := by
-  rw [Ne, dite_eq_left_iff, not_forall]
-  exact exists_congr fun h ↦ by rw [ne_comm]
+  simp [apply_dite_iff_or (· ≠ a), eq_comm]
 
 theorem dite_ne_right_iff : (dite P A fun _ ↦ b) ≠ b ↔ ∃ h, A h ≠ b := by
-  simp only [Ne, dite_eq_right_iff, not_forall]
+  simp [apply_dite_iff_or (· ≠ b)]
 
 theorem ite_ne_left_iff : ite P a b ≠ a ↔ ¬P ∧ a ≠ b :=
   dite_ne_left_iff.trans <| by rw [exists_prop]
@@ -832,10 +855,10 @@ theorem ite_ne_right_iff : ite P a b ≠ b ↔ P ∧ a ≠ b :=
   dite_ne_right_iff.trans <| by rw [exists_prop]
 
 protected theorem Ne.dite_eq_left_iff (h : ∀ h, a ≠ B h) : dite P (fun _ ↦ a) B = a ↔ P :=
-  dite_eq_left_iff.trans ⟨fun H ↦ of_not_not fun h' ↦ h h' (H h').symm, fun h H ↦ (H h).elim⟩
+  by simp_all [apply_dite_iff_or (· = a), eq_comm]
 
 protected theorem Ne.dite_eq_right_iff (h : ∀ h, A h ≠ b) : (dite P A fun _ ↦ b) = b ↔ ¬P :=
-  dite_eq_right_iff.trans ⟨fun H h' ↦ h h' (H h'), fun h' H ↦ (h' H).elim⟩
+  by simp_all [apply_dite_iff_or (· = b)]
 
 protected theorem Ne.ite_eq_left_iff (h : a ≠ b) : ite P a b = a ↔ P :=
   Ne.dite_eq_left_iff fun _ ↦ h
@@ -911,20 +934,16 @@ end
 
 variable {P Q}
 
-theorem ite_prop_iff_or : (if P then Q else R) ↔ (P ∧ Q ∨ ¬P ∧ R) := by
-  by_cases p : P <;> simp [p]
+theorem ite_prop_iff_or : (if P then Q else R) ↔ (P ∧ Q ∨ ¬P ∧ R) := apply_ite_iff_or id
 
 theorem dite_prop_iff_or {Q : P → Prop} {R : ¬P → Prop} :
-    dite P Q R ↔ (∃ p, Q p) ∨ (∃ p, R p) := by
-  by_cases h : P <;> simp [h, exists_prop_of_false, exists_prop_of_true]
+    dite P Q R ↔ (∃ p, Q p) ∨ (∃ p, R p) := apply_dite_iff_or id
 
 -- TODO make this a simp lemma in a future PR
-theorem ite_prop_iff_and : (if P then Q else R) ↔ ((P → Q) ∧ (¬P → R)) := by
-  by_cases p : P <;> simp [p]
+theorem ite_prop_iff_and : (if P then Q else R) ↔ ((P → Q) ∧ (¬P → R)) := apply_ite_iff_and id
 
 theorem dite_prop_iff_and {Q : P → Prop} {R : ¬P → Prop} :
-    dite P Q R ↔ (∀ h, Q h) ∧ (∀ h, R h) := by
-  by_cases h : P <;> simp [h, forall_prop_of_false, forall_prop_of_true]
+    dite P Q R ↔ (∀ h, Q h) ∧ (∀ h, R h) := apply_dite_iff_and id
 
 section congr
 
@@ -956,12 +975,12 @@ section Membership
 variable {α β : Type*} [Membership α β] {p : Prop} [Decidable p]
 
 theorem mem_dite {a : α} {s : p → β} {t : ¬p → β} :
-    (a ∈ if h : p then s h else t h) ↔ (∀ h, a ∈ s h) ∧ (∀ h, a ∈ t h) := by
-  by_cases h : p <;> simp [h]
+    (a ∈ if h : p then s h else t h) ↔ (∀ h, a ∈ s h) ∧ (∀ h, a ∈ t h) :=
+  apply_dite_iff_and (a ∈ ·)
 
 theorem dite_mem {a : p → α} {b : ¬p → α} {s : β} :
-    (if h : p then a h else b h) ∈ s ↔ (∀ h, a h ∈ s) ∧ (∀ h, b h ∈ s) := by
-  by_cases h : p <;> simp [h]
+    (if h : p then a h else b h) ∈ s ↔ (∀ h, a h ∈ s) ∧ (∀ h, b h ∈ s) :=
+  apply_dite_iff_and (· ∈ s)
 
 theorem mem_ite {a : α} {s t : β} : (a ∈ if p then s else t) ↔ (p → a ∈ s) ∧ (¬p → a ∈ t) :=
   mem_dite

--- a/Mathlib/MeasureTheory/Measure/WithDensity.lean
+++ b/Mathlib/MeasureTheory/Measure/WithDensity.lean
@@ -619,7 +619,7 @@ instance Measure.withDensity.instSFinite [SFinite μ] {f : α → ℝ≥0∞} :
       else simp [hx]
   have : SigmaFinite (μ.withDensity (sᶜ.indicator f)) := by
     refine SigmaFinite.withDensity_of_ne_top <| ae_of_all _ fun x hx ↦ ?_
-    simp [indicator_apply, ite_eq_iff, s] at hx
+    simp [indicator_apply, ite_eq_iff_or, s] at hx
   have : SigmaFinite (μ.withDensity (s.indicator 1)) := by
     rw [withDensity_indicator hs]
     exact SigmaFinite.withDensity 1

--- a/Mathlib/SetTheory/Ordinal/Notation.lean
+++ b/Mathlib/SetTheory/Ordinal/Notation.lean
@@ -289,22 +289,22 @@ theorem cmp_compares : ∀ (a b : ONote) [NF a] [NF b], (cmp a b).Compares a b
     case eq =>
       intro IHe; dsimp at IHe; subst IHe
       unfold _root_.cmp; cases nh : cmpUsing (· < ·) (n₁ : ℕ) n₂ <;>
-      rw [cmpUsing, ite_eq_iff, not_lt] at nh
+      rw [cmpUsing, ite_eq_iff_or, not_lt] at nh
       case lt =>
         rcases nh with nh | nh
         · exact oadd_lt_oadd_2 h₁ nh.left
-        · rw [ite_eq_iff] at nh; rcases nh.right with nh | nh <;> cases nh <;> contradiction
+        · rw [ite_eq_iff_or] at nh; rcases nh.right with nh | nh <;> cases nh <;> contradiction
       case gt =>
         rcases nh with nh | nh
         · cases nh; contradiction
         · obtain ⟨_, nh⟩ := nh
-          rw [ite_eq_iff] at nh; rcases nh with nh | nh
+          rw [ite_eq_iff_or] at nh; rcases nh with nh | nh
           · exact oadd_lt_oadd_2 h₂ nh.left
           · cases nh; contradiction
       rcases nh with nh | nh
       · cases nh; contradiction
       obtain ⟨nhl, nhr⟩ := nh
-      rw [ite_eq_iff] at nhr
+      rw [ite_eq_iff_or] at nhr
       rcases nhr with nhr | nhr
       · cases nhr; contradiction
       obtain rfl := Subtype.eq (nhl.eq_of_not_lt nhr.1)


### PR DESCRIPTION
Add new theorems and simplify proofs.
Specifically, we add the family of related theorems `apply_dite_iff_exists`, `apply_dite_iff_forall`, `apply_ite_iff_and` and `apply_ite_iff_or`.
For each other 'family' of theorems in the file that is analogous to the above, we do the following
- Simplify proofs where possible, e.g. by appealing to the new theorems
- Complete the family, if any of the corresponding four are missing
- Rename to ensure consistency with the above pattern

---
