### PR TITLE
[Merged by Bors] - feat: `IsSuccLimit a → (Iio a).Nonempty`

### DIFF
--- a/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/EnoughInjectives.lean
+++ b/Mathlib/CategoryTheory/Abelian/GrothendieckCategory/EnoughInjectives.lean
@@ -226,7 +226,7 @@ noncomputable abbrev functor : J ⥤ C :=
 
 instance : (functor hG A₀ J).IsWellOrderContinuous where
   nonempty_isColimit m hm := ⟨by
-    have : Nonempty (Set.Iio m) := ⟨⟨⊥, Ne.bot_lt (by simpa using hm.not_isMin)⟩⟩
+    have := hm.nonempty_Iio.to_subtype
     let c := (Set.principalSegIio m).cocone (functorToMonoOver hG A₀ J ⋙ MonoOver.forget _)
     have : Mono c.pt.hom := by dsimp [c]; infer_instance
     apply IsGrothendieckAbelian.isColimitMapCoconeOfSubobjectMkEqISup

--- a/Mathlib/CategoryTheory/Limits/Shapes/Preorder/HasIterationOfShape.lean
+++ b/Mathlib/CategoryTheory/Limits/Shapes/Preorder/HasIterationOfShape.lean
@@ -94,9 +94,7 @@ lemma hasIterationOfShape_of_initialSeg {α : Type*} [LinearOrder α]
     HasIterationOfShape α C where
   hasColimitsOfShape := hasColimitsOfShape_of_initialSeg C h
   hasColimitsOfShape_of_isSuccLimit j hj := by
-    have : Nonempty (Set.Iio j) := by
-      obtain ⟨a, ha⟩ := not_isMin_iff.1 hj.1
-      exact ⟨⟨a, ha⟩⟩
+    have := hj.nonempty_Iio.to_subtype
     exact hasColimitsOfShape_of_initialSeg  _
       (InitialSeg.trans (Set.principalSegIio j) h)
 

--- a/Mathlib/Order/SuccPred/Limit.lean
+++ b/Mathlib/Order/SuccPred/Limit.lean
@@ -85,6 +85,9 @@ protected theorem _root_.IsMin.not_isSuccLimit (h : IsMin a) : ¬ IsSuccLimit a 
 protected theorem _root_.IsMin.isSuccPrelimit : IsMin a → IsSuccPrelimit a := fun h _ hab =>
   not_isMin_of_lt hab.lt h
 
+theorem IsSuccLimit.nonempty_Iio (h : IsSuccLimit a) : (Set.Iio a).Nonempty :=
+  not_isMin_iff.1 h.1
+
 theorem isSuccPrelimit_bot [OrderBot α] : IsSuccPrelimit (⊥ : α) :=
   isMin_bot.isSuccPrelimit
 
@@ -414,6 +417,9 @@ protected theorem _root_.IsMax.not_isPredLimit (h : IsMax a) : ¬ IsPredLimit a 
 
 protected theorem _root_.IsMax.isPredPrelimit : IsMax a → IsPredPrelimit a := fun h _ hab =>
   not_isMax_of_lt hab.lt h
+
+theorem IsPredLimit.nonempty_Ioi (h : IsPredLimit a) : (Set.Ioi a).Nonempty :=
+  not_isMax_iff.1 h.1
 
 theorem isPredPrelimit_top [OrderTop α] : IsPredPrelimit (⊤ : α) :=
   isMax_top.isPredPrelimit

--- a/Mathlib/SetTheory/Ordinal/FixedPoint.lean
+++ b/Mathlib/SetTheory/Ordinal/FixedPoint.lean
@@ -155,7 +155,7 @@ theorem isNormal_derivFamily [Small.{u} ι] (f : ι → Ordinal.{u} → Ordinal.
   · rw [derivFamily_succ, ← succ_le_iff]
     exact le_nfpFamily _ _
   · rw [derivFamily_limit _ h, Set.image_eq_range]
-    have : Nonempty (Set.Iio o) := ⟨0, h.bot_lt⟩
+    have := h.nonempty_Iio.to_subtype
     exact isLUB_ciSup (bddAbove_of_small _)
 
 theorem derivFamily_strictMono [Small.{u} ι] (f : ι → Ordinal.{u} → Ordinal.{u}) :
@@ -172,7 +172,7 @@ theorem derivFamily_fp [Small.{u} ι] {i} (H : IsNormal (f i)) (o : Ordinal) :
     rw [derivFamily_succ]
     exact nfpFamily_fp H _
   | limit o l IH =>
-    have : Nonempty (Set.Iio o) := ⟨0, l.bot_lt⟩
+    have := l.nonempty_Iio.to_subtype
     rw [derivFamily_limit _ l, H.map_iSup]
     refine eq_of_forall_ge_iff fun c => ?_
     rw [Ordinal.iSup_le_iff, Ordinal.iSup_le_iff]


### PR DESCRIPTION
Given that I could find multiple times this gets reproved (and Bhavik was going to add one to that list!) we might as well have this as a theorem.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include at least one commit authored by each
co-author among the commits in the pull request. If necessary, you may 
create empty commits to indicate co-authorship, using commands like so:

git commit --author="Author Name <author@email.com>" --allow-empty -m "add Author Name as coauthor"

When merging, all the commits will be squashed into a single commit listing all co-authors.

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
