### PR TITLE
[Merged by Bors] - doc(Util): documentation corrections by way of LLM

### DIFF
--- a/Mathlib/Algebra/Homology/DifferentialObject.lean
+++ b/Mathlib/Algebra/Homology/DifferentialObject.lean
@@ -23,7 +23,7 @@ noncomputable section
 /-!
 We first prove some results about differential graded objects.
 
-Porting note: after the port, move these to their own file.
+TODO: We should move these to their own file.
 -/
 namespace CategoryTheory.DifferentialObject
 

--- a/Mathlib/Util/AddRelatedDecl.lean
+++ b/Mathlib/Util/AddRelatedDecl.lean
@@ -59,7 +59,7 @@ def addRelatedDecl (src : Name) (suffix : String) (ref : Syntax)
       { info with levelParams := newLevels, type := newType, name := tgt, value := newValue }
   | ConstantInfo.defnInfo info =>
     -- Structure fields are created using `def`, even when they are propositional,
-    -- so we don't rely on this to decided whether we should be constructing a `theorem` or a `def`.
+    -- so we don't rely on this to decide whether we should be constructing a `theorem` or a `def`.
     addAndCompile <| if ← isProp newType then .thmDecl
       { info with levelParams := newLevels, type := newType, name := tgt, value := newValue }
       else .defnDecl

--- a/Mathlib/Util/AssertExists.lean
+++ b/Mathlib/Util/AssertExists.lean
@@ -14,7 +14,7 @@ These commands are used to enforce the independence of different parts of mathli
 
 ## TODO
 
-After the port, potentially reimplement the mathlib 3 linters to check that declarations asserted
+Potentially reimplement the mathlib 3 linters to check that declarations asserted
 not to exist do eventually exist.
 
 Implement `assert_instance` and `assert_no_instance`.

--- a/Mathlib/Util/AssertExists.lean
+++ b/Mathlib/Util/AssertExists.lean
@@ -8,16 +8,16 @@ import Lean.Elab.Command
 import Mathlib.Util.AssertExistsExt
 
 /-!
-# User commands for assert the (non-)existence of declaration or instances.
+# User commands to assert the (non-)existence of declarations or instances.
 
 These commands are used to enforce the independence of different parts of mathlib.
 
 ## TODO
 
-Potentially after the port reimplement the mathlib 3 linters to check that declarations asserted
-about do eventually exist.
+After the port, potentially reimplement the mathlib 3 linters to check that declarations asserted
+not to exist do eventually exist.
 
-Implement `assert_instance` and `assert_no_instance`
+Implement `assert_instance` and `assert_no_instance`.
 -/
 
 section
@@ -35,7 +35,7 @@ This means that the expectation is that all checks *succeed* by the time `#check
 is used, typically once all of `Mathlib` has been built.
 
 If all declarations and imports are available when `#check_assertions` is used,
-then the command logs an info. Otherwise, it emits a warning.
+then the command logs an info message. Otherwise, it emits a warning.
 
 The variant `#check_assertions!` only prints declarations/imports that are not present in the
 environment.  In particular, it is silent if everything is imported, making it useful for testing.

--- a/Mathlib/Util/AssertExistsExt.lean
+++ b/Mathlib/Util/AssertExistsExt.lean
@@ -17,8 +17,8 @@ open Lean
 
 namespace Mathlib.AssertNotExist
 
-/-- `AssertExists` is the structure that carries the data to check if a declaration or an
-import are meant to exist somewhere in Mathlib. -/
+/-- `AssertExists` is the structure that carries the data to check whether a declaration or an
+import is meant to exist somewhere in Mathlib. -/
 structure AssertExists where
   /-- The type of the assertion: `true` means declaration, `false` means import. -/
   isDecl : Bool
@@ -28,7 +28,7 @@ structure AssertExists where
   modName : Name
   deriving BEq, Hashable
 
