### PR TITLE
chore(RingTheory/Valuation): golf entire `zero_of_hom_zero` using `grind`

### DIFF
--- a/Mathlib/RingTheory/Valuation/RankOne.lean
+++ b/Mathlib/RingTheory/Valuation/RankOne.lean
@@ -85,10 +85,7 @@ lemma nontrivial : ∃ r : R, v r ≠ 0 ∧ v r ≠ 1 := IsNontrivial.exists_val
 /-- If `v` is a rank one valuation and `x : Γ₀` has image `0` under `RankOne.hom v`, then
   `x = 0`. -/
 theorem zero_of_hom_zero {x : Γ₀} (hx : hom v x = 0) : x = 0 := by
-  refine (eq_of_le_of_not_lt (zero_le' (a := x)) fun h_lt ↦ ?_).symm
-  have hs := strictMono v h_lt
-  rw [map_zero, hx] at hs
-  exact hs.false
+  grind [map_eq_zero]
 
 /-- If `v` is a rank one valuation, then`x : Γ₀` has image `0` under `RankOne.hom v` if and
   only if `x = 0`. -/


### PR DESCRIPTION
---
<details>
<summary>Show trace profiling of <code>zero_of_hom_zero</code>: 16 ms before, 125 ms after </summary>

### Trace profiling of `zero_of_hom_zero` before PR 28848
```diff
diff --git a/Mathlib/RingTheory/Valuation/RankOne.lean b/Mathlib/RingTheory/Valuation/RankOne.lean
index a5ce11bd00..c0c85f7341 100644
--- a/Mathlib/RingTheory/Valuation/RankOne.lean
+++ b/Mathlib/RingTheory/Valuation/RankOne.lean
@@ -82,6 +82,7 @@ lemma strictMono : StrictMono (hom v) := strictMono'
 
 lemma nontrivial : ∃ r : R, v r ≠ 0 ∧ v r ≠ 1 := IsNontrivial.exists_val_nontrivial
 
+set_option trace.profiler true in
 /-- If `v` is a rank one valuation and `x : Γ₀` has image `0` under `RankOne.hom v`, then
   `x = 0`. -/
 theorem zero_of_hom_zero {x : Γ₀} (hx : hom v x = 0) : x = 0 := by
```
```
ℹ [1886/1886] Built Mathlib.RingTheory.Valuation.RankOne (3.1s)
info: Mathlib/RingTheory/Valuation/RankOne.lean:86:0: [Elab.async] [0.016857] elaborating proof of Valuation.RankOne.zero_of_hom_zero
  [Elab.definition.value] [0.016434] Valuation.RankOne.zero_of_hom_zero
    [Elab.step] [0.016082] 
          refine (eq_of_le_of_not_lt (zero_le' (a := x)) fun h_lt ↦ ?_).symm
          have hs := strictMono v h_lt
          rw [map_zero, hx] at hs
          exact hs.false
      [Elab.step] [0.016074] 
            refine (eq_of_le_of_not_lt (zero_le' (a := x)) fun h_lt ↦ ?_).symm
            have hs := strictMono v h_lt
            rw [map_zero, hx] at hs
            exact hs.false
Build completed successfully (1886 jobs).
```

### Trace profiling of `zero_of_hom_zero` after PR 28848
```diff
diff --git a/Mathlib/RingTheory/Valuation/RankOne.lean b/Mathlib/RingTheory/Valuation/RankOne.lean
index a5ce11bd00..95ffb42b73 100644
--- a/Mathlib/RingTheory/Valuation/RankOne.lean
+++ b/Mathlib/RingTheory/Valuation/RankOne.lean
@@ -82,13 +82,11 @@ lemma strictMono : StrictMono (hom v) := strictMono'
 
 lemma nontrivial : ∃ r : R, v r ≠ 0 ∧ v r ≠ 1 := IsNontrivial.exists_val_nontrivial
 
+set_option trace.profiler true in
 /-- If `v` is a rank one valuation and `x : Γ₀` has image `0` under `RankOne.hom v`, then
   `x = 0`. -/
 theorem zero_of_hom_zero {x : Γ₀} (hx : hom v x = 0) : x = 0 := by
-  refine (eq_of_le_of_not_lt (zero_le' (a := x)) fun h_lt ↦ ?_).symm
-  have hs := strictMono v h_lt
-  rw [map_zero, hx] at hs
-  exact hs.false
+  grind [map_eq_zero]
 
 /-- If `v` is a rank one valuation, then`x : Γ₀` has image `0` under `RankOne.hom v` if and
   only if `x = 0`. -/
```
```
ℹ [1886/1886] Built Mathlib.RingTheory.Valuation.RankOne (1.2s)
info: Mathlib/RingTheory/Valuation/RankOne.lean:86:0: [Elab.async] [0.125167] elaborating proof of Valuation.RankOne.zero_of_hom_zero
  [Elab.definition.value] [0.124930] Valuation.RankOne.zero_of_hom_zero
    [Elab.step] [0.124788] grind [map_eq_zero]
      [Elab.step] [0.124783] grind [map_eq_zero]
        [Elab.step] [0.124776] grind [map_eq_zero]
          [Meta.synthInstance] [0.044722] ✅️ Lean.Grind.IsCharP (Lean.Grind.Ring.OfSemiring.Q ℝ≥0) 0
            [Meta.synthInstance] [0.011296] ❌️ apply @RCLike.charZero_rclike to CharZero ℝ≥0
              [Meta.synthInstance.tryResolve] [0.011282] ❌️ CharZero ℝ≥0 ≟ CharZero ?m.58
                [Meta.isDefEq] [0.011266] ❌️ CharZero ℝ≥0 =?= CharZero ?m.58
                  [Meta.isDefEq] [0.011227] ❌️ instCommSemiringNNReal.toNonAssocSemiring.toAddCommMonoidWithOne.toAddMonoidWithOne =?= NormedField.toNormedCommRing.toAddGroupWithOne.toAddMonoidWithOne
                    [Meta.isDefEq] [0.011190] ❌️ instCommSemiringNNReal.toNonAssocSemiring.toAddCommMonoidWithOne.1 =?= NormedField.toNormedCommRing.toAddGroupWithOne.2
                      [Meta.isDefEq] [0.011164] ❌️ { toNatCast := instCommSemiringNNReal.toNonAssocSemiring.toNatCast,
                            toAddMonoid := instCommSemiringNNReal.toNonAssocSemiring.toAddMonoid,
                            toOne := instCommSemiringNNReal.toNonAssocSemiring.toOne, natCast_zero := ⋯,
                            natCast_succ :=
                              ⋯ } =?= { toNatCast := NormedField.toNormedCommRing.toNatCast,
                            toAddMonoid := NormedField.toNormedCommRing.toAddMonoid,
                            toOne := NormedField.toNormedCommRing.toOne, natCast_zero := ⋯, natCast_succ := ⋯ }
                        [Meta.isDefEq] [0.011067] ❌️ instCommSemiringNNReal.toNonAssocSemiring.toNatCast =?= NormedField.toNormedCommRing.toNatCast
                          [Meta.isDefEq] [0.011054] ❌️ instCommSemiringNNReal.toNatCast =?= NormedField.toNormedCommRing.toNatCast
          [Meta.synthInstance] [0.032067] ❌️ Lean.Grind.NoNatZeroDivisors (Lean.Grind.Ring.OfSemiring.Q ℝ≥0)
Build completed successfully (1886 jobs).
```
</details>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
