### PR TITLE
[Merged by Bors] - refactor(RingTheory/RootsOfUnity/Basic) : Corrections to "rootsOfUnity coercions"

### DIFF
--- a/Mathlib/Algebra/Polynomial/Roots.lean
+++ b/Mathlib/Algebra/Polynomial/Roots.lean
@@ -581,6 +581,12 @@ theorem mem_rootSet_of_injective [CommRing S] {p : S[X]} [Algebra S R]
   classical
   exact Multiset.mem_toFinset.trans (mem_roots_map_of_injective h hp)
 
+@[simp]
+theorem nthRootsFinset_toSet {n : ℕ} (h : 0 < n) (a : R) :
+    nthRootsFinset n a = {r | r ^ n = a} := by
+  ext x
+  simp_all
+
 end Roots
 
 lemma eq_zero_of_natDegree_lt_card_of_eval_eq_zero {R} [CommRing R] [IsDomain R]

--- a/Mathlib/RingTheory/RootsOfUnity/Basic.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Basic.lean
@@ -237,12 +237,6 @@ theorem map_rootsOfUnity_eq_pow_self [FunLike F R R] [MonoidHomClass F R R] (σ 
     zpow_natCast, rootsOfUnity.coe_pow]
   exact ⟨(m % orderOf ζ).toNat, rfl⟩
 
-lemma coe_rootsOfUnity_to_nthRootsFinset :
-    ((↑) : Rˣ → R) '' (rootsOfUnity k R) = nthRootsFinset k (1 : R) := by
-  ext x
-  rw [mem_coe, Polynomial.mem_nthRootsFinset (Nat.pos_of_neZero k),
-    Units.val_set_image_rootsOfUnity, Set.mem_setOf_eq]
-
 end IsDomain
 
 section Reduced

--- a/Mathlib/RingTheory/RootsOfUnity/Basic.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Basic.lean
@@ -151,7 +151,8 @@ theorem MulEquiv.restrictRootsOfUnity_symm (σ : R ≃* S) :
     (σ.restrictRootsOfUnity k).symm = σ.symm.restrictRootsOfUnity k :=
   rfl
 
-theorem coe_rootsOfUnity_to_set [NeZero k] :
+@[simp]
+theorem Units.val_set_image_rootsOfUnity [NeZero k] :
     ((↑) : Rˣ → _) '' (rootsOfUnity k R) = {z : R | z^k = 1} := by
   ext x
   exact ⟨fun ⟨y,hy1,hy2⟩ => by rw [← hy2]; exact (mem_rootsOfUnity' k y).mp hy1,
@@ -167,7 +168,8 @@ open Set in
 theorem rootsOfUnity_two_set [CommRing R] [NoZeroDivisors R] :
     ((↑) : Rˣ → R) '' (rootsOfUnity 2 R) = {1, -1} := by
   ext x
-  rw [mem_insert_iff, mem_singleton_iff, ← sq_eq_one_iff, coe_rootsOfUnity_to_set, mem_setOf_eq]
+  rw [mem_insert_iff, mem_singleton_iff, ← sq_eq_one_iff, Units.val_set_image_rootsOfUnity,
+    mem_setOf_eq]
 
 section IsDomain
 
@@ -239,8 +241,8 @@ theorem map_rootsOfUnity_eq_pow_self [FunLike F R R] [MonoidHomClass F R R] (σ 
 lemma coe_rootsOfUnity_to_nthRootsFinset :
     ((↑) : Rˣ → R) '' (rootsOfUnity k R) = nthRootsFinset k (1 : R) := by
   ext x
-  rw [mem_coe, Polynomial.mem_nthRootsFinset (Nat.pos_of_neZero k), coe_rootsOfUnity_to_set,
-    Set.mem_setOf_eq]
+  rw [mem_coe, Polynomial.mem_nthRootsFinset (Nat.pos_of_neZero k),
+    Units.val_set_image_rootsOfUnity, Set.mem_setOf_eq]
 
 end IsDomain
 

--- a/Mathlib/RingTheory/RootsOfUnity/Basic.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Basic.lean
@@ -158,7 +158,7 @@ theorem Units.val_set_image_rootsOfUnity [NeZero k] :
   exact ⟨fun ⟨y,hy1,hy2⟩ => by rw [← hy2]; exact (mem_rootsOfUnity' k y).mp hy1,
     fun h ↦ ⟨(rootsOfUnity.mkOfPowEq x h), ⟨Subtype.coe_prop (rootsOfUnity.mkOfPowEq x h), rfl⟩⟩⟩
 
-theorem rootsOfUnity_one_set : ((↑) : Rˣ → R) '' (rootsOfUnity 1 R) = {1} := by
+theorem Units.val_set_image_rootsOfUnity_one : ((↑) : Rˣ → R) '' (rootsOfUnity 1 R) = {1} := by
   ext x
   simp
 

--- a/Mathlib/RingTheory/RootsOfUnity/Basic.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Basic.lean
@@ -165,7 +165,7 @@ theorem Units.val_set_image_rootsOfUnity_one : ((↑) : Rˣ → R) '' (rootsOfUn
 end CommMonoid
 
 open Set in
-theorem rootsOfUnity_two_set [CommRing R] [NoZeroDivisors R] :
+theorem Units.val_set_image_rootsOfUnity_two [CommRing R] [NoZeroDivisors R] :
     ((↑) : Rˣ → R) '' (rootsOfUnity 2 R) = {1, -1} := by
   ext x
   rw [mem_insert_iff, mem_singleton_iff, ← sq_eq_one_iff, Units.val_set_image_rootsOfUnity,

--- a/Mathlib/RingTheory/RootsOfUnity/Basic.lean
+++ b/Mathlib/RingTheory/RootsOfUnity/Basic.lean
@@ -168,8 +168,7 @@ open Set in
 theorem Units.val_set_image_rootsOfUnity_two [CommRing R] [NoZeroDivisors R] :
     ((↑) : Rˣ → R) '' (rootsOfUnity 2 R) = {1, -1} := by
   ext x
-  rw [mem_insert_iff, mem_singleton_iff, ← sq_eq_one_iff, Units.val_set_image_rootsOfUnity,
-    mem_setOf_eq]
+  simp
 
 section IsDomain
 


### PR DESCRIPTION
Corrections which were missed from #26350.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
