### PR TITLE
[Merged by Bors] - feat(Data/Setoid/Basic): add theorems about lifting a function to its kernel

### DIFF
--- a/Counterexamples/AharoniKorman.lean
+++ b/Counterexamples/AharoniKorman.lean
@@ -545,7 +545,7 @@ theorem exists_partition_iff_nonempty_spinalMap
   · rintro ⟨f⟩
     refine ⟨_, (Setoid.ker f).isPartition_classes, ?_⟩
     rintro _ ⟨x, rfl⟩
-    exact ⟨f.fibre_antichain _, f x, by simp [Setoid.ker, Function.onFun]⟩
+    exact ⟨f.fibre_antichain _, f x, by simp⟩
 
 variable {f : SpinalMap C}
 

--- a/Mathlib/Data/Setoid/Basic.lean
+++ b/Mathlib/Data/Setoid/Basic.lean
@@ -339,7 +339,7 @@ theorem ker_eq_lift_of_injective {r : Setoid α} (f : α → β) (H : r ≤ ker 
       Quotient.exact <| h <| show Quotient.lift f H ⟦x⟧ = Quotient.lift f H ⟦y⟧ from hk)
     H
 
-theorem lift_injective_iff_ker_eq_of_le {r : Setoid α} (f : α → β)
+theorem lift_injective_iff_ker_eq_of_le {r : Setoid α} {f : α → β}
     (hle : r ≤ ker f) : Injective (Quotient.lift f hle) ↔ ker f = r :=
   ⟨ker_eq_lift_of_injective f hle, fun h ↦ h ▸ kerLift_injective _⟩
 

--- a/Mathlib/Data/Setoid/Basic.lean
+++ b/Mathlib/Data/Setoid/Basic.lean
@@ -339,6 +339,10 @@ theorem ker_eq_lift_of_injective {r : Setoid α} (f : α → β) (H : r ≤ ker 
       Quotient.exact <| h <| show Quotient.lift f H ⟦x⟧ = Quotient.lift f H ⟦y⟧ from hk)
     H
 
+theorem lift_injective_iff_ker_eq_of_le {r : Setoid α} (f : α → β)
+    (hle : r ≤ ker f) : Injective (Quotient.lift f hle) ↔ ker f = r :=
+  ⟨ker_eq_lift_of_injective f hle, fun h ↦ h ▸ kerLift_injective _⟩
+
 variable (r : Setoid α) (f : α → β)
 
 /-- The image of `f` lifted to the quotient by its kernel is equal to the image of `f` itself. -/

--- a/Mathlib/Data/Setoid/Basic.lean
+++ b/Mathlib/Data/Setoid/Basic.lean
@@ -346,7 +346,7 @@ theorem lift_injective_iff_ker_eq_of_le {r : Setoid α} {f : α → β}
 variable (r : Setoid α) (f : α → β)
 
 /-- The image of `f` lifted to the quotient by its kernel is equal to the image of `f` itself. -/
-theorem range_kerLift_eq_range : Set.range (kerLift f) = Set.range f :=
+@[simp] theorem range_kerLift_eq_range : Set.range (kerLift f) = Set.range f :=
   Set.range_quotient_lift (s := ker f) _
 
 /-- The quotient of `α` by the kernel of a function `f`

--- a/Mathlib/Data/Setoid/Basic.lean
+++ b/Mathlib/Data/Setoid/Basic.lean
@@ -360,7 +360,7 @@ domain. -/
 def quotientKerEquivOfRightInverse (g : β → α) (hf : Function.RightInverse g f) :
     Quotient (ker f) ≃ β where
   toFun := kerLift f
-  invFun := Quotient.mk'' ∘ g
+  invFun b := Quotient.mk'' (g b)
   left_inv a := Quotient.inductionOn' a fun a => Quotient.sound' <| hf (f a)
   right_inv := hf
 

--- a/Mathlib/Data/Setoid/Basic.lean
+++ b/Mathlib/Data/Setoid/Basic.lean
@@ -6,7 +6,6 @@ Authors: Amelia Livingston, Bryan Gin-ge Chen
 import Mathlib.Logic.Relation
 import Mathlib.Order.CompleteLattice.Basic
 import Mathlib.Order.GaloisConnection.Defs
-import Mathlib.Tactic.NthRewrite
 
 /-!
 # Equivalence relations

