### PR TITLE
[Merged by Bors] - chore: remove last uses of the field_simp set

### DIFF
--- a/Archive/Wiedijk100Theorems/SolutionOfCubicQuartic.lean
+++ b/Archive/Wiedijk100Theorems/SolutionOfCubicQuartic.lean
@@ -235,8 +235,8 @@ theorem quartic_eq_zero_iff_of_q_eq_zero (ha : a ≠ 0)
   have h16 : (16 : K) = 2 ^ 4 := by norm_num
   have h256 : (256 : K) = 2 ^ 8 := by norm_num
   have h₁ : a * x ^ 4 + b * x ^ 3 + c * x ^ 2 + d * x + e = a * (y ^ 4 + p * y ^ 2 + r) := by
-    simp [hp, hr, h4, two_ne_zero, ha, add_div', div_pow, h8, mul_div_assoc', div_mul_eq_mul_div,
-      div_add', h16, h256, eq_div_iff, y]
+    simp only [hp, hr, y, h4, h8, h16, h256]
+    simp [ha, field_simps]
     linear_combination (1048576 * a ^ 10 * x + 262144 * a ^ 9 * b) * hqz
   rw [h₁, ha.isUnit.mul_right_eq_zero]
   calc

--- a/Archive/Wiedijk100Theorems/SolutionOfCubicQuartic.lean
+++ b/Archive/Wiedijk100Theorems/SolutionOfCubicQuartic.lean
@@ -236,8 +236,7 @@ theorem quartic_eq_zero_iff_of_q_eq_zero (ha : a ≠ 0)
   have h256 : (256 : K) = 2 ^ 8 := by norm_num
   have h₁ : a * x ^ 4 + b * x ^ 3 + c * x ^ 2 + d * x + e = a * (y ^ 4 + p * y ^ 2 + r) := by
     simp only [hp, hr, y, h4, h8, h16, h256]
-    simp [ha, field_simps]
-    linear_combination (1048576 * a ^ 10 * x + 262144 * a ^ 9 * b) * hqz
+    linear_combination (norm := (field_simp; ring)) (4 * a * x + b) * hqz / a ^ 3 / 2 ^ 5
   rw [h₁, ha.isUnit.mul_right_eq_zero]
   calc
     _ ↔ 1 * (y ^ 2 * y ^ 2) + p * y ^ 2 + r = 0 := by

--- a/Archive/Wiedijk100Theorems/SolutionOfCubicQuartic.lean
+++ b/Archive/Wiedijk100Theorems/SolutionOfCubicQuartic.lean
@@ -115,8 +115,7 @@ theorem cubic_eq_zero_iff (ha : a ≠ 0) (hω : IsPrimitiveRoot ω 3)
   have h9 : (9 : K) = 3 ^ 2 := by norm_num
   have h54 : (54 : K) = 2 * 3 ^ 3 := by norm_num
   have h₁ : a * x ^ 3 + b * x ^ 2 + c * x + d = a * (y ^ 3 + 3 * p * y - 2 * q) := by
-    rw [hp, hq]
-    simp [field_simps, y, ha, h9, h54]; ring
+    simp [hp, hq, field, h9, h54]; ring
   have h₂ : ∀ x, a * x = 0 ↔ x = 0 := by intro x; simp [ha]
   rw [h₁, h₂, cubic_depressed_eq_zero_iff hω hp_nonzero hr hs3 ht]
   simp_rw [y, eq_sub_iff_add_eq]
@@ -214,8 +213,7 @@ theorem quartic_eq_zero_iff (ha : a ≠ 0)
   have h256 : (256 : K) = 2 ^ 8 := by norm_num
   have h₁ : a * x ^ 4 + b * x ^ 3 + c * x ^ 2 + d * x + e =
       a * (y ^ 4 + p * y ^ 2 + q * y + r) := by
-    rw [hp, hq, hr]
-    simp [field_simps, y, ha, h4, h8, h16, h256]; ring
+    simp [hp, hq, hr, field, y, h4, h8, h16, h256]; ring
   have h₂ : ∀ x, a * x = 0 ↔ x = 0 := by intro x; simp [ha]
   rw [h₁, h₂, quartic_depressed_eq_zero_iff hq_nonzero hu hs hv hw]
   simp_rw [y, eq_sub_iff_add_eq]
@@ -237,8 +235,8 @@ theorem quartic_eq_zero_iff_of_q_eq_zero (ha : a ≠ 0)
   have h16 : (16 : K) = 2 ^ 4 := by norm_num
   have h256 : (256 : K) = 2 ^ 8 := by norm_num
   have h₁ : a * x ^ 4 + b * x ^ 3 + c * x ^ 2 + d * x + e = a * (y ^ 4 + p * y ^ 2 + r) := by
-    rw [hp, hr]
-    simp [field_simps, y, ha, h4, h8, h16, h256]
+    simp [hp, hr, h4, two_ne_zero, ha, add_div', div_pow, h8, mul_div_assoc', div_mul_eq_mul_div,
+      div_add', h16, h256, eq_div_iff, y]
     linear_combination (1048576 * a ^ 10 * x + 262144 * a ^ 9 * b) * hqz
   rw [h₁, ha.isUnit.mul_right_eq_zero]
   calc

--- a/Mathlib/Algebra/CharP/MixedCharZero.lean
+++ b/Mathlib/Algebra/CharP/MixedCharZero.lean
@@ -213,7 +213,8 @@ noncomputable def algebraRat (h : ∀ I : Ideal R, I ≠ ⊤ → CharZero (R ⧸
     map_one' := by simp
     map_mul' := by
       intro a b
-      simp [field_simps]
+      simp only [divp_assoc', divp_mul_eq_mul_divp, divp_divp_eq_divp_mul, divp_eq_iff_mul_eq,
+        pnatCast_eq_natCast, Rat.coe_pnatDen, Units.val_mul]
       trans (↑((a * b).num * a.den * b.den) : R)
       · simp_rw [Int.cast_mul, Int.cast_natCast]
         ring
@@ -221,7 +222,8 @@ noncomputable def algebraRat (h : ∀ I : Ideal R, I ≠ ⊤ → CharZero (R ⧸
       simp
     map_add' := by
       intro a b
-      simp [field_simps]
+      simp only [Units.add_divp, pnatCast_eq_natCast, Rat.coe_pnatDen, divp_mul_eq_mul_divp,
+        Units.divp_add, divp_divp_eq_divp_mul, divp_eq_iff_mul_eq, Units.val_mul]
       trans (↑((a + b).num * a.den * b.den) : R)
       · simp_rw [Int.cast_mul, Int.cast_natCast]
         ring

--- a/Mathlib/Analysis/Calculus/BumpFunction/FiniteDimension.lean
+++ b/Mathlib/Analysis/Calculus/BumpFunction/FiniteDimension.lean
@@ -401,14 +401,13 @@ theorem y_pos_of_mem_ball {D : ℝ} {x : E} (Dpos : 0 < D) (D_lt_one : D < 1)
       · apply ball_subset_ball' _ hy
         simp only [hz, norm_smul, abs_of_nonneg Dpos.le, abs_of_nonneg B.le, dist_zero_right,
           Real.norm_eq_abs, abs_div]
-        simp only [div_mul_eq_mul_div, div_add_div_same, div_le_iff₀ B]
-        ring_nf
-        rfl
+        field_simp
+        simp [div_le_iff₀ B]
       · have ID : ‖D / (1 + D) - 1‖ = 1 / (1 + D) := by
           rw [Real.norm_of_nonpos]
-          · simp only [Ne, B.ne', not_false_iff, div_sub', mul_one, neg_div', neg_sub,
-              add_tsub_cancel_right]
-          · simp only [Ne, B.ne', not_false_eq_true, div_sub', mul_one, sub_add_cancel_right]
+          · simp [field]
+          · field_simp
+            simp only [sub_add_cancel_right]
             apply div_nonpos_of_nonpos_of_nonneg _ B.le
             linarith only
         rw [← mem_closedBall_iff_norm']

--- a/Mathlib/Analysis/Calculus/BumpFunction/FiniteDimension.lean
+++ b/Mathlib/Analysis/Calculus/BumpFunction/FiniteDimension.lean
@@ -401,20 +401,21 @@ theorem y_pos_of_mem_ball {D : ℝ} {x : E} (Dpos : 0 < D) (D_lt_one : D < 1)
       · apply ball_subset_ball' _ hy
         simp only [hz, norm_smul, abs_of_nonneg Dpos.le, abs_of_nonneg B.le, dist_zero_right,
           Real.norm_eq_abs, abs_div]
-        simp only [div_le_iff₀ B, field_simps]
+        simp only [div_mul_eq_mul_div, div_add_div_same, div_le_iff₀ B]
         ring_nf
         rfl
       · have ID : ‖D / (1 + D) - 1‖ = 1 / (1 + D) := by
           rw [Real.norm_of_nonpos]
-          · simp only [B.ne', Ne, not_false_iff, mul_one, neg_sub, add_tsub_cancel_right,
-              field_simps]
-          · simp only [B.ne', Ne, not_false_iff, mul_one, field_simps]
+          · simp only [Ne, B.ne', not_false_iff, div_sub', mul_one, neg_div', neg_sub,
+              add_tsub_cancel_right]
+          · simp only [Ne, B.ne', not_false_eq_true, div_sub', mul_one, sub_add_cancel_right]
             apply div_nonpos_of_nonpos_of_nonneg _ B.le
             linarith only
         rw [← mem_closedBall_iff_norm']
         apply closedBall_subset_closedBall' _ (ball_subset_closedBall hy)
         rw [← one_smul ℝ x, dist_eq_norm, hz, ← sub_smul, one_smul, norm_smul, ID]
-        simp only [div_le_iff₀ B, field_simps]
+        field_simp
+        rw [div_le_one_iff]; left; refine ⟨B, ?_⟩
         nlinarith only [hx, D_lt_one]
     apply lt_of_lt_of_le _ (measure_mono C)
     apply measure_ball_pos

--- a/Mathlib/Analysis/Calculus/BumpFunction/FiniteDimension.lean
+++ b/Mathlib/Analysis/Calculus/BumpFunction/FiniteDimension.lean
@@ -414,8 +414,8 @@ theorem y_pos_of_mem_ball {D : ℝ} {x : E} (Dpos : 0 < D) (D_lt_one : D < 1)
         apply closedBall_subset_closedBall' _ (ball_subset_closedBall hy)
         rw [← one_smul ℝ x, dist_eq_norm, hz, ← sub_smul, one_smul, norm_smul, ID]
         field_simp
-        rw [div_le_one_iff]; left; refine ⟨B, ?_⟩
-        nlinarith only [hx, D_lt_one]
+        rw [div_le_one_iff]
+        exact Or.inl ⟨B, by nlinarith only [hx, D_lt_one]⟩
     apply lt_of_lt_of_le _ (measure_mono C)
     apply measure_ball_pos
     exact div_pos (mul_pos Dpos (by linarith only [hx])) B

--- a/Mathlib/Analysis/SpecialFunctions/Integrals/Basic.lean
+++ b/Mathlib/Analysis/SpecialFunctions/Integrals/Basic.lean
@@ -446,14 +446,16 @@ theorem integral_sin_pow_odd :
   induction' n with k ih; · norm_num
   rw [prod_range_succ_comm, mul_left_comm, ← ih, mul_succ, integral_sin_pow]
   norm_cast
-  simp [-cast_add, field_simps]
+  field_simp
+  simp
 
 theorem integral_sin_pow_even :
     (∫ x in 0..π, sin x ^ (2 * n)) = π * ∏ i ∈ range n, (2 * (i : ℝ) + 1) / (2 * i + 2) := by
   induction' n with k ih; · simp
   rw [prod_range_succ_comm, mul_left_comm, ← ih, mul_succ, integral_sin_pow]
   norm_cast
-  simp [-cast_add, field_simps]
+  field_simp
+  simp
 
 theorem integral_sin_pow_pos : 0 < ∫ x in 0..π, sin x ^ n := by
   rcases even_or_odd' n with ⟨k, rfl | rfl⟩ <;>

--- a/Mathlib/Analysis/SpecificLimits/Basic.lean
+++ b/Mathlib/Analysis/SpecificLimits/Basic.lean
@@ -80,7 +80,7 @@ theorem tendsto_natCast_div_add_atTop {𝕜 : Type*} [DivisionRing 𝕜] [Topolo
     Tendsto (fun n : ℕ ↦ (n : 𝕜) / (n + x)) atTop (𝓝 1) := by
   convert Tendsto.congr' ((eventually_ne_atTop 0).mp (Eventually.of_forall fun n hn ↦ _)) _
   · exact fun n : ℕ ↦ 1 / (1 + x / n)
-  · simp [field_simps, Nat.cast_ne_zero.mpr hn]
+  · simp [Nat.cast_ne_zero.mpr hn, add_div']
   · have : 𝓝 (1 : 𝕜) = 𝓝 (1 / (1 + x * (0 : 𝕜))) := by
       rw [mul_zero, add_zero, div_one]
     rw [this]

--- a/Mathlib/Analysis/SpecificLimits/Basic.lean
+++ b/Mathlib/Analysis/SpecificLimits/Basic.lean
@@ -80,8 +80,7 @@ theorem tendsto_natCast_div_add_atTop {𝕜 : Type*} [DivisionRing 𝕜] [Topolo
     Tendsto (fun n : ℕ ↦ (n : 𝕜) / (n + x)) atTop (𝓝 1) := by
   convert Tendsto.congr' ((eventually_ne_atTop 0).mp (Eventually.of_forall fun n hn ↦ _)) _
   · exact fun n : ℕ ↦ 1 / (1 + x / n)
-  · -- TODO: even after a `set n' : 𝕜 := Nat.cast n`, field_simp cannot solve this
-    simp [Nat.cast_ne_zero.mpr hn, add_div']
+  · simp [Nat.cast_ne_zero.mpr hn, add_div']
   · have : 𝓝 (1 : 𝕜) = 𝓝 (1 / (1 + x * (0 : 𝕜))) := by
       rw [mul_zero, add_zero, div_one]
     rw [this]

--- a/Mathlib/Analysis/SpecificLimits/Basic.lean
+++ b/Mathlib/Analysis/SpecificLimits/Basic.lean
@@ -80,7 +80,8 @@ theorem tendsto_natCast_div_add_atTop {𝕜 : Type*} [DivisionRing 𝕜] [Topolo
     Tendsto (fun n : ℕ ↦ (n : 𝕜) / (n + x)) atTop (𝓝 1) := by
   convert Tendsto.congr' ((eventually_ne_atTop 0).mp (Eventually.of_forall fun n hn ↦ _)) _
   · exact fun n : ℕ ↦ 1 / (1 + x / n)
-  · simp [Nat.cast_ne_zero.mpr hn, add_div']
+  · -- TODO: even after a `set n' : 𝕜 := Nat.cast n`, field_simp cannot solve this
+    simp [Nat.cast_ne_zero.mpr hn, add_div']
   · have : 𝓝 (1 : 𝕜) = 𝓝 (1 / (1 + x * (0 : 𝕜))) := by
       rw [mul_zero, add_zero, div_one]
     rw [this]

--- a/Mathlib/Analysis/SpecificLimits/FloorPow.lean
+++ b/Mathlib/Analysis/SpecificLimits/FloorPow.lean
@@ -52,9 +52,7 @@ theorem tendsto_div_of_monotone_of_exists_subseq_tendsto_div (u : ℕ → ℝ) (
       filter_upwards [clim εpos, ctop (Ioi_mem_atTop 0)] with n hn cnpos'
       have cnpos : 0 < c n := cnpos'
       calc
-        u (c n) - c n * l = (u (c n) / c n - l) * c n := by
-          simp only [Ne, Nat.cast_eq_zero, cnpos.ne', not_false_iff, div_sub', div_mul_eq_mul_div,
-            eq_div_iff]
+        u (c n) - c n * l = (u (c n) / c n - l) * c n := by field_simp
         _ ≤ ε * c n := by
           gcongr
           refine (le_abs_self _).trans ?_
@@ -107,9 +105,7 @@ theorem tendsto_div_of_monotone_of_exists_subseq_tendsto_div (u : ℕ → ℝ) (
       filter_upwards [clim εpos, ctop (Ioi_mem_atTop 0)] with n hn cnpos'
       have cnpos : 0 < c n := cnpos'
       calc
-        (c n : ℝ) * l - u (c n) = -(u (c n) / c n - l) * c n := by
-          simp only [Ne, Nat.cast_eq_zero, cnpos.ne', not_false_iff, div_sub', neg_div', neg_sub,
-            div_mul_eq_mul_div, eq_div_iff]
+        (c n : ℝ) * l - u (c n) = -(u (c n) / c n - l) * c n := by field_simp; ring
         _ ≤ ε * c n := by
           gcongr
           refine le_trans (neg_le_abs _) ?_

--- a/Mathlib/Analysis/SpecificLimits/FloorPow.lean
+++ b/Mathlib/Analysis/SpecificLimits/FloorPow.lean
@@ -53,7 +53,8 @@ theorem tendsto_div_of_monotone_of_exists_subseq_tendsto_div (u : ℕ → ℝ) (
       have cnpos : 0 < c n := cnpos'
       calc
         u (c n) - c n * l = (u (c n) / c n - l) * c n := by
-          simp only [cnpos.ne', Ne, Nat.cast_eq_zero, not_false_iff, field_simps]
+          simp only [Ne, Nat.cast_eq_zero, cnpos.ne', not_false_iff, div_sub', div_mul_eq_mul_div,
+            eq_div_iff]
         _ ≤ ε * c n := by
           gcongr
           refine (le_abs_self _).trans ?_
@@ -107,7 +108,8 @@ theorem tendsto_div_of_monotone_of_exists_subseq_tendsto_div (u : ℕ → ℝ) (
       have cnpos : 0 < c n := cnpos'
       calc
         (c n : ℝ) * l - u (c n) = -(u (c n) / c n - l) * c n := by
-          simp only [cnpos.ne', Ne, Nat.cast_eq_zero, not_false_iff, neg_sub, field_simps]
+          simp only [Ne, Nat.cast_eq_zero, cnpos.ne', not_false_iff, div_sub', neg_div', neg_sub,
+            div_mul_eq_mul_div, eq_div_iff]
         _ ≤ ε * c n := by
           gcongr
           refine le_trans (neg_le_abs _) ?_

--- a/Mathlib/LinearAlgebra/QuadraticForm/Real.lean
+++ b/Mathlib/LinearAlgebra/QuadraticForm/Real.lean
@@ -35,7 +35,9 @@ noncomputable def isometryEquivSignWeightedSumSquares (w : ι → ℝ) :
     have : (u i : ℝ) ≠ 0 := (u i).ne_zero
     by positivity
   have hwu : ∀ i, w i / |(u i : ℝ)| = sign (w i) := fun i ↦ by
-    by_cases hi : w i = 0 <;> simp [field_simps, hi, u]
+    by_cases hi : w i = 0
+    · simp [hi]
+    · simp only [hi, ↓reduceDIte, Units.val_mk0, u]; field_simp; simp
   convert QuadraticMap.isometryEquivBasisRepr (weightedSumSquares ℝ w)
     ((Pi.basisFun ℝ ι).unitsSMul fun i => .mk0 _ (hu i))
   ext1 v

--- a/Mathlib/NumberTheory/FLT/Three.lean
+++ b/Mathlib/NumberTheory/FLT/Three.lean
@@ -647,7 +647,8 @@ private lemma formula2 :
     calc _ = S.X^3 *(S.u₂*S.u₂⁻¹)*(η^3*S.u₁)*(λ^((S.multiplicity-1)*3)*λ):= by push_cast; ring
     _ = S.X^3*S.u₁*λ^(3*S.multiplicity-2) := by simp [hζ.toInteger_cube_eq_one, ← pow_succ, this]
   · ring
-  · simp [field_simps, u₄_def, -one_div]
+  · simp only [u₄_def, inv_eq_one_div, mul_div_assoc', mul_one, val_div_eq_divp, Units.val_mul,
+      IsUnit.unit_spec, divp_mul_eq_mul_divp, divp_eq_iff_mul_eq]
     ring
 
 private lemma lambda_sq_div_u₅_mul : λ ^ 2 ∣ S.u₅ * (λ ^ (S.multiplicity - 1) * S.X) ^ 3 := by

--- a/Mathlib/RingTheory/WittVector/Frobenius.lean
+++ b/Mathlib/RingTheory/WittVector/Frobenius.lean
@@ -166,17 +166,10 @@ theorem map_frobeniusPoly (n : ℕ) :
   rw [C_inj]
   simp only [invOf_eq_inv, eq_intCast, inv_pow, Int.cast_natCast, Nat.cast_mul, Int.cast_mul]
   rw [Rat.natCast_div _ _ (map_frobeniusPoly.key₁ p (n - i) j hj)]
-  simp only [Nat.cast_pow, pow_add, pow_one]
-  suffices
-    (((p ^ (n - i)).choose (j + 1) : ℚ) * (p : ℚ) ^ (j - v p (j + 1)) * p * (p ^ n : ℚ))
-      = (p : ℚ) ^ j * p * ↑((p ^ (n - i)).choose (j + 1) * p ^ i) *
-        (p : ℚ) ^ (n - i - v p (j + 1)) by
-    have aux : ∀ k : ℕ, (p : ℚ) ^ k ≠ 0 := by
-      intro; apply pow_ne_zero; exact mod_cast hp.1.ne_zero
-    simpa only [inv_eq_one_div, mul_div_assoc', mul_one, div_mul_eq_mul_div, ne_eq, aux,
-      not_false_eq_true, eq_div_iff, div_eq_iff, Nat.cast_mul, Nat.cast_pow] using this.symm
-  rw [mul_comm _ (p : ℚ), mul_assoc, mul_assoc, ← pow_add,
-    map_frobeniusPoly.key₂ p hi.le hj, Nat.cast_mul, Nat.cast_pow]
+  push_cast
+  linear_combination (norm := skip) -p / p ^ n / p ^ (n - i - v p (j + 1))
+    * (p ^ (n - i)).choose (j + 1) * congr((p:ℚ) ^ $(map_frobeniusPoly.key₂ p hi.le hj))
+  field_simp [hp.1.ne_zero]
   ring
 
 theorem frobeniusPoly_zmod (n : ℕ) :

--- a/Mathlib/RingTheory/WittVector/Frobenius.lean
+++ b/Mathlib/RingTheory/WittVector/Frobenius.lean
@@ -173,7 +173,8 @@ theorem map_frobeniusPoly (n : ℕ) :
         (p : ℚ) ^ (n - i - v p (j + 1)) by
     have aux : ∀ k : ℕ, (p : ℚ) ^ k ≠ 0 := by
       intro; apply pow_ne_zero; exact mod_cast hp.1.ne_zero
-    simpa [aux, -one_div, -pow_eq_zero_iff', field_simps] using this.symm
+    simpa only [inv_eq_one_div, mul_div_assoc', mul_one, div_mul_eq_mul_div, ne_eq, aux,
+      not_false_eq_true, eq_div_iff, div_eq_iff, Nat.cast_mul, Nat.cast_pow] using this.symm
   rw [mul_comm _ (p : ℚ), mul_assoc, mul_assoc, ← pow_add,
     map_frobeniusPoly.key₂ p hi.le hj, Nat.cast_mul, Nat.cast_pow]
   ring

--- a/MathlibTest/FieldSimp.lean
+++ b/MathlibTest/FieldSimp.lean
@@ -713,10 +713,3 @@ example {K : Type*} [DivisionRing K] {n' x : K} (h : n' ≠ 0) (h' : n' + x ≠ 
 example {K : Type*} [Field K] {n' x : K} (hn : n' ≠ 0) :
     1 / (1 + x / n') = n' / (n' + x) := by
   field_simp
-
-/-! ## Miscellaneous -/
-
--- An example of "unfolding" `field_simps` to its "definition"
-example {aa : ℚ} (ha : (aa : ℚ) ≠ 0) (hb : 2 * aa = 3) : (1 : ℚ) / aa = 2/ 3 := by
-  simp (disch := field_simp_discharge) [-one_div, -one_divp, -mul_eq_zero, field_simps]
-  rw [hb]


### PR DESCRIPTION
The `field_simps` simp-set formed the basis for the former implementation of the `field_simp` tactic. Some library proofs used the simp-set rather than the tactic.

As of #28658, the `field_simp` tactic is no longer based on `simp`.  A future PR will remove the `field_simps` simp-set altogether.  In preparation, we rewrite the ~20 library proofs which used that simp-set:
- Some are rewritten using the new `field_simp`; the new proofs are generally shorter and should be also be faster.
- Some are rewritten just by squeezing the simp; these ones are out of scope for the new `field_simp` (e.g. because of noncommutativity or because there is no `/` operation -- the new `field_simp` requires `CommGroupWithZero`).


---

- [x] depends on: #28917 (for simplicity)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
