### PR TITLE
[Merged by Bors] - chore: fix spelling mistakes

### DIFF
--- a/Mathlib/Algebra/ArithmeticGeometric.lean
+++ b/Mathlib/Algebra/ArithmeticGeometric.lean
@@ -33,7 +33,7 @@ open Filter Topology
 
 variable {R : Type*} {a b u₀ : R}
 
-/-- Arithmetic-geometric sequence with starting value `u₀` and recurence relation
+/-- Arithmetic-geometric sequence with starting value `u₀` and recurrence relation
 `u (n + 1) = a * u n + b`. -/
 def arithGeom [Mul R] [Add R] (a b u₀ : R) : ℕ → R
 | 0 => u₀

--- a/Mathlib/Algebra/Group/Action/Equidecomp.lean
+++ b/Mathlib/Algebra/Group/Action/Equidecomp.lean
@@ -41,7 +41,7 @@ We take this as our definition as it is easier to work with. It is implemented a
 
 ## TODO
 
-* Prove that if two sets equidecompose into subsets of eachother, they are equidecomposable
+* Prove that if two sets equidecompose into subsets of each other, they are equidecomposable
   (Schroeder-Bernstein type theorem)
 * Define equidecomposability into subsets as a preorder on sets and
   prove that its induced equivalence relation is equidecomposability.

--- a/Mathlib/Algebra/Homology/DerivedCategory/FullyFaithful.lean
+++ b/Mathlib/Algebra/Homology/DerivedCategory/FullyFaithful.lean
@@ -22,7 +22,7 @@ namespace DerivedCategory
 variable (C : Type u) [Category.{v} C] [Abelian C] [HasDerivedCategory.{w} C]
 
 /-- The canonical isomorphism
