### PR TITLE
[Merged by Bors] - feat: perfect pairings are preserved under linear equivs

### DIFF
--- a/Mathlib/LinearAlgebra/PerfectPairing/Basic.lean
+++ b/Mathlib/LinearAlgebra/PerfectPairing/Basic.lean
@@ -23,10 +23,12 @@ to connect 1 and 2.
 open Function Module
 
 namespace LinearMap
-variable {R K M N : Type*} [AddCommGroup M] [AddCommGroup N]
+variable {R K M M' N N' : Type*} [AddCommGroup M] [AddCommGroup N] [AddCommGroup M']
+  [AddCommGroup N']
 
 section CommRing
-variable [CommRing R] [Module R M] [Module R N] {p : M →ₗ[R] N →ₗ[R] R} {x : M} {y : N}
+variable [CommRing R] [Module R M] [Module R M'] [Module R N]  [Module R N']
+  {p : M →ₗ[R] N →ₗ[R] R} {x : M} {y : N}
 
 /-- For a ring `R` and two modules `M` and `N`, a perfect pairing is a bilinear map `M × N → R`
 that is bijective in both arguments. -/
@@ -81,6 +83,24 @@ protected instance IsPerfPair.id [IsReflexive R M] : IsPerfPair (.id (R := R) (M
 
 /-- A reflexive module has a perfect pairing with its dual. -/
 instance IsPerfPair.dualEval [IsReflexive R M] : IsPerfPair (Dual.eval R M) := .flip .id
+
+instance IsPerfPair.compl₁₂ (eM : M' ≃ₗ[R] M) (eN : N' ≃ₗ[R] N) :
+    (p.compl₁₂ eM eN : M' →ₗ[R] N' →ₗ[R] R).IsPerfPair :=
+  ⟨((LinearEquiv.congrLeft R R eN).symm.bijective.comp
+    (IsPerfPair.bijective_left p)).comp eM.bijective,
+    ((LinearEquiv.congrLeft R R eM).symm.bijective.comp
+    (IsPerfPair.bijective_right p)).comp eN.bijective⟩
+
+lemma IsPerfPair.congr (eM : M' ≃ₗ[R] M) (eN : N' ≃ₗ[R] N) (q : M' →ₗ[R] N' →ₗ[R] R)
+    (H : q.compl₁₂ eM.symm eN.symm = p) : q.IsPerfPair := by
+  obtain rfl : q = p.compl₁₂ eM eN := by subst H; ext; simp
+  infer_instance
+
+lemma IsPerfPair.of_bijective (p : M →ₗ[R] N →ₗ[R] R) [IsReflexive R N] (h : Bijective p) :
+    IsPerfPair p :=
+  inferInstanceAs ((LinearMap.id (R := R) (M := Dual R N)).compl₁₂
+    (LinearEquiv.ofBijective p h : M →ₗ[R] N →ₗ[R] R)
+    (LinearEquiv.refl R N : N →ₗ[R] N)).IsPerfPair
 
 end CommRing
 

--- a/Mathlib/LinearAlgebra/PerfectPairing/Basic.lean
+++ b/Mathlib/LinearAlgebra/PerfectPairing/Basic.lean
@@ -27,7 +27,7 @@ variable {R K M M' N N' : Type*} [AddCommGroup M] [AddCommGroup N] [AddCommGroup
   [AddCommGroup N']
 
 section CommRing
-variable [CommRing R] [Module R M] [Module R M'] [Module R N]  [Module R N']
+variable [CommRing R] [Module R M] [Module R M'] [Module R N] [Module R N']
   {p : M →ₗ[R] N →ₗ[R] R} {x : M} {y : N}
 
 /-- For a ring `R` and two modules `M` and `N`, a perfect pairing is a bilinear map `M × N → R`


### PR DESCRIPTION
We obtain as a corollary `IsPerfPair.of_bijective`, which is particularly versatile.

From Toric


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
