### PR TITLE
[Merged by Bors] - feat(Topology/Algebra/Module): `prod` and `coprod` as `ContinuousLinearEquiv`s

### DIFF
--- a/Mathlib/Topology/Algebra/Module/LinearMapPiProd.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearMapPiProd.lean
@@ -322,7 +322,10 @@ lemma coprod_inl_inr : ContinuousLinearMap.coprod (.inl R M N) (.inr R M N) = .i
 
 /-- Taking the product of two maps with the same codomain is equivalent to taking the product of
 their domains.
-See note [bundled maps over different rings] for why separate `R` and `S` semirings are used. -/
+See note [bundled maps over different rings] for why separate `R` and `S` semirings are used.
+
+See `coprodEquivL` for the `ContinuousLinearEquiv` version.
+-/
 @[simps]
 def coprodEquiv [ContinuousAdd M₁] [ContinuousAdd M₂] [Semiring S] [Module S M]
     [ContinuousConstSMul S M] [SMulCommClass R S M] :

--- a/Mathlib/Topology/Algebra/Module/LinearMapPiProd.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearMapPiProd.lean
@@ -273,7 +273,9 @@ variable (S : Type*) [Semiring S]
   [Module S M₂] [ContinuousAdd M₂] [SMulCommClass R S M₂] [ContinuousConstSMul S M₂]
   [Module S M₃] [ContinuousAdd M₃] [SMulCommClass R S M₃] [ContinuousConstSMul S M₃]
 
-/-- `ContinuousLinearMap.prod` as a `LinearEquiv`. -/
+/-- `ContinuousLinearMap.prod` as a `LinearEquiv`.
+
+See `ContinuousLinearMap.prodL` for the `ContinuousLinearEquiv` version. -/
 @[simps apply]
 def prodₗ : ((M →L[R] M₂) × (M →L[R] M₃)) ≃ₗ[S] M →L[R] M₂ × M₃ :=
   { prodEquiv with
@@ -324,7 +326,7 @@ lemma coprod_inl_inr : ContinuousLinearMap.coprod (.inl R M N) (.inr R M N) = .i
 their domains.
 See note [bundled maps over different rings] for why separate `R` and `S` semirings are used.
 
-See `coprodEquivL` for the `ContinuousLinearEquiv` version.
+See `ContinuousLinearMap.coprodEquivL` for the `ContinuousLinearEquiv` version.
 -/
 @[simps]
 def coprodEquiv [ContinuousAdd M₁] [ContinuousAdd M₂] [Semiring S] [Module S M]

--- a/Mathlib/Topology/Algebra/Module/LinearMapPiProd.lean
+++ b/Mathlib/Topology/Algebra/Module/LinearMapPiProd.lean
@@ -322,11 +322,7 @@ lemma coprod_inl_inr : ContinuousLinearMap.coprod (.inl R M N) (.inr R M N) = .i
 
 /-- Taking the product of two maps with the same codomain is equivalent to taking the product of
 their domains.
-See note [bundled maps over different rings] for why separate `R` and `S` semirings are used.
-
-TODO: Upgrade this to a `ContinuousLinearEquiv`. This should be true for any topological
-vector space over a normed field thanks to `ContinuousLinearMap.precomp` and
-`ContinuousLinearMap.postcomp`. -/
+See note [bundled maps over different rings] for why separate `R` and `S` semirings are used. -/
 @[simps]
 def coprodEquiv [ContinuousAdd M₁] [ContinuousAdd M₂] [Semiring S] [Module S M]
     [ContinuousConstSMul S M] [SMulCommClass R S M] :

--- a/Mathlib/Topology/Algebra/Module/StrongTopology.lean
+++ b/Mathlib/Topology/Algebra/Module/StrongTopology.lean
@@ -575,6 +575,41 @@ theorem coe_restrict_scalarsL' : ⇑(restrictScalarsL 𝕜 E F 𝕜' 𝕜'') = r
 
 end RestrictScalars
 
