### PR TITLE
[Merged by Bors] - feat(Combinatorics/SimpleGraph): relate `⊤ ⊑ ·` to the existence of a clique

### DIFF
--- a/Mathlib/Combinatorics/SimpleGraph/Clique.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Clique.lean
@@ -185,12 +185,12 @@ lemma isClique_sup_edge_of_ne_iff {v w : α} {s : Set α} (h : v ≠ w) :
     fun h' ↦ isClique_sup_edge_of_ne_sdiff h h'.1 h'.2⟩
 
 /-- The vertices in a copy of `⊤` are a clique. -/
-theorem isClique_image_copy_top (f : Copy (⊤ : SimpleGraph β) G) :
-    G.IsClique (f '' Set.univ) := by
-  intro _ ⟨_, _, h⟩ _ ⟨_, _, h'⟩ heq
-  rw [← h, show f _ = f.topEmbedding _ by rfl, ← h', show f _ = f.topEmbedding _ by rfl] at heq ⊢
+theorem isClique_range_copy_top (f : Copy (⊤ : SimpleGraph β) G) :
+    G.IsClique (Set.range f) := by
+  intro _ ⟨_, h⟩ _ ⟨_, h'⟩ nh
+  rw [← h, show f _ = f.topEmbedding _ by rfl, ← h', show f _ = f.topEmbedding _ by rfl] at nh ⊢
   rwa [← f.topEmbedding.coe_toEmbedding, (f.topEmbedding.apply_eq_iff_eq _ _).ne,
-    ← top_adj, ← f.topEmbedding.map_adj_iff] at heq
+    ← top_adj, ← f.topEmbedding.map_adj_iff] at nh
 
 end Clique
 
@@ -317,8 +317,8 @@ lemma IsNClique.erase_of_sup_edge_of_mem [DecidableEq α] {v w : α} {s : Finset
 /-- The vertices in a copy of `⊤ : SimpleGraph β` are a `card β`-clique. -/
 theorem isNClique_map_copy_top [Fintype β] (f : Copy (⊤ : SimpleGraph β) G) :
     G.IsNClique (card β) (univ.map f.toEmbedding) := by
-  rw [isNClique_iff, card_map, card_univ, coe_map, coe_univ]
-  exact ⟨isClique_image_copy_top f, rfl⟩
+  rw [isNClique_iff, card_map, card_univ, coe_map, coe_univ, Set.image_univ]
+  exact ⟨isClique_range_copy_top f, rfl⟩
 
 end NClique
 

--- a/Mathlib/Combinatorics/SimpleGraph/Clique.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Clique.lean
@@ -315,7 +315,7 @@ lemma IsNClique.erase_of_sup_edge_of_mem [DecidableEq α] {v w : α} {s : Finset
   card_eq  := by rw [card_erase_of_mem hx, hc.2]
 
 /-- The vertices in a copy of `⊤ : SimpleGraph β` are a `card β`-clique. -/
-theorem isNClique_map_copy_top [DecidableEq α] [Fintype β] (f : Copy (⊤ : SimpleGraph β) G) :
+theorem isNClique_map_copy_top [Fintype β] (f : Copy (⊤ : SimpleGraph β) G) :
     G.IsNClique (card β) (univ.map f.toEmbedding) := by
   rw [isNClique_iff, card_map, card_univ, coe_map, coe_univ]
   exact ⟨isClique_image_copy_top f, rfl⟩

--- a/Mathlib/Combinatorics/SimpleGraph/Clique.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Clique.lean
@@ -3,8 +3,9 @@ Copyright (c) 2022 Yaël Dillies, Bhavik Mehta. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Bhavik Mehta
 -/
-import Mathlib.Combinatorics.SimpleGraph.Paths
+import Mathlib.Combinatorics.SimpleGraph.Copy
 import Mathlib.Combinatorics.SimpleGraph.Operations
+import Mathlib.Combinatorics.SimpleGraph.Paths
 import Mathlib.Data.Finset.Pairwise
 import Mathlib.Data.Fintype.Pigeonhole
 import Mathlib.Data.Fintype.Powerset

--- a/Mathlib/Combinatorics/SimpleGraph/Clique.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Clique.lean
@@ -184,6 +184,14 @@ lemma isClique_sup_edge_of_ne_iff {v w : α} {s : Set α} (h : v ≠ w) :
   ⟨fun h' ↦ ⟨h'.sdiff_of_sup_edge, (edge_comm .. ▸ h').sdiff_of_sup_edge⟩,
     fun h' ↦ isClique_sup_edge_of_ne_sdiff h h'.1 h'.2⟩
 
+/-- The vertices in a copy of `⊤` are a clique. -/
+theorem isClique_image_copy_top (f : Copy (⊤ : SimpleGraph β) G) :
+    G.IsClique (f '' Set.univ) := by
+  intro _ ⟨_, _, h⟩ _ ⟨_, _, h'⟩ heq
+  rw [← h, show f _ = f.topEmbedding _ by rfl, ← h', show f _ = f.topEmbedding _ by rfl] at heq ⊢
+  rwa [← f.topEmbedding.coe_toEmbedding, (f.topEmbedding.apply_eq_iff_eq _ _).ne,
+    ← top_adj, ← f.topEmbedding.map_adj_iff] at heq
+
 end Clique
 
 /-! ### `n`-cliques -/
@@ -306,6 +314,12 @@ lemma IsNClique.erase_of_sup_edge_of_mem [DecidableEq α] {v w : α} {s : Finset
   isClique := coe_erase v _ ▸ hc.1.sdiff_of_sup_edge
   card_eq  := by rw [card_erase_of_mem hx, hc.2]
 
+/-- The vertices in a copy of `⊤ : SimpleGraph β` are a `card β`-clique. -/
+theorem isNClique_map_copy_top [DecidableEq α] [Fintype β] (f : Copy (⊤ : SimpleGraph β) G) :
+    G.IsNClique (card β) (univ.map f.toEmbedding) := by
+  rw [isNClique_iff, card_map, card_univ, coe_map, coe_univ]
+  exact ⟨isClique_image_copy_top f, rfl⟩
+
 end NClique
 
 /-! ### Graphs without cliques -/
@@ -353,6 +367,13 @@ theorem not_cliqueFree_iff (n : ℕ) : ¬G.CliqueFree n ↔ Nonempty (completeGr
 
 theorem cliqueFree_iff {n : ℕ} : G.CliqueFree n ↔ IsEmpty (completeGraph (Fin n) ↪g G) := by
   rw [← not_iff_not, not_cliqueFree_iff, not_isEmpty_iff]
+
+/-- A simple graph has no `card β`-cliques iff it does not contain `⊤ : SimpleGraph β`. -/
+theorem cliqueFree_iff_top_free {β : Type*} [Fintype β] :
+    G.CliqueFree (card β) ↔ (⊤ : SimpleGraph β).Free G := by
+  rw [← not_iff_not, not_free, cliqueFree_iff, not_isEmpty_iff,
+    isContained_congr (Iso.completeGraph (Fintype.equivFin β)) Iso.refl]
+  exact ⟨fun ⟨f⟩ ↦ ⟨f.toCopy⟩, fun ⟨f⟩ ↦ ⟨f.topEmbedding⟩⟩
 
 theorem not_cliqueFree_card_of_top_embedding [Fintype α] (f : (⊤ : SimpleGraph α) ↪g G) :
     ¬G.CliqueFree (card α) := by

--- a/Mathlib/Combinatorics/SimpleGraph/Copy.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Copy.lean
@@ -197,6 +197,7 @@ instance [Fintype {f : G →g H // Injective f}] : Fintype (G.Copy H) :=
   }
 
 /-- A copy of `⊤` gives rise to an embedding of `⊤`. -/
+@[simps!]
 def topEmbedding (f : Copy (⊤ : SimpleGraph α) G) : (⊤ : SimpleGraph α) ↪g G :=
   { f.toEmbedding with
     map_rel_iff' := fun {v w} ↦ ⟨fun h ↦ by simpa using h.ne, f.toHom.map_adj⟩}

--- a/Mathlib/Combinatorics/SimpleGraph/Copy.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Copy.lean
@@ -196,6 +196,11 @@ instance [Fintype {f : G →g H // Injective f}] : Fintype (G.Copy H) :=
     invFun f := ⟨f.1, f.2⟩
   }
 
+/-- A copy of `⊤` gives rise to an embedding of `⊤`. -/
+def topEmbedding (f : Copy (⊤ : SimpleGraph α) G) : (⊤ : SimpleGraph α) ↪g G :=
+  { f.toEmbedding with
+    map_rel_iff' := fun {v w} ↦ ⟨fun h ↦ by simpa using h.ne, f.toHom.map_adj⟩}
+
 end Copy
 
 /-- A `Subgraph G` gives rise to a copy from the coercion to `G`. -/
@@ -374,9 +379,8 @@ alias ⟨IsIndContained.exists_iso_subgraph, IsIndContained.of_exists_iso_subgra
   isIndContained_iff_exists_iso_subgraph
 
 @[simp] lemma top_isIndContained_iff_top_isContained :
-    (⊤ : SimpleGraph V) ⊴ H ↔ (⊤ : SimpleGraph V) ⊑ H where
-  mp h := h.isContained
-  mpr := fun ⟨f⟩ ↦ ⟨f.toEmbedding, fun {v w} ↦ ⟨fun h ↦ by simpa using h.ne, f.toHom.map_adj⟩⟩
+    (⊤ : SimpleGraph V) ⊴ H ↔ (⊤ : SimpleGraph V) ⊑ H :=
+  ⟨IsIndContained.isContained, fun ⟨f⟩ ↦ ⟨f.topEmbedding⟩⟩
 
 @[simp] lemma compl_isIndContained_compl : Gᶜ ⊴ Hᶜ ↔ G ⊴ H :=
   Embedding.complEquiv.symm.nonempty_congr

--- a/Mathlib/Combinatorics/SimpleGraph/Copy.lean
+++ b/Mathlib/Combinatorics/SimpleGraph/Copy.lean
@@ -52,7 +52,7 @@ The following notation is declared in locale `SimpleGraph`:
 
 ## TODO
 
-* Relate `⊤ ⊑ H`/`⊥ ⊑ H` to there being a clique/independent set in `H`.
+* Relate `⊥ ⊴ H` to there being an independent set in `H`.
 * Count induced copies of a graph inside another.
 * Make `copyCount`/`labelledCopyCount` computable (not necessarily efficiently).
 -/


### PR DESCRIPTION
Proves that the image/map of a `Copy ⊤ ·` is a clique and that a simple graph is clique-free iff it does not contain `⊤`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
