### PR TITLE
[Merged by Bors] - chore: strengthen denselyOrdered_units_iff

### DIFF
--- a/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Canonical.lean
@@ -6,12 +6,13 @@ Authors: Kenny Lau, Johan Commelin, Patrick Massot
 import Mathlib.Algebra.GroupWithZero.InjSurj
 import Mathlib.Algebra.GroupWithZero.WithZero
 import Mathlib.Algebra.Order.AddGroupWithTop
+import Mathlib.Algebra.Order.Group.Defs
 import Mathlib.Algebra.Order.Group.Int
-import Mathlib.Algebra.Order.Monoid.Units
+import Mathlib.Algebra.Order.Group.Units
+import Mathlib.Algebra.Order.GroupWithZero.Unbundled.Basic
 import Mathlib.Algebra.Order.Monoid.Basic
 import Mathlib.Algebra.Order.Monoid.OrderDual
 import Mathlib.Algebra.Order.Monoid.TypeTags
-import Mathlib.Algebra.Order.GroupWithZero.Unbundled.Basic
 
 /-!
 # Linearly ordered commutative groups and monoids with a zero element adjoined
@@ -166,6 +167,40 @@ instance : LinearOrderedAddCommGroupWithTop (Additive αᵒᵈ) where
 instance : LinearOrderedAddCommGroupWithTop (Additive α)ᵒᵈ where
   neg_top := inv_zero (G₀ := α)
   add_neg_cancel := fun a ha ↦ mul_inv_cancel₀ (G₀ := α) (id ha : a.toMul ≠ 0)
