### PR TITLE
[Merged by Bors] - feat(Algebra/Group): add theorems about `Submonoid.pi`

### DIFF
--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -163,19 +163,6 @@ section Pi
 
 variable {η : Type*} {f : η → Type*}
 
--- defined here and not in Algebra.Group.Submonoid.Operations to have access to Algebra.Group.Pi
-/-- A version of `Set.pi` for submonoids. Given an index set `I` and a family of submodules
-`s : Π i, Submonoid f i`, `pi I s` is the submonoid of dependent functions `f : Π i, f i` such that
-`f i` belongs to `Pi I s` whenever `i ∈ I`. -/
-@[to_additive /-- A version of `Set.pi` for `AddSubmonoid`s. Given an index set `I` and a family
-  of submodules `s : Π i, AddSubmonoid f i`, `pi I s` is the `AddSubmonoid` of dependent functions
-  `f : Π i, f i` such that `f i` belongs to `pi I s` whenever `i ∈ I`. -/]
-def _root_.Submonoid.pi [∀ i, MulOneClass (f i)] (I : Set η) (s : ∀ i, Submonoid (f i)) :
-    Submonoid (∀ i, f i) where
-  carrier := I.pi fun i => (s i).carrier
-  one_mem' i _ := (s i).one_mem
-  mul_mem' hp hq i hI := (s i).mul_mem (hp i hI) (hq i hI)
-
 variable [∀ i, Group (f i)]
 
 /-- A version of `Set.pi` for subgroups. Given an index set `I` and a family of submodules

