### PR TITLE
x chore(Algebra): make MulEquivClass an abbrev of MulHomClass

### DIFF
--- a/Mathlib/Algebra/Group/Equiv/Defs.lean
+++ b/Mathlib/Algebra/Group/Equiv/Defs.lean
@@ -100,16 +100,10 @@ variable [EquivLike F M N]
 
 -- See note [lower instance priority]
 @[to_additive]
-instance (priority := 100) instMulHomClass (F : Type*)
-    [Mul M] [Mul N] [EquivLike F M N] [h : MulEquivClass F M N] : MulHomClass F M N :=
-  { h with }
-
--- See note [lower instance priority]
-@[to_additive]
 instance (priority := 100) instMonoidHomClass
     [MulOneClass M] [MulOneClass N] [MulEquivClass F M N] :
     MonoidHomClass F M N :=
-  { MulEquivClass.instMulHomClass F with
+  { ‹MulHomClass F M N› with
     map_one := fun e =>
       calc
         e 1 = e 1 * 1 := (mul_one _).symm

--- a/Mathlib/Algebra/Group/Equiv/Defs.lean
+++ b/Mathlib/Algebra/Group/Equiv/Defs.lean
@@ -53,13 +53,6 @@ end EmbeddingLike
 /-- `AddEquiv α β` is the type of an equiv `α ≃ β` which preserves addition. -/
 structure AddEquiv (A B : Type*) [Add A] [Add B] extends A ≃ B, AddHom A B
 
-/-- `AddEquivClass F A B` states that `F` is a type of addition-preserving morphisms.
-You should extend this class when you extend `AddEquiv`. -/
-class AddEquivClass (F : Type*) (A B : outParam Type*) [Add A] [Add B] [EquivLike F A B] :
-    Prop where
-  /-- Preserves addition. -/
-  map_add : ∀ (f : F) (a b), f (a + b) = f a + f b
-
 /-- The `Equiv` underlying an `AddEquiv`. -/
 add_decl_doc AddEquiv.toEquiv
 
@@ -89,12 +82,10 @@ lemma MulEquiv.toEquiv_injective {α β : Type*} [Mul α] [Mul β] :
 
 /-- `MulEquivClass F A B` states that `F` is a type of multiplication-preserving morphisms.
 You should extend this class when you extend `MulEquiv`. -/
--- TODO: make this a synonym for MulHomClass?
-@[to_additive]
-class MulEquivClass (F : Type*) (A B : outParam Type*) [Mul A] [Mul B] [EquivLike F A B] :
-    Prop where
-  /-- Preserves multiplication. -/
-  map_mul : ∀ (f : F) (a b), f (a * b) = f a * f b
+@[to_additive
+/-- `AddEquivClass F A B` states that `F` is a type of addition-preserving morphisms.
+You should extend this class when you extend `AddEquiv`. -/]
+abbrev MulEquivClass := MulHomClass
 
 @[to_additive]
 alias MulEquivClass.map_eq_one_iff := EmbeddingLike.map_eq_one_iff

--- a/Mathlib/Algebra/Order/Hom/Monoid.lean
+++ b/Mathlib/Algebra/Order/Hom/Monoid.lean
@@ -116,7 +116,11 @@ structure OrderMonoidHom (α β : Type*) [Preorder α] [Preorder β] [MulOneClas
 /-- Infix notation for `OrderMonoidHom`. -/
 infixr:25 " →*o " => OrderMonoidHom
 
-variable [Preorder α] [Preorder β] [MulOneClass α] [MulOneClass β] [FunLike F α β]
+variable [Preorder α] [Preorder β] [MulOneClass α] [MulOneClass β]
+
+section FunLike
+
+variable [FunLike F α β]
 
 /-- Turn an element of a type `F` satisfying `OrderHomClass F α β` and `MonoidHomClass F α β`
 into an actual `OrderMonoidHom`. This is declared as the default coercion from `F` to `α →*o β`. -/
@@ -135,6 +139,8 @@ def OrderMonoidHomClass.toOrderMonoidHom [OrderHomClass F α β] [MonoidHomClass
 instance [OrderHomClass F α β] [MonoidHomClass F α β] : CoeTC F (α →*o β) :=
   ⟨OrderMonoidHomClass.toOrderMonoidHom⟩
 
+end FunLike
+
 /-- `α ≃*o β` is the type of isomorphisms `α ≃ β` that preserve the `OrderedCommMonoid` structure.
 
 `OrderMonoidIso` is also used for ordered group isomorphisms.
@@ -150,8 +156,6 @@ structure OrderMonoidIso (α β : Type*) [Preorder α] [Preorder β] [Mul α] [M
 
 /-- Infix notation for `OrderMonoidIso`. -/
 infixr:25 " ≃*o " => OrderMonoidIso
-
-variable [Preorder α] [Preorder β] [MulOneClass α] [MulOneClass β] [FunLike F α β]
 
 /-- Turn an element of a type `F` satisfying `OrderIsoClass F α β` and `MulEquivClass F α β`
 into an actual `OrderMonoidIso`. This is declared as the default coercion from `F` to `α ≃*o β`. -/


### PR DESCRIPTION
Supserseded by #28737

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
