### PR TITLE
[Merged by Bors] - feat(Mathlib/Algebra/GCDMonoid): `gcd_ne_zero_iff`s

### DIFF
--- a/Mathlib/Algebra/GCDMonoid/Finset.lean
+++ b/Mathlib/Algebra/GCDMonoid/Finset.lean
@@ -187,8 +187,7 @@ theorem gcd_eq_zero_iff : s.gcd f = 0 ↔ ∀ x : β, x ∈ s → f x = 0 := by
     apply h b (mem_def.1 bs)
 
 theorem gcd_ne_zero_iff : s.gcd f ≠ 0 ↔ ∃ x ∈ s, f x ≠ 0 := by
-  convert not_congr (gcd_eq_zero_iff)
-  simp
+  simp [gcd_eq_zero_iff]
 
 theorem gcd_eq_gcd_filter_ne_zero [DecidablePred fun x : β ↦ f x = 0] :
     s.gcd f = {x ∈ s | f x ≠ 0}.gcd f := by

--- a/Mathlib/Algebra/GCDMonoid/Finset.lean
+++ b/Mathlib/Algebra/GCDMonoid/Finset.lean
@@ -186,6 +186,10 @@ theorem gcd_eq_zero_iff : s.gcd f = 0 ↔ ∀ x : β, x ∈ s → f x = 0 := by
     rcases as with ⟨b, ⟨bs, rfl⟩⟩
     apply h b (mem_def.1 bs)
 
+theorem gcd_ne_zero_iff : s.gcd f ≠ 0 ↔ ∃ x ∈ s, f x ≠ 0 := by
+  convert not_congr (gcd_eq_zero_iff)
+  simp
+
 theorem gcd_eq_gcd_filter_ne_zero [DecidablePred fun x : β ↦ f x = 0] :
     s.gcd f = {x ∈ s | f x ≠ 0}.gcd f := by
   classical

--- a/Mathlib/Algebra/GCDMonoid/Multiset.lean
+++ b/Mathlib/Algebra/GCDMonoid/Multiset.lean
@@ -151,6 +151,10 @@ theorem gcd_eq_zero_iff (s : Multiset α) : s.gcd = 0 ↔ ∀ x : α, x ∈ s �
     intro a s sgcd h
     simp [h a (mem_cons_self a s), sgcd fun x hx ↦ h x (mem_cons_of_mem hx)]
 
+theorem gcd_ne_zero_iff (s : Multiset α) : s.gcd ≠ 0 ↔ ∃ x ∈ s, x ≠ 0 := by
+  convert not_congr (gcd_eq_zero_iff s)
+  simp
+
 theorem gcd_map_mul (a : α) (s : Multiset α) : (s.map (a * ·)).gcd = normalize a * s.gcd := by
   refine s.induction_on ?_ fun b s ih ↦ ?_
   · simp_rw [map_zero, gcd_zero, mul_zero]

--- a/Mathlib/Algebra/GCDMonoid/Multiset.lean
+++ b/Mathlib/Algebra/GCDMonoid/Multiset.lean
@@ -152,8 +152,7 @@ theorem gcd_eq_zero_iff (s : Multiset α) : s.gcd = 0 ↔ ∀ x : α, x ∈ s �
     simp [h a (mem_cons_self a s), sgcd fun x hx ↦ h x (mem_cons_of_mem hx)]
 
 theorem gcd_ne_zero_iff (s : Multiset α) : s.gcd ≠ 0 ↔ ∃ x ∈ s, x ≠ 0 := by
-  convert not_congr (gcd_eq_zero_iff s)
-  simp
+  simp [gcd_eq_zero_iff]
 
 theorem gcd_map_mul (a : α) (s : Multiset α) : (s.map (a * ·)).gcd = normalize a * s.gcd := by
   refine s.induction_on ?_ fun b s ih ↦ ?_


### PR DESCRIPTION
These are the `not_congr`s of `gcd_eq_zero_iff`s, which might be useful as parameters to `rw`/`simp`/`apply` in some cases to simplify some proofs.