-`DerivedCateogry.singleFunctor C n ⋙ DerivedCateogry.homologyFunctor C n ≅ 𝟭 C` -/
+`DerivedCategory.singleFunctor C n ⋙ DerivedCategory.homologyFunctor C n ≅ 𝟭 C` -/
 noncomputable def singleFunctorCompHomologyFunctorIso (n : ℤ) :
     singleFunctor C n ⋙ homologyFunctor C n ≅ 𝟭 C :=
   Functor.isoWhiskerRight ((SingleFunctors.evaluation _ _ n).mapIso

--- a/Mathlib/Algebra/Homology/HomotopyCategory/DegreewiseSplit.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/DegreewiseSplit.lean
@@ -20,7 +20,7 @@ assert_not_exists TwoSidedIdeal
 
 open CategoryTheory Category Limits Pretriangulated Preadditive
 
--- Explicit universe annotations were used in this file to improve perfomance #12737
+-- Explicit universe annotations were used in this file to improve performance #12737
 
 universe v
 

--- a/Mathlib/Algebra/Homology/HomotopyCategory/MappingCone.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/MappingCone.lean
@@ -22,7 +22,7 @@ assert_not_exists TwoSidedIdeal
 
 open CategoryTheory Limits
 
--- Explicit universe annotations were used in this file to improve perfomance #12737
+-- Explicit universe annotations were used in this file to improve performance #12737
 
 universe v v'
 

--- a/Mathlib/Algebra/Homology/HomotopyCategory/Triangulated.lean
+++ b/Mathlib/Algebra/Homology/HomotopyCategory/Triangulated.lean
@@ -18,7 +18,7 @@ assert_not_exists TwoSidedIdeal
 
 open CategoryTheory Category Limits Pretriangulated ComposableArrows
 
--- Explicit universe annotations were used in this file to improve perfomance #12737
+-- Explicit universe annotations were used in this file to improve performance #12737
 
 universe v
 

--- a/Mathlib/Algebra/Homology/Localization.lean
+++ b/Mathlib/Algebra/Homology/Localization.lean
@@ -193,7 +193,7 @@ variable [(HomotopyCategory.quotient C c).IsLocalization
 
 /-- The category `HomologicalComplexUpToQuasiIso C c` which was defined as a localization of
 `HomologicalComplex C c` with respect to quasi-isomorphisms also identify to a localization
-of the homotopy category with respect ot quasi-isomorphisms. -/
+of the homotopy category with respect to quasi-isomorphisms. -/
 instance : HomologicalComplexUpToQuasiIso.Qh.IsLocalization (HomotopyCategory.quasiIso C c) :=
   Functor.IsLocalization.of_comp (HomotopyCategory.quotient C c)
     Qh (HomologicalComplex.homotopyEquivalences C c)

--- a/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Basic.lean
+++ b/Mathlib/AlgebraicGeometry/ProjectiveSpectrum/Basic.lean
@@ -407,7 +407,7 @@ variable (f : A →+* Γ(X, ⊤)) (hf : (HomogeneousIdeal.irrelevant 𝒜).toIde
 /-- Given a graded ring `A` and a map `f : A →+* Γ(X, ⊤)` such that the image of the
 irrelevant ideal under `f` generates the whole ring, the set of `D(f(r))` for homogeneous `r`
 of positive degree forms an open cover on `X`. -/
-def openCoverOfMapIrreleventEqTop : X.OpenCover :=
+def openCoverOfMapIrrelevantEqTop : X.OpenCover :=
   X.openCoverOfISupEqTop (fun ir : Σ' i r, 0 < i ∧ r ∈ 𝒜 i ↦
     X.basicOpen (f ir.2.1)) (by
     classical
@@ -431,31 +431,34 @@ def openCoverOfMapIrreleventEqTop : X.OpenCover :=
     rw [← Scheme.zeroLocus_span, Set.range_comp', ← Ideal.map_span, H, hf]
     simp)
 
+@[deprecated (since := "2025-08-22")] noncomputable alias openCoverOfMapIrreleventEqTop :=
+  openCoverOfMapIrrelevantEqTop
+
 /-- Given a graded ring `A` and a map `f : A →+* Γ(X, ⊤)` such that the image of the
 irrelevant ideal under `f` generates the whole ring, we can construct a map `X ⟶ Proj 𝒜`. -/
 def fromOfGlobalSections : X ⟶ Proj 𝒜 := by
-  refine (openCoverOfMapIrreleventEqTop 𝒜 f hf).glueMorphisms
+  refine (openCoverOfMapIrrelevantEqTop 𝒜 f hf).glueMorphisms
     (fun ri ↦ toBasicOpenOfGlobalSections 𝒜 f rfl ri.2.2.1 ri.2.2.2 ≫ Scheme.Opens.ι _) ?_
   rintro x y
-  let e : pullback ((openCoverOfMapIrreleventEqTop 𝒜 f hf).map x)
-      ((openCoverOfMapIrreleventEqTop 𝒜 f hf).map y) ≅ (X.basicOpen (f (x.snd.fst * y.snd.fst))) :=
+  let e : pullback ((openCoverOfMapIrrelevantEqTop 𝒜 f hf).map x)
+      ((openCoverOfMapIrrelevantEqTop 𝒜 f hf).map y) ≅ (X.basicOpen (f (x.snd.fst * y.snd.fst))) :=
     (isPullback_opens_inf _ _).isoPullback.symm ≪≫ X.isoOfEq (by simp)
   rw [← cancel_epi e.inv]
   trans toBasicOpenOfGlobalSections 𝒜 f rfl (Nat.add_pos_left x.2.2.1 y.1)
     (SetLike.mul_mem_graded x.2.2.2 y.2.2.2) ≫ (Scheme.Opens.ι _)
-  · simpa [e, openCoverOfMapIrreleventEqTop, Scheme.isoOfEq_inv] using
+  · simpa [e, openCoverOfMapIrrelevantEqTop, Scheme.isoOfEq_inv] using
       homOfLE_toBasicOpenOfGlobalSections_ι _ _ rfl rfl y.2.2.2
-  · simpa [e, openCoverOfMapIrreleventEqTop, Scheme.isoOfEq_inv] using
+  · simpa [e, openCoverOfMapIrrelevantEqTop, Scheme.isoOfEq_inv] using
       (homOfLE_toBasicOpenOfGlobalSections_ι _ _ (mul_comm _ _) (add_comm _ _) x.2.2.2).symm
 
 lemma fromOfGlobalSections_preimage_basicOpen {r : A} {n : ℕ} (hn : 0 < n) (hr : r ∈ 𝒜 n) :
     fromOfGlobalSections 𝒜 f hf ⁻¹ᵁ basicOpen 𝒜 r = X.basicOpen (f r) := by
   apply le_antisymm
   · intro x hx
-    obtain ⟨i, x, rfl⟩ := (openCoverOfMapIrreleventEqTop 𝒜 f hf).exists_eq x
+    obtain ⟨i, x, rfl⟩ := (openCoverOfMapIrrelevantEqTop 𝒜 f hf).exists_eq x
     simp only [TopologicalSpace.Opens.map_coe, Set.mem_preimage, SetLike.mem_coe,
       ← Scheme.comp_base_apply, fromOfGlobalSections, Scheme.Cover.ι_glueMorphisms] at hx
-    simp only [openCoverOfMapIrreleventEqTop, Scheme.openCoverOfISupEqTop_obj,
+    simp only [openCoverOfMapIrrelevantEqTop, Scheme.openCoverOfISupEqTop_obj,
       toBasicOpenOfGlobalSections, Scheme.isoOfEq_inv, Category.assoc, basicOpenIsoSpec_inv_ι] at hx
     simp only [Scheme.comp_coeBase, Scheme.homOfLE_base, homOfLE_leOfHom, TopCat.hom_comp,
       ContinuousMap.comp_assoc, ContinuousMap.comp_apply, morphismRestrict_base,
@@ -474,9 +477,9 @@ lemma fromOfGlobalSections_preimage_basicOpen {r : A} {n : ℕ} (hn : 0 < n) (hr
       PrimeSpectrum.basicOpen_le_basicOpen_iff, IsLocalization.mk'_mem_iff]
     exact Ideal.pow_mem_of_mem _ (Ideal.le_radical (Ideal.mem_span_singleton_self _)) _ i.2.2.1
   · intro x hx
-    let I : (openCoverOfMapIrreleventEqTop 𝒜 f hf).J := ⟨n, r, hn, hr⟩
-    obtain ⟨x, rfl⟩ : x ∈ ((openCoverOfMapIrreleventEqTop 𝒜 f hf).map I).opensRange := by
-      simpa [openCoverOfMapIrreleventEqTop] using hx
+    let I : (openCoverOfMapIrrelevantEqTop 𝒜 f hf).J := ⟨n, r, hn, hr⟩
+    obtain ⟨x, rfl⟩ : x ∈ ((openCoverOfMapIrrelevantEqTop 𝒜 f hf).map I).opensRange := by
+      simpa [openCoverOfMapIrrelevantEqTop] using hx
     simp only [TopologicalSpace.Opens.map_coe, Set.mem_preimage, SetLike.mem_coe,
       ← Scheme.comp_base_apply, fromOfGlobalSections, Scheme.Cover.ι_glueMorphisms]
     simp
@@ -488,7 +491,7 @@ lemma fromOfGlobalSections_morphismRestrict {r : A} {n : ℕ} (hn : 0 < n) (hr :
   rw [← Iso.inv_comp_eq, ← cancel_mono (basicOpen 𝒜 r).ι]
   simp only [Scheme.isoOfEq_inv, Category.assoc, morphismRestrict_ι, Scheme.homOfLE_ι_assoc,
     fromOfGlobalSections]
-  exact (openCoverOfMapIrreleventEqTop 𝒜 f hf).ι_glueMorphisms _ _ ⟨_, _, hn, hr⟩
+  exact (openCoverOfMapIrrelevantEqTop 𝒜 f hf).ι_glueMorphisms _ _ ⟨_, _, hn, hr⟩
 
 lemma fromOfGlobalSections_resLE {r : A} {n : ℕ} (hn : 0 < n) (hr : r ∈ 𝒜 n) :
     (fromOfGlobalSections 𝒜 f hf).resLE _ _
@@ -503,11 +506,11 @@ lemma fromOfGlobalSections_toSpecZero
     (f : A →+* Γ(X, ⊤)) (hf : (HomogeneousIdeal.irrelevant 𝒜).toIdeal.map f = ⊤) :
     fromOfGlobalSections 𝒜 f hf ≫ toSpecZero 𝒜 =
       X.toSpecΓ ≫ Spec.map (CommRingCat.ofHom (f.comp (algebraMap _ _))) := by
-  refine (openCoverOfMapIrreleventEqTop 𝒜 f hf).hom_ext _ _ fun x ↦ ?_
+  refine (openCoverOfMapIrrelevantEqTop 𝒜 f hf).hom_ext _ _ fun x ↦ ?_
   simp only [fromOfGlobalSections, toBasicOpenOfGlobalSections, CommRingCat.ofHom_comp,
     Category.assoc, Scheme.Cover.ι_glueMorphisms_assoc, basicOpenIsoSpec_inv_ι_assoc,
     awayι_toSpecZero, Iso.inv_comp_eq]
-  simp only [openCoverOfMapIrreleventEqTop, Scheme.openCoverOfISupEqTop_obj,
+  simp only [openCoverOfMapIrrelevantEqTop, Scheme.openCoverOfISupEqTop_obj,
     Scheme.openCoverOfISupEqTop_map, Scheme.isoOfEq_hom_ι_assoc, ← morphismRestrict_ι_assoc]
   congr 1
   simp only [basicOpenIsoSpecAway, ← CommRingCat.ofHom_comp, ← Spec.map_comp, ← Iso.eq_inv_comp,

--- a/Mathlib/AlgebraicTopology/SimplexCategory/Augmented.lean
+++ b/Mathlib/AlgebraicTopology/SimplexCategory/Augmented.lean
@@ -65,10 +65,13 @@ def equivAugmentedCosimplicialObjectFunctorCompDropIso :
 /-- Through the equivalence `(AugmentedSimplexCategory ⥤ C) ≌ CosimplicialObject.Augmented C`,
 taking the point of the augmentation corresponds to evaluation at the initial object. -/
 @[simps!]
-def equivAugmentedCosimplicialObjecFunctorCompPointIso :
+def equivAugmentedCosimplicialObjectFunctorCompPointIso :
     equivAugmentedCosimplicialObject.functor ⋙ CosimplicialObject.Augmented.point ≅
     ((evaluation _ _).obj .star : (AugmentedSimplexCategory ⥤ C) ⥤ C) :=
   .refl _
+
+@[deprecated (since := "2025-08-22")] alias equivAugmentedCosimplicialObjecFunctorCompPointIso :=
+  equivAugmentedCosimplicialObjectFunctorCompPointIso
 
 /-- Through the equivalence `(AugmentedSimplexCategory ⥤ C) ≌ CosimplicialObject.Augmented C`,
 the arrow attached to the cosimplicial object is the one obtained by evaluation at the unique arrow

--- a/Mathlib/Analysis/Meromorphic/FactorizedRational.lean
+++ b/Mathlib/Analysis/Meromorphic/FactorizedRational.lean
@@ -198,7 +198,7 @@ Compute the trailing coefficient of the factorized rational function associated 
 -/
 
 /-
-Low-priotity TODO: Using that non-trivially normed fields contain infinitely many elements that are
+Low-priority TODO: Using that non-trivially normed fields contain infinitely many elements that are
 no roots of unity, it might be possible to drop assumption `h` here and in some of the theorems
 below.
 -/

--- a/Mathlib/CategoryTheory/Abelian/GrothendieckAxioms/Colim.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckAxioms/Colim.lean
@@ -92,7 +92,7 @@ variable [HasColimitsOfShape J C] [HasExactColimitsOfShape J C] [HasZeroMorphism
   (hf : ∀ j, c₁.ι.app j ≫ f = S.f.app j ≫ c₂.ι.app j)
   (hg : ∀ j, c₂.ι.app j ≫ g = S.g.app j ≫ c₃.ι.app j)
 
-/-- Given `S : ShortCompex (J ⥤ C)` and (colimit) cocones for `S.X₁`, `S.X₂`,
+/-- Given `S : ShortComplex (J ⥤ C)` and (colimit) cocones for `S.X₁`, `S.X₂`,
 `S.X₃` equipped with suitable data, this is the induced
 short complex `c₁.pt ⟶ c₂.pt ⟶ c₃.pt`. -/
 @[simps]

--- a/Mathlib/CategoryTheory/Monoidal/Action/Basic.lean
+++ b/Mathlib/CategoryTheory/Monoidal/Action/Basic.lean
@@ -187,7 +187,7 @@ open Category
 
 variable {C D} [MonoidalCategory C] [MonoidalLeftAction C D]
 
--- Simp normal forms are aligned with the ones in `MonoidalCateogry`.
+-- Simp normal forms are aligned with the ones in `MonoidalCategory`.
 
 @[simp]
 lemma id_actionHom (c : C) {d d' : D} (f : d ⟶ d') :
@@ -496,7 +496,7 @@ open Category
 
 variable {C D} [MonoidalCategory C] [MonoidalRightAction C D]
 
--- Simp normal forms are aligned with the ones in `MonoidalCateogry`.
+-- Simp normal forms are aligned with the ones in `MonoidalCategory`.
 
 @[simp]
 lemma actionHom_id {d d' : D} (f : d ⟶ d') (c : C) :

--- a/Mathlib/CategoryTheory/WithTerminal/Cone.lean
+++ b/Mathlib/CategoryTheory/WithTerminal/Cone.lean
@@ -12,7 +12,7 @@ import Mathlib.CategoryTheory.WithTerminal.Basic
 Given categories `C` and `J`, an object `X : C` and a functor `K : J ⥤ Over X`,
 it has an obvious lift `liftFromOver K : WithTerminal J ⥤ C`, namely, send the terminal
 object to `X`. These two functors have equivalent categories of cones (`coneEquiv`).
-As a corollary, the limit of `K` is the limit of `liftFromOver K`, and viceversa.
+As a corollary, the limit of `K` is the limit of `liftFromOver K`, and vice-versa.
 -/
 
 open CategoryTheory Limits

--- a/Mathlib/Computability/Primrec.lean
+++ b/Mathlib/Computability/Primrec.lean
@@ -1133,7 +1133,7 @@ variable [Primcodable α] [Primcodable β]
 
 protected theorem not (hf : PrimrecRel R) : PrimrecRel fun a b ↦ ¬ R a b := PrimrecPred.not hf
 
-/-- If `R a b` is decidable, then given `L : List α` and `b : β`, it is primitive recurisve
+/-- If `R a b` is decidable, then given `L : List α` and `b : β`, it is primitive recursive
 to filter `L` for elements `a` with `R a b` -/
 theorem listFilter (hf : PrimrecRel R) :
     Primrec₂ fun (L : List α) b ↦ L.filter (fun a ↦ R a b) := by

--- a/Mathlib/Data/Multiset/DershowitzManna.lean
+++ b/Mathlib/Data/Multiset/DershowitzManna.lean
@@ -18,7 +18,7 @@ the Dershowitz-Manna ordering defined over multisets is also well-founded.
 
 ## Main results
 
-- `Multiset.IsDershowitzMannaLT` : the standard definition fo the `Dershowitz-Manna ordering`.
+- `Multiset.IsDershowitzMannaLT` : the standard definition of the `Dershowitz-Manna ordering`.
 - `Multiset.wellFounded_isDershowitzMannaLT` : the main theorem about the
 `Dershowitz-Manna ordering` being well-founded.
 

--- a/Mathlib/LinearAlgebra/PiTensorProduct.lean
+++ b/Mathlib/LinearAlgebra/PiTensorProduct.lean
@@ -833,7 +833,7 @@ variable (N : ι ⊕ ι₂ → Type*) [∀ i, AddCommMonoid (N i)] [∀ i, Modul
 
 /-- Equivalence between a `TensorProduct` of `PiTensorProduct`s and a single
 `PiTensorProduct` indexed by a `Sum` type. If `N` is a constant family of
-modules, use the non-dependant version `PiTensorProduct.tmulEquiv` instead. -/
+modules, use the non-dependent version `PiTensorProduct.tmulEquiv` instead. -/
 def tmulEquivDep :
     (⨂[R] i₁, N (.inl i₁)) ⊗[R] (⨂[R] i₂, N (.inr i₂)) ≃ₗ[R] ⨂[R] i, N i :=
   LinearEquiv.ofLinear

--- a/Mathlib/LinearAlgebra/UnitaryGroup.lean
+++ b/Mathlib/LinearAlgebra/UnitaryGroup.lean
@@ -83,7 +83,7 @@ open scoped Kronecker in
 /-- The kronecker product of two unitary matrices is unitary.
 
 This is stated for `unitary` instead of `unitaryGroup` as it holds even for
-non-commutive coefficients. -/
+non-commutative coefficients. -/
 theorem kronecker_mem_unitary {R m : Type*} [Semiring R] [StarRing R] [Fintype m]
     [DecidableEq m] {U₁ : Matrix n n R} {U₂ : Matrix m m R}
     (hU₁ : U₁ ∈ unitary (Matrix n n R)) (hU₂ : U₂ ∈ unitary (Matrix m m R)) :

--- a/Mathlib/Order/KrullDimension.lean
+++ b/Mathlib/Order/KrullDimension.lean
@@ -753,7 +753,7 @@ lemma _root_.LTSeries.height_last_longestOf [FiniteDimensionalOrder α] :
 The Krull dimension is the supremum of the elements' heights.
 
 This version of the lemma assumes that `α` is nonempty. In this case, the coercion from `ℕ∞` to
-`WithBot ℕ∞` is on the outside fo the right-hand side, which is usually more convenient.
+`WithBot ℕ∞` is on the outside of the right-hand side, which is usually more convenient.
 
 If `α` were empty, then `krullDim α = ⊥`. See `krullDim_eq_iSup_height` for the more general
 version, with the coercion under the supremum.

--- a/Mathlib/RingTheory/DividedPowers/SubDPIdeal.lean
+++ b/Mathlib/RingTheory/DividedPowers/SubDPIdeal.lean
@@ -280,7 +280,7 @@ instance : LT (SubDPIdeal hI) := ⟨fun J J' ↦ J.carrier < J'.carrier⟩
 
 theorem lt_iff {J J' : SubDPIdeal hI} : J < J' ↔ J.carrier < J'.carrier := Iff.rfl
 
-/-- I is a sub-dp-ideal ot itself. -/
+/-- `I` is a sub-dp-ideal of itself. -/
 instance : Top (SubDPIdeal hI) :=
   ⟨{carrier    := I
     isSubideal := le_refl _
@@ -288,7 +288,7 @@ instance : Top (SubDPIdeal hI) :=
 
 instance inhabited : Inhabited hI.SubDPIdeal := ⟨⊤⟩
 
-/-- `(0)` is a sub-dp-ideal ot the dp-ideal `I`. -/
+/-- `(0)` is a sub-dp-ideal of the dp-ideal `I`. -/
 instance : Bot (SubDPIdeal hI) :=
   ⟨{carrier    := ⊥
     isSubideal := bot_le

--- a/Mathlib/Topology/Separation/Basic.lean
+++ b/Mathlib/Topology/Separation/Basic.lean
@@ -705,17 +705,20 @@ theorem continuousWithinAt_congr_set' [TopologicalSpace Y] [T1Space X]
   rw [← continuousWithinAt_insert_self (s := s), ← continuousWithinAt_insert_self (s := t)]
   exact continuousWithinAt_congr_set (eventuallyEq_insert h)
 
-theorem ContinousWithinAt.eq_const_of_mem_closure [TopologicalSpace Y] [T1Space Y]
+theorem ContinuousWithinAt.eq_const_of_mem_closure [TopologicalSpace Y] [T1Space Y]
     {f : X → Y} {s : Set X} {x : X} {c : Y} (h : ContinuousWithinAt f s x) (hx : x ∈ closure s)
     (ht : ∀ y ∈ s, f y = c) : f x = c := by
   rw [← Set.mem_singleton_iff, ← closure_singleton]
   exact h.mem_closure hx ht
 
+@[deprecated (since := "2025-08-22")] alias ContinousWithinAt.eq_const_of_mem_closure :=
+  ContinuousWithinAt.eq_const_of_mem_closure
+
 theorem ContinuousWithinAt.eqOn_const_closure [TopologicalSpace Y] [T1Space Y]
     {f : X → Y} {s : Set X} {c : Y} (h : ∀ x ∈ closure s, ContinuousWithinAt f s x)
     (ht : s.EqOn f (fun _ ↦ c)) : (closure s).EqOn f (fun _ ↦ c) := by
   intro x hx
-  apply ContinousWithinAt.eq_const_of_mem_closure (h x hx) hx ht
+  apply ContinuousWithinAt.eq_const_of_mem_closure (h x hx) hx ht
 
 /-- To prove a function to a `T1Space` is continuous at some point `x`, it suffices to prove that
 `f` admits *some* limit at `x`. -/


### PR DESCRIPTION
Typos were found with

```
pip install codespell --upgrade
codespell --summary --ignore-words-list accpt,calle,comon,disjointness,enew,hax,hge,homs,hsa,hsi,ihs,intensional,mor,ore,pres,toword --check-filenames
codespell --summary --ignore-words-list comon,disjointness,hax,hge,homs,hsa,hsi,ihs,intensional,mor,ore,pres --check-filenames --regex "\b[a-z']*"
codespell --summary --ignore-words-list calle,comon,homs,mor,ore --check-filenames --regex "[A-Z][a-z']*"
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