-/-- Defines the `assertExistsExt` extension for adding a `HashSet` of `AssertExists`s
+/-- Defines the `assertExistsExt` extension for adding a `HashSet` of `AssertExists` entries
 to the environment. -/
 initialize assertExistsExt : SimplePersistentEnvExtension AssertExists (Std.HashSet AssertExists) ←
   registerSimplePersistentEnvExtension {
@@ -37,10 +37,10 @@ initialize assertExistsExt : SimplePersistentEnvExtension AssertExists (Std.Hash
   }
 
 /--
-`addDeclEntry isDecl declName mod` takes as input the `Bool`ean `isDecl` and the `Name`s of
-a declaration or import, `declName`, and of a module, `mod`.
+`addDeclEntry isDecl declName mod` takes as input the boolean flag `isDecl` and the names
+`declName` (a declaration or import) and `mod` (a module).
 It extends the `AssertExists` environment extension with the data `isDecl, declName, mod`.
-This information is used to capture declarations and modules that are required to not
+This information is used to record declarations and modules that are required not to
 exist/be imported at some point, but should eventually exist/be imported.
 -/
 def addDeclEntry {m : Type → Type} [MonadEnv m] (isDecl : Bool) (declName mod : Name) : m Unit :=

--- a/Mathlib/Util/AssertExistsExt.lean
+++ b/Mathlib/Util/AssertExistsExt.lean
@@ -37,10 +37,10 @@ initialize assertExistsExt : SimplePersistentEnvExtension AssertExists (Std.Hash
   }
 
 /--
-`addDeclEntry isDecl declName mod` takes as input the boolean flag `isDecl` and the names
-`declName` (a declaration or import) and `mod` (a module).
+`addDeclEntry isDecl declName mod` takes as input the `Bool`ean `isDecl` and the `Name`s of
+a declaration or import, `declName`, and of a module, `mod`.
 It extends the `AssertExists` environment extension with the data `isDecl, declName, mod`.
-This information is used to record declarations and modules that are required not to
+This information is used to capture declarations and modules that are required not to
 exist/be imported at some point, but should eventually exist/be imported.
 -/
 def addDeclEntry {m : Type → Type} [MonadEnv m] (isDecl : Bool) (declName mod : Name) : m Unit :=

--- a/Mathlib/Util/AssertExistsExt.lean
+++ b/Mathlib/Util/AssertExistsExt.lean
@@ -40,8 +40,8 @@ initialize assertExistsExt : SimplePersistentEnvExtension AssertExists (Std.Hash
 `addDeclEntry isDecl declName mod` takes as input the `Bool`ean `isDecl` and the `Name`s of
 a declaration or import, `declName`, and of a module, `mod`.
 It extends the `AssertExists` environment extension with the data `isDecl, declName, mod`.
-This information is used to capture declarations and modules that are required not to
-exist/be imported at some point, but should eventually exist/be imported.
+This information is used to capture declarations and modules that are forbidden from
+existing/being imported at some point, but should eventually exist/be imported.
 -/
 def addDeclEntry {m : Type → Type} [MonadEnv m] (isDecl : Bool) (declName mod : Name) : m Unit :=
   modifyEnv (assertExistsExt.addEntry · { isDecl := isDecl, givenName := declName, modName := mod })

--- a/Mathlib/Util/CountHeartbeats.lean
+++ b/Mathlib/Util/CountHeartbeats.lean
@@ -93,17 +93,17 @@ set_option linter.style.maxHeartbeats false in
 Use `#count_heartbeats` to count the heartbeats in *all* the following declarations.
 
 This is most useful for setting sufficient but reasonable limits via `set_option maxHeartbeats`
-for long running declarations.
+for long-running declarations.
 
 If you do so, please resist the temptation to set the limit as low as possible.
 As the `simp` set and other features of the library evolve,
 other contributors will find that their (likely unrelated) changes
 have pushed the declaration over the limit.
-`count_heartbearts in` will automatically suggest a `set_option maxHeartbeats` via "Try this:"
+`count_heartbeats in` will automatically suggest a `set_option maxHeartbeats` via "Try this:"
 using the least number of the form `2^k * 200000` that suffices.
 
-Note that that internal heartbeat counter accessible via `IO.getNumHeartbeats`
-has granularity 1000 times finer that the limits set by `set_option maxHeartbeats`.
+Note that the internal heartbeat counter accessible via `IO.getNumHeartbeats`
+has granularity 1000 times finer than the limits set by `set_option maxHeartbeats`.
 As this is intended as a user command, we divide by 1000.
 
 The optional `approximately` keyword rounds down the heartbeats to the nearest thousand.

--- a/Mathlib/Util/DischargerAsTactic.lean
+++ b/Mathlib/Util/DischargerAsTactic.lean
@@ -17,7 +17,7 @@ used via the tactic frontend of `simp` via `simp (discharger := wrapSimpDischarg
 
 open Lean Meta Elab Tactic
 
-/-- Wrap an simp discharger (a function `Expr → SimpM (Option Expr)`) as a tactic,
+/-- Wrap a simp discharger (a function `Expr → SimpM (Option Expr)`) as a tactic,
 so that it can be passed as an argument to `simp (discharger := foo)`.
 This is inverse to `mkDischargeWrapper`. -/
 def wrapSimpDischarger (dis : Simp.Discharge) : TacticM Unit := do

--- a/Mathlib/Util/Export.lean
+++ b/Mathlib/Util/Export.lean
@@ -10,7 +10,7 @@ import Lean.Util.FoldConsts
 /-!
 A rudimentary export format, adapted from
 <https://github.com/leanprover-community/lean/blob/master/doc/export_format.md>
-with support for lean 4 kernel primitives.
+with support for Lean 4 kernel primitives.
 -/
 
 open Lean

--- a/Mathlib/Util/FormatTable.lean
+++ b/Mathlib/Util/FormatTable.lean
@@ -29,10 +29,10 @@ def String.justify (s : String) (a : Alignment) (width : Nat) : String :=
     String.replicate pad ' ' ++ s ++ String.replicate (width - s.length - pad) ' '
 
 /--
-Render a two-dimensional array of `String`s` into a markdown-compliant table.
+Render a two-dimensional array of Strings into a markdown-compliant table.
 `headers` is a list of column headers,
 `table` is a 2D array of cell contents,
-`alignments` describes how to align each table column (default: left-aligned) -/
+`alignments` describes how to align each table column (default: left-aligned). -/
 def formatTable (headers : Array String) (table : Array (Array String))
     (alignments : Option (Array Alignment) := none) :
     String := Id.run do

--- a/Mathlib/Util/FormatTable.lean
+++ b/Mathlib/Util/FormatTable.lean
@@ -29,7 +29,7 @@ def String.justify (s : String) (a : Alignment) (width : Nat) : String :=
     String.replicate pad ' ' ++ s ++ String.replicate (width - s.length - pad) ' '
 
 /--
-Render a two-dimensional array of Strings into a markdown-compliant table.
+Render a two-dimensional array of `String`s into a markdown-compliant table.
 `headers` is a list of column headers,
 `table` is a 2D array of cell contents,
 `alignments` describes how to align each table column (default: left-aligned). -/

--- a/Mathlib/Util/SynthesizeUsing.lean
+++ b/Mathlib/Util/SynthesizeUsing.lean
@@ -37,7 +37,7 @@ The tactic must solve for all goals, in contrast to `synthesizeUsing`.
 -/
 def synthesizeUsing' {u : Level} (type : Q(Sort u)) (tac : TacticM Unit) : MetaM Q($type) := do
   let (goals, e) ← synthesizeUsing type tac
-  -- Note: doesn't use `tac *> Tactic.done` since that just adds a message
+  -- Note: does not use `tac *> Tactic.done` since that just adds a message
   -- rather than raising an error.
   unless goals.isEmpty do
     throwError m!"synthesizeUsing': unsolved goals\n{goalsToMessageData goals}"


### PR DESCRIPTION
I vibe-coded some documentation improvements for `Mathlib/Util`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
