### PR TITLE
[Merged by Bors] - feat: products of affine maps

### DIFF
--- a/Mathlib/Analysis/Normed/Affine/ContinuousAffineMap.lean
+++ b/Mathlib/Analysis/Normed/Affine/ContinuousAffineMap.lean
@@ -156,6 +156,26 @@ instance : AddTorsor (P →ᴬ[R] W) (P →ᴬ[R] Q) where
     (f -ᵥ g).toAffineMap = f.toAffineMap -ᵥ g.toAffineMap :=
   rfl
 
+section Prod
+
+variable {P₁ P₂ P₃ P₄ V₁ V₂ V₃ V₄ : Type*}
+  [NormedAddCommGroup V₁] [NormedSpace 𝕜 V₁] [MetricSpace P₁] [NormedAddTorsor V₁ P₁]
+  [NormedAddCommGroup V₂] [NormedSpace 𝕜 V₂] [MetricSpace P₂] [NormedAddTorsor V₂ P₂]
+  [NormedAddCommGroup V₃] [NormedSpace 𝕜 V₃] [MetricSpace P₃] [NormedAddTorsor V₃ P₃]
+  [NormedAddCommGroup V₄] [NormedSpace 𝕜 V₄] [MetricSpace P₄] [NormedAddTorsor V₄ P₄]
+
+@[simp]
+theorem prod_contLinear (f : P₁ →ᴬ[𝕜] P₂) (g : P₁ →ᴬ[𝕜] P₃) :
+    (f.prod g).contLinear = f.contLinear.prod g.contLinear :=
+  rfl
+
+@[simp]
+theorem prodMap_contLinear (f : P₁ →ᴬ[𝕜] P₂) (g : P₃ →ᴬ[𝕜] P₄) :
+    (f.prodMap g).contLinear = f.contLinear.prodMap g.contLinear :=
+  rfl
+
+end Prod
+
 section NormedSpaceStructure
 
 variable (f : V →ᴬ[𝕜] W)

--- a/Mathlib/Analysis/Normed/Group/AddTorsor.lean
+++ b/Mathlib/Analysis/Normed/Group/AddTorsor.lean
@@ -3,6 +3,7 @@ Copyright (c) 2020 Joseph Myers. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Myers, Yury Kudryashov
 -/
+import Mathlib.Analysis.Normed.Group.Constructions
 import Mathlib.Analysis.Normed.Group.Submodule
 import Mathlib.LinearAlgebra.AffineSpace.AffineSubspace.Basic
 import Mathlib.LinearAlgebra.AffineSpace.Midpoint
@@ -58,6 +59,11 @@ instance AffineSubspace.toNormedAddTorsor {R : Type*} [Ring R] [Module R V]
     (s : AffineSubspace R P) [Nonempty s] : NormedAddTorsor s.direction s :=
   { AffineSubspace.toAddTorsor s with
     dist_eq_norm' := fun x y => NormedAddTorsor.dist_eq_norm' x.val y.val }
+
+instance : NormedAddTorsor (V × W) (P × Q) where
+  dist_eq_norm' x y := by
+    simp only [Prod.dist_eq, NormedAddTorsor.dist_eq_norm', Prod.norm_def, Prod.fst_vsub,
+      Prod.snd_vsub]
 
 section
 

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineEquiv.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineEquiv.lean
@@ -369,6 +369,56 @@ def equivUnitsAffineMap : (P₁ ≃ᵃ[k] P₁) ≃* (P₁ →ᵃ[k] P₁)ˣ whe
       map_vadd' := fun _ _ => (u : P₁ →ᵃ[k] P₁).map_vadd _ _ }
   map_mul' _ _ := rfl
 
