### PR TITLE
chore(NumberTheory/LSeries): golf using "grind"

### DIFF
--- a/Mathlib/NumberTheory/LSeries/AbstractFuncEq.lean
+++ b/Mathlib/NumberTheory/LSeries/AbstractFuncEq.lean
@@ -453,8 +453,7 @@ theorem Λ_residue_k :
   · refine (tendsto_const_nhds.mono_left nhdsWithin_le_nhds).congr' ?_
     refine eventually_nhdsWithin_of_forall (fun s (hs : s ≠ P.k) ↦ ?_)
     match_scalars
-    field_simp [sub_ne_zero.mpr hs.symm]
-    ring
+    grind
 
 /-- The residue of `Λ` at `s = 0` is equal to `-f₀`. -/
 theorem Λ_residue_zero :
@@ -465,7 +464,7 @@ theorem Λ_residue_zero :
   · refine (tendsto_const_nhds.mono_left nhdsWithin_le_nhds).congr' ?_
     refine eventually_nhdsWithin_of_forall (fun s (hs : s ≠ 0) ↦ ?_)
     match_scalars
-    field_simp [sub_ne_zero.mpr hs.symm]
+    grind
   · rw [show 𝓝 0 = 𝓝 ((0 : ℂ) • (P.ε / (P.k - 0 : ℂ)) • P.g₀) by rw [zero_smul]]
     exact (continuousAt_id.smul ((continuousAt_const.div ((continuous_sub_left _).continuousAt)
       (by simpa using P.hk.ne')).smul continuousAt_const)).mono_left nhdsWithin_le_nhds

--- a/Mathlib/NumberTheory/LSeries/Basic.lean
+++ b/Mathlib/NumberTheory/LSeries/Basic.lean
@@ -124,7 +124,7 @@ lemma norm_term_le_of_re_le_re (f : ℕ → ℂ) {s s' : ℂ} (h : s.re ≤ s'.r
     ‖term f s' n‖ ≤ ‖term f s n‖ := by
   simp only [norm_term_eq]
   split
-  · next => rfl
+  · rfl
   · next hn => gcongr; exact Nat.one_le_cast.mpr <| Nat.one_le_iff_ne_zero.mpr hn
 
 section positivity
@@ -377,8 +377,7 @@ lemma LSeriesSummable_of_isBigO_rpow {f : ℕ → ℂ} {x : ℝ} {s : ℂ} (hs :
     rw [Real.norm_eq_abs, abs_rpow_of_nonneg hn₀, abs_of_nonneg hn₀]
   · have hn' : 0 < n := Nat.pos_of_ne_zero hn₀
     refine (div_le_iff₀ <| rpow_pos_of_pos (cast_pos.mpr hn') _).mp ?_
-    refine (le_max' _ _ <| mem_insert_of_mem ?_).trans <| le_max_right ..
-    exact mem_image.mpr ⟨n, mem_range.mpr hn, rfl⟩
+    exact (le_max' _ _ <| mem_insert_of_mem (by grind)).trans <| le_max_right ..
 
 /-- If `f` is bounded, then its `LSeries` is summable at `s` when `re s > 1`. -/
 theorem LSeriesSummable_of_bounded_of_one_lt_re {f : ℕ → ℂ} {m : ℝ}

--- a/Mathlib/NumberTheory/LSeries/Dirichlet.lean
+++ b/Mathlib/NumberTheory/LSeries/Dirichlet.lean
@@ -124,10 +124,10 @@ lemma mul_convolution_distrib {R : Type*} [CommSemiring R] {n : ℕ} (χ : Diric
   simp only [Pi.mul_apply, LSeries.convolution_def, Finset.mul_sum]
   refine Finset.sum_congr rfl fun p hp ↦ ?_
   rw [(mem_divisorsAntidiagonal.mp hp).1.symm, cast_mul, map_mul]
-  exact mul_mul_mul_comm ..
+  ring
 
 lemma mul_delta {n : ℕ} (χ : DirichletCharacter ℂ n) : ↗χ * δ = δ :=
-  LSeries.mul_delta <| by rw [cast_one, map_one]
+  LSeries.mul_delta <| by simp
 
 lemma delta_mul {n : ℕ} (χ : DirichletCharacter ℂ n) : δ * ↗χ = δ :=
   mul_comm δ _ ▸ mul_delta ..

--- a/Mathlib/NumberTheory/LSeries/HurwitzZeta.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZeta.lean
@@ -70,9 +70,7 @@ lemma hasSum_hurwitzZeta_of_one_lt_re {a : ℝ} (ha : a ∈ Icc 0 1) {s : ℂ} (
     HasSum (fun n : ℕ ↦ 1 / (n + a : ℂ) ^ s) (hurwitzZeta a s) := by
   convert (hasSum_nat_hurwitzZetaEven_of_mem_Icc ha hs).add
       (hasSum_nat_hurwitzZetaOdd_of_mem_Icc ha hs) using 1
-  ext1 n
-  -- plain `ring_nf` works here, but the following is faster:
-  apply show ∀ (x y : ℂ), x = (x + y) / 2 + (x - y) / 2 by intros; ring
+  grind
 
 /-- The residue of the Hurwitz zeta function at `s = 1` is `1`. -/
 lemma hurwitzZeta_residue_one (a : UnitAddCircle) :
@@ -127,7 +125,7 @@ lemma hasSum_expZeta_of_one_lt_re (a : ℝ) {s : ℂ} (hs : 1 < re s) :
   convert (hasSum_nat_cosZeta a hs).add ((hasSum_nat_sinZeta a hs).mul_left I) using 1
   ext1 n
   simp only [mul_right_comm _ I, ← cos_add_sin_I, push_cast]
-  rw [add_div, mul_div, mul_comm _ I]
+  grind
 
 lemma differentiableAt_expZeta (a : UnitAddCircle) (s : ℂ) (hs : s ≠ 1 ∨ a ≠ 0) :
     DifferentiableAt ℂ (expZeta a) s := by
@@ -156,14 +154,7 @@ lemma hurwitzZeta_one_sub (a : UnitAddCircle) {s : ℂ}
     (exp (-π * I * s / 2) * expZeta a s + exp (π * I * s / 2) * expZeta (-a) s) := by
   rw [hurwitzZeta, hurwitzZetaEven_one_sub a hs hs', hurwitzZetaOdd_one_sub a hs,
     expZeta, expZeta, Complex.cos, Complex.sin, sinZeta_neg, cosZeta_neg]
-  rw [show ↑π * I * s / 2 = ↑π * s / 2 * I by ring,
-    show -↑π * I * s / 2 = -(↑π * s / 2) * I by ring]
-  -- these `generalize` commands are not strictly needed for the `ring_nf` call to succeed, but
-  -- make it run faster:
-  generalize (2 * π : ℂ) ^ (-s) = x
-  generalize (↑π * s / 2 * I).exp = y
-  generalize (-(↑π * s / 2) * I).exp = z
-  ring_nf
+  grind
 
 /-- Functional equation for the exponential zeta function. -/
 lemma expZeta_one_sub (a : UnitAddCircle) {s : ℂ} (hs : ∀ (n : ℕ), s ≠ 1 - n) :

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaEven.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaEven.lean
@@ -67,8 +67,7 @@ completed Hurwitz zeta function). See `evenKernel_def` for the defining formula,
         ring_nf
         simp [I_sq]
       rw [this, re_ofReal_mul, ← mul_assoc, ← Real.exp_add]
-      congr
-      ring).lift a
+      grind).lift a
 
 lemma evenKernel_def (a x : ℝ) :
     ↑(evenKernel ↑a x) = cexp (-π * a ^ 2 * x) * jacobiTheta₂ (a * I * x) (I * x) := by
@@ -136,9 +135,7 @@ lemma evenKernel_functional_equation (a : UnitAddCircle) (x : ℝ) :
     push_cast
     rw [← div_div, mul_one_div, div_I, neg_one_mul, neg_neg]
   have hx' : I * x ≠ 0 := mul_ne_zero I_ne_zero (ofReal_ne_zero.mpr hx.ne')
-  have h2 : a * I * x / (I * x) = a := by
-    rw [div_eq_iff hx']
-    ring
+  have h2 : a * I * x / (I * x) = a := by grind
   have h3 : 1 / (-I * (I * x)) ^ (1 / 2 : ℂ) = 1 / ↑(x ^ (1 / 2 : ℝ)) := by
     rw [neg_mul, ← mul_assoc, I_mul_I, neg_one_mul, neg_neg,ofReal_cpow hx.le, ofReal_div,
       ofReal_one, ofReal_ofNat]
@@ -209,7 +206,7 @@ lemma hasSum_nat_cosKernel₀ (a : ℝ) {t : ℝ} (ht : 0 < t) :
   refine this.congr_fun fun n ↦ ?_
   push_cast
   rw [Complex.cos, mul_div_cancel₀ _ two_ne_zero]
-  congr 3 <;> ring
+  grind
 
 /-!
 ## Asymptotics of the kernels as `t → ∞`
@@ -409,7 +406,7 @@ lemma differentiableAt_completedHurwitzZetaEven
     simp [hurwitzEvenFEPair, h]
   · change s / 2 ≠ ↑(1 / 2 : ℝ)
     rw [ofReal_div, ofReal_one, ofReal_ofNat]
-    exact hs' ∘ (div_left_inj' two_ne_zero).mp
+    grind
 
 lemma differentiable_completedHurwitzZetaEven₀ (a : UnitAddCircle) :
     Differentiable ℂ (completedHurwitzZetaEven₀ a) :=
@@ -431,13 +428,12 @@ lemma differentiableAt_one_completedHurwitzZetaEven_sub_completedHurwitzZetaEven
 lemma differentiableAt_completedCosZeta
     (a : UnitAddCircle) {s : ℂ} (hs : s ≠ 0) (hs' : s ≠ 1 ∨ a ≠ 0) :
     DifferentiableAt ℂ (completedCosZeta a) s := by
-  refine (((hurwitzEvenFEPair a).symm.differentiableAt_Λ (Or.inl ?_) ?_).comp s
+  refine (((hurwitzEvenFEPair a).symm.differentiableAt_Λ (by grind) ?_).comp s
       (differentiableAt_id.div_const _)).div_const _
-  · exact div_ne_zero_iff.mpr ⟨hs, two_ne_zero⟩
-  · change s / 2 ≠ ↑(1 / 2 : ℝ) ∨ (if a = 0 then 1 else 0) = 0
-    refine Or.imp (fun h ↦ ?_) (fun ha ↦ ?_) hs'
-    · simpa [push_cast] using h ∘ (div_left_inj' two_ne_zero).mp
-    · simpa
+  change s / 2 ≠ ↑(1 / 2 : ℝ) ∨ (if a = 0 then 1 else 0) = 0
+  refine Or.imp (fun h ↦ ?_) (fun ha ↦ ?_) hs'
+  · simpa [push_cast] using h ∘ (div_left_inj' two_ne_zero).mp
+  · simpa
 
 lemma differentiable_completedCosZeta₀ (a : UnitAddCircle) :
     Differentiable ℂ (completedCosZeta₀ a) :=
@@ -462,7 +458,7 @@ lemma completedHurwitzZetaEven_residue_zero (a : UnitAddCircle) :
     Tendsto (fun s ↦ s * completedHurwitzZetaEven a s) (𝓝[≠] 0) (𝓝 (if a = 0 then -1 else 0)) := by
   have h1 : Tendsto (fun s : ℂ ↦ s * _) (𝓝[≠] 0)
     (𝓝 (-(if a = 0 then 1 else 0))) := (hurwitzEvenFEPair a).Λ_residue_zero
-  have : -(if a = 0 then (1 : ℂ) else 0) = (if a = 0 then -1 else 0) := by { split_ifs <;> simp }
+  have : -(if a = 0 then (1 : ℂ) else 0) = (if a = 0 then -1 else 0) := by grind
   simp only [this, push_cast] at h1
   refine (h1.comp <| zero_div (2 : ℂ) ▸ (tendsto_div_two_punctured_nhds 0)).congr (fun s ↦ ?_)
   simp [completedHurwitzZetaEven, div_mul_eq_mul_div, mul_div_assoc]
@@ -489,7 +485,7 @@ lemma hasSum_int_completedCosZeta (a : ℝ) {s : ℂ} (hs : 1 < re s) :
   have hF t (ht : 0 < t) : HasSum (fun n : ℤ ↦ if n = 0 then 0 else c n * rexp (-π * n ^ 2 * t))
       ((cosKernel a t - 1) / 2) := by
     refine ((hasSum_int_cosKernel₀ a ht).div_const 2).congr_fun fun n ↦ ?_
-    split_ifs <;> simp [c, div_mul_eq_mul_div]
+    grind
   simp only [← Int.cast_eq_zero (α := ℝ)] at hF
   rw [show completedCosZeta a s = mellin (fun t ↦ (cosKernel a t - 1 : ℂ) / 2) (s / 2) by
     rw [mellin_div_const, completedCosZeta]
@@ -515,7 +511,7 @@ lemma hasSum_nat_completedCosZeta (a : ℝ) {s : ℂ} (hs : 1 < re s) :
   rw [aux, div_zero, zero_div, add_zero] at hint
   refine hint.congr_fun fun n ↦ ?_
   split_ifs with h
-  · simp only [h, Nat.cast_zero, aux, div_zero, zero_div, neg_zero, zero_add]
+  · grind
   · simp only [ofReal_cos, ofReal_mul, ofReal_ofNat, ofReal_natCast, Complex.cos,
       show 2 * π * a * n * I = 2 * π * I * a * n by ring, neg_mul, mul_div_assoc,
       div_right_comm _ (2 : ℂ), Int.cast_natCast, Nat.abs_cast, Int.cast_neg, mul_neg, abs_neg, ←
@@ -531,7 +527,7 @@ lemma hasSum_int_completedHurwitzZetaEven (a : ℝ) {s : ℂ} (hs : 1 < re s) :
       2).congr_fun fun n ↦ ?_
     split_ifs
     · rw [ofReal_zero, zero_div]
-    · rw [mul_comm, mul_one_div]
+    · ring
   rw [show completedHurwitzZetaEven a s = mellin (fun t ↦ ((evenKernel (↑a) t : ℂ) -
         ↑(if (a : UnitAddCircle) = 0 then 1 else 0 : ℝ)) / 2) (s / 2) by
     simp_rw [mellin_div_const, apply_ite ofReal, ofReal_one, ofReal_zero]
@@ -541,7 +537,7 @@ lemma hasSum_int_completedHurwitzZetaEven (a : ℝ) {s : ℂ} (hs : 1 < re s) :
   · simp_rw [← mul_one_div ‖_‖]
     apply Summable.mul_left
     rwa [summable_one_div_int_add_rpow]
-  · rw [mul_one_div, div_right_comm]
+  · ring
 
 /-!
 ## The un-completed even Hurwitz zeta
@@ -572,7 +568,7 @@ lemma differentiableAt_update_of_residue
     -- Remains to show completed zeta is `o (s ^ (-1))` near 0.
     refine (isBigO_const_of_tendsto claim2 <| one_ne_zero' ℂ).trans_isLittleO ?_
     rw [isLittleO_iff_tendsto']
-    · exact Tendsto.congr (fun x ↦ by rw [← one_div, one_div_one_div]) nhdsWithin_le_nhds
+    · exact Tendsto.congr (fun x ↦ by grind) nhdsWithin_le_nhds
     · exact eventually_of_mem self_mem_nhdsWithin fun x hx hx' ↦ (hx <| inv_eq_zero.mp hx').elim
 
 /-- The even part of the Hurwitz zeta function, i.e. the meromorphic function of `s` which agrees
@@ -738,8 +734,8 @@ lemma hasSum_nat_cosZeta (a : ℝ) {s : ℂ} (hs : 1 < re s) :
   simp_rw [abs_neg, Int.cast_neg, Nat.abs_cast, Int.cast_natCast, mul_neg, abs_zero, Int.cast_zero,
     zero_cpow (ne_zero_of_one_lt_re hs), div_zero, zero_div, add_zero, ← add_div,
     div_right_comm _ _ (2 : ℂ)] at this
-  simp_rw [push_cast, Complex.cos, neg_mul]
-  exact this.congr_fun fun n ↦ by rw [show 2 * π * a * n * I = 2 * π * I * a * n by ring]
+  simp only [push_cast, Complex.cos]
+  grind
 
 /-- Reformulation of `hasSum_nat_cosZeta` using `LSeriesHasSum`. -/
 lemma LSeriesHasSum_cos (a : ℝ) {s : ℂ} (hs : 1 < re s) :
@@ -760,8 +756,7 @@ lemma hurwitzZetaEven_one_sub (a : UnitAddCircle) {s : ℂ}
     simpa [sub_eq_zero, eq_comm (a := s)] using hs'
   rw [this, completedHurwitzZetaEven_one_sub, inv_Gammaℝ_one_sub hs, cosZeta,
     Function.update_of_ne (by simpa using hs 0), ← Gammaℂ]
-  generalize Gammaℂ s * cos (π * s / 2) = A -- speeds up ring_nf call
-  ring_nf
+  grind
 
 /-- If `s` is not of the form `1 - n` for `n ∈ ℕ`, then `cosZeta a (1 - s)` is an explicit
 multiple of `hurwitzZetaEven s`. -/
@@ -773,7 +768,6 @@ lemma cosZeta_one_sub (a : UnitAddCircle) {s : ℂ} (hs : ∀ (n : ℕ), s ≠ 1
     simpa [sub_eq_zero] using (hs 0).symm
   rw [this, completedCosZeta_one_sub, inv_Gammaℝ_one_sub (fun n ↦ by simpa using hs (n + 1)),
     hurwitzZetaEven_def_of_ne_or_ne (Or.inr (by simpa using hs 1))]
-  generalize Gammaℂ s * cos (π * s / 2) = A -- speeds up ring_nf call
-  ring_nf
+  grind
 
 end HurwitzZeta

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaOdd.lean
@@ -73,7 +73,7 @@ lemma jacobiTheta₂''_add_left (z τ : ℂ) : jacobiTheta₂'' (z + 1) τ = jac
   -- get all exponential terms to left
   rw [mul_left_comm _ (cexp _), ← mul_add, mul_assoc (cexp _), ← mul_add, ← mul_assoc (cexp _),
     ← Complex.exp_add]
-  congrm (cexp ?_ * ?_) <;> ring
+  grind
 
 lemma jacobiTheta₂''_neg_left (z τ : ℂ) : jacobiTheta₂'' (-z) τ = -jacobiTheta₂'' z τ := by
   simp [jacobiTheta₂'', jacobiTheta₂'_neg_left, neg_div, -neg_add_rev, ← neg_add]
@@ -96,8 +96,7 @@ lemma jacobiTheta₂'_functional_equation' (z τ : ℂ) :
     ← div_mul_eq_mul_div (-2 * π : ℂ), mul_assoc, aux1, mul_div z (-1), mul_neg_one, neg_div τ z,
     jacobiTheta₂_neg_left, jacobiTheta₂'_neg_left, neg_mul, ← mul_neg, ← mul_neg,
     mul_div, mul_neg_one, neg_div, neg_mul, neg_mul, neg_div]
-  congr 2
-  rw [neg_sub, ← sub_eq_neg_add, mul_comm _ (_ * I), ← mul_assoc]
+  grind
 
 /-- Odd Hurwitz zeta kernel (function whose Mellin transform will be the odd part of the completed
 Hurwitz zeta function). See `oddKernel_def` for the defining formula, and `hasSum_int_oddKernel`
@@ -231,8 +230,8 @@ lemma hasSum_int_sinKernel (a : ℝ) {t : ℝ} (ht : 0 < t) : HasSum
     eq_div_iff h, ofReal_mul, ofReal_mul, ofReal_pow, ofReal_neg, ofReal_intCast,
     mul_comm _ (-2 * π : ℂ), ← mul_assoc]
   congrm ?_ * cexp (?_ + ?_)
-  · simp [mul_assoc]
-  · exact mul_right_comm (2 * π * I) a n
+  · grind
+  · grind
   · simp [← mul_assoc, mul_comm _ I]
 
 lemma hasSum_nat_sinKernel (a : ℝ) {t : ℝ} (ht : 0 < t) :
@@ -245,11 +244,7 @@ lemma hasSum_nat_sinKernel (a : ℝ) {t : ℝ} (ht : 0 < t) :
   simp_rw [Int.cast_neg, neg_sq, mul_neg, ofReal_mul, Int.cast_natCast, ofReal_natCast,
       ofReal_ofNat, ← add_mul, ofReal_sin, Complex.sin]
   push_cast
-  congr 1
-  rw [← mul_div_assoc, ← div_mul_eq_mul_div, ← div_mul_eq_mul_div, div_self two_ne_zero, one_mul,
-    neg_mul, neg_mul, neg_neg, mul_comm _ I, ← mul_assoc, mul_comm _ I, neg_mul,
-    ← sub_eq_neg_add, mul_sub]
-  congr 3 <;> ring
+  grind
 
 end sum_formulas
 
@@ -354,6 +349,7 @@ lemma differentiable_completedSinZeta (a : UnitAddCircle) :
 ## Parity and functional equations
 -/
 
+@[simp]
 lemma completedHurwitzZetaOdd_neg (a : UnitAddCircle) (s : ℂ) :
     completedHurwitzZetaOdd (-a) s = -completedHurwitzZetaOdd a s := by
   simp [completedHurwitzZetaOdd, StrongFEPair.Λ, hurwitzOddFEPair, mellin, oddKernel_neg,
@@ -416,12 +412,8 @@ lemma hasSum_nat_completedSinZeta (a : ℝ) {s : ℂ} (hs : 1 < re s) :
   rw [div_right_comm]
   rcases eq_or_ne n 0 with rfl | h
   · simp
-  simp_rw [Int.sign_natCast_of_ne_zero h, Int.cast_one, ofReal_sin, Complex.sin]
-  simp only [← mul_div_assoc, push_cast, mul_assoc (Gammaℝ _), ← mul_add]
-  congr 3
-  rw [mul_one, mul_neg_one, neg_neg, neg_mul I, ← sub_eq_neg_add, ← mul_sub, mul_comm,
-    mul_neg, neg_mul]
-  congr 3 <;> ring
+  simp only [push_cast, Int.sign_natCast_of_ne_zero h, Int.cast_one, ofReal_sin, Complex.sin]
+  grind
 
 /-- Formula for `completedHurwitzZetaOdd` as a Dirichlet series in the convergence range. -/
 lemma hasSum_int_completedHurwitzZetaOdd (a : ℝ) {s : ℂ} (hs : 1 < re s) :
@@ -439,7 +431,7 @@ lemma hasSum_int_completedHurwitzZetaOdd (a : ℝ) {s : ℂ} (hs : 1 < re s) :
     rwa [summable_one_div_int_add_rpow]
   have := mellin_div_const .. ▸ hasSum_mellin_pi_mul_sq' (zero_lt_one.trans hs) hF h_sum
   refine this.congr_fun fun n ↦ ?_
-  simp only [r, c, mul_one_div, div_mul_eq_mul_div, div_right_comm]
+  grind
 
 /-!
 ## Non-completed zeta functions
@@ -525,9 +517,8 @@ lemma hasSum_nat_sinZeta (a : ℝ) {s : ℂ} (hs : 1 < re s) :
   simp_rw [push_cast, Complex.sin]
   refine this.congr_fun fun n ↦ ?_
   rcases ne_or_eq n 0 with h | rfl
-  · simp only [neg_mul, sub_mul, div_right_comm _ (2 : ℂ), Int.sign_natCast_of_ne_zero h,
-      Int.cast_one, mul_one, mul_comm I, neg_neg, ← add_div, ← sub_eq_neg_add]
-    congr 5 <;> ring
+  · simp only [Int.sign_natCast_of_ne_zero h]
+    grind
   · simp
 
 /-- Reformulation of `hasSum_nat_sinZeta` using `LSeriesHasSum`. -/
@@ -538,12 +529,12 @@ lemma LSeriesHasSum_sin (a : ℝ) {s : ℂ} (hs : 1 < re s) :
 /-- The trivial zeroes of the odd Hurwitz zeta function. -/
 theorem hurwitzZetaOdd_neg_two_mul_nat_sub_one (a : UnitAddCircle) (n : ℕ) :
     hurwitzZetaOdd a (-2 * n - 1) = 0 := by
-  rw [hurwitzZetaOdd, Gammaℝ_eq_zero_iff.mpr ⟨n, by rw [neg_mul, sub_add_cancel]⟩, div_zero]
+  rw [hurwitzZetaOdd, Gammaℝ_eq_zero_iff.mpr ⟨n, by ring⟩, div_zero]
 
 /-- The trivial zeroes of the sine zeta function. -/
 theorem sinZeta_neg_two_mul_nat_sub_one (a : UnitAddCircle) (n : ℕ) :
     sinZeta a (-2 * n - 1) = 0 := by
-  rw [sinZeta, Gammaℝ_eq_zero_iff.mpr ⟨n, by rw [neg_mul, sub_add_cancel]⟩, div_zero]
+  rw [sinZeta, Gammaℝ_eq_zero_iff.mpr ⟨n, by ring⟩, div_zero]
 
 /-- If `s` is not in `-ℕ`, then `hurwitzZetaOdd a (1 - s)` is an explicit multiple of
 `sinZeta s`. -/

--- a/Mathlib/NumberTheory/LSeries/HurwitzZetaValues.lean
+++ b/Mathlib/NumberTheory/LSeries/HurwitzZetaValues.lean
@@ -123,9 +123,8 @@ theorem hurwitzZetaEven_one_sub_two_mul_nat (hk : k ≠ 0) (hx : x ∈ Icc (0 : 
       -1 / (2 * k) * ((Polynomial.bernoulli (2 * k)).map (algebraMap ℚ ℂ)).eval (x : ℂ) := by
   have h1 (n : ℕ) : (2 * k : ℂ) ≠ -n := by
     rw [← Int.cast_ofNat, ← Int.cast_natCast, ← Int.cast_mul, ← Int.cast_natCast n, ← Int.cast_neg,
-      Ne, Int.cast_inj, ← Ne]
-    refine ne_of_gt ((neg_nonpos_of_nonneg n.cast_nonneg).trans_lt (mul_pos two_pos ?_))
-    exact Nat.cast_pos.mpr (Nat.pos_of_ne_zero hk)
+      Int.cast_inj.ne]
+    grind
   have h2 : (2 * k : ℂ) ≠ 1 := by norm_cast; simp
   have h3 : Gammaℂ (2 * k) ≠ 0 := by
     refine mul_ne_zero (mul_ne_zero two_ne_zero ?_) (Gamma_ne_zero h1)
@@ -143,9 +142,8 @@ theorem hurwitzZetaOdd_neg_two_mul_nat (hk : k ≠ 0) (hx : x ∈ Icc (0 : ℝ) 
     -1 / (2 * k + 1) * ((Polynomial.bernoulli (2 * k + 1)).map (algebraMap ℚ ℂ)).eval (x : ℂ) := by
   have h1 (n : ℕ) : (2 * k + 1 : ℂ) ≠ -n := by
     rw [← Int.cast_ofNat, ← Int.cast_natCast, ← Int.cast_mul, ← Int.cast_natCast n, ← Int.cast_neg,
-      ← Int.cast_one, ← Int.cast_add, Ne, Int.cast_inj, ← Ne]
-    refine ne_of_gt ((neg_nonpos_of_nonneg n.cast_nonneg).trans_lt ?_)
-    positivity
+      ← Int.cast_one, ← Int.cast_add, Int.cast_inj.ne]
+    grind
   have h3 : Gammaℂ (2 * k + 1) ≠ 0 := by
     refine mul_ne_zero (mul_ne_zero two_ne_zero ?_) (Gamma_ne_zero h1)
     simp [pi_ne_zero]

--- a/Mathlib/NumberTheory/LSeries/Injectivity.lean
+++ b/Mathlib/NumberTheory/LSeries/Injectivity.lean
@@ -237,8 +237,5 @@ of `f` converges somewhere. -/
 lemma LSeries_injOn : Set.InjOn LSeries {f | f 0 = 0 ∧ abscissaOfAbsConv f < ⊤} := by
   intro f hf g hg h
   simp only [Set.mem_setOf] at hf hg
-  replace h := (LSeries_eq_iff_of_abscissaOfAbsConv_lt_top hf.2 hg.2).mp h
-  ext1 n
-  cases n with
-  | zero => exact hf.1.trans hg.1.symm
-  | succ n => exact h _ n.zero_ne_add_one.symm
+  rw [LSeries_eq_iff_of_abscissaOfAbsConv_lt_top hf.2 hg.2] at h
+  grind

--- a/Mathlib/NumberTheory/LSeries/MellinEqDirichlet.lean
+++ b/Mathlib/NumberTheory/LSeries/MellinEqDirichlet.lean
@@ -29,7 +29,7 @@ lemma hasSum_mellin {a : ι → ℂ} {p : ι → ℝ} {F : ℝ → ℂ} {s : ℂ
     (F := fun i t ↦ t ^ (s - 1) * (a i * rexp (-p i * t))) (fun i ↦ ?_) ?_ using 2 with i
   · simp_rw [← mul_assoc, mul_comm _ (a _), mul_assoc (a _), mul_div_assoc, integral_const_mul]
     rcases hp i with hai | hpi
-    · rw [hai, zero_mul, zero_mul]
+    · grind
     have := integral_cpow_mul_exp_neg_mul_Ioi hs hpi
     simp_rw [← ofReal_mul, ← ofReal_neg, ← ofReal_exp, ← neg_mul (p i)] at this
     rw [this, one_div, inv_cpow _ _ (arg_ofReal_of_nonneg hpi.le ▸ pi_pos.ne), div_eq_inv_mul]
@@ -69,13 +69,11 @@ lemma hasSum_mellin_pi_mul {a : ι → ℂ} {q : ι → ℝ} {F : ℝ → ℂ} {
     HasSum (fun i ↦ π ^ (-s) * Gamma s * a i / q i ^ s) (mellin F s) := by
   have hp i : a i = 0 ∨ 0 < π * q i := by rcases hq i with h | h <;> simp [h, pi_pos]
   convert hasSum_mellin hp hs (by simpa using hF) ?_ using 2 with i
-  · have : a i / ↑(π * q i) ^ s = π ^ (-s) * a i / q i ^ s := by
-      rcases hq i with h | h
-      · simp [h]
-      · rw [ofReal_mul, mul_cpow_ofReal_nonneg pi_pos.le h.le, ← div_div, cpow_neg,
-          ← div_eq_inv_mul]
-    simp_rw [mul_div_assoc, this]
-    ring_nf
+  · suffices a i / ↑(π * q i) ^ s = π ^ (-s) * a i / q i ^ s by grind
+    rcases hq i with h | h
+    · simp [h]
+    · rw [ofReal_mul, mul_cpow_ofReal_nonneg pi_pos.le h.le, ← div_div, cpow_neg,
+        ← div_eq_inv_mul]
   · have (i : _) : ‖a i‖ / ↑(π * q i) ^ s.re = π ^ (-s.re) * ‖a i‖ / q i ^ s.re := by
       rcases hq i with h | h
       · simp [h]
@@ -90,10 +88,7 @@ lemma hasSum_mellin_pi_mul₀ {a : ι → ℂ} {p : ι → ℝ} {F : ℝ → ℂ
     HasSum (fun i ↦ π ^ (-s) * Gamma s * a i / p i ^ s) (mellin F s) := by
   have hs' : s ≠ 0 := fun h ↦ lt_irrefl _ (zero_re ▸ h ▸ hs)
   let a' i := if p i = 0 then 0 else a i
-  have hp' i : a' i = 0 ∨ 0 < p i := by
-    simp only [a']
-    split_ifs with h <;> try tauto
-    exact Or.inr (lt_of_le_of_ne (hp i) (Ne.symm h))
+  have hp' i : a' i = 0 ∨ 0 < p i := by grind
   have (i t : _) : (if p i = 0 then 0 else a i * rexp (-π * p i * t)) =
       a' i * rexp (-π * p i * t) := by
     simp [a']

--- a/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
+++ b/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
@@ -134,10 +134,7 @@ lemma residueClass_nonneg (n : ℕ) : 0 ≤ residueClass a n :=
 lemma residueClass_le (n : ℕ) : residueClass a n ≤ vonMangoldt n :=
   Set.indicator_apply_le' (fun _ ↦ le_rfl) (fun _ ↦ vonMangoldt_nonneg)
 
-@[simp]
-lemma residueClass_apply_zero : residueClass a 0 = 0 := by
-  simp only [Set.indicator_apply_eq_zero, Set.mem_setOf_eq, Nat.cast_zero, map_zero,
-    implies_true]
+
 
 lemma abscissaOfAbsConv_residueClass_le_one :
     abscissaOfAbsConv ↗(residueClass a) ≤ 1 := by
@@ -229,30 +226,22 @@ lemma summable_residueClass_non_primes_div :
     refine div_le_div_of_nonneg_right ?_ n.cast_nonneg
     split_ifs; exacts [le_rfl, residueClass_le a n]
   refine Summable.of_nonneg_of_le h₀ hleF₀ ?_
-  have hF₀ (p : Nat.Primes) : F₀ p.val = 0 := by
-    simp only [p.prop, ↓reduceIte, zero_div, F₀]
+  have hF₀ (p : Nat.Primes) : F₀ p.val = 0 := by simp [p.prop, F₀]
   refine (summable_subtype_iff_indicator (s := {n | IsPrimePow n}).mp ?_).congr
       fun n ↦ Set.indicator_apply_eq_self.mpr fun (hn : ¬ IsPrimePow n) ↦ ?_
   swap
   · simp +contextual only [div_eq_zero_iff, ite_eq_left_iff, vonMangoldt_eq_zero_iff, hn,
       not_false_eq_true, implies_true, Nat.cast_eq_zero, true_or, F₀]
-  have hFF' :
-      F₀ ∘ Subtype.val (p := fun n ↦ n ∈ {n | IsPrimePow n}) = F' ∘ ⇑prodNatEquiv.symm := by
-    refine (Equiv.eq_comp_symm prodNatEquiv (F₀ ∘ Subtype.val) F').mpr ?_
-    ext1 n
-    simp only [Function.comp_apply, F']
-    congr
+  have hFF' : F₀ ∘ Subtype.val (p := fun n ↦ n ∈ {n | IsPrimePow n}) = F' ∘ ⇑prodNatEquiv.symm :=
+    (Equiv.eq_comp_symm prodNatEquiv (F₀ ∘ Subtype.val) F').mpr rfl
   rw [hFF']
   refine (Nat.Primes.prodNatEquiv.symm.summable_iff (f := F')).mpr ?_
-  have hF'₀ (p : Nat.Primes) : F' (p, 0) = 0 := by simp only [zero_add, pow_one, hF₀, F']
-  have hF'₁ : F'' = F' ∘ (Prod.map _root_.id (· + 1)) := by
-    ext1
-    simp only [Function.comp_apply, Prod.map_fst, id_eq, Prod.map_snd, F'', F']
+  have hF'₀ (p : Nat.Primes) : F' (p, 0) = 0 := by simp [hF₀, F']
+  have hF'₁ : F'' = F' ∘ (Prod.map _root_.id (· + 1)) := by simp [F'']
   refine (Function.Injective.summable_iff ?_ fun u hu ↦ ?_).mp <| hF'₁ ▸ summable_F''
-  · exact Function.Injective.prodMap (fun ⦃a₁ a₂⦄ a ↦ a) <| add_left_injective 1
-  · simp only [Set.range_prodMap, Set.range_id, Set.mem_prod, Set.mem_univ, Set.mem_range,
-      Nat.exists_add_one_eq, true_and, not_lt, nonpos_iff_eq_zero] at hu
-    rw [← hF'₀ u.1, ← hu]
+  · exact Function.injective_id.prodMap (add_left_injective 1)
+  · have : u.2 = 0 := by simpa using hu
+    grind
 
 variable [NeZero q] {a}
 
@@ -379,7 +368,7 @@ lemma LFunctionResidueClassAux_real (ha : IsUnit a) {x : ℝ} (hx : 1 < x) :
     push_cast
     refine tsum_congr fun n ↦ ?_
     rcases eq_or_ne n 0 with rfl | hn
-    · simp only [term_zero, zero_re, ofReal_zero]
+    · abel
     · simp only [term_of_ne_zero hn, ← ofReal_natCast n, ← ofReal_cpow n.cast_nonneg, ← ofReal_div,
         ofReal_re]
   · rw [← ofReal_natCast, ← ofReal_one, ← ofReal_sub, ← ofReal_inv,
@@ -403,7 +392,7 @@ lemma LSeries_residueClass_lower_bound (ha : IsUnit a) :
       LSeries, term]
     refine tsum_congr fun n ↦ ?_
     split_ifs with hn
-    · simp only [hn, residueClass_apply_zero, ofReal_zero, zero_div]
+    · simp [hn]
     · rfl
   have : ContinuousOn (fun x : ℝ ↦ (LFunctionResidueClassAux a x).re) (Set.Icc 1 2) :=
     continuous_re.continuousOn.comp (t := Set.univ) (continuousOn_LFunctionResidueClassAux a)
@@ -413,9 +402,7 @@ lemma LSeries_residueClass_lower_bound (ha : IsUnit a) :
   replace hC {x : ℝ} (hx : x ∈ Set.Icc 1 2) : C ≤ (LFunctionResidueClassAux a x).re :=
     hC (LFunctionResidueClassAux a x).re <|
       Set.mem_image_of_mem (fun x : ℝ ↦ (LFunctionResidueClassAux a x).re) hx
-  refine ⟨-C, fun {x} hx ↦ ?_⟩
-  rw [H hx.1, add_comm, sub_neg_eq_add, add_le_add_iff_left]
-  exact hC <| Set.mem_Icc_of_Ioc hx
+  exact ⟨-C, by grind⟩
 
 open vonMangoldt Filter Topology in
 /-- The function `n ↦ Λ n / n` restricted to primes in an invertible residue class
@@ -430,7 +417,7 @@ lemma not_summable_residueClass_prime_div (ha : IsUnit a) :
   have H₁ {x : ℝ} (hx : 1 < x) : ∑' n, residueClass a n / (n : ℝ) ^ x ≤ C := by
     refine Summable.tsum_le_tsum (fun n ↦ ?_) ?_ key
     · rcases n.eq_zero_or_pos with rfl | hn
-      · simp only [Nat.cast_zero, Real.zero_rpow (zero_lt_one.trans hx).ne', div_zero, le_refl]
+      · simp [Real.zero_rpow (zero_lt_one.trans hx).ne']
       · refine div_le_div_of_nonneg_left (residueClass_nonneg a _) (mod_cast hn) ?_
         conv_lhs => rw [← Real.rpow_one n]
         exact Real.rpow_le_rpow_of_exponent_le (by norm_cast) hx.le
@@ -443,15 +430,14 @@ lemma not_summable_residueClass_prime_div (ha : IsUnit a) :
   have hq : 0 < (q.totient : ℝ)⁻¹ := inv_pos.mpr (mod_cast q.totient.pos_of_neZero)
   rcases le_or_gt (C + C') 0 with h₀ | h₀
   · have := hq.trans_le (H₁ (Set.right_mem_Ioc.mpr one_lt_two))
-    rw [show (2 : ℝ) - 1 = 1 by norm_num, mul_one] at this
-    exact (this.trans_le h₀).false
+    grind
   · obtain ⟨ξ, hξ₁, hξ₂⟩ : ∃ ξ ∈ Set.Ioc 1 2, (C + C') * (ξ - 1) < (q.totient : ℝ)⁻¹ := by
       refine ⟨min (1 + (q.totient : ℝ)⁻¹ / (C + C') / 2) 2, ⟨?_, min_le_right ..⟩, ?_⟩
       · simpa only [lt_inf_iff, lt_add_iff_pos_right, Nat.ofNat_pos, div_pos_iff_of_pos_right,
           Nat.one_lt_ofNat, and_true] using div_pos hq h₀
       · rw [← min_sub_sub_right, add_sub_cancel_left, ← lt_div_iff₀' h₀]
         exact (min_le_left ..).trans_lt <| div_lt_self (div_pos hq h₀) one_lt_two
-    exact ((H₁ hξ₁).trans_lt hξ₂).false
+    grind
 
 end ArithmeticFunction.vonMangoldt
 

--- a/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
+++ b/Mathlib/NumberTheory/LSeries/PrimesInAP.lean
@@ -134,7 +134,8 @@ lemma residueClass_nonneg (n : ℕ) : 0 ≤ residueClass a n :=
 lemma residueClass_le (n : ℕ) : residueClass a n ≤ vonMangoldt n :=
   Set.indicator_apply_le' (fun _ ↦ le_rfl) (fun _ ↦ vonMangoldt_nonneg)
 
-
+-- "simp" flag removed because simp can prove this
+lemma residueClass_apply_zero : residueClass a 0 = 0 := by simp
 
 lemma abscissaOfAbsConv_residueClass_le_one :
     abscissaOfAbsConv ↗(residueClass a) ≤ 1 := by

--- a/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
+++ b/Mathlib/NumberTheory/LSeries/RiemannZeta.lean
@@ -204,10 +204,9 @@ lemma riemannZeta_residue_one : Tendsto (fun s ↦ (s - 1) * riemannZeta s) (�
 /-- The residue of `ζ(s)` at `s = 1` is equal to 1, expressed using `tsum`. -/
 theorem tendsto_sub_mul_tsum_nat_cpow :
     Tendsto (fun s : ℂ ↦ (s - 1) * ∑' (n : ℕ), 1 / (n : ℂ) ^ s) (𝓝[{s | 1 < re s}] 1) (𝓝 1) := by
-  refine (tendsto_nhdsWithin_mono_left ?_ riemannZeta_residue_one).congr' ?_
-  · simp only [subset_compl_singleton_iff, mem_setOf_eq, one_re, not_lt, le_refl]
-  · filter_upwards [eventually_mem_nhdsWithin] with s hs using
-      congr_arg _ <| zeta_eq_tsum_one_div_nat_cpow hs
+  refine (tendsto_nhdsWithin_mono_left (by simp) riemannZeta_residue_one).congr' ?_
+  filter_upwards [eventually_mem_nhdsWithin] with s hs using
+    congr_arg _ <| zeta_eq_tsum_one_div_nat_cpow hs
 
 /-- The residue of `ζ(s)` at `s = 1` is equal to 1 expressed using `tsum` and for a
 real variable. -/
@@ -217,5 +216,4 @@ theorem tendsto_sub_mul_tsum_nat_rpow :
   have : Tendsto (fun s : ℝ ↦ (s : ℂ)) (𝓝[>] 1) (𝓝[{s | 1 < re s}] 1) :=
     continuous_ofReal.continuousWithinAt.tendsto_nhdsWithin (fun _ _ ↦ by simp_all)
   apply (tendsto_sub_mul_tsum_nat_cpow.comp this).congr fun s ↦ ?_
-  simp only [one_div, Function.comp_apply, ofReal_mul, ofReal_sub, ofReal_one, ofReal_tsum,
-    ofReal_inv, ofReal_cpow (Nat.cast_nonneg _), ofReal_natCast]
+  simp [ofReal_tsum, ofReal_cpow (Nat.cast_nonneg _)]

--- a/Mathlib/NumberTheory/LSeries/SumCoeff.lean
+++ b/Mathlib/NumberTheory/LSeries/SumCoeff.lean
@@ -58,7 +58,7 @@ private theorem LSeriesSummable_of_sum_norm_bigO_aux (hf : f 0 = 0)
     (g := fun t ↦ t ^ (-(s.re + 1) + r)) _ h₃ ?_ ?_ ?_ ?_
   · refine (Iff.mpr integrableOn_Ici_iff_integrableOn_Ioi
       (integrableOn_Ioi_deriv_norm_ofReal_cpow zero_lt_one ?_)).locallyIntegrableOn
-    exact neg_re _ ▸ neg_nonpos.mpr <| hr.trans hs.le
+    grind
   · refine (IsBigO.mul_atTop_rpow_natCast_of_isBigO_rpow _ _ _ ?_ hO h₂).congr_right (by simp)
     exact (norm_ofReal_cpow_eventually_eq_atTop _).isBigO.natCast_atTop
   · refine h₄.isBigO.of_const_mul_right.mul_atTop_rpow_of_isBigO_rpow _ r _ ?_ le_rfl
@@ -110,9 +110,7 @@ private theorem LSeries_eq_mul_integral_aux {f : ℕ → ℂ} (hf : f 0 = 0) {r 
     ?_ hf h₃ ?_ ?_ ?_ (integrableAtFilter_rpow_atTop_iff.mpr h₁)
   · rw [zero_sub, ← integral_neg]
     refine setIntegral_congr_fun measurableSet_Ioi fun t ht ↦ ?_
-    rw [deriv_ofReal_cpow_const (zero_lt_one.trans ht).ne', h₄]
-    · ring_nf
-    · exact neg_ne_zero.mpr <| ne_zero_of_re_pos (hr.trans_lt hs)
+    rw [deriv_ofReal_cpow_const (zero_lt_one.trans ht).ne', h₄] <;> grind
   · refine (Iff.mpr integrableOn_Ici_iff_integrableOn_Ioi <|
       integrableOn_Ioi_deriv_ofReal_cpow zero_lt_one
         (by simpa using hr.trans_lt hs)).locallyIntegrableOn
@@ -242,8 +240,7 @@ private theorem LSeries_tendsto_sub_mul_nhds_one_of_tendsto_sum_div_aux₂ {s T 
         Real.rpow_nonneg (zero_le_one.trans ht.le) _
     _ = ε := by
       rw [integral_Ioi_rpow_of_lt (by rwa [neg_lt_neg_iff]) zero_lt_one, Real.one_rpow]
-      field_simp [show -s + 1 ≠ 0 by linarith, hε.ne']
-      ring
+      grind
 
 private theorem LSeries_tendsto_sub_mul_nhds_one_of_tendsto_sum_div_aux₃
     (hlim : Tendsto (fun n : ℕ ↦ (∑ k ∈ Icc 1 n, f k) / n) atTop (𝓝 l))
@@ -292,7 +289,7 @@ private theorem LSeries_tendsto_sub_mul_nhds_one_of_tendsto_sum_div_aux₃
       exact isBigO_atTop_natCast_rpow_of_tendsto_div_rpow (a := l) (by simpa using hlim)
     _ = ‖(s - 1) * s * ∫ t in Set.Ioi 1, (S t * (t : ℂ) ^ (-s - 1 : ℂ) - l * t ^ (-s : ℂ))‖ := by
       rw [integral_sub, integral_const_mul]
-      · congr; ring
+      · grind
       · exact (lemma₁ hlim hs).mono_set Set.Ioi_subset_Ici_self
       · exact (integrableOn_Ioi_cpow_of_lt
           (by rwa [neg_re, ofReal_re, neg_lt_neg_iff]) zero_lt_one).const_mul _


### PR DESCRIPTION
Golf lots of proofs using the "grind" tactic (and other automation tactics "simp", "abel", "ring")

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->
Found using @dwrensha 's excellent `tryAtEachStep` script. In the process I realised one simp lemma could actually be proved using `by simp`, so I removed the simp flag (not sure why the linter didn't warn on that).

(NB: I'm generally suspicious of "fixing things that aren't broken", particularly when it leads to PR's which touch lots of files and risk causing lots of conflicts. This particular PR was basically a familiarisation exercise for me to learn what `grind` can do; I deliberately chose a directory which AFAIK nobody is actively working on developing at present – apologies if I was wrong about that and it does mess up anybody else's work.)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