--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -211,7 +211,7 @@ theorem mulSingle_mem_pi [DecidableEq η] {I : Set η} {H : ∀ i, Subgroup (f i
 @[to_additive]
 theorem pi_eq_bot_iff (H : ∀ i, Subgroup (f i)) : pi Set.univ H = ⊥ ↔ ∀ i, H i = ⊥ := by
   simp_rw [SetLike.ext'_iff]
-  exact Set.pi_univ_eq_singleton_iff
+  exact Set.univ_pi_eq_singleton_iff
 
 end Pi
 

--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -196,43 +196,22 @@ theorem pi_empty (H : ∀ i, Subgroup (f i)) : pi ∅ H = ⊤ :=
 
 @[to_additive]
 theorem pi_bot : (pi Set.univ fun i => (⊥ : Subgroup (f i))) = ⊥ :=
-  (eq_bot_iff_forall _).mpr fun p hp => by
-    simp only [mem_pi, mem_bot] at *
-    ext j
-    exact hp j trivial
+  ext fun x => by simp [mem_pi, funext_iff]
 
 @[to_additive]
 theorem le_pi_iff {I : Set η} {H : ∀ i, Subgroup (f i)} {J : Subgroup (∀ i, f i)} :
-    J ≤ pi I H ↔ ∀ i : η, i ∈ I → map (Pi.evalMonoidHom f i) J ≤ H i := by
-  constructor
-  · intro h i hi
-    rintro _ ⟨x, hx, rfl⟩
-    exact (h hx) _ hi
-  · intro h x hx i hi
-    exact h i hi ⟨_, hx, rfl⟩
+    J ≤ pi I H ↔ ∀ i : η, i ∈ I → map (Pi.evalMonoidHom f i) J ≤ H i :=
+  Set.subset_pi_iff
 
 @[to_additive (attr := simp)]
 theorem mulSingle_mem_pi [DecidableEq η] {I : Set η} {H : ∀ i, Subgroup (f i)} (i : η) (x : f i) :
-    Pi.mulSingle i x ∈ pi I H ↔ i ∈ I → x ∈ H i := by
-  constructor
-  · intro h hi
-    simpa using h i hi
-  · intro h j hj
-    by_cases heq : j = i
-    · subst heq
-      simpa using h hj
-    · simp [heq, one_mem]
+    Pi.mulSingle i x ∈ pi I H ↔ i ∈ I → x ∈ H i :=
+  Set.update_mem_pi (one_mem (pi I H))
 
 @[to_additive]
 theorem pi_eq_bot_iff (H : ∀ i, Subgroup (f i)) : pi Set.univ H = ⊥ ↔ ∀ i, H i = ⊥ := by
-  classical
-    simp only [eq_bot_iff_forall]
-    constructor
-    · intro h i x hx
-      have : MonoidHom.mulSingle f i x = 1 :=
-        h (MonoidHom.mulSingle f i x) ((mulSingle_mem_pi i x).mpr fun _ => hx)
-      simpa using congr_fun this i
-    · exact fun h x hx => funext fun i => h _ _ (hx i trivial)
+  simp_rw [SetLike.ext'_iff]
+  exact Set.pi_univ_eq_singleton_iff
 
 end Pi
 

--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -200,7 +200,7 @@ theorem pi_bot : (pi Set.univ fun i => (⊥ : Subgroup (f i))) = ⊥ :=
 
 @[to_additive]
 theorem le_pi_iff {I : Set η} {H : ∀ i, Subgroup (f i)} {J : Subgroup (∀ i, f i)} :
-    J ≤ pi I H ↔ ∀ i : η, i ∈ I → map (Pi.evalMonoidHom f i) J ≤ H i :=
+    J ≤ pi I H ↔ ∀ i ∈ I, J ≤ comap (Pi.evalMonoidHom f i) (H i) :=
   Set.subset_pi_iff
 
 @[to_additive (attr := simp)]

--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -206,12 +206,12 @@ theorem le_pi_iff {I : Set η} {H : ∀ i, Subgroup (f i)} {J : Subgroup (∀ i,
 @[to_additive (attr := simp)]
 theorem mulSingle_mem_pi [DecidableEq η] {I : Set η} {H : ∀ i, Subgroup (f i)} (i : η) (x : f i) :
     Pi.mulSingle i x ∈ pi I H ↔ i ∈ I → x ∈ H i :=
-  Set.update_mem_pi (one_mem (pi I H))
+  Set.update_mem_pi_iff (one_mem (pi I H))
 
 @[to_additive]
 theorem pi_eq_bot_iff (H : ∀ i, Subgroup (f i)) : pi Set.univ H = ⊥ ↔ ∀ i, H i = ⊥ := by
   simp_rw [SetLike.ext'_iff]
-  exact Set.pi_univ_eq_singleton_iff
+  exact Set.univ_pi_eq_singleton_iff
 
 end Pi
 

--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -211,7 +211,7 @@ theorem mulSingle_mem_pi [DecidableEq η] {I : Set η} {H : ∀ i, Subgroup (f i
 @[to_additive]
 theorem pi_eq_bot_iff (H : ∀ i, Subgroup (f i)) : pi Set.univ H = ⊥ ↔ ∀ i, H i = ⊥ := by
   simp_rw [SetLike.ext'_iff]
-  exact Set.univ_pi_eq_singleton_iff
+  exact Set.pi_univ_eq_singleton_iff
 
 end Pi
 

--- a/Mathlib/Algebra/Group/Subgroup/Basic.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Basic.lean
@@ -206,7 +206,7 @@ theorem le_pi_iff {I : Set η} {H : ∀ i, Subgroup (f i)} {J : Subgroup (∀ i,
 @[to_additive (attr := simp)]
 theorem mulSingle_mem_pi [DecidableEq η] {I : Set η} {H : ∀ i, Subgroup (f i)} (i : η) (x : f i) :
     Pi.mulSingle i x ∈ pi I H ↔ i ∈ I → x ∈ H i :=
-  Set.update_mem_pi_iff (one_mem (pi I H))
+  Set.update_mem_pi_iff_of_mem (one_mem (pi I H))
 
 @[to_additive]
 theorem pi_eq_bot_iff (H : ∀ i, Subgroup (f i)) : pi Set.univ H = ⊥ ↔ ∀ i, H i = ⊥ := by

--- a/Mathlib/Algebra/Group/Submonoid/Operations.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Operations.lean
@@ -978,7 +978,7 @@ theorem mulSingle_mem_pi [DecidableEq ι] {I : Set ι} {S : ∀ i, Submonoid (M 
 @[to_additive]
 theorem pi_eq_bot_iff (S : ∀ i, Submonoid (M i)) : pi Set.univ S = ⊥ ↔ ∀ i, S i = ⊥ := by
   simp_rw [SetLike.ext'_iff]
-  exact Set.univ_pi_eq_singleton_iff
+  exact Set.pi_univ_eq_singleton_iff
 
 end Pi
 

--- a/Mathlib/Algebra/Group/Submonoid/Operations.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Operations.lean
@@ -973,12 +973,12 @@ theorem le_pi_iff {I : Set ι} {S : ∀ i, Submonoid (M i)} {J : Submonoid (∀ 
 @[to_additive (attr := simp)]
 theorem mulSingle_mem_pi [DecidableEq ι] {I : Set ι} {S : ∀ i, Submonoid (M i)} (i : ι) (x : M i) :
     Pi.mulSingle i x ∈ pi I S ↔ i ∈ I → x ∈ S i :=
-  Set.update_mem_pi (one_mem (pi I _))
+  Set.update_mem_pi_iff (one_mem (pi I _))
 
 @[to_additive]
 theorem pi_eq_bot_iff (S : ∀ i, Submonoid (M i)) : pi Set.univ S = ⊥ ↔ ∀ i, S i = ⊥ := by
   simp_rw [SetLike.ext'_iff]
-  exact Set.pi_univ_eq_singleton_iff
+  exact Set.univ_pi_eq_singleton_iff
 
 end Pi
 

--- a/Mathlib/Algebra/Group/Submonoid/Operations.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Operations.lean
@@ -978,7 +978,7 @@ theorem mulSingle_mem_pi [DecidableEq ι] {I : Set ι} {S : ∀ i, Submonoid (M 
 @[to_additive]
 theorem pi_eq_bot_iff (S : ∀ i, Submonoid (M i)) : pi Set.univ S = ⊥ ↔ ∀ i, S i = ⊥ := by
   simp_rw [SetLike.ext'_iff]
-  exact Set.pi_univ_eq_singleton_iff
+  exact Set.univ_pi_eq_singleton_iff
 
 end Pi
 

--- a/Mathlib/Algebra/Group/Submonoid/Operations.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Operations.lean
@@ -963,43 +963,22 @@ theorem pi_empty (H : ∀ i, Submonoid (M i)) : pi ∅ H = ⊤ :=
 
 @[to_additive]
 theorem pi_bot : (pi Set.univ fun i => (⊥ : Submonoid (M i))) = ⊥ :=
-  (eq_bot_iff_forall _).mpr fun p hp => by
-    simp only [mem_pi, mem_bot] at *
-    ext j
-    exact hp j trivial
+  ext fun x => by simp [mem_pi, funext_iff]
 
 @[to_additive]
 theorem le_pi_iff {I : Set ι} {S : ∀ i, Submonoid (M i)} {J : Submonoid (∀ i, M i)} :
-    J ≤ pi I S ↔ ∀ i ∈ I, map (Pi.evalMonoidHom M i) J ≤ S i := by
-  constructor
-  · intro h i hi
-    rintro _ ⟨x, hx, rfl⟩
-    exact (h hx) _ hi
-  · intro h x hx i hi
-    exact h i hi ⟨_, hx, rfl⟩
+    J ≤ pi I S ↔ ∀ i ∈ I, map (Pi.evalMonoidHom M i) J ≤ S i :=
+  Set.subset_pi_iff
 
 @[to_additive (attr := simp)]
 theorem mulSingle_mem_pi [DecidableEq ι] {I : Set ι} {S : ∀ i, Submonoid (M i)} (i : ι) (x : M i) :
-    Pi.mulSingle i x ∈ pi I S ↔ i ∈ I → x ∈ S i := by
-  constructor
-  · intro h hi
-    simpa using h i hi
-  · intro h j hj
-    by_cases heq : j = i
-    · subst heq
-      simpa using h hj
-    · simp [heq, one_mem]
+    Pi.mulSingle i x ∈ pi I S ↔ i ∈ I → x ∈ S i :=
+  Set.update_mem_pi (one_mem (pi I _))
 
 @[to_additive]
 theorem pi_eq_bot_iff (S : ∀ i, Submonoid (M i)) : pi Set.univ S = ⊥ ↔ ∀ i, S i = ⊥ := by
-  classical
-  simp only [eq_bot_iff_forall]
-  constructor
-  · intro h i x hx
-    have : MonoidHom.mulSingle M i x = 1 :=
-      h (MonoidHom.mulSingle M i x) ((mulSingle_mem_pi i x).mpr fun _ => hx)
-    simpa using congr_fun this i
-  · exact fun h x hx => funext fun i => h _ _ (hx i trivial)
+  simp_rw [SetLike.ext'_iff]
+  exact Set.pi_univ_eq_singleton_iff
 
 end Pi
 

--- a/Mathlib/Algebra/Group/Submonoid/Operations.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Operations.lean
@@ -973,7 +973,7 @@ theorem le_pi_iff {I : Set ι} {S : ∀ i, Submonoid (M i)} {J : Submonoid (∀ 
 @[to_additive (attr := simp)]
 theorem mulSingle_mem_pi [DecidableEq ι] {I : Set ι} {S : ∀ i, Submonoid (M i)} (i : ι) (x : M i) :
     Pi.mulSingle i x ∈ pi I S ↔ i ∈ I → x ∈ S i :=
-  Set.update_mem_pi_iff (one_mem (pi I _))
+  Set.update_mem_pi_iff_of_mem (one_mem (pi I _))
 
 @[to_additive]
 theorem pi_eq_bot_iff (S : ∀ i, Submonoid (M i)) : pi Set.univ S = ⊥ ↔ ∀ i, S i = ⊥ := by

--- a/Mathlib/Algebra/Group/Submonoid/Operations.lean
+++ b/Mathlib/Algebra/Group/Submonoid/Operations.lean
@@ -967,7 +967,7 @@ theorem pi_bot : (pi Set.univ fun i => (⊥ : Submonoid (M i))) = ⊥ :=
 
 @[to_additive]
 theorem le_pi_iff {I : Set ι} {S : ∀ i, Submonoid (M i)} {J : Submonoid (∀ i, M i)} :
-    J ≤ pi I S ↔ ∀ i ∈ I, map (Pi.evalMonoidHom M i) J ≤ S i :=
+    J ≤ pi I S ↔ ∀ i ∈ I, J ≤ comap (Pi.evalMonoidHom M i) (S i) :=
   Set.subset_pi_iff
 
 @[to_additive (attr := simp)]

--- a/Mathlib/Data/Set/Prod.lean
+++ b/Mathlib/Data/Set/Prod.lean
@@ -21,6 +21,11 @@ This file contains basic results on the following notions, which are defined in 
 * `Set.diagonal`: Diagonal of a type. `Set.diagonal α = {(x, x) | x : α}`.
 * `Set.offDiag`: Off-diagonal. `s ×ˢ s` without the diagonal.
 * `Set.pi`: Arbitrary product of sets.
+
+## Note
+
+Some theorems on `Set.pi` are misnamed. Since `Set.pi` does not have infix notation, we should
+preserve the order of appearance when naming declarations.
 -/
 
 
@@ -820,7 +825,7 @@ theorem update_mem_pi_iff [DecidableEq ι] {a} (ha : a ∈ pi s t) {i b} :
   · intro h j
     by_cases heq : j = i <;> grind [update_self, update_of_ne]
 
-theorem univ_pi_eq_singleton_iff {a} : pi univ t = {a} ↔ ∀ i, t i = {a i} := by
+theorem pi_univ_eq_singleton_iff {a} : pi univ t = {a} ↔ ∀ i, t i = {a i} := by
   classical
   simp only [eq_singleton_iff_unique_mem]
   refine ⟨fun ⟨h₁, h₂⟩ i => ⟨by grind, fun x hx => ?_⟩, by grind⟩

--- a/Mathlib/Data/Set/Prod.lean
+++ b/Mathlib/Data/Set/Prod.lean
@@ -813,18 +813,23 @@ theorem range_piMap (f : ∀ i, α i → β i) : range (Pi.map f) = pi univ fun 
 theorem subset_pi_iff {s'} : s' ⊆ pi s t ↔ ∀ i ∈ s, s' ⊆ (· i) ⁻¹' t i := by
   grind
 
-theorem update_mem_pi_iff [DecidableEq ι] {a} (ha : a ∈ pi s t) {i b} :
-    update a i b ∈ pi s t ↔ i ∈ s → b ∈ t i := by
+theorem update_mem_pi_iff [DecidableEq ι] {a : ∀ i, α i} {i : ι} {b : α i} :
+    update a i b ∈ pi s t ↔ a ∈ pi (s \ {i}) t ∧ (i ∈ s → b ∈ t i) := by
   constructor
   · grind [update_self, update_of_ne]
-  · intro h j
-    by_cases heq : j = i <;> grind [update_self, update_of_ne]
+  · rintro h j
+    cases eq_or_ne i j <;> grind [update_self, update_of_ne]
+
+theorem update_mem_pi_iff_of_mem [DecidableEq ι] {a : ∀ i, α i} {i : ι} {b : α i}
+    (ha : a ∈ pi s t) : update a i b ∈ pi s t ↔ i ∈ s → b ∈ t i := by
+  rw [update_mem_pi_iff, and_iff_right]
+  exact fun j hj => ha j hj.1
 
 theorem univ_pi_eq_singleton_iff {a} : pi univ t = {a} ↔ ∀ i, t i = {a i} := by
   classical
   simp only [eq_singleton_iff_unique_mem]
   refine ⟨fun ⟨h₁, h₂⟩ i => ⟨by grind, fun x hx => ?_⟩, by grind⟩
-  rw [← h₂ _ fun j _ => (update_mem_pi_iff h₁).mpr (fun _ => hx) j trivial, update_self]
+  rw [← h₂ _ fun j _ => (update_mem_pi_iff_of_mem h₁).mpr (fun _ => hx) j trivial, update_self]
 
 theorem pi_subset_pi_iff : pi s t₁ ⊆ pi s t₂ ↔ (∀ i ∈ s, t₁ i ⊆ t₂ i) ∨ pi s t₁ = ∅ := by
   refine

--- a/Mathlib/Data/Set/Prod.lean
+++ b/Mathlib/Data/Set/Prod.lean
@@ -810,7 +810,7 @@ theorem piMap_image_univ_pi (f : ∀ i, α i → β i) (t : ∀ i, Set (α i)) :
 theorem range_piMap (f : ∀ i, α i → β i) : range (Pi.map f) = pi univ fun i ↦ range (f i) := by
   simp only [← image_univ, ← piMap_image_univ_pi, pi_univ]
 
-theorem subset_pi_iff {s'} : s' ⊆ pi s t ↔ ∀ i ∈ s, (· i) '' s' ⊆ t i := by
+theorem subset_pi_iff {s'} : s' ⊆ pi s t ↔ ∀ i ∈ s, s' ⊆ (· i) ⁻¹' t i := by
   grind
 
 theorem update_mem_pi_iff [DecidableEq ι] {a} (ha : a ∈ pi s t) {i b} :

--- a/Mathlib/Data/Set/Prod.lean
+++ b/Mathlib/Data/Set/Prod.lean
@@ -21,11 +21,6 @@ This file contains basic results on the following notions, which are defined in 
 * `Set.diagonal`: Diagonal of a type. `Set.diagonal α = {(x, x) | x : α}`.
 * `Set.offDiag`: Off-diagonal. `s ×ˢ s` without the diagonal.
 * `Set.pi`: Arbitrary product of sets.
-
-## Note
-
-Some theorems on `Set.pi` are misnamed. Since `Set.pi` does not have infix notation, we should
-preserve the order of appearance when naming declarations.
 -/
 
 
@@ -825,7 +820,7 @@ theorem update_mem_pi_iff [DecidableEq ι] {a} (ha : a ∈ pi s t) {i b} :
   · intro h j
     by_cases heq : j = i <;> grind [update_self, update_of_ne]
 
-theorem pi_univ_eq_singleton_iff {a} : pi univ t = {a} ↔ ∀ i, t i = {a i} := by
+theorem univ_pi_eq_singleton_iff {a} : pi univ t = {a} ↔ ∀ i, t i = {a i} := by
   classical
   simp only [eq_singleton_iff_unique_mem]
   refine ⟨fun ⟨h₁, h₂⟩ i => ⟨by grind, fun x hx => ?_⟩, by grind⟩

--- a/Mathlib/Data/Set/Prod.lean
+++ b/Mathlib/Data/Set/Prod.lean
@@ -811,31 +811,20 @@ theorem range_piMap (f : ∀ i, α i → β i) : range (Pi.map f) = pi univ fun 
   simp only [← image_univ, ← piMap_image_univ_pi, pi_univ]
 
 theorem subset_pi_iff {s'} : s' ⊆ pi s t ↔ ∀ i ∈ s, (· i) '' s' ⊆ t i := by
-  constructor
-  · intro h i hi
-    rintro _ ⟨x, hx, rfl⟩
-    exact h hx _ hi
-  · intro h x hx i hi
-    exact h i hi ⟨_, hx, rfl⟩
+  grind
 
 theorem update_mem_pi_iff [DecidableEq ι] {a} (ha : a ∈ pi s t) {i b} :
     update a i b ∈ pi s t ↔ i ∈ s → b ∈ t i := by
   constructor
-  · intro h hi
-    simpa using h i hi
-  · intro h j hj
-    by_cases heq : j = i
-    · subst heq
-      simpa using h hj
-    · simpa [heq] using ha j hj
+  · grind [update_self, update_of_ne]
+  · intro h j
+    by_cases heq : j = i <;> grind [update_self, update_of_ne]
 
 theorem univ_pi_eq_singleton_iff {a} : pi univ t = {a} ↔ ∀ i, t i = {a i} := by
   classical
   simp only [eq_singleton_iff_unique_mem]
-  constructor
-  · refine fun ⟨h₁, h₂⟩ i => ⟨h₁ i trivial, fun x hx => ?_⟩
-    rw [← h₂ _ fun j _ => (update_mem_pi_iff h₁).mpr (fun _ => hx) j trivial, update_self]
-  · exact fun h => ⟨fun i _ => (h i).1, fun x hx => funext fun i => (h i).2 _ (hx _ trivial)⟩
+  refine ⟨fun ⟨h₁, h₂⟩ i => ⟨by grind, fun x hx => ?_⟩, by grind⟩
+  rw [← h₂ _ fun j _ => (update_mem_pi_iff h₁).mpr (fun _ => hx) j trivial, update_self]
 
 theorem pi_subset_pi_iff : pi s t₁ ⊆ pi s t₂ ↔ (∀ i ∈ s, t₁ i ⊆ t₂ i) ∨ pi s t₁ = ∅ := by
   refine

--- a/Mathlib/Data/Set/Prod.lean
+++ b/Mathlib/Data/Set/Prod.lean
@@ -814,7 +814,7 @@ theorem subset_pi_iff {s'} : s' ⊆ pi s t ↔ ∀ i ∈ s, (· i) '' s' ⊆ t i
   constructor
   · intro h i hi
     rintro _ ⟨x, hx, rfl⟩
-    exact (h hx) _ hi
+    exact h hx _ hi
   · intro h x hx i hi
     exact h i hi ⟨_, hx, rfl⟩
 
@@ -834,7 +834,7 @@ theorem univ_pi_eq_singleton_iff {a} : pi univ t = {a} ↔ ∀ i, t i = {a i} :=
   simp only [eq_singleton_iff_unique_mem]
   constructor
   · refine fun ⟨h₁, h₂⟩ i => ⟨h₁ i trivial, fun x hx => ?_⟩
-    rw [← h₂ _ fun j _ => ((update_mem_pi_iff h₁).mpr (fun _ => hx)) j trivial, update_self]
+    rw [← h₂ _ fun j _ => (update_mem_pi_iff h₁).mpr (fun _ => hx) j trivial, update_self]
   · exact fun h => ⟨fun i _ => (h i).1, fun x hx => funext fun i => (h i).2 _ (hx _ trivial)⟩
 
 theorem pi_subset_pi_iff : pi s t₁ ⊆ pi s t₂ ↔ (∀ i ∈ s, t₁ i ⊆ t₂ i) ∨ pi s t₁ = ∅ := by

--- a/Mathlib/Data/Set/Prod.lean
+++ b/Mathlib/Data/Set/Prod.lean
@@ -818,7 +818,7 @@ theorem subset_pi_iff {s'} : s' ⊆ pi s t ↔ ∀ i ∈ s, (· i) '' s' ⊆ t i
   · intro h x hx i hi
     exact h i hi ⟨_, hx, rfl⟩
 
-theorem update_mem_pi [DecidableEq ι] {a} (ha : a ∈ pi s t) {i b} :
+theorem update_mem_pi_iff [DecidableEq ι] {a} (ha : a ∈ pi s t) {i b} :
     update a i b ∈ pi s t ↔ i ∈ s → b ∈ t i := by
   constructor
   · intro h hi
@@ -829,12 +829,12 @@ theorem update_mem_pi [DecidableEq ι] {a} (ha : a ∈ pi s t) {i b} :
       simpa using h hj
     · simpa [heq] using ha j hj
 
-theorem pi_univ_eq_singleton_iff {a} : pi univ t = {a} ↔ ∀ i, t i = {a i} := by
+theorem univ_pi_eq_singleton_iff {a} : pi univ t = {a} ↔ ∀ i, t i = {a i} := by
   classical
   simp only [eq_singleton_iff_unique_mem]
   constructor
   · refine fun ⟨h₁, h₂⟩ i => ⟨h₁ i trivial, fun x hx => ?_⟩
-    rw [← h₂ _ fun j _ => ((update_mem_pi h₁).mpr (fun _ => hx)) j trivial, update_self]
+    rw [← h₂ _ fun j _ => ((update_mem_pi_iff h₁).mpr (fun _ => hx)) j trivial, update_self]
   · exact fun h => ⟨fun i _ => (h i).1, fun x hx => funext fun i => (h i).2 _ (hx _ trivial)⟩
 
 theorem pi_subset_pi_iff : pi s t₁ ⊆ pi s t₂ ↔ (∀ i ∈ s, t₁ i ⊆ t₂ i) ∨ pi s t₁ = ∅ := by

--- a/Mathlib/Data/Set/Prod.lean
+++ b/Mathlib/Data/Set/Prod.lean
@@ -810,6 +810,33 @@ theorem piMap_image_univ_pi (f : ∀ i, α i → β i) (t : ∀ i, Set (α i)) :
 theorem range_piMap (f : ∀ i, α i → β i) : range (Pi.map f) = pi univ fun i ↦ range (f i) := by
   simp only [← image_univ, ← piMap_image_univ_pi, pi_univ]
 
+theorem subset_pi_iff {s'} : s' ⊆ pi s t ↔ ∀ i ∈ s, (· i) '' s' ⊆ t i := by
+  constructor
+  · intro h i hi
+    rintro _ ⟨x, hx, rfl⟩
+    exact (h hx) _ hi
+  · intro h x hx i hi
+    exact h i hi ⟨_, hx, rfl⟩
+
+theorem update_mem_pi [DecidableEq ι] {a} (ha : a ∈ pi s t) {i b} :
+    update a i b ∈ pi s t ↔ i ∈ s → b ∈ t i := by
+  constructor
+  · intro h hi
+    simpa using h i hi
+  · intro h j hj
+    by_cases heq : j = i
+    · subst heq
+      simpa using h hj
+    · simpa [heq] using ha j hj
+
+theorem pi_univ_eq_singleton_iff {a} : pi univ t = {a} ↔ ∀ i, t i = {a i} := by
+  classical
+  simp only [eq_singleton_iff_unique_mem]
+  constructor
+  · refine fun ⟨h₁, h₂⟩ i => ⟨h₁ i trivial, fun x hx => ?_⟩
+    rw [← h₂ _ fun j _ => ((update_mem_pi h₁).mpr (fun _ => hx)) j trivial, update_self]
+  · exact fun h => ⟨fun i _ => (h i).1, fun x hx => funext fun i => (h i).2 _ (hx _ trivial)⟩
+
 theorem pi_subset_pi_iff : pi s t₁ ⊆ pi s t₂ ↔ (∀ i ∈ s, t₁ i ⊆ t₂ i) ∨ pi s t₁ = ∅ := by
   refine
     ⟨fun h => or_iff_not_imp_right.2 ?_, fun h => h.elim pi_mono fun h' => h'.symm ▸ empty_subset _⟩

--- a/Mathlib/GroupTheory/Commutator/Finite.lean
+++ b/Mathlib/GroupTheory/Commutator/Finite.lean
@@ -29,7 +29,7 @@ theorem commutator_pi_pi_of_finite {η : Type*} [Finite η] {Gs : η → Type*} 
     apply commutator_mono <;>
       · rw [le_pi_iff]
         intro j _hj
-        rintro _ ⟨_, ⟨x, hx, rfl⟩, rfl⟩
+        rintro _ ⟨x, hx, rfl⟩
         by_cases h : j = i
         · subst h
           simpa using hx


### PR DESCRIPTION
This PR adds theorems on `Submonoid.pi`, which are the same theorems on `Subgroup.pi`.

Also chore:
1. moved `Submonoid.pi` from Subgroup/Basic.lean to Submonoid/Operations.lean, which is a more suitable place.
2. changed the type of `Subgroup.le_pi_iff`, to align with its simp normal form in `Set` (see [`Set.image_subset_iff`](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/Set/Image.html#Set.image_subset_iff)).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
