### PR TITLE
feat(CategoryTheory): Additive and Linear when Hom types are only monoids

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -170,6 +170,7 @@ import Mathlib.Algebra.Category.ModuleCat.Presheaf.Sheafify
 import Mathlib.Algebra.Category.ModuleCat.Products
 import Mathlib.Algebra.Category.ModuleCat.Projective
 import Mathlib.Algebra.Category.ModuleCat.Pseudofunctor
+import Mathlib.Algebra.Category.ModuleCat.Semi
 import Mathlib.Algebra.Category.ModuleCat.Sheaf
 import Mathlib.Algebra.Category.ModuleCat.Sheaf.Abelian
 import Mathlib.Algebra.Category.ModuleCat.Sheaf.ChangeOfRings
@@ -190,6 +191,7 @@ import Mathlib.Algebra.Category.MonCat.Basic
 import Mathlib.Algebra.Category.MonCat.Colimits
 import Mathlib.Algebra.Category.MonCat.FilteredColimits
 import Mathlib.Algebra.Category.MonCat.ForgetCorepresentable
+import Mathlib.Algebra.Category.MonCat.Presemiadditive
 import Mathlib.Algebra.Category.MonCat.Limits
 import Mathlib.Algebra.Category.MonCat.Yoneda
 import Mathlib.Algebra.Category.Ring.Adjunctions
@@ -2584,6 +2586,7 @@ import Mathlib.CategoryTheory.Preadditive.Projective.LiftingProperties
 import Mathlib.CategoryTheory.Preadditive.Projective.Preserves
 import Mathlib.CategoryTheory.Preadditive.Projective.Resolution
 import Mathlib.CategoryTheory.Preadditive.Schur
+import Mathlib.CategoryTheory.Preadditive.Semi
 import Mathlib.CategoryTheory.Preadditive.SingleObj
 import Mathlib.CategoryTheory.Preadditive.Transfer
 import Mathlib.CategoryTheory.Preadditive.Yoneda.Basic

