### PR TITLE
[Merged by Bors] - chore(Algebra/Order/Nonneg/Module): don't import `Finset`

### DIFF
--- a/Mathlib/Algebra/Order/Nonneg/Module.lean
+++ b/Mathlib/Algebra/Order/Nonneg/Module.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Apurva Nakade
 -/
 import Mathlib.Algebra.Module.RingHom
-import Mathlib.Algebra.Order.Module.Defs
+import Mathlib.Algebra.Order.Module.OrderedSMul
 import Mathlib.Algebra.Order.Nonneg.Basic
 
 /-!
@@ -65,16 +65,10 @@ end SMulWithZero
 section OrderedSMul
 
 variable [IsOrderedRing R] [AddCommMonoid E] [PartialOrder E] [IsOrderedAddMonoid E]
-  [SMulWithZero R E]
+  [SMulWithZero R E] [hE : OrderedSMul R E]
 
-instance instIsOrderedModule [hE : IsOrderedModule R E] : IsOrderedModule R≥0 E where
-  smul_le_smul_of_nonneg_left _b hb _a₁ _a₂ ha := hE.1 hb ha
-  smul_le_smul_of_nonneg_right _b hb _a₁ _a₂ ha := hE.2 hb ha
-
-instance instIsStrictOrderedModule [hE : IsStrictOrderedModule R E] :
-    IsStrictOrderedModule R≥0 E where
-  smul_lt_smul_of_pos_left _b hb _a₁ _a₂ ha := hE.1 hb ha
-  smul_lt_smul_of_pos_right _b hb _a₁ _a₂ ha := hE.2 hb ha
+instance instOrderedSMul : OrderedSMul R≥0 E :=
+  ⟨hE.1, hE.2⟩
 
 end OrderedSMul
 

--- a/Mathlib/Algebra/Order/Nonneg/Module.lean
+++ b/Mathlib/Algebra/Order/Nonneg/Module.lean
@@ -3,58 +3,60 @@ Copyright (c) 2023 Apurva Nakade. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Apurva Nakade
 -/
-import Mathlib.Algebra.Order.Module.OrderedSMul
-import Mathlib.RingTheory.Finiteness.Basic
+import Mathlib.Algebra.Module.RingHom
+import Mathlib.Algebra.Order.Module.Defs
+import Mathlib.Algebra.Order.Nonneg.Basic
 
 /-!
 # Modules over nonnegative elements
 
 This file defines instances and prove some properties about modules over nonnegative elements
-`{c : 𝕜 // 0 ≤ c}` of an arbitrary `OrderedSemiring 𝕜`.
+`{c : R // 0 ≤ c}` of an arbitrary `OrderedSemiring R`.
 
 These instances are useful for working with `ConvexCone`.
 
 -/
 
