### PR TITLE
[Merged by Bors] - refactor: syntactically generalise the `Nontrivial (Fin n)` instance

### DIFF
--- a/Mathlib/Data/Fin/Basic.lean
+++ b/Mathlib/Data/Fin/Basic.lean
@@ -283,12 +283,11 @@ theorem val_one' (n : ℕ) [NeZero n] : ((1 : Fin n) : ℕ) = 1 % n :=
 theorem val_one'' {n : ℕ} : ((1 : Fin (n + 1)) : ℕ) = 1 % (n + 1) :=
   rfl
 
-instance nontrivial {n : ℕ} [NeZero n] : Nontrivial (Fin (n + 1)) where
-  exists_pair_ne := ⟨0, 1, (ne_iff_vne 0 1).mpr (by simp [val_one', val_zero, NeZero.ne])⟩
-
 theorem nontrivial_iff_two_le : Nontrivial (Fin n) ↔ 2 ≤ n := by
-  rcases n with (_ | _ | n) <;>
-  simp [Fin.nontrivial, not_nontrivial, Nat.succ_le_iff]
+  simp [← not_subsingleton_iff_nontrivial, subsingleton_iff_le_one]; omega
+
+instance instNontrivial [n.AtLeastTwo] : Nontrivial (Fin n) :=
+  nontrivial_iff_two_le.2 Nat.AtLeastTwo.one_lt
 
 /-- If working with more than two elements, we can always pick a third distinct from two existing
 elements. -/

--- a/Mathlib/Data/Nat/Cast/Defs.lean
+++ b/Mathlib/Data/Nat/Cast/Defs.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Gabriel Ebner
 -/
 import Mathlib.Algebra.Group.Defs
+import Mathlib.Data.Nat.Init
 import Mathlib.Tactic.SplitIfs
 import Mathlib.Tactic.OfNat
 
@@ -29,25 +30,6 @@ variable {R : Type*}
 protected def Nat.unaryCast [One R] [Zero R] [Add R] : ℕ → R
   | 0 => 0
   | n + 1 => Nat.unaryCast n + 1
-
--- the following four declarations are not in mathlib3 and are relevant to the way numeric
--- literals are handled in Lean 4.
-
-/-- A type class for natural numbers which are greater than or equal to `2`. -/
-class Nat.AtLeastTwo (n : ℕ) : Prop where
-  prop : 2 ≤ n
-
-instance instNatAtLeastTwo {n : ℕ} : Nat.AtLeastTwo (n + 2) where
-  prop := Nat.succ_le_succ <| Nat.succ_le_succ <| Nat.zero_le _
-
-namespace Nat.AtLeastTwo
-
-variable {n : ℕ} [n.AtLeastTwo]
-
-lemma one_lt : 1 < n := prop
-lemma ne_one : n ≠ 1 := Nat.ne_of_gt one_lt
-
-end Nat.AtLeastTwo
 
 /-- Recognize numeric literals which are at least `2` as terms of `R` via `Nat.cast`. This
 instance is what makes things like `37 : R` type check.  Note that `0` and `1` are not needed

--- a/Mathlib/Data/Nat/Init.lean
+++ b/Mathlib/Data/Nat/Init.lean
@@ -431,4 +431,24 @@ instance decidableLoHiLe (lo hi : ℕ) (P : ℕ → Prop) [DecidablePred P] :
   decidable_of_iff (∀ x, lo ≤ x → x < hi + 1 → P x) <|
     forall₂_congr fun _ _ ↦ imp_congr Nat.lt_succ_iff Iff.rfl
 
+/-! ### `Nat.AtLeastTwo` -/
+
+/-- A type class for natural numbers which are greater than or equal to `2`. -/
+class AtLeastTwo (n : ℕ) : Prop where
+  prop : 2 ≤ n
+
+instance instAtLeastTwo {n : ℕ} : Nat.AtLeastTwo (n + 2) where
+  prop := Nat.succ_le_succ <| Nat.succ_le_succ <| Nat.zero_le _
+
+instance {n : ℕ} [NeZero n] : (n + 1).AtLeastTwo := ⟨by have := NeZero.ne n; omega⟩
+
+namespace AtLeastTwo
+
+variable {n : ℕ} [n.AtLeastTwo]
+
+lemma one_lt : 1 < n := prop
+lemma ne_one : n ≠ 1 := Nat.ne_of_gt one_lt
+
+end AtLeastTwo
+
 end Nat

--- a/Mathlib/Tactic/NormNum/Result.lean
+++ b/Mathlib/Tactic/NormNum/Result.lean
@@ -121,7 +121,7 @@ def mkOfNat (α : Q(Type u)) (_sα : Q(AddMonoidWithOne $α)) (lit : Q(ℕ)) :
     | k+2 =>
       let k : Q(ℕ) := mkRawNatLit k
       let _x : Q(Nat.AtLeastTwo $lit) :=
-        (q(instNatAtLeastTwo (n := $k)) : Expr)
+        (q(Nat.instAtLeastTwo (n := $k)) : Expr)
       let a' : Q($α) := q(OfNat.ofNat $lit)
       pure ⟨a', (q(Eq.refl $a') : Expr)⟩
 

--- a/MathlibTest/FieldSimp.lean
+++ b/MathlibTest/FieldSimp.lean
@@ -622,7 +622,8 @@ example (m n : ℕ) (h : m ≤ n) (hm : (2:ℚ) < n - m) : (n:ℚ) / (n - m) = 1
 Check that `field_simp` works for units of a ring.
 -/
 
-variable {R : Type _} [CommRing R] (a b c d e f g : R) (u₁ u₂ : Rˣ)
+section CommRing
+variable {R : Type*} [CommRing R] (a b c d e f g : R) (u₁ u₂ : Rˣ)
 
 /--
 Check that `divp_add_divp_same` takes priority over `divp_add_divp`.
@@ -657,6 +658,8 @@ example : a /ₚ (u₁ / u₂) = a * u₂ /ₚ u₁ := by field_simp
 
 example : a /ₚ u₁ /ₚ u₂ = a /ₚ (u₂ * u₁) := by field_simp
 
+end CommRing
+
 /-! ## Algebraic structures weaker than `Field`
 
 TODO (new implementation): handle `CommGroupWithZero`, not just `Semifield`
@@ -664,10 +667,6 @@ TODO (new implementation): handle `CommGroupWithZero`, not just `Semifield`
 
 /--
 error: unsolved goals
-R : Type ?u.201754
-inst✝¹ : CommRing R
-a b c d e f g : R
-u₁ u₂ : Rˣ
 K : Type
 inst✝ : CommGroupWithZero K
 x y : K


### PR DESCRIPTION
This way, it applies to expression not of the form `_ + 1`.

Also move `Nat.AtLeastTwo` earlier to satisfy the `assert_not_exists` in `Data.Fin.Basic`.

From ForbiddenMatrix


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
