### PR TITLE
[Merged by Bors] - chore(Algebra): remove unnecessary tactic invocations

### DIFF
--- a/Mathlib/Algebra/Algebra/Unitization.lean
+++ b/Mathlib/Algebra/Algebra/Unitization.lean
@@ -732,7 +732,6 @@ def starLift : (A →⋆ₙₐ[R] C) ≃ (Unitization R A →⋆ₐ[R] C) :=
 { toFun := fun φ ↦
   { toAlgHom := Unitization.lift φ.toNonUnitalAlgHom
     map_star' := fun x => by
-      induction x
       simp [map_star] }
   invFun := fun φ ↦ φ.toNonUnitalStarAlgHom.comp (inrNonUnitalStarAlgHom R A),
   left_inv := fun φ => by ext; simp,

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Defs.lean
@@ -737,7 +737,6 @@ theorem disjoint_list_sum_left {a : Multiset α} {l : List (Multiset α)} :
   | nil =>
     simp only [zero_disjoint, List.not_mem_nil, IsEmpty.forall_iff, forall_const, List.sum_nil]
   | cons b bs ih =>
-    simp_rw [List.sum_cons, disjoint_add_left, List.mem_cons, forall_eq_or_imp]
     simp [ih]
 
 theorem disjoint_list_sum_right {a : Multiset α} {l : List (Multiset α)} :

--- a/Mathlib/Algebra/BigOperators/Group/Finset/Piecewise.lean
+++ b/Mathlib/Algebra/BigOperators/Group/Finset/Piecewise.lean
@@ -104,7 +104,7 @@ lemma prod_attach_eq_prod_dite [Fintype ι] (s : Finset ι) (f : s → M) [Decid
     ∏ i ∈ s.attach, f i = ∏ i, if h : i ∈ s then f ⟨i, h⟩ else 1 := by
   rw [Finset.prod_dite, Finset.univ_eq_attach, Finset.prod_const_one, mul_one]
   congr
-  · ext; simp
+  · simp
   · ext; simp
   · apply Function.hfunext <;> simp +contextual [Subtype.heq_iff_coe_eq]
 

--- a/Mathlib/Algebra/Category/AlgCat/Basic.lean
+++ b/Mathlib/Algebra/Category/AlgCat/Basic.lean
@@ -128,11 +128,9 @@ lemma ofHom_apply {R : Type u} [CommRing R] {X Y : Type v} [Ring X] [Algebra R X
     [Algebra R Y] (f : X →ₐ[R] Y) (x : X) : ofHom f x = f x := rfl
 
 lemma inv_hom_apply {A B : AlgCat.{v} R} (e : A ≅ B) (x : A) : e.inv (e.hom x) = x := by
-  rw [← comp_apply]
   simp
 
 lemma hom_inv_apply {A B : AlgCat.{v} R} (e : A ≅ B) (x : B) : e.hom (e.inv x) = x := by
-  rw [← comp_apply]
   simp
 
 instance : Inhabited (AlgCat R) :=

--- a/Mathlib/Algebra/Category/Grp/Limits.lean
+++ b/Mathlib/Algebra/Category/Grp/Limits.lean
@@ -479,7 +479,6 @@ theorem kernelIsoKer_hom_comp_subtype {G H : AddCommGrp.{u}} (f : G ⟶ H) :
 @[simp]
 theorem kernelIsoKer_inv_comp_ι {G H : AddCommGrp.{u}} (f : G ⟶ H) :
     (kernelIsoKer f).inv ≫ kernel.ι f = ofHom (AddSubgroup.subtype f.hom.ker) := by
-  ext
   simp [kernelIsoKer]
 
 /-- The categorical kernel inclusion for `f : G ⟶ H`, as an object over `G`,

--- a/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/ChangeOfRings.lean
@@ -317,7 +317,6 @@ def map' {M1 M2 : ModuleCat.{v} R} (l : M1 ⟶ M2) : obj' f M1 ⟶ obj' f M2 :=
   ofHom (@LinearMap.baseChange R S M1 M2 _ _ ((algebraMap S _).comp f).toAlgebra _ _ _ _ l.hom)
 
 theorem map'_id {M : ModuleCat.{v} R} : map' f (𝟙 M) = 𝟙 _ := by
-  ext x
   simp [map', obj']
 
 theorem map'_comp {M₁ M₂ M₃ : ModuleCat.{v} R} (l₁₂ : M₁ ⟶ M₂) (l₂₃ : M₂ ⟶ M₃) :
@@ -682,8 +681,7 @@ def HomEquiv.fromExtendScalars {X Y} (g : X ⟶ (restrictScalars f).obj Y) :
       rw [← add_smul]
     · ext x
       apply mul_smul (f r) s (g x)
-  · intros z₁ z₂
-    simp
+  · simp
   · intro s z
     change lift _ (s • z) = s • lift _ z
     induction z using TensorProduct.induction_on with

--- a/Mathlib/Algebra/Group/Basic.lean
+++ b/Mathlib/Algebra/Group/Basic.lean
@@ -174,12 +174,12 @@ lemma pow_eq_pow_mod (m : ℕ) (ha : a ^ n = 1) : a ^ m = a ^ (m % n) := by
 @[to_additive (attr := simp)]
 lemma mul_left_iterate (a : M) : ∀ n : ℕ, (a * ·)^[n] = (a ^ n * ·)
   | 0 => by ext; simp
-  | n + 1 => by ext; simp [pow_succ, mul_left_iterate]
+  | n + 1 => by simp [pow_succ, mul_left_iterate]
 
 @[to_additive (attr := simp)]
 lemma mul_right_iterate (a : M) : ∀ n : ℕ, (· * a)^[n] = (· * a ^ n)
   | 0 => by ext; simp
-  | n + 1 => by ext; simp [pow_succ', mul_right_iterate]
+  | n + 1 => by simp [pow_succ', mul_right_iterate]
 
 @[to_additive]
 lemma mul_left_iterate_apply_one (a : M) : (a * ·)^[n] 1 = a ^ n := by simp

--- a/Mathlib/Algebra/Group/Subgroup/Defs.lean
+++ b/Mathlib/Algebra/Group/Subgroup/Defs.lean
@@ -251,7 +251,6 @@ theorem inclusion_inclusion {L : S} (hHK : H ≤ K) (hKL : K ≤ L) (x : H) :
 
 @[to_additive (attr := simp)]
 theorem coe_inclusion {H K : S} {h : H ≤ K} (a : H) : (inclusion h a : G) = a := by
-  cases a
   simp only [inclusion, MonoidHom.mk'_apply]
 
 @[to_additive (attr := simp)]
@@ -567,7 +566,6 @@ def inclusion {H K : Subgroup G} (h : H ≤ K) : H →* K :=
 
 @[to_additive (attr := simp)]
 theorem coe_inclusion {H K : Subgroup G} {h : H ≤ K} (a : H) : (inclusion h a : G) = a := by
-  cases a
   simp only [inclusion, coe_mk, MonoidHom.mk'_apply]
 
 @[to_additive]

--- a/Mathlib/Algebra/Group/TransferInstance.lean
+++ b/Mathlib/Algebra/Group/TransferInstance.lean
@@ -96,7 +96,6 @@ def mulEquiv (e : α ≃ β) [Mul β] :
   exact
     { e with
       map_mul' := fun x y => by
-        apply e.symm.injective
         simp [mul_def] }
 
 @[to_additive (attr := simp)]

--- a/Mathlib/Algebra/Homology/HomotopyCategory/Shift.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/Shift.lean
@@ -198,7 +198,7 @@ def shiftEval (n i i' : ℤ) (hi : n + i = i') :
       HomologicalComplex.eval C (ComplexShape.up ℤ) i ≅
       HomologicalComplex.eval C (ComplexShape.up ℤ) i' :=
   NatIso.ofComponents (fun K => K.XIsoOfEq (by dsimp; rw [← hi, add_comm i]))
-    (by intros; simp)
+    (by simp)
 
 end CochainComplex
 

--- a/Mathlib/Algebra/Homology/ImageToKernel.lean
+++ b/Mathlib/Algebra/Homology/ImageToKernel.lean
@@ -76,7 +76,6 @@ theorem imageToKernel_zero_left [HasKernels V] [HasZeroObject V] {w} :
 theorem imageToKernel_zero_right [HasImages V] {w} :
     imageToKernel f (0 : B ⟶ C) w =
       (imageSubobject f).arrow ≫ inv (kernelSubobject (0 : B ⟶ C)).arrow := by
-  ext
   simp
 
 section

--- a/Mathlib/Algebra/Lie/Basic.lean
+++ b/Mathlib/Algebra/Lie/Basic.lean
@@ -438,7 +438,6 @@ theorem coe_mk (f : L₁ → L₂) (h₁ h₂ h₃) : ((⟨⟨⟨f, h₁⟩, h�
 def comp (f : L₂ →ₗ⁅R⁆ L₃) (g : L₁ →ₗ⁅R⁆ L₂) : L₁ →ₗ⁅R⁆ L₃ :=
   { LinearMap.comp f.toLinearMap g.toLinearMap with
     map_lie' := by
-      intros x y
       simp }
 
 theorem comp_apply (f : L₂ →ₗ⁅R⁆ L₃) (g : L₁ →ₗ⁅R⁆ L₂) (x : L₁) : f.comp g x = f (g x) :=
@@ -784,7 +783,6 @@ theorem coe_linear_mk (f : M →ₗ[R] N) (h) : ((⟨f, h⟩ : M →ₗ⁅R,L⁆
 def comp (f : N →ₗ⁅R,L⁆ P) (g : M →ₗ⁅R,L⁆ N) : M →ₗ⁅R,L⁆ P :=
   { LinearMap.comp f.toLinearMap g.toLinearMap with
     map_lie' := by
-      intros x m
       simp }
 
 theorem comp_apply (f : N →ₗ⁅R,L⁆ P) (g : M →ₗ⁅R,L⁆ N) (m : M) : f.comp g m = f (g m) :=

--- a/Mathlib/Algebra/Lie/UniversalEnveloping.lean
+++ b/Mathlib/Algebra/Lie/UniversalEnveloping.lean
@@ -139,7 +139,7 @@ theorem hom_ext {g₁ g₂ : UniversalEnvelopingAlgebra R L →ₐ[R] A}
       (g₁ : UniversalEnvelopingAlgebra R L →ₗ⁅R⁆ A).comp (ι R) =
         (g₂ : UniversalEnvelopingAlgebra R L →ₗ⁅R⁆ A).comp (ι R)) :
     g₁ = g₂ :=
-  have h' : (lift R).symm g₁ = (lift R).symm g₂ := by ext; simp [h]
+  have h' : (lift R).symm g₁ = (lift R).symm g₂ := by simp [h]
   (lift R).symm.injective h'
 
 end UniversalEnvelopingAlgebra

--- a/Mathlib/Algebra/Lie/Weights/Basic.lean
+++ b/Mathlib/Algebra/Lie/Weights/Basic.lean
@@ -297,7 +297,6 @@ end Weight
 @[simp]
 theorem zero_genWeightSpace_eq_top_of_nilpotent' [IsNilpotent L M] :
     genWeightSpace M (0 : L → R) = ⊤ := by
-  ext
   simp [genWeightSpace, genWeightSpaceOf]
 
 theorem coe_genWeightSpace_of_top (χ : L → R) :

--- a/Mathlib/Algebra/Module/Equiv/Basic.lean
+++ b/Mathlib/Algebra/Module/Equiv/Basic.lean
@@ -699,7 +699,6 @@ theorem conj_trans (e₁ : M₁' ≃ₛₗ[σ₁'₂'] M₂') (e₂ : M₂' ≃�
 
 @[simp]
 theorem conj_id (e : M₁' ≃ₛₗ[σ₁'₂'] M₂') : e.conj LinearMap.id = LinearMap.id := by
-  ext
   simp [conj_apply]
 
 @[simp]

--- a/Mathlib/Algebra/Module/LinearMap/Prod.lean
+++ b/Mathlib/Algebra/Module/LinearMap/Prod.lean
@@ -28,15 +28,12 @@ theorem isLinearMap_add [AddCommMonoid M] [Module R M] :
   · intro x y
     simp only [Prod.fst_add, Prod.snd_add]
     abel
-  · intro x y
-    simp [smul_add]
+  · simp [smul_add]
 
 theorem isLinearMap_sub [AddCommGroup M] [Module R M] :
     IsLinearMap R fun x : M × M => x.1 - x.2 := by
   apply IsLinearMap.mk
-  · intro x y
-    simp [add_comm, add_assoc, add_left_comm, sub_eq_add_neg]
-  · intro x y
-    simp [smul_sub]
+  · simp [add_comm, add_assoc, add_left_comm, sub_eq_add_neg]
+  · simp [smul_sub]
 
 end IsLinearMap

--- a/Mathlib/Algebra/Module/Projective.lean
+++ b/Mathlib/Algebra/Module/Projective.lean
@@ -173,7 +173,7 @@ theorem Projective.of_split [Module.Projective R M]
 
 theorem Projective.of_equiv [Module.Projective R M]
     (e : M ≃ₗ[R] P) : Module.Projective R P :=
-  Projective.of_split e.symm e.toLinearMap (by ext; simp)
+  Projective.of_split e.symm e.toLinearMap (by simp)
 
 /-- A quotient of a projective module is projective iff it is a direct summand. -/
 theorem Projective.iff_split_of_projective [Module.Projective R M] (s : M →ₗ[R] P)

--- a/Mathlib/Algebra/MvPolynomial/Equiv.lean
+++ b/Mathlib/Algebra/MvPolynomial/Equiv.lean
@@ -368,7 +368,7 @@ theorem optionEquivLeft_monomial (m : Option S₁ →₀ ℕ) (r : R) :
       map_mul, mul_assoc]
     apply congr_arg₂ _ rfl
     simp only [mul_comm, map_finsuppProd, map_pow]
-  · intros; simp
+  · simp
   · intros; rw [pow_add]
 
 /-- The coefficient of `n.some` in the `n none`-th coefficient of `optionEquivLeft R S₁ f`

--- a/Mathlib/Algebra/Order/Ring/Unbundled/Rat.lean
+++ b/Mathlib/Algebra/Order/Ring/Unbundled/Rat.lean
@@ -227,8 +227,7 @@ theorem div_lt_div_iff_mul_lt_mul {a b c d : ℤ} (b_pos : 0 < b) (d_pos : 0 < d
   simp only [lt_iff_le_not_ge]
   apply and_congr
   · simp [div_def', Rat.divInt_le_divInt b_pos d_pos]
-  · apply not_congr
-    simp [div_def', Rat.divInt_le_divInt d_pos b_pos]
+  · simp [div_def', Rat.divInt_le_divInt d_pos b_pos]
 
 theorem lt_one_iff_num_lt_denom {q : ℚ} : q < 1 ↔ q.num < q.den := by simp [Rat.lt_def]
 

--- a/Mathlib/Algebra/Polynomial/Basic.lean
+++ b/Mathlib/Algebra/Polynomial/Basic.lean
@@ -940,18 +940,15 @@ irreducible_def erase (n : ℕ) : R[X] → R[X]
 
 @[simp]
 theorem toFinsupp_erase (p : R[X]) (n : ℕ) : toFinsupp (p.erase n) = p.toFinsupp.erase n := by
-  rcases p with ⟨⟩
   simp only [erase_def]
 
 @[simp]
 theorem ofFinsupp_erase (p : R[ℕ]) (n : ℕ) :
     (⟨p.erase n⟩ : R[X]) = (⟨p⟩ : R[X]).erase n := by
-  rcases p with ⟨⟩
   simp only [erase_def]
 
 @[simp]
 theorem support_erase (p : R[X]) (n : ℕ) : support (p.erase n) = (support p).erase n := by
-  rcases p with ⟨⟩
   simp only [support, erase_def, Finsupp.support_erase]
 
 theorem monomial_add_erase (p : R[X]) (n : ℕ) : monomial n (coeff p n) + p.erase n = p :=

--- a/Mathlib/Algebra/Polynomial/Monic.lean
+++ b/Mathlib/Algebra/Polynomial/Monic.lean
@@ -351,8 +351,7 @@ lemma Monic.not_irreducible_iff_exists_add_mul_eq_coeff (hm : p.Monic) (hnd : p.
       · rw [p.as_sum_range_C_mul_X_pow, hnd, Finset.sum_range_succ, Finset.sum_range_succ,
           Finset.sum_range_one, ← hnd, hm.coeff_natDegree, hnd, hmul, hadd, C_mul, C_add, C_1]
         ring
-      · rw [mem_Ioc, natDegree_X_add_C _]
-        simp
+      · simp
   · rintro rfl
     simp [natDegree_one] at hnd
 

--- a/Mathlib/Algebra/Ring/CentroidHom.lean
+++ b/Mathlib/Algebra/Ring/CentroidHom.lean
@@ -220,10 +220,8 @@ instance : Add (CentroidHom α) :=
   ⟨fun f g ↦
     { (f + g : α →+ α) with
       map_mul_left' := fun a b ↦ by
-        change f (a * b) + g (a * b) = a * (f b + g b)
         simp [map_mul_left, mul_add]
       map_mul_right' := fun a b ↦ by
-        change f (a * b) + g (a * b) = (f a + g a) * b
         simp [map_mul_right, add_mul] }⟩
 
 instance : Mul (CentroidHom α) :=
@@ -538,20 +536,16 @@ instance : Neg (CentroidHom α) :=
   ⟨fun f ↦
     { (-f : α →+ α) with
       map_mul_left' := fun a b ↦ by
-        change -f (a * b) = a * (-f b)
         simp [map_mul_left]
       map_mul_right' := fun a b ↦ by
-        change -f (a * b) = (-f a) * b
         simp [map_mul_right] }⟩
 
 instance : Sub (CentroidHom α) :=
   ⟨fun f g ↦
     { (f - g : α →+ α) with
       map_mul_left' := fun a b ↦ by
-        change (⇑f - ⇑g) (a * b) = a * (⇑f - ⇑g) b
         simp [map_mul_left, mul_sub]
       map_mul_right' := fun a b ↦ by
-        change (⇑f - ⇑g) (a * b) = ((⇑f - ⇑g) a) * b
         simp [map_mul_right, sub_mul] }⟩
 
 instance : IntCast (CentroidHom α) where intCast z := z • (1 : CentroidHom α)

--- a/Mathlib/Algebra/Ring/CompTypeclasses.lean
+++ b/Mathlib/Algebra/Ring/CompTypeclasses.lean
@@ -130,12 +130,10 @@ namespace RingHomCompTriple
 
 instance ids : RingHomCompTriple (RingHom.id R₁) σ₁₂ σ₁₂ :=
   ⟨by
-    ext
     simp⟩
 
 instance right_ids : RingHomCompTriple σ₁₂ (RingHom.id R₂) σ₁₂ :=
   ⟨by
-    ext
     simp⟩
 
 end RingHomCompTriple

--- a/Mathlib/Algebra/Ring/Equiv.lean
+++ b/Mathlib/Algebra/Ring/Equiv.lean
@@ -799,12 +799,10 @@ theorem toRingHom_trans (e₁ : R ≃+* S) (e₂ : S ≃+* S') :
 
 theorem toRingHom_comp_symm_toRingHom (e : R ≃+* S) :
     e.toRingHom.comp e.symm.toRingHom = RingHom.id _ := by
-  ext
   simp
 
 theorem symm_toRingHom_comp_toRingHom (e : R ≃+* S) :
     e.symm.toRingHom.comp e.toRingHom = RingHom.id _ := by
-  ext
   simp
 
 /-- Construct an equivalence of rings from homomorphisms in both directions, which are inverses.

--- a/Mathlib/Algebra/Ring/TransferInstance.lean
+++ b/Mathlib/Algebra/Ring/TransferInstance.lean
@@ -31,10 +31,8 @@ def ringEquiv (e : α ≃ β) [Add β] [Mul β] : by
   exact
     { e with
       map_add' := fun x y => by
-        apply e.symm.injective
         simp [add_def]
       map_mul' := fun x y => by
-        apply e.symm.injective
         simp [mul_def] }
 
 @[simp]


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
