### PR TITLE
[Merged by Bors] - feat(Algebra/Order/Group): `partialSups_const_mul` and `partialSups_mul_const`

### DIFF
--- a/Mathlib.lean
+++ b/Mathlib.lean
@@ -847,6 +847,7 @@ import Mathlib.Algebra.Order.Group.Multiset
 import Mathlib.Algebra.Order.Group.Nat
 import Mathlib.Algebra.Order.Group.Opposite
 import Mathlib.Algebra.Order.Group.OrderIso
+import Mathlib.Algebra.Order.Group.PartialSups
 import Mathlib.Algebra.Order.Group.PiLex
 import Mathlib.Algebra.Order.Group.Pointwise.Bounds
 import Mathlib.Algebra.Order.Group.Pointwise.CompleteLattice

--- a/Mathlib/Algebra/Order/Group/PartialSups.lean
+++ b/Mathlib/Algebra/Order/Group/PartialSups.lean
@@ -15,9 +15,9 @@ variable {α ι : Type*}
 variable [SemilatticeSup α] [Group α] [Preorder ι] [LocallyFiniteOrderBot ι]
 
 @[to_additive]
-lemma partialSups_mulLeft [MulLeftMono α] (f : ι → α) (c : α) (i : ι) :
+lemma partialSups_const_mul [MulLeftMono α] (f : ι → α) (c : α) (i : ι) :
     partialSups (c * f ·) i = c * (partialSups f i) := map_partialSups (OrderIso.mulLeft _) ..
 
 @[to_additive]
-lemma partialSups_mulRight [MulRightMono α] (f : ι → α) (c : α) (i : ι) :
+lemma partialSups_mul_const [MulRightMono α] (f : ι → α) (c : α) (i : ι) :
     partialSups (f · * c) i = (partialSups f i) * c := map_partialSups (OrderIso.mulRight _) ..

--- a/Mathlib/Algebra/Order/Group/PartialSups.lean
+++ b/Mathlib/Algebra/Order/Group/PartialSups.lean
@@ -16,8 +16,8 @@ variable [SemilatticeSup α] [Group α] [Preorder ι] [LocallyFiniteOrderBot ι]
 
 @[to_additive]
 lemma partialSups_const_mul [MulLeftMono α] (f : ι → α) (c : α) (i : ι) :
-    partialSups (c * f ·) i = c * (partialSups f i) := map_partialSups (OrderIso.mulLeft _) ..
+    partialSups (c * f ·) i = c * partialSups f i := map_partialSups (OrderIso.mulLeft _) ..
 
 @[to_additive]
 lemma partialSups_mul_const [MulRightMono α] (f : ι → α) (c : α) (i : ι) :
-    partialSups (f · * c) i = (partialSups f i) * c := map_partialSups (OrderIso.mulRight _) ..
+    partialSups (f · * c) i = partialSups f i * c := map_partialSups (OrderIso.mulRight _) ..

--- a/Mathlib/Algebra/Order/Group/PartialSups.lean
+++ b/Mathlib/Algebra/Order/Group/PartialSups.lean
@@ -1,0 +1,23 @@
+/-
+Copyright (c) 2025 Lua Viana Reis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Lua Viana Reis
+-/
+import Mathlib.Algebra.Order.Group.OrderIso
+import Mathlib.Order.PartialSups
+
+/-!
+# Results about `partialSups` of functions taking values in a `Group`
+-/
+
+variable {α ι : Type*}
+
+variable [SemilatticeSup α] [Group α] [Preorder ι] [LocallyFiniteOrderBot ι]
+
+@[to_additive]
+lemma partialSups_mulLeft [MulLeftMono α] (f : ι → α) (c : α) (i : ι) :
+    partialSups (c * f ·) i = c * (partialSups f i) := map_partialSups (OrderIso.mulLeft _) ..
+
+@[to_additive]
+lemma partialSups_mulRight [MulRightMono α] (f : ι → α) (c : α) (i : ι) :
+    partialSups (f · * c) i = (partialSups f i) * c := map_partialSups (OrderIso.mulRight _) ..


### PR DESCRIPTION
Add the 2 lemmas (and their additive versions) about `partialSups` in a `Group`. 

---

This is a follow-up to #26851

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
