### PR TITLE
[Merged by Bors] - fix: update simp? says

### DIFF
--- a/Mathlib/CategoryTheory/GuitartExact/VerticalComposition.lean
+++ b/Mathlib/CategoryTheory/GuitartExact/VerticalComposition.lean
@@ -134,7 +134,7 @@ lemma vComp_iff_of_equivalences (eL : C₂ ≌ C₃) (eR : D₂ ≌ D₃)
           Functor.whiskerLeft_app, Functor.associator_inv_app, comp_id, id_comp, vComp_app,
           Functor.map_comp, Equivalence.inv_fun_map, CatCommSq.vInv_iso_hom_app, Iso.trans_hom,
           Functor.isoWhiskerLeft_hom, Iso.symm_hom, Functor.associator_hom_app,
-          Functor.rightUnitor_hom_app, Iso.hom_inv_id_app_assoc, w'', this, α, β]
+          Functor.rightUnitor_hom_app, Iso.hom_inv_id_app_assoc, w'', α, β]
       simp only [hw', ← eR.inverse.map_comp_assoc]
       rw [Equivalence.counitInv_app_functor, ← Functor.comp_map, ← NatTrans.naturality_assoc]
       simp [← H₂.map_comp]

--- a/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean
+++ b/Mathlib/CategoryTheory/Limits/FilteredColimitCommutesFiniteLimit.lean
@@ -81,7 +81,7 @@ theorem colimitLimitToLimitColimit_injective :
     -- and they are equations in a filtered colimit,
     -- so for each `j` we have some place `k j` to the right of both `kx` and `ky`
     simp? [colimit_eq_iff] at h says
-      simp only [Functor.comp_obj, colim_obj, ι_colimitLimitToLimitColimit_π_apply,
+      simp only [comp_obj, colim_obj, ι_colimitLimitToLimitColimit_π_apply,
         colimit_eq_iff, curry_obj_obj_obj, curry_obj_obj_map] at h
     let k j := (h j).choose
     let f : ∀ j, kx ⟶ k j := fun j => (h j).choose_spec.choose

--- a/Mathlib/CategoryTheory/Limits/Fubini.lean
+++ b/Mathlib/CategoryTheory/Limits/Fubini.lean
@@ -106,7 +106,7 @@ def coneOfConeUncurry {D : DiagramOfCones F} (Q : ∀ j, IsLimit (D.obj j))
                   have := @NatTrans.naturality _ _ _ _ _ _ c.π (j, k) (j, k') (𝟙 j, f)
                   dsimp at this
                   simp? at this says
-                    simp only [Category.id_comp, Functor.map_id, NatTrans.id_app] at this
+                    simp only [Category.id_comp, map_id, NatTrans.id_app] at this
                   exact this } }
       naturality := fun j j' f =>
         (Q j').hom_ext

--- a/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
@@ -28,7 +28,6 @@ braiding and associating isomorphisms, and the product comparison morphism.
 * [Stacks: coproducts of pairs](https://stacks.math.columbia.edu/tag/04AN)
 -/
 
-set_option says.verify true
 universe v v₁ u u₁ u₂
 
 open CategoryTheory

--- a/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/BinaryProducts.lean
@@ -28,7 +28,7 @@ braiding and associating isomorphisms, and the product comparison morphism.
 * [Stacks: coproducts of pairs](https://stacks.math.columbia.edu/tag/04AN)
 -/
 
-
+set_option says.verify true
 universe v v₁ u u₁ u₂
 
 open CategoryTheory
@@ -1395,13 +1395,12 @@ protected def IsLimit.assoc (P : IsLimit sXY) (Q : IsLimit sYZ) {s : BinaryFan s
       · exact w ⟨.left⟩
       · specialize w ⟨.right⟩
         simp? at w says
-          simp only [pair_obj_right, BinaryFan.π_app_right, BinaryFan.assoc_snd,
+          simp only [pair_obj_right, BinaryFan.assoc_snd,
             Functor.const_obj_obj, pair_obj_left] at w
-        rw [← w]
-        simp
+        simp [← w]
     · specialize w ⟨.right⟩
       simp? at w says
-        simp only [pair_obj_right, BinaryFan.π_app_right, BinaryFan.assoc_snd,
+        simp only [pair_obj_right, BinaryFan.assoc_snd,
           Functor.const_obj_obj, pair_obj_left] at w
       simp [← w]
 

--- a/Mathlib/Init.lean
+++ b/Mathlib/Init.lean
@@ -61,7 +61,6 @@ all these linters, or add the `weak.linter.mathlibStandardSet` option to their l
 register_linter_set linter.mathlibStandardSet :=
   linter.allScriptsDocumented
   linter.checkInitImports
-
   linter.hashCommand
   linter.oldObtain
   linter.style.cases


### PR DESCRIPTION
Follow-up to #28760. See [#mathlib reviewers > requests for speedy review/delegation @ 💬](https://leanprover.zulipchat.com/#narrow/channel/345428-mathlib-reviewers/topic/requests.20for.20speedy.20review.2Fdelegation/near/535615507)

---

I noticed these errors breaking the build in #28763: https://github.com/leanprover-community/mathlib4/actions/runs/17145929260/job/48642207419

See [#mathlib reviewers > requests for speedy review/delegation @ 💬](https://leanprover.zulipchat.com/#narrow/channel/345428-mathlib-reviewers/topic/requests.20for.20speedy.20review.2Fdelegation/near/535615507)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
