### PR TITLE
[Merged by Bors] - chore(Algebra/Homology/ShortComplex): remove redundant `have`:s in `ShortExact.map_of_exact`

### DIFF
--- a/Mathlib/Algebra/Homology/ShortComplex/ShortExact.lean
+++ b/Mathlib/Algebra/Homology/ShortComplex/ShortExact.lean
@@ -103,8 +103,6 @@ lemma ShortExact.map_of_exact (hS : S.ShortExact)
     [PreservesFiniteColimits F] : (S.map F).ShortExact := by
   have := hS.mono_f
   have := hS.epi_g
-  have := preserves_mono_of_preservesLimit F S.f
-  have := preserves_epi_of_preservesColimit F S.g
   exact hS.map F
 
 end


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