--- a/Mathlib/Algebra/Category/ModuleCat/Semi.lean
+++ b/Mathlib/Algebra/Category/ModuleCat/Semi.lean
@@ -1,0 +1,573 @@
+/-
+Copyright (c) 2025 Junyan Xu. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert A. Spencer, Junyan Xu
+-/
+import Mathlib.Algebra.Category.MonCat.Presemiadditive
+import Mathlib.Algebra.Module.Equiv.Basic
+import Mathlib.Algebra.Module.PUnit
+import Mathlib.CategoryTheory.Conj
+import Mathlib.CategoryTheory.Linear.Basic
+import Mathlib.CategoryTheory.Preadditive.AdditiveFunctor
+
+/-!
+# The category of `R`-modules
+
+If `R` is a semiring, `SemimoduleCat.{v} R` is the category of bundled `R`-modules with carrier
+in the universe `v`. We  show that it is preadditive and show that being an isomorphism and
+monomorphism are equivalent to being a linear equivalence and an injective linear map respectively.
+
+## Implementation details
+
+To construct an object in the category of `R`-modules from a type `M` with an instance of the
+`Module` typeclass, write `of R M`. There is a coercion in the other direction.
+The roundtrip `↑(of R M)` is definitionally equal to `M` itself (when `M` is a type with `Module`
+instance), and so is `of R ↑M` (when `M : SemimoduleCat R M`).
+
+The morphisms are given their own type, not identified with `LinearMap`.
+There is a cast from morphisms in `Module R` to linear maps,
+written `f.hom` (`SemimoduleCat.Hom.hom`).
+To go from linear maps to morphisms in `Module R`, use `SemimoduleCat.ofHom`.
+
+Similarly, given an isomorphism `f : M ≅ N` use `f.toLinearEquiv` and given a linear equiv
+`f : M ≃ₗ[R] N`, use `f.toModuleIso`.
+-/
+
+
+open CategoryTheory Limits WalkingParallelPair
+
+universe v u
+
+variable (R : Type u) [Semiring R]
+
+/-- The category of R-modules and their morphisms.
+
+Note that in the case of `R = ℕ`, we can not
+impose here that the `ℕ`-multiplication field from the module structure is defeq to the one coming
+from the `isAddCommMonoid` structure (contrary to what we do for all module structures in
+mathlib), which creates some difficulties down the road. -/
+structure SemimoduleCat where
+  private mk ::
+  /-- the underlying type of an object in `SemimoduleCat R` -/
+  carrier : Type v
+  [isAddCommMonoid : AddCommMonoid carrier]
+  [isModule : Module R carrier]
+
+attribute [instance] SemimoduleCat.isAddCommMonoid SemimoduleCat.isModule
+
+namespace SemimoduleCat
+
+instance : CoeSort (SemimoduleCat.{v} R) (Type v) :=
+  ⟨SemimoduleCat.carrier⟩
+
+attribute [coe] SemimoduleCat.carrier
+
+/-- The object in the category of R-algebras associated to a type equipped with the appropriate
+typeclasses. This is the preferred way to construct a term of `SemimoduleCat R`. -/
+abbrev of (X : Type v) [AddCommMonoid X] [Module R X] : SemimoduleCat.{v} R :=
+  ⟨X⟩
+
+lemma coe_of (X : Type v) [Semiring X] [Module R X] : (of R X : Type v) = X :=
+  rfl
+
+-- Ensure the roundtrips are reducibly defeq (so tactics like `rw` can see through them).
+example (X : Type v) [Semiring X] [Module R X] : (of R X : Type v) = X := by with_reducible rfl
+example (M : SemimoduleCat.{v} R) : of R M = M := by with_reducible rfl
+
+variable {R} in
+/-- The type of morphisms in `SemimoduleCat R`. -/
+@[ext]
+structure Hom (M N : SemimoduleCat.{v} R) where
+  private mk ::
+  /-- The underlying linear map. -/
+  hom' : M →ₗ[R] N
+
+instance moduleCategory : Category.{v, max (v+1) u} (SemimoduleCat.{v} R) where
+  Hom M N := Hom M N
+  id _ := ⟨LinearMap.id⟩
+  comp f g := ⟨g.hom'.comp f.hom'⟩
+
+instance : ConcreteCategory (SemimoduleCat.{v} R) (· →ₗ[R] ·) where
+  hom := Hom.hom'
+  ofHom := Hom.mk
+
+section
+
+variable {R}
+
+/-- Turn a morphism in `SemimoduleCat` back into a `LinearMap`. -/
+abbrev Hom.hom {A B : SemimoduleCat.{v} R} (f : Hom A B) :=
+  ConcreteCategory.hom (C := SemimoduleCat R) f
+
+/-- Typecheck a `LinearMap` as a morphism in `SemimoduleCat`. -/
+abbrev ofHom {X Y : Type v} [AddCommMonoid X] [Module R X] [AddCommMonoid Y] [Module R Y]
+    (f : X →ₗ[R] Y) : of R X ⟶ of R Y :=
+  ConcreteCategory.ofHom (C := SemimoduleCat R) f
+
+/-- Use the `ConcreteCategory.hom` projection for `@[simps]` lemmas. -/
+def Hom.Simps.hom (A B : SemimoduleCat.{v} R) (f : Hom A B) :=
+  f.hom
+
+initialize_simps_projections Hom (hom' → hom)
+
+/-!
+The results below duplicate the `ConcreteCategory` simp lemmas, but we can keep them for `dsimp`.
+-/
+
+@[simp]
+lemma hom_id {M : SemimoduleCat.{v} R} : (𝟙 M : M ⟶ M).hom = LinearMap.id := rfl
+
+/- Provided for rewriting. -/
+lemma id_apply (M : SemimoduleCat.{v} R) (x : M) :
+    (𝟙 M : M ⟶ M) x = x := by simp
+
+@[simp]
+lemma hom_comp {M N O : SemimoduleCat.{v} R} (f : M ⟶ N) (g : N ⟶ O) :
+    (f ≫ g).hom = g.hom.comp f.hom := rfl
+
+/- Provided for rewriting. -/
+lemma comp_apply {M N O : SemimoduleCat.{v} R} (f : M ⟶ N) (g : N ⟶ O) (x : M) :
+    (f ≫ g) x = g (f x) := by simp
+
+@[ext]
+lemma hom_ext {M N : SemimoduleCat.{v} R} {f g : M ⟶ N} (hf : f.hom = g.hom) : f = g :=
+  Hom.ext hf
+
+lemma hom_bijective {M N : SemimoduleCat.{v} R} :
+    Function.Bijective (Hom.hom : (M ⟶ N) → (M →ₗ[R] N)) where
+  left f g h := by cases f; cases g; simpa using h
+  right f := ⟨⟨f⟩, rfl⟩
+
+/-- Convenience shortcut for `SemimoduleCat.hom_bijective.injective`. -/
+lemma hom_injective {M N : SemimoduleCat.{v} R} :
+    Function.Injective (Hom.hom : (M ⟶ N) → (M →ₗ[R] N)) :=
+  hom_bijective.injective
+
+/-- Convenience shortcut for `SemimoduleCat.hom_bijective.surjective`. -/
+lemma hom_surjective {M N : SemimoduleCat.{v} R} :
+    Function.Surjective (Hom.hom : (M ⟶ N) → (M →ₗ[R] N)) :=
+  hom_bijective.surjective
+
+@[simp]
+lemma hom_ofHom {X Y : Type v} [AddCommMonoid X] [Module R X] [AddCommMonoid Y]
+    [Module R Y] (f : X →ₗ[R] Y) : (ofHom f).hom = f := rfl
+
+@[simp]
+lemma ofHom_hom {M N : SemimoduleCat.{v} R} (f : M ⟶ N) :
+    ofHom (Hom.hom f) = f := rfl
+
+@[simp]
+lemma ofHom_id {M : Type v} [AddCommMonoid M] [Module R M] : ofHom LinearMap.id = 𝟙 (of R M) := rfl
+
+@[simp]
+lemma ofHom_comp {M N O : Type v} [AddCommMonoid M] [AddCommMonoid N] [AddCommMonoid O] [Module R M]
+    [Module R N] [Module R O] (f : M →ₗ[R] N) (g : N →ₗ[R] O) :
+    ofHom (g.comp f) = ofHom f ≫ ofHom g :=
+  rfl
+
+/- Doesn't need to be `@[simp]` since `simp only` can solve this. -/
+lemma ofHom_apply {M N : Type v} [AddCommMonoid M] [AddCommMonoid N] [Module R M] [Module R N]
+    (f : M →ₗ[R] N) (x : M) : ofHom f x = f x := rfl
+
+lemma inv_hom_apply {M N : SemimoduleCat.{v} R} (e : M ≅ N) (x : M) : e.inv (e.hom x) = x := by
+  simp
+
+lemma hom_inv_apply {M N : SemimoduleCat.{v} R} (e : M ≅ N) (x : N) : e.hom (e.inv x) = x := by
+  simp
+
+/-- `SemimoduleCat.Hom.hom` bundled as an `Equiv`. -/
+def homEquiv {M N : SemimoduleCat.{v} R} : (M ⟶ N) ≃ (M →ₗ[R] N) where
+  toFun := Hom.hom
+  invFun := ofHom
+
+end
+
+/- Not a `@[simp]` lemma since it will rewrite the (co)domain of maps and cause
+definitional equality issues. -/
+lemma forget_obj {M : SemimoduleCat.{v} R} : (forget (SemimoduleCat.{v} R)).obj M = M := rfl
+
+@[simp]
+lemma forget_map {M N : SemimoduleCat.{v} R} (f : M ⟶ N) :
+    (forget (SemimoduleCat.{v} R)).map f = f :=
+  rfl
+
+instance hasForgetToAddCommMonoid : HasForget₂ (SemimoduleCat R) AddCommMonCat where
+  forget₂ :=
+    { obj := fun M => .of M
+      map := fun f => AddCommMonCat.ofHom f.hom.toAddMonoidHom }
+
+@[simp]
+theorem forget₂_obj (X : SemimoduleCat R) :
+    (forget₂ (SemimoduleCat R) AddCommMonCat).obj X = .of X :=
+  rfl
+
+theorem forget₂_obj_moduleCat_of (X : Type v) [AddCommMonoid X] [Module R X] :
+    (forget₂ (SemimoduleCat R) AddCommMonCat).obj (of R X) = .of X :=
+  rfl
+
+@[simp]
+theorem forget₂_map (X Y : SemimoduleCat R) (f : X ⟶ Y) :
+    (forget₂ (SemimoduleCat R) AddCommMonCat).map f = AddCommMonCat.ofHom f.hom :=
+  rfl
+
+instance : Inhabited (SemimoduleCat R) :=
+  ⟨of R PUnit⟩
+
+@[simp] theorem of_coe (X : SemimoduleCat R) : of R X = X := rfl
+
+variable {R}
+
+/-- Forgetting to the underlying type and then building the bundled object returns the original
+module. -/
+@[deprecated Iso.refl (since := "2025-05-15")]
+def ofSelfIso (M : SemimoduleCat R) : SemimoduleCat.of R M ≅ M where
+  hom := 𝟙 M
+  inv := 𝟙 M
+
+theorem isZero_of_subsingleton (M : SemimoduleCat R) [Subsingleton M] : IsZero M where
+  unique_to X := ⟨⟨⟨ofHom (0 : M →ₗ[R] X)⟩, fun f => by
+    ext x
+    rw [Subsingleton.elim x (0 : M)]
+    simp⟩⟩
+  unique_from X := ⟨⟨⟨ofHom (0 : X →ₗ[R] M)⟩, fun f => by
+    ext x
+    subsingleton⟩⟩
+
+instance : HasZeroObject (SemimoduleCat.{v} R) :=
+  ⟨⟨of R PUnit, isZero_of_subsingleton _⟩⟩
+
+end SemimoduleCat
+
+variable {R}
+variable {X₁ X₂ : Type v}
+
+open SemimoduleCat
+
+/-- Reinterpreting a linear map in the category of `R`-modules -/
+scoped[SemimoduleCat] notation "↟" f:1024 => SemimoduleCat.ofHom f
+
+section
+
+/-- Build an isomorphism in the category `Module R` from a `LinearEquiv` between `Module`s. -/
+@[simps]
+def LinearEquiv.toModuleIso {g₁ : AddCommMonoid X₁} {g₂ : AddCommMonoid X₂} {m₁ : Module R X₁}
+    {m₂ : Module R X₂} (e : X₁ ≃ₗ[R] X₂) : SemimoduleCat.of R X₁ ≅ SemimoduleCat.of R X₂ where
+  hom := ofHom (e : X₁ →ₗ[R] X₂)
+  inv := ofHom (e.symm : X₂ →ₗ[R] X₁)
+  hom_inv_id := by ext; apply e.left_inv
+  inv_hom_id := by ext; apply e.right_inv
+
+namespace CategoryTheory.Iso
+
+/-- Build a `LinearEquiv` from an isomorphism in the category `SemimoduleCat R`. -/
+def toLinearEquiv {X Y : SemimoduleCat R} (i : X ≅ Y) : X ≃ₗ[R] Y :=
+  LinearEquiv.ofLinear i.hom.hom i.inv.hom (by aesop) (by aesop)
+
+end CategoryTheory.Iso
+
+/-- linear equivalences between `Module`s are the same as (isomorphic to) isomorphisms
+in `SemimoduleCat` -/
+@[simps]
+def linearEquivIsoModuleIso {X Y : Type u} [AddCommMonoid X] [AddCommMonoid Y] [Module R X]
+    [Module R Y] : (X ≃ₗ[R] Y) ≅ SemimoduleCat.of R X ≅ SemimoduleCat.of R Y where
+  hom e := e.toModuleIso
+  inv i := i.toLinearEquiv
+
+end
+
+namespace SemimoduleCat
+
+section AddCommMonoid
+
+variable {M N : SemimoduleCat.{v} R}
+
+instance : Add (M ⟶ N) where
+  add f g := ⟨f.hom + g.hom⟩
+
+@[simp] lemma hom_add (f g : M ⟶ N) : (f + g).hom = f.hom + g.hom := rfl
+
+instance : Zero (M ⟶ N) where
+  zero := ⟨0⟩
+
+@[simp] lemma hom_zero : (0 : M ⟶ N).hom = 0 := rfl
+
+instance : SMul ℕ (M ⟶ N) where
+  smul n f := ⟨n • f.hom⟩
+
+@[simp] lemma hom_nsmul (n : ℕ) (f : M ⟶ N) : (n • f).hom = n • f.hom := rfl
+
+instance : SMul ℕ (M ⟶ N) where
+  smul n f := ⟨n • f.hom⟩
+
+@[simp] lemma hom_zsmul (n : ℕ) (f : M ⟶ N) : (n • f).hom = n • f.hom := rfl
+
+instance : AddCommMonoid (M ⟶ N) :=
+  Function.Injective.addCommMonoid Hom.hom hom_injective rfl (fun _ _ => rfl) (fun _ _ => rfl)
+
+@[simp] lemma hom_sum {ι : Type*} (f : ι → (M ⟶ N)) (s : Finset ι) :
+    (∑ i ∈ s, f i).hom = ∑ i ∈ s, (f i).hom :=
+  map_sum ({ toFun := SemimoduleCat.Hom.hom, map_zero' := SemimoduleCat.hom_zero,
+             map_add' := hom_add } : (M ⟶ N) →+ (M →ₗ[R] N)) _ _
+
+instance : Presemiadditive (SemimoduleCat.{v} R) where
+
+instance : (forget₂ (SemimoduleCat.{v} R) AddCommMonCat).Additive where
+
+instance : HasZeroMorphisms (SemimoduleCat.{v} R) where
+
+/-- `SemimoduleCat.Hom.hom` bundled as an additive equivalence. -/
+@[simps!]
+def homAddEquiv : (M ⟶ N) ≃+ (M →ₗ[R] N) :=
+  { homEquiv with
+    map_add' := fun _ _ => rfl }
+
+theorem subsingleton_of_isZero (h : IsZero M) : Subsingleton M := by
+  refine subsingleton_of_forall_eq 0 (fun x ↦ ?_)
+  rw [← LinearMap.id_apply (R := R) x, ← SemimoduleCat.hom_id]
+  simp only [(CategoryTheory.Limits.IsZero.iff_id_eq_zero M).mp h, hom_zero, LinearMap.zero_apply]
+
+lemma isZero_iff_subsingleton : IsZero M ↔ Subsingleton M where
+  mp := subsingleton_of_isZero
+  mpr _ := isZero_of_subsingleton M
+
+@[simp]
+lemma isZero_of_iff_subsingleton {M : Type*} [AddCommMonoid M] [Module R M] :
+    IsZero (of R M) ↔ Subsingleton M := isZero_iff_subsingleton
+
+end AddCommMonoid
+
+section SMul
+
+variable {M N : SemimoduleCat.{v} R}
+variable {S : Type*} [Monoid S] [DistribMulAction S N] [SMulCommClass R S N]
+
+instance : SMul S (M ⟶ N) where
+  smul c f := ⟨c • f.hom⟩
+
+@[simp] lemma hom_smul (s : S) (f : M ⟶ N) : (s • f).hom = s • f.hom := rfl
+
+end SMul
+
+section Module
+
+variable {M N : SemimoduleCat.{v} R} {S : Type*} [Semiring S] [Module S N] [SMulCommClass R S N]
+
+instance Hom.instModule : Module S (M ⟶ N) :=
+  Function.Injective.module S
+    { toFun := Hom.hom, map_zero' := hom_zero, map_add' := hom_add }
+    hom_injective
+    (fun _ _ => rfl)
+
+/-- `SemimoduleCat.Hom.hom` bundled as a linear equivalence. -/
+@[simps]
+def homLinearEquiv : (M ⟶ N) ≃ₗ[S] (M →ₗ[R] N) :=
+  { homAddEquiv with
+    map_smul' := fun _ _ => rfl }
+
+end Module
+
+section
+
+universe u₀
+
+namespace Algebra
+
+variable {S₀ : Type u₀} [CommSemiring S₀] {S : Type u} [Semiring S] [Algebra S₀ S]
+
+variable {M N : SemimoduleCat.{v} S}
+
+/--
+Let `S` be an `S₀`-algebra. Then `S`-modules are modules over `S₀`.
+-/
+scoped instance : Module S₀ M := Module.compHom _ (algebraMap S₀ S)
+
+scoped instance : IsScalarTower S₀ S M where
+  smul_assoc _ _ _ := by rw [Algebra.smul_def, mul_smul]; rfl
+
+scoped instance : SMulCommClass S S₀ M where
+  smul_comm s s₀ n :=
+    show s • algebraMap S₀ S s₀ • n = algebraMap S₀ S s₀ • s • n by
+    rw [← smul_assoc, smul_eq_mul, ← Algebra.commutes, mul_smul]
+
+/--
+Let `S` be an `S₀`-algebra. Then the category of `S`-modules is `S₀`-linear.
+-/
+scoped instance instLinear : Linear S₀ (SemimoduleCat.{v} S) where
+  smul_comp _ M N s₀ f g := by ext; simp
+
+end Algebra
+
+section
+
+variable {S : Type u} [CommSemiring S]
+
+instance : Linear S (SemimoduleCat.{v} S) := SemimoduleCat.Algebra.instLinear
+
+variable {X Y X' Y' : SemimoduleCat.{v} S}
+
+theorem Iso.homCongr_eq_arrowCongr (i : X ≅ X') (j : Y ≅ Y') (f : X ⟶ Y) :
+    Iso.homCongr i j f = ⟨LinearEquiv.arrowCongr i.toLinearEquiv j.toLinearEquiv f.hom⟩ :=
+  rfl
+
+theorem Iso.conj_eq_conj (i : X ≅ X') (f : End X) :
+    Iso.conj i f = ⟨LinearEquiv.conj i.toLinearEquiv f.hom⟩ :=
+  rfl
+
+end
+
+end
+
+variable (M N : SemimoduleCat.{v} R)
+
+/-- `SemimoduleCat.Hom.hom` as an isomorphism of rings. -/
+@[simps!] def endSemiringEquiv : End M ≃+* (M →ₗ[R] M) where
+  toFun := SemimoduleCat.Hom.hom
+  invFun := SemimoduleCat.ofHom
+  map_mul' _ _ := rfl
+  map_add' _ _ := rfl
+
+/-- The scalar multiplication on an object of `SemimoduleCat R` considered as
+a morphism of rings from `R` to the endomorphisms of the underlying abelian group. -/
+def smul : R →+* End ((forget₂ (SemimoduleCat R) AddCommMonCat).obj M) where
+  toFun r := AddCommMonCat.ofHom
+    { toFun := fun (m : M) => r • m
+      map_zero' := by rw [smul_zero]
+      map_add' := fun x y => by rw [smul_add] }
+  map_one' := AddCommMonCat.ext (fun x => by simp)
+  map_zero' := AddCommMonCat.ext (fun x => by simp)
+  map_mul' r s := AddCommMonCat.ext (fun (x : M) => (smul_smul r s x).symm)
+  map_add' r s := AddCommMonCat.ext (fun (x : M) => add_smul r s x)
+
+lemma smul_naturality {M N : SemimoduleCat.{v} R} (f : M ⟶ N) (r : R) :
+    (forget₂ (SemimoduleCat R) AddCommMonCat).map f ≫ N.smul r =
+      M.smul r ≫ (forget₂ (SemimoduleCat R) AddCommMonCat).map f := by
+  ext x
+  exact (f.hom.map_smul r x).symm
+
+variable (R) in
+/-- The scalar multiplication on `SemimoduleCat R` considered as a morphism of rings
+to the endomorphisms of the forgetful functor to `AddCommMonCat)`. -/
+@[simps]
+def smulNatTrans : R →+* End (forget₂ (SemimoduleCat R) AddCommMonCat) where
+  toFun r :=
+    { app := fun M => M.smul r
+      naturality := fun _ _ _ => smul_naturality _ r }
+  map_one' := NatTrans.ext (by cat_disch)
+  map_zero' := NatTrans.ext (by cat_disch)
+  map_mul' _ _ := NatTrans.ext (by cat_disch)
+  map_add' _ _ := NatTrans.ext (by cat_disch)
+
+/-- Given `A : AddCommMonCat` and a ring morphism `R →+* End A`, this is a type synonym
+for `A`, on which we shall define a structure of `R`-module. -/
+@[nolint unusedArguments]
+def mkOfSMul' {A : AddCommMonCat} (_ : R →+* End A) := A
+
+section
+
+variable {A : AddCommMonCat} (φ : R →+* End A)
+
+instance : AddCommMonoid (mkOfSMul' φ) := by
+  dsimp only [mkOfSMul']
+  infer_instance
+
+instance : SMul R (mkOfSMul' φ) := ⟨fun r (x : A) => (show A ⟶ A from φ r) x⟩
+
+@[simp]
+lemma mkOfSMul'_smul (r : R) (x : mkOfSMul' φ) :
+    r • x = (show A ⟶ A from φ r) x := rfl
+
+instance : Module R (mkOfSMul' φ) where
+  smul_zero _ := map_zero (N := A) _
+  smul_add _ _ _ := map_add (N := A) _ _ _
+  one_smul := by simp
+  mul_smul := by simp
+  add_smul _ _ _ := by simp; rfl
+  zero_smul := by simp
+
+/-- Given `A : AddCommMonCat` and a ring morphism `R →+* End A`, this is an object in
+`SemimoduleCat R`, whose underlying abelian group is `A` and whose scalar multiplication is
+given by `R`. -/
+abbrev mkOfSMul := SemimoduleCat.of R (mkOfSMul' φ)
+
+lemma mkOfSMul_smul (r : R) : (mkOfSMul φ).smul r = φ r := rfl
+
+end
+
+section
+
+variable {M N}
+  (φ : (forget₂ (SemimoduleCat R) AddCommMonCat).obj M ⟶
+      (forget₂ (SemimoduleCat R) AddCommMonCat).obj N)
+  (hφ : ∀ (r : R), φ ≫ N.smul r = M.smul r ≫ φ)
+
+/-- Constructor for morphisms in `SemimoduleCat R` which takes as inputs
+a morphism between the underlying objects in `AddCommMonCat` and the compatibility
+with the scalar multiplication. -/
+@[simps]
+def homMk : M ⟶ N where
+  hom'.toFun := φ
+  hom'.map_add' _ _ := φ.hom.map_add _ _
+  hom'.map_smul' r x := (congr_hom (hφ r) x).symm
+
+lemma forget₂_map_homMk :
+    (forget₂ (SemimoduleCat R) AddCommMonCat).map (homMk φ hφ) = φ := rfl
+
+end
+
+instance : (forget (SemimoduleCat.{v} R)).ReflectsIsomorphisms where
+  reflects f _ :=
+    (inferInstance : IsIso ((LinearEquiv.mk f.hom
+      (asIso ((forget (SemimoduleCat R)).map f)).toEquiv.invFun
+      (Equiv.left_inv _) (Equiv.right_inv _)).toModuleIso).hom)
+
+instance : (forget₂ (SemimoduleCat.{v} R) AddCommMonCat.{v}).ReflectsIsomorphisms where
+  reflects f _ := by
+    have : IsIso ((forget _).map f) := by
+      change IsIso ((forget _).map ((forget₂ _ AddCommMonCat).map f))
+      infer_instance
+    apply isIso_of_reflects_iso _ (forget _)
+
+end SemimoduleCat
+
+section Bilinear
+
+variable {R : Type*} [CommSemiring R]
+
+namespace SemimoduleCat
+
+/-- Turn a bilinear map into a homomorphism. -/
+@[simps!]
+def ofHom₂ {M N P : SemimoduleCat.{u} R} (f : M →ₗ[R] N →ₗ[R] P) :
+    M ⟶ of R (N ⟶ P) :=
+  ofHom <| homLinearEquiv.symm.toLinearMap ∘ₗ f
+
+/-- Turn a homomorphism into a bilinear map. -/
+@[simps!]
+def Hom.hom₂ {M N P : SemimoduleCat.{u} R}
+    -- We write `Hom` instead of `M ⟶ (of R (N ⟶ P))`, otherwise dot notation breaks
+    -- since it is expecting the type of `f` to be `SemimoduleCat.Hom`, not `Quiver.Hom`.
+    (f : Hom M (of R (N ⟶ P))) :
+    M →ₗ[R] N →ₗ[R] P :=
+  Hom.hom (by convert (f ≫ ofHom homLinearEquiv.toLinearMap))
+
+@[simp] lemma Hom.hom₂_ofHom₂ {M N P : SemimoduleCat.{u} R} (f : M →ₗ[R] N →ₗ[R] P) :
+    (ofHom₂ f).hom₂ = f := rfl
+
+@[simp] lemma ofHom₂_hom₂ {M N P : SemimoduleCat.{u} R} (f : M ⟶ of R (N ⟶ P)) :
+    ofHom₂ f.hom₂ = f := rfl
+
+end SemimoduleCat
+
+end Bilinear
+
+/-!
+`@[simp]` lemmas for `LinearMap.comp` and categorical identities.
+-/
+
+@[simp] theorem LinearMap.comp_id_moduleCat {R} [Semiring R]
+    {G : SemimoduleCat.{u} R} {H : Type u} [AddCommMonoid H] [Module R H] (f : G →ₗ[R] H) :
+    f.comp (𝟙 G : G ⟶ G).hom = f := by simp
+
+@[simp] theorem LinearMap.id_moduleCat_comp {R} [Semiring R]
+    {G : Type u} [AddCommMonoid G] [Module R G] {H : SemimoduleCat.{u} R} (f : G →ₗ[R] H) :
+    LinearMap.comp (𝟙 H : H ⟶ H).hom f = f := by simp

--- a/Mathlib/Algebra/Category/MonCat/Presemiadditive.lean
+++ b/Mathlib/Algebra/Category/MonCat/Presemiadditive.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2025 Junyan Xu. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus Himmel, Junyan Xu
+-/
+import Mathlib.Algebra.Category.MonCat.Basic
+import Mathlib.CategoryTheory.Preadditive.Semi
+
+/-!
+# The category of additive commutative monoids is pre-semiadditive.
+-/
+
+assert_not_exists Submonoid
+
+open CategoryTheory
+
+universe u
+
+namespace AddCommMonCat
+
+variable {M N : AddCommMonCat.{u}}
+
+instance : Add (M ⟶ N) where
+  add f g := ofHom (f.hom + g.hom)
+
+@[simp] lemma hom_add (f g : M ⟶ N) : (f + g).hom = f.hom + g.hom := rfl
+
+lemma hom_add_apply {P Q : AddCommMonCat} (f g : P ⟶ Q) (x : P) : (f + g) x = f x + g x := rfl
+
+instance : Zero (M ⟶ N) where
+  zero := ofHom 0
+
+@[simp] lemma hom_zero : (0 : M ⟶ N).hom = 0 := rfl
+
+instance : SMul ℕ (M ⟶ N) where
+  smul n f := ofHom (n • f.hom)
+
+@[simp] lemma hom_nsmul (n : ℕ) (f : M ⟶ N) : (n • f).hom = n • f.hom := rfl
+
+instance (P Q : AddCommMonCat) : AddCommMonoid (P ⟶ Q) :=
+  Function.Injective.addCommMonoid Hom.hom ConcreteCategory.hom_injective
+    rfl (fun _ _ => rfl) (fun _ _ => rfl)
+
+instance : Presemiadditive AddCommMonCat where
+
+/-- `AddCommGrp.Hom.hom` bundled as an additive equivalence. -/
+@[simps!]
+def homAddEquiv : (M ⟶ N) ≃+ (M →+ N) :=
+  { ConcreteCategory.homEquiv (C := AddCommMonCat) with
+    map_add' _ _ := rfl }
+
+end AddCommMonCat

--- a/Mathlib/CategoryTheory/Linear/Basic.lean
+++ b/Mathlib/CategoryTheory/Linear/Basic.lean
@@ -40,7 +40,7 @@ namespace CategoryTheory
 
 /-- A category is called `R`-linear if `P ⟶ Q` is an `R`-module such that composition is
 `R`-linear in both variables. -/
-class Linear (R : Type w) [Semiring R] (C : Type u) [Category.{v} C] [Preadditive C] where
+class Linear (R : Type w) [Semiring R] (C : Type u) [Category.{v} C] [Presemiadditive C] where
   homModule : ∀ X Y : C, Module R (X ⟶ Y) := by infer_instance
   /-- compatibility of the scalar multiplication with the post-composition -/
   smul_comp : ∀ (X Y Z : C) (r : R) (f : X ⟶ Y) (g : Y ⟶ Z), (r • f) ≫ g = r • f ≫ g := by
@@ -60,15 +60,17 @@ open CategoryTheory
 
 namespace CategoryTheory.Linear
 
-variable {C : Type u} [Category.{v} C] [Preadditive C]
+variable {C : Type u} [Category.{v} C]
 
-instance preadditiveNatLinear : Linear ℕ C where
-  smul_comp X _Y _Z r f g := by exact (Preadditive.rightComp X g).map_nsmul f r
-  comp_smul _X _Y Z f r g := by exact (Preadditive.leftComp Z f).map_nsmul g r
+instance preadditiveNatLinear [Presemiadditive C] : Linear ℕ C where
+  smul_comp X _Y _Z r f g := by exact (Presemiadditive.rightComp X g).map_nsmul f r
+  comp_smul _X _Y Z f r g := by exact (Presemiadditive.leftComp Z f).map_nsmul g r
 
-instance preadditiveIntLinear : Linear ℤ C where
+instance preadditiveIntLinear [Preadditive C] : Linear ℤ C where
   smul_comp X _Y _Z r f g := by exact (Preadditive.rightComp X g).map_zsmul f r
   comp_smul _X _Y Z f r g := by exact (Preadditive.leftComp Z f).map_zsmul g r
+
+variable [Presemiadditive C]
 
 section End
 

--- a/Mathlib/CategoryTheory/Preadditive/Biproducts.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Biproducts.lean
@@ -55,13 +55,11 @@ and `Matrix.invertibleOfFromBlocks₁₁Invertible` are all closely related.
 
 open CategoryTheory
 
-open CategoryTheory.Preadditive
+open CategoryTheory.Presemiadditive
 
 open CategoryTheory.Limits
 
 open CategoryTheory.Functor
-
-open CategoryTheory.Preadditive
 
 universe v v' u u'
 
@@ -69,7 +67,7 @@ noncomputable section
 
 namespace CategoryTheory
 
-variable {C : Type u} [Category.{v} C] [Preadditive C]
+variable {C : Type u} [Category.{v} C] [Presemiadditive C]
 
 namespace Limits
 
@@ -288,7 +286,7 @@ def biproduct.reindex {β γ : Type} [Finite β] (ε : β ≃ γ)
     cases nonempty_fintype β
     ext g g'
     by_cases h : g' = g <;>
-      simp [Preadditive.sum_comp, biproduct.lift_desc,
+      simp [Presemiadditive.sum_comp, biproduct.lift_desc,
         biproduct.ι_π, comp_dite, Equiv.apply_eq_iff_eq_symm_apply,
         h]
 
@@ -469,6 +467,12 @@ lemma biprod.ext_from_iff {f g : X ⊞ Y ⟶ Z} :
 
 end
 
+section Preadditive
+
+open Preadditive
+
+variable {C : Type u} [Category.{v} C] [Preadditive C]
+
 /-- Every split mono `f` with a cokernel induces a binary bicone with `f` as its `inl` and
 the cokernel map as its `snd`.
 We will show in `is_bilimit_binary_bicone_of_split_mono_of_cokernel` that this binary bicone is in
@@ -612,6 +616,8 @@ def isBilimitBinaryBiconeOfIsSplitEpiOfKernel {X Y : C} {f : X ⟶ Y} [IsSplitEp
     {c : KernelFork f} (i : IsLimit c) : (binaryBiconeOfIsSplitEpiOfKernel i).IsBilimit :=
   BinaryBicone.isBilimitOfKernelInl _ <| i.ofIsoLimit <| Fork.ext (Iso.refl _) (by simp)
 
+end Preadditive
+
 end
 
 section
@@ -634,19 +640,25 @@ open CategoryTheory.Limits
 
 section
 
-attribute [local ext] Preadditive
+attribute [local ext] Presemiadditive
 
-/-- The existence of binary biproducts implies that there is at most one preadditive structure. -/
-instance subsingleton_preadditive_of_hasBinaryBiproducts {C : Type u} [Category.{v} C]
-    [HasZeroMorphisms C] [HasBinaryBiproducts C] : Subsingleton (Preadditive C) where
+/-- The existence of binary biproducts implies that
+there is at most one presemiadditive structure. -/
+instance subsingleton_presemiadditive_of_hasBinaryBiproducts {C : Type u} [Category.{v} C]
+    [HasZeroMorphisms C] [HasBinaryBiproducts C] : Subsingleton (Presemiadditive C) where
   allEq := fun a b => by
-    apply Preadditive.ext; funext X Y; apply AddCommGroup.ext; funext f g
+    apply Presemiadditive.ext; funext X Y; apply AddCommMonoid.ext; funext f g
     have h₁ := @biprod.add_eq_lift_id_desc _ _ a _ _ f g
       (by convert (inferInstance : HasBinaryBiproduct X X); subsingleton)
     have h₂ := @biprod.add_eq_lift_id_desc _ _ b _ _ f g
       (by convert (inferInstance : HasBinaryBiproduct X X); subsingleton)
     refine h₁.trans (Eq.trans ?_ h₂.symm)
     congr! 2 <;> subsingleton
+
+/-- The existence of binary biproducts implies that there is at most one preadditive structure. -/
+instance subsingleton_preadditive_of_hasBinaryBiproducts {C : Type u} [Category.{v} C]
+    [HasZeroMorphisms C] [HasBinaryBiproducts C] : Subsingleton (Preadditive C) :=
+  Preadditive.instPresemiadditive_injective.subsingleton
 
 end
 
@@ -690,7 +702,7 @@ theorem Biprod.ofComponents_eq (f : X₁ ⊞ X₂ ⟶ Y₁ ⊞ Y₂) :
   ext <;>
     simp only [Category.comp_id, biprod.inr_fst, biprod.inr_snd, biprod.inl_snd, add_zero, zero_add,
       Biprod.inl_ofComponents, Biprod.inr_ofComponents, Category.assoc,
-      comp_zero, biprod.inl_fst, Preadditive.add_comp]
+      comp_zero, biprod.inl_fst, Presemiadditive.add_comp]
 
 @[simp]
 theorem Biprod.ofComponents_comp {X₁ X₂ Y₁ Y₂ Z₁ Z₂ : C} (f₁₁ : X₁ ⟶ Y₁) (f₁₂ : X₁ ⟶ Y₂)
@@ -704,6 +716,12 @@ theorem Biprod.ofComponents_comp {X₁ X₂ Y₁ Y₂ Z₁ Z₂ : C} (f₁₁ : 
     simp only [add_comp, comp_add, add_zero, zero_add, biprod.inl_fst,
       biprod.inl_snd, biprod.inr_fst, biprod.inr_snd, biprod.inl_fst_assoc, biprod.inl_snd_assoc,
       biprod.inr_fst_assoc, biprod.inr_snd_assoc, comp_zero, zero_comp, Category.assoc]
+
+section Preadditive
+
+variable {C : Type u} [Category.{v} C] [Preadditive C] [HasBinaryBiproducts.{v} C]
+variable {X₁ X₂ Y₁ Y₂ : C}
+variable (f₁₁ : X₁ ⟶ Y₁) (f₁₂ : X₁ ⟶ Y₂) (f₂₁ : X₂ ⟶ Y₁) (f₂₂ : X₂ ⟶ Y₂)
 
 /-- The unipotent upper triangular matrix
 ```
@@ -779,6 +797,8 @@ def Biprod.isoElim (f : X₁ ⊞ X₂ ≅ Y₁ ⊞ Y₂) [IsIso (biprod.inl ≫ 
   Biprod.isoElim' (biprod.inl ≫ f.hom ≫ biprod.fst) (biprod.inl ≫ f.hom ≫ biprod.snd)
     (biprod.inr ≫ f.hom ≫ biprod.fst) (biprod.inr ≫ f.hom ≫ biprod.snd)
 
+end Preadditive
+
 theorem Biprod.column_nonzero_of_iso {W X Y Z : C} (f : W ⊞ X ⟶ Y ⊞ Z) [IsIso f] :
     𝟙 W = 0 ∨ biprod.inl ≫ f ≫ biprod.fst ≠ 0 ∨ biprod.inl ≫ f ≫ biprod.snd ≠ 0 := by
   by_contra! h
@@ -841,9 +861,9 @@ def Biproduct.columnNonzeroOfIso {σ τ : Type} [Fintype τ] {S : σ → C} [Has
     simp only [not_exists_not] at h
     exact nz (t h)
 
-section Preadditive
+section Presemiadditive
 
-variable {D : Type u'} [Category.{v'} D] [Preadditive.{v'} D]
+variable {D : Type u'} [Category.{v'} D] [Presemiadditive.{v'} D]
 variable (F : C ⥤ D) [PreservesZeroMorphisms F]
 
 namespace Limits
@@ -1078,6 +1098,6 @@ lemma preservesBinaryBiproducts_of_preservesBinaryCoproducts
 
 end Limits
 
-end Preadditive
+end Presemiadditive
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Preadditive/FunctorCategory.lean
+++ b/Mathlib/CategoryTheory/Preadditive/FunctorCategory.lean
@@ -7,18 +7,22 @@ import Mathlib.CategoryTheory.Preadditive.Basic
 import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 
 /-!
-# Preadditive structure on functor categories
+# Pre(semi)additive structure on functor categories
 
-If `C` and `D` are categories and `D` is preadditive,
-then `C ⥤ D` is also preadditive.
+If `C` and `D` are categories and `D` is pre(semi)additive,
+then `C ⥤ D` is also pre(semi)additive.
 
 -/
 
 namespace CategoryTheory
 
-open CategoryTheory.Limits Preadditive
+open CategoryTheory.Limits
 
-variable {C D : Type*} [Category C] [Category D] [Preadditive D]
+variable {C D : Type*} [Category C] [Category D]
+
+section Semi
+
+variable [Presemiadditive D]
 
 instance {F G : C ⥤ D} : Zero (F ⟶ G) where
   zero := { app := fun _ => 0 }
@@ -26,14 +30,9 @@ instance {F G : C ⥤ D} : Zero (F ⟶ G) where
 instance {F G : C ⥤ D} : Add (F ⟶ G) where
   add α β := { app := fun X => α.app X + β.app X }
 
-instance {F G : C ⥤ D} : Neg (F ⟶ G) where
-  neg α := { app := fun X => -α.app X }
-
-instance functorCategoryPreadditive : Preadditive (C ⥤ D) where
-  homGroup F G :=
+instance : Presemiadditive (C ⥤ D) where
+  homMonoid F G :=
     { nsmul := nsmulRec
-      zsmul := zsmulRec
-      sub := fun α β => { app := fun X => α.app X - β.app X }
       add_assoc := by
         intros
         ext
@@ -49,23 +48,15 @@ instance functorCategoryPreadditive : Preadditive (C ⥤ D) where
       add_comm := by
         intros
         ext
-        apply add_comm
-      sub_eq_add_neg := by
-        intros
-        ext
-        apply sub_eq_add_neg
-      neg_add_cancel := by
-        intros
-        ext
-        apply neg_add_cancel }
+        apply add_comm }
   add_comp := by
     intros
     ext
-    apply add_comp
+    apply Presemiadditive.add_comp
   comp_add := by
     intros
     ext
-    apply comp_add
+    apply Presemiadditive.comp_add
 
 namespace NatTrans
 
@@ -88,16 +79,51 @@ theorem app_add (X : C) (α β : F ⟶ G) : (α + β).app X = α.app X + β.app 
   rfl
 
 @[simp]
+theorem app_nsmul (X : C) (α : F ⟶ G) (n : ℕ) : (n • α).app X = n • α.app X :=
+  (appHom X).map_nsmul α n
+
+@[simp]
+theorem app_sum {ι : Type*} (s : Finset ι) (X : C) (α : ι → (F ⟶ G)) :
+    (∑ i ∈ s, α i).app X = ∑ i ∈ s, (α i).app X := by
+  simp only [← appHom_apply, map_sum]
+
+end NatTrans
+
+end Semi
+
+section Preadditive
+
+open Preadditive
+
+variable [Preadditive D]
+
+instance {F G : C ⥤ D} : Neg (F ⟶ G) where
+  neg α := { app := fun X => -α.app X }
+
+instance functorCategoryPreadditive : Preadditive (C ⥤ D) where
+  homGroup F G :=
+    { zsmul := zsmulRec
+      sub := fun α β => { app := fun X => α.app X - β.app X }
+      sub_eq_add_neg := by
+        intros
+        ext
+        apply sub_eq_add_neg
+      neg_add_cancel := by
+        intros
+        ext
+        apply neg_add_cancel }
+
+namespace NatTrans
+
+variable {F G : C ⥤ D}
+
+@[simp]
 theorem app_sub (X : C) (α β : F ⟶ G) : (α - β).app X = α.app X - β.app X :=
   rfl
 
 @[simp]
 theorem app_neg (X : C) (α : F ⟶ G) : (-α).app X = -α.app X :=
   rfl
-
-@[simp]
-theorem app_nsmul (X : C) (α : F ⟶ G) (n : ℕ) : (n • α).app X = n • α.app X :=
-  (appHom X).map_nsmul α n
 
 @[simp]
 theorem app_zsmul (X : C) (α : F ⟶ G) (n : ℤ) : (n • α).app X = n • α.app X :=
@@ -107,11 +133,8 @@ theorem app_zsmul (X : C) (α : F ⟶ G) (n : ℤ) : (n • α).app X = n • α
 theorem app_units_zsmul (X : C) (α : F ⟶ G) (n : ℤˣ) : (n • α).app X = n • α.app X := by
   apply app_zsmul
 
-@[simp]
-theorem app_sum {ι : Type*} (s : Finset ι) (X : C) (α : ι → (F ⟶ G)) :
-    (∑ i ∈ s, α i).app X = ∑ i ∈ s, (α i).app X := by
-  simp only [← appHom_apply, map_sum]
-
 end NatTrans
+
+end Preadditive
 
 end CategoryTheory

--- a/Mathlib/CategoryTheory/Preadditive/Semi.lean
+++ b/Mathlib/CategoryTheory/Preadditive/Semi.lean
@@ -1,0 +1,173 @@
+/-
+Copyright (c) 2025 Junyan Xu. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Markus Himmel, Jakob von Raumer, Junyan Xu
+-/
+import Mathlib.Algebra.BigOperators.Group.Finset.Defs
+import Mathlib.Algebra.Group.Hom.Instances
+import Mathlib.Algebra.Module.Defs
+import Mathlib.CategoryTheory.Endomorphism
+import Mathlib.CategoryTheory.Limits.Shapes.ZeroMorphisms
+
+/-!
+# Pre-semiadditive categories
+
+A pre-semiadditive category is a category in which `X ⟶ Y` is a commutative monoid in such a way
+that composition of morphisms is linear in both variables.
+
+This file contains a definition of pre-semiadditive category that directly encodes the definition
+given above. The definition could also be phrased as follows: A pre-semiadditive category is a
+category enriched over the monoidal category of commutative monoids.
+
+## Main results
+
+* Definition of pre-semiadditive categories and basic properties
+
+## References
+
+* [F. Borceux, *Handbook of Categorical Algebra 2*][borceux-vol2]
+* https://ncatlab.org/nlab/show/biproduct#SemiadditiveCategories
+
+## Tags
+
+semiadditive, pre-semiadditive, Hom group
+-/
+
+
+universe v u
+
+open CategoryTheory.Limits
+
+namespace CategoryTheory
+
+/-- A category is called pre-semiadditive if `P ⟶ Q` is a commutative monoid such that composition
+is linear in both variables. -/
+@[stacks 00ZY]
+class Presemiadditive (C : Type u) [Category.{v} C] where
+  homMonoid (P Q : C) : AddCommMonoid (P ⟶ Q) := by infer_instance
+  protected zero_comp (P Q R : C) (g : Q ⟶ R) : (0 : P ⟶ Q) ≫ g = 0 := by cat_disch
+  add_comp (P Q R : C) (f f' : P ⟶ Q) (g : Q ⟶ R) : (f + f') ≫ g = f ≫ g + f' ≫ g := by cat_disch
+  protected comp_zero (P Q R : C) (f : P ⟶ Q) : f ≫ (0 : Q ⟶ R) = 0 := by cat_disch
+  comp_add (P Q R : C) (f : P ⟶ Q) (g g' : Q ⟶ R) : f ≫ (g + g') = f ≫ g + f ≫ g' := by cat_disch
+
+attribute [inherit_doc Presemiadditive] Presemiadditive.homMonoid
+
+attribute [instance] Presemiadditive.homMonoid
+
+-- simp can already prove reassoc version
+attribute [reassoc, simp] Presemiadditive.add_comp
+
+attribute [reassoc] Presemiadditive.comp_add
+
+attribute [simp] Presemiadditive.comp_add
+
+namespace Presemiadditive
+
+open AddMonoidHom
+
+variable {C : Type u} [Category.{v} C] [Presemiadditive C]
+
+section InducedCategory
+
+universe u'
+
+variable {D : Type u'} (F : D → C)
+
+instance inducedCategory : Presemiadditive.{v} (InducedCategory C F) where
+  homMonoid P Q := @Presemiadditive.homMonoid C _ _ (F P) (F Q)
+  zero_comp _ _ _ _ := Presemiadditive.zero_comp ..
+  add_comp _ _ _ _ _ _ := add_comp ..
+  comp_zero _ _ _ _ := Presemiadditive.comp_zero ..
+  comp_add _ _ _ _ _ _ := comp_add ..
+
+end InducedCategory
+
+instance fullSubcategory (Z : ObjectProperty C) : Presemiadditive Z.FullSubcategory where
+  homMonoid P Q := @Presemiadditive.homMonoid C _ _ P.obj Q.obj
+  zero_comp _ _ _ _ := Presemiadditive.zero_comp ..
+  add_comp _ _ _ _ _ _ := add_comp ..
+  comp_zero _ _ _ _ := Presemiadditive.comp_zero ..
+  comp_add _ _ _ _ _ _ := comp_add ..
+
+instance (X : C) : AddCommMonoid (End X) := inferInstanceAs (AddCommMonoid (X ⟶ X))
+
+/-- Composition by a fixed left argument as a group homomorphism -/
+def leftComp {P Q : C} (R : C) (f : P ⟶ Q) : (Q ⟶ R) →+ (P ⟶ R) where
+  toFun g := f ≫ g
+  map_zero' := Presemiadditive.comp_zero ..
+  map_add' _ _ := Presemiadditive.comp_add ..
+
+/-- Composition by a fixed right argument as a group homomorphism -/
+def rightComp (P : C) {Q R : C} (g : Q ⟶ R) : (P ⟶ Q) →+ (P ⟶ R) where
+  toFun f := f ≫ g
+  map_zero' := Presemiadditive.zero_comp ..
+  map_add' _ _ := Presemiadditive.add_comp ..
+
+variable {P Q R : C} (f f' : P ⟶ Q) (g g' : Q ⟶ R)
+
+/-- Composition as a bilinear group homomorphism -/
+def compHom : (P ⟶ Q) →+ (Q ⟶ R) →+ (P ⟶ R) where
+  toFun f := leftComp _ f
+  map_zero' := AddMonoidHom.ext fun _ ↦ Presemiadditive.zero_comp ..
+  map_add' _ _ := AddMonoidHom.ext fun _ ↦ Presemiadditive.add_comp ..
+
+theorem nsmul_comp (n : ℕ) : (n • f) ≫ g = n • f ≫ g :=
+  map_nsmul (rightComp P g) n f
+
+theorem comp_nsmul (n : ℕ) : f ≫ (n • g) = n • f ≫ g :=
+  map_nsmul (leftComp R f) n g
+
+@[reassoc]
+theorem comp_sum {P Q R : C} {J : Type*} (s : Finset J) (f : P ⟶ Q) (g : J → (Q ⟶ R)) :
+    (f ≫ ∑ j ∈ s, g j) = ∑ j ∈ s, f ≫ g j :=
+  map_sum (leftComp R f) _ _
+
+@[reassoc]
+theorem sum_comp {P Q R : C} {J : Type*} (s : Finset J) (f : J → (P ⟶ Q)) (g : Q ⟶ R) :
+    (∑ j ∈ s, f j) ≫ g = ∑ j ∈ s, f j ≫ g :=
+  map_sum (rightComp P g) _ _
+
+@[reassoc]
+theorem sum_comp' {P Q R S : C} {J : Type*} (s : Finset J) (f : J → (P ⟶ Q)) (g : J → (Q ⟶ R))
+    (h : R ⟶ S) : (∑ j ∈ s, f j ≫ g j) ≫ h = ∑ j ∈ s, f j ≫ g j ≫ h := by
+  simp only [← Category.assoc]
+  apply sum_comp
+
+instance (priority := 100) preadditiveHasZeroMorphisms : HasZeroMorphisms C where
+  zero := inferInstance
+  comp_zero f R := show leftComp R f 0 = 0 from map_zero _
+  zero_comp P _ _ f := show rightComp P f 0 = 0 from map_zero _
+
+/-- Porting note: adding this before the ring instance allowed moduleEndRight to find
+the correct Monoid structure on End. Moved both down after preadditiveHasZeroMorphisms
+to make use of them -/
+instance {X : C} : Semiring (End X) :=
+  { End.monoid with
+    zero_mul := (HasZeroMorphisms.comp_zero · _)
+    mul_zero := HasZeroMorphisms.zero_comp _
+    left_distrib := fun f g h => Presemiadditive.add_comp X X X g h f
+    right_distrib := fun f g h => Presemiadditive.comp_add X X X h f g }
+
+instance moduleEndRight {X Y : C} : Module (End Y) (X ⟶ Y) where
+  smul_add _ _ _ := add_comp ..
+  smul_zero _ := zero_comp
+  add_smul _ _ _ := comp_add ..
+  zero_smul _ := comp_zero
+
+namespace IsIso
+
+@[simp]
+theorem comp_left_eq_zero [IsIso f] : f ≫ g = 0 ↔ g = 0 := by
+  rw [← IsIso.eq_inv_comp, Limits.comp_zero]
+
+@[simp]
+theorem comp_right_eq_zero [IsIso g] : f ≫ g = 0 ↔ f = 0 := by
+  rw [← IsIso.eq_comp_inv, Limits.zero_comp]
+
+end IsIso
+
+open ZeroObject
+
+end Presemiadditive
+
+end CategoryTheory


### PR DESCRIPTION
+ introduce Presemiadditive categories, which generalizes Preadditive categories: the Hom sets are commutative monoids rather than groups, and `comp_zero` and `zero_comp` is no longer automatic. The new file Preadditive/Semi.lean is adapted from Preadditive/Basic.lean, though many contents can't be generalized.

+ generalize Functor.Additive and Functor.Linear to take Presemiadditive categories instead. The former needs a `map_zero` field since it's not automatic for Presemiadditive categories.

+ introduce SemimoduleCat, the category of semimodules (mathlib's Module) over a Semiring. The new file ModuleCat/Semi.lean is copied from ModuleCat/Basic.lean.

TODOs: additive/linear equivalence between SemimoduleCat and ModuleCat and use it to transfer results; monoidal structure on SemimoduleCat; change `CommRing.Pic` to use SemimoduleCat.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
