### PR TITLE
[Merged by Bors] - chore(LinearAlgebra): remove unnecessary tactic invocations

### DIFF
--- a/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/AffineMap.lean
@@ -523,7 +523,6 @@ theorem snd_lineMap (p₀ p₁ : P1 × P2) (c : k) : (lineMap p₀ p₁ c).2 = l
 
 theorem lineMap_symm (p₀ p₁ : P1) :
     lineMap p₀ p₁ = (lineMap p₁ p₀).comp (lineMap (1 : k) (0 : k)) := by
-  rw [comp_lineMap]
   simp
 
 @[simp]

--- a/Mathlib/LinearAlgebra/Basis/SMul.lean
+++ b/Mathlib/LinearAlgebra/Basis/SMul.lean
@@ -113,8 +113,7 @@ theorem coord_unitsSMul (e : Basis ι R₂ M) (w : ι → R₂ˣ) (i : ι) :
     apply e.ext
     intro j
     trans ((unitsSMul e w).coord i) ((w j)⁻¹ • (unitsSMul e w) j)
-    · congr
-      simp [Basis.unitsSMul, ← mul_smul]
+    · simp [Basis.unitsSMul, ← mul_smul]
     simp only [Basis.coord_apply, LinearMap.smul_apply, Basis.repr_self, Units.smul_def,
       map_smul, Finsupp.single_apply]
     split_ifs with h <;> simp [h]

--- a/Mathlib/LinearAlgebra/CliffordAlgebra/Even.lean
+++ b/Mathlib/LinearAlgebra/CliffordAlgebra/Even.lean
@@ -176,8 +176,7 @@ private theorem fFold_fFold (m : M) (x : A × S f) : fFold f m (fFold f m x) = Q
     · rintro _ ⟨b, m₃, rfl⟩
       change f.bilin _ _ * (f.bilin _ _ * b) = Q m • (f.bilin _ _ * b)
       rw [← smul_mul_assoc, ← mul_assoc, f.contract_mid]
-    · suffices f.bilin m₁ m * 0 = Q m • (0 : A) by simp
-      simp
+    · simp
     · rintro x y _hx _hy ihx ihy
       rw [LinearMap.add_apply, LinearMap.add_apply, mul_add, smul_add, ihx, ihy]
     · rintro x hx _c ihx

