### PR TITLE
feat: a tactic linter for continuity/measurability which can be `fun_prop`

### DIFF
--- a/Mathlib/Tactic/Continuity.lean
+++ b/Mathlib/Tactic/Continuity.lean
@@ -63,9 +63,9 @@ open Mathlib.TacticAnalysis
 @[tacticAnalysis linter.tacticAnalysis.continuityToFunProp,
   inherit_doc linter.tacticAnalysis.continuityToFunProp]
 def continuityToFunprop :=
-  terminalReplacement "continuity" "fun_prop" `tacticContinuity (fun _ _ _ ↦ `(tactic| fun_prop))
+  terminalReplacement "continuity" "fun_prop" ``tacticContinuity (fun _ _ _ ↦ `(tactic| fun_prop))
 
 @[tacticAnalysis linter.tacticAnalysis.continuityToFunProp,
   inherit_doc linter.tacticAnalysis.continuityToFunProp]
 def continuityToFunprop' :=
-  terminalReplacement "continuity?" "fun_prop" `tacticContinuity? (fun _ _ _ ↦ `(tactic| fun_prop))
+  terminalReplacement "continuity?" "fun_prop" ``tacticContinuity? (fun _ _ _ ↦ `(tactic| fun_prop))

--- a/Mathlib/Tactic/Continuity.lean
+++ b/Mathlib/Tactic/Continuity.lean
@@ -6,6 +6,8 @@ Authors: Moritz Doll
 module
 
 public import Mathlib.Tactic.Continuity.Init
+import Mathlib.Tactic.TacticAnalysis.Declarations
+import Mathlib.Tactic.FunProp.Elab
 
 /-!
 # Continuity
@@ -47,3 +49,23 @@ macro "continuity?" : tactic =>
 -- Todo: implement `continuity!` and `continuity!?` and add configuration, original
 -- syntax was (same for the missing `continuity` variants):
 -- syntax (name := continuity) "continuity" optConfig : tactic
+
+/-- Suggest replacing the `continuity` tactic (and its `continuity?` variant)
+with `fun_prop` if that also solves the goal. -/
+public register_option linter.tacticAnalysis.continuityToFunProp : Bool := {
+  defValue := true
+}
+
+open Mathlib.TacticAnalysis
+
+-- Combining these linters into one is a bit annoying, as making `terminalReplacement`
+-- take a list of syntaxes would require passing a corresponding list of names.
+@[tacticAnalysis linter.tacticAnalysis.continuityToFunProp,
+  inherit_doc linter.tacticAnalysis.continuityToFunProp]
+def continuityToFunprop :=
+  terminalReplacement "continuity" "fun_prop" `tacticContinuity (fun _ _ _ ↦ `(tactic| fun_prop))
+
+@[tacticAnalysis linter.tacticAnalysis.continuityToFunProp,
+  inherit_doc linter.tacticAnalysis.continuityToFunProp]
+def continuityToFunprop' :=
+  terminalReplacement "continuity?" "fun_prop" `tacticContinuity? (fun _ _ _ ↦ `(tactic| fun_prop))

--- a/Mathlib/Tactic/Measurability.lean
+++ b/Mathlib/Tactic/Measurability.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Tactic.FunProp.Decl
 public import Mathlib.Tactic.Measurability.Init
+import Mathlib.Tactic.TacticAnalysis.Declarations
 
 /-!
 # Measurability
@@ -80,3 +81,26 @@ macro (name := Mathlib.Tactic.measurability?) "measurability?" : tactic =>
 syntax (name := measurability!) "measurability!" : tactic
 @[tactic_alt Mathlib.Tactic.measurability?]
 syntax (name := measurability!?) "measurability!?" : tactic
+
+/-- Suggest replacing the `measurability` tactic (and its variant `measurability?`, as well as the
+currently unimplemented stubs `measurability!` and `measurability!?`) with `fun_prop`
+if that also solves the goal.
+`fun_prop` does not solve `MeasurableSet` goals, and not all measurability goals --- but when it
+works, it is usually faster (and sometimes a lot faster). -/
+register_option linter.tacticAnalysis.measurabilityToFunProp : Bool := {
+  defValue := true
+}
+
+open Mathlib.TacticAnalysis
+
+@[tacticAnalysis linter.tacticAnalysis.measurabilityToFunProp,
+  inherit_doc linter.tacticAnalysis.measurabilityToFunProp]
+def measurabilityToFunprop :=
+  terminalReplacement "measurability" "fun_prop" `tacticMeasurability
+    (fun _ _ _ ↦ `(tactic| measurability))
+
+@[tacticAnalysis linter.tacticAnalysis.measurabilityToFunProp,
+  inherit_doc linter.tacticAnalysis.measurabilityToFunProp]
+def measurabilityToFunprop2 :=
+  terminalReplacement "measurability?" "fun_prop" `tacticMeasurability?
+    (fun _ _ _ ↦ `(tactic| measurability))

--- a/MathlibTest/ContinuityToFunprop.lean
+++ b/MathlibTest/ContinuityToFunprop.lean
@@ -1,0 +1,26 @@
+module
+
+public import Mathlib.Tactic.Continuity
+public import Mathlib.Topology.Continuous
+
+#eval linter.tacticAnalysis.continuityToFunProp
+
+variable {X : Type*} [TopologicalSpace X]
+
+/-- warning: 'fun_prop' can solve this, and is almost always faster -/
+#guard_msgs in
+example : Continuous (@id X) := by continuity
+
+/--
+info: Try this:
+apply continuous_id
+---
+info: Try this:
+apply continuous_id
+---
+warning: 'fun_prop' can solve this, and is almost always faster
+-/
+#guard_msgs in
+example : Continuous (@id X) := by continuity?
+
+-- TODO: also add a test for measurability!


### PR DESCRIPTION
---

Let's see if this finds further locations in mathlib :tada:

This PR also runs the linter in mathlib by default. I strongly think this is a good idea --- but leaves all kinds of fun questions around "where do you import this linter best". Opinions on this welcome; this PR is a first start (but no more).

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
