### PR TITLE
chore: deprecate `bsup`, `lsub`, `blsub`

### DIFF
--- a/Mathlib/Order/IsNormal.lean
+++ b/Mathlib/Order/IsNormal.lean
@@ -56,23 +56,6 @@ theorem of_mem_lowerBounds_upperBounds {f : α → β} (hf : StrictMono f)
     (hl : ∀ {a}, IsSuccLimit a → f a ∈ lowerBounds (upperBounds (f '' Iio a))) : IsNormal f :=
   ⟨hf, hl⟩
 
-theorem of_succ_lt [SuccOrder α] [WellFoundedLT α]
-    (hs : ∀ a, f a < f (succ a)) (hl : ∀ {a}, IsSuccLimit a → IsLUB (f '' Iio a) (f a)) :
-    IsNormal f := by
-  refine ⟨fun a b ↦ ?_, fun ha ↦ (hl ha).2⟩
-  induction b using SuccOrder.limitRecOn with
-  | isMin b hb => exact hb.not_lt.elim
-  | succ b hb IH =>
-    intro hab
-    obtain rfl | h := (lt_succ_iff_eq_or_lt_of_not_isMax hb).1 hab
-    · exact hs a
-    · exact (IH h).trans (hs b)
-  | isSuccLimit b hb IH =>
-    intro hab
-    have hab' := hb.succ_lt hab
-    exact (IH _ hab' (lt_succ_of_not_isMax hab.not_isMax)).trans_le
-      ((hl hb).1 (mem_image_of_mem _ hab'))
-
 theorem le_iff_forall_le (hf : IsNormal f) (ha : IsSuccLimit a) {b : β} :
     f a ≤ b ↔ ∀ a' < a, f a' ≤ b := by
   simpa [mem_upperBounds] using isLUB_le_iff (hf.isLUB_image_Iio_of_isSuccLimit ha)
@@ -124,10 +107,45 @@ theorem comp (hg : IsNormal g) (hf : IsNormal f) : IsNormal (g ∘ f) := by
   simpa [hg.le_iff_forall_le (hf.map_isSuccLimit ha), hf.lt_iff_exists_lt ha] using
     fun c d hd hc ↦ (hg.strictMono hc).le.trans (hb hd)
 
+section WellFoundedLT
+
+variable [WellFoundedLT α] [SuccOrder α]
+
+theorem of_succ_lt
+    (hs : ∀ a, f a < f (succ a)) (hl : ∀ {a}, IsSuccLimit a → IsLUB (f '' Iio a) (f a)) :
+    IsNormal f := by
+  refine ⟨fun a b ↦ ?_, fun ha ↦ (hl ha).2⟩
+  induction b using SuccOrder.limitRecOn with
+  | isMin b hb => exact hb.not_lt.elim
+  | succ b hb IH =>
+    intro hab
+    obtain rfl | h := (lt_succ_iff_eq_or_lt_of_not_isMax hb).1 hab
+    · exact hs a
+    · exact (IH h).trans (hs b)
+  | isSuccLimit b hb IH =>
+    intro hab
+    have hab' := hb.succ_lt hab
+    exact (IH _ hab' (lt_succ_of_not_isMax hab.not_isMax)).trans_le
+      ((hl hb).1 (mem_image_of_mem _ hab'))
+
+protected theorem ext [OrderBot α] {g : α → β} (hf : IsNormal f) (hg : IsNormal g) :
+    f = g ↔ f ⊥ = g ⊥ ∧ ∀ a, f a = g a → f (succ a) = g (succ a) := by
+  constructor
+  · simp_all
+  · rintro ⟨H₁, H₂⟩
+    ext a
+    induction a using SuccOrder.limitRecOn with
+    | isMin a ha => rw [ha.eq_bot, H₁]
+    | succ a ha IH => exact H₂ a IH
+    | isSuccLimit a ha IH =>
+      apply (hf.isLUB_image_Iio_of_isSuccLimit ha).unique
+      convert hg.isLUB_image_Iio_of_isSuccLimit ha using 1
+      aesop
+
+end WellFoundedLT
 end LinearOrder
 
 section ConditionallyCompleteLinearOrder
-
 variable [ConditionallyCompleteLinearOrder α] [ConditionallyCompleteLinearOrder β]
 
 theorem map_sSup (hf : IsNormal f) {s : Set α} (hs : s.Nonempty) (hs' : BddAbove s) :
@@ -142,7 +160,5 @@ theorem map_iSup {ι} [Nonempty ι] {g : ι → α} (hf : IsNormal f) (hg : BddA
   simp
 
 end ConditionallyCompleteLinearOrder
-
 end IsNormal
-
 end Order

--- a/Mathlib/Order/IsNormal.lean
+++ b/Mathlib/Order/IsNormal.lean
@@ -108,7 +108,6 @@ theorem comp (hg : IsNormal g) (hf : IsNormal f) : IsNormal (g ∘ f) := by
     fun c d hd hc ↦ (hg.strictMono hc).le.trans (hb hd)
 
 section WellFoundedLT
-
 variable [WellFoundedLT α] [SuccOrder α]
 
 theorem of_succ_lt

--- a/Mathlib/SetTheory/Cardinal/Regular.lean
+++ b/Mathlib/SetTheory/Cardinal/Regular.lean
@@ -103,10 +103,14 @@ theorem isRegular_aleph_succ (o : Ordinal) : IsRegular (ℵ_ (succ o)) := by
   rw [aleph_succ]
   exact isRegular_succ (aleph0_le_aleph o)
 
+set_option linter.deprecated false in
+@[deprecated "`lsub` is deprecated" (since := "2025-08-19")]
 theorem lsub_lt_ord_lift_of_isRegular {ι} {f : ι → Ordinal} {c} (hc : IsRegular c)
     (hι : Cardinal.lift.{v, u} #ι < c) : (∀ i, f i < c.ord) → Ordinal.lsub.{u, v} f < c.ord :=
   lsub_lt_ord_lift (by rwa [hc.cof_eq])
 
+set_option linter.deprecated false in
+@[deprecated "`lsub` is deprecated" (since := "2025-08-19")]
 theorem lsub_lt_ord_of_isRegular {ι} {f : ι → Ordinal} {c} (hc : IsRegular c) (hι : #ι < c) :
     (∀ i, f i < c.ord) → Ordinal.lsub f < c.ord :=
   lsub_lt_ord (by rwa [hc.cof_eq])
@@ -119,26 +123,34 @@ theorem iSup_lt_ord_of_isRegular {ι} {f : ι → Ordinal} {c} (hc : IsRegular c
     (∀ i, f i < c.ord) → iSup f < c.ord :=
   iSup_lt_ord (by rwa [hc.cof_eq])
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated" (since := "2025-08-19")]
 theorem blsub_lt_ord_lift_of_isRegular {o : Ordinal} {f : ∀ a < o, Ordinal} {c} (hc : IsRegular c)
     (ho : Cardinal.lift.{v, u} o.card < c) :
     (∀ i hi, f i hi < c.ord) → Ordinal.blsub.{u, v} o f < c.ord :=
   blsub_lt_ord_lift (by rwa [hc.cof_eq])
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated" (since := "2025-08-19")]
 theorem blsub_lt_ord_of_isRegular {o : Ordinal} {f : ∀ a < o, Ordinal} {c} (hc : IsRegular c)
     (ho : o.card < c) : (∀ i hi, f i hi < c.ord) → Ordinal.blsub o f < c.ord :=
   blsub_lt_ord (by rwa [hc.cof_eq])
 
+set_option linter.deprecated false in
+@[deprecated iSup_lt_ord_lift_of_isRegular (since := "2025-08-19")]
 theorem bsup_lt_ord_lift_of_isRegular {o : Ordinal} {f : ∀ a < o, Ordinal} {c} (hc : IsRegular c)
     (hι : Cardinal.lift.{v, u} o.card < c) :
     (∀ i hi, f i hi < c.ord) → Ordinal.bsup.{u, v} o f < c.ord :=
   bsup_lt_ord_lift (by rwa [hc.cof_eq])
 
+set_option linter.deprecated false in
+@[deprecated iSup_lt_ord_lift_of_isRegular (since := "2025-08-19")]
 theorem bsup_lt_ord_of_isRegular {o : Ordinal} {f : ∀ a < o, Ordinal} {c} (hc : IsRegular c)
     (hι : o.card < c) : (∀ i hi, f i hi < c.ord) → Ordinal.bsup o f < c.ord :=
   bsup_lt_ord (by rwa [hc.cof_eq])
 
 theorem iSup_lt_lift_of_isRegular {ι} {f : ι → Cardinal} {c} (hc : IsRegular c)
-    (hι : Cardinal.lift.{v, u} #ι < c) : (∀ i, f i < c) → iSup.{max u v + 1, u + 1} f < c :=
+    (hι : Cardinal.lift.{v, u} #ι < c) : (∀ i, f i < c) → ⨆ i, f i < c :=
   iSup_lt_lift.{u, v} (by rwa [hc.cof_eq])
 
 theorem iSup_lt_of_isRegular {ι} {f : ι → Cardinal} {c} (hc : IsRegular c) (hι : #ι < c) :
@@ -195,6 +207,8 @@ theorem nfp_lt_ord_of_isRegular {f : Ordinal → Ordinal} {c} (hc : IsRegular c)
     (hf : ∀ i < c.ord, f i < c.ord) {a} : a < c.ord → nfp f a < c.ord :=
   nfp_lt_ord (by rw [hc.cof_eq]; exact lt_of_le_of_ne hc.1 hc'.symm) hf
 
+set_option linter.deprecated false in
+@[deprecated "we need to generalize the universes of this file" (since := "2025-08-19")]
 theorem derivFamily_lt_ord_lift {ι : Type u} {f : ι → Ordinal → Ordinal} {c} (hc : IsRegular c)
     (hι : lift.{v} #ι < c) (hc' : c ≠ ℵ₀) (hf : ∀ i, ∀ b < c.ord, f i b < c.ord) {a} :
     a < c.ord → derivFamily f a < c.ord := by
@@ -218,14 +232,18 @@ theorem derivFamily_lt_ord_lift {ι : Type u} {f : ι → Ordinal → Ordinal} {
       iSup_eq_bsup.{max u v, max u v} (f := fun x (_ : x < b) ↦ derivFamily f x)
     rw [derivFamily_limit f hb, this]
     exact
-      bsup_lt_ord_of_isRegular.{u, v} hc (ord_lt_ord.1 ((ord_card_le b).trans_lt hb')) fun o' ho' =>
+      bsup_lt_ord_of_isRegular hc (ord_lt_ord.1 ((ord_card_le b).trans_lt hb')) fun o' ho' =>
         H o' ho' (ho'.trans hb')
 
+set_option linter.deprecated false in
+@[deprecated "we need to generalize the universes of this file" (since := "2025-08-19")]
 theorem derivFamily_lt_ord {ι} {f : ι → Ordinal → Ordinal} {c} (hc : IsRegular c) (hι : #ι < c)
     (hc' : c ≠ ℵ₀) (hf : ∀ (i), ∀ b < c.ord, f i b < c.ord) {a} :
     a < c.ord → derivFamily.{u, u} f a < c.ord :=
   derivFamily_lt_ord_lift hc (by rwa [lift_id]) hc' hf
 
+set_option linter.deprecated false in
+@[deprecated "we need to generalize the universes of this file" (since := "2025-08-19")]
 theorem deriv_lt_ord {f : Ordinal.{u} → Ordinal} {c} (hc : IsRegular c) (hc' : c ≠ ℵ₀)
     (hf : ∀ i < c.ord, f i < c.ord) {a} : a < c.ord → deriv f a < c.ord :=
   derivFamily_lt_ord_lift hc

--- a/Mathlib/SetTheory/Game/Birthday.lean
+++ b/Mathlib/SetTheory/Game/Birthday.lean
@@ -105,7 +105,7 @@ theorem birthday_eq_zero {x : PGame} :
 theorem birthday_zero : birthday 0 = 0 := by simp [inferInstanceAs (IsEmpty PEmpty)]
 
 @[simp]
-theorem birthday_one : birthday 1 = 1 := by rw [birthday_def]; simp [lsub_one]
+theorem birthday_one : birthday 1 = 1 := by rw [birthday_def]; simp [lsub_unique]
 
 @[simp]
 theorem birthday_star : birthday star = 1 := by rw [birthday_def]; simp

--- a/Mathlib/SetTheory/Game/Birthday.lean
+++ b/Mathlib/SetTheory/Game/Birthday.lean
@@ -38,6 +38,7 @@ universe u
 
 open Ordinal
 
+set_option linter.deprecated false in
 namespace SetTheory
 
 open scoped NaturalOps PGame
@@ -103,7 +104,7 @@ theorem birthday_eq_zero {x : PGame} :
 theorem birthday_zero : birthday 0 = 0 := by simp [inferInstanceAs (IsEmpty PEmpty)]
 
 @[simp]
-theorem birthday_one : birthday 1 = 1 := by rw [birthday_def]; simp
+theorem birthday_one : birthday 1 = 1 := by rw [birthday_def]; simp [lsub_one]
 
 @[simp]
 theorem birthday_star : birthday star = 1 := by rw [birthday_def]; simp

--- a/Mathlib/SetTheory/Game/Birthday.lean
+++ b/Mathlib/SetTheory/Game/Birthday.lean
@@ -12,6 +12,8 @@ deprecated_module
   "This module is now at `CombinatorialGames.Game.Birthday` in the CGT repo <https://github.com/vihdzp/combinatorial-games>"
   (since := "2025-08-06")
 
+set_option linter.deprecated false
+
 /-!
 # Birthdays of games
 
@@ -38,7 +40,6 @@ universe u
 
 open Ordinal
 
-set_option linter.deprecated false in
 namespace SetTheory
 
 open scoped NaturalOps PGame

--- a/Mathlib/SetTheory/Ordinal/Family.lean
+++ b/Mathlib/SetTheory/Ordinal/Family.lean
@@ -34,26 +34,26 @@ variable {α β γ : Type*} {r : α → α → Prop} {s : β → β → Prop} {t
 
 /-! ### Families of ordinals
 
-There are two kinds of indexed families that naturally arise when dealing with ordinals: those
-indexed by some type in the appropriate universe, and those indexed by ordinals less than another.
-The following API allows one to convert from one kind of family to the other.
-
-In many cases, this makes it easy to prove claims about one kind of family via the corresponding
-claim on the other. -/
+**Do not use this API.** It was created for working with `bsup`, but you should be working with the
+conditionally complete lattice structure of `Ordinal` (i.e. `sSup` and `iSup`) instead. -/
 
 
 /-- Converts a family indexed by a `Type u` to one indexed by an `Ordinal.{u}` using a specified
 well-ordering. -/
+@[deprecated "`bsup` is deprecated" (since := "2025-08-19")]
 def bfamilyOfFamily' {ι : Type u} (r : ι → ι → Prop) [IsWellOrder ι r] (f : ι → α) :
     ∀ a < type r, α := fun a ha => f (enum r ⟨a, ha⟩)
 
+set_option linter.deprecated false in
 /-- Converts a family indexed by a `Type u` to one indexed by an `Ordinal.{u}` using a well-ordering
 given by the axiom of choice. -/
+@[deprecated "`bsup` is deprecated" (since := "2025-08-19")]
 def bfamilyOfFamily {ι : Type u} : (ι → α) → ∀ a < type (@WellOrderingRel ι), α :=
   bfamilyOfFamily' WellOrderingRel
 
 /-- Converts a family indexed by an `Ordinal.{u}` to one indexed by a `Type u` using a specified
 well-ordering. -/
+@[deprecated "`bsup` is deprecated" (since := "2025-08-19")]
 def familyOfBFamily' {ι : Type u} (r : ι → ι → Prop) [IsWellOrder ι r] {o} (ho : type r = o)
     (f : ∀ a < o, α) : ι → α := fun i =>
   f (typein r i)
@@ -61,42 +61,56 @@ def familyOfBFamily' {ι : Type u} (r : ι → ι → Prop) [IsWellOrder ι r] {
       rw [← ho]
       exact typein_lt_type r i)
 
+set_option linter.deprecated false in
 /-- Converts a family indexed by an `Ordinal.{u}` to one indexed by a `Type u` using a well-ordering
 given by the axiom of choice. -/
+@[deprecated "`bsup` is deprecated" (since := "2025-08-19")]
 def familyOfBFamily (o : Ordinal) (f : ∀ a < o, α) : o.toType → α :=
   familyOfBFamily' (· < ·) (type_toType o) f
 
-@[simp]
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated" (since := "2025-08-19")]
 theorem bfamilyOfFamily'_typein {ι} (r : ι → ι → Prop) [IsWellOrder ι r] (f : ι → α) (i) :
     bfamilyOfFamily' r f (typein r i) (typein_lt_type r i) = f i := by
   simp only [bfamilyOfFamily', enum_typein]
 
-@[simp]
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated" (since := "2025-08-19")]
 theorem bfamilyOfFamily_typein {ι} (f : ι → α) (i) :
     bfamilyOfFamily f (typein _ i) (typein_lt_type _ i) = f i :=
   bfamilyOfFamily'_typein _ f i
 
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated" (since := "2025-08-19")]
 theorem familyOfBFamily'_enum {ι : Type u} (r : ι → ι → Prop) [IsWellOrder ι r] {o}
     (ho : type r = o) (f : ∀ a < o, α) (i hi) :
     familyOfBFamily' r ho f (enum r ⟨i, by rwa [ho]⟩) = f i hi := by
   simp only [familyOfBFamily', typein_enum]
 
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated" (since := "2025-08-19")]
 theorem familyOfBFamily_enum (o : Ordinal) (f : ∀ a < o, α) (i hi) :
     familyOfBFamily o f (enum (α := o.toType) (· < ·) ⟨i, hi.trans_eq (type_toType _).symm⟩)
     = f i hi :=
   familyOfBFamily'_enum _ (type_toType o) f _ _
 
 /-- The range of a family indexed by ordinals. -/
+@[deprecated "`bsup` is deprecated" (since := "2025-08-19")]
 def brange (o : Ordinal) (f : ∀ a < o, α) : Set α :=
   { a | ∃ i hi, f i hi = a }
 
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated" (since := "2025-08-19")]
 theorem mem_brange {o : Ordinal} {f : ∀ a < o, α} {a} : a ∈ brange o f ↔ ∃ i hi, f i hi = a :=
   Iff.rfl
 
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated" (since := "2025-08-19")]
 theorem mem_brange_self {o} (f : ∀ a < o, α) (i hi) : f i hi ∈ brange o f :=
   ⟨i, hi, rfl⟩
 
-@[simp]
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated" (since := "2025-08-19")]
 theorem range_familyOfBFamily' {ι : Type u} (r : ι → ι → Prop) [IsWellOrder ι r] {o}
     (ho : type r = o) (f : ∀ a < o, α) : range (familyOfBFamily' r ho f) = brange o f := by
   refine Set.ext fun a => ⟨?_, ?_⟩
@@ -105,11 +119,13 @@ theorem range_familyOfBFamily' {ι : Type u} (r : ι → ι → Prop) [IsWellOrd
   · rintro ⟨i, hi, rfl⟩
     exact ⟨_, familyOfBFamily'_enum _ _ _ _ _⟩
 
-@[simp]
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated" (since := "2025-08-19")]
 theorem range_familyOfBFamily {o} (f : ∀ a < o, α) : range (familyOfBFamily o f) = brange o f :=
   range_familyOfBFamily' _ _ f
 
-@[simp]
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated" (since := "2025-08-19")]
 theorem brange_bfamilyOfFamily' {ι : Type u} (r : ι → ι → Prop) [IsWellOrder ι r] (f : ι → α) :
     brange _ (bfamilyOfFamily' r f) = range f := by
   refine Set.ext fun a => ⟨?_, ?_⟩
@@ -118,36 +134,47 @@ theorem brange_bfamilyOfFamily' {ι : Type u} (r : ι → ι → Prop) [IsWellOr
   · rintro ⟨b, rfl⟩
     exact ⟨_, _, bfamilyOfFamily'_typein _ _ _⟩
 
-@[simp]
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated" (since := "2025-08-19")]
 theorem brange_bfamilyOfFamily {ι : Type u} (f : ι → α) : brange _ (bfamilyOfFamily f) = range f :=
   brange_bfamilyOfFamily' _ _
 
-@[simp]
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated" (since := "2025-08-19")]
 theorem brange_const {o : Ordinal} (ho : o ≠ 0) {c : α} : (brange o fun _ _ => c) = {c} := by
   rw [← range_familyOfBFamily]
   exact @Set.range_const _ o.toType (toType_nonempty_iff_ne_zero.2 ho) c
 
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated" (since := "2025-08-19")]
 theorem comp_bfamilyOfFamily' {ι : Type u} (r : ι → ι → Prop) [IsWellOrder ι r] (f : ι → α)
     (g : α → β) : (fun i hi => g (bfamilyOfFamily' r f i hi)) = bfamilyOfFamily' r (g ∘ f) :=
   rfl
 
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated" (since := "2025-08-19")]
 theorem comp_bfamilyOfFamily {ι : Type u} (f : ι → α) (g : α → β) :
     (fun i hi => g (bfamilyOfFamily f i hi)) = bfamilyOfFamily (g ∘ f) :=
   rfl
 
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated" (since := "2025-08-19")]
 theorem comp_familyOfBFamily' {ι : Type u} (r : ι → ι → Prop) [IsWellOrder ι r] {o}
     (ho : type r = o) (f : ∀ a < o, α) (g : α → β) :
     g ∘ familyOfBFamily' r ho f = familyOfBFamily' r ho fun i hi => g (f i hi) :=
   rfl
 
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated" (since := "2025-08-19")]
 theorem comp_familyOfBFamily {o} (f : ∀ a < o, α) (g : α → β) :
     g ∘ familyOfBFamily o f = familyOfBFamily o fun i hi => g (f i hi) :=
   rfl
 
 /-! ### Supremum of a family of ordinals -/
 
--- FIXME There is undeprecated material below still depending on this?!
-/-- The supremum of a family of ordinals -/
+/-- The supremum of a family of ordinals.
+
+**Don't use this.** Use `iSup` instead. -/
 @[deprecated iSup (since := "2024-08-27")]
 def sup {ι : Type u} (f : ι → Ordinal.{max u v}) : Ordinal.{max u v} :=
   iSup f
@@ -185,7 +212,6 @@ fails to infer `f` in simple cases and needs it to be given explicitly. -/
 protected theorem le_iSup {ι} (f : ι → Ordinal.{u}) [Small.{u} ι] : ∀ i, f i ≤ iSup f :=
   le_ciSup (bddAbove_of_small _)
 
--- FIXME There is undeprecated material below still depending on this?!
 set_option linter.deprecated false in
 @[deprecated Ordinal.le_iSup (since := "2024-08-27")]
 theorem le_sup {ι : Type u} (f : ι → Ordinal.{max u v}) : ∀ i, f i ≤ sup.{_, v} f := fun i =>
@@ -196,7 +222,6 @@ protected theorem iSup_le_iff {ι} {f : ι → Ordinal.{u}} {a : Ordinal.{u}} [S
     iSup f ≤ a ↔ ∀ i, f i ≤ a :=
   ciSup_le_iff' (bddAbove_of_small _)
 
--- FIXME There is undeprecated material below still depending on this?!
 set_option linter.deprecated false in
 @[deprecated Ordinal.iSup_le_iff (since := "2024-08-27")]
 theorem sup_le_iff {ι : Type u} {f : ι → Ordinal.{max u v}} {a} : sup.{_, v} f ≤ a ↔ ∀ i, f i ≤ a :=
@@ -207,7 +232,6 @@ protected theorem iSup_le {ι} {f : ι → Ordinal} {a} :
     (∀ i, f i ≤ a) → iSup f ≤ a :=
   ciSup_le'
 
--- FIXME There is undeprecated material below still depending on this?!
 set_option linter.deprecated false in
 @[deprecated Ordinal.iSup_le (since := "2024-08-27")]
 theorem sup_le {ι : Type u} {f : ι → Ordinal.{max u v}} {a} : (∀ i, f i ≤ a) → sup.{_, v} f ≤ a :=
@@ -218,13 +242,11 @@ protected theorem lt_iSup_iff {ι} {f : ι → Ordinal.{u}} {a : Ordinal.{u}} [S
     a < iSup f ↔ ∃ i, a < f i :=
   lt_ciSup_iff' (bddAbove_of_small _)
 
--- FIXME There is undeprecated material below still depending on this?!
 @[deprecated "No deprecation message was provided." (since := "2024-08-27")]
 theorem ne_iSup_iff_lt_iSup {ι : Type u} {f : ι → Ordinal.{max u v}} :
     (∀ i, f i ≠ iSup f) ↔ ∀ i, f i < iSup f :=
   forall_congr' fun i => (Ordinal.le_iSup f i).lt_iff_ne.symm
 
--- FIXME There is undeprecated material below still depending on this?!
 set_option linter.deprecated false in
 @[deprecated ne_iSup_iff_lt_iSup (since := "2024-08-27")]
 theorem ne_sup_iff_lt_sup {ι : Type u} {f : ι → Ordinal.{max u v}} :
@@ -238,7 +260,6 @@ theorem succ_lt_iSup_of_ne_iSup {ι} {f : ι → Ordinal.{u}} [Small.{u} ι]
   exact hao.not_ge (Ordinal.iSup_le fun i => le_of_lt_succ <|
     (lt_of_le_of_ne (Ordinal.le_iSup _ _) (hf i)).trans_le hoa)
 
--- FIXME There is undeprecated material below still depending on this?!
 set_option linter.deprecated false in
 @[deprecated succ_lt_iSup_of_ne_iSup (since := "2024-08-27")]
 theorem sup_not_succ_of_ne_sup {ι : Type u} {f : ι → Ordinal.{max u v}}
@@ -256,31 +277,27 @@ theorem iSup_eq_zero_iff {ι} {f : ι → Ordinal.{u}} [Small.{u} ι] :
   rw [← Ordinal.le_zero, ← h]
   exact Ordinal.le_iSup f i
 
--- FIXME There is undeprecated material below still depending on this?!
 set_option linter.deprecated false in
 @[deprecated ciSup_const (since := "2024-08-27")]
 theorem sup_const {ι} [_hι : Nonempty ι] (o : Ordinal) : (sup fun _ : ι => o) = o :=
   ciSup_const
 
--- FIXME There is undeprecated material below still depending on this?!
 set_option linter.deprecated false in
 @[deprecated ciSup_unique (since := "2024-08-27")]
 theorem sup_unique {ι} [Unique ι] (f : ι → Ordinal) : sup f = f default :=
   ciSup_unique
 
--- FIXME There is undeprecated material below still depending on this?!
 set_option linter.deprecated false in
 @[deprecated csSup_le_csSup' (since := "2024-08-27")]
 theorem sup_le_of_range_subset {ι ι'} {f : ι → Ordinal} {g : ι' → Ordinal}
     (h : Set.range f ⊆ Set.range g) : sup.{u, max v w} f ≤ sup.{v, max u w} g :=
   csSup_le_csSup' (bddAbove_range.{v, max u w} _) h
 
--- TODO: generalize or remove
+@[deprecated congrArg (since := "2025-08-19")]
 theorem iSup_eq_of_range_eq {ι ι'} {f : ι → Ordinal} {g : ι' → Ordinal}
     (h : Set.range f = Set.range g) : iSup f = iSup g :=
   congr_arg _ h
 
--- FIXME There is undeprecated material below still depending on this?!
 set_option linter.deprecated false in
 @[deprecated iSup_eq_of_range_eq (since := "2024-08-27")]
 theorem sup_eq_of_range_eq {ι : Type u} {ι' : Type v}
@@ -305,7 +322,6 @@ theorem iSup_sum {α β} (f : α ⊕ β → Ordinal.{u}) [Small.{u} α] [Small.{
     rintro i ⟨a, rfl⟩
     apply mem_range_self
 
--- FIXME There is undeprecated material below still depending on this?!
 set_option linter.deprecated false in
 @[deprecated iSup_sum (since := "2024-08-27")]
 theorem sup_sum {α : Type u} {β : Type v} (f : α ⊕ β → Ordinal) :
@@ -329,15 +345,8 @@ theorem unbounded_range_of_le_iSup {α β : Type u} (r : α → α → Prop) [Is
 
 theorem IsNormal.map_iSup_of_bddAbove {f : Ordinal.{u} → Ordinal.{v}} (H : IsNormal f)
     {ι : Type*} (g : ι → Ordinal.{u}) (hg : BddAbove (range g))
-    [Nonempty ι] : f (⨆ i, g i) = ⨆ i, f (g i) := eq_of_forall_ge_iff fun a ↦ by
-  have := bddAbove_iff_small.mp hg
-  have := univLE_of_injective H.strictMono.injective
-  have := Small.trans_univLE.{u, v} (range g)
-  have hfg : BddAbove (range (f ∘ g)) := bddAbove_iff_small.mpr <| by
-    rw [range_comp]
-    exact small_image f (range g)
-  change _ ↔ ⨆ i, (f ∘ g) i ≤ a
-  rw [ciSup_le_iff hfg, H.le_set' _ Set.univ_nonempty g] <;> simp [ciSup_le_iff hg]
+    [Nonempty ι] : f (⨆ i, g i) = ⨆ i, f (g i) :=
+  Order.IsNormal.map_iSup H hg
 
 theorem IsNormal.map_iSup {f : Ordinal.{u} → Ordinal.{v}} (H : IsNormal f)
     {ι : Type w} (g : ι → Ordinal.{u}) [Small.{u} ι] [Nonempty ι] :
@@ -354,7 +363,6 @@ theorem IsNormal.map_sSup {f : Ordinal.{u} → Ordinal.{v}} (H : IsNormal f)
     {s : Set Ordinal.{u}} (hn : s.Nonempty) [Small.{u} s] : f (sSup s) = sSup (f '' s) :=
   H.map_sSup_of_bddAbove (bddAbove_of_small s) hn
 
--- FIXME There is undeprecated material below still depending on this?!
 set_option linter.deprecated false in
 @[deprecated IsNormal.map_iSup (since := "2024-08-27")]
 theorem IsNormal.sup {f : Ordinal.{max u v} → Ordinal.{max u w}} (H : IsNormal f) {ι : Type u}
@@ -416,6 +424,7 @@ theorem sInf_compl_lt_ord_succ {ι : Type u} (f : ι → Ordinal.{u}) :
 section bsup
 
 set_option linter.deprecated false in
+@[deprecated "`sup` is deprecated`" (since := "2025-08-19")]
 private theorem sup_le_sup {ι ι' : Type u} (r : ι → ι → Prop) (r' : ι' → ι' → Prop)
     [IsWellOrder ι r] [IsWellOrder ι' r'] {o} (ho : type r = o) (ho' : type r' = o)
     (f : ∀ a < o, Ordinal.{max u v}) :
@@ -426,55 +435,64 @@ private theorem sup_le_sup {ι ι' : Type u} (r : ι → ι → Prop) (r' : ι' 
     apply le_sup
 
 set_option linter.deprecated false in
+@[deprecated "`sup` is deprecated`" (since := "2025-08-19")]
 theorem sup_eq_sup {ι ι' : Type u} (r : ι → ι → Prop) (r' : ι' → ι' → Prop) [IsWellOrder ι r]
     [IsWellOrder ι' r'] {o : Ordinal.{u}} (ho : type r = o) (ho' : type r' = o)
     (f : ∀ a < o, Ordinal.{max u v}) :
     sup.{_, v} (familyOfBFamily' r ho f) = sup.{_, v} (familyOfBFamily' r' ho' f) :=
-  sup_eq_of_range_eq.{u, u, v} (by simp)
+  sup_eq_of_range_eq.{u, u, v} (by simp [range_familyOfBFamily'])
 
 set_option linter.deprecated false in
 /-- The supremum of a family of ordinals indexed by the set of ordinals less than some
     `o : Ordinal.{u}`. This is a special case of `sup` over the family provided by
-    `familyOfBFamily`. -/
+    `familyOfBFamily`.
+
+**Don't use this.** Use `iSup` instead. -/
+@[deprecated iSup (since := "2025-08-19")]
 def bsup (o : Ordinal.{u}) (f : ∀ a < o, Ordinal.{max u v}) : Ordinal.{max u v} :=
   sup.{_, v} (familyOfBFamily o f)
 
 set_option linter.deprecated false in
-@[simp]
+@[deprecated "`bsup` is deprecated`" (since := "2025-08-19")]
 theorem sup_eq_bsup {o : Ordinal.{u}} (f : ∀ a < o, Ordinal.{max u v}) :
     sup.{_, v} (familyOfBFamily o f) = bsup.{_, v} o f :=
   rfl
 
 set_option linter.deprecated false in
-@[simp]
+@[deprecated "`bsup` is deprecated`" (since := "2025-08-19")]
 theorem sup_eq_bsup' {o : Ordinal.{u}} {ι} (r : ι → ι → Prop) [IsWellOrder ι r] (ho : type r = o)
     (f : ∀ a < o, Ordinal.{max u v}) : sup.{_, v} (familyOfBFamily' r ho f) = bsup.{_, v} o f :=
   sup_eq_sup r _ ho _ f
 
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated`" (since := "2025-08-19")]
 theorem sSup_eq_bsup {o : Ordinal.{u}} (f : ∀ a < o, Ordinal.{max u v}) :
     sSup (brange o f) = bsup.{_, v} o f := by
   congr
   rw [range_familyOfBFamily]
 
 set_option linter.deprecated false in
-@[simp]
+@[deprecated "`bsup` is deprecated`" (since := "2025-08-19")]
 theorem bsup_eq_sup' {ι : Type u} (r : ι → ι → Prop) [IsWellOrder ι r] (f : ι → Ordinal.{max u v}) :
     bsup.{_, v} _ (bfamilyOfFamily' r f) = sup.{_, v} f := by
   simp +unfoldPartialApp only [← sup_eq_bsup' r, enum_typein,
     familyOfBFamily', bfamilyOfFamily']
 
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated`" (since := "2025-08-19")]
 theorem bsup_eq_bsup {ι : Type u} (r r' : ι → ι → Prop) [IsWellOrder ι r] [IsWellOrder ι r']
     (f : ι → Ordinal.{max u v}) :
     bsup.{_, v} _ (bfamilyOfFamily' r f) = bsup.{_, v} _ (bfamilyOfFamily' r' f) := by
   rw [bsup_eq_sup', bsup_eq_sup']
 
 set_option linter.deprecated false in
-@[simp]
+@[deprecated "`bsup` is deprecated`" (since := "2025-08-19")]
 theorem bsup_eq_sup {ι : Type u} (f : ι → Ordinal.{max u v}) :
     bsup.{_, v} _ (bfamilyOfFamily f) = sup.{_, v} f :=
   bsup_eq_sup' _ f
 
-@[congr]
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated`" (since := "2025-08-19")]
 theorem bsup_congr {o₁ o₂ : Ordinal.{u}} (f : ∀ a < o₁, Ordinal.{max u v}) (ho : o₁ = o₂) :
     bsup.{_, v} o₁ f = bsup.{_, v} o₂ fun a h => f a (h.trans_eq ho.symm) := by
   subst ho
@@ -482,24 +500,32 @@ theorem bsup_congr {o₁ o₂ : Ordinal.{u}} (f : ∀ a < o₁, Ordinal.{max u v
   rfl
 
 set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated`" (since := "2025-08-19")]
 theorem bsup_le_iff {o f a} : bsup.{u, v} o f ≤ a ↔ ∀ i h, f i h ≤ a :=
   sup_le_iff.trans
     ⟨fun h i hi => by
       rw [← familyOfBFamily_enum o f]
       exact h _, fun h _ => h _ _⟩
 
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated`" (since := "2025-08-19")]
 theorem bsup_le {o : Ordinal} {f : ∀ b < o, Ordinal} {a} :
     (∀ i h, f i h ≤ a) → bsup.{u, v} o f ≤ a :=
   bsup_le_iff.2
 
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated`" (since := "2025-08-19")]
 theorem le_bsup {o} (f : ∀ a < o, Ordinal) (i h) : f i h ≤ bsup o f :=
   bsup_le_iff.1 le_rfl _ _
 
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated`" (since := "2025-08-19")]
 theorem lt_bsup {o : Ordinal.{u}} (f : ∀ a < o, Ordinal.{max u v}) {a} :
     a < bsup.{_, v} o f ↔ ∃ i hi, a < f i hi := by
   simpa only [not_forall, not_le] using not_congr (@bsup_le_iff.{_, v} _ f a)
 
 set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated`" (since := "2025-08-19")]
 theorem IsNormal.bsup {f : Ordinal.{max u v} → Ordinal.{max u w}} (H : IsNormal f)
     {o : Ordinal.{u}} :
     ∀ (g : ∀ a < o, Ordinal), o ≠ 0 → f (bsup.{_, v} o g) = bsup.{_, w} o fun a h => f (g a h) :=
@@ -507,18 +533,22 @@ theorem IsNormal.bsup {f : Ordinal.{max u v} → Ordinal.{max u w}} (H : IsNorma
     haveI := type_ne_zero_iff_nonempty.1 h
     rw [← sup_eq_bsup' r, IsNormal.sup.{_, v, w} H, ← sup_eq_bsup' r] <;> rfl
 
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated`" (since := "2025-08-19")]
 theorem lt_bsup_of_ne_bsup {o : Ordinal.{u}} {f : ∀ a < o, Ordinal.{max u v}} :
     (∀ i h, f i h ≠ bsup.{_, v} o f) ↔ ∀ i h, f i h < bsup.{_, v} o f :=
   ⟨fun hf _ _ => lt_of_le_of_ne (le_bsup _ _ _) (hf _ _), fun hf _ _ => ne_of_lt (hf _ _)⟩
 
 set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated`" (since := "2025-08-19")]
 theorem bsup_not_succ_of_ne_bsup {o : Ordinal.{u}} {f : ∀ a < o, Ordinal.{max u v}}
     (hf : ∀ {i : Ordinal} (h : i < o), f i h ≠ bsup.{_, v} o f) (a) :
     a < bsup.{_, v} o f → succ a < bsup.{_, v} o f := by
   rw [← sup_eq_bsup] at *
   exact sup_not_succ_of_ne_sup fun i => hf _
 
-@[simp]
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated`" (since := "2025-08-19")]
 theorem bsup_eq_zero_iff {o} {f : ∀ a < o, Ordinal} : bsup o f = 0 ↔ ∀ i hi, f i hi = 0 := by
   refine
     ⟨fun h i hi => ?_, fun h =>
@@ -526,28 +556,37 @@ theorem bsup_eq_zero_iff {o} {f : ∀ a < o, Ordinal} : bsup o f = 0 ↔ ∀ i h
   rw [← Ordinal.le_zero, ← h]
   exact le_bsup f i hi
 
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated`" (since := "2025-08-19")]
 theorem lt_bsup_of_limit {o : Ordinal} {f : ∀ a < o, Ordinal}
     (hf : ∀ {a a'} (ha : a < o) (ha' : a' < o), a < a' → f a ha < f a' ha')
     (ho : ∀ a < o, succ a < o) (i h) : f i h < bsup o f :=
   (hf _ _ <| lt_succ i).trans_le (le_bsup f (succ i) <| ho _ h)
 
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated`" (since := "2025-08-19")]
 theorem bsup_succ_of_mono {o : Ordinal} {f : ∀ a < succ o, Ordinal}
     (hf : ∀ {i j} (hi hj), i ≤ j → f i hi ≤ f j hj) : bsup _ f = f o (lt_succ o) :=
   le_antisymm (bsup_le fun _i hi => hf _ _ <| le_of_lt_succ hi) (le_bsup _ _ _)
 
-@[simp]
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated`" (since := "2025-08-19")]
 theorem bsup_zero (f : ∀ a < (0 : Ordinal), Ordinal) : bsup 0 f = 0 :=
   bsup_eq_zero_iff.2 fun i hi => (Ordinal.not_lt_zero i hi).elim
 
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated`" (since := "2025-08-19")]
 theorem bsup_const {o : Ordinal.{u}} (ho : o ≠ 0) (a : Ordinal.{max u v}) :
     (bsup.{_, v} o fun _ _ => a) = a :=
   le_antisymm (bsup_le fun _ _ => le_rfl) (le_bsup _ 0 (Ordinal.pos_iff_ne_zero.2 ho))
 
 set_option linter.deprecated false in
-@[simp]
+@[deprecated "`bsup` is deprecated`" (since := "2025-08-19")]
 theorem bsup_one (f : ∀ a < (1 : Ordinal), Ordinal) : bsup 1 f = f 0 zero_lt_one := by
   simp_rw [← sup_eq_bsup, sup_unique, familyOfBFamily, familyOfBFamily', typein_one_toType]
 
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated`" (since := "2025-08-19")]
 theorem bsup_le_of_brange_subset {o o'} {f : ∀ a < o, Ordinal} {g : ∀ a < o', Ordinal}
     (h : brange o f ⊆ brange o' g) : bsup.{u, max v w} o f ≤ bsup.{v, max u w} o' g :=
   bsup_le fun i hi => by
@@ -555,59 +594,72 @@ theorem bsup_le_of_brange_subset {o o'} {f : ∀ a < o, Ordinal} {g : ∀ a < o'
     rw [← hj']
     apply le_bsup
 
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated`" (since := "2025-08-19")]
 theorem bsup_eq_of_brange_eq {o o'} {f : ∀ a < o, Ordinal} {g : ∀ a < o', Ordinal}
     (h : brange o f = brange o' g) : bsup.{u, max v w} o f = bsup.{v, max u w} o' g :=
   (bsup_le_of_brange_subset.{u, v, w} h.le).antisymm (bsup_le_of_brange_subset.{v, u, w} h.ge)
 
 set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated`" (since := "2025-08-19")]
 theorem iSup_eq_bsup {o} {f : ∀ a < o, Ordinal} : ⨆ a : Iio o, f a.1 a.2 = bsup o f := by
   simp_rw [Iio, bsup, sup, iSup, range_familyOfBFamily, brange, range, Subtype.exists, mem_setOf]
 
 end bsup
 
--- TODO: bring the lsub API in line with the sSup / iSup API, or deprecate it altogether.
-
 section lsub
 
 set_option linter.deprecated false in
-/-- The least strict upper bound of a family of ordinals. -/
+/-- The least strict upper bound of a family of ordinals.
+
+**Don't use this.** Write `⨆ i, succ (f i)` instead. -/
+@[deprecated iSup (since := "2025-08-19")]
 def lsub {ι} (f : ι → Ordinal) : Ordinal :=
   sup (succ ∘ f)
 
 set_option linter.deprecated false in
-@[simp]
+@[deprecated "`lsub` is deprecated`" (since := "2025-08-19")]
 theorem sup_eq_lsub {ι : Type u} (f : ι → Ordinal.{max u v}) :
     sup.{_, v} (succ ∘ f) = lsub.{_, v} f :=
   rfl
 
 set_option linter.deprecated false in
+@[deprecated "`lsub` is deprecated`" (since := "2025-08-19")]
 theorem lsub_le_iff {ι : Type u} {f : ι → Ordinal.{max u v}} {a} :
     lsub.{_, v} f ≤ a ↔ ∀ i, f i < a := by
   convert sup_le_iff.{_, v} (f := succ ∘ f) (a := a) using 2
   -- Porting note: `comp_apply` is required.
   simp only [comp_apply, succ_le_iff]
 
+set_option linter.deprecated false in
+@[deprecated "`lsub` is deprecated`" (since := "2025-08-19")]
 theorem lsub_le {ι} {f : ι → Ordinal} {a} : (∀ i, f i < a) → lsub f ≤ a :=
   lsub_le_iff.2
 
 set_option linter.deprecated false in
+@[deprecated "`lsub` is deprecated`" (since := "2025-08-19")]
 theorem lt_lsub {ι} (f : ι → Ordinal) (i) : f i < lsub f :=
   succ_le_iff.1 (le_sup _ i)
 
+set_option linter.deprecated false in
+@[deprecated "`lsub` is deprecated`" (since := "2025-08-19")]
 theorem lt_lsub_iff {ι : Type u} {f : ι → Ordinal.{max u v}} {a} :
     a < lsub.{_, v} f ↔ ∃ i, a ≤ f i := by
   simpa only [not_forall, not_lt, not_le] using not_congr (@lsub_le_iff.{_, v} _ f a)
 
 set_option linter.deprecated false in
+@[deprecated "`lsub` is deprecated`" (since := "2025-08-19")]
 theorem sup_le_lsub {ι : Type u} (f : ι → Ordinal.{max u v}) : sup.{_, v} f ≤ lsub.{_, v} f :=
   sup_le fun i => (lt_lsub f i).le
 
 set_option linter.deprecated false in
+@[deprecated "`lsub` is deprecated`" (since := "2025-08-19")]
 theorem lsub_le_sup_succ {ι : Type u} (f : ι → Ordinal.{max u v}) :
     lsub.{_, v} f ≤ succ (sup.{_, v} f) :=
   lsub_le fun i => lt_succ_iff.2 (le_sup f i)
 
 set_option linter.deprecated false in
+@[deprecated "`lsub` is deprecated`" (since := "2025-08-19")]
 theorem sup_eq_lsub_or_sup_succ_eq_lsub {ι : Type u} (f : ι → Ordinal.{max u v}) :
     sup.{_, v} f = lsub.{_, v} f ∨ succ (sup.{_, v} f) = lsub.{_, v} f := by
   rcases eq_or_lt_of_le (sup_le_lsub.{_, v} f) with h | h
@@ -615,6 +667,7 @@ theorem sup_eq_lsub_or_sup_succ_eq_lsub {ι : Type u} (f : ι → Ordinal.{max u
   · exact Or.inr ((succ_le_of_lt h).antisymm (lsub_le_sup_succ f))
 
 set_option linter.deprecated false in
+@[deprecated "`lsub` is deprecated`" (since := "2025-08-19")]
 theorem sup_succ_le_lsub {ι : Type u} (f : ι → Ordinal.{max u v}) :
     succ (sup.{_, v} f) ≤ lsub.{_, v} f ↔ ∃ i, f i = sup.{_, v} f := by
   refine ⟨fun h => ?_, ?_⟩
@@ -625,11 +678,13 @@ theorem sup_succ_le_lsub {ι : Type u} (f : ι → Ordinal.{max u v}) :
   exact lt_lsub _ _
 
 set_option linter.deprecated false in
+@[deprecated "`lsub` is deprecated`" (since := "2025-08-19")]
 theorem sup_succ_eq_lsub {ι : Type u} (f : ι → Ordinal.{max u v}) :
     succ (sup.{_, v} f) = lsub.{_, v} f ↔ ∃ i, f i = sup.{_, v} f :=
   (lsub_le_sup_succ f).ge_iff_eq'.symm.trans (sup_succ_le_lsub f)
 
 set_option linter.deprecated false in
+@[deprecated "`lsub` is deprecated`" (since := "2025-08-19")]
 theorem sup_eq_lsub_iff_succ {ι : Type u} (f : ι → Ordinal.{max u v}) :
     sup.{_, v} f = lsub.{_, v} f ↔ ∀ a < lsub.{_, v} f, succ a < lsub.{_, v} f := by
   refine ⟨fun h => ?_, fun hf => le_antisymm (sup_le_lsub f) (lsub_le fun i => ?_)⟩
@@ -646,21 +701,26 @@ theorem sup_eq_lsub_iff_succ {ι : Type u} (f : ι → Ordinal.{max u v}) :
   exact this.false
 
 set_option linter.deprecated false in
+@[deprecated "`lsub` is deprecated`" (since := "2025-08-19")]
 theorem sup_eq_lsub_iff_lt_sup {ι : Type u} (f : ι → Ordinal.{max u v}) :
     sup.{_, v} f = lsub.{_, v} f ↔ ∀ i, f i < sup.{_, v} f :=
   ⟨fun h i => by
     rw [h]
     apply lt_lsub, fun h => le_antisymm (sup_le_lsub f) (lsub_le h)⟩
 
-@[simp]
+set_option linter.deprecated false in
+@[deprecated "`lsub` is deprecated`" (since := "2025-08-19")]
 theorem lsub_empty {ι} [h : IsEmpty ι] (f : ι → Ordinal) : lsub f = 0 := by
   rw [← Ordinal.le_zero, lsub_le_iff]
   exact h.elim
 
+set_option linter.deprecated false in
+@[deprecated "`lsub` is deprecated`" (since := "2025-08-19")]
 theorem lsub_pos {ι : Type u} [h : Nonempty ι] (f : ι → Ordinal.{max u v}) : 0 < lsub.{_, v} f :=
   h.elim fun i => (Ordinal.zero_le _).trans_lt (lt_lsub f i)
 
-@[simp]
+set_option linter.deprecated false in
+@[deprecated "`lsub` is deprecated`" (since := "2025-08-19")]
 theorem lsub_eq_zero_iff {ι : Type u} (f : ι → Ordinal.{max u v}) :
     lsub.{_, v} f = 0 ↔ IsEmpty ι := by
   refine ⟨fun h => ⟨fun i => ?_⟩, fun h => @lsub_empty _ h _⟩
@@ -669,42 +729,49 @@ theorem lsub_eq_zero_iff {ι : Type u} (f : ι → Ordinal.{max u v}) :
   exact this.false
 
 set_option linter.deprecated false in
-@[simp]
+@[deprecated "`lsub` is deprecated`" (since := "2025-08-19")]
 theorem lsub_const {ι} [Nonempty ι] (o : Ordinal) : (lsub fun _ : ι => o) = succ o :=
   sup_const (succ o)
 
 set_option linter.deprecated false in
-@[simp]
+@[deprecated "`lsub` is deprecated`" (since := "2025-08-19")]
 theorem lsub_unique {ι} [Unique ι] (f : ι → Ordinal) : lsub f = succ (f default) :=
   sup_unique _
 
 set_option linter.deprecated false in
+@[deprecated "`lsub` is deprecated`" (since := "2025-08-19")]
 theorem lsub_le_of_range_subset {ι ι'} {f : ι → Ordinal} {g : ι' → Ordinal}
     (h : Set.range f ⊆ Set.range g) : lsub.{u, max v w} f ≤ lsub.{v, max u w} g :=
   sup_le_of_range_subset.{u, v, w} (by convert Set.image_mono h <;> apply Set.range_comp)
 
+set_option linter.deprecated false in
+@[deprecated "`lsub` is deprecated`" (since := "2025-08-19")]
 theorem lsub_eq_of_range_eq {ι ι'} {f : ι → Ordinal} {g : ι' → Ordinal}
     (h : Set.range f = Set.range g) : lsub.{u, max v w} f = lsub.{v, max u w} g :=
   (lsub_le_of_range_subset.{u, v, w} h.le).antisymm (lsub_le_of_range_subset.{v, u, w} h.ge)
 
 set_option linter.deprecated false in
-@[simp]
+@[deprecated "`lsub` is deprecated`" (since := "2025-08-19")]
 theorem lsub_sum {α : Type u} {β : Type v} (f : α ⊕ β → Ordinal) :
     lsub.{max u v, w} f =
       max (lsub.{u, max v w} fun a => f (Sum.inl a)) (lsub.{v, max u w} fun b => f (Sum.inr b)) :=
   sup_sum _
 
+set_option linter.deprecated false in
+@[deprecated "`lsub` is deprecated`" (since := "2025-08-19")]
 theorem lsub_notMem_range {ι : Type u} (f : ι → Ordinal.{max u v}) :
     lsub.{_, v} f ∉ Set.range f := fun ⟨i, h⟩ =>
   h.not_lt (lt_lsub f i)
 
 @[deprecated (since := "2025-05-23")] alias lsub_not_mem_range := lsub_notMem_range
 
+set_option linter.deprecated false in
+@[deprecated "`lsub` is deprecated`" (since := "2025-08-19")]
 theorem nonempty_compl_range {ι : Type u} (f : ι → Ordinal.{max u v}) : (Set.range f)ᶜ.Nonempty :=
   ⟨_, lsub_notMem_range.{_, v} f⟩
 
 set_option linter.deprecated false in
-@[simp]
+@[deprecated "`lsub` is deprecated`" (since := "2025-08-19")]
 theorem lsub_typein (o : Ordinal) : lsub.{u, u} (typein (α := o.toType) (· < ·)) = o :=
   (lsub_le.{u, u} typein_lt_self).antisymm
     (by
@@ -714,13 +781,14 @@ theorem lsub_typein (o : Ordinal) : lsub.{u, u} (typein (α := o.toType) (· < �
       simpa [typein_enum] using lt_lsub.{u, u} (typein (· < ·)) (enum (· < ·) ⟨_, h⟩))
 
 set_option linter.deprecated false in
+@[deprecated "`lsub` is deprecated`" (since := "2025-08-19")]
 theorem sup_typein_limit {o : Ordinal} (ho : ∀ a, a < o → succ a < o) :
     sup.{u, u} (typein ((· < ·) : o.toType → o.toType → Prop)) = o := by
   -- Porting note: `rwa` → `rw` & `assumption`
   rw [(sup_eq_lsub_iff_succ.{u, u} (typein (· < ·))).2] <;> rw [lsub_typein o]; assumption
 
 set_option linter.deprecated false in
-@[simp]
+@[deprecated "`lsub` is deprecated`" (since := "2025-08-19")]
 theorem sup_typein_succ {o : Ordinal} :
     sup.{u, u} (typein ((· < ·) : (succ o).toType → (succ o).toType → Prop)) = o := by
   rcases sup_eq_lsub_or_sup_succ_eq_lsub.{u, u}
@@ -733,88 +801,116 @@ theorem sup_typein_succ {o : Ordinal} :
 
 end lsub
 
--- TODO: either deprecate this in favor of `lsub` when its universes are generalized, or deprecate
--- both of them at once.
-
 section blsub
 
+set_option linter.deprecated false in
 /-- The least strict upper bound of a family of ordinals indexed by the set of ordinals less than
     some `o : Ordinal.{u}`.
 
-    This is to `lsub` as `bsup` is to `sup`. -/
+    This is to `lsub` as `bsup` is to `sup`.
+
+**Don't use this.** Write `⨆ a : Iio o, succ (f a)` instead. -/
+@[deprecated iSup (since := "2025-08-19")]
 def blsub (o : Ordinal.{u}) (f : ∀ a < o, Ordinal.{max u v}) : Ordinal.{max u v} :=
   bsup.{_, v} o fun a ha => succ (f a ha)
 
-@[simp]
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem bsup_eq_blsub (o : Ordinal.{u}) (f : ∀ a < o, Ordinal.{max u v}) :
     (bsup.{_, v} o fun a ha => succ (f a ha)) = blsub.{_, v} o f :=
   rfl
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem lsub_eq_blsub' {ι : Type u} (r : ι → ι → Prop) [IsWellOrder ι r] {o} (ho : type r = o)
     (f : ∀ a < o, Ordinal.{max u v}) : lsub.{_, v} (familyOfBFamily' r ho f) = blsub.{_, v} o f :=
   sup_eq_bsup'.{_, v} r ho fun a ha => succ (f a ha)
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem lsub_eq_lsub {ι ι' : Type u} (r : ι → ι → Prop) (r' : ι' → ι' → Prop) [IsWellOrder ι r]
     [IsWellOrder ι' r'] {o} (ho : type r = o) (ho' : type r' = o)
     (f : ∀ a < o, Ordinal.{max u v}) :
     lsub.{_, v} (familyOfBFamily' r ho f) = lsub.{_, v} (familyOfBFamily' r' ho' f) := by
   rw [lsub_eq_blsub', lsub_eq_blsub']
 
-@[simp]
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem lsub_eq_blsub {o : Ordinal.{u}} (f : ∀ a < o, Ordinal.{max u v}) :
     lsub.{_, v} (familyOfBFamily o f) = blsub.{_, v} o f :=
   lsub_eq_blsub' _ _ _
 
-@[simp]
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem blsub_eq_lsub' {ι : Type u} (r : ι → ι → Prop) [IsWellOrder ι r]
     (f : ι → Ordinal.{max u v}) : blsub.{_, v} _ (bfamilyOfFamily' r f) = lsub.{_, v} f :=
   bsup_eq_sup'.{_, v} r (succ ∘ f)
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem blsub_eq_blsub {ι : Type u} (r r' : ι → ι → Prop) [IsWellOrder ι r] [IsWellOrder ι r']
     (f : ι → Ordinal.{max u v}) :
     blsub.{_, v} _ (bfamilyOfFamily' r f) = blsub.{_, v} _ (bfamilyOfFamily' r' f) := by
   rw [blsub_eq_lsub', blsub_eq_lsub']
 
-@[simp]
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem blsub_eq_lsub {ι : Type u} (f : ι → Ordinal.{max u v}) :
     blsub.{_, v} _ (bfamilyOfFamily f) = lsub.{_, v} f :=
   blsub_eq_lsub' _ _
 
-@[congr]
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem blsub_congr {o₁ o₂ : Ordinal.{u}} (f : ∀ a < o₁, Ordinal.{max u v}) (ho : o₁ = o₂) :
     blsub.{_, v} o₁ f = blsub.{_, v} o₂ fun a h => f a (h.trans_eq ho.symm) := by
   subst ho
   -- Porting note: `rfl` is required.
   rfl
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem blsub_le_iff {o : Ordinal.{u}} {f : ∀ a < o, Ordinal.{max u v}} {a} :
     blsub.{_, v} o f ≤ a ↔ ∀ i h, f i h < a := by
   convert bsup_le_iff.{_, v} (f := fun a ha => succ (f a ha)) (a := a) using 2
   simp_rw [succ_le_iff]
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem blsub_le {o : Ordinal} {f : ∀ b < o, Ordinal} {a} : (∀ i h, f i h < a) → blsub o f ≤ a :=
   blsub_le_iff.2
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem lt_blsub {o} (f : ∀ a < o, Ordinal) (i h) : f i h < blsub o f :=
   blsub_le_iff.1 le_rfl _ _
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem lt_blsub_iff {o : Ordinal.{u}} {f : ∀ b < o, Ordinal.{max u v}} {a} :
     a < blsub.{_, v} o f ↔ ∃ i hi, a ≤ f i hi := by
   simpa only [not_forall, not_lt, not_le] using not_congr (@blsub_le_iff.{_, v} _ f a)
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem bsup_le_blsub {o : Ordinal.{u}} (f : ∀ a < o, Ordinal.{max u v}) :
     bsup.{_, v} o f ≤ blsub.{_, v} o f :=
   bsup_le fun i h => (lt_blsub f i h).le
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem blsub_le_bsup_succ {o : Ordinal.{u}} (f : ∀ a < o, Ordinal.{max u v}) :
     blsub.{_, v} o f ≤ succ (bsup.{_, v} o f) :=
   blsub_le fun i h => lt_succ_iff.2 (le_bsup f i h)
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem bsup_eq_blsub_or_succ_bsup_eq_blsub {o : Ordinal.{u}} (f : ∀ a < o, Ordinal.{max u v}) :
     bsup.{_, v} o f = blsub.{_, v} o f ∨ succ (bsup.{_, v} o f) = blsub.{_, v} o f := by
   rw [← sup_eq_bsup, ← lsub_eq_blsub]
   exact sup_eq_lsub_or_sup_succ_eq_lsub _
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem bsup_succ_le_blsub {o : Ordinal.{u}} (f : ∀ a < o, Ordinal.{max u v}) :
     succ (bsup.{_, v} o f) ≤ blsub.{_, v} o f ↔ ∃ i hi, f i hi = bsup.{_, v} o f := by
   refine ⟨fun h => ?_, ?_⟩
@@ -826,43 +922,58 @@ theorem bsup_succ_le_blsub {o : Ordinal.{u}} (f : ∀ a < o, Ordinal.{max u v}) 
   rw [succ_le_iff, ← hf]
   exact lt_blsub _ _ _
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem bsup_succ_eq_blsub {o : Ordinal.{u}} (f : ∀ a < o, Ordinal.{max u v}) :
     succ (bsup.{_, v} o f) = blsub.{_, v} o f ↔ ∃ i hi, f i hi = bsup.{_, v} o f :=
   (blsub_le_bsup_succ f).ge_iff_eq'.symm.trans (bsup_succ_le_blsub f)
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem bsup_eq_blsub_iff_succ {o : Ordinal.{u}} (f : ∀ a < o, Ordinal.{max u v}) :
     bsup.{_, v} o f = blsub.{_, v} o f ↔ ∀ a < blsub.{_, v} o f, succ a < blsub.{_, v} o f := by
   rw [← sup_eq_bsup, ← lsub_eq_blsub]
   apply sup_eq_lsub_iff_succ
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem bsup_eq_blsub_iff_lt_bsup {o : Ordinal.{u}} (f : ∀ a < o, Ordinal.{max u v}) :
     bsup.{_, v} o f = blsub.{_, v} o f ↔ ∀ i hi, f i hi < bsup.{_, v} o f :=
   ⟨fun h i => by
     rw [h]
     apply lt_blsub, fun h => le_antisymm (bsup_le_blsub f) (blsub_le h)⟩
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem bsup_eq_blsub_of_lt_succ_limit {o : Ordinal.{u}} (ho : IsSuccLimit o)
     {f : ∀ a < o, Ordinal.{max u v}} (hf : ∀ a ha, f a ha < f (succ a) (ho.succ_lt ha)) :
     bsup.{_, v} o f = blsub.{_, v} o f := by
   rw [bsup_eq_blsub_iff_lt_bsup]
   exact fun i hi => (hf i hi).trans_le (le_bsup f _ _)
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem blsub_succ_of_mono {o : Ordinal.{u}} {f : ∀ a < succ o, Ordinal.{max u v}}
     (hf : ∀ {i j} (hi hj), i ≤ j → f i hi ≤ f j hj) : blsub.{_, v} _ f = succ (f o (lt_succ o)) :=
   bsup_succ_of_mono fun {_ _} hi hj h => succ_le_succ (hf hi hj h)
 
-@[simp]
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem blsub_eq_zero_iff {o} {f : ∀ a < o, Ordinal} : blsub o f = 0 ↔ o = 0 := by
   rw [← lsub_eq_blsub, lsub_eq_zero_iff]
   exact toType_empty_iff_eq_zero
 
--- Porting note: `rwa` → `rw`
-@[simp]
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem blsub_zero (f : ∀ a < (0 : Ordinal), Ordinal) : blsub 0 f = 0 := by rw [blsub_eq_zero_iff]
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem blsub_pos {o : Ordinal} (ho : 0 < o) (f : ∀ a < o, Ordinal) : 0 < blsub o f :=
   (Ordinal.zero_le _).trans_lt (lt_blsub f 0 ho)
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem blsub_type {α : Type u} (r : α → α → Prop) [IsWellOrder α r]
     (f : ∀ a < type r, Ordinal.{max u v}) :
     blsub.{_, v} (type r) f = lsub.{_, v} fun a => f (typein r a) (typein_lt_type _ _) :=
@@ -870,25 +981,34 @@ theorem blsub_type {α : Type u} (r : α → α → Prop) [IsWellOrder α r]
     rw [blsub_le_iff, lsub_le_iff]
     exact ⟨fun H b => H _ _, fun H i h => by simpa only [typein_enum] using H (enum r ⟨i, h⟩)⟩
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem blsub_const {o : Ordinal} (ho : o ≠ 0) (a : Ordinal) :
     (blsub.{u, v} o fun _ _ => a) = succ a :=
   bsup_const.{u, v} ho (succ a)
 
-@[simp]
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem blsub_one (f : ∀ a < (1 : Ordinal), Ordinal) : blsub 1 f = succ (f 0 zero_lt_one) :=
   bsup_one _
 
-@[simp]
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem blsub_id : ∀ o, (blsub.{u, u} o fun x _ => x) = o :=
   lsub_typein
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem bsup_id_limit {o : Ordinal} : (∀ a < o, succ a < o) → (bsup.{u, u} o fun x _ => x) = o :=
   sup_typein_limit
 
-@[simp]
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem bsup_id_succ (o) : (bsup.{u, u} (succ o) fun x _ => x) = o :=
   sup_typein_succ
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem blsub_le_of_brange_subset {o o'} {f : ∀ a < o, Ordinal} {g : ∀ a < o', Ordinal}
     (h : brange o f ⊆ brange o' g) : blsub.{u, max v w} o f ≤ blsub.{v, max u w} o' g :=
   bsup_le_of_brange_subset.{u, v, w} fun a ⟨b, hb, hb'⟩ => by
@@ -896,11 +1016,15 @@ theorem blsub_le_of_brange_subset {o o'} {f : ∀ a < o, Ordinal} {g : ∀ a < o
     simp_rw [← hc'] at hb'
     exact ⟨c, hc, hb'⟩
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem blsub_eq_of_brange_eq {o o'} {f : ∀ a < o, Ordinal} {g : ∀ a < o', Ordinal}
     (h : { o | ∃ i hi, f i hi = o } = { o | ∃ i hi, g i hi = o }) :
     blsub.{u, max v w} o f = blsub.{v, max u w} o' g :=
   (blsub_le_of_brange_subset.{u, v, w} h.le).antisymm (blsub_le_of_brange_subset.{v, u, w} h.ge)
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem bsup_comp {o o' : Ordinal.{max u v}} {f : ∀ a < o, Ordinal.{max u v w}}
     (hf : ∀ {i j} (hi) (hj), i ≤ j → f i hi ≤ f j hj) {g : ∀ a < o', Ordinal.{max u v}}
     (hg : blsub.{_, u} o' g = o) :
@@ -911,6 +1035,8 @@ theorem bsup_comp {o o' : Ordinal.{max u v}} {f : ∀ a < o, Ordinal.{max u v w}
     rcases hi with ⟨j, hj, hj'⟩
     exact (hf _ _ hj').trans (le_bsup _ _ _)
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem blsub_comp {o o' : Ordinal.{max u v}} {f : ∀ a < o, Ordinal.{max u v w}}
     (hf : ∀ {i j} (hi) (hj), i ≤ j → f i hi ≤ f j hj) {g : ∀ a < o', Ordinal.{max u v}}
     (hg : blsub.{_, u} o' g = o) :
@@ -918,15 +1044,21 @@ theorem blsub_comp {o o' : Ordinal.{max u v}} {f : ∀ a < o, Ordinal.{max u v w
   @bsup_comp.{u, v, w} o _ (fun a ha => succ (f a ha))
     (fun {_ _} _ _ h => succ_le_succ_iff.2 (hf _ _ h)) g hg
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem IsNormal.bsup_eq {f : Ordinal.{u} → Ordinal.{max u v}} (H : IsNormal f) {o : Ordinal.{u}}
     (h : IsSuccLimit o) : (Ordinal.bsup.{_, v} o fun x _ => f x) = f o := by
   rw [← IsNormal.bsup.{u, u, v} H (fun x _ => x) h.ne_bot, bsup_id_limit fun _ ↦ h.succ_lt]
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem IsNormal.blsub_eq {f : Ordinal.{u} → Ordinal.{max u v}} (H : IsNormal f) {o : Ordinal.{u}}
     (h : IsSuccLimit o) : (blsub.{_, v} o fun x _ => f x) = f o := by
   rw [← IsNormal.bsup_eq.{u, v} H h, bsup_eq_blsub_of_lt_succ_limit h]
   exact fun a _ => H.strictMono (lt_succ a)
 
+set_option linter.deprecated false in
+@[deprecated "`bsup` is deprecated`" (since := "2025-08-19")]
 theorem isNormal_iff_lt_succ_and_bsup_eq {f : Ordinal.{u} → Ordinal.{max u v}} :
     IsNormal f ↔ (∀ a, f a < f (succ a)) ∧
       ∀ o, IsSuccLimit o → (bsup.{_, v} o fun x _ => f x) = f o :=
@@ -935,6 +1067,8 @@ theorem isNormal_iff_lt_succ_and_bsup_eq {f : Ordinal.{u} → Ordinal.{max u v}}
       rw [← h₂ _ ho]
       simpa [IsLUB, upperBounds, lowerBounds, IsLeast, bsup_le_iff] using le_bsup _⟩
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem isNormal_iff_lt_succ_and_blsub_eq {f : Ordinal.{u} → Ordinal.{max u v}} :
     IsNormal f ↔ (∀ a, f a < f (succ a)) ∧
       ∀ o, IsSuccLimit o → (blsub.{_, v} o fun x _ => f x) = f o := by
@@ -943,6 +1077,8 @@ theorem isNormal_iff_lt_succ_and_blsub_eq {f : Ordinal.{u} → Ordinal.{max u v}
   constructor <;> intro H o ho <;> have := H o ho <;>
     rwa [← bsup_eq_blsub_of_lt_succ_limit ho fun a _ => h a] at *
 
+set_option linter.deprecated false in
+@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem IsNormal.eq_iff_zero_and_succ {f g : Ordinal.{u} → Ordinal.{u}} (hf : IsNormal f)
     (hg : IsNormal g) : f = g ↔ f 0 = g 0 ∧ ∀ a, f a = g a → f (succ a) = g (succ a) :=
   ⟨fun h => by simp [h], fun ⟨h₁, h₂⟩ =>
@@ -962,9 +1098,13 @@ end Ordinal
 
 /-! ### Results about injectivity and surjectivity -/
 
-
-theorem not_surjective_of_ordinal {α : Type u} (f : α → Ordinal.{u}) : ¬Surjective f := fun h =>
-  Ordinal.lsub_notMem_range.{u, u} f (h _)
+-- TODO: why not just have the small versions?
+theorem not_surjective_of_ordinal {α : Type u} (f : α → Ordinal.{u}) : ¬Surjective f := by
+  intro h
+  obtain ⟨a, ha⟩ := h (⨆ i, succ (f i))
+  apply ha.not_lt
+  rw [Ordinal.lt_iSup_iff]
+  exact ⟨a, Order.lt_succ _⟩
 
 theorem not_injective_of_ordinal {α : Type u} (f : Ordinal.{u} → α) : ¬Injective f := fun h =>
   not_surjective_of_ordinal _ (invFun_surjective h)

--- a/Mathlib/SetTheory/Ordinal/Family.lean
+++ b/Mathlib/SetTheory/Ordinal/Family.lean
@@ -169,7 +169,7 @@ theorem comp_familyOfBFamily {o} (f : ∀ a < o, α) (g : α → β) :
 /-- The supremum of a family of ordinals.
 
 **Don't use this.** Use `iSup` instead. -/
-@[deprecated iSup (since := "2024-08-27")]
+@[deprecated iSup (since := "2025-08-19")]
 def sup {ι : Type u} (f : ι → Ordinal.{max u v}) : Ordinal.{max u v} :=
   iSup f
 
@@ -207,7 +207,7 @@ protected theorem le_iSup {ι} (f : ι → Ordinal.{u}) [Small.{u} ι] : ∀ i, 
   le_ciSup (bddAbove_of_small _)
 
 set_option linter.deprecated false in
-@[deprecated Ordinal.le_iSup (since := "2024-08-27")]
+@[deprecated Ordinal.le_iSup (since := "2025-08-19")]
 theorem le_sup {ι : Type u} (f : ι → Ordinal.{max u v}) : ∀ i, f i ≤ sup.{_, v} f := fun i =>
   Ordinal.le_iSup f i
 
@@ -217,7 +217,7 @@ protected theorem iSup_le_iff {ι} {f : ι → Ordinal.{u}} {a : Ordinal.{u}} [S
   ciSup_le_iff' (bddAbove_of_small _)
 
 set_option linter.deprecated false in
-@[deprecated Ordinal.iSup_le_iff (since := "2024-08-27")]
+@[deprecated Ordinal.iSup_le_iff (since := "2025-08-19")]
 theorem sup_le_iff {ι : Type u} {f : ι → Ordinal.{max u v}} {a} : sup.{_, v} f ≤ a ↔ ∀ i, f i ≤ a :=
   Ordinal.iSup_le_iff
 
@@ -227,7 +227,7 @@ protected theorem iSup_le {ι} {f : ι → Ordinal} {a} :
   ciSup_le'
 
 set_option linter.deprecated false in
-@[deprecated Ordinal.iSup_le (since := "2024-08-27")]
+@[deprecated Ordinal.iSup_le (since := "2025-08-19")]
 theorem sup_le {ι : Type u} {f : ι → Ordinal.{max u v}} {a} : (∀ i, f i ≤ a) → sup.{_, v} f ≤ a :=
   Ordinal.iSup_le
 
@@ -236,13 +236,13 @@ protected theorem lt_iSup_iff {ι} {f : ι → Ordinal.{u}} {a : Ordinal.{u}} [S
     a < iSup f ↔ ∃ i, a < f i :=
   lt_ciSup_iff' (bddAbove_of_small _)
 
-@[deprecated "No deprecation message was provided." (since := "2024-08-27")]
+@[deprecated "No deprecation message was provided." (since := "2025-08-19")]
 theorem ne_iSup_iff_lt_iSup {ι : Type u} {f : ι → Ordinal.{max u v}} :
     (∀ i, f i ≠ iSup f) ↔ ∀ i, f i < iSup f :=
   forall_congr' fun i => (Ordinal.le_iSup f i).lt_iff_ne.symm
 
 set_option linter.deprecated false in
-@[deprecated ne_iSup_iff_lt_iSup (since := "2024-08-27")]
+@[deprecated ne_iSup_iff_lt_iSup (since := "2025-08-19")]
 theorem ne_sup_iff_lt_sup {ι : Type u} {f : ι → Ordinal.{max u v}} :
     (∀ i, f i ≠ sup.{_, v} f) ↔ ∀ i, f i < sup.{_, v} f :=
   ne_iSup_iff_lt_iSup
@@ -255,7 +255,7 @@ theorem succ_lt_iSup_of_ne_iSup {ι} {f : ι → Ordinal.{u}} [Small.{u} ι]
     (lt_of_le_of_ne (Ordinal.le_iSup _ _) (hf i)).trans_le hoa)
 
 set_option linter.deprecated false in
-@[deprecated succ_lt_iSup_of_ne_iSup (since := "2024-08-27")]
+@[deprecated succ_lt_iSup_of_ne_iSup (since := "2025-08-19")]
 theorem sup_not_succ_of_ne_sup {ι : Type u} {f : ι → Ordinal.{max u v}}
     (hf : ∀ i, f i ≠ sup.{_, v} f) {a} (hao : a < sup.{_, v} f) : succ a < sup.{_, v} f := by
   by_contra! hoa
@@ -272,17 +272,17 @@ theorem iSup_eq_zero_iff {ι} {f : ι → Ordinal.{u}} [Small.{u} ι] :
   exact Ordinal.le_iSup f i
 
 set_option linter.deprecated false in
-@[deprecated ciSup_const (since := "2024-08-27")]
+@[deprecated ciSup_const (since := "2025-08-19")]
 theorem sup_const {ι} [_hι : Nonempty ι] (o : Ordinal) : (sup fun _ : ι => o) = o :=
   ciSup_const
 
 set_option linter.deprecated false in
-@[deprecated ciSup_unique (since := "2024-08-27")]
+@[deprecated ciSup_unique (since := "2025-08-19")]
 theorem sup_unique {ι} [Unique ι] (f : ι → Ordinal) : sup f = f default :=
   ciSup_unique
 
 set_option linter.deprecated false in
-@[deprecated csSup_le_csSup' (since := "2024-08-27")]
+@[deprecated csSup_le_csSup' (since := "2025-08-19")]
 theorem sup_le_of_range_subset {ι ι'} {f : ι → Ordinal} {g : ι' → Ordinal}
     (h : Set.range f ⊆ Set.range g) : sup.{u, max v w} f ≤ sup.{v, max u w} g :=
   csSup_le_csSup' (bddAbove_range.{v, max u w} _) h
@@ -293,7 +293,7 @@ theorem iSup_eq_of_range_eq {ι ι'} {f : ι → Ordinal} {g : ι' → Ordinal}
   congr_arg _ h
 
 set_option linter.deprecated false in
-@[deprecated iSup_eq_of_range_eq (since := "2024-08-27")]
+@[deprecated iSup_eq_of_range_eq (since := "2025-08-19")]
 theorem sup_eq_of_range_eq {ι : Type u} {ι' : Type v}
     {f : ι → Ordinal.{max u v w}} {g : ι' → Ordinal.{max u v w}}
     (h : Set.range f = Set.range g) : sup.{u, max v w} f = sup.{v, max u w} g :=
@@ -317,7 +317,7 @@ theorem iSup_sum {α β} (f : α ⊕ β → Ordinal.{u}) [Small.{u} α] [Small.{
     apply mem_range_self
 
 set_option linter.deprecated false in
-@[deprecated iSup_sum (since := "2024-08-27")]
+@[deprecated iSup_sum (since := "2025-08-19")]
 theorem sup_sum {α : Type u} {β : Type v} (f : α ⊕ β → Ordinal) :
     sup.{max u v, w} f =
       max (sup.{u, max v w} fun a => f (Sum.inl a)) (sup.{v, max u w} fun b => f (Sum.inr b)) := by
@@ -358,7 +358,7 @@ theorem IsNormal.map_sSup {f : Ordinal.{u} → Ordinal.{v}} (H : IsNormal f)
   H.map_sSup_of_bddAbove (bddAbove_of_small s) hn
 
 set_option linter.deprecated false in
-@[deprecated IsNormal.map_iSup (since := "2024-08-27")]
+@[deprecated IsNormal.map_iSup (since := "2025-08-19")]
 theorem IsNormal.sup {f : Ordinal.{max u v} → Ordinal.{max u w}} (H : IsNormal f) {ι : Type u}
     (g : ι → Ordinal.{max u v}) [Nonempty ι] : f (sup.{_, v} g) = sup.{_, w} (f ∘ g) :=
   H.map_iSup g

--- a/Mathlib/SetTheory/Ordinal/Family.lean
+++ b/Mathlib/SetTheory/Ordinal/Family.lean
@@ -9,14 +9,8 @@ import Mathlib.SetTheory.Ordinal.Arithmetic
 /-!
 # Arithmetic on families of ordinals
 
-## Main definitions and results
-
-* `sup`, `lsub`: the supremum / least strict upper bound of an indexed family of ordinals in
-  `Type u`, as an ordinal in `Type u`.
-* `bsup`, `blsub`: the supremum / least strict upper bound of a set of ordinals indexed by ordinals
-  less than a given ordinal `o`.
-
-Various other basic arithmetic results are given in `Principal.lean` instead.
+The vast majority of this file has been deprecated. The things that remain should probably be moved
+elsewhere.
 -/
 
 assert_not_exists Field Module
@@ -1077,8 +1071,6 @@ theorem isNormal_iff_lt_succ_and_blsub_eq {f : Ordinal.{u} → Ordinal.{max u v}
   constructor <;> intro H o ho <;> have := H o ho <;>
     rwa [← bsup_eq_blsub_of_lt_succ_limit ho fun a _ => h a] at *
 
-set_option linter.deprecated false in
-@[deprecated "`blsub` is deprecated`" (since := "2025-08-19")]
 theorem IsNormal.eq_iff_zero_and_succ {f g : Ordinal.{u} → Ordinal.{u}} (hf : IsNormal f)
     (hg : IsNormal g) : f = g ↔ f 0 = g 0 ∧ ∀ a, f a = g a → f (succ a) = g (succ a) :=
   Order.IsNormal.ext hf hg

--- a/Mathlib/SetTheory/Ordinal/Family.lean
+++ b/Mathlib/SetTheory/Ordinal/Family.lean
@@ -329,15 +329,8 @@ theorem unbounded_range_of_le_iSup {α β : Type u} (r : α → α → Prop) [Is
 
 theorem IsNormal.map_iSup_of_bddAbove {f : Ordinal.{u} → Ordinal.{v}} (H : IsNormal f)
     {ι : Type*} (g : ι → Ordinal.{u}) (hg : BddAbove (range g))
-    [Nonempty ι] : f (⨆ i, g i) = ⨆ i, f (g i) := eq_of_forall_ge_iff fun a ↦ by
-  have := bddAbove_iff_small.mp hg
-  have := univLE_of_injective H.strictMono.injective
-  have := Small.trans_univLE.{u, v} (range g)
-  have hfg : BddAbove (range (f ∘ g)) := bddAbove_iff_small.mpr <| by
-    rw [range_comp]
-    exact small_image f (range g)
-  change _ ↔ ⨆ i, (f ∘ g) i ≤ a
-  rw [ciSup_le_iff hfg, H.le_set' _ Set.univ_nonempty g] <;> simp [ciSup_le_iff hg]
+    [Nonempty ι] : f (⨆ i, g i) = ⨆ i, f (g i) :=
+  Order.IsNormal.map_iSup H hg
 
 theorem IsNormal.map_iSup {f : Ordinal.{u} → Ordinal.{v}} (H : IsNormal f)
     {ι : Type w} (g : ι → Ordinal.{u}) [Small.{u} ι] [Nonempty ι] :
@@ -945,16 +938,7 @@ theorem isNormal_iff_lt_succ_and_blsub_eq {f : Ordinal.{u} → Ordinal.{max u v}
 
 theorem IsNormal.eq_iff_zero_and_succ {f g : Ordinal.{u} → Ordinal.{u}} (hf : IsNormal f)
     (hg : IsNormal g) : f = g ↔ f 0 = g 0 ∧ ∀ a, f a = g a → f (succ a) = g (succ a) :=
-  ⟨fun h => by simp [h], fun ⟨h₁, h₂⟩ =>
-    funext fun a => by
-      induction a using limitRecOn with
-      | zero => solve_by_elim
-      | succ => solve_by_elim
-      | limit _ ho H =>
-        rw [← IsNormal.bsup_eq.{u, u} hf ho, ← IsNormal.bsup_eq.{u, u} hg ho]
-        congr
-        ext b hb
-        exact H b hb⟩
+  Order.IsNormal.ext hf hg
 
 end blsub
 

--- a/Mathlib/SetTheory/Ordinal/NaturalOps.lean
+++ b/Mathlib/SetTheory/Ordinal/NaturalOps.lean
@@ -11,6 +11,8 @@ deprecated_module
   "This module is now at `CombinatorialGames.NatOrdinal` in the CGT repo <https://github.com/vihdzp/combinatorial-games>"
   (since := "2025-08-06")
 
+set_option linter.deprecated false
+
 /-!
 # Natural operations on ordinals
 
@@ -48,7 +50,6 @@ universe u v
 
 open Function Order Set
 
-set_option linter.deprecated false in
 noncomputable section
 
 /-! ### Basic casts between `Ordinal` and `NatOrdinal` -/

--- a/Mathlib/SetTheory/Ordinal/NaturalOps.lean
+++ b/Mathlib/SetTheory/Ordinal/NaturalOps.lean
@@ -48,6 +48,7 @@ universe u v
 
 open Function Order Set
 
+set_option linter.deprecated false in
 noncomputable section
 
 /-! ### Basic casts between `Ordinal` and `NatOrdinal` -/

--- a/Mathlib/SetTheory/Ordinal/Topology.lean
+++ b/Mathlib/SetTheory/Ordinal/Topology.lean
@@ -20,6 +20,10 @@ We prove some miscellaneous results involving the order topology of ordinals.
   functions.
 * `Ordinal.enumOrd_isNormal_iff_isClosed`: The function enumerating the ordinals of a set is
   normal iff the set is closed.
+
+## Todo
+
+Many of these results/definitions should generalize to other well-orders.
 -/
 
 
@@ -65,6 +69,8 @@ theorem isOpen_iff : IsOpen s ↔ ∀ o ∈ s, IsSuccLimit o → ∃ a < o, Set.
     simp only [← Set.Ioo_insert_right ha, Set.insert_subset_iff, ho, true_and]
   · simp [nhds_eq_pure.2 ho', ho, ho']
 
+-- TODO: the following theorems are stated in a really unnatural form. 
+
 open List Set in
 theorem mem_closure_tfae (a : Ordinal.{u}) (s : Set Ordinal) :
     TFAE [a ∈ closure s,
@@ -105,17 +111,20 @@ theorem mem_closure_tfae (a : Ordinal.{u}) (s : Set Ordinal) :
       (bddAbove_range.{u, u} f)
   tfae_finish
 
+-- TODO: in a general well-order, `a ∈ closure s` iff `a` is the supremum of a bounded subset of `s`
 theorem mem_closure_iff_iSup :
     a ∈ closure s ↔
       ∃ (ι : Type u) (_ : Nonempty ι) (f : ι → Ordinal), (∀ i, f i ∈ s) ∧ ⨆ i, f i = a := by
   apply ((mem_closure_tfae a s).out 0 5).trans
   simp_rw [exists_prop]
 
+-- TODO: in a general well-order, the supremum of a bounded subset of a closed set is in the set.
 theorem mem_iff_iSup_of_isClosed (hs : IsClosed s) :
     a ∈ s ↔ ∃ (ι : Type u) (_hι : Nonempty ι) (f : ι → Ordinal),
       (∀ i, f i ∈ s) ∧ ⨆ i, f i = a := by
   rw [← mem_closure_iff_iSup, hs.closure_eq]
 
+@[deprecated mem_closure_iff_iSup (since := "2025-08-19")]
 theorem mem_closure_iff_bsup :
     a ∈ closure s ↔
       ∃ (o : Ordinal) (_ho : o ≠ 0) (f : ∀ a < o, Ordinal),
@@ -123,6 +132,7 @@ theorem mem_closure_iff_bsup :
   apply ((mem_closure_tfae a s).out 0 4).trans
   simp_rw [exists_prop]
 
+@[deprecated mem_iff_iSup_of_isClosed (since := "2025-08-19")]
 theorem mem_closed_iff_bsup (hs : IsClosed s) :
     a ∈ s ↔
       ∃ (o : Ordinal) (_ho : o ≠ 0) (f : ∀ a < o, Ordinal),
@@ -138,6 +148,7 @@ theorem isClosed_iff_iSup :
   rcases mem_closure_iff_iSup.1 hx with ⟨ι, hι, f, hf, rfl⟩
   exact h hι f hf
 
+@[deprecated isClosed_iff_iSup (since := "2025-08-19")]
 theorem isClosed_iff_bsup :
     IsClosed s ↔
       ∀ {o : Ordinal}, o ≠ 0 → ∀ f : ∀ a < o, Ordinal,
@@ -163,6 +174,7 @@ theorem isSuccLimit_of_mem_frontier (ha : a ∈ frontier s) : IsSuccLimit a := b
 @[deprecated (since := "2025-07-08")]
 alias isLimit_of_mem_frontier := isSuccLimit_of_mem_frontier
 
+-- TODO: prove for `Order.IsNormal` in a well-order with the order topology.
 theorem isNormal_iff_strictMono_and_continuous (f : Ordinal.{u} → Ordinal.{u}) :
     IsNormal f ↔ StrictMono f ∧ Continuous f := by
   refine ⟨fun h => ⟨h.strictMono, ?_⟩, ?_⟩

--- a/Mathlib/SetTheory/Ordinal/Topology.lean
+++ b/Mathlib/SetTheory/Ordinal/Topology.lean
@@ -69,7 +69,7 @@ theorem isOpen_iff : IsOpen s ↔ ∀ o ∈ s, IsSuccLimit o → ∃ a < o, Set.
     simp only [← Set.Ioo_insert_right ha, Set.insert_subset_iff, ho, true_and]
   · simp [nhds_eq_pure.2 ho', ho, ho']
 
--- TODO: the following theorems are stated in a really unnatural form. 
+-- TODO: the following theorems are stated in a really unnatural form.
 
 open List Set in
 theorem mem_closure_tfae (a : Ordinal.{u}) (s : Set Ordinal) :
@@ -111,14 +111,12 @@ theorem mem_closure_tfae (a : Ordinal.{u}) (s : Set Ordinal) :
       (bddAbove_range.{u, u} f)
   tfae_finish
 
--- TODO: in a general well-order, `a ∈ closure s` iff `a` is the supremum of a bounded subset of `s`
 theorem mem_closure_iff_iSup :
     a ∈ closure s ↔
       ∃ (ι : Type u) (_ : Nonempty ι) (f : ι → Ordinal), (∀ i, f i ∈ s) ∧ ⨆ i, f i = a := by
   apply ((mem_closure_tfae a s).out 0 5).trans
   simp_rw [exists_prop]
 
--- TODO: in a general well-order, the supremum of a bounded subset of a closed set is in the set.
 theorem mem_iff_iSup_of_isClosed (hs : IsClosed s) :
     a ∈ s ↔ ∃ (ι : Type u) (_hι : Nonempty ι) (f : ι → Ordinal),
       (∀ i, f i ∈ s) ∧ ⨆ i, f i = a := by

--- a/Mathlib/SetTheory/Ordinal/Topology.lean
+++ b/Mathlib/SetTheory/Ordinal/Topology.lean
@@ -72,6 +72,8 @@ theorem isOpen_iff : IsOpen s ↔ ∀ o ∈ s, IsSuccLimit o → ∃ a < o, Set.
 -- TODO: the following theorems are stated in a really unnatural form.
 
 open List Set in
+set_option linter.deprecated false in
+@[deprecated "this needs to be restated for a general well-order" (since := "2025-08-19")]
 theorem mem_closure_tfae (a : Ordinal.{u}) (s : Set Ordinal) :
     TFAE [a ∈ closure s,
       a ∈ closure (s ∩ Iic a),
@@ -111,18 +113,23 @@ theorem mem_closure_tfae (a : Ordinal.{u}) (s : Set Ordinal) :
       (bddAbove_range.{u, u} f)
   tfae_finish
 
+set_option linter.deprecated false in
+@[deprecated "this needs to be restated for a general well-order" (since := "2025-08-19")]
 theorem mem_closure_iff_iSup :
     a ∈ closure s ↔
       ∃ (ι : Type u) (_ : Nonempty ι) (f : ι → Ordinal), (∀ i, f i ∈ s) ∧ ⨆ i, f i = a := by
   apply ((mem_closure_tfae a s).out 0 5).trans
   simp_rw [exists_prop]
 
+set_option linter.deprecated false in
+@[deprecated "this needs to be restated for a general well-order" (since := "2025-08-19")]
 theorem mem_iff_iSup_of_isClosed (hs : IsClosed s) :
     a ∈ s ↔ ∃ (ι : Type u) (_hι : Nonempty ι) (f : ι → Ordinal),
       (∀ i, f i ∈ s) ∧ ⨆ i, f i = a := by
   rw [← mem_closure_iff_iSup, hs.closure_eq]
 
-@[deprecated mem_closure_iff_iSup (since := "2025-08-19")]
+set_option linter.deprecated false in
+@[deprecated "this needs to be restated for a general well-order" (since := "2025-08-19")]
 theorem mem_closure_iff_bsup :
     a ∈ closure s ↔
       ∃ (o : Ordinal) (_ho : o ≠ 0) (f : ∀ a < o, Ordinal),
@@ -130,13 +137,16 @@ theorem mem_closure_iff_bsup :
   apply ((mem_closure_tfae a s).out 0 4).trans
   simp_rw [exists_prop]
 
-@[deprecated mem_iff_iSup_of_isClosed (since := "2025-08-19")]
+set_option linter.deprecated false in
+@[deprecated "this needs to be restated for a general well-order" (since := "2025-08-19")]
 theorem mem_closed_iff_bsup (hs : IsClosed s) :
     a ∈ s ↔
       ∃ (o : Ordinal) (_ho : o ≠ 0) (f : ∀ a < o, Ordinal),
         (∀ i hi, f i hi ∈ s) ∧ bsup.{u, u} o f = a := by
   rw [← mem_closure_iff_bsup, hs.closure_eq]
 
+set_option linter.deprecated false in
+@[deprecated "this needs to be restated for a general well-order" (since := "2025-08-19")]
 theorem isClosed_iff_iSup :
     IsClosed s ↔
       ∀ {ι : Type u}, Nonempty ι → ∀ f : ι → Ordinal, (∀ i, f i ∈ s) → ⨆ i, f i ∈ s := by
@@ -146,7 +156,8 @@ theorem isClosed_iff_iSup :
   rcases mem_closure_iff_iSup.1 hx with ⟨ι, hι, f, hf, rfl⟩
   exact h hι f hf
 
-@[deprecated isClosed_iff_iSup (since := "2025-08-19")]
+set_option linter.deprecated false in
+@[deprecated "this needs to be restated for a general well-order" (since := "2025-08-19")]
 theorem isClosed_iff_bsup :
     IsClosed s ↔
       ∀ {o : Ordinal}, o ≠ 0 → ∀ f : ∀ a < o, Ordinal,
@@ -173,6 +184,8 @@ theorem isSuccLimit_of_mem_frontier (ha : a ∈ frontier s) : IsSuccLimit a := b
 alias isLimit_of_mem_frontier := isSuccLimit_of_mem_frontier
 
 -- TODO: prove for `Order.IsNormal` in a well-order with the order topology.
+set_option linter.deprecated false in
+@[deprecated "this needs to be restated for a general well-order" (since := "2025-08-19")]
 theorem isNormal_iff_strictMono_and_continuous (f : Ordinal.{u} → Ordinal.{u}) :
     IsNormal f ↔ StrictMono f ∧ Continuous f := by
   refine ⟨fun h => ⟨h.strictMono, ?_⟩, ?_⟩
@@ -195,6 +208,8 @@ theorem isNormal_iff_strictMono_and_continuous (f : Ordinal.{u} → Ordinal.{u})
       ⟨_, toType_nonempty_iff_ne_zero.2 ho.ne_bot, typein (· < ·), fun i => h _ (typein_lt_self i),
         sup_typein_limit fun _ ↦ ho.succ_lt⟩
 
+set_option linter.deprecated false in
+@[deprecated "this needs to be restated for a general well-order" (since := "2025-08-19")]
 theorem enumOrd_isNormal_iff_isClosed (hs : ¬ BddAbove s) :
     IsNormal (enumOrd s) ↔ IsClosed s := by
   have Hs := enumOrd_strictMono hs


### PR DESCRIPTION
This PR formally deprecates `Ordinal.bsup`, `Ordinal.lsub`, and `Ordinal.blsub`. These arose as ways to construct suprema of ordinals, before we realized it was a much better idea to simply work with the `ConditionallyCompleteLinearOrderBot` structure of `Ordinal`. As a consequence, it gets rid of some longstanding non-deprecated material depending on deprecated material.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

- [x] depends on: #28677

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
