### PR TITLE
[Merged by Bors] - feat: more positivity extensions

### DIFF
--- a/Mathlib/Data/Nat/Totient.lean
+++ b/Mathlib/Data/Nat/Totient.lean
@@ -382,7 +382,7 @@ def evalNatTotient : PositivityExt where eval {u α} z p e := do
     assumeInstancesCommute
     match ← core z p n with
     | .positive pa => return .positive q(Nat.totient_pos.mpr $pa)
-    | _ =>  return .nonnegative q(Nat.zero_le _)
+    | _ => failure
   | _, _, _ => throwError "not Nat.totient"
 
 end Mathlib.Meta.Positivity

--- a/Mathlib/Data/Nat/Totient.lean
+++ b/Mathlib/Data/Nat/Totient.lean
@@ -370,3 +370,19 @@ theorem totient_mul_of_prime_of_not_dvd {p n : ℕ} (hp : p.Prime) (h : ¬p ∣ 
   simpa [h] using coprime_or_dvd_of_prime hp n
 
 end Nat
+
+namespace Mathlib.Meta.Positivity
+open Lean Meta Qq
+
+/-- Extension for `Nat.totient`. -/
+@[positivity Nat.totient _]
+def evalNatTotient : PositivityExt where eval {u α} z p e := do
+  match u, α, e with
+  | 0, ~q(ℕ), ~q(Nat.totient $n) =>
+    assumeInstancesCommute
+    match ← core z p n with
+    | .positive pa => return .positive q(Nat.totient_pos.mpr $pa)
+    | _ =>  return .nonnegative q(Nat.zero_le _)
+  | _, _, _ => throwError "not Nat.totient"
+
+end Mathlib.Meta.Positivity

--- a/Mathlib/Tactic/Positivity/Basic.lean
+++ b/Mathlib/Tactic/Positivity/Basic.lean
@@ -443,6 +443,82 @@ def evalAscFactorial : PositivityExt where eval {u α} _ _ e := do
     pure (.positive q(Nat.ascFactorial_pos $n $k))
   | _, _, _ => throwError "failed to match Nat.ascFactorial"
 
+/-- Extension for `Nat.gcd`.
+Uses positivity of the left term, if available, then tries the right term.
+
+The implementation relies on the fact that `core` on `ℕ` never returns `nonzero`. -/
+@[positivity Nat.gcd _ _]
+def evalNatGCD : PositivityExt where eval {u α} z p e := do
+  match u, α, e with
+  | 0, ~q(ℕ), ~q(Nat.gcd $a $b) =>
+    assertInstancesCommute
+    match ← core z p a with
+    | .positive pa => return .positive q(Nat.gcd_pos_of_pos_left $b $pa)
+    | _ =>
+      match ← core z p b with
+      | .positive pb => return .positive q(Nat.gcd_pos_of_pos_right $a $pb)
+      | _ =>  return .nonnegative q(Nat.zero_le _)
+  | _, _, _ => throwError "not Nat.gcd"
+
+/-- Extension for `Nat.lcm`. -/
+@[positivity Nat.lcm _ _]
+def evalNatLCM : PositivityExt where eval {u α} z p e := do
+  match u, α, e with
+  | 0, ~q(ℕ), ~q(Nat.lcm $a $b) =>
+    assertInstancesCommute
+    match ← core z p a with
+    | .positive pa =>
+      match ← core z p b with
+      | .positive pb =>
+        return .positive q(Nat.lcm_pos $pa $pb)
+      | _ => return .nonnegative q(Nat.zero_le _)
+    | _ => return .nonnegative q(Nat.zero_le _)
+  | _, _, _ => throwError "not Nat.lcm"
+
+/-- Extension for `Nat.sqrt`. -/
+@[positivity Nat.sqrt _]
+def evalNatSqrt : PositivityExt where eval {u α} z p e := do
+  match u, α, e with
+  | 0, ~q(ℕ), ~q(Nat.sqrt $n) =>
+    assumeInstancesCommute
+    match ← core z p n with
+    | .positive pa => return .positive q(Nat.sqrt_pos.mpr $pa)
+    | _ =>  return .nonnegative q(Nat.zero_le _)
+  | _, _, _ => throwError "not Nat.sqrt"
+
+/-- Extension for `Int.gcd`.
+Uses positivity of the left term, if available, then tries the right term. -/
+@[positivity Int.gcd _ _]
+def evalIntGCD : PositivityExt where eval {u α} _ _ e := do
+  match u, α, e with
+  | 0, ~q(ℕ), ~q(Int.gcd $a $b) =>
+    let z ← synthInstanceQ (q(Zero ℤ) : Q(Type))
+    let p ← synthInstanceQ (q(PartialOrder ℤ) : Q(Type))
+    assertInstancesCommute
+    match (← catchNone (core z p a)).toNonzero with
+    | some na => return .positive q(Int.gcd_pos_of_ne_zero_left $b $na)
+    | none =>
+      match (← catchNone (core z p b)).toNonzero with
+      | some nb => return .positive q(Int.gcd_pos_of_ne_zero_right $a $nb)
+      | none => return .nonnegative q(Nat.zero_le _)
+  | _, _, _ => throwError "not Int.gcd"
+
+/-- Extension for `Int.lcm`. -/
+@[positivity Int.lcm _ _]
+def evalIntLCM : PositivityExt where eval {u α} _ _ e := do
+  match u, α, e with
+  | 0, ~q(ℕ), ~q(Int.lcm $a $b) =>
+    let z ← synthInstanceQ (q(Zero ℤ) : Q(Type))
+    let p ← synthInstanceQ (q(PartialOrder ℤ) : Q(Type))
+    assertInstancesCommute
+    match (← catchNone (core z p a)).toNonzero with
+    | some na =>
+      match (← catchNone (core z p b)).toNonzero with
+      | some nb => return .positive q(Int.lcm_pos $na $nb)
+      | _ => return .nonnegative q(Nat.zero_le _)
+    | _ =>  return .nonnegative q(Nat.zero_le _)
+  | _, _, _ => throwError "not Int.lcm"
+
 section NNRat
 open NNRat
 

--- a/Mathlib/Tactic/Positivity/Basic.lean
+++ b/Mathlib/Tactic/Positivity/Basic.lean
@@ -457,7 +457,7 @@ def evalNatGCD : PositivityExt where eval {u α} z p e := do
     | _ =>
       match ← core z p b with
       | .positive pb => return .positive q(Nat.gcd_pos_of_pos_right $a $pb)
-      | _ =>  return .nonnegative q(Nat.zero_le _)
+      | _ => failure
   | _, _, _ => throwError "not Nat.gcd"
 
 /-- Extension for `Nat.lcm`. -/
@@ -471,8 +471,8 @@ def evalNatLCM : PositivityExt where eval {u α} z p e := do
       match ← core z p b with
       | .positive pb =>
         return .positive q(Nat.lcm_pos $pa $pb)
-      | _ => return .nonnegative q(Nat.zero_le _)
-    | _ => return .nonnegative q(Nat.zero_le _)
+      | _ => failure
+    | _ => failure
   | _, _, _ => throwError "not Nat.lcm"
 
 /-- Extension for `Nat.sqrt`. -/
@@ -483,7 +483,7 @@ def evalNatSqrt : PositivityExt where eval {u α} z p e := do
     assumeInstancesCommute
     match ← core z p n with
     | .positive pa => return .positive q(Nat.sqrt_pos.mpr $pa)
-    | _ =>  return .nonnegative q(Nat.zero_le _)
+    | _ => failure
   | _, _, _ => throwError "not Nat.sqrt"
 
 /-- Extension for `Int.gcd`.
@@ -498,9 +498,9 @@ def evalIntGCD : PositivityExt where eval {u α} _ _ e := do
     match (← catchNone (core z p a)).toNonzero with
     | some na => return .positive q(Int.gcd_pos_of_ne_zero_left $b $na)
     | none =>
-      match (← catchNone (core z p b)).toNonzero with
+      match (← core z p b).toNonzero with
       | some nb => return .positive q(Int.gcd_pos_of_ne_zero_right $a $nb)
-      | none => return .nonnegative q(Nat.zero_le _)
+      | none => failure
   | _, _, _ => throwError "not Int.gcd"
 
 /-- Extension for `Int.lcm`. -/
@@ -511,12 +511,12 @@ def evalIntLCM : PositivityExt where eval {u α} _ _ e := do
     let z ← synthInstanceQ (q(Zero ℤ) : Q(Type))
     let p ← synthInstanceQ (q(PartialOrder ℤ) : Q(Type))
     assertInstancesCommute
-    match (← catchNone (core z p a)).toNonzero with
+    match (← core z p a).toNonzero with
     | some na =>
-      match (← catchNone (core z p b)).toNonzero with
+      match (← core z p b).toNonzero with
       | some nb => return .positive q(Int.lcm_pos $na $nb)
-      | _ => return .nonnegative q(Nat.zero_le _)
-    | _ =>  return .nonnegative q(Nat.zero_le _)
+      | _ => failure
+    | _ => failure
   | _, _, _ => throwError "not Int.lcm"
 
 section NNRat

--- a/Mathlib/Tactic/Positivity/Basic.lean
+++ b/Mathlib/Tactic/Positivity/Basic.lean
@@ -446,7 +446,7 @@ def evalAscFactorial : PositivityExt where eval {u α} _ _ e := do
 /-- Extension for `Nat.gcd`.
 Uses positivity of the left term, if available, then tries the right term.
 
-The implementation relies on the fact that `core` on `ℕ` never returns `nonzero`. -/
+The implementation relies on the fact that `Positivity.core` on `ℕ` never returns `nonzero`. -/
 @[positivity Nat.gcd _ _]
 def evalNatGCD : PositivityExt where eval {u α} z p e := do
   match u, α, e with

--- a/MathlibTest/positivity.lean
+++ b/MathlibTest/positivity.lean
@@ -234,6 +234,14 @@ example (hq : 0 ≤ q) : 0 ≤ q.num := by positivity
 
 end
 
+example (a b : ℕ) (ha : a ≠ 0) : 0 < a.gcd b := by positivity
+example (a b : ℤ) (ha : a ≠ 0) : 0 < a.gcd b := by positivity
+example (a b : ℕ) (hb : b ≠ 0) : 0 < a.gcd b := by positivity
+example (a b : ℤ) (hb : b ≠ 0) : 0 < a.gcd b := by positivity
+example (a b : ℕ) (ha : a ≠ 0) (hb : b ≠ 0) : 0 < a.lcm b := by positivity
+example (a b : ℤ) (ha : a ≠ 0) (hb : b ≠ 0) : 0 < a.lcm b := by positivity
+example (a : ℕ) (ha : a ≠ 0) : 0 < a.sqrt := by positivity
+example (a : ℕ) (ha : a ≠ 0) : 0 < a.totient := by positivity
 
 section ENNReal
 


### PR DESCRIPTION
Add `positivity` extensions for:

- `Nat.gcd`, `Nat.lcm`, `Int.gcd`, `Int.lcm`;
- `Nat.sqrt`, `Nat.totient`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
