### PR TITLE
[Merged by Bors] - chore(Tactic/NormNum): make clear the current signature of the `core` functions

### DIFF
--- a/Mathlib/Tactic/NormNum/Basic.lean
+++ b/Mathlib/Tactic/NormNum/Basic.lean
@@ -223,6 +223,67 @@ def _root_.Mathlib.Meta.monadLiftOptionMetaM : MonadLift Option MetaM where
   | some e => pure e
 
 attribute [local instance] monadLiftOptionMetaM in
+/-- Main part of `evalAdd`. -/
+def evalAdd.core {u : Level} {α : Q(Type u)} (e : Q(«$α»)) (f : Q(«$α» → «$α» → «$α»))
+    (a b : Q(«$α»)) (ra : Result a) (rb : Result b) : MetaM (Result e) := do
+  let rec intArm (rα : Q(Ring $α)) := do
+    haveI' : $e =Q $a + $b := ⟨⟩
+    let ⟨za, na, pa⟩ ← ra.toInt _; let ⟨zb, nb, pb⟩ ← rb.toInt _
+    haveI' : $f =Q HAdd.hAdd := ⟨⟩
+    let zc := za + zb
+    have c := mkRawIntLit zc
+    haveI' : Int.add $na $nb =Q $c := ⟨⟩
+    return .isInt rα c zc q(isInt_add (f := $f) (.refl $f) $pa $pb (.refl $c))
+  let rec nnratArm (dsα : Q(DivisionSemiring $α)) : Option (Result _) := do
+    haveI' : $e =Q $a + $b := ⟨⟩
+    haveI' : $f =Q HAdd.hAdd := ⟨⟩
+    let ⟨qa, na, da, pa⟩ ← ra.toNNRat' dsα; let ⟨qb, nb, db, pb⟩ ← rb.toNNRat' dsα
+    let qc := qa + qb
+    let dd := qa.den * qb.den
+    let k := dd / qc.den
+    have t1 : Q(ℕ) := mkRawNatLit (k * qc.num.toNat)
+    have t2 : Q(ℕ) := mkRawNatLit dd
+    have nc : Q(ℕ) := mkRawNatLit qc.num.toNat
+    have dc : Q(ℕ) := mkRawNatLit qc.den
+    have k : Q(ℕ) := mkRawNatLit k
+    let r1 : Q(Nat.add (Nat.mul $na $db) (Nat.mul $nb $da) = Nat.mul $k $nc) :=
+      (q(Eq.refl $t1) : Expr)
+    let r2 : Q(Nat.mul $da $db = Nat.mul $k $dc) := (q(Eq.refl $t2) : Expr)
+    return .isNNRat' dsα qc nc dc q(isNNRat_add (f := $f) (.refl $f) $pa $pb $r1 $r2)
+  let rec ratArm (dα : Q(DivisionRing $α)) : Option (Result _) := do
+    haveI' : $e =Q $a + $b := ⟨⟩
+    haveI' : $f =Q HAdd.hAdd := ⟨⟩
+    let ⟨qa, na, da, pa⟩ ← ra.toRat' dα; let ⟨qb, nb, db, pb⟩ ← rb.toRat' dα
+    let qc := qa + qb
+    let dd := qa.den * qb.den
+    let k := dd / qc.den
+    have t1 : Q(ℤ) := mkRawIntLit (k * qc.num)
+    have t2 : Q(ℕ) := mkRawNatLit dd
+    have nc : Q(ℤ) := mkRawIntLit qc.num
+    have dc : Q(ℕ) := mkRawNatLit qc.den
+    have k : Q(ℕ) := mkRawNatLit k
+    let r1 : Q(Int.add (Int.mul $na $db) (Int.mul $nb $da) = Int.mul $k $nc) :=
+      (q(Eq.refl $t1) : Expr)
+    let r2 : Q(Nat.mul $da $db = Nat.mul $k $dc) := (q(Eq.refl $t2) : Expr)
+    return .isRat dα qc nc dc q(isRat_add (f := $f) (.refl $f) $pa $pb $r1 $r2)
+  match ra, rb with
+  | .isBool .., _ | _, .isBool .. => failure
+  | .isNegNNRat dα .., _ | _, .isNegNNRat dα .. => ratArm dα
+  -- mixing positive rationals and negative naturals means we need to use the full rat handler
+  | .isNNRat _dsα .., .isNegNat _rα .. | .isNegNat _rα .., .isNNRat _dsα .. =>
+    -- could alternatively try to combine `rα` and `dsα` here, but we'd have to do a defeq check
+    -- so would still need to be in `MetaM`.
+    ratArm (←synthInstanceQ q(DivisionRing $α))
+  | .isNNRat dsα .., _ | _, .isNNRat dsα .. => nnratArm dsα
+  | .isNegNat rα .., _ | _, .isNegNat rα .. => intArm rα
+  | .isNat _ na pa, .isNat sα nb pb =>
+    haveI' : $e =Q $a + $b := ⟨⟩
+    haveI' : $f =Q HAdd.hAdd := ⟨⟩
+    assumeInstancesCommute
+    have c : Q(ℕ) := mkRawNatLit (na.natLit! + nb.natLit!)
+    haveI' : Nat.add $na $nb =Q $c := ⟨⟩
+    return .isNat sα c q(isNat_add (f := $f) (.refl $f) $pa $pb (.refl $c))
+
 /-- The `norm_num` extension which identifies expressions of the form `a + b`,
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num _ + _] def evalAdd : NormNumExt where eval {u α} e := do
@@ -239,67 +300,7 @@ such that `norm_num` successfully recognises both `a` and `b`. -/
   | .isNegNNRat _ .., .isNat _ .. | .isNegNNRat _ .., .isNegNat _ ..
     | .isNegNNRat _ .., .isNNRat _ .. | .isNegNNRat _ .., .isNegNNRat _ .. =>
     guard <|← withNewMCtxDepth <| isDefEq f q(HAdd.hAdd (α := $α))
