### PR TITLE
[Merged by Bors] - feat(Data/Int): inequality related to sqrt

### DIFF
--- a/Mathlib/Data/Int/Order/Lemmas.lean
+++ b/Mathlib/Data/Int/Order/Lemmas.lean
@@ -31,4 +31,17 @@ theorem natAbs_le_iff_mul_self_le {a b : ℤ} : a.natAbs ≤ b.natAbs ↔ a * a 
   rw [← abs_le_iff_mul_self_le, abs_eq_natAbs, abs_eq_natAbs]
   exact Int.ofNat_le.symm
 
+/-! ### Integer sqrt -/
+
+theorem abs_le_sqrt {a b : ℤ} (hn : 0 ≤ b) :
+    |a| ≤ b.sqrt ↔ a * a ≤ b := by
+  rw [← abs_mul_abs_self]
+  rw [show b = b.toNat from eq_natCast_toNat.mpr hn]
+  rw [show |a| = |a|.toNat by simp]
+  rw [Int.sqrt_natCast, ← Int.natCast_mul, Nat.cast_le, Nat.cast_le, Nat.le_sqrt]
+
+theorem abs_le_sqrt_iff_sq_le {a b : ℤ} (hn : 0 ≤ b) :
+    |a| ≤ b.sqrt ↔ a ^ 2 ≤ b :=
+  pow_two a ▸ abs_le_sqrt hn
+
 end Int

--- a/Mathlib/Data/Int/Order/Lemmas.lean
+++ b/Mathlib/Data/Int/Order/Lemmas.lean
@@ -35,10 +35,8 @@ theorem natAbs_le_iff_mul_self_le {a b : ℤ} : a.natAbs ≤ b.natAbs ↔ a * a 
 
 theorem abs_le_sqrt {a b : ℤ} (hn : 0 ≤ b) :
     |a| ≤ b.sqrt ↔ a * a ≤ b := by
-  rw [← abs_mul_abs_self]
-  rw [show b = b.toNat from eq_natCast_toNat.mpr hn]
-  rw [show |a| = |a|.toNat by simp]
-  rw [Int.sqrt_natCast, ← Int.natCast_mul, Nat.cast_le, Nat.cast_le, Nat.le_sqrt]
+  rw [← abs_mul_abs_self, eq_natCast_toNat.mpr hn, eq_natCast_toNat.mpr (abs_nonneg a),
+    Int.sqrt_natCast, ← Int.natCast_mul, Nat.cast_le, Nat.cast_le, Nat.le_sqrt]
 
 theorem abs_le_sqrt_iff_sq_le {a b : ℤ} (hn : 0 ≤ b) :
     |a| ≤ b.sqrt ↔ a ^ 2 ≤ b :=


### PR DESCRIPTION
These are similar to `Nat.sqrt_le` and `Nat.sqrt_le'`, with extra absolute value needed for integers.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
