### PR TITLE
[Merged by Bors] - feat(*): add `Decidable` instances

### DIFF
--- a/Mathlib/Algebra/Prime/Defs.lean
+++ b/Mathlib/Algebra/Prime/Defs.lean
@@ -154,8 +154,4 @@ protected theorem Prime.irreducible (hp : Prime p) : Irreducible p :=
 theorem irreducible_iff_prime [DecompositionMonoid M] {a : M} : Irreducible a ↔ Prime a :=
   ⟨Irreducible.prime, Prime.irreducible⟩
 
-instance (priority := 100) [DecompositionMonoid M] [DecidablePred (Prime : M → Prop)] :
-    DecidablePred (Irreducible : M → Prop) := fun m ↦
-  decidable_of_iff (Prime m) irreducible_iff_prime.symm
-
 end CancelCommMonoidWithZero

--- a/Mathlib/Algebra/Prime/Defs.lean
+++ b/Mathlib/Algebra/Prime/Defs.lean
@@ -154,4 +154,8 @@ protected theorem Prime.irreducible (hp : Prime p) : Irreducible p :=
 theorem irreducible_iff_prime [DecompositionMonoid M] {a : M} : Irreducible a ↔ Prime a :=
   ⟨Irreducible.prime, Prime.irreducible⟩
 
+instance (priority := 100) [DecompositionMonoid M] [DecidablePred (Prime : M → Prop)] :
+    DecidablePred (Irreducible : M → Prop) := fun m ↦
+  decidable_of_iff (Prime m) irreducible_iff_prime.symm
+
 end CancelCommMonoidWithZero

--- a/Mathlib/Data/Nat/Prime/Defs.lean
+++ b/Mathlib/Data/Nat/Prime/Defs.lean
@@ -434,6 +434,9 @@ instance instDecidablePredPrime : DecidablePred (_root_.Prime : ℕ → Prop) :=
 theorem irreducible_iff_prime {p : ℕ} : Irreducible p ↔ _root_.Prime p :=
   prime_iff
 
+instance instDecidablePredIrreducible : DecidablePred (Irreducible : ℕ → Prop) :=
+  decidablePrime
+
 /-- The type of prime numbers -/
 def Primes :=
   { p : ℕ // p.Prime }

--- a/Mathlib/Data/Nat/Prime/Defs.lean
+++ b/Mathlib/Data/Nat/Prime/Defs.lean
@@ -428,6 +428,9 @@ theorem prime_iff {p : ℕ} : p.Prime ↔ _root_.Prime p :=
 
 alias ⟨Prime.prime, _root_.Prime.nat_prime⟩ := prime_iff
 
+instance instDecidablePredPrime : DecidablePred (_root_.Prime : ℕ → Prop) := fun n ↦
+  decidable_of_iff (Nat.Prime n) Nat.prime_iff
+
 theorem irreducible_iff_prime {p : ℕ} : Irreducible p ↔ _root_.Prime p :=
   prime_iff
 

--- a/Mathlib/Order/Bounds/Basic.lean
+++ b/Mathlib/Order/Bounds/Basic.lean
@@ -977,3 +977,8 @@ theorem isGreatest_compl [HeytingAlgebra α] (a : α) :
 theorem isLeast_hnot [CoheytingAlgebra α] (a : α) :
     IsLeast {w | Codisjoint a w} (￢a) := by
   simpa only [CoheytingAlgebra.top_sdiff, codisjoint_iff_le_sup] using isLeast_sdiff ⊤ a
+
+instance Nat.instDecidableIsLeast (p : ℕ → Prop) (n : ℕ) [∀ k, Decidable (p k)] :
+    Decidable (IsLeast { n : ℕ | p n } n) :=
+  decidable_of_iff (p n ∧ ∀ k < n, ¬p k) <| .and .rfl <| by
+    simp [mem_lowerBounds, @imp_not_comm _ (p _)]

--- a/Mathlib/Order/Bounds/Basic.lean
+++ b/Mathlib/Order/Bounds/Basic.lean
@@ -978,7 +978,7 @@ theorem isLeast_hnot [CoheytingAlgebra α] (a : α) :
     IsLeast {w | Codisjoint a w} (￢a) := by
   simpa only [CoheytingAlgebra.top_sdiff, codisjoint_iff_le_sup] using isLeast_sdiff ⊤ a
 
-instance Nat.instDecidableIsLeast (p : ℕ → Prop) (n : ℕ) [∀ k, Decidable (p k)] :
+instance Nat.instDecidableIsLeast (p : ℕ → Prop) (n : ℕ) [DecidablePred p] :
     Decidable (IsLeast { n : ℕ | p n } n) :=
   decidable_of_iff (p n ∧ ∀ k < n, ¬p k) <| .and .rfl <| by
     simp [mem_lowerBounds, @imp_not_comm _ (p _)]

--- a/Mathlib/RingTheory/Int/Basic.lean
+++ b/Mathlib/RingTheory/Int/Basic.lean
@@ -92,15 +92,17 @@ theorem prime_two_or_dvd_of_dvd_two_mul_pow_self_two {m : ℤ} {p : ℕ} (hp : N
     rw [sq, Int.natAbs_mul] at hpp
     exact or_self_iff.mp ((Nat.Prime.dvd_mul hp).mp hpp)
 
-theorem Int.exists_prime_and_dvd {n : ℤ} (hn : n.natAbs ≠ 1) : ∃ p, Prime p ∧ p ∣ n := by
+namespace Int
+
+theorem exists_prime_and_dvd {n : ℤ} (hn : n.natAbs ≠ 1) : ∃ p, Prime p ∧ p ∣ n := by
   obtain ⟨p, pp, pd⟩ := Nat.exists_prime_and_dvd hn
   exact ⟨p, Nat.prime_iff_prime_int.mp pp, Int.natCast_dvd.mpr pd⟩
 
-
-theorem Int.prime_iff_natAbs_prime {k : ℤ} : Prime k ↔ Nat.Prime k.natAbs :=
+theorem prime_iff_natAbs_prime {k : ℤ} : Prime k ↔ Nat.Prime k.natAbs :=
   (Int.associated_natAbs k).prime_iff.trans Nat.prime_iff_prime_int.symm
 
-namespace Int
+instance instDecidablePredPrime : DecidablePred (Prime : ℤ → Prop) := fun m ↦
+  decidable_of_iff (Nat.Prime m.natAbs) prime_iff_natAbs_prime.symm
 
 theorem span_natAbs (a : ℤ) : Ideal.span ({(a.natAbs : ℤ)} : Set ℤ) = Ideal.span {a} := by
   rw [Ideal.span_singleton_eq_span_singleton]

--- a/Mathlib/RingTheory/Int/Basic.lean
+++ b/Mathlib/RingTheory/Int/Basic.lean
@@ -104,6 +104,9 @@ theorem prime_iff_natAbs_prime {k : ℤ} : Prime k ↔ Nat.Prime k.natAbs :=
 instance instDecidablePredPrime : DecidablePred (Prime : ℤ → Prop) := fun m ↦
   decidable_of_iff (Nat.Prime m.natAbs) prime_iff_natAbs_prime.symm
 
+instance (priority := 100) : DecidablePred (Irreducible : ℤ → Prop) := fun m ↦
+  decidable_of_iff (Prime m) irreducible_iff_prime.symm
+
 theorem span_natAbs (a : ℤ) : Ideal.span ({(a.natAbs : ℤ)} : Set ℤ) = Ideal.span {a} := by
   rw [Ideal.span_singleton_eq_span_singleton]
   exact (associated_natAbs _).symm


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
