### PR TITLE
[Merged by Bors] - refactor: generalize galRestrict to different rings

### DIFF
--- a/Mathlib/RingTheory/IntegralClosure/IntegralRestrict.lean
+++ b/Mathlib/RingTheory/IntegralClosure/IntegralRestrict.lean
@@ -26,104 +26,124 @@ defined to be the restriction of the norm map of `Frac(B)/Frac(A)`.
 -/
 open nonZeroDivisors
 
-variable (A K L F B C : Type*)
-variable [CommRing A] [CommRing B] [CommRing C]
-variable [Algebra A B] [Algebra A C]
-variable [Field K] [Field L] [Field F]
+variable (A K L L₂ L₃ B B₂ B₃ : Type*)
+variable [CommRing A] [CommRing B] [CommRing B₂] [CommRing B₃]
+variable [Algebra A B] [Algebra A B₂] [Algebra A B₃]
+variable [Field K] [Field L] [Field L₂] [Field L₃]
 variable [Algebra A K] [IsFractionRing A K]
 variable [Algebra K L] [Algebra A L] [IsScalarTower A K L]
-variable [Algebra K F] [Algebra A F] [IsScalarTower A K F]
+variable [Algebra K L₂] [Algebra A L₂] [IsScalarTower A K L₂]
+variable [Algebra K L₃] [Algebra A L₃] [IsScalarTower A K L₃]
 variable [Algebra B L] [IsScalarTower A B L] [IsIntegralClosure B A L]
-variable [Algebra C F] [IsScalarTower A C F] [IsIntegralClosure C A F]
+variable [Algebra B₂ L₂] [IsScalarTower A B₂ L₂] [IsIntegralClosure B₂ A L₂]
+variable [Algebra B₃ L₃] [IsScalarTower A B₃ L₃] [IsIntegralClosure B₃ A L₃]
 
 section galois
 
+section galRestrict'
+variable {K L L₂ L₃}
+omit [IsFractionRing A K]
+
 /-- A generalization of `galRestrictHom` beyond endomorphisms. -/
 noncomputable
-def galRestrict' (f : L →ₐ[K] F) : (B →ₐ[A] C) :=
-  (IsIntegralClosure.equiv A (integralClosure A F) F C).toAlgHom.comp
+def galRestrict' (f : L →ₐ[K] L₂) : (B →ₐ[A] B₂) :=
+  (IsIntegralClosure.equiv A (integralClosure A L₂) L₂ B₂).toAlgHom.comp
       (((f.restrictScalars A).comp (IsScalarTower.toAlgHom A B L)).codRestrict
-        (integralClosure A F) (fun x ↦ IsIntegral.map _ (IsIntegralClosure.isIntegral A L x)))
+        (integralClosure A L₂) (fun x ↦ IsIntegral.map _ (IsIntegralClosure.isIntegral A L x)))
 
-omit [IsFractionRing A K] in
 @[simp]
