### PR TITLE
[Merged by Bors] - chore(Algebra/Ring): remove redundant `have` in `add_iff`

### DIFF
--- a/Mathlib/Algebra/Ring/Idempotent.lean
+++ b/Mathlib/Algebra/Ring/Idempotent.lean
@@ -97,7 +97,6 @@ theorem add_iff [NonUnitalNonAssocSemiring R] [IsCancelAdd R]
     {a b : R} (ha : IsIdempotentElem a) (hb : IsIdempotentElem b) :
     IsIdempotentElem (a + b) ↔ a * b + b * a = 0 := by
   refine ⟨fun h ↦ ?_, ha.add hb⟩
-  have : a + b * a + (a * b + b) = a + b := by simpa [add_mul, mul_add, ha.eq, hb.eq] using h.eq
   rw [← add_right_cancel_iff (a := b), add_assoc, ← add_left_cancel_iff (a := a),
     ← add_assoc, add_add_add_comm]
   simpa [add_mul, mul_add, ha.eq, hb.eq] using h.eq


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
