### PR TITLE
[Merged by Bors] - fix(Topology/Algebra): remove slow `Finite` instances

### DIFF
--- a/Mathlib/Topology/Algebra/Field.lean
+++ b/Mathlib/Topology/Algebra/Field.lean
@@ -32,7 +32,8 @@ theorem Filter.tendsto_cocompact_mul_right₀ [ContinuousMul K] {a : K} (ha : a 
     Filter.Tendsto (fun x : K => x * a) (Filter.cocompact K) (Filter.cocompact K) :=
   Filter.tendsto_cocompact_mul_right (mul_inv_cancel₀ ha)
 
-/-- Compact Hausdorff topological fields are finite. This is not an instance to avoid slowdowns. -/
+/-- Compact Hausdorff topological fields are finite. This is not an instance, as it would apply to
+every `Finite` goal, causing slowly failing typeclass search in some cases. -/
 theorem DivisionRing.finite_of_compactSpace_of_t2Space {K} [DivisionRing K] [TopologicalSpace K]
     [IsTopologicalRing K] [CompactSpace K] [T2Space K] : Finite K := by
   suffices DiscreteTopology K by

--- a/Mathlib/Topology/Algebra/Field.lean
+++ b/Mathlib/Topology/Algebra/Field.lean
@@ -32,8 +32,8 @@ theorem Filter.tendsto_cocompact_mul_right₀ [ContinuousMul K] {a : K} (ha : a 
     Filter.Tendsto (fun x : K => x * a) (Filter.cocompact K) (Filter.cocompact K) :=
   Filter.tendsto_cocompact_mul_right (mul_inv_cancel₀ ha)
 
-/-- Compact Hausdorff topological fields are finite. -/
-instance (priority := 100) {K} [DivisionRing K] [TopologicalSpace K]
+/-- Compact Hausdorff topological fields are finite. This is not an instance to avoid slowdowns. -/
+theorem DivisionRing.finite_of_compactSpace_of_t2Space {K} [DivisionRing K] [TopologicalSpace K]
     [IsTopologicalRing K] [CompactSpace K] [T2Space K] : Finite K := by
   suffices DiscreteTopology K by
     exact finite_of_compact_of_discrete

--- a/Mathlib/Topology/Algebra/Ring/Compact.lean
+++ b/Mathlib/Topology/Algebra/Ring/Compact.lean
@@ -43,8 +43,8 @@ variable [IsTopologicalRing R] [CompactSpace R] [T2Space R]
 
 namespace IsArtinianRing
 
-/-- Compact Hausdorff artinian (commutative) rings are finite. This is not an instance to avoid
-slowdowns. -/
+/-- Compact Hausdorff artinian (commutative) rings are finite. This is not an instance, as it would
+apply to every `Finite` goal, causing slowly failing typeclass search in some cases. -/
 theorem finite_of_compactSpace_of_t2Space [IsArtinianRing R] :
     Finite R := by
   obtain ⟨n, hn⟩ := IsArtinianRing.isNilpotent_jacobson_bot (R := R)

--- a/Mathlib/Topology/Algebra/Ring/Compact.lean
+++ b/Mathlib/Topology/Algebra/Ring/Compact.lean
@@ -36,14 +36,16 @@ See https://ncatlab.org/nlab/show/compact+Hausdorff+rings+are+profinite
 -/
 
 attribute [local instance] Ideal.Quotient.field Fintype.ofFinite finite_of_compact_of_discrete
+  DivisionRing.finite_of_compactSpace_of_t2Space
 
 variable {R : Type*} [CommRing R] [TopologicalSpace R]
 variable [IsTopologicalRing R] [CompactSpace R] [T2Space R]
 
 namespace IsArtinianRing
 
-/-- Compact Hausdorff artinian (commutative) rings are finite. -/
-instance (priority := low) finite_of_compactSpace_of_t2Space [IsArtinianRing R] :
+/-- Compact Hausdorff artinian (commutative) rings are finite. This is not an instance to avoid
+slowdowns. -/
+theorem finite_of_compactSpace_of_t2Space [IsArtinianRing R] :
     Finite R := by
   obtain ⟨n, hn⟩ := IsArtinianRing.isNilpotent_jacobson_bot (R := R)
   have H : (∏ p : PrimeSpectrum R, p.asIdeal) ^ n = ⊥ := by


### PR DESCRIPTION
These instances apply to every `Finite` goal, resulting in large slowdowns in some cases.


---
In this example, the synthesis time is reduced from 60s to 40ms:
``` lean
import Mathlib

set_option synthInstance.maxHeartbeats 0
set_option maxHeartbeats 0

variable [Field k] [TopologicalSpace k]
#time #synth AddCommMonoid k
```

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