--- a/Mathlib/LinearAlgebra/Dimension/Constructions.lean
+++ b/Mathlib/LinearAlgebra/Dimension/Constructions.lean
@@ -256,7 +256,6 @@ theorem finrank_finsupp_self {ι : Type v} [Fintype ι] : finrank R (ι →₀ R
 theorem finrank_directSum {ι : Type v} [Fintype ι] (M : ι → Type w) [∀ i : ι, AddCommMonoid (M i)]
     [∀ i : ι, Module R (M i)] [∀ i : ι, Module.Free R (M i)] [∀ i : ι, Module.Finite R (M i)] :
     finrank R (⨁ i, M i) = ∑ i, finrank R (M i) := by
-  letI := nontrivial_of_invariantBasisNumber R
   simp only [finrank, fun i => rank_eq_card_chooseBasisIndex R (M i), rank_directSum, ← mk_sigma,
     mk_toNat_eq_card, card_sigma]
 
@@ -301,7 +300,6 @@ theorem Module.finrank_pi_fintype
     {ι : Type v} [Fintype ι] {M : ι → Type w} [∀ i : ι, AddCommMonoid (M i)]
     [∀ i : ι, Module R (M i)] [∀ i : ι, Module.Free R (M i)] [∀ i : ι, Module.Finite R (M i)] :
     finrank R (∀ i, M i) = ∑ i, finrank R (M i) := by
-  letI := nontrivial_of_invariantBasisNumber R
   simp only [finrank, fun i => rank_eq_card_chooseBasisIndex R (M i), rank_pi, ← mk_sigma,
     mk_toNat_eq_card, Fintype.card_sigma]
 

--- a/Mathlib/LinearAlgebra/Finsupp/Supported.lean
+++ b/Mathlib/LinearAlgebra/Finsupp/Supported.lean
@@ -56,7 +56,7 @@ theorem mem_supported {s : Set α} (p : α →₀ M) : p ∈ supported M R s ↔
 
 theorem mem_supported' {s : Set α} (p : α →₀ M) :
     p ∈ supported M R s ↔ ∀ x ∉ s, p x = 0 := by
-  haveI := Classical.decPred fun x : α => x ∈ s; simp [mem_supported, Set.subset_def, not_imp_comm]
+  simp [mem_supported, Set.subset_def, not_imp_comm]
 
 theorem mem_supported_support (p : α →₀ M) : p ∈ Finsupp.supported M R (p.support : Set α) := by
   rw [Finsupp.mem_supported]

--- a/Mathlib/LinearAlgebra/GeneralLinearGroup.lean
+++ b/Mathlib/LinearAlgebra/GeneralLinearGroup.lean
@@ -37,8 +37,8 @@ variable {R M}
 def toLinearEquiv (f : GeneralLinearGroup R M) : M ≃ₗ[R] M :=
   { f.val with
     invFun := f.inv.toFun
-    left_inv := fun m ↦ show (f.inv * f.val) m = m by rw [f.inv_val]; simp
-    right_inv := fun m ↦ show (f.val * f.inv) m = m by rw [f.val_inv]; simp }
+    left_inv := fun m ↦ show (f.inv * f.val) m = m by simp
+    right_inv := fun m ↦ show (f.val * f.inv) m = m by simp }
 
 @[simp] lemma coe_toLinearEquiv (f : GeneralLinearGroup R M) :
     f.toLinearEquiv = (f : M → M) := rfl

--- a/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
+++ b/Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/Defs.lean
@@ -151,16 +151,13 @@ variable (f : R →+* S)
 
 @[simp]
 protected lemma map_one : map f (1 : GL n R) = 1 := by
-  ext
-  simp only [map_one, Units.val_one]
+  simp only [map_one]
 
 protected lemma map_mul (g h : GL n R) : map f (g * h) = map f g * map f h := by
-  ext
-  simp only [map_mul, Units.val_mul]
+  simp only [map_mul]
 
 protected lemma map_inv (g : GL n R) : map f g⁻¹ = (map f g)⁻¹ := by
-  ext
-  simp only [map_inv, coe_units_inv]
+  simp only [map_inv]
 
 protected lemma map_det (g : GL n R) : Matrix.GeneralLinearGroup.det (map f g) =
     Units.map f (Matrix.GeneralLinearGroup.det g) := by

--- a/Mathlib/LinearAlgebra/Multilinear/Basic.lean
+++ b/Mathlib/LinearAlgebra/Multilinear/Basic.lean
@@ -1196,11 +1196,9 @@ for `A^ι` with any finite type `ι`. -/
 protected def mkPiAlgebraFin : MultilinearMap R (fun _ : Fin n => A) A :=
   MultilinearMap.mk' (fun m ↦ (List.ofFn m).prod)
     (fun m i x y ↦ by
-      have : (List.finRange n).idxOf i < n := by simp
       simp [List.ofFn_eq_map, (List.nodup_finRange n).map_update, List.prod_set, add_mul,
         mul_add, add_mul])
     (fun m i c x ↦ by
-      have : (List.finRange n).idxOf i < n := by simp
       simp [List.ofFn_eq_map, (List.nodup_finRange n).map_update, List.prod_set])
 
 variable {R A n}
@@ -1250,8 +1248,7 @@ theorem mkPiRing_eq_iff [Fintype ι] {z₁ z₂ : M₂} :
   simp_rw [MultilinearMap.ext_iff, mkPiRing_apply]
   constructor <;> intro h
   · simpa using h fun _ => 1
