### PR TITLE
[Merged by Bors] - chore(HahnSeries): make more usable, golf

### DIFF
--- a/Mathlib/Algebra/Order/Group/Synonym.lean
+++ b/Mathlib/Algebra/Order/Group/Synonym.lean
@@ -224,6 +224,8 @@ theorem toLex_one [One α] : toLex (1 : α) = 1 := rfl
 @[to_additive (attr := simp)]
 theorem ofLex_one [One α] : (ofLex 1 : α) = 1 := rfl
 
+@[to_additive (attr := simp)] lemma ofLex_eq_one [One α] {a : Lex α} : ofLex a = 1 ↔ a = 1 := .rfl
+
 @[to_additive (attr := simp)]
 theorem toLex_mul [Mul α] (a b : α) : toLex (a * b) = toLex a * toLex b := rfl
 

--- a/Mathlib/Order/WithBot.lean
+++ b/Mathlib/Order/WithBot.lean
@@ -770,8 +770,8 @@ lemma coe_lt_iff : a < y ↔ ∀ b : α, y = b → a < b := by simp [lt_def]
 `PartialOrder α`. -/
 protected lemma lt_top_iff_ne_top : x < ⊤ ↔ x ≠ ⊤ := by cases x <;> simp
 
-lemma lt_untop_iff (hy : y ≠ ⊤) : a < y.untop hy ↔ a < y := by lift y to α using id hy; simp
-lemma untop_lt_iff (hx : x ≠ ⊤) : x.untop hx < b ↔ x < b := by lift x to α using id hx; simp
+@[simp] lemma lt_untop_iff (hy : y ≠ ⊤) : a < y.untop hy ↔ a < y := by lift y to α using id hy; simp
+@[simp] lemma untop_lt_iff (hx : x ≠ ⊤) : x.untop hx < b ↔ x < b := by lift x to α using id hx; simp
 lemma lt_untopD_iff (hy : y = ⊤ → a < b) : a < y.untopD b ↔ a < y := by cases y <;> simp [hy]
 
 @[deprecated (since := "2025-02-11")]

--- a/Mathlib/RingTheory/HahnSeries/Addition.lean
+++ b/Mathlib/RingTheory/HahnSeries/Addition.lean
@@ -63,7 +63,8 @@ theorem orderTop_smul_not_lt (r : R) (x : HahnSeries Γ V) : ¬ (r • x).orderT
   by_cases hrx : r • x = 0
   · rw [hrx, orderTop_zero]
     exact not_top_lt
-  · simp only [orderTop_of_ne hrx, orderTop_of_ne <| right_ne_zero_of_smul hrx, WithTop.coe_lt_coe]
+  · simp only [orderTop_of_ne_zero hrx, orderTop_of_ne_zero <| right_ne_zero_of_smul hrx,
+      WithTop.coe_lt_coe]
     exact Set.IsWF.min_of_subset_not_lt_min
       (Function.support_smul_subset_right (fun _ => r) x.coeff)
 