-variable {𝕜 𝕜' E : Type*}
+assert_not_exists Finset
 
-local notation3 "𝕜≥0" => {c : 𝕜 // 0 ≤ c}
+variable {R S E : Type*}
+
+local notation3 "R≥0" => {c : R // 0 ≤ c}
 
 namespace Nonneg
-section Semiring
-variable [Semiring 𝕜] [PartialOrder 𝕜]
+variable [Semiring R] [PartialOrder R]
 
 section SMul
 
-variable [SMul 𝕜 𝕜']
+variable [SMul R S]
 
-instance instSMul : SMul 𝕜≥0 𝕜' where
+instance instSMul : SMul R≥0 S where
   smul c x := c.val • x
 
 @[simp, norm_cast]
-lemma coe_smul (a : 𝕜≥0) (x : 𝕜') : (a : 𝕜) • x = a • x :=
+lemma coe_smul (a : R≥0) (x : S) : (a : R) • x = a • x :=
   rfl
 
 @[simp]
-lemma mk_smul (a) (ha) (x : 𝕜') : (⟨a, ha⟩ : 𝕜≥0) • x = a • x :=
+lemma mk_smul (a) (ha) (x : S) : (⟨a, ha⟩ : R≥0) • x = a • x :=
   rfl
 
 end SMul
 
 section IsScalarTower
 
-variable [IsOrderedRing 𝕜] [SMul 𝕜 𝕜'] [SMul 𝕜 E] [SMul 𝕜' E] [IsScalarTower 𝕜 𝕜' E]
+variable [IsOrderedRing R] [SMul R S] [SMul R E] [SMul S E] [IsScalarTower R S E]
 
-instance instIsScalarTower : IsScalarTower 𝕜≥0 𝕜' E :=
+instance instIsScalarTower : IsScalarTower R≥0 S E :=
   SMul.comp.isScalarTower ↑Nonneg.coeRingHom
 
 end IsScalarTower
 
 section SMulWithZero
 
-variable [Zero 𝕜'] [SMulWithZero 𝕜 𝕜']
+variable [Zero S] [SMulWithZero R S]
 
-instance instSMulWithZero : SMulWithZero 𝕜≥0 𝕜' where
+instance instSMulWithZero : SMulWithZero R≥0 S where
   smul_zero _ := smul_zero _
   zero_smul _ := zero_smul _ _
 
@@ -62,40 +64,26 @@ end SMulWithZero
 
 section OrderedSMul
 
-variable [IsOrderedRing 𝕜] [AddCommMonoid E] [PartialOrder E] [IsOrderedAddMonoid E]
-  [SMulWithZero 𝕜 E] [hE : OrderedSMul 𝕜 E]
+variable [IsOrderedRing R] [AddCommMonoid E] [PartialOrder E] [IsOrderedAddMonoid E]
+  [SMulWithZero R E]
 
-instance instOrderedSMul : OrderedSMul 𝕜≥0 E :=
-  ⟨hE.1, hE.2⟩
+instance instIsOrderedModule [hE : IsOrderedModule R E] : IsOrderedModule R≥0 E where
+  smul_le_smul_of_nonneg_left _b hb _a₁ _a₂ ha := hE.1 hb ha
+  smul_le_smul_of_nonneg_right _b hb _a₁ _a₂ ha := hE.2 hb ha
+
+instance instIsStrictOrderedModule [hE : IsStrictOrderedModule R E] :
+    IsStrictOrderedModule R≥0 E where
+  smul_lt_smul_of_pos_left _b hb _a₁ _a₂ ha := hE.1 hb ha
+  smul_lt_smul_of_pos_right _b hb _a₁ _a₂ ha := hE.2 hb ha
 
 end OrderedSMul
 
 section Module
 
-variable [IsOrderedRing 𝕜] [AddCommMonoid E] [Module 𝕜 E]
+variable [IsOrderedRing R] [AddCommMonoid E] [Module R E]
 
 /-- A module over an ordered semiring is also a module over just the non-negative scalars. -/
-instance instModule : Module 𝕜≥0 E :=
-  Module.compHom E Nonneg.coeRingHom
+instance instModule : Module R≥0 E := .compHom E coeRingHom
 
 end Module
-end Semiring
-
-section Ring
-variable [Ring 𝕜] [LinearOrder 𝕜] [IsOrderedRing 𝕜] [AddCommMonoid E] [Module 𝕜 E]
-
-private instance instModuleFiniteAux : Module.Finite 𝕜≥0 𝕜 := by
-  simp_rw [Module.finite_def, Submodule.fg_def, Submodule.eq_top_iff']
-  refine ⟨{1, -1}, by simp, fun x ↦ ?_⟩
-  obtain hx | hx := le_total 0 x
-  · simpa using Submodule.smul_mem (M := 𝕜) (.span 𝕜≥0 {1, -1}) ⟨x, hx⟩ (x := 1)
-      (Submodule.subset_span <| by simp)
-  · simpa using Submodule.smul_mem (M := 𝕜) (.span 𝕜≥0 {1, -1}) ⟨-x, neg_nonneg.2 hx⟩ (x := -1)
-      (Submodule.subset_span <| by simp)
-
-/-- If a module is finite over a linearly ordered ring, then it is also finite over the non-negative
-scalars. -/
-instance instModuleFinite [Module.Finite 𝕜 E] : Module.Finite 𝕜≥0 E := .trans 𝕜 E
-
-end Ring
 end Nonneg

--- a/Mathlib/Algebra/Order/Nonneg/Module.lean
+++ b/Mathlib/Algebra/Order/Nonneg/Module.lean
@@ -10,16 +10,15 @@ import Mathlib.Algebra.Order.Nonneg.Basic
 /-!
 # Modules over nonnegative elements
 
-This file defines instances and prove some properties about modules over nonnegative elements
-`{c : R // 0 ≤ c}` of an arbitrary `OrderedSemiring R`.
+For an ordered ring `R`, this file proves that any (ordered) `R`-module `M` is also an (ordered)
+`R≥0`-module`.
 
-These instances are useful for working with `ConvexCone`.
-
+Among other things, these instances are useful for working with `ConvexCone`.
 -/
 
 assert_not_exists Finset
 
-variable {R S E : Type*}
+variable {R S M : Type*}
 
 local notation3 "R≥0" => {c : R // 0 ≤ c}
 
@@ -45,9 +44,9 @@ end SMul
 
 section IsScalarTower
 
-variable [IsOrderedRing R] [SMul R S] [SMul R E] [SMul S E] [IsScalarTower R S E]
+variable [IsOrderedRing R] [SMul R S] [SMul R M] [SMul S M] [IsScalarTower R S M]
 
-instance instIsScalarTower : IsScalarTower R≥0 S E :=
+instance instIsScalarTower : IsScalarTower R≥0 S M :=
   SMul.comp.isScalarTower ↑Nonneg.coeRingHom
 
 end IsScalarTower
@@ -64,20 +63,20 @@ end SMulWithZero
 
 section OrderedSMul
 
-variable [IsOrderedRing R] [AddCommMonoid E] [PartialOrder E] [IsOrderedAddMonoid E]
-  [SMulWithZero R E] [hE : OrderedSMul R E]
+variable [IsOrderedRing R] [AddCommMonoid M] [PartialOrder M] [IsOrderedAddMonoid M]
+  [SMulWithZero R M] [hE : OrderedSMul R M]
 
-instance instOrderedSMul : OrderedSMul R≥0 E :=
+instance instOrderedSMul : OrderedSMul R≥0 M :=
   ⟨hE.1, hE.2⟩
 
 end OrderedSMul
 
 section Module
 
-variable [IsOrderedRing R] [AddCommMonoid E] [Module R E]
+variable [IsOrderedRing R] [AddCommMonoid M] [Module R M]
 
 /-- A module over an ordered semiring is also a module over just the non-negative scalars. -/
-instance instModule : Module R≥0 E := .compHom E coeRingHom
+instance instModule : Module R≥0 M := .compHom M coeRingHom
 
 end Module
 end Nonneg

--- a/Mathlib/RingTheory/Finiteness/Basic.lean
+++ b/Mathlib/RingTheory/Finiteness/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
 import Mathlib.Algebra.Algebra.Tower
+import Mathlib.Algebra.Order.Nonneg.Module
 import Mathlib.LinearAlgebra.Pi
 import Mathlib.LinearAlgebra.Quotient.Defs
 import Mathlib.RingTheory.Finiteness.Defs
@@ -421,3 +422,23 @@ theorem of_comp_finite {f : A →ₐ[R] B} {g : B →ₐ[R] C} (h : (g.comp f).F
 end Finite
 
 end AlgHom
+
+section Ring
+variable {R E : Type*} [Ring R] [LinearOrder R] [IsOrderedRing R] [AddCommMonoid E] [Module R E]
+
+local notation3 "R≥0" => {c : R // 0 ≤ c}
+
+private instance instModuleFiniteAux : Module.Finite R≥0 R := by
+  simp_rw [Module.finite_def, Submodule.fg_def, Submodule.eq_top_iff']
+  refine ⟨{1, -1}, by simp, fun x ↦ ?_⟩
+  obtain hx | hx := le_total 0 x
+  · simpa using Submodule.smul_mem (M := R) (.span R≥0 {1, -1}) ⟨x, hx⟩ (x := 1)
+      (Submodule.subset_span <| by simp)
+  · simpa using Submodule.smul_mem (M := R) (.span R≥0 {1, -1}) ⟨-x, neg_nonneg.2 hx⟩ (x := -1)
+      (Submodule.subset_span <| by simp)
+
+/-- If a module is finite over a linearly ordered ring, then it is also finite over the non-negative
+scalars. -/
+instance instModuleFinite [Module.Finite R E] : Module.Finite R≥0 E := .trans R E
+
+end Ring


### PR DESCRIPTION
This way we can import it in `Data.NNReal.Defs` in #28817.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
