### PR TITLE
[Merged by Bors] - feat(Logic/Equiv/List): add `decodeList_encodeList_eq_self` and removed unnecessary linter options

### DIFF
--- a/Mathlib/Logic/Equiv/List.lean
+++ b/Mathlib/Logic/Equiv/List.lean
@@ -50,11 +50,14 @@ def decodeList : ℕ → Option (List α)
       have : v₂ < succ v := lt_succ_of_le h
       (· :: ·) <$> decode (α := α) v₁ <*> decodeList v₂
 
+@[simp]
+theorem decodeList_encodeList_eq_self (l : List α) : decodeList (encodeList l) = some l := by
+  induction l <;> simp [encodeList, decodeList, unpair_pair, encodek, *]
+
 /-- If `α` is encodable, then so is `List α`. This uses the `pair` and `unpair` functions from
 `Data.Nat.Pairing`. -/
 instance _root_.List.encodable : Encodable (List α) :=
-  ⟨encodeList, decodeList, fun l => by
-    induction l <;> simp [encodeList, decodeList, unpair_pair, encodek, *]⟩
+  ⟨encodeList, decodeList, decodeList_encodeList_eq_self⟩
 
 instance _root_.List.countable {α : Type*} [Countable α] : Countable (List α) := by
   haveI := Encodable.ofCountable α
@@ -73,7 +76,7 @@ theorem encode_list_cons (a : α) (l : List α) :
 theorem decode_list_zero : decode (α := List α) 0 = some [] :=
   show decodeList 0 = some [] by rw [decodeList]
 
-@[simp, nolint unusedHavesSuffices] -- This is a false positive in the unusedHavesSuffices linter.
+@[simp]
 theorem decode_list_succ (v : ℕ) :
     decode (α := List α) (succ v) =
       (· :: ·) <$> decode (α := α) v.unpair.1 <*> decode (α := List α) v.unpair.2 :=
@@ -124,7 +127,6 @@ open Encodable
 
 section List
 
-@[nolint unusedHavesSuffices] -- This is a false positive in the unusedHavesSuffices linter.
 theorem denumerable_list_aux : ∀ n : ℕ, ∃ a ∈ @decodeList α _ n, encodeList a = n
   | 0 => by rw [decodeList]; exact ⟨_, rfl, rfl⟩
   | succ v => by
@@ -145,7 +147,7 @@ instance denumerableList : Denumerable (List α) :=
 @[simp]
 theorem list_ofNat_zero : ofNat (List α) 0 = [] := by rw [← @encode_list_nil α, ofNat_encode]
 
-@[simp, nolint unusedHavesSuffices] -- This is a false positive in the unusedHavesSuffices linter.
+@[simp]
 theorem list_ofNat_succ (v : ℕ) :
     ofNat (List α) (succ v) = ofNat α v.unpair.1 :: ofNat (List α) v.unpair.2 :=
   ofNat_of_decode <|
@@ -155,7 +157,6 @@ theorem list_ofNat_succ (v : ℕ) :
       rw [show decodeList v₂ = decode (α := List α) v₂ from rfl, decode_eq_ofNat, Option.seq_some]
 
 end List
-
 
 end Denumerable
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

This is useful when we call `encode` and `decode` of a list to define a new `Encoder` involving `List`s.

```lean
theorem decodeList_encodeList_eq_self (l : List α) : decodeList (encodeList l) = some l
```


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
