### PR TITLE
[Merged by Bors] - chore(Order/BoundedOrder): golf entire `max_ne_top` using `grind`

### DIFF
--- a/Mathlib/Order/BoundedOrder/Lattice.lean
+++ b/Mathlib/Order/BoundedOrder/Lattice.lean
@@ -156,9 +156,7 @@ theorem max_eq_top [OrderTop α] {a b : α} : max a b = ⊤ ↔ a = ⊤ ∨ b = 
 
 @[aesop (rule_sets := [finiteness]) safe apply]
 lemma max_ne_top [OrderTop α] {a b : α} (ha : a ≠ ⊤) (hb : b ≠ ⊤) : max a b ≠ ⊤ := by
-  by_contra h
-  obtain (h | h) := max_eq_top.mp h
-  all_goals simp_all
+  grind [max_eq_top]
 
 end LinearOrder
 


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>max_ne_top</code>: 13 ms before, <10 ms after  🎉</summary>

### Trace profiling of `max_ne_top` before PR 28845
```diff
diff --git a/Mathlib/Order/BoundedOrder/Lattice.lean b/Mathlib/Order/BoundedOrder/Lattice.lean
index 3752a7e578..62cc646e23 100644
--- a/Mathlib/Order/BoundedOrder/Lattice.lean
+++ b/Mathlib/Order/BoundedOrder/Lattice.lean
@@ -154,6 +154,7 @@ theorem min_eq_bot [OrderBot α] {a b : α} : min a b = ⊥ ↔ a = ⊥ ∨ b =
 theorem max_eq_top [OrderTop α] {a b : α} : max a b = ⊤ ↔ a = ⊤ ∨ b = ⊤ :=
   @min_eq_bot αᵒᵈ _ _ a b
 
+set_option trace.profiler true in
 @[aesop (rule_sets := [finiteness]) safe apply]
 lemma max_ne_top [OrderTop α] {a b : α} (ha : a ≠ ⊤) (hb : b ≠ ⊤) : max a b ≠ ⊤ := by
   by_contra h
```
```
ℹ [335/335] Built Mathlib.Order.BoundedOrder.Lattice (749ms)
info: Mathlib/Order/BoundedOrder/Lattice.lean:158:0: [Elab.command] [0.025117] @[aesop (rule_sets := [finiteness]) safe apply]
    theorem max_ne_top [OrderTop α] {a b : α} (ha : a ≠ ⊤) (hb : b ≠ ⊤) : max a b ≠ ⊤ :=
      by
      by_contra h
      obtain (h | h) := max_eq_top.mp h
      all_goals simp_all
  [Elab.attribute] [0.022162] applying [aesop (rule_sets := [finiteness]) safe apply]
info: Mathlib/Order/BoundedOrder/Lattice.lean:158:0: [Elab.command] [0.025632] @[aesop (rule_sets := [finiteness]) safe apply]
    lemma max_ne_top [OrderTop α] {a b : α} (ha : a ≠ ⊤) (hb : b ≠ ⊤) : max a b ≠ ⊤ :=
      by
      by_contra h
      obtain (h | h) := max_eq_top.mp h
      all_goals simp_all
info: Mathlib/Order/BoundedOrder/Lattice.lean:158:0: [Elab.async] [0.013034] elaborating proof of max_ne_top
  [Elab.definition.value] [0.012642] max_ne_top
    [Elab.step] [0.012457] 
          by_contra h
          obtain (h | h) := max_eq_top.mp h
          all_goals simp_all
      [Elab.step] [0.012447] 
            by_contra h
            obtain (h | h) := max_eq_top.mp h
            all_goals simp_all
Build completed successfully (335 jobs).
```

### Trace profiling of `max_ne_top` after PR 28845
```diff
diff --git a/Mathlib/Order/BoundedOrder/Lattice.lean b/Mathlib/Order/BoundedOrder/Lattice.lean
index 3752a7e578..c0e9651360 100644
--- a/Mathlib/Order/BoundedOrder/Lattice.lean
+++ b/Mathlib/Order/BoundedOrder/Lattice.lean
@@ -154,11 +154,10 @@ theorem min_eq_bot [OrderBot α] {a b : α} : min a b = ⊥ ↔ a = ⊥ ∨ b =
 theorem max_eq_top [OrderTop α] {a b : α} : max a b = ⊤ ↔ a = ⊤ ∨ b = ⊤ :=
   @min_eq_bot αᵒᵈ _ _ a b
 
+set_option trace.profiler true in
 @[aesop (rule_sets := [finiteness]) safe apply]
 lemma max_ne_top [OrderTop α] {a b : α} (ha : a ≠ ⊤) (hb : b ≠ ⊤) : max a b ≠ ⊤ := by
-  by_contra h
-  obtain (h | h) := max_eq_top.mp h
-  all_goals simp_all
+  grind [max_eq_top]
 
 end LinearOrder
 
```
```
ℹ [335/335] Built Mathlib.Order.BoundedOrder.Lattice (728ms)
info: Mathlib/Order/BoundedOrder/Lattice.lean:158:0: [Elab.command] [0.023555] @[aesop (rule_sets := [finiteness]) safe apply]
    theorem max_ne_top [OrderTop α] {a b : α} (ha : a ≠ ⊤) (hb : b ≠ ⊤) : max a b ≠ ⊤ := by grind [max_eq_top]
  [Elab.attribute] [0.019870] applying [aesop (rule_sets := [finiteness]) safe apply]
info: Mathlib/Order/BoundedOrder/Lattice.lean:158:0: [Elab.command] [0.024063] @[aesop (rule_sets := [finiteness]) safe apply]
    lemma max_ne_top [OrderTop α] {a b : α} (ha : a ≠ ⊤) (hb : b ≠ ⊤) : max a b ≠ ⊤ := by grind [max_eq_top]
Build completed successfully (335 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
