### PR TITLE
feat(Data\Nat\ModEq.lean): add grind attribute to ModEq

### DIFF
--- a/Mathlib/Data/Nat/ModEq.lean
+++ b/Mathlib/Data/Nat/ModEq.lean
@@ -29,11 +29,18 @@ assert_not_exists OrderedAddCommMonoid Function.support
 namespace Nat
 
 /-- Modular equality. `n.ModEq a b`, or `a ≡ b [MOD n]`, means that `a % n = b % n`. -/
+@[grind]
 def ModEq (n a b : ℕ) :=
   a % n = b % n
 
 @[inherit_doc]
 notation:50 a " ≡ " b " [MOD " n "]" => ModEq n a b
+
+example (a : ℕ) (ha : a % 5 = 0) (hb : a % 5 = 1) : False := by
+  omega
+
+example (a : ℕ) (ha : a ≡ 0 [MOD 5]) (hb : a ≡ 1 [MOD 5]) : False := by
+  grind
 
 variable {m n a b c d : ℕ}
 


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