@@ -122,7 +123,7 @@ Hahn series over `Γ` with coefficients in the opposite additive monoid `Rᵃᵒ
 and the additive opposite of Hahn series over `Γ` with coefficients `R`.
 -/
 @[simps -isSimp]
-def addOppositeEquiv : HahnSeries Γ (Rᵃᵒᵖ) ≃+ (HahnSeries Γ R)ᵃᵒᵖ where
+def addOppositeEquiv : HahnSeries Γ Rᵃᵒᵖ ≃+ (HahnSeries Γ R)ᵃᵒᵖ where
   toFun x := .op ⟨fun a ↦ (x.coeff a).unop, by convert x.isPWO_support; ext; simp⟩
   invFun x := ⟨fun a ↦ .op (x.unop.coeff a), by convert x.unop.isPWO_support; ext; simp⟩
   left_inv x := by simp
@@ -135,7 +136,7 @@ def addOppositeEquiv : HahnSeries Γ (Rᵃᵒᵖ) ≃+ (HahnSeries Γ R)ᵃᵒ�
     simp
 
 @[simp]
-lemma addOppositeEquiv_support (x : HahnSeries Γ (Rᵃᵒᵖ)) :
+lemma addOppositeEquiv_support (x : HahnSeries Γ Rᵃᵒᵖ) :
     (addOppositeEquiv x).unop.support = x.support := by
   ext
   simp [addOppositeEquiv_apply]
@@ -146,7 +147,7 @@ lemma addOppositeEquiv_symm_support (x : (HahnSeries Γ R)ᵃᵒᵖ) :
   rw [← addOppositeEquiv_support, AddEquiv.apply_symm_apply]
 
 @[simp]
-lemma addOppositeEquiv_orderTop (x : HahnSeries Γ (Rᵃᵒᵖ)) :
+lemma addOppositeEquiv_orderTop (x : HahnSeries Γ Rᵃᵒᵖ) :
     (addOppositeEquiv x).unop.orderTop = x.orderTop := by
   classical
   simp only [orderTop,
@@ -161,15 +162,14 @@ lemma addOppositeEquiv_symm_orderTop (x : (HahnSeries Γ R)ᵃᵒᵖ) :
   rw [← addOppositeEquiv_orderTop, AddEquiv.apply_symm_apply]
 
 @[simp]
-lemma addOppositeEquiv_leadingCoeff (x : HahnSeries Γ (Rᵃᵒᵖ)) :
+lemma addOppositeEquiv_leadingCoeff (x : HahnSeries Γ Rᵃᵒᵖ) :
     (addOppositeEquiv x).unop.leadingCoeff = x.leadingCoeff.unop := by
   classical
-  simp only [leadingCoeff,
-    addOppositeEquiv_support]
-  simp only [addOppositeEquiv_apply, AddOpposite.unop_op, mk_eq_zero]
-  simp_rw [HahnSeries.ext_iff, funext_iff]
-  simp only [Pi.zero_apply, AddOpposite.unop_eq_zero_iff, coeff_zero]
-  split <;> rfl
+  obtain rfl | hx := eq_or_ne x 0
+  · simp
+  simp only [ne_eq, AddOpposite.unop_eq_zero_iff, EmbeddingLike.map_eq_zero_iff, hx,
+    not_false_eq_true, leadingCoeff_of_ne_zero, addOppositeEquiv_orderTop]
+  rfl
 
 @[simp]
 lemma addOppositeEquiv_symm_leadingCoeff (x : (HahnSeries Γ R)ᵃᵒᵖ) :
@@ -197,7 +197,7 @@ theorem min_orderTop_le_orderTop_add {Γ} [LinearOrder Γ] {x y : HahnSeries Γ 
   by_cases hx : x = 0; · simp [hx]
   by_cases hy : y = 0; · simp [hy]
   by_cases hxy : x + y = 0; · simp [hxy]
-  rw [orderTop_of_ne hx, orderTop_of_ne hy, orderTop_of_ne hxy, ← WithTop.coe_min,
+  rw [orderTop_of_ne_zero hx, orderTop_of_ne_zero hy, orderTop_of_ne_zero hxy, ← WithTop.coe_min,
     WithTop.coe_le_coe]
   exact HahnSeries.min_le_min_add hx hy hxy
 
@@ -210,14 +210,14 @@ theorem min_order_le_order_add {Γ} [Zero Γ] [LinearOrder Γ] {x y : HahnSeries
 
 theorem orderTop_add_eq_left {Γ} [LinearOrder Γ] {x y : HahnSeries Γ R}
     (hxy : x.orderTop < y.orderTop) : (x + y).orderTop = x.orderTop := by
-  have hx : x ≠ 0 := ne_zero_iff_orderTop.mpr hxy.ne_top
+  have hx : x ≠ 0 := orderTop_ne_top.1 hxy.ne_top
   let g : Γ := Set.IsWF.min x.isWF_support (support_nonempty_iff.2 hx)
   have hcxyne : (x + y).coeff g ≠ 0 := by
-    rw [coeff_add, coeff_eq_zero_of_lt_orderTop (lt_of_eq_of_lt (orderTop_of_ne hx).symm hxy),
+    rw [coeff_add, coeff_eq_zero_of_lt_orderTop (lt_of_eq_of_lt (orderTop_of_ne_zero hx).symm hxy),
       add_zero]
-    exact coeff_orderTop_ne (orderTop_of_ne hx)
+    exact coeff_orderTop_ne (orderTop_of_ne_zero hx)
   have hxyx : (x + y).orderTop ≤ x.orderTop := by
-    rw [orderTop_of_ne hx]
+    rw [orderTop_of_ne_zero hx]
     exact orderTop_le_of_coeff_ne_zero hcxyne
   exact le_antisymm hxyx (le_of_eq_of_le (min_eq_left_of_lt hxy).symm min_orderTop_le_orderTop_add)
 
@@ -229,14 +229,13 @@ theorem orderTop_add_eq_right {Γ} [LinearOrder Γ] {x y : HahnSeries Γ R}
 
 theorem leadingCoeff_add_eq_left {Γ} [LinearOrder Γ] {x y : HahnSeries Γ R}
     (hxy : x.orderTop < y.orderTop) : (x + y).leadingCoeff = x.leadingCoeff := by
-  have hx : x ≠ 0 := ne_zero_iff_orderTop.mpr hxy.ne_top
+  have hx : x ≠ 0 := orderTop_ne_top.1 hxy.ne_top
   have ho : (x + y).orderTop = x.orderTop := orderTop_add_eq_left hxy
   by_cases h : x + y = 0
   · rw [h, orderTop_zero] at ho
-    rw [h, orderTop_eq_top_iff.mp ho.symm]
-  · rw [orderTop_of_ne h, orderTop_of_ne hx, WithTop.coe_eq_coe] at ho
-    rw [leadingCoeff_of_ne h, leadingCoeff_of_ne hx, ho, coeff_add,
-      coeff_eq_zero_of_lt_orderTop (lt_of_eq_of_lt (orderTop_of_ne hx).symm hxy), add_zero]
+    rw [h, orderTop_eq_top.mp ho.symm]
+  · simp_rw [leadingCoeff_of_ne_zero h, leadingCoeff_of_ne_zero hx, ho, coeff_add]
+    rw [coeff_eq_zero_of_lt_orderTop (x := y) (by simpa using hxy), add_zero]
 
 theorem leadingCoeff_add_eq_right {Γ} [LinearOrder Γ] {x y : HahnSeries Γ R}
     (hxy : y.orderTop < x.orderTop) : (x + y).leadingCoeff = y.leadingCoeff := by
@@ -251,26 +250,16 @@ theorem ne_zero_of_eq_add_single [Zero Γ] {x y : HahnSeries Γ R}
   exact hy hxy.symm
 
 theorem coeff_order_of_eq_add_single {R} [AddCancelCommMonoid R] [Zero Γ] {x y : HahnSeries Γ R}
-    (hxy : x = y + single x.order x.leadingCoeff) (h : x ≠ 0) :
-    y.coeff x.order = 0 := by
-  let xo := x.isWF_support.min (support_nonempty_iff.2 h)
-  have : xo = x.order := (order_of_ne h).symm
-  have hx : x.coeff xo = y.coeff xo + (single x.order x.leadingCoeff).coeff xo := by
-    nth_rw 1 [hxy, coeff_add]
-  have hxx :
-      (single x.order x.leadingCoeff).coeff xo = (single x.order x.leadingCoeff).leadingCoeff := by
-    simp [leadingCoeff_of_single, this]
-  rw [← (leadingCoeff_of_ne h), hxx, leadingCoeff_of_single, right_eq_add, this] at hx
-  exact hx
+    (hxy : x = y + single x.order x.leadingCoeff) : y.coeff x.order = 0 := by
+  simpa [← leadingCoeff_eq] using congr(($hxy).coeff x.order)
 
 theorem order_lt_order_of_eq_add_single {R} {Γ} [LinearOrder Γ] [Zero Γ] [AddCancelCommMonoid R]
     {x y : HahnSeries Γ R} (hxy : x = y + single x.order x.leadingCoeff) (hy : y ≠ 0) :
     x.order < y.order := by
   have : x.order ≠ y.order := by
     intro h
-    have hyne : single y.order y.leadingCoeff ≠ 0 := single_ne_zero <| leadingCoeff_ne_iff.mpr hy
-    rw [leadingCoeff_eq, ← h, coeff_order_of_eq_add_single hxy <| ne_zero_of_eq_add_single hxy hy,
-      single_eq_zero] at hyne
+    have hyne : single y.order y.leadingCoeff ≠ 0 := single_ne_zero <| leadingCoeff_ne_zero.mpr hy
+    rw [leadingCoeff_eq, ← h, coeff_order_of_eq_add_single hxy, single_eq_zero] at hyne
     exact hyne rfl
   refine lt_of_le_of_ne ?_ this
   simp only [order, ne_zero_of_eq_add_single hxy hy, ↓reduceDIte, hy]
@@ -401,9 +390,7 @@ theorem order_neg [Zero Γ] {f : HahnSeries Γ R} : (-f).order = f.order := by
   simp only [order, support_neg, neg_eq_zero]
 
 theorem leadingCoeff_neg {x : HahnSeries Γ R} : (-x).leadingCoeff = -x.leadingCoeff := by
-  obtain rfl | hx := eq_or_ne x 0
-  · simp
-  · simp [← coeff_untop_eq_leadingCoeff hx, ← coeff_untop_eq_leadingCoeff (neg_ne_zero.mpr hx)]
+  obtain rfl | hx := eq_or_ne x 0 <;> simp [leadingCoeff_of_ne_zero, *]
 
 @[simp]
 protected lemma map_sub [AddGroup S] (f : R →+ S) {x y : HahnSeries Γ R} :

--- a/Mathlib/RingTheory/HahnSeries/Basic.lean
+++ b/Mathlib/RingTheory/HahnSeries/Basic.lean
@@ -224,6 +224,7 @@ instance [Nonempty Γ] [Nontrivial R] : Nontrivial (HahnSeries Γ R) :=
     rw [← coeff_single_same (default : Γ) r, con, coeff_single_same]⟩
 
 section Order
+variable {x : HahnSeries Γ R}
 
 open Classical in
 /-- The orderTop of a Hahn series `x` is a minimal element of `WithTop Γ` where `x` has a nonzero
@@ -236,53 +237,51 @@ theorem orderTop_zero : orderTop (0 : HahnSeries Γ R) = ⊤ :=
   dif_pos rfl
 
 @[simp]
-theorem orderTop_of_Subsingleton [Subsingleton R] {x : HahnSeries Γ R} : x.orderTop = ⊤ :=
+theorem orderTop_of_subsingleton [Subsingleton R] : x.orderTop = ⊤ :=
   (Subsingleton.eq_zero x) ▸ orderTop_zero
 
-theorem orderTop_of_ne {x : HahnSeries Γ R} (hx : x ≠ 0) :
+@[deprecated (since := "2025-08-19")] alias orderTop_of_Subsingleton := orderTop_of_subsingleton
+
+theorem orderTop_of_ne_zero (hx : x ≠ 0) :
     orderTop x = x.isWF_support.min (support_nonempty_iff.2 hx) :=
   dif_neg hx
 
-@[simp]
-theorem ne_zero_iff_orderTop {x : HahnSeries Γ R} : x ≠ 0 ↔ orderTop x ≠ ⊤ := by
-  constructor
-  · exact fun hx => Eq.mpr (congrArg (fun h ↦ h ≠ ⊤) (orderTop_of_ne hx)) WithTop.coe_ne_top
-  · contrapose!
-    simp_all only [orderTop_zero, implies_true]
+@[deprecated (since := "2025-08-19")] alias orderTop_of_ne := orderTop_of_ne_zero
 
-theorem orderTop_eq_top_iff {x : HahnSeries Γ R} : orderTop x = ⊤ ↔ x = 0 := by
-  constructor
-  · contrapose!
-    exact ne_zero_iff_orderTop.mp
-  · simp_all only [orderTop_zero, implies_true]
+@[simp] lemma orderTop_eq_top : orderTop x = ⊤ ↔ x = 0 := by simp [orderTop]
+@[simp] lemma orderTop_lt_top : orderTop x < ⊤ ↔ x ≠ 0 := by simp [lt_top_iff_ne_top]
+lemma orderTop_ne_top : orderTop x ≠ ⊤ ↔ x ≠ 0 := orderTop_eq_top.not
+
+@[deprecated (since := "2025-08-19")] alias orderTop_eq_top_iff := orderTop_eq_top
+@[deprecated (since := "2025-08-19")] alias ne_zero_iff_orderTop := orderTop_ne_top
 
 theorem orderTop_eq_of_le {x : HahnSeries Γ R} {g : Γ} (hg : g ∈ x.support)
     (hx : ∀ g' ∈ x.support, g ≤ g') : orderTop x = g := by
-  rw [orderTop_of_ne <| support_nonempty_iff.mp <| Set.nonempty_of_mem hg,
+  rw [orderTop_of_ne_zero <| support_nonempty_iff.mp <| Set.nonempty_of_mem hg,
     x.isWF_support.min_eq_of_le hg hx]
 
 theorem untop_orderTop_of_ne_zero {x : HahnSeries Γ R} (hx : x ≠ 0) :
-    WithTop.untop x.orderTop (ne_zero_iff_orderTop.mp hx) =
+    WithTop.untop x.orderTop (orderTop_ne_top.2 hx) =
       x.isWF_support.min (support_nonempty_iff.2 hx) :=
-  WithTop.coe_inj.mp ((WithTop.coe_untop (orderTop x) (ne_zero_iff_orderTop.mp hx)).trans
-    (orderTop_of_ne hx))
+  WithTop.coe_inj.mp ((WithTop.coe_untop (orderTop x) (orderTop_ne_top.2 hx)).trans
+    (orderTop_of_ne_zero hx))
 
 theorem coeff_orderTop_ne {x : HahnSeries Γ R} {g : Γ} (hg : x.orderTop = g) :
     x.coeff g ≠ 0 := by
   have h : orderTop x ≠ ⊤ := by simp_all only [ne_eq, WithTop.coe_ne_top, not_false_eq_true]
-  have hx : x ≠ 0 := ne_zero_iff_orderTop.mpr h
-  rw [orderTop_of_ne hx, WithTop.coe_eq_coe] at hg
+  have hx : x ≠ 0 := orderTop_ne_top.1 h
+  rw [orderTop_of_ne_zero hx, WithTop.coe_eq_coe] at hg
   rw [← hg]
   exact x.isWF_support.min_mem (support_nonempty_iff.2 hx)
 
 theorem orderTop_le_of_coeff_ne_zero {Γ} [LinearOrder Γ] {x : HahnSeries Γ R}
     {g : Γ} (h : x.coeff g ≠ 0) : x.orderTop ≤ g := by
-  rw [orderTop_of_ne (ne_zero_of_coeff_ne_zero h), WithTop.coe_le_coe]
+  rw [orderTop_of_ne_zero (ne_zero_of_coeff_ne_zero h), WithTop.coe_le_coe]
   exact Set.IsWF.min_le _ _ ((mem_support _ _).2 h)
 
 @[simp]
 theorem orderTop_single (h : r ≠ 0) : (single a r).orderTop = a :=
-  (orderTop_of_ne (single_ne_zero h)).trans
+  (orderTop_of_ne_zero (single_ne_zero h)).trans
     (WithTop.coe_inj.mpr (support_single_subset
       ((single a r).isWF_support.min_mem (support_nonempty_iff.2 (single_ne_zero h)))))
 
@@ -300,39 +299,40 @@ theorem coeff_eq_zero_of_lt_orderTop {x : HahnSeries Γ R} {i : Γ} (hi : i < x.
   · exact coeff_zero
   contrapose! hi
   rw [← mem_support] at hi
-  rw [orderTop_of_ne hx, WithTop.coe_lt_coe]
+  rw [orderTop_of_ne_zero hx, WithTop.coe_lt_coe]
   exact Set.IsWF.not_lt_min _ _ hi
 
 open Classical in
 /-- A leading coefficient of a Hahn series is the coefficient of a lowest-order nonzero term, or
 zero if the series vanishes. -/
-def leadingCoeff (x : HahnSeries Γ R) : R :=
-  if h : x = 0 then 0 else x.coeff (x.isWF_support.min (support_nonempty_iff.2 h))
+def leadingCoeff (x : HahnSeries Γ R) : R := x.orderTop.recTopCoe 0 x.coeff
 
 @[simp]
-theorem leadingCoeff_zero : leadingCoeff (0 : HahnSeries Γ R) = 0 :=
-  dif_pos rfl
+theorem leadingCoeff_zero : leadingCoeff (0 : HahnSeries Γ R) = 0 := by simp [leadingCoeff]
 
-theorem leadingCoeff_of_ne {x : HahnSeries Γ R} (hx : x ≠ 0) :
-    x.leadingCoeff = x.coeff (x.isWF_support.min (support_nonempty_iff.2 hx)) :=
-  dif_neg hx
+theorem leadingCoeff_of_ne_zero {x : HahnSeries Γ R} (hx : x ≠ 0) :
+    x.leadingCoeff = x.coeff (x.orderTop.untop <| orderTop_ne_top.2 hx) := by
+  simp [leadingCoeff, orderTop, hx]
 
-theorem leadingCoeff_eq_iff {x : HahnSeries Γ R} : x.leadingCoeff = 0 ↔ x = 0 := by
-  refine { mp := ?_, mpr := fun hx => hx ▸ leadingCoeff_zero }
-  contrapose!
-  exact fun hx => (leadingCoeff_of_ne hx) ▸ coeff_orderTop_ne (orderTop_of_ne hx)
+@[deprecated (since := "2025-08-19")] alias leadingCoeff_of_ne := leadingCoeff_of_ne_zero
 
-theorem leadingCoeff_ne_iff {x : HahnSeries Γ R} : x.leadingCoeff ≠ 0 ↔ x ≠ 0 :=
-  leadingCoeff_eq_iff.not
+theorem leadingCoeff_eq_zero {x : HahnSeries Γ R} : x.leadingCoeff = 0 ↔ x = 0 := by
+  obtain rfl | hx := eq_or_ne x 0 <;> simp [leadingCoeff_of_ne_zero, coeff_orderTop_ne, *]
+
+theorem leadingCoeff_ne_zero {x : HahnSeries Γ R} : x.leadingCoeff ≠ 0 ↔ x ≠ 0 :=
+  leadingCoeff_eq_zero.not
+
+@[deprecated (since := "2025-08-19")] alias leadingCoeff_eq_iff := leadingCoeff_eq_zero
+@[deprecated (since := "2025-08-19")] alias leadingCoeff_ne_iff := leadingCoeff_ne_zero
 
 @[simp]
 theorem leadingCoeff_of_single {a : Γ} {r : R} : leadingCoeff (single a r) = r := by
-  simp only [leadingCoeff, single_eq_zero_iff]
-  by_cases h : r = 0 <;> simp [h]
+  by_cases h : r = 0 <;> simp [leadingCoeff, h]
 
-theorem coeff_untop_eq_leadingCoeff {x : HahnSeries Γ R} (hx : x ≠ 0) :
-    x.coeff (x.orderTop.untop (ne_zero_iff_orderTop.mp hx)) = x.leadingCoeff := by
-  rw [HahnSeries.leadingCoeff_of_ne hx, (WithTop.untop_eq_iff _).mpr (HahnSeries.orderTop_of_ne hx)]
+theorem coeff_untop_eq_leadingCoeff {x : HahnSeries Γ R} (hx) :
+    x.coeff (x.orderTop.untop hx) = x.leadingCoeff := by
+  rw [orderTop_ne_top] at hx
+  rw [leadingCoeff_of_ne_zero hx, (WithTop.untop_eq_iff _).mpr (orderTop_of_ne_zero hx)]
 
 variable [Zero Γ]
 
@@ -350,8 +350,8 @@ theorem order_of_ne {x : HahnSeries Γ R} (hx : x ≠ 0) :
     order x = x.isWF_support.min (support_nonempty_iff.2 hx) :=
   dif_neg hx
 
-theorem order_eq_orderTop_of_ne {x : HahnSeries Γ R} (hx : x ≠ 0) : order x = orderTop x := by
-  rw [order_of_ne hx, orderTop_of_ne hx]
+theorem order_eq_orderTop_of_ne_zero {x : HahnSeries Γ R} (hx : x ≠ 0) : order x = orderTop x := by
+  rw [order_of_ne hx, orderTop_of_ne_zero hx]
 
 theorem coeff_order_ne_zero {x : HahnSeries Γ R} (hx : x ≠ 0) : x.coeff x.order ≠ 0 := by
   rw [order_of_ne hx]
@@ -379,7 +379,7 @@ theorem coeff_eq_zero_of_lt_order {x : HahnSeries Γ R} {i : Γ} (hi : i < x.ord
 
 theorem zero_lt_orderTop_iff {x : HahnSeries Γ R} (hx : x ≠ 0) :
     0 < x.orderTop ↔ 0 < x.order := by
-  simp_all [orderTop_of_ne hx, order_of_ne hx]
+  simp_all [orderTop_of_ne_zero hx, order_of_ne hx]
 
 theorem zero_lt_orderTop_of_order {x : HahnSeries Γ R} (hx : 0 < x.order) : 0 < x.orderTop := by
   by_cases h : x = 0
@@ -389,12 +389,12 @@ theorem zero_lt_orderTop_of_order {x : HahnSeries Γ R} (hx : 0 < x.order) : 0 <
 theorem zero_le_orderTop_iff {x : HahnSeries Γ R} : 0 ≤ x.orderTop ↔ 0 ≤ x.order := by
   by_cases h : x = 0
   · simp_all
-  · simp_all [order_of_ne h, orderTop_of_ne h]
+  · simp_all [order_of_ne h, orderTop_of_ne_zero h]
 
 theorem leadingCoeff_eq {x : HahnSeries Γ R} : x.leadingCoeff = x.coeff x.order := by
   by_cases h : x = 0
   · rw [h, leadingCoeff_zero, coeff_zero]
-  · rw [leadingCoeff_of_ne h, order_of_ne h]
+  · simp [leadingCoeff_of_ne_zero, orderTop_of_ne_zero, order_of_ne, h]
 
 end Order
 

--- a/Mathlib/RingTheory/HahnSeries/Basic.lean
+++ b/Mathlib/RingTheory/HahnSeries/Basic.lean
@@ -253,7 +253,9 @@ theorem orderTop_of_ne_zero (hx : x ≠ 0) :
 lemma orderTop_ne_top : orderTop x ≠ ⊤ ↔ x ≠ 0 := orderTop_eq_top.not
 
 @[deprecated (since := "2025-08-19")] alias orderTop_eq_top_iff := orderTop_eq_top
-@[deprecated (since := "2025-08-19")] alias ne_zero_iff_orderTop := orderTop_ne_top
+
+@[deprecated orderTop_ne_top (since := "2025-08-19")]
+lemma ne_zero_iff_orderTop : x ≠ 0 ↔ orderTop x ≠ ⊤ := orderTop_ne_top.symm
 
 theorem orderTop_eq_of_le {x : HahnSeries Γ R} {g : Γ} (hg : g ∈ x.support)
     (hx : ∀ g' ∈ x.support, g ≤ g') : orderTop x = g := by

--- a/Mathlib/RingTheory/HahnSeries/Basic.lean
+++ b/Mathlib/RingTheory/HahnSeries/Basic.lean
@@ -350,8 +350,10 @@ theorem order_of_ne {x : HahnSeries Γ R} (hx : x ≠ 0) :
     order x = x.isWF_support.min (support_nonempty_iff.2 hx) :=
   dif_neg hx
 
-theorem order_eq_orderTop_of_ne_zero {x : HahnSeries Γ R} (hx : x ≠ 0) : order x = orderTop x := by
+theorem order_eq_orderTop_of_ne_zero (hx : x ≠ 0) : order x = orderTop x := by
   rw [order_of_ne hx, orderTop_of_ne_zero hx]
+
+@[deprecated (since := "2025-08-19")] alias order_eq_orderTop_of_ne := order_eq_orderTop_of_ne_zero
 
 theorem coeff_order_ne_zero {x : HahnSeries Γ R} (hx : x ≠ 0) : x.coeff x.order ≠ 0 := by
   rw [order_of_ne hx]

--- a/Mathlib/RingTheory/HahnSeries/Lex.lean
+++ b/Mathlib/RingTheory/HahnSeries/Lex.lean
@@ -61,6 +61,7 @@ instance : LinearOrder (Lex (HahnSeries Γ R)) where
       · exact Or.inr (le_of_lt ⟨i, fun j hj ↦ (hji j hj).symm, hi⟩)
   toDecidableLE := Classical.decRel _
 
+@[simp]
 theorem leadingCoeff_pos_iff {x : Lex (HahnSeries Γ R)} : 0 < (ofLex x).leadingCoeff ↔ 0 < x := by
   rw [lt_iff]
   constructor
@@ -103,7 +104,7 @@ theorem leadingCoeff_neg_iff {x : Lex (HahnSeries Γ R)} : (ofLex x).leadingCoef
 
 theorem leadingCoeff_nonpos_iff {x : Lex (HahnSeries Γ R)} :
     (ofLex x).leadingCoeff ≤ 0 ↔ x ≤ 0 := by
-  simpa using (leadingCoeff_pos_iff (x := x)).not
+  simp [← not_lt]
 
 end LinearOrder
 
@@ -127,12 +128,14 @@ end OrderedMonoid
 section OrderedGroup
 variable [LinearOrder R] [AddCommGroup R] [IsOrderedAddMonoid R]
 
+@[simp]
 theorem support_abs (x : Lex (HahnSeries Γ R)) : (ofLex |x|).support = (ofLex x).support := by
   obtain hle | hge := le_total x 0
   · rw [abs_eq_neg_self.mpr hle]
     simp
   · rw [abs_eq_self.mpr hge]
 
+@[simp]
 theorem orderTop_abs (x : Lex (HahnSeries Γ R)) : (ofLex |x|).orderTop = (ofLex x).orderTop := by
   obtain hle | hge := le_total x 0
   · rw [abs_eq_neg_self.mpr hle, ofLex_neg, orderTop_neg]

--- a/Mathlib/RingTheory/HahnSeries/Lex.lean
+++ b/Mathlib/RingTheory/HahnSeries/Lex.lean
@@ -66,14 +66,11 @@ theorem leadingCoeff_pos_iff {x : Lex (HahnSeries Γ R)} : 0 < (ofLex x).leading
   rw [lt_iff]
   constructor
   · intro hpos
-    have hne : (ofLex x) ≠ 0 := leadingCoeff_ne_iff.mp hpos.ne.symm
-    have htop : (ofLex x).orderTop ≠ ⊤ := ne_zero_iff_orderTop.mp hne
-    use (ofLex x).orderTop.untop htop
-    constructor
-    · intro j hj
-      simpa using (coeff_eq_zero_of_lt_orderTop ((WithTop.lt_untop_iff htop).mp hj)).symm
-    · rw [coeff_untop_eq_leadingCoeff hne]
-      simpa using hpos
+    have hne : (ofLex x) ≠ 0 := leadingCoeff_ne_zero.mp hpos.ne.symm
+    have htop : (ofLex x).orderTop ≠ ⊤ := orderTop_ne_top.2 hne
+    refine ⟨(ofLex x).orderTop.untop htop, ?_, by simpa [coeff_untop_eq_leadingCoeff] using hpos⟩
+    intro j hj
+    simpa using (coeff_eq_zero_of_lt_orderTop ((WithTop.lt_untop_iff htop).mp hj)).symm
   · intro ⟨i, hj, hi⟩
     have horder : (ofLex x).orderTop = WithTop.some i := by
       apply orderTop_eq_of_le
@@ -82,9 +79,9 @@ theorem leadingCoeff_pos_iff {x : Lex (HahnSeries Γ R)} : 0 < (ofLex x).leading
         contrapose! hg
         simpa using (hj g hg).symm
     have htop : (ofLex x).orderTop ≠ ⊤ := WithTop.ne_top_iff_exists.mpr ⟨i, horder.symm⟩
-    have hne : ofLex x ≠ 0 := ne_zero_iff_orderTop.mpr htop
+    have hne : ofLex x ≠ 0 := orderTop_ne_top.1 htop
     have horder' : (ofLex x).orderTop.untop htop = i := (WithTop.untop_eq_iff _).mpr horder
-    rw [← coeff_untop_eq_leadingCoeff hne, horder']
+    rw [leadingCoeff_of_ne_zero hne, horder']
     simpa using hi
 
 theorem leadingCoeff_nonneg_iff {x : Lex (HahnSeries Γ R)} :
@@ -92,7 +89,7 @@ theorem leadingCoeff_nonneg_iff {x : Lex (HahnSeries Γ R)} :
   constructor
   · intro h
     obtain heq | hlt := h.eq_or_lt
-    · exact le_of_eq (leadingCoeff_eq_iff.mp heq.symm).symm
+    · exact le_of_eq (leadingCoeff_eq_zero.mp heq.symm).symm
     · exact (leadingCoeff_pos_iff.mp hlt).le
   · intro h
     obtain rfl | hlt := h.eq_or_lt
@@ -149,7 +146,7 @@ theorem order_abs [Zero Γ] (x : Lex (HahnSeries Γ R)) : (ofLex |x|).order = (o
       change |x| ≠ 0
       simpa using hne
     apply WithTop.coe_injective
-    rw [order_eq_orderTop_of_ne habs, order_eq_orderTop_of_ne hne']
+    rw [order_eq_orderTop_of_ne_zero habs, order_eq_orderTop_of_ne_zero hne']
     apply orderTop_abs
 
 theorem leadingCoeff_abs (x : Lex (HahnSeries Γ R)) :

--- a/Mathlib/RingTheory/HahnSeries/Multiplication.lean
+++ b/Mathlib/RingTheory/HahnSeries/Multiplication.lean
@@ -354,12 +354,12 @@ theorem orderTop_vAdd_le_orderTop_smul {Γ Γ'} [LinearOrder Γ] [LinearOrder Γ
   by_cases hx : x = 0; · simp_all
   by_cases hy : y = 0; · simp_all
   have hhy : ((of R).symm y) ≠ 0 := hy
-  rw [HahnSeries.orderTop_of_ne hx, HahnSeries.orderTop_of_ne hhy, ← h,
+  rw [HahnSeries.orderTop_of_ne_zero hx, HahnSeries.orderTop_of_ne_zero hhy, ← h,
       ← Set.IsWF.min_vadd]
   by_cases hxy : (of R).symm (x • y) = 0
   · rw [hxy, HahnSeries.orderTop_zero]
     exact OrderTop.le_top (α := WithTop Γ') _
-  · rw [HahnSeries.orderTop_of_ne hxy, WithTop.coe_le_coe]
+  · rw [HahnSeries.orderTop_of_ne_zero hxy, WithTop.coe_le_coe]
     exact Set.IsWF.min_le_min_of_subset support_smul_subset_vadd_support
 
 theorem coeff_smul_order_add_order {Γ}
@@ -370,8 +370,9 @@ theorem coeff_smul_order_add_order {Γ}
   by_cases hx : x = (0 : HahnSeries Γ R); · simp [HahnSeries.coeff_zero, hx]
   by_cases hy : (of R).symm y = 0; · simp [hy, coeff_smul]
   rw [HahnSeries.order_of_ne hx, HahnSeries.order_of_ne hy, coeff_smul,
-    HahnSeries.leadingCoeff_of_ne hx, HahnSeries.leadingCoeff_of_ne hy, ← vadd_eq_add,
+    HahnSeries.leadingCoeff_of_ne_zero hx, HahnSeries.leadingCoeff_of_ne_zero hy, ← vadd_eq_add,
     Finset.vaddAntidiagonal_min_vadd_min, Finset.sum_singleton]
+  simp [HahnSeries.orderTop, hx, hy]
 
 end DistribSMul
 
@@ -501,7 +502,7 @@ theorem order_mul_of_nonzero {x y : HahnSeries Γ R}
     ne_of_eq_of_ne (coeff_mul_order_add_order x y) h
   refine le_antisymm (order_le_of_coeff_ne_zero
     (Eq.mpr (congrArg (fun _a ↦ _a ≠ 0) (coeff_mul_order_add_order x y)) h)) ?_
-  rw [order_of_ne <| leadingCoeff_ne_iff.mp hx, order_of_ne <| leadingCoeff_ne_iff.mp hy,
+  rw [order_of_ne <| leadingCoeff_ne_zero.mp hx, order_of_ne <| leadingCoeff_ne_zero.mp hy,
     order_of_ne <| ne_zero_of_coeff_ne_zero hxy, ← Set.IsWF.min_add]
   exact Set.IsWF.min_le_min_of_subset support_mul_subset_add_support
 
@@ -510,7 +511,7 @@ theorem order_single_mul_of_isRegular {g : Γ} {r : R} (hr : IsRegular r)
   obtain _ | _ := subsingleton_or_nontrivial R
   · exact (hx <| Subsingleton.eq_zero x).elim
   have hrx : ((single g) r).leadingCoeff * x.leadingCoeff ≠ 0 := by
-    rwa [leadingCoeff_of_single, ne_eq, hr.left.mul_left_eq_zero_iff, leadingCoeff_eq_iff]
+    rwa [leadingCoeff_of_single, ne_eq, hr.left.mul_left_eq_zero_iff, leadingCoeff_eq_zero]
   rw [order_mul_of_nonzero hrx, order_single <| IsRegular.ne_zero hr]
 
 end orderLemmas
@@ -660,8 +661,8 @@ instance instNoZeroSMulDivisors {Γ} [AddCommMonoid Γ] [LinearOrder Γ] [IsOrde
     refine ⟨x.order + ((of R).symm y).order, ?_⟩
     rw [coeff_smul_order_add_order x y, of_symm_zero, HahnSeries.coeff_zero, smul_eq_zero, not_or]
     constructor
-    · exact HahnSeries.leadingCoeff_ne_iff.mpr hxy.1
-    · exact HahnSeries.leadingCoeff_ne_iff.mpr hxy.2
+    · exact HahnSeries.leadingCoeff_ne_zero.mpr hxy.1
+    · exact HahnSeries.leadingCoeff_ne_zero.mpr hxy.2
 
 end HahnModule
 
@@ -690,7 +691,7 @@ theorem order_mul {Γ} [AddCommMonoid Γ] [LinearOrder Γ] [IsOrderedCancelAddMo
   apply le_antisymm
   · apply order_le_of_coeff_ne_zero
     rw [coeff_mul_order_add_order x y]
-    exact mul_ne_zero (leadingCoeff_ne_iff.mpr hx) (leadingCoeff_ne_iff.mpr hy)
+    exact mul_ne_zero (leadingCoeff_ne_zero.mpr hx) (leadingCoeff_ne_zero.mpr hy)
   · rw [order_of_ne hx, order_of_ne hy, order_of_ne (mul_ne_zero hx hy), ← Set.IsWF.min_add]
     exact Set.IsWF.min_le_min_of_subset support_mul_subset_add_support
 

--- a/Mathlib/RingTheory/HahnSeries/Summable.lean
+++ b/Mathlib/RingTheory/HahnSeries/Summable.lean
@@ -822,7 +822,7 @@ instance instField : Field (HahnSeries Γ R) where
   mul_inv_cancel x x0 := by
     have h :=
       SummableFamily.one_sub_self_mul_hsum_powers
-        (unit_aux x (inv_mul_cancel₀ (leadingCoeff_ne_iff.mpr x0)) _ (neg_add_cancel x.order))
+        (unit_aux x (inv_mul_cancel₀ (leadingCoeff_ne_zero.mpr x0)) _ (neg_add_cancel x.order))
     rw [sub_sub_cancel] at h
     rw [inv_def, ← mul_assoc, mul_comm x, h]
   nnqsmul := (· • ·)

--- a/Mathlib/RingTheory/HahnSeries/Valuation.lean
+++ b/Mathlib/RingTheory/HahnSeries/Valuation.lean
@@ -41,8 +41,8 @@ def addVal : AddValuation (HahnSeries Γ R) (WithTop Γ) :=
   fun x y => by
     by_cases hx : x = 0; · simp [hx]
     by_cases hy : y = 0; · simp [hy]
-    rw [← order_eq_orderTop_of_ne hx, ← order_eq_orderTop_of_ne hy,
-      ← order_eq_orderTop_of_ne (mul_ne_zero hx hy), ← WithTop.coe_add, WithTop.coe_eq_coe,
+    rw [← order_eq_orderTop_of_ne_zero hx, ← order_eq_orderTop_of_ne_zero hy,
+      ← order_eq_orderTop_of_ne_zero (mul_ne_zero hx hy), ← WithTop.coe_add, WithTop.coe_eq_coe,
       order_mul hx hy]
 
 variable {Γ} {R}
@@ -53,7 +53,7 @@ theorem addVal_apply {x : HahnSeries Γ R} :
 
 @[simp]
 theorem addVal_apply_of_ne {x : HahnSeries Γ R} (hx : x ≠ 0) : addVal Γ R x = x.order :=
-  addVal_apply.trans (order_eq_orderTop_of_ne hx).symm
+  addVal_apply.trans (order_eq_orderTop_of_ne_zero hx).symm
 
 theorem addVal_le_of_coeff_ne_zero {x : HahnSeries Γ R} {g : Γ} (h : x.coeff g ≠ 0) :
     addVal Γ R x ≤ g :=


### PR DESCRIPTION
A lot of lemmas were misnamed or the wrong way around.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
