### PR TITLE
[Merged by Bors] - chore: rename `Set.surjective_onto_image`

### DIFF
--- a/Mathlib/Algebra/Group/Subgroup/ZPowers/Lemmas.lean
+++ b/Mathlib/Algebra/Group/Subgroup/ZPowers/Lemmas.lean
@@ -25,7 +25,7 @@ namespace Subgroup
 theorem range_zpowersHom (g : G) : (zpowersHom G g).range = zpowers g := rfl
 
 @[to_additive]
-instance (a : G) : Countable (zpowers a) := Set.surjective_onto_range.countable
+instance (a : G) : Countable (zpowers a) := Set.rangeFactorization_surjective.countable
 
 end Subgroup
 

--- a/Mathlib/Data/Finite/Card.lean
+++ b/Mathlib/Data/Finite/Card.lean
@@ -146,10 +146,10 @@ theorem card_sum [Finite α] [Finite β] : Nat.card (α ⊕ β) = Nat.card α + 
   simp only [Nat.card_eq_fintype_card, Fintype.card_sum]
 
 theorem card_image_le {s : Set α} [Finite s] (f : α → β) : Nat.card (f '' s) ≤ Nat.card s :=
-  card_le_of_surjective _ Set.surjective_onto_image
+  card_le_of_surjective _ Set.imageFactorization_surjective
 
 theorem card_range_le [Finite α] (f : α → β) : Nat.card (Set.range f) ≤ Nat.card α :=