+section
+
+variable (e₁ : P₁ ≃ᵃ[k] P₂) (e₂ : P₃ ≃ᵃ[k] P₄)
+
+/-- Product of two affine equivalences. The map comes from `Equiv.prodCongr` -/
+@[simps linear]
+def prodCongr : P₁ × P₃ ≃ᵃ[k] P₂ × P₄ where
+  __ := Equiv.prodCongr e₁ e₂
+  linear := e₁.linear.prodCongr e₂.linear
+  map_vadd' := by simp
+
+@[simp]
+theorem prodCongr_symm : (e₁.prodCongr e₂).symm = e₁.symm.prodCongr e₂.symm :=
+  rfl
+
+@[simp]
+theorem prodCongr_apply (p : P₁ × P₃) : e₁.prodCongr e₂ p = (e₁ p.1, e₂ p.2) :=
+  rfl
+
+@[simp, norm_cast]
+theorem coe_prodCongr :
+    (e₁.prodCongr e₂ : P₁ × P₃ →ᵃ[k] P₂ × P₄) = (e₁ : P₁ →ᵃ[k] P₂).prodMap (e₂ : P₃ →ᵃ[k] P₄) :=
+  rfl
+
+end
+
+section
+
+variable (k P₁ P₂ P₃)
+
+/-- Product of affine spaces is commutative up to affine isomorphism. -/
+@[simps! apply linear]
+def prodComm : P₁ × P₂ ≃ᵃ[k] P₂ × P₁ where
+  __ := Equiv.prodComm P₁ P₂
+  linear := LinearEquiv.prodComm k V₁ V₂
+  map_vadd' := by simp
+
+@[simp]
+theorem prodComm_symm : (prodComm k P₁ P₂).symm = prodComm k P₂ P₁ :=
+  rfl
+
+/-- Product of affine spaces is associative up to affine isomorphism. -/
+@[simps! apply symm_apply linear]
+def prodAssoc : (P₁ × P₂) × P₃ ≃ᵃ[k] P₁ × (P₂ × P₃) where
+  __ := Equiv.prodAssoc P₁ P₂ P₃
+  linear := LinearEquiv.prodAssoc k V₁ V₂ V₃
+  map_vadd' := by simp
+
+end
+
 variable (k)
 
 /-- The map `v ↦ v +ᵥ b` as an affine equivalence between a module `V` and an affine space `P` with

--- a/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
@@ -435,6 +435,34 @@ theorem image_vsub_image {s t : Set P1} (f : P1 →ᵃ[k] P2) :
     exists_exists_and_eq_and, ← f.linearMap_vsub]
   grind
 
+/-- The product of two affine maps is an affine map. -/
+@[simps linear]
+def prod (f : P1 →ᵃ[k] P2) (g : P1 →ᵃ[k] P3) : P1 →ᵃ[k] P2 × P3 where
+  toFun := Pi.prod f g
+  linear := f.linear.prod g.linear
+  map_vadd' := by simp
+
+theorem coe_prod (f : P1 →ᵃ[k] P2) (g : P1 →ᵃ[k] P3) : prod f g = Pi.prod f g :=
+  rfl
+
+@[simp]
+theorem prod_apply (f : P1 →ᵃ[k] P2) (g : P1 →ᵃ[k] P3) (p : P1) : prod f g p = (f p, g p) :=
+  rfl
+
+/-- `Prod.map` of two affine maps. -/
+@[simps linear]
+def prodMap (f : P1 →ᵃ[k] P2) (g : P3 →ᵃ[k] P4) : P1 × P3 →ᵃ[k] P2 × P4 where
+  toFun := Prod.map f g
+  linear := f.linear.prodMap g.linear
+  map_vadd' := by simp
+
+theorem coe_prodMap (f : P1 →ᵃ[k] P2) (g : P3 →ᵃ[k] P4) : ⇑(f.prodMap g) = Prod.map f g :=
+  rfl
+
+@[simp]
+theorem prodMap_apply (f : P1 →ᵃ[k] P2) (g : P3 →ᵃ[k] P4) (x) : f.prodMap g x = (f x.1, g x.2) :=
+  rfl
+
 /-! ### Definition of `AffineMap.lineMap` and lemmas about it -/
 
 /-- The affine map from `k` to `P1` sending `0` to `p₀` and `1` to `p₁`. -/

--- a/Mathlib/LinearAlgebra/AffineSpace/ContinuousAffineEquiv.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/ContinuousAffineEquiv.lean
@@ -72,6 +72,10 @@ instance instEquivLike : EquivLike (P₁ ≃ᴬ[k] P₂) P₁ P₂ where
   right_inv f := f.right_inv
   coe_injective' _ _ h _ := toAffineEquiv_injective (DFunLike.coe_injective h)
 
+instance : HomeomorphClass (P₁ ≃ᴬ[k] P₂) P₁ P₂ where
+  map_continuous f := f.continuous_toFun
+  inv_continuous f := f.continuous_invFun
+
 attribute [coe] ContinuousAffineEquiv.toAffineEquiv
 
 /-- Coerce continuous affine equivalences to affine equivalences. -/
@@ -339,6 +343,56 @@ def constVAdd [ContinuousConstVAdd V₁ P₁] (v : V₁) : P₁ ≃ᴬ[k] P₁ w
 
 lemma constVAdd_coe [ContinuousConstVAdd V₁ P₁] (v : V₁) :
     (constVAdd k P₁ v).toAffineEquiv = .constVAdd k P₁ v := rfl