-lemma algebraMap_galRestrict'_apply (σ : L →ₐ[K] F) (x : B) :
-    algebraMap C F (galRestrict' A K L F B C σ x) = σ (algebraMap B L x) := by
+lemma algebraMap_galRestrict'_apply (σ : L →ₐ[K] L₂) (x : B) :
+    algebraMap B₂ L₂ (galRestrict' A B B₂ σ x) = σ (algebraMap B L x) := by
   simp [galRestrict', galRestrict', Subalgebra.algebraMap_eq]
 
+theorem galRestrict'_comp (σ : L →ₐ[K] L₂) (σ' : L₂ →ₐ[K] L₃) :
+    galRestrict' A B B₃ (σ'.comp σ) = (galRestrict' A B₂ B₃ σ').comp (galRestrict' A B B₂ σ) := by
+  ext x
+  apply (IsIntegralClosure.equiv A (integralClosure A L₃) L₃ B₃).symm.injective
+  ext
+  simp [galRestrict', Subalgebra.algebraMap_eq]
+
+end galRestrict'
+
 variable [Algebra.IsAlgebraic K L]
+
+section galLift
+variable {A B B₂ B₃}
 
 /-- A generalization of the the lift `End(B/A) → End(L/K)` in an ALKB setup.
 This is inverse to the restriction. See `galRestrictHom`. -/
 noncomputable
-def galLift (σ : B →ₐ[A] C) : L →ₐ[K] F :=
+def galLift (σ : B →ₐ[A] B₂) : L →ₐ[K] L₂ :=
   haveI := (IsFractionRing.injective A K).isDomain
-  haveI := NoZeroSMulDivisors.trans_faithfulSMul A K F
+  haveI := NoZeroSMulDivisors.trans_faithfulSMul A K L₂
   haveI := IsIntegralClosure.isLocalization A K L B
   haveI H : ∀ (y :  Algebra.algebraMapSubmonoid B A⁰),
-      IsUnit (((algebraMap C F).comp σ) (y : B)) := by
+      IsUnit (((algebraMap B₂ L₂).comp σ) (y : B)) := by
     rintro ⟨_, x, hx, rfl⟩
     simpa only [RingHom.coe_comp, RingHom.coe_coe, Function.comp_apply, AlgHom.commutes,
       isUnit_iff_ne_zero, ne_eq, map_eq_zero_iff _ (FaithfulSMul.algebraMap_injective _ _),
       ← IsScalarTower.algebraMap_apply] using nonZeroDivisors.ne_zero hx
-  haveI H_eq : (IsLocalization.lift (S := L) H).comp (algebraMap K L) = (algebraMap K F) := by
+  haveI H_eq : (IsLocalization.lift (S := L) H).comp (algebraMap K L) = (algebraMap K L₂) := by
     apply IsLocalization.ringHom_ext A⁰
     ext
     simp only [RingHom.coe_comp, Function.comp_apply, ← IsScalarTower.algebraMap_apply A K L,
-      ← IsScalarTower.algebraMap_apply A K F,
-      IsScalarTower.algebraMap_apply A B L, IsScalarTower.algebraMap_apply A C F,
+      ← IsScalarTower.algebraMap_apply A K L₂,
+      IsScalarTower.algebraMap_apply A B L, IsScalarTower.algebraMap_apply A B₂ L₂,
       IsLocalization.lift_eq, RingHom.coe_coe, AlgHom.commutes]
   { IsLocalization.lift (S := L) H with commutes' := DFunLike.congr_fun H_eq }
 
-omit [IsIntegralClosure C A F] in
+omit [IsIntegralClosure B₂ A L₂] in
 @[simp]
-theorem galLift_algebraMap_apply (σ : B →ₐ[A] C) (x : B) :
-    galLift A K L F B C σ (algebraMap B L x) = algebraMap C F (σ x) := by
+theorem galLift_algebraMap_apply (σ : B →ₐ[A] B₂) (x : B) :
+    galLift K L L₂ σ (algebraMap B L x) = algebraMap B₂ L₂ (σ x) := by
   simp [galLift]
 
+omit [IsIntegralClosure B₃ A L₃] in
+theorem galLift_comp [Algebra.IsAlgebraic K L₂] (σ : B →ₐ[A] B₂) (σ' : B₂ →ₐ[A] B₃) :
+    galLift K L L₃ (σ'.comp σ) = (galLift K L₂ L₃ σ').comp (galLift K L L₂ σ) :=
+  have := (IsFractionRing.injective A K).isDomain
+  have := IsIntegralClosure.isLocalization A K L B
+  AlgHom.coe_ringHom_injective <| IsLocalization.ringHom_ext (Algebra.algebraMapSubmonoid B A⁰)
+    <| RingHom.ext fun x ↦ by simp
+
 @[simp]
-theorem galLift_galRestrict' (σ : L →ₐ[K] F) :
-    galLift A K L F B C (galRestrict' A K L F B C σ) = σ :=
+theorem galLift_galRestrict' (σ : L →ₐ[K] L₂) :
+    galLift K L L₂ (galRestrict' A B B₂ σ) = σ :=
   have := (IsFractionRing.injective A K).isDomain
   have := IsIntegralClosure.isLocalization A K L B
   AlgHom.coe_ringHom_injective <| IsLocalization.ringHom_ext (Algebra.algebraMapSubmonoid B A⁰)
     <| RingHom.ext fun x ↦ by simp [galRestrict', Subalgebra.algebraMap_eq, galLift]
 
 @[simp]
-theorem galRestrict'_galLift (σ : B →ₐ[A] C) :
-    galRestrict' A K L F B C (galLift A K L F B C σ) = σ :=
+theorem galRestrict'_galLift (σ : B →ₐ[A] B₂) :
+    galRestrict' A B B₂ (galLift K L L₂ σ) = σ :=
   have := (IsFractionRing.injective A K).isDomain
   have := IsIntegralClosure.isLocalization A K L B
-  AlgHom.ext fun x ↦ IsIntegralClosure.algebraMap_injective C A F
+  AlgHom.ext fun x ↦ IsIntegralClosure.algebraMap_injective B₂ A L₂
     (by simp [galRestrict', Subalgebra.algebraMap_eq, galLift])
+
+end galLift
 
 /-- The restriction `End(L/K) → End(B/A)` in an AKLB setup.
 Also see `galRestrict` for the `AlgEquiv` version. -/
+@[simps -isSimp]
 noncomputable
 def galRestrictHom : (L →ₐ[K] L) ≃* (B →ₐ[A] B) where
-  toFun f := galRestrict' A K L L B B f
-  map_mul' σ₁ σ₂ := by
-    ext x
-    apply (IsIntegralClosure.equiv A (integralClosure A L) L B).symm.injective
-    ext
-    dsimp [galRestrict']
-    simp only [AlgEquiv.symm_apply_apply, AlgHom.coe_codRestrict, AlgHom.coe_restrictScalars',
-      AlgHom.coe_comp, IsScalarTower.coe_toAlgHom', Function.comp_apply,
-      AlgHom.mul_apply, IsIntegralClosure.algebraMap_equiv, Subalgebra.algebraMap_eq]
-    rfl
-  invFun := galLift A K L L B B
-  left_inv σ := galLift_galRestrict' _ _ _ _ _ _ _
-  right_inv σ := galRestrict'_galLift _ _ _ _ _ _ _
+  toFun f := galRestrict' A B B f
+  map_mul' σ₁ σ₂ := galRestrict'_comp _ _ _ _ σ₂ σ₁
+  invFun := galLift K L L
+  left_inv σ := galLift_galRestrict' _ _ _ σ
+  right_inv σ := galRestrict'_galLift _ _ _ σ
 
 @[simp]
 lemma algebraMap_galRestrictHom_apply (σ : L →ₐ[K] L) (x : B) :
     algebraMap B L (galRestrictHom A K L B σ x) = σ (algebraMap B L x) :=
-  algebraMap_galRestrict'_apply _ _ _ _ _ _ _ _
+  algebraMap_galRestrict'_apply _ _ _ _ _
 
 @[simp, nolint unusedHavesSuffices] -- false positive from unfolding galRestrictHom
 lemma galRestrictHom_symm_algebraMap_apply (σ : B →ₐ[A] B) (x : B) :
     (galRestrictHom A K L B).symm σ (algebraMap B L x) = algebraMap B L (σ x) :=
-  galLift_algebraMap_apply _ _ _ _ _ _ _ _
+  galLift_algebraMap_apply _ _ _ _ _
 
 /-- The restriction `Aut(L/K) → Aut(B/A)` in an AKLB setup. -/
 noncomputable

--- a/Mathlib/RingTheory/IntegralClosure/IntegralRestrict.lean
+++ b/Mathlib/RingTheory/IntegralClosure/IntegralRestrict.lean
@@ -75,6 +75,12 @@ def galLift (σ : B →ₐ[A] C) : L →ₐ[K] F :=
       IsLocalization.lift_eq, RingHom.coe_coe, AlgHom.commutes]
   { IsLocalization.lift (S := L) H with commutes' := DFunLike.congr_fun H_eq }
 
+omit [IsIntegralClosure C A F] [Algebra.IsAlgebraic K F] in
+@[simp]
+theorem galLift_algebraMap_apply (σ : B →ₐ[A] C) (x : B) :
+    galLift A K L F B C σ (algebraMap B L x) = algebraMap C F (σ x) := by
+  simp [galLift]
+
 /-- The restriction `End(L/K) → End(B/A)` in an AKLB setup.
 Also see `galRestrict` for the `AlgEquiv` version. -/
 noncomputable
@@ -104,15 +110,13 @@ def galRestrictHom : (L →ₐ[K] L) ≃* (B →ₐ[A] B) where
 
 @[simp]
 lemma algebraMap_galRestrictHom_apply (σ : L →ₐ[K] L) (x : B) :
-    algebraMap B L (galRestrictHom A K L B σ x) = σ (algebraMap B L x) := by
-  simp [galRestrictHom]
+    algebraMap B L (galRestrictHom A K L B σ x) = σ (algebraMap B L x) :=
+  algebraMap_galRestrict'_apply _ _ _ _ _ _ _ _
 
 @[simp, nolint unusedHavesSuffices] -- false positive from unfolding galRestrictHom
 lemma galRestrictHom_symm_algebraMap_apply (σ : B →ₐ[A] B) (x : B) :
-    (galRestrictHom A K L B).symm σ (algebraMap B L x) = algebraMap B L (σ x) := by
-  have := (IsFractionRing.injective A K).isDomain
-  have := IsIntegralClosure.isLocalization A K L B
-  simp [galRestrictHom, galLift]
+    (galRestrictHom A K L B).symm σ (algebraMap B L x) = algebraMap B L (σ x) :=
+  galLift_algebraMap_apply _ _ _ _ _ _ _ _
 
 /-- The restriction `Aut(L/K) → Aut(B/A)` in an AKLB setup. -/
 noncomputable

--- a/Mathlib/RingTheory/IntegralClosure/IntegralRestrict.lean
+++ b/Mathlib/RingTheory/IntegralClosure/IntegralRestrict.lean
@@ -51,7 +51,7 @@ lemma algebraMap_galRestrict'_apply (σ : L →ₐ[K] F) (x : B) :
     algebraMap C F (galRestrict' A K L F B C σ x) = σ (algebraMap B L x) := by
   simp [galRestrict', galRestrict', Subalgebra.algebraMap_eq]
 
-variable [Algebra.IsAlgebraic K L] [Algebra.IsAlgebraic K F]
+variable [Algebra.IsAlgebraic K L]
 
 /-- A generalization of the the lift `End(B/A) → End(L/K)` in an ALKB setup.
 This is inverse to the restriction. See `galRestrictHom`. -/
@@ -75,19 +75,34 @@ def galLift (σ : B →ₐ[A] C) : L →ₐ[K] F :=
       IsLocalization.lift_eq, RingHom.coe_coe, AlgHom.commutes]
   { IsLocalization.lift (S := L) H with commutes' := DFunLike.congr_fun H_eq }
 
-omit [IsIntegralClosure C A F] [Algebra.IsAlgebraic K F] in
+omit [IsIntegralClosure C A F] in
 @[simp]
 theorem galLift_algebraMap_apply (σ : B →ₐ[A] C) (x : B) :
     galLift A K L F B C σ (algebraMap B L x) = algebraMap C F (σ x) := by
   simp [galLift]
+
+@[simp]
+theorem galLift_galRestrict' (σ : L →ₐ[K] F) :
+    galLift A K L F B C (galRestrict' A K L F B C σ) = σ :=
+  have := (IsFractionRing.injective A K).isDomain
+  have := IsIntegralClosure.isLocalization A K L B
+  AlgHom.coe_ringHom_injective <| IsLocalization.ringHom_ext (Algebra.algebraMapSubmonoid B A⁰)
+    <| RingHom.ext fun x ↦ by simp [galRestrict', Subalgebra.algebraMap_eq, galLift]
+
+@[simp]
+theorem galRestrict'_galLift (σ : B →ₐ[A] C) :
+    galRestrict' A K L F B C (galLift A K L F B C σ) = σ :=
+  have := (IsFractionRing.injective A K).isDomain
+  have := IsIntegralClosure.isLocalization A K L B
+  AlgHom.ext fun x ↦ IsIntegralClosure.algebraMap_injective C A F
+    (by simp [galRestrict', Subalgebra.algebraMap_eq, galLift])
 
 /-- The restriction `End(L/K) → End(B/A)` in an AKLB setup.
 Also see `galRestrict` for the `AlgEquiv` version. -/
 noncomputable
 def galRestrictHom : (L →ₐ[K] L) ≃* (B →ₐ[A] B) where
   toFun f := galRestrict' A K L L B B f
-  map_mul' := by
-    intro σ₁ σ₂
+  map_mul' σ₁ σ₂ := by
     ext x
     apply (IsIntegralClosure.equiv A (integralClosure A L) L B).symm.injective
     ext
@@ -97,16 +112,8 @@ def galRestrictHom : (L →ₐ[K] L) ≃* (B →ₐ[A] B) where
       AlgHom.mul_apply, IsIntegralClosure.algebraMap_equiv, Subalgebra.algebraMap_eq]
     rfl
   invFun := galLift A K L L B B
-  left_inv σ :=
-    have := (IsFractionRing.injective A K).isDomain
-    have := IsIntegralClosure.isLocalization A K L B
-    AlgHom.coe_ringHom_injective <| IsLocalization.ringHom_ext (Algebra.algebraMapSubmonoid B A⁰)
-      <| RingHom.ext fun x ↦ by simp [galRestrict', Subalgebra.algebraMap_eq, galLift]
-  right_inv σ :=
-    have := (IsFractionRing.injective A K).isDomain
-    have := IsIntegralClosure.isLocalization A K L B
-    AlgHom.ext fun x ↦ IsIntegralClosure.algebraMap_injective B A L
-      (by simp [galRestrict', Subalgebra.algebraMap_eq, galLift])
+  left_inv σ := galLift_galRestrict' _ _ _ _ _ _ _
+  right_inv σ := galRestrict'_galLift _ _ _ _ _ _ _
 
 @[simp]
 lemma algebraMap_galRestrictHom_apply (σ : L →ₐ[K] L) (x : B) :


### PR DESCRIPTION
This adds a new `galRestrict'` which generalizes the forward direction of `galRestrict`, and genrealizes `galLift` in-place.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
