### PR TITLE
[Merged by Bors] - chore: deprecate `OrderedSMul`

### DIFF
--- a/Mathlib/Algebra/Order/AddTorsor.lean
+++ b/Mathlib/Algebra/Order/AddTorsor.lean
@@ -57,8 +57,8 @@ class IsOrderedVAdd (G P : Type*) [LE G] [LE P] [VAdd G P] : Prop where
   protected vadd_le_vadd_right : ∀ c d : G, c ≤ d → ∀ a : P, c +ᵥ a ≤ d +ᵥ a
 
 /-- An ordered scalar multiplication is a bi-monotone scalar multiplication. Note that this is
-different from `OrderedSMul`, which uses strict inequality, requires `G` to be a semiring, and the
-defining conditions are restricted to positive elements of `G`. -/
+different from `IsOrderedModule` whose defining conditions are restricted to nonnegative elements.
+-/
 @[to_additive]
 class IsOrderedSMul (G P : Type*) [LE G] [LE P] [SMul G P] : Prop where
   protected smul_le_smul_left : ∀ a b : P, a ≤ b → ∀ c : G, c • a ≤ c • b

--- a/Mathlib/Algebra/Order/Algebra.lean
+++ b/Mathlib/Algebra/Order/Algebra.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 import Mathlib.Algebra.Algebra.Defs
-import Mathlib.Algebra.Order.Module.OrderedSMul
+import Mathlib.Algebra.Order.Module.Defs
 
 /-!
 # Ordered algebras
@@ -20,8 +20,8 @@ i.e. `A ≤ B` iff `B - A = star R * R` for some `R`.
 ## Implementation
 
 Because the axioms for an ordered algebra are exactly the same as those for the underlying
-module being ordered, we don't actually introduce a new class, but just use the `OrderedSMul`
-mixin.
+module being ordered, we don't actually introduce a new class, but just use the `IsOrderedModule`
+and `IsStrictOrderedModule` mixins.
 
 ## Tags
 
@@ -31,7 +31,7 @@ ordered algebra
 section OrderedAlgebra
 
 variable {R A : Type*} [CommRing R] [PartialOrder R] [IsOrderedRing R]
-  [Ring A] [PartialOrder A] [IsOrderedRing A] [Algebra R A] [OrderedSMul R A]
+  [Ring A] [PartialOrder A] [IsOrderedRing A] [Algebra R A] [IsOrderedModule R A]
 
 theorem algebraMap_monotone : Monotone (algebraMap R A) := fun a b h => by
   rw [Algebra.algebraMap_eq_smul_one, Algebra.algebraMap_eq_smul_one, ← sub_nonneg, ← sub_smul]

--- a/Mathlib/Algebra/Order/Module/Defs.lean
+++ b/Mathlib/Algebra/Order/Module/Defs.lean
@@ -424,14 +424,10 @@ variable [Semiring α] [PartialOrder α]
 -- See note [lower instance priority]
 instance (priority := 100) IsOrderedRing.toIsOrderedModule [IsOrderedRing α] :
     IsOrderedModule α α where
-  smul_le_smul_of_nonneg_left _b hb _a₁ _a₂ ha := smul_le_smul_of_nonneg_left ha hb
-  smul_le_smul_of_nonneg_right _b hb _a₁ _a₂ ha := smul_le_smul_of_nonneg_right ha hb
 
 -- See note [lower instance priority]
 instance (priority := 100) IsStrictOrderedRing.toIsStrictOrderedModule [IsStrictOrderedRing α] :
     IsStrictOrderedModule α α where
-  smul_lt_smul_of_pos_left _b hb _a₁ _a₂ ha := smul_lt_smul_of_pos_left ha hb
-  smul_lt_smul_of_pos_right _b hb _a₁ _a₂ ha := smul_lt_smul_of_pos_right ha hb
 
 end PartialOrder
 