-  card_le_of_surjective _ Set.surjective_onto_range
+  card_le_of_surjective _ Set.rangeFactorization_surjective
 
 theorem card_subtype_le [Finite α] (p : α → Prop) : Nat.card { x // p x } ≤ Nat.card α := by
   classical

--- a/Mathlib/Data/Set/Countable.lean
+++ b/Mathlib/Data/Set/Countable.lean
@@ -112,7 +112,7 @@ theorem Countable.mono {s₁ s₂ : Set α} (h : s₁ ⊆ s₂) (hs : s₂.Count
   have := hs.to_subtype; (inclusion_injective h).countable
 
 theorem countable_range [Countable ι] (f : ι → β) : (range f).Countable :=
-  surjective_onto_range.countable.to_set
+  rangeFactorization_surjective.countable.to_set
 
 theorem countable_iff_exists_subset_range [Nonempty α] {s : Set α} :
     s.Countable ↔ ∃ f : ℕ → α, s ⊆ range f :=

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -514,8 +514,11 @@ theorem imageFactorization_eq {f : α → β} {s : Set α} :
     Subtype.val ∘ imageFactorization f s = f ∘ Subtype.val :=
   funext fun _ => rfl
 
-theorem surjective_onto_image {f : α → β} {s : Set α} : Surjective (imageFactorization f s) :=
+theorem imageFactorization_surjective {f : α → β} {s : Set α} :
+    Surjective (imageFactorization f s) :=
   fun ⟨_, ⟨a, ha, rfl⟩⟩ => ⟨⟨a, ha⟩, rfl⟩
+
+@[deprecated (since := "2025-08-18")] alias surjective_onto_image := imageFactorization_surjective
 
 /-- If the only elements outside `s` are those left fixed by `σ`, then mapping by `σ` has no effect.
 -/

--- a/Mathlib/Data/Set/Image.lean
+++ b/Mathlib/Data/Set/Image.lean
@@ -883,7 +883,10 @@ theorem rangeFactorization_coe (f : ι → β) (a : ι) : (rangeFactorization f 
 @[simp]
 theorem coe_comp_rangeFactorization (f : ι → β) : (↑) ∘ rangeFactorization f = f := rfl
 
-theorem surjective_onto_range : Surjective (rangeFactorization f) := fun ⟨_, ⟨i, rfl⟩⟩ => ⟨i, rfl⟩
+theorem rangeFactorization_surjective : Surjective (rangeFactorization f) :=
+  fun ⟨_, ⟨i, rfl⟩⟩ => ⟨i, rfl⟩
+
+@[deprecated (since := "2025-08-18")] alias surjective_onto_range := rangeFactorization_surjective
 
 theorem image_eq_range (f : α → β) (s : Set α) : f '' s = range fun x : s => f x := by
   ext

--- a/Mathlib/Logic/Small/Set.lean
+++ b/Mathlib/Logic/Small/Set.lean
@@ -30,11 +30,11 @@ instance small_setPi {β : α → Type u2} (s : (a : α) → Set (β a))
 
 instance small_range (f : α → β) [Small.{u} α] :
     Small.{u} (Set.range f) :=
-  small_of_surjective Set.surjective_onto_range
+  small_of_surjective Set.rangeFactorization_surjective
 
 instance small_image (f : α → β) (s : Set α) [Small.{u} s] :
     Small.{u} (f '' s) :=
-  small_of_surjective Set.surjective_onto_image
+  small_of_surjective Set.imageFactorization_surjective
 
 instance small_image2 (f : α → β → γ) (s : Set α) (t : Set β) [Small.{u} s] [Small.{u} t] :
     Small.{u} (Set.image2 f s t) := by

--- a/Mathlib/MeasureTheory/Constructions/Polish/Basic.lean
+++ b/Mathlib/MeasureTheory/Constructions/Polish/Basic.lean
@@ -567,7 +567,8 @@ theorem measurableSet_preimage_iff_preimage_val {f : X → Z} [CountablySeparate
     (hf : Measurable f) {s : Set Z} :
     MeasurableSet (f ⁻¹' s) ↔ MeasurableSet ((↑) ⁻¹' s : Set (range f)) :=
   have hf' : Measurable (rangeFactorization f) := hf.subtype_mk
-  hf'.measurableSet_preimage_iff_of_surjective (s := Subtype.val ⁻¹' s) surjective_onto_range
+  hf'.measurableSet_preimage_iff_of_surjective (s := Subtype.val ⁻¹' s)
+    rangeFactorization_surjective
 
 /-- If `f : X → Z` is a Borel measurable map from a standard Borel space to a
 countably separated measurable space and the range of `f` is measurable,

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/AEStronglyMeasurable.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/AEStronglyMeasurable.lean
@@ -629,7 +629,7 @@ theorem _root_.Topology.IsEmbedding.aestronglyMeasurable_comp_iff [PseudoMetriza
   · let G : β → range g := rangeFactorization g
     have hG : IsClosedEmbedding G :=
       { hg.codRestrict _ _ with
-        isClosed_range := by rw [surjective_onto_range.range_eq]; exact isClosed_univ }
+        isClosed_range := by rw [rangeFactorization_surjective.range_eq]; exact isClosed_univ }
     have : AEMeasurable (G ∘ f) μ := AEMeasurable.subtype_mk H.aemeasurable
     exact hG.measurableEmbedding.aemeasurable_comp_iff.1 this
   · rcases (aestronglyMeasurable_iff_aemeasurable_separable.1 H).2 with ⟨t, ht, h't⟩

--- a/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/StronglyMeasurable/Basic.lean
@@ -742,7 +742,7 @@ theorem _root_.Embedding.comp_stronglyMeasurable_iff {m : MeasurableSpace α} [T
     have hG : IsClosedEmbedding G :=
       { hg.codRestrict _ _ with
         isClosed_range := by
-          rw [surjective_onto_range.range_eq]
+          rw [rangeFactorization_surjective.range_eq]
           exact isClosed_univ }
     have : Measurable (G ∘ f) := Measurable.subtype_mk H.measurable
     exact hG.measurableEmbedding.measurable_comp_iff.1 this

--- a/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
+++ b/Mathlib/MeasureTheory/MeasurableSpace/Embedding.lean
@@ -683,7 +683,7 @@ theorem of_measurable_inverse_on_range {g : range f → α} (hf₁ : Measurable 
     (hf₂ : MeasurableSet (range f)) (hg : Measurable g) (H : LeftInverse g (rangeFactorization f)) :
     MeasurableEmbedding f := by
   set e : α ≃ᵐ range f :=
-    ⟨⟨rangeFactorization f, g, H, H.rightInverse_of_surjective surjective_onto_range⟩,
+    ⟨⟨rangeFactorization f, g, H, H.rightInverse_of_surjective rangeFactorization_surjective⟩,
       hf₁.subtype_mk, hg⟩
   exact (MeasurableEmbedding.subtype_coe hf₂).comp e.measurableEmbedding
 

--- a/Mathlib/Order/Filter/Finite.lean
+++ b/Mathlib/Order/Filter/Finite.lean
@@ -120,7 +120,7 @@ theorem exists_iInter_of_mem_iInf {ι : Sort*} {α : Type*} {f : ι → Filter �
   rw [← iInf_range' (g := (·))] at hs
   let ⟨_, _, V, hVs, _, _, hVU'⟩ := mem_iInf'.1 hs
   use V ∘ rangeFactorization f, fun i ↦ hVs (rangeFactorization f i)
-  rw [hVU', ← surjective_onto_range.iInter_comp, comp_def]
+  rw [hVU', ← rangeFactorization_surjective.iInter_comp, comp_def]
 
 theorem mem_iInf_of_finite {ι : Sort*} [Finite ι] {α : Type*} {f : ι → Filter α} (s) :
     (s ∈ ⨅ i, f i) ↔ ∃ t : ι → Set α, (∀ i, t i ∈ f i) ∧ s = ⋂ i, t i := by

--- a/Mathlib/Order/SupIndep.lean
+++ b/Mathlib/Order/SupIndep.lean
@@ -340,7 +340,7 @@ theorem iSupIndep.comp' {ι ι' : Sort*} {t : ι → α} {f : ι' → ι} (ht : 
 theorem iSupIndep.sSupIndep_range (ht : iSupIndep t) : sSupIndep <| range t := by
   rw [sSupIndep_iff]
   rw [← coe_comp_rangeFactorization t] at ht
-  exact ht.comp' surjective_onto_range
+  exact ht.comp' rangeFactorization_surjective
 
 @[simp]
 theorem iSupIndep_ne_bot :

--- a/Mathlib/RingTheory/AlgebraicIndependent/TranscendenceBasis.lean
+++ b/Mathlib/RingTheory/AlgebraicIndependent/TranscendenceBasis.lean
@@ -475,7 +475,7 @@ theorem isTranscendenceBasis_of_lift_le_trdeg_of_finite
     [Finite ι] [alg : Algebra.IsAlgebraic (adjoin R (range x)) A]
     (le : lift.{w} #ι ≤ lift.{u} (trdeg R A)) : IsTranscendenceBasis R x := by
   have ⟨_, h⟩ := lift_mk_le'.mp (le.trans <| lift_le.mpr <| trdeg_le_cardinalMk R (range x))
-  have := surjective_onto_range.bijective_of_nat_card_le (Nat.card_le_card_of_injective _ h)
+  have := rangeFactorization_surjective.bijective_of_nat_card_le (Nat.card_le_card_of_injective _ h)
   refine .of_subtype_range (fun _ _ ↦ (this.1 <| Subtype.ext ·)) ?_
   have := isDomain_of_adjoin_range R (range x)
   rw [← matroid_spanning_iff, ← matroid_cRank_eq] at *

--- a/Mathlib/RingTheory/Localization/AsSubring.lean
+++ b/Mathlib/RingTheory/Localization/AsSubring.lean
@@ -60,7 +60,7 @@ instance isLocalization_range_mapToFractionRing (B : Type*) [CommRing B] [Algebr
     [IsLocalization S B] (hS : S ≤ A⁰) : IsLocalization S (mapToFractionRing K S B hS).range :=
   IsLocalization.isLocalization_of_algEquiv S <|
     show B ≃ₐ[A] _ from AlgEquiv.ofBijective (mapToFractionRing K S B hS).rangeRestrict (by
-      refine ⟨fun a b h => ?_, Set.surjective_onto_range⟩
+      refine ⟨fun a b h => ?_, Set.rangeFactorization_surjective⟩
       refine (IsLocalization.lift_injective_iff _).2 (fun a b => ?_) (Subtype.ext_iff.1 h)
       exact ⟨fun h => congr_arg _ (IsLocalization.injective _ hS h),
         fun h => congr_arg _ (IsFractionRing.injective A K h)⟩)

--- a/Mathlib/SetTheory/Cardinal/Basic.lean
+++ b/Mathlib/SetTheory/Cardinal/Basic.lean
@@ -632,7 +632,7 @@ theorem mk_univ {α : Type u} : #(@univ α) = #α :=
   rw [mul_def, mk_congr (Equiv.Set.prod ..)]
 
 theorem mk_image_le {α β : Type u} {f : α → β} {s : Set α} : #(f '' s) ≤ #s :=
-  mk_le_of_surjective surjective_onto_image
+  mk_le_of_surjective imageFactorization_surjective
 
 lemma mk_image2_le {α β γ : Type u} {f : α → β → γ} {s : Set α} {t : Set β} :
     #(image2 f s t) ≤ #s * #t := by
@@ -641,14 +641,14 @@ lemma mk_image2_le {α β γ : Type u} {f : α → β → γ} {s : Set α} {t : 
 
 theorem mk_image_le_lift {α : Type u} {β : Type v} {f : α → β} {s : Set α} :
     lift.{u} #(f '' s) ≤ lift.{v} #s :=
-  lift_mk_le.{0}.mpr ⟨Embedding.ofSurjective _ surjective_onto_image⟩
+  lift_mk_le.{0}.mpr ⟨Embedding.ofSurjective _ imageFactorization_surjective⟩
 
 theorem mk_range_le {α β : Type u} {f : α → β} : #(range f) ≤ #α :=
-  mk_le_of_surjective surjective_onto_range
+  mk_le_of_surjective rangeFactorization_surjective
 
 theorem mk_range_le_lift {α : Type u} {β : Type v} {f : α → β} :
     lift.{u} #(range f) ≤ lift.{v} #α :=
-  lift_mk_le.{0}.mpr ⟨Embedding.ofSurjective _ surjective_onto_range⟩
+  lift_mk_le.{0}.mpr ⟨Embedding.ofSurjective _ rangeFactorization_surjective⟩
 
 theorem mk_range_eq (f : α → β) (h : Injective f) : #(range f) = #α :=
   mk_congr (Equiv.ofInjective f h).symm

--- a/Mathlib/SetTheory/Cardinal/Finite.lean
+++ b/Mathlib/SetTheory/Cardinal/Finite.lean
@@ -141,7 +141,8 @@ lemma card_mono (ht : t.Finite) (h : s ⊆ t) : Nat.card s ≤ Nat.card t :=
   toNat_le_toNat (mk_le_mk_of_subset h) ht.lt_aleph0
 
 lemma card_image_le {f : α → β} (hs : s.Finite) : Nat.card (f '' s) ≤ Nat.card s :=
-  have := hs.to_subtype; card_le_card_of_surjective (imageFactorization f s) surjective_onto_image
+  have := hs.to_subtype
+  card_le_card_of_surjective (imageFactorization f s) imageFactorization_surjective
 
 lemma card_image_of_injOn {f : α → β} (hf : s.InjOn f) : Nat.card (f '' s) = Nat.card s := by
   classical

--- a/Mathlib/Topology/NoetherianSpace.lean
+++ b/Mathlib/Topology/NoetherianSpace.lean
@@ -114,7 +114,7 @@ theorem noetherianSpace_iff_of_homeomorph (f : α ≃ₜ β) : NoetherianSpace �
 theorem NoetherianSpace.range [NoetherianSpace α] (f : α → β) (hf : Continuous f) :
     NoetherianSpace (Set.range f) :=
   noetherianSpace_of_surjective (Set.rangeFactorization f) (hf.subtype_mk _)
-    Set.surjective_onto_range
+    Set.rangeFactorization_surjective
 
 theorem noetherianSpace_set_iff (s : Set α) :
     NoetherianSpace s ↔ ∀ t, t ⊆ s → IsCompact t := by


### PR DESCRIPTION
Rename `Set.surjective_onto_image` to `Set.imageFactorization_surjective`. This matches better with other theorems like `Set.restrictPreimage_surjective`. Also rename `Set.surjective_onto_range` similarly.

I was looking on loogle today and noticed this one again, which doesn't fit any of the naming conventions. I decided to fix it this time.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
