### PR TITLE
[Merged by Bors] - chore: include only master branch when migrating to fork

### DIFF
--- a/scripts/migrate_to_fork.py
+++ b/scripts/migrate_to_fork.py
@@ -290,7 +290,7 @@ def check_and_create_fork(username: str, auto_accept: bool = False) -> str:
     if yes_no_prompt("Would you like to create a fork?", auto_accept=auto_accept):
         try:
             print("Creating fork...")
-            run_command(['gh', 'repo', 'fork', 'leanprover-community/mathlib4', '--clone=false'])
+            run_command(['gh', 'repo', 'fork', 'leanprover-community/mathlib4', '--default-branch-only', '--clone=false'])
             print_success(f"Fork created: {repo_name}")
             return get_remote_url(repo_name, use_ssh)
         except Exception as e:


### PR DESCRIPTION
Forks should not include the >2k branches of mathlib4 by default as they add a lot of unnecessary overhead and make the forks harder to work with. This change matches the behavior of the githelper.py script.

See also
https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Old.20stale.20PRs/near/535150420

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