@@ -665,8 +661,6 @@ instance (priority := 100) SMulPosReflectLE.toSMulPosReflectLT [SMulPosReflectLE
 -- See note [lower instance priority]
 instance (priority := 100) IsStrictOrderedModule.toIsOrderedModule [IsStrictOrderedModule α β] :
     IsOrderedModule α β where
-  smul_le_smul_of_nonneg_left _b hb _a₁ _a₂ ha := smul_le_smul_of_nonneg_left ha hb
-  smul_le_smul_of_nonneg_right _b hb _a₁ _a₂ ha := smul_le_smul_of_nonneg_right ha hb
 
 lemma smul_eq_smul_iff_eq_and_eq_of_pos [PosSMulStrictMono α β] [SMulPosStrictMono α β]
     (ha : a₁ ≤ a₂) (hb : b₁ ≤ b₂) (h₁ : 0 < a₁) (h₂ : 0 < b₂) :
@@ -890,12 +884,7 @@ variable [Preorder α] [MonoidWithZero α] [AddCommGroup β] [PartialOrder β] [
   [DistribMulAction α β]
 
 instance instIsOrderedModule [IsOrderedModule α β] : IsOrderedModule α βᵒᵈ where
-  smul_le_smul_of_nonneg_left _b hb _a₁ _a₂ ha := smul_le_smul_of_nonneg_left ha hb
-  smul_le_smul_of_nonneg_right _b hb _a₁ _a₂ ha := smul_le_smul_of_nonneg_right ha hb
-
 instance instIsStrictOrderedModule [IsStrictOrderedModule α β] : IsStrictOrderedModule α βᵒᵈ where
-  smul_lt_smul_of_pos_left _b hb _a₁ _a₂ ha := smul_lt_smul_of_pos_left ha hb
-  smul_lt_smul_of_pos_right _b hb _a₁ _a₂ ha := smul_lt_smul_of_pos_right ha hb
 
 end LeftRight
 end OrderDual

--- a/Mathlib/Algebra/Order/Module/Defs.lean
+++ b/Mathlib/Algebra/Order/Module/Defs.lean
@@ -793,10 +793,16 @@ end PartialOrder
 end Semiring
 
 section Ring
-variable [Ring α] [AddCommGroup β] [Module α β] [NoZeroSMulDivisors α β]
+variable [Ring α] [AddCommGroup β] [Module α β] [PartialOrder α] [PartialOrder β]
 
-section PartialOrder
-variable [PartialOrder α] [PartialOrder β]
+/-- Constructor for `IsOrderedModule` when the semimodule is in fact a module. -/
+lemma IsOrderedModule.of_smul_nonneg [IsOrderedAddMonoid α] [IsOrderedAddMonoid β]
+    (h : ∀ a : α, 0 ≤ a → ∀ b : β, 0 ≤ b → 0 ≤ a • b) : IsOrderedModule α β where
+  toPosSMulMono := .of_smul_nonneg h
+  smul_le_smul_of_nonneg_right _b hb a₁ a₂ := by
+    simpa [sub_nonneg, sub_smul] using (h (a₂ - a₁) · _ hb)
+
+variable [NoZeroSMulDivisors α β]
 
 lemma SMulPosMono.toSMulPosStrictMono [SMulPosMono α β] : SMulPosStrictMono α β :=
   ⟨fun _b hb _a₁ _a₂ ha ↦ (smul_le_smul_of_nonneg_right ha.le hb.le).lt_of_ne <|
@@ -812,7 +818,6 @@ lemma SMulPosReflectLT.toSMulPosReflectLE [SMulPosReflectLT α β] : SMulPosRefl
 lemma SMulPosReflectLE_iff_smulPosReflectLT : SMulPosReflectLE α β ↔ SMulPosReflectLT α β :=
   ⟨fun _ ↦ inferInstance, fun _ ↦ SMulPosReflectLT.toSMulPosReflectLE⟩
 
-end PartialOrder
 end Ring
 
 section GroupWithZero

--- a/Mathlib/Algebra/Order/Module/Defs.lean
+++ b/Mathlib/Algebra/Order/Module/Defs.lean
@@ -21,9 +21,9 @@ We use eight typeclasses to encode the various properties we care about for thos
 These typeclasses are meant to be mostly internal to this file, to set up each lemma in the
 appropriate generality.
 
-Less granular typeclasses like `OrderedAddCommMonoid`, `LinearOrderedField`, `OrderedSMul` should be
-enough for most purposes, and the system is set up so that they imply the correct granular
-typeclasses here. If those are enough for you, you may stop reading here! Else, beware that what
+Less granular typeclasses like `IsOrderedAddMonoid` and `IsOrderedModule` should be enough for most
+purposes, and the system is set up so that they imply the correct granular typeclasses here.
+If those are enough for you, you may stop reading here! Else, beware that what
 follows is a bit technical.
 
 ## Definitions
@@ -43,6 +43,13 @@ We use the following four typeclasses to reason about right scalar multiplicatio
 * `SMulPosStrictMono`: If `b > 0`, then `a₁ < a₂` implies `a₁ • b < a₂ • b`.
 * `SMulPosReflectLT`: If `b ≥ 0`, then `a₁ • b < a₂ • b` implies `a₁ < a₂`.
 * `SMulPosReflectLE`: If `b > 0`, then `a₁ • b ≤ a₂ • b` implies `a₁ ≤ a₂`.
+
+Furthermore, in a *module*, i.e. a group acted on by a ring, `PosSMulMono` and `SMulPosMono` are
+equivalent (they are both the same as `∀ r ≥ 0, ∀ m ≥ 0, 0 ≤ r • m`),
+and similarly for `PosSMulStrictMono` and `SMulPosStrictMono`.
+To avoid dangerous instances going both, we have the extra two typeclasses:
+* `IsOrderedModule`: Conjunction of `PosSMulMono` and `SMulPosMono`
+* `IsStrictOrderedModule`: Conjunction of `PosSMulStrictMono` and `SMulPosStrictMono`.
 
 ## Constructors
 
@@ -80,8 +87,10 @@ used implications are:
   * `SMulPosMono → SMulPosStrictMono` (not registered as instance)
 
 Further, the bundled non-granular typeclasses imply the granular ones like so:
-* `OrderedSMul → PosSMulStrictMono`
-* `OrderedSMul → PosSMulReflectLT`
+* `IsOrderedModule → PosSMulMono`
+* `IsOrderedModule → SMulPosMono`
+* `IsStrictOrderedModule → PosSMulStrictMono`
+* `IsStrictOrderedModule → SMulPosStrictMono`
 
 Unless otherwise stated, all these implications are registered as instances,
 which means that in practice you should not worry about these implications.
@@ -109,17 +118,9 @@ because:
 
 In the future, it would be good to make the corresponding typeclasses in
 `Mathlib/Algebra/Order/GroupWithZero/Unbundled.lean` custom typeclasses too.
-
-## TODO
-
-This file acts as a substitute for `Mathlib/Algebra/Order/SMul.lean`. We now need to
-* finish the transition by deleting the duplicate lemmas
-* rearrange the non-duplicate lemmas into new files
-* generalise (most of) the lemmas from `Mathlib/Algebra/Order/Module.lean` to here
-* rethink `OrderedSMul`
 -/
 
-assert_not_exists Field
+assert_not_exists Field Finset
 
 open OrderDual
 
@@ -135,7 +136,7 @@ variable [Zero α]
 namely `b₁ ≤ b₂ → a • b₁ ≤ a • b₂` if `0 ≤ a`.
 
 You should usually not use this very granular typeclass directly, but rather a typeclass like
-`OrderedSMul`. -/
+`IsOrderedModule`. -/
 class PosSMulMono : Prop where
   /-- Do not use this. Use `smul_le_smul_of_nonneg_left` instead. -/
   protected smul_le_smul_of_nonneg_left ⦃a : α⦄ (ha : 0 ≤ a) ⦃b₁ b₂ : β⦄ (hb : b₁ ≤ b₂) :
@@ -145,7 +146,7 @@ class PosSMulMono : Prop where
 namely `b₁ < b₂ → a • b₁ < a • b₂` if `0 < a`.
 
 You should usually not use this very granular typeclass directly, but rather a typeclass like
-`OrderedSMul`. -/
+`IsOrderedModule`. -/
 class PosSMulStrictMono : Prop where
   /-- Do not use this. Use `smul_lt_smul_of_pos_left` instead. -/
   protected smul_lt_smul_of_pos_left ⦃a : α⦄ (ha : 0 < a) ⦃b₁ b₂ : β⦄ (hb : b₁ < b₂) :
@@ -155,7 +156,7 @@ class PosSMulStrictMono : Prop where
 the left, namely `a • b₁ < a • b₂ → b₁ < b₂` if `0 ≤ a`.
 
 You should usually not use this very granular typeclass directly, but rather a typeclass like
-`OrderedSMul`. -/
+`IsOrderedModule`. -/
 class PosSMulReflectLT : Prop where
   /-- Do not use this. Use `lt_of_smul_lt_smul_left` instead. -/
   protected lt_of_smul_lt_smul_left ⦃a : α⦄ (ha : 0 ≤ a) ⦃b₁ b₂ : β⦄ (hb : a • b₁ < a • b₂) :
@@ -165,7 +166,7 @@ class PosSMulReflectLT : Prop where
 namely `a • b₁ ≤ a • b₂ → b₁ ≤ b₂` if `0 < a`.
 
 You should usually not use this very granular typeclass directly, but rather a typeclass like
-`OrderedSMul`. -/
+`IsOrderedModule`. -/
 class PosSMulReflectLE : Prop where
   /-- Do not use this. Use `le_of_smul_le_smul_left` instead. -/
   protected le_of_smul_le_smul_left ⦃a : α⦄ (ha : 0 < a) ⦃b₁ b₂ : β⦄ (hb : a • b₁ ≤ a • b₂) :
@@ -180,7 +181,7 @@ variable [Zero β]
 namely `a₁ ≤ a₂ → a₁ • b ≤ a₂ • b` if `0 ≤ b`.
 
 You should usually not use this very granular typeclass directly, but rather a typeclass like
-`OrderedSMul`. -/
+`IsOrderedModule`. -/
 class SMulPosMono : Prop where
   /-- Do not use this. Use `smul_le_smul_of_nonneg_right` instead. -/
   protected smul_le_smul_of_nonneg_right ⦃b : β⦄ (hb : 0 ≤ b) ⦃a₁ a₂ : α⦄ (ha : a₁ ≤ a₂) :
@@ -190,7 +191,7 @@ class SMulPosMono : Prop where
 namely `a₁ < a₂ → a₁ • b < a₂ • b` if `0 < b`.
 
 You should usually not use this very granular typeclass directly, but rather a typeclass like
-`OrderedSMul`. -/
+`IsOrderedModule`. -/
 class SMulPosStrictMono : Prop where
   /-- Do not use this. Use `smul_lt_smul_of_pos_right` instead. -/
   protected smul_lt_smul_of_pos_right ⦃b : β⦄ (hb : 0 < b) ⦃a₁ a₂ : α⦄ (ha : a₁ < a₂) :
@@ -200,7 +201,7 @@ class SMulPosStrictMono : Prop where
 the left, namely `a₁ • b < a₂ • b → a₁ < a₂` if `0 ≤ b`.
 
 You should usually not use this very granular typeclass directly, but rather a typeclass like
-`OrderedSMul`. -/
+`IsOrderedModule`. -/
 class SMulPosReflectLT : Prop where
   /-- Do not use this. Use `lt_of_smul_lt_smul_right` instead. -/
   protected lt_of_smul_lt_smul_right ⦃b : β⦄ (hb : 0 ≤ b) ⦃a₁ a₂ : α⦄ (hb : a₁ • b < a₂ • b) :
@@ -210,13 +211,26 @@ class SMulPosReflectLT : Prop where
 namely `a₁ • b ≤ a₂ • b → a₁ ≤ a₂` if `0 < b`.
 
 You should usually not use this very granular typeclass directly, but rather a typeclass like
-`OrderedSMul`. -/
+`IsOrderedModule`. -/
 class SMulPosReflectLE : Prop where
   /-- Do not use this. Use `le_of_smul_le_smul_right` instead. -/
   protected le_of_smul_le_smul_right ⦃b : β⦄ (hb : 0 < b) ⦃a₁ a₂ : α⦄ (hb : a₁ • b ≤ a₂ • b) :
     a₁ ≤ a₂
 
 end Right
+
+section LeftRight
+variable [Zero α] [Zero β]
+
+/-- An ordered module is a module with a partial order such that scalar multiplication by a
+nonnegative scalar and of a nonnegative vector are both monotone. -/
+class IsOrderedModule extends PosSMulMono α β, SMulPosMono α β
+
+/-- An ordered module is a module with a partial order such that scalar multiplication by a
+positive scalar and of a positive vector are both strictly monotone. -/
+class IsStrictOrderedModule extends PosSMulStrictMono α β, SMulPosStrictMono α β
+
+end LeftRight
 end Defs
 
 variable {α β} {a a₁ a₂ : α} {b b₁ b₂ : β}
@@ -403,6 +417,23 @@ lemma smul_le_smul' [PosSMulMono α β] [SMulPosMono α β] (ha : a₁ ≤ a₂)
 
 end LeftRight
 end Preorder
+
+section PartialOrder
+variable [Semiring α] [PartialOrder α]
+
+-- See note [lower instance priority]
+instance (priority := 100) IsOrderedRing.toIsOrderedModule [IsOrderedRing α] :
+    IsOrderedModule α α where
+  smul_le_smul_of_nonneg_left _b hb _a₁ _a₂ ha := smul_le_smul_of_nonneg_left ha hb
+  smul_le_smul_of_nonneg_right _b hb _a₁ _a₂ ha := smul_le_smul_of_nonneg_right ha hb
+
+-- See note [lower instance priority]
+instance (priority := 100) IsStrictOrderedRing.toIsStrictOrderedModule [IsStrictOrderedRing α] :
+    IsStrictOrderedModule α α where
+  smul_lt_smul_of_pos_left _b hb _a₁ _a₂ ha := smul_lt_smul_of_pos_left ha hb
+  smul_lt_smul_of_pos_right _b hb _a₁ _a₂ ha := smul_lt_smul_of_pos_right ha hb
+
+end PartialOrder
 
 section LinearOrder
 variable [Preorder α] [LinearOrder β]
@@ -631,6 +662,12 @@ instance (priority := 100) SMulPosReflectLE.toSMulPosReflectLT [SMulPosReflectLE
   SMulPosReflectLT.of_pos fun b hb a₁ a₂ h ↦
     (le_of_smul_le_smul_of_pos_right h.le hb).lt_of_ne <| by rintro rfl; simp at h
 
+-- See note [lower instance priority]
+instance (priority := 100) IsStrictOrderedModule.toIsOrderedModule [IsStrictOrderedModule α β] :
+    IsOrderedModule α β where
+  smul_le_smul_of_nonneg_left _b hb _a₁ _a₂ ha := smul_le_smul_of_nonneg_left ha hb
+  smul_le_smul_of_nonneg_right _b hb _a₁ _a₂ ha := smul_le_smul_of_nonneg_right ha hb
+
 lemma smul_eq_smul_iff_eq_and_eq_of_pos [PosSMulStrictMono α β] [SMulPosStrictMono α β]
     (ha : a₁ ≤ a₂) (hb : b₁ ≤ b₂) (h₁ : 0 < a₁) (h₂ : 0 < b₂) :
     a₁ • b₁ = a₂ • b₂ ↔ a₁ = a₂ ∧ b₁ = b₂ := by
@@ -721,7 +758,14 @@ end Preorder
 end MulAction
 
 section Semiring
-variable [Semiring α] [AddCommGroup β] [Module α β] [NoZeroSMulDivisors α β]
+variable [Semiring α] [AddCommGroup β] [Module α β]
+
+/-- Constructor for `PosSMulMono` when the semimodule is in fact a group. -/
+lemma PosSMulMono.of_smul_nonneg [PartialOrder α] [PartialOrder β] [IsOrderedAddMonoid β]
+    (h : ∀ a : α, 0 ≤ a → ∀ b : β, 0 ≤ b → 0 ≤ a • b) : PosSMulMono α β where
+  smul_le_smul_of_nonneg_left _a ha b₁ b₂ := by simpa [sub_nonneg, smul_sub] using h _ ha (b₂ - b₁)
+
+variable [NoZeroSMulDivisors α β]
 
 section PartialOrder
 variable [Preorder α] [PartialOrder β]
@@ -835,6 +879,20 @@ instance instSMulPosReflectLE [SMulPosReflectLE α β] : SMulPosReflectLE α β�
     exact le_of_smul_le_smul_right (β := β) h <| neg_pos.2 hb
 
 end Right
+
+section LeftRight
+variable [Preorder α] [MonoidWithZero α] [AddCommGroup β] [PartialOrder β] [IsOrderedAddMonoid β]
+  [DistribMulAction α β]
+
+instance instIsOrderedModule [IsOrderedModule α β] : IsOrderedModule α βᵒᵈ where
+  smul_le_smul_of_nonneg_left _b hb _a₁ _a₂ ha := smul_le_smul_of_nonneg_left ha hb
+  smul_le_smul_of_nonneg_right _b hb _a₁ _a₂ ha := smul_le_smul_of_nonneg_right ha hb
+
+instance instIsStrictOrderedModule [IsStrictOrderedModule α β] : IsStrictOrderedModule α βᵒᵈ where
+  smul_lt_smul_of_pos_left _b hb _a₁ _a₂ ha := smul_lt_smul_of_pos_left ha hb
+  smul_lt_smul_of_pos_right _b hb _a₁ _a₂ ha := smul_lt_smul_of_pos_right ha hb
+
+end LeftRight
 end OrderDual
 
 section OrderedAddCommMonoid

--- a/Mathlib/Algebra/Order/Module/OrderedSMul.lean
+++ b/Mathlib/Algebra/Order/Module/OrderedSMul.lean
@@ -39,11 +39,14 @@ This file is now mostly useless. We should try deleting `OrderedSMul`
 ordered module, ordered scalar, ordered smul, ordered action, ordered vector space
 -/
 
+deprecated_module (since := "2025-08-25")
+
 /-- The ordered scalar product property is when an ordered additive commutative monoid
 with a partial order has a scalar multiplication which is compatible with the order. Note that this
 is different from `IsOrderedSMul`, which uses `≤`, has no semiring assumption, and has no positivity
 constraint on the defining conditions.
 -/
+@[deprecated IsStrictOrderedModule (since := "2025-08-25")]
 class OrderedSMul (R M : Type*) [Semiring R] [PartialOrder R]
     [AddCommMonoid M] [PartialOrder M] [SMulWithZero R M] :
   Prop where
@@ -55,6 +58,7 @@ class OrderedSMul (R M : Type*) [Semiring R] [PartialOrder R]
 variable {ι 𝕜 R M N : Type*}
 
 section OrderedSMul
+set_option linter.deprecated false
 variable [Semiring R] [PartialOrder R] [AddCommMonoid M] [PartialOrder M]
   [SMulWithZero R M] [OrderedSMul R M]
 
@@ -70,6 +74,7 @@ instance OrderDual.instOrderedSMul : OrderedSMul R Mᵒᵈ where
 
 end OrderedSMul
 
+set_option linter.deprecated false in
 /-- To prove that a linear ordered monoid is an ordered module, it suffices to verify only the first
 axiom of `OrderedSMul`. -/
 theorem OrderedSMul.mk'' [Semiring 𝕜] [PartialOrder 𝕜]
@@ -78,6 +83,7 @@ theorem OrderedSMul.mk'' [Semiring 𝕜] [PartialOrder 𝕜]
   { smul_lt_smul_of_pos := fun hab hc => h hc hab
     lt_of_smul_lt_smul_of_pos := fun hab hc => (h hc).lt_iff_lt.1 hab }
 
+set_option linter.deprecated false in
 instance Nat.orderedSMul [AddCommMonoid M] [LinearOrder M] [IsOrderedCancelAddMonoid M] :
     OrderedSMul ℕ M :=
   OrderedSMul.mk'' fun n hn a b hab => by
@@ -88,6 +94,7 @@ instance Nat.orderedSMul [AddCommMonoid M] [LinearOrder M] [IsOrderedCancelAddMo
       | zero => dsimp; rwa [one_nsmul, one_nsmul]
       | succ n ih => simp only [succ_nsmul _ n.succ, _root_.add_lt_add (ih n.succ_pos) hab]
 
+set_option linter.deprecated false in
 instance Int.orderedSMul [AddCommGroup M] [LinearOrder M] [IsOrderedAddMonoid M] :
     OrderedSMul ℤ M :=
   OrderedSMul.mk'' fun n hn => by
@@ -99,7 +106,7 @@ instance Int.orderedSMul [AddCommGroup M] [LinearOrder M] [IsOrderedAddMonoid M]
 section LinearOrderedSemiring
 variable [Semiring R] [LinearOrder R] [IsStrictOrderedRing R]
 
--- TODO: `LinearOrderedField M → OrderedSMul ℚ M`
+set_option linter.deprecated false in
 instance LinearOrderedSemiring.toOrderedSMul : OrderedSMul R R :=
   OrderedSMul.mk'' fun _ => strictMono_mul_left_of_pos
 
@@ -112,6 +119,7 @@ variable [Semifield 𝕜] [PartialOrder 𝕜] [IsStrictOrderedRing 𝕜] [PosMul
   [AddCommMonoid N] [PartialOrder N]
   [MulActionWithZero 𝕜 M] [MulActionWithZero 𝕜 N]
 
+set_option linter.deprecated false in
 /-- To prove that a vector space over a linear ordered field is ordered, it suffices to verify only
 the first axiom of `OrderedSMul`. -/
 theorem OrderedSMul.mk' (h : ∀ ⦃a b : M⦄ ⦃c : 𝕜⦄, a < b → 0 < c → c • a ≤ c • b) :
@@ -126,10 +134,12 @@ theorem OrderedSMul.mk' (h : ∀ ⦃a b : M⦄ ⦃c : 𝕜⦄, a < b → 0 < c �
   refine hlt' _ _ _ hab (pos_of_mul_pos_right ?_ hc.le)
   simp only [c.mul_inv, zero_lt_one]
 
+set_option linter.deprecated false in
 instance [OrderedSMul 𝕜 M] [OrderedSMul 𝕜 N] : OrderedSMul 𝕜 (M × N) :=
   OrderedSMul.mk' fun _ _ _ h hc =>
     ⟨smul_le_smul_of_nonneg_left h.1.1 hc.le, smul_le_smul_of_nonneg_left h.1.2 hc.le⟩
 
+set_option linter.deprecated false in
 instance Pi.orderedSMul {M : ι → Type*} [∀ i, AddCommMonoid (M i)] [∀ i, PartialOrder (M i)]
     [∀ i, MulActionWithZero 𝕜 (M i)] [∀ i, OrderedSMul 𝕜 (M i)] : OrderedSMul 𝕜 (∀ i, M i) :=
   OrderedSMul.mk' fun _ _ _ h hc i => smul_le_smul_of_nonneg_left (h.le i) hc.le

--- a/Mathlib/Algebra/Order/Monovary.lean
+++ b/Mathlib/Algebra/Order/Monovary.lean
@@ -3,7 +3,8 @@ Copyright (c) 2023 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
-import Mathlib.Algebra.Order.Module.OrderedSMul
+import Mathlib.Algebra.Field.Defs
+import Mathlib.Algebra.Order.Module.Defs
 import Mathlib.Algebra.Order.Module.Synonym
 import Mathlib.Algebra.Order.Monoid.OrderDual
 import Mathlib.Order.Monotone.Monovary
@@ -359,7 +360,7 @@ end LinearOrderedSemifield
 section LinearOrderedAddCommGroup
 variable [Ring α] [LinearOrder α] [IsStrictOrderedRing α]
   [AddCommGroup β] [LinearOrder β] [IsOrderedAddMonoid β] [Module α β]
-  [OrderedSMul α β] {f : ι → α} {g : ι → β} {s : Set ι}
+  [IsStrictOrderedModule α β] {f : ι → α} {g : ι → β} {s : Set ι}
 
 lemma monovaryOn_iff_forall_smul_nonneg :
     MonovaryOn f g s ↔ ∀ ⦃i⦄, i ∈ s → ∀ ⦃j⦄, j ∈ s → 0 ≤ (f j - f i) • (g j - g i) := by

--- a/Mathlib/Algebra/Order/Nonneg/Module.lean
+++ b/Mathlib/Algebra/Order/Nonneg/Module.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Apurva Nakade
 -/
 import Mathlib.Algebra.Module.RingHom
-import Mathlib.Algebra.Order.Module.OrderedSMul
+import Mathlib.Algebra.Order.Module.Defs
 import Mathlib.Algebra.Order.Nonneg.Basic
 
 /-!
@@ -61,15 +61,21 @@ instance instSMulWithZero : SMulWithZero R≥0 S where
 
 end SMulWithZero
 
-section OrderedSMul
+section IsOrderedModule
 
 variable [IsOrderedRing R] [AddCommMonoid M] [PartialOrder M] [IsOrderedAddMonoid M]
-  [SMulWithZero R M] [hE : OrderedSMul R M]
+  [SMulWithZero R M]
 
-instance instOrderedSMul : OrderedSMul R≥0 M :=
-  ⟨hE.1, hE.2⟩
+instance instIsOrderedModule [hM : IsOrderedModule R M] : IsOrderedModule R≥0 M where
+  smul_le_smul_of_nonneg_left _b hb _a₁ _a₂ ha := hM.1 hb ha
+  smul_le_smul_of_nonneg_right _b hb _a₁ _a₂ ha := hM.2 hb ha
 
-end OrderedSMul
+instance instIsStrictOrderedModule [hM : IsStrictOrderedModule R M] :
+    IsStrictOrderedModule R≥0 M where
+  smul_lt_smul_of_pos_left _b hb _a₁ _a₂ ha := hM.1 hb ha
+  smul_lt_smul_of_pos_right _b hb _a₁ _a₂ ha := hM.2 hb ha
+
+end IsOrderedModule
 
 section Module
 

--- a/Mathlib/Algebra/Order/Nonneg/Module.lean
+++ b/Mathlib/Algebra/Order/Nonneg/Module.lean
@@ -67,13 +67,13 @@ variable [IsOrderedRing R] [AddCommMonoid M] [PartialOrder M] [IsOrderedAddMonoi
   [SMulWithZero R M]
 
 instance instIsOrderedModule [hM : IsOrderedModule R M] : IsOrderedModule R≥0 M where
-  smul_le_smul_of_nonneg_left _b hb _a₁ _a₂ ha := hM.1 hb ha
-  smul_le_smul_of_nonneg_right _b hb _a₁ _a₂ ha := hM.2 hb ha
+  smul_le_smul_of_nonneg_left _b hb _a₁ _a₂ ha := hM.smul_le_smul_of_nonneg_left hb ha
+  smul_le_smul_of_nonneg_right _b hb _a₁ _a₂ ha := hM.smul_le_smul_of_nonneg_right hb ha
 
 instance instIsStrictOrderedModule [hM : IsStrictOrderedModule R M] :
     IsStrictOrderedModule R≥0 M where
-  smul_lt_smul_of_pos_left _b hb _a₁ _a₂ ha := hM.1 hb ha
-  smul_lt_smul_of_pos_right _b hb _a₁ _a₂ ha := hM.2 hb ha
+  smul_lt_smul_of_pos_left _b hb _a₁ _a₂ ha := hM.smul_lt_smul_of_pos_left hb ha
+  smul_lt_smul_of_pos_right _b hb _a₁ _a₂ ha := hM.smul_lt_smul_of_pos_right hb ha
 
 end IsOrderedModule
 

--- a/Mathlib/Algebra/Order/Rearrangement.lean
+++ b/Mathlib/Algebra/Order/Rearrangement.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Mantas Bakšys. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mantas Bakšys
 -/
-import Mathlib.Algebra.Order.Module.OrderedSMul
+import Mathlib.Algebra.Order.Module.Defs
 import Mathlib.Algebra.Order.Module.Synonym
 import Mathlib.Algebra.Order.Monoid.OrderDual
 import Mathlib.Data.Finset.Max

--- a/Mathlib/Algebra/Order/Star/Basic.lean
+++ b/Mathlib/Algebra/Order/Star/Basic.lean
@@ -358,14 +358,12 @@ variable [Semiring R] [PartialOrder R] [StarRing R] [StarOrderedRing R]
   [NonUnitalSemiring A] [StarRing A] [PartialOrder A] [StarOrderedRing A] [Module R A]
   [StarModule R A] [IsScalarTower R A A] [SMulCommClass R A A]
 
-instance : PosSMulMono R A where
+instance : IsOrderedModule R A where
   smul_le_smul_of_nonneg_left r hr a b hab := by
     rw [StarOrderedRing.nonneg_iff] at hr
     rw [StarOrderedRing.le_iff] at hab ⊢
     obtain ⟨a, ha, rfl⟩ := hab
     exact ⟨r • a, smul_mem_closure_star_mul hr ha, smul_add ..⟩
-
-instance : SMulPosMono R A where
   smul_le_smul_of_nonneg_right a ha r s hrs := by
     rw [StarOrderedRing.nonneg_iff] at ha
     rw [StarOrderedRing.le_iff] at hrs ⊢
@@ -382,7 +380,7 @@ instance : PosSMulStrictMono R A where
     obtain ⟨hr₀, hr⟩ := hr
     exact ⟨r • a, smul_ne_zero hr₀ ha₀, smul_mem_closure_star_mul hr ha, smul_add ..⟩
 
-instance [IsCancelAdd R] : SMulPosStrictMono R A where
+instance [IsCancelAdd R] : IsStrictOrderedModule R A where
   smul_lt_smul_of_pos_right a ha r s hrs := by
     rw [StarOrderedRing.pos_iff] at ha
     rw [StarOrderedRing.lt_iff] at hrs ⊢

--- a/Mathlib/Algebra/Star/CHSH.lean
+++ b/Mathlib/Algebra/Star/CHSH.lean
@@ -115,8 +115,7 @@ theorem CHSH_id [CommRing R] {A₀ A₁ B₀ B₁ : R} (A₀_inv : A₀ ^ 2 = 1)
 (We could work over ℤ[⅟2] if we wanted to!)
 -/
 theorem CHSH_inequality_of_comm [CommRing R] [PartialOrder R] [StarRing R] [StarOrderedRing R]
-    [Algebra ℝ R]
-    [OrderedSMul ℝ R] (A₀ A₁ B₀ B₁ : R) (T : IsCHSHTuple A₀ A₁ B₀ B₁) :
+    [Algebra ℝ R] [IsOrderedModule ℝ R] (A₀ A₁ B₀ B₁ : R) (T : IsCHSHTuple A₀ A₁ B₀ B₁) :
     A₀ * B₀ + A₀ * B₁ + A₁ * B₀ - A₁ * B₁ ≤ 2 := by
   let P := 2 - A₀ * B₀ - A₀ * B₁ - A₁ * B₀ + A₁ * B₁
   have i₁ : 0 ≤ P := by
@@ -174,8 +173,8 @@ of the difference.
 (We could work over `ℤ[2^(1/2), 2^(-1/2)]` if we really wanted to!)
 -/
 theorem tsirelson_inequality [Ring R] [PartialOrder R] [StarRing R] [StarOrderedRing R]
-    [Algebra ℝ R]
-    [OrderedSMul ℝ R] [StarModule ℝ R] (A₀ A₁ B₀ B₁ : R) (T : IsCHSHTuple A₀ A₁ B₀ B₁) :
+    [Algebra ℝ R] [IsOrderedModule ℝ R] [StarModule ℝ R]
+    (A₀ A₁ B₀ B₁ : R) (T : IsCHSHTuple A₀ A₁ B₀ B₁) :
     A₀ * B₀ + A₀ * B₁ + A₁ * B₀ - A₁ * B₁ ≤ √2 ^ 3 • (1 : R) := by
   -- abel will create `ℤ` multiplication. We will `simp` them away to `ℝ` multiplication.
   have M : ∀ (m : ℤ) (a : ℝ) (x : R), m • a • x = ((m : ℝ) * a) • x := fun m a x => by

--- a/Mathlib/Analysis/Convex/Extrema.lean
+++ b/Mathlib/Analysis/Convex/Extrema.lean
@@ -18,7 +18,7 @@ a global minimum, and likewise for concave functions.
 
 variable {E β : Type*} [AddCommGroup E] [TopologicalSpace E] [Module ℝ E] [IsTopologicalAddGroup E]
   [ContinuousSMul ℝ E] [AddCommGroup β] [PartialOrder β] [IsOrderedAddMonoid β]
-  [Module ℝ β] [OrderedSMul ℝ β] {s : Set E}
+  [Module ℝ β] [IsOrderedModule ℝ β] [PosSMulReflectLE ℝ β] {s : Set E}
 
 open Set Filter Function Topology
 

--- a/Mathlib/Analysis/Convex/Gauge.lean
+++ b/Mathlib/Analysis/Convex/Gauge.lean
@@ -233,7 +233,7 @@ theorem one_le_gauge_of_notMem (hs₁ : StarConvex ℝ 0 s) (hs₂ : Absorbs ℝ
 section LinearOrderedField
 
 variable {α : Type*} [Field α] [LinearOrder α] [IsStrictOrderedRing α]
-  [MulActionWithZero α ℝ] [OrderedSMul α ℝ]
+  [MulActionWithZero α ℝ] [IsStrictOrderedModule α ℝ]
 
 theorem gauge_smul_of_nonneg [MulActionWithZero α E] [IsScalarTower α ℝ (Set E)] {s : Set E} {a : α}
     (ha : 0 ≤ a) (x : E) : gauge s (a • x) = a • gauge s x := by

--- a/Mathlib/Analysis/Convex/Jensen.lean
+++ b/Mathlib/Analysis/Convex/Jensen.lean
@@ -40,9 +40,9 @@ variable {𝕜 E F β ι : Type*}
 
 section Jensen
 
-variable [Field 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜] [AddCommGroup E]
-  [AddCommGroup β] [PartialOrder β] [IsOrderedAddMonoid β] [Module 𝕜 E] [Module 𝕜 β]
-  [OrderedSMul 𝕜 β] {s : Set E} {f : E → β} {t : Finset ι} {w : ι → 𝕜} {p : ι → E} {v : 𝕜} {q : E}
+variable [Field 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜] [AddCommGroup E] [AddCommGroup β]
+  [PartialOrder β] [IsOrderedAddMonoid β] [Module 𝕜 E] [Module 𝕜 β] [IsStrictOrderedModule 𝕜 β]
+  {s : Set E} {f : E → β} {t : Finset ι} {w : ι → 𝕜} {p : ι → E} {v : 𝕜} {q : E}
 
 /-- Convex **Jensen's inequality**, `Finset.centerMass` version. -/
 theorem ConvexOn.map_centerMass_le (hf : ConvexOn 𝕜 s f) (h₀ : ∀ i ∈ t, 0 ≤ w i)
@@ -242,7 +242,7 @@ section MaximumPrinciple
 
 variable [Field 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜] [AddCommGroup E]
   [AddCommGroup β] [LinearOrder β] [IsOrderedAddMonoid β] [Module 𝕜 E]
-  [Module 𝕜 β] [OrderedSMul 𝕜 β] {s : Set E} {f : E → β} {w : ι → 𝕜} {p : ι → E}
+  [Module 𝕜 β] [IsStrictOrderedModule 𝕜 β] {s : Set E} {f : E → β} {w : ι → 𝕜} {p : ι → E}
   {x y z : E}
 
 theorem ConvexOn.le_sup_of_mem_convexHull {t : Finset E} (hf : ConvexOn 𝕜 s f) (hts : ↑t ⊆ s)

--- a/Mathlib/Analysis/Convex/Mul.lean
+++ b/Mathlib/Analysis/Convex/Mul.lean
@@ -29,7 +29,7 @@ variable [CommRing 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜]
   [AddCommGroup F] [LinearOrder F] [IsOrderedAddMonoid F]
   [AddCommGroup G] [Module 𝕜 G]
   [Module 𝕜 E] [Module 𝕜 F] [Module E F] [IsScalarTower 𝕜 E F] [SMulCommClass 𝕜 E F]
-  [OrderedSMul 𝕜 F] [OrderedSMul E F] {s : Set G} {f : G → E} {g : G → F}
+  [IsOrderedModule 𝕜 F] [IsStrictOrderedModule E F] {s : Set G} {f : G → E} {g : G → F}
 
 lemma ConvexOn.smul' (hf : ConvexOn 𝕜 s f) (hg : ConvexOn 𝕜 s g) (hf₀ : ∀ ⦃x⦄, x ∈ s → 0 ≤ f x)
     (hg₀ : ∀ ⦃x⦄, x ∈ s → 0 ≤ g x) (hfg : MonovaryOn f g s) : ConvexOn 𝕜 s (f • g) := by
@@ -50,7 +50,7 @@ lemma ConvexOn.smul' (hf : ConvexOn 𝕜 s f) (hg : ConvexOn 𝕜 s g) (hf₀ : 
     ← smul_smul_smul_comm b b, smul_eq_mul, smul_eq_mul, smul_eq_mul, smul_eq_mul, mul_comm b,
     add_comm _ ((b * b) • f y • g y), add_add_add_comm, add_comm ((a * b) • f y • g x)]
 
-lemma ConcaveOn.smul' [OrderedSMul 𝕜 E] (hf : ConcaveOn 𝕜 s f) (hg : ConcaveOn 𝕜 s g)
+lemma ConcaveOn.smul' [IsOrderedModule 𝕜 E] (hf : ConcaveOn 𝕜 s f) (hg : ConcaveOn 𝕜 s g)
     (hf₀ : ∀ ⦃x⦄, x ∈ s → 0 ≤ f x) (hg₀ : ∀ ⦃x⦄, x ∈ s → 0 ≤ g x) (hfg : AntivaryOn f g s) :
     ConcaveOn 𝕜 s (f • g) := by
   refine ⟨hf.1, fun x hx y hy a b ha hb hab ↦ ?_⟩
@@ -70,7 +70,7 @@ lemma ConcaveOn.smul' [OrderedSMul 𝕜 E] (hf : ConcaveOn 𝕜 s f) (hg : Conca
     ← smul_smul_smul_comm b b, smul_eq_mul, smul_eq_mul, smul_eq_mul, smul_eq_mul, mul_comm b a,
     add_comm ((a * b) • f x • g y), add_comm ((a * b) • f x • g y), add_add_add_comm]
 
-lemma ConvexOn.smul'' [OrderedSMul 𝕜 E] (hf : ConvexOn 𝕜 s f) (hg : ConvexOn 𝕜 s g)
+lemma ConvexOn.smul'' [IsOrderedModule 𝕜 E] (hf : ConvexOn 𝕜 s f) (hg : ConvexOn 𝕜 s g)
     (hf₀ : ∀ ⦃x⦄, x ∈ s → f x ≤ 0) (hg₀ : ∀ ⦃x⦄, x ∈ s → g x ≤ 0) (hfg : AntivaryOn f g s) :
     ConcaveOn 𝕜 s (f • g) := by
   rw [← neg_smul_neg]
@@ -89,13 +89,13 @@ lemma ConvexOn.smul_concaveOn (hf : ConvexOn 𝕜 s f) (hg : ConcaveOn 𝕜 s g)
   rw [← neg_convexOn_iff, ← smul_neg]
   exact hf.smul' hg.neg hf₀ (fun x hx ↦ neg_nonneg.2 <| hg₀ hx) hfg.neg_right
 
-lemma ConcaveOn.smul_convexOn [OrderedSMul 𝕜 E] (hf : ConcaveOn 𝕜 s f) (hg : ConvexOn 𝕜 s g)
+lemma ConcaveOn.smul_convexOn [IsOrderedModule 𝕜 E] (hf : ConcaveOn 𝕜 s f) (hg : ConvexOn 𝕜 s g)
     (hf₀ : ∀ ⦃x⦄, x ∈ s → 0 ≤ f x) (hg₀ : ∀ ⦃x⦄, x ∈ s → g x ≤ 0) (hfg : MonovaryOn f g s) :
     ConvexOn 𝕜 s (f • g) := by
   rw [← neg_concaveOn_iff, ← smul_neg]
   exact hf.smul' hg.neg hf₀ (fun x hx ↦ neg_nonneg.2 <| hg₀ hx) hfg.neg_right
 
-lemma ConvexOn.smul_concaveOn' [OrderedSMul 𝕜 E] (hf : ConvexOn 𝕜 s f) (hg : ConcaveOn 𝕜 s g)
+lemma ConvexOn.smul_concaveOn' [IsOrderedModule 𝕜 E] (hf : ConvexOn 𝕜 s f) (hg : ConcaveOn 𝕜 s g)
     (hf₀ : ∀ ⦃x⦄, x ∈ s → f x ≤ 0) (hg₀ : ∀ ⦃x⦄, x ∈ s → 0 ≤ g x) (hfg : MonovaryOn f g s) :
     ConvexOn 𝕜 s (f • g) := by
   rw [← neg_concaveOn_iff, ← smul_neg]
@@ -107,7 +107,7 @@ lemma ConcaveOn.smul_convexOn' (hf : ConcaveOn 𝕜 s f) (hg : ConvexOn 𝕜 s g
   rw [← neg_convexOn_iff, ← smul_neg]
   exact hf.smul'' hg.neg hf₀ (fun x hx ↦ neg_nonpos.2 <| hg₀ hx) hfg.neg_right
 
-variable [OrderedSMul 𝕜 E] [IsScalarTower 𝕜 E E] [SMulCommClass 𝕜 E E] {f g : G → E}
+variable [IsOrderedModule 𝕜 E] [IsScalarTower 𝕜 E E] [SMulCommClass 𝕜 E E] {f g : G → E}
 
 lemma ConvexOn.mul (hf : ConvexOn 𝕜 s f) (hg : ConvexOn 𝕜 s g) (hf₀ : ∀ ⦃x⦄, x ∈ s → 0 ≤ f x)
     (hg₀ : ∀ ⦃x⦄, x ∈ s → 0 ≤ g x) (hfg : MonovaryOn f g s) :

--- a/Mathlib/Analysis/Convex/Star.lean
+++ b/Mathlib/Analysis/Convex/Star.lean
@@ -358,8 +358,8 @@ end AddCommGroup
 
 section OrderedAddCommGroup
 
-variable [AddCommGroup E] [PartialOrder E] [IsOrderedAddMonoid E] [Module 𝕜 E] [OrderedSMul 𝕜 E]
-  {x y : E}
+variable [AddCommGroup E] [PartialOrder E] [IsOrderedAddMonoid E] [Module 𝕜 E]
+  [IsStrictOrderedModule 𝕜 E] [PosSMulReflectLT 𝕜 E] {x y : E}
 
 /-- If `x < y`, then `(Set.Iic x)ᶜ` is star convex at `y`. -/
 lemma starConvex_compl_Iic (h : x < y) : StarConvex 𝕜 y (Iic x)ᶜ := by

--- a/Mathlib/Analysis/RCLike/Basic.lean
+++ b/Mathlib/Analysis/RCLike/Basic.lean
@@ -11,7 +11,6 @@ import Mathlib.Analysis.CStarAlgebra.Basic
 import Mathlib.Analysis.Normed.Operator.ContinuousLinearMap
 import Mathlib.Analysis.Normed.Ring.Finite
 import Mathlib.Data.Real.Sqrt
-import Mathlib.LinearAlgebra.Basis.VectorSpace
 
 /-!
 # `RCLike`: a typeclass for ℝ or ℂ
@@ -923,26 +922,14 @@ lemma toPosMulReflectLT : PosMulReflectLT K where
 
 scoped[ComplexOrder] attribute [instance] RCLike.toPosMulReflectLT
 
-theorem toOrderedSMul : OrderedSMul ℝ K :=
-  OrderedSMul.mk' fun a b r hab hr => by
-    replace hab := hab.le
-    rw [RCLike.le_iff_re_im] at hab
-    rw [RCLike.le_iff_re_im, smul_re, smul_re, smul_im, smul_im]
-    exact hab.imp (fun h => mul_le_mul_of_nonneg_left h hr.le) (congr_arg _)
+theorem toIsStrictOrderedModule : IsStrictOrderedModule ℝ K where
+  smul_lt_smul_of_pos_left r hr a b hab := by
+    simpa [RCLike.lt_iff_re_im (K := K), smul_re, smul_im, hr, hr.ne'] using hab
+  smul_lt_smul_of_pos_right a ha r₁ r₂ hr := by
+    obtain ⟨hare, haim⟩ := RCLike.lt_iff_re_im.1 ha
+    simp_all [RCLike.lt_iff_re_im (K := K), smul_re, smul_im]
 
-scoped[ComplexOrder] attribute [instance] RCLike.toOrderedSMul
-
-/-- A star algebra over `K` has a scalar multiplication that respects the order. -/
-lemma _root_.StarModule.instOrderedSMul {A : Type*} [NonUnitalRing A] [StarRing A] [PartialOrder A]
-    [StarOrderedRing A] [Module K A] [StarModule K A] [IsScalarTower K A A] [SMulCommClass K A A] :
-    OrderedSMul K A := .mk' fun _a _b _zc hab hc ↦ (smul_lt_smul_of_pos_left hab hc).le
-
-instance {A : Type*} [NonUnitalRing A] [StarRing A] [PartialOrder A] [StarOrderedRing A]
-    [Module ℝ A] [StarModule ℝ A] [IsScalarTower ℝ A A] [SMulCommClass ℝ A A] :
-    OrderedSMul ℝ A :=
-  StarModule.instOrderedSMul
-
-scoped[ComplexOrder] attribute [instance] StarModule.instOrderedSMul
+scoped[ComplexOrder] attribute [instance] RCLike.toIsStrictOrderedModule
 
 theorem ofReal_mul_pos_iff (x : ℝ) (z : K) :
     0 < x * z ↔ (x < 0 ∧ z < 0) ∨ (0 < x ∧ 0 < z) := by

--- a/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/IntegralRepresentation.lean
+++ b/Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/IntegralRepresentation.lean
@@ -451,7 +451,7 @@ private lemma monotoneOn_nnrpow_Ioo {p : ℝ≥0} (hp : p ∈ Ioo 0 1) :
       (fun a : A => ∫ t in Ioi 0, cfcₙ (rpowIntegrand₀₁ p t) a ∂μ) :=
     fun a ha => (hμ a ha).2
   refine MonotoneOn.congr ?_ h₃'.symm
-  refine MeasureTheory.integral_monotoneOn_of_integrand_ae ?_ fun a ha => (hμ a ha).1
+  refine integral_monotoneOn_of_integrand_ae ?_ fun a ha => (hμ a ha).1
   filter_upwards [ae_restrict_mem measurableSet_Ioi] with t ht
   exact monotoneOn_cfcₙ_rpowIntegrand₀₁ hp ht
 

--- a/Mathlib/Data/NNReal/Defs.lean
+++ b/Mathlib/Data/NNReal/Defs.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
 import Mathlib.Algebra.Algebra.Defs
-import Mathlib.Algebra.Order.Module.OrderedSMul
+import Mathlib.Algebra.Order.Nonneg.Module
 import Mathlib.Data.Real.Archimedean
 
 /-!
@@ -510,12 +510,9 @@ theorem coe_min (x y : ℝ≥0) : ((min x y : ℝ≥0) : ℝ) = min (x : ℝ) (y
 theorem zero_le_coe {q : ℝ≥0} : 0 ≤ (q : ℝ) :=
   q.2
 
-instance instOrderedSMul {M : Type*} [AddCommMonoid M] [PartialOrder M]
-    [Module ℝ M] [OrderedSMul ℝ M] :
-    OrderedSMul ℝ≥0 M where
-  smul_lt_smul_of_pos hab hc := (smul_lt_smul_of_pos_left hab (NNReal.coe_pos.2 hc) :)
-  lt_of_smul_lt_smul_of_pos {_ _ c} hab _ :=
-    lt_of_smul_lt_smul_of_nonneg_left (by exact hab) (NNReal.coe_nonneg c)
+instance instIsStrictOrderedModule {M : Type*} [AddCommMonoid M] [PartialOrder M]
+    [Module ℝ M] [IsStrictOrderedModule ℝ M] :
+    IsStrictOrderedModule ℝ≥0 M := Nonneg.instIsStrictOrderedModule
 
 end NNReal
 

--- a/Mathlib/Data/Real/Embedding.lean
+++ b/Mathlib/Data/Real/Embedding.lean
@@ -3,14 +3,10 @@ Copyright (c) 2025 Weiyi Wang. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Weiyi Wang
 -/
-
-import Mathlib.Data.Real.Archimedean
-import Mathlib.Data.Real.Basic
-import Mathlib.Algebra.Order.Archimedean.Basic
 import Mathlib.Algebra.Order.Group.Pointwise.CompleteLattice
 import Mathlib.Algebra.Order.Hom.Monoid
-import Mathlib.Algebra.Order.Module.OrderedSMul
-import Mathlib.Tactic.Qify
+import Mathlib.Algebra.Order.Module.Defs
+import Mathlib.Data.Real.Archimedean
 
 /-!
 # Embedding of archimedean groups into reals

--- a/Mathlib/Data/Real/Pointwise.lean
+++ b/Mathlib/Data/Real/Pointwise.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies, Eric Wieser
 -/
 import Mathlib.Algebra.GroupWithZero.Action.Pointwise.Set
-import Mathlib.Algebra.Order.Module.OrderedSMul
 import Mathlib.Algebra.Order.Module.Pointwise
 import Mathlib.Data.Real.Archimedean
 
@@ -32,7 +31,7 @@ variable {ι : Sort*} {α : Type*} [Field α] [LinearOrder α] [IsStrictOrderedR
 
 section MulActionWithZero
 
-variable [MulActionWithZero α ℝ] [OrderedSMul α ℝ] {a : α}
+variable [MulActionWithZero α ℝ] [IsOrderedModule α ℝ] {a : α}
 
 theorem Real.sInf_smul_of_nonneg (ha : 0 ≤ a) (s : Set ℝ) : sInf (a • s) = a • sInf s := by
   obtain rfl | hs := s.eq_empty_or_nonempty
@@ -66,7 +65,7 @@ end MulActionWithZero
 
 section Module
 
-variable [Module α ℝ] [OrderedSMul α ℝ] {a : α}
+variable [Module α ℝ] [IsOrderedModule α ℝ] {a : α}
 
 theorem Real.sInf_smul_of_nonpos (ha : a ≤ 0) (s : Set ℝ) : sInf (a • s) = a • sSup s := by
   obtain rfl | hs := s.eq_empty_or_nonempty

--- a/Mathlib/Geometry/Convex/Cone/Basic.lean
+++ b/Mathlib/Geometry/Convex/Cone/Basic.lean
@@ -247,20 +247,6 @@ theorem smul_mem_iff {c : 𝕜} (hc : 0 < c) {x : M} : c • x ∈ C ↔ x ∈ C
   ⟨fun h => inv_smul_smul₀ hc.ne' x ▸ C.smul_mem (inv_pos.2 hc) h, C.smul_mem hc⟩
 
 end MulAction
-
-section OrderedAddCommGroup
-
-variable [AddCommGroup M] [PartialOrder M] [Module 𝕜 M]
-
-/-- Constructs an ordered module given an `OrderedAddCommGroup`, a cone, and a proof that
-the order relation is the one defined by the cone.
--/
-theorem to_orderedSMul (C : ConvexCone 𝕜 M) (h : ∀ x y : M, x ≤ y ↔ y - x ∈ C) : OrderedSMul 𝕜 M :=
-  .mk' fun x y z xy hz ↦ by
-    rw [h (z • x) (z • y), ← smul_sub z y x]; exact C.smul_mem hz ((h x y).mp xy.le)
-
-end OrderedAddCommGroup
-
 end LinearOrderedField
 
 /-! ### Convex cones with extra properties -/

--- a/Mathlib/Geometry/Convex/Cone/Pointed.lean
+++ b/Mathlib/Geometry/Convex/Cone/Pointed.lean
@@ -181,4 +181,16 @@ theorem toConvexCone_positive : ↑(positive R E) = ConvexCone.positive R E :=
   rfl
 
 end PositiveCone
+
+section OrderedAddCommGroup
+variable [Semiring R] [PartialOrder R] [IsOrderedRing R] [AddCommGroup E] [PartialOrder E]
+  [Module R E]
+
+/-- Constructs an ordered module given an ordered group, a cone, and a proof that
+the order relation is the one defined by the cone. -/
+lemma to_posSMulMono (C : PointedCone R E) (h : ∀ x y : E, x ≤ y ↔ y - x ∈ C) :
+    PosSMulMono R E where
+  elim r hr x y := by simpa [h, ← smul_sub] using C.smul_mem ⟨r, hr⟩
+
+end OrderedAddCommGroup
 end PointedCone

--- a/Mathlib/Geometry/Convex/Cone/Pointed.lean
+++ b/Mathlib/Geometry/Convex/Cone/Pointed.lean
@@ -34,7 +34,7 @@ open Function
 section Definitions
 
 variable [Semiring R] [PartialOrder R] [IsOrderedRing R] [AddCommMonoid E] [Module R E]
-  {C₁ C₂ : PointedCone R E}
+  {C C₁ C₂ : PointedCone R E} {x : E} {r : R}
 
 /-- Every pointed cone is a convex cone. -/
 @[coe]
@@ -61,6 +61,9 @@ lemma convex (C : PointedCone R E) : Convex R (C : Set E) := C.toConvexCone.conv
 
 instance instZero (C : PointedCone R E) : Zero C :=
   ⟨0, C.zero_mem⟩
+
+nonrec lemma smul_mem (C : PointedCone R E) (hr : 0 ≤ r) (hx : x ∈ C) : r • x ∈ C :=
+  C.smul_mem ⟨r, hr⟩ hx
 
 /-- The `PointedCone` constructed from a pointed `ConvexCone`. -/
 def _root_.ConvexCone.toPointedCone (C : ConvexCone R E) (hC : C.Pointed) : PointedCone R E where
@@ -183,14 +186,13 @@ theorem toConvexCone_positive : ↑(positive R E) = ConvexCone.positive R E :=
 end PositiveCone
 
 section OrderedAddCommGroup
-variable [Semiring R] [PartialOrder R] [IsOrderedRing R] [AddCommGroup E] [PartialOrder E]
-  [Module R E]
+variable [Ring R] [PartialOrder R] [IsOrderedRing R] [AddCommGroup E] [PartialOrder E]
+  [IsOrderedAddMonoid E] [Module R E]
 
 /-- Constructs an ordered module given an ordered group, a cone, and a proof that
 the order relation is the one defined by the cone. -/
-lemma to_posSMulMono (C : PointedCone R E) (h : ∀ x y : E, x ≤ y ↔ y - x ∈ C) :
-    PosSMulMono R E where
-  elim r hr x y := by simpa [h, ← smul_sub] using C.smul_mem ⟨r, hr⟩
+lemma to_isOrderedModule (C : PointedCone R E) (h : ∀ x y : E, x ≤ y ↔ y - x ∈ C) :
+    IsOrderedModule R E := .of_smul_nonneg <| by simp +contextual [h, C.smul_mem]
 
 end OrderedAddCommGroup
 end PointedCone

--- a/Mathlib/LinearAlgebra/AffineSpace/Ordered.lean
+++ b/Mathlib/LinearAlgebra/AffineSpace/Ordered.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
 import Mathlib.Algebra.CharP.Invertible
-import Mathlib.Algebra.Order.Module.OrderedSMul
 import Mathlib.Algebra.Order.Module.Synonym
 import Mathlib.LinearAlgebra.AffineSpace.Midpoint
 import Mathlib.LinearAlgebra.AffineSpace.Slope
@@ -43,7 +42,7 @@ other arguments belong to specific domains.
 section OrderedRing
 
 variable [Ring k] [PartialOrder k] [IsOrderedRing k]
-  [AddCommGroup E] [PartialOrder E] [IsOrderedAddMonoid E] [Module k E] [OrderedSMul k E]
+  [AddCommGroup E] [PartialOrder E] [IsOrderedAddMonoid E] [Module k E] [IsStrictOrderedModule k E]
 variable {a a' b b' : E} {r r' : k}
 
 theorem lineMap_mono_left (ha : a ≤ a') (hr : r ≤ 1) : lineMap a b r ≤ lineMap a' b r := by
@@ -75,6 +74,8 @@ theorem lineMap_strict_mono_endpoints (ha : a < a') (hb : b < b') (h₀ : 0 ≤ 
   rcases h₀.eq_or_lt with (rfl | h₀); · simpa
   exact (lineMap_mono_left ha.le h₁).trans_lt (lineMap_strict_mono_right hb h₀)
 
+variable [PosSMulReflectLT k E]
+
 theorem lineMap_lt_lineMap_iff_of_lt (h : r < r') : lineMap a b r < lineMap a b r' ↔ a < b := by
   simp only [lineMap_apply_module]
   rw [← lt_sub_iff_add_lt, add_sub_assoc, ← sub_lt_iff_lt_add', ← sub_smul, ← sub_smul,
@@ -97,7 +98,7 @@ end OrderedRing
 section LinearOrderedRing
 
 variable [Ring k] [LinearOrder k] [IsStrictOrderedRing k]
-  [AddCommGroup E] [PartialOrder E] [IsOrderedAddMonoid E] [Module k E] [OrderedSMul k E]
+  [AddCommGroup E] [PartialOrder E] [IsOrderedAddMonoid E] [Module k E] [IsStrictOrderedModule k E]
   [Invertible (2 : k)] {a a' b b' : E} {r r' : k}
 
 theorem midpoint_le_midpoint (ha : a ≤ a') (hb : b ≤ b') : midpoint k a b ≤ midpoint k a' b' :=
@@ -109,7 +110,7 @@ section LinearOrderedField
 
 variable [Field k] [LinearOrder k] [IsStrictOrderedRing k]
   [AddCommGroup E] [PartialOrder E] [IsOrderedAddMonoid E]
-variable [Module k E] [OrderedSMul k E]
+variable [Module k E] [IsStrictOrderedModule k E] [PosSMulReflectLE k E]
 
 section
 

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/Basic.lean
@@ -442,7 +442,7 @@ theorem tendsto_condExp_unique (fs gs : ℕ → α → E) (f g : α → E)
       hgs_bound hgs
   exact tendsto_nhds_unique_of_eventuallyEq hcond_gs hcond_fs (Eventually.of_forall hn_eq)
 
-variable [PartialOrder E] [OrderClosedTopology E] [IsOrderedAddMonoid E] [OrderedSMul ℝ E]
+variable [PartialOrder E] [OrderClosedTopology E] [IsOrderedAddMonoid E] [IsOrderedModule ℝ E]
 
 lemma condExp_mono (hf : Integrable f μ) (hg : Integrable g μ) (hfg : f ≤ᵐ[μ] g) :
     μ[f|m] ≤ᵐ[μ] μ[g|m] := by

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL1.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL1.lean
@@ -318,7 +318,7 @@ theorem condExpInd_of_measurable (hs : MeasurableSet[m] s) (hμs : μ s ≠ ∞)
   by_cases hx_mem : x ∈ s <;> simp [hx_mem]
 
 theorem condExpInd_nonneg {E} [NormedAddCommGroup E] [PartialOrder E] [NormedSpace ℝ E]
-    [OrderedSMul ℝ E] (hs : MeasurableSet s) (hμs : μ s ≠ ∞) (x : E) (hx : 0 ≤ x) :
+    [IsOrderedModule ℝ E] (hs : MeasurableSet s) (hμs : μ s ≠ ∞) (x : E) (hx : 0 ≤ x) :
     0 ≤ condExpInd E hm μ s x := by
   rw [← coeFn_le]
   refine EventuallyLE.trans_eq ?_ (condExpInd_ae_eq_condExpIndSMul hm hs hμs x).symm
@@ -524,8 +524,8 @@ theorem condExpL1_of_aestronglyMeasurable' (hfm : AEStronglyMeasurable[m] f μ)
 
 theorem condExpL1_mono {E}
     [NormedAddCommGroup E] [PartialOrder E] [OrderClosedTopology E] [IsOrderedAddMonoid E]
-    [CompleteSpace E] [NormedSpace ℝ E]
-    [OrderedSMul ℝ E] {f g : α → E} (hf : Integrable f μ) (hg : Integrable g μ) (hfg : f ≤ᵐ[μ] g) :
+    [CompleteSpace E] [NormedSpace ℝ E] [IsOrderedModule ℝ E] {f g : α → E} (hf : Integrable f μ)
+    (hg : Integrable g μ) (hfg : f ≤ᵐ[μ] g) :
     condExpL1 hm μ f ≤ᵐ[μ] condExpL1 hm μ g := by
   rw [coeFn_le]
   have h_nonneg : ∀ s, MeasurableSet s → μ s < ∞ → ∀ x : E, 0 ≤ x → 0 ≤ condExpInd E hm μ s x :=

--- a/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL2.lean
+++ b/Mathlib/MeasureTheory/Function/ConditionalExpectation/CondexpL2.lean
@@ -458,7 +458,7 @@ theorem condExpL2_indicator_nonneg (hm : m ≤ m0) (hs : MeasurableSet s) (hμs 
     exact ENNReal.toReal_nonneg
 
 theorem condExpIndSMul_nonneg {E}
-    [NormedAddCommGroup E] [PartialOrder E] [NormedSpace ℝ E] [OrderedSMul ℝ E]
+    [NormedAddCommGroup E] [PartialOrder E] [NormedSpace ℝ E] [IsOrderedModule ℝ E]
     [SigmaFinite (μ.trim hm)] (hs : MeasurableSet s) (hμs : μ s ≠ ∞) (x : E) (hx : 0 ≤ x) :
     (0 : α → E) ≤ᵐ[μ] condExpIndSMul hm hs hμs x := by
   refine EventuallyLE.trans_eq ?_ (condExpIndSMul_ae_eq_smul hm hs hμs x).symm

--- a/Mathlib/MeasureTheory/Integral/Bochner/Basic.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/Basic.lean
@@ -571,7 +571,7 @@ theorem integral_eq_integral_pos_part_sub_integral_neg_part {f : α → ℝ} (hf
 
 section Order
 
-variable [PartialOrder E] [IsOrderedAddMonoid E] [OrderedSMul ℝ E] [OrderClosedTopology E]
+variable [PartialOrder E] [IsOrderedAddMonoid E] [IsOrderedModule ℝ E] [OrderClosedTopology E]
 
 /-- The integral of a function which is nonnegative almost everywhere is nonnegative. -/
 lemma integral_nonneg_of_ae {f : α → E} (hf : 0 ≤ᵐ[μ] f) :

--- a/Mathlib/MeasureTheory/Integral/Bochner/L1.lean
+++ b/Mathlib/MeasureTheory/Integral/Bochner/L1.lean
@@ -136,7 +136,7 @@ theorem dominatedFinMeasAdditive_weightedSMul {_ : MeasurableSpace α} (μ : Mea
     DominatedFinMeasAdditive μ (weightedSMul μ : Set α → F →L[ℝ] F) 1 :=
   ⟨weightedSMul_union, fun s _ _ => (norm_weightedSMul_le s).trans (one_mul _).symm.le⟩
 
-theorem weightedSMul_nonneg [PartialOrder F] [OrderedSMul ℝ F]
+theorem weightedSMul_nonneg [PartialOrder F] [IsOrderedModule ℝ F]
     (s : Set α) (x : F) (hx : 0 ≤ x) : 0 ≤ weightedSMul μ s x := by
   simp only [weightedSMul, coe_smul', _root_.id, coe_id', Pi.smul_apply]
   exact smul_nonneg toReal_nonneg hx
@@ -319,7 +319,7 @@ theorem integral_add_measure {ν} (f : α →ₛ E) (hf : Integrable f (μ + ν)
 
 section Order
 
-variable [PartialOrder F] [IsOrderedAddMonoid F] [OrderedSMul ℝ F]
+variable [PartialOrder F] [IsOrderedAddMonoid F] [IsOrderedModule ℝ F]
 
 lemma integral_nonneg {f : α →ₛ F} (hf : 0 ≤ᵐ[μ] f) :
     0 ≤ f.integral μ := by

--- a/Mathlib/Probability/Martingale/Basic.lean
+++ b/Mathlib/Probability/Martingale/Basic.lean
@@ -299,7 +299,7 @@ theorem sub_martingale [Preorder E] [AddLeftMono E]
 section
 
 variable {F : Type*} [NormedAddCommGroup F] [Lattice F] [NormedSpace ℝ F] [CompleteSpace F]
-  [OrderedSMul ℝ F]
+  [IsOrderedModule ℝ F]
 
 theorem smul_nonneg {f : ι → Ω → F} {c : ℝ} (hc : 0 ≤ c) (hf : Supermartingale f ℱ μ) :
     Supermartingale (c • f) ℱ μ := by
@@ -322,7 +322,7 @@ namespace Submartingale
 section
 
 variable {F : Type*} [NormedAddCommGroup F] [Lattice F] [IsOrderedAddMonoid F]
-  [NormedSpace ℝ F] [CompleteSpace F] [OrderedSMul ℝ F]
+  [NormedSpace ℝ F] [CompleteSpace F] [IsOrderedModule ℝ F]
 
 theorem smul_nonneg {f : ι → Ω → F} {c : ℝ} (hc : 0 ≤ c) (hf : Submartingale f ℱ μ) :
     Submartingale (c • f) ℱ μ := by

--- a/Mathlib/Tactic/LinearCombination/Lemmas.lean
+++ b/Mathlib/Tactic/LinearCombination/Lemmas.lean
@@ -3,7 +3,8 @@ Copyright (c) 2022 Abby J. Goldberg. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Abby J. Goldberg, Mario Carneiro, Heather Macbeth
 -/
-import Mathlib.Algebra.Order.Module.OrderedSMul
+import Mathlib.Algebra.Field.Defs
+import Mathlib.Algebra.Order.Module.Defs
 import Mathlib.Data.Ineq
 
 /-!
@@ -81,19 +82,19 @@ theorem smul_eq_const [SMul K α] (p : t = s) (c : α) : t • c = s • c := p 
 
 theorem smul_le_const [Ring K] [PartialOrder K] [IsOrderedRing K]
     [AddCommGroup α] [PartialOrder α] [IsOrderedAddMonoid α] [Module K α]
-    [OrderedSMul K α] (p : t ≤ s) {a : α} (ha : 0 ≤ a) :
+    [IsOrderedModule K α] (p : t ≤ s) {a : α} (ha : 0 ≤ a) :
     t • a ≤ s • a :=
   smul_le_smul_of_nonneg_right p ha
 
 theorem smul_lt_const [Ring K] [PartialOrder K] [IsOrderedRing K]
     [AddCommGroup α] [PartialOrder α] [IsOrderedAddMonoid α] [Module K α]
-    [OrderedSMul K α] (p : t < s) {a : α} (ha : 0 < a) :
+    [IsStrictOrderedModule K α] (p : t < s) {a : α} (ha : 0 < a) :
     t • a < s • a :=
   smul_lt_smul_of_pos_right p ha
 
 theorem smul_lt_const_weak [Ring K] [PartialOrder K] [IsOrderedRing K]
     [AddCommGroup α] [PartialOrder α] [IsOrderedAddMonoid α] [Module K α]
-    [OrderedSMul K α] (p : t < s) {a : α} (ha : 0 ≤ a) :
+    [IsStrictOrderedModule K α] (p : t < s) {a : α} (ha : 0 ≤ a) :
     t • a ≤ s • a :=
   smul_le_smul_of_nonneg_right p.le ha
 
@@ -101,19 +102,19 @@ theorem smul_const_eq [SMul K α] (p : b = c) (s : K) : s • b = s • c := p �
 
 theorem smul_const_le [Semiring K] [PartialOrder K]
     [AddCommMonoid α] [PartialOrder α] [Module K α]
-    [OrderedSMul K α] (p : b ≤ c) {s : K} (hs : 0 ≤ s) :
+    [PosSMulMono K α] (p : b ≤ c) {s : K} (hs : 0 ≤ s) :
     s • b ≤ s • c :=
   smul_le_smul_of_nonneg_left p hs
 
 theorem smul_const_lt [Semiring K] [PartialOrder K]
     [AddCommMonoid α] [PartialOrder α] [Module K α]
-    [OrderedSMul K α] (p : b < c) {s : K} (hs : 0 < s) :
+    [PosSMulStrictMono K α] (p : b < c) {s : K} (hs : 0 < s) :
     s • b < s • c :=
   smul_lt_smul_of_pos_left p hs
 
 theorem smul_const_lt_weak [Semiring K] [PartialOrder K]
     [AddCommMonoid α] [PartialOrder α] [Module K α]
-    [OrderedSMul K α] (p : b < c) {s : K} (hs : 0 ≤ s) :
+    [PosSMulMono K α] (p : b < c) {s : K} (hs : 0 ≤ s) :
     s • b ≤ s • c :=
   smul_le_smul_of_nonneg_left p.le hs
 

--- a/MathlibTest/linear_combination.lean
+++ b/MathlibTest/linear_combination.lean
@@ -152,8 +152,8 @@ example (h : a + b ≠ 0) (H : a • x = b • y) : x = (b / (a + b)) • (x + y
 
 end
 
-example [CommSemiring K] [PartialOrder K] [IsOrderedRing K]
-    [AddCommMonoid V] [PartialOrder V] [IsOrderedCancelAddMonoid V] [Module K V] [OrderedSMul K V]
+example [CommSemiring K] [PartialOrder K] [IsOrderedRing K] [AddCommMonoid V] [PartialOrder V]
+    [IsOrderedCancelAddMonoid V] [Module K V] [PosSMulStrictMono K V]
     {x y r : V} (hx : x < r) (hy : y < r) {a b : K} (ha : 0 < a) (hb : 0 ≤ b) (hab : a + b = 1) :
     a • x + b • y < r := by
   linear_combination (norm := skip) a • hx + b • hy + hab • r
@@ -161,16 +161,16 @@ example [CommSemiring K] [PartialOrder K] [IsOrderedRing K]
   module
 
 example [CommSemiring K] [PartialOrder K] [IsOrderedRing K]
-    [AddCommMonoid V] [PartialOrder V] [IsOrderedCancelAddMonoid V] [Module K V] [OrderedSMul K V]
+    [AddCommMonoid V] [PartialOrder V] [IsOrderedCancelAddMonoid V] [Module K V] [PosSMulMono K V]
     {x y z : V} (hyz : y ≤ z) {a b : K} (hb : 0 ≤ b) (hab : a + b = 1) (H : z ≤ a • x + b • y) :
     a • z ≤ a • x := by
   linear_combination (norm := skip) b • hyz + hab • z + H
   apply le_of_eq
   module
 
-example [CommRing K] [PartialOrder K] [IsOrderedRing K]
-    [AddCommGroup V] [PartialOrder V] [IsOrderedAddMonoid V] [Module K V] [OrderedSMul K V]
-    {x y : V} (hx : 0 < x) (hxy : x < y) {a b c : K} (hc : 0 < c) (hac : c < a) (hab : a + b ≤ 1):
+example [CommRing K] [PartialOrder K] [IsOrderedRing K] [AddCommGroup V] [PartialOrder V]
+    [IsOrderedAddMonoid V] [Module K V] [IsStrictOrderedModule K V]
+    {x y : V} (hx : 0 < x) (hxy : x < y) {a b c : K} (hc : 0 < c) (hac : c < a) (hab : a + b ≤ 1) :
     c • x + b • y < y := by
   have := hx.trans hxy
   linear_combination (norm := skip) hab • y + hac • y + c • hxy

--- a/MathlibTest/positivity.lean
+++ b/MathlibTest/positivity.lean
@@ -206,7 +206,7 @@ example {a : ℤ} {b : ℚ} (ha : a ≠ 0) (hb : b ≠ 0) : a • b ≠ 0 := by 
 -- Test that the positivity extension for `a • b` can handle universe polymorphism.
 example {R M : Type*} [Semiring R] [PartialOrder R] [IsOrderedRing R]
     [Semiring M] [PartialOrder M] [IsStrictOrderedRing M]
-    [SMulWithZero R M] [OrderedSMul R M] {a : R} {b : M} (ha : 0 < a) (hb : 0 < b) :
+    [SMulWithZero R M] [PosSMulStrictMono R M] {a : R} {b : M} (ha : 0 < a) (hb : 0 < b) :
     0 < a • b := by positivity
 
 example {a : ℤ} (ha : 3 < a) : 0 ≤ a + a := by positivity
@@ -376,7 +376,7 @@ example {R : Type*} [Zero R] [Div R] [LinearOrder R] {a b c : R} (_h1 : 0 < a) (
 example
     [Semiring α] [PartialOrder α] [IsOrderedRing α]
     [AddCommMonoid β] [PartialOrder β] [IsOrderedAddMonoid β] [SMulWithZero α β]
-    [OrderedSMul α β] {a : α} (ha : 0 < a) {b : β} (hb : 0 < b) : 0 ≤ a • b := by
+    [PosSMulMono α β] {a : α} (ha : 0 < a) {b : β} (hb : 0 < b) : 0 ≤ a • b := by
   positivity
 
 example (n : ℕ) : 0 < n.succ := by positivity


### PR DESCRIPTION
I follow the pattern of `IsOrderedRing`/`IsStrictOrderedRing` by introducing two analogous typeclasses `IsOrderedModule`/`IsStrictOrderedModule`.


---

- [x] depends on: #28851
- [x] depends on: #28852
- [x] depends on: #28900
- [x] depends on: #28902
- [x] depends on: #29340

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
