### PR TITLE
[Merged by Bors] - chore(Topology/Sheaves): golf entire `exists_le_of_le_sup` using `grind`

### DIFF
--- a/Mathlib/Topology/Sheaves/Alexandrov.lean
+++ b/Mathlib/Topology/Sheaves/Alexandrov.lean
@@ -64,11 +64,7 @@ def principals : X ⥤ (Opens X)ᵒᵖ where
 lemma exists_le_of_le_sup {ι : Type v} {x : X}
     (Us : ι → Opens X) (h : principalOpen x ≤ iSup Us) :
     ∃ i : ι, principalOpen x ≤ Us i := by
-  have : x ∈ iSup Us := h <| self_mem_principalOpen x
-  simp only [Opens.mem_iSup] at this
-  obtain ⟨i, hi⟩ := this
-  refine ⟨i, ?_⟩
-  simpa
+  grind [principalOpen_le_iff, Opens.mem_iSup]
 
 /-- The right kan extension of `F` along `X ⥤ (Opens X)ᵒᵖ`. -/
 abbrev principalsKanExtension : (Opens X)ᵒᵖ ⥤ C :=


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