+
+end
+
+section
+
+variable (e₁ : P₁ ≃ᴬ[k] P₂) (e₂ : P₃ ≃ᴬ[k] P₄)
+
+/-- Product of two continuous affine equivalences. The map comes from `Equiv.prodCongr` -/
+@[simps toAffineEquiv]
+def prodCongr : P₁ × P₃ ≃ᴬ[k] P₂ × P₄ where
+  __ := AffineEquiv.prodCongr e₁ e₂
+  continuous_toFun := by eta_expand; dsimp; fun_prop
+  continuous_invFun := by eta_expand; dsimp; fun_prop
+
+@[simp]
+theorem prodCongr_symm : (e₁.prodCongr e₂).symm = e₁.symm.prodCongr e₂.symm :=
+  rfl
+
+@[simp]
+theorem prodCongr_apply (p : P₁ × P₃) : e₁.prodCongr e₂ p = (e₁ p.1, e₂ p.2) :=
+  rfl
+
+@[simp]
+theorem prodCongr_toContinuousAffineMap : (e₁.prodCongr e₂).toContinuousAffineMap =
+    e₁.toContinuousAffineMap.prodMap e₂.toContinuousAffineMap :=
+  rfl
+
+end
+
+section
+
+variable (k P₁ P₂ P₃)
+
+/-- Product of affine spaces is commutative up to continuous affine isomorphism. -/
+@[simps! apply symm_apply toAffineEquiv]
+def prodComm : P₁ × P₂ ≃ᴬ[k] P₂ × P₁ where
+  __ := AffineEquiv.prodComm k P₁ P₂
+  continuous_toFun := continuous_swap
+  continuous_invFun := continuous_swap
+
+@[simp]
+theorem prodComm_symm : (prodComm k P₁ P₂).symm = prodComm k P₂ P₁ :=
+  rfl
+
+/-- Product of affine spaces is associative up to continuous affine isomorphism. -/
+@[simps! apply symm_apply toAffineEquiv]
+def prodAssoc : (P₁ × P₂) × P₃ ≃ᴬ[k] P₁ × (P₂ × P₃) where
+  __ := AffineEquiv.prodAssoc k P₁ P₂ P₃
+  continuous_toFun := by eta_expand; dsimp; fun_prop
+  continuous_invFun := by eta_expand; dsimp; fun_prop
 
 end
 

--- a/Mathlib/Topology/Algebra/ContinuousAffineMap.lean
+++ b/Mathlib/Topology/Algebra/ContinuousAffineMap.lean
@@ -238,6 +238,42 @@ instance [Semiring S] [Module S W] [SMulCommClass R S W] [ContinuousConstSMul S 
 
 end ModuleValuedMaps
 
+section Prod
+
+variable {k P₁ P₂ P₃ P₄ V₁ V₂ V₃ V₄ : Type*} [Ring k]
+  [AddCommGroup V₁] [Module k V₁] [AddTorsor V₁ P₁] [TopologicalSpace P₁]
+  [AddCommGroup V₂] [Module k V₂] [AddTorsor V₂ P₂] [TopologicalSpace P₂]
+  [AddCommGroup V₃] [Module k V₃] [AddTorsor V₃ P₃] [TopologicalSpace P₃]
+  [AddCommGroup V₄] [Module k V₄] [AddTorsor V₄ P₄] [TopologicalSpace P₄]
+
+/-- The product of two continuous affine maps is a continuous affine map. -/
+@[simps toAffineMap]
+def prod (f : P₁ →ᴬ[k] P₂) (g : P₁ →ᴬ[k] P₃) : P₁ →ᴬ[k] P₂ × P₃ where
+  __ := AffineMap.prod f g
+  cont := by eta_expand; dsimp; fun_prop
+
+theorem coe_prod (f : P₁ →ᴬ[k] P₂) (g : P₁ →ᴬ[k] P₃) : prod f g = Pi.prod f g :=
+  rfl
+
+@[simp]
+theorem prod_apply (f : P₁ →ᴬ[k] P₂) (g : P₁ →ᴬ[k] P₃) (p : P₁) : prod f g p = (f p, g p) :=
+  rfl
+
+/-- `Prod.map` of two continuous affine maps. -/
+@[simps toAffineMap]
+def prodMap (f : P₁ →ᴬ[k] P₂) (g : P₃ →ᴬ[k] P₄) : P₁ × P₃ →ᴬ[k] P₂ × P₄ where
+  __ := AffineMap.prodMap f g
+  cont := by eta_expand; dsimp; fun_prop
+
+theorem coe_prodMap (f : P₁ →ᴬ[k] P₂) (g : P₃ →ᴬ[k] P₄) : ⇑(f.prodMap g) = Prod.map f g :=
+  rfl
+
+@[simp]
+theorem prodMap_apply (f : P₁ →ᴬ[k] P₂) (g : P₃ →ᴬ[k] P₄) (x) : f.prodMap g x = (f x.1, g x.2) :=
+  rfl
+
+end Prod
+
 end ContinuousAffineMap
 
 namespace ContinuousLinearMap


### PR DESCRIPTION
This PR defines some maps and isomorphisms between products of affine spaces.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