+section Prod
+
+variable {𝕜 E F G : Type*} (S : Type*) [NormedField 𝕜] [Semiring S]
+  [AddCommGroup E] [Module 𝕜 E]
+  [TopologicalSpace E] [IsTopologicalAddGroup E] [ContinuousConstSMul 𝕜 E]
+  [AddCommGroup F] [Module 𝕜 F]
+  [TopologicalSpace F] [IsTopologicalAddGroup F] [ContinuousConstSMul 𝕜 F]
+  [AddCommGroup G] [Module 𝕜 G]
+  [TopologicalSpace G] [IsTopologicalAddGroup G] [ContinuousConstSMul 𝕜 G]
+  [Module S G] [SMulCommClass 𝕜 S G] [ContinuousConstSMul S G]
+
+/-- `ContinuousLinearMap.coprod` as a `ContinuousLinearEquiv`. -/
+@[simps!]
+def coprodEquivL : ((E →L[𝕜] G) × (F →L[𝕜] G)) ≃L[S] (E × F →L[𝕜] G) where
+  __ := coprodEquiv
+  continuous_toFun :=
+    (((fst 𝕜 E F).precomp G).coprod ((snd 𝕜 E F).precomp G)).continuous
+  continuous_invFun :=
+    (((inl 𝕜 E F).precomp G).prod ((inr 𝕜 E F).precomp G)).continuous
+
+variable [Module S F] [SMulCommClass 𝕜 S F] [ContinuousConstSMul S F]
+
+/-- `ContinuousLinearMap.prod` as a `ContinuousLinearEquiv`. -/
+@[simps! apply]
+def prodEquivL : ((E →L[𝕜] F) × (E →L[𝕜] G)) ≃L[S] (E →L[𝕜] F × G) where
+  __ := prodₗ S
+  continuous_toFun := by
+    change Continuous fun x => id 𝕜 _ ∘L prodₗ S x
+    simp_rw [← coprod_inl_inr]
+    exact (((inl 𝕜 F G).postcomp E).coprod ((inr 𝕜 F G).postcomp E)).continuous
+  continuous_invFun :=
+    (((fst 𝕜 F G).postcomp E).prod ((snd 𝕜 F G).postcomp E)).continuous
+
+end Prod
+
 end ContinuousLinearMap
 
 open ContinuousLinearMap

--- a/Mathlib/Topology/Algebra/Module/StrongTopology.lean
+++ b/Mathlib/Topology/Algebra/Module/StrongTopology.lean
@@ -602,7 +602,7 @@ variable [Module S F] [SMulCommClass 𝕜 S F] [ContinuousConstSMul S F]
 def prodL : ((E →L[𝕜] F) × (E →L[𝕜] G)) ≃L[S] (E →L[𝕜] F × G) where
   __ := prodₗ S
   continuous_toFun := by
-    change Continuous fun x => id 𝕜 _ ∘L prodₗ S x
+    change Continuous fun x => .id 𝕜 _ ∘L prodₗ S x
     simp_rw [← coprod_inl_inr]
     exact (((inl 𝕜 F G).postcomp E).coprod ((inr 𝕜 F G).postcomp E)).continuous
   continuous_invFun :=

--- a/Mathlib/Topology/Algebra/Module/StrongTopology.lean
+++ b/Mathlib/Topology/Algebra/Module/StrongTopology.lean
@@ -599,7 +599,7 @@ variable [Module S F] [SMulCommClass 𝕜 S F] [ContinuousConstSMul S F]
 
 /-- `ContinuousLinearMap.prod` as a `ContinuousLinearEquiv`. -/
 @[simps! apply]
-def prodEquivL : ((E →L[𝕜] F) × (E →L[𝕜] G)) ≃L[S] (E →L[𝕜] F × G) where
+def prodL : ((E →L[𝕜] F) × (E →L[𝕜] G)) ≃L[S] (E →L[𝕜] F × G) where
   __ := prodₗ S
   continuous_toFun := by
     change Continuous fun x => id 𝕜 _ ∘L prodₗ S x


### PR DESCRIPTION


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
