### PR TITLE
fix: bug with `set_option ... in` in tactic analysis framework

### DIFF
--- a/MathlibTest/TacticAnalysis.lean
+++ b/MathlibTest/TacticAnalysis.lean
@@ -68,6 +68,9 @@ section internals
 
 section setOptionIn
 
+/- Test that top-level `set_option ... in` commands activate tactic analyses, and do not
+accidentally disable them (#28926) -/
+
 /-- warning: Try this: rw [xy, yz] -/
 #guard_msgs in
 set_option linter.tacticAnalysis.rwMerge true in

--- a/MathlibTest/TacticAnalysis.lean
+++ b/MathlibTest/TacticAnalysis.lean
@@ -1,5 +1,7 @@
 import Mathlib.Tactic.TacticAnalysis.Declarations
 
+section declarations
+
 section rwMerge
 
 set_option linter.tacticAnalysis.rwMerge true
@@ -59,3 +61,20 @@ example : 1 + 1 = 2 := by
   rfl
 
 end replaceWithGrind
+
+end declarations
+
+section internals
+
+section setOptionIn
+
+/-- warning: Try this: rw [xy, yz] -/
+#guard_msgs in
+set_option linter.tacticAnalysis.rwMerge true in
+example : x = z := by
+  rw [xy]
+  rw [yz]
+
+end setOptionIn
+
+end internals


### PR DESCRIPTION
Prior to this PR, `set_option ... in` was not working as expected in the tactic analysis framework.

The framework only visits trees with syntax whose range is enclosed by the range of the command syntax we're operating on. However, due to `withSetOptionIn`, the syntax we're operating on is only the syntax nested within `set_option ... in <stx>`, whereas the ranges of syntax in the infotrees tend to include the whole command. Hence, the top-level infotrees are not enclosed in the syntax we're looking at, and we accidentally skip them—ultimately, this means that `set_option linter.tacticAnalysis.foo true in <cmd>` fails to run `linter.tacticAnalysis.foo` in `cmd`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
