### PR TITLE
[Merged by Bors] - refactor(Tactic/NormNum): change `evalInv.core` to be easier to use

### DIFF
--- a/Mathlib/Tactic/NormNum/Inv.lean
+++ b/Mathlib/Tactic/NormNum/Inv.lean
@@ -154,10 +154,10 @@ theorem isRat_inv_neg {α} [DivisionRing α] [CharZero α] {a : α} {n d : ℕ} 
 open Lean
 
 attribute [local instance] monadLiftOptionMetaM in
-/-- Main part of `evalInv`. -/
-def evalInv.core {u : Level} {α : Q(Type u)} (e a : Q(«$α»)) (ra : Result a)
-    (dsα : Q(DivisionSemiring «$α»)) (i : Option Q(CharZero «$α»)) : MetaM (Result e) := do
-  haveI' : $e =Q $a⁻¹ := ⟨⟩
+/-- The result of inverting a norm_num results. -/
+def Result.inv {u : Level} {α : Q(Type u)} {a : Q(«$α»)} (ra : Result a)
+    (dsα : Q(DivisionSemiring «$α»)) : MetaM (Result q($a⁻¹)) := do
+  let i ← inferCharZeroOfDivisionSemiring? dsα
   if let .some ⟨qa, na, da, pa⟩ := ra.toNNRat' dsα then
     let qb := qa⁻¹
     if qa > 0 then
@@ -201,9 +201,8 @@ such that `norm_num` successfully recognises `a`. -/
   let .app f (a : Q($α)) ← whnfR e | failure
   let ra ← derive a
   let dsα ← inferDivisionSemiring α
-  let i ← inferCharZeroOfDivisionSemiring? dsα
   guard <| ← withNewMCtxDepth <| isDefEq f q(Inv.inv (α := $α))
   assumeInstancesCommute
-  evalInv.core e a ra dsα i
+  ra.inv dsα
 
 end Mathlib.Meta.NormNum

--- a/Mathlib/Tactic/NormNum/Inv.lean
+++ b/Mathlib/Tactic/NormNum/Inv.lean
@@ -154,7 +154,7 @@ theorem isRat_inv_neg {α} [DivisionRing α] [CharZero α] {a : α} {n d : ℕ} 
 open Lean
 
 attribute [local instance] monadLiftOptionMetaM in
-/-- The result of inverting a norm_num results. -/
+/-- The result of inverting a norm_num result. -/
 def Result.inv {u : Level} {α : Q(Type u)} {a : Q($α)} (ra : Result a)
     (dsα : Q(DivisionSemiring $α)) (czα? : Option Q(CharZero $α)) :
     MetaM (Result q($a⁻¹)) := do

--- a/Mathlib/Tactic/NormNum/Inv.lean
+++ b/Mathlib/Tactic/NormNum/Inv.lean
@@ -156,8 +156,14 @@ open Lean
 attribute [local instance] monadLiftOptionMetaM in
 /-- The result of inverting a norm_num results. -/
 def Result.inv {u : Level} {α : Q(Type u)} {a : Q(«$α»)} (ra : Result a)
-    (dsα : Q(DivisionSemiring «$α»)) : MetaM (Result q($a⁻¹)) := do
-  let i ← inferCharZeroOfDivisionSemiring? dsα
+    (dsα : Q(DivisionSemiring «$α»)) (czα : Option Q(CharZero «$α») := none) :
+    MetaM (Result q($a⁻¹)) := do
+  -- allow the caller to pass the CharZero instance as an optimization
+  let i ←
+    if let some czα := czα then
+      pure (some czα)
+    else
+      (← inferCharZeroOfDivisionSemiring? dsα)
   if let .some ⟨qa, na, da, pa⟩ := ra.toNNRat' dsα then
     let qb := qa⁻¹
     if qa > 0 then

--- a/Mathlib/Tactic/NormNum/Inv.lean
+++ b/Mathlib/Tactic/NormNum/Inv.lean
@@ -155,15 +155,15 @@ open Lean
 
 attribute [local instance] monadLiftOptionMetaM in
 /-- The result of inverting a norm_num results. -/
-def Result.inv {u : Level} {α : Q(Type u)} {a : Q(«$α»)} (ra : Result a)
-    (dsα : Q(DivisionSemiring «$α»)) (czα : Option Q(CharZero «$α») := none) :
+def Result.inv {u : Level} {α : Q(Type u)} {a : Q($α)} (ra : Result a)
+    (dsα : Q(DivisionSemiring $α)) (czα : Option Q(CharZero $α) := none) :
     MetaM (Result q($a⁻¹)) := do
   -- allow the caller to pass the CharZero instance as an optimization
   let i ←
     if let some czα := czα then
       pure (some czα)
     else
-      (← inferCharZeroOfDivisionSemiring? dsα)
+      inferCharZeroOfDivisionSemiring? dsα
   if let .some ⟨qa, na, da, pa⟩ := ra.toNNRat' dsα then
     let qb := qa⁻¹
     if qa > 0 then
@@ -208,7 +208,8 @@ such that `norm_num` successfully recognises `a`. -/
   let ra ← derive a
   let dsα ← inferDivisionSemiring α
   guard <| ← withNewMCtxDepth <| isDefEq f q(Inv.inv (α := $α))
+  haveI' : $e =Q $a⁻¹ := ⟨⟩
   assumeInstancesCommute
-  ra.inv dsα
+  ra.inv q($dsα)
 
 end Mathlib.Meta.NormNum

--- a/Mathlib/Tactic/Ring/Basic.lean
+++ b/Mathlib/Tactic/Ring/Basic.lean
@@ -1007,8 +1007,7 @@ def ExProd.evalInv {a : Q($α)} (czα : Option Q(CharZero $α)) (va : ExProd sα
   match va with
   | .const c hc =>
     let ra := Result.ofRawRat c a hc
-    match ← (Lean.observing? <|
-      NormNum.evalInv.core q($a⁻¹) a ra dsα czα :) with
+    match ← (Lean.observing? <| ra.inv dsα czα :) with
     | some rc =>
       let ⟨zc, hc⟩ := rc.toRatNZ.get!
       let ⟨c, pc⟩ := rc.toRawEq


### PR DESCRIPTION
Follows on from #28621 and #28762.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