-  let rec
-  /-- Main part of `evalAdd`. -/
-  core : MetaM (Result e) := do
-    let rec intArm (rα : Q(Ring $α)) := do
-      haveI' : $e =Q $a + $b := ⟨⟩
-      let ⟨za, na, pa⟩ ← ra.toInt _; let ⟨zb, nb, pb⟩ ← rb.toInt _
-      haveI' : $f =Q HAdd.hAdd := ⟨⟩
-      let zc := za + zb
-      have c := mkRawIntLit zc
-      haveI' : Int.add $na $nb =Q $c := ⟨⟩
-      return .isInt rα c zc q(isInt_add (f := $f) (.refl $f) $pa $pb (.refl $c))
-    let rec nnratArm (dsα : Q(DivisionSemiring $α)) : Option (Result _) := do
-      haveI' : $e =Q $a + $b := ⟨⟩
-      haveI' : $f =Q HAdd.hAdd := ⟨⟩
-      let ⟨qa, na, da, pa⟩ ← ra.toNNRat' dsα; let ⟨qb, nb, db, pb⟩ ← rb.toNNRat' dsα
-      let qc := qa + qb
-      let dd := qa.den * qb.den
-      let k := dd / qc.den
-      have t1 : Q(ℕ) := mkRawNatLit (k * qc.num.toNat)
-      have t2 : Q(ℕ) := mkRawNatLit dd
-      have nc : Q(ℕ) := mkRawNatLit qc.num.toNat
-      have dc : Q(ℕ) := mkRawNatLit qc.den
-      have k : Q(ℕ) := mkRawNatLit k
-      let r1 : Q(Nat.add (Nat.mul $na $db) (Nat.mul $nb $da) = Nat.mul $k $nc) :=
-        (q(Eq.refl $t1) : Expr)
-      let r2 : Q(Nat.mul $da $db = Nat.mul $k $dc) := (q(Eq.refl $t2) : Expr)
-      return .isNNRat' dsα qc nc dc q(isNNRat_add (f := $f) (.refl $f) $pa $pb $r1 $r2)
-    let rec ratArm (dα : Q(DivisionRing $α)) : Option (Result _) := do
-      haveI' : $e =Q $a + $b := ⟨⟩
-      haveI' : $f =Q HAdd.hAdd := ⟨⟩
-      let ⟨qa, na, da, pa⟩ ← ra.toRat' dα; let ⟨qb, nb, db, pb⟩ ← rb.toRat' dα
-      let qc := qa + qb
-      let dd := qa.den * qb.den
-      let k := dd / qc.den
-      have t1 : Q(ℤ) := mkRawIntLit (k * qc.num)
-      have t2 : Q(ℕ) := mkRawNatLit dd
-      have nc : Q(ℤ) := mkRawIntLit qc.num
-      have dc : Q(ℕ) := mkRawNatLit qc.den
-      have k : Q(ℕ) := mkRawNatLit k
-      let r1 : Q(Int.add (Int.mul $na $db) (Int.mul $nb $da) = Int.mul $k $nc) :=
-        (q(Eq.refl $t1) : Expr)
-      let r2 : Q(Nat.mul $da $db = Nat.mul $k $dc) := (q(Eq.refl $t2) : Expr)
-      return .isRat dα qc nc dc q(isRat_add (f := $f) (.refl $f) $pa $pb $r1 $r2)
-    match ra, rb with
-    | .isBool .., _ | _, .isBool .. => failure
-    | .isNegNNRat dα .., _ | _, .isNegNNRat dα .. => ratArm dα
-    -- mixing positive rationals and negative naturals means we need to use the full rat handler
-    | .isNNRat dsα .., .isNegNat rα .. | .isNegNat rα .., .isNNRat dsα .. =>
-      -- could alternatively try to combine `rα` and `dsα` here, but we'd have to do a defeq check
-      -- so would still need to be in `MetaM`.
-      ratArm (←synthInstanceQ q(DivisionRing $α))
-    | .isNNRat dsα .., _ | _, .isNNRat dsα .. => nnratArm dsα
-    | .isNegNat rα .., _ | _, .isNegNat rα .. => intArm rα
-    | .isNat _ na pa, .isNat sα nb pb =>
-      haveI' : $e =Q $a + $b := ⟨⟩
-      haveI' : $f =Q HAdd.hAdd := ⟨⟩
-      assumeInstancesCommute
-      have c : Q(ℕ) := mkRawNatLit (na.natLit! + nb.natLit!)
-      haveI' : Nat.add $na $nb =Q $c := ⟨⟩
-      return .isNat sα c q(isNat_add (f := $f) (.refl $f) $pa $pb (.refl $c))
-  core
+  evalAdd.core q($e) q($f) q($a) q($b) ra rb
 
 -- see note [norm_num lemma function equality]
 theorem isInt_neg {α} [Ring α] : ∀ {f : α → α} {a : α} {a' b : ℤ},
@@ -312,6 +313,32 @@ theorem isRat_neg {α} [Ring α] : ∀ {f : α → α} {a : α} {n n' : ℤ} {d 
   | _, _, _, _, _, rfl, ⟨h, rfl⟩, rfl => ⟨h, by rw [← neg_mul, ← Int.cast_neg]; rfl⟩
 
 attribute [local instance] monadLiftOptionMetaM in
+/-- Main part of `evalNeg`. -/
+def evalNeg.core {u : Level} {α : Q(Type u)} (e : Q(«$α»)) (f : Q(«$α» → «$α»)) (a : Q(«$α»))
+    (ra : Result a) (rα : Q(Ring «$α»)) : MetaM (Result e) := do
+  have : $f =Q Neg.neg := ⟨⟩
+  haveI' _e_eq : $e =Q -$a := ⟨⟩
+  let intArm (rα : Q(Ring $α)) := do
+    assumeInstancesCommute
+    let ⟨za, na, pa⟩ ← ra.toInt rα
+    let zb := -za
+    have b := mkRawIntLit zb
+    haveI' : Int.neg $na =Q $b := ⟨⟩
+    return .isInt rα b zb q(isInt_neg (f := $f) (.refl $f) $pa (.refl $b))
+  let ratArm (dα : Q(DivisionRing $α)) : Option (Result _) := do
+    assumeInstancesCommute
+    let ⟨qa, na, da, pa⟩ ← ra.toRat' dα
+    let qb := -qa
+    have nb := mkRawIntLit qb.num
+    haveI' : Int.neg $na =Q $nb := ⟨⟩
+    return .isRat dα qb nb da q(isRat_neg (f := $f) (.refl $f) $pa (.refl $nb))
+  match ra with
+  | .isBool _ .. => failure
+  | .isNat _ .. => intArm rα
+  | .isNegNat rα .. => intArm rα
+  | .isNNRat _dsα .. => ratArm (← synthInstanceQ q(DivisionRing $α))
+  | .isNegNNRat dα .. => ratArm dα
+
 /-- The `norm_num` extension which identifies expressions of the form `-a`,
 such that `norm_num` successfully recognises `a`. -/
 @[norm_num -_] def evalNeg : NormNumExt where eval {u α} e := do
@@ -319,31 +346,7 @@ such that `norm_num` successfully recognises `a`. -/
   let ra ← derive a
   let rα ← inferRing α
   let ⟨(_f_eq : $f =Q Neg.neg)⟩ ← withNewMCtxDepth <| assertDefEqQ _ _
-  haveI' _e_eq : $e =Q -$a := ⟨⟩
-  let rec
-  /-- Main part of `evalNeg`. -/
-  core : MetaM (Result e) := do
-    let intArm (rα : Q(Ring $α)) := do
-      assumeInstancesCommute
-      let ⟨za, na, pa⟩ ← ra.toInt rα
-      let zb := -za
-      have b := mkRawIntLit zb
-      haveI' : Int.neg $na =Q $b := ⟨⟩
-      return .isInt rα b zb q(isInt_neg (f := $f) (.refl $f) $pa (.refl $b))
-    let ratArm (dα : Q(DivisionRing $α)) : Option (Result _) := do
-      assumeInstancesCommute
-      let ⟨qa, na, da, pa⟩ ← ra.toRat' dα
-      let qb := -qa
-      have nb := mkRawIntLit qb.num
-      haveI' : Int.neg $na =Q $nb := ⟨⟩
-      return .isRat dα qb nb da q(isRat_neg (f := $f) (.refl $f) $pa (.refl $nb))
-    match ra with
-    | .isBool _ .. => failure
-    | .isNat _ .. => intArm rα
-    | .isNegNat rα .. => intArm rα
-    | .isNNRat _dsα .. => ratArm (← synthInstanceQ q(DivisionRing $α))
-    | .isNegNNRat dα .. => ratArm dα
-  core
+  evalNeg.core q($e) q($f) q($a) ra rα
 
 -- see note [norm_num lemma function equality]
 theorem isInt_sub {α} [Ring α] : ∀ {f : α → α → α} {a b : α} {a' b' c : ℤ},
@@ -361,6 +364,42 @@ theorem isRat_sub {α} [Ring α] {f : α → α → α} {a b : α} {na nb nc : �
   rw [show Int.mul (-nb) _ = _ from neg_mul ..]; exact h₁
 
 attribute [local instance] monadLiftOptionMetaM in
+/-- Main part of `evalSub`. -/
+def evalSub.core {u : Level} {α : Q(Type u)} (e : Q(«$α»)) (f : Q(«$α» → «$α» → «$α»))
+    (a b : Q(«$α»)) (rα : Q(Ring «$α»)) (ra : Result a) (rb : Result b) : MetaM (Result e) := do
+  have : $f =Q HSub.hSub := ⟨⟩
+  haveI' _e_eq : $e =Q $a - $b := ⟨⟩
+  let intArm (rα : Q(Ring $α)) := do
+    assumeInstancesCommute
+    let ⟨za, na, pa⟩ ← ra.toInt rα; let ⟨zb, nb, pb⟩ ← rb.toInt rα
+    let zc := za - zb
+    have c := mkRawIntLit zc
+    haveI' : Int.sub $na $nb =Q $c := ⟨⟩
+    return Result.isInt rα c zc q(isInt_sub (f := $f) (.refl $f) $pa $pb (.refl $c))
+  let ratArm (dα : Q(DivisionRing $α)) : Option (Result _) := do
+    assumeInstancesCommute
+    let ⟨qa, na, da, pa⟩ ← ra.toRat' dα; let ⟨qb, nb, db, pb⟩ ← rb.toRat' dα
+    let qc := qa - qb
+    let dd := qa.den * qb.den
+    let k := dd / qc.den
+    have t1 : Q(ℤ) := mkRawIntLit (k * qc.num)
+    have t2 : Q(ℕ) := mkRawNatLit dd
+    have nc : Q(ℤ) := mkRawIntLit qc.num
+    have dc : Q(ℕ) := mkRawNatLit qc.den
+    have k : Q(ℕ) := mkRawNatLit k
+    let r1 : Q(Int.sub (Int.mul $na $db) (Int.mul $nb $da) = Int.mul $k $nc) :=
+      (q(Eq.refl $t1) : Expr)
+    let r2 : Q(Nat.mul $da $db = Nat.mul $k $dc) := (q(Eq.refl $t2) : Expr)
+    return .isRat dα qc nc dc q(isRat_sub (f := $f) (.refl $f) $pa $pb $r1 $r2)
+  match ra, rb with
+  | .isBool .., _ | _, .isBool .. => failure
+  | .isNegNNRat dα .., _ | _, .isNegNNRat dα .. =>
+    ratArm dα
+  | _, .isNNRat _dsα .. | .isNNRat _dsα .., _ =>
+    ratArm (← synthInstanceQ q(DivisionRing $α))
+  | .isNegNat rα .., _ | _, .isNegNat rα ..
+  | .isNat _ .., .isNat _ .. => intArm rα
+
 /-- The `norm_num` extension which identifies expressions of the form `a - b` in a ring,
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num _ - _] def evalSub : NormNumExt where eval {u α} e := do
@@ -369,40 +408,7 @@ such that `norm_num` successfully recognises both `a` and `b`. -/
   let ⟨(_f_eq : $f =Q HSub.hSub)⟩ ← withNewMCtxDepth <| assertDefEqQ _ _
   let ra ← derive a; let rb ← derive b
   haveI' _e_eq : $e =Q $a - $b := ⟨⟩
-  let rec
-  /-- Main part of `evalSub`. -/
-  core : MetaM (Result e) := do
-    let intArm (rα : Q(Ring $α)) := do
-      assumeInstancesCommute
-      let ⟨za, na, pa⟩ ← ra.toInt rα; let ⟨zb, nb, pb⟩ ← rb.toInt rα
-      let zc := za - zb
-      have c := mkRawIntLit zc
-      haveI' : Int.sub $na $nb =Q $c := ⟨⟩
-      return Result.isInt rα c zc q(isInt_sub (f := $f) (.refl $f) $pa $pb (.refl $c))
-    let ratArm (dα : Q(DivisionRing $α)) : Option (Result _) := do
-      assumeInstancesCommute
-      let ⟨qa, na, da, pa⟩ ← ra.toRat' dα; let ⟨qb, nb, db, pb⟩ ← rb.toRat' dα
-      let qc := qa - qb
-      let dd := qa.den * qb.den
-      let k := dd / qc.den
-      have t1 : Q(ℤ) := mkRawIntLit (k * qc.num)
-      have t2 : Q(ℕ) := mkRawNatLit dd
-      have nc : Q(ℤ) := mkRawIntLit qc.num
-      have dc : Q(ℕ) := mkRawNatLit qc.den
-      have k : Q(ℕ) := mkRawNatLit k
-      let r1 : Q(Int.sub (Int.mul $na $db) (Int.mul $nb $da) = Int.mul $k $nc) :=
-        (q(Eq.refl $t1) : Expr)
-      let r2 : Q(Nat.mul $da $db = Nat.mul $k $dc) := (q(Eq.refl $t2) : Expr)
-      return .isRat dα qc nc dc q(isRat_sub (f := $f) (.refl $f) $pa $pb $r1 $r2)
-    match ra, rb with
-    | .isBool .., _ | _, .isBool .. => failure
-    | .isNegNNRat dα .., _ | _, .isNegNNRat dα .. =>
-      ratArm dα
-    | _, .isNNRat _dsα .. | .isNNRat _dsα .., _ =>
-      ratArm (← synthInstanceQ q(DivisionRing $α))
-    | .isNegNat rα .., _ | _, .isNegNat rα ..
-    | .isNat _ .., .isNat _ .. => intArm rα
-  core
+  evalSub.core q($e) q($f) q($a) q($b) q($rα) ra rb
 
 -- see note [norm_num lemma function equality]
 theorem isNat_mul {α} [Semiring α] : ∀ {f : α → α → α} {a b : α} {a' b' c : ℕ},
@@ -455,6 +461,65 @@ theorem isRat_mul {α} [Ring α] {f : α → α → α} {a b : α} {na nb nc : �
     (Nat.cast_commute (α := α) db dc).invOf_left.invOf_right.right_comm]
 
 attribute [local instance] monadLiftOptionMetaM in
+/-- Main part of `evalMul`. -/
+def evalMul.core {u : Level} {α : Q(Type u)} (e : Q(«$α»)) (f : Q(«$α» → «$α» → «$α»))
+    (a b : Q(«$α»)) (sα : Q(Semiring «$α»)) (ra : Result a) (rb : Result b) : MetaM (Result e) := do
+  haveI' : $f =Q HMul.hMul := ⟨⟩
+  haveI' : $e =Q $a * $b := ⟨⟩
+  let rec intArm (rα : Q(Ring $α)) := do
+    assumeInstancesCommute
+    let ⟨za, na, pa⟩ ← ra.toInt rα; let ⟨zb, nb, pb⟩ ← rb.toInt rα
+    let zc := za * zb
+    have c := mkRawIntLit zc
+    haveI' : Int.mul $na $nb =Q $c := ⟨⟩
+    return .isInt rα c zc q(isInt_mul (f := $f) (.refl $f) $pa $pb (.refl $c))
+  let rec nnratArm (dsα : Q(DivisionSemiring $α)) : Option (Result _) := do
+    assumeInstancesCommute
+    let ⟨qa, na, da, pa⟩ ← ra.toNNRat' dsα; let ⟨qb, nb, db, pb⟩ ← rb.toNNRat' dsα
+    let qc := qa * qb
+    let dd := qa.den * qb.den
+    let k := dd / qc.den
+    have nc : Q(ℕ) := mkRawNatLit qc.num.toNat
+    have dc : Q(ℕ) := mkRawNatLit qc.den
+    have k : Q(ℕ) := mkRawNatLit k
+    let r1 : Q(Nat.mul $na $nb = Nat.mul $k $nc) :=
+      (q(Eq.refl (Nat.mul $na $nb)) : Expr)
+    have t2 : Q(ℕ) := mkRawNatLit dd
+    let r2 : Q(Nat.mul $da $db = Nat.mul $k $dc) := (q(Eq.refl $t2) : Expr)
+    return .isNNRat' dsα qc nc dc q(isNNRat_mul (f := $f) (.refl $f) $pa $pb $r1 $r2)
+  let rec ratArm (dα : Q(DivisionRing $α)) : Option (Result _) := do
+    assumeInstancesCommute
+    let ⟨qa, na, da, pa⟩ ← ra.toRat' dα; let ⟨qb, nb, db, pb⟩ ← rb.toRat' dα
+    let qc := qa * qb
+    let dd := qa.den * qb.den
+    let k := dd / qc.den
+    have nc : Q(ℤ) := mkRawIntLit qc.num
+    have dc : Q(ℕ) := mkRawNatLit qc.den
+    have k : Q(ℕ) := mkRawNatLit k
+    let r1 : Q(Int.mul $na $nb = Int.mul $k $nc) :=
+      (q(Eq.refl (Int.mul $na $nb)) : Expr)
+    have t2 : Q(ℕ) := mkRawNatLit dd
+    let r2 : Q(Nat.mul $da $db = Nat.mul $k $dc) := (q(Eq.refl $t2) : Expr)
+    return .isRat dα qc nc dc q(isRat_mul (f := $f) (.refl $f) $pa $pb $r1 $r2)
+  match ra, rb with
+  | .isBool .., _ | _, .isBool .. => failure
+  | .isNegNNRat dα .., _ | _, .isNegNNRat dα .. =>
+    ratArm dα
+  -- mixing positive rationals and negative naturals means we need to use the full rat handler
+  | .isNNRat dsα .., .isNegNat rα .. | .isNegNat rα .., .isNNRat dsα .. =>
+    -- could alternatively try to combine `rα` and `dsα` here, but we'd have to do a defeq check
+    -- so would still need to be in `MetaM`.
+    ratArm (←synthInstanceQ q(DivisionRing $α))
+  | .isNNRat dsα .., _ | _, .isNNRat dsα .. =>
+    nnratArm dsα
+  | .isNegNat rα .., _ | _, .isNegNat rα .. => intArm rα
+  | .isNat mα' na pa, .isNat mα nb pb =>
+    haveI' : $mα =Q by clear! $mα $mα'; apply AddCommMonoidWithOne.toAddMonoidWithOne := ⟨⟩
+    assumeInstancesCommute
+    have c : Q(ℕ) := mkRawNatLit (na.natLit! * nb.natLit!)
+    haveI' : Nat.mul $na $nb =Q $c := ⟨⟩
+    return .isNat mα c q(isNat_mul (f := $f) (.refl $f) $pa $pb (.refl $c))
+
 /-- The `norm_num` extension which identifies expressions of the form `a * b`,
 such that `norm_num` successfully recognises both `a` and `b`. -/
 @[norm_num _ * _] def evalMul : NormNumExt where eval {u α} e := do
@@ -464,63 +529,7 @@ such that `norm_num` successfully recognises both `a` and `b`. -/
   guard <|← withNewMCtxDepth <| isDefEq f q(HMul.hMul (α := $α))
   haveI' : $f =Q HMul.hMul := ⟨⟩
   haveI' : $e =Q $a * $b := ⟨⟩
-  let rec
-  /-- Main part of `evalMul`. -/
-  core : MetaM (Result e) := do
-    let rec intArm (rα : Q(Ring $α)) := do
-      assumeInstancesCommute
-      let ⟨za, na, pa⟩ ← ra.toInt rα; let ⟨zb, nb, pb⟩ ← rb.toInt rα
-      let zc := za * zb
-      have c := mkRawIntLit zc
-      haveI' : Int.mul $na $nb =Q $c := ⟨⟩
-      return .isInt rα c zc q(isInt_mul (f := $f) (.refl $f) $pa $pb (.refl $c))
-    let rec nnratArm (dsα : Q(DivisionSemiring $α)) : Option (Result _) := do
-      assumeInstancesCommute
-      let ⟨qa, na, da, pa⟩ ← ra.toNNRat' dsα; let ⟨qb, nb, db, pb⟩ ← rb.toNNRat' dsα
-      let qc := qa * qb
-      let dd := qa.den * qb.den
-      let k := dd / qc.den
-      have nc : Q(ℕ) := mkRawNatLit qc.num.toNat
-      have dc : Q(ℕ) := mkRawNatLit qc.den
-      have k : Q(ℕ) := mkRawNatLit k
-      let r1 : Q(Nat.mul $na $nb = Nat.mul $k $nc) :=
-        (q(Eq.refl (Nat.mul $na $nb)) : Expr)
-      have t2 : Q(ℕ) := mkRawNatLit dd
-      let r2 : Q(Nat.mul $da $db = Nat.mul $k $dc) := (q(Eq.refl $t2) : Expr)
-      return .isNNRat' dsα qc nc dc q(isNNRat_mul (f := $f) (.refl $f) $pa $pb $r1 $r2)
-    let rec ratArm (dα : Q(DivisionRing $α)) : Option (Result _) := do
-      assumeInstancesCommute
-      let ⟨qa, na, da, pa⟩ ← ra.toRat' dα; let ⟨qb, nb, db, pb⟩ ← rb.toRat' dα
-      let qc := qa * qb
-      let dd := qa.den * qb.den
-      let k := dd / qc.den
-      have nc : Q(ℤ) := mkRawIntLit qc.num
-      have dc : Q(ℕ) := mkRawNatLit qc.den
-      have k : Q(ℕ) := mkRawNatLit k
-      let r1 : Q(Int.mul $na $nb = Int.mul $k $nc) :=
-        (q(Eq.refl (Int.mul $na $nb)) : Expr)
-      have t2 : Q(ℕ) := mkRawNatLit dd
-      let r2 : Q(Nat.mul $da $db = Nat.mul $k $dc) := (q(Eq.refl $t2) : Expr)
-      return .isRat dα qc nc dc q(isRat_mul (f := $f) (.refl $f) $pa $pb $r1 $r2)
-    match ra, rb with
-    | .isBool .., _ | _, .isBool .. => failure
-    | .isNegNNRat dα .., _ | _, .isNegNNRat dα .. =>
-      ratArm dα
-    -- mixing positive rationals and negative naturals means we need to use the full rat handler
-    | .isNNRat dsα .., .isNegNat rα .. | .isNegNat rα .., .isNNRat dsα .. =>
-      -- could alternatively try to combine `rα` and `dsα` here, but we'd have to do a defeq check
-      -- so would still need to be in `MetaM`.
-      ratArm (←synthInstanceQ q(DivisionRing $α))
-    | .isNNRat dsα .., _ | _, .isNNRat dsα .. =>
-      nnratArm dsα
-    | .isNegNat rα .., _ | _, .isNegNat rα .. => intArm rα
-    | .isNat mα' na pa, .isNat mα nb pb =>
-      haveI' : $mα =Q by clear! $mα $mα'; apply AddCommMonoidWithOne.toAddMonoidWithOne := ⟨⟩
-      assumeInstancesCommute
-      have c : Q(ℕ) := mkRawNatLit (na.natLit! * nb.natLit!)
-      haveI' : Nat.mul $na $nb =Q $c := ⟨⟩
-      return .isNat mα c q(isNat_mul (f := $f) (.refl $f) $pa $pb (.refl $c))
-  core
+  evalMul.core q($e) q($f) q($a) q($b) q($sα) ra rb
 
 theorem isNNRat_div {α : Type u} [DivisionSemiring α] : {a b : α} → {cn : ℕ} → {cd : ℕ} →
     IsNNRat (a * b⁻¹) cn cd → IsNNRat (a / b) cn cd


### PR DESCRIPTION
This signature was previously obscured by the `let rec`. This PR does not attempt to improve the signature in any way, that's a job for a follow-up after the diff caused by reordering is gone.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