--- a/Mathlib/Data/Setoid/Basic.lean
+++ b/Mathlib/Data/Setoid/Basic.lean
@@ -317,10 +317,12 @@ theorem lift_unique {r : Setoid α} {f : α → β} (H : r ≤ ker f) (g : Quoti
   rw [← Quotient.mk, Quotient.lift_mk f H, Hg, Function.comp_apply, Quotient.mk''_eq_mk]
 
 /-- Given a function `f`, lift it to the quotient by its kernel. -/
-def kerLift (f : α → β) : Quotient (ker f) → β := Quotient.lift f fun _ _ ↦ id
+def kerLift (f : α → β) : Quotient (ker f) → β :=
+  Quotient.lift f fun _ _ ↦ id
 
 @[simp]
-theorem kerLift_mk (f : α → β) (x : α) : kerLift f ⟦x⟧ = f x := rfl
+theorem kerLift_mk (f : α → β) (x : α) : kerLift f ⟦x⟧ = f x :=
+  rfl
 
 /-- Given a map f from α to β, the natural map from the quotient of α by the kernel of f is
 injective. -/

--- a/Mathlib/Data/Setoid/Basic.lean
+++ b/Mathlib/Data/Setoid/Basic.lean
@@ -317,7 +317,7 @@ theorem lift_unique {r : Setoid α} {f : α → β} (H : r ≤ ker f) (g : Quoti
   rw [← Quotient.mk, Quotient.lift_mk f H, Hg, Function.comp_apply, Quotient.mk''_eq_mk]
 
 /-- Given a function `f`, lift it to the quotient by its kernel. -/
-abbrev kerLift (f : α → β) : Quotient (ker f) → β := Quotient.lift f fun _ _ ↦ id
+def kerLift (f : α → β) : Quotient (ker f) → β := Quotient.lift f fun _ _ ↦ id
 
 @[simp]
 theorem kerLift_mk (f : α → β) (x : α) : kerLift f ⟦x⟧ = f x := rfl

--- a/Mathlib/Data/Setoid/Basic.lean
+++ b/Mathlib/Data/Setoid/Basic.lean
@@ -324,10 +324,10 @@ theorem kerLift_mk (f : α → β) (x : α) : kerLift f ⟦x⟧ = f x := rfl
 
 /-- Given a map f from α to β, the natural map from the quotient of α by the kernel of f is
 injective. -/
-theorem injective_kerLift (f : α → β) : Injective <| kerLift f :=
+theorem kerLift_injective (f : α → β) : Injective <| kerLift f :=
   fun x y => Quotient.inductionOn₂' x y fun _ _ h => Quotient.sound' h
 
-@[deprecated (since := "2025-10-11")] alias ker_lift_injective := injective_kerLift
+@[deprecated (since := "2025-10-11")] alias ker_lift_injective := kerLift_injective
 
 /-- Given a map f from α to β, the kernel of f is the unique equivalence relation on α whose
 induced map from the quotient of α to β is injective. -/
@@ -347,7 +347,7 @@ theorem range_kerLift_eq_range : Set.range (kerLift f) = Set.range f :=
 /-- The quotient of `α` by the kernel of a function `f`
 bijects with the image of `f` lifted to the quotient. -/
 noncomputable def quotientKerEquivRangeKerLift : Quotient (ker f) ≃ Set.range (kerLift f) :=
-  .ofInjective _ <| injective_kerLift _
+  .ofInjective _ <| kerLift_injective _
 
 /-- The first isomorphism theorem for sets: the quotient of α by the kernel of a function f
 bijects with f's image. -/

--- a/Mathlib/Data/Setoid/Basic.lean
+++ b/Mathlib/Data/Setoid/Basic.lean
@@ -6,6 +6,7 @@ Authors: Amelia Livingston, Bryan Gin-ge Chen
 import Mathlib.Logic.Relation
 import Mathlib.Order.CompleteLattice.Basic
 import Mathlib.Order.GaloisConnection.Defs
+import Mathlib.Tactic.NthRewrite
 
 /-!
 # Equivalence relations
@@ -77,6 +78,7 @@ theorem ker_mk_eq (r : Setoid α) : ker (@Quotient.mk'' _ r) = r :=
 theorem ker_apply_mk_out {f : α → β} (a : α) : f (⟦a⟧ : Quotient (Setoid.ker f)).out = f a :=
   @Quotient.mk_out _ (Setoid.ker f) a
 
+@[simp]
 theorem ker_def {f : α → β} {x y : α} : ker f x y ↔ f x = f y :=
   Iff.rfl
 
@@ -314,14 +316,22 @@ theorem lift_unique {r : Setoid α} {f : α → β} (H : r ≤ ker f) (g : Quoti
   ext ⟨x⟩
   rw [← Quotient.mk, Quotient.lift_mk f H, Hg, Function.comp_apply, Quotient.mk''_eq_mk]
 
+/-- Given a function `f`, lift it to the quotient by its kernel. -/
+abbrev kerLift (f : α → β) : Quotient (ker f) → β := Quotient.lift f fun _ _ ↦ id
+
+@[simp]
+theorem kerLift_mk (f : α → β) (x : α) : kerLift f ⟦x⟧ = f x := rfl
+
 /-- Given a map f from α to β, the natural map from the quotient of α by the kernel of f is
 injective. -/
-theorem ker_lift_injective (f : α → β) : Injective (@Quotient.lift _ _ (ker f) f fun _ _ h => h) :=
+theorem injective_kerLift (f : α → β) : Injective <| kerLift f :=
   fun x y => Quotient.inductionOn₂' x y fun _ _ h => Quotient.sound' h
+
+@[deprecated (since := "2025-10-11")] alias ker_lift_injective := injective_kerLift
 
 /-- Given a map f from α to β, the kernel of f is the unique equivalence relation on α whose
 induced map from the quotient of α to β is injective. -/
-theorem ker_eq_lift_of_injective {r : Setoid α} (f : α → β) (H : ∀ x y, r x y → f x = f y)
+theorem ker_eq_lift_of_injective {r : Setoid α} (f : α → β) (H : r ≤ ker f)
     (h : Injective (Quotient.lift f H)) : ker f = r :=
   le_antisymm
     (fun x y hk =>
@@ -330,23 +340,27 @@ theorem ker_eq_lift_of_injective {r : Setoid α} (f : α → β) (H : ∀ x y, r
 
 variable (r : Setoid α) (f : α → β)
 
+/-- The image of `f` lifted to the quotient by its kernel is equal to the image of `f` itself. -/
+theorem range_kerLift_eq_range : Set.range (kerLift f) = Set.range f :=
+  Set.range_quotient_lift (s := ker f) _
+
+/-- The quotient of `α` by the kernel of a function `f`
+bijects with the image of `f` lifted to the quotient. -/
+noncomputable def quotientKerEquivRangeKerLift : Quotient (ker f) ≃ Set.range (kerLift f) :=
+  .ofInjective _ <| injective_kerLift _
+
 /-- The first isomorphism theorem for sets: the quotient of α by the kernel of a function f
 bijects with f's image. -/
 noncomputable def quotientKerEquivRange : Quotient (ker f) ≃ Set.range f :=
-  Equiv.ofBijective
-    ((@Quotient.lift _ (Set.range f) (ker f) fun x => ⟨f x, Set.mem_range_self x⟩) fun _ _ h =>
-      Subtype.ext h)
-    ⟨fun x y h => ker_lift_injective f <| by rcases x with ⟨⟩; rcases y with ⟨⟩; injections,
-      fun ⟨_, z, hz⟩ =>
-      ⟨@Quotient.mk'' _ (ker f) z, Subtype.ext_iff.2 hz⟩⟩
+  quotientKerEquivRangeKerLift _ |>.trans <| .setCongr <| range_kerLift_eq_range _
 
 /-- If `f` has a computable right-inverse, then the quotient by its kernel is equivalent to its
 domain. -/
 @[simps]
 def quotientKerEquivOfRightInverse (g : β → α) (hf : Function.RightInverse g f) :
     Quotient (ker f) ≃ β where
-  toFun a := (Quotient.liftOn' a f) fun _ _ => id
-  invFun b := Quotient.mk'' (g b)
+  toFun := kerLift f
+  invFun := Quotient.mk'' ∘ g
   left_inv a := Quotient.inductionOn' a fun a => Quotient.sound' <| hf (f a)
   right_inv := hf
 

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/FundamentalCone.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/FundamentalCone.lean
@@ -391,12 +391,10 @@ def integerSetQuotEquivAssociates :
   Equiv.ofBijective
     (Quotient.lift (integerSetToAssociates K)
       fun _ _ h ↦ ((integerSetToAssociates_eq_iff _ _).mpr h).symm)
-    ⟨by convert Setoid.kerLift_injective (integerSetToAssociates K)
-        swap; focus unfold Setoid.kerLift; congr!
-        all_goals
-        · ext a b
-          rw [Setoid.ker_def, eq_comm, integerSetToAssociates_eq_iff b a,
-            MulAction.orbitRel_apply, MulAction.mem_orbit_iff],
+    ⟨Setoid.lift_injective_iff_ker_eq_of_le _ _ |>.mpr <| by
+        ext a b
+        rw [Setoid.ker_def, eq_comm, integerSetToAssociates_eq_iff b a,
+          MulAction.orbitRel_apply, MulAction.mem_orbit_iff],
         (Quot.surjective_lift _).mpr (integerSetToAssociates_surjective K)⟩
 
 @[simp]

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/FundamentalCone.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/FundamentalCone.lean
@@ -391,7 +391,7 @@ def integerSetQuotEquivAssociates :
   Equiv.ofBijective
     (Quotient.lift (integerSetToAssociates K)
       fun _ _ h ↦ ((integerSetToAssociates_eq_iff _ _).mpr h).symm)
-    ⟨Setoid.lift_injective_iff_ker_eq_of_le _ _ |>.mpr <| by
+    ⟨Setoid.lift_injective_iff_ker_eq_of_le _ |>.mpr <| by
         ext a b
         rw [Setoid.ker_def, eq_comm, integerSetToAssociates_eq_iff b a,
           MulAction.orbitRel_apply, MulAction.mem_orbit_iff],

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/FundamentalCone.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/FundamentalCone.lean
@@ -391,7 +391,7 @@ def integerSetQuotEquivAssociates :
   Equiv.ofBijective
     (Quotient.lift (integerSetToAssociates K)
       fun _ _ h ↦ ((integerSetToAssociates_eq_iff _ _).mpr h).symm)
-    ⟨by convert Setoid.ker_lift_injective (integerSetToAssociates K)
+    ⟨by convert Setoid.injective_kerLift (integerSetToAssociates K)
         all_goals
         · ext a b
           rw [Setoid.ker_def, eq_comm, integerSetToAssociates_eq_iff b a,

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/FundamentalCone.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/FundamentalCone.lean
@@ -391,7 +391,7 @@ def integerSetQuotEquivAssociates :
   Equiv.ofBijective
     (Quotient.lift (integerSetToAssociates K)
       fun _ _ h ↦ ((integerSetToAssociates_eq_iff _ _).mpr h).symm)
-    ⟨by convert Setoid.injective_kerLift (integerSetToAssociates K)
+    ⟨by convert Setoid.kerLift_injective (integerSetToAssociates K)
         swap; focus unfold Setoid.kerLift; congr!
         all_goals
         · ext a b

--- a/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/FundamentalCone.lean
+++ b/Mathlib/NumberTheory/NumberField/CanonicalEmbedding/FundamentalCone.lean
@@ -392,6 +392,7 @@ def integerSetQuotEquivAssociates :
     (Quotient.lift (integerSetToAssociates K)
       fun _ _ h ↦ ((integerSetToAssociates_eq_iff _ _).mpr h).symm)
     ⟨by convert Setoid.injective_kerLift (integerSetToAssociates K)
+        swap; focus unfold Setoid.kerLift; congr!
         all_goals
         · ext a b
           rw [Setoid.ker_def, eq_comm, integerSetToAssociates_eq_iff b a,

--- a/Mathlib/Topology/Separation/Hausdorff.lean
+++ b/Mathlib/Topology/Separation/Hausdorff.lean
@@ -445,7 +445,7 @@ lemma compatible {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] [T2Spac
     ∀ (a b : X), a ≈ b → f a = f b := by
   change t2Setoid X ≤ Setoid.ker f
   exact sInf_le <| .of_injective_continuous
-    (Setoid.injective_kerLift _) (hf.quotient_lift fun _ _ ↦ id)
+    (Setoid.kerLift_injective _) (hf.quotient_lift fun _ _ ↦ id)
 
 /-- The universal property of the largest T2 quotient of a topological space `X`: any continuous
 map from `X` to a T2 space `Y` uniquely factors through `T2Quotient X`. This declaration builds the

--- a/Mathlib/Topology/Separation/Hausdorff.lean
+++ b/Mathlib/Topology/Separation/Hausdorff.lean
@@ -445,7 +445,7 @@ lemma compatible {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] [T2Spac
     ∀ (a b : X), a ≈ b → f a = f b := by
   change t2Setoid X ≤ Setoid.ker f
   exact sInf_le <| .of_injective_continuous
-    (Setoid.ker_lift_injective _) (hf.quotient_lift fun _ _ ↦ id)
+    (Setoid.injective_kerLift _) (hf.quotient_lift fun _ _ ↦ id)
 
 /-- The universal property of the largest T2 quotient of a topological space `X`: any continuous
 map from `X` to a T2 space `Y` uniquely factors through `T2Quotient X`. This declaration builds the


### PR DESCRIPTION
Currently `ker_lift_injective` and `quotientKerEquivOfRightInverse` lift `f` to `ker f` in their definition.
This PR makes this function available as `Setoid.kerLift f` and adds a few more theorems about it.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
