### PR TITLE
[Merged by Bors] - feat: if `1 < x` then `y ^ n < x` for some `1 < y`

### DIFF
--- a/Mathlib/Algebra/Order/Group/DenselyOrdered.lean
+++ b/Mathlib/Algebra/Order/Group/DenselyOrdered.lean
@@ -119,7 +119,7 @@ section Group
 variable [CommGroup M] [IsOrderedCancelMonoid M]
 
 @[to_additive]
-theorem exists_pow_gt_of_lt_one (hx : x < 1) (n : ℕ) : ∃ y : M, y < 1 ∧ x < y ^ n := by
+theorem exists_lt_pow_of_lt_one (hx : x < 1) (n : ℕ) : ∃ y : M, y < 1 ∧ x < y ^ n := by
   obtain ⟨y, hy, hy'⟩ := exists_pow_lt_of_one_lt (one_lt_inv_of_inv hx) n
   use y⁻¹, inv_lt_one_of_one_lt hy
   simpa [lt_inv'] using hy'

--- a/Mathlib/Algebra/Order/Group/DenselyOrdered.lean
+++ b/Mathlib/Algebra/Order/Group/DenselyOrdered.lean
@@ -3,12 +3,12 @@ Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
+import Mathlib.Algebra.Order.Group.Defs
 import Mathlib.Algebra.Order.Group.Unbundled.Basic
+import Mathlib.Algebra.Order.Monoid.Defs
 import Mathlib.Algebra.Order.Monoid.Unbundled.OrderDual
 import Mathlib.Algebra.Order.Monoid.Unbundled.ExistsOfLE
 import Mathlib.Algebra.Order.Monoid.Unbundled.Pow
-import Mathlib.Algebra.Order.Monoid.Defs
-import Mathlib.Algebra.Order.Group.Defs
 
 /-!
 # Lemmas about densely linearly ordered groups.

--- a/Mathlib/Algebra/Order/Group/DenselyOrdered.lean
+++ b/Mathlib/Algebra/Order/Group/DenselyOrdered.lean
@@ -90,35 +90,38 @@ end DenselyOrdered
 variable {M : Type*} [LinearOrder M] [DenselyOrdered M] {x : M}
 
 section Monoid
-variable [AddCommMonoid M] [ExistsAddOfLE M] [IsOrderedCancelAddMonoid M]
+variable [CommMonoid M] [ExistsMulOfLE M] [IsOrderedCancelMonoid M]
 
-private theorem exists_two_nsmul_le_of_pos (hx : 0 < x) : ∃ y : M, 0 < y ∧ 2 • y ≤ x := by
+@[to_additive]
+private theorem exists_pow_two_le_of_one_lt (hx : 1 < x) : ∃ y : M, 1 < y ∧ y ^ 2 ≤ x := by
   obtain ⟨y, hy, hyx⟩ := exists_between hx
-  obtain hyx | hxy := le_total (2 • y) x
+  obtain hyx | hxy := le_total (y ^ 2) x
   · exact ⟨y, hy, hyx⟩
-  obtain ⟨z, hz, rfl⟩ := exists_pos_add_of_lt' hyx
-  exact ⟨z, hz, by simpa [two_nsmul] using hxy⟩
+  obtain ⟨z, hz, rfl⟩ := exists_one_lt_mul_of_lt' hyx
+  exact ⟨z, hz, by simpa [pow_succ] using hxy⟩
 
-theorem exists_nsmul_lt_of_pos (hx : 0 < x) : ∀ n : ℕ, ∃ y : M, 0 < y ∧ n • y < x
+@[to_additive]
+theorem exists_pow_lt_of_one_lt (hx : 1 < x) : ∀ n : ℕ, ∃ y : M, 1 < y ∧ y ^ n < x
   | 0 => ⟨x, by simpa⟩
   | 1 => by simpa using exists_between hx
   | n + 2 => by
-    obtain ⟨y, hy, hyx⟩ := exists_nsmul_lt_of_pos hx (n + 1)
-    obtain ⟨z, hz, hzy⟩ := exists_two_nsmul_le_of_pos hy
+    obtain ⟨y, hy, hyx⟩ := exists_pow_lt_of_one_lt hx (n + 1)
+    obtain ⟨z, hz, hzy⟩ := exists_pow_two_le_of_one_lt hy
     refine ⟨z, hz, hyx.trans_le' ?_⟩
-    calc (n + 2) • z
-      _ ≤ (2 * (n + 1)) • z := nsmul_left_monotone hz.le (by omega)
-      _ = (n + 1) • 2 • z := by rw [← mul_nsmul]
-      _ ≤ (n + 1) • y := nsmul_le_nsmul_right hzy _
+    calc z ^ (n + 2)
+      _ ≤ z ^ (2 * (n + 1)) := pow_right_monotone hz.le (by omega)
+      _ = (z ^ 2) ^ (n + 1) := by rw [pow_mul]
+      _ ≤ y ^ (n + 1) := pow_le_pow_left' hzy (n + 1)
 
 end Monoid
 
 section Group
-variable [AddCommGroup M] [IsOrderedCancelAddMonoid M]
+variable [CommGroup M] [IsOrderedCancelMonoid M]
 
-theorem exists_nsmul_gt_of_neg (hx : x < 0) (n : ℕ) : ∃ y : M, y < 0 ∧ x < n • y := by
-  obtain ⟨y, hy, hy'⟩ := exists_nsmul_lt_of_pos (neg_pos_of_neg hx) n
-  use -y, neg_neg_of_pos hy
-  simpa [lt_neg] using hy'
+@[to_additive]
+theorem exists_pow_gt_of_lt_one (hx : x < 1) (n : ℕ) : ∃ y : M, y < 1 ∧ x < y ^ n := by
+  obtain ⟨y, hy, hy'⟩ := exists_pow_lt_of_one_lt (one_lt_inv_of_inv hx) n
+  use y⁻¹, inv_lt_one_of_one_lt hy
+  simpa [lt_inv'] using hy'
 
 end Group

--- a/Mathlib/Algebra/Order/Group/DenselyOrdered.lean
+++ b/Mathlib/Algebra/Order/Group/DenselyOrdered.lean
@@ -6,8 +6,8 @@ Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 import Mathlib.Algebra.Order.Group.Defs
 import Mathlib.Algebra.Order.Group.Unbundled.Basic
 import Mathlib.Algebra.Order.Monoid.Defs
-import Mathlib.Algebra.Order.Monoid.Unbundled.OrderDual
 import Mathlib.Algebra.Order.Monoid.Unbundled.ExistsOfLE
+import Mathlib.Algebra.Order.Monoid.Unbundled.OrderDual
 import Mathlib.Algebra.Order.Monoid.Unbundled.Pow
 
 /-!


### PR DESCRIPTION
Co-authored-by: Yaël Dillies <yael.dillies@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