+
+-- Counterexample with monoid for the backward direction:
+-- Take `Mᵐ⁰` where `M := ℚ ×ₗ ℕ`.
+lemma denselyOrdered_iff_denselyOrdered_units_and_nontrivial_units :
+    DenselyOrdered α ↔ Nontrivial αˣ ∧ DenselyOrdered αˣ := by
+  refine ⟨fun H ↦ ⟨?_, ?_⟩, fun ⟨H₁, H₂⟩ ↦ ?_⟩
+  · obtain ⟨x, hx, hx'⟩ := exists_between (zero_lt_one' α)
+    exact ⟨Units.mk0 x hx.ne', 1, by simpa [Units.ext_iff] using hx'.ne⟩
+  · refine ⟨fun x y h ↦ ?_⟩
+    obtain ⟨z, hz⟩ := exists_between (Units.val_lt_val.mpr h)
+    refine ⟨Units.mk0 z (ne_zero_of_lt hz.1), by simp [← Units.val_lt_val, hz]⟩
+  · refine ⟨fun x y h ↦ ?_⟩
+    lift y to αˣ using (ne_zero_of_lt h).isUnit
+    obtain rfl | hx := (zero_le' (a := x)).eq_or_lt
+    · obtain ⟨z, hz⟩ := exists_one_lt' (α := αˣ)
+      exact ⟨(y * z⁻¹ : αˣ), by simp, Units.val_lt_val.mpr <| by simp [hz]⟩
+    · lift x to αˣ using hx.ne'.isUnit
+      obtain ⟨z, hz, hz'⟩ := H₂.dense x y (Units.val_lt_val.mpr h)
+      exact ⟨z, by simp [hz, hz']⟩
+
+-- Counterexample with monoid: `{ x : ℝ | 0 ≤ x ≤ 1 }`
+instance [DenselyOrdered α] : Nontrivial αˣ :=
+  have := denselyOrdered_iff_denselyOrdered_units_and_nontrivial_units (α := α)
+  by tauto
+
+-- Counterexample with monoid:
+-- `{ x : ℝ | x = 0 ∨ ∃ (a : ℤ) (b c : ℕ), x = Real.exp (a + b * √2 - c * √3) }`
+instance [DenselyOrdered α] : DenselyOrdered αˣ :=
+  have := denselyOrdered_iff_denselyOrdered_units_and_nontrivial_units (α := α)
+  by tauto
+
+lemma denselyOrdered_units_iff [Nontrivial αˣ] : DenselyOrdered αˣ ↔ DenselyOrdered α :=
+  have := denselyOrdered_iff_denselyOrdered_units_and_nontrivial_units (α := α)
+  by tauto
 
 end LinearOrderedCommGroupWithZero
 

--- a/Mathlib/Algebra/Order/GroupWithZero/Lex.lean
+++ b/Mathlib/Algebra/Order/GroupWithZero/Lex.lean
@@ -36,7 +36,7 @@ lemma inl_mono [LinearOrderedCommGroupWithZero M₀] [GroupWithZero N₀] [Preor
   intro x y
   obtain rfl | ⟨x, rfl⟩ := GroupWithZero.eq_zero_or_unit x <;>
   obtain rfl | ⟨y, rfl⟩ := GroupWithZero.eq_zero_or_unit y <;>
-  · simp [WithZero.zero_le, WithZero.withZeroUnitsEquiv]
+  · simp [WithZero.withZeroUnitsEquiv]
 
 lemma inl_strictMono [LinearOrderedCommGroupWithZero M₀] [GroupWithZero N₀] [PartialOrder N₀]
     [DecidablePred fun x : M₀ ↦ x = 0] : StrictMono (inl M₀ N₀) :=
@@ -48,7 +48,7 @@ lemma inr_mono [GroupWithZero M₀] [Preorder M₀] [LinearOrderedCommGroupWithZ
   intro x y
   obtain rfl | ⟨x, rfl⟩ := GroupWithZero.eq_zero_or_unit x <;>
   obtain rfl | ⟨y, rfl⟩ := GroupWithZero.eq_zero_or_unit y <;>
-  · simp [WithZero.zero_le, WithZero.withZeroUnitsEquiv]
+  · simp [WithZero.withZeroUnitsEquiv]
 
 lemma inr_strictMono [GroupWithZero M₀] [PartialOrder M₀] [LinearOrderedCommGroupWithZero N₀]
     [DecidablePred fun x : N₀ ↦ x = 0] : StrictMono (inr M₀ N₀) :=

--- a/Mathlib/GroupTheory/ArchimedeanDensely.lean
+++ b/Mathlib/GroupTheory/ArchimedeanDensely.lean
@@ -298,7 +298,7 @@ section
 variable {G₀ : Type*} [LinearOrderedCommGroupWithZero G₀]
 
 -- Counterexample with monoid for the backward direction:
--- Take `Mᵐ⁰` where `M := ℕ + ℚ*ω` where `ω` is larger than any `n : ℕ`.
+-- Take `Mᵐ⁰` where `M := ℚ ×ₗ ℕ`.
 lemma denselyOrdered_iff_denselyOrdered_units_and_nontrivial_units :
     DenselyOrdered G₀ ↔ Nontrivial G₀ˣ ∧ DenselyOrdered G₀ˣ := by
   refine ⟨fun H ↦ ⟨?_, ?_⟩, fun ⟨H₁, H₂⟩ ↦ ?_⟩

--- a/Mathlib/GroupTheory/ArchimedeanDensely.lean
+++ b/Mathlib/GroupTheory/ArchimedeanDensely.lean
@@ -294,45 +294,6 @@ lemma LinearOrderedCommGroup.discrete_iff_not_denselyOrdered :
   · exact ⟨MulEquiv.toAdditive' f, by simp⟩
   · exact ⟨MulEquiv.toAdditive'.symm f, by simp⟩
 
-section
-variable {G₀ : Type*} [LinearOrderedCommGroupWithZero G₀]
-
--- Counterexample with monoid for the backward direction:
--- Take `Mᵐ⁰` where `M := ℚ ×ₗ ℕ`.
-lemma denselyOrdered_iff_denselyOrdered_units_and_nontrivial_units :
-    DenselyOrdered G₀ ↔ Nontrivial G₀ˣ ∧ DenselyOrdered G₀ˣ := by
-  refine ⟨fun H ↦ ⟨?_, ?_⟩, fun ⟨H₁, H₂⟩ ↦ ?_⟩
-  · obtain ⟨x, hx, hx'⟩ := exists_between (zero_lt_one' G₀)
-    exact ⟨Units.mk0 x hx.ne', 1, by simpa [Units.ext_iff] using hx'.ne⟩
-  · refine ⟨fun x y h ↦ ?_⟩
-    obtain ⟨z, hz⟩ := exists_between (Units.val_lt_val.mpr h)
-    refine ⟨Units.mk0 z (ne_zero_of_lt hz.1), by simp [← Units.val_lt_val, hz]⟩
-  · refine ⟨fun x y h ↦ ?_⟩
-    lift y to G₀ˣ using (ne_zero_of_lt h).isUnit
-    obtain rfl | hx := (zero_le' (a := x)).eq_or_lt
-    · obtain ⟨z, hz⟩ := exists_one_lt' (α := G₀ˣ)
-      exact ⟨(y * z⁻¹ : G₀ˣ), by simp, Units.val_lt_val.mpr <| by simp [hz]⟩
-    · lift x to G₀ˣ using hx.ne'.isUnit
-      obtain ⟨z, hz, hz'⟩ := H₂.dense x y (Units.val_lt_val.mpr h)
-      exact ⟨z, by simp [hz, hz']⟩
-
--- Counterexample with monoid: `{ x : ℝ | 0 ≤ x ≤ 1 }`
-instance [DenselyOrdered G₀] : Nontrivial G₀ˣ :=
-  have := denselyOrdered_iff_denselyOrdered_units_and_nontrivial_units (G₀ := G₀)
-  by tauto
-
--- Counterexample with monoid:
--- `{ x : ℝ | x = 0 ∨ ∃ (a : ℤ) (b c : ℕ), x = Real.exp (a + b * √2 - c * √3) }`
-instance [DenselyOrdered G₀] : DenselyOrdered G₀ˣ :=
-  have := denselyOrdered_iff_denselyOrdered_units_and_nontrivial_units (G₀ := G₀)
-  by tauto
-
-lemma denselyOrdered_units_iff [Nontrivial G₀ˣ] : DenselyOrdered G₀ˣ ↔ DenselyOrdered G₀ :=
-  have := denselyOrdered_iff_denselyOrdered_units_and_nontrivial_units (G₀ := G₀)
-  by tauto
-
-end
-
 /-- Any nontrivial (has other than 0 and 1) linearly ordered mul-archimedean group with zero is
 either isomorphic (and order-isomorphic) to `ℤᵐ⁰`, or is densely ordered. -/
 lemma LinearOrderedCommGroupWithZero.discrete_or_denselyOrdered (G : Type*)

--- a/Mathlib/GroupTheory/ArchimedeanDensely.lean
+++ b/Mathlib/GroupTheory/ArchimedeanDensely.lean
@@ -294,29 +294,40 @@ lemma LinearOrderedCommGroup.discrete_iff_not_denselyOrdered :
   · exact ⟨MulEquiv.toAdditive' f, by simp⟩
   · exact ⟨MulEquiv.toAdditive'.symm f, by simp⟩
 
-lemma denselyOrdered_units_iff {G₀ : Type*} [LinearOrderedCommGroupWithZero G₀] [Nontrivial G₀ˣ] :
-    DenselyOrdered G₀ˣ ↔ DenselyOrdered G₀ := by
-  constructor
-  · intro H
-    refine ⟨fun x y h ↦ ?_⟩
-    rcases (zero_le' (a := x)).eq_or_lt with rfl | hx
-    · lift y to G₀ˣ using h.ne'.isUnit
-      obtain ⟨z, hz⟩ := exists_ne (1 : G₀ˣ)
-      refine ⟨(y * |z|ₘ⁻¹ : G₀ˣ), ?_, ?_⟩
-      · simp [zero_lt_iff]
-      · rw [Units.val_lt_val]
-        simp [hz]
-    · obtain ⟨z, hz, hz'⟩ := H.dense (Units.mk0 x hx.ne') (Units.mk0 y (hx.trans h).ne')
-        (by simp [← Units.val_lt_val, h])
-      refine ⟨z, ?_, ?_⟩ <;>
-      simpa [← Units.val_lt_val]
-  · intro H
-    refine ⟨fun x y h ↦ ?_⟩
+section
+variable {G₀ : Type*} [LinearOrderedCommGroupWithZero G₀]
+
+lemma denselyOrdered_iff_denselyOrdered_units_and_nontrivial_units :
+    DenselyOrdered G₀ ↔ Nontrivial G₀ˣ ∧ DenselyOrdered G₀ˣ := by
+  refine ⟨fun H ↦ ⟨?_, ?_⟩, fun ⟨H₁, H₂⟩ ↦ ?_⟩
+  · obtain ⟨x, hx, hx'⟩ := exists_between (zero_lt_one' G₀)
+    exact ⟨Units.mk0 x hx.ne', 1, by simpa [Units.ext_iff] using hx'.ne⟩
+  · refine ⟨fun x y h ↦ ?_⟩
     obtain ⟨z, hz⟩ := exists_between (Units.val_lt_val.mpr h)
-    rcases (zero_le' (a := z)).eq_or_lt with rfl | hz'
-    · simp at hz
-    refine ⟨Units.mk0 z hz'.ne', ?_⟩
-    simp [← Units.val_lt_val, hz]
+    refine ⟨Units.mk0 z (ne_zero_of_lt hz.1), by simp [← Units.val_lt_val, hz]⟩
+  · refine ⟨fun x y h ↦ ?_⟩
+    lift y to G₀ˣ using (ne_zero_of_lt h).isUnit
+    obtain rfl | hx := (zero_le' (a := x)).eq_or_lt
+    · obtain ⟨z, hz⟩ := exists_one_lt' (α := G₀ˣ)
+      exact ⟨(y * z⁻¹ : G₀ˣ), by simp, Units.val_lt_val.mpr <| by simp [hz]⟩
+    · lift x to G₀ˣ using hx.ne'.isUnit
+      obtain ⟨z, hz, hz'⟩ := H₂.dense x y (Units.val_lt_val.mpr h)
+      exact ⟨z, by simp [hz, hz']⟩
+
+-- Counterexample with monoid: { x : ℝ | 0 ≤ x ≤ 1 }
+instance [DenselyOrdered G₀] : Nontrivial G₀ˣ :=
+  have := denselyOrdered_iff_denselyOrdered_units_and_nontrivial_units (G₀ := G₀)
+  by tauto
+
+instance [DenselyOrdered G₀] : DenselyOrdered G₀ˣ :=
+  have := denselyOrdered_iff_denselyOrdered_units_and_nontrivial_units (G₀ := G₀)
+  by tauto
+
+lemma denselyOrdered_units_iff [Nontrivial G₀ˣ] : DenselyOrdered G₀ˣ ↔ DenselyOrdered G₀ :=
+  have := denselyOrdered_iff_denselyOrdered_units_and_nontrivial_units (G₀ := G₀)
+  by tauto
+
+end
 
 /-- Any nontrivial (has other than 0 and 1) linearly ordered mul-archimedean group with zero is
 either isomorphic (and order-isomorphic) to `ℤᵐ⁰`, or is densely ordered. -/

--- a/Mathlib/GroupTheory/ArchimedeanDensely.lean
+++ b/Mathlib/GroupTheory/ArchimedeanDensely.lean
@@ -297,6 +297,8 @@ lemma LinearOrderedCommGroup.discrete_iff_not_denselyOrdered :
 section
 variable {G₀ : Type*} [LinearOrderedCommGroupWithZero G₀]
 
+-- Counterexample with monoid for the backward direction:
+-- Take `Mᵐ⁰` where `M := ℕ + ℚ*ω` where `ω` is larger than any `n : ℕ`.
 lemma denselyOrdered_iff_denselyOrdered_units_and_nontrivial_units :
     DenselyOrdered G₀ ↔ Nontrivial G₀ˣ ∧ DenselyOrdered G₀ˣ := by
   refine ⟨fun H ↦ ⟨?_, ?_⟩, fun ⟨H₁, H₂⟩ ↦ ?_⟩

--- a/Mathlib/GroupTheory/ArchimedeanDensely.lean
+++ b/Mathlib/GroupTheory/ArchimedeanDensely.lean
@@ -314,11 +314,13 @@ lemma denselyOrdered_iff_denselyOrdered_units_and_nontrivial_units :
       obtain ⟨z, hz, hz'⟩ := H₂.dense x y (Units.val_lt_val.mpr h)
       exact ⟨z, by simp [hz, hz']⟩
 
--- Counterexample with monoid: { x : ℝ | 0 ≤ x ≤ 1 }
+-- Counterexample with monoid: `{ x : ℝ | 0 ≤ x ≤ 1 }`
 instance [DenselyOrdered G₀] : Nontrivial G₀ˣ :=
   have := denselyOrdered_iff_denselyOrdered_units_and_nontrivial_units (G₀ := G₀)
   by tauto
 
+-- Counterexample with monoid:
+-- `{ x : ℝ | x = 0 ∨ ∃ (a : ℤ) (b c : ℕ), x = Real.exp (a + b * √2 - c * √3) }`
 instance [DenselyOrdered G₀] : DenselyOrdered G₀ˣ :=
   have := denselyOrdered_iff_denselyOrdered_units_and_nontrivial_units (G₀ := G₀)
   by tauto


### PR DESCRIPTION
Where `G₀` is a linearly ordered commutative group with zero, we once had `Nontrivial G₀ˣ → (DenselyOrdered G₀ˣ ↔ DenselyOrdered G₀)`, we now strengthen it to `DenselyOrdered G₀ ↔ (Nontrivial G₀ˣ ∧ DenselyOrdered G₀ˣ)`. We also provide the decreasing instances from this equivalence.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