-  · intro x
-    simp [h]
+  · simp [h]
 
 theorem mkPiRing_zero [Fintype ι] : MultilinearMap.mkPiRing R ι (0 : M₂) = 0 := by
   ext; rw [mkPiRing_apply, smul_zero, MultilinearMap.zero_apply]

--- a/Mathlib/LinearAlgebra/PerfectPairing/Basic.lean
+++ b/Mathlib/LinearAlgebra/PerfectPairing/Basic.lean
@@ -52,7 +52,7 @@ variable (p)
 /-- Turn a perfect pairing between `M` and `N` into an isomorphism between `M` and the dual of `N`.
 -/
 noncomputable def toPerfPair : M ≃ₗ[R] Dual R N :=
-  .ofBijective { toFun := _, map_add' x y := by ext; simp, map_smul' r x := by ext; simp } <|
+  .ofBijective { toFun := _, map_add' x y := by simp, map_smul' r x := by simp } <|
     IsPerfPair.bijective_left p
 
 @[simp] lemma toLinearMap_toPerfPair (x : M) : p.toPerfPair x = p x := rfl

--- a/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Basic.lean
@@ -1219,7 +1219,6 @@ open Matrix
 @[simp]
 theorem toMatrix'_comp (Q : QuadraticMap R (m → R) R) (f : (n → R) →ₗ[R] m → R) :
     (Q.comp f).toMatrix' = (LinearMap.toMatrix' f)ᵀ * Q.toMatrix' * (LinearMap.toMatrix' f) := by
-  ext
   simp only [QuadraticMap.associated_comp, LinearMap.toMatrix₂'_compl₁₂, toMatrix']
 
 section Discriminant

--- a/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Finite/CanonicalBilinear.lean
@@ -342,7 +342,6 @@ def posRootForm : P.RootPositiveForm S where
 
 lemma algebraMap_posRootForm_posForm (x y : span S (range P.root)) :
     (algebraMap S R) ((P.posRootForm S).posForm x y) = P.RootForm x y := by
-  rw [RootPositiveForm.algebraMap_posForm]
   simp [posRootForm]
 
 @[simp]

--- a/Mathlib/LinearAlgebra/RootSystem/Hom.lean
+++ b/Mathlib/LinearAlgebra/RootSystem/Hom.lean
@@ -635,7 +635,7 @@ lemma reflection_inv (P : RootPairing ι R M N) (i : ι) :
   refine Equiv.ext ?_ ?_ ?_
   · exact LinearMap.ext_iff.mpr (fun x => by simp [← weightEquiv_apply])
   · exact LinearMap.ext_iff.mpr (fun x => by simp [← coweightEquiv_apply])
-  · exact _root_.Equiv.ext (fun j => by simp only [← indexHom_apply, map_inv]; simp)
+  · exact _root_.Equiv.ext (fun j => by simp)
 
 instance : DistribMulAction P.Aut M where
   smul w x := weightHom P w x

--- a/Mathlib/LinearAlgebra/TensorProduct/Basis.lean
+++ b/Mathlib/LinearAlgebra/TensorProduct/Basis.lean
@@ -130,7 +130,7 @@ def TensorProduct.equivFinsuppOfBasisLeft : M ⊗[R] N ≃ₗ[R] ι →₀ N :=
 lemma TensorProduct.equivFinsuppOfBasisLeft_apply_tmul (m : M) (n : N) :
     (TensorProduct.equivFinsuppOfBasisLeft ℬ) (m ⊗ₜ n) =
     (ℬ.repr m).mapRange (· • n) (zero_smul _ _) := by
-  ext; simp [equivFinsuppOfBasisLeft]
+  simp [equivFinsuppOfBasisLeft]
 
 lemma TensorProduct.equivFinsuppOfBasisLeft_apply_tmul_apply
     (m : M) (n : N) (i : ι) :


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
